### PR TITLE
Replace legacy Carbon dialogs with Cocoa NSAlerts

### DIFF
--- a/lib/framework/cocoa_wrapper.h
+++ b/lib/framework/cocoa_wrapper.h
@@ -1,0 +1,41 @@
+/*
+ This file is part of Warzone 2100.
+ Copyright (C) 1999-2004  Eidos Interactive
+ Copyright (C) 2005-2010  Warzone 2100 Project
+
+ Warzone 2100 is free software; you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation; either version 2 of the License, or
+ (at your option) any later version.
+
+ Warzone 2100 is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with Warzone 2100; if not, write to the Free Software
+ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#ifndef __INCLUDED_LIB_FRAMEWORK_COCOA_WRAPPER_H__
+#define __INCLUDED_LIB_FRAMEWORK_COCOA_WRAPPER_H__
+
+#include "wzglobal.h"
+
+#ifdef WZ_OS_MAC
+
+void cocoaInit(void);
+
+/*!
+ * Display an alert dialog.
+ * This blocks until the dialog is dismissed.
+ * \param message Summary of the issue
+ * \param information A more detailed explanation of the issue
+ * \param style 0 is a warning, 1 is informational, and 2 is critical. (NSAlertStyle)
+ */
+void cocoaShowAlert(const char *message, const char *information, unsigned style);
+
+#endif // WZ_OS_MAC
+
+#endif // __INCLUDED_LIB_FRAMEWORK_COCOA_WRAPPER_H__

--- a/lib/framework/cocoa_wrapper.m
+++ b/lib/framework/cocoa_wrapper.m
@@ -1,0 +1,43 @@
+/*
+ This file is part of Warzone 2100.
+ Copyright (C) 1999-2004  Eidos Interactive
+ Copyright (C) 2005-2010  Warzone 2100 Project
+
+ Warzone 2100 is free software; you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation; either version 2 of the License, or
+ (at your option) any later version.
+
+ Warzone 2100 is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with Warzone 2100; if not, write to the Free Software
+ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#import "cocoa_wrapper.h"
+
+#ifdef WZ_OS_MAC
+#import <AppKit/AppKit.h>
+
+void cocoaInit()
+{
+	NSApplicationLoad();
+}
+
+void cocoaShowAlert(const char *message, const char *information, unsigned style)
+{
+	NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
+	NSAlert *alert = [[NSAlert alloc] init];
+	[alert addButtonWithTitle:@"OK"];
+	[alert setMessageText:[NSString stringWithUTF8String:message]];
+	[alert setInformativeText:[NSString stringWithUTF8String:information]];
+	[alert setAlertStyle:style];
+	[alert runModal];
+	[pool release];
+}
+
+#endif // WZ_OS_MAC

--- a/lib/framework/debug.c
+++ b/lib/framework/debug.c
@@ -47,8 +47,8 @@ bool assertEnabled = true;
 #else
 bool assertEnabled = false;
 #endif
-#if defined(WZ_OS_MAC32) // FIXME: Needs to be made compatible with 64bit
-#include <Carbon/Carbon.h>
+#ifdef WZ_OS_MAC
+#include "cocoa_wrapper.h"
 #endif
 /*
  * This list _must_ match the enum in debug.h!
@@ -441,28 +441,16 @@ void _debug( code_part part, const char *function, const char *str, ... )
 			MessageBoxA( NULL,
 				wbuf,
 				"Warzone has terminated unexpectedly", MB_OK|MB_ICONERROR);
-#elif defined(WZ_OS_MAC32) // FIXME: Needs to be made compatible with 64bit
-			AlertStdCFStringAlertParamRec	param;
-			DialogRef						dialog;
-			OSStatus						err;
-			DialogItemIndex					itemHit;
-			char aBuffer[512];
-
-			GetStandardAlertDefaultParams( &param, kStdCFStringAlertVersionOne );
-			param.movable = true;
-			
-			ssprintf(aBuffer, "%s\n\nPlease check your logs for more details.\n", useInputBuffer1 ? inputBuffer[1] : inputBuffer[0] );
-			
-			err = CreateStandardAlert( kAlertStopAlert, CFStringCreateWithCString( nil, aBuffer, kCFStringEncodingMacRoman),
-				CFSTR( "Run Console.app and search for wz2100 and copy that to a file.\
-					  \n\nFor the Crash report on 10.4/10.5 check\
-					  \n~/Library/Logs/CrashReporter,\
-					  \non 10.6 check ~/Library/Logs/DiagnosticReports\
-					  \nDo not forget to upload and attach those to a bug report at http://developer.wz2100.net/newticket\
-					  \nThanks!" ), &param, &dialog );
-			SetWindowTitleWithCFString( GetDialogWindow( dialog ), CFSTR( "Warzone has terminated unexpectedly" ) );
-			
-			RunStandardAlert( dialog, NULL, &itemHit );
+#elif defined(WZ_OS_MAC)
+			cocoaShowAlert("Warzone has terminated unexpectedly.",
+			               "Please check your logs for more details."
+			               "\n\nRun Console.app, search for \"wz2100\", and copy that to a file."
+			               "\n\nIf you are on 10.4 (Tiger) or 10.5 (Leopard) the crash report"
+			               " is in ~/Library/Logs/CrashReporter."
+			               " If you are on 10.6 (Snow Leopard), it is in"
+			               "\n~/Library/Logs/DiagnosticReports."
+			               "\n\nDo not forget to upload and attach those to a bug report at http://developer.wz2100.net/newticket"
+			               "\nThanks!", 2);
 #endif
 		}
 
@@ -476,22 +464,8 @@ void _debug( code_part part, const char *function, const char *str, ... )
 			MessageBoxA( NULL,
 				wbuf,
 				"Warzone has detected a problem.", MB_OK|MB_ICONINFORMATION);
-#elif defined (WZ_OS_MAC32) // FIXME: Needs to be made compatible with 64bit
-			AlertStdCFStringAlertParamRec	param;
-			DialogRef						dialog;
-			OSStatus						err;
-			DialogItemIndex					itemHit;
-			char aBuffer[512];
-			
-			GetStandardAlertDefaultParams( &param, kStdCFStringAlertVersionOne );
-			param.movable = true;
-			
-			ssprintf(aBuffer, "A non fatal error has occurred.\n\n%s\n\n", useInputBuffer1 ? inputBuffer[1] : inputBuffer[0] );
-			
-			err = CreateStandardAlert( kAlertNoteAlert, CFStringCreateWithCString( nil, aBuffer, kCFStringEncodingMacRoman), NULL, &param, &dialog );
-			SetWindowTitleWithCFString( GetDialogWindow( dialog ), CFSTR( "Warzone has detected a problem" ) );
-			
-			RunStandardAlert( dialog, NULL, &itemHit );
+#elif defined(WZ_OS_MAC)
+			cocoaShowAlert("Warzone has detected a problem.", inputBuffer[useInputBuffer1 ? 1 : 0], 0);
 #endif
 		}
 

--- a/macosx/Warzone.xcodeproj/project.pbxproj
+++ b/macosx/Warzone.xcodeproj/project.pbxproj
@@ -419,7 +419,6 @@
 		439F36F31266877900D5EE2A /* OpenGL.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 439F36F21266877900D5EE2A /* OpenGL.framework */; };
 		439F36F5126687A900D5EE2A /* libfreetype.6.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 439F36F4126687A900D5EE2A /* libfreetype.6.dylib */; };
 		439F36F7126687E500D5EE2A /* libfontconfig.1.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 439F36F6126687E500D5EE2A /* libfontconfig.1.dylib */; };
-		439F3770126688DF00D5EE2A /* Carbon.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 439F36D41266869B00D5EE2A /* Carbon.framework */; };
 		439F3771126688DF00D5EE2A /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 97F013D10EDEAE5C004947E5 /* Cocoa.framework */; };
 		439F3772126688DF00D5EE2A /* OpenAL.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 439F36EE1266877900D5EE2A /* OpenAL.framework */; };
 		439F3773126688DF00D5EE2A /* OpenAL.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 439F36F01266877900D5EE2A /* OpenAL.framework */; };
@@ -579,6 +578,7 @@
 		97AEAB780E8C1C5100A10721 /* Ogg.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 02356E090BD3BCFE00E9A019 /* Ogg.framework */; };
 		97AEAB790E8C1C5100A10721 /* Vorbis.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 02DDA7EE0BD3C03F0049AB60 /* Vorbis.framework */; };
 		97AEAC560E8C261B00A10721 /* Theora.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 97AEAB330E8C1B5200A10721 /* Theora.framework */; };
+		BF4A227A12B3138300CE8688 /* cocoa_wrapper.m in Sources */ = {isa = PBXBuildFile; fileRef = BF4A227912B3138300CE8688 /* cocoa_wrapper.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXBuildRule section */
@@ -1617,6 +1617,8 @@
 		976AE8270EA0B59A00F2473F /* timer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = timer.h; path = ../lib/sequence/timer.h; sourceTree = SOURCE_ROOT; };
 		97AEAB330E8C1B5200A10721 /* Theora.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Theora.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		97F013D10EDEAE5C004947E5 /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = System/Library/Frameworks/Cocoa.framework; sourceTree = SDKROOT; };
+		BF4A227812B3138300CE8688 /* cocoa_wrapper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = cocoa_wrapper.h; path = ../lib/framework/cocoa_wrapper.h; sourceTree = SOURCE_ROOT; };
+		BF4A227912B3138300CE8688 /* cocoa_wrapper.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = cocoa_wrapper.m; path = ../lib/framework/cocoa_wrapper.m; sourceTree = SOURCE_ROOT; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1652,7 +1654,6 @@
 				97AEAC560E8C261B00A10721 /* Theora.framework in Frameworks */,
 				02CDDD130D159DF600722688 /* QuesoGLC.framework in Frameworks */,
 				43EA393D11442A8900AEF27C /* Gettext.framework in Frameworks */,
-				439F3770126688DF00D5EE2A /* Carbon.framework in Frameworks */,
 				439F3771126688DF00D5EE2A /* Cocoa.framework in Frameworks */,
 				439F3772126688DF00D5EE2A /* OpenAL.framework in Frameworks */,
 				439F3773126688DF00D5EE2A /* OpenAL.framework in Frameworks */,
@@ -1933,6 +1934,8 @@
 				0246A09C0BD3CBD5004D1C70 /* cursors.h */,
 				0246A09F0BD3CBD5004D1C70 /* debug.c */,
 				0246A0A00BD3CBD5004D1C70 /* debug.h */,
+				BF4A227912B3138300CE8688 /* cocoa_wrapper.m */,
+				BF4A227812B3138300CE8688 /* cocoa_wrapper.h */,
 				0246A0A30BD3CBD5004D1C70 /* frame.c */,
 				0246A0A40BD3CBD5004D1C70 /* frame.h */,
 				0246A0A50BD3CBD5004D1C70 /* frameint.h */,
@@ -4056,6 +4059,7 @@
 				43F3405B11CAA83D00D1E6C8 /* crc.cpp in Sources */,
 				43C270E911DD2EBA009BC740 /* jpeg_encoder.c in Sources */,
 				43A0C82B12176C8A006C3B89 /* netqueue.cpp in Sources */,
+				BF4A227A12B3138300CE8688 /* cocoa_wrapper.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/src/main.c
+++ b/src/main.c
@@ -97,6 +97,7 @@ typedef enum _focus_state
 #elif defined(WZ_OS_MAC)
 # include <CoreServices/CoreServices.h>
 # include <unistd.h>
+# include "cocoa_wrapper.h"
 # define WZ_WRITEDIR "Warzone 2100 master"
 #else
 # define WZ_WRITEDIR ".warzone2100-master"
@@ -1148,6 +1149,10 @@ static bool fptest2(void)
 int main(int argc, char *argv[])
 {
 	int ok;
+
+#ifdef WZ_OS_MAC
+	cocoaInit();
+#endif
 
 	setupExceptionHandler(argc, argv);
 


### PR DESCRIPTION
They're 64-bit compatible now.

This also updates the libpng download url; they renamed a folder.
