### PR TITLE
Dual screen compatability tweak

### DIFF
--- a/src/configuration.cpp
+++ b/src/configuration.cpp
@@ -134,6 +134,7 @@ bool loadConfig()
 
 	if (ini.contains("bpp")) pie_SetVideoBufferDepth(ini.value("bpp").toInt());
 	setFramerateLimit(ini.value("framerate", 60).toInt());
+	setDualScreenCompat(ini.value("dualScreenCompat", false).toBool());
 	return true;
 }
 
@@ -212,6 +213,7 @@ bool saveConfig()
 		}
 		ini.setValue("playerName", (char*)sPlayer);		// player name
 	}
+	ini.setValue("dualScreenCompat", getDualScreenCompat());
 	ini.sync();
 	return true;
 }

--- a/src/frontend.cpp
+++ b/src/frontend.cpp
@@ -1572,7 +1572,7 @@ void addBackdrop(void)
 	sFormInit.formID = 0;
 	sFormInit.id = FRONTEND_BACKDROP;
 	sFormInit.style = WFORM_PLAIN;
-	sFormInit.x = (SWORD)( (pie_GetVideoBufferWidth() - HIDDEN_FRONTEND_WIDTH)/2);
+	sFormInit.x = (SWORD) (pie_GetVideoBufferWidth() / 2 - (getDualScreenCompat() ? HIDDEN_FRONTEND_WIDTH : HIDDEN_FRONTEND_WIDTH / 2));
 	sFormInit.y = (SWORD)( (pie_GetVideoBufferHeight() - HIDDEN_FRONTEND_HEIGHT)/2);
 	sFormInit.width = HIDDEN_FRONTEND_WIDTH-1;
 	sFormInit.height = HIDDEN_FRONTEND_HEIGHT-1;

--- a/src/hci.cpp
+++ b/src/hci.cpp
@@ -3411,6 +3411,18 @@ void togglePowerBar(void)
 	}
 }
 
+bool dualScreenCompatabilityMode = false;
+
+bool getDualScreenCompat()
+{
+	return dualScreenCompatabilityMode;
+}
+
+void setDualScreenCompat(bool mode)
+{
+	dualScreenCompatabilityMode = mode;
+}
+
 /* Add the power bars to the screen */
 bool intAddPower(void)
 {

--- a/src/hci.h
+++ b/src/hci.h
@@ -143,8 +143,13 @@
 #define STAT_SLDWIDTH		70	// Slider width.
 #define STAT_SLDHEIGHT		12	//4	// Slider height.
 
+extern bool dualScreenCompatabilityMode;
+
+bool getDualScreenCompat();
+void setDualScreenCompat(bool mode);
+
 // Power bar position.
-#define POW_X			OBJ_BACKX
+#define POW_X			(getDualScreenCompat() ? (OBJ_BACKX - (OBJ_WIDTH / 2)) : (OBJ_BACKX))
 #define POW_Y			(OBJ_BACKY + OBJ_BACKHEIGHT + 6)
 #define POW_BARWIDTH	308
 

--- a/src/ingameop.h
+++ b/src/ingameop.h
@@ -52,18 +52,18 @@ extern bool isInGamePopupUp;
 #define INTINGAMEOP_H			124
 #define INTINGAMEOP_HS			88
 
-#define INTINGAMEOP_X			((320-(INTINGAMEOP_W/2))+D_W)
+#define INTINGAMEOP_X			(getDualScreenCompat() ? ((320-(INTINGAMEOP_W))+D_W) : ((320-(INTINGAMEOP_W/2))+D_W))
 #define INTINGAMEOP_Y			((240-(INTINGAMEOP_H/2))+D_H)
 
 #define INTINGAMEOP2_W			290
 #define INTINGAMEOP2_H			120
-#define INTINGAMEOP2_X			((320-(INTINGAMEOP2_W/2))+D_W)
+#define INTINGAMEOP2_X			(getDualScreenCompat() ? ((320-(INTINGAMEOP2_W))+D_W) : ((320-(INTINGAMEOP2_W/2))+D_W))
 #define INTINGAMEOP2_Y			((240-(INTINGAMEOP2_H/2))+D_H)
 
 // quit confirmation.
 #define INTINGAMEOP3_W			120
 #define INTINGAMEOP3_H			65
-#define INTINGAMEOP3_X			((320-(INTINGAMEOP3_W/2))+D_W)
+#define INTINGAMEOP3_X			(getDualScreenCompat() ? ((320-(INTINGAMEOP3_W))+D_W) : ((320-(INTINGAMEOP3_W/2))+D_W))
 #define INTINGAMEOP3_Y			((240-(INTINGAMEOP3_H/2))+D_H)
 
 #define PAUSEMESSAGE_YOFFSET (0)

--- a/src/loadsave.cpp
+++ b/src/loadsave.cpp
@@ -64,10 +64,10 @@
 #define slotsInColumn 12		// # of slots in a column
 #define totalslotspace 64		// guessing 64 max chars for filename.
 
-#define LOADSAVE_X				D_W + 16
-#define LOADSAVE_Y				D_H + 5
 #define LOADSAVE_W				610
 #define LOADSAVE_H				220
+#define LOADSAVE_X				(getDualScreenCompat() ? (D_W + 16 - LOADSAVE_W / 2) : (D_W + 16))
+#define LOADSAVE_Y				D_H + 5
 
 #define MAX_SAVE_NAME			60
 


### PR DESCRIPTION
I wrote a tweak to improve dual screen compatability for full-screen gaming. Any windows that might intersect the middle of the screen (where, in a two-screen setup, they'd be split in half by the border between the screens) are pushed to the left from the middle, if dualScreenCompat is set to "true" in the config file. There is no menu option for this yet, as the main menu is about to undergo some big changes anyway.
