### PR TITLE
Fix fullscreen display on Linux:

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1280,16 +1280,23 @@ int main(int argc, char *argv[])
 	}
 	screenWidth = w;
 	screenHeight = h;
-	mainwindow.show();
 	if (war_getFullscreen())
 	{
+		mainwindow.resize(w,h);
+		mainwindow.showFullScreen();
+		if(w>mainwindow.width()) {
+			w = mainwindow.width();
+		}
+		if(h>mainwindow.height()) {
+			h = mainwindow.height();
+		}
 		pie_SetVideoBufferWidth(w);
 		pie_SetVideoBufferHeight(h);
-		mainwindow.showFullScreen();
 	}
 	else
 	{
-		mainwindow.setMinimumSize(w, h);
+		mainwindow.show();
+																mainwindow.setMinimumSize(w, h);
 		mainwindow.setMaximumSize(w, h);
 	}
 	mainwindow.setReadyToPaint();


### PR DESCRIPTION
1) Avoid calling mainwindow.show() before mainwindow.showFullScreen()
since the show() call seems to disable the showFullScreen() call.
2) resize the window before calling showFullScreen() since
showFullScreen() takes the resolution from the size of the window, which
is not yet set (and defaults to VGA size).
3) After showFullScreen() get back the actual size; I am not sure if
this is necessary, but the resize() documentation suggests it may be.

Fixes #2711
