### PR TITLE
Workaround for #2899. (Main menu loader hang)

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1367,6 +1367,7 @@ int main(int argc, char *argv[])
 	debug_MEMSTATS();
 #endif
 	debug(LOG_MAIN, "Entering main loop");
+	mainwindow.update(); // Kick off painting. (#2899)
 	app.exec();
 	saveConfig();
 	systemShutdown();


### PR DESCRIPTION
On OS X in fullscreen mode, Qt's painting (WzMainWindow::paintGL) does not start until the game window loses focus. Queuing an update before the event loop starts gets things going.

I'm not familiar enough with Qt or Warzone's rendering internals to identify which of the two is at fault, or where the root bug resides.
