### PR TITLE
Update autorevision with latest, portable, version from git

### DIFF
--- a/build_tools/autorevision
+++ b/build_tools/autorevision
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # Copyright (c) 2012 dak180
 # See http://opensource.org/licenses/bsd-license.php for licence terms
@@ -6,7 +6,7 @@
 # autorevision - extracts metadata about the head version from your repository.
 
 # Usage message.
-function arUsage {
+arUsage() {
 	cat > "/dev/stderr" << EOF
 usage: ./autorevision {-t output-type | -s symbol} [-o cache-file [-f] ] [-V]
 	Options include:
@@ -29,6 +29,8 @@ The folowing are valid output types:
 	js			= javascript file
 	java			= Java file
 	javaprop		= Java properties file
+	tex			= (La)TeX file
+	m4			= m4 file
 
 The following are valid symbols:
 	VCS_TYPE
@@ -46,7 +48,7 @@ EOF
 }
 
 # Config
-ARVERSION="1.1"
+ARVERSION="1.4"
 TARGETFILE="/dev/stdout"
 while getopts ":t:o:s:Vf" OPTION; do
 	case "${OPTION}" in
@@ -73,14 +75,14 @@ while getopts ":t:o:s:Vf" OPTION; do
 	esac
 done
 
-if [[ ! -z "${VAROUT}" ]] && [[ ! -z "${AFILETYPE}" ]]; then
+if [ ! -z "${VAROUT}" ] && [ ! -z "${AFILETYPE}" ]; then
 	# If both -s and -t are specified:
 	echo "error: Improper argument combination." 1>&2
 	exit 1
-elif [[ -z "${VAROUT}" ]] && [[ -z "${AFILETYPE}" ]]; then
+elif [ -z "${VAROUT}" ] && [ -z "${AFILETYPE}" ]; then
 	# If neither -s or -t are specified:
 	arUsage
-elif [[ -z "${CACHEFILE}" ]] && [[ "${CACHEFORCE}" = "1" ]]; then
+elif [ -z "${CACHEFILE}" ] && [ "${CACHEFORCE}" = "1" ]; then
 	# If -f is specified without -o:
 	arUsage
 fi
@@ -88,20 +90,20 @@ fi
 
 # Functions to extract data from different repo types.
 # For git repos
-function gitRepo {
+gitRepo() {
 	cd "$(git rev-parse --show-toplevel)"
 
 	VCS_TYPE="git"
 
 	VCS_BASENAME="$(basename "${PWD}")"
 
-	# Is the working copy clean?
-	git diff --quiet HEAD &> /dev/null
+	 # Is the working copy clean?
+	test -z "$(git status -uno --porcelain)"
 	VCS_WC_MODIFIED="${?}"
 
 	# Enumeration of changesets
 	VCS_NUM="$(git rev-list --count HEAD 2>/dev/null)"
-	if [[ -z "${VCS_NUM}" ]]; then
+	if [ -z "${VCS_NUM}" ]; then
 		echo "warning: Counting the number of revisions may be slower due to an outdated git version less than 1.7.2.3. If something breaks, please update it." 1>&2
 		VCS_NUM="$(git rev-list HEAD | wc -l)"
 	fi
@@ -122,7 +124,7 @@ function gitRepo {
 	VCS_TAG="$(echo "${DESCRIPTION}" | sed -e "s:-g${VCS_SHORT_HASH}\$::" | sed -e 's:-[0-9]*$::')"
 
 	# Distance to last tag or an alias of VCS_NUM if there is no tag
-	if [[ ! -z "${DESCRIPTION}" ]]; then
+	if [ ! -z "${DESCRIPTION}" ]; then
 		VCS_TICK="$(echo "${DESCRIPTION}" | sed -e "s:${VCS_TAG}-::" -e "s:-g${VCS_SHORT_HASH}::")"
 	else
 		VCS_TICK="${VCS_NUM}"
@@ -133,7 +135,7 @@ function gitRepo {
 }
 
 # For hg repos
-function hgRepo {
+hgRepo() {
 	cd "$(hg root)"
 
 	VCS_TYPE="hg"
@@ -157,7 +159,7 @@ function hgRepo {
 	# or branch if no bookmark
 	VCS_BRANCH="$(hg id -B | cut -d ' ' -f 1)"
 	# Fall back to the branch if there are no bookmarks
-	if [[ -z "${VCS_BRANCH}" ]]; then
+	if [ -z "${VCS_BRANCH}" ]; then
 		VCS_BRANCH="$(hg id -b)"
 	fi
 
@@ -165,7 +167,7 @@ function hgRepo {
 	VCS_TAG="$(hg log -r "${VCS_NUM}" -l 1 --template '{latesttag}\n' 2>/dev/null | sed -e 's:qtip::' -e 's:tip::' -e 's:qbase::' -e 's:qparent::' -e "s:$(hg --config 'extensions.color=' --color never qtop 2>/dev/null)::" | cut -d ' ' -f 1)"
 
 	# Distance to last tag or an alias of VCS_NUM if there is no tag
-	if [[ ! -z "${VCS_TAG}" ]]; then
+	if [ ! -z "${VCS_TAG}" ]; then
 		VCS_TICK="$(hg log -r "${VCS_NUM}" -l 1 --template '{latesttagdistance}\n' 2>/dev/null)"
 	else
 		VCS_TICK="${VCS_NUM}"
@@ -176,7 +178,7 @@ function hgRepo {
 }
 
 # For bzr repos
-function bzrRepo {
+bzrRepo() {
 	cd "$(bzr root)"
 
 	VCS_TYPE="bzr"
@@ -194,7 +196,7 @@ function bzrRepo {
 	VCS_FULL_HASH="$(bzr version-info --custom --template='{revision_id}\n')"
 
 	# The short hash
-	VCS_SHORT_HASH="$VCS_NUM"
+	VCS_SHORT_HASH="${VCS_NUM}"
 
 	# Nick of the current branch
 	VCS_BRANCH="$(bzr nick)"
@@ -203,7 +205,7 @@ function bzrRepo {
 	VCS_TAG="$(bzr tags --sort=time | sed '/?$/d' | tail -n1 | cut -d ' ' -f1)"
 
 	# Distance to last tag or an alias of VCS_NUM if there is no tag
-	if [[ ! -z "${VCS_TAG}" ]]; then
+	if [ ! -z "${VCS_TAG}" ]; then
 		VCS_TICK="$(bzr log --line -r "tag:${VCS_TAG}.." | tail -n +2 | wc -l | sed -e 's:^ *::')"
 	else
 		VCS_TICK="${VCS_NUM}"
@@ -214,17 +216,17 @@ function bzrRepo {
 }
 
 # For svn repos
-function svnRepo {
+svnRepo() {
 	VCS_TYPE="svn"
 
 	case "${PWD}" in
 	/*trunk*|/*branches*|/*tags*)
 		fn="${PWD}"
-		while [[ "$(basename "${fn}")" != 'trunk' ]] && [[ "$(basename "${fn}")" != 'branches' ]] && [[ "$(basename "${fn}")" != 'tags' ]] && [[ "$(basename "${fn}")" != '/' ]]; do
+		while [ "$(basename "${fn}")" != 'trunk' ] && [ "$(basename "${fn}")" != 'branches' ] && [ "$(basename "${fn}")" != 'tags' ] && [ "$(basename "${fn}")" != '/' ]; do
 			fn="$(dirname "${fn}")"
 		done
 		fn="$(dirname "${fn}")"
-		if [[ "${fn}" == '/' ]]; then
+		if [ "${fn}" = '/' ]; then
 			VCS_BASENAME="$(basename "${PWD}")"
 		else
 			VCS_BASENAME="$(basename "${fn}")"
@@ -250,7 +252,7 @@ function svnRepo {
 	VCS_FULL_HASH="${SVNVERSION}"
 
 	# The short hash
-	VCS_SHORT_HASH="$VCS_NUM"
+	VCS_SHORT_HASH="${VCS_NUM}"
 
 	# Current branch
 	case "${PWD}" in
@@ -260,13 +262,13 @@ function svnRepo {
 		while :
 		do
 			base="$(basename "${fn}")"
-			if [[ "$base" = 'trunk' ]]; then
+			if [ "${base}" = 'trunk' ]; then
 				VCS_BRANCH='trunk'
 				break
-			elif [[ "${base}" = 'branches' ]] || [[ "${base}" = 'tags' ]]; then
+			elif [ "${base}" = 'branches' ] || [ "${base}" = 'tags' ]; then
 				VCS_BRANCH="${lastbase}"
 				break
-			elif [[ "${base}" = '/' ]]; then
+			elif [ "${base}" = '/' ]; then
 				VCS_BRANCH=""
 				break
 			fi
@@ -290,7 +292,7 @@ function svnRepo {
 
 # Functions to output data in different formats.
 # For header output
-function hOutput {
+hOutput() {
 	cat > "${TARGETFILE}" << EOF
 /* Generated by autorevision - do not hand-hack! */
 #ifndef AUTOREVISION_H
@@ -316,7 +318,7 @@ EOF
 }
 
 # A header output for use with xcode to populate info.plist strings
-function xcodeOutput {
+xcodeOutput() {
 	cat > "${TARGETFILE}" << EOF
 /* Generated by autorevision - do not hand-hack! */
 #ifndef AUTOREVISION_H
@@ -342,7 +344,7 @@ EOF
 }
 
 # For bash output
-function shOutput {
+shOutput() {
 	cat > "${TARGETFILE}" << EOF
 # Generated by autorevision - do not hand-hack!
 
@@ -364,7 +366,7 @@ EOF
 }
 
 # For Python output
-function pyOutput {
+pyOutput() {
 	case "${VCS_WC_MODIFIED}" in
 		0) VCS_WC_MODIFIED="False" ;;
 		1) VCS_WC_MODIFIED="True" ;;
@@ -390,7 +392,7 @@ EOF
 }
 
 # For Perl output
-function plOutput {
+plOutput() {
 	cat << EOF
 # Generated by autorevision - do not hand-hack!
 
@@ -412,7 +414,7 @@ EOF
 }
 
 # For lua output
-function luaOutput {
+luaOutput() {
 	case "${VCS_WC_MODIFIED}" in
 		0) VCS_WC_MODIFIED="false" ;;
 		1) VCS_WC_MODIFIED="true" ;;
@@ -438,7 +440,7 @@ EOF
 }
 
 # For php output
-function phpOutput {
+phpOutput() {
 	case "${VCS_WC_MODIFIED}" in
 		0) VCS_WC_MODIFIED="false" ;;
 		1) VCS_WC_MODIFIED="true" ;;
@@ -466,7 +468,7 @@ EOF
 }
 
 # For ini output
-function iniOutput {
+iniOutput() {
 	case "${VCS_WC_MODIFIED}" in
 		0) VCS_WC_MODIFIED="false" ;;
 		1) VCS_WC_MODIFIED="true" ;;
@@ -489,7 +491,7 @@ EOF
 }
 
 # For javascript output
-function jsOutput {
+jsOutput() {
 	case "${VCS_WC_MODIFIED}" in
 		1) VCS_WC_MODIFIED="true" ;;
 		0) VCS_WC_MODIFIED="false" ;;
@@ -522,7 +524,7 @@ EOF
 }
 
 # For Java output
-function javaOutput {
+javaOutput() {
 	case "${VCS_WC_MODIFIED}" in
 		1) VCS_WC_MODIFIED="true" ;;
 		0) VCS_WC_MODIFIED="false" ;;
@@ -550,7 +552,7 @@ EOF
 }
 
 # For Java properties output
-function javapropOutput {
+javapropOutput() {
 	case "${VCS_WC_MODIFIED}" in
 		1) VCS_WC_MODIFIED="true" ;;
 		0) VCS_WC_MODIFIED="false" ;;
@@ -573,22 +575,61 @@ VCS_WC_MODIFIED=${VCS_WC_MODIFIED}
 EOF
 }
 
+# For m4 output
+m4Output() {
+	cat > "${TARGETFILE}" << EOF
+define(\`VCS_TYPE', \`${VCS_TYPE}')dnl
+define(\`VCS_BASENAME', \`${VCS_BASENAME}')dnl
+define(\`VCS_NUM', \`${VCS_NUM}')dnl
+define(\`VCS_DATE', \`${VCS_DATE}')dnl
+define(\`VCS_BRANCH', \`${VCS_BRANCH}')dnl
+define(\`VCS_TAG', \`${VCS_TAG}')dnl
+define(\`VCS_TICK', \`${VCS_TICK}')dnl
+define(\`VCS_FULLHASH', \`${VCS_FULL_HASH}')dnl
+define(\`VCS_SHIRTHASH', \`${VCS_SHORT_HASH}')dnl
+define(\`VCS_WC_MODIFIED', \`${VCS_WC_MODIFIED}')dnl
+EOF
+}
+
+# For (La)TeX output
+texOutput() {
+	case "${VCS_WC_MODIFIED}" in
+		0) VCS_WC_MODIFIED="false" ;;
+		1) VCS_WC_MODIFIED="true" ;;
+	esac
+	cat > "${TARGETFILE}" << EOF
+% Generated by autorevision - do not hand-hack!
+\def \vcsType {${VCS_TYPE}}
+\def \vcsBasename {${VCS_BASENAME}}
+\def \vcsNum {${VCS_NUM}}
+\def \vcsDate {${VCS_DATE}}
+\def \vcsBranch {${VCS_BRANCH}}
+\def \vcsTag {${VCS_TAG}}
+\def \vcsTick {${VCS_TICK}}
+\def \vcsFullHash {${VCS_FULL_HASH}}
+\def \vcsShortHash {${VCS_SHORT_HASH}}
+\def \vcsWCModified {${VCS_WC_MODIFIED}}
+\endinput
+EOF
+}
+
+
 
 # Detect and collect repo data.
-if [[ -f "${CACHEFILE}" ]] && [[ "${CACHEFORCE}" = "1" ]]; then
+if [ -f "${CACHEFILE}" ] && [ "${CACHEFORCE}" = "1" ]; then
 	# When requested only read from the cache to populate our symbols.
 	source "${CACHEFILE}"
-elif [[ ! -z "$(git rev-parse HEAD 2>/dev/null)" ]]; then
+elif [ ! -z "$(git rev-parse HEAD 2>/dev/null)" ]; then
 	gitRepo
-elif [[ ! -z "$(hg root 2>/dev/null)" ]]; then
+elif [ ! -z "$(hg root 2>/dev/null)" ]; then
 	hgRepo
-elif [[ ! -z "$(bzr root 2>/dev/null)" ]]; then
+elif [ ! -z "$(bzr root 2>/dev/null)" ]; then
 	bzrRepo
-elif [[ ! -z "$(svn info 2>/dev/null)" ]]; then
+elif [ ! -z "$(svn info 2>/dev/null)" ]; then
 	svnRepo
-elif [[ -f "${CACHEFILE}" ]]; then
+elif [ -f "${CACHEFILE}" ]; then
 	# We are not in a repo; try to use a previously generated cache to populate our symbols.
-	source "${CACHEFILE}"
+	. "${CACHEFILE}"
 else
 	echo "error: No repo or cache detected." 1>&2
 	exit 1
@@ -596,55 +637,59 @@ fi
 
 
 # -s output is handled here.
-if [[ ! -z "${VAROUT}" ]]; then
-	if [[ "${VAROUT}" = "VCS_TYPE" ]]; then
+if [ ! -z "${VAROUT}" ]; then
+	if [ "${VAROUT}" = "VCS_TYPE" ]; then
 		echo "${VCS_TYPE}"
-	elif [[ "${VAROUT}" = "VCS_BASENAME" ]]; then
+	elif [ "${VAROUT}" = "VCS_BASENAME" ]; then
 		echo "${VCS_BASENAME}"
-	elif [[ "${VAROUT}" = "VCS_NUM" ]]; then
+	elif [ "${VAROUT}" = "VCS_NUM" ]; then
 		echo "${VCS_NUM}"
-	elif [[ "${VAROUT}" = "VCS_DATE" ]]; then
+	elif [ "${VAROUT}" = "VCS_DATE" ]; then
 		echo "${VCS_DATE}"
-	elif [[ "${VAROUT}" = "VCS_BRANCH" ]]; then
+	elif [ "${VAROUT}" = "VCS_BRANCH" ]; then
 		echo "${VCS_BRANCH}"
-	elif [[ "${VAROUT}" = "VCS_TAG" ]]; then
+	elif [ "${VAROUT}" = "VCS_TAG" ]; then
 		echo "${VCS_TAG}"
-	elif [[ "${VAROUT}" = "VCS_TICK" ]]; then
+	elif [ "${VAROUT}" = "VCS_TICK" ]; then
 		echo "${VCS_TICK}"
-	elif [[ "${VAROUT}" = "VCS_FULL_HASH" ]]; then
+	elif [ "${VAROUT}" = "VCS_FULL_HASH" ]; then
 		echo "${VCS_FULL_HASH}"
-	elif [[ "${VAROUT}" = "VCS_SHORT_HASH" ]]; then
+	elif [ "${VAROUT}" = "VCS_SHORT_HASH" ]; then
 		echo "${VCS_SHORT_HASH}"
-	elif [[ "${VAROUT}" = "VCS_WC_MODIFIED" ]]; then
+	elif [ "${VAROUT}" = "VCS_WC_MODIFIED" ]; then
 		echo "${VCS_WC_MODIFIED}"
 	fi
 fi
 
 
 # Detect requested output type and use it.
-if [[ ! -z "${AFILETYPE}" ]]; then
-	if [[ "${AFILETYPE}" = "h" ]]; then
+if [ ! -z "${AFILETYPE}" ]; then
+	if [ "${AFILETYPE}" = "h" ]; then
 		hOutput
-	elif [[ "${AFILETYPE}" = "xcode" ]]; then
+	elif [ "${AFILETYPE}" = "xcode" ]; then
 		xcodeOutput
-	elif [[ "${AFILETYPE}" = "sh" ]]; then
+	elif [ "${AFILETYPE}" = "sh" ]; then
 		shOutput
-	elif [[ "${AFILETYPE}" = "py" ]]; then
+	elif [ "${AFILETYPE}" = "py" ] || [ "${AFILETYPE}" = "python" ]; then
 		pyOutput
-	elif [[ "${AFILETYPE}" = "pl" ]]; then
+	elif [ "${AFILETYPE}" = "pl" ] || [ "${AFILETYPE}" = "perl" ]; then
 		plOutput
-	elif [[ "${AFILETYPE}" = "lua" ]]; then
+	elif [ "${AFILETYPE}" = "lua" ]; then
 		luaOutput
-	elif [[ "${AFILETYPE}" = "php" ]]; then
+	elif [ "${AFILETYPE}" = "php" ]; then
 		phpOutput
-	elif [[ "${AFILETYPE}" = "ini" ]]; then
+	elif [ "${AFILETYPE}" = "ini" ]; then
 		iniOutput
-	elif [[ "${AFILETYPE}" = "js" ]]; then
+	elif [ "${AFILETYPE}" = "js" ]; then
 		jsOutput
-	elif [[ "${AFILETYPE}" = "java" ]]; then
+	elif [ "${AFILETYPE}" = "java" ]; then
 		javaOutput
-	elif [[ "${AFILETYPE}" = "javaprop" ]]; then
+	elif [ "${AFILETYPE}" = "javaprop" ]; then
 		javapropOutput
+	elif [ "${AFILETYPE}" = "tex" ]; then
+		texOutput
+	elif [ "${AFILETYPE}" = "m4" ]; then
+		m4Output
 	else
 		echo "error: Not a valid output type." 1>&2
 		exit 1
@@ -653,7 +698,7 @@ fi
 
 
 # If requested, make a cache file.
-if [[ ! -z "${CACHEFILE}" ]] && [[ ! "${CACHEFORCE}" = "1" ]]; then
+if [ ! -z "${CACHEFILE}" ] && [ ! "${CACHEFORCE}" = "1" ]; then
 	TARGETFILE="${CACHEFILE}"
 	shOutput
 fi


### PR DESCRIPTION
This is required to build warzone2100 on FreeBSD, and was successfully tested with with 3.1.0.

I'm not sure which branch this should go in, but bugfixes seems to be appropriate given that this is technically a compatibility fix, shouldn't have any regressions and should go into both master and 3.1.
