### PR TITLE
Fix passworded games, add "hidden game" option.

### DIFF
--- a/lib/netplay/netplay.h
+++ b/lib/netplay/netplay.h
@@ -264,6 +264,7 @@ struct NETPLAY
 	char mapFileName[255];            ///< Only valid during map download.
 	char gamePassword[password_string_size];		//
 	bool GamePassworded;				// if we have a password or not.
+	bool GamePublic;					// if we want to broadcast to Lobby.
 	bool ShowedMOTD;					// only want to show this once
 	bool HaveUpgrade;					// game updates available
 	char MOTDbuffer[255];				// buffer for MOTD

--- a/src/frontend.cpp
+++ b/src/frontend.cpp
@@ -563,7 +563,8 @@ static bool startMultiPlayerMenu(void)
 	addSideText(FRONTEND_SIDETEXT ,	FRONTEND_SIDEX, FRONTEND_SIDEY, _("MULTI PLAYER"));
 
 	addTextButton(FRONTEND_HOST,     FRONTEND_POS2X, FRONTEND_POS2Y, _("Host Game"), WBUT_TXTCENTRE);
-	addTextButton(FRONTEND_JOIN,     FRONTEND_POS3X, FRONTEND_POS3Y, _("Join Game"), WBUT_TXTCENTRE);
+	addTextButton(FRONTEND_HOST_HIDDEN,     FRONTEND_POS2X, FRONTEND_POS3Y, _("Host Hidden Game"), WBUT_TXTCENTRE);
+	addTextButton(FRONTEND_JOIN,     FRONTEND_POS3X, FRONTEND_POS4Y, _("Join Game"), WBUT_TXTCENTRE);
 
 	addMultiBut(psWScreen, FRONTEND_BOTFORM, FRONTEND_QUIT, 10, 10, 30, 29, P_("menu", "Return"), IMAGE_RETURN, IMAGE_RETURN_HI, IMAGE_RETURN_HI);
 
@@ -581,6 +582,7 @@ bool runMultiPlayerMenu(void)
 	switch (id)
 	{
 	case FRONTEND_HOST:
+	case FRONTEND_HOST_HIDDEN:
 		// don't pretend we are running a network game. Really do it!
 		NetPlay.bComms = true; // use network = true
 		NetPlay.isUPNP_CONFIGURED = false;
@@ -589,6 +591,8 @@ bool runMultiPlayerMenu(void)
 		bMultiPlayer = true;
 		bMultiMessages = true;
 		NETinit(true);
+        // Here because defaults set by netplay
+		NetPlay.GamePublic = id != FRONTEND_HOST_HIDDEN;
 		NETdiscoverUPnPDevices();
 		game.type = SKIRMISH;		// needed?
 		lastTitleMode = MULTI;

--- a/src/frontend.h
+++ b/src/frontend.h
@@ -176,6 +176,7 @@ enum
 	FRONTEND_SKIRMISH,
 	FRONTEND_CHALLENGES,
 	FRONTEND_HOST			= 20300,	//multiplayer menu options
+	FRONTEND_HOST_HIDDEN,
 	FRONTEND_JOIN,
 	FE_P0,								// player 0 buton
 	FE_P1,								// player 1 buton

--- a/src/multiint.cpp
+++ b/src/multiint.cpp
@@ -2270,6 +2270,7 @@ int allPlayersOnSameTeam(int except)
 static void addTeamChooser(UDWORD player)
 {
 	UDWORD i;
+	int disallow = allPlayersOnSameTeam(player);
 
 	debug(LOG_NET, "Opened team chooser for %d, current team: %d", player, NetPlay.players[player].team);
 
@@ -2284,9 +2285,15 @@ static void addTeamChooser(UDWORD player)
 	int spaceDiv = game.maxPlayers;
 	space = std::min(space, 3 * spaceDiv);
 
-	// add the teams. Used to block "all on 1 team" configurations, but they're useful for learning.
+	// add the teams, skipping the one we CAN'T be on (if applicable)
 	for (i = 0; i < game.maxPlayers; i++)
-		addMultiBut(psWScreen, MULTIOP_TEAMCHOOSER_FORM, MULTIOP_TEAMCHOOSER + i, i * (teamW * spaceDiv + space) / spaceDiv + 3, 6, teamW, teamH, _("Team"), IMAGE_TEAM0 + i , IMAGE_TEAM0_HI + i, IMAGE_TEAM0_HI + i);
+	{
+		if (i != disallow)
+		{
+			addMultiBut(psWScreen, MULTIOP_TEAMCHOOSER_FORM, MULTIOP_TEAMCHOOSER + i, i * (teamW * spaceDiv + space) / spaceDiv + 3, 6, teamW, teamH, _("Team"), IMAGE_TEAM0 + i , IMAGE_TEAM0_HI + i, IMAGE_TEAM0_HI + i);
+		}
+		// may want to add some kind of 'can't do' icon instead of being blank?
+	}
 
 	// add a kick button
 	if (player != selectedPlayer && NetPlay.bComms && NetPlay.isHost && NetPlay.players[player].allocated)
@@ -2311,6 +2318,8 @@ static void closeTeamChooser(void)
 
 static void drawReadyButton(UDWORD player)
 {
+	int disallow = allPlayersOnSameTeam(-1);
+
 	// delete 'ready' botton form
 	widgDelete(psWScreen, MULTIOP_READY_FORM_ID + player);
 
@@ -2333,6 +2342,11 @@ static void drawReadyButton(UDWORD player)
 	else if (!NetPlay.players[player].allocated)
 	{
 		return;	// closed or open
+	}
+
+	if (disallow != -1)
+	{
+		return;
 	}
 
 	bool isMe = player == selectedPlayer;
@@ -2394,6 +2408,7 @@ void addPlayerBox(bool players)
 	if (players)
 	{
 		int  team = -1;
+		bool allOnSameTeam = true;
 
 		for (int i = 0; i < game.maxPlayers; i++)
 		{
@@ -2406,6 +2421,7 @@ void addPlayerBox(bool players)
 				}
 				else if (myTeam != team)
 				{
+					allOnSameTeam = false;
 					break;  // We just need to know if we have enough to start a game
 				}
 			}
@@ -2488,7 +2504,10 @@ void addPlayerBox(bool players)
 
 			if (ingame.localOptionsReceived)
 			{
-				drawReadyButton(i);
+				if (!allOnSameTeam)
+				{
+					drawReadyButton(i);
+				}
 
 				// draw player info box
 				W_BUTINIT sButInit;

--- a/src/multiint.cpp
+++ b/src/multiint.cpp
@@ -146,7 +146,6 @@ static bool				SettingsUp		= false;
 static UBYTE				InitialProto	= 0;
 static W_SCREEN				*psConScreen;
 static SDWORD				dwSelectedGame	= 0;						//player[] and games[] indexes
-static UDWORD				gameNumber;								// index to games icons
 static bool					safeSearch		= false;				// allow auto game finding.
 static bool disableLobbyRefresh = false;	// if we allow lobby to be refreshed or not.
 static UDWORD hideTime = 0;
@@ -154,6 +153,8 @@ static bool EnablePasswordPrompt = false;	// if we need the password prompt
 LOBBY_ERROR_TYPES LobbyError = ERROR_NOERROR;
 static char tooltipbuffer[MaxGames][256] = {{'\0'}};
 static bool toggleFilter = true;	// Used to show all games or only games that are of the same version
+static char lastJoinAddr[128]; // Last game IP that we tried to join.
+static uint32_t lastJoinPort; // Last game port we tried to join.
 /// end of globals.
 // ////////////////////////////////////////////////////////////////////////////
 // Function protos
@@ -880,7 +881,8 @@ void setLobbyError(LOBBY_ERROR_TYPES error_type)
 bool joinGame(const char *host, uint32_t port)
 {
 	PLAYERSTATS	playerStats;
-
+	sstrcpy(lastJoinAddr, host);
+	lastJoinPort = port;
 	if (ingame.localJoiningInProgress)
 	{
 		return false;
@@ -1197,7 +1199,7 @@ void runGameFind(void)
 	// we would want a modal password entry box.
 	if (id >= GAMES_GAMESTART && id <= GAMES_GAMEEND)
 	{
-		gameNumber = id - GAMES_GAMESTART;
+		UDWORD gameNumber = id - GAMES_GAMESTART;
 
 		if (NetPlay.games[gameNumber].privateGame)
 		{
@@ -1213,8 +1215,8 @@ void runGameFind(void)
 	else if (id == CON_PASSWORDYES)
 	{
 		ingame.localOptionsReceived = false;					// note, we are awaiting options
-		sstrcpy(game.name, NetPlay.games[gameNumber].name);		// store name
-		joinGame(NetPlay.games[gameNumber].desc.host, 0);
+		sstrcpy(game.name, _("Unknown Game"));
+		joinGame(lastJoinAddr, lastJoinPort);
 	}
 	else if (id == CON_PASSWORDNO)
 	{

--- a/src/multiint.cpp
+++ b/src/multiint.cpp
@@ -2268,7 +2268,6 @@ int allPlayersOnSameTeam(int except)
 static void addTeamChooser(UDWORD player)
 {
 	UDWORD i;
-	int disallow = allPlayersOnSameTeam(player);
 
 	debug(LOG_NET, "Opened team chooser for %d, current team: %d", player, NetPlay.players[player].team);
 
@@ -2283,15 +2282,9 @@ static void addTeamChooser(UDWORD player)
 	int spaceDiv = game.maxPlayers;
 	space = std::min(space, 3 * spaceDiv);
 
-	// add the teams, skipping the one we CAN'T be on (if applicable)
+	// add the teams. Used to block "all on 1 team" configurations, but they're useful for learning.
 	for (i = 0; i < game.maxPlayers; i++)
-	{
-		if (i != disallow)
-		{
-			addMultiBut(psWScreen, MULTIOP_TEAMCHOOSER_FORM, MULTIOP_TEAMCHOOSER + i, i * (teamW * spaceDiv + space) / spaceDiv + 3, 6, teamW, teamH, _("Team"), IMAGE_TEAM0 + i , IMAGE_TEAM0_HI + i, IMAGE_TEAM0_HI + i);
-		}
-		// may want to add some kind of 'can't do' icon instead of being blank?
-	}
+		addMultiBut(psWScreen, MULTIOP_TEAMCHOOSER_FORM, MULTIOP_TEAMCHOOSER + i, i * (teamW * spaceDiv + space) / spaceDiv + 3, 6, teamW, teamH, _("Team"), IMAGE_TEAM0 + i , IMAGE_TEAM0_HI + i, IMAGE_TEAM0_HI + i);
 
 	// add a kick button
 	if (player != selectedPlayer && NetPlay.bComms && NetPlay.isHost && NetPlay.players[player].allocated)
@@ -2316,8 +2309,6 @@ static void closeTeamChooser(void)
 
 static void drawReadyButton(UDWORD player)
 {
-	int disallow = allPlayersOnSameTeam(-1);
-
 	// delete 'ready' botton form
 	widgDelete(psWScreen, MULTIOP_READY_FORM_ID + player);
 
@@ -2340,11 +2331,6 @@ static void drawReadyButton(UDWORD player)
 	else if (!NetPlay.players[player].allocated)
 	{
 		return;	// closed or open
-	}
-
-	if (disallow != -1)
-	{
-		return;
 	}
 
 	bool isMe = player == selectedPlayer;
@@ -2406,7 +2392,6 @@ void addPlayerBox(bool players)
 	if (players)
 	{
 		int  team = -1;
-		bool allOnSameTeam = true;
 
 		for (int i = 0; i < game.maxPlayers; i++)
 		{
@@ -2419,7 +2404,6 @@ void addPlayerBox(bool players)
 				}
 				else if (myTeam != team)
 				{
-					allOnSameTeam = false;
 					break;  // We just need to know if we have enough to start a game
 				}
 			}
@@ -2502,10 +2486,7 @@ void addPlayerBox(bool players)
 
 			if (ingame.localOptionsReceived)
 			{
-				if (!allOnSameTeam)
-				{
-					drawReadyButton(i);
-				}
+				drawReadyButton(i);
 
 				// draw player info box
 				W_BUTINIT sButInit;


### PR DESCRIPTION
The password system as upstream has it relies on the game's index in the lobby.
This is a problem for LAN games, or if the lobby re-orders games, as it means the player connects to the wrong game.
Finally, a hidden game option for cases where a player simply doesn't want to be on the lobby (again, LAN games).