### PR TITLE
Fix segfault on opening build menu

### DIFF
--- a/src/intdisplay.cpp
+++ b/src/intdisplay.cpp
@@ -283,7 +283,7 @@ void intUpdateQuantity(WIDGET *psWidget, W_CONTEXT *psContext)
 	BASE_OBJECT *psObj = (BASE_OBJECT *)Label->pUserData; // Get the object associated with this widget.
 	STRUCTURE *Structure = (STRUCTURE *)psObj;
 
-	if (psObj != NULL && StructIsFactory(Structure) && StructureIsManufacturingPending(Structure))
+	if (psObj != NULL && psObj->type == OBJ_STRUCTURE && StructIsFactory(Structure) && StructureIsManufacturingPending(Structure))
 	{
 		ASSERT(!isDead(psObj), "Object is dead");
 


### PR DESCRIPTION
Since commit 030a39f4ca108971edb59e0f8068971a797ebe21, opening the build menu (F3) crashes the game. Instead of simply reverting the commit, this request adds back a necessary check that was removed.
