### PR TITLE
Accepting monitors with refresh rate of 59 Hz

### DIFF
--- a/lib/sdl/main_sdl.cpp
+++ b/lib/sdl/main_sdl.cpp
@@ -1319,9 +1319,9 @@ bool wzMainScreenSetup(int antialiasing, bool fullscreen, bool vsync)
 			}
 
 			debug(LOG_WZ, "Monitor[%d]%dx%d %d %s", i, displaymode.w, displaymode.h, displaymode.refresh_rate, getSDL_fmt_string(displaymode.format));
-			if (displaymode.refresh_rate <= 59)
+			if (displaymode.refresh_rate < 59)
 			{
-				continue;    // only store 60Hz & higher modes some display report 59 on linux ?
+				continue;    // only store 60Hz & higher modes, some display report 59 on linux
 			}
 			screenlist.height = displaymode.h;
 			screenlist.width = displaymode.w;


### PR DESCRIPTION
As reported in ticket trac:4324, some monitors on Linux can display refresh rate of 59 Hz, so below the previous threshold of 60 Hz hardcoded in lib/sdl/main_sdl.cpp file.