### PR TITLE
Reorder libs to fix linker error

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -21,8 +21,8 @@ framework_linktest_SOURCES = framework_linktest.cpp
 framework_linktest_LDADD = $(top_builddir)/lib/framework/libframework.a $(PHYSFS_LIBS) $(LIBCRYPTO_LIBS) $(LDFLAGS)
 
 ivis_linktest_SOURCES = ivis_linktest.cpp
-ivis_linktest_LDADD = $(top_builddir)/lib/framework/libframework.a $(top_builddir)/lib/ivis_opengl/libivis_opengl.a \
-	$(top_builddir)/3rdparty/quesoglc/libquesoglc.a $(top_builddir)/lib/sdl/libsdl.a \
+ivis_linktest_LDADD = $(top_builddir)/lib/sdl/libsdl.a $(top_builddir)/lib/framework/libframework.a \
+	$(top_builddir)/lib/ivis_opengl/libivis_opengl.a $(top_builddir)/3rdparty/quesoglc/libquesoglc.a  \
 	$(PHYSFS_LIBS) $(LIBCRYPTO_LIBS) $(QT5_LIBS) $(SDL_LIBS) $(OPENGL_LIBS) $(OPENGLC_LIBS) $(GLEW_LIBS) \
 	$(X_LIBS) $(X_EXTRA_LIBS) $(LDFLAGS) $(PNG_LIBS)
 


### PR DESCRIPTION
libsdl.a requires UTF8toUTF32 from libframework.a.
Libraries which need symbols go first then the libraries
that resolve the symbols.

Fixes:
../lib/sdl/libsdl.a(main_sdl.o): In function `inputhandleText(SDL_TextInputEvent*)':
lib/sdl/main_sdl.cpp:1108: undefined reference to `UTF8toUTF32(char const*, unsigned int*)'