### PR TITLE
Added warzone2100.appdata.xml to dist.

### DIFF
--- a/icons/Makefile.am
+++ b/icons/Makefile.am
@@ -1,5 +1,6 @@
 dist_noinst_DATA = \
 	warzone2100.desktop \
+	warzone2100.appdata.xml \
 	warzone2100.ico \
 	warzone2100.obsolete.ico \
 	warzone2100.png \


### PR DESCRIPTION
This is a followup of https://github.com/Warzone2100/warzone2100/pull/66. I assume this missing line is the reason why you didn't include the file in `warzone2100-3.2.1.tar.xz` which errors the installation:

```
/usr/bin/install: cannot stat './warzone2100.appdata.xml': No such file or directory
```