### PR TITLE
change vssprintf function remove && into signature for allow build su…

### DIFF
--- a/lib/framework/string_ext.h
+++ b/lib/framework/string_ext.h
@@ -178,9 +178,9 @@ static inline size_t sstrcat(char (&dest)[N], char const *src) { return strlcat(
 template <unsigned N1, unsigned N2>
 static inline int sstrcmp(char const (&str1)[N1], char const (&str2)[N2]) { return strncmp(str1, str2, std::min(N1, N2)); }
 template <unsigned N, typename... P>
-static inline int ssprintf(char (&dest)[N], char const *format, P &&... params) { return snprintf(dest, N, format, std::forward<P>(params)...); }
+static inline int ssprintf(char (&dest)[N], char const *format, P ... params) { return snprintf(dest, N, format, std::forward<P>(params)...); }
 template <unsigned N, typename... P>
-static inline int vssprintf(char (&dest)[N], char const *format, P &&... params) { return vsnprintf(dest, N, format, std::forward<P>(params)...); }
+static inline int vssprintf(char (&dest)[N], char const *format, P ... params) { return vsnprintf(dest, N, format, std::forward<P>(params)...); }
 
 template <typename... P>
 static inline std::string astringf(char const *format, P &&... params)


### PR DESCRIPTION
Hello,

I try to build with this command line :
`
./autogen.sh && ./configure --disable-debug CFLAGS="-O2 -gstabs -g -g3" CXXFLAGS="-O2 -gstabs -g -g3" && make
`

this give error on va_list type in file debug.cpp in function _realObjTrace().
For allow build i change copy parameter to classique parameter into vssprintf and ssprintf.

I am not an expert in C++, i hope this will help you to correct this bug.
Best regards.

ps : my configuration is archlinux 4.8.13-1 with gcc version 6.2.1. 