### PR TITLE
Fix clang error

### DIFF
--- a/lib/netplay/netplay.cpp
+++ b/lib/netplay/netplay.cpp
@@ -1783,7 +1783,7 @@ static void NETcheckPlayers(void)
 // We should not block here.
 bool NETrecvNet(NETQUEUE *queue, uint8_t *type)
 {
-	switch (upnp_status)
+	switch ((int)upnp_status)
 	{
 	case UPNP_ERROR_CONTROL_NOT_AVAILABLE:
 	case UPNP_ERROR_DEVICE_NOT_FOUND:


### PR DESCRIPTION
Fixes the following error from clang:

netplay.cpp:1786:2: error: multiple conversions from switch condition type 'std::atomic_int' (aka 'atomic<int>') to an integral or enumeration type
        switch (upnp_status)
        ^       ~~~~~~~~~~~
/usr/include/c++/v1/atomic:860:5: note: conversion to integral type 'int'
    operator _Tp() const volatile _NOEXCEPT {return load();}
    ^
/usr/include/c++/v1/atomic:862:5: note: conversion to integral type 'int'
    operator _Tp() const _NOEXCEPT          {return load();}
    ^

Since upnp_status is atomic and it's checked multiple times in this funcition, it seems more correct to store value of upnp_status into a local variable and check in in both switch and if's.