### PR TITLE
Wrap gl texture

### DIFF
--- a/lib/ivis_opengl/CMakeLists.txt
+++ b/lib/ivis_opengl/CMakeLists.txt
@@ -1,7 +1,44 @@
 cmake_minimum_required (VERSION 3.5)
 
-file(GLOB HEADERS "*.h")
-file(GLOB SRC "*.cpp")
+file(GLOB HEADERS
+	"bitimage.h"
+	"gfx_api.h"
+	"imd.h"
+	"ivisdef.h"
+	"jpeg_encoder.h"
+	"pieblitfunc.h"
+	"pieclip.h"
+	"piedef.h"
+	"piefunc.h"
+	"piematrix.h"
+	"piemode.h"
+	"piepalette.h"
+	"piestate.h"
+	"pietypes.h"
+	"png_util.h"
+	"screen.h"
+	"tex.h"
+	"textdraw.h"
+)
+
+file(GLOB SRC
+	"bitimage.cpp"
+	"gfx_api_gl.cpp"
+	"imdload.cpp"
+	"jpeg_encoder.cpp"
+	"pieblitfunc.cpp"
+	"pieclip.cpp"
+	"piedraw.cpp"
+	"piefunc.cpp"
+	"piematrix.cpp"
+	"piemode.cpp"
+	"piepalette.cpp"
+	"piestate.cpp"
+	"png_util.cpp"
+	"screen.cpp"
+	"tex.cpp"
+	"textdraw.cpp"
+)
 
 find_package(PNG REQUIRED)
 find_package(OpenGL REQUIRED)

--- a/lib/ivis_opengl/Makefile.am
+++ b/lib/ivis_opengl/Makefile.am
@@ -5,6 +5,7 @@ AM_CXXFLAGS = $(WZ_CXXFLAGS) $(QT5_CFLAGS)
 noinst_LIBRARIES = libivis_opengl.a
 noinst_HEADERS = \
 	piematrix.h \
+	gfx_api.h \
 	screen.h \
 	bitimage.h \
 	imd.h \
@@ -24,6 +25,7 @@ noinst_HEADERS = \
 
 libivis_opengl_a_SOURCES = \
 	pieblitfunc.cpp \
+	gfx_api_gl.cpp \
 	piedraw.cpp \
 	piefunc.cpp \
 	piematrix.cpp \

--- a/lib/ivis_opengl/gfx_api.h
+++ b/lib/ivis_opengl/gfx_api.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <memory>
+#include <string>
+
+namespace gfx_api
+{
+	enum class pixel_format
+	{
+		invalid,
+		rgb,
+		rgba,
+		compressed_rgb,
+		compressed_rgba,
+	};
+
+	struct texture
+	{
+		virtual ~texture() {};
+		virtual void bind() = 0;
+		virtual void upload(const size_t& mip_level, const size_t& offset_x, const size_t& offset_y, const size_t& width, const size_t& height, const pixel_format& buffer_format, const void* data) = 0;
+		virtual void generate_mip_levels() = 0;
+		virtual unsigned id() = 0;
+	};
+
+	struct context
+	{
+		virtual ~context() {};
+		virtual texture* create_texture(const size_t& width, const size_t& height, const pixel_format& internal_format, const std::string& filename = "") = 0;
+		static context& get();
+	};
+}
+

--- a/lib/ivis_opengl/gfx_api_gl.cpp
+++ b/lib/ivis_opengl/gfx_api_gl.cpp
@@ -1,0 +1,87 @@
+#include "gfx_api.h"
+
+#include <GL/glew.h>
+#include <algorithm>
+#include <cmath>
+#include "lib/framework/frame.h"
+
+static GLenum to_gl(const gfx_api::pixel_format& format)
+{
+	switch (format)
+	{
+	case gfx_api::pixel_format::rgba:
+		return GL_RGBA;
+	case gfx_api::pixel_format::rgb:
+		return GL_RGB;
+	case gfx_api::pixel_format::compressed_rgb:
+		return GL_RGB_S3TC;
+	case gfx_api::pixel_format::compressed_rgba:
+		return GL_RGBA_S3TC;
+	default:
+		debug(LOG_FATAL, "Unrecognised pixel format");
+	}
+	return GL_INVALID_ENUM;
+}
+
+struct gl_texture : public gfx_api::texture
+{
+private:
+	friend struct gl_context;
+	GLuint _id;
+
+	gl_texture()
+	{
+		glGenTextures(1, &_id);
+	}
+
+	~gl_texture()
+	{
+		glDeleteTextures(1, &_id);
+	}
+public:
+	virtual void bind() override
+	{
+		glBindTexture(GL_TEXTURE_2D, _id);
+	}
+
+	virtual void upload(const size_t& mip_level, const size_t& offset_x, const size_t& offset_y, const size_t & width, const size_t & height, const gfx_api::pixel_format & buffer_format, const void * data) override
+	{
+		bind();
+		glTexSubImage2D(GL_TEXTURE_2D, mip_level, offset_x, offset_y, width, height, to_gl(buffer_format), GL_UNSIGNED_BYTE, data);
+	}
+
+	virtual unsigned id() override
+	{
+		return _id;
+	}
+
+	virtual void generate_mip_levels() override
+	{
+		glGenerateMipmap(GL_TEXTURE_2D);
+	}
+
+};
+
+struct gl_context : public gfx_api::context
+{
+	virtual gfx_api::texture* create_texture(const size_t & width, const size_t & height, const gfx_api::pixel_format & internal_format, const std::string& filename) override
+	{
+		auto* new_texture = new gl_texture();
+		new_texture->bind();
+		if (!filename.empty() && (GLEW_VERSION_4_3 || GLEW_KHR_debug))
+		{
+			glObjectLabel(GL_TEXTURE, new_texture->id(), -1, filename.c_str());
+		}
+		for (unsigned i = 0; i < floor(log(std::max(width, height))); ++i)
+		{
+			glTexImage2D(GL_TEXTURE_2D, i, to_gl(internal_format), width >> i, height >> i, 0, to_gl(internal_format), GL_UNSIGNED_BYTE, nullptr);
+		}
+		return new_texture;
+	}
+};
+
+gfx_api::context& gfx_api::context::get()
+{
+	static gl_context ctx;
+	return ctx;
+}

--- a/lib/ivis_opengl/pieblitfunc.h
+++ b/lib/ivis_opengl/pieblitfunc.h
@@ -31,6 +31,7 @@
 
 /***************************************************************************/
 
+#include "gfx_api.h"
 #include "lib/framework/frame.h"
 #include "lib/framework/string_ext.h"
 #include "lib/framework/vector.h"
@@ -81,7 +82,7 @@ public:
 
 	/// Allocate space on the GPU for texture of given parameters. If image is non-NULL,
 	/// then that memory buffer is uploaded to the GPU.
-	void makeTexture(int width, int height, GLenum filter = GL_LINEAR, GLenum format = GL_RGBA, const GLvoid *image = nullptr);
+	void makeTexture(int width, int height, GLenum filter = GL_LINEAR, const gfx_api::pixel_format& format = gfx_api::pixel_format::rgba, const GLvoid *image = nullptr);
 
 	/// Upload given memory buffer to already allocated texture space on the GPU
 	void updateTexture(const GLvoid *image, int width = -1, int height = -1);
@@ -94,13 +95,13 @@ public:
 
 private:
 	GFXTYPE mType;
-	GLenum mFormat;
+	gfx_api::pixel_format mFormat;
 	int mWidth;
 	int mHeight;
 	GLenum mdrawType;
 	int mCoordsPerVertex;
 	GLuint mBuffers[VBO_COUNT];
-	GLuint mTexture;
+	gfx_api::texture* mTexture = nullptr;
 	int mSize;
 };
 
@@ -120,7 +121,7 @@ static inline void iV_Box(int x0, int y0, int x1, int y1, PIELIGHT first)
 }
 void pie_BoxFill(int x0, int y0, int x1, int y1, PIELIGHT colour, REND_MODE rendermode = REND_OPAQUE);
 void iV_DrawImage(GLuint TextureID, Vector2i position, Vector2i offset, Vector2i size, float angle, REND_MODE mode, PIELIGHT colour);
-void iV_DrawImageText(GLuint TextureID, Vector2i position, Vector2i offset, Vector2i size, float angle, REND_MODE mode, PIELIGHT colour);
+void iV_DrawImageText(gfx_api::texture& TextureID, Vector2i position, Vector2i offset, Vector2i size, float angle, REND_MODE mode, PIELIGHT colour);
 void iV_DrawImage(IMAGEFILE *ImageFile, UWORD ID, int x, int y, const glm::mat4 &modelViewProjection = defaultProjectionMatrix());
 void iV_DrawImage2(const QString &filename, float x, float y, float width = -0.0f, float height = -0.0f);
 void iV_DrawImageTc(Image image, Image imageTc, int x, int y, PIELIGHT colour, const glm::mat4 &modelViewProjection = defaultProjectionMatrix());

--- a/lib/ivis_opengl/piemode.cpp
+++ b/lib/ivis_opengl/piemode.cpp
@@ -53,15 +53,13 @@ bool pie_Initialise()
 	pie_TexInit();
 
 	/* Find texture compression extension */
-	if (GLEW_ARB_texture_compression && wz_texture_compression != GL_RGBA)
+	if (GLEW_ARB_texture_compression && wz_texture_compression)
 	{
 		debug(LOG_TEXTURE, "Texture compression: Yes");
-		wz_texture_compression = GL_COMPRESSED_RGBA_ARB;
 	}
 	else
 	{
 		debug(LOG_TEXTURE, "Texture compression: No");
-		wz_texture_compression = GL_RGBA;
 	}
 
 	rendSurface.width	= pie_GetVideoBufferWidth();

--- a/lib/ivis_opengl/piestate.cpp
+++ b/lib/ivis_opengl/piestate.cpp
@@ -537,17 +537,17 @@ pie_internal::SHADER_PROGRAM &pie_ActivateShaderDeprecated(SHADER_MODE shaderMod
 	if (maskpage != iV_TEX_INVALID)
 	{
 		glActiveTexture(GL_TEXTURE1);
-		glBindTexture(GL_TEXTURE_2D, pie_Texture(maskpage));
+		pie_Texture(maskpage).bind();
 	}
 	if (normalpage != iV_TEX_INVALID)
 	{
 		glActiveTexture(GL_TEXTURE2);
-		glBindTexture(GL_TEXTURE_2D, pie_Texture(normalpage));
+		pie_Texture(normalpage).bind();
 	}
 	if (specularpage != iV_TEX_INVALID)
 	{
 		glActiveTexture(GL_TEXTURE3);
-		glBindTexture(GL_TEXTURE_2D, pie_Texture(specularpage));
+		pie_Texture(specularpage).bind();
 	}
 	glActiveTexture(GL_TEXTURE0);
 
@@ -628,7 +628,7 @@ void pie_SetTexturePage(SDWORD num)
 		case TEXPAGE_EXTERN:
 			break;
 		default:
-			glBindTexture(GL_TEXTURE_2D, pie_Texture(num));
+			pie_Texture(num).bind();
 		}
 		rendStates.texPage = num;
 	}

--- a/lib/ivis_opengl/screen.cpp
+++ b/lib/ivis_opengl/screen.cpp
@@ -54,7 +54,7 @@
 #include <glm/gtx/transform.hpp>
 
 /* global used to indicate preferred internal OpenGL format */
-int wz_texture_compression = 0;
+bool wz_texture_compression = 0;
 
 // for compatibility with older versions of GLEW
 #ifndef GLEW_ARB_timer_query
@@ -537,7 +537,7 @@ void screen_Upload(const char *newBackDropBmp)
 
 	if (newBackDropBmp) // preview
 	{
-		backdropGfx->makeTexture(BACKDROP_HACK_WIDTH, BACKDROP_HACK_HEIGHT, GL_NEAREST, GL_RGB, newBackDropBmp);
+		backdropGfx->makeTexture(BACKDROP_HACK_WIDTH, BACKDROP_HACK_HEIGHT, GL_NEAREST, gfx_api::pixel_format::rgb, newBackDropBmp);
 
 		int s1 = screenWidth / preview_width;
 		int s2 = screenHeight / preview_height;

--- a/lib/ivis_opengl/screen.h
+++ b/lib/ivis_opengl/screen.h
@@ -55,7 +55,7 @@ void screen_Display();
 /* screendump */
 void screenDumpToDisk(const char *path, const char *level);
 
-extern int wz_texture_compression;
+extern bool wz_texture_compression;
 
 void screenDoDumpToDiskIfRequired();
 

--- a/lib/ivis_opengl/tex.h
+++ b/lib/ivis_opengl/tex.h
@@ -20,7 +20,7 @@
 #ifndef _tex_
 #define _tex_
 
-#include "lib/framework/opengl.h"
+#include "gfx_api.h"
 #include "png_util.h"
 
 #define iV_TEX_INVALID 0
@@ -30,15 +30,16 @@
 
 //*************************************************************************
 
-GLuint pie_Texture(int page);
+gfx_api::texture& pie_Texture(int page);
 int pie_NumberOfPages();
-int pie_ReserveTexture(const char *name);
+int pie_ReserveTexture(const char *name, const size_t& width, const size_t& height);
+void pie_AssignTexture(int page, gfx_api::texture* texture);
 
 //*************************************************************************
 
 int iV_GetTexture(const char *filename, bool compression = true);
 void iV_unloadImage(iV_Image *image);
-unsigned int iV_getPixelFormat(const iV_Image *image);
+gfx_api::pixel_format iV_getPixelFormat(const iV_Image *image);
 
 bool replaceTexture(const QString &oldfile, const QString &newfile);
 int pie_AddTexPage(iV_Image *s, const char *filename, bool gameTexture, int page = -1);

--- a/lib/ivis_opengl/textdraw.h
+++ b/lib/ivis_opengl/textdraw.h
@@ -24,7 +24,7 @@
 #include <string>
 
 #include "lib/framework/vector.h"
-#include "lib/framework/opengl.h"
+#include "gfx_api.h"
 #include "pietypes.h"
 
 enum iV_fonts
@@ -42,6 +42,7 @@ class WzText
 {
 public:
 	WzText() {}
+	WzText& operator =(WzText&& in) = default;
 	WzText(const std::string &text, iV_fonts fontID);
 	void setText(const std::string &text, iV_fonts fontID);
 	~WzText();
@@ -56,7 +57,7 @@ public:
 private:
 	iV_fonts mFontID = font_count;
 	std::string mText;
-	GLuint texture = 0;
+	gfx_api::texture* texture = nullptr;
 	int mAboveBase = 0;
 	int mBelowBase = 0;
 	int mLineSize = 0;

--- a/lib/sequence/sequence.cpp
+++ b/lib/sequence/sequence.cpp
@@ -700,7 +700,7 @@ bool seq_Play(const char *filename)
 		}
 
 		Allocate_videoFrame();
-		videoGfx->makeTexture(texture_width, texture_height, GL_LINEAR, GL_RGBA, blackframe);
+		videoGfx->makeTexture(texture_width, texture_height, GL_LINEAR, gfx_api::pixel_format::rgba, blackframe);
 		free(blackframe);
 
 		// when using scanlines we need to double the height

--- a/src/clparse.cpp
+++ b/src/clparse.cpp
@@ -617,11 +617,11 @@ bool ParseCommandLine(int argc, const char **argv)
 			break;
 
 		case CLI_TEXTURECOMPRESSION:
-			wz_texture_compression = GL_COMPRESSED_RGBA_ARB;
+			wz_texture_compression = true;
 			break;
 
 		case CLI_NOTEXTURECOMPRESSION:
-			wz_texture_compression = GL_RGBA;
+			wz_texture_compression = false;
 			break;
 
 		case CLI_AUTOGAME:

--- a/src/console.cpp
+++ b/src/console.cpp
@@ -68,6 +68,16 @@ struct CONSOLE_MESSAGE
 	int		player;			// Player who sent this message or SYSTEM_MESSAGE
 	CONSOLE_MESSAGE(const std::string &text, iV_fonts fontID, UDWORD time, CONSOLE_TEXT_JUSTIFICATION justify, int plr)
 	                : display(text, fontID), timeAdded(time), JustifyType(justify), player(plr) {}
+
+	CONSOLE_MESSAGE& operator =(CONSOLE_MESSAGE&& input)
+	{
+		display = std::move(input.display);
+		timeAdded = input.timeAdded;
+		JustifyType = input.JustifyType;
+		player = input.player;
+		return *this;
+	}
+
 };
 
 static std::deque<CONSOLE_MESSAGE> ActiveMessages;		// we add all messages to this container


### PR DESCRIPTION
This PR wraps OpenGL texture in an opaque structure so that it can be later used as an abstraction.
The next step will be to port buffer and then pipeline (alpha mode, shaders, ...)