### PR TITLE
Make zip file creation reproducible

### DIFF
--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -4,7 +4,7 @@ stamp:
 	touch stamp
 
 %.wz: $(abs_srcdir)/% stamp
-	(cd $(srcdir)/$(notdir $<) && $(ZIP) -r0 $(ZIP_UPDATE) $(abs_builddir)/$@ $(filter-out stamp,$(filter-out $<,$(^:$</%=%))) -x '*svn*' -x '*Makefile*' -x '*.svg' || [ $$? -eq 12 ] && true) # zip returns 12 on "nothing to do"
+	(cd $(srcdir)/$(notdir $<) && $(ZIP) -X -r0 $(ZIP_UPDATE) $(abs_builddir)/$@ $$(find $(filter-out stamp,$(filter-out $<,$(^:$</%=%))) -type f | LC_ALL=C sort) -x '*svn*' -x '*Makefile*' -x '*.svg' || [ $$? -eq 12 ] && true) # zip returns 12 on "nothing to do"
 	$(ZIP) -T $@
 	rm -f stamp
 


### PR DESCRIPTION
by adding -X option to not store extra UNIX timestamps
and by sorting the recursed input file list

See https://reproducible-builds.org/ for why this is good.