### PR TITLE
Cmake: Generate .DDS texture out of PNGs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@
 *.ncb
 *.suo
 *.user
+*.dds
 /devpkg/*
 build_tools/autorevision/Debug/*
 build_tools/autorevision/Release/*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,6 +70,7 @@ add_subdirectory(3rdparty/sha2)
 add_subdirectory(lib)
 add_subdirectory(src)
 add_subdirectory(po)
-add_subdirectory(data)
 add_subdirectory(doc)
 add_subdirectory(pkg/nsis)
+
+add_subdirectory(data)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,6 +71,5 @@ add_subdirectory(lib)
 add_subdirectory(src)
 add_subdirectory(po)
 add_subdirectory(doc)
-add_subdirectory(pkg/nsis)
-
 add_subdirectory(data)
+add_subdirectory(pkg/nsis)

--- a/data/CMakeLists.txt
+++ b/data/CMakeLists.txt
@@ -1,46 +1,175 @@
 project(data)
 
+include(ExternalProject)
+	if("${CMAKE_CXX_COMPILER_ID}" MATCHES "MSVC")
+	ExternalProject_Add(
+	  nvidia-texture-tools
+	  GIT_REPOSITORY "https://github.com/vlj/nvidia-texture-tools.git"
+	  GIT_TAG "master"
+	  SOURCE_DIR "${CMAKE_BINARY_DIR}/nvtt"
+	  CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${CMAKE_BINARY_DIR}/nvtt/install
+	)
+	set (nvcompress "${CMAKE_BINARY_DIR}/nvtt/install/bin/nvcompress.exe")
+else()
+	find_program (nvcompress "nvcompress")
+endif()
 
-add_custom_target(data_base ALL COMMAND
-    zip -r0 ${CMAKE_CURRENT_BINARY_DIR}/base.wz
-	"palette.txt"
-	"audio"
-	"campaigns"
-	"components"
-	"effects"
-	"features"
-	"gamedesc.lev"
-	"ruleset.json"
-	"images"
-	"messages"
-	"misc"
-	"fonts"
-	"script"
-	"sequenceaudio"
-	"shaders"
-	"stats"
-	"structs"
-	"texpages"
-	"tileset"
-	"wrf"
-	WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/base")
-
-add_custom_target(data_mp ALL COMMAND
-    zip -r0 ${CMAKE_CURRENT_BINARY_DIR}/mp.wz
-	"addon.lev"
-	"ruleset.json"
-	"anims"
-	"challenges"
-	"tests"
-	"components"
-	"effects"
-	"messages"
-	"multiplay"
-	"stats"
-	"structs"
-	"wrf"
-	WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/mp"
+file(GLOB TEXTURES_INTERFACE
+	"${CMAKE_CURRENT_SOURCE_DIR}/base/texpages/bdrops/*.png"
+	"${CMAKE_CURRENT_SOURCE_DIR}/base/images/frontend/*.png"
+	"${CMAKE_CURRENT_SOURCE_DIR}/base/images/intfac/*.png"
 )
+
+file(GLOB TEXTURE_3D
+	"${CMAKE_CURRENT_SOURCE_DIR}/base/texpages/*.png"
+	"${CMAKE_CURRENT_SOURCE_DIR}/base/texpages/tertilesc1hw-128/*.png"
+	"${CMAKE_CURRENT_SOURCE_DIR}/base/texpages/tertilesc1hw-16/*.png"
+	"${CMAKE_CURRENT_SOURCE_DIR}/base/texpages/tertilesc1hw-32/*.png"
+	"${CMAKE_CURRENT_SOURCE_DIR}/base/texpages/tertilesc1hw-64/*.png"
+	"${CMAKE_CURRENT_SOURCE_DIR}/base/texpages/tertilesc2hw-128/*.png"
+	"${CMAKE_CURRENT_SOURCE_DIR}/base/texpages/tertilesc2hw-16/*.png"
+	"${CMAKE_CURRENT_SOURCE_DIR}/base/texpages/tertilesc2hw-32/*.png"
+	"${CMAKE_CURRENT_SOURCE_DIR}/base/texpages/tertilesc2hw-64/*.png"
+	"${CMAKE_CURRENT_SOURCE_DIR}/base/texpages/tertilesc3hw-128/*.png"
+	"${CMAKE_CURRENT_SOURCE_DIR}/base/texpages/tertilesc3hw-16/*.png"
+	"${CMAKE_CURRENT_SOURCE_DIR}/base/texpages/tertilesc3hw-32/*.png"
+	"${CMAKE_CURRENT_SOURCE_DIR}/base/texpages/tertilesc3hw-64/*.png"
+)
+
+set(DDS_FILES "")
+
+#Note: only diff here is between build is nvidia-texture-tools dependency
+if("${CMAKE_CXX_COMPILER_ID}" MATCHES "MSVC")
+	foreach(TEXTURE ${TEXTURES_INTERFACE})
+		get_filename_component(PNG_FILE_PATH ${TEXTURE} DIRECTORY)
+		get_filename_component(PNG_FILE ${TEXTURE} NAME_WE)
+		add_custom_command(OUTPUT "${PNG_FILE_PATH}/${PNG_FILE}.dds"
+			COMMAND "${nvcompress}" "-color" "-alpha" "-rgb" "-nomips" "${TEXTURE}"# "${CMAKE_CURRENT_BINARY_DIR}/data/base/texpages/bdrops/backdrop0.dds"
+			DEPENDS "${TEXTURE}" nvidia-texture-tools
+			)
+		list(APPEND DDS_FILES "${PNG_FILE_PATH}/${PNG_FILE}.dds;")
+	endforeach()
+
+	foreach(TEXTURE ${TEXTURE_3D})
+		get_filename_component(PNG_FILE_PATH ${TEXTURE} DIRECTORY)
+		get_filename_component(PNG_FILE ${TEXTURE} NAME_WE)
+		add_custom_command(OUTPUT "${PNG_FILE_PATH}/${PNG_FILE}.dds"
+			COMMAND "${nvcompress}" "-color" "-alpha" "-rgb" "${TEXTURE}"# "${CMAKE_CURRENT_BINARY_DIR}/data/base/texpages/bdrops/backdrop0.dds"
+			DEPENDS "${TEXTURE}" nvidia-texture-tools
+			)
+		list(APPEND DDS_FILES "${PNG_FILE_PATH}/${PNG_FILE}.dds;")
+	endforeach()
+else()
+	foreach(TEXTURE ${TEXTURES_INTERFACE})
+		get_filename_component(PNG_FILE_PATH ${TEXTURE} DIRECTORY)
+		get_filename_component(PNG_FILE ${TEXTURE} NAME_WE)
+		add_custom_command(OUTPUT "${PNG_FILE_PATH}/${PNG_FILE}.dds"
+			COMMAND "${nvcompress}" "-color" "-alpha" "-rgb" "-nomips" "${TEXTURE}"# "${CMAKE_CURRENT_BINARY_DIR}/data/base/texpages/bdrops/backdrop0.dds"
+			DEPENDS "${TEXTURE}"
+			)
+		list(APPEND DDS_FILES "${PNG_FILE_PATH}/${PNG_FILE}.dds;")
+	endforeach()
+
+	foreach(TEXTURE ${TEXTURE_3D})
+		get_filename_component(PNG_FILE_PATH ${TEXTURE} DIRECTORY)
+		get_filename_component(PNG_FILE ${TEXTURE} NAME_WE)
+		add_custom_command(OUTPUT "${PNG_FILE_PATH}/${PNG_FILE}.dds"
+			COMMAND "${nvcompress}" "-color" "-alpha" "-rgb" "${TEXTURE}"# "${CMAKE_CURRENT_BINARY_DIR}/data/base/texpages/bdrops/backdrop0.dds"
+			DEPENDS "${TEXTURE}"
+			)
+		list(APPEND DDS_FILES "${PNG_FILE_PATH}/${PNG_FILE}.dds;")
+	endforeach()
+endif()
+
+# Bug ?: mxe build hang if zip with non 0 compression level, windows is ok
+if("${CMAKE_CXX_COMPILER_ID}" MATCHES "MSVC")
+add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/base.wz
+		COMMAND ${CMAKE_COMMAND} -E tar "cfv" "${CMAKE_CURRENT_BINARY_DIR}/base.wz" --format=zip
+		"palette.txt"
+		"audio"
+		"campaigns"
+		"components"
+		"effects"
+		"features"
+		"gamedesc.lev"
+		"ruleset.json"
+		"images"
+		"messages"
+		"misc"
+		"fonts"
+		"script"
+		"sequenceaudio"
+		"shaders"
+		"stats"
+		"structs"
+		"texpages"
+		"tileset"
+		"wrf"
+		WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/base"
+		DEPENDS ${DDS_FILES})
+	
+	add_custom_target(data_mp ALL COMMAND
+		${CMAKE_COMMAND} -E tar "cfv"  "${CMAKE_CURRENT_BINARY_DIR}/mp.wz"  --format=zip
+		"addon.lev"
+		"ruleset.json"
+		"anims"
+		"challenges"
+		"tests"
+		"components"
+		"effects"
+		"messages"
+		"multiplay"
+		"stats"
+		"structs"
+		"wrf"
+		WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/mp"
+	)
+else()
+	add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/base.wz
+		COMMAND zip -r0 ${CMAKE_CURRENT_BINARY_DIR}/base.wz
+		"palette.txt"
+		"audio"
+		"campaigns"
+		"components"
+		"effects"
+		"features"
+		"gamedesc.lev"
+		"ruleset.json"
+		"images"
+		"messages"
+		"misc"
+		"fonts"
+		"script"
+		"sequenceaudio"
+		"shaders"
+		"stats"
+		"structs"
+		"texpages"
+		"tileset"
+		"wrf"
+		WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/base"
+		DEPENDS ${DDS_FILES})
+	
+	add_custom_target(data_mp ALL COMMAND
+		zip -r0 ${CMAKE_CURRENT_BINARY_DIR}/mp.wz
+		"addon.lev"
+		"ruleset.json"
+		"anims"
+		"challenges"
+		"tests"
+		"components"
+		"effects"
+		"messages"
+		"multiplay"
+		"stats"
+		"structs"
+		"wrf"
+		WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/mp"
+	)
+endif()
+
+add_custom_target(data_base ALL
+	DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/base.wz")
 
 install(FILES
 	"${CMAKE_CURRENT_BINARY_DIR}/base.wz"

--- a/data/CMakeLists.txt
+++ b/data/CMakeLists.txt
@@ -81,49 +81,49 @@ else()
 	endforeach()
 endif()
 
-# Bug ?: mxe build hang if zip with non 0 compression level, windows is ok
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "MSVC")
-add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/base.wz
-		COMMAND ${CMAKE_COMMAND} -E tar "cfv" "${CMAKE_CURRENT_BINARY_DIR}/base.wz" --format=zip
-		"palette.txt"
-		"audio"
-		"campaigns"
-		"components"
-		"effects"
-		"features"
-		"gamedesc.lev"
-		"ruleset.json"
-		"images"
-		"messages"
-		"misc"
-		"fonts"
-		"script"
-		"sequenceaudio"
-		"shaders"
-		"stats"
-		"structs"
-		"texpages"
-		"tileset"
-		"wrf"
-		WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/base"
+	install(DIRECTORY
+		"base/audio"
+		"base/campaigns"
+		"base/components"
+		"base/effects"
+		"base/features"
+		"base/images"
+		"base/messages"
+		"base/misc"
+		"base/fonts"
+		"base/script"
+		"base/sequenceaudio"
+		"base/shaders"
+		"base/stats"
+		"base/structs"
+		"base/texpages"
+		"base/tileset"
+		"base/wrf"
+		DESTINATION "data/base/")
+	install(DIRECTORY
+		"mp/anims"
+		"mp/challenges"
+		"mp/tests"
+		"mp/components"
+		"mp/effects"
+		"mp/messages"
+		"mp/multiplay"
+		"mp/stats"
+		"mp/structs"
+		"mp/wrf"
+		DESTINATION "data/mp/")
+	install(FILES
+		"base/palette.txt"
+		"base/ruleset.json"
+		"base/gamedesc.lev"
+		DESTINATION "data/base")
+	install(FILES
+		"mp/addon.lev"
+		"mp/ruleset.json"
+		DESTINATION "data/mp")
+	add_custom_target(data_base ALL
 		DEPENDS ${DDS_FILES})
-	
-	add_custom_target(data_mp ALL COMMAND
-		${CMAKE_COMMAND} -E tar "cfv"  "${CMAKE_CURRENT_BINARY_DIR}/mp.wz"  --format=zip
-		"addon.lev"
-		"ruleset.json"
-		"anims"
-		"challenges"
-		"tests"
-		"components"
-		"effects"
-		"messages"
-		"multiplay"
-		"stats"
-		"structs"
-		"wrf"
-		WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/mp"
-	)
 else()
 	add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/base.wz
 		COMMAND zip -r0 ${CMAKE_CURRENT_BINARY_DIR}/base.wz
@@ -166,15 +166,14 @@ else()
 		"wrf"
 		WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/mp"
 	)
+	install(FILES
+		"${CMAKE_CURRENT_BINARY_DIR}/base.wz"
+		"${CMAKE_CURRENT_BINARY_DIR}/mp.wz"
+		DESTINATION ".")
+	add_custom_target(data_base ALL
+		DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/base.wz")
 endif()
 
-add_custom_target(data_base ALL
-	DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/base.wz")
-
-install(FILES
-	"${CMAKE_CURRENT_BINARY_DIR}/base.wz"
-	"${CMAKE_CURRENT_BINARY_DIR}/mp.wz"
-	DESTINATION ".")
 install(FILES
 	"${CMAKE_CURRENT_SOURCE_DIR}/music/menu.ogg"
 	"${CMAKE_CURRENT_SOURCE_DIR}/music/track1.ogg"

--- a/data/CMakeLists.txt
+++ b/data/CMakeLists.txt
@@ -100,6 +100,7 @@ if("${CMAKE_CXX_COMPILER_ID}" MATCHES "MSVC")
 		"base/texpages"
 		"base/tileset"
 		"base/wrf"
+		COMPONENT Data
 		DESTINATION "data/base/")
 	install(DIRECTORY
 		"mp/anims"
@@ -112,15 +113,18 @@ if("${CMAKE_CXX_COMPILER_ID}" MATCHES "MSVC")
 		"mp/stats"
 		"mp/structs"
 		"mp/wrf"
+		COMPONENT Data
 		DESTINATION "data/mp/")
 	install(FILES
 		"base/palette.txt"
 		"base/ruleset.json"
 		"base/gamedesc.lev"
+		COMPONENT Data
 		DESTINATION "data/base")
 	install(FILES
 		"mp/addon.lev"
 		"mp/ruleset.json"
+		COMPONENT Data
 		DESTINATION "data/mp")
 	add_custom_target(data_base ALL
 		DEPENDS ${DDS_FILES})
@@ -169,6 +173,7 @@ else()
 	install(FILES
 		"${CMAKE_CURRENT_BINARY_DIR}/base.wz"
 		"${CMAKE_CURRENT_BINARY_DIR}/mp.wz"
+		COMPONENT Data
 		DESTINATION ".")
 	add_custom_target(data_base ALL
 		DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/base.wz")
@@ -180,4 +185,5 @@ install(FILES
 	"${CMAKE_CURRENT_SOURCE_DIR}/music/track2.ogg"
 	"${CMAKE_CURRENT_SOURCE_DIR}/music/track3.ogg"
 	"${CMAKE_CURRENT_SOURCE_DIR}/music/music.wpl"
+	COMPONENT Data
 	DESTINATION "music")

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -1,4 +1,3 @@
-project(doc)
 
 if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU")
 add_custom_target(doc_wz2100 ALL)
@@ -86,8 +85,8 @@ add_custom_command(
 
 endif()
 
-install(FILES ${doc_DATA} DESTINATION "doc/images/")
-install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/docbook-xsl.css" DESTINATION "doc/")
-install(FILES "${CMAKE_CURRENT_BINARY_DIR}/quickstartguide.html" DESTINATION "doc/")
+install(FILES ${doc_DATA} COMPONENT Doc DESTINATION "doc/images/")
+install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/docbook-xsl.css" COMPONENT Doc DESTINATION "doc/")
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/quickstartguide.html" COMPONENT Doc DESTINATION "doc/")
 
 endif()

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -1,5 +1,6 @@
 project(doc)
 
+if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU")
 add_custom_target(doc_wz2100 ALL)
 
 set(doc_DATA
@@ -88,3 +89,5 @@ endif()
 install(FILES ${doc_DATA} DESTINATION "doc/images/")
 install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/docbook-xsl.css" DESTINATION "doc/")
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/quickstartguide.html" DESTINATION "doc/")
+
+endif()

--- a/docker/cross-compile/dockerfile
+++ b/docker/cross-compile/dockerfile
@@ -5,11 +5,11 @@ RUN apt-get -u update && apt-get -y install \
     git g++ gperf intltool libffi-dev libgdk-pixbuf2.0-dev \
     libtool libtool-bin libltdl-dev libssl-dev libxml-parser-perl make \
     p7zip-full patch perl pkg-config python ruby scons \
-    sed unzip wget xz-utils cmake asciidoc nsis ninja-build
+    sed unzip wget xz-utils cmake asciidoc nsis ninja-build libnvtt-bin
 
 RUN git clone https://github.com/mxe/mxe.git
 
-RUN cd mxe && make -j 2 JOBS=4 gcc zlib bfd gettext jpeg libpng ogg vorbis openal theora qt5 sdl2 physfs glew freetype fontconfig fribidi libiberty harfbuzz
+RUN cd mxe && make -j 2 JOBS=4 gcc zlib bfd gettext jpeg libpng ogg vorbis openal theora qt5 sdl2 physfs glew freetype fribidi libiberty harfbuzz
 RUN cp /usr/share/fonts/truetype/dejavu/DejaVuSans.ttf /mxe/usr/i686-w64-mingw32.static/etc/fonts/
 RUN cp /usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf /mxe/usr/i686-w64-mingw32.static/etc/fonts/
 

--- a/docker/ubuntu/Dockerfile
+++ b/docker/ubuntu/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu
 
-RUN apt-get -u update && apt-get -y install build-essential automake libpng12-dev libsdl2-dev libopenal-dev libphysfs-dev libvorbis-dev libtheora-dev libglc-dev libglew1.5-dev libxrandr-dev zip unzip libqt5opengl5-dev libssl-dev qtscript5-dev qt5-default libharfbuzz-dev git cmake
+RUN apt-get -u update && apt-get -y install build-essential automake libpng12-dev libsdl2-dev libopenal-dev libphysfs-dev libvorbis-dev libtheora-dev libglc-dev libglew1.5-dev libxrandr-dev zip unzip libqt5opengl5-dev libssl-dev qtscript5-dev qt5-default libharfbuzz-dev git cmake gettext ninja-build libnvtt-bin asciidoc
 WORKDIR /code
 CMD ["sh"]
 

--- a/pkg/nsis/CMakeLists.txt
+++ b/pkg/nsis/CMakeLists.txt
@@ -1,5 +1,5 @@
 if(${CMAKE_CXX_COMPILER_ID} MATCHES "GNU" AND ${CMAKE_CROSSCOMPILING})
-
+endif()
 set(INSTALLER_VERSION "0.0.0.0" CACHE STRING "NSIS version")
 set(INSTALLER_EXTDIR "" CACHE STRING "NSIS ext dir")
 set(INSTALLER_COMPRESSION 1 CACHE STRING "NSIS compression level")
@@ -16,4 +16,3 @@ configure_file(
   ${CMAKE_CURRENT_SOURCE_DIR}/NSIS.definitions.in
   ${CMAKE_BINARY_DIR}/NSIS.definitions.nsh
 )
-endif()

--- a/pkg/nsis/CMakeLists.txt
+++ b/pkg/nsis/CMakeLists.txt
@@ -12,6 +12,18 @@ set(CPACK_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}")
 SET(CPACK_GENERATOR "NSIS")
 INCLUDE(CPack)
 
+cpack_add_component(Core
+	DISPLAY_NAME "Core files"
+	DESCRIPTION "The core files required to run Warzone 2100."
+	REQUIRED)
+cpack_add_component(Data
+	DISPLAY_NAME "Data files"
+	DESCRIPTION "The data files required to run Warzone 2100."
+	REQUIRED)
+cpack_add_component(Lang
+	DISPLAY_NAME "Language files"
+	DESCRIPTION "Support for languages other than English.")
+
 configure_file(
   ${CMAKE_CURRENT_SOURCE_DIR}/NSIS.definitions.in
   ${CMAKE_BINARY_DIR}/NSIS.definitions.nsh

--- a/pkg/nsis/NSIS.template.in
+++ b/pkg/nsis/NSIS.template.in
@@ -26,7 +26,7 @@
   !include "MUI.nsh"
   !include "FileFunc.nsh"
   !include "LogicLib.nsh"
-  !include "../../../NSIS.definitions.nsh"
+  !include "..\..\..\NSIS.definitions.nsh"
 
 ;--------------------------------
 ;General
@@ -109,13 +109,22 @@ VIAddVersionKey "ProductVersion"	"${PACKAGE_VERSION}"
   !define INST_DIR "@CPACK_TEMPORARY_DIRECTORY@"
 
 ;--------------------------------
+; Define some macro setting for the gui
+@CPACK_NSIS_INSTALLER_MUI_ICON_CODE@
+@CPACK_NSIS_INSTALLER_ICON_CODE@
+@CPACK_NSIS_INSTALLER_MUI_WELCOMEFINISH_CODE@
+@CPACK_NSIS_INSTALLER_MUI_UNWELCOMEFINISH_CODE@
+@CPACK_NSIS_INSTALLER_MUI_COMPONENTS_DESC@
+@CPACK_NSIS_INSTALLER_MUI_FINISHPAGE_RUN_CODE@
+
+;--------------------------------
 ;Pages
 
   !define MUI_PAGE_CUSTOMFUNCTION_PRE WelcomePageSetupLinkPre
   !define MUI_PAGE_CUSTOMFUNCTION_SHOW WelcomePageSetupLinkShow
   !insertmacro MUI_PAGE_WELCOME
   !insertmacro MUI_PAGE_LICENSE "${TOP_SRCDIR}\COPYING"
-  !insertmacro MUI_PAGE_COMPONENTS
+  @CPACK_NSIS_PAGE_COMPONENTS@
   !insertmacro MUI_PAGE_DIRECTORY
 !ifndef PORTABLE
   !insertmacro MUI_PAGE_STARTMENU "Application" $STARTMENU_FOLDER
@@ -319,103 +328,6 @@ SectionGroupEnd
 !endif
 
 SectionGroup $(TEXT_SecNLS) SecNLS
-
-Section "-NLS files" SecNLS_files
-  SetOutPath "$INSTDIR\locale\ca\LC_MESSAGES"
-  File "/oname=warzone2100.mo" "${TOP_SRCDIR}\po\ca_ES.gmo"
-
-  SetOutPath "$INSTDIR\locale\cs\LC_MESSAGES"
-  File "/oname=warzone2100.mo" "${TOP_SRCDIR}\po\cs.gmo"
-
-  SetOutPath "$INSTDIR\locale\da\LC_MESSAGES"
-  File "/oname=warzone2100.mo" "${TOP_SRCDIR}\po\da.gmo"
-
-  SetOutPath "$INSTDIR\locale\de\LC_MESSAGES"
-  File "/oname=warzone2100.mo" "${TOP_SRCDIR}\po\de.gmo"
-
-  SetOutPath "$INSTDIR\locale\el\LC_MESSAGES"
-  File "/oname=warzone2100.mo" "${TOP_SRCDIR}\po\el.gmo"
-
-  SetOutPath "$INSTDIR\locale\en_GB\LC_MESSAGES"
-  File "/oname=warzone2100.mo" "${TOP_SRCDIR}\po\en_GB.gmo"
-
-  SetOutPath "$INSTDIR\locale\es\LC_MESSAGES"
-  File "/oname=warzone2100.mo" "${TOP_SRCDIR}\po\es.gmo"
-
-  SetOutPath "$INSTDIR\locale\et\LC_MESSAGES"
-  File "/oname=warzone2100.mo" "${TOP_SRCDIR}\po\et_EE.gmo"
-
-  SetOutPath "$INSTDIR\locale\fi\LC_MESSAGES"
-  File "/oname=warzone2100.mo" "${TOP_SRCDIR}\po\fi.gmo"
-
-  SetOutPath "$INSTDIR\locale\fr\LC_MESSAGES"
-  File "/oname=warzone2100.mo" "${TOP_SRCDIR}\po\fr.gmo"
-
-  SetOutPath "$INSTDIR\locale\fy\LC_MESSAGES"
-  File "/oname=warzone2100.mo" "${TOP_SRCDIR}\po\fy.gmo"
-
-  SetOutPath "$INSTDIR\locale\ga\LC_MESSAGES"
-  File "/oname=warzone2100.mo" "${TOP_SRCDIR}\po\ga.gmo"
-
-  SetOutPath "$INSTDIR\locale\hr\LC_MESSAGES"
-  File "/oname=warzone2100.mo" "${TOP_SRCDIR}\po\hr.gmo"
-
-  SetOutPath "$INSTDIR\locale\hu\LC_MESSAGES"
-  File "/oname=warzone2100.mo" "${TOP_SRCDIR}\po\hu.gmo"
-
-  SetOutPath "$INSTDIR\locale\it\LC_MESSAGES"
-  File "/oname=warzone2100.mo" "${TOP_SRCDIR}\po\it.gmo"
-
-  SetOutPath "$INSTDIR\locale\ko\LC_MESSAGES"
-  File "/oname=warzone2100.mo" "${TOP_SRCDIR}\po\ko.gmo"
-
-  SetOutPath "$INSTDIR\locale\la\LC_MESSAGES"
-  File "/oname=warzone2100.mo" "${TOP_SRCDIR}\po\la.gmo"
-
-  SetOutPath "$INSTDIR\locale\lt\LC_MESSAGES"
-  File "/oname=warzone2100.mo" "${TOP_SRCDIR}\po\lt.gmo"
-
-  SetOutPath "$INSTDIR\locale\nb\LC_MESSAGES"
-  File "/oname=warzone2100.mo" "${TOP_SRCDIR}\po\nb.gmo"
-
-  SetOutPath "$INSTDIR\locale\nl\LC_MESSAGES"
-  File "/oname=warzone2100.mo" "${TOP_SRCDIR}\po\nl.gmo"
-
-  SetOutPath "$INSTDIR\locale\pl\LC_MESSAGES"
-  File "/oname=warzone2100.mo" "${TOP_SRCDIR}\po\pl.gmo"
-
-  SetOutPath "$INSTDIR\locale\pt_BR\LC_MESSAGES"
-  File "/oname=warzone2100.mo" "${TOP_SRCDIR}\po\pt_BR.gmo"
-
-  SetOutPath "$INSTDIR\locale\pt\LC_MESSAGES"
-  File "/oname=warzone2100.mo" "${TOP_SRCDIR}\po\pt.gmo"
-
-  SetOutPath "$INSTDIR\locale\ro\LC_MESSAGES"
-  File "/oname=warzone2100.mo" "${TOP_SRCDIR}\po\ro.gmo"
-
-  SetOutPath "$INSTDIR\locale\ru\LC_MESSAGES"
-  File "/oname=warzone2100.mo" "${TOP_SRCDIR}\po\ru.gmo"
-
-  SetOutPath "$INSTDIR\locale\sk\LC_MESSAGES"
-  File "/oname=warzone2100.mo" "${TOP_SRCDIR}\po\sk.gmo"
-
-  SetOutPath "$INSTDIR\locale\sl\LC_MESSAGES"
-  File "/oname=warzone2100.mo" "${TOP_SRCDIR}\po\sl.gmo"
-
-  SetOutPath "$INSTDIR\locale\tr\LC_MESSAGES"
-  File "/oname=warzone2100.mo" "${TOP_SRCDIR}\po\tr.gmo"
-
-  SetOutPath "$INSTDIR\locale\uk\LC_MESSAGES"
-  File "/oname=warzone2100.mo" "${TOP_SRCDIR}\po\uk_UA.gmo"
-
-  SetOutPath "$INSTDIR\locale\zh_TW\LC_MESSAGES"
-  File "/oname=warzone2100.mo" "${TOP_SRCDIR}\po\zh_TW.gmo"
-
-  SetOutPath "$INSTDIR\locale\zh_CN\LC_MESSAGES"
-  File "/oname=warzone2100.mo" "${TOP_SRCDIR}\po\zh_CN.gmo"
-
-SectionEnd
-
 ;Replace fonts.conf with Windows 'fonts' enabled one
 ;Section /o $(TEXT_SecNLS_WinFonts) SecNLS_WinFonts
 ;  SetOutPath "$INSTDIR\fonts"
@@ -526,180 +438,9 @@ FunctionEnd
 ;--------------------------------
 ;Descriptions
 
-!ifndef PORTABLE
-  ;English
-  LangString WZWelcomeText ${LANG_ENGLISH} "Welcome to the Warzone 2100 installer!\r\n\r\nThis wizard will guide you through the installation of Warzone 2100.\r\n\r\nIt is recommended that you close all other applications before continuing this installation. This will make it possible to update relevant system files without having to reboot your computer.\r\n\r\nWarzone 2100 is 100% free, fully open sourced program\r\n\r\nClick Next to continue."
-!else
-  LangString WZWelcomeText ${LANG_ENGLISH} "Welcome to the Warzone 2100 portable installer!\r\n\r\nThis wizard will guide you through the installation of the portable version of Warzone 2100.\r\n\r\nThis install is fully self-contained and you can uninstall the program at any time by deleting the directory.\r\n\r\nWarzone 2100 is 100% free, fully open sourced program! \r\n\r\nClick Next to continue."
-!endif
-  LangString WZ_GPL_NEXT ${LANG_ENGLISH} "Next"
 
-
-  LangString TEXT_SecBase ${LANG_ENGLISH} "Core files"
-  LangString DESC_SecBase ${LANG_ENGLISH} "The core files required to run Warzone 2100."
-
-  LangString TEXT_SecOpenAL ${LANG_ENGLISH} "OpenAL libraries"
-  LangString DESC_SecOpenAL ${LANG_ENGLISH} "Runtime libraries for OpenAL, a free Audio interface. Implementation by Creative Labs."
-
-;  LangString TEXT_SecMods ${LANG_ENGLISH} "Mods"
-;  LangString DESC_SecMods ${LANG_ENGLISH} "Various mods for Warzone 2100."
-
-  LangString TEXT_SecFMVs ${LANG_ENGLISH} "Videos"
-  LangString DESC_SecFMVs ${LANG_ENGLISH} "Download and install in-game cutscenes."
-
-  LangString TEXT_SecFMVs_EngHi ${LANG_ENGLISH} "English (HQ)"
-  LangString DESC_SecFMVs_EngHi ${LANG_ENGLISH} "Download and install higher-quality English in-game cutscenes (920 MB)."
-
-  LangString TEXT_SecFMVs_Eng ${LANG_ENGLISH} "English"
-  LangString DESC_SecFMVs_Eng ${LANG_ENGLISH} "Download and install English in-game cutscenes (545 MB)."
-
-  LangString TEXT_SecFMVs_EngLo ${LANG_ENGLISH} "English (LQ)"
-  LangString DESC_SecFMVs_EngLo ${LANG_ENGLISH} "Download and install a low-quality version of English in-game cutscenes (162 MB)."
-
-  LangString TEXT_SecFMVs_Ger ${LANG_ENGLISH} "German"
-  LangString DESC_SecFMVs_Ger ${LANG_ENGLISH} "Download and install German in-game cutscenes (460 MB)."
-
-  LangString TEXT_SecNLS ${LANG_ENGLISH} "Language files"
-  LangString DESC_SecNLS ${LANG_ENGLISH} "Support for languages other than English."
-
-  LangString TEXT_SecNLS_WinFonts ${LANG_ENGLISH} "WinFonts"
-  LangString DESC_SecNLS_WinFonts ${LANG_ENGLISH} "Include Windows Fonts folder into the search path. Enable this if you want to use custom fonts in config file or having troubles with standard font. Can be slow on Vista and later!"
-
-;  LangString TEXT_SecOriginalMod ${LANG_ENGLISH} "1.10 balance"
-;  LangString DESC_SecOriginalMod ${LANG_ENGLISH} "Play the game as it was back in the 1.10 days."
-
-  ;Dutch
-  LangString WZWelcomeText ${LANG_DUTCH} "Deze installatiewizard leidt u door het installatieproces van Warzone 2100.\r\n\r\nHet is aangeraden om alle andere applicaties te sluiten alvorens verder te gaan met deze installatie. Dit maakt het mogelijk om de betreffende systeembestanden te vervangen zonder uw computer opnieuw op te starten"
-  LangString WZ_GPL_NEXT ${LANG_DUTCH} "volgende"
-
-
-  LangString TEXT_SecBase ${LANG_DUTCH} "Core files"
-  LangString DESC_SecBase ${LANG_DUTCH} "The core files required to run Warzone 2100."
-
-  LangString TEXT_SecOpenAL ${LANG_DUTCH} "OpenAL bibliotheken"
-  LangString DESC_SecOpenAL ${LANG_DUTCH} "Vereiste bibliotheken voor OpenAL, een opensource/vrije Audio Bibliotheek."
-
-;  LangString TEXT_SecMods ${LANG_DUTCH} "Mods"
-;  LangString DESC_SecMods ${LANG_DUTCH} "Verschillende mods."
-
-  LangString TEXT_SecFMVs ${LANG_DUTCH} "Videos"
-  LangString DESC_SecFMVs ${LANG_DUTCH} "Download and install in-game cutscenes."
-
-  LangString TEXT_SecFMVs_EngHi ${LANG_DUTCH} "English (HQ)"
-  LangString DESC_SecFMVs_EngHi ${LANG_DUTCH} "Download and install higher-quality English in-game cutscenes (920 MB)."
-
-  LangString TEXT_SecFMVs_Eng ${LANG_DUTCH} "English"
-  LangString DESC_SecFMVs_Eng ${LANG_DUTCH} "Download and install English in-game cutscenes (545 MB)."
-
-  LangString TEXT_SecFMVs_EngLo ${LANG_DUTCH} "English (LQ)"
-  LangString DESC_SecFMVs_EngLo ${LANG_DUTCH} "Download and install a low-quality version of English in-game cutscenes (162 MB)."
-
-  LangString TEXT_SecFMVs_Ger ${LANG_DUTCH} "German"
-  LangString DESC_SecFMVs_Ger ${LANG_DUTCH} "Download and install German in-game cutscenes (460 MB)."
-
-  LangString TEXT_SecNLS ${LANG_DUTCH} "Language files"
-  LangString DESC_SecNLS ${LANG_DUTCH} "Ondersteuning voor andere talen dan Engels (Nederlands inbegrepen)."
-
-  LangString TEXT_SecNLS_WinFonts ${LANG_DUTCH} "WinFonts"
-  LangString DESC_SecNLS_WinFonts ${LANG_DUTCH} "Include Windows Fonts folder into the search path. Enable this if you want to use custom fonts in config file or having troubles with standard font. Can be slow on Vista and later!"
-
-;  LangString TEXT_SecOriginalMod ${LANG_DUTCH} "1.10 balance"
-;  LangString DESC_SecOriginalMod ${LANG_DUTCH} "Speel het spel met de originele 1.10 versie balans stats."
-
-  ;German
-  LangString WZWelcomeText ${LANG_GERMAN} "Dieser Wizard wird Sie durch die Warzone-2100-Installation fьhren.\r\n\r\nEs wird empfohlen sдmtliche anderen Anwendungen zu schlieЯen, bevor Sie das Setup starten. Dies ermцglicht es relevante Systemdateien zu aktualisieren, ohne neustarten zu mьssen.\r\n\r\nWarzone 2100 ist zu 100% kostenlos, falls Sie dafьr gezahlt haben, lassen Sie es uns wissen!\r\n\r\nKlicken Sie auf Weiter, um fortzufahren."
-  LangString WZ_GPL_NEXT ${LANG_GERMAN} "nдchste"
-
-
-  LangString TEXT_SecBase ${LANG_GERMAN} "Core files"
-  LangString DESC_SecBase ${LANG_GERMAN} "Die Kerndateien, die fьr Warzone 2100 benцtigt werden."
-
-  LangString TEXT_SecOpenAL ${LANG_GERMAN} "OpenAL Bibliotheken"
-  LangString DESC_SecOpenAL ${LANG_GERMAN} "Bibliotheken fьr OpenAL, ein freies Audio Interface. Implementation von Creative Labs."
-
-;  LangString TEXT_SecMods ${LANG_GERMAN} "Mods"
-;  LangString DESC_SecMods ${LANG_GERMAN} "Verschiedene Mods."
-
-  LangString TEXT_SecFMVs ${LANG_GERMAN} "Videos"
-  LangString DESC_SecFMVs ${LANG_GERMAN} "Videos herunterladen und installieren."
-
-  LangString TEXT_SecFMVs_EngHi ${LANG_GERMAN} "English (HQ)"
-  LangString DESC_SecFMVs_EngHi ${LANG_GERMAN} "Videos in besserer Qualitдt und auf Englisch herunterladen und installieren (920 MiB)."
-
-  LangString TEXT_SecFMVs_Eng ${LANG_GERMAN} "English"
-  LangString DESC_SecFMVs_Eng ${LANG_GERMAN} "Die englischen Videos herunterladen und installieren (545 MiB)."
-
-  LangString TEXT_SecFMVs_EngLo ${LANG_GERMAN} "English (LQ)"
-  LangString DESC_SecFMVs_EngLo ${LANG_GERMAN} "Die englischen Videos in geringer Qualitдt herunterladen und installieren (162 MiB)."
-
-  LangString TEXT_SecFMVs_Ger ${LANG_GERMAN} "German"
-  LangString DESC_SecFMVs_Ger ${LANG_GERMAN} "Die deutschen Videos herunterladen und installieren (460 MiB)."
-
-  LangString TEXT_SecNLS ${LANG_GERMAN} "Language files"
-  LangString DESC_SecNLS ${LANG_GERMAN} "Unterstьtzung fьr Sprachen auЯer Englisch (Deutsch inbegriffen)."
-
-  LangString TEXT_SecNLS_WinFonts ${LANG_GERMAN} "WinFonts"
-  LangString DESC_SecNLS_WinFonts ${LANG_GERMAN} "Den Windows-Schriftarten-Ordner in den Suchpfad aufnehmen. Nutzen Sie dies, falls Sie spдter eigene Schriftarten in der Konfigurationsdatei eingeben wollen oder es zu Problemen mit der Standardschriftart kommt. Kann unter Vista und spдter langsam sein!"
-
-  LangString TEXT_SecOriginalMod ${LANG_GERMAN} "1.10 balance"
-  LangString DESC_SecOriginalMod ${LANG_GERMAN} "Spielen Sie das Spiel mit dem Balancing aus der Originalversion 1.10."
-
-  ;Russian
-  LangString WZWelcomeText ${LANG_RUSSIAN} "Этот помощник установки поможет вам установить Warzone2100.\r\n\r\nПеред началом рекомендуем закрыть все другие приложения. Это позволит обновить соответствующие системные файлы без перезагрузки системы.\r\n\r\nWarzone2100 100% бесплатный, если вы за него заплатили сообщите нам!\r\n\r\nНажмите Далее для продолжения."
-  LangString WZ_GPL_NEXT ${LANG_RUSSIAN} "Согласен"
-
-
-  LangString TEXT_SecBase ${LANG_RUSSIAN} "Базовые файлы"
-  LangString DESC_SecBase ${LANG_RUSSIAN} "Файлы требуемые для запуска Warzone 2100."
-
-  LangString TEXT_SecOpenAL ${LANG_RUSSIAN} "Библиотека OpenAL"
-  LangString DESC_SecOpenAL ${LANG_RUSSIAN} "Свободно распространяемый аппаратно- программный интерфейс (API) для работы с аудиоданными. Версия от Creative Labs."
-
-;  LangString TEXT_SecMods ${LANG_RUSSIAN} "Модификации"
-;  LangString DESC_SecMods ${LANG_RUSSIAN} "Различные модификации для Warzone 2100."
-
-  LangString TEXT_SecFMVs ${LANG_RUSSIAN} "Видео"
-  LangString DESC_SecFMVs ${LANG_RUSSIAN} "Скачать и установить внутриигровые ролики."
-
-  LangString TEXT_SecFMVs_EngHi ${LANG_RUSSIAN} "Английские (HQ)"
-  LangString DESC_SecFMVs_EngHi ${LANG_RUSSIAN} "Download and install higher-quality English in-game cutscenes (920 MB)."
-
-  LangString TEXT_SecFMVs_Eng ${LANG_RUSSIAN} "Английские"
-  LangString DESC_SecFMVs_Eng ${LANG_RUSSIAN} "Скачать и установить внутриигровые ролики на английском языке (545 MB)."
-
-  LangString TEXT_SecFMVs_EngLo ${LANG_RUSSIAN} "Английские (LQ)"
-  LangString DESC_SecFMVs_EngLo ${LANG_RUSSIAN} "Скачать и установить внутриигровые ролики (низкого качества) на английском языке (162 MB)."
-
-  LangString TEXT_SecFMVs_Ger ${LANG_RUSSIAN} "Немецкие"
-  LangString DESC_SecFMVs_Ger ${LANG_RUSSIAN} "Скачать и установить внутриигровые ролики на немецком языке (460 MB)."
-
-  LangString TEXT_SecNLS ${LANG_RUSSIAN} "Языковые файлы"
-  LangString DESC_SecNLS ${LANG_RUSSIAN} "Поддержка Русского и других языков."
-
-  LangString TEXT_SecNLS_WinFonts ${LANG_RUSSIAN} "WinШрифты"
-  LangString DESC_SecNLS_WinFonts ${LANG_RUSSIAN} "Задействовать папку шрифтов Windows при поиске. Помогает если есть проблемы с поставляемыми шрифтами. На Висте возможно замедление при загрузке!"
-
-  LangString TEXT_SecOriginalMod ${LANG_RUSSIAN} "Баланс 1.10"
-  LangString DESC_SecOriginalMod ${LANG_RUSSIAN} "Играть в игру с балансом от оригинальной версии 1.10."
-
-  ;Assign language strings to sections
-  !insertmacro MUI_FUNCTION_DESCRIPTION_BEGIN
-    !insertmacro MUI_DESCRIPTION_TEXT ${SecBase} $(DESC_SecBase)
-
-    !insertmacro MUI_DESCRIPTION_TEXT ${SecOpenAL} $(DESC_SecOpenAL)
-
-;    !insertmacro MUI_DESCRIPTION_TEXT ${SecMods} $(DESC_SecMods)
-;    !insertmacro MUI_DESCRIPTION_TEXT ${SecOriginalMod} $(DESC_SecOriginalMod)
-
-    !insertmacro MUI_DESCRIPTION_TEXT ${SecFMVs} $(DESC_SecFMVs)
-	!insertmacro MUI_DESCRIPTION_TEXT ${SecFMVs_Eng} $(DESC_SecFMVs_Eng)
-	!insertmacro MUI_DESCRIPTION_TEXT ${SecFMVs_EngHi} $(DESC_SecFMVs_EngHi)
-	!insertmacro MUI_DESCRIPTION_TEXT ${SecFMVs_EngLo} $(DESC_SecFMVs_EngLo)
-;	!insertmacro MUI_DESCRIPTION_TEXT ${SecFMVs_Ger} $(DESC_SecFMVs_Ger)
-
-    !insertmacro MUI_DESCRIPTION_TEXT ${SecNLS} $(DESC_SecNLS)
-    !insertmacro MUI_DESCRIPTION_TEXT ${SecNLS_WinFonts} $(DESC_SecNLS_WinFonts)
-  !insertmacro MUI_FUNCTION_DESCRIPTION_END
+; Component sections
+@CPACK_NSIS_COMPONENT_SECTIONS@
 
 ;--------------------------------
 ;Uninstaller Section
@@ -709,16 +450,10 @@ Section "Uninstall"
 
   ;ADD YOUR OWN FILES HERE...
 
-  Delete "$INSTDIR\${PACKAGE}.exe"
-
   Delete "$INSTDIR\oalinst.exe"
 
   Delete "$INSTDIR\dbghelp.dll.license.txt"
   Delete "$INSTDIR\dbghelp.dll"
-
-  Delete "$INSTDIR\base.wz"
-  Delete "$INSTDIR\mp.wz"
-  Delete "$INSTDIR\sequences.wz"
 
   Delete "$INSTDIR\stderr.txt"
   Delete "$INSTDIR\stdout.txt"
@@ -735,13 +470,6 @@ Section "Uninstall"
   Delete "$INSTDIR\License.txt"
   Delete "$INSTDIR\Authors.txt"
   Delete "$INSTDIR\ChangeLog.txt"
-
-  Delete "$INSTDIR\music\menu.ogg"
-  Delete "$INSTDIR\music\track1.ogg"
-  Delete "$INSTDIR\music\track2.ogg"
-  Delete "$INSTDIR\music\track3.ogg"
-  Delete "$INSTDIR\music\music.wpl"
-  RMDir "$INSTDIR\music"
 
   Delete "$INSTDIR\uninstall.exe"
 
@@ -764,136 +492,11 @@ Section "Uninstall"
 
   RMDir "$INSTDIR\mods"
 
-; remove all the locales
-
-  Delete "$INSTDIR\locale\ca\LC_MESSAGES\warzone2100.mo"
-  RMDir "$INSTDIR\locale\ca\LC_MESSAGES"
-  RMDir "$INSTDIR\locale\ca"
-
-  Delete "$INSTDIR\locale\cs\LC_MESSAGES\warzone2100.mo"
-  RMDir "$INSTDIR\locale\cs\LC_MESSAGES"
-  RMDir "$INSTDIR\locale\cs"
-
-  Delete "$INSTDIR\locale\da\LC_MESSAGES\warzone2100.mo"
-  RMDir "$INSTDIR\locale\da\LC_MESSAGES"
-  RMDir "$INSTDIR\locale\da"
-
-  Delete "$INSTDIR\locale\de\LC_MESSAGES\warzone2100.mo"
-  RMDir "$INSTDIR\locale\de\LC_MESSAGES"
-  RMDir "$INSTDIR\locale\de"
-
-  Delete "$INSTDIR\locale\el\LC_MESSAGES\warzone2100.mo"
-  RMDir "$INSTDIR\locale\el\LC_MESSAGES"
-  RMDir "$INSTDIR\locale\el"
-
-  Delete "$INSTDIR\locale\en_GB\LC_MESSAGES\warzone2100.mo"
-  RMDir "$INSTDIR\locale\en_GB\LC_MESSAGES"
-  RMDir "$INSTDIR\locale\en_GB"
-
-  Delete "$INSTDIR\locale\es\LC_MESSAGES\warzone2100.mo"
-  RMDir "$INSTDIR\locale\es\LC_MESSAGES"
-  RMDir "$INSTDIR\locale\es"
-
-  Delete "$INSTDIR\locale\et\LC_MESSAGES\warzone2100.mo"
-  RMDir "$INSTDIR\locale\et\LC_MESSAGES"
-  RMDir "$INSTDIR\locale\et"
-
-  Delete "$INSTDIR\locale\fi\LC_MESSAGES\warzone2100.mo"
-  RMDir "$INSTDIR\locale\fi\LC_MESSAGES"
-  RMDir "$INSTDIR\locale\fi"
-
-  Delete "$INSTDIR\locale\fr\LC_MESSAGES\warzone2100.mo"
-  RMDir "$INSTDIR\locale\fr\LC_MESSAGES"
-  RMDir "$INSTDIR\locale\fr"
-
-  Delete "$INSTDIR\locale\fy\LC_MESSAGES\warzone2100.mo"
-  RMDir "$INSTDIR\locale\fy\LC_MESSAGES"
-  RMDir "$INSTDIR\locale\fy"
-
-  Delete "$INSTDIR\locale\ga\LC_MESSAGES\warzone2100.mo"
-  RMDir "$INSTDIR\locale\ga\LC_MESSAGES"
-  RMDir "$INSTDIR\locale\ga"
-
-  Delete "$INSTDIR\locale\hr\LC_MESSAGES\warzone2100.mo"
-  RMDir "$INSTDIR\locale\hr\LC_MESSAGES"
-  RMDir "$INSTDIR\locale\hr"
-
-  Delete "$INSTDIR\locale\hu\LC_MESSAGES\warzone2100.mo"
-  RMDir "$INSTDIR\locale\hu\LC_MESSAGES"
-  RMDir "$INSTDIR\locale\hu"
-
-  Delete "$INSTDIR\locale\it\LC_MESSAGES\warzone2100.mo"
-  RMDir "$INSTDIR\locale\it\LC_MESSAGES"
-  RMDir "$INSTDIR\locale\it"
-
-  Delete "$INSTDIR\locale\ko\LC_MESSAGES\warzone2100.mo"
-  RMDir "$INSTDIR\locale\ko\LC_MESSAGES"
-  RMDir "$INSTDIR\locale\ko"
-
-  Delete "$INSTDIR\locale\la\LC_MESSAGES\warzone2100.mo"
-  RMDir "$INSTDIR\locale\la\LC_MESSAGES"
-  RMDir "$INSTDIR\locale\la"
-
-  Delete "$INSTDIR\locale\lt\LC_MESSAGES\warzone2100.mo"
-  RMDir "$INSTDIR\locale\lt\LC_MESSAGES"
-  RMDir "$INSTDIR\locale\lt"
-
-  Delete "$INSTDIR\locale\nb\LC_MESSAGES\warzone2100.mo"
-  RMDir "$INSTDIR\locale\nb\LC_MESSAGES"
-  RMDir "$INSTDIR\locale\nb"
-
-  Delete "$INSTDIR\locale\nl\LC_MESSAGES\warzone2100.mo"
-  RMDir "$INSTDIR\locale\nl\LC_MESSAGES"
-  RMDir "$INSTDIR\locale\nl"
-
-  Delete "$INSTDIR\locale\pl\LC_MESSAGES\warzone2100.mo"
-  RMDir "$INSTDIR\locale\pl\LC_MESSAGES"
-  RMDir "$INSTDIR\locale\pl"
-
-  Delete "$INSTDIR\locale\pt_BR\LC_MESSAGES\warzone2100.mo"
-  RMDir "$INSTDIR\locale\pt_BR\LC_MESSAGES"
-  RMDir "$INSTDIR\locale\pt_BR"
-
-  Delete "$INSTDIR\locale\pt\LC_MESSAGES\warzone2100.mo"
-  RMDir "$INSTDIR\locale\pt\LC_MESSAGES"
-  RMDir "$INSTDIR\locale\pt"
-
-  Delete "$INSTDIR\locale\ro\LC_MESSAGES\warzone2100.mo"
-  RMDir "$INSTDIR\locale\ro\LC_MESSAGES"
-  RMDir "$INSTDIR\locale\ro"
-
-  Delete "$INSTDIR\locale\ru\LC_MESSAGES\warzone2100.mo"
-  RMDir "$INSTDIR\locale\ru\LC_MESSAGES"
-  RMDir "$INSTDIR\locale\ru"
-
-  Delete "$INSTDIR\locale\sk\LC_MESSAGES\warzone2100.mo"
-  RMDir "$INSTDIR\locale\sk\LC_MESSAGES"
-  RMDir "$INSTDIR\locale\sk"
-
-  Delete "$INSTDIR\locale\sl\LC_MESSAGES\warzone2100.mo"
-  RMDir "$INSTDIR\locale\sl\LC_MESSAGES"
-  RMDir "$INSTDIR\locale\sl"
-
-  Delete "$INSTDIR\locale\tr\LC_MESSAGES\warzone2100.mo"
-  RMDir "$INSTDIR\locale\tr\LC_MESSAGES"
-  RMDir "$INSTDIR\locale\tr"
-
-  Delete "$INSTDIR\locale\uk\LC_MESSAGES\warzone2100.mo"
-  RMDir "$INSTDIR\locale\uk\LC_MESSAGES"
-  RMDir "$INSTDIR\locale\uk"
-
-  Delete "$INSTDIR\locale\zh_TW\LC_MESSAGES\warzone2100.mo"
-  RMDir "$INSTDIR\locale\zh_TW\LC_MESSAGES"
-  RMDir "$INSTDIR\locale\zh_TW"
-
-  Delete "$INSTDIR\locale\zh_CN\LC_MESSAGES\warzone2100.mo"
-  RMDir "$INSTDIR\locale\zh_CN\LC_MESSAGES"
-  RMDir "$INSTDIR\locale\zh_CN"
-
-  RMDir "$INSTDIR\locale"
-  RMDir "$INSTDIR"
-
   SetShellVarContext all
+
+  @CPACK_NSIS_EXTRA_UNINSTALL_COMMANDS@
+  @CPACK_NSIS_DELETE_FILES@
+  @CPACK_NSIS_DELETE_DIRECTORIES@
 
 ; remove the desktop shortcut icon
 

--- a/po/CMakeLists.txt
+++ b/po/CMakeLists.txt
@@ -1,23 +1,27 @@
 project(translation)
 
-add_custom_target(generate_mo ALL)
-
 file(GLOB pofiles "*.po")
+
+set(PO_FILES_LIST "")
 
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "MSVC")
 	set(MSG_FMT "msgfmt.exe")
 else()
-	set(MSG_FMT "msgfmt")
+	find_program(MSG_FMT "msgfmt")
+	foreach(f ${pofiles})
+		get_filename_component(stripped_f ${f} NAME_WE)
+		file(MAKE_DIRECTORY "${CMAKE_BINARY_DIR}/locale/${stripped_f}/LC_MESSAGES/")
+		add_custom_command(
+			OUTPUT "${CMAKE_BINARY_DIR}/locale/${stripped_f}/LC_MESSAGES/warzone2100.gmo"
+			COMMAND ${MSG_FMT} "-c" "-o" "${CMAKE_BINARY_DIR}/locale/${stripped_f}/LC_MESSAGES/warzone2100.gmo" "${f}"
+			DEPENDS ${f}
+		)
+		list(APPEND PO_FILES_LIST "${CMAKE_BINARY_DIR}/locale/${stripped_f}/LC_MESSAGES/warzone2100.gmo")
+		install(FILES "${CMAKE_BINARY_DIR}/locale/${stripped_f}/LC_MESSAGES/warzone2100.gmo" DESTINATION
+		"locale/${stripped_f}/LC_MESSAGES/")
+	endforeach()
 endif()
 
-foreach(f ${pofiles})
-	get_filename_component(stripped_f ${f} NAME_WE)
-	file(MAKE_DIRECTORY "${CMAKE_BINARY_DIR}/locale/${stripped_f}/LC_MESSAGES/")
-	add_custom_command(
-		TARGET generate_mo
-		COMMAND ${MSG_FMT}
-		ARGS "-c" "-o" "${CMAKE_BINARY_DIR}/locale/${stripped_f}/LC_MESSAGES/warzone2100.gmo" "${f}"
+add_custom_target(generate_mo ALL
+	DEPENDS ${PO_FILES_LIST}
 	)
-	install(FILES "${CMAKE_BINARY_DIR}/locale/${stripped_f}/LC_MESSAGES/warzone2100.gmo" DESTINATION
-	"locale/${stripped_f}/LC_MESSAGES/")
-endforeach()

--- a/po/CMakeLists.txt
+++ b/po/CMakeLists.txt
@@ -17,8 +17,9 @@ else()
 			DEPENDS ${f}
 		)
 		list(APPEND PO_FILES_LIST "${CMAKE_BINARY_DIR}/locale/${stripped_f}/LC_MESSAGES/warzone2100.gmo")
-		install(FILES "${CMAKE_BINARY_DIR}/locale/${stripped_f}/LC_MESSAGES/warzone2100.gmo" DESTINATION
-		"locale/${stripped_f}/LC_MESSAGES/")
+		install(FILES "${CMAKE_BINARY_DIR}/locale/${stripped_f}/LC_MESSAGES/warzone2100.gmo"
+		COMPONENT Lang
+		DESTINATION "locale/${stripped_f}/LC_MESSAGES/")
 	endforeach()
 endif()
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -57,3 +57,28 @@ endif()
 add_dependencies(warzone2100 data_base)
 
 install(TARGETS warzone2100 DESTINATION ".")
+
+if("${CMAKE_CXX_COMPILER_ID}" MATCHES "MSVC")
+    install(FILES
+        "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/bin/SDL2.dll"
+        "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/bin/ogg.dll"
+        "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/bin/vorbis.dll"
+        "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/bin/vorbisfile.dll"
+        "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/bin/theora.dll"
+        "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/bin/physfs.dll"
+        "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/bin/pcre.dll"
+        "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/bin/OpenAL32.dll"
+        "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/bin/libpng16.dll"
+        "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/bin/libintl.dll"
+        "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/bin/libiconv.dll"
+        "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/bin/LIBEAY32.dll"
+        "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/bin/libcharset.dll"
+        "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/bin/libbz2.dll"
+        "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/bin/zlib1.dll"
+        "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/bin/harfbuzz.dll"
+        "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/bin/glib-2.dll"
+        "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/bin/glew32.dll"
+        "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/bin/freetype.dll"
+        DESTINATION "."
+    )
+endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -59,6 +59,17 @@ add_dependencies(warzone2100 data_base)
 install(TARGETS warzone2100 COMPONENT Core DESTINATION ".")
 
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "MSVC")
+    get_target_property(QtCoreLib Qt5::Core LOCATION)
+    install(FILES ${QtCoreLib} COMPONENT Core DESTINATION ".")
+    get_target_property(QtGuiLib Qt5::Gui LOCATION)
+    install(FILES ${QtGuiLib} COMPONENT Core DESTINATION ".")
+    get_target_property(QtGuiPlugin Qt5::QWindowsIntegrationPlugin LOCATION)
+    install(FILES ${QtGuiPlugin} COMPONENT Core DESTINATION "platforms")
+    get_target_property(QtScriptLib Qt5::Script LOCATION)
+    install(FILES ${QtScriptLib} COMPONENT Core DESTINATION ".")
+    get_target_property(QtWidgetstLib Qt5::Widgets LOCATION)
+    install(FILES ${QtWidgetstLib} COMPONENT Core DESTINATION ".")
+
     install(FILES
         "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/bin/SDL2.dll"
         "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/bin/ogg.dll"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -56,7 +56,7 @@ endif()
 
 add_dependencies(warzone2100 data_base)
 
-install(TARGETS warzone2100 DESTINATION ".")
+install(TARGETS warzone2100 COMPONENT Core DESTINATION ".")
 
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "MSVC")
     install(FILES
@@ -79,6 +79,7 @@ if("${CMAKE_CXX_COMPILER_ID}" MATCHES "MSVC")
         "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/bin/glib-2.dll"
         "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/bin/glew32.dll"
         "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/bin/freetype.dll"
+        COMPONENT Core
         DESTINATION "."
     )
 endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -54,4 +54,6 @@ elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "MSVC")
     )
 endif()
 
+add_dependencies(warzone2100 data_base)
+
 install(TARGETS warzone2100 DESTINATION ".")


### PR DESCRIPTION
This PR adds cmake support for dds generation.
DDS is constitued of a small header describing texture width, height, format... and raw texel data which can be directly feed to gpu (ie no "decode" step like required for jpeg or png).
A single dds file can store a single texture in the API term, that is it can store mipmaps data, an array of texture, cubemap, and even an array of texture 3d, on any API supported format, that is classic 32 bits per pixel up to 128 bits per pixel (float textures), and compressed format like bc6 or 7 (which are usually too costly to be generated on the fly by drivers).
Please note that ktx format, the khronos texture format, is equivalent to dds but I didn't find any open source tool converting png to dds with mipmap...There's still tool from imgtech but you need a dev subscription to download it.

Currently the generated DDS files are uncompressed and there's no support from code to load the non base mipmal level, it will come as part of a future PR. 
There's several compression level available, BC1 to BC3 are universally supported (it's the classic S3TC compression), BC4 and BC5 are dx10 hardware compression that provides algorithm better suited for tangent space normal mapping. BC 6 and BC7 are dx11 compression format, they take more space for better result but require a lot of time to be generated. Ideally a compile flag would allow to decide which formats are prefered.

I have no experience with autotools unfortunatly so I don't know how to replicate the call to nvcompress. The cmake code just iterates on the images/ and texpages/bdrops/ directories and call nvcompress -nomips -color -alpha -rgba, and then iterates on the others texpages/ subdir and call nvcompress -color -alpha -rgba (ie without the -nomips)

nvtt is available on Ubuntu. On Windows I'm using a script that download and build nvtt in the build tree at the moment, ideally I can get it pushed to vcpkg.