### PR TITLE
Fix mac compile error

### DIFF
--- a/src/multiint.cpp
+++ b/src/multiint.cpp
@@ -97,7 +97,11 @@
 #include "levels.h"
 #include "wrappers.h"
 
-#include <QtCore/QFile> // used to strip path of challenge AI values
+#ifndef WZ_OS_MAC
+	#include <QFileInfo> // used to strip path of challenge AI values
+#else // WZ_OS_MAC
+	#include <QtCore/QFileInfo> // used to strip path of challenge AI values
+#endif
 
 #define MAP_PREVIEW_DISPLAY_TIME 2500	// number of milliseconds to show map in preview
 
@@ -311,7 +315,7 @@ void setupChallengeAIs()
 				}
 
 				// strip given path down to filename
-				QString filename(QFile(val).fileName());
+				QString filename(QFileInfo(val).fileName());
 
 				// look up AI value in vector of known skirmish AIs
 				for (int ai = 0; ai < aidata.size(); ++ai)

--- a/src/multiint.cpp
+++ b/src/multiint.cpp
@@ -97,7 +97,7 @@
 #include "levels.h"
 #include "wrappers.h"
 
-#include <QFileInfo> // used to strip path of challenge AI values
+#include <QtCore/QFile> // used to strip path of challenge AI values
 
 #define MAP_PREVIEW_DISPLAY_TIME 2500	// number of milliseconds to show map in preview
 
@@ -311,7 +311,7 @@ void setupChallengeAIs()
 				}
 
 				// strip given path down to filename
-				QString filename(QFileInfo(val).fileName());
+				QString filename(QFile(val).fileName());
 
 				// look up AI value in vector of known skirmish AIs
 				for (int ai = 0; ai < aidata.size(); ++ai)


### PR DESCRIPTION
Changing **line 100** from `#include <QFileInfo>` to `#include <QtCore/QFile>` and **line 314** from `QString filename(QFileInfo(val).fileName());` to `QString filename(QFile(val).fileName());` will resolve this compile error:  `fatal error: 'QFileInfo' file not found.`

Only tested for Mac