### PR TITLE
fix: Create missing autorevison files with cmake

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -14,7 +14,9 @@ elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU" OR "${CMAKE_CXX_COMPILER_ID}" ST
   add_custom_command(
     OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/autorevision.h"
     COMMAND "${CMAKE_SOURCE_DIR}/build_tools/autorevision"
-    ARGS "-t" "h" "-o" "${CMAKE_CURRENT_BINARY_DIR}/autorevision.cache" ">" "${CMAKE_CURRENT_BINARY_DIR}/autorevision.h")
+    ARGS "-t" "h" "-o" "${CMAKE_CURRENT_BINARY_DIR}/autorevision.cache" ">" "${CMAKE_CURRENT_BINARY_DIR}/autorevision.h"
+    WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
+    )
 endif()
 
 add_executable(warzone2100 ${HEADERS} ${SRC} ${MOCFILES} "${CMAKE_CURRENT_BINARY_DIR}/autorevision.h" "${CMAKE_SOURCE_DIR}/win32/warzone2100.rc")


### PR DESCRIPTION
Builds fail when cmake copies files from a RCS source directory
(here ../warzone2100-github) to a build directory:

    $ cmake ../warzone2100-github
    $ make -j9
    ...
    [ 53%] Generating moc_qtscriptdebug.cpp
    error: No repo or cache detected.
    make[2]: *** [src/autorevision.h] Error 1
    make[2]: *** Deleting file `src/autorevision.h'
    make[2]: *** Waiting for unfinished jobs....
    make[1]: *** [src/CMakeFiles/warzone2100.dir/all] Error 2
    make: *** [all] Error 2

Without changing directory to $CMAKE_SOURCE_DIR the "autorevision"
script is executed within the "src" directory of the build directory.
This fails silently as there is no RCS information available. Both
"src/autorevision.cache" and "src/autorevision.h" are missing during
build.

See this (part of the) diff, warzone2100-build-alt without patch,
warzone2100-build-neu contains the patch, "/tmp/warzone2100-github" is the
source directory:

    diff -ruw warzone2100-build-alt/src/CMakeFiles/warzone2100.dir/build.make warzone2100-build-neu/src/CMakeFiles/warzone2100.dir/build.make
    --- warzone2100-build-alt/src/CMakeFiles/warzone2100.dir/build.make     2018-01-14 16:37:34.000000000 +0100
    +++ warzone2100-build-neu/src/CMakeFiles/warzone2100.dir/build.make     2018-01-14 16:37:52.000000000 +0100
    @@ -46,7 +46,7 @@

     ...

     src/autorevision.h:
    -       @$(CMAKE_COMMAND) -E cmake_echo_color --switch=$(COLOR) --blue --bold --progress-dir=/tmp/warzone2100-build-alt/CMakeFiles --progress-num=$(CMAKE_PROGRESS_3) "Generating autorevision.h"
    -       cd /tmp/warzone2100-build-alt/src && /tmp/warzone2100-github/build_tools/autorevision -t h -o /tmp/warzone2100-build-alt/src/autorevision.cache > /tmp/warzone2100-build-alt/src/autorevision.h
    +       @$(CMAKE_COMMAND) -E cmake_echo_color --switch=$(COLOR) --blue --bold --progress-dir=/tmp/warzone2100-build-neu/CMakeFiles --progress-num=$(CMAKE_PROGRESS_3) "Generating autorevision.h"
    +       cd /tmp/warzone2100-github && /tmp/warzone2100-github/build_tools/autorevision -t h -o /tmp/warzone2100-build-neu/src/autorevision.cache > /tmp/warzone2100-build-neu/src/autorevision.h