### PR TITLE
open reticule menu from JS API(rules.js)

### DIFF
--- a/src/hci.cpp
+++ b/src/hci.cpp
@@ -4386,6 +4386,54 @@ void stopReticuleButtonFlash(UDWORD buttonID)
 	}
 }
 
+// show selected widget from reticule menu
+void intShowWidget(int buttonID)
+{
+switch (buttonID)
+	{
+	case RETBUT_FACTORY:
+		intResetScreen(true);
+		widgSetButtonState(psWScreen, IDRET_MANUFACTURE, WBUT_CLICKLOCK);
+		intAddManufacture(nullptr);
+		reticuleCallback(RETBUT_FACTORY);
+		break;
+	case RETBUT_RESEARCH:
+		intResetScreen(true);
+		widgSetButtonState(psWScreen, IDRET_RESEARCH, WBUT_CLICKLOCK);
+		(void)intAddResearch(nullptr);
+		reticuleCallback(RETBUT_RESEARCH);
+		break;
+	case RETBUT_BUILD:
+		intResetScreen(true);
+		widgSetButtonState(psWScreen, IDRET_BUILD, WBUT_CLICKLOCK);
+		intAddBuild(nullptr);
+		reticuleCallback(RETBUT_BUILD);
+		break;
+	case RETBUT_DESIGN:
+		intResetScreen(true);
+		widgSetButtonState(psWScreen, IDRET_DESIGN, WBUT_CLICKLOCK);
+		/*add the power bar - for looks! */
+		intShowPowerBar();
+		intAddDesign(false);
+		intMode = INT_DESIGN;
+		reticuleCallback(RETBUT_DESIGN);
+		triggerEvent(TRIGGER_MENU_DESIGN_UP);
+		break;
+	case RETBUT_COMMAND:
+		intResetScreen(false);
+		widgSetButtonState(psWScreen, IDRET_COMMAND, WBUT_CLICKLOCK);
+		intAddCommand(nullptr);
+		reticuleCallback(RETBUT_COMMAND);
+		break;
+	default:
+		intResetScreen(false);
+		psCurrentMsg = nullptr;
+		reticuleCallback(RETBUT_CANCEL);
+		break;
+	}
+}
+
+
 //displays the Power Bar
 void intShowPowerBar()
 {

--- a/src/hci.h
+++ b/src/hci.h
@@ -365,6 +365,8 @@ void togglePowerBar();
 void intShowPowerBar();
 void intHidePowerBar();
 
+void intShowWidget(int buttonID);
+
 //hides the power bar from the display - regardless of what player requested!
 void forceHidePowerBar();
 

--- a/src/qtscriptfuncs.cpp
+++ b/src/qtscriptfuncs.cpp
@@ -3186,6 +3186,15 @@ static QScriptValue js_setReticuleButton(QScriptContext *context, QScriptEngine 
 	return QScriptValue();
 }
 
+//-- \subsection{showReticuleWidget(id)} Open the reticule menu widget. (3.2.4+ only)
+static QScriptValue js_showReticuleWidget(QScriptContext *context, QScriptEngine *engine)
+{
+	int button = context->argument(0).toInt32();
+	SCRIPT_ASSERT(context, button >= 0 && button <= 6, "Invalid button %d", button);
+	intShowWidget(button);
+	return QScriptValue();
+}
+
 //-- \subsection{setReticuleFlash(id, flash)} Set reticule flash on or off. (3.2.3+ only)
 static QScriptValue js_setReticuleFlash(QScriptContext *context, QScriptEngine *engine)
 {
@@ -5644,6 +5653,7 @@ bool registerFunctions(QScriptEngine *engine, const QString& scriptName)
 	engine->globalObject().setProperty("setMiniMap", engine->newFunction(js_setMiniMap));
 	engine->globalObject().setProperty("setReticuleButton", engine->newFunction(js_setReticuleButton));
 	engine->globalObject().setProperty("setReticuleFlash", engine->newFunction(js_setReticuleFlash));
+	engine->globalObject().setProperty("showReticuleWidget", engine->newFunction(js_showReticuleWidget));
 	engine->globalObject().setProperty("showInterface", engine->newFunction(js_showInterface));
 	engine->globalObject().setProperty("hideInterface", engine->newFunction(js_hideInterface));
 	engine->globalObject().setProperty("addReticuleButton", engine->newFunction(js_removeReticuleButton)); // deprecated!!


### PR DESCRIPTION
Add function to open reticule menu from JS API
Example rules.js addons (not included)

//Bind standard hotkeys F1-F6 from rules.js
function eventKeyPressed(meta, key){
    switch(key){
        case 282:
            showReticuleWidget(1);
            break;
        case 283:
            showReticuleWidget(2);
            break;
        case 284:
            showReticuleWidget(3);
            break;
        case 285:
            showReticuleWidget(4);
            break;
        case 286:
            showReticuleWidget(5);
            break;
        case 287:
            showReticuleWidget(6);
            break;
    }
}