### PR TITLE
Improved builders behavior, fix #4719

### DIFF
--- a/data/mp/multiplay/script/builders.js
+++ b/data/mp/multiplay/script/builders.js
@@ -1,0 +1,31 @@
+function buildersAssist(structure, demolish)
+{
+	//Help build
+	if(!demolish)
+	{
+		builders = buildersIdleNearby(structure);
+		builders.forEach(function(droid){
+			orderDroidObj(droid, DORDER_HELPBUILD, structure);
+		});
+		delete builders;
+	}
+	//We don't need to help demolish the ally buildings
+	else if(structure.player == me)
+	{
+		builders = buildersIdleNearby(structure);
+		builders.forEach(function(droid){
+			orderDroidObj(droid, DORDER_DEMOLISH, structure);
+		});
+		delete builders;
+	}
+}
+
+//Get nearby idle buiders and cyborgs engeeners
+function buildersIdleNearby(structure)
+{
+	return enumRange(structure.x, structure.y, buildersAssistRadius, ALLIES).filter(function(obj)
+	{
+		if(obj.type == DROID && obj.droidType == DROID_CONSTRUCT && obj.action == DACTION_NONE) return true;
+		return false;
+	});
+}

--- a/data/mp/multiplay/skirmish/rules.js
+++ b/data/mp/multiplay/skirmish/rules.js
@@ -10,12 +10,14 @@ receiveAllEvents(true);  // If doing this in eventGameInit, it seems to be too l
 
 include("multiplay/script/camTechEnabler.js");
 include("multiplay/script/weather.js");
+include("multiplay/script/builders.js");
 
 var lastHitTime = 0;
 var cheatmode = false;
 var maxOilDrums = 0;
 var mainReticule = true;
 var allowDesign = false;
+var buildersAssistRadius = 7;
 
 function setMainReticule()
 {
@@ -390,6 +392,18 @@ function eventDroidBuilt(droid, structure)
 	if (mainReticule && update_reticule)
 	{
 		setMainReticule();
+	}
+}
+
+//Somewhere someone start (or demolish) the building
+//v3.2.4+
+function eventStructureBeginBuilt(structure, demolish, droid)
+{
+	//Assistance in the construction of the building
+	//Just for "me" and "my" ally
+	if(allianceExistsBetween(me, structure.player))
+	{
+		buildersAssist(structure, demolish);
 	}
 }
 

--- a/src/order.cpp
+++ b/src/order.cpp
@@ -248,11 +248,11 @@ static std::pair<STRUCTURE *, DROID_ACTION> checkForDamagedStruct(DROID *psDroid
 			best = {structure, DACTION_REPAIR};
 		}
 		// Check for structures to help build.
-		else if (structure->status == SS_BEING_BUILT)
-		{
-			bestDistanceSq = distanceSq;
-			best = {structure, DACTION_BUILD};
-		}
+//		else if (structure->status == SS_BEING_BUILT)
+//		{
+//			bestDistanceSq = distanceSq;
+//			best = {structure, DACTION_BUILD};
+//		}
 	}
 
 	return best;

--- a/src/qtscript.cpp
+++ b/src/qtscript.cpp
@@ -1200,6 +1200,31 @@ bool triggerEventDroidBuilt(DROID *psDroid, STRUCTURE *psFactory)
 	return true;
 }
 
+//__ \subsection{eventStructureBeginBuilt(structure, demolish [, droid])}
+//__ An event that is run every time when the Foundation is laid and construction begins construction of a new building.
+//__ Or when the Builder starts to demolish the building.
+bool triggerEventStructBeginBuilt(STRUCTURE *psStruct, bool demolish, DROID *psDroid)
+{
+	ASSERT(scriptsReady, "Scripts not initialized yet");
+	for (auto *engine : scripts)
+	{
+		int player = engine->globalObject().property("me").toInt32();
+		bool receiveAll = engine->globalObject().property("isReceivingAllEvents").toBool();
+		if (player == psStruct->player || receiveAll)
+		{
+			QScriptValueList args;
+			args += convStructure(psStruct, engine);
+			args += demolish;
+			if (psDroid)
+			{
+				args += convDroid(psDroid, engine);
+			}
+			callFunction(engine, "eventStructureBeginBuilt", args);
+		}
+	}
+	return true;
+}
+
 //__ \subsection{eventStructureBuilt(structure[, droid])}
 //__ An event that is run every time a structure is produced. The droid parameter is set
 //__ if the structure was built by a droid. It is not triggered for building theft

--- a/src/qtscript.h
+++ b/src/qtscript.h
@@ -119,6 +119,7 @@ bool triggerEvent(SCRIPT_TRIGGER_TYPE trigger, BASE_OBJECT *psObj = nullptr);
 bool triggerEventDroidBuilt(DROID *psDroid, STRUCTURE *psFactory);
 bool triggerEventAttacked(BASE_OBJECT *psVictim, BASE_OBJECT *psAttacker, int lastHit);
 bool triggerEventResearched(RESEARCH *psResearch, STRUCTURE *psStruct, int player);
+bool triggerEventStructBeginBuilt(STRUCTURE *psStruct, bool demolish, DROID *psDroid);
 bool triggerEventStructBuilt(STRUCTURE *psStruct, DROID *psDroid);
 bool triggerEventDroidIdle(DROID *psDroid);
 bool triggerEventDestroyed(BASE_OBJECT *psVictim);

--- a/src/qtscriptfuncs.cpp
+++ b/src/qtscriptfuncs.cpp
@@ -5763,12 +5763,56 @@ bool registerFunctions(QScriptEngine *engine, const QString& scriptName)
 	engine->globalObject().setProperty("RESEARCH_DATA", SCRIPT_RESEARCH, QScriptValue::ReadOnly | QScriptValue::Undeletable);
 	engine->globalObject().setProperty("LZ_COMPROMISED_TIME", JS_LZ_COMPROMISED_TIME, QScriptValue::ReadOnly | QScriptValue::Undeletable);
 	engine->globalObject().setProperty("OBJECT_FLAG_UNSELECTABLE", OBJECT_FLAG_UNSELECTABLE, QScriptValue::ReadOnly | QScriptValue::Undeletable);
+
+	// Pass droid actions too
+	engine->globalObject().setProperty("DACTION_NONE", DACTION_NONE, QScriptValue::ReadOnly | QScriptValue::Undeletable);									// 0 idle
+	engine->globalObject().setProperty("DACTION_MOVE", DACTION_MOVE, QScriptValue::ReadOnly | QScriptValue::Undeletable);
+	engine->globalObject().setProperty("DACTION_BUILD", DACTION_BUILD, QScriptValue::ReadOnly | QScriptValue::Undeletable);
+	engine->globalObject().setProperty("DACTION_UNUSED3", DACTION_UNUSED3, QScriptValue::ReadOnly | QScriptValue::Undeletable);
+	engine->globalObject().setProperty("DACTION_DEMOLISH", DACTION_DEMOLISH, QScriptValue::ReadOnly | QScriptValue::Undeletable);
+	engine->globalObject().setProperty("DACTION_REPAIR", DACTION_REPAIR, QScriptValue::ReadOnly | QScriptValue::Undeletable);								// 5
+	engine->globalObject().setProperty("DACTION_ATTACK", DACTION_ATTACK, QScriptValue::ReadOnly | QScriptValue::Undeletable);
+	engine->globalObject().setProperty("DACTION_OBSERVE", DACTION_OBSERVE, QScriptValue::ReadOnly | QScriptValue::Undeletable);
+	engine->globalObject().setProperty("DACTION_FIRESUPPORT", DACTION_FIRESUPPORT, QScriptValue::ReadOnly | QScriptValue::Undeletable);
+	engine->globalObject().setProperty("DACTION_SULK", DACTION_SULK, QScriptValue::ReadOnly | QScriptValue::Undeletable);									// 9
+	engine->globalObject().setProperty("DACTION_TRANSPORTOUT", DACTION_TRANSPORTOUT, QScriptValue::ReadOnly | QScriptValue::Undeletable);					// 11
+	engine->globalObject().setProperty("DACTION_TRANSPORTWAITTOFLYIN", DACTION_TRANSPORTWAITTOFLYIN, QScriptValue::ReadOnly | QScriptValue::Undeletable);
+	engine->globalObject().setProperty("DACTION_TRANSPORTIN", DACTION_TRANSPORTIN, QScriptValue::ReadOnly | QScriptValue::Undeletable);
+	engine->globalObject().setProperty("DACTION_DROIDREPAIR", DACTION_DROIDREPAIR, QScriptValue::ReadOnly | QScriptValue::Undeletable);
+	engine->globalObject().setProperty("DACTION_RESTORE", DACTION_RESTORE, QScriptValue::ReadOnly | QScriptValue::Undeletable);								// 15
+	// The states below are used by the action system
+	engine->globalObject().setProperty("DACTION_MOVEFIRE", DACTION_MOVEFIRE, QScriptValue::ReadOnly | QScriptValue::Undeletable);							// 17
+	engine->globalObject().setProperty("DACTION_MOVETOBUILD", DACTION_MOVETOBUILD, QScriptValue::ReadOnly | QScriptValue::Undeletable);
+	engine->globalObject().setProperty("DACTION_MOVETODEMOLISH", DACTION_MOVETODEMOLISH, QScriptValue::ReadOnly | QScriptValue::Undeletable);
+	engine->globalObject().setProperty("DACTION_MOVETOREPAIR", DACTION_MOVETOREPAIR, QScriptValue::ReadOnly | QScriptValue::Undeletable);
+	engine->globalObject().setProperty("DACTION_BUILDWANDER", DACTION_BUILDWANDER, QScriptValue::ReadOnly | QScriptValue::Undeletable);
+	engine->globalObject().setProperty("DACTION_UNUSED4", DACTION_UNUSED4, QScriptValue::ReadOnly | QScriptValue::Undeletable);								// 22 used to be moving around while building the foundation
+	engine->globalObject().setProperty("DACTION_MOVETOATTACK", DACTION_MOVETOATTACK, QScriptValue::ReadOnly | QScriptValue::Undeletable);
+	engine->globalObject().setProperty("DACTION_ROTATETOATTACK", DACTION_ROTATETOATTACK, QScriptValue::ReadOnly | QScriptValue::Undeletable);
+	engine->globalObject().setProperty("DACTION_MOVETOOBSERVE", DACTION_MOVETOOBSERVE, QScriptValue::ReadOnly | QScriptValue::Undeletable);
+	engine->globalObject().setProperty("DACTION_WAITFORREPAIR", DACTION_WAITFORREPAIR, QScriptValue::ReadOnly | QScriptValue::Undeletable);
+	engine->globalObject().setProperty("DACTION_MOVETOREPAIRPOINT", DACTION_MOVETOREPAIRPOINT, QScriptValue::ReadOnly | QScriptValue::Undeletable);
+	engine->globalObject().setProperty("DACTION_WAITDURINGREPAIR", DACTION_WAITDURINGREPAIR, QScriptValue::ReadOnly | QScriptValue::Undeletable);
+	engine->globalObject().setProperty("DACTION_MOVETODROIDREPAIR", DACTION_MOVETODROIDREPAIR, QScriptValue::ReadOnly | QScriptValue::Undeletable);
+	engine->globalObject().setProperty("DACTION_MOVETORESTORE", DACTION_MOVETORESTORE, QScriptValue::ReadOnly | QScriptValue::Undeletable);					// 30
+	engine->globalObject().setProperty("DACTION_MOVETOREARM", DACTION_MOVETOREARM, QScriptValue::ReadOnly | QScriptValue::Undeletable);						// 32
+	engine->globalObject().setProperty("DACTION_WAITFORREARM", DACTION_WAITFORREARM, QScriptValue::ReadOnly | QScriptValue::Undeletable);
+	engine->globalObject().setProperty("DACTION_MOVETOREARMPOINT", DACTION_MOVETOREARMPOINT, QScriptValue::ReadOnly | QScriptValue::Undeletable);
+	engine->globalObject().setProperty("DACTION_WAITDURINGREARM", DACTION_WAITDURINGREARM, QScriptValue::ReadOnly | QScriptValue::Undeletable);
+	engine->globalObject().setProperty("DACTION_VTOLATTACK", DACTION_VTOLATTACK, QScriptValue::ReadOnly | QScriptValue::Undeletable);
+	engine->globalObject().setProperty("DACTION_CLEARREARMPAD", DACTION_CLEARREARMPAD, QScriptValue::ReadOnly | QScriptValue::Undeletable);
+	engine->globalObject().setProperty("DACTION_RETURNTOPOS", DACTION_RETURNTOPOS, QScriptValue::ReadOnly | QScriptValue::Undeletable);
+	engine->globalObject().setProperty("DACTION_FIRESUPPORT_RETREAT", DACTION_FIRESUPPORT_RETREAT, QScriptValue::ReadOnly | QScriptValue::Undeletable);		// 39
+	engine->globalObject().setProperty("DACTION_CIRCLE", DACTION_CIRCLE, QScriptValue::ReadOnly | QScriptValue::Undeletable);								// 41
+
 	// the constants below are subject to change without notice...
 	engine->globalObject().setProperty("PROX_MSG", MSG_PROXIMITY, QScriptValue::ReadOnly | QScriptValue::Undeletable);
 	engine->globalObject().setProperty("CAMP_MSG", MSG_CAMPAIGN, QScriptValue::ReadOnly | QScriptValue::Undeletable);
 	engine->globalObject().setProperty("MISS_MSG", MSG_MISSION, QScriptValue::ReadOnly | QScriptValue::Undeletable);
 	engine->globalObject().setProperty("RES_MSG", MSG_RESEARCH, QScriptValue::ReadOnly | QScriptValue::Undeletable);
 	engine->globalObject().setProperty("LDS_EXPAND_LIMBO", LDS_EXPAND_LIMBO, QScriptValue::ReadOnly | QScriptValue::Undeletable);
+
+
 
 	/// Place to store group sizes
 	//== \item[groupSizes] A sparse array of group sizes. If a group has never been used, the entry in this array will

--- a/src/structure.cpp
+++ b/src/structure.cpp
@@ -763,6 +763,12 @@ void structureBuild(STRUCTURE *psStruct, DROID *psDroid, int buildPoints, int bu
 		{
 			buildPoints = 0;  // No power to build.
 		}
+		triggerEventStructBeginBuilt(psStruct, false, psDroid);
+	}
+
+	if (psStruct->body == 1000 && buildPoints < 0)
+	{
+		triggerEventStructBeginBuilt(psStruct, true, psDroid);
 	}
 
 	int newBuildPoints = psStruct->currentBuildPts + buildPoints;


### PR DESCRIPTION
The transfer logic micro management of constructors in JS
Pass DACTION constants in JS (I haven DACTION used as numbers in my bot, but now used in rules.js I think it is necessary to make things right)
Disabling hardcoded assistance functions of the builders
The new logic help in the construction written in JS (rules.js and script/builders.js)
Video: https://www.youtube.com/watch?v=yGmFiID0TX8

I think if you see the need, in the future it will be possible to move the auto repair buildings from hardcode in JS too.