### PR TITLE
Display scaling, live window resizing, and high-DPI support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -409,7 +409,7 @@ fi
 # Checks for modules:
 
 if test "$backend" = "sdl"; then
-	PKG_CHECK_MODULES([SDL], [sdl2 >= 2.0.5])
+	PKG_CHECK_MODULES([SDL], [sdl2 >= 2.0.0])
 fi
 PKG_CHECK_MODULES([PNG], [libpng >= 1.2])
 PKG_CHECK_MODULES([THEORA], [theora >= 1.0])

--- a/configure.ac
+++ b/configure.ac
@@ -409,7 +409,7 @@ fi
 # Checks for modules:
 
 if test "$backend" = "sdl"; then
-	PKG_CHECK_MODULES([SDL], [sdl2 >= 2.0.0])
+	PKG_CHECK_MODULES([SDL], [sdl2 >= 2.0.5])
 fi
 PKG_CHECK_MODULES([PNG], [libpng >= 1.2])
 PKG_CHECK_MODULES([THEORA], [theora >= 1.0])

--- a/lib/framework/wzapp.h
+++ b/lib/framework/wzapp.h
@@ -37,12 +37,21 @@ struct screeninfo
 };
 
 void wzMain(int &argc, char **argv);
-bool wzMainScreenSetup(int antialiasing = 0, bool fullscreen = false, bool vsync = true);
+bool wzMainScreenSetup(int antialiasing = 0, bool fullscreen = false, bool vsync = true, bool highDPI = true);
+void wzGetGameToRendererScaleFactor(float *horizScaleFactor, float *vertScaleFactor);
 void wzMainEventLoop();
 void wzQuit();              ///< Quit game
 void wzShutdown();
 void wzToggleFullscreen();
 bool wzIsFullscreen();
+void wzSetWindowIsResizable(bool resizable);
+bool wzIsWindowResizable();
+bool wzSupportsLiveResolutionChanges();
+bool wzChangeDisplayScale(unsigned int displayScale);
+bool wzChangeWindowResolution(int screen, unsigned int width, unsigned int height);
+unsigned int wzGetMaximumDisplayScaleForWindowSize(unsigned int windowWidth, unsigned int windowHeight);
+unsigned int wzGetCurrentDisplayScale();
+void wzGetWindowResolution(int *screen, unsigned int *width, unsigned int *height);
 void wzSetCursor(CURSOR index);
 void wzScreenFlip();	///< Swap the graphics buffers
 void wzShowMouse(bool visible); ///< Show the Mouse?
@@ -53,6 +62,7 @@ int wzGetTicks();		///< Milliseconds since start of game
 WZ_DECL_NONNULL(1) void wzFatalDialog(const char *text);	///< Throw up a modal warning dialog
 
 std::vector<screeninfo> wzAvailableResolutions();
+std::vector<unsigned int> wzAvailableDisplayScales();
 void wzSetSwapInterval(int swap);
 int wzGetSwapInterval();
 QString wzGetSelection();

--- a/lib/ivis_opengl/pieblitfunc.cpp
+++ b/lib/ivis_opengl/pieblitfunc.cpp
@@ -266,6 +266,35 @@ static void pie_DrawRect(float x0, float y0, float x1, float y1, PIELIGHT colour
 	pie_DeactivateShader();
 }
 
+void pie_DrawMultiRect(std::vector<PIERECT_DrawRequest> rects, REND_MODE rendermode)
+{
+	const auto projectionMatrix = defaultProjectionMatrix();
+	pie_SetRendMode(rendermode);
+	pie_SetTexturePage(TEXPAGE_NONE);
+
+	enableRect();
+	for (auto it = rects.begin(); it != rects.end(); ++it)
+	{
+		if (it->x0 > it->x1)
+		{
+			std::swap(it->x0, it->x1);
+		}
+		if (it->y0 > it->y1)
+		{
+			std::swap(it->y0, it->y1);
+		}
+		const auto& colour = it->color;
+		const auto& center = Vector2f(it->x0, it->y0);
+		const auto& mvp = projectionMatrix * glm::translate(Vector3f(center, 0.f)) * glm::scale(it->x1 - it->x0, it->y1 - it->y0, 1.f);
+		pie_ActivateShader(SHADER_RECT, mvp,
+						   glm::vec4(colour.vector[0] / 255.f, colour.vector[1] / 255.f, colour.vector[2] / 255.f, colour.vector[3] / 255.f));
+
+		glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
+	}
+	disableRect();
+	pie_DeactivateShader();
+}
+
 void iV_ShadowBox(int x0, int y0, int x1, int y1, int pad, PIELIGHT first, PIELIGHT second, PIELIGHT fill)
 {
 	pie_SetRendMode(REND_OPAQUE);

--- a/lib/ivis_opengl/pieblitfunc.h
+++ b/lib/ivis_opengl/pieblitfunc.h
@@ -120,6 +120,23 @@ static inline void iV_Box(int x0, int y0, int x1, int y1, PIELIGHT first)
 	iV_Box2(x0, y0, x1, y1, first, first);
 }
 void pie_BoxFill(int x0, int y0, int x1, int y1, PIELIGHT colour, REND_MODE rendermode = REND_OPAQUE);
+struct PIERECT_DrawRequest
+{
+	PIERECT_DrawRequest(int x0, int y0, int x1, int y1, PIELIGHT color)
+	: x0(x0)
+	, y0(y0)
+	, x1(x1)
+	, y1(y1)
+	, color(color)
+	{ }
+
+	int x0;
+	int y0;
+	int x1;
+	int y1;
+	PIELIGHT color;
+};
+void pie_DrawMultiRect(std::vector<PIERECT_DrawRequest> rects, REND_MODE rendermode = REND_OPAQUE);
 void iV_DrawImage(GLuint TextureID, Vector2i position, Vector2f offset, Vector2i size, float angle, REND_MODE mode, PIELIGHT colour);
 void iV_DrawImageText(gfx_api::texture& TextureID, Vector2i Position, Vector2f offset, Vector2f size, float angle, REND_MODE mode, PIELIGHT colour);
 void iV_DrawImage(IMAGEFILE *ImageFile, UWORD ID, int x, int y, const glm::mat4 &modelViewProjection = defaultProjectionMatrix());

--- a/lib/ivis_opengl/pieblitfunc.h
+++ b/lib/ivis_opengl/pieblitfunc.h
@@ -120,12 +120,12 @@ static inline void iV_Box(int x0, int y0, int x1, int y1, PIELIGHT first)
 	iV_Box2(x0, y0, x1, y1, first, first);
 }
 void pie_BoxFill(int x0, int y0, int x1, int y1, PIELIGHT colour, REND_MODE rendermode = REND_OPAQUE);
-void iV_DrawImage(GLuint TextureID, Vector2i position, Vector2i offset, Vector2i size, float angle, REND_MODE mode, PIELIGHT colour);
-void iV_DrawImageText(gfx_api::texture& TextureID, Vector2i position, Vector2i offset, Vector2i size, float angle, REND_MODE mode, PIELIGHT colour);
+void iV_DrawImage(GLuint TextureID, Vector2i position, Vector2f offset, Vector2i size, float angle, REND_MODE mode, PIELIGHT colour);
+void iV_DrawImageText(gfx_api::texture& TextureID, Vector2i Position, Vector2f offset, Vector2f size, float angle, REND_MODE mode, PIELIGHT colour);
 void iV_DrawImage(IMAGEFILE *ImageFile, UWORD ID, int x, int y, const glm::mat4 &modelViewProjection = defaultProjectionMatrix());
 void iV_DrawImage2(const QString &filename, float x, float y, float width = -0.0f, float height = -0.0f);
 void iV_DrawImageTc(Image image, Image imageTc, int x, int y, PIELIGHT colour, const glm::mat4 &modelViewProjection = defaultProjectionMatrix());
-void iV_DrawImageRepeatX(IMAGEFILE *ImageFile, UWORD ID, int x, int y, int Width, const glm::mat4 &modelViewProjection = defaultProjectionMatrix());
+void iV_DrawImageRepeatX(IMAGEFILE *ImageFile, UWORD ID, int x, int y, int Width, const glm::mat4 &modelViewProjection = defaultProjectionMatrix(), bool enableHorizontalTilingSeamWorkaround = false);
 void iV_DrawImageRepeatY(IMAGEFILE *ImageFile, UWORD ID, int x, int y, int Height, const glm::mat4 &modelViewProjection = defaultProjectionMatrix());
 
 static inline void iV_DrawImage(Image image, int x, int y)

--- a/lib/ivis_opengl/piedef.h
+++ b/lib/ivis_opengl/piedef.h
@@ -57,7 +57,7 @@ struct iIMDShape;
  *	Global ProtoTypes
  */
 /***************************************************************************/
-void pie_Draw3DShape(iIMDShape *shape, int frame, int team, PIELIGHT colour, int pieFlag, int pieFlagData, const glm::mat4 &modelView);
+bool pie_Draw3DShape(iIMDShape *shape, int frame, int team, PIELIGHT colour, int pieFlag, int pieFlagData, const glm::mat4 &modelView);
 
 void pie_GetResetCounts(unsigned int *pPieCount, unsigned int *pPolyCount);
 

--- a/lib/ivis_opengl/piedraw.cpp
+++ b/lib/ivis_opengl/piedraw.cpp
@@ -243,7 +243,9 @@ static void pie_Draw3DShape2(const iIMDShape *shape, int frame, PIELIGHT colour,
 	polyCount += shape->npolys;
 
 	pie_SetShaderEcmEffect(false);
-	pie_DeactivateShader();
+	// NOTE: Do *not* call pie_DeactivateShader() here, to avoid unecessary state transitions.
+	// Avoiding a call to pie_DeactivateShader() here yields a 10%+ CPU usage reduction overall.
+	// (activateShader handles changing the active shader *if necessary*.)
 }
 
 static inline bool edgeLessThan(EDGE const &e1, EDGE const &e2)
@@ -301,7 +303,15 @@ namespace
 }
 
 /// Draw the shadow for a shape
-static void pie_DrawShadow(iIMDShape *shape, int flag, int flag_data, const glm::vec4 &light, const glm::mat4 &modelViewMatrix)
+/// Prequisite:
+///		Caller must call the following before all calls to pie_DrawShadow():
+///			const auto &program = pie_ActivateShader(SHADER_GENERIC_COLOR, pie_PerspectiveGet(), glm::vec4());
+///			glEnableVertexAttribArray(program.locVertex);
+///		and must call the following after all calls to pie_DrawShadow():
+///			glDisableVertexAttribArray(program.locVertex);
+///			pie_DeactivateShader();
+///		The only place this is currently called is pie_ShadowDrawLoop(), which handles this properly.
+static inline void pie_DrawShadow(iIMDShape *shape, int flag, int flag_data, const glm::vec4 &light, const glm::mat4 &modelViewMatrix)
 {
 	static std::vector<EDGE> edgelist;  // Static, to save allocations.
 	static std::vector<EDGE> edgelistFlipped;  // Static, to save allocations.
@@ -318,10 +328,10 @@ static void pie_DrawShadow(iIMDShape *shape, int flag, int flag_data, const glm:
 	else
 	{
 		edgelist.clear();
+		glm::vec3 p[3];
 		iIMDPoly *end = shape->polys + shape->npolys;
 		for (iIMDPoly *pPolys = shape->polys; pPolys != end; ++pPolys)
 		{
-			glm::vec3 p[3];
 			for (int j = 0; j < 3; ++j)
 			{
 				int current = pPolys->pindex[j];
@@ -358,22 +368,22 @@ static void pie_DrawShadow(iIMDShape *shape, int flag, int flag_data, const glm:
 		}
 	}
 
-	std::vector<Vector3f> vertexes;
+	static std::vector<Vector3f> vertexes;
+	vertexes.clear();
+	vertexes.reserve(edge_count * 6);
 	for (unsigned i = 0; i < edge_count; i++)
 	{
 		int a = drawlist[i].from, b = drawlist[i].to;
 
 		glm::vec3 v1(pVertices[b].x, scale_y(pVertices[b].y, flag, flag_data), pVertices[b].z);
-		glm::vec3 v2(pVertices[b].x + light[0], scale_y(pVertices[b].y, flag, flag_data) + light[1], pVertices[b].z + light[2]);
 		glm::vec3 v3(pVertices[a].x + light[0], scale_y(pVertices[a].y, flag, flag_data) + light[1], pVertices[a].z + light[2]);
-		glm::vec3 v4(pVertices[a].x, scale_y(pVertices[a].y, flag, flag_data), pVertices[a].z);
 
 		vertexes.push_back(v1);
-		vertexes.push_back(v2);
+		vertexes.push_back(glm::vec3(pVertices[b].x + light[0], scale_y(pVertices[b].y, flag, flag_data) + light[1], pVertices[b].z + light[2])); //v2
 		vertexes.push_back(v3);
 
 		vertexes.push_back(v3);
-		vertexes.push_back(v4);
+		vertexes.push_back(glm::vec3(pVertices[a].x, scale_y(pVertices[a].y, flag, flag_data), pVertices[a].z)); //v4
 		vertexes.push_back(v1);
 	}
 
@@ -382,12 +392,10 @@ static void pie_DrawShadow(iIMDShape *shape, int flag, int flag_data, const glm:
 	static glBufferWrapper buffer;
 	glBindBuffer(GL_ARRAY_BUFFER, buffer.id);
 	glBufferData(GL_ARRAY_BUFFER, sizeof(Vector3f) * vertexes.size(), vertexes.data(), GL_STREAM_DRAW);
-	glEnableVertexAttribArray(program.locVertex);
 	glVertexAttribPointer(program.locVertex, 3, GL_FLOAT, GL_FALSE, 0, nullptr);
 
 	glDrawArrays(GL_TRIANGLES, 0, edge_count * 2 * 3);
-	glDisableVertexAttribArray(program.locVertex);
-	pie_DeactivateShader();
+	// NOTE: Do not call pie_DeactivateShader() here. The parent loop calls it at the end of all pie_DrawShadow() calls, for a 10%+ CPU usage reduction.
 }
 
 void pie_SetUp()
@@ -499,10 +507,14 @@ bool pie_Draw3DShape(iIMDShape *shape, int frame, int team, PIELIGHT colour, int
 
 static void pie_ShadowDrawLoop()
 {
+	const auto &program = pie_ActivateShader(SHADER_GENERIC_COLOR, pie_PerspectiveGet(), glm::vec4());
+	glEnableVertexAttribArray(program.locVertex);
 	for (unsigned i = 0; i < scshapes.size(); i++)
 	{
 		pie_DrawShadow(scshapes[i].shape, scshapes[i].flag, scshapes[i].flag_data, scshapes[i].light, scshapes[i].matrix);
 	}
+	glDisableVertexAttribArray(program.locVertex);
+	pie_DeactivateShader();
 }
 
 static void pie_DrawShadows()

--- a/lib/ivis_opengl/piedraw.cpp
+++ b/lib/ivis_opengl/piedraw.cpp
@@ -425,7 +425,7 @@ void pie_CleanUp()
 	scshapes.clear();
 }
 
-void pie_Draw3DShape(iIMDShape *shape, int frame, int team, PIELIGHT colour, int pieFlag, int pieFlagData, const glm::mat4 &modelView)
+bool pie_Draw3DShape(iIMDShape *shape, int frame, int team, PIELIGHT colour, int pieFlag, int pieFlagData, const glm::mat4 &modelView)
 {
 	pieCount++;
 
@@ -493,6 +493,8 @@ void pie_Draw3DShape(iIMDShape *shape, int frame, int team, PIELIGHT colour, int
 			shapes.push_back(tshape);
 		}
 	}
+
+	return true;
 }
 
 static void pie_ShadowDrawLoop()

--- a/lib/ivis_opengl/piematrix.h
+++ b/lib/ivis_opengl/piematrix.h
@@ -44,7 +44,7 @@ static inline Vector3f pie_SurfaceNormal3fv(const Vector3f p1, const Vector3f p2
 }
 
 int32_t pie_RotateProject(const Vector3i *src, const glm::mat4& matrix, Vector2i *dest);
-glm::mat4 pie_PerspectiveGet();
+const glm::mat4& pie_PerspectiveGet();
 void pie_SetGeometricOffset(int x, int y);
 void pie_Begin3DScene();
 void pie_BeginInterface();

--- a/lib/ivis_opengl/piemode.cpp
+++ b/lib/ivis_opengl/piemode.cpp
@@ -47,6 +47,18 @@
 
 iSurface rendSurface;
 
+void pie_UpdateSurfaceGeometry()
+{
+	rendSurface.width	= pie_GetVideoBufferWidth();
+	rendSurface.height	= pie_GetVideoBufferHeight();
+	rendSurface.xcentre	= pie_GetVideoBufferWidth() / 2;
+	rendSurface.ycentre	= pie_GetVideoBufferHeight() / 2;
+	rendSurface.clip.left	= 0;
+	rendSurface.clip.top	= 0;
+	rendSurface.clip.right	= pie_GetVideoBufferWidth();
+	rendSurface.clip.bottom	= pie_GetVideoBufferHeight();
+}
+
 bool pie_Initialise()
 {
 	pie_SetUp();
@@ -62,14 +74,7 @@ bool pie_Initialise()
 		debug(LOG_TEXTURE, "Texture compression: No");
 	}
 
-	rendSurface.width	= pie_GetVideoBufferWidth();
-	rendSurface.height	= pie_GetVideoBufferHeight();
-	rendSurface.xcentre	= pie_GetVideoBufferWidth() / 2;
-	rendSurface.ycentre	= pie_GetVideoBufferHeight() / 2;
-	rendSurface.clip.left	= 0;
-	rendSurface.clip.top	= 0;
-	rendSurface.clip.right	= pie_GetVideoBufferWidth();
-	rendSurface.clip.bottom	= pie_GetVideoBufferHeight();
+	pie_UpdateSurfaceGeometry();
 
 	pie_SetDefaultStates();
 	debug(LOG_3D, "xcentre %d; ycentre %d", rendSurface.xcentre, rendSurface.ycentre);

--- a/lib/ivis_opengl/piemode.h
+++ b/lib/ivis_opengl/piemode.h
@@ -53,6 +53,7 @@ extern iSurface rendSurface;
 bool pie_Initialise();
 void pie_ShutDown();
 void pie_ScreenFlip(int ClearMode);
+void pie_UpdateSurfaceGeometry();
 UDWORD pie_GetResScalingFactor();
 
 #endif

--- a/lib/ivis_opengl/screen.h
+++ b/lib/ivis_opengl/screen.h
@@ -62,6 +62,8 @@ void screenDoDumpToDiskIfRequired();
 void screen_enableMapPreview(int width, int height, Vector2i *playerpositions);
 void screen_disableMapPreview();
 
+void screen_updateGeometry();
+
 /// graphics performance measurement points
 enum PERF_POINT
 {

--- a/lib/qtgame/main_qt.cpp
+++ b/lib/qtgame/main_qt.cpp
@@ -48,7 +48,7 @@ void wzMain(int &argc, char **argv)
 	appPtr = new QApplication(argc, argv);
 }
 
-bool wzMainScreenSetup(int antialiasing, bool fullscreen, bool vsync)
+bool wzMainScreenSetup(int antialiasing, bool fullscreen, bool vsync, bool highDPI)
 {
 	debug(LOG_MAIN, "Qt initialization");
 	//QGL::setPreferredPaintEngine(QPaintEngine::OpenGL); // Workaround for incorrect text rendering on many platforms, doesn't exist in Qt5…
@@ -142,6 +142,86 @@ std::vector<screeninfo> wzAvailableResolutions()
 		res.push_back(info);
 	}
 	return res;
+}
+
+std::vector<unsigned int> wzAvailableDisplayScales()
+{
+	// TODO: Currently, Qt backend only supports 100% display scale.
+	static const unsigned int wzDisplayScales[] = { 100 };
+	return std::vector<unsigned int>(wzDisplayScales, wzDisplayScales + (sizeof(wzDisplayScales) / sizeof(wzDisplayScales[0])));
+}
+
+void wzGetGameToRendererScaleFactor(float *horizScaleFactor, float *vertScaleFactor)
+{
+	// TODO: Support high-DPI with Qt backend
+	if (horizScaleFactor != nullptr)
+	{
+		*horizScaleFactor = 1.0f
+	}
+	if (vertScaleFactor != nullptr)
+	{
+		*vertScaleFactor = 1.0f
+	}
+}
+
+void wzSetWindowIsResizable(bool resizable)
+{
+	// TODO: Implement
+}
+
+bool wzIsWindowResizable()
+{
+	// TODO: Implement
+	return false;
+}
+
+bool wzSupportsLiveResolutionChanges()
+{
+	// TODO: Implement support for live resolution changes (several of the other functions with TODOs here)
+	return false;
+}
+
+bool wzChangeDisplayScale(unsigned int displayScale)
+{
+	// TODO: Implement
+	return false;
+}
+
+bool wzChangeWindowResolution(int screen, unsigned int width, unsigned int height)
+{
+	// TODO: Implement support for live resolution changes
+	return false;
+}
+
+unsigned int wzGetMaximumDisplayScaleForWindowSize(unsigned int windowWidth, unsigned int windowHeight)
+{
+	// TODO: Implement
+	return 100;
+}
+
+unsigned int wzGetCurrentDisplayScale()
+{
+	// TODO: Implement
+	return 100;
+}
+
+void wzGetWindowResolution(int *screen, unsigned int *width, unsigned int *height)
+{
+	assert(mainWindowPtr != nullptr);
+	WzMainWindow &mainwindow = *mainWindowPtr;
+	if (screen != nullptr)
+	{
+		// FIXME: Determine which screen the window is on
+		*screen = 0;
+	}
+	if (width != nullptr)
+	{
+		*width = mainwindow.width();
+	}
+	if (height != nullptr)
+	{
+		*height = mainwindow.height();
+	}
 }
 
 void wzSetSwapInterval(int swap)

--- a/lib/sdl/cocoa_sdl_helpers.h
+++ b/lib/sdl/cocoa_sdl_helpers.h
@@ -1,0 +1,33 @@
+//
+//  cocoa_sdl_helpers.h
+//  Warzone
+//
+//	Copyright © 2017 pastdue (https://github.com/past-due/)
+//
+//	Permission is hereby granted, free of charge, to any person obtaining a copy
+//	of this software and associated documentation files (the "Software"), to deal
+//	in the Software without restriction, including without limitation the rights
+//	to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//	copies of the Software, and to permit persons to whom the Software is
+//	furnished to do so, subject to the following conditions:
+//
+//	The above copyright notice and this permission notice shall be included in all
+//	copies or substantial portions of the Software.
+//
+//	THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//	IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//	FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//	AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//	LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//	OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//	SOFTWARE.
+//
+
+#ifndef cocoa_sdl_helpers_h
+#define cocoa_sdl_helpers_h
+
+#include <SDL.h>
+
+bool cocoaIsSDLWindowFullscreened(SDL_Window *window);
+
+#endif /* cocoa_sdl_helpers_h */

--- a/lib/sdl/cocoa_sdl_helpers.mm
+++ b/lib/sdl/cocoa_sdl_helpers.mm
@@ -1,0 +1,51 @@
+//
+//  cocoa_sdl_helpers.m
+//  Warzone
+//
+//	Copyright © 2017 pastdue (https://github.com/past-due/)
+//
+//	Permission is hereby granted, free of charge, to any person obtaining a copy
+//	of this software and associated documentation files (the "Software"), to deal
+//	in the Software without restriction, including without limitation the rights
+//	to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//	copies of the Software, and to permit persons to whom the Software is
+//	furnished to do so, subject to the following conditions:
+//
+//	The above copyright notice and this permission notice shall be included in all
+//	copies or substantial portions of the Software.
+//
+//	THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//	IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//	FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//	AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//	LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//	OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//	SOFTWARE.
+//
+
+#import <Foundation/Foundation.h>
+#import <Cocoa/Cocoa.h>
+#import "cocoa_sdl_helpers.h"
+#include "SDL_syswm.h"
+
+bool cocoaIsNSWindowFullscreened(NSWindow __unsafe_unretained *window)
+{
+	return [window styleMask] & NSFullScreenWindowMask;
+}
+
+bool cocoaIsSDLWindowFullscreened(SDL_Window *window)
+{
+	if (window == nil) return false;
+	SDL_SysWMinfo info;
+	SDL_VERSION(&info.version); /* initialize info structure with SDL version info */
+	if(SDL_GetWindowWMInfo(window, &info) == SDL_FALSE) {
+		NSLog(@"Unable to get SDL_SysWMinfo, with error: %s", SDL_GetError());
+		return false;
+	}
+	if (info.subsystem != SDL_SYSWM_COCOA) {
+		NSLog(@"Unexpected SDL subsystem: %d", info.subsystem);
+		return false;
+	}
+	assert(info.info.cocoa.window != nil);
+	return cocoaIsNSWindowFullscreened(info.info.cocoa.window);
+}

--- a/lib/sdl/main_sdl.cpp
+++ b/lib/sdl/main_sdl.cpp
@@ -35,8 +35,11 @@
 #include "lib/framework/utf.h"
 #include "lib/framework/opengl.h"
 #include "lib/ivis_opengl/pieclip.h"
+#include "lib/ivis_opengl/piemode.h"
+#include "lib/ivis_opengl/screen.h"
 #include "lib/gamelib/gtime.h"
 #include "src/warzoneconfig.h"
+#include "src/game.h"
 #include <SDL.h>
 #include <SDL_thread.h>
 #include <SDL_clipboard.h>
@@ -68,8 +71,18 @@ int main(int argc, char *argv[])
 // At this time, we only have 1 window and 1 GL context.
 static SDL_Window *WZwindow = nullptr;
 static SDL_GLContext WZglcontext = nullptr;
+
+// The screen that the game window is on.
+int screenIndex = 0;
+// The logical resolution of the game in the game's coordinate system (points).
 unsigned int screenWidth = 0;
 unsigned int screenHeight = 0;
+// The logical resolution of the SDL window in the window's coordinate system (points) - i.e. not accounting for the Game Display Scale setting.
+unsigned int windowWidth = 0;
+unsigned int windowHeight = 0;
+// The current display scale factor.
+unsigned int current_displayScale = 100;
+float current_displayScaleFactor = 1.f;
 
 static std::vector<screeninfo> displaylist;	// holds all our possible display lists
 
@@ -124,6 +137,22 @@ static int dragY = 0;
 /* The current mouse button state */
 static INPUT_STATE aMouseState[MOUSE_END];
 static MousePresses mousePresses;
+
+/* The current screen resizing state for this iteration through the game loop, in the game coordinate system */
+struct ScreenSizeChange
+{
+	ScreenSizeChange(unsigned int oldWidth, unsigned int oldHeight, unsigned int newWidth, unsigned int newHeight)
+	:	oldWidth(oldWidth)
+	,	oldHeight(oldHeight)
+	,	newWidth(newWidth)
+	,	newHeight(newHeight)
+	{ }
+	unsigned int oldWidth;
+	unsigned int oldHeight;
+	unsigned int newWidth;
+	unsigned int newHeight;
+};
+static ScreenSizeChange* currentScreenResizingStatus = nullptr;
 
 /* The size of the input buffer */
 #define INPUT_MAXSTR 256
@@ -416,6 +445,23 @@ std::vector<screeninfo> wzAvailableResolutions()
 	return displaylist;
 }
 
+std::vector<unsigned int> wzAvailableDisplayScales()
+{
+	static const unsigned int wzDisplayScales[] = { 100, 125, 150, 200, 250, 300, 400, 500 };
+	return std::vector<unsigned int>(wzDisplayScales, wzDisplayScales + (sizeof(wzDisplayScales) / sizeof(wzDisplayScales[0])));
+}
+
+void setDisplayScale(unsigned int displayScale)
+{
+	current_displayScale = displayScale;
+	current_displayScaleFactor = (float)displayScale / 100.f;
+}
+
+unsigned int wzGetCurrentDisplayScale()
+{
+	return current_displayScale;
+}
+
 void wzShowMouse(bool visible)
 {
 	SDL_ShowCursor(visible ? SDL_ENABLE : SDL_DISABLE);
@@ -453,8 +499,24 @@ void wzToggleFullscreen()
 
 bool wzIsFullscreen()
 {
+	assert(WZwindow != nullptr);
 	Uint32 flags = SDL_GetWindowFlags(WZwindow);
-	if (flags & SDL_WINDOW_FULLSCREEN)
+	if ((flags & SDL_WINDOW_FULLSCREEN) || (flags & SDL_WINDOW_FULLSCREEN_DESKTOP))
+	{
+		return true;
+	}
+	return false;
+}
+
+#if defined(WZ_OS_MAC)
+#include "cocoa_sdl_helpers.h"
+#endif
+
+bool wzIsMaximized()
+{
+	assert(WZwindow != nullptr);
+	Uint32 flags = SDL_GetWindowFlags(WZwindow);
+	if (flags & SDL_WINDOW_MAXIMIZED)
 	{
 		return true;
 	}
@@ -1135,8 +1197,8 @@ static void inputHandleMouseWheelEvent(SDL_MouseWheelEvent *wheel)
  */
 static void inputHandleMouseButtonEvent(SDL_MouseButtonEvent *buttonEvent)
 {
-	mouseXPos = buttonEvent->x;
-	mouseYPos = buttonEvent->y;
+	mouseXPos = (int)((float)buttonEvent->x / current_displayScaleFactor);
+	mouseYPos = (int)((float)buttonEvent->y / current_displayScaleFactor);
 
 	MOUSE_KEY_CODE mouseKeyCode;
 	switch (buttonEvent->button)
@@ -1216,8 +1278,8 @@ static void inputHandleMouseMotionEvent(SDL_MouseMotionEvent *motionEvent)
 	{
 	case SDL_MOUSEMOTION:
 		/* store the current mouse position */
-		mouseXPos = motionEvent->x;
-		mouseYPos = motionEvent->y;
+		mouseXPos = (int)((float)motionEvent->x / current_displayScaleFactor);
+		mouseYPos = (int)((float)motionEvent->y / current_displayScaleFactor);
 
 		/* now see if a drag has started */
 		if ((aMouseState[dragKey].state == KEY_PRESSED ||
@@ -1240,10 +1302,293 @@ void wzMain(int &argc, char **argv)
 	appPtr = new QApplication(argc, argv);
 }
 
+#define MIN_WZ_GAMESCREEN_WIDTH 640
+#define MIN_WZ_GAMESCREEN_HEIGHT 480
+
+void handleGameScreenSizeChange(unsigned int oldWidth, unsigned int oldHeight, unsigned int newWidth, unsigned int newHeight)
+{
+	screenWidth = newWidth;
+	screenHeight = newHeight;
+
+	pie_SetVideoBufferWidth(screenWidth);
+	pie_SetVideoBufferHeight(screenHeight);
+	pie_UpdateSurfaceGeometry();
+	screen_updateGeometry();
+
+	if (currentScreenResizingStatus == nullptr)
+	{
+		// The screen size change details are stored in scaled, logical units (points)
+		// i.e. the values expect by the game engine.
+		currentScreenResizingStatus = new ScreenSizeChange(oldWidth, oldHeight, screenWidth, screenHeight);
+	}
+	else
+	{
+		// update the new screen width / height, in case more than one resize message is processed this event loop
+		currentScreenResizingStatus->newWidth = screenWidth;
+		currentScreenResizingStatus->newHeight = screenHeight;
+	}
+}
+
+void handleWindowSizeChange(unsigned int oldWidth, unsigned int oldHeight, unsigned int newWidth, unsigned int newHeight)
+{
+	windowWidth = newWidth;
+	windowHeight = newHeight;
+
+	// NOTE: This function receives the window size in the window's logical units, but not accounting for the interface scale factor.
+	// Therefore, the provided old/newWidth/Height must be divided by the interface scale factor to calculate the new
+	// *game* screen logical width / height.
+	unsigned int oldScreenWidth = oldWidth / current_displayScaleFactor;
+	unsigned int oldScreenHeight = oldHeight / current_displayScaleFactor;
+	unsigned int newScreenWidth = newWidth / current_displayScaleFactor;
+	unsigned int newScreenHeight = newHeight / current_displayScaleFactor;
+
+	handleGameScreenSizeChange(oldScreenWidth, oldScreenHeight, newScreenWidth, newScreenHeight);
+
+	// Update the viewport to use the new *drawable* size (which may be greater than the new window size
+	// if SDL's built-in high-DPI support is enabled and functioning).
+	int drawableWidth = 0, drawableHeight = 0;
+	SDL_GL_GetDrawableSize(WZwindow, &drawableWidth, &drawableHeight);
+	debug(LOG_WZ, "Logical Size: %d x %d; Drawable Size: %d x %d", screenWidth, screenHeight, drawableWidth, drawableHeight);
+	glViewport(0, 0, drawableWidth, drawableHeight);
+	glCullFace(GL_FRONT);
+	glEnable(GL_CULL_FACE);
+}
+
+
+void wzGetMinimumWindowSizeForDisplayScaleFactor(unsigned int *minWindowWidth, unsigned int *minWindowHeight, float displayScaleFactor = current_displayScaleFactor)
+{
+	if (minWindowWidth != nullptr)
+	{
+		*minWindowWidth = (int)ceil(MIN_WZ_GAMESCREEN_WIDTH * displayScaleFactor);
+	}
+	if (minWindowHeight != nullptr)
+	{
+		*minWindowHeight = (int)ceil(MIN_WZ_GAMESCREEN_HEIGHT * displayScaleFactor);
+	}
+}
+
+void wzGetMaximumDisplayScaleFactorsForWindowSize(unsigned int windowWidth, unsigned int windowHeight, float *horizScaleFactor, float *vertScaleFactor)
+{
+	if (horizScaleFactor != nullptr)
+	{
+		*horizScaleFactor = (float)windowWidth / (float)MIN_WZ_GAMESCREEN_WIDTH;
+	}
+	if (vertScaleFactor != nullptr)
+	{
+		*vertScaleFactor = (float)windowHeight / (float)MIN_WZ_GAMESCREEN_HEIGHT;
+	}
+}
+
+float wzGetMaximumDisplayScaleFactorForWindowSize(unsigned int windowWidth, unsigned int windowHeight)
+{
+	float maxHorizScaleFactor = 0.f, maxVertScaleFactor = 0.f;
+	wzGetMaximumDisplayScaleFactorsForWindowSize(windowWidth, windowHeight, &maxHorizScaleFactor, &maxVertScaleFactor);
+	return std::min(maxHorizScaleFactor, maxVertScaleFactor);
+}
+
+// returns: the maximum display scale percentage (sourced from wzAvailableDisplayScales), or 0 if window is below the minimum required size for the minimum support display scale
+unsigned int wzGetMaximumDisplayScaleForWindowSize(unsigned int windowWidth, unsigned int windowHeight)
+{
+	float maxDisplayScaleFactor = wzGetMaximumDisplayScaleFactorForWindowSize(windowWidth, windowHeight);
+	unsigned int maxDisplayScalePercentage = floor(maxDisplayScaleFactor * 100.f);
+
+	auto availableDisplayScales = wzAvailableDisplayScales();
+	std::sort(availableDisplayScales.begin(), availableDisplayScales.end());
+
+	auto maxDisplayScale = std::lower_bound(availableDisplayScales.begin(), availableDisplayScales.end(), maxDisplayScalePercentage);
+	if (maxDisplayScale == availableDisplayScales.end())
+	{
+		return 0;
+	}
+	if (*maxDisplayScale != maxDisplayScalePercentage)
+	{
+		--maxDisplayScale;
+	}
+	return *maxDisplayScale;
+}
+
+bool wzWindowSizeIsSmallerThanMinimumRequired(unsigned int windowWidth, unsigned int windowHeight, float displayScaleFactor = current_displayScaleFactor)
+{
+	unsigned int minWindowWidth = 0, minWindowHeight = 0;
+	wzGetMinimumWindowSizeForDisplayScaleFactor(&minWindowWidth, &minWindowHeight, displayScaleFactor);
+	return ((windowWidth < minWindowWidth) || (windowHeight < minWindowHeight));
+}
+
+void processScreenSizeChangeNotificationIfNeeded()
+{
+	if (currentScreenResizingStatus != nullptr)
+	{
+		// WZ must process the screen size change
+		gameScreenSizeDidChange(currentScreenResizingStatus->oldWidth, currentScreenResizingStatus->oldHeight, currentScreenResizingStatus->newWidth, currentScreenResizingStatus->newHeight);
+		delete currentScreenResizingStatus;
+		currentScreenResizingStatus = nullptr;
+	}
+}
+
+bool wzChangeDisplayScale(unsigned int displayScale)
+{
+	float newDisplayScaleFactor = (float)displayScale / 100.f;
+
+	if (wzWindowSizeIsSmallerThanMinimumRequired(windowWidth, windowHeight, newDisplayScaleFactor))
+	{
+		// The current window width and/or height are below the required minimum window size
+		// for this display scale factor.
+		return false;
+	}
+
+	// Store the new display scale factor
+	setDisplayScale(displayScale);
+
+	// Set the new minimum window size
+	unsigned int minWindowWidth = 0, minWindowHeight = 0;
+	wzGetMinimumWindowSizeForDisplayScaleFactor(&minWindowWidth, &minWindowHeight, newDisplayScaleFactor);
+	SDL_SetWindowMinimumSize(WZwindow, minWindowWidth, minWindowHeight);
+
+	// Update the game's logical screen size
+	unsigned int oldScreenWidth = screenWidth, oldScreenHeight = screenHeight;
+	unsigned int newScreenWidth = windowWidth, newScreenHeight = windowHeight;
+	if (newDisplayScaleFactor > 1.0)
+	{
+		newScreenWidth = windowWidth / newDisplayScaleFactor;
+		newScreenHeight = windowHeight / newDisplayScaleFactor;
+	}
+	handleGameScreenSizeChange(oldScreenWidth, oldScreenHeight, newScreenWidth, newScreenHeight);
+	gameDisplayScaleFactorDidChange(newDisplayScaleFactor);
+
+	// Update the current mouse coordinates
+	// (The prior stored mouseXPos / mouseYPos apply to the old coordinate system, and must be translated to the
+	// new game coordinate system. Since the mouse hasn't moved - or it would generate events that override this -
+	// the current position with respect to the window (which hasn't changed size) can be queried and used to
+	// calculate the new game coordinate system mouse position.)
+	//
+	int windowMouseXPos = 0, windowMouseYPos = 0;
+	SDL_GetMouseState(&windowMouseXPos, &windowMouseYPos);
+	debug(LOG_WZ, "Old mouse position: %d, %d", mouseXPos, mouseYPos);
+	mouseXPos = (int)((float)windowMouseXPos / current_displayScaleFactor);
+	mouseYPos = (int)((float)windowMouseYPos / current_displayScaleFactor);
+	debug(LOG_WZ, "New mouse position: %d, %d", mouseXPos, mouseYPos);
+
+
+	processScreenSizeChangeNotificationIfNeeded();
+
+	return true;
+}
+
+bool wzChangeWindowResolution(int screen, unsigned int width, unsigned int height)
+{
+	assert(WZwindow != nullptr);
+
+#if defined(WZ_OS_MAC)
+	// Workaround for SDL (2.0.5) quirk on macOS:
+	//	When the green titlebar button is used to fullscreen the app in a new space:
+	//		- SDL does not return SDL_WINDOW_MAXIMIZED nor SDL_WINDOW_FULLSCREEN.
+	//		- Attempting to change the window resolution "succeeds" (in that the new window size is "set" and returned
+	//		  by the SDL GetWindowSize functions).
+	//		- But other things break (ex. mouse coordinate translation) if the resolution is changed while the window
+	//        is maximized in this way.
+	//		- And the GL drawable size remains unchanged.
+	//		- So if it's been fullscreened by the user like this, but doesn't show as SDL_WINDOW_FULLSCREEN,
+	//		  prevent window resolution changes.
+	if (cocoaIsSDLWindowFullscreened(WZwindow) && !wzIsFullscreen())
+	{
+		debug(LOG_WZ, "The main window is fullscreened, but SDL doesn't think it is. Changing window resolution is not possible in this state. (SDL Bug).");
+		return false;
+	}
+#endif
+
+	unsigned int priorDisplayScale = current_displayScale;
+	if (wzWindowSizeIsSmallerThanMinimumRequired(width, height))
+	{
+		// The new window size is smaller than the minimum required size for the current display scale level.
+
+		unsigned int maxDisplayScale = wzGetMaximumDisplayScaleForWindowSize(width, height);
+		if (maxDisplayScale < 100)
+		{
+			// Cannot adjust display scale factor below 1. Desired window size is below the minimum supported.
+			debug(LOG_WZ, "Unable to change window size to (%d x %d) because it is smaller than the minimum supported at a 100%% display scale", width, height);
+			return false;
+		}
+
+		// Adjust the current display scale level to the nearest supported level.
+		debug(LOG_WZ, "The current Display Scale (%d%%) is too high for the desired window size. Reducing the current Display Scale to the maximum possible for the desired window size: %d%%.", current_displayScale, maxDisplayScale);
+		wzChangeDisplayScale(maxDisplayScale);
+
+		// Store the new display scale
+		war_SetDisplayScale(maxDisplayScale);
+	}
+
+	// Get current window size + position + bounds
+	int prev_x = 0, prev_y = 0, prev_width = 0, prev_height = 0;
+	SDL_GetWindowPosition(WZwindow, &prev_x, &prev_y);
+	SDL_GetWindowSize(WZwindow, &prev_width, &prev_height);
+
+	SDL_Rect bounds;
+	if (SDL_GetDisplayBounds(screen, &bounds) != 0) {
+		debug(LOG_ERROR, "Failed to get display bounds for screen: %d", screen);
+		return false;
+	}
+	bounds.w -= (bounds.w + width) / 2;
+	bounds.h -= (bounds.h + height) / 2;
+
+	// Position the window (centered) on the screen (for its upcoming new size)
+	SDL_SetWindowPosition(WZwindow, bounds.x + bounds.w, bounds.y + bounds.h);
+
+	// Change the window size
+	// NOTE: Changing the window size will trigger an SDL window size changed event which will handle recalculating layout.
+	SDL_SetWindowSize(WZwindow, width, height);
+
+	// Check that the new size is the desired size
+	int resultingWidth, resultingHeight = 0;
+	SDL_GetWindowSize(WZwindow, &resultingWidth, &resultingHeight);
+	if (resultingWidth != width || resultingHeight != height) {
+		// Attempting to set the resolution failed
+		// Revert to the prior position + resolution + display scale, and return false
+		SDL_SetWindowSize(WZwindow, prev_width, prev_height);
+		SDL_SetWindowPosition(WZwindow, prev_x, prev_y);
+		if (current_displayScale != priorDisplayScale)
+		{
+			// Reverse the correction applied to the Display Scale to support the desired resolution.
+			wzChangeDisplayScale(priorDisplayScale);
+			war_SetDisplayScale(priorDisplayScale);
+		}
+		return false;
+	}
+
+	// Store the updated screenIndex
+	screenIndex = screen;
+
+	return true;
+}
+
+// Returns the current window screen, width, and height
+void wzGetWindowResolution(int *screen, unsigned int *width, unsigned int *height)
+{
+	if (screen != nullptr)
+	{
+		*screen = screenIndex;
+	}
+
+	int currentWidth = 0, currentHeight = 0;
+	SDL_GetWindowSize(WZwindow, &currentWidth, &currentHeight);
+	assert(currentWidth >= 0);
+	assert(currentHeight >= 0);
+	if (width != nullptr)
+	{
+		*width = currentWidth;
+	}
+	if (height != nullptr)
+	{
+		*height = currentHeight;
+	}
+}
+
 // This stage, we handle display mode setting
-bool wzMainScreenSetup(int antialiasing, bool fullscreen, bool vsync)
+bool wzMainScreenSetup(int antialiasing, bool fullscreen, bool vsync, bool highDPI)
 {
 	// populate with the saved values (if we had any)
+	// NOTE: Prior to wzMainScreenSetup being run, the display system is populated with the window width + height
+	// (i.e. not taking into account the game display scale). This function later sets the display system
+	// to the *game screen* width and height (taking into account the display scale).
 	int width = pie_GetVideoBufferWidth();
 	int height = pie_GetVideoBufferHeight();
 	int bitDepth = pie_GetVideoBufferDepth();
@@ -1253,6 +1598,14 @@ bool wzMainScreenSetup(int antialiasing, bool fullscreen, bool vsync)
 		debug(LOG_ERROR, "Error: Could not initialise SDL (%s).", SDL_GetError());
 		return false;
 	}
+
+#if defined(WZ_OS_MAC)
+	// on macOS, support maximizing to a fullscreen space (modern behavior)
+	if (SDL_SetHint(SDL_HINT_VIDEO_MAC_FULLSCREEN_SPACES, "1") == SDL_FALSE)
+	{
+		debug(LOG_WARNING, "Failed to set hint: SDL_HINT_VIDEO_MAC_FULLSCREEN_SPACES");
+	}
+#endif
 
 	// Set the double buffer OpenGL attribute.
 	SDL_GL_SetAttribute(SDL_GL_DOUBLEBUFFER, 1);
@@ -1284,9 +1637,9 @@ bool wzMainScreenSetup(int antialiasing, bool fullscreen, bool vsync)
 			}
 
 			debug(LOG_WZ, "Monitor [%d] %dx%d %d %s", i, displaymode.w, displaymode.h, displaymode.refresh_rate, SDL_GetPixelFormatName(displaymode.format));
-			if (displaymode.w < 640 || displaymode.h < 480)
+			if ((displaymode.w < MIN_WZ_GAMESCREEN_WIDTH) || (displaymode.h < MIN_WZ_GAMESCREEN_HEIGHT))
 			{
-				debug(LOG_WZ, "Monitor mode resolution < 640x480 -- discarding entry");
+				debug(LOG_WZ, "Monitor mode resolution < %d x %d -- discarding entry", MIN_WZ_GAMESCREEN_WIDTH, MIN_WZ_GAMESCREEN_HEIGHT);
 			}
 			else if (displaymode.refresh_rate < 59)
 			{
@@ -1319,16 +1672,33 @@ bool wzMainScreenSetup(int antialiasing, bool fullscreen, bool vsync)
 
 	if (width == 0 || height == 0)
 	{
-		pie_SetVideoBufferWidth(width = screenWidth = current.w);
-		pie_SetVideoBufferHeight(height = screenHeight = current.h);
+		width = windowWidth = current.w;
+		height = windowHeight = current.h;
 	}
 	else
 	{
-		screenWidth = width;
-		screenHeight = height;
+		windowWidth = width;
+		windowHeight = height;
 	}
-	screenWidth = MAX(screenWidth, 640);
-	screenHeight = MAX(screenHeight, 480);
+
+	setDisplayScale(war_GetDisplayScale());
+
+	// Calculate the minimum window size given the current display scale
+	unsigned int minWindowWidth = 0, minWindowHeight = 0;
+	wzGetMinimumWindowSizeForDisplayScaleFactor(&minWindowWidth, &minWindowHeight);
+
+	if ((windowWidth < minWindowWidth) || (windowHeight < minWindowHeight))
+	{
+		// The current window width and/or height is lower than the required minimum for the current display scale.
+		//
+		// Reset the display scale to 100%, and recalculate the required minimum window size.
+		setDisplayScale(100);
+		war_SetDisplayScale(100); // save the new display scale configuration
+		wzGetMinimumWindowSizeForDisplayScaleFactor(&minWindowWidth, &minWindowHeight);
+	}
+
+	windowWidth = MAX(windowWidth, minWindowWidth);
+	windowHeight = MAX(windowHeight, minWindowHeight);
 
 	//// The flags to pass to SDL_CreateWindow
 	int video_flags  = SDL_WINDOW_OPENGL | SDL_WINDOW_SHOWN;
@@ -1336,6 +1706,21 @@ bool wzMainScreenSetup(int antialiasing, bool fullscreen, bool vsync)
 	if (fullscreen)
 	{
 		video_flags |= SDL_WINDOW_FULLSCREEN;
+
+		// FIXME: SDL's High-DPI mode does not currently work properly when fullscreened (as of SDL 2.0.5)
+		highDPI = false;
+	}
+	else
+	{
+		// Allow the window to be manually resized, if not fullscreen
+		video_flags |= SDL_WINDOW_RESIZABLE;
+	}
+
+	if (highDPI)
+	{
+		// Allow SDL to enable its built-in High-DPI display support.
+		// As of SDL 2.0.5, this only works on macOS. (But SDL 2.1.x+ may enable Windows support.)
+		video_flags |= SDL_WINDOW_ALLOW_HIGHDPI;
 	}
 
 	SDL_Rect bounds;
@@ -1350,10 +1735,11 @@ bool wzMainScreenSetup(int antialiasing, bool fullscreen, bool vsync)
 		SDL_Quit();
 		exit(EXIT_FAILURE);
 	}
-	SDL_GetDisplayBounds(war_GetScreen(), &bounds);
-	bounds.w -= (bounds.w + screenWidth) / 2;
-	bounds.h -= (bounds.h + screenHeight) / 2;
-	WZwindow = SDL_CreateWindow(PACKAGE_NAME, bounds.x + bounds.w, bounds.y + bounds.h, screenWidth, screenHeight, video_flags);
+	screenIndex = war_GetScreen();
+	SDL_GetDisplayBounds(screenIndex, &bounds);
+	int xOffset = bounds.w - ((bounds.w + windowWidth) / 2);
+	int yOffset = bounds.h - ((bounds.h + windowHeight) / 2);
+	WZwindow = SDL_CreateWindow(PACKAGE_NAME, bounds.x + xOffset, bounds.y + yOffset, windowWidth, windowHeight, video_flags);
 
 	if (!WZwindow)
 	{
@@ -1362,11 +1748,51 @@ bool wzMainScreenSetup(int antialiasing, bool fullscreen, bool vsync)
 		exit(EXIT_FAILURE);
 	}
 
+	// Check that the actual window size matches the desired window size
+	int resultingWidth, resultingHeight = 0;
+	SDL_GetWindowSize(WZwindow, &resultingWidth, &resultingHeight);
+	if (resultingWidth != windowWidth || resultingHeight != windowHeight) {
+		// Failed to create window at desired size (This can happen for a number of reasons)
+		debug(LOG_ERROR, "Failed to create window at desired resolution: [%d] %d x %d; instead, received window of resolution: [%d] %d x %d; Reverting to default resolution of %d x %d", war_GetScreen(), windowWidth, windowHeight, war_GetScreen(), resultingWidth, resultingHeight, minWindowWidth, minWindowHeight);
+
+		// Default to base resolution
+		SDL_SetWindowSize(WZwindow, minWindowWidth, minWindowHeight);
+		windowWidth = minWindowWidth;
+		windowHeight = minWindowHeight;
+	}
+
+	// Calculate the game screen's logical dimensions
+	screenWidth = windowWidth;
+	screenHeight = windowHeight;
+	if (current_displayScaleFactor > 1.0f)
+	{
+		screenWidth = windowWidth / current_displayScaleFactor;
+		screenHeight = windowHeight / current_displayScaleFactor;
+	}
+	pie_SetVideoBufferWidth(screenWidth);
+	pie_SetVideoBufferHeight(screenHeight);
+
+	// Set the minimum window size
+	SDL_SetWindowMinimumSize(WZwindow, minWindowWidth, minWindowHeight);
+
 	WZglcontext = SDL_GL_CreateContext(WZwindow);
 	if (!WZglcontext)
 	{
 		debug(LOG_ERROR, "Failed to create a openGL context! [%s]", SDL_GetError());
 		return false;
+	}
+
+	if (highDPI)
+	{
+		// When high-DPI mode is enabled, retrieve the DrawableSize in pixels
+		// for use in the glViewport function - this will be the actual
+		// pixel dimensions, not the window size (which is in points).
+		//
+		// NOTE: Do not do this if high-DPI support is disabled, or the viewport
+		// size may be set inappropriately.
+
+		SDL_GL_GetDrawableSize(WZwindow, &width, &height);
+		debug(LOG_WZ, "Logical Size: %d x %d; Drawable Size: %d x %d", windowWidth, windowHeight, width, height);
 	}
 
 	int bpp = SDL_BITSPERPIXEL(SDL_GetWindowPixelFormat(WZwindow));
@@ -1408,17 +1834,19 @@ bool wzMainScreenSetup(int antialiasing, bool fullscreen, bool vsync)
 		exit(1);
 	}
 
-#if SDL_BYTEORDER == SDL_BIG_ENDIAN
-	uint32_t rmask = 0xff000000;
-	uint32_t gmask = 0x00ff0000;
-	uint32_t bmask = 0x0000ff00;
-	uint32_t amask = 0x000000ff;
-#else
-	uint32_t rmask = 0x000000ff;
-	uint32_t gmask = 0x0000ff00;
-	uint32_t bmask = 0x00ff0000;
-	uint32_t amask = 0xff000000;
-#endif
+#if !defined(WZ_OS_MAC) // Do not use this method to set the window icon on macOS.
+
+	#if SDL_BYTEORDER == SDL_BIG_ENDIAN
+		uint32_t rmask = 0xff000000;
+		uint32_t gmask = 0x00ff0000;
+		uint32_t bmask = 0x0000ff00;
+		uint32_t amask = 0x000000ff;
+	#else
+		uint32_t rmask = 0x000000ff;
+		uint32_t gmask = 0x0000ff00;
+		uint32_t bmask = 0x00ff0000;
+		uint32_t amask = 0xff000000;
+	#endif
 
 	SDL_Surface *surface_icon = SDL_CreateRGBSurfaceFrom((void *)wz2100icon.pixel_data, wz2100icon.width, wz2100icon.height, wz2100icon.bytes_per_pixel * 8,
 	                            wz2100icon.width * wz2100icon.bytes_per_pixel, rmask, gmask, bmask, amask);
@@ -1431,6 +1859,7 @@ bool wzMainScreenSetup(int antialiasing, bool fullscreen, bool vsync)
 	{
 		debug(LOG_ERROR, "Could not set window icon because %s", SDL_GetError());
 	}
+#endif
 
 	SDL_SetWindowTitle(WZwindow, PACKAGE_NAME);
 
@@ -1449,6 +1878,111 @@ bool wzMainScreenSetup(int antialiasing, bool fullscreen, bool vsync)
 	glCullFace(GL_FRONT);
 	glEnable(GL_CULL_FACE);
 
+	return true;
+}
+
+
+// Calculates and returns the scale factor from the SDL window's coordinate system (in points) to the raw
+// underlying pixels of the viewport / renderer.
+//
+// IMPORTANT: This value is *non-inclusive* of any user-configured Game Display Scale.
+//
+// This exposes what is effectively the SDL window's "High-DPI Scale Factor", if SDL's high-DPI support is enabled and functioning.
+//
+// In the normal, non-high-DPI-supported case, (in which the context's drawable size in pixels and the window's logical
+// size in points are equal) this will return 1.0 for both values.
+//
+void wzGetWindowToRendererScaleFactor(float *horizScaleFactor, float *vertScaleFactor)
+{
+	assert(WZwindow != nullptr);
+
+	// Obtain the window context's drawable size in pixels
+	int drawableWidth, drawableHeight = 0;
+	SDL_GL_GetDrawableSize(WZwindow, &drawableWidth, &drawableHeight);
+
+	// Obtain the logical window size (in points)
+	int windowWidth, windowHeight = 0;
+	SDL_GetWindowSize(WZwindow, &windowWidth, &windowHeight);
+
+	debug(LOG_WZ, "Window Logical Size (%d, %d) vs Drawable Size in Pixels (%d, %d)", windowWidth, windowHeight, drawableWidth, drawableHeight);
+
+	if (horizScaleFactor != nullptr)
+	{
+		*horizScaleFactor = ((float)drawableWidth / (float)windowWidth) * current_displayScaleFactor;
+	}
+	if (vertScaleFactor != nullptr)
+	{
+		*vertScaleFactor = ((float)drawableHeight / (float)windowHeight) * current_displayScaleFactor;
+	}
+
+	int displayIndex = SDL_GetWindowDisplayIndex(WZwindow);
+	if (displayIndex < 0)
+	{
+		debug(LOG_ERROR, "Failed to get the display index for the window because : %s", SDL_GetError());
+	}
+
+	float hdpi, vdpi;
+	if (SDL_GetDisplayDPI(displayIndex, nullptr, &hdpi, &vdpi) < 0)
+	{
+		debug(LOG_ERROR, "Failed to get the display DPI because : %s", SDL_GetError());
+	}
+	else
+	{
+		debug(LOG_WZ, "Display DPI: %f, %f", hdpi, vdpi);
+	}
+}
+
+// Calculates and returns the total scale factor from the game's coordinate system (in points)
+// to the raw underlying pixels of the viewport / renderer.
+//
+// IMPORTANT: This value is *inclusive* of both the user-configured "Display Scale" *AND* any underlying
+// high-DPI / "Retina" display support provided by SDL.
+//
+// It is equivalent to: (SDL Window's High-DPI Scale Factor) x (WZ Game Display Scale Factor)
+//
+// Therefore, if SDL is providing a supported high-DPI window / context, this value will be greater
+// than the WZ (user-configured) Display Scale Factor.
+//
+// It should be used only for internal (non-user-displayed) cases in which the full scaling factor from
+// the game system's coordinate system (in points) to the underlying display pixels is required.
+// (For example, when rasterizing text for best display.)
+//
+void wzGetGameToRendererScaleFactor(float *horizScaleFactor, float *vertScaleFactor)
+{
+	float horizWindowScaleFactor = 0.f, vertWindowScaleFactor = 0.f;
+	wzGetWindowToRendererScaleFactor(&horizWindowScaleFactor, &vertWindowScaleFactor);
+	assert(horizWindowScaleFactor != 0.f);
+	assert(vertWindowScaleFactor != 0.f);
+
+	if (horizScaleFactor != nullptr)
+	{
+		*horizScaleFactor = horizWindowScaleFactor * current_displayScaleFactor;
+	}
+	if (vertScaleFactor != nullptr)
+	{
+		*vertScaleFactor = vertWindowScaleFactor * current_displayScaleFactor;
+	}
+}
+
+void wzSetWindowIsResizable(bool resizable)
+{
+	assert(WZwindow != nullptr);
+	SDL_bool sdl_resizable = (resizable) ? SDL_TRUE : SDL_FALSE;
+	SDL_SetWindowResizable(WZwindow, sdl_resizable);
+}
+
+bool wzIsWindowResizable()
+{
+	Uint32 flags = SDL_GetWindowFlags(WZwindow);
+	if (flags & SDL_WINDOW_RESIZABLE)
+	{
+		return true;
+	}
+	return false;
+}
+
+bool wzSupportsLiveResolutionChanges()
+{
 	return true;
 }
 
@@ -1472,9 +2006,34 @@ static void handleActiveEvent(SDL_Event *event)
 			break;
 		case SDL_WINDOWEVENT_MOVED:
 			debug(LOG_WZ, "Window %d moved to %d,%d", event->window.windowID, event->window.data1, event->window.data2);
+				// FIXME: Handle detecting which screen the window was moved to, and update saved war_SetScreen?
 			break;
 		case SDL_WINDOWEVENT_RESIZED:
+		case SDL_WINDOWEVENT_SIZE_CHANGED:
 			debug(LOG_WZ, "Window %d resized to %dx%d", event->window.windowID, event->window.data1, event->window.data2);
+			{
+				unsigned int oldWindowWidth = windowWidth;
+				unsigned int oldWindowHeight = windowHeight;
+
+				Uint32 windowFlags = SDL_GetWindowFlags(WZwindow);
+				debug(LOG_WZ, "Window resized to window flags: %u", windowFlags);
+
+				int newWindowWidth = 0, newWindowHeight = 0;
+				SDL_GetWindowSize(WZwindow, &newWindowWidth, &newWindowHeight);
+
+				if ((event->window.data1 != newWindowWidth) || (event->window.data2 != newWindowHeight))
+				{
+					// This can happen - so we use the values retrieved from SDL_GetWindowSize in any case - but
+					// log it for tracking down the SDL-related causes later.
+					debug(LOG_WARNING, "Received width and height (%d x %d) do not match those from GetWindowSize (%d x %d)", event->window.data1, event->window.data2, newWindowWidth, newWindowHeight);
+				}
+
+				handleWindowSizeChange(oldWindowWidth, oldWindowHeight, newWindowWidth, newWindowHeight);
+
+				// Store the new values (in case the user manually resized the window bounds)
+				war_SetWidth(newWindowWidth);
+				war_SetHeight(newWindowHeight);
+			}
 			break;
 		case SDL_WINDOWEVENT_MINIMIZED:
 			debug(LOG_WZ, "Window %d minimized", event->window.windowID);
@@ -1548,6 +2107,7 @@ void wzMainEventLoop(void)
 			}
 		}
 		appPtr->processEvents();		// Qt needs to do its stuff
+		processScreenSizeChangeNotificationIfNeeded();
 		mainLoop();				// WZ does its thing
 		inputNewFrame();			// reset input states
 	}

--- a/lib/widget/bar.cpp
+++ b/lib/widget/bar.cpp
@@ -127,21 +127,21 @@ static void barGraphDisplayText(W_BARGRAPH *barGraph, int x0, int x1, int y1)
 	if (!barGraph->text.isEmpty())
 	{
 		QByteArray utf = barGraph->text.toUtf8();
-		int textWidth = iV_GetTextWidth(utf.constData(), font_bar);
+		barGraph->wzCachedText.setText(utf.constData(), font_bar);
+		int textWidth = barGraph->wzCachedText.width();
 		Vector2i pos((x0 + x1 - textWidth) / 2, y1);
-		iV_SetTextColour(WZCOL_BLACK);  // Add a shadow, to make it visible against any background.
+		// Add a shadow, to make it visible against any background.
 		for (int dx = -2; dx <= 2; ++dx)
 		{
 			for (int dy = -2; dy <= 2; ++dy)
 			{
 				if (dx*dx + dy*dy <= 4)
 				{
-					iV_DrawText(utf.constData(), pos.x + dx, pos.y + dy, font_bar);
+					barGraph->wzCachedText.render(pos.x + dx, pos.y + dy, WZCOL_BLACK);
 				}
 			}
 		}
-		iV_SetTextColour(barGraph->textCol);
-		iV_DrawText(utf.constData(), pos.x, pos.y, font_bar);
+		barGraph->wzCachedText.render(pos.x, pos.y, barGraph->textCol);
 	}
 }
 

--- a/lib/widget/bar.h
+++ b/lib/widget/bar.h
@@ -61,6 +61,7 @@ public:
 
 //private:
 	PIELIGHT backgroundColour;
+	WzText	 wzCachedText;
 };
 
 /* The trough bar graph display function */

--- a/lib/widget/editbox.h
+++ b/lib/widget/editbox.h
@@ -35,6 +35,12 @@
 #define WEDBS_HILITE	0x0010		//
 #define WEDBS_DISABLE   0x0020		// disable button from selection
 
+struct EditBoxDisplayCache {
+	WzText wzDisplayedText;
+	WzText modeText;
+	WzText wzHyphen;
+};
+
 class W_EDITBOX : public WIDGET
 {
 	Q_OBJECT
@@ -76,13 +82,14 @@ private:
 	void initialise();  // Moves the cursor to the end.
 	void delCharRight();
 	void delCharLeft();
-	void insertChar(QChar ch);
-	void overwriteChar(QChar ch);
+	bool insertChar(QChar ch);
+	bool overwriteChar(QChar ch);
 	void fitStringStart();  // Calculate how much of the start of a string can fit into the edit box
 	void fitStringEnd();
 	void setCursorPosPixels(int xPos);
 
 	PIELIGHT boxColourFirst, boxColourSecond, boxColourBackground;
+	EditBoxDisplayCache displayCache;
 };
 
 #endif // __INCLUDED_LIB_WIDGET_EDITBOX_H__

--- a/lib/widget/label.cpp
+++ b/lib/widget/label.cpp
@@ -50,18 +50,19 @@ W_LABEL::W_LABEL(WIDGET *parent)
 
 void W_LABEL::display(int xOffset, int yOffset)
 {
-	iV_SetTextColour(fontColour);
-
 	QByteArray text = aText.toUtf8();
 	int fx;
+
+	displayCache.wzText.setText(text.constData(), FontID);
+
 	if (style & WLAB_ALIGNCENTRE)
 	{
-		int fw = iV_GetTextWidth(text.constData(), FontID);
+		int fw = displayCache.wzText.width();
 		fx = xOffset + x() + (width() - fw) / 2;
 	}
 	else if (style & WLAB_ALIGNRIGHT)
 	{
-		int fw = iV_GetTextWidth(text.constData(), FontID);
+		int fw = displayCache.wzText.width();
 		fx = xOffset + x() + width() - fw;
 	}
 	else
@@ -71,17 +72,17 @@ void W_LABEL::display(int xOffset, int yOffset)
 	int fy;
 	if ((style & WLAB_ALIGNTOPLEFT) != 0)  // Align top
 	{
-		fy = yOffset + y() - iV_GetTextAboveBase(FontID);
+		fy = yOffset + y() - displayCache.wzText.aboveBase();
 	}
 	else if ((style & WLAB_ALIGNBOTTOMLEFT) != 0)  // Align bottom
 	{
-		fy = yOffset + y() - iV_GetTextAboveBase(FontID) + (height() - iV_GetTextLineSize(FontID));
+		fy = yOffset + y() - displayCache.wzText.aboveBase() + (height() - displayCache.wzText.lineSize());
 	}
 	else
 	{
-		fy = yOffset + y() - iV_GetTextAboveBase(FontID) + (height() - iV_GetTextLineSize(FontID)) / 2;
+		fy = yOffset + y() - displayCache.wzText.aboveBase() + (height() - displayCache.wzText.lineSize()) / 2;
 	}
-	iV_DrawText(text.constData(), fx, fy, FontID);
+	displayCache.wzText.render(fx, fy, fontColour);
 }
 
 /* Respond to a mouse moving over a label */

--- a/lib/widget/label.h
+++ b/lib/widget/label.h
@@ -29,6 +29,10 @@
 #include "lib/ivis_opengl/textdraw.h"
 
 
+struct LabelDisplayCache {
+	WzText wzText;
+};
+
 class W_LABEL : public WIDGET
 {
 	Q_OBJECT
@@ -69,6 +73,7 @@ public:
 
 private:
 	PIELIGHT fontColour;
+	LabelDisplayCache displayCache;
 };
 
 #endif // __INCLUDED_LIB_WIDGET_LABEL_H__

--- a/lib/widget/widget.h
+++ b/lib/widget/widget.h
@@ -101,6 +101,10 @@ enum WzTextAlignment
 
 /***********************************************************************************/
 
+/* An optional function that is used to initialize the pUserData pointer per widget instance */
+/* (Useful if re-using a W_*INIT structure for multiple widget instances) */
+typedef std::function<void* ()> WIDGET_INITIALIZE_PUSERDATA_FUNC;
+
 /** The basic initialisation structure */
 struct W_INIT
 {
@@ -116,6 +120,9 @@ struct W_INIT
 	WIDGET_CALLBACK         pCallback;              ///< Optional callback function
 	void                   *pUserData;              ///< Optional user data pointer
 	UDWORD                  UserData;               ///< User data (if any)
+	WIDGET_CALCLAYOUT_FUNC  calcLayout;				///< Optional calculate layout callback function
+	WIDGET_ONDELETE_FUNC	onDelete;				///< Optional callback called when the Widget is about to be deleted
+	WIDGET_INITIALIZE_PUSERDATA_FUNC initPUserDataFunc;	///< (Optional) Used to initialize the pUserData pointer per widget instance
 };
 
 /** Form initialisation structure */

--- a/macosx/Resources/Warzone-Info.plist
+++ b/macosx/Resources/Warzone-Info.plist
@@ -148,5 +148,7 @@
 	<string>VCS_FULL_HASH</string>
 	<key>VCSShortHash</key>
 	<string>VCS_SHORT_HASH</string>
+	<key>NSHighResolutionCapable</key>
+	<true/>
 </dict>
 </plist>

--- a/macosx/Warzone.xcodeproj/project.pbxproj
+++ b/macosx/Warzone.xcodeproj/project.pbxproj
@@ -780,6 +780,7 @@
 		BCD210A21F3D82830028012B /* WZSDLAppDelegate.mm in Sources */ = {isa = PBXBuildFile; fileRef = 436D24DF149642EB00BF74E3 /* WZSDLAppDelegate.mm */; };
 		BCF97EF61F3CCCF100343E05 /* upnpdev.h in Headers */ = {isa = PBXBuildFile; fileRef = BCF97EF31F3CCCE600343E05 /* upnpdev.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D72B3A791F4E4C1F0011D653 /* gfx_api_gl.cpp in Sources */ = {isa = PBXBuildFile; fileRef = D72B3A6D1F4E4C160011D653 /* gfx_api_gl.cpp */; };
+		D7AD5BB8201BD65B000760A1 /* cocoa_sdl_helpers.mm in Sources */ = {isa = PBXBuildFile; fileRef = D7AD5BB7201BD65B000760A1 /* cocoa_sdl_helpers.mm */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXBuildRule section */
@@ -2311,6 +2312,8 @@
 		BFFD67681421661B00967210 /* macosx_screen_resolutions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = macosx_screen_resolutions.h; path = ../lib/qtgame/macosx_screen_resolutions.h; sourceTree = SOURCE_ROOT; };
 		D72B3A6D1F4E4C160011D653 /* gfx_api_gl.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = gfx_api_gl.cpp; path = ../lib/ivis_opengl/gfx_api_gl.cpp; sourceTree = "<group>"; };
 		D72B3A6E1F4E4C160011D653 /* gfx_api.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = gfx_api.h; path = ../lib/ivis_opengl/gfx_api.h; sourceTree = "<group>"; };
+		D7AD5BB6201BD65B000760A1 /* cocoa_sdl_helpers.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = cocoa_sdl_helpers.h; path = ../lib/sdl/cocoa_sdl_helpers.h; sourceTree = "<group>"; };
+		D7AD5BB7201BD65B000760A1 /* cocoa_sdl_helpers.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = cocoa_sdl_helpers.mm; path = ../lib/sdl/cocoa_sdl_helpers.mm; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -3394,6 +3397,8 @@
 				4301EC4A149A3DE90054BABB /* cursors_sdl.h */,
 				4301EC4B149A3DE90054BABB /* wz2100icon.h */,
 				436D248314963CF200BF74E3 /* main_sdl.cpp */,
+				D7AD5BB6201BD65B000760A1 /* cocoa_sdl_helpers.h */,
+				D7AD5BB7201BD65B000760A1 /* cocoa_sdl_helpers.mm */,
 			);
 			name = SDL;
 			sourceTree = "<group>";
@@ -5544,6 +5549,7 @@
 				0246A1950BD3CCBD004D1C70 /* tip.cpp in Sources */,
 				0246A1960BD3CCBD004D1C70 /* widget.cpp in Sources */,
 				0246A28D0BD3CCDC004D1C70 /* action.cpp in Sources */,
+				D7AD5BB8201BD65B000760A1 /* cocoa_sdl_helpers.mm in Sources */,
 				0246A28E0BD3CCDC004D1C70 /* advvis.cpp in Sources */,
 				0246A28F0BD3CCDC004D1C70 /* ai.cpp in Sources */,
 				0246A2920BD3CCDC004D1C70 /* astar.cpp in Sources */,

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -331,19 +331,21 @@ endif
 # Here, we need to bring in the "plugins" for Qt5 and they MUST come before the other QT libs.
 # FIXME: At a future date, we should check if they want static builds, but, since we only support those for now...
 if MINGW32
-SQT5_LIBS =  -L$(QT5_PLUGIN)/plugins/platforms -lQt5PlatformSupport -lqwindows
+SQT5_LIBS = -L$(QT5_PLUGIN)/plugins/platforms -lqwindows -lqminimal
+SQT5_LIBS2 = -lQt5FontDatabaseSupport -lQt5EventDispatcherSupport -lQt5ThemeSupport -lQt5Gui -lfreetype
 else
 SQT5_LIBS =
+SQT5_LIBS2 =
 endif
 
 if PORTABLE
 warzone2100_portable_LDADD = $(warzone2100_portable_LIBS) $(LTLIBINTL) $(SDL_LIBS) $(PHYSFS_LIBS) $(PNG_LIBS) $(VORBISFILE_LIBS) $(VORBIS_LIBS) \
 	$(THEORA_LIBS) $(OPENAL_LIBS) $(FONT_LIBS) $(OPENGL_LIBS) $(SQT5_LIBS) $(QT5_LIBS) $(GLEW_LIBS) \
-	$(X_LIBS) $(X_EXTRA_LIBS) $(LDFLAGS)
+	$(X_LIBS) $(X_EXTRA_LIBS) $(LDFLAGS) $(SQT5_LIBS2)
 else
 warzone2100_LDADD = $(warzone2100_LIBS) $(LTLIBINTL) $(SDL_LIBS) $(PHYSFS_LIBS) $(PNG_LIBS) $(VORBISFILE_LIBS) $(VORBIS_LIBS) \
 	$(THEORA_LIBS) $(OPENAL_LIBS) $(FONT_LIBS) $(OPENGL_LIBS) $(SQT5_LIBS) $(QT5_LIBS) $(GLEW_LIBS) \
-	$(X_LIBS) $(X_EXTRA_LIBS) $(LDFLAGS)
+	$(X_LIBS) $(X_EXTRA_LIBS) $(LDFLAGS) $(SQT5_LIBS2)
 endif
 
 

--- a/src/atmos.cpp
+++ b/src/atmos.cpp
@@ -305,8 +305,8 @@ void atmosDrawParticles(const glm::mat4 &viewMatrix)
 		/* Don't bother unless it's active */
 		if (asAtmosParts[i].status == APS_ACTIVE)
 		{
-			/* Is it on the grid */
-			if (clipXY(asAtmosParts[i].position.x, asAtmosParts[i].position.z))
+			/* Is it visible on the screen? */
+			if (clipXYZ(asAtmosParts[i].position.x, asAtmosParts[i].position.z, asAtmosParts[i].position.y, viewMatrix))
 			{
 				renderParticle(&asAtmosParts[i], viewMatrix);
 			}

--- a/src/challenge.h
+++ b/src/challenge.h
@@ -32,4 +32,6 @@ void updateChallenge(bool gameWon);
 extern bool challengesUp;
 extern bool challengeActive;
 
+void challengesScreenSizeDidChange(unsigned int oldWidth, unsigned int oldHeight, unsigned int newWidth, unsigned int newHeight);
+
 #endif // __INCLUDED_SRC_CHALLENGE_H__

--- a/src/component.cpp
+++ b/src/component.cpp
@@ -738,8 +738,8 @@ static bool displayCompObj(DROID *psDroid, bool bButton, const glm::mat4 &viewMa
 							didDrawSomething = true;
 						}
 
-						localModelMatrix *= glm::rotate(UNDEG(player.r.x), glm::vec3(1.f, 0.f, 0.f));
-						localModelMatrix *= glm::rotate(UNDEG(player.r.y), glm::vec3(0.f, 1.f, 0.f));
+//						localModelMatrix *= glm::rotate(UNDEG(player.r.x), glm::vec3(1.f, 0.f, 0.f)); // Not used?
+//						localModelMatrix *= glm::rotate(UNDEG(player.r.y), glm::vec3(0.f, 1.f, 0.f)); // Not used?
 					}
 				}
 				break;
@@ -852,6 +852,12 @@ void displayComponentObject(DROID *psDroid, const glm::mat4 &viewMatrix)
 	if (graphicsTime - psDroid->timeLastHit < GAME_TICKS_PER_SEC && psDroid->lastHitWeapon == WSC_ELECTRONIC)
 	{
 		modelMatrix *= objectShimmy((BASE_OBJECT *) psDroid);
+	}
+
+	// now check if the projected circle is within the screen boundaries
+	if(!clipDroidOnScreen(psDroid, viewMatrix * modelMatrix))
+	{
+		return;
 	}
 
 	if (psDroid->lastHitWeapon == WSC_EMP && graphicsTime - psDroid->timeLastHit < EMP_DISABLE_TIME)

--- a/src/configuration.cpp
+++ b/src/configuration.cpp
@@ -176,6 +176,17 @@ bool loadConfig()
 	war_SetColouredCursor(ini.value("coloredCursor", true).toBool());
 	// this should be enabled on all systems by default
 	war_SetVsync(ini.value("vsync", true).toBool());
+	// the default (and minimum) display scale is 100 (%)
+	unsigned int displayScale = ini.value("displayScale", war_GetDisplayScale()).toUInt();
+	if (displayScale < 100)
+	{
+		displayScale = 100;
+	}
+	if (displayScale > 500) // Maximum supported display scale of 500%. (Further testing needed for anything greater.)
+	{
+		displayScale = 500;
+	}
+	war_SetDisplayScale(displayScale);
 	// 640x480 is minimum that we will support, but default to something more sensible
 	int width = ini.value("width", war_GetWidth()).toInt();
 	int height = ini.value("height", war_GetHeight()).toInt();
@@ -248,6 +259,7 @@ bool saveConfig()
 	ini.setValue("radarTerrainMode", (SDWORD)radarDrawMode);
 	ini.setValue("trapCursor", war_GetTrapCursor());
 	ini.setValue("vsync", war_GetVsync());
+	ini.setValue("displayScale", war_GetDisplayScale());
 	ini.setValue("textureSize", getTextureSize());
 	ini.setValue("antialiasing", war_getAntialiasing());
 	ini.setValue("UPnP", (SDWORD)NetPlay.isUPNP);

--- a/src/console.cpp
+++ b/src/console.cpp
@@ -99,12 +99,23 @@ static int allowNewMessages;					/** Whether new messages are allowed to be adde
 
 char ConsoleString[MAX_CONSOLE_TMP_STRING_LENGTH];	/// Globally available string for new console messages.
 
+static CONSOLE_CALC_LAYOUT_FUNC calcLayoutFunc;
+
 /**
 	Specify how long messages will stay on screen.
 */
 static void	setConsoleMessageDuration(UDWORD time)
 {
 	messageDuration = time;
+}
+
+void setConsoleCalcLayout(const CONSOLE_CALC_LAYOUT_FUNC& layoutFunc)
+{
+	calcLayoutFunc = layoutFunc;
+	if (calcLayoutFunc != nullptr)
+	{
+		calcLayoutFunc();
+	}
 }
 
 /** Sets the system up */
@@ -117,13 +128,21 @@ void	initConsoleMessages()
 	enableConsoleDisplay(true);								// Turn on the console display
 
 	//	Set up the main console size and position x,y,width
-	setConsoleSizePos(16, 32, pie_GetVideoBufferWidth() - 32);
+	setConsoleCalcLayout([]() {
+		setConsoleSizePos(16, 32, pie_GetVideoBufferWidth() - 32);
+	});
 	historyConsole.topX = HISTORYBOX_X;
 	historyConsole.topY = HISTORYBOX_Y;
 	historyConsole.width = pie_GetVideoBufferWidth() - 32;
 	setConsoleLineInfo(MAX_CONSOLE_MESSAGES / 4 + 4);
 	setConsolePermanence(false, true);						// We're not initially having permanent messages
 	permitNewConsoleMessages(true);							// Allow new messages
+}
+
+void consoleScreenDidChangeSize(unsigned int oldWidth, unsigned int oldHeight, unsigned int newWidth, unsigned int newHeight)
+{
+	if (calcLayoutFunc == nullptr) return;
+	calcLayoutFunc();
 }
 
 // toggle between team & global history
@@ -454,7 +473,9 @@ void	setConsoleSizePos(UDWORD x, UDWORD y, UDWORD width)
 
 	/* Should be done below */
 	mainConsole.textDepth = 8;
-	flushConsoleMessages();
+
+	// Do not call flushConsoleMessages() when simply changing console size/position -
+	// it is possible for the console size/pos to change during display.
 }
 
 /**	Establishes whether the console messages stay there */

--- a/src/console.h
+++ b/src/console.h
@@ -86,4 +86,13 @@ void console(const char *pFormat, ...); /// Print always to the ingame console
 	sprintf x; \
 	addConsoleMessage(s, DEFAULT_JUSTIFY, INFO_MESSAGE)
 
+
+#include <functional>
+
+typedef std::function<void ()> CONSOLE_CALC_LAYOUT_FUNC;
+void setConsoleCalcLayout(const CONSOLE_CALC_LAYOUT_FUNC& layoutFunc);
+
+void consoleScreenDidChangeSize(unsigned int oldWidth, unsigned int oldHeight, unsigned int newWidth, unsigned int newHeight);
+
+
 #endif // __INCLUDED_SRC_CONSOLE_H__

--- a/src/design.cpp
+++ b/src/design.cpp
@@ -365,7 +365,9 @@ bool intAddDesign(bool bShowCentreScreen)
 	/* Add the main design form */
 	IntFormAnimated *desForm = new IntFormAnimated(parent, false);
 	desForm->id = IDDES_FORM;
-	desForm->setGeometry(DES_CENTERFORMX, DES_CENTERFORMY, DES_CENTERFORMWIDTH, DES_CENTERFORMHEIGHT);
+	desForm->setCalcLayout(LAMBDA_CALCLAYOUT_SIMPLE({
+		psWidget->setGeometry(DES_CENTERFORMX, DES_CENTERFORMY, DES_CENTERFORMWIDTH, DES_CENTERFORMHEIGHT);
+	}));
 
 	/* add the edit name box */
 	sEdInit.formID = IDDES_FORM;
@@ -546,7 +548,9 @@ bool intAddDesign(bool bShowCentreScreen)
 	/* add central stats form */
 	IntFormAnimated *statsForm = new IntFormAnimated(parent, false);
 	statsForm->id = IDDES_STATSFORM;
-	statsForm->setGeometry(DES_STATSFORMX, DES_STATSFORMY, DES_STATSFORMWIDTH, DES_STATSFORMHEIGHT);
+	statsForm->setCalcLayout(LAMBDA_CALCLAYOUT_SIMPLE({
+		psWidget->setGeometry(DES_STATSFORMX, DES_STATSFORMY, DES_STATSFORMWIDTH, DES_STATSFORMHEIGHT);
+	}));
 
 	/* Add the body form */
 	sFormInit.formID = IDDES_STATSFORM;
@@ -577,6 +581,12 @@ bool intAddDesign(bool bShowCentreScreen)
 	sBarInit.sMinorCol.byte.g = DES_CLICKBARMINORGREEN;
 	sBarInit.sMinorCol.byte.b = DES_CLICKBARMINORBLUE;
 	sBarInit.pDisplay = intDisplayStatsBar;
+	sBarInit.initPUserDataFunc = []() -> void * { return new DisplayBarCache(); };
+	sBarInit.onDelete = [](WIDGET *psWidget) {
+		assert(psWidget->pUserData != nullptr);
+		delete static_cast<DisplayBarCache *>(psWidget->pUserData);
+		psWidget->pUserData = nullptr;
+	};
 	sBarInit.pTip = _("Kinetic Armour");
 	sBarInit.iRange = getMaxBodyArmour();
 	if (!widgAddBarGraph(psWScreen, &sBarInit))
@@ -688,6 +698,12 @@ bool intAddDesign(bool bShowCentreScreen)
 	                         iV_GetImageWidth(IntImages, IMAGE_DES_BODYPOINTS));
 	sBarInit.height = iV_GetImageHeight(IntImages, IMAGE_DES_POWERBACK);
 	sBarInit.pDisplay = intDisplayDesignPowerBar;//intDisplayStatsBar;
+	sBarInit.initPUserDataFunc = []() -> void * { return new DisplayBarCache(); };
+	sBarInit.onDelete = [](WIDGET *psWidget) {
+		assert(psWidget->pUserData != nullptr);
+		delete static_cast<DisplayBarCache *>(psWidget->pUserData);
+		psWidget->pUserData = nullptr;
+	};
 	sBarInit.pTip = _("Total Power Required");
 	sBarInit.iRange = DBAR_TEMPLATEMAXPOWER;//WBAR_SCALE;
 	if (!widgAddBarGraph(psWScreen, &sBarInit))
@@ -717,6 +733,12 @@ bool intAddDesign(bool bShowCentreScreen)
 	                         iV_GetImageWidth(IntImages, IMAGE_DES_BODYPOINTS));
 	sBarInit.height = iV_GetImageHeight(IntImages, IMAGE_DES_POWERBACK);
 	sBarInit.pDisplay = intDisplayDesignPowerBar;//intDisplayStatsBar;
+	sBarInit.initPUserDataFunc = []() -> void * { return new DisplayBarCache(); };
+	sBarInit.onDelete = [](WIDGET *psWidget) {
+		assert(psWidget->pUserData != nullptr);
+		delete static_cast<DisplayBarCache *>(psWidget->pUserData);
+		psWidget->pUserData = nullptr;
+	};
 	sBarInit.pTip = _("Total Body Points");
 	sBarInit.iRange = DBAR_TEMPLATEMAXPOINTS;//(UWORD)getMaxBodyPoints();//DBAR_BODYMAXPOINTS;
 	if (!widgAddBarGraph(psWScreen, &sBarInit))
@@ -774,17 +796,25 @@ static bool intAddTemplateForm(DROID_TEMPLATE *psSelected)
 	/* add a form to place the tabbed form on */
 	IntFormAnimated *templbaseForm = new IntFormAnimated(parent, false);
 	templbaseForm->id = IDDES_TEMPLBASE;
-	templbaseForm->setGeometry(RET_X, DESIGN_Y, RET_FORMWIDTH, DES_LEFTFORMHEIGHT);
+	templbaseForm->setCalcLayout(LAMBDA_CALCLAYOUT_SIMPLE({
+		psWidget->setGeometry(RET_X, DESIGN_Y, RET_FORMWIDTH, DES_LEFTFORMHEIGHT);
+	}));
 
 	// Add the obsolete items button.
 	makeObsoleteButton(templbaseForm);
 
 	/* Add the design templates form */
 	IntListTabWidget *templList = new IntListTabWidget(templbaseForm);
-	templList->setChildSize(DES_TABBUTWIDTH, DES_TABBUTHEIGHT);
-	templList->setChildSpacing(DES_TABBUTGAP, DES_TABBUTGAP);
-	int templListWidth = OBJ_BUTWIDTH * 2 + DES_TABBUTGAP;
-	templList->setGeometry((RET_FORMWIDTH - templListWidth) / 2, 18, templListWidth, templbaseForm->height() - 18);
+	templList->setCalcLayout(LAMBDA_CALCLAYOUT_SIMPLE({
+		IntListTabWidget *templList = static_cast<IntListTabWidget *>(psWidget);
+		assert(templList != nullptr);
+		WIDGET *templbaseForm = templList->parent();
+		assert(templbaseForm != nullptr);
+		templList->setChildSize(DES_TABBUTWIDTH, DES_TABBUTHEIGHT);
+		templList->setChildSpacing(DES_TABBUTGAP, DES_TABBUTGAP);
+		int templListWidth = OBJ_BUTWIDTH * 2 + DES_TABBUTGAP;
+		templList->setGeometry((RET_FORMWIDTH - templListWidth) / 2, 18, templListWidth, templbaseForm->height() - 18);
+	}));
 
 	/* Put the buttons on it */
 	return intAddTemplateButtons(templList, psSelected);
@@ -1201,6 +1231,12 @@ static bool intSetSystemForm(COMPONENT_STATS *psStats)
 	sBarInit.sMinorCol.byte.g = DES_CLICKBARMINORGREEN;
 	sBarInit.sMinorCol.byte.b = DES_CLICKBARMINORBLUE;
 	sBarInit.pDisplay = intDisplayStatsBar;
+	sBarInit.initPUserDataFunc = []() -> void * { return new DisplayBarCache(); };
+	sBarInit.onDelete = [](WIDGET *psWidget) {
+		assert(psWidget->pUserData != nullptr);
+		delete static_cast<DisplayBarCache *>(psWidget->pUserData);
+		psWidget->pUserData = nullptr;
+	};
 
 	/* Initialise the label struct */
 	W_LABINIT sLabInit;
@@ -1528,6 +1564,12 @@ static bool intSetPropulsionForm(PROPULSION_STATS *psStats)
 	sBarInit.sMinorCol.byte.g = DES_CLICKBARMINORGREEN;
 	sBarInit.sMinorCol.byte.b = DES_CLICKBARMINORBLUE;
 	sBarInit.pDisplay = intDisplayStatsBar;
+	sBarInit.initPUserDataFunc = []() -> void * { return new DisplayBarCache(); };
+	sBarInit.onDelete = [](WIDGET *psWidget) {
+		assert(psWidget->pUserData != nullptr);
+		delete static_cast<DisplayBarCache *>(psWidget->pUserData);
+		psWidget->pUserData = nullptr;
+	};
 
 	/* Initialise the label struct */
 	W_LABINIT sLabInit;
@@ -1675,14 +1717,22 @@ static ListTabWidget *intAddComponentForm()
 	/* add a form to place the tabbed form on */
 	IntFormAnimated *rightBase = new IntFormAnimated(parent, false);
 	rightBase->id = IDDES_RIGHTBASE;
-	rightBase->setGeometry(RADTLX - 2, DESIGN_Y, RET_FORMWIDTH, DES_RIGHTFORMHEIGHT);
+	rightBase->setCalcLayout(LAMBDA_CALCLAYOUT_SIMPLE({
+		psWidget->setGeometry(RADTLX - 2, DESIGN_Y, RET_FORMWIDTH, DES_RIGHTFORMHEIGHT);
+	}));
 
 	//now a single form
 	IntListTabWidget *compList = new IntListTabWidget(rightBase);
-	compList->setChildSize(DES_TABBUTWIDTH, DES_TABBUTHEIGHT);
-	compList->setChildSpacing(DES_TABBUTGAP, DES_TABBUTGAP);
-	int objListWidth = DES_TABBUTWIDTH * 2 + DES_TABBUTGAP;
-	compList->setGeometry((rightBase->width() - objListWidth) / 2, 40, objListWidth, rightBase->height() - 40);
+	compList->setCalcLayout(LAMBDA_CALCLAYOUT_SIMPLE({
+		IntListTabWidget *compList = static_cast<IntListTabWidget *>(psWidget);
+		assert(compList != nullptr);
+		WIDGET * rightBase = compList->parent();
+		assert(rightBase != nullptr);
+		compList->setChildSize(DES_TABBUTWIDTH, DES_TABBUTHEIGHT);
+		compList->setChildSpacing(DES_TABBUTGAP, DES_TABBUTGAP);
+		int objListWidth = DES_TABBUTWIDTH * 2 + DES_TABBUTGAP;
+		compList->setGeometry((rightBase->width() - objListWidth) / 2, 40, objListWidth, rightBase->height() - 40);
+	}));
 	return compList;
 }
 
@@ -3881,7 +3931,7 @@ static void intDisplayStatForm(WIDGET *psWidget, UDWORD xOffset, UDWORD yOffset)
 
 	iV_DrawImage(IntImages, (UWORD)(IMAGE_DES_STATBACKLEFT), x0, y0);
 	iV_DrawImageRepeatX(IntImages, IMAGE_DES_STATBACKMID, x0 + iV_GetImageWidth(IntImages, IMAGE_DES_STATBACKLEFT), y0,
-	                    Form->width() - iV_GetImageWidth(IntImages, IMAGE_DES_STATBACKLEFT) - iV_GetImageWidth(IntImages, IMAGE_DES_STATBACKRIGHT));
+	                    Form->width() - iV_GetImageWidth(IntImages, IMAGE_DES_STATBACKLEFT) - iV_GetImageWidth(IntImages, IMAGE_DES_STATBACKRIGHT), defaultProjectionMatrix(), true);
 	iV_DrawImage(IntImages, IMAGE_DES_STATBACKRIGHT, x0 + Form->width() - iV_GetImageWidth(IntImages, IMAGE_DES_STATBACKRIGHT), y0);
 
 	/* display current component */

--- a/src/display.h
+++ b/src/display.h
@@ -218,5 +218,7 @@ void setZoom(float zoomSpeed, float zoomTarget);
 float getZoom();
 float getZoomSpeed();
 void zoom();
+bool clipXYZ(int x, int y, int z, const glm::mat4 &viewMatrix);
+bool clipXYZNormalized(const Vector3i &normalizedPosition, const glm::mat4 &viewMatrix);
 
 #endif // __INCLUDED_SRC_DISPLAY_H__

--- a/src/display3d.h
+++ b/src/display3d.h
@@ -83,6 +83,9 @@ bool doWeDrawProximitys();
 void setProximityDraw(bool val);
 
 bool	clipXY(SDWORD x, SDWORD y);
+inline bool clipShapeOnScreen(const iIMDShape *pIMD, const glm::mat4& viewModelMatrix, int overdrawScreenPoints = 10);
+bool clipDroidOnScreen(DROID *psDroid, const glm::mat4& viewModelMatrix, int overdrawScreenPoints = 25);
+bool clipStructureOnScreen(STRUCTURE *psStructure, const glm::mat4 &viewModelMatrix, int overdrawScreenPoints = 0);
 
 bool init3DView();
 extern iView player;

--- a/src/display3d.h
+++ b/src/display3d.h
@@ -101,6 +101,8 @@ STRUCTURE_STATS const *getTileBlueprintStats(int mapX, int mapY);  ///< Gets the
 bool anyBlueprintTooClose(STRUCTURE_STATS const *stats, Vector2i pos, uint16_t dir);  ///< Checks if any blueprint is too close to the given structure.
 void clearBlueprints();
 
+void display3dScreenSizeDidChange(unsigned int oldWidth, unsigned int oldHeight, unsigned int newWidth, unsigned int newHeight);
+
 extern SDWORD mouseTileX, mouseTileY;
 extern Vector2i mousePos;
 
@@ -127,6 +129,6 @@ extern bool CauseCrash;
 extern bool tuiTargetOrigin;
 
 /// Draws using the animation systems. Usually want to use in a while loop to get all model levels.
-void drawShape(BASE_OBJECT *psObj, iIMDShape *strImd, int colour, PIELIGHT buildingBrightness, int pieFlag, int pieFlagData, const glm::mat4& viewMatrix);
+bool drawShape(BASE_OBJECT *psObj, iIMDShape *strImd, int colour, PIELIGHT buildingBrightness, int pieFlag, int pieFlagData, const glm::mat4& viewMatrix);
 
 #endif // __INCLUDED_SRC_DISPLAY3D_H__

--- a/src/frontend.cpp
+++ b/src/frontend.cpp
@@ -1127,7 +1127,10 @@ void refreshCurrentVideoOptionsValues()
 {
 	widgSetString(psWScreen, FRONTEND_WINDOWMODE_R, videoOptionsWindowModeString());
 	widgSetString(psWScreen, FRONTEND_FSAA_R, videoOptionsAntialiasingString().c_str());
-	widgSetString(psWScreen, FRONTEND_RESOLUTION_R, videoOptionsResolutionString().c_str());
+	if (widgGetFromID(psWScreen, FRONTEND_RESOLUTION_R)) // Resolution option may not be available
+	{
+		widgSetString(psWScreen, FRONTEND_RESOLUTION_R, videoOptionsResolutionString().c_str());
+	}
 	widgSetString(psWScreen, FRONTEND_TEXTURESZ_R, videoOptionsTextureSizeString().c_str());
 	widgSetString(psWScreen, FRONTEND_VSYNC_R, videoOptionsVsyncString());
 	if (widgGetFromID(psWScreen, FRONTEND_DISPLAYSCALE_R)) // Display Scale option may not be available
@@ -1165,7 +1168,10 @@ bool runVideoOptionsMenu()
 			//
 			// Update the "Requires restart" status of the Resolution + Display Scale entries to match.
 			//
-			widgSetString(psWScreen, FRONTEND_RESOLUTION, videoOptionsResolutionLabel());
+			if (widgGetFromID(psWScreen, FRONTEND_RESOLUTION)) // Resolution option may not be available
+			{
+				widgSetString(psWScreen, FRONTEND_RESOLUTION, videoOptionsResolutionLabel());
+			}
 			if (widgGetFromID(psWScreen, FRONTEND_DISPLAYSCALE)) // Display Scale option may not be available
 			{
 				widgSetString(psWScreen, FRONTEND_DISPLAYSCALE, videoOptionsDisplayScaleLabel());
@@ -1270,6 +1276,15 @@ bool runVideoOptionsMenu()
 
 			if (canChangeResolutionLive())
 			{
+				// Disable the ability to use the Video options menu to live-change the window size when in windowed mode.
+				// Why?
+				//	- Certain window managers don't report their own changes to window size through SDL in all circumstances.
+				//	  (For example, attempting to set a window size of 800x600 might result in no actual change when using a
+				//	   tiling window manager (ex. i3), but SDL thinks the window size has been set to 800x600. This obviously
+				//     breaks things.)
+				//  - Manual window resizing is supported (so there is no need for this functionality in the Video menu).
+				if (!wzIsFullscreen()) break;
+
 				while (current != startingResolution)
 				{
 					// Attempt to change the resolution

--- a/src/frontend.cpp
+++ b/src/frontend.cpp
@@ -986,6 +986,15 @@ bool runAudioAndZoomOptionsMenu()
 	return true;
 }
 
+bool canChangeResolutionLive()
+{
+	// Since changing fullscreen mode without restarting is not yet supported (because of various SDL/OS issues),
+	// if the fullscreen mode does not match the *current* mode, the resolution changes are queued until the
+	// next program restart.
+	//
+	return wzSupportsLiveResolutionChanges() && (war_getFullscreen() == wzIsFullscreen());
+}
+
 static char const *videoOptionsWindowModeString()
 {
 	return war_getFullscreen()? _("Fullscreen") : _("Windowed");
@@ -1001,6 +1010,16 @@ static std::string videoOptionsAntialiasingString()
 	{
 		return std::to_string(war_getAntialiasing()) + "×";
 	}
+}
+
+static char const *videoOptionsResolutionLabel()
+{
+	return (!canChangeResolutionLive())? _("Resolution*") : _("Resolution");
+}
+
+static char const *videoOptionsDisplayScaleLabel()
+{
+	return (!canChangeResolutionLive())? _("Display Scale*") : _("Display Scale");
 }
 
 static std::string videoOptionsResolutionString()
@@ -1020,6 +1039,13 @@ static std::string videoOptionsTextureSizeString()
 static char const *videoOptionsVsyncString()
 {
 	return war_GetVsync()? _("On") : _("Off");
+}
+
+static std::string videoOptionsDisplayScaleString()
+{
+	char resolution[100];
+	ssprintf(resolution, "%d%%", war_GetDisplayScale());
+	return resolution;
 }
 
 // ////////////////////////////////////////////////////////////////////////////
@@ -1044,7 +1070,7 @@ static bool startVideoOptionsMenu()
 	addTextButton(FRONTEND_WINDOWMODE_R, FRONTEND_POS2M - 55, FRONTEND_POS2Y, videoOptionsWindowModeString(), WBUT_SECONDARY);
 
 	// Resolution
-	addTextButton(FRONTEND_RESOLUTION, FRONTEND_POS3X - 35, FRONTEND_POS3Y, _("Resolution*"), WBUT_SECONDARY);
+	addTextButton(FRONTEND_RESOLUTION, FRONTEND_POS3X - 35, FRONTEND_POS3Y, videoOptionsResolutionLabel(), WBUT_SECONDARY);
 	addTextButton(FRONTEND_RESOLUTION_R, FRONTEND_POS3M - 55, FRONTEND_POS3Y, videoOptionsResolutionString(), WBUT_SECONDARY);
 
 	// Texture size
@@ -1059,6 +1085,13 @@ static bool startVideoOptionsMenu()
 	addTextButton(FRONTEND_FSAA, FRONTEND_POS5X - 35, FRONTEND_POS6Y, "Antialiasing*", WBUT_SECONDARY);
 	addTextButton(FRONTEND_FSAA_R, FRONTEND_POS5M - 55, FRONTEND_POS6Y, videoOptionsAntialiasingString(), WBUT_SECONDARY);
 
+	// Display Scale
+	if (wzAvailableDisplayScales().size() > 1)
+	{
+		addTextButton(FRONTEND_DISPLAYSCALE, FRONTEND_POS6X - 35, FRONTEND_POS7Y, videoOptionsDisplayScaleLabel(), WBUT_SECONDARY);
+		addTextButton(FRONTEND_DISPLAYSCALE_R, FRONTEND_POS6M - 55, FRONTEND_POS7Y, videoOptionsDisplayScaleString(), WBUT_SECONDARY);
+	}
+
 	// Add some text down the side of the form
 	addSideText(FRONTEND_SIDETEXT, FRONTEND_SIDEX, FRONTEND_SIDEY, _("VIDEO OPTIONS"));
 
@@ -1068,17 +1101,128 @@ static bool startVideoOptionsMenu()
 	return true;
 }
 
+// Get available resolutions list, sorted, with duplicates removed.
+std::vector<screeninfo> availableResolutionsSorted()
+{
+	auto compareKey = [](screeninfo const &x) { return std::make_tuple(x.screen, x.width, x.height); };
+	auto compareLess = [&](screeninfo const &a, screeninfo const &b) { return compareKey(a) < compareKey(b); };
+	auto compareEq = [&](screeninfo const &a, screeninfo const &b) { return compareKey(a) == compareKey(b); };
+
+	// Get resolutions, sorted with duplicates removed.
+	std::vector<screeninfo> modes = wzAvailableResolutions();
+	std::sort(modes.begin(), modes.end(), compareLess);
+	modes.erase(std::unique(modes.begin(), modes.end(), compareEq), modes.end());
+
+	return modes;
+}
+
+std::vector<unsigned int> availableDisplayScalesSorted()
+{
+	std::vector<unsigned int> displayScales = wzAvailableDisplayScales();
+	std::sort(displayScales.begin(), displayScales.end());
+	return displayScales;
+}
+
+void refreshCurrentVideoOptionsValues()
+{
+	widgSetString(psWScreen, FRONTEND_WINDOWMODE_R, videoOptionsWindowModeString());
+	widgSetString(psWScreen, FRONTEND_FSAA_R, videoOptionsAntialiasingString().c_str());
+	widgSetString(psWScreen, FRONTEND_RESOLUTION_R, videoOptionsResolutionString().c_str());
+	widgSetString(psWScreen, FRONTEND_TEXTURESZ_R, videoOptionsTextureSizeString().c_str());
+	widgSetString(psWScreen, FRONTEND_VSYNC_R, videoOptionsVsyncString());
+	if (widgGetFromID(psWScreen, FRONTEND_DISPLAYSCALE_R)) // Display Scale option may not be available
+	{
+		widgSetString(psWScreen, FRONTEND_DISPLAYSCALE_R, videoOptionsDisplayScaleString().c_str());
+	}
+}
+
 bool runVideoOptionsMenu()
 {
 	WidgetTriggers const &triggers = widgRunScreen(psWScreen);
 	unsigned id = triggers.empty() ? 0 : triggers.front().widget->id; // Just use first click here, since the next click could be on another menu.
 
+	auto compareKey = [](screeninfo const &x) { return std::make_tuple(x.screen, x.width, x.height); };
+	auto compareLess = [&](screeninfo const &a, screeninfo const &b) { return compareKey(a) < compareKey(b); };
+	auto compareEq = [&](screeninfo const &a, screeninfo const &b) { return compareKey(a) == compareKey(b); };
+
 	switch (id)
 	{
 	case FRONTEND_WINDOWMODE:
 	case FRONTEND_WINDOWMODE_R:
-		war_setFullscreen(!war_getFullscreen());
-		widgSetString(psWScreen, FRONTEND_WINDOWMODE_R, videoOptionsWindowModeString());
+		{
+			war_setFullscreen(!war_getFullscreen());
+			widgSetString(psWScreen, FRONTEND_WINDOWMODE_R, videoOptionsWindowModeString());
+
+			if (!wzSupportsLiveResolutionChanges())
+			{
+				refreshCurrentVideoOptionsValues();
+				break;
+			}
+
+			// Since changing fullscreen mode without restarting is not yet supported (because of various issues),
+			// if the fullscreen mode does not match the *current* mode, the resolution changes are queued until
+			// the next program restart.
+			//
+			// Update the "Requires restart" status of the Resolution + Display Scale entries to match.
+			//
+			widgSetString(psWScreen, FRONTEND_RESOLUTION, videoOptionsResolutionLabel());
+			if (widgGetFromID(psWScreen, FRONTEND_DISPLAYSCALE)) // Display Scale option may not be available
+			{
+				widgSetString(psWScreen, FRONTEND_DISPLAYSCALE, videoOptionsDisplayScaleLabel());
+			}
+
+			if (war_getFullscreen() == wzIsFullscreen())
+			{
+				// Update the resolution to reflect the current resolution / display scale settings.
+				// This reverts any queued changes if the user changes their mind and switches back to the current
+				// window mode.
+				int screen = 0;
+				unsigned int width = 0, height = 0;
+				wzGetWindowResolution(&screen, &width, &height);
+				war_SetScreen(screen);
+				war_SetWidth(width);
+				war_SetHeight(height);
+				unsigned int displayScale = wzGetCurrentDisplayScale();
+				war_SetDisplayScale(displayScale);
+			}
+			else if (war_getFullscreen())
+			{
+				// If configuring a fullscreen window mode (when it's currently windowed), the current resolution
+				// must be set to the nearest supported resolution in the wzAvailableResolutions list.
+				// (As the user may have manually resized the window to a custom size.)
+
+				// Get resolutions, sorted with duplicates removed.
+				std::vector<screeninfo> modes = availableResolutionsSorted();
+
+				// We can't pick a resolution if there aren't any.
+				if (modes.empty())
+				{
+					debug(LOG_ERROR, "No resolutions available to change.");
+					break;
+				}
+
+				// Get currently configured resolution.
+				screeninfo config;
+				config.screen = war_GetScreen();
+				config.width = war_GetWidth();
+				config.height = war_GetHeight();
+				config.refresh_rate = -1;  // Unused.
+
+				// Find current resolution in list.
+				auto current = std::lower_bound(modes.begin(), modes.end(), config, compareLess);
+				if (current == modes.end() || !compareEq(*current, config))
+				{
+					--current;  // If current resolution doesn't exist, round down to next-highest one.
+				}
+
+				// Set the current resolution to the nearest available resolution
+				war_SetScreen(current->screen);
+				war_SetWidth(current->width);
+				war_SetHeight(current->height);
+			}
+			// Update the widget(s)
+			refreshCurrentVideoOptionsValues();
+		}
 		break;
 
 	case FRONTEND_FSAA:
@@ -1092,14 +1236,8 @@ bool runVideoOptionsMenu()
 	case FRONTEND_RESOLUTION:
 	case FRONTEND_RESOLUTION_R:
 		{
-			auto compareKey = [](screeninfo const &x) { return std::make_tuple(x.screen, x.width, x.height); };
-			auto compareLess = [&](screeninfo const &a, screeninfo const &b) { return compareKey(a) < compareKey(b); };
-			auto compareEq = [&](screeninfo const &a, screeninfo const &b) { return compareKey(a) == compareKey(b); };
-
 			// Get resolutions, sorted with duplicates removed.
-			std::vector<screeninfo> modes = wzAvailableResolutions();
-			std::sort(modes.begin(), modes.end(), compareLess);
-			modes.erase(std::unique(modes.begin(), modes.end(), compareEq), modes.end());
+			std::vector<screeninfo> modes = availableResolutionsSorted();
 
 			// We can't pick resolutions if there aren't any.
 			if (modes.empty())
@@ -1123,15 +1261,51 @@ bool runVideoOptionsMenu()
 			}
 
 			// Increment/decrement and loop if required.
+			auto startingResolution = current;
+			bool successfulResolutionChange = false;
 			current = seqCycle(current, modes.begin(), 1, modes.end() - 1);
 
-			// Set the new width and height (takes effect on restart)
+			if (canChangeResolutionLive())
+			{
+				while (current != startingResolution)
+				{
+					// Attempt to change the resolution
+					if (!wzChangeWindowResolution(current->screen, current->width, current->height))
+					{
+						debug(LOG_WARNING, "Failed to change active resolution from: [%d] %d x %d to: [%d] %d x %d", config.screen, config.width, config.height, current->screen, current->width, current->height);
+
+						// try the next resolution, and loop
+						current = seqCycle(current, modes.begin(), 1, modes.end() - 1);
+						continue;
+					}
+					else
+					{
+						successfulResolutionChange = true;
+						break;
+					}
+				}
+
+				if (!successfulResolutionChange) break;
+			}
+			else
+			{
+				// when live resolution changes are unavailable, check to see if the current display scale is supported at the desired resolution
+				unsigned int maxDisplayScale = wzGetMaximumDisplayScaleForWindowSize(current->width, current->height);
+				unsigned int current_displayScale = war_GetDisplayScale();
+				if (maxDisplayScale < current_displayScale)
+				{
+					// Reduce the display scale to the maximum supported for this resolution
+					war_SetDisplayScale(maxDisplayScale);
+				}
+			}
+
+			// Store the new width and height
 			war_SetScreen(current->screen);
 			war_SetWidth(current->width);
 			war_SetHeight(current->height);
 
-			// Update the widget
-			widgSetString(psWScreen, FRONTEND_RESOLUTION_R, videoOptionsResolutionString().c_str());
+			// Update the widget(s)
+			refreshCurrentVideoOptionsValues();
 			break;
 		}
 
@@ -1154,6 +1328,76 @@ bool runVideoOptionsMenu()
 		wzSetSwapInterval(!war_GetVsync());
 		war_SetVsync(!war_GetVsync());
 		widgSetString(psWScreen, FRONTEND_VSYNC_R, videoOptionsVsyncString());
+		break;
+
+	case FRONTEND_DISPLAYSCALE:
+	case FRONTEND_DISPLAYSCALE_R:
+		{
+			std::vector<unsigned int> displayScales = availableDisplayScalesSorted();
+			assert(!displayScales.empty());
+
+			// Get currently-configured display scale.
+			unsigned int current_displayScale = war_GetDisplayScale();
+
+			// Find current display scale in list.
+			auto current = std::lower_bound(displayScales.begin(), displayScales.end(), current_displayScale);
+			if (current == displayScales.end() || *current != current_displayScale)
+			{
+				--current;  // If current display scale doesn't exist, round down to next-highest one.
+			}
+
+			// Increment/decrement and loop if required.
+			auto startingDisplayScale = current;
+			bool successfulDisplayScaleChange = false;
+			current = seqCycle(current, displayScales.begin(), 1, displayScales.end() - 1);
+
+			unsigned int maxDisplayScale = wzGetMaximumDisplayScaleForWindowSize(war_GetWidth(), war_GetHeight());
+
+			while (current != startingDisplayScale)
+			{
+				if (canChangeResolutionLive())
+				{
+					// Attempt to change the display scale
+					if (!wzChangeDisplayScale(*current))
+					{
+						debug(LOG_WARNING, "Failed to change display scale from: %d to: %d", current_displayScale, *current);
+
+						// try the next display scale factor, and loop
+						current = seqCycle(current, displayScales.begin(), 1, displayScales.end() - 1);
+						continue;
+					}
+					else
+					{
+						successfulDisplayScaleChange = true;
+						break;
+					}
+				}
+				else
+				{
+					// when live resolution changes are unavailable, check to see if the display scale is supported at the desired resolution
+					if (maxDisplayScale < *current)
+					{
+						// try the next display scale factor, and loop
+						current = seqCycle(current, displayScales.begin(), 1, displayScales.end() - 1);
+						continue;
+					}
+					else
+					{
+						successfulDisplayScaleChange = true;
+						break;
+					}
+				}
+			}
+
+			if (!successfulDisplayScaleChange) break;
+
+			// Store the new display scale
+			war_SetDisplayScale(*current);
+
+			// Update the widget(s)
+			refreshCurrentVideoOptionsValues();
+
+		}
 		break;
 
 	case FRONTEND_QUIT:
@@ -1518,6 +1762,10 @@ bool runGameOptionsMenu()
 	return true;
 }
 
+struct TitleBitmapCache {
+	WzText formattedVersionString;
+	WzText modListText;
+};
 
 // ////////////////////////////////////////////////////////////////////////////
 // drawing functions
@@ -1527,22 +1775,31 @@ static void displayTitleBitmap(WZ_DECL_UNUSED WIDGET *psWidget, WZ_DECL_UNUSED U
 {
 	char modListText[MAX_STR_LENGTH] = "";
 
-	iV_SetTextColour(WZCOL_GREY);
-	iV_DrawTextRotated(version_getFormattedVersionString(), pie_GetVideoBufferWidth() - 9, pie_GetVideoBufferHeight() - 14, 270.f, font_regular);
-
 	if (!getModList().empty())
 	{
 		sstrcat(modListText, _("Mod: "));
 		sstrcat(modListText, getModList().c_str());
-		iV_DrawText(modListText, 9, 14, font_regular);
 	}
 
-	iV_SetTextColour(WZCOL_TEXT_BRIGHT);
-	iV_DrawTextRotated(version_getFormattedVersionString(), pie_GetVideoBufferWidth() - 10, pie_GetVideoBufferHeight() - 15, 270.f, font_regular);
+	assert(psWidget->pUserData != nullptr);
+	TitleBitmapCache& cache = *static_cast<TitleBitmapCache*>(psWidget->pUserData);
+
+	cache.formattedVersionString.setText(version_getFormattedVersionString(), font_regular);
+	cache.modListText.setText(modListText, font_regular);
+
+	cache.formattedVersionString.render(pie_GetVideoBufferWidth() - 9, pie_GetVideoBufferHeight() - 14, WZCOL_GREY, 270.f);
 
 	if (!getModList().empty())
 	{
-		iV_DrawText(modListText, 10, 15, font_regular);
+		cache.modListText.render(9, 14, WZCOL_GREY);
+	}
+
+	cache.formattedVersionString.render(pie_GetVideoBufferWidth() - 10, pie_GetVideoBufferHeight() - 15, WZCOL_TEXT_BRIGHT, 270.f);
+
+
+	if (!getModList().empty())
+	{
+		cache.modListText.render(10, 15, WZCOL_TEXT_BRIGHT);
 	}
 }
 
@@ -1577,13 +1834,17 @@ static void displayTextAt270(WIDGET *psWidget, UDWORD xOffset, UDWORD yOffset)
 
 	psLab = (W_LABEL *)psWidget;
 
-	fx = xOffset + psWidget->x();
-	fy = yOffset + psWidget->y() + iV_GetTextWidth(psLab->aText.toUtf8().constData(), font_large);
+	// Any widget using displayTextAt270 must have its pUserData initialized to a (DisplayTextOptionCache*)
+	assert(psWidget->pUserData != nullptr);
+	DisplayTextOptionCache& cache = *static_cast<DisplayTextOptionCache*>(psWidget->pUserData);
 
-	iV_SetTextColour(WZCOL_GREY);
-	iV_DrawTextRotated(psLab->aText.toUtf8().constData(), fx + 2, fy + 2, 270.f, font_large);
-	iV_SetTextColour(WZCOL_TEXT_BRIGHT);
-	iV_DrawTextRotated(psLab->aText.toUtf8().constData(), fx, fy, 270.f, font_large);
+	cache.wzText.setText(psLab->aText.toUtf8().constData(), font_large);
+
+	fx = xOffset + psWidget->x();
+	fy = yOffset + psWidget->y() + cache.wzText.width();
+
+	cache.wzText.render(fx + 2, fy + 2, WZCOL_GREY, 270.f);
+	cache.wzText.render(fx, fy, WZCOL_TEXT_BRIGHT, 270.f);
 }
 
 // ////////////////////////////////////////////////////////////////////////////
@@ -1595,13 +1856,19 @@ void displayTextOption(WIDGET *psWidget, UDWORD xOffset, UDWORD yOffset)
 	bool			hilight = false;
 	bool			greyOut = psWidget->UserData; // if option is unavailable.
 
+	// Any widget using displayTextOption must have its pUserData initialized to a (DisplayTextOptionCache*)
+	assert(psWidget->pUserData != nullptr);
+	DisplayTextOptionCache& cache = *static_cast<DisplayTextOptionCache*>(psWidget->pUserData);
+
+	cache.wzText.setText(psBut->pText.toUtf8().constData(), psBut->FontID);
+
 	if (widgGetMouseOver(psWScreen) == psBut->id)					// if mouse is over text then hilight.
 	{
 		hilight = true;
 	}
 
-	fw = iV_GetTextWidth(psBut->pText.toUtf8().constData(), psBut->FontID);
-	fy = yOffset + psWidget->y() + (psWidget->height() - iV_GetTextLineSize(psBut->FontID)) / 2 - iV_GetTextAboveBase(psBut->FontID);
+	fw = cache.wzText.width();
+	fy = yOffset + psWidget->y() + (psWidget->height() - cache.wzText.lineSize()) / 2 - cache.wzText.aboveBase();
 
 	if (psWidget->style & WBUT_TXTCENTRE)							//check for centering, calculate offset.
 	{
@@ -1612,27 +1879,29 @@ void displayTextOption(WIDGET *psWidget, UDWORD xOffset, UDWORD yOffset)
 		fx = xOffset + psWidget->x();
 	}
 
+	PIELIGHT colour;
+
 	if (greyOut)														// unavailable
 	{
-		iV_SetTextColour(WZCOL_TEXT_DARK);
+		colour = WZCOL_TEXT_DARK;
 	}
 	else															// available
 	{
 		if (hilight)													// hilight
 		{
-			iV_SetTextColour(WZCOL_TEXT_BRIGHT);
+			colour = WZCOL_TEXT_BRIGHT;
 		}
 		else if (psWidget->id == FRONTEND_HYPERLINK || psWidget->id == FRONTEND_DONATELINK || psWidget->id == FRONTEND_CHATLINK) // special case for our hyperlink
 		{
-			iV_SetTextColour(WZCOL_YELLOW);
+			colour = WZCOL_YELLOW;
 		}
 		else														// don't highlight
 		{
-			iV_SetTextColour(WZCOL_TEXT_MEDIUM);
+			colour = WZCOL_TEXT_MEDIUM;
 		}
 	}
 
-	iV_DrawText(psBut->pText.toUtf8().constData(), fx, fy, psBut->FontID);
+	cache.wzText.render(fx, fy, colour);
 
 	return;
 }
@@ -1649,11 +1918,19 @@ void addBackdrop()
 	sFormInit.formID = 0;
 	sFormInit.id = FRONTEND_BACKDROP;
 	sFormInit.style = WFORM_PLAIN;
-	sFormInit.x = (SWORD)((pie_GetVideoBufferWidth() - HIDDEN_FRONTEND_WIDTH) / 2);
-	sFormInit.y = (SWORD)((pie_GetVideoBufferHeight() - HIDDEN_FRONTEND_HEIGHT) / 2);
-	sFormInit.width = HIDDEN_FRONTEND_WIDTH - 1;
-	sFormInit.height = HIDDEN_FRONTEND_HEIGHT - 1;
+	sFormInit.calcLayout = LAMBDA_CALCLAYOUT_SIMPLE({
+		psWidget->setGeometry((SWORD)((pie_GetVideoBufferWidth() - HIDDEN_FRONTEND_WIDTH) / 2),
+							  (SWORD)((pie_GetVideoBufferHeight() - HIDDEN_FRONTEND_HEIGHT) / 2),
+							  HIDDEN_FRONTEND_WIDTH - 1,
+							  HIDDEN_FRONTEND_HEIGHT - 1);
+	});
 	sFormInit.pDisplay = displayTitleBitmap;
+	sFormInit.pUserData = new TitleBitmapCache();
+	sFormInit.onDelete = [](WIDGET *psWidget) {
+		assert(psWidget->pUserData != nullptr);
+		delete ((TitleBitmapCache *)psWidget->pUserData);
+		psWidget->pUserData = nullptr;
+	};
 	widgAddForm(psWScreen, &sFormInit);
 }
 
@@ -1664,14 +1941,16 @@ void addTopForm()
 
 	IntFormAnimated *topForm = new IntFormAnimated(parent, false);
 	topForm->id = FRONTEND_TOPFORM;
-	if (titleMode == MULTIOPTION)
-	{
-		topForm->setGeometry(FRONTEND_TOPFORM_WIDEX, FRONTEND_TOPFORM_WIDEY, FRONTEND_TOPFORM_WIDEW, FRONTEND_TOPFORM_WIDEH);
-	}
-	else
-	{
-		topForm->setGeometry(FRONTEND_TOPFORMX, FRONTEND_TOPFORMY, FRONTEND_TOPFORMW, FRONTEND_TOPFORMH);
-	}
+	topForm->setCalcLayout(LAMBDA_CALCLAYOUT_SIMPLE({
+		if (titleMode == MULTIOPTION)
+		{
+			psWidget->setGeometry(FRONTEND_TOPFORM_WIDEX, FRONTEND_TOPFORM_WIDEY, FRONTEND_TOPFORM_WIDEW, FRONTEND_TOPFORM_WIDEH);
+		}
+		else
+		{
+			psWidget->setGeometry(FRONTEND_TOPFORMX, FRONTEND_TOPFORMY, FRONTEND_TOPFORMW, FRONTEND_TOPFORMH);
+		}
+	}));
 
 	W_FORMINIT sFormInit;
 	sFormInit.formID = FRONTEND_TOPFORM;
@@ -1703,7 +1982,9 @@ void addBottomForm()
 
 	IntFormAnimated *botForm = new IntFormAnimated(parent);
 	botForm->id = FRONTEND_BOTFORM;
-	botForm->setGeometry(FRONTEND_BOTFORMX, FRONTEND_BOTFORMY, FRONTEND_BOTFORMW, FRONTEND_BOTFORMH);
+	botForm->setCalcLayout(LAMBDA_CALCLAYOUT_SIMPLE({
+		psWidget->setGeometry(FRONTEND_BOTFORMX, FRONTEND_BOTFORMY, FRONTEND_BOTFORMW, FRONTEND_BOTFORMH);
+	}));
 }
 
 // ////////////////////////////////////////////////////////////////////////////
@@ -1735,6 +2016,12 @@ void addSideText(UDWORD id,  UDWORD PosX, UDWORD PosY, const char *txt)
 
 	sLabInit.pDisplay = displayTextAt270;
 	sLabInit.pText = txt;
+	sLabInit.pUserData = new DisplayTextOptionCache();
+	sLabInit.onDelete = [](WIDGET *psWidget) {
+		assert(psWidget->pUserData != nullptr);
+		delete static_cast<DisplayTextOptionCache *>(psWidget->pUserData);
+		psWidget->pUserData = nullptr;
+	};
 	widgAddLabel(psWScreen, &sLabInit);
 }
 
@@ -1767,6 +2054,12 @@ void addTextButton(UDWORD id,  UDWORD PosX, UDWORD PosY, const std::string &txt,
 	}
 
 	sButInit.UserData = (style & WBUT_DISABLE); // store disable state
+	sButInit.pUserData = new DisplayTextOptionCache();
+	sButInit.onDelete = [](WIDGET *psWidget) {
+		assert(psWidget->pUserData != nullptr);
+		delete static_cast<DisplayTextOptionCache *>(psWidget->pUserData);
+		psWidget->pUserData = nullptr;
+	};
 
 	sButInit.height = FRONTEND_BUTHEIGHT;
 	sButInit.pDisplay = displayTextOption;
@@ -1809,6 +2102,12 @@ void addSmallTextButton(UDWORD id,  UDWORD PosX, UDWORD PosY, const char *txt, u
 	}
 
 	sButInit.UserData = (style & WBUT_DISABLE); // store disable state
+	sButInit.pUserData = new DisplayTextOptionCache();
+	sButInit.onDelete = [](WIDGET *psWidget) {
+		assert(psWidget->pUserData != nullptr);
+		delete static_cast<DisplayTextOptionCache *>(psWidget->pUserData);
+		psWidget->pUserData = nullptr;
+	};
 
 	sButInit.height = FRONTEND_BUTHEIGHT;
 	sButInit.pDisplay = displayTextOption;
@@ -1918,4 +2217,21 @@ void changeTitleMode(tMode mode)
 	}
 
 	return;
+}
+
+// ////////////////////////////////////////////////////////////////////////////
+// Handling Screen Size Changes
+
+/* Tell the frontend when the screen has been resized */
+void frontendScreenSizeDidChange(int oldWidth, int oldHeight, int newWidth, int newHeight)
+{
+	// NOTE:
+	// By setting the appropriate calcLayout functions on all interface elements,
+	// they should automatically recalculate their layout on screen resize.
+
+	// If the Video Options screen is up, the current resolution text must be updated
+	if (widgGetFromID(psWScreen, FRONTEND_RESOLUTION_R) != nullptr)
+	{
+		widgSetString(psWScreen, FRONTEND_RESOLUTION_R, videoOptionsResolutionString().c_str());
+	}
 }

--- a/src/frontend.cpp
+++ b/src/frontend.cpp
@@ -1257,7 +1257,10 @@ bool runVideoOptionsMenu()
 			auto current = std::lower_bound(modes.begin(), modes.end(), config, compareLess);
 			if (current == modes.end() || !compareEq(*current, config))
 			{
-				--current;  // If current resolution doesn't exist, round down to next-highest one.
+				if (current != modes.begin())
+				{
+					--current;  // If current resolution doesn't exist, round down to next-highest one.
+				}
 			}
 
 			// Increment/decrement and loop if required.

--- a/src/frontend.h
+++ b/src/frontend.h
@@ -84,6 +84,14 @@ void displayTextOption(WIDGET *psWidget, UDWORD xOffset, UDWORD yOffset);
 
 bool CancelPressed();
 
+/* Tell the frontend when the screen has been resized */
+void frontendScreenSizeDidChange(int oldWidth, int oldHeight, int newWidth, int newHeight);
+
+struct DisplayTextOptionCache
+{
+	WzText wzText;
+};
+
 
 // ////////////////////////////////////////////////////////////////////////////
 // defines.
@@ -243,6 +251,8 @@ enum
 	FRONTEND_VSYNC_R,
 	FRONTEND_FSAA,
 	FRONTEND_FSAA_R,
+	FRONTEND_DISPLAYSCALE,
+	FRONTEND_DISPLAYSCALE_R,
 
 	FRONTEND_MOUSEOPTIONS = 25000,          // Mouse Options Menu
 	FRONTEND_CURSORMODE,

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -38,6 +38,7 @@
 #include "lib/ivis_opengl/pieblitfunc.h"
 #include "lib/ivis_opengl/piestate.h"
 #include "lib/ivis_opengl/piepalette.h"
+#include "lib/ivis_opengl/textdraw.h"
 #include "lib/netplay/netplay.h"
 #include "lib/script/script.h"
 #include "lib/sound/audio.h"
@@ -92,6 +93,31 @@
 #include "lib/ivis_opengl/screen.h"
 #include "keymap.h"
 #include <ctime>
+#include "multimenu.h"
+#include "console.h"
+
+
+void gameScreenSizeDidChange(unsigned int oldWidth, unsigned int oldHeight, unsigned int newWidth, unsigned int newHeight)
+{
+	intScreenSizeDidChange(oldWidth, oldHeight, newWidth, newHeight);
+	loadSaveScreenSizeDidChange(oldWidth, oldHeight, newWidth, newHeight);
+	challengesScreenSizeDidChange(oldWidth, oldHeight, newWidth, newHeight);
+	multiOptionsScreenSizeDidChange(oldWidth, oldHeight, newWidth, newHeight);
+	multiMenuScreenSizeDidChange(oldWidth, oldHeight, newWidth, newHeight);
+	display3dScreenSizeDidChange(oldWidth, oldHeight, newWidth, newHeight);
+	consoleScreenDidChangeSize(oldWidth, oldHeight, newWidth, newHeight);
+	frontendScreenSizeDidChange(oldWidth, oldHeight, newWidth, newHeight);
+}
+
+void gameDisplayScaleFactorDidChange(float newDisplayScaleFactor)
+{
+	// The text subsystem requires the game -> renderer scale factor, which potentially differs from
+	// the display scale factor.
+	float horizGameToRendererScaleFactor = 0.f, vertGameToRendererScaleFactor = 0.f;
+	wzGetGameToRendererScaleFactor(&horizGameToRendererScaleFactor, &vertGameToRendererScaleFactor);
+	iV_TextUpdateScaleFactor(horizGameToRendererScaleFactor, vertGameToRendererScaleFactor);
+}
+
 
 #define MAX_SAVE_NAME_SIZE_V19	40
 #define MAX_SAVE_NAME_SIZE	60

--- a/src/game.h
+++ b/src/game.h
@@ -133,4 +133,7 @@ UDWORD getSaveGameType();
 
 bool plotStructurePreview16(char *backDropSprite, Vector2i playeridpos[]);
 
+void gameScreenSizeDidChange(unsigned int oldWidth, unsigned int oldHeight, unsigned int newWidth, unsigned int newHeight);
+void gameDisplayScaleFactorDidChange(float newDisplayScaleFactor);
+
 #endif // __INCLUDED_SRC_GAME_H__

--- a/src/hci.cpp
+++ b/src/hci.cpp
@@ -2442,6 +2442,13 @@ void intNewObj(BASE_OBJECT *psObj)
 	}
 }
 
+/* Tell the interface when the screen has been resized */
+void intScreenSizeDidChange(int oldWidth, int oldHeight, int newWidth, int newHeight)
+{
+	if (psWScreen == nullptr) return;
+	psWScreen->screenSizeDidChange(oldWidth, oldHeight, newWidth, newHeight);
+}
+
 
 // clean up when an object dies
 static void intObjectDied(UDWORD objID)
@@ -2706,7 +2713,9 @@ bool intAddReticule()
 	WIDGET *parent = psWScreen->psForm;
 	IntFormAnimated *retForm = new IntFormAnimated(parent, false);
 	retForm->id = IDRET_FORM;
-	retForm->setGeometry(RET_X, RET_Y, RET_FORMWIDTH, RET_FORMHEIGHT);
+	retForm->setCalcLayout(LAMBDA_CALCLAYOUT_SIMPLE({
+		psWidget->setGeometry(RET_X, RET_Y, RET_FORMWIDTH, RET_FORMHEIGHT);
+	}));
 	for (int i = 0; i < NUMRETBUTS; i++)
 	{
 		setReticuleBut(i);
@@ -2750,12 +2759,17 @@ bool intAddPower()
 	sBarInit.id = IDPOW_POWERBAR_T;
 	//start the power bar off in view (default)
 	sBarInit.style = WBAR_TROUGH;
-	sBarInit.x = (SWORD)POW_X;
-	sBarInit.y = (SWORD)POW_Y;
-	sBarInit.width = POW_BARWIDTH;
-	sBarInit.height = iV_GetImageHeight(IntImages, IMAGE_PBAR_EMPTY);
+	sBarInit.calcLayout = LAMBDA_CALCLAYOUT_SIMPLE({
+		psWidget->setGeometry((SWORD)POW_X, (SWORD)POW_Y, POW_BARWIDTH, iV_GetImageHeight(IntImages, IMAGE_PBAR_EMPTY));
+	});
 	sBarInit.sCol = WZCOL_POWER_BAR;
 	sBarInit.pDisplay = intDisplayPowerBar;
+	sBarInit.pUserData = new DisplayPowerBarCache();
+	sBarInit.onDelete = [](WIDGET *psWidget) {
+		assert(psWidget->pUserData != nullptr);
+		delete static_cast<DisplayPowerBarCache *>(psWidget->pUserData);
+		psWidget->pUserData = nullptr;
+	};
 	sBarInit.iRange = POWERBAR_SCALE;
 
 	sBarInit.pTip = _("Power");
@@ -2893,16 +2907,17 @@ static bool intAddObjectWindow(BASE_OBJECT *psObjects, BASE_OBJECT *psSelected, 
 	/* Create the basic form */
 	IntFormAnimated *objForm = new IntFormAnimated(parent, false);
 	objForm->id = IDOBJ_FORM;
-	objForm->setGeometry(OBJ_BACKX, OBJ_BACKY, OBJ_BACKWIDTH, OBJ_BACKHEIGHT);
+	objForm->setCalcLayout(LAMBDA_CALCLAYOUT_SIMPLE({
+		psWidget->setGeometry(OBJ_BACKX, OBJ_BACKY, OBJ_BACKWIDTH, OBJ_BACKHEIGHT);
+	}));
 
 	/* Add the close button */
 	W_BUTINIT sButInit;
 	sButInit.formID = IDOBJ_FORM;
 	sButInit.id = IDOBJ_CLOSE;
-	sButInit.x = OBJ_BACKWIDTH - CLOSE_WIDTH;
-	sButInit.y = 0;
-	sButInit.width = CLOSE_WIDTH;
-	sButInit.height = CLOSE_HEIGHT;
+	sButInit.calcLayout = LAMBDA_CALCLAYOUT_SIMPLE({
+		psWidget->setGeometry(OBJ_BACKWIDTH - CLOSE_WIDTH, 0, CLOSE_WIDTH, CLOSE_HEIGHT);
+	});
 	sButInit.pTip = _("Close");
 	sButInit.pDisplay = intDisplayImageHilight;
 	sButInit.UserData = PACKDWORD_TRI(0, IMAGE_CLOSEHILIGHT , IMAGE_CLOSE);
@@ -2914,10 +2929,14 @@ static bool intAddObjectWindow(BASE_OBJECT *psObjects, BASE_OBJECT *psSelected, 
 	/*add the tabbed form */
 	IntListTabWidget *objList = new IntListTabWidget(objForm);
 	objList->id = IDOBJ_TABFORM;
-	objList->setChildSize(OBJ_BUTWIDTH, OBJ_BUTHEIGHT * 2);
-	objList->setChildSpacing(OBJ_GAP, OBJ_GAP);
-	int objListWidth = OBJ_BUTWIDTH * 5 + STAT_GAP * 4;
-	objList->setGeometry((OBJ_BACKWIDTH - objListWidth) / 2, OBJ_TABY, objListWidth, OBJ_BACKHEIGHT - OBJ_TABY);
+	objList->setCalcLayout(LAMBDA_CALCLAYOUT_SIMPLE({
+		IntListTabWidget *objList = static_cast<IntListTabWidget *>(psWidget);
+		assert(objList != nullptr);
+		objList->setChildSize(OBJ_BUTWIDTH, OBJ_BUTHEIGHT * 2);
+		objList->setChildSpacing(OBJ_GAP, OBJ_GAP);
+		int objListWidth = OBJ_BUTWIDTH * 5 + STAT_GAP * 4;
+		objList->setGeometry((OBJ_BACKWIDTH - objListWidth) / 2, OBJ_TABY, objListWidth, OBJ_BACKHEIGHT - OBJ_TABY);
+	}));
 
 	/* Add the object and stats buttons */
 	int nextObjButtonId = IDOBJ_OBJSTART;
@@ -2928,10 +2947,9 @@ static bool intAddObjectWindow(BASE_OBJECT *psObjects, BASE_OBJECT *psSelected, 
 	sBarInit.formID = IDOBJ_OBJSTART;
 	sBarInit.id = IDOBJ_PROGBARSTART;
 	sBarInit.style = WBAR_TROUGH | WIDG_HIDDEN;
-	sBarInit.x = STAT_PROGBARX;
-	sBarInit.y = STAT_PROGBARY;
-	sBarInit.width = STAT_PROGBARWIDTH;
-	sBarInit.height = STAT_PROGBARHEIGHT;
+	sBarInit.calcLayout = LAMBDA_CALCLAYOUT_SIMPLE({
+		psWidget->setGeometry(STAT_PROGBARX, STAT_PROGBARY, STAT_PROGBARWIDTH, STAT_PROGBARHEIGHT);
+	});
 	sBarInit.size = 0;
 	sBarInit.sCol = WZCOL_ACTION_PROGRESS_BAR_MAJOR;
 	sBarInit.sMinorCol = WZCOL_ACTION_PROGRESS_BAR_MINOR;
@@ -2941,17 +2959,17 @@ static bool intAddObjectWindow(BASE_OBJECT *psObjects, BASE_OBJECT *psSelected, 
 	W_BARINIT sBarInit2 = sBarInit;
 	sBarInit2.id = IDOBJ_POWERBARSTART;
 	sBarInit2.style = WBAR_PLAIN;
-	sBarInit2.x = STAT_POWERBARX;
-	sBarInit2.y = STAT_POWERBARY;
+	sBarInit2.calcLayout = LAMBDA_CALCLAYOUT_SIMPLE({
+		psWidget->move(STAT_POWERBARX, STAT_POWERBARY);
+	});
 	sBarInit2.size = 50;
 
 	W_LABINIT sLabInit;
 	sLabInit.id = IDOBJ_COUNTSTART;
 	sLabInit.style = WIDG_HIDDEN;
-	sLabInit.x = OBJ_TEXTX;
-	sLabInit.y = OBJ_T1TEXTY;
-	sLabInit.width = 16;
-	sLabInit.height = 16;
+	sLabInit.calcLayout = LAMBDA_CALCLAYOUT_SIMPLE({
+		psWidget->setGeometry(OBJ_TEXTX, OBJ_T1TEXTY, 16, 16);
+	});
 	sLabInit.pText = "BUG! (a)";
 
 	W_LABINIT sLabInitCmdFac;
@@ -3531,7 +3549,9 @@ static bool intAddStats(BASE_STATS **ppsStatsList, UDWORD numStats,
 	/* Create the basic form */
 	IntFormAnimated *statForm = new IntFormAnimated(parent, false);
 	statForm->id = IDSTAT_FORM;
-	statForm->setGeometry(STAT_X, STAT_Y, STAT_WIDTH, STAT_HEIGHT);
+	statForm->setCalcLayout(LAMBDA_CALCLAYOUT_SIMPLE({
+		psWidget->setGeometry(STAT_X, STAT_Y, STAT_WIDTH, STAT_HEIGHT);
+	}));
 
 	W_LABINIT sLabInit;
 
@@ -4890,7 +4910,9 @@ void chatDialog(int mode)
 
 		consoleBox = new IntFormAnimated(parent);
 		consoleBox->id = CHAT_CONSOLEBOX;
-		consoleBox->setGeometry(CHAT_CONSOLEBOXX, CHAT_CONSOLEBOXY, CHAT_CONSOLEBOXW, CHAT_CONSOLEBOXH);
+		consoleBox->setCalcLayout(LAMBDA_CALCLAYOUT_SIMPLE({
+			psWidget->setGeometry(CHAT_CONSOLEBOXX, CHAT_CONSOLEBOXY, CHAT_CONSOLEBOXW, CHAT_CONSOLEBOXH);
+		}));
 
 		chatBox = new W_EDITBOX(consoleBox);
 		chatBox->id = CHAT_EDITBOX;

--- a/src/hci.h
+++ b/src/hci.h
@@ -339,6 +339,8 @@ void addIntelScreen();
 /* Reset the widget screen to just the reticule */
 void intResetScreen(bool NoAnim);
 
+void intScreenSizeDidChange(int oldWidth, int oldHeight, int newWidth, int newHeight);
+
 /* Refresh icons on the interface, without disturbing the layout. i.e. smartreset*/
 void intRefreshScreen();
 

--- a/src/ingameop.cpp
+++ b/src/ingameop.cpp
@@ -79,6 +79,12 @@ static bool addIGTextButton(UDWORD id, UWORD x, UWORD y, UWORD width, const char
 
 	sButInit.pDisplay	= displayTextOption;
 	sButInit.pText		= string;
+	sButInit.pUserData = new DisplayTextOptionCache();
+	sButInit.onDelete = [](WIDGET *psWidget) {
+		assert(psWidget->pUserData != nullptr);
+		delete static_cast<DisplayTextOptionCache *>(psWidget->pUserData);
+		psWidget->pUserData = nullptr;
+	};
 	widgAddButton(psWScreen, &sButInit);
 
 	return true;
@@ -87,15 +93,17 @@ static bool addIGTextButton(UDWORD id, UWORD x, UWORD y, UWORD width, const char
 static bool addQuitOptions()
 {
 	// get rid of the old stuff.
-	delete widgGetFromID(psWScreen, INTINGAMEOP);
 	delete widgGetFromID(psWScreen, INTINGAMEPOPUP);
+	delete widgGetFromID(psWScreen, INTINGAMEOP);
 
 	WIDGET *parent = psWScreen->psForm;
 
 	// add form
 	auto inGameOp = new IntFormAnimated(parent);
 	inGameOp->id = INTINGAMEOP;
-	inGameOp->setGeometry(INTINGAMEOP3_X, INTINGAMEOP3_Y, INTINGAMEOP3_W, INTINGAMEOP3_H);
+	inGameOp->setCalcLayout(LAMBDA_CALCLAYOUT_SIMPLE({
+		psWidget->setGeometry(INTINGAMEOP3_X, INTINGAMEOP3_Y, INTINGAMEOP3_W, INTINGAMEOP3_H);
+	}));
 
 	addIGTextButton(INTINGAMEOP_RESUME, INTINGAMEOP_1_X, INTINGAMEOP_1_Y, INTINGAMEOP_OP_W, _("Resume Game"), OPALIGN);
 
@@ -103,7 +111,12 @@ static bool addQuitOptions()
 	{
 		auto inGamePopup = new IntFormAnimated(parent);
 		inGamePopup->id = INTINGAMEPOPUP;
-		inGamePopup->setGeometry((pie_GetVideoBufferWidth() - 600)/2, inGameOp->y() - 26 - 20, 600, 26);
+		inGamePopup->setCalcLayout(LAMBDA_CALCLAYOUT_SIMPLE({
+			assert(psWScreen != nullptr);
+			WIDGET * inGameOp = widgGetFromID(psWScreen, INTINGAMEOP);
+			assert(inGameOp != nullptr);
+			psWidget->setGeometry((pie_GetVideoBufferWidth() - 600)/2, inGameOp->y() - 26 - 20, 600, 26);
+		}));
 
 		auto label = new W_LABEL(inGamePopup);
 		label->setGeometry(0, 0, inGamePopup->width(), inGamePopup->height());
@@ -131,7 +144,9 @@ static bool addSlideOptions()
 	// add form
 	IntFormAnimated *ingameOp = new IntFormAnimated(parent);
 	ingameOp->id = INTINGAMEOP;
-	ingameOp->setGeometry(INTINGAMEOP2_X, INTINGAMEOP2_Y, INTINGAMEOP2_W, INTINGAMEOP2_H);
+	ingameOp->setCalcLayout(LAMBDA_CALCLAYOUT_SIMPLE({
+		psWidget->setGeometry(INTINGAMEOP2_X, INTINGAMEOP2_Y, INTINGAMEOP2_W, INTINGAMEOP2_H);
+	}));
 
 	// fx vol
 	addIGTextButton(INTINGAMEOP_FXVOL, INTINGAMEOP_2_X, INTINGAMEOP_1_Y, INTINGAMEOP_OP_W, _("Voice Volume"), WBUT_PLAIN);
@@ -203,7 +218,10 @@ static bool _intAddInGameOptions()
 	// add form
 	IntFormAnimated *ingameOp = new IntFormAnimated(parent);
 	ingameOp->id = INTINGAMEOP;
-	ingameOp->setGeometry(INTINGAMEOP_X, INTINGAMEOP_Y, INTINGAMEOP_W, s ? INTINGAMEOP_HS : INTINGAMEOP_H);
+	ingameOp->setCalcLayout(LAMBDA_CALCLAYOUT_SIMPLE({
+		bool s = (bMultiPlayer && NetPlay.bComms != 0) || bInTutorial;
+		psWidget->setGeometry(INTINGAMEOP_X, INTINGAMEOP_Y, INTINGAMEOP_W, s ? INTINGAMEOP_HS : INTINGAMEOP_H);
+	}));
 
 	// add 'quit' text
 	if (NetPlay.isHost && bMultiPlayer && NetPlay.bComms)
@@ -280,7 +298,9 @@ void intAddInGamePopup()
 
 	IntFormAnimated *ingamePopup = new IntFormAnimated(parent);
 	ingamePopup->id = INTINGAMEPOPUP;
-	ingamePopup->setGeometry(20 + D_W, (240 - 160 / 2) + D_H, 600, 160);
+	ingamePopup->setCalcLayout(LAMBDA_CALCLAYOUT_SIMPLE({
+		psWidget->setGeometry(20 + D_W, (240 - 160 / 2) + D_H, 600, 160);
+	}));
 
 	// add the text "buttons" now
 	W_BUTINIT sButInit;
@@ -292,6 +312,12 @@ void intAddInGamePopup()
 	sButInit.x			= 0;
 	sButInit.height		= 10;
 	sButInit.pDisplay	= displayTextOption;
+	sButInit.pUserData = new DisplayTextOptionCache();
+	sButInit.onDelete = [](WIDGET *psWidget) {
+		assert(psWidget->pUserData != nullptr);
+		delete static_cast<DisplayTextOptionCache *>(psWidget->pUserData);
+		psWidget->pUserData = nullptr;
+	};
 
 	sButInit.id			= INTINGAMEOP_POPUP_MSG2;
 	sButInit.y			= 20;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -152,6 +152,7 @@ bool loadLevFile(const char *filename, searchPathMode datadir, bool ignoreWrf, c
 	if (!levParse(pBuffer, size, datadir, ignoreWrf, realFileName))
 	{
 		debug(LOG_ERROR, "Parse error in %s\n", filename);
+		free(pBuffer);
 		return false;
 	}
 	free(pBuffer);
@@ -679,7 +680,7 @@ bool buildMapList()
 // ////////////////////////////////////////////////////////////////////////////
 // Called once on program startup.
 //
-bool systemInitialise()
+bool systemInitialise(float horizScaleFactor, float vertScaleFactor)
 {
 	if (!widgInitialise())
 	{
@@ -720,7 +721,7 @@ bool systemInitialise()
 
 	// Initialize the iVis text rendering module
 	wzSceneBegin("Main menu loop");
-	iV_TextInit();
+	iV_TextInit(horizScaleFactor, vertScaleFactor);
 
 	pie_InitRadar();
 

--- a/src/init.h
+++ b/src/init.h
@@ -31,7 +31,7 @@ struct IMAGEFILE;
 #define FILE_LOAD_BUFFER_SIZE (1024*1024*4)
 extern char fileLoadBuffer[];
 
-bool systemInitialise();
+bool systemInitialise(float horizScaleFactor, float vertScaleFactor);
 void systemShutdown();
 bool frontendInitialise(const char *ResourceFile);
 bool frontendShutdown();

--- a/src/intdisplay.h
+++ b/src/intdisplay.h
@@ -116,6 +116,12 @@ void intAddFactoryInc(WIDGET *psWidget, W_CONTEXT *psContext);
 //callback to display the production quantity number for a template
 void intAddProdQuantity(WIDGET *psWidget, W_CONTEXT *psContext);
 
+/* Holds the cached rendered text for the power bar */
+struct DisplayPowerBarCache
+{
+	WzText wzText;
+	WzText wzNeedText;
+};
 void intDisplayPowerBar(WIDGET *psWidget, UDWORD xOffset, UDWORD yOffset);
 
 class IntFancyButton : public W_CLICKFORM
@@ -260,6 +266,12 @@ SDWORD StatIsComponent(BASE_STATS *Stat);
 bool StatGetComponentIMD(BASE_STATS *Stat, SDWORD compID, iIMDShape **CompIMD, iIMDShape **MountIMD);
 
 bool StatIsResearch(BASE_STATS *Stat);
+
+/* The cache (pUserData) expected by both intDisplayStatsBar and intDisplayDesignPowerBar */
+struct DisplayBarCache {
+	WzText wzCheckWidthText;
+	WzText wzText;
+};
 
 /* Draws a stats bar for the design screen */
 void intDisplayStatsBar(WIDGET *psWidget, UDWORD xOffset, UDWORD yOffset);

--- a/src/intelmap.cpp
+++ b/src/intelmap.cpp
@@ -255,7 +255,9 @@ bool intAddIntelMap()
 	// Add the main Intelligence Map form
 	IntFormAnimated *intMapForm = new IntFormAnimated(parent, Animate);  // Do not animate the opening, if the window was already open.
 	intMapForm->id = IDINTMAP_FORM;
-	intMapForm->setGeometry(INTMAP_X, INTMAP_Y, INTMAP_WIDTH, INTMAP_HEIGHT);
+	intMapForm->setCalcLayout(LAMBDA_CALCLAYOUT_SIMPLE({
+		psWidget->setGeometry(INTMAP_X, INTMAP_Y, INTMAP_WIDTH, INTMAP_HEIGHT);
+	}));
 
 	if (!intAddMessageForm(playCurrent))
 	{
@@ -386,7 +388,9 @@ bool intAddMessageView(MESSAGE *psMessage)
 
 	IntFormAnimated *intMapMsgView = new IntFormAnimated(parent, Animate);  // Do not animate the opening, if the window was already open.
 	intMapMsgView->id = IDINTMAP_MSGVIEW;
-	intMapMsgView->setGeometry(INTMAP_RESEARCHX, INTMAP_RESEARCHY, INTMAP_RESEARCHWIDTH, INTMAP_RESEARCHHEIGHT);
+	intMapMsgView->setCalcLayout(LAMBDA_CALCLAYOUT_SIMPLE({
+		psWidget->setGeometry(INTMAP_RESEARCHX, INTMAP_RESEARCHY, INTMAP_RESEARCHWIDTH, INTMAP_RESEARCHHEIGHT);
+	}));
 
 	/* Add the close box */
 	W_BUTINIT sButInit;

--- a/src/intorder.cpp
+++ b/src/intorder.cpp
@@ -555,7 +555,9 @@ bool intAddOrder(BASE_OBJECT *psObj)
 	/* Create the basic form */
 	IntFormAnimated *orderForm = new IntFormAnimated(parent, Animate);  // Do not animate the opening, if the window was already open.
 	orderForm->id = IDORDER_FORM;
-	orderForm->setGeometry(ORDER_X, ORDER_Y, ORDER_WIDTH, ORDER_HEIGHT);
+	orderForm->setCalcLayout(LAMBDA_CALCLAYOUT_SIMPLE({
+		psWidget->setGeometry(ORDER_X, ORDER_Y, ORDER_WIDTH, ORDER_HEIGHT);
+	}));
 
 	// Add the close button.
 	W_BUTINIT sButInit;

--- a/src/loadsave.h
+++ b/src/loadsave.h
@@ -74,4 +74,6 @@ bool saveMidMission();
 
 void deleteSaveGame(char *saveGameName);
 
+void loadSaveScreenSizeDidChange(unsigned int oldWidth, unsigned int oldHeight, unsigned int newWidth, unsigned int newHeight);
+
 #endif // __INCLUDED_SRC_LOADSAVE_H__

--- a/src/multiint.h
+++ b/src/multiint.h
@@ -123,6 +123,8 @@ void kickPlayer(uint32_t player_id, const char *reason, LOBBY_ERROR_TYPES type);
 void addPlayerBox(bool);			// players (mid) box
 void loadMapPreview(bool hideInterface);
 
+void multiOptionsScreenSizeDidChange(unsigned int oldWidth, unsigned int oldHeight, unsigned int newWidth, unsigned int newHeight);
+
 
 // ////////////////////////////////////////////////////////////////
 // CONNECTION SCREEN

--- a/src/multijoin.h
+++ b/src/multijoin.h
@@ -26,6 +26,7 @@
 
 #include "droiddef.h"
 
+void clearDisplayMultiJoiningStatusCache();						// Call when bDisplayMultiJoiningStatus is set to 0
 bool intDisplayMultiJoiningStatus(UBYTE joinCount);
 void recvPlayerLeft(NETQUEUE queue);
 bool MultiPlayerLeave(UDWORD playerIndex);						// A player has left the game.

--- a/src/multimenu.h
+++ b/src/multimenu.h
@@ -43,6 +43,8 @@ bool intCloseMultiMenu();
 void intCloseMultiMenuNoAnim();
 bool intAddMultiMenu();
 
+void multiMenuScreenSizeDidChange(unsigned int oldWidth, unsigned int oldHeight, unsigned int newWidth, unsigned int newHeight);
+
 extern bool		MultiMenuUp;
 
 extern UDWORD		current_numplayers;

--- a/src/multiplay.cpp
+++ b/src/multiplay.cpp
@@ -235,6 +235,7 @@ bool multiPlayerLoop()
 		if (keyPressed(KEY_ESC))// check for cancel
 		{
 			bDisplayMultiJoiningStatus = 0;
+			clearDisplayMultiJoiningStatusCache();
 			setWidgetsStatus(true);
 			setPlayerHasLost(true);
 		}
@@ -244,6 +245,7 @@ bool multiPlayerLoop()
 		if (bDisplayMultiJoiningStatus)
 		{
 			bDisplayMultiJoiningStatus = 0;
+			clearDisplayMultiJoiningStatusCache();
 			setWidgetsStatus(true);
 		}
 		if (!ingame.TimeEveryoneIsInGame)

--- a/src/scores.cpp
+++ b/src/scores.cpp
@@ -271,7 +271,7 @@ void getAsciiTime(char *psText, unsigned time)
 	}
 }
 
-void scoreDataToScreen(WIDGET *psWidget)
+void scoreDataToScreen(WIDGET *psWidget, ScoreDataToScreenCache& cache)
 {
 	int index, x, y, width, height;
 	bool bMoreBars;
@@ -288,9 +288,12 @@ void scoreDataToScreen(WIDGET *psWidget)
 	pie_UniTransBoxFill(16 + D_W, MT_Y_POS - 16, pie_GetVideoBufferWidth() - D_W - 16, MT_Y_POS + 256 + 16, WZCOL_SCORE_BOX);
 	iV_Box(16 + D_W, MT_Y_POS - 16, pie_GetVideoBufferWidth() - D_W - 16, MT_Y_POS + 256 + 16, WZCOL_SCORE_BOX_BORDER);
 
-	iV_DrawText(_("Unit Losses"), LC_X + D_W, 80 + 16 + D_H, font_regular);
-	iV_DrawText(_("Structure Losses"), LC_X + D_W, 140 + 16 + D_H, font_regular);
-	iV_DrawText(_("Force Information"), LC_X + D_W, 200 + 16 + D_H, font_regular);
+	cache.wzLabelText_UnitLosses.setText(_("Unit Losses"), font_regular);
+	cache.wzLabelText_UnitLosses.render(LC_X + D_W, 80 + 16 + D_H, WZCOL_FORM_TEXT);
+	cache.wzLabelText_StructureLosses.setText(_("Structure Losses"), font_regular);
+	cache.wzLabelText_StructureLosses.render(LC_X + D_W, 140 + 16 + D_H, WZCOL_FORM_TEXT);
+	cache.wzLabelText_ForceInformation.setText(_("Force Information"), font_regular);
+	cache.wzLabelText_ForceInformation.render(LC_X + D_W, 200 + 16 + D_H, WZCOL_FORM_TEXT);
 
 	index = 0;
 	bMoreBars = true;
@@ -342,7 +345,12 @@ void scoreDataToScreen(WIDGET *psWidget)
 			}
 			/* Now render the text by the bar */
 			sprintf(text, getDescription((MR_STRING)infoBars[index].stringID), infoBars[index].number);
-			iV_DrawText(text, x + width + 16, y + 12, font_regular);
+			if (index >= cache.wzInfoBarText.size())
+			{
+				cache.wzInfoBarText.resize(index + 1);
+			}
+			cache.wzInfoBarText[index].setText(text, font_regular);
+			cache.wzInfoBarText[index].render(x + width + 16, y + 12, WZCOL_FORM_TEXT);
 
 			/* If we're beyond STAT_ROOKIE, then we're on rankings */
 			if (index >= STAT_GREEN && index <= STAT_ACE)
@@ -362,24 +370,27 @@ void scoreDataToScreen(WIDGET *psWidget)
 
 	/* Firstly, top of the screen, number of artefacts found */
 	sprintf(text, _("ARTIFACTS RECOVERED: %d"), missionData.artefactsFound);
-	iV_DrawText(text, (pie_GetVideoBufferWidth() - iV_GetTextWidth(text, font_regular)) / 2, 300 + D_H, font_regular);
+	cache.wzInfoText_ArtifactsFound.setText(text, font_regular);
+	cache.wzInfoText_ArtifactsFound.render((pie_GetVideoBufferWidth() - cache.wzInfoText_ArtifactsFound.width()) / 2, 300 + D_H, WZCOL_FORM_TEXT);
 
 	/* Get the mission result time in a string - and write it out */
 	getAsciiTime((char *)&text2, gameTime - missionData.missionStarted);
 	sprintf(text, _("Mission Time - %s"), text2);
-	iV_DrawText(text, (pie_GetVideoBufferWidth() - iV_GetTextWidth(text, font_regular)) / 2, 320 + D_H, font_regular);
+	cache.wzInfoText_MissionTime.setText(text, font_regular);
+	cache.wzInfoText_MissionTime.render((pie_GetVideoBufferWidth() - cache.wzInfoText_MissionTime.width()) / 2, 320 + D_H, WZCOL_FORM_TEXT);
 
 	/* Write out total game time so far */
 	getAsciiTime((char *)&text2, gameTime);
 	sprintf(text, _("Total Game Time - %s"), text2);
-	iV_DrawText(text, (pie_GetVideoBufferWidth() - iV_GetTextWidth(text, font_regular)) / 2, 340 + D_H, font_regular);
+	cache.wzInfoText_TotalGameTime.setText(text, font_regular);
+	cache.wzInfoText_TotalGameTime.render((pie_GetVideoBufferWidth() - cache.wzInfoText_TotalGameTime.width()) / 2, 340 + D_H, WZCOL_FORM_TEXT);
 	if (Cheated)
 	{
 		// A quick way to flash the text
-		((realTime / 250) % 2) ? iV_SetTextColour(WZCOL_RED) : iV_SetTextColour(WZCOL_YELLOW);
+		PIELIGHT cheatedTextColor = ((realTime / 250) % 2) ? WZCOL_RED : WZCOL_YELLOW;
 		sprintf(text, _("You cheated!"));
-		iV_DrawText(text, (pie_GetVideoBufferWidth() - iV_GetTextWidth(text, font_regular)) / 2, 360 + D_H, font_regular);
-		iV_SetTextColour(WZCOL_TEXT_BRIGHT);
+		cache.wzInfoText_Cheated.setText(text, font_regular);
+		cache.wzInfoText_Cheated.render((pie_GetVideoBufferWidth() - cache.wzInfoText_Cheated.width()) / 2, 360 + D_H, cheatedTextColor);
 	}
 }
 

--- a/src/scores.h
+++ b/src/scores.h
@@ -89,10 +89,24 @@ enum
 	STAT_ACE
 };
 
+#include "lib/ivis_opengl/textdraw.h"
+struct ScoreDataToScreenCache {
+	WzText wzLabelText_UnitLosses;
+	WzText wzLabelText_StructureLosses;
+	WzText wzLabelText_ForceInformation;
+
+	std::vector<WzText> wzInfoBarText;
+
+	WzText wzInfoText_ArtifactsFound;
+	WzText wzInfoText_MissionTime;
+	WzText wzInfoText_TotalGameTime;
+	WzText wzInfoText_Cheated;
+};
+
 bool scoreInitSystem();
 void scoreUpdateVar(DATA_INDEX var);
 void scoreDataToConsole();
-void scoreDataToScreen(WIDGET *psWidget);
+void scoreDataToScreen(WIDGET *psWidget, ScoreDataToScreenCache& cache);
 void getAsciiTime(char *psText, unsigned time);
 bool readScoreData(const char *fileName);
 bool writeScoreData(const char *fileName);

--- a/src/seqdisp.cpp
+++ b/src/seqdisp.cpp
@@ -112,6 +112,9 @@ static SEQLIST aSeqList[MAX_SEQ_LIST];
 static SDWORD currentSeq = -1;
 static SDWORD currentPlaySeq = -1;
 
+// local rendered text cache
+static std::vector<WzText> wzCachedSeqText;
+
 /***************************************************************************/
 /*
  *	local ProtoTypes
@@ -340,17 +343,20 @@ bool seq_UpdateFullScreenVideo(int *pbClear)
 			if (((realTime >= currentText.startTime) && (realTime <= currentText.endTime)) ||
 			    (aSeqList[currentPlaySeq].bSeqLoop)) //if its a looped video always draw the text
 			{
+				if (i >= wzCachedSeqText.size())
+				{
+					wzCachedSeqText.resize(i + 1);
+				}
 				if (bMoreThanOneSequenceLine)
 				{
 					currentText.x = 20 + D_W2;
 				}
-				iV_SetTextColour(WZCOL_GREY);
-				iV_DrawText(&(currentText.pText[0]), currentText.x - 1, currentText.y - 1, font_scaled);
-				iV_DrawText(&(currentText.pText[0]), currentText.x - 1, currentText.y + 1, font_scaled);
-				iV_DrawText(&(currentText.pText[0]), currentText.x - 1, currentText.y + 1, font_scaled);
-				iV_DrawText(&(currentText.pText[0]), currentText.x + 1, currentText.y + 1, font_scaled);
-				iV_SetTextColour(WZCOL_WHITE);
-				iV_DrawText(&(currentText.pText[0]), currentText.x, currentText.y, font_scaled);
+				wzCachedSeqText[i].setText(&(currentText.pText[0]), font_scaled);
+				wzCachedSeqText[i].render(currentText.x - 1, currentText.y - 1, WZCOL_GREY);
+				wzCachedSeqText[i].render(currentText.x - 1, currentText.y + 1, WZCOL_GREY);
+				wzCachedSeqText[i].render(currentText.x + 1, currentText.y - 1, WZCOL_GREY);
+				wzCachedSeqText[i].render(currentText.x + 1, currentText.y + 1, WZCOL_GREY);
+				wzCachedSeqText[i].render(currentText.x, currentText.y, WZCOL_WHITE);
 			}
 		}
 	}
@@ -390,6 +396,8 @@ bool seq_StopFullScreenVideo()
 	}
 
 	seq_Shutdown();
+
+	wzCachedSeqText.clear();
 
 	return true;
 }

--- a/src/transporter.cpp
+++ b/src/transporter.cpp
@@ -185,7 +185,9 @@ bool intAddTransporter(DROID *psSelected, bool offWorld)
 
 	IntFormAnimated *transForm = new IntFormAnimated(parent, Animate);  // Do not animate the opening, if the window was already open.
 	transForm->id = IDTRANS_FORM;
-	transForm->setGeometry(TRANS_X, TRANS_Y, TRANS_WIDTH, TRANS_HEIGHT);
+	transForm->setCalcLayout(LAMBDA_CALCLAYOUT_SIMPLE({
+		psWidget->setGeometry(TRANS_X, TRANS_Y, TRANS_WIDTH, TRANS_HEIGHT);
+	}));
 
 	/* Add the close button */
 	W_BUTINIT sButInit;
@@ -244,16 +246,17 @@ bool intAddTransporterContents()
 
 	IntFormAnimated *transContentForm = new IntFormAnimated(parent, Animate);  // Do not animate the opening, if the window was already open.
 	transContentForm->id = IDTRANS_CONTENTFORM;
-	transContentForm->setGeometry(TRANSCONT_X, TRANSCONT_Y, TRANSCONT_WIDTH, TRANSCONT_HEIGHT);
+	transContentForm->setCalcLayout(LAMBDA_CALCLAYOUT_SIMPLE({
+		psWidget->setGeometry(TRANSCONT_X, TRANSCONT_Y, TRANSCONT_WIDTH, TRANSCONT_HEIGHT);
+	}));
 
 	/* Add the close button */
 	W_BUTINIT sButInit;
 	sButInit.formID = IDTRANS_CONTENTFORM;
 	sButInit.id = IDTRANS_CONTCLOSE;
-	sButInit.x = STAT_WIDTH - CLOSE_WIDTH;
-	sButInit.y = 0;
-	sButInit.width = CLOSE_WIDTH;
-	sButInit.height = CLOSE_HEIGHT;
+	sButInit.calcLayout = (LAMBDA_CALCLAYOUT_SIMPLE({
+		psWidget->setGeometry(STAT_WIDTH - CLOSE_WIDTH, 0, CLOSE_WIDTH, CLOSE_HEIGHT);
+	}));
 	sButInit.pTip = _("Close");
 	sButInit.pDisplay = intDisplayImageHilight;
 	sButInit.UserData = PACKDWORD_TRI(0, IMAGE_CLOSEHILIGHT , IMAGE_CLOSE);
@@ -522,16 +525,17 @@ bool intAddDroidsAvailForm()
 	/* Add the droids available form */
 	IntFormAnimated *transDroids = new IntFormAnimated(parent, Animate);  // Do not animate the opening, if the window was already open.
 	transDroids->id = IDTRANS_DROIDS;
-	transDroids->setGeometry(TRANSDROID_X, TRANSDROID_Y, TRANSDROID_WIDTH, TRANSDROID_HEIGHT);
+	transDroids->setCalcLayout(LAMBDA_CALCLAYOUT_SIMPLE({
+		psWidget->setGeometry(TRANSDROID_X, TRANSDROID_Y, TRANSDROID_WIDTH, TRANSDROID_HEIGHT);
+	}));
 
 	/* Add the close button */
 	W_BUTINIT sButInit;
 	sButInit.formID = IDTRANS_DROIDS;
 	sButInit.id = IDTRANS_DROIDCLOSE;
-	sButInit.x = TRANSDROID_WIDTH - CLOSE_WIDTH;
-	sButInit.y = 0;
-	sButInit.width = CLOSE_WIDTH;
-	sButInit.height = CLOSE_HEIGHT;
+	sButInit.calcLayout = (LAMBDA_CALCLAYOUT_SIMPLE({
+		psWidget->setGeometry(TRANSDROID_WIDTH - CLOSE_WIDTH, 0, CLOSE_WIDTH, CLOSE_HEIGHT);
+	}));
 	sButInit.pTip = _("Close");
 	sButInit.pDisplay = intDisplayImageHilight;
 	sButInit.UserData = PACKDWORD_TRI(0, IMAGE_CLOSEHILIGHT , IMAGE_CLOSE);
@@ -543,10 +547,14 @@ bool intAddDroidsAvailForm()
 	//now add the tabbed droids available form
 	IntListTabWidget *droidList = new IntListTabWidget(transDroids);
 	droidList->id = IDTRANS_DROIDTAB;
-	droidList->setChildSize(OBJ_BUTWIDTH, OBJ_BUTHEIGHT);
-	droidList->setChildSpacing(OBJ_GAP, OBJ_GAP);
-	int droidListWidth = OBJ_BUTWIDTH * 2 + OBJ_GAP;
-	droidList->setGeometry((TRANSDROID_WIDTH - droidListWidth) / 2, AVAIL_STARTY + 15, droidListWidth, TRANSDROID_HEIGHT - (AVAIL_STARTY + 15));
+	droidList->setCalcLayout(LAMBDA_CALCLAYOUT_SIMPLE({
+		IntListTabWidget *droidList = static_cast<IntListTabWidget *>(psWidget);
+		assert(droidList != nullptr);
+		droidList->setChildSize(OBJ_BUTWIDTH, OBJ_BUTHEIGHT);
+		droidList->setChildSpacing(OBJ_GAP, OBJ_GAP);
+		int droidListWidth = OBJ_BUTWIDTH * 2 + OBJ_GAP;
+		droidList->setGeometry((TRANSDROID_WIDTH - droidListWidth) / 2, AVAIL_STARTY + 15, droidListWidth, TRANSDROID_HEIGHT - (AVAIL_STARTY + 15));
+	}));
 
 	/* Add the droids available buttons */
 	int nextButtonId = IDTRANS_DROIDSTART;

--- a/src/warzoneconfig.cpp
+++ b/src/warzoneconfig.cpp
@@ -40,6 +40,7 @@ struct WARZONE_GLOBALS
 	FMV_MODE FMVmode = FMV_FULLSCREEN;
 	UDWORD width = 1024;
 	UDWORD height = 768;
+	int displayScale = 100;
 	int screen = 0;
 	int8_t SPcolor = 0;
 	int MPcolour = -1;
@@ -131,6 +132,16 @@ void war_SetVsync(bool b)
 bool war_GetVsync()
 {
 	return warGlobs.vsync;
+}
+
+unsigned int war_GetDisplayScale()
+{
+	return warGlobs.displayScale;
+}
+
+void war_SetDisplayScale(unsigned int scale)
+{
+	warGlobs.displayScale = scale;
 }
 
 void war_SetWidth(UDWORD width)

--- a/src/warzoneconfig.h
+++ b/src/warzoneconfig.h
@@ -65,6 +65,8 @@ bool war_GetColouredCursor();
 void war_SetColouredCursor(bool enabled);
 void war_SetVsync(bool b);
 bool war_GetVsync();
+void war_SetDisplayScale(unsigned int scale);
+unsigned int war_GetDisplayScale();
 void war_SetWidth(UDWORD width);
 UDWORD war_GetWidth();
 void war_SetScreen(int screen);


### PR DESCRIPTION
Trac: [#4720](http://developer.wz2100.net/ticket/4720)

### Overview

1. Internal enhancements to support screen / game / rendering scaling factors.
2. Internal enhancements to support live window resizing / resolution changes.
3. Internal enhancements to support **UI layout recalculation**.
4. **Support for live window resizing / resolution changes.**<sup>[SDL backend]</sup>
5. **"Display Scale"** option in the Video options menu, offering 100%+ display scaling options. <sup>[SDL backend]</sup>
6. Automatic high-DPI ("retina") display support. <sup>[macOS-only]</sup>
7. Better caching of text rasterization and reduction in unnecessary OpenGL state changes (required to support higher display scaling levels).
8. Better clipping and other small tweaks (required to support higher display scaling levels).

-----

### General

These changes all essentially depend on each other, thus this is a single PR.

### Additional Details

1. Text and other rendering now supports scaling factors.
2. New functions in all of the various UI-related components / files enable a call to a new parent `gameScreenSizeDidChange` function that distributes notifications of screen size changes.
3. Several enhancements of note:
    - `WIDGET` now supports a new `calcLayout` callback function / lambda that is called when layout needs to be recalculated.
    - `WIDGET` now supports a new `onDelete` callback function / lambda that is called when the instance is about to be deleted.
    - `W_INIT` now supports a new `initPUserDataFunc` attribute which can be used to initialize the `pUserData` pointer per widget instance.
    - Parent `WIDGET`s automatically distribute screen size change notifications to all children.
    - Where needed, UI widgets have been migrated to setting a `calcLayout` lambda.
4. Simply open the **Video options** and change the Resolution. **Or resize the window at the corners / edges** (as supported by your OS).
    > Current Limitations:
    > - Only live resolution changes **in the current mode** are supported. If you change the display mode (windowed / fullscreen), changes will be queued until Warzone is restarted (matching previous behavior). This is due to several current SDL quirks.
    > - **Live resizing is disabled while in a multiplayer game** because pausing is disabled in multiplayer games (and with how the current event loop + SDL works, the game effectively pauses while the window is being actively resized).
    > - Only the SDL backend currently supports live resizing. Compiling with the QT backend will revert to the prior behavior.
5. Open the **Video options** and select from the new **Display Scale** percentages (100%+) available at the current window size. (Display scale options are limited by the window / screen size, as no combination can result in a logical screen size lower than the minimum supported by Warzone. Hence, only users with very large displays - and the Warzone window expanded on those displays - will see the highest display scaling options. Most users probably won't see over 250% available.)
    > Current Limitations:
    > - Only the SDL backend currently supports Display Scale options. Compiling with the QT backend will not currently show the Display Scale option in the menu.
6. On macOS, automatic support for high-DPI ("retina") displays is enabled. Once a future version of SDL enables proper support for other OSes, they can be supported.
7. Some highlights:
    - Switched over most text rendering to using the improved `WzText`, which caches and reduces text rasterization calls by over 99%, for a significant performance win. (Previously, most text was being re-rasterized on every frame, even if unchanged.)
    - A lot of time was previously being wasted disabling shaders... in loops that just kept enabling / disabling the same shader. New functions to batch calls and moving `pie_DeactivateShader` outside of loops yield a significant performance improvement (especially when running at higher display scaling modes that necessarily stress the engine more).
8. Previously, the game engine spent a lot of time rendering things that were far off the visible screen. More accurate clipping techniques yield a large reduction in wasted non-visible drawing.
