### PR TITLE
Some changes to fix #4677

### DIFF
--- a/src/design.cpp
+++ b/src/design.cpp
@@ -69,7 +69,7 @@
 
 
 #define MAX_DESIGN_COMPONENTS 40		// Max number of stats the design screen can cope with.
-#define MAX_SYSTEM_COMPONENTS 128
+#define MAX_SYSTEM_COMPONENTS 65535
 
 
 /***************************************************************************************/

--- a/src/design.h
+++ b/src/design.h
@@ -107,8 +107,8 @@
 #define IDDES_TEMPLEND			5339		// The last design template button
 #define IDDES_BARSTART			5400
 #define IDDES_BAREND			5499
-#define IDDES_COMPSTART			5500		// The first component button
-#define IDDES_COMPEND			5699		// The last component button
+#define IDDES_COMPSTART			5500000		// The first component button
+#define IDDES_COMPEND			5565535		// The last component button
 #define IDDES_EXTRASYSSTART		5700		// The first extra system button
 #define IDDES_EXTRASYSEND		5899		// The last extra system button
 

--- a/src/droid.cpp
+++ b/src/droid.cpp
@@ -1364,7 +1364,7 @@ UDWORD calcDroidWeight(DROID_TEMPLATE *psTemplate)
 	return weight;
 }
 
-static uint32_t calcDroidOrTemplateBody(uint8_t (&asParts)[DROID_MAXCOMP], unsigned numWeaps, uint16_t (&asWeaps)[MAX_WEAPONS], unsigned player)
+static uint32_t calcDroidOrTemplateBody(uint8_t (&asParts)[DROID_MAXCOMP], unsigned numWeaps, uint32_t (&asWeaps)[MAX_WEAPONS], unsigned player)
 {
 	const auto &bodyStats = asBodyStats[asParts[COMP_BODY]];
 
@@ -1419,7 +1419,7 @@ UDWORD calcTemplateBody(DROID_TEMPLATE *psTemplate, UBYTE player)
 // Calculate the base body points of a droid with upgrades
 static UDWORD calcDroidBaseBody(DROID *psDroid)
 {
-	uint16_t asWeaps[MAX_WEAPONS];
+	uint32_t asWeaps[MAX_WEAPONS];
 	std::transform(std::begin(psDroid->asWeaps), std::end(psDroid->asWeaps), asWeaps, [](WEAPON &weap) {
 		return weap.nStat;
 	});

--- a/src/droiddef.h
+++ b/src/droiddef.h
@@ -67,8 +67,8 @@ struct DROID_TEMPLATE : public BASE_STATS
 	 */
 	uint8_t         asParts[DROID_MAXCOMP];
 	/* The weapon systems */
-	int16_t          numWeaps;                   ///< Number of weapons
-	uint16_t         asWeaps[MAX_WEAPONS];       ///< weapon indices
+	int8_t          numWeaps;                   ///< Number of weapons
+	uint32_t        asWeaps[MAX_WEAPONS];       ///< weapon indices
 	DROID_TYPE      droidType;                  ///< The type of droid
 	UDWORD          multiPlayerID;              ///< multiplayer unique descriptor(cant use id's for templates). Used for save games as well now - AB 29/10/98
 	bool            prefab;                     ///< Not player designed, not saved, never delete or change

--- a/src/hci.h
+++ b/src/hci.h
@@ -219,8 +219,8 @@ enum  				  // Reticule button indecies.
 #define STAT_POWERBARY			(OBJ_BUTHEIGHT-STAT_PROGBARHEIGHT-6)
 
 /* maximum array sizes */
-#define	MAXSTRUCTURES	200	//bumped up from 80.  NOTE: was used for max # in build menus.
-#define	MAXRESEARCH		200 //was 80 topic displayed   "           "
+#define	MAXSTRUCTURES	65535	//bumped up from 80.  NOTE: was used for max # in build menus.
+#define	MAXRESEARCH		65535	//was 80 topic displayed   "           "
 #define	MAXFEATURES		80
 #define	MAXCOMPONENT	200
 #define	MAXEXTRASYS		80

--- a/src/multibot.cpp
+++ b/src/multibot.cpp
@@ -346,10 +346,10 @@ bool SendDroid(DROID_TEMPLATE *pTemplate, uint32_t x, uint32_t y, uint8_t player
 		NETuint8_t(&pTemplate->asParts[COMP_ECM]);
 		NETuint8_t(&pTemplate->asParts[COMP_SENSOR]);
 		NETuint8_t(&pTemplate->asParts[COMP_CONSTRUCT]);
-		NETint16_t(&pTemplate->numWeaps);
+		NETint8_t(&pTemplate->numWeaps);
 		for (int i = 0; i < pTemplate->numWeaps; i++)
 		{
-			NETuint16_t(&pTemplate->asWeaps[i]);
+			NETuint32_t(&pTemplate->asWeaps[i]);
 		}
 		NETbool(&haveInitialOrders);
 		if (haveInitialOrders)
@@ -394,11 +394,11 @@ bool recvDroid(NETQUEUE queue)
 		NETuint8_t(&pT->asParts[COMP_ECM]);
 		NETuint8_t(&pT->asParts[COMP_SENSOR]);
 		NETuint8_t(&pT->asParts[COMP_CONSTRUCT]);
-		NETint16_t(&pT->numWeaps);
+		NETint8_t(&pT->numWeaps);
 		ASSERT_OR_RETURN(false, pT->numWeaps >= 0 && pT->numWeaps <= ARRAY_SIZE(pT->asWeaps), "Bad numWeaps %d", pT->numWeaps);
 		for (int i = 0; i < pT->numWeaps; i++)
 		{
-			NETuint16_t(&pT->asWeaps[i]);
+			NETuint32_t(&pT->asWeaps[i]);
 		}
 		NETbool(&haveInitialOrders);
 		if (haveInitialOrders)

--- a/src/multistruct.cpp
+++ b/src/multistruct.cpp
@@ -295,10 +295,10 @@ void sendStructureInfo(STRUCTURE *psStruct, STRUCTURE_INFO structureInfo_, DROID
 		NETuint8_t(&pT->asParts[COMP_ECM]);
 		NETuint8_t(&pT->asParts[COMP_SENSOR]);
 		NETuint8_t(&pT->asParts[COMP_CONSTRUCT]);
-		NETint16_t(&pT->numWeaps);
+		NETint8_t(&pT->numWeaps);
 		for (int i = 0; i < pT->numWeaps; i++)
 		{
-			NETuint16_t(&pT->asWeaps[i]);
+			NETuint32_t(&pT->asWeaps[i]);
 		}
 	}
 	NETend();
@@ -329,11 +329,11 @@ void recvStructureInfo(NETQUEUE queue)
 		NETuint8_t(&pT->asParts[COMP_ECM]);
 		NETuint8_t(&pT->asParts[COMP_SENSOR]);
 		NETuint8_t(&pT->asParts[COMP_CONSTRUCT]);
-		NETint16_t(&pT->numWeaps);
+		NETint8_t(&pT->numWeaps);
 		ASSERT_OR_RETURN(, pT->numWeaps >= 0 && pT->numWeaps <= ARRAY_SIZE(pT->asWeaps), "Bad numWeaps %d", pT->numWeaps);
 		for (int i = 0; i < pT->numWeaps; i++)
 		{
-			NETuint16_t(&pT->asWeaps[i]);
+			NETuint32_t(&pT->asWeaps[i]);
 		}
 		pT->droidType = (DROID_TYPE)droidType;
 		pT = copyTemplate(player, pT);


### PR DESCRIPTION
Bumped up MAXSTRUCTURES and MAXRESEARCH to display more parts in widgets
Return numWeaps int16_t back to int8_t as Cyp recommended and it works.
Change asWeaps uint16_t to uint32_t to save some bytes in the serializer
Briefly tested, seems to work.