### PR TITLE
Fix various memory leaks

### DIFF
--- a/lib/ivis_opengl/bitimage.cpp
+++ b/lib/ivis_opengl/bitimage.cpp
@@ -202,6 +202,7 @@ IMAGEFILE *iV_LoadImageFile(const char *fileName)
 		{
 			debug(LOG_ERROR, "Bad line in \"%s\".", fileName);
 			delete imageFile;
+			free(pFileData);
 			return nullptr;
 		}
 		imageFile->imageNames[numImages].first = tmpName;
@@ -215,6 +216,7 @@ IMAGEFILE *iV_LoadImageFile(const char *fileName)
 		{
 			debug(LOG_ERROR, "Failed to find image \"%s\" listed in \"%s\".", spriteName.c_str(), fileName);
 			delete imageFile;
+			free(pFileData);
 			return nullptr;
 		}
 		imageRect->siz = Vector2i(imageRect->data->width, imageRect->data->height);

--- a/lib/ivis_opengl/imdload.cpp
+++ b/lib/ivis_opengl/imdload.cpp
@@ -130,11 +130,13 @@ static bool tryLoad(const QString &path, const QString &filename)
 			return false;
 		}
 		fileEnd = pFileData + size;
-		iIMDShape *s = iV_ProcessIMD(filename, (const char **)&pFileData, fileEnd);
+		const char *pFileDataPt = pFileData;
+		iIMDShape *s = iV_ProcessIMD(filename, (const char **)&pFileDataPt, fileEnd);
 		if (s)
 		{
 			models.insert(filename, s);
 		}
+		free(pFileData);
 		return true;
 	}
 	return false;
@@ -700,6 +702,7 @@ static iIMDShape *_imd_load_level(const QString &filename, const char **ppFileDa
 		if (sscanf(pFileData, "%255s %255s %255s%n", buffer, vertex, fragment, &cnt) != 3)
 		{
 			debug(LOG_ERROR, "%s shader corrupt: %s", filename.toUtf8().constData(), buffer);
+			delete s;
 			return nullptr;
 		}
 		std::vector<std::string> uniform_names { "colour", "teamcolour", "stretch", "tcmask", "fogEnabled", "normalmap",
@@ -711,6 +714,7 @@ static iIMDShape *_imd_load_level(const QString &filename, const char **ppFileDa
 	if (sscanf(pFileData, "%255s %d%n", buffer, &s->npoints, &cnt) != 2)
 	{
 		debug(LOG_ERROR, "_imd_load_level(2): file corrupt");
+		delete s;
 		return nullptr;
 	}
 	pFileData += cnt;
@@ -761,6 +765,7 @@ static iIMDShape *_imd_load_level(const QString &filename, const char **ppFileDa
 			if (sscanf(pFileData, "%d %d%n", &s->objanimcycles, &s->objanimframes, &cnt) != 2)
 			{
 				debug(LOG_ERROR, "%s bad ANIMOBJ: %s", filename.toUtf8().constData(), pFileData);
+				delete s;
 				return nullptr;
 			}
 			pFileData += cnt;

--- a/lib/ivis_opengl/textdraw.cpp
+++ b/lib/ivis_opengl/textdraw.cpp
@@ -93,7 +93,6 @@ struct FTFace
 	FTFace(FT_Library &lib, const std::string &fileName, int32_t charSize, int32_t horizDPI, int32_t vertDPI)
 	{
 		UDWORD pFileSize = 0;
-		char *pFileData = nullptr;
 		if (!loadFile(fileName.c_str(), &pFileData, &pFileSize))
 		{
 			debug(LOG_FATAL, "Unknown font file format for %s", fileName.c_str());
@@ -119,6 +118,10 @@ struct FTFace
 	{
 		hb_font_destroy(m_font);
 		FT_Done_Face(m_face);
+		if (pFileData != nullptr)
+		{
+			free(pFileData);
+		}
 	}
 
 	uint32_t getGlyphWidth(uint32_t codePoint)
@@ -192,6 +195,7 @@ struct FTFace
 	FT_Face &face() { return m_face; }
 
 	hb_font_t *m_font;
+	char *pFileData = nullptr;
 
 private:
 	FT_Face m_face;

--- a/src/multistat.cpp
+++ b/src/multistat.cpp
@@ -175,21 +175,24 @@ bool loadMultiStats(char *sPlayerName, PLAYERSTATS *st)
 	// check player already exists
 	if (PHYSFS_exists(fileName))
 	{
-		loadFile(fileName, &pFileData, &size);
-
-		if (strncmp(pFileData, "WZ.STA.v3", 9) != 0)
+		if (loadFile(fileName, &pFileData, &size))
 		{
-			return false; // wrong version or not a stats file
-		}
+			if (strncmp(pFileData, "WZ.STA.v3", 9) != 0)
+			{
+				free(pFileData);
+				pFileData = nullptr;
+				return false; // wrong version or not a stats file
+			}
 
-		char identity[1001];
-		identity[0] = '\0';
-		sscanf(pFileData, "WZ.STA.v3\n%u %u %u %u %u\n%1000[A-Za-z0-9+/=]",
-		       &st->wins, &st->losses, &st->totalKills, &st->totalScore, &st->played, identity);
-		free(pFileData);
-		if (identity[0] != '\0')
-		{
-			st->identity.fromBytes(base64Decode(identity), EcKey::Private);
+			char identity[1001];
+			identity[0] = '\0';
+			sscanf(pFileData, "WZ.STA.v3\n%u %u %u %u %u\n%1000[A-Za-z0-9+/=]",
+				   &st->wins, &st->losses, &st->totalKills, &st->totalScore, &st->played, identity);
+			free(pFileData);
+			if (identity[0] != '\0')
+			{
+				st->identity.fromBytes(base64Decode(identity), EcKey::Private);
+			}
 		}
 	}
 


### PR DESCRIPTION
- Fix memory leaks related to loading files
   The memory buffer allocated by `loadFile` (or subsequent processing) was not always properly freed.
- Fix memory leak related to releasing Font resources
   Font resources may now be reinitialized when DPI / scaling changes occur, which revealed the pre-existing leak.