### PR TITLE
Use `#ifdef DEBUG` instead of `#if DEBUG`

### DIFF
--- a/lib/widget/widget.cpp
+++ b/lib/widget/widget.cpp
@@ -220,7 +220,7 @@ void WIDGET::callCalcLayout()
 	{
 		calcLayout(this, screenWidth, screenHeight, screenWidth, screenHeight);
 	}
-#if DEBUG
+#ifdef DEBUG
 //	// FOR DEBUGGING:
 //	// To help track down WIDGETs missing a calc layout function
 //	// (because something isn't properly re-adjusting when live window resizing occurs)


### PR DESCRIPTION
Depending on settings / compiler, `#if DEBUG` can result in a compiler error.
(Example: `fatal error C1017: invalid integer constant expression`)

Use `#ifdef DEBUG` instead.