### PR TITLE
Fix crash when failing a mission (and attempting to draw the results screen)

### DIFF
--- a/src/mission.cpp
+++ b/src/mission.cpp
@@ -2312,7 +2312,7 @@ static bool _intAddMissionResult(bool result, bool bPlaySuccess, bool showBackDr
 	sButInit.width		= MISSION_TEXT_W;
 	sButInit.height		= MISSION_TEXT_H;
 	sButInit.pDisplay	= displayTextOption;
-	sButInit.pUserData = new DisplayTextOptionCache();
+	sButInit.initPUserDataFunc = []() -> void * { return new DisplayTextOptionCache(); };
 	sButInit.onDelete = [](WIDGET *psWidget) {
 		assert(psWidget->pUserData != nullptr);
 		delete static_cast<DisplayTextOptionCache *>(psWidget->pUserData);


### PR DESCRIPTION
Since `sButInit` is a `W_BUTINIT` that is **re-used** on failure, `initPUserDataFunc` must be used (instead of setting `pUserData`) to ensure that each created `W_BUTTON` instance has a unique `DisplayTextOptionCache` in its `pUserData`.