### PR TITLE
Fix crash when host drops connection (and attempting to draw the in-game popup menu)

### DIFF
--- a/src/ingameop.cpp
+++ b/src/ingameop.cpp
@@ -312,7 +312,7 @@ void intAddInGamePopup()
 	sButInit.x			= 0;
 	sButInit.height		= 10;
 	sButInit.pDisplay	= displayTextOption;
-	sButInit.pUserData = new DisplayTextOptionCache();
+	sButInit.initPUserDataFunc = []() -> void * { return new DisplayTextOptionCache(); };
 	sButInit.onDelete = [](WIDGET *psWidget) {
 		assert(psWidget->pUserData != nullptr);
 		delete static_cast<DisplayTextOptionCache *>(psWidget->pUserData);


### PR DESCRIPTION
Since `sButInit` is a `W_BUTINIT` that is **re-used**, `initPUserDataFunc` must be used (instead of setting `pUserData`) to ensure that each created `W_BUTTON` instance has a unique `DisplayTextOptionCache` in its `pUserData`.