### PR TITLE
Improve the drawing performance of the Multiplayer Lobby screen

### DIFF
--- a/lib/ivis_opengl/textdraw.cpp
+++ b/lib/ivis_opengl/textdraw.cpp
@@ -942,3 +942,25 @@ void WzText::render(Vector2i position, PIELIGHT colour, float rotation)
 	iV_DrawImageText(*texture, position, Vector2f(offsets.x / mRenderingHorizScaleFactor, offsets.y / mRenderingVertScaleFactor), Vector2f(dimensions.x / mRenderingHorizScaleFactor, dimensions.y / mRenderingVertScaleFactor), rotation, REND_TEXT, colour);
 	glEnable(GL_CULL_FACE);
 }
+
+// Sets the text, truncating to a desired width limit (in *points*) if needed
+// returns: the length of the string that will be drawn (may be less than the input text.length() if truncated)
+size_t WidthLimitedWzText::setTruncatableText(const std::string &text, iV_fonts fontID, size_t limitWidthInPoints)
+{
+	if ((mFullText == text) && (mLimitWidthPts == limitWidthInPoints) && (getFontID() == fontID))
+	{
+		return getText().length(); // skip; no change
+	}
+
+	mFullText = text;
+	mLimitWidthPts = limitWidthInPoints;
+
+	std::string truncatedText = text;
+	while ((truncatedText.length() > 0) && (iV_GetTextWidth(truncatedText.c_str(), fontID) > limitWidthInPoints))
+	{
+		truncatedText.pop_back();
+	}
+
+	WzText::setText(truncatedText, fontID);
+	return truncatedText.length();
+}

--- a/lib/ivis_opengl/textdraw.h
+++ b/lib/ivis_opengl/textdraw.h
@@ -60,6 +60,10 @@ public:
 	WzText& operator=(WzText&& other);
 	WzText(WzText&& other);
 
+protected:
+	const std::string& getText() { return mText; }
+	iV_fonts getFontID() { return mFontID; }
+
 private:
 	void drawAndCacheText(const std::string &text, iV_fonts fontID);
 	void redrawAndCacheText();
@@ -75,6 +79,18 @@ private:
 	Vector2i dimensions;
 	float mRenderingHorizScaleFactor = 0.f;
 	float mRenderingVertScaleFactor = 0.f;
+};
+
+class WidthLimitedWzText: public WzText
+{
+public:
+	// Sets the text, truncating to a desired width limit (in *points*) if needed
+	// returns: the length of the string that will be drawn (may be less than the input text.length() if truncated)
+	size_t setTruncatableText(const std::string &text, iV_fonts fontID, size_t limitWidthInPoints);
+
+private:
+	std::string mFullText;
+	size_t mLimitWidthPts = 0;
 };
 
 /**


### PR DESCRIPTION
- Add `WidthLimitedWzText`, for simple, cached, width-limited (truncatable) text display
- Improve the drawing performance of the Multiplayer Lobby screen
   Previously, text was rasterized when drawing every frame. Adding text caching (`WzText`, `WidthLimitedWzText`) drastically reduces work done per frame (and, thus, reduces CPU usage when viewing the Multiplayer Lobby screen).

   (On a high-DPI test system, CPU usage on this screen went from 64% to 14%.)