### PR TITLE
Fix QScriptEngine forward-declaration warning

### DIFF
--- a/src/hci.h
+++ b/src/hci.h
@@ -38,7 +38,7 @@ struct PROXIMITY_DISPLAY;
 struct STRUCTURE;
 struct W_SCREEN;
 struct iIMDShape;
-struct QScriptEngine;
+class QScriptEngine;
 
 enum  				  // Reticule button indecies.
 {


### PR DESCRIPTION
`Warning: (Class / Struct) 'QScriptEngine' was previously declared as a (struct / class)`

QScriptEngine is a class.

(Fixes 25 warnings on macOS builds.)