### PR TITLE
Empty strings should not be wrapped for gettext

### DIFF
--- a/src/frontend.cpp
+++ b/src/frontend.cpp
@@ -1006,9 +1006,9 @@ void videoOptionsDisableResolutionButtons(QString toolTip)
 void videoOptionsEnableResolutionButtons()
 {
 	widgSetButtonState(psWScreen, FRONTEND_RESOLUTION, 0);
-	widgSetTip(psWScreen, FRONTEND_RESOLUTION, _(""));
+	widgSetTip(psWScreen, FRONTEND_RESOLUTION, "");
 	widgSetButtonState(psWScreen, FRONTEND_RESOLUTION_R, 0);
-	widgSetTip(psWScreen, FRONTEND_RESOLUTION_R, _(""));
+	widgSetTip(psWScreen, FRONTEND_RESOLUTION_R, "");
 }
 
 static char const *videoOptionsWindowModeString()


### PR DESCRIPTION
Fixes:
`src/frontend.cpp:1009: warning: Empty msgid.  It is reserved by GNU gettext:`
`src/frontend.cpp:1011: warning: Empty msgid.  It is reserved by GNU gettext:`