### PR TITLE
configure.ac: Enable DEP and ASLR for Windows builds

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -125,7 +125,7 @@ case ${host_os} in
 		AC_CHECK_TOOL([WINDRES], [windres], AC_MSG_ERROR([windres not found]))
 		WIN32_LIBS='-ldbghelp -lshfolder -lshlwapi -lpsapi -lshell32 -lwinmm -lws2_32 -liphlpapi -ladvapi32'
 		AC_SUBST([WIN32_LIBS], [${WIN32_LIBS}])
-		LDFLAGS="-Wl,-subsystem,windows ${LDFLAGS}"
+		LDFLAGS="-Wl,-subsystem,windows ${LDFLAGS} -Wl,--dynamicbase -Wl,--nxcompat"
 		;;
 	*)
 		# Some platforms don't need _XOPEN_SOURCE


### PR DESCRIPTION
Opt-in *Makefile* (autoconf) Windows builds to these standard Windows security features (Data Execution Prevention and Address Space Layout Randomization).

Affects mingw32 builds using the Makefile generated by autoconf + configure.
(A prior commit enabled this for CMake Windows builds.)