### PR TITLE
Replace remaining QT signals / slots in Widgets

### DIFF
--- a/lib/widget/CMakeLists.txt
+++ b/lib/widget/CMakeLists.txt
@@ -1,10 +1,8 @@
 cmake_minimum_required (VERSION 3.5)
 project (widget CXX)
 
-qt5_wrap_cpp(MOCFILES bar.h button.h editbox.h form.h label.h listwidget.h slider.h widgbase.h)
-
 file(GLOB HEADERS "*.h")
 file(GLOB SRC "*.cpp")
 
-add_library(widget ${HEADERS} ${SRC} ${MOCFILES})
+add_library(widget ${HEADERS} ${SRC})
 target_link_libraries(widget PRIVATE framework ivis-opengl)

--- a/lib/widget/Makefile.am
+++ b/lib/widget/Makefile.am
@@ -2,8 +2,11 @@ AM_CPPFLAGS = $(SDL_CFLAGS) $(WZ_CPPFLAGS) $(QT5_CFLAGS)
 AM_CFLAGS = $(WZ_CFLAGS)
 AM_CXXFLAGS = $(WZ_CXXFLAGS) $(QT5_CFLAGS)
 
-# Signals/slots
-MOCHEADER = \
+noinst_LIBRARIES = libwidget.a
+noinst_HEADERS = \
+	tip.h \
+	widget.h \
+	widgint.h \
 	bar.h \
 	button.h \
 	editbox.h \
@@ -13,20 +16,6 @@ MOCHEADER = \
 	slider.h \
 	widgbase.h
 
-MOCEDFILES = $(MOCHEADER:%.h=%_moc.cpp)
-%_moc.cpp: %.h
-	$(MOC5) -o $@ $<
-CLEANFILES = \
-	$(MOCEDFILES)
-
-noinst_LIBRARIES = libwidget.a
-noinst_HEADERS = \
-	tip.h \
-	widget.h \
-	widgint.h \
-	$(MOCHEADER)
-
-#"nodist_libwidget_a_SOURCES = $(MOCEDFILES)" doesn't work here (not sure why).
 nodist_libwidget_a_SOURCES = \
 	bar_moc.cpp \
 	button_moc.cpp \

--- a/lib/widget/bar.h
+++ b/lib/widget/bar.h
@@ -29,7 +29,6 @@
 
 class W_BARGRAPH : public WIDGET
 {
-	Q_OBJECT
 
 public:
 	W_BARGRAPH(W_BARINIT const *init);

--- a/lib/widget/button.cpp
+++ b/lib/widget/button.cpp
@@ -143,7 +143,16 @@ void W_BUTTON::released(W_CONTEXT *, WIDGET_KEY key)
 		if ((!(style & WBUT_NOPRIMARY) && key == WKEY_PRIMARY) ||
 		    ((style & WBUT_SECONDARY) && key == WKEY_SECONDARY))
 		{
-			emit clicked();
+			/* Call all onClick event handlers */
+			for (auto it = onClickHandlers.begin(); it != onClickHandlers.end(); it++)
+			{
+				auto onClickHandler = *it;
+				if (onClickHandler)
+				{
+					onClickHandler(*this);
+				}
+			}
+
 			screenPointer->setReturn(this);
 			state &= ~WBUT_DOWN;
 			dirty = true;
@@ -262,6 +271,11 @@ void W_BUTTON::setImages(Image image, Image imageDown, Image imageHighlight, Ima
 {
 	dirty = true;
 	setImages(Images(image, imageDown, imageHighlight, imageDisabled));
+}
+
+void W_BUTTON::addOnClickHandler(const W_BUTTON_ONCLICK_FUNC& onClickFunc)
+{
+	onClickHandlers.push_back(onClickFunc);
 }
 
 void StateButton::setState(unsigned state)

--- a/lib/widget/button.h
+++ b/lib/widget/button.h
@@ -29,11 +29,11 @@
 #include "widget.h"
 #include "widgbase.h"
 #include <map>
+#include <functional>
 
 
 class W_BUTTON : public WIDGET
 {
-	Q_OBJECT
 
 public:
 	struct Images
@@ -71,8 +71,10 @@ public:
 	using WIDGET::setString;
 	using WIDGET::setTip;
 
-signals:
-	void clicked();
+	/* The optional "onClick" callback function */
+	typedef std::function<void (W_BUTTON& button)> W_BUTTON_ONCLICK_FUNC;
+
+	void addOnClickHandler(const W_BUTTON_ONCLICK_FUNC& onClickFunc);
 
 public:
 	UDWORD		state;				// The current button state
@@ -83,11 +85,12 @@ public:
 	SWORD ClickedAudioID;				// Audio ID for form hilighted sound
 	WIDGET_AUDIOCALLBACK AudioCallback;	// Pointer to audio callback function
 	iV_fonts        FontID;
+private:
+	std::vector<W_BUTTON_ONCLICK_FUNC> onClickHandlers;
 };
 
 class StateButton : public W_BUTTON
 {
-	Q_OBJECT
 
 public:
 	StateButton(WIDGET *parent) : W_BUTTON(parent) {}

--- a/lib/widget/editbox.h
+++ b/lib/widget/editbox.h
@@ -43,7 +43,6 @@ struct EditBoxDisplayCache {
 
 class W_EDITBOX : public WIDGET
 {
-	Q_OBJECT
 
 public:
 	W_EDITBOX(W_EDBINIT const *init);

--- a/lib/widget/form.h
+++ b/lib/widget/form.h
@@ -30,7 +30,6 @@
 /* The standard form */
 class W_FORM : public WIDGET
 {
-	Q_OBJECT
 
 public:
 	W_FORM(W_FORMINIT const *init);
@@ -46,7 +45,6 @@ public:
 /* The clickable form data structure */
 class W_CLICKFORM : public W_FORM
 {
-	Q_OBJECT
 
 public:
 	W_CLICKFORM(W_FORMINIT const *init);

--- a/lib/widget/label.h
+++ b/lib/widget/label.h
@@ -35,7 +35,6 @@ struct LabelDisplayCache {
 
 class W_LABEL : public WIDGET
 {
-	Q_OBJECT
 
 public:
 	W_LABEL(W_LABINIT const *init);

--- a/lib/widget/listwidget.cpp
+++ b/lib/widget/listwidget.cpp
@@ -23,7 +23,6 @@
 
 #include "listwidget.h"
 #include "button.h"
-#include <QtCore/QSignalMapper>
 #include "lib/framework/math_ext.h"
 
 TabSelectionStyle::TabSelectionStyle(Image tab, Image tabDown, Image tabHighlight, Image prev, Image prevDown, Image prevHighlight, Image next, Image nextDown, Image nextHighlight, int gap)
@@ -46,11 +45,17 @@ TabSelectionWidget::TabSelectionWidget(WIDGET *parent)
 	, tabsAtOnce(1)
 	, prevTabPageButton(new W_BUTTON(this))
 	, nextTabPageButton(new W_BUTTON(this))
-	, setTabMapper(new QSignalMapper(this))
 {
-	connect(setTabMapper, SIGNAL(mapped(int)), this, SLOT(setTab(int)));
-	connect(prevTabPageButton, SIGNAL(clicked()), this, SLOT(prevTabPage()));
-	connect(nextTabPageButton, SIGNAL(clicked()), this, SLOT(nextTabPage()));
+	prevTabPageButton->addOnClickHandler([](W_BUTTON& button) {
+		TabSelectionWidget* pParent = static_cast<TabSelectionWidget*>(button.parent());
+		assert(pParent != nullptr);
+		pParent->prevTabPage();
+	});
+	nextTabPageButton->addOnClickHandler([](W_BUTTON& button) {
+		TabSelectionWidget* pParent = static_cast<TabSelectionWidget*>(button.parent());
+		assert(pParent != nullptr);
+		pParent->nextTabPage();
+	});
 
 	prevTabPageButton->setTip(_("Tab Scroll left"));
 	nextTabPageButton->setTip(_("Tab Scroll right"));
@@ -80,7 +85,21 @@ void TabSelectionWidget::setTab(int tab)
 		return;  // Nothing to do.
 	}
 	doLayoutAll();
-	emit tabChanged(currentTab);
+
+	/* Call all onTabChanged event handlers */
+	for (auto it = onTabChangedHandlers.begin(); it != onTabChangedHandlers.end(); it++)
+	{
+		auto onTabChanged = *it;
+		if (onTabChanged)
+		{
+			onTabChanged(*this, currentTab);
+		}
+	}
+}
+
+void TabSelectionWidget::addOnTabChangedHandler(const W_TABSELECTION_ON_TAB_CHANGED_FUNC& onTabChangedFunc)
+{
+	onTabChangedHandlers.push_back(onTabChangedFunc);
 }
 
 void TabSelectionWidget::setNumberOfTabs(int tabs)
@@ -96,8 +115,11 @@ void TabSelectionWidget::setNumberOfTabs(int tabs)
 	for (unsigned n = previousSize; n < tabButtons.size(); ++n)
 	{
 		tabButtons[n] = new W_BUTTON(this);
-		connect(tabButtons[n], SIGNAL(clicked()), setTabMapper, SLOT(map()));
-		setTabMapper->setMapping(tabButtons[n], n);
+		tabButtons[n]->addOnClickHandler([n](W_BUTTON& button) {
+			TabSelectionWidget* pParent = static_cast<TabSelectionWidget*>(button.parent());
+			assert(pParent != nullptr);
+			pParent->setTab(n);
+		});
 	}
 
 	doLayoutAll();
@@ -199,7 +221,15 @@ void ListWidget::addWidgetToLayout(WIDGET *widget)
 	int numPages = pages();
 	if (oldNumPages != numPages)
 	{
-		emit numberOfPagesChanged(numPages);
+		/* Call all onNumberOfPagesChanged event handlers */
+		for (auto it = onNumberOfPagesChangedHandlers.begin(); it != onNumberOfPagesChangedHandlers.end(); it++)
+		{
+			auto onNumberOfPagesChanged = *it;
+			if (onNumberOfPagesChanged)
+			{
+				onNumberOfPagesChanged(*this, numPages);
+			}
+		}
 	}
 }
 
@@ -220,7 +250,16 @@ void ListWidget::setCurrentPage(int page)
 	{
 		myChildren[n]->show();
 	}
-	emit currentPageChanged(currentPage_);
+
+	/* Call all onCurrentPageChanged event handlers */
+	for (auto it = onCurrentPageChangedHandlers.begin(); it != onCurrentPageChangedHandlers.end(); it++)
+	{
+		auto onCurrentPageChanged = *it;
+		if (onCurrentPageChanged)
+		{
+			onCurrentPageChanged(*this, currentPage_);
+		}
+	}
 }
 
 void ListWidget::doLayoutAll()
@@ -251,15 +290,37 @@ void ListWidget::doLayout(int num)
 	myChildren[num]->show(page == currentPage_);
 }
 
+void ListWidget::addOnCurrentPageChangedHandler(const W_LISTWIDGET_ON_CURRENTPAGECHANGED_FUNC& handlerFunc)
+{
+	onCurrentPageChangedHandlers.push_back(handlerFunc);
+}
+
+void ListWidget::addOnNumberOfPagesChangedHandler(const W_LISTWIDGET_ON_NUMBEROFPAGESCHANGED_FUNC& handlerFunc)
+{
+	onNumberOfPagesChangedHandlers.push_back(handlerFunc);
+}
+
 ListTabWidget::ListTabWidget(WIDGET *parent)
 	: WIDGET(parent)
 	, tabs(new TabSelectionWidget(this))
 	, widgets(new ListWidget(this))
 	, tabPos(Top)
 {
-	connect(tabs, SIGNAL(tabChanged(int)), widgets, SLOT(setCurrentPage(int)));
-	connect(widgets, SIGNAL(currentPageChanged(int)), tabs, SLOT(setTab(int)));
-	connect(widgets, SIGNAL(numberOfPagesChanged(int)), tabs, SLOT(setNumberOfTabs(int)));
+	tabs->addOnTabChangedHandler([](TabSelectionWidget& tabsWidget, int currentTab) {
+		ListTabWidget* pParent = static_cast<ListTabWidget*>(tabsWidget.parent());
+		assert(pParent != nullptr);
+		pParent->setCurrentPage(currentTab);
+	});
+	widgets->addOnCurrentPageChangedHandler([](ListWidget& listWidget, int currentPage) {
+		ListTabWidget* pParent = static_cast<ListTabWidget*>(listWidget.parent());
+		assert(pParent != nullptr);
+		pParent->tabs->setTab(currentPage);
+	});
+	widgets->addOnNumberOfPagesChangedHandler([](ListWidget& listWidget, int numberOfPages) {
+		ListTabWidget* pParent = static_cast<ListTabWidget*>(listWidget.parent());
+		assert(pParent != nullptr);
+		pParent->tabs->setNumberOfTabs(numberOfPages);
+	});
 	tabs->setNumberOfTabs(widgets->pages());
 }
 

--- a/lib/widget/listwidget.h
+++ b/lib/widget/listwidget.h
@@ -28,6 +28,7 @@
 #include "lib/ivis_opengl/ivisdef.h"
 
 #include "widget.h"
+#include <functional>
 
 
 struct TabSelectionStyle
@@ -45,7 +46,6 @@ struct TabSelectionStyle
 
 class TabSelectionWidget : public WIDGET
 {
-	Q_OBJECT
 
 public:
 	TabSelectionWidget(WIDGET *parent);
@@ -58,14 +58,16 @@ public:
 		return tabButtons.size();
 	}
 
-signals:
-	void tabChanged(int);
+	/* The optional "onTabChanged" callback function */
+	typedef std::function<void (TabSelectionWidget& widget, int currentTab)> W_TABSELECTION_ON_TAB_CHANGED_FUNC;
 
-public slots:
+	void addOnTabChangedHandler(const W_TABSELECTION_ON_TAB_CHANGED_FUNC& onTabChangedFunc);
+
+public:
 	void setTab(int tab);
 	void setNumberOfTabs(int tabs);
 
-private slots:
+private:
 	void prevTabPage();
 	void nextTabPage();
 
@@ -78,12 +80,11 @@ private:
 	std::vector<W_BUTTON *> tabButtons;
 	W_BUTTON *prevTabPageButton;
 	W_BUTTON *nextTabPageButton;
-	class QSignalMapper *setTabMapper;
+	std::vector<W_TABSELECTION_ON_TAB_CHANGED_FUNC> onTabChangedHandlers;
 };
 
 class ListWidget : public WIDGET
 {
-	Q_OBJECT
 
 public:
 	enum Order {RightThenDown, DownThenRight};
@@ -106,11 +107,16 @@ public:
 		return std::max(((int)myChildren.size() - 1) / widgetsPerPage(), 0) + 1;
 	}
 
-signals:
-	void currentPageChanged(int);
-	void numberOfPagesChanged(int);
+	/* The optional "onCurrentPageChanged" callback function */
+	typedef std::function<void (ListWidget& psWidget, int currentPage)> W_LISTWIDGET_ON_CURRENTPAGECHANGED_FUNC;
 
-public slots:
+	/* The optional "onNumberOfPagesChanged" callback function */
+	typedef std::function<void (ListWidget& psWidget, int numberOfPages)> W_LISTWIDGET_ON_NUMBEROFPAGESCHANGED_FUNC;
+
+	void addOnCurrentPageChangedHandler(const W_LISTWIDGET_ON_CURRENTPAGECHANGED_FUNC& handlerFunc);
+	void addOnNumberOfPagesChangedHandler(const W_LISTWIDGET_ON_NUMBEROFPAGESCHANGED_FUNC& handlerFunc);
+
+public:
 	void setCurrentPage(int page);
 
 private:
@@ -143,11 +149,12 @@ private:
 	unsigned currentPage_;
 	std::vector<WIDGET *> myChildren;
 	Order order;
+	std::vector<W_LISTWIDGET_ON_CURRENTPAGECHANGED_FUNC> onCurrentPageChangedHandlers;
+	std::vector<W_LISTWIDGET_ON_NUMBEROFPAGESCHANGED_FUNC> onNumberOfPagesChangedHandlers;
 };
 
 class ListTabWidget : public WIDGET
 {
-	Q_OBJECT
 
 public:
 	enum TabPosition {Top, Bottom};

--- a/lib/widget/slider.h
+++ b/lib/widget/slider.h
@@ -34,7 +34,6 @@
 
 class W_SLIDER : public WIDGET
 {
-	Q_OBJECT
 
 public:
 	W_SLIDER(W_SLDINIT const *init);

--- a/lib/widget/widgbase.h
+++ b/lib/widget/widgbase.h
@@ -28,7 +28,7 @@
 #include "lib/ivis_opengl/piedef.h"
 #include "lib/ivis_opengl/textdraw.h"
 #include <QtCore/QRect>
-#include <QtCore/QObject>
+#include <vector>
 #include <functional>
 
 
@@ -91,9 +91,8 @@ enum
 };
 
 /* The base widget data type */
-class WIDGET : public QObject
+class WIDGET
 {
-	Q_OBJECT
 
 public:
 	typedef std::vector<WIDGET *> Children;

--- a/lib/widget/widget.vcxproj
+++ b/lib/widget/widget.vcxproj
@@ -92,18 +92,6 @@
       <WarningLevel>Level4</WarningLevel>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
-    <PreBuildEvent>
-      <Command>$(Qt5dir)\bin\moc.exe bar.h. -o bar_moc.h
-$(Qt5dir)\bin\moc.exe  button.h -o button_moc.h 
-$(Qt5dir)\bin\moc.exe  editbox.h -o editbox_moc.h
-$(Qt5dir)\bin\moc.exe  form.h   -o form_moc.h 
-$(Qt5dir)\bin\moc.exe  label.h  -o label_moc.h 
-$(Qt5dir)\bin\moc.exe  listwidget.h -o listwidget_moc.h 
-$(Qt5dir)\bin\moc.exe  slider.h -o slider_moc.h 
-$(Qt5dir)\bin\moc.exe  widgbase.h -o widgbase_moc.h
-
-</Command>
-    </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug_QT_backend|Win32'">
     <ClCompile>
@@ -120,18 +108,6 @@ $(Qt5dir)\bin\moc.exe  widgbase.h -o widgbase_moc.h
       <WarningLevel>Level4</WarningLevel>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
-    <PreBuildEvent>
-      <Command>$(Qt5dir)\bin\moc.exe bar.h. -o bar_moc.h
-$(Qt5dir)\bin\moc.exe  button.h -o button_moc.h 
-$(Qt5dir)\bin\moc.exe  editbox.h -o editbox_moc.h
-$(Qt5dir)\bin\moc.exe  form.h   -o form_moc.h 
-$(Qt5dir)\bin\moc.exe  label.h  -o label_moc.h 
-$(Qt5dir)\bin\moc.exe  listwidget.h -o listwidget_moc.h 
-$(Qt5dir)\bin\moc.exe  slider.h -o slider_moc.h 
-$(Qt5dir)\bin\moc.exe  widgbase.h -o widgbase_moc.h
-
-</Command>
-    </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
@@ -176,10 +152,8 @@ $(Qt5dir)\bin\moc.exe  widgbase.h -o widgbase_moc.h
     <ClInclude Include="editbox.h" />
     <ClInclude Include="form.h" />
     <ClInclude Include="label.h" />
-    <ClInclude Include="label_moc.h" />
     <ClInclude Include="listwidget.h" />
     <ClInclude Include="slider.h" />
-    <ClInclude Include="slider_moc.h" />
     <ClInclude Include="tip.h" />
     <ClInclude Include="widgbase.h" />
     <ClInclude Include="widget.h" />

--- a/lib/widget/widget.vcxproj.filters
+++ b/lib/widget/widget.vcxproj.filters
@@ -73,11 +73,5 @@
     <ClInclude Include="listwidget.h">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="label_moc.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="slider_moc.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
   </ItemGroup>
 </Project>

--- a/macosx/Warzone.xcodeproj/project.pbxproj
+++ b/macosx/Warzone.xcodeproj/project.pbxproj
@@ -405,15 +405,6 @@
 		4371B60F11D93FD1005A67AB /* pngpriv.h in Headers */ = {isa = PBXBuildFile; fileRef = 4371B60D11D93FD0005A67AB /* pngpriv.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		437487CF14AE41C100ABC9C7 /* template.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4343651C149EA04800527137 /* template.cpp */; };
 		4377CF1616F7E89C008B1083 /* listwidget.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4377CF1416F7E89B008B1083 /* listwidget.cpp */; };
-		4377CF2416F7EA86008B1083 /* listwidget.h in Sources */ = {isa = PBXBuildFile; fileRef = 4377CF1516F7E89C008B1083 /* listwidget.h */; };
-		4377CF2516F7EA86008B1083 /* bar.h in Sources */ = {isa = PBXBuildFile; fileRef = 0246A17B0BD3CCBD004D1C70 /* bar.h */; };
-		4377CF2616F7EA86008B1083 /* button.h in Sources */ = {isa = PBXBuildFile; fileRef = 0246A17D0BD3CCBD004D1C70 /* button.h */; };
-		4377CF2716F7EA86008B1083 /* editbox.h in Sources */ = {isa = PBXBuildFile; fileRef = 0246A17F0BD3CCBD004D1C70 /* editbox.h */; };
-		4377CF2816F7EA86008B1083 /* form.h in Sources */ = {isa = PBXBuildFile; fileRef = 0246A1810BD3CCBD004D1C70 /* form.h */; };
-		4377CF2916F7EA86008B1083 /* label.h in Sources */ = {isa = PBXBuildFile; fileRef = 0246A1830BD3CCBD004D1C70 /* label.h */; };
-		4377CF2A16F7EA86008B1083 /* slider.h in Sources */ = {isa = PBXBuildFile; fileRef = 0246A1870BD3CCBD004D1C70 /* slider.h */; };
-		4377CF2B16F7EA86008B1083 /* widgbase.h in Sources */ = {isa = PBXBuildFile; fileRef = 0246A18A0BD3CCBD004D1C70 /* widgbase.h */; };
-		4377CF2C16F7EB03008B1083 /* multiint.h in Sources */ = {isa = PBXBuildFile; fileRef = 0246A2360BD3CCDB004D1C70 /* multiint.h */; };
 		437D3360150A53E000B45AAE /* qslint in Copy Additional Executables */ = {isa = PBXBuildFile; fileRef = 437D32D9150A47A800B45AAE /* qslint */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		437DABE714C3345B00DB5F94 /* swapinterval.mm in Sources */ = {isa = PBXBuildFile; fileRef = 437DABE614C3345B00DB5F94 /* swapinterval.mm */; };
 		438BDDF31129DC9A00998660 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 438BDDD71129DC9A00998660 /* InfoPlist.strings */; };
@@ -5514,15 +5505,6 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				4377CF2416F7EA86008B1083 /* listwidget.h in Sources */,
-				4377CF2516F7EA86008B1083 /* bar.h in Sources */,
-				4377CF2616F7EA86008B1083 /* button.h in Sources */,
-				4377CF2716F7EA86008B1083 /* editbox.h in Sources */,
-				4377CF2816F7EA86008B1083 /* form.h in Sources */,
-				4377CF2916F7EA86008B1083 /* label.h in Sources */,
-				4377CF2A16F7EA86008B1083 /* slider.h in Sources */,
-				4377CF2B16F7EA86008B1083 /* widgbase.h in Sources */,
-				4377CF2C16F7EB03008B1083 /* multiint.h in Sources */,
 				435213E316BD7F97001B3D42 /* qtscriptdebug.h in Sources */,
 				0246A0C20BD3CBD5004D1C70 /* debug.cpp in Sources */,
 				0246A0C40BD3CBD5004D1C70 /* frame.cpp in Sources */,

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -34,7 +34,7 @@ endif()
 
 file(GLOB HEADERS "*.h")
 file(GLOB SRC "*.cpp")
-qt5_wrap_cpp(MOCFILES multiint.h qtscriptdebug.h)
+qt5_wrap_cpp(MOCFILES qtscriptdebug.h)
 
 add_executable(warzone2100 ${HEADERS} ${SRC} ${MOCFILES} "${CMAKE_CURRENT_BINARY_DIR}/autorevision.h" "${CMAKE_SOURCE_DIR}/win32/warzone2100.rc")
 target_compile_definitions(warzone2100 PRIVATE "YY_NO_UNISTD_H")

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -11,7 +11,6 @@ AM_CXXFLAGS += -DQT_STATICPLUGIN
 endif
 
 MOCHEADER = \
-	multiint.h \
 	qtscriptdebug.h
 MOCEDFILES = $(MOCHEADER:%.h=%_moc.cpp)
 
@@ -167,7 +166,6 @@ noinst_HEADERS = \
 	$(MOCHEADER)
 
 nodist_COMMONSOURCES = \
-	multiint_moc.cpp \
 	qtscriptdebug_moc.cpp
 
 COMMONSOURCES = \

--- a/src/multiint.cpp
+++ b/src/multiint.cpp
@@ -1505,13 +1505,11 @@ static void showPasswordForm()
 MultibuttonWidget::MultibuttonWidget(WIDGET *parent, int value)
 	: W_FORM(parent)
 	, label(nullptr)
-	, mapper(new QSignalMapper(this))
 	, currentValue_(value)
 	, disabled(false)
 	, gap_(3)
 	, lockCurrent(false)
 {
-	connect(mapper, SIGNAL(mapped(int)), this, SLOT(choose(int)));
 }
 
 void MultibuttonWidget::display(int xOffset, int yOffset)
@@ -1550,8 +1548,11 @@ void MultibuttonWidget::addButton(int value, Image image, Image imageDown, char 
 	button->setState(value == currentValue_ && lockCurrent ? WBUT_LOCK : disabled ? WBUT_DISABLE : 0);
 	buttons.push_back(std::make_pair(button, value));
 
-	mapper->setMapping(button, value);
-	connect(button, SIGNAL(clicked()), mapper, SLOT(map()));
+	button->addOnClickHandler([value](W_BUTTON& button) {
+		MultibuttonWidget* pParent = static_cast<MultibuttonWidget*>(button.parent());
+		assert(pParent != nullptr);
+		pParent->choose(value);
+	});
 
 	geometryChanged();
 }
@@ -1588,7 +1589,16 @@ void MultibuttonWidget::choose(int value)
 	currentValue_ = value;
 	stateChanged();
 
-	emit chosen(currentValue_);
+	/* Call all onChoose event handlers */
+	for (auto it = onChooseHandlers.begin(); it != onChooseHandlers.end(); it++)
+	{
+		auto onChoose = *it;
+		if (onChoose)
+		{
+			onChoose(*this, currentValue_);
+		}
+	}
+
 	screenPointer->setReturn(this);
 }
 

--- a/src/multiint.h
+++ b/src/multiint.h
@@ -28,7 +28,8 @@
 #include "lib/netplay/netplay.h"
 #include "lib/widget/widgbase.h"
 #include "lib/widget/form.h"
-#include <QtCore/QSignalMapper>
+#include <functional>
+#include <vector>
 
 
 #define MAX_LEN_AI_NAME   40
@@ -40,7 +41,6 @@
 
 class MultibuttonWidget : public W_FORM
 {
-	Q_OBJECT
 
 public:
 	MultibuttonWidget(WIDGET *parent, int value = -1);
@@ -61,10 +61,12 @@ public:
 		return currentValue_;
 	}
 
-signals:
-	void chosen(int);
+	/* The optional "onChoose" callback function */
+	typedef std::function<void (MultibuttonWidget& widget, int newValue)> W_ON_CHOOSE_FUNC;
 
-public slots:
+	void addOnChooseHandler(const W_ON_CHOOSE_FUNC& onChooseFunc);
+
+public:
 	void choose(int value);
 
 private:
@@ -73,16 +75,15 @@ private:
 protected:
 	W_LABEL *label;
 	std::vector<std::pair<W_BUTTON *, int> > buttons;
-	QSignalMapper *mapper;
 	int currentValue_;
 	bool disabled;
 	int gap_;
 	bool lockCurrent;
+	std::vector<W_ON_CHOOSE_FUNC> onChooseHandlers;
 };
 
 class MultichoiceWidget : public MultibuttonWidget
 {
-	Q_OBJECT
 
 public:
 	MultichoiceWidget(WIDGET *parent, int value = -1);


### PR DESCRIPTION
- Replace remaining uses of QT signals / slots in Widgets
- Replace remaining uses of QSignalMapper in Widgets
- Widgets no longer inherit from QObject
- Widgets no longer require QT moc

With these changes, the only remaining file that requires QT moc is `qtscriptdebug.h`.