### PR TITLE
Fix terrain shadow / lighting

### DIFF
--- a/src/lighting.cpp
+++ b/src/lighting.cpp
@@ -60,8 +60,14 @@ static void calcTileIllum(UDWORD tileX, UDWORD tileY);
 
 void setTheSun(Vector3f newSun)
 {
+	Vector3f oldSun = theSun;
 	theSun = normalise(newSun) * float(FP12_MULTIPLIER);
 	theSun_ForTileIllumination = Vector3f(-theSun.x, -theSun.y, theSun.z);
+	if(oldSun != theSun)
+	{
+		// The sun has changed - must relcalulate lighting
+		initLighting(0, 0, mapWidth, mapHeight);
+	}
 }
 
 Vector3f getTheSun()

--- a/src/lighting.cpp
+++ b/src/lighting.cpp
@@ -52,6 +52,7 @@
 
 /*	The vector that holds the sun's lighting direction - planar */
 static Vector3f theSun;
+static Vector3f theSun_ForTileIllumination;
 
 /*	Module function Prototypes */
 static UDWORD calcDistToTile(UDWORD tileX, UDWORD tileY, Vector3i *pos);
@@ -60,6 +61,7 @@ static void calcTileIllum(UDWORD tileX, UDWORD tileY);
 void setTheSun(Vector3f newSun)
 {
 	theSun = normalise(newSun) * float(FP12_MULTIPLIER);
+	theSun_ForTileIllumination = Vector3f(-theSun.x, -theSun.y, theSun.z);
 }
 
 Vector3f getTheSun()
@@ -212,7 +214,7 @@ static void calcTileIllum(UDWORD tileX, UDWORD tileY)
 		finalVector = finalVector + normals[i];
 	}
 
-	dotProduct = glm::dot(normalise(finalVector), theSun);
+	dotProduct = glm::dot(normalise(finalVector), theSun_ForTileIllumination);
 
 	val = abs(dotProduct) / 16;
 	if (val == 0)


### PR DESCRIPTION
Previously, the terrain lighting was the opposite direction of the object (structure, droid, etc) lighting. ([trac #4749](http://developer.wz2100.net/ticket/4749))

Also, tile illumination is now recalculated when the sun vector changes.

Testing and feedback is appreciated.