### PR TITLE
[macOS] Improve JS doc Markdown generation

### DIFF
--- a/macosx/configs/fetchscripts/SetupPrebuiltComponents-Docs.sh
+++ b/macosx/configs/fetchscripts/SetupPrebuiltComponents-Docs.sh
@@ -100,14 +100,14 @@ else
 fi
 
 # javascript doc
-	grep src/qtscript.cpp -e '//==' | sed -E 's:.*//==[[:space:]]?::' > doc/js-globals.md
-	grep src/qtscriptfuncs.cpp -e '//==' | sed -E 's:.*//==[[:space:]]?::' >> doc/js-globals.md
-	grep src/qtscript.cpp -e '//__' | sed -E 's:.*//__[[:space:]]?::' > doc/js-events.md
-	grep src/qtscript.cpp -e '//--' | sed -E 's:.*//--[[:space:]]?::' > doc/js-functions.md
-	grep src/qtscriptfuncs.cpp -e '//--' | sed -E 's:.*//--[[:space:]]?::' >> doc/js-functions.md
-	grep src/qtscript.cpp -e '//;;' | sed -E 's:.*//;;[[:space:]]?::' > doc/js-objects.md
-	grep src/qtscriptfuncs.cpp -e '//;;' | sed -E 's:.*//;;[[:space:]]?::' >> doc/js-objects.md
-	grep data/base/script/campaign/libcampaign.js -e '.*//;;' | sed -E 's://;;[[:space:]]?::' > doc/js-campaign.md
+	grep src/qtscript.cpp -e '//==' | sed -E 's:.*//== ?::' > doc/js-globals.md
+	grep src/qtscriptfuncs.cpp -e '//==' | sed -E 's:.*//== ?::' >> doc/js-globals.md
+	grep src/qtscript.cpp -e '//__' | sed -E 's:.*//__ ?::' > doc/js-events.md
+	grep src/qtscript.cpp -e '//--' | sed -E 's:.*//-- ?::' > doc/js-functions.md
+	grep src/qtscriptfuncs.cpp -e '//--' | sed -E 's:.*//-- ?::' >> doc/js-functions.md
+	grep src/qtscript.cpp -e '//;;' | sed -E 's:.*//;; ?::' > doc/js-objects.md
+	grep src/qtscriptfuncs.cpp -e '//;;' | sed -E 's:.*//;; ?::' >> doc/js-objects.md
+	grep data/base/script/campaign/libcampaign.js -e '.*//;;' | sed -E 's://;; ?::' > doc/js-campaign.md
 cp -af doc/Scripting.md ${mWarzoneHelpLproj}
 cp -af doc/js-{globals,events,functions,objects,campaign}*.md ${mWarzoneHelpLproj}
 


### PR DESCRIPTION
Since other JS doc generation scripts do not use `[[:space:]]` (or an equivalent that matches *any* whitespace character), revert to use of a literal space to better match the output.