### PR TITLE
[SDL backend] Do not call QCoreApplication::processEvents() on Windows or macOS

### DIFF
--- a/lib/sdl/main_sdl.cpp
+++ b/lib/sdl/main_sdl.cpp
@@ -2129,7 +2129,18 @@ void wzMainEventLoop(void)
 				break;
 			}
 		}
+#if !defined(WZ_OS_WIN) && !defined(WZ_OS_MAC)
+		// Ideally, we don't want Qt processing events in addition to SDL - this causes
+		// all kinds of issues (crashes taking screenshots on Windows, freezing on
+		// macOS without a nasty workaround) - but without the following line the script
+		// debugger window won't display properly on Linux.
+		//
+		// Therefore, do not include it on Windows and macOS builds, which does not
+		// impact the script debugger's functionality, but include it (for now) on other
+		// builds until an alternative script debugger UI is available.
+		//
 		appPtr->processEvents();		// Qt needs to do its stuff
+#endif
 		processScreenSizeChangeNotificationIfNeeded();
 		mainLoop();				// WZ does its thing
 		inputNewFrame();			// reset input states

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -848,10 +848,6 @@ int realmain(int argc, char *argv[])
 	const char **utfargv = (const char **)argv;
 	wzMain(argc, argv);		// init Qt integration first
 
-#ifdef WZ_OS_MAC
-	cocoaInit();
-#endif
-
 	debug_init();
 	debug_register_callback(debug_callback_stderr, nullptr, nullptr, nullptr);
 #if defined(WZ_OS_WIN) && defined(DEBUG_INSANE)
@@ -1106,12 +1102,7 @@ int realmain(int argc, char *argv[])
 	debug_MEMSTATS();
 #endif
 	debug(LOG_MAIN, "Entering main loop");
-#ifndef WZ_OS_MAC
 	wzMainEventLoop();
-#else // WZ_OS_MAC
-	// On Mac, use special method of launching NSApplication properly
-	cocoaRunApplication(&wzMainEventLoop);
-#endif
 	saveConfig();
 	systemShutdown();
 #ifdef WZ_OS_WIN	// clean up the memory allocated for the command line conversion

--- a/src/qtscript.cpp
+++ b/src/qtscript.cpp
@@ -602,6 +602,9 @@ QScriptEngine *loadPlayerScript(const QString& path, int player, int difficulty)
 {
 	ASSERT_OR_RETURN(nullptr, player < MAX_PLAYERS, "Player index %d out of bounds", player);
 	QScriptEngine *engine = new QScriptEngine();
+	// Set processEventsInterval to -1 because the interpreter should *never* call
+	// QCoreApplication::processEvents() (or SDL builds will break in various ways).
+	engine->setProcessEventsInterval(-1);
 	UDWORD size;
 	char *bytes = nullptr;
 	if (!loadFile(path.toUtf8().constData(), &bytes, &size))


### PR DESCRIPTION
In SDL backend builds, the only thing that currently requires Qt's `QCoreApplication::processEvents()` is the script debugger window (which is built using Qt) - and only on non-Windows/macOS operating systems.

Since the script debugger window works on Windows and macOS without `processEvents()`, do not call it on Windows and macOS builds.

This fixes:
- [trac #4714](http://developer.wz2100.net/ticket/4714) "can't take in-game screenshots anymore" (on Windows)
- the need for a (somewhat crude) workaround on macOS
- issues with keys getting "stuck" on macOS