### PR TITLE
Attempt to workaround Nvidia driver bug by ensuring glEnableVertexAttribArray always comes after glVertexAttribPointer

### DIFF
--- a/lib/ivis_opengl/pieblitfunc.cpp
+++ b/lib/ivis_opengl/pieblitfunc.cpp
@@ -156,21 +156,21 @@ void GFX::draw(const glm::mat4 &modelViewProjectionMatrix)
 		pie_SetTexturePage(TEXPAGE_EXTERN);
 		mTexture->bind();
 		pie_ActivateShader(SHADER_GFX_TEXT, modelViewProjectionMatrix, glm::vec4(1), 0);
-		glEnableVertexAttribArray(VERTEX_COORDS_ATTRIB_INDEX);
 		glBindBuffer(GL_ARRAY_BUFFER, mBuffers[VBO_TEXCOORD]);
 		glVertexAttribPointer(VERTEX_COORDS_ATTRIB_INDEX, 2, GL_FLOAT, false, 0, nullptr);
+		glEnableVertexAttribArray(VERTEX_COORDS_ATTRIB_INDEX);
 	}
 	else if (mType == GFX_COLOUR)
 	{
 		pie_SetTexturePage(TEXPAGE_NONE);
 		pie_ActivateShader(SHADER_GFX_COLOUR, modelViewProjectionMatrix);
-		glEnableVertexAttribArray(VERTEX_COLOR_ATTRIB_INDEX);
 		glBindBuffer(GL_ARRAY_BUFFER, mBuffers[VBO_TEXCOORD]);
 		glVertexAttribPointer(VERTEX_COLOR_ATTRIB_INDEX, 4, GL_UNSIGNED_BYTE, true, 0, nullptr);
+		glEnableVertexAttribArray(VERTEX_COLOR_ATTRIB_INDEX);
 	}
-	glEnableVertexAttribArray(VERTEX_POS_ATTRIB_INDEX);
 	glBindBuffer(GL_ARRAY_BUFFER, mBuffers[VBO_VERTEX]);
 	glVertexAttribPointer(VERTEX_POS_ATTRIB_INDEX, mCoordsPerVertex, GL_FLOAT, false, 0, nullptr);
+	glEnableVertexAttribArray(VERTEX_POS_ATTRIB_INDEX);
 	glDrawArrays(mdrawType, 0, mSize);
 	glDisableVertexAttribArray(VERTEX_POS_ATTRIB_INDEX);
 	if (mType == GFX_TEXTURE)
@@ -194,10 +194,10 @@ GFX::~GFX()
 
 static void enableRect()
 {
-	glEnableVertexAttribArray(VERTEX_POS_ATTRIB_INDEX);
 	glBindBuffer(GL_ARRAY_BUFFER, pie_internal::rectBuffer);
 	glVertexAttribPointer(VERTEX_POS_ATTRIB_INDEX, 4, GL_BYTE, false, 0, nullptr);
 	glBindBuffer(GL_ARRAY_BUFFER, 0);
+	glEnableVertexAttribArray(VERTEX_POS_ATTRIB_INDEX);
 }
 
 static void disableRect()

--- a/lib/ivis_opengl/piefunc.cpp
+++ b/lib/ivis_opengl/piefunc.cpp
@@ -112,8 +112,8 @@ void pie_TransColouredTriangle(const std::array<Vector3f, 3> &vrt, PIELIGHT c, c
 	static glBufferWrapper buffer;
 	glBindBuffer(GL_ARRAY_BUFFER, buffer.id);
 	glBufferData(GL_ARRAY_BUFFER, 3 * sizeof(Vector3f), vrt.data(), GL_STREAM_DRAW);
-	glEnableVertexAttribArray(program.locVertex);
 	glVertexAttribPointer(program.locVertex, 3, GL_FLOAT, GL_FALSE, 0, nullptr);
+	glEnableVertexAttribArray(program.locVertex);
 	glDrawArrays(GL_TRIANGLE_FAN, 0, 3);
 	glDisableVertexAttribArray(program.locVertex);
 }

--- a/src/terrain.cpp
+++ b/src/terrain.cpp
@@ -1090,11 +1090,11 @@ static void drawDepthOnly(const glm::mat4 &ModelViewProjection, const glm::vec4 
 	glPolygonOffset(0.1f, 1.0f);
 
 	// bind the vertex buffer
-	glEnableVertexAttribArray(program.locVertex);
 	glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, geometryIndexVBO);
 	glBindBuffer(GL_ARRAY_BUFFER, geometryVBO);
 
 	glVertexAttribPointer(program.locVertex, 3, GL_FLOAT, GL_FALSE, sizeof(RenderVertex), BUFFER_OFFSET(0));
+	glEnableVertexAttribArray(program.locVertex);
 
 	for (int x = 0; x < xSectors; x++)
 	{
@@ -1148,10 +1148,9 @@ static void drawTerrainLayers(const glm::mat4 &ModelViewProjection, const glm::v
 
 	// load the vertex (geometry) buffer
 	glBindBuffer(GL_ARRAY_BUFFER, geometryVBO);
-	glEnableVertexAttribArray(program.locVertex);
 	glVertexAttribPointer(program.locVertex, 3, GL_FLOAT, GL_FALSE, sizeof(RenderVertex), BUFFER_OFFSET(0));
+	glEnableVertexAttribArray(program.locVertex);
 
-	glEnableVertexAttribArray(program.locColor);
 	glBindBuffer(GL_ARRAY_BUFFER, textureVBO);
 
 	ASSERT_OR_RETURN(, psGroundTypes, "Ground type was not set, no textures will be seen.");
@@ -1172,6 +1171,7 @@ static void drawTerrainLayers(const glm::mat4 &ModelViewProjection, const glm::v
 
 		// load the color buffer
 		glVertexAttribPointer(program.locColor, 4, GL_UNSIGNED_BYTE, GL_TRUE, sizeof(PIELIGHT), BUFFER_OFFSET(sizeof(PIELIGHT)*xSectors * ySectors * (sectorSize + 1) * (sectorSize + 1) * 2 * layer));
+		glEnableVertexAttribArray(program.locColor);
 
 		for (int x = 0; x < xSectors; x++)
 		{
@@ -1216,12 +1216,12 @@ static void drawDecals(const glm::mat4 &ModelViewProjection, const glm::vec4 &pa
 	pie_SetRendMode(REND_ALPHA);
 
 	// and the texture coordinates buffer
-	glEnableVertexAttribArray(program.locVertex);
 	glBindBuffer(GL_ARRAY_BUFFER, decalVBO);
 	glVertexAttribPointer(program.locVertex, 3, GL_FLOAT, GL_FALSE, sizeof(DecalVertex), BUFFER_OFFSET(0));
+	glEnableVertexAttribArray(program.locVertex);
 
-	glEnableVertexAttribArray(program.locTexCoord);
 	glVertexAttribPointer(program.locTexCoord, 2, GL_FLOAT, GL_FALSE, sizeof(DecalVertex), BUFFER_OFFSET(12));
+	glEnableVertexAttribArray(program.locTexCoord);
 	glBindBuffer(GL_ARRAY_BUFFER, 0);
 
 	int size = 0;
@@ -1348,8 +1348,8 @@ void drawWater(const glm::mat4 &viewMatrix)
 	// bind the vertex buffer
 	glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, waterIndexVBO);
 	glBindBuffer(GL_ARRAY_BUFFER, waterVBO);
-	glEnableVertexAttribArray(program.locVertex);
 	glVertexAttribPointer(program.locVertex, 3, GL_FLOAT, GL_FALSE, sizeof(RenderVertex), BUFFER_OFFSET(0));
+	glEnableVertexAttribArray(program.locVertex);
 
 	for (x = 0; x < xSectors; x++)
 	{


### PR DESCRIPTION
On certain Nvidia driver versions, on certain Nvidia graphics hardware, Warzone 3.2.3 (and the master branch, to a possibly lesser extent) likes to crash inside the Nvidia drivers.

The recent crash logs we've obtained include a call to `glEnableVertexAttribArray` - and it consistently seems to be a call to `glEnableVertexAttribArray` that comes *before* the appropriate call to `glVertexAttribPointer`, and never one of the calls to `glEnableVertexAttribArray` that comes after the appropriate call to `glVertexAttribPointer`.

Let's make sure everything follows the latter pattern.