### PR TITLE
[CMake] Always include debug info for Windows builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,12 @@ if(LINK_FLAG_PIE_SUPPORTED AND NOT CMAKE_SYSTEM_NAME MATCHES "Windows")
 	set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -pie")
 endif()
 
+# Ensure all builds always have debug info built (MSVC)
+if("${CMAKE_CXX_COMPILER_ID}" MATCHES "MSVC")
+	set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /Zi")
+	set(CMAKE_EXE_LINKER_FLAGS_RELEASE "${CMAKE_EXE_LINKER_FLAGS_RELEASE} /DEBUG /OPT:REF /OPT:ICF" CACHE STRING "Flags used by the linker (Release builds)" FORCE)
+endif()
+
 include(CheckCCompilerFlag)
 include(CheckCXXCompilerFlag)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -164,6 +164,11 @@ if(CMAKE_SYSTEM_NAME MATCHES "Windows" AND NOT CMAKE_CROSSCOMPILING)
 			include(BundleUtilities)
 			fixup_bundle(\"\${CMAKE_INSTALL_PREFIX}/${_mainexename}.exe\" \"\" \"\${dll_source_dirs}\")
 		" COMPONENT Core)
+
+		if("${CMAKE_CXX_COMPILER_ID}" MATCHES "MSVC")
+			# Must install the PDB file or crash dumps won't be as useful
+			install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${_mainexename}.pdb" COMPONENT Core DESTINATION ".")
+		endif()
 	else()
 		message( WARNING "Unable to get OUTPUT_NAME from warzone2100 target" )
 	endif()


### PR DESCRIPTION
When building with MSVC, the `.PDB` file must be included or crash dumps won't be as useful.