### PR TITLE
Improve shadow performance (particularly, CPU performance)

### DIFF
--- a/lib/ivis_opengl/piedef.h
+++ b/lib/ivis_opengl/piedef.h
@@ -69,7 +69,7 @@ void pie_setShadows(bool drawShadows);
 void pie_InitLighting();
 void pie_Lighting0(LIGHTING_TYPE entry, const float value[4]);
 
-void pie_RemainingPasses(UDWORD currentGameFrame);
+void pie_RemainingPasses(uint64_t currentGameFrame);
 
 void pie_SetUp();
 void pie_CleanUp();

--- a/lib/ivis_opengl/piedef.h
+++ b/lib/ivis_opengl/piedef.h
@@ -69,7 +69,7 @@ void pie_setShadows(bool drawShadows);
 void pie_InitLighting();
 void pie_Lighting0(LIGHTING_TYPE entry, const float value[4]);
 
-void pie_RemainingPasses();
+void pie_RemainingPasses(UDWORD currentGameFrame);
 
 void pie_SetUp();
 void pie_CleanUp();

--- a/src/display3d.cpp
+++ b/src/display3d.cpp
@@ -1131,7 +1131,7 @@ static void drawTiles(iView *player)
 	GL_DEBUG("Draw 3D scene - blueprints");
 	displayBlueprints(viewMatrix);
 
-	pie_RemainingPasses(); // draws shadows and transparent shapes
+	pie_RemainingPasses(currentGameFrame); // draws shadows and transparent shapes
 
 	if (!gamePaused())
 	{


### PR DESCRIPTION
- **Reduce CPU usage when drawing shadows** by intelligently caching calculations and data
   - Previously, a number of fairly costly calculations (including filtering and sorting vertices) were occurring for every shadow-casting shape on every frame. (Potentially _twice_ on every frame if using a 2-pass shadow implementation.) The output of these calculations can be intelligently cached to avoid having to recalculate them every frame.
- **Aggregate shadow vertices and batch `glDrawArrays()` calls**
   - Instead of a `glDrawArrays` call for every shadow-casting shape, we now aggregate vertices that are pre-multiplied by the `modelViewMatrix`, and batch `glDrawArrays` calls. This massively reduces the number of gl calls (both for filling buffers and drawing) as now only a single (large) buffer needs to be allocated and streamed per call to `pie_ShadowDrawLoop`.
   - Additionally, a round-robin arrangement of buffers for shadow drawing is used to try to avoid implicit synchronization in the graphics driver.

### Benchmarks
**Hardware:** MacBook Pro (Retina, Mid 2012), 2.6 GHz Intel Core i7, NVIDIA GeForce GT 650M
**Test:** Loading a saved game with a screen full of units and structures
**Configuration:** Release build, **VSYNC on**, shadows on

| Measured | Before | After |
| - | - | - |
| CPU Usage | 40% | **27%** |
| FPS | 60fps | 60fps |