### PR TITLE
More robust handling of retrieving the app user-data (prefs) dir (and fixes)

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,20 +57,42 @@ location of this directory depends on the operating system.
 
 ### Warzone directory under GNU/Linux
 
-Under GNU/Linux the warzone-dir can be found in your home-directory, it is called
-".warzone2100-<version>". The leading dot indicates that it is a hidden
-directory so depending on your configuration you may not be able to see it.
+Under GNU/Linux, Warzone conforms to the [XDG base directory spec]
+(https://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html).
+
+By default, the directory `warzone2100-<version>` can be found in your home-directory 
+under the path `~/.local/share/`.
+(If the `XDG_DATA_HOME` environment variable is defined, the Warzone folder will
+be located within `$XDG_DATA_HOME`.)
+
+The leading dot in the `.local` part of the path indicates that it is a hidden
+directory, so depending on your configuration you may not be able to see it. 
 However, you can still access it by typing the path into your address-bar.
 
 ### Warzone directory under Windows
 
-The directory is called "Warzone 2100 <version>" and is located in "My
-Documents".
+The directory `Warzone 2100 Project\Warzone 2100 <version>` is located under the 
+`%APPDATA%` folder.
+
+Typical `%APPDATA%` paths:
+- Windows XP: `\Documents and Settings\$USER$\Application Data`
+- Windows Vista+: `\Users\$USER$\AppData\Roaming`
+
+Hence, the default path for the Warzone configuration data on Windows Vista+ would be:
+`C:\Users\$USER$\AppData\Roaming\Warzone 2100 Project\Warzone 2100 <version>\`
+
+By default, the `%APPDATA%` folder is hidden. Entering:
+`%APPDATA%\Warzone 2100 Project\` into the address bar of Windows Explorer
+will browse to your Warzone directory.
 
 ### Warzone directory under Mac OS X
 
-The directory "Warzone 2100 <version>" can be found in your home-directory at:
-~/Library/Application Support/
+The directory `Warzone 2100 <version>` can be found in your home-directory at:
+`~/Library/Application Support/`
+
+By default, recent version of macOS hide your account's Library folder. To view it in
+Finder, hold down the Option key while clicking the Go menu, and your Library folder
+will appear as a menu choice.
 
 ### Configuration file
 

--- a/lib/exceptionhandler/exceptionhandler.cpp
+++ b/lib/exceptionhandler/exceptionhandler.cpp
@@ -792,7 +792,7 @@ static bool fetchProgramPath(char *const programPath, size_t const bufSize, cons
  *
  * \param programCommand Command used to launch this program. Only used for POSIX handler.
  */
-void setupExceptionHandler(int argc, const char **argv, const char *packageVersion)
+void setupExceptionHandler(int argc, const char **argv, const char *packageVersion, const std::string &writeDir)
 {
 #if defined(WZ_OS_UNIX) && !defined(WZ_OS_MAC)
 	const char *programCommand;
@@ -805,7 +805,7 @@ void setupExceptionHandler(int argc, const char **argv, const char *packageVersi
 
 #if defined(WZ_OS_WIN)
 # if defined(WZ_CC_MINGW)
-	ExchndlSetup(packageVersion);
+	ExchndlSetup(packageVersion, writeDir);
 # else
 	prevExceptionHandler = SetUnhandledExceptionFilter(windowsExceptionHandler);
 # endif // !defined(WZ_CC_MINGW)

--- a/lib/exceptionhandler/exceptionhandler.cpp
+++ b/lib/exceptionhandler/exceptionhandler.cpp
@@ -828,7 +828,7 @@ void setupExceptionHandler(int argc, const char **argv, const char *packageVersi
 	setFatalSignalHandler(posixExceptionHandler);
 #endif // WZ_OS_*
 }
-bool OverrideRPTDirectory(char *newPath)
+bool OverrideRPTDirectory(const char *newPath)
 {
 # if defined(WZ_CC_MINGW)
 	wchar_t buf[MAX_PATH];

--- a/lib/exceptionhandler/exceptionhandler.h
+++ b/lib/exceptionhandler/exceptionhandler.h
@@ -20,7 +20,7 @@
 #ifndef __INCLUDED_LIB_EXCEPTIONHANDLER_EXCEPTIONHANDLER_H__
 #define __INCLUDED_LIB_EXCEPTIONHANDLER_EXCEPTIONHANDLER_H__
 
-extern void setupExceptionHandler(int argc, const char **argv, const char *packageVersion);
+extern void setupExceptionHandler(int argc, const char **argv, const char *packageVersion, const std::string &writeDir);
 
 extern bool OverrideRPTDirectory(const char *newPath);
 

--- a/lib/exceptionhandler/exceptionhandler.h
+++ b/lib/exceptionhandler/exceptionhandler.h
@@ -22,6 +22,6 @@
 
 extern void setupExceptionHandler(int argc, const char **argv, const char *packageVersion);
 
-extern bool OverrideRPTDirectory(char *newPath);
+extern bool OverrideRPTDirectory(const char *newPath);
 
 #endif // __INCLUDED_LIB_EXCEPTIONHANDLER_EXCEPTIONHANDLER_H__

--- a/lib/exceptionhandler/exchndl.h
+++ b/lib/exceptionhandler/exchndl.h
@@ -21,7 +21,7 @@
 #ifndef __INCLUDED_LIB_EXCEPTIONHANDLER_EXCHNDL_H__
 #define __INCLUDED_LIB_EXCEPTIONHANDLER_EXCHNDL_H__
 
-void ExchndlSetup(const char *packageVersion);
+void ExchndlSetup(const char *packageVersion, const std::string &writeDir);
 void ExchndlShutdown();
 void ResetRPTDirectory(wchar_t *newPath);
 

--- a/lib/framework/frame.h
+++ b/lib/framework/frame.h
@@ -75,14 +75,6 @@ typedef uint16_t PlayerMask;
 #error Warzone 2100 is not a MMO.
 #endif
 
-#if defined(WZ_OS_WIN)
-# define WZ_WRITEDIR "Warzone 2100 master"
-#elif defined(WZ_OS_MAC)
-# define WZ_WRITEDIR "Warzone 2100 master"
-#else
-# define WZ_WRITEDIR ".warzone2100-master"
-#endif
-
 enum QUEUE_MODE
 {
 	ModeQueue,      ///< Sends a message on the game queue, which will get synchronised, by sending a GAME_ message.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -305,10 +305,10 @@ static std::string getPlatformPrefDir_Fallback(const char *org, const char *app)
 
 // Retrieves the appropriate storage directory for application-created files / prefs
 // (Ensures the directory exists. Creates folders if necessary.)
-static std::string getPlatformPrefDir(const char * org, const char * app)
+static std::string getPlatformPrefDir(const char * org, const std::string &app)
 {
 #if defined(WZ_PHYSFS_2_1_OR_GREATER)
-	const char * prefsDir = PHYSFS_getPrefDir(org, app);
+	const char * prefsDir = PHYSFS_getPrefDir(org, app.c_str());
 	if (prefsDir == nullptr)
 	{
 		debug(LOG_FATAL, "Failed to obtain prefs directory: %s", WZ_PHYSFS_getLastError());
@@ -317,7 +317,7 @@ static std::string getPlatformPrefDir(const char * org, const char * app)
 	return std::string(prefsDir) + PHYSFS_getDirSeparator();
 #else
 	// PHYSFS_getPrefDir is not available - use fallback method (which requires OS-specific code)
-	std::string prefDir = getPlatformPrefDir_Fallback(org, app);
+	std::string prefDir = getPlatformPrefDir_Fallback(org, app.c_str());
 	if (prefDir.empty())
 	{
 		debug(LOG_FATAL, "Failed to obtain prefs directory (fallback)");
@@ -341,7 +341,7 @@ static void initialize_ConfigDir()
 
 	if (strlen(configdir) == 0)
 	{
-		configDir = getPlatformPrefDir("Warzone 2100 Project", WZ_WRITEDIR);
+		configDir = getPlatformPrefDir("Warzone 2100 Project", version_getVersionedAppDirFolderName());
 	}
 	else
 	{
@@ -938,7 +938,7 @@ int realmain(int argc, char *argv[])
 		return EXIT_FAILURE;
 	}
 
-	setupExceptionHandler(utfargc, utfargv, version_getFormattedVersionString());
+	setupExceptionHandler(utfargc, utfargv, version_getFormattedVersionString(), version_getVersionedAppDirFolderName());
 
 	/*** Initialize PhysicsFS ***/
 	initialize_PhysicsFS(utfargv[0]);

--- a/src/version.cpp
+++ b/src/version.cpp
@@ -30,6 +30,48 @@
 static const char vcs_branch_cstr[] = VCS_BRANCH;
 static const char vcs_tag[] = VCS_TAG;
 
+/** Obtain the versioned application-data / config writedir folder name
+ *  If on a tag, this is "Warzone 2100 <tag>" / "warzone2100-<tag>"
+ *  If not on a tag, this is "Warzone 2100 <branch>" / "warzone2100-<branch>"
+ *  If no branch is defined, this is "Warzone 2100 <VCS_EXTRA>" / "warzone2100-<VCS_EXTRA>"
+ */
+std::string version_getVersionedAppDirFolderName()
+{
+	std::string versionedWriteDirFolderName;
+
+#if defined(WZ_OS_WIN) || defined(WZ_OS_MAC)
+	versionedWriteDirFolderName = "Warzone 2100 ";
+#else
+	versionedWriteDirFolderName = "warzone2100-";
+#endif
+
+	if (strlen(vcs_tag))
+	{
+		versionedWriteDirFolderName += vcs_tag;
+	}
+	else if (strlen(vcs_branch_cstr))
+	{
+#if defined(DEBUG) || defined(WZ_USE_MASTER_BRANCH_APP_DIR)
+		// To ease testing new branches with existing files, DEBUG builds
+		// (or when WZ_USE_MASTER_BRANCH_APP_DIR is defined)
+		// default to using "master" as the branch
+		versionedWriteDirFolderName += "master";
+#else
+		// For Release builds, use the actual branch name
+		versionedWriteDirFolderName += vcs_branch_cstr;
+#endif
+	}
+	else
+	{
+		// not a branch or a tag, so we are detached most likely.
+		std::string vcs_extra_str = VCS_EXTRA;
+		// remove any spaces from VCS_EXTRA
+		std::remove(vcs_extra_str.begin(), vcs_extra_str.end(), ' ');
+		versionedWriteDirFolderName += vcs_extra_str;
+	}
+	return versionedWriteDirFolderName;
+}
+
 /** Composes a nicely formatted version string.
 * Determine if we are on a tag (which will NOT show the hash)
 * or a branch (which WILL show the hash)

--- a/src/version.h
+++ b/src/version.h
@@ -22,8 +22,10 @@
 #define __INCLUDED_VERSION_H__
 
 #include "lib/framework/types.h"
+#include <string>
 
 const char *version_getVersionString();
 const char *version_getFormattedVersionString();
+std::string version_getVersionedAppDirFolderName();
 
 #endif // __INCLUDED_VERSION_H__


### PR DESCRIPTION
- Fixed: On Windows, applications should never write application-data files to My Documents (`CSIDL_PERSONAL`) - instead, use `%APPDATA%\org\appname`.
- Fixed: By using `PHYSFS_getPrefDir` when available (PhysFS >= 2.1), we include proper support for numerous other operating systems / configurations.
- Fixed: Fallback when `PHYSFS_getPrefDir` is not available (PhysFS < 2.1) that matches its behavior as closely as possible.
- Fixed: Crash introduced by commit: 827cd59 when `getenv("HOME")` returns `NULL`.
- The "\<version\>" part of the application-data-path is now determined automatically. (See new function `version_getVersionedAppDirFolderName()`) Hence, there is no need to manually update the obsolete (now-removed) `WZ_WRITEDIR` before releases / branches / etc.

Changes of note:
- On Windows the application-data path has changed to the appropriate location under `%APPDATA%\Warzone 2100 Project\Warzone 2100 <version>`
- On Linux / Unix, the warzone application-data path follows the [XDG base directory spec](https://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html) the same way that `PHYSFS_getPrefDir` does, which matches many (up-to-date) apps / games.

`README.md` has been updated to reflect this.