### PR TITLE
SDL fullscreen toggling & window positioning improvements

### DIFF
--- a/lib/sdl/main_sdl.cpp
+++ b/lib/sdl/main_sdl.cpp
@@ -1579,9 +1579,7 @@ bool wzChangeWindowResolution(int screen, unsigned int width, unsigned int heigh
 	}
 
 	// Position the window (centered) on the screen (for its upcoming new size)
-	bounds.w -= (bounds.w + width) / 2;
-	bounds.h -= (bounds.h + height) / 2;
-	SDL_SetWindowPosition(WZwindow, bounds.x + bounds.w, bounds.y + bounds.h);
+	SDL_SetWindowPosition(WZwindow, SDL_WINDOWPOS_CENTERED_DISPLAY(screen), SDL_WINDOWPOS_CENTERED_DISPLAY(screen));
 
 	// Change the window size
 	// NOTE: Changing the window size will trigger an SDL window size changed event which will handle recalculating layout.
@@ -1795,10 +1793,7 @@ bool wzMainScreenSetup(int antialiasing, bool fullscreen, bool vsync, bool highD
 		exit(EXIT_FAILURE);
 	}
 	screenIndex = war_GetScreen();
-	SDL_GetDisplayBounds(screenIndex, &bounds);
-	int xOffset = bounds.w - ((bounds.w + windowWidth) / 2);
-	int yOffset = bounds.h - ((bounds.h + windowHeight) / 2);
-	WZwindow = SDL_CreateWindow(PACKAGE_NAME, bounds.x + xOffset, bounds.y + yOffset, windowWidth, windowHeight, video_flags);
+	WZwindow = SDL_CreateWindow(PACKAGE_NAME, SDL_WINDOWPOS_CENTERED_DISPLAY(screenIndex), SDL_WINDOWPOS_CENTERED_DISPLAY(screenIndex), windowWidth, windowHeight, video_flags);
 
 	if (!WZwindow)
 	{
@@ -1818,6 +1813,9 @@ bool wzMainScreenSetup(int antialiasing, bool fullscreen, bool vsync, bool highD
 		SDL_SetWindowSize(WZwindow, minWindowWidth, minWindowHeight);
 		windowWidth = minWindowWidth;
 		windowHeight = minWindowHeight;
+
+		// Center window on screen
+		SDL_SetWindowPosition(WZwindow, SDL_WINDOWPOS_CENTERED_DISPLAY(screenIndex), SDL_WINDOWPOS_CENTERED_DISPLAY(screenIndex));
 	}
 
 	// Calculate the game screen's logical dimensions

--- a/lib/sdl/main_sdl.cpp
+++ b/lib/sdl/main_sdl.cpp
@@ -1786,13 +1786,20 @@ bool wzMainScreenSetup(int antialiasing, bool fullscreen, bool vsync, bool highD
 		SDL_GetDisplayBounds(i, &bounds);
 		debug(LOG_WZ, "Monitor %d: pos %d x %d : res %d x %d", i, (int)bounds.x, (int)bounds.y, (int)bounds.w, (int)bounds.h);
 	}
-	if (war_GetScreen() > SDL_GetNumVideoDisplays())
+	screenIndex = war_GetScreen();
+	const int currentNumDisplays = SDL_GetNumVideoDisplays();
+	if (currentNumDisplays < 1)
 	{
-		debug(LOG_FATAL, "Invalid screen defined in configuration");
+		debug(LOG_FATAL, "SDL_GetNumVideoDisplays returned: %d, with error: %s", currentNumDisplays, SDL_GetError());
 		SDL_Quit();
 		exit(EXIT_FAILURE);
 	}
-	screenIndex = war_GetScreen();
+	if (screenIndex > currentNumDisplays)
+	{
+		debug(LOG_WARNING, "Invalid screen [%d] defined in configuration; there are only %d displays; falling back to display 0", screenIndex, currentNumDisplays);
+		screenIndex = 0;
+		war_SetScreen(0);
+	}
 	WZwindow = SDL_CreateWindow(PACKAGE_NAME, SDL_WINDOWPOS_CENTERED_DISPLAY(screenIndex), SDL_WINDOWPOS_CENTERED_DISPLAY(screenIndex), windowWidth, windowHeight, video_flags);
 
 	if (!WZwindow)

--- a/lib/sdl/main_sdl.cpp
+++ b/lib/sdl/main_sdl.cpp
@@ -1503,6 +1503,7 @@ bool wzChangeDisplayScale(unsigned int displayScale)
 bool wzChangeWindowResolution(int screen, unsigned int width, unsigned int height)
 {
 	assert(WZwindow != nullptr);
+	debug(LOG_WZ, "Attempt to change resolution to [%d] %dx%d", screen, width, height);
 
 #if defined(WZ_OS_MAC)
 	// Workaround for SDL (2.0.5) quirk on macOS:
@@ -1591,6 +1592,8 @@ bool wzChangeWindowResolution(int screen, unsigned int width, unsigned int heigh
 	SDL_GetWindowSize(WZwindow, &resultingWidth, &resultingHeight);
 	if (resultingWidth != width || resultingHeight != height) {
 		// Attempting to set the resolution failed
+		debug(LOG_WZ, "Attempting to change the resolution to %dx%d seems to have failed (result: %dx%d).", width, height, resultingWidth, resultingHeight);
+
 		// Revert to the prior position + resolution + display scale, and return false
 		SDL_SetWindowSize(WZwindow, prev_width, prev_height);
 		SDL_SetWindowPosition(WZwindow, prev_x, prev_y);

--- a/src/frontend.cpp
+++ b/src/frontend.cpp
@@ -2282,9 +2282,10 @@ void frontendScreenSizeDidChange(int oldWidth, int oldHeight, int newWidth, int 
 	// By setting the appropriate calcLayout functions on all interface elements,
 	// they should automatically recalculate their layout on screen resize.
 
-	// If the Video Options screen is up, the current resolution text must be updated
-	if (widgGetFromID(psWScreen, FRONTEND_RESOLUTION_R) != nullptr)
+	// If the Video Options screen is up, the current resolution text (and other values) should be refreshed
+	if (titleMode == VIDEO_OPTIONS)
 	{
-		widgSetString(psWScreen, FRONTEND_RESOLUTION_R, videoOptionsResolutionString().c_str());
+		ASSERT(widgGetFromID(psWScreen, FRONTEND_WINDOWMODE_R) != nullptr, "Expected the Video options menu to be open.");
+		refreshCurrentVideoOptionsValues();
 	}
 }


### PR DESCRIPTION
- [SDL backend] Fix fullscreen toggle on macOS
- [SDL backend] Additional debug logging for resolution changes
- Fix: Properly refresh the Video options menu when toggling fullscreen
- Enable toggling fullscreen / windowed mode from the Video options menu without app restart
- [SDL backend] Use `SDL_WINDOWPOS_CENTERED_DISPLAY(n)` to center window
- [SDL backend] Gracefully fallback to display 0 if desired display doesn't exist