### PR TITLE
Work around mingw + libintl + json.hpp symbol clash

### DIFF
--- a/lib/framework/wzconfig.h
+++ b/lib/framework/wzconfig.h
@@ -20,8 +20,23 @@
 #ifndef WZCONFIG_H
 #define WZCONFIG_H
 
+#if (defined(WZ_OS_WIN) && defined(WZ_CC_MINGW))
+#  if (defined(snprintf) && !defined(_GL_STDIO_H) && defined(_LIBINTL_H))
+// On mingw / MXE builds, libintl's define of snprintf breaks json.hpp
+// So undef it here and restore it later (HACK)
+#    define _wz_restore_libintl_snprintf
+#    undef snprintf
+#  endif
+#endif
+
 #include <3rdparty/json/json.hpp>
 using json = nlohmann::json;
+
+#if defined(_wz_restore_libintl_snprintf)
+#  undef _wz_restore_libintl_snprintf
+#  undef snprintf
+#  define snprintf libintl_snprintf
+#endif
 
 #include <QtCore/QStringList>
 #include <physfs.h>


### PR DESCRIPTION
libintl.h `#defines snprintf`, which conflicts with json.hpp's usage of `std::snprintf`