### PR TITLE
[CMake] Add Asciidoctor support for documentation generation

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -34,7 +34,13 @@ configuration:
   - Release
 
 install:
+  # Initialize Git submodules
   - git submodule update --init --recursive
+  # Setup Ruby path (for Asciidoctor gem install)
+  - set PATH=C:\Ruby25-x64\bin;%PATH%
+  # Install Asciidoctor (for documentation generation)
+  # NOTE: Specify an explicit Asciidoctor version to help ensure reproducible builds
+  - gem install asciidoctor -v 1.5.7.1 --no-rdoc --no-ri --no-document
 
 before_build:
   # Set expanded environment variables for release build jobs

--- a/cmake/FindAsciidoctor.cmake
+++ b/cmake/FindAsciidoctor.cmake
@@ -1,0 +1,61 @@
+# License: MIT License ( https://opensource.org/licenses/MIT )
+#
+# CMake module to find Asciidoctor
+#
+# Variables generated:
+#
+# Asciidoctor_FOUND     true when Asciidoctor_COMMAND is valid
+# Asciidoctor_COMMAND   The command to run Asciidoctor
+# Asciidoctor_VERSION   The Asciidoctor version that has been found
+#
+
+# Try to find an Asciidoctor executable
+find_program(ASCIIDOCTOR_EXECUTABLE asciidoctor)
+find_program(ASCIIDOCTOR_BAT asciidoctor.bat)
+
+if(ASCIIDOCTOR_EXECUTABLE)
+	execute_process(
+		COMMAND ${ASCIIDOCTOR_EXECUTABLE} --version
+		OUTPUT_VARIABLE _ASCIIDOCTOR_COMMAND_OUTPUT
+		ERROR_VARIABLE _ASCIIDOCTOR_COMMAND_ERROR
+		RESULT_VARIABLE _ASCIIDOCTOR_COMMAND_RESULT
+		OUTPUT_STRIP_TRAILING_WHITESPACE
+	)
+
+	# If success, set the ASCIIDOCTOR_COMMAND
+	if(_ASCIIDOCTOR_COMMAND_RESULT MATCHES "^0$")
+		set(Asciidoctor_COMMAND "${ASCIIDOCTOR_EXECUTABLE}")
+
+	# Else, check if running the ASCIIDOCTOR_BAT succeeds (on Windows)
+	elseif((CMAKE_HOST_SYSTEM_NAME MATCHES "Windows") AND ASCIIDOCTOR_BAT)
+		execute_process(
+			COMMAND ${ASCIIDOCTOR_BAT} --version
+			OUTPUT_VARIABLE _ASCIIDOCTOR_COMMAND_OUTPUT
+			ERROR_VARIABLE _ASCIIDOCTOR_COMMAND_ERROR
+			RESULT_VARIABLE _ASCIIDOCTOR_COMMAND_RESULT
+			OUTPUT_STRIP_TRAILING_WHITESPACE
+		)
+
+		if(_ASCIIDOCTOR_COMMAND_RESULT MATCHES "^0$")
+			set(Asciidoctor_COMMAND "${ASCIIDOCTOR_BAT}")
+		endif()
+	endif()
+endif()
+
+# If a command was found, check the version
+if(Asciidoctor_COMMAND)
+	string(REGEX MATCH "[0-9]+\\.[0-9]+\\.[0-9]+" Asciidoctor_VERSION "${_ASCIIDOCTOR_COMMAND_OUTPUT}")
+endif()
+
+unset(ASCIIDOCTOR_EXECUTABLE)
+unset(ASCIIDOCTOR_BAT)
+unset(_ASCIIDOCTOR_COMMAND_OUTPUT)
+unset(_ASCIIDOCTOR_COMMAND_ERROR)
+unset(_ASCIIDOCTOR_COMMAND_RESULT)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(
+	Asciidoctor
+	REQUIRED_VARS Asciidoctor_COMMAND
+	VERSION_VAR Asciidoctor_VERSION
+)

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -27,10 +27,13 @@ install(FILES
 #######################
 # Main documentation
 
-find_package(A2X)
-if(NOT A2X_FOUND)
-	message( WARNING "a2x is not found. Documentation cannot be generated if asciidoc is not installed. (Skipping documentation generation.)" )
-	return()
+find_package(Asciidoctor)
+if(NOT Asciidoctor_FOUND)
+	find_package(A2X)
+	if(NOT A2X_FOUND)
+		message( WARNING "Neither Asciidoctor nor a2x was found. Documentation cannot be generated unless at least one is installed. (Skipping documentation generation.)" )
+		return()
+	endif()
 endif()
 
 set(doc_DATA
@@ -82,38 +85,80 @@ set(doc_DATA
 	"ScriptingManual.htm"
 	"docbook-xsl.css")
 
-add_custom_command(
-	TARGET doc_wz2100
-	COMMAND ${A2X_COMMAND}
-	ARGS
-		"-f"
-		"xhtml"
-		"-D"
-		"${CMAKE_CURRENT_BINARY_DIR}"
-		"${CMAKE_CURRENT_SOURCE_DIR}/quickstartguide.asciidoc"
-	)
+if(Asciidoctor_FOUND)
+	# Prefer Asciidoctor if it's available
 
-add_custom_command(
-	TARGET doc_wz2100
-	COMMAND ${A2X_COMMAND}
-	ARGS
-		"-f"
-		"xhtml"
-		"-D"
-		"${CMAKE_CURRENT_BINARY_DIR}"
-		"${CMAKE_CURRENT_SOURCE_DIR}/warzone2100.6.asciidoc"
-	)
+	configure_file("quickstartguide.asciidoc" "${CMAKE_CURRENT_BINARY_DIR}/quickstartguide.asciidoc" COPYONLY)
 
-if (${WKHTMLTOPDF_AVAILABLE})
+	add_custom_command(
+		TARGET doc_wz2100
+		COMMAND ${Asciidoctor_COMMAND}
+		ARGS
+			"-S"
+			"server"
+			"--failure-level=ERROR"
+			"-B"
+			"${CMAKE_CURRENT_BINARY_DIR}"
+			"-b"
+			"html5"
+			"-D"
+			"${CMAKE_CURRENT_BINARY_DIR}"
+			"${CMAKE_CURRENT_BINARY_DIR}/quickstartguide.asciidoc"
+		)
 
-add_custom_command(
-	TARGET doc_wz2100
-	COMMAND "wkhtmltopdf"
-	ARGS
-		"${CMAKE_CURRENT_SOURCE_DIR}/quickstartguide.htm"
-		"${CMAKE_CURRENT_BINARY_DIR}/quickstartguide.pdf"
-	)
+	configure_file("warzone2100.6.asciidoc" "${CMAKE_CURRENT_BINARY_DIR}/warzone2100.6.asciidoc" COPYONLY)
 
+	add_custom_command(
+		TARGET doc_wz2100
+		COMMAND ${Asciidoctor_COMMAND}
+		ARGS
+			"-S"
+			"server"
+			"--failure-level=ERROR"
+			"-B"
+			"${CMAKE_CURRENT_BINARY_DIR}"
+			"-b"
+			"html5"
+			"-D"
+			"${CMAKE_CURRENT_BINARY_DIR}"
+			"${CMAKE_CURRENT_BINARY_DIR}/warzone2100.6.asciidoc"
+		)
+
+elseif(A2X_FOUND)
+
+	add_custom_command(
+		TARGET doc_wz2100
+		COMMAND ${A2X_COMMAND}
+		ARGS
+			"-f"
+			"xhtml"
+			"-D"
+			"${CMAKE_CURRENT_BINARY_DIR}"
+			"${CMAKE_CURRENT_SOURCE_DIR}/quickstartguide.asciidoc"
+		)
+
+	add_custom_command(
+		TARGET doc_wz2100
+		COMMAND ${A2X_COMMAND}
+		ARGS
+			"-f"
+			"xhtml"
+			"-D"
+			"${CMAKE_CURRENT_BINARY_DIR}"
+			"${CMAKE_CURRENT_SOURCE_DIR}/warzone2100.6.asciidoc"
+		)
+
+	if (${WKHTMLTOPDF_AVAILABLE})
+
+		add_custom_command(
+			TARGET doc_wz2100
+			COMMAND "wkhtmltopdf"
+			ARGS
+				"${CMAKE_CURRENT_SOURCE_DIR}/quickstartguide.htm"
+				"${CMAKE_CURRENT_BINARY_DIR}/quickstartguide.pdf"
+			)
+
+	endif()
 endif()
 
 install(FILES ${doc_DATA} DESTINATION "doc/images/" COMPONENT Core)

--- a/doc/quickstartguide.asciidoc
+++ b/doc/quickstartguide.asciidoc
@@ -740,7 +740,7 @@ image:images/intelligencedisplay.jpg[]
 'Intelligence display with piece of intelligence selected'
 
 What's displayed
-^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~
 
 When you open the Intelligence Display, two rows of icons appear on the bottom
 of the screen. Selecting an icon will display information in the middle of the
@@ -748,7 +748,7 @@ screen. This is helpful for looking at technologies you have researched. During
 Campaign, a piece of intelligence always displayed is your mission objective.
 
 We Brake For Nobody
-^^^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~
 
 Please note that while the Intelligence Display pauses the game in Campaign
 mode, it doesn't do so in Multiplayer and Skirmish!


### PR DESCRIPTION
[Asciidoctor](https://asciidoctor.org) is a fast, modern toolchain for converting AsciiDoc, and may be easier to install on certain systems (especially: Windows).

This also fixes documentation generation for Windows builds on AppVeyor.