### PR TITLE
Fix default-ctor-related issues with GLM 0.9.9.0+

### DIFF
--- a/lib/framework/input.h
+++ b/lib/framework/input.h
@@ -163,7 +163,7 @@ struct MousePress
 {
 	enum Action {None, Press, Release};
 
-	MousePress(Action action = None, MOUSE_KEY_CODE key = MOUSE_END) : action(action), key(key) {}
+	MousePress(Action action = None, MOUSE_KEY_CODE key = MOUSE_END) : action(action), key(key), pos(0,0) {}
 	bool empty() const
 	{
 		return action == None;

--- a/lib/ivis_opengl/bitimage.cpp
+++ b/lib/ivis_opengl/bitimage.cpp
@@ -50,7 +50,7 @@ struct ImageMergeRectangle
 
 	int index;  // Index in ImageDefs array.
 	int page;   // Texture page index.
-	Vector2i loc, siz;
+	Vector2i loc = Vector2i(0, 0), siz = Vector2i(0, 0);
 	iV_Image *data;
 };
 

--- a/lib/ivis_opengl/imdload.cpp
+++ b/lib/ivis_opengl/imdload.cpp
@@ -697,7 +697,7 @@ static iIMDShape *_imd_load_level(const WzString &filename, const char **ppFileD
 			for (int i = 0; i < s.objanimframes; i++)
 			{
 				int frame;
-				Vector3i pos, rot;
+				Vector3i pos(0, 0, 0), rot(0, 0, 0);
 
 				if (sscanf(pFileData, "%d %d %d %d %d %d %d %f %f %f%n",
 				           &frame, &pos.x, &pos.y, &pos.z, &rot.x, &rot.y, &rot.z,

--- a/lib/ivis_opengl/ivisdef.h
+++ b/lib/ivis_opengl/ivisdef.h
@@ -72,18 +72,18 @@ struct EDGE
 
 struct ANIMFRAME
 {
-	Vector3f scale;
-	Position pos;
+	Vector3f scale = Vector3f(0.f, 0.f, 0.f);
+	Position pos = Position(0, 0, 0);
 	Rotation rot;
 };
 
 struct iIMDPoly
 {
 	Vector2f *texCoord = nullptr;
-	Vector2f texAnim;
+	Vector2f texAnim = Vector2f(0.f, 0.f);
 	uint32_t flags = 0;
 	int32_t zcentre = 0;
-	Vector3f normal;
+	Vector3f normal = Vector3f(0.f, 0.f, 0.f);
 	int pindex[3] = { 0 };
 };
 
@@ -110,8 +110,8 @@ struct iIMDShape
 {
 	~iIMDShape();
 
-	Vector3i min;
-	Vector3i max;
+	Vector3i min = Vector3i(0, 0, 0);
+	Vector3i max = Vector3i(0, 0, 0);
 	unsigned int flags = 0;
 	int texpage = iV_TEX_INVALID;
 	int tcmaskpage = iV_TEX_INVALID;
@@ -120,7 +120,7 @@ struct iIMDShape
 	int sradius = 0;
 	int radius = 0;
 
-	Vector3f ocen;
+	Vector3f ocen = Vector3f(0.f, 0.f, 0.f);
 	unsigned short numFrames = 0;
 	unsigned short animInterval = 0;
 

--- a/lib/ivis_opengl/piedraw.cpp
+++ b/lib/ivis_opengl/piedraw.cpp
@@ -115,7 +115,7 @@ void pie_setShadows(bool drawShadows)
 	shadows = drawShadows;
 }
 
-static Vector3f currentSunPosition;
+static Vector3f currentSunPosition(0.f, 0.f, 0.f);
 
 void pie_BeginLighting(const Vector3f &light)
 {

--- a/lib/ivis_opengl/piefunc.cpp
+++ b/lib/ivis_opengl/piefunc.cpp
@@ -54,6 +54,7 @@ void pie_SetViewingWindow(Vector3i *v, PIELIGHT colour)
 		radarViewGfx[1] = new GFX(GFX_COLOUR, GL_LINE_STRIP, 2);
 	}
 
+	static_assert(VW_VERTICES == 5, "Assumption that VW_VERTICES == 5 invalid. Update the following code.");
 	pieVrts[0] = v[1];
 	pieVrts[1] = v[0];
 	pieVrts[2] = v[2];

--- a/lib/ivis_opengl/textdraw.h
+++ b/lib/ivis_opengl/textdraw.h
@@ -74,8 +74,8 @@ private:
 	int mPtsAboveBase = 0;
 	int mPtsBelowBase = 0;
 	int mPtsLineSize = 0;
-	Vector2i offsets;
-	Vector2i dimensions;
+	Vector2i offsets = Vector2i(0, 0);
+	Vector2i dimensions = Vector2i(0, 0);
 	float mRenderingHorizScaleFactor = 0.f;
 	float mRenderingVertScaleFactor = 0.f;
 	iV_fonts mFontID = font_count;

--- a/src/action.cpp
+++ b/src/action.cpp
@@ -1853,7 +1853,7 @@ static void actionDroidBase(DROID *psDroid, DROID_ACTION_DATA *psAction)
 	ASSERT_OR_RETURN(, psAction->psObj == nullptr || !psAction->psObj->died, "Droid dead");
 
 	WEAPON_STATS *psWeapStats = getWeaponStats(psDroid, 0);
-	Vector2i pos;
+	Vector2i pos(0, 0);
 
 	CHECK_DROID(psDroid);
 
@@ -2355,7 +2355,7 @@ bool actionVTOLLandingPos(DROID const *psDroid, Vector2i *p)
 	// set blocking flags for all the other droids
 	for (const DROID *psCurr = apsDroidLists[psDroid->player]; psCurr; psCurr = psCurr->psNext)
 	{
-		Vector2i t;
+		Vector2i t(0, 0);
 		if (DROID_STOPPED(psCurr))
 		{
 			t = map_coord(psCurr->pos.xy);
@@ -2374,7 +2374,7 @@ bool actionVTOLLandingPos(DROID const *psDroid, Vector2i *p)
 	}
 
 	// search for landing tile; will stop when found or radius exceeded
-	Vector2i xyCoords;
+	Vector2i xyCoords(0, 0);
 	const bool foundTile = spiralSearch(startX, startY, vtolLandingRadius,
 	                                    vtolLandingTileSearchFunction, &xyCoords);
 	if (foundTile)
@@ -2387,7 +2387,7 @@ bool actionVTOLLandingPos(DROID const *psDroid, Vector2i *p)
 	// clear blocking flags for all the other droids
 	for (DROID *psCurr = apsDroidLists[psDroid->player]; psCurr; psCurr = psCurr->psNext)
 	{
-		Vector2i t;
+		Vector2i t(0, 0);
 		if (DROID_STOPPED(psCurr))
 		{
 			t = map_coord(psCurr->pos.xy);

--- a/src/astar.cpp
+++ b/src/astar.cpp
@@ -516,7 +516,7 @@ ASR_RETVAL fpathAStarRoute(MOVE_CONTROL *psMove, PATHJOB *psJob)
 	static std::vector<Vector2i> path;  // Declared static to save allocations.
 	path.clear();
 
-	Vector2i newP;
+	Vector2i newP(0, 0);
 	for (Vector2i p(world_coord(endCoord.x) + TILE_UNITS / 2, world_coord(endCoord.y) + TILE_UNITS / 2); true; p = newP)
 	{
 		ASSERT_OR_RETURN(ASR_FAILED, worldOnMap(p.x, p.y), "Assigned XY coordinates (%d, %d) not on map!", (int)p.x, (int)p.y);

--- a/src/basedef.h
+++ b/src/basedef.h
@@ -88,7 +88,7 @@ struct SIMPLE_OBJECT
 
 	const OBJECT_TYPE type;                         ///< The type of object
 	UDWORD          id;                             ///< ID number of the object
-	Position        pos;                            ///< Position of the object
+	Position        pos = Position(0, 0, 0);        ///< Position of the object
 	Rotation        rot;                            ///< Object's yaw +ve rotation around up-axis
 	UBYTE           player;                         ///< Which player the object belongs to
 	UDWORD          born;                           ///< Time the game object was born
@@ -144,9 +144,9 @@ struct Spacetime
 	Spacetime() {}
 	Spacetime(Position pos_, Rotation rot_, uint32_t time_) : time(time_), pos(pos_), rot(rot_) {}
 
-	uint32_t time = 0;  ///< Game time
-	Position pos;       ///< Position of the object
-	Rotation rot;       ///< Rotation of the object
+	uint32_t time = 0;                  ///< Game time
+	Position pos = Position(0, 0, 0);   ///< Position of the object
+	Rotation rot;                       ///< Rotation of the object
 };
 
 static inline Spacetime getSpacetime(SIMPLE_OBJECT const *psObj)

--- a/src/baseobject.h
+++ b/src/baseobject.h
@@ -34,7 +34,10 @@ struct Spacetime;
 
 struct StructureBounds
 {
-	StructureBounds() {}
+	StructureBounds()
+		: map(0,0)
+		, size(0,0)
+	{}
 	StructureBounds(Vector2i const &map, Vector2i const &size) : map(map), size(size) {}
 	bool valid()
 	{

--- a/src/bucket3d.cpp
+++ b/src/bucket3d.cpp
@@ -62,8 +62,8 @@ static std::vector<BUCKET_TAG> bucketArray;
 static SDWORD bucketCalculateZ(RENDER_TYPE objectType, void *pObject, const glm::mat4 &viewMatrix)
 {
 	SDWORD				z = 0, radius;
-	Vector2i				pixel;
-	Vector3i				position;
+	Vector2i				pixel(0, 0);
+	Vector3i				position(0, 0, 0);
 	UDWORD				droidSize;
 	DROID				*psDroid;
 	BODY_STATS			*psBStats;

--- a/src/display3d.cpp
+++ b/src/display3d.cpp
@@ -1254,7 +1254,7 @@ bool clipXY(SDWORD x, SDWORD y)
 
 bool clipXYZNormalized(const Vector3i &normalizedPosition, const glm::mat4 &viewMatrix)
 {
-	Vector2i pixel;
+	Vector2i pixel(0, 0);
 	pie_RotateProject(&normalizedPosition, viewMatrix, &pixel);
 	return pixel.x >= 0 && pixel.y >= 0 && pixel.x < pie_GetVideoBufferWidth() && pixel.y < pie_GetVideoBufferHeight();
 }
@@ -1275,7 +1275,7 @@ bool clipShapeOnScreen(const iIMDShape *pIMD, const glm::mat4& viewModelMatrix, 
 {
 	/* Get its absolute dimensions */
 	Vector3i origin;
-	Vector2i center;
+	Vector2i center(0, 0);
 	int wsRadius = 22; // World space radius, 22 = magic minimum
 	float radius;
 
@@ -3215,7 +3215,7 @@ void calcScreenCoords(DROID *psDroid, const glm::mat4 &viewMatrix)
 	/* Get it's absolute dimensions */
 	const BODY_STATS *psBStats = asBodyStats + psDroid->asBits[COMP_BODY];
 	Vector3i origin;
-	Vector2i center;
+	Vector2i center(0, 0);
 	int wsRadius = 22; // World space radius, 22 = magic minimum
 	float radius;
 

--- a/src/display3d.h
+++ b/src/display3d.h
@@ -49,7 +49,8 @@ enum ENERGY_BAR
 
 struct iView
 {
-	Vector3i p, r;
+	Vector3i p = Vector3i(0, 0, 0);
+	Vector3i r = Vector3i(0, 0, 0);
 };
 
 extern bool showFPS;

--- a/src/effects.h
+++ b/src/effects.h
@@ -142,7 +142,7 @@ struct EFFECT
 	EFFECT *prev, *next; // Previous and next element in linked list
 
 	EFFECT() : player(MAX_PLAYERS), control(0), group(EFFECT_FREED), type(EXPLOSION_TYPE_SMALL), frameNumber(0), size(0),
-	           baseScale(0), specific(0), birthTime(0), lastFrame(0), frameDelay(0), lifeSpan(0), radius(0),
+	           baseScale(0), specific(0), position(0.f, 0.f, 0.f), velocity(0.f, 0.f, 0.f), rotation(0, 0, 0), spin(0, 0, 0), birthTime(0), lastFrame(0), frameDelay(0), lifeSpan(0), radius(0),
 	           imd(nullptr), prev(nullptr), next(nullptr) {}
 };
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -4537,7 +4537,6 @@ static bool loadSaveDroid(const char *pFileName, DROID **ppsCurrentDroidLists)
 		int id = ini.value("id", -1).toInt();
 		Position pos = ini.vector3i("position");
 		Rotation rot = ini.vector3i("rotation");
-		Vector2i tmp;
 		bool onMission = ini.value("onMission", false).toBool();
 		DROID_TEMPLATE templ, *psTemplate = &templ;
 
@@ -4673,7 +4672,7 @@ static bool loadSaveDroid(const char *pFileName, DROID **ppsCurrentDroidLists)
 		}
 		psDroid->sMove.lastBump = ini.value("lastBump").toInt();
 		psDroid->sMove.pauseTime = ini.value("pauseTime").toInt();
-		tmp = ini.vector2i("bumpPosition");
+		Vector2i tmp = ini.vector2i("bumpPosition");
 		psDroid->sMove.bumpPos = Vector3i(tmp.x, tmp.y, 0);
 
 		// Recreate path-finding jobs

--- a/src/geometry.h
+++ b/src/geometry.h
@@ -25,7 +25,7 @@
 
 struct QUAD
 {
-	Vector2i coords[4];
+	Vector2i coords[4] = {{0,0}, {0,0}, {0,0}, {0,0}};
 };
 
 uint16_t calcDirection(int32_t x0, int32_t y0, int32_t x1, int32_t y1);

--- a/src/lighting.cpp
+++ b/src/lighting.cpp
@@ -52,8 +52,8 @@
 #define FOG_END_SCALE 0.6
 
 /*	The vector that holds the sun's lighting direction - planar */
-static Vector3f theSun;
-static Vector3f theSun_ForTileIllumination;
+static Vector3f theSun(0.f, 0.f, 0.f);
+static Vector3f theSun_ForTileIllumination(0.f, 0.f, 0.f);
 
 /*	Module function Prototypes */
 static UDWORD calcDistToTile(UDWORD tileX, UDWORD tileY, Vector3i *pos);

--- a/src/lighting.h
+++ b/src/lighting.h
@@ -25,7 +25,7 @@
 
 struct LIGHT
 {
-	Vector3i position;
+	Vector3i position = Vector3i(0, 0, 0);
 	UDWORD range;
 	PIELIGHT colour;
 };

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -1781,7 +1781,7 @@ static int dangerFloodFill(int player)
 {
 	int i;
 	Vector2i pos = getPlayerStartPosition(player);
-	Vector2i npos;
+	Vector2i npos(0, 0);
 	uint8_t aux, block;
 	int x, y;
 	bool start = true;	// hack to disregard the blocking status of any building exactly on the starting position

--- a/src/mission.cpp
+++ b/src/mission.cpp
@@ -271,7 +271,10 @@ void initMission()
 	}
 
 	// init the vtol return pos
-	memset(asVTOLReturnPos, 0, sizeof(Vector2i) * MAX_PLAYERS);
+	for (size_t i = 0; i < MAX_PLAYERS; ++i)
+	{
+		asVTOLReturnPos[i] = Vector2i(0, 0);
+	}
 
 	bDroidsToSafety = false;
 	setPlayCountDown(true);
@@ -283,7 +286,10 @@ void initMission()
 // reset the vtol landing pos
 void resetVTOLLandingPos()
 {
-	memset(asVTOLReturnPos, 0, sizeof(Vector2i)*MAX_PLAYERS);
+	for (size_t i = 0; i < MAX_PLAYERS; ++i)
+	{
+		asVTOLReturnPos[i] = Vector2i(0, 0);
+	}
 }
 
 //this is called everytime the game is quit

--- a/src/move.cpp
+++ b/src/move.cpp
@@ -2039,7 +2039,7 @@ void moveUpdateDroid(DROID *psDroid)
 	SDWORD				moveSpeed;
 	uint16_t			moveDir;
 	PROPULSION_STATS	*psPropStats;
-	Vector3i 			pos;
+	Vector3i 			pos(0, 0, 0);
 	bool				bStarted = false, bStopped;
 
 	CHECK_DROID(psDroid);

--- a/src/movedef.h
+++ b/src/movedef.h
@@ -47,9 +47,9 @@ struct MOVE_CONTROL
 	int pathIndex = 0;                    ///< Position in asPath
 	std::vector<Vector2i> asPath;         ///< Pointer to list of block X,Y map coordinates.
 
-	Vector2i destination;                 ///< World coordinates of movement destination
-	Vector2i src;
-	Vector2i target;
+	Vector2i destination = Vector2i(0, 0);                 ///< World coordinates of movement destination
+	Vector2i src = Vector2i(0, 0);
+	Vector2i target = Vector2i(0, 0);
 	int speed = 0;                        ///< Speed of motion
 
 	uint16_t moveDir = 0;                 ///< Direction of motion (not the direction the droid is facing)
@@ -57,7 +57,7 @@ struct MOVE_CONTROL
 	unsigned bumpTime = 0;                ///< Time of first bump with something
 	uint16_t lastBump = 0;                ///< Time of last bump with a droid - relative to bumpTime
 	uint16_t pauseTime = 0;               ///< When MOVEPAUSE started - relative to bumpTime
-	Position bumpPos;                     ///< Position of last bump
+	Position bumpPos = Position(0, 0, 0); ///< Position of last bump
 
 	unsigned shuffleStart = 0;            ///< When a shuffle started
 

--- a/src/multibot.cpp
+++ b/src/multibot.cpp
@@ -162,12 +162,12 @@ struct QueuedDroidInfo
 	DROID_ORDER order = DORDER_NONE;
 	uint32_t    destId = 0;     // if (subType == ObjOrder)
 	OBJECT_TYPE destType = OBJ_DROID;   // if (subType == ObjOrder)
-	Vector2i    pos;            // if (subType == LocOrder)
+	Vector2i    pos = Vector2i(0, 0);            // if (subType == LocOrder)
 	uint32_t    y = 0;          // if (subType == LocOrder)
 	uint32_t    structRef = 0;  // if (order == DORDER_BUILD || order == DORDER_LINEBUILD)
 	uint16_t    direction = 0;  // if (order == DORDER_BUILD || order == DORDER_LINEBUILD)
 	uint32_t    index = 0;      // if (order == DORDER_BUILDMODULE)
-	Vector2i    pos2;           // if (order == DORDER_LINEBUILD)
+	Vector2i    pos2 = Vector2i(0, 0);           // if (order == DORDER_LINEBUILD)
 	bool        add = false;
 	// subType == SecondaryOrder
 	SECONDARY_ORDER secOrder = DSO_UNUSED;

--- a/src/multiint.cpp
+++ b/src/multiint.cpp
@@ -541,7 +541,10 @@ static void loadEmptyMapPreview()
 
 	// Slight hack to init array with a special value used to determine how many players on map
 	Vector2i playerpos[MAX_PLAYERS];
-	memset(playerpos, 0x77, sizeof(playerpos));
+	for (size_t i = 0; i < MAX_PLAYERS; ++i)
+	{
+		playerpos[i] = Vector2i(0x77777777, 0x77777777);
+	}
 
 	screen_enableMapPreview(ex, ey, playerpos);
 
@@ -698,7 +701,10 @@ void loadMapPreview(bool hideInterface)
 		psTile += mapWidth;
 	}
 	// Slight hack to init array with a special value used to determine how many players on map
-	memset(playerpos, 0x77, sizeof(playerpos));
+	for (size_t i = 0; i < MAX_PLAYERS; ++i)
+	{
+		playerpos[i] = Vector2i(0x77777777, 0x77777777);
+	}
 	// color our texture with clancolors @ correct position
 	plotStructurePreview16(imageData, playerpos);
 

--- a/src/multiplay.cpp
+++ b/src/multiplay.cpp
@@ -130,8 +130,7 @@ void turnOffMultiMsg(bool bDoit)
 // throw a party when you win!
 bool multiplayerWinSequence(bool firstCall)
 {
-	static Position pos;
-	Position pos2;
+	static Position pos = Position(0, 0, 0);
 	static UDWORD last = 0;
 	float		rotAmount;
 	STRUCTURE	*psStruct;
@@ -176,7 +175,7 @@ bool multiplayerWinSequence(bool firstCall)
 
 	if (rand() % 3 == 0)
 	{
-		pos2 = pos;
+		Position pos2 = pos;
 		pos2.x += (rand() % world_coord(8)) - world_coord(4);
 		pos2.z += (rand() % world_coord(8)) - world_coord(4);
 
@@ -564,7 +563,6 @@ int scavengerPlayer()
 // probably temporary. Places the camera on the players 1st droid or struct.
 Vector3i cameraToHome(UDWORD player, bool scroll)
 {
-	Vector3i res;
 	UDWORD x, y;
 	STRUCTURE	*psBuilding;
 
@@ -601,6 +599,7 @@ Vector3i cameraToHome(UDWORD player, bool scroll)
 		setViewPos(x, y, true);
 	}
 
+	Vector3i res;
 	res.x = world_coord(x);
 	res.y = map_TileHeight(x, y);
 	res.z = world_coord(y);

--- a/src/order.cpp
+++ b/src/order.cpp
@@ -2143,7 +2143,7 @@ void orderDroidAddPending(DROID *psDroid, DROID_ORDER_DATA *psOrder)
 	// Only display one arrow, bOrderEffectDisplayed must be set to false once per arrow.
 	if (!bOrderEffectDisplayed)
 	{
-		Vector3i position;
+		Vector3i position(0, 0, 0);
 		if (psOrder->psObj == nullptr)
 		{
 			position.x = psOrder->pos.x;

--- a/src/orderdef.h
+++ b/src/orderdef.h
@@ -144,7 +144,7 @@ enum SECONDARY_STATE
 /** struct used to store the data for retreating. */
 struct RUN_DATA
 {
-	Vector2i sPos;           ///< position to where units should flee to.
+	Vector2i sPos = Vector2i(0, 0); ///< position to where units should flee to.
 	uint8_t forceLevel = 0;  ///< number of units below which others might flee.
 	uint8_t healthLevel = 0; ///< health percentage value below which it might flee. This value is used for groups only.
 	uint8_t leadership = 0;  ///< basic value that will be used on calculations of the flee probability.

--- a/src/projectile.cpp
+++ b/src/projectile.cpp
@@ -97,7 +97,7 @@ BASE_OBJECT		*g_pProjLastAttacker;
 
 struct ObjectShape
 {
-	ObjectShape() {}
+	ObjectShape() : isRectangular(false), size(0, 0) {}
 	ObjectShape(int radius) : isRectangular(false), size(radius, radius) {}
 	ObjectShape(int width, int breadth) : isRectangular(true), size(width, breadth) {}
 	ObjectShape(Vector2i widthBreadth) : isRectangular(true), size(widthBreadth) {}

--- a/src/projectiledef.h
+++ b/src/projectiledef.h
@@ -60,8 +60,8 @@ struct PROJECTILE : public SIMPLE_OBJECT
 	BASE_OBJECT    *psDest;                 ///< target of this projectile
 	std::vector<BASE_OBJECT *> psDamaged;   ///< the targets that have already been dealt damage to (don't damage the same target twice)
 
-	Vector3i        src;                    ///< Where projectile started
-	Vector3i        dst;                    ///< The target coordinates
+	Vector3i        src = Vector3i(0, 0, 0); ///< Where projectile started
+	Vector3i        dst = Vector3i(0, 0, 0); ///< The target coordinates
 	SDWORD          vXY, vZ;                ///< axis velocities
 	Spacetime       prevSpacetime;          ///< Location of projectile in previous tick.
 	UDWORD          expectedDamageCaused;   ///< Expected damage that this projectile will cause to the target.

--- a/src/radar.cpp
+++ b/src/radar.cpp
@@ -65,7 +65,7 @@ bool radarRotationArrow; ///< display arrow when radar rotation enabled?
 static PIELIGHT		colRadarAlly, colRadarMe, colRadarEnemy;
 static PIELIGHT		tileColours[MAX_TILES];
 static UDWORD		*radarBuffer = nullptr;
-static Vector3i		playerpos;
+static Vector3i		playerpos = {0, 0, 0};
 
 PIELIGHT clanColours[] =
 {
@@ -565,7 +565,7 @@ static SDWORD getLengthAdjust()
 static void setViewingWindow()
 {
 	float pixSizeH, pixSizeV;
-	Vector3i v[4], tv[4], centre;
+	Vector3i v[4] = {{0, 0, 0}}, tv[4] = {{0, 0, 0}}, centre = {0, 0, 0};
 	int	shortX, longX, yDrop, yDropVar;
 	int	dif = getDistanceAdjust();
 	int	dif2 = getLengthAdjust();

--- a/src/raycast.cpp
+++ b/src/raycast.cpp
@@ -73,7 +73,7 @@ void rayCast(Vector2i src, Vector2i dst, RAY_CALLBACK callback, void *data)
 	Vector2i srcM = map_coord(src);
 	Vector2i dstM = map_coord(dst);
 
-	Vector2i step, tile, cur, end;
+	Vector2i step(0, 0), tile(0, 0), cur(0, 0), end(0, 0);
 	initSteps(srcM.x, dstM.x, tile.x, step.x, cur.x, end.x);
 	initSteps(srcM.y, dstM.y, tile.y, step.y, cur.y, end.y);
 

--- a/src/scriptfuncs.cpp
+++ b/src/scriptfuncs.cpp
@@ -111,7 +111,7 @@ static bool	structHasModule(STRUCTURE *psStruct);
 static DROID_TEMPLATE *scrCheckTemplateExists(SDWORD player, DROID_TEMPLATE *psTempl);
 
 /// Hold the previously assigned player
-Vector2i positions[MAX_PLAYERS];
+Vector2i positions[MAX_PLAYERS] = {{0,0}};
 std::vector<Vector2i> derricks;
 
 bool scriptOperatorEquals(INTERP_VAL const &v1, INTERP_VAL const &v2)

--- a/src/structuredef.h
+++ b/src/structuredef.h
@@ -66,7 +66,7 @@ enum STRUCTURE_TYPE
 
 struct FLAG_POSITION : public OBJECT_POSITION
 {
-	Vector3i coords;               //the world coords of the Position
+	Vector3i coords = Vector3i(0, 0, 0); //the world coords of the Position
 	UBYTE    factoryInc;           //indicates whether the first, second etc factory
 	UBYTE    factoryType;          //indicates whether standard, cyborg or vtol factory
 	FLAG_POSITION *psNext;

--- a/src/terrain.cpp
+++ b/src/terrain.cpp
@@ -85,8 +85,8 @@ using RenderVertex = Vector3f;
 /// A vertex with a position and texture coordinates
 struct DecalVertex
 {
-	Vector3f pos;
-	Vector2f uv;
+	Vector3f pos = Vector3f(0.f, 0.f, 0.f);
+	Vector2f uv = Vector2f(0.f, 0.f);
 };
 
 /// The lightmap texture

--- a/src/visibility.cpp
+++ b/src/visibility.cpp
@@ -925,9 +925,9 @@ static inline void angle_check(int64_t *angletan, int positionSq, int height, in
  */
 static int checkFireLine(const SIMPLE_OBJECT *psViewer, const BASE_OBJECT *psTarget, int weapon_slot, bool wallsBlock, bool direct)
 {
-	Vector3i pos, dest;
-	Vector2i start, diff, current, halfway, next, part;
-	Vector3i muzzle;
+	Vector3i pos(0, 0, 0), dest(0, 0, 0);
+	Vector2i start(0, 0), diff(0, 0), current(0, 0), halfway(0, 0), next(0, 0), part(0, 0);
+	Vector3i muzzle(0, 0, 0);
 	int distSq, partSq, oldPartSq;
 	int64_t angletan;
 

--- a/src/warcam.cpp
+++ b/src/warcam.cpp
@@ -66,13 +66,13 @@ struct WARCAM
 	UDWORD lastUpdate;
 	iView oldView;
 
-	Vector3f acceleration;
-	Vector3f velocity;
-	Vector3f position;
+	Vector3f acceleration = Vector3f(0.f, 0.f, 0.f);
+	Vector3f velocity = Vector3f(0.f, 0.f, 0.f);
+	Vector3f position = Vector3f(0.f, 0.f, 0.f);
 
-	Vector3f rotation;
-	Vector3f rotVel;
-	Vector3f rotAccel;
+	Vector3f rotation = Vector3f(0.f, 0.f, 0.f);
+	Vector3f rotVel = Vector3f(0.f, 0.f, 0.f);
+	Vector3f rotAccel = Vector3f(0.f, 0.f, 0.f);
 
 	UDWORD oldDistance;
 	BASE_OBJECT *target;


### PR DESCRIPTION
Because of default-ctor-related changes in GLM 0.9.9.0+, initialization of GLM types must now be explicit.

This was caught in the previous GLM upgrade commit for most GLM types. This commit fixes it for a few typedefs to GLM types.

Closes ticket:4807.
