### PR TITLE
Clear out fPath tasks when a game shuts down

### DIFF
--- a/src/fpath.cpp
+++ b/src/fpath.cpp
@@ -124,12 +124,12 @@ bool fpathInitialise()
 
 void fpathShutdown()
 {
-	// Signal the path finding thread to quit
-	fpathQuit = true;
-	wzSemaphorePost(fpathSemaphore);  // Wake up thread.
-
 	if (fpathThread)
 	{
+		// Signal the path finding thread to quit
+		fpathQuit = true;
+		wzSemaphorePost(fpathSemaphore);  // Wake up thread.
+
 		wzThreadJoin(fpathThread);
 		fpathThread = nullptr;
 		wzMutexDestroy(fpathMutex);

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1325,6 +1325,8 @@ bool stageThreeShutDown()
 
 	setScriptWinLoseVideo(PLAY_NONE);
 
+	fpathShutdown();
+
 	return true;
 }
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -714,11 +714,6 @@ bool systemInitialise(float horizScaleFactor, float vertScaleFactor)
 		return false;
 	}
 
-	if (!fpathInitialise())
-	{
-		return false;
-	}
-
 	// Initialize the iVis text rendering module
 	wzSceneBegin("Main menu loop");
 	iV_TextInit(horizScaleFactor, vertScaleFactor);


### PR DESCRIPTION
Please see ticket "Astar crash?": http://developer.wz2100.net/ticket/4810

Starting and quitting multiple skirmish games (with different maps) fairly quickly can lead to a crash inside the fPath / astar system. 

The fPath job/task queue is not being cleared / shutdown when a game shuts down - only on "system" (i.e. "app") shutdown. 

@perim: Any objections to this fix? (Those tasks / jobs are invalid once a game ends, so it sure seems like they ought to be cleared.)