### PR TITLE
Add missing data file CRC checks

### DIFF
--- a/lib/framework/wzconfig.cpp
+++ b/lib/framework/wzconfig.cpp
@@ -141,6 +141,17 @@ WzConfig::WzConfig(const WzString &name, WzConfig::warning warning)
 	pCurrentObj = &mRoot;
 }
 
+bool WzConfig::isAtDocumentRoot() const
+{
+	return pCurrentObj == &mRoot;
+}
+
+std::string WzConfig::compactStringRepresentation(const bool ensure_ascii) const
+{
+	// Use the most compact representation of the JSON
+	return mRoot.dump(-1, ' ', ensure_ascii);
+}
+
 std::vector<WzString> WzConfig::childGroups() const
 {
 	std::vector<WzString> keys;

--- a/lib/framework/wzconfig.h
+++ b/lib/framework/wzconfig.h
@@ -129,6 +129,8 @@ public:
 	bool beginGroup(const WzString &name);
 	void endGroup();
 
+	bool isAtDocumentRoot() const;
+
 	WzString fileName() const
 	{
 		return mFilename;
@@ -151,6 +153,8 @@ public:
 	{
 		return mStatus;
 	}
+
+	std::string compactStringRepresentation(const bool ensure_ascii = false) const;
 };
 
 // Enable JSON support for custom types

--- a/src/data.cpp
+++ b/src/data.cpp
@@ -66,7 +66,7 @@ uint32_t	DataHash[DATA_MAXDATA] = {0};
 *	This is almost the same routine that Pumpkin had, minus the ugly bug :)
 *	And minus the old algorithm and debugging trace, replaced with a simple CRC...
 */
-static UDWORD	hashBuffer(uint8_t *pData, uint32_t size)
+static UDWORD	hashBuffer(const uint8_t *pData, uint32_t size)
 {
 	char nl = '\n';
 	uint32_t crc = 0;
@@ -94,7 +94,7 @@ static UDWORD	hashBuffer(uint8_t *pData, uint32_t size)
 
 // create the hash for that data block.
 // Data should be converted to Network byte order
-static void calcDataHash(uint8_t *pBuffer, uint32_t size, uint32_t index)
+static void calcDataHash(const uint8_t *pBuffer, uint32_t size, uint32_t index)
 {
 	const uint32_t oldHash = DataHash[index];
 
@@ -113,6 +113,12 @@ static void calcDataHash(uint8_t *pBuffer, uint32_t size, uint32_t index)
 	debug(LOG_NET, "DataHash[%2u] = %08x", index, DataHash[index]);
 
 	return;
+}
+
+static void calcDataHash(const WzConfig &ini, uint32_t index)
+{
+	std::string jsonDump = ini.compactStringRepresentation();
+	calcDataHash(reinterpret_cast<const uint8_t *>(jsonDump.data()), jsonDump.size(), index);
 }
 
 void resetDataHash()
@@ -140,7 +146,10 @@ void dataClearSaveFlag()
 /* Load the body stats */
 static bool bufferSBODYLoad(const char *fileName, void **ppData)
 {
-	if (!loadBodyStats(fileName) || !allocComponentList(COMP_BODY, numBodyStats))
+	WzConfig ini(fileName, WzConfig::ReadOnlyAndRequired);
+	calcDataHash(ini, DATA_SBODY);
+
+	if (!loadBodyStats(ini) || !allocComponentList(COMP_BODY, numBodyStats))
 	{
 		return false;
 	}
@@ -159,7 +168,10 @@ static void dataReleaseStats(WZ_DECL_UNUSED void *pData)
 /* Load the weapon stats */
 static bool bufferSWEAPONLoad(const char *fileName, void **ppData)
 {
-	if (!loadWeaponStats(fileName)
+	WzConfig ini(fileName, WzConfig::ReadOnlyAndRequired);
+	calcDataHash(ini, DATA_SWEAPON);
+
+	if (!loadWeaponStats(ini)
 	    || !allocComponentList(COMP_WEAPON, numWeaponStats))
 	{
 		return false;
@@ -173,7 +185,10 @@ static bool bufferSWEAPONLoad(const char *fileName, void **ppData)
 /* Load the constructor stats */
 static bool bufferSCONSTRLoad(const char *fileName, void **ppData)
 {
-	if (!loadConstructStats(fileName)
+	WzConfig ini(fileName, WzConfig::ReadOnlyAndRequired);
+	calcDataHash(ini, DATA_SCONSTR);
+
+	if (!loadConstructStats(ini)
 	    || !allocComponentList(COMP_CONSTRUCT, numConstructStats))
 	{
 		return false;
@@ -187,7 +202,10 @@ static bool bufferSCONSTRLoad(const char *fileName, void **ppData)
 /* Load the ECM stats */
 static bool bufferSECMLoad(const char *fileName, void **ppData)
 {
-	if (!loadECMStats(fileName)
+	WzConfig ini(fileName, WzConfig::ReadOnlyAndRequired);
+	calcDataHash(ini, DATA_SECM);
+
+	if (!loadECMStats(ini)
 	    || !allocComponentList(COMP_ECM, numECMStats))
 	{
 		return false;
@@ -201,7 +219,10 @@ static bool bufferSECMLoad(const char *fileName, void **ppData)
 /* Load the Propulsion stats */
 static bool bufferSPROPLoad(const char *fileName, void **ppData)
 {
-	if (!loadPropulsionStats(fileName) || !allocComponentList(COMP_PROPULSION, numPropulsionStats))
+	WzConfig ini(fileName, WzConfig::ReadOnlyAndRequired);
+	calcDataHash(ini, DATA_SPROP);
+
+	if (!loadPropulsionStats(ini) || !allocComponentList(COMP_PROPULSION, numPropulsionStats))
 	{
 		return false;
 	}
@@ -213,7 +234,10 @@ static bool bufferSPROPLoad(const char *fileName, void **ppData)
 
 static bool bufferSSENSORLoad(const char *fileName, void **ppData)
 {
-	if (!loadSensorStats(fileName)
+	WzConfig ini(fileName, WzConfig::ReadOnlyAndRequired);
+	calcDataHash(ini, DATA_SSENSOR);
+
+	if (!loadSensorStats(ini)
 	    || !allocComponentList(COMP_SENSOR, numSensorStats))
 	{
 		return false;
@@ -227,7 +251,10 @@ static bool bufferSSENSORLoad(const char *fileName, void **ppData)
 /* Load the Repair stats */
 static bool bufferSREPAIRLoad(const char *fileName, void **ppData)
 {
-	if (!loadRepairStats(fileName) || !allocComponentList(COMP_REPAIRUNIT, numRepairStats))
+	WzConfig ini(fileName, WzConfig::ReadOnlyAndRequired);
+	calcDataHash(ini, DATA_SREPAIR);
+
+	if (!loadRepairStats(ini) || !allocComponentList(COMP_REPAIRUNIT, numRepairStats))
 	{
 		return false;
 	}
@@ -240,7 +267,10 @@ static bool bufferSREPAIRLoad(const char *fileName, void **ppData)
 /* Load the Brain stats */
 static bool bufferSBRAINLoad(const char *fileName, void **ppData)
 {
-	if (!loadBrainStats(fileName) || !allocComponentList(COMP_BRAIN, numBrainStats))
+	WzConfig ini(fileName, WzConfig::ReadOnlyAndRequired);
+	calcDataHash(ini, DATA_SBRAIN);
+
+	if (!loadBrainStats(ini) || !allocComponentList(COMP_BRAIN, numBrainStats))
 	{
 		return false;
 	}
@@ -252,11 +282,13 @@ static bool bufferSBRAINLoad(const char *fileName, void **ppData)
 /* Load the PropulsionType stats */
 static bool bufferSPROPTYPESLoad(const char *fileName, void **ppData)
 {
-	if (!loadPropulsionTypes(fileName))
+	WzConfig ini(fileName, WzConfig::ReadOnlyAndRequired);
+	calcDataHash(ini, DATA_SPROPTY);
+
+	if (!loadPropulsionTypes(ini))
 	{
 		return false;
 	}
-
 
 	//not interested in this value
 	*ppData = nullptr;
@@ -279,7 +311,10 @@ static bool bufferSPROPSNDLoad(const char *fileName, void **ppData)
 /* Load the STERRTABLE stats */
 static bool bufferSTERRTABLELoad(const char *fileName, void **ppData)
 {
-	if (!loadTerrainTable(fileName))
+	WzConfig ini(fileName, WzConfig::ReadOnlyAndRequired);
+	calcDataHash(ini, DATA_STERRT);
+
+	if (!loadTerrainTable(ini))
 	{
 		return false;
 	}
@@ -300,7 +335,10 @@ static bool bufferSBPIMDLoad(const char *fileName, void **ppData)
 /* Load the Weapon Effect modifier stats */
 static bool bufferSWEAPMODLoad(const char *fileName, void **ppData)
 {
-	if (!loadWeaponModifiers(fileName))
+	WzConfig ini(fileName, WzConfig::ReadOnlyAndRequired);
+	calcDataHash(ini, DATA_SWEAPMOD);
+
+	if (!loadWeaponModifiers(ini))
 	{
 		return false;
 	}
@@ -334,7 +372,10 @@ static void dataSTEMPLRelease(WZ_DECL_UNUSED void *pData)
 /* Load the Structure stats */
 static bool bufferSSTRUCTLoad(const char *fileName, void **ppData)
 {
-	if (!loadStructureStats(WzString::fromUtf8(fileName)))
+	WzConfig ini(fileName, WzConfig::ReadOnlyAndRequired);
+	calcDataHash(ini, DATA_SSTRUCT);
+
+	if (!loadStructureStats(ini))
 	{
 		return false;
 	}
@@ -359,7 +400,10 @@ static void dataSSTRUCTRelease(WZ_DECL_UNUSED void *pData)
 /* Load the Structure strength modifier stats */
 static bool bufferSSTRMODLoad(const char *fileName, void **ppData)
 {
-	if (!loadStructureStrengthModifiers(fileName))
+	WzConfig ini(fileName, WzConfig::ReadOnlyAndRequired);
+	calcDataHash(ini, DATA_SSTRMOD);
+
+	if (!loadStructureStrengthModifiers(ini))
 	{
 		return false;
 	}
@@ -372,7 +416,10 @@ static bool bufferSSTRMODLoad(const char *fileName, void **ppData)
 /* Load the Feature stats */
 static bool bufferSFEATLoad(const char *fileName, void **ppData)
 {
-	if (!loadFeatureStats(fileName))
+	WzConfig ini(fileName, WzConfig::ReadOnlyAndRequired);
+	calcDataHash(ini, DATA_SFEAT);
+
+	if (!loadFeatureStats(ini))
 	{
 		return false;
 	}
@@ -397,8 +444,6 @@ static void dataRESCHRelease(WZ_DECL_UNUSED void *pData)
 /* Load the Research stats */
 static bool bufferRESCHLoad(const char *fileName, void **ppData)
 {
-	//calcDataHash((uint8_t *)pBuffer, size, DATA_RESCH);
-
 	//check to see if already loaded
 	if (!asResearch.empty())
 	{
@@ -406,7 +451,10 @@ static bool bufferRESCHLoad(const char *fileName, void **ppData)
 		dataRESCHRelease(nullptr);
 	}
 
-	if (!loadResearch(WzString::fromUtf8(fileName)))
+	WzConfig ini(fileName, WzConfig::ReadOnlyAndRequired);
+	calcDataHash(ini, DATA_RESCH);
+
+	if (!loadResearch(ini))
 	{
 		return false;
 	}

--- a/src/feature.cpp
+++ b/src/feature.cpp
@@ -23,7 +23,6 @@
  * Load feature stats
  */
 #include "lib/framework/frame.h"
-#include "lib/framework/wzconfig.h"
 
 #include "lib/gamelib/gtime.h"
 #include "lib/sound/audio.h"
@@ -66,9 +65,9 @@ void featureInitVars()
 }
 
 /* Load the feature stats */
-bool loadFeatureStats(const char *pFileName)
+bool loadFeatureStats(WzConfig &ini)
 {
-	WzConfig ini(WzString::fromUtf8(pFileName), WzConfig::ReadOnlyAndRequired);
+	ASSERT(ini.isAtDocumentRoot(), "WzConfig instance is in the middle of traversal");
 	std::vector<WzString> list = ini.childGroups();
 	asFeatureStats = new FEATURE_STATS[list.size()];
 	numFeatureStats = list.size();

--- a/src/feature.h
+++ b/src/feature.h
@@ -25,6 +25,7 @@
 #define __INCLUDED_SRC_FEATURE_H__
 
 #include "objectdef.h"
+#include "lib/framework/wzconfig.h"
 
 /* The statistics for the features */
 extern FEATURE_STATS	*asFeatureStats;
@@ -34,7 +35,7 @@ extern UDWORD			numFeatureStats;
 extern FEATURE_STATS *oilResFeature;
 
 /* Load the feature stats */
-bool loadFeatureStats(const char *pFileName);
+bool loadFeatureStats(WzConfig &ini);
 
 /* Release the feature stats memory */
 void featureStatsShutDown();

--- a/src/research.cpp
+++ b/src/research.cpp
@@ -27,7 +27,6 @@
 #include <map>
 
 #include "lib/framework/frame.h"
-#include "lib/framework/wzconfig.h"
 #include "lib/netplay/netplay.h"
 #include "lib/ivis_opengl/imd.h"
 #include "objects.h"
@@ -102,9 +101,9 @@ bool researchInitVars()
 }
 
 /** Load the research stats */
-bool loadResearch(const WzString& filename)
+bool loadResearch(WzConfig &ini)
 {
-	WzConfig ini(filename, WzConfig::ReadOnlyAndRequired);
+	ASSERT(ini.isAtDocumentRoot(), "WzConfig instance is in the middle of traversal");
 	std::vector<WzString> list = ini.childGroups();
 	PLAYER_RESEARCH dummy;
 	memset(&dummy, 0, sizeof(dummy));

--- a/src/research.h
+++ b/src/research.h
@@ -24,6 +24,8 @@
 #ifndef __INCLUDED_SRC_RESEARCH_H__
 #define __INCLUDED_SRC_RESEARCH_H__
 
+#include "lib/framework/wzconfig.h"
+
 #include "objectdef.h"
 
 struct VIEWDATA;
@@ -81,7 +83,7 @@ extern UDWORD	aDefaultSensor[MAX_PLAYERS];
 extern UDWORD	aDefaultECM[MAX_PLAYERS];
 extern UDWORD	aDefaultRepair[MAX_PLAYERS];
 
-bool loadResearch(const WzString& filename);
+bool loadResearch(WzConfig &ini);
 
 /*function to check what can be researched for a particular player at any one
   instant. Returns the number to research*/

--- a/src/stats.cpp
+++ b/src/stats.cpp
@@ -335,9 +335,9 @@ static void loadCompStats(WzConfig &json, COMPONENT_STATS *psStats, size_t index
 }
 
 /*Load the weapon stats from the file exported from Access*/
-bool loadWeaponStats(const char *pFileName)
+bool loadWeaponStats(WzConfig &ini)
 {
-	WzConfig ini(pFileName, WzConfig::ReadOnlyAndRequired);
+	ASSERT(ini.isAtDocumentRoot(), "WzConfig instance is in the middle of traversal");
 	std::vector<WzString> list = ini.childGroups();
 	statsAllocWeapons(list.size());
 	// Hack to make sure ZNULLWEAPON is always first in list
@@ -552,9 +552,9 @@ bool loadWeaponStats(const char *pFileName)
 	return true;
 }
 
-bool loadBodyStats(const char *pFileName)
+bool loadBodyStats(WzConfig &ini)
 {
-	WzConfig ini(pFileName, WzConfig::ReadOnlyAndRequired);
+	ASSERT(ini.isAtDocumentRoot(), "WzConfig instance is in the middle of traversal");
 	std::vector<WzString> list = ini.childGroups();
 	statsAllocBody(list.size());
 	// Hack to make sure ZNULLBODY is always first in list
@@ -668,9 +668,9 @@ bool loadBodyStats(const char *pFileName)
 }
 
 /*Load the Brain stats from the file exported from Access*/
-bool loadBrainStats(const char *pFileName)
+bool loadBrainStats(WzConfig &ini)
 {
-	WzConfig ini(pFileName, WzConfig::ReadOnlyAndRequired);
+	ASSERT(ini.isAtDocumentRoot(), "WzConfig instance is in the middle of traversal");
 	std::vector<WzString> list = ini.childGroups();
 	statsAllocBrain(list.size());
 	// Hack to make sure ZNULLBRAIN is always first in list
@@ -762,9 +762,9 @@ bool getPropulsionType(const char *typeName, PROPULSION_TYPE *type)
 }
 
 /*Load the Propulsion stats from the file exported from Access*/
-bool loadPropulsionStats(const char *pFileName)
+bool loadPropulsionStats(WzConfig &ini)
 {
-	WzConfig ini(pFileName, WzConfig::ReadOnlyAndRequired);
+	ASSERT(ini.isAtDocumentRoot(), "WzConfig instance is in the middle of traversal");
 	std::vector<WzString> list = ini.childGroups();
 	statsAllocPropulsion(list.size());
 	// Hack to make sure ZNULLPROP is always first in list
@@ -834,9 +834,9 @@ bool loadPropulsionStats(const char *pFileName)
 }
 
 /*Load the Sensor stats from the file exported from Access*/
-bool loadSensorStats(const char *pFileName)
+bool loadSensorStats(WzConfig &ini)
 {
-	WzConfig ini(pFileName, WzConfig::ReadOnlyAndRequired);
+	ASSERT(ini.isAtDocumentRoot(), "WzConfig instance is in the middle of traversal");
 	std::vector<WzString> list = ini.childGroups();
 	statsAllocSensor(list.size());
 	// Hack to make sure ZNULLSENSOR is always first in list
@@ -920,9 +920,9 @@ bool loadSensorStats(const char *pFileName)
 }
 
 /*Load the ECM stats from the file exported from Access*/
-bool loadECMStats(const char *pFileName)
+bool loadECMStats(WzConfig &ini)
 {
-	WzConfig ini(pFileName, WzConfig::ReadOnlyAndRequired);
+	ASSERT(ini.isAtDocumentRoot(), "WzConfig instance is in the middle of traversal");
 	std::vector<WzString> list = ini.childGroups();
 	statsAllocECM(list.size());
 	// Hack to make sure ZNULLECM is always first in list
@@ -976,9 +976,9 @@ bool loadECMStats(const char *pFileName)
 }
 
 /*Load the Repair stats from the file exported from Access*/
-bool loadRepairStats(const char *pFileName)
+bool loadRepairStats(WzConfig &ini)
 {
-	WzConfig ini(pFileName, WzConfig::ReadOnlyAndRequired);
+	ASSERT(ini.isAtDocumentRoot(), "WzConfig instance is in the middle of traversal");
 	std::vector<WzString> list = ini.childGroups();
 	statsAllocRepair(list.size());
 	// Hack to make sure ZNULLREPAIR is always first in list
@@ -1036,9 +1036,9 @@ bool loadRepairStats(const char *pFileName)
 }
 
 /*Load the Construct stats from the file exported from Access*/
-bool loadConstructStats(const char *pFileName)
+bool loadConstructStats(WzConfig &ini)
 {
-	WzConfig ini(pFileName, WzConfig::ReadOnlyAndRequired);
+	ASSERT(ini.isAtDocumentRoot(), "WzConfig instance is in the middle of traversal");
 	std::vector<WzString> list = ini.childGroups();
 	statsAllocConstruct(list.size());
 	// Hack to make sure ZNULLCONSTRUCT is always first in list
@@ -1078,13 +1078,13 @@ bool loadConstructStats(const char *pFileName)
 
 
 /*Load the Propulsion Types from the file exported from Access*/
-bool loadPropulsionTypes(const char *pFileName)
+bool loadPropulsionTypes(WzConfig &ini)
 {
 	const unsigned int NumTypes = PROPULSION_TYPE_NUM;
 
 	//allocate storage for the stats
 	asPropulsionTypes.resize(NumTypes);
-	WzConfig ini(pFileName, WzConfig::ReadOnlyAndRequired);
+	ASSERT(ini.isAtDocumentRoot(), "WzConfig instance is in the middle of traversal");
 	std::vector<WzString> list = ini.childGroups();
 
 	for (int i = 0; i < NumTypes; ++i)
@@ -1141,10 +1141,10 @@ bool loadPropulsionTypes(const char *pFileName)
 	return true;
 }
 
-bool loadTerrainTable(const char *pFileName)
+bool loadTerrainTable(WzConfig &ini)
 {
 	asTerrainTable = (int *)malloc(sizeof(*asTerrainTable) * PROPULSION_TYPE_NUM * TER_MAX);
-	WzConfig ini(pFileName, WzConfig::ReadOnlyAndRequired);
+	ASSERT(ini.isAtDocumentRoot(), "WzConfig instance is in the middle of traversal");
 	std::vector<WzString> list = ini.childGroups();
 	for (int i = 0; i < list.size(); ++i)
 	{
@@ -1183,7 +1183,7 @@ static bool statsGetAudioIDFromString(const WzString &szStatName, const WzString
 	return true;
 }
 
-bool loadWeaponModifiers(const char *pFileName)
+bool loadWeaponModifiers(WzConfig &ini)
 {
 	//initialise to 100%
 	for (int i = 0; i < WE_NUMEFFECTS; i++)
@@ -1197,7 +1197,7 @@ bool loadWeaponModifiers(const char *pFileName)
 			asWeaponModifierBody[i][j] = 100;
 		}
 	}
-	WzConfig ini(pFileName, WzConfig::ReadOnlyAndRequired);
+	ASSERT(ini.isAtDocumentRoot(), "WzConfig instance is in the middle of traversal");
 	std::vector<WzString> list = ini.childGroups();
 	for (int i = 0; i < list.size(); i++)
 	{

--- a/src/stats.h
+++ b/src/stats.h
@@ -127,40 +127,40 @@ bool statsAllocConstruct(UDWORD numEntries);
 void loadStats(WzConfig &json, BASE_STATS *psStats, size_t index);
 
 /*Load the weapon stats from the file exported from Access*/
-bool loadWeaponStats(const char *pFileName);
+bool loadWeaponStats(WzConfig &ini);
 
 /*Load the body stats from the file exported from Access*/
-bool loadBodyStats(const char *pFileName);
+bool loadBodyStats(WzConfig &ini);
 
 /*Load the brain stats from the file exported from Access*/
-bool loadBrainStats(const char *pFileName);
+bool loadBrainStats(WzConfig &ini);
 
 /*Load the propulsion stats from the file exported from Access*/
-bool loadPropulsionStats(const char *pFileName);
+bool loadPropulsionStats(WzConfig &ini);
 
 /*Load the sensor stats from the file exported from Access*/
-bool loadSensorStats(const char *pFileName);
+bool loadSensorStats(WzConfig &ini);
 
 /*Load the ecm stats from the file exported from Access*/
-bool loadECMStats(const char *fileName);
+bool loadECMStats(WzConfig &ini);
 
 /*Load the repair stats from the file exported from Access*/
-bool loadRepairStats(const char *pFileName);
+bool loadRepairStats(WzConfig &ini);
 
 /*Load the construct stats from the file exported from Access*/
-bool loadConstructStats(const char *pFileName);
+bool loadConstructStats(WzConfig &ini);
 
 /*Load the Propulsion Types from the file exported from Access*/
-bool loadPropulsionTypes(const char *pFileName);
+bool loadPropulsionTypes(WzConfig &ini);
 
 /*Load the propulsion sounds from the file exported from Access*/
 bool loadPropulsionSounds(const char *pFileName);
 
 /*Load the Terrain Table from the file exported from Access*/
-bool loadTerrainTable(const char *pFileName);
+bool loadTerrainTable(WzConfig &ini);
 
 /*Load the Weapon Effect Modifiers from the file exported from Access*/
-bool loadWeaponModifiers(const char *pFileName);
+bool loadWeaponModifiers(WzConfig &ini);
 
 /*******************************************************************************
 *		Generic stats functions

--- a/src/structure.cpp
+++ b/src/structure.cpp
@@ -30,7 +30,6 @@
 
 #include "lib/framework/frame.h"
 #include "lib/framework/geometry.h"
-#include "lib/framework/wzconfig.h"
 #include "lib/ivis_opengl/imd.h"
 #include "objects.h"
 #include "ai.h"
@@ -418,7 +417,7 @@ size_t sizeOfArray(const T(&)[ N ])
 }
 
 /* load the structure stats from the ini file */
-bool loadStructureStats(const WzString& filename)
+bool loadStructureStats(WzConfig &ini)
 {
 	std::map<WzString, STRUCTURE_TYPE> structType;
 	for (int i = 0; i < sizeOfArray(map_STRUCTURE_TYPE); i++)
@@ -432,7 +431,7 @@ bool loadStructureStats(const WzString& filename)
 		structStrength.emplace(WzString::fromUtf8(map_STRUCT_STRENGTH[i].string), map_STRUCT_STRENGTH[i].value);
 	}
 
-	WzConfig ini(filename, WzConfig::ReadOnlyAndRequired);
+	ASSERT(ini.isAtDocumentRoot(), "WzConfig instance is in the middle of traversal");
 	std::vector<WzString> list = ini.childGroups();
 	asStructureStats = new STRUCTURE_STATS[list.size()];
 	numStructureStats = list.size();
@@ -610,7 +609,7 @@ void setCurrentStructQuantity(bool displayError)
 }
 
 /*Load the Structure Strength Modifiers from the file exported from Access*/
-bool loadStructureStrengthModifiers(const char *pFileName)
+bool loadStructureStrengthModifiers(WzConfig &ini)
 {
 	//initialise to 100%
 	for (unsigned i = 0; i < WE_NUMEFFECTS; ++i)
@@ -620,7 +619,7 @@ bool loadStructureStrengthModifiers(const char *pFileName)
 			asStructStrengthModifier[i][j] = 100;
 		}
 	}
-	WzConfig ini(pFileName, WzConfig::ReadOnlyAndRequired);
+	ASSERT(ini.isAtDocumentRoot(), "WzConfig instance is in the middle of traversal");
 	std::vector<WzString> list = ini.childGroups();
 	for (size_t i = 0; i < list.size(); i++)
 	{

--- a/src/structure.h
+++ b/src/structure.h
@@ -25,6 +25,7 @@
 #define __INCLUDED_SRC_STRUCTURE_H__
 
 #include "lib/framework/string_ext.h"
+#include "lib/framework/wzconfig.h"
 
 #include "objectdef.h"
 #include "structuredef.h"
@@ -80,9 +81,9 @@ void setMaxConstructors(int player, int value);
 bool IsPlayerDroidLimitReached(int player);
 bool CheckHaltOnMaxUnitsReached(STRUCTURE *psStructure);
 
-bool loadStructureStats(const WzString& filename);
+bool loadStructureStats(WzConfig &ini);
 /*Load the Structure Strength Modifiers from the file exported from Access*/
-bool loadStructureStrengthModifiers(const char *pFileName);
+bool loadStructureStrengthModifiers(WzConfig &ini);
 
 bool structureStatsShutDown();
 


### PR DESCRIPTION
See ticket "Missing CRC hash checks for ini files": http://developer.wz2100.net/ticket/3794

This PR adds back those CRC hash checks, using a new method in `WzConfig` that constructs a `compactStringRepresentation` of the loaded JSON data (and then calling `calcDataHash` on that compact representation). This should take into account any "diff/patch" processing (see `WzConfig`), as well as simple JSON whitespace / newline changes that don't actually alter the data itself.

Once this is merged, we'll need to request help testing cross-platform multiplayer games with the latest development builds (to double-check that everything is working as expected).