### PR TITLE
Wrap buffers (revised)

### DIFF
--- a/lib/ivis_opengl/gfx_api.h
+++ b/lib/ivis_opengl/gfx_api.h
@@ -5,6 +5,12 @@
 
 namespace gfx_api
 {
+#ifdef GL_ONLY
+	using gfxFloat = GLfloat;
+#else
+	using gfxFloat = float;
+#endif
+
 	enum class pixel_format
 	{
 		invalid,
@@ -23,10 +29,48 @@ namespace gfx_api
 		virtual unsigned id() = 0;
 	};
 
+	// An abstract base that manages a single gfx buffer
+	struct buffer
+	{
+		enum class usage
+		{
+			 vertex_buffer,
+			 index_buffer,
+		};
+
+		// Create a new data store for the buffer. Any existing data store will be deleted.
+		// The new data store is created with the specified `size` in bytes.
+		// If `data` is not NULL, the data store is initialized with `size` bytes of data from the pointer.
+		// - If data is NULL, a data store of the specified `size` is still created, but its contents may be uninitialized (and thus undefined).
+		virtual void upload(const size_t& size, const void* data) = 0;
+
+		// Update `size` bytes in the existing data store, from the `start` offset, using the data at `data`.
+		// - The `start` offset must be within the range of the existing data store (0 to buffer_size - 1, inclusive).
+		// - The `size` of the data specified (+ the offset) must not attempt to write past the end of the existing data store.
+		// - A data store must be allocated before it can be updated - call `upload` on a `buffer` instance before `update`.
+		virtual void update(const size_t& start, const size_t& size, const void* data) = 0;
+
+		virtual void bind() = 0;
+
+		virtual ~buffer() {};
+
+		buffer( const buffer& other ) = delete; // non construction-copyable
+		buffer& operator=( const buffer& ) = delete; // non copyable
+		buffer() {};
+	};
+
 	struct context
 	{
+		enum class buffer_storage_hint
+		{
+				static_draw,
+				stream_draw,
+				dynamic_draw,
+		};
+
 		virtual ~context() {};
 		virtual texture* create_texture(const size_t& width, const size_t& height, const pixel_format& internal_format, const std::string& filename = "") = 0;
+		virtual buffer* create_buffer_object(const buffer::usage&, const buffer_storage_hint& = buffer_storage_hint::static_draw) = 0;
 		static context& get();
 	};
 }

--- a/lib/ivis_opengl/gfx_api_gl.cpp
+++ b/lib/ivis_opengl/gfx_api_gl.cpp
@@ -23,6 +23,36 @@ static GLenum to_gl(const gfx_api::pixel_format& format)
 	return GL_INVALID_ENUM;
 }
 
+static GLenum to_gl(const gfx_api::context::buffer_storage_hint& hint)
+{
+	switch (hint)
+	{
+		case gfx_api::context::buffer_storage_hint::static_draw:
+			return GL_STATIC_DRAW;
+		case gfx_api::context::buffer_storage_hint::dynamic_draw:
+			return GL_DYNAMIC_DRAW;
+		case gfx_api::context::buffer_storage_hint::stream_draw:
+			return GL_STREAM_DRAW;
+		default:
+			debug(LOG_FATAL, "Unsupported buffer hint");
+	}
+	return GL_INVALID_ENUM;
+}
+
+static GLenum to_gl(const gfx_api::buffer::usage& usage)
+{
+	switch (usage)
+	{
+		case gfx_api::buffer::usage::index_buffer:
+			return GL_ELEMENT_ARRAY_BUFFER;
+		case gfx_api::buffer::usage::vertex_buffer:
+			return GL_ARRAY_BUFFER;
+		default:
+			debug(LOG_FATAL, "Unrecognised buffer usage");
+	}
+	return GL_INVALID_ENUM;
+ }
+
 struct gl_texture : public gfx_api::texture
 {
 private:
@@ -62,6 +92,52 @@ public:
 
 };
 
+struct gl_buffer : public gfx_api::buffer
+{
+	gfx_api::buffer::usage usage;
+	gfx_api::context::buffer_storage_hint hint;
+	GLuint buffer = 0;
+	size_t buffer_size = 0;
+
+	virtual ~gl_buffer() override
+	{
+		glDeleteBuffers(1, &buffer);
+	}
+
+	gl_buffer(const gfx_api::buffer::usage& usage, const gfx_api::context::buffer_storage_hint& hint)
+	: usage(usage)
+	, hint(hint)
+	{
+		glGenBuffers(1, &buffer);
+	}
+
+	void bind() override
+	{
+		glBindBuffer(to_gl(usage), buffer);
+	}
+
+	virtual void upload(const size_t & size, const void * data) override
+	{
+		glBindBuffer(to_gl(usage), buffer);
+		glBufferData(to_gl(usage), size, data, to_gl(hint));
+		buffer_size = size;
+	}
+
+	virtual void update(const size_t & start, const size_t & size, const void * data) override
+	{
+		ASSERT(start < buffer_size, "Starting offset (%zu) is past end of buffer (length: %zu)", start, buffer_size);
+		ASSERT(start + size <= buffer_size, "Attempt to write past end of buffer");
+		if (size == 0)
+		{
+			debug(LOG_WARNING, "Attempt to update buffer with 0 bytes of new data");
+			return;
+		}
+		glBindBuffer(to_gl(usage), buffer);
+		glBufferSubData(to_gl(usage), start, size, data);
+	}
+	
+};
+
 struct gl_context : public gfx_api::context
 {
 	virtual gfx_api::texture* create_texture(const size_t & width, const size_t & height, const gfx_api::pixel_format & internal_format, const std::string& filename) override
@@ -77,6 +153,11 @@ struct gl_context : public gfx_api::context
 			glTexImage2D(GL_TEXTURE_2D, i, to_gl(internal_format), width >> i, height >> i, 0, to_gl(internal_format), GL_UNSIGNED_BYTE, nullptr);
 		}
 		return new_texture;
+	}
+
+	virtual gfx_api::buffer * create_buffer_object(const gfx_api::buffer::usage &usage, const buffer_storage_hint& hint = buffer_storage_hint::static_draw) override
+	{
+		return new gl_buffer(usage, hint);
 	}
 };
 

--- a/lib/ivis_opengl/imdload.cpp
+++ b/lib/ivis_opengl/imdload.cpp
@@ -52,7 +52,10 @@ iIMDShape::~iIMDShape()
 {
 	free(connectors);
 	free(shadowEdgeList);
-	glDeleteBuffers(VBO_COUNT, buffers);
+	for (auto* buffer : buffers)
+	{
+		delete buffer;
+	}
 }
 
 void modelShutdown()
@@ -536,10 +539,10 @@ bool _imd_load_connectors(const char **ppFileData, iIMDShape &s)
 }
 
 // performance hack
-static std::vector<GLfloat> vertices;
-static std::vector<GLfloat> normals;
-static std::vector<GLfloat> texcoords;
-static std::vector<GLfloat> tangents;
+static std::vector<gfx_api::gfxFloat> vertices;
+static std::vector<gfx_api::gfxFloat> normals;
+static std::vector<gfx_api::gfxFloat> texcoords;
+static std::vector<gfx_api::gfxFloat> tangents;
 static std::vector<uint16_t> indices; // size is npolys * 3 * numFrames
 static uint16_t vertexCount = 0;
 
@@ -722,7 +725,6 @@ static iIMDShape *_imd_load_level(const WzString &filename, const char **ppFileD
 	}
 
 	// FINALLY, massage the data into what can stream directly to OpenGL
-	glGenBuffers(VBO_COUNT, s.buffers);
 	vertexCount = 0;
 	for (int k = 0; k < MAX(1, s.numFrames); k++)
 	{
@@ -735,14 +737,23 @@ static iIMDShape *_imd_load_level(const WzString &filename, const char **ppFileD
 			indices.emplace_back(addVertex(s, 2, &p, k));
 		}
 	}
-	glBindBuffer(GL_ARRAY_BUFFER, s.buffers[VBO_VERTEX]);
-	glBufferData(GL_ARRAY_BUFFER, vertices.size() * sizeof(GLfloat), vertices.data(), GL_STATIC_DRAW);
-	glBindBuffer(GL_ARRAY_BUFFER, s.buffers[VBO_NORMAL]);
-	glBufferData(GL_ARRAY_BUFFER, normals.size() * sizeof(GLfloat), normals.data(), GL_STATIC_DRAW);
-	glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, s.buffers[VBO_INDEX]);
-	glBufferData(GL_ELEMENT_ARRAY_BUFFER, indices.size() * sizeof(uint16_t), indices.data(), GL_STATIC_DRAW);
-	glBindBuffer(GL_ARRAY_BUFFER, s.buffers[VBO_TEXCOORD]);
-	glBufferData(GL_ARRAY_BUFFER, texcoords.size() * sizeof(GLfloat), texcoords.data(), GL_STATIC_DRAW);
+
+	if (!s.buffers[VBO_VERTEX])
+		s.buffers[VBO_VERTEX] = gfx_api::context::get().create_buffer_object(gfx_api::buffer::usage::vertex_buffer);
+	s.buffers[VBO_VERTEX]->upload(vertices.size() * sizeof(gfx_api::gfxFloat), vertices.data());
+
+	if (!s.buffers[VBO_NORMAL])
+		s.buffers[VBO_NORMAL] = gfx_api::context::get().create_buffer_object(gfx_api::buffer::usage::vertex_buffer);
+	s.buffers[VBO_NORMAL]->upload(normals.size() * sizeof(gfx_api::gfxFloat), normals.data());
+
+	if (!s.buffers[VBO_INDEX])
+		s.buffers[VBO_INDEX] = gfx_api::context::get().create_buffer_object(gfx_api::buffer::usage::index_buffer);
+	s.buffers[VBO_INDEX]->upload(indices.size() * sizeof(uint16_t), indices.data());
+
+	if (!s.buffers[VBO_TEXCOORD])
+		s.buffers[VBO_TEXCOORD] = gfx_api::context::get().create_buffer_object(gfx_api::buffer::usage::vertex_buffer);
+	s.buffers[VBO_TEXCOORD]->upload(texcoords.size() * sizeof(gfx_api::gfxFloat), texcoords.data());
+
 	glBindBuffer(GL_ARRAY_BUFFER, 0); // unbind
 
 	indices.resize(0);

--- a/lib/ivis_opengl/ivisdef.h
+++ b/lib/ivis_opengl/ivisdef.h
@@ -30,7 +30,7 @@
 #define _ivisdef_h
 
 #include "lib/framework/frame.h"
-#include "lib/framework/opengl.h"
+#include "lib/ivis_opengl/gfx_api.h"
 #include "pietypes.h"
 #include "tex.h"
 
@@ -135,7 +135,7 @@ struct iIMDShape
 	std::vector<iIMDPoly> polys;
 
 	// The new rendering data
-	GLuint buffers[VBO_COUNT] = { 0 };
+	gfx_api::buffer* buffers[VBO_COUNT] = { nullptr };
 	SHADER_MODE shaderProgram = SHADER_NONE; // if using specialized shader for this model
 
 	// object animation (animating a level, rather than its texture)
@@ -168,7 +168,7 @@ struct ImageDef
 	int YOffset;            /**< Y offset into source position */
 
 	int textureId;		///< duplicate of below, fix later
-	GLfloat invTextureSize;
+	gfx_api::gfxFloat invTextureSize;
 };
 
 struct Image;

--- a/lib/ivis_opengl/pieblitfunc.h
+++ b/lib/ivis_opengl/pieblitfunc.h
@@ -42,6 +42,7 @@
 #include "pietypes.h"
 #include "piepalette.h"
 #include "pieclip.h"
+#include "lib/framework/opengl.h"
 #include <list>
 
 /***************************************************************************/
@@ -102,7 +103,7 @@ private:
 	int mHeight;
 	GLenum mdrawType;
 	int mCoordsPerVertex;
-	GLuint mBuffers[VBO_COUNT];
+	gfx_api::buffer* mBuffers[VBO_COUNT] = { nullptr };
 	gfx_api::texture* mTexture = nullptr;
 	int mSize;
 };

--- a/lib/ivis_opengl/piestate.cpp
+++ b/lib/ivis_opengl/piestate.cpp
@@ -53,7 +53,7 @@
 std::vector<pie_internal::SHADER_PROGRAM> pie_internal::shaderProgram;
 static GLfloat shaderStretch = 0;
 SHADER_MODE pie_internal::currentShaderMode = SHADER_NONE;
-GLuint pie_internal::rectBuffer = 0;
+gfx_api::buffer* pie_internal::rectBuffer = nullptr;
 static RENDER_STATE rendStates;
 static GLint ecmState = 0;
 static GLfloat timeState = 0.0f;
@@ -761,9 +761,9 @@ bool pie_LoadShaders()
 		1, 1, 0, 1,
 		1, 0, 0, 1
 	};
-	glGenBuffers(1, &pie_internal::rectBuffer);
-	glBindBuffer(GL_ARRAY_BUFFER, pie_internal::rectBuffer);
-	glBufferData(GL_ARRAY_BUFFER, 16 * sizeof(GLbyte), rect, GL_STATIC_DRAW);
+	if (!pie_internal::rectBuffer)
+		pie_internal::rectBuffer = gfx_api::context::get().create_buffer_object(gfx_api::buffer::usage::vertex_buffer);
+	pie_internal::rectBuffer->upload(16 * sizeof(GLbyte), rect);
 	glBindBuffer(GL_ARRAY_BUFFER, 0);
 
 	return true;

--- a/lib/ivis_opengl/piestate.h
+++ b/lib/ivis_opengl/piestate.h
@@ -37,6 +37,7 @@
 #include "lib/framework/frame.h"
 #include "lib/framework/vector.h"
 #include "lib/framework/opengl.h"
+#include "lib/ivis_opengl/gfx_api.h"
 #include <glm/gtc/type_ptr.hpp>
 #include "piedef.h"
 
@@ -125,7 +126,7 @@ namespace pie_internal
 
 	extern std::vector<SHADER_PROGRAM> shaderProgram;
 	extern SHADER_MODE currentShaderMode;
-	extern GLuint rectBuffer;
+	extern gfx_api::buffer* rectBuffer;
 
 	/**
 	 * setUniforms is an overloaded wrapper around glUniform* functions


### PR DESCRIPTION
This is a revised version of @vlj 's work in #96, rebased from the current `master` branch (and with other tweaks / fixes as suggested in #96).

As discussed at the end of #96, this tweaks the (new) API behavior to preserve the current efficiency of the existing OpenGL code path, in a way that should be easy to adapt any future Vulkan implementation.