### PR TITLE
Add support for changing map, game name, and hosting player's name after already hosting

### DIFF
--- a/lib/netplay/netplay.cpp
+++ b/lib/netplay/netplay.cpp
@@ -71,10 +71,6 @@
 char masterserver_name[255] = {'\0'};
 static unsigned int masterserver_port = 0, gameserver_port = 0;
 
-#define WZ_SERVER_DISCONNECT 0
-#define WZ_SERVER_CONNECT    1
-#define WZ_SERVER_UPDATE     3
-
 #define NET_TIMEOUT_DELAY	2500		// we wait this amount of time for socket activity
 #define NET_READ_TIMEOUT	0
 /*
@@ -95,7 +91,6 @@ static unsigned int masterserver_port = 0, gameserver_port = 0;
 // Function prototypes
 static void NETplayerLeaving(UDWORD player);		// Cleanup sockets on player leaving (nicely)
 static void NETplayerDropped(UDWORD player);		// Broadcast NET_PLAYER_DROPPED & cleanup
-static void NETregisterServer(int state);
 static void NETallowJoining();
 static void recvDebugSync(NETQUEUE queue);
 static bool onBanList(const char *ip);
@@ -217,6 +212,25 @@ void NETGameLocked(bool flag)
 	}
 	NETlogEntry("Password is", SYNC_FLAG, NetPlay.GamePassworded);
 	debug(LOG_NET, "Passworded game is %s", NetPlay.GamePassworded ? "TRUE" : "FALSE");
+}
+
+void NETsetLobbyOptField(const char *Value, const NET_LOBBY_OPT_FIELD Field)
+{
+	switch (Field)
+	{
+		case NET_LOBBY_OPT_FIELD::GNAME:
+			sstrcpy(gamestruct.name, Value);
+			break;
+		case NET_LOBBY_OPT_FIELD::MAPNAME:
+			sstrcpy(gamestruct.mapname, Value);
+			break;
+		case NET_LOBBY_OPT_FIELD::HOSTNAME:
+			sstrcpy(gamestruct.hostname, Value);
+			break;
+		default:
+			debug(LOG_WARNING, "Invalid field specified for NETsetGameOptField()");
+			break;
+	}
 }
 
 //	Sets the game password
@@ -2132,7 +2146,7 @@ error:
 	return SOCKET_ERROR;
 }
 
-static void NETregisterServer(int state)
+void NETregisterServer(int state)
 {
 	static Socket *rs_socket = nullptr;
 	static int registered = 0;

--- a/lib/netplay/netplay.h
+++ b/lib/netplay/netplay.h
@@ -120,6 +120,10 @@ enum MESSAGE_TYPES
 
 #define SYNC_FLAG 0x10000000	//special flag used for logging. (Not sure what this is. Was added in trunk, NUM_GAME_PACKETS not in newnet.)
 
+#define WZ_SERVER_DISCONNECT 0
+#define WZ_SERVER_CONNECT    1
+#define WZ_SERVER_UPDATE     3
+
 // Constants
 // @NOTE / FIXME: We need a way to detect what should happen if the msg buffer exceeds this.
 #define MaxMsgSize		16384		// max size of a message in bytes.
@@ -208,6 +212,15 @@ struct WZFile
 enum
 {
 	DIFFICULTY_EASY, DIFFICULTY_MEDIUM, DIFFICULTY_HARD, DIFFICULTY_INSANE
+};
+
+enum class NET_LOBBY_OPT_FIELD
+{
+	INVALID,
+	GNAME,
+	MAPNAME,
+	HOSTNAME,
+	MAX
 };
 
 // ////////////////////////////////////////////////////////////////////////
@@ -326,9 +339,11 @@ int NETGetMinorVersion();
 void NET_InitPlayer(int i, bool initPosition, bool initTeams = false);
 void NET_InitPlayers(bool initTeams = false);
 
+void NETsetLobbyOptField(const char *Value, const NET_LOBBY_OPT_FIELD Field);
+
 void NETGameLocked(bool flag);
 void NETresetGamePassword();
-
+void NETregisterServer(int state);
 void NETsetPlayerConnectionStatus(CONNECTION_STATUS status, unsigned player);    ///< Cumulative, except that CONNECTIONSTATUS_NORMAL resets.
 bool NETcheckPlayerConnectionStatus(CONNECTION_STATUS status, unsigned player);  ///< True iff connection status icon hasn't expired for this player. CONNECTIONSTATUS_NORMAL means any status, NET_ALL_PLAYERS means all players.
 

--- a/src/multiint.cpp
+++ b/src/multiint.cpp
@@ -2851,16 +2851,15 @@ static void addConsoleBox()
 // ////////////////////////////////////////////////////////////////////////////
 static void disableMultiButs()
 {
-
-	// edit box icons.
-	widgSetButtonState(psWScreen, MULTIOP_GNAME_ICON, WBUT_DISABLE);
-	widgSetButtonState(psWScreen, MULTIOP_MAP_ICON, WBUT_DISABLE);
-
-	// edit boxes
-	widgSetButtonState(psWScreen, MULTIOP_GNAME, WEDBS_DISABLE);
-
 	if (!NetPlay.isHost)
 	{
+		// edit box icons.
+		widgSetButtonState(psWScreen, MULTIOP_GNAME_ICON, WBUT_DISABLE);
+		widgSetButtonState(psWScreen, MULTIOP_MAP_ICON, WBUT_DISABLE);
+		
+		// edit boxes
+		widgSetButtonState(psWScreen, MULTIOP_GNAME, WEDBS_DISABLE);
+		
 		((MultichoiceWidget *)widgGetFromID(psWScreen, MULTIOP_GAMETYPE))->disable();  // Scavengers.
 		((MultichoiceWidget *)widgGetFromID(psWScreen, MULTIOP_BASETYPE))->disable();  // camapign subtype.
 		((MultichoiceWidget *)widgGetFromID(psWScreen, MULTIOP_POWER))->disable();  // pow levels
@@ -3065,7 +3064,7 @@ static void processMultiopWidgets(UDWORD id)
 	PLAYERSTATS playerStats;
 
 	// host, who is setting up the game
-	if ((ingame.bHostSetup && !bHosted))
+	if (ingame.bHostSetup)
 	{
 		switch (id)												// Options buttons
 		{
@@ -3073,6 +3072,15 @@ static void processMultiopWidgets(UDWORD id)
 			sstrcpy(game.name, widgGetString(psWScreen, MULTIOP_GNAME));
 			removeWildcards(game.name);
 			widgSetString(psWScreen, MULTIOP_GNAME, game.name);
+			
+			if (NetPlay.isHost && NetPlay.bComms)
+			{
+				NETsetLobbyOptField(game.name, NET_LOBBY_OPT_FIELD::GNAME);
+				sendOptions();
+				NETregisterServer(WZ_SERVER_UPDATE);
+			
+				addConsoleMessage(_("Game Name Updated."), DEFAULT_JUSTIFY, SYSTEM_MESSAGE);
+			}
 			break;
 
 		case MULTIOP_GNAME_ICON:
@@ -3095,6 +3103,14 @@ static void processMultiopWidgets(UDWORD id)
 
 			debug(LOG_WZ, "processMultiopWidgets[MULTIOP_MAP_ICON]: %s.wrf", MultiCustomMapsPath);
 			addMultiRequest(MultiCustomMapsPath, ".wrf", MULTIOP_MAP, current_tech, current_numplayers);
+
+			if (NetPlay.isHost && bHosted && NetPlay.bComms)
+			{
+				sendOptions();
+			
+				NETsetLobbyOptField(game.map, NET_LOBBY_OPT_FIELD::MAPNAME);
+				NETregisterServer(WZ_SERVER_UPDATE);
+			}
 			break;
 
 		case MULTIOP_MAP_PREVIEW:
@@ -3222,6 +3238,14 @@ static void processMultiopWidgets(UDWORD id)
 		setMultiStats(selectedPlayer, playerStats, false);
 		setMultiStats(selectedPlayer, playerStats, true);
 		netPlayersUpdated = true;
+
+		if (NetPlay.isHost && bHosted && NetPlay.bComms)
+		{
+			sendOptions();
+			NETsetLobbyOptField(NetPlay.players[selectedPlayer].name, NET_LOBBY_OPT_FIELD::HOSTNAME);
+			NETregisterServer(WZ_SERVER_UPDATE);
+		}
+
 		break;
 
 	case MULTIOP_PNAME_ICON:
@@ -3839,6 +3863,12 @@ void runMultiOptions()
 				setMultiStats(selectedPlayer, playerStats, false);
 				setMultiStats(selectedPlayer, playerStats, true);
 				netPlayersUpdated = true;
+				if (NetPlay.isHost && bHosted && NetPlay.bComms)
+				{
+					sendOptions();
+					NETsetLobbyOptField(NetPlay.players[selectedPlayer].name, NET_LOBBY_OPT_FIELD::HOSTNAME);
+					NETregisterServer(WZ_SERVER_UPDATE);
+				}
 				break;
 			case MULTIOP_MAP:
 				{
@@ -3865,6 +3895,14 @@ void runMultiOptions()
 
 					widgSetString(psWScreen, MULTIOP_MAP + 1, mapData->pName); //What a horrible, horrible way to do this! FIX ME! (See addBlueForm)
 					addGameOptions();
+					
+					if (NetPlay.isHost && bHosted && NetPlay.bComms && !isHoverPreview)
+					{
+						sendOptions();
+						NETsetLobbyOptField(game.map, NET_LOBBY_OPT_FIELD::MAPNAME);
+						NETregisterServer(WZ_SERVER_UPDATE);
+					}
+
 					break;
 				}
 			default:


### PR DESCRIPTION
I wrote a patch for this a couple years back, but never got around to cleaning it up.
There's a minor issue that should be worked out (I'll fix it) before 3.3 is released, but this patch is functional and working.
That issue is:
Trying to figure out how we want to handle changing to a map that has less available player slots. Auto-kick? Refuse to change? Comments welcome.