### PR TITLE
[OpenGL backend] Add fallback for if glGenerateMipmap is unavailable

### DIFF
--- a/lib/ivis_opengl/gfx_api.h
+++ b/lib/ivis_opengl/gfx_api.h
@@ -43,8 +43,7 @@ namespace gfx_api
 	{
 		virtual ~texture() {};
 		virtual void bind() = 0;
-		virtual void upload(const size_t& mip_level, const size_t& offset_x, const size_t& offset_y, const size_t& width, const size_t& height, const pixel_format& buffer_format, const void* data) = 0;
-		virtual void generate_mip_levels() = 0;
+		virtual void upload(const size_t& mip_level, const size_t& offset_x, const size_t& offset_y, const size_t& width, const size_t& height, const pixel_format& buffer_format, const void* data, bool generate_mip_levels = false) = 0;
 		virtual unsigned id() = 0;
 	};
 

--- a/lib/ivis_opengl/gfx_api_gl.cpp
+++ b/lib/ivis_opengl/gfx_api_gl.cpp
@@ -85,20 +85,28 @@ void gl_texture::bind()
 	glBindTexture(GL_TEXTURE_2D, _id);
 }
 
-void gl_texture::upload(const size_t& mip_level, const size_t& offset_x, const size_t& offset_y, const size_t & width, const size_t & height, const gfx_api::pixel_format & buffer_format, const void * data)
+void gl_texture::upload(const size_t& mip_level, const size_t& offset_x, const size_t& offset_y, const size_t & width, const size_t & height, const gfx_api::pixel_format & buffer_format, const void * data, bool generate_mip_levels /*= false*/)
 {
 	bind();
+	if(generate_mip_levels && !glGenerateMipmap)
+	{
+		// fallback for if glGenerateMipmap is unavailable
+		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT);
+		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT);
+		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_LINEAR);
+		glTexParameteri(GL_TEXTURE_2D, GL_GENERATE_MIPMAP, GL_TRUE);
+	}
 	glTexSubImage2D(GL_TEXTURE_2D, mip_level, offset_x, offset_y, width, height, to_gl(buffer_format), GL_UNSIGNED_BYTE, data);
+	if(generate_mip_levels && glGenerateMipmap)
+	{
+		glGenerateMipmap(GL_TEXTURE_2D);
+	}
 }
 
 unsigned gl_texture::id()
 {
 	return _id;
-}
-
-void gl_texture::generate_mip_levels()
-{
-	glGenerateMipmap(GL_TEXTURE_2D);
 }
 
 // MARK: gl_buffer

--- a/lib/ivis_opengl/gfx_api_gl.h
+++ b/lib/ivis_opengl/gfx_api_gl.h
@@ -35,9 +35,8 @@ private:
 	virtual ~gl_texture();
 public:
 	virtual void bind() override;
-	virtual void upload(const size_t& mip_level, const size_t& offset_x, const size_t& offset_y, const size_t & width, const size_t & height, const gfx_api::pixel_format & buffer_format, const void * data) override;
+	virtual void upload(const size_t& mip_level, const size_t& offset_x, const size_t& offset_y, const size_t & width, const size_t & height, const gfx_api::pixel_format & buffer_format, const void * data, bool generate_mip_levels = false) override;
 	virtual unsigned id() override;
-	virtual void generate_mip_levels() override;
 };
 
 struct gl_buffer final : public gfx_api::buffer

--- a/lib/ivis_opengl/screen.cpp
+++ b/lib/ivis_opengl/screen.cpp
@@ -275,6 +275,7 @@ bool screenInitialise()
 	debug(LOG_3D, "  * Total number of Texture Units (TUs) supported is %d.", (int) glMaxTUs);
 	debug(LOG_3D, "  * GL_ARB_timer_query %s supported!", GLEW_ARB_timer_query ? "is" : "is NOT");
 	debug(LOG_3D, "  * KHR_DEBUG support %s detected", khr_debug ? "was" : "was NOT");
+	debug(LOG_3D, "  * glGenerateMipmap support %s detected", glGenerateMipmap ? "was" : "was NOT");
 
 	if (!GLEW_VERSION_2_0)
 	{

--- a/lib/ivis_opengl/tex.cpp
+++ b/lib/ivis_opengl/tex.cpp
@@ -116,8 +116,7 @@ int pie_AddTexPage(iV_Image *s, const char *filename, bool gameTexture, int page
 		if (_TEX_PAGE[page].id)
 			delete _TEX_PAGE[page].id;
 		_TEX_PAGE[page].id = gfx_api::context::get().create_texture(s->width, s->height, format, filename);
-		pie_Texture(page).upload(0u, 0u, 0u, s->width, s->height, iV_getPixelFormat(s), s->bmp);
-		pie_Texture(page).generate_mip_levels();
+		pie_Texture(page).upload(0u, 0u, 0u, s->width, s->height, iV_getPixelFormat(s), s->bmp, true);
 		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_LINEAR);
 	}
 	else	// this is an interface texture, do not use compression


### PR DESCRIPTION
We have reports that certain (older) Intel graphics drivers may not provide `glGenerateMipmap` support on Windows (in certain situations).

Provide a fallback path for when `glGenerateMipmap` is unavailable.