### PR TITLE
Restore the pursue, guard, and hold secondary orders

### DIFF
--- a/src/action.cpp
+++ b/src/action.cpp
@@ -684,7 +684,7 @@ void actionUpdateDroid(DROID *psDroid)
 		// doing nothing
 		// see if there's anything to shoot.
 		if (psDroid->numWeaps > 0 && !isVtolDroid(psDroid)
-		    && (order->type == DORDER_NONE || order->type == DORDER_HOLD || order->type == DORDER_RTR))
+		    && (order->type == DORDER_NONE || order->type == DORDER_HOLD || order->type == DORDER_RTR || order->type == DORDER_GUARD))
 		{
 			for (unsigned i = 0; i < psDroid->numWeaps; ++i)
 			{

--- a/src/action.cpp
+++ b/src/action.cpp
@@ -1591,7 +1591,7 @@ void actionUpdateDroid(DROID *psDroid)
 			if (!visibleObject(psDroid, psDroid->psActionTarget[0], false)
 			    || xdiff * xdiff + ydiff * ydiff >= rangeSq)
 			{
-				if (secondaryGetState(psDroid, DSO_HALTTYPE) != DSS_HALT_GUARD && (order->type == DORDER_OBSERVE || order->type == DORDER_NONE || order->type == DORDER_HOLD))
+				if (secondaryGetState(psDroid, DSO_HALTTYPE) != DSS_HALT_GUARD && (order->type == DORDER_NONE || order->type == DORDER_HOLD))
 				{
 					psDroid->action = DACTION_NONE;
 				}
@@ -2097,7 +2097,7 @@ static void actionDroidBase(DROID *psDroid, DROID_ACTION_DATA *psAction)
 		setDroidActionTarget(psDroid, psAction->psObj, 0);
 		psDroid->actionPos.x = psDroid->pos.x;
 		psDroid->actionPos.y = psDroid->pos.y;
-		if (secondaryGetState(psDroid, DSO_HALTTYPE) != DSS_HALT_GUARD && (order->type == DORDER_OBSERVE || order->type == DORDER_NONE || order->type == DORDER_HOLD))
+		if (secondaryGetState(psDroid, DSO_HALTTYPE) != DSS_HALT_GUARD && (order->type == DORDER_NONE || order->type == DORDER_HOLD))
 		{
 			psDroid->action = visibleObject(psDroid, psDroid->psActionTarget[0], false) ? DACTION_OBSERVE : DACTION_NONE;
 		}

--- a/src/ai.cpp
+++ b/src/ai.cpp
@@ -813,6 +813,11 @@ bool aiChooseTarget(BASE_OBJECT *psObj, BASE_OBJECT **ppsTarget, int weapon_slot
 		*targetOrigin = ORIGIN_UNKNOWN;
 	}
 
+	if (psObj->type == OBJ_DROID && secondaryGetState((DROID *)psObj, DSO_HALTTYPE) == DSS_HALT_HOLD)
+	{
+		return false;	// Not sure why we check this here...
+	}
+
 	ASSERT_OR_RETURN(false, (unsigned)weapon_slot < psObj->numWeaps, "Invalid weapon selected");
 
 	/* See if there is a something in range */

--- a/src/ai.cpp
+++ b/src/ai.cpp
@@ -1174,7 +1174,8 @@ void aiUpdateDroid(DROID *psDroid)
 		{
 			if (aiChooseSensorTarget(psDroid, &psTarget))
 			{
-				if (!orderState(psDroid, DORDER_HOLD))
+				if (!orderState(psDroid, DORDER_HOLD)
+					&& secondaryGetState(psDroid, DSO_HALTTYPE) == DSS_HALT_PURSUE)
 				{
 					psDroid->order = DroidOrder(DORDER_OBSERVE, psTarget);
 				}
@@ -1185,7 +1186,8 @@ void aiUpdateDroid(DROID *psDroid)
 		{
 			if (aiChooseTarget((BASE_OBJECT *)psDroid, &psTarget, 0, true, nullptr))
 			{
-				if (!orderState(psDroid, DORDER_HOLD))
+				if (!orderState(psDroid, DORDER_HOLD)
+					&& secondaryGetState(psDroid, DSO_HALTTYPE) == DSS_HALT_PURSUE)
 				{
 					psDroid->order = DroidOrder(DORDER_ATTACK, psTarget);
 				}

--- a/src/cmddroid.cpp
+++ b/src/cmddroid.cpp
@@ -99,6 +99,7 @@ void cmdDroidAddDroid(DROID *psCommander, DROID *psDroid)
 		// set the secondary states for the unit
 		secondarySetState(psDroid, DSO_REPAIR_LEVEL, (SECONDARY_STATE)(psCommander->secondaryOrder & DSS_REPLEV_MASK), ModeImmediate);
 		secondarySetState(psDroid, DSO_ATTACK_LEVEL, (SECONDARY_STATE)(psCommander->secondaryOrder & DSS_ALEV_MASK), ModeImmediate);
+		secondarySetState(psDroid, DSO_HALTTYPE, (SECONDARY_STATE)(psCommander->secondaryOrder & DSS_HALT_MASK), ModeImmediate);
 
 		orderDroidObj(psDroid, DORDER_GUARD, (BASE_OBJECT *)psCommander, ModeImmediate);
 	}

--- a/src/droid.cpp
+++ b/src/droid.cpp
@@ -790,6 +790,16 @@ void droidUpdate(DROID *psDroid)
 		{
 			psBeingTargetted->flags.set(OBJECT_FLAG_TARGETED, true);
 		}
+		else if (secondaryGetState(psDroid, DSO_HALTTYPE) != DSS_HALT_PURSUE &&
+		    psDroid->psActionTarget[0] != nullptr &&
+		    validTarget(psDroid, psDroid->psActionTarget[0], 0) &&
+		    (psDroid->action == DACTION_ATTACK ||
+		    psDroid->action == DACTION_OBSERVE ||
+	         orderState(psDroid, DORDER_HOLD)))
+		{
+			psBeingTargetted = psDroid->psActionTarget[0];
+			psBeingTargetted->flags.set(OBJECT_FLAG_TARGETED, true);
+		}
 	}
 	// -----------------
 

--- a/src/droid.cpp
+++ b/src/droid.cpp
@@ -321,8 +321,8 @@ DROID::DROID(uint32_t id, unsigned player)
 	, droidType(DROID_ANY)
 	, psGroup(nullptr)
 	, psGrpNext(nullptr)
-	, secondaryOrder(DSS_REPLEV_NEVER | DSS_ALEV_ALWAYS)
-	, secondaryOrderPending(DSS_REPLEV_NEVER | DSS_ALEV_ALWAYS)
+	, secondaryOrder(DSS_REPLEV_NEVER | DSS_ALEV_ALWAYS | DSS_HALT_GUARD)
+	, secondaryOrderPending(DSS_REPLEV_NEVER | DSS_ALEV_ALWAYS | DSS_HALT_GUARD)
 	, secondaryOrderPendingCount(0)
 	, action(DACTION_NONE)
 	, actionPos(0, 0)
@@ -1694,6 +1694,9 @@ DROID *reallyBuildDroid(DROID_TEMPLATE *pTemplate, Position pos, UDWORD player, 
 
 		//set droid height to be above the terrain
 		psDroid->pos.z += TRANSPORTER_HOVER_HEIGHT;
+
+		/* reset halt secondary order from guard to hold */
+		secondarySetState( psDroid, DSO_HALTTYPE, DSS_HALT_HOLD );
 	}
 
 	if (player == selectedPlayer)

--- a/src/intorder.cpp
+++ b/src/intorder.cpp
@@ -415,7 +415,7 @@ static std::vector<AVORDER> buildStructureOrderList(STRUCTURE *psStructure)
 	std::vector<AVORDER> orders(3);
 	orders[0].OrderIndex = 0;//DSO_REPAIR_LEVEL;
 	orders[1].OrderIndex = 1;//DSO_ATTACK_LEVEL;
-	orders[2].OrderIndex = 2;//DSO_HALTTYPE;
+	orders[2].OrderIndex = 5;//DSO_HALTTYPE;
 
 	return orders;
 }

--- a/src/intorder.cpp
+++ b/src/intorder.cpp
@@ -47,6 +47,7 @@
 #define IDORDER_REPAIR_LEVEL				8020
 #define IDORDER_ATTACK_LEVEL				8030
 #define IDORDER_PATROL						8040
+#define IDORDER_HALT_TYPE					8050
 #define IDORDER_RETURN						8060
 #define IDORDER_RECYCLE						8070
 #define IDORDER_ASSIGN_PRODUCTION			8080
@@ -138,6 +139,9 @@ enum
 	STR_DORD_FIRE2,
 	STR_DORD_FIRE3,
 	STR_DORD_PATROL,
+	STR_DORD_PURSUE,
+	STR_DORD_GUARD,
+	STR_DORD_HOLDPOS,
 	STR_DORD_RETREPAIR,
 	STR_DORD_RETBASE,
 	STR_DORD_EMBARK,
@@ -162,6 +166,9 @@ static const char *getDORDDescription(int id)
 	case STR_DORD_FIRE2          : return _("Return Fire");
 	case STR_DORD_FIRE3          : return _("Hold Fire");
 	case STR_DORD_PATROL         : return _("Patrol");
+	case STR_DORD_PURSUE         : return _("Pursue");
+	case STR_DORD_GUARD          : return _("Guard Position");
+	case STR_DORD_HOLDPOS        : return _("Hold Position");
 	case STR_DORD_RETREPAIR      : return _("Return For Repair");
 	case STR_DORD_RETBASE        : return _("Return To HQ");
 	case STR_DORD_EMBARK         : return _("Go to Transport");
@@ -249,6 +256,20 @@ static ORDERBUTTONS OrderButtons[NUM_ORDERS] =
 		{IMAGE_DES_HILIGHT,	0,	0},
 		{STR_DORD_CIRCLE,	0,	0},
 		{DSS_CIRCLE_SET,	0,	0}
+	},
+	{
+		ORDBUTCLASS_NORMAL,
+		DSO_HALTTYPE,
+		DSS_HALT_MASK,
+		ORD_BTYPE_RADIO,
+		ORD_JUSTIFY_CENTER | ORD_JUSTIFY_NEWLINE,
+		IDORDER_HALT_TYPE,
+		3,0,
+		{IMAGE_ORD_PURSUEUP,	IMAGE_ORD_GUARDUP,	IMAGE_ORD_HALTUP},
+		{IMAGE_ORD_PURSUEUP,	IMAGE_ORD_GUARDUP,	IMAGE_ORD_HALTUP},
+		{IMAGE_DES_HILIGHT,		IMAGE_DES_HILIGHT,	IMAGE_DES_HILIGHT},
+		{STR_DORD_PURSUE,	STR_DORD_GUARD,	STR_DORD_HOLDPOS},
+		{DSS_HALT_PURSUE,	DSS_HALT_GUARD,	DSS_HALT_HOLD}
 	},
 	{
 		ORDBUTCLASS_NORMAL,
@@ -391,9 +412,10 @@ static std::vector<AVORDER> buildStructureOrderList(STRUCTURE *psStructure)
 	ASSERT_OR_RETURN(std::vector<AVORDER>(), StructIsFactory(psStructure), "BuildStructureOrderList: structure is not a factory");
 
 	//this can be hard-coded!
-	std::vector<AVORDER> orders(2);
+	std::vector<AVORDER> orders(3);
 	orders[0].OrderIndex = 0;//DSO_REPAIR_LEVEL;
 	orders[1].OrderIndex = 1;//DSO_ATTACK_LEVEL;
+	orders[2].OrderIndex = 2;//DSO_HALTTYPE;
 
 	return orders;
 }

--- a/src/keybind.cpp
+++ b/src/keybind.cpp
@@ -2266,6 +2266,18 @@ void	kf_SetDroidOrderStop()
 }
 
 // --------------------------------------------------------------------------
+void	kf_SetDroidMoveGuard()
+{
+	kfsf_SetSelectedDroidsState(DSO_HALTTYPE, DSS_HALT_GUARD);
+}
+
+// --------------------------------------------------------------------------
+void	kf_SetDroidMovePursue()
+{
+	kfsf_SetSelectedDroidsState(DSO_HALTTYPE, DSS_HALT_PURSUE);	// ASK?
+}
+
+// --------------------------------------------------------------------------
 void	kf_SetDroidMovePatrol()
 {
 	kfsf_SetSelectedDroidsState(DSO_PATROL, DSS_PATROL_SET);	// ASK

--- a/src/keymap.cpp
+++ b/src/keymap.cpp
@@ -232,6 +232,8 @@ static KeyMapSaveEntry const keyMapSaveTable[] =
 	{kf_SelectAllTrucks, "SelectAllTrucks"},
 	{kf_SetDroidOrderStop, "SetDroidOrderStop"},
 	{kf_SelectAllArmedVTOLs, "SelectAllArmedVTOLs"},
+	{kf_SetDroidMovePursue, "SetDroidMovePursue"},
+	{kf_SetDroidMoveGuard, "SetDroidMoveGuard"},
 };
 
 KeyMapSaveEntry const *keymapEntryByFunction(void (*function)())
@@ -380,8 +382,10 @@ void keyInitMappings(bool bForceDefaults)
 	keyAddMapping(KEYMAP_ASSIGNABLE, KEY_IGNORE, KEY_D,      KEYMAP_PRESSED, kf_JumpToUnassignedUnits, N_("View Unassigned Units"));
 	keyAddMapping(KEYMAP_ASSIGNABLE, KEY_IGNORE, KEY_E,      KEYMAP_PRESSED, kf_SetDroidAttackReturn,  N_("Return Fire"));
 	keyAddMapping(KEYMAP_ASSIGNABLE, KEY_IGNORE, KEY_F,      KEYMAP_PRESSED, kf_SetDroidAttackAtWill,  N_("Fire at Will"));
+	keyAddMapping(KEYMAP_ASSIGNABLE, KEY_IGNORE, KEY_G,      KEYMAP_PRESSED, kf_SetDroidMoveGuard,     N_("Guard Position"));
 	keyAddMapping(KEYMAP_ASSIGNABLE, KEY_LSHIFT, KEY_H,      KEYMAP_PRESSED, kf_SetDroidReturnToBase,  N_("Return to HQ"));
 	keyAddMapping(KEYMAP_ASSIGNABLE, KEY_IGNORE, KEY_H,      KEYMAP_PRESSED, kf_SetDroidOrderHold,     N_("Hold Position"));
+	keyAddMapping(KEYMAP_ASSIGNABLE, KEY_IGNORE, KEY_P,      KEYMAP_PRESSED, kf_SetDroidMovePursue,    N_("Pursue"));
 	keyAddMapping(KEYMAP_ASSIGNABLE, KEY_IGNORE, KEY_Q,      KEYMAP_PRESSED, kf_SetDroidMovePatrol,    N_("Patrol"));
 	keyAddMapping(KEYMAP_ASSIGNABLE, KEY_IGNORE, KEY_R,      KEYMAP_PRESSED, kf_SetDroidGoForRepair,   N_("Return For Repair"));
 	keyAddMapping(KEYMAP_ASSIGNABLE, KEY_IGNORE, KEY_S,      KEYMAP_PRESSED, kf_SetDroidOrderStop,     N_("Stop Droid"));

--- a/src/order.cpp
+++ b/src/order.cpp
@@ -580,11 +580,13 @@ void orderUpdateDroid(DROID *psDroid)
 				actionDroid(psDroid, DACTION_MOVE, psDroid->order.pos.x, psDroid->order.pos.y);
 			}
 		}
-		else if ((psDroid->action == DACTION_ATTACK) ||
+		else if (((psDroid->action == DACTION_ATTACK) ||
+		         (psDroid->action == DACTION_VTOLATTACK) ||
 		         (psDroid->action == DACTION_MOVETOATTACK) ||
 		         (psDroid->action == DACTION_ROTATETOATTACK) ||
 		         (psDroid->action == DACTION_OBSERVE) ||
-		         (psDroid->action == DACTION_MOVETOOBSERVE))
+		         (psDroid->action == DACTION_MOVETOOBSERVE)) &&
+		         secondaryGetState(psDroid, DSO_HALTTYPE) != DSS_HALT_PURSUE)
 		{
 			// attacking something - see if the droid has gone too far, go up to twice the distance we want to go, so that we don't repeatedly turn back when the target is almost in range.
 			if (objPosDiffSq(psDroid->pos, Vector3i(psDroid->actionPos, 0)) > (SCOUT_ATTACK_DIST * 2 * SCOUT_ATTACK_DIST * 2))
@@ -655,11 +657,13 @@ void orderUpdateDroid(DROID *psDroid)
 				break;
 			}
 		}
-		else if ((psDroid->action == DACTION_ATTACK) ||
+		else if (((psDroid->action == DACTION_ATTACK) ||
+		         (psDroid->action == DACTION_VTOLATTACK) ||
 		         (psDroid->action == DACTION_MOVETOATTACK) ||
 		         (psDroid->action == DACTION_ROTATETOATTACK) ||
 		         (psDroid->action == DACTION_OBSERVE) ||
-		         (psDroid->action == DACTION_MOVETOOBSERVE))
+		         (psDroid->action == DACTION_MOVETOOBSERVE)) &&
+		         secondaryGetState(psDroid, DSO_HALTTYPE) != DSS_HALT_PURSUE)
 		{
 			// attacking something - see if the droid has gone too far
 			xdiff = psDroid->pos.x - psDroid->actionPos.x;

--- a/src/orderdef.h
+++ b/src/orderdef.h
@@ -96,7 +96,7 @@ enum SECONDARY_ORDER
 	DSO_CLEAR_PRODUCTION,           /**< Removes the production from a command droid. */
 	DSO_RECYCLE,                    /**< If can be recycled or not. */
 	DSO_PATROL,                     /**< If it is assigned to patrol between current pos and next move target. */
-	DSO_UNUSED2,                    /**< The type of halt. It can be hold, guard or pursue. Used with DSS_HALT_HOLD, DSS_HALT_GUARD,  DSS_HALT_PURSUE. */
+	DSO_HALTTYPE,                    /**< The type of halt. It can be hold, guard or pursue. Used with DSS_HALT_HOLD, DSS_HALT_GUARD,  DSS_HALT_PURSUE. */
 	DSO_RETURN_TO_LOC,              /**< Generic secondary order to return to a location. Will depend on the secondary state DSS_RTL* to be specific. */
 	DSO_FIRE_DESIGNATOR,            /**< Assigns a droid to be a target designator. */
 	DSO_ASSIGN_VTOL_PRODUCTION,     /**< Assigns a vtol factory to a command droid - the state is given by the factory number. */
@@ -113,6 +113,9 @@ enum SECONDARY_STATE
 	DSS_ALEV_ALWAYS     = 0x000010,	/**< state referred to secondary order DSO_ATTACK_LEVEL. Droid attacks by its free will everytime. */
 	DSS_ALEV_ATTACKED   = 0x000020,	/**< state referred to secondary order DSO_ATTACK_LEVEL. Droid attacks if it is attacked. */
 	DSS_ALEV_NEVER      = 0x000030,	/**< state referred to secondary order DSO_ATTACK_LEVEL. Droid never attacks. */
+	DSS_HALT_HOLD       = 0x000040,	/**< state referred to secondary order DSO_HALTTYPE. If halted, droid never moves by its free will. */
+	DSS_HALT_GUARD      = 0x000080,	/**< state referred to secondary order DSO_HALTTYPE. If halted, droid moves on a given region by its free will. */
+	DSS_HALT_PURSUE     = 0x0000c0,	/**< state referred to secondary order DSO_HALTTYPE. If halted, droid pursues the target by its free will. */
 	DSS_RECYCLE_SET     = 0x000100,	/**< state referred to secondary order DSO_RECYCLE. If set, the droid can be recycled. */
 	DSS_ASSPROD_START   = 0x000200,	/**< @todo this state is not called on the code. Consider removing it. */
 	DSS_ASSPROD_MID     = 0x002000,	/**< @todo this state is not called on the code. Consider removing it. */
@@ -128,6 +131,7 @@ enum SECONDARY_STATE
 /** masks for the secondary order state. */
 #define DSS_REPLEV_MASK             0x00000c
 #define DSS_ALEV_MASK               0x000030
+#define DSS_HALT_MASK               0x0000c0
 #define DSS_RECYCLE_MASK            0x000100
 #define DSS_ASSPROD_MASK            0x1f07fe00
 #define DSS_ASSPROD_FACT_MASK       0x003e00

--- a/src/scripttabs.cpp
+++ b/src/scripttabs.cpp
@@ -2599,6 +2599,7 @@ CONST_SYMBOL asConstantTable[] =
 	{ "DSO_ATTACK_LEVEL",	VAL_INT,	false,	DSO_ATTACK_LEVEL,	nullptr, nullptr, 0.0f },
 	{ "DSO_RECYCLE",		VAL_INT,	false,	DSO_RECYCLE,		nullptr, nullptr, 0.0f },
 	{ "DSO_PATROL",			VAL_INT,	false,	DSO_PATROL,			nullptr, nullptr, 0.0f },
+	{ "DSO_HALTTYPE",		VAL_INT,	false,	DSO_HALTTYPE,		NULL, NULL, 0.0f },
 	{ "DSO_RETURN_TO_LOC",	VAL_INT,	false,	DSO_RETURN_TO_LOC,	nullptr, nullptr, 0.0f },
 
 	// secondary order stats
@@ -2608,6 +2609,9 @@ CONST_SYMBOL asConstantTable[] =
 	{ "DSS_ALEV_ALWAYS",	VAL_INT,	false,	DSS_ALEV_ALWAYS,	nullptr, nullptr, 0.0f },
 	{ "DSS_ALEV_ATTACKED",	VAL_INT,	false,	DSS_ALEV_ATTACKED,	nullptr, nullptr, 0.0f },
 	{ "DSS_ALEV_NEVER",		VAL_INT,	false,	DSS_ALEV_NEVER,		nullptr, nullptr, 0.0f },
+	{ "DSS_HALT_HOLD",		VAL_INT,	false,	DSS_HALT_HOLD,		NULL, NULL, 0.0f },
+	{ "DSS_HALT_GUARD",		VAL_INT,	false,	DSS_HALT_GUARD,		NULL, NULL, 0.0f },
+	{ "DSS_HALT_PERSUE",	VAL_INT,	false,	DSS_HALT_PURSUE,	NULL, NULL, 0.0f },
 	{ "DSS_RECYCLE_SET",	VAL_INT,	false,	DSS_RECYCLE_SET,	nullptr, nullptr, 0.0f },
 	{ "DSS_ASSPROD_START",	VAL_INT,	false,	DSS_ASSPROD_START,	nullptr, nullptr, 0.0f },
 	{ "DSS_ASSPROD_END ",	VAL_INT,	false,	DSS_ASSPROD_END ,	nullptr, nullptr, 0.0f },

--- a/src/structure.cpp
+++ b/src/structure.cpp
@@ -1838,7 +1838,7 @@ static bool setFunctionality(STRUCTURE	*psBuilding, STRUCTURE_TYPE functionType)
 			psFactory->psSubject = nullptr;
 
 			// Default the secondary order - AB 22/04/99
-			psFactory->secondaryOrder = DSS_REPLEV_NEVER | DSS_ALEV_ALWAYS;
+			psFactory->secondaryOrder = DSS_REPLEV_NEVER | DSS_ALEV_ALWAYS | DSS_HALT_GUARD;
 
 			// Create the assembly point for the factory
 			if (!createFlagPosition(&psFactory->psAssemblyPoint, psBuilding->player))

--- a/src/structure.cpp
+++ b/src/structure.cpp
@@ -2234,6 +2234,10 @@ void setFactorySecondaryState(DROID *psDroid, STRUCTURE *psStructure)
 		{
 			secondarySetState(psDroid, DSO_CIRCLE, (SECONDARY_STATE)(newState & DSS_CIRCLE_MASK));
 		}
+		if ((diff & DSS_HALT_MASK) != 0)
+		{
+			secondarySetState(psDroid, DSO_HALTTYPE, (SECONDARY_STATE)(newState & DSS_HALT_MASK));
+		}
 	}
 }
 


### PR DESCRIPTION
Like how it was years ago.

These patches additionally:
1. Provide the option to set these order from the factory right-click menu.
2. Show the target icon when auto-acquiring new targets in many more cases.
3. Fix patrol and circle so that, when guarding, they obey the distance limit checks.
4. Prevent primary guard from being overridden by DORDER_ATTACK or DORDER_OBSERVE. Meaning units will only move a few tiles to chase something then return to where they were.

These patches should be thoroughly tested before being merged. Not that I haven't but there is a lot to test and I might have missed something.