### PR TITLE
Improve reticule button hit-testing / click area

### DIFF
--- a/lib/widget/widgbase.h
+++ b/lib/widget/widgbase.h
@@ -66,6 +66,9 @@ typedef std::function<void (WIDGET *psWidget, unsigned int oldScreenWidth, unsig
 /* The optional "onDelete" callback function */
 typedef std::function<void (WIDGET *psWidget)> WIDGET_ONDELETE_FUNC;
 
+/* The optional hit-testing function, used for custom hit-testing within the outer bounding rectangle */
+typedef std::function<bool (WIDGET *psWidget, int x, int y)> WIDGET_HITTEST_FUNC;
+
 
 /* The different base types of widget */
 enum WIDGET_TYPE
@@ -128,6 +131,8 @@ protected:
 	virtual void run(W_CONTEXT *) {}
 	virtual void display(int, int) {}
 	virtual void geometryChanged() {}
+
+	virtual bool hitTest(int x, int y);
 
 public:
 	virtual unsigned getState();
@@ -207,6 +212,8 @@ public:
 
 	void setOnDelete(const WIDGET_ONDELETE_FUNC& onDeleteFunc);
 
+	void setCustomHitTest(const WIDGET_HITTEST_FUNC& newCustomHitTestFunc);
+
 	UDWORD                  id;                     ///< The user set ID number for the widget. This is returned when e.g. a button is pressed.
 	WIDGET_TYPE             type;                   ///< The widget type
 	UDWORD                  style;                  ///< The style of the widget
@@ -219,6 +226,7 @@ public:
 private:
 	WIDGET_CALCLAYOUT_FUNC  calcLayout;				///< Optional calc layout callback
 	WIDGET_ONDELETE_FUNC	onDelete;				///< Optional callback called when the Widget is about to be deleted
+	WIDGET_HITTEST_FUNC		customHitTest;			///< Optional hit-testing custom function
 	void setScreenPointer(W_SCREEN *screen);        ///< Set screen pointer for us and all children.
 public:
 	void processClickRecursive(W_CONTEXT *psContext, WIDGET_KEY key, bool wasPressed);

--- a/lib/widget/widget.cpp
+++ b/lib/widget/widget.cpp
@@ -111,6 +111,7 @@ W_INIT::W_INIT()
 	, UserData(0)
 	, calcLayout(nullptr)
 	, onDelete(nullptr)
+	, customHitTest(nullptr)
 	, initPUserDataFunc(nullptr)
 {}
 
@@ -125,6 +126,7 @@ WIDGET::WIDGET(W_INIT const *init, WIDGET_TYPE type)
 	, screenPointer(nullptr)
 	, calcLayout(init->calcLayout)
 	, onDelete(init->onDelete)
+	, customHitTest(init->customHitTest)
 	, parentWidget(nullptr)
 	, dim(init->x, init->y, init->width, init->height)
 	, dirty(true)
@@ -151,6 +153,7 @@ WIDGET::WIDGET(WIDGET *parent, WIDGET_TYPE type)
 	, screenPointer(nullptr)
 	, calcLayout(nullptr)
 	, onDelete(nullptr)
+	, customHitTest(nullptr)
 	, parentWidget(nullptr)
 	, dim(0, 0, 1, 1)
 	, dirty(true)
@@ -235,6 +238,11 @@ void WIDGET::callCalcLayout()
 void WIDGET::setOnDelete(const WIDGET_ONDELETE_FUNC& onDeleteFunc)
 {
 	onDelete = onDeleteFunc;
+}
+
+void WIDGET::setCustomHitTest(const WIDGET_HITTEST_FUNC& newCustomHitTestFunc)
+{
+	customHitTest = newCustomHitTestFunc;
 }
 
 void WIDGET::attach(WIDGET *widget)
@@ -739,6 +747,20 @@ void WIDGET::runRecursive(W_CONTEXT *psContext)
 	}
 }
 
+bool WIDGET::hitTest(int x, int y)
+{
+	// default hit-testing bounding rect (based on the widget's x, y, width, height)
+	bool hitTestResult = dim.contains(x, y);
+
+	if(customHitTest)
+	{
+		// if the default bounding-rect hit-test succeeded, use the custom hit-testing func
+		hitTestResult = hitTestResult && customHitTest(this, x, y);
+	}
+
+	return hitTestResult;
+}
+
 void WIDGET::processClickRecursive(W_CONTEXT *psContext, WIDGET_KEY key, bool wasPressed)
 {
 	W_CONTEXT shiftedContext;
@@ -752,7 +774,7 @@ void WIDGET::processClickRecursive(W_CONTEXT *psContext, WIDGET_KEY key, bool wa
 	{
 		WIDGET *psCurr = *i;
 
-		if (!psCurr->visible() || !psCurr->dim.contains(shiftedContext.mx, shiftedContext.my))
+		if (!psCurr->visible() || !psCurr->hitTest(shiftedContext.mx, shiftedContext.my))
 		{
 			continue;  // Skip any hidden widgets, or widgets the click missed.
 		}

--- a/lib/widget/widget.h
+++ b/lib/widget/widget.h
@@ -123,6 +123,7 @@ struct W_INIT
 	UDWORD                  UserData;               ///< User data (if any)
 	WIDGET_CALCLAYOUT_FUNC  calcLayout;				///< Optional calculate layout callback function
 	WIDGET_ONDELETE_FUNC	onDelete;				///< Optional callback called when the Widget is about to be deleted
+	WIDGET_HITTEST_FUNC		customHitTest;			///< Optional custom hit-testing function
 	WIDGET_INITIALIZE_PUSERDATA_FUNC initPUserDataFunc;	///< (Optional) Used to initialize the pUserData pointer per widget instance
 };
 


### PR DESCRIPTION
The hit-testing for the reticule buttons has not been ideal, but it worsened after commit cb1252c (and the attempt to fix the visual offsets in commit 6731c4c). The hit-test boxes were wrong, and it made the buttons much harder to click.

This implements custom hit-testing behavior based on the image dimensions (and a bounding ellipse based on those dimensions that much more accurately reflects the actual shape of the button images).