### PR TITLE
Fix Asciidoctor warnings

### DIFF
--- a/doc/quickstartguide.asciidoc
+++ b/doc/quickstartguide.asciidoc
@@ -715,10 +715,9 @@ completed designs)
 8. Select the System turrets (turret only, normal units only)
 
 9. Select the Weapon turrets (turret only, normal units only)
-
++
 image:images/design-bars.jpg[]
 
-[start=10]
 10. How fast the unit moves over roads
 
 11. How fast the unit moves off-road


### PR DESCRIPTION
Use list continuation to fix Asciidoctor warnings:
```
asciidoctor : warning : quickstartguide.asciidoc: line 722: list item index: expected 1, got 10
asciidoctor : warning : quickstartguide.asciidoc: line 724: list item index: expected 2, got 11
asciidoctor : warning : quickstartguide.asciidoc: line 726: list item index: expected 3, got 12
asciidoctor : warning : quickstartguide.asciidoc: line 728: list item index: expected 4, got 13
```