### PR TITLE
mission.apsDroidLists transporter count check

### DIFF
--- a/src/loop.cpp
+++ b/src/loop.cpp
@@ -445,24 +445,7 @@ void countUpdate(bool synch)
 				break;
 			case DROID_TRANSPORTER:
 			case DROID_SUPERTRANSPORTER:
-				if ((psCurr->psGroup != nullptr))
-				{
-					DROID *psDroid = nullptr;
-
-					numTransporterDroids[i] += psCurr->psGroup->refCount - 1;
-					// and count the units inside it...
-					for (psDroid = psCurr->psGroup->psList; psDroid != nullptr && psDroid != psCurr; psDroid = psDroid->psGrpNext)
-					{
-						if (psDroid->droidType == DROID_CYBORG_CONSTRUCT || psDroid->droidType == DROID_CONSTRUCT)
-						{
-							numConstructorDroids[i] += 1;
-						}
-						if (psDroid->droidType == DROID_COMMAND)
-						{
-							numCommandDroids[i] += 1;
-						}
-					}
-				}
+				droidCountsInTransporter(psCurr, i);
 				break;
 			default:
 				break;
@@ -482,10 +465,7 @@ void countUpdate(bool synch)
 				break;
 			case DROID_TRANSPORTER:
 			case DROID_SUPERTRANSPORTER:
-				if ((psCurr->psGroup != nullptr))
-				{
-					numTransporterDroids[i] += psCurr->psGroup->refCount - 1;
-				}
+				droidCountsInTransporter(psCurr, i);
 				break;
 			default:
 				break;
@@ -909,6 +889,32 @@ void adjustDroidCount(DROID *droid, int delta) {
 		break;
 	default:
 		break;
+	}
+}
+
+// Increase counts of droids in a transporter
+void droidCountsInTransporter(DROID *droid, int player)
+{
+	DROID *psDroid = nullptr;
+
+	if (!isTransporter(droid) || droid->psGroup == nullptr)
+	{
+		return;
+	}
+
+	numTransporterDroids[player] += droid->psGroup->refCount - 1;
+
+	// and count the units inside it...
+	for (psDroid = droid->psGroup->psList; psDroid != nullptr && psDroid != droid; psDroid = psDroid->psGrpNext)
+	{
+		if (psDroid->droidType == DROID_CYBORG_CONSTRUCT || psDroid->droidType == DROID_CONSTRUCT)
+		{
+			numConstructorDroids[player] += 1;
+		}
+		if (psDroid->droidType == DROID_COMMAND)
+		{
+			numCommandDroids[player] += 1;
+		}
 	}
 }
 

--- a/src/loop.h
+++ b/src/loop.h
@@ -90,6 +90,8 @@ UDWORD getNumCommandDroids(UDWORD player);
 UDWORD getNumConstructorDroids(UDWORD player);
 // increase the droid counts - used by update factory to keep the counts in sync
 void adjustDroidCount(struct DROID *droid, int delta);
+// Increase counts of droids in a transporter
+void droidCountsInTransporter(DROID *droid, int player);
 
 void countUpdate(bool synch = false);
 


### PR DESCRIPTION
In the scenario a player's first transport load does not contain any trucks in Gamma-1, and said player tries to bring in all their trucks from the transporter menu, the mission will instantly fail.

Compound this with the transporter loads getting mixed up if loading saves from Beta-end and we essentially come across a potential soft-lock.

Campaign library function __camPlayerDead() checks if a player is dead by seeing if there are no factories or trucks. Specifically, countDroid(DROID_CONSTRUCT) is returning zero. Thus the player is not considered alive.

So, this PR updates the counts for trucks and commanders that are inside a transporter inside the mission list. Below is a savegame to reproduce this issue.

[gamma-fail.zip](https://github.com/Warzone2100/warzone2100/files/3010912/gamma-fail.zip)
