### PR TITLE
[WIP] Add config option to prevent idle trucks building

### DIFF
--- a/src/configuration.cpp
+++ b/src/configuration.cpp
@@ -40,6 +40,7 @@
 #include "ingameop.h"
 #include "multiint.h"
 #include "multiplay.h"
+#include "order.h" // for variable idleTrucksBuilding
 #include "radar.h"
 #include "seqdisp.h"
 #include "texture.h"
@@ -124,6 +125,7 @@ bool loadConfig()
 	rotateRadar = ini.value("rotateRadar", true).toBool();
 	radarRotationArrow = ini.value("radarRotationArrow", true).toBool();
 	hostQuitConfirmation = ini.value("hostQuitConfirmation", true).toBool();
+	idleTrucksBuilding = ini.value("idleTrucksBuilding", true).toBool();
 	war_SetPauseOnFocusLoss(ini.value("PauseOnFocusLoss", false).toBool());
 	NETsetMasterserverName(ini.value("masterserver_name", "lobby.wz2100.net").toString().toUtf8().constData());
 	iV_font(ini.value("fontname", "DejaVu Sans").toString().toUtf8().constData(),
@@ -268,6 +270,7 @@ bool saveConfig()
 	ini.setValue("rotateRadar", rotateRadar);
 	ini.setValue("radarRotationArrow", radarRotationArrow);
 	ini.setValue("hostQuitConfirmation", hostQuitConfirmation);
+	ini.setValue("idleTrucksBuilding", idleTrucksBuilding);
 	ini.setValue("PauseOnFocusLoss", war_GetPauseOnFocusLoss());
 	ini.setValue("masterserver_name", NETgetMasterserverName());
 	ini.setValue("masterserver_port", NETgetMasterserverPort());

--- a/src/order.cpp
+++ b/src/order.cpp
@@ -65,6 +65,9 @@
 
 #include "random.h"
 
+// If set to false, idle trucks owned by a human player will not try to help building structures.
+bool idleTrucksBuilding;
+
 /** How long a droid runs after it fails do respond due to low moral. */
 #define RUN_TIME		8000
 
@@ -303,7 +306,7 @@ static bool tryDoRepairlikeAction(DROID *psDroid)
 			{
 				actionDroid(psDroid, damaged.second, damaged.first);
 			}
-			else if (damaged.second == DACTION_BUILD)
+			else if (damaged.second == DACTION_BUILD && (idleTrucksBuilding || !isHumanPlayer(psDroid->player)))
 			{
 				psDroid->order.psStats = damaged.first->pStructureType;
 				psDroid->order.direction = damaged.first->rot.direction;

--- a/src/order.h
+++ b/src/order.h
@@ -29,6 +29,8 @@
 
 #include "orderdef.h"
 
+extern bool idleTrucksBuilding;
+
 /** Retreat positions for the players. This is a global instance of RUN_DATA.*/
 extern RUN_DATA asRunData[MAX_PLAYERS];
 


### PR DESCRIPTION
In version 3.2.0 beta2, commit 24c8416c1345594e834629d0cf467e37088964b7 granted
idle construction units the capability to assist with the building of structures
without explicit orders to do so.

Some human players prefer more control over their units.
To accommodate them, a new configuration option "idleTrucksBuilding" allows them
to disable this behavior for their own units. AIs are not affected by this.

Thanks to Cyp and Berserk Cyborg for making the code so nice to work with.

In [ticket 4719](http://developer.wz2100.net/ticket/4719), Prot complained about
construction units leaving their designated positions.
Is the patch sufficient to address his concerns or does it need more work?

The attached zip file contains: 
* a savegame with a single idle truck next to an unfinished power generator
* screenshots and videos generated with the savegame via a shell script,
  which document the new feature. The shell script is also included.

[idle_trucks_building_documentation.zip](https://github.com/Warzone2100/warzone2100/files/3020153/idle_trucks_building_documentation.zip)
