### PR TITLE
Fix horizontal offset of chatbox cursor

### DIFF
--- a/lib/widget/editbox.cpp
+++ b/lib/widget/editbox.cpp
@@ -626,8 +626,6 @@ void W_EDITBOX::display(int xOffset, int yOffset)
 		displayCache.modeText.setText(tmp.toUtf8(), FontID);
 
 		int cx = x0 + WEDB_XGAP + displayCache.modeText.width();
-		displayCache.wzHyphen.setText("-", FontID);
-		cx += displayCache.wzHyphen.width();
 		int cy = fy;
 		iV_Line(cx, cy + iV_GetTextAboveBase(FontID), cx, cy - iV_GetTextBelowBase(FontID), WZCOL_FORM_CURSOR);
 	}

--- a/lib/widget/editbox.h
+++ b/lib/widget/editbox.h
@@ -39,7 +39,6 @@
 struct EditBoxDisplayCache {
 	WzText wzDisplayedText;
 	WzText modeText;
-	WzText wzHyphen;
 };
 
 class W_EDITBOX : public WIDGET


### PR DESCRIPTION
The chatbox cursor no longer appears the width of an hyphen ahead of text.

The attached zip file contains: 
* screenshots and videos showing the cursor position in the game setup screen
* a shell script to generate them

[chatbox_cursor_offset_documentation.zip](https://github.com/Warzone2100/warzone2100/files/3020144/chatbox_cursor_offset_documentation.zip)
