### PR TITLE
Fix rotated structure shadows

### DIFF
--- a/src/display3d.cpp
+++ b/src/display3d.cpp
@@ -2362,7 +2362,8 @@ void renderStructure(STRUCTURE *psStructure, const glm::mat4 &viewMatrix)
 	}
 	else
 	{
-		pieFlag = pie_STATIC_SHADOW | ecmFlag;
+		// structures can be rotated, so use a dynamic shadow for them
+		pieFlag = pie_SHADOW | ecmFlag;
 		pieFlagData = 0;
 	}
 


### PR DESCRIPTION
Since structures can be rotated, they must use `pie_SHADOW` instead of `pie_STATIC_SHADOW`.

(Note: Because of the new `ShadowCache` (see: `piedraw.cpp`), it's not clear whether there's much of a use for `pie_STATIC_SHADOW` anymore - but this is the minimal change that fixes the rotated structure shadow issue. In the future, maybe reconsider whether `pie_STATIC_SHADOW` is needed in the few remaining places it's used.)

Resolves #284