### PR TITLE
Improvements / fixes to textdraw.cpp

### DIFF
--- a/lib/ivis_opengl/textdraw.cpp
+++ b/lib/ivis_opengl/textdraw.cpp
@@ -426,6 +426,7 @@ public:
 
 		hb_buffer_add_utf8(m_buffer, text.text.c_str(), length, 0, length);
 		hb_buffer_guess_segment_properties(m_buffer);
+		hb_buffer_set_flags(m_buffer, (hb_buffer_flags_t)(HB_BUFFER_FLAG_BOT | HB_BUFFER_FLAG_EOT));
 
 		// harfbuzz shaping
 		std::array<hb_feature_t, 3> features = { {HBFeature::KerningOn, HBFeature::LigatureOn, HBFeature::CligOn} };

--- a/lib/ivis_opengl/textdraw.cpp
+++ b/lib/ivis_opengl/textdraw.cpp
@@ -150,6 +150,10 @@ struct FTFace
 
 	RasterizedGlyph get(uint32_t codePoint, Vector2i subpixeloffset64)
 	{
+		FT_Vector delta;
+		delta.x = subpixeloffset64.x;
+		delta.y = subpixeloffset64.y;
+		FT_Set_Transform(m_face, nullptr, &delta);
 		FT_Error error = FT_Load_Glyph(m_face,
 			codePoint, // the glyph_index in the font file
 			WZ_FT_LOAD_FLAGS

--- a/lib/ivis_opengl/textdraw.cpp
+++ b/lib/ivis_opengl/textdraw.cpp
@@ -241,11 +241,40 @@ struct TextRun
 		text(t), language(l), script(s), direction(d) {}
 };
 
-struct ShapedText
+struct TextLayoutMetrics
 {
-	std::unique_ptr<unsigned char[]> texture;
+	TextLayoutMetrics(uint32_t _width, uint32_t _height) : width(_width), height(_height) { }
+	TextLayoutMetrics() : width(0), height(0) { }
 	uint32_t width;
 	uint32_t height;
+};
+
+struct RenderedText
+{
+	RenderedText(std::unique_ptr<unsigned char[]> &&_data, uint32_t _width, uint32_t _height, int32_t _offset_x, int32_t _offset_y)
+	: data(std::move(_data)), width(_width), height(_height), offset_x(_offset_x), offset_y(_offset_y)
+	{ }
+
+	RenderedText() : data(nullptr) , width(0) , height(0) , offset_x(0) , offset_y(0)
+	{ }
+
+	std::unique_ptr<unsigned char[]> data;
+	uint32_t width;
+	uint32_t height;
+	int32_t offset_x;
+	int32_t offset_y;
+};
+
+struct DrawTextResult
+{
+	DrawTextResult(RenderedText &&_text, TextLayoutMetrics _layoutMetrics) : text(std::move(_text)), layoutMetrics(_layoutMetrics)
+	{ }
+
+	DrawTextResult()
+	{ }
+
+	RenderedText text;
+	TextLayoutMetrics layoutMetrics;
 };
 
 // Note:
@@ -266,18 +295,20 @@ struct TextShaper
 	}
 
 	// Returns the text width and height *IN PIXELS*
-	std::tuple<uint32_t, uint32_t> getTextMetrics(const TextRun& text, FTFace &face)
+	TextLayoutMetrics getTextMetrics(const TextRun& text, FTFace &face)
 	{
-		const std::vector<HarfbuzzPosition> &shapingResult = shapeText(text, face);
-		if (shapingResult.empty())
-			return std::make_tuple(0, 0);
+		const ShapingResult &shapingResult = shapeText(text, face);
+		if (shapingResult.glyphes.empty())
+		{
+			return TextLayoutMetrics(shapingResult.x_advance / 64, shapingResult.y_advance / 64);
+		}
 
 		int32_t min_x;
 		int32_t max_x;
 		int32_t min_y;
 		int32_t max_y;
 
-		std::tie(min_x, max_x, min_y, max_y) = std::accumulate(shapingResult.begin(), shapingResult.end(), std::make_tuple(1000, -1000, 1000, -1000),
+		std::tie(min_x, max_x, min_y, max_y) = std::accumulate(shapingResult.glyphes.begin(), shapingResult.glyphes.end(), std::make_tuple(1000, -1000, 1000, -1000),
 			[&face] (const std::tuple<int32_t, int32_t, int32_t, int32_t> &bounds, const HarfbuzzPosition &g) {
 			RasterizedGlyph glyph = face.get(g.codepoint, g.penPosition % 64);
 			int32_t x0 = g.penPosition.x / 64 + glyph.bearing_x;
@@ -290,17 +321,22 @@ struct TextShaper
 				);
 			});
 
-		return std::make_tuple(max_x - min_x + 1, max_y - min_y + 1);
+		const uint32_t texture_width = max_x - min_x + 1;
+		const uint32_t texture_height = max_y - min_y + 1;
+		const uint32_t x_advance = (shapingResult.x_advance / 64);
+		const uint32_t y_advance = (shapingResult.y_advance / 64);
+
+		// return the maximum of the x_advance / y_advance (converted from harfbuzz units) and the texture dimensions
+		return TextLayoutMetrics(std::max(texture_width, x_advance), std::max(texture_height, y_advance));
 	}
 
 	// Draws the text and returns the text buffer, width and height, etc *IN PIXELS*
-	std::tuple<std::unique_ptr<unsigned char[]>, uint32_t, uint32_t, int32_t, int32_t> drawText(const TextRun& text, FTFace &face)
+	DrawTextResult drawText(const TextRun& text, FTFace &face)
 	{
-		const std::vector<HarfbuzzPosition> &shapingResult = shapeText(text, face);
-
-		if (shapingResult.empty())
+		const ShapingResult &shapingResult = shapeText(text, face);
+		if (shapingResult.glyphes.empty())
 		{
-			return std::make_tuple(nullptr, 0, 0, 0, 0);
+			return DrawTextResult(RenderedText(), TextLayoutMetrics(shapingResult.x_advance / 64, shapingResult.y_advance / 64));
 		}
 
 		int32_t min_x = 1000;
@@ -321,7 +357,7 @@ struct TextShaper
 		};
 
 		std::vector<glyphRaster> glyphs;
-		std::transform(shapingResult.begin(), shapingResult.end(), std::back_inserter(glyphs),
+		std::transform(shapingResult.glyphes.begin(), shapingResult.glyphes.end(), std::back_inserter(glyphs),
 			[&] (const HarfbuzzPosition &g) {
 			RasterizedGlyph glyph = face.get(g.codepoint, g.penPosition % 64);
 			int32_t x0 = g.penPosition.x / 64 + glyph.bearing_x;
@@ -333,11 +369,13 @@ struct TextShaper
 			return glyphRaster(std::move(glyph.buffer), Vector2i(x0, y0), Vector2i(glyph.width, glyph.height), glyph.pitch);
 			});
 
-		uint32_t width = max_x - min_x + 1;
-		uint32_t height = max_y - min_y + 1;
+		const uint32_t texture_width = max_x - min_x + 1;
+		const uint32_t texture_height = max_y - min_y + 1;
+		const uint32_t x_advance = (shapingResult.x_advance / 64);
+		const uint32_t y_advance = (shapingResult.y_advance / 64);
 
-		std::unique_ptr<unsigned char[]> stringTexture(new unsigned char[4 * width * height]);
-		memset(stringTexture.get(), 0, 4 * width * height);
+		std::unique_ptr<unsigned char[]> stringTexture(new unsigned char[4 * texture_width * texture_height]);
+		memset(stringTexture.get(), 0, 4 * texture_width * texture_height);
 
 		std::for_each(glyphs.begin(), glyphs.end(),
 			[&](const glyphRaster &g)
@@ -349,7 +387,7 @@ struct TextShaper
 					{
 						uint32_t j0 = g.pixelPosition.x - min_x;
 						uint8_t const *src = &g.buffer[i * g.pitch + 3 * j];
-						uint8_t *dst = &stringTexture[4 * ((i0 + i) * width + j + j0)];
+						uint8_t *dst = &stringTexture[4 * ((i0 + i) * texture_width + j + j0)];
 						dst[0] = std::min(dst[0] + src[0], 255);
 						dst[1] = std::min(dst[1] + src[1], 255);
 						dst[2] = std::min(dst[2] + src[2], 255);
@@ -357,7 +395,10 @@ struct TextShaper
 					}
 				}
 			});
-		return std::make_tuple(std::move(stringTexture), width, height, min_x, min_y);
+		return DrawTextResult(
+				RenderedText(std::move(stringTexture), texture_width, texture_height, min_x, min_y),
+				TextLayoutMetrics(std::max(texture_width, x_advance), std::max(texture_height, y_advance))
+		);
 	}
 
 public:
@@ -371,7 +412,14 @@ public:
 		HarfbuzzPosition(hb_codepoint_t c, Vector2i &&p) : codepoint(c), penPosition(p) {}
 	};
 
-	std::vector<HarfbuzzPosition> shapeText(const TextRun& text, FTFace &face)
+	struct ShapingResult
+	{
+		std::vector<HarfbuzzPosition> glyphes;
+		int32_t x_advance = 0;
+		int32_t y_advance = 0;
+	};
+
+	ShapingResult shapeText(const TextRun& text, FTFace &face)
 	{
 		hb_buffer_reset(m_buffer);
 		size_t length = text.text.size();
@@ -380,7 +428,7 @@ public:
 		hb_buffer_guess_segment_properties(m_buffer);
 
 		// harfbuzz shaping
-		std::array<hb_feature_t, 3> features = { HBFeature::KerningOn, HBFeature::LigatureOn, HBFeature::CligOn };
+		std::array<hb_feature_t, 3> features = { {HBFeature::KerningOn, HBFeature::LigatureOn, HBFeature::CligOn} };
 		hb_shape(face.m_font, m_buffer, features.data(), features.size());
 
 		unsigned int glyphCount;
@@ -393,15 +441,18 @@ public:
 
 		int32_t x = 0;
 		int32_t y = 0;
-		std::vector<HarfbuzzPosition> glyphes;
+		ShapingResult result;
 		for (unsigned int glyphIndex = 0; glyphIndex < glyphCount; ++glyphIndex)
 		{
-			glyphes.emplace_back(glyphInfo[glyphIndex].codepoint, Vector2i(x + glyphPos[glyphIndex].x_offset, y + glyphPos[glyphIndex].y_offset));
+			hb_glyph_position_t &current_glyphPos = glyphPos[glyphIndex];
+			result.glyphes.emplace_back(glyphInfo[glyphIndex].codepoint, Vector2i(x + current_glyphPos.x_offset, y + current_glyphPos.y_offset));
 
 			x += glyphPos[glyphIndex].x_advance;
 			y += glyphPos[glyphIndex].y_advance;
 		};
-		return glyphes;
+		result.x_advance = x;
+		result.y_advance = y;
+		return result;
 	}
 };
 
@@ -523,10 +574,9 @@ unsigned int height_pixelsToPoints(unsigned int heightInPixels)
 // Returns the text width *in points*
 unsigned int iV_GetTextWidth(const char *string, iV_fonts fontID)
 {
-	uint32_t width;
 	TextRun tr(string, "en", HB_SCRIPT_COMMON, HB_DIRECTION_LTR);
-	std::tie(width, std::ignore) = getShaper().getTextMetrics(tr, getFTFace(fontID));
-	return width_pixelsToPoints(width);
+	TextLayoutMetrics metrics = getShaper().getTextMetrics(tr, getFTFace(fontID));
+	return width_pixelsToPoints(metrics.width);
 }
 
 // Returns the counted text width *in points*
@@ -538,10 +588,9 @@ unsigned int iV_GetCountedTextWidth(const char *string, size_t string_length, iV
 // Returns the text height *in points*
 unsigned int iV_GetTextHeight(const char *string, iV_fonts fontID)
 {
-	uint32_t height;
 	TextRun tr(string, "en", HB_SCRIPT_COMMON, HB_DIRECTION_LTR);
-	std::tie(std::ignore, height) = getShaper().getTextMetrics(tr, getFTFace(fontID));
-	return height_pixelsToPoints(height);
+	TextLayoutMetrics metrics = getShaper().getTextMetrics(tr, getFTFace(fontID));
+	return height_pixelsToPoints(metrics.height);
 }
 
 // Returns the character width *in points*
@@ -745,24 +794,21 @@ void iV_DrawTextRotated(const char *string, float XPos, float YPos, float rotati
 	color.vector[3] = font_colour[3] * 255.f;
 
 	TextRun tr(string, "en", HB_SCRIPT_COMMON, HB_DIRECTION_LTR);
-	uint32_t width, height;
-	std::unique_ptr<unsigned char[]> texture;
-	int32_t xoffset, yoffset;
-	std::tie(texture, width, height, xoffset, yoffset) = getShaper().drawText(tr, getFTFace(fontID));
+	DrawTextResult drawResult = getShaper().drawText(tr, getFTFace(fontID));
 
-	if (width > 0 && height > 0)
+	if (drawResult.text.width > 0 && drawResult.text.height > 0)
 	{
 		pie_SetTexturePage(TEXPAGE_EXTERN);
 		if (textureID)
 			delete textureID;
-		textureID = gfx_api::context::get().create_texture(width, height, gfx_api::pixel_format::rgba);
-		textureID->upload(0u, 0u, 0u, width, height, gfx_api::pixel_format::rgba, texture.get());
+		textureID = gfx_api::context::get().create_texture(drawResult.text.width, drawResult.text.height, gfx_api::pixel_format::rgba);
+		textureID->upload(0u, 0u, 0u, drawResult.text.width, drawResult.text.height, gfx_api::pixel_format::rgba, drawResult.text.data.get());
 		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, text_filtering);
 		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, text_filtering);
 		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
 		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
 		glDisable(GL_CULL_FACE);
-		iV_DrawImageText(*textureID, Vector2i(XPos, YPos), Vector2f((float)xoffset / _horizScaleFactor, (float)yoffset / _vertScaleFactor), Vector2f((float)width / _horizScaleFactor, (float)height / _vertScaleFactor), rotation, REND_TEXT, color);
+		iV_DrawImageText(*textureID, Vector2i(XPos, YPos), Vector2f((float)drawResult.text.offset_x / _horizScaleFactor, (float)drawResult.text.offset_y / _vertScaleFactor), Vector2f((float)drawResult.text.width / _horizScaleFactor, (float)drawResult.text.height / _vertScaleFactor), rotation, REND_TEXT, color);
 		glEnable(GL_CULL_FACE);
 	}
 }
@@ -805,12 +851,12 @@ void iV_DrawTextF(float x, float y, const char *format, ...)
 int WzText::width()
 {
 	updateCacheIfNecessary();
-	return width_pixelsToPoints(dimensions.x);
+	return width_pixelsToPoints(layoutMetrics.x);
 }
 int WzText::height()
 {
 	updateCacheIfNecessary();
-	return height_pixelsToPoints(dimensions.y);
+	return height_pixelsToPoints(layoutMetrics.y);
 }
 int WzText::aboveBase()
 {
@@ -845,7 +891,6 @@ void WzText::drawAndCacheText(const std::string &string, iV_fonts fontID)
 	mRenderingVertScaleFactor = iV_GetVertScaleFactor();
 
 	TextRun tr(string, "en", HB_SCRIPT_COMMON, HB_DIRECTION_LTR);
-	std::unique_ptr<unsigned char[]> data;
 	FTFace &face = getFTFace(fontID);
 	FT_Face &type = face.face();
 
@@ -853,7 +898,10 @@ void WzText::drawAndCacheText(const std::string &string, iV_fonts fontID)
 	mPtsLineSize = metricsHeight_PixelsToPoints((type->size->metrics.ascender - type->size->metrics.descender) >> 6);
 	mPtsBelowBase = metricsHeight_PixelsToPoints(type->size->metrics.descender >> 6);
 
-	std::tie(data, dimensions.x, dimensions.y, offsets.x, offsets.y) = getShaper().drawText(tr, face);
+	DrawTextResult drawResult = getShaper().drawText(tr, face);
+	dimensions = Vector2i(drawResult.text.width, drawResult.text.height);
+	offsets = Vector2i(drawResult.text.offset_x, drawResult.text.offset_y);
+	layoutMetrics = Vector2i(drawResult.layoutMetrics.width, drawResult.layoutMetrics.height);
 
 	if (texture)
 	{
@@ -865,7 +913,7 @@ void WzText::drawAndCacheText(const std::string &string, iV_fonts fontID)
 	{
 		pie_SetTexturePage(TEXPAGE_EXTERN);
 		texture = gfx_api::context::get().create_texture(dimensions.x, dimensions.y, gfx_api::pixel_format::rgba);
-		texture->upload(0u, 0u, 0u, dimensions.x , dimensions.y, gfx_api::pixel_format::rgba, data.get());
+		texture->upload(0u, 0u, 0u, dimensions.x , dimensions.y, gfx_api::pixel_format::rgba, drawResult.text.data.get());
 		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, text_filtering);
 		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, text_filtering);
 		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
@@ -911,6 +959,7 @@ WzText& WzText::operator=(WzText&& other)
 		dimensions = other.dimensions;
 		mRenderingHorizScaleFactor = other.mRenderingHorizScaleFactor;
 		mRenderingVertScaleFactor = other.mRenderingVertScaleFactor;
+		layoutMetrics = other.layoutMetrics;
 
 		// Reset other's texture
 		other.texture = nullptr;

--- a/lib/ivis_opengl/textdraw.h
+++ b/lib/ivis_opengl/textdraw.h
@@ -79,6 +79,7 @@ private:
 	float mRenderingHorizScaleFactor = 0.f;
 	float mRenderingVertScaleFactor = 0.f;
 	iV_fonts mFontID = font_count;
+	Vector2i layoutMetrics = Vector2i(0, 0);
 };
 
 class WidthLimitedWzText: public WzText

--- a/src/frontend.cpp
+++ b/src/frontend.cpp
@@ -100,7 +100,7 @@ bool			bLimiterLoaded = false;
 // ////////////////////////////////////////////////////////////////////////////
 // Forward definitions
 
-static void addSmallTextButton(UDWORD id, UDWORD PosX, UDWORD PosY, const char *txt, unsigned int style);
+static W_BUTTON * addSmallTextButton(UDWORD id, UDWORD PosX, UDWORD PosY, const char *txt, unsigned int style);
 
 // ////////////////////////////////////////////////////////////////////////////
 // Helper functions
@@ -163,9 +163,13 @@ static bool startTitleMenu()
 
 	addSmallTextButton(FRONTEND_HYPERLINK, FRONTEND_POS8X, FRONTEND_POS8Y, _("Official site: http://wz2100.net/"), 0);
 	widgSetTip(psWScreen, FRONTEND_HYPERLINK, _("Come visit the forums and all Warzone 2100 news! Click this link."));
-	addSmallTextButton(FRONTEND_DONATELINK, FRONTEND_POS8X + 360, FRONTEND_POS8Y, _("Donate: http://donations.wz2100.net/"), 0);
+	W_BUTTON * pRightAlignedButton = addSmallTextButton(FRONTEND_DONATELINK, FRONTEND_POS8X + 360, FRONTEND_POS8Y, _("Donate: http://donations.wz2100.net/"), 0);
+	// fix-up right-aligned link's positioning (based on size of text)
+	pRightAlignedButton->move(pRightAlignedButton->parent()->width() - (pRightAlignedButton->width() + 1), pRightAlignedButton->y());
 	widgSetTip(psWScreen, FRONTEND_DONATELINK, _("Help support the project with our server costs, Click this link."));
-	addSmallTextButton(FRONTEND_CHATLINK, FRONTEND_POS8X + 360, 0, _("Chat with players on #warzone2100"), 0);
+	pRightAlignedButton = addSmallTextButton(FRONTEND_CHATLINK, FRONTEND_POS8X + 360, 0, _("Chat with players on #warzone2100"), 0);
+	// fix-up right-aligned link's positioning (based on size of text)
+	pRightAlignedButton->move(pRightAlignedButton->parent()->width() - (pRightAlignedButton->width() + 6), pRightAlignedButton->y());
 	widgSetTip(psWScreen, FRONTEND_CHATLINK, _("Connect to Freenode through webchat by clicking this link."));
 	addMultiBut(psWScreen, FRONTEND_BOTFORM, FRONTEND_UPGRDLINK, 7, 7, MULTIOP_BUTW, MULTIOP_BUTH, _("Check for a newer version"), IMAGE_GAMEVERSION, IMAGE_GAMEVERSION_HI, true);
 
@@ -2078,7 +2082,7 @@ void addTextButton(UDWORD id,  UDWORD PosX, UDWORD PosY, const std::string &txt,
 	}
 }
 
-void addSmallTextButton(UDWORD id,  UDWORD PosX, UDWORD PosY, const char *txt, unsigned int style)
+W_BUTTON * addSmallTextButton(UDWORD id,  UDWORD PosX, UDWORD PosY, const char *txt, unsigned int style)
 {
 	W_BUTINIT sButInit;
 
@@ -2090,7 +2094,7 @@ void addSmallTextButton(UDWORD id,  UDWORD PosX, UDWORD PosY, const char *txt, u
 	// Align
 	if (!(style & WBUT_TXTCENTRE))
 	{
-		sButInit.width = (short)(iV_GetTextWidth(txt, font_small) + 10);
+		sButInit.width = (uint16_t)(iV_GetTextWidth(txt, font_small)) + 4;
 		sButInit.x += 35;
 	}
 	else
@@ -2117,13 +2121,14 @@ void addSmallTextButton(UDWORD id,  UDWORD PosX, UDWORD PosY, const char *txt, u
 	sButInit.pDisplay = displayTextOption;
 	sButInit.FontID = font_small;
 	sButInit.pText = txt;
-	widgAddButton(psWScreen, &sButInit);
+	W_BUTTON * pButton = widgAddButton(psWScreen, &sButInit);
 
 	// Disable button
 	if (style & WBUT_DISABLE)
 	{
 		widgSetButtonState(psWScreen, id, WBUT_DISABLE);
 	}
+	return pButton;
 }
 
 // ////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This should yield:
- More accurate glyph spacing (fewer unexpected "gaps" between characters)
- More accurate glyph shaping / sizing
- Much more accurate text width calculations - especially noticeable in the case of a string with trailing spaces
- More accurate cursor positioning in text fields (`W_EDITBOX`).