### PR TITLE
W_EDITBOX: Improve ESC handling behavior

### DIFF
--- a/lib/widget/editbox.cpp
+++ b/lib/widget/editbox.cpp
@@ -417,6 +417,21 @@ void W_EDITBOX::run(W_CONTEXT *psContext)
 			break;
 		case INPBUF_ESC :
 			debug(LOG_INPUT, "EditBox cursor escape");
+			if (aText.length() > 0)
+			{
+				// hitting ESC while the editbox contains text clears the text
+				aText.clear();
+				insPos = 0;
+				printStart = 0;
+				fitStringStart();
+			}
+			else
+			{
+				// hitting ESC while the editbox is empty ends editing mode
+				StopTextInput();
+				screenPointer->setFocus(nullptr);
+				return;
+			}
 			break;
 
 		default:


### PR DESCRIPTION
This enables hitting ESC to:
1.) Clear the current text in the EditBox (if it has text)
2.) End editing mode (if the EditBox is empty)

Thus, to quickly cancel out / close an in-game chat box that contains text, hit escape twice (once to clear, once to end editing mode).

NOTE: There are unrelated issues with how the main menus handle widget & input processing (and the ESC key) that prevent this from working in the main menus (yet). But the _in-game_ edit boxes, such as the in-game chatbox, can take advantage of this immediately.