### PR TITLE
Fix documentation of PIE format

### DIFF
--- a/doc/PIE.md
+++ b/doc/PIE.md
@@ -26,13 +26,21 @@ The first line specifies the version number -- either 2 or 3.
 
 ### TYPE
 
-> TYPE X
+> TYPE 211
 
-This indicates the type of the file through a hexadecimal combination of flags. The following values can be used:
+This indicates the type of the file through a hexadecimal combination of the flags 0x200, 0x10 and 0x1.
+The following flags are available:
 
- * 0x00200 -- Reserved for backward compatibility.
- * 0x01000 -- Specifies that the model should not be stretched to fit terrain. For defensive buildings that have a deep foundation.
- * 0x10000 -- Specifies the usage of the TCMask feature, for which a texture named 'page-N_tcmask.png' (*N* being a number) should be used together with the model's ordinary texture. This flag replaced old team coloration methods (read ticket #851).
+* 0x00001 -- Disables additive rendering
+* 0x00002 -- Enables additive rendering
+* 0x00004 -- Enables premultiplied rendering
+
+* 0x00010 -- Rolls object to face the camera. Used for projectiles shaped like a cylinder.
+* 0x00020 -- Pitches object to completely face the camera. Used for projectiles shaped like a sphere.
+
+* 0x00200 -- Reserved for backward compatibility.
+* 0x01000 -- Specifies that the model should not be stretched to fit terrain. For defensive buildings that have a deep foundation.
+* 0x10000 -- Specifies the usage of the TCMask feature, for which a texture named 'page-N_tcmask.png' (*N* being a number) should be used together with the model's ordinary texture. This flag replaced old team coloration methods (read ticket #851).
 
 ### TEXTURE
 
@@ -71,10 +79,10 @@ Optional. As above, but this sets the specular map texture page for the model.
 An animation event associated with this model. If the event type is triggered, the model is
 replaced with the specified model for the duration of the event. The following event types are defined:
 
-  * 1 -- Active event. What this means depends on the type of model. For droids this means movement,
+* 1 -- Active event. What this means depends on the type of model. For droids this means movement,
     while for power generators it means they are linked to a power source.
-  * 2 -- Firing. The model is firing at some enemy.
-  * 3 -- Dying. The model is dying. You (almost) always want to make sure animation cycles for this model is set to 1 for the specified model -- if it is zero, it will never die!
+* 2 -- Firing. The model is firing at some enemy.
+* 3 -- Dying. The model is dying. You (almost) always want to make sure animation cycles for this model is set to 1 for the specified model -- if it is zero, it will never die!
 
 ### LEVELS
 
@@ -87,6 +95,14 @@ This gives the number of meshes that are contained in this model. Each mesh can 
 > LEVEL 1
 
 This starts the model description for mesh 1. Repeat the below as necessary while incrementing the value above as needed.
+
+### MATERIALS (disabled, PIE 3 only)
+
+This feature was removed in commit 823cf08bb18cf24852bac8595b3899aca12d4f7b.
+
+> MATERIALS 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 20
+
+Optional. Specifies the material properties of a mesh. The nine first values give the RGB values for ambient, diffuse and specular lighting, respectively. The last value sets shininess.
 
 ### SHADERS (PIE 3 only)
 
@@ -175,12 +191,6 @@ Not every model requires them; the meaning of each connector is special and hard
 
 Each connector must be on a separate line and must be indented with a tab.
 It contains the x, y, and z coordinates of a connector. Note that unlike in point coordinates, the Z coordinate denotes "up".
-
-### MATERIALS (PIE 3 only)
-
-> MATERIALS 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 20
-
-Optional. Specifies the material properties of a mesh. The nine first values give the RGB values for ambient, diffuse and specular lighting, respectively. The last value sets shininess.
 
 ### ANIMOBJECT (PIE 3 only)
 


### PR DESCRIPTION
Fix documentation of PIE format

MaNGusT has [found mistakes in the PIE format documentation](http://forums.wz2100.net/viewtopic.php?f=33&t=4245&start=735#p144330):
* the MATERIALS directive is disabled
* some mode flags are not mentioned

According to him, this patch is [correct](http://forums.wz2100.net/viewtopic.php?f=33&t=4245&p=144336#p144351).