### PR TITLE
Fix terraindepth.frag warning on some systems

### DIFF
--- a/data/base/shaders/terraindepth.frag
+++ b/data/base/shaders/terraindepth.frag
@@ -4,7 +4,7 @@
 uniform sampler2D lightmap_tex;
 
 #if (!defined(GL_ES) && (__VERSION__ >= 130)) || (defined(GL_ES) && (__VERSION__ >= 300))
-out vec2 uv2;
+in vec2 uv2;
 out vec4 FragColor;
 #else
 varying vec2 uv2;


### PR DESCRIPTION
```
[khr_callback:144] GL::SC(Other:High) : 0:18(36): warning: 'uv2' used uninitialized
```

Resolves: #317