### PR TITLE
Update German translation

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -1350,7 +1350,7 @@ msgstr "NP-Hartbeton"
 #: data/mp/messages/strings/names.txt:395
 #: po/custom/fromJson.txt:587
 msgid "Heavy Machinegun Bunker"
-msgstr "Bunker mit schwerem Maschinengewehr"
+msgstr "Bunker mit Schwerem Maschinengewehr"
 
 #: data/base/messages/strings/names.txt:316
 #: data/mp/messages/strings/names.txt:397
@@ -1361,7 +1361,7 @@ msgstr "Stellung mit Flashlight"
 #: data/base/messages/strings/names.txt:322
 #: po/custom/fromJson.txt:592
 msgid "Heavy Machinegun Guard Tower"
-msgstr "Wachturm mit schwerem Maschinengewehr"
+msgstr "Wachturm mit Schwerem Maschinengewehr"
 
 #: data/base/messages/strings/names.txt:323
 #: po/custom/fromJson.txt:479
@@ -2075,7 +2075,7 @@ msgstr "Verstärkter Turm mit Sturmgewehr"
 #: data/base/messages/strings/resstrings.txt:234
 #: data/mp/messages/strings/resstrings.txt:117
 msgid "Armored guard tower with Heavy Machinegun"
-msgstr "Gepanzerter Wachturm mit schwerem Maschinengewehr"
+msgstr "Gepanzerter Wachturm mit Schwerem Maschinengewehr"
 
 #: data/base/messages/strings/resstrings.txt:235
 #: data/base/messages/strings/resstrings.txt:241
@@ -2112,7 +2112,7 @@ msgstr "Gepanzerter Wachturm mit Lancer-Antipanzerrakete"
 #: data/base/messages/strings/resstrings.txt:260
 #: data/mp/messages/strings/resstrings.txt:132
 msgid "Armored bunker with Heavy Machinegun"
-msgstr "Gepanzerter Bunker mit schwerem Maschinengewehr"
+msgstr "Gepanzerter Bunker mit Schwerem Maschinengewehr"
 
 #: data/base/messages/strings/resstrings.txt:280
 #: data/mp/messages/strings/resstrings.txt:137
@@ -2900,7 +2900,7 @@ msgstr "Beste Ziele: Fahrzeuge"
 #: data/mp/messages/strings/resstrings.txt:354
 #: po/custom/fromJson.txt:1125
 msgid "Replaces Medium Cannon"
-msgstr "Ersetzt mittleres Geschütz"
+msgstr "Ersetzt Mittleres Geschütz"
 
 #: data/base/messages/strings/resstrings.txt:736
 #: data/mp/messages/strings/resstrings.txt:357
@@ -4433,7 +4433,7 @@ msgstr "Cyborg-Antrieb"
 #: data/mp/messages/strings/names.txt:404
 #: po/custom/fromJson.txt:596
 msgid "Heavy Machinegun Tower"
-msgstr "Turm mit schwerem Maschinengewehr"
+msgstr "Turm mit Schwerem Maschinengewehr"
 
 #: data/mp/messages/strings/names.txt:405
 msgid "Flamer Tower"
@@ -5109,7 +5109,7 @@ msgstr "Bewaffnet mit einem Maschinengewehr"
 
 #: po/custom/fromJson.txt:136
 msgid "Armed with medium cannon"
-msgstr "Bewaffnet mit mittlerem Geschütz"
+msgstr "Bewaffnet mit Mittlerem Geschütz"
 
 #: po/custom/fromJson.txt:137
 msgid "Armed with Needle Gun"
@@ -5137,7 +5137,7 @@ msgstr "Gepanzerter Bunker mit Lancer-Antipanzerrakete"
 
 #: po/custom/fromJson.txt:145
 msgid "Armored bunker with Light Cannon"
-msgstr "Gepanzerter Bunker mit leichtem Geschütz"
+msgstr "Gepanzerter Bunker mit Leichtem Geschütz"
 
 #: po/custom/fromJson.txt:146
 msgid "Armored bunker with Machinegun"
@@ -5193,11 +5193,11 @@ msgstr "Gepanzerte Aufhängung mit Gaußkanone"
 
 #: po/custom/fromJson.txt:162
 msgid "Armored hardpoint with Heavy Cannon"
-msgstr "Gepanzerte Aufhängung mit schwerem Geschütz"
+msgstr "Gepanzerte Aufhängung mit Schwerem Geschütz"
 
 #: po/custom/fromJson.txt:163
 msgid "Armored hardpoint with Heavy Machinegun"
-msgstr "Gepanzerte Aufhängung mit schwerem Maschinengewehr"
+msgstr "Gepanzerte Aufhängung mit Schwerem Maschinengewehr"
 
 #: po/custom/fromJson.txt:164
 msgid "Armored hardpoint with Hyper-Velocity Cannon"
@@ -5209,11 +5209,11 @@ msgstr "Gepanzerte Aufhängung mit Lancer-Antipanzerrakete"
 
 #: po/custom/fromJson.txt:167
 msgid "Armored hardpoint with Light Cannon"
-msgstr "Gepanzerte Aufhängung mit leichtem Geschütz"
+msgstr "Gepanzerte Aufhängung mit Leichtem Geschütz"
 
 #: po/custom/fromJson.txt:168
 msgid "Armored hardpoint with Medium Cannon"
-msgstr "Gepanzerte Aufhängung mit mittlerem Geschütz"
+msgstr "Gepanzerte Aufhängung mit Mittlerem Geschütz"
 
 #: po/custom/fromJson.txt:169
 msgid "Armored hardpoint with Rail Gun"
@@ -5241,7 +5241,7 @@ msgstr "Gepanzerte Stellung mit Gaußkanone"
 
 #: po/custom/fromJson.txt:180
 msgid "Armored strongpoint with Heavy Laser"
-msgstr "Gepanzerte Stellung mit schwerem Laser"
+msgstr "Gepanzerte Stellung mit Schwerem Laser"
 
 #: po/custom/fromJson.txt:183
 msgid "Armored strongpoint with Plasmite Flamer"
@@ -6590,7 +6590,7 @@ msgstr "Schweres Geschütz mit 120-mm-Geschossen"
 
 #: po/custom/fromJson.txt:571
 msgid "Heavy Cannon Hardpoint"
-msgstr "Aufhängung mit schwerem Geschütz"
+msgstr "Aufhängung mit Schwerem Geschütz"
 
 #: po/custom/fromJson.txt:572
 msgid "Heavy Cannon Mantis Tracks"
@@ -6630,7 +6630,7 @@ msgstr "Schwerer Laser"
 
 #: po/custom/fromJson.txt:583
 msgid "Heavy Laser Emplacement"
-msgstr "Stellung mit schweren Laser"
+msgstr "Stellung mit Schwerem Laser"
 
 #: po/custom/fromJson.txt:584
 msgid "Heavy Laser Tiger Tracks"
@@ -6662,7 +6662,7 @@ msgstr "Schweres Maschinengewehr Cobra Räder"
 
 #: po/custom/fromJson.txt:593
 msgid "Heavy Machinegun Hardpoint"
-msgstr "Aufhängung mit schwerem Maschinengewehr"
+msgstr "Aufhängung mit Schwerem Maschinengewehr"
 
 #: po/custom/fromJson.txt:594
 msgid "Heavy Machinegun Scorpion Half Tracks"
@@ -7415,7 +7415,7 @@ msgstr "Leichtes Geschütz"
 
 #: po/custom/fromJson.txt:828
 msgid "Light Cannon Bunker"
-msgstr "Bunker mit leichtem Geschütz"
+msgstr "Bunker mit Leichtem Geschütz"
 
 #: po/custom/fromJson.txt:829
 msgid "Light Cannon Cobra Tracks"
@@ -7427,7 +7427,7 @@ msgstr "Leichtes Geschütz mit 40-mm-Geschossen"
 
 #: po/custom/fromJson.txt:831
 msgid "Light Cannon Hardpoint"
-msgstr "Aufhängung mit leichtem Geschütz"
+msgstr "Aufhängung mit Leichtem Geschütz"
 
 #: po/custom/fromJson.txt:832
 msgid "Light Cannon Python Tracks"
@@ -7559,7 +7559,7 @@ msgstr "Mittleres Geschütz mit 76-mm-Geschossen"
 
 #: po/custom/fromJson.txt:872
 msgid "Medium Cannon Hardpoint"
-msgstr "Aufhängung mit mittlerem Geschütz"
+msgstr "Aufhängung mit Mittlerem Geschütz"
 
 #: po/custom/fromJson.txt:873
 msgid "Medium Cannon Python Hover"

--- a/po/de.po
+++ b/po/de.po
@@ -10475,7 +10475,7 @@ msgstr "Minikartenzoom"
 
 #: src/frontend.cpp:918
 msgid "AUDIO / ZOOM OPTIONS"
-msgstr "AUDIO- UND ZOOMEINSTELLUNGEN"
+msgstr "AUDIO- UND ZOOM-\nEINSTELLUNGEN"
 
 #: src/frontend.cpp:1014
 msgid "Windowed"

--- a/po/de.po
+++ b/po/de.po
@@ -1203,7 +1203,7 @@ msgstr "Neuer Entwurf"
 #: data/base/messages/strings/names.txt:103
 #: data/mp/messages/strings/names.txt:160
 msgid "Cyborg Cannon"
-msgstr "Cyborggeschütz"
+msgstr "Cyborgkanone"
 
 #: data/base/messages/strings/names.txt:149
 #: data/base/messages/strings/names.txt:182
@@ -2030,7 +2030,7 @@ msgstr "Greift automatisch Ziele in Reichweite an"
 #: data/mp/messages/strings/resstrings.txt:97
 #: po/custom/fromJson.txt:181
 msgid "Armored strongpoint with Hyper-Velocity Cannon"
-msgstr "Gepanzerte Stellung mit Hochgeschwindigkeitsgeschütz"
+msgstr "Gepanzerte Stellung mit Hochgeschwindigkeitskanone"
 
 #: data/base/messages/strings/resstrings.txt:200
 #: data/base/messages/strings/resstrings.txt:220
@@ -2064,7 +2064,7 @@ msgstr "Gepanzerte Stellung mit Inferno-Flammenwerfer"
 #: data/mp/messages/strings/resstrings.txt:107
 #: po/custom/fromJson.txt:177
 msgid "Armored strongpoint with Assault Cannon"
-msgstr "Gepanzerte Stellung mit Sturmgeschütz"
+msgstr "Gepanzerte Stellung mit Sturmkanone"
 
 #: data/base/messages/strings/resstrings.txt:224
 #: data/mp/messages/strings/resstrings.txt:112
@@ -2129,7 +2129,7 @@ msgstr "Gepanzerte Aufhängung mit Sturmgewehr"
 #: data/mp/messages/strings/resstrings.txt:147
 #: po/custom/fromJson.txt:158
 msgid "Armored hardpoint with Assault Cannon"
-msgstr "Gepanzerte Aufhängung mit Sturmgeschütz"
+msgstr "Gepanzerte Aufhängung mit Sturmkanone"
 
 #: data/base/messages/strings/resstrings.txt:302
 #: data/mp/messages/strings/resstrings.txt:152
@@ -2886,7 +2886,7 @@ msgstr "Neuer Waffenturm verfügbar"
 #: data/mp/messages/strings/resstrings.txt:352
 #: po/custom/fromJson.txt:684
 msgid "Hyper-velocity automatic-cannon firing 88mm rounds"
-msgstr "Hochgeschwindigkeitsautomatikgeschütz mit 88-mm-Geschossen"
+msgstr "Hochgeschwindigkeitsautomatikkanone mit 88-mm-Geschossen"
 
 #: data/base/messages/strings/resstrings.txt:731
 #: data/base/messages/strings/resstrings.txt:737
@@ -2900,13 +2900,13 @@ msgstr "Beste Ziele: Fahrzeuge"
 #: data/mp/messages/strings/resstrings.txt:354
 #: po/custom/fromJson.txt:1125
 msgid "Replaces Medium Cannon"
-msgstr "Ersetzt Mittleres Geschütz"
+msgstr "Ersetzt Mittlere Kanone"
 
 #: data/base/messages/strings/resstrings.txt:736
 #: data/mp/messages/strings/resstrings.txt:357
 #: po/custom/fromJson.txt:8
 msgid "76mm hyper-velocity quad-barrel automatic-cannon"
-msgstr "Vierläufiges 76-mm-Hochgeschwindigkeitsautomatikgeschütz"
+msgstr "Vierläufige 76-mm-Hochgeschwindigkeitsautomatikkanone"
 
 #: data/base/messages/strings/resstrings.txt:738
 #: data/mp/messages/strings/resstrings.txt:359
@@ -4541,12 +4541,12 @@ msgstr "Schwerer Superschütze"
 #: data/mp/messages/strings/names.txt:777
 #: po/custom/fromJson.txt:1252
 msgid "Super Auto-Cannon Cyborg"
-msgstr "Sturmgeschütz-Supercyborg"
+msgstr "Sturmkanonensupercyborg"
 
 #: data/mp/messages/strings/names.txt:779
 #: po/custom/fromJson.txt:1268
 msgid "Super HPV Cyborg"
-msgstr "Hochgeschwindigkeitsgeschütz-Supercyborg"
+msgstr "Hochgeschwindigkeitskanonensupercyborg"
 
 #: data/mp/messages/strings/names.txt:781
 #: po/custom/fromJson.txt:1274
@@ -4744,7 +4744,7 @@ msgstr "7,62-mm-Maschinengewehr"
 
 #: po/custom/fromJson.txt:9
 msgid "76mm twin-barrel automatic-cannon"
-msgstr "Doppelläufiges 76-mm-Schnellfeuergeschütz"
+msgstr "Doppelläufige 76-mm-Schnellfeuerkanone"
 
 #: po/custom/fromJson.txt:10
 msgid "AA accuracy +10%"
@@ -4937,7 +4937,7 @@ msgstr "Aerodynamiklabor"
 
 #: po/custom/fromJson.txt:70
 msgid "All cannons upgraded automatically"
-msgstr "Alle Geschütze wurden automatisch aufgerüstet"
+msgstr "Alle Kanonen wurden automatisch aufgerüstet"
 
 #: po/custom/fromJson.txt:71
 msgid "All CB sensors upgraded automatically"
@@ -5025,15 +5025,15 @@ msgstr "Panzerbrechende Treibspiegelprojektile für Maschinengewehre Mk3"
 
 #: po/custom/fromJson.txt:113
 msgid "APFSDS Cannon Rounds"
-msgstr "Panzerbrechende flügelstabilisierte Treibspiegelgeschosse für Geschütze"
+msgstr "Panzerbrechende flügelstabilisierte Treibspiegelgeschosse für Kanonen"
 
 #: po/custom/fromJson.txt:114
 msgid "APFSDS Cannon Rounds Mk2"
-msgstr "Panzerbrechende flügelstabilisierte Treibspiegelgeschosse für Geschütze Mk2"
+msgstr "Panzerbrechende flügelstabilisierte Treibspiegelgeschosse für Kanonen Mk2"
 
 #: po/custom/fromJson.txt:115
 msgid "APFSDS Cannon Rounds Mk3"
-msgstr "Panzerbrechende flügelstabilisierte Treibspiegelgeschosse für Geschütze Mk3"
+msgstr "Panzerbrechende flügelstabilisierte Treibspiegelgeschosse für Kanonen Mk3"
 
 #: po/custom/fromJson.txt:116
 msgid "Archangel Missile"
@@ -5053,7 +5053,7 @@ msgstr "Bewaffnet mit Cyborgsturmgewehr"
 
 #: po/custom/fromJson.txt:122
 msgid "Armed with Cyborg Cannon"
-msgstr "Bewaffnet mit Cyborggeschütz"
+msgstr "Bewaffnet mit Cyborgkanone"
 
 #: po/custom/fromJson.txt:123
 msgid "Armed with Cyborg Flamer"
@@ -5069,7 +5069,7 @@ msgstr "Bewaffnet mit Pulslaser für Cyborgs"
 
 #: po/custom/fromJson.txt:126
 msgid "Armed with Cyborg Rail Gun"
-msgstr "Bewaffnet mit Magnetgeschütz für Cyborgs"
+msgstr "Bewaffnet mit Magnetkanone für Cyborgs"
 
 #: po/custom/fromJson.txt:127
 msgid "Armed with Cyborg Scourge Missile Launcher"
@@ -5093,7 +5093,7 @@ msgstr "Bewaffnet mit Mörsergranaten"
 
 #: po/custom/fromJson.txt:132
 msgid "Armed with hyper velocity cannon"
-msgstr "Bewaffnet mit Hochgeschwindigkeitsgeschütz"
+msgstr "Bewaffnet mit Hochgeschwindigkeitskanone"
 
 #: po/custom/fromJson.txt:133
 msgid "Armed with Lance Anti-Tank rocket"
@@ -5109,11 +5109,11 @@ msgstr "Bewaffnet mit einem Maschinengewehr"
 
 #: po/custom/fromJson.txt:136
 msgid "Armed with medium cannon"
-msgstr "Bewaffnet mit Mittlerem Geschütz"
+msgstr "Bewaffnet mit Mittlerer Kanone"
 
 #: po/custom/fromJson.txt:137
 msgid "Armed with Needle Gun"
-msgstr "Bewaffnet mit Nadelgeschütz"
+msgstr "Bewaffnet mit Nadelkanone"
 
 #: po/custom/fromJson.txt:139
 msgid "Armed with Scourge anti-tank missile"
@@ -5137,7 +5137,7 @@ msgstr "Gepanzerter Bunker mit Lancer-Antipanzerrakete"
 
 #: po/custom/fromJson.txt:145
 msgid "Armored bunker with Light Cannon"
-msgstr "Gepanzerter Bunker mit Leichtem Geschütz"
+msgstr "Gepanzerter Bunker mit Leichter Kanone"
 
 #: po/custom/fromJson.txt:146
 msgid "Armored bunker with Machinegun"
@@ -5149,7 +5149,7 @@ msgstr "Gepanzerte Grube mit EMP-Mörser"
 
 #: po/custom/fromJson.txt:149
 msgid "Armored guard tower with EMP Cannon"
-msgstr "Gepanzerter Wachturm mit EMP-Geschütz"
+msgstr "Gepanzerter Wachturm mit EMP-Kanone"
 
 #: po/custom/fromJson.txt:150
 msgid "Armored guard tower with Lancer AT rocket"
@@ -5165,7 +5165,7 @@ msgstr "Gepanzerter Wachturm mit Miniraketenhalter"
 
 #: po/custom/fromJson.txt:153
 msgid "Armored guard tower with Needle Gun"
-msgstr "Gepanzerter Wachturm mit Nadelgeschütz"
+msgstr "Gepanzerter Wachturm mit Nadelkanone"
 
 #: po/custom/fromJson.txt:154
 msgid "Armored guard tower with Nexus Link"
@@ -5193,7 +5193,7 @@ msgstr "Gepanzerte Aufhängung mit Gaußkanone"
 
 #: po/custom/fromJson.txt:162
 msgid "Armored hardpoint with Heavy Cannon"
-msgstr "Gepanzerte Aufhängung mit Schwerem Geschütz"
+msgstr "Gepanzerte Aufhängung mit Schwerer Kanone"
 
 #: po/custom/fromJson.txt:163
 msgid "Armored hardpoint with Heavy Machinegun"
@@ -5201,7 +5201,7 @@ msgstr "Gepanzerte Aufhängung mit Schwerem Maschinengewehr"
 
 #: po/custom/fromJson.txt:164
 msgid "Armored hardpoint with Hyper-Velocity Cannon"
-msgstr "Gepanzerte Aufhängung mit Hochgeschwindigkeitsgeschütz"
+msgstr "Gepanzerte Aufhängung mit Hochgeschwindigkeitskanone"
 
 #: po/custom/fromJson.txt:166
 msgid "Armored hardpoint with Lancer AT missile"
@@ -5209,15 +5209,15 @@ msgstr "Gepanzerte Aufhängung mit Lancer-Antipanzerrakete"
 
 #: po/custom/fromJson.txt:167
 msgid "Armored hardpoint with Light Cannon"
-msgstr "Gepanzerte Aufhängung mit Leichtem Geschütz"
+msgstr "Gepanzerte Aufhängung mit Leichter Kanone"
 
 #: po/custom/fromJson.txt:168
 msgid "Armored hardpoint with Medium Cannon"
-msgstr "Gepanzerte Aufhängung mit Mittlerem Geschütz"
+msgstr "Gepanzerte Aufhängung mit Mittlerer Kanone"
 
 #: po/custom/fromJson.txt:169
 msgid "Armored hardpoint with Rail Gun"
-msgstr "Gepanzerte Aufhängung mit Magnetgeschütz"
+msgstr "Gepanzerte Aufhängung mit Magnetkanone"
 
 #: po/custom/fromJson.txt:170
 msgid "Armored hardpoint with Scourge AT Missile"
@@ -5253,7 +5253,7 @@ msgstr "Gepanzerte Stellung mit Pulslaser"
 
 #: po/custom/fromJson.txt:185
 msgid "Armored strongpoint with Rail Gun"
-msgstr "Gepanzerte Stellung mit Magnetgeschütz"
+msgstr "Gepanzerte Stellung mit Magnetkanone"
 
 #: po/custom/fromJson.txt:187
 msgid "Armored Tracks"
@@ -5285,23 +5285,23 @@ msgstr "Artilleriebatterie verschießt Novastorm-Lenkraketen"
 
 #: po/custom/fromJson.txt:194
 msgid "Assault Cannon"
-msgstr "Sturmgeschütz"
+msgstr "Sturmkanone"
 
 #: po/custom/fromJson.txt:195
 msgid "Assault Cannon Emplacement"
-msgstr "Stellung mit Sturmgeschütz"
+msgstr "Stellung mit Sturmkanone"
 
 #: po/custom/fromJson.txt:196
 msgid "Assault Cannon Guard Tower"
-msgstr "Wachturm mit Sturmgeschütz"
+msgstr "Wachturm mit Sturmkanone"
 
 #: po/custom/fromJson.txt:197
 msgid "Assault Cannon Hardpoint"
-msgstr "Aufhängung mit Sturmgeschütz"
+msgstr "Aufhängung mit Sturmkanone"
 
 #: po/custom/fromJson.txt:198
 msgid "Assault Cannon Mantis Hover"
-msgstr "Sturmgeschütz Mantis Hover"
+msgstr "Sturmkanone Mantis Hover"
 
 #: po/custom/fromJson.txt:199
 msgid "Assault Gun"
@@ -5605,66 +5605,66 @@ msgstr "Verbrennt Öl effizienter"
 
 #: po/custom/fromJson.txt:296
 msgid "Cannon accuracy +10%"
-msgstr "Geschützgenauigkeit +10%"
+msgstr "Kanonengenauigkeit +10%"
 
 # auto -> selbst
 # Substantiv im Englischen absichtlich als Adjektiv im Deutschen -Kreuvf
 #: po/custom/fromJson.txt:297
 msgid "Cannon Autoloader"
-msgstr "Selbstladende Geschütze"
+msgstr "Selbstladende Kanonen"
 
 #: po/custom/fromJson.txt:298
 msgid "Cannon Autoloader Mk2"
-msgstr "Selbstladende Geschütze Mk2"
+msgstr "Selbstladende Kanonen Mk2"
 
 #: po/custom/fromJson.txt:299
 msgid "Cannon Autoloader Mk3"
-msgstr "Selbstladende Geschütze Mk3"
+msgstr "Selbstladende Kanonen Mk3"
 
 #: po/custom/fromJson.txt:300
 msgid "Cannon damage +25%"
-msgstr "Geschützschaden +25%"
+msgstr "Kanonenschaden +25%"
 
 #: po/custom/fromJson.txt:301
 msgid "Cannon Fire Truck"
-msgstr "Feuerwehrfahrzeug mit Geschütz"
+msgstr "Feuerwehrfahrzeug mit Kanone"
 
 #: po/custom/fromJson.txt:302
 msgid "Cannon Fortress"
-msgstr "Geschützfestung"
+msgstr "Kanonenfestung"
 
 #: po/custom/fromJson.txt:303
 msgid "Cannon Laser Designator"
-msgstr "Laserzielgeber für Geschütze"
+msgstr "Laserzielgeber für Kanonen"
 
 #: po/custom/fromJson.txt:304
 msgid "Cannon Laser Rangefinder"
-msgstr "Laserentfernungsmesser für Geschütze"
+msgstr "Laserentfernungsmesser für Kanonen"
 
 # Substantiv im Englischen absichtlich adjektivisch im Deutschen -Kreuvf
 #: po/custom/fromJson.txt:305
 msgid "Cannon Rapid Loader"
-msgstr "Schnell ladende Geschütze"
+msgstr "Schnell ladende Kanonen"
 
 #: po/custom/fromJson.txt:306
 msgid "Cannon Rapid Loader Mk2"
-msgstr "Schnell ladende Geschütze Mk2"
+msgstr "Schnell ladende Kanonen Mk2"
 
 #: po/custom/fromJson.txt:307
 msgid "Cannon Rapid Loader Mk3"
-msgstr "Schnell ladende Geschütze Mk3"
+msgstr "Schnell ladende Kanonen Mk3"
 
 #: po/custom/fromJson.txt:308
 msgid "Cannon reload time -10%"
-msgstr "Geschütznachladezeit -10%"
+msgstr "Kanonennachladezeit -10%"
 
 #: po/custom/fromJson.txt:309
 msgid "Cannon Tower"
-msgstr "Geschützturm"
+msgstr "Kanonenturm"
 
 #: po/custom/fromJson.txt:310
 msgid "Cannon Upgrade"
-msgstr "Geschützverbesserung"
+msgstr "Kanonenverbesserung"
 
 #: po/custom/fromJson.txt:311
 msgid "CB Radar Turret"
@@ -5716,7 +5716,7 @@ msgstr "Cobra Flammenwerfer Ketten"
 
 #: po/custom/fromJson.txt:323
 msgid "Cobra Medium Cannon Tracks"
-msgstr "Cobra Mittleres Geschütz Ketten"
+msgstr "Cobra Mittlere Kanone Ketten"
 
 #: po/custom/fromJson.txt:324
 msgid "Cobra Truck"
@@ -6064,11 +6064,11 @@ msgstr "Greift feindliche Gebäude an und stört diese elektronisch"
 
 #: po/custom/fromJson.txt:428
 msgid "EMP Cannon"
-msgstr "EMP-Geschütz"
+msgstr "EMP-Kanone"
 
 #: po/custom/fromJson.txt:429
 msgid "EMP Cannon Tower"
-msgstr "Turm mit EMP-Geschütz"
+msgstr "Turm mit EMP-Kanone"
 
 #: po/custom/fromJson.txt:430
 msgid "EMP Missile Launcher"
@@ -6522,15 +6522,15 @@ msgstr "Hochexplosive panzerbrechende Mörsergranaten Mk3"
 
 #: po/custom/fromJson.txt:552
 msgid "HEAT Cannon Shells"
-msgstr "Hochexplosive Antipanzergeschosse für Geschütze"
+msgstr "Hochexplosive Antipanzergeschosse für Kanonen"
 
 #: po/custom/fromJson.txt:553
 msgid "HEAT Cannon Shells Mk2"
-msgstr "Hochexplosive Antipanzergeschosse für Geschütze Mk2"
+msgstr "Hochexplosive Antipanzergeschosse für Kanonen Mk2"
 
 #: po/custom/fromJson.txt:554
 msgid "HEAT Cannon Shells Mk3"
-msgstr "Hochexplosive Antipanzergeschosse für Geschütze Mk3"
+msgstr "Hochexplosive Antipanzergeschosse für Kanonen Mk3"
 
 #: po/custom/fromJson.txt:557
 msgid "HEAT Rocket Warhead"
@@ -6574,43 +6574,43 @@ msgstr "Schwerer Rumpf - Wyvern"
 
 #: po/custom/fromJson.txt:567
 msgid "Heavy Cannon"
-msgstr "Schweres Geschütz"
+msgstr "Schwere Kanone"
 
 #: po/custom/fromJson.txt:568
 msgid "Heavy Cannon Cobra Hover"
-msgstr "Schweres Geschütz Cobra Hover"
+msgstr "Schwere Kanone Cobra Hover"
 
 #: po/custom/fromJson.txt:569
 msgid "Heavy Cannon Cobra Tracks"
-msgstr "Schweres Geschütz Cobra Ketten"
+msgstr "Schwere Kanone Cobra Ketten"
 
 #: po/custom/fromJson.txt:570
 msgid "Heavy Cannon firing 120 mm rounds"
-msgstr "Schweres Geschütz mit 120-mm-Geschossen"
+msgstr "Schwere Kanone mit 120-mm-Geschossen"
 
 #: po/custom/fromJson.txt:571
 msgid "Heavy Cannon Hardpoint"
-msgstr "Aufhängung mit Schwerem Geschütz"
+msgstr "Aufhängung mit Schwerer Kanone"
 
 #: po/custom/fromJson.txt:572
 msgid "Heavy Cannon Mantis Tracks"
-msgstr "Schweres Geschütz Mantis Ketten"
+msgstr "Schwere Kanone Mantis Ketten"
 
 #: po/custom/fromJson.txt:573
 msgid "Heavy Cannon Python Hover"
-msgstr "Schweres Geschütz Python Hover"
+msgstr "Schwere Kanone Python Hover"
 
 #: po/custom/fromJson.txt:574
 msgid "Heavy Cannon Python Tracks"
-msgstr "Schweres Geschütz Python Ketten"
+msgstr "Schwere Kanone Python Ketten"
 
 #: po/custom/fromJson.txt:575
 msgid "Heavy Cannon Scorpion Tracks"
-msgstr "Schweres Geschütz Scorpion Ketten"
+msgstr "Schwere Kanone Scorpion Ketten"
 
 #: po/custom/fromJson.txt:576
 msgid "Heavy Cannon Tiger Tracks"
-msgstr "Schweres Geschütz Tiger Ketten"
+msgstr "Schwere Kanone Tiger Ketten"
 
 #: po/custom/fromJson.txt:577
 msgid "Heavy Flamer - Inferno"
@@ -6807,7 +6807,7 @@ msgstr "Hochverdichtete Materialien für Basisgebäude"
 
 #: po/custom/fromJson.txt:633
 msgid "High Explosive Anti-Tank Cannon Shells"
-msgstr "Hochexplosive Antipanzergeschosse für Geschütze"
+msgstr "Hochexplosive Antipanzergeschosse für Kanonen"
 
 #: po/custom/fromJson.txt:634
 msgid "High Explosive Anti-Tank warhead"
@@ -6927,15 +6927,15 @@ msgstr "Haubitzennachladezeit -10%"
 
 #: po/custom/fromJson.txt:674
 msgid "HPV Cannon Emplacement"
-msgstr "Stellung mit Hochgeschwindigkeitsgeschütz"
+msgstr "Stellung mit Hochgeschwindigkeitskanone"
 
 #: po/custom/fromJson.txt:675
 msgid "HPV Cannon Hardpoint"
-msgstr "Aufhängung mit Hochgeschwindigkeitsgeschütz"
+msgstr "Aufhängung mit Hochgeschwindigkeitskanone"
 
 #: po/custom/fromJson.txt:676
 msgid "HPV Cannon Python Tracks"
-msgstr "Hochgeschwindigkeitsgeschütz Python Ketten"
+msgstr "Hochgeschwindigkeitskanone Python Ketten"
 
 #: po/custom/fromJson.txt:677
 msgid "Hurricane AA Site"
@@ -6951,15 +6951,15 @@ msgstr "Hütte"
 
 #: po/custom/fromJson.txt:680
 msgid "HVAPFSDS Cannon Rounds"
-msgstr "Panzerbrechende flügelstabilisierte Hochgeschwindigkeitstreibspiegelgeschosse für Geschütze"
+msgstr "Panzerbrechende flügelstabilisierte Hochgeschwindigkeitstreibspiegelgeschosse für Kanonen"
 
 #: po/custom/fromJson.txt:681
 msgid "HVAPFSDS Cannon Rounds Mk2"
-msgstr "Panzerbrechende flügelstabilisierte Hochgeschwindigkeitstreibspiegelgeschosse für Geschütze Mk2"
+msgstr "Panzerbrechende flügelstabilisierte Hochgeschwindigkeitstreibspiegelgeschosse für Kanonen Mk2"
 
 #: po/custom/fromJson.txt:682
 msgid "HVAPFSDS Cannon Rounds Mk3"
-msgstr "Panzerbrechende flügelstabilisierte Hochgeschwindigkeitstreibspiegelgeschosse für Geschütze Mk3"
+msgstr "Panzerbrechende flügelstabilisierte Hochgeschwindigkeitstreibspiegelgeschosse für Kanonen Mk3"
 
 #: po/custom/fromJson.txt:683
 msgid "Hyper Fire Chaingun Upgrade"
@@ -6967,23 +6967,23 @@ msgstr "Hyperschnellfeuermechanismus für Maschinengewehre"
 
 #: po/custom/fromJson.txt:685
 msgid "Hyper Velocity Cannon"
-msgstr "Hochgeschwindigkeitsgeschütz"
+msgstr "Hochgeschwindigkeitskanone"
 
 #: po/custom/fromJson.txt:686
 msgid "Hyper Velocity Cannon Emplacement"
-msgstr "Stellung mit Hochgeschwindigkeitsgeschütz"
+msgstr "Stellung mit Hochgeschwindigkeitskanone"
 
 #: po/custom/fromJson.txt:687
 msgid "Hyper Velocity Cannon Hardpoint"
-msgstr "Aufhängung mit Hochgeschwindigkeitsgeschütz"
+msgstr "Aufhängung mit Hochgeschwindigkeitskanone"
 
 #: po/custom/fromJson.txt:688
 msgid "Hyper Velocity Cannon Python Hover"
-msgstr "Hochgeschwindigkeitsgeschütz Python Hover"
+msgstr "Hochgeschwindigkeitskanone Python Hover"
 
 #: po/custom/fromJson.txt:689
 msgid "Hyper Velocity Cannon Python Tracks"
-msgstr "Hochgeschwindigkeitsgeschütz Python Ketten"
+msgstr "Hochgeschwindigkeitskanone Python Ketten"
 
 #: po/custom/fromJson.txt:690
 msgid "Immense damage infliction capability"
@@ -7111,15 +7111,15 @@ msgstr "Erhöht Panzerung und Rumpfpunkte"
 
 #: po/custom/fromJson.txt:730
 msgid "Increases Cannon accuracy"
-msgstr "Erhöht Genauigkeit von Geschützen"
+msgstr "Erhöht Genauigkeit von Kanonen"
 
 #: po/custom/fromJson.txt:731
 msgid "Increases Cannon damage"
-msgstr "Erhöht Schaden von Geschützen"
+msgstr "Erhöht Schaden von Kanonen"
 
 #: po/custom/fromJson.txt:732
 msgid "Increases Cannon ROF"
-msgstr "Erhöht Feuerrate von Geschützen"
+msgstr "Erhöht Feuerrate von Kanonen"
 
 #: po/custom/fromJson.txt:733
 msgid "Increases construction speed"
@@ -7411,39 +7411,39 @@ msgstr "Anfällig gegen schwere Waffen"
 
 #: po/custom/fromJson.txt:827
 msgid "Light Cannon"
-msgstr "Leichtes Geschütz"
+msgstr "Leichte Kanone"
 
 #: po/custom/fromJson.txt:828
 msgid "Light Cannon Bunker"
-msgstr "Bunker mit Leichtem Geschütz"
+msgstr "Bunker mit Leichter Kanone"
 
 #: po/custom/fromJson.txt:829
 msgid "Light Cannon Cobra Tracks"
-msgstr "Leichtes Geschütz Cobra Ketten"
+msgstr "Leichte Kanone Cobra Ketten"
 
 #: po/custom/fromJson.txt:830
 msgid "Light Cannon firing 40mm rounds"
-msgstr "Leichtes Geschütz mit 40-mm-Geschossen"
+msgstr "Leichte Kanone mit 40-mm-Geschossen"
 
 #: po/custom/fromJson.txt:831
 msgid "Light Cannon Hardpoint"
-msgstr "Aufhängung mit Leichtem Geschütz"
+msgstr "Aufhängung mit Leichter Kanone"
 
 #: po/custom/fromJson.txt:832
 msgid "Light Cannon Python Tracks"
-msgstr "Leichtes Geschütz Python Ketten"
+msgstr "Leichte Kanone Python Ketten"
 
 #: po/custom/fromJson.txt:833
 msgid "Light Cannon Viper Half-tracks"
-msgstr "Leichtes Geschütz Viper Halbketten"
+msgstr "Leichte Kanone Viper Halbketten"
 
 #: po/custom/fromJson.txt:834
 msgid "Light Cannon Viper Tracks"
-msgstr "Leichtes Geschütz Viper Ketten"
+msgstr "Leichte Kanone Viper Ketten"
 
 #: po/custom/fromJson.txt:835
 msgid "Light Cannon Viper Wheels"
-msgstr "Leichtes Geschütz Viper Räder"
+msgstr "Leichte Kanone Viper Räder"
 
 #: po/custom/fromJson.txt:837
 msgid "Look-Out Tower"
@@ -7539,47 +7539,47 @@ msgstr "Mittlerer Rumpf - Scorpion"
 
 #: po/custom/fromJson.txt:867
 msgid "Medium Cannon"
-msgstr "Mittleres Geschütz"
+msgstr "Mittlere Kanone"
 
 #: po/custom/fromJson.txt:868
 msgid "Medium Cannon Cobra Half Track"
-msgstr "Mittleres Geschütz Cobra Halbketten"
+msgstr "Mittlere Kanone Cobra Halbketten"
 
 #: po/custom/fromJson.txt:869
 msgid "Medium Cannon Cobra Hover"
-msgstr "Mittleres Geschütz Cobra Hover"
+msgstr "Mittlere Kanone Cobra Hover"
 
 #: po/custom/fromJson.txt:870
 msgid "Medium Cannon Cobra Tracks"
-msgstr "Mittleres Geschütz Cobra Ketten"
+msgstr "Mittlere Kanone Cobra Ketten"
 
 #: po/custom/fromJson.txt:871
 msgid "Medium Cannon firing 76mm rounds"
-msgstr "Mittleres Geschütz mit 76-mm-Geschossen"
+msgstr "Mittlere Kanone mit 76-mm-Geschossen"
 
 #: po/custom/fromJson.txt:872
 msgid "Medium Cannon Hardpoint"
-msgstr "Aufhängung mit Mittlerem Geschütz"
+msgstr "Aufhängung mit Mittlerer Kanone"
 
 #: po/custom/fromJson.txt:873
 msgid "Medium Cannon Python Hover"
-msgstr "Mittleres Geschütz Python Hover"
+msgstr "Mittlere Kanone Python Hover"
 
 #: po/custom/fromJson.txt:874
 msgid "Medium Cannon Python Tracks"
-msgstr "Mittleres Geschütz Python Ketten"
+msgstr "Mittlere Kanone Python Ketten"
 
 #: po/custom/fromJson.txt:875
 msgid "Medium Cannon Scorpion Hover"
-msgstr "Mittleres Geschütz Scorpion Hover"
+msgstr "Mittlere Kanone Scorpion Hover"
 
 #: po/custom/fromJson.txt:876
 msgid "Medium Cannon Scorpion Tracks"
-msgstr "Mittleres Geschütz Scorpion Ketten"
+msgstr "Mittlere Kanone Scorpion Ketten"
 
 #: po/custom/fromJson.txt:877
 msgid "Medium Cannon Viper Tracks"
-msgstr "Mittleres Geschütz Viper Ketten"
+msgstr "Mittlere Kanone Viper Ketten"
 
 #: po/custom/fromJson.txt:878
 msgid "Medium Super Heavy Body"
@@ -7759,7 +7759,7 @@ msgstr "Geringer Wirkungsradius"
 
 #: po/custom/fromJson.txt:927
 msgid "Needle Gun"
-msgstr "Nadelgeschütz"
+msgstr "Nadelkanone"
 
 #: po/custom/fromJson.txt:928
 msgid "Needle Gunner"
@@ -7771,19 +7771,19 @@ msgstr "Nadelschütze"
 
 #: po/custom/fromJson.txt:930
 msgid "Needle Gun Retribution Tracks"
-msgstr "Nadelgeschütz Retribution Ketten"
+msgstr "Nadelkanone Retribution Ketten"
 
 #: po/custom/fromJson.txt:931
 msgid "Needle Gun Tiger Tracks"
-msgstr "Nadelgeschütz Tiger Ketten"
+msgstr "Nadelkanone Tiger Ketten"
 
 #: po/custom/fromJson.txt:932
 msgid "Needle Gun Tower"
-msgstr "Turm mit Nadelgeschütz"
+msgstr "Turm mit Nadelkanone"
 
 #: po/custom/fromJson.txt:933
 msgid "Needle Gun Vengeance Tracks"
-msgstr "Nadelgeschütz Vengeance Ketten"
+msgstr "Nadelkanone Vengeance Ketten"
 
 # Wenn man Brain als KI-gestütztes Forschungsorgan betrachtet, könnte die Übersetzung hinhauen -Kreuvf
 #: po/custom/fromJson.txt:934
@@ -8276,7 +8276,7 @@ msgstr "Python"
 
 #: po/custom/fromJson.txt:1075
 msgid "Python Heavy Cannon Tracks"
-msgstr "Python Schweres Geschütz Ketten"
+msgstr "Python Schwere Kanone Ketten"
 
 #: po/custom/fromJson.txt:1077
 msgid "Quad 80mm Anti-Aircraft machinegun"
@@ -8300,7 +8300,7 @@ msgstr "Radardetektorturm"
 
 #: po/custom/fromJson.txt:1083
 msgid "Rail Gun"
-msgstr "Magnetgeschütz"
+msgstr "Magnetkanone"
 
 #: po/custom/fromJson.txt:1084
 msgid "Rail Gun accuracy +10%"
@@ -8312,11 +8312,11 @@ msgstr "Magnetwaffenschaden +25%"
 
 #: po/custom/fromJson.txt:1086
 msgid "Railgun Emplacement"
-msgstr "Stellung mit Magnetgeschütz"
+msgstr "Stellung mit Magnetkanone"
 
 #: po/custom/fromJson.txt:1087
 msgid "Rail Gun Emplacement"
-msgstr "Stellung mit Magnetgeschütz"
+msgstr "Stellung mit Magnetkanone"
 
 #: po/custom/fromJson.txt:1088
 msgid "Rail gun firing armor-piercing darts"
@@ -8324,11 +8324,11 @@ msgstr "Magnetwaffe verschießt panzerbrechende Pfeile"
 
 #: po/custom/fromJson.txt:1089
 msgid "Rail Gun Hardpoint"
-msgstr "Aufhängung mit Magnetgeschütz"
+msgstr "Aufhängung mit Magnetkanone"
 
 #: po/custom/fromJson.txt:1090
 msgid "Rail Gun Mantis Tracks"
-msgstr "Magnetgeschütz Mantis Ketten"
+msgstr "Magnetkanone Mantis Ketten"
 
 #: po/custom/fromJson.txt:1091
 msgid "Rail Gun reload time -15%"
@@ -8348,7 +8348,7 @@ msgstr "Verbesserte Feuerrate von Magnetwaffen Mk3"
 
 #: po/custom/fromJson.txt:1095
 msgid "Rail Gun Tiger Hover"
-msgstr "Magnetgeschütz Tiger Hover"
+msgstr "Magnetkanone Tiger Hover"
 
 #: po/custom/fromJson.txt:1096
 msgid "Rail Gun Upgrade"
@@ -9231,11 +9231,11 @@ msgstr "7,62-mm-Zwillingsmaschinengewehr"
 
 #: po/custom/fromJson.txt:1348
 msgid "Twin Assault Cannon"
-msgstr "Zwillingssturmgeschütz"
+msgstr "Zwillingssturmkanone"
 
 #: po/custom/fromJson.txt:1349
 msgid "Twin Assault Cannon Bunker"
-msgstr "Bunker mit Zwillingssturmgeschütz"
+msgstr "Bunker mit Zwillingssturmkanone"
 
 #: po/custom/fromJson.txt:1350
 msgid "Twin Assault Gun"
@@ -9308,7 +9308,7 @@ msgstr "Verwenden Sie einen LKW, um eine Forschungseinrichtung um ein Modul zu e
 
 #: po/custom/fromJson.txt:1367
 msgid "Uses advanced cannon technology"
-msgstr "Verwendet fortschrittliche Geschütztechnologie"
+msgstr "Verwendet fortschrittliche Kanonentechnologie"
 
 #: po/custom/fromJson.txt:1368
 msgid "Uses advanced mass driver railgun technology"
@@ -9372,7 +9372,7 @@ msgstr "Vengeance Ketten Gauß Scourge-Lenkrakete"
 
 #: po/custom/fromJson.txt:1388
 msgid "Vengeance Tracks Rail Gun"
-msgstr "Vengeance Ketten Magnetgeschütz"
+msgstr "Vengeance Ketten Magnetkanone"
 
 #: po/custom/fromJson.txt:1389
 msgid "Vertical Take Off and Landing Propulsion"
@@ -9416,7 +9416,7 @@ msgstr "VTOL"
 
 #: po/custom/fromJson.txt:1399
 msgid "VTOL Assault Cannon"
-msgstr "VTOL-Sturmgeschütz"
+msgstr "VTOL-Sturmkanone"
 
 #: po/custom/fromJson.txt:1400
 msgid "VTOL Assault Gun"
@@ -9436,7 +9436,7 @@ msgstr "VTOL-Bunker Buster Scorpion VTOL"
 
 #: po/custom/fromJson.txt:1404
 msgid "VTOL Cannon"
-msgstr "VTOL-Geschütz"
+msgstr "VTOL-Kanone"
 
 #: po/custom/fromJson.txt:1406
 msgid "VTOL CB Radar Tower"
@@ -9505,19 +9505,19 @@ msgstr "Schweres VTOL-Maschinengewehr"
 
 #: po/custom/fromJson.txt:1423
 msgid "VTOL Hyper Velocity Cannon"
-msgstr "VTOL-Hochgeschwindigkeitsgeschütz"
+msgstr "VTOL-Hochgeschwindigkeitskanone"
 
 #: po/custom/fromJson.txt:1424
 msgid "VTOL Hyper Velocity Cannon Bug VTOL"
-msgstr "VTOL-Hochgeschwindigkeitsgeschütz Bug VTOL"
+msgstr "VTOL-Hochgeschwindigkeitskanone Bug VTOL"
 
 #: po/custom/fromJson.txt:1425
 msgid "VTOL Hyper Velocity Cannon Mantis VTOL"
-msgstr "VTOL-Hochgeschwindigkeitsgeschütz Mantis VTOL"
+msgstr "VTOL-Hochgeschwindigkeitskanone Mantis VTOL"
 
 #: po/custom/fromJson.txt:1426
 msgid "VTOL Hyper Velocity Cannon Scorpion VTOL"
-msgstr "VTOL-Hochgeschwindigkeitsgeschütz Scorpion VTOL"
+msgstr "VTOL-Hochgeschwindigkeitskanone Scorpion VTOL"
 
 #: po/custom/fromJson.txt:1427
 msgid "VTOL II"
@@ -9553,7 +9553,7 @@ msgstr "VTOL-Miniraketen"
 
 #: po/custom/fromJson.txt:1435
 msgid "VTOL Needle Gun"
-msgstr "VTOL-Nadelgeschütz"
+msgstr "VTOL-Nadelkanone"
 
 #: po/custom/fromJson.txt:1436
 msgid "VTOL Phosphor Bomb Bay"
@@ -9577,7 +9577,7 @@ msgstr "VTOL-Radarturm"
 
 #: po/custom/fromJson.txt:1442
 msgid "VTOL Rail Gun"
-msgstr "VTOL-Magnetgeschütz"
+msgstr "VTOL-Magnetkanone"
 
 # Diese Stationen reparieren und wiederbewaffnen VTOLs, von daher ist Servicestation sehr gut -Kreuvf
 #: po/custom/fromJson.txt:1443

--- a/po/de.po
+++ b/po/de.po
@@ -12739,10 +12739,13 @@ msgstr[1] "%u Einheiten ausgewählt"
 msgid "Can't build anymore units, Unit Limit Reached — Production Halted"
 msgstr "Kann keine weiteren Einheiten mehr bauen, Einheitenlimit erreicht — Produktion angehalten"
 
-#: src/structure.cpp:2504
 #, c-format
-msgid "Can't build anymore \"%s\", Command Control Limit Reached — Production Halted"
-msgstr "Kann keine weiteren \"%s\" mehr bauen, Commandereinheit hat Kontrollgrenze erreicht — Produktion angehalten"
+msgid "Can't build \"%s\" without a Command Relay Center — Production Halted"
+msgstr "Kann keinen \"%s\" ohne Kommandorelais bauen — Produktion angehalten"
+
+#, c-format
+msgid "Can't build \"%s\", Commander Limit Reached — Production Halted"
+msgstr "Kann keinen \"%s\" bauen, Commanderlimit erreicht — Produktion angehalten"
 
 #: src/structure.cpp:2512
 #, c-format

--- a/po/de.po
+++ b/po/de.po
@@ -16,7 +16,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: warzone2100-project@lists.sourceforge.net\n"
 "POT-Creation-Date: 2019-02-16 09:53+0000\n"
 "PO-Revision-Date: 2019-04-07 18:10+0200\n"
-"Last-Translator: Steven 'Kreuvf' Koenig <translations@kreuvf.de>\n"
+"Last-Translator: Forgon <forgon2100@protonmail.com>\n"
 "Language-Team: Deutsch <warzone2100-project@lists.sourceforge.net>\n"
 "Language: de\n"
 "MIME-Version: 1.0\n"
@@ -377,7 +377,7 @@ msgstr "SCAVENGER-BASIS ENTDECKT"
 
 #: data/base/messages/strings/cam1strings.txt:146
 msgid "Defeat the scavengers and retrieve any artifacts."
-msgstr "Vernichten Sie die Scavengers und bergen Sie alle Artefakte."
+msgstr "Vernichten Sie die Scavenger und bergen Sie alle Artefakte."
 
 #: data/base/messages/strings/cam1strings.txt:150
 msgid "Congratulations on defeating the New Paradigm, this sector is now secure."
@@ -1282,12 +1282,12 @@ msgstr "Tornado-Flak-Turm"
 #: data/base/messages/strings/names.txt:247
 #: data/mp/messages/strings/names.txt:288
 msgid "Proximity Bomb Turret"
-msgstr "Näherungsbombenabwurfschacht"
+msgstr "Näherungsbombe"
 
 #: data/base/messages/strings/names.txt:248
 #: data/mp/messages/strings/names.txt:289
 msgid "Proximity Superbomb Turret"
-msgstr "Näherungssuperbombenabwurfschacht"
+msgstr "Näherungssuperbombe"
 
 #: data/base/messages/strings/names.txt:287
 #: data/mp/messages/strings/names.txt:370
@@ -1555,7 +1555,7 @@ msgstr "Störturm Mk2"
 #: data/base/messages/strings/names.txt:389
 #: data/mp/messages/strings/names.txt:494
 msgid "Sensor Lock"
-msgstr "Sensorsperre"
+msgstr "Zielbestimmung für Sensoren"
 
 #: data/base/messages/strings/names.txt:417
 #: data/mp/messages/strings/names.txt:527
@@ -2772,14 +2772,13 @@ msgstr "Rückstoßbetriebener Munitionstrichter für Flugabwehrkanonen"
 msgid "Increases AA ROF"
 msgstr "Erhöht Feuerrate von Flugabwehrkanonen"
 
-# Gibt sicherlich einen deutschen Fachausdruck dafür, nur her damit -Kreuvf
 #: data/base/messages/strings/resstrings.txt:685
 #: data/base/messages/strings/resstrings.txt:691
 #: data/mp/messages/strings/resstrings.txt:326
 #: data/mp/messages/strings/resstrings.txt:331
 #: po/custom/fromJson.txt:964
 msgid "New Proximity Bomb Turret Available"
-msgstr "Neuer Näherungsbombenabwurfschacht verfügbar"
+msgstr "Neue Näherungsbombe verfügbar"
 
 #: data/base/messages/strings/resstrings.txt:686
 #: data/mp/messages/strings/resstrings.txt:327
@@ -3767,7 +3766,7 @@ msgstr "Es ist wahrscheinlich, dass er gegen Ihre Stellung gerichtet ist."
 
 #: data/base/sequenceaudio/cam2/c2diif2.txt:4
 msgid "You are to start the immediate evacuation of Beta Base to the safe haven."
-msgstr "Beginnen Sie sofort damit die Betabasis in die Sicherheitszone zu evakuieren."
+msgstr "Beginnen Sie sofort damit die Betabasis zum sicheren Hafen zu evakuieren."
 
 #: data/base/sequenceaudio/cam2/cam22fmv.txt:1
 msgid "NASDA is the North American Strategic Defense Agency."
@@ -4567,7 +4566,7 @@ msgstr "Pulslaser-Supercyborg"
 #: data/mp/messages/strings/names.txt:801
 #: po/custom/fromJson.txt:1272
 msgid "Super Rail-Gunner"
-msgstr "Supermagnetschütze"
+msgstr "Magnet-Superschütze"
 
 #: data/mp/messages/strings/names.txt:803
 #: po/custom/fromJson.txt:1273
@@ -8949,15 +8948,15 @@ msgstr "Flammenwerfergel für sehr hohe Temperaturen Mk3"
 
 #: po/custom/fromJson.txt:1265
 msgid "Superhot Plasmite gel"
-msgstr "Superheißes Plasmitflammenwerfergel"
+msgstr "Plasmitflammenwerfergel für sehr hohe Temperaturen"
 
 #: po/custom/fromJson.txt:1266
 msgid "Superhot Plasmite gel Mk2"
-msgstr "Superheißes Plasmitflammenwerfergel Mk2"
+msgstr "Plasmitflammenwerfergel für sehr hohe Temperaturen Mk2"
 
 #: po/custom/fromJson.txt:1267
 msgid "Superhot Plasmite gel Mk3"
-msgstr "Superheißes Plasmitflammenwerfergel Mk3"
+msgstr "Plasmitflammenwerfergel für sehr hohe Temperaturen Mk3"
 
 #: po/custom/fromJson.txt:1275
 #: src/design.cpp:1063
@@ -11925,7 +11924,7 @@ msgstr "Falsche Spielversion!"
 
 #: src/multiint.cpp:1204
 msgid "You have an incompatible mod."
-msgstr "Sie haben einen inkompatiblen Mod."
+msgstr "Sie haben eine inkompatible Mod."
 
 #: src/multiint.cpp:1208
 msgid "Host couldn't send file?"
@@ -12347,7 +12346,7 @@ msgstr "Dateiübertragung für %d abgebrochen."
 #: src/multijoin.cpp:455
 #, c-format
 msgid "%s (%u) has an incompatible mod, and has been kicked."
-msgstr "%s (%u) hat einen inkompatiblen Mod und wurde rausgeschmissen."
+msgstr "%s (%u) hat eine inkompatible Mod und wurde rausgeschmissen."
 
 #: src/multijoin.cpp:496
 #, c-format
@@ -12761,7 +12760,7 @@ msgstr[1] "%s - %u Einheiten zugewiesen - Trefferpunkte %d/%d"
 
 #: src/structure.cpp:5447
 #, c-format
-msgid "%s - %u Unit assigned - Damage %3.0f%%"
+msgid "%s - %u Unit assigned - Damage %d/%d"
 msgid_plural "%s - %u Units assigned - Hitpoints %d/%d"
 msgstr[0] "%s - %u Einheit zugewiesen - Trefferpunkte %d/%d"
 msgstr[1] "%s - %u Einheiten zugewiesen - Trefferpunkte %d/%d"

--- a/po/de.po
+++ b/po/de.po
@@ -8752,13 +8752,11 @@ msgstr "Selbstständig zielsuchende raketengetriebene Geschosse"
 msgid "Self-Replicating Manufacturing"
 msgstr "Selbstreplizierende Fertigung"
 
-#: po/custom/fromJson.txt:1211
-msgid "Semperfi"
+msgid "SemperFi"
 msgstr "SemperFi"
 
-#: po/custom/fromJson.txt:1212
-msgid "SemperFi JS"
-msgstr "SemperFi JS"
+msgid "SemperFi JavaScript"
+msgstr "SemperFi JavaScript"
 
 #: po/custom/fromJson.txt:1213
 msgid "Sensor Cobra Half-tracks"
@@ -12842,6 +12840,30 @@ msgstr " - DEBUG"
 #, c-format
 msgid "Version: %s,%s Built: %s%s"
 msgstr "Version: %s,%s Erstellt: %s%s"
+
+# NullBot tooltip
+msgid "Adaptive AI with multiple personalities"
+msgstr "Anpassungsfähige KI mit mehreren Persönlichkeiten"
+
+# Hover AI tooltip
+msgid "Sea map AI, based on NullBot"
+msgstr "KI für Seekarten, basierend auf NullBot"
+
+# Turtle AI tooltip
+msgid "Tower wars AI, based on NullBot"
+msgstr "KI für Befestigungen, basierend auf NullBot"
+
+# Nexus tooltip
+msgid "Initial AI, now supplanted by NullBot"
+msgstr "Ursprüngliche KI, von NullBot verdrängt"
+
+# SemperFi JavaScript tooltip
+msgid "Prototypical JavaScript AI focusing on rockets/missiles"
+msgstr "Prototyp für JavaScript-KI mit Schwerpunkt (Lenk-)Raketen"
+
+# SemperFi tooltip
+msgid "Enhanced Nexus AI"
+msgstr "Verbesserte Nexus-KI"
 
 #~ msgid "Electronic Countermeasures"
 #~ msgstr "Elektronische Gegenmaßnahmen"


### PR DESCRIPTION
The first patch fixes mistakes noticed when reviewing #326 and this PR.

* consistently translate:
  * "save haven" as "sicherer Hafen"
  * "mod" as noun with feminine gender
  * "scavengers" as "Scavenger"
  * "superhot gel" as "Gel für sehr hohe Temperaturen"
  * "super XYZ cyborg" as "XYZ-Supercyborg"

* fix format specifier to comply with ticket:4872

* fix translations of unused technologies:
  * a "proximity bomb" is a suicidal bomb (only used in demos from 1999)
  * "sensor lock" enables targeting for sensors (unimplemented)

In consultation with Kreuvf, highlander1599 created [#1](https://github.com/Forgon2100/warzone2100/pull/1) in my repository,
which resulted in two additional commits to

* fix the capitalization of turret names
* call rail guns, cannons and the EMP Cannon "Kanone", a more specific
  term than "Geschütz", which it replaces. This completes #326, in which
  the same change was applied to flak weapons.

The fourth patch adds German translations for changes of #281.

The fifth patch adds German translations for changes of #329.

The sixth patch fixes the German translation of "AUDIO / ZOOM OPTIONS",
which was too long for the minimum screen resolution of 640x480 pixels.
PR #345 adds support for an optional delimiter "\n" to split the message
into two lines. It also also contains screenshots showing the change.