### PR TITLE
Change console messages for production limits

### DIFF
--- a/src/structure.cpp
+++ b/src/structure.cpp
@@ -2525,7 +2525,7 @@ static bool checkHaltOnMaxUnitsReached(STRUCTURE *psStructure, bool isMission)
 			break;
 		}
 
-	if (isLimit && player == selectedPlayer && lastMaxUnitMessage + MAX_UNIT_MESSAGE_PAUSE < gameTime)
+	if (isLimit && player == selectedPlayer && (lastMaxUnitMessage == 0 || lastMaxUnitMessage + MAX_UNIT_MESSAGE_PAUSE <= gameTime))
 	{
 		addConsoleMessage(limitMsg, DEFAULT_JUSTIFY, SYSTEM_MESSAGE);
 		lastMaxUnitMessage = gameTime;

--- a/src/structure.cpp
+++ b/src/structure.cpp
@@ -2502,10 +2502,15 @@ static bool checkHaltOnMaxUnitsReached(STRUCTURE *psStructure, bool isMission)
 	else switch (droidTemplateType(templ))
 		{
 		case DROID_COMMAND:
-			if (!hasBuiltCommandRelay(isMission, player) || getNumCommandDroids(player) >= getMaxCommanders(player))
+			if (!hasBuiltCommandRelay(isMission, player))
 			{
 				isLimit = true;
-				ssprintf(limitMsg, _("Can't build anymore \"%s\", Command Control Limit Reached — Production Halted"), templ->name.toUtf8().c_str());
+				ssprintf(limitMsg, _("Can't build \"%s\" without a Command Relay Center — Production Halted"), templ->name.toUtf8().c_str());
+			}
+			else if (getNumCommandDroids(player) >= getMaxCommanders(player))
+			{
+				isLimit = true;
+				ssprintf(limitMsg, _("Can't build \"%s\", Commander Limit Reached — Production Halted"), templ->name.toUtf8().c_str());
 			}
 			break;
 		case DROID_CONSTRUCT:


### PR DESCRIPTION
* add console message informing about missing Command Relay Center
  if this prevents commander production (suggested in #327 by spikebike)
* remove delay of 40 seconds before showing first console message
  about exceeded manufacturing limits (ending in "Production Halted")