### PR TITLE
Change configuration directory of debug builds

### DIFF
--- a/src/version.cpp
+++ b/src/version.cpp
@@ -53,13 +53,12 @@ std::string version_getVersionedAppDirFolderName()
 	}
 	else if (strlen(vcs_branch_cstr))
 	{
-#if defined(DEBUG) || defined(WZ_USE_MASTER_BRANCH_APP_DIR)
-		// To ease testing new branches with existing files, DEBUG builds
-		// (or when WZ_USE_MASTER_BRANCH_APP_DIR is defined)
-		// default to using "master" as the branch
+#if defined(WZ_USE_MASTER_BRANCH_APP_DIR)
+		// To ease testing new branches with existing files
+		// default to using "master" as the branch name
+		// if WZ_USE_MASTER_BRANCH_APP_DIR is defined
 		versionedWriteDirFolderName += "master";
 #else
-		// For Release builds, use the actual branch name
 		versionedWriteDirFolderName += vcs_branch_cstr;
 #endif
 	}


### PR DESCRIPTION
When testing new branches with debug builds, the configuration directory
ends in "master", irrespective of the branch it belongs to (unless the
build is checked out at a specific tag).

This behavior is obscure, not least because the version string is not
changed in a similar manner. In addition, this can lead to bugs if files
in the configuration directory have been changed by another branch, e.g.
keymap.json.

It may be a remnant of changing the configuration directory's location
(view 6198e8f308e7ced9221e480defc460e286edc92d for details).

I suggest to create a new configuration directory for each new branch.