### PR TITLE
Stop shooting through walls

### DIFF
--- a/src/ai.cpp
+++ b/src/ai.cpp
@@ -690,16 +690,18 @@ int aiBestNearestTarget(DROID *psDroid, BASE_OBJECT **ppsObj, int weapon_slot, i
 	if (bestTarget)
 	{
 		ASSERT(!bestTarget->died, "AI gave us a target that is already dead.");
-		targetStructure = visGetBlockingWall((BASE_OBJECT *)psDroid, bestTarget);
+		targetStructure = visGetBlockingWall(psDroid, bestTarget);
 
-		/* See if target is blocked by a wall; only affects direct weapons */
+		// See if target is blocked by a wall; only affects direct weapons
+		// Ignore friendly walls here
 		if (proj_Direct(asWeaponStats + psDroid->asWeaps[weapon_slot].nStat)
-		    && targetStructure)
+			&& targetStructure
+			&& !aiCheckAlliances(psDroid->player, targetStructure->player))
 		{
 			//are we any good against walls?
-			if (asStructStrengthModifier[weaponEffect][targetStructure->pStructureType->strength] >= 100)		//can attack atleast with default strength
+			if (asStructStrengthModifier[weaponEffect][targetStructure->pStructureType->strength] >= 100) //can attack atleast with default strength
 			{
-				bestTarget = (BASE_OBJECT *)targetStructure;			//attack wall
+				bestTarget = (BASE_OBJECT *)targetStructure; //attack wall
 			}
 		}
 

--- a/src/order.cpp
+++ b/src/order.cpp
@@ -749,7 +749,7 @@ void orderUpdateDroid(DROID *psDroid)
 		         && psDroid->order.psObj == psDroid->psActionTarget[0]
 		         && actionInRange(psDroid, psDroid->order.psObj, 0)
 		         && (psWall = visGetBlockingWall(psDroid, psDroid->order.psObj))
-		         && psWall->player != psDroid->player)
+		         && !aiCheckAlliances(psWall->player, psDroid->player))
 		{
 			// there is a wall in the way - attack that
 			actionDroid(psDroid, DACTION_ATTACK, psWall);


### PR DESCRIPTION
Brought back the deleted wall LOS blocking code which Just Works(tm) with a few tweaks to get
it to compile.

As I expected, too much has changed since this was removed and the restoration itself resulted in units
firing at targets through walls when moving, or, firing at friendly walls to get to targets. Not sure if I did it right but I was able to stop all that and get units to path to targets unobstructed (if direct projectile weapon). It is rather ugly but I couldn't see any other way about it.