### PR TITLE
[WIP] Fix printing of key names

### DIFF
--- a/lib/framework/input.h
+++ b/lib/framework/input.h
@@ -32,6 +32,7 @@
 
 #include "types.h"
 #include "lib/framework/utf.h"
+#include "lib/framework/wzstring.h"
 #include "vector.h"
 #include <vector>
 
@@ -178,8 +179,8 @@ typedef std::vector<MousePress> MousePresses;
 /** Tell the input system that we have lost the focus. */
 void inputLoseFocus();
 void StopTextInput();
-/** Converts the key code into an ascii string. */
-WZ_DECL_NONNULL(2) void keyScanToString(KEY_CODE code, char *ascii, UDWORD maxStringSize);
+/** Converts the key code into an human-readable string. */
+WzString getKeyName(KEY_CODE keyCode);
 
 /** Initialise the input module. */
 void inputInitialise();

--- a/lib/sdl/main_sdl.cpp
+++ b/lib/sdl/main_sdl.cpp
@@ -646,51 +646,45 @@ static void inputAddBuffer(UDWORD key, utf_32_char unicode)
 	pEndBuffer = pNext;
 }
 
-void keyScanToString(KEY_CODE code, char *ascii, UDWORD maxStringSize)
+// wrapper function for SDL_GetKeyName()
+WzString getKeyName(KEY_CODE keyCode)
 {
-	if (code == KEY_LCTRL)
+	WzString keyName;
+	// shortcuts with modifier keys work with either key.
+	if (keyCode == KEY_LCTRL)
 	{
-		// shortcuts with modifier keys work with either key.
-		strcpy(ascii, "Ctrl");
-		return;
+		keyName = "Ctrl";
 	}
-	else if (code == KEY_LSHIFT)
+	else if (keyCode == KEY_LSHIFT)
 	{
-		// shortcuts with modifier keys work with either key.
-		strcpy(ascii, "Shift");
-		return;
+		keyName = "Shift";
 	}
-	else if (code == KEY_LALT)
+	else if (keyCode == KEY_LALT)
 	{
-		// shortcuts with modifier keys work with either key.
-		strcpy(ascii, "Alt");
-		return;
+		keyName = "Alt";
 	}
-	else if (code == KEY_LMETA)
+	else if (keyCode == KEY_LMETA)
 	{
-		// shortcuts with modifier keys work with either key.
 #ifdef WZ_OS_MAC
-		strcpy(ascii, "Cmd");
+		keyName = "Cmd";
 #else
-		strcpy(ascii, "Meta");
+		keyName = "Meta";
 #endif
-		return;
 	}
-
-	if (code < KEY_MAXSCAN)
+	else if (keyCode < KEY_MAXSCAN)
 	{
-		snprintf(ascii, maxStringSize, "%s", SDL_GetKeyName(keyCodeToSDLKey(code)));
-		if (ascii[0] >= 'a' && ascii[0] <= 'z' && ascii[1] != 0)
+		keyName = SDL_GetKeyName(keyCodeToSDLKey(keyCode));
+		if (keyCode >= KEY_KP_0 && keyCode <= KEY_KPENTER)
 		{
-			// capitalize
-			ascii[0] += 'A' - 'a';
-			return;
+		    keyName.remove("Keypad ");
+		    keyName.append(" (numpad)");
 		}
 	}
 	else
 	{
-		strcpy(ascii, "???");
+		keyName = "???";
 	}
+	return keyName;
 }
 
 /* Initialise the input module */
@@ -767,13 +761,13 @@ void inputNewFrame(void)
 		if (aKeyState[i].state == KEY_PRESSED)
 		{
 			aKeyState[i].state = KEY_DOWN;
-			debug(LOG_NEVER, "This key is DOWN! %x, %d [%s]", i, i, SDL_GetKeyName(keyCodeToSDLKey((KEY_CODE)i)));
+			debug(LOG_NEVER, "This key is DOWN! %x, %d [%s]", i, i, getKeyName((KEY_CODE)i).toStdString().c_str());
 		}
 		else if (aKeyState[i].state == KEY_RELEASED  ||
 		         aKeyState[i].state == KEY_PRESSRELEASE)
 		{
 			aKeyState[i].state = KEY_UP;
-			debug(LOG_NEVER, "This key is UP! %x, %d [%s]", i, i, SDL_GetKeyName(keyCodeToSDLKey((KEY_CODE)i)));
+			debug(LOG_NEVER, "This key is UP! %x, %d [%s]", i, i, getKeyName((KEY_CODE)i).toStdString().c_str());
 		}
 	}
 
@@ -968,7 +962,7 @@ static void inputHandleKeyEvent(SDL_KeyboardEvent *keyEvent)
 		{
 			// Take care of 'editing' keys that were pressed
 			inputAddBuffer(vk, 0);
-			debug(LOG_INPUT, "Editing key: 0x%x, %d SDLkey=[%s] pressed", vk, vk, SDL_GetKeyName(CurrentKey));
+			debug(LOG_INPUT, "Editing key: 0x%x, %d SDLkey=[%s] pressed", vk, vk, getKeyName((KEY_CODE)CurrentKey).toStdString().c_str());
 		}
 		else
 		{
@@ -976,7 +970,7 @@ static void inputHandleKeyEvent(SDL_KeyboardEvent *keyEvent)
 			inputAddBuffer(CurrentKey, 0);
 		}
 
-		debug(LOG_INPUT, "Key Code (pressed): 0x%x, %d, [%c] SDLkey=[%s]", CurrentKey, CurrentKey, (CurrentKey < 128) && (CurrentKey > 31) ? (char)CurrentKey : '?', SDL_GetKeyName(CurrentKey));
+		debug(LOG_INPUT, "Key Code (pressed): 0x%x, %d, [%c] SDLkey=[%s]", CurrentKey, CurrentKey, (CurrentKey < 128) && (CurrentKey > 31) ? (char)CurrentKey : '?', getKeyName((KEY_CODE)CurrentKey).toStdString().c_str());
 
 		code = sdlKeyToKeyCode(CurrentKey);
 		if (code >= KEY_MAXSCAN)
@@ -995,7 +989,7 @@ static void inputHandleKeyEvent(SDL_KeyboardEvent *keyEvent)
 
 	case SDL_KEYUP:
 		code = keyEvent->keysym.sym;
-		debug(LOG_INPUT, "Key Code (*Depressed*): 0x%x, %d, [%c] SDLkey=[%s]", code, code, (code < 128) && (code > 31) ? (char)code : '?', SDL_GetKeyName(code));
+		debug(LOG_INPUT, "Key Code (*Depressed*): 0x%x, %d, [%c] SDLkey=[%s]", code, code, (code < 128) && (code > 31) ? (char)code : '?', getKeyName((KEY_CODE)CurrentKey).toStdString().c_str());
 		code = sdlKeyToKeyCode(keyEvent->keysym.sym);
 		if (code >= KEY_MAXSCAN)
 		{

--- a/src/keyedit.cpp
+++ b/src/keyedit.cpp
@@ -29,6 +29,7 @@
 #include <physfs.h>
 
 #include "lib/framework/frame.h"
+#include "lib/framework/input.h"
 #include "lib/ivis_opengl/bitimage.h"
 #include "lib/ivis_opengl/pieblitfunc.h"
 #include "lib/sound/audio.h"
@@ -236,27 +237,26 @@ bool runKeyMapEditor()
 
 // ////////////////////////////////////////////////////////////////////////////
 // returns key to press given a mapping.
-static bool keyMapToString(char *pStr, KEY_MAPPING *psMapping)
+WzString keyMapToString(KEY_MAPPING *psMapping)
 {
 	bool	onlySub = true;
-	char	asciiSub[20], asciiMeta[20];
+	WzString metaKey, subKey;
 
 	if (psMapping->metaKeyCode != KEY_IGNORE)
 	{
-		keyScanToString(psMapping->metaKeyCode, (char *)&asciiMeta, 20);
+		metaKey = getKeyName(psMapping->metaKeyCode);
 		onlySub = false;
 	}
-	keyScanToString(psMapping->subKeyCode, (char *)&asciiSub, 20);
+	subKey = getKeyName(psMapping->subKeyCode);
 
 	if (onlySub)
 	{
-		sprintf(pStr, "%s", asciiSub);
+		return subKey;
 	}
 	else
 	{
-		sprintf(pStr, "%s %s", asciiMeta, asciiSub);
+		return metaKey.append(" " + subKey);
 	}
-	return true;
 }
 
 // ////////////////////////////////////////////////////////////////////////////
@@ -272,7 +272,6 @@ static void displayKeyMap(WIDGET *psWidget, UDWORD xOffset, UDWORD yOffset)
 	int w = psWidget->width();
 	int h = psWidget->height();
 	KEY_MAPPING *psMapping = data.psMapping;
-	char sKey[MAX_STR_LENGTH];
 
 	if (psMapping == selectedKeyMap)
 	{
@@ -292,16 +291,13 @@ static void displayKeyMap(WIDGET *psWidget, UDWORD xOffset, UDWORD yOffset)
 	data.cache.wzNameText.setText(_(psMapping->name.c_str()), font_regular);
 	data.cache.wzNameText.render(x + 2, y + (psWidget->height() / 2) + 3, WZCOL_FORM_TEXT);
 
-	// draw binding
-	keyMapToString(sKey, psMapping);
 	// Check to see if key is on the numpad, if so tell user and change color
 	PIELIGHT bindingTextColor = WZCOL_FORM_TEXT;
 	if (psMapping->subKeyCode >= KEY_KP_0 && psMapping->subKeyCode <= KEY_KPENTER)
 	{
 		bindingTextColor = WZCOL_YELLOW;
-		sstrcat(sKey, " (numpad)");
 	}
-	data.cache.wzBindingText.setText(sKey, font_regular);
+	data.cache.wzBindingText.setText(keyMapToString(psMapping).toStdString().c_str(), font_regular);
 	data.cache.wzBindingText.render(x + 364, y + (psWidget->height() / 2) + 3, bindingTextColor);
 }
 

--- a/src/keyedit.h
+++ b/src/keyedit.h
@@ -21,9 +21,13 @@
 #ifndef __INCLUDED_SRC_KEYEDIT_H__
 #define __INCLUDED_SRC_KEYEDIT_H__
 
+#include "keymap.h"
+#include "lib/framework/wzstring.h"
+
 bool runKeyMapEditor();
 bool startKeyMapEditor(bool first);
 bool saveKeyMap();
 bool loadKeyMap();
+WzString keyMapToString(KEY_MAPPING *psMapping);
 
 #endif // __INCLUDED_SRC_KEYEDIT_H__

--- a/src/keymap.cpp
+++ b/src/keymap.cpp
@@ -38,7 +38,6 @@
 #include "console.h"
 #include "keybind.h"
 #include "display3d.h"
-#include "keymap.h"
 #include "keyedit.h"
 
 #include <algorithm>
@@ -746,25 +745,7 @@ void	keyProcessMappings(bool bExclude)
 /* Sends a particular key mapping to the console */
 static void keyShowMapping(KEY_MAPPING *psMapping)
 {
-	char	asciiSub[20], asciiMeta[20];
-	bool	onlySub;
-
-	onlySub = true;
-	if (psMapping->metaKeyCode != KEY_IGNORE)
-	{
-		keyScanToString(psMapping->metaKeyCode, (char *)&asciiMeta, 20);
-		onlySub = false;
-	}
-
-	keyScanToString(psMapping->subKeyCode, (char *)&asciiSub, 20);
-	if (onlySub)
-	{
-		CONPRINTF("%s - %s", asciiSub, _(psMapping->name.c_str()));
-	}
-	else
-	{
-		CONPRINTF("%s and %s - %s", asciiMeta, asciiSub, _(psMapping->name.c_str()));
-	}
+	CONPRINTF("%s - %s", keyMapToString(psMapping).toStdString().c_str(), _(psMapping->name.c_str()));
 	debug(LOG_INPUT, "Received %s from Console", ConsoleString);
 }
 


### PR DESCRIPTION
Keynames are [determined by SDL](https://wiki.libsdl.org/SDL_Keycode),
except for the suffix " (numpad)" and some modifier keys.

* fix the broken layout of the "Options->Key Mappings" screen by
  renaming keypad keys so that they appear as in version 3.1.5 with the
  exception of not putting square brackets around numbers. I am not sure
  whether we should distinguish between numbers in the numbers row and
  on a numpad at all, because some keyboards and keyboard layouts rely
  on integrated numpads.
* name keys consistently throughout the game

The attached ZIP file contains
* two screenshots (old and new layout)
* a shell script to generate them

[key_mappings_documentation.zip](https://github.com/Warzone2100/warzone2100/files/3125127/key_mappings_documentation.zip)
