### PR TITLE
Change date and time representation to ISO 8601

### DIFF
--- a/lib/exceptionhandler/dumpinfo.cpp
+++ b/lib/exceptionhandler/dumpinfo.cpp
@@ -31,6 +31,7 @@
 #include "lib/framework/stdio_ext.h"
 #include "lib/framework/wzglobal.h" // required for config.h
 #include "lib/framework/wzapp.h"
+#include "lib/framework/i18n.h" // required to print build date in ISO 8601
 
 #if defined(WZ_OS_UNIX)
 # include <sys/utsname.h>
@@ -486,10 +487,9 @@ static void createHeader(int const argc, const char * const *argv, const char *p
 	}
 
 	os << endl;
-
 	os << "Version: "     << packageVersion << endl
 	   << "Distributor: " PACKAGE_DISTRIBUTOR << endl
-	   << "Compiled on: " __DATE__ " " __TIME__ << endl
+	   << "Compiled on: " << getCompileDate() << " " << __TIME__ << endl
 	   << "Compiled by: "
 #if defined(WZ_CC_GNU) && !defined(WZ_CC_INTEL) && !defined(WZ_CC_CLANG)
 	   << "GCC " __VERSION__ << endl

--- a/lib/framework/debug.cpp
+++ b/lib/framework/debug.cpp
@@ -504,7 +504,7 @@ void _debug(int line, code_part part, const char *function, const char *str, ...
 
 		time(&rawtime);
 		timeinfo = localtime(&rawtime);
-		strftime(ourtime, 15, "%I:%M:%S", timeinfo);
+		strftime(ourtime, 15, "%H:%M:%S", timeinfo);
 
 		// Assemble the outputBuffer:
 		ssprintf(outputBuffer, "%-8s|%s: %s", code_part_names[part], ourtime, useInputBuffer1 ? inputBuffer[1] : inputBuffer[0]);

--- a/lib/framework/i18n.cpp
+++ b/lib/framework/i18n.cpp
@@ -18,6 +18,8 @@
 */
 #include "frame.h"
 
+#include <sstream>
+
 #include <locale.h>
 #include <physfs.h>
 #include "wzpaths.h"
@@ -209,6 +211,7 @@ static const struct
 
 static unsigned int selectedLanguage = 0;
 
+static char *compileDate = nullptr;
 
 /*!
  * Return the language part of the selected locale
@@ -469,4 +472,32 @@ void initI18n()
 
 	(void)bind_textdomain_codeset(PACKAGE, "UTF-8");
 	(void)textdomain(PACKAGE);
+}
+
+// convert macro __DATE__ to ISO 8601 format
+const char *getCompileDate()
+{
+	if (compileDate == nullptr)
+	{
+		std::istringstream date(__DATE__);
+		std::string monthName;
+		int day = 0, month = 0, year = 0;
+		date >> monthName >> day >> year;
+
+		std::string monthNames[] = {
+						"Jan", "Feb", "Mar", "Apr",
+						"May", "Jun", "Jul", "Aug",
+						"Sep", "Oct", "Nov", "Dec"
+		                           };
+		for (int i = 0; i < 12; i++)
+		{
+			if (monthNames[i] == monthName)
+			{
+				month = i + 1;
+				break;
+			}
+		}
+		asprintfNull(&compileDate, "%04d-%02d-%02d", year, month, day);
+	}
+	return compileDate;
 }

--- a/lib/framework/i18n.h
+++ b/lib/framework/i18n.h
@@ -58,4 +58,6 @@ WZ_DECL_NONNULL(1) bool setLanguage(const char *name);
 void setNextLanguage(bool prev = false);
 void initI18n();
 
+const char *getCompileDate();
+
 #endif // _i18n_h

--- a/src/keybind.cpp
+++ b/src/keybind.cpp
@@ -476,7 +476,7 @@ void kf_Unselectable()
 ///* Prints out the date and time of the build of the game */
 void	kf_BuildInfo()
 {
-	CONPRINTF("Built at %s on %s", __TIME__, __DATE__);
+	CONPRINTF("Built: %s %s", getCompileDate(), __TIME__);
 }
 
 // --------------------------------------------------------------------------
@@ -651,7 +651,7 @@ void	kf_FrameRate()
 		                          NETgetStatistic(NetStatisticPackets, false));
 	}
 	gameStats = !gameStats;
-	CONPRINTF("Built at %s on %s", __TIME__, __DATE__);
+	CONPRINTF("Built: %s %s", getCompileDate(), __TIME__);
 }
 
 // --------------------------------------------------------------------------

--- a/src/loadsave.cpp
+++ b/src/loadsave.cpp
@@ -310,7 +310,7 @@ bool addLoadSave(LOADSAVE_MODE savemode, const char *title)
 		snprintf(savefile, sizeof(savefile), "%s/%s", NewSaveGamePath, *i);
 		savetime = WZ_PHYSFS_getLastModTime(savefile);
 		timeinfo = localtime(&savetime);
-		strftime(sSlotTips[slotCount], sizeof(sSlotTips[slotCount]), "%x %X", timeinfo);
+		strftime(sSlotTips[slotCount], sizeof(sSlotTips[slotCount]), "%F %H:%M:%S", timeinfo);
 
 		/* Set the button-text */
 		(*i)[strlen(*i) - 4] = '\0'; // remove .gam extension

--- a/src/version.cpp
+++ b/src/version.cpp
@@ -124,11 +124,11 @@ const char *version_getFormattedVersionString()
 #else
 		const char *build_type = "";
 #endif
-
 		// Construct the version string
 		// TRANSLATORS: This string looks as follows when expanded.
-		// "Version <version name/number> <working copy state><BUILD DATE><BUILD TYPE>"
-		snprintf(versionString, MAX_STR_LENGTH, _("Version: %s,%s Built: %s%s"), version_getVersionString(), wc_state, __DATE__, build_type);
+		// "Version: <version name/number>, <working copy state>,
+		// Built: <BUILD DATE><BUILD TYPE>"
+		snprintf(versionString, MAX_STR_LENGTH, _("Version: %s,%s Built: %s%s"), version_getVersionString(), wc_state, getCompileDate(), build_type);
 	}
 
 	return versionString;


### PR DESCRIPTION
The notation used to represent date and time [varies around the world](https://en.wikipedia.org/wiki/Date_and_time_representation_by_country),
but is standardized by [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601):
* dates are written in the format "YYYY-MM-DD", e.g. "2018-12-24"
* times are written in the format "HH:MM:SS", e.g. "23:59:59"

Consistently using this format avoids the programming effort required
to support all the different conventions used by the languages we offer.

The build date is generated with the macro [\_\_DATE\_\_](http://eel.is/c++draft/cpp.predefined#:__DATE__),
which follows the American convention to print the month name ahead of
the day of the month. Via getCompileDate() it is converted to ISO 8601.
This change is observable
* on the right margin of main menu screens
* when starting the game with the commandline option '--version'
* when using the cheats "build info" and "timedemo".
  They show the date ahead of the time, no longer reversing their order.

Savegame screens show file modification time on button tooltips.
Their strftime() format is "%F %T", locale-independent unlike "%x %X".

Debug output uses the 24-hour clock instead of the 12-hour-clock:

```
main    |18:53:28: [realmain:1219] initializing
```

The attached ZIP file contains
* screenshots showing savegame buttons tooltips (old and new)
* a savegame and a shell script used to generate them

[iso_8601_documentation.zip](https://github.com/Warzone2100/warzone2100/files/3127251/iso_8601_documentation.zip)