### PR TITLE
Fix version string being printed in wrong language

### DIFF
--- a/src/version.cpp
+++ b/src/version.cpp
@@ -110,26 +110,26 @@ const char *version_getFormattedVersionString()
 {
 	static char versionString[MAX_STR_LENGTH] = {'\0'};
 
-	if (versionString[0] == '\0')
-	{
-		// Compose the working copy state string
+	// Compose the working copy state string
 #if (VCS_WC_MODIFIED)
-		const char *wc_state = _(" (modified locally)");
+	// TRANSLATORS: Printed when compiling with uncommitted changes
+	const char *wc_state = _(" (modified locally)");
 #else
-		const char *wc_state = "";
+	const char *wc_state = "";
 #endif
-		// Compose the build type string
+	// Compose the build type string
 #ifdef DEBUG
-		const char *build_type = _(" - DEBUG");
+	// TRANSLATORS: Printed in Debug builds
+	const char *build_type = _(" - DEBUG");
 #else
-		const char *build_type = "";
+	const char *build_type = "";
 #endif
-		// Construct the version string
-		// TRANSLATORS: This string looks as follows when expanded.
-		// "Version: <version name/number>, <working copy state>,
-		// Built: <BUILD DATE><BUILD TYPE>"
-		snprintf(versionString, MAX_STR_LENGTH, _("Version: %s,%s Built: %s%s"), version_getVersionString(), wc_state, getCompileDate(), build_type);
-	}
+
+	// Construct the version string
+	// TRANSLATORS: This string looks as follows when expanded.
+	// "Version: <version name/number>, <working copy state>,
+	// Built: <BUILD DATE><BUILD TYPE>"
+	snprintf(versionString, MAX_STR_LENGTH, _("Version: %s,%s Built: %s%s"), version_getVersionString(), wc_state, getCompileDate(), build_type);
 
 	return versionString;
 }


### PR DESCRIPTION
Updating the version string each time before it gets printed prevents
it from being printed in the wrong language if the game language
* differs from the system locale
* is changed via the "Options" -> "Game Options" screen

The attached ZIP file contains
* screenshots of the version string with a foreign language enabled
* a shell script to generate them