### PR TITLE
Support second line for "AUDIO / ZOOM OPTIONS" message

### DIFF
--- a/data/base/messages/strings/cam1strings.txt
+++ b/data/base/messages/strings/cam1strings.txt
@@ -59,7 +59,7 @@ CAM1D_MSG3			_("This is our chance to defeat the New Paradigm and destroy their 
 
 
 /* New Paradigm - incoming transmission */
-NP_MSG2				_(" ")
+NP_MSG2				" "
 
 /* Cam 1B Player Ident Congrats */
 P1B_MSG1			_("ALPHA BASE MISSION: Power Surge Detected") 
@@ -69,7 +69,7 @@ P1B_MSG3			_("We now have a further task for you.")
 /* Cam 1.1 Player Ident Congrats */
 P1-1_MSG1			_("ALPHA BASE MISSION: Locate and Recover Artifacts")
 P1-1_MSG2			_("The first two zones are now secure.")
-P1-1_MSG3			_(" ")
+P1-1_MSG3			" "
 
 /* Project Team updates */
 P1-3A_MSG1			_("PROJECT TEAM UPDATES")
@@ -87,7 +87,7 @@ GAMMA_MSG3			_("We've discovered no artifacts and encountered no hostiles.")
 /* Map1c mission brief - intelligence report */
 CAM1C_MSG4			_("ALPHA BASE INTELLIGENCE REPORT: Enemy Attack")
 CAM1C_MSG5			_("We are detecting an enemy attack force at this location.")
-CAM1C_MSG6			_(" ")
+CAM1C_MSG6			" "
 
 /* Map1c project update - enemy attack */
 CAM1C_MSG7			_("PRIMARY OBJECTIVE")
@@ -113,7 +113,7 @@ SUP_MSG3			_("Establish a forward base then continue the search for the synaptic
 /* Submap1_4 Player ident */
 SUB1_4A_MSG4			_("INCOMING TRANSMISSION")
 SUB1_4A_MSG5			_("Decoding in progress.....")
-SUB1_4A_MSG6			_(" ")
+SUB1_4A_MSG6			" "
 
 /* Submap 1_4b - Destroy Enemy Base */
 SUB1_4B_MSG2			_("Commander.")
@@ -151,7 +151,7 @@ CAM1OUT_MSG1			_("Congratulations on defeating the New Paradigm, this sector is 
 CAM1OUT_MSG2			_("The Nexus Intruder Program was in the New Paradigm system.")
 CAM1OUT_MSG3			_("We recorded two conversations with it, extracts follow...")
 
-CAM1OUT_MSG4			_(" ")
+CAM1OUT_MSG4			" "
 CAM1OUT_MSG5			_("We'll keep you informed of further developments")
 
 CAM1OUT_MSG6			_("Commander you are to assist Team Beta")

--- a/data/base/messages/strings/cam2strings.txt
+++ b/data/base/messages/strings/cam2strings.txt
@@ -105,7 +105,7 @@ CAM2_5_MSG6			_("Do not allow the Collective to bring the reactor on-line.")
 /* Cam2DI Capture NASDA central - briefing */
 CAM2_DI_MSG3			_("BETA BASE MISSION: Capture NASDA Central")
 CAM2_DI_MSG4			_("Capture NASDA central before NEXUS and the Collective can use it.")
-CAM2_DI_MSG5			_(" ")
+CAM2_DI_MSG5			" "
 
 /* Cam2_6 part2 Satellite Uplink - player ident*/
 CAM2_6_MSG			_("TRANSPORT MISSION: Satellite Uplink Site")

--- a/data/base/messages/strings/cam3strings.txt
+++ b/data/base/messages/strings/cam3strings.txt
@@ -153,7 +153,7 @@ CAM3A_D2_MSG6		_("Assign this task to a research facility.")
 CAM3A_D2_MSG7		_("NEXUS forces detected at these locations.")
 
 /* Cam3A-D2 NEXUS Counter-attacks - player ident part 3 restored */
-CAM3A_D2_MSG8		_(" ")
+CAM3A_D2_MSG8		" "
 CAM3A_D2_MSG9		_("NEXUS has been eradicated from all Project systems.")
 CAM3A_D2_MSG10		_("We are attempting to access the missile control codes.")
 

--- a/po/ca_ES.po
+++ b/po/ca_ES.po
@@ -191,16 +191,6 @@ msgstr "Estem detectant forces enemigues en aquestes localitzacions."
 msgid "This is our chance to defeat the New Paradigm and destroy their base."
 msgstr "És la nostra oportunitat d'eliminar el Nou Paradigma i destruir la seva base."
 
-#: data/base/messages/strings/cam1strings.txt:62
-#: data/base/messages/strings/cam1strings.txt:72
-#: data/base/messages/strings/cam1strings.txt:90
-#: data/base/messages/strings/cam1strings.txt:116
-#: data/base/messages/strings/cam1strings.txt:154
-#: data/base/messages/strings/cam2strings.txt:108
-#: data/base/messages/strings/cam3strings.txt:156
-msgid " "
-msgstr " "
-
 #: data/base/messages/strings/cam1strings.txt:66
 msgid "Congratulations Commander."
 msgstr "Us felicitem Comandant"

--- a/po/cs.po
+++ b/po/cs.po
@@ -193,16 +193,6 @@ msgstr ""
 msgid "This is our chance to defeat the New Paradigm and destroy their base."
 msgstr ""
 
-#: data/base/messages/strings/cam1strings.txt:62
-#: data/base/messages/strings/cam1strings.txt:72
-#: data/base/messages/strings/cam1strings.txt:90
-#: data/base/messages/strings/cam1strings.txt:116
-#: data/base/messages/strings/cam1strings.txt:154
-#: data/base/messages/strings/cam2strings.txt:108
-#: data/base/messages/strings/cam3strings.txt:156
-msgid " "
-msgstr " "
-
 #: data/base/messages/strings/cam1strings.txt:66
 msgid "Congratulations Commander."
 msgstr ""

--- a/po/da.po
+++ b/po/da.po
@@ -194,16 +194,6 @@ msgstr ""
 msgid "This is our chance to defeat the New Paradigm and destroy their base."
 msgstr ""
 
-#: data/base/messages/strings/cam1strings.txt:62
-#: data/base/messages/strings/cam1strings.txt:72
-#: data/base/messages/strings/cam1strings.txt:90
-#: data/base/messages/strings/cam1strings.txt:116
-#: data/base/messages/strings/cam1strings.txt:154
-#: data/base/messages/strings/cam2strings.txt:108
-#: data/base/messages/strings/cam3strings.txt:156
-msgid " "
-msgstr " "
-
 #: data/base/messages/strings/cam1strings.txt:66
 msgid "Congratulations Commander."
 msgstr ""

--- a/po/de.po
+++ b/po/de.po
@@ -201,16 +201,6 @@ msgstr "Wir orten feindliche Truppen an diesen Positionen."
 msgid "This is our chance to defeat the New Paradigm and destroy their base."
 msgstr "Das ist unsere Chance das New Paradigm zu besiegen und ihre Basis zu zerstören."
 
-#: data/base/messages/strings/cam1strings.txt:62
-#: data/base/messages/strings/cam1strings.txt:72
-#: data/base/messages/strings/cam1strings.txt:90
-#: data/base/messages/strings/cam1strings.txt:116
-#: data/base/messages/strings/cam1strings.txt:154
-#: data/base/messages/strings/cam2strings.txt:108
-#: data/base/messages/strings/cam3strings.txt:156
-msgid " "
-msgstr " "
-
 #: data/base/messages/strings/cam1strings.txt:66
 msgid "Congratulations Commander."
 msgstr "Glückwunsch, Commander."

--- a/po/el.po
+++ b/po/el.po
@@ -192,16 +192,6 @@ msgstr "Εντοπίζουμε εχθρικές δυνάμεις σε αυτές
 msgid "This is our chance to defeat the New Paradigm and destroy their base."
 msgstr "Αυτή είναι η ευκαιρία μας, να νικήσουμε το Νέο Παράδειγμα, και να καταστρέψουμε τη βάση τους."
 
-#: data/base/messages/strings/cam1strings.txt:62
-#: data/base/messages/strings/cam1strings.txt:72
-#: data/base/messages/strings/cam1strings.txt:90
-#: data/base/messages/strings/cam1strings.txt:116
-#: data/base/messages/strings/cam1strings.txt:154
-#: data/base/messages/strings/cam2strings.txt:108
-#: data/base/messages/strings/cam3strings.txt:156
-msgid " "
-msgstr " "
-
 #: data/base/messages/strings/cam1strings.txt:66
 msgid "Congratulations Commander."
 msgstr "Συγχαρητήρια Διοικητή."

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -193,16 +193,6 @@ msgstr "We are detecting enemy forces at these locations."
 msgid "This is our chance to defeat the New Paradigm and destroy their base."
 msgstr "This is our chance to defeat the New Paradigm and destroy their base."
 
-#: data/base/messages/strings/cam1strings.txt:62
-#: data/base/messages/strings/cam1strings.txt:72
-#: data/base/messages/strings/cam1strings.txt:90
-#: data/base/messages/strings/cam1strings.txt:116
-#: data/base/messages/strings/cam1strings.txt:154
-#: data/base/messages/strings/cam2strings.txt:108
-#: data/base/messages/strings/cam3strings.txt:156
-msgid " "
-msgstr " "
-
 #: data/base/messages/strings/cam1strings.txt:66
 msgid "Congratulations Commander."
 msgstr "Congratulations Commander."

--- a/po/eo.po
+++ b/po/eo.po
@@ -190,16 +190,6 @@ msgstr ""
 msgid "This is our chance to defeat the New Paradigm and destroy their base."
 msgstr ""
 
-#: data/base/messages/strings/cam1strings.txt:62
-#: data/base/messages/strings/cam1strings.txt:72
-#: data/base/messages/strings/cam1strings.txt:90
-#: data/base/messages/strings/cam1strings.txt:116
-#: data/base/messages/strings/cam1strings.txt:154
-#: data/base/messages/strings/cam2strings.txt:108
-#: data/base/messages/strings/cam3strings.txt:156
-msgid " "
-msgstr ""
-
 #: data/base/messages/strings/cam1strings.txt:66
 msgid "Congratulations Commander."
 msgstr ""

--- a/po/es.po
+++ b/po/es.po
@@ -197,16 +197,6 @@ msgstr "Estamos detectando fuerzas enemigas en estos lugares."
 msgid "This is our chance to defeat the New Paradigm and destroy their base."
 msgstr "Es nuestra oportunidad de defender el Nuevo Paradigma y destruir su base."
 
-#: data/base/messages/strings/cam1strings.txt:62
-#: data/base/messages/strings/cam1strings.txt:72
-#: data/base/messages/strings/cam1strings.txt:90
-#: data/base/messages/strings/cam1strings.txt:116
-#: data/base/messages/strings/cam1strings.txt:154
-#: data/base/messages/strings/cam2strings.txt:108
-#: data/base/messages/strings/cam3strings.txt:156
-msgid " "
-msgstr " "
-
 #: data/base/messages/strings/cam1strings.txt:66
 msgid "Congratulations Commander."
 msgstr "Enhorabuena, Comandante."

--- a/po/et_EE.po
+++ b/po/et_EE.po
@@ -193,16 +193,6 @@ msgstr "Me tuvastasime vaenlase väed nendes asukohtades."
 msgid "This is our chance to defeat the New Paradigm and destroy their base."
 msgstr "See on meie võimalus lüüa Uus Paradigmid ja hävitada nende baas."
 
-#: data/base/messages/strings/cam1strings.txt:62
-#: data/base/messages/strings/cam1strings.txt:72
-#: data/base/messages/strings/cam1strings.txt:90
-#: data/base/messages/strings/cam1strings.txt:116
-#: data/base/messages/strings/cam1strings.txt:154
-#: data/base/messages/strings/cam2strings.txt:108
-#: data/base/messages/strings/cam3strings.txt:156
-msgid " "
-msgstr " "
-
 #: data/base/messages/strings/cam1strings.txt:66
 msgid "Congratulations Commander."
 msgstr "Õnnitlused Komandör."

--- a/po/fi.po
+++ b/po/fi.po
@@ -193,16 +193,6 @@ msgstr ""
 msgid "This is our chance to defeat the New Paradigm and destroy their base."
 msgstr ""
 
-#: data/base/messages/strings/cam1strings.txt:62
-#: data/base/messages/strings/cam1strings.txt:72
-#: data/base/messages/strings/cam1strings.txt:90
-#: data/base/messages/strings/cam1strings.txt:116
-#: data/base/messages/strings/cam1strings.txt:154
-#: data/base/messages/strings/cam2strings.txt:108
-#: data/base/messages/strings/cam3strings.txt:156
-msgid " "
-msgstr ""
-
 #: data/base/messages/strings/cam1strings.txt:66
 msgid "Congratulations Commander."
 msgstr ""

--- a/po/fr.po
+++ b/po/fr.po
@@ -189,16 +189,6 @@ msgstr "Nous détectons des forces ennemies dans les alentours."
 msgid "This is our chance to defeat the New Paradigm and destroy their base."
 msgstr "Voilà notre chance de renverser le Nouveau Paradigme et de détruire leur base."
 
-#: data/base/messages/strings/cam1strings.txt:62
-#: data/base/messages/strings/cam1strings.txt:72
-#: data/base/messages/strings/cam1strings.txt:90
-#: data/base/messages/strings/cam1strings.txt:116
-#: data/base/messages/strings/cam1strings.txt:154
-#: data/base/messages/strings/cam2strings.txt:108
-#: data/base/messages/strings/cam3strings.txt:156
-msgid " "
-msgstr ""
-
 #: data/base/messages/strings/cam1strings.txt:66
 msgid "Congratulations Commander."
 msgstr "Nos félicitations, Commandant !"

--- a/po/fy.po
+++ b/po/fy.po
@@ -193,16 +193,6 @@ msgstr ""
 msgid "This is our chance to defeat the New Paradigm and destroy their base."
 msgstr ""
 
-#: data/base/messages/strings/cam1strings.txt:62
-#: data/base/messages/strings/cam1strings.txt:72
-#: data/base/messages/strings/cam1strings.txt:90
-#: data/base/messages/strings/cam1strings.txt:116
-#: data/base/messages/strings/cam1strings.txt:154
-#: data/base/messages/strings/cam2strings.txt:108
-#: data/base/messages/strings/cam3strings.txt:156
-msgid " "
-msgstr ""
-
 #: data/base/messages/strings/cam1strings.txt:66
 msgid "Congratulations Commander."
 msgstr ""

--- a/po/ga.po
+++ b/po/ga.po
@@ -193,16 +193,6 @@ msgstr ""
 msgid "This is our chance to defeat the New Paradigm and destroy their base."
 msgstr ""
 
-#: data/base/messages/strings/cam1strings.txt:62
-#: data/base/messages/strings/cam1strings.txt:72
-#: data/base/messages/strings/cam1strings.txt:90
-#: data/base/messages/strings/cam1strings.txt:116
-#: data/base/messages/strings/cam1strings.txt:154
-#: data/base/messages/strings/cam2strings.txt:108
-#: data/base/messages/strings/cam3strings.txt:156
-msgid " "
-msgstr ""
-
 #: data/base/messages/strings/cam1strings.txt:66
 msgid "Congratulations Commander."
 msgstr ""

--- a/po/hr.po
+++ b/po/hr.po
@@ -185,16 +185,6 @@ msgstr ""
 msgid "This is our chance to defeat the New Paradigm and destroy their base."
 msgstr ""
 
-#: data/base/messages/strings/cam1strings.txt:62
-#: data/base/messages/strings/cam1strings.txt:72
-#: data/base/messages/strings/cam1strings.txt:90
-#: data/base/messages/strings/cam1strings.txt:116
-#: data/base/messages/strings/cam1strings.txt:154
-#: data/base/messages/strings/cam2strings.txt:108
-#: data/base/messages/strings/cam3strings.txt:156
-msgid " "
-msgstr " "
-
 #: data/base/messages/strings/cam1strings.txt:66
 msgid "Congratulations Commander."
 msgstr ""

--- a/po/hu.po
+++ b/po/hu.po
@@ -195,16 +195,6 @@ msgstr "Ellenséges erőket észleltünk ezen a helyszínen."
 msgid "This is our chance to defeat the New Paradigm and destroy their base."
 msgstr "Ez a mi lehetőségünk, elpusztítani az Új Paradigmát és lerombolni a bázisát."
 
-#: data/base/messages/strings/cam1strings.txt:62
-#: data/base/messages/strings/cam1strings.txt:72
-#: data/base/messages/strings/cam1strings.txt:90
-#: data/base/messages/strings/cam1strings.txt:116
-#: data/base/messages/strings/cam1strings.txt:154
-#: data/base/messages/strings/cam2strings.txt:108
-#: data/base/messages/strings/cam3strings.txt:156
-msgid " "
-msgstr " "
-
 #: data/base/messages/strings/cam1strings.txt:66
 msgid "Congratulations Commander."
 msgstr "Gratulálunk parancsnok."

--- a/po/id.po
+++ b/po/id.po
@@ -191,16 +191,6 @@ msgstr ""
 msgid "This is our chance to defeat the New Paradigm and destroy their base."
 msgstr ""
 
-#: data/base/messages/strings/cam1strings.txt:62
-#: data/base/messages/strings/cam1strings.txt:72
-#: data/base/messages/strings/cam1strings.txt:90
-#: data/base/messages/strings/cam1strings.txt:116
-#: data/base/messages/strings/cam1strings.txt:154
-#: data/base/messages/strings/cam2strings.txt:108
-#: data/base/messages/strings/cam3strings.txt:156
-msgid " "
-msgstr ""
-
 #: data/base/messages/strings/cam1strings.txt:66
 msgid "Congratulations Commander."
 msgstr ""

--- a/po/it.po
+++ b/po/it.po
@@ -198,16 +198,6 @@ msgstr "Stiamo localizzando forze nemiche in queste posizioni."
 msgid "This is our chance to defeat the New Paradigm and destroy their base."
 msgstr "Questa è la nostra chance per sconfiggere il New Paradigm e distruggere la loro base."
 
-#: data/base/messages/strings/cam1strings.txt:62
-#: data/base/messages/strings/cam1strings.txt:72
-#: data/base/messages/strings/cam1strings.txt:90
-#: data/base/messages/strings/cam1strings.txt:116
-#: data/base/messages/strings/cam1strings.txt:154
-#: data/base/messages/strings/cam2strings.txt:108
-#: data/base/messages/strings/cam3strings.txt:156
-msgid " "
-msgstr " "
-
 #: data/base/messages/strings/cam1strings.txt:66
 msgid "Congratulations Commander."
 msgstr "Congratulazioni Comandante."

--- a/po/ko.po
+++ b/po/ko.po
@@ -192,16 +192,6 @@ msgstr "우리가 이 위치들에 적군을 감지하고 있습니다"
 msgid "This is our chance to defeat the New Paradigm and destroy their base."
 msgstr "이것은 우리가 뉴 패러다임을 물리치고 그들의 기지를 파괴할 기회입니다."
 
-#: data/base/messages/strings/cam1strings.txt:62
-#: data/base/messages/strings/cam1strings.txt:72
-#: data/base/messages/strings/cam1strings.txt:90
-#: data/base/messages/strings/cam1strings.txt:116
-#: data/base/messages/strings/cam1strings.txt:154
-#: data/base/messages/strings/cam2strings.txt:108
-#: data/base/messages/strings/cam3strings.txt:156
-msgid " "
-msgstr " "
-
 #: data/base/messages/strings/cam1strings.txt:66
 msgid "Congratulations Commander."
 msgstr "축하합니다 사령관님."

--- a/po/la.po
+++ b/po/la.po
@@ -193,16 +193,6 @@ msgstr ""
 msgid "This is our chance to defeat the New Paradigm and destroy their base."
 msgstr ""
 
-#: data/base/messages/strings/cam1strings.txt:62
-#: data/base/messages/strings/cam1strings.txt:72
-#: data/base/messages/strings/cam1strings.txt:90
-#: data/base/messages/strings/cam1strings.txt:116
-#: data/base/messages/strings/cam1strings.txt:154
-#: data/base/messages/strings/cam2strings.txt:108
-#: data/base/messages/strings/cam3strings.txt:156
-msgid " "
-msgstr " "
-
 #: data/base/messages/strings/cam1strings.txt:66
 msgid "Congratulations Commander."
 msgstr ""

--- a/po/lt.po
+++ b/po/lt.po
@@ -193,16 +193,6 @@ msgstr ""
 msgid "This is our chance to defeat the New Paradigm and destroy their base."
 msgstr ""
 
-#: data/base/messages/strings/cam1strings.txt:62
-#: data/base/messages/strings/cam1strings.txt:72
-#: data/base/messages/strings/cam1strings.txt:90
-#: data/base/messages/strings/cam1strings.txt:116
-#: data/base/messages/strings/cam1strings.txt:154
-#: data/base/messages/strings/cam2strings.txt:108
-#: data/base/messages/strings/cam3strings.txt:156
-msgid " "
-msgstr " "
-
 #: data/base/messages/strings/cam1strings.txt:66
 msgid "Congratulations Commander."
 msgstr ""

--- a/po/nb.po
+++ b/po/nb.po
@@ -194,16 +194,6 @@ msgstr ""
 msgid "This is our chance to defeat the New Paradigm and destroy their base."
 msgstr ""
 
-#: data/base/messages/strings/cam1strings.txt:62
-#: data/base/messages/strings/cam1strings.txt:72
-#: data/base/messages/strings/cam1strings.txt:90
-#: data/base/messages/strings/cam1strings.txt:116
-#: data/base/messages/strings/cam1strings.txt:154
-#: data/base/messages/strings/cam2strings.txt:108
-#: data/base/messages/strings/cam3strings.txt:156
-msgid " "
-msgstr " "
-
 #: data/base/messages/strings/cam1strings.txt:66
 msgid "Congratulations Commander."
 msgstr ""

--- a/po/nl.po
+++ b/po/nl.po
@@ -185,16 +185,6 @@ msgstr "Wij detecteren vijandelijke krachten op deze locaties."
 msgid "This is our chance to defeat the New Paradigm and destroy their base."
 msgstr "Dit is onze kans om de basis van de New Paradigm te verslaan."
 
-#: data/base/messages/strings/cam1strings.txt:62
-#: data/base/messages/strings/cam1strings.txt:72
-#: data/base/messages/strings/cam1strings.txt:90
-#: data/base/messages/strings/cam1strings.txt:116
-#: data/base/messages/strings/cam1strings.txt:154
-#: data/base/messages/strings/cam2strings.txt:108
-#: data/base/messages/strings/cam3strings.txt:156
-msgid " "
-msgstr " "
-
 #: data/base/messages/strings/cam1strings.txt:66
 msgid "Congratulations Commander."
 msgstr "Gefeliciteerd Commandant."

--- a/po/pl.po
+++ b/po/pl.po
@@ -195,16 +195,6 @@ msgstr "Wykryto siły wroga na tych lokacjach."
 msgid "This is our chance to defeat the New Paradigm and destroy their base."
 msgstr "To nasza szansa na pokonanie New Paragidm i zniszczenie ich bazy."
 
-#: data/base/messages/strings/cam1strings.txt:62
-#: data/base/messages/strings/cam1strings.txt:72
-#: data/base/messages/strings/cam1strings.txt:90
-#: data/base/messages/strings/cam1strings.txt:116
-#: data/base/messages/strings/cam1strings.txt:154
-#: data/base/messages/strings/cam2strings.txt:108
-#: data/base/messages/strings/cam3strings.txt:156
-msgid " "
-msgstr " "
-
 #: data/base/messages/strings/cam1strings.txt:66
 msgid "Congratulations Commander."
 msgstr "Gratulacje dowódco."

--- a/po/pt.po
+++ b/po/pt.po
@@ -193,16 +193,6 @@ msgstr "Estamos a detectar forças inimigas nestas localizações."
 msgid "This is our chance to defeat the New Paradigm and destroy their base."
 msgstr "Esta é a nossa hipótese de derrotar o Novo Paradigma e destruir a base deles."
 
-#: data/base/messages/strings/cam1strings.txt:62
-#: data/base/messages/strings/cam1strings.txt:72
-#: data/base/messages/strings/cam1strings.txt:90
-#: data/base/messages/strings/cam1strings.txt:116
-#: data/base/messages/strings/cam1strings.txt:154
-#: data/base/messages/strings/cam2strings.txt:108
-#: data/base/messages/strings/cam3strings.txt:156
-msgid " "
-msgstr " "
-
 #: data/base/messages/strings/cam1strings.txt:66
 msgid "Congratulations Commander."
 msgstr "Parabéns Comandante."

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -189,16 +189,6 @@ msgstr "Estamos detectando forças inimigas nessas localidades."
 msgid "This is our chance to defeat the New Paradigm and destroy their base."
 msgstr "Essa é nossa chance de derrotar o Novo Paradigma e destruir sua base."
 
-#: data/base/messages/strings/cam1strings.txt:62
-#: data/base/messages/strings/cam1strings.txt:72
-#: data/base/messages/strings/cam1strings.txt:90
-#: data/base/messages/strings/cam1strings.txt:116
-#: data/base/messages/strings/cam1strings.txt:154
-#: data/base/messages/strings/cam2strings.txt:108
-#: data/base/messages/strings/cam3strings.txt:156
-msgid " "
-msgstr " "
-
 #: data/base/messages/strings/cam1strings.txt:66
 msgid "Congratulations Commander."
 msgstr "Parabéns, Comandante."

--- a/po/ro.po
+++ b/po/ro.po
@@ -193,16 +193,6 @@ msgstr "Detectăm forțe inamice la această locație."
 msgid "This is our chance to defeat the New Paradigm and destroy their base."
 msgstr "Aceasta esteșansa noastră să învingem Noua Paradigmă și să le distrugem baza."
 
-#: data/base/messages/strings/cam1strings.txt:62
-#: data/base/messages/strings/cam1strings.txt:72
-#: data/base/messages/strings/cam1strings.txt:90
-#: data/base/messages/strings/cam1strings.txt:116
-#: data/base/messages/strings/cam1strings.txt:154
-#: data/base/messages/strings/cam2strings.txt:108
-#: data/base/messages/strings/cam3strings.txt:156
-msgid " "
-msgstr " "
-
 #: data/base/messages/strings/cam1strings.txt:66
 msgid "Congratulations Commander."
 msgstr "Felicitări, comandante."

--- a/po/ru.po
+++ b/po/ru.po
@@ -198,16 +198,6 @@ msgstr "Мы обнаружили вражеские войска в этом р
 msgid "This is our chance to defeat the New Paradigm and destroy their base."
 msgstr "Это наш шанс разгромить Новую Парадигму и уничтожить их базу."
 
-#: data/base/messages/strings/cam1strings.txt:62
-#: data/base/messages/strings/cam1strings.txt:72
-#: data/base/messages/strings/cam1strings.txt:90
-#: data/base/messages/strings/cam1strings.txt:116
-#: data/base/messages/strings/cam1strings.txt:154
-#: data/base/messages/strings/cam2strings.txt:108
-#: data/base/messages/strings/cam3strings.txt:156
-msgid " "
-msgstr " "
-
 #: data/base/messages/strings/cam1strings.txt:66
 msgid "Congratulations Commander."
 msgstr "Поздравляем, Командующий."

--- a/po/sk.po
+++ b/po/sk.po
@@ -196,16 +196,6 @@ msgstr ""
 msgid "This is our chance to defeat the New Paradigm and destroy their base."
 msgstr ""
 
-#: data/base/messages/strings/cam1strings.txt:62
-#: data/base/messages/strings/cam1strings.txt:72
-#: data/base/messages/strings/cam1strings.txt:90
-#: data/base/messages/strings/cam1strings.txt:116
-#: data/base/messages/strings/cam1strings.txt:154
-#: data/base/messages/strings/cam2strings.txt:108
-#: data/base/messages/strings/cam3strings.txt:156
-msgid " "
-msgstr " "
-
 #: data/base/messages/strings/cam1strings.txt:66
 msgid "Congratulations Commander."
 msgstr ""

--- a/po/sl.po
+++ b/po/sl.po
@@ -191,16 +191,6 @@ msgstr "Na teh položajih zaznavamo sovražne posadke."
 msgid "This is our chance to defeat the New Paradigm and destroy their base."
 msgstr "To je naša priložnost, da premagamo Novo Paradigmo in uničimo njihovo bazo."
 
-#: data/base/messages/strings/cam1strings.txt:62
-#: data/base/messages/strings/cam1strings.txt:72
-#: data/base/messages/strings/cam1strings.txt:90
-#: data/base/messages/strings/cam1strings.txt:116
-#: data/base/messages/strings/cam1strings.txt:154
-#: data/base/messages/strings/cam2strings.txt:108
-#: data/base/messages/strings/cam3strings.txt:156
-msgid " "
-msgstr " "
-
 #: data/base/messages/strings/cam1strings.txt:66
 msgid "Congratulations Commander."
 msgstr "Čestitke, poveljnik."

--- a/po/tr.po
+++ b/po/tr.po
@@ -196,16 +196,6 @@ msgstr "Bu bölgelerde düşman birlikleri tespit ettik."
 msgid "This is our chance to defeat the New Paradigm and destroy their base."
 msgstr "Bu Yeni Paradigmayı yenip üslerini yok etmek için bir şans."
 
-#: data/base/messages/strings/cam1strings.txt:62
-#: data/base/messages/strings/cam1strings.txt:72
-#: data/base/messages/strings/cam1strings.txt:90
-#: data/base/messages/strings/cam1strings.txt:116
-#: data/base/messages/strings/cam1strings.txt:154
-#: data/base/messages/strings/cam2strings.txt:108
-#: data/base/messages/strings/cam3strings.txt:156
-msgid " "
-msgstr " "
-
 #: data/base/messages/strings/cam1strings.txt:66
 msgid "Congratulations Commander."
 msgstr "Tebrikler Komutan."

--- a/po/uk_UA.po
+++ b/po/uk_UA.po
@@ -187,16 +187,6 @@ msgstr "Ми фіксуємо ворожі сили на цих територі
 msgid "This is our chance to defeat the New Paradigm and destroy their base."
 msgstr "Це наш шанс завдати поразки Новій Парадігмі та знищити їх базу."
 
-#: data/base/messages/strings/cam1strings.txt:62
-#: data/base/messages/strings/cam1strings.txt:72
-#: data/base/messages/strings/cam1strings.txt:90
-#: data/base/messages/strings/cam1strings.txt:116
-#: data/base/messages/strings/cam1strings.txt:154
-#: data/base/messages/strings/cam2strings.txt:108
-#: data/base/messages/strings/cam3strings.txt:156
-msgid " "
-msgstr " "
-
 #: data/base/messages/strings/cam1strings.txt:66
 msgid "Congratulations Commander."
 msgstr "Вітаємо, Командире."

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -195,16 +195,6 @@ msgstr "我们在这个区域侦测到了敌军"
 msgid "This is our chance to defeat the New Paradigm and destroy their base."
 msgstr "这是我们打败New Paradigm并摧毁他们基地的最好机会！"
 
-#: data/base/messages/strings/cam1strings.txt:62
-#: data/base/messages/strings/cam1strings.txt:72
-#: data/base/messages/strings/cam1strings.txt:90
-#: data/base/messages/strings/cam1strings.txt:116
-#: data/base/messages/strings/cam1strings.txt:154
-#: data/base/messages/strings/cam2strings.txt:108
-#: data/base/messages/strings/cam3strings.txt:156
-msgid " "
-msgstr " "
-
 #: data/base/messages/strings/cam1strings.txt:66
 msgid "Congratulations Commander."
 msgstr "恭喜你，指挥官！"

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -196,16 +196,6 @@ msgstr "我們在這個區域偵測到了敵軍"
 msgid "This is our chance to defeat the New Paradigm and destroy their base."
 msgstr "這是我們打敗New Paradigm並摧毀他們基地的最好機會！"
 
-#: data/base/messages/strings/cam1strings.txt:62
-#: data/base/messages/strings/cam1strings.txt:72
-#: data/base/messages/strings/cam1strings.txt:90
-#: data/base/messages/strings/cam1strings.txt:116
-#: data/base/messages/strings/cam1strings.txt:154
-#: data/base/messages/strings/cam2strings.txt:108
-#: data/base/messages/strings/cam3strings.txt:156
-msgid " "
-msgstr " "
-
 #: data/base/messages/strings/cam1strings.txt:66
 msgid "Congratulations Commander."
 msgstr "恭喜你，指揮官！"

--- a/src/frontend.cpp
+++ b/src/frontend.cpp
@@ -921,8 +921,20 @@ static bool startAudioAndZoomOptionsMenu()
 	addMultiBut(psWScreen, FRONTEND_BOTFORM, FRONTEND_QUIT, 10, 10, 30, 29, P_("menu", "Return"), IMAGE_RETURN, IMAGE_RETURN_HI, IMAGE_RETURN_HI);
 
 	//add some text down the side of the form
-	addSideText(FRONTEND_SIDETEXT, FRONTEND_SIDEX, FRONTEND_SIDEY, _("AUDIO / ZOOM OPTIONS"));
-
+	// TRANSLATORS: "AUDIO" options determine the volume of game sounds.
+	// "OPTIONS" means "SETTINGS".
+	// To break this message into two lines, you can use the delimiter "\n",
+	// e.g. "AUDIO / ZOOM\nOPTIONS" would show "OPTIONS" in a second line.
+	WzString messageString = WzString::fromUtf8(_("AUDIO / ZOOM OPTIONS"));
+	std::vector<WzString> messageStringLines = messageString.split("\n");
+	addSideText(FRONTEND_SIDETEXT, FRONTEND_SIDEX, FRONTEND_SIDEY, messageStringLines[0].toUtf8().c_str());
+	// show a second sidetext line if the translation requires it
+	if (messageStringLines.size() > 1)
+	{
+		messageString.remove(0, messageStringLines[0].length() + 1);
+		addSideText(FRONTEND_MULTILINE_SIDETEXT, FRONTEND_SIDEX + 22, \
+		FRONTEND_SIDEY, messageString.toUtf8().c_str());
+	}
 
 	return true;
 }

--- a/src/frontend.h
+++ b/src/frontend.h
@@ -159,6 +159,7 @@ enum
 	FRONTEND_BOTFORM,
 	FRONTEND_LOGO,
 	FRONTEND_SIDETEXT,					// sideways text
+	FRONTEND_MULTILINE_SIDETEXT,				// sideways text
 	FRONTEND_SIDETEXT1,					// sideways text
 	FRONTEND_SIDETEXT2,					// sideways text
 	FRONTEND_SIDETEXT3,					// sideways text


### PR DESCRIPTION
The translation of the sidetext "AUDIO / ZOOM OPTIONS" is too long in
some foreign languages so that it cannot fit in the 640x480 screen.
Therefore, an optional delimiter "\n" allows to split it into two lines.
Any additional instances of that delimiter are ignored.

Note that the message's translation must not begin or end with "\n",
because otherwise msgfmt will terminate with a fatal error. Example:

PO file:

```
msgid "AUDIO / ZOOM OPTIONS"
msgstr "AUDIO- UND ZOOM-\nEINSTELLUNGEN\n"
```

Partial output of `make -C po update-po`:

```
de.po:10475: 'msgid' and 'msgstr' entries do not both end with '\n'
/usr/bin/msgfmt: found 1 fatal error
2882 translated messages, 3 fuzzy translations, 1 untranslated message.
make[1]: *** [Makefile:467: de.gmo] Error 1
make[1]: Leaving directory '/home/x/the_project/warzone2100/po'
make: *** [Makefile:764: update-po] Error 2
```

The attached ZIP file contains
* screenshots of the translated message with both one and two delimiters
* a shell script to generate them

As a paragraph separator for campaign mission briefings, the string " "
should not be translatable. That same message remains commented out in
the following lines of data/base/messages/strings/resstrings.txt:

```
19://RES_CYW_LG1_MSG1			_(" ")
20://RES_CYW_LG1_MSG2			_(" ")
21://RES_CYW_LG1_MSG3			_(" ")
429://RES_SY_SP1MK1_MSG1		_(" ")
430://RES_SY_SP1MK1_MSG2		_(" ")
431://RES_SY_SP1MK1_MSG3		_(" ")
432://RES_SY_SP1MK1_MSG4		_(" ")
```

[translation_placeholder_documentation.zip](https://github.com/Warzone2100/warzone2100/files/3270185/translation_placeholder_documentation.zip)
