### PR TITLE
fix some undefined behaviour

### DIFF
--- a/src/display3d.cpp
+++ b/src/display3d.cpp
@@ -1304,8 +1304,8 @@ bool clipShapeOnScreen(const iIMDShape *pIMD, const glm::mat4& viewModelMatrix, 
 	/* get the screen coordinates */
 	const float cZ = pie_RotateProject(&origin, viewModelMatrix, &center) * 0.1;
 
-	//Watermelon:added a crash protection hack...
-	if (cZ >= 0)
+	// avoid division by zero
+	if (cZ > 0)
 	{
 		radius = wsRadius / cZ * pie_GetResScalingFactor();
 	}
@@ -3253,8 +3253,8 @@ void calcScreenCoords(DROID *psDroid, const glm::mat4 &viewMatrix)
 	/* get the screen coordinates */
 	const float cZ = pie_RotateProject(&origin, viewMatrix, &center) * 0.1;
 
-	//Watermelon:added a crash protection hack...
-	if (cZ >= 0)
+	// avoid division by zero
+	if (cZ > 0)
 	{
 		radius = wsRadius / cZ * pie_GetResScalingFactor();
 	}

--- a/src/mapgrid.cpp
+++ b/src/mapgrid.cpp
@@ -94,7 +94,8 @@ void gridShutDown()
 
 static bool isInRadius(int32_t x, int32_t y, uint32_t radius)
 {
-	return (uint32_t)(x * x + y * y) <= radius * radius;
+	// cast to int64 to avoid integer overflow
+	return ((int64_t)x * (int64_t)x + (int64_t)y * (int64_t)y) <= ((int64_t)radius * (int64_t)radius);
 }
 
 // initialise the grid system to start iterating through units that


### PR DESCRIPTION
fix integer overflow and division by zero

```
warzone2100/src/mapgrid.cpp:97:22: runtime error: signed integer overflow: 53568 * 53568 cannot be represented in type 'int'
warzone2100/src/mapgrid.cpp:97:30: runtime error: signed integer overflow: 52288 * 52288 cannot be represented in type 'int'
warzone2100/src/mapgrid.cpp:97:26: runtime error: signed integer overflow: -1425436672 + -1560932352 cannot be represented in type 'int'
```
