### PR TITLE
fix nullpointer member access

### DIFF
--- a/src/intelmap.cpp
+++ b/src/intelmap.cpp
@@ -908,7 +908,11 @@ void intRemoveMessageView(bool animated)
 
 	//stop the video
 	VIEW_RESEARCH *psViewResearch = (VIEW_RESEARCH *)form->pUserData;
-	seq_RenderVideoToBuffer(psViewResearch->sequenceName, SEQUENCE_KILL);
+
+	if (psViewResearch != nullptr)
+	{
+		seq_RenderVideoToBuffer(psViewResearch->sequenceName, SEQUENCE_KILL);
+	}
 
 	if (animated)
 	{


### PR DESCRIPTION
nullpointer member acess occurs the first time a dialog is opened and closed.

`warzone2100/src/intelmap.cpp:911:42: runtime error: member access within null pointer of type 'VIEW_RESEARCH'`