### PR TITLE
Ignore deprecated-copy warnings to allow compilation with GCC 9

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -277,7 +277,7 @@ fi
 WZ_WARNINGS_GCC="-Wall -Wextra ${WZ_Wno_}unused-parameter ${WZ_Wno_}sign-compare -Wcast-align -Wwrite-strings -Wpointer-arith ${WZ_Wno_}format-security"
 AX_C_CHECK_FLAG([-Werror -Wno-expansion-to-defined -Wno-error=cpp], [#warning x], , WZ_WARNINGS_GCC="${WZ_WARNINGS_GCC} -Wno-expansion-to-defined")
 WZ_WARNINGS_GCC_C="${WZ_WARNINGS_GCC} -Wstrict-prototypes -Wdeclaration-after-statement ${CFLAGS_IGNORE_WARNINGS}"
-WZ_WARNINGS_GCC_CXX="${WZ_Wno_}enum-compare ${WZ_WARNINGS_GCC}"
+WZ_WARNINGS_GCC_CXX="${WZ_Wno_}enum-compare ${WZ_Wno_}deprecated-copy ${WZ_WARNINGS_GCC}"
 # gcc 8.0 added some fairly obnoxious string truncation warnings
 AX_C_CHECK_FLAG([-Werror -Wno-stringop-truncation -Wno-error=cpp], [#warning x], , WZ_WARNINGS_GCC_CXX="${WZ_WARNINGS_GCC_CXX} -Wno-stringop-truncation")
 AX_C_CHECK_FLAG([-Werror -Wno-stringop-truncation -Wno-error=cpp], [#warning x], , WZ_WARNINGS_GCC_C="${WZ_WARNINGS_GCC_C} -Wno-stringop-truncation")


### PR DESCRIPTION
Wz fails to compile on Fedora 30 (GCC9, Qt 5.12):

> In file included from /usr/include/qt5/QtCore/qlocale.h:43,
                 from /usr/include/qt5/QtGui/qguiapplication.h:47,
                 from /usr/include/qt5/QtWidgets/qapplication.h:52,
                 from /usr/include/qt5/QtWidgets/QApplication:1,
                 from main_sdl.cpp:26:
/usr/include/qt5/QtCore/qvariant.h: In constructor ‘QVariant::QVariant(QVariant&&)’:
/usr/include/qt5/QtCore/qvariant.h:273:25: error: implicitly-declared ‘QVariant::Private& QVariant::Private::operator=(const QVariant::Private&)’ is deprecated [-Werror=deprecated-copy]
  273 |     { other.d = Private(); }
      |                         ^
/usr/include/qt5/QtCore/qvariant.h:399:16: note: because ‘QVariant::Private’ has user-provided ‘QVariant::Private::Private(const QVariant::Private&)’
  399 |         inline Private(const Private &other) Q_DECL_NOTHROW
      |                ^~~~~~~
cc1plus: all warnings being treated as errors

The offending code is in Qt and not it wz, so this is hard to workaround. According to https://github.com/bitcoin/bitcoin/issues/15822 there is a fix in works for Qt 5.13.