### PR TITLE
Ignore Qt < 5.13 `deprecated-copy` warnings on GCC9

### DIFF
--- a/lib/sdl/main_sdl.cpp
+++ b/lib/sdl/main_sdl.cpp
@@ -22,11 +22,20 @@
  * SDL backend code
  */
 
+#if defined(__GNUC__) && !defined(__INTEL_COMPILER) && !defined(__clang__) && (9 <= __GNUC__)
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wdeprecated-copy" // Workaround Qt < 5.13 `deprecated-copy` issues with GCC 9
+#endif
+
 // **NOTE: Qt headers _must_ be before platform specific headers so we don't get conflicts.
 #include <QtWidgets/QApplication>
 // This is for the cross-compiler, for static QT 5 builds to avoid the 'plugins' crap on windows
 #if defined(QT_STATICPLUGIN)
 #include <QtCore/QtPlugin>
+#endif
+
+#if defined(__GNUC__) && !defined(__INTEL_COMPILER) && !defined(__clang__) && (9 <= __GNUC__)
+# pragma GCC diagnostic pop // Workaround Qt < 5.13 `deprecated-copy` issues with GCC 9
 #endif
 
 // Get platform defines before checking for them!

--- a/src/configuration.cpp
+++ b/src/configuration.cpp
@@ -23,7 +23,17 @@
  *
  */
 
+#if defined(__GNUC__) && !defined(__INTEL_COMPILER) && !defined(__clang__) && (9 <= __GNUC__)
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wdeprecated-copy" // Workaround Qt < 5.13 `deprecated-copy` issues with GCC 9
+#endif
+
 #include <QtCore/QSettings> // **NOTE: Qt headers _must_ be before platform specific headers so we don't get conflicts.
+
+#if defined(__GNUC__) && !defined(__INTEL_COMPILER) && !defined(__clang__) && (9 <= __GNUC__)
+# pragma GCC diagnostic pop // Workaround Qt < 5.13 `deprecated-copy` issues with GCC 9
+#endif
+
 #include "lib/framework/wzconfig.h"
 #include "lib/framework/input.h"
 #include "lib/netplay/netplay.h"

--- a/src/multiint.cpp
+++ b/src/multiint.cpp
@@ -25,8 +25,17 @@
  * along with connection and game options.
  */
 
+#if defined(__GNUC__) && !defined(__INTEL_COMPILER) && !defined(__clang__) && (9 <= __GNUC__)
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wdeprecated-copy" // Workaround Qt < 5.13 `deprecated-copy` issues with GCC 9
+#endif
+
 // **NOTE: Qt headers _must_ be before platform specific headers so we don't get conflicts.
 #include <QtCore/QFileInfo> // used to strip path of challenge AI values
+
+#if defined(__GNUC__) && !defined(__INTEL_COMPILER) && !defined(__clang__) && (9 <= __GNUC__)
+# pragma GCC diagnostic pop // Workaround Qt < 5.13 `deprecated-copy` issues with GCC 9
+#endif
 
 #include "lib/framework/wzapp.h"
 #include "lib/framework/wzconfig.h"

--- a/src/multistat.cpp
+++ b/src/multistat.cpp
@@ -25,7 +25,16 @@
  * load / update / store multiplayer statistics for league tables etc...
  */
 
+#if defined(__GNUC__) && !defined(__INTEL_COMPILER) && !defined(__clang__) && (9 <= __GNUC__)
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wdeprecated-copy" // Workaround Qt < 5.13 `deprecated-copy` issues with GCC 9
+#endif
+
 #include <QtCore/QSettings> // **NOTE: Qt headers _must_ be before platform specific headers so we don't get conflicts.
+
+#if defined(__GNUC__) && !defined(__INTEL_COMPILER) && !defined(__clang__) && (9 <= __GNUC__)
+# pragma GCC diagnostic pop // Workaround Qt < 5.13 `deprecated-copy` issues with GCC 9
+#endif
 
 #include "lib/framework/frame.h"
 #include "lib/framework/file.h"

--- a/src/qtscript.cpp
+++ b/src/qtscript.cpp
@@ -51,6 +51,11 @@
 //;; function that does something with the **game object**.
 //;;
 
+#if defined(__GNUC__) && !defined(__INTEL_COMPILER) && !defined(__clang__) && (9 <= __GNUC__)
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wdeprecated-copy" // Workaround Qt < 5.13 `deprecated-copy` issues with GCC 9
+#endif
+
 // **NOTE: Qt headers _must_ be before platform specific headers so we don't get conflicts.
 #include <QtCore/QTextStream>
 #include <QtCore/QHash>
@@ -66,6 +71,10 @@
 #include <QtCore/QElapsedTimer>
 #include <QtGui/QStandardItemModel>
 #include <QtWidgets/QFileDialog>
+
+#if defined(__GNUC__) && !defined(__INTEL_COMPILER) && !defined(__clang__) && (9 <= __GNUC__)
+# pragma GCC diagnostic pop // Workaround Qt < 5.13 `deprecated-copy` issues with GCC 9
+#endif
 
 #include "qtscript.h"
 

--- a/src/qtscriptdebug.cpp
+++ b/src/qtscriptdebug.cpp
@@ -22,6 +22,11 @@
  * New scripting system - debug GUI
  */
 
+#if defined(__GNUC__) && !defined(__INTEL_COMPILER) && !defined(__clang__) && (9 <= __GNUC__)
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wdeprecated-copy" // Workaround Qt < 5.13 `deprecated-copy` issues with GCC 9
+#endif
+
 // **NOTE: Qt headers _must_ be before platform specific headers so we don't get conflicts.
 #include <QtCore/QHash>
 #include <QtScript/QScriptEngine>
@@ -39,6 +44,10 @@
 #include <QtWidgets/QHBoxLayout>
 #include <QtWidgets/QVBoxLayout>
 #include <QtGui/QStandardItemModel>
+
+#if defined(__GNUC__) && !defined(__INTEL_COMPILER) && !defined(__clang__) && (9 <= __GNUC__)
+# pragma GCC diagnostic pop // Workaround Qt < 5.13 `deprecated-copy` issues with GCC 9
+#endif
 
 #include "qtscriptdebug.h"
 

--- a/src/qtscriptdebug.h
+++ b/src/qtscriptdebug.h
@@ -20,6 +20,11 @@
 #ifndef __INCLUDED_QTSCRIPTDEBUG_H__
 #define __INCLUDED_QTSCRIPTDEBUG_H__
 
+#if defined(__GNUC__) && !defined(__INTEL_COMPILER) && !defined(__clang__) && (9 <= __GNUC__)
+// not push / pop because this is needed for the generated qtscriptdebug moc cpp file
+# pragma GCC diagnostic ignored "-Wdeprecated-copy" // Workaround Qt < 5.13 `deprecated-copy` issues with GCC 9
+#endif
+
 // **NOTE: Qt headers _must_ be before platform specific headers so we don't get conflicts.
 #include <QtGui/QStandardItemModel>
 #include <QtCore/QHash>

--- a/src/qtscriptfuncs.cpp
+++ b/src/qtscriptfuncs.cpp
@@ -22,11 +22,20 @@
  * New scripting system -- script functions
  */
 
+#if defined(__GNUC__) && !defined(__INTEL_COMPILER) && !defined(__clang__) && (9 <= __GNUC__)
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wdeprecated-copy" // Workaround Qt < 5.13 `deprecated-copy` issues with GCC 9
+#endif
+
 // **NOTE: Qt headers _must_ be before platform specific headers so we don't get conflicts.
 #include <QtScript/QScriptValue>
 #include <QtCore/QStringList>
 #include <QtCore/QJsonArray>
 #include <QtGui/QStandardItemModel>
+
+#if defined(__GNUC__) && !defined(__INTEL_COMPILER) && !defined(__clang__) && (9 <= __GNUC__)
+# pragma GCC diagnostic pop // Workaround Qt < 5.13 `deprecated-copy` issues with GCC 9
+#endif
 
 #include "lib/framework/wzapp.h"
 #include "lib/framework/wzconfig.h"

--- a/src/qtscriptfuncs.h
+++ b/src/qtscriptfuncs.h
@@ -38,7 +38,16 @@ enum SCRIPT_TYPE
 	SCRIPT_COUNT
 };
 
+#if defined(__GNUC__) && !defined(__INTEL_COMPILER) && !defined(__clang__) && (9 <= __GNUC__)
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wdeprecated-copy" // Workaround Qt < 5.13 `deprecated-copy` issues with GCC 9
+#endif
+
 #include <QtScript/QScriptEngine>
+
+#if defined(__GNUC__) && !defined(__INTEL_COMPILER) && !defined(__clang__) && (9 <= __GNUC__)
+# pragma GCC diagnostic pop // Workaround Qt < 5.13 `deprecated-copy` issues with GCC 9
+#endif
 
 // ----------------------------------------------
 // Private to scripting module functions below


### PR DESCRIPTION
A revised version of #360 that limits the scope (largely) to the Qt headers.