### PR TITLE
Fix more broken shadows on walls and some features

### DIFF
--- a/src/display3d.cpp
+++ b/src/display3d.cpp
@@ -1934,7 +1934,7 @@ void	renderFeature(FEATURE *psFeature, const glm::mat4 &viewMatrix)
 	    || psFeature->psStats->subType == FEAT_OIL_DRUM)
 	{
 		/* these cast a shadow */
-		pieFlags = pie_STATIC_SHADOW;
+		pieFlags = pie_SHADOW;
 	}
 	iIMDShape *imd = psFeature->sDisplay.imd;
 	while (imd)

--- a/src/display3d.cpp
+++ b/src/display3d.cpp
@@ -2478,15 +2478,8 @@ static bool renderWallSection(STRUCTURE *psStructure, const glm::mat4 &viewMatri
 		}
 		else
 		{
-			if (psStructure->pStructureType->type == REF_WALL || psStructure->pStructureType->type == REF_GATE)
-			{
-				// walls can be rotated, so use a dynamic shadow for them
-				pieFlag = pie_SHADOW;
-			}
-			else
-			{
-				pieFlag = pie_STATIC_SHADOW;
-			}
+			// Use a dynamic shadow
+			pieFlag = pie_SHADOW;
 			pieFlagData = 0;
 		}
 		iIMDShape *imd = psStructure->sDisplay.imd;


### PR DESCRIPTION
Building off of #285, these patches will fix broken shadows on rotated buildings/huts (good to test against the [hydrofin](http://addons.wz2100.net/239) map), and broken wall-corner shadows mostly seen with scavenger bases in the campaign.

These patches obsolete the last uses of pie_STATIC_SHADOW everywhere in the source.