### PR TITLE
Improve projectile miss mechanism.

### DIFF
--- a/src/combat.cpp
+++ b/src/combat.cpp
@@ -273,10 +273,31 @@ bool combFire(WEAPON *psWeap, BASE_OBJECT *psAttacker, BASE_OBJECT *psTarget, in
 	}
 	else /* Deal with a missed shot */
 	{
-		const int minOffset = 5;
+		// Get the shape of the target to avoid "missing" inside of it
+		const ObjectShape targetShape = establishTargetShape(psTarget);
 
-		int missDist = 2 * (100 - resultHitChance) + minOffset;
-		Vector3i miss = Vector3i(iSinCosR(gameRand(DEG(360)), missDist), 0);
+		// Worst possible shot based on distance and weapon accuracy
+		Vector3i deltaPosPredict = psAttacker->pos - predict;
+		int worstShot;
+		if (resultHitChance > 0)
+		{
+			worstShot = (iHypot(deltaPosPredict.xy()) * 100 / resultHitChance) / 5;
+ 		}
+		else
+		{
+			worstShot = iHypot(deltaPosPredict.xy()) * 2;
+		}
+
+		// Use a random seed to determine how far the miss will land from the target
+		// That (num/100)^3 allow the misses to fall much more frequently close to the target
+		int num = gameRand(100) + 1;
+		int minOffset = 2 * targetShape.radius();
+
+		int missDist = minOffset + (worstShot * num * num * num) / (100 * 100 * 100);
+
+		// Determine the angle of the miss in the 270 degrees in "front" of the target.
+		// The 90 degrees behind would most probably cause an unwanted hit when the projectile will be drawn through the hitbox.
+		Vector3i miss = Vector3i(iSinCosR(gameRand(DEG(270)) - DEG(135) + iAtan2(deltaPosPredict.xy()), missDist), 0);
 		predict += miss;
 
 		psTarget = nullptr;  // Missed the target, so don't expect to hit it.

--- a/src/projectile.cpp
+++ b/src/projectile.cpp
@@ -95,22 +95,6 @@ BASE_OBJECT		*g_pProjLastAttacker;
 
 /***************************************************************************/
 
-struct ObjectShape
-{
-	ObjectShape() : isRectangular(false), size(0, 0) {}
-	ObjectShape(int radius) : isRectangular(false), size(radius, radius) {}
-	ObjectShape(int width, int breadth) : isRectangular(true), size(width, breadth) {}
-	ObjectShape(Vector2i widthBreadth) : isRectangular(true), size(widthBreadth) {}
-	int radius() const
-	{
-		return size.x;
-	}
-
-	bool     isRectangular;  ///< True if rectangular, false if circular.
-	Vector2i size;           ///< x == y if circular.
-};
-
-static ObjectShape establishTargetShape(BASE_OBJECT *psTarget);
 static void	proj_ImpactFunc(PROJECTILE *psObj);
 static void	proj_PostImpactFunc(PROJECTILE *psObj);
 static void proj_checkPeriodicalDamage(PROJECTILE *psProj);
@@ -1434,7 +1418,7 @@ int proj_GetLongRange(const WEAPON_STATS *psStats, int player)
 
 
 /***************************************************************************/
-static ObjectShape establishTargetShape(BASE_OBJECT *psTarget)
+ObjectShape establishTargetShape(BASE_OBJECT *psTarget)
 {
 	CHECK_OBJECT(psTarget);
 

--- a/src/projectile.h
+++ b/src/projectile.h
@@ -116,4 +116,21 @@ void checkProjectile(const PROJECTILE *psProjectile, const char *const location_
 #define syncDebugProjectile(psProj, ch) _syncDebugProjectile(__FUNCTION__, psProj, ch)
 void _syncDebugProjectile(const char *function, PROJECTILE const *psProj, char ch);
 
+struct ObjectShape
+{
+	ObjectShape() : isRectangular(false), size(0, 0) {}
+	ObjectShape(int radius) : isRectangular(false), size(radius, radius) {}
+	ObjectShape(int width, int breadth) : isRectangular(true), size(width, breadth) {}
+	ObjectShape(Vector2i widthBreadth) : isRectangular(true), size(widthBreadth) {}
+	int radius() const
+	{
+		return size.x;
+	}
+
+	bool     isRectangular;  ///< True if rectangular, false if circular.
+	Vector2i size;           ///< x == y if circular.
+};
+
+ObjectShape establishTargetShape(BASE_OBJECT *psTarget);
+
 #endif // __INCLUDED_SRC_PROJECTILE_H__


### PR DESCRIPTION
This is Iluvalar's patch to avoid shooting "behind" targets when the game tries to miss the target along with a few additional tweaks after some discussion to make it visually better in more cases.

Resolves #347.