### PR TITLE
GCC 32-bit compilation fixes (and CI testing)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -158,6 +158,25 @@ matrix:
         - docker run --rm -e CI -e TRAVIS -e "TRAVIS_BUILD_DIR=/code" -e TRAVIS_BRANCH -e TRAVIS_COMMIT -e TRAVIS_PULL_REQUEST_BRANCH -e TRAVIS_TAG -e MAKEFLAGS -v $(pwd):/code fedora cmake '-H.' -Bbuild -DCMAKE_BUILD_TYPE=RelWithDebInfo -DWZ_ENABLE_WARNINGS:BOOL=ON -G"Ninja"
         - docker run --rm -e CI -e TRAVIS -e "TRAVIS_BUILD_DIR=/code" -e TRAVIS_BRANCH -e TRAVIS_COMMIT -e TRAVIS_PULL_REQUEST_BRANCH -e TRAVIS_TAG -e MAKEFLAGS -v $(pwd):/code fedora cmake --build build
 
+    # Build for Fedora :LATEST (CMake) (GCC) (32-bit -m32 cross-compile)
+    - name: "Fedora :LATEST (CMake) [GCC -m32]"
+      language: cpp
+      compiler: gcc
+      sudo: required
+      services:
+        - docker
+      install:
+        - cd docker/fedora-latest-m32/
+        - docker build -t fedora .
+        - cd ../..
+      script:
+        - export MAKEFLAGS="-j$((`grep -c ^processor /proc/cpuinfo`*2))"
+        # Must supply the TRAVIS environment variables to the docker container so autorevision properly receives the revision info from Travis
+        # To do this, append the following to the pertinent lines after —rm:
+        # -e CI -e TRAVIS -e "TRAVIS_BUILD_DIR=/code" -e TRAVIS_BRANCH -e TRAVIS_COMMIT -e TRAVIS_PULL_REQUEST_BRANCH -e TRAVIS_TAG
+        - docker run --rm -e CI -e TRAVIS -e "TRAVIS_BUILD_DIR=/code" -e TRAVIS_BRANCH -e TRAVIS_COMMIT -e TRAVIS_PULL_REQUEST_BRANCH -e TRAVIS_TAG -e MAKEFLAGS -v $(pwd):/code fedora cmake '-H.' -Bbuild -DCMAKE_TOOLCHAIN_FILE=build_tools/ci/cmake/Toolchain-Linux-cross-m32.cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DWZ_ENABLE_WARNINGS:BOOL=ON -G"Ninja"
+        - docker run --rm -e CI -e TRAVIS -e "TRAVIS_BUILD_DIR=/code" -e TRAVIS_BRANCH -e TRAVIS_COMMIT -e TRAVIS_PULL_REQUEST_BRANCH -e TRAVIS_TAG -e MAKEFLAGS -v $(pwd):/code fedora cmake --build build
+
     # Build for macOS (CMake)
     - name: "macOS (CMake) [Xcode 8.3, macOS 10.12 SDK]"
       language: objective-c

--- a/build_tools/ci/cmake/Toolchain-Linux-cross-m32.cmake
+++ b/build_tools/ci/cmake/Toolchain-Linux-cross-m32.cmake
@@ -1,0 +1,25 @@
+# Toolchain for cross-compiling i686 (32-bit) on 64-bit Linux
+
+set(CMAKE_SYSTEM_NAME Linux)
+set(CMAKE_SYSTEM_PROCESSOR "i686")
+
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -m32" CACHE STRING "C compiler flags" FORCE)
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -m32" CACHE STRING "C++ compiler flags" FORCE)
+
+set(LIB32 "/usr/lib") # Fedora
+
+set(CMAKE_FIND_ROOT_PATH "${LIB32}" CACHE STRING "Find root path" FORCE)
+
+#set(CMAKE_LIBRARY_PATH "${LIB32}" CACHE STRING "Library search path" FORCE)
+
+set(CMAKE_EXE_LINKER_FLAGS "-m32 -L${LIB32}" CACHE STRING "Executable linker flags" FORCE)
+set(CMAKE_SHARED_LINKER_FLAGS "-m32 -L${LIB32}" CACHE STRING "Shared library linker flags" FORCE)
+set(CMAKE_MODULE_LINKER_FLAGS "-m32 -L${LIB32}" CACHE STRING "Module linker flags" FORCE)
+
+# Point pkgconfig at 32-bit .pc files first, falling back to regular system .pc files
+if(EXISTS "${LIB32}/pkgconfig")
+	set(ENV{PKG_CONFIG_LIBDIR} "${LIB32}/pkgconfig:/usr/share/pkgconfig:/usr/lib/pkgconfig:/usr/lib64/pkgconfig")
+endif()
+
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE BOTH)

--- a/docker/fedora-latest-m32/Dockerfile
+++ b/docker/fedora-latest-m32/Dockerfile
@@ -1,0 +1,16 @@
+FROM fedora:latest
+
+RUN cat /etc/fedora-release
+
+RUN dnf -y update && dnf clean all
+RUN dnf -y install git gcc gcc-c++ cmake ninja-build p7zip gettext rubygem-asciidoctor \
+ && dnf clean all
+
+# Install WZ dependencies - 32-bit (i686, for cross-compile)
+RUN dnf -y install glibc-devel.i686 \
+ && dnf -y install qt5-qtbase-devel.i686 qt5-qtscript-devel.i686 libpng-devel.i686 SDL2-devel.i686 openal-soft-devel.i686 physfs-devel.i686 libogg-devel.i686 libvorbis-devel.i686 libtheora-devel.i686 glew-devel.i686 freetype-devel.i686 harfbuzz-devel.i686 \
+ && dnf clean all
+
+WORKDIR /code
+CMD ["/bin/sh"]
+

--- a/docker/fedora-latest/Dockerfile
+++ b/docker/fedora-latest/Dockerfile
@@ -4,7 +4,11 @@ RUN cat /etc/fedora-release
 
 RUN dnf -y update && dnf clean all
 RUN dnf -y install git gcc gcc-c++ cmake ninja-build p7zip gettext rubygem-asciidoctor \
- && dnf -y install qt5-qtbase-devel qt5-qtscript-devel libpng-devel SDL2-devel openal-soft-devel physfs-devel libvorbis-devel libtheora-devel glew-devel freetype-devel harfbuzz-devel && dnf clean all
+ && dnf clean all
+
+# Install WZ dependencies
+RUN dnf -y install qt5-qtbase-devel qt5-qtscript-devel libpng-devel SDL2-devel openal-soft-devel physfs-devel libogg-devel libvorbis-devel libtheora-devel glew-devel freetype-devel harfbuzz-devel \
+ && dnf clean all
 
 WORKDIR /code
 CMD ["/bin/sh"]

--- a/lib/exceptionhandler/CMakeLists.txt
+++ b/lib/exceptionhandler/CMakeLists.txt
@@ -4,25 +4,22 @@ project (exception-handler CXX)
 file(GLOB HEADERS "*.h")
 set(SRC "dumpinfo.cpp" "exceptionhandler.cpp")
 
-if(CMAKE_SYSTEM_NAME MATCHES "Windows")
-	if("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU" AND ${CMAKE_CROSSCOMPILING})
-		# Cross-compiling for Windows with MINGW
-		list(APPEND SRC "exchndl_mingw.cpp")
-	else()
-		# Compiling with MSVC (etc) on Windows
-		list(APPEND SRC "3rdparty/StackWalker.cpp")
-		list(APPEND SRC "exchndl_win.cpp")
-	endif()
-endif()
-
 add_library(exception-handler STATIC ${HEADERS} ${SRC})
 set_property(TARGET exception-handler PROPERTY FOLDER "lib")
 if(WZ_TARGET_ADDITIONAL_PROPERTIES)
 	SET_TARGET_PROPERTIES(exception-handler PROPERTIES ${WZ_TARGET_ADDITIONAL_PROPERTIES})
 endif()
-if("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU" AND ${CMAKE_CROSSCOMPILING})
-  target_link_libraries(exception-handler PRIVATE bfd iberty)
-elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "MSVC")
-  target_link_libraries(exception-handler PRIVATE dbghelp version shlwapi)
+
+if(CMAKE_SYSTEM_NAME MATCHES "Windows")
+	if("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU" AND ${CMAKE_CROSSCOMPILING})
+		# Cross-compiling for Windows with MINGW
+		target_sources(exception-handler PRIVATE "exchndl_mingw.cpp")
+		target_link_libraries(exception-handler PRIVATE bfd iberty)
+	else()
+		# Compiling with MSVC (etc) on Windows
+		target_sources(exception-handler PRIVATE "3rdparty/StackWalker.cpp" "exchndl_win.cpp")
+		target_link_libraries(exception-handler PRIVATE dbghelp version shlwapi)
+	endif()
 endif()
+
 target_link_libraries(exception-handler PRIVATE framework)

--- a/lib/framework/wzconfig.cpp
+++ b/lib/framework/wzconfig.cpp
@@ -32,7 +32,7 @@ WzConfig::~WzConfig()
 {
 	if (mWarning == ReadAndWrite)
 	{
-		ASSERT(mObjStack.empty(), "Some json groups have not been closed, stack size %lu.", mObjStack.size());
+		ASSERT(mObjStack.empty(), "Some json groups have not been closed, stack size %zu.", mObjStack.size());
 		std::ostringstream stream;
 		stream << mRoot.dump(4) << std::endl;
 		std::string jsonString = stream.str();

--- a/lib/framework/wzstring.cpp
+++ b/lib/framework/wzstring.cpp
@@ -48,7 +48,7 @@ std::vector<WzUniCodepoint> WzUniCodepoint::caseFolded() const
 	if (retVal < 0)
 	{
 		// case folding failed
-		ASSERT(retVal > 0, "Case folding attempt failed with error code: %ld", retVal);
+		ASSERT(retVal > 0, "Case folding attempt failed with error code: %" PRIdPTR"", retVal);
 		return std::vector<WzUniCodepoint>();
 	}
 	std::vector<WzUniCodepoint> resultCodepoints;

--- a/lib/sdl/CMakeLists.txt
+++ b/lib/sdl/CMakeLists.txt
@@ -74,8 +74,6 @@ endif()
 
 target_link_libraries(sdl-backend PRIVATE Qt5::Core Qt5::Widgets)
 
-if("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU")
-  if(${CMAKE_CROSSCOMPILING})
+if((CMAKE_SYSTEM_NAME MATCHES "Windows") AND ("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU") AND ${CMAKE_CROSSCOMPILING})
     target_compile_definitions(sdl-backend PRIVATE "QT_STATICPLUGIN")
-  endif()
 endif()

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -5706,7 +5706,7 @@ bool loadSaveFeature2(const char *pFileName)
 	}
 	WzConfig ini(pFileName, WzConfig::ReadOnly);
 	std::vector<WzString> list = ini.childGroups();
-	debug(LOG_SAVE, "Loading new style features (%lu found)", list.size());
+	debug(LOG_SAVE, "Loading new style features (%zu found)", list.size());
 
 	for (size_t i = 0; i < list.size(); ++i)
 	{

--- a/src/qtscript.cpp
+++ b/src/qtscript.cpp
@@ -830,7 +830,7 @@ bool loadScriptStates(const char *filename)
 		else if (engine && list[i].startsWith("globals_"))
 		{
 			std::vector<WzString> keys = ini.childKeys();
-			debug(LOG_SAVE, "Loading script globals for player %d, script %s -- found %lu values",
+			debug(LOG_SAVE, "Loading script globals for player %d, script %s -- found %zu values",
 			      player, scriptName.toUtf8().constData(), keys.size());
 			for (size_t j = 0; j < keys.size(); ++j)
 			{

--- a/src/qtscriptfuncs.cpp
+++ b/src/qtscriptfuncs.cpp
@@ -921,7 +921,7 @@ bool loadLabels(const char *filename)
 	WzConfig ini(filename, WzConfig::ReadOnly);
 	labels.clear();
 	std::vector<WzString> list = ini.childGroups();
-	debug(LOG_SAVE, "Loading %lu labels...", list.size());
+	debug(LOG_SAVE, "Loading %zu labels...", list.size());
 	for (int i = 0; i < list.size(); ++i)
 	{
 		ini.beginGroup(list[i]);

--- a/src/template.cpp
+++ b/src/template.cpp
@@ -208,7 +208,7 @@ bool loadTemplateCommon(WzConfig &ini, DROID_TEMPLATE &outputTemplate)
 	if (!droidTemplate_LoadPartByName(COMP_CONSTRUCT, ini.value("construct", WzString("ZNULLCONSTRUCT")).toWzString(), design)) return false;
 
 	std::vector<WzString> weapons = ini.value("weapons").toWzStringList();
-	ASSERT(weapons.size() <= MAX_WEAPONS, "Number of weapons (%lu) exceeds MAX_WEAPONS (%d)", weapons.size(), MAX_WEAPONS);
+	ASSERT(weapons.size() <= MAX_WEAPONS, "Number of weapons (%zu) exceeds MAX_WEAPONS (%d)", weapons.size(), MAX_WEAPONS);
 	design.numWeaps = (weapons.size() <= MAX_WEAPONS) ? (int8_t)weapons.size() : MAX_WEAPONS;
 	if (!droidTemplate_LoadWeapByName(0, (weapons.size() >= 1) ? weapons[0] : "ZNULLWEAPON", design)) return false;
 	if (!droidTemplate_LoadWeapByName(1, (weapons.size() >= 2) ? weapons[1] : "ZNULLWEAPON", design)) return false;


### PR DESCRIPTION
- Fix GCC 32-bit portability / compilation issues
- CI: Test a 32-bit cross-compile on `fedora:latest` (i.e. GCC's `-m32` option)
- CMake: Fixes for cross-compilation targeting non-Windows platforms