### PR TITLE
Tutorial updates

### DIFF
--- a/data/base/script/tutorial.js
+++ b/data/base/script/tutorial.js
@@ -3,6 +3,7 @@ include("script/campaign/templates.js");
 var consoleVar;
 var tutState;
 var didTheyHelpBuildGen;
+var producedUnits;
 
 //Alias for button
 const CLOSE_BUTTON = 0;
@@ -85,18 +86,30 @@ function increaseTutorialState()
 function grantStartTech()
 {
 	const TECH = [
-		"R-Vehicle-Body01", "R-Sys-Spade1Mk1", "R-Vehicle-Prop-Wheels"
+		"R-Vehicle-Body01", "R-Vehicle-Prop-Wheels"
 	];
 
 	camCompleteRequiredResearch(TECH, CAM_HUMAN_PLAYER);
 }
 
-function eventDroidBuilt()
+function eventDroidBuilt(droid, structure)
 {
 	if (tutState === 25)
 	{
-		increaseTutorialState();
-		setReticuleButton(PRODUCTION_BUTTON, _("Manufacture - build factory first"), "", "");
+		if (droid.droidType === DROID_CONSTRUCT)
+		{
+			producedUnits.truck = true;
+		}
+		else
+		{
+			producedUnits.tank = true;
+		}
+
+		if (producedUnits.truck === true && producedUnits.tank === true)
+		{
+			increaseTutorialState();
+			setReticuleButton(PRODUCTION_BUTTON, _("Manufacture - build factory first"), "", "");
+		}
 	}
 }
 
@@ -106,6 +119,8 @@ function eventDeliveryPointMoved()
 	{
 		increaseTutorialState();
 		setReticuleButton(PRODUCTION_BUTTON, _("Manufacture (F1)"), "image_manufacture_up.png", "image_manufacture_down.png");
+		// Change: Allow player to produce the truck.
+		completeResearch("R-Sys-Spade1Mk1", CAM_HUMAN_PLAYER);
 		setReticuleFlash(PRODUCTION_BUTTON, true);
 	}
 }
@@ -445,6 +460,10 @@ function eventStartLevel()
 	var startpos = getObject("startPosition");
 	tutState = 0;
 	didTheyHelpBuildGen = false;
+	producedUnits = {
+		tank: false,
+		truck: false,
+	};
 	setUpConsoleAndAudioVar();
 
 	centreView(startpos.x, startpos.y);
@@ -463,7 +482,6 @@ function eventStartLevel()
 
 	setMiniMap(true);
 	setDesign(false);
-	removeTemplate("ConstructionDroid");
 	removeTemplate("ViperLtMGWheels");
 
 	setReticuleButton(CLOSE_BUTTON, _("Close"), "", "");

--- a/data/base/script/tutorial.js
+++ b/data/base/script/tutorial.js
@@ -36,8 +36,8 @@ function setUpConsoleAndAudioVar()
 		{"audio": "tut10.ogg", "clear": false, "message": _("To increase your build rate, select your second truck"), "state": 5, "wait": 0},
 		{"audio": "tut11.ogg", "clear": false, "message": _("Now left click the power generator site"), "state": 6, "wait": 2},
 		{"audio": "tut12.ogg", "clear": false, "message": _("The other truck will now help to build the power generator"), "state": 7, "wait": 2},
-		{"audio": "tut13.ogg", "clear": true, "message": _("During missions you need to locate and recover technologies from before the Collapse"), "state": 7, "wait": 3},
 		//==PART TWO== Power Station has been built, by whatever means
+		{"audio": "tut13.ogg", "clear": true, "message": _("During missions you need to locate and recover technologies from before the Collapse"), "state": 8, "wait": 3},
 		{"audio": "tut15.ogg", "clear": false, "message": _("Use a truck to search for the artifact indicated by the radar pulse"), "state": 8, "wait": 3, "func": "addTheArtifact"},
 		{"audio": "tut16.ogg", "clear": false, "message": _("Move the pointer over the artifact and left click to recover it"), "state": 8, "wait": 4},
 		{"audio": "tut17.ogg", "clear": false, "message": undefined, "state": 8, "wait": 3},

--- a/data/base/script/tutorial.js
+++ b/data/base/script/tutorial.js
@@ -4,6 +4,7 @@ var consoleVar;
 var tutState;
 var didTheyHelpBuildGen;
 var producedUnits;
+var firstTruckID;
 
 //Alias for button
 const CLOSE_BUTTON = 0;
@@ -275,6 +276,23 @@ function checkForPowGen()
 		{
 			setReticuleButton(BUILD_BUTTON, _("Build - manufacture constructor droids first"), "", "");
 			increaseTutorialState();
+
+			//Get the truck that is building the generator and store its ID.
+			var trucks = enumDroid(CAM_HUMAN_PLAYER, DROID_CONSTRUCT);
+			for (var i = 0, len = trucks.length; i < len; ++i)
+			{
+				var truck = trucks[i];
+				if (truck.order === DORDER_BUILD)
+				{
+					firstTruckID = truck.id;
+					break;
+				}
+			}
+
+			if (firstTruckID === 0)
+			{
+				firstTruckID = trucks[0].id;
+			}
 		}
 		else
 		{
@@ -307,7 +325,10 @@ function checkHelpBuild()
 		for (var i = 0, l = objects.length; i < l; ++i)
 		{
 			var obj = objects[i];
-			if (obj.type === DROID && obj.droidType === DROID_CONSTRUCT && obj.order === DORDER_HELPBUILD)
+			if (obj.type === DROID &&
+				obj.droidType === DROID_CONSTRUCT &&
+				(obj.order === DORDER_HELPBUILD || obj.order === DORDER_BUILD) &&
+				obj.id !== firstTruckID)
 			{
 				increaseTutorialState();
 				didTheyHelpBuildGen = true;
@@ -399,7 +420,7 @@ function eventSelectionChanged(objects)
 					enableStructure("A0ResourceExtractor", CAM_HUMAN_PLAYER);
 					increaseTutorialState();
 				}
-				else if (tut5 && obj.order !== DORDER_BUILD)
+				else if (tut5 && obj.id !== firstTruckID)
 				{
 					increaseTutorialState();
 					checkHelpBuild();
@@ -419,6 +440,7 @@ function eventStructureBuilt(structure, droid)
 	else if (tutState <= 7 && structure.stattype === POWER_GEN)
 	{
 		//Maybe they did not understand instructions. Whatever the case, move on.
+		firstTruckID = 0;
 		if (!didTheyHelpBuildGen)
 		{
 			const NEXT_STATE = 8;
@@ -460,6 +482,7 @@ function eventStartLevel()
 	var startpos = getObject("startPosition");
 	tutState = 0;
 	didTheyHelpBuildGen = false;
+	firstTruckID = 0;
 	producedUnits = {
 		tank: false,
 		truck: false,

--- a/data/base/script/tutorial.js
+++ b/data/base/script/tutorial.js
@@ -401,16 +401,17 @@ function eventStructureBuilt(structure, droid)
 	{
 		increaseTutorialState();
 	}
-	else if (tutState === 7 && structure.stattype === POWER_GEN)
+	else if (tutState <= 7 && structure.stattype === POWER_GEN)
 	{
 		//Maybe they did not understand instructions. Whatever the case, move on.
 		if (!didTheyHelpBuildGen)
 		{
-			for (var i = 0; i < 3; ++i)
+			const NEXT_STATE = 8;
+			while (consoleVar[0].state < NEXT_STATE)
 			{
 				consoleVar.shift(); //skip ahead
 			}
-			tutState = 8;
+			tutState = NEXT_STATE;
 		}
 		else
 		{


### PR DESCRIPTION
- Correctly checks if the player skipped helping to build the power generator with the other truck.
- Moves a message about technology one state later.
- Forces the player to manufacture both a truck and tank to complete the tutorial ([Original](https://github.com/Warzone2100/warzone2100/blob/9d3c2ce8dcc1c7fafcacce9d94c3661350365b7f/data/base/script/text/tutorial3.slo#L1044)).
- Prevents players from designing a truck instead of a MG tank during the design phase.

Resolves #379.