### PR TITLE
Change difficulty of campaign mission Alpha 1

### DIFF
--- a/data/base/script/campaign/cam1a.js
+++ b/data/base/script/campaign/cam1a.js
@@ -136,7 +136,19 @@ function eventStartLevel()
 	centreView(startpos.x, startpos.y);
 	setNoGoArea(lz.x, lz.y, lz.x2, lz.y2, CAM_HUMAN_PLAYER);
 
-	setPower(PLAYER_POWER, CAM_HUMAN_PLAYER);
+	if (difficulty === HARD)
+	{
+		setPower(600, CAM_HUMAN_PLAYER);
+	}
+	else if (difficulty === INSANE)
+	{
+		setPower(300, CAM_HUMAN_PLAYER);
+	}
+	else
+	{
+		setPower(PLAYER_POWER, CAM_HUMAN_PLAYER);
+	}
+
 	setAlliance(6, 7, true);
 
 	enableBaseStructures();

--- a/data/base/script/campaign/cam1a.js
+++ b/data/base/script/campaign/cam1a.js
@@ -17,7 +17,10 @@ camAreaEvent("launchScavAttack", function(droid)
 		morale: 50
 	});
 	// Activate mission timer, unlike the original campaign.
-	setMissionTime(camChangeOnDiff(camHoursToSeconds(1)));
+	if (difficulty !== HARD && difficulty !== INSANE)
+	{
+		setMissionTime(camChangeOnDiff(camHoursToSeconds(1)));
+	}
 });
 
 function runAway()
@@ -141,7 +144,18 @@ function eventStartLevel()
 
 	// Give player briefing.
 	hackAddMessage("CMB1_MSG", CAMP_MSG, CAM_HUMAN_PLAYER, false);
-	setMissionTime(-1);
+	if (difficulty === HARD)
+	{
+		setMissionTime(camMinutesToSeconds(40));
+	}
+	else if (difficulty === INSANE)
+	{
+		setMissionTime(camMinutesToSeconds(30));
+	}
+	else
+	{
+		setMissionTime(-1); // will start mission timer later
+	}
 
 	// Feed libcampaign.js with data to do the rest.
 	camSetEnemyBases({

--- a/data/base/script/tutorial.js
+++ b/data/base/script/tutorial.js
@@ -505,7 +505,6 @@ function eventStartLevel()
 
 	setMiniMap(true);
 	setDesign(false);
-	removeTemplate("ViperLtMGWheels");
 
 	setReticuleButton(CLOSE_BUTTON, _("Close"), "", "");
 	setReticuleButton(PRODUCTION_BUTTON, _("Manufacture - build factory first"), "", "");

--- a/data/base/stats/templates.json
+++ b/data/base/stats/templates.json
@@ -1537,7 +1537,6 @@
         ]
     },
     "ViperLtMGWheels": {
-        "available": true,
         "body": "Body1REC",
         "id": "ViperLtMGWheels",
         "name": "Machinegun Viper Wheels",


### PR DESCRIPTION
The Machinegun template should not be available in Alpha 1 before a HQ
has been built. This change may become unnecessary if #378 included it.

With campaign difficulty levels "Hard" and "Insane", mission timers
* start instantly, instead of waiting for the player to move into the
  scavengers' area close to the power resource in his base
* limit the available time to
  * 40 minutes for difficulty "Hard"
  * 30 minutes for difficulty "Insane"

Starting power has been reduced to
* 600 oil for difficulty "Hard"
* 300 oil for difficulty "Insane".
  This is sufficient to build a power generator, a HQ and a factory.
  However, it also requires the player to manage his resources much more
  carefully. Still, the mission can be comfortably won in 20 minutes.
  At http://forums.wz2100.net/viewtopic.php?f=6&p=144657#p144657 you can
  find a strategy to win in 17:25 minutes.