### PR TITLE
[WIP] Change unit limits for campaign

### DIFF
--- a/data/base/script/rules.js
+++ b/data/base/script/rules.js
@@ -265,7 +265,20 @@ function eventGameInit()
 
 function setLimits()
 {
-	setDroidLimit(selectedPlayer, 100, DROID_ANY);
+	var armySize = 80;
+	switch (difficulty)
+	{
+		case EASY:
+			armySize = 100;
+			break;
+		case HARD:
+			armySize = 60;
+			break;
+		case INSANE:
+			armySize = 40;
+			break;
+	}
+	setDroidLimit(selectedPlayer, armySize, DROID_ANY);
 	setDroidLimit(selectedPlayer, 10, DROID_COMMAND);
 	setDroidLimit(selectedPlayer, 15, DROID_CONSTRUCT);
 


### PR DESCRIPTION
This is a new edition of [ticket:4862](http://developer.wz2100.net/ticket/4862).
The change has also been discussed in the campaign development thread at
http://forums.wz2100.net/viewtopic.php?f=6&t=15119.

Forum user xNEXTx (or Next67 here on GitHub) suggested that the campaign
unit limit should be reduced to 40, as it was in the original campaign
of PlayStation days. This should make the campaign more challenging.

That limit was seen as overly harsh on the players by some testers.
Thus, unit limits should depend on campaign difficulty:
 * Easy: 100 (unchanged)
 * Medium: 80
 * Hard: 60
 * Insane: 40

These limits also apply to the tutorial "Fast Play".