### PR TITLE
Fix clients not being sent mods when previewing 3rd party maps

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -397,7 +397,7 @@ bool rebuildSearchPath(searchPathMode mode, bool force, const char *current_map)
 				// Add global and multiplay mods
 				PHYSFS_mount(curSearchPath->path, NULL, PHYSFS_APPEND);
 				addSubdirs(curSearchPath->path, "mods/music", PHYSFS_APPEND, nullptr, false);
-				if (NetPlay.isHost || !NetPlay.bComms)
+				if (NetPlay.isHost || !NetPlay.bComms || ingame.bHostSetup)
 				{
 					addSubdirs(curSearchPath->path, "mods/global", PHYSFS_APPEND, use_override_mods ? &override_mods : &global_mods, true);
 					addSubdirs(curSearchPath->path, "mods", PHYSFS_APPEND, use_override_mods ? &override_mods : &global_mods, true);


### PR DESCRIPTION
Previewing 3rd party maps causes a search path cleanup (and once again when switching back to in-game maps afterwards) so they need to be added again.

Resolves #336.

Maybe?