### PR TITLE
Fix some `-Wcast-align` warnings

### DIFF
--- a/lib/framework/frame.h
+++ b/lib/framework/frame.h
@@ -50,11 +50,9 @@
 #include "trig.h"
 #include "cursors.h"
 
-#if __clang__
+#if defined(__clang__)
 // workaround LLVM bug https://bugs.llvm.org//show_bug.cgi?id=21629
 #pragma clang diagnostic ignored "-Wmissing-braces"
-// workaround bad implementations in our code
-#pragma clang diagnostic ignored "-Wcast-align"
 #endif
 
 #define REALCONCAT(x, y) x ## y

--- a/lib/netplay/netplay.cpp
+++ b/lib/netplay/netplay.cpp
@@ -845,6 +845,14 @@ static bool NETrecvGAMESTRUCT(GAMESTRUCT *ourgamestruct)
 	unsigned int i;
 	ssize_t result = 0;
 
+	auto pop32 = [&]() -> uint32_t {
+		uint32_t value = 0;
+		memcpy(&value, buffer, sizeof(value));
+		value = ntohl(value);
+		buffer += sizeof(value);
+		return value;
+	};
+
 	// Read a GAMESTRUCT from the connection
 	result = readAll(tcp_socket, buf, sizeof(buf), NET_TIMEOUT_DELAY);
 	bool failed = false;
@@ -867,31 +875,25 @@ static bool NETrecvGAMESTRUCT(GAMESTRUCT *ourgamestruct)
 
 	// Now dump the data into the game struct
 	// Copy 32bit large big endian numbers
-	ourgamestruct->GAMESTRUCT_VERSION = ntohl(*(uint32_t *)buffer);
-	buffer += sizeof(uint32_t);
+	ourgamestruct->GAMESTRUCT_VERSION = pop32();
 	// Copy a string
 	sstrcpy(ourgamestruct->name, buffer);
 	buffer += sizeof(ourgamestruct->name);
 
 	// Copy 32bit large big endian numbers
-	ourgamestruct->desc.dwSize = ntohl(*(int32_t *)buffer);
-	buffer += sizeof(int32_t);
-	ourgamestruct->desc.dwFlags = ntohl(*(int32_t *)buffer);
-	buffer += sizeof(int32_t);
+	ourgamestruct->desc.dwSize = pop32();
+	ourgamestruct->desc.dwFlags = pop32();
 
 	// Copy yet another string
 	sstrcpy(ourgamestruct->desc.host, buffer);
 	buffer += sizeof(ourgamestruct->desc.host);
 
 	// Copy 32bit large big endian numbers
-	ourgamestruct->desc.dwMaxPlayers = ntohl(*(int32_t *)buffer);
-	buffer += sizeof(int32_t);
-	ourgamestruct->desc.dwCurrentPlayers = ntohl(*(int32_t *)buffer);
-	buffer += sizeof(int32_t);
+	ourgamestruct->desc.dwMaxPlayers = pop32();
+	ourgamestruct->desc.dwCurrentPlayers = pop32();
 	for (i = 0; i < ARRAY_SIZE(ourgamestruct->desc.dwUserFlags); ++i)
 	{
-		ourgamestruct->desc.dwUserFlags[i] = ntohl(*(int32_t *)buffer);
-		buffer += sizeof(int32_t);
+		ourgamestruct->desc.dwUserFlags[i] = pop32();
 	}
 
 	// Copy a string
@@ -922,24 +924,15 @@ static bool NETrecvGAMESTRUCT(GAMESTRUCT *ourgamestruct)
 	buffer += sizeof(ourgamestruct->modlist);
 
 	// Copy 32bit large big endian numbers
-	ourgamestruct->game_version_major = ntohl(*(uint32_t *)buffer);
-	buffer += sizeof(uint32_t);
-	ourgamestruct->game_version_minor = ntohl(*(uint32_t *)buffer);
-	buffer += sizeof(uint32_t);
-	ourgamestruct->privateGame = ntohl(*(uint32_t *)buffer);
-	buffer += sizeof(uint32_t);
-	ourgamestruct->pureMap = ntohl(*(uint32_t *)buffer);
-	buffer += sizeof(uint32_t);
-	ourgamestruct->Mods = ntohl(*(uint32_t *)buffer);
-	buffer += sizeof(uint32_t);
-	ourgamestruct->gameId = ntohl(*(uint32_t *)buffer);
-	buffer += sizeof(uint32_t);
-	ourgamestruct->limits = ntohl(*(uint32_t *)buffer);
-	buffer += sizeof(uint32_t);
-	ourgamestruct->future3 = ntohl(*(uint32_t *)buffer);
-	buffer += sizeof(uint32_t);
-	ourgamestruct->future4 = ntohl(*(uint32_t *)buffer);
-	buffer += sizeof(uint32_t);
+	ourgamestruct->game_version_major = pop32();
+	ourgamestruct->game_version_minor = pop32();
+	ourgamestruct->privateGame = pop32();
+	ourgamestruct->pureMap = pop32();
+	ourgamestruct->Mods = pop32();
+	ourgamestruct->gameId = pop32();
+	ourgamestruct->limits = pop32();
+	ourgamestruct->future3 = pop32();
+	ourgamestruct->future4 = pop32();
 
 	debug(LOG_NET, "received GAMESTRUCT");
 
@@ -2957,9 +2950,13 @@ bool NETjoinGame(const char *host, uint32_t port, const char *playername)
 
 	// Send NETCODE_VERSION_MAJOR and NETCODE_VERSION_MINOR
 	p_buffer = buffer;
-	*(int32_t *)p_buffer = htonl(NETCODE_VERSION_MAJOR);
-	p_buffer += sizeof(uint32_t);
-	*(int32_t *)p_buffer = htonl(NETCODE_VERSION_MINOR);
+	auto pushi32 = [&](int32_t value) {
+		int32_t swapped = htonl(value);
+		memcpy(p_buffer, &swapped, sizeof(swapped));
+		p_buffer += sizeof(swapped);
+	};
+	pushi32(NETCODE_VERSION_MAJOR);
+	pushi32(NETCODE_VERSION_MINOR);
 
 	if (writeAll(tcp_socket, buffer, sizeof(buffer)) == SOCKET_ERROR
 	    || readAll(tcp_socket, &result, sizeof(result), 1500) != sizeof(result))

--- a/lib/netplay/netsocket.cpp
+++ b/lib/netplay/netsocket.cpp
@@ -220,7 +220,6 @@ static int addressToText(const struct sockaddr *addr, char *buf, size_t size)
 	case AF_INET6:
 		{
 
-			const uint16_t *address = (const uint16_t *) & (reinterpret_cast<const sockaddr_in6 *>(addr))->sin6_addr.s6_addr;
 			// Check to see if this is really a IPv6 address
 			const struct sockaddr_in6 *mappedIP = reinterpret_cast<const sockaddr_in6 *>(addr);
 			if (IN6_IS_ADDR_V4MAPPED(&mappedIP->sin6_addr))
@@ -234,6 +233,10 @@ static int addressToText(const struct sockaddr *addr, char *buf, size_t size)
 			}
 			else
 			{
+				static_assert(sizeof(in6_addr::s6_addr) == 16, "Standard expects in6_addr structure that contains member s6_addr[16], a 16-element array of uint8_t");
+				const uint8_t *address_u8 = &((reinterpret_cast<const sockaddr_in6 *>(addr))->sin6_addr.s6_addr[0]);
+				uint16_t address[8] = {0};
+				memcpy(&address, address_u8, sizeof(uint8_t) * 16);
 				return snprintf(buf, size,
 								"%hx:%hx:%hx:%hx:%hx:%hx:%hx:%hx",
 								ntohs(address[0]),

--- a/lib/script/codeprint.cpp
+++ b/lib/script/codeprint.cpp
@@ -214,7 +214,14 @@ void cpPrintProgram(SCRIPT_CODE *psProg)
 	}
 
 	ip = psProg->pCode;
+#if defined(__clang__)
+	#pragma clang diagnostic push
+	#pragma clang diagnostic ignored "-Wcast-align"
+#endif
 	end = (INTERP_VAL *)((UBYTE *)ip + psProg->size);
+#if defined(__clang__)
+	#pragma clang diagnostic pop
+#endif
 	triggerCode = (psProg->numTriggers > 0);
 
 	opcode = (OPCODE)(ip->v.ival >> OPCODE_SHIFT);

--- a/src/design.cpp
+++ b/src/design.cpp
@@ -67,6 +67,10 @@
 #include "multiplay.h"
 #include "qtscript.h"
 
+#if defined(__clang__)
+#pragma clang diagnostic ignored "-Wcast-align"	// TODO: FIXME!
+#endif
+
 
 #define MAX_DESIGN_COMPONENTS 40		// Max number of stats the design screen can cope with.
 #define MAX_SYSTEM_COMPONENTS 65535

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -95,6 +95,10 @@
 #include "multimenu.h"
 #include "console.h"
 
+#if defined(__clang__)
+#pragma clang diagnostic ignored "-Wcast-align"	// TODO: FIXME!
+#endif
+
 
 void gameScreenSizeDidChange(unsigned int oldWidth, unsigned int oldHeight, unsigned int newWidth, unsigned int newHeight)
 {

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -928,17 +928,14 @@ failure:
 /* Save the map data */
 bool mapSave(char **ppFileData, UDWORD *pFileSize)
 {
-	MAP_SAVEHEADER	*psHeader = nullptr;
-	MAP_SAVETILE	*psTileData = nullptr;
-	MAPTILE	*psTile = nullptr;
-	GATEWAY_SAVEHEADER *psGateHeader = nullptr;
-	GATEWAY_SAVE *psGate = nullptr;
-	SDWORD	numGateways = gwNumGateways();
+	UDWORD	numGateways = gwNumGateways();
 
 	/* Allocate the data buffer */
+	static_assert(SAVE_HEADER_SIZE == (sizeof(char) * 4) + (sizeof(UDWORD) * 3), "SAVE_HEADER_SIZE doesn't match?");
+	static_assert(SAVE_TILE_SIZE == sizeof(UWORD) + sizeof(UBYTE), "SAVE_TILE_SIZE doesn't match?");
 	*pFileSize = SAVE_HEADER_SIZE + mapWidth * mapHeight * SAVE_TILE_SIZE;
 	// Add on the size of the gateway data.
-	*pFileSize += sizeof(GATEWAY_SAVEHEADER) + sizeof(GATEWAY_SAVE) * numGateways;
+	*pFileSize += (sizeof(UDWORD) * 2) + ((sizeof(UBYTE) * 4) * numGateways);
 
 	*ppFileData = (char *)malloc(*pFileSize);
 	if (*ppFileData == nullptr)
@@ -947,67 +944,78 @@ bool mapSave(char **ppFileData, UDWORD *pFileSize)
 		abort();
 		return false;
 	}
+	char *pCurrFileData = *ppFileData;
+
+	auto push_uword = [&](UWORD value) {
+		endian_uword(&value);
+		memcpy(pCurrFileData, &value, sizeof(value));
+		pCurrFileData += sizeof(value);
+		ASSERT(pCurrFileData - *ppFileData <= *pFileSize, "Buffer overrun (buffer size: %" PRIu32") (writing to: %" PRIu32")", *pFileSize, static_cast<uint32_t>(pCurrFileData - *ppFileData));
+	};
+	auto push_udword = [&](UDWORD value) {
+		endian_udword(&value);
+		memcpy(pCurrFileData, &value, sizeof(value));
+		pCurrFileData += sizeof(value);
+		ASSERT(pCurrFileData - *ppFileData <= *pFileSize, "Buffer overrun (buffer size: %" PRIu32") (writing to: %" PRIu32")", *pFileSize, static_cast<uint32_t>(pCurrFileData - *ppFileData));
+	};
 
 	/* Put the file header on the file */
-	psHeader = (MAP_SAVEHEADER *)*ppFileData;
-	psHeader->aFileType[0] = 'm';
-	psHeader->aFileType[1] = 'a';
-	psHeader->aFileType[2] = 'p';
-	psHeader->aFileType[3] = ' ';
-	psHeader->version = CURRENT_VERSION_NUM;
-	psHeader->width = mapWidth;
-	psHeader->height = mapHeight;
+	char aFileType[4];
+	aFileType[0] = 'm';
+	aFileType[1] = 'a';
+	aFileType[2] = 'p';
+	aFileType[3] = ' ';
+	memcpy(pCurrFileData, aFileType, sizeof(aFileType));
+	pCurrFileData += sizeof(aFileType);
 
-	/* MAP_SAVEHEADER */
-	endian_udword(&psHeader->version);
-	endian_udword(&psHeader->width);
-	endian_udword(&psHeader->height);
+	push_udword(CURRENT_VERSION_NUM);
+	push_udword(mapWidth);
+	push_udword(mapHeight);
 
 	/* Put the map data into the buffer */
-	psTileData = (MAP_SAVETILE *)(*ppFileData + SAVE_HEADER_SIZE);
-	psTile = psMapTiles;
+	MAPTILE	*psTile = psMapTiles;
 	for (int i = 0; i < mapWidth * mapHeight; i++)
 	{
-		psTileData->texture = psTile->texture;
+		UWORD	texture;
+		UBYTE	height;
+
+		texture = psTile->texture;
 		if (terrainType(psTile) == TER_WATER)
 		{
-			psTileData->height = (psTile->waterLevel + world_coord(1) / 3) / ELEVATION_SCALE;
+			height = (psTile->waterLevel + world_coord(1) / 3) / ELEVATION_SCALE;
 		}
 		else
 		{
-			psTileData->height = psTile->height / ELEVATION_SCALE;
+			height = psTile->height / ELEVATION_SCALE;
 		}
 
-		/* MAP_SAVETILE */
-		endian_uword(&psTileData->texture);
+		push_uword(texture);
+		memcpy(pCurrFileData, &height, sizeof(height)); pCurrFileData += sizeof(height);
 
-		psTileData = (MAP_SAVETILE *)((UBYTE *)psTileData + SAVE_TILE_SIZE);
 		psTile++;
 	}
 
 	// Put the gateway header.
-	psGateHeader = (GATEWAY_SAVEHEADER *)psTileData;
-	psGateHeader->version = 1;
-	psGateHeader->numGateways = numGateways;
-
-	/* GATEWAY_SAVEHEADER */
-	endian_udword(&psGateHeader->version);
-	endian_udword(&psGateHeader->numGateways);
-
-	psGate = (GATEWAY_SAVE *)(psGateHeader + 1);
+	UDWORD version = 1;
+	push_udword(version);
+	push_udword(numGateways);
 
 	// Put the gateway data.
+	UBYTE	x0, y0, x1, y1;
 	for (auto psCurrGate : gwGetGateways())
 	{
-		psGate->x0 = psCurrGate->x1;
-		psGate->y0 = psCurrGate->y1;
-		psGate->x1 = psCurrGate->x2;
-		psGate->y1 = psCurrGate->y2;
-		ASSERT(psGate->x0 == psGate->x1 || psGate->y0 == psGate->y1, "Invalid gateway coordinates (%d, %d, %d, %d)",
-		       psGate->x0, psGate->y0, psGate->x1, psGate->y1);
-		ASSERT(psGate->x0 < mapWidth && psGate->y0 < mapHeight && psGate->x1 < mapWidth && psGate->y1 < mapHeight,
+		x0 = psCurrGate->x1;
+		y0 = psCurrGate->y1;
+		x1 = psCurrGate->x2;
+		y1 = psCurrGate->y2;
+		ASSERT(x0 == x1 || y0 == y1, "Invalid gateway coordinates (%d, %d, %d, %d)",
+		       x0, y0, x1, y1);
+		ASSERT(x0 < mapWidth && y0 < mapHeight && x1 < mapWidth && y1 < mapHeight,
 		       "Bad gateway dimensions for savegame");
-		psGate++;
+		memcpy(pCurrFileData, &x0, sizeof(x0)); pCurrFileData += sizeof(x0);
+		memcpy(pCurrFileData, &y0, sizeof(y0)); pCurrFileData += sizeof(y0);
+		memcpy(pCurrFileData, &x1, sizeof(x1)); pCurrFileData += sizeof(x1);
+		memcpy(pCurrFileData, &y1, sizeof(y1)); pCurrFileData += sizeof(y1);
 	}
 
 	return true;


### PR DESCRIPTION
Also, reduces the scope of files that have `-Wcast-align` disabled. (Previously, this was disabled in `lib/framework/frame.h`, so it ended up applying almost everywhere.)

`design.cpp` and `game.cpp` still require work, so they have `-Wcast-align` disabled at the top (for now).