### PR TITLE
Improve `sendMap()` performance

### DIFF
--- a/lib/netplay/netplay.cpp
+++ b/lib/netplay/netplay.cpp
@@ -2047,18 +2047,18 @@ int NETrecvFile(NETQUEUE queue)
 	return 100;		// file is nullbyte, so we are done.
 }
 
-int NETgetDownloadProgress(unsigned player)
+unsigned NETgetDownloadProgress(unsigned player)
 {
 	std::vector<WZFile> const &files = player == selectedPlayer ?
 		NetPlay.wzFiles :  // Check our own download progress.
 		NetPlay.players[player].wzFiles;  // Check their download progress (currently only works if we are the host).
 
-	int progress = 100;
+	uint32_t progress = 100;
 	for (WZFile const &file : files)
 	{
-		progress = std::min<unsigned>(progress, file.pos * 100 / std::max<unsigned>(file.size, 1));
+		progress = std::min<uint32_t>(progress, (uint32_t)((uint64_t)file.pos * 100 / (uint64_t)std::max<uint32_t>(file.size, 1)));
 	}
-	return progress;
+	return static_cast<unsigned>(progress);
 }
 
 static ssize_t readLobbyResponse(Socket *sock, unsigned int timeout)

--- a/lib/netplay/netplay.h
+++ b/lib/netplay/netplay.h
@@ -281,7 +281,7 @@ void NETflush();                                                              //
 
 int NETsendFile(WZFile &file, unsigned player);  ///< Send file chunk. Returns 100 when done.
 int NETrecvFile(NETQUEUE queue);                 ///< Receive file chunk. Returns 100 when done.
-int NETgetDownloadProgress(unsigned player);     ///< Returns 100 when done.
+unsigned NETgetDownloadProgress(unsigned player);     ///< Returns 100 when done.
 
 int NETclose();					// close current game
 int NETshutdown();					// leave the game in play.

--- a/src/multiint.cpp
+++ b/src/multiint.cpp
@@ -4356,13 +4356,13 @@ void displayPlayer(WIDGET *psWidget, UDWORD xOffset, UDWORD yOffset)
 
 	const int nameX = 32;
 
-	int downloadProgress = NETgetDownloadProgress(j);
+	unsigned downloadProgress = NETgetDownloadProgress(j);
 
 	drawBlueBox(x, y, psWidget->width(), psWidget->height());
 	if (downloadProgress != 100)
 	{
 		char progressString[MAX_STR_LENGTH];
-		ssprintf(progressString, j != selectedPlayer ? _("Sending Map: %d%% ") : _("Map: %d%% downloaded"), downloadProgress);
+		ssprintf(progressString, j != selectedPlayer ? _("Sending Map: %u%% ") : _("Map: %u%% downloaded"), downloadProgress);
 		cache.wzMainText.setText(progressString, font_regular);
 		cache.wzMainText.render(x + 5, y + 22, WZCOL_FORM_TEXT);
 		return;


### PR DESCRIPTION
`sendMap()` was effectively being throttled heavily by vsync / FPS - every call to `sendMap()` (which is once per frame), it would only call `NETsendFile(...)` once per file, which sends at most `MAX_FILE_TRANSFER_PACKET` (which is currently `2048`).

This resulted in very slow map / mod transfer times (especially noticeable for larger maps / mods).