### PR TITLE
Fixing truck template availability

### DIFF
--- a/data/base/script/campaign/cam1a.js
+++ b/data/base/script/campaign/cam1a.js
@@ -138,9 +138,6 @@ function eventStartLevel()
 
 	enableBaseStructures();
 	camCompleteRequiredResearch(PLAYER_RES, CAM_HUMAN_PLAYER);
-	// These are available without needing to build a HQ.
-	enableTemplate("ConstructionDroid");
-	enableTemplate("ViperLtMGWheels");
 
 	// Give player briefing.
 	hackAddMessage("CMB1_MSG", CAMP_MSG, CAM_HUMAN_PLAYER, false);

--- a/data/base/script/campaign/cam3-a.js
+++ b/data/base/script/campaign/cam3-a.js
@@ -232,8 +232,6 @@ function eventStartLevel()
 	setPower(PLAYER_POWER, CAM_HUMAN_PLAYER);
 	cam3Setup();
 
-	enableTemplate("ConstructionDroid");
-
 	camSetEnemyBases({
 		"NEXUS-WBase": {
 			cleanup: "westBaseCleanup",

--- a/data/base/script/fastplay/fastdemo.js
+++ b/data/base/script/fastplay/fastdemo.js
@@ -198,9 +198,6 @@ function eventStartLevel()
 	camPlayVideos("MBDEMO_MSG");
 	hackAddMessage("FAST_OBJ1", PROX_MSG, CAM_HUMAN_PLAYER, false);
 
-	enableTemplate("ConstructionDroid");
-	enableTemplate("ViperLtMGWheels");
-
 	queue("sendAttackGroup1", camSecondsToMilliseconds(10));
 	queue("sendAttackGroup2", camSecondsToMilliseconds(20));
 	queue("activateDefenders", camSecondsToMilliseconds(30));

--- a/data/base/stats/templates.json
+++ b/data/base/stats/templates.json
@@ -91,7 +91,7 @@
         "construct": "Spade1Mk1",
         "id": "BabaPickUp",
         "name": "Pick-Up Truck",
-        "type": "DROID"
+        "type": "CONSTRUCT"
     },
     "BabaRKJeep": {
         "body": "B2RKJeepBody",
@@ -309,7 +309,7 @@
         "id": "CO-M-Con-T",
         "name": "*CO-M-Con-T*",
         "propulsion": "tracked01",
-        "type": "DROID"
+        "type": "CONSTRUCT"
     },
     "CO-M-HMG-T": {
         "body": "Body6SUPP",
@@ -588,7 +588,7 @@
         "id": "CobraSpadeTracks",
         "name": "Cobra Truck",
         "propulsion": "tracked01",
-        "type": "DROID"
+        "type": "CONSTRUCT"
     },
     "ConstructionDroid": {
         "available": true,
@@ -597,7 +597,7 @@
         "id": "ConstructionDroid",
         "name": "Truck",
         "propulsion": "wheeled01",
-        "type": "DROID"
+        "type": "CONSTRUCT"
     },
     "ConstructorDroid": {
         "body": "Body1REC",
@@ -605,7 +605,7 @@
         "id": "ConstructorDroid",
         "name": "Truck",
         "propulsion": "wheeled01",
-        "type": "DROID"
+        "type": "CONSTRUCT"
     },
     "Cyb-Atmiss-GROUND": {
         "available": true,
@@ -851,7 +851,7 @@
         "id": "NP-M-CON-HalfTrack",
         "name": "*NP-M-CON-Half-track*",
         "propulsion": "HalfTrack",
-        "type": "DROID"
+        "type": "CONSTRUCT"
     },
     "NP-M-CON-Track": {
         "body": "Body8MBT",
@@ -859,7 +859,7 @@
         "id": "NP-M-CON-Track",
         "name": "*NP-M-CON-Track*",
         "propulsion": "tracked01",
-        "type": "DROID"
+        "type": "CONSTRUCT"
     },
     "NP-M-Command-Halftrack": {
         "body": "Body8MBT",
@@ -1167,7 +1167,7 @@
         "name": "*NX-M-Con-Hover*",
         "propulsion": "hover01",
         "sensor": "NavGunSensor",
-        "type": "DROID"
+        "type": "CONSTRUCT"
     },
     "NX-M-HvSam-Hover": {
         "body": "Body7ABT",
@@ -1294,7 +1294,7 @@
         "id": "P0CobraSpadeTracks",
         "name": "Cobra Truck",
         "propulsion": "tracked01",
-        "type": "DROID"
+        "type": "CONSTRUCT"
     },
     "P0PythonComTracks": {
         "body": "Body11ABT",
@@ -1323,7 +1323,7 @@
         "id": "P0cam3CobCONTrk",
         "name": "Truck",
         "propulsion": "tracked01",
-        "type": "DROID"
+        "type": "CONSTRUCT"
     },
     "P0cam3PyAsltGnTrk": {
         "body": "Body11ABT",

--- a/data/mp/multiplay/skirmish/rules.js
+++ b/data/mp/multiplay/skirmish/rules.js
@@ -378,9 +378,6 @@ function eventGameInit()
 		grantTech(TECH_THREE);
 	}
 
-	// This is the only template that should be enabled before design is allowed
-	enableTemplate("ConstructionDroid");
-
 	hackNetOn();
 	setTimer("checkEndConditions", 3000);
 	if (tilesetType === "URBAN" || tilesetType === "ROCKIES")

--- a/data/mp/stats/templates.json
+++ b/data/mp/stats/templates.json
@@ -367,7 +367,7 @@
         "construct": "Spade1Mk1",
         "id": "BabaPickUp",
         "name": "Pick-Up Truck",
-        "type": "DROID"
+        "type": "CONSTRUCT"
     },
     "BabaRKJeep": {
         "body": "B2RKJeepBody",
@@ -495,7 +495,7 @@
         "id": "CobraHoverTruck",
         "name": "Truck Cobra Hover",
         "propulsion": "hover01",
-        "type": "DROID"
+        "type": "CONSTRUCT"
     },
     "CobraHvyCnTrks": {
         "body": "Body5REC",
@@ -641,7 +641,7 @@
         "id": "CobraSpadeTracks",
         "name": "Cobra Truck",
         "propulsion": "tracked01",
-        "type": "DROID"
+        "type": "CONSTRUCT"
     },
     "CobraTrkLancer": {
         "body": "Body5REC",
@@ -660,7 +660,7 @@
         "id": "ConstructionDroid",
         "name": "Truck",
         "propulsion": "wheeled01",
-        "type": "DROID"
+        "type": "CONSTRUCT"
     },
     "ConstructorDroid": {
         "body": "Body1REC",
@@ -668,7 +668,7 @@
         "id": "ConstructorDroid",
         "name": "Truck",
         "propulsion": "wheeled01",
-        "type": "DROID"
+        "type": "CONSTRUCT"
     },
     "Cyb-Atmiss-GROUND": {
         "available": true,
@@ -1053,7 +1053,7 @@
         "id": "MantisHoverTruck",
         "name": "Truck Mantis Hover",
         "propulsion": "hover01",
-        "type": "DROID"
+        "type": "CONSTRUCT"
     },
     "MantisScourgeTracks": {
         "body": "Body12SUP",
@@ -1139,7 +1139,7 @@
         "id": "P0CobraSpadeTracks",
         "name": "Cobra Truck",
         "propulsion": "tracked01",
-        "type": "DROID"
+        "type": "CONSTRUCT"
     },
     "P0PythonComTracks": {
         "body": "Body11ABT",
@@ -1168,7 +1168,7 @@
         "id": "P0cam3CobCONTrk",
         "name": "Truck",
         "propulsion": "tracked01",
-        "type": "DROID"
+        "type": "CONSTRUCT"
     },
     "P0cam3PyAsltGnTrk": {
         "body": "Body11ABT",
@@ -2262,7 +2262,7 @@
         "id": "ScorpHoverTruck",
         "name": "Truck Scorpion Hover",
         "propulsion": "hover01",
-        "type": "DROID"
+        "type": "CONSTRUCT"
     },
     "ScorpRepairTrk": {
         "body": "Body8MBT",

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1243,6 +1243,8 @@ bool stageThreeInitialise()
 
 	// Re-inititialise some static variables.
 
+	playerBuiltHQ = false;
+
 	resizeRadar();
 
 	setAllPauseStates(false);

--- a/src/template.cpp
+++ b/src/template.cpp
@@ -668,7 +668,7 @@ void fillTemplateList(std::vector<DROID_TEMPLATE *> &pList, STRUCTURE *psFactory
 			}
 
 			if (!psCurr->enabled
-				|| (bMultiPlayer && !playerBuiltHQ)
+				|| (bMultiPlayer && !playerBuiltHQ && (psCurr->droidType != DROID_CONSTRUCT && psCurr->droidType != DROID_CYBORG_CONSTRUCT))
 				|| !validTemplateForFactory(psCurr, psFactory, false)
 				|| !researchedTemplate(psCurr, player, includeRedundantDesigns))
 			{

--- a/src/template.cpp
+++ b/src/template.cpp
@@ -648,7 +648,7 @@ void fillTemplateList(std::vector<DROID_TEMPLATE *> &pList, STRUCTURE *psFactory
 
 	if (!playerBuiltHQ)
 	{
-		playerBuiltHQ = structureExists(player, REF_HQ, true, false) || structureExists(player, REF_HQ, true, true);
+		playerBuiltHQ = structureExists(player, REF_HQ, true, false);
 	}
 
 	/* Add the templates to the list*/


### PR DESCRIPTION
#378 needed more work, unfortunately.

This:
- Sets the correct droid type for all truck templates in their respective templates.json files.
- Cleans up a bunch of useless `enableTemplate` calls in the scripts since the default truck template is always available while the MG viper is always available in campaign.
- Adds an exception for trucks to not require the player to build a HQ.
- Reset playerBuiltHQ at game load so design behavior stays consistent across games.

AFAIK, the one issue not addressed so far is the availability of saved truck templates on T2/T3 no bases. If researched they will appear without the HQ.

Refs #393.