### PR TITLE
Upgrade shortHit values in accuracy research

### DIFF
--- a/data/base/stats/research.json
+++ b/data/base/stats/research.json
@@ -2214,6 +2214,13 @@
                 "filterValue": "CANNON",
                 "parameter": "HitChance",
                 "value": 10
+            },
+            {
+                "class": "Weapon",
+                "filterParameter": "ImpactClass",
+                "filterValue": "CANNON",
+                "parameter": "ShortHitChance",
+                "value": 10
             }
         ],
         "statID": "Cannon1Mk1",
@@ -2679,6 +2686,13 @@
                 "filterValue": "MORTARS",
                 "parameter": "HitChance",
                 "value": 10
+            },
+            {
+                "class": "Weapon",
+                "filterParameter": "ImpactClass",
+                "filterValue": "MORTARS",
+                "parameter": "ShortHitChance",
+                "value": 10
             }
         ],
         "statID": "Mortar1Mk1",
@@ -2873,6 +2887,13 @@
                 "filterValue": "ROCKET",
                 "parameter": "HitChance",
                 "value": 10
+            },
+            {
+                "class": "Weapon",
+                "filterParameter": "ImpactClass",
+                "filterValue": "ROCKET",
+                "parameter": "ShortHitChance",
+                "value": 10
             }
         ],
         "statID": "Rocket-Pod",
@@ -2894,6 +2915,13 @@
                 "filterParameter": "ImpactClass",
                 "filterValue": "ROCKET",
                 "parameter": "HitChance",
+                "value": 10
+            },
+            {
+                "class": "Weapon",
+                "filterParameter": "ImpactClass",
+                "filterValue": "ROCKET",
+                "parameter": "ShortHitChance",
                 "value": 10
             }
         ],
@@ -3161,6 +3189,13 @@
                 "filterValue": "SLOW ROCKET",
                 "parameter": "HitChance",
                 "value": 10
+            },
+            {
+                "class": "Weapon",
+                "filterParameter": "ImpactClass",
+                "filterValue": "SLOW ROCKET",
+                "parameter": "ShortHitChance",
+                "value": 10
             }
         ],
         "statID": "Rocket-LtA-T",
@@ -3184,6 +3219,13 @@
                 "filterValue": "SLOW ROCKET",
                 "parameter": "HitChance",
                 "value": 10
+            },
+            {
+                "class": "Weapon",
+                "filterParameter": "ImpactClass",
+                "filterValue": "SLOW ROCKET",
+                "parameter": "ShortHitChance",
+                "value": 10
             }
         ],
         "statID": "Rocket-LtA-T",
@@ -3206,6 +3248,13 @@
                 "filterParameter": "ImpactClass",
                 "filterValue": "SLOW ROCKET",
                 "parameter": "HitChance",
+                "value": 10
+            },
+            {
+                "class": "Weapon",
+                "filterParameter": "ImpactClass",
+                "filterValue": "SLOW ROCKET",
+                "parameter": "ShortHitChance",
                 "value": 10
             }
         ],
@@ -4389,6 +4438,13 @@
                 "filterValue": "A-A GUN",
                 "parameter": "HitChance",
                 "value": 10
+            },
+            {
+                "class": "Weapon",
+                "filterParameter": "ImpactClass",
+                "filterValue": "A-A GUN",
+                "parameter": "ShortHitChance",
+                "value": 10
             }
         ],
         "statID": "QuadMg1AAGun",
@@ -4411,6 +4467,13 @@
                 "filterParameter": "ImpactClass",
                 "filterValue": "A-A GUN",
                 "parameter": "HitChance",
+                "value": 10
+            },
+            {
+                "class": "Weapon",
+                "filterParameter": "ImpactClass",
+                "filterValue": "A-A GUN",
+                "parameter": "ShortHitChance",
                 "value": 10
             }
         ],
@@ -4781,6 +4844,13 @@
                 "filterParameter": "ImpactClass",
                 "filterValue": "CANNON",
                 "parameter": "HitChance",
+                "value": 10
+            },
+            {
+                "class": "Weapon",
+                "filterParameter": "ImpactClass",
+                "filterValue": "CANNON",
+                "parameter": "ShortHitChance",
                 "value": 10
             }
         ],
@@ -5186,6 +5256,13 @@
                 "filterValue": "HOWITZERS",
                 "parameter": "HitChance",
                 "value": 10
+            },
+            {
+                "class": "Weapon",
+                "filterParameter": "ImpactClass",
+                "filterValue": "HOWITZERS",
+                "parameter": "ShortHitChance",
+                "value": 10
             }
         ],
         "statID": "Howitzer105Mk1",
@@ -5206,6 +5283,13 @@
                 "filterParameter": "ImpactClass",
                 "filterValue": "HOWITZERS",
                 "parameter": "HitChance",
+                "value": 10
+            },
+            {
+                "class": "Weapon",
+                "filterParameter": "ImpactClass",
+                "filterValue": "HOWITZERS",
+                "parameter": "ShortHitChance",
                 "value": 10
             }
         ],
@@ -5630,6 +5714,13 @@
                 "filterParameter": "ImpactClass",
                 "filterValue": "MORTARS",
                 "parameter": "HitChance",
+                "value": 10
+            },
+            {
+                "class": "Weapon",
+                "filterParameter": "ImpactClass",
+                "filterValue": "MORTARS",
+                "parameter": "ShortHitChance",
                 "value": 10
             }
         ],
@@ -7081,6 +7172,13 @@
                 "filterValue": "A-A GUN",
                 "parameter": "HitChance",
                 "value": 10
+            },
+            {
+                "class": "Weapon",
+                "filterParameter": "ImpactClass",
+                "filterValue": "A-A GUN",
+                "parameter": "ShortHitChance",
+                "value": 10
             }
         ],
         "statID": "QuadMg1AAGun",
@@ -7508,6 +7606,13 @@
                 "filterValue": "ENERGY",
                 "parameter": "HitChance",
                 "value": 10
+            },
+            {
+                "class": "Weapon",
+                "filterParameter": "ImpactClass",
+                "filterValue": "ENERGY",
+                "parameter": "ShortHitChance",
+                "value": 10
             }
         ],
         "statID": "Laser2PULSEMk1",
@@ -7708,6 +7813,13 @@
                 "filterParameter": "ImpactClass",
                 "filterValue": "HOWITZERS",
                 "parameter": "HitChance",
+                "value": 10
+            },
+            {
+                "class": "Weapon",
+                "filterParameter": "ImpactClass",
+                "filterValue": "HOWITZERS",
+                "parameter": "ShortHitChance",
                 "value": 10
             }
         ],
@@ -7976,6 +8088,13 @@
                 "filterValue": "MISSILE",
                 "parameter": "HitChance",
                 "value": 10
+            },
+            {
+                "class": "Weapon",
+                "filterParameter": "ImpactClass",
+                "filterValue": "MISSILE",
+                "parameter": "ShortHitChance",
+                "value": 10
             }
         ],
         "statID": "Missile-LtSAM",
@@ -7998,6 +8117,13 @@
                 "filterParameter": "ImpactClass",
                 "filterValue": "MISSILE",
                 "parameter": "HitChance",
+                "value": 10
+            },
+            {
+                "class": "Weapon",
+                "filterParameter": "ImpactClass",
+                "filterValue": "MISSILE",
+                "parameter": "ShortHitChance",
                 "value": 10
             }
         ],
@@ -8246,6 +8372,13 @@
                 "filterValue": "MORTARS",
                 "parameter": "HitChance",
                 "value": 10
+            },
+            {
+                "class": "Weapon",
+                "filterParameter": "ImpactClass",
+                "filterValue": "MORTARS",
+                "parameter": "ShortHitChance",
+                "value": 10
             }
         ],
         "statID": "Mortar2Mk1",
@@ -8297,6 +8430,13 @@
                 "filterParameter": "ImpactClass",
                 "filterValue": "GAUSS",
                 "parameter": "HitChance",
+                "value": 10
+            },
+            {
+                "class": "Weapon",
+                "filterParameter": "ImpactClass",
+                "filterValue": "GAUSS",
+                "parameter": "ShortHitChance",
                 "value": 10
             }
         ],

--- a/data/mp/stats/research.json
+++ b/data/mp/stats/research.json
@@ -4606,6 +4606,13 @@
                 "filterValue": "A-A GUN",
                 "parameter": "HitChance",
                 "value": 10
+            },
+            {
+                "class": "Weapon",
+                "filterParameter": "ImpactClass",
+                "filterValue": "A-A GUN",
+                "parameter": "ShortHitChance",
+                "value": 10
             }
         ],
         "statID": "QuadMg1AAGun",
@@ -4629,6 +4636,13 @@
                 "filterValue": "A-A GUN",
                 "parameter": "HitChance",
                 "value": 10
+            },
+            {
+                "class": "Weapon",
+                "filterParameter": "ImpactClass",
+                "filterValue": "A-A GUN",
+                "parameter": "ShortHitChance",
+                "value": 10
             }
         ],
         "statID": "QuadMg1AAGun",
@@ -4651,6 +4665,13 @@
                 "filterParameter": "ImpactClass",
                 "filterValue": "A-A GUN",
                 "parameter": "HitChance",
+                "value": 10
+            },
+            {
+                "class": "Weapon",
+                "filterParameter": "ImpactClass",
+                "filterValue": "A-A GUN",
+                "parameter": "ShortHitChance",
                 "value": 10
             }
         ],
@@ -5300,6 +5321,13 @@
                 "filterValue": "CANNON",
                 "parameter": "HitChance",
                 "value": 10
+            },
+            {
+                "class": "Weapon",
+                "filterParameter": "ImpactClass",
+                "filterValue": "CANNON",
+                "parameter": "ShortHitChance",
+                "value": 10
             }
         ],
         "statID": "Cannon1Mk1",
@@ -5323,6 +5351,13 @@
                 "filterParameter": "ImpactClass",
                 "filterValue": "CANNON",
                 "parameter": "HitChance",
+                "value": 10
+            },
+            {
+                "class": "Weapon",
+                "filterParameter": "ImpactClass",
+                "filterValue": "CANNON",
+                "parameter": "ShortHitChance",
                 "value": 10
             }
         ],
@@ -5905,6 +5940,13 @@
                 "filterParameter": "ImpactClass",
                 "filterValue": "ENERGY",
                 "parameter": "HitChance",
+                "value": 10
+            },
+            {
+                "class": "Weapon",
+                "filterParameter": "ImpactClass",
+                "filterValue": "ENERGY",
+                "parameter": "ShortHitChance",
                 "value": 10
             }
         ],
@@ -6494,6 +6536,13 @@
                 "filterValue": "HOWITZERS",
                 "parameter": "HitChance",
                 "value": 10
+            },
+            {
+                "class": "Weapon",
+                "filterParameter": "ImpactClass",
+                "filterValue": "HOWITZERS",
+                "parameter": "ShortHitChance",
+                "value": 10
             }
         ],
         "statID": "Howitzer105Mk1",
@@ -6515,6 +6564,13 @@
                 "filterParameter": "ImpactClass",
                 "filterValue": "HOWITZERS",
                 "parameter": "HitChance",
+                "value": 10
+            },
+            {
+                "class": "Weapon",
+                "filterParameter": "ImpactClass",
+                "filterValue": "HOWITZERS",
+                "parameter": "ShortHitChance",
                 "value": 10
             }
         ],
@@ -6538,6 +6594,13 @@
                 "filterParameter": "ImpactClass",
                 "filterValue": "HOWITZERS",
                 "parameter": "HitChance",
+                "value": 10
+            },
+            {
+                "class": "Weapon",
+                "filterParameter": "ImpactClass",
+                "filterValue": "HOWITZERS",
+                "parameter": "ShortHitChance",
                 "value": 10
             }
         ],
@@ -7443,6 +7506,13 @@
                 "filterValue": "MISSILE",
                 "parameter": "HitChance",
                 "value": 10
+            },
+            {
+                "class": "Weapon",
+                "filterParameter": "ImpactClass",
+                "filterValue": "MISSILE",
+                "parameter": "ShortHitChance",
+                "value": 10
             }
         ],
         "statID": "Missile-A-T",
@@ -7464,6 +7534,13 @@
                 "filterParameter": "ImpactClass",
                 "filterValue": "MISSILE",
                 "parameter": "HitChance",
+                "value": 10
+            },
+            {
+                "class": "Weapon",
+                "filterParameter": "ImpactClass",
+                "filterValue": "MISSILE",
+                "parameter": "ShortHitChance",
                 "value": 10
             }
         ],
@@ -7720,6 +7797,13 @@
                 "filterValue": "MORTARS",
                 "parameter": "HitChance",
                 "value": 10
+            },
+            {
+                "class": "Weapon",
+                "filterParameter": "ImpactClass",
+                "filterValue": "MORTARS",
+                "parameter": "ShortHitChance",
+                "value": 10
             }
         ],
         "statID": "Mortar1Mk1",
@@ -7742,6 +7826,13 @@
                 "filterParameter": "ImpactClass",
                 "filterValue": "MORTARS",
                 "parameter": "HitChance",
+                "value": 10
+            },
+            {
+                "class": "Weapon",
+                "filterParameter": "ImpactClass",
+                "filterValue": "MORTARS",
+                "parameter": "ShortHitChance",
                 "value": 10
             }
         ],
@@ -7766,6 +7857,13 @@
                 "filterParameter": "ImpactClass",
                 "filterValue": "MORTARS",
                 "parameter": "HitChance",
+                "value": 10
+            },
+            {
+                "class": "Weapon",
+                "filterParameter": "ImpactClass",
+                "filterValue": "MORTARS",
+                "parameter": "ShortHitChance",
                 "value": 10
             }
         ],
@@ -8246,6 +8344,13 @@
                 "filterValue": "GAUSS",
                 "parameter": "HitChance",
                 "value": 10
+            },
+            {
+                "class": "Weapon",
+                "filterParameter": "ImpactClass",
+                "filterValue": "GAUSS",
+                "parameter": "ShortHitChance",
+                "value": 10
             }
         ],
         "statID": "RailGun1Mk1",
@@ -8503,6 +8608,13 @@
                 "filterValue": "ROCKET",
                 "parameter": "HitChance",
                 "value": 10
+            },
+            {
+                "class": "Weapon",
+                "filterParameter": "ImpactClass",
+                "filterValue": "ROCKET",
+                "parameter": "ShortHitChance",
+                "value": 10
             }
         ],
         "statID": "Rocket-Pod",
@@ -8524,6 +8636,13 @@
                 "filterParameter": "ImpactClass",
                 "filterValue": "ROCKET",
                 "parameter": "HitChance",
+                "value": 10
+            },
+            {
+                "class": "Weapon",
+                "filterParameter": "ImpactClass",
+                "filterValue": "ROCKET",
+                "parameter": "ShortHitChance",
                 "value": 10
             }
         ],
@@ -9001,6 +9120,13 @@
                 "filterValue": "ROCKET",
                 "parameter": "HitChance",
                 "value": 10
+            },
+            {
+                "class": "Weapon",
+                "filterParameter": "ImpactClass",
+                "filterValue": "ROCKET",
+                "parameter": "ShortHitChance",
+                "value": 10
             }
         ],
         "statID": "Rocket-LtA-T",
@@ -9023,6 +9149,13 @@
                 "filterParameter": "ImpactClass",
                 "filterValue": "ROCKET",
                 "parameter": "HitChance",
+                "value": 10
+            },
+            {
+                "class": "Weapon",
+                "filterParameter": "ImpactClass",
+                "filterValue": "ROCKET",
+                "parameter": "ShortHitChance",
                 "value": 10
             }
         ],


### PR DESCRIPTION
The final piece to the ranges/accuracy puzzle. This PR will increase the shortHit values by 10% of the base value for every accuracy upgrade in campaign and multiplayer, just like for longHit.

This fixes two things:
1. Eventually, all weapons that are better at short range can flip to being better at long range. Provided with enough accuracy upgrades, especially if the difference between a weapon's longHit and shortHit is very close, this situation can certainly happen.
2. Weapons without any accuracy difference at a given range will keep having an equal longHit and shortHit value.

The result of accuracy upgrades can be seen in the script contexts in the debug window in the Upgrades object (current stat values of all players).