### PR TITLE
Fix missing AI difficulty buttons for locked teams

### DIFF
--- a/src/multiint.cpp
+++ b/src/multiint.cpp
@@ -2678,7 +2678,9 @@ void addPlayerBox(bool players)
 
 			if (ingame.localOptionsReceived)
 			{
-				if (!allOnSameTeam)
+				// do not draw "Ready" button if all players are on the same team,
+				// but always draw the difficulty buttons for AI players
+				if (!allOnSameTeam || (!NetPlay.players[i].allocated && NetPlay.players[i].ai >= 0))
 				{
 					drawReadyButton(i);
 				}


### PR DESCRIPTION
With alliances set to either "Locked Teams, No Shared Research" or
"Locked Teams", AI player boxes were shown without difficulty buttons if
all players were on the same team:

![skirmish_shared_research_old](https://user-images.githubusercontent.com/24465795/60585371-7e806400-9d87-11e9-82ce-21fbd1abc71b.png)

The attached ZIP file contains
* screenshots showing an AI player box with all players on the same team
  and alliances set to either "Locked Teams, No Shared Research" or
  "Locked Teams", both before and after applying this PR when
  * hosting a skirmish game
  * hosting a challenge
  * hosting a multiplayer game
  * joining a multiplayer game
* a shell script to generate them

[missing_difficulty_buttons_documentation.zip](https://github.com/Warzone2100/warzone2100/files/3354589/missing_difficulty_buttons_documentation.zip)