### PR TITLE
Fix printing of help text for commandline options

### DIFF
--- a/src/clparse.cpp
+++ b/src/clparse.cpp
@@ -54,7 +54,6 @@
 struct poptOption
 {
 	const char *string;
-	char short_form;
 	bool argument;
 	void *nullpointer;		// unused
 	int enumeration;
@@ -89,15 +88,7 @@ static void poptPrintHelp(poptContext ctx, FILE *output)
 	for (int i = 0; i < ctx->size; i++)
 	{
 		char txt[128];
-
-		if (ctx->table[i].short_form != '\0')
-		{
-			ssprintf(txt, "  -%c, --%s", ctx->table[i].short_form, ctx->table[i].string);
-		}
-		else
-		{
-			ssprintf(txt, "  --%s", ctx->table[i].string);
-		}
+		ssprintf(txt, "  --%s", ctx->table[i].string);
 
 		if (ctx->table[i].argument)
 		{
@@ -192,12 +183,10 @@ static int poptGetNextOpt(poptContext ctx)
 
 	for (i = 0; i < ctx->size; i++)
 	{
-		char sshort[3];
 		char slong[64];
 
-		ssprintf(sshort, "-%c", ctx->table[i].short_form);
 		ssprintf(slong, "--%s", ctx->table[i].string);
-		if ((strcmp(sshort, match) == 0 && ctx->table[i].short_form != '\0') || strcmp(slong, match) == 0)
+		if (strcmp(slong, match) == 0)
 		{
 			if (ctx->table[i].argument && pparam)
 			{
@@ -265,37 +254,37 @@ static const struct poptOption *getOptionsTable()
 {
 	static const struct poptOption optionsTable[] =
 	{
-		{ "configdir",  '\0', POPT_ARG_STRING, nullptr, CLI_CONFIGDIR,  N_("Set configuration directory"),       N_("configuration directory") },
-		{ "datadir",    '\0', POPT_ARG_STRING, nullptr, CLI_DATADIR,    N_("Add data directory"),                N_("data directory") },
-		{ "debug",      '\0', POPT_ARG_STRING, nullptr, CLI_DEBUG,      N_("Show debug for given level"),        N_("debug level") },
-		{ "debugfile",  '\0', POPT_ARG_STRING, nullptr, CLI_DEBUGFILE,  N_("Log debug output to file"),          N_("file") },
-		{ "flush-debug-stderr", '\0', POPT_ARG_NONE, nullptr, CLI_FLUSHDEBUGSTDERR, N_("Flush all debug output written to stderr"), nullptr },
-		{ "fullscreen", '\0', POPT_ARG_NONE,   nullptr, CLI_FULLSCREEN, N_("Play in fullscreen mode"),           nullptr },
-		{ "game",       '\0', POPT_ARG_STRING, nullptr, CLI_GAME,       N_("Load a specific game mode"),         N_("level name") },
-		{ "help",       'h',  POPT_ARG_NONE,   nullptr, CLI_HELP,       N_("Show options and exit"),             nullptr },
-		{ "mod",        '\0', POPT_ARG_STRING, nullptr, CLI_MOD_GLOB,   N_("Enable a global mod"),               N_("mod") },
-		{ "mod_ca",     '\0', POPT_ARG_STRING, nullptr, CLI_MOD_CA,     N_("Enable a campaign only mod"),        N_("mod") },
-		{ "mod_mp",     '\0', POPT_ARG_STRING, nullptr, CLI_MOD_MP,     N_("Enable a multiplay only mod"),       N_("mod") },
-		{ "noassert",	'\0', POPT_ARG_NONE,   nullptr, CLI_NOASSERT,   N_("Disable asserts"),                   nullptr },
-		{ "crash",		'\0', POPT_ARG_NONE,   nullptr, CLI_CRASH,      N_("Causes a crash to test the crash handler"), nullptr },
-		{ "loadskirmish",'\0', POPT_ARG_STRING, nullptr, CLI_LOADSKIRMISH, N_("Load a saved skirmish game"),     N_("savegame") },
-		{ "loadcampaign",'\0', POPT_ARG_STRING, nullptr, CLI_LOADCAMPAIGN, N_("Load a saved campaign game"),     N_("savegame") },
-		{ "window",     '\0', POPT_ARG_NONE,   nullptr, CLI_WINDOW,     N_("Play in windowed mode"),             nullptr },
-		{ "version",    '\0', POPT_ARG_NONE,   nullptr, CLI_VERSION,    N_("Show version information and exit"), nullptr },
-		{ "resolution", '\0', POPT_ARG_STRING, nullptr, CLI_RESOLUTION, N_("Set the resolution to use"),         N_("WIDTHxHEIGHT") },
-		{ "shadows",    '\0', POPT_ARG_NONE,   nullptr, CLI_SHADOWS,    N_("Enable shadows"),                    nullptr },
-		{ "noshadows",  '\0', POPT_ARG_NONE,   nullptr, CLI_NOSHADOWS,  N_("Disable shadows"),                   nullptr },
-		{ "sound",      '\0', POPT_ARG_NONE,   nullptr, CLI_SOUND,      N_("Enable sound"),                      nullptr },
-		{ "nosound",    '\0', POPT_ARG_NONE,   nullptr, CLI_NOSOUND,    N_("Disable sound"),                     nullptr },
-		{ "join",       '\0', POPT_ARG_STRING, nullptr, CLI_CONNECTTOIP, N_("Connect directly to IP/hostname"),  N_("host") },
-		{ "host",       '\0', POPT_ARG_NONE,   nullptr, CLI_HOSTLAUNCH, N_("Go directly to host screen"),        nullptr },
-		{ "texturecompression", '\0', POPT_ARG_NONE, nullptr, CLI_TEXTURECOMPRESSION, N_("Enable texture compression"), nullptr },
-		{ "notexturecompression", '\0', POPT_ARG_NONE, nullptr, CLI_NOTEXTURECOMPRESSION, N_("Disable texture compression"), nullptr },
-		{ "autogame",   '\0', POPT_ARG_NONE,   nullptr, CLI_AUTOGAME,   N_("Run games automatically for testing"), nullptr },
-		{ "saveandquit", '\0', POPT_ARG_STRING, nullptr, CLI_SAVEANDQUIT, N_("Immediately save game and quit"), N_("save name") },
-		{ "skirmish",   '\0', POPT_ARG_STRING, nullptr, CLI_SKIRMISH,   N_("Start skirmish game with given settings file"), N_("test") },
+		{ "configdir", POPT_ARG_STRING, nullptr, CLI_CONFIGDIR,  N_("Set configuration directory"),       N_("configuration directory") },
+		{ "datadir", POPT_ARG_STRING, nullptr, CLI_DATADIR,    N_("Add data directory"),                N_("data directory") },
+		{ "debug", POPT_ARG_STRING, nullptr, CLI_DEBUG,      N_("Show debug for given level"),        N_("debug level") },
+		{ "debugfile", POPT_ARG_STRING, nullptr, CLI_DEBUGFILE,  N_("Log debug output to file"),          N_("file") },
+		{ "flush-debug-stderr", POPT_ARG_NONE, nullptr, CLI_FLUSHDEBUGSTDERR, N_("Flush all debug output written to stderr"), nullptr },
+		{ "fullscreen", POPT_ARG_NONE,   nullptr, CLI_FULLSCREEN, N_("Play in fullscreen mode"),           nullptr },
+		{ "game", POPT_ARG_STRING, nullptr, CLI_GAME,       N_("Load a specific game mode"),         N_("level name") },
+		{ "help",  POPT_ARG_NONE,   nullptr, CLI_HELP,       N_("Show options and exit"),             nullptr },
+		{ "mod", POPT_ARG_STRING, nullptr, CLI_MOD_GLOB,   N_("Enable a global mod"),               N_("mod") },
+		{ "mod_ca", POPT_ARG_STRING, nullptr, CLI_MOD_CA,     N_("Enable a campaign only mod"),        N_("mod") },
+		{ "mod_mp", POPT_ARG_STRING, nullptr, CLI_MOD_MP,     N_("Enable a multiplay only mod"),       N_("mod") },
+		{ "noassert", POPT_ARG_NONE,   nullptr, CLI_NOASSERT,   N_("Disable asserts"),                   nullptr },
+		{ "crash", POPT_ARG_NONE,   nullptr, CLI_CRASH,      N_("Causes a crash to test the crash handler"), nullptr },
+		{ "loadskirmish", POPT_ARG_STRING, nullptr, CLI_LOADSKIRMISH, N_("Load a saved skirmish game"),     N_("savegame") },
+		{ "loadcampaign", POPT_ARG_STRING, nullptr, CLI_LOADCAMPAIGN, N_("Load a saved campaign game"),     N_("savegame") },
+		{ "window", POPT_ARG_NONE,   nullptr, CLI_WINDOW,     N_("Play in windowed mode"),             nullptr },
+		{ "version", POPT_ARG_NONE,   nullptr, CLI_VERSION,    N_("Show version information and exit"), nullptr },
+		{ "resolution", POPT_ARG_STRING, nullptr, CLI_RESOLUTION, N_("Set the resolution to use"),         N_("WIDTHxHEIGHT") },
+		{ "shadows", POPT_ARG_NONE,   nullptr, CLI_SHADOWS,    N_("Enable shadows"),                    nullptr },
+		{ "noshadows", POPT_ARG_NONE,   nullptr, CLI_NOSHADOWS,  N_("Disable shadows"),                   nullptr },
+		{ "sound", POPT_ARG_NONE,   nullptr, CLI_SOUND,      N_("Enable sound"),                      nullptr },
+		{ "nosound", POPT_ARG_NONE,   nullptr, CLI_NOSOUND,    N_("Disable sound"),                     nullptr },
+		{ "join", POPT_ARG_STRING, nullptr, CLI_CONNECTTOIP, N_("Connect directly to IP/hostname"),  N_("host") },
+		{ "host", POPT_ARG_NONE,   nullptr, CLI_HOSTLAUNCH, N_("Go directly to host screen"),        nullptr },
+		{ "texturecompression", POPT_ARG_NONE, nullptr, CLI_TEXTURECOMPRESSION, N_("Enable texture compression"), nullptr },
+		{ "notexturecompression", POPT_ARG_NONE, nullptr, CLI_NOTEXTURECOMPRESSION, N_("Disable texture compression"), nullptr },
+		{ "autogame", POPT_ARG_NONE,   nullptr, CLI_AUTOGAME,   N_("Run games automatically for testing"), nullptr },
+		{ "saveandquit", POPT_ARG_STRING, nullptr, CLI_SAVEANDQUIT, N_("Immediately save game and quit"), N_("save name") },
+		{ "skirmish", POPT_ARG_STRING, nullptr, CLI_SKIRMISH,   N_("Start skirmish game with given settings file"), N_("test") },
 		// Terminating entry
-		{ nullptr,         '\0', 0,               nullptr, 0,              nullptr,                                    nullptr },
+		{ nullptr, 0,               nullptr, 0,              nullptr,                                    nullptr },
 	};
 
 	static struct poptOption TranslatedOptionsTable[sizeof(optionsTable) / sizeof(struct poptOption)];

--- a/src/clparse.cpp
+++ b/src/clparse.cpp
@@ -60,7 +60,6 @@ struct poptOption
 	int enumeration;
 	const char *descrip;
 	const char *argDescrip;
-	bool hidden;
 };
 
 typedef struct _poptContext
@@ -83,18 +82,13 @@ static bool wz_autogame = false;
 static std::string wz_saveandquit;
 static std::string wz_test;
 
-static void poptPrintHelp(poptContext ctx, FILE *output, bool show_all)
+static void poptPrintHelp(poptContext ctx, FILE *output)
 {
 	// TRANSLATORS: Summary of commandline option syntax
 	fprintf(output, _("Usage: %s [OPTION...]\n"), ctx->argv[0]);
 	for (int i = 0; i < ctx->size; i++)
 	{
 		char txt[128];
-
-		if (ctx->table[i].hidden && !show_all)
-		{
-			continue;
-		}
 
 		if (ctx->table[i].short_form != '\0')
 		{
@@ -244,7 +238,6 @@ typedef enum
 	CLI_FULLSCREEN,
 	CLI_GAME,
 	CLI_HELP,
-	CLI_HELP_ALL,
 	CLI_MOD_GLOB,
 	CLI_MOD_CA,
 	CLI_MOD_MP,
@@ -272,38 +265,37 @@ static const struct poptOption *getOptionsTable()
 {
 	static const struct poptOption optionsTable[] =
 	{
-		{ "configdir",  '\0', POPT_ARG_STRING, nullptr, CLI_CONFIGDIR,  N_("Set configuration directory"),       N_("configuration directory"), false },
-		{ "datadir",    '\0', POPT_ARG_STRING, nullptr, CLI_DATADIR,    N_("Add data directory"),                N_("data directory"), false },
-		{ "debug",      '\0', POPT_ARG_STRING, nullptr, CLI_DEBUG,      N_("Show debug for given level"),        N_("debug level"), false },
-		{ "debugfile",  '\0', POPT_ARG_STRING, nullptr, CLI_DEBUGFILE,  N_("Log debug output to file"),          N_("file"), false },
-		{ "flush-debug-stderr", '\0', POPT_ARG_NONE, nullptr, CLI_FLUSHDEBUGSTDERR, N_("Flush all debug output written to stderr"), nullptr, true },
-		{ "fullscreen", '\0', POPT_ARG_NONE,   nullptr, CLI_FULLSCREEN, N_("Play in fullscreen mode"),           nullptr, false },
-		{ "game",       '\0', POPT_ARG_STRING, nullptr, CLI_GAME,       N_("Load a specific game mode"),         N_("level name"), true },
-		{ "help",       'h',  POPT_ARG_NONE,   nullptr, CLI_HELP,       N_("Show options and exit"),             nullptr, false },
-		{ "help-all",   '\0', POPT_ARG_NONE,   nullptr, CLI_HELP_ALL,   N_("Show all options and exit"),         nullptr, false },
-		{ "mod",        '\0', POPT_ARG_STRING, nullptr, CLI_MOD_GLOB,   N_("Enable a global mod"),               N_("mod"), false },
-		{ "mod_ca",     '\0', POPT_ARG_STRING, nullptr, CLI_MOD_CA,     N_("Enable a campaign only mod"),        N_("mod"), false },
-		{ "mod_mp",     '\0', POPT_ARG_STRING, nullptr, CLI_MOD_MP,     N_("Enable a multiplay only mod"),       N_("mod"), false },
-		{ "noassert",	'\0', POPT_ARG_NONE,   nullptr, CLI_NOASSERT,   N_("Disable asserts"),                   nullptr, false },
-		{ "crash",		'\0', POPT_ARG_NONE,   nullptr, CLI_CRASH,      N_("Causes a crash to test the crash handler"), nullptr, true },
-		{ "loadskirmish",'\0', POPT_ARG_STRING, nullptr, CLI_LOADSKIRMISH, N_("Load a saved skirmish game"),     N_("savegame"), true },
-		{ "loadcampaign",'\0', POPT_ARG_STRING, nullptr, CLI_LOADCAMPAIGN, N_("Load a saved campaign game"),     N_("savegame"), true },
-		{ "window",     '\0', POPT_ARG_NONE,   nullptr, CLI_WINDOW,     N_("Play in windowed mode"),             nullptr, false },
-		{ "version",    '\0', POPT_ARG_NONE,   nullptr, CLI_VERSION,    N_("Show version information and exit"), nullptr, false },
-		{ "resolution", '\0', POPT_ARG_STRING, nullptr, CLI_RESOLUTION, N_("Set the resolution to use"),         N_("WIDTHxHEIGHT"), false },
-		{ "shadows",    '\0', POPT_ARG_NONE,   nullptr, CLI_SHADOWS,    N_("Enable shadows"),                    nullptr, false },
-		{ "noshadows",  '\0', POPT_ARG_NONE,   nullptr, CLI_NOSHADOWS,  N_("Disable shadows"),                   nullptr, false },
-		{ "sound",      '\0', POPT_ARG_NONE,   nullptr, CLI_SOUND,      N_("Enable sound"),                      nullptr, false },
-		{ "nosound",    '\0', POPT_ARG_NONE,   nullptr, CLI_NOSOUND,    N_("Disable sound"),                     nullptr, false },
-		{ "join",       '\0', POPT_ARG_STRING, nullptr, CLI_CONNECTTOIP, N_("Connect directly to IP/hostname"),  N_("host"), true },
-		{ "host",       '\0', POPT_ARG_NONE,   nullptr, CLI_HOSTLAUNCH, N_("Go directly to host screen"),        nullptr, true },
-		{ "texturecompression", '\0', POPT_ARG_NONE, nullptr, CLI_TEXTURECOMPRESSION, N_("Enable texture compression"), nullptr, false },
-		{ "notexturecompression", '\0', POPT_ARG_NONE, nullptr, CLI_NOTEXTURECOMPRESSION, N_("Disable texture compression"), nullptr, false },
-		{ "autogame",   '\0', POPT_ARG_NONE,   nullptr, CLI_AUTOGAME,   N_("Run games automatically for testing"), nullptr, true },
-		{ "saveandquit", '\0', POPT_ARG_STRING, nullptr, CLI_SAVEANDQUIT, N_("Immediately save game and quit"), N_("save name"), true },
-		{ "skirmish",   '\0', POPT_ARG_STRING, nullptr, CLI_SKIRMISH,   N_("Start skirmish game with given settings file"), N_("test"), true },
+		{ "configdir",  '\0', POPT_ARG_STRING, nullptr, CLI_CONFIGDIR,  N_("Set configuration directory"),       N_("configuration directory") },
+		{ "datadir",    '\0', POPT_ARG_STRING, nullptr, CLI_DATADIR,    N_("Add data directory"),                N_("data directory") },
+		{ "debug",      '\0', POPT_ARG_STRING, nullptr, CLI_DEBUG,      N_("Show debug for given level"),        N_("debug level") },
+		{ "debugfile",  '\0', POPT_ARG_STRING, nullptr, CLI_DEBUGFILE,  N_("Log debug output to file"),          N_("file") },
+		{ "flush-debug-stderr", '\0', POPT_ARG_NONE, nullptr, CLI_FLUSHDEBUGSTDERR, N_("Flush all debug output written to stderr"), nullptr },
+		{ "fullscreen", '\0', POPT_ARG_NONE,   nullptr, CLI_FULLSCREEN, N_("Play in fullscreen mode"),           nullptr },
+		{ "game",       '\0', POPT_ARG_STRING, nullptr, CLI_GAME,       N_("Load a specific game mode"),         N_("level name") },
+		{ "help",       'h',  POPT_ARG_NONE,   nullptr, CLI_HELP,       N_("Show options and exit"),             nullptr },
+		{ "mod",        '\0', POPT_ARG_STRING, nullptr, CLI_MOD_GLOB,   N_("Enable a global mod"),               N_("mod") },
+		{ "mod_ca",     '\0', POPT_ARG_STRING, nullptr, CLI_MOD_CA,     N_("Enable a campaign only mod"),        N_("mod") },
+		{ "mod_mp",     '\0', POPT_ARG_STRING, nullptr, CLI_MOD_MP,     N_("Enable a multiplay only mod"),       N_("mod") },
+		{ "noassert",	'\0', POPT_ARG_NONE,   nullptr, CLI_NOASSERT,   N_("Disable asserts"),                   nullptr },
+		{ "crash",		'\0', POPT_ARG_NONE,   nullptr, CLI_CRASH,      N_("Causes a crash to test the crash handler"), nullptr },
+		{ "loadskirmish",'\0', POPT_ARG_STRING, nullptr, CLI_LOADSKIRMISH, N_("Load a saved skirmish game"),     N_("savegame") },
+		{ "loadcampaign",'\0', POPT_ARG_STRING, nullptr, CLI_LOADCAMPAIGN, N_("Load a saved campaign game"),     N_("savegame") },
+		{ "window",     '\0', POPT_ARG_NONE,   nullptr, CLI_WINDOW,     N_("Play in windowed mode"),             nullptr },
+		{ "version",    '\0', POPT_ARG_NONE,   nullptr, CLI_VERSION,    N_("Show version information and exit"), nullptr },
+		{ "resolution", '\0', POPT_ARG_STRING, nullptr, CLI_RESOLUTION, N_("Set the resolution to use"),         N_("WIDTHxHEIGHT") },
+		{ "shadows",    '\0', POPT_ARG_NONE,   nullptr, CLI_SHADOWS,    N_("Enable shadows"),                    nullptr },
+		{ "noshadows",  '\0', POPT_ARG_NONE,   nullptr, CLI_NOSHADOWS,  N_("Disable shadows"),                   nullptr },
+		{ "sound",      '\0', POPT_ARG_NONE,   nullptr, CLI_SOUND,      N_("Enable sound"),                      nullptr },
+		{ "nosound",    '\0', POPT_ARG_NONE,   nullptr, CLI_NOSOUND,    N_("Disable sound"),                     nullptr },
+		{ "join",       '\0', POPT_ARG_STRING, nullptr, CLI_CONNECTTOIP, N_("Connect directly to IP/hostname"),  N_("host") },
+		{ "host",       '\0', POPT_ARG_NONE,   nullptr, CLI_HOSTLAUNCH, N_("Go directly to host screen"),        nullptr },
+		{ "texturecompression", '\0', POPT_ARG_NONE, nullptr, CLI_TEXTURECOMPRESSION, N_("Enable texture compression"), nullptr },
+		{ "notexturecompression", '\0', POPT_ARG_NONE, nullptr, CLI_NOTEXTURECOMPRESSION, N_("Disable texture compression"), nullptr },
+		{ "autogame",   '\0', POPT_ARG_NONE,   nullptr, CLI_AUTOGAME,   N_("Run games automatically for testing"), nullptr },
+		{ "saveandquit", '\0', POPT_ARG_STRING, nullptr, CLI_SAVEANDQUIT, N_("Immediately save game and quit"), N_("save name") },
+		{ "skirmish",   '\0', POPT_ARG_STRING, nullptr, CLI_SKIRMISH,   N_("Start skirmish game with given settings file"), N_("test") },
 		// Terminating entry
-		{ nullptr,         '\0', 0,               nullptr, 0,              nullptr,                                    nullptr, true },
+		{ nullptr,         '\0', 0,               nullptr, 0,              nullptr,                                    nullptr },
 	};
 
 	static struct poptOption TranslatedOptionsTable[sizeof(optionsTable) / sizeof(struct poptOption)];
@@ -416,8 +408,7 @@ bool ParseCommandLineEarly(int argc, const char * const *argv)
 			break;
 
 		case CLI_HELP:
-		case CLI_HELP_ALL:
-			poptPrintHelp(poptCon, stdout, option == CLI_HELP_ALL);
+			poptPrintHelp(poptCon, stdout);
 			return false;
 
 		case CLI_VERSION:
@@ -457,7 +448,6 @@ bool ParseCommandLine(int argc, const char * const *argv)
 		case CLI_FLUSHDEBUGSTDERR:
 		case CLI_CONFIGDIR:
 		case CLI_HELP:
-		case CLI_HELP_ALL:
 		case CLI_VERSION:
 			// These options are parsed in ParseCommandLineEarly() already, so ignore them
 			break;

--- a/src/clparse.cpp
+++ b/src/clparse.cpp
@@ -111,7 +111,20 @@ static void poptPrintHelp(poptContext ctx, FILE *output, bool show_all)
 			sstrcat(txt, ctx->table[i].argDescrip);
 		}
 
-		fprintf(output, "%-40s", txt);
+		// calculate number of terminal columns required to print
+		// for languages with multibyte characters
+		const size_t txtSize = strlen(txt) + 1;
+		int txtOffset = (int) mbstowcs(nullptr, txt, txtSize) + 1 - txtSize;
+		// CJK characters take up two columns
+		char language[3]; // stores ISO 639-1 code
+		strlcpy(language, setlocale(LC_MESSAGES, nullptr), sizeof(language));
+		if (strcmp(language, "zh") == 0 || strcmp(language, "ko") == 0)
+		{
+			txtOffset /= 2;
+		}
+
+		fprintf(output, "%-*s", 40 - txtOffset, txt);
+
 		if (ctx->table[i].descrip)
 		{
 			fprintf(output, "%s", ctx->table[i].descrip);

--- a/src/clparse.cpp
+++ b/src/clparse.cpp
@@ -55,7 +55,6 @@ struct poptOption
 {
 	const char *string;
 	bool argument;
-	void *nullpointer;		// unused
 	int enumeration;
 	const char *descrip;
 	const char *argDescrip;
@@ -254,37 +253,37 @@ static const struct poptOption *getOptionsTable()
 {
 	static const struct poptOption optionsTable[] =
 	{
-		{ "configdir", POPT_ARG_STRING, nullptr, CLI_CONFIGDIR,  N_("Set configuration directory"),       N_("configuration directory") },
-		{ "datadir", POPT_ARG_STRING, nullptr, CLI_DATADIR,    N_("Add data directory"),                N_("data directory") },
-		{ "debug", POPT_ARG_STRING, nullptr, CLI_DEBUG,      N_("Show debug for given level"),        N_("debug level") },
-		{ "debugfile", POPT_ARG_STRING, nullptr, CLI_DEBUGFILE,  N_("Log debug output to file"),          N_("file") },
-		{ "flush-debug-stderr", POPT_ARG_NONE, nullptr, CLI_FLUSHDEBUGSTDERR, N_("Flush all debug output written to stderr"), nullptr },
-		{ "fullscreen", POPT_ARG_NONE,   nullptr, CLI_FULLSCREEN, N_("Play in fullscreen mode"),           nullptr },
-		{ "game", POPT_ARG_STRING, nullptr, CLI_GAME,       N_("Load a specific game mode"),         N_("level name") },
-		{ "help",  POPT_ARG_NONE,   nullptr, CLI_HELP,       N_("Show options and exit"),             nullptr },
-		{ "mod", POPT_ARG_STRING, nullptr, CLI_MOD_GLOB,   N_("Enable a global mod"),               N_("mod") },
-		{ "mod_ca", POPT_ARG_STRING, nullptr, CLI_MOD_CA,     N_("Enable a campaign only mod"),        N_("mod") },
-		{ "mod_mp", POPT_ARG_STRING, nullptr, CLI_MOD_MP,     N_("Enable a multiplay only mod"),       N_("mod") },
-		{ "noassert", POPT_ARG_NONE,   nullptr, CLI_NOASSERT,   N_("Disable asserts"),                   nullptr },
-		{ "crash", POPT_ARG_NONE,   nullptr, CLI_CRASH,      N_("Causes a crash to test the crash handler"), nullptr },
-		{ "loadskirmish", POPT_ARG_STRING, nullptr, CLI_LOADSKIRMISH, N_("Load a saved skirmish game"),     N_("savegame") },
-		{ "loadcampaign", POPT_ARG_STRING, nullptr, CLI_LOADCAMPAIGN, N_("Load a saved campaign game"),     N_("savegame") },
-		{ "window", POPT_ARG_NONE,   nullptr, CLI_WINDOW,     N_("Play in windowed mode"),             nullptr },
-		{ "version", POPT_ARG_NONE,   nullptr, CLI_VERSION,    N_("Show version information and exit"), nullptr },
-		{ "resolution", POPT_ARG_STRING, nullptr, CLI_RESOLUTION, N_("Set the resolution to use"),         N_("WIDTHxHEIGHT") },
-		{ "shadows", POPT_ARG_NONE,   nullptr, CLI_SHADOWS,    N_("Enable shadows"),                    nullptr },
-		{ "noshadows", POPT_ARG_NONE,   nullptr, CLI_NOSHADOWS,  N_("Disable shadows"),                   nullptr },
-		{ "sound", POPT_ARG_NONE,   nullptr, CLI_SOUND,      N_("Enable sound"),                      nullptr },
-		{ "nosound", POPT_ARG_NONE,   nullptr, CLI_NOSOUND,    N_("Disable sound"),                     nullptr },
-		{ "join", POPT_ARG_STRING, nullptr, CLI_CONNECTTOIP, N_("Connect directly to IP/hostname"),  N_("host") },
-		{ "host", POPT_ARG_NONE,   nullptr, CLI_HOSTLAUNCH, N_("Go directly to host screen"),        nullptr },
-		{ "texturecompression", POPT_ARG_NONE, nullptr, CLI_TEXTURECOMPRESSION, N_("Enable texture compression"), nullptr },
-		{ "notexturecompression", POPT_ARG_NONE, nullptr, CLI_NOTEXTURECOMPRESSION, N_("Disable texture compression"), nullptr },
-		{ "autogame", POPT_ARG_NONE,   nullptr, CLI_AUTOGAME,   N_("Run games automatically for testing"), nullptr },
-		{ "saveandquit", POPT_ARG_STRING, nullptr, CLI_SAVEANDQUIT, N_("Immediately save game and quit"), N_("save name") },
-		{ "skirmish", POPT_ARG_STRING, nullptr, CLI_SKIRMISH,   N_("Start skirmish game with given settings file"), N_("test") },
+		{ "configdir", POPT_ARG_STRING, CLI_CONFIGDIR,  N_("Set configuration directory"),       N_("configuration directory") },
+		{ "datadir", POPT_ARG_STRING, CLI_DATADIR,    N_("Add data directory"),                N_("data directory") },
+		{ "debug", POPT_ARG_STRING, CLI_DEBUG,      N_("Show debug for given level"),        N_("debug level") },
+		{ "debugfile", POPT_ARG_STRING, CLI_DEBUGFILE,  N_("Log debug output to file"),          N_("file") },
+		{ "flush-debug-stderr", POPT_ARG_NONE, CLI_FLUSHDEBUGSTDERR, N_("Flush all debug output written to stderr"), nullptr },
+		{ "fullscreen", POPT_ARG_NONE, CLI_FULLSCREEN, N_("Play in fullscreen mode"),           nullptr },
+		{ "game", POPT_ARG_STRING, CLI_GAME,       N_("Load a specific game mode"),         N_("level name") },
+		{ "help",  POPT_ARG_NONE, CLI_HELP,       N_("Show options and exit"),             nullptr },
+		{ "mod", POPT_ARG_STRING, CLI_MOD_GLOB,   N_("Enable a global mod"),               N_("mod") },
+		{ "mod_ca", POPT_ARG_STRING, CLI_MOD_CA,     N_("Enable a campaign only mod"),        N_("mod") },
+		{ "mod_mp", POPT_ARG_STRING, CLI_MOD_MP,     N_("Enable a multiplay only mod"),       N_("mod") },
+		{ "noassert", POPT_ARG_NONE, CLI_NOASSERT,   N_("Disable asserts"),                   nullptr },
+		{ "crash", POPT_ARG_NONE, CLI_CRASH,      N_("Causes a crash to test the crash handler"), nullptr },
+		{ "loadskirmish", POPT_ARG_STRING, CLI_LOADSKIRMISH, N_("Load a saved skirmish game"),     N_("savegame") },
+		{ "loadcampaign", POPT_ARG_STRING, CLI_LOADCAMPAIGN, N_("Load a saved campaign game"),     N_("savegame") },
+		{ "window", POPT_ARG_NONE, CLI_WINDOW,     N_("Play in windowed mode"),             nullptr },
+		{ "version", POPT_ARG_NONE, CLI_VERSION,    N_("Show version information and exit"), nullptr },
+		{ "resolution", POPT_ARG_STRING, CLI_RESOLUTION, N_("Set the resolution to use"),         N_("WIDTHxHEIGHT") },
+		{ "shadows", POPT_ARG_NONE, CLI_SHADOWS,    N_("Enable shadows"),                    nullptr },
+		{ "noshadows", POPT_ARG_NONE, CLI_NOSHADOWS,  N_("Disable shadows"),                   nullptr },
+		{ "sound", POPT_ARG_NONE, CLI_SOUND,      N_("Enable sound"),                      nullptr },
+		{ "nosound", POPT_ARG_NONE, CLI_NOSOUND,    N_("Disable sound"),                     nullptr },
+		{ "join", POPT_ARG_STRING, CLI_CONNECTTOIP, N_("Connect directly to IP/hostname"),  N_("host") },
+		{ "host", POPT_ARG_NONE, CLI_HOSTLAUNCH, N_("Go directly to host screen"),        nullptr },
+		{ "texturecompression", POPT_ARG_NONE, CLI_TEXTURECOMPRESSION, N_("Enable texture compression"), nullptr },
+		{ "notexturecompression", POPT_ARG_NONE, CLI_NOTEXTURECOMPRESSION, N_("Disable texture compression"), nullptr },
+		{ "autogame", POPT_ARG_NONE, CLI_AUTOGAME,   N_("Run games automatically for testing"), nullptr },
+		{ "saveandquit", POPT_ARG_STRING, CLI_SAVEANDQUIT, N_("Immediately save game and quit"), N_("save name") },
+		{ "skirmish", POPT_ARG_STRING, CLI_SKIRMISH,   N_("Start skirmish game with given settings file"), N_("test") },
 		// Terminating entry
-		{ nullptr, 0,               nullptr, 0,              nullptr,                                    nullptr },
+		{ nullptr, 0, 0,              nullptr,                                    nullptr },
 	};
 
 	static struct poptOption TranslatedOptionsTable[sizeof(optionsTable) / sizeof(struct poptOption)];

--- a/src/clparse.cpp
+++ b/src/clparse.cpp
@@ -85,7 +85,8 @@ static std::string wz_test;
 
 static void poptPrintHelp(poptContext ctx, FILE *output, bool show_all)
 {
-	fprintf(output, "Usage: %s [OPTION...]\n", ctx->argv[0]);
+	// TRANSLATORS: Summary of commandline option syntax
+	fprintf(output, _("Usage: %s [OPTION...]\n"), ctx->argv[0]);
 	for (int i = 0; i < ctx->size; i++)
 	{
 		char txt[128];


### PR DESCRIPTION
The commandline interface can print a usage message listing its options.
Its first line was untranslatable. This has been fixed.

When printing commandline option arguments, the help text could appear
misaligned in terminal output because of multibyte characters:

```
Usage: ../warzone2100/src/warzone2100 [OPTION...]
  --configdir=设定资料夹           设定设定资料夹
  --datadir=资料夹                   Add data directory
  --debug=debug level                   Show debug for given level
  --debugfile=档案                    将除错讯息输出至档案
  --flush-debug-stderr                  Flush all debug output written to stderr
  --fullscreen                          以全萤幕模式运行
  --game=level name                     Load a specific game mode
  -h, --help                            Show options and exit
  --help-all                            Show all options and exit
  --mod=mod                             开启global mod
  --mod_ca=mod                          开启战役模式
  --mod_mp=mod                          开启多人模式
  --noassert                            停用宣告
  --crash                               引发一个事故去进行一个事故处理程序测试
  --loadskirmish=储存游戏           Load a saved skirmish game
  --loadcampaign=储存游戏           Load a saved campaign game
  --window                              以视窗模式运行
  --version                             显示版本资讯及离开
  --resolution=宽 x 高                设定解析度
  --shadows                             开启影子
  --noshadows                           关闭影子
  --sound                               开启声音
  --nosound                             关闭声音
  --join=host                           Connect directly to IP/hostname
  --host                                Go directly to host screen
  --texturecompression                  启用纹理压缩
  --notexturecompression                禁用纹理压缩
  --autogame                            Run games automatically for testing
  --saveandquit=save name               Immediately save game and quit
  --skirmish=test                       Start skirmish game with given settings file
```

To solve this problem, the number of spaces between option arguments and
option summaries is reduced by the number of multibyte characters.
If the game is running with a Chinese or Korean locale, that number is
halved because CJK characters usually require two columns for printing.

The option --help had the single-dash alias -h, which has been removed.
It no longer omits some commandline switches, but lists all of them.
Consequently, the option --help-all has been removed as well.
Note that neither -h nor --help-all were documented in our man page.
Removing them makes commandline processing a bit easier.
To that end, a useless nullpointer variable for all commandline options
has also been removed.

After applying this PR, the terminal output in Chinese looks as below:

```
Usage: ../warzone2100/src/warzone2100 [OPTION...]
  --configdir=设定资料夹                设定设定资料夹
  --datadir=资料夹                      Add data directory
  --debug=debug level                   Show debug for given level
  --debugfile=档案                      将除错讯息输出至档案
  --flush-debug-stderr                  Flush all debug output written to stderr
  --fullscreen                          以全萤幕模式运行
  --game=level name                     Load a specific game mode
  --help                                Show options and exit
  --mod=mod                             开启global mod
  --mod_ca=mod                          开启战役模式
  --mod_mp=mod                          开启多人模式
  --noassert                            停用宣告
  --crash                               引发一个事故去进行一个事故处理程序测试
  --loadskirmish=储存游戏               Load a saved skirmish game
  --loadcampaign=储存游戏               Load a saved campaign game
  --window                              以视窗模式运行
  --version                             显示版本资讯及离开
  --resolution=宽 x 高                  设定解析度
  --shadows                             开启影子
  --noshadows                           关闭影子
  --sound                               开启声音
  --nosound                             关闭声音
  --join=host                           Connect directly to IP/hostname
  --host                                Go directly to host screen
  --texturecompression                  启用纹理压缩
  --notexturecompression                禁用纹理压缩
  --autogame                            Run games automatically for testing
  --saveandquit=save name               Immediately save game and quit
  --skirmish=test                       Start skirmish game with given settings file
```

The attached ZIP file contains
* help texts in Chinese, English and German before and after this PR
* a shell script to generate them

[cli_help_documentation.zip](https://github.com/Warzone2100/warzone2100/files/3356994/cli_help_documentation.zip)