### PR TITLE
Fix bug tracker and wiki URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ Latest development builds
 Reporting bugs
 --------------
 
-This game still has bugs and if you run into one, please use the bugtracker
-(http://developer.wz2100.net/) to report this bug. In order to faster fix
+This game still has bugs and if you run into one, please use the GitHub bugtracker
+(https://github.com/Warzone2100/warzone2100/issues) to report this bug. In order to faster fix
 those bugs we require that you follow these rules:
 
    1. If the game crashes you may save a memory dump. Please do so and upload it

--- a/doc/Release.md
+++ b/doc/Release.md
@@ -150,8 +150,6 @@ Additionally:
 
 Then you should revert the changes you made to `configure.ac`, so that git master again becomes git master.
 
-Go to [trac](http://developer.wz2100.net/admin/ticket/versions) to add the new version to the bug tracker.
-
 Time to publish the release!
 ----------------------------
  * Add new version to the Bug Tracker, just in case people find bugs and want to report them.
@@ -165,13 +163,6 @@ Time to publish the release!
 
 And, I am sure that people will spread the word about this new release at the following sites & others.
  * [ModDb](http://www.moddb.com/games/275/warzone-2100), [Softonic](http://warzone-2100.en.softonic.com/), [Gamershell](http://www.gamershell.com/news), [Gamedev](http://www.gamedev.net/community/forums/forum.asp?forum_id=6), [Reddit](www.reddit.com/r/warzone2100)
-
-### Update version numbers in Trac
-
-Add the new release, mark previous release as "(unsupported)" and update the new release as latest version in resolution dropdown:
-
-    http://developer.wz2100.net/admin/ticket/versions
-    http://developer.wz2100.net/admin/ticket/resolution
 
 ### Updating the version numbers on the server
 

--- a/icons/warzone2100.appdata.xml
+++ b/icons/warzone2100.appdata.xml
@@ -17,7 +17,7 @@
 		</p>
 	</description>
 	<url type="homepage">https://wz2100.net/</url>
-	<url type="bugtracker">http://developer.wz2100.net/newticket</url>
+	<url type="bugtracker">https://github.com/Warzone2100/warzone2100/issues/new</url>
 	<url type="faq">http://developer.wz2100.net/wiki/NewFAQ</url>
 	<url type="translate">http://developer.wz2100.net/wiki/Translation</url>
 	<url type="help">http://betaguide.wz2100.net/</url>

--- a/lib/framework/debug.cpp
+++ b/lib/framework/debug.cpp
@@ -528,7 +528,7 @@ void _debug(int line, code_part part, const char *function, const char *str, ...
 #if defined(WZ_OS_WIN)
 			char wbuf[512];
 			ssprintf(wbuf, "%s\n\nPlease check the file (%s) in your configuration directory for more details. \
-				\nDo not forget to upload the %s file, WZdebuginfo.txt and the warzone2100.rpt files in your bug reports at http://developer.wz2100.net/newticket!", useInputBuffer1 ? inputBuffer[1] : inputBuffer[0], WZ_DBGFile, WZ_DBGFile);
+				\nDo not forget to upload the %s file, WZdebuginfo.txt and the warzone2100.rpt files in your bug reports at https://github.com/Warzone2100/warzone2100/issues/new!", useInputBuffer1 ? inputBuffer[1] : inputBuffer[0], WZ_DBGFile, WZ_DBGFile);
 			MessageBoxA(NULL, wbuf, "Warzone has terminated unexpectedly", MB_OK | MB_ICONERROR);
 #elif defined(WZ_OS_MAC)
 			int clickedIndex = \
@@ -537,10 +537,10 @@ void _debug(int line, code_part part, const char *function, const char *str, ...
 			                                  2, "Show Log Files & Open Bug Reporter", "Ignore", NULL);
 			if (clickedIndex == 0)
 			{
-				if (!cocoaOpenURL("http://developer.wz2100.net/newticket"))
+				if (!cocoaOpenURL("https://github.com/Warzone2100/warzone2100/issues/new"))
                 {
                     cocoaShowAlert("Failed to open URL",
-                                   "Could not open URL: http://developer.wz2100.net/newticket\nPlease open this URL manually in your web browser.",
+                                   "Could not open URL: https://github.com/Warzone2100/warzone2100/issues/new\nPlease open this URL manually in your web browser.",
                                    2, "Continue", NULL);
                 }
                 if (strnlen(WZ_DBGFile, sizeof(WZ_DBGFile)/sizeof(WZ_DBGFile[0])) <= 0)

--- a/macosx/Resources/Warzone-Info.plist.in
+++ b/macosx/Resources/Warzone-Info.plist.in
@@ -54,7 +54,7 @@
 			<key>UTTypeIdentifier</key>
 			<string>net.wz2100.wz</string>
 			<key>UTTypeReferenceURL</key>
-			<string>http://developer.wz2100.net/wiki/.wz</string>
+			<string>http://developer.wz2100.net/wiki/ModsAndMaps</string>
 			<key>UTTypeTagSpecification</key>
 			<dict>
 				<key>public.filename-extension</key>
@@ -73,7 +73,7 @@
 			<key>UTTypeIdentifier</key>
 			<string>net.wz2100.wz.mod</string>
 			<key>UTTypeReferenceURL</key>
-			<string>http://developer.wz2100.net/wiki/.wz</string>
+			<string>http://developer.wz2100.net/wiki/ModsAndMaps</string>
 			<key>UTTypeTagSpecification</key>
 			<dict>
 				<key>public.filename-extension</key>
@@ -92,7 +92,7 @@
 			<key>UTTypeIdentifier</key>
 			<string>net.wz2100.wz.cam</string>
 			<key>UTTypeReferenceURL</key>
-			<string>http://developer.wz2100.net/wiki/.wz</string>
+			<string>http://developer.wz2100.net/wiki/ModsAndMaps</string>
 			<key>UTTypeTagSpecification</key>
 			<dict>
 				<key>public.filename-extension</key>
@@ -111,7 +111,7 @@
 			<key>UTTypeIdentifier</key>
 			<string>net.wz2100.wz.gmod</string>
 			<key>UTTypeReferenceURL</key>
-			<string>http://developer.wz2100.net/wiki/.wz</string>
+			<string>http://developer.wz2100.net/wiki/ModsAndMaps</string>
 			<key>UTTypeTagSpecification</key>
 			<dict>
 				<key>public.filename-extension</key>
@@ -130,7 +130,7 @@
 			<key>UTTypeIdentifier</key>
 			<string>net.wz2100.wz.music</string>
 			<key>UTTypeReferenceURL</key>
-			<string>http://developer.wz2100.net/wiki/.wz</string>
+			<string>http://developer.wz2100.net/wiki/ModsAndMaps</string>
 			<key>UTTypeTagSpecification</key>
 			<dict>
 				<key>public.filename-extension</key>

--- a/tools/conversion/pie2wzm.c
+++ b/tools/conversion/pie2wzm.c
@@ -35,7 +35,7 @@ typedef int bool;
 #endif
 
 // The WZM format is a proposed successor to the PIE format used by Warzone.
-// For an explanation of the WZM format, see http://wiki.wz2100.net/WZM_format
+// For an explanation of the WZM format, see http://developer.wz2100.net/wiki/WZM_format
 
 // To compile: gcc -o pie2wzm pie2wzm.c -Wall -g -O0 -Wshadow
 

--- a/tools/display/wzmviewer.c
+++ b/tools/display/wzmviewer.c
@@ -33,7 +33,7 @@
 #endif
 
 // The WZM format is a proposed successor to the PIE format used by Warzone.
-// For an explanation of the WZM format, see http://wiki.wz2100.net/WZM_format
+// For an explanation of the WZM format, see http://developer.wz2100.net/wiki/WZM_format
 
 // To compile: gcc -o wzmviewer wzmviewer.c wzmutils.c -Wall -g -O0 -Wshadow -lpng `sdl-config --libs --cflags` -lGL -lGLU
 

--- a/tools/guidecode/guide.inc.php
+++ b/tools/guidecode/guide.inc.php
@@ -470,7 +470,7 @@ On most distributions of Linux, Warzone should be available in your repositories
 </p>
 <blockquote><p><code>./configure && make</code></p></blockquote>
 <p>
-For compiling tips on other platforms, or if the above fails, see the <a href="http://developer.wz2100.net/wiki/Compile_Guide">Compile Guide</a>.
+For compiling tips on other platforms, or if the above fails, see the <a href="http://developer.wz2100.net/wiki/CompileGuide">Compile Guide</a>.
 </p>
 
 <h3 id="playing">Playing Warzone</h3>
@@ -1998,7 +1998,7 @@ If you\'re new to installing from source on Linux, "the usual" refers to the pro
 </p>
 <blockquote><p><code>./configure && make</code></p></blockquote>
 <p>
-For more detailed information, or if the above fails, see the <a href="http://developer.wz2100.net/wiki/LinuxCompileGuide">Linux Compile Guide</a>.
+For more detailed information, or if the above fails, see the <a href="http://developer.wz2100.net/wiki/CompileGuideLinux">Linux Compile Guide</a>.
 </p>
 <h4 id="other">Other OSes</h4>
 <p>
@@ -3481,7 +3481,7 @@ foreach ($comments as $i => $comment)
 		'autogen' => TRUE,
 		'title' => 'Cheats',
 		'titlebar' => '<span class="arrow">&raquo;</span> <strong>Cheats</strong>',
-		'text' => '<strong style="color:red">These instructions only apply to 2.3 beta 6 and higher. For older versions, see <a href="http://developer.wz2100.net/wiki/Cheats">wiki:cheats</a></strong>
+		'text' => '<strong style="color:red">These instructions only apply to 2.3 beta 6 and higher. For older versions, see <a href="http://developer.wz2100.net/wiki/cheats">wiki:cheats</a></strong>
 <h3 id="enabling">Enabling cheats</h3>
 <p>
 Before you can use cheat codes, you must either use the cheat code "<tt>cheat on</tt>" or press Shift+Backspace. You should get a "Cheats enabled" message when you do this.


### PR DESCRIPTION
Trac's bug tracker has been dropped in favor of GitHub's issue tracker.
References to the old bug tracker still existed in the sourcecode and
have been updated. In addition, broken wiki URLs have been fixed.

Together with #428, this PR contains commits first published in #374.