### PR TITLE
Fix SemperFi-js building its fourth research lab.

### DIFF
--- a/data/mp/multiplay/skirmish/semperfi_includes/build.js
+++ b/data/mp/multiplay/skirmish/semperfi_includes/build.js
@@ -496,7 +496,7 @@ function buildResearchLabs()
 		{
 			amount = 5;
 		}
-		else if (amount >= 7)
+		else if (derrCount >= 7)
 		{
 			amount = 4;
 		}


### PR DESCRIPTION
Semperfi-JS was unable to build its forth research lab due to checking the wrong variable (as revealed by LGTM). This meant it had to jump from 3->5 instantly and that could only happen on maps with a decent average of oils per player (12).

SemperFi-JS may not have a perfect research order or build behavior, but the results of having an additional lab with enough oil derricks is always nice on a lot of maps. Here are some simple 2v2 bot battles to show the difference.

- RollingHills (T1)
- bases
- shared research
- High power
- Medium difficulties

Test 1
Players:
0 - Cobra v1.30 (rocket personality)
1 - Cobra v1.30 (machinegun personality)
2 - SemperFi-JS
3 - SemperFi-JS

Without patch: Cobra team won in 30 minutes.
With patch: Cobra team won in 47 minutes.


Test 2
Players:
0 - Cobra v1.30 (cannon personality)
1 - Cobra v1.30 (cannon personality)
2 - SemperFi-JS
3 - SemperFi-JS

Without patch: Cobra team won in 35 minutes.
With patch: SemperFi-JS team won in 56 minutes

Overall, SemperFi-JS can prove to be a tougher opponent. For other bots, anyway.