### PR TITLE
Remove research differences given from bases and advanced bases.

### DIFF
--- a/data/mp/multiplay/script/camTechEnabler.js
+++ b/data/mp/multiplay/script/camTechEnabler.js
@@ -1,7 +1,6 @@
 
 const TECH_TWO = [
      "R-Comp-CommandTurret01",
-     "R-Comp-SynapticLink",
      "R-Cyborg-Metals01",
      "R-Cyborg-Metals02",
      "R-Cyborg-Metals03",
@@ -116,7 +115,6 @@ const TECH_THREE = [
      "R-Wpn-Rocket-Accuracy02",
      "R-Wpn-Rocket-ROF03",
      "R-Comp-CommandTurret01",
-     "R-Comp-SynapticLink",
      "R-Cyborg-Metals01",
      "R-Cyborg-Metals02",
      "R-Defense-Pillbox01",

--- a/data/mp/multiplay/skirmish/rules.js
+++ b/data/mp/multiplay/skirmish/rules.js
@@ -267,48 +267,16 @@ function eventGameInit()
 	}
 	applyLimitSet();	// set limit options
 
-	const numCleanTech = 4;	// do x for clean
-	const numBaseTech = 18; // do x for base
-	var techlist = new Array(
+	var techlist = [
 		"R-Vehicle-Prop-Wheels",
 		"R-Sys-Spade1Mk1",
 		"R-Vehicle-Body01",
-		"R-Comp-SynapticLink",
-		"R-Wpn-MG1Mk1",
-		"R-Defense-HardcreteWall",
-		"R-Vehicle-Prop-Wheels",
-		"R-Sys-Spade1Mk1",
-		"R-Struc-Factory-Cyborg",
-		"R-Defense-Pillbox01",
-		"R-Defense-Tower01",
-		"R-Vehicle-Body01",
-		"R-Sys-Engineering01",
-		"R-Struc-CommandRelay",
-		"R-Vehicle-Prop-Halftracks",
-		"R-Comp-CommandTurret01",
-		"R-Sys-Sensor-Turret01",
-		"R-Wpn-Flamer01Mk1",
-		"R-Vehicle-Body05",
-		"R-Struc-Research-Module",
-		"R-Struc-PowerModuleMk1",
-		"R-Struc-Factory-Module",
-		"R-Struc-RepairFacility",
-		"R-Sys-MobileRepairTurret01",
-		"R-Vehicle-Engine01",
-		"R-Wpn-MG3Mk1",
-		"R-Wpn-Cannon1Mk1",
-		"R-Wpn-Mortar01Lt",
-		"R-Defense-Pillbox05",
-		"R-Defense-TankTrap01",
-		"R-Defense-WallTower02",
-		"R-Sys-Sensor-Tower01",
-		"R-Defense-Pillbox04",
-		"R-Wpn-MG2Mk1",
-		"R-Wpn-Rocket05-MiniPod",
-		"R-Wpn-MG-Damage01",
-		"R-Wpn-Rocket-Damage01",
-		"R-Defense-WallTower01",
-		"R-Defense-Tower06");
+	];
+	var cyborgComponents = [
+		"CyborgLightBody",
+		"CyborgLegs",
+		"CyborgSpade",
+	];
 
 	for (var playnum = 0; playnum < maxPlayers; playnum++)
 	{
@@ -316,16 +284,22 @@ function eventGameInit()
 		enableResearch("R-Wpn-MG1Mk1", playnum);
 		enableResearch("R-Sys-Engineering01", playnum);
 
-		// enable cyborgs components that can't be enabled with research
-		makeComponentAvailable("CyborgSpade", playnum);
+		for (var count = 0; count < techlist.length; ++count)
+		{
+			completeResearch(techlist[count], playnum);
+		}
+
+		if (baseType !== CAMP_CLEAN)
+		{
+			for (var count = 0; count < cyborgComponents.length; ++count)
+			{
+				makeComponentAvailable(cyborgComponents[count], playnum);
+			}
+		}
 
 		if (baseType == CAMP_CLEAN)
 		{
 			setPower(1300, playnum);
-			for (var count = 0; count < numCleanTech; count++)
-			{
-				completeResearch(techlist[count], playnum);
-			}
 			// Keep only some structures for insane AI
 			var structs = enumStruct(playnum);
 			for (var i = 0; i < structs.length; i++)
@@ -342,10 +316,6 @@ function eventGameInit()
 		else if (baseType == CAMP_BASE)
 		{
 			setPower(2500, playnum);
-			for (var count = 0; count < numBaseTech; count++)
-			{
-				completeResearch(techlist[count], playnum);
-			}
 			// Keep only some structures
 			var structs = enumStruct(playnum);
 			for (var i = 0; i < structs.length; i++)
@@ -361,10 +331,6 @@ function eventGameInit()
 		else // CAMP_WALLS
 		{
 			setPower(2500, playnum);
-			for (var count = 0; count < techlist.length; count++)
-			{
-				completeResearch(techlist[count], playnum);
-			}
 		}
 	}
 


### PR DESCRIPTION
As requested by Vaut, bases and advanced bases shouldn't give additional research bonuses because it is harder to balance them. This only applies for T1 since T2+ includes all these deleted technologies from rules.js.

[topic](http://forums.wz2100.net/viewtopic.php?f=30&p=144739)