### PR TITLE
Remove starting power bonus for insane Beta 1

### DIFF
--- a/data/base/script/campaign/cam2-a.js
+++ b/data/base/script/campaign/cam2-a.js
@@ -293,7 +293,7 @@ function eventGameLoaded()
 
 function eventStartLevel()
 {
-	const PLAYER_POWER = (difficulty === INSANE) ? 9000 : 5000;
+	const PLAYER_POWER = 5000;
 	var startpos = getObject("startPosition");
 	var lz = getObject("landingZone"); //player lz
 	var enemyLz = getObject("COLandingZone");


### PR DESCRIPTION
Since 9de49658725bfaf6929befc6e47c87952ef00396 players receive 9000
power at the start of Beta 1 with difficulty Insane, but only 5000 power
with other difficulty levels.

Highlander1599 and me both think that this rule is too permissive:
http://forums.wz2100.net/viewtopic.php?p=144747#p144747

With this PR, Beta 1 begins with 5000 starting power regardless of the
campaign difficulty setting used.