### PR TITLE
Fix intelligence display sequences not shutting down.

### DIFF
--- a/src/intelmap.cpp
+++ b/src/intelmap.cpp
@@ -913,6 +913,11 @@ void intRemoveMessageView(bool animated)
 	{
 		seq_RenderVideoToBuffer(psViewResearch->sequenceName, SEQUENCE_KILL);
 	}
+	else
+	{
+		const WzString dummy = "";
+		seq_RenderVideoToBuffer(dummy, SEQUENCE_KILL);
+	}
 
 	if (animated)
 	{


### PR DESCRIPTION
Video sequences were not being shut down correctly since 41af29c6a58431042cd2649b8aa1984c8e53ef0a.

Fixes #431.