### PR TITLE
Add subscriber checks to a few more labels.

### DIFF
--- a/data/base/wrf/cam1/cam1a/labels.json
+++ b/data/base/wrf/cam1/cam1a/labels.json
@@ -44,7 +44,8 @@
 	"area_1": {
 		"label": "roadblockArea",
 		"pos1": [4500, 3600],
-		"pos2": [5500, 4700]
+		"pos2": [5500, 4700],
+		"subscriber": 0
 	},
 	"area_2": {
 		"label": "landingZone",
@@ -54,7 +55,8 @@
 	"area_3": {
 		"label": "launchScavAttack",
 		"pos1": [2496, 6080],
-		"pos2": [4928, 7232]
+		"pos2": [4928, 7232],
+		"subscriber": 0
 	},
 	"area_4": {
 		"label": "scavBase1Cleanup",
@@ -69,7 +71,8 @@
 	"area_6": {
 		"label": "scavBase3Cleanup",
 		"pos1": [1088, 1216],
-		"pos2": [2240, 2240]
+		"pos2": [2240, 2240],
+		"subscriber": 0
 	},
 	"area_7": {
 		"label": "scavBase4Cleanup",

--- a/data/base/wrf/cam1/sub1-1/labels.json
+++ b/data/base/wrf/cam1/sub1-1/labels.json
@@ -61,17 +61,20 @@
 	"area_6": {
 		"label": "ambush1Trigger",
 		"pos1": [2816, 6272],
-		"pos2": [5504, 6600]
+		"pos2": [5504, 6600],
+		"subscriber": 0
 	},
 	"area_7": {
 		"label": "ambush2Trigger",
 		"pos1": [1024, 7680],
-		"pos2": [1408, 8320]
+		"pos2": [1408, 8320],
+		"subscriber": 0
 	},
 	"area_8": {
 		"label": "scavBaseTrigger",
 		"pos1": [2048, 3000],
-		"pos2": [5504, 3300]
+		"pos2": [5504, 3300],
+		"subscriber": 0
 	},
 
 	"object_0": {

--- a/data/base/wrf/cam3/cam3c/labels.json
+++ b/data/base/wrf/cam3/cam3c/labels.json
@@ -86,7 +86,8 @@
 	"area_7": {
 		"label": "gammaBaseTrigger",
 		"pos1": [192, 22208],
-		"pos2": [2368, 24256]
+		"pos2": [2368, 24256],
+		"subscriber": 0
 	},
 	"area_8": {
 		"label": "northBaseCleanup",


### PR DESCRIPTION
These trigger labels could be triggered by non-player units. Out of those, Alpha 1 area label "roadBlockArea" could activate the second base factory early when scavengers run though it, and the act of the third base factory producing units would trigger the 4th base factory early. The others are a non-factor unless a mod does something to make units pass through them.