### PR TITLE
Don't skip drawing animation frames at animation start.

### DIFF
--- a/src/display3d.cpp
+++ b/src/display3d.cpp
@@ -366,12 +366,13 @@ bool drawShape(BASE_OBJECT *psObj, iIMDShape *strImd, int colour, PIELIGHT build
 	}
 	if (strImd->objanimframes)
 	{
-		const int elapsed = graphicsTime - psObj->timeAnimationStarted;
+		int elapsed = graphicsTime - psObj->timeAnimationStarted;
 		if (elapsed < 0)
 		{
-			return false;  // Animation hasn't started yet.
+			elapsed = 0; // Animation hasn't started yet.
 		}
 		const int frame = (elapsed / strImd->objanimtime) % strImd->objanimframes;
+		ASSERT(frame < strImd->objanimframes, "Bad index %d >= %d", frame, strImd->objanimframes);
 		const ANIMFRAME &state = strImd->objanimdata.at(frame);
 		if (state.scale.x == -1.0f) // disabled frame, for implementing key frame animation
 		{


### PR DESCRIPTION
Commit 123ded59aedc53dc2344be9807c321774613946f can result in dropped animation frames. This most knowingly manifests itself as cyborg legs disappearing for each animation start. My solution is to just display the first frame in the event animations haven't started yet. Preventing draw updates from being skipped.

This patch stops (super)cyborg legs from disappearing and the entire scavenger model from flickering. The Mechs in MIH-XTC's EBmod are fixed also by this. ArtRev has an errant 3rd frame for its super cyborg run animation, which is a easy fix (-1.0 1.0 1.0 -> 1.0 1.0 1.0).

I wouldn't think this would cause issues?