### PR TITLE
TitleUI refactor & fix for password box in IP mode

### DIFF
--- a/lib/sdl/cursors_sdl.cpp
+++ b/lib/sdl/cursors_sdl.cpp
@@ -25,7 +25,6 @@
 #include "lib/ivis_opengl/bitimage.h"
 #include "lib/ivis_opengl/tex.h"
 #include "src/warzoneconfig.h"
-#include "src/frontend.h"
 #include "cursors_sdl.h"
 #include <SDL.h>
 
@@ -1361,8 +1360,8 @@ SDL_Cursor *init_system_cursor32(CURSOR cur)
 void wzSetCursor(CURSOR cur)
 {
 	ASSERT(cur < CURSOR_MAX, "Specified cursor(%d) is over our limit of (%d)!", (int)cur, (int)CURSOR_MAX);
-	// we reset mouse cursors on the fly...(only in the mouse options screen!)
-	if ((!(war_GetColouredCursor() ^ monoCursor)) && (titleMode == MOUSE_OPTIONS))
+	// If mouse cursor options change, change cursors (used to only work on mouse options screen for some reason)
+	if (!(war_GetColouredCursor() ^ monoCursor))
 	{
 		sdlFreeCursors();
 		war_GetColouredCursor() ? sdlInitColoredCursors() : sdlInitCursors();

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -322,6 +322,8 @@ src/template.cpp
 src/terrain.cpp
 src/text.cpp
 src/texture.cpp
+src/titleui/old.cpp
+src/titleui/titleui.cpp
 src/transporter.cpp
 src/version.cpp
 src/visibility.cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -86,7 +86,7 @@ if(ENABLE_NLS)
 endif()
 
 file(GLOB HEADERS "*.h")
-file(GLOB SRC "*.cpp")
+file(GLOB SRC "*.cpp" "*/*.cpp")
 qt5_wrap_cpp(MOCFILES qtscriptdebug.h)
 
 set(_additionalSourceFiles)

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -155,6 +155,7 @@ noinst_HEADERS = \
 	terrain.h \
 	text.h \
 	texture.h \
+	titleui/titleui.h \
 	transporter.h \
 	visibility.h \
 	version.h \
@@ -268,6 +269,8 @@ COMMONSOURCES = \
 	terrain.cpp \
 	text.cpp \
 	texture.cpp \
+	titleui/old.cpp \
+	titleui/titleui.cpp \
 	transporter.cpp \
 	version.cpp \
 	visibility.cpp \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -271,6 +271,7 @@ COMMONSOURCES = \
 	texture.cpp \
 	titleui/msgbox.cpp \
 	titleui/old.cpp \
+	titleui/passbox.cpp \
 	titleui/protocol.cpp \
 	titleui/titleui.cpp \
 	transporter.cpp \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -269,7 +269,9 @@ COMMONSOURCES = \
 	terrain.cpp \
 	text.cpp \
 	texture.cpp \
+	titleui/msgbox.cpp \
 	titleui/old.cpp \
+	titleui/protocol.cpp \
 	titleui/titleui.cpp \
 	transporter.cpp \
 	version.cpp \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -269,6 +269,7 @@ COMMONSOURCES = \
 	terrain.cpp \
 	text.cpp \
 	texture.cpp \
+	titleui/gamefind.cpp \
 	titleui/msgbox.cpp \
 	titleui/old.cpp \
 	titleui/passbox.cpp \

--- a/src/challenge.cpp
+++ b/src/challenge.cpp
@@ -417,7 +417,7 @@ success:
 	closeChallenges();
 	challengeActive = true;
 	ingame.bHostSetup = true;
-	changeTitleUI(std::make_shared<WzMultiOptionTitleUI>());
+	changeTitleUI(std::make_shared<WzMultiOptionTitleUI>(wzTitleUICurrent));
 	return true;
 }
 

--- a/src/challenge.cpp
+++ b/src/challenge.cpp
@@ -41,6 +41,7 @@
 #include "loadsave.h"
 #include "multiplay.h"
 #include "mission.h"
+#include "titleui/titleui.h"
 
 #define totalslots 36			// challenge slots
 #define slotsInColumn 12		// # of slots in a column
@@ -416,7 +417,7 @@ success:
 	closeChallenges();
 	challengeActive = true;
 	ingame.bHostSetup = true;
-	changeTitleMode(MULTIOPTION);
+	changeTitleUI(std::make_shared<WzMultiOptionTitleUI>());
 	return true;
 }
 

--- a/src/frontend.cpp
+++ b/src/frontend.cpp
@@ -88,8 +88,6 @@ struct CAMPAIGN_FILE
 // ////////////////////////////////////////////////////////////////////////////
 // Global variables
 
-tMode lastTitleMode; // Since skirmish and multiplayer setup use the same functions, we use this to go back to the corresponding menu.
-
 char			aLevelName[MAX_LEVEL_NAME_SIZE + 1];	//256];			// vital! the wrf file to use.
 
 bool			bLimiterLoaded = false;
@@ -532,8 +530,7 @@ bool runSinglePlayerMenu()
 		case FRONTEND_SKIRMISH:
 			SPinit();
 			ingame.bHostSetup = true;
-			lastTitleMode = SINGLE;
-			changeTitleUI(std::make_shared<WzMultiOptionTitleUI>());
+			changeTitleUI(std::make_shared<WzMultiOptionTitleUI>(wzTitleUICurrent));
 			break;
 
 		case FRONTEND_QUIT:
@@ -609,8 +606,7 @@ bool runMultiPlayerMenu()
 		NETinit(true);
 		NETdiscoverUPnPDevices();
 		game.type = SKIRMISH;		// needed?
-		lastTitleMode = MULTI;
-		changeTitleUI(std::make_shared<WzMultiOptionTitleUI>());
+		changeTitleUI(std::make_shared<WzMultiOptionTitleUI>(wzTitleUICurrent));
 		break;
 	case FRONTEND_JOIN:
 		NETinit(true);
@@ -619,7 +615,7 @@ bool runMultiPlayerMenu()
 		{
 			setLobbyError(ERROR_NOERROR);
 		}
-		changeTitleMode(PROTOCOL);
+		changeTitleUI(std::make_shared<WzProtocolTitleUI>());
 		break;
 
 	case FRONTEND_QUIT:
@@ -2162,6 +2158,6 @@ void frontendScreenSizeDidChange(int oldWidth, int oldHeight, int newWidth, int 
 	if (wzTitleUICurrent)
 	{
 		std::shared_ptr<WzTitleUI> current = wzTitleUICurrent;
-		current->screenSizeDidChange();
+		current->screenSizeDidChange(oldWidth, oldHeight, newWidth, newHeight);
 	}
 }

--- a/src/frontend.cpp
+++ b/src/frontend.cpp
@@ -73,7 +73,7 @@
 #include "version.h"
 #include "warzoneconfig.h"
 #include "wrappers.h"
-
+#include "titleui/titleui.h"
 
 struct CAMPAIGN_FILE
 {
@@ -88,7 +88,6 @@ struct CAMPAIGN_FILE
 // ////////////////////////////////////////////////////////////////////////////
 // Global variables
 
-tMode titleMode; // the global case
 tMode lastTitleMode; // Since skirmish and multiplayer setup use the same functions, we use this to go back to the corresponding menu.
 
 char			aLevelName[MAX_LEVEL_NAME_SIZE + 1];	//256];			// vital! the wrf file to use.
@@ -136,12 +135,12 @@ template <typename T> static T pow2Cycle(T value, T min, T max)
 
 // ////////////////////////////////////////////////////////////////////////////
 // Title Screen
-static bool startTitleMenu()
+void startTitleMenu()
 {
 	intRemoveReticule();
 
 	addBackdrop();
-	addTopForm();
+	addTopForm(false);
 	addBottomForm();
 
 	addTextButton(FRONTEND_SINGLEPLAYER, FRONTEND_POS2X, FRONTEND_POS2Y, _("Single Player"), WBUT_TXTCENTRE);
@@ -172,8 +171,6 @@ static bool startTitleMenu()
 	pRightAlignedButton->move(pRightAlignedButton->parent()->width() - (pRightAlignedButton->width() + 6), pRightAlignedButton->y());
 	widgSetTip(psWScreen, FRONTEND_CHATLINK, _("Connect to Freenode through webchat by clicking this link."));
 	addMultiBut(psWScreen, FRONTEND_BOTFORM, FRONTEND_UPGRDLINK, 7, 7, MULTIOP_BUTW, MULTIOP_BUTH, _("Check for a newer version"), IMAGE_GAMEVERSION, IMAGE_GAMEVERSION_HI, true);
-
-	return true;
 }
 
 static void runLink(char const *link)
@@ -271,10 +268,10 @@ bool runTitleMenu()
 
 // ////////////////////////////////////////////////////////////////////////////
 // Tutorial Menu
-static bool startTutorialMenu()
+void startTutorialMenu()
 {
 	addBackdrop();
-	addTopForm();
+	addTopForm(false);
 	addBottomForm();
 
 
@@ -283,8 +280,6 @@ static bool startTutorialMenu()
 	addSideText(FRONTEND_SIDETEXT , FRONTEND_SIDEX, FRONTEND_SIDEY, _("TUTORIALS"));
 	// TRANSLATORS: "Return", in this context, means "return to previous screen/menu"
 	addMultiBut(psWScreen, FRONTEND_BOTFORM, FRONTEND_QUIT, 10, 10, 30, 29, P_("menu", "Return"), IMAGE_RETURN, IMAGE_RETURN_HI, IMAGE_RETURN_HI);
-
-	return true;
 }
 
 bool runTutorialMenu()
@@ -331,11 +326,11 @@ bool runTutorialMenu()
 
 // ////////////////////////////////////////////////////////////////////////////
 // Single Player Menu
-static void startSinglePlayerMenu()
+void startSinglePlayerMenu()
 {
 	challengeActive = false;
 	addBackdrop();
-	addTopForm();
+	addTopForm(false);
 	addBottomForm();
 
 	addTextButton(FRONTEND_NEWGAME,  FRONTEND_POS2X, FRONTEND_POS2Y, _("New Campaign") , WBUT_TXTCENTRE);
@@ -379,10 +374,10 @@ static std::vector<CAMPAIGN_FILE> readCampaignFiles()
 	return result;
 }
 
-static void startCampaignSelector()
+void startCampaignSelector()
 {
 	addBackdrop();
-	addTopForm();
+	addTopForm(false);
 	addBottomForm();
 
 	std::vector<CAMPAIGN_FILE> list = readCampaignFiles();
@@ -538,7 +533,7 @@ bool runSinglePlayerMenu()
 			SPinit();
 			ingame.bHostSetup = true;
 			lastTitleMode = SINGLE;
-			changeTitleMode(MULTIOPTION);
+			changeTitleUI(std::make_shared<WzMultiOptionTitleUI>());
 			break;
 
 		case FRONTEND_QUIT:
@@ -579,10 +574,10 @@ bool runSinglePlayerMenu()
 
 // ////////////////////////////////////////////////////////////////////////////
 // Multi Player Menu
-static bool startMultiPlayerMenu()
+void startMultiPlayerMenu()
 {
 	addBackdrop();
-	addTopForm();
+	addTopForm(false);
 	addBottomForm();
 
 	addSideText(FRONTEND_SIDETEXT ,	FRONTEND_SIDEX, FRONTEND_SIDEY, _("MULTI PLAYER"));
@@ -594,8 +589,6 @@ static bool startMultiPlayerMenu()
 
 	// This isn't really a hyperlink for now... perhaps link to the wiki ?
 	addSmallTextButton(FRONTEND_HYPERLINK, FRONTEND_POS8X, FRONTEND_POS8Y, _("TCP port 2100 must be opened in your firewall or router to host games!"), 0);
-
-	return true;
 }
 
 bool runMultiPlayerMenu()
@@ -617,7 +610,7 @@ bool runMultiPlayerMenu()
 		NETdiscoverUPnPDevices();
 		game.type = SKIRMISH;		// needed?
 		lastTitleMode = MULTI;
-		changeTitleMode(MULTIOPTION);
+		changeTitleUI(std::make_shared<WzMultiOptionTitleUI>());
 		break;
 	case FRONTEND_JOIN:
 		NETinit(true);
@@ -649,12 +642,12 @@ bool runMultiPlayerMenu()
 
 // ////////////////////////////////////////////////////////////////////////////
 // Options Menu
-static bool startOptionsMenu()
+void startOptionsMenu()
 {
 	sliderEnableDrag(true);
 
 	addBackdrop();
-	addTopForm();
+	addTopForm(false);
 	addBottomForm();
 
 	addSideText(FRONTEND_SIDETEXT, FRONTEND_SIDEX, FRONTEND_SIDEY, _("OPTIONS"));
@@ -665,8 +658,6 @@ static bool startOptionsMenu()
 	addTextButton(FRONTEND_MOUSEOPTIONS, FRONTEND_POS6X, FRONTEND_POS6Y, _("Mouse Options"), WBUT_TXTCENTRE);
 	addTextButton(FRONTEND_KEYMAP,		FRONTEND_POS7X, FRONTEND_POS7Y, _("Key Mappings"), WBUT_TXTCENTRE);
 	addMultiBut(psWScreen, FRONTEND_BOTFORM, FRONTEND_QUIT, 10, 10, 30, 29, P_("menu", "Return"), IMAGE_RETURN, IMAGE_RETURN_HI, IMAGE_RETURN_HI);
-
-	return true;
 }
 
 bool runOptionsMenu()
@@ -756,10 +747,10 @@ static char const *graphicsOptionsRadarJumpString()
 
 // ////////////////////////////////////////////////////////////////////////////
 // Graphics Options
-static bool startGraphicsOptionsMenu()
+void startGraphicsOptionsMenu()
 {
 	addBackdrop();
-	addTopForm();
+	addTopForm(false);
 	addBottomForm();
 
 	////////////
@@ -795,8 +786,6 @@ static bool startGraphicsOptionsMenu()
 	////////////
 	// quit.
 	addMultiBut(psWScreen, FRONTEND_BOTFORM, FRONTEND_QUIT, 10, 10, 30, 29, P_("menu", "Return"), IMAGE_RETURN, IMAGE_RETURN_HI, IMAGE_RETURN_HI);
-
-	return true;
 }
 
 bool runGraphicsOptionsMenu()
@@ -885,10 +874,10 @@ static std::string audioAndZoomOptionsRadarZoomString()
 
 // ////////////////////////////////////////////////////////////////////////////
 // Audio and Zoom Options Menu
-static bool startAudioAndZoomOptionsMenu()
+void startAudioAndZoomOptionsMenu()
 {
 	addBackdrop();
-	addTopForm();
+	addTopForm(false);
 	addBottomForm();
 
 	// 2d audio
@@ -933,8 +922,6 @@ static bool startAudioAndZoomOptionsMenu()
 		addSideText(FRONTEND_MULTILINE_SIDETEXT, FRONTEND_SIDEX + 22, \
 		FRONTEND_SIDEY, messageString.toUtf8().c_str());
 	}
-
-	return true;
 }
 
 bool runAudioAndZoomOptionsMenu()
@@ -1118,10 +1105,10 @@ void refreshCurrentVideoOptionsValues()
 	}
 }
 
-static bool startVideoOptionsMenu()
+void startVideoOptionsMenu()
 {
 	addBackdrop();
-	addTopForm();
+	addTopForm(false);
 	addBottomForm();
 
 	// Add a note about changes taking effect on restart for certain options
@@ -1173,8 +1160,6 @@ static bool startVideoOptionsMenu()
 	addMultiBut(psWScreen, FRONTEND_BOTFORM, FRONTEND_QUIT, 10, 10, 30, 29, P_("menu", "Return"), IMAGE_RETURN, IMAGE_RETURN_HI, IMAGE_RETURN_HI);
 
 	refreshCurrentVideoOptionsValues();
-
-	return true;
 }
 
 // Get available resolutions list, sorted, with duplicates removed.
@@ -1475,10 +1460,10 @@ static char const *mouseOptionsScrollEventString()
 
 // ////////////////////////////////////////////////////////////////////////////
 // Mouse Options
-static bool startMouseOptionsMenu()
+void startMouseOptionsMenu()
 {
 	addBackdrop();
-	addTopForm();
+	addTopForm(false);
 	addBottomForm();
 
 	////////////
@@ -1513,8 +1498,6 @@ static bool startMouseOptionsMenu()
 
 	// Quit/return
 	addMultiBut(psWScreen, FRONTEND_BOTFORM, FRONTEND_QUIT, 10, 10, 30, 29, P_("menu", "Return"), IMAGE_RETURN, IMAGE_RETURN_HI, IMAGE_RETURN_HI);
-
-	return true;
 }
 
 bool runMouseOptionsMenu()
@@ -1608,13 +1591,13 @@ static std::string gameOptionsCameraSpeedString()
 
 // ////////////////////////////////////////////////////////////////////////////
 // Game Options Menu
-static bool startGameOptionsMenu()
+void startGameOptionsMenu()
 {
 	UDWORD	w, h;
 	int playercolor;
 
 	addBackdrop();
-	addTopForm();
+	addTopForm(false);
 	addBottomForm();
 
 	// language
@@ -1667,8 +1650,6 @@ static bool startGameOptionsMenu()
 
 	// Add some text down the side of the form
 	addSideText(FRONTEND_SIDETEXT, FRONTEND_SIDEX, FRONTEND_SIDEY, _("GAME OPTIONS"));
-
-	return true;
 }
 
 bool runGameOptionsMenu()
@@ -1954,22 +1935,24 @@ void addBackdrop()
 }
 
 // ////////////////////////////////////////////////////////////////////////////
-void addTopForm()
+void addTopForm(bool wide)
 {
 	WIDGET *parent = widgGetFromID(psWScreen, FRONTEND_BACKDROP);
 
 	IntFormAnimated *topForm = new IntFormAnimated(parent, false);
 	topForm->id = FRONTEND_TOPFORM;
-	topForm->setCalcLayout(LAMBDA_CALCLAYOUT_SIMPLE({
-		if (titleMode == MULTIOPTION)
-		{
+	if (wide)
+	{
+		topForm->setCalcLayout(LAMBDA_CALCLAYOUT_SIMPLE({
 			psWidget->setGeometry(FRONTEND_TOPFORM_WIDEX, FRONTEND_TOPFORM_WIDEY, FRONTEND_TOPFORM_WIDEW, FRONTEND_TOPFORM_WIDEH);
-		}
-		else
-		{
+		}));
+	}
+	else
+	{
+		topForm->setCalcLayout(LAMBDA_CALCLAYOUT_SIMPLE({
 			psWidget->setGeometry(FRONTEND_TOPFORMX, FRONTEND_TOPFORMY, FRONTEND_TOPFORMW, FRONTEND_TOPFORMH);
-		}
-	}));
+		}));
+	}
 
 	W_FORMINIT sFormInit;
 	sFormInit.formID = FRONTEND_TOPFORM;
@@ -2164,79 +2147,7 @@ void addFESlider(UDWORD id, UDWORD parent, UDWORD x, UDWORD y, UDWORD stops, UDW
 // Change Mode
 void changeTitleMode(tMode mode)
 {
-	tMode oldMode;
-
-	widgDelete(psWScreen, FRONTEND_BACKDROP);		// delete backdrop.
-
-	oldMode = titleMode;							// store old mode
-	titleMode = mode;								// set new mode
-
-	switch (mode)
-	{
-	case CAMPAIGNS:
-		startCampaignSelector();
-		break;
-	case SINGLE:
-		startSinglePlayerMenu();
-		break;
-	case GAME:
-		startGameOptionsMenu();
-		break;
-	case GRAPHICS_OPTIONS:
-		startGraphicsOptionsMenu();
-		break;
-	case AUDIO_AND_ZOOM_OPTIONS:
-		startAudioAndZoomOptionsMenu();
-		break;
-	case VIDEO_OPTIONS:
-		startVideoOptionsMenu();
-		break;
-	case MOUSE_OPTIONS:
-		startMouseOptionsMenu();
-		break;
-	case TUTORIAL:
-		startTutorialMenu();
-		break;
-	case OPTIONS:
-		startOptionsMenu();
-		break;
-	case TITLE:
-		startTitleMenu();
-		break;
-	case CREDITS:
-		startCreditsScreen();
-		break;
-	case MULTI:
-		startMultiPlayerMenu();		// goto multiplayer menu
-		break;
-	case PROTOCOL:
-		startConnectionScreen();
-		break;
-	case MULTIOPTION:
-		startMultiOptions(oldMode == MULTILIMIT);
-		break;
-	case GAMEFIND:
-		startGameFind();
-		break;
-	case MULTILIMIT:
-		startLimitScreen();
-		break;
-	case KEYMAP:
-		startKeyMapEditor(true);
-		break;
-	case STARTGAME:
-	case QUIT:
-	case LOADSAVEGAME:
-		bLimiterLoaded = false;
-	case SHOWINTRO:
-		break;
-	default:
-		debug(LOG_FATAL, "Unknown title mode requested");
-		abort();
-		break;
-	}
-
-	return;
+	changeTitleUI(std::make_shared<WzOldTitleUI>(mode));
 }
 
 // ////////////////////////////////////////////////////////////////////////////
@@ -2248,11 +2159,9 @@ void frontendScreenSizeDidChange(int oldWidth, int oldHeight, int newWidth, int 
 	// NOTE:
 	// By setting the appropriate calcLayout functions on all interface elements,
 	// they should automatically recalculate their layout on screen resize.
-
-	// If the Video Options screen is up, the current resolution text (and other values) should be refreshed
-	if (titleMode == VIDEO_OPTIONS)
+	if (wzTitleUICurrent)
 	{
-		ASSERT(widgGetFromID(psWScreen, FRONTEND_WINDOWMODE_R) != nullptr, "Expected the Video options menu to be open.");
-		refreshCurrentVideoOptionsValues();
+		std::shared_ptr<WzTitleUI> current = wzTitleUICurrent;
+		current->screenSizeDidChange();
 	}
 }

--- a/src/frontend.h
+++ b/src/frontend.h
@@ -33,24 +33,19 @@ enum tMode
 	GAME,			// 4
 	TUTORIAL,		// 5  tutorial/fastplay
 	CREDITS,		// 6  credits
-	PROTOCOL,		// 7  MULTIPLAYER, select proto
-	OBS_MULTI_OPT,	// 8 MULTIPLAYER, select game options - DO NOT USE, now a WzTitleUI thing, see src/titleui/titleui.h -- 20kdc
-	FORCESELECT,	// 9 MULTIPLAYER, Force design screen
-	GAMEFIND,		// 10 MULTIPLAYER, gamefinder.
-	OBS_MULLIM,		// 11 MULTIPLAYER, Limit the multistuff - DO NOT USE, now a WzTitleUI thing, see src/titleui/titleui.h -- 20kdc
-	STARTGAME,		// 12 Fire up the game
-	SHOWINTRO,		// 13 reshow the intro
-	QUIT,			// 14 leaving game
-	LOADSAVEGAME,	// 15 loading a save game
-	KEYMAP,			// 16 keymap editor
-	GRAPHICS_OPTIONS,       // 17 graphics options menu
-	AUDIO_AND_ZOOM_OPTIONS, // 18 audio and zoom options menu
-	VIDEO_OPTIONS,          // 19 video options menu
-	MOUSE_OPTIONS,          // 20 mouse options menu
-	CAMPAIGNS,              // 21 campaign selector
+	FORCESELECT,	// 7 MULTIPLAYER, Force design screen
+	GAMEFIND,		// 8 MULTIPLAYER, gamefinder.
+	STARTGAME,		// 9 Fire up the game
+	SHOWINTRO,		// 10 reshow the intro
+	QUIT,			// 11 leaving game
+	LOADSAVEGAME,	// 12 loading a save game
+	KEYMAP,			// 13 keymap editor
+	GRAPHICS_OPTIONS,       // 14 graphics options menu
+	AUDIO_AND_ZOOM_OPTIONS, // 15 audio and zoom options menu
+	VIDEO_OPTIONS,          // 16 video options menu
+	MOUSE_OPTIONS,          // 17 mouse options menu
+	CAMPAIGNS,              // 18 campaign selector
 };
-
-extern tMode lastTitleMode;
 
 #define MAX_LEVEL_NAME_SIZE	(256)
 

--- a/src/frontend.h
+++ b/src/frontend.h
@@ -34,17 +34,16 @@ enum tMode
 	TUTORIAL,		// 5  tutorial/fastplay
 	CREDITS,		// 6  credits
 	FORCESELECT,	// 7 MULTIPLAYER, Force design screen
-	GAMEFIND,		// 8 MULTIPLAYER, gamefinder.
-	STARTGAME,		// 9 Fire up the game
-	SHOWINTRO,		// 10 reshow the intro
-	QUIT,			// 11 leaving game
-	LOADSAVEGAME,	// 12 loading a save game
-	KEYMAP,			// 13 keymap editor
-	GRAPHICS_OPTIONS,       // 14 graphics options menu
-	AUDIO_AND_ZOOM_OPTIONS, // 15 audio and zoom options menu
-	VIDEO_OPTIONS,          // 16 video options menu
-	MOUSE_OPTIONS,          // 17 mouse options menu
-	CAMPAIGNS,              // 18 campaign selector
+	STARTGAME,		// 8 Fire up the game
+	SHOWINTRO,		// 9 reshow the intro
+	QUIT,			// 10 leaving game
+	LOADSAVEGAME,	// 11 loading a save game
+	KEYMAP,			// 12 keymap editor
+	GRAPHICS_OPTIONS,       // 13 graphics options menu
+	AUDIO_AND_ZOOM_OPTIONS, // 14 audio and zoom options menu
+	VIDEO_OPTIONS,          // 15 video options menu
+	MOUSE_OPTIONS,          // 16 mouse options menu
+	CAMPAIGNS,              // 17 campaign selector
 };
 
 #define MAX_LEVEL_NAME_SIZE	(256)

--- a/src/frontend.h
+++ b/src/frontend.h
@@ -34,10 +34,10 @@ enum tMode
 	TUTORIAL,		// 5  tutorial/fastplay
 	CREDITS,		// 6  credits
 	PROTOCOL,		// 7  MULTIPLAYER, select proto
-	MULTIOPTION,	// 8 MULTIPLAYER, select game options
+	OBS_MULTI_OPT,	// 8 MULTIPLAYER, select game options - DO NOT USE, now a WzTitleUI thing, see src/titleui/titleui.h -- 20kdc
 	FORCESELECT,	// 9 MULTIPLAYER, Force design screen
 	GAMEFIND,		// 10 MULTIPLAYER, gamefinder.
-	MULTILIMIT,		// 11 MULTIPLAYER, Limit the multistuff.
+	OBS_MULLIM,		// 11 MULTIPLAYER, Limit the multistuff - DO NOT USE, now a WzTitleUI thing, see src/titleui/titleui.h -- 20kdc
 	STARTGAME,		// 12 Fire up the game
 	SHOWINTRO,		// 13 reshow the intro
 	QUIT,			// 14 leaving game
@@ -50,7 +50,6 @@ enum tMode
 	CAMPAIGNS,              // 21 campaign selector
 };
 
-extern tMode titleMode;					// the global case
 extern tMode lastTitleMode;
 
 #define MAX_LEVEL_NAME_SIZE	(256)
@@ -73,7 +72,7 @@ bool runVideoOptionsMenu();
 bool runMouseOptionsMenu();
 bool runTutorialMenu();
 
-void addTopForm();
+void addTopForm(bool wide);
 void addBottomForm();
 void addBackdrop();
 void addTextButton(UDWORD id, UDWORD PosX, UDWORD PosY, const std::string &txt, unsigned int style);

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -105,7 +105,6 @@ void gameScreenSizeDidChange(unsigned int oldWidth, unsigned int oldHeight, unsi
 	intScreenSizeDidChange(oldWidth, oldHeight, newWidth, newHeight);
 	loadSaveScreenSizeDidChange(oldWidth, oldHeight, newWidth, newHeight);
 	challengesScreenSizeDidChange(oldWidth, oldHeight, newWidth, newHeight);
-	multiOptionsScreenSizeDidChange(oldWidth, oldHeight, newWidth, newHeight);
 	multiMenuScreenSizeDidChange(oldWidth, oldHeight, newWidth, newHeight);
 	display3dScreenSizeDidChange(oldWidth, oldHeight, newWidth, newHeight);
 	consoleScreenDidChangeSize(oldWidth, oldHeight, newWidth, newHeight);

--- a/src/multiint.cpp
+++ b/src/multiint.cpp
@@ -151,19 +151,15 @@ extern bool bSendingMap;			// used to indicate we are sending a map
 
 bool						bHosted			= false;				//we have set up a game
 char						sPlayer[128];							// player name (to be used)
+bool multiintDisableLobbyRefresh = false;	// if we allow lobby to be refreshed or not.
+
 static int					colourChooserUp = -1;
 static int					teamChooserUp = -1;
 static int					aiChooserUp = -1;
 static int					difficultyChooserUp = -1;
 static int					positionChooserUp = -1;
-static SDWORD				dwSelectedGame	= 0;						//player[] and games[] indexes
-static UDWORD				gameNumber;								// index to games icons
-static bool					safeSearch		= false;				// allow auto game finding.
-static bool disableLobbyRefresh = false;	// if we allow lobby to be refreshed or not.
 static UDWORD hideTime = 0;
 LOBBY_ERROR_TYPES LobbyError = ERROR_NOERROR;
-static char tooltipbuffer[MaxGames][256] = {{'\0'}};
-static bool toggleFilter = true;	// Used to show all games or only games that are of the same version
 /// end of globals.
 // ////////////////////////////////////////////////////////////////////////////
 // Function protos
@@ -175,7 +171,6 @@ static void drawReadyButton(UDWORD player);
 
 // Drawing Functions
 static void displayChatEdit(WIDGET *psWidget, UDWORD xOffset, UDWORD yOffset);
-static void displayRemoteGame(WIDGET *psWidget, UDWORD xOffset, UDWORD yOffset);
 static void displayPlayer(WIDGET *psWidget, UDWORD xOffset, UDWORD yOffset);
 static void displayPosition(WIDGET *psWidget, UDWORD xOffset, UDWORD yOffset);
 static void displayColour(WIDGET *psWidget, UDWORD xOffset, UDWORD yOffset);
@@ -200,31 +195,10 @@ struct DisplayAICache {
 struct DisplayDifficultyCache {
 	WzText wzDifficultyText;
 };
-struct DisplayRemoteGameHeaderCache
-{
-	WzText wzHeaderText_GameName;
-	WzText wzHeaderText_MapName;
-	WzText wzHeaderText_Players;
-	WzText wzHeaderText_Status;
-};
-struct DisplayRemoteGameCache
-{
-	WzText wzText_CurrentVsMaxNumPlayers;
-	WidthLimitedWzText wzText_GameName;
-	WidthLimitedWzText wzText_MapName;
-	WidthLimitedWzText wzText_ModNames;
-	WidthLimitedWzText wzText_VersionString;
-};
-
-static DisplayRemoteGameHeaderCache remoteGameListHeaderCache;
-
-// find games
-static void addGames();
 
 // Game option functions
 static	void	addGameOptions();
 static void addChatBox(bool preserveOldChat = false);
-static void		addConsoleBox();
 static	void	disableMultiButs();
 static	void	SendFireUp();
 
@@ -857,11 +831,11 @@ void setLobbyError(LOBBY_ERROR_TYPES error_type)
 	LobbyError = error_type;
 	if (LobbyError <= ERROR_FULL)
 	{
-		disableLobbyRefresh = false;
+		multiintDisableLobbyRefresh = false;
 	}
 	else
 	{
-		disableLobbyRefresh = true;
+		multiintDisableLobbyRefresh = true;
 	}
 }
 
@@ -929,345 +903,6 @@ static bool joinGameInternal(const char *host, uint32_t port, std::shared_ptr<Wz
 	}
 
 	return true;
-}
-
-// ////////////////////////////////////////////////////////////////////////////
-// Game Chooser Screen.
-
-static void addGames()
-{
-	int i, gcount = 0, added = 0;
-	static const char *wrongVersionTip = _("Your version of Warzone is incompatible with this game.");
-
-	//count games to see if need two columns.
-	for (i = 0; i < MaxGames; i++)
-	{
-		if (NetPlay.games[i].desc.dwSize != 0)
-		{
-			gcount++;
-		}
-	}
-
-	W_BUTINIT sButInit;
-	sButInit.formID = FRONTEND_BOTFORM;
-	sButInit.width = GAMES_GAMEWIDTH;
-	sButInit.height = GAMES_GAMEHEIGHT;
-	sButInit.pDisplay = displayRemoteGame;
-	sButInit.initPUserDataFunc = []() -> void * { return new DisplayRemoteGameCache(); };
-	sButInit.onDelete = [](WIDGET *psWidget) {
-		assert(psWidget->pUserData != nullptr);
-		delete static_cast<DisplayRemoteGameCache *>(psWidget->pUserData);
-		psWidget->pUserData = nullptr;
-	};
-
-	// we want the old games deleted, and only list games when we should
-	if (getLobbyError() || !gcount)
-	{
-		for (i = 0; i < MaxGames; i++)
-		{
-			widgDelete(psWScreen, GAMES_GAMESTART + i);	// remove old widget
-		}
-		gcount = 0;
-	}
-	// in case they refresh, and a game becomes available.
-	widgDelete(psWScreen, FRONTEND_NOGAMESAVAILABLE);
-
-	// only have to do this if we have any games available.
-	if (!getLobbyError() && gcount)
-	{
-		for (i = 0; i < MaxGames; i++)							// draw games
-		{
-			widgDelete(psWScreen, GAMES_GAMESTART + i);	// remove old icon.
-
-			if (NetPlay.games[i].desc.dwSize != 0)
-			{
-				// either display all games, or games that are the client's specific version
-				if (toggleFilter)
-				{
-					if ((NetPlay.games[i].game_version_major != (unsigned)NETGetMajorVersion()) || (NetPlay.games[i].game_version_minor != (unsigned)NETGetMinorVersion()))
-					{
-						continue;
-					}
-				}
-				added++;
-				sButInit.id = GAMES_GAMESTART + i;
-				sButInit.x = 20;
-				sButInit.y = (UWORD)(45 + ((5 + GAMES_GAMEHEIGHT) * i));
-
-				// display the correct tooltip message.
-				if (!NETisCorrectVersion(NetPlay.games[i].game_version_major, NetPlay.games[i].game_version_minor))
-				{
-					sButInit.pTip = wrongVersionTip;
-				}
-				else
-				{
-					WzString flags;
-					if (NetPlay.games[i].privateGame)
-					{
-						flags += " "; flags += _("[Password required]");
-					}
-					if (NetPlay.games[i].limits & NO_TANKS)
-					{
-						flags += " "; flags += _("[No Tanks]");
-					}
-					if (NetPlay.games[i].limits & NO_BORGS)
-					{
-						flags += " "; flags += _("[No Cyborgs]");
-					}
-					if (NetPlay.games[i].limits & NO_VTOLS)
-					{
-						flags += " "; flags += _("[No VTOLs]");
-					}
-					if (flags.isEmpty())
-					{
-						ssprintf(tooltipbuffer[i], _("Hosted by %s"), NetPlay.games[i].hostname);
-					}
-					else
-					{
-						ssprintf(tooltipbuffer[i], _("Hosted by %s —%s"), NetPlay.games[i].hostname, flags.toUtf8().c_str());
-					}
-					sButInit.pTip = tooltipbuffer[i];
-				}
-				sButInit.UserData = i;
-
-				widgAddButton(psWScreen, &sButInit);
-			}
-		}
-		if (!added)
-		{
-			sButInit = W_BUTINIT();
-			sButInit.formID = FRONTEND_BOTFORM;
-			sButInit.id = FRONTEND_NOGAMESAVAILABLE;
-			sButInit.x = 70;
-			sButInit.y = 378;
-			sButInit.style = WBUT_TXTCENTRE;
-			sButInit.width = FRONTEND_BUTWIDTH;
-			sButInit.UserData = 0; // store disable state
-			sButInit.height = FRONTEND_BUTHEIGHT;
-			sButInit.pDisplay = displayTextOption;
-			sButInit.pUserData = new DisplayTextOptionCache();
-			sButInit.onDelete = [](WIDGET *psWidget) {
-				assert(psWidget->pUserData != nullptr);
-				delete static_cast<DisplayTextOptionCache *>(psWidget->pUserData);
-				psWidget->pUserData = nullptr;
-			};
-			sButInit.FontID = font_large;
-			sButInit.pText = _("Can't find any games for your version.");
-
-			widgAddButton(psWScreen, &sButInit);
-		}
-	}
-	else
-	{
-		// display lobby message based on results.
-		// This is a 'button', not text so it can be hilighted/centered.
-		const char *txt;
-		W_BUTINIT sButInit;
-
-		switch (getLobbyError())
-		{
-		case ERROR_NOERROR:
-			if (NetPlay.HaveUpgrade)
-			{
-				txt = _("There appears to be a game update available!");
-			}
-			else
-			{
-				txt = _("No games are available for your version");
-			}
-			break;
-		case ERROR_FULL:
-			txt = _("Game is full");
-			break;
-		case ERROR_KICKED:
-		case ERROR_INVALID:
-			txt = _("You were kicked!");
-			break;
-		case ERROR_WRONGVERSION:
-			txt = _("Wrong Game Version!");
-			break;
-		case ERROR_WRONGDATA:
-			txt = _("You have an incompatible mod.");
-			break;
-		// AFAIK, the only way this can really happy is if the Host's file is named wrong, or a client side error.
-		case ERROR_UNKNOWNFILEISSUE:
-			txt = _("Host couldn't send file?");
-			debug(LOG_POPUP, "Warzone couldn't complete a file request.\n\nPossibly, Host's file is incorrect. Check your logs for more details.");
-			break;
-		case ERROR_WRONGPASSWORD:
-			txt = _("Incorrect Password!");
-			break;
-		case ERROR_HOSTDROPPED:
-			txt = _("Host has dropped connection!");
-			break;
-		case ERROR_CONNECTION:
-		default:
-			txt = _("Connection Error");
-			break;
-		}
-
-		// delete old widget if necessary
-		widgDelete(psWScreen, FRONTEND_NOGAMESAVAILABLE);
-
-		sButInit = W_BUTINIT();
-		sButInit.formID = FRONTEND_BOTFORM;
-		sButInit.id = FRONTEND_NOGAMESAVAILABLE;
-		sButInit.x = 70;
-		sButInit.y = 50;
-		sButInit.style = WBUT_TXTCENTRE;
-		sButInit.width = FRONTEND_BUTWIDTH;
-		sButInit.UserData = 0; // store disable state
-		sButInit.height = FRONTEND_BUTHEIGHT;
-		sButInit.pDisplay = displayTextOption;
-		sButInit.pUserData = new DisplayTextOptionCache();
-		sButInit.onDelete = [](WIDGET *psWidget) {
-			assert(psWidget->pUserData != nullptr);
-			delete static_cast<DisplayTextOptionCache *>(psWidget->pUserData);
-			psWidget->pUserData = nullptr;
-		};
-		sButInit.FontID = font_medium;
-		sButInit.pText = txt;
-
-		widgAddButton(psWScreen, &sButInit);
-	}
-	if (strlen(NetPlay.MOTD))
-	{
-		permitNewConsoleMessages(true);
-		addConsoleMessage(NetPlay.MOTD, DEFAULT_JUSTIFY, SYSTEM_MESSAGE);
-	}
-	setConsolePermanence(false, false);
-	updateConsoleMessages();
-	displayConsoleMessages();
-}
-
-void runGameFind()
-{
-	static UDWORD lastupdate = 0;
-
-	if (lastupdate > gameTime)
-	{
-		lastupdate = 0;
-	}
-	if (gameTime - lastupdate > 6000)
-	{
-		lastupdate = gameTime;
-		addConsoleBox();
-		if (safeSearch)
-		{
-			if (!NETfindGame())						// find games synchronously
-			{
-				pie_LoadBackDrop(SCREEN_RANDOMBDROP);
-			}
-		}
-		addGames();									//redraw list
-	}
-
-	WidgetTriggers const &triggers = widgRunScreen(psWScreen);
-	unsigned id = triggers.empty() ? 0 : triggers.front().widget->id; // Just use first click here, since the next click could be on another menu.
-
-	if (id == CON_CANCEL)								// ok
-	{
-		changeTitleUI(std::make_shared<WzProtocolTitleUI>());
-	}
-
-	if (id == MULTIOP_REFRESH || id == MULTIOP_FILTER_TOGGLE)
-	{
-		if (id == MULTIOP_FILTER_TOGGLE)
-		{
-			toggleFilter = !toggleFilter;
-			toggleFilter ? widgSetButtonState(psWScreen, MULTIOP_FILTER_TOGGLE, WBUT_CLICKLOCK) : widgSetButtonState(psWScreen, MULTIOP_FILTER_TOGGLE, 0);
-		}
-		else
-		{
-			widgSetButtonState(psWScreen, MULTIOP_FILTER_TOGGLE, 0);
-		}
-		ingame.localOptionsReceived = true;
-		addConsoleBox();
-		if (!NETfindGame())							// find games synchronously
-		{
-			pie_LoadBackDrop(SCREEN_RANDOMBDROP);
-		}
-		addConsoleMessage(_("Refreshing..."), DEFAULT_JUSTIFY, NOTIFY_MESSAGE);
-		addGames();									//redraw list.
-	}
-
-	// below is when they hit a game box to connect to--ideally this would be where
-	// we would want a modal password entry box.
-	if (id >= GAMES_GAMESTART && id <= GAMES_GAMEEND)
-	{
-		gameNumber = id - GAMES_GAMESTART;
-
-		// joinGame is quite capable of asking the user for a password, & is decoupled from lobby, so let it take over
-		ingame.localOptionsReceived = false;					// note, we are awaiting options
-		sstrcpy(game.name, NetPlay.games[gameNumber].name);		// store name
-		joinGame(NetPlay.games[gameNumber].desc.host, 0);
-		return;
-	}
-
-	widgDisplayScreen(psWScreen);								// show the widgets currently running
-	if (safeSearch)
-	{
-		iV_DrawText(_("Searching"), D_W + 260, D_H + 460, font_large);
-	}
-
-	if (CancelPressed())
-	{
-		changeTitleUI(std::make_shared<WzProtocolTitleUI>());
-	}
-
-	// console box handling
-	if (widgGetFromID(psWScreen, MULTIOP_CONSOLEBOX))
-	{
-		while (getNumberConsoleMessages() > getConsoleLineInfo())
-		{
-			removeTopConsoleMessage();
-		}
-		updateConsoleMessages();
-	}
-	displayConsoleMessages();
-}
-
-// This is what starts the lobby screen
-void startGameFind()
-{
-	addBackdrop();										//background image
-
-	WIDGET *parent = widgGetFromID(psWScreen, FRONTEND_BACKDROP);
-
-	// draws the background of the games listed
-	IntFormAnimated *botForm = new IntFormAnimated(parent);
-	botForm->id = FRONTEND_BOTFORM;
-	botForm->setCalcLayout(LAMBDA_CALCLAYOUT_SIMPLE({
-		psWidget->setGeometry(MULTIOP_OPTIONSX, MULTIOP_OPTIONSY, MULTIOP_CHATBOXW, 415);  // FIXME: Add box at bottom for server messages
-	}));
-
-	addSideText(FRONTEND_SIDETEXT,  MULTIOP_OPTIONSX - 3, MULTIOP_OPTIONSY, _("GAMES"));
-
-	// cancel
-	addMultiBut(psWScreen, FRONTEND_BOTFORM, CON_CANCEL, 10, 5, MULTIOP_OKW, MULTIOP_OKH, _("Return To Previous Screen"),
-	            IMAGE_RETURN, IMAGE_RETURN_HI, IMAGE_RETURN_HI);
-
-	//refresh
-	addMultiBut(psWScreen, FRONTEND_BOTFORM, MULTIOP_REFRESH, MULTIOP_CHATBOXW - MULTIOP_OKW - 5, 5, MULTIOP_OKW, MULTIOP_OKH,
-	            _("Refresh Games List"), IMAGE_RELOAD_HI, IMAGE_RELOAD, IMAGE_RELOAD);
-	//filter toggle
-	addMultiBut(psWScreen, FRONTEND_BOTFORM, MULTIOP_FILTER_TOGGLE, MULTIOP_CHATBOXW - MULTIOP_OKW - 45, 5, MULTIOP_OKW, MULTIOP_OKH,
-	            _("Filter Games List"), IMAGE_FILTER, IMAGE_FILTER_ON, IMAGE_FILTER_ON);
-
-	if (safeSearch || disableLobbyRefresh)
-	{
-		widgHide(psWScreen, MULTIOP_REFRESH);
-		widgHide(psWScreen, MULTIOP_FILTER_TOGGLE);
-	}
-
-	addConsoleBox();
-	if (!NETfindGame())
-	{
-		pie_LoadBackDrop(SCREEN_RANDOMBDROP);
-	}
-
-	addGames();	// now add games.
-	displayConsoleMessages();
 }
 
 // ////////////////////////////////////////////////////////////////////////////
@@ -2609,41 +2244,6 @@ static void addChatBox(bool preserveOldChat)
 	return;
 }
 
-static void addConsoleBox()
-{
-	if (widgGetFromID(psWScreen, FRONTEND_TOPFORM))
-	{
-		widgDelete(psWScreen, FRONTEND_TOPFORM);
-	}
-
-	if (widgGetFromID(psWScreen, MULTIOP_CONSOLEBOX))
-	{
-		return;
-	}
-
-	WIDGET *parent = widgGetFromID(psWScreen, FRONTEND_BACKDROP);
-
-	IntFormAnimated *consoleBox = new IntFormAnimated(parent);
-	consoleBox->id = MULTIOP_CONSOLEBOX;
-	consoleBox->setCalcLayout(LAMBDA_CALCLAYOUT_SIMPLE({
-		psWidget->setGeometry(MULTIOP_CONSOLEBOXX, MULTIOP_CONSOLEBOXY, MULTIOP_CONSOLEBOXW, MULTIOP_CONSOLEBOXH);
-	}));
-
-	flushConsoleMessages();											// add the chatbox.
-	initConsoleMessages();
-	enableConsoleDisplay(true);
-	setConsoleBackdropStatus(false);
-	setConsoleCalcLayout([]() {
-		setConsoleSizePos(MULTIOP_CONSOLEBOXX + 4 + D_W, MULTIOP_CONSOLEBOXY + 14 + D_H, MULTIOP_CONSOLEBOXW - 4);
-	});
-	setConsolePermanence(true, true);
-	setConsoleLineInfo(3);											// use x lines on chat window
-
-	addConsoleMessage(_("Connecting to the lobby server..."), DEFAULT_JUSTIFY, NOTIFY_MESSAGE);
-	displayConsoleMessages();
-	return;
-}
-
 // ////////////////////////////////////////////////////////////////////////////
 static void disableMultiButs()
 {
@@ -2667,7 +2267,6 @@ static void disableMultiButs()
 ////////////////////////////////////////////////////////////////////////////
 static void stopJoining(std::shared_ptr<WzTitleUI> parent)
 {
-	dwSelectedGame	 = 0;
 	reloadMPConfig(); // reload own settings
 
 	debug(LOG_NET, "player %u (Host is %s) stopping.", selectedPlayer, NetPlay.isHost ? "true" : "false");
@@ -3903,149 +3502,6 @@ void displayChatEdit(WIDGET *psWidget, UDWORD xOffset, UDWORD yOffset)
 }
 
 // ////////////////////////////////////////////////////////////////////////////
-void displayRemoteGame(WIDGET *psWidget, UDWORD xOffset, UDWORD yOffset)
-{
-	int x = xOffset + psWidget->x();
-	int y = yOffset + psWidget->y();
-	UDWORD	gameID = psWidget->UserData;
-	char tmp[80], name[StringSize];
-
-	// Any widget using displayRemoteGame must have its pUserData initialized to a (DisplayRemoteGameCache*)
-	assert(psWidget->pUserData != nullptr);
-	DisplayRemoteGameCache& cache = *static_cast<DisplayRemoteGameCache*>(psWidget->pUserData);
-
-	if ((LobbyError != ERROR_NOERROR) && (bMultiPlayer && !NetPlay.bComms))
-	{
-		addConsoleMessage(_("Can't connect to lobby server!"), DEFAULT_JUSTIFY, NOTIFY_MESSAGE);
-		return;
-	}
-
-	// Draw blue boxes for games (buttons) & headers
-	drawBlueBox(x, y, psWidget->width(), psWidget->height());
-	drawBlueBox(x, y, GAMES_STATUS_START - 4 , psWidget->height());
-	drawBlueBox(x, y, GAMES_PLAYERS_START - 4 , psWidget->height());
-	drawBlueBox(x, y, GAMES_MAPNAME_START - 4, psWidget->height());
-
-	int lamp = IMAGE_LAMP_RED;
-	int statusStart = IMAGE_NOJOIN;
-	bool disableButton = true;
-	PIELIGHT textColor = WZCOL_TEXT_DARK;
-
-	// As long as they got room, and mods are the same then we process the button(s)
-	if (NETisCorrectVersion(NetPlay.games[gameID].game_version_major, NetPlay.games[gameID].game_version_minor))
-	{
-		if (NetPlay.games[gameID].desc.dwCurrentPlayers >= NetPlay.games[gameID].desc.dwMaxPlayers)
-		{
-			// If game is full.
-			statusStart = IMAGE_NOJOIN_FULL;
-		}
-		else
-		{
-			// Game is ok to join!
-			textColor = WZCOL_FORM_TEXT;
-			statusStart = IMAGE_SKIRMISH_OVER;
-			lamp = IMAGE_LAMP_GREEN;
-			disableButton = false;
-
-			if (NetPlay.games[gameID].privateGame)  // check to see if it is a private game
-			{
-				statusStart = IMAGE_LOCKED_NOBG;
-				lamp = IMAGE_LAMP_AMBER;
-			}
-			else if (NetPlay.games[gameID].modlist[0] != '\0')
-			{
-				statusStart = IMAGE_MOD_OVER;
-			}
-		}
-
-		ssprintf(tmp, "%d/%d", NetPlay.games[gameID].desc.dwCurrentPlayers, NetPlay.games[gameID].desc.dwMaxPlayers);
-		cache.wzText_CurrentVsMaxNumPlayers.setText(tmp, font_regular);
-		cache.wzText_CurrentVsMaxNumPlayers.render(x + GAMES_PLAYERS_START + 4 , y + 18, textColor);
-
-		// see what host limits are... then draw them.
-		if (NetPlay.games[gameID].limits)
-		{
-			if (NetPlay.games[gameID].limits & NO_TANKS)
-			{
-				iV_DrawImage(FrontImages, IMAGE_NO_TANK, x + GAMES_STATUS_START + 37, y + 2);
-			}
-			if (NetPlay.games[gameID].limits & NO_BORGS)
-			{
-				iV_DrawImage(FrontImages, IMAGE_NO_CYBORG, x + GAMES_STATUS_START + (37 * 2), y + 2);
-			}
-			if (NetPlay.games[gameID].limits & NO_VTOLS)
-			{
-				iV_DrawImage(FrontImages, IMAGE_NO_VTOL, x + GAMES_STATUS_START + (37 * 3) , y + 2);
-			}
-		}
-	}
-	// Draw type overlay.
-	iV_DrawImage(FrontImages, statusStart, x + GAMES_STATUS_START, y + 3);
-	iV_DrawImage(FrontImages, lamp, x - 14, y + 8);
-	if (disableButton)
-	{
-		widgSetButtonState(psWScreen, psWidget->id, WBUT_DISABLE);
-	}
-
-	//draw game name, chop when we get a too long name
-	sstrcpy(name, NetPlay.games[gameID].name);
-	cache.wzText_GameName.setTruncatableText(name, font_regular, (GAMES_MAPNAME_START - GAMES_GAMENAME_START - 4));
-	cache.wzText_GameName.render(x + GAMES_GAMENAME_START, y + 12, textColor);
-
-	if (NetPlay.games[gameID].pureMap)
-	{
-		textColor = WZCOL_RED;
-	}
-	else
-	{
-		textColor = WZCOL_FORM_TEXT;
-	}
-	// draw map name, chop when we get a too long name
-	sstrcpy(name, NetPlay.games[gameID].mapname);
-	cache.wzText_MapName.setTruncatableText(name, font_regular, (GAMES_PLAYERS_START - GAMES_MAPNAME_START - 4));
-	cache.wzText_MapName.render(x + GAMES_MAPNAME_START, y + 12, textColor);
-
-	textColor = WZCOL_FORM_TEXT;
-	// draw mod name (if any)
-	if (strlen(NetPlay.games[gameID].modlist))
-	{
-		// FIXME: we really don't have enough space to list all mods
-		char tmp[300];
-		sprintf(tmp, _("Mods: %s"), NetPlay.games[gameID].modlist);
-		tmp[StringSize] = '\0';
-		sstrcpy(name, tmp);
-	}
-	else
-	{
-		sstrcpy(name, _("Mods: None!"));
-	}
-	cache.wzText_ModNames.setTruncatableText(name, font_small, (GAMES_PLAYERS_START - GAMES_MAPNAME_START - 8));
-	cache.wzText_ModNames.render(x + GAMES_MODNAME_START, y + 24, textColor);
-
-	// draw version string
-	ssprintf(name, _("Version: %s"), NetPlay.games[gameID].versionstring);
-	cache.wzText_VersionString.setTruncatableText(name, font_small, (GAMES_MAPNAME_START - 6 - GAMES_GAMENAME_START - 4));
-	cache.wzText_VersionString.render(x + GAMES_GAMENAME_START + 6, y + 24, textColor);
-
-	// crappy hack to only draw this once for the header.  TODO fix GUI
-	if (gameID == 0)
-	{
-		// make the 'header' for the table...
-		drawBlueBox(x , y - 12 , GAMES_GAMEWIDTH, 12);
-
-		remoteGameListHeaderCache.wzHeaderText_GameName.setText(_("Game Name"), font_small);
-		remoteGameListHeaderCache.wzHeaderText_GameName.render(x - 2 + GAMES_GAMENAME_START + 48, y - 3, WZCOL_YELLOW);
-
-		remoteGameListHeaderCache.wzHeaderText_MapName.setText(_("Map Name"), font_small);
-		remoteGameListHeaderCache.wzHeaderText_MapName.render(x - 2 + GAMES_MAPNAME_START + 48, y - 3, WZCOL_YELLOW);
-
-		remoteGameListHeaderCache.wzHeaderText_Players.setText(_("Players"), font_small);
-		remoteGameListHeaderCache.wzHeaderText_Players.render(x - 2 + GAMES_PLAYERS_START, y - 3, WZCOL_YELLOW);
-
-		remoteGameListHeaderCache.wzHeaderText_Status.setText(_("Status"), font_small);
-		remoteGameListHeaderCache.wzHeaderText_Status.render(x - 2 + GAMES_STATUS_START + 48, y - 3, WZCOL_YELLOW);
-	}
-}
 
 void displayTeamChooser(WIDGET *psWidget, UDWORD xOffset, UDWORD yOffset)
 {

--- a/src/multiint.h
+++ b/src/multiint.h
@@ -32,7 +32,6 @@
 #include <vector>
 #include "lib/framework/wzstring.h"
 
-
 #define MAX_LEN_AI_NAME   40
 #define AI_CUSTOM        127
 #define AI_OPEN           -2
@@ -90,6 +89,7 @@ public:
 	MultichoiceWidget(WIDGET *parent, int value = -1);
 };
 
+// WzMultiOptionTitleUI is in titleui.h to prevent dependency explosions
 
 void readAIs();	///< step 1, load AI definition files
 void setupChallengeAIs();	///< dirty hack to allow correct display of names from challenges
@@ -102,8 +102,6 @@ int getNextAIAssignment(const char *name);
 LOBBY_ERROR_TYPES getLobbyError();
 void setLobbyError(LOBBY_ERROR_TYPES error_type);
 
-void runConnectionScreen();
-bool startConnectionScreen();
 void intProcessConnection(UDWORD id);
 
 void runGameFind();
@@ -114,6 +112,8 @@ void updateLimitFlags();
 void runMultiOptions();
 bool startMultiOptions(bool bReenter);
 void frontendMultiMessages();
+
+void intDisplayFeBox(WIDGET *psWidget, UDWORD xOffset, UDWORD yOffset);
 
 bool addMultiBut(W_SCREEN *screen, UDWORD formid, UDWORD id, UDWORD x, UDWORD y, UDWORD width, UDWORD height, const char *tipres, UDWORD norm, UDWORD down, UDWORD hi, unsigned tc = MAX_PLAYERS);
 bool changeColour(unsigned player, int col, bool isHost);

--- a/src/multiint.h
+++ b/src/multiint.h
@@ -111,7 +111,6 @@ void updateLimitFlags();
 
 void runMultiOptions();
 bool startMultiOptions(bool bReenter);
-void frontendMultiMessages();
 
 void intDisplayFeBox(WIDGET *psWidget, UDWORD xOffset, UDWORD yOffset);
 
@@ -124,8 +123,6 @@ extern bool bHosted;
 void kickPlayer(uint32_t player_id, const char *reason, LOBBY_ERROR_TYPES type);
 void addPlayerBox(bool);			// players (mid) box
 void loadMapPreview(bool hideInterface);
-
-void multiOptionsScreenSizeDidChange(unsigned int oldWidth, unsigned int oldHeight, unsigned int newWidth, unsigned int newHeight);
 
 
 // ////////////////////////////////////////////////////////////////

--- a/src/multiint.h
+++ b/src/multiint.h
@@ -115,6 +115,7 @@ bool startMultiOptions(bool bReenter);
 void intDisplayFeBox(WIDGET *psWidget, UDWORD xOffset, UDWORD yOffset);
 
 bool addMultiBut(W_SCREEN *screen, UDWORD formid, UDWORD id, UDWORD x, UDWORD y, UDWORD width, UDWORD height, const char *tipres, UDWORD norm, UDWORD down, UDWORD hi, unsigned tc = MAX_PLAYERS);
+Image mpwidgetGetFrontHighlightImage(Image image);
 bool changeColour(unsigned player, int col, bool isHost);
 
 extern char sPlayer[128];

--- a/src/multiint.h
+++ b/src/multiint.h
@@ -104,9 +104,6 @@ void setLobbyError(LOBBY_ERROR_TYPES error_type);
 
 void intProcessConnection(UDWORD id);
 
-void runGameFind();
-void startGameFind();
-
 void updateLimitFlags();
 
 void runMultiOptions();
@@ -120,6 +117,7 @@ bool changeColour(unsigned player, int col, bool isHost);
 
 extern char sPlayer[128];
 extern bool bHosted;
+extern bool multiintDisableLobbyRefresh; // gamefind
 
 void kickPlayer(uint32_t player_id, const char *reason, LOBBY_ERROR_TYPES type);
 void addPlayerBox(bool);			// players (mid) box

--- a/src/multilimit.cpp
+++ b/src/multilimit.cpp
@@ -223,9 +223,7 @@ void WzMultiLimitTitleUI::start()
 	// TRANSLATORS: Sidetext of structure limits screen
 	addSideText(FRONTEND_SIDETEXT1, LIMITSX - 2, LIMITSY, _("LIMITS"));
 
-	WIDGET *parent = widgGetFromID(psWScreen, FRONTEND_BACKDROP);
-
-	IntFormAnimated *limitsForm = new IntFormAnimated(parent, false);
+	IntFormAnimated *limitsForm = new IntFormAnimated(widgGetFromID(psWScreen, FRONTEND_BACKDROP), false);
 	limitsForm->id = IDLIMITS;
 	limitsForm->setCalcLayout(LAMBDA_CALCLAYOUT_SIMPLE({
 		psWidget->setGeometry(LIMITSX, LIMITSY, LIMITSW, LIMITSH);

--- a/src/multilimit.cpp
+++ b/src/multilimit.cpp
@@ -52,6 +52,7 @@
 #include "lib/ivis_opengl/piemode.h"
 #include "lib/script/script.h"
 #include "challenge.h"
+#include "titleui/titleui.h"
 
 // ////////////////////////////////////////////////////////////////////////////
 // defines
@@ -284,7 +285,7 @@ void WzMultiLimitTitleUI::start()
 
 TITLECODE WzMultiLimitTitleUI::run()
 {
-	frontendMultiMessages();							// network stuff.
+	parent->frontendMultiMessages(false);							// network stuff.
 
 	WidgetTriggers const &triggers = widgRunScreen(psWScreen);
 	unsigned id = triggers.empty() ? 0 : triggers.front().widget->id; // Just use first click here, since the next click could be on another menu.

--- a/src/multilimit.h
+++ b/src/multilimit.h
@@ -24,18 +24,7 @@
 #ifndef __INCLUDED_MULTILIMIT_H__
 #define __INCLUDED_MULTILIMIT_H__
 
-#include "titleui/titleui.h"
-
-class WzMultiLimitTitleUI: public WzTitleUI
-{
-public:
-	WzMultiLimitTitleUI(std::shared_ptr<WzMultiOptionTitleUI> parent);
-	virtual void start() override;
-	virtual TITLECODE run() override;
-private:
-	// The parent WzMultiOptionTitleUI to return to.
-	std::shared_ptr<WzMultiOptionTitleUI> parent;
-};
+// See titleui.h for the actual class; dependency reduction measure
 
 void applyLimitSet();
 void createLimitSet();

--- a/src/multiplay.cpp
+++ b/src/multiplay.cpp
@@ -75,6 +75,7 @@
 #include "multiint.h"
 #include "keymap.h"
 #include "cheat.h"
+#include "main.h"								// for gamemode
 
 // ////////////////////////////////////////////////////////////////////////////
 // ////////////////////////////////////////////////////////////////////////////
@@ -1502,7 +1503,7 @@ bool recvTextMessage(NETQUEUE queue)
 	eventFireCallbackTrigger((TRIGGER_TYPE)CALL_AI_MSG);
 
 	// make some noise!
-	if (titleMode == MULTIOPTION || titleMode == MULTILIMIT)
+	if (GetGameMode() != GS_NORMAL)
 	{
 		audio_PlayTrack(FE_AUDIO_MESSAGEEND);
 	}

--- a/src/multisync.cpp
+++ b/src/multisync.cpp
@@ -34,7 +34,7 @@
 #include "lib/gamelib/gtime.h"
 #include "lib/netplay/netplay.h"
 #include "multiplay.h"
-#include "frontend.h"								// for titlemode
+#include "main.h"								// for gamemode
 #include "multistat.h"
 #include "multirecv.h"
 
@@ -58,7 +58,8 @@ static uint8_t pingChallenge[8];                                // Random data s
 bool sendScoreCheck()
 {
 	// Broadcast any changes in other players, but not in FRONTEND!!!
-	if (titleMode != MULTIOPTION && titleMode != MULTILIMIT)
+	// Detection for this no longer uses title mode, but instead game mode, because that makes more sense
+	if (GetGameMode() == GS_NORMAL)
 	{
 		uint8_t			i;
 

--- a/src/titleui/gamefind.cpp
+++ b/src/titleui/gamefind.cpp
@@ -1,0 +1,594 @@
+/*
+	This file is part of Warzone 2100.
+	Copyright (C) 1999-2004  Eidos Interactive
+	Copyright (C) 2005-2019  Warzone 2100 Project
+
+	Warzone 2100 is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+
+	Warzone 2100 is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with Warzone 2100; if not, write to the Free Software
+	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+/*
+ * titleui/gamefind.cpp
+ *
+ * This is the lobby menu.
+ * Code adapted from multiint.cpp
+ */
+
+#include "titleui.h"
+#include "lib/ivis_opengl/pieblitfunc.h"
+#include "lib/ivis_opengl/piemode.h"
+#include "lib/ivis_opengl/piestate.h"
+#include "lib/ivis_opengl/screen.h"
+#include "lib/netplay/netplay.h"
+#include "../intdisplay.h"
+#include "../hci.h"
+#include "../mission.h"
+#include "../console.h"
+#include "../multiint.h"
+#include "../multilimit.h"
+#include "../multistat.h"
+#include "../warzoneconfig.h"
+#include "../frend.h"
+#include "../loadsave.h"			// for blueboxes.
+
+struct DisplayRemoteGameHeaderCache
+{
+	WzText wzHeaderText_GameName;
+	WzText wzHeaderText_MapName;
+	WzText wzHeaderText_Players;
+	WzText wzHeaderText_Status;
+};
+struct DisplayRemoteGameCache
+{
+	WzText wzText_CurrentVsMaxNumPlayers;
+	WidthLimitedWzText wzText_GameName;
+	WidthLimitedWzText wzText_MapName;
+	WidthLimitedWzText wzText_ModNames;
+	WidthLimitedWzText wzText_VersionString;
+};
+
+static DisplayRemoteGameHeaderCache remoteGameListHeaderCache;
+
+// find games
+static void addGames();
+static void addConsoleBox();
+static void displayRemoteGame(WIDGET *psWidget, UDWORD xOffset, UDWORD yOffset);
+
+WzGameFindTitleUI::WzGameFindTitleUI() {
+}
+
+// This is what starts the lobby screen
+void WzGameFindTitleUI::start()
+{
+	addBackdrop();										//background image
+
+	WIDGET *parent = widgGetFromID(psWScreen, FRONTEND_BACKDROP);
+
+	// draws the background of the games listed
+	IntFormAnimated *botForm = new IntFormAnimated(parent);
+	botForm->id = FRONTEND_BOTFORM;
+	botForm->setCalcLayout(LAMBDA_CALCLAYOUT_SIMPLE({
+		psWidget->setGeometry(MULTIOP_OPTIONSX, MULTIOP_OPTIONSY, MULTIOP_CHATBOXW, 415);  // FIXME: Add box at bottom for server messages
+	}));
+
+	addSideText(FRONTEND_SIDETEXT,  MULTIOP_OPTIONSX - 3, MULTIOP_OPTIONSY, _("GAMES"));
+
+	// cancel
+	addMultiBut(psWScreen, FRONTEND_BOTFORM, CON_CANCEL, 10, 5, MULTIOP_OKW, MULTIOP_OKH, _("Return To Previous Screen"),
+	            IMAGE_RETURN, IMAGE_RETURN_HI, IMAGE_RETURN_HI);
+
+	//refresh
+	addMultiBut(psWScreen, FRONTEND_BOTFORM, MULTIOP_REFRESH, MULTIOP_CHATBOXW - MULTIOP_OKW - 5, 5, MULTIOP_OKW, MULTIOP_OKH,
+	            _("Refresh Games List"), IMAGE_RELOAD_HI, IMAGE_RELOAD, IMAGE_RELOAD);
+	//filter toggle
+	addMultiBut(psWScreen, FRONTEND_BOTFORM, MULTIOP_FILTER_TOGGLE, MULTIOP_CHATBOXW - MULTIOP_OKW - 45, 5, MULTIOP_OKW, MULTIOP_OKH,
+	            _("Filter Games List"), IMAGE_FILTER, IMAGE_FILTER_ON, IMAGE_FILTER_ON);
+
+	if (safeSearch || multiintDisableLobbyRefresh)
+	{
+		widgHide(psWScreen, MULTIOP_REFRESH);
+		widgHide(psWScreen, MULTIOP_FILTER_TOGGLE);
+	}
+
+	addConsoleBox();
+	if (!NETfindGame())
+	{
+		pie_LoadBackDrop(SCREEN_RANDOMBDROP);
+	}
+
+	addGames();	// now add games.
+	displayConsoleMessages();
+}
+
+TITLECODE WzGameFindTitleUI::run()
+{
+	screen_disableMapPreview();
+
+	static UDWORD lastupdate = 0;
+
+	if (lastupdate > gameTime)
+	{
+		lastupdate = 0;
+	}
+	if (gameTime - lastupdate > 6000)
+	{
+		lastupdate = gameTime;
+		addConsoleBox();
+		if (safeSearch)
+		{
+			if (!NETfindGame())						// find games synchronously
+			{
+				pie_LoadBackDrop(SCREEN_RANDOMBDROP);
+			}
+		}
+		addGames();									//redraw list
+	}
+
+	WidgetTriggers const &triggers = widgRunScreen(psWScreen);
+	unsigned id = triggers.empty() ? 0 : triggers.front().widget->id; // Just use first click here, since the next click could be on another menu.
+
+	if (id == CON_CANCEL)								// ok
+	{
+		changeTitleUI(std::make_shared<WzProtocolTitleUI>());
+	}
+
+	if (id == MULTIOP_REFRESH || id == MULTIOP_FILTER_TOGGLE)
+	{
+		if (id == MULTIOP_FILTER_TOGGLE)
+		{
+			toggleFilter = !toggleFilter;
+			toggleFilter ? widgSetButtonState(psWScreen, MULTIOP_FILTER_TOGGLE, WBUT_CLICKLOCK) : widgSetButtonState(psWScreen, MULTIOP_FILTER_TOGGLE, 0);
+		}
+		else
+		{
+			widgSetButtonState(psWScreen, MULTIOP_FILTER_TOGGLE, 0);
+		}
+		ingame.localOptionsReceived = true;
+		addConsoleBox();
+		if (!NETfindGame())							// find games synchronously
+		{
+			pie_LoadBackDrop(SCREEN_RANDOMBDROP);
+		}
+		addConsoleMessage(_("Refreshing..."), DEFAULT_JUSTIFY, NOTIFY_MESSAGE);
+		addGames();									//redraw list.
+	}
+
+	// below is when they hit a game box to connect to--ideally this would be where
+	// we would want a modal password entry box.
+	if (id >= GAMES_GAMESTART && id <= GAMES_GAMEEND)
+	{
+		UDWORD gameNumber = id - GAMES_GAMESTART;
+
+		// joinGame is quite capable of asking the user for a password, & is decoupled from lobby, so let it take over
+		ingame.localOptionsReceived = false;					// note, we are awaiting options
+		sstrcpy(game.name, NetPlay.games[gameNumber].name);		// store name
+		joinGame(NetPlay.games[gameNumber].desc.host, 0);
+		return TITLECODE_CONTINUE;
+	}
+
+	widgDisplayScreen(psWScreen);								// show the widgets currently running
+	if (safeSearch)
+	{
+		iV_DrawText(_("Searching"), D_W + 260, D_H + 460, font_large);
+	}
+
+	if (CancelPressed())
+	{
+		changeTitleUI(std::make_shared<WzProtocolTitleUI>());
+	}
+
+	// console box handling
+	if (widgGetFromID(psWScreen, MULTIOP_CONSOLEBOX))
+	{
+		while (getNumberConsoleMessages() > getConsoleLineInfo())
+		{
+			removeTopConsoleMessage();
+		}
+		updateConsoleMessages();
+	}
+	displayConsoleMessages();
+	return TITLECODE_CONTINUE;
+}
+
+// --- Various statics ---
+
+static void addConsoleBox()
+{
+	if (widgGetFromID(psWScreen, FRONTEND_TOPFORM))
+	{
+		widgDelete(psWScreen, FRONTEND_TOPFORM);
+	}
+
+	if (widgGetFromID(psWScreen, MULTIOP_CONSOLEBOX))
+	{
+		return;
+	}
+
+	WIDGET *parent = widgGetFromID(psWScreen, FRONTEND_BACKDROP);
+
+	IntFormAnimated *consoleBox = new IntFormAnimated(parent);
+	consoleBox->id = MULTIOP_CONSOLEBOX;
+	consoleBox->setCalcLayout(LAMBDA_CALCLAYOUT_SIMPLE({
+		psWidget->setGeometry(MULTIOP_CONSOLEBOXX, MULTIOP_CONSOLEBOXY, MULTIOP_CONSOLEBOXW, MULTIOP_CONSOLEBOXH);
+	}));
+
+	flushConsoleMessages();											// add the chatbox.
+	initConsoleMessages();
+	enableConsoleDisplay(true);
+	setConsoleBackdropStatus(false);
+	setConsoleCalcLayout([]() {
+		setConsoleSizePos(MULTIOP_CONSOLEBOXX + 4 + D_W, MULTIOP_CONSOLEBOXY + 14 + D_H, MULTIOP_CONSOLEBOXW - 4);
+	});
+	setConsolePermanence(true, true);
+	setConsoleLineInfo(3);											// use x lines on chat window
+
+	addConsoleMessage(_("Connecting to the lobby server..."), DEFAULT_JUSTIFY, NOTIFY_MESSAGE);
+	displayConsoleMessages();
+	return;
+}
+
+// ////////////////////////////////////////////////////////////////////////////
+// Game Chooser Screen.
+
+static void addGames()
+{
+	int i, gcount = 0, added = 0;
+	static const char *wrongVersionTip = _("Your version of Warzone is incompatible with this game.");
+
+	//count games to see if need two columns.
+	for (i = 0; i < MaxGames; i++)
+	{
+		if (NetPlay.games[i].desc.dwSize != 0)
+		{
+			gcount++;
+		}
+	}
+
+	W_BUTINIT sButInit;
+	sButInit.formID = FRONTEND_BOTFORM;
+	sButInit.width = GAMES_GAMEWIDTH;
+	sButInit.height = GAMES_GAMEHEIGHT;
+	sButInit.pDisplay = displayRemoteGame;
+	sButInit.initPUserDataFunc = []() -> void * { return new DisplayRemoteGameCache(); };
+	sButInit.onDelete = [](WIDGET *psWidget) {
+		assert(psWidget->pUserData != nullptr);
+		delete static_cast<DisplayRemoteGameCache *>(psWidget->pUserData);
+		psWidget->pUserData = nullptr;
+	};
+
+	// we want the old games deleted, and only list games when we should
+	if (getLobbyError() || !gcount)
+	{
+		for (i = 0; i < MaxGames; i++)
+		{
+			widgDelete(psWScreen, GAMES_GAMESTART + i);	// remove old widget
+		}
+		gcount = 0;
+	}
+	// in case they refresh, and a game becomes available.
+	widgDelete(psWScreen, FRONTEND_NOGAMESAVAILABLE);
+
+	// only have to do this if we have any games available.
+	if (!getLobbyError() && gcount)
+	{
+		for (i = 0; i < MaxGames; i++)							// draw games
+		{
+			widgDelete(psWScreen, GAMES_GAMESTART + i);	// remove old icon.
+
+			if (NetPlay.games[i].desc.dwSize != 0)
+			{
+				// either display all games, or games that are the client's specific version
+				if (toggleFilter)
+				{
+					if ((NetPlay.games[i].game_version_major != (unsigned)NETGetMajorVersion()) || (NetPlay.games[i].game_version_minor != (unsigned)NETGetMinorVersion()))
+					{
+						continue;
+					}
+				}
+				added++;
+				sButInit.id = GAMES_GAMESTART + i;
+				sButInit.x = 20;
+				sButInit.y = (UWORD)(45 + ((5 + GAMES_GAMEHEIGHT) * i));
+
+				// display the correct tooltip message.
+				if (!NETisCorrectVersion(NetPlay.games[i].game_version_major, NetPlay.games[i].game_version_minor))
+				{
+					sButInit.pTip = wrongVersionTip;
+				}
+				else
+				{
+					WzString flags;
+					if (NetPlay.games[i].privateGame)
+					{
+						flags += " "; flags += _("[Password required]");
+					}
+					if (NetPlay.games[i].limits & NO_TANKS)
+					{
+						flags += " "; flags += _("[No Tanks]");
+					}
+					if (NetPlay.games[i].limits & NO_BORGS)
+					{
+						flags += " "; flags += _("[No Cyborgs]");
+					}
+					if (NetPlay.games[i].limits & NO_VTOLS)
+					{
+						flags += " "; flags += _("[No VTOLs]");
+					}
+					char tooltipbuffer[256];
+					if (flags.isEmpty())
+					{
+						ssprintf(tooltipbuffer, _("Hosted by %s"), NetPlay.games[i].hostname);
+					}
+					else
+					{
+						ssprintf(tooltipbuffer, _("Hosted by %s —%s"), NetPlay.games[i].hostname, flags.toUtf8().c_str());
+					}
+					// this is an std::string
+					sButInit.pTip = tooltipbuffer;
+				}
+				sButInit.UserData = i;
+
+				widgAddButton(psWScreen, &sButInit);
+			}
+		}
+		if (!added)
+		{
+			sButInit = W_BUTINIT();
+			sButInit.formID = FRONTEND_BOTFORM;
+			sButInit.id = FRONTEND_NOGAMESAVAILABLE;
+			sButInit.x = 70;
+			sButInit.y = 378;
+			sButInit.style = WBUT_TXTCENTRE;
+			sButInit.width = FRONTEND_BUTWIDTH;
+			sButInit.UserData = 0; // store disable state
+			sButInit.height = FRONTEND_BUTHEIGHT;
+			sButInit.pDisplay = displayTextOption;
+			sButInit.pUserData = new DisplayTextOptionCache();
+			sButInit.onDelete = [](WIDGET *psWidget) {
+				assert(psWidget->pUserData != nullptr);
+				delete static_cast<DisplayTextOptionCache *>(psWidget->pUserData);
+				psWidget->pUserData = nullptr;
+			};
+			sButInit.FontID = font_large;
+			sButInit.pText = _("Can't find any games for your version.");
+
+			widgAddButton(psWScreen, &sButInit);
+		}
+	}
+	else
+	{
+		// display lobby message based on results.
+		// This is a 'button', not text so it can be hilighted/centered.
+		const char *txt;
+		W_BUTINIT sButInit;
+
+		switch (getLobbyError())
+		{
+		case ERROR_NOERROR:
+			if (NetPlay.HaveUpgrade)
+			{
+				txt = _("There appears to be a game update available!");
+			}
+			else
+			{
+				txt = _("No games are available for your version");
+			}
+			break;
+		case ERROR_FULL:
+			txt = _("Game is full");
+			break;
+		case ERROR_KICKED:
+		case ERROR_INVALID:
+			txt = _("You were kicked!");
+			break;
+		case ERROR_WRONGVERSION:
+			txt = _("Wrong Game Version!");
+			break;
+		case ERROR_WRONGDATA:
+			txt = _("You have an incompatible mod.");
+			break;
+		// AFAIK, the only way this can really happy is if the Host's file is named wrong, or a client side error.
+		case ERROR_UNKNOWNFILEISSUE:
+			txt = _("Host couldn't send file?");
+			debug(LOG_POPUP, "Warzone couldn't complete a file request.\n\nPossibly, Host's file is incorrect. Check your logs for more details.");
+			break;
+		case ERROR_WRONGPASSWORD:
+			txt = _("Incorrect Password!");
+			break;
+		case ERROR_HOSTDROPPED:
+			txt = _("Host has dropped connection!");
+			break;
+		case ERROR_CONNECTION:
+		default:
+			txt = _("Connection Error");
+			break;
+		}
+
+		// delete old widget if necessary
+		widgDelete(psWScreen, FRONTEND_NOGAMESAVAILABLE);
+
+		sButInit = W_BUTINIT();
+		sButInit.formID = FRONTEND_BOTFORM;
+		sButInit.id = FRONTEND_NOGAMESAVAILABLE;
+		sButInit.x = 70;
+		sButInit.y = 50;
+		sButInit.style = WBUT_TXTCENTRE;
+		sButInit.width = FRONTEND_BUTWIDTH;
+		sButInit.UserData = 0; // store disable state
+		sButInit.height = FRONTEND_BUTHEIGHT;
+		sButInit.pDisplay = displayTextOption;
+		sButInit.pUserData = new DisplayTextOptionCache();
+		sButInit.onDelete = [](WIDGET *psWidget) {
+			assert(psWidget->pUserData != nullptr);
+			delete static_cast<DisplayTextOptionCache *>(psWidget->pUserData);
+			psWidget->pUserData = nullptr;
+		};
+		sButInit.FontID = font_medium;
+		sButInit.pText = txt;
+
+		widgAddButton(psWScreen, &sButInit);
+	}
+	if (strlen(NetPlay.MOTD))
+	{
+		permitNewConsoleMessages(true);
+		addConsoleMessage(NetPlay.MOTD, DEFAULT_JUSTIFY, SYSTEM_MESSAGE);
+	}
+	setConsolePermanence(false, false);
+	updateConsoleMessages();
+	displayConsoleMessages();
+}
+
+void displayRemoteGame(WIDGET *psWidget, UDWORD xOffset, UDWORD yOffset)
+{
+	int x = xOffset + psWidget->x();
+	int y = yOffset + psWidget->y();
+	UDWORD	gameID = psWidget->UserData;
+	char tmp[80], name[StringSize];
+
+	// Any widget using displayRemoteGame must have its pUserData initialized to a (DisplayRemoteGameCache*)
+	assert(psWidget->pUserData != nullptr);
+	DisplayRemoteGameCache& cache = *static_cast<DisplayRemoteGameCache*>(psWidget->pUserData);
+
+	if ((getLobbyError() != ERROR_NOERROR) && (bMultiPlayer && !NetPlay.bComms))
+	{
+		addConsoleMessage(_("Can't connect to lobby server!"), DEFAULT_JUSTIFY, NOTIFY_MESSAGE);
+		return;
+	}
+
+	// Draw blue boxes for games (buttons) & headers
+	drawBlueBox(x, y, psWidget->width(), psWidget->height());
+	drawBlueBox(x, y, GAMES_STATUS_START - 4 , psWidget->height());
+	drawBlueBox(x, y, GAMES_PLAYERS_START - 4 , psWidget->height());
+	drawBlueBox(x, y, GAMES_MAPNAME_START - 4, psWidget->height());
+
+	int lamp = IMAGE_LAMP_RED;
+	int statusStart = IMAGE_NOJOIN;
+	bool disableButton = true;
+	PIELIGHT textColor = WZCOL_TEXT_DARK;
+
+	// As long as they got room, and mods are the same then we process the button(s)
+	if (NETisCorrectVersion(NetPlay.games[gameID].game_version_major, NetPlay.games[gameID].game_version_minor))
+	{
+		if (NetPlay.games[gameID].desc.dwCurrentPlayers >= NetPlay.games[gameID].desc.dwMaxPlayers)
+		{
+			// If game is full.
+			statusStart = IMAGE_NOJOIN_FULL;
+		}
+		else
+		{
+			// Game is ok to join!
+			textColor = WZCOL_FORM_TEXT;
+			statusStart = IMAGE_SKIRMISH_OVER;
+			lamp = IMAGE_LAMP_GREEN;
+			disableButton = false;
+
+			if (NetPlay.games[gameID].privateGame)  // check to see if it is a private game
+			{
+				statusStart = IMAGE_LOCKED_NOBG;
+				lamp = IMAGE_LAMP_AMBER;
+			}
+			else if (NetPlay.games[gameID].modlist[0] != '\0')
+			{
+				statusStart = IMAGE_MOD_OVER;
+			}
+		}
+
+		ssprintf(tmp, "%d/%d", NetPlay.games[gameID].desc.dwCurrentPlayers, NetPlay.games[gameID].desc.dwMaxPlayers);
+		cache.wzText_CurrentVsMaxNumPlayers.setText(tmp, font_regular);
+		cache.wzText_CurrentVsMaxNumPlayers.render(x + GAMES_PLAYERS_START + 4 , y + 18, textColor);
+
+		// see what host limits are... then draw them.
+		if (NetPlay.games[gameID].limits)
+		{
+			if (NetPlay.games[gameID].limits & NO_TANKS)
+			{
+				iV_DrawImage(FrontImages, IMAGE_NO_TANK, x + GAMES_STATUS_START + 37, y + 2);
+			}
+			if (NetPlay.games[gameID].limits & NO_BORGS)
+			{
+				iV_DrawImage(FrontImages, IMAGE_NO_CYBORG, x + GAMES_STATUS_START + (37 * 2), y + 2);
+			}
+			if (NetPlay.games[gameID].limits & NO_VTOLS)
+			{
+				iV_DrawImage(FrontImages, IMAGE_NO_VTOL, x + GAMES_STATUS_START + (37 * 3) , y + 2);
+			}
+		}
+	}
+	// Draw type overlay.
+	iV_DrawImage(FrontImages, statusStart, x + GAMES_STATUS_START, y + 3);
+	iV_DrawImage(FrontImages, lamp, x - 14, y + 8);
+	if (disableButton)
+	{
+		widgSetButtonState(psWScreen, psWidget->id, WBUT_DISABLE);
+	}
+
+	//draw game name, chop when we get a too long name
+	sstrcpy(name, NetPlay.games[gameID].name);
+	cache.wzText_GameName.setTruncatableText(name, font_regular, (GAMES_MAPNAME_START - GAMES_GAMENAME_START - 4));
+	cache.wzText_GameName.render(x + GAMES_GAMENAME_START, y + 12, textColor);
+
+	if (NetPlay.games[gameID].pureMap)
+	{
+		textColor = WZCOL_RED;
+	}
+	else
+	{
+		textColor = WZCOL_FORM_TEXT;
+	}
+	// draw map name, chop when we get a too long name
+	sstrcpy(name, NetPlay.games[gameID].mapname);
+	cache.wzText_MapName.setTruncatableText(name, font_regular, (GAMES_PLAYERS_START - GAMES_MAPNAME_START - 4));
+	cache.wzText_MapName.render(x + GAMES_MAPNAME_START, y + 12, textColor);
+
+	textColor = WZCOL_FORM_TEXT;
+	// draw mod name (if any)
+	if (strlen(NetPlay.games[gameID].modlist))
+	{
+		// FIXME: we really don't have enough space to list all mods
+		char tmp[300];
+		ssprintf(tmp, _("Mods: %s"), NetPlay.games[gameID].modlist);
+		tmp[StringSize] = '\0';
+		sstrcpy(name, tmp);
+	}
+	else
+	{
+		sstrcpy(name, _("Mods: None!"));
+	}
+	cache.wzText_ModNames.setTruncatableText(name, font_small, (GAMES_PLAYERS_START - GAMES_MAPNAME_START - 8));
+	cache.wzText_ModNames.render(x + GAMES_MODNAME_START, y + 24, textColor);
+
+	// draw version string
+	ssprintf(name, _("Version: %s"), NetPlay.games[gameID].versionstring);
+	cache.wzText_VersionString.setTruncatableText(name, font_small, (GAMES_MAPNAME_START - 6 - GAMES_GAMENAME_START - 4));
+	cache.wzText_VersionString.render(x + GAMES_GAMENAME_START + 6, y + 24, textColor);
+
+	// crappy hack to only draw this once for the header.  TODO fix GUI
+	if (gameID == 0)
+	{
+		// make the 'header' for the table...
+		drawBlueBox(x , y - 12 , GAMES_GAMEWIDTH, 12);
+
+		remoteGameListHeaderCache.wzHeaderText_GameName.setText(_("Game Name"), font_small);
+		remoteGameListHeaderCache.wzHeaderText_GameName.render(x - 2 + GAMES_GAMENAME_START + 48, y - 3, WZCOL_YELLOW);
+
+		remoteGameListHeaderCache.wzHeaderText_MapName.setText(_("Map Name"), font_small);
+		remoteGameListHeaderCache.wzHeaderText_MapName.render(x - 2 + GAMES_MAPNAME_START + 48, y - 3, WZCOL_YELLOW);
+
+		remoteGameListHeaderCache.wzHeaderText_Players.setText(_("Players"), font_small);
+		remoteGameListHeaderCache.wzHeaderText_Players.render(x - 2 + GAMES_PLAYERS_START, y - 3, WZCOL_YELLOW);
+
+		remoteGameListHeaderCache.wzHeaderText_Status.setText(_("Status"), font_small);
+		remoteGameListHeaderCache.wzHeaderText_Status.render(x - 2 + GAMES_STATUS_START + 48, y - 3, WZCOL_YELLOW);
+	}
+}
+

--- a/src/titleui/gamefind.cpp
+++ b/src/titleui/gamefind.cpp
@@ -60,8 +60,6 @@ struct DisplayRemoteGameCache
 static DisplayRemoteGameHeaderCache remoteGameListHeaderCache;
 
 // find games
-static void addGames();
-static void addConsoleBox();
 static void displayRemoteGame(WIDGET *psWidget, UDWORD xOffset, UDWORD yOffset);
 
 WzGameFindTitleUI::WzGameFindTitleUI() {
@@ -202,7 +200,7 @@ TITLECODE WzGameFindTitleUI::run()
 
 // --- Various statics ---
 
-static void addConsoleBox()
+void WzGameFindTitleUI::addConsoleBox()
 {
 	if (widgGetFromID(psWScreen, FRONTEND_TOPFORM))
 	{
@@ -240,7 +238,7 @@ static void addConsoleBox()
 // ////////////////////////////////////////////////////////////////////////////
 // Game Chooser Screen.
 
-static void addGames()
+void WzGameFindTitleUI::addGames()
 {
 	int i, gcount = 0, added = 0;
 	static const char *wrongVersionTip = _("Your version of Warzone is incompatible with this game.");

--- a/src/titleui/msgbox.cpp
+++ b/src/titleui/msgbox.cpp
@@ -1,0 +1,77 @@
+/*
+	This file is part of Warzone 2100.
+	Copyright (C) 1999-2004  Eidos Interactive
+	Copyright (C) 2005-2019  Warzone 2100 Project
+
+	Warzone 2100 is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+
+	Warzone 2100 is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with Warzone 2100; if not, write to the Free Software
+	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+/*
+ * titleui/msgbox.cpp
+ *
+ * My own little UI, this shows you the console so that you can work out what went wrong
+ *  after (for example) a join.
+ * This prevents various problems that came up with using the lobby-based-console,
+ *  including (for example) the big tangling-up of everything...
+ * -- 20kdc
+ */
+
+#include "titleui.h"
+#include "lib/ivis_opengl/pieblitfunc.h"
+#include "lib/ivis_opengl/piemode.h"
+#include "lib/ivis_opengl/piestate.h"
+#include "lib/ivis_opengl/screen.h"
+#include "lib/netplay/netplay.h"
+#include "../multiplay.h"
+#include "../intdisplay.h"
+#include "../hci.h"
+#include "../multiint.h"
+#include "../warzoneconfig.h"
+#include "../frend.h"
+
+WzMsgBoxTitleUI::WzMsgBoxTitleUI(WzString text, std::shared_ptr<WzTitleUI> next) : text(text), next(next)
+{
+}
+
+void WzMsgBoxTitleUI::start()
+{
+	addBackdrop();
+	addTopForm(false);
+	addBottomForm();
+
+	W_LABINIT sLabInit;
+	sLabInit.formID = FRONTEND_BOTFORM;
+	sLabInit.id	= WZ_MSGBOX_TUI_LEAVE;
+	sLabInit.style = WLAB_ALIGNCENTRE;
+	sLabInit.x = MULTIOP_OKW;
+	sLabInit.y = MULTIOP_OKH;
+	sLabInit.width = FRONTEND_BOTFORMW - (MULTIOP_OKW * 2);
+	sLabInit.height = FRONTEND_BOTFORMH - (MULTIOP_OKH * 3);
+	sLabInit.pText = text;
+	widgAddLabel(psWScreen, &sLabInit);
+
+	addMultiBut(psWScreen, FRONTEND_BOTFORM, WZ_MSGBOX_TUI_LEAVE, FRONTEND_BOTFORMW - (MULTIOP_OKW * 2), FRONTEND_BOTFORMH - (MULTIOP_OKH * 2), MULTIOP_OKW, MULTIOP_OKH, _("Continue"), IMAGE_OK, IMAGE_OK, true);
+}
+
+TITLECODE WzMsgBoxTitleUI::run()
+{
+	screen_disableMapPreview();
+	WidgetTriggers const &triggers = widgRunScreen(psWScreen);
+	unsigned id = triggers.empty() ? 0 : triggers.front().widget->id;
+	if (id == WZ_MSGBOX_TUI_LEAVE)
+		changeTitleUI(next);
+	widgDisplayScreen(psWScreen);
+	return TITLECODE_CONTINUE;
+}
+

--- a/src/titleui/old.cpp
+++ b/src/titleui/old.cpp
@@ -1,0 +1,390 @@
+/*
+	This file is part of Warzone 2100.
+	Copyright (C) 1999-2004  Eidos Interactive
+	Copyright (C) 2005-2019  Warzone 2100 Project
+
+	Warzone 2100 is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+
+	Warzone 2100 is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with Warzone 2100; if not, write to the Free Software
+	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+/*
+ * titleui/old.cpp
+ *
+ * This is a catch-all for stuff that hasn't properly been encapsulated into individual classes yet.
+ * Code adapted from frontend.cpp & wrappers.cpp & frontend.h by Alex Lee / Pumpkin Studios / Eidos PLC.
+ */
+
+#include "titleui.h"
+#include "lib/ivis_opengl/pieblitfunc.h"
+#include "lib/ivis_opengl/piemode.h"
+#include "lib/ivis_opengl/piestate.h"
+#include "lib/ivis_opengl/screen.h"
+#include "lib/netplay/netplay.h"
+#include "../intdisplay.h"
+#include "../hci.h"
+#include "../keyedit.h"
+#include "../keymap.h"
+#include "../mission.h"
+#include "../multiint.h"
+#include "../multilimit.h"
+#include "../multistat.h"
+#include "../warzoneconfig.h"
+#include "../frend.h"
+
+// wrappers.cpp
+void runCreditsScreen();
+// frontend.cpp
+void startTitleMenu();
+void startTutorialMenu();
+void startSinglePlayerMenu();
+void startCampaignSelector();
+void startMultiPlayerMenu();
+void startOptionsMenu();
+void startGraphicsOptionsMenu();
+void startAudioAndZoomOptionsMenu();
+void startVideoOptionsMenu();
+void startMouseOptionsMenu();
+void startGameOptionsMenu();
+void refreshCurrentVideoOptionsValues();
+
+// Adopted (see below)
+static void runConnectionScreen();
+static bool startConnectionScreen();
+
+WzOldTitleUI::WzOldTitleUI(tMode mode) : mode(mode)
+{
+	
+}
+
+void WzOldTitleUI::start()
+{
+	switch (mode)
+	{
+	case CAMPAIGNS:
+		startCampaignSelector();
+		break;
+	case SINGLE:
+		startSinglePlayerMenu();
+		break;
+	case GAME:
+		startGameOptionsMenu();
+		break;
+	case GRAPHICS_OPTIONS:
+		startGraphicsOptionsMenu();
+		break;
+	case AUDIO_AND_ZOOM_OPTIONS:
+		startAudioAndZoomOptionsMenu();
+		break;
+	case VIDEO_OPTIONS:
+		startVideoOptionsMenu();
+		break;
+	case MOUSE_OPTIONS:
+		startMouseOptionsMenu();
+		break;
+	case TUTORIAL:
+		startTutorialMenu();
+		break;
+	case OPTIONS:
+		startOptionsMenu();
+		break;
+	case TITLE:
+		startTitleMenu();
+		break;
+	case CREDITS:
+		startCreditsScreen();
+		break;
+	case MULTI:
+		startMultiPlayerMenu();		// goto multiplayer menu
+		break;
+	case PROTOCOL:
+		startConnectionScreen();
+		break;
+	case GAMEFIND:
+		startGameFind();
+		break;
+	case KEYMAP:
+		startKeyMapEditor(true);
+		break;
+	case STARTGAME:
+	case QUIT:
+	case LOADSAVEGAME:
+		bLimiterLoaded = false;
+	case SHOWINTRO:
+		break;
+	default:
+		debug(LOG_FATAL, "Unknown title mode requested");
+		abort();
+		break;
+	}
+
+	return;
+}
+
+TITLECODE WzOldTitleUI::run()
+{
+	if (mode != STARTGAME)
+	{
+		screen_disableMapPreview();
+	}
+
+	switch (mode) // run relevant title screen code.
+	{
+	// MULTIPLAYER screens
+	case PROTOCOL:
+		runConnectionScreen(); // multiplayer connection screen.
+		break;
+	case GAMEFIND:
+		runGameFind();
+		break;
+	case MULTI:
+		runMultiPlayerMenu();
+		break;
+	case KEYMAP:
+		runKeyMapEditor();
+		break;
+
+	case TITLE:
+		runTitleMenu();
+		break;
+
+	case CAMPAIGNS:
+		runCampaignSelector();
+		break;
+
+	case SINGLE:
+		runSinglePlayerMenu();
+		break;
+
+	case TUTORIAL:
+		runTutorialMenu();
+		break;
+
+	case CREDITS:
+		runCreditsScreen();
+		break;
+
+	case OPTIONS:
+		runOptionsMenu();
+		break;
+
+	case GAME:
+		runGameOptionsMenu();
+		break;
+
+	case GRAPHICS_OPTIONS:
+		runGraphicsOptionsMenu();
+		break;
+
+	case AUDIO_AND_ZOOM_OPTIONS:
+		runAudioAndZoomOptionsMenu();
+		break;
+
+	case VIDEO_OPTIONS:
+		runVideoOptionsMenu();
+		break;
+
+	case MOUSE_OPTIONS:
+		runMouseOptionsMenu();
+		break;
+
+	case QUIT:
+		return TITLECODE_QUITGAME;
+
+	// The "don't flip" behavior is preserved in wrappers.cpp by checking for these title codes (which are clearly special)
+	case STARTGAME:
+		return TITLECODE_STARTGAME;
+	case LOADSAVEGAME:
+		return TITLECODE_SAVEGAMELOAD;
+
+	case SHOWINTRO:
+		pie_SetFogStatus(false);
+		pie_ScreenFlip(CLEAR_BLACK);
+		changeTitleMode(TITLE);
+		return TITLECODE_SHOWINTRO;
+
+	default:
+		debug(LOG_FATAL, "unknown title screen mode");
+		abort();
+	}
+	return TITLECODE_CONTINUE;
+}
+
+void WzOldTitleUI::screenSizeDidChange()
+{
+	// If the Video Options screen is up, the current resolution text (and other values) should be refreshed
+	if (mode == VIDEO_OPTIONS)
+		refreshCurrentVideoOptionsValues();
+}
+
+// --- Adopted to clean up multiint.cpp ---
+
+static bool				SettingsUp		= false;
+static UBYTE				InitialProto	= 0;
+static W_SCREEN				*psConScreen;
+
+// ////////////////////////////////////////////////////////////////////////////
+// Connection Options Screen.
+
+void multiOptionsScreenSizeDidChange(unsigned int oldWidth, unsigned int oldHeight, unsigned int newWidth, unsigned int newHeight)
+{
+	if (psConScreen == nullptr) return;
+	psConScreen->screenSizeDidChange(oldWidth, oldHeight, newWidth, newHeight);
+}
+
+static bool OptionsInet()			//internet options
+{
+	psConScreen = new W_SCREEN;
+
+	W_FORMINIT sFormInit;           //Connection Settings
+	sFormInit.formID = 0;
+	sFormInit.id = CON_SETTINGS;
+	sFormInit.style = WFORM_PLAIN;
+	sFormInit.calcLayout = LAMBDA_CALCLAYOUT_SIMPLE({
+		psWidget->setGeometry(CON_SETTINGSX, CON_SETTINGSY, CON_SETTINGSWIDTH, CON_SETTINGSHEIGHT);
+	});
+	sFormInit.pDisplay = intDisplayFeBox;
+	widgAddForm(psConScreen, &sFormInit);
+
+	addMultiBut(psConScreen, CON_SETTINGS, CON_OK, CON_OKX, CON_OKY, MULTIOP_OKW, MULTIOP_OKH,
+	            _("Accept Settings"), IMAGE_OK, IMAGE_OK, true);
+	addMultiBut(psConScreen, CON_SETTINGS, CON_IP_CANCEL, CON_OKX + MULTIOP_OKW + 10, CON_OKY, MULTIOP_OKW, MULTIOP_OKH,
+	            _("Cancel"), IMAGE_NO, IMAGE_NO, true);
+
+	//label.
+	W_LABINIT sLabInit;
+	sLabInit.formID = CON_SETTINGS;
+	sLabInit.id		= CON_SETTINGS_LABEL;
+	sLabInit.style	= WLAB_ALIGNCENTRE;
+	sLabInit.x		= 0;
+	sLabInit.y		= 10;
+	sLabInit.width	= CON_SETTINGSWIDTH;
+	sLabInit.height = 20;
+	sLabInit.pText	= WzString::fromUtf8(_("IP Address or Machine Name"));
+	widgAddLabel(psConScreen, &sLabInit);
+
+
+	W_EDBINIT sEdInit;             // address
+	sEdInit.formID = CON_SETTINGS;
+	sEdInit.id = CON_IP;
+	sEdInit.x = CON_IPX;
+	sEdInit.y = CON_IPY;
+	sEdInit.width = CON_NAMEBOXWIDTH;
+	sEdInit.height = CON_NAMEBOXHEIGHT;
+	sEdInit.pText = "";									//_("IP Address or Machine Name");
+	sEdInit.pBoxDisplay = intDisplayEditBox;
+	if (!widgAddEditBox(psConScreen, &sEdInit))
+	{
+		return false;
+	}
+	// auto click in the text box
+	W_CONTEXT sContext;
+	sContext.xOffset	= 0;
+	sContext.yOffset	= 0;
+	sContext.mx			= 0;
+	sContext.my			= 0;
+	widgGetFromID(psConScreen, CON_IP)->clicked(&sContext);
+
+	SettingsUp = true;
+	return true;
+}
+
+// ////////////////////////////////////////////////////////////////////////////
+// Draw the connections screen.
+static bool startConnectionScreen()
+{
+	addBackdrop();										//background
+	addTopForm(false);										// logo
+	addBottomForm();
+
+	SettingsUp		= false;
+	InitialProto	= 0;
+	// is it really a problem to remember this? in any case, when gamefinder is made a TitleUI it can properly forget again
+	// safeSearch		= false;
+
+	// don't pretend we are running a network game. Really do it!
+	NetPlay.bComms = true; // use network = true
+
+	addSideText(FRONTEND_SIDETEXT,  FRONTEND_SIDEX, FRONTEND_SIDEY, _("CONNECTION"));
+
+	addMultiBut(psWScreen, FRONTEND_BOTFORM, CON_CANCEL, 10, 10, MULTIOP_OKW, MULTIOP_OKH,
+	            _("Return To Previous Screen"), IMAGE_RETURN, IMAGE_RETURN_HI, IMAGE_RETURN_HI);	// goback buttpn levels
+
+	addTextButton(CON_TYPESID_START + 0, FRONTEND_POS2X, FRONTEND_POS2Y, _("Lobby"), WBUT_TXTCENTRE);
+	addTextButton(CON_TYPESID_START + 1, FRONTEND_POS3X, FRONTEND_POS3Y, _("IP"), WBUT_TXTCENTRE);
+
+	return true;
+}
+
+static void runConnectionScreen()
+{
+	static char addr[128];
+
+	W_SCREEN *curScreen = SettingsUp ? psConScreen : psWScreen;
+	WidgetTriggers const &triggers = widgRunScreen(curScreen);
+	unsigned id = triggers.empty() ? 0 : triggers.front().widget->id; // Just use first click here, since the next click could be on another menu.
+
+	switch (id)
+	{
+	case CON_CANCEL: //cancel
+		changeTitleMode(MULTI);
+		bMultiPlayer = false;
+		bMultiMessages = false;
+		break;
+	case CON_TYPESID_START+0: // Lobby button
+		if (getLobbyError() != ERROR_INVALID)
+		{
+			setLobbyError(ERROR_NOERROR);
+		}
+		changeTitleMode(GAMEFIND);
+		break;
+	case CON_TYPESID_START+1: // IP button
+		OptionsInet();
+		break;
+	case CON_OK:
+		sstrcpy(addr, widgGetString(psConScreen, CON_IP));
+		if (addr[0] == '\0')
+		{
+			sstrcpy(addr, "127.0.0.1");  // Default to localhost.
+		}
+
+		if (SettingsUp == true)
+		{
+			delete psConScreen;
+			psConScreen = nullptr;
+			SettingsUp = false;
+		}
+
+		joinGame(addr, 0);
+		break;
+	case CON_IP_CANCEL:
+		if (SettingsUp == true)
+		{
+			delete psConScreen;
+			psConScreen = nullptr;
+			SettingsUp = false;
+		}
+		break;
+	}
+
+	widgDisplayScreen(psWScreen);							// show the widgets currently running
+	if (SettingsUp == true)
+	{
+		widgDisplayScreen(psConScreen);						// show the widgets currently running
+	}
+
+	if (CancelPressed())
+	{
+		changeTitleMode(MULTI);
+	}
+}
+

--- a/src/titleui/old.cpp
+++ b/src/titleui/old.cpp
@@ -102,9 +102,6 @@ void WzOldTitleUI::start()
 	case MULTI:
 		startMultiPlayerMenu();		// goto multiplayer menu
 		break;
-	case GAMEFIND:
-		startGameFind();
-		break;
 	case KEYMAP:
 		startKeyMapEditor(true);
 		break;
@@ -133,9 +130,6 @@ TITLECODE WzOldTitleUI::run()
 	switch (mode) // run relevant title screen code.
 	{
 	// MULTIPLAYER screens
-	case GAMEFIND:
-		runGameFind();
-		break;
 	case MULTI:
 		runMultiPlayerMenu();
 		break;

--- a/src/titleui/old.cpp
+++ b/src/titleui/old.cpp
@@ -57,10 +57,6 @@ void startMouseOptionsMenu();
 void startGameOptionsMenu();
 void refreshCurrentVideoOptionsValues();
 
-// Adopted (see below)
-static void runConnectionScreen();
-static bool startConnectionScreen();
-
 WzOldTitleUI::WzOldTitleUI(tMode mode) : mode(mode)
 {
 	
@@ -106,9 +102,6 @@ void WzOldTitleUI::start()
 	case MULTI:
 		startMultiPlayerMenu();		// goto multiplayer menu
 		break;
-	case PROTOCOL:
-		startConnectionScreen();
-		break;
 	case GAMEFIND:
 		startGameFind();
 		break;
@@ -140,9 +133,6 @@ TITLECODE WzOldTitleUI::run()
 	switch (mode) // run relevant title screen code.
 	{
 	// MULTIPLAYER screens
-	case PROTOCOL:
-		runConnectionScreen(); // multiplayer connection screen.
-		break;
 	case GAMEFIND:
 		runGameFind();
 		break;
@@ -219,172 +209,10 @@ TITLECODE WzOldTitleUI::run()
 	return TITLECODE_CONTINUE;
 }
 
-void WzOldTitleUI::screenSizeDidChange()
+void WzOldTitleUI::screenSizeDidChange(unsigned int oldWidth, unsigned int oldHeight, unsigned int newWidth, unsigned int newHeight)
 {
 	// If the Video Options screen is up, the current resolution text (and other values) should be refreshed
 	if (mode == VIDEO_OPTIONS)
 		refreshCurrentVideoOptionsValues();
-}
-
-// --- Adopted to clean up multiint.cpp ---
-
-static bool				SettingsUp		= false;
-static UBYTE				InitialProto	= 0;
-static W_SCREEN				*psConScreen;
-
-// ////////////////////////////////////////////////////////////////////////////
-// Connection Options Screen.
-
-void multiOptionsScreenSizeDidChange(unsigned int oldWidth, unsigned int oldHeight, unsigned int newWidth, unsigned int newHeight)
-{
-	if (psConScreen == nullptr) return;
-	psConScreen->screenSizeDidChange(oldWidth, oldHeight, newWidth, newHeight);
-}
-
-static bool OptionsInet()			//internet options
-{
-	psConScreen = new W_SCREEN;
-
-	W_FORMINIT sFormInit;           //Connection Settings
-	sFormInit.formID = 0;
-	sFormInit.id = CON_SETTINGS;
-	sFormInit.style = WFORM_PLAIN;
-	sFormInit.calcLayout = LAMBDA_CALCLAYOUT_SIMPLE({
-		psWidget->setGeometry(CON_SETTINGSX, CON_SETTINGSY, CON_SETTINGSWIDTH, CON_SETTINGSHEIGHT);
-	});
-	sFormInit.pDisplay = intDisplayFeBox;
-	widgAddForm(psConScreen, &sFormInit);
-
-	addMultiBut(psConScreen, CON_SETTINGS, CON_OK, CON_OKX, CON_OKY, MULTIOP_OKW, MULTIOP_OKH,
-	            _("Accept Settings"), IMAGE_OK, IMAGE_OK, true);
-	addMultiBut(psConScreen, CON_SETTINGS, CON_IP_CANCEL, CON_OKX + MULTIOP_OKW + 10, CON_OKY, MULTIOP_OKW, MULTIOP_OKH,
-	            _("Cancel"), IMAGE_NO, IMAGE_NO, true);
-
-	//label.
-	W_LABINIT sLabInit;
-	sLabInit.formID = CON_SETTINGS;
-	sLabInit.id		= CON_SETTINGS_LABEL;
-	sLabInit.style	= WLAB_ALIGNCENTRE;
-	sLabInit.x		= 0;
-	sLabInit.y		= 10;
-	sLabInit.width	= CON_SETTINGSWIDTH;
-	sLabInit.height = 20;
-	sLabInit.pText	= WzString::fromUtf8(_("IP Address or Machine Name"));
-	widgAddLabel(psConScreen, &sLabInit);
-
-
-	W_EDBINIT sEdInit;             // address
-	sEdInit.formID = CON_SETTINGS;
-	sEdInit.id = CON_IP;
-	sEdInit.x = CON_IPX;
-	sEdInit.y = CON_IPY;
-	sEdInit.width = CON_NAMEBOXWIDTH;
-	sEdInit.height = CON_NAMEBOXHEIGHT;
-	sEdInit.pText = "";									//_("IP Address or Machine Name");
-	sEdInit.pBoxDisplay = intDisplayEditBox;
-	if (!widgAddEditBox(psConScreen, &sEdInit))
-	{
-		return false;
-	}
-	// auto click in the text box
-	W_CONTEXT sContext;
-	sContext.xOffset	= 0;
-	sContext.yOffset	= 0;
-	sContext.mx			= 0;
-	sContext.my			= 0;
-	widgGetFromID(psConScreen, CON_IP)->clicked(&sContext);
-
-	SettingsUp = true;
-	return true;
-}
-
-// ////////////////////////////////////////////////////////////////////////////
-// Draw the connections screen.
-static bool startConnectionScreen()
-{
-	addBackdrop();										//background
-	addTopForm(false);										// logo
-	addBottomForm();
-
-	SettingsUp		= false;
-	InitialProto	= 0;
-	// is it really a problem to remember this? in any case, when gamefinder is made a TitleUI it can properly forget again
-	// safeSearch		= false;
-
-	// don't pretend we are running a network game. Really do it!
-	NetPlay.bComms = true; // use network = true
-
-	addSideText(FRONTEND_SIDETEXT,  FRONTEND_SIDEX, FRONTEND_SIDEY, _("CONNECTION"));
-
-	addMultiBut(psWScreen, FRONTEND_BOTFORM, CON_CANCEL, 10, 10, MULTIOP_OKW, MULTIOP_OKH,
-	            _("Return To Previous Screen"), IMAGE_RETURN, IMAGE_RETURN_HI, IMAGE_RETURN_HI);	// goback buttpn levels
-
-	addTextButton(CON_TYPESID_START + 0, FRONTEND_POS2X, FRONTEND_POS2Y, _("Lobby"), WBUT_TXTCENTRE);
-	addTextButton(CON_TYPESID_START + 1, FRONTEND_POS3X, FRONTEND_POS3Y, _("IP"), WBUT_TXTCENTRE);
-
-	return true;
-}
-
-static void runConnectionScreen()
-{
-	static char addr[128];
-
-	W_SCREEN *curScreen = SettingsUp ? psConScreen : psWScreen;
-	WidgetTriggers const &triggers = widgRunScreen(curScreen);
-	unsigned id = triggers.empty() ? 0 : triggers.front().widget->id; // Just use first click here, since the next click could be on another menu.
-
-	switch (id)
-	{
-	case CON_CANCEL: //cancel
-		changeTitleMode(MULTI);
-		bMultiPlayer = false;
-		bMultiMessages = false;
-		break;
-	case CON_TYPESID_START+0: // Lobby button
-		if (getLobbyError() != ERROR_INVALID)
-		{
-			setLobbyError(ERROR_NOERROR);
-		}
-		changeTitleMode(GAMEFIND);
-		break;
-	case CON_TYPESID_START+1: // IP button
-		OptionsInet();
-		break;
-	case CON_OK:
-		sstrcpy(addr, widgGetString(psConScreen, CON_IP));
-		if (addr[0] == '\0')
-		{
-			sstrcpy(addr, "127.0.0.1");  // Default to localhost.
-		}
-
-		if (SettingsUp == true)
-		{
-			delete psConScreen;
-			psConScreen = nullptr;
-			SettingsUp = false;
-		}
-
-		joinGame(addr, 0);
-		break;
-	case CON_IP_CANCEL:
-		if (SettingsUp == true)
-		{
-			delete psConScreen;
-			psConScreen = nullptr;
-			SettingsUp = false;
-		}
-		break;
-	}
-
-	widgDisplayScreen(psWScreen);							// show the widgets currently running
-	if (SettingsUp == true)
-	{
-		widgDisplayScreen(psConScreen);						// show the widgets currently running
-	}
-
-	if (CancelPressed())
-	{
-		changeTitleMode(MULTI);
-	}
 }
 

--- a/src/titleui/passbox.cpp
+++ b/src/titleui/passbox.cpp
@@ -1,0 +1,116 @@
+/*
+	This file is part of Warzone 2100.
+	Copyright (C) 1999-2004  Eidos Interactive
+	Copyright (C) 2005-2019  Warzone 2100 Project
+
+	Warzone 2100 is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+
+	Warzone 2100 is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with Warzone 2100; if not, write to the Free Software
+	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+/*
+ * titleui/passbox.cpp
+ *
+ * A separated version of the password box that used to be in multiint.
+ * The old password modal hides all the UI under normal conditions.
+ * This version does that and also prevents any cross-talk
+ *  between the Lobby-related code and the general network game code.
+ * -- 20kdc
+ *
+ * As this comes from multiint.cpp, see that for original origin details of the UI code
+ */
+
+#include "titleui.h"
+#include "lib/ivis_opengl/pieblitfunc.h"
+#include "lib/ivis_opengl/piemode.h"
+#include "lib/ivis_opengl/piestate.h"
+#include "lib/ivis_opengl/screen.h"
+
+#include "lib/widget/editbox.h"
+#include "lib/widget/button.h"
+#include "lib/widget/widget.h"
+#include "lib/widget/widgint.h"
+#include "lib/widget/label.h"
+
+#include "lib/netplay/netplay.h"
+#include "../multiplay.h"
+#include "../intdisplay.h"
+#include "../hci.h"
+#include "../multiint.h"
+#include "../warzoneconfig.h"
+#include "../frend.h"
+#include "../init.h"
+
+WzPassBoxTitleUI::WzPassBoxTitleUI(std::function<void(const char *)> next) : next(next)
+{
+}
+
+void WzPassBoxTitleUI::start()
+{
+	addBackdrop();
+
+	WIDGET *parent = widgGetFromID(psWScreen, FRONTEND_BACKDROP);
+
+	// draws the background of the password box
+	IntFormAnimated *passwordForm = new IntFormAnimated(parent);
+	passwordForm->id = FRONTEND_PASSWORDFORM;
+	passwordForm->setCalcLayout(LAMBDA_CALCLAYOUT_SIMPLE({
+		psWidget->setGeometry(FRONTEND_BOTFORMX, 160, FRONTEND_TOPFORMW, FRONTEND_TOPFORMH - 40);
+	}));
+
+	// password label.
+	W_LABEL *enterPasswordLabel = new W_LABEL(passwordForm);
+	enterPasswordLabel->setTextAlignment(WLAB_ALIGNCENTRE);
+	enterPasswordLabel->setGeometry(130, 0, 280, 40);
+	enterPasswordLabel->setFont(font_large, WZCOL_FORM_TEXT);
+	enterPasswordLabel->setString(_("Enter Password:"));
+
+	// and finally draw the password entry box
+	W_EDITBOX *passwordBox = new W_EDITBOX(passwordForm);
+	passwordBox->id = CON_PASSWORD;
+	passwordBox->setGeometry(130, 40, 280, 20);
+	passwordBox->setBoxColours(WZCOL_MENU_BORDER, WZCOL_MENU_BORDER, WZCOL_MENU_BACKGROUND);
+
+	W_BUTTON *buttonYes = new W_BUTTON(passwordForm);
+	buttonYes->id = CON_PASSWORDYES;
+	buttonYes->setImages(Image(FrontImages, IMAGE_OK), Image(FrontImages, IMAGE_OK), mpwidgetGetFrontHighlightImage(Image(FrontImages, IMAGE_OK)));
+	buttonYes->move(180, 65);
+	buttonYes->setTip(_("OK"));
+	W_BUTTON *buttonNo = new W_BUTTON(passwordForm);
+	buttonNo->id = CON_PASSWORDNO;
+	buttonNo->setImages(Image(FrontImages, IMAGE_NO), Image(FrontImages, IMAGE_NO), mpwidgetGetFrontHighlightImage(Image(FrontImages, IMAGE_NO)));
+	buttonNo->move(230, 65);
+	buttonNo->setTip(_("Cancel"));
+
+	// auto click in the password box
+	W_CONTEXT sContext;
+	sContext.xOffset	= 0;
+	sContext.yOffset	= 0;
+	sContext.mx			= 0;
+	sContext.my			= 0;
+	widgGetFromID(psWScreen, CON_PASSWORD)->clicked(&sContext);
+}
+
+TITLECODE WzPassBoxTitleUI::run()
+{
+	screen_disableMapPreview();
+	WidgetTriggers const &triggers = widgRunScreen(psWScreen);
+	unsigned id = triggers.empty() ? 0 : triggers.front().widget->id;
+	if (id == CON_PASSWORDYES) {
+		next(widgGetString(psWScreen, CON_PASSWORD));
+	} else if ((id == CON_PASSWORDNO) || CancelPressed()) {
+		next(nullptr);
+	}
+	widgDisplayScreen(psWScreen);
+	return TITLECODE_CONTINUE;
+}
+

--- a/src/titleui/protocol.cpp
+++ b/src/titleui/protocol.cpp
@@ -1,0 +1,210 @@
+/*
+	This file is part of Warzone 2100.
+	Copyright (C) 1999-2004  Eidos Interactive
+	Copyright (C) 2005-2019  Warzone 2100 Project
+
+	Warzone 2100 is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+
+	Warzone 2100 is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with Warzone 2100; if not, write to the Free Software
+	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+/*
+ * titleui/protocol.cpp
+ *
+ * This is the protocol menu.
+ * It can open the lobby menu, or allows you to enter an IP address to join a game directly.
+ * Code adapted from multiint.cpp
+ */
+
+#include "titleui.h"
+#include "lib/ivis_opengl/pieblitfunc.h"
+#include "lib/ivis_opengl/piemode.h"
+#include "lib/ivis_opengl/piestate.h"
+#include "lib/ivis_opengl/screen.h"
+#include "lib/netplay/netplay.h"
+#include "../multiplay.h"
+#include "../intdisplay.h"
+#include "../hci.h"
+#include "../multiint.h"
+#include "../warzoneconfig.h"
+#include "../frend.h"
+
+WzProtocolTitleUI::WzProtocolTitleUI()
+{
+	
+}
+
+WzProtocolTitleUI::~WzProtocolTitleUI()
+{
+	if (psSettingsScreen)
+		delete psSettingsScreen;
+}
+
+void WzProtocolTitleUI::start()
+{
+	addBackdrop();										//background
+	addTopForm(false);										// logo
+	addBottomForm();
+
+	// Obliterate any hanging settings screen
+	closeIPDialog();
+
+	// is it really a problem to leave this unchanged? in any case, when gamefinder is made a TitleUI it can properly forget again
+	// safeSearch		= false;
+
+	// don't pretend we are running a network game. Really do it!
+	NetPlay.bComms = true; // use network = true
+
+	addSideText(FRONTEND_SIDETEXT,  FRONTEND_SIDEX, FRONTEND_SIDEY, _("CONNECTION"));
+
+	addMultiBut(psWScreen, FRONTEND_BOTFORM, CON_CANCEL, 10, 10, MULTIOP_OKW, MULTIOP_OKH,
+	            _("Return To Previous Screen"), IMAGE_RETURN, IMAGE_RETURN_HI, IMAGE_RETURN_HI);	// goback buttpn levels
+
+	addTextButton(CON_TYPESID_START + 0, FRONTEND_POS2X, FRONTEND_POS2Y, _("Lobby"), WBUT_TXTCENTRE);
+	addTextButton(CON_TYPESID_START + 1, FRONTEND_POS3X, FRONTEND_POS3Y, _("IP"), WBUT_TXTCENTRE);
+
+	if (hasWaitingIP) {
+		hasWaitingIP = false;
+		openIPDialog();
+	}
+}
+
+TITLECODE WzProtocolTitleUI::run()
+{
+	screen_disableMapPreview();
+
+	static char addr[128];
+
+	W_SCREEN *curScreen = psSettingsScreen ? psSettingsScreen : psWScreen;
+	WidgetTriggers const &triggers = widgRunScreen(curScreen);
+	unsigned id = triggers.empty() ? 0 : triggers.front().widget->id; // Just use first click here, since the next click could be on another menu.
+
+	switch (id)
+	{
+	case CON_CANCEL: //cancel
+		changeTitleMode(MULTI);
+		bMultiPlayer = false;
+		bMultiMessages = false;
+		break;
+	case CON_TYPESID_START+0: // Lobby button
+		if (getLobbyError() != ERROR_INVALID)
+		{
+			setLobbyError(ERROR_NOERROR);
+		}
+		changeTitleMode(GAMEFIND);
+		break;
+	case CON_TYPESID_START+1: // IP button
+		openIPDialog();
+		break;
+	case CON_OK:
+		sstrcpy(addr, widgGetString(curScreen, CON_IP));
+		if (addr[0] == '\0')
+		{
+			sstrcpy(addr, "127.0.0.1");  // Default to localhost.
+		}
+		ipPrompt = addr;
+		hasWaitingIP = true;
+		closeIPDialog();
+		joinGame(addr, 0);
+		break;
+	case CON_IP_CANCEL:
+		closeIPDialog();
+		break;
+	}
+
+	widgDisplayScreen(psWScreen);							// show the widgets currently running
+	if (psSettingsScreen)
+	{
+		widgDisplayScreen(psSettingsScreen);						// show the widgets currently running
+	}
+
+	if (CancelPressed())
+	{
+		changeTitleMode(MULTI);
+	}
+	return TITLECODE_CONTINUE;
+}
+
+// ////////////////////////////////////////////////////////////////////////////
+// Connection Options Screen.
+
+void WzProtocolTitleUI::screenSizeDidChange(unsigned int oldWidth, unsigned int oldHeight, unsigned int newWidth, unsigned int newHeight)
+{
+	if (!psSettingsScreen) return;
+	psSettingsScreen->screenSizeDidChange(oldWidth, oldHeight, newWidth, newHeight);
+}
+
+void WzProtocolTitleUI::openIPDialog()			//internet options
+{
+	psSettingsScreen = new W_SCREEN;
+
+	W_FORMINIT sFormInit;           //Connection Settings
+	sFormInit.formID = 0;
+	sFormInit.id = CON_SETTINGS;
+	sFormInit.style = WFORM_PLAIN;
+	sFormInit.calcLayout = LAMBDA_CALCLAYOUT_SIMPLE({
+		psWidget->setGeometry(CON_SETTINGSX, CON_SETTINGSY, CON_SETTINGSWIDTH, CON_SETTINGSHEIGHT);
+	});
+	sFormInit.pDisplay = intDisplayFeBox;
+	widgAddForm(psSettingsScreen, &sFormInit);
+
+	addMultiBut(psSettingsScreen, CON_SETTINGS, CON_OK, CON_OKX, CON_OKY, MULTIOP_OKW, MULTIOP_OKH,
+	            _("Accept Settings"), IMAGE_OK, IMAGE_OK, true);
+	addMultiBut(psSettingsScreen, CON_SETTINGS, CON_IP_CANCEL, CON_OKX + MULTIOP_OKW + 10, CON_OKY, MULTIOP_OKW, MULTIOP_OKH,
+	            _("Cancel"), IMAGE_NO, IMAGE_NO, true);
+
+	//label.
+	W_LABINIT sLabInit;
+	sLabInit.formID = CON_SETTINGS;
+	sLabInit.id		= CON_SETTINGS_LABEL;
+	sLabInit.style	= WLAB_ALIGNCENTRE;
+	sLabInit.x		= 0;
+	sLabInit.y		= 10;
+	sLabInit.width	= CON_SETTINGSWIDTH;
+	sLabInit.height = 20;
+	sLabInit.pText	= WzString::fromUtf8(_("IP Address or Machine Name"));
+	widgAddLabel(psSettingsScreen, &sLabInit);
+
+
+	W_EDBINIT sEdInit;             // address
+	sEdInit.formID = CON_SETTINGS;
+	sEdInit.id = CON_IP;
+	sEdInit.x = CON_IPX;
+	sEdInit.y = CON_IPY;
+	sEdInit.width = CON_NAMEBOXWIDTH;
+	sEdInit.height = CON_NAMEBOXHEIGHT;
+	sEdInit.pText = "";									//_("IP Address or Machine Name");
+	sEdInit.pBoxDisplay = intDisplayEditBox;
+	if (!widgAddEditBox(psSettingsScreen, &sEdInit))
+	{
+		closeIPDialog();
+		return;
+	}
+	widgSetString(psSettingsScreen, CON_IP, ipPrompt.c_str());
+	// auto click in the text box
+	W_CONTEXT sContext;
+	sContext.xOffset	= 0;
+	sContext.yOffset	= 0;
+	sContext.mx			= 0;
+	sContext.my			= 0;
+	widgGetFromID(psSettingsScreen, CON_IP)->clicked(&sContext);
+}
+
+void WzProtocolTitleUI::closeIPDialog()
+{
+	if (psSettingsScreen)
+	{
+		delete psSettingsScreen;
+		psSettingsScreen = nullptr;
+	}
+}
+

--- a/src/titleui/protocol.cpp
+++ b/src/titleui/protocol.cpp
@@ -100,7 +100,7 @@ TITLECODE WzProtocolTitleUI::run()
 		{
 			setLobbyError(ERROR_NOERROR);
 		}
-		changeTitleMode(GAMEFIND);
+		changeTitleUI(std::make_shared<WzGameFindTitleUI>());
 		break;
 	case CON_TYPESID_START+1: // IP button
 		openIPDialog();

--- a/src/titleui/titleui.cpp
+++ b/src/titleui/titleui.cpp
@@ -33,7 +33,7 @@ WzTitleUI::~WzTitleUI()
 {
 }
 
-void WzTitleUI::screenSizeDidChange()
+void WzTitleUI::screenSizeDidChange(unsigned int oldWidth, unsigned int oldHeight, unsigned int newWidth, unsigned int newHeight)
 {
 }
 
@@ -42,6 +42,7 @@ void changeTitleUI(std::shared_ptr<WzTitleUI> target)
 	wzTitleUICurrent = target;
 	// Deletes the backdrop, which in turn deletes the rest of the UI from whatever was on screen before this UI
 	widgDelete(psWScreen, FRONTEND_BACKDROP);
-	target->start();
+	if (target)
+		target->start();
 }
 

--- a/src/titleui/titleui.cpp
+++ b/src/titleui/titleui.cpp
@@ -18,26 +18,30 @@
 	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
 */
 /*
- * multilimit.h
+ * titleui/titleui.cpp
+ *
+ * WzTitleUI common stuff
  */
 
-#ifndef __INCLUDED_MULTILIMIT_H__
-#define __INCLUDED_MULTILIMIT_H__
+#include "titleui.h"
+#include "../intdisplay.h"
+#include "../hci.h"
 
-#include "titleui/titleui.h"
+std::shared_ptr<WzTitleUI> wzTitleUICurrent;
 
-class WzMultiLimitTitleUI: public WzTitleUI
+WzTitleUI::~WzTitleUI()
 {
-public:
-	WzMultiLimitTitleUI(std::shared_ptr<WzMultiOptionTitleUI> parent);
-	virtual void start() override;
-	virtual TITLECODE run() override;
-private:
-	// The parent WzMultiOptionTitleUI to return to.
-	std::shared_ptr<WzMultiOptionTitleUI> parent;
-};
+}
 
-void applyLimitSet();
-void createLimitSet();
+void WzTitleUI::screenSizeDidChange()
+{
+}
 
-#endif //__cplusplus //__INCLUDED_MULTILIMIT_H__
+void changeTitleUI(std::shared_ptr<WzTitleUI> target)
+{
+	wzTitleUICurrent = target;
+	// Deletes the backdrop, which in turn deletes the rest of the UI from whatever was on screen before this UI
+	widgDelete(psWScreen, FRONTEND_BACKDROP);
+	target->start();
+}
+

--- a/src/titleui/titleui.h
+++ b/src/titleui/titleui.h
@@ -142,6 +142,8 @@ public:
 	virtual void start() override;
 	virtual TITLECODE run() override;
 private:
+	void addGames();
+	void addConsoleBox();
 	bool safeSearch = false; // allow auto game finding.
 	bool toggleFilter = true; // Used to show all games or only games that are of the same version
 };

--- a/src/titleui/titleui.h
+++ b/src/titleui/titleui.h
@@ -30,6 +30,7 @@
 #include "../wrappers.h"
 
 #include <memory>
+#include <functional>
 
 // Regarding construction vs. start():
 // This allows a reference to the parent to be held for a stack-like effect.
@@ -117,6 +118,20 @@ private:
 	WzString text;
 	// Where to go after the user has acknowledged.
 	std::shared_ptr<WzTitleUI> next;
+};
+
+// - passbox.cpp -
+class WzPassBoxTitleUI: public WzTitleUI
+{
+public:
+	// The callback receives nullptr for cancellation, or a widgGetString result otherwise.
+	// The callback is expected to change current UI.
+	WzPassBoxTitleUI(std::function<void(const char *)> next);
+	virtual void start() override;
+	virtual TITLECODE run() override;
+private:
+	// Where to go after the user has acknowledged.
+	std::function<void(const char *)> next;
 };
 
 #define WZ_MSGBOX_TUI_LEAVE 4597000

--- a/src/titleui/titleui.h
+++ b/src/titleui/titleui.h
@@ -134,6 +134,18 @@ private:
 	std::function<void(const char *)> next;
 };
 
+// - gamefind.cpp -
+class WzGameFindTitleUI: public WzTitleUI
+{
+public:
+	WzGameFindTitleUI();
+	virtual void start() override;
+	virtual TITLECODE run() override;
+private:
+	bool safeSearch = false; // allow auto game finding.
+	bool toggleFilter = true; // Used to show all games or only games that are of the same version
+};
+
 #define WZ_MSGBOX_TUI_LEAVE 4597000
 
 #endif

--- a/src/titleui/titleui.h
+++ b/src/titleui/titleui.h
@@ -1,0 +1,75 @@
+/*
+	This file is part of Warzone 2100.
+	Copyright (C) 1999-2004  Eidos Interactive
+	Copyright (C) 2005-2019  Warzone 2100 Project
+
+	Warzone 2100 is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+
+	Warzone 2100 is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with Warzone 2100; if not, write to the Free Software
+	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+/** \file
+ *  The various title screen UIs go here.
+ */
+
+#ifndef __INCLUDED_SRC_TITLEUI_TITLEUI_H__
+#define __INCLUDED_SRC_TITLEUI_TITLEUI_H__
+
+#include <memory>
+
+// tMode
+#include "../frontend.h"
+// TITLECODE
+#include "../wrappers.h"
+
+// Regarding construction vs. start():
+// This allows a reference to the parent to be held for a stack-like effect.
+class WzTitleUI
+{
+public:
+	virtual ~WzTitleUI();
+	virtual void start() = 0;
+	// NOTE! When porting, add screen_disableMapPreview(); if relevant!
+	virtual TITLECODE run() = 0;
+	virtual void screenSizeDidChange();
+};
+
+// Pointer to the current UI. Dynamic allocation helps with the encapsulation.
+extern std::shared_ptr<WzTitleUI> wzTitleUICurrent;
+void changeTitleUI(std::shared_ptr<WzTitleUI> ui);
+
+// - old.cpp -
+class WzOldTitleUI: public WzTitleUI
+{
+public:
+	WzOldTitleUI(tMode mode);
+	virtual void start() override;
+	virtual TITLECODE run() override;
+	virtual void screenSizeDidChange() override;
+private:
+	tMode mode;
+};
+
+// - multiint.cpp -
+class WzMultiOptionTitleUI: public WzTitleUI
+{
+public:
+	WzMultiOptionTitleUI();
+	virtual void start() override;
+	virtual TITLECODE run() override;
+private:
+	bool performedFirstStart = false;
+};
+
+// WzMultiLimitTitleUI: multilimit.cpp/h
+
+#endif

--- a/src/titleui/titleui.h
+++ b/src/titleui/titleui.h
@@ -24,12 +24,12 @@
 #ifndef __INCLUDED_SRC_TITLEUI_TITLEUI_H__
 #define __INCLUDED_SRC_TITLEUI_TITLEUI_H__
 
-#include <memory>
-
 // tMode
 #include "../frontend.h"
 // TITLECODE
 #include "../wrappers.h"
+
+#include <memory>
 
 // Regarding construction vs. start():
 // This allows a reference to the parent to be held for a stack-like effect.
@@ -40,11 +40,12 @@ public:
 	virtual void start() = 0;
 	// NOTE! When porting, add screen_disableMapPreview(); if relevant!
 	virtual TITLECODE run() = 0;
-	virtual void screenSizeDidChange();
+	virtual void screenSizeDidChange(unsigned int oldWidth, unsigned int oldHeight, unsigned int newWidth, unsigned int newHeight);
 };
 
 // Pointer to the current UI. Dynamic allocation helps with the encapsulation.
 extern std::shared_ptr<WzTitleUI> wzTitleUICurrent;
+
 void changeTitleUI(std::shared_ptr<WzTitleUI> ui);
 
 // - old.cpp -
@@ -54,22 +55,70 @@ public:
 	WzOldTitleUI(tMode mode);
 	virtual void start() override;
 	virtual TITLECODE run() override;
-	virtual void screenSizeDidChange() override;
+	virtual void screenSizeDidChange(unsigned int oldWidth, unsigned int oldHeight, unsigned int newWidth, unsigned int newHeight) override;
 private:
 	tMode mode;
+};
+
+// - protocol.cpp -
+class WzProtocolTitleUI: public WzTitleUI
+{
+public:
+	WzProtocolTitleUI();
+	virtual ~WzProtocolTitleUI() override;
+	virtual void start() override;
+	virtual TITLECODE run() override;
+	virtual void screenSizeDidChange(unsigned int oldWidth, unsigned int oldHeight, unsigned int newWidth, unsigned int newHeight) override;
+private:
+	void openIPDialog();
+	void closeIPDialog();
+	// Not-null: the settings screen is up
+	W_SCREEN * psSettingsScreen = nullptr;
+	// If true, there's an IP address waiting to be used.
+	bool hasWaitingIP = false;
+	// Saves the content of the IP prompt.
+	std::string ipPrompt = "";
 };
 
 // - multiint.cpp -
 class WzMultiOptionTitleUI: public WzTitleUI
 {
 public:
-	WzMultiOptionTitleUI();
+	WzMultiOptionTitleUI(std::shared_ptr<WzTitleUI> parent);
 	virtual void start() override;
 	virtual TITLECODE run() override;
+	void frontendMultiMessages(bool running);
 private:
+	void processMultiopWidgets(UDWORD button);
+	std::shared_ptr<WzTitleUI> parent;
 	bool performedFirstStart = false;
 };
 
-// WzMultiLimitTitleUI: multilimit.cpp/h
+// - multilimit.cpp -
+class WzMultiLimitTitleUI: public WzTitleUI
+{
+public:
+	WzMultiLimitTitleUI(std::shared_ptr<WzMultiOptionTitleUI> parent);
+	virtual void start() override;
+	virtual TITLECODE run() override;
+private:
+	// The parent WzMultiOptionTitleUI to return to.
+	std::shared_ptr<WzMultiOptionTitleUI> parent;
+};
+
+// - msgbox.cpp -
+class WzMsgBoxTitleUI: public WzTitleUI
+{
+public:
+	WzMsgBoxTitleUI(WzString text, std::shared_ptr<WzTitleUI> next);
+	virtual void start() override;
+	virtual TITLECODE run() override;
+private:
+	WzString text;
+	// Where to go after the user has acknowledged.
+	std::shared_ptr<WzTitleUI> next;
+};
+
+#define WZ_MSGBOX_TUI_LEAVE 4597000
 
 #endif

--- a/src/wrappers.cpp
+++ b/src/wrappers.cpp
@@ -43,6 +43,7 @@
 #include "multistat.h"
 #include "warzoneconfig.h"
 #include "wrappers.h"
+#include "titleui/titleui.h"
 
 struct STAR
 {
@@ -55,8 +56,6 @@ static bool		firstcall = false;
 static bool		bPlayerHasLost = false;
 static bool		bPlayerHasWon = false;
 static UBYTE    scriptWinLoseVideo = PLAY_NONE;
-
-void	runCreditsScreen();
 
 static	UDWORD	lastChange = 0;
 int hostlaunch = 0;				// used to detect if we are hosting a game via command line option.
@@ -151,7 +150,7 @@ TITLECODE titleLoop()
 			bMultiPlayer = true;
 			ingame.bHostSetup = true;
 			game.type = SKIRMISH;
-			changeTitleMode(MULTIOPTION);
+			changeTitleUI(std::make_shared<WzMultiOptionTitleUI>());
 		}
 		else if (strlen(iptoconnect))
 		{
@@ -167,104 +166,14 @@ TITLECODE titleLoop()
 		wzSetCursor(CURSOR_DEFAULT);
 	}
 
-	if (titleMode != MULTIOPTION && titleMode != MULTILIMIT && titleMode != STARTGAME)
 	{
-		screen_disableMapPreview();
+		// Creates a pointer, so if... when, the UI changes during a run, this does not disappear
+		std::shared_ptr<WzTitleUI> current = wzTitleUICurrent;
+		RetCode = current->run();
 	}
 
-	switch (titleMode) // run relevant title screen code.
-	{
-	// MULTIPLAYER screens
-	case PROTOCOL:
-		runConnectionScreen(); // multiplayer connection screen.
-		break;
-	case MULTIOPTION:
-		runMultiOptions();
-		break;
-	case GAMEFIND:
-		runGameFind();
-		break;
-	case MULTI:
-		runMultiPlayerMenu();
-		break;
-	case MULTILIMIT:
-		runLimitScreen();
-		break;
-	case KEYMAP:
-		runKeyMapEditor();
-		break;
-
-	case TITLE:
-		runTitleMenu();
-		break;
-
-	case CAMPAIGNS:
-		runCampaignSelector();
-		break;
-
-	case SINGLE:
-		runSinglePlayerMenu();
-		break;
-
-	case TUTORIAL:
-		runTutorialMenu();
-		break;
-
-	case CREDITS:
-		runCreditsScreen();
-		break;
-
-	case OPTIONS:
-		runOptionsMenu();
-		break;
-
-	case GAME:
-		runGameOptionsMenu();
-		break;
-
-	case GRAPHICS_OPTIONS:
-		runGraphicsOptionsMenu();
-		break;
-
-	case AUDIO_AND_ZOOM_OPTIONS:
-		runAudioAndZoomOptionsMenu();
-		break;
-
-	case VIDEO_OPTIONS:
-		runVideoOptionsMenu();
-		break;
-
-	case MOUSE_OPTIONS:
-		runMouseOptionsMenu();
-		break;
-
-	case QUIT:
-		RetCode = TITLECODE_QUITGAME;
-		break;
-
-	case STARTGAME:
-	case LOADSAVEGAME:
-		if (titleMode == LOADSAVEGAME)
-		{
-			RetCode = TITLECODE_SAVEGAMELOAD;
-		}
-		else
-		{
-			RetCode = TITLECODE_STARTGAME;
-		}
-		return RetCode;			// don't flip!
-
-	case SHOWINTRO:
-		pie_SetFogStatus(false);
-		pie_ScreenFlip(CLEAR_BLACK);
-		changeTitleMode(TITLE);
-		RetCode = TITLECODE_SHOWINTRO;
-		break;
-
-	default:
-		debug(LOG_FATAL, "unknown title screen mode");
-		abort();
-	}
+	if ((RetCode == TITLECODE_SAVEGAMELOAD) || (RetCode == TITLECODE_STARTGAME))
+		return RetCode; // don't flip
 	NETflush();  // Send any pending network data.
 
 	audio_Update();

--- a/src/wrappers.cpp
+++ b/src/wrappers.cpp
@@ -150,12 +150,16 @@ TITLECODE titleLoop()
 			bMultiPlayer = true;
 			ingame.bHostSetup = true;
 			game.type = SKIRMISH;
-			changeTitleUI(std::make_shared<WzMultiOptionTitleUI>());
+			// Ensure the game has a place to return to
+			changeTitleMode(TITLE);
+			changeTitleUI(std::make_shared<WzMultiOptionTitleUI>(wzTitleUICurrent));
 		}
 		else if (strlen(iptoconnect))
 		{
 			NetPlay.bComms = true; // use network = true
 			NETinit(true);
+			// Ensure the joinGame has a place to return to
+			changeTitleMode(TITLE);
 			joinGame(iptoconnect, 0);
 		}
 		else
@@ -166,6 +170,7 @@ TITLECODE titleLoop()
 		wzSetCursor(CURSOR_DEFAULT);
 	}
 
+	if (wzTitleUICurrent)
 	{
 		// Creates a pointer, so if... when, the UI changes during a run, this does not disappear
 		std::shared_ptr<WzTitleUI> current = wzTitleUICurrent;


### PR DESCRIPTION
This attempts to remove 'titleMode'-related stuff in favour of an abstract-class, and tries to split apart the code for different UIs.
For those UIs which aren't moved, the two main switch statements have been put in one file (src/titleui/old.cpp).

The abstract classes allow encapsulation for various UI state.

The password prompt would have issues for connection-by-IP games (connecting to the wrong game if a password had to be entered) due to it running joinGame based on lobby game number.

The new system uses a lambda passed to the password box's constructor.
A message box state is added for future & more generic reporting of connection errors/etc. (perhaps replacing the lobby's usage of a console box for this purpose)

As a further effect, more code is moved out of multiint.cpp (a rather large file).

Note that not all UIs are fully split. WzOldTitleUI remains in use for tMode-based UIs which don't particularly need to be moved into a separate file.