### PR TITLE
configure.ac: Raise AM_GNU_GETTEXT_VERSION to 0.17

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -71,7 +71,7 @@ AC_CHECK_HEADERS(alloca.h sys/ucontext.h)
 
 # Check for gettext
 AM_GNU_GETTEXT([external])
-AM_GNU_GETTEXT_VERSION([0.15])
+AM_GNU_GETTEXT_VERSION([0.17])
 
 # Check for pkg-config
 PKG_PROG_PKG_CONFIG


### PR DESCRIPTION
the shipped copy of po/Makefile.in.in comes from gettext-0.17 and since
m4/po.m4 has been changed to use AC_PROG_MKDIR_P (Trac ticket #4701)
autopoint from gettext would produce a broken po/Makefile.in.in which has
no MKDIR_P definition. This again would result in "make install" throwing
the following error when invoking install-data-yes target in /po/ dir:

  make[1]: execvp: /usr/share: Permission denied

Raising AM_GNU_GETTEXT_VERSION fixes the described issue.

Signed-off-by: Lars Wendler <polynomial-c@gentoo.org>