### PR TITLE
Fix attacking orders against jammed objects.

### DIFF
--- a/src/action.cpp
+++ b/src/action.cpp
@@ -422,7 +422,7 @@ bool actionVisibleTarget(DROID *psDroid, BASE_OBJECT *psTarget, int weapon_slot)
 	{
 		return true;
 	}
-	return (orderState(psDroid, DORDER_FIRESUPPORT)	|| visibleObject(psDroid, psTarget, false))
+	return (orderState(psDroid, DORDER_FIRESUPPORT)	|| visibleObject(psDroid, psTarget, false) > UBYTE_MAX / 2)
 	       && lineOfFire(psDroid, psTarget, weapon_slot, true);
 }
 
@@ -885,7 +885,7 @@ void actionUpdateDroid(DROID *psDroid)
 				}
 			}
 			// If we have a target for the weapon: is it visible?
-			if (psDroid->psActionTarget[i] != nullptr && visibleObject(psDroid, psDroid->psActionTarget[i], false))
+			if (psDroid->psActionTarget[i] != nullptr && visibleObject(psDroid, psDroid->psActionTarget[i], false) > UBYTE_MAX / 2)
 			{
 				hasVisibleTarget = true; // droid have a visible target to shoot
 				targetVisibile[i] = true;// it is at least visible for this weapon

--- a/src/visibility.cpp
+++ b/src/visibility.cpp
@@ -597,18 +597,24 @@ int visibleObject(const BASE_OBJECT *psViewer, const BASE_OBJECT *psTarget, bool
 	int top = psTarget->pos.z + map_Height(psViewer->pos.x, psViewer->pos.y) - help.startHeight;
 	int targetGrad = top * GRAD_MUL / MAX(1, help.lastDist);
 
+	bool tileWatched = psTile->watchers[psViewer->player] > 0;
+	bool tileWatchedSensor = psTile->sensors[psViewer->player] > 0;
+
 	// Show objects hidden by ECM jamming with radar blips
-	if (psTile->watchers[psViewer->player] == 0 && psTile->sensors[psViewer->player] > 0 && jammed)
+	if (jammed)
 	{
-		return UBYTE_MAX / 2;
+		if (!tileWatched && tileWatchedSensor)
+		{
+			return UBYTE_MAX / 2;
+		}
 	}
-	// Show objects that are seen directly or with unjammed sensors
-	else if ((psTile->watchers[psViewer->player] > 0 && targetGrad >= help.currGrad) || (psTile->sensors[psViewer->player] > 0 && !jammed))
+	// Show objects that are seen directly
+	if ((tileWatched && targetGrad >= help.currGrad) || (!jammed && tileWatchedSensor))
 	{
 		return UBYTE_MAX;
 	}
 	// Show detected sensors as radar blips
-	else if (objRadarDetector(psViewer) && objActiveRadar(psTarget) && dist < range * 10)
+	if (objRadarDetector(psViewer) && objActiveRadar(psTarget) && dist < range * 10)
 	{
 		return UBYTE_MAX / 2;
 	}


### PR DESCRIPTION
Combat units would align their turret towards targets but would not fire at them unless within
"vision range" of the target.

The jammer structure is still available in the debug structures menu in case anyone wants to test this.