### PR TITLE
Quicksave feature

### DIFF
--- a/src/keybind.h
+++ b/src/keybind.h
@@ -272,4 +272,7 @@ void kf_AutoGame();
 
 void kf_PerformanceSample();
 
+void kf_QuickSave();
+void kf_QuickLoad();
+
 #endif // __INCLUDED_SRC_KEYBIND_H__

--- a/src/keymap.cpp
+++ b/src/keymap.cpp
@@ -237,6 +237,8 @@ static KeyMapSaveEntry const keyMapSaveTable[] =
 	{kf_SetDroidRangeOptimum, "SetDroidRangeOptimum"},
 	{kf_SetDroidRangeShort, "SetDroidRangeShort"},
 	{kf_SetDroidRangeLong, "SetDroidRangeLong"},
+	{kf_QuickSave, "QuickSave"},
+	{kf_QuickLoad, "QuickLoad"},
 };
 
 KeyMapSaveEntry const *keymapEntryByFunction(void (*function)())
@@ -298,8 +300,10 @@ void keyInitMappings(bool bForceDefaults)
 	keyAddMapping(KEYMAP_ALWAYS_PROCESS, KEY_IGNORE, KEY_F4,  KEYMAP_PRESSED, kf_ChooseDesign,                 N_("Design"));
 	keyAddMapping(KEYMAP_ALWAYS_PROCESS, KEY_IGNORE, KEY_F5,  KEYMAP_PRESSED, kf_ChooseIntelligence,           N_("Intelligence Display"));
 	keyAddMapping(KEYMAP_ALWAYS_PROCESS, KEY_IGNORE, KEY_F6,  KEYMAP_PRESSED, kf_ChooseCommand,                N_("Commanders"));
-	keyAddMapping(KEYMAP_ASSIGNABLE,     KEY_IGNORE, KEY_F7,  KEYMAP_PRESSED, kf_ToggleRadar,                  N_("Toggle Radar"));
-	keyAddMapping(KEYMAP_ASSIGNABLE,     KEY_IGNORE, KEY_F8,  KEYMAP_PRESSED, kf_ToggleConsole,                N_("Toggle Console Display"));
+	keyAddMapping(KEYMAP_ASSIGNABLE,     KEY_IGNORE, KEY_F7,  KEYMAP_PRESSED, kf_QuickSave,                    N_("QuickSave"));
+	keyAddMapping(KEYMAP_ASSIGNABLE,     KEY_LSHIFT, KEY_F7,  KEYMAP_PRESSED, kf_ToggleRadar,                  N_("Toggle Radar"));
+	keyAddMapping(KEYMAP_ASSIGNABLE,     KEY_IGNORE, KEY_F8,  KEYMAP_PRESSED, kf_QuickLoad,                    N_("QuickLoad"));
+	keyAddMapping(KEYMAP_ASSIGNABLE,     KEY_LSHIFT, KEY_F8,  KEYMAP_PRESSED, kf_ToggleConsole,                N_("Toggle Console Display"));
 	keyAddMapping(KEYMAP_ASSIGNABLE,     KEY_IGNORE, KEY_F9,  KEYMAP_PRESSED, kf_ToggleEnergyBars,             N_("Toggle Damage Bars On/Off"));
 	keyAddMapping(KEYMAP_ALWAYS,         KEY_IGNORE, KEY_F10, KEYMAP_PRESSED, kf_ScreenDump,                   N_("Take Screen Shot"));
 	keyAddMapping(KEYMAP_ASSIGNABLE,     KEY_IGNORE, KEY_F11, KEYMAP_PRESSED, kf_ToggleFormationSpeedLimiting, N_("Toggle Formation Speed Limiting"));


### PR DESCRIPTION
Modern games often have a way to save and load the game quickly
without prompting. Because the commonly used keys for quicksave and
quickload (F6 and F7) are already bound to other functions, let's use
their shifted versions.