### PR TITLE
Add GitHub sponsors button to feature donations page

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+custom: http://donations.wz2100.net/


### PR DESCRIPTION
Changes proposed in this request:
- Adds the GitHub sponsors button. Here's an example with playnite:
![image](https://user-images.githubusercontent.com/7173984/62919048-7eed2100-bd6f-11e9-8fe8-06c949dd5693.png)
https://github.com/JosefNemec/Playnite
Info from GitHub on this below:
```
.github/FUNDING.yml shows the community how to support this project. Please see our repository funding links [documentation ](https://help.github.com/en/articles/displaying-a-sponsor-button-in-your-repository) for more information on formatting and what is and isn't allowed in this file.

Please note that funding links are currently disabled on this repository. Visit repository settings to enable display of your funding links.
```
This button needs to be enabled from the repo settings, and after that this pull request can be merged.