### PR TITLE
Workaround: Issue loading OpenGL on old(er) Intel chipsets / drivers on Win10

### DIFF
--- a/win32/warzone2100.manifest
+++ b/win32/warzone2100.manifest
@@ -27,7 +27,8 @@
 			<!-- Windows 8.1 -->
 			<supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>
 			<!-- Windows 10 -->
-			<supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
+			<!-- NOTE: This is commented out to avoid an issue loading OpenGL drivers for old Intel chipsets on Windows 10. -->
+			<!-- <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/> -->
 		</application>
 	</compatibility>
 </assembly>

--- a/win32/warzone2100.manifest.in
+++ b/win32/warzone2100.manifest.in
@@ -27,7 +27,8 @@
 			<!-- Windows 8.1 -->
 			<supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>
 			<!-- Windows 10 -->
-			<supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
+			<!-- NOTE: This is commented out to avoid an issue loading OpenGL drivers for old Intel chipsets on Windows 10. -->
+			<!-- <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/> -->
 		</application>
 	</compatibility>
 </assembly>


### PR DESCRIPTION
The issue: Advertising Windows 10 compatibility in the application manifest can lead to a failure with old(er) Intel OpenGL drivers on Windows 10. (Attempting to create an OpenGL context falls back to the "GDI Generic" OpenGL Renderer, which is limited to OpenGL 1.1.0.)

See: https://github.com/pal1000/save-legacy-intel-graphics