### PR TITLE
Tweak initDroidMovement()

### DIFF
--- a/src/droid.cpp
+++ b/src/droid.cpp
@@ -1738,6 +1738,7 @@ DROID *buildDroid(DROID_TEMPLATE *pTemplate, UDWORD x, UDWORD y, UDWORD player, 
 void initDroidMovement(DROID *psDroid)
 {
 	psDroid->sMove.asPath.clear();
+	psDroid->sMove.pathIndex = 0;
 }
 
 // Set the asBits in a DROID structure given it's template.


### PR DESCRIPTION
Since `pathIndex` is the position in `asPath`, reset it to 0 when `asPath` is cleared.

Possible fix for: #292

Needs testing (both to verify that it fixes the `psDroid->sMove.pathIndex out of bounds` error, and also to verify that it doesn't break anything else that might have been relying on the prior - seemingly incorrect - behavior).