### PR TITLE
Lower auto-target threshold when attacking blocking walls.

### DIFF
--- a/src/action.cpp
+++ b/src/action.cpp
@@ -915,7 +915,7 @@ void actionUpdateDroid(DROID *psDroid)
 							WEAPON_EFFECT weapEffect = psStats->weaponEffect;
 
 							if (!aiCheckAlliances(psDroid->player, blockingWall->player)
-								&& asStructStrengthModifier[weapEffect][blockingWall->pStructureType->strength] >= 100)
+								&& asStructStrengthModifier[weapEffect][blockingWall->pStructureType->strength] >= MIN_STRUCTURE_BLOCK_STRENGTH)
 							{
 								psActionTarget = blockingWall;
 								setDroidActionTarget(psDroid, psActionTarget, i); // attack enemy wall
@@ -1032,7 +1032,7 @@ void actionUpdateDroid(DROID *psDroid)
 				if (proj_Direct(psWeapStats) && blockingWall)
 				{
 					if (!aiCheckAlliances(psDroid->player, blockingWall->player)
-						&& asStructStrengthModifier[weapEffect][blockingWall->pStructureType->strength] >= 100)
+						&& asStructStrengthModifier[weapEffect][blockingWall->pStructureType->strength] >= MIN_STRUCTURE_BLOCK_STRENGTH)
 					{
 						psActionTarget = (BASE_OBJECT *)blockingWall;
 						setDroidActionTarget(psDroid, psActionTarget, i);
@@ -1316,7 +1316,7 @@ void actionUpdateDroid(DROID *psDroid)
 								WEAPON_EFFECT weapEffect = psWeapStats->weaponEffect;
 
 								if (!aiCheckAlliances(psDroid->player, blockingWall->player)
-									&& asStructStrengthModifier[weapEffect][blockingWall->pStructureType->strength] >= 100)
+									&& asStructStrengthModifier[weapEffect][blockingWall->pStructureType->strength] >= MIN_STRUCTURE_BLOCK_STRENGTH)
 								{
 									//Shoot at wall if the weapon is good enough against them
 									combFire(&psDroid->asWeaps[i], psDroid, (BASE_OBJECT *)blockingWall, i);

--- a/src/action.h
+++ b/src/action.h
@@ -49,6 +49,9 @@ const char *getDroidActionName(DROID_ACTION action);
 /// The maximum distance a repair droid will automatically go in guard mode.
 #define REPAIR_MAXDIST  (5 * TILE_UNITS)
 
+// The minimum structure strength modifier needed to automatically target blocking walls.
+#define MIN_STRUCTURE_BLOCK_STRENGTH 50
+
 /**
  * Update the action state for a droid.
  *

--- a/src/ai.cpp
+++ b/src/ai.cpp
@@ -699,7 +699,7 @@ int aiBestNearestTarget(DROID *psDroid, BASE_OBJECT **ppsObj, int weapon_slot, i
 			&& !aiCheckAlliances(psDroid->player, targetStructure->player))
 		{
 			//are we any good against walls?
-			if (asStructStrengthModifier[weaponEffect][targetStructure->pStructureType->strength] >= 100) //can attack atleast with default strength
+			if (asStructStrengthModifier[weaponEffect][targetStructure->pStructureType->strength] >= MIN_STRUCTURE_BLOCK_STRENGTH)
 			{
 				bestTarget = (BASE_OBJECT *)targetStructure; //attack wall
 			}


### PR DESCRIPTION
Most weapon lines don't meet the magic default strength modifier, 100, to attack them.