### PR TITLE
Remove unused credits screen code

### DIFF
--- a/lib/ivis_opengl/pieblitfunc.cpp
+++ b/lib/ivis_opengl/pieblitfunc.cpp
@@ -685,9 +685,6 @@ void pie_LoadBackDrop(SCREENTYPE screenType)
 	case SCREEN_MISSIONEND:
 		screen_SetRandomBackdrop("texpages/bdrops/", "missionend");
 		break;
-	case SCREEN_CREDITS:
-		screen_SetRandomBackdrop("texpages/bdrops/", "credits");
-		break;
 	}
 }
 

--- a/lib/ivis_opengl/pieblitfunc.h
+++ b/lib/ivis_opengl/pieblitfunc.h
@@ -223,7 +223,6 @@ void pie_SetRadar(gfx_api::gfxFloat x, gfx_api::gfxFloat y, gfx_api::gfxFloat wi
 enum SCREENTYPE
 {
 	SCREEN_RANDOMBDROP,
-	SCREEN_CREDITS,
 	SCREEN_MISSIONEND,
 };
 

--- a/src/frontend.cpp
+++ b/src/frontend.cpp
@@ -2203,9 +2203,6 @@ void changeTitleMode(tMode mode)
 	case TITLE:
 		startTitleMenu();
 		break;
-	case CREDITS:
-		startCreditsScreen();
-		break;
 	case MULTI:
 		startMultiPlayerMenu();		// goto multiplayer menu
 		break;

--- a/src/frontend.h
+++ b/src/frontend.h
@@ -32,7 +32,7 @@ enum tMode
 	OPTIONS,		// 3 options menu
 	GAME,			// 4
 	TUTORIAL,		// 5  tutorial/fastplay
-	CREDITS,		// 6  credits
+	TITLE_UNUSED,	// 6
 	PROTOCOL,		// 7  MULTIPLAYER, select proto
 	MULTIOPTION,	// 8 MULTIPLAYER, select game options
 	FORCESELECT,	// 9 MULTIPLAYER, Force design screen

--- a/src/wrappers.cpp
+++ b/src/wrappers.cpp
@@ -56,9 +56,6 @@ static bool		bPlayerHasLost = false;
 static bool		bPlayerHasWon = false;
 static UBYTE    scriptWinLoseVideo = PLAY_NONE;
 
-void	runCreditsScreen();
-
-static	UDWORD	lastChange = 0;
 int hostlaunch = 0;				// used to detect if we are hosting a game via command line option.
 
 static uint32_t lastTick = 0;
@@ -210,10 +207,6 @@ TITLECODE titleLoop()
 		runTutorialMenu();
 		break;
 
-	case CREDITS:
-		runCreditsScreen();
-		break;
-
 	case OPTIONS:
 		runOptionsMenu();
 		break;
@@ -348,33 +341,6 @@ void initLoadingScreen(bool drawbdrop)
 	// Start with two cleared buffers as the hacky loading screen code re-uses old buffers to create its effect.
 	pie_ScreenFlip(CLEAR_BLACK);
 	pie_ScreenFlip(CLEAR_BLACK);
-}
-
-
-// fill buffers with the static screen
-void startCreditsScreen()
-{
-	lastChange = gameTime;
-
-	pie_LoadBackDrop(SCREEN_CREDITS);
-
-	pie_SetFogStatus(false);
-	pie_ScreenFlip(CLEAR_BLACK);//init loading
-}
-
-/* This function does nothing - since it's already been drawn */
-void runCreditsScreen()
-{
-	// Check for key presses now.
-	if (keyReleased(KEY_ESC)
-	    || keyReleased(KEY_SPACE)
-	    || mouseReleased(MOUSE_LMB)
-	    || gameTime - lastChange > 4000)
-	{
-		lastChange = gameTime;
-		changeTitleMode(QUIT);
-	}
-	return;
 }
 
 // shut down the loading screen

--- a/src/wrappers.h
+++ b/src/wrappers.h
@@ -44,8 +44,6 @@ void initLoadingScreen(bool drawbdrop);
 void closeLoadingScreen();
 void loadingScreenCallback();
 
-void startCreditsScreen();
-
 bool displayGameOver(bool success, bool showBackDrop);
 void setPlayerHasLost(bool val);
 bool testPlayerHasLost();


### PR DESCRIPTION
Removes the credits splash screen related code, which is totally unused and unnecessary.

Instead of outright deleting the "credits" backdrop, I wonder if it could be used as one of the random frontend backdrops. So, at the moment, I included a commit that does just that as it would be a shame to waste perfectly good artwork.