### PR TITLE
On victory, offer shortcut to quit.

### DIFF
--- a/src/mission.cpp
+++ b/src/mission.cpp
@@ -2311,22 +2311,23 @@ static bool _intAddMissionResult(bool result, bool bPlaySuccess, bool showBackDr
 	//if won
 	if (result || bMultiPlayer)
 	{
-		//continue
-		sButInit.x			= MISSION_2_X;
-		// Won the game, so display "Quit to main menu"
-		if (testPlayerHasWon() && !bMultiPlayer)
+		// Finished the mission, so display "Continue Game"
+		if (!testPlayerHasWon() || bMultiPlayer)
 		{
-			sButInit.id			= IDMISSIONRES_QUIT;
-			sButInit.y			= MISSION_2_Y - 8;
-			sButInit.pText		= _("Quit To Main Menu");
-			widgAddButton(psWScreen, &sButInit);
-		}
-		else
-		{
-			// Finished the mission, so display "Continue Game"
-			sButInit.y			= MISSION_2_Y;
+			sButInit.x			= MISSION_1_X;
+			sButInit.y			= MISSION_1_Y;
 			sButInit.id			= IDMISSIONRES_CONTINUE;
 			sButInit.pText		= _("Continue Game");//"Continue Game";
+			widgAddButton(psWScreen, &sButInit);
+		}
+
+		// Won the game, so display "Quit to main menu"
+		if (bMultiPlayer || (testPlayerHasWon() && !bMultiPlayer))
+		{
+			sButInit.x			= MISSION_2_X;
+			sButInit.y			= MISSION_2_Y;
+			sButInit.id			= IDMISSIONRES_QUIT;
+			sButInit.pText		= _("Quit To Main Menu");
 			widgAddButton(psWScreen, &sButInit);
 		}
 


### PR DESCRIPTION
Continuation of #424.

My iteration of the patch removes the continue option from the menu after winning the last Gamma mission, which is pointless anyway. So, in essence, continue gets swapped with quit. If new campaigns are added to happen after Gamma, libcampaign will need to tweak the gameOver function arguments. But that isn't likely for a long time.