### PR TITLE
Improve console message display.

### DIFF
--- a/src/console.cpp
+++ b/src/console.cpp
@@ -305,6 +305,10 @@ static PIELIGHT getConsoleTextColor(int player)
 		{
 			if (aiCheckAlliances(player, selectedPlayer))
 			{
+				if (selectedPlayer == player)
+				{
+					return WZCOL_TEXT_BRIGHT;
+				}
 				return WZCOL_CONS_TEXT_USER_ALLY;
 			}
 			else
@@ -312,7 +316,7 @@ static PIELIGHT getConsoleTextColor(int player)
 				return WZCOL_CONS_TEXT_USER_ENEMY;
 			}
 		}
-		// Friend-foe is off
+
 		return WZCOL_TEXT_BRIGHT;
 	}
 }
@@ -333,7 +337,7 @@ static void console_drawtext(WzText &display, PIELIGHT colour, int x, int y, CON
 	display.render(x, y, colour);
 }
 
-// Show global (mode=true) or team (mode=false) history messages
+// Show global (mode=false) or team (mode=true) history messages
 void displayOldMessages(bool mode)
 {
 	int startpos = 0;

--- a/src/multiplay.cpp
+++ b/src/multiplay.cpp
@@ -1137,6 +1137,17 @@ static void printchatmsg(const char *text, int from, bool team = false)
 	char msg[MAX_CONSOLE_STRING_LENGTH];
 
 	sstrcpy(msg, getPlayerName(from));
+	if (from == selectedPlayer)
+	{
+		if (team)
+		{
+			sstrcat(msg, _(" (Ally)"));
+		}
+		else
+		{
+			sstrcat(msg, _(" (Global)"));
+		}
+	}
 	sstrcat(msg, ": ");					// separator
 	sstrcat(msg, text);					// add message
 	addConsoleMessage(msg, DEFAULT_JUSTIFY, from, team);	// display


### PR DESCRIPTION
- Adds " (Ally)" for team chat, or, " (Global)" for everything else when displaying messages.
- Messages from self stay white, messages from allies turn yellow, and messages from enemies are red.

Fixes #290.