### PR TITLE
Fix division by zero in addAiChooser() if there is just one AI.

### DIFF
--- a/src/multiint.cpp
+++ b/src/multiint.cpp
@@ -2045,7 +2045,7 @@ static void addAiChooser(int player)
 
 	// button height * how many AI + possible buttons (openclosed)
 	int gap = MULTIOP_PLAYERSH - ((sButInit.height) * (capAIs + 1 + mpbutton));
-	int gapDiv = capAIs - 1;
+	int gapDiv = (capAIs > 1) ? capAIs - 1 : 1; //avoid zero division with only 1 AI
 	gap = std::min(gap, 5 * gapDiv);
 
 	// Open button


### PR DESCRIPTION
The game would crash if only one AI is available to choose from. This patch makes it possible to have just one AI.

Fixes #522.