### PR TITLE
More consistent layout for loading and challenge selection

### DIFF
--- a/src/challenge.cpp
+++ b/src/challenge.cpp
@@ -49,7 +49,7 @@
 #define CHALLENGE_X				D_W + 16
 #define CHALLENGE_Y				D_H + 5
 #define CHALLENGE_W				610
-#define CHALLENGE_H				220
+#define CHALLENGE_H				215
 
 #define CHALLENGE_HGAP			9
 #define CHALLENGE_VGAP			9
@@ -206,10 +206,11 @@ bool addChallenges()
 	// Add Banner Label
 	W_LABINIT sLabInit;
 	sLabInit.formID		= CHALLENGE_BANNER;
+	sLabInit.FontID		= font_large;
 	sLabInit.id		= CHALLENGE_LABEL;
 	sLabInit.style		= WLAB_ALIGNCENTRE;
 	sLabInit.x		= 0;
-	sLabInit.y		= 3;
+	sLabInit.y		= 0;
 	sLabInit.width		= CHALLENGE_W - (2 * CHALLENGE_HGAP);	//CHALLENGE_W;
 	sLabInit.height		= CHALLENGE_BANNER_DEPTH;		//This looks right -Q
 	sLabInit.pText		= WzString::fromUtf8("Challenge");

--- a/src/loadsave.cpp
+++ b/src/loadsave.cpp
@@ -62,7 +62,7 @@
 #define LOADSAVE_X				D_W + 16
 #define LOADSAVE_Y				D_H + 5
 #define LOADSAVE_W				610
-#define LOADSAVE_H				220
+#define LOADSAVE_H				215
 
 #define MAX_SAVE_NAME			60
 


### PR DESCRIPTION
Center vertically the blue area of Load Campaign/Skirmish Game menus
for more pleasant look in 640x480 resolution. Use the same large font
for Challenges banner label as for Load Game.