### PR TITLE
Fix T4 for some maps

### DIFF
--- a/src/multiint.cpp
+++ b/src/multiint.cpp
@@ -3130,25 +3130,6 @@ static void loadMapSettings2()
 		ini.endGroup();
 	}
 
-	if (!challengeActive)
-	{
-		switch (psLevel->type)
-		{
-		case MULTI_SKIRMISH2:
-			game.techLevel = 2;
-			break;
-		case MULTI_SKIRMISH3:
-			game.techLevel = 3;
-			break;
-		case MULTI_SKIRMISH4:
-			game.techLevel = 4;
-			break;
-		default:
-			game.techLevel = 1;
-			break;
-		}
-	}
-
 	// Fix duplicate or unset player positions.
 	PlayerMask havePosition = 0;
 	for (int i = 0; i < MAX_PLAYERS; ++i)


### PR DESCRIPTION
In case a map had JSON format ini file (for example Fishnets has this
but SK-Rush doesn't have), the old tech level in the map was
overriding user selected tech level. Remove old code.