### PR TITLE
Add support for changing map, game name, and hosting player's name after already hosting 

### DIFF
--- a/lib/netplay/netplay.cpp
+++ b/lib/netplay/netplay.cpp
@@ -3715,6 +3715,7 @@ const char *messageTypeToString(unsigned messageType_)
 	case NET_FILE_CANCELLED:            return "NET_FILE_CANCELLED";
 	case NET_FILE_PAYLOAD:              return "NET_FILE_PAYLOAD";
 	case NET_DEBUG_SYNC:                return "NET_DEBUG_SYNC";
+	case NET_VOTE:                      return "NET_VOTE";
 	case NET_MAX_TYPE:                  return "NET_MAX_TYPE";
 
 	// Game-state-related messages, must be processed by all clients at the same game time.

--- a/lib/netplay/netplay.cpp
+++ b/lib/netplay/netplay.cpp
@@ -222,7 +222,7 @@ void NETsetLobbyOptField(const char *Value, const NET_LOBBY_OPT_FIELD Field)
 			sstrcpy(gamestruct.name, Value);
 			break;
 		case NET_LOBBY_OPT_FIELD::MAPNAME:
-			sstrcpy(gamestruct.mapname, Value);
+			sstrcpy(gamestruct.mapname, formatGameName(Value).toUtf8().c_str());
 			break;
 		case NET_LOBBY_OPT_FIELD::HOSTNAME:
 			sstrcpy(gamestruct.hostname, Value);

--- a/lib/netplay/netplay.cpp
+++ b/lib/netplay/netplay.cpp
@@ -71,10 +71,6 @@
 char masterserver_name[255] = {'\0'};
 static unsigned int masterserver_port = 0, gameserver_port = 0;
 
-#define WZ_SERVER_DISCONNECT 0
-#define WZ_SERVER_CONNECT    1
-#define WZ_SERVER_UPDATE     3
-
 #define NET_TIMEOUT_DELAY	2500		// we wait this amount of time for socket activity
 #define NET_READ_TIMEOUT	0
 /*
@@ -95,7 +91,6 @@ static unsigned int masterserver_port = 0, gameserver_port = 0;
 // Function prototypes
 static void NETplayerLeaving(UDWORD player);		// Cleanup sockets on player leaving (nicely)
 static void NETplayerDropped(UDWORD player);		// Broadcast NET_PLAYER_DROPPED & cleanup
-static void NETregisterServer(int state);
 static void NETallowJoining();
 static void recvDebugSync(NETQUEUE queue);
 static bool onBanList(const char *ip);
@@ -217,6 +212,25 @@ void NETGameLocked(bool flag)
 	}
 	NETlogEntry("Password is", SYNC_FLAG, NetPlay.GamePassworded);
 	debug(LOG_NET, "Passworded game is %s", NetPlay.GamePassworded ? "TRUE" : "FALSE");
+}
+
+void NETsetLobbyOptField(const char *Value, const NET_LOBBY_OPT_FIELD Field)
+{
+	switch (Field)
+	{
+		case NET_LOBBY_OPT_FIELD::GNAME:
+			sstrcpy(gamestruct.name, Value);
+			break;
+		case NET_LOBBY_OPT_FIELD::MAPNAME:
+			sstrcpy(gamestruct.mapname, Value);
+			break;
+		case NET_LOBBY_OPT_FIELD::HOSTNAME:
+			sstrcpy(gamestruct.hostname, Value);
+			break;
+		default:
+			debug(LOG_WARNING, "Invalid field specified for NETsetGameOptField()");
+			break;
+	}
 }
 
 //	Sets the game password
@@ -2136,7 +2150,7 @@ error:
 	return SOCKET_ERROR;
 }
 
-static void NETregisterServer(int state)
+void NETregisterServer(int state)
 {
 	static Socket *rs_socket = nullptr;
 	static int registered = 0;

--- a/lib/netplay/netplay.cpp
+++ b/lib/netplay/netplay.cpp
@@ -371,6 +371,19 @@ uint8_t NET_numHumanPlayers(void)
 	return RetVal;
 }
 
+std::vector<uint8_t> NET_getHumanPlayers(void)
+{
+	std::vector<uint8_t> RetVal;
+	RetVal.reserve(MAX_PLAYERS);
+
+	for (uint8_t Inc = 0; Inc < MAX_PLAYERS; ++Inc)
+	{
+		if (NetPlay.players[Inc].allocated) RetVal.push_back(Inc);
+	}
+
+	return RetVal;
+}
+
 void NET_InitPlayers(bool initTeams)
 {
 	unsigned int i;

--- a/lib/netplay/netplay.h
+++ b/lib/netplay/netplay.h
@@ -29,7 +29,7 @@
 #include "lib/framework/crc.h"
 #include "nettypes.h"
 #include <physfs.h>
-
+#include <vector>
 // Lobby Connection errors
 
 enum LOBBY_ERROR_TYPES
@@ -341,6 +341,7 @@ void NET_InitPlayers(bool initTeams = false);
 
 uint8_t NET_numHumanPlayers(void);
 void NETsetLobbyOptField(const char *Value, const NET_LOBBY_OPT_FIELD Field);
+std::vector<uint8_t> NET_getHumanPlayers(void);
 
 void NETGameLocked(bool flag);
 void NETresetGamePassword();

--- a/lib/netplay/netplay.h
+++ b/lib/netplay/netplay.h
@@ -120,6 +120,10 @@ enum MESSAGE_TYPES
 
 #define SYNC_FLAG 0x10000000	//special flag used for logging. (Not sure what this is. Was added in trunk, NUM_GAME_PACKETS not in newnet.)
 
+#define WZ_SERVER_DISCONNECT 0
+#define WZ_SERVER_CONNECT    1
+#define WZ_SERVER_UPDATE     3
+
 // Constants
 // @NOTE / FIXME: We need a way to detect what should happen if the msg buffer exceeds this.
 #define MaxMsgSize		16384		// max size of a message in bytes.
@@ -208,6 +212,15 @@ struct WZFile
 enum
 {
 	DIFFICULTY_EASY, DIFFICULTY_MEDIUM, DIFFICULTY_HARD, DIFFICULTY_INSANE
+};
+
+enum class NET_LOBBY_OPT_FIELD
+{
+	INVALID,
+	GNAME,
+	MAPNAME,
+	HOSTNAME,
+	MAX
 };
 
 // ////////////////////////////////////////////////////////////////////////
@@ -327,10 +340,11 @@ void NET_InitPlayer(int i, bool initPosition, bool initTeams = false);
 void NET_InitPlayers(bool initTeams = false);
 
 uint8_t NET_numHumanPlayers(void);
+void NETsetLobbyOptField(const char *Value, const NET_LOBBY_OPT_FIELD Field);
 
 void NETGameLocked(bool flag);
 void NETresetGamePassword();
-
+void NETregisterServer(int state);
 void NETsetPlayerConnectionStatus(CONNECTION_STATUS status, unsigned player);    ///< Cumulative, except that CONNECTIONSTATUS_NORMAL resets.
 bool NETcheckPlayerConnectionStatus(CONNECTION_STATUS status, unsigned player);  ///< True iff connection status icon hasn't expired for this player. CONNECTIONSTATUS_NORMAL means any status, NET_ALL_PLAYERS means all players.
 

--- a/lib/netplay/netplay.h
+++ b/lib/netplay/netplay.h
@@ -89,6 +89,7 @@ enum MESSAGE_TYPES
 	NET_FILE_CANCELLED,             ///< Player cancelled a file request
 	NET_FILE_PAYLOAD,               ///< sending file to the player that needs it
 	NET_DEBUG_SYNC,                 ///< Synch error messages, so people don't have to use pastebin.
+	NET_VOTE,                       ///< vote request
 	NET_MAX_TYPE,                   ///< Maximum+1 valid NET_ type, *MUST* be last.
 
 	// Game-state-related messages, must be processed by all clients at the same game time.

--- a/src/frontend.cpp
+++ b/src/frontend.cpp
@@ -632,12 +632,14 @@ bool runMultiPlayerMenu()
 		ingame.bHostSetup = true;
 		bMultiPlayer = true;
 		bMultiMessages = true;
+		resetVoteData();
 		NETinit(true);
 		NETdiscoverUPnPDevices();
 		game.type = SKIRMISH;		// needed?
 		changeTitleUI(std::make_shared<WzMultiOptionTitleUI>(wzTitleUICurrent));
 		break;
 	case FRONTEND_JOIN:
+		resetVoteData();
 		NETinit(true);
 		ingame.bHostSetup = false;
 		if (getLobbyError() != ERROR_INVALID)

--- a/src/multiint.cpp
+++ b/src/multiint.cpp
@@ -1244,7 +1244,7 @@ static void addGameOptions()
 	// MCOL for N >= 1 is basically useless because that's not the actual rule followed by addMultiEditBox.
 	// And that's what this panel is meant to align to.
 	addBlueForm(MULTIOP_OPTIONS, MULTIOP_MAP, formatGameName(game.map), MCOL0, MROW3, MULTIOP_EDITBOXW + MULTIOP_EDITBOXH, MULTIOP_EDITBOXH);
-	addMultiBut(psWScreen, MULTIOP_MAP, MULTIOP_MAP_ICON, MULTIOP_EDITBOXW + 2, 2, MULTIOP_EDITBOXH, MULTIOP_EDITBOXH, _("Select Map"), IMAGE_EDIT_MAP, IMAGE_EDIT_MAP_HI, true);
+	addMultiBut(psWScreen, MULTIOP_MAP, MULTIOP_MAP_ICON, MULTIOP_EDITBOXW + 2, 2, MULTIOP_EDITBOXH, MULTIOP_EDITBOXH, _("Select Map\nCan be blocked by players' votes"), IMAGE_EDIT_MAP, IMAGE_EDIT_MAP_HI, true);
 	addMultiBut(psWScreen, MULTIOP_MAP, MULTIOP_MAP_MOD, MULTIOP_EDITBOXW - 14, 1, 12, 12, _("Map-Mod!"), IMAGE_LAMP_RED, IMAGE_LAMP_AMBER, false);
 	if (!game.isMapMod)
 	{
@@ -1332,7 +1332,7 @@ static void addGameOptions()
 		MultibuttonWidget *randomButton = new MultibuttonWidget(optionsList);
 		randomButton->id = MULTIOP_RANDOM;
 		randomButton->setLabel(_("Random Game Options"));
-		randomButton->addButton(0, Image(FrontImages, IMAGE_RELOAD), Image(FrontImages, IMAGE_RELOAD), _("Random Game Options"));
+		randomButton->addButton(0, Image(FrontImages, IMAGE_RELOAD), Image(FrontImages, IMAGE_RELOAD), _("Random Game Options\nCan be blocked by players' votes"));
 		optionsList->addWidgetToLayout(randomButton);
 	}
 
@@ -1349,8 +1349,8 @@ static void addGameOptions()
 		MultichoiceWidget *voteChoice = new MultichoiceWidget(optionsList, currentVote);
 		voteChoice->id = MULTIOP_VOTE;
 		voteChoice->setLabel(_("Vote"));
-		voteChoice->addButton(MULTIOP_VOTE_NO, Image(FrontImages, IMAGE_CHECK_OFF), Image(FrontImages, IMAGE_CHECK_OFF_HI), _("No"));
-		voteChoice->addButton(MULTIOP_VOTE_YES, Image(FrontImages, IMAGE_CHECK_ON), Image(FrontImages, IMAGE_CHECK_ON_HI), _("Yes"));
+		voteChoice->addButton(MULTIOP_VOTE_NO, Image(FrontImages, IMAGE_CHECK_OFF), Image(FrontImages, IMAGE_CHECK_OFF_HI), _("No. Do not allow host to randomize or change map"));
+		voteChoice->addButton(MULTIOP_VOTE_YES, Image(FrontImages, IMAGE_CHECK_ON), Image(FrontImages, IMAGE_CHECK_ON_HI), _("Yes. Allow host to randomize or change map"));
 		voteChoice->enable(true);
 		optionsList->addWidgetToLayout(voteChoice);
 

--- a/src/multiint.cpp
+++ b/src/multiint.cpp
@@ -1109,7 +1109,7 @@ static void updateLimitIcons()
 	}
 }
 
-static WzString formatGameName(WzString name)
+WzString formatGameName(WzString name)
 {
 	WzString withoutTechlevel = mapNameWithoutTechlevel(name.toUtf8().c_str());
 	return withoutTechlevel + " (T" + WzString::number(game.techLevel) + " " + WzString::number(game.maxPlayers) + "P)";

--- a/src/multiint.cpp
+++ b/src/multiint.cpp
@@ -3499,6 +3499,11 @@ TITLECODE WzMultiOptionTitleUI::run()
 				break;
 			case MULTIOP_MAP:
 				{
+					if (NetPlay.bComms && bHosted && !isHoverPreview && NET_numHumanPlayers() > mapData->players)
+					{
+						addConsoleMessage(_("Cannot change to a map with too few slots for all players."), DEFAULT_JUSTIFY, SYSTEM_MESSAGE);
+						break;
+					}
 					sstrcpy(oldGameMap, game.map);
 					oldGameHash = game.hash;
 					oldMaxPlayers = game.maxPlayers;
@@ -3520,6 +3525,20 @@ TITLECODE WzMultiOptionTitleUI::run()
 					else
 					{
 						loadMapSettings1();
+					}
+
+					//Reset player slots if it's a smaller map.
+					if (NetPlay.isHost && NetPlay.bComms && bHosted && !isHoverPreview && oldMaxPlayers > game.maxPlayers)
+					{
+						const std::vector<uint8_t> &Humans = NET_getHumanPlayers();
+
+						//This is pretty ugly tbh, but seems like the easiest way to achieve the goal to my tired mind.
+						size_t PlayerInc = 0;
+						for (uint8_t SlotInc = 0; SlotInc < game.maxPlayers && PlayerInc < Humans.size(); ++SlotInc)
+						{
+							changePosition(Humans[PlayerInc], SlotInc);
+							++PlayerInc;
+						}
 					}
 
 					WzString name = formatGameName(game.map);

--- a/src/multiint.h
+++ b/src/multiint.h
@@ -125,6 +125,7 @@ void loadMapPreview(bool hideInterface);
 
 bool changeReadyStatus(UBYTE player, bool bReady);
 WzString formatGameName(WzString name);
+void resetVoteData();
 
 // ////////////////////////////////////////////////////////////////
 // CONNECTION SCREEN
@@ -309,6 +310,10 @@ WzString formatGameName(WzString name);
 
 #define MULTIOP_DIFFICULTY_CHOOSE_START	(MULTIOP_DIFFICULTY_INIT_END + 1)
 #define MULTIOP_DIFFICULTY_CHOOSE_END	(MULTIOP_DIFFICULTY_CHOOSE_START + MAX_PLAYERS)
+
+#define MULTIOP_VOTE			148940
+#define MULTIOP_VOTE_YES			1
+#define MULTIOP_VOTE_NO			0
 
 
 // ///////////////////////////////

--- a/src/multiint.h
+++ b/src/multiint.h
@@ -124,6 +124,7 @@ void addPlayerBox(bool);			// players (mid) box
 void loadMapPreview(bool hideInterface);
 
 bool changeReadyStatus(UBYTE player, bool bReady);
+WzString formatGameName(WzString name);
 
 // ////////////////////////////////////////////////////////////////
 // CONNECTION SCREEN

--- a/src/titleui/protocol.cpp
+++ b/src/titleui/protocol.cpp
@@ -111,6 +111,7 @@ TITLECODE WzProtocolTitleUI::run()
 		bMultiMessages = false;
 		break;
 	case CON_TYPESID_START+0: // Lobby button
+		resetVoteData();
 		if (getLobbyError() != ERROR_INVALID)
 		{
 			setLobbyError(ERROR_NOERROR);
@@ -118,9 +119,11 @@ TITLECODE WzProtocolTitleUI::run()
 		changeTitleUI(std::make_shared<WzGameFindTitleUI>());
 		break;
 	case CON_TYPESID_START+1: // IP button
+		resetVoteData();
 		openIPDialog();
 		break;
 	case CON_OK:
+		resetVoteData();
 		sstrcpy(serverName, widgGetString(curScreen, CON_IP));
 		if (serverName[0] == '\0')
 		{


### PR DESCRIPTION
Reopen #219

road map:

-  Adding to the settings the parameter "action when changing the map to an unknown" and the options "leave the room" / "load"
 -   The cancellation is “ready” when changing ANY settings that change the game:
    (map, energy, base, scavengers, teams, etc ...)
