### PR TITLE
Fix unexplored minimap tile color in campaign.

### DIFF
--- a/src/radar.cpp
+++ b/src/radar.cpp
@@ -309,7 +309,7 @@ static PIELIGHT appliedRadarColour(RADAR_DRAW_MODE radarDrawMode, MAPTILE *WTile
 	// draw radar on/off feature
 	if (!getRevealStatus() && !TEST_TILE_VISIBLE(selectedPlayer, WTile))
 	{
-		return WZCOL_RADAR_BACKGROUND;
+		return WZCOL_TRANSPARENT_BOX;
 	}
 
 	switch (radarDrawMode)


### PR DESCRIPTION
Uses the regular GUI blue box color to match with releases before 3.1.

Fixes #528.