### PR TITLE
Increase map zoom minimum distance configuration option.

### DIFF
--- a/src/display.h
+++ b/src/display.h
@@ -194,6 +194,7 @@ void	setDesiredPitch(SDWORD pitch);
 
 #define MAXDISTANCE	(5000)
 #define MINDISTANCE	(0)
+#define MINDISTANCE_CONFIG (1600)
 #define STARTDISTANCE	(2500)
 #define OLD_START_HEIGHT (1500) // only used in savegames <= 10
 

--- a/src/frontend.cpp
+++ b/src/frontend.cpp
@@ -991,7 +991,7 @@ bool runAudioAndZoomOptionsMenu()
 	case FRONTEND_MAP_ZOOM:
 	case FRONTEND_MAP_ZOOM_R:
 		{
-		    war_SetMapZoom(seqCycle(war_GetMapZoom(), MINDISTANCE, war_GetMapZoomRate(), MAXDISTANCE));
+		    war_SetMapZoom(seqCycle(war_GetMapZoom(), MINDISTANCE_CONFIG, war_GetMapZoomRate(), MAXDISTANCE));
 		    widgSetString(psWScreen, FRONTEND_MAP_ZOOM_R, audioAndZoomOptionsMapZoomString().c_str());
 		    break;
 		}

--- a/src/warzoneconfig.cpp
+++ b/src/warzoneconfig.cpp
@@ -247,9 +247,9 @@ int war_GetMapZoom()
 
 void war_SetMapZoom(int mapZoom)
 {
-        if (mapZoom % MAP_ZOOM_RATE_MIN == 0 && ! (mapZoom < MINDISTANCE || mapZoom > MAXDISTANCE))
+	if (mapZoom % MAP_ZOOM_RATE_MIN == 0 && ! (mapZoom < MINDISTANCE_CONFIG || mapZoom > MAXDISTANCE))
 	{
-	    warGlobs.mapZoom = mapZoom;
+		warGlobs.mapZoom = mapZoom;
 	}
 }
 
@@ -260,9 +260,9 @@ int war_GetMapZoomRate()
 
 void war_SetMapZoomRate(int mapZoomRate)
 {
-        if (mapZoomRate % MAP_ZOOM_RATE_STEP == 0 && ! (mapZoomRate < MAP_ZOOM_RATE_MIN || mapZoomRate > MAP_ZOOM_RATE_MAX))
+	if (mapZoomRate % MAP_ZOOM_RATE_STEP == 0 && ! (mapZoomRate < MAP_ZOOM_RATE_MIN || mapZoomRate > MAP_ZOOM_RATE_MAX))
 	{
-	    warGlobs.mapZoomRate = mapZoomRate;
+		warGlobs.mapZoomRate = mapZoomRate;
 	}
 }
 
@@ -273,9 +273,9 @@ int war_GetRadarZoom()
 
 void war_SetRadarZoom(int radarZoom)
 {
-        if (radarZoom % RADARZOOM_STEP == 0 && ! (radarZoom < MIN_RADARZOOM || radarZoom > MAX_RADARZOOM))
+	if (radarZoom % RADARZOOM_STEP == 0 && ! (radarZoom < MIN_RADARZOOM || radarZoom > MAX_RADARZOOM))
 	{
-	    warGlobs.radarZoom = radarZoom;
+		warGlobs.radarZoom = radarZoom;
 	}
 }
 
@@ -286,9 +286,9 @@ int war_GetCameraSpeed()
 
 void war_SetCameraSpeed(int cameraSpeed)
 {
-        if (cameraSpeed % CAMERASPEED_STEP == 0 && ! (cameraSpeed < CAMERASPEED_MIN || cameraSpeed > CAMERASPEED_MAX))
+	if (cameraSpeed % CAMERASPEED_STEP == 0 && ! (cameraSpeed < CAMERASPEED_MIN || cameraSpeed > CAMERASPEED_MAX))
 	{
-	    warGlobs.cameraSpeed = cameraSpeed;
+		warGlobs.cameraSpeed = cameraSpeed;
 	}
 }
 


### PR DESCRIPTION
Up to 1600. Small map zoom settings could make the camera get way too close to terrain or other
surrounding objects near the start position.

Closes #311.

Edit: To be more clear, this is for the frontend starting zoom option, not the in-game camera zoom limits.