### PR TITLE
Play derrick pump sound.

### DIFF
--- a/data/base/audio/audio.cfg
+++ b/data/base/audio/audio.cfg
@@ -402,10 +402,10 @@ audio_module
 
 /*Building FX*/
 
-	audio	"oilpump.ogg"	loop	 3 1800
+	audio	"oilpump.ogg"	oneshot	5 1800
 	audio	"powerhum.ogg"	loop     10 1800
 	audio	"powerspk.ogg"	oneshot  10 1800
-	audio	"steam.ogg"		oneshot  20 1800
+	audio	"steam.ogg"	oneshot  20 1800
 	audio	"ecmtower.ogg"	oneshot  20 1800
 	audio	"freroar.ogg"	oneshot 100 1800
 

--- a/src/structure.cpp
+++ b/src/structure.cpp
@@ -3575,6 +3575,20 @@ void structureUpdate(STRUCTURE *psBuilding, bool mission)
 			psBuilding->timeAnimationStarted = gameTime;  // so start animation
 			psBuilding->animationEvent = ANIM_EVENT_ACTIVE;
 		}
+
+		if (psBuilding->player == selectedPlayer)
+		{
+			if (psBuilding->visible[selectedPlayer]
+				&& psBuilding->pFunctionality->resourceExtractor.psPowerGen
+				&& psBuilding->animationEvent == ANIM_EVENT_ACTIVE)
+			{
+				audio_PlayObjStaticTrack(psBuilding, ID_SOUND_OIL_PUMP_2);
+			}
+			else
+			{
+				audio_StopObjTrack(psBuilding, ID_SOUND_OIL_PUMP_2);
+			}
+		}
 	}
 
 	// Remove invalid targets. This must be done each frame.


### PR DESCRIPTION
The pump sound depends on the current animation of the derrick. This was presumably forgotten
about and wasn't reimplemented after commit af9c9137d231d4b2c1d4e5e1ffde0e86dc443b3c (see display3d.cpp diffs).

Turns up the sound volume a tiny bit, and, makes it a "oneshot" sound.

Closes #542.