### PR TITLE
Don't trigger eventGameLoaded if not loading a save. 

### DIFF
--- a/data/mp/multiplay/skirmish/rules.js
+++ b/data/mp/multiplay/skirmish/rules.js
@@ -399,6 +399,10 @@ function eventGameInit()
 	}
 
 	hackNetOn();
+
+	//Structures might have been removed so we need to update the reticule button states again
+	setMainReticule();
+
 	setTimer("checkEndConditions", 3000);
 	if (tilesetType === "URBAN" || tilesetType === "ROCKIES")
 	{

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1265,7 +1265,12 @@ bool stageThreeInitialise()
 	}
 
 	countUpdate();
-	if (getLevelLoadType() != GTYPE_SAVE_MIDMISSION)
+
+	if (getLevelLoadType() == GTYPE_SAVE_MIDMISSION || getLevelLoadType() == GTYPE_SAVE_START)
+	{
+		triggerEvent(TRIGGER_GAME_LOADED);
+	}
+	else
 	{
 		if (getDebugMappingStatus())
 		{

--- a/src/levels.cpp
+++ b/src/levels.cpp
@@ -1035,8 +1035,6 @@ bool levLoadData(char const *name, Sha256 const *hash, char *pSaveName, GAME_TYP
 	ssprintf(buf, "Current Level/map is %s", psCurrLevel->pName);
 	addDumpInfo(buf);
 
-	triggerEvent(TRIGGER_GAME_LOADED);
-
 	if (autogame_enabled())
 	{
 		gameTimeSetMod(Rational(500));


### PR DESCRIPTION
Instead, trigger it in stageThreeInitialise() if loading from a save.

Fixes #548.