### PR TITLE
Feature: favorite build items

### DIFF
--- a/src/configuration.cpp
+++ b/src/configuration.cpp
@@ -219,6 +219,7 @@ bool loadConfig()
 	{
 		pie_SetVideoBufferDepth(ini.value("bpp").toInt());
 	}
+	setFavoriteStructs(ini.value("favoriteStructs").toString().toUtf8().constData());
 	return true;
 }
 
@@ -303,6 +304,7 @@ bool saveConfig()
 		ini.setValue("playerName", (char *)sPlayer);		// player name
 	}
 	ini.setValue("colourMP", war_getMPcolour());
+	ini.setValue("favoriteStructs", getFavoriteStructs().toUtf8().c_str());
 	ini.sync();
 	return true;
 }

--- a/src/hci.h
+++ b/src/hci.h
@@ -111,6 +111,7 @@ enum  				  // Reticule button indecies.
 #define IDSTAT_LOOP_LABEL		4404
 #define IDSTAT_DP_BUTTON		4405
 #define IDSTAT_OBSOLETE_BUTTON          4406
+#define IDSTAT_FAVORITE_BUTTON          4407
 #define IDSTAT_RESICONSTART		4500
 #define IDSTAT_RESICONEND		4599
 #define IDSTAT_PRODSTART		4600

--- a/src/structure.h
+++ b/src/structure.h
@@ -118,7 +118,7 @@ bool destroyStruct(STRUCTURE *psDel, unsigned impactTime);
 bool removeStruct(STRUCTURE *psDel, bool bDestroy);
 
 //fills the list with Structures that can be built
-UDWORD fillStructureList(STRUCTURE_STATS **ppList, UDWORD selectedPlayer, UDWORD limit);
+UDWORD fillStructureList(STRUCTURE_STATS **ppList, UDWORD selectedPlayer, UDWORD limit, bool showFavorites);
 
 /// Checks if the two structures would be too close to build together.
 bool isBlueprintTooClose(STRUCTURE_STATS const *stats1, Vector2i pos1, uint16_t dir1, STRUCTURE_STATS const *stats2, Vector2i pos2, uint16_t dir2);
@@ -508,5 +508,8 @@ static inline int getBuildingRearmPoints(STRUCTURE *psStruct)
 {
 	return psStruct->pStructureType->upgrade[psStruct->player].rearm;
 }
+
+WzString getFavoriteStructs();
+void setFavoriteStructs(WzString list);
 
 #endif // __INCLUDED_SRC_STRUCTURE_H__

--- a/src/structuredef.h
+++ b/src/structuredef.h
@@ -142,6 +142,7 @@ struct STRUCTURE_STATS : public BASE_STATS
 		unsigned resistance;	// resist enemy takeover; 0 = immune
 		unsigned limit;		// current max limit for this type, LOTS_OF = no limit
 	} upgrade[MAX_PLAYERS], base;
+	bool isFavorite;		///< on Favorites list
 
 	inline Vector2i size(uint16_t direction) const
 	{


### PR DESCRIPTION
Later in the game, build menu contains dozens of various structures,
most of which are probably never used by the player. Going through the
menu can be slow and in the heat of the game it's easy to miss the
structure you want to build at first.

Add Showing Favorite Tech button to structure build menu. Items can be
added or removed with RMB. Adding works when showing all items and
removing when showing only favorites.

Closes #549.