### PR TITLE
Rename one of the HMG bunkers.

### DIFF
--- a/data/base/script/campaign/cam1-4a.js
+++ b/data/base/script/campaign/cam1-4a.js
@@ -95,8 +95,8 @@ function buildDefenses()
 {
 	// First wave of trucks
 	camQueueBuilding(NEW_PARADIGM, "GuardTower6", "BuildTower0");
-	camQueueBuilding(NEW_PARADIGM, "PillBox3",    "BuildTower3");
-	camQueueBuilding(NEW_PARADIGM, "PillBox3",    "BuildTower6");
+	camQueueBuilding(NEW_PARADIGM, "PillBox1",    "BuildTower3");
+	camQueueBuilding(NEW_PARADIGM, "PillBox1",    "BuildTower6");
 
 	// Second wave of trucks
 	camQueueBuilding(NEW_PARADIGM, "GuardTower3", "BuildTower1");

--- a/data/base/stats/structure.json
+++ b/data/base/stats/structure.json
@@ -2053,7 +2053,7 @@
         "height": 1,
         "hitpoints": 500,
         "id": "PillBox3",
-        "name": "Heavy Machinegun Bunker",
+        "name": "HMG Bunker",
         "resistance": 150,
         "sensorID": "DefaultSensor1Mk1",
         "strength": "BUNKER",

--- a/data/mp/stats/structure.json
+++ b/data/mp/stats/structure.json
@@ -1654,7 +1654,7 @@
         "height": 1,
         "hitpoints": 700,
         "id": "PillBox3",
-        "name": "Heavy Machinegun Bunker",
+        "name": "HMG Bunker",
         "resistance": 150,
         "sensorID": "DefaultSensor1Mk1",
         "strength": "BUNKER",


### PR DESCRIPTION
Maps, AI, scripts, and stats confused the MG bunker for the HMG bunker.

Closes #555.

I have only done light tests. Should work. The result of this issue was the "HMG" bunker wasn't affected by upgrades.