### PR TITLE
Reset ready buttons when host changes game settings

### DIFF
--- a/src/multiint.cpp
+++ b/src/multiint.cpp
@@ -211,7 +211,7 @@ static void		closeDifficultyChooser();
 static bool		SendColourRequest(UBYTE player, UBYTE col);
 static bool		SendPositionRequest(UBYTE player, UBYTE chosenPlayer);
 static bool		safeToUseColour(UDWORD player, UDWORD col);
-static bool		changeReadyStatus(UBYTE player, bool bReady);
+bool changeReadyStatus(UBYTE player, bool bReady);
 static void stopJoining(std::shared_ptr<WzTitleUI> parent);
 static int difficultyIcon(int difficulty);
 // ////////////////////////////////////////////////////////////////////////////
@@ -1634,7 +1634,7 @@ bool recvReadyRequest(NETQUEUE queue)
 	return changeReadyStatus((UBYTE)player, bReady);
 }
 
-static bool changeReadyStatus(UBYTE player, bool bReady)
+bool changeReadyStatus(UBYTE player, bool bReady)
 {
 	NetPlay.players[player].ready = bReady;
 	NETBroadcastPlayerInfo(player);

--- a/src/multiint.cpp
+++ b/src/multiint.cpp
@@ -2797,6 +2797,7 @@ void WzMultiOptionTitleUI::processMultiopWidgets(UDWORD id)
 		NETBroadcastPlayerInfo(aiChooserUp);
 		closeAiChooser();
 		addPlayerBox(!ingame.bHostSetup || bHosted);
+		resetReadyStatus(false);
 	}
 
 	if (id >= MULTIOP_DIFFICULTY_CHOOSE_START && id <= MULTIOP_DIFFICULTY_CHOOSE_END && difficultyChooserUp != -1)
@@ -2807,6 +2808,7 @@ void WzMultiOptionTitleUI::processMultiopWidgets(UDWORD id)
 		NETBroadcastPlayerInfo(difficultyChooserUp);
 		closeDifficultyChooser();
 		addPlayerBox(!ingame.bHostSetup || bHosted);
+		resetReadyStatus(false);
 	}
 
 	if (id >= MULTIOP_AI_START && id <= MULTIOP_AI_END && aiChooserUp != -1)
@@ -2818,6 +2820,7 @@ void WzMultiOptionTitleUI::processMultiopWidgets(UDWORD id)
 		NETBroadcastPlayerInfo(aiChooserUp);
 		closeAiChooser();
 		addPlayerBox(!ingame.bHostSetup || bHosted);
+		resetReadyStatus(false);
 	}
 
 	STATIC_ASSERT(MULTIOP_TEAMS_START + MAX_PLAYERS - 1 <= MULTIOP_TEAMS_END);
@@ -2935,6 +2938,7 @@ void WzMultiOptionTitleUI::processMultiopWidgets(UDWORD id)
 					}
 				}
 				addPlayerBox(!ingame.bHostSetup || bHosted);
+				resetReadyStatus(false);
 			}
 			else
 			{

--- a/src/multiint.h
+++ b/src/multiint.h
@@ -123,6 +123,7 @@ void kickPlayer(uint32_t player_id, const char *reason, LOBBY_ERROR_TYPES type);
 void addPlayerBox(bool);			// players (mid) box
 void loadMapPreview(bool hideInterface);
 
+bool changeReadyStatus(UBYTE player, bool bReady);
 
 // ////////////////////////////////////////////////////////////////
 // CONNECTION SCREEN

--- a/src/multilimit.cpp
+++ b/src/multilimit.cpp
@@ -289,6 +289,8 @@ TITLECODE WzMultiLimitTitleUI::run()
 				sendTextMessage("Limits Reset To Default Values", true);
 			}
 
+			resetReadyStatus(false);
+
 			break;
 		case IDLIMITS_OK:
 			if (!challengeActive && widgGetButtonState(psWScreen, IDLIMITS_FORCE))

--- a/src/multiplay.cpp
+++ b/src/multiplay.cpp
@@ -72,6 +72,7 @@
 #include "keymap.h"
 #include "cheat.h"
 #include "main.h"								// for gamemode
+#include "multiint.h"
 
 // ////////////////////////////////////////////////////////////////////////////
 // ////////////////////////////////////////////////////////////////////////////
@@ -1928,4 +1929,16 @@ void resetReadyStatus(bool bSendOptions)
 		sendOptions();
 	}
 	netPlayersUpdated = true;
+
+	//Really reset ready status
+	if (NetPlay.isHost)
+	{
+		for (unsigned int i = 0; i < game.maxPlayers; ++i)
+		{
+			if (isHumanPlayer(i) && ingame.JoiningInProgress[i])
+			{
+				changeReadyStatus(i, false);
+			}
+		}
+	}
 }


### PR DESCRIPTION
Requested feature for #526.

This PR will makes sure everybody agrees with all intermittent changes a host makes to game settings, at least for current settings and behaviors. Testing and/or feedback is very much welcome.