### PR TITLE
Protect game.isMapMod when hovering over maps to preview them.

### DIFF
--- a/src/multiint.cpp
+++ b/src/multiint.cpp
@@ -3443,6 +3443,7 @@ TITLECODE WzMultiOptionTitleUI::run()
 		if (runMultiRequester(id, &id, &sTemp, &mapData, &isHoverPreview))
 		{
 			Sha256 oldGameHash;
+			bool oldGameIsMapMod;
 
 			switch (id)
 			{
@@ -3465,6 +3466,7 @@ TITLECODE WzMultiOptionTitleUI::run()
 					sstrcpy(oldGameMap, game.map);
 					oldGameHash = game.hash;
 					oldMaxPlayers = game.maxPlayers;
+					oldGameIsMapMod = game.isMapMod;
 
 					sstrcpy(game.map, mapData->pName);
 					game.hash = levGetFileHash(mapData);
@@ -3477,6 +3479,7 @@ TITLECODE WzMultiOptionTitleUI::run()
 						sstrcpy(game.map, oldGameMap);
 						game.hash = oldGameHash;
 						game.maxPlayers = oldMaxPlayers;
+						game.isMapMod = oldGameIsMapMod;
 					}
 					else
 					{


### PR DESCRIPTION
Map-mods can cause a small issue when hover previewing them. It's possible to get the red icon to stay, for example, on the Rush map when it clearly shouldn't by previewing different maps and then pressing the cancel button.

With #526 patches, another side effect of differing game.isMapMod states can leave the clients with an invalid warning about the host having altered the game code when changing maps after hosting.