### PR TITLE
Fix bug with old limits not always reset when randomizing

### DIFF
--- a/src/multiint.cpp
+++ b/src/multiint.cpp
@@ -2601,6 +2601,7 @@ static void randomizeOptions()
 			}
 			closeLoadingScreen();
 		}
+		resetLimits();
 		for (int i = 0; i < ARRAY_SIZE(limitIcons) - 1; ++i)	// skip last item, MPFLAGS_FORCELIMITS
 		{
 			randomizeLimit(limitIcons[i].stat);

--- a/src/multilimit.cpp
+++ b/src/multilimit.cpp
@@ -130,11 +130,7 @@ void WzMultiLimitTitleUI::start()
 
 	if (challengeActive)
 	{
-		for (unsigned i = 0; i < numStructureStats; ++i)
-		{
-			asStructureStats[i].upgrade[0].limit = asStructureStats[i].base.limit;
-		}
-
+		resetLimits();
 		// turn off the sliders
 		sliderEnableDrag(false);
 	}
@@ -264,10 +260,7 @@ TITLECODE WzMultiLimitTitleUI::run()
 			break;
 		case IDLIMITS_RETURN:
 			// reset the sliders..
-			for (unsigned i = 0; i < numStructureStats; ++i)
-			{
-				asStructureStats[i].upgrade[0].limit = asStructureStats[i].base.limit;
-			}
+			resetLimits();
 			// free limiter structure
 			freeLimitSet();
 			if (widgGetButtonState(psWScreen, IDLIMITS_FORCE))
@@ -522,4 +515,12 @@ static void displayStructureBar(WIDGET *psWidget, UDWORD xOffset, UDWORD yOffset
 	cache.wzLimitText.render(x + 270, y + psWidget->height() / 2 + 3, WZCOL_TEXT_BRIGHT);
 
 	return;
+}
+
+void resetLimits(void)
+{
+	for (unsigned i = 0; i < numStructureStats; ++i)
+	{
+		asStructureStats[i].upgrade[0].limit = asStructureStats[i].base.limit;
+	}
 }

--- a/src/multilimit.h
+++ b/src/multilimit.h
@@ -28,5 +28,6 @@
 
 void applyLimitSet();
 void createLimitSet();
+void resetLimits(void);
 
 #endif //__cplusplus //__INCLUDED_MULTILIMIT_H__


### PR DESCRIPTION
When randomizing the game, effects of old structure limits would still
apply when they shouldn't. For example, AA structures would not be available
(due to old setting of no-VTOL + enforced limits) when VTOLs can be
built. Fix by resetting all limits before randomizing.