### PR TITLE
Fastplay and Tutorial updates.

### DIFF
--- a/src/frontend.cpp
+++ b/src/frontend.cpp
@@ -320,16 +320,13 @@ bool runTutorialMenu()
 	switch (id)
 	{
 	case FRONTEND_TUTORIAL:
-		NetPlay.players[0].allocated = true;
-		game.skDiff[0] = UBYTE_MAX;
+		SPinit();
 		sstrcpy(aLevelName, TUTORIAL_LEVEL);
 		changeTitleMode(STARTGAME);
 		break;
 
 	case FRONTEND_FASTPLAY:
-		NETinit(true);
-		NetPlay.players[0].allocated = true;
-		game.skDiff[0] = UBYTE_MAX;
+		SPinit();
 		sstrcpy(aLevelName, "FASTPLAY");
 		changeTitleMode(STARTGAME);
 		break;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1303,6 +1303,7 @@ bool stageThreeShutDown()
 	challengesUp = false;
 	challengeActive = false;
 	isInGamePopupUp = false;
+	bInTutorial = false;
 
 	shutdownTemplates();
 


### PR DESCRIPTION
Entering fastplay would create netplay logs which was obviously wrong behavior. It was using NETinit(true) here. I replaced it with SPinit() instead (among a few lines that already get set in that function) and did that with tutorial as well. Also, I reset bInTutorial in stageThreeShutdown() so the demolish button doesn't disappear in future games after visiting tutorial.