### PR TITLE
[Travis CI] Add initial ARM64 Ubuntu build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -104,6 +104,28 @@ matrix:
         - docker run --rm -e CI -e TRAVIS -e "TRAVIS_BUILD_DIR=/code" -e TRAVIS_BRANCH -e TRAVIS_COMMIT -e TRAVIS_PULL_REQUEST_BRANCH -e TRAVIS_TAG -e MAKEFLAGS -v $(pwd):/code ubuntu cmake '-H.' -Bbuild -DCMAKE_BUILD_TYPE=RelWithDebInfo -DWZ_ENABLE_WARNINGS:BOOL=ON -G"Ninja"
         - docker run --rm -e CI -e TRAVIS -e "TRAVIS_BUILD_DIR=/code" -e TRAVIS_BRANCH -e TRAVIS_COMMIT -e TRAVIS_PULL_REQUEST_BRANCH -e TRAVIS_TAG -e MAKEFLAGS -v $(pwd):/code ubuntu cmake --build build
 
+    # Build for Ubuntu 18.04 (CMake) (GCC) [ARM64]
+    - name: "Ubuntu 18.04 (CMake) [GCC] [ARM64]"
+      arch: arm64
+      os: linux
+      dist: xenial
+      language: cpp
+      compiler: gcc
+      sudo: required
+      services:
+        - docker
+      install:
+        - cd docker/ubuntu-18.04/
+        - docker build -t ubuntu -f Dockerfile.arm64 .
+        - cd ../..
+      script:
+        - export MAKEFLAGS="-j$((`grep -c ^processor /proc/cpuinfo`*2))"
+        # Must supply the TRAVIS environment variables to the docker container so autorevision properly receives the revision info from Travis
+        # To do this, append the following to the pertinent lines after —rm:
+        # -e CI -e TRAVIS -e "TRAVIS_BUILD_DIR=/code" -e TRAVIS_BRANCH -e TRAVIS_COMMIT -e TRAVIS_PULL_REQUEST_BRANCH -e TRAVIS_TAG
+        - docker run --rm -e CI -e TRAVIS -e "TRAVIS_BUILD_DIR=/code" -e TRAVIS_BRANCH -e TRAVIS_COMMIT -e TRAVIS_PULL_REQUEST_BRANCH -e TRAVIS_TAG -e MAKEFLAGS -v $(pwd):/code ubuntu cmake '-H.' -Bbuild -DCMAKE_BUILD_TYPE=RelWithDebInfo -DWZ_ENABLE_WARNINGS:BOOL=ON -G"Ninja"
+        - docker run --rm -e CI -e TRAVIS -e "TRAVIS_BUILD_DIR=/code" -e TRAVIS_BRANCH -e TRAVIS_COMMIT -e TRAVIS_PULL_REQUEST_BRANCH -e TRAVIS_TAG -e MAKEFLAGS -v $(pwd):/code ubuntu cmake --build build
+
     # Package source (Ubuntu 18.04, CMake)
     - name: "Package Source (Ubuntu 18.04, CMake) [GCC]"
       language: cpp

--- a/docker/ubuntu-18.04/Dockerfile.arm64
+++ b/docker/ubuntu-18.04/Dockerfile.arm64
@@ -1,0 +1,11 @@
+FROM arm64v8/ubuntu:18.04
+
+RUN cat /etc/lsb-release
+
+RUN apt-get -u update \
+ && DEBIAN_FRONTEND=noninteractive apt-get -y install build-essential automake ninja-build pkg-config libpng-dev libsdl2-dev libopenal-dev libphysfs-dev libvorbis-dev libtheora-dev libglew-dev libxrandr-dev zip unzip qtscript5-dev qt5-default libfribidi-dev libfreetype6-dev libharfbuzz-dev libfontconfig1-dev docbook-xsl xsltproc asciidoc gettext git cmake sudo \
+ && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /code
+CMD ["sh"]
+


### PR DESCRIPTION
Uses a new `docker/ubuntu-18.04/Dockerfile.arm64` file, which differs only in the first line:
```dockerfile
FROM arm64v8/ubuntu:18.04
```