### PR TITLE
[Travis CI] macOS: Resolve `brew upgrade cmake` failure when CMake is already upgraded

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -229,10 +229,10 @@ matrix:
         - build_tools/ci/travis/travis_deploy.sh "tmp/wz_upload" "warzone2100-${WZ_BUILD_DESC_PREFIX}-*_macOS.zip" --cleanold
 
     # Build for macOS (CMake)
-    - name: "macOS (CMake) [Xcode 10.2, macOS 10.14 SDK]"
+    - name: "macOS (CMake) [Xcode 10.3, macOS 10.14 SDK]"
       language: objective-c
       os: osx
-      osx_image: xcode10.2
+      osx_image: xcode10.3
       env:
         - MACOSX_DEPLOYMENT_TARGET=10.10
       before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -213,7 +213,7 @@ matrix:
         - MACOSX_DEPLOYMENT_TARGET=10.10
       before_install:
         - brew update
-        - brew upgrade cmake
+        - if (brew outdated | grep cmake > /dev/null); then echo "upgrading CMake"; brew upgrade cmake; fi
         - brew install gettext
         # NOTE: Specify an explicit Asciidoctor version to help ensure reproducible builds
         - gem install asciidoctor -v 2.0.10 --no-document
@@ -237,7 +237,7 @@ matrix:
         - MACOSX_DEPLOYMENT_TARGET=10.10
       before_install:
         - brew update
-        - brew upgrade cmake
+        - if (brew outdated | grep cmake > /dev/null); then echo "upgrading CMake"; brew upgrade cmake; fi
         - brew install gettext
         # NOTE: Specify an explicit Asciidoctor version to help ensure reproducible builds
         - gem install asciidoctor -v 2.0.10 --no-document


### PR DESCRIPTION
(See prior Travis CI runs - at the moment, impacts the "Xcode 10.2, macOS 10.14 SDK" job.)