### PR TITLE
Call jsDebugShutdown when ScriptDebugger window is closed

### DIFF
--- a/src/qtscript.cpp
+++ b/src/qtscript.cpp
@@ -998,6 +998,11 @@ void jsAutogame()
 	jsAutogameSpecific(QStringToWzString("scripts/" + basename.fileName()), selectedPlayer);
 }
 
+void jsHandleDebugClosed()
+{
+	globalDialog = false;
+}
+
 void jsShowDebug()
 {
 	// Add globals
@@ -1020,7 +1025,7 @@ void jsShowDebug()
 
 	globalDialog = true;
 	updateGlobalModels();
-	jsDebugCreate(models, triggerModel);
+	jsDebugCreate(models, triggerModel, createLabelModel(), jsHandleDebugClosed);
 }
 
 // ----------------------------------------------------------------------------------------

--- a/src/qtscriptdebug.h
+++ b/src/qtscriptdebug.h
@@ -34,6 +34,8 @@
 #include <QtWidgets/QTreeView>
 #include <QtWidgets/QComboBox>
 
+#include <functional>
+
 #include "lib/framework/frame.h"
 #include "basedef.h"
 #include "droiddef.h"
@@ -53,7 +55,7 @@ class ScriptDebugger : public QDialog
 	Q_OBJECT
 
 public:
-	ScriptDebugger(const MODELMAP &models, QStandardItemModel *triggerModel);
+	ScriptDebugger(const MODELMAP &models, QStandardItemModel *triggerModel, QStandardItemModel *labelModel);
 	~ScriptDebugger();
 	void selected(const BASE_OBJECT *psObj);
 	void updateMessages();
@@ -104,9 +106,11 @@ protected slots:
 	void shadowButtonClicked();
 	void fogButtonClicked();
 	void attachScriptClicked();
+	void debuggerClosed();
 };
 
-void jsDebugCreate(const MODELMAP &models, QStandardItemModel *triggerModel);
+typedef std::function<void ()> jsDebugShutdownHandlerFunction;
+void jsDebugCreate(const MODELMAP &models, QStandardItemModel *triggerModel, QStandardItemModel *labelModel, const jsDebugShutdownHandlerFunction& shutdownFunc);
 bool jsDebugShutdown();
 
 // jsDebugSelected() and jsDebugMessageUpdate() defined in qtscript.h since it is used widely

--- a/src/qtscriptfuncs.cpp
+++ b/src/qtscriptfuncs.cpp
@@ -32,6 +32,7 @@
 #include <QtCore/QStringList>
 #include <QtCore/QJsonArray>
 #include <QtGui/QStandardItemModel>
+#include <QtCore/QPointer>
 
 #if defined(__GNUC__) && !defined(__INTEL_COMPILER) && !defined(__clang__) && (9 <= __GNUC__)
 # pragma GCC diagnostic pop // Workaround Qt < 5.13 `deprecated-copy` issues with GCC 9
@@ -240,7 +241,7 @@ struct LABEL
 };
 typedef QMap<QString, LABEL> LABELMAP;
 static LABELMAP labels;
-static QStandardItemModel *labelModel = nullptr;
+static QPointer<QStandardItemModel> labelModel;
 
 #define SCRIPT_ASSERT_PLAYER(_context, _player) \
 	SCRIPT_ASSERT(_context, _player >= 0 && _player < MAX_PLAYERS, "Invalid player index %d", _player);


### PR DESCRIPTION
The performance impact of having the script debugger window open should now cease when the script debugger window is closed.