### PR TITLE
DROID_CYBORG_CONSTRUCT not passed to global #610

### DIFF
--- a/src/qtscriptfuncs.cpp
+++ b/src/qtscriptfuncs.cpp
@@ -6308,6 +6308,7 @@ bool registerFunctions(QScriptEngine *engine, const QString& scriptName)
 	engine->globalObject().setProperty("BEING_BUILT", SS_BEING_BUILT, QScriptValue::ReadOnly | QScriptValue::Undeletable);
 	engine->globalObject().setProperty("BUILT", SS_BUILT, QScriptValue::ReadOnly | QScriptValue::Undeletable);
 	engine->globalObject().setProperty("DROID_CONSTRUCT", DROID_CONSTRUCT, QScriptValue::ReadOnly | QScriptValue::Undeletable);
+	engine->globalObject().setProperty("DROID_CYBORG_CONSTRUCT", DROID_CYBORG_CONSTRUCT, QScriptValue::ReadOnly | QScriptValue::Undeletable);
 	engine->globalObject().setProperty("DROID_WEAPON", DROID_WEAPON, QScriptValue::ReadOnly | QScriptValue::Undeletable);
 	engine->globalObject().setProperty("DROID_PERSON", DROID_PERSON, QScriptValue::ReadOnly | QScriptValue::Undeletable);
 	engine->globalObject().setProperty("DROID_REPAIR", DROID_REPAIR, QScriptValue::ReadOnly | QScriptValue::Undeletable);


### PR DESCRIPTION
Fixed #610 

In fact we can enum all builders by just enumDroid(me, DROID_CONSTRUCT), but we get all in one, and Cyborgs and Engine Droids constructors.
Of course we can apply enumDroid().filter() by the property .body and weed out the excess, but it is an additional cycle. So same we can get all cyborg-builders by enumDroid(me, 10), this will work, because in statsdef.h DROID_CYBORG_CONSTRUCTOR is registered, but it was not passed to js scope, now it is passed.
