### PR TITLE
Windows: Enable v6 Common Control support in the manifest

### DIFF
--- a/win32/warzone2100.manifest
+++ b/win32/warzone2100.manifest
@@ -1,6 +1,18 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
 	<assemblyIdentity type="win32" name="Warzone2100Project.Warzone2100" version="1.0.0.0"/>
+	<dependency>
+		<dependentAssembly>
+			<assemblyIdentity
+				type="win32"
+				name="Microsoft.Windows.Common-Controls"
+				version="6.0.0.0"
+				processorArchitecture="*"
+				publicKeyToken="6595b64144ccf1df"
+				language="*"
+			/>
+		</dependentAssembly>
+	</dependency>
 	<trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
 		<security>
 			<!-- Do not require administrator privileges to run -->

--- a/win32/warzone2100.manifest.in
+++ b/win32/warzone2100.manifest.in
@@ -1,6 +1,18 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
 	<assemblyIdentity type="win32" name="Warzone2100Project.Warzone2100" version="@MANIFEST_assemblyIdentityVersion@"/>
+	<dependency>
+		<dependentAssembly>
+			<assemblyIdentity
+				type="win32"
+				name="Microsoft.Windows.Common-Controls"
+				version="6.0.0.0"
+				processorArchitecture="*"
+				publicKeyToken="6595b64144ccf1df"
+				language="*"
+			/>
+		</dependentAssembly>
+	</dependency>
 	<trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
 		<security>
 			<!-- Do not require administrator privileges to run -->


### PR DESCRIPTION
See: https://docs.microsoft.com/en-us/windows/win32/sbscs/enabling-updated-common-controls-visual-styles-and-themes
And: https://docs.microsoft.com/en-us/windows/win32/controls/cookbook-overview

This also enables support for modern [Task Dialogs](https://docs.microsoft.com/en-us/windows/win32/controls/task-dialogs-overview) (instead of classic Message boxes) when using `SDL_ShowMessageBox` / `SDL_ShowSimpleMessageBox` on Windows.