### PR TITLE
Improve LOG_FATAL, LOG_POPUP handling

### DIFF
--- a/lib/framework/debug.cpp
+++ b/lib/framework/debug.cpp
@@ -526,10 +526,10 @@ void _debug(int line, code_part part, const char *function, const char *str, ...
 				wzToggleFullscreen();
 			}
 #if defined(WZ_OS_WIN)
-			char wbuf[512];
+			char wbuf[1024];
 			ssprintf(wbuf, "%s\n\nPlease check the file (%s) in your configuration directory for more details. \
 				\nDo not forget to upload the %s file, WZdebuginfo.txt and the warzone2100.rpt files in your bug reports at https://github.com/Warzone2100/warzone2100/issues/new!", useInputBuffer1 ? inputBuffer[1] : inputBuffer[0], WZ_DBGFile, WZ_DBGFile);
-			MessageBoxA(NULL, wbuf, "Warzone has terminated unexpectedly", MB_OK | MB_ICONERROR);
+			wzDisplayDialog(Dialog_Error, "Warzone has terminated unexpectedly", wbuf);
 #elif defined(WZ_OS_MAC)
 			char wbuf[1024];
 			ssprintf(wbuf, "%s\n\nPlease check your logs and attach them along with a bug report. Thanks!", useInputBuffer1 ? inputBuffer[1] : inputBuffer[0]);

--- a/lib/framework/debug.cpp
+++ b/lib/framework/debug.cpp
@@ -572,15 +572,7 @@ void _debug(int line, code_part part, const char *function, const char *str, ...
 		// This is a popup dialog used for times when the error isn't fatal, but we still need to notify user what is going on.
 		if (part == LOG_POPUP)
 		{
-#if defined(WZ_OS_WIN)
-			char wbuf[512];
-			ssprintf(wbuf, "A non fatal error has occurred.\n\n%s\n\n", useInputBuffer1 ? inputBuffer[1] : inputBuffer[0]);
-			MessageBoxA(NULL,
-			            wbuf,
-			            "Warzone has detected a problem.", MB_OK | MB_ICONINFORMATION);
-#elif defined(WZ_OS_MAC)
-			cocoaShowAlert("Warzone has detected a problem.", inputBuffer[useInputBuffer1 ? 1 : 0], 0, "OK", NULL);
-#endif
+			wzDisplayDialog(Dialog_Information, "Warzone has detected a problem.", inputBuffer[useInputBuffer1 ? 1 : 0]);
 		}
 
 	}

--- a/lib/framework/debug.cpp
+++ b/lib/framework/debug.cpp
@@ -564,7 +564,7 @@ void _debug(int line, code_part part, const char *function, const char *str, ...
 			}
 #else
 			const char *popupBuf = useInputBuffer1 ? inputBuffer[1] : inputBuffer[0];
-			wzFatalDialog(popupBuf);
+			wzDisplayDialog(Dialog_Error, "Warzone has terminated unexpectedly", popupBuf);
 #endif
 		}
 

--- a/lib/framework/wzapp.h
+++ b/lib/framework/wzapp.h
@@ -89,7 +89,12 @@ void wzGrabMouse();		///< Trap mouse cursor in application window
 void wzReleaseMouse();	///< Undo the wzGrabMouse operation
 bool wzActiveWindow();	///< Whether application currently has the mouse pointer over it
 int wzGetTicks();		///< Milliseconds since start of game
-WZ_DECL_NONNULL(1) void wzFatalDialog(const char *text);	///< Throw up a modal warning dialog
+enum DialogType {
+	Dialog_Error,
+	Dialog_Warning,
+	Dialog_Information
+};
+WZ_DECL_NONNULL(2, 3) void wzDisplayDialog(DialogType type, const char *title, const char *message);	///< Throw up a modal warning dialog - title & message are UTF-8 text
 
 std::vector<screeninfo> wzAvailableResolutions();
 std::vector<unsigned int> wzAvailableDisplayScales();

--- a/lib/sdl/main_sdl.cpp
+++ b/lib/sdl/main_sdl.cpp
@@ -306,9 +306,22 @@ int wzGetTicks()
 	return SDL_GetTicks();
 }
 
-void wzFatalDialog(const char *msg)
+void wzDisplayDialog(DialogType type, const char *title, const char *message)
 {
-	SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_ERROR, "We have a problem!", msg, nullptr);
+	Uint32 sdl_messagebox_flags = 0;
+	switch (type)
+	{
+		case Dialog_Error:
+			sdl_messagebox_flags = SDL_MESSAGEBOX_ERROR;
+			break;
+		case Dialog_Warning:
+			sdl_messagebox_flags = SDL_MESSAGEBOX_WARNING;
+			break;
+		case Dialog_Information:
+			sdl_messagebox_flags = SDL_MESSAGEBOX_INFORMATION;
+			break;
+	}
+	SDL_ShowSimpleMessageBox(sdl_messagebox_flags, title, message, WZwindow);
 }
 
 void wzScreenFlip()


### PR DESCRIPTION
- Replace `wzFatalDialog` with (more flexible) `wzDisplayDialog`
- Improve `LOG_FATAL` handling on Windows
   - Expand message buffer
   - Use `wzDisplayDialog` instead of `MessageBoxA` (for UTF-8 support, etc)
- Use `wzDisplayDialog` for `LOG_POPUP` handling