### PR TITLE
[macOS] Initial entitlement support for Hardened Runtime exceptions

### DIFF
--- a/macosx/Resources/Warzone.entitlements
+++ b/macosx/Resources/Warzone.entitlements
@@ -4,6 +4,12 @@
 <dict>
 	<key>com.apple.security.app-sandbox</key>
 	<true/>
+	<key>com.apple.security.cs.allow-jit</key>
+	<true/>
+	<key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+	<true/>
+	<key>com.apple.security.cs.disable-library-validation</key>
+	<true/>
 	<key>com.apple.security.network.client</key>
 	<true/>
 	<key>com.apple.security.network.server</key>


### PR DESCRIPTION
- "Allow Unsigned Executable Memory" is currently required for QtScript.