### PR TITLE
Improve HQ/template designing measures

### DIFF
--- a/data/base/script/rules.js
+++ b/data/base/script/rules.js
@@ -166,14 +166,11 @@ function reticuleDesignCheck()
 	{
 		setReticuleButton(4, _("Design (F4)"), "image_design_up.png", "image_design_down.png");
 		setMiniMap(true);
-		setDesign(true);
 	}
 	else
 	{
 		setReticuleButton(4, _("Design - construct HQ first"), "", "");
 		setMiniMap(false);
-		// Will enable templates that are researched whenever the reticule buttons update.
-		setDesign(false);
 	}
 }
 
@@ -264,7 +261,8 @@ function setupGame()
 
 	// Disable by default
 	setMiniMap(false);
-	setDesign(false);
+	// Enable all templates
+	setDesign(true);
 
 	setMainReticule();
 	showInterface();

--- a/data/mp/multiplay/skirmish/rules.js
+++ b/data/mp/multiplay/skirmish/rules.js
@@ -148,7 +148,6 @@ function reticuleDesignCheck()
 	{
 		setReticuleButton(4, _("Design (F4)"), "image_design_up.png", "image_design_down.png");
 		setMiniMap(true);
-		setDesign(true);
 	}
 	else
 	{
@@ -236,7 +235,8 @@ function setupGame()
 	}
 	// Disabled by default
 	setMiniMap(false);
-	setDesign(false);
+	// Enable all templates
+	setDesign(true);
 
 	setMainReticule();
 	showInterface();

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -3781,6 +3781,11 @@ static bool loadMainFile(const std::string &fileName)
 {
 	WzConfig save(WzString::fromUtf8(fileName), WzConfig::ReadOnly);
 
+	if (save.contains("playerBuiltHQ"))
+	{
+		playerBuiltHQ = save.value("playerBuiltHQ").toBool();
+	}
+
 	save.beginArray("players");
 	while (save.remainingArrayItems() > 0)
 	{
@@ -3922,6 +3927,7 @@ static bool writeMainFile(const std::string &fileName, SDWORD saveType)
 	save.setValue("hostPlayer", NetPlay.hostPlayer);
 	save.setValue("bComms", NetPlay.bComms);
 	save.setValue("modList", getModList().c_str());
+	save.setValue("playerBuiltHQ", playerBuiltHQ);
 
 	return true;
 }

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1226,7 +1226,6 @@ bool stageThreeInitialise()
 
 	// Re-inititialise some static variables.
 
-	playerBuiltHQ = false;
 	bInTutorial = false;
 
 	resizeRadar();
@@ -1277,6 +1276,7 @@ bool stageThreeInitialise()
 			triggerEventCheatMode(true);
 		}
 		triggerEvent(TRIGGER_GAME_INIT);
+		playerBuiltHQ = structureExists(selectedPlayer, REF_HQ, true, false);
 	}
 
 	return true;

--- a/src/multistruct.cpp
+++ b/src/multistruct.cpp
@@ -151,6 +151,7 @@ bool recvBuildFinished(NETQUEUE queue)
 		NETlogEntry("had to plonk down a building", SYNC_FLAG, player);
 #endif
 		triggerEventStructBuilt(psStruct, nullptr);
+		checkPlayerBuiltHQ(psStruct);
 	}
 	else
 	{

--- a/src/structure.cpp
+++ b/src/structure.cpp
@@ -829,6 +829,7 @@ void structureBuild(STRUCTURE *psStruct, DROID *psDroid, int buildPoints, int bu
 			audio_StopObjTrack(psDroid, ID_SOUND_CONSTRUCTION_LOOP);
 		}
 		triggerEventStructBuilt(psStruct, psDroid);
+		checkPlayerBuiltHQ(psStruct);
 	}
 	else
 	{
@@ -6910,6 +6911,7 @@ STRUCTURE *giftSingleStructure(STRUCTURE *psStructure, UBYTE attackPlayer, bool 
 			psNewStruct->status = SS_BUILT;
 			buildingComplete(psNewStruct);
 			triggerEventStructBuilt(psNewStruct, nullptr);
+			checkPlayerBuiltHQ(psNewStruct);
 		}
 
 		if (!bMultiPlayer)

--- a/src/template.cpp
+++ b/src/template.cpp
@@ -646,11 +646,6 @@ void fillTemplateList(std::vector<DROID_TEMPLATE *> &pList, STRUCTURE *psFactory
 
 	BODY_SIZE	iCapacity = (BODY_SIZE)psFactory->capacity;
 
-	if (!playerBuiltHQ)
-	{
-		playerBuiltHQ = structureExists(player, REF_HQ, true, false);
-	}
-
 	/* Add the templates to the list*/
 	for (DROID_TEMPLATE &i : localTemplates)
 	{
@@ -689,5 +684,13 @@ void fillTemplateList(std::vector<DROID_TEMPLATE *> &pList, STRUCTURE *psFactory
 				pList.push_back(psCurr);
 			}
 		}
+	}
+}
+
+void checkPlayerBuiltHQ(const STRUCTURE *psStruct)
+{
+	if (selectedPlayer == psStruct->player && psStruct->pStructureType->type == REF_HQ)
+	{
+		playerBuiltHQ = true;
 	}
 }

--- a/src/template.h
+++ b/src/template.h
@@ -65,4 +65,6 @@ void listTemplates();
 void saveTemplateCommon(WzConfig &ini, DROID_TEMPLATE *psCurr);
 bool loadTemplateCommon(WzConfig &ini, DROID_TEMPLATE &outputTemplate);
 
+void checkPlayerBuiltHQ(const STRUCTURE *psStruct);
+
 #endif // TEMPLATE_H


### PR DESCRIPTION
`playerBuiltHQ` is now saved in main.json and loaded when Warzone loads this file. Fixing skirmish saves that removed the first HQ built.

Initializes `playerBuiltHQ` after eventGameInit instead of when loading the production  template buttons so as to prevent the below issue.

Additionally, setDesign(false) has strange behavior if the player has saved templates that have yet to be researched when loading skirmish saves without a HQ. Ultimately, this required building an HQ to enable them as well because they were not enabled until then.

Fixes #629 
