### PR TITLE
Allow more features to cast a shadow.

### DIFF
--- a/src/display3d.cpp
+++ b/src/display3d.cpp
@@ -1934,6 +1934,9 @@ void	renderFeature(FEATURE *psFeature, const glm::mat4 &viewMatrix)
 
 	if (psFeature->psStats->subType == FEAT_BUILDING
 	    || psFeature->psStats->subType == FEAT_SKYSCRAPER
+	    || psFeature->psStats->subType == FEAT_GEN_ARTE
+	    || psFeature->psStats->subType == FEAT_BOULDER
+	    || psFeature->psStats->subType == FEAT_VEHICLE
 	    || psFeature->psStats->subType == FEAT_OIL_DRUM)
 	{
 		/* these cast a shadow */


### PR DESCRIPTION
Basically everything but "tank wrecks", oil resources, and trees will now cast shadows.

Refs #633.