### PR TITLE
Resolve _LIBCPP_DEPRECATED_IN_CXX11 warnings

### DIFF
--- a/src/projectile.cpp
+++ b/src/projectile.cpp
@@ -1283,7 +1283,7 @@ void PROJECTILE::update()
 		setProjectileDestination(psObj, nullptr);
 	}
 	// Remove dead objects from psDamaged.
-	psDamaged.erase(std::remove_if(psDamaged.begin(), psDamaged.end(), std::ptr_fun(&::isDead)), psDamaged.end());
+	psDamaged.erase(std::remove_if(psDamaged.begin(), psDamaged.end(), [](const BASE_OBJECT *psObj) { return ::isDead(psObj); }), psDamaged.end());
 
 	// This extra check fixes a crash in cam2, mission1
 	if (worldOnMap(psObj->pos.x, psObj->pos.y) == false)
@@ -1328,10 +1328,10 @@ void proj_UpdateAll()
 	std::vector<PROJECTILE *> psProjectileListOld = psProjectileList;
 
 	// Update all projectiles. Penetrating projectiles may add to psProjectileList.
-	std::for_each(psProjectileListOld.begin(), psProjectileListOld.end(), std::mem_fun(&PROJECTILE::update));
+	std::for_each(psProjectileListOld.begin(), psProjectileListOld.end(), std::mem_fn(&PROJECTILE::update));
 
 	// Remove and free dead projectiles.
-	psProjectileList.erase(std::remove_if(psProjectileList.begin(), psProjectileList.end(), std::mem_fun(&PROJECTILE::deleteIfDead)), psProjectileList.end());
+	psProjectileList.erase(std::remove_if(psProjectileList.begin(), psProjectileList.end(), std::mem_fn(&PROJECTILE::deleteIfDead)), psProjectileList.end());
 }
 
 /***************************************************************************/

--- a/src/selection.cpp
+++ b/src/selection.cpp
@@ -74,7 +74,7 @@ static unsigned selSelectUnitsIf(unsigned player, T condition, bool onlyOnScreen
 template <typename T, typename U>
 static unsigned selSelectUnitsIf(unsigned player, T condition, U value, bool onlyOnScreen)
 {
-	return selSelectUnitsIf(player, std::bind2nd(std::ptr_fun(condition), value), onlyOnScreen);
+	return selSelectUnitsIf(player, [condition, value](DROID *psDroid) { return condition(psDroid, value); }, onlyOnScreen);
 }
 
 static bool selTransporter(DROID *droid)

--- a/src/structure.cpp
+++ b/src/structure.cpp
@@ -6246,7 +6246,7 @@ DROID_TEMPLATE *factoryProdUpdate(STRUCTURE *psStructure, DROID_TEMPLATE *psTemp
 		}
 
 		//need to reset the quantity built for each entry in the production list
-		std::for_each(productionRun.begin(), productionRun.end(), std::mem_fun_ref(&ProductionRunEntry::restart));
+		std::for_each(productionRun.begin(), productionRun.end(), std::mem_fn(&ProductionRunEntry::restart));
 
 		//get the first to build again
 		return productionRun[0].psTemplate;


### PR DESCRIPTION
Replaces deprecated:
- `std::ptr_fun`
- `std::mem_fun` / `std::mem_fun_ref`
- `std::bind2nd`