### PR TITLE
Prevent selected campaign transporters from responding to most orders.

### DIFF
--- a/src/order.cpp
+++ b/src/order.cpp
@@ -1304,6 +1304,19 @@ void orderDroidBase(DROID *psDroid, DROID_ORDER_DATA *psOrder)
 		}
 	}
 
+	// A selected campaign transporter shouldn't be given orders by the player.
+	// Campaign transporter selection is required for it to be tracked by the camera, and
+	// should be the only case when it does get selected.
+	if (isTransporter(psDroid) &&
+		!bMultiPlayer &&
+		psDroid->selected &&
+		(psOrder->type != DORDER_TRANSPORTOUT &&
+		psOrder->type != DORDER_TRANSPORTIN &&
+		psOrder->type != DORDER_TRANSPORTRETURN))
+	{
+		return;
+	}
+
 	switch (psOrder->type)
 	{
 	case DORDER_NONE:


### PR DESCRIPTION
With this PR the campaign transporter won't respond to human issued orders anymore, like stop or hold. The only time the transporter in the campaign will be selected is if a script wishes to track the transporter via `cameraTrack()`, as showcased in mission Alpha 9.

Thus, the campaign transporter will only be able to follow:
```
DORDER_TRANSPORTOUT
DORDER_TRANSPORTIN
DORDER_TRANSPORTRETURN
```
Which does not appear to break anything with the testing I did.

This can be tested by typing in the cheat "ascend sub-1-5s" while starting from Alpha campaign to skip to the Alpha 9 pre-away mission. Once offworld the transporter will be selected but unable to be put on hold or whatever.

Closes #642 