### PR TITLE
Oil drum placement improvements

### DIFF
--- a/data/mp/multiplay/skirmish/rules.js
+++ b/data/mp/multiplay/skirmish/rules.js
@@ -690,7 +690,7 @@ function placeOilDrum()
 	var unreachable = true;
 	for (var i = 0; i < maxPlayers; ++i)
 	{
-		if (propulsionCanReach("wheeled01", x, y, startPositions[i].x, startPositions[i].y))
+		if (propulsionCanReach("hover01", x, y, startPositions[i].x, startPositions[i].y))
 		{
 			unreachable = false;
 			break;

--- a/data/mp/multiplay/skirmish/rules.js
+++ b/data/mp/multiplay/skirmish/rules.js
@@ -13,8 +13,12 @@ include("multiplay/script/weather.js");
 
 var lastHitTime = 0;
 var cheatmode = false;
-var maxOilDrums = 0;
 var mainReticule = false;
+var oilDrumData = {
+	delay: 0, // time delay to prevent multiple drums from spawning on the same frame
+	lastSpawn: 0, // time of the last successful drum added to the map
+	maxOilDrums: 0 // maximum amount of random oil drums allowed on the map
+};
 
 
 function printGameSettings()
@@ -255,8 +259,8 @@ function eventGameInit()
 	printGameSettings();
 
 	// always at least one oil drum, and one more for every 64x64 tiles of map area
-	maxOilDrums = (mapWidth * mapHeight) >> 12; // replace float division with shift for sync-safety
-	for (var i = 0; i < maxOilDrums; ++i)
+	oilDrumData.maxOilDrums = (mapWidth * mapHeight) >> 12; // replace float division with shift for sync-safety
+	for (var i = 0; i < oilDrumData.maxOilDrums; ++i)
 	{
 		queue("placeOilDrum", 10000 * i);
 	}
@@ -654,7 +658,7 @@ function eventChat(from, to, message)
 function placeOilDrum()
 {
 	var drums = enumFeature(-1, "OilDrum").length;
-	if (drums >= maxOilDrums)
+	if (drums >= oilDrumData.maxOilDrums)
 	{
 		return;
 	}
@@ -662,8 +666,27 @@ function placeOilDrum()
 	var x = syncRandom(mapWidth - 20) + 10;
 	var y = syncRandom(mapHeight - 20) + 10;
 
+	// Don't allow placement of structures onto a potential drum location if a truck
+	// could suddenly built something near it.
+	var nearbyTruck = false;
+	const SCAN_RANGE_TRUCKS = 6;
+	var nearbyObjects = enumRange(x, y, SCAN_RANGE_TRUCKS, ALL_PLAYERS, false);
+	for (var i = 0, len = nearbyObjects.length; i < len; ++i)
+	{
+		var object = nearbyObjects[i];
+		if (object.type === DROID && object.droidType === DROID_CONSTRUCT)
+		{
+			nearbyTruck = true;
+			break;
+		}
+	}
+
+	// scan about the same radius as the biggest game objects in the case a drum
+	// wants to be placed near once. This way the scan should touch the center
+	// tile of the object.
+	const SCAN_RANGE_OCCUPIED = 3;
 	// see if the random position is valid
-	var occupied = (enumRange(x, y, 2, ALL_PLAYERS, false).length > 0);
+	var occupied = (enumRange(x, y, SCAN_RANGE_OCCUPIED, ALL_PLAYERS, false).length > 0);
 	var unreachable = true;
 	for (var i = 0; i < maxPlayers; ++i)
 	{
@@ -673,18 +696,21 @@ function placeOilDrum()
 			break;
 		}
 	}
+
 	var terrain = terrainType(x, y);
 	if (terrain == TER_WATER || terrain == TER_CLIFFFACE)
 	{
 		unreachable = true;
 	}
-	if (occupied || unreachable)
+
+	if (occupied || unreachable || nearbyTruck || (gameTime - oilDrumData.lastSpawn <= 200))
 	{
 		// try again in a different position after 1 second
 		queue("placeOilDrum", 1000);
 		return;
 	}
 
+	oilDrumData.lastSpawn = gameTime;
 	addFeature("OilDrum", x, y);
 }
 
@@ -701,7 +727,12 @@ function eventPickup(feature, droid)
 				break;
 			}
 		}
+		if (oilDrumData.delay > 120000)
+		{
+			oilDrumData.delay = 0;
+		}
+		oilDrumData.delay = oilDrumData.delay + 100;
 		// amounts to 10 minutes average respawn time
-		queue("placeOilDrum", delay * 120000);
+		queue("placeOilDrum", (delay * 120000) + oilDrumData.delay);
 	}
 }


### PR DESCRIPTION
This PR:
1. Prevent multiple oil drums from being added at the same time.
2. Increases the potential spawn position scan up to 3 tiles, from 2, to account for big objects like factories and skyscrapers (with the added bonus that big features are less likely to be magically removed to place the new drum. Thus another harmless warning about placing a feature on a tile already occupied by a feature should be less common, or never happen again).
3. Makes sure a drum is never going to be placed within 6 tiles of a constructor droid. I suspect it's possible to perfectly time placing a structure on the position where the drum would spawn on. So this is an extra precaution.
4. Additionally allows the placement of oil drums on locations accessible only by hover. For example, the islands at the middle sections of SK-Manhattan can now have drums!

Fixes #606 