### PR TITLE
Fix skirmish initialize issue with saves.

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1199,10 +1199,7 @@ bool stageThreeInitialise()
 
 	if (bMultiPlayer)
 	{
-		if (!fromSave)
-		{
-			multiGameInit();
-		}
+		multiGameInit();
 		initTemplates();
 	}
 


### PR DESCRIPTION
AI communication channels (global chat and beacon recognition) were closed when loading saves _after_ exiting the application.

Fixes #593 
Fixes #656 