### PR TITLE
Fix overflowing of negative scores in debug window

### DIFF
--- a/src/multiplay.h
+++ b/src/multiplay.h
@@ -89,7 +89,7 @@ struct MULTIPLAYERINGAME
 #define MPFLAGS_NO_LASSAT	0x10  		///< Flag for Laser Satellite Command Post disabled
 #define MPFLAGS_FORCELIMITS	0x20  		///< Flag to force structure limits
 #define MPFLAGS_MAX		0x3f
-	UDWORD		skScores[MAX_PLAYERS][2];			// score+kills for local skirmish players.
+	SDWORD		skScores[MAX_PLAYERS][2];			// score+kills for local skirmish players.
 	char		phrases[5][255];					// 5 favourite text messages.
 };
 


### PR DESCRIPTION
The scores of skirmish players were stored as UDWORD (a.k.a. uint32_t),
causing an overflow in the debug window when their values were negative:

![skirmish_scores_overflow_old](https://user-images.githubusercontent.com/24465795/75143071-45b54680-56ec-11ea-92ff-1ef42df96792.png)

Use an SDWORD (a.k.a. int32_t) for their storage to solve the problem.
    
The attached ZIP file contains
* screenshots and videos showing the intelligence screen together with
  the "Players" tab of the debug window while losing units in a skirmish
  game, both before and after applying this PR
* a shell script and savegame used to generate them

[skirmish_scores_overflow_documentation.zip](https://github.com/Warzone2100/warzone2100/files/4243939/skirmish_scores_overflow_documentation.zip)