### PR TITLE
Change info message shown when player loses a unit

### DIFF
--- a/src/droid.cpp
+++ b/src/droid.cpp
@@ -244,7 +244,8 @@ int32_t droidDamage(DROID *psDroid, unsigned damage, WEAPON_CLASS weaponClass, W
 		// Deal with score increase/decrease and messages to the player
 		if (psDroid->player == selectedPlayer)
 		{
-			CONPRINTF("%s", _("Unit Lost!"));
+			// TRANSLATORS:	Refers to the loss of a single unit, known by its name
+			CONPRINTF(_("%s Lost!"), objInfo(psDroid));
 			scoreUpdateVar(WD_UNITS_LOST);
 			audio_QueueTrackMinDelayPos(ID_SOUND_UNIT_DESTROYED, UNIT_LOST_DELAY,
 			                            psDroid->pos.x, psDroid->pos.y, psDroid->pos.z);


### PR DESCRIPTION
The translatable message shown when a player loses a unit has changed.
Showing the name of the most recent casualty should reduce confusion:

![unit_lost_message_new](https://user-images.githubusercontent.com/24465795/75143433-f0c60000-56ec-11ea-897b-8eb8b4a842f8.png)

The attached ZIP file contains
* screenshots showing the message after losing a unit in Alpha 1, both
  before and after applying this PR
* a savegame showing a unit in Alpha 1 before its imminent destruction
* a shell script used to generate the screenshots from the savegame

[unit_lost_message_documentation.zip](https://github.com/Warzone2100/warzone2100/files/4243967/unit_lost_message_documentation.zip)