### PR TITLE
Change keyboard shortcut "Select Similar Units"

### DIFF
--- a/doc/quickstartguide.asciidoc
+++ b/doc/quickstartguide.asciidoc
@@ -1109,8 +1109,8 @@ Unit selection by type
 ~~~~~~~~~~~~~~~~~~~~~~
 |====
 |Ctrl+U       |Select all units
-|Ctrl+Z       |Select all similar units
-|double-click |Select all similar units
+|Ctrl+Z       |Select all units with the same components
+|double-click |Select all units with the same components
 |Ctrl+S       |Select all units on screen
 |Ctrl+D       |Select all heavily damaged units
 |Ctrl+A       |Select all attack units (units with weapons)

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -2009,17 +2009,8 @@ static void dealWithLMBDClick()
 			psDroid = (DROID *) psClickedOn;
 			if (psDroid->player == selectedPlayer)
 			{
-				/* If we've double clicked on a constructor droid, activate build menu */
-				if (psDroid->droidType == DROID_COMMAND)
-				{
-					intResetScreen(true);
-					intCommanderSelected(psDroid);
-				}
-				else
-				{
-					// Now selects all of same type on screen
-					selDroidSelection(selectedPlayer, DS_BY_TYPE, DST_ALL_SAME, true);
-				}
+				// Now selects all of same type on screen
+				selDroidSelection(selectedPlayer, DS_BY_TYPE, DST_ALL_SAME, true);
 			}
 		}
 		else if (psClickedOn->type == OBJ_STRUCTURE)

--- a/src/hci.cpp
+++ b/src/hci.cpp
@@ -2391,14 +2391,6 @@ void intConstructorSelected(DROID *psDroid)
 	widgHide(psWScreen, IDOBJ_FORM);
 }
 
-// add the construction interface if a constructor droid is selected
-void intCommanderSelected(DROID *psDroid)
-{
-	setWidgetsStatus(true);
-	intAddCommand(psDroid);
-	widgHide(psWScreen, IDOBJ_FORM);
-}
-
 /* Start looking for a structure location */
 static void intStartStructPosition(BASE_STATS *psStats)
 {

--- a/src/hci.h
+++ b/src/hci.h
@@ -331,9 +331,6 @@ bool intBuildSelectMode();
 bool intDemolishSelectMode();
 bool intBuildMode();
 
-/* add the construction interface if a constructor droid is selected */
-void intCommanderSelected(DROID *psDroid);
-
 //sets up the Intelligence Screen as far as the interface is concerned
 void addIntelScreen();
 

--- a/src/keymap.cpp
+++ b/src/keymap.cpp
@@ -430,7 +430,7 @@ void keyInitMappings(bool bForceDefaults)
 	keyAddMapping(KEYMAP_ASSIGNABLE, KEY_LSHIFT, KEY_V, KEYMAP_PRESSED, kf_SelectAllArmedVTOLs,   N_("Select all fully-armed VTOLs"));
 	keyAddMapping(KEYMAP_ASSIGNABLE, KEY_LCTRL, KEY_W, KEYMAP_PRESSED, kf_SelectAllWheeled,       N_("Select all Wheels"));
 	keyAddMapping(KEYMAP__DEBUG,     KEY_LCTRL, KEY_Y, KEYMAP_PRESSED, kf_FrameRate,              N_("Show frame rate"));
-	keyAddMapping(KEYMAP_ASSIGNABLE, KEY_LCTRL, KEY_Z, KEYMAP_PRESSED, kf_SelectAllSameType,      N_("Select all Similar Units"));
+	keyAddMapping(KEYMAP_ASSIGNABLE, KEY_LCTRL, KEY_Z, KEYMAP_PRESSED, kf_SelectAllSameType,      N_("Select all units with the same components"));
 	//                                **********************************
 	//                                **********************************
 	//                                                              In game mappings - COMBO (SHIFT + LETTER) presses.

--- a/tools/guidecode/guide.inc.php
+++ b/tools/guidecode/guide.inc.php
@@ -1270,8 +1270,8 @@ These are the default keyboard shortcuts. If you have customized your key mappin
 <h4 id="type">By type</h4>
 <table class="list">
 <tr><th><kbd class="lkey">Ctrl</kbd>+<kbd>U</kbd></th><td>Select all <u>u</u>nits</td></tr>
-<tr><th><kbd class="lkey">Ctrl</kbd>+<kbd>Z</kbd></th><td>Select all similar units</tr>
-<tr><th><span class="dblclick"><span class="click">double-click</span></span></th><td>Select all similar units</tr>
+<tr><th><kbd class="lkey">Ctrl</kbd>+<kbd>Z</kbd></th><td>Select all units with the same components</tr>
+<tr><th><span class="dblclick"><span class="click">double-click</span></span></th><td>Select all units with the same components</tr>
 <tr><th><kbd class="lkey">Ctrl</kbd>+<kbd>S</kbd></th><td>Select all units on <u>s</u>creen</td></tr>
 <tr><th><kbd class="lkey">Ctrl</kbd>+<kbd>D</kbd></th><td>Select all heavily <u>d</u>amaged units</td></tr>
 <tr><th><kbd class="lkey">Ctrl</kbd>+<kbd>A</kbd></th><td>Select all <u>a</u>ttack units (units with weapons)</td></tr>


### PR DESCRIPTION
When double-clicking on a unit or pressing Ctrl-Z, select units with the
same components rather than the same name.

This prevents unwanted surprises because units can have unusual names
that fail to list their components and were not chosen by their owner.

In multiplayer games, players can receive units with incomprehensible
names if the allies who transfer them use a different language.
Obviously, savegames created and shared by them would also contain such
unhelpful unit names like "Aerobarco Caminhão Cobra".

At several points in the campaign, players receive reinforcements that
use many different components but are all named "Reinforcement". Beta 1
for instance begins with such reinforcements. Similarly, at the start of
a new Gamma campaign, all units thus have the same name. As can be seen
in the screenshot below, this is undesirable given how much they differ:

![select_reinforcements_old](https://user-images.githubusercontent.com/24465795/75143703-75188300-56ed-11ea-8a9f-170e4eae6539.png)

Hydra tanks whose components are identical except for the weapon used by
their second turret always have the same name (note that if the second
turret is not used, their names do not contain the word "Hydra"). For
example, the selected units in the screenshot below are both called
"Twin Assault Cannon Hydra Dragon Hover":

![select_hydras_old](https://user-images.githubusercontent.com/24465795/75143713-7a75cd80-56ed-11ea-8978-85c313c7f817.png)

When double-clicking on commanders, their unit order panel was opened
instead of selecting other commanders. Why this odd exception was ever
introduced is a mystery since selecting commanders via Ctrl-Z works as
usual. Thus, the quirk shown in the screenshot below has been removed:

![select_commanders_old](https://user-images.githubusercontent.com/24465795/75143731-806bae80-56ed-11ea-9fc3-cdba23a8a1e1.png)

The word "similar" is quite vague. Therefore, the keyboard shortcut
"Select Similar Units" has been renamed to "Select all units with the
same components". This requires a translation upgrade. Remember that you
need a new keymap.json file in your configuration directory to see the
new name in the key mappings screen. Because it shows key mappings in
alphabetical order, the keyboard shortcut is now found in tab no. 5:

![keyboard_shortcut_new](https://user-images.githubusercontent.com/24465795/75143786-97120580-56ed-11ea-8d22-b033741a394e.png)

The attached ZIP file contains
* screenshots and videos to test whether
  * a keyboard shortcut to select similar units is shown in tab no. 4
    and named "Select Similar Units" (old behavior) or tab no. 5 and
    named "Select all units with the same components" (new behavior) of
    the key mappings screen
  * double-clicking on a commander will open its unit order panel (old
    behavior) or select all commanders on the screen (new behavior)
  * Hydra tanks can be distinguished from each other when the only
    difference between them is their second weapon turret (both tanks
    must have 2 turrets)
  * reinforcement tanks received at the start of a new Gamma campaign
    can be distinguished from each other (despite sharing the same name)
* a shell script and savegames used to generate them

[select_similar_units_documentation.zip](https://github.com/Warzone2100/warzone2100/files/4243994/select_similar_units_documentation.zip)
