### PR TITLE
Potentially fix in-game keymap ghosting the win/loss multiplayer widgets

### DIFF
--- a/src/ingameop.cpp
+++ b/src/ingameop.cpp
@@ -399,9 +399,15 @@ void intCloseInGameOptionsNoAnim(bool bResetMissionWidgets)
 // ////////////////////////////////////////////////////////////////////////////
 bool intCloseInGameOptions(bool bPutUpLoadSave, bool bResetMissionWidgets)
 {
+	bool keymapWasUp = isKeyMapEditorUp;
+
 	isGraphicsOptionsUp = false;
 	isVideoOptionsUp = false;
 	isMouseOptionsUp = false;
+	if (isKeyMapEditorUp)
+	{
+		runInGameKeyMapEditor(KM_RETURN);
+	}
 	isKeyMapEditorUp = false;
 
 	if (NetPlay.isHost)
@@ -409,7 +415,7 @@ bool intCloseInGameOptions(bool bPutUpLoadSave, bool bResetMissionWidgets)
 		widgDelete(psWScreen, INTINGAMEPOPUP);
 	}
 
-	if (bPutUpLoadSave)
+	if (bPutUpLoadSave || keymapWasUp)
 	{
 		WIDGET *widg = widgGetFromID(psWScreen, INTINGAMEOP);
 		if (widg)
@@ -419,7 +425,7 @@ bool intCloseInGameOptions(bool bPutUpLoadSave, bool bResetMissionWidgets)
 
 		InGameOpUp = false;
 	}
-	else
+	if (!bPutUpLoadSave || keymapWasUp)
 	{
 		// close the form.
 		// Start the window close animation.

--- a/src/keyedit.cpp
+++ b/src/keyedit.cpp
@@ -52,10 +52,6 @@
 // ////////////////////////////////////////////////////////////////////////////
 // defines
 
-#define KM_FORM				10200
-#define KM_RETURN			10202
-#define KM_DEFAULT			10203
-
 #define	KM_START			10204
 #define	KM_END				10399
 

--- a/src/keyedit.cpp
+++ b/src/keyedit.cpp
@@ -370,7 +370,7 @@ static bool keyMapEditor(bool first, WIDGET *parent, bool ingame)
 	{
 		// Text versions for in-game where image resources are not available
 		kmForm->setCalcLayout(LAMBDA_CALCLAYOUT_SIMPLE({
-			psWidget->setGeometry(((300-(KM_W/2))+D_W), ((240-(KM_H/2))+D_H), KM_W, KM_H);
+			psWidget->setGeometry(((300-(KM_W/2))+D_W), ((240-(KM_H/2))+D_H), KM_W, KM_H + 10);
 				}));
 
 		W_BUTINIT sButInit;
@@ -398,7 +398,7 @@ static bool keyMapEditor(bool first, WIDGET *parent, bool ingame)
 		if (!(bMultiPlayer && NetPlay.bComms != 0)) // no editing in true multiplayer
 		{
 			sButInit.id			= KM_DEFAULT;
-			sButInit.y			= KM_H - 16;
+			sButInit.y			= KM_H - 8;
 			sButInit.pText		= _("Select Default");
 
 			widgAddButton(psWScreen, &sButInit);

--- a/src/keyedit.h
+++ b/src/keyedit.h
@@ -21,6 +21,10 @@
 #ifndef __INCLUDED_SRC_KEYEDIT_H__
 #define __INCLUDED_SRC_KEYEDIT_H__
 
+#define KM_FORM			10200
+#define KM_RETURN			10202
+#define KM_DEFAULT			10203
+
 bool runKeyMapEditor();
 bool runInGameKeyMapEditor(unsigned id);
 bool startKeyMapEditor(bool first);


### PR DESCRIPTION
I'm a noob with anything GUI here but this "just works" and doesn't force players to exit the application if they had the in-game keymap menu open during a multiplayer win/loss. I can't say I know how to fix this properly so if this is wrong somebody else will need to deal with that issue.

Also spaced out the text buttons a little.

Closes #663 