### PR TITLE
OpenAL improvements

### DIFF
--- a/configure_mac.cmake
+++ b/configure_mac.cmake
@@ -11,7 +11,7 @@ cmake_minimum_required(VERSION 3.5)
 set(VCPKG_COMMIT_SHA "5c415ff8a0aad831ee90ee4327f26992d5fe3fb3")
 
 # WZ macOS dependencies (for vcpkg install)
-set(VCPKG_INSTALL_DEPENDENCIES physfs harfbuzz libogg libtheora libvorbis libpng sdl2 glew freetype gettext zlib)
+set(VCPKG_INSTALL_DEPENDENCIES physfs harfbuzz libogg libtheora libvorbis libpng sdl2 glew freetype gettext zlib openal-soft)
 
 # WZ minimum supported macOS deployment target (this is 10.10 because of Qt 5.9.x)
 set(MIN_SUPPORTED_MACOSX_DEPLOYMENT_TARGET "10.10")

--- a/lib/sequence/sequence.cpp
+++ b/lib/sequence/sequence.cpp
@@ -76,11 +76,7 @@
 #include <physfs.h>
 
 #include <vorbis/codec.h>
-#if defined(WZ_OS_MAC)
-#include <OpenAL/al.h>
-#else
 #include <AL/al.h>
-#endif
 
 #include "lib/framework/physfs_ext.h"
 

--- a/lib/sound/CMakeLists.txt
+++ b/lib/sound/CMakeLists.txt
@@ -4,7 +4,24 @@ file(GLOB HEADERS "*.h")
 file(GLOB SRC "*.cpp")
 
 find_package(OpenAL REQUIRED)
+# Since FindOpenAL.cmake may not define an imported target, do it here
+if (NOT TARGET OpenAL::OpenAL)
+	add_library(OpenAL::OpenAL UNKNOWN IMPORTED)
+	set_target_properties(OpenAL::OpenAL PROPERTIES
+	  INTERFACE_INCLUDE_DIRECTORIES ${OPENAL_INCLUDE_DIR}
+	  IMPORTED_LOCATION ${OPENAL_LIBRARY}
+	)
+endif()
 find_package(OggVorbis REQUIRED)
+
+INCLUDE(CMakePushCheckState)
+INCLUDE(CheckIncludeFileCXX)
+get_target_property(_openal_includes OpenAL::OpenAL INTERFACE_INCLUDE_DIRECTORIES)
+cmake_push_check_state(RESET)
+set(CMAKE_REQUIRED_INCLUDES ${_openal_includes})
+message(STATUS "OpenAL INTERFACE_INCLUDE_DIRECTORIES = \"${_openal_includes}\"")
+CHECK_INCLUDE_FILE_CXX("AL/alext.h" HAVE_OPENAL_ALEXT_H)
+cmake_pop_check_state()
 
 add_library(sound ${HEADERS} ${SRC})
 set_property(TARGET sound PROPERTY FOLDER "lib")
@@ -12,5 +29,8 @@ if(WZ_TARGET_ADDITIONAL_PROPERTIES)
 	SET_TARGET_PROPERTIES(sound PROPERTIES ${WZ_TARGET_ADDITIONAL_PROPERTIES})
 endif()
 target_compile_definitions(sound PRIVATE "-DAL_LIBTYPE_STATIC")
-target_include_directories(sound PRIVATE "${OPENAL_INCLUDE_DIR}" "${OGGVORBIS_INCLUDE_DIR}")
-target_link_libraries(sound PRIVATE framework ${OPENAL_LIBRARY} ${OGGVORBIS_LIBRARIES})
+if (HAVE_OPENAL_ALEXT_H)
+	target_compile_definitions(sound PRIVATE "-DHAVE_OPENAL_ALEXT_H")
+endif()
+target_include_directories(sound PRIVATE "${OGGVORBIS_INCLUDE_DIR}")
+target_link_libraries(sound PRIVATE framework OpenAL::OpenAL ${OGGVORBIS_LIBRARIES})

--- a/lib/sound/CMakeLists.txt
+++ b/lib/sound/CMakeLists.txt
@@ -3,14 +3,22 @@ cmake_minimum_required (VERSION 3.5)
 file(GLOB HEADERS "*.h")
 file(GLOB SRC "*.cpp")
 
-find_package(OpenAL REQUIRED)
-# Since FindOpenAL.cmake may not define an imported target, do it here
+set(_openal_config_required)
+if(CMAKE_SYSTEM_NAME MATCHES "Darwin")
+	# CONFIG mode should be REQUIRED (to avoid the deprecated OpenAL.framework)
+	set(_openal_config_required REQUIRED)
+endif()
+find_package(OpenAL CONFIG ${_openal_config_required}) # explicitly try via CONFIG mode first
 if (NOT TARGET OpenAL::OpenAL)
-	add_library(OpenAL::OpenAL UNKNOWN IMPORTED)
-	set_target_properties(OpenAL::OpenAL PROPERTIES
-	  INTERFACE_INCLUDE_DIRECTORIES ${OPENAL_INCLUDE_DIR}
-	  IMPORTED_LOCATION ${OPENAL_LIBRARY}
-	)
+	find_package(OpenAL MODULE REQUIRED)
+	# Since FindOpenAL.cmake may not define an imported target, do it here
+	if (NOT TARGET OpenAL::OpenAL)
+		add_library(OpenAL::OpenAL UNKNOWN IMPORTED)
+		set_target_properties(OpenAL::OpenAL PROPERTIES
+		  INTERFACE_INCLUDE_DIRECTORIES ${OPENAL_INCLUDE_DIR}
+		  IMPORTED_LOCATION ${OPENAL_LIBRARY}
+		)
+	endif()
 endif()
 find_package(OggVorbis REQUIRED)
 

--- a/lib/sound/audio.cpp
+++ b/lib/sound/audio.cpp
@@ -96,7 +96,7 @@ bool audio_Disabled(void)
 // =======================================================================================================================
 // =======================================================================================================================
 //
-bool audio_Init(AUDIO_CALLBACK pStopTrackCallback, bool really_enable)
+bool audio_Init(AUDIO_CALLBACK pStopTrackCallback, HRTFMode hrtf, bool really_enable)
 {
 	// init audio system
 	g_sPreviousSample.iTrack = NO_SAMPLE;
@@ -106,7 +106,7 @@ bool audio_Init(AUDIO_CALLBACK pStopTrackCallback, bool really_enable)
 	g_bAudioEnabled = really_enable;
 	if (g_bAudioEnabled)
 	{
-		g_bAudioEnabled = sound_Init();
+		g_bAudioEnabled = sound_Init(hrtf);
 	}
 	if (g_bAudioEnabled)
 	{

--- a/lib/sound/audio.h
+++ b/lib/sound/audio.h
@@ -22,8 +22,9 @@
 #define __INCLUDED_LIB_SOUND_AUDIO_H__
 
 #include "track.h"
+#include "sounddefs.h"
 
-bool audio_Init(AUDIO_CALLBACK pStopTrackCallback, bool really_init);
+bool audio_Init(AUDIO_CALLBACK pStopTrackCallback, HRTFMode hrtf, bool really_init);
 void audio_Update();
 bool audio_Shutdown();
 bool audio_Disabled();

--- a/lib/sound/openal_error.cpp
+++ b/lib/sound/openal_error.cpp
@@ -23,13 +23,8 @@
 
 #include "lib/framework/stdio_ext.h"
 
-#ifdef WZ_OS_MAC
-# include <OpenAL/al.h>
-# include <OpenAL/alc.h>
-#else
-# include <AL/al.h>
-# include <AL/alc.h>
-#endif
+#include <AL/al.h>
+#include <AL/alc.h>
 
 ALenum __sound_GetError(const char *location_description)
 {

--- a/lib/sound/openal_error.h
+++ b/lib/sound/openal_error.h
@@ -23,13 +23,8 @@
 
 #include "lib/framework/frame.h"
 
-#ifdef WZ_OS_MAC
-# include <OpenAL/al.h>
-# include <OpenAL/alc.h>
-#else
-# include <AL/al.h>
-# include <AL/alc.h>
-#endif
+#include <AL/al.h>
+#include <AL/alc.h>
 
 ALenum __sound_GetError(const char *location_description);
 ALenum __sound_GetContextError(ALCdevice *device, const char *location_description);

--- a/lib/sound/openal_info.cpp
+++ b/lib/sound/openal_info.cpp
@@ -206,6 +206,13 @@ void OpenALInfo::Output_ALCInfo(ALCdevice *device, const outputHandlerFuncType& 
 	{
 		buf << "ALC extensions:" << printList(alcGetString(device, ALC_EXTENSIONS), ' ') << "\n";
 		checkALCErrors(buf, device);
+
+		ALCint srate;
+		alcGetIntegerv(device, ALC_FREQUENCY, 1, &srate);
+		buf << "Output frequency: " << srate << " Hz \n";
+
+		alcGetIntegerv(device, ALC_REFRESH, 1, &srate);
+		buf << "Update rate: " << srate << " Hz \n";
 	}
 
 	if (outputHandler)

--- a/lib/sound/openal_info.cpp
+++ b/lib/sound/openal_info.cpp
@@ -29,13 +29,8 @@
 #include "lib/framework/frame.h"
 #include "openal_info.h"
 
-#ifdef WZ_OS_MAC
-# include <OpenAL/al.h>
-# include <OpenAL/alc.h>
-#else
-# include <AL/al.h>
-# include <AL/alc.h>
-#endif
+#include <AL/al.h>
+#include <AL/alc.h>
 
 #include <sstream>
 #include <iomanip>

--- a/lib/sound/openal_info.h
+++ b/lib/sound/openal_info.h
@@ -33,13 +33,8 @@
 
 #include "lib/framework/frame.h"
 
-#ifdef WZ_OS_MAC
-# include <OpenAL/al.h>
-# include <OpenAL/alc.h>
-#else
-# include <AL/al.h>
-# include <AL/alc.h>
-#endif
+#include <AL/al.h>
+#include <AL/alc.h>
 
 #include <functional>
 #include <string>

--- a/lib/sound/openal_track.cpp
+++ b/lib/sound/openal_track.cpp
@@ -27,15 +27,10 @@
 #include "lib/framework/frameresource.h"
 #include "lib/exceptionhandler/dumpinfo.h"
 
-#ifdef WZ_OS_MAC
-#include <OpenAL/al.h>
-#include <OpenAL/alc.h>
-#else
 #include <AL/al.h>
 #include <AL/alc.h>
-# if defined(HAVE_OPENAL_ALEXT_H)
-#  include <AL/alext.h>
-# endif
+#if defined(HAVE_OPENAL_ALEXT_H)
+# include <AL/alext.h>
 #endif
 
 #include <physfs.h>

--- a/lib/sound/sounddefs.h
+++ b/lib/sound/sounddefs.h
@@ -1,0 +1,38 @@
+/*
+	This file is part of Warzone 2100.
+	Copyright (C) 1999-2004  Eidos Interactive
+	Copyright (C) 2005-2020  Warzone 2100 Project
+
+	Warzone 2100 is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+
+	Warzone 2100 is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with Warzone 2100; if not, write to the Free Software
+	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+/** \file
+ *  Some type definitions needed outside the sound library
+ */
+
+#ifndef __INCLUDED_LIB_SOUND_SOUNDDEFS_H__
+#define __INCLUDED_LIB_SOUND_SOUNDDEFS_H__
+
+enum class HRTFMode : int
+{
+	Unsupported = -1,
+	Disabled = 0,
+	Enabled = 1,
+	Auto = 2 // Can be used for setting - will never be returned by sound_GetHRTFMode
+};
+
+#define MIN_VALID_HRTFMode HRTFMode::Disabled
+#define MAX_VALID_HRTFMode HRTFMode::Auto
+
+#endif	// __INCLUDED_LIB_SOUND_SOUNDDEFS_H__

--- a/lib/sound/track.cpp
+++ b/lib/sound/track.cpp
@@ -46,10 +46,10 @@ static AUDIO_CALLBACK	g_pStopTrackCallback = nullptr;
 // =======================================================================================================================
 // =======================================================================================================================
 //
-bool sound_Init()
+bool sound_Init(HRTFMode hrtf)
 {
 	g_iCurTracks = 0;
-	if (!sound_InitLibrary())
+	if (!sound_InitLibrary(hrtf))
 	{
 		debug(LOG_ERROR, "Cannot init sound library");
 		return false;

--- a/lib/sound/track.h
+++ b/lib/sound/track.h
@@ -24,11 +24,7 @@
 #include "lib/framework/frame.h"
 #include <physfs.h>
 
-#ifdef WZ_OS_MAC
-#include <OpenAL/al.h>
-#else
 #include <AL/al.h>
-#endif
 
 #define ATTENUATION_FACTOR	0.0003f
 

--- a/lib/sound/track.h
+++ b/lib/sound/track.h
@@ -23,6 +23,7 @@
 
 #include "lib/framework/frame.h"
 #include <physfs.h>
+#include "sounddefs.h"
 
 #include <AL/al.h>
 
@@ -77,7 +78,7 @@ struct TRACK
 /* functions
  */
 
-bool	sound_Init();
+bool	sound_Init(HRTFMode hrtf);
 bool	sound_Shutdown();
 
 TRACK 	*sound_LoadTrackFromFile(const char *fileName);

--- a/lib/sound/tracklib.h
+++ b/lib/sound/tracklib.h
@@ -27,9 +27,13 @@
 
 #include "track.h"
 #include "lib/framework/vector.h"
+#include "sounddefs.h"
 
-bool	sound_InitLibrary();
+bool	sound_InitLibrary(HRTFMode hrtf);
 void	sound_ShutdownLibrary();
+
+HRTFMode	sound_GetHRTFMode();
+bool	sound_SetHRTFMode(HRTFMode mode);
 
 void	sound_FreeTrack(TRACK *psTrack);
 

--- a/src/configuration.cpp
+++ b/src/configuration.cpp
@@ -38,6 +38,7 @@
 #include "lib/framework/input.h"
 #include "lib/netplay/netplay.h"
 #include "lib/sound/mixer.h"
+#include "lib/sound/sounddefs.h"
 #include "lib/ivis_opengl/screen.h"
 #include "lib/framework/opengl.h"
 #include "lib/ivis_opengl/pieclip.h"
@@ -55,6 +56,8 @@
 #include "texture.h"
 #include "warzoneconfig.h"
 #include "titleui/titleui.h"
+
+#include <type_traits>
 
 // ////////////////////////////////////////////////////////////////////////////
 
@@ -88,6 +91,14 @@ bool loadConfig()
 	if (ini.contains("music_enabled"))
 	{
 		war_SetMusicEnabled(ini.value("music_enabled").toBool());
+	}
+	if (ini.contains("hrtf"))
+	{
+		int hrtfmode_int = ini.value("hrtf").toInt();
+		if (hrtfmode_int >= static_cast<int>(MIN_VALID_HRTFMode) && hrtfmode_int <= static_cast<int>(MAX_VALID_HRTFMode))
+		{
+			war_SetHRTFMode(static_cast<HRTFMode>(hrtfmode_int));
+		}
 	}
 	if (ini.contains("mapZoom"))
 	{
@@ -241,6 +252,7 @@ bool saveConfig()
 	ini.setValue("fxvol", (int)(sound_GetEffectsVolume() * 100.0));
 	ini.setValue("cdvol", (int)(sound_GetMusicVolume() * 100.0));
 	ini.setValue("music_enabled", war_GetMusicEnabled());
+	ini.setValue("hrtf", static_cast<typename std::underlying_type<HRTFMode>::type>(war_GetHRTFMode()));
 	ini.setValue("mapZoom", war_GetMapZoom());
 	ini.setValue("mapZoomRate", war_GetMapZoomRate());
 	ini.setValue("radarZoom", war_GetRadarZoom());

--- a/src/frontend.h
+++ b/src/frontend.h
@@ -256,12 +256,14 @@ enum
 	FRONTEND_3D_FX,						// 3d sound volume
 	FRONTEND_FX,						// 2d (voice) sound volume
 	FRONTEND_MUSIC,						// music volume
+	FRONTEND_SOUND_HRTF,				// HRTF mode
 	FRONTEND_MAP_ZOOM,					// map zoom
 	FRONTEND_MAP_ZOOM_RATE,					// map zoom rate
 	FRONTEND_RADAR_ZOOM,					// radar zoom rate
 	FRONTEND_3D_FX_SL,
 	FRONTEND_FX_SL,
 	FRONTEND_MUSIC_SL,
+	FRONTEND_SOUND_HRTF_R,
 	FRONTEND_MAP_ZOOM_R,
 	FRONTEND_MAP_ZOOM_RATE_R,
 	FRONTEND_RADAR_ZOOM_R,

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -694,7 +694,7 @@ bool systemInitialise(float horizScaleFactor, float vertScaleFactor)
 		return false;
 	}
 
-	if (!audio_Init(droidAudioTrackStopped, war_getSoundEnabled()))
+	if (!audio_Init(droidAudioTrackStopped, war_GetHRTFMode(), war_getSoundEnabled()))
 	{
 		debug(LOG_SOUND, "Continuing without audio");
 	}

--- a/src/warzoneconfig.cpp
+++ b/src/warzoneconfig.cpp
@@ -27,6 +27,7 @@
 #include "warzoneconfig.h"
 #include "lib/ivis_opengl/piestate.h"
 #include "lib/ivis_opengl/piepalette.h"
+#include "lib/sound/sounddefs.h"
 #include "advvis.h"
 #include "component.h"
 #include "display.h"
@@ -52,6 +53,7 @@ struct WARZONE_GLOBALS
 	bool pauseOnFocusLoss = true;
 	bool ColouredCursor = true;
 	bool MusicEnabled = true;
+	HRTFMode hrtfMode = HRTFMode::Auto;
 	int mapZoom = STARTDISTANCE;
 	int mapZoomRate = MAP_ZOOM_RATE_DEFAULT;
 	int radarZoom = DEFAULT_RADARZOOM;
@@ -238,6 +240,16 @@ bool war_GetMusicEnabled()
 void war_SetMusicEnabled(bool enabled)
 {
 	warGlobs.MusicEnabled = enabled;
+}
+
+HRTFMode war_GetHRTFMode()
+{
+	return warGlobs.hrtfMode;
+}
+
+void war_SetHRTFMode(HRTFMode mode)
+{
+	warGlobs.hrtfMode = mode;
 }
 
 int war_GetMapZoom()

--- a/src/warzoneconfig.h
+++ b/src/warzoneconfig.h
@@ -26,6 +26,7 @@
 
 #include "lib/framework/frame.h"
 #include "lib/sequence/sequence.h"
+#include "lib/sound/sounddefs.h"
 
 #define	CAMERASPEED_MAX		(5000)
 #define	CAMERASPEED_MIN		(100)
@@ -77,6 +78,8 @@ void war_SetPauseOnFocusLoss(bool enabled);
 bool war_GetPauseOnFocusLoss();
 bool war_GetMusicEnabled();
 void war_SetMusicEnabled(bool enabled);
+HRTFMode war_GetHRTFMode();
+void war_SetHRTFMode(HRTFMode mode);
 int war_GetMapZoom();
 void war_SetMapZoom(int mapZoom);
 int war_GetMapZoomRate();


### PR DESCRIPTION
- Output more OpenAL device info
- Output OpenAL-Soft HRTF status
- [CMake] macOS: Use OpenAL-Soft
   - Avoid the deprecated `OpenAL.framework`
- Support configuration of OpenAL-Soft HRTF mode
   - HRTF status may depend on OpenAL-Soft version / backend / devices / configuration files, but overrides may be desirable. This adds the ability to view HRTF status (to the "Audio / Zoom Options" menu) and to change between Disabled / Enabled / Auto mode (where supported).