### PR TITLE
[Azure Pipelines] Fix vcpkg build errors on runners

### DIFF
--- a/.ci/azure/templates/macos-build-pipeline-template.yml
+++ b/.ci/azure/templates/macos-build-pipeline-template.yml
@@ -57,13 +57,6 @@ jobs:
         gem install asciidoctor -v 2.0.10 --no-document
         cmake --version
   - task: CmdLine@2
-    displayName: Set Xcode toolchain / version
-    condition: ne('${{ parameters.xcodeDeveloperDir }}', 'default')
-    inputs:
-      script: |
-        # Set default Xcode for all following commands (configure script, build, etc)
-        sudo xcode-select -switch ${DESIRED_XCODE_DEV_DIR}
-  - task: CmdLine@2
     displayName: configure_mac.cmake
     inputs:
       script: |
@@ -72,13 +65,13 @@ jobs:
         echo "AGENT_BUILDDIRECTORY=${AGENT_BUILDDIRECTORY}"
 
         cd "${AGENT_BUILDDIRECTORY}"
-      
+
         # Delete any prior build dir, create a fresh one
         rm -rf build
         if [ ! -d "build" ]; then
         	mkdir build
         fi
-      
+
         # configure_mac.cmake (gets dependencies, configures CMake)
         cd build
         WZ_DISTRIBUTOR="UNKNOWN"
@@ -86,9 +79,23 @@ jobs:
         	# Building from main repo - set distributor
         	WZ_DISTRIBUTOR="wz2100.net"
         fi
-        echo "cmake -DVCPKG_BUILD_TYPE=release -DWZ_DISTRIBUTOR:STRING=\"${WZ_DISTRIBUTOR}\" -DADDITIONAL_CMAKE_ARGUMENTS=\"-DCMAKE_XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY=;-DCODE_SIGN_INJECT_BASE_ENTITLEMENTS=NO\" -P ../configure_mac.cmake"
+
         echo "Current directory: $(pwd)"
-        cmake -DVCPKG_BUILD_TYPE=release -DWZ_DISTRIBUTOR:STRING="${WZ_DISTRIBUTOR}" -DADDITIONAL_CMAKE_ARGUMENTS="-DCMAKE_XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY=;-DCMAKE_XCODE_ATTRIBUTE_CODE_SIGN_INJECT_BASE_ENTITLEMENTS=NO" -P ../src/configure_mac.cmake
+        ADDITIONAL_CONFIGURE_ARGS=""
+        if [ "${DESIRED_XCODE_DEV_DIR}" != "default" ]; then
+          # Need to run configure_mac script twice
+
+          echo "Run configure_mac to just build vcpkg (with system default Xcode)"
+          ADDITIONAL_CONFIGURE_ARGS="-DONLY_BUILD_VCPKG=true"
+          echo "cmake ${ADDITIONAL_CONFIGURE_ARGS} -DVCPKG_BUILD_TYPE=release -DWZ_DISTRIBUTOR:STRING=\"${WZ_DISTRIBUTOR}\" -DADDITIONAL_CMAKE_ARGUMENTS=\"-DCMAKE_XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY=;-DCODE_SIGN_INJECT_BASE_ENTITLEMENTS=NO\" -P ../configure_mac.cmake"
+          cmake ${ADDITIONAL_CONFIGURE_ARGS} -DVCPKG_BUILD_TYPE=release -DWZ_DISTRIBUTOR:STRING="${WZ_DISTRIBUTOR}" -DADDITIONAL_CMAKE_ARGUMENTS="-DCMAKE_XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY=;-DCMAKE_XCODE_ATTRIBUTE_CODE_SIGN_INJECT_BASE_ENTITLEMENTS=NO" -P ../src/configure_mac.cmake
+
+          echo "Switching Xcode: ${DESIRED_XCODE_DEV_DIR}"
+          sudo xcode-select -switch "${DESIRED_XCODE_DEV_DIR}"
+          ADDITIONAL_CONFIGURE_ARGS="-DSKIP_VCPKG_BUILD=true"
+        fi
+        echo "cmake ${ADDITIONAL_CONFIGURE_ARGS} -DVCPKG_BUILD_TYPE=release -DWZ_DISTRIBUTOR:STRING=\"${WZ_DISTRIBUTOR}\" -DADDITIONAL_CMAKE_ARGUMENTS=\"-DCMAKE_XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY=;-DCODE_SIGN_INJECT_BASE_ENTITLEMENTS=NO\" -P ../configure_mac.cmake"
+        cmake ${ADDITIONAL_CONFIGURE_ARGS} -DVCPKG_BUILD_TYPE=release -DWZ_DISTRIBUTOR:STRING="${WZ_DISTRIBUTOR}" -DADDITIONAL_CMAKE_ARGUMENTS="-DCMAKE_XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY=;-DCMAKE_XCODE_ATTRIBUTE_CODE_SIGN_INJECT_BASE_ENTITLEMENTS=NO" -P ../src/configure_mac.cmake
         result=${?}
         if [ $result -ne 0 ]; then
         	echo "ERROR: configure_mac.cmake failed"
@@ -112,9 +119,9 @@ jobs:
         cd "${AGENT_BUILDDIRECTORY}"
         echo "BUILD_ARTIFACTSTAGINGDIRECTORY=${BUILD_ARTIFACTSTAGINGDIRECTORY}"
         OUTPUT_DIR="${BUILD_ARTIFACTSTAGINGDIRECTORY}"
-      
+
         cat "build/src/autorevision.h"
-      
+
         # Verify "warzone2100.zip" was created
         BUILT_WARZONE_ZIP="build/warzone2100.zip"
         if [ ! -f "${BUILT_WARZONE_ZIP}" ]; then
@@ -152,7 +159,7 @@ jobs:
           echo "     (No output?)"
         fi
         cd - > /dev/null
-      
+
         # Move warzone2100.zip to the output directory, renaming it
         DESIRED_ZIP_NAME="warzone2100_macOS.zip"
         mv "$BUILT_WARZONE_ZIP" "${OUTPUT_DIR}/${DESIRED_ZIP_NAME}"

--- a/configure_mac.cmake
+++ b/configure_mac.cmake
@@ -4,6 +4,8 @@ cmake_minimum_required(VERSION 3.5)
 #  - VCPKG_BUILD_TYPE : This will be used to modify the current triplet (once vcpkg is downloaded)
 #  - WZ_DISTRIBUTOR : Passed to the main WZ CMake configure command
 #  - ADDITIONAL_CMAKE_ARGUMENTS : Additional arguments to be passed to CMake configure
+#  - ONLY_BUILD_VCPKG : Only proceed through the steps to build vcpkg
+#  - SKIP_VCPKG_BUILD : Skip building vcpkg itself, proceed with remaining steps
 
 ########################################################
 
@@ -49,6 +51,8 @@ execute_process(COMMAND ${CMAKE_COMMAND} -E echo "++ CMAKE_HOST_SYSTEM_NAME (${C
 ########################################################
 # 1.) Download & build vcpkg, install dependencies
 
+
+if((NOT DEFINED SKIP_VCPKG_BUILD) OR NOT SKIP_VCPKG_BUILD)
 
 ########################################################
 ## 1-a.) Download vcpkg, pin to commit
@@ -196,6 +200,13 @@ if(DEFINED VCPKG_BUILD_TYPE)
 	unset(tripletCommand)
 	unset(tripletFile)
 	unset(triplet)
+endif()
+
+endif((NOT DEFINED SKIP_VCPKG_BUILD) OR NOT SKIP_VCPKG_BUILD)
+
+if(DEFINED ONLY_BUILD_VCPKG AND ONLY_BUILD_VCPKG)
+	message(STATUS "ONLY_BUILD_VCPKG: Stopping configure script after vcpkg build")
+	return()
 endif()
 
 ########################################################


### PR DESCRIPTION
Always build vcpkg itself with the latest Xcode toolchain installed on the runner. (This avoids a "broken gcc" error, which we were seeing on the Xcode 9.4.1 build job.)

Then switch to the desired Xcode toolchain (if specified) for building dependencies + the main application.