### PR TITLE
Add deprecation notice for autotools toolchain

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ matrix:
         # To do this, append the following to the pertinent lines after —rm:
         # -e CI -e TRAVIS -e "TRAVIS_BUILD_DIR=/code" -e TRAVIS_BRANCH -e TRAVIS_COMMIT -e TRAVIS_PULL_REQUEST_BRANCH -e TRAVIS_TAG
         - docker run --rm -v $(pwd):/code ubuntu ./autogen.sh
-        - docker run --rm -e MAKEFLAGS -v $(pwd):/code ubuntu ./configure
+        - docker run --rm -e MAKEFLAGS -v $(pwd):/code ubuntu ./configure --enable-promise-to-use-cmake
         - docker run --rm -e CI -e TRAVIS -e "TRAVIS_BUILD_DIR=/code" -e TRAVIS_BRANCH -e TRAVIS_COMMIT -e TRAVIS_PULL_REQUEST_BRANCH -e TRAVIS_TAG -e MAKEFLAGS -v $(pwd):/code ubuntu make
         - docker run --rm -e CI -e TRAVIS -e "TRAVIS_BUILD_DIR=/code" -e TRAVIS_BRANCH -e TRAVIS_COMMIT -e TRAVIS_PULL_REQUEST_BRANCH -e TRAVIS_TAG -e MAKEFLAGS -v $(pwd):/code ubuntu make check
         - docker run --rm -e CI -e TRAVIS -e "TRAVIS_BUILD_DIR=/code" -e TRAVIS_BRANCH -e TRAVIS_COMMIT -e TRAVIS_PULL_REQUEST_BRANCH -e TRAVIS_TAG -e MAKEFLAGS -v $(pwd):/code ubuntu sudo make install
@@ -39,7 +39,7 @@ matrix:
         # To do this, append the following to the pertinent lines after —rm:
         # -e CI -e TRAVIS -e "TRAVIS_BUILD_DIR=/code" -e TRAVIS_BRANCH -e TRAVIS_COMMIT -e TRAVIS_PULL_REQUEST_BRANCH -e TRAVIS_TAG
         - docker run --rm -v $(pwd):/code ubuntu ./autogen.sh
-        - docker run --rm -e MAKEFLAGS -v $(pwd):/code ubuntu ./configure
+        - docker run --rm -e MAKEFLAGS -v $(pwd):/code ubuntu ./configure --enable-promise-to-use-cmake
         - docker run --rm -e CI -e TRAVIS -e "TRAVIS_BUILD_DIR=/code" -e TRAVIS_BRANCH -e TRAVIS_COMMIT -e TRAVIS_PULL_REQUEST_BRANCH -e TRAVIS_TAG -e MAKEFLAGS -v $(pwd):/code ubuntu make
         - docker run --rm -e CI -e TRAVIS -e "TRAVIS_BUILD_DIR=/code" -e TRAVIS_BRANCH -e TRAVIS_COMMIT -e TRAVIS_PULL_REQUEST_BRANCH -e TRAVIS_TAG -e MAKEFLAGS -v $(pwd):/code ubuntu make check
         - docker run --rm -e CI -e TRAVIS -e "TRAVIS_BUILD_DIR=/code" -e TRAVIS_BRANCH -e TRAVIS_COMMIT -e TRAVIS_PULL_REQUEST_BRANCH -e TRAVIS_TAG -e MAKEFLAGS -v $(pwd):/code ubuntu sudo make install

--- a/configure.ac
+++ b/configure.ac
@@ -18,6 +18,12 @@ CXXFLAGS="${CXXFLAGS} -std=c++11"
 # Make cross compilation options available in --help
 AC_CANONICAL_HOST
 
+# This build toolchain is deprecated - please switch to CMake
+AC_ARG_ENABLE([promise-to-use-cmake],
+	AS_HELP_STRING([--enable-promise-to-use-cmake], [Bypass deprecation notice (for now)]),
+	[ AC_MSG_WARN([*** This build toolchain is deprecated (and will be removed) - please move to the CMake build toolchain. (Ignoring deprecation, for now.) ***]) ],
+	[ AC_MSG_ERROR([*** This build toolchain is deprecated (and will be removed) - please use the CMake build toolchain. (If you really want to ignore this for now, specify: --enable-promise-to-use-cmake) ***]) ])
+
 # Checks for programs.
 AC_PROG_CC_STDC
 AC_CHECK_PROG(CCOMPILER, ${CC}, ccompiler)


### PR DESCRIPTION
Provide notice / encouragement to use CMake, so we can standardize on a single build toolchain for all platforms.