### PR TITLE
po scripts: Do not treat strings from JSON as c-format

### DIFF
--- a/po/aggregateParsedJson.py
+++ b/po/aggregateParsedJson.py
@@ -54,4 +54,7 @@ for line in sorted(output_lines, key=str.casefold):
 		print("// " + src_ref)
 	if len(sorted_src_refs) > src_ref_limit:
 		print("// ... + " + str(len(sorted_src_refs) - src_ref_limit) + " refs")
+	if "%" in line:
+		# ensure xgettext doesn't decide to treat this as a c-format line
+		print("// xgettext:no-c-format")
 	print(line)

--- a/po/custom/fromJson.txt
+++ b/po/custom/fromJson.txt
@@ -37,6 +37,7 @@ _("76mm twin-barrel automatic-cannon")
 // data/mp/messages/resmessages2.json: $.RES_W_AAAC1.text[2]
 // data/mp/messages/resmessages23.json: $.RES_W_AAAC2.text[2]
 // data/mp/messages/resmessages3.json: $.RES_W_AAAC3.text[2]
+// xgettext:no-c-format
 _("AA accuracy +10%")  
 // TRANSLATORS: 
 // data/base/stats/research.json: $.R-Wpn-AAGun-ROF02.name
@@ -80,6 +81,7 @@ _("AA Flak Cannon")
 // TRANSLATORS: 
 // data/mp/messages/resmessages2.json: $.RES_W_AAD1.text[2]
 // data/mp/messages/resmessages3.json: $.RES_W_AAD4.text[2]
+// xgettext:no-c-format
 _("AA Flak damage +25%")  
 // TRANSLATORS: 
 // data/base/messages/resmessages2.json: $.RES_W_AAD1.text[0]
@@ -114,6 +116,7 @@ _("AA HEAP Flak")
 // TRANSLATORS: 
 // data/mp/messages/resmessages2.json: $.RES_W_AAROF1.text[2]
 // data/mp/messages/resmessages3.json: $.RES_W_AAROF4.text[2]
+// xgettext:no-c-format
 _("AA reload time -15%")  
 // TRANSLATORS: 
 // data/base/messages/resmessages2.json: $.RES_EMP_AA1.text[1]
@@ -627,6 +630,7 @@ _("Armed with tank killer rockets")
 // data/mp/messages/resmessages2.json: $.RES_DF_WU4.text[2]
 // data/mp/messages/resmessages2.json: $.RES_ST_MAT4.text[2]
 // ... + 4 refs
+// xgettext:no-c-format
 _("Armor +35%, Body Points +30%")  
 // TRANSLATORS: 
 // data/base/messages/resmessages1.json: $.RES_W_MG_D2.text[1]
@@ -812,6 +816,7 @@ _("Armored strongpoint with Tank Killer rocket")
 _("Armored Tracks")  
 // TRANSLATORS: 
 // data/mp/messages/resmessages1.json: $.RES_DF_WU1.text[2]
+// xgettext:no-c-format
 _("Armour +35%, Body Points +30%")  
 // TRANSLATORS: 
 // data/base/stats/features.json: $.Crate.name
@@ -1191,6 +1196,7 @@ _("Body Points: Very low")
 // data/mp/messages/resmessages2.json: $.RES_W_BAC1.text[2]
 // data/mp/messages/resmessages23.json: $.RES_W_BAC2.text[2]
 // data/mp/messages/resmessages3.json: $.RES_W_BAC3.text[2]
+// xgettext:no-c-format
 _("Bomb damage +25%")  
 // TRANSLATORS: 
 // data/base/messages/resmessages2.json: $.RES_W_PBMB1.text[1]
@@ -1284,6 +1290,7 @@ _("Burns oil more efficiently")
 // TRANSLATORS: 
 // data/mp/messages/resmessages12.json: $.RES_W_CNAC1.text[2]
 // data/mp/messages/resmessagesall.json: $.RES_W_CNAC2.text[2]
+// xgettext:no-c-format
 _("Cannon accuracy +10%")  
 // TRANSLATORS: 
 // data/base/stats/research.json: $.R-Wpn-Cannon-ROF02.name
@@ -1301,6 +1308,7 @@ _("Cannon Autoloader")
 // data/mp/messages/resmessages1.json: $.RES_W_CN_D1.text[2]
 // data/mp/messages/resmessages12.json: $.RES_W_CN_D4.text[2]
 // data/mp/messages/resmessages3.json: $.RES_W_CN_D7.text[2]
+// xgettext:no-c-format
 _("Cannon damage +25%")  
 // TRANSLATORS: 
 // data/base/stats/templates.json: $.BabaFireCan.name
@@ -1334,6 +1342,7 @@ _("Cannon Rapid Loader")
 // TRANSLATORS: 
 // data/mp/messages/resmessages12.json: $.RES_W_CN_ROF1.text[2]
 // data/mp/messages/resmessages3.json: $.RES_W_CN_ROF4.text[2]
+// xgettext:no-c-format
 _("Cannon reload time -10%")  
 // TRANSLATORS: 
 // data/base/stats/structure.json: $.A0CannonTower.name
@@ -1530,10 +1539,12 @@ _("Computer systems can now be 'ring-fenced' from NEXUS")
 _("Computer Technology Breakthrough")  
 // TRANSLATORS: 
 // data/mp/messages/resmessages12.json: $.RES_ENGIN1.text[2]
+// xgettext:no-c-format
 _("Construction speed +10%")  
 // TRANSLATORS: 
 // data/mp/messages/resmessages23.json: $.RES_ENGIN2.text[2]
 // data/mp/messages/resmessages3.json: $.RES_ENGIN3.text[2]
+// xgettext:no-c-format
 _("Construction speed +20%")  
 // TRANSLATORS: 
 // data/base/stats/research.json: $.R-Sys-Spade1Mk1.name
@@ -1932,13 +1943,16 @@ _("Factory module enables medium and large bodies")
 _("Factory Module")  
 // TRANSLATORS: 
 // data/mp/messages/resmessages1.json: $.RES_ST_FM1.text[2]
+// xgettext:no-c-format
 _("Factory output speed +100%% per module")  
 // TRANSLATORS: 
 // data/mp/messages/resmessages1.json: $.RES_ST_FU1.text[2]
 // data/mp/messages/resmessagesall.json: $.RES_ST_FU7.text[2]
+// xgettext:no-c-format
 _("Factory output speed +60%")  
 // TRANSLATORS: 
 // data/mp/messages/resmessages2.json: $.RES_ST_FU4.text[2]
+// xgettext:no-c-format
 _("Factory production rate +60%")  
 // TRANSLATORS: 
 // data/base/stats/structure.json: $.A0LightFactory.name
@@ -2037,6 +2051,7 @@ _("Flamer Cyborg")
 // data/mp/messages/resmessages1.json: $.RES_W_FL_D1.text[2]
 // data/mp/messages/resmessages2.json: $.RES_W_FL_D4.text[2]
 // data/mp/messages/resmessagesall.json: $.RES_W_FL_D7.text[2]
+// xgettext:no-c-format
 _("Flamer damage +25%")  
 // TRANSLATORS: 
 // data/base/stats/structure.json: $.GuardTower4.name
@@ -2048,6 +2063,7 @@ _("Flamer Guard Tower")
 _("Flamer Hardpoint")  
 // TRANSLATORS: 
 // data/mp/messages/resmessages12.json: $.RES_W_FL_ROF1.text[2]
+// xgettext:no-c-format
 _("Flamer reload time -15%")  
 // TRANSLATORS: 
 // data/base/messages/resmessages1.json: $.RES_W_FL_D1.text[0]
@@ -2174,22 +2190,27 @@ _("Generates and concentrates bursts of laser energy")
 // data/mp/multiplay/skirmish/nb_generic.json: $.AI.insane_tip
 // data/mp/multiplay/skirmish/nb_hover.json: $.AI.insane_tip
 // ... + 3 refs
+// xgettext:no-c-format
 _("Gets ~ 100% more power from each oil derrick\nStarts with defensive structures and oil derricks")  
 // TRANSLATORS: 
 // data/mp/multiplay/skirmish/Cobra.json: $.AI.insane_tip
+// xgettext:no-c-format
 _("Gets ~ 100% more power from each oil derrick\nUses the Heavy Plasma Launcher and EMP Mortar\nStarts with defensive structures and oil derricks")  
 // TRANSLATORS: 
 // data/mp/multiplay/skirmish/bonecrusher.json: $.AI.easy_tip
 // data/mp/multiplay/skirmish/nb_hover.json: $.AI.easy_tip
 // data/mp/multiplay/skirmish/nexus.json: $.AI.easy_tip
 // data/mp/multiplay/skirmish/semperfi.json: $.AI.easy_tip
+// xgettext:no-c-format
 _("Gets ~ 25% less power from each oil derrick")  
 // TRANSLATORS: 
 // data/mp/multiplay/skirmish/Cobra.json: $.AI.easy_tip
+// xgettext:no-c-format
 _("Gets ~ 25% less power from each oil derrick\nBasic decision making is slower")  
 // TRANSLATORS: 
 // data/mp/multiplay/skirmish/nb_generic.json: $.AI.easy_tip
 // data/mp/multiplay/skirmish/nb_turtle.json: $.AI.easy_tip
+// xgettext:no-c-format
 _("Gets ~ 25% less power from each oil derrick\nResearch is not focused on a specific weapon branch")  
 // TRANSLATORS: 
 // data/base/messages/resmessages3.json: $.RES_CY_JP1.text[2]
@@ -2802,6 +2823,7 @@ _("Hover")
 // TRANSLATORS: 
 // data/mp/messages/resmessages2.json: $.RES_W_HOWAC1.text[2]
 // data/mp/messages/resmessages3.json: $.RES_W_HOWAC3.text[2]
+// xgettext:no-c-format
 _("Howitzer accuracy +10%")  
 // TRANSLATORS: 
 // data/base/stats/research.json: $.R-Wpn-Howitzer-ROF02.name
@@ -2818,6 +2840,7 @@ _("Howitzer Autoloader")
 // TRANSLATORS: 
 // data/mp/messages/resmessages2.json: $.RES_W_HOWD1.text[2]
 // data/mp/messages/resmessages3.json: $.RES_W_HOWD4.text[2]
+// xgettext:no-c-format
 _("Howitzer damage +25%")  
 // TRANSLATORS: 
 // data/base/stats/research.json: $.R-Defense-Howitzer.name
@@ -2831,6 +2854,7 @@ _("Howitzer Fast Loader")
 // TRANSLATORS: 
 // data/mp/messages/resmessages2.json: $.RES_W_HOWRF1.text[2]
 // data/mp/messages/resmessages3.json: $.RES_W_HOWRF4.text[2]
+// xgettext:no-c-format
 _("Howitzer reload time -10%")  
 // TRANSLATORS: 
 // data/base/messages/resmessages2.json: $.RES_W_HOWAC1.text[0]
@@ -3316,14 +3340,17 @@ _("Keeps map areas under constant surveillance")
 // data/mp/messages/resmessages2.json: $.RES_V_MET4.text[2]
 // data/mp/messages/resmessages3.json: $.RES_V_MET10.text[2]
 // data/mp/messages/resmessages3.json: $.RES_V_MET7.text[2]
+// xgettext:no-c-format
 _("Kinetic armor +30%, body points +30%")  
 // TRANSLATORS: 
 // data/mp/messages/resmessages2.json: $.RES_CYMET4.text[2]
+// xgettext:no-c-format
 _("Kinetic Armor +35%, and Body Points +35%")  
 // TRANSLATORS: 
 // data/mp/messages/resmessages1.json: $.RES_CYMET1.text[2]
 // data/mp/messages/resmessages3.json: $.RES_CYMET10.text[2]
 // data/mp/messages/resmessages3.json: $.RES_CYMET7.text[2]
+// xgettext:no-c-format
 _("Kinetic Armor +35%, Body Points +35%")  
 // TRANSLATORS: 
 // data/base/messages/resmessages3.json: $.RES_CYMET10.text[1]
@@ -3400,9 +3427,11 @@ _("Laser - Flashlight")
 _("Laser AA Gun Available")  
 // TRANSLATORS: 
 // data/mp/messages/resmessages3.json: $.RES_LASAC1.text[2]
+// xgettext:no-c-format
 _("Laser accuracy +10%")  
 // TRANSLATORS: 
 // data/mp/messages/resmessages3.json: $.RES_LASD1.text[2]
+// xgettext:no-c-format
 _("Laser damage +25%")  
 // TRANSLATORS: 
 // data/base/messages/resmessages23.json: $.RES_W_BAC2.text[1]
@@ -3416,6 +3445,7 @@ _("Laser designator paints and guides rounds to the target")
 _("Laser Guided Bombsight")  
 // TRANSLATORS: 
 // data/mp/messages/resmessages3.json: $.RES_LASROF1.text[2]
+// xgettext:no-c-format
 _("Laser reload time -15%")  
 // TRANSLATORS: 
 // data/mp/stats/research.json: $.R-Wpn-LasSat.name
@@ -3543,11 +3573,13 @@ _("Machinegun Bunker")
 // data/mp/messages/resmessages1.json: $.RES_W_MG_D2.text[2]
 // data/mp/messages/resmessages2.json: $.RES_W_MG_D5.text[2]
 // ... + 2 refs
+// xgettext:no-c-format
 _("Machinegun damage +25%")  
 // TRANSLATORS: 
 // data/mp/messages/resmessages12.json: $.RES_W_MG_ROF1.text[2]
 // data/mp/messages/resmessages2.json: $.RES_W_MG_ROF2.text[2]
 // data/mp/messages/resmessages23.json: $.RES_W_MG_ROF3.text[2]
+// xgettext:no-c-format
 _("Machinegun reload time -15%")  
 // TRANSLATORS: 
 // data/base/messages/resmessages1.json: $.RES_W_MG_D1.text[0]
@@ -3766,6 +3798,7 @@ _("Mini-Rocket Viper Wheels")
 // TRANSLATORS: 
 // data/mp/messages/resmessages3.json: $.RES_W_MS_AC1.text[2]
 // data/mp/messages/resmessages3.json: $.RES_W_MS_AC2.text[2]
+// xgettext:no-c-format
 _("Missile accuracy +10%")  
 // TRANSLATORS: 
 // data/base/messages/resmessages3.json: $.RES_W_MS_AC2.text[1]
@@ -3773,6 +3806,7 @@ _("Missile accuracy +10%")
 _("Missile actively seeks and homes on targets")  
 // TRANSLATORS: 
 // data/mp/messages/resmessages3.json: $.RES_W_MS_D1.text[2]
+// xgettext:no-c-format
 _("Missile damage +25%")  
 // TRANSLATORS: 
 // data/mp/stats/research.json: $.R-Defense-Super-Missile.name
@@ -3782,6 +3816,7 @@ _("Missile Fortress")
 // TRANSLATORS: 
 // data/mp/messages/resmessages3.json: $.RES_W_MS_ROF1.text[2]
 // data/mp/messages/resmessages3.json: $.RES_W_SMS_ROF1.text[2]
+// xgettext:no-c-format
 _("Missile reload time -15%")  
 // TRANSLATORS: 
 // data/base/stats/structure.json: $.NX-CruiseSite.name
@@ -3816,6 +3851,7 @@ _("More armor and body points than Vengeance")
 // data/mp/messages/resmessages12.json: $.RES_W_M_AC1.text[2]
 // data/mp/messages/resmessages23.json: $.RES_W_M_AC2.text[2]
 // data/mp/messages/resmessages3.json: $.RES_W_M_AC3.text[2]
+// xgettext:no-c-format
 _("Mortar accuracy +10%")  
 // TRANSLATORS: 
 // data/base/stats/research.json: $.R-Wpn-Mortar-ROF02.name
@@ -3836,6 +3872,7 @@ _("Mortar Cobra Half-tracks")
 // TRANSLATORS: 
 // data/mp/messages/resmessages1.json: $.RES_W_M_D1.text[2]
 // data/mp/messages/resmessages2.json: $.RES_W_M_D4.text[2]
+// xgettext:no-c-format
 _("Mortar damage +25%")  
 // TRANSLATORS: 
 // data/base/stats/research.json: $.R-Wpn-Mortar-ROF04.name
@@ -3850,6 +3887,7 @@ _("Mortar Pit")
 // TRANSLATORS: 
 // data/mp/messages/resmessages12.json: $.RES_W_M_ROF1.text[2]
 // data/mp/messages/resmessages3.json: $.RES_W_M_ROF4.text[2]
+// xgettext:no-c-format
 _("Mortar reload time -10%")  
 // TRANSLATORS: 
 // data/base/stats/research.json: $.R-Wpn-Mortar-Acc01.name
@@ -4377,9 +4415,11 @@ _("Power Module Available")
 _("Power Module")  
 // TRANSLATORS: 
 // data/mp/messages/resmessages23.json: $.RES_POWU1.text[2]
+// xgettext:no-c-format
 _("Power output +25%")  
 // TRANSLATORS: 
 // data/mp/messages/resmessages3.json: $.RES_POWU2.text[2]
+// xgettext:no-c-format
 _("Power output +30%")  
 // TRANSLATORS: 
 // data/base/messages/messages.json: $.MSG2.text[0]
@@ -4503,9 +4543,11 @@ _("Radar Detector Tower")
 _("Radar Detector")  
 // TRANSLATORS: 
 // data/mp/messages/resmessages3.json: $.RES_W_RAIL_AC1.text[2]
+// xgettext:no-c-format
 _("Rail Gun accuracy +10%")  
 // TRANSLATORS: 
 // data/mp/messages/resmessages3.json: $.RES_W_RAIL_D1.text[2]
+// xgettext:no-c-format
 _("Rail Gun damage +25%")  
 // TRANSLATORS: 
 // data/base/stats/research.json: $.R-Defense-Rail2.name
@@ -4526,6 +4568,7 @@ _("Rail Gun Hardpoint")
 _("Rail Gun Mantis Tracks")  
 // TRANSLATORS: 
 // data/mp/messages/resmessages3.json: $.RES_W_RAIL_ROF1.text[2]
+// xgettext:no-c-format
 _("Rail Gun reload time -15%")  
 // TRANSLATORS: 
 // data/base/stats/research.json: $.R-Wpn-Rail-ROF02.name
@@ -4574,6 +4617,7 @@ _("Rapid fire rail gun firing needle darts")
 // TRANSLATORS: 
 // data/mp/messages/resmessages2.json: $.RES_ST_VPU1.text[2]
 // data/mp/messages/resmessages3.json: $.RES_ST_VPU4.text[2]
+// xgettext:no-c-format
 _("Rearming speed +30%")  
 // TRANSLATORS: 
 // data/base/messages/resmessages2.json: $.RES_W_AAROF1.text[1]
@@ -4640,6 +4684,7 @@ _("Repair Scorpion Tracks")
 // data/mp/messages/resmessages1.json: $.RES_ST_RFU1.text[2]
 // data/mp/messages/resmessages2.json: $.RES_ST_RFU4.text[2]
 // data/mp/messages/resmessages3.json: $.RES_ST_RFU7.text[2]
+// xgettext:no-c-format
 _("Repair Speed +100%")  
 // TRANSLATORS: 
 // data/base/stats/templates.json: $.P0CobraRepairTrks.name
@@ -4728,9 +4773,11 @@ _("Research Module")
 // data/mp/messages/resmessages1.json: $.RES_ST_RU1.text[2]
 // data/mp/messages/resmessages2.json: $.RES_ST_RU4.text[2]
 // data/mp/messages/resmessages3.json: $.RES_ST_RU7.text[2]
+// xgettext:no-c-format
 _("Research speed +30%")  
 // TRANSLATORS: 
 // data/mp/messages/resmessages1.json: $.RES_ST_RM1.text[2]
+// xgettext:no-c-format
 _("Research speed +85%")  
 // TRANSLATORS: 
 // data/base/stats/body.json: $.Body3MBT.name
@@ -4827,6 +4874,7 @@ _("Robotic VTOL Rearming")
 // data/mp/messages/resmessages1.json: $.RES_W_SRK_AC1.text[2]
 // data/mp/messages/resmessages12.json: $.RES_W_SRK_AC2.text[2]
 // data/mp/messages/resmessagesall.json: $.RES_W_SRK_AC3.text[2]
+// xgettext:no-c-format
 _("Rocket accuracy +10%")  
 // TRANSLATORS: 
 // data/base/messages/resmessages12.json: $.RES_W_RK_IDF.text[1]
@@ -4853,6 +4901,7 @@ _("Rocket Buggy")
 // data/mp/messages/resmessages1.json: $.RES_W_SRK_D1.text[2]
 // data/mp/messages/resmessages2.json: $.RES_W_RK_D4.text[2]
 // data/mp/messages/resmessages2.json: $.RES_W_SRK_D4.text[2]
+// xgettext:no-c-format
 _("Rocket damage +25%")  
 // TRANSLATORS: 
 // data/base/messages/resmessagesall.json: $.RES_W_SRK_AC3.text[1]
@@ -4869,6 +4918,7 @@ _("Rocket Laser Designator")
 // TRANSLATORS: 
 // data/mp/messages/resmessages1.json: $.RES_W_RK_ROF1.text[2]
 // data/mp/messages/resmessages12.json: $.RES_W_SRK_ROF1.text[2]
+// xgettext:no-c-format
 _("Rocket reload time -15%")  
 // TRANSLATORS: 
 // data/base/messages/resmessages12.json: $.RES_W_SRK_AC2.text[1]
@@ -5040,12 +5090,15 @@ _("SemperFi")
 _("Sensor Cobra Half-tracks")  
 // TRANSLATORS: 
 // data/mp/messages/resmessagesall.json: $.RES_SY_SU3.text[2]
+// xgettext:no-c-format
 _("Sensor Range +10%")  
 // TRANSLATORS: 
 // data/mp/messages/resmessagesall.json: $.RES_SY_SU2.text[2]
+// xgettext:no-c-format
 _("Sensor Range +15%")  
 // TRANSLATORS: 
 // data/mp/messages/resmessagesall.json: $.RES_SY_SU1.text[2]
+// xgettext:no-c-format
 _("Sensor Range +25%")  
 // TRANSLATORS: 
 // data/base/stats/research.json: $.R-Sys-Sensor-Tower01.name
@@ -5414,16 +5467,20 @@ _("Targeting systems compensate for distance and weather conditions")
 _("The VTOL returns to the selected pad for rearming")  
 // TRANSLATORS: 
 // data/mp/messages/resmessages3.json: $.RES_CY_AH4.text[2]
+// xgettext:no-c-format
 _("Thermal Armor +35%")  
 // TRANSLATORS: 
 // data/mp/messages/resmessages2.json: $.RES_V_AH1.text[2]
+// xgettext:no-c-format
 _("Thermal armor +40%")  
 // TRANSLATORS: 
 // data/mp/messages/resmessages3.json: $.RES_V_AH4.text[2]
 // data/mp/messages/resmessagesall.json: $.RES_V_AH7.text[2]
+// xgettext:no-c-format
 _("Thermal Armor +40%")  
 // TRANSLATORS: 
 // data/mp/messages/resmessages2.json: $.RES_CY_AH1.text[2]
+// xgettext:no-c-format
 _("Thermal Armor +45%")  
 // TRANSLATORS: 
 // data/base/messages/resmessages2.json: $.RES_CY_AH1.text[2]
@@ -5712,6 +5769,7 @@ _("Vehicle Propulsion Improved")
 // data/mp/messages/resmessages2.json: $.RES_V_EN4.text[2]
 // data/mp/messages/resmessages3.json: $.RES_V_EN10.text[2]
 // data/mp/messages/resmessages3.json: $.RES_V_EN7.text[2]
+// xgettext:no-c-format
 _("Vehicle speed +5%")  
 // TRANSLATORS: 
 // data/mp/stats/research.json: $.R-Vehicle-Armor-Heat08.name

--- a/po/warzone2100.pot
+++ b/po/warzone2100.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: warzone2100\n"
 "Report-Msgid-Bugs-To: warzone2100-project@lists.sourceforge.net\n"
-"POT-Creation-Date: 2020-03-09 03:23+0000\n"
+"POT-Creation-Date: 2020-03-10 22:55+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1193,7 +1193,7 @@ msgstr ""
 #. TRANSLATORS:
 #. data/mp/stats/propulsion.json: $.Naval.name
 #: data/base/messages/strings/names.txt:156
-#: po/custom/fromJson.txt:3888
+#: po/custom/fromJson.txt:3926
 msgid "Naval"
 msgstr ""
 
@@ -1226,7 +1226,7 @@ msgstr ""
 #. data/mp/stats/structure.json: $.Emplacement-Howitzer105.name
 #: data/base/messages/strings/names.txt:215
 #: data/mp/messages/strings/names.txt:251
-#: po/custom/fromJson.txt:2827
+#: po/custom/fromJson.txt:2850
 msgid "Howitzer Emplacement"
 msgstr ""
 
@@ -1237,7 +1237,7 @@ msgstr ""
 #. data/mp/stats/structure.json: $.Emplacement-Howitzer150.name
 #: data/base/messages/strings/names.txt:216
 #: data/mp/messages/strings/names.txt:252
-#: po/custom/fromJson.txt:2218
+#: po/custom/fromJson.txt:2239
 msgid "Ground Shaker Emplacement"
 msgstr ""
 
@@ -1248,7 +1248,7 @@ msgstr ""
 #. data/mp/stats/structure.json: $.Emplacement-RotHow.name
 #: data/base/messages/strings/names.txt:217
 #: data/mp/messages/strings/names.txt:253
-#: po/custom/fromJson.txt:2643
+#: po/custom/fromJson.txt:2664
 msgid "Hellstorm Emplacement"
 msgstr ""
 
@@ -1326,7 +1326,7 @@ msgstr ""
 #. data/base/stats/research.json: $.R-Cyborg-Legs02.name
 #: data/base/messages/strings/names.txt:298
 #: data/mp/messages/strings/names.txt:381
-#: po/custom/fromJson.txt:1637
+#: po/custom/fromJson.txt:1648
 msgid "Cyborg Propulsion II"
 msgstr ""
 
@@ -1334,7 +1334,7 @@ msgstr ""
 #. data/base/stats/propulsion.json: $.CyborgLegs03.name
 #: data/base/messages/strings/names.txt:299
 #: data/mp/messages/strings/names.txt:382
-#: po/custom/fromJson.txt:1640
+#: po/custom/fromJson.txt:1651
 msgid "Cyborg Propulsion III"
 msgstr ""
 
@@ -1350,7 +1350,7 @@ msgstr ""
 #. ... + 3 refs
 #: data/base/messages/strings/names.txt:314
 #: data/mp/messages/strings/names.txt:395
-#: po/custom/fromJson.txt:2543
+#: po/custom/fromJson.txt:2564
 msgid "Heavy Machinegun Bunker"
 msgstr ""
 
@@ -1361,7 +1361,7 @@ msgstr ""
 #. data/mp/stats/structure.json: $.Emplacement-PrisLas.name
 #: data/base/messages/strings/names.txt:316
 #: data/mp/messages/strings/names.txt:397
-#: po/custom/fromJson.txt:2076
+#: po/custom/fromJson.txt:2092
 msgid "Flashlight Emplacement"
 msgstr ""
 
@@ -1371,7 +1371,7 @@ msgstr ""
 #. data/mp/stats/research.json: $.R-Defense-Tower01.name
 #. data/mp/stats/structure.json: $.GuardTower1.name
 #: data/base/messages/strings/names.txt:322
-#: po/custom/fromJson.txt:2565
+#: po/custom/fromJson.txt:2586
 msgid "Heavy Machinegun Guard Tower"
 msgstr ""
 
@@ -1379,7 +1379,7 @@ msgstr ""
 #. data/base/stats/structure.json: $.GuardTower4.name
 #. data/mp/stats/structure.json: $.GuardTower4.name
 #: data/base/messages/strings/names.txt:323
-#: po/custom/fromJson.txt:2044
+#: po/custom/fromJson.txt:2059
 msgid "Flamer Guard Tower"
 msgstr ""
 
@@ -1392,14 +1392,14 @@ msgstr ""
 #. data/mp/stats/structure.json: $.WallTower05.name
 #: data/base/messages/strings/names.txt:327
 #: data/mp/messages/strings/names.txt:409
-#: po/custom/fromJson.txt:2048
+#: po/custom/fromJson.txt:2063
 msgid "Flamer Hardpoint"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/messages/resmessagesall.json: $.RES_ST_FCY7.text[1]
 #: data/base/messages/strings/names.txt:330
-#: po/custom/fromJson.txt:174
+#: po/custom/fromJson.txt:177
 msgid "Advanced Cyborg Production"
 msgstr ""
 
@@ -1414,7 +1414,7 @@ msgstr ""
 #. TRANSLATORS:
 #. data/mp/messages/resmessagesall.json: $.RES_ST_FU7.text[1]
 #: data/base/messages/strings/names.txt:334
-#: po/custom/fromJson.txt:185
+#: po/custom/fromJson.txt:188
 msgid "Advanced Factory Production"
 msgstr ""
 
@@ -1701,7 +1701,7 @@ msgstr ""
 #. ... + 5 refs
 #: data/base/messages/strings/resstrings.txt:31
 #: data/mp/messages/strings/resstrings.txt:1
-#: po/custom/fromJson.txt:1624
+#: po/custom/fromJson.txt:1635
 msgid "Cyborg Materials Improved"
 msgstr ""
 
@@ -1714,7 +1714,7 @@ msgstr ""
 #: data/base/messages/strings/resstrings.txt:572
 #: data/mp/messages/strings/resstrings.txt:2
 #: data/mp/messages/strings/resstrings.txt:262
-#: po/custom/fromJson.txt:3448
+#: po/custom/fromJson.txt:3478
 msgid "Layered dense composite alloys and energy-absorbing fibres"
 msgstr ""
 
@@ -1725,7 +1725,7 @@ msgstr ""
 #. data/base/messages/resmessages3.json: $.RES_CYMET7.text[2]
 #: data/base/messages/strings/resstrings.txt:33
 #: data/mp/messages/strings/resstrings.txt:3
-#: po/custom/fromJson.txt:3143
+#: po/custom/fromJson.txt:3167
 msgid "Increases Kinetic Armor and Body Points"
 msgstr ""
 
@@ -1738,7 +1738,7 @@ msgstr ""
 #: data/base/messages/strings/resstrings.txt:44
 #: data/mp/messages/strings/resstrings.txt:4
 #: data/mp/messages/strings/resstrings.txt:9
-#: po/custom/fromJson.txt:308
+#: po/custom/fromJson.txt:311
 msgid "All Cyborgs upgraded automatically"
 msgstr ""
 
@@ -1749,7 +1749,7 @@ msgstr ""
 #. data/mp/messages/resmessages3.json: $.RES_CY_AH4.text[0]
 #: data/base/messages/strings/resstrings.txt:41
 #: data/mp/messages/strings/resstrings.txt:6
-#: po/custom/fromJson.txt:1678
+#: po/custom/fromJson.txt:1689
 msgid "Cyborg Thermal Armor Improved"
 msgstr ""
 
@@ -1760,7 +1760,7 @@ msgstr ""
 #. data/mp/messages/resmessages3.json: $.RES_CY_AH4.text[1]
 #: data/base/messages/strings/resstrings.txt:42
 #: data/mp/messages/strings/resstrings.txt:7
-#: po/custom/fromJson.txt:2416
+#: po/custom/fromJson.txt:2437
 msgid "Heat resistant armored layers"
 msgstr ""
 
@@ -1769,7 +1769,7 @@ msgstr ""
 #. data/base/messages/resmessages3.json: $.RES_CY_AH4.text[2]
 #: data/base/messages/strings/resstrings.txt:43
 #: data/mp/messages/strings/resstrings.txt:8
-#: po/custom/fromJson.txt:5431
+#: po/custom/fromJson.txt:5488
 msgid "Thermal Armor increased"
 msgstr ""
 
@@ -1782,7 +1782,7 @@ msgstr ""
 #: data/base/messages/strings/resstrings.txt:65
 #: data/mp/messages/strings/resstrings.txt:11
 #: data/mp/messages/strings/resstrings.txt:16
-#: po/custom/fromJson.txt:3986
+#: po/custom/fromJson.txt:4024
 msgid "New Cyborg Available"
 msgstr ""
 
@@ -1793,7 +1793,7 @@ msgstr ""
 #: data/base/messages/strings/resstrings.txt:84
 #: data/mp/messages/strings/resstrings.txt:12
 #: data/mp/messages/strings/resstrings.txt:27
-#: po/custom/fromJson.txt:543
+#: po/custom/fromJson.txt:546
 msgid "Armed with Bunker Buster rocket"
 msgstr ""
 
@@ -1822,7 +1822,7 @@ msgstr ""
 #: data/mp/messages/strings/resstrings.txt:309
 #: data/mp/messages/strings/resstrings.txt:329
 #: data/mp/messages/strings/resstrings.txt:334
-#: po/custom/fromJson.txt:1178
+#: po/custom/fromJson.txt:1183
 msgid "Body Points: Medium"
 msgstr ""
 
@@ -1839,7 +1839,7 @@ msgstr ""
 #: data/mp/messages/strings/resstrings.txt:19
 #: data/mp/messages/strings/resstrings.txt:24
 #: data/mp/messages/strings/resstrings.txt:29
-#: po/custom/fromJson.txt:4684
+#: po/custom/fromJson.txt:4729
 msgid "Requires Cyborg factory to produce"
 msgstr ""
 
@@ -1848,7 +1848,7 @@ msgstr ""
 #. data/mp/messages/resmessages2.json: $.RES_CYW_MG4.text[1]
 #: data/base/messages/strings/resstrings.txt:66
 #: data/mp/messages/strings/resstrings.txt:17
-#: po/custom/fromJson.txt:547
+#: po/custom/fromJson.txt:550
 msgid "Armed with Cyborg Assault Gun"
 msgstr ""
 
@@ -1861,7 +1861,7 @@ msgstr ""
 #: data/base/messages/strings/resstrings.txt:83
 #: data/mp/messages/strings/resstrings.txt:21
 #: data/mp/messages/strings/resstrings.txt:26
-#: po/custom/fromJson.txt:4017
+#: po/custom/fromJson.txt:4055
 msgid "New Jump Cyborg Available"
 msgstr ""
 
@@ -1870,7 +1870,7 @@ msgstr ""
 #. data/mp/messages/resmessages3.json: $.RES_CYW_MIS.text[1]
 #: data/base/messages/strings/resstrings.txt:78
 #: data/mp/messages/strings/resstrings.txt:22
-#: po/custom/fromJson.txt:615
+#: po/custom/fromJson.txt:618
 msgid "Armed with Revenger Surface-to-Air missile"
 msgstr ""
 
@@ -1881,7 +1881,7 @@ msgstr ""
 #. ... + 5 refs
 #: data/base/messages/strings/resstrings.txt:103
 #: data/mp/messages/strings/resstrings.txt:31
-#: po/custom/fromJson.txt:1732
+#: po/custom/fromJson.txt:1743
 msgid "Defenses Improved"
 msgstr ""
 
@@ -1890,7 +1890,7 @@ msgstr ""
 #. data/mp/messages/resmessages2.json: $.RES_DF_WU4.text[1]
 #: data/base/messages/strings/resstrings.txt:104
 #: data/mp/messages/strings/resstrings.txt:32
-#: po/custom/fromJson.txt:2773
+#: po/custom/fromJson.txt:2794
 msgid "High-tensile concrete reinforced with boron"
 msgstr ""
 
@@ -1903,7 +1903,7 @@ msgstr ""
 #: data/base/messages/strings/resstrings.txt:401
 #: data/mp/messages/strings/resstrings.txt:33
 #: data/mp/messages/strings/resstrings.txt:198
-#: po/custom/fromJson.txt:3067
+#: po/custom/fromJson.txt:3091
 msgid "Increases Armor and Body Points"
 msgstr ""
 
@@ -1914,7 +1914,7 @@ msgstr ""
 #. ... + 5 refs
 #: data/base/messages/strings/resstrings.txt:106
 #: data/mp/messages/strings/resstrings.txt:34
-#: po/custom/fromJson.txt:314
+#: po/custom/fromJson.txt:317
 msgid "All defenses and walls upgraded automatically"
 msgstr ""
 
@@ -1975,7 +1975,7 @@ msgstr ""
 #: data/mp/messages/strings/resstrings.txt:151
 #: data/mp/messages/strings/resstrings.txt:156
 #: data/mp/messages/strings/resstrings.txt:161
-#: po/custom/fromJson.txt:3996
+#: po/custom/fromJson.txt:4034
 msgid "New Defensive Structure Available"
 msgstr ""
 
@@ -1984,7 +1984,7 @@ msgstr ""
 #. data/mp/messages/resmessages2.json: $.RES_EMP_AA4.text[1]
 #: data/base/messages/strings/resstrings.txt:114
 #: data/mp/messages/strings/resstrings.txt:37
-#: po/custom/fromJson.txt:129
+#: po/custom/fromJson.txt:132
 msgid "AA Site with Tornado Flak Turret"
 msgstr ""
 
@@ -1999,7 +1999,7 @@ msgstr ""
 #: data/mp/messages/strings/resstrings.txt:38
 #: data/mp/messages/strings/resstrings.txt:43
 #: data/mp/messages/strings/resstrings.txt:53
-#: po/custom/fromJson.txt:1008
+#: po/custom/fromJson.txt:1013
 msgid "Automatically targets VTOLs"
 msgstr ""
 
@@ -2042,7 +2042,7 @@ msgstr ""
 #: data/mp/messages/strings/resstrings.txt:119
 #: data/mp/messages/strings/resstrings.txt:124
 #: data/mp/messages/strings/resstrings.txt:129
-#: po/custom/fromJson.txt:1754
+#: po/custom/fromJson.txt:1765
 msgid "Defensive Strength: Medium"
 msgstr ""
 
@@ -2051,7 +2051,7 @@ msgstr ""
 #. data/mp/messages/resmessages2.json: $.RES_EMP_AA1.text[1]
 #: data/base/messages/strings/resstrings.txt:120
 #: data/mp/messages/strings/resstrings.txt:42
-#: po/custom/fromJson.txt:121
+#: po/custom/fromJson.txt:124
 msgid "AA Site with Cyclone Flak Turret"
 msgstr ""
 
@@ -2060,7 +2060,7 @@ msgstr ""
 #. data/mp/messages/resmessages2.json: $.RES_EMP_AA2.text[1]
 #: data/base/messages/strings/resstrings.txt:126
 #: data/mp/messages/strings/resstrings.txt:47
-#: po/custom/fromJson.txt:125
+#: po/custom/fromJson.txt:128
 msgid "AA Site with Hurricane Gun Turret"
 msgstr ""
 
@@ -2069,7 +2069,7 @@ msgstr ""
 #. data/mp/messages/resmessages2.json: $.RES_EMP_AA2.text[2]
 #: data/base/messages/strings/resstrings.txt:127
 #: data/mp/messages/strings/resstrings.txt:48
-#: po/custom/fromJson.txt:1002
+#: po/custom/fromJson.txt:1007
 msgid "Automatically targets VTOL"
 msgstr ""
 
@@ -2078,7 +2078,7 @@ msgstr ""
 #. data/mp/messages/resmessages2.json: $.RES_EMP_AA3.text[1]
 #: data/base/messages/strings/resstrings.txt:132
 #: data/mp/messages/strings/resstrings.txt:52
-#: po/custom/fromJson.txt:133
+#: po/custom/fromJson.txt:136
 msgid "AA Site with Whirlwind Gun Turret"
 msgstr ""
 
@@ -2087,7 +2087,7 @@ msgstr ""
 #. data/mp/messages/resmessages2.json: $.RES_EMP_IDFR.text[1]
 #: data/base/messages/strings/resstrings.txt:142
 #: data/mp/messages/strings/resstrings.txt:57
-#: po/custom/fromJson.txt:3249
+#: po/custom/fromJson.txt:3273
 msgid "Indirect fire rocket battery"
 msgstr ""
 
@@ -2110,7 +2110,7 @@ msgstr ""
 #: data/mp/messages/strings/resstrings.txt:78
 #: data/mp/messages/strings/resstrings.txt:83
 #: data/mp/messages/strings/resstrings.txt:88
-#: po/custom/fromJson.txt:899
+#: po/custom/fromJson.txt:904
 msgid "Assigned automatically to nearest sensor or CB tower"
 msgstr ""
 
@@ -2119,7 +2119,7 @@ msgstr ""
 #. data/mp/messages/resmessages2.json: $.RES_EMP_HvyMor.text[1]
 #: data/base/messages/strings/resstrings.txt:154
 #: data/mp/messages/strings/resstrings.txt:62
-#: po/custom/fromJson.txt:642
+#: po/custom/fromJson.txt:646
 msgid "Armored Bombard battery pit"
 msgstr ""
 
@@ -2128,7 +2128,7 @@ msgstr ""
 #. data/mp/messages/resmessages2.json: $.RES_EMP_RotMor.text[1]
 #: data/base/messages/strings/resstrings.txt:160
 #: data/mp/messages/strings/resstrings.txt:67
-#: po/custom/fromJson.txt:771
+#: po/custom/fromJson.txt:775
 msgid "Armored Pepperpot mortar battery pit"
 msgstr ""
 
@@ -2137,7 +2137,7 @@ msgstr ""
 #. data/mp/messages/resmessages2.json: $.RES_EMP_HOW.text[1]
 #: data/base/messages/strings/resstrings.txt:168
 #: data/mp/messages/strings/resstrings.txt:72
-#: po/custom/fromJson.txt:760
+#: po/custom/fromJson.txt:764
 msgid "Armored howitzer emplacement"
 msgstr ""
 
@@ -2146,7 +2146,7 @@ msgstr ""
 #. data/mp/messages/resmessages2.json: $.RES_EMP_HvHOW.text[1]
 #: data/base/messages/strings/resstrings.txt:174
 #: data/mp/messages/strings/resstrings.txt:77
-#: po/custom/fromJson.txt:664
+#: po/custom/fromJson.txt:668
 msgid "Armored Ground Shaker howitzer emplacement"
 msgstr ""
 
@@ -2159,7 +2159,7 @@ msgstr ""
 #: data/base/messages/strings/resstrings.txt:186
 #: data/mp/messages/strings/resstrings.txt:82
 #: data/mp/messages/strings/resstrings.txt:87
-#: po/custom/fromJson.txt:756
+#: po/custom/fromJson.txt:760
 msgid "Armored Hellstorm howitzer emplacement"
 msgstr ""
 
@@ -2168,7 +2168,7 @@ msgstr ""
 #. data/mp/messages/resmessages2.json: $.RES_EMP_HVATR.text[1]
 #: data/base/messages/strings/resstrings.txt:192
 #: data/mp/messages/strings/resstrings.txt:92
-#: po/custom/fromJson.txt:808
+#: po/custom/fromJson.txt:812
 msgid "Armored strongpoint with Tank Killer rocket"
 msgstr ""
 
@@ -2187,7 +2187,7 @@ msgstr ""
 #: data/mp/messages/strings/resstrings.txt:103
 #: data/mp/messages/strings/resstrings.txt:108
 #: data/mp/messages/strings/resstrings.txt:113
-#: po/custom/fromJson.txt:992
+#: po/custom/fromJson.txt:997
 msgid "Automatically targets enemies in range"
 msgstr ""
 
@@ -2196,7 +2196,7 @@ msgstr ""
 #. data/mp/messages/resmessages2.json: $.RES_EMP_HPV.text[1]
 #: data/base/messages/strings/resstrings.txt:198
 #: data/mp/messages/strings/resstrings.txt:97
-#: po/custom/fromJson.txt:790
+#: po/custom/fromJson.txt:794
 msgid "Armored strongpoint with Hyper-Velocity Cannon"
 msgstr ""
 
@@ -2223,7 +2223,7 @@ msgstr ""
 #: data/mp/messages/strings/resstrings.txt:154
 #: data/mp/messages/strings/resstrings.txt:159
 #: data/mp/messages/strings/resstrings.txt:164
-#: po/custom/fromJson.txt:1744
+#: po/custom/fromJson.txt:1755
 msgid "Defensive Strength: High"
 msgstr ""
 
@@ -2232,7 +2232,7 @@ msgstr ""
 #. data/mp/messages/resmessages2.json: $.RES_EMP_HVFL.text[1]
 #: data/base/messages/strings/resstrings.txt:204
 #: data/mp/messages/strings/resstrings.txt:102
-#: po/custom/fromJson.txt:794
+#: po/custom/fromJson.txt:798
 msgid "Armored strongpoint with Inferno Flamer"
 msgstr ""
 
@@ -2241,7 +2241,7 @@ msgstr ""
 #. data/mp/messages/resmessages2.json: $.RES_EMP_RotCan.text[1]
 #: data/base/messages/strings/resstrings.txt:218
 #: data/mp/messages/strings/resstrings.txt:107
-#: po/custom/fromJson.txt:775
+#: po/custom/fromJson.txt:779
 msgid "Armored strongpoint with Assault Cannon"
 msgstr ""
 
@@ -2250,7 +2250,7 @@ msgstr ""
 #. data/mp/messages/resmessages2.json: $.RES_DEF_RotMG.text[1]
 #: data/base/messages/strings/resstrings.txt:224
 #: data/mp/messages/strings/resstrings.txt:112
-#: po/custom/fromJson.txt:4617
+#: po/custom/fromJson.txt:4661
 msgid "Reinforced tower with Assault Gun"
 msgstr ""
 
@@ -2282,7 +2282,7 @@ msgstr ""
 #: data/mp/messages/strings/resstrings.txt:148
 #: data/mp/messages/strings/resstrings.txt:153
 #: data/mp/messages/strings/resstrings.txt:158
-#: po/custom/fromJson.txt:998
+#: po/custom/fromJson.txt:1003
 msgid "Automatically targets enemies within sensor range"
 msgstr ""
 
@@ -2311,7 +2311,7 @@ msgstr ""
 #. data/mp/messages/resmessages2.json: $.RES_WT7_RMG.text[1]
 #: data/base/messages/strings/resstrings.txt:288
 #: data/mp/messages/strings/resstrings.txt:142
-#: po/custom/fromJson.txt:702
+#: po/custom/fromJson.txt:706
 msgid "Armored hardpoint with Assault Gun"
 msgstr ""
 
@@ -2320,7 +2320,7 @@ msgstr ""
 #. data/mp/messages/resmessages2.json: $.RES_WT8_RC.text[1]
 #: data/base/messages/strings/resstrings.txt:294
 #: data/mp/messages/strings/resstrings.txt:147
-#: po/custom/fromJson.txt:698
+#: po/custom/fromJson.txt:702
 msgid "Armored hardpoint with Assault Cannon"
 msgstr ""
 
@@ -2329,7 +2329,7 @@ msgstr ""
 #. data/mp/messages/resmessages2.json: $.RES_WT11_HFL.text[1]
 #: data/base/messages/strings/resstrings.txt:302
 #: data/mp/messages/strings/resstrings.txt:152
-#: po/custom/fromJson.txt:726
+#: po/custom/fromJson.txt:730
 msgid "Armored hardpoint with Inferno flamer"
 msgstr ""
 
@@ -2338,7 +2338,7 @@ msgstr ""
 #. data/mp/messages/resmessages2.json: $.RES_WT12_HAT.text[1]
 #: data/base/messages/strings/resstrings.txt:308
 #: data/mp/messages/strings/resstrings.txt:157
-#: po/custom/fromJson.txt:750
+#: po/custom/fromJson.txt:754
 msgid "Armored hardpoint with Tank Killer AT missile"
 msgstr ""
 
@@ -2347,7 +2347,7 @@ msgstr ""
 #. data/mp/messages/resmessages1.json: $.RES_TTRAP1.text[1]
 #: data/base/messages/strings/resstrings.txt:324
 #: data/mp/messages/strings/resstrings.txt:162
-#: po/custom/fromJson.txt:4613
+#: po/custom/fromJson.txt:4657
 msgid "Reinforced concrete tank traps"
 msgstr ""
 
@@ -2356,7 +2356,7 @@ msgstr ""
 #. data/mp/messages/resmessages1.json: $.RES_TTRAP1.text[2]
 #: data/base/messages/strings/resstrings.txt:325
 #: data/mp/messages/strings/resstrings.txt:163
-#: po/custom/fromJson.txt:4396
+#: po/custom/fromJson.txt:4436
 msgid "Prevents enemy movement"
 msgstr ""
 
@@ -2367,7 +2367,7 @@ msgstr ""
 #. ... + 3 refs
 #: data/base/messages/strings/resstrings.txt:333
 #: data/mp/messages/strings/resstrings.txt:166
-#: po/custom/fromJson.txt:4629
+#: po/custom/fromJson.txt:4673
 msgid "Repair Facility Improved"
 msgstr ""
 
@@ -2376,7 +2376,7 @@ msgstr ""
 #. data/mp/messages/resmessages2.json: $.RES_ST_RFU4.text[1]
 #: data/base/messages/strings/resstrings.txt:334
 #: data/mp/messages/strings/resstrings.txt:167
-#: po/custom/fromJson.txt:4094
+#: po/custom/fromJson.txt:4132
 msgid "New robotic repair techniques"
 msgstr ""
 
@@ -2386,7 +2386,7 @@ msgstr ""
 #. data/base/messages/resmessages3.json: $.RES_ST_RFU7.text[2]
 #: data/base/messages/strings/resstrings.txt:335
 #: data/mp/messages/strings/resstrings.txt:168
-#: po/custom/fromJson.txt:3217
+#: po/custom/fromJson.txt:3241
 msgid "Increases Repair Speed"
 msgstr ""
 
@@ -2397,7 +2397,7 @@ msgstr ""
 #. ... + 3 refs
 #: data/base/messages/strings/resstrings.txt:336
 #: data/mp/messages/strings/resstrings.txt:169
-#: po/custom/fromJson.txt:396
+#: po/custom/fromJson.txt:399
 msgid "All repair facilities upgraded automatically"
 msgstr ""
 
@@ -2410,7 +2410,7 @@ msgstr ""
 #: data/base/messages/strings/resstrings.txt:355
 #: data/mp/messages/strings/resstrings.txt:171
 #: data/mp/messages/strings/resstrings.txt:176
-#: po/custom/fromJson.txt:1633
+#: po/custom/fromJson.txt:1644
 msgid "Cyborg Production Improved"
 msgstr ""
 
@@ -2420,7 +2420,7 @@ msgstr ""
 #. data/mp/messages/resmessages2.json: $.RES_ST_FCY4.text[1]
 #: data/base/messages/strings/resstrings.txt:348
 #: data/mp/messages/strings/resstrings.txt:172
-#: po/custom/fromJson.txt:4769
+#: po/custom/fromJson.txt:4816
 msgid "Robotic Cyborg Production"
 msgstr ""
 
@@ -2433,7 +2433,7 @@ msgstr ""
 #: data/base/messages/strings/resstrings.txt:357
 #: data/mp/messages/strings/resstrings.txt:173
 #: data/mp/messages/strings/resstrings.txt:178
-#: po/custom/fromJson.txt:3105
+#: po/custom/fromJson.txt:3129
 msgid "Increases Cyborg factory output"
 msgstr ""
 
@@ -2446,7 +2446,7 @@ msgstr ""
 #: data/base/messages/strings/resstrings.txt:358
 #: data/mp/messages/strings/resstrings.txt:174
 #: data/mp/messages/strings/resstrings.txt:179
-#: po/custom/fromJson.txt:302
+#: po/custom/fromJson.txt:305
 msgid "All Cyborg factories upgraded automatically"
 msgstr ""
 
@@ -2463,7 +2463,7 @@ msgstr ""
 #: data/base/messages/strings/resstrings.txt:373
 #: data/mp/messages/strings/resstrings.txt:181
 #: data/mp/messages/strings/resstrings.txt:186
-#: po/custom/fromJson.txt:5703
+#: po/custom/fromJson.txt:5760
 msgid "Vehicle Production Improved"
 msgstr ""
 
@@ -2472,7 +2472,7 @@ msgstr ""
 #. data/mp/messages/resmessages2.json: $.RES_ST_FU4.text[1]
 #: data/base/messages/strings/resstrings.txt:366
 #: data/mp/messages/strings/resstrings.txt:182
-#: po/custom/fromJson.txt:4098
+#: po/custom/fromJson.txt:4136
 msgid "New Robotic Techniques improve factory production"
 msgstr ""
 
@@ -2480,7 +2480,7 @@ msgstr ""
 #. data/base/messages/resmessages2.json: $.RES_ST_FU4.text[2]
 #: data/base/messages/strings/resstrings.txt:367
 #: data/mp/messages/strings/resstrings.txt:183
-#: po/custom/fromJson.txt:3118
+#: po/custom/fromJson.txt:3142
 msgid "Increases factory production rate"
 msgstr ""
 
@@ -2492,7 +2492,7 @@ msgstr ""
 #: data/base/messages/strings/resstrings.txt:376
 #: data/mp/messages/strings/resstrings.txt:184
 #: data/mp/messages/strings/resstrings.txt:189
-#: po/custom/fromJson.txt:431
+#: po/custom/fromJson.txt:434
 msgid "All vehicle factories upgraded automatically"
 msgstr ""
 
@@ -2506,7 +2506,7 @@ msgstr ""
 #. data/base/messages/resmessages1.json: $.RES_ST_FU1.text[2]
 #: data/base/messages/strings/resstrings.txt:375
 #: data/mp/messages/strings/resstrings.txt:188
-#: po/custom/fromJson.txt:3115
+#: po/custom/fromJson.txt:3139
 msgid "Increases factory output"
 msgstr ""
 
@@ -2517,7 +2517,7 @@ msgstr ""
 #. ... + 3 refs
 #: data/base/messages/strings/resstrings.txt:389
 #: data/mp/messages/strings/resstrings.txt:191
-#: po/custom/fromJson.txt:4708
+#: po/custom/fromJson.txt:4753
 msgid "Research Improved"
 msgstr ""
 
@@ -2528,7 +2528,7 @@ msgstr ""
 #. data/mp/stats/research.json: $.R-Struc-Research-Upgrade04.name
 #: data/base/messages/strings/resstrings.txt:390
 #: data/mp/messages/strings/resstrings.txt:192
-#: po/custom/fromJson.txt:1726
+#: po/custom/fromJson.txt:1737
 msgid "Dedicated Synaptic Link Data Analysis"
 msgstr ""
 
@@ -2539,7 +2539,7 @@ msgstr ""
 #. data/base/messages/resmessages3.json: $.RES_ST_RU7.text[2]
 #: data/base/messages/strings/resstrings.txt:391
 #: data/mp/messages/strings/resstrings.txt:193
-#: po/custom/fromJson.txt:3223
+#: po/custom/fromJson.txt:3247
 msgid "Increases research speed"
 msgstr ""
 
@@ -2550,7 +2550,7 @@ msgstr ""
 #. ... + 3 refs
 #: data/base/messages/strings/resstrings.txt:392
 #: data/mp/messages/strings/resstrings.txt:194
-#: po/custom/fromJson.txt:402
+#: po/custom/fromJson.txt:405
 msgid "All research facilities upgraded automatically"
 msgstr ""
 
@@ -2561,7 +2561,7 @@ msgstr ""
 #. ... + 5 refs
 #: data/base/messages/strings/resstrings.txt:399
 #: data/mp/messages/strings/resstrings.txt:196
-#: po/custom/fromJson.txt:3111
+#: po/custom/fromJson.txt:3135
 msgid "Increases Damage Resistance"
 msgstr ""
 
@@ -2572,7 +2572,7 @@ msgstr ""
 #. data/mp/stats/research.json: $.R-Struc-Materials04.name
 #: data/base/messages/strings/resstrings.txt:400
 #: data/mp/messages/strings/resstrings.txt:197
-#: po/custom/fromJson.txt:2269
+#: po/custom/fromJson.txt:2290
 msgid "Hardened Base Structure Materials"
 msgstr ""
 
@@ -2583,7 +2583,7 @@ msgstr ""
 #. ... + 5 refs
 #: data/base/messages/strings/resstrings.txt:402
 #: data/mp/messages/strings/resstrings.txt:199
-#: po/custom/fromJson.txt:278
+#: po/custom/fromJson.txt:281
 msgid "All base structures upgraded automatically"
 msgstr ""
 
@@ -2594,7 +2594,7 @@ msgstr ""
 #. ... + 5 refs
 #: data/base/messages/strings/resstrings.txt:411
 #: data/mp/messages/strings/resstrings.txt:201
-#: po/custom/fromJson.txt:4406
+#: po/custom/fromJson.txt:4446
 msgid "Production Improved"
 msgstr ""
 
@@ -2604,7 +2604,7 @@ msgstr ""
 #. data/mp/messages/resmessages2.json: $.RES_ST_VFU1.text[1]
 #: data/base/messages/strings/resstrings.txt:412
 #: data/mp/messages/strings/resstrings.txt:202
-#: po/custom/fromJson.txt:4810
+#: po/custom/fromJson.txt:4857
 msgid "Robotic VTOL Production"
 msgstr ""
 
@@ -2615,7 +2615,7 @@ msgstr ""
 #. data/mp/messages/resmessages3.json: $.RES_ST_VFU4.text[2]
 #: data/base/messages/strings/resstrings.txt:413
 #: data/mp/messages/strings/resstrings.txt:203
-#: po/custom/fromJson.txt:3245
+#: po/custom/fromJson.txt:3269
 msgid "Increases VTOL factory output"
 msgstr ""
 
@@ -2626,7 +2626,7 @@ msgstr ""
 #. data/mp/messages/resmessages3.json: $.RES_ST_VFU4.text[3]
 #: data/base/messages/strings/resstrings.txt:414
 #: data/mp/messages/strings/resstrings.txt:204
-#: po/custom/fromJson.txt:449
+#: po/custom/fromJson.txt:452
 msgid "All VTOL factories upgraded automatically"
 msgstr ""
 
@@ -2637,7 +2637,7 @@ msgstr ""
 #. data/mp/messages/resmessages3.json: $.RES_ST_VPU4.text[0]
 #: data/base/messages/strings/resstrings.txt:421
 #: data/mp/messages/strings/resstrings.txt:206
-#: po/custom/fromJson.txt:5964
+#: po/custom/fromJson.txt:6022
 msgid "VTOL Rearming Times Reduced"
 msgstr ""
 
@@ -2648,7 +2648,7 @@ msgstr ""
 #. data/mp/stats/research.json: $.R-Struc-VTOLPad-Upgrade01.name
 #: data/base/messages/strings/resstrings.txt:422
 #: data/mp/messages/strings/resstrings.txt:207
-#: po/custom/fromJson.txt:971
+#: po/custom/fromJson.txt:976
 msgid "Automated VTOL Rearming"
 msgstr ""
 
@@ -2657,7 +2657,7 @@ msgstr ""
 #. data/base/messages/resmessages3.json: $.RES_ST_VPU4.text[2]
 #: data/base/messages/strings/resstrings.txt:423
 #: data/mp/messages/strings/resstrings.txt:208
-#: po/custom/fromJson.txt:4591
+#: po/custom/fromJson.txt:4635
 msgid "Reduces rearming time"
 msgstr ""
 
@@ -2668,7 +2668,7 @@ msgstr ""
 #. data/mp/messages/resmessages3.json: $.RES_ST_VPU4.text[3]
 #: data/base/messages/strings/resstrings.txt:424
 #: data/mp/messages/strings/resstrings.txt:209
-#: po/custom/fromJson.txt:390
+#: po/custom/fromJson.txt:393
 msgid "All rearming pads upgraded automatically"
 msgstr ""
 
@@ -2681,7 +2681,7 @@ msgstr ""
 #: data/base/messages/strings/resstrings.txt:479
 #: data/mp/messages/strings/resstrings.txt:211
 #: data/mp/messages/strings/resstrings.txt:226
-#: po/custom/fromJson.txt:4142
+#: po/custom/fromJson.txt:4180
 msgid "New Systems Turret Available"
 msgstr ""
 
@@ -2689,7 +2689,7 @@ msgstr ""
 #. data/mp/messages/resmessagesall.json: $.RES_REPTUHVY.text[1]
 #: data/base/messages/strings/resstrings.txt:444
 #: data/mp/messages/strings/resstrings.txt:212
-#: po/custom/fromJson.txt:2621
+#: po/custom/fromJson.txt:2642
 msgid "Heavy repair unit"
 msgstr ""
 
@@ -2699,7 +2699,7 @@ msgstr ""
 #. data/mp/messages/resmessagesall.json: $.RES_REPTUHVY.text[2]
 #: data/base/messages/strings/resstrings.txt:445
 #: data/mp/messages/strings/resstrings.txt:213
-#: po/custom/fromJson.txt:986
+#: po/custom/fromJson.txt:991
 msgid "Automatically Repairs Damaged Units"
 msgstr ""
 
@@ -2709,7 +2709,7 @@ msgstr ""
 #. data/mp/messages/resmessagesall.json: $.RES_REPTUHVY.text[3]
 #: data/base/messages/strings/resstrings.txt:446
 #: data/mp/messages/strings/resstrings.txt:214
-#: po/custom/fromJson.txt:4251
+#: po/custom/fromJson.txt:4289
 msgid "Or damaged units may be selected as target"
 msgstr ""
 
@@ -2733,7 +2733,7 @@ msgstr ""
 #. data/mp/messages/resmessages2.json: $.RES_SY_STW2.text[0]
 #: data/base/messages/strings/resstrings.txt:459
 #: data/mp/messages/strings/resstrings.txt:221
-#: po/custom/fromJson.txt:2990
+#: po/custom/fromJson.txt:3014
 msgid "Improved Sensor Tower Available"
 msgstr ""
 
@@ -2742,7 +2742,7 @@ msgstr ""
 #. data/mp/messages/resmessages2.json: $.RES_SY_STW2.text[1]
 #: data/base/messages/strings/resstrings.txt:460
 #: data/mp/messages/strings/resstrings.txt:222
-#: po/custom/fromJson.txt:3980
+#: po/custom/fromJson.txt:4018
 msgid "New construction techniques improve tower"
 msgstr ""
 
@@ -2751,7 +2751,7 @@ msgstr ""
 #. data/mp/messages/resmessages2.json: $.RES_SY_STW2.text[2]
 #: data/base/messages/strings/resstrings.txt:461
 #: data/mp/messages/strings/resstrings.txt:223
-#: po/custom/fromJson.txt:4674
+#: po/custom/fromJson.txt:4719
 msgid "Replaces existing sensor tower"
 msgstr ""
 
@@ -2762,7 +2762,7 @@ msgstr ""
 #. ... + 3 refs
 #: data/base/messages/strings/resstrings.txt:462
 #: data/mp/messages/strings/resstrings.txt:224
-#: po/custom/fromJson.txt:3608
+#: po/custom/fromJson.txt:3640
 msgid "May be assigned as spotter for indirect fire weapons"
 msgstr ""
 
@@ -2771,7 +2771,7 @@ msgstr ""
 #. data/mp/messages/resmessages2.json: $.RES_SY_VCBSTU1.text[1]
 #: data/base/messages/strings/resstrings.txt:480
 #: data/mp/messages/strings/resstrings.txt:227
-#: po/custom/fromJson.txt:5833
+#: po/custom/fromJson.txt:5891
 msgid "VTOL CB turret detects enemy indirect fire batteries"
 msgstr ""
 
@@ -2782,7 +2782,7 @@ msgstr ""
 #. data/mp/messages/resmessages23.json: $.RES_SY_VCBSTW1.text[2]
 #: data/base/messages/strings/resstrings.txt:481
 #: data/mp/messages/strings/resstrings.txt:228
-#: po/custom/fromJson.txt:4267
+#: po/custom/fromJson.txt:4305
 msgid "Orders assigned VTOLs to attack the enemy batteries"
 msgstr ""
 
@@ -2793,7 +2793,7 @@ msgstr ""
 #. data/mp/messages/resmessages23.json: $.RES_SY_VCBSTW1.text[3]
 #: data/base/messages/strings/resstrings.txt:482
 #: data/mp/messages/strings/resstrings.txt:229
-#: po/custom/fromJson.txt:6018
+#: po/custom/fromJson.txt:6076
 msgid "VTOLs attack until enemy battery is suppressed"
 msgstr ""
 
@@ -2804,7 +2804,7 @@ msgstr ""
 #. ... + 3 refs
 #: data/base/messages/strings/resstrings.txt:485
 #: data/mp/messages/strings/resstrings.txt:231
-#: po/custom/fromJson.txt:5811
+#: po/custom/fromJson.txt:5869
 msgid "VTOL CB Improved"
 msgstr ""
 
@@ -2815,7 +2815,7 @@ msgstr ""
 #. data/mp/messages/resmessages2.json: $.RES_SY_VCBSU1.text[1]
 #: data/base/messages/strings/resstrings.txt:486
 #: data/mp/messages/strings/resstrings.txt:232
-#: po/custom/fromJson.txt:4005
+#: po/custom/fromJson.txt:4043
 msgid "New fire detection systems"
 msgstr ""
 
@@ -2826,7 +2826,7 @@ msgstr ""
 #. ... + 3 refs
 #: data/base/messages/strings/resstrings.txt:487
 #: data/mp/messages/strings/resstrings.txt:233
-#: po/custom/fromJson.txt:1916
+#: po/custom/fromJson.txt:1927
 msgid "Extends VTOL CB Range"
 msgstr ""
 
@@ -2837,7 +2837,7 @@ msgstr ""
 #. ... + 3 refs
 #: data/base/messages/strings/resstrings.txt:488
 #: data/mp/messages/strings/resstrings.txt:234
-#: po/custom/fromJson.txt:443
+#: po/custom/fromJson.txt:446
 msgid "All VTOL CB sensors upgraded automatically"
 msgstr ""
 
@@ -2848,7 +2848,7 @@ msgstr ""
 #. ... + 3 refs
 #: data/base/messages/strings/resstrings.txt:499
 #: data/mp/messages/strings/resstrings.txt:236
-#: po/custom/fromJson.txt:5974
+#: po/custom/fromJson.txt:6032
 msgid "VTOL Strike Improved"
 msgstr ""
 
@@ -2857,7 +2857,7 @@ msgstr ""
 #. data/mp/messages/resmessages2.json: $.RES_SY_VS1.text[1]
 #: data/base/messages/strings/resstrings.txt:500
 #: data/mp/messages/strings/resstrings.txt:237
-#: po/custom/fromJson.txt:4146
+#: po/custom/fromJson.txt:4184
 msgid "New target recognition systems"
 msgstr ""
 
@@ -2868,7 +2868,7 @@ msgstr ""
 #. ... + 3 refs
 #: data/base/messages/strings/resstrings.txt:501
 #: data/mp/messages/strings/resstrings.txt:238
-#: po/custom/fromJson.txt:1922
+#: po/custom/fromJson.txt:1933
 msgid "Extends VTOL Strike Range"
 msgstr ""
 
@@ -2879,7 +2879,7 @@ msgstr ""
 #. ... + 3 refs
 #: data/base/messages/strings/resstrings.txt:502
 #: data/mp/messages/strings/resstrings.txt:239
-#: po/custom/fromJson.txt:455
+#: po/custom/fromJson.txt:458
 msgid "All VTOL Strike sensors upgraded automatically"
 msgstr ""
 
@@ -2908,7 +2908,7 @@ msgstr ""
 #. data/mp/messages/resmessages2.json: $.RES_V_B02.text[0]
 #: data/base/messages/strings/resstrings.txt:527
 #: data/mp/messages/strings/resstrings.txt:246
-#: po/custom/fromJson.txt:1424
+#: po/custom/fromJson.txt:1433
 msgid "Collective Light Body"
 msgstr ""
 
@@ -2919,7 +2919,7 @@ msgstr ""
 #. data/mp/messages/resmessages3.json: $.RES_V_B03.text[1]
 #: data/base/messages/strings/resstrings.txt:528
 #: data/mp/messages/strings/resstrings.txt:247
-#: po/custom/fromJson.txt:5297
+#: po/custom/fromJson.txt:5350
 msgid "Superior armor and body points to Viper"
 msgstr ""
 
@@ -2928,7 +2928,7 @@ msgstr ""
 #. data/mp/messages/resmessages2.json: $.RES_V_B02.text[2]
 #: data/base/messages/strings/resstrings.txt:529
 #: data/mp/messages/strings/resstrings.txt:248
-#: po/custom/fromJson.txt:5111
+#: po/custom/fromJson.txt:5164
 msgid "Slower than Viper"
 msgstr ""
 
@@ -2937,7 +2937,7 @@ msgstr ""
 #. data/mp/messages/resmessages2.json: $.RES_V_B02.text[3]
 #: data/base/messages/strings/resstrings.txt:530
 #: data/mp/messages/strings/resstrings.txt:249
-#: po/custom/fromJson.txt:2753
+#: po/custom/fromJson.txt:2774
 msgid "High power costs and slower to produce than Viper"
 msgstr ""
 
@@ -2946,7 +2946,7 @@ msgstr ""
 #. data/mp/messages/resmessages2.json: $.RES_V_B06.text[0]
 #: data/base/messages/strings/resstrings.txt:539
 #: data/mp/messages/strings/resstrings.txt:251
-#: po/custom/fromJson.txt:1428
+#: po/custom/fromJson.txt:1437
 msgid "Collective Medium Body"
 msgstr ""
 
@@ -2957,7 +2957,7 @@ msgstr ""
 #. data/mp/messages/resmessages3.json: $.RES_V_B07.text[1]
 #: data/base/messages/strings/resstrings.txt:540
 #: data/mp/messages/strings/resstrings.txt:252
-#: po/custom/fromJson.txt:5291
+#: po/custom/fromJson.txt:5344
 msgid "Superior armor and body points to Cobra"
 msgstr ""
 
@@ -2966,7 +2966,7 @@ msgstr ""
 #. data/mp/messages/resmessages2.json: $.RES_V_B06.text[2]
 #: data/base/messages/strings/resstrings.txt:541
 #: data/mp/messages/strings/resstrings.txt:253
-#: po/custom/fromJson.txt:5103
+#: po/custom/fromJson.txt:5156
 msgid "Slower than Cobra"
 msgstr ""
 
@@ -2975,7 +2975,7 @@ msgstr ""
 #. data/mp/messages/resmessages2.json: $.RES_V_B06.text[3]
 #: data/base/messages/strings/resstrings.txt:542
 #: data/mp/messages/strings/resstrings.txt:254
-#: po/custom/fromJson.txt:2749
+#: po/custom/fromJson.txt:2770
 msgid "High power costs and slower to produce than Cobra"
 msgstr ""
 
@@ -2986,7 +2986,7 @@ msgstr ""
 #. ... + 5 refs
 #: data/base/messages/strings/resstrings.txt:559
 #: data/mp/messages/strings/resstrings.txt:256
-#: po/custom/fromJson.txt:5698
+#: po/custom/fromJson.txt:5755
 msgid "Vehicle Engine Upgrade"
 msgstr ""
 
@@ -2997,7 +2997,7 @@ msgstr ""
 #. data/mp/stats/research.json: $.R-Vehicle-Engine04.name
 #: data/base/messages/strings/resstrings.txt:560
 #: data/mp/messages/strings/resstrings.txt:257
-#: po/custom/fromJson.txt:5564
+#: po/custom/fromJson.txt:5621
 msgid "Turbo-Charged Engine"
 msgstr ""
 
@@ -3008,7 +3008,7 @@ msgstr ""
 #. data/base/messages/resmessages3.json: $.RES_V_EN7.text[2]
 #: data/base/messages/strings/resstrings.txt:561
 #: data/mp/messages/strings/resstrings.txt:258
-#: po/custom/fromJson.txt:3022
+#: po/custom/fromJson.txt:3046
 msgid "Improves vehicle speed"
 msgstr ""
 
@@ -3023,7 +3023,7 @@ msgstr ""
 #: data/mp/messages/strings/resstrings.txt:259
 #: data/mp/messages/strings/resstrings.txt:264
 #: data/mp/messages/strings/resstrings.txt:269
-#: po/custom/fromJson.txt:437
+#: po/custom/fromJson.txt:440
 msgid "All vehicles upgraded automatically"
 msgstr ""
 
@@ -3034,7 +3034,7 @@ msgstr ""
 #. ... + 5 refs
 #: data/base/messages/strings/resstrings.txt:571
 #: data/mp/messages/strings/resstrings.txt:261
-#: po/custom/fromJson.txt:5692
+#: po/custom/fromJson.txt:5749
 msgid "Vehicle Bodies Improved"
 msgstr ""
 
@@ -3045,7 +3045,7 @@ msgstr ""
 #. data/base/messages/resmessages3.json: $.RES_V_MET7.text[2]
 #: data/base/messages/strings/resstrings.txt:573
 #: data/mp/messages/strings/resstrings.txt:263
-#: po/custom/fromJson.txt:3149
+#: po/custom/fromJson.txt:3173
 msgid "Increases kinetic armor and body points"
 msgstr ""
 
@@ -3056,7 +3056,7 @@ msgstr ""
 #. ... + 2 refs
 #: data/base/messages/strings/resstrings.txt:581
 #: data/mp/messages/strings/resstrings.txt:266
-#: po/custom/fromJson.txt:5730
+#: po/custom/fromJson.txt:5788
 msgid "Vehicle Thermal Armor Improved"
 msgstr ""
 
@@ -3067,7 +3067,7 @@ msgstr ""
 #. ... + 2 refs
 #: data/base/messages/strings/resstrings.txt:582
 #: data/mp/messages/strings/resstrings.txt:267
-#: po/custom/fromJson.txt:2434
+#: po/custom/fromJson.txt:2455
 msgid "Heat-resistant armored layers"
 msgstr ""
 
@@ -3076,7 +3076,7 @@ msgstr ""
 #. data/base/messages/resmessages3.json: $.RES_V_AH4.text[2]
 #: data/base/messages/strings/resstrings.txt:583
 #: data/mp/messages/strings/resstrings.txt:268
-#: po/custom/fromJson.txt:3239
+#: po/custom/fromJson.txt:3263
 msgid "Increases Thermal Armor"
 msgstr ""
 
@@ -3093,7 +3093,7 @@ msgstr ""
 #: data/mp/messages/strings/resstrings.txt:276
 #: data/mp/messages/strings/resstrings.txt:281
 #: data/mp/messages/strings/resstrings.txt:286
-#: po/custom/fromJson.txt:5709
+#: po/custom/fromJson.txt:5766
 msgid "Vehicle Propulsion Improved"
 msgstr ""
 
@@ -3110,7 +3110,7 @@ msgstr ""
 #: data/mp/messages/strings/resstrings.txt:277
 #: data/mp/messages/strings/resstrings.txt:282
 #: data/mp/messages/strings/resstrings.txt:287
-#: po/custom/fromJson.txt:3946
+#: po/custom/fromJson.txt:3984
 msgid "New armored construction"
 msgstr ""
 
@@ -3127,7 +3127,7 @@ msgstr ""
 #: data/mp/messages/strings/resstrings.txt:278
 #: data/mp/messages/strings/resstrings.txt:283
 #: data/mp/messages/strings/resstrings.txt:288
-#: po/custom/fromJson.txt:3076
+#: po/custom/fromJson.txt:3100
 msgid "Increases Body Points"
 msgstr ""
 
@@ -3138,7 +3138,7 @@ msgstr ""
 #. data/mp/messages/resmessages3.json: $.RES_HALFT3.text[3]
 #: data/base/messages/strings/resstrings.txt:594
 #: data/mp/messages/strings/resstrings.txt:274
-#: po/custom/fromJson.txt:330
+#: po/custom/fromJson.txt:333
 msgid "All half-tracks upgraded automatically"
 msgstr ""
 
@@ -3149,7 +3149,7 @@ msgstr ""
 #. data/mp/messages/resmessages3.json: $.RES_V_P_H3.text[3]
 #: data/base/messages/strings/resstrings.txt:604
 #: data/mp/messages/strings/resstrings.txt:279
-#: po/custom/fromJson.txt:336
+#: po/custom/fromJson.txt:339
 msgid "All hovers upgraded automatically"
 msgstr ""
 
@@ -3160,7 +3160,7 @@ msgstr ""
 #. data/mp/messages/resmessages3.json: $.RES_TRACK3.text[3]
 #: data/base/messages/strings/resstrings.txt:614
 #: data/mp/messages/strings/resstrings.txt:284
-#: po/custom/fromJson.txt:420
+#: po/custom/fromJson.txt:423
 msgid "All tracks upgraded automatically"
 msgstr ""
 
@@ -3171,7 +3171,7 @@ msgstr ""
 #. data/mp/messages/resmessages3.json: $.RES_V_P_W3.text[3]
 #: data/base/messages/strings/resstrings.txt:624
 #: data/mp/messages/strings/resstrings.txt:289
-#: po/custom/fromJson.txt:467
+#: po/custom/fromJson.txt:470
 msgid "All wheels upgraded automatically"
 msgstr ""
 
@@ -3188,7 +3188,7 @@ msgstr ""
 #: data/mp/messages/strings/resstrings.txt:296
 #: data/mp/messages/strings/resstrings.txt:301
 #: data/mp/messages/strings/resstrings.txt:306
-#: po/custom/fromJson.txt:3937
+#: po/custom/fromJson.txt:3975
 msgid "New AA Turret Available"
 msgstr ""
 
@@ -3197,7 +3197,7 @@ msgstr ""
 #. data/mp/messages/resmessages2.json: $.RES_W_AA1.text[1]
 #: data/base/messages/strings/resstrings.txt:636
 #: data/mp/messages/strings/resstrings.txt:292
-#: po/custom/fromJson.txt:5575
+#: po/custom/fromJson.txt:5632
 msgid "Twin 80mm flak weapon"
 msgstr ""
 
@@ -3214,7 +3214,7 @@ msgstr ""
 #: data/mp/messages/strings/resstrings.txt:298
 #: data/mp/messages/strings/resstrings.txt:303
 #: data/mp/messages/strings/resstrings.txt:308
-#: po/custom/fromJson.txt:253
+#: po/custom/fromJson.txt:256
 msgid "Aerial targets only"
 msgstr ""
 
@@ -3223,7 +3223,7 @@ msgstr ""
 #. data/mp/messages/resmessages2.json: $.RES_W_AA2.text[1]
 #: data/base/messages/strings/resstrings.txt:642
 #: data/mp/messages/strings/resstrings.txt:297
-#: po/custom/fromJson.txt:4489
+#: po/custom/fromJson.txt:4529
 msgid "Quad 80mm flak weapon"
 msgstr ""
 
@@ -3242,7 +3242,7 @@ msgstr ""
 #. data/mp/messages/resmessagesall.json: $.RES_WT_QUADAA.text[1]
 #: data/base/messages/strings/resstrings.txt:654
 #: data/mp/messages/strings/resstrings.txt:307
-#: po/custom/fromJson.txt:4482
+#: po/custom/fromJson.txt:4522
 msgid "Quad 30mm Anti-Aircraft machinegun"
 msgstr ""
 
@@ -3255,7 +3255,7 @@ msgstr ""
 #: data/base/messages/strings/resstrings.txt:677
 #: data/mp/messages/strings/resstrings.txt:311
 #: data/mp/messages/strings/resstrings.txt:321
-#: po/custom/fromJson.txt:151
+#: po/custom/fromJson.txt:154
 msgid "AA Upgrade"
 msgstr ""
 
@@ -3264,7 +3264,7 @@ msgstr ""
 #. data/mp/messages/resmessages2.json: $.RES_W_AAAC1.text[1]
 #: data/base/messages/strings/resstrings.txt:660
 #: data/mp/messages/strings/resstrings.txt:312
-#: po/custom/fromJson.txt:1788
+#: po/custom/fromJson.txt:1799
 msgid "Detects and locks-on to VTOL engine emissions"
 msgstr ""
 
@@ -3274,7 +3274,7 @@ msgstr ""
 #. data/base/messages/resmessages3.json: $.RES_W_AAAC3.text[2]
 #: data/base/messages/strings/resstrings.txt:661
 #: data/mp/messages/strings/resstrings.txt:313
-#: po/custom/fromJson.txt:3053
+#: po/custom/fromJson.txt:3077
 msgid "Increases AA accuracy"
 msgstr ""
 
@@ -3287,7 +3287,7 @@ msgstr ""
 #: data/base/messages/strings/resstrings.txt:680
 #: data/mp/messages/strings/resstrings.txt:314
 #: data/mp/messages/strings/resstrings.txt:324
-#: po/custom/fromJson.txt:272
+#: po/custom/fromJson.txt:275
 msgid "All AA weapons upgraded automatically"
 msgstr ""
 
@@ -3298,7 +3298,7 @@ msgstr ""
 #. data/mp/messages/resmessages3.json: $.RES_W_AAD4.text[0]
 #: data/base/messages/strings/resstrings.txt:669
 #: data/mp/messages/strings/resstrings.txt:316
-#: po/custom/fromJson.txt:89
+#: po/custom/fromJson.txt:91
 msgid "AA Flak Upgrade"
 msgstr ""
 
@@ -3307,7 +3307,7 @@ msgstr ""
 #. data/mp/messages/resmessages2.json: $.RES_W_AAD1.text[1]
 #: data/base/messages/strings/resstrings.txt:670
 #: data/mp/messages/strings/resstrings.txt:317
-#: po/custom/fromJson.txt:2712
+#: po/custom/fromJson.txt:2733
 msgid "High Explosive Flak shards"
 msgstr ""
 
@@ -3316,7 +3316,7 @@ msgstr ""
 #. data/base/messages/resmessages3.json: $.RES_W_AAD4.text[2]
 #: data/base/messages/strings/resstrings.txt:671
 #: data/mp/messages/strings/resstrings.txt:318
-#: po/custom/fromJson.txt:3057
+#: po/custom/fromJson.txt:3081
 msgid "Increases AA Flak damage"
 msgstr ""
 
@@ -3327,7 +3327,7 @@ msgstr ""
 #. data/mp/messages/resmessages3.json: $.RES_W_AAD4.text[3]
 #: data/base/messages/strings/resstrings.txt:672
 #: data/mp/messages/strings/resstrings.txt:319
-#: po/custom/fromJson.txt:266
+#: po/custom/fromJson.txt:269
 msgid "All AA flak weapons upgraded automatically"
 msgstr ""
 
@@ -3336,7 +3336,7 @@ msgstr ""
 #. data/mp/messages/resmessages2.json: $.RES_W_AAROF1.text[1]
 #: data/base/messages/strings/resstrings.txt:678
 #: data/mp/messages/strings/resstrings.txt:322
-#: po/custom/fromJson.txt:4581
+#: po/custom/fromJson.txt:4625
 msgid "Recoil loaded AA ammunition hopper"
 msgstr ""
 
@@ -3345,7 +3345,7 @@ msgstr ""
 #. data/base/messages/resmessages3.json: $.RES_W_AAROF4.text[2]
 #: data/base/messages/strings/resstrings.txt:679
 #: data/mp/messages/strings/resstrings.txt:323
-#: po/custom/fromJson.txt:3061
+#: po/custom/fromJson.txt:3085
 msgid "Increases AA ROF"
 msgstr ""
 
@@ -3358,7 +3358,7 @@ msgstr ""
 #: data/base/messages/strings/resstrings.txt:691
 #: data/mp/messages/strings/resstrings.txt:326
 #: data/mp/messages/strings/resstrings.txt:331
-#: po/custom/fromJson.txt:4070
+#: po/custom/fromJson.txt:4108
 msgid "New Proximity Bomb Turret Available"
 msgstr ""
 
@@ -3367,7 +3367,7 @@ msgstr ""
 #. data/mp/messages/resmessages2.json: $.RES_W_PBMB1.text[1]
 #: data/base/messages/strings/resstrings.txt:686
 #: data/mp/messages/strings/resstrings.txt:327
-#: po/custom/fromJson.txt:1198
+#: po/custom/fromJson.txt:1204
 msgid "Bomb turret explodes in proximity to enemy"
 msgstr ""
 
@@ -3380,7 +3380,7 @@ msgstr ""
 #: data/base/messages/strings/resstrings.txt:693
 #: data/mp/messages/strings/resstrings.txt:328
 #: data/mp/messages/strings/resstrings.txt:333
-#: po/custom/fromJson.txt:1070
+#: po/custom/fromJson.txt:1075
 msgid "Best Targets: Base Structures and Defenses"
 msgstr ""
 
@@ -3389,7 +3389,7 @@ msgstr ""
 #. data/mp/messages/resmessages2.json: $.RES_W_PBMB2.text[1]
 #: data/base/messages/strings/resstrings.txt:692
 #: data/mp/messages/strings/resstrings.txt:332
-#: po/custom/fromJson.txt:5234
+#: po/custom/fromJson.txt:5287
 msgid "Superbomb turret explodes in proximity to enemy"
 msgstr ""
 
@@ -3402,7 +3402,7 @@ msgstr ""
 #: data/base/messages/strings/resstrings.txt:703
 #: data/mp/messages/strings/resstrings.txt:336
 #: data/mp/messages/strings/resstrings.txt:341
-#: po/custom/fromJson.txt:3972
+#: po/custom/fromJson.txt:4010
 msgid "New Bomb Bay Available"
 msgstr ""
 
@@ -3411,7 +3411,7 @@ msgstr ""
 #. data/mp/messages/resmessages2.json: $.RES_W_BMB1.text[1]
 #: data/base/messages/strings/resstrings.txt:698
 #: data/mp/messages/strings/resstrings.txt:337
-#: po/custom/fromJson.txt:1814
+#: po/custom/fromJson.txt:1825
 msgid "Drops High Explosive Cluster bombs"
 msgstr ""
 
@@ -3420,7 +3420,7 @@ msgstr ""
 #. data/mp/messages/resmessages2.json: $.RES_W_BMB1.text[2]
 #: data/base/messages/strings/resstrings.txt:699
 #: data/mp/messages/strings/resstrings.txt:338
-#: po/custom/fromJson.txt:1074
+#: po/custom/fromJson.txt:1079
 msgid "Best Targets: Base Structures"
 msgstr ""
 
@@ -3441,7 +3441,7 @@ msgstr ""
 #: data/mp/messages/strings/resstrings.txt:374
 #: data/mp/messages/strings/resstrings.txt:379
 #: data/mp/messages/strings/resstrings.txt:384
-#: po/custom/fromJson.txt:1172
+#: po/custom/fromJson.txt:1177
 msgid "Body Points: Low"
 msgstr ""
 
@@ -3450,7 +3450,7 @@ msgstr ""
 #. data/mp/messages/resmessages2.json: $.RES_W_BMB2.text[1]
 #: data/base/messages/strings/resstrings.txt:704
 #: data/mp/messages/strings/resstrings.txt:342
-#: po/custom/fromJson.txt:1810
+#: po/custom/fromJson.txt:1821
 msgid "Drops High Explosive Armor Piercing bombs"
 msgstr ""
 
@@ -3459,7 +3459,7 @@ msgstr ""
 #. data/mp/messages/resmessages2.json: $.RES_W_BMB2.text[2]
 #: data/base/messages/strings/resstrings.txt:705
 #: data/mp/messages/strings/resstrings.txt:343
-#: po/custom/fromJson.txt:1120
+#: po/custom/fromJson.txt:1125
 msgid "Best Targets: Defenses"
 msgstr ""
 
@@ -3469,7 +3469,7 @@ msgstr ""
 #. data/base/messages/resmessages3.json: $.RES_W_BAC3.text[0]
 #: data/base/messages/strings/resstrings.txt:713
 #: data/mp/messages/strings/resstrings.txt:346
-#: po/custom/fromJson.txt:1225
+#: po/custom/fromJson.txt:1231
 msgid "Bombsight Upgrade"
 msgstr ""
 
@@ -3477,7 +3477,7 @@ msgstr ""
 #. data/base/messages/resmessages2.json: $.RES_W_BAC1.text[1]
 #: data/base/messages/strings/resstrings.txt:714
 #: data/mp/messages/strings/resstrings.txt:347
-#: po/custom/fromJson.txt:3520
+#: po/custom/fromJson.txt:3550
 msgid "Locks on to thermal emissions"
 msgstr ""
 
@@ -3487,7 +3487,7 @@ msgstr ""
 #. data/base/messages/resmessages3.json: $.RES_W_BAC3.text[2]
 #: data/base/messages/strings/resstrings.txt:715
 #: data/mp/messages/strings/resstrings.txt:348
-#: po/custom/fromJson.txt:3081
+#: po/custom/fromJson.txt:3105
 msgid "Increases Bombing accuracy"
 msgstr ""
 
@@ -3498,7 +3498,7 @@ msgstr ""
 #. ... + 3 refs
 #: data/base/messages/strings/resstrings.txt:716
 #: data/mp/messages/strings/resstrings.txt:349
-#: po/custom/fromJson.txt:284
+#: po/custom/fromJson.txt:287
 msgid "All bomb bays upgraded automatically"
 msgstr ""
 
@@ -3513,7 +3513,7 @@ msgstr ""
 #: data/mp/messages/strings/resstrings.txt:351
 #: data/mp/messages/strings/resstrings.txt:356
 #: data/mp/messages/strings/resstrings.txt:361
-#: po/custom/fromJson.txt:4160
+#: po/custom/fromJson.txt:4198
 msgid "New Weapon Turret Available"
 msgstr ""
 
@@ -3522,7 +3522,7 @@ msgstr ""
 #. data/mp/messages/resmessages2.json: $.RES_W_CN_4A.text[1]
 #: data/base/messages/strings/resstrings.txt:730
 #: data/mp/messages/strings/resstrings.txt:352
-#: po/custom/fromJson.txt:2912
+#: po/custom/fromJson.txt:2936
 msgid "Hyper-velocity automatic-cannon firing 88mm rounds"
 msgstr ""
 
@@ -3535,7 +3535,7 @@ msgstr ""
 #: data/base/messages/strings/resstrings.txt:737
 #: data/mp/messages/strings/resstrings.txt:353
 #: data/mp/messages/strings/resstrings.txt:358
-#: po/custom/fromJson.txt:1139
+#: po/custom/fromJson.txt:1144
 msgid "Best Targets: Vehicles"
 msgstr ""
 
@@ -3544,7 +3544,7 @@ msgstr ""
 #. data/mp/messages/resmessages2.json: $.RES_W_CN_4A.text[3]
 #: data/base/messages/strings/resstrings.txt:732
 #: data/mp/messages/strings/resstrings.txt:354
-#: po/custom/fromJson.txt:4678
+#: po/custom/fromJson.txt:4723
 msgid "Replaces Medium Cannon"
 msgstr ""
 
@@ -3564,7 +3564,7 @@ msgstr ""
 #. ... + 11 refs
 #: data/base/messages/strings/resstrings.txt:738
 #: data/mp/messages/strings/resstrings.txt:359
-#: po/custom/fromJson.txt:1166
+#: po/custom/fromJson.txt:1171
 msgid "Body Points: High"
 msgstr ""
 
@@ -3573,7 +3573,7 @@ msgstr ""
 #. data/mp/messages/resmessages2.json: $.RES_FLAME2.text[1]
 #: data/base/messages/strings/resstrings.txt:758
 #: data/mp/messages/strings/resstrings.txt:362
-#: po/custom/fromJson.txt:2506
+#: po/custom/fromJson.txt:2527
 msgid "Heavy Flame-thrower firing Propylene Oxide gel"
 msgstr ""
 
@@ -3584,7 +3584,7 @@ msgstr ""
 #. ... + 2 refs
 #: data/base/messages/strings/resstrings.txt:759
 #: data/mp/messages/strings/resstrings.txt:363
-#: po/custom/fromJson.txt:1110
+#: po/custom/fromJson.txt:1115
 msgid "Best Targets: Bunkers, wheeled and hover vehicles"
 msgstr ""
 
@@ -3595,7 +3595,7 @@ msgstr ""
 #. ... + 4 refs
 #: data/base/messages/strings/resstrings.txt:765
 #: data/mp/messages/strings/resstrings.txt:366
-#: po/custom/fromJson.txt:2057
+#: po/custom/fromJson.txt:2073
 msgid "Flamer Upgrade"
 msgstr ""
 
@@ -3605,7 +3605,7 @@ msgstr ""
 #. data/mp/messages/resmessagesall.json: $.RES_W_FL_D7.text[1]
 #: data/base/messages/strings/resstrings.txt:766
 #: data/mp/messages/strings/resstrings.txt:367
-#: po/custom/fromJson.txt:4427
+#: po/custom/fromJson.txt:4467
 msgid "Propylene Oxide treated to burn at superhot temperatures"
 msgstr ""
 
@@ -3614,7 +3614,7 @@ msgstr ""
 #. data/base/messages/resmessages2.json: $.RES_W_FL_D4.text[2]
 #: data/base/messages/strings/resstrings.txt:767
 #: data/mp/messages/strings/resstrings.txt:368
-#: po/custom/fromJson.txt:3122
+#: po/custom/fromJson.txt:3146
 msgid "Increases Flamer damage"
 msgstr ""
 
@@ -3625,7 +3625,7 @@ msgstr ""
 #. ... + 4 refs
 #: data/base/messages/strings/resstrings.txt:768
 #: data/mp/messages/strings/resstrings.txt:369
-#: po/custom/fromJson.txt:324
+#: po/custom/fromJson.txt:327
 msgid "All flamers upgraded automatically"
 msgstr ""
 
@@ -3642,7 +3642,7 @@ msgstr ""
 #: data/mp/messages/strings/resstrings.txt:376
 #: data/mp/messages/strings/resstrings.txt:381
 #: data/mp/messages/strings/resstrings.txt:411
-#: po/custom/fromJson.txt:4011
+#: po/custom/fromJson.txt:4049
 msgid "New Indirect Fire Weapon Available"
 msgstr ""
 
@@ -3664,7 +3664,7 @@ msgstr ""
 #: data/base/messages/strings/resstrings.txt:781
 #: data/mp/messages/strings/resstrings.txt:373
 #: data/mp/messages/strings/resstrings.txt:378
-#: po/custom/fromJson.txt:1088
+#: po/custom/fromJson.txt:1093
 msgid "Best Targets: Base Structures, infantry, wheeled vehicles"
 msgstr ""
 
@@ -3691,7 +3691,7 @@ msgstr ""
 #. data/mp/messages/resmessages2.json: $.RES_W_IHOW.text[2]
 #: data/base/messages/strings/resstrings.txt:789
 #: data/mp/messages/strings/resstrings.txt:383
-#: po/custom/fromJson.txt:1082
+#: po/custom/fromJson.txt:1087
 msgid "Best Targets: Base Structures, bunkers"
 msgstr ""
 
@@ -3706,7 +3706,7 @@ msgstr ""
 #: data/mp/messages/strings/resstrings.txt:386
 #: data/mp/messages/strings/resstrings.txt:391
 #: data/mp/messages/strings/resstrings.txt:396
-#: po/custom/fromJson.txt:2840
+#: po/custom/fromJson.txt:2864
 msgid "Howitzer Upgrade"
 msgstr ""
 
@@ -3717,7 +3717,7 @@ msgstr ""
 #. data/mp/messages/resmessages23.json: $.RES_W_AAAC2.text[1]
 #: data/base/messages/strings/resstrings.txt:794
 #: data/mp/messages/strings/resstrings.txt:387
-#: po/custom/fromJson.txt:5027
+#: po/custom/fromJson.txt:5077
 msgid "Self-guided rocket powered shells"
 msgstr ""
 
@@ -3726,7 +3726,7 @@ msgstr ""
 #. data/base/messages/resmessages3.json: $.RES_W_HOWAC3.text[2]
 #: data/base/messages/strings/resstrings.txt:795
 #: data/mp/messages/strings/resstrings.txt:388
-#: po/custom/fromJson.txt:3129
+#: po/custom/fromJson.txt:3153
 msgid "Increases Howitzer accuracy"
 msgstr ""
 
@@ -3741,7 +3741,7 @@ msgstr ""
 #: data/mp/messages/strings/resstrings.txt:389
 #: data/mp/messages/strings/resstrings.txt:394
 #: data/mp/messages/strings/resstrings.txt:399
-#: po/custom/fromJson.txt:342
+#: po/custom/fromJson.txt:345
 msgid "All howitzers upgraded automatically"
 msgstr ""
 
@@ -3751,7 +3751,7 @@ msgstr ""
 #. data/mp/messages/resmessages2.json: $.RES_W_HOWD1.text[1]
 #: data/base/messages/strings/resstrings.txt:802
 #: data/mp/messages/strings/resstrings.txt:392
-#: po/custom/fromJson.txt:2725
+#: po/custom/fromJson.txt:2746
 msgid "High Explosive shells"
 msgstr ""
 
@@ -3760,7 +3760,7 @@ msgstr ""
 #. data/base/messages/resmessages3.json: $.RES_W_HOWD4.text[2]
 #: data/base/messages/strings/resstrings.txt:803
 #: data/mp/messages/strings/resstrings.txt:393
-#: po/custom/fromJson.txt:3133
+#: po/custom/fromJson.txt:3157
 msgid "Increases Howitzer damage"
 msgstr ""
 
@@ -3771,7 +3771,7 @@ msgstr ""
 #. ... + 3 refs
 #: data/base/messages/strings/resstrings.txt:810
 #: data/mp/messages/strings/resstrings.txt:397
-#: po/custom/fromJson.txt:981
+#: po/custom/fromJson.txt:986
 msgid "Automatic loading mechanism replaces manual loader"
 msgstr ""
 
@@ -3780,7 +3780,7 @@ msgstr ""
 #. data/base/messages/resmessages3.json: $.RES_W_HOWRF4.text[2]
 #: data/base/messages/strings/resstrings.txt:811
 #: data/mp/messages/strings/resstrings.txt:398
-#: po/custom/fromJson.txt:3137
+#: po/custom/fromJson.txt:3161
 msgid "Increases Howitzer ROF"
 msgstr ""
 
@@ -3793,7 +3793,7 @@ msgstr ""
 #: data/base/messages/strings/resstrings.txt:857
 #: data/mp/messages/strings/resstrings.txt:401
 #: data/mp/messages/strings/resstrings.txt:406
-#: po/custom/fromJson.txt:3557
+#: po/custom/fromJson.txt:3589
 msgid "Machinegun Upgrade"
 msgstr ""
 
@@ -3802,7 +3802,7 @@ msgstr ""
 #. data/mp/messages/resmessages2.json: $.RES_W_MG_D5.text[1]
 #: data/base/messages/strings/resstrings.txt:846
 #: data/mp/messages/strings/resstrings.txt:402
-#: po/custom/fromJson.txt:5538
+#: po/custom/fromJson.txt:5595
 msgid "Tungsten-tipped armor-piercing bullets"
 msgstr ""
 
@@ -3813,7 +3813,7 @@ msgstr ""
 #. ... + 2 refs
 #: data/base/messages/strings/resstrings.txt:847
 #: data/mp/messages/strings/resstrings.txt:403
-#: po/custom/fromJson.txt:3164
+#: po/custom/fromJson.txt:3188
 msgid "Increases Machinegun damage"
 msgstr ""
 
@@ -3826,7 +3826,7 @@ msgstr ""
 #: data/base/messages/strings/resstrings.txt:860
 #: data/mp/messages/strings/resstrings.txt:404
 #: data/mp/messages/strings/resstrings.txt:409
-#: po/custom/fromJson.txt:354
+#: po/custom/fromJson.txt:357
 msgid "All machineguns upgraded automatically"
 msgstr ""
 
@@ -3835,7 +3835,7 @@ msgstr ""
 #. data/mp/messages/resmessages2.json: $.RES_W_MG_ROF2.text[1]
 #: data/base/messages/strings/resstrings.txt:858
 #: data/mp/messages/strings/resstrings.txt:407
-#: po/custom/fromJson.txt:2926
+#: po/custom/fromJson.txt:2950
 msgid "Improved chaingun mechanism"
 msgstr ""
 
@@ -3845,7 +3845,7 @@ msgstr ""
 #. data/base/messages/resmessages23.json: $.RES_W_MG_ROF3.text[2]
 #: data/base/messages/strings/resstrings.txt:859
 #: data/mp/messages/strings/resstrings.txt:408
-#: po/custom/fromJson.txt:3169
+#: po/custom/fromJson.txt:3193
 msgid "Increases Machinegun ROF"
 msgstr ""
 
@@ -3856,7 +3856,7 @@ msgstr ""
 #. data/mp/messages/resmessages2.json: $.RES_W_M3.text[1]
 #: data/base/messages/strings/resstrings.txt:892
 #: data/mp/messages/strings/resstrings.txt:412
-#: po/custom/fromJson.txt:3614
+#: po/custom/fromJson.txt:3646
 msgid "May be assigned to a sensor"
 msgstr ""
 
@@ -3867,7 +3867,7 @@ msgstr ""
 #. ... + 4 refs
 #: data/base/messages/strings/resstrings.txt:893
 #: data/mp/messages/strings/resstrings.txt:413
-#: po/custom/fromJson.txt:1094
+#: po/custom/fromJson.txt:1099
 msgid "Best Targets: Base structures, infantry, wheeled vehicles"
 msgstr ""
 
@@ -3878,7 +3878,7 @@ msgstr ""
 #. ... + 28 refs
 #: data/base/messages/strings/resstrings.txt:894
 #: data/mp/messages/strings/resstrings.txt:414
-#: po/custom/fromJson.txt:1184
+#: po/custom/fromJson.txt:1189
 msgid "Body Points: Very Low"
 msgstr ""
 
@@ -3889,7 +3889,7 @@ msgstr ""
 #. ... + 11 refs
 #: data/base/messages/strings/resstrings.txt:905
 #: data/mp/messages/strings/resstrings.txt:416
-#: po/custom/fromJson.txt:3863
+#: po/custom/fromJson.txt:3901
 msgid "Mortar Upgrade"
 msgstr ""
 
@@ -3898,7 +3898,7 @@ msgstr ""
 #. data/mp/messages/resmessages2.json: $.RES_W_M_D4.text[1]
 #: data/base/messages/strings/resstrings.txt:906
 #: data/mp/messages/strings/resstrings.txt:417
-#: po/custom/fromJson.txt:2701
+#: po/custom/fromJson.txt:2722
 msgid "High Explosive Armor-Piercing Shells"
 msgstr ""
 
@@ -3907,7 +3907,7 @@ msgstr ""
 #. data/base/messages/resmessages2.json: $.RES_W_M_D4.text[2]
 #: data/base/messages/strings/resstrings.txt:907
 #: data/mp/messages/strings/resstrings.txt:418
-#: po/custom/fromJson.txt:3199
+#: po/custom/fromJson.txt:3223
 msgid "Increases Mortar damage"
 msgstr ""
 
@@ -3918,7 +3918,7 @@ msgstr ""
 #. ... + 11 refs
 #: data/base/messages/strings/resstrings.txt:908
 #: data/mp/messages/strings/resstrings.txt:419
-#: po/custom/fromJson.txt:372
+#: po/custom/fromJson.txt:375
 msgid "All mortars upgraded automatically"
 msgstr ""
 
@@ -3931,7 +3931,7 @@ msgstr ""
 #: data/base/messages/strings/resstrings.txt:951
 #: data/mp/messages/strings/resstrings.txt:421
 #: data/mp/messages/strings/resstrings.txt:426
-#: po/custom/fromJson.txt:3758
+#: po/custom/fromJson.txt:3790
 msgid "Mini-Rocket Upgrade"
 msgstr ""
 
@@ -3939,7 +3939,7 @@ msgstr ""
 #. data/base/messages/resmessages2.json: $.RES_W_RK_D4.text[1]
 #: data/base/messages/strings/resstrings.txt:944
 #: data/mp/messages/strings/resstrings.txt:422
-#: po/custom/fromJson.txt:2704
+#: po/custom/fromJson.txt:2725
 msgid "High Explosive Armor-Piercing warheads"
 msgstr ""
 
@@ -3948,7 +3948,7 @@ msgstr ""
 #. data/base/messages/resmessages2.json: $.RES_W_RK_D4.text[2]
 #: data/base/messages/strings/resstrings.txt:945
 #: data/mp/messages/strings/resstrings.txt:423
-#: po/custom/fromJson.txt:3176
+#: po/custom/fromJson.txt:3200
 msgid "Increases Mini-Rocket damage"
 msgstr ""
 
@@ -3961,7 +3961,7 @@ msgstr ""
 #: data/base/messages/strings/resstrings.txt:954
 #: data/mp/messages/strings/resstrings.txt:424
 #: data/mp/messages/strings/resstrings.txt:429
-#: po/custom/fromJson.txt:360
+#: po/custom/fromJson.txt:363
 msgid "All mini-rockets upgraded automatically"
 msgstr ""
 
@@ -3982,7 +3982,7 @@ msgstr ""
 #. ... + 13 refs
 #: data/base/messages/strings/resstrings.txt:965
 #: data/mp/messages/strings/resstrings.txt:431
-#: po/custom/fromJson.txt:4882
+#: po/custom/fromJson.txt:4932
 msgid "Rocket Upgrade"
 msgstr ""
 
@@ -3991,7 +3991,7 @@ msgstr ""
 #. data/mp/messages/resmessages2.json: $.RES_W_SRK_D4.text[1]
 #: data/base/messages/strings/resstrings.txt:966
 #: data/mp/messages/strings/resstrings.txt:432
-#: po/custom/fromJson.txt:2729
+#: po/custom/fromJson.txt:2750
 msgid "High Explosive Squash Head warhead"
 msgstr ""
 
@@ -4000,7 +4000,7 @@ msgstr ""
 #. data/base/messages/resmessages2.json: $.RES_W_SRK_D4.text[2]
 #: data/base/messages/strings/resstrings.txt:967
 #: data/mp/messages/strings/resstrings.txt:433
-#: po/custom/fromJson.txt:3232
+#: po/custom/fromJson.txt:3256
 msgid "Increases Rocket damage"
 msgstr ""
 
@@ -4011,7 +4011,7 @@ msgstr ""
 #. ... + 13 refs
 #: data/base/messages/strings/resstrings.txt:968
 #: data/mp/messages/strings/resstrings.txt:434
-#: po/custom/fromJson.txt:408
+#: po/custom/fromJson.txt:411
 msgid "All rockets upgraded automatically"
 msgstr ""
 
@@ -4091,8 +4091,8 @@ msgstr ""
 #: data/base/script/tutorial.js:510
 #: data/mp/multiplay/skirmish/rules.js:177
 #: src/challenge.cpp:230
-#: src/hci.cpp:2972
-#: src/hci.cpp:3693
+#: src/hci.cpp:2964
+#: src/hci.cpp:3685
 #: src/intelmap.cpp:400
 #: src/intorder.cpp:608
 #: src/loadsave.cpp:258
@@ -5113,7 +5113,7 @@ msgstr ""
 #. data/mp/stats/templates.json: $.A-Viper-Wheels-MG.name
 #. data/mp/stats/templates.json: $.ViperMG01Wheels.name
 #: data/mp/messages/strings/names.txt:15
-#: po/custom/fromJson.txt:3569
+#: po/custom/fromJson.txt:3601
 msgid "Machinegun Viper Wheels"
 msgstr ""
 
@@ -5123,7 +5123,7 @@ msgstr ""
 #. data/base/stats/structure.json: $.Sys-SensoTower01.name
 #. ... + 2 refs
 #: data/mp/messages/strings/names.txt:213
-#: po/custom/fromJson.txt:5055
+#: po/custom/fromJson.txt:5108
 msgid "Sensor Tower"
 msgstr ""
 
@@ -5137,7 +5137,7 @@ msgstr ""
 #. data/mp/stats/research.json: $.R-Wpn-MG1Mk1.name
 #. data/mp/stats/weapons.json: $.MG1Mk1.name
 #: data/mp/messages/strings/names.txt:271
-#: po/custom/fromJson.txt:3575
+#: po/custom/fromJson.txt:3607
 msgid "Machinegun"
 msgstr ""
 
@@ -5148,7 +5148,7 @@ msgstr ""
 #. TRANSLATORS:
 #. data/base/stats/structure.json: $.CollectiveWall.name
 #: data/mp/messages/strings/names.txt:293
-#: po/custom/fromJson.txt:1431
+#: po/custom/fromJson.txt:1440
 msgid "Collective Wall"
 msgstr ""
 
@@ -5171,7 +5171,7 @@ msgstr ""
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.ADVANCEDRESEARCH.name
 #: data/mp/messages/strings/names.txt:336
-#: po/custom/fromJson.txt:226
+#: po/custom/fromJson.txt:229
 msgid "ADVANCED RESEARCH"
 msgstr ""
 
@@ -5230,42 +5230,42 @@ msgstr ""
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Comp-MissileCodes01.name
 #: data/mp/messages/strings/names.txt:361
-#: po/custom/fromJson.txt:3791
+#: po/custom/fromJson.txt:3826
 msgid "Missile Targeting Codes"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Comp-MissileCodes02.name
 #: data/mp/messages/strings/names.txt:362
-#: po/custom/fromJson.txt:5017
+#: po/custom/fromJson.txt:5067
 msgid "Second Level Missile Targeting Codes"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Comp-MissileCodes03.name
 #: data/mp/messages/strings/names.txt:363
-#: po/custom/fromJson.txt:5476
+#: po/custom/fromJson.txt:5533
 msgid "Third Level Missile Firing Codes"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Cyborg-Wpn-Cannon.name
 #: data/mp/messages/strings/names.txt:371
-#: po/custom/fromJson.txt:2513
+#: po/custom/fromJson.txt:2534
 msgid "Heavy Gunner Cyborg"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Cyborg-Wpn-Flamer.name
 #: data/mp/messages/strings/names.txt:372
-#: po/custom/fromJson.txt:2035
+#: po/custom/fromJson.txt:2049
 msgid "Flamer Cyborg"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Cyborg-Wpn-MG.name
 #: data/mp/messages/strings/names.txt:373
-#: po/custom/fromJson.txt:3578
+#: po/custom/fromJson.txt:3610
 msgid "Machinegunner Cyborg"
 msgstr ""
 
@@ -5274,7 +5274,7 @@ msgstr ""
 #. data/base/stats/research.json: $.R-Cyborg-Legs01.name
 #. data/mp/stats/propulsion.json: $.CyborgLegs.name
 #: data/mp/messages/strings/names.txt:380
-#: po/custom/fromJson.txt:1651
+#: po/custom/fromJson.txt:1662
 msgid "Cyborg Propulsion"
 msgstr ""
 
@@ -5282,7 +5282,7 @@ msgstr ""
 #. data/base/stats/structure.json: $.GuardTower3.name
 #. data/mp/stats/structure.json: $.GuardTower3.name
 #: data/mp/messages/strings/names.txt:404
-#: po/custom/fromJson.txt:2581
+#: po/custom/fromJson.txt:2602
 msgid "Heavy Machinegun Tower"
 msgstr ""
 
@@ -5295,7 +5295,7 @@ msgstr ""
 #. data/mp/stats/research.json: $.R-Defense-Pillbox06.name
 #. data/mp/stats/structure.json: $.GuardTower5.name
 #: data/mp/messages/strings/names.txt:406
-#: po/custom/fromJson.txt:3377
+#: po/custom/fromJson.txt:3404
 msgid "Lancer Tower"
 msgstr ""
 
@@ -5319,7 +5319,7 @@ msgstr ""
 #. data/mp/stats/repair.json: $.HeavyRepair.name
 #. data/mp/stats/research.json: $.R-Sys-MobileRepairTurretHvy.name
 #: data/mp/messages/strings/names.txt:469
-#: po/custom/fromJson.txt:2618
+#: po/custom/fromJson.txt:2639
 msgid "Heavy Repair Turret"
 msgstr ""
 
@@ -5330,7 +5330,7 @@ msgstr ""
 #. TRANSLATORS:
 #. data/mp/stats/research.json: $.R-Sys-Resistance-Circuits.name
 #: data/mp/messages/strings/names.txt:490
-#: po/custom/fromJson.txt:4202
+#: po/custom/fromJson.txt:4240
 msgid "Nexus Resistance Circuits"
 msgstr ""
 
@@ -5345,63 +5345,63 @@ msgstr ""
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Vehicle-Prop-Hover02.name
 #: data/mp/messages/strings/names.txt:504
-#: po/custom/fromJson.txt:2793
+#: po/custom/fromJson.txt:2814
 msgid "Hover Propulsion II"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Vehicle-Prop-Halftracks02.name
 #: data/mp/messages/strings/names.txt:506
-#: po/custom/fromJson.txt:2225
+#: po/custom/fromJson.txt:2246
 msgid "Half-tracked Propulsion II"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Vehicle-Prop-Tracks02.name
 #: data/mp/messages/strings/names.txt:508
-#: po/custom/fromJson.txt:5490
+#: po/custom/fromJson.txt:5547
 msgid "Tracked Propulsion II"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Vehicle-Prop-VTOL02.name
 #: data/mp/messages/strings/names.txt:510
-#: po/custom/fromJson.txt:5931
+#: po/custom/fromJson.txt:5989
 msgid "VTOL Propulsion II"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Vehicle-Prop-Wheels02.name
 #: data/mp/messages/strings/names.txt:512
-#: po/custom/fromJson.txt:6033
+#: po/custom/fromJson.txt:6091
 msgid "Wheeled Propulsion II"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Wpn-MG-Damage09.name
 #: data/mp/messages/strings/names.txt:537
-#: po/custom/fromJson.txt:1777
+#: po/custom/fromJson.txt:1788
 msgid "Depleted Uranium MG Bullets Mk2"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Wpn-TUTMG.name
 #: data/mp/messages/strings/names.txt:566
-#: po/custom/fromJson.txt:3536
+#: po/custom/fromJson.txt:3566
 msgid "Machinegun Artifact"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/structure.json: $.A0CommandCentreNP.name
 #: data/mp/messages/strings/names.txt:569
-#: po/custom/fromJson.txt:4032
+#: po/custom/fromJson.txt:4070
 msgid "New Paradigm Command Center"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/structure.json: $.A0CommandCentreCO.name
 #: data/mp/messages/strings/names.txt:570
-#: po/custom/fromJson.txt:1413
+#: po/custom/fromJson.txt:1422
 msgid "Collective Command Center"
 msgstr ""
 
@@ -5409,7 +5409,7 @@ msgstr ""
 #. data/base/stats/structure.json: $.NX-CruiseSite.name
 #: data/mp/messages/strings/names.txt:723
 #: data/mp/messages/strings/names.txt:724
-#: po/custom/fromJson.txt:3788
+#: po/custom/fromJson.txt:3823
 msgid "Missile Silo"
 msgstr ""
 
@@ -5418,7 +5418,7 @@ msgstr ""
 #. data/mp/stats/templates.json: $.Cyb-Hvy-Mcannon.name
 #. data/mp/stats/weapons.json: $.Cyb-Hvywpn-Mcannon.name
 #: data/mp/messages/strings/names.txt:775
-#: po/custom/fromJson.txt:5195
+#: po/custom/fromJson.txt:5248
 msgid "Super Heavy-Gunner"
 msgstr ""
 
@@ -5427,7 +5427,7 @@ msgstr ""
 #. data/mp/stats/templates.json: $.Cyb-Hvy-Acannon.name
 #. data/mp/stats/weapons.json: $.Cyb-Hvywpn-Acannon.name
 #: data/mp/messages/strings/names.txt:777
-#: po/custom/fromJson.txt:5190
+#: po/custom/fromJson.txt:5243
 msgid "Super Auto-Cannon Cyborg"
 msgstr ""
 
@@ -5436,7 +5436,7 @@ msgstr ""
 #. data/mp/stats/templates.json: $.Cyb-Hvy-HPV.name
 #. data/mp/stats/weapons.json: $.Cyb-Hvywpn-HPV.name
 #: data/mp/messages/strings/names.txt:779
-#: po/custom/fromJson.txt:5200
+#: po/custom/fromJson.txt:5253
 msgid "Super HPV Cyborg"
 msgstr ""
 
@@ -5445,7 +5445,7 @@ msgstr ""
 #. data/mp/stats/templates.json: $.Cyb-Hvy-TK.name
 #. data/mp/stats/weapons.json: $.Cyb-Hvywpn-TK.name
 #: data/mp/messages/strings/names.txt:781
-#: po/custom/fromJson.txt:5220
+#: po/custom/fromJson.txt:5273
 msgid "Super Tank-Killer Cyborg"
 msgstr ""
 
@@ -5453,7 +5453,7 @@ msgstr ""
 #. data/mp/stats/research.json: $.R-Sys-Sensor-UpLink.name
 #. data/mp/stats/structure.json: $.A0Sat-linkCentre.name
 #: data/mp/messages/strings/names.txt:788
-#: po/custom/fromJson.txt:4914
+#: po/custom/fromJson.txt:4964
 msgid "Satellite Uplink Center"
 msgstr ""
 
@@ -5462,7 +5462,7 @@ msgstr ""
 #. data/mp/stats/templates.json: $.Cyb-Hvy-PulseLsr.name
 #. data/mp/stats/weapons.json: $.Cyb-Hvywpn-PulseLsr.name
 #: data/mp/messages/strings/names.txt:799
-#: po/custom/fromJson.txt:5205
+#: po/custom/fromJson.txt:5258
 msgid "Super Pulse Laser Cyborg"
 msgstr ""
 
@@ -5471,7 +5471,7 @@ msgstr ""
 #. data/mp/stats/templates.json: $.Cyb-Hvy-RailGunner.name
 #. data/mp/stats/weapons.json: $.Cyb-Hvywpn-RailGunner.name
 #: data/mp/messages/strings/names.txt:801
-#: po/custom/fromJson.txt:5210
+#: po/custom/fromJson.txt:5263
 msgid "Super Rail-Gunner"
 msgstr ""
 
@@ -5480,7 +5480,7 @@ msgstr ""
 #. data/mp/stats/templates.json: $.Cyb-Hvy-A-T.name
 #. data/mp/stats/weapons.json: $.Cyb-Hvywpn-A-T.name
 #: data/mp/messages/strings/names.txt:803
-#: po/custom/fromJson.txt:5215
+#: po/custom/fromJson.txt:5268
 msgid "Super Scourge Cyborg"
 msgstr ""
 
@@ -5725,173 +5725,176 @@ msgstr ""
 #. data/mp/messages/resmessages2.json: $.RES_W_AAAC1.text[2]
 #. data/mp/messages/resmessages23.json: $.RES_W_AAAC2.text[2]
 #. data/mp/messages/resmessages3.json: $.RES_W_AAAC3.text[2]
-#: po/custom/fromJson.txt:40
+#: po/custom/fromJson.txt:41
+#, no-c-format
 msgid "AA accuracy +10%"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Wpn-AAGun-ROF02.name
 #. data/mp/stats/research.json: $.R-Wpn-AAGun-ROF02.name
-#: po/custom/fromJson.txt:44
+#: po/custom/fromJson.txt:45
 msgid "AA Ammunition Hopper Mk2"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Wpn-AAGun-ROF03.name
 #. data/mp/stats/research.json: $.R-Wpn-AAGun-ROF03.name
-#: po/custom/fromJson.txt:48
+#: po/custom/fromJson.txt:49
 msgid "AA Ammunition Hopper Mk3"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Wpn-AAGun-ROF01.name
 #. data/mp/stats/research.json: $.R-Wpn-AAGun-ROF01.name
-#: po/custom/fromJson.txt:52
+#: po/custom/fromJson.txt:53
 msgid "AA Ammunition Hopper"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Wpn-AAGun-ROF05.name
 #. data/mp/stats/research.json: $.R-Wpn-AAGun-ROF05.name
-#: po/custom/fromJson.txt:56
+#: po/custom/fromJson.txt:57
 msgid "AA Chainfeed Loader Mk2"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Wpn-AAGun-ROF06.name
 #. data/mp/stats/research.json: $.R-Wpn-AAGun-ROF06.name
-#: po/custom/fromJson.txt:60
+#: po/custom/fromJson.txt:61
 msgid "AA Chainfeed Loader Mk3"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Wpn-AAGun-ROF04.name
 #. data/mp/stats/research.json: $.R-Wpn-AAGun-ROF04.name
-#: po/custom/fromJson.txt:64
+#: po/custom/fromJson.txt:65
 msgid "AA Chainfeed Loader"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/research.json: $.R-Defense-AASite-QuadBof.name
 #. data/mp/stats/structure.json: $.AASite-QuadBof.name
-#: po/custom/fromJson.txt:68
+#: po/custom/fromJson.txt:69
 msgid "AA Flak Cannon Emplacement"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/research.json: $.R-Defense-WallTower-DoubleAAgun.name
 #. data/mp/stats/structure.json: $.WallTower-DoubleAAGun.name
-#: po/custom/fromJson.txt:72
+#: po/custom/fromJson.txt:73
 msgid "AA Flak Cannon Hardpoint"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/templates.json: $.P0cam3PyFlakHT.name
-#: po/custom/fromJson.txt:75
+#: po/custom/fromJson.txt:76
 msgid "AA Flak Cannon Python Half-tracks"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/research.json: $.R-Wpn-AAGun02.name
 #. data/mp/stats/weapons.json: $.AAGun2Mk1.name
-#: po/custom/fromJson.txt:79
+#: po/custom/fromJson.txt:80
 msgid "AA Flak Cannon"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/messages/resmessages2.json: $.RES_W_AAD1.text[2]
 #. data/mp/messages/resmessages3.json: $.RES_W_AAD4.text[2]
-#: po/custom/fromJson.txt:83
+#: po/custom/fromJson.txt:85
+#, no-c-format
 msgid "AA Flak damage +25%"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Wpn-AAGun-Damage02.name
 #. data/mp/stats/research.json: $.R-Wpn-AAGun-Damage02.name
-#: po/custom/fromJson.txt:93
+#: po/custom/fromJson.txt:95
 msgid "AA HE Flak Mk2"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Wpn-AAGun-Damage03.name
 #. data/mp/stats/research.json: $.R-Wpn-AAGun-Damage03.name
-#: po/custom/fromJson.txt:97
+#: po/custom/fromJson.txt:99
 msgid "AA HE Flak Mk3"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Wpn-AAGun-Damage01.name
 #. data/mp/stats/research.json: $.R-Wpn-AAGun-Damage01.name
-#: po/custom/fromJson.txt:101
+#: po/custom/fromJson.txt:103
 msgid "AA HE Flak"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Wpn-AAGun-Damage05.name
 #. data/mp/stats/research.json: $.R-Wpn-AAGun-Damage05.name
-#: po/custom/fromJson.txt:105
+#: po/custom/fromJson.txt:107
 msgid "AA HEAP Flak Mk2"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Wpn-AAGun-Damage06.name
 #. data/mp/stats/research.json: $.R-Wpn-AAGun-Damage06.name
-#: po/custom/fromJson.txt:109
+#: po/custom/fromJson.txt:111
 msgid "AA HEAP Flak Mk3"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Wpn-AAGun-Damage04.name
 #. data/mp/stats/research.json: $.R-Wpn-AAGun-Damage04.name
-#: po/custom/fromJson.txt:113
+#: po/custom/fromJson.txt:115
 msgid "AA HEAP Flak"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/messages/resmessages2.json: $.RES_W_AAROF1.text[2]
 #. data/mp/messages/resmessages3.json: $.RES_W_AAROF4.text[2]
-#: po/custom/fromJson.txt:117
+#: po/custom/fromJson.txt:120
+#, no-c-format
 msgid "AA reload time -15%"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Wpn-AAGun-Accuracy02.name
 #. data/mp/stats/research.json: $.R-Wpn-AAGun-Accuracy02.name
-#: po/custom/fromJson.txt:137
+#: po/custom/fromJson.txt:140
 msgid "AA Target Acquisition Shells"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Wpn-AAGun-Accuracy03.name
 #. data/mp/stats/research.json: $.R-Wpn-AAGun-Accuracy03.name
-#: po/custom/fromJson.txt:141
+#: po/custom/fromJson.txt:144
 msgid "AA Target Prediction Computer"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Wpn-AAGun-Accuracy01.name
 #. data/mp/stats/research.json: $.R-Wpn-AAGun-Accuracy01.name
-#: po/custom/fromJson.txt:145
+#: po/custom/fromJson.txt:148
 msgid "AA Thermal Imaging Sensor"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/multiplay/skirmish/nb_generic.json: $.AI.tip
-#: po/custom/fromJson.txt:154
+#: po/custom/fromJson.txt:157
 msgid "Adaptive AI with multiple personalities"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Struc-Materials08.name
 #. data/mp/stats/research.json: $.R-Struc-Materials08.name
-#: po/custom/fromJson.txt:158
+#: po/custom/fromJson.txt:161
 msgid "Advanced Base Structure Materials Mk2"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Struc-Materials09.name
 #. data/mp/stats/research.json: $.R-Struc-Materials09.name
-#: po/custom/fromJson.txt:162
+#: po/custom/fromJson.txt:165
 msgid "Advanced Base Structure Materials Mk3"
 msgstr ""
 
@@ -5900,120 +5903,120 @@ msgstr ""
 #. data/base/stats/research.json: $.R-Struc-Materials07.name
 #. data/mp/messages/resmessages3.json: $.RES_ST_MAT7.text[1]
 #. data/mp/stats/research.json: $.R-Struc-Materials07.name
-#: po/custom/fromJson.txt:168
+#: po/custom/fromJson.txt:171
 msgid "Advanced Base Structure Materials"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/research.json: $.R-Wpn-Bomb-Accuracy03.name
-#: po/custom/fromJson.txt:171
+#: po/custom/fromJson.txt:174
 msgid "Advanced Bomb Warhead"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages3.json: $.RES_ENGIN3.text[1]
 #. data/mp/messages/resmessages3.json: $.RES_ENGIN3.text[1]
-#: po/custom/fromJson.txt:178
+#: po/custom/fromJson.txt:181
 msgid "Advanced Engineering Techniques"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Sys-Engineering03.name
 #. data/mp/stats/research.json: $.R-Sys-Engineering03.name
-#: po/custom/fromJson.txt:182
+#: po/custom/fromJson.txt:185
 msgid "Advanced Engineering"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages3.json: $.RES_SY_VCBSU3.text[1]
 #. data/mp/messages/resmessages3.json: $.RES_SY_VCBSU3.text[1]
-#: po/custom/fromJson.txt:189
+#: po/custom/fromJson.txt:192
 msgid "Advanced fire detection systems"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/research.json: $.R-Struc-Factory-Upgrade07.name
-#: po/custom/fromJson.txt:192
+#: po/custom/fromJson.txt:195
 msgid "Advanced Manufacturing"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Wpn-Missile-ROF02.name
 #. data/mp/stats/research.json: $.R-Wpn-Missile-ROF02.name
-#: po/custom/fromJson.txt:196
+#: po/custom/fromJson.txt:199
 msgid "Advanced Missile Allocation System Mk2"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Wpn-Missile-ROF03.name
 #. data/mp/stats/research.json: $.R-Wpn-Missile-ROF03.name
-#: po/custom/fromJson.txt:200
+#: po/custom/fromJson.txt:203
 msgid "Advanced Missile Allocation System Mk3"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Wpn-Missile-ROF01.name
 #. data/mp/stats/research.json: $.R-Wpn-Missile-ROF01.name
-#: po/custom/fromJson.txt:204
+#: po/custom/fromJson.txt:207
 msgid "Advanced Missile Allocation System"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Wpn-Missile-Damage02.name
 #. data/mp/stats/research.json: $.R-Wpn-Missile-Damage02.name
-#: po/custom/fromJson.txt:208
+#: po/custom/fromJson.txt:211
 msgid "Advanced Missile Warhead Mk2"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Wpn-Missile-Damage03.name
 #. data/mp/stats/research.json: $.R-Wpn-Missile-Damage03.name
-#: po/custom/fromJson.txt:212
+#: po/custom/fromJson.txt:215
 msgid "Advanced Missile Warhead Mk3"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Wpn-Missile-Damage01.name
 #. data/mp/stats/research.json: $.R-Wpn-Missile-Damage01.name
-#: po/custom/fromJson.txt:216
+#: po/custom/fromJson.txt:219
 msgid "Advanced Missile Warhead"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/research.json: $.R-Struc-RprFac-Upgrade06.name
-#: po/custom/fromJson.txt:219
+#: po/custom/fromJson.txt:222
 msgid "Advanced Repair Facility"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages3.json: $.RES_ST_RFU7.text[1]
 #. data/mp/messages/resmessages3.json: $.RES_ST_RFU7.text[1]
-#: po/custom/fromJson.txt:223
+#: po/custom/fromJson.txt:226
 msgid "Advanced repair techniques"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages3.json: $.RES_SY_VS3.text[1]
 #. data/mp/messages/resmessages3.json: $.RES_SY_VS3.text[1]
-#: po/custom/fromJson.txt:230
+#: po/custom/fromJson.txt:233
 msgid "Advanced target recognition systems"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/messages/resmessagesall.json: $.RES_SY_SU3.text[1]
-#: po/custom/fromJson.txt:233
+#: po/custom/fromJson.txt:236
 msgid "Advanced Thermal Emissions detection"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Struc-VTOLFactory-Upgrade05.name
-#: po/custom/fromJson.txt:236
+#: po/custom/fromJson.txt:239
 msgid "Advanced VTOL Production Mk2"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Struc-VTOLFactory-Upgrade06.name
-#: po/custom/fromJson.txt:239
+#: po/custom/fromJson.txt:242
 msgid "Advanced VTOL Production Mk3"
 msgstr ""
 
@@ -6021,26 +6024,26 @@ msgstr ""
 #. data/base/messages/resmessages3.json: $.RES_ST_VFU4.text[1]
 #. data/base/stats/research.json: $.R-Struc-VTOLFactory-Upgrade04.name
 #. data/mp/messages/resmessages3.json: $.RES_ST_VFU4.text[1]
-#: po/custom/fromJson.txt:244
+#: po/custom/fromJson.txt:247
 msgid "Advanced VTOL Production"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/features.json: $.Advmaterialslab.name
-#: po/custom/fromJson.txt:247
+#: po/custom/fromJson.txt:250
 msgid "Advancedmaterialslab"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages3.json: $.RES_CY_JP1.text[1]
 #. data/mp/messages/resmessages3.json: $.RES_CY_JP1.text[1]
-#: po/custom/fromJson.txt:257
+#: po/custom/fromJson.txt:260
 msgid "Aerodynamic Jump Pack"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/features.json: $.Aerodynamicslab.name
-#: po/custom/fromJson.txt:260
+#: po/custom/fromJson.txt:263
 msgid "Aerodynamicslab"
 msgstr ""
 
@@ -6049,7 +6052,7 @@ msgstr ""
 #. data/base/messages/resmessages12.json: $.RES_W_CN_D4.text[3]
 #. data/base/messages/resmessages12.json: $.RES_W_CN_ROF1.text[3]
 #. ... + 11 refs
-#: po/custom/fromJson.txt:290
+#: po/custom/fromJson.txt:293
 msgid "All cannons upgraded automatically"
 msgstr ""
 
@@ -6058,14 +6061,14 @@ msgstr ""
 #. data/base/messages/resmessages23.json: $.RES_SY_CBSU2.text[3]
 #. data/base/messages/resmessages3.json: $.RES_SY_CBSU3.text[3]
 #. ... + 3 refs
-#: po/custom/fromJson.txt:296
+#: po/custom/fromJson.txt:299
 msgid "All CB sensors upgraded automatically"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/messages/resmessages2.json: $.RES_ST_FU4.text[3]
 #. data/mp/messages/resmessagesall.json: $.RES_ST_FU7.text[3]
-#: po/custom/fromJson.txt:318
+#: po/custom/fromJson.txt:321
 msgid "All factories upgraded automatically"
 msgstr ""
 
@@ -6074,7 +6077,7 @@ msgstr ""
 #. data/base/messages/resmessages3.json: $.RES_LASD1.text[3]
 #. data/base/messages/resmessages3.json: $.RES_LASROF1.text[3]
 #. ... + 3 refs
-#: po/custom/fromJson.txt:348
+#: po/custom/fromJson.txt:351
 msgid "All lasers upgraded automatically"
 msgstr ""
 
@@ -6083,7 +6086,7 @@ msgstr ""
 #. data/base/messages/resmessages3.json: $.RES_W_MS_AC2.text[3]
 #. data/base/messages/resmessages3.json: $.RES_W_MS_D1.text[3]
 #. ... + 7 refs
-#: po/custom/fromJson.txt:366
+#: po/custom/fromJson.txt:369
 msgid "All missiles upgraded automatically"
 msgstr ""
 
@@ -6092,7 +6095,7 @@ msgstr ""
 #. data/base/messages/resmessages3.json: $.RES_POWU2.text[3]
 #. data/mp/messages/resmessages23.json: $.RES_POWU1.text[3]
 #. data/mp/messages/resmessages3.json: $.RES_POWU2.text[3]
-#: po/custom/fromJson.txt:378
+#: po/custom/fromJson.txt:381
 msgid "All power generators upgraded automatically"
 msgstr ""
 
@@ -6101,7 +6104,7 @@ msgstr ""
 #. data/base/messages/resmessages3.json: $.RES_W_RAIL_D1.text[3]
 #. data/base/messages/resmessages3.json: $.RES_W_RAIL_ROF1.text[3]
 #. ... + 3 refs
-#: po/custom/fromJson.txt:384
+#: po/custom/fromJson.txt:387
 msgid "All rail guns upgraded automatically"
 msgstr ""
 
@@ -6110,7 +6113,7 @@ msgstr ""
 #. data/mp/messages/resmessagesall.json: $.RES_SY_SU1.text[3]
 #. data/mp/messages/resmessagesall.json: $.RES_SY_SU2.text[3]
 #. data/mp/messages/resmessagesall.json: $.RES_SY_SU3.text[3]
-#: po/custom/fromJson.txt:414
+#: po/custom/fromJson.txt:417
 msgid "All sensors upgraded automatically"
 msgstr ""
 
@@ -6119,7 +6122,7 @@ msgstr ""
 #. data/base/messages/resmessages23.json: $.RES_ENGIN2.text[3]
 #. data/base/messages/resmessages3.json: $.RES_ENGIN3.text[3]
 #. ... + 3 refs
-#: po/custom/fromJson.txt:426
+#: po/custom/fromJson.txt:429
 msgid "All trucks upgraded automatically"
 msgstr ""
 
@@ -6128,7 +6131,7 @@ msgstr ""
 #. data/base/messages/resmessages3.json: $.RES_V_P_V3.text[3]
 #. data/mp/messages/resmessages3.json: $.RES_V_P_V2.text[3]
 #. data/mp/messages/resmessages3.json: $.RES_V_P_V3.text[3]
-#: po/custom/fromJson.txt:461
+#: po/custom/fromJson.txt:464
 msgid "All VTOLs upgraded automatically"
 msgstr ""
 
@@ -6137,115 +6140,115 @@ msgstr ""
 #. data/mp/challenges/hidebehind.json: $.player_2.name
 #. data/mp/tests/miza.json: $.player_1.name
 #. data/mp/tests/miza.json: $.player_2.name
-#: po/custom/fromJson.txt:473
+#: po/custom/fromJson.txt:476
 msgid "Ally"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/campaigns/alpha.json: $.name
-#: po/custom/fromJson.txt:476
+#: po/custom/fromJson.txt:479
 msgid "Alpha Campaign"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/challenges/two-faced.json: $.player_1.name
-#: po/custom/fromJson.txt:479
+#: po/custom/fromJson.txt:482
 msgid "Alpha"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages1.json: $.RES_V_P_H1.text[1]
 #. data/mp/messages/resmessages1.json: $.RES_V_P_H1.text[1]
-#: po/custom/fromJson.txt:483
+#: po/custom/fromJson.txt:486
 msgid "Amphibious hover propulsion"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Defense-MdArtMissile.name
-#: po/custom/fromJson.txt:486
+#: po/custom/fromJson.txt:489
 msgid "Angel Missile Battery"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/structure.json: $.Emplacement-MdART-pit.name
-#: po/custom/fromJson.txt:489
+#: po/custom/fromJson.txt:492
 msgid "Angel Missile Emplacement"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Wpn-MdArtMissile.name
 #. data/base/stats/weapons.json: $.Missile-MdArt.name
-#: po/custom/fromJson.txt:493
+#: po/custom/fromJson.txt:496
 msgid "Angel Missile"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages3.json: $.RES_W_ASM_AT.text[1]
 #. data/mp/messages/resmessages3.json: $.RES_W_ASM_AT.text[1]
-#: po/custom/fromJson.txt:497
+#: po/custom/fromJson.txt:500
 msgid "Anti-tank missile"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessagesall.json: $.RES_W_RK_LTAT1.text[1]
 #. data/mp/messages/resmessagesall.json: $.RES_W_RK_LTAT1.text[1]
-#: po/custom/fromJson.txt:501
+#: po/custom/fromJson.txt:504
 msgid "Anti-tank rocket"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Wpn-MG-Damage03.name
 #. data/mp/stats/research.json: $.R-Wpn-MG-Damage03.name
-#: po/custom/fromJson.txt:505
+#: po/custom/fromJson.txt:508
 msgid "APDSB MG Bullets Mk2"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Wpn-MG-Damage04.name
 #. data/mp/stats/research.json: $.R-Wpn-MG-Damage04.name
-#: po/custom/fromJson.txt:509
+#: po/custom/fromJson.txt:512
 msgid "APDSB MG Bullets Mk3"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Wpn-MG-Damage02.name
 #. data/mp/stats/research.json: $.R-Wpn-MG-Damage02.name
-#: po/custom/fromJson.txt:513
+#: po/custom/fromJson.txt:516
 msgid "APDSB MG Bullets"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Wpn-Cannon-Damage05.name
 #. data/mp/stats/research.json: $.R-Wpn-Cannon-Damage05.name
-#: po/custom/fromJson.txt:517
+#: po/custom/fromJson.txt:520
 msgid "APFSDS Cannon Rounds Mk2"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Wpn-Cannon-Damage06.name
 #. data/mp/stats/research.json: $.R-Wpn-Cannon-Damage06.name
-#: po/custom/fromJson.txt:521
+#: po/custom/fromJson.txt:524
 msgid "APFSDS Cannon Rounds Mk3"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Wpn-Cannon-Damage04.name
 #. data/mp/stats/research.json: $.R-Wpn-Cannon-Damage04.name
-#: po/custom/fromJson.txt:525
+#: po/custom/fromJson.txt:528
 msgid "APFSDS Cannon Rounds"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Defense-HvyArtMissile.name
 #. data/mp/stats/research.json: $.R-Defense-HvyArtMissile.name
-#: po/custom/fromJson.txt:529
+#: po/custom/fromJson.txt:532
 msgid "Archangel Missile Battery"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/structure.json: $.Emplacement-HvART-pit.name
 #. data/mp/stats/structure.json: $.Emplacement-HvART-pit.name
-#: po/custom/fromJson.txt:533
+#: po/custom/fromJson.txt:536
 msgid "Archangel Missile Emplacement"
 msgstr ""
 
@@ -6254,113 +6257,113 @@ msgstr ""
 #. data/base/stats/weapons.json: $.Missile-HvyArt.name
 #. data/mp/stats/research.json: $.R-Wpn-HvArtMissile.name
 #. data/mp/stats/weapons.json: $.Missile-HvyArt.name
-#: po/custom/fromJson.txt:539
+#: po/custom/fromJson.txt:542
 msgid "Archangel Missile"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages3.json: $.RES_CYJ_MG4.text[1]
 #. data/mp/messages/resmessages3.json: $.RES_CYJ_MG4.text[1]
-#: po/custom/fromJson.txt:551
+#: po/custom/fromJson.txt:554
 msgid "Armed with Cyborg assault gun"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages1.json: $.RES_CYW_CN1.text[1]
 #. data/mp/messages/resmessages1.json: $.RES_CYW_CN1.text[1]
-#: po/custom/fromJson.txt:555
+#: po/custom/fromJson.txt:558
 msgid "Armed with Cyborg Cannon"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages1.json: $.RES_CYW_FL1.text[1]
 #. data/mp/messages/resmessages1.json: $.RES_CYW_FL1.text[1]
-#: po/custom/fromJson.txt:559
+#: po/custom/fromJson.txt:562
 msgid "Armed with Cyborg Flamer"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages1.json: $.RES_CYW_MG1.text[1]
 #. data/mp/messages/resmessages1.json: $.RES_CYW_MG1.text[1]
-#: po/custom/fromJson.txt:563
+#: po/custom/fromJson.txt:566
 msgid "Armed with Cyborg Machinegun"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/messages/resmessagesall.json: $.RES_CYW_H_PLAS.text[1]
-#: po/custom/fromJson.txt:566
+#: po/custom/fromJson.txt:569
 msgid "Armed with Cyborg Pulse Laser"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/messages/resmessagesall.json: $.RES_CYW_H_RG.text[1]
-#: po/custom/fromJson.txt:569
+#: po/custom/fromJson.txt:572
 msgid "Armed with Cyborg Rail Gun"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/messages/resmessagesall.json: $.RES_CYW_H_AT.text[1]
-#: po/custom/fromJson.txt:572
+#: po/custom/fromJson.txt:575
 msgid "Armed with Cyborg Scourge Missile Launcher"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/messages/resmessagesall.json: $.RES_CYW_TFL.text[1]
-#: po/custom/fromJson.txt:575
+#: po/custom/fromJson.txt:578
 msgid "Armed with Cyborg Thermite Flamer"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages3.json: $.RES_CYJ_LS1.text[1]
 #. data/mp/messages/resmessages3.json: $.RES_CYJ_LS1.text[1]
-#: po/custom/fromJson.txt:579
+#: po/custom/fromJson.txt:582
 msgid "Armed with Flashlight Laser"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages3.json: $.RES_CYW_LS1.text[1]
 #. data/mp/messages/resmessages3.json: $.RES_CYW_LS1.text[1]
-#: po/custom/fromJson.txt:583
+#: po/custom/fromJson.txt:586
 msgid "Armed with flashlight laser"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/messages/resmessagesall.json: $.RES_CYW_GRN.text[1]
-#: po/custom/fromJson.txt:586
+#: po/custom/fromJson.txt:589
 msgid "Armed with grenades"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/messages/resmessagesall.json: $.RES_CYW_H_AC.text[1]
 #. data/mp/messages/resmessagesall.json: $.RES_CYW_H_HPV.text[1]
-#: po/custom/fromJson.txt:590
+#: po/custom/fromJson.txt:593
 msgid "Armed with hyper velocity cannon"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages1.json: $.RES_CYW_RK1.text[1]
 #. data/mp/messages/resmessages1.json: $.RES_CYW_RK1.text[1]
-#: po/custom/fromJson.txt:594
+#: po/custom/fromJson.txt:597
 msgid "Armed with Lance Anti-Tank rocket"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages3.json: $.RES_CYJ_RKT.text[1]
 #. data/mp/messages/resmessages3.json: $.RES_CYJ_RKT.text[1]
-#: po/custom/fromJson.txt:598
+#: po/custom/fromJson.txt:601
 msgid "Armed with Lancer anti-tank missile"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/messages/resmessagesall.json: $.RES_CYTRANS.text[1]
 #. data/mp/messages/resmessagesall.json: $.RES_SUPERTRANS.text[1]
-#: po/custom/fromJson.txt:602
+#: po/custom/fromJson.txt:605
 msgid "Armed with Machinegun"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/messages/resmessagesall.json: $.RES_CYW_H_MC.text[1]
-#: po/custom/fromJson.txt:605
+#: po/custom/fromJson.txt:608
 msgid "Armed with medium cannon"
 msgstr ""
 
@@ -6369,7 +6372,7 @@ msgstr ""
 #. data/base/messages/resmessages3.json: $.RES_CYW_RL1.text[1]
 #. data/mp/messages/resmessages3.json: $.RES_CYJ_RL1.text[1]
 #. data/mp/messages/resmessages3.json: $.RES_CYW_RL1.text[1]
-#: po/custom/fromJson.txt:611
+#: po/custom/fromJson.txt:614
 msgid "Armed with Needle Gun"
 msgstr ""
 
@@ -6378,13 +6381,13 @@ msgstr ""
 #. data/base/messages/resmessages3.json: $.RES_CYW_ATM.text[1]
 #. data/mp/messages/resmessages3.json: $.RES_CYJ_ATM.text[1]
 #. data/mp/messages/resmessages3.json: $.RES_CYW_ATM.text[1]
-#: po/custom/fromJson.txt:621
+#: po/custom/fromJson.txt:624
 msgid "Armed with Scourge anti-tank missile"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/messages/resmessagesall.json: $.RES_CYW_H_TK.text[1]
-#: po/custom/fromJson.txt:624
+#: po/custom/fromJson.txt:627
 msgid "Armed with tank killer rockets"
 msgstr ""
 
@@ -6393,279 +6396,281 @@ msgstr ""
 #. data/mp/messages/resmessages2.json: $.RES_DF_WU4.text[2]
 #. data/mp/messages/resmessages2.json: $.RES_ST_MAT4.text[2]
 #. ... + 4 refs
-#: po/custom/fromJson.txt:630
+#: po/custom/fromJson.txt:634
+#, no-c-format
 msgid "Armor +35%, Body Points +30%"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages1.json: $.RES_W_MG_D2.text[1]
 #. data/mp/messages/resmessages1.json: $.RES_W_MG_D2.text[1]
-#: po/custom/fromJson.txt:634
+#: po/custom/fromJson.txt:638
 msgid "Armor-Piercing Discard Sabot Bullets"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages12.json: $.RES_W_CN_D4.text[1]
 #. data/mp/messages/resmessages12.json: $.RES_W_CN_D4.text[1]
-#: po/custom/fromJson.txt:638
+#: po/custom/fromJson.txt:642
 msgid "Armor-Piercing Fin-Stabilized Discarding Sabot"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages1.json: $.RES_PB_FL.text[1]
 #. data/mp/messages/resmessages1.json: $.RES_PB_FL.text[1]
-#: po/custom/fromJson.txt:646
+#: po/custom/fromJson.txt:650
 msgid "Armored bunker with Flamer"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages1.json: $.RES_PB_ATR.text[1]
-#: po/custom/fromJson.txt:649
+#: po/custom/fromJson.txt:653
 msgid "Armored bunker with Lancer AT rocket"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages1.json: $.RES_PB_LC.text[1]
 #. data/mp/messages/resmessages1.json: $.RES_PB_LC.text[1]
-#: po/custom/fromJson.txt:653
+#: po/custom/fromJson.txt:657
 msgid "Armored bunker with Light Cannon"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages1.json: $.RES_DF_P1.text[1]
 #. data/mp/messages/resmessages1.json: $.RES_DF_P1.text[1]
-#: po/custom/fromJson.txt:657
+#: po/custom/fromJson.txt:661
 msgid "Armored bunker with Machinegun"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/messages/resmessagesall.json: $.RES_DEF_EMPM.text[1]
-#: po/custom/fromJson.txt:660
+#: po/custom/fromJson.txt:664
 msgid "Armored EMP Mortar battery pit"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/messages/resmessagesall.json: $.RES_DEF_EMP.text[1]
-#: po/custom/fromJson.txt:667
+#: po/custom/fromJson.txt:671
 msgid "Armored guard tower with EMP Cannon"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/messages/resmessages1.json: $.RES_PB_ATR.text[1]
-#: po/custom/fromJson.txt:670
+#: po/custom/fromJson.txt:674
 msgid "Armored guard tower with Lancer AT rocket"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages1.json: $.RES_EMP_PODTOW.text[1]
-#: po/custom/fromJson.txt:673
+#: po/custom/fromJson.txt:677
 msgid "Armored guard tower with Mini-Pod Rocket"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/messages/resmessages1.json: $.RES_EMP_PODTOW.text[1]
-#: po/custom/fromJson.txt:676
+#: po/custom/fromJson.txt:680
 msgid "Armored guard tower with Mini-Rocket Pod"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages3.json: $.RES_EMP_RL1TOW.text[1]
 #. data/mp/messages/resmessages3.json: $.RES_EMP_RL1TOW.text[1]
-#: po/custom/fromJson.txt:680
+#: po/custom/fromJson.txt:684
 msgid "Armored guard tower with Needle Gun"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/messages/resmessagesall.json: $.RES_SY_SPYT.text[1]
-#: po/custom/fromJson.txt:683
+#: po/custom/fromJson.txt:687
 msgid "Armored guard tower with Nexus Link"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/messages/resmessages3.json: $.RES_EMP_PulseLas.text[1]
-#: po/custom/fromJson.txt:686
+#: po/custom/fromJson.txt:690
 msgid "Armored guard tower with Pulse Laser"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages3.json: $.RES_EMP_ATMTOW.text[1]
 #. data/mp/messages/resmessages3.json: $.RES_EMP_ATMTOW.text[1]
-#: po/custom/fromJson.txt:690
+#: po/custom/fromJson.txt:694
 msgid "Armored guard tower with Scourge Missile"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages1.json: $.RES_HALFT1.text[1]
 #. data/mp/messages/resmessages1.json: $.RES_HALFT1.text[1]
-#: po/custom/fromJson.txt:694
+#: po/custom/fromJson.txt:698
 msgid "Armored Half-tracks"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages3.json: $.RES_WT14_PLS.text[1]
 #. data/mp/messages/resmessages3.json: $.RES_WT14_PLS.text[1]
-#: po/custom/fromJson.txt:706
+#: po/custom/fromJson.txt:710
 msgid "Armored hardpoint with Flashlight laser"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages3.json: $.RES_WT15_RL3.text[1]
 #. data/mp/messages/resmessages3.json: $.RES_WT15_RL3.text[1]
-#: po/custom/fromJson.txt:710
+#: po/custom/fromJson.txt:714
 msgid "Armored hardpoint with Gauss Cannon"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages1.json: $.RES_WT4_HC.text[1]
 #. data/mp/messages/resmessages1.json: $.RES_WT4_HC.text[1]
-#: po/custom/fromJson.txt:714
+#: po/custom/fromJson.txt:718
 msgid "Armored hardpoint with Heavy Cannon"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages12.json: $.RES_DF_WT1.text[1]
 #. data/mp/messages/resmessages12.json: $.RES_DF_WT1.text[1]
-#: po/custom/fromJson.txt:718
+#: po/custom/fromJson.txt:722
 msgid "Armored hardpoint with Heavy Machinegun"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages23.json: $.RES_WT13_HPV.text[1]
 #. data/mp/messages/resmessages23.json: $.RES_WT13_HPV.text[1]
-#: po/custom/fromJson.txt:722
+#: po/custom/fromJson.txt:726
 msgid "Armored hardpoint with Hyper-Velocity Cannon"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages12.json: $.RES_WT6_ATR.text[1]
 #. data/mp/messages/resmessages12.json: $.RES_WT6_ATR.text[1]
-#: po/custom/fromJson.txt:730
+#: po/custom/fromJson.txt:734
 msgid "Armored hardpoint with Lancer AT missile"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages1.json: $.RES_WT2_LC.text[1]
 #. data/mp/messages/resmessages1.json: $.RES_WT2_LC.text[1]
-#: po/custom/fromJson.txt:734
+#: po/custom/fromJson.txt:738
 msgid "Armored hardpoint with Light Cannon"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages1.json: $.RES_WT3_MC.text[1]
 #. data/mp/messages/resmessages1.json: $.RES_WT3_MC.text[1]
-#: po/custom/fromJson.txt:738
+#: po/custom/fromJson.txt:742
 msgid "Armored hardpoint with Medium Cannon"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages3.json: $.RES_WT15_RL2.text[1]
 #. data/mp/messages/resmessages3.json: $.RES_WT15_RL2.text[1]
-#: po/custom/fromJson.txt:742
+#: po/custom/fromJson.txt:746
 msgid "Armored hardpoint with Rail Gun"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages3.json: $.RES_WT9_ATM.text[1]
 #. data/mp/messages/resmessages3.json: $.RES_WT9_ATM.text[1]
-#: po/custom/fromJson.txt:746
+#: po/custom/fromJson.txt:750
 msgid "Armored hardpoint with Scourge AT Missile"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/messages/resmessagesall.json: $.RES_EMP_IMP.text[1]
-#: po/custom/fromJson.txt:763
+#: po/custom/fromJson.txt:767
 msgid "Armored Incendiary Mortar battery pit"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages12.json: $.RES_EMP_Mpit.text[1]
 #. data/mp/messages/resmessages12.json: $.RES_EMP_Mpit.text[1]
-#: po/custom/fromJson.txt:767
+#: po/custom/fromJson.txt:771
 msgid "Armored Mortar battery pit"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages3.json: $.RES_EMP_PrisLas.text[1]
 #. data/mp/messages/resmessages3.json: $.RES_EMP_PrisLas.text[1]
-#: po/custom/fromJson.txt:779
+#: po/custom/fromJson.txt:783
 msgid "Armored strongpoint with Flashlight laser"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages3.json: $.RES_EMP_Rail3.text[1]
 #. data/mp/messages/resmessages3.json: $.RES_EMP_Rail3.text[1]
-#: po/custom/fromJson.txt:783
+#: po/custom/fromJson.txt:787
 msgid "Armored strongpoint with Gauss Cannon"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/messages/resmessagesall.json: $.RES_EMP_HEAVYLAS.text[1]
-#: po/custom/fromJson.txt:786
+#: po/custom/fromJson.txt:790
 msgid "Armored strongpoint with Heavy Laser"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/messages/resmessagesall.json: $.RES_EMP_PFL.text[1]
-#: po/custom/fromJson.txt:797
+#: po/custom/fromJson.txt:801
 msgid "Armored strongpoint with Plasmite Flamer"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages3.json: $.RES_EMP_PulseLas.text[1]
-#: po/custom/fromJson.txt:800
+#: po/custom/fromJson.txt:804
 msgid "Armored strongpoint with Pulse Laser"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages3.json: $.RES_EMP_Rail2.text[1]
 #. data/mp/messages/resmessages3.json: $.RES_EMP_Rail2.text[1]
-#: po/custom/fromJson.txt:804
+#: po/custom/fromJson.txt:808
 msgid "Armored strongpoint with Rail Gun"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages1.json: $.RES_TRACK1.text[1]
 #. data/mp/messages/resmessages1.json: $.RES_TRACK1.text[1]
-#: po/custom/fromJson.txt:812
+#: po/custom/fromJson.txt:816
 msgid "Armored Tracks"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/messages/resmessages1.json: $.RES_DF_WU1.text[2]
-#: po/custom/fromJson.txt:815
+#: po/custom/fromJson.txt:820
+#, no-c-format
 msgid "Armour +35%, Body Points +30%"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/features.json: $.Crate.name
-#: po/custom/fromJson.txt:818
+#: po/custom/fromJson.txt:823
 msgid "Artifact"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages3.json: $.RES_EMP_MdAM.text[1]
 #. data/mp/messages/resmessages3.json: $.RES_EMP_MdAM.text[1]
-#: po/custom/fromJson.txt:822
+#: po/custom/fromJson.txt:827
 msgid "Artillery battery firing Firestorm Missiles"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages3.json: $.RES_EMP_HvAM.text[1]
 #. data/mp/messages/resmessages3.json: $.RES_EMP_HvAM.text[1]
-#: po/custom/fromJson.txt:826
+#: po/custom/fromJson.txt:831
 msgid "Artillery battery firing Novastorm Missiles"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Defense-RotCannon.name
-#: po/custom/fromJson.txt:829
+#: po/custom/fromJson.txt:834
 msgid "Assault Cannon Emplacement"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/structure.json: $.Tower-VulcanCan.name
 #. data/mp/stats/structure.json: $.Tower-VulcanCan.name
-#: po/custom/fromJson.txt:833
+#: po/custom/fromJson.txt:838
 msgid "Assault Cannon Guard Tower"
 msgstr ""
 
@@ -6674,13 +6679,13 @@ msgstr ""
 #. data/base/stats/structure.json: $.Wall-VulcanCan.name
 #. data/mp/stats/research.json: $.R-Defense-Wall-VulcanCan.name
 #. data/mp/stats/structure.json: $.Wall-VulcanCan.name
-#: po/custom/fromJson.txt:839
+#: po/custom/fromJson.txt:844
 msgid "Assault Cannon Hardpoint"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/templates.json: $.MantisHoverAC.name
-#: po/custom/fromJson.txt:842
+#: po/custom/fromJson.txt:847
 msgid "Assault Cannon Mantis Hover"
 msgstr ""
 
@@ -6689,21 +6694,21 @@ msgstr ""
 #. data/base/stats/weapons.json: $.Cannon5VulcanMk1.name
 #. data/mp/stats/research.json: $.R-Wpn-Cannon5.name
 #. data/mp/stats/weapons.json: $.Cannon5VulcanMk1.name
-#: po/custom/fromJson.txt:848
+#: po/custom/fromJson.txt:853
 msgid "Assault Cannon"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Defense-RotMG.name
 #. data/mp/stats/structure.json: $.Tower-RotMg.name
-#: po/custom/fromJson.txt:852
+#: po/custom/fromJson.txt:857
 msgid "Assault Gun Emplacement"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/structure.json: $.GuardTower-RotMg.name
 #. data/base/stats/structure.json: $.Tower-RotMg.name
-#: po/custom/fromJson.txt:856
+#: po/custom/fromJson.txt:861
 msgid "Assault Gun Guard Tower"
 msgstr ""
 
@@ -6712,32 +6717,32 @@ msgstr ""
 #. data/base/stats/structure.json: $.Wall-RotMg.name
 #. data/mp/stats/research.json: $.R-Defense-Wall-RotMg.name
 #. data/mp/stats/structure.json: $.Wall-RotMg.name
-#: po/custom/fromJson.txt:862
+#: po/custom/fromJson.txt:867
 msgid "Assault Gun Hardpoint"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/templates.json: $.PhytonHTrackAssGun.name
-#: po/custom/fromJson.txt:865
+#: po/custom/fromJson.txt:870
 msgid "Assault Gun Python Half Track"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/templates.json: $.PhytonHoverAssGun.name
-#: po/custom/fromJson.txt:868
+#: po/custom/fromJson.txt:873
 msgid "Assault Gun Python Hover"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/templates.json: $.P0cam3PyAsltGnTrk.name
 #. data/mp/stats/templates.json: $.P0cam3PyAsltGnTrk.name
-#: po/custom/fromJson.txt:872
+#: po/custom/fromJson.txt:877
 msgid "Assault Gun Python Tracks"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/structure.json: $.GuardTower-RotMg.name
-#: po/custom/fromJson.txt:875
+#: po/custom/fromJson.txt:880
 msgid "Assault Gun Tower"
 msgstr ""
 
@@ -6746,13 +6751,13 @@ msgstr ""
 #. data/base/stats/weapons.json: $.MG4ROTARYMk1.name
 #. data/mp/stats/research.json: $.R-Wpn-MG4.name
 #. data/mp/stats/weapons.json: $.MG4ROTARYMk1.name
-#: po/custom/fromJson.txt:881
+#: po/custom/fromJson.txt:886
 msgid "Assault Gun"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Cyborg-Wpn-RotMG.name
-#: po/custom/fromJson.txt:884
+#: po/custom/fromJson.txt:889
 msgid "Assault Gunner Cyborg"
 msgstr ""
 
@@ -6760,59 +6765,59 @@ msgstr ""
 #. data/base/stats/templates.json: $.Cyb-RotMG-GROUND.name
 #. data/mp/stats/templates.json: $.Cyb-RotMG-GROUND.name
 #. data/mp/stats/templates.json: $.CyborgRotMgGround.name
-#: po/custom/fromJson.txt:889
+#: po/custom/fromJson.txt:894
 msgid "Assault Gunner"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessagesall.json: $.RES_ST_VP.text[2]
 #. data/mp/messages/resmessagesall.json: $.RES_ST_VP.text[2]
-#: po/custom/fromJson.txt:893
+#: po/custom/fromJson.txt:898
 msgid "Assign a VTOL by selecting the rearming pad as its target"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages23.json: $.RES_SY_VSTU1.text[2]
 #. data/mp/messages/resmessages23.json: $.RES_SY_VSTU1.text[2]
-#: po/custom/fromJson.txt:903
+#: po/custom/fromJson.txt:908
 msgid "Assigned VTOLs attack the designated targets"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages23.json: $.RES_SY_VSTW1.text[2]
 #. data/mp/messages/resmessages23.json: $.RES_SY_VSTW1.text[2]
-#: po/custom/fromJson.txt:907
+#: po/custom/fromJson.txt:912
 msgid "Assigned VTOLs attack the enemy units"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/repair.json: $.AutoRepair.name
-#: po/custom/fromJson.txt:910
+#: po/custom/fromJson.txt:915
 msgid "Auto Repair"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/research.json: $.R-Sys-Autorepair-General.name
-#: po/custom/fromJson.txt:913
+#: po/custom/fromJson.txt:918
 msgid "Auto-Repair"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages12.json: $.RES_W_SRK_ROF1.text[1]
 #. data/mp/messages/resmessages12.json: $.RES_W_SRK_ROF1.text[1]
-#: po/custom/fromJson.txt:917
+#: po/custom/fromJson.txt:922
 msgid "Autoloader increases reload rate"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Struc-Factory-Cyborg-Upgrade02.name
-#: po/custom/fromJson.txt:920
+#: po/custom/fromJson.txt:925
 msgid "Automated Cyborg Production Mk2"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Struc-Factory-Cyborg-Upgrade03.name
-#: po/custom/fromJson.txt:923
+#: po/custom/fromJson.txt:928
 msgid "Automated Cyborg Production Mk3"
 msgstr ""
 
@@ -6820,19 +6825,19 @@ msgstr ""
 #. data/base/messages/resmessages1.json: $.RES_ST_FCY01.text[1]
 #. data/base/stats/research.json: $.R-Struc-Factory-Cyborg-Upgrade01.name
 #. data/mp/messages/resmessages1.json: $.RES_ST_FCY01.text[1]
-#: po/custom/fromJson.txt:928
+#: po/custom/fromJson.txt:933
 msgid "Automated Cyborg Production"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Struc-Factory-Upgrade02.name
-#: po/custom/fromJson.txt:931
+#: po/custom/fromJson.txt:936
 msgid "Automated Factory Production Mk2"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Struc-Factory-Upgrade03.name
-#: po/custom/fromJson.txt:934
+#: po/custom/fromJson.txt:939
 msgid "Automated Factory Production Mk3"
 msgstr ""
 
@@ -6841,67 +6846,67 @@ msgstr ""
 #. data/base/stats/research.json: $.R-Struc-Factory-Upgrade-AI.name
 #. data/base/stats/research.json: $.R-Struc-Factory-Upgrade01.name
 #. data/mp/messages/resmessages1.json: $.RES_ST_FU1.text[1]
-#: po/custom/fromJson.txt:940
+#: po/custom/fromJson.txt:945
 msgid "Automated Factory Production"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/research.json: $.R-Struc-Factory-Upgrade01.name
-#: po/custom/fromJson.txt:943
+#: po/custom/fromJson.txt:948
 msgid "Automated Manufacturing"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages1.json: $.RES_W_RK_ROF1.text[1]
 #. data/mp/messages/resmessages1.json: $.RES_W_RK_ROF1.text[1]
-#: po/custom/fromJson.txt:947
+#: po/custom/fromJson.txt:952
 msgid "Automated reload system"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Struc-RprFac-Upgrade02.name
-#: po/custom/fromJson.txt:950
+#: po/custom/fromJson.txt:955
 msgid "Automated Repair Facility Upgrade Mk2"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Struc-RprFac-Upgrade03.name
-#: po/custom/fromJson.txt:953
+#: po/custom/fromJson.txt:958
 msgid "Automated Repair Facility Upgrade Mk3"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Struc-RprFac-Upgrade01.name
 #. data/mp/stats/research.json: $.R-Struc-RprFac-Upgrade01.name
-#: po/custom/fromJson.txt:957
+#: po/custom/fromJson.txt:962
 msgid "Automated Repair Facility"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Struc-VTOLPad-Upgrade02.name
 #. data/mp/stats/research.json: $.R-Struc-VTOLPad-Upgrade02.name
-#: po/custom/fromJson.txt:961
+#: po/custom/fromJson.txt:966
 msgid "Automated VTOL Rearming Mk2"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Struc-VTOLPad-Upgrade03.name
 #. data/mp/stats/research.json: $.R-Struc-VTOLPad-Upgrade03.name
-#: po/custom/fromJson.txt:965
+#: po/custom/fromJson.txt:970
 msgid "Automated VTOL Rearming Mk3"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages12.json: $.RES_W_M_ROF1.text[1]
 #. data/mp/messages/resmessages12.json: $.RES_W_M_ROF1.text[1]
-#: po/custom/fromJson.txt:975
+#: po/custom/fromJson.txt:980
 msgid "Automatic loader replaces manual feed"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/research.json: $.R-Defense-WallTower-SamSite.name
 #. data/mp/stats/structure.json: $.WallTower-SamSite.name
-#: po/custom/fromJson.txt:1012
+#: po/custom/fromJson.txt:1017
 msgid "Avenger Hardpoint"
 msgstr ""
 
@@ -6910,7 +6915,7 @@ msgstr ""
 #. data/base/stats/structure.json: $.P0-AASite-SAM1.name
 #. data/mp/stats/research.json: $.R-Defense-SamSite1.name
 #. data/mp/stats/structure.json: $.P0-AASite-SAM1.name
-#: po/custom/fromJson.txt:1018
+#: po/custom/fromJson.txt:1023
 msgid "Avenger SAM Site"
 msgstr ""
 
@@ -6919,47 +6924,47 @@ msgstr ""
 #. data/base/stats/weapons.json: $.Missile-LtSAM.name
 #. data/mp/stats/research.json: $.R-Wpn-Missile-LtSAM.name
 #. data/mp/stats/weapons.json: $.Missile-LtSAM.name
-#: po/custom/fromJson.txt:1024
+#: po/custom/fromJson.txt:1029
 msgid "Avenger SAM"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages1.json: $.RES_V_B05.text[3]
 #. data/mp/messages/resmessages1.json: $.RES_V_B05.text[3]
-#: po/custom/fromJson.txt:1028
+#: po/custom/fromJson.txt:1033
 msgid "Average power costs and production times"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/propulsion.json: $.BaBaLegs.name
 #. data/mp/stats/propulsion.json: $.BaBaLegs.name
-#: po/custom/fromJson.txt:1032
+#: po/custom/fromJson.txt:1037
 msgid "BaBaLegs"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/propulsion.json: $.BaBaProp.name
 #. data/mp/stats/propulsion.json: $.BaBaProp.name
-#: po/custom/fromJson.txt:1036
+#: po/custom/fromJson.txt:1041
 msgid "BaBaProp"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/challenges/b2basics.json: $.challenge.name
-#: po/custom/fromJson.txt:1039
+#: po/custom/fromJson.txt:1044
 msgid "Back to Basics"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/multiplay/skirmish/nexus.json: $.AI.tip
-#: po/custom/fromJson.txt:1042
+#: po/custom/fromJson.txt:1047
 msgid "based off the original AI, now for beginners"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessagesall.json: $.RES_REPTU1.text[1]
 #. data/mp/messages/resmessagesall.json: $.RES_REPTU1.text[1]
-#: po/custom/fromJson.txt:1046
+#: po/custom/fromJson.txt:1051
 msgid "Battlefield repair unit"
 msgstr ""
 
@@ -6968,7 +6973,7 @@ msgstr ""
 #. data/mp/messages/resmessagesall.json: $.RES_EMP_CANT.text[2]
 #. data/mp/messages/resmessagesall.json: $.RES_EMP_MD.text[2]
 #. ... + 3 refs
-#: po/custom/fromJson.txt:1052
+#: po/custom/fromJson.txt:1057
 msgid "Best Targets : Vehicles"
 msgstr ""
 
@@ -6977,7 +6982,7 @@ msgstr ""
 #. data/base/messages/resmessages3.json: $.RES_W_MS_LtSAM1.text[2]
 #. data/mp/messages/resmessages3.json: $.RES_W_MS_HvSAM1.text[2]
 #. ... + 3 refs
-#: po/custom/fromJson.txt:1058
+#: po/custom/fromJson.txt:1063
 msgid "Best Targets: Aerial targets only"
 msgstr ""
 
@@ -6986,14 +6991,14 @@ msgstr ""
 #. data/base/messages/resmessages3.json: $.RES_W_MS_MART.text[2]
 #. data/mp/messages/resmessages3.json: $.RES_W_MS_HART.text[2]
 #. data/mp/messages/resmessages3.json: $.RES_W_MS_MART.text[2]
-#: po/custom/fromJson.txt:1064
+#: po/custom/fromJson.txt:1069
 msgid "Best Targets: Base structures and cyborgs"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages12.json: $.RES_W_RK_MRL1.text[2]
 #. data/mp/messages/resmessages12.json: $.RES_W_RK_MRL1.text[2]
-#: po/custom/fromJson.txt:1078
+#: po/custom/fromJson.txt:1083
 msgid "Best Targets: Base structures"
 msgstr ""
 
@@ -7002,14 +7007,14 @@ msgstr ""
 #. data/base/messages/resmessages3.json: $.RES_W_BMB4.text[2]
 #. data/base/messages/resmessagesall.json: $.RES_W_RK_HVAT1.text[2]
 #. ... + 4 refs
-#: po/custom/fromJson.txt:1100
+#: po/custom/fromJson.txt:1105
 msgid "Best Targets: Bunkers and hardpoints"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages23.json: $.RES_W_BMB3.text[2]
 #. data/mp/messages/resmessages23.json: $.RES_W_BMB3.text[2]
-#: po/custom/fromJson.txt:1104
+#: po/custom/fromJson.txt:1109
 msgid "Best Targets: Bunkers and Hardpoints"
 msgstr ""
 
@@ -7018,13 +7023,13 @@ msgstr ""
 #. data/base/messages/resmessages3.json: $.RES_W_LAS2.text[2]
 #. data/mp/messages/resmessages3.json: $.RES_W_LAS1.text[2]
 #. data/mp/messages/resmessages3.json: $.RES_W_LAS2.text[2]
-#: po/custom/fromJson.txt:1116
+#: po/custom/fromJson.txt:1121
 msgid "Best Targets: Cyborgs"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/messages/resmessagesall.json: $.RES_W_HLAS.text[2]
-#: po/custom/fromJson.txt:1123
+#: po/custom/fromJson.txt:1128
 msgid "Best Targets: Heavy cyborgs"
 msgstr ""
 
@@ -7033,14 +7038,14 @@ msgstr ""
 #. data/base/messages/resmessages1.json: $.RES_MG2MK1.text[2]
 #. data/base/messages/resmessages12.json: $.RES_MG3MK1.text[2]
 #. ... + 7 refs
-#: po/custom/fromJson.txt:1129
+#: po/custom/fromJson.txt:1134
 msgid "Best Targets: Infantry, base structures, wheeled vehicles"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages12.json: $.RES_W_RK_IDF.text[2]
 #. data/mp/messages/resmessages12.json: $.RES_W_RK_IDF.text[2]
-#: po/custom/fromJson.txt:1133
+#: po/custom/fromJson.txt:1138
 msgid "Best Targets: Vehicles and Emplacements"
 msgstr ""
 
@@ -7048,26 +7053,26 @@ msgstr ""
 #. data/mp/messages/resmessages1.json: $.RES_CN2MK1.text[2]
 #. data/mp/messages/resmessages1.json: $.RES_CN3MK1.text[2]
 #. data/mp/messages/resmessages2.json: $.RES_W_CN_4A.text[2]
-#: po/custom/fromJson.txt:1144
+#: po/custom/fromJson.txt:1149
 msgid "Best Targets: Vehicles, Hardpoints"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages1.json: $.RES_W_RK_MP1.text[2]
 #. data/mp/messages/resmessages1.json: $.RES_W_RK_MP1.text[2]
-#: po/custom/fromJson.txt:1148
+#: po/custom/fromJson.txt:1153
 msgid "Best Targets: Wheeled and hover vehicles"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/campaigns/beta.json: $.name
-#: po/custom/fromJson.txt:1151
+#: po/custom/fromJson.txt:1156
 msgid "Beta Campaign"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/challenges/two-faced.json: $.player_2.name
-#: po/custom/fromJson.txt:1154
+#: po/custom/fromJson.txt:1159
 msgid "Beta"
 msgstr ""
 
@@ -7076,7 +7081,7 @@ msgstr ""
 #. data/base/messages/resmessages3.json: $.RES_V_P_V3.text[2]
 #. data/mp/messages/resmessages3.json: $.RES_V_P_V2.text[2]
 #. data/mp/messages/resmessages3.json: $.RES_V_P_V3.text[2]
-#: po/custom/fromJson.txt:1160
+#: po/custom/fromJson.txt:1165
 msgid "Body Points and Speed Increased"
 msgstr ""
 
@@ -7084,7 +7089,7 @@ msgstr ""
 #. data/base/messages/resmessages1.json: $.RES_FLAME1.text[3]
 #. data/mp/messages/resmessages1.json: $.RES_FLAME1.text[3]
 #. data/mp/messages/resmessagesall.json: $.RES_PLFL.text[3]
-#: po/custom/fromJson.txt:1189
+#: po/custom/fromJson.txt:1194
 msgid "Body Points: Very low"
 msgstr ""
 
@@ -7092,7 +7097,8 @@ msgstr ""
 #. data/mp/messages/resmessages2.json: $.RES_W_BAC1.text[2]
 #. data/mp/messages/resmessages23.json: $.RES_W_BAC2.text[2]
 #. data/mp/messages/resmessages3.json: $.RES_W_BAC3.text[2]
-#: po/custom/fromJson.txt:1194
+#: po/custom/fromJson.txt:1200
+#, no-c-format
 msgid "Bomb damage +25%"
 msgstr ""
 
@@ -7100,14 +7106,14 @@ msgstr ""
 #. data/mp/messages/resmessages2.json: $.RES_W_BAC1.text[0]
 #. data/mp/messages/resmessages23.json: $.RES_W_BAC2.text[0]
 #. data/mp/messages/resmessages3.json: $.RES_W_BAC3.text[0]
-#: po/custom/fromJson.txt:1203
+#: po/custom/fromJson.txt:1209
 msgid "Bomb Upgrade"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/templates.json: $.CobraHvyMortarHalftrack.name
 #. data/mp/stats/templates.json: $.CobraHvyMortarHalftrack.name
-#: po/custom/fromJson.txt:1207
+#: po/custom/fromJson.txt:1213
 msgid "Bombard Cobra Half-tracks"
 msgstr ""
 
@@ -7116,47 +7122,47 @@ msgstr ""
 #. data/base/stats/structure.json: $.Emplacement-MortarPit02.name
 #. data/mp/stats/research.json: $.R-Defense-HvyMor.name
 #. data/mp/stats/structure.json: $.Emplacement-MortarPit02.name
-#: po/custom/fromJson.txt:1213
+#: po/custom/fromJson.txt:1219
 msgid "Bombard Pit"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/weapons.json: $.Mortar2Mk1.name
 #. data/mp/stats/weapons.json: $.Mortar2Mk1.name
-#: po/custom/fromJson.txt:1217
+#: po/custom/fromJson.txt:1223
 msgid "Bombard"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages3.json: $.RES_W_BAC3.text[1]
-#: po/custom/fromJson.txt:1220
+#: po/custom/fromJson.txt:1226
 msgid "Bombs lock on and guide themselves to the target"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages3.json: $.RES_DF_WU10.text[1]
 #. data/mp/messages/resmessages3.json: $.RES_DF_WU10.text[1]
-#: po/custom/fromJson.txt:1229
+#: po/custom/fromJson.txt:1235
 msgid "Bonded metallic laminates formed into walls and defenses"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/multiplay/skirmish/bonecrusher.json: $.AI.name
-#: po/custom/fromJson.txt:1232
+#: po/custom/fromJson.txt:1238
 msgid "BoneCrusher!"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/body.json: $.Body4ABT.name
 #. data/mp/stats/body.json: $.Body4ABT.name
-#: po/custom/fromJson.txt:1236
+#: po/custom/fromJson.txt:1242
 msgid "Bug"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/templates.json: $.BarbarianBuggy.name
 #. data/mp/stats/templates.json: $.BarbarianBuggy.name
-#: po/custom/fromJson.txt:1240
+#: po/custom/fromJson.txt:1246
 msgid "Buggy"
 msgstr ""
 
@@ -7165,105 +7171,106 @@ msgstr ""
 #. data/base/messages/resmessages3.json: $.RES_SY_ASTRUC.text[2]
 #. data/mp/messages/resmessages3.json: $.RES_SY_ADEF.text[2]
 #. data/mp/messages/resmessages3.json: $.RES_SY_ASTRUC.text[2]
-#: po/custom/fromJson.txt:1246
+#: po/custom/fromJson.txt:1252
 msgid "Built-in diagnostic and repair systems"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/templates.json: $.Sk-CobraBBHover.name
-#: po/custom/fromJson.txt:1249
+#: po/custom/fromJson.txt:1255
 msgid "Bunker Buster Cobra Hover"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/templates.json: $.CobraBBTracks.name
-#: po/custom/fromJson.txt:1252
+#: po/custom/fromJson.txt:1258
 msgid "Bunker Buster Cobra Tracks"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/templates.json: $.MantisBBTracks.name
-#: po/custom/fromJson.txt:1255
+#: po/custom/fromJson.txt:1261
 msgid "Bunker Buster Mantis Tracks"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages3.json: $.RES_W_ASM_BB.text[1]
 #. data/mp/messages/resmessages3.json: $.RES_W_ASM_BB.text[1]
-#: po/custom/fromJson.txt:1259
+#: po/custom/fromJson.txt:1265
 msgid "Bunker buster missile"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Wpn-Rocket03-HvAT.name
 #. data/mp/stats/research.json: $.R-Wpn-Rocket03-HvAT.name
-#: po/custom/fromJson.txt:1263
+#: po/custom/fromJson.txt:1269
 msgid "Bunker Buster Rocket"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/templates.json: $.ViperBBWheels.name
-#: po/custom/fromJson.txt:1266
+#: po/custom/fromJson.txt:1272
 msgid "Bunker Buster Rockets Viper Wheels"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/templates.json: $.ScorpBBTracks.name
-#: po/custom/fromJson.txt:1269
+#: po/custom/fromJson.txt:1275
 msgid "Bunker Buster Scorpion Tracks"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/templates.json: $.H-Scorp-VTOL-BB.name
-#: po/custom/fromJson.txt:1272
+#: po/custom/fromJson.txt:1278
 msgid "Bunker Buster Scorpion VTOL"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/templates.json: $.ViperBBWheels.name
-#: po/custom/fromJson.txt:1275
+#: po/custom/fromJson.txt:1281
 msgid "Bunker Buster Viper Wheels"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/weapons.json: $.Rocket-BB.name
 #. data/mp/stats/weapons.json: $.Rocket-BB.name
-#: po/custom/fromJson.txt:1279
+#: po/custom/fromJson.txt:1285
 msgid "Bunker Buster"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages1.json: $.RES_POWMD1.text[2]
 #. data/mp/messages/resmessages1.json: $.RES_POWMD1.text[2]
-#: po/custom/fromJson.txt:1283
+#: po/custom/fromJson.txt:1289
 msgid "Burns oil more efficiently"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/messages/resmessages12.json: $.RES_W_CNAC1.text[2]
 #. data/mp/messages/resmessagesall.json: $.RES_W_CNAC2.text[2]
-#: po/custom/fromJson.txt:1287
+#: po/custom/fromJson.txt:1294
+#, no-c-format
 msgid "Cannon accuracy +10%"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Wpn-Cannon-ROF02.name
 #. data/mp/stats/research.json: $.R-Wpn-Cannon-ROF02.name
-#: po/custom/fromJson.txt:1291
+#: po/custom/fromJson.txt:1298
 msgid "Cannon Autoloader Mk2"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Wpn-Cannon-ROF03.name
 #. data/mp/stats/research.json: $.R-Wpn-Cannon-ROF03.name
-#: po/custom/fromJson.txt:1295
+#: po/custom/fromJson.txt:1302
 msgid "Cannon Autoloader Mk3"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Wpn-Cannon-ROF01.name
 #. data/mp/stats/research.json: $.R-Wpn-Cannon-ROF01.name
-#: po/custom/fromJson.txt:1299
+#: po/custom/fromJson.txt:1306
 msgid "Cannon Autoloader"
 msgstr ""
 
@@ -7271,14 +7278,15 @@ msgstr ""
 #. data/mp/messages/resmessages1.json: $.RES_W_CN_D1.text[2]
 #. data/mp/messages/resmessages12.json: $.RES_W_CN_D4.text[2]
 #. data/mp/messages/resmessages3.json: $.RES_W_CN_D7.text[2]
-#: po/custom/fromJson.txt:1304
+#: po/custom/fromJson.txt:1312
+#, no-c-format
 msgid "Cannon damage +25%"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/templates.json: $.BabaFireCan.name
 #. data/mp/stats/templates.json: $.BabaFireCan.name
-#: po/custom/fromJson.txt:1308
+#: po/custom/fromJson.txt:1316
 msgid "Cannon Fire Truck"
 msgstr ""
 
@@ -7286,56 +7294,57 @@ msgstr ""
 #. data/mp/stats/research.json: $.R-Defense-Super-Cannon.name
 #. data/mp/stats/structure.json: $.X-Super-Cannon.name
 #. data/mp/stats/weapons.json: $.CannonSuper.name
-#: po/custom/fromJson.txt:1313
+#: po/custom/fromJson.txt:1321
 msgid "Cannon Fortress"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Wpn-Cannon-Accuracy02.name
 #. data/mp/stats/research.json: $.R-Wpn-Cannon-Accuracy02.name
-#: po/custom/fromJson.txt:1317
+#: po/custom/fromJson.txt:1325
 msgid "Cannon Laser Designator"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Wpn-Cannon-Accuracy01.name
 #. data/mp/stats/research.json: $.R-Wpn-Cannon-Accuracy01.name
-#: po/custom/fromJson.txt:1321
+#: po/custom/fromJson.txt:1329
 msgid "Cannon Laser Rangefinder"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Wpn-Cannon-ROF05.name
 #. data/mp/stats/research.json: $.R-Wpn-Cannon-ROF05.name
-#: po/custom/fromJson.txt:1325
+#: po/custom/fromJson.txt:1333
 msgid "Cannon Rapid Loader Mk2"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Wpn-Cannon-ROF06.name
 #. data/mp/stats/research.json: $.R-Wpn-Cannon-ROF06.name
-#: po/custom/fromJson.txt:1329
+#: po/custom/fromJson.txt:1337
 msgid "Cannon Rapid Loader Mk3"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Wpn-Cannon-ROF04.name
 #. data/mp/stats/research.json: $.R-Wpn-Cannon-ROF04.name
-#: po/custom/fromJson.txt:1333
+#: po/custom/fromJson.txt:1341
 msgid "Cannon Rapid Loader"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/messages/resmessages12.json: $.RES_W_CN_ROF1.text[2]
 #. data/mp/messages/resmessages3.json: $.RES_W_CN_ROF4.text[2]
-#: po/custom/fromJson.txt:1337
+#: po/custom/fromJson.txt:1346
+#, no-c-format
 msgid "Cannon reload time -10%"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/structure.json: $.A0CannonTower.name
 #. data/mp/stats/structure.json: $.A0CannonTower.name
-#: po/custom/fromJson.txt:1341
+#: po/custom/fromJson.txt:1350
 msgid "Cannon Tower"
 msgstr ""
 
@@ -7344,14 +7353,14 @@ msgstr ""
 #. data/base/messages/resmessages12.json: $.RES_W_CN_D4.text[0]
 #. data/base/messages/resmessages12.json: $.RES_W_CN_ROF1.text[0]
 #. ... + 11 refs
-#: po/custom/fromJson.txt:1347
+#: po/custom/fromJson.txt:1356
 msgid "Cannon Upgrade"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/sensor.json: $.Sys-CBTurret01.name
 #. data/mp/stats/sensor.json: $.Sys-CBTurret01.name
-#: po/custom/fromJson.txt:1351
+#: po/custom/fromJson.txt:1360
 msgid "CB Radar Turret"
 msgstr ""
 
@@ -7360,7 +7369,7 @@ msgstr ""
 #. data/base/messages/resmessages23.json: $.RES_SY_CBSU2.text[0]
 #. data/base/messages/resmessages3.json: $.RES_SY_CBSU3.text[0]
 #. ... + 3 refs
-#: po/custom/fromJson.txt:1357
+#: po/custom/fromJson.txt:1366
 msgid "CB Sensor Improved"
 msgstr ""
 
@@ -7369,66 +7378,66 @@ msgstr ""
 #. data/base/stats/structure.json: $.Sys-CB-Tower01.name
 #. data/mp/stats/research.json: $.R-Sys-CBSensor-Tower01.name
 #. data/mp/stats/structure.json: $.Sys-CB-Tower01.name
-#: po/custom/fromJson.txt:1363
+#: po/custom/fromJson.txt:1372
 msgid "CB Tower"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Sys-CBSensor-Turret01.name
 #. data/mp/stats/research.json: $.R-Sys-CBSensor-Turret01.name
-#: po/custom/fromJson.txt:1367
+#: po/custom/fromJson.txt:1376
 msgid "CB Turret"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages3.json: $.RES_W_AAROF4.text[1]
 #. data/mp/messages/resmessages3.json: $.RES_W_AAROF4.text[1]
-#: po/custom/fromJson.txt:1371
+#: po/custom/fromJson.txt:1380
 msgid "Chainfeed loader eradicates jams and improves performance"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages12.json: $.RES_W_MG_ROF1.text[1]
 #. data/mp/messages/resmessages12.json: $.RES_W_MG_ROF1.text[1]
-#: po/custom/fromJson.txt:1375
+#: po/custom/fromJson.txt:1384
 msgid "Chaingun mechanism replaces belt-feed"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Wpn-MG-ROF01.name
 #. data/mp/stats/research.json: $.R-Wpn-MG-ROF01.name
-#: po/custom/fromJson.txt:1379
+#: po/custom/fromJson.txt:1388
 msgid "Chaingun Upgrade"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/templates.json: $.BaBaCivilian.name
 #. data/mp/stats/templates.json: $.BaBaCivilian.name
-#: po/custom/fromJson.txt:1383
+#: po/custom/fromJson.txt:1392
 msgid "Civilian"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/research.json: $.R-Wpn-Bomb01.name
-#: po/custom/fromJson.txt:1386
+#: po/custom/fromJson.txt:1395
 msgid "Cluster Bomb Bay"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Wpn-Bomb01.name
-#: po/custom/fromJson.txt:1389
+#: po/custom/fromJson.txt:1398
 msgid "Cluster Bombs Bay"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/templates.json: $.P0CobraFlameTracks.name
-#: po/custom/fromJson.txt:1392
+#: po/custom/fromJson.txt:1401
 msgid "Cobra Flamer Tracks"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/templates.json: $.P0CobraMedCnTrks.name
-#: po/custom/fromJson.txt:1395
+#: po/custom/fromJson.txt:1404
 msgid "Cobra Medium Cannon Tracks"
 msgstr ""
 
@@ -7437,7 +7446,7 @@ msgstr ""
 #. data/base/stats/templates.json: $.P0CobraSpadeTracks.name
 #. data/mp/stats/templates.json: $.CobraSpadeTracks.name
 #. data/mp/stats/templates.json: $.P0CobraSpadeTracks.name
-#: po/custom/fromJson.txt:1401
+#: po/custom/fromJson.txt:1410
 msgid "Cobra Truck"
 msgstr ""
 
@@ -7445,86 +7454,86 @@ msgstr ""
 #. data/base/stats/body.json: $.Body5REC.name
 #. data/mp/multiplay/skirmish/Cobra.json: $.AI.name
 #. data/mp/stats/body.json: $.Body5REC.name
-#: po/custom/fromJson.txt:1406
+#: po/custom/fromJson.txt:1415
 msgid "Cobra"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages3.json: $.RES_W_MG_D10.text[1]
 #. data/mp/messages/resmessages3.json: $.RES_W_MG_D10.text[1]
-#: po/custom/fromJson.txt:1410
+#: po/custom/fromJson.txt:1419
 msgid "Collapsing Plutonium kinetic energy bullets"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/structure.json: $.CollectiveCWall.name
-#: po/custom/fromJson.txt:1416
+#: po/custom/fromJson.txt:1425
 msgid "Collective CWall"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessagesall.json: $.RES_V_B09.text[0]
 #. data/mp/messages/resmessagesall.json: $.RES_V_B09.text[0]
-#: po/custom/fromJson.txt:1420
+#: po/custom/fromJson.txt:1429
 msgid "Collective Heavy Body"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/messages/resmessagesall.json: $.RES_CYS_CEN.text[1]
-#: po/custom/fromJson.txt:1434
+#: po/custom/fromJson.txt:1443
 msgid "Combat engineer with construction ability"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/templates.json: $.Cyb-ComEng.name
-#: po/custom/fromJson.txt:1437
+#: po/custom/fromJson.txt:1446
 msgid "Combat Engineer"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/messages/resmessagesall.json: $.RES_SY_S_WS.text[1]
 #. data/mp/messages/resmessagesall.json: $.RES_SY_S_WST.text[1]
-#: po/custom/fromJson.txt:1441
+#: po/custom/fromJson.txt:1450
 msgid "Combines standard, counter battery and VTOL sensors"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/structure.json: $.A0CommandCentre.name
 #. data/mp/stats/structure.json: $.A0CommandCentre.name
-#: po/custom/fromJson.txt:1445
+#: po/custom/fromJson.txt:1454
 msgid "Command Center"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/structure.json: $.A0ComDroidControl.name
 #. data/mp/stats/structure.json: $.A0ComDroidControl.name
-#: po/custom/fromJson.txt:1449
+#: po/custom/fromJson.txt:1458
 msgid "Command Relay Center"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Struc-CommandRelay.name
 #. data/mp/stats/research.json: $.R-Struc-CommandRelay.name
-#: po/custom/fromJson.txt:1453
+#: po/custom/fromJson.txt:1462
 msgid "Command Relay Post"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/templates.json: $.CobraComHalftrack.name
 #. data/mp/stats/templates.json: $.CobraComHalftrack.name
-#: po/custom/fromJson.txt:1457
+#: po/custom/fromJson.txt:1466
 msgid "Command Turret Cobra Half-tracks"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/templates.json: $.Cobra-Trk-Com.name
-#: po/custom/fromJson.txt:1460
+#: po/custom/fromJson.txt:1469
 msgid "Command Turret Cobra Tracks"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/templates.json: $.Mantis-Trk-Com.name
-#: po/custom/fromJson.txt:1463
+#: po/custom/fromJson.txt:1472
 msgid "Command Turret Mantis Tracks"
 msgstr ""
 
@@ -7533,25 +7542,25 @@ msgstr ""
 #. data/base/stats/templates.json: $.PythonComTracks.name
 #. data/mp/stats/templates.json: $.P0PythonComTracks.name
 #. data/mp/stats/templates.json: $.PythonComTracks.name
-#: po/custom/fromJson.txt:1469
+#: po/custom/fromJson.txt:1478
 msgid "Command Turret Python Tracks"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/templates.json: $.Scorp-Trk-Com.name
-#: po/custom/fromJson.txt:1472
+#: po/custom/fromJson.txt:1481
 msgid "Command Turret Scorpion Tracks"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/research.json: $.R-Comp-CommandTurret02.name
-#: po/custom/fromJson.txt:1475
+#: po/custom/fromJson.txt:1484
 msgid "Command Turret Upgrade"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/templates.json: $.Viper-Trk-Com.name
-#: po/custom/fromJson.txt:1478
+#: po/custom/fromJson.txt:1487
 msgid "Command Turret Viper Tracks"
 msgstr ""
 
@@ -7560,7 +7569,7 @@ msgstr ""
 #. data/base/stats/research.json: $.R-Comp-CommandTurret01.name
 #. data/base/stats/weapons.json: $.CommandTurret1.name
 #. ... + 2 refs
-#: po/custom/fromJson.txt:1484
+#: po/custom/fromJson.txt:1493
 msgid "Command Turret"
 msgstr ""
 
@@ -7569,68 +7578,68 @@ msgstr ""
 #. data/mp/messages/resmessages1.json: $.RES_C_CT1.text[2]
 #. data/mp/messages/resmessagesall.json: $.RES_C_CT2.text[2]
 #. ... + 2 refs
-#: po/custom/fromJson.txt:1490
+#: po/custom/fromJson.txt:1499
 msgid "Commander leads groups acts as factory delivery point"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/messages/resmessagesall.json: $.RES_SY_S_UP.text[1]
-#: po/custom/fromJson.txt:1493
+#: po/custom/fromJson.txt:1502
 msgid "Complete battlefield visibility"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Vehicle-Metals02.name
 #. data/mp/stats/research.json: $.R-Vehicle-Metals02.name
-#: po/custom/fromJson.txt:1497
+#: po/custom/fromJson.txt:1506
 msgid "Composite Alloys Mk2"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Vehicle-Metals03.name
 #. data/mp/stats/research.json: $.R-Vehicle-Metals03.name
-#: po/custom/fromJson.txt:1501
+#: po/custom/fromJson.txt:1510
 msgid "Composite Alloys Mk3"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Vehicle-Metals01.name
 #. data/mp/stats/research.json: $.R-Vehicle-Metals01.name
-#: po/custom/fromJson.txt:1505
+#: po/custom/fromJson.txt:1514
 msgid "Composite Alloys"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages3.json: $.RES_W_HOWAC3.text[1]
 #. data/mp/messages/resmessages3.json: $.RES_W_HOWAC3.text[1]
-#: po/custom/fromJson.txt:1509
+#: po/custom/fromJson.txt:1518
 msgid "Computer guided shells"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages3.json: $.RES_W_AAAC3.text[1]
 #. data/mp/messages/resmessages3.json: $.RES_W_AAAC3.text[1]
-#: po/custom/fromJson.txt:1513
+#: po/custom/fromJson.txt:1522
 msgid "Computer plots and guides shell to target's position"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages3.json: $.RES_W_RAIL_AC1.text[1]
 #. data/mp/messages/resmessages3.json: $.RES_W_RAIL_AC1.text[1]
-#: po/custom/fromJson.txt:1517
+#: po/custom/fromJson.txt:1526
 msgid "Computer predicts and compensates for target's movement"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/messages.json: $.MSG3.text[0]
-#: po/custom/fromJson.txt:1520
+#: po/custom/fromJson.txt:1529
 msgid "Computer Research Completed"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages3.json: $.RES_SY_RESU2.text[2]
 #. data/mp/messages/resmessages3.json: $.RES_SY_RESU2.text[2]
-#: po/custom/fromJson.txt:1524
+#: po/custom/fromJson.txt:1533
 msgid "Computer systems can now be 'ring-fenced' from NEXUS"
 msgstr ""
 
@@ -7639,34 +7648,36 @@ msgstr ""
 #. data/base/messages/resmessages3.json: $.RES_SY_RESU1.text[0]
 #. data/base/messages/resmessages3.json: $.RES_SY_RESU2.text[0]
 #. ... + 3 refs
-#: po/custom/fromJson.txt:1530
+#: po/custom/fromJson.txt:1539
 msgid "Computer Technology Breakthrough"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/messages/resmessages12.json: $.RES_ENGIN1.text[2]
-#: po/custom/fromJson.txt:1533
+#: po/custom/fromJson.txt:1543
+#, no-c-format
 msgid "Construction speed +10%"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/messages/resmessages23.json: $.RES_ENGIN2.text[2]
 #. data/mp/messages/resmessages3.json: $.RES_ENGIN3.text[2]
-#: po/custom/fromJson.txt:1537
+#: po/custom/fromJson.txt:1548
+#, no-c-format
 msgid "Construction speed +20%"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Sys-Spade1Mk1.name
 #. data/mp/stats/research.json: $.R-Sys-Spade1Mk1.name
-#: po/custom/fromJson.txt:1541
+#: po/custom/fromJson.txt:1552
 msgid "Construction Unit"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages1.json: $.RES_ST_CR1.text[3]
 #. data/mp/messages/resmessages1.json: $.RES_ST_CR1.text[3]
-#: po/custom/fromJson.txt:1545
+#: po/custom/fromJson.txt:1556
 msgid "Controls up to ten commanders"
 msgstr ""
 
@@ -7675,63 +7686,63 @@ msgstr ""
 #. data/base/messages/resmessagesall.json: $.RES_SY_CBSTW1.text[3]
 #. data/mp/messages/resmessages12.json: $.RES_SY_CBSTU1.text[3]
 #. data/mp/messages/resmessagesall.json: $.RES_SY_CBSTW1.text[3]
-#: po/custom/fromJson.txt:1551
+#: po/custom/fromJson.txt:1562
 msgid "Counter-battery fire continues until enemy battery is suppressed"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessagesall.json: $.RES_SY_CBSTW1.text[1]
 #. data/mp/messages/resmessagesall.json: $.RES_SY_CBSTW1.text[1]
-#: po/custom/fromJson.txt:1555
+#: po/custom/fromJson.txt:1566
 msgid "Counter-battery tower detects enemy indirect fire batteries"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages12.json: $.RES_SY_CBSTU1.text[1]
 #. data/mp/messages/resmessages12.json: $.RES_SY_CBSTU1.text[1]
-#: po/custom/fromJson.txt:1559
+#: po/custom/fromJson.txt:1570
 msgid "Counter-battery turret detects enemy indirect fire batteries"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Cyborg-Metals02.name
 #. data/mp/stats/research.json: $.R-Cyborg-Metals02.name
-#: po/custom/fromJson.txt:1563
+#: po/custom/fromJson.txt:1574
 msgid "Cyborg Composite Alloys Mk2"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Cyborg-Metals03.name
 #. data/mp/stats/research.json: $.R-Cyborg-Metals03.name
-#: po/custom/fromJson.txt:1567
+#: po/custom/fromJson.txt:1578
 msgid "Cyborg Composite Alloys Mk3"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Cyborg-Metals01.name
 #. data/mp/stats/research.json: $.R-Cyborg-Metals01.name
-#: po/custom/fromJson.txt:1571
+#: po/custom/fromJson.txt:1582
 msgid "Cyborg Composite Alloys"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Cyborg-Metals05.name
 #. data/mp/stats/research.json: $.R-Cyborg-Metals05.name
-#: po/custom/fromJson.txt:1575
+#: po/custom/fromJson.txt:1586
 msgid "Cyborg Dense Composite Alloys Mk2"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Cyborg-Metals06.name
 #. data/mp/stats/research.json: $.R-Cyborg-Metals06.name
-#: po/custom/fromJson.txt:1579
+#: po/custom/fromJson.txt:1590
 msgid "Cyborg Dense Composite Alloys Mk3"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Cyborg-Metals04.name
 #. data/mp/stats/research.json: $.R-Cyborg-Metals04.name
-#: po/custom/fromJson.txt:1583
+#: po/custom/fromJson.txt:1594
 msgid "Cyborg Dense Composite Alloys"
 msgstr ""
 
@@ -7740,7 +7751,7 @@ msgstr ""
 #. data/base/stats/research.json: $.R-Struc-Factory-Cyborg.name
 #. data/base/stats/structure.json: $.A0CyborgFactory.name
 #. ... + 3 refs
-#: po/custom/fromJson.txt:1589
+#: po/custom/fromJson.txt:1600
 msgid "Cyborg Factory"
 msgstr ""
 
@@ -7749,54 +7760,54 @@ msgstr ""
 #. data/base/stats/templates.json: $.CyborgFlamer01Grd.name
 #. data/base/stats/weapons.json: $.CyborgFlamer01.name
 #. ... + 2 refs
-#: po/custom/fromJson.txt:1595
+#: po/custom/fromJson.txt:1606
 msgid "Cyborg Flamer"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/body.json: $.CyborgHeavyBody.name
-#: po/custom/fromJson.txt:1598
+#: po/custom/fromJson.txt:1609
 msgid "Cyborg Heavy Body"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Cyborg-Armor-Heat05.name
 #. data/mp/stats/research.json: $.R-Cyborg-Armor-Heat05.name
-#: po/custom/fromJson.txt:1602
+#: po/custom/fromJson.txt:1613
 msgid "Cyborg High Intensity Thermal Armor Mk2"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Cyborg-Armor-Heat06.name
 #. data/mp/stats/research.json: $.R-Cyborg-Armor-Heat06.name
-#: po/custom/fromJson.txt:1606
+#: po/custom/fromJson.txt:1617
 msgid "Cyborg High Intensity Thermal Armor Mk3"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Cyborg-Armor-Heat04.name
 #. data/mp/stats/research.json: $.R-Cyborg-Armor-Heat04.name
-#: po/custom/fromJson.txt:1610
+#: po/custom/fromJson.txt:1621
 msgid "Cyborg High Intensity Thermal Armor"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/weapons.json: $.CyborgRocket.name
 #. data/mp/stats/weapons.json: $.CyborgRocket.name
-#: po/custom/fromJson.txt:1614
+#: po/custom/fromJson.txt:1625
 msgid "Cyborg Lancer"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/body.json: $.CyborgLightBody.name
 #. data/mp/stats/body.json: $.CyborgLightBody.name
-#: po/custom/fromJson.txt:1618
+#: po/custom/fromJson.txt:1629
 msgid "Cyborg Light Body"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/templates.json: $.Cyb-Mechanic.name
-#: po/custom/fromJson.txt:1627
+#: po/custom/fromJson.txt:1638
 msgid "Cyborg Mechanic"
 msgstr ""
 
@@ -7805,121 +7816,121 @@ msgstr ""
 #. data/base/messages/resmessages3.json: $.RES_CY_LG3.text[0]
 #. data/mp/messages/resmessages23.json: $.RES_CY_LG2.text[0]
 #. data/mp/messages/resmessages3.json: $.RES_CY_LG3.text[0]
-#: po/custom/fromJson.txt:1646
+#: po/custom/fromJson.txt:1657
 msgid "Cyborg Propulsion Improved"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Cyborg-Metals08.name
 #. data/mp/stats/research.json: $.R-Cyborg-Metals08.name
-#: po/custom/fromJson.txt:1655
+#: po/custom/fromJson.txt:1666
 msgid "Cyborg Superdense Composite Alloys Mk2"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Cyborg-Metals09.name
 #. data/mp/stats/research.json: $.R-Cyborg-Metals09.name
-#: po/custom/fromJson.txt:1659
+#: po/custom/fromJson.txt:1670
 msgid "Cyborg Superdense Composite Alloys Mk3"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Cyborg-Metals07.name
 #. data/mp/stats/research.json: $.R-Cyborg-Metals07.name
-#: po/custom/fromJson.txt:1663
+#: po/custom/fromJson.txt:1674
 msgid "Cyborg Superdense Composite Alloys"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/research.json: $.R-Cyborg-Armor-Heat08.name
-#: po/custom/fromJson.txt:1666
+#: po/custom/fromJson.txt:1677
 msgid "Cyborg Superdense Thermal Armor Mk2"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/research.json: $.R-Cyborg-Armor-Heat09.name
-#: po/custom/fromJson.txt:1669
+#: po/custom/fromJson.txt:1680
 msgid "Cyborg Superdense Thermal Armor Mk3"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/research.json: $.R-Cyborg-Armor-Heat07.name
-#: po/custom/fromJson.txt:1672
+#: po/custom/fromJson.txt:1683
 msgid "Cyborg Superdense Thermal Armor"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Cyborg-Armor-Heat02.name
 #. data/mp/stats/research.json: $.R-Cyborg-Armor-Heat02.name
-#: po/custom/fromJson.txt:1682
+#: po/custom/fromJson.txt:1693
 msgid "Cyborg Thermal Armor Mk2"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Cyborg-Armor-Heat03.name
 #. data/mp/stats/research.json: $.R-Cyborg-Armor-Heat03.name
-#: po/custom/fromJson.txt:1686
+#: po/custom/fromJson.txt:1697
 msgid "Cyborg Thermal Armor Mk3"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Cyborg-Armor-Heat01.name
 #. data/mp/stats/research.json: $.R-Cyborg-Armor-Heat01.name
-#: po/custom/fromJson.txt:1690
+#: po/custom/fromJson.txt:1701
 msgid "Cyborg Thermal Armor"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/messages/resmessagesall.json: $.RES_CYTRANS.text[0]
-#: po/custom/fromJson.txt:1693
+#: po/custom/fromJson.txt:1704
 msgid "Cyborg Transport Available"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/research.json: $.R-Cyborg-Transport.name
 #. data/mp/stats/templates.json: $.Transporter.name
-#: po/custom/fromJson.txt:1697
+#: po/custom/fromJson.txt:1708
 msgid "Cyborg Transport"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages1.json: $.RES_C_SL1.text[2]
 #. data/mp/messages/resmessages1.json: $.RES_C_SL1.text[2]
-#: po/custom/fromJson.txt:1701
+#: po/custom/fromJson.txt:1712
 msgid "Cyborgs can now be researched"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Defense-AASite-QuadBof.name
 #. data/base/stats/structure.json: $.AASite-QuadBof.name
-#: po/custom/fromJson.txt:1705
+#: po/custom/fromJson.txt:1716
 msgid "Cyclone AA Flak Site"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/templates.json: $.P0cam3PyFlakHT.name
-#: po/custom/fromJson.txt:1708
+#: po/custom/fromJson.txt:1719
 msgid "Cyclone AA Python Half-tracks"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Wpn-AAGun02.name
 #. data/base/stats/weapons.json: $.AAGun2Mk1.name
-#: po/custom/fromJson.txt:1712
+#: po/custom/fromJson.txt:1723
 msgid "Cyclone Flak Turret"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Struc-Research-Upgrade05.name
 #. data/mp/stats/research.json: $.R-Struc-Research-Upgrade05.name
-#: po/custom/fromJson.txt:1716
+#: po/custom/fromJson.txt:1727
 msgid "Dedicated Synaptic Link Data Analysis Mk2"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Struc-Research-Upgrade06.name
 #. data/mp/stats/research.json: $.R-Struc-Research-Upgrade06.name
-#: po/custom/fromJson.txt:1720
+#: po/custom/fromJson.txt:1731
 msgid "Dedicated Synaptic Link Data Analysis Mk3"
 msgstr ""
 
@@ -7928,115 +7939,115 @@ msgstr ""
 #. data/mp/messages/resmessagesall.json: $.RES_EMP_MD.text[3]
 #. data/mp/messages/resmessagesall.json: $.RES_EMP_MSL.text[3]
 #. data/mp/messages/resmessagesall.json: $.RES_EMP_RKT.text[3]
-#: po/custom/fromJson.txt:1738
+#: po/custom/fromJson.txt:1749
 msgid "Defensive Strength : High"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages1.json: $.RES_TOWER1.text[3]
 #. data/mp/messages/resmessages1.json: $.RES_TOWER1.text[3]
-#: po/custom/fromJson.txt:1748
+#: po/custom/fromJson.txt:1759
 msgid "Defensive Strength: Low"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/structure.json: $.A0ADemolishStructure.name
 #. data/mp/stats/structure.json: $.A0ADemolishStructure.name
-#: po/custom/fromJson.txt:1758
+#: po/custom/fromJson.txt:1769
 msgid "Demolish Structure"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Vehicle-Metals05.name
 #. data/mp/stats/research.json: $.R-Vehicle-Metals05.name
-#: po/custom/fromJson.txt:1762
+#: po/custom/fromJson.txt:1773
 msgid "Dense Composite Alloys Mk2"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Vehicle-Metals06.name
 #. data/mp/stats/research.json: $.R-Vehicle-Metals06.name
-#: po/custom/fromJson.txt:1766
+#: po/custom/fromJson.txt:1777
 msgid "Dense Composite Alloys Mk3"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Vehicle-Metals04.name
 #. data/mp/stats/research.json: $.R-Vehicle-Metals04.name
-#: po/custom/fromJson.txt:1770
+#: po/custom/fromJson.txt:1781
 msgid "Dense Composite Alloys"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages3.json: $.RES_W_MG_D8.text[1]
 #. data/mp/messages/resmessages3.json: $.RES_W_MG_D8.text[1]
-#: po/custom/fromJson.txt:1774
+#: po/custom/fromJson.txt:1785
 msgid "Depleted uranium kinetic energy bullets"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Wpn-MG-Damage08.name
 #. data/mp/stats/research.json: $.R-Wpn-MG-Damage08.name
-#: po/custom/fromJson.txt:1781
+#: po/custom/fromJson.txt:1792
 msgid "Depleted Uranium MG Bullets"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/multiplay/skirmish/Cobra.json: $.AI.tip
-#: po/custom/fromJson.txt:1784
+#: po/custom/fromJson.txt:1795
 msgid "Designed for shared research team battles"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages12.json: $.RES_W_CNAC1.text[1]
 #. data/mp/messages/resmessages12.json: $.RES_W_CNAC1.text[1]
-#: po/custom/fromJson.txt:1792
+#: po/custom/fromJson.txt:1803
 msgid "Determines range to target"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages1.json: $.RES_ST_CR1.text[2]
 #. data/mp/messages/resmessages1.json: $.RES_ST_CR1.text[2]
-#: po/custom/fromJson.txt:1796
+#: po/custom/fromJson.txt:1807
 msgid "Directs and collates information for command turrets"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/messages/resmessagesall.json: $.RES_SY_S_UP.text[3]
-#: po/custom/fromJson.txt:1799
+#: po/custom/fromJson.txt:1810
 msgid "Does not offer sensor targeting"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/structure.json: $.WreckedTransporter.name
 #. data/mp/stats/structure.json: $.WreckedTransporter.name
-#: po/custom/fromJson.txt:1803
+#: po/custom/fromJson.txt:1814
 msgid "Downed Transport"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/body.json: $.Body14SUP.name
-#: po/custom/fromJson.txt:1806
+#: po/custom/fromJson.txt:1817
 msgid "Dragon"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/messages/resmessagesall.json: $.RES_W_BMB5.text[1]
-#: po/custom/fromJson.txt:1817
+#: po/custom/fromJson.txt:1828
 msgid "Drops high intensity Plasmite bombs"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages3.json: $.RES_W_BMB4.text[1]
 #. data/mp/messages/resmessages3.json: $.RES_W_BMB4.text[1]
-#: po/custom/fromJson.txt:1821
+#: po/custom/fromJson.txt:1832
 msgid "Drops high intensity thermite bombs"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages23.json: $.RES_W_BMB3.text[1]
 #. data/mp/messages/resmessages23.json: $.RES_W_BMB3.text[1]
-#: po/custom/fromJson.txt:1825
+#: po/custom/fromJson.txt:1836
 msgid "Drops incendiary bombs"
 msgstr ""
 
@@ -8044,95 +8055,95 @@ msgstr ""
 #. data/base/messages/resmessages3.json: $.RES_SY_ST1.text[2]
 #. data/mp/messages/resmessages3.json: $.RES_SY_ST1.text[2]
 #. data/mp/messages/resmessagesall.json: $.RES_SY_SPT.text[2]
-#: po/custom/fromJson.txt:1830
+#: po/custom/fromJson.txt:1841
 msgid "Electronically attacks and disrupts enemy structures"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/research.json: $.R-Defense-EMPCannon.name
 #. data/mp/stats/structure.json: $.WallTower-EMP.name
-#: po/custom/fromJson.txt:1834
+#: po/custom/fromJson.txt:1845
 msgid "EMP Cannon Tower"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/research.json: $.R-Wpn-EMPCannon.name
 #. data/mp/stats/weapons.json: $.EMP-Cannon.name
-#: po/custom/fromJson.txt:1838
+#: po/custom/fromJson.txt:1849
 msgid "EMP Cannon"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/research.json: $.R-Wpn-Bomb06.name
-#: po/custom/fromJson.txt:1841
+#: po/custom/fromJson.txt:1852
 msgid "EMP Missile Launcher"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/research.json: $.R-Defense-EMPMortar.name
 #. data/mp/stats/structure.json: $.Emplacement-MortarEMP.name
-#: po/custom/fromJson.txt:1845
+#: po/custom/fromJson.txt:1856
 msgid "EMP Mortar Pit"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/research.json: $.R-Wpn-MortarEMP.name
 #. data/mp/stats/weapons.json: $.MortarEMP.name
-#: po/custom/fromJson.txt:1849
+#: po/custom/fromJson.txt:1860
 msgid "EMP Mortar"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages1.json: $.RES_ST_CR1.text[1]
 #. data/mp/messages/resmessages1.json: $.RES_ST_CR1.text[1]
-#: po/custom/fromJson.txt:1853
+#: po/custom/fromJson.txt:1864
 msgid "Enables command turret research"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessagesall.json: $.RES_DF_HCW1.text[2]
 #. data/mp/messages/resmessagesall.json: $.RES_DF_HCW1.text[2]
-#: po/custom/fromJson.txt:1857
+#: po/custom/fromJson.txt:1868
 msgid "Enables Hardcrete walls"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/messages/resmessagesall.json: $.RES_SY_RC.text[3]
-#: po/custom/fromJson.txt:1860
+#: po/custom/fromJson.txt:1871
 msgid "Enables resistance to Nexus Link technology"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages3.json: $.RES_SY_ASTRUC.text[3]
 #. data/mp/messages/resmessages3.json: $.RES_SY_ASTRUC.text[3]
-#: po/custom/fromJson.txt:1864
+#: po/custom/fromJson.txt:1875
 msgid "Enables self-repair in all base structures"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages3.json: $.RES_SY_ACYB.text[3]
 #. data/mp/messages/resmessages3.json: $.RES_SY_ACYB.text[3]
-#: po/custom/fromJson.txt:1868
+#: po/custom/fromJson.txt:1879
 msgid "Enables self-repair in all Cyborgs"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages3.json: $.RES_SY_ADEF.text[3]
 #. data/mp/messages/resmessages3.json: $.RES_SY_ADEF.text[3]
-#: po/custom/fromJson.txt:1872
+#: po/custom/fromJson.txt:1883
 msgid "Enables self-repair in all defenses"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages3.json: $.RES_SY_AVEH.text[3]
 #. data/mp/messages/resmessages3.json: $.RES_SY_AVEH.text[3]
-#: po/custom/fromJson.txt:1876
+#: po/custom/fromJson.txt:1887
 msgid "Enables self-repair in all vehicles"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/messages/resmessagesall.json: $.RES_SY_AR.text[3]
-#: po/custom/fromJson.txt:1879
+#: po/custom/fromJson.txt:1890
 msgid "Enables self-repair"
 msgstr ""
 
@@ -8141,35 +8152,35 @@ msgstr ""
 #. data/mp/challenges/hidebehind.json: $.player_4.name
 #. data/mp/challenges/hidebehind.json: $.player_5.name
 #. ... + 7 refs
-#: po/custom/fromJson.txt:1885
+#: po/custom/fromJson.txt:1896
 msgid "Enemy"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Sys-Engineering01.name
 #. data/mp/stats/research.json: $.R-Sys-Engineering01.name
-#: po/custom/fromJson.txt:1889
+#: po/custom/fromJson.txt:1900
 msgid "Engineering"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages3.json: $.RES_V_B07.text[3]
 #. data/mp/messages/resmessages3.json: $.RES_V_B07.text[3]
-#: po/custom/fromJson.txt:1893
+#: po/custom/fromJson.txt:1904
 msgid "Expensive and slow to produce"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages3.json: $.RES_V_B03.text[3]
 #. data/mp/messages/resmessages3.json: $.RES_V_B03.text[3]
-#: po/custom/fromJson.txt:1897
+#: po/custom/fromJson.txt:1908
 msgid "Expensive to produce"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessagesall.json: $.RES_SY_STW1.text[1]
 #. data/mp/messages/resmessagesall.json: $.RES_SY_STW1.text[1]
-#: po/custom/fromJson.txt:1901
+#: po/custom/fromJson.txt:1912
 msgid "Extended sensor range"
 msgstr ""
 
@@ -8178,20 +8189,20 @@ msgstr ""
 #. data/base/messages/resmessages23.json: $.RES_SY_CBSU2.text[2]
 #. data/base/messages/resmessages3.json: $.RES_SY_CBSU3.text[2]
 #. ... + 3 refs
-#: po/custom/fromJson.txt:1907
+#: po/custom/fromJson.txt:1918
 msgid "Extends CB Range"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessagesall.json: $.RES_SY_SU1.text[2]
-#: po/custom/fromJson.txt:1910
+#: po/custom/fromJson.txt:1921
 msgid "Extends Sensor Range"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages1.json: $.RES_ST_FM1.text[1]
 #. data/mp/messages/resmessages1.json: $.RES_ST_FM1.text[1]
-#: po/custom/fromJson.txt:1926
+#: po/custom/fromJson.txt:1937
 msgid "Factory module enables medium and large bodies"
 msgstr ""
 
@@ -8200,71 +8211,73 @@ msgstr ""
 #. data/base/stats/structure.json: $.A0FacMod1.name
 #. data/mp/stats/research.json: $.R-Struc-Factory-Module.name
 #. data/mp/stats/structure.json: $.A0FacMod1.name
-#: po/custom/fromJson.txt:1932
+#: po/custom/fromJson.txt:1943
 msgid "Factory Module"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/messages/resmessages1.json: $.RES_ST_FM1.text[2]
-#: po/custom/fromJson.txt:1935
-#, c-format
+#: po/custom/fromJson.txt:1947
+#, no-c-format
 msgid "Factory output speed +100%% per module"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/messages/resmessages1.json: $.RES_ST_FU1.text[2]
 #. data/mp/messages/resmessagesall.json: $.RES_ST_FU7.text[2]
-#: po/custom/fromJson.txt:1939
+#: po/custom/fromJson.txt:1952
+#, no-c-format
 msgid "Factory output speed +60%"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/messages/resmessages2.json: $.RES_ST_FU4.text[2]
-#: po/custom/fromJson.txt:1942
+#: po/custom/fromJson.txt:1956
+#, no-c-format
 msgid "Factory production rate +60%"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/structure.json: $.A0LightFactory.name
 #. data/mp/stats/structure.json: $.A0LightFactory.name
-#: po/custom/fromJson.txt:1946
+#: po/custom/fromJson.txt:1960
 msgid "Factory"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/messages/resmessagesall.json: $.RES_SY_RDST1.text[3]
-#: po/custom/fromJson.txt:1949
+#: po/custom/fromJson.txt:1963
 msgid "Farther range compared to other sensors"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Wpn-Rocket-ROF02.name
-#: po/custom/fromJson.txt:1952
+#: po/custom/fromJson.txt:1966
 msgid "Fast Fire Mini-Rockets Mk2"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Wpn-Rocket-ROF03.name
-#: po/custom/fromJson.txt:1955
+#: po/custom/fromJson.txt:1969
 msgid "Fast Fire Mini-Rockets Mk3"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Wpn-Rocket-ROF01.name
-#: po/custom/fromJson.txt:1958
+#: po/custom/fromJson.txt:1972
 msgid "Fast Fire Mini-Rockets"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages1.json: $.RES_W_RK_MP1.text[1]
 #. data/mp/messages/resmessages1.json: $.RES_W_RK_MP1.text[1]
-#: po/custom/fromJson.txt:1962
+#: po/custom/fromJson.txt:1976
 msgid "Fast firing light anti-vehicle rockets"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Wpn-Howitzer-ROF04.name
-#: po/custom/fromJson.txt:1965
+#: po/custom/fromJson.txt:1979
 msgid "Fast Loader"
 msgstr ""
 
@@ -8273,7 +8286,7 @@ msgstr ""
 #. data/base/messages/resmessages3.json: $.RES_V_B07.text[2]
 #. data/mp/messages/resmessages1.json: $.RES_V_B08.text[2]
 #. data/mp/messages/resmessages3.json: $.RES_V_B07.text[2]
-#: po/custom/fromJson.txt:1971
+#: po/custom/fromJson.txt:1985
 msgid "Faster than Cobra"
 msgstr ""
 
@@ -8282,7 +8295,7 @@ msgstr ""
 #. data/base/messages/resmessages3.json: $.RES_V_B10.text[2]
 #. data/mp/messages/resmessages1.json: $.RES_V_B12.text[2]
 #. data/mp/messages/resmessages3.json: $.RES_V_B10.text[2]
-#: po/custom/fromJson.txt:1977
+#: po/custom/fromJson.txt:1991
 msgid "Faster than Python"
 msgstr ""
 
@@ -8291,75 +8304,75 @@ msgstr ""
 #. data/base/messages/resmessages3.json: $.RES_V_B03.text[2]
 #. data/mp/messages/resmessages1.json: $.RES_V_B04.text[2]
 #. data/mp/messages/resmessages3.json: $.RES_V_B03.text[2]
-#: po/custom/fromJson.txt:1983
+#: po/custom/fromJson.txt:1997
 msgid "Faster than Viper"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages1.json: $.RES_W_RK_AC1.text[1]
 #. data/mp/messages/resmessages1.json: $.RES_W_RK_AC1.text[1]
-#: po/custom/fromJson.txt:1987
+#: po/custom/fromJson.txt:2001
 msgid "Fin-stabilization improves flight trajectory"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/templates.json: $.BabaFireTruck.name
 #. data/mp/stats/templates.json: $.BabaFireTruck.name
-#: po/custom/fromJson.txt:1991
+#: po/custom/fromJson.txt:2005
 msgid "Fire Truck"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/messages/resmessagesall.json: $.RES_W_BMB6.text[1]
-#: po/custom/fromJson.txt:1994
+#: po/custom/fromJson.txt:2008
 msgid "Fires Electronic Magnetic Pulse Missiles"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/messages/resmessagesall.json: $.RES_W_HLAS.text[1]
-#: po/custom/fromJson.txt:1997
+#: po/custom/fromJson.txt:2011
 msgid "Fires heavy pulses of laser light"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages3.json: $.RES_W_LAS2.text[1]
 #. data/mp/messages/resmessages3.json: $.RES_W_LAS2.text[1]
-#: po/custom/fromJson.txt:2001
+#: po/custom/fromJson.txt:2015
 msgid "Fires pulses of laser light"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages12.json: $.RES_W_RK_MRL1.text[1]
 #. data/mp/messages/resmessages12.json: $.RES_W_RK_MRL1.text[1]
-#: po/custom/fromJson.txt:2005
+#: po/custom/fromJson.txt:2019
 msgid "Fires salvoes of mini-rockets"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages1.json: $.RES_FLAME1.text[1]
 #. data/mp/messages/resmessages1.json: $.RES_FLAME1.text[1]
-#: po/custom/fromJson.txt:2009
+#: po/custom/fromJson.txt:2023
 msgid "Flame-thrower firing Propylene Oxide gel"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Wpn-Flamer-ROF02.name
 #. data/mp/stats/research.json: $.R-Wpn-Flamer-ROF02.name
-#: po/custom/fromJson.txt:2013
+#: po/custom/fromJson.txt:2027
 msgid "Flamer Autoloader Mk2"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Wpn-Flamer-ROF03.name
 #. data/mp/stats/research.json: $.R-Wpn-Flamer-ROF03.name
-#: po/custom/fromJson.txt:2017
+#: po/custom/fromJson.txt:2031
 msgid "Flamer Autoloader Mk3"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Wpn-Flamer-ROF01.name
 #. data/mp/stats/research.json: $.R-Wpn-Flamer-ROF01.name
-#: po/custom/fromJson.txt:2021
+#: po/custom/fromJson.txt:2035
 msgid "Flamer Autoloader"
 msgstr ""
 
@@ -8368,7 +8381,7 @@ msgstr ""
 #. data/base/stats/structure.json: $.PillBox5.name
 #. data/mp/stats/research.json: $.R-Defense-Pillbox05.name
 #. data/mp/stats/structure.json: $.PillBox5.name
-#: po/custom/fromJson.txt:2027
+#: po/custom/fromJson.txt:2041
 msgid "Flamer Bunker"
 msgstr ""
 
@@ -8376,7 +8389,7 @@ msgstr ""
 #. data/base/stats/templates.json: $.CobraFlameTracks.name
 #. data/mp/stats/templates.json: $.CobraFlameTracks.name
 #. data/mp/stats/templates.json: $.P0CobraFlameTracks.name
-#: po/custom/fromJson.txt:2032
+#: po/custom/fromJson.txt:2046
 msgid "Flamer Cobra Tracks"
 msgstr ""
 
@@ -8384,26 +8397,28 @@ msgstr ""
 #. data/mp/messages/resmessages1.json: $.RES_W_FL_D1.text[2]
 #. data/mp/messages/resmessages2.json: $.RES_W_FL_D4.text[2]
 #. data/mp/messages/resmessagesall.json: $.RES_W_FL_D7.text[2]
-#: po/custom/fromJson.txt:2040
+#: po/custom/fromJson.txt:2055
+#, no-c-format
 msgid "Flamer damage +25%"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/messages/resmessages12.json: $.RES_W_FL_ROF1.text[2]
-#: po/custom/fromJson.txt:2051
+#: po/custom/fromJson.txt:2067
+#, no-c-format
 msgid "Flamer reload time -15%"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/templates.json: $.ViperFlameHalfTracks.name
-#: po/custom/fromJson.txt:2060
+#: po/custom/fromJson.txt:2076
 msgid "Flamer Viper Half-Tracks"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/templates.json: $.ViperFlameWheels.name
 #. data/mp/stats/templates.json: $.ViperFlameWheels.name
-#: po/custom/fromJson.txt:2064
+#: po/custom/fromJson.txt:2080
 msgid "Flamer Viper Wheels"
 msgstr ""
 
@@ -8412,13 +8427,13 @@ msgstr ""
 #. data/base/stats/weapons.json: $.Flame1Mk1.name
 #. data/mp/stats/research.json: $.R-Wpn-Flamer01Mk1.name
 #. ... + 2 refs
-#: po/custom/fromJson.txt:2070
+#: po/custom/fromJson.txt:2086
 msgid "Flamer"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Cyborg-Wpn-Laser1.name
-#: po/custom/fromJson.txt:2079
+#: po/custom/fromJson.txt:2095
 msgid "Flashlight Gunner Cyborg"
 msgstr ""
 
@@ -8426,41 +8441,41 @@ msgstr ""
 #. data/base/stats/templates.json: $.Cyb-Laser1-GROUND.name
 #. data/mp/stats/templates.json: $.Cyb-Laser1-GROUND.name
 #. data/mp/stats/templates.json: $.MP-Cyb-Laser1-GRD.name
-#: po/custom/fromJson.txt:2084
+#: po/custom/fromJson.txt:2100
 msgid "Flashlight Gunner"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Defense-WallTower-PulseLas.name
 #. data/base/stats/structure.json: $.WallTower-PulseLas.name
-#: po/custom/fromJson.txt:2088
+#: po/custom/fromJson.txt:2104
 msgid "Flashlight Hardpoint"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/templates.json: $.RetreHoverFlashLight.name
-#: po/custom/fromJson.txt:2091
+#: po/custom/fromJson.txt:2107
 msgid "Flashlight Retribution Hover"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/weapons.json: $.Laser3BEAMMk1.name
 #. data/mp/stats/weapons.json: $.Laser3BEAMMk1.name
-#: po/custom/fromJson.txt:2095
+#: po/custom/fromJson.txt:2111
 msgid "Flashlight"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Vehicle-Engine02.name
 #. data/mp/stats/research.json: $.R-Vehicle-Engine02.name
-#: po/custom/fromJson.txt:2099
+#: po/custom/fromJson.txt:2115
 msgid "Fuel Injection Engine Mk2"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Vehicle-Engine03.name
 #. data/mp/stats/research.json: $.R-Vehicle-Engine03.name
-#: po/custom/fromJson.txt:2103
+#: po/custom/fromJson.txt:2119
 msgid "Fuel Injection Engine Mk3"
 msgstr ""
 
@@ -8469,40 +8484,40 @@ msgstr ""
 #. data/base/stats/research.json: $.R-Vehicle-Engine01.name
 #. data/mp/messages/resmessages1.json: $.RES_V_EN1.text[1]
 #. data/mp/stats/research.json: $.R-Vehicle-Engine01.name
-#: po/custom/fromJson.txt:2109
+#: po/custom/fromJson.txt:2125
 msgid "Fuel Injection Engine"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/campaigns/gamma.json: $.name
-#: po/custom/fromJson.txt:2112
+#: po/custom/fromJson.txt:2128
 msgid "Gamma Campaign"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/challenges/two-faced.json: $.player_3.name
-#: po/custom/fromJson.txt:2115
+#: po/custom/fromJson.txt:2131
 msgid "Gamma"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages23.json: $.RES_POWU1.text[2]
 #. data/mp/messages/resmessages23.json: $.RES_POWU1.text[1]
-#: po/custom/fromJson.txt:2119
+#: po/custom/fromJson.txt:2135
 msgid "Gas turbine boosts power output"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Vehicle-Engine08.name
 #. data/mp/stats/research.json: $.R-Vehicle-Engine08.name
-#: po/custom/fromJson.txt:2123
+#: po/custom/fromJson.txt:2139
 msgid "Gas Turbine Engine Mk2"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Vehicle-Engine09.name
 #. data/mp/stats/research.json: $.R-Vehicle-Engine09.name
-#: po/custom/fromJson.txt:2127
+#: po/custom/fromJson.txt:2143
 msgid "Gas Turbine Engine Mk3"
 msgstr ""
 
@@ -8511,26 +8526,26 @@ msgstr ""
 #. data/base/stats/research.json: $.R-Vehicle-Engine07.name
 #. data/mp/messages/resmessages3.json: $.RES_V_EN7.text[1]
 #. data/mp/stats/research.json: $.R-Vehicle-Engine07.name
-#: po/custom/fromJson.txt:2133
+#: po/custom/fromJson.txt:2149
 msgid "Gas Turbine Engine"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/research.json: $.R-Struc-Power-Upgrade01b.name
-#: po/custom/fromJson.txt:2136
+#: po/custom/fromJson.txt:2152
 msgid "Gas Turbine Generator Mk2"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/research.json: $.R-Struc-Power-Upgrade01c.name
-#: po/custom/fromJson.txt:2139
+#: po/custom/fromJson.txt:2155
 msgid "Gas Turbine Generator Mk3"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Struc-Power-Upgrade01.name
 #. data/mp/stats/research.json: $.R-Struc-Power-Upgrade01.name
-#: po/custom/fromJson.txt:2143
+#: po/custom/fromJson.txt:2159
 msgid "Gas Turbine Generator"
 msgstr ""
 
@@ -8539,7 +8554,7 @@ msgstr ""
 #. data/base/stats/structure.json: $.Emplacement-Rail3.name
 #. data/mp/stats/research.json: $.R-Defense-Rail3.name
 #. data/mp/stats/structure.json: $.Emplacement-Rail3.name
-#: po/custom/fromJson.txt:2149
+#: po/custom/fromJson.txt:2165
 msgid "Gauss Cannon Emplacement"
 msgstr ""
 
@@ -8548,19 +8563,19 @@ msgstr ""
 #. data/base/stats/structure.json: $.WallTower-Rail3.name
 #. data/mp/stats/research.json: $.R-Defense-WallTower-Rail3.name
 #. data/mp/stats/structure.json: $.WallTower-Rail3.name
-#: po/custom/fromJson.txt:2155
+#: po/custom/fromJson.txt:2171
 msgid "Gauss Cannon Hardpoint"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/templates.json: $.PythonGaussTracks.name
-#: po/custom/fromJson.txt:2158
+#: po/custom/fromJson.txt:2174
 msgid "Gauss Cannon Python Tracks"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/templates.json: $.WyvernGaussTracks.name
-#: po/custom/fromJson.txt:2161
+#: po/custom/fromJson.txt:2177
 msgid "Gauss Cannon Wyvern Tracks"
 msgstr ""
 
@@ -8569,14 +8584,14 @@ msgstr ""
 #. data/base/stats/weapons.json: $.RailGun3Mk1.name
 #. data/mp/stats/research.json: $.R-Wpn-RailGun03.name
 #. data/mp/stats/weapons.json: $.RailGun3Mk1.name
-#: po/custom/fromJson.txt:2167
+#: po/custom/fromJson.txt:2183
 msgid "Gauss Cannon"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages3.json: $.RES_W_LAS1.text[1]
 #. data/mp/messages/resmessages3.json: $.RES_W_LAS1.text[1]
-#: po/custom/fromJson.txt:2171
+#: po/custom/fromJson.txt:2187
 msgid "Generates and concentrates bursts of laser energy"
 msgstr ""
 
@@ -8585,8 +8600,8 @@ msgstr ""
 #. data/mp/multiplay/skirmish/nb_generic.json: $.AI.insane_tip
 #. data/mp/multiplay/skirmish/nb_hover.json: $.AI.insane_tip
 #. ... + 3 refs
-#: po/custom/fromJson.txt:2177
-#, c-format
+#: po/custom/fromJson.txt:2194
+#, no-c-format
 msgid ""
 "Gets ~ 100% more power from each oil derrick\n"
 "Starts with defensive structures and oil derricks"
@@ -8594,8 +8609,8 @@ msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/multiplay/skirmish/Cobra.json: $.AI.insane_tip
-#: po/custom/fromJson.txt:2180
-#, c-format
+#: po/custom/fromJson.txt:2198
+#, no-c-format
 msgid ""
 "Gets ~ 100% more power from each oil derrick\n"
 "Uses the Heavy Plasma Launcher and EMP Mortar\n"
@@ -8607,15 +8622,15 @@ msgstr ""
 #. data/mp/multiplay/skirmish/nb_hover.json: $.AI.easy_tip
 #. data/mp/multiplay/skirmish/nexus.json: $.AI.easy_tip
 #. data/mp/multiplay/skirmish/semperfi.json: $.AI.easy_tip
-#: po/custom/fromJson.txt:2186
-#, c-format
+#: po/custom/fromJson.txt:2205
+#, no-c-format
 msgid "Gets ~ 25% less power from each oil derrick"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/multiplay/skirmish/Cobra.json: $.AI.easy_tip
-#: po/custom/fromJson.txt:2189
-#, c-format
+#: po/custom/fromJson.txt:2209
+#, no-c-format
 msgid ""
 "Gets ~ 25% less power from each oil derrick\n"
 "Basic decision making is slower"
@@ -8624,8 +8639,8 @@ msgstr ""
 #. TRANSLATORS:
 #. data/mp/multiplay/skirmish/nb_generic.json: $.AI.easy_tip
 #. data/mp/multiplay/skirmish/nb_turtle.json: $.AI.easy_tip
-#: po/custom/fromJson.txt:2193
-#, c-format
+#: po/custom/fromJson.txt:2214
+#, no-c-format
 msgid ""
 "Gets ~ 25% less power from each oil derrick\n"
 "Research is not focused on a specific weapon branch"
@@ -8634,144 +8649,144 @@ msgstr ""
 #. TRANSLATORS:
 #. data/base/messages/resmessages3.json: $.RES_CY_JP1.text[2]
 #. data/mp/messages/resmessages3.json: $.RES_CY_JP1.text[2]
-#: po/custom/fromJson.txt:2197
+#: po/custom/fromJson.txt:2218
 msgid "Gives Cyborg limited flight abilities"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages1.json: $.RES_V_B11.text[2]
 #. data/mp/messages/resmessages1.json: $.RES_V_B11.text[2]
-#: po/custom/fromJson.txt:2201
+#: po/custom/fromJson.txt:2222
 msgid "Good main battle tank and heavy artillery platform"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages1.json: $.RES_V_B05.text[2]
 #. data/mp/messages/resmessages1.json: $.RES_V_B05.text[2]
-#: po/custom/fromJson.txt:2205
+#: po/custom/fromJson.txt:2226
 msgid "Good medium tank and support vehicle"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages1.json: $.RES_V_B01.text[2]
 #. data/mp/messages/resmessages1.json: $.RES_V_B01.text[2]
-#: po/custom/fromJson.txt:2209
+#: po/custom/fromJson.txt:2230
 msgid "Good scout vehicle"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/templates.json: $.Cyb-Gren.name
-#: po/custom/fromJson.txt:2212
+#: po/custom/fromJson.txt:2233
 msgid "Grenadier"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/weapons.json: $.Howitzer150Mk1.name
 #. data/mp/stats/weapons.json: $.Howitzer150Mk1.name
-#: po/custom/fromJson.txt:2222
+#: po/custom/fromJson.txt:2243
 msgid "Ground Shaker"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Vehicle-Prop-Halftracks.name
 #. data/mp/stats/research.json: $.R-Vehicle-Prop-Halftracks.name
-#: po/custom/fromJson.txt:2229
+#: po/custom/fromJson.txt:2250
 msgid "Half-tracked Propulsion"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/propulsion.json: $.HalfTrack02.name
-#: po/custom/fromJson.txt:2232
+#: po/custom/fromJson.txt:2253
 msgid "Half-tracks II"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/propulsion.json: $.HalfTrack03.name
-#: po/custom/fromJson.txt:2235
+#: po/custom/fromJson.txt:2256
 msgid "Half-tracks III"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/propulsion.json: $.HalfTrack.name
 #. data/mp/stats/propulsion.json: $.HalfTrack.name
-#: po/custom/fromJson.txt:2239
+#: po/custom/fromJson.txt:2260
 msgid "Half-tracks"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/structure.json: $.A0HardcreteMk1CWall.name
 #. data/mp/stats/structure.json: $.A0HardcreteMk1CWall.name
-#: po/custom/fromJson.txt:2243
+#: po/custom/fromJson.txt:2264
 msgid "Hardcrete Corner Wall"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/research.json: $.R-Defense-HardcreteGate.name
 #. data/mp/stats/structure.json: $.A0HardcreteMk1Gate.name
-#: po/custom/fromJson.txt:2247
+#: po/custom/fromJson.txt:2268
 msgid "Hardcrete Gate"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/structure.json: $.A0HardcreteMk1Wall.name
 #. data/mp/stats/structure.json: $.A0HardcreteMk1Wall.name
-#: po/custom/fromJson.txt:2251
+#: po/custom/fromJson.txt:2272
 msgid "Hardcrete Wall"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Defense-HardcreteWall.name
 #. data/mp/stats/research.json: $.R-Defense-HardcreteWall.name
-#: po/custom/fromJson.txt:2255
+#: po/custom/fromJson.txt:2276
 msgid "Hardcrete"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Struc-Materials05.name
 #. data/mp/stats/research.json: $.R-Struc-Materials05.name
-#: po/custom/fromJson.txt:2259
+#: po/custom/fromJson.txt:2280
 msgid "Hardened Base Structure Materials Mk2"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Struc-Materials06.name
 #. data/mp/stats/research.json: $.R-Struc-Materials06.name
-#: po/custom/fromJson.txt:2263
+#: po/custom/fromJson.txt:2284
 msgid "Hardened Base Structure Materials Mk3"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages1.json: $.RES_W_MG_D1.text[1]
 #. data/mp/messages/resmessages1.json: $.RES_W_MG_D1.text[1]
-#: po/custom/fromJson.txt:2273
+#: po/custom/fromJson.txt:2294
 msgid "Hardened case machinegun bullets"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Wpn-MG-Damage01.name
 #. data/mp/stats/research.json: $.R-Wpn-MG-Damage01.name
-#: po/custom/fromJson.txt:2277
+#: po/custom/fromJson.txt:2298
 msgid "Hardened MG Bullets"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Wpn-Rail-Damage02.name
 #. data/mp/stats/research.json: $.R-Wpn-Rail-Damage02.name
-#: po/custom/fromJson.txt:2281
+#: po/custom/fromJson.txt:2302
 msgid "Hardened Rail Dart Mk2"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Wpn-Rail-Damage03.name
 #. data/mp/stats/research.json: $.R-Wpn-Rail-Damage03.name
-#: po/custom/fromJson.txt:2285
+#: po/custom/fromJson.txt:2306
 msgid "Hardened Rail Dart Mk3"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Wpn-Rail-Damage01.name
 #. data/mp/stats/research.json: $.R-Wpn-Rail-Damage01.name
-#: po/custom/fromJson.txt:2289
+#: po/custom/fromJson.txt:2310
 msgid "Hardened Rail Dart"
 msgstr ""
 
@@ -8780,310 +8795,310 @@ msgstr ""
 #. data/base/stats/sensor.json: $.SensorTower2Mk1.name
 #. data/base/stats/structure.json: $.Sys-SensoTower02.name
 #. ... + 3 refs
-#: po/custom/fromJson.txt:2295
+#: po/custom/fromJson.txt:2316
 msgid "Hardened Sensor Tower"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/messages/resmessagesall.json: $.RES_MS_SAM1WT.text[0]
-#: po/custom/fromJson.txt:2298
+#: po/custom/fromJson.txt:2319
 msgid "Hardpoint Avenger SAM Site Available"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/messages/resmessagesall.json: $.RES_WT_DOUBLEAA.text[0]
-#: po/custom/fromJson.txt:2301
+#: po/custom/fromJson.txt:2322
 msgid "Hardpoint Cyclone AA Gun Available"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/messages/resmessagesall.json: $.RES_WT_TWINAGHP.text[0]
-#: po/custom/fromJson.txt:2304
+#: po/custom/fromJson.txt:2325
 msgid "Hardpoint Twin Assault Gun Available"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/messages/resmessagesall.json: $.RES_MS_SAM2WT.text[0]
-#: po/custom/fromJson.txt:2307
+#: po/custom/fromJson.txt:2328
 msgid "Hardpoint Vindicator SAM Site Available"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/messages/resmessagesall.json: $.RES_WT_QUADAA.text[0]
-#: po/custom/fromJson.txt:2310
+#: po/custom/fromJson.txt:2331
 msgid "Hardpoint Whirlwind AA Gun Available"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/research.json: $.R-Wpn-Bomb-Accuracy01.name
-#: po/custom/fromJson.txt:2313
+#: po/custom/fromJson.txt:2334
 msgid "HE Bomb Shells"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Wpn-Howitzer-Damage02.name
 #. data/mp/stats/research.json: $.R-Wpn-Howitzer-Damage02.name
-#: po/custom/fromJson.txt:2317
+#: po/custom/fromJson.txt:2338
 msgid "HE Howitzer Shells Mk2"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Wpn-Howitzer-Damage03.name
 #. data/mp/stats/research.json: $.R-Wpn-Howitzer-Damage03.name
-#: po/custom/fromJson.txt:2321
+#: po/custom/fromJson.txt:2342
 msgid "HE Howitzer Shells Mk3"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Wpn-Howitzer-Damage01.name
 #. data/mp/stats/research.json: $.R-Wpn-Howitzer-Damage01.name
-#: po/custom/fromJson.txt:2325
+#: po/custom/fromJson.txt:2346
 msgid "HE Howitzer Shells"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Wpn-Rocket-Damage02.name
-#: po/custom/fromJson.txt:2328
+#: po/custom/fromJson.txt:2349
 msgid "HE Mini-Rockets Mk2"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Wpn-Rocket-Damage03.name
-#: po/custom/fromJson.txt:2331
+#: po/custom/fromJson.txt:2352
 msgid "HE Mini-Rockets Mk3"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Wpn-Rocket-Damage01.name
-#: po/custom/fromJson.txt:2334
+#: po/custom/fromJson.txt:2355
 msgid "HE Mini-Rockets"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Wpn-Mortar-Damage02.name
 #. data/mp/stats/research.json: $.R-Wpn-Mortar-Damage02.name
-#: po/custom/fromJson.txt:2338
+#: po/custom/fromJson.txt:2359
 msgid "HE Mortar Shells Mk2"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Wpn-Mortar-Damage03.name
 #. data/mp/stats/research.json: $.R-Wpn-Mortar-Damage03.name
-#: po/custom/fromJson.txt:2342
+#: po/custom/fromJson.txt:2363
 msgid "HE Mortar Shells Mk3"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Wpn-Mortar-Damage01.name
 #. data/mp/stats/research.json: $.R-Wpn-Mortar-Damage01.name
-#: po/custom/fromJson.txt:2346
+#: po/custom/fromJson.txt:2367
 msgid "HE Mortar Shells"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/research.json: $.R-Wpn-Rocket-Damage02.name
-#: po/custom/fromJson.txt:2349
+#: po/custom/fromJson.txt:2370
 msgid "HE Rockets Mk2"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/research.json: $.R-Wpn-Rocket-Damage03.name
-#: po/custom/fromJson.txt:2352
+#: po/custom/fromJson.txt:2373
 msgid "HE Rockets Mk3"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/research.json: $.R-Wpn-Rocket-Damage01.name
-#: po/custom/fromJson.txt:2355
+#: po/custom/fromJson.txt:2376
 msgid "HE Rockets"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/templates.json: $.SK-Mantis-VTOL-HBB.name
-#: po/custom/fromJson.txt:2358
+#: po/custom/fromJson.txt:2379
 msgid "Heap Bomb Bay Mantis VTOL"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/templates.json: $.SK-Retre-VTOL-HBB.name
-#: po/custom/fromJson.txt:2361
+#: po/custom/fromJson.txt:2382
 msgid "Heap Bomb Bay Retribution VTOL"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Wpn-Bomb02.name
 #. data/mp/stats/research.json: $.R-Wpn-Bomb02.name
-#: po/custom/fromJson.txt:2365
+#: po/custom/fromJson.txt:2386
 msgid "HEAP Bomb Bay"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Wpn-Howitzer-Damage05.name
 #. data/mp/stats/research.json: $.R-Wpn-Howitzer-Damage05.name
-#: po/custom/fromJson.txt:2369
+#: po/custom/fromJson.txt:2390
 msgid "HEAP Howitzer Shells Mk2"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Wpn-Howitzer-Damage06.name
 #. data/mp/stats/research.json: $.R-Wpn-Howitzer-Damage06.name
-#: po/custom/fromJson.txt:2373
+#: po/custom/fromJson.txt:2394
 msgid "HEAP Howitzer Shells Mk3"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Wpn-Howitzer-Damage04.name
 #. data/mp/stats/research.json: $.R-Wpn-Howitzer-Damage04.name
-#: po/custom/fromJson.txt:2377
+#: po/custom/fromJson.txt:2398
 msgid "HEAP Howitzer Shells"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Wpn-Rocket-Damage05.name
-#: po/custom/fromJson.txt:2380
+#: po/custom/fromJson.txt:2401
 msgid "HEAP Mini-Rockets Mk2"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Wpn-Rocket-Damage06.name
-#: po/custom/fromJson.txt:2383
+#: po/custom/fromJson.txt:2404
 msgid "HEAP Mini-Rockets Mk3"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Wpn-Rocket-Damage04.name
-#: po/custom/fromJson.txt:2386
+#: po/custom/fromJson.txt:2407
 msgid "HEAP Mini-Rockets"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Wpn-Mortar-Damage05.name
 #. data/mp/stats/research.json: $.R-Wpn-Mortar-Damage05.name
-#: po/custom/fromJson.txt:2390
+#: po/custom/fromJson.txt:2411
 msgid "HEAP Mortar Shells Mk2"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Wpn-Mortar-Damage06.name
 #. data/mp/stats/research.json: $.R-Wpn-Mortar-Damage06.name
-#: po/custom/fromJson.txt:2394
+#: po/custom/fromJson.txt:2415
 msgid "HEAP Mortar Shells Mk3"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Wpn-Mortar-Damage04.name
 #. data/mp/stats/research.json: $.R-Wpn-Mortar-Damage04.name
-#: po/custom/fromJson.txt:2398
+#: po/custom/fromJson.txt:2419
 msgid "HEAP Mortar Shells"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Wpn-Cannon-Damage02.name
 #. data/mp/stats/research.json: $.R-Wpn-Cannon-Damage02.name
-#: po/custom/fromJson.txt:2402
+#: po/custom/fromJson.txt:2423
 msgid "HEAT Cannon Shells Mk2"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Wpn-Cannon-Damage03.name
 #. data/mp/stats/research.json: $.R-Wpn-Cannon-Damage03.name
-#: po/custom/fromJson.txt:2406
+#: po/custom/fromJson.txt:2427
 msgid "HEAT Cannon Shells Mk3"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Wpn-Cannon-Damage01.name
 #. data/mp/stats/research.json: $.R-Wpn-Cannon-Damage01.name
-#: po/custom/fromJson.txt:2410
+#: po/custom/fromJson.txt:2431
 msgid "HEAT Cannon Shells"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Wpn-RocketSlow-Damage02.name
 #. data/mp/stats/research.json: $.R-Wpn-Rocket-Damage05.name
-#: po/custom/fromJson.txt:2420
+#: po/custom/fromJson.txt:2441
 msgid "HEAT Rocket Warhead Mk2"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Wpn-RocketSlow-Damage03.name
 #. data/mp/stats/research.json: $.R-Wpn-Rocket-Damage06.name
-#: po/custom/fromJson.txt:2424
+#: po/custom/fromJson.txt:2445
 msgid "HEAT Rocket Warhead Mk3"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Wpn-RocketSlow-Damage01.name
 #. data/mp/stats/research.json: $.R-Wpn-Rocket-Damage04.name
-#: po/custom/fromJson.txt:2428
+#: po/custom/fromJson.txt:2449
 msgid "HEAT Rocket Warhead"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages12.json: $.RES_W_RK_HvAT.text[1]
 #. data/mp/messages/resmessages12.json: $.RES_W_RK_HvAT.text[1]
-#: po/custom/fromJson.txt:2438
+#: po/custom/fromJson.txt:2459
 msgid "Heavy anti-tank rocket"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Vehicle-Body12.name
 #. data/mp/stats/research.json: $.R-Vehicle-Body12.name
-#: po/custom/fromJson.txt:2442
+#: po/custom/fromJson.txt:2463
 msgid "Heavy Body - Mantis"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Vehicle-Body11.name
 #. data/mp/stats/research.json: $.R-Vehicle-Body11.name
-#: po/custom/fromJson.txt:2446
+#: po/custom/fromJson.txt:2467
 msgid "Heavy Body - Python"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Vehicle-Body09.name
 #. data/mp/stats/research.json: $.R-Vehicle-Body09.name
-#: po/custom/fromJson.txt:2450
+#: po/custom/fromJson.txt:2471
 msgid "Heavy Body - Tiger"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Vehicle-Body10.name
 #. data/mp/stats/research.json: $.R-Vehicle-Body10.name
-#: po/custom/fromJson.txt:2454
+#: po/custom/fromJson.txt:2475
 msgid "Heavy Body - Vengeance"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/research.json: $.R-Vehicle-Body13.name
-#: po/custom/fromJson.txt:2457
+#: po/custom/fromJson.txt:2478
 msgid "Heavy Body - Wyvern"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages1.json: $.RES_V_B11.text[1]
 #. data/mp/messages/resmessages1.json: $.RES_V_B11.text[1]
-#: po/custom/fromJson.txt:2461
+#: po/custom/fromJson.txt:2482
 msgid "Heavy body increases armor and body points"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/templates.json: $.Cobra-Hover-HC.name
-#: po/custom/fromJson.txt:2464
+#: po/custom/fromJson.txt:2485
 msgid "Heavy Cannon Cobra Hover"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/templates.json: $.CobraHvyCnTrks.name
 #. data/mp/stats/templates.json: $.CobraHvyCnTrks.name
-#: po/custom/fromJson.txt:2468
+#: po/custom/fromJson.txt:2489
 msgid "Heavy Cannon Cobra Tracks"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages1.json: $.RES_CN3MK1.text[1]
 #. data/mp/messages/resmessages1.json: $.RES_CN3MK1.text[1]
-#: po/custom/fromJson.txt:2472
+#: po/custom/fromJson.txt:2493
 msgid "Heavy Cannon firing 120 mm rounds"
 msgstr ""
 
@@ -9092,19 +9107,19 @@ msgstr ""
 #. data/base/stats/structure.json: $.WallTower04.name
 #. data/mp/stats/research.json: $.R-Defense-WallTower04.name
 #. data/mp/stats/structure.json: $.WallTower04.name
-#: po/custom/fromJson.txt:2478
+#: po/custom/fromJson.txt:2499
 msgid "Heavy Cannon Hardpoint"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/templates.json: $.MantisTrkHC.name
-#: po/custom/fromJson.txt:2481
+#: po/custom/fromJson.txt:2502
 msgid "Heavy Cannon Mantis Tracks"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/templates.json: $.A-Python-Hover-HC.name
-#: po/custom/fromJson.txt:2484
+#: po/custom/fromJson.txt:2505
 msgid "Heavy Cannon Python Hover"
 msgstr ""
 
@@ -9113,19 +9128,19 @@ msgstr ""
 #. data/mp/stats/templates.json: $.A-Python-Trk-HC.name
 #. data/mp/stats/templates.json: $.P0PythonHvyCnTrks.name
 #. ... + 2 refs
-#: po/custom/fromJson.txt:2490
+#: po/custom/fromJson.txt:2511
 msgid "Heavy Cannon Python Tracks"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/templates.json: $.H-Scorp-Trk-HC.name
-#: po/custom/fromJson.txt:2493
+#: po/custom/fromJson.txt:2514
 msgid "Heavy Cannon Scorpion Tracks"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/templates.json: $.A-Tiger-Trk-HC.name
-#: po/custom/fromJson.txt:2496
+#: po/custom/fromJson.txt:2517
 msgid "Heavy Cannon Tiger Tracks"
 msgstr ""
 
@@ -9134,14 +9149,14 @@ msgstr ""
 #. data/base/stats/weapons.json: $.Cannon375mmMk1.name
 #. data/mp/stats/research.json: $.R-Wpn-Cannon3Mk1.name
 #. data/mp/stats/weapons.json: $.Cannon375mmMk1.name
-#: po/custom/fromJson.txt:2502
+#: po/custom/fromJson.txt:2523
 msgid "Heavy Cannon"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Wpn-Flame2.name
 #. data/mp/stats/research.json: $.R-Wpn-Flame2.name
-#: po/custom/fromJson.txt:2510
+#: po/custom/fromJson.txt:2531
 msgid "Heavy Flamer - Inferno"
 msgstr ""
 
@@ -9150,40 +9165,40 @@ msgstr ""
 #. data/base/stats/templates.json: $.CyborgCannon01Grd.name
 #. data/base/stats/weapons.json: $.CyborgCannon.name
 #. ... + 3 refs
-#: po/custom/fromJson.txt:2519
+#: po/custom/fromJson.txt:2540
 msgid "Heavy Gunner"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Wpn-HvyHowitzer.name
 #. data/mp/stats/research.json: $.R-Wpn-HvyHowitzer.name
-#: po/custom/fromJson.txt:2523
+#: po/custom/fromJson.txt:2544
 msgid "Heavy Howitzer - Ground Shaker"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/research.json: $.R-Defense-HeavyLas.name
 #. data/mp/stats/structure.json: $.Emplacement-HeavyLaser.name
-#: po/custom/fromJson.txt:2527
+#: po/custom/fromJson.txt:2548
 msgid "Heavy Laser Emplacement"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/templates.json: $.TigerHvLaserTracks.name
-#: po/custom/fromJson.txt:2530
+#: po/custom/fromJson.txt:2551
 msgid "Heavy Laser Tiger Tracks"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/templates.json: $.WyvernHvLaserTracks.name
-#: po/custom/fromJson.txt:2533
+#: po/custom/fromJson.txt:2554
 msgid "Heavy Laser Wyvern Tracks"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/research.json: $.R-Wpn-HvyLaser.name
 #. data/mp/stats/weapons.json: $.HeavyLaser.name
-#: po/custom/fromJson.txt:2537
+#: po/custom/fromJson.txt:2558
 msgid "Heavy Laser"
 msgstr ""
 
@@ -9192,26 +9207,26 @@ msgstr ""
 #. data/base/stats/templates.json: $.P0CobraHvyMGHtrack.name
 #. data/mp/stats/templates.json: $.CobraHMGHalfTrack.name
 #. data/mp/stats/templates.json: $.P0CobraHvyMGHtrack.name
-#: po/custom/fromJson.txt:2549
+#: po/custom/fromJson.txt:2570
 msgid "Heavy Machinegun Cobra Half-tracks"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/templates.json: $.A-Cobra-Hover-HMG.name
-#: po/custom/fromJson.txt:2552
+#: po/custom/fromJson.txt:2573
 msgid "Heavy Machinegun Cobra Hover"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/templates.json: $.A-Cobra-Trk-HMG.name
 #. data/mp/stats/templates.json: $.CobraHMGTracks.name
-#: po/custom/fromJson.txt:2556
+#: po/custom/fromJson.txt:2577
 msgid "Heavy Machinegun Cobra Tracks"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/templates.json: $.A-Cobra-Wheels-HMG.name
-#: po/custom/fromJson.txt:2559
+#: po/custom/fromJson.txt:2580
 msgid "Heavy Machinegun Cobra Wheels"
 msgstr ""
 
@@ -9220,26 +9235,26 @@ msgstr ""
 #. data/base/stats/structure.json: $.WallTower01.name
 #. data/mp/stats/research.json: $.R-Defense-WallTower01.name
 #. data/mp/stats/structure.json: $.WallTower01.name
-#: po/custom/fromJson.txt:2571
+#: po/custom/fromJson.txt:2592
 msgid "Heavy Machinegun Hardpoint"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/templates.json: $.ScorpHTrackHMG.name
-#: po/custom/fromJson.txt:2574
+#: po/custom/fromJson.txt:2595
 msgid "Heavy Machinegun Scorpion Half Tracks"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/templates.json: $.ScorpTrkHMG.name
-#: po/custom/fromJson.txt:2577
+#: po/custom/fromJson.txt:2598
 msgid "Heavy Machinegun Scorpion Tracks"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/templates.json: $.ViperHMGHalftrack.name
 #. data/mp/stats/templates.json: $.ViperHMGHalftrack.name
-#: po/custom/fromJson.txt:2585
+#: po/custom/fromJson.txt:2606
 msgid "Heavy Machinegun Viper Half-tracks"
 msgstr ""
 
@@ -9247,14 +9262,14 @@ msgstr ""
 #. data/base/stats/templates.json: $.ViperHMGTracks.name
 #. data/mp/stats/templates.json: $.A-Viper-Trk-HMG.name
 #. data/mp/stats/templates.json: $.ViperHMGTracks.name
-#: po/custom/fromJson.txt:2590
+#: po/custom/fromJson.txt:2611
 msgid "Heavy Machinegun Viper Tracks"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/templates.json: $.A-Viper-Wheels-HMG.name
 #. data/mp/stats/templates.json: $.ViperHMGWheels.name
-#: po/custom/fromJson.txt:2594
+#: po/custom/fromJson.txt:2615
 msgid "Heavy Machinegun Viper Wheels"
 msgstr ""
 
@@ -9263,33 +9278,33 @@ msgstr ""
 #. data/base/stats/weapons.json: $.MG3Mk1.name
 #. data/mp/stats/research.json: $.R-Wpn-MG3Mk1.name
 #. data/mp/stats/weapons.json: $.MG3Mk1.name
-#: po/custom/fromJson.txt:2600
+#: po/custom/fromJson.txt:2621
 msgid "Heavy Machinegun"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Wpn-Mortar02Hvy.name
 #. data/mp/stats/research.json: $.R-Wpn-Mortar02Hvy.name
-#: po/custom/fromJson.txt:2604
+#: po/custom/fromJson.txt:2625
 msgid "Heavy Mortar - Bombard"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages3.json: $.RES_W_RAIL3.text[1]
 #. data/mp/messages/resmessages3.json: $.RES_W_RAIL3.text[1]
-#: po/custom/fromJson.txt:2608
+#: po/custom/fromJson.txt:2629
 msgid "Heavy rail gun firing large kinetic energy darts"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/templates.json: $.ScorpHRepairHover.name
-#: po/custom/fromJson.txt:2611
+#: po/custom/fromJson.txt:2632
 msgid "Heavy Repair Scorpion Hover"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/templates.json: $.CobraHRepairHover.name
-#: po/custom/fromJson.txt:2614
+#: po/custom/fromJson.txt:2635
 msgid "Heavy Repair Turret Cobra Hover"
 msgstr ""
 
@@ -9297,7 +9312,7 @@ msgstr ""
 #. data/mp/stats/research.json: $.R-Defense-Super-Rocket.name
 #. data/mp/stats/structure.json: $.X-Super-Rocket.name
 #. data/mp/stats/weapons.json: $.RocketSuper.name
-#: po/custom/fromJson.txt:2626
+#: po/custom/fromJson.txt:2647
 msgid "Heavy Rocket Bastion"
 msgstr ""
 
@@ -9305,286 +9320,289 @@ msgstr ""
 #. data/base/messages/resmessages3.json: $.RES_W_MS_HvSAM1.text[1]
 #. data/mp/messages/resmessages3.json: $.RES_W_MS_HvSAM1.text[1]
 #. data/mp/messages/resmessagesall.json: $.RES_MS_SAM2WT.text[1]
-#: po/custom/fromJson.txt:2631
+#: po/custom/fromJson.txt:2652
 msgid "Heavy surface-to-air missile"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/features.json: $.Heavywepslab.name
-#: po/custom/fromJson.txt:2634
+#: po/custom/fromJson.txt:2655
 msgid "Heavyweaponslab"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/propulsion.json: $.Helicopter.name
-#: po/custom/fromJson.txt:2637
+#: po/custom/fromJson.txt:2658
 msgid "Helicopter"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/weapons.json: $.Howitzer03-Rot.name
 #. data/mp/stats/weapons.json: $.Howitzer03-Rot.name
-#: po/custom/fromJson.txt:2647
+#: po/custom/fromJson.txt:2668
 msgid "Hellstorm"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Wpn-RocketSlow-Damage05.name
 #. data/mp/stats/research.json: $.R-Wpn-Rocket-Damage08.name
-#: po/custom/fromJson.txt:2651
+#: po/custom/fromJson.txt:2672
 msgid "HESH Rocket Warhead Mk2"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Wpn-RocketSlow-Damage06.name
 #. data/mp/stats/research.json: $.R-Wpn-Rocket-Damage09.name
-#: po/custom/fromJson.txt:2655
+#: po/custom/fromJson.txt:2676
 msgid "HESH Rocket Warhead Mk3"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Wpn-RocketSlow-Damage04.name
 #. data/mp/stats/research.json: $.R-Wpn-Rocket-Damage07.name
-#: po/custom/fromJson.txt:2659
+#: po/custom/fromJson.txt:2680
 msgid "HESH Rocket Warhead"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Wpn-Energy-Damage02.name
 #. data/mp/stats/research.json: $.R-Wpn-Energy-Damage02.name
-#: po/custom/fromJson.txt:2663
+#: po/custom/fromJson.txt:2684
 msgid "Hi-Energy Laser Emitter Mk2"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Wpn-Energy-Damage03.name
 #. data/mp/stats/research.json: $.R-Wpn-Energy-Damage03.name
-#: po/custom/fromJson.txt:2667
+#: po/custom/fromJson.txt:2688
 msgid "Hi-Energy Laser Emitter Mk3"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Wpn-Energy-Damage01.name
 #. data/mp/stats/research.json: $.R-Wpn-Energy-Damage01.name
-#: po/custom/fromJson.txt:2671
+#: po/custom/fromJson.txt:2692
 msgid "Hi-Energy Laser Emitter"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/challenges/hidebehind.json: $.challenge.name
-#: po/custom/fromJson.txt:2674
+#: po/custom/fromJson.txt:2695
 msgid "Hide Behind Me"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages3.json: $.RES_ST_MAT10.text[1]
 #. data/mp/messages/resmessages3.json: $.RES_ST_MAT10.text[1]
-#: po/custom/fromJson.txt:2678
+#: po/custom/fromJson.txt:2699
 msgid "High Density Base Structure Materials"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages1.json: $.RES_W_CN_D1.text[1]
 #. data/mp/messages/resmessages1.json: $.RES_W_CN_D1.text[1]
-#: po/custom/fromJson.txt:2682
+#: po/custom/fromJson.txt:2703
 msgid "High Explosive Anti-Tank Cannon Shells"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages1.json: $.RES_W_SRK_D1.text[1]
 #. data/mp/messages/resmessages1.json: $.RES_W_SRK_D1.text[1]
-#: po/custom/fromJson.txt:2686
+#: po/custom/fromJson.txt:2707
 msgid "High Explosive Anti-Tank warhead"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/messages/resmessages2.json: $.RES_W_RK_D4.text[1]
-#: po/custom/fromJson.txt:2689
+#: po/custom/fromJson.txt:2710
 msgid "High Explosive Anti-Tank warheads"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages3.json: $.RES_W_AAD4.text[1]
 #. data/mp/messages/resmessages3.json: $.RES_W_AAD4.text[1]
-#: po/custom/fromJson.txt:2693
+#: po/custom/fromJson.txt:2714
 msgid "High Explosive Armor Piercing Flak"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages3.json: $.RES_W_HOWD4.text[1]
 #. data/mp/messages/resmessages3.json: $.RES_W_HOWD4.text[1]
-#: po/custom/fromJson.txt:2697
+#: po/custom/fromJson.txt:2718
 msgid "High Explosive Armor Piercing Shells"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages3.json: $.RES_W_MS_MART.text[1]
 #. data/mp/messages/resmessages3.json: $.RES_W_MS_MART.text[1]
-#: po/custom/fromJson.txt:2708
+#: po/custom/fromJson.txt:2729
 msgid "High explosive artillery missile"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages3.json: $.RES_W_MS_HART.text[1]
 #. data/mp/messages/resmessages3.json: $.RES_W_MS_HART.text[1]
-#: po/custom/fromJson.txt:2716
+#: po/custom/fromJson.txt:2737
 msgid "High explosive heavy artillery missile"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessagesall.json: $.RES_W_RK_HVAT1.text[1]
 #. data/mp/messages/resmessagesall.json: $.RES_W_RK_HVAT1.text[1]
-#: po/custom/fromJson.txt:2720
+#: po/custom/fromJson.txt:2741
 msgid "High explosive shaped charge missile"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Vehicle-Armor-Heat05.name
 #. data/mp/stats/research.json: $.R-Vehicle-Armor-Heat05.name
-#: po/custom/fromJson.txt:2733
+#: po/custom/fromJson.txt:2754
 msgid "High Intensity Thermal Armor Mk2"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Vehicle-Armor-Heat06.name
 #. data/mp/stats/research.json: $.R-Vehicle-Armor-Heat06.name
-#: po/custom/fromJson.txt:2737
+#: po/custom/fromJson.txt:2758
 msgid "High Intensity Thermal Armor Mk3"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Vehicle-Armor-Heat04.name
 #. data/mp/stats/research.json: $.R-Vehicle-Armor-Heat04.name
-#: po/custom/fromJson.txt:2741
+#: po/custom/fromJson.txt:2762
 msgid "High Intensity Thermal Armor"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessagesall.json: $.RES_V_B09.text[3]
 #. data/mp/messages/resmessagesall.json: $.RES_V_B09.text[3]
-#: po/custom/fromJson.txt:2745
+#: po/custom/fromJson.txt:2766
 msgid "High power costs and slow to produce"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Wpn-Flamer-Damage02.name
 #. data/mp/stats/research.json: $.R-Wpn-Flamer-Damage02.name
-#: po/custom/fromJson.txt:2757
+#: po/custom/fromJson.txt:2778
 msgid "High Temperature Flamer Gel Mk2"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Wpn-Flamer-Damage03.name
 #. data/mp/stats/research.json: $.R-Wpn-Flamer-Damage03.name
-#: po/custom/fromJson.txt:2761
+#: po/custom/fromJson.txt:2782
 msgid "High Temperature Flamer Gel Mk3"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Wpn-Flamer-Damage01.name
 #. data/mp/stats/research.json: $.R-Wpn-Flamer-Damage01.name
-#: po/custom/fromJson.txt:2765
+#: po/custom/fromJson.txt:2786
 msgid "High Temperature Flamer Gel"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages3.json: $.RES_DF_WU7.text[1]
 #. data/mp/messages/resmessages3.json: $.RES_DF_WU7.text[1]
-#: po/custom/fromJson.txt:2769
+#: po/custom/fromJson.txt:2790
 msgid "High tensile concrete-plastic composite"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages3.json: $.RES_W_CN_D7.text[1]
 #. data/mp/messages/resmessages3.json: $.RES_W_CN_D7.text[1]
-#: po/custom/fromJson.txt:2777
+#: po/custom/fromJson.txt:2798
 msgid "High-Velocity Armor-Piercing Fin-Stabilised Discarding Sabot"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/structure.json: $.PillBox3.name
 #. data/mp/stats/structure.json: $.PillBox3.name
-#: po/custom/fromJson.txt:2781
+#: po/custom/fromJson.txt:2802
 msgid "HMG Bunker"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/multiplay/skirmish/nb_hover.json: $.AI.name
-#: po/custom/fromJson.txt:2784
+#: po/custom/fromJson.txt:2805
 msgid "Hover AI"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/propulsion.json: $.hover02.name
-#: po/custom/fromJson.txt:2787
+#: po/custom/fromJson.txt:2808
 msgid "Hover II"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/propulsion.json: $.hover03.name
-#: po/custom/fromJson.txt:2790
+#: po/custom/fromJson.txt:2811
 msgid "Hover III"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Vehicle-Prop-Hover.name
 #. data/mp/stats/research.json: $.R-Vehicle-Prop-Hover.name
-#: po/custom/fromJson.txt:2797
+#: po/custom/fromJson.txt:2818
 msgid "Hover Propulsion"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/propulsion.json: $.hover01.name
 #. data/mp/stats/propulsion.json: $.hover01.name
-#: po/custom/fromJson.txt:2801
+#: po/custom/fromJson.txt:2822
 msgid "Hover"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/messages/resmessages2.json: $.RES_W_HOWAC1.text[2]
 #. data/mp/messages/resmessages3.json: $.RES_W_HOWAC3.text[2]
-#: po/custom/fromJson.txt:2805
+#: po/custom/fromJson.txt:2827
+#, no-c-format
 msgid "Howitzer accuracy +10%"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Wpn-Howitzer-ROF02.name
 #. data/mp/stats/research.json: $.R-Wpn-Howitzer-ROF02.name
-#: po/custom/fromJson.txt:2809
+#: po/custom/fromJson.txt:2831
 msgid "Howitzer Autoloader Mk2"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Wpn-Howitzer-ROF03.name
 #. data/mp/stats/research.json: $.R-Wpn-Howitzer-ROF03.name
-#: po/custom/fromJson.txt:2813
+#: po/custom/fromJson.txt:2835
 msgid "Howitzer Autoloader Mk3"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Wpn-Howitzer-ROF01.name
 #. data/mp/stats/research.json: $.R-Wpn-Howitzer-ROF01.name
-#: po/custom/fromJson.txt:2817
+#: po/custom/fromJson.txt:2839
 msgid "Howitzer Autoloader"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/messages/resmessages2.json: $.RES_W_HOWD1.text[2]
 #. data/mp/messages/resmessages3.json: $.RES_W_HOWD4.text[2]
-#: po/custom/fromJson.txt:2821
+#: po/custom/fromJson.txt:2844
+#, no-c-format
 msgid "Howitzer damage +25%"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/research.json: $.R-Wpn-Howitzer-ROF04.name
-#: po/custom/fromJson.txt:2830
+#: po/custom/fromJson.txt:2853
 msgid "Howitzer Fast Loader"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/messages/resmessages2.json: $.RES_W_HOWRF1.text[2]
 #. data/mp/messages/resmessages3.json: $.RES_W_HOWRF4.text[2]
-#: po/custom/fromJson.txt:2834
+#: po/custom/fromJson.txt:2858
+#, no-c-format
 msgid "Howitzer reload time -10%"
 msgstr ""
 
@@ -9593,27 +9611,27 @@ msgstr ""
 #. data/base/stats/weapons.json: $.Howitzer105Mk1.name
 #. data/mp/stats/research.json: $.R-Wpn-HowitzerMk1.name
 #. data/mp/stats/weapons.json: $.Howitzer105Mk1.name
-#: po/custom/fromJson.txt:2846
+#: po/custom/fromJson.txt:2870
 msgid "Howitzer"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Defense-Emplacement-HPVcannon.name
 #. data/base/stats/structure.json: $.Emplacement-HPVcannon.name
-#: po/custom/fromJson.txt:2850
+#: po/custom/fromJson.txt:2874
 msgid "HPV Cannon Emplacement"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Defense-WallTower-HPVcannon.name
 #. data/base/stats/structure.json: $.WallTower-HPVcannon.name
-#: po/custom/fromJson.txt:2854
+#: po/custom/fromJson.txt:2878
 msgid "HPV Cannon Hardpoint"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/templates.json: $.P0cam3PyHPVcanTrk.name
-#: po/custom/fromJson.txt:2857
+#: po/custom/fromJson.txt:2881
 msgid "HPV Cannon Python Tracks"
 msgstr ""
 
@@ -9622,7 +9640,7 @@ msgstr ""
 #. data/base/stats/structure.json: $.AASite-QuadMg1.name
 #. data/mp/stats/research.json: $.R-Defense-AASite-QuadMg1.name
 #. data/mp/stats/structure.json: $.AASite-QuadMg1.name
-#: po/custom/fromJson.txt:2863
+#: po/custom/fromJson.txt:2887
 msgid "Hurricane AA Site"
 msgstr ""
 
@@ -9631,67 +9649,67 @@ msgstr ""
 #. data/base/stats/weapons.json: $.QuadMg1AAGun.name
 #. data/mp/stats/research.json: $.R-Wpn-AAGun03.name
 #. data/mp/stats/weapons.json: $.QuadMg1AAGun.name
-#: po/custom/fromJson.txt:2869
+#: po/custom/fromJson.txt:2893
 msgid "Hurricane AA Turret"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/features.json: $.BarbHUT.name
-#: po/custom/fromJson.txt:2872
+#: po/custom/fromJson.txt:2896
 msgid "Hut"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Wpn-Cannon-Damage08.name
 #. data/mp/stats/research.json: $.R-Wpn-Cannon-Damage08.name
-#: po/custom/fromJson.txt:2876
+#: po/custom/fromJson.txt:2900
 msgid "HVAPFSDS Cannon Rounds Mk2"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Wpn-Cannon-Damage09.name
 #. data/mp/stats/research.json: $.R-Wpn-Cannon-Damage09.name
-#: po/custom/fromJson.txt:2880
+#: po/custom/fromJson.txt:2904
 msgid "HVAPFSDS Cannon Rounds Mk3"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Wpn-Cannon-Damage07.name
 #. data/mp/stats/research.json: $.R-Wpn-Cannon-Damage07.name
-#: po/custom/fromJson.txt:2884
+#: po/custom/fromJson.txt:2908
 msgid "HVAPFSDS Cannon Rounds"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Wpn-MG-ROF03.name
 #. data/mp/stats/research.json: $.R-Wpn-MG-ROF03.name
-#: po/custom/fromJson.txt:2888
+#: po/custom/fromJson.txt:2912
 msgid "Hyper Fire Chaingun Upgrade"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/research.json: $.R-Defense-Emplacement-HPVcannon.name
 #. data/mp/stats/structure.json: $.Emplacement-HPVcannon.name
-#: po/custom/fromJson.txt:2892
+#: po/custom/fromJson.txt:2916
 msgid "Hyper Velocity Cannon Emplacement"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/research.json: $.R-Defense-WallTower-HPVcannon.name
 #. data/mp/stats/structure.json: $.WallTower-HPVcannon.name
-#: po/custom/fromJson.txt:2896
+#: po/custom/fromJson.txt:2920
 msgid "Hyper Velocity Cannon Hardpoint"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/templates.json: $.PythonHoverHVC.name
-#: po/custom/fromJson.txt:2899
+#: po/custom/fromJson.txt:2923
 msgid "Hyper Velocity Cannon Python Hover"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/templates.json: $.P0cam3PyHPVcanTrk.name
-#: po/custom/fromJson.txt:2902
+#: po/custom/fromJson.txt:2926
 msgid "Hyper Velocity Cannon Python Tracks"
 msgstr ""
 
@@ -9700,33 +9718,33 @@ msgstr ""
 #. data/base/stats/weapons.json: $.Cannon4AUTOMk1.name
 #. data/mp/stats/research.json: $.R-Wpn-Cannon4AMk1.name
 #. data/mp/stats/weapons.json: $.Cannon4AUTOMk1.name
-#: po/custom/fromJson.txt:2908
+#: po/custom/fromJson.txt:2932
 msgid "Hyper Velocity Cannon"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/messages/resmessagesall.json: $.RES_W_LASSAT.text[2]
-#: po/custom/fromJson.txt:2915
+#: po/custom/fromJson.txt:2939
 msgid "Immense damage infliction capability"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages3.json: $.RES_W_RAIL_D1.text[1]
 #. data/mp/messages/resmessages3.json: $.RES_W_RAIL_D1.text[1]
-#: po/custom/fromJson.txt:2919
+#: po/custom/fromJson.txt:2943
 msgid "Improved armor-piercing dart"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/research.json: $.R-Wpn-Bomb-Accuracy02.name
-#: po/custom/fromJson.txt:2922
+#: po/custom/fromJson.txt:2946
 msgid "Improved Bomb Warhead"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages3.json: $.RES_LASROF1.text[1]
 #. data/mp/messages/resmessages3.json: $.RES_LASROF1.text[1]
-#: po/custom/fromJson.txt:2930
+#: po/custom/fromJson.txt:2954
 msgid "Improved Energizer reduces laser recharge time"
 msgstr ""
 
@@ -9735,14 +9753,14 @@ msgstr ""
 #. data/base/messages/resmessages23.json: $.RES_ENGIN2.text[1]
 #. data/mp/messages/resmessages12.json: $.RES_ENGIN1.text[1]
 #. data/mp/messages/resmessages23.json: $.RES_ENGIN2.text[1]
-#: po/custom/fromJson.txt:2936
+#: po/custom/fromJson.txt:2960
 msgid "Improved Engineering Techniques"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Sys-Engineering02.name
 #. data/mp/stats/research.json: $.R-Sys-Engineering02.name
-#: po/custom/fromJson.txt:2940
+#: po/custom/fromJson.txt:2964
 msgid "Improved Engineering"
 msgstr ""
 
@@ -9751,49 +9769,49 @@ msgstr ""
 #. data/base/messages/resmessages23.json: $.RES_SY_VCBSU2.text[1]
 #. data/base/messages/resmessages3.json: $.RES_SY_CBSU3.text[1]
 #. ... + 3 refs
-#: po/custom/fromJson.txt:2946
+#: po/custom/fromJson.txt:2970
 msgid "Improved fire detection systems"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Defense-WallUpgrade02.name
 #. data/mp/stats/research.json: $.R-Defense-WallUpgrade02.name
-#: po/custom/fromJson.txt:2950
+#: po/custom/fromJson.txt:2974
 msgid "Improved Hardcrete Mk2"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Defense-WallUpgrade03.name
 #. data/mp/stats/research.json: $.R-Defense-WallUpgrade03.name
-#: po/custom/fromJson.txt:2954
+#: po/custom/fromJson.txt:2978
 msgid "Improved Hardcrete Mk3"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Defense-WallUpgrade01.name
 #. data/mp/stats/research.json: $.R-Defense-WallUpgrade01.name
-#: po/custom/fromJson.txt:2958
+#: po/custom/fromJson.txt:2982
 msgid "Improved Hardcrete"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages1.json: $.RES_W_M_D1.text[1]
 #. data/mp/messages/resmessages1.json: $.RES_W_M_D1.text[1]
-#: po/custom/fromJson.txt:2962
+#: po/custom/fromJson.txt:2986
 msgid "Improved high explosive shells"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Wpn-Energy-Accuracy01.name
 #. data/mp/stats/research.json: $.R-Wpn-Energy-Accuracy01.name
-#: po/custom/fromJson.txt:2966
+#: po/custom/fromJson.txt:2990
 msgid "Improved Laser Focusing"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages3.json: $.RES_SY_RESU2.text[1]
 #. data/mp/messages/resmessages3.json: $.RES_SY_RESU2.text[1]
-#: po/custom/fromJson.txt:2970
+#: po/custom/fromJson.txt:2994
 msgid "Improved NEXUS resistance circuitry"
 msgstr ""
 
@@ -9802,14 +9820,14 @@ msgstr ""
 #. data/base/messages/resmessages23.json: $.RES_POWU1.text[0]
 #. data/base/messages/resmessages3.json: $.RES_POWU2.text[0]
 #. ... + 3 refs
-#: po/custom/fromJson.txt:2976
+#: po/custom/fromJson.txt:3000
 msgid "Improved Power Generator Performance"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Wpn-RocketSlow-Accuracy01.name
 #. data/mp/stats/research.json: $.R-Wpn-Rocket-Accuracy02.name
-#: po/custom/fromJson.txt:2980
+#: po/custom/fromJson.txt:3004
 msgid "Improved Rocket Wire Guidance"
 msgstr ""
 
@@ -9818,114 +9836,114 @@ msgstr ""
 #. data/mp/messages/resmessagesall.json: $.RES_SENSO1.text[1]
 #. data/mp/messages/resmessagesall.json: $.RES_SY_S_WS.text[3]
 #. data/mp/messages/resmessagesall.json: $.RES_SY_S_WST.text[3]
-#: po/custom/fromJson.txt:2986
+#: po/custom/fromJson.txt:3010
 msgid "Improved sensor range"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages1.json: $.RES_W_RK_D1.text[1]
 #. data/mp/messages/resmessages1.json: $.RES_W_RK_D1.text[1]
-#: po/custom/fromJson.txt:2994
+#: po/custom/fromJson.txt:3018
 msgid "Improved shaped charge warhead"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages23.json: $.RES_SY_VS2.text[1]
 #. data/mp/messages/resmessages23.json: $.RES_SY_VS2.text[1]
-#: po/custom/fromJson.txt:2998
+#: po/custom/fromJson.txt:3022
 msgid "Improved target recognition systems"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/messages/resmessagesall.json: $.RES_SY_SU2.text[1]
-#: po/custom/fromJson.txt:3001
+#: po/custom/fromJson.txt:3025
 msgid "Improved Thermal Emissions detection"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages1.json: $.RES_DF_WU1.text[1]
 #. data/mp/messages/resmessages1.json: $.RES_DF_WU1.text[1]
-#: po/custom/fromJson.txt:3005
+#: po/custom/fromJson.txt:3029
 msgid "Improved Titanium-reinforced concrete"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/messages/resmessages23.json: $.RES_W_BAC2.text[1]
-#: po/custom/fromJson.txt:3008
+#: po/custom/fromJson.txt:3032
 msgid "Improved trinitramine explosive formula"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages3.json: $.RES_LASD1.text[1]
 #. data/mp/messages/resmessages3.json: $.RES_LASD1.text[1]
-#: po/custom/fromJson.txt:3012
+#: po/custom/fromJson.txt:3036
 msgid "Improvement in laser emission density"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages3.json: $.RES_LASAC1.text[1]
 #. data/mp/messages/resmessages3.json: $.RES_LASAC1.text[1]
-#: po/custom/fromJson.txt:3016
+#: po/custom/fromJson.txt:3040
 msgid "Improvement in laser optics reduces light dispersal"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/messages/resmessagesall.json: $.RES_EMP_INH.text[1]
-#: po/custom/fromJson.txt:3025
+#: po/custom/fromJson.txt:3049
 msgid "Incendiary howitzer emplacement"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/research.json: $.R-Defense-Howitzer-Incenediary.name
 #. data/mp/stats/structure.json: $.Emplacement-Howitzer-Incenediary.name
-#: po/custom/fromJson.txt:3029
+#: po/custom/fromJson.txt:3053
 msgid "Incendiary Howitzer Emplacement"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/messages/resmessagesall.json: $.RES_W_INH.text[1]
-#: po/custom/fromJson.txt:3032
+#: po/custom/fromJson.txt:3056
 msgid "Incendiary Howitzer may be assigned to a sensor"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/research.json: $.R-Wpn-Howitzer-Incenediary.name
 #. data/mp/stats/weapons.json: $.Howitzer-Incenediary.name
-#: po/custom/fromJson.txt:3036
+#: po/custom/fromJson.txt:3060
 msgid "Incendiary Howitzer"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/research.json: $.R-Defense-MortarPit-Incenediary.name
 #. data/mp/stats/structure.json: $.Emplacement-MortarPit-Incenediary.name
-#: po/custom/fromJson.txt:3040
+#: po/custom/fromJson.txt:3064
 msgid "Incendiary Mortar Pit"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/research.json: $.R-Wpn-Mortar-Incenediary.name
 #. data/mp/stats/weapons.json: $.Mortar-Incenediary.name
-#: po/custom/fromJson.txt:3044
+#: po/custom/fromJson.txt:3068
 msgid "Incendiary Mortar"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages3.json: $.RES_W_RAIL_ROF1.text[1]
 #. data/mp/messages/resmessages3.json: $.RES_W_RAIL_ROF1.text[1]
-#: po/custom/fromJson.txt:3048
+#: po/custom/fromJson.txt:3072
 msgid "Increased gauss output speeds up reload time"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages1.json: $.RES_DF_WU1.text[2]
-#: po/custom/fromJson.txt:3070
+#: po/custom/fromJson.txt:3094
 msgid "Increases Armour and Body Points"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages12.json: $.RES_W_CNAC1.text[2]
 #. data/base/messages/resmessagesall.json: $.RES_W_CNAC2.text[2]
-#: po/custom/fromJson.txt:3085
+#: po/custom/fromJson.txt:3109
 msgid "Increases Cannon accuracy"
 msgstr ""
 
@@ -9933,14 +9951,14 @@ msgstr ""
 #. data/base/messages/resmessages1.json: $.RES_W_CN_D1.text[2]
 #. data/base/messages/resmessages12.json: $.RES_W_CN_D4.text[2]
 #. data/base/messages/resmessages3.json: $.RES_W_CN_D7.text[2]
-#: po/custom/fromJson.txt:3090
+#: po/custom/fromJson.txt:3114
 msgid "Increases Cannon damage"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages12.json: $.RES_W_CN_ROF1.text[2]
 #. data/base/messages/resmessages3.json: $.RES_W_CN_ROF4.text[2]
-#: po/custom/fromJson.txt:3094
+#: po/custom/fromJson.txt:3118
 msgid "Increases Cannon ROF"
 msgstr ""
 
@@ -9948,63 +9966,63 @@ msgstr ""
 #. data/base/messages/resmessages12.json: $.RES_ENGIN1.text[2]
 #. data/base/messages/resmessages23.json: $.RES_ENGIN2.text[2]
 #. data/base/messages/resmessages3.json: $.RES_ENGIN3.text[2]
-#: po/custom/fromJson.txt:3099
+#: po/custom/fromJson.txt:3123
 msgid "Increases construction speed"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages12.json: $.RES_W_FL_ROF1.text[2]
-#: po/custom/fromJson.txt:3125
+#: po/custom/fromJson.txt:3149
 msgid "Increases Flamer ROF"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages3.json: $.RES_LASAC1.text[2]
-#: po/custom/fromJson.txt:3152
+#: po/custom/fromJson.txt:3176
 msgid "Increases Laser accuracy"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages3.json: $.RES_LASD1.text[2]
-#: po/custom/fromJson.txt:3155
+#: po/custom/fromJson.txt:3179
 msgid "Increases Laser damage"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages3.json: $.RES_LASROF1.text[2]
-#: po/custom/fromJson.txt:3158
+#: po/custom/fromJson.txt:3182
 msgid "Increases Laser ROF"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages1.json: $.RES_W_RK_AC1.text[2]
-#: po/custom/fromJson.txt:3172
+#: po/custom/fromJson.txt:3196
 msgid "Increases Mini-Rocket accuracy"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages1.json: $.RES_W_RK_ROF1.text[2]
-#: po/custom/fromJson.txt:3179
+#: po/custom/fromJson.txt:3203
 msgid "Increases Mini-Rockets ROF"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages3.json: $.RES_W_MS_AC1.text[2]
 #. data/base/messages/resmessages3.json: $.RES_W_MS_AC2.text[2]
-#: po/custom/fromJson.txt:3183
+#: po/custom/fromJson.txt:3207
 msgid "Increases Missile accuracy"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages3.json: $.RES_W_MS_D1.text[2]
-#: po/custom/fromJson.txt:3186
+#: po/custom/fromJson.txt:3210
 msgid "Increases Missile damage"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages3.json: $.RES_W_MS_ROF1.text[2]
 #. data/base/messages/resmessages3.json: $.RES_W_SMS_ROF1.text[2]
-#: po/custom/fromJson.txt:3190
+#: po/custom/fromJson.txt:3214
 msgid "Increases Missile ROF"
 msgstr ""
 
@@ -10012,32 +10030,32 @@ msgstr ""
 #. data/base/messages/resmessages12.json: $.RES_W_M_AC1.text[2]
 #. data/base/messages/resmessages23.json: $.RES_W_M_AC2.text[2]
 #. data/base/messages/resmessages3.json: $.RES_W_M_AC3.text[2]
-#: po/custom/fromJson.txt:3195
+#: po/custom/fromJson.txt:3219
 msgid "Increases Mortar accuracy"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages12.json: $.RES_W_M_ROF1.text[2]
 #. data/base/messages/resmessages3.json: $.RES_W_M_ROF4.text[2]
-#: po/custom/fromJson.txt:3203
+#: po/custom/fromJson.txt:3227
 msgid "Increases Mortar ROF"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages3.json: $.RES_W_RAIL_AC1.text[2]
-#: po/custom/fromJson.txt:3206
+#: po/custom/fromJson.txt:3230
 msgid "Increases Rail Gun accuracy"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages3.json: $.RES_W_RAIL_D1.text[2]
-#: po/custom/fromJson.txt:3209
+#: po/custom/fromJson.txt:3233
 msgid "Increases Rail Gun damage"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages3.json: $.RES_W_RAIL_ROF1.text[2]
-#: po/custom/fromJson.txt:3212
+#: po/custom/fromJson.txt:3236
 msgid "Increases Rail Gun ROF"
 msgstr ""
 
@@ -10045,119 +10063,119 @@ msgstr ""
 #. data/base/messages/resmessages1.json: $.RES_W_SRK_AC1.text[2]
 #. data/base/messages/resmessages12.json: $.RES_W_SRK_AC2.text[2]
 #. data/base/messages/resmessagesall.json: $.RES_W_SRK_AC3.text[2]
-#: po/custom/fromJson.txt:3228
+#: po/custom/fromJson.txt:3252
 msgid "Increases Rocket accuracy"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages12.json: $.RES_W_SRK_ROF1.text[2]
-#: po/custom/fromJson.txt:3235
+#: po/custom/fromJson.txt:3259
 msgid "Increases Rocket ROF"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/features.json: $.Indirectlab.name
-#: po/custom/fromJson.txt:3252
+#: po/custom/fromJson.txt:3276
 msgid "Indirectweaponslab"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages1.json: $.RES_V_B08.text[1]
 #. data/mp/messages/resmessages1.json: $.RES_V_B08.text[1]
-#: po/custom/fromJson.txt:3256
+#: po/custom/fromJson.txt:3280
 msgid "Inferior armor and body points to Cobra"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages1.json: $.RES_V_B04.text[1]
 #. data/mp/messages/resmessages1.json: $.RES_V_B04.text[1]
-#: po/custom/fromJson.txt:3260
+#: po/custom/fromJson.txt:3284
 msgid "Inferior armor and body points to Viper"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/research.json: $.R-Defense-HvyFlamer.name
 #. data/mp/stats/structure.json: $.Tower-Projector.name
-#: po/custom/fromJson.txt:3264
+#: po/custom/fromJson.txt:3288
 msgid "Inferno Bunker"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/templates.json: $.CobraInfernoHTracks.name
-#: po/custom/fromJson.txt:3267
+#: po/custom/fromJson.txt:3291
 msgid "Inferno Cobra Half-Tracks"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/templates.json: $.CobraInfernoHover.name
-#: po/custom/fromJson.txt:3270
+#: po/custom/fromJson.txt:3294
 msgid "Inferno Cobra Hover"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Defense-HvyFlamer.name
 #. data/base/stats/structure.json: $.Tower-Projector.name
-#: po/custom/fromJson.txt:3274
+#: po/custom/fromJson.txt:3298
 msgid "Inferno Emplacement"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/structure.json: $.WallTower-Projector.name
 #. data/mp/stats/structure.json: $.WallTower-Projector.name
-#: po/custom/fromJson.txt:3278
+#: po/custom/fromJson.txt:3302
 msgid "Inferno Hardpoint"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/templates.json: $.PythonHoverInferno.name
-#: po/custom/fromJson.txt:3281
+#: po/custom/fromJson.txt:3305
 msgid "Inferno Python Hover"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/weapons.json: $.Flame2.name
 #. data/mp/stats/weapons.json: $.Flame2.name
-#: po/custom/fromJson.txt:3285
+#: po/custom/fromJson.txt:3309
 msgid "Inferno"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages3.json: $.RES_SY_RESU1.text[2]
 #. data/mp/messages/resmessages3.json: $.RES_SY_RESU1.text[2]
-#: po/custom/fromJson.txt:3289
+#: po/custom/fromJson.txt:3313
 msgid "Intruder parasite isolated"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages3.json: $.RES_V_EN10.text[1]
 #. data/mp/messages/resmessages3.json: $.RES_V_EN10.text[1]
-#: po/custom/fromJson.txt:3293
+#: po/custom/fromJson.txt:3317
 msgid "Ionizing Turbine Engine"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/structure.json: $.ECM1PylonMk1.name
-#: po/custom/fromJson.txt:3296
+#: po/custom/fromJson.txt:3320
 msgid "Jammer Tower"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/ecm.json: $.ECM1TurretMk1.name
-#: po/custom/fromJson.txt:3299
+#: po/custom/fromJson.txt:3323
 msgid "Jammer Turret"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/templates.json: $.BabaJeep.name
 #. data/mp/stats/templates.json: $.BabaJeep.name
-#: po/custom/fromJson.txt:3303
+#: po/custom/fromJson.txt:3327
 msgid "Jeep"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages3.json: $.RES_CY_JP1.text[3]
 #. data/mp/messages/resmessages3.json: $.RES_CY_JP1.text[3]
-#: po/custom/fromJson.txt:3307
+#: po/custom/fromJson.txt:3331
 msgid "Jump Cyborgs can now be researched"
 msgstr ""
 
@@ -10166,7 +10184,7 @@ msgstr ""
 #. data/mp/messages/resmessagesall.json: $.RES_SY_S_UP.text[2]
 #. data/mp/messages/resmessagesall.json: $.RES_SY_S_WS.text[2]
 #. ... + 2 refs
-#: po/custom/fromJson.txt:3313
+#: po/custom/fromJson.txt:3337
 msgid "Keeps map areas under constant surveillance"
 msgstr ""
 
@@ -10175,13 +10193,15 @@ msgstr ""
 #. data/mp/messages/resmessages2.json: $.RES_V_MET4.text[2]
 #. data/mp/messages/resmessages3.json: $.RES_V_MET10.text[2]
 #. data/mp/messages/resmessages3.json: $.RES_V_MET7.text[2]
-#: po/custom/fromJson.txt:3319
+#: po/custom/fromJson.txt:3344
+#, no-c-format
 msgid "Kinetic armor +30%, body points +30%"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/messages/resmessages2.json: $.RES_CYMET4.text[2]
-#: po/custom/fromJson.txt:3322
+#: po/custom/fromJson.txt:3348
+#, no-c-format
 msgid "Kinetic Armor +35%, and Body Points +35%"
 msgstr ""
 
@@ -10189,7 +10209,8 @@ msgstr ""
 #. data/mp/messages/resmessages1.json: $.RES_CYMET1.text[2]
 #. data/mp/messages/resmessages3.json: $.RES_CYMET10.text[2]
 #. data/mp/messages/resmessages3.json: $.RES_CYMET7.text[2]
-#: po/custom/fromJson.txt:3327
+#: po/custom/fromJson.txt:3354
+#, no-c-format
 msgid "Kinetic Armor +35%, Body Points +35%"
 msgstr ""
 
@@ -10198,14 +10219,14 @@ msgstr ""
 #. data/base/messages/resmessages3.json: $.RES_V_MET10.text[1]
 #. data/mp/messages/resmessages3.json: $.RES_CYMET10.text[1]
 #. data/mp/messages/resmessages3.json: $.RES_V_MET10.text[1]
-#: po/custom/fromJson.txt:3333
+#: po/custom/fromJson.txt:3360
 msgid "Laminated alloys bonded with energy-deflecting optic bundles"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Wpn-Rocket01-LtAT.name
 #. data/mp/stats/research.json: $.R-Wpn-Rocket01-LtAT.name
-#: po/custom/fromJson.txt:3337
+#: po/custom/fromJson.txt:3364
 msgid "Lancer AT Rocket"
 msgstr ""
 
@@ -10213,7 +10234,7 @@ msgstr ""
 #. data/base/stats/research.json: $.R-Defense-Pillbox06.name
 #. data/base/stats/structure.json: $.PillBox6.name
 #. data/mp/stats/structure.json: $.PillBox6.name
-#: po/custom/fromJson.txt:3342
+#: po/custom/fromJson.txt:3369
 msgid "Lancer Bunker"
 msgstr ""
 
@@ -10222,19 +10243,19 @@ msgstr ""
 #. data/base/stats/templates.json: $.P0CobraLtATRktHtrack.name
 #. data/mp/stats/templates.json: $.CobraLtA-Thalftrack.name
 #. data/mp/stats/templates.json: $.P0CobraLtATRktHtrack.name
-#: po/custom/fromJson.txt:3348
+#: po/custom/fromJson.txt:3375
 msgid "Lancer Cobra Half-tracks"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/templates.json: $.CobraTrkLancer.name
-#: po/custom/fromJson.txt:3351
+#: po/custom/fromJson.txt:3378
 msgid "Lancer Cobra Tracks"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Cyborg-Wpn-Rocket.name
-#: po/custom/fromJson.txt:3354
+#: po/custom/fromJson.txt:3381
 msgid "Lancer Cyborg"
 msgstr ""
 
@@ -10243,44 +10264,44 @@ msgstr ""
 #. data/base/stats/structure.json: $.WallTower06.name
 #. data/mp/stats/research.json: $.R-Defense-WallTower06.name
 #. data/mp/stats/structure.json: $.WallTower06.name
-#: po/custom/fromJson.txt:3360
+#: po/custom/fromJson.txt:3387
 msgid "Lancer Hardpoint"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/templates.json: $.A-Mantis-Trk-Lancer.name
-#: po/custom/fromJson.txt:3363
+#: po/custom/fromJson.txt:3390
 msgid "Lancer Mantis Tracks"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/templates.json: $.A-Python-Trk-Lancer.name
-#: po/custom/fromJson.txt:3366
+#: po/custom/fromJson.txt:3393
 msgid "Lancer Python Tracks"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/templates.json: $.H-Scorp-Trk-Lancer.name
-#: po/custom/fromJson.txt:3369
+#: po/custom/fromJson.txt:3396
 msgid "Lancer Scorpion Tracks"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/templates.json: $.H-Scorp-VTOL-Lancer.name
-#: po/custom/fromJson.txt:3372
+#: po/custom/fromJson.txt:3399
 msgid "Lancer Scorpion VTOL"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/templates.json: $.ViperTrkLancer.name
-#: po/custom/fromJson.txt:3380
+#: po/custom/fromJson.txt:3407
 msgid "Lancer Viper Tracks"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/templates.json: $.ViperLtA-Twheels.name
 #. data/mp/stats/templates.json: $.ViperLtA-Twheels.name
-#: po/custom/fromJson.txt:3384
+#: po/custom/fromJson.txt:3411
 msgid "Lancer Viper Wheels"
 msgstr ""
 
@@ -10289,63 +10310,66 @@ msgstr ""
 #. data/base/stats/templates.json: $.CyborgRkt01Ground.name
 #. data/base/stats/weapons.json: $.Rocket-LtA-T.name
 #. ... + 3 refs
-#: po/custom/fromJson.txt:3390
+#: po/custom/fromJson.txt:3417
 msgid "Lancer"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/messages/resmessagesall.json: $.RES_V_B14.text[0]
-#: po/custom/fromJson.txt:3393
+#: po/custom/fromJson.txt:3420
 msgid "Large Super Heavy Body"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Wpn-Laser01.name
 #. data/mp/stats/research.json: $.R-Wpn-Laser01.name
-#: po/custom/fromJson.txt:3397
+#: po/custom/fromJson.txt:3424
 msgid "Laser - Flashlight"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/messages/resmessagesall.json: $.RES_DEF_AALAS.text[0]
-#: po/custom/fromJson.txt:3400
+#: po/custom/fromJson.txt:3427
 msgid "Laser AA Gun Available"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/messages/resmessages3.json: $.RES_LASAC1.text[2]
-#: po/custom/fromJson.txt:3403
+#: po/custom/fromJson.txt:3431
+#, no-c-format
 msgid "Laser accuracy +10%"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/messages/resmessages3.json: $.RES_LASD1.text[2]
-#: po/custom/fromJson.txt:3406
+#: po/custom/fromJson.txt:3435
+#, no-c-format
 msgid "Laser damage +25%"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages23.json: $.RES_W_BAC2.text[1]
-#: po/custom/fromJson.txt:3409
+#: po/custom/fromJson.txt:3438
 msgid "Laser designator paints and guides bombs to the target"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessagesall.json: $.RES_W_CNAC2.text[1]
 #. data/mp/messages/resmessagesall.json: $.RES_W_CNAC2.text[1]
-#: po/custom/fromJson.txt:3413
+#: po/custom/fromJson.txt:3442
 msgid "Laser designator paints and guides rounds to the target"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Wpn-Bomb-Accuracy02.name
-#: po/custom/fromJson.txt:3416
+#: po/custom/fromJson.txt:3445
 msgid "Laser Guided Bombsight"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/messages/resmessages3.json: $.RES_LASROF1.text[2]
-#: po/custom/fromJson.txt:3419
+#: po/custom/fromJson.txt:3449
+#, no-c-format
 msgid "Laser reload time -15%"
 msgstr ""
 
@@ -10353,7 +10377,7 @@ msgstr ""
 #. data/mp/stats/research.json: $.R-Wpn-LasSat.name
 #. data/mp/stats/structure.json: $.A0LasSatCommand.name
 #. data/mp/stats/weapons.json: $.LasSat.name
-#: po/custom/fromJson.txt:3424
+#: po/custom/fromJson.txt:3454
 msgid "Laser Satellite Command Post"
 msgstr ""
 
@@ -10362,19 +10386,19 @@ msgstr ""
 #. data/base/messages/resmessages3.json: $.RES_LASD1.text[0]
 #. data/base/messages/resmessages3.json: $.RES_LASROF1.text[0]
 #. ... + 3 refs
-#: po/custom/fromJson.txt:3430
+#: po/custom/fromJson.txt:3460
 msgid "Laser Upgrade"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/features.json: $.Laseropticslab.name
-#: po/custom/fromJson.txt:3433
+#: po/custom/fromJson.txt:3463
 msgid "Laseropticslab"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/weapons.json: $.LasSat.name
-#: po/custom/fromJson.txt:3436
+#: po/custom/fromJson.txt:3466
 msgid "LasSat"
 msgstr ""
 
@@ -10383,56 +10407,56 @@ msgstr ""
 #. data/base/messages/resmessages1.json: $.RES_V_MET1.text[1]
 #. data/mp/messages/resmessages1.json: $.RES_CYMET1.text[1]
 #. data/mp/messages/resmessages1.json: $.RES_V_MET1.text[1]
-#: po/custom/fromJson.txt:3442
+#: po/custom/fromJson.txt:3472
 msgid "Layered composite alloys and energy-absorbing fibres"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/body.json: $.Body2SUP.name
 #. data/mp/stats/body.json: $.Body2SUP.name
-#: po/custom/fromJson.txt:3452
+#: po/custom/fromJson.txt:3482
 msgid "Leopard"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages1.json: $.RES_V_B12.text[1]
 #. data/mp/messages/resmessages1.json: $.RES_V_B12.text[1]
-#: po/custom/fromJson.txt:3456
+#: po/custom/fromJson.txt:3486
 msgid "Less armor and body points than Python"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Vehicle-Body04.name
 #. data/mp/stats/research.json: $.R-Vehicle-Body04.name
-#: po/custom/fromJson.txt:3460
+#: po/custom/fromJson.txt:3490
 msgid "Light Body - Bug"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Vehicle-Body02.name
 #. data/mp/stats/research.json: $.R-Vehicle-Body02.name
-#: po/custom/fromJson.txt:3464
+#: po/custom/fromJson.txt:3494
 msgid "Light Body - Leopard"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Vehicle-Body03.name
 #. data/mp/stats/research.json: $.R-Vehicle-Body03.name
-#: po/custom/fromJson.txt:3468
+#: po/custom/fromJson.txt:3498
 msgid "Light Body - Retaliation"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Vehicle-Body01.name
 #. data/mp/stats/research.json: $.R-Vehicle-Body01.name
-#: po/custom/fromJson.txt:3472
+#: po/custom/fromJson.txt:3502
 msgid "Light Body - Viper"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages1.json: $.RES_V_B01.text[1]
 #. data/mp/messages/resmessages1.json: $.RES_V_B01.text[1]
-#: po/custom/fromJson.txt:3476
+#: po/custom/fromJson.txt:3506
 msgid "Light body vulnerable to heavy weapons"
 msgstr ""
 
@@ -10441,21 +10465,21 @@ msgstr ""
 #. data/base/stats/structure.json: $.PillBox4.name
 #. data/mp/stats/research.json: $.R-Defense-Pillbox04.name
 #. data/mp/stats/structure.json: $.PillBox4.name
-#: po/custom/fromJson.txt:3482
+#: po/custom/fromJson.txt:3512
 msgid "Light Cannon Bunker"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/templates.json: $.CobraLtCnTrks.name
 #. data/mp/stats/templates.json: $.CobraLtCnTrks.name
-#: po/custom/fromJson.txt:3486
+#: po/custom/fromJson.txt:3516
 msgid "Light Cannon Cobra Tracks"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages1.json: $.RES_CN1MK1.text[1]
 #. data/mp/messages/resmessages1.json: $.RES_CN1MK1.text[1]
-#: po/custom/fromJson.txt:3490
+#: po/custom/fromJson.txt:3520
 msgid "Light Cannon firing 40mm rounds"
 msgstr ""
 
@@ -10464,34 +10488,34 @@ msgstr ""
 #. data/base/stats/structure.json: $.WallTower02.name
 #. data/mp/stats/research.json: $.R-Defense-WallTower02.name
 #. data/mp/stats/structure.json: $.WallTower02.name
-#: po/custom/fromJson.txt:3496
+#: po/custom/fromJson.txt:3526
 msgid "Light Cannon Hardpoint"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/templates.json: $.PythonLtCnTrks.name
 #. data/mp/stats/templates.json: $.PythonLtCnTrks.name
-#: po/custom/fromJson.txt:3500
+#: po/custom/fromJson.txt:3530
 msgid "Light Cannon Python Tracks"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/templates.json: $.ViperLtCannonHTracks.name
-#: po/custom/fromJson.txt:3503
+#: po/custom/fromJson.txt:3533
 msgid "Light Cannon Viper Half-tracks"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/templates.json: $.ViperLtCannonTracks.name
 #. data/mp/stats/templates.json: $.ViperLtCannonTracks.name
-#: po/custom/fromJson.txt:3507
+#: po/custom/fromJson.txt:3537
 msgid "Light Cannon Viper Tracks"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/templates.json: $.ViperLtCannonWheels.name
 #. data/mp/stats/templates.json: $.ViperLtCannonWheels.name
-#: po/custom/fromJson.txt:3511
+#: po/custom/fromJson.txt:3541
 msgid "Light Cannon Viper Wheels"
 msgstr ""
 
@@ -10500,21 +10524,21 @@ msgstr ""
 #. data/base/stats/weapons.json: $.Cannon1Mk1.name
 #. data/mp/stats/research.json: $.R-Wpn-Cannon1Mk1.name
 #. data/mp/stats/weapons.json: $.Cannon1Mk1.name
-#: po/custom/fromJson.txt:3517
+#: po/custom/fromJson.txt:3547
 msgid "Light Cannon"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/structure.json: $.LookOutTower.name
 #. data/mp/stats/structure.json: $.LookOutTower.name
-#: po/custom/fromJson.txt:3524
+#: po/custom/fromJson.txt:3554
 msgid "Look-Out Tower"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages1.json: $.RES_V_B01.text[3]
 #. data/mp/messages/resmessages1.json: $.RES_V_B01.text[3]
-#: po/custom/fromJson.txt:3528
+#: po/custom/fromJson.txt:3558
 msgid "Low power cost and low production times"
 msgstr ""
 
@@ -10522,14 +10546,14 @@ msgstr ""
 #. data/base/messages/resmessages3.json: $.RES_W_MS_D1.text[1]
 #. data/mp/messages/resmessages3.json: $.RES_W_BAC3.text[1]
 #. data/mp/messages/resmessages3.json: $.RES_W_MS_D1.text[1]
-#: po/custom/fromJson.txt:3533
+#: po/custom/fromJson.txt:3563
 msgid "Low yield thermonuclear warhead"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/weapons.json: $.MG1-Pillbox.name
 #. data/mp/stats/weapons.json: $.MG1-Pillbox.name
-#: po/custom/fromJson.txt:3540
+#: po/custom/fromJson.txt:3570
 msgid "Machinegun Bunker"
 msgstr ""
 
@@ -10538,7 +10562,8 @@ msgstr ""
 #. data/mp/messages/resmessages1.json: $.RES_W_MG_D2.text[2]
 #. data/mp/messages/resmessages2.json: $.RES_W_MG_D5.text[2]
 #. ... + 2 refs
-#: po/custom/fromJson.txt:3546
+#: po/custom/fromJson.txt:3577
+#, no-c-format
 msgid "Machinegun damage +25%"
 msgstr ""
 
@@ -10546,19 +10571,20 @@ msgstr ""
 #. data/mp/messages/resmessages12.json: $.RES_W_MG_ROF1.text[2]
 #. data/mp/messages/resmessages2.json: $.RES_W_MG_ROF2.text[2]
 #. data/mp/messages/resmessages23.json: $.RES_W_MG_ROF3.text[2]
-#: po/custom/fromJson.txt:3551
+#: po/custom/fromJson.txt:3583
+#, no-c-format
 msgid "Machinegun reload time -15%"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/templates.json: $.ViperLtMGHalfTracks.name
-#: po/custom/fromJson.txt:3560
+#: po/custom/fromJson.txt:3592
 msgid "Machinegun Viper Half-Tracks"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/templates.json: $.A-Viper-Trk-MG.name
-#: po/custom/fromJson.txt:3563
+#: po/custom/fromJson.txt:3595
 msgid "Machinegun Viper Tracks"
 msgstr ""
 
@@ -10567,46 +10593,46 @@ msgstr ""
 #. data/base/stats/templates.json: $.CyborgChain01Ground.name
 #. data/base/stats/weapons.json: $.CyborgChaingun.name
 #. ... + 3 refs
-#: po/custom/fromJson.txt:3584
+#: po/custom/fromJson.txt:3616
 msgid "Machinegunner"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessagesall.json: $.RES_SENSO1.text[2]
 #. data/mp/messages/resmessagesall.json: $.RES_SENSO1.text[2]
-#: po/custom/fromJson.txt:3588
+#: po/custom/fromJson.txt:3620
 msgid "Makes excellent scout vehicle"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/body.json: $.Body12SUP.name
 #. data/mp/stats/body.json: $.Body12SUP.name
-#: po/custom/fromJson.txt:3592
+#: po/custom/fromJson.txt:3624
 msgid "Mantis"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/research.json: $.R-Defense-MassDriver.name
 #. data/mp/stats/structure.json: $.X-Super-MassDriver.name
-#: po/custom/fromJson.txt:3596
+#: po/custom/fromJson.txt:3628
 msgid "Mass Driver Fortress"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/weapons.json: $.MassDriver.name
-#: po/custom/fromJson.txt:3599
+#: po/custom/fromJson.txt:3631
 msgid "Mass Driver"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/messages/resmessagesall.json: $.RES_V_B14.text[1]
-#: po/custom/fromJson.txt:3602
+#: po/custom/fromJson.txt:3634
 msgid "Maximum armor and body points"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/messages/resmessagesall.json: $.RES_SY_SUE1.text[3]
-#: po/custom/fromJson.txt:3617
+#: po/custom/fromJson.txt:3649
 msgid "May be assigned to follow units"
 msgstr ""
 
@@ -10614,67 +10640,67 @@ msgstr ""
 #. data/base/messages/resmessages1.json: $.RES_MORTA1.text[1]
 #. data/mp/messages/resmessages1.json: $.RES_MORTA1.text[1]
 #. data/mp/messages/resmessagesall.json: $.RES_IMORT.text[1]
-#: po/custom/fromJson.txt:3622
+#: po/custom/fromJson.txt:3654
 msgid "May be targeted directly or assigned to a sensor turret or tower"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessagesall.json: $.RES_ST_VF.text[3]
 #. data/mp/messages/resmessagesall.json: $.RES_ST_VF.text[3]
-#: po/custom/fromJson.txt:3626
+#: po/custom/fromJson.txt:3658
 msgid "May be upgraded using factory modules"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/messages/resmessagesall.json: $.RES_CYS_MCH.text[1]
-#: po/custom/fromJson.txt:3629
+#: po/custom/fromJson.txt:3661
 msgid "Mechanic with repair ability"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Vehicle-Body05.name
 #. data/mp/stats/research.json: $.R-Vehicle-Body05.name
-#: po/custom/fromJson.txt:3633
+#: po/custom/fromJson.txt:3665
 msgid "Medium Body - Cobra"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Vehicle-Body06.name
 #. data/mp/stats/research.json: $.R-Vehicle-Body06.name
-#: po/custom/fromJson.txt:3637
+#: po/custom/fromJson.txt:3669
 msgid "Medium Body - Panther"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Vehicle-Body07.name
 #. data/mp/stats/research.json: $.R-Vehicle-Body07.name
-#: po/custom/fromJson.txt:3641
+#: po/custom/fromJson.txt:3673
 msgid "Medium Body - Retribution"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Vehicle-Body08.name
 #. data/mp/stats/research.json: $.R-Vehicle-Body08.name
-#: po/custom/fromJson.txt:3645
+#: po/custom/fromJson.txt:3677
 msgid "Medium Body - Scorpion"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages1.json: $.RES_V_B05.text[1]
 #. data/mp/messages/resmessages1.json: $.RES_V_B05.text[1]
-#: po/custom/fromJson.txt:3649
+#: po/custom/fromJson.txt:3681
 msgid "Medium body increases armor and body points"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/templates.json: $.CobraMedCnHTrks.name
-#: po/custom/fromJson.txt:3652
+#: po/custom/fromJson.txt:3684
 msgid "Medium Cannon Cobra Half Track"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/templates.json: $.A-Cobra-Hover-MC.name
-#: po/custom/fromJson.txt:3655
+#: po/custom/fromJson.txt:3687
 msgid "Medium Cannon Cobra Hover"
 msgstr ""
 
@@ -10682,14 +10708,14 @@ msgstr ""
 #. data/base/stats/templates.json: $.CobraMedCnTrks.name
 #. data/mp/stats/templates.json: $.CobraMedCnTrks.name
 #. data/mp/stats/templates.json: $.P0CobraMedCnTrks.name
-#: po/custom/fromJson.txt:3660
+#: po/custom/fromJson.txt:3692
 msgid "Medium Cannon Cobra Tracks"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages1.json: $.RES_CN2MK1.text[1]
 #. data/mp/messages/resmessages1.json: $.RES_CN2MK1.text[1]
-#: po/custom/fromJson.txt:3664
+#: po/custom/fromJson.txt:3696
 msgid "Medium Cannon firing 76mm rounds"
 msgstr ""
 
@@ -10698,13 +10724,13 @@ msgstr ""
 #. data/base/stats/structure.json: $.WallTower03.name
 #. data/mp/stats/research.json: $.R-Defense-WallTower03.name
 #. data/mp/stats/structure.json: $.WallTower03.name
-#: po/custom/fromJson.txt:3670
+#: po/custom/fromJson.txt:3702
 msgid "Medium Cannon Hardpoint"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/templates.json: $.A-Python-Hover-MC.name
-#: po/custom/fromJson.txt:3673
+#: po/custom/fromJson.txt:3705
 msgid "Medium Cannon Python Hover"
 msgstr ""
 
@@ -10712,26 +10738,26 @@ msgstr ""
 #. data/base/stats/templates.json: $.PythonMedCnTrks.name
 #. data/mp/stats/templates.json: $.PythonMedCanTracks.name
 #. data/mp/stats/templates.json: $.PythonMedCnTrks.name
-#: po/custom/fromJson.txt:3678
+#: po/custom/fromJson.txt:3710
 msgid "Medium Cannon Python Tracks"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/templates.json: $.A-Scorp-Hover-MC.name
-#: po/custom/fromJson.txt:3681
+#: po/custom/fromJson.txt:3713
 msgid "Medium Cannon Scorpion Hover"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/templates.json: $.A-Scorp-Trk-MC.name
-#: po/custom/fromJson.txt:3684
+#: po/custom/fromJson.txt:3716
 msgid "Medium Cannon Scorpion Tracks"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/templates.json: $.ViperMedCnTrks.name
 #. data/mp/stats/templates.json: $.ViperMedCnTrks.name
-#: po/custom/fromJson.txt:3688
+#: po/custom/fromJson.txt:3720
 msgid "Medium Cannon Viper Tracks"
 msgstr ""
 
@@ -10740,70 +10766,70 @@ msgstr ""
 #. data/base/stats/weapons.json: $.Cannon2A-TMk1.name
 #. data/mp/stats/research.json: $.R-Wpn-Cannon2Mk1.name
 #. data/mp/stats/weapons.json: $.Cannon2A-TMk1.name
-#: po/custom/fromJson.txt:3694
+#: po/custom/fromJson.txt:3726
 msgid "Medium Cannon"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/messages/resmessagesall.json: $.RES_V_B13.text[0]
-#: po/custom/fromJson.txt:3697
+#: po/custom/fromJson.txt:3729
 msgid "Medium Super Heavy Body"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages12.json: $.RES_EMP_MRL.text[1]
 #. data/mp/messages/resmessages12.json: $.RES_EMP_MRL.text[1]
-#: po/custom/fromJson.txt:3701
+#: po/custom/fromJson.txt:3733
 msgid "Mini-rocket armored strongpoint"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/templates.json: $.CobraMRLHalftrack.name
-#: po/custom/fromJson.txt:3704
+#: po/custom/fromJson.txt:3736
 msgid "Mini-Rocket Array Cobra Half-tracks"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/templates.json: $.CobraMRLTracks.name
-#: po/custom/fromJson.txt:3707
+#: po/custom/fromJson.txt:3739
 msgid "Mini-Rocket Array Cobra Tracks"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/templates.json: $.ViperMRLHalfTracks.name
-#: po/custom/fromJson.txt:3710
+#: po/custom/fromJson.txt:3742
 msgid "Mini-Rocket Array Viper Half Track"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/templates.json: $.ViperMRLWheels.name
-#: po/custom/fromJson.txt:3713
+#: po/custom/fromJson.txt:3745
 msgid "Mini-Rocket Array Viper Wheels"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/research.json: $.R-Wpn-Rocket02-MRL.name
 #. data/mp/stats/weapons.json: $.Rocket-MRL.name
-#: po/custom/fromJson.txt:3717
+#: po/custom/fromJson.txt:3749
 msgid "Mini-Rocket Array"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/templates.json: $.CobraMRLHalftrack.name
-#: po/custom/fromJson.txt:3720
+#: po/custom/fromJson.txt:3752
 msgid "Mini-Rocket Artillery Cobra Half-tracks"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/templates.json: $.ViperMRLWheels.name
-#: po/custom/fromJson.txt:3723
+#: po/custom/fromJson.txt:3755
 msgid "Mini-Rocket Artillery Viper Wheels"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Wpn-Rocket02-MRL.name
 #. data/base/stats/weapons.json: $.Rocket-MRL.name
-#: po/custom/fromJson.txt:3727
+#: po/custom/fromJson.txt:3759
 msgid "Mini-Rocket Artillery"
 msgstr ""
 
@@ -10811,25 +10837,25 @@ msgstr ""
 #. data/base/stats/research.json: $.R-Defense-MRL.name
 #. data/mp/stats/research.json: $.R-Defense-MRL.name
 #. data/mp/stats/structure.json: $.Emplacement-MRL-pit.name
-#: po/custom/fromJson.txt:3732
+#: po/custom/fromJson.txt:3764
 msgid "Mini-Rocket Battery"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/templates.json: $.CobraPODHTracks.name
-#: po/custom/fromJson.txt:3735
+#: po/custom/fromJson.txt:3767
 msgid "Mini-Rocket Cobra Half-Tracks"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/templates.json: $.CobraPODTracks.name
-#: po/custom/fromJson.txt:3738
+#: po/custom/fromJson.txt:3770
 msgid "Mini-Rocket Cobra Tracks"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Defense-Tower06.name
-#: po/custom/fromJson.txt:3741
+#: po/custom/fromJson.txt:3773
 msgid "Mini-Rocket Guard Tower"
 msgstr ""
 
@@ -10838,7 +10864,7 @@ msgstr ""
 #. data/base/stats/weapons.json: $.Rocket-Pod.name
 #. data/mp/stats/research.json: $.R-Wpn-Rocket05-MiniPod.name
 #. data/mp/stats/weapons.json: $.Rocket-Pod.name
-#: po/custom/fromJson.txt:3747
+#: po/custom/fromJson.txt:3779
 msgid "Mini-Rocket Pod"
 msgstr ""
 
@@ -10846,40 +10872,42 @@ msgstr ""
 #. data/base/stats/structure.json: $.GuardTower6.name
 #. data/mp/stats/research.json: $.R-Defense-Tower06.name
 #. data/mp/stats/structure.json: $.GuardTower6.name
-#: po/custom/fromJson.txt:3752
+#: po/custom/fromJson.txt:3784
 msgid "Mini-Rocket Tower"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/templates.json: $.ViperPODHalfTracks.name
-#: po/custom/fromJson.txt:3761
+#: po/custom/fromJson.txt:3793
 msgid "Mini-Rocket Viper Half Track"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/templates.json: $.ViperPODWheels.name
 #. data/mp/stats/templates.json: $.ViperPODWheels.name
-#: po/custom/fromJson.txt:3765
+#: po/custom/fromJson.txt:3797
 msgid "Mini-Rocket Viper Wheels"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/messages/resmessages3.json: $.RES_W_MS_AC1.text[2]
 #. data/mp/messages/resmessages3.json: $.RES_W_MS_AC2.text[2]
-#: po/custom/fromJson.txt:3769
+#: po/custom/fromJson.txt:3802
+#, no-c-format
 msgid "Missile accuracy +10%"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages3.json: $.RES_W_MS_AC2.text[1]
 #. data/mp/messages/resmessages3.json: $.RES_W_MS_AC2.text[1]
-#: po/custom/fromJson.txt:3773
+#: po/custom/fromJson.txt:3806
 msgid "Missile actively seeks and homes on targets"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/messages/resmessages3.json: $.RES_W_MS_D1.text[2]
-#: po/custom/fromJson.txt:3776
+#: po/custom/fromJson.txt:3810
+#, no-c-format
 msgid "Missile damage +25%"
 msgstr ""
 
@@ -10887,14 +10915,15 @@ msgstr ""
 #. data/mp/stats/research.json: $.R-Defense-Super-Missile.name
 #. data/mp/stats/structure.json: $.X-Super-Missile.name
 #. data/mp/stats/weapons.json: $.MissileSuper.name
-#: po/custom/fromJson.txt:3781
+#: po/custom/fromJson.txt:3815
 msgid "Missile Fortress"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/messages/resmessages3.json: $.RES_W_MS_ROF1.text[2]
 #. data/mp/messages/resmessages3.json: $.RES_W_SMS_ROF1.text[2]
-#: po/custom/fromJson.txt:3785
+#: po/custom/fromJson.txt:3820
+#, no-c-format
 msgid "Missile reload time -15%"
 msgstr ""
 
@@ -10903,21 +10932,21 @@ msgstr ""
 #. data/base/messages/resmessages3.json: $.RES_W_MS_AC2.text[0]
 #. data/base/messages/resmessages3.json: $.RES_W_MS_D1.text[0]
 #. ... + 7 refs
-#: po/custom/fromJson.txt:3797
+#: po/custom/fromJson.txt:3832
 msgid "Missile Upgrade"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages3.json: $.RES_W_MS_ROF1.text[1]
 #. data/mp/messages/resmessages3.json: $.RES_W_MS_ROF1.text[1]
-#: po/custom/fromJson.txt:3801
+#: po/custom/fromJson.txt:3836
 msgid "Missiles detect and lock-on to targets while loading"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Sys-MobileRepairTurret01.name
 #. data/mp/stats/research.json: $.R-Sys-MobileRepairTurret01.name
-#: po/custom/fromJson.txt:3805
+#: po/custom/fromJson.txt:3840
 msgid "Mobile Repair Turret"
 msgstr ""
 
@@ -10926,13 +10955,13 @@ msgstr ""
 #. data/base/messages/resmessagesall.json: $.RES_V_B09.text[1]
 #. data/mp/messages/resmessages3.json: $.RES_V_B10.text[1]
 #. data/mp/messages/resmessagesall.json: $.RES_V_B09.text[1]
-#: po/custom/fromJson.txt:3811
+#: po/custom/fromJson.txt:3846
 msgid "More armor and body points than Python"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/messages/resmessagesall.json: $.RES_V_B13.text[1]
-#: po/custom/fromJson.txt:3814
+#: po/custom/fromJson.txt:3849
 msgid "More armor and body points than Vengeance"
 msgstr ""
 
@@ -10940,49 +10969,51 @@ msgstr ""
 #. data/mp/messages/resmessages12.json: $.RES_W_M_AC1.text[2]
 #. data/mp/messages/resmessages23.json: $.RES_W_M_AC2.text[2]
 #. data/mp/messages/resmessages3.json: $.RES_W_M_AC3.text[2]
-#: po/custom/fromJson.txt:3819
+#: po/custom/fromJson.txt:3855
+#, no-c-format
 msgid "Mortar accuracy +10%"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Wpn-Mortar-ROF02.name
 #. data/mp/stats/research.json: $.R-Wpn-Mortar-ROF02.name
-#: po/custom/fromJson.txt:3823
+#: po/custom/fromJson.txt:3859
 msgid "Mortar Autoloader Mk2"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Wpn-Mortar-ROF03.name
 #. data/mp/stats/research.json: $.R-Wpn-Mortar-ROF03.name
-#: po/custom/fromJson.txt:3827
+#: po/custom/fromJson.txt:3863
 msgid "Mortar Autoloader Mk3"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Wpn-Mortar-ROF01.name
 #. data/mp/stats/research.json: $.R-Wpn-Mortar-ROF01.name
-#: po/custom/fromJson.txt:3831
+#: po/custom/fromJson.txt:3867
 msgid "Mortar Autoloader"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/templates.json: $.CobraMortarHalfTrack.name
 #. data/mp/stats/templates.json: $.CobraMortarHalfTrack.name
-#: po/custom/fromJson.txt:3835
+#: po/custom/fromJson.txt:3871
 msgid "Mortar Cobra Half-tracks"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/messages/resmessages1.json: $.RES_W_M_D1.text[2]
 #. data/mp/messages/resmessages2.json: $.RES_W_M_D4.text[2]
-#: po/custom/fromJson.txt:3839
+#: po/custom/fromJson.txt:3876
+#, no-c-format
 msgid "Mortar damage +25%"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Wpn-Mortar-ROF04.name
 #. data/mp/stats/research.json: $.R-Wpn-Mortar-ROF04.name
-#: po/custom/fromJson.txt:3843
+#: po/custom/fromJson.txt:3880
 msgid "Mortar Fast Loader"
 msgstr ""
 
@@ -10991,21 +11022,22 @@ msgstr ""
 #. data/base/stats/structure.json: $.Emplacement-MortarPit01.name
 #. data/mp/stats/research.json: $.R-Defense-MortarPit.name
 #. data/mp/stats/structure.json: $.Emplacement-MortarPit01.name
-#: po/custom/fromJson.txt:3849
+#: po/custom/fromJson.txt:3886
 msgid "Mortar Pit"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/messages/resmessages12.json: $.RES_W_M_ROF1.text[2]
 #. data/mp/messages/resmessages3.json: $.RES_W_M_ROF4.text[2]
-#: po/custom/fromJson.txt:3853
+#: po/custom/fromJson.txt:3891
+#, no-c-format
 msgid "Mortar reload time -10%"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Wpn-Mortar-Acc01.name
 #. data/mp/stats/research.json: $.R-Wpn-Mortar-Acc01.name
-#: po/custom/fromJson.txt:3857
+#: po/custom/fromJson.txt:3895
 msgid "Mortar Targeting Computer"
 msgstr ""
 
@@ -11014,50 +11046,50 @@ msgstr ""
 #. data/base/stats/weapons.json: $.Mortar1Mk1.name
 #. data/mp/stats/research.json: $.R-Wpn-Mortar01Lt.name
 #. data/mp/stats/weapons.json: $.Mortar1Mk1.name
-#: po/custom/fromJson.txt:3869
+#: po/custom/fromJson.txt:3907
 msgid "Mortar"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/structure.json: $.Emplacement-MRL-pit.name
-#: po/custom/fromJson.txt:3872
+#: po/custom/fromJson.txt:3910
 msgid "MRL Emplacement"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/research.json: $.R-Vehicle-Body14.name
-#: po/custom/fromJson.txt:3875
+#: po/custom/fromJson.txt:3913
 msgid "Multi Turret Body - Dragon"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages23.json: $.RES_W_MG4.text[1]
 #. data/mp/messages/resmessages23.json: $.RES_W_MG4.text[1]
-#: po/custom/fromJson.txt:3879
+#: po/custom/fromJson.txt:3917
 msgid "Multi-barrel, rapid-fire machinegun"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/features.json: $.Nanolab.name
-#: po/custom/fromJson.txt:3882
+#: po/custom/fromJson.txt:3920
 msgid "Nanolab"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/messages/resmessagesall.json: $.RES_W_LASSAT.text[3]
-#: po/custom/fromJson.txt:3885
+#: po/custom/fromJson.txt:3923
 msgid "Narrow area of effect"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/templates.json: $.A-Retrib-Trk-Needle.name
-#: po/custom/fromJson.txt:3891
+#: po/custom/fromJson.txt:3929
 msgid "Needle Gun Retribution Tracks"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/templates.json: $.A-Tiger-Trk-Needle.name
-#: po/custom/fromJson.txt:3894
+#: po/custom/fromJson.txt:3932
 msgid "Needle Gun Tiger Tracks"
 msgstr ""
 
@@ -11066,13 +11098,13 @@ msgstr ""
 #. data/base/stats/structure.json: $.GuardTower-Rail1.name
 #. data/mp/stats/research.json: $.R-Defense-GuardTower-Rail1.name
 #. data/mp/stats/structure.json: $.GuardTower-Rail1.name
-#: po/custom/fromJson.txt:3900
+#: po/custom/fromJson.txt:3938
 msgid "Needle Gun Tower"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/templates.json: $.A-Veng-Trk-Needle.name
-#: po/custom/fromJson.txt:3903
+#: po/custom/fromJson.txt:3941
 msgid "Needle Gun Vengeance Tracks"
 msgstr ""
 
@@ -11081,13 +11113,13 @@ msgstr ""
 #. data/base/stats/weapons.json: $.RailGun1Mk1.name
 #. data/mp/stats/research.json: $.R-Wpn-RailGun01.name
 #. data/mp/stats/weapons.json: $.RailGun1Mk1.name
-#: po/custom/fromJson.txt:3909
+#: po/custom/fromJson.txt:3947
 msgid "Needle Gun"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Cyborg-Wpn-Rail1.name
-#: po/custom/fromJson.txt:3912
+#: po/custom/fromJson.txt:3950
 msgid "Needle Gunner Cyborg"
 msgstr ""
 
@@ -11095,21 +11127,21 @@ msgstr ""
 #. data/base/stats/templates.json: $.Cyb-Rail1-GROUND.name
 #. data/mp/stats/templates.json: $.Cyb-Rail1-GROUND.name
 #. data/mp/stats/templates.json: $.MP-Cyb-Needle-GRD.name
-#: po/custom/fromJson.txt:3917
+#: po/custom/fromJson.txt:3955
 msgid "Needle Gunner"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Struc-Research-Upgrade08.name
 #. data/mp/stats/research.json: $.R-Struc-Research-Upgrade08.name
-#: po/custom/fromJson.txt:3921
+#: po/custom/fromJson.txt:3959
 msgid "Neural Synapse Research Brain Mk2"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Struc-Research-Upgrade09.name
 #. data/mp/stats/research.json: $.R-Struc-Research-Upgrade09.name
-#: po/custom/fromJson.txt:3925
+#: po/custom/fromJson.txt:3963
 msgid "Neural Synapse Research Brain Mk3"
 msgstr ""
 
@@ -11118,13 +11150,13 @@ msgstr ""
 #. data/base/stats/research.json: $.R-Struc-Research-Upgrade07.name
 #. data/mp/messages/resmessages3.json: $.RES_ST_RU7.text[1]
 #. data/mp/stats/research.json: $.R-Struc-Research-Upgrade07.name
-#: po/custom/fromJson.txt:3931
+#: po/custom/fromJson.txt:3969
 msgid "Neural Synapse Research Brain"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/messages/resmessagesall.json: $.RES_W_LASSAT.text[0]
-#: po/custom/fromJson.txt:3940
+#: po/custom/fromJson.txt:3978
 msgid "New Advanced Weapon Available"
 msgstr ""
 
@@ -11133,14 +11165,14 @@ msgstr ""
 #. data/base/messages/resmessages3.json: $.RES_W_MS_MART.text[0]
 #. data/mp/messages/resmessages3.json: $.RES_W_MS_HART.text[0]
 #. data/mp/messages/resmessages3.json: $.RES_W_MS_MART.text[0]
-#: po/custom/fromJson.txt:3952
+#: po/custom/fromJson.txt:3990
 msgid "New Artillery Missile Turret Available"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages1.json: $.RES_ST_RFU1.text[1]
 #. data/mp/messages/resmessages1.json: $.RES_ST_RFU1.text[1]
-#: po/custom/fromJson.txt:3956
+#: po/custom/fromJson.txt:3994
 msgid "New automated repair techniques"
 msgstr ""
 
@@ -11149,34 +11181,34 @@ msgstr ""
 #. data/base/messages/resmessages1.json: $.RES_ST_CR1.text[0]
 #. data/base/messages/resmessages1.json: $.RES_ST_FCY1.text[0]
 #. ... + 7 refs
-#: po/custom/fromJson.txt:3962
+#: po/custom/fromJson.txt:4000
 msgid "New Base Structure Available"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages1.json: $.RES_C_CT1.text[1]
 #. data/mp/messages/resmessages1.json: $.RES_C_CT1.text[1]
-#: po/custom/fromJson.txt:3966
+#: po/custom/fromJson.txt:4004
 msgid "New battlefield computer system"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessagesall.json: $.RES_DF_HCW1.text[0]
 #. data/mp/messages/resmessagesall.json: $.RES_DF_HCW1.text[0]
-#: po/custom/fromJson.txt:3976
+#: po/custom/fromJson.txt:4014
 msgid "New Construction Options Available"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages3.json: $.RES_CY_JP1.text[0]
 #. data/mp/messages/resmessages3.json: $.RES_CY_JP1.text[0]
-#: po/custom/fromJson.txt:3990
+#: po/custom/fromJson.txt:4028
 msgid "New Cyborg Research Available"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/messages/resmessagesall.json: $.RES_SY_RC.text[0]
-#: po/custom/fromJson.txt:3999
+#: po/custom/fromJson.txt:4037
 msgid "New Electronic Technology Discovered"
 msgstr ""
 
@@ -11185,7 +11217,7 @@ msgstr ""
 #. data/base/messages/resmessages3.json: $.RES_W_LAS2.text[0]
 #. data/mp/messages/resmessages3.json: $.RES_W_LAS1.text[0]
 #. ... + 2 refs
-#: po/custom/fromJson.txt:4023
+#: po/custom/fromJson.txt:4061
 msgid "New Laser Weapon Available"
 msgstr ""
 
@@ -11194,28 +11226,28 @@ msgstr ""
 #. data/base/messages/resmessages3.json: $.RES_W_ASM_BB.text[0]
 #. data/mp/messages/resmessages3.json: $.RES_W_ASM_AT.text[0]
 #. data/mp/messages/resmessages3.json: $.RES_W_ASM_BB.text[0]
-#: po/custom/fromJson.txt:4029
+#: po/custom/fromJson.txt:4067
 msgid "New Missile Turret Available"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages1.json: $.RES_V_B12.text[0]
 #. data/mp/messages/resmessages1.json: $.RES_V_B12.text[0]
-#: po/custom/fromJson.txt:4036
+#: po/custom/fromJson.txt:4074
 msgid "New Paradigm Heavy Body"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages1.json: $.RES_V_B04.text[0]
 #. data/mp/messages/resmessages1.json: $.RES_V_B04.text[0]
-#: po/custom/fromJson.txt:4040
+#: po/custom/fromJson.txt:4078
 msgid "New Paradigm Light Body"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages1.json: $.RES_V_B08.text[0]
 #. data/mp/messages/resmessages1.json: $.RES_V_B08.text[0]
-#: po/custom/fromJson.txt:4044
+#: po/custom/fromJson.txt:4082
 msgid "New Paradigm Medium body"
 msgstr ""
 
@@ -11224,21 +11256,21 @@ msgstr ""
 #. data/base/messages/resmessages3.json: $.RES_V_P_V3.text[1]
 #. data/mp/messages/resmessages3.json: $.RES_V_P_V2.text[1]
 #. data/mp/messages/resmessages3.json: $.RES_V_P_V3.text[1]
-#: po/custom/fromJson.txt:4050
+#: po/custom/fromJson.txt:4088
 msgid "New power efficient propulsion"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages23.json: $.RES_POWU1.text[1]
 #. data/base/messages/resmessages3.json: $.RES_POWU2.text[1]
-#: po/custom/fromJson.txt:4054
+#: po/custom/fromJson.txt:4092
 msgid "New Power Generation Technology"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessagesall.json: $.RES_V_P_V1.text[0]
 #. data/mp/messages/resmessagesall.json: $.RES_V_P_V1.text[0]
-#: po/custom/fromJson.txt:4058
+#: po/custom/fromJson.txt:4096
 msgid "New Propulsion Available for Design"
 msgstr ""
 
@@ -11247,7 +11279,7 @@ msgstr ""
 #. data/base/messages/resmessages1.json: $.RES_TRACK1.text[0]
 #. data/base/messages/resmessages1.json: $.RES_V_P_H1.text[0]
 #. ... + 5 refs
-#: po/custom/fromJson.txt:4064
+#: po/custom/fromJson.txt:4102
 msgid "New Propulsion Available"
 msgstr ""
 
@@ -11256,14 +11288,14 @@ msgstr ""
 #. data/base/messages/resmessages3.json: $.RES_W_RAIL2.text[0]
 #. data/base/messages/resmessages3.json: $.RES_W_RAIL3.text[0]
 #. ... + 3 refs
-#: po/custom/fromJson.txt:4076
+#: po/custom/fromJson.txt:4114
 msgid "New Rail Gun Available"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages1.json: $.RES_REPAI1.text[1]
 #. data/mp/messages/resmessages1.json: $.RES_REPAI1.text[1]
-#: po/custom/fromJson.txt:4080
+#: po/custom/fromJson.txt:4118
 msgid "New Repair Facility Repairs Damaged Units"
 msgstr ""
 
@@ -11272,14 +11304,14 @@ msgstr ""
 #. data/base/messages/resmessages3.json: $.RES_SY_ADEF.text[0]
 #. data/base/messages/resmessages3.json: $.RES_SY_ASTRUC.text[0]
 #. ... + 6 refs
-#: po/custom/fromJson.txt:4086
+#: po/custom/fromJson.txt:4124
 msgid "New Repair Technology Discovered"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages1.json: $.RES_C_SL1.text[3]
 #. data/mp/messages/resmessages1.json: $.RES_C_SL1.text[3]
-#: po/custom/fromJson.txt:4090
+#: po/custom/fromJson.txt:4128
 msgid "New research options available"
 msgstr ""
 
@@ -11288,7 +11320,7 @@ msgstr ""
 #. data/base/messages/resmessages12.json: $.RES_W_RK_HvAT.text[0]
 #. data/base/messages/resmessages12.json: $.RES_W_RK_IDF.text[0]
 #. ... + 9 refs
-#: po/custom/fromJson.txt:4104
+#: po/custom/fromJson.txt:4142
 msgid "New Rocket Available"
 msgstr ""
 
@@ -11297,26 +11329,26 @@ msgstr ""
 #. data/base/messages/resmessages3.json: $.RES_W_MS_LtSAM1.text[0]
 #. data/mp/messages/resmessages3.json: $.RES_W_MS_HvSAM1.text[0]
 #. data/mp/messages/resmessages3.json: $.RES_W_MS_LtSAM1.text[0]
-#: po/custom/fromJson.txt:4110
+#: po/custom/fromJson.txt:4148
 msgid "New SAM Turret Available"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/messages/resmessagesall.json: $.RES_SY_S_WST.text[0]
-#: po/custom/fromJson.txt:4113
+#: po/custom/fromJson.txt:4151
 msgid "New System Available"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/messages/resmessagesall.json: $.RES_SY_SUE1.text[0]
-#: po/custom/fromJson.txt:4116
+#: po/custom/fromJson.txt:4154
 msgid "New Systems Sensor Available"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/messages/resmessagesall.json: $.RES_SY_S_UP.text[0]
 #. data/mp/messages/resmessagesall.json: $.RES_SY_S_WS.text[0]
-#: po/custom/fromJson.txt:4120
+#: po/custom/fromJson.txt:4158
 msgid "New Systems Structure Available"
 msgstr ""
 
@@ -11325,7 +11357,7 @@ msgstr ""
 #. data/base/messages/resmessages23.json: $.RES_SY_VSTW1.text[0]
 #. data/base/messages/resmessagesall.json: $.RES_SY_CBSTW1.text[0]
 #. ... + 6 refs
-#: po/custom/fromJson.txt:4126
+#: po/custom/fromJson.txt:4164
 msgid "New Systems Tower Available"
 msgstr ""
 
@@ -11334,14 +11366,14 @@ msgstr ""
 #. data/base/messages/resmessages12.json: $.RES_SY_CBSTU1.text[0]
 #. data/mp/messages/resmessages1.json: $.RES_C_CT1.text[0]
 #. data/mp/messages/resmessages12.json: $.RES_SY_CBSTU1.text[0]
-#: po/custom/fromJson.txt:4132
+#: po/custom/fromJson.txt:4170
 msgid "New Systems Turret Available for Design"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessagesall.json: $.RES_SENSO1.text[0]
 #. data/mp/messages/resmessagesall.json: $.RES_SENSO1.text[0]
-#: po/custom/fromJson.txt:4136
+#: po/custom/fromJson.txt:4174
 msgid "New Systems Turret Available For Design"
 msgstr ""
 
@@ -11349,153 +11381,153 @@ msgstr ""
 #. data/base/messages/resmessagesall.json: $.RES_SY_SU1.text[1]
 #. data/mp/messages/resmessagesall.json: $.RES_SY_SU1.text[1]
 #. data/mp/messages/resmessagesall.json: $.RES_SY_SUE1.text[1]
-#: po/custom/fromJson.txt:4151
+#: po/custom/fromJson.txt:4189
 msgid "New Thermal Emissions detection"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/messages/resmessagesall.json: $.RES_W_BMB6.text[0]
-#: po/custom/fromJson.txt:4154
+#: po/custom/fromJson.txt:4192
 msgid "New VTOL Missile Launcher"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/structure.json: $.NEXUSCWall.name
-#: po/custom/fromJson.txt:4163
+#: po/custom/fromJson.txt:4201
 msgid "NEXUS CWall"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages3.json: $.RES_V_B10.text[0]
 #. data/mp/messages/resmessages3.json: $.RES_V_B10.text[0]
-#: po/custom/fromJson.txt:4167
+#: po/custom/fromJson.txt:4205
 msgid "NEXUS Heavy Body"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages3.json: $.RES_SY_RESU1.text[1]
 #. data/mp/messages/resmessages3.json: $.RES_SY_RESU1.text[1]
-#: po/custom/fromJson.txt:4171
+#: po/custom/fromJson.txt:4209
 msgid "NEXUS Intruder Program analyzed"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Sys-Resistance.name
-#: po/custom/fromJson.txt:4174
+#: po/custom/fromJson.txt:4212
 msgid "NEXUS Intruder Program"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages3.json: $.RES_V_B03.text[0]
 #. data/mp/messages/resmessages3.json: $.RES_V_B03.text[0]
-#: po/custom/fromJson.txt:4178
+#: po/custom/fromJson.txt:4216
 msgid "NEXUS Light Body"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/research.json: $.R-Sys-SpyTower.name
 #. data/mp/stats/structure.json: $.Sys-SpyTower.name
-#: po/custom/fromJson.txt:4182
+#: po/custom/fromJson.txt:4220
 msgid "Nexus Link Tower"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/research.json: $.R-Sys-SpyTurret.name
 #. data/mp/stats/weapons.json: $.SpyTurret01.name
-#: po/custom/fromJson.txt:4186
+#: po/custom/fromJson.txt:4224
 msgid "Nexus Link Turret"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages3.json: $.RES_V_B07.text[0]
 #. data/mp/messages/resmessages3.json: $.RES_V_B07.text[0]
-#: po/custom/fromJson.txt:4190
+#: po/custom/fromJson.txt:4228
 msgid "NEXUS Medium Body"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/structure.json: $.NX-ANTI-SATSite.name
-#: po/custom/fromJson.txt:4193
+#: po/custom/fromJson.txt:4231
 msgid "Nexus Missile Silo"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Sys-Resistance-Upgrade02.name
-#: po/custom/fromJson.txt:4196
+#: po/custom/fromJson.txt:4234
 msgid "NEXUS Resistance Circuits Mk2"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Sys-Resistance-Upgrade03.name
-#: po/custom/fromJson.txt:4199
+#: po/custom/fromJson.txt:4237
 msgid "NEXUS Resistance Circuits Mk3"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Sys-Resistance-Upgrade01.name
-#: po/custom/fromJson.txt:4205
+#: po/custom/fromJson.txt:4243
 msgid "NEXUS Resistance Circuits"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/structure.json: $.NEXUSWall.name
-#: po/custom/fromJson.txt:4208
+#: po/custom/fromJson.txt:4246
 msgid "NEXUS Wall"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/multiplay/skirmish/nexus.json: $.AI.name
-#: po/custom/fromJson.txt:4211
+#: po/custom/fromJson.txt:4249
 msgid "Nexus"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/challenges/noplace.json: $.challenge.name
-#: po/custom/fromJson.txt:4214
+#: po/custom/fromJson.txt:4252
 msgid "No Place To Hide"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/multiplay/skirmish/bonecrusher.json: $.AI.tip
-#: po/custom/fromJson.txt:4217
+#: po/custom/fromJson.txt:4255
 msgid "Non-Cheating. Hard. Fun. Crush!"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/multiplay/skirmish/nb_generic.json: $.AI.name
-#: po/custom/fromJson.txt:4220
+#: po/custom/fromJson.txt:4258
 msgid "NullBot"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/messages/resmessagesall.json: $.RES_SY_SUE1.text[2]
-#: po/custom/fromJson.txt:4223
+#: po/custom/fromJson.txt:4261
 msgid "Objects become difficult to locate near it"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/structure.json: $.A0ResourceExtractor.name
 #. data/mp/stats/structure.json: $.A0ResourceExtractor.name
-#: po/custom/fromJson.txt:4227
+#: po/custom/fromJson.txt:4265
 msgid "Oil Derrick"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/features.json: $.OilDrum.name
-#: po/custom/fromJson.txt:4230
+#: po/custom/fromJson.txt:4268
 msgid "Oil Drum"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/features.json: $.OilResource.name
-#: po/custom/fromJson.txt:4233
+#: po/custom/fromJson.txt:4271
 msgid "Oil Resource"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages3.json: $.RES_W_MS_AC1.text[1]
 #. data/mp/messages/resmessages3.json: $.RES_W_MS_AC1.text[1]
-#: po/custom/fromJson.txt:4237
+#: po/custom/fromJson.txt:4275
 msgid "On-board computer predicts target movement"
 msgstr ""
 
@@ -11504,20 +11536,20 @@ msgstr ""
 #. data/base/messages/resmessages3.json: $.RES_SY_AVEH.text[2]
 #. data/mp/messages/resmessages3.json: $.RES_SY_ACYB.text[2]
 #. ... + 2 refs
-#: po/custom/fromJson.txt:4243
+#: po/custom/fromJson.txt:4281
 msgid "On-board diagnostic and repair systems"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/messages/resmessagesall.json: $.RES_SY_RC.text[2]
-#: po/custom/fromJson.txt:4246
+#: po/custom/fromJson.txt:4284
 msgid "On-board resistance circuit systems"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages1.json: $.RES_REPAI1.text[3]
 #. data/mp/messages/resmessages1.json: $.RES_REPAI1.text[3]
-#: po/custom/fromJson.txt:4255
+#: po/custom/fromJson.txt:4293
 msgid "Or select the Repair Facility as a unit's target"
 msgstr ""
 
@@ -11526,26 +11558,26 @@ msgstr ""
 #. data/base/messages/resmessagesall.json: $.RES_SY_CBSTW1.text[2]
 #. data/mp/messages/resmessages12.json: $.RES_SY_CBSTU1.text[2]
 #. data/mp/messages/resmessagesall.json: $.RES_SY_CBSTW1.text[2]
-#: po/custom/fromJson.txt:4261
+#: po/custom/fromJson.txt:4299
 msgid "Orders assigned indirect fire units to fire at the enemy batteries"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/ruleset.json: $.name
-#: po/custom/fromJson.txt:4270
+#: po/custom/fromJson.txt:4308
 msgid "Original Campaign"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/ruleset.json: $.name
-#: po/custom/fromJson.txt:4273
+#: po/custom/fromJson.txt:4311
 msgid "Original Skirmish"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/body.json: $.Body6SUPP.name
 #. data/mp/stats/body.json: $.Body6SUPP.name
-#: po/custom/fromJson.txt:4277
+#: po/custom/fromJson.txt:4315
 msgid "Panther"
 msgstr ""
 
@@ -11554,167 +11586,167 @@ msgstr ""
 #. data/base/stats/structure.json: $.Emplacement-RotMor.name
 #. data/mp/stats/research.json: $.R-Defense-RotMor.name
 #. data/mp/stats/structure.json: $.Emplacement-RotMor.name
-#: po/custom/fromJson.txt:4283
+#: po/custom/fromJson.txt:4321
 msgid "Pepperpot Pit"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/weapons.json: $.Mortar3ROTARYMk1.name
 #. data/mp/stats/weapons.json: $.Mortar3ROTARYMk1.name
-#: po/custom/fromJson.txt:4287
+#: po/custom/fromJson.txt:4325
 msgid "Pepperpot"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/templates.json: $.SK-Mantis-VTOL-PBB.name
-#: po/custom/fromJson.txt:4290
+#: po/custom/fromJson.txt:4328
 msgid "Phosphor Bomb Bay Mantis VTOL"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Wpn-Bomb03.name
 #. data/mp/stats/research.json: $.R-Wpn-Bomb03.name
-#: po/custom/fromJson.txt:4294
+#: po/custom/fromJson.txt:4332
 msgid "Phosphor Bomb Bay"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/templates.json: $.BabaPickUp.name
 #. data/mp/stats/templates.json: $.BabaPickUp.name
-#: po/custom/fromJson.txt:4298
+#: po/custom/fromJson.txt:4336
 msgid "Pick-Up Truck"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Defense-WallUpgrade08.name
 #. data/mp/stats/research.json: $.R-Defense-WallUpgrade08.name
-#: po/custom/fromJson.txt:4302
+#: po/custom/fromJson.txt:4340
 msgid "Plascrete Mk2"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Defense-WallUpgrade09.name
 #. data/mp/stats/research.json: $.R-Defense-WallUpgrade09.name
-#: po/custom/fromJson.txt:4306
+#: po/custom/fromJson.txt:4344
 msgid "Plascrete Mk3"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Defense-WallUpgrade07.name
 #. data/mp/stats/research.json: $.R-Defense-WallUpgrade07.name
-#: po/custom/fromJson.txt:4310
+#: po/custom/fromJson.txt:4348
 msgid "Plascrete"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/research.json: $.R-Defense-PlasmaCannon.name
 #. data/mp/stats/structure.json: $.Emplacement-PlasmaCannon.name
-#: po/custom/fromJson.txt:4314
+#: po/custom/fromJson.txt:4352
 msgid "Plasma Cannon Emplacement"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/messages/resmessagesall.json: $.RES_EMP_PLASCAN.text[1]
 #. data/mp/messages/resmessagesall.json: $.RES_W_PLASCAN.text[1]
-#: po/custom/fromJson.txt:4318
+#: po/custom/fromJson.txt:4356
 msgid "Plasma Cannon firing plasma"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/templates.json: $.WyvernPlasmaCTracks.name
-#: po/custom/fromJson.txt:4321
+#: po/custom/fromJson.txt:4359
 msgid "Plasma Cannon Wyvern Tracks"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/research.json: $.R-Wpn-PlasmaCannon.name
 #. data/mp/stats/weapons.json: $.Laser4-PlasmaCannon.name
-#: po/custom/fromJson.txt:4325
+#: po/custom/fromJson.txt:4363
 msgid "Plasma Cannon"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/research.json: $.R-Wpn-Bomb05.name
-#: po/custom/fromJson.txt:4328
+#: po/custom/fromJson.txt:4366
 msgid "Plasmite Bomb"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/messages/resmessagesall.json: $.RES_PLFL.text[1]
-#: po/custom/fromJson.txt:4331
+#: po/custom/fromJson.txt:4369
 msgid "Plasmite Flame-thrower"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/research.json: $.R-Defense-PlasmiteFlamer.name
 #. data/mp/stats/structure.json: $.Plasmite-flamer-bunker.name
-#: po/custom/fromJson.txt:4335
+#: po/custom/fromJson.txt:4373
 msgid "Plasmite Flamer Bunker"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/research.json: $.R-Wpn-Plasmite-Flamer.name
 #. data/mp/stats/weapons.json: $.PlasmiteFlamer.name
-#: po/custom/fromJson.txt:4339
+#: po/custom/fromJson.txt:4377
 msgid "Plasmite Flamer"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/templates.json: $.SK-Retre-VTOL-Plasmite.name
-#: po/custom/fromJson.txt:4342
+#: po/custom/fromJson.txt:4380
 msgid "Plasmite Retribution VTOL"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/research.json: $.R-Defense-WallUpgrade11.name
-#: po/custom/fromJson.txt:4345
+#: po/custom/fromJson.txt:4383
 msgid "Plasteel Mk2"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/research.json: $.R-Defense-WallUpgrade12.name
-#: po/custom/fromJson.txt:4348
+#: po/custom/fromJson.txt:4386
 msgid "Plasteel Mk3"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/research.json: $.R-Defense-WallUpgrade10.name
-#: po/custom/fromJson.txt:4351
+#: po/custom/fromJson.txt:4389
 msgid "Plasteel"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages1.json: $.RES_V_B08.text[3]
 #. data/mp/messages/resmessages1.json: $.RES_V_B08.text[3]
-#: po/custom/fromJson.txt:4355
+#: po/custom/fromJson.txt:4393
 msgid "Power cost and production time similar to Cobra"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages1.json: $.RES_V_B04.text[3]
 #. data/mp/messages/resmessages1.json: $.RES_V_B04.text[3]
-#: po/custom/fromJson.txt:4359
+#: po/custom/fromJson.txt:4397
 msgid "Power cost and production time similar to Viper"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages1.json: $.RES_V_B12.text[3]
 #. data/mp/messages/resmessages1.json: $.RES_V_B12.text[3]
-#: po/custom/fromJson.txt:4363
+#: po/custom/fromJson.txt:4401
 msgid "Power cost and production time the same as Python"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/structure.json: $.A0PowerGenerator.name
 #. data/mp/stats/structure.json: $.A0PowerGenerator.name
-#: po/custom/fromJson.txt:4367
+#: po/custom/fromJson.txt:4405
 msgid "Power Generator"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages1.json: $.RES_POWMD1.text[0]
 #. data/mp/messages/resmessages1.json: $.RES_POWMD1.text[0]
-#: po/custom/fromJson.txt:4371
+#: po/custom/fromJson.txt:4409
 msgid "Power Module Available"
 msgstr ""
 
@@ -11723,78 +11755,80 @@ msgstr ""
 #. data/base/stats/structure.json: $.A0PowMod1.name
 #. data/mp/stats/research.json: $.R-Struc-PowerModuleMk1.name
 #. data/mp/stats/structure.json: $.A0PowMod1.name
-#: po/custom/fromJson.txt:4377
+#: po/custom/fromJson.txt:4415
 msgid "Power Module"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/messages/resmessages23.json: $.RES_POWU1.text[2]
-#: po/custom/fromJson.txt:4380
+#: po/custom/fromJson.txt:4419
+#, no-c-format
 msgid "Power output +25%"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/messages/resmessages3.json: $.RES_POWU2.text[2]
-#: po/custom/fromJson.txt:4383
+#: po/custom/fromJson.txt:4423
+#, no-c-format
 msgid "Power output +30%"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/messages.json: $.MSG2.text[0]
-#: po/custom/fromJson.txt:4386
+#: po/custom/fromJson.txt:4426
 msgid "Power Research Completed"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/messages/resmessagesall.json: $.RES_EMP_CANT.text[1]
-#: po/custom/fromJson.txt:4389
+#: po/custom/fromJson.txt:4429
 msgid "Powerful Electronic magnetic pulse weapon"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/features.json: $.Powlab.name
-#: po/custom/fromJson.txt:4392
+#: po/custom/fromJson.txt:4432
 msgid "Powerlab"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages1.json: $.RES_ST_FCY1.text[2]
 #. data/mp/messages/resmessages1.json: $.RES_ST_FCY1.text[2]
-#: po/custom/fromJson.txt:4400
+#: po/custom/fromJson.txt:4440
 msgid "Produces Cyborgs"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages1.json: $.RES_V_B11.text[0]
 #. data/mp/messages/resmessages1.json: $.RES_V_B11.text[0]
-#: po/custom/fromJson.txt:4410
+#: po/custom/fromJson.txt:4450
 msgid "Project Heavy Body"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages1.json: $.RES_V_B01.text[0]
 #. data/mp/messages/resmessages1.json: $.RES_V_B01.text[0]
-#: po/custom/fromJson.txt:4414
+#: po/custom/fromJson.txt:4454
 msgid "Project Light Body"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages1.json: $.RES_V_B05.text[0]
 #. data/mp/messages/resmessages1.json: $.RES_V_B05.text[0]
-#: po/custom/fromJson.txt:4418
+#: po/custom/fromJson.txt:4458
 msgid "Project Medium Body"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages1.json: $.RES_W_FL_D1.text[1]
 #. data/mp/messages/resmessages1.json: $.RES_W_FL_D1.text[1]
-#: po/custom/fromJson.txt:4422
+#: po/custom/fromJson.txt:4462
 msgid "Propylene Oxide gel treated to burn at higher temperatures"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/multiplay/skirmish/semperfi.json: $.AI.tip
-#: po/custom/fromJson.txt:4430
+#: po/custom/fromJson.txt:4470
 msgid "Prototypical AI focusing on rockets/missiles"
 msgstr ""
 
@@ -11802,63 +11836,63 @@ msgstr ""
 #. data/base/stats/research.json: $.R-Defense-PulseLas.name
 #. data/base/stats/structure.json: $.Emplacement-PulseLaser.name
 #. data/mp/stats/structure.json: $.Emplacement-PulseLaser.name
-#: po/custom/fromJson.txt:4435
+#: po/custom/fromJson.txt:4475
 msgid "Pulse Laser Emplacement"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/research.json: $.R-Defense-WallTower-PulseLas.name
 #. data/mp/stats/structure.json: $.WallTower-PulseLas.name
-#: po/custom/fromJson.txt:4439
+#: po/custom/fromJson.txt:4479
 msgid "Pulse Laser Hardpoint"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/templates.json: $.LeopardHoverPulseLas.name
-#: po/custom/fromJson.txt:4442
+#: po/custom/fromJson.txt:4482
 msgid "Pulse Laser Leopard Hover"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/templates.json: $.A-Mantis-Trk-Pulse.name
-#: po/custom/fromJson.txt:4445
+#: po/custom/fromJson.txt:4485
 msgid "Pulse Laser Mantis Tracks"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/templates.json: $.PantherHoverPulseLas.name
-#: po/custom/fromJson.txt:4448
+#: po/custom/fromJson.txt:4488
 msgid "Pulse Laser Panther Hover"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/templates.json: $.PythonPulseTracks.name
-#: po/custom/fromJson.txt:4451
+#: po/custom/fromJson.txt:4491
 msgid "Pulse Laser Python Tracks"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/templates.json: $.TigerHoverPulseLas.name
-#: po/custom/fromJson.txt:4454
+#: po/custom/fromJson.txt:4494
 msgid "Pulse Laser Tiger Hover"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/templates.json: $.TigerPulseTracks.name
-#: po/custom/fromJson.txt:4457
+#: po/custom/fromJson.txt:4497
 msgid "Pulse Laser Tiger Tracks"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/research.json: $.R-Defense-PulseLas.name
 #. data/mp/stats/structure.json: $.GuardTower-BeamLas.name
-#: po/custom/fromJson.txt:4461
+#: po/custom/fromJson.txt:4501
 msgid "Pulse Laser Tower"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/templates.json: $.WyvernPulseTracks.name
-#: po/custom/fromJson.txt:4464
+#: po/custom/fromJson.txt:4504
 msgid "Pulse Laser Wyvern Tracks"
 msgstr ""
 
@@ -11867,78 +11901,80 @@ msgstr ""
 #. data/base/stats/weapons.json: $.Laser2PULSEMk1.name
 #. data/mp/stats/research.json: $.R-Wpn-Laser02.name
 #. data/mp/stats/weapons.json: $.Laser2PULSEMk1.name
-#: po/custom/fromJson.txt:4470
+#: po/custom/fromJson.txt:4510
 msgid "Pulse Laser"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/templates.json: $.P0PythonHvyCnTrks.name
-#: po/custom/fromJson.txt:4473
+#: po/custom/fromJson.txt:4513
 msgid "Python Heavy Cannon Tracks"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/body.json: $.Body11ABT.name
 #. data/mp/stats/body.json: $.Body11ABT.name
-#: po/custom/fromJson.txt:4477
+#: po/custom/fromJson.txt:4517
 msgid "Python"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/messages/resmessagesall.json: $.RES_WT_DOUBLEAA.text[1]
-#: po/custom/fromJson.txt:4485
+#: po/custom/fromJson.txt:4525
 msgid "Quad 80mm Anti-Aircraft machinegun"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages3.json: $.RES_W_SMS_ROF1.text[1]
 #. data/mp/messages/resmessages3.json: $.RES_W_SMS_ROF1.text[1]
-#: po/custom/fromJson.txt:4493
+#: po/custom/fromJson.txt:4533
 msgid "Racked missile dispensers allow for fast reloading"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/messages/resmessagesall.json: $.RES_SY_RDST1.text[2]
-#: po/custom/fromJson.txt:4496
+#: po/custom/fromJson.txt:4536
 msgid "Radar detector detects enemy sensors"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/structure.json: $.Sys-RadarDetector01.name
-#: po/custom/fromJson.txt:4499
+#: po/custom/fromJson.txt:4539
 msgid "Radar Detector Tower"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/research.json: $.R-Sys-RadarDetector01.name
 #. data/mp/stats/sensor.json: $.RadarDetector.name
-#: po/custom/fromJson.txt:4503
+#: po/custom/fromJson.txt:4543
 msgid "Radar Detector"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/messages/resmessages3.json: $.RES_W_RAIL_AC1.text[2]
-#: po/custom/fromJson.txt:4506
+#: po/custom/fromJson.txt:4547
+#, no-c-format
 msgid "Rail Gun accuracy +10%"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/messages/resmessages3.json: $.RES_W_RAIL_D1.text[2]
-#: po/custom/fromJson.txt:4509
+#: po/custom/fromJson.txt:4551
+#, no-c-format
 msgid "Rail Gun damage +25%"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Defense-Rail2.name
 #. data/mp/stats/research.json: $.R-Defense-Rail2.name
-#: po/custom/fromJson.txt:4513
+#: po/custom/fromJson.txt:4555
 msgid "Rail Gun Emplacement"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages3.json: $.RES_W_RAIL2.text[1]
 #. data/mp/messages/resmessages3.json: $.RES_W_RAIL2.text[1]
-#: po/custom/fromJson.txt:4517
+#: po/custom/fromJson.txt:4559
 msgid "Rail gun firing armor-piercing darts"
 msgstr ""
 
@@ -11947,46 +11983,47 @@ msgstr ""
 #. data/base/stats/structure.json: $.WallTower-Rail2.name
 #. data/mp/stats/research.json: $.R-Defense-WallTower-Rail2.name
 #. data/mp/stats/structure.json: $.WallTower-Rail2.name
-#: po/custom/fromJson.txt:4523
+#: po/custom/fromJson.txt:4565
 msgid "Rail Gun Hardpoint"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/templates.json: $.A-Mantis-Trk-Rail.name
-#: po/custom/fromJson.txt:4526
+#: po/custom/fromJson.txt:4568
 msgid "Rail Gun Mantis Tracks"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/messages/resmessages3.json: $.RES_W_RAIL_ROF1.text[2]
-#: po/custom/fromJson.txt:4529
+#: po/custom/fromJson.txt:4572
+#, no-c-format
 msgid "Rail Gun reload time -15%"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Wpn-Rail-ROF02.name
 #. data/mp/stats/research.json: $.R-Wpn-Rail-ROF02.name
-#: po/custom/fromJson.txt:4533
+#: po/custom/fromJson.txt:4576
 msgid "Rail Gun ROF Mk2"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Wpn-Rail-ROF03.name
 #. data/mp/stats/research.json: $.R-Wpn-Rail-ROF03.name
-#: po/custom/fromJson.txt:4537
+#: po/custom/fromJson.txt:4580
 msgid "Rail Gun ROF Mk3"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Wpn-Rail-ROF01.name
 #. data/mp/stats/research.json: $.R-Wpn-Rail-ROF01.name
-#: po/custom/fromJson.txt:4541
+#: po/custom/fromJson.txt:4584
 msgid "Rail Gun ROF"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/templates.json: $.TigerHoverRailGun.name
-#: po/custom/fromJson.txt:4544
+#: po/custom/fromJson.txt:4587
 msgid "Rail Gun Tiger Hover"
 msgstr ""
 
@@ -11995,7 +12032,7 @@ msgstr ""
 #. data/base/messages/resmessages3.json: $.RES_W_RAIL_D1.text[0]
 #. data/base/messages/resmessages3.json: $.RES_W_RAIL_ROF1.text[0]
 #. ... + 3 refs
-#: po/custom/fromJson.txt:4550
+#: po/custom/fromJson.txt:4593
 msgid "Rail Gun Upgrade"
 msgstr ""
 
@@ -12004,46 +12041,47 @@ msgstr ""
 #. data/base/stats/weapons.json: $.RailGun2Mk1.name
 #. data/mp/stats/research.json: $.R-Wpn-RailGun02.name
 #. data/mp/stats/weapons.json: $.RailGun2Mk1.name
-#: po/custom/fromJson.txt:4556
+#: po/custom/fromJson.txt:4599
 msgid "Rail Gun"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/research.json: $.R-Wpn-Rail-Accuracy01.name
-#: po/custom/fromJson.txt:4559
+#: po/custom/fromJson.txt:4602
 msgid "Rail Target Prediction Computer"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/structure.json: $.Emplacement-Rail2.name
 #. data/mp/stats/structure.json: $.Emplacement-Rail2.name
-#: po/custom/fromJson.txt:4563
+#: po/custom/fromJson.txt:4606
 msgid "Railgun Emplacement"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Wpn-MG-ROF02.name
-#: po/custom/fromJson.txt:4566
+#: po/custom/fromJson.txt:4609
 msgid "Rapid Fire Chaingun Upgrade"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/research.json: $.R-Wpn-MG-ROF02.name
-#: po/custom/fromJson.txt:4569
+#: po/custom/fromJson.txt:4612
 msgid "Rapid Fire Chaingun"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages3.json: $.RES_W_RAIL1.text[1]
 #. data/mp/messages/resmessages3.json: $.RES_W_RAIL1.text[1]
-#: po/custom/fromJson.txt:4573
+#: po/custom/fromJson.txt:4616
 msgid "Rapid fire rail gun firing needle darts"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/messages/resmessages2.json: $.RES_ST_VPU1.text[2]
 #. data/mp/messages/resmessages3.json: $.RES_ST_VPU4.text[2]
-#: po/custom/fromJson.txt:4577
+#: po/custom/fromJson.txt:4621
+#, no-c-format
 msgid "Rearming speed +30%"
 msgstr ""
 
@@ -12052,28 +12090,28 @@ msgstr ""
 #. data/base/messages/resmessages3.json: $.RES_SY_RESU2.text[3]
 #. data/mp/messages/resmessages3.json: $.RES_SY_RESU1.text[3]
 #. data/mp/messages/resmessages3.json: $.RES_SY_RESU2.text[3]
-#: po/custom/fromJson.txt:4587
+#: po/custom/fromJson.txt:4631
 msgid "Reduced chance of NEXUS take-over"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessagesall.json: $.RES_ST_VP.text[1]
 #. data/mp/messages/resmessagesall.json: $.RES_ST_VP.text[1]
-#: po/custom/fromJson.txt:4595
+#: po/custom/fromJson.txt:4639
 msgid "Refuels, rearms and repairs VTOLs"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Struc-Materials02.name
 #. data/mp/stats/research.json: $.R-Struc-Materials02.name
-#: po/custom/fromJson.txt:4599
+#: po/custom/fromJson.txt:4643
 msgid "Reinforced Base Structure Materials Mk2"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Struc-Materials03.name
 #. data/mp/stats/research.json: $.R-Struc-Materials03.name
-#: po/custom/fromJson.txt:4603
+#: po/custom/fromJson.txt:4647
 msgid "Reinforced Base Structure Materials Mk3"
 msgstr ""
 
@@ -12082,19 +12120,19 @@ msgstr ""
 #. data/base/stats/research.json: $.R-Struc-Materials01.name
 #. data/mp/messages/resmessages1.json: $.RES_ST_MAT1.text[1]
 #. data/mp/stats/research.json: $.R-Struc-Materials01.name
-#: po/custom/fromJson.txt:4609
+#: po/custom/fromJson.txt:4653
 msgid "Reinforced Base Structure Materials"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/ecm.json: $.RepairCentre.name
-#: po/custom/fromJson.txt:4620
+#: po/custom/fromJson.txt:4664
 msgid "Repair Center Turret"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/templates.json: $.P0CobraRepairTrks.name
-#: po/custom/fromJson.txt:4623
+#: po/custom/fromJson.txt:4667
 msgid "Repair Cobra Tracks"
 msgstr ""
 
@@ -12103,13 +12141,13 @@ msgstr ""
 #. data/base/stats/structure.json: $.A0RepairCentre3.name
 #. data/mp/stats/research.json: $.R-Struc-RepairFacility.name
 #. data/mp/stats/structure.json: $.A0RepairCentre3.name
-#: po/custom/fromJson.txt:4635
+#: po/custom/fromJson.txt:4679
 msgid "Repair Facility"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/templates.json: $.ScorpRepairTrk.name
-#: po/custom/fromJson.txt:4638
+#: po/custom/fromJson.txt:4682
 msgid "Repair Scorpion Tracks"
 msgstr ""
 
@@ -12117,46 +12155,47 @@ msgstr ""
 #. data/mp/messages/resmessages1.json: $.RES_ST_RFU1.text[2]
 #. data/mp/messages/resmessages2.json: $.RES_ST_RFU4.text[2]
 #. data/mp/messages/resmessages3.json: $.RES_ST_RFU7.text[2]
-#: po/custom/fromJson.txt:4643
+#: po/custom/fromJson.txt:4688
+#, no-c-format
 msgid "Repair Speed +100%"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/templates.json: $.P0CobraRepairTrks.name
 #. data/mp/stats/templates.json: $.A-Rep-Cobra-Trk.name
-#: po/custom/fromJson.txt:4647
+#: po/custom/fromJson.txt:4692
 msgid "Repair Turret Cobra Tracks"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/templates.json: $.A-Rep-Mantis-Trk.name
-#: po/custom/fromJson.txt:4650
+#: po/custom/fromJson.txt:4695
 msgid "Repair Turret Mantis Tracks"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/templates.json: $.ViperRepairHalftrack.name
-#: po/custom/fromJson.txt:4653
+#: po/custom/fromJson.txt:4698
 msgid "Repair Turret Viper Half-track"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/templates.json: $.ViperRepairHalftrack.name
-#: po/custom/fromJson.txt:4656
+#: po/custom/fromJson.txt:4701
 msgid "Repair Turret Viper Half-tracks"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/templates.json: $.ViperRepairWheels.name
 #. data/mp/stats/templates.json: $.ViperRepairWheels.name
-#: po/custom/fromJson.txt:4660
+#: po/custom/fromJson.txt:4705
 msgid "Repair Turret Viper Wheels"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/repair.json: $.LightRepair1.name
 #. data/mp/stats/repair.json: $.LightRepair1.name
-#: po/custom/fromJson.txt:4664
+#: po/custom/fromJson.txt:4709
 msgid "Repair Turret"
 msgstr ""
 
@@ -12165,21 +12204,21 @@ msgstr ""
 #. data/mp/messages/resmessages23.json: $.RES_W_MG4.text[3]
 #. data/mp/messages/resmessagesall.json: $.RES_WT_TWINAGHP.text[3]
 #. data/mp/messages/resmessagesall.json: $.RES_WT_TWINAGUN.text[3]
-#: po/custom/fromJson.txt:4670
+#: po/custom/fromJson.txt:4715
 msgid "Replaces all machineguns"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages3.json: $.RES_CYJ_LS1.text[3]
 #. data/mp/messages/resmessages3.json: $.RES_CYJ_LS1.text[3]
-#: po/custom/fromJson.txt:4688
+#: po/custom/fromJson.txt:4733
 msgid "Requires cyborg factory to produce"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/messages/resmessagesall.json: $.RES_CYTRANS.text[3]
 #. data/mp/messages/resmessagesall.json: $.RES_SUPERTRANS.text[3]
-#: po/custom/fromJson.txt:4692
+#: po/custom/fromJson.txt:4737
 msgid "Requires heavy VTOL factory to produce"
 msgstr ""
 
@@ -12188,35 +12227,35 @@ msgstr ""
 #. data/base/messages/resmessages23.json: $.RES_ENGIN2.text[0]
 #. data/base/messages/resmessages3.json: $.RES_ENGIN3.text[0]
 #. ... + 3 refs
-#: po/custom/fromJson.txt:4698
+#: po/custom/fromJson.txt:4743
 msgid "Research Breakthrough Improves Construction Rates"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/structure.json: $.A0ResearchFacility.name
 #. data/mp/stats/structure.json: $.A0ResearchFacility.name
-#: po/custom/fromJson.txt:4702
+#: po/custom/fromJson.txt:4747
 msgid "Research Facility"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages1.json: $.RES_ST_FCY1.text[3]
 #. data/mp/messages/resmessages1.json: $.RES_ST_FCY1.text[3]
-#: po/custom/fromJson.txt:4712
+#: po/custom/fromJson.txt:4757
 msgid "Research makes additional Cyborgs available"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages1.json: $.RES_ST_RM1.text[0]
 #. data/mp/messages/resmessages1.json: $.RES_ST_RM1.text[0]
-#: po/custom/fromJson.txt:4716
+#: po/custom/fromJson.txt:4761
 msgid "Research Module Available"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages1.json: $.RES_ST_RM1.text[1]
 #. data/mp/messages/resmessages1.json: $.RES_ST_RM1.text[1]
-#: po/custom/fromJson.txt:4720
+#: po/custom/fromJson.txt:4765
 msgid "Research module expands research facilities"
 msgstr ""
 
@@ -12225,7 +12264,7 @@ msgstr ""
 #. data/base/stats/structure.json: $.A0ResearchModule1.name
 #. data/mp/stats/research.json: $.R-Struc-Research-Module.name
 #. data/mp/stats/structure.json: $.A0ResearchModule1.name
-#: po/custom/fromJson.txt:4726
+#: po/custom/fromJson.txt:4771
 msgid "Research Module"
 msgstr ""
 
@@ -12233,27 +12272,29 @@ msgstr ""
 #. data/mp/messages/resmessages1.json: $.RES_ST_RU1.text[2]
 #. data/mp/messages/resmessages2.json: $.RES_ST_RU4.text[2]
 #. data/mp/messages/resmessages3.json: $.RES_ST_RU7.text[2]
-#: po/custom/fromJson.txt:4731
+#: po/custom/fromJson.txt:4777
+#, no-c-format
 msgid "Research speed +30%"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/messages/resmessages1.json: $.RES_ST_RM1.text[2]
-#: po/custom/fromJson.txt:4734
+#: po/custom/fromJson.txt:4781
+#, no-c-format
 msgid "Research speed +85%"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/body.json: $.Body3MBT.name
 #. data/mp/stats/body.json: $.Body3MBT.name
-#: po/custom/fromJson.txt:4738
+#: po/custom/fromJson.txt:4785
 msgid "Retaliation"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/body.json: $.Body7ABT.name
 #. data/mp/stats/body.json: $.Body7ABT.name
-#: po/custom/fromJson.txt:4742
+#: po/custom/fromJson.txt:4789
 msgid "Retribution"
 msgstr ""
 
@@ -12262,7 +12303,7 @@ msgstr ""
 #. data/base/stats/structure.json: $.Emplacement-Rocket06-IDF.name
 #. data/mp/stats/research.json: $.R-Defense-IDFRocket.name
 #. data/mp/stats/structure.json: $.Emplacement-Rocket06-IDF.name
-#: po/custom/fromJson.txt:4748
+#: po/custom/fromJson.txt:4795
 msgid "Ripple Rocket Battery"
 msgstr ""
 
@@ -12271,44 +12312,44 @@ msgstr ""
 #. data/base/stats/weapons.json: $.Rocket-IDF.name
 #. data/mp/stats/research.json: $.R-Wpn-Rocket06-IDF.name
 #. data/mp/stats/weapons.json: $.Rocket-IDF.name
-#: po/custom/fromJson.txt:4754
+#: po/custom/fromJson.txt:4801
 msgid "Ripple Rockets"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages23.json: $.RES_W_MG_ROF3.text[1]
 #. data/mp/messages/resmessages23.json: $.RES_W_MG_ROF3.text[1]
-#: po/custom/fromJson.txt:4758
+#: po/custom/fromJson.txt:4805
 msgid "Robotic advances make new chaingun upgrade available"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Struc-Factory-Cyborg-Upgrade05.name
-#: po/custom/fromJson.txt:4761
+#: po/custom/fromJson.txt:4808
 msgid "Robotic Cyborg Production Mk2"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Struc-Factory-Cyborg-Upgrade06.name
-#: po/custom/fromJson.txt:4764
+#: po/custom/fromJson.txt:4811
 msgid "Robotic Cyborg Production Mk3"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Struc-Factory-Upgrade05.name
-#: po/custom/fromJson.txt:4772
+#: po/custom/fromJson.txt:4819
 msgid "Robotic Factory Production Mk2"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Struc-Factory-Upgrade06.name
-#: po/custom/fromJson.txt:4775
+#: po/custom/fromJson.txt:4822
 msgid "Robotic Factory Production Mk3"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Struc-Factory-Upgrade04.name
-#: po/custom/fromJson.txt:4778
+#: po/custom/fromJson.txt:4825
 msgid "Robotic Factory Production"
 msgstr ""
 
@@ -12317,63 +12358,63 @@ msgstr ""
 #. data/base/messages/resmessages3.json: $.RES_W_HOWRF4.text[1]
 #. data/base/messages/resmessages3.json: $.RES_W_M_ROF4.text[1]
 #. ... + 3 refs
-#: po/custom/fromJson.txt:4784
+#: po/custom/fromJson.txt:4831
 msgid "Robotic loading system feeds rounds into breech"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/research.json: $.R-Struc-Factory-Upgrade04.name
-#: po/custom/fromJson.txt:4787
+#: po/custom/fromJson.txt:4834
 msgid "Robotic Manufacturing"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Struc-RprFac-Upgrade05.name
-#: po/custom/fromJson.txt:4790
+#: po/custom/fromJson.txt:4837
 msgid "Robotic Repair Facility Upgrade Mk2"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Struc-RprFac-Upgrade06.name
-#: po/custom/fromJson.txt:4793
+#: po/custom/fromJson.txt:4840
 msgid "Robotic Repair Facility Upgrade Mk3"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Struc-RprFac-Upgrade04.name
-#: po/custom/fromJson.txt:4796
+#: po/custom/fromJson.txt:4843
 msgid "Robotic Repair Facility Upgrade"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/research.json: $.R-Struc-RprFac-Upgrade04.name
-#: po/custom/fromJson.txt:4799
+#: po/custom/fromJson.txt:4846
 msgid "Robotic Repair Facility"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Struc-VTOLFactory-Upgrade02.name
-#: po/custom/fromJson.txt:4802
+#: po/custom/fromJson.txt:4849
 msgid "Robotic VTOL Production Mk2"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Struc-VTOLFactory-Upgrade03.name
-#: po/custom/fromJson.txt:4805
+#: po/custom/fromJson.txt:4852
 msgid "Robotic VTOL Production Mk3"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Struc-VTOLPad-Upgrade05.name
 #. data/mp/stats/research.json: $.R-Struc-VTOLPad-Upgrade05.name
-#: po/custom/fromJson.txt:4814
+#: po/custom/fromJson.txt:4861
 msgid "Robotic VTOL Rearming Mk2"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Struc-VTOLPad-Upgrade06.name
 #. data/mp/stats/research.json: $.R-Struc-VTOLPad-Upgrade06.name
-#: po/custom/fromJson.txt:4818
+#: po/custom/fromJson.txt:4865
 msgid "Robotic VTOL Rearming Mk3"
 msgstr ""
 
@@ -12382,7 +12423,7 @@ msgstr ""
 #. data/base/stats/research.json: $.R-Struc-VTOLPad-Upgrade04.name
 #. data/mp/messages/resmessages3.json: $.RES_ST_VPU4.text[1]
 #. data/mp/stats/research.json: $.R-Struc-VTOLPad-Upgrade04.name
-#: po/custom/fromJson.txt:4824
+#: po/custom/fromJson.txt:4871
 msgid "Robotic VTOL Rearming"
 msgstr ""
 
@@ -12391,42 +12432,43 @@ msgstr ""
 #. data/mp/messages/resmessages1.json: $.RES_W_SRK_AC1.text[2]
 #. data/mp/messages/resmessages12.json: $.RES_W_SRK_AC2.text[2]
 #. data/mp/messages/resmessagesall.json: $.RES_W_SRK_AC3.text[2]
-#: po/custom/fromJson.txt:4830
+#: po/custom/fromJson.txt:4878
+#, no-c-format
 msgid "Rocket accuracy +10%"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages12.json: $.RES_W_RK_IDF.text[1]
 #. data/mp/messages/resmessages12.json: $.RES_W_RK_IDF.text[1]
-#: po/custom/fromJson.txt:4834
+#: po/custom/fromJson.txt:4882
 msgid "Rocket artillery; can be assigned to a sensor"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Wpn-RocketSlow-ROF02.name
 #. data/mp/stats/research.json: $.R-Wpn-Rocket-ROF02.name
-#: po/custom/fromJson.txt:4838
+#: po/custom/fromJson.txt:4886
 msgid "Rocket Autoloader Mk2"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Wpn-RocketSlow-ROF03.name
 #. data/mp/stats/research.json: $.R-Wpn-Rocket-ROF03.name
-#: po/custom/fromJson.txt:4842
+#: po/custom/fromJson.txt:4890
 msgid "Rocket Autoloader Mk3"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Wpn-RocketSlow-ROF01.name
 #. data/mp/stats/research.json: $.R-Wpn-Rocket-ROF01.name
-#: po/custom/fromJson.txt:4846
+#: po/custom/fromJson.txt:4894
 msgid "Rocket Autoloader"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/templates.json: $.BarbarianRKBuggy.name
 #. data/mp/stats/templates.json: $.BarbarianRKBuggy.name
-#: po/custom/fromJson.txt:4850
+#: po/custom/fromJson.txt:4898
 msgid "Rocket Buggy"
 msgstr ""
 
@@ -12435,49 +12477,51 @@ msgstr ""
 #. data/mp/messages/resmessages1.json: $.RES_W_SRK_D1.text[2]
 #. data/mp/messages/resmessages2.json: $.RES_W_RK_D4.text[2]
 #. data/mp/messages/resmessages2.json: $.RES_W_SRK_D4.text[2]
-#: po/custom/fromJson.txt:4856
+#: po/custom/fromJson.txt:4905
+#, no-c-format
 msgid "Rocket damage +25%"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessagesall.json: $.RES_W_SRK_AC3.text[1]
 #. data/mp/messages/resmessagesall.json: $.RES_W_SRK_AC3.text[1]
-#: po/custom/fromJson.txt:4860
+#: po/custom/fromJson.txt:4909
 msgid "Rocket detects and locks on to engine emissions"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/templates.json: $.BabaRKJeep.name
 #. data/mp/stats/templates.json: $.BabaRKJeep.name
-#: po/custom/fromJson.txt:4864
+#: po/custom/fromJson.txt:4913
 msgid "Rocket Jeep"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Wpn-RocketSlow-Accuracy02.name
 #. data/mp/stats/research.json: $.R-Wpn-RocketSlow-Accuracy01.name
-#: po/custom/fromJson.txt:4868
+#: po/custom/fromJson.txt:4917
 msgid "Rocket Laser Designator"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/messages/resmessages1.json: $.RES_W_RK_ROF1.text[2]
 #. data/mp/messages/resmessages12.json: $.RES_W_SRK_ROF1.text[2]
-#: po/custom/fromJson.txt:4872
+#: po/custom/fromJson.txt:4922
+#, no-c-format
 msgid "Rocket reload time -15%"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages12.json: $.RES_W_SRK_AC2.text[1]
 #. data/mp/messages/resmessages12.json: $.RES_W_SRK_AC2.text[1]
-#: po/custom/fromJson.txt:4876
+#: po/custom/fromJson.txt:4926
 msgid "Rocket tracks the laser designator to the target"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Wpn-Howitzer03-Rot.name
 #. data/mp/stats/research.json: $.R-Wpn-Howitzer03-Rot.name
-#: po/custom/fromJson.txt:4886
+#: po/custom/fromJson.txt:4936
 msgid "Rotary Howitzer - Hellstorm"
 msgstr ""
 
@@ -12486,142 +12530,142 @@ msgstr ""
 #. data/base/stats/structure.json: $.Pillbox-RotMG.name
 #. data/mp/stats/research.json: $.R-Defense-RotMG.name
 #. data/mp/stats/structure.json: $.Pillbox-RotMG.name
-#: po/custom/fromJson.txt:4892
+#: po/custom/fromJson.txt:4942
 msgid "Rotary MG Bunker"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Wpn-Mortar3.name
 #. data/mp/stats/research.json: $.R-Wpn-Mortar3.name
-#: po/custom/fromJson.txt:4896
+#: po/custom/fromJson.txt:4946
 msgid "Rotary Mortar - Pepperpot"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/features.json: $.Rotarywepslab.name
-#: po/custom/fromJson.txt:4899
+#: po/custom/fromJson.txt:4949
 msgid "Rotaryweaponslab"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/features.json: $.BarbTechRuin.name
-#: po/custom/fromJson.txt:4902
+#: po/custom/fromJson.txt:4952
 msgid "Ruined Factory"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages3.json: $.RES_EMP_SAM1.text[1]
 #. data/mp/messages/resmessages3.json: $.RES_EMP_SAM1.text[1]
-#: po/custom/fromJson.txt:4906
+#: po/custom/fromJson.txt:4956
 msgid "SAM site with Avenger missiles"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages3.json: $.RES_EMP_SAM2.text[1]
 #. data/mp/messages/resmessages3.json: $.RES_EMP_SAM2.text[1]
-#: po/custom/fromJson.txt:4910
+#: po/custom/fromJson.txt:4960
 msgid "SAM site with Vindicator missiles"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/structure.json: $.A0BaBaRocketPitAT.name
 #. data/mp/stats/structure.json: $.A0BaBaRocketPitAT.name
-#: po/custom/fromJson.txt:4918
+#: po/custom/fromJson.txt:4968
 msgid "Scavenger AT-Rocket Pit"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/structure.json: $.A0BaBaBunker.name
 #. data/mp/stats/structure.json: $.A0BaBaBunker.name
-#: po/custom/fromJson.txt:4922
+#: po/custom/fromJson.txt:4972
 msgid "Scavenger Bunker"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/structure.json: $.A0BabaCornerWall.name
 #. data/mp/stats/structure.json: $.A0BabaCornerWall.name
-#: po/custom/fromJson.txt:4926
+#: po/custom/fromJson.txt:4976
 msgid "Scavenger CornerWall"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/structure.json: $.A0BaBaFactory.name
 #. data/mp/stats/structure.json: $.A0BaBaFactory.name
-#: po/custom/fromJson.txt:4930
+#: po/custom/fromJson.txt:4980
 msgid "Scavenger Factory"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/structure.json: $.A0BaBaFlameTower.name
 #. data/mp/stats/structure.json: $.A0BaBaFlameTower.name
-#: po/custom/fromJson.txt:4934
+#: po/custom/fromJson.txt:4984
 msgid "Scavenger Flame Tower"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/structure.json: $.A0BaBaGunTower.name
 #. data/mp/stats/structure.json: $.A0BaBaGunTower.name
-#: po/custom/fromJson.txt:4938
+#: po/custom/fromJson.txt:4988
 msgid "Scavenger Gun Tower"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/structure.json: $.A0BaBaHorizontalWall.name
 #. data/mp/stats/structure.json: $.A0BaBaHorizontalWall.name
-#: po/custom/fromJson.txt:4942
+#: po/custom/fromJson.txt:4992
 msgid "Scavenger Horizontal Wall"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/structure.json: $.A0BaBaPowerGenerator.name
 #. data/mp/stats/structure.json: $.A0BaBaPowerGenerator.name
-#: po/custom/fromJson.txt:4946
+#: po/custom/fromJson.txt:4996
 msgid "Scavenger Power Generator"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/structure.json: $.A0BaBaRocketPit.name
 #. data/mp/stats/structure.json: $.A0BaBaRocketPit.name
-#: po/custom/fromJson.txt:4950
+#: po/custom/fromJson.txt:5000
 msgid "Scavenger Rocket Pit"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/templates.json: $.BaBaPeople.name
 #. data/mp/stats/templates.json: $.BaBaPeople.name
-#: po/custom/fromJson.txt:4954
+#: po/custom/fromJson.txt:5004
 msgid "Scavenger"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/templates.json: $.BabaBusCan.name
 #. data/mp/stats/templates.json: $.BabaBusCan.name
-#: po/custom/fromJson.txt:4958
+#: po/custom/fromJson.txt:5008
 msgid "School Bus"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/body.json: $.Body8MBT.name
 #. data/mp/stats/body.json: $.Body8MBT.name
-#: po/custom/fromJson.txt:4962
+#: po/custom/fromJson.txt:5012
 msgid "Scorpion"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Cyborg-Wpn-ATMiss.name
-#: po/custom/fromJson.txt:4965
+#: po/custom/fromJson.txt:5015
 msgid "Scourge Cyborg"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/templates.json: $.Scourge-Mantis-H.name
-#: po/custom/fromJson.txt:4968
+#: po/custom/fromJson.txt:5018
 msgid "Scourge Mantis Hover"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/templates.json: $.MantisScourgeTracks.name
-#: po/custom/fromJson.txt:4971
+#: po/custom/fromJson.txt:5021
 msgid "Scourge Mantis Tracks"
 msgstr ""
 
@@ -12630,7 +12674,7 @@ msgstr ""
 #. data/base/stats/structure.json: $.WallTower-Atmiss.name
 #. data/mp/stats/research.json: $.R-Defense-WallTower-A-Tmiss.name
 #. data/mp/stats/structure.json: $.WallTower-Atmiss.name
-#: po/custom/fromJson.txt:4977
+#: po/custom/fromJson.txt:5027
 msgid "Scourge Missile Hardpoint"
 msgstr ""
 
@@ -12639,13 +12683,13 @@ msgstr ""
 #. data/base/stats/structure.json: $.GuardTower-ATMiss.name
 #. data/mp/stats/research.json: $.R-Defense-GuardTower-ATMiss.name
 #. data/mp/stats/structure.json: $.GuardTower-ATMiss.name
-#: po/custom/fromJson.txt:4983
+#: po/custom/fromJson.txt:5033
 msgid "Scourge Missile Tower"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/templates.json: $.WyvernScourgeTracks.name
-#: po/custom/fromJson.txt:4986
+#: po/custom/fromJson.txt:5036
 msgid "Scourge Missile Wyvern Tracks"
 msgstr ""
 
@@ -12654,19 +12698,19 @@ msgstr ""
 #. data/base/stats/weapons.json: $.Missile-A-T.name
 #. data/mp/stats/research.json: $.R-Wpn-Missile2A-T.name
 #. data/mp/stats/weapons.json: $.Missile-A-T.name
-#: po/custom/fromJson.txt:4992
+#: po/custom/fromJson.txt:5042
 msgid "Scourge Missile"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/templates.json: $.PythonScourgeTracks.name
-#: po/custom/fromJson.txt:4995
+#: po/custom/fromJson.txt:5045
 msgid "Scourge Python Tracks"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/templates.json: $.SK-Retal-VTOL-Scourge.name
-#: po/custom/fromJson.txt:4998
+#: po/custom/fromJson.txt:5048
 msgid "Scourge Retaliation VTOL"
 msgstr ""
 
@@ -12674,90 +12718,93 @@ msgstr ""
 #. data/base/stats/templates.json: $.Cyb-Atmiss-GROUND.name
 #. data/mp/stats/templates.json: $.Cyb-Atmiss-GROUND.name
 #. data/mp/stats/templates.json: $.MP-Cyb-ATmiss-GRD.name
-#: po/custom/fromJson.txt:5003
+#: po/custom/fromJson.txt:5053
 msgid "Scourge"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Sys-SpyTurret.name
 #. data/base/stats/weapons.json: $.SpyTurret01.name
-#: po/custom/fromJson.txt:5007
+#: po/custom/fromJson.txt:5057
 msgid "Scrambler Turret"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/multiplay/skirmish/nb_hover.json: $.AI.tip
-#: po/custom/fromJson.txt:5010
+#: po/custom/fromJson.txt:5060
 msgid "Sea map AI, based on NullBot"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Wpn-Missile-Accuracy02.name
 #. data/mp/stats/research.json: $.R-Wpn-Missile-Accuracy02.name
-#: po/custom/fromJson.txt:5014
+#: po/custom/fromJson.txt:5064
 msgid "Search & Destroy Missiles"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages23.json: $.RES_SY_VSTU1.text[3]
 #. data/mp/messages/resmessages23.json: $.RES_SY_VSTU1.text[3]
-#: po/custom/fromJson.txt:5021
+#: po/custom/fromJson.txt:5071
 msgid "Select new targets to continue the VTOL strikes"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages3.json: $.RES_W_M_AC3.text[1]
 #. data/mp/messages/resmessages3.json: $.RES_W_M_AC3.text[1]
-#: po/custom/fromJson.txt:5031
+#: po/custom/fromJson.txt:5081
 msgid "Self-guided rocket-powered shells"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/research.json: $.R-Struc-Factory-Upgrade09.name
-#: po/custom/fromJson.txt:5034
+#: po/custom/fromJson.txt:5084
 msgid "Self-Replicating Manufacturing"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/multiplay/skirmish/semperfi.json: $.AI.name
-#: po/custom/fromJson.txt:5037
+#: po/custom/fromJson.txt:5087
 msgid "SemperFi"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/templates.json: $.CobraSensorHalftrack.name
-#: po/custom/fromJson.txt:5040
+#: po/custom/fromJson.txt:5090
 msgid "Sensor Cobra Half-tracks"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/messages/resmessagesall.json: $.RES_SY_SU3.text[2]
-#: po/custom/fromJson.txt:5043
+#: po/custom/fromJson.txt:5094
+#, no-c-format
 msgid "Sensor Range +10%"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/messages/resmessagesall.json: $.RES_SY_SU2.text[2]
-#: po/custom/fromJson.txt:5046
+#: po/custom/fromJson.txt:5098
+#, no-c-format
 msgid "Sensor Range +15%"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/messages/resmessagesall.json: $.RES_SY_SU1.text[2]
-#: po/custom/fromJson.txt:5049
+#: po/custom/fromJson.txt:5102
+#, no-c-format
 msgid "Sensor Range +25%"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/templates.json: $.CobraSensorHalftrack.name
-#: po/custom/fromJson.txt:5058
+#: po/custom/fromJson.txt:5111
 msgid "Sensor Turret Cobra Half-tracks"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/templates.json: $.ViperSensorWheels.name
 #. data/mp/stats/templates.json: $.ViperSensorWheels.name
-#: po/custom/fromJson.txt:5062
+#: po/custom/fromJson.txt:5115
 msgid "Sensor Turret Viper Wheels"
 msgstr ""
 
@@ -12766,26 +12813,26 @@ msgstr ""
 #. data/base/stats/sensor.json: $.SensorTurret1Mk1.name
 #. data/mp/stats/research.json: $.R-Sys-Sensor-Turret01.name
 #. data/mp/stats/sensor.json: $.SensorTurret1Mk1.name
-#: po/custom/fromJson.txt:5068
+#: po/custom/fromJson.txt:5121
 msgid "Sensor Turret"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/research.json: $.R-Sys-Sensor-Upgrade02.name
-#: po/custom/fromJson.txt:5071
+#: po/custom/fromJson.txt:5124
 msgid "Sensor Upgrade Mk2"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/research.json: $.R-Sys-Sensor-Upgrade03.name
-#: po/custom/fromJson.txt:5074
+#: po/custom/fromJson.txt:5127
 msgid "Sensor Upgrade Mk3"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Sys-Sensor-Upgrade01.name
 #. data/mp/stats/research.json: $.R-Sys-Sensor-Upgrade01.name
-#: po/custom/fromJson.txt:5078
+#: po/custom/fromJson.txt:5131
 msgid "Sensor Upgrade"
 msgstr ""
 
@@ -12794,53 +12841,53 @@ msgstr ""
 #. data/mp/messages/resmessagesall.json: $.RES_SY_SU1.text[0]
 #. data/mp/messages/resmessagesall.json: $.RES_SY_SU2.text[0]
 #. data/mp/messages/resmessagesall.json: $.RES_SY_SU3.text[0]
-#: po/custom/fromJson.txt:5084
+#: po/custom/fromJson.txt:5137
 msgid "Sensors Improved"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/research.json: $.R-Wpn-MdArtMissile.name
 #. data/mp/stats/weapons.json: $.Missile-MdArt.name
-#: po/custom/fromJson.txt:5088
+#: po/custom/fromJson.txt:5141
 msgid "Seraph Missile Array"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/research.json: $.R-Defense-MdArtMissile.name
 #. data/mp/stats/structure.json: $.Emplacement-MdART-pit.name
-#: po/custom/fromJson.txt:5092
+#: po/custom/fromJson.txt:5145
 msgid "Seraph Missile Battery"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages23.json: $.RES_W_M_AC2.text[1]
 #. data/mp/messages/resmessages23.json: $.RES_W_M_AC2.text[1]
-#: po/custom/fromJson.txt:5096
+#: po/custom/fromJson.txt:5149
 msgid "Shells detect and home to thermal heat signatures"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/messages/resmessagesall.json: $.RES_V_B13.text[2]
-#: po/custom/fromJson.txt:5099
+#: po/custom/fromJson.txt:5152
 msgid "Slow moving Body"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessagesall.json: $.RES_V_B09.text[2]
 #. data/mp/messages/resmessagesall.json: $.RES_V_B09.text[2]
-#: po/custom/fromJson.txt:5107
+#: po/custom/fromJson.txt:5160
 msgid "Slower than Python"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/features.json: $.WallCornerSmashed.name
-#: po/custom/fromJson.txt:5114
+#: po/custom/fromJson.txt:5167
 msgid "Smashedcornerwall"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/features.json: $.WallSmashed.name
-#: po/custom/fromJson.txt:5117
+#: po/custom/fromJson.txt:5170
 msgid "Smashedwall"
 msgstr ""
 
@@ -12849,87 +12896,87 @@ msgstr ""
 #. data/base/messages/resmessages1.json: $.RES_V_P_W1.text[2]
 #. data/mp/messages/resmessages1.json: $.RES_V_P_H1.text[2]
 #. data/mp/messages/resmessages1.json: $.RES_V_P_W1.text[2]
-#: po/custom/fromJson.txt:5123
+#: po/custom/fromJson.txt:5176
 msgid "Speed: Fast"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages1.json: $.RES_HALFT1.text[2]
 #. data/mp/messages/resmessages1.json: $.RES_HALFT1.text[2]
-#: po/custom/fromJson.txt:5127
+#: po/custom/fromJson.txt:5180
 msgid "Speed: Medium"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages1.json: $.RES_TRACK1.text[2]
 #. data/mp/messages/resmessages1.json: $.RES_TRACK1.text[2]
-#: po/custom/fromJson.txt:5131
+#: po/custom/fromJson.txt:5184
 msgid "Speed: Slow"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessagesall.json: $.RES_V_P_V1.text[2]
 #. data/mp/messages/resmessagesall.json: $.RES_V_P_V1.text[2]
-#: po/custom/fromJson.txt:5135
+#: po/custom/fromJson.txt:5188
 msgid "Speed: VTOL"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Wpn-Rocket-Accuracy02.name
-#: po/custom/fromJson.txt:5138
+#: po/custom/fromJson.txt:5191
 msgid "Stabilized Mini-Rockets Mk2"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Wpn-Rocket-Accuracy01.name
-#: po/custom/fromJson.txt:5141
+#: po/custom/fromJson.txt:5194
 msgid "Stabilized Mini-Rockets"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/research.json: $.R-Wpn-Rocket-Accuracy01.name
-#: po/custom/fromJson.txt:5144
+#: po/custom/fromJson.txt:5197
 msgid "Stabilized Rockets"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages3.json: $.RES_SY_ST1.text[3]
 #. data/mp/messages/resmessages3.json: $.RES_SY_ST1.text[3]
-#: po/custom/fromJson.txt:5148
+#: po/custom/fromJson.txt:5201
 msgid "Steals technology from enemies"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/messages/resmessagesall.json: $.RES_SY_SPT.text[3]
-#: po/custom/fromJson.txt:5151
+#: po/custom/fromJson.txt:5204
 msgid "Steals technology from structures and takes control of weapons"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages1.json: $.RES_TOWER1.text[1]
 #. data/mp/messages/resmessages1.json: $.RES_TOWER1.text[1]
-#: po/custom/fromJson.txt:5155
+#: po/custom/fromJson.txt:5208
 msgid "Steel tower with machinegun"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/research.json: $.R-Wpn-AALaser.name
 #. data/mp/stats/weapons.json: $.AAGunLaser.name
-#: po/custom/fromJson.txt:5159
+#: po/custom/fromJson.txt:5212
 msgid "Stormbringer AA Laser"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/research.json: $.R-Defense-AA-Laser.name
 #. data/mp/stats/structure.json: $.P0-AASite-Laser.name
-#: po/custom/fromJson.txt:5163
+#: po/custom/fromJson.txt:5216
 msgid "Stormbringer Emplacement"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages23.json: $.RES_SY_VSTW1.text[3]
 #. data/mp/messages/resmessages23.json: $.RES_SY_VSTW1.text[3]
-#: po/custom/fromJson.txt:5167
+#: po/custom/fromJson.txt:5220
 msgid "Strike mission continues until enemy destroyed or they retreat"
 msgstr ""
 
@@ -12937,51 +12984,51 @@ msgstr ""
 #. data/mp/messages/resmessagesall.json: $.RES_C_CT2.text[0]
 #. data/mp/messages/resmessagesall.json: $.RES_C_CT3.text[0]
 #. data/mp/messages/resmessagesall.json: $.RES_C_CT4.text[0]
-#: po/custom/fromJson.txt:5172
+#: po/custom/fromJson.txt:5225
 msgid "Stronger Commander Turret Available for Design"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/messages.json: $.MSG1.text[0]
-#: po/custom/fromJson.txt:5175
+#: po/custom/fromJson.txt:5228
 msgid "Structure Research Completed"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/research.json: $.R-Wpn-Sunburst.name
-#: po/custom/fromJson.txt:5178
+#: po/custom/fromJson.txt:5231
 msgid "Sunburst AA Rocket Array"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/research.json: $.R-Defense-Sunburst.name
 #. data/mp/stats/structure.json: $.P0-AASite-Sunburst.name
-#: po/custom/fromJson.txt:5182
+#: po/custom/fromJson.txt:5235
 msgid "Sunburst AA Site"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/weapons.json: $.Rocket-Sunburst.name
-#: po/custom/fromJson.txt:5185
+#: po/custom/fromJson.txt:5238
 msgid "Sunburst AA"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/messages/resmessagesall.json: $.RES_SUPERTRANS.text[0]
-#: po/custom/fromJson.txt:5223
+#: po/custom/fromJson.txt:5276
 msgid "Super Transport Available"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/body.json: $.SuperTransportBody.name
-#: po/custom/fromJson.txt:5226
+#: po/custom/fromJson.txt:5279
 msgid "Super Transport Body"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/research.json: $.R-SuperTransport.name
 #. data/mp/stats/templates.json: $.SuperTransport.name
-#: po/custom/fromJson.txt:5230
+#: po/custom/fromJson.txt:5283
 #: src/design.cpp:1059
 msgid "Super Transport"
 msgstr ""
@@ -12989,21 +13036,21 @@ msgstr ""
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Defense-WallUpgrade05.name
 #. data/mp/stats/research.json: $.R-Defense-WallUpgrade05.name
-#: po/custom/fromJson.txt:5238
+#: po/custom/fromJson.txt:5291
 msgid "Supercrete Mk2"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Defense-WallUpgrade06.name
 #. data/mp/stats/research.json: $.R-Defense-WallUpgrade06.name
-#: po/custom/fromJson.txt:5242
+#: po/custom/fromJson.txt:5295
 msgid "Supercrete Mk3"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Defense-WallUpgrade04.name
 #. data/mp/stats/research.json: $.R-Defense-WallUpgrade04.name
-#: po/custom/fromJson.txt:5246
+#: po/custom/fromJson.txt:5299
 msgid "Supercrete"
 msgstr ""
 
@@ -13012,67 +13059,67 @@ msgstr ""
 #. data/base/messages/resmessages3.json: $.RES_V_MET7.text[1]
 #. data/mp/messages/resmessages3.json: $.RES_CYMET7.text[1]
 #. data/mp/messages/resmessages3.json: $.RES_V_MET7.text[1]
-#: po/custom/fromJson.txt:5252
+#: po/custom/fromJson.txt:5305
 msgid "Superdense composite alloys and energy-absorbing fibres"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Vehicle-Metals08.name
 #. data/mp/stats/research.json: $.R-Vehicle-Metals08.name
-#: po/custom/fromJson.txt:5256
+#: po/custom/fromJson.txt:5309
 msgid "Superdense Composite Alloys Mk2"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Vehicle-Metals09.name
 #. data/mp/stats/research.json: $.R-Vehicle-Metals09.name
-#: po/custom/fromJson.txt:5260
+#: po/custom/fromJson.txt:5313
 msgid "Superdense Composite Alloys Mk3"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Vehicle-Metals07.name
 #. data/mp/stats/research.json: $.R-Vehicle-Metals07.name
-#: po/custom/fromJson.txt:5264
+#: po/custom/fromJson.txt:5317
 msgid "Superdense Composite Alloys"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Wpn-Flamer-Damage05.name
 #. data/mp/stats/research.json: $.R-Wpn-Flamer-Damage05.name
-#: po/custom/fromJson.txt:5268
+#: po/custom/fromJson.txt:5321
 msgid "Superhot Flamer Gel Mk2"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Wpn-Flamer-Damage06.name
 #. data/mp/stats/research.json: $.R-Wpn-Flamer-Damage06.name
-#: po/custom/fromJson.txt:5272
+#: po/custom/fromJson.txt:5325
 msgid "Superhot Flamer Gel Mk3"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Wpn-Flamer-Damage04.name
 #. data/mp/stats/research.json: $.R-Wpn-Flamer-Damage04.name
-#: po/custom/fromJson.txt:5276
+#: po/custom/fromJson.txt:5329
 msgid "Superhot Flamer Gel"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/research.json: $.R-Wpn-Flamer-Damage08.name
-#: po/custom/fromJson.txt:5279
+#: po/custom/fromJson.txt:5332
 msgid "Superhot Plasmite gel Mk2"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/research.json: $.R-Wpn-Flamer-Damage09.name
-#: po/custom/fromJson.txt:5282
+#: po/custom/fromJson.txt:5335
 msgid "Superhot Plasmite gel Mk3"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/research.json: $.R-Wpn-Flamer-Damage07.name
-#: po/custom/fromJson.txt:5285
+#: po/custom/fromJson.txt:5338
 msgid "Superhot Plasmite gel"
 msgstr ""
 
@@ -13080,42 +13127,42 @@ msgstr ""
 #. data/base/messages/resmessages3.json: $.RES_W_MS_LtSAM1.text[1]
 #. data/mp/messages/resmessages3.json: $.RES_W_MS_LtSAM1.text[1]
 #. data/mp/messages/resmessagesall.json: $.RES_MS_SAM1WT.text[1]
-#: po/custom/fromJson.txt:5302
+#: po/custom/fromJson.txt:5355
 msgid "Surface-to-air missile"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages1.json: $.RES_C_SL1.text[1]
 #. data/mp/messages/resmessages1.json: $.RES_C_SL1.text[1]
-#: po/custom/fromJson.txt:5306
+#: po/custom/fromJson.txt:5359
 msgid "Synaptic Link allows humans to interface directly with computers"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Struc-Research-Upgrade02.name
 #. data/mp/stats/research.json: $.R-Struc-Research-Upgrade02.name
-#: po/custom/fromJson.txt:5310
+#: po/custom/fromJson.txt:5363
 msgid "Synaptic Link Data Analysis Mk2"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Struc-Research-Upgrade03.name
 #. data/mp/stats/research.json: $.R-Struc-Research-Upgrade03.name
-#: po/custom/fromJson.txt:5314
+#: po/custom/fromJson.txt:5367
 msgid "Synaptic Link Data Analysis Mk3"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages1.json: $.RES_ST_RU1.text[1]
 #. data/mp/messages/resmessages1.json: $.RES_ST_RU1.text[1]
-#: po/custom/fromJson.txt:5318
+#: po/custom/fromJson.txt:5371
 msgid "Synaptic link data analysis"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Struc-Research-Upgrade01.name
 #. data/mp/stats/research.json: $.R-Struc-Research-Upgrade01.name
-#: po/custom/fromJson.txt:5322
+#: po/custom/fromJson.txt:5375
 msgid "Synaptic Link Data Analysis"
 msgstr ""
 
@@ -13123,7 +13170,7 @@ msgstr ""
 #. data/base/messages/resmessages3.json: $.RES_SY_ST1.text[1]
 #. data/mp/messages/resmessages3.json: $.RES_SY_ST1.text[1]
 #. data/mp/messages/resmessagesall.json: $.RES_SY_SPT.text[1]
-#: po/custom/fromJson.txt:5327
+#: po/custom/fromJson.txt:5380
 msgid "Synaptic Link Scrambler technology"
 msgstr ""
 
@@ -13132,20 +13179,20 @@ msgstr ""
 #. data/base/messages/resmessages3.json: $.RES_SY_ADEF.text[1]
 #. data/base/messages/resmessages3.json: $.RES_SY_ASTRUC.text[1]
 #. ... + 7 refs
-#: po/custom/fromJson.txt:5333
+#: po/custom/fromJson.txt:5386
 msgid "Synaptic Link technology breakthrough"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Comp-SynapticLink.name
 #. data/mp/stats/research.json: $.R-Comp-SynapticLink.name
-#: po/custom/fromJson.txt:5337
+#: po/custom/fromJson.txt:5390
 msgid "Synaptic Link"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/messages.json: $.MSG5.text[0]
-#: po/custom/fromJson.txt:5340
+#: po/custom/fromJson.txt:5393
 msgid "Systems Research Completed"
 msgstr ""
 
@@ -13154,7 +13201,7 @@ msgstr ""
 #. data/base/stats/structure.json: $.Emplacement-HvyATrocket.name
 #. data/mp/stats/research.json: $.R-Defense-HvyA-Trocket.name
 #. data/mp/stats/structure.json: $.Emplacement-HvyATrocket.name
-#: po/custom/fromJson.txt:5346
+#: po/custom/fromJson.txt:5399
 msgid "Tank Killer Emplacement"
 msgstr ""
 
@@ -13163,19 +13210,19 @@ msgstr ""
 #. data/base/stats/structure.json: $.WallTower-HvATrocket.name
 #. data/mp/stats/research.json: $.R-Defense-WallTower-HvyA-Trocket.name
 #. data/mp/stats/structure.json: $.WallTower-HvATrocket.name
-#: po/custom/fromJson.txt:5352
+#: po/custom/fromJson.txt:5405
 msgid "Tank Killer Hardpoint"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/templates.json: $.TK-Mantis-H.name
-#: po/custom/fromJson.txt:5355
+#: po/custom/fromJson.txt:5408
 msgid "Tank Killer Mantis Hover"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/templates.json: $.MantisTKTracks.name
-#: po/custom/fromJson.txt:5358
+#: po/custom/fromJson.txt:5411
 msgid "Tank Killer Mantis Tracks"
 msgstr ""
 
@@ -13183,27 +13230,27 @@ msgstr ""
 #. data/base/stats/templates.json: $.P0cam3PyHvyATTrk.name
 #. data/mp/stats/templates.json: $.P0cam3PyHvyATTrk.name
 #. data/mp/stats/templates.json: $.PythonTKTracks.name
-#: po/custom/fromJson.txt:5363
+#: po/custom/fromJson.txt:5416
 msgid "Tank Killer Python Tracks"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Wpn-Rocket07-Tank-Killer.name
 #. data/mp/stats/research.json: $.R-Wpn-Rocket07-Tank-Killer.name
-#: po/custom/fromJson.txt:5367
+#: po/custom/fromJson.txt:5420
 msgid "Tank Killer Rocket"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/templates.json: $.A-Veng-Trk-TK.name
-#: po/custom/fromJson.txt:5370
+#: po/custom/fromJson.txt:5423
 msgid "Tank Killer Vengeance Tracks"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/weapons.json: $.Rocket-HvyA-T.name
 #. data/mp/stats/weapons.json: $.Rocket-HvyA-T.name
-#: po/custom/fromJson.txt:5374
+#: po/custom/fromJson.txt:5427
 msgid "Tank Killer"
 msgstr ""
 
@@ -13212,234 +13259,238 @@ msgstr ""
 #. data/base/stats/structure.json: $.A0TankTrap.name
 #. data/base/stats/structure.json: $.TankTrapC.name
 #. ... + 3 refs
-#: po/custom/fromJson.txt:5380
+#: po/custom/fromJson.txt:5433
 msgid "Tank Traps"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Wpn-Howitzer-Accuracy02.name
 #. data/mp/stats/research.json: $.R-Wpn-Howitzer-Accuracy02.name
-#: po/custom/fromJson.txt:5384
+#: po/custom/fromJson.txt:5437
 msgid "Target Acquisition Artillery Shells Mk2"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Wpn-Howitzer-Accuracy01.name
 #. data/mp/stats/research.json: $.R-Wpn-Howitzer-Accuracy01.name
-#: po/custom/fromJson.txt:5388
+#: po/custom/fromJson.txt:5441
 msgid "Target Acquisition Artillery Shells"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Wpn-Bomb-Accuracy03.name
-#: po/custom/fromJson.txt:5391
+#: po/custom/fromJson.txt:5444
 msgid "Target Acquisition Bombsight"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Wpn-Mortar-Acc03.name
 #. data/mp/stats/research.json: $.R-Wpn-Mortar-Acc03.name
-#: po/custom/fromJson.txt:5395
+#: po/custom/fromJson.txt:5448
 msgid "Target Acquisition Mortar Shells"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Wpn-Howitzer-Accuracy03.name
 #. data/mp/stats/research.json: $.R-Wpn-Howitzer-Accuracy03.name
-#: po/custom/fromJson.txt:5399
+#: po/custom/fromJson.txt:5452
 msgid "Target Prediction Artillery Shells"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Wpn-Rail-Accuracy01.name
-#: po/custom/fromJson.txt:5402
+#: po/custom/fromJson.txt:5455
 msgid "Target Prediction Computer"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Wpn-Missile-Accuracy01.name
 #. data/mp/stats/research.json: $.R-Wpn-Missile-Accuracy01.name
-#: po/custom/fromJson.txt:5406
+#: po/custom/fromJson.txt:5459
 msgid "Target Prediction Missiles"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages12.json: $.RES_W_M_AC1.text[1]
 #. data/mp/messages/resmessages12.json: $.RES_W_M_AC1.text[1]
-#: po/custom/fromJson.txt:5410
+#: po/custom/fromJson.txt:5463
 msgid "Targeting systems compensate for distance and weather conditions"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessagesall.json: $.RES_ST_VP.text[3]
 #. data/mp/messages/resmessagesall.json: $.RES_ST_VP.text[3]
-#: po/custom/fromJson.txt:5414
+#: po/custom/fromJson.txt:5467
 msgid "The VTOL returns to the selected pad for rearming"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/messages/resmessages3.json: $.RES_CY_AH4.text[2]
-#: po/custom/fromJson.txt:5417
+#: po/custom/fromJson.txt:5471
+#, no-c-format
 msgid "Thermal Armor +35%"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/messages/resmessages2.json: $.RES_V_AH1.text[2]
-#: po/custom/fromJson.txt:5420
+#: po/custom/fromJson.txt:5475
+#, no-c-format
 msgid "Thermal armor +40%"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/messages/resmessages3.json: $.RES_V_AH4.text[2]
 #. data/mp/messages/resmessagesall.json: $.RES_V_AH7.text[2]
-#: po/custom/fromJson.txt:5424
+#: po/custom/fromJson.txt:5480
+#, no-c-format
 msgid "Thermal Armor +40%"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/messages/resmessages2.json: $.RES_CY_AH1.text[2]
-#: po/custom/fromJson.txt:5427
+#: po/custom/fromJson.txt:5484
+#, no-c-format
 msgid "Thermal Armor +45%"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Vehicle-Armor-Heat02.name
 #. data/mp/stats/research.json: $.R-Vehicle-Armor-Heat02.name
-#: po/custom/fromJson.txt:5435
+#: po/custom/fromJson.txt:5492
 msgid "Thermal Armor Mk2"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Vehicle-Armor-Heat03.name
 #. data/mp/stats/research.json: $.R-Vehicle-Armor-Heat03.name
-#: po/custom/fromJson.txt:5439
+#: po/custom/fromJson.txt:5496
 msgid "Thermal Armor Mk3"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Vehicle-Armor-Heat01.name
 #. data/mp/stats/research.json: $.R-Vehicle-Armor-Heat01.name
-#: po/custom/fromJson.txt:5443
+#: po/custom/fromJson.txt:5500
 msgid "Thermal Armor"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Wpn-Bomb-Accuracy01.name
-#: po/custom/fromJson.txt:5446
+#: po/custom/fromJson.txt:5503
 msgid "Thermal Imaging Bombsight"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Wpn-Mortar-Acc02.name
 #. data/mp/stats/research.json: $.R-Wpn-Mortar-Acc02.name
-#: po/custom/fromJson.txt:5450
+#: po/custom/fromJson.txt:5507
 msgid "Thermal Imaging Mortar Shells"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Wpn-RocketSlow-Accuracy03.name
 #. data/mp/stats/research.json: $.R-Wpn-RocketSlow-Accuracy02.name
-#: po/custom/fromJson.txt:5454
+#: po/custom/fromJson.txt:5511
 msgid "Thermal Imaging Rockets"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Wpn-Bomb04.name
 #. data/mp/stats/research.json: $.R-Wpn-Bomb04.name
-#: po/custom/fromJson.txt:5458
+#: po/custom/fromJson.txt:5515
 msgid "Thermite Bomb Bay"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/templates.json: $.Cyb-Thermite.name
-#: po/custom/fromJson.txt:5461
+#: po/custom/fromJson.txt:5518
 msgid "Thermite Flamer"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Wpn-Energy-ROF02.name
 #. data/mp/stats/research.json: $.R-Wpn-Energy-ROF02.name
-#: po/custom/fromJson.txt:5465
+#: po/custom/fromJson.txt:5522
 msgid "Thermopole Energizer Mk2"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Wpn-Energy-ROF03.name
 #. data/mp/stats/research.json: $.R-Wpn-Energy-ROF03.name
-#: po/custom/fromJson.txt:5469
+#: po/custom/fromJson.txt:5526
 msgid "Thermopole Energizer Mk3"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Wpn-Energy-ROF01.name
 #. data/mp/stats/research.json: $.R-Wpn-Energy-ROF01.name
-#: po/custom/fromJson.txt:5473
+#: po/custom/fromJson.txt:5530
 msgid "Thermopole Energizer"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/body.json: $.Body9REC.name
 #. data/mp/stats/body.json: $.Body9REC.name
-#: po/custom/fromJson.txt:5480
+#: po/custom/fromJson.txt:5537
 msgid "Tiger"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessagesall.json: $.RES_DF_HCW1.text[1]
 #. data/mp/messages/resmessagesall.json: $.RES_DF_HCW1.text[1]
-#: po/custom/fromJson.txt:5484
+#: po/custom/fromJson.txt:5541
 msgid "Titanium-reinforced concrete"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/multiplay/skirmish/nb_turtle.json: $.AI.tip
-#: po/custom/fromJson.txt:5487
+#: po/custom/fromJson.txt:5544
 msgid "Tower wars AI, based on NullBot"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Vehicle-Prop-Tracks.name
 #. data/mp/stats/research.json: $.R-Vehicle-Prop-Tracks.name
-#: po/custom/fromJson.txt:5494
+#: po/custom/fromJson.txt:5551
 msgid "Tracked Propulsion"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages1.json: $.RES_W_SRK_AC1.text[1]
 #. data/mp/messages/resmessages1.json: $.RES_W_SRK_AC1.text[1]
-#: po/custom/fromJson.txt:5498
+#: po/custom/fromJson.txt:5555
 msgid "Tracks and directs in-flight rocket to target"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/propulsion.json: $.tracked02.name
-#: po/custom/fromJson.txt:5501
+#: po/custom/fromJson.txt:5558
 msgid "Tracks II"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/propulsion.json: $.tracked03.name
-#: po/custom/fromJson.txt:5504
+#: po/custom/fromJson.txt:5561
 msgid "Tracks III"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/propulsion.json: $.tracked01.name
 #. data/mp/stats/propulsion.json: $.tracked01.name
-#: po/custom/fromJson.txt:5508
+#: po/custom/fromJson.txt:5565
 msgid "Tracks"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/body.json: $.TransporterBody.name
 #. data/mp/stats/body.json: $.TransporterBody.name
-#: po/custom/fromJson.txt:5512
+#: po/custom/fromJson.txt:5569
 msgid "Transport Body"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/templates.json: $.Transporter.name
-#: po/custom/fromJson.txt:5515
+#: po/custom/fromJson.txt:5572
 #: src/design.cpp:1054
 msgid "Transport"
 msgstr ""
@@ -13447,25 +13498,25 @@ msgstr ""
 #. TRANSLATORS:
 #. data/base/stats/templates.json: $.BarbarianTrike.name
 #. data/mp/stats/templates.json: $.BarbarianTrike.name
-#: po/custom/fromJson.txt:5519
+#: po/custom/fromJson.txt:5576
 msgid "Trike"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/templates.json: $.CobraHoverTruck.name
-#: po/custom/fromJson.txt:5522
+#: po/custom/fromJson.txt:5579
 msgid "Truck Cobra Hover"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/templates.json: $.MantisHoverTruck.name
-#: po/custom/fromJson.txt:5525
+#: po/custom/fromJson.txt:5582
 msgid "Truck Mantis Hover"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/templates.json: $.ScorpHoverTruck.name
-#: po/custom/fromJson.txt:5528
+#: po/custom/fromJson.txt:5585
 msgid "Truck Scorpion Hover"
 msgstr ""
 
@@ -13474,83 +13525,83 @@ msgstr ""
 #. data/base/stats/templates.json: $.ConstructionDroid.name
 #. data/base/stats/templates.json: $.ConstructorDroid.name
 #. ... + 5 refs
-#: po/custom/fromJson.txt:5534
+#: po/custom/fromJson.txt:5591
 msgid "Truck"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Wpn-MG-Damage06.name
 #. data/mp/stats/research.json: $.R-Wpn-MG-Damage06.name
-#: po/custom/fromJson.txt:5542
+#: po/custom/fromJson.txt:5599
 msgid "Tungsten-Tipped MG Bullets Mk2"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Wpn-MG-Damage07.name
 #. data/mp/stats/research.json: $.R-Wpn-MG-Damage07.name
-#: po/custom/fromJson.txt:5546
+#: po/custom/fromJson.txt:5603
 msgid "Tungsten-Tipped MG Bullets Mk3"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Wpn-MG-Damage05.name
 #. data/mp/stats/research.json: $.R-Wpn-MG-Damage05.name
-#: po/custom/fromJson.txt:5550
+#: po/custom/fromJson.txt:5607
 msgid "Tungsten-Tipped MG Bullets"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Vehicle-Engine05.name
 #. data/mp/stats/research.json: $.R-Vehicle-Engine05.name
-#: po/custom/fromJson.txt:5554
+#: po/custom/fromJson.txt:5611
 msgid "Turbo-Charged Engine Mk2"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Vehicle-Engine06.name
 #. data/mp/stats/research.json: $.R-Vehicle-Engine06.name
-#: po/custom/fromJson.txt:5558
+#: po/custom/fromJson.txt:5615
 msgid "Turbo-Charged Engine Mk3"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/multiplay/skirmish/nb_turtle.json: $.AI.name
-#: po/custom/fromJson.txt:5567
+#: po/custom/fromJson.txt:5624
 msgid "Turtle AI"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages1.json: $.RES_MG2MK1.text[1]
 #. data/mp/messages/resmessages1.json: $.RES_MG2MK1.text[1]
-#: po/custom/fromJson.txt:5571
+#: po/custom/fromJson.txt:5628
 msgid "Twin 7.62mm machineguns"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/research.json: $.R-Defense-Cannon6.name
 #. data/mp/stats/structure.json: $.PillBox-Cannon6.name
-#: po/custom/fromJson.txt:5579
+#: po/custom/fromJson.txt:5636
 msgid "Twin Assault Cannon Bunker"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/research.json: $.R-Wpn-Cannon6TwinAslt.name
 #. data/mp/stats/weapons.json: $.Cannon6TwinAslt.name
-#: po/custom/fromJson.txt:5583
+#: po/custom/fromJson.txt:5640
 msgid "Twin Assault Cannon"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/research.json: $.R-Defense-WallTower-TwinAGun.name
 #. data/mp/stats/structure.json: $.WallTower-TwinAssaultGun.name
-#: po/custom/fromJson.txt:5587
+#: po/custom/fromJson.txt:5644
 msgid "Twin Assault Gun Hardpoint"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/research.json: $.R-Wpn-MG5.name
 #. data/mp/stats/weapons.json: $.MG5TWINROTARY.name
-#: po/custom/fromJson.txt:5591
+#: po/custom/fromJson.txt:5648
 msgid "Twin Assault Gun"
 msgstr ""
 
@@ -13559,27 +13610,27 @@ msgstr ""
 #. data/base/stats/weapons.json: $.MG2-Pillbox.name
 #. data/mp/stats/structure.json: $.PillBox2.name
 #. data/mp/stats/weapons.json: $.MG2-Pillbox.name
-#: po/custom/fromJson.txt:5597
+#: po/custom/fromJson.txt:5654
 msgid "Twin Machinegun Bunker"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/structure.json: $.GuardTower2.name
 #. data/mp/stats/structure.json: $.GuardTower2.name
-#: po/custom/fromJson.txt:5601
+#: po/custom/fromJson.txt:5658
 msgid "Twin Machinegun Guard Tower"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/templates.json: $.ViperMG02Halftrack.name
 #. data/mp/stats/templates.json: $.ViperMG02Halftrack.name
-#: po/custom/fromJson.txt:5605
+#: po/custom/fromJson.txt:5662
 msgid "Twin Machinegun Viper Half-tracks"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/templates.json: $.A-Viper-Trk-TMG.name
-#: po/custom/fromJson.txt:5608
+#: po/custom/fromJson.txt:5665
 msgid "Twin Machinegun Viper Tracks"
 msgstr ""
 
@@ -13587,7 +13638,7 @@ msgstr ""
 #. data/base/stats/templates.json: $.ViperMG02Wheels.name
 #. data/mp/stats/templates.json: $.A-Viper-Wheels-TMG.name
 #. data/mp/stats/templates.json: $.ViperMG02Wheels.name
-#: po/custom/fromJson.txt:5613
+#: po/custom/fromJson.txt:5670
 msgid "Twin Machinegun Viper Wheels"
 msgstr ""
 
@@ -13596,32 +13647,32 @@ msgstr ""
 #. data/base/stats/weapons.json: $.MG2Mk1.name
 #. data/mp/stats/research.json: $.R-Wpn-MG2Mk1.name
 #. data/mp/stats/weapons.json: $.MG2Mk1.name
-#: po/custom/fromJson.txt:5619
+#: po/custom/fromJson.txt:5676
 msgid "Twin Machinegun"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/messages/resmessagesall.json: $.RES_DEF_AALAS.text[1]
-#: po/custom/fromJson.txt:5622
+#: po/custom/fromJson.txt:5679
 msgid "Twin Medium Anti-Aircraft Laser"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/messages/resmessagesall.json: $.RES_WT_TWINAGHP.text[1]
 #. data/mp/messages/resmessagesall.json: $.RES_WT_TWINAGUN.text[1]
-#: po/custom/fromJson.txt:5626
+#: po/custom/fromJson.txt:5683
 msgid "Twin Multi-barrel, rapid-fire machinegun"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/challenges/two-faced.json: $.challenge.name
-#: po/custom/fromJson.txt:5629
+#: po/custom/fromJson.txt:5686
 msgid "Two-faced"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/messages.json: $.MSG4.text[0]
-#: po/custom/fromJson.txt:5632
+#: po/custom/fromJson.txt:5689
 msgid "Unit Research Completed"
 msgstr ""
 
@@ -13629,98 +13680,98 @@ msgstr ""
 #. data/mp/messages/resmessagesall.json: $.RES_C_CT2.text[1]
 #. data/mp/messages/resmessagesall.json: $.RES_C_CT3.text[1]
 #. data/mp/messages/resmessagesall.json: $.RES_C_CT4.text[1]
-#: po/custom/fromJson.txt:5637
+#: po/custom/fromJson.txt:5694
 msgid "Upgraded battlefield computer system"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/sensor.json: $.UplinkSensor.name
 #. data/mp/stats/sensor.json: $.UplinkSensor.name
-#: po/custom/fromJson.txt:5641
+#: po/custom/fromJson.txt:5698
 msgid "Uplink Sensor"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages1.json: $.RES_ST_FM1.text[3]
 #. data/mp/messages/resmessages1.json: $.RES_ST_FM1.text[3]
-#: po/custom/fromJson.txt:5645
+#: po/custom/fromJson.txt:5702
 msgid "Use a truck to add modules to a factory"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages1.json: $.RES_POWMD1.text[3]
 #. data/mp/messages/resmessages1.json: $.RES_POWMD1.text[3]
-#: po/custom/fromJson.txt:5649
+#: po/custom/fromJson.txt:5706
 msgid "Use a truck to add the module to a power generator"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages1.json: $.RES_ST_RM1.text[3]
 #. data/mp/messages/resmessages1.json: $.RES_ST_RM1.text[3]
-#: po/custom/fromJson.txt:5653
+#: po/custom/fromJson.txt:5710
 msgid "Use a truck to add the module to a research facility"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages1.json: $.RES_REPAI1.text[2]
 #. data/mp/messages/resmessages1.json: $.RES_REPAI1.text[2]
-#: po/custom/fromJson.txt:5657
+#: po/custom/fromJson.txt:5714
 msgid "Use the Command Console to send units back for repair"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/messages/resmessagesall.json: $.RES_EMP_CAN.text[1]
-#: po/custom/fromJson.txt:5660
+#: po/custom/fromJson.txt:5717
 msgid "Uses advanced cannon technology"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/messages/resmessagesall.json: $.RES_EMP_MD.text[1]
-#: po/custom/fromJson.txt:5663
+#: po/custom/fromJson.txt:5720
 msgid "Uses advanced mass driver railgun technology"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/messages/resmessagesall.json: $.RES_EMP_MSL.text[1]
-#: po/custom/fromJson.txt:5666
+#: po/custom/fromJson.txt:5723
 msgid "Uses advanced missile gun technology"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/messages/resmessagesall.json: $.RES_EMP_RKT.text[1]
-#: po/custom/fromJson.txt:5669
+#: po/custom/fromJson.txt:5726
 msgid "Uses advanced rocket gun technology"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/multiplay/skirmish/Cobra.json: $.AI.hard_tip
-#: po/custom/fromJson.txt:5672
+#: po/custom/fromJson.txt:5729
 msgid "Uses the Heavy Plasma Launcher"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages3.json: $.RES_POWU2.text[2]
 #. data/mp/messages/resmessages3.json: $.RES_POWU2.text[1]
-#: po/custom/fromJson.txt:5676
+#: po/custom/fromJson.txt:5733
 msgid "Vapor Turbine boosts power output"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/research.json: $.R-Struc-Power-Upgrade03.name
-#: po/custom/fromJson.txt:5679
+#: po/custom/fromJson.txt:5736
 msgid "Vapor Turbine Generator Mk2"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/research.json: $.R-Struc-Power-Upgrade03a.name
-#: po/custom/fromJson.txt:5682
+#: po/custom/fromJson.txt:5739
 msgid "Vapor Turbine Generator Mk3"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Struc-Power-Upgrade02.name
 #. data/mp/stats/research.json: $.R-Struc-Power-Upgrade02.name
-#: po/custom/fromJson.txt:5686
+#: po/custom/fromJson.txt:5743
 msgid "Vapor Turbine Generator"
 msgstr ""
 
@@ -13729,57 +13780,58 @@ msgstr ""
 #. data/mp/messages/resmessages2.json: $.RES_V_EN4.text[2]
 #. data/mp/messages/resmessages3.json: $.RES_V_EN10.text[2]
 #. data/mp/messages/resmessages3.json: $.RES_V_EN7.text[2]
-#: po/custom/fromJson.txt:5715
+#: po/custom/fromJson.txt:5773
+#, no-c-format
 msgid "Vehicle speed +5%"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/research.json: $.R-Vehicle-Armor-Heat08.name
-#: po/custom/fromJson.txt:5718
+#: po/custom/fromJson.txt:5776
 msgid "Vehicle Superdense Thermal Armor Mk2"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/research.json: $.R-Vehicle-Armor-Heat09.name
-#: po/custom/fromJson.txt:5721
+#: po/custom/fromJson.txt:5779
 msgid "Vehicle Superdense Thermal Armor Mk3"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/research.json: $.R-Vehicle-Armor-Heat07.name
-#: po/custom/fromJson.txt:5724
+#: po/custom/fromJson.txt:5782
 msgid "Vehicle Superdense Thermal Armor"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/templates.json: $.A-Veng-Trk-Guass.name
-#: po/custom/fromJson.txt:5733
+#: po/custom/fromJson.txt:5791
 msgid "Vengeance Tracks Gauss Cannon"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/templates.json: $.A-Veng-Trk-Scourge.name
-#: po/custom/fromJson.txt:5736
+#: po/custom/fromJson.txt:5794
 msgid "Vengeance Tracks Gauss Scourge"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/templates.json: $.A-Veng-Trk-Rail.name
-#: po/custom/fromJson.txt:5739
+#: po/custom/fromJson.txt:5797
 msgid "Vengeance Tracks Rail Gun"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/body.json: $.Body10MBT.name
 #. data/mp/stats/body.json: $.Body10MBT.name
-#: po/custom/fromJson.txt:5743
+#: po/custom/fromJson.txt:5801
 msgid "Vengeance"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessagesall.json: $.RES_V_P_V1.text[1]
 #. data/mp/messages/resmessagesall.json: $.RES_V_P_V1.text[1]
-#: po/custom/fromJson.txt:5747
+#: po/custom/fromJson.txt:5805
 msgid "Vertical Take Off and Landing Propulsion"
 msgstr ""
 
@@ -13788,33 +13840,33 @@ msgstr ""
 #. data/mp/messages/resmessages3.json: $.RES_V_B10.text[3]
 #. data/mp/messages/resmessagesall.json: $.RES_V_B13.text[3]
 #. data/mp/messages/resmessagesall.json: $.RES_V_B14.text[3]
-#: po/custom/fromJson.txt:5753
+#: po/custom/fromJson.txt:5811
 msgid "Very expensive to produce"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages1.json: $.RES_V_B11.text[3]
 #. data/mp/messages/resmessages1.json: $.RES_V_B11.text[3]
-#: po/custom/fromJson.txt:5757
+#: po/custom/fromJson.txt:5815
 msgid "Very high power costs and very slow to produce"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/messages/resmessagesall.json: $.RES_V_B14.text[2]
-#: po/custom/fromJson.txt:5760
+#: po/custom/fromJson.txt:5818
 msgid "Very slow moving Body"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/messages/resmessagesall.json: $.RES_W_LASSAT.text[1]
-#: po/custom/fromJson.txt:5763
+#: po/custom/fromJson.txt:5821
 msgid "Very slow recharge time"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/research.json: $.R-Defense-WallTower-SamHvy.name
 #. data/mp/stats/structure.json: $.WallTower-SamHvy.name
-#: po/custom/fromJson.txt:5767
+#: po/custom/fromJson.txt:5825
 msgid "Vindicator Hardpoint"
 msgstr ""
 
@@ -13823,7 +13875,7 @@ msgstr ""
 #. data/base/stats/structure.json: $.P0-AASite-SAM2.name
 #. data/mp/stats/research.json: $.R-Defense-SamSite2.name
 #. data/mp/stats/structure.json: $.P0-AASite-SAM2.name
-#: po/custom/fromJson.txt:5773
+#: po/custom/fromJson.txt:5831
 msgid "Vindicator SAM Site"
 msgstr ""
 
@@ -13832,75 +13884,75 @@ msgstr ""
 #. data/base/stats/weapons.json: $.Missile-HvySAM.name
 #. data/mp/stats/research.json: $.R-Wpn-Missile-HvSAM.name
 #. data/mp/stats/weapons.json: $.Missile-HvySAM.name
-#: po/custom/fromJson.txt:5779
+#: po/custom/fromJson.txt:5837
 msgid "Vindicator SAM"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/body.json: $.Body1REC.name
 #. data/mp/stats/body.json: $.Body1REC.name
-#: po/custom/fromJson.txt:5783
+#: po/custom/fromJson.txt:5841
 msgid "Viper"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/weapons.json: $.Cannon5Vulcan-VTOL.name
 #. data/mp/stats/weapons.json: $.Cannon5Vulcan-VTOL.name
-#: po/custom/fromJson.txt:5787
+#: po/custom/fromJson.txt:5845
 msgid "VTOL Assault Cannon"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/weapons.json: $.MG4ROTARY-VTOL.name
 #. data/mp/stats/weapons.json: $.MG4ROTARY-VTOL.name
-#: po/custom/fromJson.txt:5791
+#: po/custom/fromJson.txt:5849
 msgid "VTOL Assault Gun"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/templates.json: $.V-Bug-BB.name
-#: po/custom/fromJson.txt:5794
+#: po/custom/fromJson.txt:5852
 msgid "VTOL Bunker Buster Bug VTOL"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/templates.json: $.V-Scor-BB.name
-#: po/custom/fromJson.txt:5797
+#: po/custom/fromJson.txt:5855
 msgid "VTOL Bunker Buster Scorpion VTOL"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/weapons.json: $.Rocket-VTOL-BB.name
 #. data/mp/stats/weapons.json: $.Rocket-VTOL-BB.name
-#: po/custom/fromJson.txt:5801
+#: po/custom/fromJson.txt:5859
 msgid "VTOL Bunker Buster"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/weapons.json: $.Cannon1-VTOL.name
 #. data/mp/stats/weapons.json: $.Cannon1-VTOL.name
-#: po/custom/fromJson.txt:5805
+#: po/custom/fromJson.txt:5863
 msgid "VTOL Cannon"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/sensor.json: $.Sys-VTOLCBTower01.name
 #. data/mp/stats/sensor.json: $.Sys-VTOLCBTower01.name
-#: po/custom/fromJson.txt:5815
+#: po/custom/fromJson.txt:5873
 msgid "VTOL CB Radar Tower"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/sensor.json: $.Sys-VTOLCBTurret01.name
 #. data/mp/stats/sensor.json: $.Sys-VTOLCBTurret01.name
-#: po/custom/fromJson.txt:5819
+#: po/custom/fromJson.txt:5877
 msgid "VTOL CB Radar Turret"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages23.json: $.RES_SY_VCBSTW1.text[1]
 #. data/mp/messages/resmessages23.json: $.RES_SY_VCBSTW1.text[1]
-#: po/custom/fromJson.txt:5823
+#: po/custom/fromJson.txt:5881
 msgid "VTOL CB Tower detects enemy indirect fire batteries"
 msgstr ""
 
@@ -13909,51 +13961,51 @@ msgstr ""
 #. data/base/stats/structure.json: $.Sys-VTOL-CB-Tower01.name
 #. data/mp/stats/research.json: $.R-Sys-VTOLCBS-Tower01.name
 #. data/mp/stats/structure.json: $.Sys-VTOL-CB-Tower01.name
-#: po/custom/fromJson.txt:5829
+#: po/custom/fromJson.txt:5887
 msgid "VTOL CB Tower"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Sys-VTOLCBS-Turret01.name
 #. data/mp/stats/research.json: $.R-Sys-VTOLCBS-Turret01.name
-#: po/custom/fromJson.txt:5837
+#: po/custom/fromJson.txt:5895
 msgid "VTOL CB Turret"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/templates.json: $.V-Bug-ClusterBomb.name
-#: po/custom/fromJson.txt:5840
+#: po/custom/fromJson.txt:5898
 msgid "VTOL Cluster Bomb Bay Bug VTOL"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/templates.json: $.V-Scor-ClusterBomb.name
-#: po/custom/fromJson.txt:5843
+#: po/custom/fromJson.txt:5901
 msgid "VTOL Cluster Bomb Bay Scorpion VTOL"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/weapons.json: $.Bomb1-VTOL-LtHE.name
-#: po/custom/fromJson.txt:5846
+#: po/custom/fromJson.txt:5904
 msgid "VTOL Cluster Bomb Bay"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/weapons.json: $.Bomb1-VTOL-LtHE.name
-#: po/custom/fromJson.txt:5849
+#: po/custom/fromJson.txt:5907
 msgid "VTOL Cluster Bombs Bay"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/weapons.json: $.Bomb6-VTOL-EMP.name
-#: po/custom/fromJson.txt:5852
+#: po/custom/fromJson.txt:5910
 msgid "VTOL EMP Missile Launcher"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessagesall.json: $.RES_ST_VF.text[1]
 #. data/mp/messages/resmessagesall.json: $.RES_ST_VF.text[1]
-#: po/custom/fromJson.txt:5856
+#: po/custom/fromJson.txt:5914
 msgid "VTOL factory enables VTOL production"
 msgstr ""
 
@@ -13962,144 +14014,144 @@ msgstr ""
 #. data/base/stats/structure.json: $.A0VTolFactory1.name
 #. data/mp/stats/research.json: $.R-Struc-VTOLFactory.name
 #. data/mp/stats/structure.json: $.A0VTolFactory1.name
-#: po/custom/fromJson.txt:5862
+#: po/custom/fromJson.txt:5920
 msgid "VTOL Factory"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/weapons.json: $.Laser3BEAM-VTOL.name
 #. data/mp/stats/weapons.json: $.Laser3BEAM-VTOL.name
-#: po/custom/fromJson.txt:5866
+#: po/custom/fromJson.txt:5924
 msgid "VTOL Flashlight"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/weapons.json: $.Bomb2-VTOL-HvHE.name
 #. data/mp/stats/weapons.json: $.Bomb2-VTOL-HvHE.name
-#: po/custom/fromJson.txt:5870
+#: po/custom/fromJson.txt:5928
 msgid "VTOL Heap Bomb Bay"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/weapons.json: $.HeavyLaser-VTOL.name
-#: po/custom/fromJson.txt:5873
+#: po/custom/fromJson.txt:5931
 msgid "VTOL Heavy Laser"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/weapons.json: $.MG3-VTOL.name
 #. data/mp/stats/weapons.json: $.MG3-VTOL.name
-#: po/custom/fromJson.txt:5877
+#: po/custom/fromJson.txt:5935
 msgid "VTOL Heavy Machinegun"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/templates.json: $.V-Bug-HPV.name
-#: po/custom/fromJson.txt:5880
+#: po/custom/fromJson.txt:5938
 msgid "VTOL Hyper Velocity Cannon Bug VTOL"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/templates.json: $.V-Mantis-HPV.name
-#: po/custom/fromJson.txt:5883
+#: po/custom/fromJson.txt:5941
 msgid "VTOL Hyper Velocity Cannon Mantis VTOL"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/templates.json: $.V-Scor-HPV.name
-#: po/custom/fromJson.txt:5886
+#: po/custom/fromJson.txt:5944
 msgid "VTOL Hyper Velocity Cannon Scorpion VTOL"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/weapons.json: $.Cannon4AUTO-VTOL.name
 #. data/mp/stats/weapons.json: $.Cannon4AUTO-VTOL.name
-#: po/custom/fromJson.txt:5890
+#: po/custom/fromJson.txt:5948
 msgid "VTOL Hyper Velocity Cannon"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/propulsion.json: $.V-Tol02.name
-#: po/custom/fromJson.txt:5893
+#: po/custom/fromJson.txt:5951
 msgid "VTOL II"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/propulsion.json: $.V-Tol03.name
-#: po/custom/fromJson.txt:5896
+#: po/custom/fromJson.txt:5954
 msgid "VTOL III"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/templates.json: $.V-Bug-Lancer.name
-#: po/custom/fromJson.txt:5899
+#: po/custom/fromJson.txt:5957
 msgid "VTOL Lancer Bug VTOL"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/templates.json: $.V-Mantis-Lancer.name
-#: po/custom/fromJson.txt:5902
+#: po/custom/fromJson.txt:5960
 msgid "VTOL Lancer Mantis VTOL"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/templates.json: $.V-Scor-Lancer.name
-#: po/custom/fromJson.txt:5905
+#: po/custom/fromJson.txt:5963
 msgid "VTOL Lancer Scorpion VTOL"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/weapons.json: $.Rocket-VTOL-LtA-T.name
 #. data/mp/stats/weapons.json: $.Rocket-VTOL-LtA-T.name
-#: po/custom/fromJson.txt:5909
+#: po/custom/fromJson.txt:5967
 msgid "VTOL Lancer"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/weapons.json: $.MG1-VTOL.name
 #. data/mp/stats/weapons.json: $.MG1-VTOL.name
-#: po/custom/fromJson.txt:5913
+#: po/custom/fromJson.txt:5971
 msgid "VTOL Machinegun"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/weapons.json: $.Rocket-VTOL-Pod.name
 #. data/mp/stats/weapons.json: $.Rocket-VTOL-Pod.name
-#: po/custom/fromJson.txt:5917
+#: po/custom/fromJson.txt:5975
 msgid "VTOL Mini-Rocket"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/weapons.json: $.RailGun1-VTOL.name
 #. data/mp/stats/weapons.json: $.RailGun1-VTOL.name
-#: po/custom/fromJson.txt:5921
+#: po/custom/fromJson.txt:5979
 msgid "VTOL Needle Gun"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/weapons.json: $.Bomb3-VTOL-LtINC.name
 #. data/mp/stats/weapons.json: $.Bomb3-VTOL-LtINC.name
-#: po/custom/fromJson.txt:5925
+#: po/custom/fromJson.txt:5983
 msgid "VTOL Phosphor Bomb Bay"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/weapons.json: $.Bomb5-VTOL-Plasmite.name
-#: po/custom/fromJson.txt:5928
+#: po/custom/fromJson.txt:5986
 msgid "VTOL Plasmite Bomb Bay"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/research.json: $.R-Vehicle-Prop-VTOL.name
 #. data/mp/stats/research.json: $.R-Vehicle-Prop-VTOL.name
-#: po/custom/fromJson.txt:5935
+#: po/custom/fromJson.txt:5993
 msgid "VTOL Propulsion"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/weapons.json: $.Laser2PULSE-VTOL.name
 #. data/mp/stats/weapons.json: $.Laser2PULSE-VTOL.name
-#: po/custom/fromJson.txt:5939
+#: po/custom/fromJson.txt:5997
 msgid "VTOL Pulse Laser"
 msgstr ""
 
@@ -14107,14 +14159,14 @@ msgstr ""
 #. data/base/stats/sensor.json: $.Sys-VTOLRadarTower01.name
 #. data/base/stats/structure.json: $.Sys-VTOL-RadarTower01.name
 #. data/mp/stats/sensor.json: $.Sys-VTOLRadarTower01.name
-#: po/custom/fromJson.txt:5944
+#: po/custom/fromJson.txt:6002
 msgid "VTOL Radar Tower"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/weapons.json: $.RailGun2-VTOL.name
 #. data/mp/stats/weapons.json: $.RailGun2-VTOL.name
-#: po/custom/fromJson.txt:5948
+#: po/custom/fromJson.txt:6006
 msgid "VTOL Rail Gun"
 msgstr ""
 
@@ -14123,28 +14175,28 @@ msgstr ""
 #. data/base/stats/structure.json: $.A0VtolPad.name
 #. data/mp/stats/research.json: $.R-Struc-VTOLPad.name
 #. data/mp/stats/structure.json: $.A0VtolPad.name
-#: po/custom/fromJson.txt:5954
+#: po/custom/fromJson.txt:6012
 msgid "VTOL Rearming Pad"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessagesall.json: $.RES_ST_VF.text[2]
 #. data/mp/messages/resmessagesall.json: $.RES_ST_VF.text[2]
-#: po/custom/fromJson.txt:5958
+#: po/custom/fromJson.txt:6016
 msgid "VTOL rearming pads required to keep VTOLs flying"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/weapons.json: $.Missile-VTOL-AT.name
 #. data/mp/stats/weapons.json: $.Missile-VTOL-AT.name
-#: po/custom/fromJson.txt:5968
+#: po/custom/fromJson.txt:6026
 msgid "VTOL Scourge Missile"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages23.json: $.RES_SY_VSTW1.text[1]
 #. data/mp/messages/resmessages23.json: $.RES_SY_VSTW1.text[1]
-#: po/custom/fromJson.txt:5978
+#: po/custom/fromJson.txt:6036
 msgid "VTOL Strike Tower detects approaching enemies"
 msgstr ""
 
@@ -14152,14 +14204,14 @@ msgstr ""
 #. data/base/stats/research.json: $.R-Sys-VTOLStrike-Tower01.name
 #. data/mp/stats/research.json: $.R-Sys-VTOLStrike-Tower01.name
 #. data/mp/stats/structure.json: $.Sys-VTOL-RadarTower01.name
-#: po/custom/fromJson.txt:5983
+#: po/custom/fromJson.txt:6041
 msgid "VTOL Strike Tower"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/resmessages23.json: $.RES_SY_VSTU1.text[1]
 #. data/mp/messages/resmessages23.json: $.RES_SY_VSTU1.text[1]
-#: po/custom/fromJson.txt:5987
+#: po/custom/fromJson.txt:6045
 msgid "VTOL Strike turret used to spot targets"
 msgstr ""
 
@@ -14168,65 +14220,65 @@ msgstr ""
 #. data/base/stats/sensor.json: $.Sys-VstrikeTurret01.name
 #. data/mp/stats/research.json: $.R-Sys-VTOLStrike-Turret01.name
 #. data/mp/stats/sensor.json: $.Sys-VstrikeTurret01.name
-#: po/custom/fromJson.txt:5993
+#: po/custom/fromJson.txt:6051
 msgid "VTOL Strike Turret"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/weapons.json: $.Rocket-VTOL-Sunburst.name
-#: po/custom/fromJson.txt:5996
+#: po/custom/fromJson.txt:6054
 msgid "VTOL Sunburst AA"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/weapons.json: $.Rocket-VTOL-HvyA-T.name
 #. data/mp/stats/weapons.json: $.Rocket-VTOL-HvyA-T.name
-#: po/custom/fromJson.txt:6000
+#: po/custom/fromJson.txt:6058
 msgid "VTOL Tank Killer"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/weapons.json: $.Bomb4-VTOL-HvyINC.name
 #. data/mp/stats/weapons.json: $.Bomb4-VTOL-HvyINC.name
-#: po/custom/fromJson.txt:6004
+#: po/custom/fromJson.txt:6062
 msgid "VTOL Thermite Bomb Bay"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/weapons.json: $.MG2-VTOL.name
 #. data/mp/stats/weapons.json: $.MG2-VTOL.name
-#: po/custom/fromJson.txt:6008
+#: po/custom/fromJson.txt:6066
 msgid "VTOL Twin Machinegun"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/propulsion.json: $.V-Tol.name
 #. data/mp/stats/propulsion.json: $.V-Tol.name
-#: po/custom/fromJson.txt:6012
+#: po/custom/fromJson.txt:6070
 msgid "VTOL"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/features.json: $.Wall.name
-#: po/custom/fromJson.txt:6021
+#: po/custom/fromJson.txt:6079
 msgid "Wall"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/features.json: $.WallCorner.name
-#: po/custom/fromJson.txt:6024
+#: po/custom/fromJson.txt:6082
 msgid "Wallcorner"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/features.json: $.BarbWarehouse1.name
-#: po/custom/fromJson.txt:6027
+#: po/custom/fromJson.txt:6085
 msgid "Warehouse"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/messages/messages.json: $.MSG6.text[0]
-#: po/custom/fromJson.txt:6030
+#: po/custom/fromJson.txt:6088
 msgid "Weapon Research Completed"
 msgstr ""
 
@@ -14235,26 +14287,26 @@ msgstr ""
 #. data/base/stats/research.json: $.R-Vehicle-Prop-Wheels.name
 #. data/mp/messages/resmessages1.json: $.RES_V_P_W1.text[1]
 #. data/mp/stats/research.json: $.R-Vehicle-Prop-Wheels.name
-#: po/custom/fromJson.txt:6039
+#: po/custom/fromJson.txt:6097
 msgid "Wheeled Propulsion"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/propulsion.json: $.wheeled02.name
-#: po/custom/fromJson.txt:6042
+#: po/custom/fromJson.txt:6100
 msgid "Wheels II"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/propulsion.json: $.wheeled03.name
-#: po/custom/fromJson.txt:6045
+#: po/custom/fromJson.txt:6103
 msgid "Wheels III"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/propulsion.json: $.wheeled01.name
 #. data/mp/stats/propulsion.json: $.wheeled01.name
-#: po/custom/fromJson.txt:6049
+#: po/custom/fromJson.txt:6107
 msgid "Wheels"
 msgstr ""
 
@@ -14263,7 +14315,7 @@ msgstr ""
 #. data/base/stats/structure.json: $.AASite-QuadRotMg.name
 #. data/mp/stats/research.json: $.R-Defense-AASite-QuadRotMg.name
 #. data/mp/stats/structure.json: $.AASite-QuadRotMg.name
-#: po/custom/fromJson.txt:6055
+#: po/custom/fromJson.txt:6113
 msgid "Whirlwind AA Site"
 msgstr ""
 
@@ -14272,71 +14324,71 @@ msgstr ""
 #. data/base/stats/weapons.json: $.QuadRotAAGun.name
 #. data/mp/stats/research.json: $.R-Wpn-AAGun04.name
 #. data/mp/stats/weapons.json: $.QuadRotAAGun.name
-#: po/custom/fromJson.txt:6061
+#: po/custom/fromJson.txt:6119
 msgid "Whirlwind AA Turret"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/research.json: $.R-Defense-WallTower-QuadRotAA.name
 #. data/mp/stats/structure.json: $.WallTower-QuadRotAAGun.name
-#: po/custom/fromJson.txt:6065
+#: po/custom/fromJson.txt:6123
 msgid "Whirlwind Hardpoint"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/research.json: $.R-Sys-Sensor-WSTower.name
 #. data/mp/stats/structure.json: $.Sys-SensoTowerWS.name
-#: po/custom/fromJson.txt:6069
+#: po/custom/fromJson.txt:6127
 msgid "Wide Spectrum Sensor Tower"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/research.json: $.R-Sys-Sensor-WS.name
 #. data/mp/stats/sensor.json: $.Sensor-WideSpec.name
-#: po/custom/fromJson.txt:6073
+#: po/custom/fromJson.txt:6131
 msgid "Wide Spectrum Sensor"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/features.json: $.WreckedDroidHub.name
-#: po/custom/fromJson.txt:6076
+#: po/custom/fromJson.txt:6134
 msgid "Wreck"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/features.json: $.WreckedBridge.name
-#: po/custom/fromJson.txt:6079
+#: po/custom/fromJson.txt:6137
 msgid "Wrecked Bridge"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/features.json: $.WreckedTankerV.name
-#: po/custom/fromJson.txt:6082
+#: po/custom/fromJson.txt:6140
 msgid "Wrecked Tanker"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/features.json: $.WreckedVertCampVan.name
-#: po/custom/fromJson.txt:6085
+#: po/custom/fromJson.txt:6143
 msgid "Wrecked Van"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/features.json: $.WreckedSuzukiJeep.name
-#: po/custom/fromJson.txt:6088
+#: po/custom/fromJson.txt:6146
 msgid "Wrecked Vehicle"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/mp/stats/body.json: $.Body13SUP.name
-#: po/custom/fromJson.txt:6091
+#: po/custom/fromJson.txt:6149
 msgid "Wyvern"
 msgstr ""
 
 #. TRANSLATORS:
 #. data/base/stats/brain.json: $.CommandBrain01.ranks[6]
 #. data/base/stats/brain.json: $.ZNULLBRAIN.ranks[6]
-#: po/custom/fromJson.txt:6095
+#: po/custom/fromJson.txt:6153
 msgctxt "rank"
 msgid "Elite"
 msgstr ""
@@ -14344,7 +14396,7 @@ msgstr ""
 #. TRANSLATORS:
 #. data/base/stats/brain.json: $.CommandBrain01.ranks[1]
 #. data/base/stats/brain.json: $.ZNULLBRAIN.ranks[1]
-#: po/custom/fromJson.txt:6099
+#: po/custom/fromJson.txt:6157
 msgctxt "rank"
 msgid "Green"
 msgstr ""
@@ -14352,7 +14404,7 @@ msgstr ""
 #. TRANSLATORS:
 #. data/base/stats/brain.json: $.CommandBrain01.ranks[8]
 #. data/base/stats/brain.json: $.ZNULLBRAIN.ranks[8]
-#: po/custom/fromJson.txt:6103
+#: po/custom/fromJson.txt:6161
 msgctxt "rank"
 msgid "Hero"
 msgstr ""
@@ -14360,7 +14412,7 @@ msgstr ""
 #. TRANSLATORS:
 #. data/base/stats/brain.json: $.CommandBrain01.ranks[4]
 #. data/base/stats/brain.json: $.ZNULLBRAIN.ranks[4]
-#: po/custom/fromJson.txt:6107
+#: po/custom/fromJson.txt:6165
 msgctxt "rank"
 msgid "Professional"
 msgstr ""
@@ -14368,7 +14420,7 @@ msgstr ""
 #. TRANSLATORS:
 #. data/base/stats/brain.json: $.CommandBrain01.ranks[3]
 #. data/base/stats/brain.json: $.ZNULLBRAIN.ranks[3]
-#: po/custom/fromJson.txt:6111
+#: po/custom/fromJson.txt:6169
 msgctxt "rank"
 msgid "Regular"
 msgstr ""
@@ -14376,7 +14428,7 @@ msgstr ""
 #. TRANSLATORS:
 #. data/base/stats/brain.json: $.CommandBrain01.ranks[0]
 #. data/base/stats/brain.json: $.ZNULLBRAIN.ranks[0]
-#: po/custom/fromJson.txt:6115
+#: po/custom/fromJson.txt:6173
 msgctxt "rank"
 msgid "Rookie"
 msgstr ""
@@ -14384,7 +14436,7 @@ msgstr ""
 #. TRANSLATORS:
 #. data/base/stats/brain.json: $.CommandBrain01.ranks[7]
 #. data/base/stats/brain.json: $.ZNULLBRAIN.ranks[7]
-#: po/custom/fromJson.txt:6119
+#: po/custom/fromJson.txt:6177
 msgctxt "rank"
 msgid "Special"
 msgstr ""
@@ -14392,7 +14444,7 @@ msgstr ""
 #. TRANSLATORS:
 #. data/base/stats/brain.json: $.CommandBrain01.ranks[2]
 #. data/base/stats/brain.json: $.ZNULLBRAIN.ranks[2]
-#: po/custom/fromJson.txt:6123
+#: po/custom/fromJson.txt:6181
 msgctxt "rank"
 msgid "Trained"
 msgstr ""
@@ -14400,7 +14452,7 @@ msgstr ""
 #. TRANSLATORS:
 #. data/base/stats/brain.json: $.CommandBrain01.ranks[5]
 #. data/base/stats/brain.json: $.ZNULLBRAIN.ranks[5]
-#: po/custom/fromJson.txt:6127
+#: po/custom/fromJson.txt:6185
 msgctxt "rank"
 msgid "Veteran"
 msgstr ""
@@ -15428,59 +15480,59 @@ msgstr ""
 msgid "Player %u is cheating (debug menu) him/herself a new droid."
 msgstr ""
 
-#: src/hci.cpp:2826
+#: src/hci.cpp:2818
 #: src/multiint.cpp:1300
 #: src/multimenu.cpp:770
 msgid "Power"
 msgstr ""
 
-#: src/hci.cpp:3007
+#: src/hci.cpp:2999
 msgid "Progress Bar"
 msgstr ""
 
-#: src/hci.cpp:3537
+#: src/hci.cpp:3529
 msgid "Hiding Obsolete Tech"
 msgstr ""
 
-#: src/hci.cpp:3539
+#: src/hci.cpp:3531
 msgid "Showing Obsolete Tech"
 msgstr ""
 
-#: src/hci.cpp:3551
+#: src/hci.cpp:3543
 msgid ""
 "Showing All Tech\n"
 "Right-click to add to Favorites"
 msgstr ""
 
-#: src/hci.cpp:3553
+#: src/hci.cpp:3545
 msgid ""
 "Showing Only Favorite Tech\n"
 "Right-click to remove from Favorites"
 msgstr ""
 
-#: src/hci.cpp:3633
+#: src/hci.cpp:3625
 msgid "Factory Delivery Point"
 msgstr ""
 
-#: src/hci.cpp:3642
+#: src/hci.cpp:3634
 msgid "Loop Production"
 msgstr ""
 
-#: src/hci.cpp:3840
+#: src/hci.cpp:3832
 msgid "Ally progress"
 msgstr ""
 
-#: src/hci.cpp:3855
+#: src/hci.cpp:3847
 msgid ""
 "\n"
 "Cost: %1"
 msgstr ""
 
-#: src/hci.cpp:4954
+#: src/hci.cpp:4946
 msgid "Chat: All"
 msgstr ""
 
-#: src/hci.cpp:4959
+#: src/hci.cpp:4951
 msgid "Chat: Team"
 msgstr ""
 
@@ -16399,7 +16451,7 @@ msgid "Show frame rate"
 msgstr ""
 
 #: src/keymap.cpp:433
-msgid "Select all Similar Units"
+msgid "Select all units with the same components"
 msgstr ""
 
 #: src/keymap.cpp:437
@@ -17392,24 +17444,24 @@ msgstr ""
 msgid "You cheated!"
 msgstr ""
 
-#: src/selection.cpp:281
-#: src/selection.cpp:361
+#: src/selection.cpp:352
+#: src/selection.cpp:432
 msgid "Unable to locate any repair units!"
 msgstr ""
 
-#: src/selection.cpp:284
+#: src/selection.cpp:355
 msgid "Unable to locate any Trucks!"
 msgstr ""
 
-#: src/selection.cpp:287
+#: src/selection.cpp:358
 msgid "Unable to locate any Sensor Units!"
 msgstr ""
 
-#: src/selection.cpp:290
+#: src/selection.cpp:361
 msgid "Unable to locate any Commanders!"
 msgstr ""
 
-#: src/selection.cpp:561
+#: src/selection.cpp:632
 #, c-format
 msgid "%u unit selected"
 msgid_plural "%u units selected"


### PR DESCRIPTION
Explicitly specify "xgettext:no-c-format" for strings containing "%" to ensure that xgettext's heuristics do not decide to treat these as c-format strings.