### PR TITLE
Fix back arrow in load/save and challenge banners

### DIFF
--- a/lib/sdl/CMakeLists.txt
+++ b/lib/sdl/CMakeLists.txt
@@ -14,21 +14,55 @@ set(_sdl2_library)
 set(_sdl2_include_dir)
 set(_sdl2_main_library)
 
+function(test_link_to_sdl_target sdl_target output_var)
+
+	set(CMAKE_REQUIRED_LIBRARIES "${sdl_target}")
+	check_cxx_source_compiles(
+	   "#include <SDL_version.h>
+		#include <cstdio>
+
+		void print_sdl_version() {
+		  SDL_version linked_sdl_version;
+		  SDL_GetVersion(&linked_sdl_version);
+		  printf(\"Linked SDL version: %u.%u.%u\", (unsigned int)linked_sdl_version.major, (unsigned int)linked_sdl_version.minor, (unsigned int)linked_sdl_version.patch);
+		}
+
+		int main()
+		{
+		  print_sdl_version();
+		  return 0;
+		}"
+	  ${output_var}
+	)
+	set(CMAKE_REQUIRED_LIBRARIES "")
+
+    set(${output_var} "${${output_var}}" PARENT_SCOPE)
+endfunction()
+
 # Prefer finding SDL2 using CMake Config, to properly include any dependencies / linked libraries (with complete, imported targets)
 # - This should work for vcpkg-installed SDL2, as well as other installs that generate a full (proper) CMake Config,
 # - and is required to properly link with a static SDL2 library (at least on Windows and macOS)
 find_package(SDL2 ${SDL2_MIN_VERSION} CONFIG QUIET)
 if(SDL2_FOUND)
 	if (TARGET SDL2::SDL2-static)
-		set(_sdl2_library SDL2::SDL2-static)
-	elseif(TARGET SDL2::SDL2)
-		set(_sdl2_library SDL2::SDL2)
-	else()
-		# Fall-back to FindSDL2 module (below)
-		set(_sdl2_main_library)
+		test_link_to_sdl_target(SDL2::SDL2-static LINK_SUCCESS_SDL2_SDL2STATIC_TARGET)
+		if (LINK_SUCCESS_SDL2_SDL2STATIC_TARGET)
+			set(_sdl2_library SDL2::SDL2-static)
+		endif()
 	endif()
-	if (TARGET SDL2::SDL2main)
-		set(_sdl2_main_library SDL2::SDL2main)
+	if (NOT _sdl2_library AND TARGET SDL2::SDL2)
+		test_link_to_sdl_target(SDL2::SDL2 LINK_SUCCESS_SDL2_SDL2_TARGET)
+		if (LINK_SUCCESS_SDL2_SDL2_TARGET)
+			set(_sdl2_library SDL2::SDL2)
+		endif()
+	endif()
+	if (NOT _sdl2_library)
+		# Fall-back to FindSDL2 module (below)
+	elseif (TARGET SDL2::SDL2main)
+		test_link_to_sdl_target("${_sdl2_library};SDL2::SDL2main" LINK_SUCCESS_SDL2_SDL2MAIN_TARGET)
+		if (LINK_SUCCESS_SDL2_SDL2MAIN_TARGET)
+			set(_sdl2_main_library SDL2::SDL2main)
+		endif()
 	endif()
 
 	if(_sdl2_library)

--- a/src/challenge.cpp
+++ b/src/challenge.cpp
@@ -204,19 +204,6 @@ bool addChallenges()
 	sFormInit.UserData = 0;
 	widgAddForm(psRequestScreen, &sFormInit);
 
-	// Add Banner Label
-	W_LABINIT sLabInit;
-	sLabInit.formID		= CHALLENGE_BANNER;
-	sLabInit.FontID		= font_large;
-	sLabInit.id		= CHALLENGE_LABEL;
-	sLabInit.style		= WLAB_ALIGNCENTRE;
-	sLabInit.x		= 0;
-	sLabInit.y		= 0;
-	sLabInit.width		= CHALLENGE_W - (2 * CHALLENGE_HGAP);	//CHALLENGE_W;
-	sLabInit.height		= CHALLENGE_BANNER_DEPTH;		//This looks right -Q
-	sLabInit.pText		= WzString::fromUtf8("Challenge");
-	widgAddLabel(psRequestScreen, &sLabInit);
-
 	// add cancel.
 	W_BUTINIT sButInit;
 	sButInit.formID = CHALLENGE_BANNER;
@@ -230,6 +217,19 @@ bool addChallenges()
 	sButInit.pTip = _("Close");
 	sButInit.pDisplay = intDisplayImageHilight;
 	widgAddButton(psRequestScreen, &sButInit);
+
+	// Add Banner Label
+	W_LABINIT sLabInit;
+	sLabInit.formID		= CHALLENGE_BANNER;
+	sLabInit.FontID		= font_large;
+	sLabInit.id		= CHALLENGE_LABEL;
+	sLabInit.style		= WLAB_ALIGNCENTRE;
+	sLabInit.x		= 0;
+	sLabInit.y		= 0;
+	sLabInit.width		= CHALLENGE_W - (2 * CHALLENGE_HGAP);	//CHALLENGE_W;
+	sLabInit.height		= CHALLENGE_BANNER_DEPTH;		//This looks right -Q
+	sLabInit.pText		= WzString::fromUtf8("Challenge");
+	widgAddLabel(psRequestScreen, &sLabInit);
 
 	// add slots
 	sButInit = W_BUTINIT();

--- a/src/loadsave.cpp
+++ b/src/loadsave.cpp
@@ -231,19 +231,6 @@ bool addLoadSave(LOADSAVE_MODE savemode, const char *title)
 	sFormInit.UserData = bLoad;
 	widgAddForm(psRequestScreen, &sFormInit);
 
-	// Add Banner Label
-	W_LABINIT sLabInit;
-	sLabInit.formID = LOADSAVE_BANNER;
-	sLabInit.FontID = font_large;
-	sLabInit.id		= LOADSAVE_LABEL;
-	sLabInit.style	= WLAB_ALIGNCENTRE;
-	sLabInit.x		= 0;
-	sLabInit.y		= 0;
-	sLabInit.width	= LOADSAVE_W - (2 * LOADSAVE_HGAP);	//LOADSAVE_W;
-	sLabInit.height = LOADSAVE_BANNER_DEPTH;		//This looks right -Q
-	sLabInit.pText	= WzString::fromUtf8(title);
-	widgAddLabel(psRequestScreen, &sLabInit);
-
 	// add cancel.
 	W_BUTINIT sButInit;
 	sButInit.formID = LOADSAVE_BANNER;
@@ -258,6 +245,19 @@ bool addLoadSave(LOADSAVE_MODE savemode, const char *title)
 	sButInit.pTip = _("Close");
 	sButInit.pDisplay = intDisplayImageHilight;
 	widgAddButton(psRequestScreen, &sButInit);
+
+	// Add Banner Label
+	W_LABINIT sLabInit;
+	sLabInit.formID = LOADSAVE_BANNER;
+	sLabInit.FontID = font_large;
+	sLabInit.id		= LOADSAVE_LABEL;
+	sLabInit.style	= WLAB_ALIGNCENTRE;
+	sLabInit.x		= 0;
+	sLabInit.y		= 0;
+	sLabInit.width	= LOADSAVE_W - (2 * LOADSAVE_HGAP);	//LOADSAVE_W;
+	sLabInit.height = LOADSAVE_BANNER_DEPTH;		//This looks right -Q
+	sLabInit.pText	= WzString::fromUtf8(title);
+	widgAddLabel(psRequestScreen, &sLabInit);
 
 	// add slots
 	sButInit = W_BUTINIT();


### PR DESCRIPTION
The label, which overlaps the back button, was capturing the click (as it comes earlier in the array of child widgets). Flip the order that the button and the label are added so the back button gets a chance to capture the click first.

Should fix #712