### PR TITLE
Use notification popups for voting.

### DIFF
--- a/lib/netplay/netplay.cpp
+++ b/lib/netplay/netplay.cpp
@@ -3716,6 +3716,7 @@ const char *messageTypeToString(unsigned messageType_)
 	case NET_FILE_PAYLOAD:              return "NET_FILE_PAYLOAD";
 	case NET_DEBUG_SYNC:                return "NET_DEBUG_SYNC";
 	case NET_VOTE:                      return "NET_VOTE";
+	case NET_VOTE_REQUEST:              return "NET_VOTE_REQUEST";
 	case NET_MAX_TYPE:                  return "NET_MAX_TYPE";
 
 	// Game-state-related messages, must be processed by all clients at the same game time.

--- a/lib/netplay/netplay.h
+++ b/lib/netplay/netplay.h
@@ -89,7 +89,8 @@ enum MESSAGE_TYPES
 	NET_FILE_CANCELLED,             ///< Player cancelled a file request
 	NET_FILE_PAYLOAD,               ///< sending file to the player that needs it
 	NET_DEBUG_SYNC,                 ///< Synch error messages, so people don't have to use pastebin.
-	NET_VOTE,                       ///< vote request
+	NET_VOTE,                       ///< player vote
+	NET_VOTE_REQUEST,               ///< Setup a vote popup
 	NET_MAX_TYPE,                   ///< Maximum+1 valid NET_ type, *MUST* be last.
 
 	// Game-state-related messages, must be processed by all clients at the same game time.

--- a/src/frontend.cpp
+++ b/src/frontend.cpp
@@ -633,14 +633,12 @@ bool runMultiPlayerMenu()
 		ingame.bHostSetup = true;
 		bMultiPlayer = true;
 		bMultiMessages = true;
-		resetVoteData();
 		NETinit(true);
 		NETdiscoverUPnPDevices();
 		game.type = SKIRMISH;		// needed?
 		changeTitleUI(std::make_shared<WzMultiOptionTitleUI>(wzTitleUICurrent));
 		break;
 	case FRONTEND_JOIN:
-		resetVoteData();
 		NETinit(true);
 		ingame.bHostSetup = false;
 		if (getLobbyError() != ERROR_INVALID)

--- a/src/multiint.h
+++ b/src/multiint.h
@@ -313,10 +313,6 @@ void resetVoteData();
 #define MULTIOP_DIFFICULTY_CHOOSE_START	(MULTIOP_DIFFICULTY_INIT_END + 1)
 #define MULTIOP_DIFFICULTY_CHOOSE_END	(MULTIOP_DIFFICULTY_CHOOSE_START + MAX_PLAYERS)
 
-#define MULTIOP_VOTE			148940
-#define MULTIOP_VOTE_YES			1
-#define MULTIOP_VOTE_NO			0
-
 
 // ///////////////////////////////
 // Many Button Variations..

--- a/src/titleui/protocol.cpp
+++ b/src/titleui/protocol.cpp
@@ -111,7 +111,6 @@ TITLECODE WzProtocolTitleUI::run()
 		bMultiMessages = false;
 		break;
 	case CON_TYPESID_START+0: // Lobby button
-		resetVoteData();
 		if (getLobbyError() != ERROR_INVALID)
 		{
 			setLobbyError(ERROR_NOERROR);
@@ -119,11 +118,9 @@ TITLECODE WzProtocolTitleUI::run()
 		changeTitleUI(std::make_shared<WzGameFindTitleUI>());
 		break;
 	case CON_TYPESID_START+1: // IP button
-		resetVoteData();
 		openIPDialog();
 		break;
 	case CON_OK:
-		resetVoteData();
 		sstrcpy(serverName, widgGetString(curScreen, CON_IP));
 		if (serverName[0] == '\0')
 		{


### PR DESCRIPTION
With the new notification system I saw an opportunity to simplify the vote system (and close an issue). Overall, I think it should work much better than the current implementation does and removes several hacks and all the current vote stuff on the left side. Plus it catches visual attention better.

To my knowledge the only awkward thing is a host needs to try randomizing or changing the map to initiate a vote popup on a client's game.

Vote behavior changes:

1. Fixed a bug where a host could override the vote of a player if it's only the host and one other player. Most significant for 2-player maps but can apply everywhere else.

2. Unlike the current implementation, hosts will need authorization again for every map change or randomization.

Fixes #632 