### PR TITLE
Make it possible to clear the content of an edit widget with the first click

### DIFF
--- a/lib/widget/editbox.cpp
+++ b/lib/widget/editbox.cpp
@@ -76,6 +76,7 @@ W_EDITBOX::W_EDITBOX(W_EDBINIT const *init)
 	, boxColourSecond(WZCOL_FORM_LIGHT)
 	, boxColourBackground(WZCOL_FORM_BACKGROUND)
 {
+	bBeenClicked = false;
 	char const *text = init->pText;
 	if (!text)
 	{
@@ -106,7 +107,9 @@ W_EDITBOX::W_EDITBOX(WIDGET *parent)
 	, boxColourFirst(WZCOL_FORM_DARK)
 	, boxColourSecond(WZCOL_FORM_LIGHT)
 	, boxColourBackground(WZCOL_FORM_BACKGROUND)
-{}
+{
+	bBeenClicked = false;
+}
 
 void W_EDITBOX::initialise()
 {
@@ -514,6 +517,12 @@ void W_EDITBOX::clicked(W_CONTEXT *psContext, WIDGET_KEY)
 	if (state & WEDBS_DISABLE)  // disabled button.
 	{
 		return;
+	}
+	/* When this is the first click into the widget, clear the current content*/
+	if (bBeenClicked == false)
+	{
+		setString("");
+		bBeenClicked = true;
 	}
 
 	// Set cursor position to the click location.

--- a/lib/widget/editbox.h
+++ b/lib/widget/editbox.h
@@ -89,6 +89,7 @@ private:
 
 	PIELIGHT boxColourFirst, boxColourSecond, boxColourBackground;
 	EditBoxDisplayCache displayCache;
+	bool                bBeenClicked;
 };
 
 #endif // __INCLUDED_LIB_WIDGET_EDITBOX_H__


### PR DESCRIPTION
These changes make it possible to clear the content of an edit widget with the first click.
This is especially useful, when setting the password, the game-name or your name in the hosting-configuration (Main-menu -> Multi Player -> Host Game).