### PR TITLE
Initial support spectators

### DIFF
--- a/data/mp/multiplay/script/rules/endconditions.js
+++ b/data/mp/multiplay/script/rules/endconditions.js
@@ -18,49 +18,41 @@ const USERTYPE = {
 // - completion of the research
 // - construction of base structures (factories, power plants, laboratories, modules and oil rigs)
 // - dealing damage
-const IDLETIME = 5*60*1000;
+const IDLETIME = 5 * 60 * 1000;
 
-function inOneTeam(playnum, splaynum)
-{
-//	FIXME allianceExistsBetween dont correct if leave player in ALLIANCES_UNSHARED, ALLIANCES_TEAMS mode
-//	and  team is garbage in NO_ALLIANCES, ALLIANCES mode
-	if ((alliancesType == ALLIANCES_UNSHARED ||
-		alliancesType == ALLIANCES_TEAMS) &&
- 		(playerData[playnum].team != playerData[splaynum].team))
-	{
+function inOneTeam(playnum, splaynum) {
+  //	FIXME allianceExistsBetween dont correct if leave player in ALLIANCES_UNSHARED, ALLIANCES_TEAMS mode
+  //	and  team is garbage in NO_ALLIANCES, ALLIANCES mode
+	if (
+		(alliancesType == ALLIANCES_UNSHARED || alliancesType == ALLIANCES_TEAMS) &&
+    playerData[playnum].team != playerData[splaynum].team
+	) {
 		return false;
-	}
-	else if (alliancesType == NO_ALLIANCES && playnum != splaynum)
-	{
+	} else if (alliancesType == NO_ALLIANCES && playnum != splaynum) {
 		return false;
-	}
-	else if (alliancesType == ALLIANCES && !allianceExistsBetween(playnum, splaynum))
-	{
+	} else if (
+		alliancesType == ALLIANCES &&
+    !allianceExistsBetween(playnum, splaynum)
+	) {
 		return false;
 	}
 
 	return true;
 }
 
-function hasFactory(playnum)
-{
+function hasFactory(playnum) {
 	let structs = [FACTORY, CYBORG_FACTORY, VTOL_FACTORY];
 
-	for (let splaynum = 0; splaynum < maxPlayers; splaynum++)
-		{
-		if (!inOneTeam(playnum, splaynum))
-		{
+	for (let splaynum = 0; splaynum < maxPlayers; splaynum++) {
+		if (!inOneTeam(playnum, splaynum)) {
 			continue;
 		}
 
-		for (let i = 0; i < structs.length; ++i)
-		{
+		for (let i = 0; i < structs.length; ++i) {
 			let onMapStructss = enumStruct(splaynum, structs[i]);
 
-			for (let j = 0; j < onMapStructss.length; ++j)
-			{
-				if (onMapStructss[j].status === BUILT)
-				{
+			for (let j = 0; j < onMapStructss.length; ++j) {
+				if (onMapStructss[j].status === BUILT) {
 					return true;
 				}
 			}
@@ -70,12 +62,10 @@ function hasFactory(playnum)
 	return false;
 }
 
-function hasDroid(playnum)
-{
-	for (let splaynum = 0; splaynum < maxPlayers; splaynum++)
-	{
-		if (inOneTeam(playnum, splaynum) && countDroid(DROID_ANY, splaynum) > 0)	// checking enemy player
-		{
+function hasDroid(playnum) {
+	for (let splaynum = 0; splaynum < maxPlayers; splaynum++) {
+		if (inOneTeam(playnum, splaynum) && countDroid(DROID_ANY, splaynum) > 0) {
+      // checking enemy player
 			return true;
 		}
 	}
@@ -83,56 +73,47 @@ function hasDroid(playnum)
 	return false;
 }
 
-function hasOnlyConstructor(playnum)
-{
+function hasOnlyConstructor(playnum) {
 	let count = 0;
-	for (let splaynum = 0; splaynum < maxPlayers; splaynum++)
-	{
-		if (inOneTeam(playnum, splaynum))
-		{
-			count += countDroid(DROID_ANY, splaynum) - countDroid(DROID_CONSTRUCT, splaynum);
+	for (let splaynum = 0; splaynum < maxPlayers; splaynum++) {
+		if (inOneTeam(playnum, splaynum)) {
+			count +=
+        countDroid(DROID_ANY, splaynum) - countDroid(DROID_CONSTRUCT, splaynum);
 		}
 	}
-	if (count === 0) {return true;}
-	else {return false;}
+	if (count === 0) {
+		return true;
+	} else {
+		return false;
+	}
 }
 
-function canReachOil(playnum)
-{
-	let oils = enumFeature(ALL_PLAYERS).filter(function(e) {
+function canReachOil(playnum) {
+	let oils = enumFeature(ALL_PLAYERS).filter(function (e) {
 		return e.stattype === OIL_RESOURCE;
 	});
 
-	for (let tplaynum = 0; tplaynum < maxPlayers; tplaynum++)
-	{
+	for (let tplaynum = 0; tplaynum < maxPlayers; tplaynum++) {
 		oils = oils.concat(enumStruct(tplaynum, "A0ResourceExtractor"));
 	}
 
-	for (let splaynum = 0; splaynum < maxPlayers; splaynum++)
-	{
-		if (!inOneTeam(playnum, splaynum))
-		{
+	for (let splaynum = 0; splaynum < maxPlayers; splaynum++) {
+		if (!inOneTeam(playnum, splaynum)) {
 			continue;
 		}
 
-		if (enumStruct(splaynum, RESOURCE_EXTRACTOR).length != 0)
-		{
+		if (enumStruct(splaynum, RESOURCE_EXTRACTOR).length != 0) {
 			return true;
-		}
-		else
-		{
+		} else {
 			let trucks = enumDroid(splaynum, DROID_CONSTRUCT);
 
-			for (let i = 0, len = trucks.length; i < len; ++i)
-			{
+			for (let i = 0, len = trucks.length; i < len; ++i) {
 				let truck = trucks[i];
 
-				for (let j = 0, len2 = oils.length; j < len2; ++j)
-				{
+				for (let j = 0, len2 = oils.length; j < len2; ++j) {
 					let oil = oils[j];
 
-					if (droidCanReach(truck, oil.x, oil.y))
-					{
+					if (droidCanReach(truck, oil.x, oil.y)) {
 						return true;
 					}
 				}
@@ -143,112 +124,91 @@ function canReachOil(playnum)
 	return false;
 }
 
-function activeGame(playnum)
-{
-	for (let splaynum = 0; splaynum < maxPlayers; splaynum++)
-	{
-		if (inOneTeam(playnum, splaynum) &&
-		playerData[playnum].lastActivity + IDLETIME >= gameTime)
-		{
+function activeGame(playnum) {
+	for (let splaynum = 0; splaynum < maxPlayers; splaynum++) {
+		if (
+			inOneTeam(playnum, splaynum) &&
+      playerData[playnum].lastActivity + IDLETIME >= gameTime
+		) {
 			return true;
 		}
 	}
 	return false;
 }
 
-
-function canPlay(playnum)
-{
-/*
-	let feature = {
-		factory: hasFactory(playnum),
-		droid: hasDroid(playnum),
-		onlyConstruct: hasOnlyConstructor(playnum),
-		oilReach: canReachOil(playnum),
-		activeGame: activeGame(playnum)
-	};
-	debug(playerData[playnum].name + JSON.stringify(feature));
-*/
-
-	if (!hasFactory(playnum) && !hasDroid(playnum))
-	{
+function canPlay(playnum) {
+	if (!hasFactory(playnum) && !hasDroid(playnum)) {
 		return false;
-	}
-	else if (!hasFactory(playnum) && hasOnlyConstructor(playnum) && !canReachOil(playnum) )
-	{
+	} else if (
+		!hasFactory(playnum) &&
+    hasOnlyConstructor(playnum) &&
+    !canReachOil(playnum)
+	) {
 		return false;
-	}
-	else if (!activeGame(playnum))
-	{
+	} else if (!activeGame(playnum)) {
 		return false;
 	}
 	return true;
 }
 
-function roomPlayability()
-{
+function roomPlayability() {
 	let unPlayability = true;
-	for (let playnum = 0; playnum < maxPlayers; playnum++)
-	{
-		for (let splaynum = 0; splaynum < maxPlayers; splaynum++)
-		{
-			if (playnum != splaynum &&
-			playerData[playnum].usertype == USERTYPE.player.fighter &&
-			playerData[splaynum].usertype == USERTYPE.player.fighter &&
-			!inOneTeam (playnum, splaynum))
-			{
+	for (let playnum = 0; playnum < maxPlayers; playnum++) {
+		for (let splaynum = 0; splaynum < maxPlayers; splaynum++) {
+			if (
+				playnum != splaynum &&
+        playerData[playnum].usertype == USERTYPE.player.fighter &&
+        playerData[splaynum].usertype == USERTYPE.player.fighter &&
+        !inOneTeam(playnum, splaynum)
+			) {
 				unPlayability = false;
 			}
 		}
 	}
-	if (unPlayability)
-	{
-//		debug(_("There are no opponents in the game."));
+	if (unPlayability) {
+    //		debug(_("There are no opponents in the game."));
 		console(_("There are no opponents in the game"));
-//		gameOverMessage(true);
+    //		gameOverMessage(true);
 		return false;
+	} else {
+		return true;
 	}
-	else {return true;}
 }
 
-function toSpectator(playnum, remove)
-{
+function toSpectator(playnum, remove) {
 	hackNetOff();
 	setPower(0, playnum);
 	let spotter = {
-		X: mapWidth/2,
-		Y: mapHeight/2,
-		radius: Math.sqrt(mapWidth*mapWidth + mapHeight*mapHeight)/2*128
+		X: mapWidth / 2,
+		Y: mapHeight / 2,
+		radius: (Math.sqrt(mapWidth * mapWidth + mapHeight * mapHeight) / 2) * 128,
 	};
 	addSpotter(spotter.X, spotter.Y, playnum, spotter.radius, 0, 0);
 
 	let HQstructs = enumStruct(playnum, HQ);
-	HQstructs.forEach(function(e) {
+	HQstructs.forEach(function (e) {
 		removeObject(e);
 	});
 
-	if (remove === true)
-	{
+	if (remove === true) {
 		let droids = enumDroid(playnum, DROID_ANY);
-		droids.forEach(function(e) {
+		droids.forEach(function (e) {
 			removeObject(e);
 		});
 
 		let structs = enumStruct(playnum);
-		structs.forEach(function(e) {
+		structs.forEach(function (e) {
 			removeObject(e);
 		});
 	}
 
-	if (selectedPlayer === playnum)
-	{
+	if (selectedPlayer === playnum) {
 		queue("hud", 100);
 	}
 	hackNetOn();
 }
 
-function hud()
-{
+function hud() {
 	setMiniMap(true);
 	setReticuleButton(4, "", "", "");
 	setReticuleButton(5, "", "image_intelmap_up.png", "image_intelmap_down.png");
@@ -260,155 +220,126 @@ function hud()
 // /////////////////////////////////////////////////////////////////
 // END CONDITIONS
 
-function checkPlayerVictoryStatus()
-{
-	for (let playnum = 0; playnum < maxPlayers; playnum++)
-	{
-		if (playerData[playnum].usertype === USERTYPE.player.winner)
-		{
+function checkPlayerVictoryStatus() {
+	for (let playnum = 0; playnum < maxPlayers; playnum++) {
+		if (playerData[playnum].usertype === USERTYPE.player.winner) {
 			return; // When the winner is determined, nothing needs to be done.
 		}
 	}
 
-	for (let playnum = 0; playnum < maxPlayers; playnum++)
-	{
-		if (playerData[playnum].usertype === USERTYPE.player.loser)
-		{
+	for (let playnum = 0; playnum < maxPlayers; playnum++) {
+		if (playerData[playnum].usertype === USERTYPE.player.loser) {
 			continue;
 		}
-		//we mark the retired players as lost and give them visibility. we save buildings
-		else if (!canPlay(playnum) && (playerData[playnum].usertype != USERTYPE.spectator))
-		{
-			//See loss check in function canPlay()
+    //we mark the retired players as lost and give them visibility. we save buildings
+		else if (
+			!canPlay(playnum) &&
+      playerData[playnum].usertype != USERTYPE.spectator
+		) {
+      //See loss check in function canPlay()
 			playerData[playnum].usertype = USERTYPE.player.loser;
 			toSpectator(playnum, false);
-			if  (selectedPlayer == playnum)
-			{
+			if (selectedPlayer == playnum) {
 				gameOverMessage(false);
 			}
 		}
 
-		// Winning Conditions
-		// all participants except teammates (this is not the same as the allies) cannot continue the game
+    // Winning Conditions
+    // all participants except teammates (this is not the same as the allies) cannot continue the game
 	}
 
 	let endGame = true;
-	for (let playnum = 0; playnum < maxPlayers; playnum++)
-	{
-		if (playerData[playnum].usertype != USERTYPE.player.fighter)
-		{
+	for (let playnum = 0; playnum < maxPlayers; playnum++) {
+		if (playerData[playnum].usertype != USERTYPE.player.fighter) {
 			continue;
 		}
 
-		for (let splaynum = 0; splaynum < maxPlayers; splaynum++)
-		{
-			if (inOneTeam(playnum, splaynum))
-			{
+		for (let splaynum = 0; splaynum < maxPlayers; splaynum++) {
+			if (inOneTeam(playnum, splaynum)) {
 				continue;
-			}
-			else if (playerData[splaynum].usertype === USERTYPE.player.fighter)
-			{
+			} else if (playerData[splaynum].usertype === USERTYPE.player.fighter) {
 				endGame = false;
 			}
 		}
 	}
 
-	if (endGame == true)
-	{
-		for (let playnum = 0; playnum < maxPlayers; playnum++)
-		{
-			if (playerData[playnum].usertype === USERTYPE.player.fighter)
-			{
+	if (endGame == true) {
+		for (let playnum = 0; playnum < maxPlayers; playnum++) {
+			if (playerData[playnum].usertype === USERTYPE.player.fighter) {
 				playerData[playnum].usertype = USERTYPE.player.winner;
 			}
 		}
 
-		if (playerData[selectedPlayer].usertype ===  USERTYPE.player.winner)
-		{
+		if (playerData[selectedPlayer].usertype === USERTYPE.player.winner) {
 			gameOverMessage(true);
 		}
-		if (playerData[selectedPlayer].usertype == USERTYPE.spectator)
-		{
-//			gameOverMessage(true);
+		if (playerData[selectedPlayer].usertype == USERTYPE.spectator) {
+      //			gameOverMessage(true);
 			console(_("the battle is over, you can leave the room"));
-//			debug("the battle is over, you can leave the room");
+      //			debug("the battle is over, you can leave the room");
 		}
 	}
 }
 
-function co_eventGameInit()
-{
-	for (let playnum = 0; playnum < maxPlayers; playnum++)
-	{
+function co_eventGameInit() {
+	for (let playnum = 0; playnum < maxPlayers; playnum++) {
 		playerData[playnum].lastActivity = gameTime;
-			//we consider observers to players who cannot play from the beginning of the game
-		if (!canPlay(playnum))
-		{
+    //we consider observers to players who cannot play from the beginning of the game
+		if (!canPlay(playnum)) {
 			playerData[playnum].usertype = USERTYPE.spectator;
 			toSpectator(playnum, true);
 			continue;
-		}
-		else
-		{
+		} else {
 			playerData[playnum].usertype = USERTYPE.player.fighter;
 		}
-
 	}
-	if (roomPlayability())
-	{
+	if (roomPlayability()) {
 		setTimer("checkPlayerVictoryStatus", 3000);
 		setTimer("activityAlert", 10000);
 	}
 }
 
-function activityAlert()
-{
-	if (playerData[selectedPlayer].usertype != USERTYPE.player.fighter)
-	{
+function activityAlert() {
+	if (playerData[selectedPlayer].usertype != USERTYPE.player.fighter) {
 		setMissionTime(-1);
 		removeTimer("activityAlert");
 		return;
 	}
-	if (playerData[selectedPlayer].lastActivity + IDLETIME/2 < gameTime)
-	{
-		console(_("Playing passively will lead to defeat. Actions that are considered: - unit building - research completion - construction of base structures (factories, power plants, laboratories, modules and oil derricks) - dealing damage"));
-	//		debug (getMissionTime());
-		if (getMissionTime() > IDLETIME)
-		{
-			setMissionTime((playerData[selectedPlayer].lastActivity + IDLETIME - gameTime)/1000);
+	if (playerData[selectedPlayer].lastActivity + IDLETIME / 2 < gameTime) {
+		console(
+			_(
+				"Playing passively will lead to defeat. Actions that are considered: - unit building - research completion - construction of base structures (factories, power plants, laboratories, modules and oil derricks) - dealing damage"
+			)
+		);
+    //		debug (getMissionTime());
+		if (getMissionTime() > IDLETIME) {
+			setMissionTime(
+				(playerData[selectedPlayer].lastActivity + IDLETIME - gameTime) / 1000
+			);
 		}
 	}
-	if (playerData[selectedPlayer].lastActivity + IDLETIME/2 > gameTime)
-	{
+	if (playerData[selectedPlayer].lastActivity + IDLETIME / 2 > gameTime) {
 		setMissionTime(-1);
 	}
 }
 
-function co_eventDroidBuilt (droid)
-{
-	if (droid.player != scavengerPlayer)
-	{
+function co_eventDroidBuilt(droid) {
+	if (droid.player != scavengerPlayer) {
 		playerData[droid.player].lastActivity = gameTime;
 	}
 }
-function co_eventStructureBuilt (structure)
-{
-	if (structure.player != scavengerPlayer)
-	{
+function co_eventStructureBuilt(structure) {
+	if (structure.player != scavengerPlayer) {
 		playerData[structure.player].lastActivity = gameTime;
 	}
 }
-function co_eventResearched (research, structure, player)
-{
-	if (player != scavengerPlayer)
-	{
+function co_eventResearched(research, structure, player) {
+	if (player != scavengerPlayer) {
 		playerData[player].lastActivity = gameTime;
 	}
 }
-function co_eventAttacked (victim, attacker)
-{
-	if (attacker.player != scavengerPlayer)
-	{
+function co_eventAttacked(victim, attacker) {
+	if (attacker.player != scavengerPlayer) {
 		playerData[attacker.player].lastActivity = gameTime;
 	}
 }

--- a/data/mp/multiplay/script/rules/endconditions.js
+++ b/data/mp/multiplay/script/rules/endconditions.js
@@ -1,62 +1,414 @@
-// /////////////////////////////////////////////////////////////////
-// END CONDITIONS
-function checkEndConditions()
+//The all logic of determining winners, losers and observers.
+//From rules.js, the code from this file is not called.
+//Everything fulfills through eventGameInit event in a separate namespace
+//In rules.js, there was only one hack to save the minimap for the losers and observers function setMainReticule ().
+
+namespace("co_");
+const USERTYPE = {
+	spectator: "spectator",
+	player: {
+		fighter: "fighter",
+		winner: "winner",
+		loser: "loser",
+	},
+};
+
+// The time that the player's inactivity is allowed. Actions are considered
+// - unit building
+// - completion of the research
+// - construction of base structures (factories, power plants, laboratories, modules and oil rigs)
+// - dealing damage
+const IDLETIME = 5*60*1000;
+
+function inOneTeam(playnum, splaynum)
 {
-	var factories = countStruct("A0LightFactory") + countStruct("A0CyborgFactory");
-	var droids = countDroid(DROID_ANY);
-
-	// Losing Conditions
-	if (droids == 0 && factories == 0)
+//	FIXME allianceExistsBetween dont correct if leave player in ALLIANCES_UNSHARED, ALLIANCES_TEAMS mode
+//	and  team is garbage in NO_ALLIANCES, ALLIANCES mode
+	if ((alliancesType == ALLIANCES_UNSHARED ||
+		alliancesType == ALLIANCES_TEAMS) &&
+ 		(playerData[playnum].team != playerData[splaynum].team))
 	{
-		var gameLost = true;
+		return false;
+	}
+	else if (alliancesType == NO_ALLIANCES && playnum != splaynum)
+	{
+		return false;
+	}
+	else if (alliancesType == ALLIANCES && !allianceExistsBetween(playnum, splaynum))
+	{
+		return false;
+	}
 
-		/* If teams enabled check if all team members have lost  */
-		if (alliancesType == ALLIANCES_TEAMS || alliancesType == ALLIANCES_UNSHARED)
+	return true;
+}
+
+function hasFactory(playnum)
+{
+	var structs = [FACTORY, CYBORG_FACTORY, VTOL_FACTORY];
+
+	for (var splaynum = 0; splaynum < maxPlayers; splaynum++)
 		{
-			for (var playnum = 0; playnum < maxPlayers; playnum++)
+		if (!inOneTeam(playnum, splaynum))
+		{
+			continue;
+		}
+
+		for (var i = 0; i < structs.length; ++i)
+		{
+			var onMapStructss = enumStruct(splaynum, structs[i]);
+
+			for (var j = 0; j < onMapStructss.length; ++j)
 			{
-				if (playnum != selectedPlayer && allianceExistsBetween(selectedPlayer, playnum))
+				if (onMapStructss[j].status === BUILT)
 				{
-					factories = countStruct("A0LightFactory", playnum) + countStruct("A0CyborgFactory", playnum);
-					droids = countDroid(DROID_ANY, playnum);
-					if (droids > 0 || factories > 0)
+					return true;
+				}
+			}
+		}
+	}
+
+	return false;
+}
+
+function hasDroid(playnum)
+{
+	for (var splaynum = 0; splaynum < maxPlayers; splaynum++)
+	{
+		if (inOneTeam(playnum, splaynum) && countDroid(DROID_ANY, splaynum) > 0)	// checking enemy player
+		{
+			return true;
+		}
+	}
+
+	return false;
+}
+
+function hasOnlyConstructor(playnum)
+{
+	var count = 0;
+	for (var splaynum = 0; splaynum < maxPlayers; splaynum++)
+	{
+		if (inOneTeam(playnum, splaynum))
+		{
+			count += countDroid(DROID_ANY, splaynum) - countDroid(DROID_CONSTRUCT, splaynum);
+		}
+	}
+	if (count === 0) {return true;}
+	else {return false;}
+}
+
+function canReachOil(playnum)
+{
+	var oils = enumFeature(ALL_PLAYERS).filter(function(e) {
+		return e.stattype === OIL_RESOURCE;
+	});
+
+	for (var tplaynum = 0; tplaynum < maxPlayers; tplaynum++)
+	{
+		oils = oils.concat(enumStruct(tplaynum, "A0ResourceExtractor"));
+	}
+
+	for (var splaynum = 0; splaynum < maxPlayers; splaynum++)
+	{
+		if (!inOneTeam(playnum, splaynum))
+		{
+			continue;
+		}
+
+		if (enumStruct(splaynum, RESOURCE_EXTRACTOR).length != 0)
+		{
+			return true;
+		}
+		else
+		{
+			var trucks = enumDroid(splaynum, DROID_CONSTRUCT);
+
+			for (var i = 0, len = trucks.length; i < len; ++i)
+			{
+				var truck = trucks[i];
+
+				for (var j = 0, len2 = oils.length; j < len2; ++j)
+				{
+					var oil = oils[j];
+
+					if (droidCanReach(truck, oil.x, oil.y))
 					{
-						gameLost = false;	// someone from our team still alive
-						break;
+						return true;
 					}
 				}
 			}
 		}
+	}
 
-		if (gameLost)
+	return false;
+}
+
+function activeGame(playnum)
+{
+	for (var splaynum = 0; splaynum < maxPlayers; splaynum++)
+	{
+		if (inOneTeam(playnum, splaynum) &&
+		playerData[playnum].lastActivity + IDLETIME >= gameTime)
 		{
-			gameOverMessage(false);
-			removeTimer("checkEndConditions");
-			return;
+			return true;
+		}
+	}
+	return false;
+}
+
+
+function canPlay(playnum)
+{
+
+//	var feature = {
+//		factory: hasFactory(playnum),
+//		droid: hasDroid(playnum),
+//		onlyConstruct: hasOnlyConstructor(playnum),
+//		oilReach: canReachOil(playnum),
+//		activeGame: activeGame(playnum)
+//	};
+//	debug(playerData[playnum].name + JSON.stringify(feature));
+
+	if (!hasFactory(playnum) && !hasDroid(playnum))
+	{
+		return false;
+	}
+	else if (!hasFactory(playnum) && hasOnlyConstructor(playnum) && !canReachOil(playnum) )
+	{
+		return false;
+	}
+	else if (!activeGame(playnum))
+	{
+		return false;
+	}
+	return true;
+}
+
+function roomPlayability()
+{
+	var unPlayability = true;
+	for (var playnum = 0; playnum < maxPlayers; playnum++)
+	{
+		for (var splaynum = 0; splaynum < maxPlayers; splaynum++)
+		{
+			if (playnum != splaynum &&
+			playerData[playnum].usertype == USERTYPE.player.fighter &&
+			playerData[splaynum].usertype == USERTYPE.player.fighter &&
+			!inOneTeam (playnum, splaynum))
+			{
+				unPlayability = false;
+			}
+		}
+	}
+	if (unPlayability)
+	{
+//		debug(_("There are no opponents in the game."));
+		console(_("There are no opponents in the game"));
+//		gameOverMessage(false);
+		return false;
+	}
+	else {return true;}
+}
+
+function toSpectator(playnum, remove)
+{
+	hackNetOff();
+	setPower(0, playnum);
+	var spotter = {
+		X: mapWidth/2,
+		Y: mapHeight/2,
+		radius: Math.sqrt(mapWidth*mapWidth + mapHeight*mapHeight)/2*128
+	};
+	addSpotter(spotter.X, spotter.Y, playnum, spotter.radius, 0, 0);
+
+	var HQstructs = enumStruct(playnum, HQ);
+	HQstructs.forEach(function(e) {
+		removeObject(e);
+	});
+
+	if (remove === true)
+	{
+		var droids = enumDroid(playnum, DROID_ANY);
+		droids.forEach(function(e) {
+			removeObject(e);
+		});
+
+		var structs = enumStruct(playnum);
+		structs.forEach(function(e) {
+			removeObject(e);
+		});
+	}
+
+	if (selectedPlayer === playnum)
+	{
+		queue("hud", 100);
+	}
+	hackNetOn();
+}
+
+function hud()
+{
+	setMiniMap(true);
+	setReticuleButton(4, "", "", "");
+	setReticuleButton(5, "", "image_intelmap_up.png", "image_intelmap_down.png");
+	setDesign(false);
+	showInterface();
+	hackPlayIngameAudio();
+}
+
+// /////////////////////////////////////////////////////////////////
+// END CONDITIONS
+
+function checkPlayerVictoryStatus()
+{
+	for (var playnum = 0; playnum < maxPlayers; playnum++)
+	{
+		if (playerData[playnum].usertype === USERTYPE.player.winner)
+		{
+			return; // When the winner is determined, nothing needs to be done.
 		}
 	}
 
-	// Winning Conditions
-	var gamewon = true;
-
-	// check if all enemies defeated
 	for (var playnum = 0; playnum < maxPlayers; playnum++)
 	{
-		if (playnum != selectedPlayer && !allianceExistsBetween(selectedPlayer, playnum))	// checking enemy player
+		if (playerData[playnum].usertype === USERTYPE.player.loser)
 		{
-			factories = countStruct("A0LightFactory", playnum) + countStruct("A0CyborgFactory", playnum); // nope
-			droids = countDroid(DROID_ANY, playnum);
-			if (droids > 0 || factories > 0)
+			continue;
+		}
+		//we mark the retired players as lost and give them visibility. we save buildings
+		else if (!canPlay(playnum) && (playerData[playnum].usertype != USERTYPE.spectator))
+		{
+			//See loss check in function canPlay()
+			playerData[playnum].usertype = USERTYPE.player.loser;
+			toSpectator(playnum, false);
+			if  (selectedPlayer == playnum)
 			{
-				gamewon = false;	//one of the enemies still alive
-				break;
+				gameOverMessage(false);
+			}
+		}
+
+		// Winning Conditions
+		// all participants except teammates (this is not the same as the allies) cannot continue the game
+	}
+
+	var endGame = true;
+	for (var playnum = 0; playnum < maxPlayers; playnum++)
+	{
+		if (playerData[playnum].usertype != USERTYPE.player.fighter)
+		{
+			continue;
+		}
+
+		for (var splaynum = 0; splaynum < maxPlayers; splaynum++)
+		{
+			if (inOneTeam(playnum, splaynum))
+			{
+				continue;
+			}
+			else if (playerData[splaynum].usertype === USERTYPE.player.fighter)
+			{
+				endGame = false;
 			}
 		}
 	}
 
-	if (gamewon)
+	if (endGame == true)
 	{
-		gameOverMessage(true);
-		removeTimer("checkEndConditions");
+		for (var playnum = 0; playnum < maxPlayers; playnum++)
+		{
+			if (playerData[playnum].usertype === USERTYPE.player.fighter)
+			{
+				playerData[playnum].usertype = USERTYPE.player.winner;
+			}
+		}
+
+		if (playerData[selectedPlayer].usertype ===  USERTYPE.player.winner)
+		{
+			gameOverMessage(true);
+		}
+		if (playerData[selectedPlayer].usertype == USERTYPE.spectator)
+		{
+//			gameOverMessage(true);
+			console(_("the battle is over, you can leave the room"));
+//			debug("the battle is over, you can leave the room");
+		}
+	}
+}
+
+function co_eventGameInit()
+{
+	for (var playnum = 0; playnum < maxPlayers; playnum++)
+	{
+		playerData[playnum].lastActivity = gameTime;
+			//we consider observers to players who cannot play from the beginning of the game
+		if (!canPlay(playnum))
+		{
+			playerData[playnum].usertype = USERTYPE.spectator;
+			toSpectator(playnum, true);
+			continue;
+		}
+		else
+		{
+			playerData[playnum].usertype = USERTYPE.player.fighter;
+		}
+
+	}
+	if (roomPlayability())
+	{
+		setTimer("checkPlayerVictoryStatus", 3000);
+		setTimer("activityAlert", 10000);
+	}
+}
+
+function activityAlert()
+{
+	if (playerData[selectedPlayer].usertype != USERTYPE.player.fighter)
+	{
+		setMissionTime(-1);
+		removeTimer("activityAlert");
+		return;
+	}
+	if (playerData[selectedPlayer].lastActivity + IDLETIME/2 < gameTime)
+	{
+		console(_("Playing passively will lead to defeat. Actions that are considered: - unit building - research completion - construction of base structures (factories, power plants, laboratories, modules and oil derricks) - dealing damage"));
+	//		debug (getMissionTime());
+		if (getMissionTime() > IDLETIME)
+		{
+			setMissionTime((playerData[selectedPlayer].lastActivity + IDLETIME - gameTime)/1000);
+		}
+	}
+	if (playerData[selectedPlayer].lastActivity + IDLETIME/2 > gameTime)
+	{
+		setMissionTime(-1);
+	}
+}
+
+function co_eventDroidBuilt (droid)
+{
+	if (droid.player != scavengerPlayer)
+	{
+		playerData[droid.player].lastActivity = gameTime;
+	}
+}
+function co_eventStructureBuilt (structure)
+{
+	if (structure.player != scavengerPlayer)
+	{
+		playerData[structure.player].lastActivity = gameTime;
+	}
+}
+
+function co_eventResearched (research, structure, player)
+{
+	if (player != scavengerPlayer)
+	{
+		playerData[player].lastActivity = gameTime;
+	}
+}
+function co_eventAttacked (victim, attacker)
+{
+	if (attacker.player != scavengerPlayer)
+	{
+		playerData[attacker.player].lastActivity = gameTime;
 	}
 }

--- a/data/mp/multiplay/script/rules/endconditions.js
+++ b/data/mp/multiplay/script/rules/endconditions.js
@@ -44,20 +44,20 @@ function inOneTeam(playnum, splaynum)
 
 function hasFactory(playnum)
 {
-	var structs = [FACTORY, CYBORG_FACTORY, VTOL_FACTORY];
+	let structs = [FACTORY, CYBORG_FACTORY, VTOL_FACTORY];
 
-	for (var splaynum = 0; splaynum < maxPlayers; splaynum++)
+	for (let splaynum = 0; splaynum < maxPlayers; splaynum++)
 		{
 		if (!inOneTeam(playnum, splaynum))
 		{
 			continue;
 		}
 
-		for (var i = 0; i < structs.length; ++i)
+		for (let i = 0; i < structs.length; ++i)
 		{
-			var onMapStructss = enumStruct(splaynum, structs[i]);
+			let onMapStructss = enumStruct(splaynum, structs[i]);
 
-			for (var j = 0; j < onMapStructss.length; ++j)
+			for (let j = 0; j < onMapStructss.length; ++j)
 			{
 				if (onMapStructss[j].status === BUILT)
 				{
@@ -72,7 +72,7 @@ function hasFactory(playnum)
 
 function hasDroid(playnum)
 {
-	for (var splaynum = 0; splaynum < maxPlayers; splaynum++)
+	for (let splaynum = 0; splaynum < maxPlayers; splaynum++)
 	{
 		if (inOneTeam(playnum, splaynum) && countDroid(DROID_ANY, splaynum) > 0)	// checking enemy player
 		{
@@ -85,8 +85,8 @@ function hasDroid(playnum)
 
 function hasOnlyConstructor(playnum)
 {
-	var count = 0;
-	for (var splaynum = 0; splaynum < maxPlayers; splaynum++)
+	let count = 0;
+	for (let splaynum = 0; splaynum < maxPlayers; splaynum++)
 	{
 		if (inOneTeam(playnum, splaynum))
 		{
@@ -99,16 +99,16 @@ function hasOnlyConstructor(playnum)
 
 function canReachOil(playnum)
 {
-	var oils = enumFeature(ALL_PLAYERS).filter(function(e) {
+	let oils = enumFeature(ALL_PLAYERS).filter(function(e) {
 		return e.stattype === OIL_RESOURCE;
 	});
 
-	for (var tplaynum = 0; tplaynum < maxPlayers; tplaynum++)
+	for (let tplaynum = 0; tplaynum < maxPlayers; tplaynum++)
 	{
 		oils = oils.concat(enumStruct(tplaynum, "A0ResourceExtractor"));
 	}
 
-	for (var splaynum = 0; splaynum < maxPlayers; splaynum++)
+	for (let splaynum = 0; splaynum < maxPlayers; splaynum++)
 	{
 		if (!inOneTeam(playnum, splaynum))
 		{
@@ -121,15 +121,15 @@ function canReachOil(playnum)
 		}
 		else
 		{
-			var trucks = enumDroid(splaynum, DROID_CONSTRUCT);
+			let trucks = enumDroid(splaynum, DROID_CONSTRUCT);
 
-			for (var i = 0, len = trucks.length; i < len; ++i)
+			for (let i = 0, len = trucks.length; i < len; ++i)
 			{
-				var truck = trucks[i];
+				let truck = trucks[i];
 
-				for (var j = 0, len2 = oils.length; j < len2; ++j)
+				for (let j = 0, len2 = oils.length; j < len2; ++j)
 				{
-					var oil = oils[j];
+					let oil = oils[j];
 
 					if (droidCanReach(truck, oil.x, oil.y))
 					{
@@ -145,7 +145,7 @@ function canReachOil(playnum)
 
 function activeGame(playnum)
 {
-	for (var splaynum = 0; splaynum < maxPlayers; splaynum++)
+	for (let splaynum = 0; splaynum < maxPlayers; splaynum++)
 	{
 		if (inOneTeam(playnum, splaynum) &&
 		playerData[playnum].lastActivity + IDLETIME >= gameTime)
@@ -159,15 +159,16 @@ function activeGame(playnum)
 
 function canPlay(playnum)
 {
-
-//	var feature = {
-//		factory: hasFactory(playnum),
-//		droid: hasDroid(playnum),
-//		onlyConstruct: hasOnlyConstructor(playnum),
-//		oilReach: canReachOil(playnum),
-//		activeGame: activeGame(playnum)
-//	};
-//	debug(playerData[playnum].name + JSON.stringify(feature));
+/*
+	let feature = {
+		factory: hasFactory(playnum),
+		droid: hasDroid(playnum),
+		onlyConstruct: hasOnlyConstructor(playnum),
+		oilReach: canReachOil(playnum),
+		activeGame: activeGame(playnum)
+	};
+	debug(playerData[playnum].name + JSON.stringify(feature));
+*/
 
 	if (!hasFactory(playnum) && !hasDroid(playnum))
 	{
@@ -186,10 +187,10 @@ function canPlay(playnum)
 
 function roomPlayability()
 {
-	var unPlayability = true;
-	for (var playnum = 0; playnum < maxPlayers; playnum++)
+	let unPlayability = true;
+	for (let playnum = 0; playnum < maxPlayers; playnum++)
 	{
-		for (var splaynum = 0; splaynum < maxPlayers; splaynum++)
+		for (let splaynum = 0; splaynum < maxPlayers; splaynum++)
 		{
 			if (playnum != splaynum &&
 			playerData[playnum].usertype == USERTYPE.player.fighter &&
@@ -204,7 +205,7 @@ function roomPlayability()
 	{
 //		debug(_("There are no opponents in the game."));
 		console(_("There are no opponents in the game"));
-//		gameOverMessage(false);
+//		gameOverMessage(true);
 		return false;
 	}
 	else {return true;}
@@ -214,26 +215,26 @@ function toSpectator(playnum, remove)
 {
 	hackNetOff();
 	setPower(0, playnum);
-	var spotter = {
+	let spotter = {
 		X: mapWidth/2,
 		Y: mapHeight/2,
 		radius: Math.sqrt(mapWidth*mapWidth + mapHeight*mapHeight)/2*128
 	};
 	addSpotter(spotter.X, spotter.Y, playnum, spotter.radius, 0, 0);
 
-	var HQstructs = enumStruct(playnum, HQ);
+	let HQstructs = enumStruct(playnum, HQ);
 	HQstructs.forEach(function(e) {
 		removeObject(e);
 	});
 
 	if (remove === true)
 	{
-		var droids = enumDroid(playnum, DROID_ANY);
+		let droids = enumDroid(playnum, DROID_ANY);
 		droids.forEach(function(e) {
 			removeObject(e);
 		});
 
-		var structs = enumStruct(playnum);
+		let structs = enumStruct(playnum);
 		structs.forEach(function(e) {
 			removeObject(e);
 		});
@@ -261,7 +262,7 @@ function hud()
 
 function checkPlayerVictoryStatus()
 {
-	for (var playnum = 0; playnum < maxPlayers; playnum++)
+	for (let playnum = 0; playnum < maxPlayers; playnum++)
 	{
 		if (playerData[playnum].usertype === USERTYPE.player.winner)
 		{
@@ -269,7 +270,7 @@ function checkPlayerVictoryStatus()
 		}
 	}
 
-	for (var playnum = 0; playnum < maxPlayers; playnum++)
+	for (let playnum = 0; playnum < maxPlayers; playnum++)
 	{
 		if (playerData[playnum].usertype === USERTYPE.player.loser)
 		{
@@ -291,15 +292,15 @@ function checkPlayerVictoryStatus()
 		// all participants except teammates (this is not the same as the allies) cannot continue the game
 	}
 
-	var endGame = true;
-	for (var playnum = 0; playnum < maxPlayers; playnum++)
+	let endGame = true;
+	for (let playnum = 0; playnum < maxPlayers; playnum++)
 	{
 		if (playerData[playnum].usertype != USERTYPE.player.fighter)
 		{
 			continue;
 		}
 
-		for (var splaynum = 0; splaynum < maxPlayers; splaynum++)
+		for (let splaynum = 0; splaynum < maxPlayers; splaynum++)
 		{
 			if (inOneTeam(playnum, splaynum))
 			{
@@ -314,7 +315,7 @@ function checkPlayerVictoryStatus()
 
 	if (endGame == true)
 	{
-		for (var playnum = 0; playnum < maxPlayers; playnum++)
+		for (let playnum = 0; playnum < maxPlayers; playnum++)
 		{
 			if (playerData[playnum].usertype === USERTYPE.player.fighter)
 			{
@@ -337,7 +338,7 @@ function checkPlayerVictoryStatus()
 
 function co_eventGameInit()
 {
-	for (var playnum = 0; playnum < maxPlayers; playnum++)
+	for (let playnum = 0; playnum < maxPlayers; playnum++)
 	{
 		playerData[playnum].lastActivity = gameTime;
 			//we consider observers to players who cannot play from the beginning of the game
@@ -397,7 +398,6 @@ function co_eventStructureBuilt (structure)
 		playerData[structure.player].lastActivity = gameTime;
 	}
 }
-
 function co_eventResearched (research, structure, player)
 {
 	if (player != scavengerPlayer)

--- a/data/mp/multiplay/script/rules/endconditions.js
+++ b/data/mp/multiplay/script/rules/endconditions.js
@@ -21,8 +21,8 @@ const USERTYPE = {
 const IDLETIME = 5 * 60 * 1000;
 
 function inOneTeam(playnum, splaynum) {
-  //	FIXME allianceExistsBetween dont correct if leave player in ALLIANCES_UNSHARED, ALLIANCES_TEAMS mode
-  //	and  team is garbage in NO_ALLIANCES, ALLIANCES mode
+//	FIXME allianceExistsBetween dont correct if leave player in ALLIANCES_UNSHARED, ALLIANCES_TEAMS mode
+//	and  team is garbage in NO_ALLIANCES, ALLIANCES mode
 	if (
 		(alliancesType == ALLIANCES_UNSHARED || alliancesType == ALLIANCES_TEAMS) &&
     playerData[playnum].team != playerData[splaynum].team
@@ -65,7 +65,6 @@ function hasFactory(playnum) {
 function hasDroid(playnum) {
 	for (let splaynum = 0; splaynum < maxPlayers; splaynum++) {
 		if (inOneTeam(playnum, splaynum) && countDroid(DROID_ANY, splaynum) > 0) {
-      // checking enemy player
 			return true;
 		}
 	}
@@ -166,9 +165,7 @@ function roomPlayability() {
 		}
 	}
 	if (unPlayability) {
-    //		debug(_("There are no opponents in the game."));
 		console(_("There are no opponents in the game"));
-    //		gameOverMessage(true);
 		return false;
 	} else {
 		return true;
@@ -179,11 +176,11 @@ function toSpectator(playnum, remove) {
 	hackNetOff();
 	setPower(0, playnum);
 	let spotter = {
-		X: mapWidth / 2,
-		Y: mapHeight / 2,
+		x: mapWidth / 2,
+		y: mapHeight / 2,
 		radius: (Math.sqrt(mapWidth * mapWidth + mapHeight * mapHeight) / 2) * 128,
 	};
-	addSpotter(spotter.X, spotter.Y, playnum, spotter.radius, 0, 0);
+	addSpotter(spotter.x, spotter.y, playnum, spotter.radius, 0, 0);
 
 	let HQstructs = enumStruct(playnum, HQ);
 	HQstructs.forEach(function (e) {
@@ -217,9 +214,6 @@ function hud() {
 	hackPlayIngameAudio();
 }
 
-// /////////////////////////////////////////////////////////////////
-// END CONDITIONS
-
 function checkPlayerVictoryStatus() {
 	for (let playnum = 0; playnum < maxPlayers; playnum++) {
 		if (playerData[playnum].usertype === USERTYPE.player.winner) {
@@ -231,23 +225,22 @@ function checkPlayerVictoryStatus() {
 		if (playerData[playnum].usertype === USERTYPE.player.loser) {
 			continue;
 		}
-    //we mark the retired players as lost and give them visibility. we save buildings
 		else if (
-			!canPlay(playnum) &&
-      playerData[playnum].usertype != USERTYPE.spectator
+			playerData[playnum].usertype != USERTYPE.spectator &&
+		!canPlay(playnum)
 		) {
-      //See loss check in function canPlay()
+		//See loss check in function canPlay()
+		//we mark the retired players as lost and give them visibility. we save buildings
 			playerData[playnum].usertype = USERTYPE.player.loser;
 			toSpectator(playnum, false);
 			if (selectedPlayer == playnum) {
 				gameOverMessage(false);
 			}
 		}
-
-    // Winning Conditions
-    // all participants except teammates (this is not the same as the allies) cannot continue the game
 	}
 
+// Winning Conditions
+// all participants except teammates (this is not the same as the allies) cannot continue the game
 	let endGame = true;
 	for (let playnum = 0; playnum < maxPlayers; playnum++) {
 		if (playerData[playnum].usertype != USERTYPE.player.fighter) {
@@ -274,9 +267,7 @@ function checkPlayerVictoryStatus() {
 			gameOverMessage(true);
 		}
 		if (playerData[selectedPlayer].usertype == USERTYPE.spectator) {
-      //			gameOverMessage(true);
 			console(_("the battle is over, you can leave the room"));
-      //			debug("the battle is over, you can leave the room");
 		}
 	}
 }
@@ -284,7 +275,7 @@ function checkPlayerVictoryStatus() {
 function co_eventGameInit() {
 	for (let playnum = 0; playnum < maxPlayers; playnum++) {
 		playerData[playnum].lastActivity = gameTime;
-    //we consider observers to players who cannot play from the beginning of the game
+		// we consider observers to players who cannot play from the beginning of the game
 		if (!canPlay(playnum)) {
 			playerData[playnum].usertype = USERTYPE.spectator;
 			toSpectator(playnum, true);
@@ -311,7 +302,6 @@ function activityAlert() {
 				"Playing passively will lead to defeat. Actions that are considered: - unit building - research completion - construction of base structures (factories, power plants, laboratories, modules and oil derricks) - dealing damage"
 			)
 		);
-    //		debug (getMissionTime());
 		if (getMissionTime() > IDLETIME) {
 			setMissionTime(
 				(playerData[selectedPlayer].lastActivity + IDLETIME - gameTime) / 1000

--- a/data/mp/multiplay/script/rules/events/gameinit.js
+++ b/data/mp/multiplay/script/rules/events/gameinit.js
@@ -51,7 +51,6 @@ function eventGameInit()
 	//From script/rules/reticule.js
 	setMainReticule();
 
-	setTimer("checkEndConditions", 3000);
 	if (tilesetType === "URBAN" || tilesetType === "ROCKIES")
 	{
 		setTimer("weatherCycle", 45000);

--- a/data/mp/multiplay/script/rules/reticule.js
+++ b/data/mp/multiplay/script/rules/reticule.js
@@ -108,6 +108,10 @@ function reticuleCommandCheck()
 
 function setMainReticule()
 {
+	if (playerData[selectedPlayer].usertype != USERTYPE.player.fighter)
+	{
+		return;
+	}
 	setReticuleButton(0, _("Close"), "image_cancel_up.png", "image_cancel_down.png");
 	reticuleManufactureCheck();
 	reticuleResearchCheck();


### PR DESCRIPTION
These changes add observers to the game.
The definition of losers was completely redesigned and moved to a separate file.
New functionality:
- losers open the entire map. A very useful addition in FFA mode.
- players who cannot play from the very beginning of the game are marked by an observer and the whole map is opened to them.
- a message to the observer about the end of the game.
- punishment for passive play. If a player does not deal damage, does not build structures, does not complete research in 5 minutes, he is considered a loser.

Thanks to these changes to the map with the observer are easier to create. The smallest map with an observer looks like this:
```
level SK-rush2-observer
players 5
type 14
dataset MULTI_CAM_1
game "multiplay / maps / 4c-rush2.gam"
```

If in the game menu add the ability to enter slots without HQ, then the observers will work on all* maps.
*it’s not always always sometimes the empty 7th slot turns out to be scavengers

These changes have not yet been reliably tested.