### PR TITLE
Improve zooming logic

### DIFF
--- a/src/display.h
+++ b/src/display.h
@@ -216,6 +216,8 @@ bool ctrlShiftDown();
 
 UDWORD getTargetType();
 
+#define	DEFAULT_ZOOM_SPEED (5000)
+
 void setZoom(float zoomSpeed, float zoomTarget);
 float getZoom();
 float getZoomSpeed();

--- a/src/display3d.cpp
+++ b/src/display3d.cpp
@@ -1884,7 +1884,7 @@ float getViewDistance()
 void setViewDistance(float dist)
 {
 	distance = dist;
-	CONPRINTF(_("Setting zoom to %.0f"), distance);
+	debug(LOG_WZ, _("Setting zoom to %.0f"), distance);
 }
 
 /// Draw a feature (tree/rock/etc.)

--- a/src/keybind.cpp
+++ b/src/keybind.cpp
@@ -889,11 +889,11 @@ void kf_ZoomOutStep()
 {
 	if (getDebugMappingStatus())
 	{
-		setViewDistance(getViewDistance() + war_GetMapZoomRate());
+		setZoom(DEFAULT_ZOOM_SPEED, (getViewDistance() + war_GetMapZoomRate()));
 	}
 	else
 	{
-		setViewDistance(std::min<int>(getViewDistance() + war_GetMapZoomRate(), MAXDISTANCE));
+		setZoom(DEFAULT_ZOOM_SPEED, std::min<int>(getViewDistance() + war_GetMapZoomRate(), MAXDISTANCE));
 	}
 	UpdateFogDistance(getViewDistance());
 }
@@ -944,11 +944,11 @@ void kf_ZoomInStep()
 {
 	if (getDebugMappingStatus())
 	{
-		setViewDistance(getViewDistance() - war_GetMapZoomRate());
+		setZoom(DEFAULT_ZOOM_SPEED, getViewDistance() - war_GetMapZoomRate());
 	}
 	else
 	{
-		setViewDistance(std::max<int>(getViewDistance() - war_GetMapZoomRate(), MINDISTANCE));
+		setZoom(DEFAULT_ZOOM_SPEED, std::max<int>(getViewDistance() - war_GetMapZoomRate(), MINDISTANCE));
 	}
 	UpdateFogDistance(getViewDistance());
 }


### PR DESCRIPTION
First off, we DON'T want to show the scroll value as a console message. That info is relegated to the logs. 😁

Then, we reuse the existing setZoom function (with a new DEFAULT_ZOOM_SPEED = 5000 🤷‍♂️) when zoomstepping (ie. using the mouse wheel). 