### PR TITLE
Adjust height tracking logic

### DIFF
--- a/src/display3d.cpp
+++ b/src/display3d.cpp
@@ -3366,6 +3366,7 @@ static void renderSurroundings(const glm::mat4 &viewMatrix)
 /// Smoothly adjust player height to match the desired height
 static void trackHeight(float desiredHeight)
 {
+	desiredHeight = (int)(desiredHeight / HEIGHT_TRACK_INCREMENTS) * HEIGHT_TRACK_INCREMENTS;
 	static float heightSpeed = 0.0f;
 	float separation = desiredHeight - player.p.y;	// How far are we from desired height?
 

--- a/src/display3d.cpp
+++ b/src/display3d.cpp
@@ -1850,6 +1850,9 @@ void setViewPos(UDWORD x, UDWORD y, WZ_DECL_UNUSED bool Pan)
 	player.p.x = world_coord(x);
 	player.p.z = world_coord(y);
 	player.r.z = 0;
+	
+	calcAverageTerrainHeight(&player);
+	player.p.y = averageCentreTerrainHeight + CAMERA_PIVOT_HEIGHT - HEIGHT_TRACK_INCREMENTS;
 
 	if (getWarCamStatus())
 	{

--- a/src/display3d.cpp
+++ b/src/display3d.cpp
@@ -1852,7 +1852,11 @@ void setViewPos(UDWORD x, UDWORD y, WZ_DECL_UNUSED bool Pan)
 	player.r.z = 0;
 	
 	calcAverageTerrainHeight(&player);
-	player.p.y = averageCentreTerrainHeight + CAMERA_PIVOT_HEIGHT - HEIGHT_TRACK_INCREMENTS;
+
+	if(player.p.y < averageCentreTerrainHeight)
+	{
+		player.p.y = averageCentreTerrainHeight + CAMERA_PIVOT_HEIGHT - HEIGHT_TRACK_INCREMENTS;
+	}
 
 	if (getWarCamStatus())
 	{

--- a/src/display3d.cpp
+++ b/src/display3d.cpp
@@ -3366,7 +3366,7 @@ static void renderSurroundings(const glm::mat4 &viewMatrix)
 /// Smoothly adjust player height to match the desired height
 static void trackHeight(float desiredHeight)
 {
-	desiredHeight = (int)(desiredHeight / HEIGHT_TRACK_INCREMENTS) * HEIGHT_TRACK_INCREMENTS;
+	desiredHeight = std::ceil(desiredHeight / HEIGHT_TRACK_INCREMENTS) * HEIGHT_TRACK_INCREMENTS;
 	static float heightSpeed = 0.0f;
 	float separation = desiredHeight - player.p.y;	// How far are we from desired height?
 

--- a/src/display3d.h
+++ b/src/display3d.h
@@ -28,6 +28,8 @@
 #include "objectdef.h"
 #include "message.h"
 
+#define HEIGHT_TRACK_INCREMENTS (250)
+
 /*!
  * Special tile types
  */


### PR DESCRIPTION
This one's been driving me nuts ... so sorry about all the PRs ... 😁

The terrain height tracking is currently sort of "licking the ground", and it's kinda motion sickness inducing, not kidding... Because of a levels terrain fluctuations across tiles, as I move a few squares, 
 you notice the camera constantly adjusting its height, even if the height difference on the ground isn't noticeable.

In fact, there is a small delay that distracts the player as soon as they have stopped navigating with the camera. about 1-2s after, the camera will sink or rise depending on where you landed.

This PR changes the terrain tracking to snapping to increments of 250 (units?), and even ignores very small elevations. Ideally, you should only have one (big) correction when going upon a mountain.