### PR TITLE
[WIP] Make loading animation smoother

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1027,6 +1027,10 @@ void mainLoop()
 {
 	frameUpdate(); // General housekeeping
 
+
+	if(isStarsAllocated()){
+		printf("Stars allocated\n");
+	}
 	// Screenshot key is now available globally
 	if (keyPressed(KEY_F10))
 	{

--- a/src/wrappers.cpp
+++ b/src/wrappers.cpp
@@ -72,6 +72,11 @@ static STAR newStar()
 	return s;
 }
 
+bool isStarsAllocated()
+{
+	return !!stars;
+}
+
 static void setupLoadingScreen()
 {
 	unsigned int i;

--- a/src/wrappers.h
+++ b/src/wrappers.h
@@ -40,6 +40,7 @@ extern int hostlaunch;
 bool frontendInitVars();
 TITLECODE titleLoop();
 
+bool isStarsAllocated();
 void initLoadingScreen(bool drawbdrop);
 void closeLoadingScreen();
 void loadingScreenCallback();


### PR DESCRIPTION
This one's a bit tricky.

Current changes are just a quick test for showing if the loading screen is properly cleaned up at all situations.

The reason I wanted to do this test is because the loading screen is manually setup and "cleanupped" - but in some places you only find the setup function being called, no cleanup. Now, there's nothing that says the loading screen wasn't being properly cleaned up outside that function, but ideally, the function that sets up the loading screen **should also do the cleanup**.

And whaddaya know, we actually missed a spot ✨🧹😅

When running `/root/wz/install/bin/warzone2100 --game=CAM_1A` the output continously says "Stars allocated" when having started the game.

So, it would be good to do cleanup in all the same functions as we are doing the setup.

The point of all this? I was experimenting with the code to run the star update on each frame instead, and "discovered" that the loading actually blocks the main thread ... fair enough. That's for another day I guess.

But, if we meticulously cleanup after each loading screen setup, can we perhaps afford to start a new thread to update the loading animation?

I am GUESSING this would be the least invasive option, not offloading the loading from the main thread.

Thoughts? Ideas?