### PR TITLE
Vary initial direction of rotating radars

### DIFF
--- a/src/structure.cpp
+++ b/src/structure.cpp
@@ -2601,7 +2601,7 @@ static void aiUpdateStructure(STRUCTURE *psStructure, bool isMission)
 			//////
 			// - radar should rotate every three seconds ... 'cause we timed it at Heathrow !
 			// gameTime is in milliseconds - one rotation every 3 seconds = 1 rotation event 3000 millisecs
-			psStructure->asWeaps[0].rot.direction = (uint16_t)((uint64_t)gameTime * 65536 / 3000);  // Cast wrapping intended.
+			psStructure->asWeaps[0].rot.direction = (uint16_t)((uint64_t)gameTime * 65536 / 3000) + ((psStructure->pos.x + psStructure->pos.y) % 10) * 4096;  // Randomize by hashing position as seed for rotating 1/16th turns. Cast wrapping intended.
 			psStructure->asWeaps[0].rot.pitch = 0;
 		}
 	}

--- a/src/structure.cpp
+++ b/src/structure.cpp
@@ -2601,7 +2601,7 @@ static void aiUpdateStructure(STRUCTURE *psStructure, bool isMission)
 			//////
 			// - radar should rotate every three seconds ... 'cause we timed it at Heathrow !
 			// gameTime is in milliseconds - one rotation every 3 seconds = 1 rotation event 3000 millisecs
-			psStructure->asWeaps[0].rot.direction = (uint16_t)((uint64_t)gameTime * 65536 / 3000) + ((psStructure->pos.x + psStructure->pos.y) % 10) * 4096;  // Randomize by hashing position as seed for rotating 1/16th turns. Cast wrapping intended.
+			psStructure->asWeaps[0].rot.direction = (uint16_t)((uint64_t)gameTime * 65536 / 3000) + ((psStructure->pos.x + psStructure->pos.y) % 10) * 6550;  // Randomize by hashing position as seed for rotating 1/10th turns. Cast wrapping intended.
 			psStructure->asWeaps[0].rot.pitch = 0;
 		}
 	}


### PR DESCRIPTION
Here's something that has annoyed me for a looong time ... 😁

Why are all rotating radars linked to the same direction? Even enemies' radars are synched with mine!!

Here, I use the position of the structure to make a "seed" for making a pseudo-random 1/10th of a turn, to vary the positions of the radars a little.

Simple, but effective, and also deterministic. Dunno if that's a good thing ...

About the "Cast wrapping intended". I'm adding to something that will be up to 65535. Can this cause some sort of overflow?

Obligatory screenshots:

Before:
![before-changes](https://user-images.githubusercontent.com/668160/78504230-027ad880-776c-11ea-8d83-5e79d5fd9d14.png)

After:
![after-changes](https://user-images.githubusercontent.com/668160/78504232-060e5f80-776c-11ea-98f4-a9197fe44d84.png)