### PR TITLE
Vary initial oil derrick animation

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -4977,6 +4977,21 @@ bool loadSaveStructure(char *pFileData, UDWORD filesize)
 		}
 		else if (psStructure->pStructureType->type == REF_RESOURCE_EXTRACTOR)
 		{
+			iIMDShape *strImd;
+			strImd = psStructure->sDisplay.imd;
+			strImd = strImd->objanimpie[ANIM_EVENT_ACTIVE];
+
+			while (strImd)
+			{
+				if(strImd->objanimframes)
+				{
+					psStructure->timeAnimationStarted = -(rand() % (strImd->objanimframes * strImd->objanimtime * strImd->objanimframes));
+					break;
+				}
+				
+				strImd = strImd->next;
+			}
+
 			scriptSetDerrickPos(psStructure->pos.x, psStructure->pos.y);
 		}
 	}
@@ -5014,6 +5029,7 @@ static bool loadSaveStructure2(const char *pFileName, STRUCTURE **ppList)
 		debug(LOG_SAVE, "No %s found -- use fallback method", pFileName);
 		return false;	// try to use fallback method
 	}
+	iIMDShape *strImd;
 	WzConfig ini(WzString::fromUtf8(pFileName), WzConfig::ReadOnly);
 
 	freeAllFlagPositions();		//clear any flags put in during level loads
@@ -5193,6 +5209,19 @@ static bool loadSaveStructure2(const char *pFileName, STRUCTURE **ppList)
 			}
 			break;
 		case REF_RESOURCE_EXTRACTOR:
+			strImd = psStructure->sDisplay.imd;
+			strImd = strImd->objanimpie[ANIM_EVENT_ACTIVE];
+
+			while (strImd)
+			{
+				if(strImd->objanimframes)
+				{
+					psStructure->timeAnimationStarted = -(rand() % (strImd->objanimframes * strImd->objanimtime * strImd->objanimframes));
+					break;
+				}
+				
+				strImd = strImd->next;
+			}
 			break;
 		case REF_REPAIR_FACILITY:
 			psRepair = ((REPAIR_FACILITY *)psStructure->pFunctionality);

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -96,8 +96,6 @@
 #pragma GCC diagnostic ignored "-Wcast-align"	// TODO: FIXME!
 #endif
 
-static void startPieAnimationAtRandomFrame(STRUCTURE *psStructure, ANIMATION_EVENTS animation);
-
 
 void gameScreenSizeDidChange(unsigned int oldWidth, unsigned int oldHeight, unsigned int newWidth, unsigned int newHeight)
 {
@@ -4979,8 +4977,6 @@ bool loadSaveStructure(char *pFileData, UDWORD filesize)
 		}
 		else if (psStructure->pStructureType->type == REF_RESOURCE_EXTRACTOR)
 		{
-			startPieAnimationAtRandomFrame(psStructure, ANIM_EVENT_ACTIVE);
-
 			scriptSetDerrickPos(psStructure->pos.x, psStructure->pos.y);
 		}
 	}
@@ -5197,7 +5193,6 @@ static bool loadSaveStructure2(const char *pFileName, STRUCTURE **ppList)
 			}
 			break;
 		case REF_RESOURCE_EXTRACTOR:
-			startPieAnimationAtRandomFrame(psStructure, ANIM_EVENT_ACTIVE);
 			break;
 		case REF_REPAIR_FACILITY:
 			psRepair = ((REPAIR_FACILITY *)psStructure->pFunctionality);
@@ -5263,23 +5258,6 @@ static bool loadSaveStructure2(const char *pFileName, STRUCTURE **ppList)
 	resetFactoryNumFlag();	//reset flags into the masks
 
 	return true;
-}
-
-static void startPieAnimationAtRandomFrame(STRUCTURE *psStructure, ANIMATION_EVENTS animation)
-{
-	iIMDShape *strImd = psStructure->sDisplay.imd;
-	strImd = strImd->objanimpie[animation];
-
-	while (strImd)
-	{
-		if(strImd->objanimframes)
-		{
-			psStructure->timeAnimationStarted = (rand() % (strImd->objanimframes * strImd->objanimtime));
-			break;
-		}
-		
-		strImd = strImd->next;
-	}
 }
 
 // -----------------------------------------------------------------------------------------

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -96,6 +96,8 @@
 #pragma GCC diagnostic ignored "-Wcast-align"	// TODO: FIXME!
 #endif
 
+static void startPieAnimationAtRandomFrame(STRUCTURE *psStructure, ANIMATION_EVENTS animation);
+
 
 void gameScreenSizeDidChange(unsigned int oldWidth, unsigned int oldHeight, unsigned int newWidth, unsigned int newHeight)
 {
@@ -4977,20 +4979,7 @@ bool loadSaveStructure(char *pFileData, UDWORD filesize)
 		}
 		else if (psStructure->pStructureType->type == REF_RESOURCE_EXTRACTOR)
 		{
-			iIMDShape *strImd;
-			strImd = psStructure->sDisplay.imd;
-			strImd = strImd->objanimpie[ANIM_EVENT_ACTIVE];
-
-			while (strImd)
-			{
-				if(strImd->objanimframes)
-				{
-					psStructure->timeAnimationStarted = -(rand() % (strImd->objanimframes * strImd->objanimtime * strImd->objanimframes));
-					break;
-				}
-				
-				strImd = strImd->next;
-			}
+			startPieAnimationAtRandomFrame(psStructure, ANIM_EVENT_ACTIVE);
 
 			scriptSetDerrickPos(psStructure->pos.x, psStructure->pos.y);
 		}
@@ -5029,7 +5018,6 @@ static bool loadSaveStructure2(const char *pFileName, STRUCTURE **ppList)
 		debug(LOG_SAVE, "No %s found -- use fallback method", pFileName);
 		return false;	// try to use fallback method
 	}
-	iIMDShape *strImd;
 	WzConfig ini(WzString::fromUtf8(pFileName), WzConfig::ReadOnly);
 
 	freeAllFlagPositions();		//clear any flags put in during level loads
@@ -5209,19 +5197,7 @@ static bool loadSaveStructure2(const char *pFileName, STRUCTURE **ppList)
 			}
 			break;
 		case REF_RESOURCE_EXTRACTOR:
-			strImd = psStructure->sDisplay.imd;
-			strImd = strImd->objanimpie[ANIM_EVENT_ACTIVE];
-
-			while (strImd)
-			{
-				if(strImd->objanimframes)
-				{
-					psStructure->timeAnimationStarted = -(rand() % (strImd->objanimframes * strImd->objanimtime * strImd->objanimframes));
-					break;
-				}
-				
-				strImd = strImd->next;
-			}
+			startPieAnimationAtRandomFrame(psStructure, ANIM_EVENT_ACTIVE);
 			break;
 		case REF_REPAIR_FACILITY:
 			psRepair = ((REPAIR_FACILITY *)psStructure->pFunctionality);
@@ -5287,6 +5263,23 @@ static bool loadSaveStructure2(const char *pFileName, STRUCTURE **ppList)
 	resetFactoryNumFlag();	//reset flags into the masks
 
 	return true;
+}
+
+static void startPieAnimationAtRandomFrame(STRUCTURE *psStructure, ANIMATION_EVENTS animation)
+{
+	iIMDShape *strImd = psStructure->sDisplay.imd;
+	strImd = strImd->objanimpie[animation];
+
+	while (strImd)
+	{
+		if(strImd->objanimframes)
+		{
+			psStructure->timeAnimationStarted = (rand() % (strImd->objanimframes * strImd->objanimtime));
+			break;
+		}
+		
+		strImd = strImd->next;
+	}
 }
 
 // -----------------------------------------------------------------------------------------

--- a/src/structure.cpp
+++ b/src/structure.cpp
@@ -3582,8 +3582,17 @@ void structureUpdate(STRUCTURE *psBuilding, bool mission)
 		{
 			psBuilding->animationEvent = ANIM_EVENT_ACTIVE;
 
-			iIMDShape *strImd = psBuilding->sDisplay.imd->objanimpie[psBuilding->animationEvent]->next; // first imd isn't animated
-			psBuilding->timeAnimationStarted = gameTime + (rand() % (strImd->objanimframes * strImd->objanimtime)); // vary animation start time
+			iIMDShape *strFirstImd = psBuilding->sDisplay.imd->objanimpie[psBuilding->animationEvent];
+			if (strFirstImd != nullptr && strFirstImd->next != nullptr)
+			{
+				iIMDShape *strImd = strFirstImd->next; // first imd isn't animated
+				psBuilding->timeAnimationStarted = gameTime + (rand() % (strImd->objanimframes * strImd->objanimtime)); // vary animation start time
+			}
+			else
+			{
+				ASSERT(strFirstImd != nullptr && strFirstImd->next != nullptr, "Unexpected objanimpie");
+				psBuilding->timeAnimationStarted = gameTime;  // so start animation
+			}
 		}
 
 		if (psBuilding->player == selectedPlayer)

--- a/src/structure.cpp
+++ b/src/structure.cpp
@@ -3582,7 +3582,7 @@ void structureUpdate(STRUCTURE *psBuilding, bool mission)
 		{
 			psBuilding->animationEvent = ANIM_EVENT_ACTIVE;
 
-			iIMDShape *strImd = psBuilding->sDisplay.imd->objanimpie[psBuilding->animationEvent]->next;
+			iIMDShape *strImd = psBuilding->sDisplay.imd->objanimpie[psBuilding->animationEvent]->next; // first imd isn't animated
 			psBuilding->timeAnimationStarted = gameTime + (rand() % (strImd->objanimframes * strImd->objanimtime)); // vary animation start time
 		}
 

--- a/src/structure.cpp
+++ b/src/structure.cpp
@@ -3580,7 +3580,19 @@ void structureUpdate(STRUCTURE *psBuilding, bool mission)
 		else if (psBuilding->pFunctionality->resourceExtractor.psPowerGen
 		         && psBuilding->animationEvent == ANIM_EVENT_NONE) // we have a power generator, but no animation
 		{
-			psBuilding->timeAnimationStarted = gameTime;  // so start animation
+			iIMDShape *strImd = psBuilding->sDisplay.imd->objanimpie[ANIM_EVENT_ACTIVE];
+
+			while (strImd)
+			{
+				if(!strImd->objanimframes)
+				{
+					strImd = strImd->next;
+					break;
+				}
+				
+				psBuilding->timeAnimationStarted = gameTime + (rand() % (strImd->objanimframes * strImd->objanimtime)); // vary animation start time
+			}
+
 			psBuilding->animationEvent = ANIM_EVENT_ACTIVE;
 		}
 

--- a/src/structure.cpp
+++ b/src/structure.cpp
@@ -3580,20 +3580,10 @@ void structureUpdate(STRUCTURE *psBuilding, bool mission)
 		else if (psBuilding->pFunctionality->resourceExtractor.psPowerGen
 		         && psBuilding->animationEvent == ANIM_EVENT_NONE) // we have a power generator, but no animation
 		{
-			iIMDShape *strImd = psBuilding->sDisplay.imd->objanimpie[ANIM_EVENT_ACTIVE];
-
-			while (strImd)
-			{
-				if(!strImd->objanimframes)
-				{
-					strImd = strImd->next;
-					break;
-				}
-				
-				psBuilding->timeAnimationStarted = gameTime + (rand() % (strImd->objanimframes * strImd->objanimtime)); // vary animation start time
-			}
-
 			psBuilding->animationEvent = ANIM_EVENT_ACTIVE;
+
+			iIMDShape *strImd = psBuilding->sDisplay.imd->objanimpie[psBuilding->animationEvent]->next;
+			psBuilding->timeAnimationStarted = gameTime + (rand() % (strImd->objanimframes * strImd->objanimtime)); // vary animation start time
 		}
 
 		if (psBuilding->player == selectedPlayer)


### PR DESCRIPTION
Here goes @KJeff01 !

This PR has some duplicated code; because we need to do this both at game start and savegame start. I didn't find a good place where both code paths converge. (too far away from the loading logic)

But in essential the code randomizes the starting frame (by postponing the animation start very slightly) by a random amount.

Also, I feel that the member name `objanimtime` (also present in the PIE files) is a bit misleading, if I understand it's role correctly.

The comment mentions that it's the "total time to render all animation frames" (like 60 for the oil derrick pumping animation), but in actuality it seems to be the number of milliseconds for each frame. If I am correct, then the comment is wrong and I could update it.