### PR TITLE
Fade from black when starting game.

### DIFF
--- a/src/display.cpp
+++ b/src/display.cpp
@@ -143,7 +143,7 @@ static UDWORD CurrentItemUnderMouse = 0;
 bool	rotActive = false;
 bool	gameStats = false;
 
-static const float FADE_START_OF_GAME_TIME = 4000;
+static const float FADE_START_OF_GAME_TIME = 1000;
 static void fadeStartOfGame();
 
 //used to determine is a weapon droid is assigned to a sensor tower or sensor droid
@@ -1216,7 +1216,7 @@ void displayWorld()
 
 	draw3DScene();
 
-	if(realTime < FADE_START_OF_GAME_TIME)
+	if(graphicsTime < FADE_START_OF_GAME_TIME)
 	{
 		fadeStartOfGame();
 	}
@@ -1226,7 +1226,7 @@ static void fadeStartOfGame()
 {
 	pie_SetDepthBufferStatus(DEPTH_CMP_ALWAYS_WRT_OFF);
 	PIELIGHT color = WZCOL_BLACK;
-	float delta = realTime / FADE_START_OF_GAME_TIME;
+	float delta = graphicsTime / FADE_START_OF_GAME_TIME;
 	color.byte.a = 255 * (1 - delta * delta * delta); // cubic easing
 	pie_UniTransBoxFill(0, 0, pie_GetVideoBufferWidth(), pie_GetVideoBufferHeight(), color);
 	pie_SetDepthBufferStatus(DEPTH_CMP_LEQ_WRT_ON);

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -143,6 +143,9 @@ static UDWORD CurrentItemUnderMouse = 0;
 bool	rotActive = false;
 bool	gameStats = false;
 
+static const float FADE_START_OF_GAME_TIME = 4000;
+static void fadeStartOfGame();
+
 //used to determine is a weapon droid is assigned to a sensor tower or sensor droid
 static bool bSensorAssigned;
 //used to determine if the player has selected a Las Sat structure
@@ -1212,6 +1215,21 @@ void displayWorld()
 	}
 
 	draw3DScene();
+
+	if(realTime < FADE_START_OF_GAME_TIME)
+	{
+		fadeStartOfGame();
+	}
+}
+
+static void fadeStartOfGame()
+{
+	pie_SetDepthBufferStatus(DEPTH_CMP_ALWAYS_WRT_OFF);
+	PIELIGHT color = WZCOL_BLACK;
+	float delta = realTime / FADE_START_OF_GAME_TIME;
+	color.byte.a = 255 * (1 - delta * delta * delta); // cubic easing
+	pie_UniTransBoxFill(0, 0, pie_GetVideoBufferWidth(), pie_GetVideoBufferHeight(), color);
+	pie_SetDepthBufferStatus(DEPTH_CMP_LEQ_WRT_ON);
 }
 
 static bool mouseInBox(SDWORD x0, SDWORD y0, SDWORD x1, SDWORD y1)

--- a/src/display.h
+++ b/src/display.h
@@ -31,6 +31,9 @@
 /* Initialise the display system */
 bool dispInitialise();
 
+/* Initialize fade-in transition */
+bool transitionInit();
+
 void ProcessRadarInput();
 
 void processInput();

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -955,6 +955,7 @@ bool stageOneInitialise()
 	scriptInit();
 
 	gameTimeInit();
+	transitionInit();
 
 	return true;
 }


### PR DESCRIPTION
Hello!

I used gameTime to set the fade alpha, but that seems to only update so often ... if using realTime, it's much smoother, but not zeroed on game start. So the fade only works when starting a game on startup, ie with --game argument from the command line.

Anyone know how to do this correctly?

UPDATE: Ready for testing!