### PR TITLE
Split "set cursor" and "apply cursor"

### DIFF
--- a/lib/framework/wzapp.h
+++ b/lib/framework/wzapp.h
@@ -83,7 +83,7 @@ unsigned int wzGetMaximumDisplayScaleForWindowSize(unsigned int windowWidth, uns
 unsigned int wzGetCurrentDisplayScale();
 void wzGetWindowResolution(int *screen, unsigned int *width, unsigned int *height);
 void wzSetCursor(CURSOR index);
-void wzUpdateCursor();
+void wzApplyCursor();
 void wzScreenFlip();	///< Swap the graphics buffers
 void wzShowMouse(bool visible); ///< Show the Mouse?
 void wzGrabMouse();		///< Trap mouse cursor in application window

--- a/lib/framework/wzapp.h
+++ b/lib/framework/wzapp.h
@@ -83,6 +83,7 @@ unsigned int wzGetMaximumDisplayScaleForWindowSize(unsigned int windowWidth, uns
 unsigned int wzGetCurrentDisplayScale();
 void wzGetWindowResolution(int *screen, unsigned int *width, unsigned int *height);
 void wzSetCursor(CURSOR index);
+void wzUpdateCursor();
 void wzScreenFlip();	///< Swap the graphics buffers
 void wzShowMouse(bool visible); ///< Show the Mouse?
 void wzGrabMouse();		///< Trap mouse cursor in application window

--- a/lib/sdl/cursors_sdl.cpp
+++ b/lib/sdl/cursors_sdl.cpp
@@ -29,6 +29,7 @@
 #include <SDL.h>
 
 static CURSOR currentCursor = CURSOR_MAX;
+static bool newCursor = false;
 static SDL_Cursor *aCursors[CURSOR_MAX];
 static bool monoCursor;
 
@@ -1355,24 +1356,40 @@ SDL_Cursor *init_system_cursor32(CURSOR cur)
 }
 
 /**
-	wzSetCursor()-- Set the current cursor
+	wzSetCursor()-- Set the current cursor. Needs to be combined with wzUpdateCursor() !
  */
 void wzSetCursor(CURSOR cur)
 {
 	ASSERT(cur < CURSOR_MAX, "Specified cursor(%d) is over our limit of (%d)!", (int)cur, (int)CURSOR_MAX);
+	
+	if(currentCursor == cur)
+	{
+		return;
+	}
+
+	currentCursor = cur;
+	newCursor = true;
+}
+
+void wzUpdateCursor()
+{
 	// If mouse cursor options change, change cursors (used to only work on mouse options screen for some reason)
 	if (!(war_GetColouredCursor() ^ monoCursor))
 	{
 		sdlFreeCursors();
 		war_GetColouredCursor() ? sdlInitColoredCursors() : sdlInitCursors();
-		SDL_SetCursor(aCursors[cur]);
+		SDL_SetCursor(aCursors[currentCursor]);
+		return;
 	}
-	// If we are already using this cursor then  return
-	if (cur != currentCursor)
+
+	if(!newCursor)
 	{
-		SDL_SetCursor(aCursors[cur]);
-		currentCursor = cur;
+		return;
 	}
+
+	// If we are already using this cursor then return
+	SDL_SetCursor(aCursors[currentCursor]);
+	newCursor = false;
 }
 
 /**

--- a/lib/sdl/cursors_sdl.cpp
+++ b/lib/sdl/cursors_sdl.cpp
@@ -1356,7 +1356,7 @@ SDL_Cursor *init_system_cursor32(CURSOR cur)
 }
 
 /**
-	wzSetCursor()-- Set the current cursor. Needs to be combined with wzUpdateCursor() !
+	wzSetCursor()-- Set the current cursor. Needs to be combined with wzApplyCursor() !
  */
 void wzSetCursor(CURSOR cur)
 {
@@ -1371,7 +1371,7 @@ void wzSetCursor(CURSOR cur)
 	newCursor = true;
 }
 
-void wzUpdateCursor()
+void wzApplyCursor()
 {
 	// If mouse cursor options change, change cursors (used to only work on mouse options screen for some reason)
 	if (!(war_GetColouredCursor() ^ monoCursor))

--- a/src/frontend.cpp
+++ b/src/frontend.cpp
@@ -1643,6 +1643,7 @@ bool runMouseOptionsMenu()
 		war_SetColouredCursor(!war_GetColouredCursor());
 		widgSetString(psWScreen, FRONTEND_CURSORMODE_R, mouseOptionsCursorModeString());
 		wzSetCursor(CURSOR_DEFAULT);
+		wzUpdateCursor();
 		break;
 
 	case FRONTEND_SCROLLEVENT:

--- a/src/frontend.cpp
+++ b/src/frontend.cpp
@@ -1643,7 +1643,7 @@ bool runMouseOptionsMenu()
 		war_SetColouredCursor(!war_GetColouredCursor());
 		widgSetString(psWScreen, FRONTEND_CURSORMODE_R, mouseOptionsCursorModeString());
 		wzSetCursor(CURSOR_DEFAULT);
-		wzUpdateCursor();
+		wzApplyCursor();
 		break;
 
 	case FRONTEND_SCROLLEVENT:

--- a/src/ingameop.cpp
+++ b/src/ingameop.cpp
@@ -279,6 +279,7 @@ static bool _intAddInGameOptions()
 	InGameOpUp	= true;					// inform interface.
 
 	wzSetCursor(CURSOR_DEFAULT);
+	wzUpdateCursor();
 
 	return true;
 }
@@ -765,6 +766,7 @@ static bool runIGMouseOptionsMenu(UDWORD id)
 		war_SetColouredCursor(!war_GetColouredCursor());
 		widgSetString(psWScreen, INTINGAMEOP_CURSORMODE_R, mouseOptionsCursorModeString());
 		wzSetCursor(CURSOR_DEFAULT);
+		wzUpdateCursor();
 		break;
 
 	case INTINGAMEOP_SCROLLEVENT:

--- a/src/ingameop.cpp
+++ b/src/ingameop.cpp
@@ -279,7 +279,7 @@ static bool _intAddInGameOptions()
 	InGameOpUp	= true;					// inform interface.
 
 	wzSetCursor(CURSOR_DEFAULT);
-	wzUpdateCursor();
+	wzApplyCursor();
 
 	return true;
 }
@@ -766,7 +766,7 @@ static bool runIGMouseOptionsMenu(UDWORD id)
 		war_SetColouredCursor(!war_GetColouredCursor());
 		widgSetString(psWScreen, INTINGAMEOP_CURSORMODE_R, mouseOptionsCursorModeString());
 		wzSetCursor(CURSOR_DEFAULT);
-		wzUpdateCursor();
+		wzApplyCursor();
 		break;
 
 	case INTINGAMEOP_SCROLLEVENT:

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -834,6 +834,7 @@ bool frontendInitialise(const char *ResourceFile)
 	// Set the default uncoloured cursor here, since it looks slightly
 	// better for menus and such.
 	wzSetCursor(CURSOR_DEFAULT);
+	wzUpdateCursor();
 
 	SetFormAudioIDs(-1, ID_SOUND_WINDOWCLOSE);			// disable the open noise since distorted in 3dfx builds.
 
@@ -1088,6 +1089,7 @@ bool stageTwoInitialise()
 	// Set the default uncoloured cursor here, since it looks slightly
 	// better for menus and such.
 	wzSetCursor(CURSOR_DEFAULT);
+	wzUpdateCursor();
 
 	SetFormAudioIDs(ID_SOUND_WINDOWOPEN, ID_SOUND_WINDOWCLOSE);
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -834,7 +834,7 @@ bool frontendInitialise(const char *ResourceFile)
 	// Set the default uncoloured cursor here, since it looks slightly
 	// better for menus and such.
 	wzSetCursor(CURSOR_DEFAULT);
-	wzUpdateCursor();
+	wzApplyCursor();
 
 	SetFormAudioIDs(-1, ID_SOUND_WINDOWCLOSE);			// disable the open noise since distorted in 3dfx builds.
 
@@ -1089,7 +1089,7 @@ bool stageTwoInitialise()
 	// Set the default uncoloured cursor here, since it looks slightly
 	// better for menus and such.
 	wzSetCursor(CURSOR_DEFAULT);
-	wzUpdateCursor();
+	wzApplyCursor();
 
 	SetFormAudioIDs(ID_SOUND_WINDOWOPEN, ID_SOUND_WINDOWCLOSE);
 

--- a/src/keybind.cpp
+++ b/src/keybind.cpp
@@ -2798,7 +2798,7 @@ void kf_QuickLoad()
 		setWidgetsStatus(true);
 		intResetScreen(false);
 		wzSetCursor(CURSOR_DEFAULT);
-		wzUpdateCursor();
+		wzApplyCursor();
 		int campaign = getCampaign(filename);
 		setCampaignNumber(campaign);
 

--- a/src/keybind.cpp
+++ b/src/keybind.cpp
@@ -2798,6 +2798,7 @@ void kf_QuickLoad()
 		setWidgetsStatus(true);
 		intResetScreen(false);
 		wzSetCursor(CURSOR_DEFAULT);
+		wzUpdateCursor();
 		int campaign = getCampaign(filename);
 		setCampaignNumber(campaign);
 

--- a/src/loop.cpp
+++ b/src/loop.cpp
@@ -160,7 +160,7 @@ static GAMECODE renderLoop()
 			{
 				// Using software cursors (when on) for these menus due to a bug in SDL's SDL_ShowCursor()
 				wzSetCursor(CURSOR_DEFAULT);
-				wzUpdateCursor();
+				wzApplyCursor();
 			}
 
 #ifdef DEBUG
@@ -204,7 +204,7 @@ static GAMECODE renderLoop()
 	{
 		// Using software cursors (when on) for these menus due to a bug in SDL's SDL_ShowCursor()
 		wzSetCursor(CURSOR_DEFAULT);
-		wzUpdateCursor();
+		wzApplyCursor();
 
 		if (dragBox3D.status != DRAG_DRAGGING)
 		{
@@ -336,7 +336,7 @@ static GAMECODE renderLoop()
 	}
 
 	wzSetCursor(cursor);
-	wzUpdateCursor();
+	wzApplyCursor();
 
 	pie_GetResetCounts(&loopPieCount, &loopPolyCount);
 

--- a/src/loop.cpp
+++ b/src/loop.cpp
@@ -160,6 +160,7 @@ static GAMECODE renderLoop()
 			{
 				// Using software cursors (when on) for these menus due to a bug in SDL's SDL_ShowCursor()
 				wzSetCursor(CURSOR_DEFAULT);
+				wzUpdateCursor();
 			}
 
 #ifdef DEBUG
@@ -203,6 +204,7 @@ static GAMECODE renderLoop()
 	{
 		// Using software cursors (when on) for these menus due to a bug in SDL's SDL_ShowCursor()
 		wzSetCursor(CURSOR_DEFAULT);
+		wzUpdateCursor();
 
 		if (dragBox3D.status != DRAG_DRAGGING)
 		{
@@ -334,6 +336,7 @@ static GAMECODE renderLoop()
 	}
 
 	wzSetCursor(cursor);
+	wzUpdateCursor();
 
 	pie_GetResetCounts(&loopPieCount, &loopPolyCount);
 

--- a/src/mission.cpp
+++ b/src/mission.cpp
@@ -2408,6 +2408,7 @@ void intRemoveMissionResultNoAnim()
 void intRunMissionResult()
 {
 	wzSetCursor(CURSOR_DEFAULT);
+	wzUpdateCursor();
 
 	if (bLoadSaveUp)
 	{

--- a/src/mission.cpp
+++ b/src/mission.cpp
@@ -2408,7 +2408,7 @@ void intRemoveMissionResultNoAnim()
 void intRunMissionResult()
 {
 	wzSetCursor(CURSOR_DEFAULT);
-	wzUpdateCursor();
+	wzApplyCursor();
 
 	if (bLoadSaveUp)
 	{

--- a/src/wrappers.cpp
+++ b/src/wrappers.cpp
@@ -167,7 +167,7 @@ TITLECODE titleLoop()
 		}
 		// Using software cursors (when on) for these menus due to a bug in SDL's SDL_ShowCursor()
 		wzSetCursor(CURSOR_DEFAULT);
-		wzUpdateCursor();
+		wzApplyCursor();
 	}
 
 	if (wzTitleUICurrent)

--- a/src/wrappers.cpp
+++ b/src/wrappers.cpp
@@ -167,6 +167,7 @@ TITLECODE titleLoop()
 		}
 		// Using software cursors (when on) for these menus due to a bug in SDL's SDL_ShowCursor()
 		wzSetCursor(CURSOR_DEFAULT);
+		wzUpdateCursor();
 	}
 
 	if (wzTitleUICurrent)


### PR DESCRIPTION
Ideally, we don't want to switch cursors several times during a single update. This sentiment is already present in the code. But we also do not want to occupy the return value of a function with CURSOR.

So, it's better to remember cursor state and do the actual switching of the cursor in the end of the game update.

This will enable us from getting rid of the scroll() function returning a CURSOR and keeping that state inside renderLoop.

BTW, I added the apply cursor after each set cursor call for simplicitys sake, to simplify the PR. We would probably be OK with doing the wzApplyCursor directly after the mainLoop call, only once?