### PR TITLE
fix duplicate projectile ids

### DIFF
--- a/src/basedef.h
+++ b/src/basedef.h
@@ -87,12 +87,12 @@ struct SIMPLE_OBJECT
 	virtual ~SIMPLE_OBJECT();
 
 	const OBJECT_TYPE type;                         ///< The type of object
-	UDWORD          id;                             ///< ID number of the object
+	uint32_t        id;                             ///< ID number of the object
 	Position        pos = Position(0, 0, 0);        ///< Position of the object
 	Rotation        rot;                            ///< Object's yaw +ve rotation around up-axis
-	UBYTE           player;                         ///< Which player the object belongs to
-	UDWORD          born;                           ///< Time the game object was born
-	UDWORD          died;                           ///< When an object was destroyed, if 0 still alive
+	uint8_t         player;                         ///< Which player the object belongs to
+	uint32_t        born;                           ///< Time the game object was born
+	uint32_t        died;                           ///< When an object was destroyed, if 0 still alive
 	uint32_t        time;                           ///< Game time of given space-time position.
 };
 

--- a/src/projectile.cpp
+++ b/src/projectile.cpp
@@ -81,6 +81,7 @@ struct INTERVAL
 #define PROJ_NEIGHBOUR_RANGE (TILE_UNITS*4)
 // used to create a specific ID for projectile objects to facilitate tracking them.
 static const UDWORD ProjectileTrackerID =	0xdead0000;
+static UDWORD ProjectileTrackerIDIncrement =	0;
 
 /* The list of projectiles in play */
 static std::vector<PROJECTILE *> psProjectileList;
@@ -413,7 +414,7 @@ bool proj_SendProjectileAngled(WEAPON *psWeap, SIMPLE_OBJECT *psAttacker, int pl
 	ASSERT_OR_RETURN(false, psStats != nullptr, "Invalid weapon stats");
 	ASSERT_OR_RETURN(false, psTarget == nullptr || !psTarget->died, "Aiming at dead target!");
 
-	PROJECTILE *psProj = new PROJECTILE(ProjectileTrackerID | (realTime >> 4), player);
+	PROJECTILE *psProj = new PROJECTILE(ProjectileTrackerID | (ProjectileTrackerIDIncrement++), player);
 
 	/* get muzzle offset */
 	if (psAttacker == nullptr)

--- a/src/projectile.cpp
+++ b/src/projectile.cpp
@@ -80,8 +80,8 @@ struct INTERVAL
 /* The range for neighbouring objects */
 #define PROJ_NEIGHBOUR_RANGE (TILE_UNITS*4)
 // used to create a specific ID for projectile objects to facilitate tracking them.
-static const UDWORD ProjectileTrackerID =	0xdead0000;
-static UDWORD ProjectileTrackerIDIncrement =	0;
+static const uint32_t ProjectileTrackerID = 0xdead0000;
+static uint32_t projectileTrackerIDIncrement = 0;
 
 /* The list of projectiles in play */
 static std::vector<PROJECTILE *> psProjectileList;
@@ -415,7 +415,7 @@ bool proj_SendProjectileAngled(WEAPON *psWeap, SIMPLE_OBJECT *psAttacker, int pl
 	ASSERT_OR_RETURN(false, psStats != nullptr, "Invalid weapon stats");
 	ASSERT_OR_RETURN(false, psTarget == nullptr || !psTarget->died, "Aiming at dead target!");
 
-	PROJECTILE *psProj = new PROJECTILE(ProjectileTrackerID | (ProjectileTrackerIDIncrement++), player);
+	PROJECTILE *psProj = new PROJECTILE(ProjectileTrackerID + ++projectileTrackerIDIncrement, player);
 
 	/* get muzzle offset */
 	if (psAttacker == nullptr)

--- a/src/projectile.cpp
+++ b/src/projectile.cpp
@@ -187,6 +187,7 @@ proj_InitSystem()
 	{
 		experienceGain[x] = 100;
 	}
+	ProjectileTrackerIDIncrement = 0;
 	return true;
 }
 

--- a/src/projectile.cpp
+++ b/src/projectile.cpp
@@ -187,7 +187,7 @@ proj_InitSystem()
 	{
 		experienceGain[x] = 100;
 	}
-	ProjectileTrackerIDIncrement = 0;
+	projectileTrackerIDIncrement = 0;
 	return true;
 }
 


### PR DESCRIPTION
Currently we use realTime >> 4 to generate unique IDs for projectiles, but this generates lots of duplicates:

![Screenshot from 2020-04-25 10-02-25](https://user-images.githubusercontent.com/668160/80274941-61ce6780-86de-11ea-8cca-d32b7a69995d.png)

Even removing the bitshift creates occasional duplicates. So, let's replace this mechanism with a  incrementing number that resets between games, instead.

Not as interesting perhaps, but at least we're still basing the ID off ProjectileTrackerID (which is `0xdead0000`) :grin: 