### PR TITLE
Disable cursor swap when key scrolling

### DIFF
--- a/po/warzone2100.pot
+++ b/po/warzone2100.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: warzone2100\n"
 "Report-Msgid-Bugs-To: warzone2100-project@lists.sourceforge.net\n"
-"POT-Creation-Date: 2020-04-05 12:49+0000\n"
+"POT-Creation-Date: 2020-04-26 07:30+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -14882,16 +14882,16 @@ msgstr ""
 msgid "Setting zoom to %.0f"
 msgstr ""
 
-#: src/display.cpp:1511
+#: src/display.cpp:1522
 msgid "Cannot Build. Oil Resource Burning."
 msgstr ""
 
-#: src/display.cpp:1527
+#: src/display.cpp:1538
 #, c-format
 msgid "%s - Hitpoints %d/%d - Experience %.1f, %s"
 msgstr ""
 
-#: src/display.cpp:1689
+#: src/display.cpp:1700
 #, c-format
 msgid "%s - Allied - Hitpoints %d/%d - Experience %d, %s"
 msgstr ""

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -938,26 +938,6 @@ CURSOR processMouseClickInput()
 		{
 			cursor = CURSOR_SELECT; // Special casing for LasSat or own unit
 		}
-		else
-		{
-			// when one of the arrow key gets pressed, set cursor appropriately
-			if (keyDown(KEY_UPARROW))
-			{
-				cursor = CURSOR_UARROW;
-			}
-			else if (keyDown(KEY_DOWNARROW))
-			{
-				cursor = CURSOR_DARROW;
-			}
-			else if (keyDown(KEY_LEFTARROW))
-			{
-				cursor = CURSOR_LARROW;
-			}
-			else if (keyDown(KEY_RIGHTARROW))
-			{
-				cursor = CURSOR_RARROW;
-			}
-		}
 	}
 
 	CurrentItemUnderMouse = item;
@@ -1026,27 +1006,25 @@ CURSOR scroll()
 
 	if (mouseScroll && wzMouseInWindow())
 	{
-		// Scroll left or right
-		scrollDirLeftRight += (mouseX() > (pie_GetVideoBufferWidth() - BOUNDARY_X)) - (mouseX() < BOUNDARY_X);
-
-		// Scroll down or up
-		scrollDirUpDown += (mouseY() < BOUNDARY_Y) - (mouseY() > (pie_GetVideoBufferHeight() - BOUNDARY_Y));
-		// when mouse cursor goes to an edge, set cursor appropriately
-		if (scrollDirUpDown > 0)
+		if (mouseY() < BOUNDARY_Y)
 		{
+			scrollDirUpDown++;
 			cursor = CURSOR_UARROW;
 		}
-		else if (scrollDirUpDown < 0)
+		else if (mouseY() > (pie_GetVideoBufferHeight() - BOUNDARY_Y))
 		{
+			scrollDirUpDown--;
 			cursor = CURSOR_DARROW;
 		}
-		else if (scrollDirLeftRight < 0)
+		else if (mouseX() < BOUNDARY_X)
 		{
 			cursor = CURSOR_LARROW;
+			scrollDirLeftRight--;
 		}
-		else if (scrollDirLeftRight > 0)
+		else if (mouseX() > (pie_GetVideoBufferWidth() - BOUNDARY_X))
 		{
 			cursor = CURSOR_RARROW;
+			scrollDirLeftRight++;
 		}
 	}
 	CLIP(scrollDirLeftRight, -1, 1);

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -1011,17 +1011,17 @@ CURSOR scroll()
 			scrollDirUpDown++;
 			cursor = CURSOR_UARROW;
 		}
-		else if (mouseY() > (pie_GetVideoBufferHeight() - BOUNDARY_Y))
+		if (mouseY() > (pie_GetVideoBufferHeight() - BOUNDARY_Y))
 		{
 			scrollDirUpDown--;
 			cursor = CURSOR_DARROW;
 		}
-		else if (mouseX() < BOUNDARY_X)
+		if (mouseX() < BOUNDARY_X)
 		{
 			cursor = CURSOR_LARROW;
 			scrollDirLeftRight--;
 		}
-		else if (mouseX() > (pie_GetVideoBufferWidth() - BOUNDARY_X))
+		if (mouseX() > (pie_GetVideoBufferWidth() - BOUNDARY_X))
 		{
 			cursor = CURSOR_RARROW;
 			scrollDirLeftRight++;


### PR DESCRIPTION
As [Zoid put it](http://forums.wz2100.net/viewtopic.php?f=1&t=12507&p=134633#p134633) in the forums:

> Any chance that we could remove the changing cursors when scrolling around the map with the arrow keys? It's visually distracting and doesn't provide any useful information to the player (I already know that I am pressing an arrow key).

The cursor was actually being set twice when key scrolling, but now it's been fixed in favor of clearer code.

(it does have a check for `if (mouseScroll &&...` but mouseScroll is always true and never set :joy:)