### PR TITLE
Password UI / widget improvements

### DIFF
--- a/lib/widget/button.cpp
+++ b/lib/widget/button.cpp
@@ -109,6 +109,12 @@ void W_BUTTON::setTip(std::string string)
 
 void W_BUTTON::clicked(W_CONTEXT *, WIDGET_KEY key)
 {
+	if ((minClickInterval > 0) && (realTime - lastClickTime < minClickInterval))
+	{
+		return;
+	}
+	lastClickTime = realTime;
+
 	dirty = true;
 
 	/* Can't click a button if it is disabled or locked down */

--- a/lib/widget/button.h
+++ b/lib/widget/button.h
@@ -89,7 +89,9 @@ public:
 	SWORD ClickedAudioID;				// Audio ID for form hilighted sound
 	WIDGET_AUDIOCALLBACK AudioCallback;	// Pointer to audio callback function
 	iV_fonts        FontID;
+	UDWORD minClickInterval = 0;
 private:
+	UDWORD lastClickTime = 0;
 	std::vector<W_BUTTON_ONCLICK_FUNC> onClickHandlers;
 };
 

--- a/lib/widget/editbox.cpp
+++ b/lib/widget/editbox.cpp
@@ -424,6 +424,7 @@ void W_EDITBOX::run(W_CONTEXT *psContext)
 				insPos = 0;
 				printStart = 0;
 				fitStringStart();
+				inputLoseFocus();	// clear the input buffer.
 			}
 			else
 			{

--- a/lib/widget/editbox.cpp
+++ b/lib/widget/editbox.cpp
@@ -507,6 +507,18 @@ void W_EDITBOX::setString(WzString string)
 	dirty = true;
 }
 
+void W_EDITBOX::simulateClick(W_CONTEXT *psContext, bool silenceClickAudio /*= false*/, WIDGET_KEY key /*= WKEY_PRIMARY*/)
+{
+	if (silenceClickAudio)
+	{
+		suppressAudioCallback = true;
+	}
+	clicked(psContext, key);
+	if (silenceClickAudio)
+	{
+		suppressAudioCallback = false;
+	}
+}
 
 /* Respond to a mouse click */
 void W_EDITBOX::clicked(W_CONTEXT *psContext, WIDGET_KEY)
@@ -524,7 +536,7 @@ void W_EDITBOX::clicked(W_CONTEXT *psContext, WIDGET_KEY)
 
 	if ((state & WEDBS_MASK) == WEDBS_FIXED)
 	{
-		if (AudioCallback)
+		if (AudioCallback && !suppressAudioCallback)
 		{
 			AudioCallback(ClickedAudioID);
 		}

--- a/lib/widget/editbox.h
+++ b/lib/widget/editbox.h
@@ -49,6 +49,7 @@ public:
 	W_EDITBOX(WIDGET *parent);
 
 	void clicked(W_CONTEXT *psContext, WIDGET_KEY key = WKEY_PRIMARY) override;
+	void simulateClick(W_CONTEXT *psContext, bool silenceClickAudio = false, WIDGET_KEY key = WKEY_PRIMARY);
 	void highlight(W_CONTEXT *psContext) override;
 	void highlightLost() override;
 	void focusLost() override;
@@ -89,6 +90,7 @@ private:
 
 	PIELIGHT boxColourFirst, boxColourSecond, boxColourBackground;
 	EditBoxDisplayCache displayCache;
+	bool suppressAudioCallback = false;
 };
 
 #endif // __INCLUDED_LIB_WIDGET_EDITBOX_H__

--- a/src/multiint.cpp
+++ b/src/multiint.cpp
@@ -963,6 +963,17 @@ void MultibuttonWidget::addButton(int value, Image image, Image imageDown, char 
 	geometryChanged();
 }
 
+void MultibuttonWidget::setButtonMinClickInterval(UDWORD interval)
+{
+	for (auto& button_pair : buttons)
+	{
+		if (button_pair.first)
+		{
+			button_pair.first->minClickInterval = interval;
+		}
+	}
+}
+
 void MultibuttonWidget::enable(bool enabled)
 {
 	if (!enabled == disabled)
@@ -1382,6 +1393,7 @@ static void addGameOptions()
 		randomButton->id = MULTIOP_RANDOM;
 		randomButton->setLabel(_("Random Game Options"));
 		randomButton->addButton(0, Image(FrontImages, IMAGE_RELOAD), Image(FrontImages, IMAGE_RELOAD), _("Random Game Options\nCan be blocked by players' votes"));
+		randomButton->setButtonMinClickInterval(GAME_TICKS_PER_SEC / 2);
 		optionsList->addWidgetToLayout(randomButton);
 	}
 

--- a/src/multiint.cpp
+++ b/src/multiint.cpp
@@ -3631,9 +3631,10 @@ TITLECODE WzMultiOptionTitleUI::run()
 		context.mx			= mouseX();
 		context.my			= mouseY();
 
-		if (widgGetFromID(psWScreen, MULTIOP_CHATEDIT))
+		W_EDITBOX* pChatEdit = dynamic_cast<W_EDITBOX*>(widgGetFromID(psWScreen, MULTIOP_CHATEDIT));
+		if (pChatEdit)
 		{
-			widgGetFromID(psWScreen, MULTIOP_CHATEDIT)->clicked(&context);
+			pChatEdit->simulateClick(&context, true);
 		}
 	}
 

--- a/src/multiint.h
+++ b/src/multiint.h
@@ -50,6 +50,7 @@ public:
 
 	void setLabel(char const *text);
 	void addButton(int value, Image image, Image imageHighlight, char const *tip);
+	void setButtonMinClickInterval(UDWORD interval);
 	void enable(bool enabled = true);
 	void disable()
 	{


### PR DESCRIPTION
- Improve password setting UI behavior
   - Ignore empty passwords
- `W_EDITBOX`: Add `simulateClick`
   - Use to avoid click audio when simulating a click (see `WzMultiOptionTitleUI::run()`)
- Support using ESC to clear entered text on every `W_EDITBOX`
   - Previously this only worked on certain screens / menus / fields. Now this works everywhere.