### PR TITLE
Change reticule buttons to no longer visually responsive while the game is paused

### DIFF
--- a/src/hci.cpp
+++ b/src/hci.cpp
@@ -83,8 +83,9 @@
 #include "frend.h"
 
 // Is a button widget highlighted, either because the cursor is over it or it is flashing.
+// Do not highlight buttons while paused.
 //
-#define buttonIsHilite(p)  ((p->getState() & WBUT_HIGHLIGHT) != 0)
+#define buttonIsHilite(p)  ((p->getState() & WBUT_HIGHLIGHT) != 0 && !gamePaused())
 
 // Empty edit window
 static bool SecondaryWindowUp = false;
@@ -496,7 +497,7 @@ static void intDisplayReticuleButton(WIDGET *psWidget, UDWORD xOffset, UDWORD yO
 	bool Down = psButton->state & (WBUT_DOWN | WBUT_CLICKLOCK);
 	bool Hilight = buttonIsHilite(psButton);
 
-	if (Down)
+	if (Down && !gamePaused())
 	{
 		if ((DownTime < 1) && (psWidget->UserData != RETBUT_CANCEL))
 		{
@@ -511,7 +512,7 @@ static void intDisplayReticuleButton(WIDGET *psWidget, UDWORD xOffset, UDWORD yO
 	}
 	else
 	{
-		if (flashing)
+		if (flashing && !gamePaused())
 		{
 			if (((realTime / 250) % 2) != 0)
 			{


### PR DESCRIPTION
This PR will limit the visual responiveness of the reticule buttons on the bottom left while the game is paused.

idea by @bjorn-ali-goransson in https://github.com/Warzone2100/warzone2100/issues/785 and https://github.com/Warzone2100/warzone2100/issues/780

Current changes:
- no highlight while hovering with the mouse
- no flashing buttons
- no click down effect

The buttons are not interactable in pause mode and the visual feedback should reflect that.

![out](https://user-images.githubusercontent.com/9959527/80871318-30403800-8cac-11ea-9319-aed3b3d6f8c8.gif)

Questions:
 - should the hover tooltip also be disabled?
 - should the audio cue when clicking on the button be disabled?

