### PR TITLE
Fix radar jump, then camera rotate bug

### DIFF
--- a/src/display.cpp
+++ b/src/display.cpp
@@ -732,7 +732,7 @@ CURSOR processMouseClickInput()
 	{
 		cancelDeliveryRepos();
 	}
-	if (mouseDrag(MOUSE_ROTATE, (UDWORD *)&rotX, (UDWORD *)&rotY) && !rotActive && !bRadarDragging)
+	if (mouseDrag(MOUSE_ROTATE, (UDWORD *)&rotX, (UDWORD *)&rotY) && !rotActive && !bRadarDragging && !getRadarTrackingStatus())
 	{
 		rotInitial = (player.r.y % 65536) / DEG(1.0f); // negative values caused problems with float conversion
 		rotInitialUp = player.r.x;
@@ -1195,6 +1195,8 @@ void displayWorld()
 		player.r.x = glm::clamp(player.r.x, DEG(360 + MIN_PLAYER_X_ANGLE), DEG(360 + MAX_PLAYER_X_ANGLE));
 
 		setDesiredPitch(player.r.x / DEG_1);
+
+		
 	}
 
 	if (!mouseDown(MOUSE_ROTATE) && rotActive)

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -1195,8 +1195,6 @@ void displayWorld()
 		player.r.x = glm::clamp(player.r.x, DEG(360 + MIN_PLAYER_X_ANGLE), DEG(360 + MAX_PLAYER_X_ANGLE));
 
 		setDesiredPitch(player.r.x / DEG_1);
-
-		
 	}
 
 	if (!mouseDown(MOUSE_ROTATE) && rotActive)


### PR DESCRIPTION
If you jump with the radar, then try to rotate with the camera, it will snap back to where it was before the rotation. This is because the radar jump officially ends a while after it **seems** to stop.

Demonstration:

https://youtu.be/5QG5KL3EGWY