### PR TITLE
Add ActivityManager, numerous core improvements to support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -153,7 +153,7 @@ if(CMAKE_SYSTEM_NAME MATCHES "Windows")
 		message( WARNING "WindowsStore builds are not currently supported" )
 		add_definitions(-D_WIN32_WINNT=0x0A00) # Windows 10+
 	else()
-		add_definitions(-D_WIN32_WINNT=0x0501) # Windows XP+
+		add_definitions(-D_WIN32_WINNT=0x0600) # Windows Vista+
 	endif()
 endif()
 

--- a/lib/framework/debug.cpp
+++ b/lib/framework/debug.cpp
@@ -105,6 +105,7 @@ static const char *code_part_names[] =
 	"input",
 	"popup",
 	"console",
+	"activity",
 	"last"
 };
 

--- a/lib/framework/debug.h
+++ b/lib/framework/debug.h
@@ -187,6 +187,7 @@ enum code_part
 	LOG_INPUT,	// mouse / keyboard events
 	LOG_POPUP,	// special, on by default, for both debug & release builds (used for OS dependent popup code)
 	LOG_CONSOLE,	// send console messages to file
+	LOG_ACTIVITY,
 	LOG_LAST /**< _must_ be last! */
 };
 

--- a/lib/ivis_opengl/png_util.cpp
+++ b/lib/ivis_opengl/png_util.cpp
@@ -34,9 +34,25 @@ IMGSaveError IMGSaveError::None = IMGSaveError();
 // PNG callbacks
 static void wzpng_read_data(png_structp ctx, png_bytep area, png_size_t size)
 {
-	PHYSFS_file *fileHandle = (PHYSFS_file *)png_get_io_ptr(ctx);
-
-	WZ_PHYSFS_readBytes(fileHandle, area, size);
+	if (ctx != nullptr)
+	{
+		PHYSFS_file *fileHandle = (PHYSFS_file *)png_get_io_ptr(ctx);
+		if (fileHandle != nullptr)
+		{
+			PHYSFS_sint64 result = WZ_PHYSFS_readBytes(fileHandle, area, size);
+			if (result > -1)
+			{
+				size_t byteCountRead = static_cast<size_t>(result);
+				if (byteCountRead == size)
+				{
+					return;
+				}
+				png_error(ctx, "Attempt to read beyond end of data");
+			}
+			png_error(ctx, "readBytes failure");
+		}
+		png_error(ctx, "Invalid memory read");
+	}
 }
 
 static void wzpng_write_data(png_structp png_ptr, png_bytep data, png_size_t length)

--- a/lib/ivis_opengl/png_util.cpp
+++ b/lib/ivis_opengl/png_util.cpp
@@ -25,6 +25,7 @@
 #include <png.h>
 #include <physfs.h>
 #include "lib/framework/physfs_ext.h"
+#include <algorithm>
 
 #define PNG_BYTES_TO_CHECK 8
 
@@ -188,6 +189,149 @@ bool iV_loadImage_PNG(const char *fileName, iV_Image *image)
 	ASSERT_OR_RETURN(false, image->depth > 3, "Unsupported image depth (%d) found.  We only support 3 (RGB) or 4 (ARGB)", image->depth);
 
 	return true;
+}
+
+struct MemoryBufferInputStream
+{
+public:
+	MemoryBufferInputStream(const std::vector<unsigned char> *pMemoryBuffer, size_t currentPos = 0)
+	: pMemoryBuffer(pMemoryBuffer)
+	, currentPos(currentPos)
+	{ }
+
+	size_t readBytes(png_bytep destBytes, size_t byteCountToRead)
+	{
+		const size_t remainingBytes = pMemoryBuffer->size() - currentPos;
+		size_t bytesToActuallyRead = std::min(byteCountToRead, remainingBytes);
+		if (bytesToActuallyRead > 0)
+		{
+			memcpy(destBytes, pMemoryBuffer->data() + currentPos, bytesToActuallyRead);
+		}
+		currentPos += bytesToActuallyRead;
+		return bytesToActuallyRead;
+	}
+
+private:
+	const std::vector<unsigned char> *pMemoryBuffer;
+	size_t currentPos = 0;
+};
+
+static void wzpng_read_data_from_buffer(png_structp png_ptr, png_bytep outBytes, png_size_t byteCountToRead)
+{
+	if (png_ptr != nullptr)
+	{
+		MemoryBufferInputStream *pMemoryStream = (MemoryBufferInputStream *)png_get_io_ptr(png_ptr);
+		if (pMemoryStream != nullptr)
+		{
+			size_t byteCountRead = pMemoryStream->readBytes(outBytes, byteCountToRead);
+			if (byteCountRead == byteCountToRead)
+			{
+				return;
+			}
+			png_error(png_ptr, "Attempt to read beyond end of data");
+		}
+		png_error(png_ptr, "Invalid memory read");
+	}
+}
+
+// Note: This function must be thread-safe.
+//       It does not call the debug() macro directly, but instead returns an IMGSaveError structure with the text of any error.
+IMGSaveError iV_loadImage_PNG(const std::vector<unsigned char>& memoryBuffer, iV_Image *image)
+{
+	unsigned char PNGheader[PNG_BYTES_TO_CHECK];
+	png_structp png_ptr = nullptr;
+	png_infop info_ptr = nullptr;
+
+	MemoryBufferInputStream inputStream = MemoryBufferInputStream(&memoryBuffer, 0);
+
+	size_t readSize = inputStream.readBytes(PNGheader, PNG_BYTES_TO_CHECK);
+	if (readSize < PNG_BYTES_TO_CHECK)
+	{
+		PNGReadCleanup(&info_ptr, &png_ptr, nullptr);
+		return IMGSaveError("iV_loadImage_PNG: Insufficient length for PNG header");
+	}
+
+	// Verify the PNG header to be correct
+	if (png_sig_cmp(PNGheader, 0, PNG_BYTES_TO_CHECK))
+	{
+		PNGReadCleanup(&info_ptr, &png_ptr, nullptr);
+		return IMGSaveError("iV_loadImage_PNG: Did not recognize PNG header");
+	}
+
+	png_ptr = png_create_read_struct(PNG_LIBPNG_VER_STRING, nullptr, nullptr, nullptr);
+	if (png_ptr == nullptr)
+	{
+		PNGReadCleanup(&info_ptr, &png_ptr, nullptr);
+		return IMGSaveError("iV_loadImage_PNG: Unable to create png struct");
+	}
+
+	info_ptr = png_create_info_struct(png_ptr);
+	if (info_ptr == nullptr)
+	{
+		PNGReadCleanup(&info_ptr, &png_ptr, nullptr);
+		return IMGSaveError("iV_loadImage_PNG: Unable to create png info struct");
+	}
+
+	// Set libpng's failure jump position to the if branch,
+	// setjmp evaluates to false so the else branch will be executed at first
+	if (setjmp(png_jmpbuf(png_ptr)))
+	{
+		PNGReadCleanup(&info_ptr, &png_ptr, nullptr);
+		return IMGSaveError("iV_loadImage_PNG: Error decoding PNG data");
+	}
+
+	// Tell libpng how many byte we already read
+	png_set_sig_bytes(png_ptr, PNG_BYTES_TO_CHECK);
+
+	/* Set up the input control */
+	png_set_read_fn(png_ptr, &inputStream, wzpng_read_data_from_buffer);
+
+	// Most of the following transformations are seemingly not needed
+	// Filler is, however, for an unknown reason required for tertilesc[23]
+
+	/* tell libpng to strip 16 bit/color files down to 8 bits/color */
+	png_set_strip_16(png_ptr);
+
+	/* Extract multiple pixels with bit depths of 1, 2, and 4 from a single
+	 * byte into separate bytes (useful for paletted and grayscale images).
+	 */
+// 	png_set_packing(png_ptr);
+
+	/* More transformations to ensure we end up with 32bpp, 4 channel RGBA */
+	png_set_gray_to_rgb(png_ptr);
+	png_set_palette_to_rgb(png_ptr);
+	png_set_tRNS_to_alpha(png_ptr);
+	png_set_filler(png_ptr, 0xff, PNG_FILLER_AFTER);
+//	png_set_gray_1_2_4_to_8(png_ptr);
+
+	png_read_png(png_ptr, info_ptr, PNG_TRANSFORM_IDENTITY, nullptr);
+
+	image->width = png_get_image_width(png_ptr, info_ptr);
+	image->height = png_get_image_height(png_ptr, info_ptr);
+	image->depth = png_get_channels(png_ptr, info_ptr);
+	image->bmp = (unsigned char *)malloc(image->height * png_get_rowbytes(png_ptr, info_ptr));
+
+	{
+		unsigned int i = 0;
+		png_bytepp row_pointers = png_get_rows(png_ptr, info_ptr);
+		for (i = 0; i < png_get_image_height(png_ptr, info_ptr); i++)
+		{
+			memcpy(image->bmp + (png_get_rowbytes(png_ptr, info_ptr) * i), row_pointers[i], png_get_rowbytes(png_ptr, info_ptr));
+		}
+	}
+
+	PNGReadCleanup(&info_ptr, &png_ptr, nullptr);
+
+	if (image->depth < 3 || image->depth > 4)
+	{
+		IMGSaveError error;
+		error.text = "Unsupported image depth (";
+		error.text += std::to_string(image->depth);
+		error.text += ") found.  We only support 3 (RGB) or 4 (ARGB)";
+		return error;
+	}
+
+	return IMGSaveError::None;
 }
 
 // Note: This function must be thread-safe.

--- a/lib/ivis_opengl/png_util.h
+++ b/lib/ivis_opengl/png_util.h
@@ -22,6 +22,7 @@
 #define _LIBIVIS_COMMON_PNG_H_
 
 #include "pietypes.h"
+#include <vector>
 
 struct IMGSaveError
 {
@@ -49,6 +50,15 @@ struct IMGSaveError
  * \return true on success, false otherwise
  */
 bool iV_loadImage_PNG(const char *fileName, iV_Image *image);
+
+/*!
+ * Load a PNG from a memory buffer into an image
+ *
+ * \param memoryBuffer input memory buffer to load from
+ * \param image Sprite to read into
+ * \return true on success, false otherwise
+ */
+IMGSaveError iV_loadImage_PNG(const std::vector<unsigned char>& memoryBuffer, iV_Image *image);
 
 /*!
  * Save a PNG from image into file

--- a/lib/netplay/netjoin_stub.cpp
+++ b/lib/netplay/netjoin_stub.cpp
@@ -25,10 +25,9 @@
 #include "lib/framework/frame.h"
 #include "netplay.h"
 
-int32_t NETgetGameFlagsUnjoined(unsigned int gameid, unsigned int flag)
+int32_t NETgetGameFlagsUnjoined(const GAMESTRUCT& game, unsigned int flag)
 {
-	ASSERT(gameid < ARRAY_SIZE(NetPlay.games), "Out of range gameid: %u", gameid);
-	ASSERT(flag < ARRAY_SIZE(NetPlay.games[gameid].desc.dwUserFlags), "Out of range flag number: %u", flag);
+	ASSERT_OR_RETURN(0, flag < ARRAY_SIZE(game.desc.dwUserFlags), "Out of range flag number: %u", flag);
 
-	return NetPlay.games[gameid].desc.dwUserFlags[flag];
+	return game.desc.dwUserFlags[flag];
 }

--- a/lib/netplay/netplay.cpp
+++ b/lib/netplay/netplay.cpp
@@ -614,6 +614,8 @@ static void NETplayerDropped(UDWORD index)
  */
 void NETplayerKicked(UDWORD index)
 {
+	ASSERT_OR_RETURN(, index < MAX_PLAYERS, "NETplayerKicked invalid player_id: (%" PRIu32")", index);
+
 	// kicking a player counts as "leaving nicely", since "nicely" in this case
 	// simply means "there wasn't a connection error."
 	debug(LOG_INFO, "Player %u was kicked.", index);

--- a/lib/netplay/netplay.cpp
+++ b/lib/netplay/netplay.cpp
@@ -70,6 +70,7 @@
 // WARNING !!! This is initialised via configuration.c !!!
 char masterserver_name[255] = {'\0'};
 static unsigned int masterserver_port = 0, gameserver_port = 0;
+static bool bJoinPrefTryIPv6First = true;
 
 #define NET_TIMEOUT_DELAY	2500		// we wait this amount of time for socket activity
 #define NET_READ_TIMEOUT	0
@@ -3212,6 +3213,23 @@ void NETsetGameserverPort(unsigned int port)
 unsigned int NETgetGameserverPort()
 {
 	return gameserver_port;
+}
+
+/*!
+* Set the join preference for IPv6
+* \param bTryIPv6First Whether to attempt IPv6 first when joining, before IPv4.
+*/
+void NETsetJoinPreferenceIPv6(bool bTryIPv6First)
+{
+	bJoinPrefTryIPv6First = bTryIPv6First;
+}
+
+/**
+* @return Whether joining a game that advertises both IPv6 and IPv4 should attempt IPv6 first.
+*/
+bool NETgetJoinPreferenceIPv6()
+{
+	return bJoinPrefTryIPv6First;
 }
 
 

--- a/lib/netplay/netplay.cpp
+++ b/lib/netplay/netplay.cpp
@@ -906,9 +906,8 @@ static bool NETrecvGAMESTRUCT(GAMESTRUCT *ourgamestruct)
 	}
 	if (failed)
 	{
-		SocketSet_DelSocket(socket_set, tcp_socket);  // mark it invalid
-		socketClose(tcp_socket);
-		tcp_socket = nullptr;
+		// caller handles invalidating and closing tcp_socket
+		return false;
 	}
 
 	// Now dump the data into the game struct

--- a/lib/netplay/netplay.cpp
+++ b/lib/netplay/netplay.cpp
@@ -200,6 +200,11 @@ int NETGetMinorVersion()
 	return NETCODE_VERSION_MINOR;
 }
 
+bool NETGameIsLocked()
+{
+	return NetPlay.GamePassworded;
+}
+
 //	Sets if the game is password protected or not
 void NETGameLocked(bool flag)
 {
@@ -239,6 +244,7 @@ void NETsetGamePassword(const char *password)
 {
 	sstrcpy(NetPlay.gamePassword, password);
 	debug(LOG_NET, "Password entered is: [%s]", NetPlay.gamePassword);
+	NETGameLocked(true);
 }
 
 //	Resets the game password

--- a/lib/netplay/netplay.cpp
+++ b/lib/netplay/netplay.cpp
@@ -1642,7 +1642,7 @@ static bool NETprocessSystemMessage(NETQUEUE playerQueue, uint8_t type)
 			for (n = 0; n < indexLen; ++n)
 			{
 				bool wasAllocated = false;
-				char oldName[sizeof(NetPlay.players[index].name)];
+				std::string oldName;
 
 				// Retrieve the player's ID
 				NETuint32_t(&index);
@@ -1660,8 +1660,8 @@ static bool NETprocessSystemMessage(NETQUEUE playerQueue, uint8_t type)
 				NETbool(&NetPlay.players[index].allocated);
 				NETbool(&NetPlay.players[index].heartbeat);
 				NETbool(&NetPlay.players[index].kick);
-				memset(oldName, 0, sizeof(oldName));
-				strncpy(oldName, NetPlay.players[index].name, sizeof(oldName) - 1);
+				oldName.clear();
+				oldName = NetPlay.players[index].name;
 				NETstring(NetPlay.players[index].name, sizeof(NetPlay.players[index].name));
 				NETuint32_t(&NetPlay.players[index].heartattacktime);
 				NETint32_t(&colour);
@@ -1687,9 +1687,9 @@ static bool NETprocessSystemMessage(NETQUEUE playerQueue, uint8_t type)
 				// update the color to the local array
 				setPlayerColour(index, NetPlay.players[index].colour);
 
-				if (wasAllocated && NetPlay.players[index].allocated && strncmp(oldName, NetPlay.players[index].name, sizeof(NetPlay.players[index].name)) != 0)
+				if (wasAllocated && NetPlay.players[index].allocated && strncmp(oldName.c_str(), NetPlay.players[index].name, sizeof(NetPlay.players[index].name)) != 0)
 				{
-					printConsoleNameChange(oldName, NetPlay.players[index].name);
+					printConsoleNameChange(oldName.c_str(), NetPlay.players[index].name);
 				}
 			}
 			NETend();

--- a/lib/netplay/netplay.h
+++ b/lib/netplay/netplay.h
@@ -30,6 +30,7 @@
 #include "nettypes.h"
 #include <physfs.h>
 #include <vector>
+#include <functional>
 // Lobby Connection errors
 
 enum LOBBY_ERROR_TYPES
@@ -251,7 +252,6 @@ struct PLAYER
 // all the luvly Netplay info....
 struct NETPLAY
 {
-	GAMESTRUCT	games[MaxGames];	///< The collection of games
 	PLAYER		players[MAX_PLAYERS];	///< The array of players.
 	uint32_t	playercount;		///< Number of players in game.
 	uint32_t	hostPlayer;		///< Index of host in player array
@@ -312,10 +312,12 @@ void NETplayerKicked(UDWORD index);			// Cleanup after player has been kicked
 
 // from netjoin.c
 SDWORD NETgetGameFlags(UDWORD flag);			// return one of the four flags(dword) about the game.
-int32_t NETgetGameFlagsUnjoined(unsigned int gameid, unsigned int flag);	// return one of the four flags(dword) about the game.
+int32_t NETgetGameFlagsUnjoined(const GAMESTRUCT& game, unsigned int flag);	// return one of the four flags(dword) about the game.
 bool NETsetGameFlags(UDWORD flag, SDWORD value);	// set game flag(1-4) to value.
 bool NEThaltJoining();				// stop new players joining this game
-bool NETfindGame();		// find games being played(uses GAME_GUID);
+bool NETenumerateGames(const std::function<bool (const GAMESTRUCT& game)>& handleEnumerateGameFunc);
+bool NETfindGames(std::vector<GAMESTRUCT>& results, size_t startingIndex, size_t resultsLimit, bool onlyMatchingLocalVersion = false);
+bool NETfindGame(uint32_t gameId, GAMESTRUCT& output);
 bool NETjoinGame(const char *host, uint32_t port, const char *playername); // join game given with playername
 bool NEThostGame(const char *SessionName, const char *PlayerName,// host a game
                  SDWORD one, SDWORD two, SDWORD three, SDWORD four, UDWORD plyrs);

--- a/lib/netplay/netplay.h
+++ b/lib/netplay/netplay.h
@@ -351,7 +351,8 @@ std::vector<uint8_t> NET_getHumanPlayers(void);
 
 void NETGameLocked(bool flag);
 void NETresetGamePassword();
-void NETregisterServer(int state);
+bool NETregisterServer(int state);
+bool NETprocessQueuedServerUpdates();
 void NETsetPlayerConnectionStatus(CONNECTION_STATUS status, unsigned player);    ///< Cumulative, except that CONNECTIONSTATUS_NORMAL resets.
 bool NETcheckPlayerConnectionStatus(CONNECTION_STATUS status, unsigned player);  ///< True iff connection status icon hasn't expired for this player. CONNECTIONSTATUS_NORMAL means any status, NET_ALL_PLAYERS means all players.
 

--- a/lib/netplay/netplay.h
+++ b/lib/netplay/netplay.h
@@ -349,6 +349,7 @@ uint8_t NET_numHumanPlayers(void);
 void NETsetLobbyOptField(const char *Value, const NET_LOBBY_OPT_FIELD Field);
 std::vector<uint8_t> NET_getHumanPlayers(void);
 
+bool NETGameIsLocked();
 void NETGameLocked(bool flag);
 void NETresetGamePassword();
 bool NETregisterServer(int state);

--- a/lib/netplay/netplay.h
+++ b/lib/netplay/netplay.h
@@ -332,6 +332,8 @@ void NETsetMasterserverPort(unsigned int port);
 unsigned int NETgetMasterserverPort();
 void NETsetGameserverPort(unsigned int port);
 unsigned int NETgetGameserverPort();
+void NETsetJoinPreferenceIPv6(bool bTryIPv6First);
+bool NETgetJoinPreferenceIPv6();
 
 bool NETsetupTCPIP(const char *machine);
 void NETsetGamePassword(const char *password);

--- a/lib/netplay/netplay.h
+++ b/lib/netplay/netplay.h
@@ -252,7 +252,7 @@ struct PLAYER
 // all the luvly Netplay info....
 struct NETPLAY
 {
-	PLAYER		players[MAX_PLAYERS];	///< The array of players.
+	std::vector<PLAYER>	players;	///< The array of players.
 	uint32_t	playercount;		///< Number of players in game.
 	uint32_t	hostPlayer;		///< Index of host in player array
 	uint32_t	bComms;			///< Actually do the comms?
@@ -268,6 +268,11 @@ struct NETPLAY
 	bool HaveUpgrade;					// game updates available
 	char MOTDbuffer[255];				// buffer for MOTD
 	char *MOTD;
+
+	NETPLAY()
+	{
+		players.resize(MAX_PLAYERS);
+	}
 };
 
 struct PLAYER_IP

--- a/lib/netplay/netsocket.cpp
+++ b/lib/netplay/netsocket.cpp
@@ -1454,9 +1454,79 @@ void socketArrayClose(Socket **sockets, size_t maxSockets)
 	std::fill(sockets, sockets + maxSockets, (Socket *)nullptr);      // Set the pointers to NULL.
 }
 
+WZ_DECL_NONNULL(1) bool socketHasIPv4(Socket *sock)
+{
+	return sock->fd[SOCK_IPV4_LISTEN] != INVALID_SOCKET;
+}
+
+WZ_DECL_NONNULL(1) bool socketHasIPv6(Socket *sock)
+{
+	return sock->fd[SOCK_IPV6_LISTEN] != INVALID_SOCKET;
+}
+
 char const *getSocketTextAddress(Socket const *sock)
 {
 	return sock->textAddress;
+}
+
+std::vector<unsigned char> ipv4_AddressString_To_NetBinary(const std::string& ipv4Address)
+{
+	std::vector<unsigned char> binaryForm(sizeof(struct in_addr), 0);
+	if (inet_pton(AF_INET, ipv4Address.c_str(), binaryForm.data()) <= 0)
+	{
+		// inet_pton failed
+		binaryForm.clear();
+	}
+	return binaryForm;
+}
+
+#ifndef INET_ADDRSTRLEN
+# define INET_ADDRSTRLEN 16
+#endif
+
+std::string ipv4_NetBinary_To_AddressString(const std::vector<unsigned char>& ip4NetBinaryForm)
+{
+	if (ip4NetBinaryForm.size() != sizeof(struct in_addr))
+	{
+		return "";
+	}
+	std::string ipv4Address;
+	ipv4Address.resize(INET_ADDRSTRLEN);
+	if (inet_ntop(AF_INET, ip4NetBinaryForm.data(), &ipv4Address[0], ipv4Address.size()) == nullptr)
+	{
+		return "";
+	}
+	return ipv4Address;
+}
+
+std::vector<unsigned char> ipv6_AddressString_To_NetBinary(const std::string& ipv6Address)
+{
+	std::vector<unsigned char> binaryForm(sizeof(struct in6_addr), 0);
+	if (inet_pton(AF_INET6, ipv6Address.c_str(), binaryForm.data()) <= 0)
+	{
+		// inet_pton failed
+		binaryForm.clear();
+	}
+	return binaryForm;
+}
+
+#ifndef INET6_ADDRSTRLEN
+# define INET6_ADDRSTRLEN 46
+#endif
+
+std::string ipv6_NetBinary_To_AddressString(const std::vector<unsigned char>& ip6NetBinaryForm)
+{
+	if (ip6NetBinaryForm.size() != sizeof(struct in_addr))
+	{
+		return "";
+	}
+	std::string ipv6Address;
+	ipv6Address.resize(INET6_ADDRSTRLEN);
+	if (inet_ntop(AF_INET6, ip6NetBinaryForm.data(), &ipv6Address[0], ipv6Address.size()) == nullptr)
+	{
+		return "";
+	}
+	return ipv6Address;
 }
 
 SocketAddress *resolveHost(const char *host, unsigned int port)

--- a/lib/netplay/netsocket.h
+++ b/lib/netplay/netsocket.h
@@ -22,6 +22,8 @@
 #define _net_socket_h
 
 #include "lib/framework/types.h"
+#include <string>
+#include <vector>
 
 #if   defined(WZ_OS_UNIX)
 # include <arpa/inet.h>
@@ -100,8 +102,14 @@ WZ_DECL_NONNULL(1) void socketClose(Socket *sock);                      ///< Des
 Socket *socketOpenAny(const SocketAddress *addr, unsigned timeout);     ///< Opens a Socket, using the first address that works in addr.
 size_t socketArrayOpen(Socket **sockets, size_t maxSockets, const SocketAddress *addr, unsigned timeout);  ///< Opens up to maxSockets Sockets, of the types listed in addr.
 void socketArrayClose(Socket **sockets, size_t maxSockets);             ///< Closes all Sockets in the array.
+WZ_DECL_NONNULL(1) bool socketHasIPv4(Socket *sock);
+WZ_DECL_NONNULL(1) bool socketHasIPv6(Socket *sock);
 
 WZ_DECL_NONNULL(1) char const *getSocketTextAddress(Socket const *sock); ///< Gets a string with the socket address.
+std::vector<unsigned char> ipv4_AddressString_To_NetBinary(const std::string& ipv4Address);
+std::vector<unsigned char> ipv6_AddressString_To_NetBinary(const std::string& ipv6Address);
+std::string ipv4_NetBinary_To_AddressString(const std::vector<unsigned char>& ip4NetBinaryForm);
+std::string ipv6_NetBinary_To_AddressString(const std::vector<unsigned char>& ip6NetBinaryForm);
 WZ_DECL_NONNULL(1) bool socketReadReady(Socket const *sock);            ///< Returns if checkSockets found data to read from this Socket.
 WZ_DECL_NONNULL(1, 2)
 ssize_t readNoInt(Socket *sock, void *buf, size_t max_size, size_t *rawByteCount = nullptr);  ///< Reads up to max_size bytes from the Socket. Raw count of bytes (after compression) returned in rawByteCount.

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -45,6 +45,7 @@ noinst_HEADERS = \
 	3rdparty/propertymatcher.h \
 	action.h \
 	actiondef.h \
+	activity.h \
 	advvis.h \
 	ai.h \
 	astar.h \
@@ -171,6 +172,7 @@ nodist_COMMONSOURCES = \
 COMMONSOURCES = \
 	3rdparty/propertymatcher.cpp \
 	action.cpp \
+	activity.cpp \
 	advvis.cpp \
 	ai.cpp \
 	astar.cpp \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -118,6 +118,7 @@ noinst_HEADERS = \
 	multiplay.h \
 	multirecv.h \
 	multistat.h \
+	nethelpers.h \
 	notifications.h \
 	objectdef.h \
 	objects.h \
@@ -236,6 +237,7 @@ COMMONSOURCES = \
 	multistat.cpp \
 	multistruct.cpp \
 	multisync.cpp \
+	nethelpers.cpp \
 	notifications.cpp \
 	objects.cpp \
 	objmem.cpp \

--- a/src/activity.cpp
+++ b/src/activity.cpp
@@ -1,0 +1,548 @@
+/*
+	This file is part of Warzone 2100.
+	Copyright (C) 2020  Warzone 2100 Project
+
+	Warzone 2100 is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+
+	Warzone 2100 is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with Warzone 2100; if not, write to the Free Software
+	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+
+#include "lib/framework/frame.h"
+#include "lib/framework/vector.h"
+#include "ai.h"
+#include "activity.h"
+#include "multiint.h"
+#include "mission.h"
+#include "challenge.h"
+#include <algorithm>
+
+std::string ActivitySink::getTeamDescription(const ActivitySink::SkirmishGameInfo& info)
+{
+	if (!alliancesSetTeamsBeforeGame(info.game.alliance))
+	{
+		return "";
+	}
+	std::map<int32_t, size_t> teamIdToCountOfPlayers;
+	for (size_t index = 0; index < std::min<size_t>(info.players.size(), (size_t)game.maxPlayers); ++index)
+	{
+		PLAYER const &p = NetPlay.players[index];
+		if (p.ai == AI_CLOSED)
+		{
+			// closed slot - skip
+			continue;
+		}
+		else if (p.ai == AI_OPEN)
+		{
+			if (!p.allocated)
+			{
+				// available slot - count team association
+				// (since available slots can have assigned teams)
+				teamIdToCountOfPlayers[p.team]++;
+			}
+			else
+			{
+				// human player
+				teamIdToCountOfPlayers[p.team]++;
+			}
+		}
+		else
+		{
+			// bot player
+			teamIdToCountOfPlayers[p.team]++;
+		}
+	}
+	if (teamIdToCountOfPlayers.size() <= 1)
+	{
+		// does not have multiple teams
+		return "";
+	}
+	std::string teamDescription;
+	for (const auto& team : teamIdToCountOfPlayers)
+	{
+		if (!teamDescription.empty())
+		{
+			teamDescription += "v";
+		}
+		teamDescription += std::to_string(team.second);
+	}
+	return teamDescription;
+}
+
+std::string to_string(const ActivitySink::GameEndReason& reason)
+{
+	switch (reason)
+	{
+		case ActivitySink::GameEndReason::WON:
+			return "Won";
+		case ActivitySink::GameEndReason::LOST:
+			return "Lost";
+		case ActivitySink::GameEndReason::QUIT:
+			return "Quit";
+	}
+	return ""; // silence warning
+}
+
+std::string to_string(const END_GAME_STATS_DATA& stats)
+{
+	return astringf("numUnits: %u, missionStartedTime: %u, unitsBuilt: %u, unitsLost: %u, unitsKilled: %u", stats.numUnits, stats.missionData.missionStarted, stats.missionData.unitsBuilt, stats.missionData.unitsLost, stats.missionData.unitsKilled);
+}
+
+class LoggingActivitySink : public ActivitySink {
+public:
+	// campaign games
+	virtual void startedCampaignMission(const std::string& campaign, const std::string& levelName) override
+	{
+		debug(LOG_ACTIVITY, "- startedCampaignMission: %s:%s", campaign.c_str(), levelName.c_str());
+	}
+	virtual void endedCampaignMission(const std::string& campaign, const std::string& levelName, GameEndReason result, END_GAME_STATS_DATA stats, bool cheatsUsed) override
+	{
+		debug(LOG_ACTIVITY, "- endedCampaignMission: %s:%s; result: %s; stats: (%s)", campaign.c_str(), levelName.c_str(), to_string(result).c_str(), to_string(stats).c_str());
+	}
+
+	// challenges
+	virtual void startedChallenge(const std::string& challengeName) override
+	{
+		debug(LOG_ACTIVITY, "- startedChallenge: %s", challengeName.c_str());
+	}
+
+	virtual void endedChallenge(const std::string& challengeName, GameEndReason result, const END_GAME_STATS_DATA& stats, bool cheatsUsed) override
+	{
+		debug(LOG_ACTIVITY, "- endedChallenge: %s; result: %s; stats: (%s)", challengeName.c_str(), to_string(result).c_str(), to_string(stats).c_str());
+	}
+
+	virtual void startedSkirmishGame(const SkirmishGameInfo& info) override
+	{
+		debug(LOG_ACTIVITY, "- startedSkirmishGame: %s", info.game.name);
+	}
+
+	virtual void endedSkirmishGame(const SkirmishGameInfo& info, GameEndReason result, const END_GAME_STATS_DATA& stats) override
+	{
+		debug(LOG_ACTIVITY, "- endedSkirmishGame: %s; result: %s; stats: (%s)", info.game.name, to_string(result).c_str(), to_string(stats).c_str());
+	}
+
+	// multiplayer
+	virtual void hostingMultiplayerGame(const MultiplayerGameInfo& info) override
+	{
+		debug(LOG_ACTIVITY, "- hostingMultiplayerGame: %s; isLobbyGame: %s", info.game.name, (info.lobbyGameId != 0) ? "true" : "false");
+	}
+	virtual void joinedMultiplayerGame(const MultiplayerGameInfo& info) override
+	{
+		debug(LOG_ACTIVITY, "- joinedMultiplayerGame: %s", info.game.name);
+	}
+	virtual void updateMultiplayerGameInfo(const MultiplayerGameInfo& info) override
+	{
+		debug(LOG_ACTIVITY, "- updateMultiplayerGameInfo: (name: %s), (map: %s), maxPlayers: %u, numAvailableSlots: %zu, numHumanPlayers: %u, numAIBotPlayers: %u", info.game.name, info.game.map, info.maxPlayers, (size_t)info.numAvailableSlots, info.numHumanPlayers, info.numAIBotPlayers);
+	}
+	virtual void startedMultiplayerGame(const MultiplayerGameInfo& info) override
+	{
+		debug(LOG_ACTIVITY, "- startedMultiplayerGame: %s", info.game.name);
+	}
+	virtual void endedMultiplayerGame(const MultiplayerGameInfo& info, GameEndReason result, const END_GAME_STATS_DATA& stats) override
+	{
+		debug(LOG_ACTIVITY, "- endedMultiplayerGame: %s; result: %s; stats: (%s)", info.game.name, to_string(result).c_str(), to_string(stats).c_str());
+	}
+
+	// changing settings
+	virtual void changedSetting(const std::string& settingKey, const std::string& settingValue) override
+	{
+		debug(LOG_ACTIVITY, "- changedSetting: %s = %s", settingKey.c_str(), settingValue.c_str());
+	}
+
+	// cheats used
+	virtual void cheatUsed(const std::string& cheatName) override
+	{
+		debug(LOG_ACTIVITY, "- cheatUsed: %s", cheatName.c_str());
+	}
+};
+
+ActivityManager& ActivityManager::instance()
+{
+	static ActivityManager sharedInstance = ActivityManager();
+	return sharedInstance;
+}
+
+bool ActivityManager::initialize()
+{
+	addActivitySink(std::make_shared<LoggingActivitySink>());
+	return true;
+}
+
+void ActivityManager::shutdown()
+{
+	// Free up the activity sinks
+	activitySinks.clear();
+}
+
+void ActivityManager::addActivitySink(std::shared_ptr<ActivitySink> sink)
+{
+	activitySinks.push_back(sink);
+}
+
+void ActivityManager::removeActivitySink(const std::shared_ptr<ActivitySink>& sink)
+{
+	activitySinks.erase(std::remove(activitySinks.begin(), activitySinks.end(), sink));
+}
+
+ActivitySink::GameMode ActivityManager::getCurrentGameMode() const
+{
+	return currentMode;
+}
+
+ActivitySink::GameMode currentGameTypeToMode()
+{
+	ActivitySink::GameMode mode = ActivitySink::GameMode::CAMPAIGN;
+	if (challengeActive)
+	{
+		mode = ActivitySink::GameMode::CHALLENGE;
+	}
+	else if (game.type == SKIRMISH)
+	{
+		mode = (NetPlay.bComms) ? ActivitySink::GameMode::MULTIPLAYER : ActivitySink::GameMode::SKIRMISH;
+	}
+	else if (game.type == CAMPAIGN)
+	{
+		mode = ActivitySink::GameMode::CAMPAIGN;
+	}
+	return mode;
+}
+
+void ActivityManager::startingGame()
+{
+	ActivitySink::GameMode mode = currentGameTypeToMode();
+	bEndedCurrentMission = false;
+
+	currentMode = mode;
+}
+
+void ActivityManager::startingSavedGame()
+{
+	ActivitySink::GameMode mode = currentGameTypeToMode();
+	bEndedCurrentMission = false;
+
+	if (mode == ActivitySink::GameMode::SKIRMISH)
+	{
+		// synthesize an "update multiplay game data" call on skirmish save game load
+		ActivityManager::instance().updateMultiplayGameData(game, ingame, false);
+	}
+
+	currentMode = mode;
+
+	if (cachedLoadedLevelEvent)
+	{
+		// process a (delayed) loaded level event
+		loadedLevel(cachedLoadedLevelEvent->type, cachedLoadedLevelEvent->levelName);
+		delete cachedLoadedLevelEvent;
+		cachedLoadedLevelEvent = nullptr;
+	}
+}
+
+void ActivityManager::loadedLevel(LEVEL_TYPE type, const std::string& levelName)
+{
+	bEndedCurrentMission = false;
+
+	if (currentMode == ActivitySink::GameMode::MENUS)
+	{
+		// hit a case where startedGameMode is called *after* loadedLevel, so cache the loadedLevel call
+		// (for example, on save game load, the game mode isn't set until the save is loaded)
+		ASSERT(cachedLoadedLevelEvent == nullptr, "Missed a cached loaded level event?");
+		if (cachedLoadedLevelEvent) delete cachedLoadedLevelEvent;
+		cachedLoadedLevelEvent = new LoadedLevelEvent{type, levelName};
+		return;
+	}
+
+	lastLoadedLevelEvent.type = type;
+	lastLoadedLevelEvent.levelName = levelName;
+
+	switch (currentMode)
+	{
+		case ActivitySink::GameMode::CAMPAIGN:
+			for (auto sink : activitySinks) { sink->startedCampaignMission(getCampaignName(), levelName); }
+			break;
+		case ActivitySink::GameMode::CHALLENGE:
+			for (auto sink : activitySinks) { sink->startedChallenge(currentChallengeName()); }
+			break;
+		case ActivitySink::GameMode::SKIRMISH:
+			for (auto sink : activitySinks) { sink->startedSkirmishGame(currentMultiplayGameInfo); }
+			break;
+		case ActivitySink::GameMode::MULTIPLAYER:
+			for (auto sink : activitySinks) { sink->startedMultiplayerGame(currentMultiplayGameInfo); }
+			break;
+		default:
+			debug(LOG_ACTIVITY, "loadedLevel: %s; Unhandled case: %u", levelName.c_str(), (unsigned int)currentMode);
+	}
+}
+
+void ActivityManager::_endedMission(ActivitySink::GameEndReason result, END_GAME_STATS_DATA stats, bool cheatsUsed)
+{
+	if (bEndedCurrentMission) return;
+
+	lastLobbyGameJoinAttempt.clear();
+
+	switch (currentMode)
+	{
+		case ActivitySink::GameMode::CAMPAIGN:
+			for (auto sink : activitySinks) { sink->endedCampaignMission(getCampaignName(), lastLoadedLevelEvent.levelName, result, stats, cheatsUsed); }
+			break;
+		case ActivitySink::GameMode::CHALLENGE:
+			for (auto sink : activitySinks) { sink->endedChallenge(currentChallengeName(), result, stats, cheatsUsed); }
+			break;
+		case ActivitySink::GameMode::SKIRMISH:
+			for (auto sink : activitySinks) { sink->endedSkirmishGame(currentMultiplayGameInfo, result, stats); }
+			break;
+		case ActivitySink::GameMode::MULTIPLAYER:
+			for (auto sink : activitySinks) { sink->endedMultiplayerGame(currentMultiplayGameInfo, result, stats); }
+			break;
+		default:
+			debug(LOG_ACTIVITY, "endedMission: Unhandled case: %u", (unsigned int)currentMode);
+	}
+	bEndedCurrentMission = true;
+}
+
+void ActivityManager::completedMission(bool result, END_GAME_STATS_DATA stats, bool cheatsUsed)
+{
+	_endedMission(result ? ActivitySink::GameEndReason::WON : ActivitySink::GameEndReason::LOST, stats, cheatsUsed);
+}
+
+void ActivityManager::quitGame(END_GAME_STATS_DATA stats, bool cheatsUsed)
+{
+	if (currentMode != ActivitySink::GameMode::MENUS)
+	{
+		_endedMission(ActivitySink::GameEndReason::QUIT, stats, cheatsUsed);
+	}
+
+	currentMode = ActivitySink::GameMode::MENUS;
+}
+
+void ActivityManager::preSystemShutdown()
+{
+	// Synthesize appropriate events, as needed
+	// For example, may need to synthesize a "quitGame" event if the user quit directly from window menus, etc
+	if (currentMode != ActivitySink::GameMode::MENUS)
+	{
+		// quitGame was never generated - synthesize it
+		ActivityManager::instance().quitGame(collectEndGameStatsData(), Cheated);
+	}
+}
+
+void ActivityManager::beginLoadingSettings()
+{
+	bIsLoadingConfiguration = true;
+}
+
+void ActivityManager::changedSetting(const std::string& settingKey, const std::string& settingValue)
+{
+	if (bIsLoadingConfiguration) return;
+
+	for (auto sink : activitySinks) { sink->changedSetting(settingKey, settingValue); }
+}
+
+void ActivityManager::endLoadingSettings()
+{
+	bIsLoadingConfiguration = false;
+}
+
+// cheats used
+void ActivityManager::cheatUsed(const std::string& cheatName)
+{
+	for (auto sink : activitySinks) { sink->cheatUsed(cheatName); }
+}
+
+// called when a joinable multiplayer game is hosted
+// lobbyGameId is 0 if the lobby can't be contacted / the game is not registered with the lobby
+void ActivityManager::hostGame(const char *SessionName, const char *PlayerName, const char *lobbyAddress, unsigned int lobbyPort, const ActivitySink::ListeningInterfaces& listeningInterfaces, uint32_t lobbyGameId /*= 0*/)
+{
+	currentMode = ActivitySink::GameMode::HOSTING_IN_LOBBY;
+
+	// updateMultiplayGameData should have already been called with the main details before this function is called
+
+	currentMultiplayGameInfo.hostName = PlayerName;
+	currentMultiplayGameInfo.listeningInterfaces = listeningInterfaces;
+	currentMultiplayGameInfo.lobbyAddress = (lobbyAddress != nullptr) ? lobbyAddress : std::string();
+	currentMultiplayGameInfo.lobbyPort = lobbyPort;
+	currentMultiplayGameInfo.lobbyGameId = lobbyGameId;
+	currentMultiplayGameInfo.isHost = true;
+
+	for (auto sink : activitySinks) { sink->hostingMultiplayerGame(currentMultiplayGameInfo); }
+}
+
+void ActivityManager::hostLobbyQuit()
+{
+	if (currentMode != ActivitySink::GameMode::HOSTING_IN_LOBBY)
+	{
+		debug(LOG_ACTIVITY, "Unexpected call to hostLobbyQuit - currentMode (%u) - ignoring", (unsigned int)currentMode);
+		return;
+	}
+	currentMode = ActivitySink::GameMode::MENUS;
+
+	// Notify the ActivitySink that we've left the game lobby
+	for (auto sink : activitySinks) { sink->leftMultiplayerGameLobby(true, getLobbyError()); }
+}
+
+// called when attempting to join a lobby game
+void ActivityManager::willAttemptToJoinLobbyGame(const std::string& lobbyAddress, unsigned int lobbyPort, uint32_t lobbyGameId, const std::vector<JoinConnectionDescription>& connections)
+{
+	lastLobbyGameJoinAttempt.lobbyAddress = lobbyAddress;
+	lastLobbyGameJoinAttempt.lobbyPort = lobbyPort;
+	lastLobbyGameJoinAttempt.lobbyGameId = lobbyGameId;
+	lastLobbyGameJoinAttempt.connections = connections;
+}
+
+// called when an attempt to join fails
+void ActivityManager::joinGameFailed(const std::vector<JoinConnectionDescription>& connection_list)
+{
+	lastLobbyGameJoinAttempt.clear();
+}
+
+// called when joining a multiplayer game
+void ActivityManager::joinGameSucceeded(const char *host, uint32_t port)
+{
+	currentMode = ActivitySink::GameMode::JOINING_IN_PROGRESS;
+	currentMultiplayGameInfo.isHost = false;
+
+	// If the host and port match information in the lastLobbyGameJoinAttempt.connections,
+	// store the lastLobbyGameJoinAttempt lookup info in currentMultiplayGameInfo
+	bool joinedLobbyGame = false;
+	for (const auto& connection : lastLobbyGameJoinAttempt.connections)
+	{
+		if ((connection.host == host) && (connection.port == port))
+		{
+			joinedLobbyGame = true;
+			break;
+		}
+	}
+	if (joinedLobbyGame)
+	{
+		currentMultiplayGameInfo.lobbyAddress = lastLobbyGameJoinAttempt.lobbyAddress;
+		currentMultiplayGameInfo.lobbyPort = lastLobbyGameJoinAttempt.lobbyPort;
+		currentMultiplayGameInfo.lobbyGameId = lastLobbyGameJoinAttempt.lobbyGameId;
+	}
+	lastLobbyGameJoinAttempt.clear();
+
+	// NOTE: This is called once the join is accepted, but before all game information has been received from the host
+	// Therefore, delay ActivitySink::joinedMultiplayerGame until after we receive the initial game data
+}
+
+void ActivityManager::joinedLobbyQuit()
+{
+	if (currentMode != ActivitySink::GameMode::JOINING_IN_LOBBY)
+	{
+		debug(LOG_ACTIVITY, "Unexpected call to joinedLobbyQuit - currentMode (%u) - ignoring", (unsigned int)currentMode);
+		return;
+	}
+	currentMode = ActivitySink::GameMode::MENUS;
+
+	// Notify the ActivitySink that we've left the game lobby
+	for (auto sink : activitySinks) { sink->leftMultiplayerGameLobby(false, getLobbyError()); }
+}
+
+// for skirmish / multiplayer, provide additional data / state
+void ActivityManager::updateMultiplayGameData(const MULTIPLAYERGAME& game, const MULTIPLAYERINGAME& ingame, optional<bool> privateGame)
+{
+	uint8_t maxPlayers = game.maxPlayers;
+	uint8_t numAIBotPlayers = 0;
+	uint8_t numHumanPlayers = 0;
+	uint8_t numAvailableSlots = 0;
+
+	for (size_t index = 0; index < std::min<size_t>(MAX_PLAYERS, (size_t)game.maxPlayers); ++index)
+	{
+		PLAYER const &p = NetPlay.players[index];
+		if (p.ai == AI_CLOSED)
+		{
+			--maxPlayers;
+		}
+		else if (p.ai == AI_OPEN)
+		{
+			if (!p.allocated)
+			{
+				++numAvailableSlots;
+			}
+			else
+			{
+				++numHumanPlayers;
+			}
+		}
+		else
+		{
+			++numAIBotPlayers;
+		}
+	}
+
+	ActivitySink::MultiplayerGameInfo::AllianceOption alliances = ActivitySink::MultiplayerGameInfo::AllianceOption::NO_ALLIANCES;
+	if (game.alliance == ::AllianceType::ALLIANCES)
+	{
+		alliances = ActivitySink::MultiplayerGameInfo::AllianceOption::ALLIANCES;
+	}
+	else if (game.alliance == ::AllianceType::ALLIANCES_TEAMS)
+	{
+		alliances = ActivitySink::MultiplayerGameInfo::AllianceOption::ALLIANCES_TEAMS;
+	}
+	else if (game.alliance == ::AllianceType::ALLIANCES_UNSHARED)
+	{
+		alliances = ActivitySink::MultiplayerGameInfo::AllianceOption::ALLIANCES_UNSHARED;
+	}
+	currentMultiplayGameInfo.alliances = alliances;
+
+	currentMultiplayGameInfo.maxPlayers = maxPlayers; // accounts for closed slots
+	currentMultiplayGameInfo.numHumanPlayers = numHumanPlayers;
+	currentMultiplayGameInfo.numAvailableSlots = numAvailableSlots;
+	// NOTE: privateGame will currently only be up-to-date for the host
+	// for a joined client, it will reflect the passworded state at the time of join
+	if (privateGame.has_value())
+	{
+		currentMultiplayGameInfo.privateGame = privateGame.value();
+	}
+
+	currentMultiplayGameInfo.game = game;
+	currentMultiplayGameInfo.numAIBotPlayers = numAIBotPlayers;
+	currentMultiplayGameInfo.currentPlayerIdx = selectedPlayer;
+	currentMultiplayGameInfo.players = NetPlay.players;
+	currentMultiplayGameInfo.players.resize(game.maxPlayers);
+
+	currentMultiplayGameInfo.limit_no_tanks = (ingame.flags & MPFLAGS_NO_TANKS) != 0;
+	currentMultiplayGameInfo.limit_no_cyborgs = (ingame.flags & MPFLAGS_NO_CYBORGS) != 0;
+	currentMultiplayGameInfo.limit_no_vtols = (ingame.flags & MPFLAGS_NO_VTOLS) != 0;
+	currentMultiplayGameInfo.limit_no_uplink = (ingame.flags & MPFLAGS_NO_UPLINK) != 0;
+	currentMultiplayGameInfo.limit_no_lassat = (ingame.flags & MPFLAGS_NO_LASSAT) != 0;
+	currentMultiplayGameInfo.force_structure_limits = (ingame.flags & MPFLAGS_FORCELIMITS) != 0;
+
+	currentMultiplayGameInfo.structureLimits = ingame.structureLimits;
+
+	if (currentMode == ActivitySink::GameMode::JOINING_IN_PROGRESS || currentMode == ActivitySink::GameMode::JOINING_IN_LOBBY)
+	{
+		currentMultiplayGameInfo.hostName = currentMultiplayGameInfo.players[0].name; // host is always player index 0?
+	}
+
+	if (currentMode == ActivitySink::GameMode::HOSTING_IN_LOBBY || currentMode == ActivitySink::GameMode::JOINING_IN_LOBBY)
+	{
+		for (auto sink : activitySinks) { sink->updateMultiplayerGameInfo(currentMultiplayGameInfo); }
+	}
+	else if (currentMode == ActivitySink::GameMode::JOINING_IN_PROGRESS)
+	{
+		// Have now received the initial game data, so trigger ActivitySink::joinedMultiplayerGame
+		currentMode = ActivitySink::GameMode::JOINING_IN_LOBBY;
+		for (auto sink : activitySinks) { sink->joinedMultiplayerGame(currentMultiplayGameInfo); }
+	}
+}
+
+// called on the host when the host kicks a player
+void ActivityManager::hostKickPlayer(const PLAYER& player, LOBBY_ERROR_TYPES kick_type, const std::string& reason)
+{
+	/* currently, no-op */
+}
+
+// called on the kicked player when they are kicked by another player
+void ActivityManager::wasKickedByPlayer(const PLAYER& kicker, LOBBY_ERROR_TYPES kick_type, const std::string& reason)
+{
+	/* currently, no-op */
+}
+

--- a/src/activity.h
+++ b/src/activity.h
@@ -1,0 +1,230 @@
+/*
+	This file is part of Warzone 2100.
+	Copyright (C) 2020  Warzone 2100 Project
+
+	Warzone 2100 is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+
+	Warzone 2100 is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with Warzone 2100; if not, write to the Free Software
+	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+
+#ifndef __INCLUDED_SRC_ACTIVITY_H__
+#define __INCLUDED_SRC_ACTIVITY_H__
+
+#include "scores.h"
+#include "multiplay.h"
+#include "levels.h"
+#include "lib/netplay/netplay.h"
+#include <vector>
+#include <string>
+
+#include <optional-lite/optional.hpp>
+using nonstd::optional;
+using nonstd::nullopt;
+
+// Subclass ActivitySink to implement a custom handler for higher-level game-state event callbacks.
+class ActivitySink
+{
+public:
+	enum class GameMode {
+		MENUS,
+		TUTORIAL,
+		CAMPAIGN,
+		CHALLENGE,
+		SKIRMISH,
+		HOSTING_IN_LOBBY,
+		JOINING_IN_PROGRESS, // joined but waiting on game information from host
+		JOINING_IN_LOBBY,
+		MULTIPLAYER
+	};
+
+	enum class GameEndReason {
+		WON,
+		LOST,
+		QUIT
+	};
+public:
+	virtual ~ActivitySink() { }
+public:
+	// campaign games
+	virtual void startedCampaignMission(const std::string& campaign, const std::string& levelName) { }
+	virtual void endedCampaignMission(const std::string& campaign, const std::string& levelName, GameEndReason result, END_GAME_STATS_DATA stats, bool cheatsUsed) { }
+
+	// challenges
+	virtual void startedChallenge(const std::string& challengeName) { }
+	virtual void endedChallenge(const std::string& challengeName, GameEndReason result, const END_GAME_STATS_DATA& stats, bool cheatsUsed) { }
+
+	// skirmish
+	struct SkirmishGameInfo
+	{
+		MULTIPLAYERGAME game;
+		uint8_t numAIBotPlayers = 0;
+		size_t currentPlayerIdx = 0;			// = the selectedPlayer global for the current client (points to currently controlled player in the players array)
+		std::vector<PLAYER> players;
+
+		// information on limits
+		bool limit_no_tanks;					///< Flag for tanks disabled
+		bool limit_no_cyborgs;					///< Flag for cyborgs disabled
+		bool limit_no_vtols;					///< Flag for VTOLs disabled
+		bool limit_no_uplink;					///< Flag for Satellite Uplink disabled
+		bool limit_no_lassat;					///< Flag for Laser Satellite Command Post disabled
+		bool force_structure_limits;			///< Flag to force structure limits
+		std::vector<MULTISTRUCTLIMITS> structureLimits;
+
+		// information on alliance settings
+		enum class AllianceOption
+		{
+			NO_ALLIANCES,        // FFA
+			ALLIANCES,           // Players can make and break alliances during the game.
+			ALLIANCES_TEAMS,     // Alliances are set before the game.
+			ALLIANCES_UNSHARED,  // Alliances are set before the game. No shared research.
+		};
+		AllianceOption alliances;
+
+	public:
+		virtual ~SkirmishGameInfo() { }
+		// some convenience functions to get data
+		const char * gameName() const { return game.name; }
+		const char * mapName() const { return game.map; }
+		virtual uint8_t numberOfPlayers() const { return numAIBotPlayers + 1; }
+		bool hasLimits() const { return limit_no_tanks || limit_no_cyborgs || limit_no_vtols || limit_no_uplink || limit_no_lassat || force_structure_limits; }
+	};
+	virtual void startedSkirmishGame(const SkirmishGameInfo& info) { }
+	virtual void endedSkirmishGame(const SkirmishGameInfo& info, GameEndReason result, const END_GAME_STATS_DATA& stats) { }
+
+	// multiplayer
+	struct ListeningInterfaces {
+		bool IPv4 = false;
+		bool IPv6 = false;
+		unsigned int ipv4_port;
+		unsigned int ipv6_port;
+	};
+	struct MultiplayerGameInfo : public SkirmishGameInfo {
+		// host information
+		std::string hostName;		// host player name
+		ListeningInterfaces listeningInterfaces;
+		std::string lobbyAddress;
+		unsigned int lobbyPort;
+		uint32_t lobbyGameId = 0;
+
+		bool isHost;	// whether the current client is the game host
+		bool privateGame;			// whether game is password-protected
+		uint8_t maxPlayers = 0;
+		uint8_t numHumanPlayers = 0;
+		uint8_t numAvailableSlots = 0;
+	};
+	virtual void hostingMultiplayerGame(const MultiplayerGameInfo& info) { }
+	virtual void joinedMultiplayerGame(const MultiplayerGameInfo& info) { }
+	virtual void updateMultiplayerGameInfo(const MultiplayerGameInfo& info) { }
+	virtual void leftMultiplayerGameLobby(bool wasHost, LOBBY_ERROR_TYPES type) { }
+	virtual void startedMultiplayerGame(const MultiplayerGameInfo& info) { }
+	virtual void endedMultiplayerGame(const MultiplayerGameInfo& info, GameEndReason result, const END_GAME_STATS_DATA& stats) { }
+
+	// changing settings
+	virtual void changedSetting(const std::string& settingKey, const std::string& settingValue) { }
+
+	// cheats used
+	virtual void cheatUsed(const std::string& cheatName) { }
+
+public:
+	// Helper Functions
+	static std::string getTeamDescription(const ActivitySink::SkirmishGameInfo& info);
+};
+
+std::string to_string(const ActivitySink::GameEndReason& reason);
+std::string to_string(const END_GAME_STATS_DATA& stats);
+
+// ActivityManager accepts numerous event callbacks from the core game and synthesizes
+// a (more) sensible stream of higher-level event callbacks to subscribed ActivitySinks.
+//
+// To access the single, global instance of ActivityManager, use ActivityManager::instance()
+//
+class ActivityManager
+{
+public:
+	void startingGame();
+	void startingSavedGame();
+	void loadedLevel(LEVEL_TYPE type, const std::string& levelName);
+	void completedMission(bool result, END_GAME_STATS_DATA stats, bool cheatsUsed);
+	void quitGame(END_GAME_STATS_DATA stats, bool cheatsUsed);
+	void preSystemShutdown();
+
+	// changing settings
+	void beginLoadingSettings();
+	void changedSetting(const std::string& settingKey, const std::string& settingValue);
+	void endLoadingSettings();
+
+	// cheats used
+	void cheatUsed(const std::string& cheatName);
+
+	// called when a joinable multiplayer game is hosted
+	// lobbyGameId is 0 if the lobby can't be contacted / the game is not registered with the lobby
+	void hostGame(const char *SessionName, const char *PlayerName, const char* lobbyAddress, unsigned int lobbyPort, const ActivitySink::ListeningInterfaces& listeningInterfaces, uint32_t lobbyGameId = 0);
+	void hostLobbyQuit();
+	// called when attempting to join a lobby game
+	void willAttemptToJoinLobbyGame(const std::string& lobbyAddress, unsigned int lobbyPort, uint32_t lobbyGameId, const std::vector<JoinConnectionDescription>& connections);
+	// called when an attempt to join fails
+	void joinGameFailed(const std::vector<JoinConnectionDescription>& connection_list);
+	// called when joining a multiplayer game
+	void joinGameSucceeded(const char *host, uint32_t port);
+	void joinedLobbyQuit();
+	// for skirmish / multiplayer, provide additional data / state
+	void updateMultiplayGameData(const MULTIPLAYERGAME& game, const MULTIPLAYERINGAME& ingame, optional<bool> privateGame);
+	// called on the host when the host kicks a player
+	void hostKickPlayer(const PLAYER& player, LOBBY_ERROR_TYPES kick_type, const std::string& reason);
+	// called on the kicked player when they are kicked by another player
+	void wasKickedByPlayer(const PLAYER& kicker, LOBBY_ERROR_TYPES kick_type, const std::string& reason);
+public:
+	static ActivityManager& instance();
+	bool initialize();
+	void shutdown();
+	void addActivitySink(std::shared_ptr<ActivitySink> sink);
+	void removeActivitySink(const std::shared_ptr<ActivitySink>& sink);
+	ActivitySink::GameMode getCurrentGameMode() const;
+private:
+	void _endedMission(ActivitySink::GameEndReason result, END_GAME_STATS_DATA stats, bool cheatsUsed);
+private:
+	std::vector<std::shared_ptr<ActivitySink>> activitySinks;
+
+	// storing current game state, to aide in synthesizing events
+	bool bIsLoadingConfiguration = false;
+	ActivitySink::GameMode currentMode = ActivitySink::GameMode::MENUS;
+	bool bEndedCurrentMission = false;
+	ActivitySink::MultiplayerGameInfo currentMultiplayGameInfo;
+
+	struct LoadedLevelEvent {
+		LEVEL_TYPE type;
+		std::string levelName;
+	};
+	LoadedLevelEvent* cachedLoadedLevelEvent = nullptr;
+
+	LoadedLevelEvent lastLoadedLevelEvent;
+
+	struct FoundLobbyGameDetails
+	{
+		std::string lobbyAddress;
+		unsigned int lobbyPort;
+		uint32_t lobbyGameId;
+		std::vector<JoinConnectionDescription> connections;
+
+		void clear()
+		{
+			lobbyAddress.clear();
+			lobbyPort = 0;
+			lobbyGameId = 0;
+			connections.clear();
+		}
+	};
+	FoundLobbyGameDetails lastLobbyGameJoinAttempt;
+};
+
+#endif // __INCLUDED_SRC_ACTIVITY_H__

--- a/src/challenge.cpp
+++ b/src/challenge.cpp
@@ -25,6 +25,7 @@
 
 #include <physfs.h>
 #include <ctime>
+#include <string>
 
 #include "lib/framework/frame.h"
 #include "lib/framework/input.h"
@@ -72,6 +73,7 @@ static	W_SCREEN	*psRequestScreen;					// Widget screen for requester
 
 bool		challengesUp = false;		///< True when interface is up and should be run.
 bool		challengeActive = false;	///< Whether we are running a challenge
+std::string challengeName;
 
 static void displayLoadBanner(WIDGET *psWidget, UDWORD xOffset, UDWORD yOffset)
 {
@@ -81,6 +83,15 @@ static void displayLoadBanner(WIDGET *psWidget, UDWORD xOffset, UDWORD yOffset)
 
 	pie_BoxFill(x, y, x + psWidget->width(), y + psWidget->height(), col);
 	pie_BoxFill(x + 2, y + 2, x + psWidget->width() - 2, y + psWidget->height() - 2, WZCOL_MENU_BACKGROUND);
+}
+
+const char* currentChallengeName()
+{
+	if (challengeActive)
+	{
+		return challengeName.c_str();
+	}
+	return nullptr;
 }
 
 // quite the hack, game name is stored in global sRequestResult
@@ -396,6 +407,7 @@ bool runChallenges()
 				assert(data != nullptr);
 				assert(data->filename != nullptr);
 				sstrcpy(sRequestResult, data->filename);
+				challengeName = psWidget->pText.toStdString();
 			}
 			else
 			{

--- a/src/challenge.h
+++ b/src/challenge.h
@@ -32,6 +32,8 @@ void updateChallenge(bool gameWon);
 extern bool challengesUp;
 extern bool challengeActive;
 
+const char* currentChallengeName();
+
 void challengesScreenSizeDidChange(unsigned int oldWidth, unsigned int oldHeight, unsigned int newWidth, unsigned int newHeight);
 
 #endif // __INCLUDED_SRC_CHALLENGE_H__

--- a/src/cheat.cpp
+++ b/src/cheat.cpp
@@ -34,6 +34,7 @@
 #include "multiplay.h"
 #include "qtscript.h"
 #include "template.h"
+#include "activity.h"
 
 struct CHEAT_ENTRY
 {
@@ -89,7 +90,7 @@ static CHEAT_ENTRY cheatCodes[] =
 
 };
 
-bool attemptCheatCode(const char *cheat_name)
+bool _attemptCheatCode(const char *cheat_name)
 {
 	const CHEAT_ENTRY *curCheat;
 	static const CHEAT_ENTRY *const EndCheat = &cheatCodes[ARRAY_SIZE(cheatCodes)];
@@ -139,6 +140,16 @@ bool attemptCheatCode(const char *cheat_name)
 	}
 
 	return false;
+}
+
+bool attemptCheatCode(const char *cheat_name)
+{
+	bool result = _attemptCheatCode(cheat_name);
+	if (result)
+	{
+		ActivityManager::instance().cheatUsed(cheat_name);
+	}
+	return result;
 }
 
 void sendProcessDebugMappings(bool val)

--- a/src/configuration.cpp
+++ b/src/configuration.cpp
@@ -154,6 +154,7 @@ bool loadConfig()
 	        ini.value("fontfacebold", "Bold").toString().toUtf8().constData());
 	NETsetMasterserverPort(ini.value("masterserver_port", MASTERSERVERPORT).toInt());
 	NETsetGameserverPort(ini.value("gameserver_port", GAMESERVERPORT).toInt());
+	NETsetJoinPreferenceIPv6(ini.value("prefer_ipv6", true).toBool());
 	war_SetFMVmode((FMV_MODE)ini.value("FMVmode", FMV_FULLSCREEN).toInt());
 	war_setScanlineMode((SCANLINE_MODE)ini.value("scanlines", SCANLINES_OFF).toInt());
 	seq_SetSubtitles(ini.value("subtitles", true).toBool());
@@ -294,6 +295,7 @@ bool saveConfig()
 	ini.setValue("masterserver_port", NETgetMasterserverPort());
 	ini.setValue("server_name", mpGetServerName());
 	ini.setValue("gameserver_port", NETgetGameserverPort());
+	ini.setValue("prefer_ipv6", NETgetJoinPreferenceIPv6());
 	if (!bMultiPlayer)
 	{
 		ini.setValue("colour", getPlayerColour(0));			// favourite colour.

--- a/src/configuration.cpp
+++ b/src/configuration.cpp
@@ -56,6 +56,7 @@
 #include "texture.h"
 #include "warzoneconfig.h"
 #include "titleui/titleui.h"
+#include "activity.h"
 #include "nethelpers.h"
 
 #include <type_traits>
@@ -76,6 +77,9 @@ bool loadConfig()
 		debug(LOG_ERROR, "Could not open configuration file \"%s\"", fileName);
 		return false;
 	}
+
+	ActivityManager::instance().beginLoadingSettings();
+
 	debug(LOG_WZ, "Reading configuration from %s", ini.fileName().toUtf8().constData());
 	if (ini.contains("voicevol"))
 	{
@@ -236,6 +240,8 @@ bool loadConfig()
 		pie_SetVideoBufferDepth(ini.value("bpp").toInt());
 	}
 	setFavoriteStructs(ini.value("favoriteStructs").toString().toUtf8().constData());
+
+	ActivityManager::instance().endLoadingSettings();
 	return true;
 }
 

--- a/src/configuration.cpp
+++ b/src/configuration.cpp
@@ -56,6 +56,7 @@
 #include "texture.h"
 #include "warzoneconfig.h"
 #include "titleui/titleui.h"
+#include "nethelpers.h"
 
 #include <type_traits>
 
@@ -155,6 +156,8 @@ bool loadConfig()
 	NETsetMasterserverPort(ini.value("masterserver_port", MASTERSERVERPORT).toInt());
 	NETsetGameserverPort(ini.value("gameserver_port", GAMESERVERPORT).toInt());
 	NETsetJoinPreferenceIPv6(ini.value("prefer_ipv6", true).toBool());
+	setPublicIPv4LookupService(ini.value("publicIPv4LookupService_Url", WZ_DEFAULT_PUBLIC_IPv4_LOOKUP_SERVICE_URL).toString().toStdString(), ini.value("publicIPv4LookupService_JSONKey", WZ_DEFAULT_PUBLIC_IPv4_LOOKUP_SERVICE_JSONKEY).toString().toStdString());
+	setPublicIPv6LookupService(ini.value("publicIPv6LookupService_Url", WZ_DEFAULT_PUBLIC_IPv6_LOOKUP_SERVICE_URL).toString().toStdString(), ini.value("publicIPv6LookupService_JSONKey", WZ_DEFAULT_PUBLIC_IPv6_LOOKUP_SERVICE_JSONKEY).toString().toStdString());
 	war_SetFMVmode((FMV_MODE)ini.value("FMVmode", FMV_FULLSCREEN).toInt());
 	war_setScanlineMode((SCANLINE_MODE)ini.value("scanlines", SCANLINES_OFF).toInt());
 	seq_SetSubtitles(ini.value("subtitles", true).toBool());
@@ -296,6 +299,10 @@ bool saveConfig()
 	ini.setValue("server_name", mpGetServerName());
 	ini.setValue("gameserver_port", NETgetGameserverPort());
 	ini.setValue("prefer_ipv6", NETgetJoinPreferenceIPv6());
+	ini.setValue("publicIPv4LookupService_Url", getPublicIPv4LookupServiceUrl().c_str());
+	ini.setValue("publicIPv4LookupService_JSONKey", getPublicIPv4LookupServiceJSONKey().c_str());
+	ini.setValue("publicIPv6LookupService_Url", getPublicIPv6LookupServiceUrl().c_str());
+	ini.setValue("publicIPv6LookupService_JSONKey", getPublicIPv6LookupServiceJSONKey().c_str());
 	if (!bMultiPlayer)
 	{
 		ini.setValue("colour", getPlayerColour(0));			// favourite colour.

--- a/src/display3d.cpp
+++ b/src/display3d.cpp
@@ -1223,9 +1223,7 @@ bool init3DView()
 		return false;
 	}
 
-	char *withoutTechlevel = mapNameWithoutTechlevel(getLevelName());
-	txtLevelName.setText(withoutTechlevel, font_small);
-	free(withoutTechlevel);
+	txtLevelName.setText(mapNameWithoutTechlevel(getLevelName()), font_small);
 	txtDebugStatus.setText("DEBUG ", font_small);
 
 	return true;

--- a/src/frontend.cpp
+++ b/src/frontend.cpp
@@ -70,16 +70,6 @@
 #include "titleui/titleui.h"
 #include "urlhelpers.h"
 
-struct CAMPAIGN_FILE
-{
-	WzString name;
-	WzString level;
-	WzString video;
-	WzString captions;
-	WzString package;
-	WzString loading;
-};
-
 // ////////////////////////////////////////////////////////////////////////////
 // Global variables
 
@@ -350,32 +340,6 @@ void startSinglePlayerMenu()
 	{
 		addSmallTextButton(FRONTEND_HYPERLINK, FRONTEND_POS9X, FRONTEND_POS9Y, _("Campaign videos are missing! Get them from http://wz2100.net"), 0);
 	}
-}
-
-static std::vector<CAMPAIGN_FILE> readCampaignFiles()
-{
-	std::vector<CAMPAIGN_FILE> result;
-	char **files = PHYSFS_enumerateFiles("campaigns");
-	for (char **i = files; *i != nullptr; ++i)
-	{
-		CAMPAIGN_FILE c;
-		WzString filename("campaigns/");
-		filename += *i;
-		if (!filename.endsWith(".json"))
-		{
-			continue;
-		}
-		WzConfig ini(filename, WzConfig::ReadOnlyAndRequired);
-		c.name = ini.value("name").toWzString();
-		c.level = ini.value("level").toWzString();
-		c.package = ini.value("package").toWzString();
-		c.loading = ini.value("loading").toWzString();
-		c.video = ini.value("video").toWzString();
-		c.captions = ini.value("captions").toWzString();
-		result.push_back(c);
-	}
-	PHYSFS_freeList(files);
-	return result;
 }
 
 void startCampaignSelector()

--- a/src/levels.cpp
+++ b/src/levels.cpp
@@ -52,6 +52,7 @@
 #include "multiint.h"
 #include "qtscript.h"
 #include "wrappers.h"
+#include "activity.h"
 
 extern int lev_get_lineno();
 extern char *lev_get_text();
@@ -1043,6 +1044,8 @@ bool levLoadData(char const *name, Sha256 const *hash, char *pSaveName, GAME_TYP
 			jsAutogameSpecific("multiplay/skirmish/semperfi.js", selectedPlayer);
 		}
 	}
+
+	ActivityManager::instance().loadedLevel(psCurrLevel->type, mapNameWithoutTechlevel(getLevelName()));
 
 	return true;
 }

--- a/src/levels.cpp
+++ b/src/levels.cpp
@@ -1047,15 +1047,16 @@ bool levLoadData(char const *name, Sha256 const *hash, char *pSaveName, GAME_TYP
 	return true;
 }
 
-char *mapNameWithoutTechlevel(const char *mapName)
+std::string mapNameWithoutTechlevel(const char *mapName)
 {
-	size_t len = strlen(mapName);
-	char *r = strdup(mapName);
-	if (len > 2 && mapName[len - 3] == '-' && mapName[len - 2] == 'T' && isdigit(mapName[len - 1]))
+	ASSERT_OR_RETURN("", mapName != nullptr, "null mapName provided");
+	std::string result(mapName);
+	size_t len = result.length();
+	if (len > 2 && result[len - 3] == '-' && result[len - 2] == 'T' && isdigit(result[len - 1]))
 	{
-		r[len - 3] = '\0';
+		result.resize(len - 3);
 	}
-	return r;
+	return result;
 }
 
 /// returns maps of the right 'type'
@@ -1103,17 +1104,13 @@ LEVEL_LIST enumerateMultiMaps(int camToUse, int numPlayers)
 					{
 						continue;
 					}
-					char *levelBaseName = mapNameWithoutTechlevel(lev->pName);
-					char *mapBaseName = mapNameWithoutTechlevel(map->pName);
-					if (strcmp(levelBaseName, mapBaseName) == 0)
+					std::string levelBaseName = mapNameWithoutTechlevel(lev->pName);
+					std::string mapBaseName = mapNameWithoutTechlevel(map->pName);
+					if (strcmp(levelBaseName.c_str(), mapBaseName.c_str()) == 0)
 					{
 						already_added = true;
-						free(levelBaseName);
-						free(mapBaseName);
 						break;
 					}
-					free(levelBaseName);
-					free(mapBaseName);
 				}
 				if (!already_added)
 				{

--- a/src/levels.h
+++ b/src/levels.h
@@ -107,6 +107,6 @@ const char *getLevelName();
 
 void levTest();
 
-char *mapNameWithoutTechlevel(const char *mapName);
+std::string mapNameWithoutTechlevel(const char *mapName);
 
 #endif // __INCLUDED_SRC_LEVELS_H__

--- a/src/loadsave.cpp
+++ b/src/loadsave.cpp
@@ -870,9 +870,9 @@ void autoSave()
 	char savedate[PATH_MAX];
 	strftime(savedate, sizeof(savedate), "%F_%H%M%S", timeinfo);
 
-	char *withoutTechlevel = mapNameWithoutTechlevel(getLevelName());
+	std::string withoutTechlevel = mapNameWithoutTechlevel(getLevelName());
 	char savefile[PATH_MAX];
-	snprintf(savefile, sizeof(savefile), "%s/%s_%s.gam", dir, withoutTechlevel, savedate);
+	snprintf(savefile, sizeof(savefile), "%s/%s_%s.gam", dir, withoutTechlevel.c_str(), savedate);
 	if (saveGame(savefile, GTYPE_SAVE_MIDMISSION))
 	{
 		console("AutoSave %s", savefile);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -88,6 +88,7 @@
 #include <LaunchInfo.h>
 #include <sodium.h>
 #include "updatemanager.h"
+#include "activity.h"
 
 #if defined(WZ_OS_UNIX)
 # include <signal.h>
@@ -827,6 +828,8 @@ static void startGameLoop()
 {
 	SetGameMode(GS_NORMAL);
 
+	ActivityManager::instance().startingGame();
+
 	// Not sure what aLevelName is, in relation to game.map. But need to use aLevelName here, to be able to start the right map for campaign, and need game.hash, to start the right non-campaign map, if there are multiple identically named maps.
 	if (!levLoadData(aLevelName, &game.hash, nullptr, GTYPE_SCENARIO_START))
 	{
@@ -912,6 +915,7 @@ static bool initSaveGameLoad()
 	// NOTE: always setGameMode correctly before *any* loading routines!
 	SetGameMode(GS_NORMAL);
 	screen_RestartBackDrop();
+
 	// load up a save game
 	if (!loadGameInit(saveGameName))
 	{
@@ -926,6 +930,8 @@ static bool initSaveGameLoad()
 		SetGameMode(GS_TITLE_SCREEN);
 		return false;
 	}
+
+	ActivityManager::instance().startingSavedGame();
 
 	screen_StopBackDrop();
 	closeLoadingScreen();
@@ -957,6 +963,7 @@ static void runGameLoop()
 		break;
 	case GAMECODE_QUITGAME:
 		debug(LOG_MAIN, "GAMECODE_QUITGAME");
+		ActivityManager::instance().quitGame(collectEndGameStatsData(), Cheated);
 		stopGameLoop();
 		startTitleLoop(); // Restart into titleloop
 		break;
@@ -1467,6 +1474,8 @@ int realmain(int argc, char *argv[])
 		}
 	}
 
+	ActivityManager::instance().initialize();
+
 	if (!wzMainScreenSetup(war_getAntialiasing(), war_getFullscreen(), war_GetVsync()))
 	{
 		return EXIT_FAILURE;
@@ -1554,6 +1563,7 @@ int realmain(int argc, char *argv[])
 #endif
 	debug(LOG_MAIN, "Entering main loop");
 	wzMainEventLoop();
+	ActivityManager::instance().preSystemShutdown();
 	saveConfig();
 	systemShutdown();
 #ifdef WZ_OS_WIN	// clean up the memory allocated for the command line conversion
@@ -1564,6 +1574,7 @@ int realmain(int argc, char *argv[])
 	}
 	free(utfargv);
 #endif
+	ActivityManager::instance().shutdown();
 	wzShutdown();
 	urlRequestShutdown();
 	debug(LOG_MAIN, "Completed shutting down Warzone 2100");

--- a/src/mission.cpp
+++ b/src/mission.cpp
@@ -3126,6 +3126,37 @@ UDWORD	getCampaignNumber()
 	return camNumber;
 }
 
+std::vector<CAMPAIGN_FILE> readCampaignFiles()
+{
+	static std::vector<CAMPAIGN_FILE> result;
+	if (!result.empty())
+	{
+		return result;
+	}
+
+	char **files = PHYSFS_enumerateFiles("campaigns");
+	for (char **i = files; *i != nullptr; ++i)
+	{
+		CAMPAIGN_FILE c;
+		WzString filename("campaigns/");
+		filename += *i;
+		if (!filename.endsWith(".json"))
+		{
+			continue;
+		}
+		WzConfig ini(filename, WzConfig::ReadOnlyAndRequired);
+		c.name = ini.value("name").toWzString();
+		c.level = ini.value("level").toWzString();
+		c.package = ini.value("package").toWzString();
+		c.loading = ini.value("loading").toWzString();
+		c.video = ini.value("video").toWzString();
+		c.captions = ini.value("captions").toWzString();
+		result.push_back(c);
+	}
+	PHYSFS_freeList(files);
+	return result;
+}
+
 /*deals with any selectedPlayer's transporters that are flying in when the
 mission ends. bOffWorld is true if the Mission is currently offWorld*/
 void emptyTransporters(bool bOffWorld)

--- a/src/mission.cpp
+++ b/src/mission.cpp
@@ -77,6 +77,7 @@
 #include "warzoneconfig.h"
 #include "combat.h"
 #include "qtscript.h"
+#include "activity.h"
 
 #define		IDMISSIONRES_TXT		11004
 #define		IDMISSIONRES_LOAD		11005
@@ -2382,6 +2383,7 @@ static bool _intAddMissionResult(bool result, bool bPlaySuccess, bool showBackDr
 
 bool intAddMissionResult(bool result, bool bPlaySuccess, bool showBackDrop)
 {
+	ActivityManager::instance().completedMission(result, collectEndGameStatsData(), Cheated);
 	return _intAddMissionResult(result, bPlaySuccess, showBackDrop);
 }
 
@@ -3124,6 +3126,18 @@ void	setCampaignNumber(UDWORD number)
 UDWORD	getCampaignNumber()
 {
 	return camNumber;
+}
+
+std::string getCampaignName()
+{
+	UDWORD campaignNum = getCampaignNumber();
+	std::string campaignName;
+	std::vector<CAMPAIGN_FILE> list = readCampaignFiles();
+	if (list.size() >= campaignNum)
+	{
+		campaignName = list[campaignNum - 1].name.toStdString();
+	}
+	return campaignName;
 }
 
 std::vector<CAMPAIGN_FILE> readCampaignFiles()

--- a/src/mission.h
+++ b/src/mission.h
@@ -190,6 +190,8 @@ void resetMissionWidgets();
 UDWORD	getCampaignNumber();
 void	setCampaignNumber(UDWORD number);
 
+std::string getCampaignName();
+
 struct CAMPAIGN_FILE
 {
 	WzString name;

--- a/src/mission.h
+++ b/src/mission.h
@@ -189,6 +189,18 @@ void resetMissionWidgets();
 
 UDWORD	getCampaignNumber();
 void	setCampaignNumber(UDWORD number);
+
+struct CAMPAIGN_FILE
+{
+	WzString name;
+	WzString level;
+	WzString video;
+	WzString captions;
+	WzString package;
+	WzString loading;
+};
+std::vector<CAMPAIGN_FILE> readCampaignFiles();
+
 bool intAddMissionResult(bool result, bool bPlaySuccess, bool showBackDrop);
 
 

--- a/src/multiint.cpp
+++ b/src/multiint.cpp
@@ -3092,7 +3092,6 @@ void WzMultiOptionTitleUI::processMultiopWidgets(UDWORD id)
 					ssprintf(buf, "%s", _("*** password is NOT required! ***"));
 					addConsoleMessage(buf, DEFAULT_JUSTIFY, NOTIFY_MESSAGE);
 				}
-				NETGameLocked(willSet);
 			}
 			break;
 		}

--- a/src/multiint.cpp
+++ b/src/multiint.cpp
@@ -1125,7 +1125,7 @@ static void updateLimitIcons()
 
 WzString formatGameName(WzString name)
 {
-	WzString withoutTechlevel = mapNameWithoutTechlevel(name.toUtf8().c_str());
+	WzString withoutTechlevel = WzString::fromUtf8(mapNameWithoutTechlevel(name.toUtf8().c_str()));
 	return withoutTechlevel + " (T" + WzString::number(game.techLevel) + " " + WzString::number(game.maxPlayers) + "P)";
 }
 

--- a/src/multiint.cpp
+++ b/src/multiint.cpp
@@ -3862,12 +3862,7 @@ void WzMultiOptionTitleUI::start()
 	// free limiter structure
 	if (!bReenter || challengeActive)
 	{
-		if (ingame.numStructureLimits)
-		{
-			ingame.numStructureLimits = 0;
-			free(ingame.pStructureLimits);
-			ingame.pStructureLimits = nullptr;
-		}
+		ingame.structureLimits.clear();
 	}
 
 	if (!bReenter)

--- a/src/multiint.cpp
+++ b/src/multiint.cpp
@@ -3649,6 +3649,12 @@ void WzMultiOptionTitleUI::frontendMultiMessages(bool running)
 				NETenum(&KICK_TYPE);
 				NETend();
 
+				if (player_id >= MAX_PLAYERS)
+				{
+					debug(LOG_ERROR, "NET_KICK message with invalid player_id: (%" PRIu32")", player_id);
+					break;
+				}
+
 				playerVotes[player_id] = 0;
 
 				if (player_id == NET_HOST_ONLY)

--- a/src/multilimit.cpp
+++ b/src/multilimit.cpp
@@ -92,12 +92,7 @@ struct DisplayStructureBarCache {
 static inline void freeLimitSet()
 {
 	// Free the old set if required
-	if (ingame.numStructureLimits)
-	{
-		free(ingame.pStructureLimits);
-		ingame.numStructureLimits = 0;
-		ingame.pStructureLimits = nullptr;
-	}
+	ingame.structureLimits.clear();
 }
 
 // ////////////////////////////////////////////////////////////////////////////
@@ -313,8 +308,7 @@ TITLECODE WzMultiLimitTitleUI::run()
 // ////////////////////////////////////////////////////////////////////////////
 void createLimitSet()
 {
-	UDWORD			numchanges = 0, bufSize, idx = 0;
-	MULTISTRUCTLIMITS	*pEntry = nullptr;
+	UDWORD			numchanges = 0;
 
 	debug(LOG_NET, "LimitSet created");
 	// free old limiter structure
@@ -339,25 +333,18 @@ void createLimitSet()
 	if (numchanges > 0)
 	{
 		// Allocate some memory for the changes
-		bufSize = numchanges * sizeof(MULTISTRUCTLIMITS);
-		pEntry = (MULTISTRUCTLIMITS *)malloc(bufSize);
-		memset(pEntry, 255, bufSize);
+		ingame.structureLimits.reserve(numchanges);
 
 		// Prepare chunk
 		for (unsigned i = 0; i < numStructureStats; i++)
 		{
 			if (asStructureStats[i].upgrade[0].limit != LOTS_OF)
 			{
-				ASSERT_OR_RETURN(, idx < numchanges, "Bad number of changed limits");
-				pEntry[idx].id		= i;
-				pEntry[idx].limit	= asStructureStats[i].upgrade[0].limit;
-				idx++;
+				ASSERT_OR_RETURN(, ingame.structureLimits.size() < numchanges, "Bad number of changed limits");
+				ingame.structureLimits.push_back(MULTISTRUCTLIMITS { i, asStructureStats[i].upgrade[0].limit });
 			}
 		}
 	}
-
-	ingame.numStructureLimits	= numchanges;
-	ingame.pStructureLimits		= pEntry;
 
 	if (bHosted)
 	{
@@ -368,24 +355,23 @@ void createLimitSet()
 // ////////////////////////////////////////////////////////////////////////////
 void applyLimitSet()
 {
-	if (ingame.numStructureLimits == 0)
+	if (ingame.structureLimits.empty())
 	{
 		return;
 	}
 
 	// Get the limits and decode
-	const MULTISTRUCTLIMITS *pEntry = ingame.pStructureLimits;
 	UBYTE flags = ingame.flags & MPFLAGS_FORCELIMITS;
-	for (int i = 0; i < ingame.numStructureLimits; ++i)
+	for (const auto& structLimit : ingame.structureLimits)
 	{
-		int id = pEntry[i].id;
+		int id = structLimit.id;
 
 		// So long as the ID is valid
 		if (id < numStructureStats)
 		{
 			for (int player = 0; player < MAX_PLAYERS; player++)
 			{
-				asStructureStats[id].upgrade[player].limit = pEntry[i].limit;
+				asStructureStats[id].upgrade[player].limit = structLimit.limit;
 
 				if (ingame.flags & MPFLAGS_FORCELIMITS)
 				{
@@ -403,19 +389,19 @@ void applyLimitSet()
 					}
 				}
 			}
-			if (asStructureStats[id].type == REF_VTOL_FACTORY && pEntry[i].limit == 0)
+			if (asStructureStats[id].type == REF_VTOL_FACTORY && structLimit.limit == 0)
 			{
 				flags |= MPFLAGS_NO_VTOLS;
 			}
-			if (asStructureStats[id].type == REF_CYBORG_FACTORY && pEntry[i].limit == 0)
+			if (asStructureStats[id].type == REF_CYBORG_FACTORY && structLimit.limit == 0)
 			{
 				flags |= MPFLAGS_NO_CYBORGS;
 			}
-			if (asStructureStats[id].type == REF_LASSAT && pEntry[i].limit == 0)
+			if (asStructureStats[id].type == REF_LASSAT && structLimit.limit == 0)
 			{
 				flags |= MPFLAGS_NO_LASSAT;
 			}
-			if (asStructureStats[id].type == REF_SAT_UPLINK && pEntry[i].limit == 0)
+			if (asStructureStats[id].type == REF_SAT_UPLINK && structLimit.limit == 0)
 			{
 				flags |= MPFLAGS_NO_UPLINK;
 			}

--- a/src/multimenu.cpp
+++ b/src/multimenu.cpp
@@ -492,14 +492,14 @@ void addMultiRequest(const char *searchDir, const char *fileExtension, UDWORD mo
 
 		char *withoutExtension = strdup(*currFile);
 		withoutExtension[fileNameLength - extensionLength] = '\0';
-		char *withoutTechlevel = mapNameWithoutTechlevel(withoutExtension);
+		std::string withoutTechlevel = mapNameWithoutTechlevel(withoutExtension);
 		free(withoutExtension);
 
 		// Set the tip and add the button
 		W_BUTTON *button = new W_BUTTON(requestList);
 		button->id = nextButtonId;
 		button->setTip(withoutTechlevel);
-		button->setString(withoutTechlevel);
+		button->setString(WzString::fromUtf8(withoutTechlevel));
 		button->displayFunction = displayRequestOption;
 		button->pUserData = new DisplayRequestOptionData();
 		button->setOnDelete([](WIDGET *psWidget) {
@@ -508,8 +508,6 @@ void addMultiRequest(const char *searchDir, const char *fileExtension, UDWORD mo
 			psWidget->pUserData = nullptr;
 		});
 		requestList->addWidgetToLayout(button);
-
-		free(withoutTechlevel);
 
 		/* Update the init struct for the next button */
 		++nextButtonId;
@@ -529,12 +527,12 @@ void addMultiRequest(const char *searchDir, const char *fileExtension, UDWORD mo
 
 		for (auto mapData : levels)
 		{
-			char *withoutTechlevel = mapNameWithoutTechlevel(mapData->pName);
+			std::string withoutTechlevel = mapNameWithoutTechlevel(mapData->pName);
 			// add number of players to string.
 			W_BUTTON *button = new W_BUTTON(requestList);
 			button->id = nextButtonId;
 			button->setTip(withoutTechlevel);
-			button->setString(withoutTechlevel);
+			button->setString(WzString::fromUtf8(withoutTechlevel));
 			button->displayFunction = displayRequestOption;
 			button->pUserData = new DisplayRequestOptionData(mapData);
 			button->setOnDelete([](WIDGET *psWidget) {
@@ -543,7 +541,6 @@ void addMultiRequest(const char *searchDir, const char *fileExtension, UDWORD mo
 				psWidget->pUserData = nullptr;
 			});
 			buttons.push_back({stringRelevance(mapData->pName, searchString), button});
-			free(withoutTechlevel);
 
 			++nextButtonId;
 		}

--- a/src/multiopt.cpp
+++ b/src/multiopt.cpp
@@ -118,13 +118,14 @@ void sendOptions()
 	}
 
 	// Send the number of structure limits to expect
-	NETuint32_t(&ingame.numStructureLimits);
-	debug(LOG_NET, "(Host) Structure limits to process on client is %u", ingame.numStructureLimits);
+	uint32_t numStructureLimits = static_cast<uint32_t>(ingame.structureLimits.size());
+	NETuint32_t(&numStructureLimits);
+	debug(LOG_NET, "(Host) Structure limits to process on client is %zu", ingame.structureLimits.size());
 	// Send the structures changed
-	for (i = 0; i < ingame.numStructureLimits; i++)
+	for (auto structLimit : ingame.structureLimits)
 	{
-		NETuint32_t(&ingame.pStructureLimits[i].id);
-		NETuint32_t(&ingame.pStructureLimits[i].limit);
+		NETuint32_t(&structLimit.id);
+		NETuint32_t(&structLimit.limit);
 	}
 	updateLimitFlags();
 	NETuint8_t(&ingame.flags);
@@ -186,26 +187,22 @@ void recvOptions(NETQUEUE queue)
 	netPlayersUpdated = true;
 
 	// Free any structure limits we may have in-place
-	if (ingame.numStructureLimits)
-	{
-		ingame.numStructureLimits = 0;
-		free(ingame.pStructureLimits);
-		ingame.pStructureLimits = nullptr;
-	}
+	ingame.structureLimits.clear();
 
 	// Get the number of structure limits to expect
-	NETuint32_t(&ingame.numStructureLimits);
-	debug(LOG_NET, "Host is sending us %u structure limits", ingame.numStructureLimits);
+	uint32_t numStructureLimits = 0;
+	NETuint32_t(&numStructureLimits);
+	debug(LOG_NET, "Host is sending us %u structure limits", numStructureLimits);
 	// If there were any changes allocate memory for them
-	if (ingame.numStructureLimits)
+	if (numStructureLimits)
 	{
-		ingame.pStructureLimits = (MULTISTRUCTLIMITS *)malloc(ingame.numStructureLimits * sizeof(MULTISTRUCTLIMITS));
+		ingame.structureLimits.resize(numStructureLimits);
 	}
 
-	for (i = 0; i < ingame.numStructureLimits; i++)
+	for (i = 0; i < numStructureLimits; i++)
 	{
-		NETuint32_t(&ingame.pStructureLimits[i].id);
-		NETuint32_t(&ingame.pStructureLimits[i].limit);
+		NETuint32_t(&ingame.structureLimits[i].id);
+		NETuint32_t(&ingame.structureLimits[i].limit);
 	}
 	NETuint8_t(&ingame.flags);
 
@@ -393,12 +390,7 @@ bool multiShutdown()
 	NETshutdown();
 
 	debug(LOG_MAIN, "free game data (structure limits)");
-	if (ingame.numStructureLimits)
-	{
-		ingame.numStructureLimits = 0;
-		free(ingame.pStructureLimits);
-		ingame.pStructureLimits = nullptr;
-	}
+	ingame.structureLimits.clear();
 
 	return true;
 }
@@ -494,12 +486,7 @@ bool multiGameShutdown()
 	NETclose();
 	NETremRedirects();
 
-	if (ingame.numStructureLimits)
-	{
-		ingame.numStructureLimits = 0;
-		free(ingame.pStructureLimits);
-		ingame.pStructureLimits = nullptr;
-	}
+	ingame.structureLimits.clear();
 	ingame.flags = 0;
 
 	ingame.localJoiningInProgress = false; // Clean up

--- a/src/multiopt.cpp
+++ b/src/multiopt.cpp
@@ -60,6 +60,7 @@
 #include "multiint.h"
 #include "multirecv.h"
 #include "template.h"
+#include "activity.h"
 
 // send complete game info set!
 void sendOptions()
@@ -131,6 +132,8 @@ void sendOptions()
 	NETuint8_t(&ingame.flags);
 
 	NETend();
+
+	ActivityManager::instance().updateMultiplayGameData(game, ingame, NETGameIsLocked());
 }
 
 // ////////////////////////////////////////////////////////////////////////////
@@ -308,6 +311,8 @@ void recvOptions(NETQUEUE queue)
 	{
 		loadMapPreview(false);
 	}
+
+	ActivityManager::instance().updateMultiplayGameData(game, ingame, NETGameIsLocked());
 }
 
 

--- a/src/multiplay.cpp
+++ b/src/multiplay.cpp
@@ -73,6 +73,7 @@
 #include "cheat.h"
 #include "main.h"								// for gamemode
 #include "multiint.h"
+#include "activity.h"
 
 // ////////////////////////////////////////////////////////////////////////////
 // ////////////////////////////////////////////////////////////////////////////
@@ -838,6 +839,7 @@ bool recvMessage()
 				{
 					debug(LOG_ERROR, "You were kicked because %s", reason);
 					setPlayerHasLost(true);
+					ActivityManager::instance().wasKickedByPlayer(NetPlay.players[queue.index], KICK_TYPE, reason);
 				}
 				else
 				{

--- a/src/multiplay.h
+++ b/src/multiplay.h
@@ -31,6 +31,7 @@
 #include "orderdef.h"
 #include "stringdef.h"
 #include "messagedef.h"
+#include <vector>
 
 class DROID_GROUP;
 struct BASE_OBJECT;
@@ -79,8 +80,7 @@ struct MULTIPLAYERINGAME
 	int32_t				TimeEveryoneIsInGame;
 	bool				isAllPlayersDataOK;
 	UDWORD				startTime;
-	UDWORD				numStructureLimits;					// number of limits
-	MULTISTRUCTLIMITS	*pStructureLimits;					// limits chunk.
+	std::vector<MULTISTRUCTLIMITS> structureLimits;
 	uint8_t				flags;  ///< Bitmask, shows which structures are disabled.
 #define MPFLAGS_NO_TANKS	0x01  		///< Flag for tanks disabled
 #define MPFLAGS_NO_CYBORGS	0x02  		///< Flag for cyborgs disabled

--- a/src/multiplay.h
+++ b/src/multiplay.h
@@ -210,6 +210,7 @@ public:
 	std::string host;
 	uint32_t port = 0;
 };
+std::vector<JoinConnectionDescription> findLobbyGame(const std::string& lobbyAddress, unsigned int lobbyPort, uint32_t lobbyGameId);
 enum class JoinGameResult {
 	FAILED,
 	JOINED,

--- a/src/multiplay.h
+++ b/src/multiplay.h
@@ -32,6 +32,7 @@
 #include "stringdef.h"
 #include "messagedef.h"
 #include <vector>
+#include <string>
 
 class DROID_GROUP;
 struct BASE_OBJECT;
@@ -197,7 +198,25 @@ bool multiShutdown();
 bool sendLeavingMsg();
 
 bool hostCampaign(char *sGame, char *sPlayer);
-bool joinGame(const char *host, uint32_t port);
+struct JoinConnectionDescription
+{
+public:
+	JoinConnectionDescription() { }
+	JoinConnectionDescription(const std::string& host, uint32_t port)
+	: host(host)
+	, port(port)
+	{ }
+public:
+	std::string host;
+	uint32_t port = 0;
+};
+enum class JoinGameResult {
+	FAILED,
+	JOINED,
+	PENDING_PASSWORD
+};
+JoinGameResult joinGame(const char *host, uint32_t port);
+JoinGameResult joinGame(const std::vector<JoinConnectionDescription>& connection_list);
 void playerResponding();
 bool multiGameInit();
 bool multiGameShutdown();

--- a/src/nethelpers.cpp
+++ b/src/nethelpers.cpp
@@ -1,0 +1,230 @@
+/*
+	This file is part of Warzone 2100.
+	Copyright (C) 2020  Warzone 2100 Project
+
+	Warzone 2100 is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+
+	Warzone 2100 is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with Warzone 2100; if not, write to the Free Software
+	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+
+#include "nethelpers.h"
+#include "urlrequest.h"
+#include <mutex>
+#include <memory>
+#include <optional-lite/optional.hpp>
+using nonstd::optional;
+using nonstd::nullopt;
+#include <3rdparty/json/json.hpp>
+using json = nlohmann::json;
+
+static std::string publicIPv4LookupService = WZ_DEFAULT_PUBLIC_IPv4_LOOKUP_SERVICE_URL;
+static std::string publicIPv4LookupServiceJSONKey = WZ_DEFAULT_PUBLIC_IPv4_LOOKUP_SERVICE_JSONKEY;
+static std::string publicIPv6LookupService = WZ_DEFAULT_PUBLIC_IPv6_LOOKUP_SERVICE_URL;
+static std::string publicIPv6LookupServiceJSONKey = WZ_DEFAULT_PUBLIC_IPv6_LOOKUP_SERVICE_JSONKEY;
+
+void setPublicIPv4LookupService(const std::string& publicIPv4LookupServiceUrl, const std::string& jsonKey)
+{
+	if (publicIPv4LookupServiceUrl.empty() || jsonKey.empty())
+	{
+		return;
+	}
+	publicIPv4LookupService = publicIPv4LookupServiceUrl;
+	publicIPv4LookupServiceJSONKey = jsonKey;
+}
+const std::string& getPublicIPv4LookupServiceUrl()
+{
+	return publicIPv4LookupService;
+}
+const std::string& getPublicIPv4LookupServiceJSONKey()
+{
+	return publicIPv4LookupServiceJSONKey;
+}
+
+void setPublicIPv6LookupService(const std::string& publicIPv6LookupServiceUrl, const std::string& jsonKey)
+{
+	if (publicIPv6LookupServiceUrl.empty() || jsonKey.empty())
+	{
+		return;
+	}
+	publicIPv6LookupService = publicIPv6LookupServiceUrl;
+	publicIPv6LookupServiceJSONKey = jsonKey;
+}
+const std::string& getPublicIPv6LookupServiceUrl()
+{
+	return publicIPv6LookupService;
+}
+const std::string& getPublicIPv6LookupServiceJSONKey()
+{
+	return publicIPv6LookupServiceJSONKey;
+}
+
+static void requestPublicIPAddress(const std::string& lookupServiceUrl, InternetProtocol protocol, const std::string& jsonResponseKey, const std::function<void (optional<std::string> ipAddressString, optional<std::string> errorString)>& callback)
+{
+	URLDataRequest request;
+	request.url = lookupServiceUrl;
+	request.protocol = protocol;
+	request.noProxy = true;
+	request.onSuccess = [jsonResponseKey, callback](const std::string& url, const HTTPResponseDetails& responseDetails, const std::shared_ptr<MemoryStruct>& data) {
+
+		long httpStatusCode = responseDetails.httpStatusCode();
+		if (httpStatusCode != 200)
+		{
+			std::string errorString = "Request returned HTTP status code: ";
+			errorString += std::to_string(httpStatusCode);
+			callback(nullopt, errorString);
+			return;
+		}
+
+		// Parse the remaining json (minus the digital signature)
+		json updateData;
+		try {
+			updateData = json::parse(data->memory, data->memory + data->size);
+		}
+		catch (const std::exception &e) {
+			std::string errorString = "Failed to parse JSON response: ";
+			errorString += e.what();
+			callback(nullopt, errorString);
+			return;
+		}
+
+		// Get the IP address from the JSON response
+		if (!updateData.is_object())
+		{
+			callback(nullopt, "JSON response is not an object");
+			return;
+		}
+
+		auto it = updateData.find(jsonResponseKey);
+		if (it == updateData.end() || !it.value().is_string())
+		{
+			// Missing expected property
+			std::string errorString = "JSON object missing expected property: ";
+			errorString += jsonResponseKey;
+			callback(nullopt, errorString);
+			return;
+		}
+
+		std::string ipAddressString = it.value().get<std::string>();
+		callback(ipAddressString, nullopt);
+	};
+	request.onFailure = [callback](const std::string& url, URLRequestFailureType type, optional<HTTPResponseDetails> transferDetails) {
+		std::string errorString = "Request failed; failure type: ";
+		errorString += std::to_string(type);
+		if (transferDetails.has_value())
+		{
+			errorString += "; status code: " + std::to_string(transferDetails.value().httpStatusCode());
+		}
+		callback(nullopt, errorString);
+	};
+	request.maxDownloadSizeLimit = 1024 * 1024; // response should never be > 1 MB
+	AsyncURLRequestHandle handle = urlRequestData(request);
+}
+
+class GetPublicIPAddress {
+private:
+	IPAddressResultCallbackFunc resultCallback;
+	optional<std::string> ipv4;
+	optional<std::string> ipv4_error;
+	optional<std::string> ipv6;
+	optional<std::string> ipv6_error;
+	std::mutex ip_mutex;
+
+	bool allRequestsFinished() const {
+		return (ipv4.has_value() || ipv4_error.has_value()) && (ipv6.has_value() || ipv6_error.has_value());
+	}
+	bool dispatchCallbackIfDone() const {
+		if (!allRequestsFinished())
+		{
+			return false;
+		}
+		std::vector<std::string> errors;
+		if (ipv4_error.has_value())
+		{
+			errors.push_back(std::string("IPv4: ") + ipv4_error.value());
+		}
+		if (ipv6_error.has_value())
+		{
+			errors.push_back(std::string("IPv6: ") + ipv6_error.value());
+		}
+		resultCallback((ipv4.has_value()) ? ipv4.value() : "", (ipv6.has_value()) ? ipv6.value() : "", errors);
+		return true;
+	}
+public:
+	GetPublicIPAddress(const IPAddressResultCallbackFunc& resultCallback)
+	: resultCallback(resultCallback)
+	{ }
+
+public:
+	static void getPublicIPAddress(const IPAddressResultCallbackFunc& resultCallback, bool ipv4 = true, bool ipv6 = true)
+	{
+		std::shared_ptr<GetPublicIPAddress> pPublicIpAddresses = std::make_shared<GetPublicIPAddress>(resultCallback);
+		if (!ipv4)
+		{
+			pPublicIpAddresses->ipv4 = std::string();
+		}
+		if (!ipv6)
+		{
+			pPublicIpAddresses->ipv6 = std::string();
+		}
+
+		if (ipv4)
+		{
+			requestPublicIPAddress(publicIPv4LookupService, InternetProtocol::IPv4, publicIPv4LookupServiceJSONKey, [pPublicIpAddresses](optional<std::string> ipAddressString, optional<std::string> errorString){
+				std::lock_guard<std::mutex> guard(pPublicIpAddresses->ip_mutex);
+				if (!errorString.has_value())
+				{
+					if (ipAddressString.has_value() && (pPublicIpAddresses->ipv6 != ipAddressString))
+					{
+						pPublicIpAddresses->ipv4 = ipAddressString;
+					}
+					else
+					{
+						pPublicIpAddresses->ipv4 = std::string();
+					}
+				}
+				else
+				{
+					pPublicIpAddresses->ipv4_error = errorString.value();
+				}
+				pPublicIpAddresses->dispatchCallbackIfDone();
+			});
+		}
+		if (ipv6)
+		{
+			requestPublicIPAddress(publicIPv6LookupService, InternetProtocol::IPv6, publicIPv6LookupServiceJSONKey, [pPublicIpAddresses](optional<std::string> ipAddressString, optional<std::string> errorString){
+				std::lock_guard<std::mutex> guard(pPublicIpAddresses->ip_mutex);
+				if (!errorString.has_value())
+				{
+					if (ipAddressString.has_value() && (pPublicIpAddresses->ipv4 != ipAddressString))
+					{
+						pPublicIpAddresses->ipv6 = ipAddressString;
+					}
+					else
+					{
+						pPublicIpAddresses->ipv6 = std::string();
+					}
+				}
+				else
+				{
+					pPublicIpAddresses->ipv6_error = errorString.value();
+				}
+				pPublicIpAddresses->dispatchCallbackIfDone();
+			});
+		}
+	}
+};
+
+void getPublicIPAddress(const IPAddressResultCallbackFunc& resultCallback, bool ipv4 /*= true*/, bool ipv6 /*= true*/)
+{
+	GetPublicIPAddress::getPublicIPAddress(resultCallback, ipv4, ipv6);
+}

--- a/src/nethelpers.h
+++ b/src/nethelpers.h
@@ -1,0 +1,46 @@
+/*
+	This file is part of Warzone 2100.
+	Copyright (C) 2020  Warzone 2100 Project
+
+	Warzone 2100 is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+
+	Warzone 2100 is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with Warzone 2100; if not, write to the Free Software
+	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+
+#ifndef __INCLUDED_WZ_NET_HELPERS_H__
+#define __INCLUDED_WZ_NET_HELPERS_H__
+
+#include <functional>
+#include <string>
+#include <vector>
+
+#define WZ_DEFAULT_PUBLIC_IPv4_LOOKUP_SERVICE_URL "https://api.ipify.org?format=json"
+#define WZ_DEFAULT_PUBLIC_IPv4_LOOKUP_SERVICE_JSONKEY "ip"
+#define WZ_DEFAULT_PUBLIC_IPv6_LOOKUP_SERVICE_URL "https://api6.ipify.org?format=json"
+#define WZ_DEFAULT_PUBLIC_IPv6_LOOKUP_SERVICE_JSONKEY "ip"
+
+typedef std::function<void (const std::string& ipv4Address, const std::string& ipv6Address, const std::vector<std::string>& errors)> IPAddressResultCallbackFunc;
+
+// Asynchronously query the current device's public IP address(es), using a webservice
+// The `resultCallback` may be called on any thread
+void getPublicIPAddress(const IPAddressResultCallbackFunc& resultCallback, bool ipv4 = true, bool ipv6 = true);
+
+void setPublicIPv4LookupService(const std::string& publicIPv4LookupServiceUrl, const std::string& jsonKey);
+const std::string& getPublicIPv4LookupServiceUrl();
+const std::string& getPublicIPv4LookupServiceJSONKey();
+
+void setPublicIPv6LookupService(const std::string& publicIPv6LookupServiceUrl, const std::string& jsonKey);
+const std::string& getPublicIPv6LookupServiceUrl();
+const std::string& getPublicIPv6LookupServiceJSONKey();
+
+#endif // __INCLUDED_WZ_NET_HELPERS_H__

--- a/src/notifications.cpp
+++ b/src/notifications.cpp
@@ -398,7 +398,7 @@ public:
 	bool dismissNotification(float animationSpeed = 1.0f);
 private:
 	bool calculateNotificationWidgetPos();
-	gfx_api::texture* loadImage(const std::string& filename);
+	gfx_api::texture* loadImage(const WZ_Notification_Image& image);
 	void internalDismissNotification(float animationSpeed = 1.0f);
 public:
 	WzCheckboxButton *pOnDoNotShowAgainCheckbox = nullptr;
@@ -647,9 +647,9 @@ W_NOTIFICATION::W_NOTIFICATION(WZ_Queued_Notification* request, W_FORMINIT init 
 	psNotificationOverlayScreen->psForm->attach(psNewNotificationForm);
 
 	// Load the image, if specified
-	if (!request->notification.largeIconPath.empty())
+	if (!request->notification.largeIcon.empty())
 	{
-		pImageTexture = loadImage(request->notification.largeIconPath);
+		pImageTexture = loadImage(request->notification.largeIcon);
 	}
 
 	const int notificationWidth = width();
@@ -821,21 +821,41 @@ gfx_api::texture* makeTexture(int width, int height, const gfx_api::pixel_format
 	return mTexture;
 }
 
-gfx_api::texture* W_NOTIFICATION::loadImage(const std::string &filename)
+gfx_api::texture* W_NOTIFICATION::loadImage(const WZ_Notification_Image& image)
 {
 	gfx_api::texture* pTexture = nullptr;
-	const char *extension = strrchr(filename.c_str(), '.'); // determine the filetype
-	iV_Image image;
-	if (!extension || strcmp(extension, ".png") != 0)
+	iV_Image ivImage;
+	if (!image.imagePath().empty())
 	{
-		debug(LOG_ERROR, "Bad image filename: %s", filename.c_str());
+		const std::string& filename = image.imagePath();
+		const char *extension = strrchr(filename.c_str(), '.'); // determine the filetype
+
+		if (!extension || strcmp(extension, ".png") != 0)
+		{
+			debug(LOG_ERROR, "Bad image filename: %s", filename.c_str());
+			return nullptr;
+		}
+		if (!iV_loadImage_PNG(filename.c_str(), &ivImage))
+		{
+			return nullptr;
+		}
+	}
+	else if (!image.memoryBuffer().empty())
+	{
+		auto result = iV_loadImage_PNG(image.memoryBuffer(), &ivImage);
+		if (!result.noError())
+		{
+			debug(LOG_ERROR, "Failed to load image from memory buffer: %s", result.text.c_str());
+			return nullptr;
+		}
+	}
+	else
+	{
+		// empty or unhandled case
 		return nullptr;
 	}
-	if (iV_loadImage_PNG(filename.c_str(), &image))
-	{
-		pTexture = makeTexture(image.width, image.height, iV_getPixelFormat(&image), image.bmp);
-		iV_unloadImage(&image);
-	}
+	pTexture = makeTexture(ivImage.width, ivImage.height, iV_getPixelFormat(&ivImage), ivImage.bmp);
+	iV_unloadImage(&ivImage);
 	return pTexture;
 }
 

--- a/src/notifications.cpp
+++ b/src/notifications.cpp
@@ -439,6 +439,10 @@ std::unique_ptr<WZ_Queued_Notification> popNextQueuedNotification()
 		{
 			// ignore this notification - remove from the list
 			debug(LOG_GUI, "Ignoring notification: %s", request->notification.displayOptions.uniqueNotificationIdentifier().c_str());
+			if (request->notification.onIgnored)
+			{
+				request->notification.onIgnored(request->notification);
+			}
 			it = notificationQueue.erase(it);
 			continue;
 		}

--- a/src/notifications.cpp
+++ b/src/notifications.cpp
@@ -1236,6 +1236,11 @@ void finishedProcessingNotificationRequest(WZ_Queued_Notification* request, bool
 		notificationPrefs->doNotShowNotificationAgain(request->notification.displayOptions.uniqueNotificationIdentifier());
 	}
 
+	if (request->notification.onDismissed)
+	{
+		request->notification.onDismissed(request->notification, request->wasProgrammaticallyDismissed());
+	}
+
 	// finished with this notification
 	currentNotification.reset(); // at this point request is no longer valid!
 	lastNotificationClosed = realTime;

--- a/src/notifications.h
+++ b/src/notifications.h
@@ -26,6 +26,7 @@
 #include <list>
 #include <memory>
 #include <functional>
+#include <vector>
 
 class WZ_Notification_Display_Options
 {
@@ -87,6 +88,43 @@ private:
 	bool _isOneTimeNotification = false;
 };
 
+class WZ_Notification_Image
+{
+public:
+	enum class ImageType {
+		PNG
+	};
+public:
+	WZ_Notification_Image()
+	: _type(ImageType::PNG)
+	{ }
+
+	explicit WZ_Notification_Image(const char* imagePath, const ImageType& imageType = ImageType::PNG)
+	: _imagePath(imagePath)
+	, _type(imageType)
+	{ }
+	explicit WZ_Notification_Image(const std::string& imagePath, const ImageType& imageType = ImageType::PNG)
+	: _imagePath(imagePath)
+	, _type(imageType)
+	{ }
+	explicit WZ_Notification_Image(const std::vector<unsigned char>& memoryBuffer, const ImageType& imageType = ImageType::PNG)
+	: _memoryBuffer(memoryBuffer)
+	, _type(imageType)
+	{ }
+public:
+	bool empty() const
+	{
+		return _imagePath.empty() && _memoryBuffer.empty();
+	}
+	const std::string& imagePath() const { return _imagePath; }
+	const std::vector<unsigned char>& memoryBuffer() const { return _memoryBuffer; }
+	ImageType imageType() const { return _type; }
+private:
+	std::string _imagePath;
+	std::vector<unsigned char> _memoryBuffer;
+	ImageType _type;
+};
+
 class WZ_Notification; // forward-declare
 
 class WZ_Notification_Action
@@ -122,9 +160,10 @@ public:
 
 	// [Optional properties]:
 
-	// The path to a PNG to be displayed on the right side of the notification.
+	// A PNG to be displayed on the right side of the notification.
 	// (Suggestion: Make sure the PNG is *at least* 72x72 pixels to ensure sharper display on higher resolution screens.)
-	std::string largeIconPath;
+	WZ_Notification_Image largeIcon;
+
 	// Displays an Action button on the notification which calls the handler when clicked.
 	WZ_Notification_Action action;
 	// See: WZ_Notification_Display_Options

--- a/src/notifications.h
+++ b/src/notifications.h
@@ -135,6 +135,8 @@ public:
 	// Called when the notification is dismissed *without* pressing the "Action" button
 	// (i.e. by pressing the "Dismiss" button or dragging it upwards)
 	std::function<void (const WZ_Notification&, bool wasProgrammaticallyDismissed)> onDismissed;
+	// Called if an ignorable notification is ignored / not displayed
+	std::function<void (const WZ_Notification&)> onIgnored;
 public:
 	bool isIgnorable() const { return !displayOptions.uniqueNotificationIdentifier().empty(); }
 };

--- a/src/notifications.h
+++ b/src/notifications.h
@@ -132,6 +132,9 @@ public:
 	// An optional string tag that can be filtered on to cancel / dismiss existing notifications
 	// Multiple notifications can share the same tag, if they ought to be "grouped" for this purpose
 	std::string tag;
+	// Called when the notification is dismissed *without* pressing the "Action" button
+	// (i.e. by pressing the "Dismiss" button or dragging it upwards)
+	std::function<void (const WZ_Notification&, bool wasProgrammaticallyDismissed)> onDismissed;
 public:
 	bool isIgnorable() const { return !displayOptions.uniqueNotificationIdentifier().empty(); }
 };

--- a/src/scores.cpp
+++ b/src/scores.cpp
@@ -55,6 +55,8 @@
 #include "lib/sound/audio_id.h"
 #include "intimage.h"
 
+#include <algorithm>
+
 #define	BAR_CRAWL_TIME	(GAME_TICKS_PER_SEC*3)
 
 #define MT_Y_POS	(MISSIONRES_TITLE_Y  + D_H + 80)
@@ -173,7 +175,7 @@ STAT_BAR	infoBars[] =
 };
 
 // --------------------------------------------------------------------
-static void fillUpStats();
+static void fillUpStats(const END_GAME_STATS_DATA& stats);
 // --------------------------------------------------------------------
 
 /* The present mission data */
@@ -271,6 +273,23 @@ void getAsciiTime(char *psText, unsigned time)
 	}
 }
 
+END_GAME_STATS_DATA	collectEndGameStatsData()
+{
+	END_GAME_STATS_DATA fullStats;
+	fullStats.missionData = missionData;
+
+	for (size_t i = 0; i < DROID_LEVELS; i++)
+	{
+		fullStats.numDroidsPerLevel.push_back(getNumDroidsForLevel(i));
+	}
+
+	fullStats.numUnits = 0;
+	for (DROID *psDroid = apsDroidLists[selectedPlayer]; psDroid; psDroid = psDroid->psNext, fullStats.numUnits++) {}
+	for (DROID *psDroid = mission.apsDroidLists[selectedPlayer]; psDroid; psDroid = psDroid->psNext, fullStats.numUnits++) {}
+
+	return fullStats;
+}
+
 void scoreDataToScreen(WIDGET *psWidget, ScoreDataToScreenCache& cache)
 {
 	int index, x, y, width, height;
@@ -283,7 +302,7 @@ void scoreDataToScreen(WIDGET *psWidget, ScoreDataToScreenCache& cache)
 		audio_PlayTrack(ID_SOUND_BUTTON_CLICK_5);
 	}
 
-	fillUpStats();
+	fillUpStats(collectEndGameStatsData());
 
 	pie_UniTransBoxFill(16 + D_W, MT_Y_POS - 16, pie_GetVideoBufferWidth() - D_W - 16, MT_Y_POS + 256 + 16, WZCOL_SCORE_BOX);
 	iV_Box(16 + D_W, MT_Y_POS - 16, pie_GetVideoBufferWidth() - D_W - 16, MT_Y_POS + 256 + 16, WZCOL_SCORE_BOX_BORDER);
@@ -395,23 +414,17 @@ void scoreDataToScreen(WIDGET *psWidget, ScoreDataToScreenCache& cache)
 }
 
 // -----------------------------------------------------------------------------------
-void	fillUpStats()
+void	fillUpStats(const END_GAME_STATS_DATA& stats)
 {
 	UDWORD	i;
-	UDWORD	maxi, num;
+	UDWORD	maxi;
 	float	scaleFactor;
 	UDWORD	length;
-	UDWORD	numUnits;
-	DROID	*psDroid;
 
 	/* Do rankings first cos they're easier */
 	for (i = 0, maxi = 0; i < DROID_LEVELS; i++)
 	{
-		num = getNumDroidsForLevel(i);
-		if (num > maxi)
-		{
-			maxi = num;
-		}
+		maxi = std::max(maxi, stats.numDroidsPerLevel[i]);
 	}
 
 	/* Make sure we got something */
@@ -427,14 +440,14 @@ void	fillUpStats()
 	/* Scale for percent */
 	for (i = 0; i < DROID_LEVELS; i++)
 	{
-		length = scaleFactor * getNumDroidsForLevel(i);
+		length = scaleFactor * stats.numDroidsPerLevel[i];
 		infoBars[STAT_ROOKIE + i].percent = PERCENT(length, RANK_BAR_WIDTH);
-		infoBars[STAT_ROOKIE + i].number = getNumDroidsForLevel(i);
+		infoBars[STAT_ROOKIE + i].number = stats.numDroidsPerLevel[i];
 	}
 
 	/* Now do the other stuff... */
 	/* Units killed and lost... */
-	maxi = MAX(missionData.unitsLost, missionData.unitsKilled);
+	maxi = MAX(stats.missionData.unitsLost, stats.missionData.unitsKilled);
 	if (maxi == 0)
 	{
 		scaleFactor = 0.f;
@@ -444,13 +457,13 @@ void	fillUpStats()
 		scaleFactor = (float)STAT_BAR_WIDTH / maxi;
 	}
 
-	length = scaleFactor * missionData.unitsLost;
+	length = scaleFactor * stats.missionData.unitsLost;
 	infoBars[STAT_UNIT_LOST].percent = PERCENT(length, STAT_BAR_WIDTH);
-	length = scaleFactor * missionData.unitsKilled;
+	length = scaleFactor * stats.missionData.unitsKilled;
 	infoBars[STAT_UNIT_KILLED].percent = PERCENT(length, STAT_BAR_WIDTH);
 
 	/* Now do the structure losses */
-	maxi = MAX(missionData.strLost, missionData.strKilled);
+	maxi = MAX(stats.missionData.strLost, stats.missionData.strKilled);
 	if (maxi == 0)
 	{
 		scaleFactor = 0.f;
@@ -460,18 +473,15 @@ void	fillUpStats()
 		scaleFactor = (float)STAT_BAR_WIDTH / maxi;
 	}
 
-	length = scaleFactor * missionData.strLost;
+	length = scaleFactor * stats.missionData.strLost;
 	infoBars[STAT_STR_LOST].percent = PERCENT(length, STAT_BAR_WIDTH);
-	length = scaleFactor * missionData.strKilled;
+	length = scaleFactor * stats.missionData.strKilled;
 	infoBars[STAT_STR_BLOWN_UP].percent = PERCENT(length, STAT_BAR_WIDTH);
 
 	/* Finally the force information - need amount of droids as well*/
-	for (psDroid = apsDroidLists[selectedPlayer], numUnits = 0; psDroid; psDroid = psDroid->psNext, numUnits++) {}
 
-	for (psDroid = mission.apsDroidLists[selectedPlayer]; psDroid; psDroid = psDroid->psNext, numUnits++) {}
-
-	maxi = MAX(missionData.unitsBuilt, missionData.strBuilt);
-	maxi = MAX(maxi, numUnits);
+	maxi = MAX(stats.missionData.unitsBuilt, stats.missionData.strBuilt);
+	maxi = MAX(maxi, stats.numUnits);
 
 	if (maxi == 0)
 	{
@@ -482,21 +492,21 @@ void	fillUpStats()
 		scaleFactor = (float)STAT_BAR_WIDTH / maxi;
 	}
 
-	length = scaleFactor * missionData.unitsBuilt;
+	length = scaleFactor * stats.missionData.unitsBuilt;
 	infoBars[STAT_UNITS_BUILT].percent = PERCENT(length, STAT_BAR_WIDTH);
-	length = scaleFactor * numUnits;
+	length = scaleFactor * stats.numUnits;
 	infoBars[STAT_UNITS_NOW].percent = PERCENT(length, STAT_BAR_WIDTH);
-	length = scaleFactor * missionData.strBuilt;
+	length = scaleFactor * stats.missionData.strBuilt;
 	infoBars[STAT_STR_BUILT].percent = PERCENT(length, STAT_BAR_WIDTH);
 
 	/* Finally the numbers themselves */
-	infoBars[STAT_UNIT_LOST].number = missionData.unitsLost;
-	infoBars[STAT_UNIT_KILLED].number = missionData.unitsKilled;
-	infoBars[STAT_STR_LOST].number = missionData.strLost;
-	infoBars[STAT_STR_BLOWN_UP].number = missionData.strKilled;
-	infoBars[STAT_UNITS_BUILT].number =	missionData.unitsBuilt;
-	infoBars[STAT_UNITS_NOW].number = numUnits;
-	infoBars[STAT_STR_BUILT].number = missionData.strBuilt;
+	infoBars[STAT_UNIT_LOST].number = stats.missionData.unitsLost;
+	infoBars[STAT_UNIT_KILLED].number = stats.missionData.unitsKilled;
+	infoBars[STAT_STR_LOST].number = stats.missionData.strLost;
+	infoBars[STAT_STR_BLOWN_UP].number = stats.missionData.strKilled;
+	infoBars[STAT_UNITS_BUILT].number =	stats.missionData.unitsBuilt;
+	infoBars[STAT_UNITS_NOW].number = stats.numUnits;
+	infoBars[STAT_STR_BUILT].number = stats.missionData.strBuilt;
 }
 
 // -----------------------------------------------------------------------------------

--- a/src/scores.h
+++ b/src/scores.h
@@ -21,6 +21,8 @@
 #ifndef __INCLUDED_SRC_SCORES_H__
 #define __INCLUDED_SRC_SCORES_H__
 
+#include <vector>
+
 class WIDGET;
 
 enum DATA_INDEX
@@ -68,6 +70,14 @@ struct STAT_BAR
 	UDWORD	number;			// %d string for the associated text string.
 };
 
+struct END_GAME_STATS_DATA
+{
+	MISSION_DATA missionData;
+	uint32_t maxDroidsPerLevel = 0;
+	std::vector<uint32_t> numDroidsPerLevel = {0};
+	uint32_t numUnits = 0;
+};
+
 enum
 {
 	STAT_UNIT_LOST,
@@ -106,6 +116,7 @@ struct ScoreDataToScreenCache {
 bool scoreInitSystem();
 void scoreUpdateVar(DATA_INDEX var);
 void scoreDataToConsole();
+END_GAME_STATS_DATA	collectEndGameStatsData();
 void scoreDataToScreen(WIDGET *psWidget, ScoreDataToScreenCache& cache);
 void getAsciiTime(char *psText, unsigned time);
 bool readScoreData(const char *fileName);

--- a/src/titleui/gamefind.cpp
+++ b/src/titleui/gamefind.cpp
@@ -40,6 +40,7 @@
 #include "../warzoneconfig.h"
 #include "../frend.h"
 #include "../loadsave.h"			// for blueboxes.
+#include "../activity.h"
 
 struct DisplayRemoteGameHeaderCache
 {
@@ -171,10 +172,13 @@ TITLECODE WzGameFindTitleUI::run()
 	{
 		UDWORD gameNumber = id - GAMES_GAMESTART;
 
+		std::vector<JoinConnectionDescription> connectionDesc = {JoinConnectionDescription(gamesList[gameNumber].desc.host, 0)};
+		ActivityManager::instance().willAttemptToJoinLobbyGame(NETgetMasterserverName(), NETgetMasterserverPort(), gamesList[gameNumber].gameId, connectionDesc);
+
 		// joinGame is quite capable of asking the user for a password, & is decoupled from lobby, so let it take over
 		ingame.localOptionsReceived = false;					// note, we are awaiting options
 		sstrcpy(game.name, gamesList[gameNumber].name);		// store name
-		joinGame(gamesList[gameNumber].desc.host, 0);
+		joinGame(connectionDesc);
 		return TITLECODE_CONTINUE;
 	}
 

--- a/src/titleui/titleui.h
+++ b/src/titleui/titleui.h
@@ -139,6 +139,7 @@ class WzGameFindTitleUI: public WzTitleUI
 {
 public:
 	WzGameFindTitleUI();
+	~WzGameFindTitleUI();
 	virtual void start() override;
 	virtual TITLECODE run() override;
 private:

--- a/src/updatemanager.cpp
+++ b/src/updatemanager.cpp
@@ -253,7 +253,7 @@ WzUpdateManager::ProcessResult WzUpdateManager::processUpdateJSONFile(const json
 								}
 							});
 						});
-						notification.largeIconPath = "images/warzone2100.png";
+						notification.largeIcon = WZ_Notification_Image("images/warzone2100.png");
 						if (notificationInfo.is_object())
 						{
 							const auto& notificationBase = notificationInfo["base"];

--- a/src/updatemanager.cpp
+++ b/src/updatemanager.cpp
@@ -132,7 +132,7 @@ bool WzUpdateManager::isValidExpiry(const json& updateData)
 {
 	if (!updateData.is_object())
 	{
-		wzAsyncExecOnMainThread([]{ debug(LOG_ERROR, "Update data is not an object"); });
+		wzAsyncExecOnMainThread([]{ debug(LOG_WARNING, "Update data is not an object"); });
 		return false;
 	}
 	if (!updateData.contains("validThru")) { return false; }
@@ -158,13 +158,13 @@ WzUpdateManager::ProcessResult WzUpdateManager::processUpdateJSONFile(const json
 {
 	if (!updateData.is_object())
 	{
-		wzAsyncExecOnMainThread([]{ debug(LOG_ERROR, "Update data is not an object"); });
+		wzAsyncExecOnMainThread([]{ debug(LOG_WARNING, "Update data is not an object"); });
 		return ProcessResult::INVALID_JSON;
 	}
 	const auto& channels = updateData["channels"];
 	if (!channels.is_array())
 	{
-		wzAsyncExecOnMainThread([]{ debug(LOG_ERROR, "Channels should be an array"); });
+		wzAsyncExecOnMainThread([]{ debug(LOG_WARNING, "Channels should be an array"); });
 		return ProcessResult::INVALID_JSON;
 	}
 	BuildPropertyProvider buildPropProvider;
@@ -232,7 +232,7 @@ WzUpdateManager::ProcessResult WzUpdateManager::processUpdateJSONFile(const json
 					updateLink = configureUpdateLinkURL(updateLink, buildPropProvider);
 					// submit notification (on main thread)
 					wzAsyncExecOnMainThread([validSignature, channelNameStr, releaseVersionStr, notificationInfo, updateLink]{
-						debug(LOG_ERROR, "Found an available update (%s) in channel (%s)", releaseVersionStr.c_str(), channelNameStr.c_str());
+						debug(LOG_INFO, "Found an available update (%s) in channel (%s)", releaseVersionStr.c_str(), channelNameStr.c_str());
 						WZ_Notification notification;
 						notification.duration = 0;
 						notification.contentTitle = _("Update Available");
@@ -387,7 +387,7 @@ void WzUpdateManager::initUpdateCheck()
 		if (httpStatusCode != 200)
 		{
 			wzAsyncExecOnMainThread([httpStatusCode]{
-				debug(LOG_ERROR, "Update check returned HTTP status code: %ld", httpStatusCode);
+				debug(LOG_WARNING, "Update check returned HTTP status code: %ld", httpStatusCode);
 			});
 			return;
 		}

--- a/src/updatemanager.cpp
+++ b/src/updatemanager.cpp
@@ -448,14 +448,14 @@ void WzUpdateManager::initUpdateCheck()
 		{
 			case URLRequestFailureType::INITIALIZE_REQUEST_ERROR:
 				wzAsyncExecOnMainThread([]{
-					debug(LOG_ERROR, "Failed to initialize request for update check");
+					debug(LOG_WARNING, "Failed to initialize request for update check");
 				});
 				break;
 			case URLRequestFailureType::TRANSFER_FAILED:
 				if (!transferDetails.has_value())
 				{
 					wzAsyncExecOnMainThread([]{
-						debug(LOG_ERROR, "Update check request failed - but no transfer failure details provided!");
+						debug(LOG_WARNING, "Update check request failed - but no transfer failure details provided!");
 					});
 				}
 				else
@@ -463,13 +463,18 @@ void WzUpdateManager::initUpdateCheck()
 					CURLcode result = transferDetails->curlResult();
 					long httpStatusCode = transferDetails->httpStatusCode();
 					wzAsyncExecOnMainThread([result, httpStatusCode]{
-						debug(LOG_ERROR, "Update check request failed with error %d, and HTTP response code: %ld", result, httpStatusCode);
+						debug(LOG_WARNING, "Update check request failed with error %d, and HTTP response code: %ld", result, httpStatusCode);
 					});
 				}
 				break;
+			case URLRequestFailureType::CANCELLED:
+				wzAsyncExecOnMainThread([url]{
+					debug(LOG_INFO, "Update check was cancelled");
+				});
+				break;
 			case URLRequestFailureType::CANCELLED_BY_SHUTDOWN:
 				wzAsyncExecOnMainThread([url]{
-					debug(LOG_ERROR, "Update check was cancelled by application shutdown");
+					debug(LOG_WARNING, "Update check was cancelled by application shutdown");
 				});
 				break;
 		}

--- a/src/urlrequest.cpp
+++ b/src/urlrequest.cpp
@@ -1178,10 +1178,10 @@ void urlSelectSSLBackend()
 	}
 	else
 	{
-		debug(LOG_ERROR, "cURL has no available thread-safe SSL backends to configure");
+		debug(LOG_INFO, "cURL has no available thread-safe SSL backends to configure");
 		for (const auto& ignoredBackend : ignoredBackends)
 		{
-			debug(LOG_ERROR, "(Ignored backend: %d (build did not permit thread-safe configuration)", ignoredBackend);
+			debug(LOG_INFO, "(Ignored backend: %d (build did not permit thread-safe configuration)", ignoredBackend);
 		}
 	}
 #else

--- a/src/warzoneconfig.cpp
+++ b/src/warzoneconfig.cpp
@@ -33,6 +33,7 @@
 #include "display.h"
 #include "keybind.h"
 #include "radar.h"
+#include "activity.h"
 
 /***************************************************************************/
 
@@ -79,6 +80,7 @@ void war_SetSPcolor(int color)
 	}
 	warGlobs.SPcolor = color;
 	setPlayerColour(0, color);
+	ActivityManager::instance().changedSetting("SPcolor", std::to_string(color));
 }
 
 int8_t war_GetSPcolor()
@@ -89,6 +91,7 @@ int8_t war_GetSPcolor()
 void war_setMPcolour(int colour)
 {
 	warGlobs.MPcolour = colour;
+	ActivityManager::instance().changedSetting("MPcolour", std::to_string(colour));
 }
 
 int war_getMPcolour()
@@ -113,6 +116,7 @@ void war_setAntialiasing(int antialiasing)
 		debug(LOG_WARNING, "Antialising set to value > 16, which can cause crashes.");
 	}
 	warGlobs.antialiasing = antialiasing;
+	ActivityManager::instance().changedSetting("antialiasing", std::to_string(antialiasing));
 }
 
 int war_getAntialiasing()
@@ -123,6 +127,7 @@ int war_getAntialiasing()
 void war_SetTrapCursor(bool b)
 {
 	warGlobs.trapCursor = b;
+	ActivityManager::instance().changedSetting("trapCursor", std::to_string(b));
 }
 
 bool war_GetTrapCursor()
@@ -148,6 +153,7 @@ unsigned int war_GetDisplayScale()
 void war_SetDisplayScale(unsigned int scale)
 {
 	warGlobs.displayScale = scale;
+	ActivityManager::instance().changedSetting("displayScale", std::to_string(scale));
 }
 
 void war_SetWidth(UDWORD width)
@@ -205,6 +211,7 @@ SCANLINE_MODE war_getScanlineMode()
 void war_SetPauseOnFocusLoss(bool enabled)
 {
 	warGlobs.pauseOnFocusLoss = enabled;
+	ActivityManager::instance().changedSetting("pauseOnFocusLoss", std::to_string(enabled));
 }
 
 bool war_GetPauseOnFocusLoss()
@@ -215,6 +222,7 @@ bool war_GetPauseOnFocusLoss()
 void war_SetColouredCursor(bool enabled)
 {
 	warGlobs.ColouredCursor = enabled;
+	ActivityManager::instance().changedSetting("ColouredCursor", std::to_string(enabled));
 }
 
 bool war_GetColouredCursor()
@@ -225,6 +233,7 @@ bool war_GetColouredCursor()
 void war_setSoundEnabled(bool soundEnabled)
 {
 	warGlobs.soundEnabled = soundEnabled;
+	ActivityManager::instance().changedSetting("soundEnabled", std::to_string(soundEnabled));
 }
 
 bool war_getSoundEnabled()
@@ -240,6 +249,7 @@ bool war_GetMusicEnabled()
 void war_SetMusicEnabled(bool enabled)
 {
 	warGlobs.MusicEnabled = enabled;
+	ActivityManager::instance().changedSetting("musicEnabled", std::to_string(enabled));
 }
 
 HRTFMode war_GetHRTFMode()
@@ -250,6 +260,7 @@ HRTFMode war_GetHRTFMode()
 void war_SetHRTFMode(HRTFMode mode)
 {
 	warGlobs.hrtfMode = mode;
+	ActivityManager::instance().changedSetting("hrtfMode", std::to_string(static_cast<typename std::underlying_type<HRTFMode>::type>(mode)));
 }
 
 int war_GetMapZoom()
@@ -262,6 +273,7 @@ void war_SetMapZoom(int mapZoom)
 	if (mapZoom % MAP_ZOOM_RATE_MIN == 0 && ! (mapZoom < MINDISTANCE_CONFIG || mapZoom > MAXDISTANCE))
 	{
 		warGlobs.mapZoom = mapZoom;
+		ActivityManager::instance().changedSetting("mapZoom", std::to_string(mapZoom));
 	}
 }
 
@@ -275,6 +287,7 @@ void war_SetMapZoomRate(int mapZoomRate)
 	if (mapZoomRate % MAP_ZOOM_RATE_STEP == 0 && ! (mapZoomRate < MAP_ZOOM_RATE_MIN || mapZoomRate > MAP_ZOOM_RATE_MAX))
 	{
 		warGlobs.mapZoomRate = mapZoomRate;
+		ActivityManager::instance().changedSetting("mapZoomRate", std::to_string(mapZoomRate));
 	}
 }
 
@@ -288,6 +301,7 @@ void war_SetRadarZoom(int radarZoom)
 	if (radarZoom % RADARZOOM_STEP == 0 && ! (radarZoom < MIN_RADARZOOM || radarZoom > MAX_RADARZOOM))
 	{
 		warGlobs.radarZoom = radarZoom;
+		ActivityManager::instance().changedSetting("radarZoom", std::to_string(radarZoom));
 	}
 }
 
@@ -301,6 +315,7 @@ void war_SetCameraSpeed(int cameraSpeed)
 	if (cameraSpeed % CAMERASPEED_STEP == 0 && ! (cameraSpeed < CAMERASPEED_MIN || cameraSpeed > CAMERASPEED_MAX))
 	{
 		warGlobs.cameraSpeed = cameraSpeed;
+		ActivityManager::instance().changedSetting("cameraSpeed", std::to_string(cameraSpeed));
 	}
 }
 
@@ -322,4 +337,5 @@ bool war_GetRadarJump()
 void war_SetRadarJump(bool radarJump)
 {
 	warGlobs.radarJump = radarJump;
+	ActivityManager::instance().changedSetting("radarJump", std::to_string(radarJump));
 }


### PR DESCRIPTION
#### Highlights:
- Add `ActivityManager`
   - `ActivityManager` accepts numerous event callbacks from the core game and synthesizes a (more) sensible stream of higher-level event callbacks to subscribed `ActivitySink`s.
   - Now, instead of adding more code strewn throughout the codebase to react to major game state changes (and duplicate code to handle oddities of how the game stores / transitions state), it's possible to implement and register an `ActivitySink` subclass.
- Improvements to IPv6 support
- Additional callbacks in `WZ_Notification`
- Support for cancelling asynchronous urlRequests
- Refactored a few functions so their core functionality is useful elsewhere in the codebase
- If `SOCK_CLOEXEC` is not available, set `FD_CLOEXEC` (or `HANDLE_FLAG_INHERIT` on Windows)