### PR TITLE
Give half-track propulsion movement sound.

### DIFF
--- a/data/base/stats/propulsionsounds.json
+++ b/data/base/stats/propulsionsounds.json
@@ -1,4 +1,12 @@
 {
+    "Half-Tracked": {
+        "szHiss": -1,
+        "szIdle": -1,
+        "szMove": "tread.ogg",
+        "szMoveOff": -1,
+        "szShutDown": "con-shut-down.ogg",
+        "szStart": -1
+    },
     "Hover": {
         "szHiss": -1,
         "szIdle": -1,

--- a/data/mp/stats/propulsionsounds.json
+++ b/data/mp/stats/propulsionsounds.json
@@ -1,4 +1,12 @@
 {
+    "Half-Tracked": {
+        "szHiss": -1,
+        "szIdle": -1,
+        "szMove": "tread.ogg",
+        "szMoveOff": -1,
+        "szShutDown": "con-shut-down.ogg",
+        "szStart": -1
+    },
     "Hover": {
         "szHiss": -1,
         "szIdle": -1,


### PR DESCRIPTION
Half-tracks now make sound when they move. Sounds like treads but with the wheels shutdown sound. Apparently, using the start sound that wheels uses somehow distorts the tracks movement sound so I didn't include that here. Which probably means the start sound keeps playing for the duration of unit movement.

Originally noted in [ticket 4181](http://developer.wz2100.net/ticket/4181).

Fixes #866 