### PR TITLE
allow half transparent structure bases

### DIFF
--- a/src/display3d.cpp
+++ b/src/display3d.cpp
@@ -2344,7 +2344,6 @@ void renderStructure(STRUCTURE *psStructure, const glm::mat4 &viewMatrix)
 		{
 			if (structureIsBlueprint(psStructure))
 			{
-				pieFlag = pie_TRANSLUCENT;
 				pieFlagData = BLUEPRINT_OPACITY;
 			}
 			else
@@ -2352,6 +2351,7 @@ void renderStructure(STRUCTURE *psStructure, const glm::mat4 &viewMatrix)
 				pieFlag = pie_FORCE_FOG | ecmFlag;
 				pieFlagData = 255;
 			}
+			pieFlag |= pie_TRANSLUCENT;
 			pie_Draw3DShape(psStructure->pStructureType->pBaseIMD, 0, colour, buildingBrightness, pieFlag, pieFlagData,
 				viewMatrix * modelMatrix);
 		}

--- a/src/display3d.cpp
+++ b/src/display3d.cpp
@@ -2283,7 +2283,7 @@ static void renderStructureTurrets(STRUCTURE *psStructure, iIMDShape *strImd, PI
 /// Draw the structures
 void renderStructure(STRUCTURE *psStructure, const glm::mat4 &viewMatrix)
 {
-	int colour, pieFlag, pieFlagData, ecmFlag = 0;
+	int colour, pieFlagData, ecmFlag = 0, pieFlag = 0;
 	PIELIGHT buildingBrightness;
 	const Vector3i dv = Vector3i(psStructure->pos.x - player.p.x, psStructure->pos.z, -(psStructure->pos.y - player.p.z));
 	bool bHitByElectronic = false;

--- a/src/display3d.cpp
+++ b/src/display3d.cpp
@@ -2351,8 +2351,7 @@ void renderStructure(STRUCTURE *psStructure, const glm::mat4 &viewMatrix)
 				pieFlag = pie_FORCE_FOG | ecmFlag;
 				pieFlagData = 255;
 			}
-			pieFlag |= pie_TRANSLUCENT;
-			pie_Draw3DShape(psStructure->pStructureType->pBaseIMD, 0, colour, buildingBrightness, pieFlag, pieFlagData,
+			pie_Draw3DShape(psStructure->pStructureType->pBaseIMD, 0, colour, buildingBrightness, pieFlag | pie_TRANSLUCENT, pieFlagData,
 				viewMatrix * modelMatrix);
 		}
 


### PR DESCRIPTION

![grafik](https://user-images.githubusercontent.com/17467758/83021549-775ee600-a02a-11ea-9845-c7b26a4cb0a4.png)
> aliswe: I believe adding that flag will not affect rendering in any way other than enabling alpha?
> aliswe: If you can, create a separate PR for that
> aliswe: it should IMO be able possible to merge it directly

That PR will affect only new base textures, because the old don't use alpha