### PR TITLE
Use setCampaignNumber() in multiplayer rules.js too.

### DIFF
--- a/data/mp/multiplay/skirmish/rules.js
+++ b/data/mp/multiplay/skirmish/rules.js
@@ -220,14 +220,20 @@ function setupGame()
 	//Use light fog for multiplayer
 	setRevealStatus(true);
 
-	if (tilesetType == "URBAN")
+	if (tilesetType == "ARIZONA")
 	{
+		setCampaignNumber(1);
+	}
+	else if (tilesetType == "URBAN")
+	{
+		setCampaignNumber(2);
 		replaceTexture("page-8-player-buildings-bases.png", "page-8-player-buildings-bases-urban.png");
 		replaceTexture("page-9-player-buildings-bases.png", "page-9-player-buildings-bases-urban.png");
 		replaceTexture("page-7-barbarians-arizona.png", "page-7-barbarians-urban.png");
 	}
 	else if (tilesetType == "ROCKIES")
 	{
+		setCampaignNumber(3);
 		replaceTexture("page-8-player-buildings-bases.png", "page-8-player-buildings-bases-rockies.png");
 		replaceTexture("page-9-player-buildings-bases.png", "page-9-player-buildings-bases-rockies.png");
 		replaceTexture("page-7-barbarians-arizona.png", "page-7-barbarians-kevlar.png");


### PR DESCRIPTION
Prevents the radar viewing window staying green when switching from Gamma to skirmish/multiplayer games.

Additionally, because this function affects the radar trapezoid color in `setViewingWindow()`, skirmish/multiplayer will have the green color for all Rockies maps like the campaign has. Why Arizona and Urban share the same color, I don't know, however maybe Urban could use a bit of blue? For another time I suppose.