### PR TITLE
Adjust height tracking logic (option 2)

### DIFF
--- a/src/display3d.cpp
+++ b/src/display3d.cpp
@@ -3389,6 +3389,7 @@ static void renderSurroundings(const glm::mat4 &viewMatrix)
 /// Smoothly adjust player height to match the desired height
 static void trackHeight(float desiredHeight)
 {
+	desiredHeight = std::ceil(desiredHeight / HEIGHT_TRACK_INCREMENTS) * HEIGHT_TRACK_INCREMENTS;
 	static float heightSpeed = 0.0f;
 	float separation = desiredHeight - player.p.y;	// How far are we from desired height?
 

--- a/src/display3d.cpp
+++ b/src/display3d.cpp
@@ -94,7 +94,7 @@ static void displayStaticObjects(const glm::mat4 &viewMatrix);
 static void displayFeatures(const glm::mat4 &viewMatrix);
 static UDWORD	getTargettingGfx();
 static void	drawDroidGroupNumber(DROID *psDroid);
-static void	trackHeight(float desiredHeight);
+static void	trackHeight(int desiredHeight);
 static void	renderSurroundings(const glm::mat4 &viewMatrix);
 static void	locateMouse();
 static bool	renderWallSection(STRUCTURE *psStructure, const glm::mat4 &viewMatrix);
@@ -3394,17 +3394,25 @@ static void renderSurroundings(const glm::mat4 &viewMatrix)
 }
 
 /// Smoothly adjust player height to match the desired height
-static void trackHeight(float desiredHeight)
+static void trackHeight(int desiredHeight)
 {
-	desiredHeight = std::ceil(desiredHeight / HEIGHT_TRACK_INCREMENTS) * HEIGHT_TRACK_INCREMENTS;
 	static float heightSpeed = 0.0f;
+
+	desiredHeight = static_cast<int>(std::ceil(static_cast<float>(desiredHeight) / static_cast<float>(HEIGHT_TRACK_INCREMENTS))) * HEIGHT_TRACK_INCREMENTS;
+
+	if ((desiredHeight == player.p.y) && ((heightSpeed > -5.f) && (heightSpeed < 5.f)))
+	{
+		heightSpeed = 0.0f;
+		return;
+	}
+
 	float separation = desiredHeight - player.p.y;	// How far are we from desired height?
 
 	// d²/dt² player.p.y = -ACCEL_CONSTANT * (player.p.y - desiredHeight) - VELOCITY_CONSTANT * d/dt player.p.y
 	solveDifferential2ndOrder(&separation, &heightSpeed, ACCEL_CONSTANT, VELOCITY_CONSTANT, realTimeAdjustedIncrement(1));
 
 	/* Adjust the height accordingly */
-	player.p.y = desiredHeight - separation;
+	player.p.y = desiredHeight - static_cast<int>(std::trunc(separation));
 }
 
 /// Select the next energy bar display mode

--- a/src/display3d.cpp
+++ b/src/display3d.cpp
@@ -1873,7 +1873,11 @@ void setViewPos(UDWORD x, UDWORD y, WZ_DECL_UNUSED bool Pan)
 	player.r.z = 0;
 	
 	calcAverageTerrainHeight(&player);
-	player.p.y = averageCentreTerrainHeight + CAMERA_PIVOT_HEIGHT - HEIGHT_TRACK_INCREMENTS;
+
+	if(player.p.y < averageCentreTerrainHeight)
+	{
+		player.p.y = averageCentreTerrainHeight + CAMERA_PIVOT_HEIGHT - HEIGHT_TRACK_INCREMENTS;
+	}
 
 	if (getWarCamStatus())
 	{

--- a/src/display3d.cpp
+++ b/src/display3d.cpp
@@ -1871,6 +1871,9 @@ void setViewPos(UDWORD x, UDWORD y, WZ_DECL_UNUSED bool Pan)
 	player.p.x = world_coord(x);
 	player.p.z = world_coord(y);
 	player.r.z = 0;
+	
+	calcAverageTerrainHeight(&player);
+	player.p.y = averageCentreTerrainHeight + CAMERA_PIVOT_HEIGHT - HEIGHT_TRACK_INCREMENTS;
 
 	if (getWarCamStatus())
 	{

--- a/src/display3d.h
+++ b/src/display3d.h
@@ -28,6 +28,8 @@
 #include "objectdef.h"
 #include "message.h"
 
+#define HEIGHT_TRACK_INCREMENTS (250)
+
 /*!
  * Special tile types
  */

--- a/src/display3d.h
+++ b/src/display3d.h
@@ -28,7 +28,7 @@
 #include "objectdef.h"
 #include "message.h"
 
-#define HEIGHT_TRACK_INCREMENTS (250)
+#define HEIGHT_TRACK_INCREMENTS (50)
 
 /*!
  * Special tile types

--- a/src/keybind.cpp
+++ b/src/keybind.cpp
@@ -1528,8 +1528,6 @@ void	kf_ToggleProximitys()
 // --------------------------------------------------------------------------
 void	kf_JumpToResourceExtractor()
 {
-	int xJump, yJump;
-
 	if (psOldRE && (STRUCTURE *)psOldRE->psNextFunc)
 	{
 		psOldRE = psOldRE->psNextFunc;
@@ -1541,10 +1539,6 @@ void	kf_JumpToResourceExtractor()
 
 	if (psOldRE)
 	{
-		xJump = psOldRE->pos.x;
-		yJump = psOldRE->pos.y;
-		player.p.x = xJump;
-		player.p.z = yJump;
 		player.r.y = 0; // face north
 		setViewPos(map_coord(psOldRE->pos.x), map_coord(psOldRE->pos.y), true);
 	}


### PR DESCRIPTION
A second attempt, building on part of the work in #789, but keeping the use of `solveDifferential2ndOrder`, and the current more "floaty" easing of height adjustments.

@bjorn-ali-goransson: Let me know what you think. I think this (largely) avoids the annoying 1 unit intermittent height adjustment problem.