### PR TITLE
Tweaks to error / warning handling

### DIFF
--- a/lib/gamelib/audp_lexer.cpp
+++ b/lib/gamelib/audp_lexer.cpp
@@ -1,6 +1,28 @@
+/*
+	This file is part of Warzone 2100.
+	Copyright (C) 2005-2020  Warzone 2100 Project
+
+	Warzone 2100 is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+
+	Warzone 2100 is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with Warzone 2100; if not, write to the Free Software
+	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+*/
 
 #if defined(__clang__)
 	#pragma clang diagnostic ignored "-Wunneeded-internal-declaration" // warning: function 'yyinput' is not needed and will not be emitted
+#elif defined(__GNUC__)
+	#if 7 <= __GNUC__
+		#pragma GCC diagnostic ignored "-Wnull-dereference"
+	#endif
 #endif
 
 #line 3 "lex.audp_.c"

--- a/lib/ivis_opengl/screen.cpp
+++ b/lib/ivis_opengl/screen.cpp
@@ -526,6 +526,18 @@ void screen_SetRandomBackdrop(const char *dirname, const char *basename)
 	}
 	PHYSFS_freeList(rc);
 
+	if (names.empty())
+	{
+		std::string searchPath = dirname;
+		if (!searchPath.empty() && searchPath.back() != '/')
+		{
+			searchPath += "/";
+		}
+		debug(LOG_FATAL, "Missing files: \"%s%s*\" - data files / folders may be corrupt.", searchPath.c_str(), basename);
+		abort();
+		return;
+	}
+
 	// pick a random name from our vector of names
 	int ran = rand() % names.size();
 	std::string full_path = std::string(dirname) + names[ran];


### PR DESCRIPTION
- Add explicit error handling for missing backdrops
   - Instead of failing with:
   > "SIGFPE: Erroneous arithmetic operation: Integer divide by zero"
   - Fixes crash mentioned in #845
- audp_lexer.cpp: Silence GCC warning (for now)
   - Should fix #788