### PR TITLE
[BUGFIX] Issue #871 "Cannot build. Resource burning" will pop up for …

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,9 @@ endif()
 
 # CXX Standard
 if(MSVC)
+	# MSVC doesn't support enforcing c++11 - the minimum it will allow is c++14
+	# See https://docs.microsoft.com/en-us/cpp/build/reference/std-specify-language-standard-version
+	# However, avoid using any features not supported by c++11 or the build will fail on other platforms.
 	set(CMAKE_CXX_STANDARD 14)
 else()
 	set(CMAKE_CXX_STANDARD 11)

--- a/src/console.cpp
+++ b/src/console.cpp
@@ -173,16 +173,16 @@ void	toggleConsoleDrop()
 bool addConsoleMessageDebounced(const char * Text, CONSOLE_TEXT_JUSTIFICATION jusType, SDWORD player, const DEBOUNCED_MESSAGE & message, bool team, UDWORD duration)
 {
 	// Messages are debounced individually - one debounced message won't stop a different one from appearing
-	static std::map<const DEBOUNCED_MESSAGE *, std::chrono::milliseconds> nextAllowedMessageTimes;
+	static std::map<const DEBOUNCED_MESSAGE *, std::chrono::steady_clock::time_point> lastAllowedMessageTimes;
 
 	const std::chrono::milliseconds DEBOUNCE_TIME(message.debounceTime);
-	const std::chrono::milliseconds now = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now().time_since_epoch());
+	const std::chrono::steady_clock::time_point now = std::chrono::steady_clock::now();
 
-	const auto nextAllowedMessageTime = nextAllowedMessageTimes.find(&message);
+	const auto lastAllowedMessageTime = lastAllowedMessageTimes.find(&message);
 
-	if (nextAllowedMessageTime == nextAllowedMessageTimes.end() || now > nextAllowedMessageTime->second)
+	if (lastAllowedMessageTime == lastAllowedMessageTimes.end() || std::chrono::duration_cast<std::chrono::milliseconds>(now - lastAllowedMessageTime->second) >= DEBOUNCE_TIME)
 	{
-		nextAllowedMessageTimes[&message] = now + DEBOUNCE_TIME;
+		lastAllowedMessageTimes[&message] = now;
 		return addConsoleMessage(Text, jusType, player, team, duration);
 	}
 	else

--- a/src/console.cpp
+++ b/src/console.cpp
@@ -40,6 +40,7 @@
 #include <istream>
 #include <sstream>
 #include <deque>
+#include <chrono>
 
 // FIXME: When we switch over to full JS, use class version of this file
 
@@ -166,6 +167,27 @@ void	toggleConsoleDrop()
 		// play closing sound
 		audio_PlayTrack(ID_SOUND_WINDOWCLOSE);
 		bConsoleDropped = false;
+	}
+}
+
+bool addConsoleMessageDebounced(const char * Text, CONSOLE_TEXT_JUSTIFICATION jusType, SDWORD player, const DEBOUNCED_MESSAGE & message, bool team, UDWORD duration)
+{
+	// Messages are debounced individually - one debounced message won't stop a different one from appearing
+	static std::map<const DEBOUNCED_MESSAGE *, std::chrono::milliseconds> nextAllowedMessageTimes;
+
+	const std::chrono::milliseconds DEBOUNCE_TIME(message.debounceTime);
+	const std::chrono::milliseconds now = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now().time_since_epoch());
+
+	const auto nextAllowedMessageTime = nextAllowedMessageTimes.find(&message);
+
+	if (nextAllowedMessageTime == nextAllowedMessageTimes.end() || now > nextAllowedMessageTime->second)
+	{
+		nextAllowedMessageTimes[&message] = now + DEBOUNCE_TIME;
+		return addConsoleMessage(Text, jusType, player, team, duration);
+	}
+	else
+	{
+		return false;
 	}
 }
 

--- a/src/console.h
+++ b/src/console.h
@@ -33,6 +33,17 @@ enum CONSOLE_TEXT_JUSTIFICATION
 	CENTRE_JUSTIFY
 };
 
+// Declare any messages that you want to be debounced here, along with their debounce time.
+// This has to be done as a 1-member struct rather than an enum to allow distinguishing
+// between different mesages with the same bounce time.
+struct DEBOUNCED_MESSAGE
+{
+	unsigned int debounceTime;
+};
+
+const DEBOUNCED_MESSAGE CANNOT_BUILD_BURNING({2500});
+
+
 /* ID to use for addConsoleMessage() in case of a system message */
 #define	SYSTEM_MESSAGE				(-1)
 #define NOTIFY_MESSAGE				(-2)	// mainly used for lobby & error messages
@@ -44,6 +55,7 @@ enum CONSOLE_TEXT_JUSTIFICATION
 extern char ConsoleString[MAX_CONSOLE_TMP_STRING_LENGTH];
 
 bool addConsoleMessage(const char *Text, CONSOLE_TEXT_JUSTIFICATION jusType, SDWORD player, bool team = false, UDWORD duration = DEFAULT_CONSOLE_MESSAGE_DURATION);
+bool addConsoleMessageDebounced(const char* Text, CONSOLE_TEXT_JUSTIFICATION jusType, SDWORD player, const DEBOUNCED_MESSAGE & debouncedMessage, bool team = false, UDWORD duration = DEFAULT_CONSOLE_MESSAGE_DURATION);
 void updateConsoleMessages();
 void initConsoleMessages();
 void removeTopConsoleMessage();

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -1528,8 +1528,10 @@ bool ctrlShiftDown()
 
 void AddDerrickBurningMessage()
 {
-	addConsoleMessage(_("Cannot Build. Oil Resource Burning."), DEFAULT_JUSTIFY, SYSTEM_MESSAGE);
-	audio_PlayTrack(ID_SOUND_BUILD_FAIL);
+	if (addConsoleMessageDebounced(_("Cannot Build. Oil Resource Burning."), DEFAULT_JUSTIFY, SYSTEM_MESSAGE, CANNOT_BUILD_BURNING))
+	{
+		audio_PlayTrack(ID_SOUND_BUILD_FAIL);
+	}
 }
 
 static void printDroidClickInfo(DROID *psDroid)


### PR DESCRIPTION
…each selected truck

https://github.com/Warzone2100/warzone2100/issues/871

I've gone with a general function to debounce specific console messages, starting with the
burning message. Any other messages that need debounced can be done the same way.

The intent is to debounce each message individually, but there's nothing preventing adding
a generic debounce time and using it for multiple message types.