### PR TITLE
[BUGFIX] Issue #795 Atmospheric effects should respect game time slowdown

### DIFF
--- a/lib/framework/rational.h
+++ b/lib/framework/rational.h
@@ -26,7 +26,7 @@
 #define RATIONAL_H
 
 #include <algorithm>
-
+#include <cmath>
 
 static inline int gcd(int a, int b)
 {
@@ -116,6 +116,17 @@ struct Rational
 	int ceil() const
 	{
 		return n >= 0 ? (n + (d - 1)) / d : n / d;
+	}
+
+	// We can't do this with a operator as it ambiguates the comparison operators
+	double asDouble() const
+	{
+		if (0 == d)
+		{
+			return nan("");
+		}
+
+		return (double)n / (double)d;
 	}
 
 	// If int16_t isn't big enough, the comparison operations might overflow.

--- a/lib/gamelib/gtime.cpp
+++ b/lib/gamelib/gtime.cpp
@@ -26,7 +26,6 @@
 
 #include "lib/framework/frame.h"
 #include "lib/framework/wzapp.h"
-#include "lib/framework/rational.h"
 #include "lib/framework/math_ext.h"
 #include "gtime.h"
 #include "src/multiplay.h"

--- a/lib/gamelib/gtime.h
+++ b/lib/gamelib/gtime.h
@@ -25,10 +25,10 @@
 #define _gtime_h
 
 #include "lib/framework/vector.h"
+#include "lib/framework/rational.h"
 
 
 struct NETQUEUE;
-struct Rational;
 
 /// The number of time units per second of the game clock.
 #define GAME_TICKS_PER_SEC 1000

--- a/src/atmos.cpp
+++ b/src/atmos.cpp
@@ -34,7 +34,7 @@
 #include "map.h"
 #include "miscimd.h"
 #include "lib/gamelib/gtime.h"
-#include <math.h>
+#include <cmath>
 
 #ifndef GLM_ENABLE_EXPERIMENTAL
 	#define GLM_ENABLE_EXPERIMENTAL

--- a/src/atmos.cpp
+++ b/src/atmos.cpp
@@ -268,7 +268,7 @@ void atmosUpdateSystem()
 		static double accumulatedParticlesToAdd = 0.0;
 
 		double gameTimeModVal = gameTimeGetMod().asDouble();
-		if (!isnan(gameTimeModVal))
+		if (!std::isnan(gameTimeModVal))
 		{
 			accumulatedParticlesToAdd += ((weather == WT_SNOWING) ? 2.0 : 4.0) * gameTimeModVal;
 		}

--- a/src/atmos.cpp
+++ b/src/atmos.cpp
@@ -33,6 +33,7 @@
 #include "loop.h"
 #include "map.h"
 #include "miscimd.h"
+#include "lib/gamelib/gtime.h"
 
 #ifndef GLM_ENABLE_EXPERIMENTAL
 	#define GLM_ENABLE_EXPERIMENTAL
@@ -261,8 +262,14 @@ void atmosUpdateSystem()
 			}
 		}
 
-		/* This bit below needs to go into a "precipitation function" */
-		numberToAdd = ((weather == WT_SNOWING) ? 2 : 4);
+		// The original code added a fixed number of particles per tick. To take into account game speed
+		// we have to accumulate a fractional number of particles to add them at a slower or faster rate.
+		static double accumulatedParticlesToAdd = 0.0;
+
+		accumulatedParticlesToAdd += ((weather == WT_SNOWING) ? 2.0 : 4.0) * gameTimeGetMod().asDouble();
+
+		numberToAdd = accumulatedParticlesToAdd;
+		accumulatedParticlesToAdd -= numberToAdd;
 
 		/* Temporary stuff - just adds a few particles! */
 		for (i = 0; i < numberToAdd; i++)

--- a/src/atmos.cpp
+++ b/src/atmos.cpp
@@ -34,6 +34,7 @@
 #include "map.h"
 #include "miscimd.h"
 #include "lib/gamelib/gtime.h"
+#include <math.h>
 
 #ifndef GLM_ENABLE_EXPERIMENTAL
 	#define GLM_ENABLE_EXPERIMENTAL
@@ -266,7 +267,11 @@ void atmosUpdateSystem()
 		// we have to accumulate a fractional number of particles to add them at a slower or faster rate.
 		static double accumulatedParticlesToAdd = 0.0;
 
-		accumulatedParticlesToAdd += ((weather == WT_SNOWING) ? 2.0 : 4.0) * gameTimeGetMod().asDouble();
+		double gameTimeModVal = gameTimeGetMod().asDouble();
+		if (!isnan(gameTimeModVal))
+		{
+			accumulatedParticlesToAdd += ((weather == WT_SNOWING) ? 2.0 : 4.0) * gameTimeModVal;
+		}
 
 		numberToAdd = accumulatedParticlesToAdd;
 		accumulatedParticlesToAdd -= numberToAdd;

--- a/src/levels.cpp
+++ b/src/levels.cpp
@@ -32,7 +32,6 @@
 #include "lib/framework/file.h"
 #include "lib/framework/crc.h"
 #include "lib/framework/physfs_ext.h"
-#include "lib/framework/rational.h"
 #include "lib/gamelib/gtime.h"
 #include "lib/exceptionhandler/dumpinfo.h"
 #include "clparse.h"

--- a/src/loop.cpp
+++ b/src/loop.cpp
@@ -27,7 +27,6 @@
 #include "lib/framework/input.h"
 #include "lib/framework/strres.h"
 #include "lib/framework/wzapp.h"
-#include "lib/framework/rational.h"
 
 #include "lib/ivis_opengl/pieblitfunc.h"
 #include "lib/ivis_opengl/piestate.h" //ivis render code

--- a/src/scores.cpp
+++ b/src/scores.cpp
@@ -31,7 +31,6 @@
 #include "lib/framework/wzconfig.h"
 #include "lib/framework/math_ext.h"
 #include "lib/framework/strres.h"
-#include "lib/framework/rational.h"
 #include "lib/gamelib/gtime.h"
 #include "console.h"
 #include "scores.h"


### PR DESCRIPTION
Fixes #795

Scale the volume of precipitation generation to the current game speed.

I've added a toDouble() approximation to rational.h and included rational.h directly in gtime.h as everything that includes gtime.h also had to include rational.h in order to use it, so it simply shifted the burden to the cpp files.

**Testing note**
Entering debug mode and sending the message "john kettley" cycles through weather conditions on any level.