### PR TITLE
Fixes #794 - Trucks should stop mid-way if structure becomes finished

### DIFF
--- a/src/droid.cpp
+++ b/src/droid.cpp
@@ -115,6 +115,9 @@ void cancelBuild(DROID *psDroid)
 		psDroid->order = DroidOrder(DORDER_NONE);
 		setDroidActionTarget(psDroid, nullptr, 0);
 
+		// The droid has no more build orders, so halt in place rather than clumping around the build objective
+		moveStopDroid(psDroid);
+
 		triggerEventDroidIdle(psDroid);
 	}
 }

--- a/src/structure.cpp
+++ b/src/structure.cpp
@@ -7100,3 +7100,26 @@ void setFavoriteStructs(WzString list)
 {
 	favoriteStructs = list;
 }
+
+// This follows the logic in droid.cpp nextModuleToBuild()
+bool canStructureHaveAModuleAdded(const STRUCTURE* const structure)
+{
+	if (nullptr == structure || nullptr == structure->pStructureType || structure->status != SS_BUILT)
+	{
+		return false;
+	}
+
+	switch (structure->pStructureType->type)
+	{
+		case REF_FACTORY:
+		case REF_CYBORG_FACTORY:
+			return structure->capacity < NUM_FACTORY_MODULES;
+
+		case REF_POWER_GEN:
+		case REF_RESEARCH:
+			return structure->capacity == 0;
+
+		default:
+			return false;
+	}
+}

--- a/src/structure.h
+++ b/src/structure.h
@@ -365,6 +365,8 @@ void cbNewDroid(STRUCTURE *psFactory, DROID *psDroid);
 StructureBounds getStructureBounds(const STRUCTURE *object);
 StructureBounds getStructureBounds(const STRUCTURE_STATS *stats, Vector2i pos, uint16_t direction);
 
+bool canStructureHaveAModuleAdded(const STRUCTURE* const structure);
+
 static inline int structSensorRange(const STRUCTURE *psObj)
 {
 	return objSensorRange((const BASE_OBJECT *)psObj);
@@ -511,5 +513,4 @@ static inline int getBuildingRearmPoints(STRUCTURE *psStruct)
 
 WzString getFavoriteStructs();
 void setFavoriteStructs(WzString list);
-
 #endif // __INCLUDED_SRC_STRUCTURE_H__


### PR DESCRIPTION
Fixes #794

This does two things:

1) When a truck discovers that it can't build the ordered structure, either because:
 1.1) There's an enemy structure in the way
 1.2) There's a structure of another type in the way, and it's not a wall section that the truck can upgrade.
 1.3) The structure is already complete and the truck hasn't been told to add a module, or if it has all modules added.

Then the truck will immediately go on to the next structure in its build queue, or the next structure in a linebuild.

2) After running out of structures to build, the truck will halt in place.

I tried Cyp's suggestion for continuing to the last structure that was ordered to be built,  It's reasonable, but it does result in clumping of groups of trucks around the last target.  It's easy enough to implement - just remove the moveStopDroid() call from droid.cpp cancelBuild()
