### PR TITLE
Netlobby enhancements

### DIFF
--- a/lib/netplay/netplay.cpp
+++ b/lib/netplay/netplay.cpp
@@ -2299,6 +2299,7 @@ bool NETregisterServer(int state)
 					socketClose(rs_socket);
 					rs_socket = nullptr;
 					server_not_there = true;
+					ActivityManager::instance().hostGameLobbyServerDisconnect();
 				}
 				lastServerUpdate = realTime;
 				return bProcessingConnectOrDisconnectThisCall;
@@ -2319,6 +2320,7 @@ bool NETregisterServer(int state)
 					{
 						socketClose(rs_socket);
 						rs_socket = nullptr;
+						ActivityManager::instance().hostGameLobbyServerDisconnect();
 					}
 					lastServerUpdate = realTime;
 					queuedServerUpdate = false;
@@ -2328,6 +2330,7 @@ bool NETregisterServer(int state)
 						socketClose(rs_socket);
 						server_not_there = true;
 						rs_socket = nullptr;
+						ActivityManager::instance().hostGameLobbyServerDisconnect();
 						return bProcessingConnectOrDisconnectThisCall;
 					}
 				}

--- a/lib/netplay/netplay.h
+++ b/lib/netplay/netplay.h
@@ -126,6 +126,7 @@ enum MESSAGE_TYPES
 #define WZ_SERVER_DISCONNECT 0
 #define WZ_SERVER_CONNECT    1
 #define WZ_SERVER_UPDATE     3
+#define WZ_SERVER_KEEPALIVE  4
 
 // Constants
 // @NOTE / FIXME: We need a way to detect what should happen if the msg buffer exceeds this.

--- a/src/activity.cpp
+++ b/src/activity.cpp
@@ -375,6 +375,31 @@ void ActivityManager::hostGame(const char *SessionName, const char *PlayerName, 
 	for (auto sink : activitySinks) { sink->hostingMultiplayerGame(currentMultiplayGameInfo); }
 }
 
+void ActivityManager::hostGameLobbyServerDisconnect()
+{
+	if (currentMode != ActivitySink::GameMode::HOSTING_IN_LOBBY)
+	{
+		debug(LOG_ACTIVITY, "Unexpected call to hostGameLobbyServerDisconnect - currentMode (%u) - ignoring", (unsigned int)currentMode);
+		return;
+	}
+
+	if (currentMultiplayGameInfo.lobbyGameId == 0)
+	{
+		debug(LOG_ACTIVITY, "Unexpected call to hostGameLobbyServerDisconnect - prior lobbyGameId is %u - ignoring", currentMultiplayGameInfo.lobbyGameId);
+		return;
+	}
+
+	// The lobby server has disconnected the host (us)
+	// Hence any prior lobbyGameId, etc is now invalid
+	currentMultiplayGameInfo.lobbyAddress.clear();
+	currentMultiplayGameInfo.lobbyPort = 0;
+	currentMultiplayGameInfo.lobbyGameId = 0;
+
+	// Inform the ActivitySinks
+	// Trigger a new hostingMultiplayerGame event
+	for (auto sink : activitySinks) { sink->hostingMultiplayerGame(currentMultiplayGameInfo); }
+}
+
 void ActivityManager::hostLobbyQuit()
 {
 	if (currentMode != ActivitySink::GameMode::HOSTING_IN_LOBBY)

--- a/src/activity.h
+++ b/src/activity.h
@@ -169,6 +169,7 @@ public:
 	// called when a joinable multiplayer game is hosted
 	// lobbyGameId is 0 if the lobby can't be contacted / the game is not registered with the lobby
 	void hostGame(const char *SessionName, const char *PlayerName, const char* lobbyAddress, unsigned int lobbyPort, const ActivitySink::ListeningInterfaces& listeningInterfaces, uint32_t lobbyGameId = 0);
+	void hostGameLobbyServerDisconnect();
 	void hostLobbyQuit();
 	// called when attempting to join a lobby game
 	void willAttemptToJoinLobbyGame(const std::string& lobbyAddress, unsigned int lobbyPort, uint32_t lobbyGameId, const std::vector<JoinConnectionDescription>& connections);

--- a/src/multijoin.cpp
+++ b/src/multijoin.cpp
@@ -503,11 +503,19 @@ void ShowMOTD()
 	char buf[250] = { '\0' };
 	// when HOST joins the game, show server MOTD message first
 	addConsoleMessage(_("Server message:"), DEFAULT_JUSTIFY, NOTIFY_MESSAGE);
-	addConsoleMessage(NetPlay.MOTD, DEFAULT_JUSTIFY, NOTIFY_MESSAGE);
+	if (NetPlay.MOTD)
+	{
+		addConsoleMessage(NetPlay.MOTD, DEFAULT_JUSTIFY, NOTIFY_MESSAGE);
+	}
+	else
+	{
+		ssprintf(buf, "%s", "Null message");
+		addConsoleMessage(buf, DEFAULT_JUSTIFY, NOTIFY_MESSAGE);
+	}
 	if (NetPlay.HaveUpgrade)
 	{
 		audio_PlayTrack(ID_SOUND_BUILD_FAIL);
-		ssprintf(buf, "%s", _("There is an update to the game, please visit http://wz2100.net to download new version."));
+		ssprintf(buf, "%s", _("There is an update to the game, please visit https://wz2100.net to download new version."));
 		addConsoleMessage(buf, DEFAULT_JUSTIFY, NOTIFY_MESSAGE);
 	}
 	else

--- a/src/titleui/titleui.h
+++ b/src/titleui/titleui.h
@@ -147,6 +147,7 @@ private:
 	void addConsoleBox();
 	bool safeSearch = false; // allow auto game finding.
 	bool toggleFilter = true; // Used to show all games or only games that are of the same version
+	bool queuedRefreshOfGamesList = false;
 };
 
 #define WZ_MSGBOX_TUI_LEAVE 4597000


### PR DESCRIPTION
- `NETenumerateGames`: Enhance protocol to remove strict limit on number of games

> Earlier versions of WZ did not support > 11 games in the response. If > 11 games were returned, the client would incorrectly interpret the additional game structs as part of the "lobby response".
>
> To enable backwards-compatibility (with both earlier versions of WZ and earlier lobby server implementations), change the acceptable "list" response to:
> - a list of game structs
> - "lobby response" (MOTD, etc)
> - (new, optional) a parameter to signify whether to ignore the first list of game structs
> - (new, optional) a second list of game structs

While we're at it, also:
- Add support for a host -> lobby "keep alive"
- Support status response from server for updates

And:
- Enhance ActivityManager to handle hostGameLobbyServerDisconnect events