### PR TITLE
Persist MOTD on the lobby screen

### DIFF
--- a/src/console.cpp
+++ b/src/console.cpp
@@ -64,15 +64,17 @@ struct CONSOLE_MESSAGE
 {
 	WzText display;
 	UDWORD	timeAdded;		// When was it added to our list?
+	UDWORD	duration;
 	CONSOLE_TEXT_JUSTIFICATION JustifyType;	// text justification
 	int		player;			// Player who sent this message or SYSTEM_MESSAGE
-	CONSOLE_MESSAGE(const std::string &text, iV_fonts fontID, UDWORD time, CONSOLE_TEXT_JUSTIFICATION justify, int plr)
-	                : display(text, fontID), timeAdded(time), JustifyType(justify), player(plr) {}
+	CONSOLE_MESSAGE(const std::string &text, iV_fonts fontID, UDWORD time, UDWORD duration, CONSOLE_TEXT_JUSTIFICATION justify, int plr)
+	                : display(text, fontID), timeAdded(time), duration(duration), JustifyType(justify), player(plr) {}
 
 	CONSOLE_MESSAGE& operator =(CONSOLE_MESSAGE&& input)
 	{
 		display = std::move(input.display);
 		timeAdded = input.timeAdded;
+		duration = input.duration;
 		JustifyType = input.JustifyType;
 		player = input.player;
 		return *this;
@@ -168,7 +170,7 @@ void	toggleConsoleDrop()
 }
 
 /** Add a string to the console. */
-bool addConsoleMessage(const char *Text, CONSOLE_TEXT_JUSTIFICATION jusType, SDWORD player, bool team)
+bool addConsoleMessage(const char *Text, CONSOLE_TEXT_JUSTIFICATION jusType, SDWORD player, bool team, UDWORD duration)
 {
 	if (!allowNewMessages)
 	{
@@ -196,18 +198,20 @@ bool addConsoleMessage(const char *Text, CONSOLE_TEXT_JUSTIFICATION jusType, SDW
 
 		debug(LOG_CONSOLE, "(to player %d): %s", (int)player, FitText.c_str());
 
+		UDWORD newMsgDuration = (duration != DEFAULT_CONSOLE_MESSAGE_DURATION) ? duration : messageDuration;
+
 		if (player == INFO_MESSAGE)
 		{
-			InfoMessages.emplace_back(FitText, font_regular, realTime, jusType, player);
+			InfoMessages.emplace_back(FitText, font_regular, realTime, newMsgDuration, jusType, player);
 		}
 		else
 		{
-			ActiveMessages.emplace_back(FitText, font_regular, realTime, jusType, player);	// everything gets logged here for a specific period of time
+			ActiveMessages.emplace_back(FitText, font_regular, realTime, newMsgDuration, jusType, player);	// everything gets logged here for a specific period of time
 			if (team)
 			{
-				TeamMessages.emplace_back(FitText, font_regular, realTime, jusType, player);	// persistent team specific logs
+				TeamMessages.emplace_back(FitText, font_regular, realTime, newMsgDuration, jusType, player);	// persistent team specific logs
 			}
-			HistoryMessages.emplace_back(FitText, font_regular, realTime, jusType, player);	// persistent messages (all types)
+			HistoryMessages.emplace_back(FitText, font_regular, realTime, newMsgDuration, jusType, player);	// persistent messages (all types)
 		}
 	}
 	return true;
@@ -231,7 +235,7 @@ void	updateConsoleMessages()
 	}
 	for (auto i = InfoMessages.begin(); i != InfoMessages.end();)
 	{
-		if (realTime - i->timeAdded > messageDuration)
+		if ((i->duration != MAX_CONSOLE_MESSAGE_DURATION) && (realTime - i->timeAdded > i->duration))
 		{
 			i = InfoMessages.erase(i);
 		}
@@ -243,7 +247,7 @@ void	updateConsoleMessages()
 	// Time to kill all expired ones
 	for (auto i = ActiveMessages.begin(); i != ActiveMessages.end();)
 	{
-		if (realTime - i->timeAdded > messageDuration)
+		if ((i->duration != MAX_CONSOLE_MESSAGE_DURATION) && (realTime - i->timeAdded > i->duration))
 		{
 			i = ActiveMessages.erase(i);
 		}

--- a/src/console.h
+++ b/src/console.h
@@ -38,9 +38,12 @@ enum CONSOLE_TEXT_JUSTIFICATION
 #define NOTIFY_MESSAGE				(-2)	// mainly used for lobby & error messages
 #define INFO_MESSAGE				(-3)	// This type is not stored, it is used for simple messages
 
+#define MAX_CONSOLE_MESSAGE_DURATION	((UDWORD)-1)
+#define DEFAULT_CONSOLE_MESSAGE_DURATION	0
+
 extern char ConsoleString[MAX_CONSOLE_TMP_STRING_LENGTH];
 
-bool addConsoleMessage(const char *Text, CONSOLE_TEXT_JUSTIFICATION jusType, SDWORD player, bool team = false);
+bool addConsoleMessage(const char *Text, CONSOLE_TEXT_JUSTIFICATION jusType, SDWORD player, bool team = false, UDWORD duration = DEFAULT_CONSOLE_MESSAGE_DURATION);
 void updateConsoleMessages();
 void initConsoleMessages();
 void removeTopConsoleMessage();

--- a/src/titleui/gamefind.cpp
+++ b/src/titleui/gamefind.cpp
@@ -137,8 +137,8 @@ TITLECODE WzGameFindTitleUI::run()
 			}
 			lastFetchRealTime = realTime;
 			queuedRefreshOfGamesList = false;
+			addGames();	//redraw list
 		}
-		addGames();	//redraw list
 	}
 
 	WidgetTriggers const &triggers = widgRunScreen(psWScreen);
@@ -146,6 +146,7 @@ TITLECODE WzGameFindTitleUI::run()
 
 	if (id == CON_CANCEL)								// ok
 	{
+		clearActiveConsole();
 		changeTitleUI(std::make_shared<WzProtocolTitleUI>());
 	}
 
@@ -164,6 +165,7 @@ TITLECODE WzGameFindTitleUI::run()
 		addConsoleBox();
 		if (!queuedRefreshOfGamesList)
 		{
+			clearActiveConsole();
 			addConsoleMessage(_("Refreshing..."), DEFAULT_JUSTIFY, NOTIFY_MESSAGE);
 			queuedRefreshOfGamesList = true;
 		}
@@ -177,6 +179,8 @@ TITLECODE WzGameFindTitleUI::run()
 
 		std::vector<JoinConnectionDescription> connectionDesc = {JoinConnectionDescription(gamesList[gameNumber].desc.host, 0)};
 		ActivityManager::instance().willAttemptToJoinLobbyGame(NETgetMasterserverName(), NETgetMasterserverPort(), gamesList[gameNumber].gameId, connectionDesc);
+
+		clearActiveConsole();
 
 		// joinGame is quite capable of asking the user for a password, & is decoupled from lobby, so let it take over
 		ingame.localOptionsReceived = false;					// note, we are awaiting options
@@ -434,7 +438,7 @@ void WzGameFindTitleUI::addGames()
 	if (strlen(NetPlay.MOTD))
 	{
 		permitNewConsoleMessages(true);
-		addConsoleMessage(NetPlay.MOTD, DEFAULT_JUSTIFY, SYSTEM_MESSAGE);
+		addConsoleMessage(NetPlay.MOTD, DEFAULT_JUSTIFY, SYSTEM_MESSAGE, false, MAX_CONSOLE_MESSAGE_DURATION);
 	}
 	setConsolePermanence(false, false);
 	updateConsoleMessages();


### PR DESCRIPTION
- `addConsoleMessage`: Support per-message duration
- Persist the server message-of-the-day (MOTD) in the console on the lobby screen (previously it was disappearing after 4 seconds)