### PR TITLE
Fixes #483 - empty player debug menu friendly fire

### DIFF
--- a/src/multijoin.cpp
+++ b/src/multijoin.cpp
@@ -180,8 +180,15 @@ void clearPlayer(UDWORD player, bool quietly)
 
 	for (i = 0; i < MAX_PLAYERS; i++)				// remove alliances
 	{
-		alliances[player][i]	= ALLIANCE_BROKEN;
-		alliances[i][player]	= ALLIANCE_BROKEN;
+		// Never remove a player's self-alliance, as the player can be selected and units added via the debug menu
+		// even after they have left, and this would lead to them firing on each other.
+		if (i != player)
+		{
+			alliances[player][i] = ALLIANCE_BROKEN;
+			alliances[i][player] = ALLIANCE_BROKEN;
+			alliancebits[i] &= ~(1 << player);
+			alliancebits[player] &= ~(1 << i);
+		}
 	}
 
 	debug(LOG_DEATH, "killing off all droids for player %d", player);
@@ -471,17 +478,9 @@ bool recvDataCheck(NETQUEUE queue)
 // Setup Stuff for a new player.
 void setupNewPlayer(UDWORD player)
 {
-	UDWORD i;
-
 	ingame.PingTimes[player] = 0;					// Reset ping time
 	ingame.JoiningInProgress[player] = true;			// Note that player is now joining
 	ingame.DataIntegrity[player] = false;
-
-	for (i = 0; i < MAX_PLAYERS; i++)				// Set all alliances to broken
-	{
-		alliances[selectedPlayer][i] = ALLIANCE_BROKEN;
-		alliances[i][selectedPlayer] = ALLIANCE_BROKEN;
-	}
 
 	resetMultiVisibility(player);						// set visibility flags.
 


### PR DESCRIPTION
Fixes #483

When a player leaves the game, including by setting the slot as closed in the lobby, do not clear their alliance flag with themselves. If we do this, then selecting the empty player and adding units via the debug menu causes them to fire on each other.

When we do clear alliances for a leaving player, also clear the alliancebits flag for consistency.

In setupNewPlayer(), called when each player joins before the game starts, remove the code to clear all alliances.  This is redundant, as we always go through aiInitialise() before game start, which clears all alliances and alliancebits, and sets up the initial self-alliances.

If the setupNewPlayer() code did anything do anything, it would result in all players treating themselves as enemies, so we can be pretty confident that it's only still there for ritual purposes.