### PR TITLE
Fixes #922 Moduled building demolishing

### DIFF
--- a/src/structure.h
+++ b/src/structure.h
@@ -350,8 +350,8 @@ bool IsStatExpansionModule(const STRUCTURE_STATS *psStats);
 bool structureIsBlueprint(const STRUCTURE *psStructure);
 bool isBlueprint(const BASE_OBJECT *psObject);
 
-/*returns the power cost to build this structure*/
-UDWORD structPowerToBuild(const STRUCTURE *psStruct);
+/*returns the power cost to build this structure, or to add its next module */
+UDWORD structPowerToBuildOrAddNextModule(const STRUCTURE *psStruct);
 
 // check whether a factory of a certain number and type exists
 bool checkFactoryExists(UDWORD player, UDWORD factoryType, UDWORD inc);


### PR DESCRIPTION
Fixes #922 

The function structPowerToBuild() is rather confusingly named, as it returns the power to either build the structure, or to add its next module, not the total power it took to build it as might have been mistakenly inferred.  I've renamed it to structPowerToBuildOrAddNextModule(), since that's what it returns.

The real problem is in structureTotalReturn() which (ab)uses structPowerToBuild() and then tries to correct the (bad) number it gets back from that depending on whether the structure has any modules (irrespective of how many).

What we actually want to do is to return:

(power to build basic structure + (power to build a module * number of modules)) / 2