### PR TITLE
Add unit / kill count gui feature (rebased, simplified)

### DIFF
--- a/src/cheat.cpp
+++ b/src/cheat.cpp
@@ -78,6 +78,7 @@ static CHEAT_ENTRY cheatCodes[] =
 	{"work harder", kf_FinishResearch},
 	{"tileinfo", kf_TileInfo}, // output debug info about a tile
 	{"showfps", kf_ToggleFPS},	//displays your average FPS
+	{"showunits", kf_ToggleUnitCount},	//displays unit count information
 	{"showsamples", kf_ToggleSamples}, //displays the # of Sound samples in Queue & List
 	{"showorders", kf_ToggleOrders}, //displays unit order/action state.
 	{"pause", kf_TogglePauseMode}, // Pause the game.
@@ -99,6 +100,11 @@ bool _attemptCheatCode(const char *cheat_name)
 	if (!strcasecmp("showfps", cheat_name))
 	{
 		kf_ToggleFPS();
+		return true;
+	}
+	if (!strcasecmp("showunits", cheat_name))
+	{
+		kf_ToggleUnitCount();
 		return true;
 	}
 

--- a/src/configuration.cpp
+++ b/src/configuration.cpp
@@ -130,6 +130,7 @@ bool loadConfig()
 		wz_texture_compression = false;
 	}
 	showFPS = ini.value("showFPS", false).toBool();
+	showUNITCOUNT = ini.value("showUNITCOUNT", false).toBool();
 	if (ini.contains("cameraSpeed"))
 	{
 		war_SetCameraSpeed(ini.value("cameraSpeed").toInt());
@@ -283,6 +284,7 @@ bool saveConfig()
 	ini.setValue("RightClickOrders", (SDWORD)(getRightClickOrders()));
 	ini.setValue("MiddleClickRotate", (SDWORD)(getMiddleClickRotate()));
 	ini.setValue("showFPS", (SDWORD)showFPS);
+	ini.setValue("showUNITCOUNT", (SDWORD)showUNITCOUNT);
 	ini.setValue("shadows", (SDWORD)(getDrawShadows()));	// shadows
 	ini.setValue("sound", (SDWORD)war_getSoundEnabled());
 	ini.setValue("FMVmode", (SDWORD)(war_GetFMVmode()));		// sequences

--- a/src/display3d.cpp
+++ b/src/display3d.cpp
@@ -84,6 +84,7 @@
 #include "cmddroid.h"
 #include "terrain.h"
 #include "warzoneconfig.h"
+#include "multistat.h"
 
 /********************  Prototypes  ********************/
 
@@ -129,6 +130,7 @@ static WzText txtLevelName;
 static WzText txtDebugStatus;
 static WzText txtCurrentTime;
 static WzText txtShowFPS;
+static WzText txtUnits;
 // show Samples text
 static WzText txtShowSamples_Que;
 static WzText txtShowSamples_Lst;
@@ -228,6 +230,10 @@ static unsigned int rubbleTile = BLOCKING_RUBBLE_TILE;
 bool showFPS = false;       //
 /** Show how many samples we are rendering per second
  * default OFF, turn ON via console command 'showsamples'
+ */
+bool showUNITCOUNT = false;
+/** Show how many kills/deaths (produced units) made
+ * default OFF, turn ON via console command 'showunits'
  */
 bool showSAMPLES = false;
 /**  Show the current selected units order / action
@@ -841,8 +847,16 @@ void draw3DScene()
 		std::string fps = astringf("FPS: %d", frameRate());
 		txtShowFPS.setText(fps, font_regular);
 		const unsigned width = txtShowFPS.width() + 10;
-		const unsigned height = txtShowFPS.height();
+		const unsigned height = 9; //txtShowFPS.height();
 		txtShowFPS.render(pie_GetVideoBufferWidth() - width, pie_GetVideoBufferHeight() - height, WZCOL_TEXT_BRIGHT);
+	}
+	if (showUNITCOUNT)
+	{
+		std::string killdiff = astringf("Units: %u lost / %u built / %u killed", missionData.unitsLost, missionData.unitsBuilt, getSelectedPlayerUnitsKilled());
+		txtUnits.setText(killdiff, font_regular);
+		const unsigned width = txtUnits.width() + 10;
+		const unsigned height = 9; //txtUnits.height();
+		txtUnits.render(pie_GetVideoBufferWidth() - width - ((showFPS) ? txtShowFPS.width() + 10 : 0), pie_GetVideoBufferHeight() - height, WZCOL_TEXT_BRIGHT);
 	}
 	if (showORDERS)
 	{

--- a/src/display3d.h
+++ b/src/display3d.h
@@ -56,6 +56,7 @@ struct iView
 };
 
 extern bool showFPS;
+extern bool showUNITCOUNT;
 extern bool showSAMPLES;
 extern bool showORDERS;
 

--- a/src/keybind.cpp
+++ b/src/keybind.cpp
@@ -607,6 +607,20 @@ void kf_ToggleFPS() //This shows *just FPS* and is always visible (when active) 
 		CONPRINTF("%s", _("FPS display is disabled."));
 	}
 }
+void kf_ToggleUnitCount()		// Display units built / lost / produced counter
+{
+	// Toggle the boolean value of showUNITCOUNT
+	showUNITCOUNT = !showUNITCOUNT;
+
+	if (showUNITCOUNT)
+	{
+		CONPRINTF("%s", _("Unit count display is enabled."));
+	}
+	else
+	{
+		CONPRINTF("%s", _("Unit count display is disabled."));
+	}
+}
 void kf_ToggleSamples() //Displays number of sound sample in the sound queues & lists.
 {
 	// Toggle the boolean value of showSAMPLES

--- a/src/keybind.h
+++ b/src/keybind.h
@@ -39,6 +39,7 @@ void kf_HalveHeights();
 void kf_DebugDroidInfo();
 void kf_BuildInfo();
 void kf_ToggleFPS();			//FPS counter NOT same as kf_Framerate! -Q
+void kf_ToggleUnitCount();		// Display units built / lost / produced counter
 void kf_ToggleSamples();		// Displays # of sound samples in Queue/list.
 void kf_ToggleOrders();		//displays unit's Order/action state.
 void kf_FrameRate();

--- a/src/multistat.cpp
+++ b/src/multistat.cpp
@@ -43,6 +43,7 @@
 #include "main.h"
 #include "mission.h" // for cheats
 #include "multistat.h"
+#include "activity.h"
 #include <utility>
 
 
@@ -362,3 +363,26 @@ void addKnownPlayer(std::string const &name, EcKey const &key, bool override)
 	knownPlayersIni->setValue(QString::fromUtf8(name.c_str()), base64Encode(key.toBytes(EcKey::Public)).c_str());
 	knownPlayersIni->sync();
 }
+
+uint32_t getSelectedPlayerUnitsKilled()
+{
+	if (ActivityManager::instance().getCurrentGameMode() != ActivitySink::GameMode::CAMPAIGN)
+	{
+		// Let's use the real score for MP games
+		// FIXME: Why in the world are we using two different structs for stats when we can use only one?
+		if (NetPlay.bComms)
+		{
+			return getMultiStats(selectedPlayer).recentKills;
+		}
+		else
+		{
+			// estimated kills
+			return static_cast<uint32_t>(ingame.skScores[selectedPlayer][1]);
+		}
+	}
+	else
+	{
+		return missionData.unitsKilled;
+	}
+}
+

--- a/src/multistat.h
+++ b/src/multistat.h
@@ -58,4 +58,6 @@ void recvMultiStats(NETQUEUE queue);
 std::map<std::string, EcKey::Key> const &getKnownPlayers();
 void addKnownPlayer(std::string const &name, EcKey const &key, bool override = false);
 
+uint32_t getSelectedPlayerUnitsKilled();
+
 #endif // __INCLUDED_SRC_MULTISTATS_H__


### PR DESCRIPTION
Rebased, simplified version of #569

Show how many kills/deaths (produced units) made
Defaults to OFF; turn ON via console command `showunits`

@maxsupermanhd