### PR TITLE
#923 Production procedure aborting (power refund)

### DIFF
--- a/src/structure.cpp
+++ b/src/structure.cpp
@@ -6090,6 +6090,22 @@ STRUCTURE	*findDeliveryFactory(FLAG_POSITION *psDelPoint)
 	return nullptr;
 }
 
+static void cancelBuildInProgressAndRefundPower(FACTORY* const psFactory, const uint8_t playerNumber)
+{
+	if (psFactory->psSubject)
+	{
+		if (psFactory->buildPointsRemaining < calcTemplateBuild(psFactory->psSubject))
+		{
+			// We started building, so give the power back that was used.
+			addPower(playerNumber, calcTemplatePower(psFactory->psSubject));
+		}
+
+		//clear the factory's subject
+		psFactory->psSubject = nullptr;
+	}
+
+}
+
 
 /*cancels the production run for the factory and returns any power that was
 accrued but not used*/
@@ -6120,18 +6136,7 @@ void cancelProduction(STRUCTURE *psBuilding, QUEUE_MODE mode, bool mayClearProdu
 		return;
 	}
 
-	//check its the correct factory
-	if (psFactory->psSubject)
-	{
-		if (psFactory->buildPointsRemaining < calcTemplateBuild(psFactory->psSubject))
-		{
-			// We started building, so give the power back that was used.
-			addPower(psBuilding->player, calcTemplatePower(psFactory->psSubject));
-		}
-
-		//clear the factory's subject
-		psFactory->psSubject = nullptr;
-	}
+	cancelBuildInProgressAndRefundPower(psFactory, psBuilding->player);
 
 	delPowerRequest(psBuilding);
 }
@@ -6316,6 +6321,8 @@ void factoryProdAdjust(STRUCTURE *psStructure, DROID_TEMPLATE *psTemplate, bool 
 		if (entry->quantity <= 0 || entry->quantity > MAX_IN_RUN)
 		{
 			productionRun.erase(entry);  // Entry empty, so get rid of it.
+
+			cancelBuildInProgressAndRefundPower(psFactory, psStructure->player);
 		}
 	}
 	else


### PR DESCRIPTION
Fixes #923

When stopping the current production of a unit by right-clicking on that unit and reducing the number required to zero, we do have a test for that, which erases the active production run.  However, it doesn't go through cancelProduction() and doesn't refund the spent power.

I've factored out the code from cancelProduction() that refunds the power if production is actually in progress (build points remaining are less than the total required) and am calling that from the existing test to cancel the current production when the number required equals zero.

Something to note is the last unit of power refunded can take several seconds to appear, making it look as though there's an off-by-one in the refund, but it eventually settles down at the original amount.