### PR TITLE
Guard autohost ready status.

### DIFF
--- a/src/multiplay.cpp
+++ b/src/multiplay.cpp
@@ -1950,6 +1950,12 @@ void resetReadyStatus(bool bSendOptions)
 	{
 		for (unsigned int i = 0; i < game.maxPlayers; ++i)
 		{
+			//Ignore for autohost launch option.
+			if (selectedPlayer == i && hostlaunch == 3)
+			{
+				continue;
+			}
+
 			if (isHumanPlayer(i) && ingame.JoiningInProgress[i])
 			{
 				changeReadyStatus(i, false);


### PR DESCRIPTION
Might fix autohost ready status being reset.

Fixes #955.