### PR TITLE
Ignore ready status reset when changing flag color.

### DIFF
--- a/src/multiint.cpp
+++ b/src/multiint.cpp
@@ -2072,7 +2072,7 @@ bool recvColourRequest(NETQUEUE queue)
 		return false;
 	}
 
-	resetReadyStatus(false);
+	resetReadyStatus(false, true);
 
 	return changeColour(player, col, false);
 }
@@ -3430,7 +3430,7 @@ void WzMultiOptionTitleUI::processMultiopWidgets(UDWORD id)
 	STATIC_ASSERT(MULTIOP_COLCHOOSER + MAX_PLAYERS - 1 <= MULTIOP_COLCHOOSER_END);
 	if (id >= MULTIOP_COLCHOOSER && id < MULTIOP_COLCHOOSER + MAX_PLAYERS - 1)  // chose a new colour.
 	{
-		resetReadyStatus(false);		// will reset only locally if not a host
+		resetReadyStatus(false, true);		// will reset only locally if not a host
 		SendColourRequest(colourChooserUp, id - MULTIOP_COLCHOOSER);
 		closeColourChooser();
 		addPlayerBox(!ingame.bHostSetup || bHosted);

--- a/src/multiplay.cpp
+++ b/src/multiplay.cpp
@@ -1936,7 +1936,7 @@ const char *getPlayerColourName(int player)
 }
 
 /* Reset ready status for all players */
-void resetReadyStatus(bool bSendOptions)
+void resetReadyStatus(bool bSendOptions, bool ignoreReadyReset)
 {
 	// notify all clients if needed
 	if (bSendOptions)
@@ -1946,7 +1946,7 @@ void resetReadyStatus(bool bSendOptions)
 	netPlayersUpdated = true;
 
 	//Really reset ready status
-	if (NetPlay.isHost)
+	if (NetPlay.isHost && !ignoreReadyReset)
 	{
 		for (unsigned int i = 0; i < game.maxPlayers; ++i)
 		{

--- a/src/multiplay.h
+++ b/src/multiplay.h
@@ -241,7 +241,7 @@ bool sendBeacon(int32_t locX, int32_t locY, int32_t forPlayer, int32_t sender, c
 
 bool multiplayPlayersReady(bool bNotifyStatus);
 void startMultiplayerGame();
-void resetReadyStatus(bool bSendOptions);
+void resetReadyStatus(bool bSendOptions, bool ignoreReadyReset = false);
 
 STRUCTURE *findResearchingFacilityByResearchIndex(unsigned player, unsigned index);
 


### PR DESCRIPTION
Every time `resetReadyStatus()` gets called it will reset the ready status for everyone. So, I made an option to ignore it. This PR does just that for changing the flag color.

Closes #962. 