### PR TITLE
Set new zoom rate min/max bounds and default.

### DIFF
--- a/src/keybind.h
+++ b/src/keybind.h
@@ -24,9 +24,9 @@
 #include "console.h"
 #include "lib/framework/fixedpoint.h"
 
-#define	MAP_ZOOM_RATE_MAX	(500)
-#define	MAP_ZOOM_RATE_MIN	(50)
-#define	MAP_ZOOM_RATE_DEFAULT	(250)
+#define	MAP_ZOOM_RATE_MAX	(1000)
+#define	MAP_ZOOM_RATE_MIN	(200)
+#define	MAP_ZOOM_RATE_DEFAULT	(500)
 #define	MAP_ZOOM_RATE_STEP	(50)
 
 #define MAP_PITCH_RATE		(SPIN_SCALING/SECS_PER_SPIN)


### PR DESCRIPTION
While the new smoothing of the camera zoom is nice it isn't, I think, fair for some situations like multiplayer (as mentioned in discord). I've thus set a new minimum (200 instead of 50) and maximum (1000 instead of 500) and set the default rate to 500 so it doesn't feel like it takes forever to adjust the camera.

Higher values have a more "step" like appearance. Not sure if that is a big deal however.