### PR TITLE
Fix map preview replacing backdrops after being kicked.

### DIFF
--- a/src/multiint.cpp
+++ b/src/multiint.cpp
@@ -2590,6 +2590,8 @@ static void stopJoining(std::shared_ptr<WzTitleUI> parent)
 
 	debug(LOG_NET, "player %u (Host is %s) stopping.", selectedPlayer, NetPlay.isHost ? "true" : "false");
 
+	pie_LoadBackDrop(SCREEN_RANDOMBDROP);
+
 	if (bHosted)											// cancel a hosted game.
 	{
 		// annouce we are leaving...
@@ -2636,8 +2638,6 @@ static void stopJoining(std::shared_ptr<WzTitleUI> parent)
 	changeTitleUI(parent);
 	selectedPlayer = 0;
 	realSelectedPlayer = 0;
-
-	pie_LoadBackDrop(SCREEN_RANDOMBDROP);
 }
 
 static void resetPlayerPositions()


### PR DESCRIPTION
A kicked player will enter the `else if (ingame.localJoiningInProgress)` statement in `stopJoining()`. This means they miss the call to reset the backdrop so their backdrop becomes the map preview until it changes again.

Fixes #972.

@past-due There is something bothering me about this function... does anything truly make it past the `if... else if` block in `stopJoining()`? I never see the debug output from `debug(LOG_NET, "We have stopped joining.")`.