### PR TITLE
Prevent toggling chat box when UI overlays are disabled

### DIFF
--- a/src/keybind.cpp
+++ b/src/keybind.cpp
@@ -1936,6 +1936,11 @@ void kf_ShowGridInfo()
 // Chat message. NOTE THIS FUNCTION CAN DISABLE ALL OTHER KEYPRESSES
 void kf_SendTeamMessage()
 {
+	if (!getWidgetsStatus())
+	{
+		return;
+	}
+
 	if (bAllowOtherKeyPresses && !gamePaused())  // just starting.
 	{
 		bAllowOtherKeyPresses = false;
@@ -1953,6 +1958,11 @@ void kf_SendTeamMessage()
 // Chat message. NOTE THIS FUNCTION CAN DISABLE ALL OTHER KEYPRESSES
 void kf_SendGlobalMessage()
 {
+	if (!getWidgetsStatus())
+	{
+		return;
+	}
+
 	if (bAllowOtherKeyPresses && !gamePaused())  // just starting.
 	{
 		bAllowOtherKeyPresses = false;


### PR DESCRIPTION
Otherwise input becomes soft-locked by the (non-displayed) chat box.

Fixes #975