### PR TITLE
Fix calcDamage() returning 0 unintentionally

### DIFF
--- a/src/projectile.cpp
+++ b/src/projectile.cpp
@@ -1479,6 +1479,11 @@ ObjectShape establishTargetShape(BASE_OBJECT *psTarget)
 structure strength*/
 UDWORD	calcDamage(UDWORD baseDamage, WEAPON_EFFECT weaponEffect, BASE_OBJECT *psTarget)
 {
+	if (baseDamage == 0)
+	{
+		return 0;
+	}
+
 	UDWORD	damage = baseDamage * 100;
 
 	if (psTarget->type == OBJ_STRUCTURE)
@@ -1493,13 +1498,8 @@ UDWORD	calcDamage(UDWORD baseDamage, WEAPON_EFFECT weaponEffect, BASE_OBJECT *ps
 		damage += baseDamage * (asWeaponModifierBody[weaponEffect][body] - 100);
 	}
 
-	// A little fail safe!
-	if (damage == 0 && baseDamage != 0)
-	{
-		return 1;
-	}
-
-	return damage / 100;
+	//Always do at least one damage.
+	return MAX(damage / 100, 1);
 }
 
 /*

--- a/src/stats.cpp
+++ b/src/stats.cpp
@@ -771,6 +771,8 @@ bool getPropulsionType(const char *typeName, PROPULSION_TYPE *type)
 	{
 		debug(LOG_ERROR, "getPropulsionType: Invalid Propulsion type %s - assuming Hover", typeName);
 		*type = PROPULSION_TYPE_HOVER;
+
+		return false;
 	}
 
 	return true;

--- a/src/stats.cpp
+++ b/src/stats.cpp
@@ -43,6 +43,8 @@
 
 #define WEAPON_TIME		100
 
+#define DEFAULT_DROID_RESISTANCE	150
+
 /* The stores for the different stats */
 BODY_STATS		*asBodyStats;
 BRAIN_STATS		*asBrainStats;
@@ -589,7 +591,7 @@ bool loadBodyStats(WzConfig &ini)
 		psStats->base.thermal = ini.value("armourHeat").toInt();
 		psStats->base.armour = ini.value("armourKinetic").toInt();
 		psStats->base.power = ini.value("powerOutput").toInt();
-		psStats->base.resistance = ini.value("resistance", 30).toInt();
+		psStats->base.resistance = ini.value("resistance", DEFAULT_DROID_RESISTANCE).toInt();
 		for (int j = 0; j < MAX_PLAYERS; j++)
 		{
 			psStats->upgrade[j] = psStats->base;


### PR DESCRIPTION
Basically, if a weapon does very little damage or the math is "just right" it would be possible for calcDamage() to unintentionally return 0 due to truncated integer division.

Lets for fun see what happens when a Nexus Link currently hits a tracked droid...

baseDamage = 2
weaponEffect = anti-personnel (modifier of 40 against tracked)

```
UDWORD	calcDamage(UDWORD baseDamage, WEAPON_EFFECT weaponEffect, BASE_OBJECT *psTarget)
{
	UDWORD	damage = baseDamage * 100; // 200

...

	else if (psTarget->type == OBJ_DROID)
	{
		const int propulsion = (asPropulsionStats + ((DROID *)psTarget)->asBits[COMP_PROPULSION])->propulsionType;
		const int body = (asBodyStats + ((DROID *)psTarget)->asBits[COMP_BODY])->size;

                // 200 += ( 2 * (40 - 100) = 80
		damage += baseDamage * (asWeaponModifier[weaponEffect][propulsion] - 100); 
                // 80 += (2 * (100 - 100) = 80
		damage += baseDamage * (asWeaponModifierBody[weaponEffect][body] - 100);
	}

	// A little fail safe!
	if (damage == 0 && baseDamage != 0)
	{
		return 1;
	}

        // 80 / 100 = 0 
	return damage / 100;
}
```

The fun don't stop there. `asWeaponModifierBody` is a completely useless "body" modifier that is always default initialized to 100 for everything. Which led me to `getPropulsionType()` always returning true as well (and the only time it wouldn't fatally stop the game is to set a value in this body modifier thing).

Oh, and ever wonder why some structures could never be captured by a Nexus Link? Again, 0 damage to their resistance value.

Dropping this off here since I need to further look at the implications of this change.

Fixes #980.