### PR TITLE
Remove hard-coded limit on number of tiles seen by object.

### DIFF
--- a/src/basedef.h
+++ b/src/basedef.h
@@ -117,14 +117,13 @@ struct BASE_OBJECT : public SIMPLE_OBJECT
 	UBYTE               selected;                   ///< Whether the object is selected (might want this elsewhere)
 	UBYTE               visible[MAX_PLAYERS];       ///< Whether object is visible to specific player
 	UBYTE               seenThisTick[MAX_PLAYERS];  ///< Whether object has been seen this tick by the specific player.
-	UWORD               numWatchedTiles;            ///< Number of watched tiles, zero for features
 	UDWORD              lastEmission;               ///< When did it last puff out smoke?
 	WEAPON_SUBCLASS     lastHitWeapon;              ///< The weapon that last hit it
 	UDWORD              timeLastHit;                ///< The time the structure was last attacked
 	UDWORD              body;                       ///< Hit points with lame name
 	UDWORD              periodicalDamageStart;                  ///< When the object entered the fire
 	UDWORD              periodicalDamage;                 ///< How much damage has been done since the object entered the fire
-	TILEPOS             *watchedTiles;              ///< Variable size array of watched tiles, NULL for features
+	std::vector<TILEPOS> watchedTiles;              ///< Variable size array of watched tiles, empty for features
 
 	UDWORD              timeAnimationStarted;       ///< Animation start time, zero for do not animate
 	UBYTE               animationEvent;             ///< If animation start time > 0, this points to which animation to run

--- a/src/baseobject.cpp
+++ b/src/baseobject.cpp
@@ -95,14 +95,12 @@ SIMPLE_OBJECT::~SIMPLE_OBJECT()
 BASE_OBJECT::BASE_OBJECT(OBJECT_TYPE type, uint32_t id, unsigned player)
 	: SIMPLE_OBJECT(type, id, player)
 	, selected(false)
-	, numWatchedTiles(0)
 	, lastEmission(0)
 	, lastHitWeapon(WSC_NUM_WEAPON_SUBCLASSES)  // No such weapon.
 	, timeLastHit(UDWORD_MAX)
 	, body(0)
 	, periodicalDamageStart(0)
 	, periodicalDamage(0)
-	, watchedTiles(nullptr)
 	, timeAnimationStarted(0)
 	, animationEvent(ANIM_EVENT_NONE)
 {
@@ -117,7 +115,6 @@ BASE_OBJECT::BASE_OBJECT(OBJECT_TYPE type, uint32_t id, unsigned player)
 BASE_OBJECT::~BASE_OBJECT()
 {
 	visRemoveVisibility(this);
-	free(watchedTiles);
 
 #ifdef DEBUG
 	psNext = this;                                                       // Hopefully this will trigger an infinite loop       if someone uses the freed object.

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -1871,14 +1871,10 @@ static int dangerThreadFunc(WZ_DECL_UNUSED void *data)
 
 static inline void threatUpdateTarget(int player, BASE_OBJECT *psObj, bool ground, bool air)
 {
-	int i;
-
 	if (psObj->visible[player] || psObj->born == 2)
 	{
-		for (i = 0; i < psObj->numWatchedTiles; i++)
+		for (TILEPOS pos : psObj->watchedTiles)
 		{
-			const TILEPOS pos = psObj->watchedTiles[i];
-
 			if (ground)
 			{
 				auxSet(pos.x, pos.y, MAX_PLAYERS + AUX_DANGERMAP, AUXBITS_THREAT);	// set ground threat for this tile

--- a/src/mission.cpp
+++ b/src/mission.cpp
@@ -628,9 +628,7 @@ void missionFlyTransportersIn(SDWORD iPlayer, bool bTrackTransporter)
 			if (psTransporter->psGroup && psTransporter->psGroup->refCount > 1)
 			{
 				// Remove map information from previous map
-				free(psTransporter->watchedTiles);
-				psTransporter->watchedTiles = nullptr;
-				psTransporter->numWatchedTiles = 0;
+				psTransporter->watchedTiles.clear();
 
 				// Remove out of stored list and add to current Droid list
 				if (droidRemove(psTransporter, mission.apsDroidLists))

--- a/src/qtscriptdebug.cpp
+++ b/src/qtscriptdebug.cpp
@@ -698,7 +698,7 @@ void ScriptDebugger::selected(const BASE_OBJECT *psObj)
 	setPair(row, selectedModel, "Born", QString::number(psObj->born));
 	setPair(row, selectedModel, "Died", QString::number(psObj->died));
 	setPair(row, selectedModel, "Group", QString::number(psObj->group));
-	setPair(row, selectedModel, "Watched tiles", QString::number(psObj->numWatchedTiles));
+	setPair(row, selectedModel, "Watched tiles", QString::number(psObj->watchedTiles.size()));
 	setPair(row, selectedModel, "Last hit", QString::number(psObj->timeLastHit));
 	setPair(row, selectedModel, "Hit points", QString::number(psObj->body));
 	setPair(row, selectedModel, "Periodical start", QString::number(psObj->periodicalDamageStart));

--- a/src/visibility.cpp
+++ b/src/visibility.cpp
@@ -78,9 +78,6 @@ public:
 };
 static std::vector<SPOTTER *> apsInvisibleViewers;
 
-// horrible hack because this code is full of them and I ain't rewriting it all - Per
-#define MAX_SEEN_TILES (29*29 * 355/113)  // Increased hack to support 28 tile sensor radius. - Cyp
-
 #define MIN_VIS_HEIGHT 80
 
 struct VisibleObjectHelp_t
@@ -227,9 +224,8 @@ SPOTTER::~SPOTTER()
 
 /* Record all tiles that some object confers visibility to. Only record each tile
  * once. Note that there is both a limit to how many objects can watch any given
- * tile, and a limit to how many tiles each object can watch. Strange but non fatal
- * things will happen if these limits are exceeded. This function uses icky globals. */
-static inline void visMarkTile(const BASE_OBJECT *psObj, int mapX, int mapY, MAPTILE *psTile, TILEPOS *recordTilePos, int *lastRecordTilePos)
+ * tile. Strange but non fatal things will happen if these limits are exceeded. */
+static inline void visMarkTile(const BASE_OBJECT *psObj, int mapX, int mapY, MAPTILE *psTile, std::vector<TILEPOS> &watchedTiles)
 {
 	const int rayPlayer = psObj->player;
 	const int xdiff = map_coord(psObj->pos.x) - mapX;
@@ -238,7 +234,7 @@ static inline void visMarkTile(const BASE_OBJECT *psObj, int mapX, int mapY, MAP
 	const bool inRange = (distSq < 16);
 	uint8_t *visionType = inRange ? psTile->watchers : psTile->sensors;
 
-	if (visionType[rayPlayer] < UBYTE_MAX && *lastRecordTilePos < MAX_SEEN_TILES)
+	if (visionType[rayPlayer] < UBYTE_MAX)
 	{
 		TILEPOS tilePos = {uint8_t(mapX), uint8_t(mapY), uint8_t(inRange)};
 
@@ -249,13 +245,12 @@ static inline void visMarkTile(const BASE_OBJECT *psObj, int mapX, int mapY, MAP
 			psTile->jammerBits |= (1 << rayPlayer); // mark it as being jammed
 		}
 		updateTileVis(psTile);
-		recordTilePos[*lastRecordTilePos] = tilePos;    // record having seen it
-		++*lastRecordTilePos;
+		watchedTiles.push_back(tilePos);  // record having seen it
 	}
 }
 
 /* The terrain revealing ray callback */
-static void doWaveTerrain(const BASE_OBJECT *psObj, TILEPOS *recordTilePos, int *lastRecordTilePos)
+static void doWaveTerrain(BASE_OBJECT *psObj)
 {
 	const int sx = psObj->pos.x;
 	const int sy = psObj->pos.y;
@@ -277,6 +272,7 @@ static void doWaveTerrain(const BASE_OBJECT *psObj, TILEPOS *recordTilePos, int 
 	angles[!readList][writeListPos] = 0;               // Smallest angle.
 	++writeListPos;
 
+	psObj->watchedTiles.clear();
 	for (size_t i = 0; i < size; ++i)
 	{
 		const int mapX = map_coord(sx) + tiles[i].dx;
@@ -332,7 +328,7 @@ static void doWaveTerrain(const BASE_OBJECT *psObj, TILEPOS *recordTilePos, int 
 		{
 			// Can see this tile.
 			psTile->tileExploredBits |= alliancebits[rayPlayer];                        // Share exploration with allies too
-			visMarkTile(psObj, mapX, mapY, psTile, recordTilePos, lastRecordTilePos);   // Mark this tile as seen by our sensor
+			visMarkTile(psObj, mapX, mapY, psTile, psObj->watchedTiles);   // Mark this tile as seen by our sensor
 		}
 	}
 }
@@ -385,11 +381,10 @@ static bool rayLOSCallback(Vector2i pos, int32_t dist, void *data)
 /* Remove tile visibility from object */
 void visRemoveVisibility(BASE_OBJECT *psObj)
 {
-	if (psObj->watchedTiles && mapWidth && mapHeight)
+	if (mapWidth && mapHeight)
 	{
-		for (int i = 0; i < psObj->numWatchedTiles; i++)
+		for (TILEPOS pos : psObj->watchedTiles)
 		{
-			const TILEPOS pos = psObj->watchedTiles[i];
 			// FIXME: the mapTile might have been swapped out, see swapMissionPointers()
 			MAPTILE *psTile = mapTile(pos.x, pos.y);
 
@@ -414,25 +409,18 @@ void visRemoveVisibility(BASE_OBJECT *psObj)
 			updateTileVis(psTile);
 		}
 	}
-	free(psObj->watchedTiles);
-	psObj->watchedTiles = nullptr;
-	psObj->numWatchedTiles = 0;
+	psObj->watchedTiles.clear();
 	psObj->flags.set(OBJECT_FLAG_JAMMED_TILES, false);
 }
 
 void visRemoveVisibilityOffWorld(BASE_OBJECT *psObj)
 {
-	free(psObj->watchedTiles);
-	psObj->watchedTiles = nullptr;
-	psObj->numWatchedTiles = 0;
+	psObj->watchedTiles.clear();
 }
 
 /* Check which tiles can be seen by an object */
 void visTilesUpdate(BASE_OBJECT *psObj)
 {
-	TILEPOS recordTilePos[MAX_SEEN_TILES];
-	int lastRecordTilePos = 0;
-
 	ASSERT(psObj->type != OBJ_FEATURE, "visTilesUpdate: visibility updates are not for features!");
 
 	// Remove previous map visibility provided by object
@@ -451,15 +439,7 @@ void visTilesUpdate(BASE_OBJECT *psObj)
 
 	// Do the whole circle in ∞ steps. No more pretty moiré patterns.
 	psObj->flags.set(OBJECT_FLAG_JAMMED_TILES, objJammerPower(psObj) > 0);
-	doWaveTerrain(psObj, recordTilePos, &lastRecordTilePos);
-
-	// Record new map visibility provided by object
-	if (lastRecordTilePos > 0)
-	{
-		psObj->watchedTiles = (TILEPOS *)malloc(lastRecordTilePos * sizeof(*psObj->watchedTiles));
-		psObj->numWatchedTiles = lastRecordTilePos;
-		memcpy(psObj->watchedTiles, recordTilePos, lastRecordTilePos * sizeof(*psObj->watchedTiles));
-	}
+	doWaveTerrain(psObj);
 }
 
 /*reveals all the terrain in the map*/


### PR DESCRIPTION
This fixes the HQ visibility becoming a diamond instead of a circle, if having full
sensor upgrades and with the HQ far from obstacles and map edges.

Before:
![image](https://user-images.githubusercontent.com/48363/85941510-ccd92c00-b923-11ea-84c4-7093bba196e8.png)

After:
![image](https://user-images.githubusercontent.com/48363/85941576-0ad65000-b924-11ea-9ae0-e82a9c8ad9f6.png)
