### PR TITLE
Trigger an enemy attack when bases are eliminated on eliminateBases victory.

### DIFF
--- a/data/base/script/campaign/libcampaign_includes/victory.js
+++ b/data/base/script/campaign/libcampaign_includes/victory.js
@@ -334,12 +334,22 @@ function __camVictoryOffworld()
 	{
 		if (elimBases)
 		{
-			var enemyDroids = enumArea(0, 0, mapWidth, mapHeight, ENEMIES, false).filter(function(obj) {
-				return obj.type === DROID;
-			}).length;
-			if (!enemyDroids && camAllEnemyBasesEliminated())
+			if (camAllEnemyBasesEliminated())
 			{
-				__camGameWon();
+				var enemyDroids = enumArea(0, 0, mapWidth, mapHeight, ENEMIES, false).filter(function(obj) {
+					return obj.type === DROID;
+				}).length;
+
+
+				if (!enemyDroids)
+				{
+					__camGameWon();
+					return;
+				}
+				else
+				{
+					__camTriggerLastAttack();
+				}
 			}
 		}
 		else


### PR DESCRIPTION
Seeing as we have no way to display victory conditions to the player yet, and this type of victory condition requires destroying all units, make any remaining enemy combat units seek out the player if they can.

Missions cam1-d and cam2-7 use this victory condition.

Closes #985.

I keep seeing some people missing the combat units shown in the screenshot I uploaded in that report. So I'm going to tweak it so those units attack the player like standard missions and offworld missions can do. Of course, trucks/repairs/sensors will still need to be sought out like in other missions since we don't want those units blindly rushing into danger.