### PR TITLE
Tweak build and line build.

### DIFF
--- a/lib/framework/vector.h
+++ b/lib/framework/vector.h
@@ -146,4 +146,10 @@ static inline bool WZ_DECL_PURE Vector3i_InSphere(Vector3i v, Vector3i c, unsign
 	return (unsigned int)dot(delta, delta) < r * r;
 }
 
+// Round direction to nearest axis-aligned direction.
+static inline uint16_t snapDirection(uint16_t direction)
+{
+	return (direction + 0x2000) & 0xC000;
+}
+
 #endif // VECTOR_H

--- a/src/action.cpp
+++ b/src/action.cpp
@@ -1529,9 +1529,7 @@ void actionUpdateDroid(DROID *psDroid)
 					psDroid->actionPoints = 0;
 				}
 			}
-			else if ((order->type == DORDER_LINEBUILD || order->type == DORDER_BUILD)
-			         && (psStructStats->type == REF_WALL || psStructStats->type == REF_WALLCORNER || psStructStats->type == REF_GATE ||
-			             psStructStats->type == REF_DEFENSE || psStructStats->type == REF_REARM_PAD))
+			else if (order->type == DORDER_LINEBUILD || order->type == DORDER_BUILD)
 			{
 				// building a wall.
 				MAPTILE *const psTile = worldTile(psDroid->actionPos);

--- a/src/design.cpp
+++ b/src/design.cpp
@@ -2156,7 +2156,7 @@ static void intSetSystemShadowStats(COMPONENT_STATS *psStats)
 static void intSetSensorStats(SENSOR_STATS *psStats)
 {
 	ASSERT_OR_RETURN(, psStats != nullptr, "Invalid stats pointer");
-	ASSERT_OR_RETURN(, psStats->hasType(STAT_SENSOR), "stats ref is out of range");
+	ASSERT_OR_RETURN(, psStats->hasType(STAT_SENSOR), "stats have wrong type");
 
 	/* range */
 	widgSetBarSize(psWScreen, IDDES_SENSORRANGE, sensorRange(psStats, selectedPlayer));
@@ -2167,7 +2167,7 @@ static void intSetSensorStats(SENSOR_STATS *psStats)
 /* Set the shadow bar graphs for the sensor stats */
 static void intSetSensorShadowStats(SENSOR_STATS *psStats)
 {
-	ASSERT(psStats == nullptr || psStats->hasType(STAT_SENSOR), "stats ref is out of range");
+	ASSERT(psStats == nullptr || psStats->hasType(STAT_SENSOR), "stats have wrong type");
 
 	if (psStats)
 	{
@@ -2190,7 +2190,7 @@ static void intSetSensorShadowStats(SENSOR_STATS *psStats)
 static void intSetECMStats(ECM_STATS *psStats)
 {
 	ASSERT_OR_RETURN(, psStats != nullptr, "Invalid stats pointer");
-	ASSERT_OR_RETURN(, psStats->hasType(STAT_ECM), "stats ref is out of range");
+	ASSERT_OR_RETURN(, psStats->hasType(STAT_ECM), "stats have wrong type");
 
 	/* range */
 	widgSetBarSize(psWScreen, IDDES_ECMPOWER, ecmRange(psStats, selectedPlayer));
@@ -2201,7 +2201,7 @@ static void intSetECMStats(ECM_STATS *psStats)
 /* Set the shadow bar graphs for the ECM stats */
 static void intSetECMShadowStats(ECM_STATS *psStats)
 {
-	ASSERT(psStats == nullptr || psStats->hasType(STAT_ECM), "stats ref is out of range");
+	ASSERT(psStats == nullptr || psStats->hasType(STAT_ECM), "stats have wrong type");
 
 	if (psStats)
 	{
@@ -2223,7 +2223,7 @@ static void intSetECMShadowStats(ECM_STATS *psStats)
 static void intSetConstructStats(CONSTRUCT_STATS *psStats)
 {
 	ASSERT_OR_RETURN(, psStats != nullptr, "Invalid stats pointer");
-	ASSERT_OR_RETURN(, psStats->hasType(STAT_CONSTRUCT), "stats ref is out of range");
+	ASSERT_OR_RETURN(, psStats->hasType(STAT_CONSTRUCT), "stats have wrong type");
 
 	/* power */
 	widgSetBarSize(psWScreen, IDDES_CONSTPOINTS,
@@ -2236,7 +2236,7 @@ static void intSetConstructStats(CONSTRUCT_STATS *psStats)
 /* Set the shadow bar graphs for the Constructor stats */
 static void intSetConstructShadowStats(CONSTRUCT_STATS *psStats)
 {
-	ASSERT(psStats == nullptr || psStats->hasType(STAT_CONSTRUCT), "stats ref is out of range");
+	ASSERT(psStats == nullptr || psStats->hasType(STAT_CONSTRUCT), "stats have wrong type");
 
 	if (psStats)
 	{
@@ -2258,7 +2258,7 @@ static void intSetConstructShadowStats(CONSTRUCT_STATS *psStats)
 static void intSetRepairStats(REPAIR_STATS *psStats)
 {
 	ASSERT_OR_RETURN(, psStats != nullptr, "Invalid stats pointer");
-	ASSERT_OR_RETURN(, psStats->hasType(STAT_REPAIR), "stats ref is out of range");
+	ASSERT_OR_RETURN(, psStats->hasType(STAT_REPAIR), "stats have wrong type");
 
 	/* power */
 	widgSetBarSize(psWScreen, IDDES_REPAIRPOINTS,
@@ -2271,7 +2271,7 @@ static void intSetRepairStats(REPAIR_STATS *psStats)
 /* Set the shadow bar graphs for the Repair stats */
 static void intSetRepairShadowStats(REPAIR_STATS *psStats)
 {
-	ASSERT(psStats == nullptr || psStats->hasType(STAT_REPAIR), "stats ref is out of range");
+	ASSERT(psStats == nullptr || psStats->hasType(STAT_REPAIR), "stats have wrong type");
 
 	if (psStats)
 	{
@@ -2294,7 +2294,7 @@ static void intSetRepairShadowStats(REPAIR_STATS *psStats)
 static void intSetWeaponStats(WEAPON_STATS *psStats)
 {
 	ASSERT_OR_RETURN(, psStats != nullptr, "Invalid stats pointer");
-	ASSERT_OR_RETURN(, psStats->hasType(STAT_WEAPON), "stats ref is out of range");
+	ASSERT_OR_RETURN(, psStats->hasType(STAT_WEAPON), "stats have wrong type");
 
 	/* range */
 	widgSetBarSize(psWScreen, IDDES_WEAPRANGE, proj_GetLongRange(psStats, selectedPlayer));
@@ -2310,7 +2310,7 @@ static void intSetWeaponStats(WEAPON_STATS *psStats)
 /* Set the shadow bar graphs for the Weapon stats */
 static void intSetWeaponShadowStats(WEAPON_STATS *psStats)
 {
-	ASSERT(psStats == nullptr || psStats->hasType(STAT_WEAPON), "stats ref is out of range");
+	ASSERT(psStats == nullptr || psStats->hasType(STAT_WEAPON), "stats have wrong type");
 
 	if (psStats)
 	{
@@ -2340,7 +2340,7 @@ static void intSetBodyStats(BODY_STATS *psStats)
 	W_FORM	*psForm;
 
 	ASSERT_OR_RETURN(, psStats != nullptr, "Invalid stats pointer");
-	ASSERT_OR_RETURN(, psStats->hasType(STAT_BODY), "stats ref is out of range");
+	ASSERT_OR_RETURN(, psStats->hasType(STAT_BODY), "stats have wrong type");
 
 	/* set form tip to stats string */
 	widgSetTip(psWScreen, IDDES_BODYFORM, getName(psStats));
@@ -2366,7 +2366,7 @@ static void intSetBodyStats(BODY_STATS *psStats)
 /* Set the shadow bar graphs for the Body stats */
 static void intSetBodyShadowStats(BODY_STATS *psStats)
 {
-	ASSERT(psStats == nullptr || psStats->hasType(STAT_BODY), "stats ref is out of range");
+	ASSERT(psStats == nullptr || psStats->hasType(STAT_BODY), "stats have wrong type");
 
 	if (psStats)
 	{
@@ -2736,7 +2736,7 @@ static void intSetPropulsionStats(PROPULSION_STATS *psStats)
 	UDWORD      weight;
 
 	ASSERT_OR_RETURN(, psStats != nullptr, "Invalid stats pointer");
-	ASSERT_OR_RETURN(, psStats->hasType(STAT_PROPULSION), "stats ref is out of range");
+	ASSERT_OR_RETURN(, psStats->hasType(STAT_PROPULSION), "stats have wrong type");
 
 	/* set form tip to stats string */
 	widgSetTip(psWScreen, IDDES_PROPFORM, getName(psStats));
@@ -2788,7 +2788,7 @@ static void intSetPropulsionShadowStats(PROPULSION_STATS *psStats)
 {
 	UDWORD      weight;
 
-	ASSERT(psStats == nullptr || psStats->hasType(STAT_PROPULSION), "stats ref is out of range");
+	ASSERT(psStats == nullptr || psStats->hasType(STAT_PROPULSION), "stats have wrong type");
 
 	/* Only set the shadow stats if they are the right type */
 	if (psStats &&

--- a/src/design.cpp
+++ b/src/design.cpp
@@ -2602,7 +2602,7 @@ static void intSetTemplateBodyShadowStats(COMPONENT_STATS *psStats)
 	UDWORD weapon1Body     = asWeaponStats[sCurrDesign.numWeaps ? sCurrDesign.asWeaps[0] : 0].upgrade[plr].hitpoints;
 	UDWORD weapon2Body     = asWeaponStats[sCurrDesign.numWeaps >= 2 ? sCurrDesign.asWeaps[1] : 0].upgrade[plr].hitpoints;
 	UDWORD weapon3Body     = asWeaponStats[sCurrDesign.numWeaps >= 3 ? sCurrDesign.asWeaps[2] : 0].upgrade[plr].hitpoints;
-	UDWORD newComponentHP = psStats->pUpgrade[plr]->hitpoints;
+	UDWORD newComponentHP = psStats->getUpgrade(plr).hitpoints;
 
 	UDWORD hitPointPct;
 	UDWORD bodyPct        = asBodyStats[sCurrDesign.asParts[COMP_BODY]].upgrade[plr].hitpointPct - 100;
@@ -2615,7 +2615,7 @@ static void intSetTemplateBodyShadowStats(COMPONENT_STATS *psStats)
 	UDWORD weapon1Pct     = asWeaponStats[sCurrDesign.numWeaps ? sCurrDesign.asWeaps[0] : 0].upgrade[plr].hitpointPct - 100;
 	UDWORD weapon2Pct     = asWeaponStats[sCurrDesign.numWeaps >= 2 ? sCurrDesign.asWeaps[1] : 0].upgrade[plr].hitpointPct - 100;
 	UDWORD weapon3Pct     = asWeaponStats[sCurrDesign.numWeaps >= 3 ? sCurrDesign.asWeaps[2] : 0].upgrade[plr].hitpointPct - 100;
-	UDWORD newComponentPct = psStats->pUpgrade[plr]->hitpointPct - 100;
+	UDWORD newComponentPct = psStats->getUpgrade(plr).hitpointPct - 100;
 
 	UDWORD psPropPctBody = asPropulsionStats[sCurrDesign.asParts[COMP_PROPULSION]].upgrade[plr].hitpointPctOfBody / 100;
 

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -78,7 +78,8 @@
 #include "warzoneconfig.h"
 #include "lib/ivis_opengl/piematrix.h"
 
-struct	_dragBox dragBox3D, wallDrag;
+DragBox3D dragBox3D;
+WallDrag wallDrag;
 
 #define POSSIBLE_SELECTIONS		14
 #define POSSIBLE_TARGETS		23
@@ -483,14 +484,9 @@ static void CheckFinishedDrag()
 				    && sBuildDetails.psStats->ref >= REF_STRUCTURE_START
 				    && sBuildDetails.psStats->ref < (REF_STRUCTURE_START + REF_RANGE))
 				{
-					if ((((STRUCTURE_STATS *)sBuildDetails.psStats)->type == REF_WALL
-					     || ((STRUCTURE_STATS *)sBuildDetails.psStats)->type == REF_DEFENSE
-					     || ((STRUCTURE_STATS *)sBuildDetails.psStats)->type == REF_GATE
-					     || ((STRUCTURE_STATS *)sBuildDetails.psStats)->type == REF_REARM_PAD)
-					    && !isLasSat((STRUCTURE_STATS *)sBuildDetails.psStats))
+					if (canLineBuild())
 					{
-						wallDrag.x2 = mouseTileX;
-						wallDrag.y2 = mouseTileY;
+						wallDrag.pos2 = mousePos;
 						wallDrag.status = DRAG_RELEASED;
 					}
 				}
@@ -524,14 +520,9 @@ static void CheckStartWallDrag()
 		    && sBuildDetails.psStats->ref >= REF_STRUCTURE_START
 		    && sBuildDetails.psStats->ref < (REF_STRUCTURE_START + REF_RANGE))
 		{
-			if ((((STRUCTURE_STATS *)sBuildDetails.psStats)->type == REF_WALL
-			     || ((STRUCTURE_STATS *)sBuildDetails.psStats)->type == REF_DEFENSE
-			     || ((STRUCTURE_STATS *)sBuildDetails.psStats)->type == REF_GATE
-			     || ((STRUCTURE_STATS *)sBuildDetails.psStats)->type == REF_REARM_PAD)
-			    && !isLasSat((STRUCTURE_STATS *)sBuildDetails.psStats))
+			if (canLineBuild())
 			{
-				wallDrag.x1 = wallDrag.x2 = mouseTileX;
-				wallDrag.y1 = wallDrag.y2 = mouseTileY;
+				wallDrag.pos = wallDrag.pos2 = mousePos;
 				wallDrag.status = DRAG_PLACING;
 				debug(LOG_NEVER, "Start Wall Drag\n");
 			}
@@ -560,31 +551,9 @@ static bool CheckFinishedFindPosition()
 		}
 		else if (buildState == BUILD3D_VALID)
 		{
-			if ((((STRUCTURE_STATS *)sBuildDetails.psStats)->type == REF_WALL
-			     || ((STRUCTURE_STATS *)sBuildDetails.psStats)->type == REF_GATE
-			     || ((STRUCTURE_STATS *)sBuildDetails.psStats)->type == REF_REARM_PAD
-			     || ((STRUCTURE_STATS *)sBuildDetails.psStats)->type == REF_DEFENSE)
-			    && sBuildDetails.psStats->ref >= REF_STRUCTURE_START
-			    && sBuildDetails.psStats->ref < (REF_STRUCTURE_START + REF_RANGE)
-			    && !isLasSat((STRUCTURE_STATS *)sBuildDetails.psStats))
+			if (sBuildDetails.psStats->typeIs(REF_STRUCTURE_START) && canLineBuild())
 			{
-				int dx, dy;
-
-				wallDrag.x2 = mouseTileX;
-				wallDrag.y2 = mouseTileY;
-
-				dx = abs(mouseTileX - wallDrag.x1);
-				dy = abs(mouseTileY - wallDrag.y1);
-
-				if (dx >= dy)
-				{
-					wallDrag.y2 = wallDrag.y1;
-				}
-				else if (dx < dy)
-				{
-					wallDrag.x2 = wallDrag.x1;
-				}
-
+				wallDrag.pos2 = mousePos;
 				wallDrag.status = DRAG_RELEASED;
 			}
 			debug(LOG_NEVER, "BUILD3D_FINISHED\n");
@@ -608,33 +577,10 @@ static void HandleDrag()
 		dragBox3D.y2 = mouseY();
 		dragBox3D.status = DRAG_DRAGGING;
 
-		if (buildState == BUILD3D_VALID)
+		if (buildState == BUILD3D_VALID && canLineBuild())
 		{
-			if ((((STRUCTURE_STATS *)sBuildDetails.psStats)->type == REF_WALL
-			     || ((STRUCTURE_STATS *)sBuildDetails.psStats)->type == REF_GATE
-			     || ((STRUCTURE_STATS *)sBuildDetails.psStats)->type == REF_DEFENSE
-			     || ((STRUCTURE_STATS *)sBuildDetails.psStats)->type == REF_REARM_PAD)
-			    && !isLasSat((STRUCTURE_STATS *)sBuildDetails.psStats))
-			{
-				int dx, dy;
-
-				wallDrag.x2 = mouseTileX;
-				wallDrag.y2 = mouseTileY;
-
-				dx = abs(mouseTileX - wallDrag.x1);
-				dy = abs(mouseTileY - wallDrag.y1);
-
-				if (dx >= dy)
-				{
-					wallDrag.y2 = wallDrag.y1;
-				}
-				else if (dx < dy)
-				{
-					wallDrag.x2 = wallDrag.x1;
-				}
-
-				wallDrag.status = DRAG_DRAGGING;
-			}
+			wallDrag.pos2 = mousePos;
+			wallDrag.status = DRAG_DRAGGING;
 		}
 	}
 }

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -481,8 +481,7 @@ static void CheckFinishedDrag()
 			{
 				//if invalid location keep looking for a valid one
 				if ((buildState == BUILD3D_VALID || buildState == BUILD3D_FINISHED)
-				    && sBuildDetails.psStats->ref >= REF_STRUCTURE_START
-				    && sBuildDetails.psStats->ref < (REF_STRUCTURE_START + REF_RANGE))
+				    && sBuildDetails.psStats->hasType(STAT_STRUCTURE))
 				{
 					if (canLineBuild())
 					{
@@ -517,8 +516,7 @@ static void CheckStartWallDrag()
 		// You can start dragging walls from invalid locations so check for
 		// BUILD3D_POS or BUILD3D_VALID, used tojust check for BUILD3D_VALID.
 		if ((buildState == BUILD3D_POS || buildState == BUILD3D_VALID)
-		    && sBuildDetails.psStats->ref >= REF_STRUCTURE_START
-		    && sBuildDetails.psStats->ref < (REF_STRUCTURE_START + REF_RANGE))
+		    && sBuildDetails.psStats->hasType(STAT_STRUCTURE))
 		{
 			if (canLineBuild())
 			{
@@ -551,7 +549,7 @@ static bool CheckFinishedFindPosition()
 		}
 		else if (buildState == BUILD3D_VALID)
 		{
-			if (sBuildDetails.psStats->typeIs(REF_STRUCTURE_START) && canLineBuild())
+			if (sBuildDetails.psStats->hasType(STAT_STRUCTURE) && canLineBuild())
 			{
 				wallDrag.pos2 = mousePos;
 				wallDrag.status = DRAG_RELEASED;

--- a/src/display.h
+++ b/src/display.h
@@ -75,24 +75,33 @@ void displayWorld();
 
 // Illumination value for standard light level "as the artist drew it" ... not darker, not lighter
 
-#define DRAG_INACTIVE 0
-#define DRAG_DRAGGING 1
-#define DRAG_RELEASED 2
-#define DRAG_PLACING  3
+enum DragState
+{
+	DRAG_INACTIVE,
+	DRAG_DRAGGING,
+	DRAG_RELEASED,
+	DRAG_PLACING
+};
 
-#define BOX_PULSE_SPEED	50
-
-struct	_dragBox
+struct DragBox3D
 {
 	int x1;
 	int y1;
 	int x2;
 	int y2;
-	UDWORD status;
+	DragState status;
 	float pulse = 0;
 };
 
-extern struct	_dragBox dragBox3D, wallDrag;
+struct WallDrag
+{
+	Vector2i pos;
+	Vector2i pos2;
+	DragState status;
+};
+
+extern DragBox3D dragBox3D;
+extern WallDrag wallDrag;
 
 enum MOUSE_POINTER
 {

--- a/src/display3d.cpp
+++ b/src/display3d.cpp
@@ -1702,17 +1702,18 @@ void displayBlueprints(const glm::mat4 &viewMatrix)
 			state = SS_BLUEPRINT_INVALID;
 		}
 		// we are placing a building or a delivery point
-		if (sBuildDetails.psStats->hasType(STAT_STRUCTURE))
+		if (STRUCTURE_STATS *stats = castStructureStats(sBuildDetails.psStats))
 		{
 			// it's a building
+			uint16_t direction = snapDirection(player.r.y);
 			if (wallDrag.status == DRAG_PLACING || wallDrag.status == DRAG_DRAGGING)
 			{
-				drawLineBuild((STRUCTURE_STATS *)sBuildDetails.psStats, wallDrag.pos, wallDrag.pos2, (player.r.y + 0x2000) & 0xC000, state);
+				drawLineBuild(stats, wallDrag.pos, wallDrag.pos2, direction, state);
 			}
 			else
 			{
 				unsigned width, height;
-				if (((player.r.y + 0x2000) & 0x4000) == 0)
+				if ((direction & 0x4000) == 0)
 				{
 					width  = sBuildDetails.width;
 					height = sBuildDetails.height;
@@ -1725,7 +1726,7 @@ void displayBlueprints(const glm::mat4 &viewMatrix)
 				}
 				// a single building
 				Vector2i pos(world_coord(sBuildDetails.x) + world_coord(width) / 2, world_coord(sBuildDetails.y) + world_coord(height) / 2);
-				Blueprint blueprint((STRUCTURE_STATS *)sBuildDetails.psStats, pos, (player.r.y + 0x2000) & 0xC000, 0, state);
+				Blueprint blueprint(stats, pos, direction, 0, state);
 				blueprints.push_back(blueprint);
 			}
 		}

--- a/src/display3d.cpp
+++ b/src/display3d.cpp
@@ -1689,8 +1689,8 @@ void displayBlueprints(const glm::mat4 &viewMatrix)
 	blueprints.clear();  // Delete old blueprints and draw new ones.
 
 	if ((buildState == BUILD3D_VALID || buildState == BUILD3D_POS) &&
-	    sBuildDetails.x > 0 && sBuildDetails.x < mapWidth &&
-	    sBuildDetails.y > 0 && sBuildDetails.y < mapHeight)
+	    sBuildDetails.x > 0 && sBuildDetails.x < (int)mapWidth &&
+	    sBuildDetails.y > 0 && sBuildDetails.y < (int)mapHeight)
 	{
 		STRUCT_STATES state;
 		if (buildState == BUILD3D_VALID)
@@ -1702,8 +1702,7 @@ void displayBlueprints(const glm::mat4 &viewMatrix)
 			state = SS_BLUEPRINT_INVALID;
 		}
 		// we are placing a building or a delivery point
-		if (sBuildDetails.psStats->ref >= REF_STRUCTURE_START
-		    && sBuildDetails.psStats->ref < (REF_STRUCTURE_START + REF_RANGE))
+		if (sBuildDetails.psStats->hasType(STAT_STRUCTURE))
 		{
 			// it's a building
 			if (wallDrag.status == DRAG_PLACING || wallDrag.status == DRAG_DRAGGING)
@@ -1733,7 +1732,7 @@ void displayBlueprints(const glm::mat4 &viewMatrix)
 	}
 
 	// now we draw the blueprints for all ordered buildings
-	for (int player = 0; player < MAX_PLAYERS; ++player)
+	for (unsigned player = 0; player < MAX_PLAYERS; ++player)
 	{
 		if (!hasSharedVision(selectedPlayer, player))
 		{

--- a/src/droiddef.h
+++ b/src/droiddef.h
@@ -78,12 +78,12 @@ struct DROID_TEMPLATE : public BASE_STATS
 
 static inline DROID_TEMPLATE *castDroidTemplate(BASE_STATS *stats)
 {
-	return stats != nullptr && stats->typeIs(REF_TEMPLATE_START)? static_cast<DROID_TEMPLATE *>(stats) : nullptr;
+	return stats != nullptr && stats->hasType(STAT_TEMPLATE)? static_cast<DROID_TEMPLATE *>(stats) : nullptr;
 }
 
 static inline DROID_TEMPLATE const *castDroidTemplate(BASE_STATS const *stats)
 {
-	return stats != nullptr && stats->typeIs(REF_TEMPLATE_START)? static_cast<DROID_TEMPLATE const *>(stats) : nullptr;
+	return stats != nullptr && stats->hasType(STAT_TEMPLATE)? static_cast<DROID_TEMPLATE const *>(stats) : nullptr;
 }
 
 class DROID_GROUP;

--- a/src/droiddef.h
+++ b/src/droiddef.h
@@ -76,6 +76,16 @@ struct DROID_TEMPLATE : public BASE_STATS
 	bool            enabled;                    ///< Has been enabled
 };
 
+static inline DROID_TEMPLATE *castDroidTemplate(BASE_STATS *stats)
+{
+	return stats != nullptr && stats->typeIs(REF_TEMPLATE_START)? static_cast<DROID_TEMPLATE *>(stats) : nullptr;
+}
+
+static inline DROID_TEMPLATE const *castDroidTemplate(BASE_STATS const *stats)
+{
+	return stats != nullptr && stats->typeIs(REF_TEMPLATE_START)? static_cast<DROID_TEMPLATE const *>(stats) : nullptr;
+}
+
 class DROID_GROUP;
 struct STRUCTURE;
 

--- a/src/edit3d.cpp
+++ b/src/edit3d.cpp
@@ -126,19 +126,19 @@ void init3DBuilding(BASE_STATS *psStats, BUILDCALLBACK CallBack, void *UserData)
 	sBuildDetails.CallBack = CallBack;
 	sBuildDetails.UserData = UserData;
 
-	if (psStats->typeIs(REF_STRUCTURE_START))
+	if (psStats->hasType(STAT_STRUCTURE))
 	{
 		sBuildDetails.width = ((STRUCTURE_STATS *)psStats)->baseWidth;
 		sBuildDetails.height = ((STRUCTURE_STATS *)psStats)->baseBreadth;
 		sBuildDetails.psStats = psStats;
 	}
-	else if (psStats->typeIs(REF_FEATURE_START))
+	else if (psStats->hasType(STAT_FEATURE))
 	{
 		sBuildDetails.width = ((FEATURE_STATS *)psStats)->baseWidth;
 		sBuildDetails.height = ((FEATURE_STATS *)psStats)->baseBreadth;
 		sBuildDetails.psStats = psStats;
 	}
-	else /*if (psStats->typeIs(REF_TEMPLATE_START))*/
+	else /*if (psStats->hasType(STAT_TEMPLATE))*/
 	{
 		sBuildDetails.width = 1;
 		sBuildDetails.height = 1;
@@ -183,7 +183,7 @@ bool process3DBuilding()
 	if (buildState != BUILD3D_FINISHED)
 	{
 		bool isValid = true;
-		if (wallDrag.status != DRAG_INACTIVE && sBuildDetails.psStats->typeIs(REF_STRUCTURE_START) && canLineBuild())
+		if (wallDrag.status != DRAG_INACTIVE && sBuildDetails.psStats->hasType(STAT_STRUCTURE) && canLineBuild())
 		{
 			wallDrag.pos2 = mousePos;  // Why must this be done here? If not doing it here, dragging works almost normally, except it suddenly stops working if the drag becomes invalid.
 

--- a/src/edit3d.cpp
+++ b/src/edit3d.cpp
@@ -203,7 +203,7 @@ bool process3DBuilding()
 
 	sBuildDetails.x = buildSite.xTL = map_coord(bv.x - worldSize.x/2);
 	sBuildDetails.y = buildSite.yTL = map_coord(bv.y - worldSize.y/2);
-	if (((player.r.y + 0x2000) & 0x4000) == 0)
+	if ((snapDirection(player.r.y) & 0x4000) == 0)
 	{
 		buildSite.xBR = buildSite.xTL + sBuildDetails.width - 1;
 		buildSite.yBR = buildSite.yTL + sBuildDetails.height - 1;
@@ -270,8 +270,7 @@ bool found3DBuildLocTwo(Vector2i &pos, Vector2i &pos2)
 
 	wallDrag.status = DRAG_INACTIVE;
 	STRUCTURE_STATS *stats = (STRUCTURE_STATS *)sBuildDetails.psStats;
-	uint16_t direction = (player.r.y + 0x2000) & 0xC000;
-	LineBuild lb = calcLineBuild(stats, direction, wallDrag.pos, wallDrag.pos2);
+	LineBuild lb = calcLineBuild(stats, player.r.y, wallDrag.pos, wallDrag.pos2);
 	pos = lb.begin;
 	pos2 = lb.back();
 

--- a/src/edit3d.cpp
+++ b/src/edit3d.cpp
@@ -39,9 +39,9 @@ x coordinate that is greater than mapWidth implies that the highlight
 is invalid (not currently being used)
 */
 
-UDWORD	buildState = BUILD3D_NONE;
-BUILDDETAILS	sBuildDetails;
-HIGHLIGHT		buildSite;
+BuildState buildState = BUILD3D_NONE;
+HIGHLIGHT buildSite;
+BUILDDETAILS sBuildDetails;
 int brushSize = 1;
 bool quickQueueMode = false;
 
@@ -125,30 +125,28 @@ void init3DBuilding(BASE_STATS *psStats, BUILDCALLBACK CallBack, void *UserData)
 
 	sBuildDetails.CallBack = CallBack;
 	sBuildDetails.UserData = UserData;
-	sBuildDetails.x = mouseTileX;
-	sBuildDetails.y = mouseTileY;
 
-	if (psStats->ref >= REF_STRUCTURE_START &&
-	    psStats->ref < (REF_STRUCTURE_START + REF_RANGE))
+	if (psStats->typeIs(REF_STRUCTURE_START))
 	{
 		sBuildDetails.width = ((STRUCTURE_STATS *)psStats)->baseWidth;
 		sBuildDetails.height = ((STRUCTURE_STATS *)psStats)->baseBreadth;
 		sBuildDetails.psStats = psStats;
 	}
-	else if (psStats->ref >= REF_FEATURE_START &&
-	         psStats->ref < (REF_FEATURE_START + REF_RANGE))
+	else if (psStats->typeIs(REF_FEATURE_START))
 	{
 		sBuildDetails.width = ((FEATURE_STATS *)psStats)->baseWidth;
 		sBuildDetails.height = ((FEATURE_STATS *)psStats)->baseBreadth;
 		sBuildDetails.psStats = psStats;
 	}
-	else /*if (psStats->ref >= REF_TEMPLATE_START &&
-			 psStats->ref < (REF_TEMPLATE_START + REF_RANGE))*/
+	else /*if (psStats->typeIs(REF_TEMPLATE_START))*/
 	{
 		sBuildDetails.width = 1;
 		sBuildDetails.height = 1;
 		sBuildDetails.psStats = psStats;
 	}
+
+	sBuildDetails.x = map_coord(mousePos.x - world_coord(sBuildDetails.width)/2);
+	sBuildDetails.y = map_coord(mousePos.y - world_coord(sBuildDetails.height)/2);
 }
 
 void	kill3DBuilding()
@@ -176,26 +174,35 @@ bool process3DBuilding()
 	}
 
 	/* Need to update the building locations if we're building */
-	int bX = clip(mouseTileX, 2, mapWidth - 3);
-	int bY = clip(mouseTileY, 2, mapHeight - 3);
+	int border = 5*TILE_UNITS/2;
+	Vector2i bv = {clip(mousePos.x, border, mapWidth*TILE_UNITS - border), clip(mousePos.y, border, mapHeight*TILE_UNITS - border)};
+	Vector2i size = getStatsSize(sBuildDetails.psStats, player.r.y);
+	Vector2i worldSize = world_coord(size);
+	bv = round_to_nearest_tile(bv - worldSize/2) + worldSize/2;
 
 	if (buildState != BUILD3D_FINISHED)
 	{
-		Vector2i size = getStatsSize(sBuildDetails.psStats, player.r.y);
-		Vector2i offset = size * (TILE_UNITS / 2);  // This presumably gets added to the chosen coordinates, somewhere, based on looking at what pickStructLocation does. No idea where it gets added, though.
-
-		if (validLocation(sBuildDetails.psStats, world_coord(Vector2i(bX, bY)) + offset, player.r.y, selectedPlayer, true))
+		bool isValid = true;
+		if (wallDrag.status != DRAG_INACTIVE && sBuildDetails.psStats->typeIs(REF_STRUCTURE_START) && canLineBuild())
 		{
-			buildState = BUILD3D_VALID;
+			wallDrag.pos2 = mousePos;  // Why must this be done here? If not doing it here, dragging works almost normally, except it suddenly stops working if the drag becomes invalid.
+
+			auto lb = calcLineBuild(static_cast<STRUCTURE_STATS *>(sBuildDetails.psStats), player.r.y, wallDrag.pos, wallDrag.pos2);
+			for (int i = 0; i < lb.count && isValid; ++i)
+			{
+				isValid &= validLocation(sBuildDetails.psStats, lb[i], player.r.y, selectedPlayer, true);
+			}
 		}
 		else
 		{
-			buildState = BUILD3D_POS;
+			isValid = validLocation(sBuildDetails.psStats, bv, player.r.y, selectedPlayer, true);
 		}
+
+		buildState = isValid? BUILD3D_VALID : BUILD3D_POS;
 	}
 
-	sBuildDetails.x = buildSite.xTL = bX;
-	sBuildDetails.y = buildSite.yTL = bY;
+	sBuildDetails.x = buildSite.xTL = map_coord(bv.x - worldSize.x/2);
+	sBuildDetails.y = buildSite.yTL = map_coord(bv.y - worldSize.y/2);
 	if (((player.r.y + 0x2000) & 0x4000) == 0)
 	{
 		buildSite.xBR = buildSite.xTL + sBuildDetails.width - 1;
@@ -225,15 +232,14 @@ bool process3DBuilding()
 
 
 /* See if a structure location has been found */
-bool found3DBuilding(UDWORD *x, UDWORD *y)
+bool found3DBuilding(Vector2i &pos)
 {
-	if (buildState != BUILD3D_FINISHED || x == nullptr || y == nullptr)
+	if (buildState != BUILD3D_FINISHED)
 	{
 		return false;
 	}
 
-	*x = sBuildDetails.x;
-	*y = sBuildDetails.y;
+	pos = world_coord({sBuildDetails.x, sBuildDetails.y}) + world_coord({sBuildDetails.width, sBuildDetails.height})/2;
 
 	if (ctrlShiftDown())
 	{
@@ -249,13 +255,9 @@ bool found3DBuilding(UDWORD *x, UDWORD *y)
 }
 
 /* See if a second position for a build has been found */
-bool found3DBuildLocTwo(UDWORD *px1, UDWORD *py1, UDWORD *px2, UDWORD *py2)
+bool found3DBuildLocTwo(Vector2i &pos, Vector2i &pos2)
 {
-	if ((((STRUCTURE_STATS *)sBuildDetails.psStats)->type != REF_WALL &&
-	     ((STRUCTURE_STATS *)sBuildDetails.psStats)->type != REF_GATE &&
-	     ((STRUCTURE_STATS *)sBuildDetails.psStats)->type != REF_DEFENSE &&
-	     ((STRUCTURE_STATS *)sBuildDetails.psStats)->type != REF_REARM_PAD) ||
-	    wallDrag.status != DRAG_RELEASED)
+	if (wallDrag.status != DRAG_RELEASED || !canLineBuild())
 	{
 		return false;
 	}
@@ -267,10 +269,11 @@ bool found3DBuildLocTwo(UDWORD *px1, UDWORD *py1, UDWORD *px2, UDWORD *py2)
 	}
 
 	wallDrag.status = DRAG_INACTIVE;
-	*px1 = wallDrag.x1;
-	*py1 = wallDrag.y1;
-	*px2 = wallDrag.x2;
-	*py2 = wallDrag.y2;
+	STRUCTURE_STATS *stats = (STRUCTURE_STATS *)sBuildDetails.psStats;
+	uint16_t direction = (player.r.y + 0x2000) & 0xC000;
+	LineBuild lb = calcLineBuild(stats, direction, wallDrag.pos, wallDrag.pos2);
+	pos = lb.begin;
+	pos2 = lb.back();
 
 	if (ctrlShiftDown())
 	{

--- a/src/edit3d.h
+++ b/src/edit3d.h
@@ -31,8 +31,8 @@
 typedef void (*BUILDCALLBACK)(UDWORD xPos, UDWORD yPos, void *UserData);
 
 void Edit3DInitVars();
-bool found3DBuilding(UDWORD *x, UDWORD *y);
-bool found3DBuildLocTwo(UDWORD *px1, UDWORD *py1, UDWORD *px2, UDWORD *py2);
+bool found3DBuilding(Vector2i &pos);
+bool found3DBuildLocTwo(Vector2i &pos, Vector2i &pos2);
 void init3DBuilding(BASE_STATS *psStats, BUILDCALLBACK CallBack, void *UserData);
 void kill3DBuilding();
 bool process3DBuilding();
@@ -42,6 +42,16 @@ void raiseTile(int tile3dX, int tile3dY);
 void lowerTile(int tile3dX, int tile3dY);
 bool inHighlight(UDWORD realX, UDWORD realY);
 
+enum BuildState
+{
+	BUILD3D_NONE,
+	BUILD3D_POS,
+	BUILD3D_FINISHED,
+	BUILD3D_VALID
+};
+
+extern BuildState buildState;
+
 struct HIGHLIGHT
 {
 	UWORD	xTL, yTL;		// Top left of box to highlight
@@ -49,13 +59,6 @@ struct HIGHLIGHT
 };
 
 extern HIGHLIGHT	buildSite;
-
-
-#define BUILD3D_NONE		99
-#define BUILD3D_POS			100
-#define BUILD3D_FINISHED	101
-#define BUILD3D_VALID		102
-
 
 struct BUILDDETAILS
 {
@@ -68,8 +71,12 @@ struct BUILDDETAILS
 
 extern BUILDDETAILS	sBuildDetails;
 
-extern UDWORD buildState;
-extern UDWORD temp;
+// May only call if sBuildDetails.psStats points to a STRUCTURE_STATS.
+static inline bool canLineBuild()
+{
+	return ((STRUCTURE_STATS *)sBuildDetails.psStats)->upgrade[selectedPlayer].limit > 1;
+}
+
 extern int brushSize;
 extern bool quickQueueMode;
 

--- a/src/feature.cpp
+++ b/src/feature.cpp
@@ -74,7 +74,7 @@ bool loadFeatureStats(WzConfig &ini)
 	for (int i = 0; i < list.size(); ++i)
 	{
 		ini.beginGroup(list[i]);
-		asFeatureStats[i] = FEATURE_STATS(REF_FEATURE_START + i);
+		asFeatureStats[i] = FEATURE_STATS(STAT_FEATURE + i);
 		FEATURE_STATS *p = &asFeatureStats[i];
 		p->name = ini.string(WzString::fromUtf8("name"));
 		p->id = list[i];

--- a/src/hci.cpp
+++ b/src/hci.cpp
@@ -1027,8 +1027,7 @@ static void intProcessEditStats(UDWORD id)
 	{
 		/* Clicked on a stat button - need to look for a location for it */
 		psPositionStats = ppsStatsList[id - IDSTAT_START];
-		if (psPositionStats->ref >= REF_TEMPLATE_START &&
-		    psPositionStats->ref < REF_TEMPLATE_START + REF_RANGE)
+		if (psPositionStats->hasType(STAT_TEMPLATE))
 		{
 			FLAG_POSITION debugMenuDroidDeliveryPoint;
 			// Placing a droid from the debug menu, set up the flag. (This would probably be safe to do, even if we're placing something else.)
@@ -1564,7 +1563,7 @@ INT_RETVAL intRunWidgets()
 							Cheated = true;
 						}
 					}
-					else if (psPositionStats->typeIs(REF_FEATURE_START))
+					else if (psPositionStats->hasType(STAT_FEATURE))
 					{
 						// Send a text message to all players, notifying them of the fact that we're cheating ourselves a new feature.
 						std::string msg = astringf(_("Player %u is cheating (debug menu) him/herself a new feature: %s."),
@@ -1575,7 +1574,7 @@ INT_RETVAL intRunWidgets()
 						//sendMultiPlayerFeature(result->psStats->subType, result->pos.x, result->pos.y, result->id);
 						sendMultiPlayerFeature(((FEATURE_STATS *)psPositionStats)->ref, pos.x, pos.y, generateNewObjectId());
 					}
-					else if (psPositionStats->typeIs(REF_TEMPLATE_START))
+					else if (psPositionStats->hasType(STAT_TEMPLATE))
 					{
 						std::string msg;
 						DROID *psDroid = buildDroid((DROID_TEMPLATE *)psPositionStats, pos.x, pos.y, selectedPlayer, false, nullptr);
@@ -1642,21 +1641,18 @@ static void intRunPower()
 	if (statID >= IDSTAT_START && statID <= IDSTAT_END)
 	{
 		psStat = ppsStatsList[statID - IDSTAT_START];
-		if (psStat->ref >= REF_STRUCTURE_START && psStat->ref <
-		    REF_STRUCTURE_START + REF_RANGE)
+		if (psStat->hasType(STAT_STRUCTURE))
 		{
 			//get the structure build points
 			quantity = ((STRUCTURE_STATS *)apsStructStatsList[statID -
 			            IDSTAT_START])->powerToBuild;
 		}
-		else if (psStat->ref >= REF_TEMPLATE_START &&
-		         psStat->ref < REF_TEMPLATE_START + REF_RANGE)
+		else if (psStat->hasType(STAT_TEMPLATE))
 		{
 			//get the template build points
 			quantity = calcTemplatePower(apsTemplateList[statID - IDSTAT_START]);
 		}
-		else if (psStat->ref >= REF_RESEARCH_START &&
-		         psStat->ref < REF_RESEARCH_START + REF_RANGE)
+		else if (psStat->hasType(STAT_RESEARCH))
 		{
 			//get the research points
 			psResearch = (RESEARCH *)ppResearchList[statID - IDSTAT_START];
@@ -3158,7 +3154,7 @@ static bool intAddObjectWindow(BASE_OBJECT *psObjects, BASE_OBJECT *psSelected, 
 				{
 					sAllyResearch.formID = nextObjButtonId;
 					sAllyResearch.x = STAT_BUTWIDTH  - (sAllyResearch.width + 2) * ii - sAllyResearch.width - 2;
-					sAllyResearch.UserData = PACKDWORD(Stat->ref - REF_RESEARCH_START, ii);
+					sAllyResearch.UserData = PACKDWORD(Stat->ref - STAT_RESEARCH, ii);
 					sAllyResearch.pTip = getPlayerName(researches[ii].player);
 					widgAddLabel(psWScreen, &sAllyResearch);
 
@@ -3723,8 +3719,7 @@ static bool intAddStats(BASE_STATS **ppsStatsList, UDWORD numStats,
 		WzString tipString = getName(ppsStatsList[i]);
 		unsigned powerCost = 0;
 		W_BARGRAPH *bar;
-		if (Stat->ref >= REF_STRUCTURE_START &&
-		    Stat->ref < REF_STRUCTURE_START + REF_RANGE)  		// It's a structure.
+		if (Stat->hasType(STAT_STRUCTURE))  // It's a structure.
 		{
 			powerCost = ((STRUCTURE_STATS *)Stat)->powerToBuild;
 			sBarInit.size = powerCost / POWERPOINTS_DROIDDIV;
@@ -3738,8 +3733,7 @@ static bool intAddStats(BASE_STATS **ppsStatsList, UDWORD numStats,
 			bar = widgAddBarGraph(psWScreen, &sBarInit);
 			bar->setBackgroundColour(WZCOL_BLACK);
 		}
-		else if (Stat->ref >= REF_TEMPLATE_START &&
-		         Stat->ref < REF_TEMPLATE_START + REF_RANGE)  	// It's a droid.
+		else if (Stat->hasType(STAT_TEMPLATE))  // It's a droid.
 		{
 			powerCost = calcTemplatePower((DROID_TEMPLATE *)Stat);
 			sBarInit.size = powerCost / POWERPOINTS_DROIDDIV;
@@ -3762,8 +3756,7 @@ static bool intAddStats(BASE_STATS **ppsStatsList, UDWORD numStats,
 			}
 			sLabInit.id++;
 		}
-		else if (Stat->ref >= REF_RESEARCH_START &&
-		         Stat->ref < REF_RESEARCH_START + REF_RANGE)				// It's a Research topic.
+		else if (Stat->hasType(STAT_RESEARCH))  // It's a Research topic.
 		{
 			sLabInit = W_LABINIT();
 			sLabInit.formID = nextButtonId;
@@ -3801,7 +3794,7 @@ static bool intAddStats(BASE_STATS **ppsStatsList, UDWORD numStats,
 					sLabInit.height = iV_GetImageHeight(IntImages, IMAGE_ALLY_RESEARCH);
 					sLabInit.x = STAT_BUTWIDTH  - (sLabInit.width + 2) * ii - sLabInit.width - 2;
 					sLabInit.y = STAT_BUTHEIGHT - sLabInit.height - 3 - STAT_PROGBARHEIGHT;
-					sLabInit.UserData = PACKDWORD(Stat->ref - REF_RESEARCH_START, ii);
+					sLabInit.UserData = PACKDWORD(Stat->ref - STAT_RESEARCH, ii);
 					sLabInit.pTip = getPlayerName(researches[ii].player);
 					sLabInit.pDisplay = intDisplayAllyIcon;
 					widgAddLabel(psWScreen, &sLabInit);
@@ -3819,7 +3812,7 @@ static bool intAddStats(BASE_STATS **ppsStatsList, UDWORD numStats,
 					progress.height = STAT_PROGBARHEIGHT;
 					progress.x = STAT_TIMEBARX;
 					progress.y = STAT_TIMEBARY;
-					progress.UserData = Stat->ref - REF_RESEARCH_START;
+					progress.UserData = Stat->ref - STAT_RESEARCH;
 					progress.pTip = _("Ally progress");
 					progress.pDisplay = intDisplayAllyBar;
 					W_BARGRAPH *bar = widgAddBarGraph(psWScreen, &progress);
@@ -4024,7 +4017,7 @@ static bool setResearchStats(BASE_OBJECT *psObj, BASE_STATS *psStats)
 		if (pResearch != nullptr)
 		{
 			// Say that we want to do research [sic].
-			sendResearchStatus(psBuilding, pResearch->ref - REF_RESEARCH_START, selectedPlayer, true);
+			sendResearchStatus(psBuilding, pResearch->ref - STAT_RESEARCH, selectedPlayer, true);
 			setStatusPendingStart(*psResFacilty, pResearch);  // Tell UI that we are going to research.
 		}
 		else
@@ -4042,7 +4035,7 @@ static bool setResearchStats(BASE_OBJECT *psObj, BASE_STATS *psStats)
 	//set up the player_research
 	if (pResearch != nullptr)
 	{
-		count = pResearch->ref - REF_RESEARCH_START;
+		count = pResearch->ref - STAT_RESEARCH;
 		//meant to still be in the list but greyed out
 		pPlayerRes = &asPlayerResList[selectedPlayer][count];
 

--- a/src/intdisplay.cpp
+++ b/src/intdisplay.cpp
@@ -1838,14 +1838,12 @@ DROID_TEMPLATE *FactoryGetTemplate(FACTORY *Factory)
 
 bool StatIsStructure(BASE_STATS const *Stat)
 {
-	return (Stat->ref >= REF_STRUCTURE_START && Stat->ref <
-	        REF_STRUCTURE_START + REF_RANGE);
+	return Stat->hasType(STAT_STRUCTURE);
 }
 
 bool StatIsFeature(BASE_STATS const *Stat)
 {
-	return (Stat->ref >= REF_FEATURE_START && Stat->ref <
-	        REF_FEATURE_START + REF_RANGE);
+	return Stat->hasType(STAT_FEATURE);
 }
 
 iIMDShape *StatGetStructureIMD(BASE_STATS *Stat, UDWORD Player)
@@ -1856,61 +1854,23 @@ iIMDShape *StatGetStructureIMD(BASE_STATS *Stat, UDWORD Player)
 
 bool StatIsTemplate(BASE_STATS *Stat)
 {
-	return (Stat->ref >= REF_TEMPLATE_START &&
-	        Stat->ref < REF_TEMPLATE_START + REF_RANGE);
+	return Stat->hasType(STAT_TEMPLATE);
 }
 
-SDWORD StatIsComponent(BASE_STATS *Stat)
+COMPONENT_TYPE StatIsComponent(BASE_STATS *Stat)
 {
-	if (Stat->ref >= REF_BODY_START &&
-	    Stat->ref < REF_BODY_START + REF_RANGE)
+	switch (StatType(Stat->ref & STAT_MASK))
 	{
-		return COMP_BODY;
+		case STAT_BODY: return COMP_BODY;
+		case STAT_BRAIN: return COMP_BRAIN;
+		case STAT_PROPULSION: return COMP_PROPULSION;
+		case STAT_WEAPON: return COMP_WEAPON;
+		case STAT_SENSOR: return COMP_SENSOR;
+		case STAT_ECM: return COMP_ECM;
+		case STAT_CONSTRUCT: return COMP_CONSTRUCT;
+		case STAT_REPAIR: return COMP_REPAIRUNIT;
+		default: return COMP_NUMCOMPONENTS;
 	}
-
-	if (Stat->ref >= REF_BRAIN_START &&
-	    Stat->ref < REF_BRAIN_START + REF_RANGE)
-	{
-		return COMP_BRAIN;
-	}
-
-	if (Stat->ref >= REF_PROPULSION_START &&
-	    Stat->ref < REF_PROPULSION_START + REF_RANGE)
-	{
-		return COMP_PROPULSION;
-	}
-
-	if (Stat->ref >= REF_WEAPON_START &&
-	    Stat->ref < REF_WEAPON_START + REF_RANGE)
-	{
-		return COMP_WEAPON;
-	}
-
-	if (Stat->ref >= REF_SENSOR_START &&
-	    Stat->ref < REF_SENSOR_START + REF_RANGE)
-	{
-		return COMP_SENSOR;
-	}
-
-	if (Stat->ref >= REF_ECM_START &&
-	    Stat->ref < REF_ECM_START + REF_RANGE)
-	{
-		return COMP_ECM;
-	}
-
-	if (Stat->ref >= REF_CONSTRUCT_START &&
-	    Stat->ref < REF_CONSTRUCT_START + REF_RANGE)
-	{
-		return COMP_CONSTRUCT;
-	}
-
-	if (Stat->ref >= REF_REPAIR_START &&
-	    Stat->ref < REF_REPAIR_START + REF_RANGE)
-	{
-		return COMP_REPAIRUNIT;
-	}
-
-	return COMP_NUMCOMPONENTS;
 }
 
 bool StatGetComponentIMD(BASE_STATS *Stat, SDWORD compID, iIMDShape **CompIMD, iIMDShape **MountIMD)
@@ -1971,8 +1931,7 @@ bool StatGetComponentIMD(BASE_STATS *Stat, SDWORD compID, iIMDShape **CompIMD, i
 
 bool StatIsResearch(BASE_STATS *Stat)
 {
-	return (Stat->ref >= REF_RESEARCH_START && Stat->ref <
-	        REF_RESEARCH_START + REF_RANGE);
+	return Stat->hasType(STAT_RESEARCH);
 }
 
 static void StatGetResearchImage(BASE_STATS *psStat, Image *image, iIMDShape **Shape, BASE_STATS **ppGraphicData, bool drawTechIcon)
@@ -2374,7 +2333,7 @@ void intDisplayAllyIcon(WIDGET *psWidget, UDWORD xOffset, UDWORD yOffset)
 	UDWORD		x = Label->x() + xOffset;
 	UDWORD		y = Label->y() + yOffset;
 
-	unsigned ref = UNPACKDWORD_HI(psWidget->UserData) + REF_RESEARCH_START;
+	unsigned ref = UNPACKDWORD_HI(psWidget->UserData) + STAT_RESEARCH;
 	unsigned num = UNPACKDWORD_LOW(psWidget->UserData);
 
 	std::vector<AllyResearch> const &researches = listAllyResearch(ref);

--- a/src/intdisplay.h
+++ b/src/intdisplay.h
@@ -271,7 +271,7 @@ iIMDShape *StatGetStructureIMD(BASE_STATS *Stat, UDWORD Player);
 bool StatIsTemplate(BASE_STATS *Stat);
 bool StatIsFeature(BASE_STATS const *Stat);
 
-SDWORD StatIsComponent(BASE_STATS *Stat);
+COMPONENT_TYPE StatIsComponent(BASE_STATS *Stat);
 bool StatGetComponentIMD(BASE_STATS *Stat, SDWORD compID, iIMDShape **CompIMD, iIMDShape **MountIMD);
 
 bool StatIsResearch(BASE_STATS *Stat);

--- a/src/map.h
+++ b/src/map.h
@@ -386,12 +386,22 @@ static inline float map_coordf(int32_t worldCoord)
 
 static inline Vector2i world_coord(Vector2i const &mapCoord)
 {
-	return Vector2i(world_coord(mapCoord.x), world_coord(mapCoord.y));
+	return {world_coord(mapCoord.x), world_coord(mapCoord.y)};
 }
 
 static inline Vector2i map_coord(Vector2i const &worldCoord)
 {
-	return Vector2i(map_coord(worldCoord.x), map_coord(worldCoord.y));
+	return {map_coord(worldCoord.x), map_coord(worldCoord.y)};
+}
+
+static inline int32_t round_to_nearest_tile(int32_t worldCoord)
+{
+	return (worldCoord + TILE_UNITS/2) & ~TILE_MASK;
+}
+
+static inline Vector2i round_to_nearest_tile(Vector2i const &worldCoord)
+{
+	return {round_to_nearest_tile(worldCoord.x), round_to_nearest_tile(worldCoord.y)};
 }
 
 /* Make sure world coordinates are inside the map */

--- a/src/multiplay.cpp
+++ b/src/multiplay.cpp
@@ -1011,7 +1011,7 @@ STRUCTURE *findResearchingFacilityByResearchIndex(unsigned player, unsigned inde
 	{
 		if (psBuilding->pStructureType->type == REF_RESEARCH
 		    && ((RESEARCH_FACILITY *)psBuilding->pFunctionality)->psSubject
-		    && ((RESEARCH_FACILITY *)psBuilding->pFunctionality)->psSubject->ref - REF_RESEARCH_START == index)
+		    && ((RESEARCH_FACILITY *)psBuilding->pFunctionality)->psSubject->ref - STAT_RESEARCH == index)
 		{
 			return psBuilding;
 		}

--- a/src/oprint.cpp
+++ b/src/oprint.cpp
@@ -61,7 +61,7 @@ static void printComponentInfo(const COMPONENT_STATS *psStats)
 	CONPRINTF("%s ref %d\n"
 	                          "   bPwr %d bPnts %d wt %d bdy %d imd %p\n",
 	                          getName(psStats), psStats->ref, psStats->buildPower,
-	                          psStats->buildPoints, psStats->weight, psStats->pBase->hitpoints,
+	                          psStats->buildPoints, psStats->weight, psStats->getBase().hitpoints,
 	                          static_cast<void *>(psStats->pIMD));
 }
 

--- a/src/order.cpp
+++ b/src/order.cpp
@@ -879,7 +879,8 @@ void orderUpdateDroid(DROID *psDroid)
 		    (psDroid->action == DACTION_BUILD && psDroid->order.psObj == nullptr))
 		{
 			// finished building the current structure
-			if (map_coord(psDroid->order.pos) == map_coord(psDroid->order.pos2))
+			auto lb = calcLineBuild(psDroid->order.psStats, psDroid->order.direction, psDroid->order.pos, psDroid->order.pos2);
+			if (lb.count <= 1)
 			{
 				// finished all the structures - done
 				psDroid->order = DroidOrder(DORDER_NONE);
@@ -887,35 +888,7 @@ void orderUpdateDroid(DROID *psDroid)
 			}
 
 			// update the position for another structure
-			if (map_coord(psDroid->order.pos.x) == map_coord(psDroid->order.pos2.x))
-			{
-				// still got building to do - working vertically
-				if (psDroid->order.pos.y < psDroid->order.pos2.y)
-				{
-					psDroid->order.pos.y += TILE_UNITS;
-				}
-				else
-				{
-					psDroid->order.pos.y -= TILE_UNITS;
-				}
-			}
-			else if (map_coord(psDroid->order.pos.y) == map_coord(psDroid->order.pos2.y))
-			{
-				// still got building to do - working horizontally
-				if (psDroid->order.pos.x < psDroid->order.pos2.x)
-				{
-					psDroid->order.pos.x += TILE_UNITS;
-				}
-				else
-				{
-					psDroid->order.pos.x -= TILE_UNITS;
-				}
-			}
-			else
-			{
-				ASSERT(false, "orderUpdateUnit: LINEBUILD order on diagonal line");
-				break;
-			}
+			psDroid->order.pos = lb[1];
 
 			// build another structure
 			setDroidTarget(psDroid, nullptr);
@@ -2006,7 +1979,6 @@ void orderDroidStatsTwoLocDir(DROID *psDroid, DROID_ORDER order, STRUCTURE_STATS
 {
 	ASSERT(psDroid != nullptr,	"Invalid unit pointer");
 	ASSERT(order == DORDER_LINEBUILD, "Invalid order for location");
-	ASSERT(x1 == x2 || y1 == y2, "Invalid locations for LINEBUILD");
 
 	DroidOrder sOrder(order, psStats, Vector2i(x1, y1), Vector2i(x2, y2), direction);
 	if (mode == ModeQueue && bMultiPlayer)
@@ -2027,7 +1999,6 @@ void orderDroidStatsTwoLocDirAdd(DROID *psDroid, DROID_ORDER order, STRUCTURE_ST
 {
 	ASSERT(psDroid != nullptr, "Invalid unit pointer");
 	ASSERT(order == DORDER_LINEBUILD, "Invalid order for location");
-	ASSERT(x1 == x2 || y1 == y2, "Invalid locations for LINEBUILD");
 
 	sendDroidInfo(psDroid, DroidOrder(order, psStats, Vector2i(x1, y1), Vector2i(x2, y2), direction), true);
 }

--- a/src/qtscriptdebug.cpp
+++ b/src/qtscriptdebug.cpp
@@ -621,8 +621,8 @@ QStandardItemList componentToString(const QString &name, const COMPONENT_STATS *
 	key->appendRow(QStandardItemList{ new QStandardItem("^Power"), new QStandardItem(QString::number(psStats->buildPower)) });
 	key->appendRow(QStandardItemList{ new QStandardItem("^Build Points"), new QStandardItem(QString::number(psStats->buildPoints)) });
 	key->appendRow(QStandardItemList{ new QStandardItem("^Weight"), new QStandardItem(QString::number(psStats->weight)) });
-	key->appendRow(QStandardItemList{ new QStandardItem("^Hit points"), new QStandardItem(QString::number(psStats->pUpgrade[player]->hitpoints)) });
-	key->appendRow(QStandardItemList{ new QStandardItem("^Hit points +% of total"), new QStandardItem(QString::number(psStats->pUpgrade[player]->hitpointPct)) });
+	key->appendRow(QStandardItemList{ new QStandardItem("^Hit points"), new QStandardItem(QString::number(psStats->getUpgrade(player).hitpoints)) });
+	key->appendRow(QStandardItemList{ new QStandardItem("^Hit points +% of total"), new QStandardItem(QString::number(psStats->getUpgrade(player).hitpointPct)) });
 	key->appendRow(QStandardItemList{ new QStandardItem("^Designable"), new QStandardItem(QString::number(psStats->designable)) });
 	if (psStats->compType == COMP_BODY)
 	{

--- a/src/qtscriptfuncs.cpp
+++ b/src/qtscriptfuncs.cpp
@@ -5778,8 +5778,8 @@ QScriptValue register_common(QScriptEngine *engine, COMPONENT_STATS *psStats)
 	v.setProperty("Weight", psStats->weight, QScriptValue::ReadOnly | QScriptValue::Undeletable);
 	v.setProperty("BuildPower", psStats->buildPower, QScriptValue::ReadOnly | QScriptValue::Undeletable);
 	v.setProperty("BuildTime", psStats->buildPoints, QScriptValue::ReadOnly | QScriptValue::Undeletable);
-	v.setProperty("HitPoints", psStats->pBase->hitpoints, QScriptValue::ReadOnly | QScriptValue::Undeletable);
-	v.setProperty("HitPointPct", psStats->pBase->hitpointPct, QScriptValue::ReadOnly | QScriptValue::Undeletable);
+	v.setProperty("HitPoints", psStats->getBase().hitpoints, QScriptValue::ReadOnly | QScriptValue::Undeletable);
+	v.setProperty("HitPointPct", psStats->getBase().hitpointPct, QScriptValue::ReadOnly | QScriptValue::Undeletable);
 	return v;
 }
 

--- a/src/research.cpp
+++ b/src/research.cpp
@@ -125,7 +125,7 @@ bool loadResearch(WzConfig &ini)
 		//check the name hasn't been used already
 		ASSERT_OR_RETURN(false, checkResearchName(&research, inc), "Research name '%s' used already", getName(&research));
 
-		research.ref = REF_RESEARCH_START + inc;
+		research.ref = STAT_RESEARCH + inc;
 
 		research.results = ini.json("results", nlohmann::json::array());
 
@@ -1131,20 +1131,16 @@ bool enableResearch(RESEARCH *psResearch, UDWORD player)
 void researchReward(UBYTE losingPlayer, UBYTE rewardPlayer)
 {
 	UDWORD topicIndex = 0, researchPoints = 0, rewardID = 0;
-	STRUCTURE			*psStruct;
-	RESEARCH_FACILITY	*psFacility;
 
 	//look through the losing players structures to find a research facility
-	for (psStruct = apsStructLists[losingPlayer]; psStruct != nullptr; psStruct =
-	         psStruct->psNext)
+	for (STRUCTURE *psStruct = apsStructLists[losingPlayer]; psStruct != nullptr; psStruct = psStruct->psNext)
 	{
 		if (psStruct->pStructureType->type == REF_RESEARCH)
 		{
-			psFacility = (RESEARCH_FACILITY *)psStruct->pFunctionality;
+			RESEARCH_FACILITY *psFacility = (RESEARCH_FACILITY *)psStruct->pFunctionality;
 			if (psFacility->psBestTopic)
 			{
-				topicIndex = ((RESEARCH *)psFacility->psBestTopic)->ref -
-				             REF_RESEARCH_START;
+				topicIndex = ((RESEARCH *)psFacility->psBestTopic)->ref - STAT_RESEARCH;
 				if (topicIndex)
 				{
 					//if it cost more - it is better (or should be)

--- a/src/stats.cpp
+++ b/src/stats.cpp
@@ -140,7 +140,7 @@ static void deallocTerrainTable()
 
 /* Macro to allocate memory for a set of stats */
 #define ALLOC_STATS(numEntries, list, listSize, type) \
-	ASSERT((numEntries) < REF_RANGE, "Number of stats entries too large for " #type);\
+	ASSERT((numEntries) < ~STAT_MASK + 1, "Number of stats entries too large for " #type);\
 	if ((list))	delete [] (list);	\
 	(list) = new type[numEntries]; \
 	(listSize) = (numEntries); \
@@ -407,7 +407,7 @@ bool loadWeaponStats(WzConfig &ini)
 
 		ASSERT(psStats->flightSpeed > 0, "Invalid flight speed for %s", list[i].toUtf8().c_str());
 
-		psStats->ref = REF_WEAPON_START + i;
+		psStats->ref = STAT_WEAPON + i;
 
 		//get the IMD for the component
 		psStats->pIMD = statsGetIMD(ini, psStats, "model");
@@ -596,7 +596,7 @@ bool loadBodyStats(WzConfig &ini)
 		{
 			psStats->upgrade[j] = psStats->base;
 		}
-		psStats->ref = REF_BODY_START + i;
+		psStats->ref = STAT_BODY + i;
 		if (!getBodySize(ini.value("size").toWzString(), &psStats->size))
 		{
 			ASSERT(false, "Unknown body size for %s", getName(psStats));
@@ -716,7 +716,7 @@ bool loadBrainStats(WzConfig &ini)
 		{
 			psStats->base.rankThresholds.push_back(v.get<int>());
 		}
-		psStats->ref = REF_BRAIN_START + i;
+		psStats->ref = STAT_BRAIN + i;
 
 		for (int j = 0; j < MAX_PLAYERS; j++)
 		{
@@ -800,7 +800,7 @@ bool loadPropulsionStats(WzConfig &ini)
 
 		psStats->base.hitpointPctOfBody = ini.value("hitpointPctOfBody", 0).toInt();
 		psStats->maxSpeed = ini.value("speed").toInt();
-		psStats->ref = REF_PROPULSION_START + i;
+		psStats->ref = STAT_PROPULSION + i;
 		psStats->turnSpeed = ini.value("turnSpeed", DEG(1) / 3).toInt();
 		psStats->spinSpeed = ini.value("spinSpeed", DEG(3) / 4).toInt();
 		psStats->spinAngle = ini.value("spinAngle", 180).toInt();
@@ -876,7 +876,7 @@ bool loadSensorStats(WzConfig &ini)
 			psStats->upgrade[j] = psStats->base;
 		}
 
-		psStats->ref = REF_SENSOR_START + i;
+		psStats->ref = STAT_SENSOR + i;
 
 		WzString location = ini.value("location").toWzString();
 		if (location.compare("DEFAULT") == 0)
@@ -962,7 +962,7 @@ bool loadECMStats(WzConfig &ini)
 			psStats->upgrade[j] = psStats->base;
 		}
 
-		psStats->ref = REF_ECM_START + i;
+		psStats->ref = STAT_ECM + i;
 
 		WzString location = ini.value("location").toWzString();
 		if (location.compare("DEFAULT") == 0)
@@ -1019,7 +1019,7 @@ bool loadRepairStats(WzConfig &ini)
 		}
 		psStats->time = ini.value("time", 0).toInt() * WEAPON_TIME;
 
-		psStats->ref = REF_REPAIR_START + i;
+		psStats->ref = STAT_REPAIR + i;
 
 		WzString location = ini.value("location").toWzString();
 		if (location.compare("DEFAULT") == 0)
@@ -1077,7 +1077,7 @@ bool loadConstructStats(WzConfig &ini)
 		{
 			psStats->upgrade[j] = psStats->base;
 		}
-		psStats->ref = REF_CONSTRUCT_START + i;
+		psStats->ref = STAT_CONSTRUCT + i;
 
 		//get the IMD for the component
 		psStats->pIMD = statsGetIMD(ini, psStats, "sensorModel");
@@ -1316,110 +1316,6 @@ UDWORD getSpeedFactor(UDWORD type, UDWORD propulsionType)
 {
 	ASSERT(propulsionType < PROPULSION_TYPE_NUM, "The propulsion type is too large");
 	return asTerrainTable[type * PROPULSION_TYPE_NUM + propulsionType];
-}
-
-//return the type of stat this stat is!
-UDWORD statType(UDWORD ref)
-{
-	if (ref >= REF_BODY_START && ref < REF_BODY_START +
-	    REF_RANGE)
-	{
-		return COMP_BODY;
-	}
-	if (ref >= REF_BRAIN_START && ref < REF_BRAIN_START +
-	    REF_RANGE)
-	{
-		return COMP_BRAIN;
-	}
-	if (ref >= REF_PROPULSION_START && ref <
-	    REF_PROPULSION_START + REF_RANGE)
-	{
-		return COMP_PROPULSION;
-	}
-	if (ref >= REF_SENSOR_START && ref < REF_SENSOR_START +
-	    REF_RANGE)
-	{
-		return COMP_SENSOR;
-	}
-	if (ref >= REF_ECM_START && ref < REF_ECM_START +
-	    REF_RANGE)
-	{
-		return COMP_ECM;
-	}
-	if (ref >= REF_REPAIR_START && ref < REF_REPAIR_START +
-	    REF_RANGE)
-	{
-		return COMP_REPAIRUNIT;
-	}
-	if (ref >= REF_WEAPON_START && ref < REF_WEAPON_START +
-	    REF_RANGE)
-	{
-		return COMP_WEAPON;
-	}
-	if (ref >= REF_CONSTRUCT_START && ref < REF_CONSTRUCT_START +
-	    REF_RANGE)
-	{
-		return COMP_CONSTRUCT;
-	}
-	//else
-	ASSERT(false, "Invalid stat pointer - cannot determine Stat Type");
-	return COMP_NUMCOMPONENTS;
-}
-
-//return the REF_START value of this type of stat
-UDWORD statRefStart(UDWORD stat)
-{
-	UDWORD start;
-
-	switch (stat)
-	{
-	case COMP_BODY:
-		{
-			start = REF_BODY_START;
-			break;
-		}
-	case COMP_BRAIN:
-		{
-			start = REF_BRAIN_START;
-			break;
-		}
-	case COMP_PROPULSION:
-		{
-			start = REF_PROPULSION_START;
-			break;
-		}
-	case COMP_SENSOR:
-		{
-			start = REF_SENSOR_START;
-			break;
-		}
-	case COMP_ECM:
-		{
-			start = REF_ECM_START;
-			break;
-		}
-	case COMP_REPAIRUNIT:
-		{
-			start = REF_REPAIR_START;
-			break;
-		}
-	case COMP_WEAPON:
-		{
-			start = REF_WEAPON_START;
-			break;
-		}
-	case COMP_CONSTRUCT:
-		{
-			start = REF_CONSTRUCT_START;
-			break;
-		}
-	default:
-		{
-			debug(LOG_FATAL, "Invalid stat type");
-			start = 0;
-		}
-	}
-	return start;
 }
 
 int getCompFromName(COMPONENT_TYPE compType, const WzString &name)

--- a/src/stats.cpp
+++ b/src/stats.cpp
@@ -281,8 +281,8 @@ static void loadCompStats(WzConfig &json, COMPONENT_STATS *psStats, size_t index
 	psStats->buildPoints = json.value("buildPoints", 0).toUInt();
 	psStats->designable = json.value("designable", false).toBool();
 	psStats->weight = json.value("weight", 0).toUInt();
-	psStats->pBase->hitpoints = json.value("hitpoints", 0).toUInt();
-	psStats->pBase->hitpointPct = json.value("hitpointPct", 100).toUInt();
+	psStats->getBase().hitpoints = json.value("hitpoints", 0).toUInt();
+	psStats->getBase().hitpointPct = json.value("hitpointPct", 100).toUInt();
 
 	WzString dtype = json.value("droidType", "DROID").toWzString();
 	psStats->droidTypeOverride = DROID_ANY;

--- a/src/stats.h
+++ b/src/stats.h
@@ -60,25 +60,6 @@ extern UDWORD		numWeaponStats;
 extern UDWORD		numConstructStats;
 extern UDWORD		numTerrainTypes;
 
-/* What number the ref numbers start at for each type of stat */
-#define REF_BODY_START			0x010000
-#define REF_BRAIN_START			0x020000
-#define REF_PROPULSION_START	0x040000
-#define REF_SENSOR_START		0x050000
-#define REF_ECM_START			0x060000
-#define REF_REPAIR_START		0x080000
-#define REF_WEAPON_START		0x0a0000
-#define REF_RESEARCH_START		0x0b0000
-#define REF_TEMPLATE_START		0x0c0000
-#define REF_STRUCTURE_START		0x0d0000
-#define REF_FUNCTION_START		0x0e0000
-#define REF_CONSTRUCT_START		0x0f0000
-#define REF_FEATURE_START		0x100000
-
-/* The maximum number of refs for a type of stat */
-#define REF_RANGE				0x010000
-
-
 //stores for each players component states - see below
 extern UBYTE		*apCompLists[MAX_PLAYERS][COMP_NUMCOMPONENTS];
 

--- a/src/statsdef.h
+++ b/src/statsdef.h
@@ -253,22 +253,22 @@ enum TRAVEL_MEDIUM
 // What number the ref numbers start at for each type of stat
 enum StatType
 {
-	REF_BODY_START       = 0x010000,
-	REF_BRAIN_START      = 0x020000,
-	REF_PROPULSION_START = 0x040000,
-	REF_SENSOR_START     = 0x050000,
-	REF_ECM_START        = 0x060000,
-	REF_REPAIR_START     = 0x080000,
-	REF_WEAPON_START     = 0x0a0000,
-	REF_RESEARCH_START   = 0x0b0000,
-	REF_TEMPLATE_START   = 0x0c0000,
-	REF_STRUCTURE_START  = 0x0d0000,
-	REF_FUNCTION_START   = 0x0e0000,
-	REF_CONSTRUCT_START  = 0x0f0000,
-	REF_FEATURE_START    = 0x100000,
+	STAT_BODY       = 0x010000,
+	STAT_BRAIN      = 0x020000,
+	STAT_PROPULSION = 0x040000,
+	STAT_SENSOR     = 0x050000,
+	STAT_ECM        = 0x060000,
+	STAT_REPAIR     = 0x080000,
+	STAT_WEAPON     = 0x0a0000,
+	STAT_RESEARCH   = 0x0b0000,
+	STAT_TEMPLATE   = 0x0c0000,
+	STAT_STRUCTURE  = 0x0d0000,
+	STAT_FUNCTION   = 0x0e0000,
+	STAT_CONSTRUCT  = 0x0f0000,
+	STAT_FEATURE    = 0x100000,
 
 /* The maximum number of refs for a type of stat */
-	REF_RANGE            = 0x010000
+	STAT_MASK       = 0xffff0000
 };
 
 /* Stats common to all stats structs */
@@ -277,7 +277,7 @@ struct BASE_STATS
 	BASE_STATS(unsigned ref = 0) : ref(ref) {}
 	virtual ~BASE_STATS() = default;
 
-	bool typeIs(StatType type) const { return (ref & -REF_RANGE) == type; }
+	bool hasType(StatType type) const { return (ref & STAT_MASK) == type; }
 
 	WzString id;    ///< Text id (i.e. short language-independent name)
 	WzString name;  ///< Full / real name of the item

--- a/src/statsdef.h
+++ b/src/statsdef.h
@@ -250,10 +250,33 @@ enum TRAVEL_MEDIUM
 
 /* Elements common to all stats structures */
 
+// What number the ref numbers start at for each type of stat
+enum StatType
+{
+	REF_BODY_START       = 0x010000,
+	REF_BRAIN_START      = 0x020000,
+	REF_PROPULSION_START = 0x040000,
+	REF_SENSOR_START     = 0x050000,
+	REF_ECM_START        = 0x060000,
+	REF_REPAIR_START     = 0x080000,
+	REF_WEAPON_START     = 0x0a0000,
+	REF_RESEARCH_START   = 0x0b0000,
+	REF_TEMPLATE_START   = 0x0c0000,
+	REF_STRUCTURE_START  = 0x0d0000,
+	REF_FUNCTION_START   = 0x0e0000,
+	REF_CONSTRUCT_START  = 0x0f0000,
+	REF_FEATURE_START    = 0x100000,
+
+/* The maximum number of refs for a type of stat */
+	REF_RANGE            = 0x010000
+};
+
 /* Stats common to all stats structs */
 struct BASE_STATS
 {
 	BASE_STATS(unsigned ref = 0) : ref(ref) {}
+
+	bool typeIs(StatType type) const { return (ref & -REF_RANGE) == type; }
 
 	WzString id;    ///< Text id (i.e. short language-independent name)
 	WzString name;  ///< Full / real name of the item

--- a/src/structure.cpp
+++ b/src/structure.cpp
@@ -1350,7 +1350,7 @@ STRUCTURE *buildStructureDir(STRUCTURE_STATS *pStructureType, UDWORD x, UDWORD y
 
 		psBuilding->pos.x = x;
 		psBuilding->pos.y = y;
-		psBuilding->rot.direction = (direction + 0x2000) & 0xC000;
+		psBuilding->rot.direction = snapDirection(direction);
 		psBuilding->rot.pitch = 0;
 		psBuilding->rot.roll = 0;
 
@@ -1744,7 +1744,7 @@ STRUCTURE *buildBlueprint(STRUCTURE_STATS const *psStats, Vector2i xy, uint16_t 
 	ASSERT_OR_RETURN(nullptr, psStats->pIMD[0] != nullptr, "No blueprint model for %s", getName(psStats));
 
 	Vector3i pos(xy, INT32_MIN);
-	Rotation rot((direction + 0x2000) & 0xC000, 0, 0); // Round direction to nearest 90°.
+	Rotation rot(snapDirection(direction), 0, 0); // Round direction to nearest 90°.
 
 	StructureBounds b = getStructureBounds(psStats, xy, direction);
 	for (int j = 0; j <= b.size.y; ++j)
@@ -1829,7 +1829,7 @@ static Vector2i defaultAssemblyPointPos(STRUCTURE *psBuilding)
 {
 	const Vector2i size = psBuilding->size() + Vector2i(1, 1);  // Adding Vector2i(1, 1) to select the middle of the tile outside the building instead of the corner.
 	Vector2i pos = psBuilding->pos;
-	switch ((psBuilding->rot.direction + 0x2000) & 0xC000)
+	switch (snapDirection(psBuilding->rot.direction))
 	{
 	case 0x0000: return pos + TILE_UNITS/2 * Vector2i( size.x,  size.y);
 	case 0x4000: return pos + TILE_UNITS/2 * Vector2i( size.x, -size.y);
@@ -2160,7 +2160,7 @@ bool placeDroid(STRUCTURE *psStructure, UDWORD *droidX, UDWORD *droidY)
 	}
 
 	/* Round direction to nearest 90°. */
-	uint16_t direction = (psStructure->rot.direction + 0x2000) & 0xC000;
+	uint16_t direction = snapDirection(psStructure->rot.direction);
 
 	/* We sort all adjacent tiles by their Manhattan distance to the
 	target droid exit tile, misplaced by (1/3, 1/4) tiles.

--- a/src/structure.cpp
+++ b/src/structure.cpp
@@ -442,7 +442,7 @@ bool loadStructureStats(WzConfig &ini)
 		STRUCTURE_STATS *psStats = &asStructureStats[inc];
 		loadStats(ini, psStats, inc);
 
-		psStats->ref = REF_STRUCTURE_START + inc;
+		psStats->ref = STAT_STRUCTURE + inc;
 
 		// set structure type
 		WzString type = ini.value("type", "").toWzString();
@@ -3100,7 +3100,7 @@ static void aiUpdateStructure(STRUCTURE *psStructure, bool isMission)
 				return;
 			}
 
-			int researchIndex = pSubject->ref - REF_RESEARCH_START;
+			int researchIndex = pSubject->ref - STAT_RESEARCH;
 
 			PLAYER_RESEARCH *pPlayerRes = &asPlayerResList[psStructure->player][researchIndex];
 			//check research has not already been completed by another structure
@@ -4817,25 +4817,19 @@ bool checkStructureStatus(STRUCTURE_STATS *psStats, UDWORD player, UDWORD status
 stat type*/
 bool checkSpecificStructExists(UDWORD structInc, UDWORD player)
 {
-	STRUCTURE	*psStructure;
-	bool		found = false;
-
 	ASSERT_OR_RETURN(false, structInc < numStructureStats, "Invalid structure inc");
 
-	for (psStructure = apsStructLists[player]; psStructure != nullptr;
-	     psStructure = psStructure->psNext)
+	for (STRUCTURE *psStructure = apsStructLists[player]; psStructure != nullptr; psStructure = psStructure->psNext)
 	{
 		if (psStructure->status == SS_BUILT)
 		{
-			if ((psStructure->pStructureType->ref - REF_STRUCTURE_START) ==
-			    structInc)
+			if (psStructure->pStructureType->ref - STAT_STRUCTURE == structInc)
 			{
-				found = true;
-				break;
+				return true;
 			}
 		}
 	}
-	return found;
+	return false;
 }
 
 

--- a/src/structure.h
+++ b/src/structure.h
@@ -513,4 +513,18 @@ static inline int getBuildingRearmPoints(STRUCTURE *psStruct)
 
 WzString getFavoriteStructs();
 void setFavoriteStructs(WzString list);
+
+struct LineBuild
+{
+	Vector2i back() const { return (*this)[count - 1]; }
+	Vector2i operator [](int i) const { return begin + i*step; }
+
+	Vector2i begin = {0, 0};
+	Vector2i step = {0, 0};
+	int count = 0;
+};
+
+LineBuild calcLineBuild(Vector2i size, STRUCTURE_TYPE type, Vector2i pos, Vector2i pos2);
+LineBuild calcLineBuild(STRUCTURE_STATS const *stats, uint16_t direction, Vector2i pos, Vector2i pos2);
+
 #endif // __INCLUDED_SRC_STRUCTURE_H__

--- a/src/structuredef.h
+++ b/src/structuredef.h
@@ -158,12 +158,12 @@ struct STRUCTURE_STATS : public BASE_STATS
 
 static inline STRUCTURE_STATS *castStructureStats(BASE_STATS *stats)
 {
-	return stats != nullptr && stats->typeIs(REF_STRUCTURE_START)? static_cast<STRUCTURE_STATS *>(stats) : nullptr;
+	return stats != nullptr && stats->hasType(STAT_STRUCTURE)? static_cast<STRUCTURE_STATS *>(stats) : nullptr;
 }
 
 static inline STRUCTURE_STATS const *castStructureStats(BASE_STATS const *stats)
 {
-	return stats != nullptr && stats->typeIs(REF_STRUCTURE_START)? static_cast<STRUCTURE_STATS const *>(stats) : nullptr;
+	return stats != nullptr && stats->hasType(STAT_STRUCTURE)? static_cast<STRUCTURE_STATS const *>(stats) : nullptr;
 }
 
 enum STRUCT_STATES

--- a/src/structuredef.h
+++ b/src/structuredef.h
@@ -148,7 +148,7 @@ struct STRUCTURE_STATS : public BASE_STATS
 	inline Vector2i size(uint16_t direction) const
 	{
 		Vector2i size(baseWidth, baseBreadth);
-		if (((direction + 0x2000) & 0x4000) != 0) // if building is rotated left or right by 90°, swap width and height
+		if ((snapDirection(direction) & 0x4000) != 0) // if building is rotated left or right by 90°, swap width and height
 		{
 			std::swap(size.x, size.y);
 		}

--- a/src/structuredef.h
+++ b/src/structuredef.h
@@ -156,6 +156,16 @@ struct STRUCTURE_STATS : public BASE_STATS
 	}
 };
 
+static inline STRUCTURE_STATS *castStructureStats(BASE_STATS *stats)
+{
+	return stats != nullptr && stats->typeIs(REF_STRUCTURE_START)? static_cast<STRUCTURE_STATS *>(stats) : nullptr;
+}
+
+static inline STRUCTURE_STATS const *castStructureStats(BASE_STATS const *stats)
+{
+	return stats != nullptr && stats->typeIs(REF_STRUCTURE_START)? static_cast<STRUCTURE_STATS const *>(stats) : nullptr;
+}
+
 enum STRUCT_STATES
 {
 	SS_BEING_BUILT,

--- a/src/template.cpp
+++ b/src/template.cpp
@@ -399,7 +399,7 @@ bool shutdownTemplates()
 }
 
 DROID_TEMPLATE::DROID_TEMPLATE()  // This constructor replaces a memset in scrAssembleWeaponTemplate(), not needed elsewhere.
-	: BASE_STATS(REF_TEMPLATE_START)
+	: BASE_STATS(STAT_TEMPLATE)
 	  //, asParts
 	, numWeaps(0)
 	  //, asWeaps


### PR DESCRIPTION
Now builds centred on the mouse cursor, instead of with the top-left corner of the
building on the mouse cursor.

If trying to line build a previously non-linebuildable structure, it would deselect
trucks, and then when placing a structure, one random truck would then try to build.

Now if trying to line build a previously non-linebuildable structure, it just line
builds it.

Also, be less restrictive about line build directions.

![image](https://user-images.githubusercontent.com/48363/86219183-1e7ef200-bb82-11ea-85cd-977d08067bc5.png)
