### PR TITLE
Tweak platform independent / dependent path notation handling in listMapFiles

### DIFF
--- a/lib/framework/frame.cpp
+++ b/lib/framework/frame.cpp
@@ -141,7 +141,7 @@ bool getMouseWarp()
 PHYSFS_file *openLoadFile(const char *fileName, bool hard_fail)
 {
 	PHYSFS_file *fileHandle = PHYSFS_openRead(fileName);
-	debug(LOG_NEVER, "Reading...[directory: %s] %s", PHYSFS_getRealDir(fileName), fileName);
+	debug(LOG_NEVER, "Reading...[directory: %s] %s", WZ_PHYSFS_getRealDir_String(fileName).c_str(), fileName);
 	if (!fileHandle)
 	{
 		if (hard_fail)
@@ -296,7 +296,7 @@ bool saveFile(const char *pFileName, const char *pFileData, UDWORD fileSize)
 	}
 	else
 	{
-		debug(LOG_WZ, "Successfully wrote to %s%s with %d bytes", PHYSFS_getRealDir(pFileName), pFileName, size);
+		debug(LOG_WZ, "Successfully wrote to %s%s with %d bytes", WZ_PHYSFS_getRealDir_String(pFileName).c_str(), pFileName, size);
 	}
 	return true;
 }

--- a/lib/framework/frameresource.cpp
+++ b/lib/framework/frameresource.cpp
@@ -26,6 +26,7 @@
 #include "frameresource.h"
 
 #include "string_ext.h"
+#include "physfs_ext.h"
 
 #include "file.h"
 #include "resly.h"
@@ -190,7 +191,7 @@ bool resLoad(const char *pResFile, SDWORD blockID)
 	// Note the block id number
 	resBlockID = blockID;
 
-	debug(LOG_WZ, "resLoad: loading [directory: %s] %s", PHYSFS_getRealDir(pResFile), pResFile);
+	debug(LOG_WZ, "resLoad: loading [directory: %s] %s", WZ_PHYSFS_getRealDir_String(pResFile).c_str(), pResFile);
 
 	// Load the RES file; allocate memory for a wrf, and load it
 	input.type = LEXINPUT_PHYSFS;

--- a/lib/framework/physfs_ext.h
+++ b/lib/framework/physfs_ext.h
@@ -102,6 +102,17 @@ static inline int WZ_PHYSFS_isDirectory (const char * fname)
 #endif
 }
 
+static inline std::string WZ_PHYSFS_getRealDir_String(const char *filename)
+{
+	// PHYSFS_getRealDir can return null
+	const char* pResultStr = PHYSFS_getRealDir(filename);
+	if (!pResultStr)
+	{
+		return std::string();
+	}
+	return std::string(pResultStr);
+}
+
 static inline bool PHYSFS_exists(const WzString &filename)
 {
 	return PHYSFS_exists(filename.toUtf8().c_str());

--- a/lib/framework/strres.cpp
+++ b/lib/framework/strres.cpp
@@ -102,7 +102,7 @@ bool strresLoad(STR_RES *psRes, const char *fileName)
 
 	input.type = LEXINPUT_PHYSFS;
 	input.input.physfsfile = PHYSFS_openRead(fileName);
-	debug(LOG_WZ, "Reading...[directory %s] %s", PHYSFS_getRealDir(fileName), fileName);
+	debug(LOG_WZ, "Reading...[directory %s] %s", WZ_PHYSFS_getRealDir_String(fileName).c_str(), fileName);
 	if (!input.input.physfsfile)
 	{
 		debug(LOG_ERROR, "strresLoadFile: PHYSFS_openRead(\"%s\") failed with error: %s\n", fileName, WZ_PHYSFS_getLastError());

--- a/lib/netplay/netplay.cpp
+++ b/lib/netplay/netplay.cpp
@@ -3883,7 +3883,7 @@ static void dumpDebugSync(uint8_t *buf, size_t bufLen, uint32_t time, unsigned p
 	WZ_PHYSFS_writeBytes(fp, buf, bufLen);
 	PHYSFS_close(fp);
 
-	debug(LOG_ERROR, "Dumped player %u's sync error at gameTime %u to file: %s%s", player, time, PHYSFS_getRealDir(fname), fname);
+	debug(LOG_ERROR, "Dumped player %u's sync error at gameTime %u to file: %s%s", player, time, WZ_PHYSFS_getRealDir_String(fname).c_str(), fname);
 }
 
 static void sendDebugSync(uint8_t *buf, uint32_t bufLen, uint32_t time)

--- a/lib/sound/audio.cpp
+++ b/lib/sound/audio.cpp
@@ -878,7 +878,7 @@ AUDIO_STREAM *audio_PlayStream(const char *fileName, float volume, void (*onFini
 
 	// Open up the file
 	fileHandle = PHYSFS_openRead(fileName);
-	debug(LOG_WZ, "Reading...[directory: %s] %s", PHYSFS_getRealDir(fileName), fileName);
+	debug(LOG_WZ, "Reading...[directory: %s] %s", WZ_PHYSFS_getRealDir_String(fileName).c_str(), fileName);
 	if (fileHandle == nullptr)
 	{
 		debug(LOG_ERROR, "sound_LoadTrackFromFile: PHYSFS_openRead(\"%s\") failed with error: %s\n", fileName, WZ_PHYSFS_getLastError());

--- a/lib/sound/cdaudio.cpp
+++ b/lib/sound/cdaudio.cpp
@@ -84,10 +84,10 @@ static bool cdAudio_OpenTrack(const char *filename)
 	{
 		PHYSFS_file *music_file = PHYSFS_openRead(filename);
 
-		debug(LOG_WZ, "Reading...[directory: %s] %s", PHYSFS_getRealDir(filename), filename);
+		debug(LOG_WZ, "Reading...[directory: %s] %s", WZ_PHYSFS_getRealDir_String(filename).c_str(), filename);
 		if (music_file == nullptr)
 		{
-			debug(LOG_ERROR, "Failed opening file [directory: %s] %s, with error %s", PHYSFS_getRealDir(filename), filename, WZ_PHYSFS_getLastError());
+			debug(LOG_ERROR, "Failed opening file [directory: %s] %s, with error %s", WZ_PHYSFS_getRealDir_String(filename).c_str(), filename, WZ_PHYSFS_getLastError());
 			return false;
 		}
 

--- a/lib/sound/openal_track.cpp
+++ b/lib/sound/openal_track.cpp
@@ -667,7 +667,7 @@ TRACK *sound_LoadTrackFromFile(const char *fileName)
 
 	// Use PhysicsFS to open the file
 	fileHandle = PHYSFS_openRead(fileName);
-	debug(LOG_NEVER, "Reading...[directory: %s] %s", PHYSFS_getRealDir(fileName), fileName);
+	debug(LOG_NEVER, "Reading...[directory: %s] %s", WZ_PHYSFS_getRealDir_String(fileName).c_str(), fileName);
 	if (fileHandle == nullptr)
 	{
 		debug(LOG_ERROR, "sound_LoadTrackFromFile: PHYSFS_openRead(\"%s\") failed with error: %s\n", fileName, WZ_PHYSFS_getLastError());

--- a/lib/sound/playlist.cpp
+++ b/lib/sound/playlist.cpp
@@ -71,7 +71,7 @@ bool PlayList_Read(const char *path)
 
 	// Attempt to open the playlist file
 	fileHandle = PHYSFS_openRead(listName);
-	debug(LOG_WZ, "Reading...[directory: %s] %s", PHYSFS_getRealDir(listName), listName);
+	debug(LOG_WZ, "Reading...[directory: %s] %s", WZ_PHYSFS_getRealDir_String(listName).c_str(), listName);
 	if (fileHandle == nullptr)
 	{
 		debug(LOG_INFO, "PHYSFS_openRead(\"%s\") failed with error: %s\n", listName, WZ_PHYSFS_getLastError());

--- a/src/data.cpp
+++ b/src/data.cpp
@@ -594,7 +594,7 @@ static bool dataAudioCfgLoad(const char *fileName, void **ppData)
 	{
 		return true;
 	}
-	debug(LOG_WZ, "Reading...[directory: %s] %s", PHYSFS_getRealDir(fileName), fileName);
+	debug(LOG_WZ, "Reading...[directory: %s] %s", WZ_PHYSFS_getRealDir_String(fileName).c_str(), fileName);
 	fileHandle = PHYSFS_openRead(fileName);
 
 	if (fileHandle == nullptr)

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2617,7 +2617,7 @@ bool loadGame(const char *pGameToLoad, bool keepObjects, bool freeMem, bool User
 	return true;
 
 error:
-	debug(LOG_ERROR, "Game load failed for %s, FS:%s, params=%s,%s,%s", pGameToLoad, PHYSFS_getRealDir(pGameToLoad),
+	debug(LOG_ERROR, "Game load failed for %s, FS:%s, params=%s,%s,%s", pGameToLoad, WZ_PHYSFS_getRealDir_String(pGameToLoad).c_str(),
 	      keepObjects ? "true" : "false", freeMem ? "true" : "false", UserSaveGame ? "true" : "false");
 
 	/* Clear all the objects off the map and free up the map memory */

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -647,7 +647,13 @@ bool buildMapList()
 	{
 		bool mapmod = false;
 		struct WZmaps CurrentMap;
-		std::string realFilePathAndName = PHYSFS_getRealDir(realFileName.platformIndependent.c_str()) + realFileName.platformDependent;
+		const char * pRealDirStr = PHYSFS_getRealDir(realFileName.platformIndependent.c_str());
+		if (!pRealDirStr)
+		{
+			debug(LOG_ERROR, "Failed to find realdir for: %s", realFileName.platformIndependent.c_str());
+			continue; // skip
+		}
+		std::string realFilePathAndName = pRealDirStr + realFileName.platformDependent;
 
 		PHYSFS_mount(realFilePathAndName.c_str(), NULL, PHYSFS_APPEND);
 

--- a/src/levels.cpp
+++ b/src/levels.cpp
@@ -753,7 +753,7 @@ bool levLoadData(char const *name, Sha256 const *hash, char *pSaveName, GAME_TYP
 			if (psBaseData->apDataFiles[i])
 			{
 				// load the data
-				debug(LOG_WZ, "Loading [directory: %s] %s ...", PHYSFS_getRealDir(psBaseData->apDataFiles[i]), psBaseData->apDataFiles[i]);
+				debug(LOG_WZ, "Loading [directory: %s] %s ...", WZ_PHYSFS_getRealDir_String(psBaseData->apDataFiles[i]).c_str(), psBaseData->apDataFiles[i]);
 				if (!resLoad(psBaseData->apDataFiles[i], i))
 				{
 					debug(LOG_ERROR, "Failed resLoad(%s)!", psBaseData->apDataFiles[i]);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -752,7 +752,7 @@ static void scanDataDirs()
 
 	if (PHYSFS_exists("gamedesc.lev"))
 	{
-		debug(LOG_WZ, "gamedesc.lev found at %s", PHYSFS_getRealDir("gamedesc.lev"));
+		debug(LOG_WZ, "gamedesc.lev found at %s", WZ_PHYSFS_getRealDir_String("gamedesc.lev").c_str());
 	}
 	else
 	{

--- a/src/multiint.cpp
+++ b/src/multiint.cpp
@@ -45,6 +45,7 @@
 #include "lib/framework/frameresource.h"
 #include "lib/framework/file.h"
 #include "lib/framework/stdio_ext.h"
+#include "lib/framework/physfs_ext.h"
 
 /* Includes direct access to render library */
 #include "lib/ivis_opengl/bitimage.h"
@@ -564,7 +565,7 @@ void loadMapPreview(bool hideInterface)
 	}
 	else
 	{
-		debug(LOG_WZ, "Loading map preview: \"%s\" in (%s)\"%s\"  %s t%d", psLevel->pName, PHYSFS_getRealDir(psLevel->realFileName), psLevel->realFileName, psLevel->realFileHash.toString().c_str(), psLevel->dataDir);
+		debug(LOG_WZ, "Loading map preview: \"%s\" in (%s)\"%s\"  %s t%d", psLevel->pName, WZ_PHYSFS_getRealDir_String(psLevel->realFileName).c_str(), psLevel->realFileName, psLevel->realFileHash.toString().c_str(), psLevel->dataDir);
 	}
 	rebuildSearchPath(psLevel->dataDir, false, psLevel->realFileName);
 	sstrcpy(aFileName, psLevel->apDataFiles[psLevel->game]);

--- a/src/multiplay.cpp
+++ b/src/multiplay.cpp
@@ -1638,7 +1638,7 @@ bool recvMapFileRequested(NETQUEUE queue)
 		abort();
 	}
 
-	debug(LOG_INFO, "File is valid, sending [directory: %s] %s to client %u", PHYSFS_getRealDir(filename.c_str()), filename.c_str(), player);
+	debug(LOG_INFO, "File is valid, sending [directory: %s] %s to client %u", WZ_PHYSFS_getRealDir_String(filename.c_str()).c_str(), filename.c_str(), player);
 
 	PHYSFS_sint64 fileSize_64 = PHYSFS_fileLength(pFileHandle);
 	ASSERT_OR_RETURN(false, fileSize_64 <= 0xFFFFFFFF, "File too big!");


### PR DESCRIPTION
Previously, the proper platform independent / dependent path notation was not being used in all cases (different `PHYSFS_*()` APIs expect different notation for different parameters).

Also: 
- Fix: PHYSFS_getRealDir() can return NULL