### PR TITLE
Add Alpine Linux CI, fix compilation with musl libc

### DIFF
--- a/.github/workflows/CI_alpine.yml
+++ b/.github/workflows/CI_alpine.yml
@@ -39,7 +39,7 @@ jobs:
       env:
         CC: ${{ matrix.cc }}
         CXX: ${{ matrix.cxx }}
-      run: docker run --rm -e CC -e CXX -e "CI=true" -e GITHUB_WORKFLOW -e GITHUB_ACTIONS -e GITHUB_REPOSITORY -e "GITHUB_WORKSPACE=/code" -e GITHUB_SHA -e GITHUB_REF -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e MAKEFLAGS -v $(pwd):/code alpine cmake '-H.' -Bbuild -DCMAKE_BUILD_TYPE=RelWithDebInfo -DWZ_ENABLE_WARNINGS:BOOL=OFF
+      run: docker run --rm -e CC -e CXX -e "CI=true" -e GITHUB_WORKFLOW -e GITHUB_ACTIONS -e GITHUB_REPOSITORY -e "GITHUB_WORKSPACE=/code" -e GITHUB_SHA -e GITHUB_REF -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e MAKEFLAGS -v $(pwd):/code alpine cmake '-H.' -Bbuild -DCMAKE_BUILD_TYPE=RelWithDebInfo -DWZ_ENABLE_WARNINGS:BOOL=OFF -DWZ_FINDSDL2_NOCONFIG:BOOL=ON
     - name: CMake Build
       env:
         CC: ${{ matrix.cc }}

--- a/.github/workflows/CI_alpine.yml
+++ b/.github/workflows/CI_alpine.yml
@@ -1,0 +1,47 @@
+name: Alpine
+
+on:
+  push:
+    branches-ignore:
+      - 'l10n_**' # Push events to translation service branches (that begin with "l10n_")
+    # Sequence of patterns matched against refs/tags
+    tags:
+      - '*'
+  pull_request:
+    # Match all pull requests
+
+jobs:
+  alpine-latest:
+    strategy:
+      matrix:
+        include:
+          - name: ":LATEST (CMake) [GCC]"
+            cc: '/usr/bin/gcc'
+            cxx: '/usr/bin/g++'
+      fail-fast: false
+    name: '${{ matrix.name }}'
+    runs-on: ubuntu-latest
+    if: "!contains(github.event.head_commit.message, '[ci skip]')"
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Prepare Git Repo for autorevision
+      run: cmake -P .ci/githubactions/prepare_git_repo.cmake
+    - name: Init Git Submodules
+      run: git submodule update --init --recursive
+    - name: Build the Docker image
+      run: |
+        cd docker/alpine-latest/
+        docker build -t alpine .
+        cd ../..
+    - name: CMake Configure
+      env:
+        CC: ${{ matrix.cc }}
+        CXX: ${{ matrix.cxx }}
+      run: docker run --rm -e CC -e CXX -e "CI=true" -e GITHUB_WORKFLOW -e GITHUB_ACTIONS -e GITHUB_REPOSITORY -e "GITHUB_WORKSPACE=/code" -e GITHUB_SHA -e GITHUB_REF -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e MAKEFLAGS -v $(pwd):/code alpine cmake '-H.' -Bbuild -DCMAKE_BUILD_TYPE=RelWithDebInfo -DWZ_ENABLE_WARNINGS:BOOL=OFF
+    - name: CMake Build
+      env:
+        CC: ${{ matrix.cc }}
+        CXX: ${{ matrix.cxx }}
+      run: docker run --rm -e CC -e CXX -e "CI=true" -e GITHUB_WORKFLOW -e GITHUB_ACTIONS -e GITHUB_REPOSITORY -e "GITHUB_WORKSPACE=/code" -e GITHUB_SHA -e GITHUB_REF -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e MAKEFLAGS -v $(pwd):/code alpine cmake --build build

--- a/docker/alpine-latest/Dockerfile
+++ b/docker/alpine-latest/Dockerfile
@@ -1,0 +1,9 @@
+FROM alpine:latest
+
+RUN apk add --no-cache git build-base clang cmake ninja gdb p7zip gettext asciidoctor
+RUN apk add --no-cache sdl2-dev physfs-dev libpng-dev openal-soft-dev libogg-dev libvorbis-dev libtheora-dev glew-dev freetype-dev harfbuzz-dev curl-dev libsodium-dev qt5-qtbase-dev qt5-qtscript-dev
+
+RUN cat /etc/alpine-release
+
+WORKDIR /code
+CMD ["/bin/sh"]

--- a/lib/framework/debug.cpp
+++ b/lib/framework/debug.cpp
@@ -34,9 +34,9 @@
 #include <map>
 #include <string>
 
-#ifdef WZ_OS_LINUX
+#if defined(WZ_OS_LINUX) && defined(__GLIBC__)
 #include <execinfo.h>  // Nonfatal runtime backtraces.
-#endif //WZ_OS_LINUX
+#endif // defined(WZ_OS_LINUX) && defined(__GLIBC__)
 
 #if defined(WZ_OS_UNIX)
 # include <fcntl.h>
@@ -607,7 +607,7 @@ void _debug(int line, code_part part, const char *function, const char *str, ...
 
 void _debugBacktrace(code_part part)
 {
-#ifdef WZ_OS_LINUX
+#if defined(WZ_OS_LINUX) && defined(__GLIBC__)
 	void *btv[20];
 	unsigned num = backtrace(btv, sizeof(btv) / sizeof(*btv));
 	char **btc = backtrace_symbols(btv, num);

--- a/lib/netplay/netplay.cpp
+++ b/lib/netplay/netplay.cpp
@@ -64,9 +64,9 @@
 #include "src/loadsave.h"
 #include "src/activity.h"
 
-#ifdef WZ_OS_LINUX
+#if defined(WZ_OS_LINUX) && defined(__GLIBC__)
 #include <execinfo.h>  // Nonfatal runtime backtraces.
-#endif //WZ_OS_LINUX
+#endif // defined(WZ_OS_LINUX) && defined(__GLIBC__)
 
 // WARNING !!! This is initialised via configuration.c !!!
 char masterserver_name[255] = {'\0'};
@@ -3815,7 +3815,7 @@ void _syncDebugBacktrace(const char *function)
 
 	uint32_t backupCrc = syncDebugLog[syncDebugNext].getCrc();  // Ignore CRC changes from _syncDebug(), since identical backtraces can be printed differently.
 
-#ifdef WZ_OS_LINUX
+#if defined(WZ_OS_LINUX) && defined(__GLIBC__)
 	void *btv[20];
 	unsigned num = backtrace(btv, sizeof(btv) / sizeof(*btv));
 	char **btc = backtrace_symbols(btv, num);

--- a/lib/sdl/CMakeLists.txt
+++ b/lib/sdl/CMakeLists.txt
@@ -1,6 +1,12 @@
 cmake_minimum_required (VERSION 3.5)
 project (sdl-backend CXX)
 
+if(NOT (CMAKE_SYSTEM_NAME MATCHES "Windows" OR CMAKE_SYSTEM_NAME MATCHES "Darwin"))
+	# Temporary workaround for systems with broken SDL2 CMake config (ex. imported target does not exist in "SDL2Targets.cmake")
+	# Can be manually set to "ON" to avoid using the CONFIG mode
+	OPTION(WZ_FINDSDL2_NOCONFIG "Disable trying to find SDL2 using CONFIG mode" OFF)
+endif()
+
 file(GLOB HEADERS "*.h")
 file(GLOB SRC "*.cpp")
 
@@ -42,7 +48,9 @@ endfunction()
 # Prefer finding SDL2 using CMake Config, to properly include any dependencies / linked libraries (with complete, imported targets)
 # - This should work for vcpkg-installed SDL2, as well as other installs that generate a full (proper) CMake Config,
 # - and is required to properly link with a static SDL2 library (at least on Windows and macOS)
-find_package(SDL2 ${SDL2_MIN_VERSION} CONFIG QUIET)
+if(NOT DEFINED WZ_FINDSDL2_NOCONFIG OR NOT WZ_FINDSDL2_NOCONFIG)
+	find_package(SDL2 ${SDL2_MIN_VERSION} CONFIG QUIET)
+endif()
 if(SDL2_FOUND)
 	if (TARGET SDL2::SDL2-static)
 		test_link_to_sdl_target(SDL2::SDL2-static LINK_SUCCESS_SDL2_SDL2STATIC_TARGET)


### PR DESCRIPTION
Alpine Linux is one of [a number of Linux distributions using musl libc](https://wiki.musl-libc.org/projects-using-musl.html#Linux-distributions-using-musl).

Adding this to CI uncovered a few minor issues when compiling with musl libc.