### PR TITLE
Fix player stat "played" being unrelated to total games played.

### DIFF
--- a/src/multiint.cpp
+++ b/src/multiint.cpp
@@ -4366,7 +4366,7 @@ void displayPlayer(WIDGET *psWidget, UDWORD xOffset, UDWORD yOffset)
 		}
 
 		PLAYERSTATS stat = getMultiStats(j);
-		if (stat.wins + stat.losses < 5)
+		if (stat.played < 5)
 		{
 			iV_DrawImage(FrontImages, IMAGE_MEDAL_DUMMY, x + 4, y + 13);
 		}
@@ -4389,8 +4389,8 @@ void displayPlayer(WIDGET *psWidget, UDWORD xOffset, UDWORD yOffset)
 				iV_DrawImage(FrontImages, IMAGE_MULTIRANK3, x + 4, y + 3);
 			}
 
-			// star 2 games played (Cannot use stat.played, since that's just the number of times the player exited via the game menu, not the number of games played.)
-			eval = stat.wins + stat.losses;
+			// star 2 games played
+			eval = stat.played;
 			if (eval > 200)
 			{
 				iV_DrawImage(FrontImages, IMAGE_MULTIRANK1, x + 4, y + 13);

--- a/src/multiopt.cpp
+++ b/src/multiopt.cpp
@@ -476,7 +476,6 @@ bool multiGameShutdown()
 	debug(LOG_NET, "%s is shutting down.", getPlayerName(selectedPlayer));
 
 	sendLeavingMsg();							// say goodbye
-	updateMultiStatsGames();					// update games played.
 
 	st = getMultiStats(selectedPlayer);	// save stats
 

--- a/src/wrappers.cpp
+++ b/src/wrappers.cpp
@@ -303,6 +303,8 @@ bool displayGameOver(bool bDidit, bool showBackDrop)
 	}
 	if (bMultiPlayer)
 	{
+		updateMultiStatsGames(); // update games played.
+
 		PLAYERSTATS st = getMultiStats(selectedPlayer);
 		saveMultiStats(getPlayerName(selectedPlayer), getPlayerName(selectedPlayer), &st);
 	}


### PR DESCRIPTION
Previously represented how many times the player exited back to the main menu.

Note: Lightly tested and the idea is that the played stat only updates after the win/loss screen gets displayed.

Fixes #1011.