### PR TITLE
Reload palette after using downloaded mods.

### DIFF
--- a/src/multiopt.cpp
+++ b/src/multiopt.cpp
@@ -29,6 +29,7 @@
 #include "lib/framework/file.h"
 #include "lib/framework/wzapp.h"
 
+#include "lib/ivis_opengl/piepalette.h" // for pal_Init()
 #include "lib/ivis_opengl/piestate.h"
 
 #include "map.h"
@@ -245,6 +246,7 @@ void recvOptions(NETQUEUE queue)
 		}
 		else
 		{
+			pal_Init(); // Palette could be modded.
 			return false;  // Have the file already.
 		}
 

--- a/src/multiplay.cpp
+++ b/src/multiplay.cpp
@@ -29,6 +29,7 @@
 #include <chrono>
 
 #include "lib/framework/frame.h"
+#include "lib/ivis_opengl/piepalette.h" // for pal_Init()
 #include "lib/framework/input.h"
 #include "lib/framework/strres.h"
 #include "lib/framework/physfs_ext.h"
@@ -1707,6 +1708,7 @@ bool recvMapFileData(NETQUEUE queue)
 		levShutDown();
 		levInitialise();
 		rebuildSearchPath(mod_multiplay, true);	// MUST rebuild search path for the new maps we just got!
+		pal_Init(); //Update palettes.
 		if (!buildMapList())
 		{
 			return false;


### PR DESCRIPTION
Function pal_Init() is, at this moment, only called once at game start after the the game loads mods for the first time. This means that if a host has a mod that modifies palette.txt then all clients won't have updated palettes to match the host. These changes, to my knowledge, should be sufficient to fix this issue.

Below is a simple test mod I used during my tests.

[pal.zip](https://github.com/Warzone2100/warzone2100/files/4874436/pal.zip)

Fixes #944.