### PR TITLE
[Cirrus CI] Disable FreeBSD 11.3 (for now)

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -8,7 +8,7 @@ freebsd_build_task:
     # See the list of available FreeBSD image families here: https://cirrus-ci.org/guide/FreeBSD/
     matrix:
       - image_family: freebsd-12-1-snap # FreeBSD 12.1-STABLE
-      - image_family: freebsd-11-3-snap # FreeBSD 11.3-STABLE
+#      - image_family: freebsd-11-3-snap # FreeBSD 11.3-STABLE # currently disabled because of Qt5 port issue
 #    cpu: 4
 #    memory: 8G
 


### PR DESCRIPTION
Disabling this temporarily until we can figure out if a workaround is possible.