### PR TITLE
Add snapcraft build files

### DIFF
--- a/.github/workflows/CI_snapcraft.yml
+++ b/.github/workflows/CI_snapcraft.yml
@@ -95,6 +95,7 @@ jobs:
       if: success()
       with:
         name: ${{ steps.snapcraft.outputs.snap }}
+        path: '${{ env.WZ_FULL_OUTPUT_SNAP_PATH }}'
     - name: Upload artifact to release
       if: success() && startsWith(github.ref, 'refs/tags/')
       uses: past-due/action-gh-release@v1

--- a/.github/workflows/CI_snapcraft.yml
+++ b/.github/workflows/CI_snapcraft.yml
@@ -85,7 +85,7 @@ jobs:
         echo "OUTPUT_DIR=${OUTPUT_DIR}"
         echo "::set-env name=OUTPUT_DIR::${OUTPUT_DIR}"
         mkdir -p "${OUTPUT_DIR}"
-        OUTPUT_FILE_NAME="warzone2100_${{ matrix.arch }}.snap"
+        OUTPUT_FILE_NAME="warzone2100_linux_${{ matrix.arch }}.snap"
         cp "${{ steps.snapcraft.outputs.snap }}" "${OUTPUT_DIR}/${OUTPUT_FILE_NAME}"
         echo "Generated .snap: \"${OUTPUT_FILE_NAME}\""
         echo "  -> SHA512: $(sha512sum "${OUTPUT_DIR}/${OUTPUT_FILE_NAME}")"
@@ -94,7 +94,7 @@ jobs:
     - uses: actions/upload-artifact@v1
       if: success()
       with:
-        name: ${{ steps.snapcraft.outputs.snap }}
+        name: 'warzone2100_linux_${{ matrix.arch }}_snap'
         path: '${{ env.WZ_FULL_OUTPUT_SNAP_PATH }}'
     - name: Upload artifact to release
       if: success() && startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/CI_snapcraft.yml
+++ b/.github/workflows/CI_snapcraft.yml
@@ -1,0 +1,105 @@
+name: Snapcraft
+
+on:
+  push:
+    branches-ignore:
+      - 'l10n_**' # Push events to translation service branches (that begin with "l10n_")
+    # Sequence of patterns matched against refs/tags
+    tags:
+      - '*'
+  pull_request:
+    # Match all pull requests
+
+jobs:
+  snapcraft:
+    strategy:
+      matrix:
+        include:
+          - name: "Snapcraft"
+            arch: "amd64"
+    name: '${{ matrix.name }}'
+    runs-on: ubuntu-latest
+    if: "!contains(github.event.head_commit.message, '[ci skip]')"
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Prepare Git Repo for autorevision
+      run: cmake -P .ci/githubactions/prepare_git_repo.cmake
+    - name: Init Git Submodules
+      run: git submodule update --init --recursive
+    - name: Compute build variables
+      run: |
+        . .ci/githubactions/export_build_output_desc.sh
+        echo "::set-env name=WZ_BUILD_DESC_IS_TAG::${WZ_BUILD_DESC_IS_TAG}"
+        echo "::set-env name=WZ_BUILD_DESC_PREFIX::${WZ_BUILD_DESC_PREFIX}"
+        WZ_OUTPUT_NAME_SUFFIX=""
+        WZ_NAME_SUFFIX=""
+        if [ "$WZ_BUILD_DESC_IS_TAG" == "false" ]; then
+          WZ_OUTPUT_NAME_SUFFIX="_$(echo "${WZ_BUILD_DESC_PREFIX}" | sed 's/[^a-zA-Z0-9\.]/_/g')"
+          WZ_NAME_SUFFIX=" ($(echo "${WZ_BUILD_DESC_PREFIX}" | sed 's/[^a-zA-Z0-9\.]/_/g'))"
+        fi
+        echo "WZ_OUTPUT_NAME_SUFFIX=${WZ_OUTPUT_NAME_SUFFIX}"
+        echo "::set-env name=WZ_OUTPUT_NAME_SUFFIX::${WZ_OUTPUT_NAME_SUFFIX}"
+        echo "::set-env name=WZ_NAME_SUFFIX::${WZ_NAME_SUFFIX}"
+
+        WZ_DISTRIBUTOR="UNKNOWN"
+        if [ "${GITHUB_REPOSITORY}" == "Warzone2100/warzone2100" ]; then
+          WZ_DISTRIBUTOR="wz2100.net"
+        fi
+        echo "WZ_DISTRIBUTOR=${WZ_DISTRIBUTOR}"
+        echo "::set-env name=WZ_DISTRIBUTOR::${WZ_DISTRIBUTOR}"
+
+    - name: Prepare to build .SNAP
+      run: |
+        WZ_PACKAGE_VAR_OVERRIDES=""
+        WZ_SHORT_SHA=$(echo "${GITHUB_SHA}" | head -c 7)
+        if [ "$WZ_BUILD_DESC_IS_TAG" == "false" ]; then
+          SNAP_VERSION_SAFE_DESC_PREFIX=$(echo "${WZ_BUILD_DESC_PREFIX}" | sed 's/[^a-zA-Z0-9]/~/g')
+          WZ_PACKAGE_VAR_OVERRIDES="-D WZ_DEVELOPMENT_BUILD=ON"
+        fi
+        WZ_SNAP_PACKAGE_NAME=$(echo "warzone2100${WZ_OUTPUT_NAME_SUFFIX}" | sed 's/[^a-zA-Z0-9\.\+\-]/-/g')
+        
+        cat > .snapenv <<EOENV
+        CI=true
+        GITHUB_WORKFLOW="$GITHUB_WORKFLOW"
+        GITHUB_ACTIONS="$GITHUB_ACTIONS"
+        GITHUB_REPOSITORY="$GITHUB_REPOSITORY"
+        GITHUB_WORKSPACE="$GITHUB_WORKSPACE"
+        GITHUB_SHA="$GITHUB_SHA"
+        GITHUB_REF="$GITHUB_REF"
+        GITHUB_HEAD_REF="$GITHUB_HEAD_REF"
+        GITHUB_BASE_REF="$GITHUB_BASE_REF"
+        MAKEFLAGS="$MAKEFLAGS"
+        SNAP_VERSION_SAFE_DESC_PREFIX="$SNAP_VERSION_SAFE_DESC_PREFIX"
+        WZ_SHORT_SHA="$WZ_SHORT_SHA"
+        WZ_PACKAGE_VAR_OVERRIDES="$WZ_PACKAGE_VAR_OVERRIDES"
+        WZ_SNAP_PACKAGE_NAME="$WZ_SNAP_PACKAGE_NAME"
+        EOENV
+    - name: Build .SNAP
+      uses: snapcore/action-build@v1
+    - name: Gather .SNAP
+      run: |
+        OUTPUT_DIR="${HOME}/output"
+        echo "OUTPUT_DIR=${OUTPUT_DIR}"
+        echo "::set-env name=OUTPUT_DIR::${OUTPUT_DIR}"
+        mkdir -p "${OUTPUT_DIR}"
+        OUTPUT_FILE_NAME="warzone2100_${{ matrix.arch }}.snap"
+        cp "warzone2100_*.snap" "${OUTPUT_DIR}/${OUTPUT_FILE_NAME}"
+        echo "Generated .snap: \"${OUTPUT_FILE_NAME}\""
+        echo "  -> SHA512: $(sha512sum "${OUTPUT_DIR}/${OUTPUT_FILE_NAME}")"
+        echo "  -> Size (bytes): $(stat -c %s "${OUTPUT_DIR}/${OUTPUT_FILE_NAME}")"
+        echo "::set-env name=WZ_FULL_OUTPUT_SNAP_PATH::${OUTPUT_DIR}/${OUTPUT_FILE_NAME}"
+    - uses: actions/upload-artifact@v1
+      if: success()
+      with:
+        name: "warzone2100_${{ matrix.arch }}.snap"
+    - name: Upload artifact to release
+      if: success() && startsWith(github.ref, 'refs/tags/')
+      uses: past-due/action-gh-release@v1
+      with:
+        # Do not explicitly specify a tag_name, so this action takes the github.ref and parses it for just the tag
+        files: ${{ env.WZ_FULL_OUTPUT_SNAP_PATH }}
+        draft: true
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI_snapcraft.yml
+++ b/.github/workflows/CI_snapcraft.yml
@@ -77,6 +77,7 @@ jobs:
         WZ_SNAP_PACKAGE_NAME="$WZ_SNAP_PACKAGE_NAME"
         EOENV
     - name: Build .SNAP
+      id: snapcraft
       uses: snapcore/action-build@v1
     - name: Gather .SNAP
       run: |
@@ -85,7 +86,7 @@ jobs:
         echo "::set-env name=OUTPUT_DIR::${OUTPUT_DIR}"
         mkdir -p "${OUTPUT_DIR}"
         OUTPUT_FILE_NAME="warzone2100_${{ matrix.arch }}.snap"
-        cp "warzone2100_*.snap" "${OUTPUT_DIR}/${OUTPUT_FILE_NAME}"
+        cp "${{ steps.snapcraft.outputs.snap }}" "${OUTPUT_DIR}/${OUTPUT_FILE_NAME}"
         echo "Generated .snap: \"${OUTPUT_FILE_NAME}\""
         echo "  -> SHA512: $(sha512sum "${OUTPUT_DIR}/${OUTPUT_FILE_NAME}")"
         echo "  -> Size (bytes): $(stat -c %s "${OUTPUT_DIR}/${OUTPUT_FILE_NAME}")"
@@ -93,7 +94,7 @@ jobs:
     - uses: actions/upload-artifact@v1
       if: success()
       with:
-        name: "warzone2100_${{ matrix.arch }}.snap"
+        name: ${{ steps.snapcraft.outputs.snap }}
     - name: Upload artifact to release
       if: success() && startsWith(github.ref, 'refs/tags/')
       uses: past-due/action-gh-release@v1

--- a/.gitignore
+++ b/.gitignore
@@ -206,6 +206,12 @@ commit-*
 /pkg/dpkg/warzone2100.substvars
 /pkg/dpkg/warzone2100/
 
+#Snapcraft Stuff
+/prime
+/stage
+/parts
+/.snapenv
+
 #Mac Stuff
 .DS_Store
 *.pbxuser

--- a/.snapcraft.yaml
+++ b/.snapcraft.yaml
@@ -124,6 +124,7 @@ parts:
 
   warzone2100:
     after: [desktop-qt5, sdl]
+    plugin: cmake
     source: .
     parse-info:
       # Parse this appdata/metainfo file for summary, description,
@@ -131,34 +132,17 @@ parts:
       - usr/share/metainfo/warzone2100.appdata.xml
     override-pull: |
       snapcraftctl pull
-
-      last_committed_tag="$(git tag -l --sort=version:refname | grep -E -e '^[1-9]+(\.[0-9]+){2,}' | grep -E -v '[-_](beta([0-9]+)?)' | tail -n 1)"
-      echo "last_committed_tag: $last_committed_tag"
-      last_released_tag="$(snap info warzone2100 | awk '$1 == "latest/beta:" { print $2 }')"
-      echo "last_released_tag: $last_released_tag"
-      # If the latest tag from the upstream project has not been released to
-      # beta, build that tag instead of master.
-      if [ "${last_committed_tag}" != "${last_released_tag}" ]; then
-        echo "git submodule deinit --all"
-        git submodule deinit --all
-        echo "git fetch ..."
-        git fetch
-        echo "git checkout $last_committed_tag ..."
-        git checkout "${last_committed_tag}"
-        echo "git submodule update"
-        git submodule update --init
-        snapcraftctl set-version "$last_committed_tag"
-      else
-        snapcraftctl set-version "$(git describe --always)"
-      fi
+      snapcraftctl set-version "$(git describe --always)"
+      git submodule update --init
 
       # Include the icon's path in the desktop file, not just the name.
       sed -i -E 's|Icon=(.*)|Icon=/usr/share/icons/\1.png|' icons/warzone2100.desktop.in
-    plugin: cmake
-    configflags:
-      - -DCMAKE_INSTALL_PREFIX=/usr
-      - -DCMAKE_BUILD_TYPE=RelWithDebInfo
-      - -DWZ_DISTRIBUTOR=Snapcraft
+    override-build: |
+      if [ -f ".snapenv" ]; then set -a; source .snapenv; set +a; fi
+      if [ -z "$WZ_DISTRIBUTOR" ]; then export WZ_DISTRIBUTOR="UNKNOWN"; fi
+      cmake -S "$SNAPCRAFT_PART_SRC" -B. -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=RelWithDebInfo -DWZ_ENABLE_WARNINGS:BOOL=ON -DWZ_DISTRIBUTOR:STRING="${WZ_DISTRIBUTOR}" -DWZ_OUTPUT_NAME_SUFFIX="${WZ_OUTPUT_NAME_SUFFIX}" -DWZ_NAME_SUFFIX="${WZ_NAME_SUFFIX}" -G"Ninja"
+      cmake --build . -- -j$SNAPCRAFT_PARALLEL_BUILD_COUNT
+      DESTDIR=$SNAPCRAFT_PART_INSTALL cmake --build . -- install
     build-packages:
       - asciidoctor
       - g++
@@ -179,6 +163,7 @@ parts:
       - libcurl4-gnutls-dev
       - libgnutls28-dev
       - libsodium-dev
+      - ninja-build
       - unzip
       - zip
     stage-packages:

--- a/.snapcraft.yaml
+++ b/.snapcraft.yaml
@@ -124,7 +124,7 @@ parts:
 
   warzone2100:
     after: [desktop-qt5, sdl]
-    source: https://github.com/Warzone2100/warzone2100.git
+    source: .
     parse-info:
       # Parse this appdata/metainfo file for summary, description,
       # and icon. Use the installed path relative to the Snap's root

--- a/.snapcraft.yaml
+++ b/.snapcraft.yaml
@@ -154,7 +154,6 @@ parts:
 
       # Include the icon's path in the desktop file, not just the name.
       sed -i -E 's|Icon=(.*)|Icon=/usr/share/icons/\1.png|' icons/warzone2100.desktop.in
-    source-type: git
     plugin: cmake
     configflags:
       - -DCMAKE_INSTALL_PREFIX=/usr

--- a/.snapcraft.yaml
+++ b/.snapcraft.yaml
@@ -1,0 +1,206 @@
+name: warzone2100 # no spaces, all lower-case
+# summary, description, and icon are parsed from the appdata/metainfo file
+adopt-info: warzone2100
+confinement: strict
+grade: stable
+base: core18
+
+apps:
+  warzone2100:
+    command: usr/bin/warzone2100
+    command-chain: [bin/desktop-launch]
+    common-id: warzone2100 # should match the appdata/metainfo file's <id> field
+    desktop: usr/share/applications/warzone2100.desktop
+    plugs:
+      - audio-playback
+      - desktop
+      - desktop-legacy
+      - network
+      - network-bind
+      - opengl
+      - pulseaudio
+      - unity7
+      - wayland
+      - x11
+
+  download-videos:
+    command: bin/download-videos
+    plugs: [network]
+
+parts:
+  scripts:
+    plugin: dump
+    source: pkg/snap
+    organize:
+      download-videos: bin/download-videos
+    stage-packages:
+      - curl
+
+  desktop-qt5:
+    source: https://github.com/ubuntu/snapcraft-desktop-helpers.git
+    source-subdir: qt
+    plugin: make
+    make-parameters: ["FLAVOR=qt5"]
+    build-packages:
+      - qtbase5-dev
+      - dpkg-dev
+    stage-packages:
+      - libxkbcommon0
+      - ttf-ubuntu-font-family
+      - dmz-cursor-theme
+      - light-themes
+      - adwaita-icon-theme
+      - gnome-themes-standard
+      - shared-mime-info
+      - libqt5gui5
+      - libgdk-pixbuf2.0-0
+      - libqt5svg5 # for loading icon themes which are svg
+      - qtwayland5
+      - try: [appmenu-qt5] # not available on core18
+      - locales-all
+      - libgtk2.0-0
+
+  sdl:
+    source: https://www.libsdl.org/release/SDL2-2.0.12.tar.gz
+    plugin: autotools
+    configflags:
+    - --prefix=/usr
+    - --disable-alsa
+    - --disable-arts
+    - --disable-esd
+    - --disable-nas
+    - --disable-oss
+    override-build: |
+      snapcraftctl build
+      sed -i 's|"/usr"|"'"$SNAPCRAFT_STAGE/usr"'"|g' "$SNAPCRAFT_PART_INSTALL/usr/lib/cmake/SDL2/sdl2-config.cmake"
+    build-packages:
+    - fcitx-libs-dev
+    - libegl1-mesa-dev
+    - libgl1-mesa-dev
+    - libgles2-mesa-dev
+    - libibus-1.0-dev
+    - libjack-dev
+    - libpulse-dev
+    - libsamplerate0-dev
+    - libsndfile1-dev
+    - libts-dev
+    - libvulkan-dev
+    - libwayland-dev
+    - libx11-dev
+    - libxcursor-dev
+    - libxext-dev
+    - libxi-dev
+    - libxinerama-dev
+    - libxkbcommon-dev
+    - libxrandr-dev
+    - libxrender-dev
+    - libxss-dev
+    - libxxf86vm-dev
+    stage-packages:
+    - fcitx-libs
+    - libdrm2
+    - libegl1-mesa
+    - libgl1
+    - libgles2
+    - libibus-1.0-5
+    - libjack0
+    - libpulse0
+    - libsamplerate0
+    - libts0
+    - libsndfile1
+    - libwayland-client0
+    - libwayland-egl1-mesa
+    - libvulkan1
+    - libx11-6
+    - libxcursor1
+    - libxext6
+    - libxi6
+    - libxinerama1
+    - libxkbcommon0
+    - libxrandr2
+    - libxrender1
+    - libxss1
+    - libxxf86vm1
+
+  warzone2100:
+    after: [desktop-qt5, sdl]
+    source: https://github.com/Warzone2100/warzone2100.git
+    parse-info:
+      # Parse this appdata/metainfo file for summary, description,
+      # and icon. Use the installed path relative to the Snap's root
+      - usr/share/metainfo/warzone2100.appdata.xml
+    override-pull: |
+      snapcraftctl pull
+
+      last_committed_tag="$(git tag -l --sort=version:refname | grep -E -e '^[1-9]+(\.[0-9]+){2,}' | grep -E -v '[-_](beta([0-9]+)?)' | tail -n 1)"
+      echo "last_committed_tag: $last_committed_tag"
+      last_released_tag="$(snap info warzone2100 | awk '$1 == "latest/beta:" { print $2 }')"
+      echo "last_released_tag: $last_released_tag"
+      # If the latest tag from the upstream project has not been released to
+      # beta, build that tag instead of master.
+      if [ "${last_committed_tag}" != "${last_released_tag}" ]; then
+        echo "git submodule deinit --all"
+        git submodule deinit --all
+        echo "git fetch ..."
+        git fetch
+        echo "git checkout $last_committed_tag ..."
+        git checkout "${last_committed_tag}"
+        echo "git submodule update"
+        git submodule update --init
+        snapcraftctl set-version "$last_committed_tag"
+      else
+        snapcraftctl set-version "$(git describe --always)"
+      fi
+
+      # Include the icon's path in the desktop file, not just the name.
+      sed -i -E 's|Icon=(.*)|Icon=/usr/share/icons/\1.png|' icons/warzone2100.desktop.in
+    source-type: git
+    plugin: cmake
+    configflags:
+      - -DCMAKE_INSTALL_PREFIX=/usr
+      - -DCMAKE_BUILD_TYPE=RelWithDebInfo
+      - -DWZ_DISTRIBUTOR=Snapcraft
+    build-packages:
+      - asciidoctor
+      - g++
+      - gettext
+      - libfontconfig1-dev
+      - libfreetype6-dev
+      - libfribidi-dev
+      - libglc-dev
+      - libglew-dev
+      - libharfbuzz-dev
+      - libopenal-dev
+      - libphysfs-dev
+      - libpng-dev
+      - libtheora-dev
+      - libvorbis-dev
+      - qtbase5-dev
+      - qtscript5-dev
+      - libcurl4-gnutls-dev
+      - libgnutls28-dev
+      - libsodium-dev
+      - unzip
+      - zip
+    stage-packages:
+      - libfontconfig1
+      - libfreetype6
+      - libfribidi0
+      - libglc0
+      - libglew2.0
+      - libharfbuzz0b
+      - libogg0
+      - libopenal1
+      - libphysfs1
+      - libpng16-16
+      - libqt5opengl5
+      - libqt5script5
+      - libtheora0
+      - libvorbis0a
+      - libvorbisenc2
+      - libvorbisfile3
+      - libcurl3-gnutls
+      - libsodium23
+      - libglu1-mesa
+      - unzip
+      - zip

--- a/pkg/snap/download-videos
+++ b/pkg/snap/download-videos
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+ME="$0"
+URL=""
+STAMPFILE="$HOME/.downloaded-video-format"
+WARZONEDIR="$HOME/.local/share/warzone2100-$SNAP_VERSION"
+VIDEOTYPE=""
+VIDEOFILE="$WARZONEDIR/sequences.wz"
+CURRENTVIDEOTYPE="$(cat "$STAMPFILE")"
+
+usage() {
+	echo -ne "Warzone 2100 Video Pack Download\n"
+	echo -ne "--------------------------------\n\n"
+
+	if [ -n "$1" ]; then
+		echo -ne "Error: $1\n\n"
+	fi
+
+	echo -ne "USAGE:  $ME { FORMAT } [--force]\n\n"
+	echo -ne "  FORMAT may be any one of the following:\n"
+	echo -ne "    [ low-en  ] : Low quality re-encoded English videos  (162MB)\n"
+	echo -ne "    [ std-de  ] : Original quality German videos         (476MB)\n"
+	echo -ne "    [ std-en  ] : Original quality English videos        (545MB)\n"
+	echo -ne "    [ high-en ] : High quality re-encoded English videos (920MB)\n\n"
+	echo -ne "  --force: Always download the video pack, even if you already have the same pack.\n\n"
+}
+
+case $1 in
+	low|low-en)
+		VIDEOTYPE="low-en"
+		URL="https://sourceforge.net/projects/warzone2100/files/warzone2100/Videos/low-quality-en/sequences.wz/download"
+		;;
+	high|high-en)
+		VIDEOTYPE="high-en"
+		URL="https://sourceforge.net/projects/warzone2100/files/warzone2100/Videos/high-quality-en/sequences.wz/download"
+		;;
+	std|std-en|en)
+		VIDEOTYPE="std-en"
+		URL="https://sourceforge.net/projects/warzone2100/files/warzone2100/Videos/standard-quality-en/sequences.wz/download"
+		;;
+	std-de|de)
+		VIDEOTYPE="std-de"
+		URL="https://sourceforge.net/projects/warzone2100/files/warzone2100/Videos/standard-quality-de/sequences.wz/download"
+		;;
+esac
+
+if [ -z "$VIDEOTYPE" ]; then
+	usage "You need to choose a video format"
+	exit
+fi
+
+if [ -z "$CURRENTVIDEOTYPE" ] || [ "$VIDEOTYPE" != "$CURRENTVIDEOTYPE" ] || [ "$2" = "--force" ]; then
+	[ -e "$VIDEOFILE" ] && rm -f "$VIDEOFILE"
+	mkdir -p "$(dirname "$VIDEOFILE")"
+	curl -L -o "$VIDEOFILE" "$URL" && echo "$VIDEOTYPE" > "$STAMPFILE"
+else
+	echo -ne "You already have this video pack. Skipping redownload."
+fi


### PR DESCRIPTION
* Add `.snapcraft.yaml`.
* Add `pkg/snap/download-videos` as used by the currently available Snap Package in the Snap Store.

--

There are likely places that you will want to streamline. This PR is an almost direct import of the current build setup for the Snap Package as released by Snapcrafters. Places to improve likely include the version setting script in `.snapcraft.yaml` [lines 135 thru 153](https://github.com/Warzone2100/warzone2100/pull/1050/files#diff-c971b793f776ed6edcb09d8999371845R135-R153), and unifying the [`download-videos` script](https://github.com/Warzone2100/warzone2100/pull/1050/files#diff-4d236d46bf4402357917091af90a6421) with the project's current script that does the same job.