### PR TITLE
[Snap] Support warzone2100-videos content snap

### DIFF
--- a/.snapcraft.yaml
+++ b/.snapcraft.yaml
@@ -5,6 +5,13 @@ confinement: strict
 grade: stable
 base: core18
 
+plugs:
+  wz2100-sequences:
+    interface: content
+    content: wz2100-sequences
+    target: $SNAP/usr/share/warzone2100/sequences
+    default-provider: warzone2100-videos
+
 apps:
   warzone2100:
     command: usr/bin/warzone2100


### PR DESCRIPTION
Use the separate `warzone2100-videos` snap as a content provider for the sequences files.

By setting the `default-provider: warzone2100-videos`, `snapd` should automatically install (and connect) the video sequences snap when installing the main `warzone2100` snap. (It is also possible to install & connect manually.)

This also means that the videos should only be downloaded once, and won't impact the size of `warzone2100` snap updates.