### PR TITLE
Show mission victory conditions periodically

### DIFF
--- a/data/base/script/campaign/cam1-7.js
+++ b/data/base/script/campaign/cam1-7.js
@@ -232,6 +232,8 @@ function eventPickup(feature, droid)
 //Mission setup stuff
 function eventStartLevel()
 {
+	camSetExtraObjectiveMessage(_("Destroy all New Paradigm units"));
+
 	enemyHasArtifact = false;
 	enemyStoleArtifact = false;
 	var startpos = getObject("startPosition");

--- a/data/base/script/campaign/cam1a-c.js
+++ b/data/base/script/campaign/cam1a-c.js
@@ -134,6 +134,8 @@ function sendTransport()
 
 function eventStartLevel()
 {
+	camSetExtraObjectiveMessage(_("Destroy all New Paradigm reinforcements"));
+
 	camSetStandardWinLossConditions(CAM_VICTORY_STANDARD, "SUB_1_7S", {
 		callback: "extraVictoryCondition"
 	});

--- a/data/base/script/campaign/cam1ca.js
+++ b/data/base/script/campaign/cam1ca.js
@@ -118,6 +118,8 @@ function sendTransport()
 
 function eventStartLevel()
 {
+	camSetExtraObjectiveMessage(_("Build non-wall structures on the plateau and destroy all New Paradigm reinforcements"));
+
 	totalTransportLoads = 0;
 	blipActive = false;
 

--- a/data/base/script/campaign/cam2-1x.js
+++ b/data/base/script/campaign/cam2-1x.js
@@ -111,6 +111,8 @@ function checkCrashedTeam()
 
 function eventStartLevel()
 {
+	camSetExtraObjectiveMessage(_("Locate and rescue your units from the shot down transporter"));
+
 	camSetStandardWinLossConditions(CAM_VICTORY_OFFWORLD, "CAM_2B", {
 		area: "RTLZ",
 		message: "C21_LZ",

--- a/data/base/script/campaign/cam2-c.js
+++ b/data/base/script/campaign/cam2-c.js
@@ -27,6 +27,8 @@ const COLLECTIVE_RES = [
 //by destroying the air base or crossing the base3Trigger area.
 function videoTrigger()
 {
+	camSetExtraObjectiveMessage(_("Rescue the civilians from The Collective before too many are captured"));
+
 	setMissionTime(getMissionTime() + camChangeOnDiff(camMinutesToSeconds(30)));
 	civilianOrders();
 	captureCivilians();

--- a/data/base/script/campaign/cam2-d.js
+++ b/data/base/script/campaign/cam2-d.js
@@ -73,6 +73,8 @@ function checkNASDACentral()
 
 function eventStartLevel()
 {
+	camSetExtraObjectiveMessage(_("Secure the Uplink from The Collective"));
+
 	camSetStandardWinLossConditions(CAM_VICTORY_OFFWORLD, "SUB_2_6S", {
 		area: "RTLZ",
 		message: "C2D_LZ",

--- a/data/base/script/campaign/cam2-end.js
+++ b/data/base/script/campaign/cam2-end.js
@@ -143,6 +143,8 @@ function checkIfLaunched()
 //Everything in this level mostly just requeues itself until the mission ends.
 function eventStartLevel()
 {
+	camSetExtraObjectiveMessage(_("Send off at least one transporter with a truck and survive The Collective assault"));
+
 	var startpos = {"x": 88, "y": 101};
 	var lz = {"x": 86, "y": 99, "x2": 88, "y2": 101};
 	var tCoords = {"xStart": 87, "yStart": 100, "xOut": 0, "yOut": 55};

--- a/data/base/script/campaign/cam3-1.js
+++ b/data/base/script/campaign/cam3-1.js
@@ -160,6 +160,8 @@ function setupNextMission()
 {
 	if (missileSilosDestroyed())
 	{
+		camSetExtraObjectiveMessage(_("Move all units into the valley"));
+
 		camPlayVideos(["labort.ogg", "MB3_1B_MSG", "MB3_1B_MSG2"]);
 
 		setScrollLimits(0, 0, 64, 64); //Reveal the whole map.
@@ -246,6 +248,8 @@ function unitsInValley()
 
 function eventStartLevel()
 {
+	camSetExtraObjectiveMessage(_("Destroy the missile silos"));
+
 	var startpos = getObject("startPosition");
 	var lz = getObject("landingZone");
 	var tent = getObject("transporterEntry");

--- a/data/base/script/campaign/cam3-2.js
+++ b/data/base/script/campaign/cam3-2.js
@@ -255,6 +255,8 @@ function alphaTeamAlive()
 
 function eventStartLevel()
 {
+	camSetExtraObjectiveMessage(_("Rescue Alpha team from Nexus"));
+
 	var startpos = getObject("startPosition");
 	var lz = getObject("landingZone");
 	var tent = getObject("transporterEntry");

--- a/data/base/script/campaign/cam3-ab.js
+++ b/data/base/script/campaign/cam3-ab.js
@@ -213,6 +213,7 @@ function resistanceResearched()
 
 function eventStartLevel()
 {
+	camSetExtraObjectiveMessage(_("Research resistance circuits and survive the assault from Nexus"));
 
 	var startpos = getObject("startPosition");
 	var lz = getObject("landingZone");

--- a/data/base/script/campaign/cam3-ad1.js
+++ b/data/base/script/campaign/cam3-ad1.js
@@ -213,6 +213,8 @@ function checkMissileSilos()
 
 function eventStartLevel()
 {
+	camSetExtraObjectiveMessage(_("Secure a missile silo"));
+
 	var siloZone = getObject("missileSilos");
 	var startpos = getObject("startPosition");
 	var lz = getObject("landingZone");

--- a/data/base/script/campaign/cam3-ad2.js
+++ b/data/base/script/campaign/cam3-ad2.js
@@ -268,6 +268,8 @@ function checkMissileSilos()
 
 function eventStartLevel()
 {
+	camSetExtraObjectiveMessage(_("Protect the missile silos and research for the missile codes"));
+
 	var startpos = getObject("startPosition");
 	var lz = getObject("landingZone");
 	mapLimit = 137.0;

--- a/data/base/script/campaign/cam3-c.js
+++ b/data/base/script/campaign/cam3-c.js
@@ -124,6 +124,8 @@ function betaAlive()
 
 function eventStartLevel()
 {
+	camSetExtraObjectiveMessage(_("Reunite a part of Beta team with a Gamma team outpost"));
+
 	var startpos = getObject("startPosition");
 	var limboLZ = getObject("limboDroidLZ");
 	reunited = false;

--- a/data/base/script/campaign/libcampaign.js
+++ b/data/base/script/campaign/libcampaign.js
@@ -187,6 +187,8 @@ var __camRTLZTicker;
 var __camLZCompromisedTicker;
 var __camLastAttackTriggered;
 var __camLevelEnded;
+var __camExtraObjectiveMessage;
+var __camVictoryMessageThrottle;
 
 //video
 var __camVideoSequences;

--- a/data/base/script/campaign/libcampaign.js
+++ b/data/base/script/campaign/libcampaign.js
@@ -174,10 +174,10 @@ var __camTransporterMessage;
 var __camTruckInfo;
 
 //victory
-const CAM_VICTORY_STANDARD = 0;
-const CAM_VICTORY_PRE_OFFWORLD = 1;
-const CAM_VICTORY_OFFWORLD = 2;
-const CAM_VICTORY_TIMEOUT = 3;
+const CAM_VICTORY_STANDARD = "__camVictoryStandard";
+const CAM_VICTORY_PRE_OFFWORLD = "__camVictoryPreOffworld";
+const CAM_VICTORY_OFFWORLD = "__camVictoryOffworld";
+const CAM_VICTORY_TIMEOUT = "__camVictoryTimeout";
 var __camWinLossCallback;
 var __camNextLevel;
 var __camNeedBonusTime;

--- a/data/base/script/campaign/libcampaign_includes/artifact.js
+++ b/data/base/script/campaign/libcampaign_includes/artifact.js
@@ -170,6 +170,8 @@ function __camPickupArtifact(artifact)
 	{
 		callback();
 	}
+
+	queue("__camShowVictoryConditions", camSecondsToMilliseconds(1));
 }
 
 function __camLetMeWinArtifacts()

--- a/data/base/script/campaign/libcampaign_includes/base.js
+++ b/data/base/script/campaign/libcampaign_includes/base.js
@@ -311,6 +311,8 @@ function __camCheckBaseEliminated(group)
 		{
 			callback();
 		}
+
+		queue("__camShowVictoryConditions", camSecondsToMilliseconds(1));
 	}
 }
 

--- a/data/base/script/campaign/libcampaign_includes/debug.js
+++ b/data/base/script/campaign/libcampaign_includes/debug.js
@@ -154,14 +154,6 @@ function __camLetMeWin()
 	__camGameWon();
 }
 
-function __camWinInfo()
-{
-	console("Picked up", __camNumArtifacts,
-	        "artifacts out of", Object.keys(__camArtifacts).length);
-	console("Eliminated", __camNumEnemyBases,
-	        "enemy bases out of", Object.keys(__camEnemyBases).length);
-}
-
 function __camGenericDebug(flag, func, args, err, bt)
 {
 	if (camDef(bt) && bt)

--- a/data/base/script/campaign/libcampaign_includes/events.js
+++ b/data/base/script/campaign/libcampaign_includes/events.js
@@ -44,6 +44,10 @@ function cam_eventCheatMode(entered)
 
 function cam_eventChat(from, to, message)
 {
+	if (message === "win info")
+	{
+		__camShowVictoryConditions(true);
+	}
 	if (!__camCheatMode)
 	{
 		return;
@@ -52,10 +56,6 @@ function cam_eventChat(from, to, message)
 	if (message === "let me win" && __camNextLevel !== "SUB_1_1")
 	{
 		__camLetMeWin();
-	}
-	if (message === "win info")
-	{
-		__camWinInfo();
 	}
 	if (message === "make cc")
 	{
@@ -129,12 +129,14 @@ function cam_eventStartLevel()
 	__camSaveLoading = false;
 	__camNeverGroupDroids = [];
 	__camNumTransporterExits = 0;
+	__camVictoryMessageThrottle = 0;
 	camSetPropulsionTypeLimit(); //disable the propulsion changer by default
 	__camAiPowerReset(); //grant power to the AI
 	setTimer("__checkEnemyFactoryProductionTick", camSecondsToMilliseconds(0.8));
 	setTimer("__camTick", camSecondsToMilliseconds(1)); // campaign pollers
 	setTimer("__camTruckTick", camSecondsToMilliseconds(40) + camSecondsToMilliseconds(0.1)); // some slower campaign pollers
 	setTimer("__camAiPowerReset", camMinutesToMilliseconds(3)); //reset AI power every so often
+	setTimer("__camShowVictoryConditions", camMinutesToMilliseconds(5));
 	queue("__camTacticsTick", camSecondsToMilliseconds(0.1)); // would re-queue itself
 	queue("__camGrantSpecialResearch", camSecondsToMilliseconds(6));
 }

--- a/data/base/script/campaign/libcampaign_includes/events.js
+++ b/data/base/script/campaign/libcampaign_includes/events.js
@@ -193,9 +193,9 @@ function cam_eventTransporterExit(transport)
 		//assumes the player can bring in reinforcements immediately after the first
 		//transporter leaves the map. Mission scripts can handle special situations.
 		if (__camNumTransporterExits === 1 &&
-			((__camWinLossCallback === "__camVictoryOffworld" &&
+			((__camWinLossCallback === CAM_VICTORY_OFFWORLD &&
 			__camVictoryData.reinforcements > -1) ||
-			__camWinLossCallback === "__camVictoryStandard"))
+			__camWinLossCallback === CAM_VICTORY_STANDARD))
 		{
 			const REINFORCEMENTS_AVAILABLE_SOUND = "pcv440.ogg";
 			playSound(REINFORCEMENTS_AVAILABLE_SOUND);
@@ -203,7 +203,7 @@ function cam_eventTransporterExit(transport)
 	}
 
 	if (transport.player !== CAM_HUMAN_PLAYER ||
-		(__camWinLossCallback === "__camVictoryStandard" &&
+		(__camWinLossCallback === CAM_VICTORY_STANDARD &&
 		transport.player === CAM_HUMAN_PLAYER))
 	{
 		// allow the next transport to enter
@@ -212,7 +212,7 @@ function cam_eventTransporterExit(transport)
 			delete __camIncomingTransports[transport.player];
 		}
 	}
-	else if (__camWinLossCallback === "__camVictoryPreOffworld")
+	else if (__camWinLossCallback === CAM_VICTORY_PRE_OFFWORLD)
 	{
 		camTrace("Transporter is away.");
 		__camGameWon();

--- a/data/base/script/campaign/libcampaign_includes/victory.js
+++ b/data/base/script/campaign/libcampaign_includes/victory.js
@@ -150,6 +150,13 @@ function camCheckExtraObjective()
 	return extraObjMet;
 }
 
+//Message(s) the mission script can set to further explain specific victory conditions.
+//Allows a single string or an array of strings.
+function camSetExtraObjectiveMessage(message)
+{
+	__camExtraObjectiveMessage = message;
+}
+
 //////////// privates
 
 function __camGameLostCB()
@@ -448,4 +455,89 @@ function __camVictoryOffworld()
 			camUnmarkTiles(lz);
 		}
 	}
+}
+
+function __camShowVictoryConditions(forceMessage)
+{
+	if (!camDef(forceMessage))
+	{
+		if (__camVictoryMessageThrottle + camSecondsToMilliseconds(10) > gameTime)
+		{
+			return;
+		}
+		if (!camDef(__camNextLevel))
+		{
+			return; // fastplay / tutorial. Should be a better identifier for this.
+		}
+		if (__camWinLossCallback === "__camVictoryPreOffworld")
+		{
+			return; // do not need this on these missions.
+		}
+	}
+
+	const ANNIHILATE_MESSAGE = _("Destroy all enemy units and structures");
+
+	var unitsOnMap = 0;
+	var structuresOnMap = 0;
+
+	enumArea(0, 0, mapWidth, mapHeight, ENEMIES, false).forEach(function(obj) {
+		if (obj.type === DROID)
+		{
+			++unitsOnMap;
+		}
+		else if (obj.type === STRUCTURE)
+		{
+			++structuresOnMap;
+		}
+	});
+
+	console(__camNumArtifacts + "/" + Object.keys(__camArtifacts).length + " " + _("Artifacts collected"));
+	console(__camNumEnemyBases + "/" + Object.keys(__camEnemyBases).length + " " + _("Bases destroyed"));
+	console(unitsOnMap + " " + _("Enemy units remaining"));
+	console(structuresOnMap + " " + _("Enemy structures remaining"));
+
+	if (__camWinLossCallback === "__camVictoryOffworld")
+	{
+		if (camDef(__camVictoryData.retlz) && __camVictoryData.retlz)
+		{
+			console(_("Return to LZ required"));
+		}
+
+		if (camDef(__camVictoryData.annihilate) && __camVictoryData.annihilate)
+		{
+			console(ANNIHILATE_MESSAGE);
+		}
+
+		if (camDef(__camVictoryData.eliminateBases) && __camVictoryData.eliminateBases)
+		{
+			console(_("Destroy all enemy units and bases"));
+		}
+	}
+	else if (__camWinLossCallback === "__camVictoryTimeout")
+	{
+		console(_("Survive until the timer reaches zero"));
+	}
+	else if (__camWinLossCallback === "__camVictoryStandard")
+	{
+		console(ANNIHILATE_MESSAGE);
+	}
+
+	//More specific messages set through the mission scripts.
+	if (camDef(__camExtraObjectiveMessage))
+	{
+		if (__camExtraObjectiveMessage instanceof Array)
+		{
+			for (var i = 0, len = __camExtraObjectiveMessage.length; i < len; ++i)
+			{
+				var mes = __camExtraObjectiveMessage[i];
+				console(mes);
+			}
+		}
+		else
+		{
+			console(__camExtraObjectiveMessage);
+		}
+	}
+
+	__camVictoryMessageThrottle = gameTime;
 }

--- a/data/base/script/campaign/libcampaign_includes/victory.js
+++ b/data/base/script/campaign/libcampaign_includes/victory.js
@@ -90,20 +90,20 @@ function camSetStandardWinLossConditions(kind, nextLevel, data)
 	switch(kind)
 	{
 		case CAM_VICTORY_STANDARD:
-			__camWinLossCallback = "__camVictoryStandard";
+			__camWinLossCallback = CAM_VICTORY_STANDARD;
 			__camNeedBonusTime = true;
 			__camDefeatOnTimeout = true;
 			__camVictoryData = data;
 			useSafetyTransport(false);
 			break;
 		case CAM_VICTORY_PRE_OFFWORLD:
-			__camWinLossCallback = "__camVictoryPreOffworld";
+			__camWinLossCallback = CAM_VICTORY_PRE_OFFWORLD;
 			__camNeedBonusTime = false;
 			__camDefeatOnTimeout = true;
 			useSafetyTransport(false);
 			break;
 		case CAM_VICTORY_OFFWORLD:
-			__camWinLossCallback = "__camVictoryOffworld";
+			__camWinLossCallback = CAM_VICTORY_OFFWORLD;
 			__camNeedBonusTime = true;
 			__camDefeatOnTimeout = true;
 			__camVictoryData = data;
@@ -112,7 +112,7 @@ function camSetStandardWinLossConditions(kind, nextLevel, data)
 			useSafetyTransport(false);
 			break;
 		case CAM_VICTORY_TIMEOUT:
-			__camWinLossCallback = "__camVictoryTimeout";
+			__camWinLossCallback = CAM_VICTORY_TIMEOUT;
 			__camNeedBonusTime = false;
 			__camDefeatOnTimeout = false;
 			__camVictoryData = data;
@@ -253,7 +253,7 @@ function __camPlayerDead()
 		}
 	}
 
-	if (__camWinLossCallback === "__camVictoryTimeout")
+	if (__camWinLossCallback === CAM_VICTORY_TIMEOUT)
 	{
 		//Make the mission fail if no units are alive on map while having no factories.
 		var droidCount = 0;
@@ -469,7 +469,7 @@ function __camShowVictoryConditions(forceMessage)
 		{
 			return; // fastplay / tutorial. Should be a better identifier for this.
 		}
-		if (__camWinLossCallback === "__camVictoryPreOffworld")
+		if (__camWinLossCallback === CAM_VICTORY_PRE_OFFWORLD)
 		{
 			return; // do not need this on these missions.
 		}
@@ -496,7 +496,7 @@ function __camShowVictoryConditions(forceMessage)
 	console(unitsOnMap + " " + _("Enemy units remaining"));
 	console(structuresOnMap + " " + _("Enemy structures remaining"));
 
-	if (__camWinLossCallback === "__camVictoryOffworld")
+	if (__camWinLossCallback === CAM_VICTORY_OFFWORLD)
 	{
 		if (camDef(__camVictoryData.retlz) && __camVictoryData.retlz)
 		{
@@ -513,11 +513,11 @@ function __camShowVictoryConditions(forceMessage)
 			console(_("Destroy all enemy units and bases"));
 		}
 	}
-	else if (__camWinLossCallback === "__camVictoryTimeout")
+	else if (__camWinLossCallback === CAM_VICTORY_TIMEOUT)
 	{
 		console(_("Survive until the timer reaches zero"));
 	}
-	else if (__camWinLossCallback === "__camVictoryStandard")
+	else if (__camWinLossCallback === CAM_VICTORY_STANDARD)
 	{
 		console(ANNIHILATE_MESSAGE);
 	}


### PR DESCRIPTION
Conveniently displays victory related information via console messages every five minutes and after destroying a base or obtaining an artifact. These messages are put on a ten second throttle so they can't be spammed.

Displays stuff like:
1. Amount of artifacts collected over the total.
2. Amount of bases destroyed over the total.
3. Enemy units remaining.
4. Enemy structures remaining.
5. Specific messages for standard, offworld (return to LZ, annihilate, bases), and timeout mission victory types.
6. Even more instructions set through the mission scripts (I set messages for all missions with extra conditions).

I also allow the player to type the "win info" command without needing to be in cheat/debug mode to display all this stuff again.