### PR TITLE
Prevent players from changing positions in the current challenges.

### DIFF
--- a/data/mp/challenges/b2basics.json
+++ b/data/mp/challenges/b2basics.json
@@ -12,7 +12,7 @@
         "version": 2
     },
     "locked": {
-        "position": "false"
+        "position": "true"
     },
     "player_0": {
         "team": 0

--- a/data/mp/challenges/hidebehind.json
+++ b/data/mp/challenges/hidebehind.json
@@ -12,7 +12,7 @@
         "version": 2
     },
     "locked": {
-        "position": "false"
+        "position": "true"
     },
     "player_0": {
         "team": 0

--- a/data/mp/challenges/noplace.json
+++ b/data/mp/challenges/noplace.json
@@ -12,7 +12,7 @@
         "version": 2
     },
     "locked": {
-        "position": "false"
+        "position": "true"
     },
     "player_0": {
         "team": 0

--- a/data/mp/challenges/two-faced.json
+++ b/data/mp/challenges/two-faced.json
@@ -9,11 +9,10 @@
         "powerLevel": 2,
         "scavengers": "false",
         "version": 0,
-        "techLevel": 1,
-	"allowPositionChange": "true"
+        "techLevel": 1
     },
     "locked": {
-        "position": "false"
+        "position": "true"
     },
     "player_0": {
         "team": 0


### PR DESCRIPTION
Prevent changing positions with all the current challenges. Note that Two-Faced intended to allow position change but because teams are locked into their respective slot, and therefore can't be changed, that breaks the whole purpose of the challenge (as the player will be teamed with the NullBots) so I disabled switching on that one explicitly.

Fixes #1058 