### PR TITLE
Fix regressions from #994

### DIFF
--- a/lib/netplay/netplay.cpp
+++ b/lib/netplay/netplay.cpp
@@ -381,7 +381,7 @@ void NET_InitPlayer(int i, bool initPosition, bool initTeams)
 {
 	initPlayerNetworkProps(i);
 
-	NetPlay.players[i].difficulty = AIDifficulty::DEFAULT;
+	NetPlay.players[i].difficulty = AIDifficulty::DISABLED;
 	if (ingame.localJoiningInProgress)
 	{
 		// only clear name outside of games.

--- a/src/multiint.cpp
+++ b/src/multiint.cpp
@@ -2799,14 +2799,13 @@ static void loadMapPlayerSettings(WzConfig& ini)
 /**
  * Resets all player difficulties, positions, teams and colors etc.
  */
-static void resetPlayerConfiguration()
+static void resetPlayerConfiguration(const bool bShouldResetLocal = false)
 {
 	for (unsigned playerIndex = 0; playerIndex < MAX_PLAYERS; playerIndex++)
 	{
 		setPlayerColour(playerIndex, playerIndex);
 
-		/* Never touch the local player */
-		if (playerIndex == selectedPlayer)
+		if (!bShouldResetLocal && playerIndex == selectedPlayer)
 		{
 			continue;
 		}
@@ -4107,7 +4106,7 @@ void WzMultiplayerOptionsTitleUI::start()
 	/* Entering the first time */
 	if (!bReenter)
 	{
-		resetPlayerConfiguration();
+		resetPlayerConfiguration(true);
 		memset(&locked, 0, sizeof(locked));
 		loadMapChallengeAndPlayerSettings(true);
 		game.isMapMod = false;

--- a/src/multiint.cpp
+++ b/src/multiint.cpp
@@ -2796,6 +2796,18 @@ static void loadMapPlayerSettings(WzConfig& ini)
 	}
 }
 
+static int playersPerTeam()
+{
+	for (unsigned numTeams = game.maxPlayers - 1; numTeams > 1; --numTeams)
+	{
+		if (game.maxPlayers % numTeams == 0)
+		{
+			return numTeams;
+		}
+	}
+	return 1;
+}
+
 /**
  * Resets all player difficulties, positions, teams and colors etc.
  */
@@ -2811,7 +2823,7 @@ static void resetPlayerConfiguration(const bool bShouldResetLocal = false)
 		}
 
 		NetPlay.players[playerIndex].position = playerIndex;
-		NetPlay.players[playerIndex].team = playerIndex;
+		NetPlay.players[playerIndex].team = playerIndex / playersPerTeam();
 		NetPlay.players[playerIndex].name[0] = '\0';
 
 		if (NetPlay.bComms)


### PR DESCRIPTION
Fixes to some regressions/bugs introduced in #994

### Knwown bugs / TODO
- [x] Host crashes when backing out of host after changing position for local player
- [x] Default teams are assigned different than before; revert to old behavior _(e.g. ABCD instead of AABB on 4 player maps)_
- [x] Players disconnecting from lobby before the game starts causes assertion failures/corrupt player state
- [ ] Loading campaign save from offworld mission spams warnings about not being able to find AI script called "Commander"