### PR TITLE
Event eventPlayerLeft should only fire while in actual games.

### DIFF
--- a/src/multijoin.cpp
+++ b/src/multijoin.cpp
@@ -60,6 +60,7 @@
 #include "intimage.h"
 #include "data.h"
 #include "activity.h"
+#include "main.h"					// for GetGameMode
 
 #include "multimenu.h"
 #include "multiplay.h"
@@ -340,7 +341,10 @@ bool MultiPlayerLeave(UDWORD playerIndex)
 	}
 
 	// fire script callback to reassign skirmish players.
-	triggerEventPlayerLeft(playerIndex);
+	if (GetGameMode() == GS_NORMAL)
+	{
+		triggerEventPlayerLeft(playerIndex);
+	}
 
 	netPlayersUpdated = true;
 	return true;


### PR DESCRIPTION
Will stop an unnecessary assert about scripts not being ready when a client leaves a hosting session.