### PR TITLE
Change a few minor things in the cam3a mission.

### DIFF
--- a/data/base/script/campaign/cam3-a.js
+++ b/data/base/script/campaign/cam3-a.js
@@ -30,11 +30,12 @@ camAreaEvent("cybAttackers", function(droid)
 		fallback: camMakePos("SWBaseRetreat")
 	});
 
-	camManageGroup(camMakeGroup("NEDefenderGroup"), CAM_ORDER_DEFEND, {
+	camManageGroup(camMakeGroup("NEDefenderGroup"), CAM_ORDER_PATROL, {
 		pos: [
 			camMakePos("genericasAssembly"),
 			camMakePos("northFacAssembly"),
 		],
+		interval: camMinutesToMilliseconds(1),
 		regroup: true,
 	});
 });
@@ -324,19 +325,14 @@ function eventStartLevel()
 		},
 		"NXcybFac-b4": {
 			assembly: "NXcybFac-b4Assembly",
-			order: CAM_ORDER_PATROL,
+			order: CAM_ORDER_ATTACK,
 			data: {
-				pos: [
-					camMakePos("genericasAssembly"),
-					camMakePos("northFacAssembly"),
-				],
 				regroup: false,
 				repair: 40,
 				count: -1,
 			},
 			groupSize: 4,
-			throttle: camChangeOnDiff(camSecondsToMilliseconds(30)),
-			group: camMakeGroup("NEDefenderGroup"),
+			throttle: camChangeOnDiff(camSecondsToMilliseconds(50)),
 			templates: [cTempl.nxcyrail, cTempl.nxcyscou]
 		},
 	});

--- a/data/base/wrf/cam3/cam3a/labels.json
+++ b/data/base/wrf/cam3/cam3a/labels.json
@@ -116,7 +116,7 @@
 	"area_4": {
 		"label": "NEDefenderGroup",
 		"pos1": [4032, 9536],
-		"pos2": [5440, 9920]
+		"pos2": [4480, 10112]
 	},
 	"area_5": {
 		"label": "NEAttackerGroup",


### PR DESCRIPTION
- Stop allowing a cyborg factory to send a patrol group far away from it. Make it attack instead.
- Fix group area label collision resulting in a conflict of orders for a couple of units on the map.