### PR TITLE
Stop NullBot from attacking its derricks after winning games.

### DIFF
--- a/data/mp/multiplay/skirmish/nb_includes/tactics.js
+++ b/data/mp/multiplay/skirmish/nb_includes/tactics.js
@@ -107,6 +107,8 @@ function vtolTargetLabel() {
 }
 
 function findTarget(gr) {
+	if (enumLivingPlayers().filter(isEnemy).length === 0)
+		return undefined;
 	var obj = safeGetObject(groupMicroTargetLabel(gr));
 	var obj2 = safeGetObject(groupTargetLabel(gr));
 	getGroupInfo(gr);
@@ -408,6 +410,8 @@ _global.dangerLevel = function(loc) {
 }
 
 _global.checkAttack = function() {
+	if (enumLivingPlayers().filter(isEnemy).length === 0)
+		return;
 	for (var i = 0; i < MAX_GROUPS; ++i)
 		if (!throttled(3000, i)) {
 			regroup(i).forEach(attackTarget);


### PR DESCRIPTION
enumStructList(structure, player) was being passed in an undefined value for the player which, in turn, defaults to "me" if undefined.

fixes #1026 

Example:

var enemy = undefined ...
enumStructList(miscTargets, enemy).filter(canHit); (miscTargets = derricks)
if (list.length > 0) return list.random();

That is why you see NullBot VTOLs go crazy after winning and destroy all of its derricks. I simply added a couple checks to see if any enemy players are alive still to prevent this.
```
function pickVtolTarget(droid) {
	function uncached() {
		function canHit(obj) {
			return vtolCanHit(droid, obj);
		}
		var enemy = enumLivingPlayers().filter(isEnemy).random();
		var list;
		list = enumStructList(miscTargets, enemy).filter(canHit);
		if (list.length > 0) return list.random();
		list = enumStruct(enemy, DEFENSE).filterProperty("canHitAir", true).filter(canHit);
		if (list.length > 0) return list.random();
		list = enumDroid(enemy, DROID_WEAPON).filterProperty("canHitAir", true).filter(canHit);
		if (list.length > 0) return list.random();
		list = enumDroid(enemy, DROID_CYBORG).filterProperty("canHitAir", true).filter(canHit);
		if (list.length > 0) return list.random();
		list = enumStructList(targets, enemy).filter(canHit);
		if (list.length > 0) return list.random();
		list = enumDroid(enemy).filter(canHit);
		if (list.length > 0) return list.random();
	}
	return cached(uncached, 100, droid.canHitAir + 2 * droid.canHitGround);
}
```