### PR TITLE
Fix initial delivery point, droid orientation and puff effect for rotated factories.

### DIFF
--- a/src/display3d.cpp
+++ b/src/display3d.cpp
@@ -499,6 +499,24 @@ void clearBlueprints()
 	blueprints.clear();
 }
 
+static PIELIGHT selectionBrightness()
+{
+	int brightVar;
+	if (!gamePaused())
+	{
+		brightVar = getModularScaledGraphicsTime(990, 110);
+		if (brightVar > 55)
+		{
+			brightVar = 110 - brightVar;
+		}
+	}
+	else
+	{
+		brightVar = 55;
+	}
+	return pal_SetBrightness(200 + brightVar);
+}
+
 static PIELIGHT structureBrightness(STRUCTURE *psStructure)
 {
 	PIELIGHT buildingBrightness;
@@ -514,21 +532,7 @@ static PIELIGHT structureBrightness(STRUCTURE *psStructure)
 		/* If it's selected, then it's brighter */
 		if (psStructure->selected)
 		{
-			SDWORD brightVar;
-
-			if (!gamePaused())
-			{
-				brightVar = getModularScaledGraphicsTime(990, 110);
-				if (brightVar > 55)
-				{
-					brightVar = 110 - brightVar;
-				}
-			}
-			else
-			{
-				brightVar = 55;
-			}
-			buildingBrightness = pal_SetBrightness(200 + brightVar);
+			buildingBrightness = selectionBrightness();
 		}
 		if (!getRevealStatus())
 		{
@@ -2468,6 +2472,11 @@ void renderDeliveryPoint(FLAG_POSITION *psPosition, bool blueprint, const glm::m
 	{
 		pieFlag |= pie_FORCE_FOG;
 		colour = WZCOL_WHITE;
+		STRUCTURE *structure = findDeliveryFactory(psPosition);
+		if (structure != nullptr && structure->selected)
+		{
+			colour = selectionBrightness();
+		}
 	}
 	pie_Draw3DShape(pAssemblyPointIMDs[psPosition->factoryType][psPosition->factoryInc], 0, 0, colour, pieFlag, pieFlagData, viewMatrix * modelMatrix);
 

--- a/src/droid.cpp
+++ b/src/droid.cpp
@@ -1690,7 +1690,7 @@ DROID *reallyBuildDroid(DROID_TEMPLATE *pTemplate, Position pos, UDWORD player, 
 	return psDroid;
 }
 
-DROID *buildDroid(DROID_TEMPLATE *pTemplate, UDWORD x, UDWORD y, UDWORD player, bool onMission, const INITIAL_DROID_ORDERS *initialOrders)
+DROID *buildDroid(DROID_TEMPLATE *pTemplate, UDWORD x, UDWORD y, UDWORD player, bool onMission, const INITIAL_DROID_ORDERS *initialOrders, Rotation rot)
 {
 	// ajl. droid will be created, so inform others
 	if (bMultiMessages)
@@ -1701,7 +1701,7 @@ DROID *buildDroid(DROID_TEMPLATE *pTemplate, UDWORD x, UDWORD y, UDWORD player, 
 	}
 	else
 	{
-		return reallyBuildDroid(pTemplate, Position(x, y, 0), player, onMission);
+		return reallyBuildDroid(pTemplate, Position(x, y, 0), player, onMission, rot);
 	}
 }
 

--- a/src/droid.h
+++ b/src/droid.h
@@ -77,7 +77,7 @@ struct INITIAL_DROID_ORDERS
 };
 /*Builds an instance of a Structure - the x/y passed in are in world coords.*/
 /// Sends a GAME_DROID message if bMultiMessages is true, or actually creates it if false. Only uses initialOrders if sending a GAME_DROID message.
-DROID *buildDroid(DROID_TEMPLATE *pTemplate, UDWORD x, UDWORD y, UDWORD player, bool onMission, const INITIAL_DROID_ORDERS *initialOrders);
+DROID *buildDroid(DROID_TEMPLATE *pTemplate, UDWORD x, UDWORD y, UDWORD player, bool onMission, const INITIAL_DROID_ORDERS *initialOrders, Rotation rot = Rotation());
 /// Creates a droid locally, instead of sending a message, even if the bMultiMessages HACK is set to true.
 DROID *reallyBuildDroid(DROID_TEMPLATE *pTemplate, Position pos, UDWORD player, bool onMission, Rotation rot = Rotation());
 

--- a/src/effects.cpp
+++ b/src/effects.cpp
@@ -44,6 +44,7 @@
 #include "lib/ivis_opengl/ivisdef.h"
 #include "lib/ivis_opengl/pietypes.h"
 #include "lib/framework/fixedpoint.h"
+#include "lib/framework/geometry.h"
 #include "lib/ivis_opengl/piepalette.h"
 #include "lib/ivis_opengl/piestate.h"
 #include "lib/ivis_opengl/piematrix.h"
@@ -67,6 +68,7 @@
 
 #include "multiplay.h"
 #include "component.h"
+
 #ifndef GLM_ENABLE_EXPERIMENTAL
 	#define GLM_ENABLE_EXPERIMENTAL
 #endif
@@ -2179,7 +2181,7 @@ static void effectStructureUpdates()
 				*/
 				if (psStructure->sDisplay.imd->nconnectors == 1)
 				{
-					Vector3i eventPos = psStructure->pos.xzy() + Vector3i(
+					Vector3i eventPos = psStructure->pos.xzy() + Affine3F().RotY(psStructure->rot.direction)*Vector3i(
 					                        psStructure->sDisplay.imd->connectors->x,
 					                        psStructure->sDisplay.imd->connectors->z,
 					                        -psStructure->sDisplay.imd->connectors->y


### PR DESCRIPTION
Also, pulse delivery point of selected factory with the factory. Makes it possible to
check which repair facility has which delivery point.

Fixes #1039.