### PR TITLE
Auto-orientate delivery points

### DIFF
--- a/src/display3d.cpp
+++ b/src/display3d.cpp
@@ -2436,7 +2436,7 @@ void renderDeliveryPoint(FLAG_POSITION *psPosition, bool blueprint, const glm::m
 	//quick check for invalid data
 	ASSERT_OR_RETURN(, psPosition->factoryType < NUM_FLAG_TYPES && psPosition->factoryInc < MAX_FACTORY_FLAG_IMDS, "Invalid assembly point");
 
-	const glm::mat4 modelMatrix = glm::translate(glm::vec3(dv)) * glm::scale(glm::vec3(.5f));
+	const glm::mat4 modelMatrix = glm::translate(glm::vec3(dv)) * glm::scale(glm::vec3(.5f)) * glm::rotate(-UNDEG(player.r.y), glm::vec3(0,1,0));
 
 	pieFlag = pie_TRANSLUCENT;
 	pieFlagData = BLUEPRINT_OPACITY;


### PR DESCRIPTION
https://youtu.be/wHjV7jYNE58

This PR makes the assembly points/delivery points auto rotate to face the camera, to increase legibility.

Before change:

![Screenshot from 2020-08-30 14-20-41](https://user-images.githubusercontent.com/668160/91658839-0b2dcb80-eacc-11ea-9fc1-eaff21142846.png)


After change:

![Screenshot from 2020-08-30 14-19-50](https://user-images.githubusercontent.com/668160/91658840-0b2dcb80-eacc-11ea-8e7e-75fd2fde09d3.png)
