### PR TITLE
Make campaign Assault Cannon research also grant the VTOL version.

### DIFF
--- a/data/base/stats/research.json
+++ b/data/base/stats/research.json
@@ -5066,7 +5066,8 @@
         "researchPoints": 9000,
         "researchPower": 281,
         "resultComponents": [
-            "Cannon5VulcanMk1"
+            "Cannon5VulcanMk1",
+            "Cannon5Vulcan-VTOL"
         ],
         "statID": "Cannon5VulcanMk1"
     },


### PR DESCRIPTION
Assault Cannon research did not give the player the VTOL Assault Cannon.

Fixes #1134 