### PR TITLE
Add counter for droid's number of kills

### DIFF
--- a/src/cmddroid.cpp
+++ b/src/cmddroid.cpp
@@ -170,14 +170,14 @@ unsigned int cmdDroidMaxGroup(const DROID *psCommander)
 	return getDroidLevel(psCommander) * psStats->upgrade[psCommander->player].maxDroidsMult + psStats->upgrade[psCommander->player].maxDroids;
 }
 
-/** This function adds experience to the command droid of the psKiller's command group.*/
-void cmdDroidUpdateKills(DROID *psKiller, uint32_t experienceInc)
+/** This function adds experience to the command droid of the psShooter's command group.*/
+void cmdDroidUpdateExperience(DROID *psShooter, uint32_t experienceInc)
 {
-	ASSERT_OR_RETURN(, psKiller != nullptr, "invalid Unit pointer");
+	ASSERT_OR_RETURN(, psShooter != nullptr, "invalid Unit pointer");
 
-	if (hasCommander(psKiller))
+	if (hasCommander(psShooter))
 	{
-		DROID *psCommander = psKiller->psGroup->psCommander;
+		DROID *psCommander = psShooter->psGroup->psCommander;
 		psCommander->experience += MIN(experienceInc, UINT32_MAX - psCommander->experience);
 	}
 }

--- a/src/cmddroid.h
+++ b/src/cmddroid.h
@@ -58,8 +58,8 @@ SDWORD cmdDroidGetIndex(DROID *psCommander);
 /** \brief Gets the maximum group size for a command droid.*/
 unsigned int cmdDroidMaxGroup(const DROID *psCommander);
 
-/** \brief Updates the experience of a command droid if psKiller is in a command group.*/
-void cmdDroidUpdateKills(DROID *psKiller, uint32_t experienceInc);
+/** \brief Updates the experience of a command droid if psShooter is in a command group.*/
+void cmdDroidUpdateExperience(DROID *psShooter, uint32_t experienceInc);
 
 /** \brief Gets the level of the droid group's commander, if any.*/
 unsigned int cmdGetCommanderLevel(const DROID *psDroid);

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -1482,16 +1482,16 @@ static void printDroidClickInfo(DROID *psDroid)
 {
 	if (getDebugMappingStatus()) // cheating on, so output debug info
 	{
-		console("%s - Hitpoints %d/%d - ID %d - experience %f, %s - order %s - action %s - sensor range %hu - ECM %u - pitch %.0f - frust %u",
+		console("%s - Hitpoints %d/%d - ID %d - experience %f, %s - order %s - action %s - sensor range %hu - ECM %u - pitch %.0f - frust %u - kills %d",
 		        droidGetName(psDroid), psDroid->body, psDroid->originalBody, psDroid->id,
 		        psDroid->experience / 65536.f, getDroidLevelName(psDroid), getDroidOrderName(psDroid->order.type), getDroidActionName(psDroid->action),
-		        droidSensorRange(psDroid), objJammerPower(psDroid), UNDEG(psDroid->rot.pitch), psDroid->lastFrustratedTime);
+		        droidSensorRange(psDroid), objJammerPower(psDroid), UNDEG(psDroid->rot.pitch), psDroid->lastFrustratedTime, psDroid->kills);
 		FeedbackOrderGiven();
 	}
 	else if (!psDroid->selected)
 	{
-		console(_("%s - Hitpoints %d/%d - Experience %.1f, %s"), droidGetName(psDroid), psDroid->body, psDroid->originalBody,
-		        psDroid->experience / 65536.f, _(getDroidLevelName(psDroid)));
+		console(_("%s - Hitpoints %d/%d - Experience %.1f, %s, Kills %d"), droidGetName(psDroid), psDroid->body, psDroid->originalBody,
+		        psDroid->experience / 65536.f, _(getDroidLevelName(psDroid)), psDroid->kills);
 		FeedbackOrderGiven();
 	}
 	clearSelection();

--- a/src/droid.cpp
+++ b/src/droid.cpp
@@ -1630,6 +1630,7 @@ DROID *reallyBuildDroid(DROID_TEMPLATE *pTemplate, Position pos, UDWORD player, 
 	{
 		psDroid->experience = 0;
 	}
+	psDroid->kills = 0;
 
 	droidSetBits(pTemplate, psDroid);
 

--- a/src/droiddef.h
+++ b/src/droiddef.h
@@ -110,6 +110,7 @@ struct DROID : public BASE_OBJECT
 	UDWORD          baseSpeed;                      ///< the base speed dependent on propulsion type
 	UDWORD          originalBody;                   ///< the original body points
 	uint32_t        experience;
+	uint32_t        kills;
 	UDWORD          lastFrustratedTime;             ///< Set when eg being stuck; used for eg firing indiscriminately at map features to clear the way
 	SWORD           resistance;                     ///< used in Electronic Warfare
 	// The group the droid belongs to

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -4612,6 +4612,7 @@ static bool loadSaveDroid(const char *pFileName, DROID **ppsCurrentDroidLists)
 		psDroid->body = healthValue(ini, psDroid->originalBody);
 		ASSERT(psDroid->body != 0, "%s : %d has zero hp!", pFileName, i);
 		psDroid->experience = ini.value("experience", 0).toInt();
+		psDroid->kills = ini.value("kills", 0).toInt();
 		psDroid->secondaryOrder = ini.value("secondaryOrder", psDroid->secondaryOrder).toInt();
 		psDroid->secondaryOrderPending = psDroid->secondaryOrder;
 		psDroid->action = (DROID_ACTION)ini.value("action", DACTION_NONE).toInt();
@@ -4759,6 +4760,10 @@ static bool writeDroid(WzConfig &ini, DROID *psCurr, bool onMission, int &counte
 	if (psCurr->experience > 0)
 	{
 		ini.setValue("experience", psCurr->experience);
+	}
+	if (psCurr->kills > 0)
+	{
+		ini.setValue("kills", psCurr->kills);
 	}
 
 	setIniDroidOrder(ini, "order", psCurr->order);

--- a/src/projectile.cpp
+++ b/src/projectile.cpp
@@ -76,6 +76,18 @@ struct INTERVAL
 	int begin, end;  // Time 1 = 0, time 2 = 1024. Or begin >= end if empty.
 };
 
+struct DAMAGE
+{
+	PROJECTILE *psProjectile;
+	BASE_OBJECT *psDest;
+	unsigned damage;
+	WEAPON_CLASS weaponClass;
+	WEAPON_SUBCLASS weaponSubClass;
+	unsigned impactTime;
+	bool isDamagePerSecond;
+	int minDamage;
+};
+
 // Watermelon:they are from droid.c
 /* The range for neighbouring objects */
 #define PROJ_NEIGHBOUR_RANGE (TILE_UNITS*4)
@@ -100,7 +112,7 @@ static void	proj_ImpactFunc(PROJECTILE *psObj);
 static void	proj_PostImpactFunc(PROJECTILE *psObj);
 static void proj_checkPeriodicalDamage(PROJECTILE *psProj);
 
-static int32_t objectDamage(BASE_OBJECT *psObj, unsigned damage, WEAPON_CLASS weaponClass, WEAPON_SUBCLASS weaponSubClass, unsigned impactTime, bool isDamagePerSecond, int minDamage);
+static int32_t objectDamage(DAMAGE *damage);
 
 
 static inline void setProjectileDestination(PROJECTILE *psProj, BASE_OBJECT *psObj)
@@ -259,28 +271,23 @@ int getExpGain(int player)
 	return experienceGain[player];
 }
 
-// update the kills after a target is damaged/destroyed
-static void proj_UpdateKills(PROJECTILE *psObj, int32_t experienceInc)
+DROID *getDesignatorAttackingObject(int player, BASE_OBJECT *target)
+{
+	DROID* psCommander = cmdDroidGetDesignator(player);
+
+	return psCommander != nullptr && psCommander->action == DACTION_ATTACK && psCommander->psActionTarget[0] == target
+		? psCommander
+		: nullptr;
+}
+
+
+// update the source experience after a target is damaged/destroyed
+static void proj_UpdateExperience(PROJECTILE *psObj, uint32_t experienceInc)
 {
 	DROID	        *psDroid;
 	BASE_OBJECT     *psSensor;
 
 	CHECK_PROJECTILE(psObj);
-
-	if (psObj->psSource == nullptr || (psObj->psDest && psObj->psDest->type == OBJ_FEATURE)
-	    || (psObj->psDest && psObj->psSource->player == psObj->psDest->player))	// no exp for friendly fire
-	{
-		return;
-	}
-
-	// If experienceInc is negative then the target was killed
-	if (bMultiPlayer && experienceInc < 0)
-	{
-		updateMultiStatsKills(psObj->psDest, psObj->psSource->player);
-	}
-
-	// Since we are no longer interested if it was killed or not, abs it
-	experienceInc = abs(experienceInc) * getExpGain(psObj->psSource->player) / 100;
 
 	if (psObj->psSource->type == OBJ_DROID)			/* update droid kills */
 	{
@@ -296,10 +303,10 @@ static void proj_UpdateKills(PROJECTILE *psObj, int32_t experienceInc)
 			experienceInc = (uint64_t)experienceInc * qualityFactor(psDroid, (DROID *)psObj->psDest) / 65536;
 		}
 
-		ASSERT_OR_RETURN(, 0 <= experienceInc && experienceInc < (int)(2.1 * 65536), "Experience increase out of range");
+		ASSERT_OR_RETURN(, experienceInc < (int)(2.1 * 65536), "Experience increase out of range");
 
 		psDroid->experience += experienceInc;
-		cmdDroidUpdateKills(psDroid, experienceInc);
+		cmdDroidUpdateExperience(psDroid, experienceInc);
 
 		psSensor = orderStateObj(psDroid, DORDER_FIRESUPPORT);
 		if (psSensor
@@ -310,14 +317,11 @@ static void proj_UpdateKills(PROJECTILE *psObj, int32_t experienceInc)
 	}
 	else if (psObj->psSource->type == OBJ_STRUCTURE)
 	{
-		ASSERT_OR_RETURN(, 0 <= experienceInc && experienceInc < (int)(2.1 * 65536), "Experience increase out of range");
+		ASSERT_OR_RETURN(, experienceInc < (int)(2.1 * 65536), "Experience increase out of range");
 
-		// See if there was a command droid designating this target
-		psDroid = cmdDroidGetDesignator(psObj->psSource->player);
+		psDroid = getDesignatorAttackingObject(psObj->psSource->player, psObj->psDest);
 
-		if (psDroid != nullptr
-		    && psDroid->action == DACTION_ATTACK
-		    && psDroid->psActionTarget[0] == psObj->psDest)
+		if (psDroid != nullptr)
 		{
 			psDroid->experience += experienceInc;
 		}
@@ -1123,11 +1127,19 @@ static void proj_ImpactFunc(PROJECTILE *psObj)
 			debug(LOG_NEVER, "Damage to object %d, player %d\n",
 			      psObj->psDest->id, psObj->psDest->player);
 
-			// Damage the object
-			relativeDamage = objectDamage(psObj->psDest, damage, psStats->weaponClass, psStats->weaponSubClass,
-			                              psObj->time, false, psStats->upgrade[psObj->player].minimumDamage);
+			struct DAMAGE sDamage = {
+				psObj,
+				psObj->psDest,
+				damage,
+				psStats->weaponClass,
+				psStats->weaponSubClass,
+				psObj->time,
+				false,
+				(int)psStats->upgrade[psObj->player].minimumDamage
+			};
 
-			proj_UpdateKills(psObj, relativeDamage);
+			// Damage the object
+			relativeDamage = objectDamage(&sDamage);
 
 			if (relativeDamage >= 0)	// So long as the target wasn't killed
 			{
@@ -1215,9 +1227,19 @@ static void proj_ImpactFunc(PROJECTILE *psObj)
 			{
 				updateMultiStatsDamage(psObj->psSource->player, psCurr->player, damage);
 			}
-			int relativeDamage = objectDamage(psCurr, damage, psStats->weaponClass, psStats->weaponSubClass,
-			                                  psObj->time, false, psStats->upgrade[psObj->player].minimumDamage);
-			proj_UpdateKills(psObj, relativeDamage);
+
+			struct DAMAGE sDamage = {
+				psObj,
+				psCurr,
+				damage,
+				psStats->weaponClass,
+				psStats->weaponSubClass,
+				psObj->time,
+				false,
+				(int)psStats->upgrade[psObj->player].minimumDamage
+			};
+
+			objectDamage(&sDamage);
 		}
 	}
 
@@ -1383,10 +1405,18 @@ static void proj_checkPeriodicalDamage(PROJECTILE *psProj)
 		unsigned damageRate = calcDamage(weaponPeriodicalDamage(psStats, psProj->player), psStats->periodicalDamageWeaponEffect, psCurr);
 		debug(LOG_NEVER, "Periodical damage of %d per second to object %d, player %d\n", damageRate, psCurr->id, psCurr->player);
 
-		int relativeDamage = objectDamage(psCurr, damageRate, psStats->periodicalDamageWeaponClass,
-		                                  psStats->periodicalDamageWeaponSubClass, gameTime - deltaGameTime / 2 + 1, true,
-		                                  psStats->upgrade[psProj->player].minimumDamage);
-		proj_UpdateKills(psProj, relativeDamage);
+		struct DAMAGE sDamage = {
+			psProj,
+			psCurr,
+			damageRate,
+			psStats->periodicalDamageWeaponClass,
+			psStats->periodicalDamageWeaponSubClass,
+			gameTime - deltaGameTime / 2 + 1,
+			true,
+			(int)psStats->upgrade[psProj->player].minimumDamage
+		};
+
+		objectDamage(&sDamage);
 	}
 }
 
@@ -1517,34 +1547,90 @@ UDWORD	calcDamage(UDWORD baseDamage, WEAPON_EFFECT weaponEffect, BASE_OBJECT *ps
  *    multiplied by -1, resulting in a negative number. Killed features do not
  *    result in negative numbers.
  */
-static int32_t objectDamage(BASE_OBJECT *psObj, unsigned damage, WEAPON_CLASS weaponClass, WEAPON_SUBCLASS weaponSubClass, unsigned impactTime, bool isDamagePerSecond, int minDamage)
+static int32_t objectDamageDispatch(DAMAGE *damage)
 {
-	switch (psObj->type)
+	switch (damage->psDest->type)
 	{
 	case OBJ_DROID:
-		return droidDamage((DROID *)psObj, damage, weaponClass, weaponSubClass, impactTime, isDamagePerSecond, minDamage);
+		return droidDamage((DROID *)damage->psDest, damage->damage, damage->weaponClass, damage->weaponSubClass, damage->impactTime, damage->isDamagePerSecond, damage->minDamage);
 		break;
 
 	case OBJ_STRUCTURE:
-		return structureDamage((STRUCTURE *)psObj, damage, weaponClass, weaponSubClass, impactTime, isDamagePerSecond, minDamage);
+		return structureDamage((STRUCTURE *)damage->psDest, damage->damage, damage->weaponClass, damage->weaponSubClass, damage->impactTime, damage->isDamagePerSecond, damage->minDamage);
 		break;
 
 	case OBJ_FEATURE:
-		return featureDamage((FEATURE *)psObj, damage, weaponClass, weaponSubClass, impactTime, isDamagePerSecond, minDamage);
+		return featureDamage((FEATURE *)damage->psDest, damage->damage, damage->weaponClass, damage->weaponSubClass, damage->impactTime, damage->isDamagePerSecond, damage->minDamage);
 		break;
 
 	case OBJ_PROJECTILE:
-		ASSERT(!"invalid object type: bullet", "invalid object type: OBJ_PROJECTILE (id=%d)", psObj->id);
+		ASSERT(!"invalid object type: bullet", "invalid object type: OBJ_PROJECTILE (id=%d)", damage->psDest->id);
 		break;
 
 	case OBJ_TARGET:
-		ASSERT(!"invalid object type: target", "invalid object type: OBJ_TARGET (id=%d)", psObj->id);
+		ASSERT(!"invalid object type: target", "invalid object type: OBJ_TARGET (id=%d)", damage->psDest->id);
 		break;
 
 	default:
-		ASSERT(!"unknown object type", "unknown object type %d, id=%d", psObj->type, psObj->id);
+		ASSERT(!"unknown object type", "unknown object type %d, id=%d", damage->psDest->type, damage->psDest->id);
 	}
 	return 0;
+}
+
+static bool isFriendlyFire(DAMAGE* sDamage)
+{
+	return sDamage->psProjectile->psDest && sDamage->psProjectile->psSource->player == sDamage->psProjectile->psDest->player;
+}
+
+static bool shouldIncreaseExperience(DAMAGE *sDamage)
+{
+	return sDamage->psProjectile->psSource && !isFeature(sDamage->psProjectile->psDest) && !isFriendlyFire(sDamage);
+}
+
+static void updateKills(DAMAGE* psDamage)
+{
+	if (bMultiPlayer)
+	{
+		updateMultiStatsKills(psDamage->psDest, psDamage->psProjectile->psSource->player);
+	}
+
+	if (psDamage->psProjectile->psSource->type == OBJ_DROID)
+	{
+		DROID *psDroid = (DROID *) psDamage->psProjectile->psSource;
+
+		psDroid->kills++;
+
+		if (hasCommander(psDroid))
+		{
+			DROID *psCommander = psDroid->psGroup->psCommander;
+			psCommander->kills++;
+		}
+	}
+	else if (psDamage->psProjectile->psSource->type == OBJ_STRUCTURE)
+	{
+		DROID *psCommander = getDesignatorAttackingObject(psDamage->psProjectile->psSource->player, psDamage->psProjectile->psDest);
+
+		if (psCommander != nullptr) {
+			psCommander->kills++;
+		}
+	}
+}
+
+static int32_t objectDamage(DAMAGE *psDamage)
+{
+	int32_t relativeDamage = objectDamageDispatch(psDamage);
+
+	if (shouldIncreaseExperience(psDamage)) {
+		proj_UpdateExperience(psDamage->psProjectile, abs(relativeDamage) * getExpGain(psDamage->psProjectile->psSource->player) / 100);
+
+		bool isTargetDestroyed = relativeDamage < 0;
+
+		if (isTargetDestroyed) {
+			updateKills(psDamage);
+		}
+	}
+
+	return relativeDamage;
 }
 
 /* Returns true if an object has just been hit by an electronic warfare weapon*/

--- a/src/projectile.cpp
+++ b/src/projectile.cpp
@@ -112,7 +112,7 @@ static void	proj_ImpactFunc(PROJECTILE *psObj);
 static void	proj_PostImpactFunc(PROJECTILE *psObj);
 static void proj_checkPeriodicalDamage(PROJECTILE *psProj);
 
-static int32_t objectDamage(DAMAGE *damage);
+static int32_t objectDamage(DAMAGE *psDamage);
 
 
 static inline void setProjectileDestination(PROJECTILE *psProj, BASE_OBJECT *psObj)
@@ -1547,44 +1547,44 @@ UDWORD	calcDamage(UDWORD baseDamage, WEAPON_EFFECT weaponEffect, BASE_OBJECT *ps
  *    multiplied by -1, resulting in a negative number. Killed features do not
  *    result in negative numbers.
  */
-static int32_t objectDamageDispatch(DAMAGE *damage)
+static int32_t objectDamageDispatch(DAMAGE *psDamage)
 {
-	switch (damage->psDest->type)
+	switch (psDamage->psDest->type)
 	{
 	case OBJ_DROID:
-		return droidDamage((DROID *)damage->psDest, damage->damage, damage->weaponClass, damage->weaponSubClass, damage->impactTime, damage->isDamagePerSecond, damage->minDamage);
+		return droidDamage((DROID *)psDamage->psDest, psDamage->damage, psDamage->weaponClass, psDamage->weaponSubClass, psDamage->impactTime, psDamage->isDamagePerSecond, psDamage->minDamage);
 		break;
 
 	case OBJ_STRUCTURE:
-		return structureDamage((STRUCTURE *)damage->psDest, damage->damage, damage->weaponClass, damage->weaponSubClass, damage->impactTime, damage->isDamagePerSecond, damage->minDamage);
+		return structureDamage((STRUCTURE *)psDamage->psDest, psDamage->damage, psDamage->weaponClass, psDamage->weaponSubClass, psDamage->impactTime, psDamage->isDamagePerSecond, psDamage->minDamage);
 		break;
 
 	case OBJ_FEATURE:
-		return featureDamage((FEATURE *)damage->psDest, damage->damage, damage->weaponClass, damage->weaponSubClass, damage->impactTime, damage->isDamagePerSecond, damage->minDamage);
+		return featureDamage((FEATURE *)psDamage->psDest, psDamage->damage, psDamage->weaponClass, psDamage->weaponSubClass, psDamage->impactTime, psDamage->isDamagePerSecond, psDamage->minDamage);
 		break;
 
 	case OBJ_PROJECTILE:
-		ASSERT(!"invalid object type: bullet", "invalid object type: OBJ_PROJECTILE (id=%d)", damage->psDest->id);
+		ASSERT(!"invalid object type: bullet", "invalid object type: OBJ_PROJECTILE (id=%d)", psDamage->psDest->id);
 		break;
 
 	case OBJ_TARGET:
-		ASSERT(!"invalid object type: target", "invalid object type: OBJ_TARGET (id=%d)", damage->psDest->id);
+		ASSERT(!"invalid object type: target", "invalid object type: OBJ_TARGET (id=%d)", psDamage->psDest->id);
 		break;
 
 	default:
-		ASSERT(!"unknown object type", "unknown object type %d, id=%d", damage->psDest->type, damage->psDest->id);
+		ASSERT(!"unknown object type", "unknown object type %d, id=%d", psDamage->psDest->type, psDamage->psDest->id);
 	}
 	return 0;
 }
 
-static bool isFriendlyFire(DAMAGE* sDamage)
+static bool isFriendlyFire(DAMAGE* psDamage)
 {
-	return sDamage->psProjectile->psDest && sDamage->psProjectile->psSource->player == sDamage->psProjectile->psDest->player;
+	return psDamage->psProjectile->psDest && psDamage->psProjectile->psSource->player == psDamage->psProjectile->psDest->player;
 }
 
-static bool shouldIncreaseExperience(DAMAGE *sDamage)
+static bool shouldIncreaseExperience(DAMAGE *psDamage)
 {
-	return sDamage->psProjectile->psSource && !isFeature(sDamage->psProjectile->psDest) && !isFriendlyFire(sDamage);
+	return psDamage->psProjectile->psSource && !isFeature(psDamage->psProjectile->psDest) && !isFriendlyFire(psDamage);
 }
 
 static void updateKills(DAMAGE* psDamage)


### PR DESCRIPTION
Hello!

This is my first attempt of contributing to this project. :)

It implements the feature for counting suggested in https://github.com/Warzone2100/warzone2100/issues/804.

I did some refactoring in the projectile module, and renamed some functions to make them a bit more clear.

The translations for the console message must be updated, but if I understood it right, according to the Translations.md, they must be updated via Crowdin. I saw that there are already translations for "Kills", so I was thinking about just appending those translations to the one modified in this PR.