### PR TITLE
Prevent giving electronic rewards to players in the campaign.

### DIFF
--- a/src/structure.cpp
+++ b/src/structure.cpp
@@ -5798,6 +5798,11 @@ UDWORD	structureResistance(const STRUCTURE_STATS *psStats, UBYTE player)
 been attacked*/
 bool electronicReward(STRUCTURE *psStructure, UBYTE attackPlayer)
 {
+	if (!bMultiPlayer)
+	{
+		return false; //campaign should not give rewards (especially to the player)
+	}
+
 	bool    bRewarded = false;
 
 	switch (psStructure->pStructureType->type)


### PR DESCRIPTION
This game has so many features that you would probably never experience...

I elected to give Gamma player on Gamma 3 Nexus's research list to help make the phony battle
scene less likely to destroy what would become a Nexus base. Note that research propagates throughout the entirety of a campaign. Because of this, when the game transfers an object via `donateObject()` it is transferred by means like electronic warfare does in multiplayer. Which, interestingly, allows a player to take the best component of some type, in the case of factory-like object.

Because Nexus has research that unlocks Type II Hover, CyborgLegs, and VTOL, it meant the player could get these special components if being donated something from a player that researched them. Not that the campaign AI needs to research things to use components anymore but eh, why not.

We probably have no need for this feature in campaign nor should it affect Nexus at all so I'm going to disable it from now on.

fixes #1154.
