### PR TITLE
Decrease HQ sensor range 24->18

### DIFF
--- a/data/mp/stats/sensor.json
+++ b/data/mp/stats/sensor.json
@@ -20,7 +20,7 @@
         "mountModel": "TRLSNSR1.PIE",
         "name": "*CC Sensor*",
         "power": 1000,
-        "range": 3072,
+        "range": 2304,
         "sensorModel": "misensor.PIE",
         "type": "STANDARD",
         "weight": 1


### PR DESCRIPTION
Decrease the range of the sensor to 18 tiles.
This is still the largest range of all sensors. 
fix #1155