### PR TITLE
Use timers for functions that need to be called repeatedly in campaign.

### DIFF
--- a/data/base/script/campaign/cam1-1s.js
+++ b/data/base/script/campaign/cam1-1s.js
@@ -1,6 +1,7 @@
 include("script/campaign/libcampaign.js");
 
 var cheat;
+var powModVideoPlayed;
 
 function eventChat(from, to, message)
 {
@@ -13,6 +14,7 @@ function eventChat(from, to, message)
 //Video if player does not yet have power module built
 function resPowModVideo()
 {
+	powModVideoPlayed = true;
 	camPlayVideos("MB1_B2_MSG");
 }
 
@@ -44,10 +46,11 @@ function checkForPowerModule()
 		camSetupTransporter(11, 52, 1, 32);
 		setMissionTime(camChangeOnDiff(camMinutesToSeconds(15))); // 15 min for offworld
 		secondVideo();
-	}
-	else
-	{
-		queue("checkForPowerModule", camSecondsToMilliseconds(3));
+
+		if (powModVideoPlayed)
+		{
+			removeTimer("checkForPowerModule");
+		}
 	}
 }
 
@@ -58,10 +61,12 @@ function eventStartLevel()
 	setMissionTime(camChangeOnDiff(camMinutesToSeconds(10))); // 10 min for building module.
 	camSetStandardWinLossConditions(CAM_VICTORY_PRE_OFFWORLD, "SUB_1_1");
 	cheat = false;
+	powModVideoPlayed = false;
 
 	if (!powerModuleBuilt())
 	{
 		resPowModVideo();
+		setTimer("checkForPowerModule", camSecondsToMilliseconds(3));
 	}
 
 	checkForPowerModule();

--- a/data/base/script/campaign/cam1-5.js
+++ b/data/base/script/campaign/cam1-5.js
@@ -76,6 +76,7 @@ camAreaEvent("NPFactoryTrigger", function(droid)
 camAreaEvent("NPLZTrigger", function()
 {
 	sendNPTransport();
+	setTimer("sendNPTransport", camChangeOnDiff(camMinutesToMilliseconds(3)));
 });
 
 function sendNPTransport()
@@ -83,7 +84,7 @@ function sendNPTransport()
 	var tPos = getObject("NPTransportPos");
 	var nearbyDefense = enumRange(tPos.x, tPos.y, 6, NEW_PARADIGM, false);
 
-	if (nearbyDefense.length)
+	if (nearbyDefense.length > 0)
 	{
 		var list = getDroidsForNPLZ();
 		camSendReinforcement(NEW_PARADIGM, camMakePos("NPTransportPos"), list, CAM_REINFORCE_TRANSPORT, {
@@ -97,8 +98,10 @@ function sendNPTransport()
 				repair: 66,
 			},
 		});
-
-		queue("sendNPTransport", camChangeOnDiff(camMinutesToMilliseconds(3)));
+	}
+	else
+	{
+		removeTimer("sendNPTransport");
 	}
 }
 

--- a/data/base/script/campaign/cam1-7.js
+++ b/data/base/script/campaign/cam1-7.js
@@ -119,6 +119,7 @@ function getArtifact()
 {
 	if (groupSize(artiGroup) === 0)
 	{
+		removeTimer("getArtifact");
 		return;
 	}
 
@@ -172,8 +173,6 @@ function getArtifact()
 			regroup: false
 		});
 	}
-
-	queue("getArtifact", camSecondsToMilliseconds(0.2));
 }
 
 //New Paradigm truck builds six lancer hardpoints around LZ
@@ -227,6 +226,11 @@ function eventPickup(feature, droid)
 			camCallOnce("removeCanyonBlip");
 		}
 	}
+}
+
+function startArtifactCollection()
+{
+	setTimer("getArtifact", camSecondsToMilliseconds(0.2));
 }
 
 //Mission setup stuff
@@ -328,5 +332,5 @@ function eventStartLevel()
 	buildLancers();
 
 	hackAddMessage("C1-7_OBJ1", PROX_MSG, CAM_HUMAN_PLAYER, true); //Canyon
-	queue("getArtifact", camChangeOnDiff(camMinutesToMilliseconds(1.5)));
+	queue("startArtifactCollection", camChangeOnDiff(camMinutesToMilliseconds(1.5)));
 }

--- a/data/base/script/campaign/cam1a-c.js
+++ b/data/base/script/campaign/cam1a-c.js
@@ -124,12 +124,15 @@ function sendTransport()
 
 	if (index === 5)
 	{
+		removeTimer("sendTransport");
 		return;
 	}
-	else
-	{
-		queue("sendTransport", camChangeOnDiff(camMinutesToMilliseconds(1)));
-	}
+}
+
+function startTransporterAttack()
+{
+	sendTransport();
+	setTimer("sendTransport", camChangeOnDiff(camMinutesToMilliseconds(1)));
 }
 
 function eventStartLevel()
@@ -160,5 +163,5 @@ function eventStartLevel()
 	index = 0;
 	switchLZ = 0;
 
-	queue("sendTransport", camSecondsToMilliseconds(10));
+	queue("startTransporterAttack", camSecondsToMilliseconds(10));
 }

--- a/data/base/script/campaign/cam1ca.js
+++ b/data/base/script/campaign/cam1ca.js
@@ -86,13 +86,11 @@ function sendTransport()
 	if (lastHeavy)
 	{
 		lastHeavy = false;
-		queue("sendTransport", camChangeOnDiff(camMinutesToMilliseconds(1.5)));
 		templates = [ cTempl.nppod, cTempl.nphmg, cTempl.npmrl, cTempl.npsmc ];
 	}
 	else
 	{
 		lastHeavy = true;
-		queue("sendTransport", camChangeOnDiff(camMinutesToMilliseconds(3)));
 		templates = [ cTempl.npsmct, cTempl.npmor, cTempl.npsmc, cTempl.npmmct, cTempl.npmrl, cTempl.nphmg, cTempl.npsbb ];
 	}
 
@@ -114,6 +112,12 @@ function sendTransport()
 	});
 
 	totalTransportLoads = totalTransportLoads + 1;
+}
+
+function startTransporterAttack()
+{
+	sendTransport();
+	setTimer("sendTransport", camChangeOnDiff(camMinutesToMilliseconds(2.2)));
 }
 
 function eventStartLevel()
@@ -143,6 +147,6 @@ function eventStartLevel()
 	setMissionTime(camChangeOnDiff(camMinutesToSeconds(30)));
 	camPlayVideos("MB1CA_MSG");
 
-	// first transport after 10 seconds; will re-queue itself
-	queue('sendTransport', camSecondsToMilliseconds(10));
+	// first transport after 10 seconds
+	queue("startTransporterAttack", camSecondsToMilliseconds(10));
 }

--- a/data/base/script/campaign/cam2-2.js
+++ b/data/base/script/campaign/cam2-2.js
@@ -110,9 +110,10 @@ function vtolAttack()
 //Order the truck to build some defenses.
 function truckDefense()
 {
-	if (enumDroid(THE_COLLECTIVE, DROID_CONSTRUCT).length > 0)
+	if (enumDroid(THE_COLLECTIVE, DROID_CONSTRUCT).length === 0)
 	{
-		queue("truckDefense", camSecondsToMilliseconds(160));
+		removeTimer("truckDefense");
+		return;
 	}
 
 	const list = ["CO-Tower-LtATRkt", "PillBox1", "CO-Tower-MdCan"];
@@ -231,4 +232,5 @@ function eventStartLevel()
 	hackAddMessage("C22_OBJ1", PROX_MSG, CAM_HUMAN_PLAYER, true);
 
 	queue("vtolAttack", camMinutesToMilliseconds(2));
+	setTimer("truckDefense", camSecondsToMilliseconds(160));
 }

--- a/data/base/script/campaign/cam2-8.js
+++ b/data/base/script/campaign/cam2-8.js
@@ -75,9 +75,10 @@ function enableFactories()
 
 function truckDefense()
 {
-	if (enumDroid(THE_COLLECTIVE, DROID_CONSTRUCT).length > 0)
+	if (enumDroid(THE_COLLECTIVE, DROID_CONSTRUCT).length === 0)
 	{
-		queue("truckDefense", camMinutesToMilliseconds(2));
+		removeTimer("truckDefense");
+		return;
 	}
 
 	var list = ["AASite-QuadBof", "CO-WallTower-HvCan", "CO-Tower-RotMG"];
@@ -187,4 +188,5 @@ function eventStartLevel()
 	queue("setupLandGroups", camSecondsToMilliseconds(50));
 	queue("vtolAttack", camMinutesToMilliseconds(1));
 	queue("enableFactories", camChangeOnDiff(camMinutesToMilliseconds(1.5)));
+	setTimer("truckDefense", camMinutesToMilliseconds(2));
 }

--- a/data/base/script/campaign/cam2-a.js
+++ b/data/base/script/campaign/cam2-a.js
@@ -81,7 +81,7 @@ function sendCOTransporter()
 	var tPos = getObject("COTransportPos");
 	var nearbyDefense = enumRange(tPos.x, tPos.y, 15, THE_COLLECTIVE, false);
 
-	if (nearbyDefense.length)
+	if (nearbyDefense.length > 0)
 	{
 		var list = getDroidsForCOLZ();
 		camSendReinforcement(THE_COLLECTIVE, camMakePos("COTransportPos"), list,
@@ -90,8 +90,10 @@ function sendCOTransporter()
 				exit: { x: 125, y: 70 }
 			}
 		);
-
-		queue("sendCOTransporter", camChangeOnDiff(camMinutesToMilliseconds(4)));
+	}
+	else
+	{
+		removeTimer("sendCOTransporter");
 	}
 }
 
@@ -110,7 +112,6 @@ function sendPlayerTransporter()
 		return;
 	}
 
-	var ti = (index === (TRANSPORT_LIMIT - 1)) ? camMinutesToMilliseconds(1) : camMinutesToMilliseconds(5);
 	var droids = [];
 	var list = [cTempl.prhct, cTempl.prhct, cTempl.prhct, cTempl.prltat, cTempl.prltat, cTempl.npcybr, cTempl.prrept];
 
@@ -125,8 +126,6 @@ function sendPlayerTransporter()
 			exit: { x: 87, y: 126 }
 		}
 	);
-
-	queue("sendPlayerTransporter", ti);
 }
 
 //Continuously spawns heavy units on the north part of the map every 7 minutes
@@ -142,7 +141,6 @@ function mapEdgeDroids()
 	}
 
 	camSendReinforcement(THE_COLLECTIVE, camMakePos("groundUnitPos"), droids, CAM_REINFORCE_GROUND);
-	queue("mapEdgeDroids", camChangeOnDiff(camMinutesToMilliseconds(7)));
 }
 
 function vtolAttack()
@@ -176,13 +174,14 @@ function groupPatrol()
 //Build defenses around oil resource
 function truckDefense()
 {
-	if (enumDroid(THE_COLLECTIVE, DROID_CONSTRUCT).length > 0)
+	if (enumDroid(THE_COLLECTIVE, DROID_CONSTRUCT).length === 0)
 	{
-		const DEFENSES = ["CO-Tower-LtATRkt", "PillBox1", "CO-Tower-MdCan"];
-		camQueueBuilding(THE_COLLECTIVE, DEFENSES[camRand(DEFENSES.length)]);
-
-		queue("truckDefense", camSecondsToMilliseconds(160));
+		removeTimer("truckDefense");
+		return;
 	}
+
+	const DEFENSES = ["CO-Tower-LtATRkt", "PillBox1", "CO-Tower-MdCan"];
+	camQueueBuilding(THE_COLLECTIVE, DEFENSES[camRand(DEFENSES.length)]);
 }
 
 //Gives starting tech and research.
@@ -266,6 +265,7 @@ function eventTransporterLanded(transport)
 //Warn that something bad happened to the fifth transport
 function reallyDownTransporter()
 {
+	removeTimer("sendPlayerTransporter");
 	setReinforcementTime(LZ_COMPROMISED_TIME);
 	playSound("pcv443.ogg");
 }
@@ -346,6 +346,7 @@ function eventStartLevel()
 	{
 		startedFromMenu = true;
 		sendPlayerTransporter();
+		setTimer("sendPlayerTransporter", camMinutesToMilliseconds(5));
 	}
 	else
 	{
@@ -353,9 +354,9 @@ function eventStartLevel()
 	}
 
 	queue("secondVideo", camSecondsToMilliseconds(12));
-	queue("truckDefense", camSecondsToMilliseconds(15));
 	queue("groupPatrol", camChangeOnDiff(camMinutesToMilliseconds(1)));
 	queue("vtolAttack", camChangeOnDiff(camMinutesToMilliseconds(3)));
-	queue("sendCOTransporter", camChangeOnDiff(camMinutesToMilliseconds(4)));
-	queue("mapEdgeDroids", camChangeOnDiff(camMinutesToMilliseconds(7)));
+	setTimer("truckDefense", camSecondsToMilliseconds(160));
+	setTimer("sendCOTransporter", camChangeOnDiff(camMinutesToMilliseconds(4)));
+	setTimer("mapEdgeDroids", camChangeOnDiff(camMinutesToMilliseconds(7)));
 }

--- a/data/base/script/campaign/cam2-b.js
+++ b/data/base/script/campaign/cam2-b.js
@@ -95,9 +95,10 @@ function vtolAttack()
 
 function truckDefense()
 {
-	if (enumDroid(THE_COLLECTIVE, DROID_CONSTRUCT).length > 0)
+	if (enumDroid(THE_COLLECTIVE, DROID_CONSTRUCT).length === 0)
 	{
-		queue("truckDefense", camSecondsToMilliseconds(160));
+		removeTimer("truckDefense");
+		return;
 	}
 
 	const list = ["CO-Tower-MG3", "CO-Tower-LtATRkt", "CO-Tower-MdCan", "CO-Tower-LtATRkt"];
@@ -243,4 +244,5 @@ function eventStartLevel()
 	queue("vtolAttack", camChangeOnDiff(camMinutesToMilliseconds(4)));
 	queue("activateBase1Defenders2", camChangeOnDiff(camMinutesToMilliseconds(20)));
 	queue("activateBase1Defenders", camChangeOnDiff(camMinutesToMilliseconds(30)));
+	setTimer("truckDefense", camSecondsToMilliseconds(160));
 }

--- a/data/base/script/campaign/cam2-c.js
+++ b/data/base/script/campaign/cam2-c.js
@@ -30,8 +30,8 @@ function videoTrigger()
 	camSetExtraObjectiveMessage(_("Rescue the civilians from The Collective before too many are captured"));
 
 	setMissionTime(getMissionTime() + camChangeOnDiff(camMinutesToSeconds(30)));
-	civilianOrders();
-	captureCivilians();
+	setTimer("civilianOrders", camSecondsToMilliseconds(2));
+	setTimer("captureCivilians", camChangeOnDiff(camSecondsToMilliseconds(10)));
 
 	hackRemoveMessage("C2C_OBJ1", PROX_MSG, CAM_HUMAN_PLAYER);
 	camPlayVideos("MB2_C_MSG2");
@@ -123,9 +123,10 @@ function activateGroups()
 
 function truckDefense()
 {
-	if (enumDroid(THE_COLLECTIVE, DROID_CONSTRUCT).length > 0)
+	if (enumDroid(THE_COLLECTIVE, DROID_CONSTRUCT).length === 0)
 	{
-		queue("truckDefense", camSecondsToMilliseconds(160));
+		removeTimer("truckDefense");
+		return;
 	}
 
 	const LIST = ["CO-Tower-LtATRkt", "PillBox1", "CO-Tower-MdCan"];
@@ -144,7 +145,7 @@ function captureCivilians()
 	var currPos = getObject(wayPoints[civilianPosIndex]);
 	var shepardDroids = enumGroup(shepardGroup);
 
-	if (shepardDroids.length)
+	if (shepardDroids.length > 0)
 	{
 		//add some civs
 		var i = 0;
@@ -176,7 +177,10 @@ function captureCivilians()
 			queue("sendCOTransporter", camSecondsToMilliseconds(6));
 		}
 		civilianPosIndex = (civilianPosIndex > 6) ? 0 : (civilianPosIndex + 1);
-		queue("captureCivilians", camChangeOnDiff(camSecondsToMilliseconds(10)));
+	}
+	else
+	{
+		removeTimer("captureCivilians");
 	}
 }
 
@@ -210,8 +214,6 @@ function civilianOrders()
 		lastSoundTime = gameTime;
 		playSound(rescueSound);
 	}
-
-	queue("civilianOrders", camSecondsToMilliseconds(2));
 }
 
 //Capture civilans.
@@ -409,4 +411,5 @@ function eventStartLevel()
 	hackAddMessage("C2C_OBJ1", PROX_MSG, CAM_HUMAN_PLAYER, true);
 
 	queue("activateGroups", camChangeOnDiff(camMinutesToMilliseconds(8)));
+	setTimer("truckDefense", camSecondsToMilliseconds(160));
 }

--- a/data/base/script/campaign/cam2-d.js
+++ b/data/base/script/campaign/cam2-d.js
@@ -32,9 +32,10 @@ camAreaEvent("vtolRemoveZone", function(droid)
 //Order the truck to build some defenses.
 function truckDefense()
 {
-	if (enumDroid(THE_COLLECTIVE, DROID_CONSTRUCT).length > 0)
+	if (enumDroid(THE_COLLECTIVE, DROID_CONSTRUCT).length === 0)
 	{
-		queue("truckDefense", camSecondsToMilliseconds(160));
+		removeTimer("truckDefense");
+		return;
 	}
 
 	var list = ["AASite-QuadBof", "CO-WallTower-HvCan", "CO-Tower-RotMG", "CO-Tower-HvFlame"];
@@ -152,4 +153,5 @@ function eventStartLevel()
 	camEnableFactory("COSouthCyborgFactory");
 
 	queue("vtolAttack", camMinutesToMilliseconds(2));
+	setTimer("truckDefense", camSecondsToMilliseconds(160));
 }

--- a/data/base/script/campaign/cam2-end.js
+++ b/data/base/script/campaign/cam2-end.js
@@ -35,8 +35,6 @@ function checkEnemyVtolArea()
 			camSafeRemoveObject(vtols[i], false);
 		}
 	}
-
-	queue("checkEnemyVtolArea", camSecondsToMilliseconds(1));
 }
 
 //Play last video sequence and destroy all droids on map.
@@ -101,8 +99,6 @@ function cyborgAttack()
 	camSendReinforcement(THE_COLLECTIVE, camMakePos(southCyborgAssembly), randomTemplates(list), CAM_REINFORCE_GROUND, {
 		data: { regroup: false, count: -1 }
 	});
-
-	queue("cyborgAttack", camChangeOnDiff(camMinutesToMilliseconds(4)));
 }
 
 //North road attacker consisting of powerful weaponry.
@@ -118,7 +114,6 @@ function tankAttack()
 	camSendReinforcement(THE_COLLECTIVE, camMakePos(northTankAssembly), randomTemplates(list), CAM_REINFORCE_GROUND, {
 		data: { regroup: false, count: -1, },
 	});
-	queue("tankAttack", camChangeOnDiff(camMinutesToMilliseconds(3)));
 }
 
 //NOTE: this is only called once from the library's eventMissionTimeout().
@@ -166,9 +161,8 @@ function eventStartLevel()
 	allowWin = false;
 	camPlayVideos(["MB2_DII_MSG", "MB2_DII_MSG2"]);
 
-	//These requeue themselves every so often.
 	vtolAttack();
-	cyborgAttack();
-	tankAttack();
-	checkEnemyVtolArea();
+	setTimer("cyborgAttack", camChangeOnDiff(camMinutesToMilliseconds(4)));
+	setTimer("tankAttack", camChangeOnDiff(camMinutesToMilliseconds(3)));
+	setTimer("checkEnemyVtolArea", camSecondsToMilliseconds(1));
 }

--- a/data/base/script/campaign/cam3-1.js
+++ b/data/base/script/campaign/cam3-1.js
@@ -171,10 +171,7 @@ function setupNextMission()
 		hackAddMessage("CM31_HIDE_LOC", PROX_MSG, CAM_HUMAN_PLAYER);
 
 		setReinforcementTime(-1);
-	}
-	else
-	{
-		queue("setupNextMission", camSecondsToMilliseconds(2));
+		removeTimer("setupNextMission");
 	}
 }
 
@@ -212,8 +209,6 @@ function getCountdown()
 			break;
 		}
 	}
-
-	queue("getCountdown", camSecondsToMilliseconds(0.4));
 }
 
 function enableAllFactories()
@@ -367,7 +362,8 @@ function eventStartLevel()
 	cyborgAttack();
 	getCountdown();
 
-	queue("setupNextMission", camSecondsToMilliseconds(8));
+	setTimer("getCountdown", camSecondsToMilliseconds(0.4));
+	setTimer("setupNextMission", camSecondsToMilliseconds(2));
 	queue("hoverAttack", camChangeOnDiff(camMinutesToMilliseconds(4)));
 	queue("vtolAttack", camChangeOnDiff(camMinutesToMilliseconds(5)));
 	queue("enableAllFactories", camChangeOnDiff(camMinutesToMilliseconds(5)));

--- a/data/base/script/campaign/cam3-2.js
+++ b/data/base/script/campaign/cam3-2.js
@@ -47,7 +47,10 @@ camAreaEvent("rescueTrigger", function(droid)
 	phantomFactorySE();
 	setAlliance(ALPHA, NEXUS, false);
 	camAbsorbPlayer(ALPHA, CAM_HUMAN_PLAYER);
+
 	queue("getAlphaUnitIDs", camSecondsToMilliseconds(2));
+	setTimer("phantomFactorySE", camChangeOnDiff(camMinutesToMilliseconds(4)));
+
 	camPlayVideos("MB3_2_MSG4");
 });
 
@@ -96,21 +99,18 @@ function phantomFactoryNE()
 {
 	var list = [cTempl.nxcyrail, cTempl.nxcyscou, cTempl.nxcylas];
 	sendEdgeMapDroids(6, "NE-PhantomFactory", list);
-	queue("phantomFactoryNE", camChangeOnDiff(camMinutesToMilliseconds(2)));
 }
 
 function phantomFactorySW()
 {
 	var list = [cTempl.nxcyrail, cTempl.nxcyscou, cTempl.nxcylas];
 	sendEdgeMapDroids(8, "SW-PhantomFactory", list);
-	queue("phantomFactorySW", camChangeOnDiff(camMinutesToMilliseconds(3)));
 }
 
 function phantomFactorySE()
 {
 	var list = [cTempl.nxcyrail, cTempl.nxcyscou, cTempl.nxcylas, cTempl.nxlflash, cTempl.nxmrailh, cTempl.nxmlinkh];
 	sendEdgeMapDroids(10 + camRand(6), "SE-PhantomFactory", list); //10-15 units
-	queue("phantomFactorySE", camChangeOnDiff(camMinutesToMilliseconds(4)));
 }
 
 function sendEdgeMapDroids(droidCount, location, list)
@@ -291,4 +291,7 @@ function eventStartLevel()
 	hackAddMessage("C3-2_OBJ1", PROX_MSG, CAM_HUMAN_PLAYER);
 	queue("setAlphaExp", camSecondsToMilliseconds(2));
 	queue("setupPatrolGroups", camSecondsToMilliseconds(15));
+
+	setTimer("phantomFactoryNE", camChangeOnDiff(camMinutesToMilliseconds(2)));
+	setTimer("phantomFactorySW", camChangeOnDiff(camMinutesToMilliseconds(3)));
 }

--- a/data/base/script/campaign/cam3-4.js
+++ b/data/base/script/campaign/cam3-4.js
@@ -104,8 +104,10 @@ function truckDefense()
 			camQueueBuilding(NEXUS, list[camRand(list.length)]);
 		}
 	}
-
-	queue("truckDefense", camChangeOnDiff(camMinutesToMilliseconds(5)));
+	else
+	{
+		removeTimer("truckDefense");
+	}
 }
 
 function eventStartLevel()
@@ -329,4 +331,5 @@ function eventStartLevel()
 	hackAddMessage("CM34_OBJ1", PROX_MSG, CAM_HUMAN_PLAYER);
 
 	queue("enableAllFactories", camChangeOnDiff(camMinutesToMilliseconds(10)));
+	setTimer("truckDefense", camChangeOnDiff(camMinutesToMilliseconds(5)));
 }

--- a/data/base/script/campaign/cam3-a.js
+++ b/data/base/script/campaign/cam3-a.js
@@ -93,6 +93,7 @@ function sendPlayerTransporter()
 
 	if (index === transportLimit)
 	{
+		removeTimer("sendPlayerTransporter");
 		return;
 	}
 
@@ -113,7 +114,6 @@ function sendPlayerTransporter()
 	);
 
 	index = index + 1;
-	queue("sendPlayerTransporter", camMinutesToMilliseconds(5));
 }
 
 //Setup Nexus VTOL hit and runners.
@@ -154,18 +154,6 @@ function groupPatrolNoTrigger()
 	});
 
 	camManageGroup(camMakeGroup("NAmbushCyborgs"), CAM_ORDER_ATTACK);
-}
-
-//Build defenses.
-function truckDefense()
-{
-	if (enumDroid(NEXUS, DROID_CONSTRUCT).length > 0)
-	{
-		queue("truckDefense", camSecondsToMilliseconds(160));
-	}
-
-	const DEFENSE = ["NX-Tower-Rail1", "NX-Tower-ATMiss"];
-	camQueueBuilding(NEXUS, DEFENSE[camRand(DEFENSE.length)]);
 }
 
 //Gives starting tech and research.
@@ -338,7 +326,6 @@ function eventStartLevel()
 	});
 
 	camManageTrucks(NEXUS);
-	truckDefense();
 	camPlayVideos(["MB3A_MSG", "MB3A_MSG2"]);
 	startedFromMenu = false;
 
@@ -348,6 +335,7 @@ function eventStartLevel()
 		startedFromMenu = true;
 		setReinforcementTime(LZ_COMPROMISED_TIME);
 		sendPlayerTransporter();
+		setTimer("sendPlayerTransporter", camMinutesToMilliseconds(5));
 	}
 	else
 	{

--- a/data/base/script/campaign/cam3-ab.js
+++ b/data/base/script/campaign/cam3-ab.js
@@ -57,7 +57,6 @@ function sendEdgeMapDroids()
 	);
 
 	edgeMapCounter += 1;
-	queue("sendEdgeMapDroids", camChangeOnDiff(camMinutesToMilliseconds(3)));
 }
 
 //Setup Nexus VTOL hit and runners. NOTE: These do not go away in this mission.
@@ -188,11 +187,13 @@ function eventResearched(research, structure, player)
 
 function hackPlayer()
 {
-	camHackIntoPlayer(CAM_HUMAN_PLAYER, NEXUS);
-	if (camGetNexusState())
+	if (!camGetNexusState())
 	{
-		queue("hackPlayer", camSecondsToMilliseconds(5));
+		removeTimer("hackPlayer");
+		return;
 	}
+
+	camHackIntoPlayer(CAM_HUMAN_PLAYER, NEXUS);
 }
 
 function synapticsSound()
@@ -241,9 +242,10 @@ function eventStartLevel()
 
 	queue("powerTransfer", camSecondsToMilliseconds(0.8));
 	queue("synapticsSound", camSecondsToMilliseconds(2.5));
-	queue("hackPlayer", camSecondsToMilliseconds(8));
 	queue("sendEdgeMapDroids", camSecondsToMilliseconds(15));
 
 	setTimer("truckDefense", camSecondsToMilliseconds(2));
+	setTimer("hackPlayer", camSecondsToMilliseconds(8));
 	setTimer("nexusManufacture", camSecondsToMilliseconds(10));
+	setTimer("sendEdgeMapDroids", camChangeOnDiff(camMinutesToMilliseconds(3)));
 }

--- a/data/base/script/campaign/cam3-ad1.js
+++ b/data/base/script/campaign/cam3-ad1.js
@@ -124,7 +124,6 @@ function vaporizeTarget()
 		mapLimit = mapLimit + 0.36; //sector clear; move closer
 	}
 	laserSatFuzzyStrike(target);
-	queue("vaporizeTarget", camSecondsToMilliseconds(10));
 }
 
 //A simple way to fire the LasSat with a chance of missing.
@@ -319,4 +318,6 @@ function eventStartLevel()
 	queue("vaporizeTarget", camSecondsToMilliseconds(2));
 	queue("setupGroups", camSecondsToMilliseconds(5));
 	queue("enableAllFactories", camChangeOnDiff(camMinutesToMilliseconds(5)));
+
+	setTimer("vaporizeTarget", camSecondsToMilliseconds(10));
 }

--- a/data/base/script/campaign/cam3-ad2.js
+++ b/data/base/script/campaign/cam3-ad2.js
@@ -95,8 +95,6 @@ function phantomFactorySpawn()
 			data: { regroup: false, count: -1, },
 		});
 	}
-
-	queue("phantomFactorySpawn", camChangeOnDiff(camMinutesToMilliseconds(5)));
 }
 
 //Choose a target to fire the LasSat at. Automatically increases the limits
@@ -155,7 +153,10 @@ function vaporizeTarget()
 			mapLimit = mapLimit + 0.33; //sector clear; move closer
 		}
 		laserSatFuzzyStrike(target);
-		queue("vaporizeTarget", camSecondsToMilliseconds(10));
+	}
+	else
+	{
+		removeTimer("vaporizeTarget");
 	}
 }
 
@@ -242,12 +243,12 @@ function checkTime()
 	{
 		camPlayVideos("MB3_AD2_MSG2");
 		setMissionTime(camHoursToSeconds(1));
+
 		phantomFactorySpawn();
 		queue("vaporizeTarget", camSecondsToMilliseconds(2));
-	}
-	else
-	{
-		queue("checkTime", camSecondsToMilliseconds(0.2));
+		setTimer("vaporizeTarget", camSecondsToMilliseconds(10));
+		setTimer("phantomFactorySpawn", camChangeOnDiff(camMinutesToMilliseconds(5)));
+		removeTimer("checkTime");
 	}
 }
 
@@ -305,6 +306,6 @@ function eventStartLevel()
 	camCompleteRequiredResearch(NEXUS_RES, NEXUS);
 	camPlayVideos("MB3_AD2_MSG");
 
-	queue("checkTime", camSecondsToMilliseconds(0.2));
+	setTimer("checkTime", camSecondsToMilliseconds(0.2));
 	queue("vtolAttack", camChangeOnDiff(camMinutesToMilliseconds(3)));
 }

--- a/data/base/script/campaign/cam3-b.js
+++ b/data/base/script/campaign/cam3-b.js
@@ -124,8 +124,10 @@ function sendNXTransporter()
 			entry: { x: 62, y: 4 },
 			exit: { x: 62, y: 4 }
 		});
-
-		queue("sendNXTransporter", camChangeOnDiff(camMinutesToMilliseconds(3)));
+	}
+	else
+	{
+		removeTimer("sendNXTransporter");
 	}
 }
 
@@ -134,6 +136,7 @@ function sendNXlandReinforcements()
 {
 	if (!enumArea("NXWestBaseCleanup", NEXUS, false).length)
 	{
+		removeTimer("sendNXlandReinforcements");
 		return;
 	}
 
@@ -142,8 +145,6 @@ function sendNXlandReinforcements()
 			data: {regroup: true, count: -1,},
 		}
 	);
-
-	queue("sendNXlandReinforcements", camChangeOnDiff(camMinutesToMilliseconds(4)));
 }
 
 function transferPower()
@@ -197,15 +198,6 @@ function activateNexusGroups()
 //Take everything Gamma has and donate to Nexus.
 function trapSprung()
 {
-	if (!trapActive)
-	{
-		playSound("pcv455.ogg"); //Incoming message.
-		trapActive = true;
-		setAlliance(GAMMA, NEXUS, false);
-		queue("trapSprung", camSecondsToMilliseconds(2)); //call this a few seconds later
-		return;
-	}
-
 	setAlliance(GAMMA, NEXUS, true);
 	setAlliance(GAMMA, CAM_HUMAN_PLAYER, false);
 	camPlayVideos("MB3_B_MSG3");
@@ -215,15 +207,21 @@ function trapSprung()
 	camCallOnce("activateNexusGroups");
 	enableAllFactories();
 
-	queue("sendNXlandReinforcements", camChangeOnDiff(camMinutesToMilliseconds(5)));
 	sendNXTransporter();
 	changePlayerColour(GAMMA, NEXUS); // Black painting.
 	playSound(SYNAPTICS_ACTIVATED);
+
+	setTimer("sendNXTransporter", camChangeOnDiff(camMinutesToMilliseconds(3)));
+	setTimer("sendNXlandReinforcements", camChangeOnDiff(camMinutesToMilliseconds(4)));
 }
 
 function setupCapture()
 {
-	trapSprung();
+	trapActive = true;
+	playSound("pcv455.ogg"); //Incoming message.
+	setAlliance(GAMMA, NEXUS, false);
+
+	queue("trapSprung", camSecondsToMilliseconds(2)); //call this a few seconds later
 }
 
 function eventAttacked(victim, attacker)

--- a/data/base/script/campaign/libcampaign.js
+++ b/data/base/script/campaign/libcampaign.js
@@ -198,7 +198,6 @@ var __camVtolPlayer;
 var __camVtolStartPosition;
 var __camVtolTemplates;
 var __camVtolExitPosition;
-var __camVtolTimer;
 var __camVtolSpawnActive;
 var __camVtolSpawnStopObject;
 var __camVtolExtras;

--- a/data/base/script/campaign/libcampaign_includes/events.js
+++ b/data/base/script/campaign/libcampaign_includes/events.js
@@ -119,7 +119,6 @@ function cam_eventStartLevel()
 	__camVtolStartPosition = {};
 	__camVtolTemplates = {};
 	__camVtolExitPosition = {};
-	__camVtolTimer = 0;
 	__camVtolSpawnActive = false;
 	__camVtolExtras = {};
 	__camLastNexusAttack = 0;
@@ -137,7 +136,7 @@ function cam_eventStartLevel()
 	setTimer("__camTruckTick", camSecondsToMilliseconds(40) + camSecondsToMilliseconds(0.1)); // some slower campaign pollers
 	setTimer("__camAiPowerReset", camMinutesToMilliseconds(3)); //reset AI power every so often
 	setTimer("__camShowVictoryConditions", camMinutesToMilliseconds(5));
-	queue("__camTacticsTick", camSecondsToMilliseconds(0.1)); // would re-queue itself
+	setTimer("__camTacticsTick", camSecondsToMilliseconds(0.1));
 	queue("__camGrantSpecialResearch", camSecondsToMilliseconds(6));
 }
 

--- a/data/base/script/campaign/libcampaign_includes/tactics.js
+++ b/data/base/script/campaign/libcampaign_includes/tactics.js
@@ -304,7 +304,9 @@ function __camTacticsTick()
 		queue("__camTacticsTickForGroup", dt, group);
 		dt += CAM_TICKS_PER_FRAME;
 	}
-	queue("__camTacticsTick", dt);
+	//Emulate a queue...
+	removeTimer("__camTacticsTick");
+	setTimer("__camTacticsTick", dt);
 }
 
 //Return the range (in tiles) a droid will scout for stuff to attack around it.

--- a/data/base/script/campaign/libcampaign_includes/victory.js
+++ b/data/base/script/campaign/libcampaign_includes/victory.js
@@ -108,7 +108,7 @@ function camSetStandardWinLossConditions(kind, nextLevel, data)
 			__camDefeatOnTimeout = true;
 			__camVictoryData = data;
 			setReinforcementTime(__camVictoryData.reinforcements);
-			queue("__camSetOffworldLimits", camSecondsToMilliseconds(0.1));
+			__camSetOffworldLimits();
 			useSafetyTransport(false);
 			break;
 		case CAM_VICTORY_TIMEOUT:

--- a/data/base/script/campaign/libcampaign_includes/vtol.js
+++ b/data/base/script/campaign/libcampaign_includes/vtol.js
@@ -13,14 +13,13 @@ function camSetVtolData(player, startPos, exitPos, templates, timer, obj, extras
 	__camVtolStartPosition = startPos;
 	__camVtolExitPosition = camMakePos(exitPos);
 	__camVtolTemplates = templates;
-	__camVtolTimer = timer;
 	__camVtolSpawnStopObject = obj;
 	__camVtolExtras = extras;
 
 	camSetVtolSpawn(true);
-	__checkVtolSpawnObject();
-	__camSpawnVtols();
-	__camRetreatVtols();
+	setTimer("__camRetreatVtols", camSecondsToMilliseconds(0.8));
+	setTimer("__checkVtolSpawnObject", camSecondsToMilliseconds(5));
+	setTimer("__camSpawnVtols", timer);
 }
 
 function camSetVtolSpawn(value)
@@ -37,10 +36,7 @@ function __checkVtolSpawnObject()
 		if (getObject(__camVtolSpawnStopObject) === null)
 		{
 			camSetVtolSpawn(false); //Deactive hit and runner VTOLs.
-		}
-		else
-		{
-			queue("__checkVtolSpawnObject", camSecondsToMilliseconds(5));
+			removeTimer("__checkVtolSpawnObject");
 		}
 	}
 }
@@ -49,6 +45,7 @@ function __camSpawnVtols()
 {
 	if (__camVtolSpawnActive === false)
 	{
+		removeTimer("__camSpawnVtols");
 		return;
 	}
 
@@ -129,8 +126,6 @@ function __camSpawnVtols()
 		order: CAM_ORDER_ATTACK,
 		data: { regroup: false, count: -1 }
 	});
-
-	queue("__camSpawnVtols", __camVtolTimer);
 }
 
 function __camRetreatVtols()
@@ -158,6 +153,4 @@ function __camRetreatVtols()
 			}
 		}
 	}
-
-	queue("__camRetreatVtols", camSecondsToMilliseconds(0.8));
 }


### PR DESCRIPTION
Could be possible to do a tick-perfect pause, save the game, and lose the function that wanted to be queued again.

...

Given certain queued functions in the campaign library/scripts, that requeue themselves, seem to be randomly missing in the `scriptstate` file on rare occasion, and that the game runs through and saves everything in the `timers` global that holds all queues and timers, I can only possibly conclude the above about tick-perfect saving is true.

The only major behavior change this patch _should_ introduce is on Alpha 7 where I didn't feel it was necessary to create strange timer magic for the previous queue alteration of 1.5 then 3 minutes. Instead, it will be a constant 2.2 minutes which is ~0.2 minutes more wait time to complete this mission if playing optimally on Normal difficulty.

Should hopefully fix #1101.