### PR TITLE
Fix deselecting with RMB

### DIFF
--- a/src/display.cpp
+++ b/src/display.cpp
@@ -2618,7 +2618,7 @@ bool cyborgDroidSelected(UDWORD player)
 }
 
 /* Clear the selection flag for a player */
-void clearSel()
+void clearSelection()
 {
 	DROID			*psCurrDroid;
 	STRUCTURE		*psStruct;
@@ -2642,11 +2642,6 @@ void clearSel()
 	intRefreshScreen();
 
 	triggerEventSelected();
-}
-
-void clearSelection()
-{
-	clearSel();
 }
 
 //access function for bSensorAssigned variable

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -108,6 +108,7 @@ static SELECTION_TYPE	establishSelection(UDWORD selectedPlayer);
 static void	dealWithLMB();
 static void	dealWithLMBDClick();
 static void	dealWithRMB();
+static void	handleDeselectionClick();
 static bool	mouseInBox(SDWORD x0, SDWORD y0, SDWORD x1, SDWORD y1);
 static OBJECT_POSITION *checkMouseLoc();
 
@@ -2100,10 +2101,14 @@ static void dealWithRMB()
 					}
 				}
 			}
-			else if (bMultiPlayer && isHumanPlayer(psDroid->player))
+			else
 			{
-				console("%s", droidGetName(psDroid));
-				FeedbackOrderGiven();
+				handleDeselectionClick();
+				if (bMultiPlayer && isHumanPlayer(psDroid->player))
+				{
+					console("%s", droidGetName(psDroid));
+					FeedbackOrderGiven();
+				}
 			}
 		}	// end if its a droid
 		else if (psClickedOn->type == OBJ_STRUCTURE)
@@ -2166,10 +2171,13 @@ static void dealWithRMB()
 						intObjectSelected((BASE_OBJECT *)psStructure);
 					}
 				}
+			} else {
+				handleDeselectionClick();
 			}
 		}	// end if its a structure
 		else
 		{
+			handleDeselectionClick();
 			/* And if it's not a feature, then we're in trouble! */
 			ASSERT(psClickedOn->type == OBJ_FEATURE, "Weird selection from RMB - type of clicked object is %d", (int)psClickedOn->type);
 		}
@@ -2210,9 +2218,7 @@ static void dealWithRMB()
 		}
 		else
 		{
-			clearSelection();
-			intObjectSelected(nullptr);
-			memset(DROIDDOING, 0x0 , sizeof(DROIDDOING));	// clear string when deselected
+			handleDeselectionClick();
 		}
 	}
 }
@@ -2624,6 +2630,8 @@ void clearSelection()
 	STRUCTURE		*psStruct;
 	FLAG_POSITION	*psFlagPos;
 
+	memset(DROIDDOING, 0x0 , sizeof(DROIDDOING));	// clear string when deselected
+
 	for (psCurrDroid = apsDroidLists[selectedPlayer]; psCurrDroid; psCurrDroid = psCurrDroid->psNext)
 	{
 		psCurrDroid->selected = false;
@@ -2642,6 +2650,12 @@ void clearSelection()
 	intRefreshScreen();
 
 	triggerEventSelected();
+}
+
+static void handleDeselectionClick()
+{
+	clearSelection();
+	intObjectSelected(nullptr);
 }
 
 //access function for bSensorAssigned variable

--- a/src/display.h
+++ b/src/display.h
@@ -46,9 +46,7 @@ void setMouseScroll(bool);
 
 bool DrawnInLastFrame(SDWORD Frame);
 
-// Clear all selections.
-void clearSel();
-// Clear all selections and stop driver mode.
+// Clear all selections
 void clearSelection();
 // deal with selecting a droid
 void dealWithDroidSelect(DROID *psDroid, bool bDragBox);

--- a/src/hci.cpp
+++ b/src/hci.cpp
@@ -973,7 +973,7 @@ void intResetScreen(bool NoAnim)
 	}
 	SecondaryWindowUp = false;
 	intMode = INT_NORMAL;
-	//clearSel() sets IntRefreshPending = true by calling intRefreshScreen() but if we're doing this then we won't need to refresh - hopefully!
+	//clearSelelection() sets IntRefreshPending = true by calling intRefreshScreen() but if we're doing this then we won't need to refresh - hopefully!
 	IntRefreshPending = false;
 }
 
@@ -4735,7 +4735,7 @@ static STRUCTURE *intGotoNextStructureType(UDWORD structType)
 		{
 			if (psStruct != CurrentStruct)
 			{
-				clearSel();
+				clearSelection();
 				psStruct->selected = true;
 				CurrentStruct = psStruct;
 				Found = true;
@@ -4753,7 +4753,7 @@ static STRUCTURE *intGotoNextStructureType(UDWORD structType)
 			{
 				if (psStruct != CurrentStruct)
 				{
-					clearSel();
+					clearSelection();
 					psStruct->selected = true;
 					jsDebugSelected(psStruct);
 					CurrentStruct = psStruct;
@@ -4826,7 +4826,7 @@ DROID *intGotoNextDroidType(DROID *CurrDroid, DROID_TYPE droidType, bool AllowGr
 		{
 			if (psDroid != CurrentDroid)
 			{
-				clearSel();
+				clearSelection();
 				SelectDroid(psDroid);
 				CurrentDroid = psDroid;
 				Found = true;
@@ -4846,7 +4846,7 @@ DROID *intGotoNextDroidType(DROID *CurrDroid, DROID_TYPE droidType, bool AllowGr
 			{
 				if (psDroid != CurrentDroid)
 				{
-					clearSel();
+					clearSelection();
 					SelectDroid(psDroid);
 					CurrentDroid = psDroid;
 					Found = true;


### PR DESCRIPTION
This fixes https://github.com/Warzone2100/warzone2100/issues/1181.

Unfortunately the fix for the problem feels a lot like duct taping. I started refactoring the code multiple times, and reverted everything thinking I was going too far.

## Notes about refactors
- Function `clearSel` was removed and its implementation was moved to `clearSelection`, cause all `clearSelection` was doing, was calling `clearSel`:
https://github.com/Warzone2100/warzone2100/blob/0bdc6f2a955317153a6aff9635f44c694205c522/src/display.cpp#L2647-L2650
- `checkMouseLoc` was renamed to `findMouseDeliveryPoint`, and its implementation was changed so that it always returns a **delivery point** from **selectedPlayer**, which eliminates the need for checking this in multiple places like:
https://github.com/Warzone2100/warzone2100/blob/0bdc6f2a955317153a6aff9635f44c694205c522/src/display.cpp#L1918-L1922
and:
https://github.com/Warzone2100/warzone2100/blob/0bdc6f2a955317153a6aff9635f44c694205c522/src/display.cpp#L2184-L2188
