### PR TITLE
Loading performance improvements

### DIFF
--- a/lib/framework/frameresource.cpp
+++ b/lib/framework/frameresource.cpp
@@ -133,7 +133,7 @@ void resSetLoadCallback(RESLOAD_CALLBACK funcToCall)
 }
 
 /* do the callback for the resload display function */
-static inline void resDoResLoadCallback()
+void resDoResLoadCallback()
 {
 	if (resLoadCallback)
 	{

--- a/lib/framework/frameresource.h
+++ b/lib/framework/frameresource.h
@@ -78,6 +78,9 @@ struct RES_TYPE
 /** Set the function to call when loading files with resloadfile. */
 void resSetLoadCallback(RESLOAD_CALLBACK funcToCall);
 
+/* do the callback for the resload display function */
+void resDoResLoadCallback();
+
 /** Initialise the resource module. */
 bool resInitialise();
 

--- a/lib/framework/strres.cpp
+++ b/lib/framework/strres.cpp
@@ -108,6 +108,7 @@ bool strresLoad(STR_RES *psRes, const char *fileName)
 		debug(LOG_ERROR, "strresLoadFile: PHYSFS_openRead(\"%s\") failed with error: %s\n", fileName, WZ_PHYSFS_getLastError());
 		return false;
 	}
+	WZ_PHYSFS_SETBUFFER(input.input.physfsfile, 4096)//;
 
 	strres_set_extra(&input);
 	retval = (strres_parse(psRes) == 0);

--- a/lib/ivis_opengl/png_util.cpp
+++ b/lib/ivis_opengl/png_util.cpp
@@ -117,6 +117,7 @@ bool iV_loadImage_PNG(const char *fileName, iV_Image *image)
 	// Open file
 	PHYSFS_file *fileHandle = PHYSFS_openRead(fileName);
 	ASSERT_OR_RETURN(false, fileHandle != nullptr, "Could not open %s: %s", fileName, WZ_PHYSFS_getLastError());
+	WZ_PHYSFS_SETBUFFER(fileHandle, 4096)//;
 
 	// Read PNG header from file
 	readSize = WZ_PHYSFS_readBytes(fileHandle, PNGheader, PNG_BYTES_TO_CHECK);

--- a/lib/ivis_opengl/tex.cpp
+++ b/lib/ivis_opengl/tex.cpp
@@ -19,6 +19,7 @@
 */
 
 #include "lib/framework/frame.h"
+#include "lib/framework/frameresource.h"
 
 #include "lib/ivis_opengl/ivisdef.h"
 #include "lib/ivis_opengl/piestate.h"
@@ -259,7 +260,9 @@ int iV_GetTexture(const char *filename, bool compression, int maxWidth /*= -1*/,
 		return -1;
 	}
 	scaleImageMaxSize(&sSprite, maxWidth, maxHeight);
-	return pie_AddTexPage(&sSprite, path.c_str(), compression);
+	int page = pie_AddTexPage(&sSprite, path.c_str(), compression);
+	resDoResLoadCallback(); // ensure loading screen doesn't freeze when loading large images
+	return page;
 }
 
 bool replaceTexture(const WzString &oldfile, const WzString &newfile)

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -802,6 +802,12 @@ bool mapLoad(char const *filename, bool preview)
 		goto failure;
 	}
 
+	if (!preview)
+	{
+		//preload the terrain textures
+		loadTerrainTextures();
+	}
+
 	//load in the map data itself
 
 	/* Load in the map data */
@@ -898,6 +904,12 @@ bool mapLoadFromScriptData(ScriptMapData const &data, bool preview)
 	if (!mapLoadGroundTypes())
 	{
 		return false;
+	}
+
+	if (!preview)
+	{
+		//preload the terrain textures
+		loadTerrainTextures();
 	}
 
 	//load in the map data itself

--- a/src/terrain.cpp
+++ b/src/terrain.cpp
@@ -132,6 +132,8 @@ GLsizei dreCount;
 /// Are we actually drawing something using the DrawRangeElements functions?
 bool drawRangeElementsStarted = false;
 
+#define MIN_TERRAIN_TEXTURE_SIZE 512
+
 /// Pass all remaining triangles to OpenGL
 template<typename PSO>
 static void finishDrawRangeElements()
@@ -565,6 +567,21 @@ void markTileDirty(int i, int j)
 		{
 			sectors[(x - 1)*ySectors + (y - 1)].dirty = true;
 		}
+	}
+}
+
+void loadTerrainTextures()
+{
+	ASSERT_OR_RETURN(, psGroundTypes, "Ground type was not set, no textures will be seen.");
+
+	int32_t maxGfxTextureSize = gfx_api::context::get().get_context_value(gfx_api::context::context_value::MAX_TEXTURE_SIZE);
+	int maxTerrainTextureSize = std::max(std::min({getTextureSize(), maxGfxTextureSize}), MIN_TERRAIN_TEXTURE_SIZE);
+
+	// for each terrain layer
+	for (int layer = 0; layer < numGroundTypes; layer++)
+	{
+		// pre-load the texture
+		iV_GetTexture(psGroundTypes[layer].textureName, true, maxTerrainTextureSize, maxTerrainTextureSize);
 	}
 }
 
@@ -1106,8 +1123,6 @@ static void drawDepthOnly(const glm::mat4 &ModelViewProjection, const glm::vec4 
 	gfx_api::TerrainDepth::get().unbind_vertex_buffers(geometryVBO);
 	gfx_api::context::get().unbind_index_buffer(*geometryIndexVBO);
 }
-
-#define MIN_TERRAIN_TEXTURE_SIZE 512
 
 static void drawTerrainLayers(const glm::mat4 &ModelViewProjection, const glm::vec4 &paramsXLight, const glm::vec4 &paramsYLight, const glm::mat4 &textureMatrix)
 {

--- a/src/terrain.h
+++ b/src/terrain.h
@@ -24,6 +24,8 @@
 #include <glm/fwd.hpp>
 #include "lib/ivis_opengl/pietypes.h"
 
+void loadTerrainTextures();
+
 bool initTerrain();
 void shutdownTerrain();
 


### PR DESCRIPTION
- Load terrain textures earlier during game init
   - Load the terrain textures much earlier, around the same time that other resources are being loaded (and the loading screen / progress is displayed).
   - This is particularly important with the new, higher-res terrain textures, which can take noticeably longer to load. (Previously, they were effectively loaded after the game had "started", when the first attempt to draw each terrain layer was made.)
- Use buffered file reading in a few places