### PR TITLE
Use module build points for module construction

### DIFF
--- a/data/base/stats/structure.json
+++ b/data/base/stats/structure.json
@@ -415,7 +415,7 @@
     "A0FacMod1": {
         "armour": 10,
         "breadth": 3,
-        "buildPoints": 250,
+        "buildPoints": 500,
         "buildPower": 100,
         "ecmID": "ZNULLECM",
         "height": 2,
@@ -504,7 +504,7 @@
     "A0PowMod1": {
         "armour": 10,
         "breadth": 2,
-        "buildPoints": 250,
+        "buildPoints": 500,
         "ecmID": "ZNULLECM",
         "height": 2,
         "hitpoints": 500,
@@ -595,7 +595,7 @@
     "A0ResearchModule1": {
         "armour": 10,
         "breadth": 2,
-        "buildPoints": 250,
+        "buildPoints": 500,
         "buildPower": 100,
         "ecmID": "ZNULLECM",
         "height": 2,

--- a/data/mp/stats/structure.json
+++ b/data/mp/stats/structure.json
@@ -334,7 +334,7 @@
     "A0FacMod1": {
         "armour": 10,
         "breadth": 3,
-        "buildPoints": 250,
+        "buildPoints": 500,
         "buildPower": 100,
         "height": 2,
         "hitpoints": 500,
@@ -458,7 +458,7 @@
     "A0PowMod1": {
         "armour": 10,
         "breadth": 2,
-        "buildPoints": 250,
+        "buildPoints": 500,
         "height": 2,
         "hitpoints": 1000,
         "id": "A0PowMod1",
@@ -549,7 +549,7 @@
     "A0ResearchModule1": {
         "armour": 10,
         "breadth": 2,
-        "buildPoints": 250,
+        "buildPoints": 500,
         "buildPower": 100,
         "height": 2,
         "hitpoints": 800,

--- a/src/display3d.cpp
+++ b/src/display3d.cpp
@@ -2765,21 +2765,14 @@ static void drawStructureHealth(STRUCTURE *psStruct)
 /// draw the construction bar for the specified structure
 static void drawStructureBuildProgress(STRUCTURE *psStruct)
 {
-	SDWORD		scrX, scrY, scrR;
-	UDWORD		health, width;
-	UDWORD		scale;
-
-	scale = MAX(psStruct->pStructureType->baseWidth, psStruct->pStructureType->baseBreadth);
-	width = scale * 20;
-	scrX = psStruct->sDisplay.screenX;
-	scrY = psStruct->sDisplay.screenY + (scale * 10);
-	scrR = width;
-	health =  PERCENT(psStruct->currentBuildPts , psStruct->pStructureType->buildPoints);
-	health = (((width * 10000) / 100) * health) / 10000;
-	health *= 2;
+	auto scale = MAX(psStruct->pStructureType->baseWidth, psStruct->pStructureType->baseBreadth);
+	auto scrX = psStruct->sDisplay.screenX;
+	auto scrY = psStruct->sDisplay.screenY + (scale * 10);
+	auto scrR = scale * 20;
+	auto progress = scale * 40 * structureCompletionProgress(*psStruct);
 	pie_BoxFill(scrX - scrR - 1, scrY - 1 + 5, scrX + scrR + 1, scrY + 3 + 5, WZCOL_RELOAD_BACKGROUND);
-	pie_BoxFill(scrX - scrR, scrY + 5, scrX - scrR + health, scrY + 1 + 5, WZCOL_HEALTH_MEDIUM_SHADOW);
-	pie_BoxFill(scrX - scrR, scrY + 1 + 5, scrX - scrR + health, scrY + 2 + 5, WZCOL_HEALTH_MEDIUM);
+	pie_BoxFill(scrX - scrR, scrY + 5, scrX - scrR + progress, scrY + 1 + 5, WZCOL_HEALTH_MEDIUM_SHADOW);
+	pie_BoxFill(scrX - scrR, scrY + 1 + 5, scrX - scrR + progress, scrY + 2 + 5, WZCOL_HEALTH_MEDIUM);
 }
 
 /// Draw the health of structures and show enemy structures being targetted

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -5329,7 +5329,7 @@ static bool loadSaveStructure2(const char *pFileName, STRUCTURE **ppList)
 			break;
 		}
 		psStructure->body = healthValue(ini, structureBody(psStructure));
-		psStructure->currentBuildPts = ini.value("currentBuildPts", psStructure->pStructureType->buildPoints).toInt();
+		psStructure->currentBuildPts = ini.value("currentBuildPts", structureBuildPointsToCompletion(*psStructure)).toInt();
 		if (psStructure->status == SS_BUILT)
 		{
 			switch (psStructure->pStructureType->type)

--- a/src/intdisplay.cpp
+++ b/src/intdisplay.cpp
@@ -209,7 +209,7 @@ void intUpdateProgressBar(WIDGET *psWidget, W_CONTEXT *psContext)
 				//show progress of build
 				if (Structure->currentBuildPts != 0)
 				{
-					formatTime(BarGraph, Structure->currentBuildPts, Structure->pStructureType->buildPoints, Structure->lastBuildRate, _("Build Progress"));
+					formatTime(BarGraph, Structure->currentBuildPts, structureBuildPointsToCompletion(*Structure), Structure->lastBuildRate, _("Build Progress"));
 				}
 				else
 				{

--- a/src/mission.cpp
+++ b/src/mission.cpp
@@ -726,7 +726,7 @@ static void saveMissionData()
 				    && psStructBeingBuilt == psStruct)
 				{
 					// just give it all its build points
-					structureBuild(psStruct, nullptr, psStruct->pStructureType->buildPoints);
+					structureBuild(psStruct, nullptr, structureBuildPointsToCompletion(*psStruct));
 					//don't bother looking for any other droids working on it
 					break;
 				}

--- a/src/multistruct.cpp
+++ b/src/multistruct.cpp
@@ -103,7 +103,7 @@ bool recvBuildFinished(NETQUEUE queue)
 	if (psStruct)
 	{
 		// make it complete.
-		psStruct->currentBuildPts = psStruct->pStructureType->buildPoints + 1;
+		psStruct->currentBuildPts = structureBuildPointsToCompletion(*psStruct) + 1;
 
 		if (psStruct->status != SS_BUILT)
 		{

--- a/src/qtscriptdebug.cpp
+++ b/src/qtscriptdebug.cpp
@@ -774,7 +774,7 @@ void ScriptDebugger::selected(const BASE_OBJECT *psObj)
 		setPair(row, selectedModel, "Foundation depth", QString::number(psStruct->foundationDepth));
 		setPair(row, selectedModel, "Capacity", QString::number(psStruct->capacity));
 		setPair(row, selectedModel, "^Type", QString::number(psStruct->pStructureType->type));
-		setPair(row, selectedModel, "^Build points", QString::number(psStruct->pStructureType->buildPoints));
+		setPair(row, selectedModel, "^Build points", QString::number(structureBuildPointsToCompletion(*psStruct)));
 		setPair(row, selectedModel, "^Power points", QString::number(psStruct->pStructureType->powerToBuild));
 		setPair(row, selectedModel, "^Height", QString::number(psStruct->pStructureType->height));
 		setPair(row, selectedModel, componentToString("ECM", psStruct->pStructureType->pECM, psObj->player));

--- a/src/structure.h
+++ b/src/structure.h
@@ -97,6 +97,8 @@ void structureDemolish(STRUCTURE *psStructure, DROID *psDroid, int buildPoints);
 void structureRepair(STRUCTURE *psStruct, DROID *psDroid, int buildRate);
 /* Set the type of droid for a factory to build */
 bool structSetManufacture(STRUCTURE *psStruct, DROID_TEMPLATE *psTempl, QUEUE_MODE mode);
+uint32_t structureBuildPointsToCompletion(const STRUCTURE & structure);
+float structureCompletionProgress(const STRUCTURE & structure);
 
 //temp test function for creating structures at the start of the game
 void createTestStructures();


### PR DESCRIPTION
This is a fix for https://github.com/Warzone2100/warzone2100/issues/494.

~~I marked as WIP because we need to figure out what to do with the game balance.~~

The current setting for modules' build points is 250, but this value was never used. The used value was the one from the parent structure, which is 500.

If we keep the current settings, after this PR gets merged the time for building modules will drop by half. Which has a small impact in game balance.

The values that would need to be changed are:
- **MP** Factory module build points: https://github.com/Warzone2100/warzone2100/blob/267412911df889b0246fb936772ea57ce056b2ad/data/mp/stats/structure.json#L337
- **MP** Power module build points: https://github.com/Warzone2100/warzone2100/blob/267412911df889b0246fb936772ea57ce056b2ad/data/mp/stats/structure.json#L461
- **MP** Research module build points:
https://github.com/Warzone2100/warzone2100/blob/267412911df889b0246fb936772ea57ce056b2ad/data/mp/stats/structure.json#L552
- **Base** Factory module build points: https://github.com/Warzone2100/warzone2100/blob/267412911df889b0246fb936772ea57ce056b2ad/data/base/stats/structure.json#L418
- **MP** Power module build points: https://github.com/Warzone2100/warzone2100/blob/267412911df889b0246fb936772ea57ce056b2ad/data/base/stats/structure.json#L507
- **MP** Research module build points:
https://github.com/Warzone2100/warzone2100/blob/267412911df889b0246fb936772ea57ce056b2ad/data/base/stats/structure.json#L598