### PR TITLE
Add Hotkey to rotate building during placement

### DIFF
--- a/src/display3d.cpp
+++ b/src/display3d.cpp
@@ -1725,7 +1725,7 @@ void displayBlueprints(const glm::mat4 &viewMatrix)
 		if (STRUCTURE_STATS *stats = castStructureStats(sBuildDetails.psStats))
 		{
 			// it's a building
-			uint16_t direction = snapDirection(player.r.y);
+			uint16_t direction = getBuildingDirection();
 			if (wallDrag.status == DRAG_PLACING || wallDrag.status == DRAG_DRAGGING)
 			{
 				drawLineBuild(stats, wallDrag.pos, wallDrag.pos2, direction, state);

--- a/src/edit3d.h
+++ b/src/edit3d.h
@@ -36,6 +36,8 @@ bool found3DBuildLocTwo(Vector2i &pos, Vector2i &pos2);
 void init3DBuilding(BASE_STATS *psStats, BUILDCALLBACK CallBack, void *UserData);
 void kill3DBuilding();
 bool process3DBuilding();
+void incrementBuildingDirection(uint16_t amount);
+uint16_t getBuildingDirection();
 
 void adjustTileHeight(MAPTILE *psTile, SDWORD adjust);
 void raiseTile(int tile3dX, int tile3dY);
@@ -63,10 +65,11 @@ extern HIGHLIGHT	buildSite;
 struct BUILDDETAILS
 {
 	BUILDCALLBACK	CallBack;
-	void 			*UserData;  //this holds the OBJECT_POSITION pointer for a Deliv Point
-	UDWORD			x, y;
-	UDWORD			width, height;
-	BASE_STATS		*psStats;
+	void         	*UserData;  //this holds the OBJECT_POSITION pointer for a Deliv Point
+	UDWORD       	x, y;
+	UDWORD       	width, height;
+	BASE_STATS   	*psStats;
+	uint16_t     	directionShift;
 };
 
 extern BUILDDETAILS	sBuildDetails;

--- a/src/hci.cpp
+++ b/src/hci.cpp
@@ -1438,11 +1438,11 @@ INT_RETVAL intRunWidgets()
 					&& intNumSelectedDroids(DROID_CYBORG_CONSTRUCT) == 0
 					&& psObjSelected != nullptr && isConstructionDroid(psObjSelected))
 				{
-					orderDroidStatsTwoLocDir((DROID *)psObjSelected, DORDER_LINEBUILD, (STRUCTURE_STATS *)psPositionStats, pos.x, pos.y, pos2.x, pos2.y, player.r.y, ModeQueue);
+					orderDroidStatsTwoLocDir((DROID *)psObjSelected, DORDER_LINEBUILD, (STRUCTURE_STATS *)psPositionStats, pos.x, pos.y, pos2.x, pos2.y, getBuildingDirection(), ModeQueue);
 				}
 				else
 				{
-					orderSelectedStatsTwoLocDir(selectedPlayer, DORDER_LINEBUILD, (STRUCTURE_STATS *)psPositionStats, pos.x, pos.y, pos2.x, pos2.y, player.r.y, ctrlShiftDown());
+					orderSelectedStatsTwoLocDir(selectedPlayer, DORDER_LINEBUILD, (STRUCTURE_STATS *)psPositionStats, pos.x, pos.y, pos2.x, pos2.y, getBuildingDirection(), ctrlShiftDown());
 				}
 				if (!quickQueueMode)
 				{
@@ -1473,11 +1473,11 @@ INT_RETVAL intRunWidgets()
 						&& intNumSelectedDroids(DROID_CYBORG_CONSTRUCT) == 0
 						&& psObjSelected != nullptr)
 					{
-						orderDroidStatsLocDir((DROID *)psObjSelected, DORDER_BUILD, (STRUCTURE_STATS *)psPositionStats, pos.x, pos.y, player.r.y, ModeQueue);
+						orderDroidStatsLocDir((DROID *)psObjSelected, DORDER_BUILD, (STRUCTURE_STATS *)psPositionStats, pos.x, pos.y, getBuildingDirection(), ModeQueue);
 					}
 					else
 					{
-						orderSelectedStatsLocDir(selectedPlayer, DORDER_BUILD, (STRUCTURE_STATS *)psPositionStats, pos.x, pos.y, player.r.y, ctrlShiftDown());
+						orderSelectedStatsLocDir(selectedPlayer, DORDER_BUILD, (STRUCTURE_STATS *)psPositionStats, pos.x, pos.y, getBuildingDirection(), ctrlShiftDown());
 					}
 				}
 

--- a/src/keybind.cpp
+++ b/src/keybind.cpp
@@ -971,6 +971,20 @@ void	kf_RotateRight()
 }
 
 // --------------------------------------------------------------------------
+/* Rotate editing building direction clockwise */
+void kf_RotateBuildingCW()
+{
+	incrementBuildingDirection(DEG(-90));
+}
+
+// --------------------------------------------------------------------------
+/* Rotate editing building direction anticlockwise */
+void kf_RotateBuildingACW()
+{
+	incrementBuildingDirection(DEG(90));
+}
+
+// --------------------------------------------------------------------------
 /* Pitches camera back */
 void	kf_PitchBack()
 {

--- a/src/keybind.h
+++ b/src/keybind.h
@@ -65,6 +65,8 @@ void kf_ShrinkScreen();
 void kf_ExpandScreen();
 void kf_RotateLeft();
 void kf_RotateRight();
+void kf_RotateBuildingCW();
+void kf_RotateBuildingACW();
 void kf_PitchBack();
 void kf_PitchForward();
 void kf_ResetPitch();

--- a/src/keymap.cpp
+++ b/src/keymap.cpp
@@ -241,6 +241,8 @@ static KeyMapSaveTable const keyMapSaveTable(
 	{kf_ToggleOverlays, "ToggleOverlays"},
 	{kf_ToggleConsoleDrop, "ToggleConsoleDrop"},
 	{kf_ToggleTeamChat, "ToggleTeamChat"},
+	{kf_RotateBuildingCW, "RotateBuildingClockwise"},
+	{kf_RotateBuildingACW, "RotateBuildingAnticlockwise"},
 	// **********************************
 	// IN GAME MAPPINGS - Single key presses - ALL __DEBUG keymappings will be removed for master
 	{kf_CentreOnBase, "CentreOnBase"},
@@ -491,6 +493,8 @@ void keyInitMappings(bool bForceDefaults)
 	didAdd = keyAddDefaultMapping(KEYMAP_ASSIGNABLE, KEY_IGNORE, KEY_TAB,               KEYMAP_PRESSED, kf_ToggleOverlays,          N_("Toggle Overlays"), bForceDefaults) || didAdd;
 	didAdd = keyAddDefaultMapping(KEYMAP_ASSIGNABLE, KEY_IGNORE, KEY_BACKQUOTE,         KEYMAP_PRESSED, kf_ToggleConsoleDrop,       N_("Toggle Console History "), bForceDefaults) || didAdd;
 	didAdd = keyAddDefaultMapping(KEYMAP_ASSIGNABLE, KEY_LCTRL,  KEY_BACKQUOTE,         KEYMAP_PRESSED, kf_ToggleTeamChat,          N_("Toggle Team Chat History"), bForceDefaults) || didAdd;
+	didAdd = keyAddDefaultMapping(KEYMAP_ASSIGNABLE, KEY_IGNORE, (KEY_CODE)KEY_MAXSCAN, KEYMAP_PRESSED, kf_RotateBuildingCW,        N_("Rotate Building Clockwise"), bForceDefaults) || didAdd;
+	didAdd = keyAddDefaultMapping(KEYMAP_ASSIGNABLE, KEY_IGNORE, (KEY_CODE)KEY_MAXSCAN, KEYMAP_PRESSED, kf_RotateBuildingACW,       N_("Rotate Building Anticlockwise"), bForceDefaults) || didAdd;
 	//                                **********************************
 	// IN GAME MAPPINGS - Single key presses - ALL __DEBUG keymappings will be removed for master
 	didAdd = keyAddDefaultMapping(KEYMAP_ASSIGNABLE, KEY_IGNORE, KEY_B,      KEYMAP_PRESSED, kf_CentreOnBase,          N_("Center View on HQ"), bForceDefaults) || didAdd;


### PR DESCRIPTION
I didn't add a default hotkey, cause it is getting hard to find some sequence that is not yet assigned, so I think it is better if the players define their own.

fixes #1165 