### PR TITLE
Add indicator for unused derricks

### DIFF
--- a/src/intdisplay.cpp
+++ b/src/intdisplay.cpp
@@ -663,25 +663,34 @@ void intDisplayPowerBar(WIDGET *psWidget, UDWORD xOffset, UDWORD yOffset)
 
 	imageDrawBatch.draw(true);
 
-	PIELIGHT colour;
-	if (Avail < 0)
+	PIELIGHT colour = WZCOL_TEXT_BRIGHT;
+	auto unusedDerricks = countPlayerUnusedDerricks();
+
+	auto showNeedMessage = true;
+	if (unusedDerricks > 0)
 	{
-		const char *need = _("Need more resources!");
-		cache.wzNeedText.setText(need, font_small);
-		if ((realTime / 1250) % 5 == 0)
-		{
-			cache.wzNeedText.render(iX + 102, iY - 1, WZCOL_BLACK);
-		}
-		else
-		{
-			cache.wzNeedText.render(iX + 102, iY - 1, WZCOL_RED);
-		}
+		char unusedText[50];
+		ssprintf(unusedText, _("%d derrick(s) inactive"), unusedDerricks);
+		cache.wzNeedText.setText(unusedText, font_small);
+	}
+	else if (Avail < 0)
+	{
+		cache.wzNeedText.setText(_("Need more resources!"), font_small);
 		colour = WZCOL_RED;
 	}
 	else
 	{
-		colour = WZCOL_TEXT_BRIGHT;
+		showNeedMessage = false;
 	}
+
+	if (showNeedMessage)
+	{
+		auto needTextWidth = cache.wzNeedText.width();
+		auto textX = iX + (BarGraph->width() - needTextWidth) / 2;
+		pie_UniTransBoxFill(textX - 3, y0 + 1, textX + needTextWidth + 3, y0 + BarGraph->height() - 1, WZCOL_TRANSPARENT_BOX);
+		cache.wzNeedText.render(textX, iY - 1, (realTime / 1250) % 5 ? WZCOL_WHITE: WZCOL_RED);
+	}
+
 	// draw text value
 	cache.wzText.render(iX, iY, colour);
 }

--- a/src/structure.cpp
+++ b/src/structure.cpp
@@ -5153,6 +5153,22 @@ void checkForResExtractors(STRUCTURE *psBuilding)
 	}
 }
 
+uint16_t countPlayerUnusedDerricks()
+{
+	uint16_t total = 0;
+
+	for (STRUCTURE *psStruct = apsExtractorLists[selectedPlayer]; psStruct; psStruct = psStruct->psNext)
+	{
+		if (psStruct->status == SS_BUILT && psStruct->pStructureType->type == REF_RESOURCE_EXTRACTOR)
+		{
+			if (!psStruct->pFunctionality->resourceExtractor.psPowerGen) {
+				total++;
+			}
+		}
+	}
+
+	return total;
+}
 
 /*Looks through the list of structures to see if there are any Power Gens
 with available slots for the new Res Ext*/

--- a/src/structure.h
+++ b/src/structure.h
@@ -205,6 +205,8 @@ void buildingComplete(STRUCTURE *psBuilding);
 void checkForResExtractors(STRUCTURE *psPowerGen);
 void checkForPowerGen(STRUCTURE *psPowerGen);
 
+uint16_t countPlayerUnusedDerricks();
+
 // Set the command droid that factory production should go to struct _command_droid;
 void assignFactoryCommandDroid(STRUCTURE *psStruct, struct DROID *psCommander);
 


### PR DESCRIPTION
Fixes https://github.com/Warzone2100/warzone2100/issues/1163.

The code that shows the message "Need more resources" when the player has negative energy was adapted, to display the message "X derrick(s) inactive".

A background rectangle was added to give a bit more contrast, otherwise the text wouldn't be very readable.

Preview: https://youtu.be/cHY0GZBOvLI