### PR TITLE
Tweak: Disengage the dragging since it stops menu input

### DIFF
--- a/src/display.cpp
+++ b/src/display.cpp
@@ -361,7 +361,7 @@ void processInput()
 
 	if (InGameOpUp || isInGamePopupUp)
 	{
-		dragBox3D.status = DRAG_RELEASED;	// disengage the dragging since it stops menu input
+		dragBox3D.status = DRAG_INACTIVE;	// disengage the dragging since it stops menu input
 	}
 
 	if (CoordInBuild(mouseX(), mouseY()))


### PR DESCRIPTION
Use `DRAG_INACTIVE` instead of `DRAG_RELEASED` to avoid a performance issue when in-game options / menus are displayed.