### PR TITLE
Turn off sensor range cheat on game init.

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1285,6 +1285,7 @@ bool stageThreeInitialise()
 	// Re-inititialise some static variables.
 
 	bInTutorial = false;
+	rangeOnScreen = false;
 
 	if (fromSave && ActivityManager::instance().getCurrentGameMode() == ActivitySink::GameMode::CHALLENGE)
 	{


### PR DESCRIPTION
Fixes #1222. Not sure if there is a better location for this.

Basically, the global that makes the range explosion effect work never gets reset so it can persist across game states, reloading saves (although, because these are indeed effects, they get saved so they will reappear momentarily if there are selected objects on such saves), multiplayer games if debug stuff is available, and so on.