### PR TITLE
Add configuration directory link - redux

### DIFF
--- a/lib/framework/cocoa_wrapper.h
+++ b/lib/framework/cocoa_wrapper.h
@@ -38,6 +38,7 @@ int cocoaShowAlert(const char *message, const char *information, unsigned style,
                    const char *buttonTitles, ...) __attribute__((sentinel));
 
 bool cocoaSelectFileInFinder(const char *filename);
+bool cocoaSelectFolderInFinder(const char* path);
 bool cocoaOpenURL(const char *url);
 bool cocoaOpenUserCrashReportFolder();
 

--- a/lib/framework/cocoa_wrapper.mm
+++ b/lib/framework/cocoa_wrapper.mm
@@ -71,6 +71,18 @@ bool cocoaSelectFileInFinder(const char *filename)
     return success;
 }
 
+bool cocoaSelectFolderInFinder(const char* path)
+{
+	if (path == nullptr) return false;
+	BOOL success = NO;
+	@autoreleasepool {
+		NSURL *pathURL = [NSURL fileURLWithPath:nsstringify(path) isDirectory:YES];
+		if (pathURL == nil) return false;
+		success = [[NSWorkspace sharedWorkspace] openURL:pathURL];
+	}
+	return success;
+}
+
 bool cocoaOpenURL(const char *url)
 {
     assert(url != nullptr);

--- a/src/frontend.cpp
+++ b/src/frontend.cpp
@@ -622,6 +622,7 @@ void startOptionsMenu()
 	addTextButton(FRONTEND_MOUSEOPTIONS, FRONTEND_POS6X, FRONTEND_POS6Y, _("Mouse Options"), WBUT_TXTCENTRE);
 	addTextButton(FRONTEND_KEYMAP,		FRONTEND_POS7X, FRONTEND_POS7Y, _("Key Mappings"), WBUT_TXTCENTRE);
 	addMultiBut(psWScreen, FRONTEND_BOTFORM, FRONTEND_QUIT, 10, 10, 30, 29, P_("menu", "Return"), IMAGE_RETURN, IMAGE_RETURN_HI, IMAGE_RETURN_HI);
+	addSmallTextButton(FRONTEND_HYPERLINK, FRONTEND_POS9X, FRONTEND_POS9Y, _("Open Configuration Directory"), 0);
 }
 
 bool runOptionsMenu()
@@ -651,6 +652,22 @@ bool runOptionsMenu()
 		break;
 	case FRONTEND_QUIT:
 		changeTitleMode(TITLE);
+		break;
+	case FRONTEND_HYPERLINK:
+		if (!openFolderInDefaultFileManager(PHYSFS_getWriteDir()))
+		{
+			// Failed to open write dir in default filesystem browser
+			std::string configErrorMessage = _("Failed to open configuration directory in system default file browser.");
+			configErrorMessage += "\n\n";
+			configErrorMessage += _("Configuration directory is reported as:");
+			configErrorMessage += "\n";
+			configErrorMessage += PHYSFS_getWriteDir();
+			configErrorMessage += "\n\n";
+			configErrorMessage += _("If running inside a container / isolated environment, this may differ from the actual path on disk.");
+			configErrorMessage += "\n";
+			configErrorMessage += _("Please see the documentation for more information on how to locate it manually.");
+			wzDisplayDialog(Dialog_Warning, _("Failed to open configuration directory"), configErrorMessage.c_str());
+		}
 		break;
 	default:
 		break;

--- a/src/urlhelpers.h
+++ b/src/urlhelpers.h
@@ -26,4 +26,6 @@ bool openURLInBrowser(char const *url);
 std::string urlEncode(const char* urlFragment);
 bool urlHasHTTPorHTTPSPrefix(char const *url);
 
+bool openFolderInDefaultFileManager(const char* path);
+
 #endif // __INCLUDED_SRC_URL_HELPERS_H__


### PR DESCRIPTION
An adjusted version of #1227.

- Does not use `system` except as last-resort fallback on *nix.
- Link changed to "Open Configuration Directory".
- Attempts to open the configuration directory, and only if that fails does it display a messagebox containing the `PHYSFS_getWriteDir()` (along with an explanation of how it could differ when run inside a container / isolated environment).