### PR TITLE
Delete dead code for message macros

### DIFF
--- a/src/configuration.cpp
+++ b/src/configuration.cpp
@@ -183,15 +183,6 @@ bool loadConfig()
 	game.base = ini.value("base", CAMP_BASE).toInt();
 	game.alliance = ini.value("alliance", NO_ALLIANCES).toInt();
 	game.scavengers = ini.value("scavengers", false).toBool();
-	memset(&ingame.phrases, 0, sizeof(ingame.phrases));
-	for (int i = 1; i < 5; i++)
-	{
-		QString key("phrase" + QString::number(i));
-		if (ini.contains(key))
-		{
-			sstrcpy(ingame.phrases[i], ini.value(key).toString().toUtf8().constData());
-		}
-	}
 	bEnemyAllyRadarColor = ini.value("radarObjectMode").toBool();
 	radarDrawMode = (RADAR_DRAW_MODE)ini.value("radarTerrainMode", RADAR_MODE_DEFAULT).toInt();
 	radarDrawMode = (RADAR_DRAW_MODE)MIN(NUM_RADAR_MODES - 1, radarDrawMode); // restrict to allowed values

--- a/src/keybind.cpp
+++ b/src/keybind.cpp
@@ -92,7 +92,6 @@ extern char	ScreenDumpPath[];
 
 bool	bMovePause = false;
 bool		bAllowOtherKeyPresses = true;
-char	sTextToSend[MAX_CONSOLE_STRING_LENGTH];
 char	beaconMsg[MAX_PLAYERS][MAX_CONSOLE_STRING_LENGTH];		//beacon msg for each player
 
 static STRUCTURE	*psOldRE = nullptr;
@@ -2019,7 +2018,6 @@ void kf_SendTeamMessage()
 	if (bAllowOtherKeyPresses && !gamePaused())  // just starting.
 	{
 		bAllowOtherKeyPresses = false;
-		sstrcpy(sTextToSend, "");
 		sstrcpy(sCurrentConsoleText, "");			//for beacons
 		inputClearBuffer();
 		chatDialog(CHAT_TEAM);						// throw up the dialog
@@ -2041,7 +2039,6 @@ void kf_SendGlobalMessage()
 	if (bAllowOtherKeyPresses && !gamePaused())  // just starting.
 	{
 		bAllowOtherKeyPresses = false;
-		sstrcpy(sTextToSend, "");
 		sstrcpy(sCurrentConsoleText, "");			//for beacons
 		inputClearBuffer();
 		chatDialog(CHAT_GLOB);						// throw up the dialog
@@ -2049,73 +2046,6 @@ void kf_SendGlobalMessage()
 	else
 	{
 		bAllowOtherKeyPresses = true;
-	}
-
-	// macro store stuff
-	if (keyPressed(KEY_F1))
-	{
-		if (keyDown(KEY_LCTRL))
-		{
-			sstrcpy(ingame.phrases[0], sTextToSend);
-		}
-		else
-		{
-			sstrcpy(sTextToSend, ingame.phrases[0]);
-			sendTextMessage(sTextToSend, false);
-			return;
-		}
-	}
-	if (keyPressed(KEY_F2))
-	{
-		if (keyDown(KEY_LCTRL))
-		{
-			sstrcpy(ingame.phrases[1], sTextToSend);
-		}
-		else
-		{
-			sstrcpy(sTextToSend, ingame.phrases[1]);
-			sendTextMessage(sTextToSend, false);
-			return;
-		}
-	}
-	if (keyPressed(KEY_F3))
-	{
-		if (keyDown(KEY_LCTRL))
-		{
-			sstrcpy(ingame.phrases[2], sTextToSend);
-		}
-		else
-		{
-			sstrcpy(sTextToSend, ingame.phrases[2]);
-			sendTextMessage(sTextToSend, false);
-			return;
-		}
-	}
-	if (keyPressed(KEY_F4))
-	{
-		if (keyDown(KEY_LCTRL))
-		{
-			sstrcpy(ingame.phrases[3], sTextToSend);
-		}
-		else
-		{
-			sstrcpy(sTextToSend, ingame.phrases[3]);
-			sendTextMessage(sTextToSend, false);
-			return;
-		}
-	}
-	if (keyPressed(KEY_F5))
-	{
-		if (keyDown(KEY_LCTRL))
-		{
-			sstrcpy(ingame.phrases[4], sTextToSend);
-		}
-		else
-		{
-			sstrcpy(sTextToSend, ingame.phrases[4]);
-			sendTextMessage(sTextToSend, false);
-			return;
-		}
 	}
 }
 

--- a/src/keybind.h
+++ b/src/keybind.h
@@ -249,9 +249,6 @@ void kf_ToggleReopenBuildMenu();
 void kf_ToggleShowGateways();
 void kf_ToggleShowPath();
 
-// dirty but necessary
-extern char sTextToSend[MAX_CONSOLE_STRING_LENGTH];
-
 void kf_FaceNorth();
 void kf_FaceSouth();
 void kf_FaceEast();

--- a/src/multiplay.h
+++ b/src/multiplay.h
@@ -100,7 +100,6 @@ struct MULTIPLAYERINGAME
 #define MPFLAGS_FORCELIMITS	0x20  		///< Flag to force structure limits
 #define MPFLAGS_MAX		0x3f
 	SDWORD		skScores[MAX_PLAYERS][2];			// score+kills for local skirmish players.
-	char		phrases[5][255];					// 5 favourite text messages.
 };
 
 enum STRUCTURE_INFO


### PR DESCRIPTION
Message macros is a very old feature that allowed players to define
message macros. To define a macro, the player would type the message in
the message input, then press CTRL+F[1..5]. To use the defined macro the
player would open the message input and press F[1..5]. The message
defined in the macro would be copied to the message input.

This feature doesn't work anymore since the commit
e252b9a460829f03ea0557330de1789fd5f4ee30, which introduced the chat box.
What causes it not to work anymore is:
1. The code that handles macro's usage is not reachable anymore. The
aforementioned commit removed the call to `kf_SendTextMessage` in
display.cpp. That call was responsible for processing the macro-related
key presses. This function is now called `kf_SendGlobalMessage` and is
accessible only through the user-defined key mapping for sending
messages globally.
2. The message typed in the chat box is not copied to the global
variable `sTextToSend`, and vice-versa.