### PR TITLE
Improve droid transfer function.

### DIFF
--- a/src/droid.h
+++ b/src/droid.h
@@ -273,7 +273,7 @@ bool cbSensorDroid(const DROID *psDroid);
 bool standardSensorDroid(const DROID *psDroid);
 
 // give a droid from one player to another - used in Electronic Warfare and multiplayer
- DROID *giftSingleDroid(DROID *psD, UDWORD to);
+ DROID *giftSingleDroid(DROID *psD, UDWORD to, bool electronic = false);
 
 /// Calculates the electronic resistance of a droid based on its experience level
 SWORD droidResistance(const DROID *psDroid);

--- a/src/multigifts.cpp
+++ b/src/multigifts.cpp
@@ -256,7 +256,7 @@ static void recvGiftDroids(uint8_t from, uint8_t to, uint32_t droidID)
 	if (psDroid)
 	{
 		syncDebugDroid(psDroid, '<');
-		giftSingleDroid(psDroid, to);
+		giftSingleDroid(psDroid, to, false);
 		syncDebugDroid(psDroid, '>');
 		if (to == selectedPlayer)
 		{

--- a/src/structure.cpp
+++ b/src/structure.cpp
@@ -5726,7 +5726,7 @@ bool electronicDamage(BASE_OBJECT *psTarget, UDWORD damage, UBYTE attackPlayer)
 						addEffect(&pos, EFFECT_EXPLOSION, EXPLOSION_TYPE_FLAMETHROWER, false, nullptr, 0, gameTime - deltaGameTime);
 					}
 				}
-				if (!giftSingleDroid(psDroid, attackPlayer) && !isDead(psDroid))
+				if (!isDead(psDroid) && !giftSingleDroid(psDroid, attackPlayer, true))
 				{
 					// droid limit reached, recycle
 					// don't check for transporter/mission coz multiplayer only issue.


### PR DESCRIPTION
- Electronic or campaign transfers remain the same: destroy and recreate.
- Normal transfers mostly changes the player and will keep all necessary information intact while being more bug free.

Partial revert of 9830d8d7672018bcab66b3bc5d68a7c4b78c1cca.

Fixes #272. 

---
Not sure why this was removed since it seems to function perfectly fine bar me having to fix transfers with units attached to a leader. The tickets mentioned in the mostly reverted commit don't apply anymore.

Basically, with this patch, transferred droids are much more closely original to what the donating player gives you instead of the game magically manufacturing a completely new droid for the receiving player at some given spot.