### PR TITLE
CI improvements / fixes

### DIFF
--- a/.github/workflows/CI_snapcraft.yml
+++ b/.github/workflows/CI_snapcraft.yml
@@ -31,8 +31,8 @@ jobs:
     - name: Compute build variables
       run: |
         . .ci/githubactions/export_build_output_desc.sh
-        echo "::set-env name=WZ_BUILD_DESC_IS_TAG::${WZ_BUILD_DESC_IS_TAG}"
-        echo "::set-env name=WZ_BUILD_DESC_PREFIX::${WZ_BUILD_DESC_PREFIX}"
+        echo "WZ_BUILD_DESC_IS_TAG=${WZ_BUILD_DESC_IS_TAG}" >> $GITHUB_ENV
+        echo "WZ_BUILD_DESC_PREFIX=${WZ_BUILD_DESC_PREFIX}" >> $GITHUB_ENV
         WZ_OUTPUT_NAME_SUFFIX=""
         WZ_NAME_SUFFIX=""
         if [ "$WZ_BUILD_DESC_IS_TAG" == "false" ]; then
@@ -40,15 +40,15 @@ jobs:
           WZ_NAME_SUFFIX=" ($(echo "${WZ_BUILD_DESC_PREFIX}" | sed 's/[^a-zA-Z0-9\.]/_/g'))"
         fi
         echo "WZ_OUTPUT_NAME_SUFFIX=${WZ_OUTPUT_NAME_SUFFIX}"
-        echo "::set-env name=WZ_OUTPUT_NAME_SUFFIX::${WZ_OUTPUT_NAME_SUFFIX}"
-        echo "::set-env name=WZ_NAME_SUFFIX::${WZ_NAME_SUFFIX}"
+        echo "WZ_OUTPUT_NAME_SUFFIX=${WZ_OUTPUT_NAME_SUFFIX}" >> $GITHUB_ENV
+        echo "WZ_NAME_SUFFIX=${WZ_NAME_SUFFIX}" >> $GITHUB_ENV
 
         WZ_DISTRIBUTOR="UNKNOWN"
         if [ "${GITHUB_REPOSITORY}" == "Warzone2100/warzone2100" ]; then
           WZ_DISTRIBUTOR="wz2100.net"
         fi
         echo "WZ_DISTRIBUTOR=${WZ_DISTRIBUTOR}"
-        echo "::set-env name=WZ_DISTRIBUTOR::${WZ_DISTRIBUTOR}"
+        echo "WZ_DISTRIBUTOR=${WZ_DISTRIBUTOR}" >> $GITHUB_ENV
 
     - name: Prepare to build .SNAP
       run: |
@@ -83,14 +83,14 @@ jobs:
       run: |
         OUTPUT_DIR="${HOME}/output"
         echo "OUTPUT_DIR=${OUTPUT_DIR}"
-        echo "::set-env name=OUTPUT_DIR::${OUTPUT_DIR}"
+        echo "OUTPUT_DIR=${OUTPUT_DIR}" >> $GITHUB_ENV
         mkdir -p "${OUTPUT_DIR}"
         OUTPUT_FILE_NAME="warzone2100_linux_${{ matrix.arch }}.snap"
         cp "${{ steps.snapcraft.outputs.snap }}" "${OUTPUT_DIR}/${OUTPUT_FILE_NAME}"
         echo "Generated .snap: \"${OUTPUT_FILE_NAME}\""
         echo "  -> SHA512: $(sha512sum "${OUTPUT_DIR}/${OUTPUT_FILE_NAME}")"
         echo "  -> Size (bytes): $(stat -c %s "${OUTPUT_DIR}/${OUTPUT_FILE_NAME}")"
-        echo "::set-env name=WZ_FULL_OUTPUT_SNAP_PATH::${OUTPUT_DIR}/${OUTPUT_FILE_NAME}"
+        echo "WZ_FULL_OUTPUT_SNAP_PATH=${OUTPUT_DIR}/${OUTPUT_FILE_NAME}" >> $GITHUB_ENV
     - uses: actions/upload-artifact@v1
       if: success()
       with:

--- a/.github/workflows/CI_ubuntu.yml
+++ b/.github/workflows/CI_ubuntu.yml
@@ -69,8 +69,8 @@ jobs:
     - name: Compute build variables
       run: |
         . .ci/githubactions/export_build_output_desc.sh
-        echo "::set-env name=WZ_BUILD_DESC_IS_TAG::${WZ_BUILD_DESC_IS_TAG}"
-        echo "::set-env name=WZ_BUILD_DESC_PREFIX::${WZ_BUILD_DESC_PREFIX}"
+        echo "WZ_BUILD_DESC_IS_TAG=${WZ_BUILD_DESC_IS_TAG}" >> $GITHUB_ENV
+        echo "WZ_BUILD_DESC_PREFIX=${WZ_BUILD_DESC_PREFIX}" >> $GITHUB_ENV
         WZ_OUTPUT_NAME_SUFFIX=""
         WZ_NAME_SUFFIX=""
         if [ "$WZ_BUILD_DESC_IS_TAG" == "false" ]; then
@@ -78,15 +78,15 @@ jobs:
           WZ_NAME_SUFFIX=" ($(echo "${WZ_BUILD_DESC_PREFIX}" | sed 's/[^a-zA-Z0-9\.]/_/g'))"
         fi
         echo "WZ_OUTPUT_NAME_SUFFIX=${WZ_OUTPUT_NAME_SUFFIX}"
-        echo "::set-env name=WZ_OUTPUT_NAME_SUFFIX::${WZ_OUTPUT_NAME_SUFFIX}"
-        echo "::set-env name=WZ_NAME_SUFFIX::${WZ_NAME_SUFFIX}"
+        echo "WZ_OUTPUT_NAME_SUFFIX=${WZ_OUTPUT_NAME_SUFFIX}" >> $GITHUB_ENV
+        echo "WZ_NAME_SUFFIX=${WZ_NAME_SUFFIX}" >> $GITHUB_ENV
 
         WZ_DISTRIBUTOR="UNKNOWN"
         if [ "${GITHUB_REPOSITORY}" == "Warzone2100/warzone2100" ]; then
           WZ_DISTRIBUTOR="wz2100.net"
         fi
         echo "WZ_DISTRIBUTOR=${WZ_DISTRIBUTOR}"
-        echo "::set-env name=WZ_DISTRIBUTOR::${WZ_DISTRIBUTOR}"
+        echo "WZ_DISTRIBUTOR=${WZ_DISTRIBUTOR}" >> $GITHUB_ENV
     - name: CMake Configure
       run: docker run --rm -e "CI=true" -e GITHUB_WORKFLOW -e GITHUB_ACTIONS -e GITHUB_REPOSITORY -e "GITHUB_WORKSPACE=/code" -e GITHUB_SHA -e GITHUB_REF -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e MAKEFLAGS -v $(pwd):/code ubuntu cmake '-H.' -Bbuild -DCMAKE_BUILD_TYPE=RelWithDebInfo -DWZ_ENABLE_WARNINGS:BOOL=ON -DWZ_DISTRIBUTOR:STRING="${WZ_DISTRIBUTOR}" -DWZ_OUTPUT_NAME_SUFFIX="${WZ_OUTPUT_NAME_SUFFIX}" -DWZ_NAME_SUFFIX="${WZ_NAME_SUFFIX}" -G"Ninja"
     - name: CMake Build
@@ -103,14 +103,14 @@ jobs:
         docker run --rm -e "CI=true" -e GITHUB_WORKFLOW -e GITHUB_ACTIONS -e GITHUB_REPOSITORY -e "GITHUB_WORKSPACE=/code" -e GITHUB_SHA -e GITHUB_REF -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e MAKEFLAGS -v $(pwd):/code ubuntu cpack --config "build/CPackConfig.cmake" -G DEB -D CPACK_DEBIAN_PACKAGE_MAINTAINER="${WZ_DISTRIBUTOR}" -D CPACK_DEB_COMPONENT_INSTALL=OFF -D CPACK_MONOLITHIC_INSTALL=1 -D CPACK_DEBIAN_PACKAGE_NAME="${WZ_DEB_PACKAGE_NAME}" -D CPACK_DEBIAN_FILE_NAME="warzone2100.deb" ${WZ_PACKAGE_VAR_OVERRIDES}
         OUTPUT_DIR="${HOME}/output"
         echo "OUTPUT_DIR=${OUTPUT_DIR}"
-        echo "::set-env name=OUTPUT_DIR::${OUTPUT_DIR}"
+        echo "OUTPUT_DIR=${OUTPUT_DIR}" >> $GITHUB_ENV
         mkdir -p "${OUTPUT_DIR}"
         OUTPUT_FILE_NAME="warzone2100_${{ matrix.output-suffix }}_${{ matrix.arch }}.deb"
         cp "warzone2100.deb" "${OUTPUT_DIR}/${OUTPUT_FILE_NAME}"
         echo "Generated .deb: \"${OUTPUT_FILE_NAME}\""
         echo "  -> SHA512: $(sha512sum "${OUTPUT_DIR}/${OUTPUT_FILE_NAME}")"
         echo "  -> Size (bytes): $(stat -c %s "${OUTPUT_DIR}/${OUTPUT_FILE_NAME}")"
-        echo "::set-env name=WZ_FULL_OUTPUT_DEB_PATH::${OUTPUT_DIR}/${OUTPUT_FILE_NAME}"
+        echo "WZ_FULL_OUTPUT_DEB_PATH=${OUTPUT_DIR}/${OUTPUT_FILE_NAME}" >> $GITHUB_ENV
     - uses: actions/upload-artifact@v1
       if: success()
       with:
@@ -158,7 +158,7 @@ jobs:
       run: |
         OUTPUT_DIR="${HOME}/output"
         echo "OUTPUT_DIR=${OUTPUT_DIR}"
-        echo "::set-env name=OUTPUT_DIR::${OUTPUT_DIR}"
+        echo "OUTPUT_DIR=${OUTPUT_DIR}" >> $GITHUB_ENV
         mkdir -p "${OUTPUT_DIR}"
         cp "build/warzone2100.tar.xz" "${OUTPUT_DIR}/warzone2100_src.tar.xz"
         echo "Generated warzone2100 tarball: \"warzone2100_src.tar.xz\""

--- a/.github/workflows/CI_windows.yml
+++ b/.github/workflows/CI_windows.yml
@@ -283,7 +283,7 @@ jobs:
     #####################################################
     - name: Install Qt (Alt Method)
       if: env.WZ_USE_ALT_QT_INSTALL_METHOD == 'true'
-      uses: jurplel/install-qt-action@v2.6.2
+      uses: jurplel/install-qt-action@v2.9.0
       with:
         version: 5.9.9
         arch: ${{ steps.settings.outputs.QTCI_ARCH }}

--- a/.github/workflows/CI_windows.yml
+++ b/.github/workflows/CI_windows.yml
@@ -141,21 +141,21 @@ jobs:
         # Export Variables
 
         # Export everything important to environment variables (for future steps)
-        echo "::set-env name=WZ_REPO_PATH::${{ github.workspace }}\src"
-        echo "::set-env name=VCPKG_DEFAULT_TRIPLET::${VCPKG_DEFAULT_TRIPLET}"
-        echo "::set-env name=WZ_VC_TARGET_PLATFORMNAME::${WZ_VC_TARGET_PLATFORMNAME}"
-        echo "::set-env name=WZ_BUILD_DESC::${WZ_BUILD_DESC}"
-        echo "::set-env name=QT5DIR::${QT5DIR}"
-        echo "::set-env name=QTCI_ARCH::${QTCI_ARCH}"
+        echo "WZ_REPO_PATH=${{ github.workspace }}\src" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+        echo "VCPKG_DEFAULT_TRIPLET=${VCPKG_DEFAULT_TRIPLET}" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+        echo "WZ_VC_TARGET_PLATFORMNAME=${WZ_VC_TARGET_PLATFORMNAME}" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+        echo "WZ_BUILD_DESC=${WZ_BUILD_DESC}" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+        echo "QT5DIR=${QT5DIR}" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+        echo "QTCI_ARCH=${QTCI_ARCH}" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
         echo "::set-output name=QTCI_ARCH::${QTCI_ARCH}"
-        echo "::set-env name=QTCI_PACKAGES::${QTCI_PACKAGES}"
-        echo "::set-env name=QT_DL_URL::${QT_DL_URL}"
-        echo "::set-env name=QT_DL_SHA512::${QT_DL_SHA512}"
-        echo "::set-env name=WZ_VC_GENERATOR::${WZ_VC_GENERATOR}"
-        #echo "::set-env name=WZ_VC_TOOLCHAIN::${WZ_VC_TOOLCHAIN}"
-        echo "::set-env name=WZ_VISUAL_STUDIO_INSTALL_PATH::${WZ_VISUAL_STUDIO_INSTALL_PATH}"
-        echo "::set-env name=VCPKG_VISUAL_STUDIO_PATH::${VCPKG_VISUAL_STUDIO_PATH}"
-        echo "::set-env name=WZ_DISTRIBUTOR::${WZ_DISTRIBUTOR}"
+        echo "QTCI_PACKAGES=${QTCI_PACKAGES}" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+        echo "QT_DL_URL=${QT_DL_URL}" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+        echo "QT_DL_SHA512=${QT_DL_SHA512}" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+        echo "WZ_VC_GENERATOR=${WZ_VC_GENERATOR}" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+        #echo "WZ_VC_TOOLCHAIN=${WZ_VC_TOOLCHAIN}" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+        echo "WZ_VISUAL_STUDIO_INSTALL_PATH=${WZ_VISUAL_STUDIO_INSTALL_PATH}" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+        echo "VCPKG_VISUAL_STUDIO_PATH=${VCPKG_VISUAL_STUDIO_PATH}" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+        echo "WZ_DISTRIBUTOR=${WZ_DISTRIBUTOR}" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
         echo "::set-output name=WZ_DEPLOY_RELEASE::${WZ_DEPLOY_RELEASE}"
     - name: Check Environment for Qt Install
       env:
@@ -166,7 +166,7 @@ jobs:
         {
           # Looks like we don't have access to secrets - might be a pull request, fork, etc
           # So use an alternative method to download + install Qt
-          echo "::set-env name=WZ_USE_ALT_QT_INSTALL_METHOD::true"
+          echo "WZ_USE_ALT_QT_INSTALL_METHOD=true" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
         }
     #####################################################
     # Standard Qt install method
@@ -227,7 +227,7 @@ jobs:
         }
 
         # Output Qt download path for next step
-        echo "::set-env name=QT_DL_PATH::${QT_DL_PATH}"
+        echo "QT_DL_PATH=${QT_DL_PATH}" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
     - name: Install Qt
       if: env.WZ_USE_ALT_QT_INSTALL_METHOD != 'true'
       env:
@@ -266,7 +266,7 @@ jobs:
         # Clean-up the installer exe
         Remove-Item "${env:QT_DL_PATH}"
         # Output install path for following steps
-        echo "::set-env name=QT_INSTALL_ROOT::${QT_INSTALL_ROOT}"
+        echo "QT_INSTALL_ROOT=${QT_INSTALL_ROOT}" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
     - name: Verify Qt version
       if: env.WZ_USE_ALT_QT_INSTALL_METHOD != 'true'
       run: |
@@ -275,7 +275,7 @@ jobs:
 
         # Add the QT5 \bin dir to PATH (for future steps)
         Write-Host "Adding Qt bin folder to PATH: `"${env:QT_INSTALL_ROOT}\${env:QT5DIR}\bin`""
-        echo "::add-path::${env:QT_INSTALL_ROOT}\${env:QT5DIR}\bin"
+        echo "${env:QT_INSTALL_ROOT}\${env:QT5DIR}\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
     #####################################################
     # Alternative Qt Install method
     # - relies on external action that uses unofficial
@@ -332,7 +332,7 @@ jobs:
         Write-Host "New system VULKAN_SDK environment variable: $($machineEnvironment["VULKAN_SDK"])"
 
         # Ensure future steps pick up the new VULKAN_SDK environment variable
-        echo "::set-env name=VULKAN_SDK::$($machineEnvironment["VULKAN_SDK"])"
+        echo "VULKAN_SDK=$($machineEnvironment["VULKAN_SDK"])" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
     - name: 'Check environment'
       run: |
         if ([string]::IsNullOrWhitespace(${env:VULKAN_SDK}))

--- a/.github/workflows/generate_snap_stable_config.yml
+++ b/.github/workflows/generate_snap_stable_config.yml
@@ -59,7 +59,7 @@ jobs:
             PUBLISH_CONFIG="true"
           fi
           echo "::set-output name=PUBLISH_CONFIG::${PUBLISH_CONFIG}"
-          echo "::set-env name=PUBLISH_CONFIG::${PUBLISH_CONFIG}"
+          echo "PUBLISH_CONFIG=${PUBLISH_CONFIG}" >> $GITHUB_ENV
       - name: Install Prereqs
         run: |
           sudo snap install yq
@@ -130,7 +130,7 @@ jobs:
             exit 1
           fi
           echo "${LATEST_GITHUB_RELEASE_TAG}" > "${GITHUB_WORKSPACE}/snap-stable-build/.stable_tag"
-          echo "::set-env name=LATEST_GITHUB_RELEASE_TAG::${LATEST_GITHUB_RELEASE_TAG}"
+          echo "LATEST_GITHUB_RELEASE_TAG=${LATEST_GITHUB_RELEASE_TAG}" >> $GITHUB_ENV
           
           # Copy pkg/snap directory to pkg/snap in dest repo (overwriting old version)
           rm -rf "${GITHUB_WORKSPACE}/snap-stable-build/pkg/snap"

--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -38,7 +38,7 @@ jobs:
     - name: Create Pull Request to update base files (if needed)
       if: (github.repository == 'Warzone2100/warzone2100')
       id: cpr
-      uses: past-due/create-pull-request@v2
+      uses: past-due/create-pull-request@v3
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         path: 'master'
@@ -48,9 +48,10 @@ jobs:
           Update base string / translation files in the `master` branch
           - Auto-generated
         labels: automated pr
+        author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
         draft: false
         branch: update_base_translations
     - name: Check outputs
       if: ${{ success() }}
       run: |
-        echo "Pull Request Number - ${{ steps.cpr.outputs.pr_number }}"
+        echo "Pull Request Number - ${{ steps.cpr.outputs.pull-request-number }}"

--- a/docker/fedora-latest-m32/Dockerfile
+++ b/docker/fedora-latest-m32/Dockerfile
@@ -1,4 +1,6 @@
-FROM fedora:latest
+FROM fedora:32
+# pin at 32 until pkg-config multi-arch failures on 33 are fixed
+#FROM fedora:latest
 
 RUN cat /etc/fedora-release
 


### PR DESCRIPTION
Tweak Fedora m32 Dockerfile
- Pin to Fedora 32 until the pkg-config multi-arch failures on 33 are fixed. Example:
   ```
   file /usr/bin/pkg-config conflicts between attempted installs of pkgconf-pkg-config-1.7.3-2.fc33.i686 and pkgconf-pkg-config-1.7.3-2.fc33.x86_64
   ```

[GitHub Actions] Replace deprecated `set-env` and `add-path` commands
- See: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/