### PR TITLE
Add AngleAnimation class

### DIFF
--- a/src/animation.cpp
+++ b/src/animation.cpp
@@ -23,6 +23,43 @@
 
 #include "animation.h"
 
+AngleAnimation* AngleAnimation::setInitial(Vector3i value){
+	this->initialX = (UWORD)value.x;
+	this->initialY = (UWORD)value.y;
+	this->initialZ = (UWORD)value.z;
+	return this;
+}
+AngleAnimation* AngleAnimation::setDuration(int milliseconds){
+	this->duration = milliseconds;
+	return this;
+}
+AngleAnimation* AngleAnimation::startNow(){
+	this->startTime = graphicsTime;
+	return this;
+}
+AngleAnimation* AngleAnimation::setTarget(int x, int y, int z){
+	this->targetX = (UWORD)x;
+	this->targetY = (UWORD)y;
+	this->targetZ = (UWORD)z;
+	return this;
+}
+AngleAnimation* AngleAnimation::update(){
+	float t = (graphicsTime - this->startTime) / (float)this->duration;
+
+	t = t < 0.5 ? 2 * t * t : t * (4 - 2 * t) - 1;
+
+	// the SWORD here is the secret juice. It takes the target delta
+	// (target minus initial) and makes it wrap to the other side if > 180.
+	this->currentX = (this->initialX + (SWORD)(this->targetX - this->initialX) * t);
+	this->currentY = (this->initialY + (SWORD)(this->targetY - this->initialY) * t);
+	this->currentZ = (this->initialZ + (SWORD)(this->targetZ - this->initialZ) * t);
+
+	return this;
+}
+Vector3i AngleAnimation::getCurrent(){
+	return { this->currentX, this->currentY, this->currentZ };
+}
+
 static uint16_t calculateEasing(EasingType easingType, uint16_t progress)
 {
 	switch (easingType)

--- a/src/animation.h
+++ b/src/animation.h
@@ -27,6 +27,33 @@
 #ifndef __INCLUDED_SRC_ANIMATION_H__
 #define __INCLUDED_SRC_ANIMATION_H__
 
+/// Helper class for linearly interpolating angles, with support for wrapping.
+class AngleAnimation {
+    private:
+    UDWORD startTime;
+    int duration;
+
+    int initialX;
+    int initialY;
+    int initialZ;
+
+    int currentX;
+    int currentY;
+    int currentZ;
+
+    int targetX;
+    int targetY;
+    int targetZ;
+
+    public:
+    AngleAnimation* setInitial(Vector3i value);
+    AngleAnimation* setDuration(int milliseconds);
+    AngleAnimation* startNow();
+    AngleAnimation* setTarget(int x, int y, int z);
+    AngleAnimation* update();
+    Vector3i getCurrent();
+};
+
 enum EasingType
 {
 	LINEAR,


### PR DESCRIPTION
This class is quite handy (and difficult to get right).

It allows you to linearly interpolate an angle with support for the special use case: when an angle is supposed to go from 5 to -5 (eg. 355), on a normal LERP function it will take the long way to 5...355, when it instead should go 5...0...355.