### PR TITLE
[Drone.io] Add ARM64 builds CI config

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,0 +1,64 @@
+kind: pipeline
+type: docker
+name: ubuntu-18-04-arm64-gcc
+
+platform:
+  os: linux
+  arch: arm64
+
+steps:
+- name: build
+  image: arm64v8/ubuntu:20.04
+  commands:
+  - cat /etc/lsb-release
+  - apt-get -u update
+  - DEBIAN_FRONTEND=noninteractive apt-get -y install gcc g++ clang libc-dev dpkg-dev ninja-build pkg-config libpng-dev libsdl2-dev libopenal-dev libphysfs-dev libvorbis-dev libtheora-dev libxrandr-dev zip unzip qtscript5-dev qt5-default libfribidi-dev libfreetype6-dev libharfbuzz-dev libfontconfig1-dev asciidoctor gettext git cmake libcurl4-gnutls-dev gnutls-dev libsodium-dev
+  - rm -rf /var/lib/apt/lists/*
+  - cmake -P ".ci/travis/prepare_git_repo.cmake"
+  - git submodule update --init --recursive
+  - cmake '-H.' -Bbuild -DCMAKE_BUILD_TYPE=RelWithDebInfo -DWZ_ENABLE_WARNINGS:BOOL=ON -G"Ninja"
+  - cmake --build build
+
+---
+kind: pipeline
+type: docker
+name: ubuntu-20-04-arm64-gcc
+
+platform:
+  os: linux
+  arch: arm64
+
+steps:
+- name: build
+  image: arm64v8/ubuntu:20.04
+  commands:
+  - cat /etc/lsb-release
+  - apt-get -u update
+  - DEBIAN_FRONTEND=noninteractive apt-get -y install gcc g++ clang libc-dev dpkg-dev ninja-build pkg-config libpng-dev libsdl2-dev libopenal-dev libphysfs-dev libvorbis-dev libtheora-dev libxrandr-dev zip unzip qtscript5-dev qt5-default libfribidi-dev libfreetype6-dev libharfbuzz-dev libfontconfig1-dev asciidoctor gettext git cmake libcurl4-gnutls-dev gnutls-dev libsodium-dev
+  - rm -rf /var/lib/apt/lists/*
+  - cmake -P ".ci/travis/prepare_git_repo.cmake"
+  - git submodule update --init --recursive
+  - cmake '-H.' -Bbuild -DCMAKE_BUILD_TYPE=RelWithDebInfo -DWZ_ENABLE_WARNINGS:BOOL=ON -G"Ninja"
+  - cmake --build build
+
+---
+kind: pipeline
+type: docker
+name: ubuntu-20-04-arm64-clang
+
+platform:
+  os: linux
+  arch: arm64
+
+steps:
+- name: build
+  image: arm64v8/ubuntu:20.04
+  commands:
+  - cat /etc/lsb-release
+  - apt-get -u update
+  - DEBIAN_FRONTEND=noninteractive apt-get -y install gcc g++ clang libc-dev dpkg-dev ninja-build pkg-config libpng-dev libsdl2-dev libopenal-dev libphysfs-dev libvorbis-dev libtheora-dev libxrandr-dev zip unzip qtscript5-dev qt5-default libfribidi-dev libfreetype6-dev libharfbuzz-dev libfontconfig1-dev asciidoctor gettext git cmake libcurl4-gnutls-dev gnutls-dev libsodium-dev
+  - rm -rf /var/lib/apt/lists/*
+  - cmake -P ".ci/travis/prepare_git_repo.cmake"
+  - git submodule update --init --recursive
+  - CC=/usr/bin/clang CXX=/usr/bin/clang++ cmake '-H.' -Bbuild -DCMAKE_BUILD_TYPE=RelWithDebInfo -DWZ_ENABLE_WARNINGS:BOOL=ON -G"Ninja"
+  - CC=/usr/bin/clang CXX=/usr/bin/clang++ cmake --build build


### PR DESCRIPTION
Moving ARM64 CI builds away from Travis CI to [Drone Cloud](https://cloud.drone.io/).

> Drone Cloud is a free Continuous Integration service for the Open Source community, powered by blazing fast bare-metal servers.

> Multiple Architectures
> Our goal is to upstream all the things! In order to do that with the diverse Arm ecosystem, we're providing gobs of CI/CD infrastructure.
