### PR TITLE
Fix music playlist selection when loading savegames

### DIFF
--- a/data/base/script/rules.js
+++ b/data/base/script/rules.js
@@ -266,7 +266,6 @@ function setupGame()
 
 	setMainReticule();
 	showInterface();
-	hackPlayIngameAudio();
 	mainReticule = true;
 	queue("resetPower", 1000);
 }

--- a/data/mp/multiplay/skirmish/rules.js
+++ b/data/mp/multiplay/skirmish/rules.js
@@ -251,7 +251,6 @@ function setupGame()
 	setMainReticule();
 	showInterface();
 	mainReticule = true;
-	hackPlayIngameAudio();
 }
 
 function eventGameLoaded()

--- a/lib/sound/cdaudio.cpp
+++ b/lib/sound/cdaudio.cpp
@@ -299,7 +299,7 @@ bool cdAudio_PlayTrack(SONG_CONTEXT context)
 				return true;
 			}
 
-			auto nextTrack = PlayList_CurrentSong();
+			auto nextTrack = PlayList_RandomizeCurrentSong();
 
 			if (!nextTrack)
 			{

--- a/lib/sound/playlist.cpp
+++ b/lib/sound/playlist.cpp
@@ -360,9 +360,17 @@ size_t PlayList_SetTrackFilter(const std::function<bool (const std::shared_ptr<c
 
 size_t PlayList_FilterByMusicMode(MusicGameMode currentMode)
 {
-	size_t result = PlayList_SetTrackFilter([currentMode](const std::shared_ptr<const WZ_TRACK>& track) -> bool {
-		return PlayList_IsTrackEnabledForMusicMode(track, currentMode);
-	});
+	size_t result = 0;
+	if (currentMode != MusicGameMode::MENUS)
+	{
+		result = PlayList_SetTrackFilter([currentMode](const std::shared_ptr<const WZ_TRACK>& track) -> bool {
+			return PlayList_IsTrackEnabledForMusicMode(track, currentMode);
+		});
+	}
+	else
+	{
+		currentFilterFunc = nullptr;
+	}
 	if (lastFilteredMode != currentMode)
 	{
 		currentSong = nullopt;
@@ -565,6 +573,7 @@ bool PlayList_Read(const char *path)
 
 static optional<size_t> PlayList_FindNextMatchingTrack(size_t startingSongIdx)
 {
+	if (!currentFilterFunc) { return nullopt; }
 	size_t idx = (startingSongIdx < (fullTrackList.size() - 1)) ? (startingSongIdx + 1) : 0;
 	while (idx != startingSongIdx)
 	{

--- a/lib/sound/playlist.cpp
+++ b/lib/sound/playlist.cpp
@@ -610,6 +610,22 @@ std::shared_ptr<const WZ_TRACK> PlayList_NextSong()
 	return PlayList_CurrentSong();
 }
 
+std::shared_ptr<const WZ_TRACK> PlayList_RandomizeCurrentSong()
+{
+	size_t incrementByNum = ((size_t)rand() % fullTrackList.size());
+	size_t currentSongIdx = currentSong.has_value() ? currentSong.value() : (fullTrackList.size() - 1);
+	for (size_t i = 0; i < incrementByNum; i++)
+	{
+		currentSong = PlayList_FindNextMatchingTrack(currentSongIdx);
+		if (!currentSong.has_value())
+		{
+			break;
+		}
+		currentSongIdx = currentSong.value();
+	}
+	return PlayList_CurrentSong();
+}
+
 bool PlayList_SetCurrentSong(const std::shared_ptr<const WZ_TRACK>& track)
 {
 	if (!track) { return false; }

--- a/lib/sound/playlist.h
+++ b/lib/sound/playlist.h
@@ -33,6 +33,7 @@ MusicGameMode PlayList_GetCurrentMusicMode();
 
 std::shared_ptr<const WZ_TRACK> PlayList_CurrentSong();
 std::shared_ptr<const WZ_TRACK> PlayList_NextSong();
+std::shared_ptr<const WZ_TRACK> PlayList_RandomizeCurrentSong();
 bool PlayList_SetCurrentSong(const std::shared_ptr<const WZ_TRACK>& track);
 
 const std::vector<std::shared_ptr<const WZ_TRACK>>& PlayList_GetFullTrackList();

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1343,6 +1343,9 @@ bool stageThreeInitialise()
 		playerBuiltHQ = structureExists(selectedPlayer, REF_HQ, true, false);
 	}
 
+	// Start / randomize in-game music
+	cdAudio_PlayTrack(SONG_INGAME);
+
 	return true;
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -822,18 +822,8 @@ static void stopTitleLoop()
 	}
 }
 
-
-/*!
- * Preparations before entering the game loop
- * Would start the timer in an event based mainloop
- */
-static void startGameLoop()
+static void setCDAudioForCurrentGameMode()
 {
-	SetGameMode(GS_NORMAL);
-
-	ActivityManager::instance().startingGame();
-
-	// set up CD audio for game mode
 	auto gameMode = ActivityManager::instance().getCurrentGameMode();
 	switch (gameMode)
 	{
@@ -853,6 +843,20 @@ static void startGameLoop()
 			debug(LOG_ERROR, "Unhandled started game mode for cd audio: %u", (unsigned int)gameMode);
 			break;
 	}
+}
+
+/*!
+ * Preparations before entering the game loop
+ * Would start the timer in an event based mainloop
+ */
+static void startGameLoop()
+{
+	SetGameMode(GS_NORMAL);
+
+	ActivityManager::instance().startingGame();
+
+	// set up CD audio for game mode
+	setCDAudioForCurrentGameMode();
 
 	// Not sure what aLevelName is, in relation to game.map. But need to use aLevelName here, to be able to start the right map for campaign, and need game.hash, to start the right non-campaign map, if there are multiple identically named maps.
 	if (!levLoadData(aLevelName, &game.hash, nullptr, GTYPE_SCENARIO_START))
@@ -956,6 +960,10 @@ static bool initSaveGameLoad()
 	}
 
 	ActivityManager::instance().startingSavedGame();
+
+	// set up CD audio for game mode
+	// (must come after savegame is loaded so that proper game mode can be determined)
+	setCDAudioForCurrentGameMode();
 
 	screen_StopBackDrop();
 	closeLoadingScreen();

--- a/src/wzapi.cpp
+++ b/src/wzapi.cpp
@@ -739,7 +739,9 @@ wzapi::no_return_value wzapi::hackPlayIngameAudio(WZAPI_NO_PARAMS)
 
 //-- ## hackStopIngameAudio()
 //--
-//-- (3.3+ only)
+//-- Stop the in-game music. (3.3+ only)
+//-- This should be called from the eventStartLevel() event (or later).
+//-- Currently only used from the tutorial.
 //--
 wzapi::no_return_value wzapi::hackStopIngameAudio(WZAPI_NO_PARAMS)
 {


### PR DESCRIPTION
Resolves a slight oversight in #1280, caused by how game state management is handled when loading savegames.