### PR TITLE
Fix skybox alpha blending

### DIFF
--- a/lib/ivis_opengl/gfx_api.h
+++ b/lib/ivis_opengl/gfx_api.h
@@ -691,7 +691,7 @@ namespace gfx_api
 	using GFX = typename gfx_api::pipeline_state_helper<rasterizer_state<rm, dm, 255, polygon_offset::disabled, stencil_mode::stencil_disabled, cull_mode::back>, primitive, index_type::u16, std::tuple<VTX, Second>, texture, shader>;
 	using VideoPSO = GFX<REND_OPAQUE, DEPTH_CMP_ALWAYS_WRT_OFF, primitive_type::triangle_strip, gfx_vtx2, gfx_tc, SHADER_GFX_TEXT, std::tuple<texture_description<0, gfx_api::sampler_type::bilinear>>>;
 	using BackDropPSO = GFX<REND_OPAQUE, DEPTH_CMP_ALWAYS_WRT_OFF, primitive_type::triangle_strip, gfx_vtx2, gfx_tc, SHADER_GFX_TEXT, std::tuple<texture_description<0, gfx_api::sampler_type::nearest_clamped>>>;
-	using SkyboxPSO = GFX<REND_OPAQUE, DEPTH_CMP_LEQ_WRT_OFF, primitive_type::triangles, gfx_vtx3, gfx_tc, SHADER_GFX_TEXT, std::tuple<texture_description<0, gfx_api::sampler_type::bilinear_repeat>>>;
+	using SkyboxPSO = GFX<REND_ALPHA, DEPTH_CMP_LEQ_WRT_OFF, primitive_type::triangles, gfx_vtx3, gfx_tc, SHADER_GFX_TEXT, std::tuple<texture_description<0, gfx_api::sampler_type::bilinear_repeat>>>;
 	using RadarPSO = GFX<REND_ALPHA, DEPTH_CMP_ALWAYS_WRT_OFF, primitive_type::triangle_strip, gfx_vtx2, gfx_tc, SHADER_GFX_TEXT, std::tuple<texture_description<0, gfx_api::sampler_type::nearest_clamped>>>;
 	using RadarViewInsideFillPSO = GFX<REND_ALPHA, DEPTH_CMP_ALWAYS_WRT_OFF, primitive_type::triangle_strip, gfx_vtx2, gfx_colour, SHADER_GFX_COLOUR, notexture>;
 	using RadarViewOutlinePSO = GFX<REND_ALPHA, DEPTH_CMP_ALWAYS_WRT_OFF, primitive_type::line_strip, gfx_vtx2, gfx_colour, SHADER_GFX_COLOUR, notexture>;

--- a/lib/ivis_opengl/piefunc.cpp
+++ b/lib/ivis_opengl/piefunc.cpp
@@ -129,65 +129,50 @@ void pie_TransColouredTriangle(const std::array<Vector3f, 3> &vrt, PIELIGHT c, c
 
 void pie_Skybox_Init()
 {
-	const int u = 0;
-	const int v = 0;
-	const int w = 1;
-	const int h = 1;
-	const float r = 1.0f; // just because it is shorter than 1.0f
-
 	const Vector3f
-		vertexFront0 = Vector3f(-r, 0, r), // front
-		vertexFront1 = Vector3f(-r, r, r),
-		vertexFront2 = Vector3f(r, 0, r),
-		vertexFront3 = Vector3f(r, r, r),
-		vertexRight0 = Vector3f(r, 0, -r), // right
-		vertexRight1 = Vector3f(r, r, -r),
-		vertexBack0 = Vector3f(-r, 0, -r), // back
-		vertexBack1 = Vector3f(-r, r, -r),
-		vertexLeft0 = Vector3f(-r, 0, r),
-		vertexLeft1 = Vector3f(-r, r, r);
+		northWestBelow = Vector3f(-1, 0, 1), // nw
+		northWestAbove = Vector3f(-1, 1, 1),
+		northEastBelow = Vector3f(1, 0, 1), // ne
+		northEastAbove = Vector3f(1, 1, 1),
+		southEastBelow = Vector3f(1, 0, -1), // se
+		southEastAbove = Vector3f(1, 1, -1),
+		southWestBelow = Vector3f(-1, 0, -1), // sw
+		southWestAbove = Vector3f(-1, 1, -1);
 
 	const std::array<Vector3f, 24> vertex{
-		// Front quad
-		vertexFront0, vertexFront1, vertexFront2,
-		vertexFront3, vertexFront2, vertexFront1,
-		// Right quad
-		vertexFront2, vertexFront3, vertexRight0,
-		vertexRight1, vertexRight0, vertexFront3,
-		// Back quad
-		vertexRight0, vertexRight1, vertexBack0,
-		vertexBack1, vertexBack0, vertexRight1,
-		// Left quad
-		vertexBack0, vertexBack1, vertexLeft0,
-		vertexLeft1, vertexLeft0, vertexBack1,
-
+		// North quad
+		northWestBelow, northWestAbove, northEastBelow,
+		northEastAbove, northEastBelow, northWestAbove,
+		// East quad
+		northEastBelow, northEastAbove, southEastBelow,
+		southEastAbove, southEastBelow, northEastAbove,
+		// South quad
+		southEastBelow, southEastAbove, southWestBelow,
+		southWestAbove, southWestBelow, southEastAbove,
+		// West quad
+		southWestBelow, southWestAbove, northWestBelow,
+		northWestAbove, northWestBelow, southWestAbove,
 	};
 	const Vector2f
-		uvFront0 = Vector2f(u + w * 0, (v + h)),
-		uvFront1 = Vector2f(u + w * 0, v),
-		uvFront2 = Vector2f(u + w * 2, v + h),
-		uvFront3 = Vector2f(u + w * 2, v),
-		uvRight0 = Vector2f(u + w * 4, v + h),
-		uvRight1 = Vector2f(u + w * 4, v),
-		uvBack0 = Vector2f(u + w * 6, v + h),
-		uvBack1 = Vector2f(u + w * 6, v),
-		uvLeft0 = Vector2f(u + w * 8, v + h),
-		uvLeft1 = Vector2f(u + w * 8, v);
+		uvSouthWest = Vector2f(0, 0.99),     // 0.99 avoids an ugly 1px border on the bottom
+		uvNorthWest = Vector2f(0, 0),
+		uvSouthEast = Vector2f(2, 0.99),     // 2 = each side of the skybox contains 2 repeats of the same texture
+		uvNorthEast = Vector2f(2, 0);
 
 	const std::array<Vector2f, 24> texc =
 	{
-		// Front quad
-		uvFront0, uvFront1, uvFront2,
-		uvFront3, uvFront2, uvFront1,
-		// Right quad
-		uvFront2, uvFront3, uvRight0,
-		uvRight1, uvRight0, uvFront3,
-		// Back quad
-		uvRight0, uvRight1, uvBack0,
-		uvBack1, uvBack0, uvRight1,
-		// Left quad
-		uvBack0, uvBack1, uvLeft0,
-		uvLeft1, uvLeft0, uvBack1,
+		// North quad
+		uvSouthWest, uvNorthWest, uvSouthEast,
+		uvNorthEast, uvSouthEast, uvNorthWest,
+		// East quad
+		uvSouthWest, uvNorthWest, uvSouthEast,
+		uvNorthEast, uvSouthEast, uvNorthWest,
+		// West quad
+		uvSouthWest, uvNorthWest, uvSouthEast,
+		uvNorthEast, uvSouthEast, uvNorthWest,
+		// South quad
+		uvSouthWest, uvNorthWest, uvSouthEast,
+		uvNorthEast, uvSouthEast, uvNorthWest,
 	};
 
 	gfx_api::context::get().debugStringMarker("Initializing skybox");


### PR DESCRIPTION
Skybox always had alpha, but never used it.

Also, the Beta campaign skybox showed a 1mm blue border at the bottom, caused by the texture repeating from the top. Perhaps just my GFX card, but I skip the last ~1 pixel of the texture to avoid that.

Also a small refactor of the very cryptic skybox vertex/uv coordinate array generation code.

![Screenshot from 2020-11-10 20-56-32](https://user-images.githubusercontent.com/668160/98726852-56e7d580-2397-11eb-8f60-661cc84c43f3.png)

![Screenshot from 2020-11-10 21-00-05](https://user-images.githubusercontent.com/668160/98727124-bc3bc680-2397-11eb-918b-13f526033f6f.png)
