### PR TITLE
[CMake] QuickJS: Workaround optimizer bug in earlier GCC versions

### DIFF
--- a/3rdparty/CMakeLists.txt
+++ b/3rdparty/CMakeLists.txt
@@ -89,6 +89,14 @@ set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
 set(THREADS_PREFER_PTHREAD_FLAG TRUE)
 find_package(Threads REQUIRED)
 target_link_libraries(quickjs PRIVATE Threads::Threads)
+if(CMAKE_C_COMPILER_ID STREQUAL "GNU")
+	# GCC 9.3.0+ has been tested to be fine at -O2
+	if((CMAKE_C_COMPILER_VERSION VERSION_LESS 9.3) AND (CMAKE_C_COMPILER_VERSION VERSION_GREATER 7.0))
+		# Avoid SEGFAULT with earlier GCC and fcode-hoisting
+		message(STATUS "QuickJS: Using -fno-code-hoisting (${CMAKE_C_COMPILER_ID} ${CMAKE_C_COMPILER_VERSION})")
+		target_compile_options(quickjs PRIVATE -fno-code-hoisting)
+	endif()
+endif()
 if(MSVC)
 	# Disable some warnings for QuickJS
 	set(QUICKJS_COMPILE_OPTIONS "")


### PR DESCRIPTION
Avoid SEGFAULT in QuickJS with earlier GCC and `fcode-hoisting` (which is enabled by default for `-O2` and higher on GCC 7.1+).

GCC versions tested that exhibit the issue:
- GCC 7.3.0
- GCC 8.4.0

GCC versions tested that pass:
- GCC 9.3.0
- GCC 10