### PR TITLE
Fix several potential crashers

### DIFF
--- a/lib/ivis_opengl/gfx_api_gl.cpp
+++ b/lib/ivis_opengl/gfx_api_gl.cpp
@@ -1325,6 +1325,7 @@ inline void gl_context::disableVertexAttribArray(GLuint index)
 
 void gl_context::bind_vertex_buffers(const std::size_t& first, const std::vector<std::tuple<gfx_api::buffer*, std::size_t>>& vertex_buffers_offset)
 {
+	ASSERT_OR_RETURN(, current_program != nullptr, "current_program == NULL");
 	for (size_t i = 0, e = vertex_buffers_offset.size(); i < e && (first + i) < current_program->vertex_buffer_desc.size(); ++i)
 	{
 		const auto& buffer_desc = current_program->vertex_buffer_desc[first + i];
@@ -1345,6 +1346,7 @@ void gl_context::bind_vertex_buffers(const std::size_t& first, const std::vector
 
 void gl_context::unbind_vertex_buffers(const std::size_t& first, const std::vector<std::tuple<gfx_api::buffer*, std::size_t>>& vertex_buffers_offset)
 {
+	ASSERT_OR_RETURN(, current_program != nullptr, "current_program == NULL");
 	for (size_t i = 0, e = vertex_buffers_offset.size(); i < e && (first + i) < current_program->vertex_buffer_desc.size(); ++i)
 	{
 		const auto& buffer_desc = current_program->vertex_buffer_desc[first + i];
@@ -1370,6 +1372,7 @@ void gl_context::disable_all_vertex_buffers()
 
 void gl_context::bind_streamed_vertex_buffers(const void* data, const std::size_t size)
 {
+	ASSERT_OR_RETURN(, current_program != nullptr, "current_program == NULL");
 	ASSERT(size > 0, "bind_streamed_vertex_buffers called with size 0");
 	glBindBuffer(GL_ARRAY_BUFFER, scratchbuffer);
 	if (scratchbuffer_size > 0)
@@ -1388,6 +1391,7 @@ void gl_context::bind_streamed_vertex_buffers(const void* data, const std::size_
 
 void gl_context::bind_index_buffer(gfx_api::buffer& _buffer, const gfx_api::index_type&)
 {
+	ASSERT_OR_RETURN(, current_program != nullptr, "current_program == NULL");
 	auto& buffer = static_cast<gl_buffer&>(_buffer);
 	ASSERT(buffer.usage == gfx_api::buffer::usage::index_buffer, "Passed gfx_api::buffer is not an index buffer");
 	glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, buffer.buffer);
@@ -1400,6 +1404,7 @@ void gl_context::unbind_index_buffer(gfx_api::buffer&)
 
 void gl_context::bind_textures(const std::vector<gfx_api::texture_input>& texture_descriptions, const std::vector<gfx_api::texture*>& textures)
 {
+	ASSERT_OR_RETURN(, current_program != nullptr, "current_program == NULL");
 	ASSERT(textures.size() <= texture_descriptions.size(), "Received more textures than expected");
 	for (size_t i = 0; i < texture_descriptions.size() && i < textures.size(); ++i)
 	{
@@ -1461,6 +1466,7 @@ void gl_context::bind_textures(const std::vector<gfx_api::texture_input>& textur
 
 void gl_context::set_constants(const void* buffer, const size_t& size)
 {
+	ASSERT_OR_RETURN(, current_program != nullptr, "current_program == NULL");
 	current_program->set_constants(buffer);
 }
 

--- a/lib/ivis_opengl/gfx_api_vk.cpp
+++ b/lib/ivis_opengl/gfx_api_vk.cpp
@@ -3052,6 +3052,7 @@ void VkRoot::draw(const std::size_t& offset, const std::size_t& count, const gfx
 
 void VkRoot::draw_elements(const std::size_t& offset, const std::size_t& count, const gfx_api::primitive_type&, const gfx_api::index_type&)
 {
+	ASSERT_OR_RETURN(, currentPSO != nullptr, "currentPSO == NULL");
 	ASSERT(offset <= static_cast<size_t>(std::numeric_limits<uint32_t>::max()), "offset (%zu) exceeds uint32_t max", offset);
 	ASSERT(count <= static_cast<size_t>(std::numeric_limits<uint32_t>::max()), "count (%zu) exceeds uint32_t max", count);
 	buffering_mechanism::get_current_resources().cmdDraw.drawIndexed(static_cast<uint32_t>(count), 1, static_cast<uint32_t>(offset) >> 2, 0, 0, vkDynLoader);
@@ -3059,6 +3060,7 @@ void VkRoot::draw_elements(const std::size_t& offset, const std::size_t& count, 
 
 void VkRoot::bind_vertex_buffers(const std::size_t& first, const std::vector<std::tuple<gfx_api::buffer*, std::size_t>>& vertex_buffers_offset)
 {
+	ASSERT_OR_RETURN(, currentPSO != nullptr, "currentPSO == NULL");
 	std::vector<vk::Buffer> buffers;
 	std::vector<VkDeviceSize> offsets;
 	for (const auto &input : vertex_buffers_offset)
@@ -3085,6 +3087,7 @@ void VkRoot::disable_all_vertex_buffers()
 
 void VkRoot::bind_streamed_vertex_buffers(const void* data, const std::size_t size)
 {
+	ASSERT_OR_RETURN(, currentPSO != nullptr, "currentPSO == NULL");
 	ASSERT(size > 0, "bind_streamed_vertex_buffers called with size 0");
 	ASSERT(size <= static_cast<size_t>(std::numeric_limits<uint32_t>::max()), "size (%zu) exceeds uint32_t max", size);
 	auto& frameResources = buffering_mechanism::get_current_resources();
@@ -3203,6 +3206,7 @@ vk::IndexType VkRoot::to_vk(const gfx_api::index_type& index)
 
 void VkRoot::bind_index_buffer(gfx_api::buffer& index_buffer, const gfx_api::index_type& index)
 {
+	ASSERT_OR_RETURN(, currentPSO != nullptr, "currentPSO == NULL");
 	auto& casted_buf = static_cast<VkBuf&>(index_buffer);
 	ASSERT(casted_buf.usage == gfx_api::buffer::usage::index_buffer, "Passed gfx_api::buffer is not an index buffer");
 	buffering_mechanism::get_current_resources().cmdDraw.bindIndexBuffer(casted_buf.object, 0, to_vk(index), vkDynLoader);
@@ -3215,6 +3219,7 @@ void VkRoot::unbind_index_buffer(gfx_api::buffer&)
 
 void VkRoot::bind_textures(const std::vector<gfx_api::texture_input>& attribute_descriptions, const std::vector<gfx_api::texture*>& textures)
 {
+	ASSERT_OR_RETURN(, currentPSO != nullptr, "currentPSO == NULL");
 	ASSERT(textures.size() <= attribute_descriptions.size(), "Received more textures than expected");
 
 	const auto set = allocateDescriptorSets(currentPSO->textures_set_layout);
@@ -3247,6 +3252,7 @@ void VkRoot::bind_textures(const std::vector<gfx_api::texture_input>& attribute_
 
 void VkRoot::set_constants(const void* buffer, const std::size_t& size)
 {
+	ASSERT_OR_RETURN(, currentPSO != nullptr, "currentPSO == NULL");
 	ASSERT(size <= static_cast<size_t>(std::numeric_limits<uint32_t>::max()), "size (%zu) exceeds uint32_t max", size);
 	const auto stagingMemory = buffering_mechanism::get_current_resources().uniformBufferAllocator.alloc(static_cast<uint32_t>(size), physDeviceProps.limits.minUniformBufferOffsetAlignment);
 	void * pDynamicUniformBufferMapped = buffering_mechanism::get_current_resources().uniformBufferAllocator.mapMemory(stagingMemory);

--- a/lib/ivis_opengl/gfx_api_vk.cpp
+++ b/lib/ivis_opengl/gfx_api_vk.cpp
@@ -3015,6 +3015,7 @@ bool VkRoot::createAllocator()
 	VmaAllocatorCreateInfo allocatorInfo = {};
 	allocatorInfo.physicalDevice = physicalDevice;
 	allocatorInfo.device = dev;
+	allocatorInfo.instance = inst;
 	allocatorInfo.pVulkanFunctions = &vulkanFunctions;
 	allocatorInfo.flags |= VMA_ALLOCATOR_CREATE_EXTERNALLY_SYNCHRONIZED_BIT;
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2985,7 +2985,6 @@ static bool gameLoad(const char *fileName)
 		// Failure to open the file is a failure to load the specified savegame
 		return true;
 	}
-	initLoadingScreen(true);
 	debug(LOG_WZ, "gameLoad");
 
 	// Read the header from the file

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -852,6 +852,7 @@ static void setCDAudioForCurrentGameMode()
 static void startGameLoop()
 {
 	SetGameMode(GS_NORMAL);
+	initLoadingScreen(true);
 
 	ActivityManager::instance().startingGame();
 
@@ -866,6 +867,7 @@ static void startGameLoop()
 	}
 
 	screen_StopBackDrop();
+	closeLoadingScreen();
 
 	// Trap the cursor if cursor snapping is enabled
 	if (war_GetTrapCursor())

--- a/src/terrain.cpp
+++ b/src/terrain.cpp
@@ -1283,10 +1283,10 @@ void drawWater(const glm::mat4 &viewMatrix)
 	const glm::vec4 paramsY2(1.0f / world_coord(5), 0, 0, 0);
 	const auto &renderState = getCurrentRenderState();
 
-	gfx_api::WaterPSO::get().bind();
 	optional<size_t> water1_texPage = iV_GetTexture("page-80-water-1.png");
 	optional<size_t> water2_texPage = iV_GetTexture("page-81-water-2.png");
 	ASSERT_OR_RETURN(, water1_texPage.has_value() && water2_texPage.has_value(), "Failed to load water texture");
+	gfx_api::WaterPSO::get().bind();
 	gfx_api::WaterPSO::get().bind_textures(&pie_Texture(water1_texPage.value()), &pie_Texture(water2_texPage.value()));
 	gfx_api::WaterPSO::get().bind_vertex_buffers(waterVBO);
 	gfx_api::WaterPSO::get().bind_constants({ viewMatrix, paramsX, paramsY, paramsX2, paramsY2,


### PR DESCRIPTION
Should fix #1299

Notes:
- `closeLoadingScreen()` should *always* be called after `initLoadingScreen()`. Where this is called should probably be more dramatically refactored, because the current maze of loading code sometimes leads to both being called twice, but this should resolve the immediate crashes.