### PR TITLE
Check bounds when mouse panning

### DIFF
--- a/src/display.cpp
+++ b/src/display.cpp
@@ -1116,6 +1116,7 @@ void displayWorld()
 			player.p.z = panZTracker->getInitial()
 				+ sin(-player.r.y * (M_PI / 32768)) * horizontalMovement
 				- cos(-player.r.y * (M_PI / 32768)) * verticalMovement;
+			CheckScrollLimits();
 		}
 	}
 


### PR DESCRIPTION
Oops, when panning you can drag the camera out of bounds, making a blip back to the bounds when releasing MMB. Fix.

@KJeff01 