### PR TITLE
[CMake] Windows: Determine latest available runtimes / AppLocalConfig at config time

### DIFF
--- a/pkg/CMakeLists.txt
+++ b/pkg/CMakeLists.txt
@@ -21,6 +21,39 @@ function(copyFileToDir _file _destDir)
 	)
 endfunction()
 
+function(downloadFile URL OUTPUT_FILENAME RETRY_COUNT RESULT_STATUS_CODE RESULT_STATUS_STRING)
+	set(_dl_attempts 0)
+	message(STATUS "Fetching: ${URL}")
+	while(_dl_attempts LESS ${RETRY_COUNT})
+		if(EXISTS "${OUTPUT_FILENAME}")
+			file(REMOVE "${OUTPUT_FILENAME}")
+		endif()
+		file(
+			DOWNLOAD "${URL}" "${OUTPUT_FILENAME}"
+			INACTIVITY_TIMEOUT 60
+			TLS_VERIFY ON
+			STATUS _dl_status
+			LOG _dl_log
+		)
+		list(GET _dl_status 0 _dl_status_code)
+		list(GET _dl_status 1 _dl_status_string)
+		if (_dl_status_code EQUAL 0)
+			# Download succeeded
+			set(${RESULT_STATUS_CODE} ${_dl_status_code} PARENT_SCOPE)
+			set(${RESULT_STATUS_STRING} ${_dl_status_string} PARENT_SCOPE)
+			return()
+		else()
+			MATH(EXPR _num_attempt "${_dl_attempts}+1")
+			message(STATUS "Error (${_dl_status_code}); Attempt (${_num_attempt})...")
+		endif()
+		MATH(EXPR _dl_attempts "${_dl_attempts}+1")
+	endwhile()
+	set(${RESULT_STATUS_CODE} ${_dl_status_code} PARENT_SCOPE)
+	set(${RESULT_STATUS_STRING} ${_dl_status_string} PARENT_SCOPE)
+endfunction()
+
+#########################
+
 if(NOT DEFINED WZ_DIST_LICENSE OR NOT EXISTS "${WZ_DIST_LICENSE}")
 	message(FATAL_ERROR "This file should be included in the project's root CMakeLists.txt, after WZ_DIST_LICENSE is defined.")
 endif()
@@ -144,6 +177,21 @@ if(CMAKE_SYSTEM_NAME MATCHES "Windows")
 
 	if(MSVC)
 		set(NSIS_MSVCRUNTIME "on")
+		# Determine the latest available version of the MSVC runtime
+		# Fetch https://aka.ms/vs/16/release/vc_redist.x64.exe
+		set(_vcredict_dl_url "https://aka.ms/vs/16/release/vc_redist.x64.exe")
+		set(_tmp_vcredist_dl_path "${CMAKE_BINARY_DIR}/_tmp/vc_redist.x64.exe")
+		downloadFile("${_vcredict_dl_url}" "${_tmp_vcredist_dl_path}" 3 _dl_status_code _dl_status_string)
+		if (_dl_status_code EQUAL 0)
+			# Download succeeded - extract version info
+			if(CMAKE_HOST_SYSTEM_NAME MATCHES "Windows")
+				execute_process(COMMAND powershell -ExecutionPolicy Bypass -Command "(Get-Command \"${_tmp_vcredist_dl_path}\").FileVersionInfo.FileBuildPart" OUTPUT_VARIABLE _dl_vcredist_bld_version OUTPUT_STRIP_TRAILING_WHITESPACE)
+				message(STATUS "Latest vc_redist FileBuildPart: \"${_dl_vcredist_bld_version}\"")
+				set(NSIS_CALCULATED_MSVCRT_BLD_MINIMUM "${_dl_vcredist_bld_version}")
+			endif()
+		else()
+			message(WARNING "Failed to fetch: ${_vcredict_dl_url}; error: \"${_dl_status_string}\"")
+		endif()
 	else()
 		unset(NSIS_MSVCRUNTIME)
 	endif()

--- a/pkg/CMakeLists.txt
+++ b/pkg/CMakeLists.txt
@@ -52,6 +52,23 @@ function(downloadFile URL OUTPUT_FILENAME RETRY_COUNT RESULT_STATUS_CODE RESULT_
 	set(${RESULT_STATUS_STRING} ${_dl_status_string} PARENT_SCOPE)
 endfunction()
 
+function(downloadFileCalculateHash URL TMP_DIR HASH RETURN_VARIABLE)
+	set(_tmp_dl_path "${TMP_DIR}/_tmpFileDl")
+	downloadFile("${URL}" "${_tmp_dl_path}" 3 _dl_status_code _dl_status_string)
+	if (_dl_status_code EQUAL 0)
+		# Download succeeded - calculate hash
+		file(${HASH} "${_tmp_dl_path}" _result_hash)
+		set(${RETURN_VARIABLE} "${_result_hash}" PARENT_SCOPE)
+	else()
+		message(WARNING "Failed to fetch: ${URL}")
+		set(${RETURN_VARIABLE} FALSE PARENT_SCOPE)
+	endif()
+	# Delete the temporary download file
+	if(EXISTS "${_tmp_dl_path}")
+		file(REMOVE "${_tmp_dl_path}")
+	endif()
+endfunction()
+
 #########################
 
 if(NOT DEFINED WZ_DIST_LICENSE OR NOT EXISTS "${WZ_DIST_LICENSE}")
@@ -191,6 +208,29 @@ if(CMAKE_SYSTEM_NAME MATCHES "Windows")
 			endif()
 		else()
 			message(WARNING "Failed to fetch: ${_vcredict_dl_url}; error: \"${_dl_status_string}\"")
+		endif()
+		# Determine the latest available AppLocalConfig
+		set(_applocalconfig_buildinfo_dl_url "https://github.com/past-due/applocalconfig/releases/latest/download/BUILD_INFO.md")
+		set(_tmp_applocalconfig_dir "${CMAKE_BINARY_DIR}/_tmp/applocalconfig")
+		set(_tmp_applocalconfig_buildinfo_path "${_tmp_applocalconfig_dir}/BUILD_INFO.md")
+		downloadFile("${_applocalconfig_buildinfo_dl_url}" "${_tmp_applocalconfig_buildinfo_path}" 3 _dl_status_code _dl_status_string)
+		if (_dl_status_code EQUAL 0)
+			# Extract the version from the first line of the BUILD_INFO.md
+			file(STRINGS "${_tmp_applocalconfig_buildinfo_path}" _applocalconfig_build_info_strings LIMIT_COUNT 1)
+			list(GET _applocalconfig_build_info_strings 0 NSIS_APPLOCALCONFIG_VERSION)
+			message(STATUS "NSIS_APPLOCALCONFIG_VERSION: \"${NSIS_APPLOCALCONFIG_VERSION}\"")
+			# Calculate the hashes for the current version
+			downloadFileCalculateHash("https://github.com/past-due/applocalconfig/releases/download/${NSIS_APPLOCALCONFIG_VERSION}/applocalconfig-vc2019-x86.zip" "${_tmp_applocalconfig_dir}" SHA512 _applocalconfig_x86_sha512)
+			downloadFileCalculateHash("https://github.com/past-due/applocalconfig/releases/download/${NSIS_APPLOCALCONFIG_VERSION}/applocalconfig-vc2019-x64.zip" "${_tmp_applocalconfig_dir}" SHA512 _applocalconfig_x64_sha512)
+			if(NOT _applocalconfig_x86_sha512 OR NOT _applocalconfig_x64_sha512)
+				message(FATAL_ERROR "Unable to fetch / calculate hash for applocalconfig: ${NSIS_APPLOCALCONFIG_VERSION}")
+			endif()
+			set(NSIS_APPLOCALCONFIG_SHA512_X86 "${_applocalconfig_x86_sha512}")
+			set(NSIS_APPLOCALCONFIG_SHA512_X64 "${_applocalconfig_x64_sha512}")
+			message(STATUS "NSIS_APPLOCALCONFIG_SHA512_X86: \"${NSIS_APPLOCALCONFIG_SHA512_X86}\"")
+			message(STATUS "NSIS_APPLOCALCONFIG_SHA512_X64: \"${NSIS_APPLOCALCONFIG_SHA512_X64}\"")
+		else()
+			message(FATAL_ERROR "Failed to fetch: ${_applocalconfig_buildinfo_dl_url}; error: \"${_dl_status_string}\"")
 		endif()
 	else()
 		unset(NSIS_MSVCRUNTIME)

--- a/pkg/nsis/NSIS.definitions.in
+++ b/pkg/nsis/NSIS.definitions.in
@@ -9,7 +9,12 @@
 !define WZ_DATADIR_APPEND "@NSIS_WZ_DATADIR_APPEND@"
 !if "@NSIS_MSVCRUNTIME@" == "ON"
   !define MSVCRUNTIME "ON"
-  !define MSVCRT14_BLD_MINIMUM 28720 ; (14.26.28720.3)
+  !if "@NSIS_CALCULATED_MSVCRT_BLD_MINIMUM@" == ""
+    # default minimum if one couldn't be determined at build time - last updated 2020-11-18
+    !define MSVCRT14_BLD_MINIMUM 29325 ; (14.28.29325.2)
+  !else
+    !define MSVCRT14_BLD_MINIMUM @NSIS_CALCULATED_MSVCRT_BLD_MINIMUM@
+  !endif
 
   !if "@CMAKE_VS_PLATFORM_NAME@" == "Win32"
     ; AppLocal (for portable version)

--- a/pkg/nsis/NSIS.definitions.in
+++ b/pkg/nsis/NSIS.definitions.in
@@ -18,18 +18,18 @@
 
   !if "@CMAKE_VS_PLATFORM_NAME@" == "Win32"
     ; AppLocal (for portable version)
-    !define MSVCRT_PORTABLE_DL_URL1 "https://github.com/past-due/applocalconfig/releases/download/v1.1.1/applocalconfig-vc2019-x86.zip"
-    !define MSVCRT_PORTABLE_DL_URL2 "https://downloads.sourceforge.net/project/applocalconfig/releases/1.1.1/applocalconfig-vc2019-x86.zip"
-    !define MSVCRT_PORTABLE_DL_URL_HTTPALT "http://downloads.sourceforge.net/project/applocalconfig/releases/1.1.1/applocalconfig-vc2019-x86.zip"
-    !define MSVCRT_PORTABLE_DL_SHA512 "48849dadfb8691960a12deb924d0137bb1288d69721e18997a914a2642190635795189bb6c10005c4b966b39ea3c30547662239a66adea7c6542a7fb608c2230"
+    !define MSVCRT_PORTABLE_DL_URL1 "https://github.com/past-due/applocalconfig/releases/download/@NSIS_APPLOCALCONFIG_VERSION@/applocalconfig-vc2019-x86.zip"
+    !define MSVCRT_PORTABLE_DL_URL2 "https://downloads.sourceforge.net/project/applocalconfig/releases/@NSIS_APPLOCALCONFIG_VERSION@/applocalconfig-vc2019-x86.zip"
+    !define MSVCRT_PORTABLE_DL_URL_HTTPALT "http://downloads.sourceforge.net/project/applocalconfig/releases/@NSIS_APPLOCALCONFIG_VERSION@/applocalconfig-vc2019-x86.zip"
+    !define MSVCRT_PORTABLE_DL_SHA512 "@NSIS_APPLOCALCONFIG_SHA512_X86@"
     !define MSVCRT_PORTABLE_DL_CAPTION "Downloading applocalconfig-vc2019-x86.zip"
   !else
     !if "@CMAKE_VS_PLATFORM_NAME@" == "x64"
       ; AppLocal (for portable version)
-      !define MSVCRT_PORTABLE_DL_URL1 "https://github.com/past-due/applocalconfig/releases/download/v1.1.1/applocalconfig-vc2019-x64.zip"
-      !define MSVCRT_PORTABLE_DL_URL2 "https://downloads.sourceforge.net/project/applocalconfig/releases/1.1.1/applocalconfig-vc2019-x64.zip"
-      !define MSVCRT_PORTABLE_DL_URL_HTTPALT "http://downloads.sourceforge.net/project/applocalconfig/releases/1.1.1/applocalconfig-vc2019-x64.zip"
-      !define MSVCRT_PORTABLE_DL_SHA512 "1ea42e1de870cbb860eea4db8bb7d356257040ba0a7fa48d4f9cb072b3aa88a3dec6a72179002e26d381d54af6f500ed015ca568678033ab2c848e4120eadf8c"
+      !define MSVCRT_PORTABLE_DL_URL1 "https://github.com/past-due/applocalconfig/releases/download/@NSIS_APPLOCALCONFIG_VERSION@/applocalconfig-vc2019-x64.zip"
+      !define MSVCRT_PORTABLE_DL_URL2 "https://downloads.sourceforge.net/project/applocalconfig/releases/@NSIS_APPLOCALCONFIG_VERSION@/applocalconfig-vc2019-x64.zip"
+      !define MSVCRT_PORTABLE_DL_URL_HTTPALT "http://downloads.sourceforge.net/project/applocalconfig/releases/@NSIS_APPLOCALCONFIG_VERSION@/applocalconfig-vc2019-x64.zip"
+      !define MSVCRT_PORTABLE_DL_SHA512 "@NSIS_APPLOCALCONFIG_SHA512_X64@"
       !define MSVCRT_PORTABLE_DL_CAPTION "Downloading applocalconfig-vc2019-x64.zip"
     !else
       !warning "Missing defines for platform: (@CMAKE_VS_PLATFORM_NAME@) in NSIS.definitions.in"


### PR DESCRIPTION
This should largely avoid the need to manually update `pkg/nsis/NSIS.definitions.in`