### PR TITLE
Revert "Fix buildDroid leak"

### DIFF
--- a/src/wzapi.cpp
+++ b/src/wzapi.cpp
@@ -1754,10 +1754,8 @@ bool wzapi::buildDroid(WZAPI_PARAMS(STRUCTURE *psFactory, std::string templName,
 			debug(LOG_ERROR, "Could not produce template %s in %s", getName(psTemplate), objInfo(psStruct));
 			return false;
 		}
-		delete psTemplate;
-		return true;
 	}
-	return false;
+	return (psTemplate != nullptr);
 }
 
 //-- ## addDroid(player, x, y, name, body, propulsion, reserved, reserved, turrets...)


### PR DESCRIPTION
This reverts commit 845d596c7b886cca71285b2635e510c939be50ba.

`addTemplate` takes ownership of the template, and `droidTemplateShutDown` then later attempts to delete it.

A better refactoring of this template logic will be forthcoming.