### PR TITLE
Allow destroying transporters in campaign.

### DIFF
--- a/data/base/script/campaign/libcampaign_includes/events.js
+++ b/data/base/script/campaign/libcampaign_includes/events.js
@@ -164,9 +164,26 @@ function cam_eventDroidBuilt(droid, structure)
 function cam_eventDestroyed(obj)
 {
 	__camCheckPlaceArtifact(obj);
-	if (obj.type === DROID && obj.droidType === DROID_CONSTRUCT)
+	if (obj.type === DROID)
 	{
-		__camCheckDeadTruck(obj);
+		if (obj.droidType === DROID_CONSTRUCT)
+		{
+			__camCheckDeadTruck(obj);
+		}
+		else if (camIsTransporter(obj))
+		{
+			__camRemoveIncomingTransporter(obj.player);
+			if (obj.player === CAM_HUMAN_PLAYER)
+			{
+				// Player will lose if their transporter gets destroyed
+				__camGameLost();
+				return;
+			}
+			if (camDef(__camPlayerTransports[obj.player]))
+			{
+				delete __camPlayerTransports[obj.player];
+			}
+		}
 	}
 }
 
@@ -205,11 +222,7 @@ function cam_eventTransporterExit(transport)
 		(__camWinLossCallback === CAM_VICTORY_STANDARD &&
 		transport.player === CAM_HUMAN_PLAYER))
 	{
-		// allow the next transport to enter
-		if (camDef(__camIncomingTransports[transport.player]))
-		{
-			delete __camIncomingTransports[transport.player];
-		}
+		__camRemoveIncomingTransporter(transport.player);
 	}
 	else if (__camWinLossCallback === CAM_VICTORY_PRE_OFFWORLD)
 	{

--- a/data/base/script/campaign/libcampaign_includes/transport.js
+++ b/data/base/script/campaign/libcampaign_includes/transport.js
@@ -149,3 +149,12 @@ function __camLandTransporter(player, pos)
 	playSound("pcv395.ogg", pos.x, pos.y, 0); //Incoming enemy transport.
 	camManageGroup(camMakeGroup(ti.droids), ti.order, ti.data);
 }
+
+function __camRemoveIncomingTransporter(player)
+{
+	// allow the next transporter to enter
+	if (camDef(__camIncomingTransports[player]))
+	{
+		delete __camIncomingTransports[player];
+	}
+}

--- a/src/droid.cpp
+++ b/src/droid.cpp
@@ -202,7 +202,6 @@ int droidReloadBar(const BASE_OBJECT *psObj, const WEAPON *psWeap, int weapon_sl
  * \param angle angle of impact (from the damage dealing projectile in relation to this droid)
  * \return > 0 when the dealt damage destroys the droid, < 0 when the droid survives
  *
- * NOTE: This function will damage but _never_ destroy transports when in single player (campaign) mode
  */
 int32_t droidDamage(DROID *psDroid, unsigned damage, WEAPON_CLASS weaponClass, WEAPON_SUBCLASS weaponSubClass, unsigned impactTime, bool isDamagePerSecond, int minDamage)
 {
@@ -232,15 +231,6 @@ int32_t droidDamage(DROID *psDroid, unsigned damage, WEAPON_CLASS weaponClass, W
 	}
 	else if (relativeDamage < 0)
 	{
-		// HACK: Prevent transporters from being destroyed in single player
-		// FIXME: When we fix campaign scripts to use DROID_SUPERTRANSPORTER
-		if ((game.type == LEVEL_TYPE::CAMPAIGN) && !bMultiPlayer && (psDroid->droidType == DROID_TRANSPORTER))
-		{
-			debug(LOG_ATTACK, "Transport(%d) saved from death--since it should never die (SP only)", psDroid->id);
-			psDroid->body = 1;
-			return 0;
-		}
-
 		// Droid destroyed
 		debug(LOG_ATTACK, "droid (%d): DESTROYED", psDroid->id);
 


### PR DESCRIPTION
- Fixes cam2-c video sequence telling the player they can destroy Collective transporters to stop civilians from being captured.
- Fixes cam2-end situation where the player simply does not send off the transporter and the AI is unable to destroy it (delaying a loss).

The original purpose of destroying the player transporter was to prevent "breaking" the game. I do not see this as necessary to hardcode hack into the source since we can fail the player instantly within `eventDestroyed()` from libcampaign in the nigh impossible event it does occur in current campaign maps.

Destroying enemy transporters is trivial and probably not going to happen because of the basic design of missions, however, there is one such possible scenario this is viable and that is in Beta 5 yet could never come to fruition because the game would not allow it despite the video sequence mentioning using AA to take down Collective transporters.