### PR TITLE
Fix hyperlinks for missing videos not linking to the website.

### DIFF
--- a/src/frontend.cpp
+++ b/src/frontend.cpp
@@ -446,6 +446,10 @@ bool runCampaignSelector()
 		SPinit(LEVEL_TYPE::CAMPAIGN);
 		frontEndNewGame(id - FRONTEND_CAMPAIGN_1);
 	}
+	else if (id == FRONTEND_HYPERLINK)
+	{
+		runHyperlink();
+	}
 
 	widgDisplayScreen(psWScreen); // show the widgets currently running
 
@@ -509,6 +513,10 @@ bool runSinglePlayerMenu()
 		case FRONTEND_CHALLENGES:
 			SPinit(LEVEL_TYPE::CAMPAIGN);
 			addChallenges();
+			break;
+
+		case FRONTEND_HYPERLINK:
+			runHyperlink();
 			break;
 
 		default:


### PR DESCRIPTION
"Campaign videos are missing!" is displayed in the bottom left corner if you don't have sequences installed in both the single player menu and the campaign selector menu. These should link to the website like the "official website" text in the topmost menu.

Also, `runHyperlink()` is a 10/10 function description, lol.