### PR TITLE
Use SUPERTRANSPORTER for campaign scripts.

### DIFF
--- a/data/base/script/campaign/cam2-a.js
+++ b/data/base/script/campaign/cam2-a.js
@@ -345,7 +345,7 @@ function eventStartLevel()
 	startedFromMenu = false;
 
 	//Only if starting Beta directly rather than going through Alpha
-	if (enumDroid(CAM_HUMAN_PLAYER, DROID_TRANSPORTER).length === 0)
+	if (enumDroid(CAM_HUMAN_PLAYER, DROID_SUPERTRANSPORTER).length === 0)
 	{
 		startedFromMenu = true;
 		sendPlayerTransporter();

--- a/data/base/script/campaign/cam3-a.js
+++ b/data/base/script/campaign/cam3-a.js
@@ -330,7 +330,7 @@ function eventStartLevel()
 	startedFromMenu = false;
 
 	//Only if starting Gamma directly rather than going through Beta
-	if (enumDroid(CAM_HUMAN_PLAYER, DROID_TRANSPORTER).length === 0)
+	if (enumDroid(CAM_HUMAN_PLAYER, DROID_SUPERTRANSPORTER).length === 0)
 	{
 		startedFromMenu = true;
 		setReinforcementTime(LZ_COMPROMISED_TIME);

--- a/data/base/script/campaign/libcampaign_includes/transport.js
+++ b/data/base/script/campaign/libcampaign_includes/transport.js
@@ -20,7 +20,7 @@ function camIsTransporter(object)
 		return false;
 	}
 
-	return ((object.droidType === DROID_TRANSPORTER) || (object.droidType === DROID_SUPERTRANSPORTER));
+	return object.droidType === DROID_SUPERTRANSPORTER;
 }
 
 //;; ## camSetupTransport(place x, place y, exit x, exit y)

--- a/data/base/script/campaign/libcampaign_includes/victory.js
+++ b/data/base/script/campaign/libcampaign_includes/victory.js
@@ -237,7 +237,7 @@ function __camPlayerDead()
 	else
 	{
 		//Check the transporter.
-		var transporter = enumDroid(CAM_HUMAN_PLAYER, DROID_TRANSPORTER);
+		var transporter = enumDroid(CAM_HUMAN_PLAYER, DROID_SUPERTRANSPORTER);
 		if (transporter.length > 0)
 		{
 			var cargoDroids = enumCargo(transporter[0]);
@@ -259,7 +259,7 @@ function __camPlayerDead()
 		var droidCount = 0;
 		enumDroid(CAM_HUMAN_PLAYER).forEach(function(obj) {
 			droidCount += 1;
-			if (obj.droidType === DROID_TRANSPORTER)
+			if (obj.droidType === DROID_SUPERTRANSPORTER)
 			{
 				droidCount += enumCargo(obj).length;
 			}

--- a/data/base/stats/body.json
+++ b/data/base/stats/body.json
@@ -1283,7 +1283,7 @@
         "armourKinetic": 100,
         "buildPoints": 5000,
         "class": "Transports",
-        "droidType": "TRANSPORTER",
+        "droidType": "SUPERTRANSPORTER",
         "hitpoints": 5000,
         "id": "TransporterBody",
         "model": "drtrans.pie",

--- a/data/mp/stats/body.json
+++ b/data/mp/stats/body.json
@@ -802,7 +802,7 @@
         "buildPoints": 625,
         "buildPower": 500,
         "class": "Transports",
-        "droidType": "TRANSPORTER",
+        "droidType": "SUPERTRANSPORTER",
         "hitpoints": 500,
         "id": "SuperTransportBody",
         "model": "drtrans.pie",

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -586,7 +586,7 @@ void processMouseClickInput()
 		}
 		else
 		{
-			if (!bMultiPlayer  && (establishSelection(selectedPlayer) == SC_DROID_TRANSPORTER || establishSelection(selectedPlayer) == SC_DROID_SUPERTRANSPORTER))
+			if (!bMultiPlayer && establishSelection(selectedPlayer) == SC_DROID_SUPERTRANSPORTER)
 			{
 				// Never, *ever* let user control the transport in SP games--it breaks the scripts!
 				ASSERT(game.type == LEVEL_TYPE::CAMPAIGN, "Game type was set incorrectly!");
@@ -1126,7 +1126,7 @@ void displayWorld()
 		float mouseDeltaY = mouseY() - rotY;
 
 		player.r.y = rotationHorizontalTracker->setTargetDelta(DEG(-mouseDeltaX) / 4)->update()->getCurrent();
-		
+
 		if(bInvertMouse)
 		{
 			mouseDeltaY *= -1;

--- a/src/mission.cpp
+++ b/src/mission.cpp
@@ -621,8 +621,8 @@ void missionFlyTransportersIn(SDWORD iPlayer, bool bTrackTransporter)
 	for (psTransporter = mission.apsDroidLists[iPlayer]; psTransporter != nullptr; psTransporter = psNext)
 	{
 		psNext = psTransporter->psNext;
-		// FIXME: When we convert campaign scripts to use DROID_SUPERTRANSPORTER
-		if (psTransporter->droidType == DROID_TRANSPORTER)
+
+		if (psTransporter->droidType == DROID_SUPERTRANSPORTER)
 		{
 			// Check that this transporter actually contains some droids
 			if (psTransporter->psGroup && psTransporter->psGroup->refCount > 1)
@@ -1792,8 +1792,8 @@ void missionMoveTransporterOffWorld(DROID *psTransporter)
 {
 	W_CLICKFORM     *psForm;
 	DROID           *psDroid;
-	// FIXME: When we convert campaign scripts, use DROID_SUPERTRANSPORTER
-	if (psTransporter->droidType == DROID_TRANSPORTER)
+
+	if (psTransporter->droidType == DROID_SUPERTRANSPORTER)
 	{
 		/* trigger script callback */
 		transporterSetScriptCurrent(psTransporter);

--- a/src/move.cpp
+++ b/src/move.cpp
@@ -1306,7 +1306,7 @@ SDWORD moveCalcDroidSpeed(DROID *psDroid)
 	CHECK_DROID(psDroid);
 
 	// NOTE: This screws up since the transporter is offscreen still (on a mission!), and we are trying to find terrainType of a tile (that is offscreen!)
-	if (psDroid->droidType == DROID_TRANSPORTER && missionIsOffworld())
+	if (psDroid->droidType == DROID_SUPERTRANSPORTER && missionIsOffworld())
 	{
 		PROPULSION_STATS	*propulsion = asPropulsionStats + psDroid->asBits[COMP_PROPULSION];
 		speed = propulsion->maxSpeed;

--- a/src/order.cpp
+++ b/src/order.cpp
@@ -765,8 +765,7 @@ void orderUpdateDroid(DROID *psDroid)
 			// only place it can be trapped - in multiPlayer can only put cyborgs onto a Cyborg Transporter
 			DROID *temp = (DROID *)psDroid->order.psObj;	// NOTE: It is possible to have a NULL here
 
-			// FIXME: since we now have 2 transporter types, we should fix this in the scripts for campaign
-			if (temp && temp->droidType == DROID_TRANSPORTER && !cyborgDroid(psDroid) && game.type != LEVEL_TYPE::CAMPAIGN && bMultiPlayer)
+			if (temp && temp->droidType == DROID_TRANSPORTER && !cyborgDroid(psDroid))
 			{
 				psDroid->order = DroidOrder(DORDER_NONE);
 				actionDroid(psDroid, DACTION_NONE);
@@ -2349,8 +2348,7 @@ void orderSelectedLoc(uint32_t player, uint32_t x, uint32_t y, bool add)
 		if (psCurr->selected)
 		{
 			// can't use bMultiPlayer since multimsg could be off.
-			// FIXME: Fix this for DROID_SUPERTRANSPORTER when we fix campaign scripts
-			if (psCurr->droidType == DROID_TRANSPORTER && game.type == LEVEL_TYPE::CAMPAIGN)
+			if (psCurr->droidType == DROID_SUPERTRANSPORTER && game.type == LEVEL_TYPE::CAMPAIGN)
 			{
 				// Transport in campaign cannot be controlled by players
 				DeSelectDroid(psCurr);
@@ -2770,7 +2768,7 @@ void orderSelectedStatsTwoLocDir(UDWORD player, DROID_ORDER order, STRUCTURE_STA
 /** This function runs though all player's droids to check if any of then is a transporter. Returns the transporter droid if any was found, and NULL else.*/
 DROID *FindATransporter(DROID const *embarkee)
 {
-	bool isCyborg = cyborgDroid(embarkee) || !bMultiPlayer;  // In campaign, any unit can go on a regular transporter, so consider any unit to be a cyborg.
+	bool isCyborg = cyborgDroid(embarkee);
 
 	DROID *bestDroid = nullptr;
 	unsigned bestDist = ~0u;

--- a/src/stats.cpp
+++ b/src/stats.cpp
@@ -294,6 +294,10 @@ static void loadCompStats(WzConfig &json, COMPONENT_STATS *psStats, size_t index
 	{
 		psStats->droidTypeOverride = DROID_TRANSPORTER;
 	}
+	else if (dtype.compare("SUPERTRANSPORTER") == 0)
+	{
+		psStats->droidTypeOverride = DROID_SUPERTRANSPORTER;
+	}
 	else if (dtype.compare("CYBORG") == 0)
 	{
 		psStats->droidTypeOverride = DROID_CYBORG;


### PR DESCRIPTION
Long overdue this one is. Campaign transporter were using DROID_TRANSPORTER instead of DROID_SUPERTRANSPORTER. Currently allows selecting cyborg transporters in campaign but maybe this is useless given the supertransporter is the only type that can fly off map.