### PR TITLE
Show kick reasons.

### DIFF
--- a/src/multiint.h
+++ b/src/multiint.h
@@ -120,6 +120,7 @@ extern char sPlayer[128];
 extern bool multiintDisableLobbyRefresh; // gamefind
 
 void kickPlayer(uint32_t player_id, const char *reason, LOBBY_ERROR_TYPES type);
+void displayKickReasonPopup(const std::string &reason);
 void loadMapPreview(bool hideInterface);
 
 bool changeReadyStatus(UBYTE player, bool bReady);

--- a/src/multijoin.cpp
+++ b/src/multijoin.cpp
@@ -385,7 +385,7 @@ bool MultiPlayerJoin(UDWORD playerIndex)
 		// if skirmish and game full, then kick...
 		if (NetPlay.playercount > game.maxPlayers)
 		{
-			kickPlayer(playerIndex, "the game is already full.", ERROR_FULL);
+			kickPlayer(playerIndex, _("The game is already full."), ERROR_FULL);
 		}
 		// send everyone's stats to the new guy
 		{
@@ -464,7 +464,7 @@ bool recvDataCheck(NETQUEUE queue)
 			sendInGameSystemMessage(msg);
 			addConsoleMessage(msg, LEFT_JUSTIFY, NOTIFY_MESSAGE);
 
-			kickPlayer(player, "your data doesn't match the host's!", ERROR_WRONGDATA);
+			kickPlayer(player, _("Your data doesn't match the host's!"), ERROR_WRONGDATA);
 			debug(LOG_WARNING, "%s (%u) has an incompatible mod. ([%d] got %x, expected %x)", getPlayerName(player), player, i, tempBuffer[i], DataHash[i]);
 			debug(LOG_POPUP, "%s (%u), has an incompatible mod. ([%d] got %x, expected %x)", getPlayerName(player), player, i, tempBuffer[i], DataHash[i]);
 

--- a/src/multimenu.cpp
+++ b/src/multimenu.cpp
@@ -1242,7 +1242,7 @@ void intProcessMultiMenu(UDWORD id)
 				sendInGameSystemMessage(buf);
 				ssprintf(buf, _("kicked %s : %s from the game, and added them to the banned list!"), getPlayerName((unsigned int) i), NetPlay.players[i].IPtextAddress);
 				NETlogEntry(buf, SYNC_FLAG, (unsigned int) i);
-				kickPlayer((unsigned int) i, "you are unwanted by the host.", ERROR_KICKED);
+				kickPlayer((unsigned int) i, _("The host has kicked you from the game."), ERROR_KICKED);
 				return;
 			}
 		}

--- a/src/multiplay.cpp
+++ b/src/multiplay.cpp
@@ -269,7 +269,7 @@ bool multiPlayerLoop()
 						NETlogEntry(msg, SYNC_FLAG, index);
 
 #ifndef DEBUG
-						kickPlayer(index, "invalid data!", ERROR_INVALID);
+						kickPlayer(index, _("Invalid data!"), ERROR_INVALID);
 #endif
 						debug(LOG_WARNING, "Kicking Player %s (%u), they tried to bypass data integrity check!", getPlayerName(index), index);
 					}
@@ -839,7 +839,8 @@ bool recvMessage()
 				}
 				else if (selectedPlayer == player_id)  // we've been told to leave.
 				{
-					debug(LOG_ERROR, "You were kicked because %s", reason);
+					debug(LOG_INFO, "You were kicked because %s", reason);
+					displayKickReasonPopup(reason);
 					setPlayerHasLost(true);
 					ActivityManager::instance().wasKickedByPlayer(NetPlay.players[queue.index], KICK_TYPE, reason);
 				}
@@ -891,7 +892,7 @@ void HandleBadParam(const char *msg, const int from, const int actual)
 	NETlogEntry(buf, SYNC_FLAG, actual);
 	if (NetPlay.isHost)
 	{
-		ssprintf(buf, "Auto kicking player %s, invalid command received.", NetPlay.players[actual].name);
+		ssprintf(buf, _("Auto kicking player %s, invalid command received."), NetPlay.players[actual].name);
 		sendInGameSystemMessage(buf);
 		kickPlayer(actual, buf, KICK_TYPE);
 	}


### PR DESCRIPTION
Makes use of a popup displaying why a player was kicked. Changed the kick error logs to info logs since those aren't really errors.

Fixes #1069. 