### PR TITLE
Do not change the tileset texture of water tiles on the edges of a map.

### DIFF
--- a/src/lighting.cpp
+++ b/src/lighting.cpp
@@ -103,12 +103,6 @@ void initLighting(UDWORD x1, UDWORD y1, UDWORD x2, UDWORD y2)
 			if (i == 0 || j == 0 || i >= mapWidth - 1 || j >= mapHeight - 1)
 			{
 				psTile->illumination = 16;
-
-				// give water tiles at edge of map a border
-				if (terrainType(psTile) == TER_WATER)
-				{
-					psTile->texture = 0;
-				}
 			}
 			else
 			{


### PR DESCRIPTION
isWaterVertex() will fail to identify these water tiles because terrainType() won't be seeing the same tile texture as before.

Since the texture got changed, the game would save an altered version of the map that replaced water with land on the borders.

Fixes #1094. 

Note: I really don't see why we need this? The appearance is the same with or without this code...