### PR TITLE
Only show component tooltips for valid stats.

### DIFF
--- a/src/design.cpp
+++ b/src/design.cpp
@@ -2026,7 +2026,7 @@ static void intSetSystemStats(COMPONENT_STATS *psStats)
 	ASSERT_OR_RETURN(, psStats != nullptr, "Invalid stats pointer");
 
 	/* set form tip to stats string */
-	widgSetTip(psWScreen, IDDES_SYSTEMFORM, getName(psStats));
+	widgSetTip(psWScreen, IDDES_SYSTEMFORM, checkIfZNullStat(psStats) ? "" : getName(psStats));
 
 	/* set form stats for later display in intDisplayStatForm */
 	psForm = (W_FORM *) widgGetFromID(psWScreen, IDDES_SYSTEMFORM);
@@ -2344,7 +2344,7 @@ static void intSetBodyStats(BODY_STATS *psStats)
 	ASSERT_OR_RETURN(, psStats->hasType(STAT_BODY), "stats have wrong type");
 
 	/* set form tip to stats string */
-	widgSetTip(psWScreen, IDDES_BODYFORM, getName(psStats));
+	widgSetTip(psWScreen, IDDES_BODYFORM, checkIfZNullStat(psStats) ? "" : getName(psStats));
 
 	/* armour */
 	//do kinetic armour
@@ -2561,7 +2561,7 @@ static void intSetPropulsionStats(PROPULSION_STATS *psStats)
 	ASSERT_OR_RETURN(, psStats->hasType(STAT_PROPULSION), "stats have wrong type");
 
 	/* set form tip to stats string */
-	widgSetTip(psWScreen, IDDES_PROPFORM, getName(psStats));
+	widgSetTip(psWScreen, IDDES_PROPFORM, checkIfZNullStat(psStats) ? "" : getName(psStats));
 
 	/* set form stats for later display in intDisplayStatForm */
 	psForm = (W_FORM *) widgGetFromID(psWScreen, IDDES_PROPFORM);

--- a/src/statsdef.h
+++ b/src/statsdef.h
@@ -285,8 +285,9 @@ struct BASE_STATS
 	size_t index = 0;  ///< Index into containing array
 };
 
-#define getName(_psStats) ((_psStats)->name.isEmpty()? "" : gettext((_psStats)->name.toUtf8().c_str()))
+#define getName(_psStats) ((_psStats)->name.isEmpty() ? "" : gettext((_psStats)->name.toUtf8().c_str()))
 #define getID(_psStats) (_psStats)->id.toUtf8().c_str()
+#define checkIfZNullStat(_psStats) ((_psStats)->id.toUtf8().find("ZNULL") != std::string::npos)
 
 /* Stats common to all droid components */
 struct COMPONENT_STATS : public BASE_STATS


### PR DESCRIPTION
Check if the stat is one of the "ZNULL" ones and, if so, do not show any tip.

Fixes #1109. 