### PR TITLE
Fix names of campaign Assault Gun towers.

### DIFF
--- a/data/base/stats/research.json
+++ b/data/base/stats/research.json
@@ -3479,7 +3479,7 @@
         "iconID": "IMAGE_RES_DEFENCE",
         "id": "R-Defense-RotMG",
         "msgName": "RES_DEF_RotMG",
-        "name": "Assault Gun Emplacement",
+        "name": "Assault Gun Guard Tower",
         "requiredResearch": [
             "R-Wpn-MG4"
         ],

--- a/data/base/stats/structure.json
+++ b/data/base/stats/structure.json
@@ -2412,7 +2412,7 @@
         "height": 2,
         "hitpoints": 400,
         "id": "Tower-RotMg",
-        "name": "Assault Gun Guard Tower",
+        "name": "Assault Gun Guard Tower 2",
         "resistance": 150,
         "sensorID": "DefaultSensor1Mk1",
         "strength": "MEDIUM",


### PR DESCRIPTION
- Research name no longer calls it an emplacement. This gets reflected in the Intel menu research description.
- Change the name of structure "Tower-RotMg" which is identical to the one given to the player which fixes research applications on both of them.

Fixes #1150. 