### PR TITLE
Prevent debug menu causing a crash and debug add objects menus opening when paused

### DIFF
--- a/src/hci.cpp
+++ b/src/hci.cpp
@@ -1689,6 +1689,10 @@ static void intRunStats()
 	if (intMode != INT_EDITSTAT && objMode == IOBJ_MANUFACTURE)
 	{
 		psOwner = (BASE_OBJECT *)widgGetUserData(psWScreen, IDSTAT_LOOP_LABEL);
+		if (psOwner == nullptr)
+		{
+			return;
+		}
 		ASSERT_OR_RETURN(, psOwner->type == OBJ_STRUCTURE, "Invalid object type");
 
 		psStruct = (STRUCTURE *)psOwner;

--- a/src/hci.cpp
+++ b/src/hci.cpp
@@ -980,6 +980,12 @@ void intResetScreen(bool NoAnim)
 
 void intOpenDebugMenu(OBJECT_TYPE id)
 {
+	if (gamePaused())
+	{
+		// All menu tabs will not work if they are opened, and the forms will fail to cleanup properly, if the game is paused.
+		return;
+	}
+
 	switch (id)
 	{
 	case OBJ_DROID:


### PR DESCRIPTION
Checks if a structure object exists, stopping a crash after opening the droid debug menu when paused. I also prevent the player from opening the "add ..." menus when paused since the tabs don't work afterwords and the GUI code can't cleanup these menus unless you open other menus or pause or...

Fixes #1273. 