### PR TITLE
[JS backends] Specify when arguments / return values map to undefined or null

### DIFF
--- a/src/qtscript.cpp
+++ b/src/qtscript.cpp
@@ -1260,13 +1260,14 @@ bool triggerEventDroidIdle(DROID *psDroid)
 bool triggerEventDroidBuilt(DROID *psDroid, STRUCTURE *psFactory)
 {
 	ASSERT(scriptsReady, "Scripts not initialized yet");
+	optional<const STRUCTURE *> opt_factory = (psFactory) ? optional<const STRUCTURE *>(psFactory) : nullopt;
 	for (auto *instance : scripts)
 	{
 		int player = instance->player();
 		bool receiveAll = instance->isReceivingAllEvents();
 		if (player == psDroid->player || receiveAll)
 		{
-			instance->handle_eventDroidBuilt(psDroid, psFactory);
+			instance->handle_eventDroidBuilt(psDroid, opt_factory);
 		}
 	}
 	return true;
@@ -1281,13 +1282,14 @@ bool triggerEventDroidBuilt(DROID *psDroid, STRUCTURE *psFactory)
 bool triggerEventStructBuilt(STRUCTURE *psStruct, DROID *psDroid)
 {
 	ASSERT(scriptsReady, "Scripts not initialized yet");
+	optional<const DROID *> opt_droid = (psDroid) ? optional<const DROID *>(psDroid) : nullopt;
 	for (auto *instance : scripts)
 	{
 		int player = instance->player();
 		bool receiveAll = instance->isReceivingAllEvents();
 		if (player == psStruct->player || receiveAll)
 		{
-			instance->handle_eventStructureBuilt(psStruct, psDroid);
+			instance->handle_eventStructureBuilt(psStruct, opt_droid);
 		}
 	}
 	return true;
@@ -1301,13 +1303,14 @@ bool triggerEventStructBuilt(STRUCTURE *psStruct, DROID *psDroid)
 bool triggerEventStructDemolish(STRUCTURE *psStruct, DROID *psDroid)
 {
 	ASSERT(scriptsReady, "Scripts not initialized yet");
+	optional<const DROID *> opt_droid = (psDroid) ? optional<const DROID *>(psDroid) : nullopt;
 	for (auto *instance : scripts)
 	{
 		int player = instance->player();
 		bool receiveAll = instance->isReceivingAllEvents();
 		if (player == psStruct->player || receiveAll)
 		{
-			instance->handle_eventStructureDemolish(psStruct, psDroid);
+			instance->handle_eventStructureDemolish(psStruct, opt_droid);
 		}
 	}
 	return true;
@@ -1522,13 +1525,14 @@ bool triggerEventChat(int from, int to, const char *message)
 bool triggerEventBeacon(int from, int to, const char *message, int x, int y)
 {
 	ASSERT(scriptsReady, "Scripts not initialized yet");
+	optional<const char *> opt_message = (message) ? optional<const char *>(message) : nullopt;
 	for (auto *instance : scripts)
 	{
 		int me = instance->player();
 		bool receiveAll = instance->isReceivingAllEvents();
 		if (me == to || receiveAll)
 		{
-			instance->handle_eventBeacon(map_coord(x), map_coord(y), from, to, message);
+			instance->handle_eventBeacon(map_coord(x), map_coord(y), from, to, opt_message);
 		}
 	}
 	return true;

--- a/src/qtscriptfuncs.cpp
+++ b/src/qtscriptfuncs.cpp
@@ -391,7 +391,7 @@ public:
 	//__ if the droid was produced in a factory. It is not triggered for droid theft or
 	//__ gift (check ```eventObjectTransfer``` for that).
 	//__
-	virtual bool handle_eventDroidBuilt(const DROID *psDroid, const STRUCTURE *psFactory) override;
+	virtual bool handle_eventDroidBuilt(const DROID *psDroid, optional<const STRUCTURE *> psFactory) override;
 
 	//__ ## eventStructureBuilt(structure[, droid])
 	//__
@@ -399,14 +399,14 @@ public:
 	//__ if the structure was built by a droid. It is not triggered for building theft
 	//__ (check ```eventObjectTransfer``` for that).
 	//__
-	virtual bool handle_eventStructureBuilt(const STRUCTURE *psStruct, const DROID *psDroid) override;
+	virtual bool handle_eventStructureBuilt(const STRUCTURE *psStruct, optional<const DROID *> psDroid) override;
 
 	//__ ## eventStructureDemolish(structure[, droid])
 	//__
 	//__ An event that is run every time a structure begins to be demolished. This does
 	//__ not trigger again if the structure is partially demolished.
 	//__
-	virtual bool handle_eventStructureDemolish(const STRUCTURE *psStruct, const DROID *psDroid) override;
+	virtual bool handle_eventStructureDemolish(const STRUCTURE *psStruct, optional<const DROID *> psDroid) override;
 
 	//__ ## eventStructureReady(structure)
 	//__
@@ -489,7 +489,7 @@ public:
 	//__ player sending the beacon. For the moment, the ```to``` parameter is always the script player.
 	//__ Message may be undefined.
 	//__
-	virtual bool handle_eventBeacon(int x, int y, int from, int to, const char *message) override;
+	virtual bool handle_eventBeacon(int x, int y, int from, int to, optional<const char *> message) override;
 
 	//__ ## eventBeaconRemoved(from, to)
 	//__
@@ -2703,9 +2703,9 @@ IMPL_EVENT_HANDLER(eventObjectRecycled, const BASE_OBJECT *)
 IMPL_EVENT_HANDLER(eventPlayerLeft, int)
 IMPL_EVENT_HANDLER(eventCheatMode, bool)
 IMPL_EVENT_HANDLER(eventDroidIdle, const DROID *)
-IMPL_EVENT_HANDLER(eventDroidBuilt, const DROID *, const STRUCTURE *)
-IMPL_EVENT_HANDLER(eventStructureBuilt, const STRUCTURE *, const DROID *)
-IMPL_EVENT_HANDLER(eventStructureDemolish, const STRUCTURE *, const DROID *)
+IMPL_EVENT_HANDLER(eventDroidBuilt, const DROID *, optional<const STRUCTURE *>)
+IMPL_EVENT_HANDLER(eventStructureBuilt, const STRUCTURE *, optional<const DROID *>)
+IMPL_EVENT_HANDLER(eventStructureDemolish, const STRUCTURE *, optional<const DROID *>)
 IMPL_EVENT_HANDLER(eventStructureReady, const STRUCTURE *)
 IMPL_EVENT_HANDLER(eventAttacked, const BASE_OBJECT *, const BASE_OBJECT *)
 IMPL_EVENT_HANDLER(eventResearched, const wzapi::researchResult&, wzapi::event_nullable_ptr<const STRUCTURE>, int)
@@ -2715,7 +2715,7 @@ IMPL_EVENT_HANDLER(eventObjectSeen, const BASE_OBJECT *, const BASE_OBJECT *)
 IMPL_EVENT_HANDLER(eventGroupSeen, const BASE_OBJECT *, int)
 IMPL_EVENT_HANDLER(eventObjectTransfer, const BASE_OBJECT *, int)
 IMPL_EVENT_HANDLER(eventChat, int, int, const char *)
-IMPL_EVENT_HANDLER(eventBeacon, int, int, int, int, const char *)
+IMPL_EVENT_HANDLER(eventBeacon, int, int, int, int, optional<const char *>)
 IMPL_EVENT_HANDLER(eventBeaconRemoved, int, int)
 IMPL_EVENT_HANDLER(eventGroupLoss, const BASE_OBJECT *, int, int)
 bool qtscript_scripting_instance::handle_eventArea(const std::string& label, const DROID *psDroid)

--- a/src/qtscriptfuncs.cpp
+++ b/src/qtscriptfuncs.cpp
@@ -1780,6 +1780,19 @@ static QScriptValue callFunction(QScriptEngine *engine, const QString &function,
 		}
 
 		template<typename PtrType>
+		QScriptValue box(wzapi::returned_nullable_ptr<PtrType> result, QScriptEngine* engine)
+		{
+			if (result)
+			{
+				return box<PtrType *>(result, engine);
+			}
+			else
+			{
+				return QScriptValue::NullValue;
+			}
+		}
+
+		template<typename PtrType>
 		QScriptValue box(std::unique_ptr<PtrType> result, QScriptEngine* engine)
 		{
 			if (result)

--- a/src/qtscriptfuncs.cpp
+++ b/src/qtscriptfuncs.cpp
@@ -430,7 +430,7 @@ public:
 	//__ current player. If an ally does the research, the structure parameter will
 	//__ be set to null. The player parameter gives the player it is called for.
 	//__
-	virtual bool handle_eventResearched(const wzapi::researchResult& research, const STRUCTURE *psStruct, int player) override;
+	virtual bool handle_eventResearched(const wzapi::researchResult& research, wzapi::event_nullable_ptr<const STRUCTURE> psStruct, int player) override;
 
 	//__ ## eventDestroyed(object)
 	//__
@@ -1780,6 +1780,19 @@ static QScriptValue callFunction(QScriptEngine *engine, const QString &function,
 		}
 
 		template<typename PtrType>
+		QScriptValue box(wzapi::event_nullable_ptr<PtrType> result, QScriptEngine* engine)
+		{
+			if (result)
+			{
+				return box<PtrType *>(result, engine);
+			}
+			else
+			{
+				return QScriptValue::NullValue;
+			}
+		}
+
+		template<typename PtrType>
 		QScriptValue box(wzapi::returned_nullable_ptr<PtrType> result, QScriptEngine* engine)
 		{
 			if (result)
@@ -2695,7 +2708,7 @@ IMPL_EVENT_HANDLER(eventStructureBuilt, const STRUCTURE *, const DROID *)
 IMPL_EVENT_HANDLER(eventStructureDemolish, const STRUCTURE *, const DROID *)
 IMPL_EVENT_HANDLER(eventStructureReady, const STRUCTURE *)
 IMPL_EVENT_HANDLER(eventAttacked, const BASE_OBJECT *, const BASE_OBJECT *)
-IMPL_EVENT_HANDLER(eventResearched, const wzapi::researchResult&, const STRUCTURE *, int)
+IMPL_EVENT_HANDLER(eventResearched, const wzapi::researchResult&, wzapi::event_nullable_ptr<const STRUCTURE>, int)
 IMPL_EVENT_HANDLER(eventDestroyed, const BASE_OBJECT *)
 IMPL_EVENT_HANDLER(eventPickup, const FEATURE *, const DROID *)
 IMPL_EVENT_HANDLER(eventObjectSeen, const BASE_OBJECT *, const BASE_OBJECT *)

--- a/src/quickjs_backend.cpp
+++ b/src/quickjs_backend.cpp
@@ -480,7 +480,7 @@ public:
 	//__ current player. If an ally does the research, the structure parameter will
 	//__ be set to null. The player parameter gives the player it is called for.
 	//__
-	virtual bool handle_eventResearched(const wzapi::researchResult& research, const STRUCTURE *psStruct, int player) override;
+	virtual bool handle_eventResearched(const wzapi::researchResult& research, wzapi::event_nullable_ptr<const STRUCTURE> psStruct, int player) override;
 
 	//__ ## eventDestroyed(object)
 	//__
@@ -1989,6 +1989,19 @@ static JSValue callFunction(JSContext *ctx, const std::string &function, std::ve
 		}
 
 		template<typename PtrType>
+		JSValue box(wzapi::event_nullable_ptr<PtrType> result, JSContext* ctx)
+		{
+			if (result)
+			{
+				return box<PtrType *>(result, ctx);
+			}
+			else
+			{
+				return JS_NULL;
+			}
+		}
+
+		template<typename PtrType>
 		JSValue box(wzapi::returned_nullable_ptr<PtrType> result, JSContext* ctx)
 		{
 			if (result)
@@ -3162,7 +3175,7 @@ IMPL_EVENT_HANDLER(eventStructureBuilt, const STRUCTURE *, const DROID *)
 IMPL_EVENT_HANDLER(eventStructureDemolish, const STRUCTURE *, const DROID *)
 IMPL_EVENT_HANDLER(eventStructureReady, const STRUCTURE *)
 IMPL_EVENT_HANDLER(eventAttacked, const BASE_OBJECT *, const BASE_OBJECT *)
-IMPL_EVENT_HANDLER(eventResearched, const wzapi::researchResult&, const STRUCTURE *, int)
+IMPL_EVENT_HANDLER(eventResearched, const wzapi::researchResult&, wzapi::event_nullable_ptr<const STRUCTURE>, int)
 IMPL_EVENT_HANDLER(eventDestroyed, const BASE_OBJECT *)
 IMPL_EVENT_HANDLER(eventPickup, const FEATURE *, const DROID *)
 IMPL_EVENT_HANDLER(eventObjectSeen, const BASE_OBJECT *, const BASE_OBJECT *)

--- a/src/quickjs_backend.cpp
+++ b/src/quickjs_backend.cpp
@@ -441,7 +441,7 @@ public:
 	//__ if the droid was produced in a factory. It is not triggered for droid theft or
 	//__ gift (check ```eventObjectTransfer``` for that).
 	//__
-	virtual bool handle_eventDroidBuilt(const DROID *psDroid, const STRUCTURE *psFactory) override;
+	virtual bool handle_eventDroidBuilt(const DROID *psDroid, optional<const STRUCTURE *> psFactory) override;
 
 	//__ ## eventStructureBuilt(structure[, droid])
 	//__
@@ -449,14 +449,14 @@ public:
 	//__ if the structure was built by a droid. It is not triggered for building theft
 	//__ (check ```eventObjectTransfer``` for that).
 	//__
-	virtual bool handle_eventStructureBuilt(const STRUCTURE *psStruct, const DROID *psDroid) override;
+	virtual bool handle_eventStructureBuilt(const STRUCTURE *psStruct, optional<const DROID *> psDroid) override;
 
 	//__ ## eventStructureDemolish(structure[, droid])
 	//__
 	//__ An event that is run every time a structure begins to be demolished. This does
 	//__ not trigger again if the structure is partially demolished.
 	//__
-	virtual bool handle_eventStructureDemolish(const STRUCTURE *psStruct, const DROID *psDroid) override;
+	virtual bool handle_eventStructureDemolish(const STRUCTURE *psStruct, optional<const DROID *> psDroid) override;
 
 	//__ ## eventStructureReady(structure)
 	//__
@@ -539,7 +539,7 @@ public:
 	//__ player sending the beacon. For the moment, the ```to``` parameter is always the script player.
 	//__ Message may be undefined.
 	//__
-	virtual bool handle_eventBeacon(int x, int y, int from, int to, const char *message) override;
+	virtual bool handle_eventBeacon(int x, int y, int from, int to, optional<const char *> message) override;
 
 	//__ ## eventBeaconRemoved(from, to)
 	//__
@@ -3170,9 +3170,9 @@ IMPL_EVENT_HANDLER(eventObjectRecycled, const BASE_OBJECT *)
 IMPL_EVENT_HANDLER(eventPlayerLeft, int)
 IMPL_EVENT_HANDLER(eventCheatMode, bool)
 IMPL_EVENT_HANDLER(eventDroidIdle, const DROID *)
-IMPL_EVENT_HANDLER(eventDroidBuilt, const DROID *, const STRUCTURE *)
-IMPL_EVENT_HANDLER(eventStructureBuilt, const STRUCTURE *, const DROID *)
-IMPL_EVENT_HANDLER(eventStructureDemolish, const STRUCTURE *, const DROID *)
+IMPL_EVENT_HANDLER(eventDroidBuilt, const DROID *, optional<const STRUCTURE *>)
+IMPL_EVENT_HANDLER(eventStructureBuilt, const STRUCTURE *, optional<const DROID *>)
+IMPL_EVENT_HANDLER(eventStructureDemolish, const STRUCTURE *, optional<const DROID *>)
 IMPL_EVENT_HANDLER(eventStructureReady, const STRUCTURE *)
 IMPL_EVENT_HANDLER(eventAttacked, const BASE_OBJECT *, const BASE_OBJECT *)
 IMPL_EVENT_HANDLER(eventResearched, const wzapi::researchResult&, wzapi::event_nullable_ptr<const STRUCTURE>, int)
@@ -3182,7 +3182,7 @@ IMPL_EVENT_HANDLER(eventObjectSeen, const BASE_OBJECT *, const BASE_OBJECT *)
 IMPL_EVENT_HANDLER(eventGroupSeen, const BASE_OBJECT *, int)
 IMPL_EVENT_HANDLER(eventObjectTransfer, const BASE_OBJECT *, int)
 IMPL_EVENT_HANDLER(eventChat, int, int, const char *)
-IMPL_EVENT_HANDLER(eventBeacon, int, int, int, int, const char *)
+IMPL_EVENT_HANDLER(eventBeacon, int, int, int, int, optional<const char *>)
 IMPL_EVENT_HANDLER(eventBeaconRemoved, int, int)
 IMPL_EVENT_HANDLER(eventGroupLoss, const BASE_OBJECT *, int, int)
 bool quickjs_scripting_instance::handle_eventArea(const std::string& label, const DROID *psDroid)

--- a/src/quickjs_backend.cpp
+++ b/src/quickjs_backend.cpp
@@ -1989,6 +1989,19 @@ static JSValue callFunction(JSContext *ctx, const std::string &function, std::ve
 		}
 
 		template<typename PtrType>
+		JSValue box(wzapi::returned_nullable_ptr<PtrType> result, JSContext* ctx)
+		{
+			if (result)
+			{
+				return box<PtrType *>(result, ctx);
+			}
+			else
+			{
+				return JS_NULL;
+			}
+		}
+
+		template<typename PtrType>
 		JSValue box(std::unique_ptr<PtrType> result, JSContext* ctx)
 		{
 			if (result)

--- a/src/wzapi.cpp
+++ b/src/wzapi.cpp
@@ -672,7 +672,7 @@ wzapi::no_return_value wzapi::hackRemoveMessage(WZAPI_PARAMS(std::string message
 //-- Function to find and return a game object of DROID, FEATURE or STRUCTURE types, if it exists.
 //-- Otherwise, it will return null. This function is deprecated by getObject(). (3.2+ only)
 //--
-const BASE_OBJECT * wzapi::hackGetObj(WZAPI_PARAMS(int _type, int player, int id)) WZAPI_DEPRECATED
+wzapi::returned_nullable_ptr<const BASE_OBJECT> wzapi::hackGetObj(WZAPI_PARAMS(int _type, int player, int id)) WZAPI_DEPRECATED
 {
 	OBJECT_TYPE type = (OBJECT_TYPE)_type;
 	SCRIPT_ASSERT_PLAYER(nullptr, context, player);
@@ -1766,7 +1766,7 @@ bool wzapi::buildDroid(WZAPI_PARAMS(STRUCTURE *psFactory, std::string templName,
 //-- reserved parameters is recommended. In 3.2+ only, to create droids in off-world (campaign mission list),
 //-- pass -1 as both x and y.
 //--
-const DROID* wzapi::addDroid(WZAPI_PARAMS(int player, int x, int y, std::string templName, string_or_string_list body, string_or_string_list propulsion, reservedParam reserved1, reservedParam reserved2, va_list<string_or_string_list> turrets)) MUTLIPLAY_UNSAFE
+wzapi::returned_nullable_ptr<const DROID> wzapi::addDroid(WZAPI_PARAMS(int player, int x, int y, std::string templName, string_or_string_list body, string_or_string_list propulsion, reservedParam reserved1, reservedParam reserved2, va_list<string_or_string_list> turrets)) MUTLIPLAY_UNSAFE
 {
 	SCRIPT_ASSERT_PLAYER(nullptr, context, player);
 	bool onMission = (x == -1) && (y == -1);
@@ -1851,7 +1851,7 @@ bool wzapi::addDroidToTransporter(WZAPI_PARAMS(game_object_identifier transporte
 //-- Create and place a feature at the given x, y position. Will cause a desync in multiplayer.
 //-- Returns the created game object on success, null otherwise. (3.2+ only)
 //--
-const FEATURE * wzapi::addFeature(WZAPI_PARAMS(std::string featName, int x, int y)) MUTLIPLAY_UNSAFE
+wzapi::returned_nullable_ptr<const FEATURE> wzapi::addFeature(WZAPI_PARAMS(std::string featName, int x, int y)) MUTLIPLAY_UNSAFE
 {
 	int feature = getFeatureStatFromName(WzString::fromUtf8(featName));
 	FEATURE_STATS *psStats = &asFeatureStats[feature];
@@ -2838,7 +2838,7 @@ scr_area wzapi::getScrollLimits(WZAPI_NO_PARAMS)
 //-- Position uses world coordinates, if you want use position based on Map Tiles, then
 //-- use as addStructure(structure id, players, x*128, y*128)
 //--
-const STRUCTURE * wzapi::addStructure(WZAPI_PARAMS(std::string structureName, int player, int x, int y))
+wzapi::returned_nullable_ptr<const STRUCTURE> wzapi::addStructure(WZAPI_PARAMS(std::string structureName, int player, int x, int y))
 {
 	int index = getStructStatFromName(WzString::fromUtf8(structureName.c_str()));
 	SCRIPT_ASSERT(nullptr, context, index >= 0, "%s not found", structureName.c_str());

--- a/src/wzapi.h
+++ b/src/wzapi.h
@@ -112,6 +112,35 @@ namespace wzapi
 
 	struct researchResult; // forward-declare
 
+	template<typename T>
+	struct event_nullable_ptr
+	{
+	private:
+		using TYPE_POINTER = T*;
+		TYPE_POINTER pt;
+
+	public:
+		event_nullable_ptr(TYPE_POINTER _pt)
+		: pt(_pt)
+		{ }
+		event_nullable_ptr()
+		: pt(nullptr)
+		{ }
+
+		operator TYPE_POINTER&()
+		{
+			return pt;
+		}
+		operator TYPE_POINTER() const
+		{
+			return pt;
+		}
+		explicit operator bool() const noexcept
+		{
+			return pt != nullptr;
+		}
+	};
+
 	class scripting_event_handling_interface
 	{
 	public:
@@ -366,7 +395,7 @@ namespace wzapi
 		//__ current player. If an ally does the research, the structure parameter will
 		//__ be set to null. The player parameter gives the player it is called for.
 		//__
-		virtual bool handle_eventResearched(const researchResult& research, const STRUCTURE *psStruct, int player) = 0;
+		virtual bool handle_eventResearched(const researchResult& research, event_nullable_ptr<const STRUCTURE> psStruct, int player) = 0;
 
 		//__ ## eventDestroyed(object)
 		//__

--- a/src/wzapi.h
+++ b/src/wzapi.h
@@ -356,7 +356,7 @@ namespace wzapi
 		//__ if the droid was produced in a factory. It is not triggered for droid theft or
 		//__ gift (check ```eventObjectTransfer``` for that).
 		//__
-		virtual bool handle_eventDroidBuilt(const DROID *psDroid, const STRUCTURE *psFactory) = 0;
+		virtual bool handle_eventDroidBuilt(const DROID *psDroid, optional<const STRUCTURE *> psFactory) = 0;
 
 		//__ ## eventStructureBuilt(structure[, droid])
 		//__
@@ -364,14 +364,14 @@ namespace wzapi
 		//__ if the structure was built by a droid. It is not triggered for building theft
 		//__ (check ```eventObjectTransfer``` for that).
 		//__
-		virtual bool handle_eventStructureBuilt(const STRUCTURE *psStruct, const DROID *psDroid) = 0;
+		virtual bool handle_eventStructureBuilt(const STRUCTURE *psStruct, optional<const DROID *> psDroid) = 0;
 
 		//__ ## eventStructureDemolish(structure[, droid])
 		//__
 		//__ An event that is run every time a structure begins to be demolished. This does
 		//__ not trigger again if the structure is partially demolished.
 		//__
-		virtual bool handle_eventStructureDemolish(const STRUCTURE *psStruct, const DROID *psDroid) = 0;
+		virtual bool handle_eventStructureDemolish(const STRUCTURE *psStruct, optional<const DROID *> psDroid) = 0;
 
 		//__ ## eventStructureReady(structure)
 		//__
@@ -454,7 +454,7 @@ namespace wzapi
 		//__ player sending the beacon. For the moment, the ```to``` parameter is always the script player.
 		//__ Message may be undefined.
 		//__
-		virtual bool handle_eventBeacon(int x, int y, int from, int to, const char *message) = 0;
+		virtual bool handle_eventBeacon(int x, int y, int from, int to, optional<const char *> message) = 0;
 
 		//__ ## eventBeaconRemoved(from, to)
 		//__

--- a/src/wzapi.h
+++ b/src/wzapi.h
@@ -740,6 +740,34 @@ namespace wzapi
 		std::vector<const RESEARCH *> resList;
 		int player;
 	};
+	template<typename T>
+	struct returned_nullable_ptr
+	{
+	private:
+		using TYPE_POINTER = T*;
+		TYPE_POINTER pt;
+
+	public:
+		returned_nullable_ptr(TYPE_POINTER _pt)
+		: pt(_pt)
+		{ }
+		returned_nullable_ptr()
+		: pt(nullptr)
+		{ }
+
+		operator TYPE_POINTER&()
+		{
+			return pt;
+		}
+		operator TYPE_POINTER() const
+		{
+			return pt;
+		}
+		explicit operator bool() const noexcept
+		{
+			return pt != nullptr;
+		}
+	};
 
 	class GameEntityRules
 	{
@@ -873,7 +901,7 @@ namespace wzapi
 	no_return_value hackNetOn(WZAPI_NO_PARAMS);
 	no_return_value hackAddMessage(WZAPI_PARAMS(std::string message, int type, int player, bool immediate));
 	no_return_value hackRemoveMessage(WZAPI_PARAMS(std::string message, int type, int player));
-	const BASE_OBJECT * hackGetObj(WZAPI_PARAMS(int _type, int player, int id)) WZAPI_DEPRECATED;
+	returned_nullable_ptr<const BASE_OBJECT> hackGetObj(WZAPI_PARAMS(int _type, int player, int id)) WZAPI_DEPRECATED;
 	no_return_value hackAssert(WZAPI_PARAMS(bool condition, va_list_treat_as_strings message));
 	bool receiveAllEvents(WZAPI_PARAMS(optional<bool> enabled));
 	no_return_value hackDoNotSave(WZAPI_PARAMS(std::string name));
@@ -910,10 +938,10 @@ namespace wzapi
 	int terrainType(WZAPI_PARAMS(int x, int y));
 	bool orderDroidObj(WZAPI_PARAMS(DROID *psDroid, int _order, BASE_OBJECT *psObj));
 	bool buildDroid(WZAPI_PARAMS(STRUCTURE *psFactory, std::string templName, string_or_string_list body, string_or_string_list propulsion, reservedParam reserved1, reservedParam reserved2, va_list<string_or_string_list> turrets));
-	const DROID* addDroid(WZAPI_PARAMS(int player, int x, int y, std::string templName, string_or_string_list body, string_or_string_list propulsion, reservedParam reserved1, reservedParam reserved2, va_list<string_or_string_list> turrets)); MUTLIPLAY_UNSAFE
+	returned_nullable_ptr<const DROID> addDroid(WZAPI_PARAMS(int player, int x, int y, std::string templName, string_or_string_list body, string_or_string_list propulsion, reservedParam reserved1, reservedParam reserved2, va_list<string_or_string_list> turrets)); MUTLIPLAY_UNSAFE
 	std::unique_ptr<const DROID_TEMPLATE> makeTemplate(WZAPI_PARAMS(int player, std::string templName, string_or_string_list body, string_or_string_list propulsion, reservedParam reserved1, va_list<string_or_string_list> turrets));
 	bool addDroidToTransporter(WZAPI_PARAMS(game_object_identifier transporter, game_object_identifier droid));
-	const FEATURE * addFeature(WZAPI_PARAMS(std::string featName, int x, int y)) MUTLIPLAY_UNSAFE;
+	returned_nullable_ptr<const FEATURE> addFeature(WZAPI_PARAMS(std::string featName, int x, int y)) MUTLIPLAY_UNSAFE;
 	bool componentAvailable(WZAPI_PARAMS(std::string arg1, optional<std::string> arg2));
 	bool isVTOL(WZAPI_PARAMS(const DROID *psDroid));
 	bool safeDest(WZAPI_PARAMS(int player, int x, int y));
@@ -968,7 +996,7 @@ namespace wzapi
 	bool removeObject(WZAPI_PARAMS(BASE_OBJECT *psObj, optional<bool> _sfx));
 	no_return_value setScrollLimits(WZAPI_PARAMS(int x1, int y1, int x2, int y2));
 	scr_area getScrollLimits(WZAPI_NO_PARAMS);
-	const STRUCTURE * addStructure(WZAPI_PARAMS(std::string structureName, int player, int x, int y));
+	returned_nullable_ptr<const STRUCTURE> addStructure(WZAPI_PARAMS(std::string structureName, int player, int x, int y));
 	unsigned int getStructureLimit(WZAPI_PARAMS(std::string structureName, optional<int> _player));
 	int countStruct(WZAPI_PARAMS(std::string structureName, optional<int> _player));
 	int countDroid(WZAPI_PARAMS(optional<int> _type, optional<int> _player));


### PR DESCRIPTION
EDIT:

- event arguments should be wrapped with `optional<>` if they are possibly not provided
   - this will guarantee a mapping to `undefined` on JS (assuming the code that sets the argument properly sets it to `nullopt` when desired)
- wzapi functions that return a single pointer of type T that may be null, should use `wzapi::returned_nullable_ptr<T>`
   - this will guarantee a mapping to `null` on JS if the pointer is null