### PR TITLE
[CMake] Fix Xcode "new build system" error

### DIFF
--- a/po/CMakeLists.txt
+++ b/po/CMakeLists.txt
@@ -154,10 +154,6 @@ ADD_CUSTOM_COMMAND(
 	VERBATIM
 )
 
-ADD_CUSTOM_TARGET(pot_file ALL
-	DEPENDS ${_potFile})
-set_property(TARGET pot_file PROPERTY FOLDER "po")
-
 # Update the in-source warzone2100.pot (Should only run when explicitly built, ex. by CI)
 set(_potFile_inRepo "${CMAKE_CURRENT_SOURCE_DIR}/warzone2100.pot")
 ADD_CUSTOM_COMMAND(


### PR DESCRIPTION
```
CMake Error in po/CMakeLists.txt:
  The custom command generating

    [...]/build/po/warzone2100.pot

  is attached to multiple targets:

    translations_1
    pot_file

  but none of these is a common dependency of the other(s).  This is not
  allowed by the Xcode "new build system".
```