### PR TITLE
Save the file name of challenge files so the extra scripts can be loaded again

### DIFF
--- a/src/challenge.cpp
+++ b/src/challenge.cpp
@@ -76,6 +76,7 @@ static	W_SCREEN	*psRequestScreen;					// Widget screen for requester
 bool		challengesUp = false;		///< True when interface is up and should be run.
 bool		challengeActive = false;	///< Whether we are running a challenge
 std::string challengeName;
+WzString challengeFileName;
 
 static void displayLoadBanner(WIDGET *psWidget, UDWORD xOffset, UDWORD yOffset)
 {
@@ -403,6 +404,7 @@ bool runChallenges()
 				assert(data != nullptr);
 				assert(data->filename != nullptr);
 				sstrcpy(sRequestResult, data->filename);
+				challengeFileName = sRequestResult;
 				challengeName = psWidget->pText.toStdString();
 			}
 			else

--- a/src/challenge.h
+++ b/src/challenge.h
@@ -31,6 +31,7 @@ void updateChallenge(bool gameWon);
 
 extern bool challengesUp;
 extern bool challengeActive;
+extern WzString challengeFileName;
 
 const char* currentChallengeName();
 

--- a/src/multiint.cpp
+++ b/src/multiint.cpp
@@ -393,19 +393,29 @@ void loadMultiScripts()
 	sstrcpy(aPathName, aFileName);
 	sstrcat(aFileName, ".json");
 	sstrcat(aPathName, "/");
-	WzString ininame = challengeActive ? sRequestResult : aFileName;
-	WzString path = challengeActive ? "challenges/" : aPathName;
+	WzString ininame;
+	WzString path;
+	bool loadExtra = false;
+
+	if (challengeFileName.length() > 0)
+	{
+		ininame = challengeFileName;
+		path = "challenges/";
+		loadExtra = true;
+	}
 
 	if (hostlaunch == HostLaunch::Skirmish)
 	{
 		ininame = "tests/" + WzString::fromUtf8(wz_skirmish_test());
 		path = "tests/";
+		loadExtra = true;
 	}
 
 	if (hostlaunch == HostLaunch::Autohost)
 	{
 		ininame = "autohost/" + WzString::fromUtf8(wz_skirmish_test());
 		path = "autohost/";
+		loadExtra = true;
 	}
 
 	// Reset assigned counter
@@ -415,7 +425,7 @@ void loadMultiScripts()
 	}
 
 	// Load map scripts
-	if (PHYSFS_exists(ininame.toUtf8().c_str()))
+	if (loadExtra && PHYSFS_exists(ininame.toUtf8().c_str()))
 	{
 		WzConfig ini(ininame, WzConfig::ReadOnly);
 		debug(LOG_SAVE, "Loading map scripts");


### PR DESCRIPTION
Took the journey of madness and delved into the level loading code once again. Challenge files have the ability to load some additional scripts (see [challenges](https://github.com/Warzone2100/warzone2100/blob/master/doc/Scripting.md#challenges) section of our scripting doc for more details). If the menu option to load the last save is used, it causes a crash if starting from a fresh app start since one of the strings is "" and that can't be opened. If it doesn't crash, ie. through accessing the menus, `loadMultiScripts()` will attempt to load the .gam file of a save thinking it's a JSON file and there will be warning complaints.

Worse yet, challengeActive is always false if the user didn't start a challenge directly from the main menu... luckily it's only there to use the challenge file name, which I ended up saving into main.json to later to load these special scripts correctly when needed.

Fixes #1187. 