### PR TITLE
Correct name of research

### DIFF
--- a/src/research.cpp
+++ b/src/research.cpp
@@ -592,15 +592,8 @@ void researchResult(UDWORD researchIndex, UBYTE player, bool bDisplay, STRUCTURE
 	if (player == selectedPlayer && bDisplay)
 	{
 		//add console text message
-		if (pResearch->pViewData != nullptr)
-		{
-			snprintf(consoleMsg, MAX_RESEARCH_MSG_SIZE, _("Research completed: %s"), _(pResearch->pViewData->textMsg[0].toUtf8().c_str()));
-			addConsoleMessage(consoleMsg, LEFT_JUSTIFY, SYSTEM_MESSAGE);
-		}
-		else
-		{
-			addConsoleMessage(_("Research Completed"), LEFT_JUSTIFY, SYSTEM_MESSAGE);
-		}
+		snprintf(consoleMsg, MAX_RESEARCH_MSG_SIZE, _("Research completed: %s"), _(getName(pResearch)));
+		addConsoleMessage(consoleMsg, LEFT_JUSTIFY, SYSTEM_MESSAGE);
 	}
 
 	if (psResearchFacility)


### PR DESCRIPTION
Correcting the name of the completed research on the screen and in the history console.
Instead of this:
![1](https://user-images.githubusercontent.com/50840397/101282097-0d4aa900-37e4-11eb-9562-cb4120f3a613.png)

Now this:
![2](https://user-images.githubusercontent.com/50840397/101282120-25bac380-37e4-11eb-89ec-124269400ab0.png)
