### PR TITLE
wzapi / JS - Add MapTile info

### DIFF
--- a/src/qtscript.cpp
+++ b/src/qtscript.cpp
@@ -642,6 +642,9 @@ wzapi::scripting_instance* scripting_engine::loadPlayerScript(const WzString& pa
 	// Register 'Stats' object. It is a read-only representation of basic game component states.
 	pNewInstance->setSpecifiedGlobalVariable("Stats", wzapi::constructStatsObject(), wzapi::GlobalVariableFlags::ReadOnly | wzapi::GlobalVariableFlags::DoNotSave);
 
+	// Register 'MapTiles' two-dimensional array. It is a read-only representation of static map tile states.
+	pNewInstance->setSpecifiedGlobalVariable("MapTiles", wzapi::constructMapTilesArray(), wzapi::GlobalVariableFlags::ReadOnly | wzapi::GlobalVariableFlags::DoNotSave);
+
 	// Set some useful constants
 	pNewInstance->setSpecifiedGlobalVariables(wzapi::getUsefulConstants(), wzapi::GlobalVariableFlags::ReadOnly | wzapi::GlobalVariableFlags::DoNotSave);
 

--- a/src/qtscriptfuncs.cpp
+++ b/src/qtscriptfuncs.cpp
@@ -2806,6 +2806,7 @@ IMPL_JS_FUNC(distBetweenTwoPoints, wzapi::distBetweenTwoPoints)
 IMPL_JS_FUNC(droidCanReach, wzapi::droidCanReach)
 IMPL_JS_FUNC(propulsionCanReach, wzapi::propulsionCanReach)
 IMPL_JS_FUNC(terrainType, wzapi::terrainType)
+IMPL_JS_FUNC(tileIsBurning, wzapi::tileIsBurning)
 IMPL_JS_FUNC(orderDroid, wzapi::orderDroid)
 IMPL_JS_FUNC(orderDroidObj, wzapi::orderDroidObj)
 IMPL_JS_FUNC(orderDroidBuild, wzapi::orderDroidBuild)
@@ -3094,6 +3095,7 @@ bool qtscript_scripting_instance::registerFunctions(const QString& scriptName)
 	JS_REGISTER_FUNC(droidCanReach); // WZAPI
 	JS_REGISTER_FUNC(propulsionCanReach); // WZAPI
 	JS_REGISTER_FUNC(terrainType); // WZAPI
+	JS_REGISTER_FUNC(tileIsBurning); // WZAPI
 	JS_REGISTER_FUNC(orderDroidBuild); // WZAPI
 	JS_REGISTER_FUNC(orderDroidObj); // WZAPI
 	JS_REGISTER_FUNC(orderDroid); // WZAPI

--- a/src/quickjs_backend.cpp
+++ b/src/quickjs_backend.cpp
@@ -3276,6 +3276,7 @@ IMPL_JS_FUNC(distBetweenTwoPoints, wzapi::distBetweenTwoPoints)
 IMPL_JS_FUNC(droidCanReach, wzapi::droidCanReach)
 IMPL_JS_FUNC(propulsionCanReach, wzapi::propulsionCanReach)
 IMPL_JS_FUNC(terrainType, wzapi::terrainType)
+IMPL_JS_FUNC(tileIsBurning, wzapi::tileIsBurning)
 IMPL_JS_FUNC(orderDroid, wzapi::orderDroid)
 IMPL_JS_FUNC(orderDroidObj, wzapi::orderDroidObj)
 IMPL_JS_FUNC(orderDroidBuild, wzapi::orderDroidBuild)
@@ -3619,6 +3620,7 @@ bool quickjs_scripting_instance::registerFunctions(const std::string& scriptName
 	JS_REGISTER_FUNC(droidCanReach, 3); // WZAPI
 	JS_REGISTER_FUNC(propulsionCanReach, 5); // WZAPI
 	JS_REGISTER_FUNC(terrainType, 2); // WZAPI
+	JS_REGISTER_FUNC(tileIsBurning, 2); // WZAPI
 	JS_REGISTER_FUNC2(orderDroidBuild, 5, 6); // WZAPI
 	JS_REGISTER_FUNC(orderDroidObj, 3); // WZAPI
 	JS_REGISTER_FUNC(orderDroid, 2); // WZAPI

--- a/src/wzapi.cpp
+++ b/src/wzapi.cpp
@@ -1581,6 +1581,17 @@ int wzapi::terrainType(WZAPI_PARAMS(int x, int y))
 	return ::terrainType(mapTile(x, y));
 }
 
+//-- ## tileIsBurning(x, y)
+//--
+//-- Returns whether the given map tile is burning. (3.5+ only)
+//--
+bool wzapi::tileIsBurning(WZAPI_PARAMS(int x, int y))
+{
+	const MAPTILE *psTile = mapTile(x, y);
+	SCRIPT_ASSERT(false, context, psTile, "Checking fire on tile outside the map (%d, %d)", x, y);
+	return ::TileIsBurning(psTile);
+}
+
 //-- ## orderDroidObj(droid, order, object)
 //--
 //-- Give a droid an order to do something to something.

--- a/src/wzapi.cpp
+++ b/src/wzapi.cpp
@@ -4339,3 +4339,31 @@ nlohmann::json wzapi::constructStaticPlayerData()
 	}
 	return playerData;
 }
+
+nlohmann::json wzapi::constructMapTilesArray()
+{
+	// Static knowledge about map tiles
+	//== * ```MapTiles``` A two-dimensional array of static information about the map tiles in a game. Each item in MapTiles[y][x] is an object
+	//== containing the following variables:
+	//==   * ```terrainType``` (see ```terrainType(x, y)``` function)
+	//==   * ```height``` the height at the top left of the tile
+	//==   * ```hoverContinent``` (For hover type propulsions)
+	//==   * ```limitedContinent``` (For land or sea limited propulsion types)
+	nlohmann::json mapTileArray = nlohmann::json::array();
+	for (SDWORD y = 0; y < mapHeight; y++)
+	{
+		nlohmann::json mapRow = nlohmann::json::array();
+		for (SDWORD x = 0; x < mapWidth; x++)
+		{
+			MAPTILE *psTile = mapTile(x, y);
+			nlohmann::json mapTile = nlohmann::json::object();
+			mapTile["terrainType"] = ::terrainType(psTile);
+			mapTile["height"] = psTile->height;
+			mapTile["hoverContinent"] = psTile->hoverContinent;
+			mapTile["limitedContinent"] = psTile->limitedContinent;
+			mapRow.push_back(std::move(mapTile));
+		}
+		mapTileArray.push_back(std::move(mapRow));
+	}
+	return mapTileArray;
+}

--- a/src/wzapi.cpp
+++ b/src/wzapi.cpp
@@ -4043,9 +4043,9 @@ nlohmann::json wzapi::constructStatsObject()
 			body["Size"] = psStats->size;
 			body["WeaponSlots"] = psStats->weaponSlots;
 			body["BodyClass"] = psStats->bodyClass;
-			bodybase[psStats->name.toUtf8()] = body;
+			bodybase[psStats->name.toUtf8()] = std::move(body);
 		}
-		stats["Body"] = bodybase;
+		stats["Body"] = std::move(bodybase);
 
 		//==   * ```Sensor``` Sensor turrets
 		nlohmann::json sensorbase = nlohmann::json::object();
@@ -4054,9 +4054,9 @@ nlohmann::json wzapi::constructStatsObject()
 			SENSOR_STATS *psStats = asSensorStats + j;
 			nlohmann::json sensor = register_common(psStats);
 			sensor["Range"] = psStats->base.range;
-			sensorbase[psStats->name.toUtf8()] = sensor;
+			sensorbase[psStats->name.toUtf8()] = std::move(sensor);
 		}
-		stats["Sensor"] = sensorbase;
+		stats["Sensor"] = std::move(sensorbase);
 
 		//==   * ```ECM``` ECM (Electronic Counter-Measure) turrets
 		nlohmann::json ecmbase = nlohmann::json::object();
@@ -4065,9 +4065,9 @@ nlohmann::json wzapi::constructStatsObject()
 			ECM_STATS *psStats = asECMStats + j;
 			nlohmann::json ecm = register_common(psStats);
 			ecm["Range"] = psStats->base.range;
-			ecmbase[psStats->name.toUtf8()] = ecm;
+			ecmbase[psStats->name.toUtf8()] = std::move(ecm);
 		}
-		stats["ECM"] = ecmbase;
+		stats["ECM"] = std::move(ecmbase);
 
 		//==   * ```Propulsion``` Propulsions
 		nlohmann::json propbase = nlohmann::json::object();
@@ -4083,9 +4083,9 @@ nlohmann::json wzapi::constructStatsObject()
 			v["SkidDeceleration"] = psStats->skidDeceleration;
 			v["Acceleration"] = psStats->acceleration;
 			v["Deceleration"] = psStats->deceleration;
-			propbase[psStats->name.toUtf8()] = v;
+			propbase[psStats->name.toUtf8()] = std::move(v);
 		}
-		stats["Propulsion"] = propbase;
+		stats["Propulsion"] = std::move(propbase);
 
 		//==   * ```Repair``` Repair turrets (not used, incidentally, for repair centers)
 		nlohmann::json repairbase = nlohmann::json::object();
@@ -4094,9 +4094,9 @@ nlohmann::json wzapi::constructStatsObject()
 			REPAIR_STATS *psStats = asRepairStats + j;
 			nlohmann::json repair = register_common(psStats);
 			repair["RepairPoints"] = psStats->base.repairPoints;
-			repairbase[psStats->name.toUtf8()] = repair;
+			repairbase[psStats->name.toUtf8()] = std::move(repair);
 		}
-		stats["Repair"] = repairbase;
+		stats["Repair"] = std::move(repairbase);
 
 		//==   * ```Construct``` Constructor turrets (eg for trucks)
 		nlohmann::json conbase = nlohmann::json::object();
@@ -4105,9 +4105,9 @@ nlohmann::json wzapi::constructStatsObject()
 			CONSTRUCT_STATS *psStats = asConstructStats + j;
 			nlohmann::json con = register_common(psStats);
 			con["ConstructorPoints"] = psStats->base.constructPoints;
-			conbase[psStats->name.toUtf8()] = con;
+			conbase[psStats->name.toUtf8()] = std::move(con);
 		}
-		stats["Construct"] = conbase;
+		stats["Construct"] = std::move(conbase);
 
 		//==   * ```Brain``` Brains
 		nlohmann::json brainbase = nlohmann::json::object();
@@ -4129,9 +4129,9 @@ nlohmann::json wzapi::constructStatsObject()
 				ranks.push_back(psStats->rankNames.at(x));
 			}
 			br["RankNames"] = ranks;
-			brainbase[psStats->name.toUtf8()] = br;
+			brainbase[psStats->name.toUtf8()] = std::move(br);
 		}
-		stats["Brain"] = brainbase;
+		stats["Brain"] = std::move(brainbase);
 
 		//==   * ```Weapon``` Weapon turrets
 		nlohmann::json wbase = nlohmann::json::object();
@@ -4159,9 +4159,9 @@ nlohmann::json wzapi::constructStatsObject()
 			weap["ImpactClass"] = getWeaponSubClass(psStats->weaponSubClass);
 			weap["RepeatClass"] = getWeaponSubClass(psStats->periodicalDamageWeaponSubClass);
 			weap["FireOnMove"] = psStats->fireOnMove;
-			wbase[psStats->name.toUtf8()] = weap;
+			wbase[psStats->name.toUtf8()] = std::move(weap);
 		}
-		stats["Weapon"] = wbase;
+		stats["Weapon"] = std::move(wbase);
 
 		//==   * ```WeaponClass``` Defined weapon classes
 		nlohmann::json weaptypes = nlohmann::json::array(); //engine->newArray(WSC_NUM_WEAPON_SUBCLASSES);
@@ -4169,7 +4169,7 @@ nlohmann::json wzapi::constructStatsObject()
 		{
 			weaptypes.push_back(getWeaponSubClass((WEAPON_SUBCLASS)j));
 		}
-		stats["WeaponClass"] = weaptypes;
+		stats["WeaponClass"] = std::move(weaptypes);
 
 		//==   * ```Building``` Buildings
 		nlohmann::json structbase = nlohmann::json::object();
@@ -4200,9 +4200,9 @@ nlohmann::json wzapi::constructStatsObject()
 			strct["Thermal"] = psStats->base.thermal;
 			strct["HitPoints"] = psStats->base.hitpoints;
 			strct["Resistance"] = psStats->base.resistance;
-			structbase[psStats->name.toUtf8()] = strct;
+			structbase[psStats->name.toUtf8()] = std::move(strct);
 		}
-		stats["Building"] = structbase;
+		stats["Building"] = std::move(structbase);
 	}
 	return stats;
 }
@@ -4335,7 +4335,7 @@ nlohmann::json wzapi::constructStaticPlayerData()
 		vector["isAI"] = !NetPlay.players[i].allocated && NetPlay.players[i].ai >= 0;
 		vector["isHuman"] = NetPlay.players[i].allocated;
 		vector["type"] = SCRIPT_PLAYER;
-		playerData.push_back(vector);
+		playerData.push_back(std::move(vector));
 	}
 	return playerData;
 }

--- a/src/wzapi.h
+++ b/src/wzapi.h
@@ -1047,6 +1047,7 @@ namespace wzapi
 	nlohmann::json getUsefulConstants();
 	nlohmann::json constructStaticPlayerData();
 	std::vector<PerPlayerUpgrades> getUpgradesObject();
+	nlohmann::json constructMapTilesArray();
 }
 
 #endif

--- a/src/wzapi.h
+++ b/src/wzapi.h
@@ -965,6 +965,7 @@ namespace wzapi
 	bool droidCanReach(WZAPI_PARAMS(const DROID *psDroid, int x, int y));
 	bool propulsionCanReach(WZAPI_PARAMS(std::string propulsionName, int x1, int y1, int x2, int y2));
 	int terrainType(WZAPI_PARAMS(int x, int y));
+	bool tileIsBurning(WZAPI_PARAMS(int x, int y));
 	bool orderDroidObj(WZAPI_PARAMS(DROID *psDroid, int _order, BASE_OBJECT *psObj));
 	bool buildDroid(WZAPI_PARAMS(STRUCTURE *psFactory, std::string templName, string_or_string_list body, string_or_string_list propulsion, reservedParam reserved1, reservedParam reserved2, va_list<string_or_string_list> turrets));
 	returned_nullable_ptr<const DROID> addDroid(WZAPI_PARAMS(int player, int x, int y, std::string templName, string_or_string_list body, string_or_string_list propulsion, reservedParam reserved1, reservedParam reserved2, va_list<string_or_string_list> turrets)); MUTLIPLAY_UNSAFE


### PR DESCRIPTION
- Add `MapTiles` global for static map tile information
   >    ```MapTiles``` A two-dimensional array of static information about the map tiles in a game. Each item in MapTiles[y][x] is an object containing the following variables:
   > * ```terrainType``` (see ```terrainType(x, y)``` function)
   > * ```height``` the height at the top left of the tile
   > * ```hoverContinent``` (For hover type propulsions)
   > * ```limitedContinent``` (For land or sea limited propulsion types)
- Add `tileIsBurning(x, y)`
   > Returns whether the given map tile is burning. (3.5+ only)

An evolution of #862, rebased on top of all the wzapi changes.

@EuPhobos @maxsupermanhd @KJeff01