### PR TITLE
Godmode toggle minimap without CC

### DIFF
--- a/src/keybind.cpp
+++ b/src/keybind.cpp
@@ -1252,6 +1252,7 @@ void	kf_ToggleGodMode()
 		}
 		// remove all proximity messages
 		releaseAllProxDisp();
+		radarPermitted = structureExists(selectedPlayer, REF_HQ, true, false) || structureExists(selectedPlayer, REF_HQ, true, true);
 	}
 	else
 	{
@@ -1259,6 +1260,7 @@ void	kf_ToggleGodMode()
 		revealAll(selectedPlayer);
 		pastReveal = getRevealStatus();
 		setRevealStatus(true); // view the entire map
+		radarPermitted = true; //add minimap without CC building
 	}
 
 	std::string cmsg = astringf(_("(Player %u) is using cheat :%s"),


### PR DESCRIPTION
It's really helps for debugging.
Minimap is toggled when using godmode, like click button in debug window "Reveal All" or using hotkeys, without building CC.
Note: Godmode still cannot call without cheat mode enabled.