### PR TITLE
Improvements to cam3-4 mission

### DIFF
--- a/data/base/script/campaign/cam3-4.js
+++ b/data/base/script/campaign/cam3-4.js
@@ -98,7 +98,7 @@ function truckDefense()
 			"NX-Tower-ATMiss", "Sys-NX-CBTower"
 		];
 
-		for (var i = 0; i < truckNum * 2; ++i)
+		for (var i = 0; i < truckNum; ++i)
 		{
 			camQueueBuilding(NEXUS, list[camRand(list.length)]);
 		}
@@ -133,7 +133,6 @@ function eventStartLevel()
 	camCompleteRequiredResearch(NEXUS_RES, NEXUS);
 	setupNexusPatrols();
 	camManageTrucks(NEXUS);
-	truckDefense();
 
 	camSetArtifacts({
 		"NX-NWCyborgFactory": { tech: "R-Wpn-RailGun03" },
@@ -330,5 +329,5 @@ function eventStartLevel()
 	hackAddMessage("CM34_OBJ1", PROX_MSG, CAM_HUMAN_PLAYER);
 
 	queue("enableAllFactories", camChangeOnDiff(camMinutesToMilliseconds(10)));
-	setTimer("truckDefense", camChangeOnDiff(camMinutesToMilliseconds(5)));
+	setTimer("truckDefense", camChangeOnDiff(camMinutesToMilliseconds(15)));
 }

--- a/data/base/script/campaign/cam3-4.js
+++ b/data/base/script/campaign/cam3-4.js
@@ -95,7 +95,8 @@ function truckDefense()
 	{
 		var list = [
 			"Sys-NEXUSLinkTOW", "P0-AASite-SAM2", "Emplacement-PrisLas",
-			"NX-Tower-ATMiss", "Sys-NX-CBTower"
+			"NX-Tower-ATMiss", "Sys-NX-CBTower", "Emplacement-HvART-pit",
+			"Sys-SensoTower02"
 		];
 
 		for (var i = 0; i < truckNum; ++i)

--- a/data/base/script/campaign/libcampaign_includes/events.js
+++ b/data/base/script/campaign/libcampaign_includes/events.js
@@ -294,6 +294,15 @@ function cam_eventAttacked(victim, attacker)
 			if (camDef(__camGroupInfo[victim.group]))
 			{
 				__camGroupInfo[victim.group].lastHit = gameTime;
+
+				//Increased Nexus intelligence if struck on cam3-4
+				if (__camNextLevel === "GAMMA_OUT")
+				{
+					if (__camGroupInfo[victim.group].order === CAM_ORDER_PATROL)
+					{
+						__camGroupInfo[victim.group].order = CAM_ORDER_ATTACK;
+					}
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Dramatically slow down truck build order pace, allow trucks to build Archangel Missile Emplacements and Hardened Sensor Towers, and make Nexus patrol groups turn aggressive if attacked.

I noticed two trucks build and two don't on this mission. I don't really see any reason why the build order fails, script-side, despite returning true in `__camTruckTick()`. With debug outputs the failing trucks are choosing locations directly underneath them which may be causing issues.