### PR TITLE
Rotary MG Bunker research Fix

### DIFF
--- a/data/base/stats/research.json
+++ b/data/base/stats/research.json
@@ -3452,9 +3452,12 @@
     },
     "R-Defense-Pillbox-RotMG": {
         "id": "R-Defense-Pillbox-RotMG",
-        "name": "Rotary MG Bunker",
+        "name": "Assault Gun Bunker",
         "redStructures": [
             "PillBox1"
+        ],
+	    "requiredResearch": [
+            "R-Wpn-MG4"
         ],
         "researchPoints": 4800,
         "researchPower": 150,

--- a/data/base/stats/structure.json
+++ b/data/base/stats/structure.json
@@ -2153,7 +2153,7 @@
         "height": 1,
         "hitpoints": 500,
         "id": "Pillbox-RotMG",
-        "name": "Rotary MG Bunker",
+        "name": "Assault Gun Bunker",
         "resistance": 150,
         "sensorID": "DefaultSensor1Mk1",
         "strength": "BUNKER",


### PR DESCRIPTION
- Makes the Rotary MG Bunker researchable
- Renames it to Assault Gun Bunker to clarify the name
Fixes #1401 