### PR TITLE
Reset libcampaign cheat mode var on loading saves.

### DIFF
--- a/data/base/script/campaign/libcampaign_includes/debug.js
+++ b/data/base/script/campaign/libcampaign_includes/debug.js
@@ -93,7 +93,7 @@ function camDebugOnce()
 //;;
 function camTrace()
 {
-	if (!__camCheatMode)
+	if (!camIsCheating())
 	{
 		return;
 	}
@@ -109,7 +109,7 @@ function camTrace()
 //;;
 function camTraceOnce()
 {
-	if (!__camCheatMode)
+	if (!camIsCheating())
 	{
 		return;
 	}
@@ -138,7 +138,7 @@ function camIsCheating()
 function __camUpdateMarkedTiles()
 {
 	hackMarkTiles();
-	if (__camCheatMode && camDef(__camMarkedTiles))
+	if (camIsCheating() && camDef(__camMarkedTiles))
 	{
 		for (var label in __camMarkedTiles)
 		{

--- a/data/base/script/campaign/libcampaign_includes/events.js
+++ b/data/base/script/campaign/libcampaign_includes/events.js
@@ -48,7 +48,7 @@ function cam_eventChat(from, to, message)
 	{
 		__camShowVictoryConditions(true);
 	}
-	if (!__camCheatMode)
+	if (!camIsCheating())
 	{
 		return;
 	}
@@ -332,6 +332,10 @@ function cam_eventGameLoaded()
 
 	//Subscribe to eventGroupSeen again.
 	camSetEnemyBases();
+
+	//Reset any vars
+	__camCheatMode = false;
+
 	__camSaveLoading = false;
 }
 


### PR DESCRIPTION
Also use camIsCheating() in place of the var where possible.