### PR TITLE
Prevent CB sensors from observing homing-indirect projectiles.

### DIFF
--- a/src/projectile.cpp
+++ b/src/projectile.cpp
@@ -569,7 +569,7 @@ bool proj_SendProjectileAngled(WEAPON *psWeap, SIMPLE_OBJECT *psAttacker, int pl
 		}
 	}
 
-	if (psAttacker != nullptr && !proj_Direct(psStats))
+	if (psAttacker != nullptr && !proj_Direct(psStats) && psProj->psWStats->movementModel != MM_HOMINGINDIRECT)
 	{
 		//check for Counter Battery Sensor in range of target
 		counterBatteryFire(castBaseObject(psAttacker), psTarget);


### PR DESCRIPTION
Archangel Missile and Seraph Missile Array will not be targeted by (VTOL) CB sensors.

Fixes #1174. 

I believe this achieved what was requested in that issue... whether the idea is acceptable is up to everyone else. Feel free to thumb up/down this post for voting, if you don't feel like contributing thoughts.