### PR TITLE
wzapi: newGroup() - do not generate "duplicate" group ids

### DIFF
--- a/src/qtscript.cpp
+++ b/src/qtscript.cpp
@@ -98,6 +98,12 @@ typedef QList<QStandardItem *> QStandardItemList;
 static bool selectionChanged = false;
 extern bool doUpdateModels; // ugh-ly hack; fix with signal when moc-ing this file
 
+void scripting_engine::GROUPMAP::saveLoadSetLastNewGroupId(int value)
+{
+	ASSERT_OR_RETURN(, value >= 0, "Invalid value: %d", value);
+	lastNewGroupId = value;
+}
+
 int scripting_engine::GROUPMAP::newGroupID()
 {
 	groupID newId = lastNewGroupId + 1;
@@ -907,6 +913,16 @@ bool scripting_engine::loadScriptStates(const char *filename)
 				{
 					int groupId = values.at(k).toInt();
 					loadGroup(instance, groupId, droidId);
+				}
+			}
+			bool bHasLastNewGroupId = false;
+			int lastNewGroupId = ini.value("lastNewGroupId").toInt(&bHasLastNewGroupId);
+			if (bHasLastNewGroupId)
+			{
+				GROUPMAP *psMap = getGroupMap(instance);
+				if (psMap)
+				{
+					psMap->saveLoadSetLastNewGroupId(lastNewGroupId);
 				}
 			}
 		}
@@ -2074,6 +2090,7 @@ bool scripting_engine::saveGroups(nlohmann::json &result, wzapi::scripting_insta
 	// Save group info as a list of group memberships for each droid
 	GROUPMAP *psMap = getGroupMap(instance);
 	ASSERT_OR_RETURN(false, psMap, "Non-existent groupmap for engine");
+	result["lastNewGroupId"] = psMap->getLastNewGroupId();
 	for (auto i = psMap->map().begin(); i != psMap->map().end(); ++i)
 	{
 		const BASE_OBJECT *psObj = i->first;

--- a/src/qtscript.h
+++ b/src/qtscript.h
@@ -26,6 +26,7 @@
 #include "wzapi.h"
 #include <chrono>
 #include <memory>
+#include <unordered_set>
 
 class QString;
 class QStandardItemModel;
@@ -273,7 +274,8 @@ public:
 		typedef std::map<const BASE_OBJECT *, groupID> ObjectToGroupMap;
 	private:
 		ObjectToGroupMap m_map;
-		std::map<groupID, size_t> m_groupCount;
+		typedef std::unordered_set<const BASE_OBJECT *> GroupSet;
+		std::map<groupID, GroupSet> m_groups;
 		int lastNewGroupId = 0;
 	protected:
 		int getLastNewGroupId() const { return lastNewGroupId; }
@@ -283,6 +285,7 @@ public:
 		inline const ObjectToGroupMap& map() const { return m_map; }
 		size_t groupSize(groupID groupId) const;
 		optional<groupID> removeObjectFromGroup(const BASE_OBJECT *psObj);
+		std::vector<const BASE_OBJECT *> getGroupObjects(groupID groupId) const;
 	};
 
 	struct timerNode

--- a/src/qtscript.h
+++ b/src/qtscript.h
@@ -279,7 +279,9 @@ public:
 		std::unordered_map<groupID, GroupSet> m_groups;
 		int lastNewGroupId = 0;
 	protected:
+		friend class scripting_engine;
 		int getLastNewGroupId() const { return lastNewGroupId; }
+		void saveLoadSetLastNewGroupId(int value);
 	public:
 		groupID newGroupID();
 		void insertObjectIntoGroup(const BASE_OBJECT *psObj, groupID groupId);

--- a/src/qtscript.h
+++ b/src/qtscript.h
@@ -27,6 +27,7 @@
 #include <chrono>
 #include <memory>
 #include <unordered_set>
+#include <unordered_map>
 
 class QString;
 class QStandardItemModel;
@@ -271,11 +272,11 @@ public:
 	struct GROUPMAP
 	{
 		typedef int groupID;
-		typedef std::map<const BASE_OBJECT *, groupID> ObjectToGroupMap;
+		typedef std::unordered_map<const BASE_OBJECT *, groupID> ObjectToGroupMap;
 	private:
 		ObjectToGroupMap m_map;
 		typedef std::unordered_set<const BASE_OBJECT *> GroupSet;
-		std::map<groupID, GroupSet> m_groups;
+		std::unordered_map<groupID, GroupSet> m_groups;
 		int lastNewGroupId = 0;
 	protected:
 		int getLastNewGroupId() const { return lastNewGroupId; }

--- a/src/qtscript.h
+++ b/src/qtscript.h
@@ -274,7 +274,11 @@ public:
 	private:
 		ObjectToGroupMap m_map;
 		std::map<groupID, size_t> m_groupCount;
+		int lastNewGroupId = 0;
+	protected:
+		int getLastNewGroupId() const { return lastNewGroupId; }
 	public:
+		groupID newGroupID();
 		void insertObjectIntoGroup(const BASE_OBJECT *psObj, groupID groupId);
 		inline const ObjectToGroupMap& map() const { return m_map; }
 		size_t groupSize(groupID groupId) const;


### PR DESCRIPTION
Note: `newGroup()` is still considered deprecated. There is no way to fully "relinquish" group ids, and while this will not generate new group ids that collide with group ids containing objects, nothing can prevent it from generating a group id that code just decides to hard-code and use for other purposes later.

Hence the recommendation in its deprecation notice still stands.

That said, this should fix existing scripts that rely on it re: loading saves.