### PR TITLE
Additional autohost fixes

### DIFF
--- a/lib/netplay/netplay.cpp
+++ b/lib/netplay/netplay.cpp
@@ -512,7 +512,7 @@ void NETBroadcastPlayerInfo(uint32_t index)
 	NETSendPlayerInfoTo(index, NET_ALL_PLAYERS);
 }
 
-static int NET_CreatePlayer(char const *name)
+static int NET_CreatePlayer(char const *name, bool forceTakeLowestAvailablePlayerNumber = false)
 {
 	int index = -1;
 	int position = INT_MAX;
@@ -524,6 +524,10 @@ static int NET_CreatePlayer(char const *name)
 		{
 			index = i;
 			position = p.position;
+			if (forceTakeLowestAvailablePlayerNumber)
+			{
+				break;
+			}
 		}
 	}
 
@@ -3190,7 +3194,7 @@ bool NEThostGame(const char *SessionName, const char *PlayerName,
 #endif
 	gamestruct.future4 = NETCODE_VERSION_MAJOR << 16 | NETCODE_VERSION_MINOR;	// for future use
 
-	selectedPlayer = NET_CreatePlayer(PlayerName);
+	selectedPlayer = NET_CreatePlayer(PlayerName, (hostlaunch == HostLaunch::Autohost));
 	ASSERT_OR_RETURN(false, selectedPlayer < MAX_PLAYERS, "Failed to create player");
 	realSelectedPlayer = selectedPlayer;
 	NetPlay.isHost	= true;

--- a/src/multiint.cpp
+++ b/src/multiint.cpp
@@ -2899,6 +2899,15 @@ static void loadMapChallengeSettings(WzConfig& ini)
 			game.hash = levGetMapNameHash(game.map);
 
 			LEVEL_DATASET* mapData = levFindDataSet(game.map, &game.hash);
+			if (!mapData)
+			{
+				code_part log_level = (bIsAutoHostOrAutoGame) ? LOG_ERROR : LOG_FATAL;
+				debug(log_level, "Map %s not found!", game.map);
+				if (bIsAutoHostOrAutoGame)
+				{
+					exit(1);
+				}
+			}
 			game.maxPlayers = mapData->players;
 
 			uint8_t configuredMaxPlayers = ini.value("maxPlayers", game.maxPlayers).toUInt();

--- a/src/multiint.cpp
+++ b/src/multiint.cpp
@@ -2913,7 +2913,8 @@ static void loadMapChallengeSettings(WzConfig& ini)
 			uint8_t configuredMaxPlayers = ini.value("maxPlayers", game.maxPlayers).toUInt();
 			if (hostlaunch == HostLaunch::Autohost)
 			{
-				game.maxPlayers = std::max(std::max((uint8_t)1u, configuredMaxPlayers), game.maxPlayers);
+				// always use the autohost config - if it specifies an invalid number of players, this is a bug in the config
+				game.maxPlayers = std::max((uint8_t)1u, configuredMaxPlayers);
 			}
 			else
 			{


### PR DESCRIPTION
- Log error if autohost / challenge map cannot be found (instead of crashing)
- Support autohost maxPlayers overrides in all cases
   - The prior fix still did not permit the autohost config to reduce maxPlayers
- Fix autohost player_0 ("host") override (`NEThostGame` was finding the player index with the lowest "slot position" and using that for the host's "player", conflicting with autohost configs that attempt to move player_0 (the autohost) "out of the way").