### PR TITLE
Fix reticule button init.

### DIFF
--- a/data/base/script/rules.js
+++ b/data/base/script/rules.js
@@ -264,8 +264,8 @@ function setupGame()
 	// Enable all templates
 	setDesign(true);
 
+	showInterface(); // init buttons. This MUST come before setting the reticule button data
 	setMainReticule();
-	showInterface();
 	mainReticule = true;
 	queue("resetPower", 1000);
 }

--- a/data/base/script/tutorial.js
+++ b/data/base/script/tutorial.js
@@ -507,6 +507,7 @@ function eventStartLevel()
 	setMiniMap(true);
 	setDesign(false);
 
+	showInterface(); // init buttons. This MUST come before setting the reticule button data
 	setReticuleButton(CLOSE_BUTTON, _("Close"), "", "");
 	setReticuleButton(PRODUCTION_BUTTON, _("Manufacture - build factory first"), "", "");
 	setReticuleButton(RESEARCH_BUTTON, _("Research - build research facility first"), "", "");
@@ -514,7 +515,6 @@ function eventStartLevel()
 	setReticuleButton(DESIGN_BUTTON, _("Design - construct HQ first"), "", "");
 	setReticuleButton(INTEL_BUTTON, _("Intelligence Display (F5)"), "", "");
 	setReticuleButton(COMMAND_BUTTON, _("Commanders - manufacture commanders first"), "", "");
-	showInterface();
 
 	queue("addToConsole", camSecondsToMilliseconds(2));
 }

--- a/data/mp/multiplay/skirmish/rules.js
+++ b/data/mp/multiplay/skirmish/rules.js
@@ -248,8 +248,8 @@ function setupGame()
 	// Enable all templates
 	setDesign(true);
 
+	showInterface(); // init buttons. This MUST come before setting the reticule button data
 	setMainReticule();
-	showInterface();
 	mainReticule = true;
 }
 


### PR DESCRIPTION
Fixes #1413. 

The first call to `setReticuleButton()` would exit early and leave out a few bits of data the was essential for making the F1-F6 buttons work. This wasn't really a problem because the buttons would get set again, eventually, but for the campaign's Beta 1 this was an issue.