### PR TITLE
Improvements to multiplayer lobby widgets / screens

### DIFF
--- a/lib/netplay/netplay.h
+++ b/lib/netplay/netplay.h
@@ -257,6 +257,24 @@ struct PLAYER
 	bool                autoGame;           ///< if we are running a autogame (AI controls us)
 	std::vector<WZFile> wzFiles;            ///< for each player, we keep track of map/mod download progress
 	char                IPtextAddress[40];  ///< IP of this player
+
+	void resetAll()
+	{
+		name[0] = '\0';
+		position = -1;
+		colour = 0;
+		allocated = false;
+		heartattacktime = 0;
+		heartbeat = false;
+		kick = false;
+		connection = -1;
+		team = -1;
+		ready = false;
+		ai = 0;
+		difficulty = AIDifficulty::DISABLED;
+		autoGame = false;
+		IPtextAddress[0] = '\0';
+	}
 };
 
 struct PlayerReference;

--- a/lib/widget/cliprect.cpp
+++ b/lib/widget/cliprect.cpp
@@ -28,7 +28,7 @@
 
 void ClipRectWidget::run(W_CONTEXT *psContext)
 {
-	W_CONTEXT newContext;
+	W_CONTEXT newContext(psContext);
 	newContext.xOffset = psContext->xOffset + x();
 	newContext.yOffset = psContext->yOffset + y();
 	newContext.mx = psContext->mx - x();
@@ -39,10 +39,7 @@ void ClipRectWidget::run(W_CONTEXT *psContext)
 
 bool ClipRectWidget::processClickRecursive(W_CONTEXT *psContext, WIDGET_KEY key, bool wasPressed)
 {
-	W_CONTEXT newContext;
-	newContext.xOffset = psContext->xOffset;
-	newContext.yOffset = psContext->yOffset;
-	newContext.mx = psContext->mx;
+	W_CONTEXT newContext(psContext);
 	newContext.my = psContext->my + offset.y;
 	return WIDGET::processClickRecursive(&newContext, key, wasPressed);
 }

--- a/lib/widget/cliprect.cpp
+++ b/lib/widget/cliprect.cpp
@@ -40,6 +40,9 @@ void ClipRectWidget::run(W_CONTEXT *psContext)
 bool ClipRectWidget::processClickRecursive(W_CONTEXT *psContext, WIDGET_KEY key, bool wasPressed)
 {
 	W_CONTEXT newContext(psContext);
+	newContext.xOffset = psContext->xOffset - offset.x;
+	newContext.yOffset = psContext->yOffset - offset.y;
+	newContext.mx = psContext->mx + offset.x;
 	newContext.my = psContext->my + offset.y;
 	return WIDGET::processClickRecursive(&newContext, key, wasPressed);
 }

--- a/lib/widget/widgbase.h
+++ b/lib/widget/widgbase.h
@@ -213,6 +213,24 @@ public:
 	{
 		return dim.y();
 	}
+	int screenPosX() const
+	{
+		int screenX = x();
+		for (auto psParent = parent(); psParent != nullptr; psParent = psParent->parent())
+		{
+			screenX += psParent->x();
+		}
+		return screenX;
+	}
+	int screenPosY() const
+	{
+		int screenY = y();
+		for (auto psParent = parent(); psParent != nullptr; psParent = psParent->parent())
+		{
+			screenY += psParent->y();
+		}
+		return screenY;
+	}
 	int width() const
 	{
 		return dim.width();

--- a/lib/widget/widgbase.h
+++ b/lib/widget/widgbase.h
@@ -364,8 +364,39 @@ private:
 /* Context information to pass into the widget functions */
 struct W_CONTEXT
 {
+public:
 	SDWORD		xOffset, yOffset;	// Screen offset of the parent form
 	SDWORD		mx, my;				// mouse position on the form
+
+private:
+	W_CONTEXT()
+	: xOffset(0)
+	, yOffset(0)
+	, mx(0)
+	, my(0)
+	{ }
+public:
+	static W_CONTEXT ZeroContext()
+	{
+		return W_CONTEXT();
+	}
+	W_CONTEXT(SDWORD xOffset, SDWORD yOffset, SDWORD mx, SDWORD my)
+	: xOffset(xOffset)
+	, yOffset(yOffset)
+	, mx(mx)
+	, my(my)
+	{ }
+	W_CONTEXT(const W_CONTEXT& other) = default;
+	W_CONTEXT(const W_CONTEXT* other)
+	: xOffset(0)
+	, yOffset(0)
+	, mx(0)
+	, my(0)
+	{
+		ASSERT_OR_RETURN(, other, "Initializing with null W_CONTEXT");
+		*this = *other;
+	}
+	W_CONTEXT& operator=(const W_CONTEXT& other) = default;
 };
 
 #endif // __INCLUDED_LIB_WIDGET_WIDGBASE_H__

--- a/lib/widget/widgbase.h
+++ b/lib/widget/widgbase.h
@@ -189,7 +189,7 @@ public:
 		setTip((stringUtf8 != nullptr) ? std::string(stringUtf8) : std::string());
 	}
 
-	std::shared_ptr<WIDGET> parent()
+	std::shared_ptr<WIDGET> parent() const
 	{
 		return parentWidget.lock();
 	}

--- a/lib/widget/widget.cpp
+++ b/lib/widget/widget.cpp
@@ -114,6 +114,25 @@ void widgShutDown(void)
 void widgRegisterOverlayScreen(const std::shared_ptr<W_SCREEN> &psScreen, uint16_t zOrder)
 {
 	OverlayScreen newOverlay {psScreen, zOrder};
+	auto it = std::find_if(overlays.begin(), overlays.end(), [psScreen](const OverlayScreen& overlay) -> bool {
+		return overlay.psScreen == psScreen;
+	});
+	if (it != overlays.end())
+	{
+		// screen already exists in overlay stack
+		if (zOrder == it->zOrder)
+		{
+			// no need to update - duplicate call (same zOrder)
+			return;
+		}
+		else
+		{
+			// remove the existing entry
+			overlays.erase(it);
+			it = overlays.end();
+			// fall-through to inserting it again in the new zOrder
+		}
+	}
 	overlays.insert(std::upper_bound(overlays.begin(), overlays.end(), newOverlay, [](const OverlayScreen& a, const OverlayScreen& b){ return a.zOrder > b.zOrder; }), newOverlay);
 }
 

--- a/lib/widget/widget.cpp
+++ b/lib/widget/widget.cpp
@@ -514,6 +514,15 @@ void widgDelete(const std::shared_ptr<W_SCREEN> &psScreen, UDWORD id)
 	ASSERT_OR_RETURN(, psScreen != nullptr, "Invalid screen pointer");
 	widgDelete(widgGetFromID(psScreen, id));
 }
+void widgDeleteLater(const std::shared_ptr<W_SCREEN> &psScreen, UDWORD id)
+{
+	ASSERT_OR_RETURN(, psScreen != nullptr, "Invalid screen pointer");
+	auto psWidget = widgGetFromID(psScreen, id);
+	if (psWidget)
+	{
+		psWidget->deleteLater();
+	}
+}
 
 /* Find a widget on a form from its id number */
 static WIDGET *widgFormGetFromID(WIDGET *widget, UDWORD id)

--- a/lib/widget/widget.cpp
+++ b/lib/widget/widget.cpp
@@ -123,7 +123,8 @@ void widgRemoveOverlayScreen(const std::shared_ptr<W_SCREEN> &psScreen)
 		std::remove_if(
 			overlays.begin(), overlays.end(),
 			[psScreen](const OverlayScreen& a) { return a.psScreen == psScreen; }
-		)
+		),
+		overlays.end()
 	);
 }
 

--- a/lib/widget/widget.cpp
+++ b/lib/widget/widget.cpp
@@ -796,7 +796,7 @@ void WIDGET::processCallbacksRecursive(W_CONTEXT *psContext)
 		}
 
 		/* and then recurse */
-		W_CONTEXT sFormContext;
+		W_CONTEXT sFormContext(psContext);
 		sFormContext.mx = psContext->mx - psCurr->x();
 		sFormContext.my = psContext->my - psCurr->y();
 		sFormContext.xOffset = psContext->xOffset + psCurr->x();
@@ -820,7 +820,7 @@ void WIDGET::runRecursive(W_CONTEXT *psContext)
 		}
 
 		/* Found a sub form, so set up the context */
-		W_CONTEXT sFormContext;
+		W_CONTEXT sFormContext(psContext);
 		sFormContext.mx = psContext->mx - psCurr->x();
 		sFormContext.my = psContext->my - psCurr->y();
 		sFormContext.xOffset = psContext->xOffset + psCurr->x();
@@ -852,7 +852,7 @@ bool WIDGET::processClickRecursive(W_CONTEXT *psContext, WIDGET_KEY key, bool wa
 {
 	bool didProcessClick = false;
 
-	W_CONTEXT shiftedContext;
+	W_CONTEXT shiftedContext(psContext);
 	shiftedContext.mx = psContext->mx - x();
 	shiftedContext.my = psContext->my - y();
 	shiftedContext.xOffset = psContext->xOffset + x();
@@ -928,9 +928,7 @@ WidgetTriggers const &widgRunScreen(const std::shared_ptr<W_SCREEN> &psScreen)
 	psScreen->retWidgets.clear();
 
 	/* Initialise the context */
-	W_CONTEXT sContext;
-	sContext.xOffset = 0;
-	sContext.yOffset = 0;
+	W_CONTEXT sContext = W_CONTEXT::ZeroContext();
 	psMouseOverWidget.reset();
 
 	// Note which keys have been pressed
@@ -1060,9 +1058,7 @@ void widgDisplayScreen(const std::shared_ptr<W_SCREEN> &psScreen)
 	debugBoundingBoxes = debugBoundingBoxes ^ (debugLoc[1] == -1);
 
 	/* Process any user callback functions */
-	W_CONTEXT sContext;
-	sContext.xOffset = 0;
-	sContext.yOffset = 0;
+	W_CONTEXT sContext = W_CONTEXT::ZeroContext();
 	sContext.mx = mouseX();
 	sContext.my = mouseY();
 	psScreen->psForm->processCallbacksRecursive(&sContext);

--- a/lib/widget/widget.h
+++ b/lib/widget/widget.h
@@ -253,6 +253,7 @@ WZ_DECL_NONNULL(2) W_SLIDER *widgAddSlider(const std::shared_ptr<W_SCREEN> &psSc
 /** Delete a widget from the screen */
 void widgDelete(WIDGET *widget);
 void widgDelete(const std::shared_ptr<W_SCREEN> &psScreen, UDWORD id);
+void widgDeleteLater(const std::shared_ptr<W_SCREEN> &psScreen, UDWORD id);
 
 /** Hide a widget */
 void widgHide(const std::shared_ptr<W_SCREEN> &psScreen, UDWORD id);

--- a/src/frontend.cpp
+++ b/src/frontend.cpp
@@ -2181,11 +2181,13 @@ void addText(UDWORD id, UDWORD PosX, UDWORD PosY, const char *txt, UDWORD formID
 }
 
 // ////////////////////////////////////////////////////////////////////////////
-void addSideText(UDWORD id,  UDWORD PosX, UDWORD PosY, const char *txt)
+W_LABEL *addSideText(const std::shared_ptr<W_SCREEN> &psScreen, UDWORD formId, UDWORD id, UDWORD PosX, UDWORD PosY, const char *txt)
 {
+	ASSERT_OR_RETURN(nullptr, psScreen != nullptr, "Invalid screen pointer");
+
 	W_LABINIT sLabInit;
 
-	sLabInit.formID = FRONTEND_BACKDROP;
+	sLabInit.formID = formId;
 	sLabInit.id = id;
 	sLabInit.x = (short) PosX;
 	sLabInit.y = (short) PosY;
@@ -2202,7 +2204,13 @@ void addSideText(UDWORD id,  UDWORD PosX, UDWORD PosY, const char *txt)
 		delete static_cast<DisplayTextOptionCache *>(psWidget->pUserData);
 		psWidget->pUserData = nullptr;
 	};
-	widgAddLabel(psWScreen, &sLabInit);
+
+	return widgAddLabel(psScreen, &sLabInit);
+}
+
+W_LABEL *addSideText(UDWORD id, UDWORD PosX, UDWORD PosY, const char *txt)
+{
+	return addSideText(psWScreen, FRONTEND_BACKDROP, id, PosX, PosY, txt);
 }
 
 // ////////////////////////////////////////////////////////////////////////////

--- a/src/frontend.h
+++ b/src/frontend.h
@@ -74,7 +74,8 @@ void addBottomForm();
 W_FORM *addBackdrop();
 W_FORM *addBackdrop(const std::shared_ptr<W_SCREEN> &screen);
 void addTextButton(UDWORD id, UDWORD PosX, UDWORD PosY, const std::string &txt, unsigned int style);
-void addSideText(UDWORD id, UDWORD PosX, UDWORD PosY, const char *txt);
+W_LABEL *addSideText(UDWORD id, UDWORD PosX, UDWORD PosY, const char *txt);
+W_LABEL *addSideText(const std::shared_ptr<W_SCREEN> &screen, UDWORD formId, UDWORD id, UDWORD PosX, UDWORD PosY, const char *txt);
 void addFESlider(UDWORD id, UDWORD parent, UDWORD x, UDWORD y, UDWORD stops, UDWORD pos);
 
 void displayTextOption(WIDGET *psWidget, UDWORD xOffset, UDWORD yOffset);

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -104,7 +104,7 @@ void gameScreenSizeDidChange(unsigned int oldWidth, unsigned int oldHeight, unsi
 	multiMenuScreenSizeDidChange(oldWidth, oldHeight, newWidth, newHeight);
 	display3dScreenSizeDidChange(oldWidth, oldHeight, newWidth, newHeight);
 	consoleScreenDidChangeSize(oldWidth, oldHeight, newWidth, newHeight);
-	frontendScreenSizeDidChange(oldWidth, oldHeight, newWidth, newHeight);
+	frontendScreenSizeDidChange(oldWidth, oldHeight, newWidth, newHeight); // must be last!
 }
 
 void gameDisplayScaleFactorDidChange(float newDisplayScaleFactor)

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1796,6 +1796,7 @@ static void allocatePlayers()
 		NetPlay.players[i].ai = saveGameData.sNetPlay.players[i].ai;
 		NetPlay.players[i].difficulty = saveGameData.sNetPlay.players[i].difficulty;
 		sstrcpy(NetPlay.players[i].name, saveGameData.sNetPlay.players[i].name);
+		NetPlay.players[i].position = saveGameData.sNetPlay.players[i].position;
 		if (NetPlay.players[i].difficulty == AIDifficulty::HUMAN || (game.type == LEVEL_TYPE::CAMPAIGN && i == 0))
 		{
 			NetPlay.players[i].allocated = true;

--- a/src/hci.cpp
+++ b/src/hci.cpp
@@ -4924,7 +4924,7 @@ void chatDialog(int mode)
 	if (!ChatDialogUp)
 	{
 		auto const &parent = psWScreen->psForm;
-		W_CONTEXT sContext;
+		W_CONTEXT sContext = W_CONTEXT::ZeroContext();
 
 		auto consoleBox = std::make_shared<IntFormAnimated>();
 		parent->attach(consoleBox);
@@ -4947,8 +4947,6 @@ void chatDialog(int mode)
 			chatBox->setBoxColours(WZCOL_YELLOW, WZCOL_YELLOW, WZCOL_MENU_BACKGROUND);
 			widgSetUserData2(psWScreen, CHAT_EDITBOX, CHAT_TEAM);
 		}
-		sContext.xOffset = sContext.yOffset = 0;
-		sContext.mx = sContext.my = 0;
 
 		auto label = std::make_shared<W_LABEL>();
 		consoleBox->attach(label);

--- a/src/loadsave.cpp
+++ b/src/loadsave.cpp
@@ -545,7 +545,6 @@ bool runLoadSave(bool bResetMissionWidgets)
 {
 	static char     sDelete[PATH_MAX];
 	UDWORD		i, campaign;
-	W_CONTEXT		context;
 	char NewSaveGamePath[PATH_MAX] = {'\0'};
 
 	WidgetTriggers const &triggers = widgRunScreen(psRequestScreen);
@@ -634,8 +633,7 @@ bool runLoadSave(bool bResetMissionWidgets)
 				chosenSlotId = id;
 
 				// auto click in the edit box we just made.
-				context.xOffset		= 0;
-				context.yOffset		= 0;
+				W_CONTEXT context = W_CONTEXT::ZeroContext();
 				context.mx			= mouseX();
 				context.my			= mouseY();
 				saveEntryEdit->clicked(&context);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -916,6 +916,10 @@ static void stopGameLoop()
 			{
 				debug(LOG_ERROR, "levReleaseAll failed!");
 			}
+			for (auto& player : NetPlay.players)
+			{
+				player.resetAll();
+			}
 		}
 		closeLoadingScreen();
 		reloadMPConfig();

--- a/src/multiint.cpp
+++ b/src/multiint.cpp
@@ -4495,6 +4495,11 @@ WzMultiplayerOptionsTitleUI::WzMultiplayerOptionsTitleUI(std::shared_ptr<WzTitle
 {
 }
 
+WzMultiplayerOptionsTitleUI::~WzMultiplayerOptionsTitleUI()
+{
+	widgRemoveOverlayScreen(psInlineChooserOverlayScreen);
+}
+
 void WzMultiplayerOptionsTitleUI::screenSizeDidChange(unsigned int oldWidth, unsigned int oldHeight, unsigned int newWidth, unsigned int newHeight)
 {
 	// NOTE: To properly support resizing the inline overlay screen based on underlying screen layer recalculations

--- a/src/multiint.cpp
+++ b/src/multiint.cpp
@@ -2847,6 +2847,10 @@ static void stopJoining(std::shared_ptr<WzTitleUI> parent)
 	changeTitleUI(parent);
 	selectedPlayer = 0;
 	realSelectedPlayer = 0;
+	for (auto& player : NetPlay.players)
+	{
+		player.resetAll();
+	}
 }
 
 static void resetPlayerPositions()

--- a/src/multiint.cpp
+++ b/src/multiint.cpp
@@ -4208,7 +4208,6 @@ TITLECODE WzMultiplayerOptionsTitleUI::run()
 {
 	static UDWORD	lastrefresh = 0;
 	PLAYERSTATS		playerStats;
-	W_CONTEXT		context;
 
 	frontendMultiMessages(true);
 	if (NetPlay.isHost)
@@ -4240,7 +4239,7 @@ TITLECODE WzMultiplayerOptionsTitleUI::run()
 	// if we don't have the focus, then autoclick in the chatbox.
 	if (psWScreen->psFocus.expired())
 	{
-		context.xOffset = 	context.yOffset = 0;
+		W_CONTEXT context = W_CONTEXT::ZeroContext();
 		context.mx			= mouseX();
 		context.my			= mouseY();
 

--- a/src/multiint.h
+++ b/src/multiint.h
@@ -207,6 +207,8 @@ void displayRoomNotifyMessage(char const *text);
 #define MULTIOP_TEAMCHOOSER_END     102841
 #define MULTIOP_TEAMCHOOSER_KICK	10289
 
+#define MULTIOP_INLINE_OVERLAY_ROOT_FRM	10287
+
 // 'Ready' button
 #define MULTIOP_READY_FORM_ID		102900
 #define MULTIOP_READY_START         (MULTIOP_READY_FORM_ID + MAX_PLAYERS + 1)

--- a/src/multijoin.cpp
+++ b/src/multijoin.cpp
@@ -296,6 +296,7 @@ void recvPlayerLeft(NETQUEUE queue)
 	turnOffMultiMsg(true);
 	clearPlayer(playerIndex, false);  // don't do it quietly
 	turnOffMultiMsg(false);
+	setMultiStats(playerIndex, PLAYERSTATS(), true); // local only
 	NetPlay.players[playerIndex].allocated = false;
 
 	NETsetPlayerConnectionStatus(CONNECTIONSTATUS_PLAYER_DROPPED, playerIndex);
@@ -321,6 +322,7 @@ bool MultiPlayerLeave(UDWORD playerIndex)
 	{
 		addConsolePlayerLeftMessage(playerIndex);
 		clearPlayer(playerIndex, false);
+		setMultiStats(playerIndex, PLAYERSTATS(), true); // local only
 	}
 	else if (NetPlay.isHost)  // If hosting, and game has started (not in pre-game lobby screen, that is).
 	{

--- a/src/titleui/multiplayer.h
+++ b/src/titleui/multiplayer.h
@@ -27,6 +27,8 @@
 #include "../wrappers.h"
 #include "titleui.h"
 
+class IntFormAnimated; // forward-declare
+
 class WzMultiplayerOptionsTitleUI : public WzTitleUI
 {
 public:
@@ -59,6 +61,12 @@ private:
 	 * any widgets that may have been positioned on that player's row.
 	 */
 	void initInlineChooser(uint32_t playerIndex);
+
+	/**
+	 * Initializes a chooser, preparing to replace the "right side". This involves removing
+	 * the player list.
+	 */
+	IntFormAnimated* initRightSideChooser(const char* sideText);
 
 	/**
 	 * Initializes the right side box which usually contains the list of players. Handles opening difficulty

--- a/src/titleui/multiplayer.h
+++ b/src/titleui/multiplayer.h
@@ -33,6 +33,7 @@ class WzMultiplayerOptionsTitleUI : public WzTitleUI
 {
 public:
 	WzMultiplayerOptionsTitleUI(std::shared_ptr<WzTitleUI> parent);
+	virtual ~WzMultiplayerOptionsTitleUI();
 	virtual void start() override;
 	virtual TITLECODE run() override;
 	void frontendMultiMessages(bool running);

--- a/src/titleui/multiplayer.h
+++ b/src/titleui/multiplayer.h
@@ -51,6 +51,8 @@ public:
 	void closeColourChooser();
 
 	void closeAllChoosers();
+
+	void screenSizeDidChange(unsigned int oldWidth, unsigned int oldHeight, unsigned int newWidth, unsigned int newHeight) override;
 private:
 	/**
 	 * Initializes a chooser, preparing to add it on a single line on player list. This involves removing
@@ -72,11 +74,11 @@ private:
 
 	void processMultiopWidgets(UDWORD button);
 
+	std::shared_ptr<W_SCREEN> psInlineChooserOverlayScreen = nullptr;
 	std::shared_ptr<WzTitleUI> parent;
 	bool performedFirstStart = false;
 
-	int8_t colourChooserUp;
-	int8_t teamChooserUp;
+	int8_t inlineChooserUp;
 	int8_t aiChooserUp;
 	int8_t difficultyChooserUp;
 	int8_t positionChooserUp;

--- a/src/titleui/passbox.cpp
+++ b/src/titleui/passbox.cpp
@@ -97,11 +97,7 @@ void WzPassBoxTitleUI::start()
 	buttonNo->setTip(_("Cancel"));
 
 	// auto click in the password box
-	W_CONTEXT sContext;
-	sContext.xOffset	= 0;
-	sContext.yOffset	= 0;
-	sContext.mx			= 0;
-	sContext.my			= 0;
+	W_CONTEXT sContext = W_CONTEXT::ZeroContext();
 	widgGetFromID(psWScreen, CON_PASSWORD)->clicked(&sContext);
 }
 

--- a/src/titleui/protocol.cpp
+++ b/src/titleui/protocol.cpp
@@ -199,9 +199,7 @@ void WzProtocolTitleUI::openIPDialog()			//internet options
 	}
 	widgSetString(psSettingsScreen, CON_IP, sEdInit.pText);
 	// auto click in the text box
-	W_CONTEXT sContext;
-	sContext.xOffset	= 0;
-	sContext.yOffset	= 0;
+	W_CONTEXT sContext = W_CONTEXT::ZeroContext();
 	sContext.mx			= CON_NAMEBOXWIDTH;
 	sContext.my			= 0;
 	widgGetFromID(psSettingsScreen, CON_IP)->clicked(&sContext);

--- a/src/titleui/titleui.h
+++ b/src/titleui/titleui.h
@@ -34,7 +34,7 @@
 
 // Regarding construction vs. start():
 // This allows a reference to the parent to be held for a stack-like effect.
-class WzTitleUI
+class WzTitleUI : public std::enable_shared_from_this<WzTitleUI>
 {
 public:
 	virtual ~WzTitleUI();


### PR DESCRIPTION
- Using an overlay screen / layer, "choosers" on the WzMultiplayerOptionsTitleUI now "take over" the screen.
   - This means that:
      - The background is darkened.
      - Keypresses are captured by the chooser until it is dismissed. (Pressing ESC can dismiss it.)
      - Clicking outside of the chooser widgets also dismisses the chooser / overlay.
   - Or, in other words, they now function like true "overlays", and it's possible to dismiss them without being forced to select an option, yielding much more predictable behavior (and simplifying some of the other logic).
   - This impacts:
      - AI chooser, difficulty chooser, color chooser, & team chooser
- Use the ScrollableListWidget for the AI list, removing the limitation on the number of AIs that can be displayed (Fixes #1000)
- Fix tooltip position for ClipRectWidget children
- Clear multiStats for player index on player leave (should prevent slots from retaining the identity of a player who has left if they are later changed to AI slots)
- Add PLAYER::resetAll() - to better reset PLAYER data after games shutdown


https://user-images.githubusercontent.com/30942300/102819400-677d6980-43a1-11eb-9276-337eee234849.mov

