### PR TITLE
wzapi: Fix resetLabel() to match documentation

### DIFF
--- a/src/qtscript.cpp
+++ b/src/qtscript.cpp
@@ -2316,10 +2316,7 @@ wzapi::no_return_value scripting_engine::resetLabel(WZAPI_PARAMS(std::string lab
 	SCRIPT_ASSERT({}, context, labels.count(labelName) > 0, "Label %s not found", labelName.c_str());
 	LABEL &l = labels[labelName];
 	l.triggered = 0; // make active again
-	if (filter.has_value())
-	{
-		l.subscriber = filter.value();
-	}
+	l.subscriber = (filter.has_value()) ? filter.value() : ALL_PLAYERS;
 	return {};
 }
 


### PR DESCRIPTION
> Optionally add a filter on it in the second parameter, which can be a specific player to watch for, or ALL_PLAYERS by default.

@KJeff01 I'm assuming this should not break anything, unless something was (incorrectly) relying on `subscriber` not being reset to `ALL_PLAYERS` if not specified.