### PR TITLE
Implement dropdown widget for resolution picker

### DIFF
--- a/lib/widget/dropdown.cpp
+++ b/lib/widget/dropdown.cpp
@@ -103,6 +103,7 @@ void DropdownWidget::run(W_CONTEXT *psContext)
 
 		if (keyPressed(KEY_ESC))
 		{
+			inputLoseFocus();	// clear the input buffer.
 			close();
 		}
 	}

--- a/lib/widget/dropdown.cpp
+++ b/lib/widget/dropdown.cpp
@@ -118,7 +118,7 @@ void DropdownWidget::open()
 {
 	widgScheduleTask([this]() {
 		overlayScreen = W_SCREEN::make();
-		widgRegisterOverlayScreen(overlayScreen, 1);
+		widgRegisterOverlayScreenOnTopOfScreen(overlayScreen, screenPointer.lock());
 		itemsList->setGeometry(screenPosX(), screenPosY() + height(), width(), itemsList->height());
 		overlayScreen->psForm->attach(itemsList);
 		overlayScreen->psForm->attach(std::make_shared<DropdownOverlay>([this]() { close(); }));

--- a/lib/widget/dropdown.cpp
+++ b/lib/widget/dropdown.cpp
@@ -1,0 +1,189 @@
+/*
+	This file is part of Warzone 2100.
+	Copyright (C) 2020  Warzone 2100 Project
+
+	Warzone 2100 is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+
+	Warzone 2100 is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with Warzone 2100; if not, write to the Free Software
+	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+/**
+ * @file
+ * Functions for dropdown.
+ */
+
+#include "dropdown.h"
+#include "label.h"
+#include "widgbase.h"
+#include "form.h"
+#include "lib/ivis_opengl/pieblitfunc.h"
+#include "lib/framework/input.h"
+
+class DropdownItemWrapper;
+
+class DropdownOverlay: public WIDGET
+{
+public:
+	DropdownOverlay(std::function<void ()> onClickedFunc): onClickedFunc(onClickedFunc)
+	{
+		setCalcLayout(LAMBDA_CALCLAYOUT_SIMPLE({
+			psWidget->setGeometry(0, 0, screenWidth - 1, screenHeight - 1);
+		}));
+	}
+
+	void clicked(W_CONTEXT *, WIDGET_KEY = WKEY_PRIMARY) override
+	{
+		onClickedFunc();
+	}
+
+	std::function<void ()> onClickedFunc;
+};
+
+void DropdownItemWrapper::initialize(const std::shared_ptr<WIDGET> &newItem, DropdownOnSelectHandler newOnSelect)
+{
+	item = newItem;
+	setGeometry(item->geometry());
+	attach(item);
+	onSelect = newOnSelect;
+}
+
+bool DropdownItemWrapper::processClickRecursive(W_CONTEXT *psContext, WIDGET_KEY key, bool wasPressed)
+{
+	auto result = WIDGET::processClickRecursive(psContext, key, wasPressed);
+
+	if (key != WKEY_NONE && wasPressed && item->isMouseOverWidget())
+	{
+		onSelect(std::static_pointer_cast<DropdownItemWrapper>(shared_from_this()));
+	}
+
+	return result;
+}
+
+void DropdownItemWrapper::geometryChanged()
+{
+	item->setGeometry(
+		padding.left,
+		padding.top,
+		width() - padding.left - padding.right,
+		height() - padding.top - padding.bottom
+	);
+}
+
+void DropdownItemWrapper::display(int xOffset, int yOffset)
+{
+	if (selected)
+	{
+		auto x0 = xOffset + x();
+		auto y0 = yOffset + y();
+		pie_UniTransBoxFill(x0, y0, x0 + width(), y0 + height(), WZCOL_MENU_SCORE_BUILT);
+	}
+}
+
+DropdownWidget::DropdownWidget()
+{
+	itemsList = ScrollableListWidget::make();
+	itemsList->setBackgroundColor(WZCOL_MENU_BACKGROUND);
+	setListHeight(100);
+}
+
+void DropdownWidget::run(W_CONTEXT *psContext)
+{
+	if (overlayScreen)
+	{
+		itemsList->setGeometry(screenPosX(), screenPosY() + height(), width(), itemsList->height());
+
+		if (keyPressed(KEY_ESC))
+		{
+			close();
+		}
+	}
+}
+
+void DropdownWidget::clicked(W_CONTEXT *psContext, WIDGET_KEY key)
+{
+	open();
+}
+
+void DropdownWidget::open()
+{
+	widgScheduleTask([this]() {
+		overlayScreen = W_SCREEN::make();
+		widgRegisterOverlayScreen(overlayScreen, 1);
+		itemsList->setGeometry(screenPosX(), screenPosY() + height(), width(), itemsList->height());
+		overlayScreen->psForm->attach(itemsList);
+		overlayScreen->psForm->attach(std::make_shared<DropdownOverlay>([this]() { close(); }));
+	});
+}
+
+void DropdownWidget::close()
+{
+	widgScheduleTask([this]() {
+		widgRemoveOverlayScreen(overlayScreen);
+		overlayScreen->psForm->detach(itemsList);
+		overlayScreen = nullptr;
+	});
+}
+
+void DropdownWidget::display(int xOffset, int yOffset)
+{
+	auto x0 = xOffset + x();
+	auto y0 = yOffset + y();
+
+	if (overlayScreen)
+	{
+		pie_UniTransBoxFill(x0, y0, x0 + width(), y0 + height(), WZCOL_MENU_SCORE_BUILT);
+	}
+
+	if (selectedItem)
+	{
+		WidgetGraphicsContext context;
+		context = context.translatedBy(x0, y0);
+		selectedItem->getItem().displayRecursive(context);
+	}
+}
+
+void DropdownWidget::addItem(const std::shared_ptr<WIDGET> &item)
+{
+	auto itemOnSelect = [this](std::shared_ptr<DropdownItemWrapper> selected) {
+		if (!overlayScreen) {
+			open();
+			return;
+		}
+
+		select(selected);
+		close();
+	};
+
+	auto wrapper = DropdownItemWrapper::make(item, itemOnSelect);
+	wrapper->setPadding(itemPadding);
+	wrapper->setGeometry(0, 0, width(), height());
+
+	items.push_back(wrapper);
+	itemsList->addItem(wrapper);
+}
+
+bool DropdownWidget::processClickRecursive(W_CONTEXT *psContext, WIDGET_KEY key, bool wasPressed)
+{
+	if (!overlayScreen && selectedItem)
+	{
+		W_CONTEXT shiftedContext(psContext);
+		auto deltaX = x() - selectedItem->x();
+		auto deltaY = y() - selectedItem->y();
+		shiftedContext.mx = psContext->mx - deltaX;
+		shiftedContext.my = psContext->my - deltaY;
+		shiftedContext.xOffset = psContext->xOffset + deltaX;
+		shiftedContext.yOffset = psContext->yOffset + deltaY;
+		selectedItem->processClickRecursive(&shiftedContext, key, wasPressed);
+	}
+
+	return WIDGET::processClickRecursive(psContext, key, wasPressed);
+}

--- a/lib/widget/dropdown.h
+++ b/lib/widget/dropdown.h
@@ -1,0 +1,154 @@
+/*
+	This file is part of Warzone 2100.
+	Copyright (C) 2020  Warzone 2100 Project
+
+	Warzone 2100 is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+
+	Warzone 2100 is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with Warzone 2100; if not, write to the Free Software
+	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+/**
+ * @file
+ * Definitions for scroll bar functions.
+ */
+
+#ifndef __INCLUDED_LIB_WIDGET_DROPDOWN_H__
+#define __INCLUDED_LIB_WIDGET_DROPDOWN_H__
+
+#include <optional-lite/optional.hpp>
+#include "widget.h"
+#include "scrollablelist.h"
+
+class DropdownItemWrapper;
+typedef std::function<void(std::shared_ptr<DropdownItemWrapper> item)> DropdownOnSelectHandler;
+
+class DropdownItemWrapper: public WIDGET
+{
+protected:
+	DropdownItemWrapper() {}
+
+	void initialize(const std::shared_ptr<WIDGET> &newItem, DropdownOnSelectHandler newOnSelect);
+
+public:
+	static std::shared_ptr<DropdownItemWrapper> make(const std::shared_ptr<WIDGET> &item, DropdownOnSelectHandler onSelect)
+	{
+		class make_shared_enabler: public DropdownItemWrapper {};
+		auto widget = std::make_shared<make_shared_enabler>();
+		widget->initialize(item, onSelect);
+		return widget;
+	}
+
+	bool processClickRecursive(W_CONTEXT *psContext, WIDGET_KEY key, bool wasPressed) override;
+	void geometryChanged() override;
+
+	WIDGET &getItem() const
+	{
+		return *(item.get());
+	}
+
+	void setPadding(const Padding &value)
+	{
+		padding = value;
+	}
+
+	void setSelected(bool value)
+	{
+		selected = value;
+	}
+
+protected:
+	void display(int xOffset, int yOffset) override;
+
+private:
+	std::shared_ptr<WIDGET> item;
+	DropdownOnSelectHandler onSelect;
+	Padding padding;
+	bool selected = false;
+};
+
+class DropdownWidget : public WIDGET
+{
+public:
+	DropdownWidget();
+
+	void addItem(const std::shared_ptr<WIDGET> &widget);
+	void display(int xOffset, int yOffset) override;
+	void clicked(W_CONTEXT *psContext, WIDGET_KEY key) override;
+	void run(W_CONTEXT *) override;
+	void open();
+	void close();
+	bool processClickRecursive(W_CONTEXT *psContext, WIDGET_KEY key, bool wasPressed) override;
+	void setListHeight(uint32_t value)
+	{
+		itemsList->setGeometry(itemsList->x(), itemsList->y(), itemsList->width(), value);
+	}
+	void setItemPadding(const Padding &value)
+	{
+		itemPadding = value;
+	}
+	void setSelectedIndex(size_t index)
+	{
+		ASSERT_OR_RETURN(, index < items.size(), "Invalid dropdown item index");
+		select(items[index]);
+	}
+	void setOnChange(std::function<void()> value)
+	{
+		onChange = value;
+	}
+	nonstd::optional<size_t> getSelectedIndex() const
+	{
+		if (selectedItem == nullptr)
+		{
+			return nonstd::nullopt;
+		}
+
+		for (auto item = items.begin(); item != items.end(); item++)
+		{
+			if (*item == selectedItem)
+			{
+				return item - items.begin();
+			}
+		}
+
+		return nonstd::nullopt;
+	}
+
+private:
+	std::vector<std::shared_ptr<DropdownItemWrapper>> items;
+	std::shared_ptr<ScrollableListWidget> itemsList;
+	std::shared_ptr<W_SCREEN> overlayScreen;
+	std::shared_ptr<DropdownItemWrapper> selectedItem;
+	Padding itemPadding;
+	std::function<void()> onChange;
+
+	void select(const std::shared_ptr<DropdownItemWrapper> &selected)
+	{
+		if (selectedItem == selected)
+		{
+			return;
+		}
+
+		if (selectedItem)
+		{
+			selectedItem->setSelected(false);
+		}
+		selectedItem = selected;
+		selectedItem->setSelected(true);
+
+		if (onChange)
+		{
+			onChange();
+		}
+	}
+};
+
+#endif // __INCLUDED_LIB_WIDGET_DROPDOWN_H__

--- a/lib/widget/scrollablelist.h
+++ b/lib/widget/scrollablelist.h
@@ -28,14 +28,6 @@
 #include "scrollbar.h"
 #include "cliprect.h"
 
-struct Padding
-{
-	uint32_t top;
-	uint32_t right;
-	uint32_t bottom;
-	uint32_t left;
-};
-
 class ScrollableListWidget : public WIDGET
 {
 protected:

--- a/lib/widget/widgbase.h
+++ b/lib/widget/widgbase.h
@@ -159,7 +159,6 @@ protected:
 	virtual void geometryChanged() {}
 
 	virtual bool hitTest(int x, int y);
-	bool isMouseOverWidget() const;
 
 public:
 	virtual unsigned getState();
@@ -267,6 +266,8 @@ public:
 	void setOnDelete(const WIDGET_ONDELETE_FUNC& onDeleteFunc);
 
 	void setCustomHitTest(const WIDGET_HITTEST_FUNC& newCustomHitTestFunc);
+
+	bool isMouseOverWidget() const;
 
 	UDWORD                  id;                     ///< The user set ID number for the widget. This is returned when e.g. a button is pressed.
 	WIDGET_TYPE             type;                   ///< The widget type

--- a/lib/widget/widget.cpp
+++ b/lib/widget/widget.cpp
@@ -153,6 +153,26 @@ void widgRegisterOverlayScreen(const std::shared_ptr<W_SCREEN> &psScreen, uint16
 	overlays.insert(std::upper_bound(overlays.begin(), overlays.end(), newOverlay, [](const OverlayScreen& a, const OverlayScreen& b){ return a.zOrder > b.zOrder; }), newOverlay);
 }
 
+// Note: If priorScreen is not the "regular" screen (i.e. if priorScreen is an overlay screen) it should already be registered
+void widgRegisterOverlayScreenOnTopOfScreen(const std::shared_ptr<W_SCREEN> &psScreen, const std::shared_ptr<W_SCREEN> &priorScreen)
+{
+	auto it = std::find_if(overlays.begin(), overlays.end(), [priorScreen](const OverlayScreen& overlay) -> bool {
+		return overlay.psScreen == priorScreen;
+	});
+	if (it != overlays.end())
+	{
+		OverlayScreen newOverlay {psScreen, it->zOrder}; // use the same z-order as priorScreen, but insert *after* it in the list
+		overlays.insert((it + 1), newOverlay);
+	}
+	else
+	{
+		// priorScreen does not exist in the overlays list, so it is probably the "regular" screen
+		// just insert this overlay at the front of the overlay list
+		OverlayScreen newOverlay {psScreen, 0};
+		overlays.insert(overlays.begin(), newOverlay);
+	}
+}
+
 void widgRemoveOverlayScreen(const std::shared_ptr<W_SCREEN> &psScreen)
 {
 	auto it = std::find_if(overlays.begin(), overlays.end(), [psScreen](const OverlayScreen& overlay) -> bool {

--- a/lib/widget/widget.h
+++ b/lib/widget/widget.h
@@ -237,6 +237,7 @@ void widgShutDown();
 
 /** Used by the notifications system to register forms that are "over the top", and may consume click / mouse-over events */
 void widgRegisterOverlayScreen(const std::shared_ptr<W_SCREEN> &psScreen, uint16_t zOrder);
+void widgRegisterOverlayScreenOnTopOfScreen(const std::shared_ptr<W_SCREEN> &psScreen, const std::shared_ptr<W_SCREEN> &priorScreen);
 void widgRemoveOverlayScreen(const std::shared_ptr<W_SCREEN> &psScreen);
 bool isMouseOverScreenOverlayChild(int mx, int my); // global mouse coordinates - i.e. those returned from mouseX()/mouseY()
 void widgScheduleTask(std::function<void ()> f);

--- a/lib/widget/widget.h
+++ b/lib/widget/widget.h
@@ -106,6 +106,14 @@ enum WzTextAlignment
 /* (Useful if re-using a W_*INIT structure for multiple widget instances) */
 typedef std::function<void* ()> WIDGET_INITIALIZE_PUSERDATA_FUNC;
 
+struct Padding
+{
+	uint32_t top;
+	uint32_t right;
+	uint32_t bottom;
+	uint32_t left;
+};
+
 /** The basic initialisation structure */
 struct W_INIT
 {
@@ -231,6 +239,7 @@ void widgShutDown();
 void widgRegisterOverlayScreen(const std::shared_ptr<W_SCREEN> &psScreen, uint16_t zOrder);
 void widgRemoveOverlayScreen(const std::shared_ptr<W_SCREEN> &psScreen);
 bool isMouseOverScreenOverlayChild(int mx, int my); // global mouse coordinates - i.e. those returned from mouseX()/mouseY()
+void widgScheduleTask(std::function<void ()> f);
 
 /** Add a form to the widget screen */
 WZ_DECL_NONNULL(2) W_FORM *widgAddForm(const std::shared_ptr<W_SCREEN> &psScreen, const W_FORMINIT *psInit);

--- a/src/frontend.cpp
+++ b/src/frontend.cpp
@@ -37,6 +37,7 @@
 #include "lib/widget/button.h"
 #include "lib/widget/label.h"
 #include "lib/widget/slider.h"
+#include "lib/widget/dropdown.h"
 
 #include "advvis.h"
 #include "challenge.h"
@@ -85,6 +86,7 @@ bool			bLimiterLoaded = false;
 // Forward definitions
 
 static W_BUTTON * addSmallTextButton(UDWORD id, UDWORD PosX, UDWORD PosY, const char *txt, unsigned int style);
+static std::shared_ptr<W_BUTTON> makeTextButton(UDWORD id,  UDWORD PosX, UDWORD PosY, const std::string &txt, unsigned int style);
 
 // ////////////////////////////////////////////////////////////////////////////
 // Helper functions
@@ -140,6 +142,7 @@ void startTitleMenu()
 	addTextButton(FRONTEND_MULTIPLAYER, FRONTEND_POS3X, FRONTEND_POS3Y, _("Multi Player"), WBUT_TXTCENTRE);
 	addTextButton(FRONTEND_TUTORIAL, FRONTEND_POS4X, FRONTEND_POS4Y, _("Tutorial"), WBUT_TXTCENTRE);
 	addTextButton(FRONTEND_OPTIONS, FRONTEND_POS5X, FRONTEND_POS5Y, _("Options"), WBUT_TXTCENTRE);
+
 	// check whether video sequences are installed
 	if (PHYSFS_exists("sequences/devastation.ogg"))
 	{
@@ -1069,20 +1072,20 @@ static bool canChangeResolutionLive()
 	return wzSupportsLiveResolutionChanges();
 }
 
-static void videoOptionsDisableResolutionButtons(std::string toolTip)
+static void videoOptionsDisableResolutionButtons()
 {
-	widgSetButtonState(psWScreen, FRONTEND_RESOLUTION, WBUT_DISABLE);
-	widgSetTip(psWScreen, FRONTEND_RESOLUTION, toolTip);
-	widgSetButtonState(psWScreen, FRONTEND_RESOLUTION_R, WBUT_DISABLE);
-	widgSetTip(psWScreen, FRONTEND_RESOLUTION_R, toolTip);
+	widgReveal(psWScreen, FRONTEND_RESOLUTION_READONLY_LABEL);
+	widgReveal(psWScreen, FRONTEND_RESOLUTION_READONLY);
+	widgHide(psWScreen, FRONTEND_RESOLUTION_DROPDOWN_LABEL);
+	widgHide(psWScreen, FRONTEND_RESOLUTION_DROPDOWN);
 }
 
 static void videoOptionsEnableResolutionButtons()
 {
-	widgSetButtonState(psWScreen, FRONTEND_RESOLUTION, 0);
-	widgSetTip(psWScreen, FRONTEND_RESOLUTION, "");
-	widgSetButtonState(psWScreen, FRONTEND_RESOLUTION_R, 0);
-	widgSetTip(psWScreen, FRONTEND_RESOLUTION_R, "");
+	widgHide(psWScreen, FRONTEND_RESOLUTION_READONLY_LABEL);
+	widgHide(psWScreen, FRONTEND_RESOLUTION_READONLY);
+	widgReveal(psWScreen, FRONTEND_RESOLUTION_DROPDOWN_LABEL);
+	widgReveal(psWScreen, FRONTEND_RESOLUTION_DROPDOWN);
 }
 
 static char const *videoOptionsWindowModeString()
@@ -1115,13 +1118,6 @@ static char const *videoOptionsResolutionLabel()
 char const *videoOptionsDisplayScaleLabel()
 {
 	return (!canChangeResolutionLive())? _("Display Scale*") : _("Display Scale");
-}
-
-static std::string videoOptionsResolutionString()
-{
-	char resolution[100];
-	ssprintf(resolution, "[%d] %d × %d", war_GetScreen(), war_GetWidth(), war_GetHeight());
-	return resolution;
 }
 
 static std::string videoOptionsTextureSizeString()
@@ -1168,20 +1164,157 @@ std::string videoOptionsGfxBackendString()
 
 // ////////////////////////////////////////////////////////////////////////////
 // Video Options
+
+class ScreenResolutionsModel
+{
+public:
+	typedef const std::vector<screeninfo>::iterator iterator;
+	typedef const std::vector<screeninfo>::const_iterator const_iterator;
+
+	ScreenResolutionsModel(): modes(ScreenResolutionsModel::loadModes())
+	{
+	}
+
+	const_iterator begin() const
+	{
+		return modes.begin();
+	}
+
+	const_iterator end() const
+	{
+		return modes.end();
+	}
+
+	const_iterator findResolutionClosestToCurrent() const
+	{
+		auto currentResolution = getCurrentResolution();
+		auto closest = std::lower_bound(modes.begin(), modes.end(), currentResolution, compareLess);
+		if (closest != modes.end() && compareEq(*closest, currentResolution))
+		{
+			return closest;
+		}
+
+		if (closest != modes.begin())
+		{
+			--closest;  // If current resolution doesn't exist, round down to next-highest one.
+		}
+
+		return closest;
+	}
+
+	void selectAt(size_t index) const
+	{
+		// Disable the ability to use the Video options menu to live-change the window size when in windowed mode.
+		// Why?
+		//	- Certain window managers don't report their own changes to window size through SDL in all circumstances.
+		//	  (For example, attempting to set a window size of 800x600 might result in no actual change when using a
+		//	   tiling window manager (ex. i3), but SDL thinks the window size has been set to 800x600. This obviously
+		//     breaks things.)
+		//  - Manual window resizing is supported (so there is no need for this functionality in the Video menu).
+		ASSERT_OR_RETURN(, wzIsFullscreen(), "Attempt to change resolution in windowed-mode");
+
+		ASSERT_OR_RETURN(, index < modes.size(), "Invalid mode index passed to ScreenResolutionsModel::selectAt");
+
+		auto selectedResolution = modes.at(index);
+
+		if (canChangeResolutionLive())
+		{
+			auto currentResolution = getCurrentResolution();
+			// Attempt to change the resolution
+			if (!wzChangeWindowResolution(selectedResolution.screen, selectedResolution.width, selectedResolution.height))
+			{
+				debug(
+					LOG_WARNING,
+					"Failed to change active resolution from: %s to: %s",
+					ScreenResolutionsModel::resolutionString(currentResolution).c_str(),
+					ScreenResolutionsModel::resolutionString(selectedResolution).c_str()
+				);
+			}
+		}
+		else
+		{
+			// when live resolution changes are unavailable, check to see if the current display scale is supported at the desired resolution
+			unsigned int maxDisplayScale = std::max(100u, wzGetMaximumDisplayScaleForWindowSize(selectedResolution.width, selectedResolution.height));
+			unsigned int current_displayScale = war_GetDisplayScale();
+			if (maxDisplayScale < current_displayScale)
+			{
+				// Reduce the display scale to the maximum supported for this resolution
+				war_SetDisplayScale(maxDisplayScale);
+			}
+		}
+
+		// Store the new width and height
+		war_SetScreen(selectedResolution.screen);
+		war_SetWidth(selectedResolution.width);
+		war_SetHeight(selectedResolution.height);
+
+		// Update the widget(s)
+		refreshCurrentVideoOptionsValues();
+	}
+
+	static std::string currentResolutionString()
+	{
+		return ScreenResolutionsModel::resolutionString(getCurrentResolution());
+	}
+
+	static std::string resolutionString(const screeninfo &info)
+	{
+		return astringf("[%d] %d × %d", info.screen, info.width, info.height);
+	}
+
+private:
+	const std::vector<screeninfo> modes;
+
+	static screeninfo getCurrentResolution()
+	{
+		screeninfo info;
+		info.screen = war_GetScreen();
+		info.width = war_GetWidth();
+		info.height = war_GetHeight();
+		info.refresh_rate = -1;  // Unused.
+		return info;
+	}
+
+	static std::vector<screeninfo> loadModes()
+	{
+		// Get resolutions, sorted with duplicates removed.
+		std::vector<screeninfo> modes = wzAvailableResolutions();
+		std::sort(modes.begin(), modes.end(), ScreenResolutionsModel::compareLess);
+		modes.erase(std::unique(modes.begin(), modes.end(), ScreenResolutionsModel::compareEq), modes.end());
+
+		return modes;
+	}
+
+	static std::tuple<int, int, int> compareKey(const screeninfo &x)
+	{
+		return std::make_tuple(x.screen, x.width, x.height);
+	}
+
+	static bool compareLess(const screeninfo &a, const screeninfo &b)
+	{
+		return ScreenResolutionsModel::compareKey(a) < ScreenResolutionsModel::compareKey(b);
+	}
+
+	static bool compareEq(const screeninfo &a, const screeninfo &b)
+	{
+		return ScreenResolutionsModel::compareKey(a) == ScreenResolutionsModel::compareKey(b);
+	}
+};
+
 void refreshCurrentVideoOptionsValues()
 {
 	widgSetString(psWScreen, FRONTEND_WINDOWMODE_R, videoOptionsWindowModeString());
 	widgSetString(psWScreen, FRONTEND_FSAA_R, videoOptionsAntialiasingString().c_str());
-	if (widgGetFromID(psWScreen, FRONTEND_RESOLUTION_R)) // Resolution option may not be available
+	if (widgGetFromID(psWScreen, FRONTEND_RESOLUTION_READONLY)) // Resolution option may not be available
 	{
-		widgSetString(psWScreen, FRONTEND_RESOLUTION_R, videoOptionsResolutionString().c_str());
+		widgSetString(psWScreen, FRONTEND_RESOLUTION_READONLY, ScreenResolutionsModel::currentResolutionString().c_str());
 		if (canChangeResolutionLive())
 		{
 			if (!war_getFullscreen())
 			{
 				// If live window resizing is supported & the current mode is "windowed", disable the Resolution option and add a tooltip
 				// explaining the user can now resize the window normally.
-				videoOptionsDisableResolutionButtons(_("You can change the resolution by resizing the window normally. (Try dragging a corner / edge.)"));
+				videoOptionsDisableResolutionButtons();
 			}
 			else
 			{
@@ -1199,6 +1332,38 @@ void refreshCurrentVideoOptionsValues()
 	{
 		widgSetString(psWScreen, FRONTEND_DISPLAYSCALE_R, videoOptionsDisplayScaleString().c_str());
 	}
+}
+
+static void addResolutionDropdown()
+{
+	auto dropdown = std::make_shared<DropdownWidget>();
+	dropdown->id = FRONTEND_RESOLUTION_DROPDOWN;
+	uint32_t dropdownLeftPadding = 10;
+	auto dropdownX = FRONTEND_POS3M - 20 - dropdownLeftPadding;
+	dropdown->setGeometry(dropdownX, FRONTEND_POS3Y, FRONTEND_BOTFORMW - dropdownX - FRONTEND_POS3X, FRONTEND_BUTHEIGHT);
+	dropdown->setListHeight(FRONTEND_BUTHEIGHT * 5);
+	dropdown->setItemPadding({ 0, 0, 0, dropdownLeftPadding });
+
+	ScreenResolutionsModel screenResolutionsModel;
+	for (auto resolution: screenResolutionsModel)
+	{
+		dropdown->addItem(makeTextButton(0, 0, 0, ScreenResolutionsModel::resolutionString(resolution), 0));
+	}
+
+	auto closestResolution = screenResolutionsModel.findResolutionClosestToCurrent();
+	if (closestResolution != screenResolutionsModel.end())
+	{
+		dropdown->setSelectedIndex(closestResolution - screenResolutionsModel.begin());
+	}
+
+	dropdown->setOnChange([dropdown, screenResolutionsModel]() {
+		if (auto selectedIndex = dropdown->getSelectedIndex())
+		{
+			screenResolutionsModel.selectAt(selectedIndex.value());
+		}
+	});
+
+	widgGetFromID(psWScreen, FRONTEND_BOTFORM)->attach(dropdown);
 }
 
 void startVideoOptionsMenu()
@@ -1222,8 +1387,13 @@ void startVideoOptionsMenu()
 	addTextButton(FRONTEND_WINDOWMODE_R, FRONTEND_POS2M - 55, FRONTEND_POS2Y, videoOptionsWindowModeString(), WBUT_SECONDARY);
 
 	// Resolution
-	addTextButton(FRONTEND_RESOLUTION, FRONTEND_POS3X - 35, FRONTEND_POS3Y, videoOptionsResolutionLabel(), WBUT_SECONDARY);
-	addTextButton(FRONTEND_RESOLUTION_R, FRONTEND_POS3M - 55, FRONTEND_POS3Y, videoOptionsResolutionString(), WBUT_SECONDARY);
+	addTextButton(FRONTEND_RESOLUTION_READONLY_LABEL, FRONTEND_POS3X - 35, FRONTEND_POS3Y, videoOptionsResolutionLabel(), WBUT_SECONDARY | WBUT_DISABLE);
+	addTextButton(FRONTEND_RESOLUTION_READONLY, FRONTEND_POS3M - 55, FRONTEND_POS3Y, ScreenResolutionsModel::currentResolutionString(), WBUT_SECONDARY | WBUT_DISABLE);
+	auto readonlyResolutionTooltip = _("You can change the resolution by resizing the window normally. (Try dragging a corner / edge.)");
+	widgSetTip(psWScreen, FRONTEND_RESOLUTION_READONLY_LABEL, readonlyResolutionTooltip);
+	widgSetTip(psWScreen, FRONTEND_RESOLUTION_READONLY, readonlyResolutionTooltip);
+	addTextButton(FRONTEND_RESOLUTION_DROPDOWN_LABEL, FRONTEND_POS3X - 35, FRONTEND_POS3Y, videoOptionsResolutionLabel(), WBUT_SECONDARY);
+	addResolutionDropdown();
 
 	// Texture size
 	addTextButton(FRONTEND_TEXTURESZ, FRONTEND_POS4X - 35, FRONTEND_POS4Y, _("Texture size"), WBUT_SECONDARY);
@@ -1263,21 +1433,6 @@ void startVideoOptionsMenu()
 	addMultiBut(psWScreen, FRONTEND_BOTFORM, FRONTEND_QUIT, 10, 10, 30, 29, P_("menu", "Return"), IMAGE_RETURN, IMAGE_RETURN_HI, IMAGE_RETURN_HI);
 
 	refreshCurrentVideoOptionsValues();
-}
-
-// Get available resolutions list, sorted, with duplicates removed.
-std::vector<screeninfo> availableResolutionsSorted()
-{
-	auto compareKey = [](screeninfo const &x) { return std::make_tuple(x.screen, x.width, x.height); };
-	auto compareLess = [&](screeninfo const &a, screeninfo const &b) { return compareKey(a) < compareKey(b); };
-	auto compareEq = [&](screeninfo const &a, screeninfo const &b) { return compareKey(a) == compareKey(b); };
-
-	// Get resolutions, sorted with duplicates removed.
-	std::vector<screeninfo> modes = wzAvailableResolutions();
-	std::sort(modes.begin(), modes.end(), compareLess);
-	modes.erase(std::unique(modes.begin(), modes.end(), compareEq), modes.end());
-
-	return modes;
 }
 
 std::vector<unsigned int> availableDisplayScalesSorted()
@@ -1383,10 +1538,6 @@ bool runVideoOptionsMenu()
 	WidgetTriggers const &triggers = widgRunScreen(psWScreen);
 	unsigned id = triggers.empty() ? 0 : triggers.front().widget->id; // Just use first click here, since the next click could be on another menu.
 
-	auto compareKey = [](screeninfo const &x) { return std::make_tuple(x.screen, x.width, x.height); };
-	auto compareLess = [&](screeninfo const &a, screeninfo const &b) { return compareKey(a) < compareKey(b); };
-	auto compareEq = [&](screeninfo const &a, screeninfo const &b) { return compareKey(a) == compareKey(b); };
-
 	switch (id)
 	{
 	case FRONTEND_WINDOWMODE:
@@ -1415,94 +1566,6 @@ bool runVideoOptionsMenu()
 		{
 			war_setAntialiasing(pow2Cycle(war_getAntialiasing(), 0, pie_GetMaxAntialiasing()));
 			widgSetString(psWScreen, FRONTEND_FSAA_R, videoOptionsAntialiasingString().c_str());
-			break;
-		}
-
-	case FRONTEND_RESOLUTION:
-	case FRONTEND_RESOLUTION_R:
-		{
-			// Get resolutions, sorted with duplicates removed.
-			std::vector<screeninfo> modes = availableResolutionsSorted();
-
-			// We can't pick resolutions if there aren't any.
-			if (modes.empty())
-			{
-				debug(LOG_ERROR, "No resolutions available to change.");
-				break;
-			}
-
-			// Get currently configured resolution.
-			screeninfo config;
-			config.screen = war_GetScreen();
-			config.width = war_GetWidth();
-			config.height = war_GetHeight();
-			config.refresh_rate = -1;  // Unused.
-
-			// Find current resolution in list.
-			auto current = std::lower_bound(modes.begin(), modes.end(), config, compareLess);
-			if (current == modes.end() || !compareEq(*current, config))
-			{
-				if (current != modes.begin())
-				{
-					--current;  // If current resolution doesn't exist, round down to next-highest one.
-				}
-			}
-
-			// Increment/decrement and loop if required.
-			auto startingResolution = current;
-			bool successfulResolutionChange = false;
-			current = seqCycle(current, modes.begin(), 1, modes.end() - 1);
-
-			if (canChangeResolutionLive())
-			{
-				// Disable the ability to use the Video options menu to live-change the window size when in windowed mode.
-				// Why?
-				//	- Certain window managers don't report their own changes to window size through SDL in all circumstances.
-				//	  (For example, attempting to set a window size of 800x600 might result in no actual change when using a
-				//	   tiling window manager (ex. i3), but SDL thinks the window size has been set to 800x600. This obviously
-				//     breaks things.)
-				//  - Manual window resizing is supported (so there is no need for this functionality in the Video menu).
-				if (!wzIsFullscreen()) break;
-
-				while (current != startingResolution)
-				{
-					// Attempt to change the resolution
-					if (!wzChangeWindowResolution(current->screen, current->width, current->height))
-					{
-						debug(LOG_WARNING, "Failed to change active resolution from: [%d] %d x %d to: [%d] %d x %d", config.screen, config.width, config.height, current->screen, current->width, current->height);
-
-						// try the next resolution, and loop
-						current = seqCycle(current, modes.begin(), 1, modes.end() - 1);
-						continue;
-					}
-					else
-					{
-						successfulResolutionChange = true;
-						break;
-					}
-				}
-
-				if (!successfulResolutionChange) break;
-			}
-			else
-			{
-				// when live resolution changes are unavailable, check to see if the current display scale is supported at the desired resolution
-				unsigned int maxDisplayScale = std::max(100u, wzGetMaximumDisplayScaleForWindowSize(current->width, current->height));
-				unsigned int current_displayScale = war_GetDisplayScale();
-				if (maxDisplayScale < current_displayScale)
-				{
-					// Reduce the display scale to the maximum supported for this resolution
-					war_SetDisplayScale(maxDisplayScale);
-				}
-			}
-
-			// Store the new width and height
-			war_SetScreen(current->screen);
-			war_SetWidth(current->width);
-			war_SetHeight(current->height);
-
-			// Update the widget(s)
-			refreshCurrentVideoOptionsValues();
 			break;
 		}
 
@@ -2032,7 +2095,7 @@ void displayTextOption(WIDGET *psWidget, UDWORD xOffset, UDWORD yOffset)
 
 	cache.wzText.setText(psBut->pText.toUtf8(), psBut->FontID);
 
-	if (widgGetMouseOver(psWScreen) == psBut->id)					// if mouse is over text then hilight.
+	if (psBut->isMouseOverWidget()) // if mouse is over text then hilight.
 	{
 		hilight = true;
 	}
@@ -2216,7 +2279,7 @@ W_LABEL *addSideText(UDWORD id, UDWORD PosX, UDWORD PosY, const char *txt)
 }
 
 // ////////////////////////////////////////////////////////////////////////////
-void addTextButton(UDWORD id,  UDWORD PosX, UDWORD PosY, const std::string &txt, unsigned int style)
+static std::shared_ptr<W_BUTTON> makeTextButton(UDWORD id,  UDWORD PosX, UDWORD PosY, const std::string &txt, unsigned int style)
 {
 	W_BUTINIT sButInit;
 
@@ -2255,13 +2318,20 @@ void addTextButton(UDWORD id,  UDWORD PosX, UDWORD PosY, const std::string &txt,
 	sButInit.pDisplay = displayTextOption;
 	sButInit.FontID = font_large;
 	sButInit.pText = txt.c_str();
-	widgAddButton(psWScreen, &sButInit);
 
+	auto button = std::make_shared<W_BUTTON>(&sButInit);
 	// Disable button
 	if (style & WBUT_DISABLE)
 	{
-		widgSetButtonState(psWScreen, id, WBUT_DISABLE);
+		button->setState(WBUT_DISABLE);
 	}
+
+	return button;
+}
+
+void addTextButton(UDWORD id,  UDWORD PosX, UDWORD PosY, const std::string &txt, unsigned int style)
+{
+	widgGetFromID(psWScreen, FRONTEND_BOTFORM)->attach(makeTextButton(id, PosX, PosY, txt, style));
 }
 
 W_BUTTON * addSmallTextButton(UDWORD id,  UDWORD PosX, UDWORD PosY, const char *txt, unsigned int style)

--- a/src/frontend.h
+++ b/src/frontend.h
@@ -68,6 +68,18 @@ bool runVideoOptionsMenu();
 bool runMouseOptionsMenu();
 bool runTutorialMenu();
 void runContinue();
+void startTitleMenu();
+void startTutorialMenu();
+void startSinglePlayerMenu();
+void startCampaignSelector();
+void startMultiPlayerMenu();
+void startOptionsMenu();
+void startGraphicsOptionsMenu();
+void startAudioAndZoomOptionsMenu();
+void startVideoOptionsMenu();
+void startMouseOptionsMenu();
+void startGameOptionsMenu();
+void refreshCurrentVideoOptionsValues();
 
 void addTopForm(bool wide);
 void addBottomForm();
@@ -276,8 +288,10 @@ enum
 	FRONTEND_VIDEOOPTIONS = 24000,          // video Options Menu
 	FRONTEND_WINDOWMODE,
 	FRONTEND_WINDOWMODE_R,
-	FRONTEND_RESOLUTION,
-	FRONTEND_RESOLUTION_R,
+	FRONTEND_RESOLUTION_READONLY_LABEL,
+	FRONTEND_RESOLUTION_READONLY,
+	FRONTEND_RESOLUTION_DROPDOWN_LABEL,
+	FRONTEND_RESOLUTION_DROPDOWN,
 	FRONTEND_TEXTURESZ,
 	FRONTEND_TEXTURESZ_R,
 	FRONTEND_VSYNC,

--- a/src/titleui/old.cpp
+++ b/src/titleui/old.cpp
@@ -31,6 +31,7 @@
 #include "lib/ivis_opengl/screen.h"
 #include "lib/netplay/netplay.h"
 #include "../intdisplay.h"
+#include "../frontend.h"
 #include "../hci.h"
 #include "../keyedit.h"
 #include "../keymap.h"
@@ -41,20 +42,6 @@
 #include "../musicmanager.h"
 #include "../warzoneconfig.h"
 #include "../frend.h"
-
-// frontend.cpp
-void startTitleMenu();
-void startTutorialMenu();
-void startSinglePlayerMenu();
-void startCampaignSelector();
-void startMultiPlayerMenu();
-void startOptionsMenu();
-void startGraphicsOptionsMenu();
-void startAudioAndZoomOptionsMenu();
-void startVideoOptionsMenu();
-void startMouseOptionsMenu();
-void startGameOptionsMenu();
-void refreshCurrentVideoOptionsValues();
 
 WzOldTitleUI::WzOldTitleUI(tMode mode) : mode(mode)
 {


### PR DESCRIPTION
Preview: https://streamable.com/ur8r3f

Obs.: I had to modify the interface behavior to record the preview video, that is why the "Graphics Mode" is "Windowed", but it is still possible to choose the resolution. The normal behavior is the same as before: when on "Windowed" mode, the resolution picker is disabled, and just shows the current window size.

Fixes https://github.com/Warzone2100/warzone2100/issues/843.