### PR TITLE
Overlay screen and DropdownWidget improvements

### DIFF
--- a/lib/widget/dropdown.h
+++ b/lib/widget/dropdown.h
@@ -84,6 +84,7 @@ public:
 	void display(int xOffset, int yOffset) override;
 	void clicked(W_CONTEXT *psContext, WIDGET_KEY key) override;
 	void run(W_CONTEXT *) override;
+	void geometryChanged() override;
 	void open();
 	void close();
 	bool processClickRecursive(W_CONTEXT *psContext, WIDGET_KEY key, bool wasPressed) override;
@@ -100,7 +101,7 @@ public:
 		ASSERT_OR_RETURN(, index < items.size(), "Invalid dropdown item index");
 		select(items[index]);
 	}
-	void setOnChange(std::function<void()> value)
+	void setOnChange(std::function<void(DropdownWidget&)> value)
 	{
 		onChange = value;
 	}
@@ -128,7 +129,7 @@ private:
 	std::shared_ptr<W_SCREEN> overlayScreen;
 	std::shared_ptr<DropdownItemWrapper> selectedItem;
 	Padding itemPadding;
-	std::function<void()> onChange;
+	std::function<void(DropdownWidget&)> onChange;
 
 	void select(const std::shared_ptr<DropdownItemWrapper> &selected)
 	{
@@ -146,7 +147,7 @@ private:
 
 		if (onChange)
 		{
-			onChange();
+			onChange(*this);
 		}
 	}
 };

--- a/src/frontend.cpp
+++ b/src/frontend.cpp
@@ -1476,7 +1476,7 @@ void seqWindowMode()
 
 	do
 	{
-		currentFullscreenModePos = seqCycle(currentFullscreenModePos, static_cast<size_t>(0), 1, supportedFullscreenModes.size());
+		currentFullscreenModePos = seqCycle(currentFullscreenModePos, static_cast<size_t>(0), 1, supportedFullscreenModes.size() - 1);
 		success = wzChangeWindowMode(supportedFullscreenModes[currentFullscreenModePos]);
 
 	} while ((!success) && (currentFullscreenModePos != startingFullscreenModePos));

--- a/src/frontend.cpp
+++ b/src/frontend.cpp
@@ -1370,8 +1370,8 @@ static void addResolutionDropdown()
 		dropdown->setSelectedIndex(closestResolution - screenResolutionsModel.begin());
 	}
 
-	dropdown->setOnChange([dropdown, screenResolutionsModel]() {
-		if (auto selectedIndex = dropdown->getSelectedIndex())
+	dropdown->setOnChange([screenResolutionsModel](DropdownWidget& dropdown) {
+		if (auto selectedIndex = dropdown.getSelectedIndex())
 		{
 			screenResolutionsModel.selectAt(selectedIndex.value());
 		}


### PR DESCRIPTION
- Overlay screen refactoring / fixes
   - Fixes a few bugs affecting multiple simultaneous overlay screens, but since this wasn't (previously) likely to occur they were not obviously triggerable.
- DropdownWidget: Handle `geometryChanged()`, use `weak_ptr` in closures, pass into `onChange` handler