### PR TITLE
Prevent overflow in kf_BuildPrevPage().

### DIFF
--- a/src/keybind.cpp
+++ b/src/keybind.cpp
@@ -2796,7 +2796,7 @@ void kf_BuildPrevPage()
 		return;
 	}
 
-	if (!psTForm->setCurrentPage(psTForm->currentPage() - 1))
+	if ((psTForm->currentPage() == 0) || !psTForm->setCurrentPage(psTForm->currentPage() - 1))
 	{
 		audio_PlayTrack(ID_SOUND_BUILD_FAIL);
 		return;


### PR DESCRIPTION
Make sure to check if the current page is zero when attempting to subtract from an unsigned data type.

Fixes #1306.