### PR TITLE
Various Vulkan fixes

### DIFF
--- a/configure_mac.cmake
+++ b/configure_mac.cmake
@@ -16,10 +16,10 @@ set(VCPKG_COMMIT_SHA "d1ef42c0fd7b9d5ac90be74df62b12e1184d02a1")
 set(MIN_SUPPORTED_MACOSX_DEPLOYMENT_TARGET "10.10")
 
 # Vulkan SDK
-set(VULKAN_SDK_VERSION "1.2.148.1")
+set(VULKAN_SDK_VERSION "1.2.162.0")
 set(VULKAN_SDK_DL_FILENAME "vulkansdk-macos-${VULKAN_SDK_VERSION}.dmg")
 set(VULKAN_SDK_DL_URL "https://sdk.lunarg.com/sdk/download/${VULKAN_SDK_VERSION}/mac/${VULKAN_SDK_DL_FILENAME}?Human=true")
-set(VULKAN_SDK_DL_SHA256 "b76c58d086486b803405522183a46a16928356449db229afadecb995b624ffa0")
+set(VULKAN_SDK_DL_SHA256 "d5d25d801eb83130db1e41fa6c09f125ba57e7503ae81553182ba7196f32a0a3")
 
 ########################################################
 

--- a/lib/ivis_opengl/gfx_api_vk.cpp
+++ b/lib/ivis_opengl/gfx_api_vk.cpp
@@ -77,7 +77,8 @@ const std::vector<const char*> deviceExtensions = {
 
 const std::vector<const char*> optionalDeviceExtensions = {
 	VK_KHR_GET_MEMORY_REQUIREMENTS_2_EXTENSION_NAME,
-	VK_KHR_DEDICATED_ALLOCATION_EXTENSION_NAME
+	VK_KHR_DEDICATED_ALLOCATION_EXTENSION_NAME,
+	"VK_KHR_portability_subset" // According to VUID-VkDeviceCreateInfo-pProperties-04451, if device supports this extension it *must* be enabled
 };
 
 const std::vector<vk::Format> supportedDepthFormats = {

--- a/lib/sdl/main_sdl.cpp
+++ b/lib/sdl/main_sdl.cpp
@@ -1379,7 +1379,6 @@ void handleGameScreenSizeChange(unsigned int oldWidth, unsigned int oldHeight, u
 	pie_SetVideoBufferWidth(screenWidth);
 	pie_SetVideoBufferHeight(screenHeight);
 	pie_UpdateSurfaceGeometry();
-	screen_updateGeometry();
 
 	if (currentScreenResizingStatus == nullptr)
 	{
@@ -1484,6 +1483,7 @@ void processScreenSizeChangeNotificationIfNeeded()
 	if (currentScreenResizingStatus != nullptr)
 	{
 		// WZ must process the screen size change
+		screen_updateGeometry(); // must come after gfx_api::context::handleWindowSizeChange
 		gameScreenSizeDidChange(currentScreenResizingStatus->oldWidth, currentScreenResizingStatus->oldHeight, currentScreenResizingStatus->newWidth, currentScreenResizingStatus->newHeight);
 		delete currentScreenResizingStatus;
 		currentScreenResizingStatus = nullptr;


### PR DESCRIPTION
Specifically in regards to how (and when) window resizing / window mode changing is handled.

This fixes issues on MoltenVK (on macOS) when attempting to trigger such changes at runtime (depending on the screen, etc).

Areas of focus for testing (in Vulkan mode, of course):
- live window resizing (in windowed mode)
- switching fullscreen mode in Video Options
- using ALT+ENTER to toggle fullscreen / windowed mode in: (a) main menus, (b) Skirmish setup screen, (c) in-game