### PR TITLE
QuickJS: Various leak (and other) fixes

### DIFF
--- a/3rdparty/quickjs/patches/008-freeruntime2.patch
+++ b/3rdparty/quickjs/patches/008-freeruntime2.patch
@@ -1,0 +1,39 @@
+diff --git a/quickjs.c b/quickjs.c
+--- a/quickjs.c
++++ b/quickjs.c
+@@ -1952,6 +1952,11 @@ void JS_SetRuntimeInfo(JSRuntime *rt, const char *s)
+ }
+ 
+ void JS_FreeRuntime(JSRuntime *rt)
++{
++	JS_FreeRuntime2(rt, NULL);
++}
++
++void JS_FreeRuntime2(JSRuntime *rt, void (*gc_leak_handler)(const char* msg))
+ {
+     struct list_head *el, *el1;
+     int i;
+@@ -2007,7 +2012,11 @@ void JS_FreeRuntime(JSRuntime *rt)
+             printf("Secondary object leaks: %d\n", count);
+     }
+ #endif
+-    assert(list_empty(&rt->gc_obj_list));
++    if (!list_empty(&rt->gc_obj_list)) {
++		if (gc_leak_handler != NULL) {
++			gc_leak_handler("gc_obj_list is not empty");
++		}
++	}
+ 
+     /* free the classes */
+     for(i = 0; i < rt->class_count; i++) {
+diff --git a/quickjs.h b/quickjs.h
+--- a/quickjs.h
++++ b/quickjs.h
+@@ -355,6 +355,7 @@ void JS_SetGCThreshold(JSRuntime *rt, size_t gc_threshold);
+ void JS_SetMaxStackSize(JSRuntime *rt, size_t stack_size);
+ JSRuntime *JS_NewRuntime2(const JSMallocFunctions *mf, void *opaque);
+ void JS_FreeRuntime(JSRuntime *rt);
++void JS_FreeRuntime2(JSRuntime *rt, void (*gc_leak_handler)(const char* msg));
+ void *JS_GetRuntimeOpaque(JSRuntime *rt);
+ void JS_SetRuntimeOpaque(JSRuntime *rt, void *opaque);
+ typedef void JS_MarkFunc(JSRuntime *rt, JSGCObjectHeader *gp);

--- a/3rdparty/quickjs/patches/apply_quickjs_patches.cmake
+++ b/3rdparty/quickjs/patches/apply_quickjs_patches.cmake
@@ -59,6 +59,7 @@ quickjs_apply_patches(
 		"005-fix-pedantic-cxx-warnings.patch"
 		"006-bsd-compile-fixes.patch"
 		"007-msvc-64bit-compatibility.patch"
+		"008-freeruntime2.patch"
 )
 
 message(STATUS "Finished applying patches.")

--- a/3rdparty/quickjs/quickjs.c
+++ b/3rdparty/quickjs/quickjs.c
@@ -1953,6 +1953,11 @@ void JS_SetRuntimeInfo(JSRuntime *rt, const char *s)
 
 void JS_FreeRuntime(JSRuntime *rt)
 {
+	JS_FreeRuntime2(rt, NULL);
+}
+
+void JS_FreeRuntime2(JSRuntime *rt, void (*gc_leak_handler)(const char* msg))
+{
     struct list_head *el, *el1;
     int i;
 
@@ -2007,7 +2012,11 @@ void JS_FreeRuntime(JSRuntime *rt)
             printf("Secondary object leaks: %d\n", count);
     }
 #endif
-    assert(list_empty(&rt->gc_obj_list));
+    if (!list_empty(&rt->gc_obj_list)) {
+		if (gc_leak_handler != NULL) {
+			gc_leak_handler("gc_obj_list is not empty");
+		}
+	}
 
     /* free the classes */
     for(i = 0; i < rt->class_count; i++) {

--- a/3rdparty/quickjs/quickjs.h
+++ b/3rdparty/quickjs/quickjs.h
@@ -355,6 +355,7 @@ void JS_SetGCThreshold(JSRuntime *rt, size_t gc_threshold);
 void JS_SetMaxStackSize(JSRuntime *rt, size_t stack_size);
 JSRuntime *JS_NewRuntime2(const JSMallocFunctions *mf, void *opaque);
 void JS_FreeRuntime(JSRuntime *rt);
+void JS_FreeRuntime2(JSRuntime *rt, void (*gc_leak_handler)(const char* msg));
 void *JS_GetRuntimeOpaque(JSRuntime *rt);
 void JS_SetRuntimeOpaque(JSRuntime *rt, void *opaque);
 typedef void JS_MarkFunc(JSRuntime *rt, JSGCObjectHeader *gp);

--- a/lib/widget/jsontable.h
+++ b/lib/widget/jsontable.h
@@ -76,14 +76,19 @@ class JSONTableWidget : public W_FORM
 {
 public:
 	typedef std::function<void (JSONTableWidget&)> CallbackFunc;
+	enum class SpecialJSONStringTypes
+	{
+		TYPE_DESCRIPTION
+	};
+	typedef std::unordered_map<std::string, SpecialJSONStringTypes> SpecialStrings;
 public:
 	JSONTableWidget() : W_FORM() {}
 	~JSONTableWidget();
 
 public:
 	static std::shared_ptr<JSONTableWidget> make(const std::string& title = std::string());
-	void updateData(const nlohmann::ordered_json& json, bool tryToPreservePath = false);
-	void updateData(const nlohmann::json& json, bool tryToPreservePath = false);
+	void updateData(const nlohmann::ordered_json& json, bool tryToPreservePath = false, const SpecialStrings& specialStrings = SpecialStrings());
+	void updateData(const nlohmann::json& json, bool tryToPreservePath = false, const SpecialStrings& specialStrings = SpecialStrings());
 	bool pushJSONPath(const std::string& keyInCurrentJSONPointer);
 	size_t popJSONPath(size_t numLevels = 1);
 	std::string currentJSONPathStr() const;
@@ -98,7 +103,8 @@ public:
 	virtual void run(W_CONTEXT *psContext) override;
 
 private:
-	void updateData_Internal(const std::function<void ()>& setJsonFunc, bool tryToPreservePath);
+	void updateData_Internal(const std::function<void ()>& setJsonFunc, bool tryToPreservePath, const SpecialStrings& specialStrings);
+	void setSpecialStrings_Internal(const SpecialStrings& specialStrings);
 	bool rootJsonHasExpandableChildren() const;
 	void refreshUpdateButtonState();
 	void resizeColumnWidths(bool overrideUserColumnSizing);
@@ -127,6 +133,8 @@ private:
 
 	optional<nlohmann::json>				_json;
 	std::vector<nlohmann::json*>			_json_currentPointer;
+
+	SpecialStrings							_specialStrings;
 
 	std::vector<int>						currentMaxColumnWidths = {0,0,0};
 	std::vector<std::string>				actualPushedPathComponents;

--- a/src/quickjs_backend.cpp
+++ b/src/quickjs_backend.cpp
@@ -192,6 +192,7 @@ public:
 public:
 	// get state for debugging
 	nlohmann::json debugGetAllScriptGlobals() override;
+	std::unordered_map<std::string, wzapi::scripting_instance::DebugSpecialStringType> debugGetScriptGlobalSpecialStringValues() override;
 
 	bool debugEvaluateCommand(const std::string &text) override;
 
@@ -3059,6 +3060,13 @@ nlohmann::json quickjs_scripting_instance::debugGetAllScriptGlobals()
         JS_FreeValue(ctx, jsVal);
 	});
 	return globals;
+}
+
+std::unordered_map<std::string, wzapi::scripting_instance::DebugSpecialStringType> quickjs_scripting_instance::debugGetScriptGlobalSpecialStringValues()
+{
+	std::unordered_map<std::string, wzapi::scripting_instance::DebugSpecialStringType> result;
+	result["<constructor>"] = wzapi::scripting_instance::DebugSpecialStringType::TYPE_DESCRIPTION;
+	return result;
 }
 
 bool quickjs_scripting_instance::debugEvaluateCommand(const std::string &text)

--- a/src/quickjs_backend.cpp
+++ b/src/quickjs_backend.cpp
@@ -160,6 +160,12 @@ public:
 	{
 		engineToInstanceMap.erase(ctx);
 
+		if (!(JS_IsUninitialized(compiledScriptObj)))
+		{
+			JS_FreeValue(ctx, compiledScriptObj);
+			compiledScriptObj = JS_UNINITIALIZED;
+		}
+
 		JS_FreeValue(ctx, global_obj);
 		JS_FreeContext(ctx);
 		ctx = nullptr;
@@ -2825,6 +2831,7 @@ ScriptMapData runMapScript_QuickJS(WzString const &path, uint64_t seed, bool pre
 		return data;
 	}
 
+	JS_FreeValue(ctx, result);
 	return data;
 }
 
@@ -2927,6 +2934,7 @@ bool quickjs_scripting_instance::loadScript(const WzString& path, int player, in
 
 bool quickjs_scripting_instance::readyInstanceForExecution()
 {
+	ASSERT_OR_RETURN(false, !JS_IsUninitialized(compiledScriptObj), "compiledScriptObj is uninitialized");
 	JSValue result = JS_EvalFunction(ctx, compiledScriptObj);
 	compiledScriptObj = JS_UNINITIALIZED;
 	if (JS_IsException(result))
@@ -2939,6 +2947,7 @@ bool quickjs_scripting_instance::readyInstanceForExecution()
 		return false;
 	}
 
+	JS_FreeValue(ctx, result);
 	return true;
 }
 

--- a/src/wzapi.cpp
+++ b/src/wzapi.cpp
@@ -114,6 +114,10 @@ wzapi::scripting_instance::scripting_instance(int player, const std::string& scr
 { }
 wzapi::scripting_instance::~scripting_instance()
 { }
+std::unordered_map<std::string, wzapi::scripting_instance::DebugSpecialStringType> wzapi::scripting_instance::debugGetScriptGlobalSpecialStringValues()
+{
+	return {};
+}
 void wzapi::scripting_instance::dumpScriptLog(const std::string &info)
 {
 	dumpScriptLog(info, player());

--- a/src/wzapi.h
+++ b/src/wzapi.h
@@ -587,6 +587,10 @@ namespace wzapi
 	public:
 		// get state for debugging
 		virtual nlohmann::json debugGetAllScriptGlobals() = 0;
+		enum class DebugSpecialStringType {
+			TYPE_DESCRIPTION
+		};
+		virtual std::unordered_map<std::string, DebugSpecialStringType> debugGetScriptGlobalSpecialStringValues();
 
 		virtual bool debugEvaluateCommand(const std::string &text) = 0;
 

--- a/src/wzscriptdebug.cpp
+++ b/src/wzscriptdebug.cpp
@@ -907,9 +907,30 @@ public:
 			const auto& modelMap = scriptDebuggerStrong->getModelMap();
 			auto it = modelMap.find(context);
 			ASSERT_OR_RETURN(, it != modelMap.end(), "context not found?!");
-			table->updateData(it->second, tryToPreservePath);
+			table->updateData(it->second, tryToPreservePath, transformContextSpecialStrings(context));
 			currentContext = context;
 		}
+	}
+private:
+	JSONTableWidget::SpecialJSONStringTypes toJSONSpecialStringType(wzapi::scripting_instance::DebugSpecialStringType debugStringType) const
+	{
+		switch (debugStringType)
+		{
+		case wzapi::scripting_instance::DebugSpecialStringType::TYPE_DESCRIPTION:
+			return JSONTableWidget::SpecialJSONStringTypes::TYPE_DESCRIPTION;
+		}
+		return static_cast<JSONTableWidget::SpecialJSONStringTypes>(0); // silence warning
+	}
+	std::unordered_map<std::string, JSONTableWidget::SpecialJSONStringTypes> transformContextSpecialStrings(wzapi::scripting_instance *context)
+	{
+		ASSERT_OR_RETURN({}, context != nullptr, "null context");
+		auto contextSpecialStringInfo = context->debugGetScriptGlobalSpecialStringValues();
+		std::unordered_map<std::string, JSONTableWidget::SpecialJSONStringTypes> result;
+		for (auto& it : contextSpecialStringInfo)
+		{
+			result[it.first] = toJSONSpecialStringType(it.second);
+		}
+		return result;
 	}
 public:
 	wzapi::scripting_instance *currentContext = nullptr;


### PR DESCRIPTION
Patches the QuickJS default behavior of `assert`-ing if there are GC leaks. Instead, log that there were leaks and continue.