### PR TITLE
Snap: Improve Vulkan SDK install

### DIFF
--- a/.ci/snap/install_vulkan_sdk.sh
+++ b/.ci/snap/install_vulkan_sdk.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+TARGET_BUILD_ARCH="$("${SNAPCRAFT_PART_SRC}/.ci/snap/snapcraft_build_get_target_arch.sh")"
+
+echo "[install_vulkan_sdk.sh]"
+echo "Target Arch: $TARGET_BUILD_ARCH"
+
+if [ "$TARGET_BUILD_ARCH" = "amd64" ]; then
+  # Install Vulkan SDK (binary package)
+  echo "Installing Vulkan SDK"
+
+  # Add Vulkan SDK repo
+  wget -qO - https://packages.lunarg.com/lunarg-signing-key-pub.asc | apt-key add -
+  wget -qO /etc/apt/sources.list.d/lunarg-vulkan-1.2.148-bionic.list https://packages.lunarg.com/vulkan/1.2.148/lunarg-vulkan-1.2.148-bionic.list
+  apt update
+  apt install --yes vulkan-sdk
+
+else
+  # Compile the necessary components of the Vulkan SDK from source
+  echo "Compiling Vulkan SDK (selected components)"
+
+  mkdir tmp_vulkan_sdk_build
+  cd "tmp_vulkan_sdk_build"
+
+  # glslc
+  DEBIAN_FRONTEND=noninteractive apt-get -y install cmake python3 lcov
+
+  # glslc - clone
+  echo "Fetching shaderc"
+  git clone https://github.com/google/shaderc shaderc
+  cd shaderc
+  git checkout tags/v2020.4 -b v2020.4
+  ./utils/git-sync-deps
+  cd ..
+
+  # glslc - cmake build + install
+  mkdir shaderc_build
+  cd shaderc_build
+  echo "Configuring shaderc"
+  cmake -GNinja -DSHADERC_SKIP_TESTS=ON -DCMAKE_BUILD_TYPE=Release ../shaderc/
+  echo "Compiling shaderc"
+  cmake --build . --target install
+  cd ..
+
+  cd ..
+  rm -rf "tmp_vulkan_sdk_build"
+fi
+
+echo "Installing Vulkan SDK - done"

--- a/.ci/snap/snapcraft_build_get_target_arch.sh
+++ b/.ci/snap/snapcraft_build_get_target_arch.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# Get Snapcraft build-time target arch
+
+echoerr() { echo "$@" 1>&2; }
+
+BUILDTIME_TARGET_ARCH=""
+if [ -n "${SNAPCRAFT_TARGET_ARCH}" ]; then
+  # SNAPCRAFT_TARGET_ARCH is available - use it!
+  BUILDTIME_TARGET_ARCH="${SNAPCRAFT_TARGET_ARCH}"
+else
+  # If SNAPCRAFT_TARGET_ARCH is not available, parse the SNAPCRAFT_ARCH_TRIPLET and convert it
+  case ${SNAPCRAFT_ARCH_TRIPLET%%-*} in
+  x86_64)
+      BUILDTIME_TARGET_ARCH="amd64"
+      ;;
+  i386)
+      BUILDTIME_TARGET_ARCH="i386"
+      ;;
+  aarch64)
+      BUILDTIME_TARGET_ARCH="arm64"
+      ;;
+  *)
+      BUILDTIME_TARGET_ARCH=""
+  esac
+fi
+
+echo "${BUILDTIME_TARGET_ARCH}"

--- a/.snapcraft.yaml
+++ b/.snapcraft.yaml
@@ -151,12 +151,12 @@ parts:
       snapcraftctl set-version "$(git describe --always)"
       git submodule update --init
     override-build: |
+      echo "SNAPCRAFT_TARGET_ARCH=${SNAPCRAFT_TARGET_ARCH}"
+      echo "SNAPCRAFT_ARCH_TRIPLET=${SNAPCRAFT_ARCH_TRIPLET}"
+      
       # Install Vulkan SDK
-      wget -qO - https://packages.lunarg.com/lunarg-signing-key-pub.asc | apt-key add -
-      wget -qO /etc/apt/sources.list.d/lunarg-vulkan-1.2.148-bionic.list https://packages.lunarg.com/vulkan/1.2.148/lunarg-vulkan-1.2.148-bionic.list
-      apt update
-      apt install --yes vulkan-sdk
-
+      . "${SNAPCRAFT_PART_SRC}/.ci/snap/install_vulkan_sdk.sh"
+      
       if [ -f ".snapenv" ]; then set -a; source .snapenv; set +a; fi
       if [ -z "$WZ_DISTRIBUTOR" ]; then export WZ_DISTRIBUTOR="UNKNOWN"; fi
       cmake -S "$SNAPCRAFT_PART_SRC" -B. -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=RelWithDebInfo -DWZ_ENABLE_WARNINGS:BOOL=ON -DWZ_DISTRIBUTOR:STRING="${WZ_DISTRIBUTOR}" -DWZ_OUTPUT_NAME_SUFFIX="${WZ_OUTPUT_NAME_SUFFIX}" -DWZ_NAME_SUFFIX="${WZ_NAME_SUFFIX}" -G"Ninja"

--- a/cmake/FindVulkanHeaders.cmake
+++ b/cmake/FindVulkanHeaders.cmake
@@ -14,6 +14,15 @@
 set(VK_HEADER_VERSION_STRING "")
 
 find_package(Vulkan)
+if(NOT Vulkan_FOUND)
+	# Try to find *just* the headers
+	find_path(Vulkan_INCLUDE_DIRS
+		NAMES vulkan/vulkan.h
+		HINTS "$ENV{VULKAN_SDK}/include")
+	if(Vulkan_INCLUDE_DIRS)
+		set(Vulkan_FOUND TRUE)
+	endif()
+endif()
 if(Vulkan_FOUND)
 	# Check to ensure that the headers are at least the minimum supported version
 	if(Vulkan_INCLUDE_DIRS AND EXISTS "${Vulkan_INCLUDE_DIRS}/vulkan/vulkan_core.h")

--- a/lib/ivis_opengl/CMakeLists.txt
+++ b/lib/ivis_opengl/CMakeLists.txt
@@ -65,13 +65,14 @@ target_link_libraries(ivis-opengl PRIVATE framework PNG::PNG ${HARFBUZZ_LIBRARIE
 target_link_libraries(ivis-opengl PUBLIC glad)
 if(WZ_ENABLE_BACKEND_VULKAN)
 	find_package(VulkanHeaders 148) # minimum supported version of the Vulkan headers is 148
+	set(_vulkanheaders_dl_gittag "sdk-1.2.148.0")
 	if((NOT VulkanHeaders_FOUND AND NOT ${CMAKE_VERSION} VERSION_LESS "3.11.0") AND (NOT WZ_DISABLE_FETCHCONTENT_GIT_CLONE))
 		# Fetch newer Vulkan headers (using FetchContent, which requires CMake 3.11+)
 		include(FetchContent)
 		FetchContent_Declare(
 			vulkan_headers
 			GIT_REPOSITORY https://github.com/KhronosGroup/Vulkan-Headers.git
-			GIT_TAG        sdk-1.2.148.0
+			GIT_TAG        ${_vulkanheaders_dl_gittag}
 		)
 		FetchContent_GetProperties(vulkan_headers)
 		if(NOT vulkan_headers_POPULATED)
@@ -80,6 +81,34 @@ if(WZ_ENABLE_BACKEND_VULKAN)
 		set(VulkanHeaders_FOUND TRUE)
 		set(VulkanHeaders_INCLUDE_DIRS "${vulkan_headers_SOURCE_DIR}/include")
 		message(STATUS "Using fetched Vulkan headers: ${VulkanHeaders_INCLUDE_DIRS}")
+	elseif((NOT VulkanHeaders_FOUND AND ${CMAKE_VERSION} VERSION_LESS "3.11.0") AND (NOT WZ_DISABLE_FETCHCONTENT_GIT_CLONE))
+		# Fetch newer Vulkan headers using Git directly (on CMake < 3.11)
+		find_package(Git QUIET)
+		if(Git_FOUND)
+			if(EXISTS "${CMAKE_CURRENT_BINARY_DIR}/vulkan_headers" AND IS_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/vulkan_headers")
+				# Because this branch is only executed for CMake < 3.11, use "remove_directory"
+				execute_process(
+					COMMAND ${CMAKE_COMMAND} "-E" "remove_directory" "vulkan_headers"
+					WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}")
+			endif()
+			execute_process(
+				COMMAND ${GIT_EXECUTABLE} clone https://github.com/KhronosGroup/Vulkan-Headers.git "vulkan_headers"
+				WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
+				RESULT_VARIABLE _git_exstatus
+				ERROR_QUIET)
+			if(_git_exstatus EQUAL 0)
+				execute_process(
+					COMMAND ${GIT_EXECUTABLE} checkout "tags/${_vulkanheaders_dl_gittag}" -b version_commit
+					WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/vulkan_headers"
+					RESULT_VARIABLE _git_exstatus
+					ERROR_QUIET)
+			endif()
+			if(_git_exstatus EQUAL 0)
+				set(VulkanHeaders_FOUND TRUE)
+				set(VulkanHeaders_INCLUDE_DIRS "${CMAKE_CURRENT_BINARY_DIR}/vulkan_headers/include")
+				message(STATUS "Using (Git) fetched Vulkan headers: ${VulkanHeaders_INCLUDE_DIRS}")
+			endif()
+		endif()
 	endif()
 	if(VulkanHeaders_FOUND AND TARGET glsl_compilation)
 		target_compile_definitions(ivis-opengl PUBLIC "-DWZ_VULKAN_ENABLED")


### PR DESCRIPTION
Support building the Vulkan backend on non-amd64 architectures.

(Currently the Linux Vulkan SDK is only available pre-compiled for amd64/x86_64, but the only pieces that we actually need to compile WZ are: `glslc` (part of `shaderc`) and the Vulkan headers.)