### PR TITLE
Snap: Tweak install_vulkan_sdk.sh, attempt to fix compiler warnings on armhf

### DIFF
--- a/.ci/snap/install_vulkan_sdk.sh
+++ b/.ci/snap/install_vulkan_sdk.sh
@@ -15,7 +15,7 @@ if [ "$TARGET_BUILD_ARCH" = "amd64" ]; then
   apt update
   apt install --yes vulkan-sdk
 
-elif [ "$TARGET_BUILD_ARCH" = "i386" ] || [ "$TARGET_BUILD_ARCH" = "arm64" ] || [ "$TARGET_BUILD_ARCH" = "ppc64el" ] || [ "$TARGET_BUILD_ARCH" = "s390x" ]; then
+else
   # Compile the necessary components of the Vulkan SDK from source
   echo "Compiling Vulkan SDK (selected components)"
 
@@ -44,10 +44,6 @@ elif [ "$TARGET_BUILD_ARCH" = "i386" ] || [ "$TARGET_BUILD_ARCH" = "arm64" ] || 
 
   cd ..
   rm -rf "tmp_vulkan_sdk_build"
-
-else
-  # Skip Vulkan SDK
-  echo "Skipping Vulkan SDK (for TARGET_BUILD_ARCH: $TARGET_BUILD_ARCH)"
 
 fi
 

--- a/.ci/snap/install_vulkan_sdk.sh
+++ b/.ci/snap/install_vulkan_sdk.sh
@@ -48,7 +48,6 @@ elif [ "$TARGET_BUILD_ARCH" = "i386" ] || [ "$TARGET_BUILD_ARCH" = "arm64" ] || 
 else
   # Skip Vulkan SDK
   echo "Skipping Vulkan SDK (for TARGET_BUILD_ARCH: $TARGET_BUILD_ARCH)"
-  exit 0
 
 fi
 

--- a/lib/ivis_opengl/3rdparty/vk_mem_alloc.cpp
+++ b/lib/ivis_opengl/3rdparty/vk_mem_alloc.cpp
@@ -40,6 +40,9 @@
 # pragma GCC diagnostic ignored "-Wunused-variable"
 # pragma GCC diagnostic ignored "-Wmissing-field-initializers"
 # pragma GCC diagnostic ignored "-Wmissing-noreturn"
+#  if (defined(__arm__) || defined(__thumb__)) && !defined(__aarch64__)
+#    pragma GCC diagnostic ignored "-Wcast-align"
+#  endif
 #elif defined(_MSC_VER)
 # pragma warning( push )
 # pragma warning( disable : 4189 ) // warning C4189: 'identifier' : local variable is initialized but not referenced


### PR DESCRIPTION
Don't exit from the `install_vulkan_sdk.sh` script because it is sourced in `.snapcraft.yaml` (this was breaking `armhf` builds, which were not configured to attempt to build the Vulkan SDK components).

Suppress some compiler warnings with Vulkan Memory Allocator on GCC + ARM.