### PR TITLE
Fix multiple line breaks in a row

### DIFF
--- a/lib/ivis_opengl/textdraw.cpp
+++ b/lib/ivis_opengl/textdraw.cpp
@@ -671,9 +671,14 @@ void iV_SetTextColour(PIELIGHT colour)
 	font_colour[3] = colour.byte.a / 255.0f;
 }
 
+static bool breaksLine(char const c)
+{
+	return c == ASCII_NEWLINE || c == '\n';
+}
+
 static bool breaksWord(char const c)
 {
-	return c == ASCII_SPACE || c == ASCII_NEWLINE || c == '\n';
+	return c == ASCII_SPACE || breaksLine(c);
 }
 
 std::vector<TextLine> iV_FormatText(const char *String, UDWORD MaxWidth, UDWORD Justify, iV_fonts fontID, bool ignoreNewlines /*= false*/)
@@ -714,7 +719,7 @@ std::vector<TextLine> iV_FormatText(const char *String, UDWORD MaxWidth, UDWORD 
 			FWord.clear();
 			for (
 				;
-				*curChar && (indexWithinLine == 0 || !breaksWord(*curChar));
+				*curChar && ((indexWithinLine == 0 && !breaksLine(*curChar)) || !breaksWord(*curChar));
 				++i, ++curChar, ++indexWithinLine
 			)
 			{
@@ -754,8 +759,7 @@ std::vector<TextLine> iV_FormatText(const char *String, UDWORD MaxWidth, UDWORD 
 				}
 			}
 			// Check for new line character.
-			else if (*curChar == ASCII_NEWLINE
-			         || *curChar == '\n')
+			else if (breaksLine(*curChar))
 			{
 				if (!ignoreNewlines)
 				{


### PR DESCRIPTION
f14bd8b038 introduced an issue when a text contains multiple '\n' in sequence.

It is not easy to reproduce the problem cause it requires that a label is shown containing the sequence of '\n'. One way to reproduce it is to add the following snippet to the top of the function `startTitleMenu`:

```
#include "notifications.h"
// ...
void startTitleMenu()
{
	WZ_Notification notification;
	notification.contentTitle = "test";
	notification.contentText = "a\n\nb";
	addNotification(notification, WZ_Notification_Trigger::Immediate());
// ...
```