### PR TITLE
Add prompt to increase game's Display Scale

### DIFF
--- a/lib/framework/wzapp.h
+++ b/lib/framework/wzapp.h
@@ -88,6 +88,8 @@ bool wzIsWindowResizable();
 bool wzChangeDisplayScale(unsigned int displayScale);
 bool wzChangeWindowResolution(int screen, unsigned int width, unsigned int height);
 unsigned int wzGetMaximumDisplayScaleForWindowSize(unsigned int windowWidth, unsigned int windowHeight);
+unsigned int wzGetMaximumDisplayScaleForCurrentWindowSize();
+unsigned int wzGetSuggestedDisplayScaleForCurrentWindowSize(unsigned int desiredMaxScreenDimension);
 unsigned int wzGetCurrentDisplayScale();
 void wzGetWindowResolution(int *screen, unsigned int *width, unsigned int *height);
 bool wzSetClipboardText(const char *text);

--- a/lib/sdl/main_sdl.cpp
+++ b/lib/sdl/main_sdl.cpp
@@ -1542,6 +1542,31 @@ unsigned int wzGetMaximumDisplayScaleForWindowSize(unsigned int windowWidth, uns
 	return *maxDisplayScale;
 }
 
+unsigned int wzGetMaximumDisplayScaleForCurrentWindowSize()
+{
+	return wzGetMaximumDisplayScaleForWindowSize(windowWidth, windowHeight);
+}
+
+unsigned int wzGetSuggestedDisplayScaleForCurrentWindowSize(unsigned int desiredMaxScreenDimension)
+{
+	unsigned int maxDisplayScale = wzGetMaximumDisplayScaleForCurrentWindowSize();
+
+	auto availableDisplayScales = wzAvailableDisplayScales();
+	std::sort(availableDisplayScales.begin(), availableDisplayScales.end());
+
+	for (auto it = availableDisplayScales.begin(); it != availableDisplayScales.end() && (*it <= maxDisplayScale); it++)
+	{
+		auto resultingLogicalScreenWidth = (windowWidth * 100) / *it;
+		auto resultingLogicalScreenHeight = (windowHeight * 100) / *it;
+		if (resultingLogicalScreenWidth <= desiredMaxScreenDimension && resultingLogicalScreenHeight <= desiredMaxScreenDimension)
+		{
+			return *it;
+		}
+	}
+
+	return maxDisplayScale;
+}
+
 bool wzWindowSizeIsSmallerThanMinimumRequired(unsigned int windowWidth, unsigned int windowHeight, float displayScaleFactor = current_displayScaleFactor)
 {
 	unsigned int minWindowWidth = 0, minWindowHeight = 0;

--- a/src/frontend.cpp
+++ b/src/frontend.cpp
@@ -2505,8 +2505,8 @@ void frontendScreenSizeDidChange(int oldWidth, int oldHeight, int newWidth, int 
 					war_SetDisplayScale(priorDisplayScale);
 				}
 			});
-			notification.onDismissed = [](const WZ_Notification&, bool wasProgrammaticallyDismissed) {
-				if (wasProgrammaticallyDismissed) { return; }
+			notification.onDismissed = [](const WZ_Notification&, WZ_Notification_Dismissal_Reason reason) {
+				if (reason != WZ_Notification_Dismissal_Reason::USER_DISMISSED) { return; }
 				WZ_Notification dismissed_notification;
 				dismissed_notification.duration = 0;
 				dismissed_notification.contentTitle = _("Tip: Adjusting Display Scale");

--- a/src/integrations/wzdiscordrpc.cpp
+++ b/src/integrations/wzdiscordrpc.cpp
@@ -1085,7 +1085,8 @@ static void handleDiscordJoinRequest(const DiscordUser* request)
 				Discord_Respond(userId.c_str(), DISCORD_REPLY_YES);
 				lastDismissedJoinRequestByUserId.erase(userId);
 			});
-			notification.onDismissed = [userId](const WZ_Notification&, bool){
+			notification.onDismissed = [userId](const WZ_Notification&, WZ_Notification_Dismissal_Reason reason){
+				if (reason == WZ_Notification_Dismissal_Reason::ACTION_BUTTON_CLICK) { return; }
 				Discord_Respond(userId.c_str(), DISCORD_REPLY_NO);
 				// store this to prevent join-spamming
 				lastDismissedJoinRequestByUserId[userId] = std::chrono::system_clock::now();

--- a/src/notifications.h
+++ b/src/notifications.h
@@ -140,6 +140,15 @@ public:
 	std::function<void (WZ_Notification&)> onAction;
 };
 
+enum class WZ_Notification_Dismissal_Reason {
+	// the user pressed the "Dismiss" button (or dragged the notification upwards)
+	USER_DISMISSED,
+	// the notification was dismissed because the "Action" button was pressed
+	ACTION_BUTTON_CLICK,
+	// the notification was cancelled or dismissed by one of the `cancelOrDismissNotification*()` functions (or similar)
+	PROGRAMMATIC
+};
+
 class WZ_Notification
 {
 public:
@@ -173,9 +182,9 @@ public:
 	std::string tag;
 	// Called when the notification is initially (fully) displayed
 	std::function<void (const WZ_Notification&)> onDisplay;
-	// Called when the notification is dismissed *without* pressing the "Action" button
-	// (i.e. by pressing the "Dismiss" button or dragging it upwards)
-	std::function<void (const WZ_Notification&, bool wasProgrammaticallyDismissed)> onDismissed;
+	// Called when the notification is dismissed / closed
+	// see: `WZ_Notification_Dismissal_Reason`
+	std::function<void (const WZ_Notification&, WZ_Notification_Dismissal_Reason reason)> onDismissed;
 	// Called if an ignorable notification is ignored / not displayed
 	std::function<void (const WZ_Notification&)> onIgnored;
 public:


### PR DESCRIPTION
If logical resolution exceeds a defined amount.

Uses a new function (`wzGetSuggestedDisplayScaleForCurrentWindowSize`) to attempt to calculate a "good" suggested Display Scale.

Fixes #1211