### PR TITLE
[SDL backend] Auto-increase the game's Display Scale on Windows w/ high-DPI

### DIFF
--- a/src/configuration.cpp
+++ b/src/configuration.cpp
@@ -414,6 +414,7 @@ bool loadConfig()
 		displayScale = 500;
 	}
 	war_SetDisplayScale(static_cast<unsigned int>(displayScale));
+	war_setAutoAdjustDisplayScale(iniGetBool("autoAdjustDisplayScale", true).value());
 	// 640x480 is minimum that we will support, but default to something more sensible
 	int width = iniGetInteger("width", war_GetWidth()).value();
 	int height = iniGetInteger("height", war_GetHeight()).value();
@@ -549,6 +550,7 @@ bool saveConfig()
 	iniSetBool("trapCursor", war_GetTrapCursor());
 	iniSetInteger("vsync", war_GetVsync());
 	iniSetInteger("displayScale", war_GetDisplayScale());
+	iniSetBool("autoAdjustDisplayScale", war_getAutoAdjustDisplayScale());
 	iniSetInteger("textureSize", getTextureSize());
 	iniSetInteger("antialiasing", war_getAntialiasing());
 	iniSetInteger("UPnP", (int)NetPlay.isUPNP);

--- a/src/warzoneconfig.cpp
+++ b/src/warzoneconfig.cpp
@@ -64,6 +64,7 @@ struct WARZONE_GLOBALS
 	bool radarJump = false;
 	video_backend gfxBackend = video_backend::opengl; // the actual default value is determined in loadConfig()
 	JS_BACKEND jsBackend = (JS_BACKEND)0;
+	bool autoAdjustDisplayScale = true;
 };
 
 static WARZONE_GLOBALS warGlobs;
@@ -400,4 +401,14 @@ JS_BACKEND war_getJSBackend()
 void war_setJSBackend(JS_BACKEND backend)
 {
 	warGlobs.jsBackend = backend;
+}
+
+bool war_getAutoAdjustDisplayScale()
+{
+	return warGlobs.autoAdjustDisplayScale;
+}
+
+void war_setAutoAdjustDisplayScale(bool autoAdjustDisplayScale)
+{
+	warGlobs.autoAdjustDisplayScale = autoAdjustDisplayScale;
 }

--- a/src/warzoneconfig.h
+++ b/src/warzoneconfig.h
@@ -114,6 +114,8 @@ video_backend war_getGfxBackend();
 void war_setGfxBackend(video_backend backend);
 JS_BACKEND war_getJSBackend();
 void war_setJSBackend(JS_BACKEND backend);
+bool war_getAutoAdjustDisplayScale();
+void war_setAutoAdjustDisplayScale(bool autoAdjustDisplayScale);
 
 /**
  * Enable or disable sound initialization


### PR DESCRIPTION
A basic attempt to provide a better default experience on Windows, absent proper built-in SDL support for high-DPI (on Windows).

If this behavior is undesirable, it can be disabled by setting the new `config` file option "autoAdjustDisplayScale" to false.