### PR TITLE
Various JS API enhancements / refactoring, `includeJSON`

### DIFF
--- a/src/quickjs_backend.cpp
+++ b/src/quickjs_backend.cpp
@@ -2280,6 +2280,11 @@ static std::string QuickJS_DumpError(JSContext *ctx)
 	return result;
 }
 
+static bool strEndsWith(const std::string &str, const std::string &suffix)
+{
+	return (str.size() >= suffix.size()) && (str.compare(str.size() - suffix.size(), suffix.size(), suffix) == 0);
+}
+
 //-- ## include(file)
 //-- Includes another source code file at this point. You should generally only specify the filename,
 //-- not try to specify its path, here.
@@ -2292,6 +2297,7 @@ static JSValue js_include(JSContext *ctx, JSValueConst this_val, int argc, JSVal
 	auto free_global_obj = gsl::finally([ctx, global_obj] { JS_FreeValue(ctx, global_obj); });  // establish exit action
 	std::string basePath = QuickJS_GetStdString(ctx, global_obj, "scriptPath");
 	std::string basenameStr = JSValueToStdString(ctx, argv[0]);
+	SCRIPT_ASSERT(ctx, strEndsWith(basenameStr, ".js"), "Include file must end in .js");
 	WzPathInfo basename = WzPathInfo::fromPlatformIndependentPath(basenameStr);
 	std::string path = basePath + "/" + basename.fileName();
 	// allow users to use subdirectories too

--- a/src/stats.cpp
+++ b/src/stats.cpp
@@ -1567,6 +1567,23 @@ bool getWeaponEffect(const WzString& weaponEffect, WEAPON_EFFECT *effect)
 	return true;
 }
 
+/*returns the weapon effect string based on the enum passed in */
+const char *getWeaponEffect(WEAPON_EFFECT effect)
+{
+	switch (effect)
+	{
+	case WE_ANTI_PERSONNEL: return "ANTI PERSONNEL";
+	case WE_ANTI_TANK: return "ANTI TANK";
+	case WE_BUNKER_BUSTER: return "BUNKER BUSTER";
+	case WE_ARTILLERY_ROUND: return "ARTILLERY ROUND";
+	case WE_FLAMER: return "FLAMER";
+	case WE_ANTI_AIRCRAFT: return "ANTI AIRCRAFT";
+	case WE_NUMEFFECTS: break;
+	}
+	ASSERT(false, "No such weapon effect");
+	return "Bad weapon effect";
+}
+
 bool getWeaponClass(const WzString& weaponClassStr, WEAPON_CLASS *weaponClass)
 {
 	if (weaponClassStr.compare("KINETIC") == 0)

--- a/src/stats.h
+++ b/src/stats.h
@@ -235,6 +235,9 @@ WZ_DECL_PURE bool objHasWeapon(const BASE_OBJECT *psObj);
 void statsInitVars();
 
 bool getWeaponEffect(const WzString& weaponEffect, WEAPON_EFFECT *effect);
+/*returns the weapon effect string based on the enum passed in */
+const char *getWeaponEffect(WEAPON_EFFECT effect);
+
 bool getWeaponClass(const WzString& weaponClassStr, WEAPON_CLASS *weaponClass);
 
 /* Wrappers */

--- a/src/wzapi.cpp
+++ b/src/wzapi.cpp
@@ -4251,6 +4251,8 @@ nlohmann::json wzapi::constructStatsObject()
 			weap["RepeatClass"] = getWeaponSubClass(psStats->periodicalDamageWeaponSubClass);
 			weap["FireOnMove"] = psStats->fireOnMove;
 			weap["Effect"] = getWeaponEffect(psStats->weaponEffect);
+			weap["ShootInAir"] = static_cast<bool>((psStats->surfaceToAir & SHOOT_IN_AIR) != 0);
+			weap["ShootOnGround"] = static_cast<bool>((psStats->surfaceToAir & SHOOT_ON_GROUND) != 0);
 			wbase[psStats->name.toUtf8()] = std::move(weap);
 		}
 		stats["Weapon"] = std::move(wbase);

--- a/src/wzapi.cpp
+++ b/src/wzapi.cpp
@@ -4250,6 +4250,7 @@ nlohmann::json wzapi::constructStatsObject()
 			weap["ImpactClass"] = getWeaponSubClass(psStats->weaponSubClass);
 			weap["RepeatClass"] = getWeaponSubClass(psStats->periodicalDamageWeaponSubClass);
 			weap["FireOnMove"] = psStats->fireOnMove;
+			weap["Effect"] = getWeaponEffect(psStats->weaponEffect);
 			wbase[psStats->name.toUtf8()] = std::move(weap);
 		}
 		stats["Weapon"] = std::move(wbase);

--- a/src/wzapi.cpp
+++ b/src/wzapi.cpp
@@ -4253,6 +4253,13 @@ nlohmann::json wzapi::constructStatsObject()
 			weap["Effect"] = getWeaponEffect(psStats->weaponEffect);
 			weap["ShootInAir"] = static_cast<bool>((psStats->surfaceToAir & SHOOT_IN_AIR) != 0);
 			weap["ShootOnGround"] = static_cast<bool>((psStats->surfaceToAir & SHOOT_ON_GROUND) != 0);
+			weap["NoFriendlyFire"] = psStats->flags.test(WEAPON_FLAG_NO_FRIENDLY_FIRE);
+			weap["FlightSpeed"] = psStats->flightSpeed;
+			weap["Rotate"] = psStats->rotate;
+			weap["MinElevation"] = psStats->minElevation;
+			weap["MaxElevation"] = psStats->maxElevation;
+			weap["Recoil"] = psStats->recoilValue;
+			weap["Penetrate"] = psStats->penetrate;
 			wbase[psStats->name.toUtf8()] = std::move(weap);
 		}
 		stats["Weapon"] = std::move(wbase);

--- a/src/wzapi.cpp
+++ b/src/wzapi.cpp
@@ -108,9 +108,10 @@ BASE_OBJECT *IdToObject(OBJECT_TYPE type, int id, int player)
 	}
 }
 
-wzapi::scripting_instance::scripting_instance(int player, const std::string& scriptName)
+wzapi::scripting_instance::scripting_instance(int player, const std::string& scriptName, const std::string& scriptPath)
 : m_player(player)
 , m_scriptName(scriptName)
+, m_scriptPath(scriptPath)
 { }
 wzapi::scripting_instance::~scripting_instance()
 { }

--- a/src/wzapi.h
+++ b/src/wzapi.h
@@ -572,6 +572,29 @@ namespace wzapi
 		inline bool isReceivingAllEvents() const { return m_isReceivingAllEvents; }
 
 	public:
+		// Helpers for loading a file from the "context" of a scripting_instance
+		class LoadFileSearchOptions
+		{
+		public:
+			static const uint32_t ScriptPath_FileNameOnlyBackwardsCompat = 0x00000001;
+			static const uint32_t ScriptPath = 0x00000002;
+			static const uint32_t DataDir = 0x00000004;
+			static const uint32_t ConfigScriptDir = 0x00000008;
+			static const uint32_t All = ScriptPath | DataDir | ConfigScriptDir;
+			static const uint32_t All_BackwardsCompat = ScriptPath_FileNameOnlyBackwardsCompat | All;
+		};
+
+		// Loads a file.
+		// (Intended for use from implementations of things like "include" functions.)
+		//
+		// Lookup order is as follows (based on the value of `searchFlags`):
+		// - 1.) The filename *only* is checked relative to the main scriptPath (LoadFileSearchOptions::ScriptPath_FileNameOnlyBackwardsCompat) - for backwards-compat only
+		// - 2.) The filePath is checked relative to the main scriptPath (LoadFileSearchOptions::ScriptPath)
+		// - 3.) The filePath is checked relative to the read-only data dir search paths (LoadFileSearchOptions::DataDir)
+		// - 4.) The filePath is checked relative to "<user's config dir>/script/" (LoadFileSearchOptions::ConfigScriptDir)
+		bool loadFileForInclude(const std::string& filePath, std::string& loadedFilePath, char **ppFileData, UDWORD *pFileSize, uint32_t searchFlags = LoadFileSearchOptions::All);
+
+	public:
 		// event handling
 		// - see `scripting_event_handling_interface`
 

--- a/src/wzapi.h
+++ b/src/wzapi.h
@@ -556,7 +556,7 @@ namespace wzapi
 	class scripting_instance : public scripting_event_handling_interface
 	{
 	public:
-		scripting_instance(int player, const std::string& scriptName);
+		scripting_instance(int player, const std::string& scriptName, const std::string& scriptPath);
 		virtual ~scripting_instance();
 
 	public:
@@ -564,6 +564,7 @@ namespace wzapi
 
 	public:
 		const std::string& scriptName() const { return m_scriptName; }
+		const std::string& scriptPath() const { return m_scriptPath; }
 		int player() const { return m_player; }
 
 	public:
@@ -623,6 +624,7 @@ namespace wzapi
 	private:
 		int m_player;
 		std::string m_scriptName;
+		std::string m_scriptPath;
 		bool m_isReceivingAllEvents = false;
 	};
 


### PR DESCRIPTION
- [QuickJS] js_include: Check for expected file extension
- Store scriptPath in the `scripting_instance`
- Refactor "include" file search / load to `scripting_instance::loadFileForInclude`
- [QuickJS] Add `includeJSON` function

This incorporates a modified version of #1494.

For now, `includeJSON` is limited to including files at or beneath the main script's `scriptPath` - the intention being to enable including JSON files belonging to / bundled with the script.

(Other files elsewhere - like the game's internal JSON files - may change formats / locations and thus break compatibility. Needed information from those files should be exposed as script globals such that backwards compatibility can be maintained more easily.)

Stats information not currently exposed to scripts:
- [x] Weapon `weaponEffect`
- [x] Weapon `surfaceToAir`
   - Convert to: `shootInAir` and `shootOnGround` in Stats object
- [x] Weapon `WEAPON_FLAG_NO_FRIENDLY_FIRE`
- [x] Weapon `flightSpeed`
- [x] Weapon `rotate`
- [x] Weapon `minElevation`
- [x] Weapon `maxElevation`
- [x] Weapon `recoilValue`
- [x] Weapon `penetrate`