### PR TITLE
Fix the Gamma introduction sequences.

### DIFF
--- a/data/base/script/campaign/cam3-a.js
+++ b/data/base/script/campaign/cam3-a.js
@@ -325,7 +325,7 @@ function eventStartLevel()
 	});
 
 	camManageTrucks(NEXUS);
-	camPlayVideos(["MB3A_MSG", "MB3A_MSG2"]);
+	camPlayVideos(["CAM3_INT", "MB3A_MSG2"]);
 	startedFromMenu = false;
 
 	//Only if starting Gamma directly rather than going through Beta

--- a/data/base/wrf/cam3/cam3a.wrf
+++ b/data/base/wrf/cam3/cam3a.wrf
@@ -6,6 +6,7 @@
 /* Directory for Proximity messages and mission briefs */
 directory	"messages"
 file		SMSG		"brief3-a.txt"
+file		SMSG		"brief3intro.txt"
 file		SMSG		"prox3a.txt"
 
 directory "script"


### PR DESCRIPTION
Was missing the video showing a Nexus base missile launch in the intro.

NOTE: "CAM3_INT2" is the same as "MB3A_MSG2" except with an extra "briefing commences" sequence. I have opted to use the latter since that was how it used to be in an old video walk-through I am using as a reference.