### PR TITLE
Non-default gameport support for lobby

### DIFF
--- a/lib/netplay/netplay.h
+++ b/lib/netplay/netplay.h
@@ -127,7 +127,6 @@ enum MESSAGE_TYPES
 #define WZ_SERVER_DISCONNECT 0
 #define WZ_SERVER_CONNECT    1
 #define WZ_SERVER_UPDATE     3
-#define WZ_SERVER_KEEPALIVE  4
 
 // Constants
 // @NOTE / FIXME: We need a way to detect what should happen if the msg buffer exceeds this.
@@ -299,7 +298,7 @@ struct NETPLAY
 	bool ShowedMOTD;					// only want to show this once
 	bool HaveUpgrade;					// game updates available
 	char MOTDbuffer[255];				// buffer for MOTD
-	char *MOTD;
+	char *MOTD = nullptr;
 
 	std::vector<std::shared_ptr<PlayerReference>> playerReferences;
 

--- a/lib/netplay/netplay.h
+++ b/lib/netplay/netplay.h
@@ -134,7 +134,7 @@ enum MESSAGE_TYPES
 #define MaxMsgSize		16384		// max size of a message in bytes.
 #define	StringSize		64			// size of strings used.
 #define MaxGames		11			// max number of concurrently playable games to allow.
-#define extra_string_size	159		// extra 199 char for future use
+#define extra_string_size	157		// extra 199 char for future use
 #define map_string_size		40
 #define	hostname_string_size	40
 #define modlist_string_size	255		// For a concatenated list of mods
@@ -172,6 +172,7 @@ struct GAMESTRUCT
 	// NOTE: do NOT save the following items in game.c--it will break savegames.
 	char		secondaryHosts[2][40];
 	char		extra[extra_string_size];		// extra string (future use)
+	uint16_t	hostPort;						// server port
 	char		mapname[map_string_size];		// map server is hosting
 	char		hostname[hostname_string_size];	// ...
 	char		versionstring[StringSize];		//

--- a/src/multiint.cpp
+++ b/src/multiint.cpp
@@ -950,7 +950,7 @@ std::vector<JoinConnectionDescription> findLobbyGame(const std::string& lobbyAdd
 		return {};
 	}
 	std::string host = game.desc.host;
-	return {JoinConnectionDescription(host, 0)};
+	return {JoinConnectionDescription(host, game.hostPort)};
 }
 
 static JoinGameResult joinGameInternal(std::vector<JoinConnectionDescription> connection_list, std::shared_ptr<WzTitleUI> oldUI);

--- a/src/titleui/gamefind.cpp
+++ b/src/titleui/gamefind.cpp
@@ -178,7 +178,7 @@ TITLECODE WzGameFindTitleUI::run()
 	{
 		UDWORD gameNumber = id - GAMES_GAMESTART;
 
-		std::vector<JoinConnectionDescription> connectionDesc = {JoinConnectionDescription(gamesList[gameNumber].desc.host, 0)};
+		std::vector<JoinConnectionDescription> connectionDesc = {JoinConnectionDescription(gamesList[gameNumber].desc.host, gamesList[gameNumber].hostPort)};
 		ActivityManager::instance().willAttemptToJoinLobbyGame(NETgetMasterserverName(), NETgetMasterserverPort(), gamesList[gameNumber].gameId, connectionDesc);
 
 		clearActiveConsole();

--- a/src/titleui/gamefind.cpp
+++ b/src/titleui/gamefind.cpp
@@ -437,7 +437,7 @@ void WzGameFindTitleUI::addGames()
 
 		widgAddButton(psWScreen, &sButInit);
 	}
-	if (strlen(NetPlay.MOTD))
+	if (NetPlay.MOTD && strlen(NetPlay.MOTD))
 	{
 		permitNewConsoleMessages(true);
 		addConsoleMessage(NetPlay.MOTD, DEFAULT_JUSTIFY, SYSTEM_MESSAGE, false, MAX_CONSOLE_MESSAGE_DURATION);


### PR DESCRIPTION
This adds the necessary support for hosting from non-default (non-`2100`) ports (and advertising such on the lobby server).

- Add `hostPort` to `GAMESTRUCT`
  - Use 2 bytes from the end of `extra` for it, to maintain the current struct size
  - Bump `GAMESTRUCT_VERSION` (4+ signifies that `hostPort` is available)
- NETallowJoining: Better lobby connection check support
- Refactor lobby connection handling
   - This is needed to support processing the expanded lobby connection check (i.e. running the normal runloop) while also waiting for the lobby response.