### PR TITLE
macOS Vulkan / library loading improvements

### DIFF
--- a/cmake/AddTargetLinkFlagsIfSupported.cmake
+++ b/cmake/AddTargetLinkFlagsIfSupported.cmake
@@ -2,12 +2,13 @@
 # Copyright © 2018 pastdue ( https://github.com/past-due/ ) and contributors
 # License: MIT License ( https://opensource.org/licenses/MIT )
 #
-# Script Version: 2018-02-19a
+# Script Version: 2021-02-04a
 #
 
 # ADD_TARGET_LINK_FLAGS_IF_SUPPORTED( TARGET <target>
 #									  [COMPILER_TYPE <C | CXX> = CXX]
 #									  LINK_FLAGS <link_flags>
+#									  [CONFIG <DEBUG | RELEASE | ...>]
 #									  [CACHED_RESULT_NAME <cached_result_name>]
 #									  [QUIET <ALL | FAILURES | OFF> = FAILURES] )
 #
@@ -33,7 +34,7 @@
 #
 function(ADD_TARGET_LINK_FLAGS_IF_SUPPORTED)
 	set(_options)
-	set(_oneValueArgs TARGET COMPILER_TYPE LINK_FLAGS CACHED_RESULT_NAME QUIET)
+	set(_oneValueArgs TARGET COMPILER_TYPE LINK_FLAGS CONFIG CACHED_RESULT_NAME QUIET)
 	set(_multiValueArgs)
 
 	CMAKE_PARSE_ARGUMENTS(_parsedArguments "${_options}" "${_oneValueArgs}" "${_multiValueArgs}" ${ARGN})
@@ -56,6 +57,11 @@ function(ADD_TARGET_LINK_FLAGS_IF_SUPPORTED)
 
 	if(NOT DEFINED _parsedArguments_COMPILER_TYPE)
 		set(_parsedArguments_COMPILER_TYPE "CXX")
+	endif()
+
+	set(_link_flags_config_suffix)
+	if(DEFINED _parsedArguments_CONFIG)
+		set(_link_flags_config_suffix "_${_parsedArguments_CONFIG}")
 	endif()
 
 	set(_check_cached_status)
@@ -85,12 +91,12 @@ function(ADD_TARGET_LINK_FLAGS_IF_SUPPORTED)
 
 	if(${_cached_result_variable_name})
 		if(NOT _parsedArguments_QUIET OR _parsedArguments_QUIET MATCHES "FAILURES")
-			message( STATUS "Set TARGET ${_parsedArguments_TARGET} LINK_FLAG: ${_parsedArguments_LINK_FLAGS} ... YES${_check_cached_status}" )
+			message( STATUS "Set TARGET ${_parsedArguments_TARGET} LINK_FLAG${_link_flags_config_suffix}: ${_parsedArguments_LINK_FLAGS} ... YES${_check_cached_status}" )
 		endif()
-		set_property(TARGET ${_parsedArguments_TARGET} APPEND_STRING PROPERTY LINK_FLAGS " ${_parsedArguments_LINK_FLAGS}")
+		set_property(TARGET ${_parsedArguments_TARGET} APPEND_STRING PROPERTY "LINK_FLAGS${_link_flags_config_suffix}" " ${_parsedArguments_LINK_FLAGS}")
 	else()
 		if(NOT _parsedArguments_QUIET)
-			message( STATUS "Set TARGET ${_parsedArguments_TARGET} LINK_FLAG: ${_parsedArguments_LINK_FLAGS} ... no${_check_cached_status}" )
+			message( STATUS "Set TARGET ${_parsedArguments_TARGET} LINK_FLAG${_link_flags_config_suffix}: ${_parsedArguments_LINK_FLAGS} ... no${_check_cached_status}" )
 		endif()
 	endif()
 

--- a/lib/sdl/cocoa_sdl_helpers.h
+++ b/lib/sdl/cocoa_sdl_helpers.h
@@ -27,7 +27,10 @@
 #define cocoa_sdl_helpers_h
 
 #include <SDL.h>
+#include <string>
 
 bool cocoaIsSDLWindowFullscreened(SDL_Window *window);
+std::string cocoaGetCurrentExecutablePath();
+std::string cocoaGetFrameworksPath(const char* resourceName);
 
 #endif /* cocoa_sdl_helpers_h */

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -483,8 +483,10 @@ if(CMAKE_SYSTEM_NAME MATCHES "Darwin")
 		endif(Vulkan_FOUND)
 	endif(WZ_ENABLE_BACKEND_VULKAN)
 
-	# Set install RPATH for WZ app bundle
-	set_target_properties(warzone2100 PROPERTIES INSTALL_RPATH "@executable_path/../Frameworks")
+	if (BUILD_SHARED_LIBS)
+		# Set install RPATH for WZ app bundle
+		set_target_properties(warzone2100 PROPERTIES INSTALL_RPATH "@executable_path/../Frameworks")
+	endif()
 
 	# Since the dependencies are bundled as part of the build stages (and not at install-time), build with the install rpath
 	set_target_properties(warzone2100 PROPERTIES BUILD_WITH_INSTALL_RPATH True)
@@ -532,6 +534,12 @@ if(NOT CMAKE_SYSTEM_NAME MATCHES "Darwin")
 	# Enable RELRO (if supported)
 	ADD_TARGET_LINK_FLAGS_IF_SUPPORTED(TARGET warzone2100 LINK_FLAGS "-Wl,-z,relro" CACHED_RESULT_NAME LINK_FLAG_WL_Z_RELRO_SUPPORTED)
 	ADD_TARGET_LINK_FLAGS_IF_SUPPORTED(TARGET warzone2100 LINK_FLAGS "-Wl,-z,now" CACHED_RESULT_NAME LINK_FLAG_WL_Z_NOW_SUPPORTED)
+endif()
+
+if(CMAKE_SYSTEM_NAME MATCHES "Darwin")
+	if (NOT BUILD_SHARED_LIBS)
+		ADD_TARGET_LINK_FLAGS_IF_SUPPORTED(TARGET warzone2100 LINK_FLAGS "-Wl,-sectcreate,__RESTRICT,__restrict,/dev/null" CONFIG RELEASE CACHED_RESULT_NAME LINK_FLAG_WL_SECTCREATE_RESTRICT_SUPPORTED)
+	endif()
 endif()
 
 #######################


### PR DESCRIPTION
- [SDL backend] macOS: Explicitly load `libvulkan.dylib`
   - To support situations where run-time search paths using `@executable_path` are prohibited.
- [CMake] macOS: Set `__RESTRICT` segment
   - To help prevent other processes from interfering (purposefully or accidentally) with WZ by injecting libraries.