### PR TITLE
fix #1512 incorrect ru translation for Switch Mouse Buttons

### DIFF
--- a/po/ru.po
+++ b/po/ru.po
@@ -15524,7 +15524,7 @@ msgstr "Захват курсора"
 #: src/frontend.cpp:1615
 #: src/ingameop.cpp:711
 msgid "Switch Mouse Buttons"
-msgstr "Настройки Мыши"
+msgstr "Поменять кнопки мыши"
 
 #: src/frontend.cpp:1620
 #: src/ingameop.cpp:716


### PR DESCRIPTION
Current Russian translation for "Switch Mouse Buttons" just reads "Mouse configuration", which is misleading and obviously copypasted from somewhere and forgot. This commit fixes it.

fix issue #1512

I'm not sure if I should modify POT-Creation-Date, PO-Revision-Date. Please, do so if needed.