### PR TITLE
Enable and fix more compiler warnings

### DIFF
--- a/3rdparty/CMakeLists.txt
+++ b/3rdparty/CMakeLists.txt
@@ -143,6 +143,9 @@ else()
 	# -Wcast-align				(GCC 3.4+, Clang 3.2+)
 	check_compiler_flags_output("-Werror -Wno-cast-align -Wno-error=cpp" COMPILER_TYPE C   OUTPUT_FLAGS "-Wno-cast-align" OUTPUT_VARIABLE _supported_quickjs_c_compiler_flags APPEND)
 
+	# -Wshadow					(GCC 3.4+, Clang 3.2+)
+	check_compiler_flags_output("-Werror -Wno-shadow -Wno-error=cpp" COMPILER_TYPE C   OUTPUT_FLAGS "-Wno-shadow" OUTPUT_VARIABLE _supported_quickjs_c_compiler_flags APPEND)
+
 	if (NOT _supported_quickjs_c_compiler_flags STREQUAL "")
 		string(REPLACE " " ";" _supported_quickjs_c_compiler_flags "${_supported_quickjs_c_compiler_flags}")
 		target_compile_options(quickjs PRIVATE ${_supported_quickjs_c_compiler_flags})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -277,8 +277,6 @@ macro(CONFIGURE_WZ_COMPILER_WARNINGS)
 		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4100")
 		# C4244: 'conversion' conversion from 'type1' to 'type2', possible loss of data // FIXME!!
 		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4244")
-		# C4456: declaration of 'identifier' hides previous local declaration
-		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4456")
 		# C4459: declaration of 'identifier' hides global declaration
 		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4459")
 		# C4702: unreachable code

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -285,8 +285,6 @@ macro(CONFIGURE_WZ_COMPILER_WARNINGS)
 		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4702")
 		# C4245: 'conversion' : conversion from 'type1' to 'type2', signed/unsigned mismatch
 		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4245")
-		# C4701: Potentially uninitialized local variable 'name' used
-		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4701")
 		# C4706: assignment within conditional expression
 		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4706")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -342,6 +342,14 @@ macro(CONFIGURE_WZ_COMPILER_WARNINGS)
 		# Custom Warning Flags - No Error Tweaks
 		set(CMAKE_XCODE_ATTRIBUTE_WARNING_CFLAGS "${CMAKE_XCODE_ATTRIBUTE_WARNING_CFLAGS} -Wno-error=deprecated-declarations")
 
+		set(_supported_cxx_compiler_flags "")
+
+		# -Wno-shadow-field-in-constructor (Clang 3.9+)
+		check_compiler_flags_output("-Werror -Wno-shadow-field-in-constructor -Wno-error=cpp" COMPILER_TYPE CXX OUTPUT_FLAGS "-Wno-shadow-field-in-constructor" OUTPUT_VARIABLE _supported_cxx_compiler_flags APPEND)
+
+		message( STATUS "Supported additional CXX compiler_flags=${_supported_cxx_compiler_flags}" )
+		set(CMAKE_XCODE_ATTRIBUTE_WARNING_CFLAGS "${CMAKE_XCODE_ATTRIBUTE_WARNING_CFLAGS} ${_supported_cxx_compiler_flags}")
+
 		# Apple Clang - Preprocessing
 		set(CMAKE_XCODE_ATTRIBUTE_ENABLE_STRICT_OBJC_MSGSEND YES)
 
@@ -361,7 +369,7 @@ macro(CONFIGURE_WZ_COMPILER_WARNINGS)
 		set(CMAKE_XCODE_ATTRIBUTE_CLANG_WARN_DOCUMENTATION_COMMENTS NO)				# -Wdocumentation		[DISABLED]
 		set(CMAKE_XCODE_ATTRIBUTE_CLANG_WARN_EMPTY_BODY YES)						# -Wempty-body
 		set(CMAKE_XCODE_ATTRIBUTE_GCC_WARN_FOUR_CHARACTER_CONSTANTS YES)			# -Wfour-char-constants
-		set(CMAKE_XCODE_ATTRIBUTE_GCC_WARN_SHADOW NO)								# -Wshadow				[DISABLED] - FIXME
+		set(CMAKE_XCODE_ATTRIBUTE_GCC_WARN_SHADOW YES)								# -Wshadow
 		set(CMAKE_XCODE_ATTRIBUTE_CLANG_WARN_BOOL_CONVERSION YES)					# -Wbool-conversion
 		set(CMAKE_XCODE_ATTRIBUTE_CLANG_WARN_CONSTANT_CONVERSION YES)				# -Wconstant-conversion
 		set(CMAKE_XCODE_ATTRIBUTE_GCC_WARN_64_TO_32_BIT_CONVERSION NO)				# -Wshorten-64-to-32	[DISABLED] - FIXME
@@ -513,10 +521,20 @@ macro(CONFIGURE_WZ_COMPILER_WARNINGS)
 		# -Wnon-virtual-dtor		(GCC 3.4+, Clang 3.2+) [C++ only]
 		check_compiler_flags_output("-Werror -Wnon-virtual-dtor -Wno-error=cpp" COMPILER_TYPE CXX OUTPUT_FLAGS "-Wnon-virtual-dtor" OUTPUT_VARIABLE _supported_cxx_compiler_flags APPEND)
 
-#		# FUTURE-TODO: Enable -Wshadow (lots of warnings to fix, some due to 3rdparty dependencies?)
-#		# -Wshadow					(GCC 3.4+, Clang 3.2+)
-#		check_compiler_flags_output("-Werror -Wshadow -Wno-error=cpp" COMPILER_TYPE C   OUTPUT_FLAGS "-Wshadow" OUTPUT_VARIABLE _supported_c_compiler_flags APPEND)
-#		check_compiler_flags_output("-Werror -Wshadow -Wno-error=cpp" COMPILER_TYPE CXX OUTPUT_FLAGS "-Wshadow" OUTPUT_VARIABLE _supported_cxx_compiler_flags APPEND)
+		# -Wshadow					(GCC 3.4+, Clang 3.2+)
+		# NOTE: -Wshadow on GCC is currently too noisy, but Clang 3.9+ is much more selective
+		if (CMAKE_C_COMPILER_ID MATCHES "Clang" AND (NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 3.9))
+			check_compiler_flags_output("-Werror -Wshadow -Wno-error=cpp" COMPILER_TYPE C   OUTPUT_FLAGS "-Wshadow" OUTPUT_VARIABLE _supported_c_compiler_flags APPEND)
+
+			# -Wno-shadow-field-in-constructor (Clang 3.9+)
+			check_compiler_flags_output("-Werror -Wno-shadow-field-in-constructor -Wno-error=cpp" COMPILER_TYPE C   OUTPUT_FLAGS "-Wno-shadow-field-in-constructor" OUTPUT_VARIABLE _supported_c_compiler_flags APPEND)
+		endif()
+		if (CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND (NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 3.9))
+			check_compiler_flags_output("-Werror -Wshadow -Wno-error=cpp" COMPILER_TYPE CXX OUTPUT_FLAGS "-Wshadow" OUTPUT_VARIABLE _supported_cxx_compiler_flags APPEND)
+
+			# -Wno-shadow-field-in-constructor (Clang 3.9+)
+			check_compiler_flags_output("-Werror -Wno-shadow-field-in-constructor -Wno-error=cpp" COMPILER_TYPE CXX OUTPUT_FLAGS "-Wno-shadow-field-in-constructor" OUTPUT_VARIABLE _supported_cxx_compiler_flags APPEND)
+		endif()
 
 #		# FUTURE-TODO: Enable -Wuseless-cast (large number of warnings to fix)
 #		# -Wuseless-cast			(GCC 4.8+)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -277,8 +277,6 @@ macro(CONFIGURE_WZ_COMPILER_WARNINGS)
 		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4100")
 		# C4244: 'conversion' conversion from 'type1' to 'type2', possible loss of data // FIXME!!
 		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4244")
-		# C4459: declaration of 'identifier' hides global declaration
-		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4459")
 		# C4702: unreachable code
 		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4702")
 		# C4245: 'conversion' : conversion from 'type1' to 'type2', signed/unsigned mismatch

--- a/lib/exceptionhandler/exceptionhandler.cpp
+++ b/lib/exceptionhandler/exceptionhandler.cpp
@@ -712,7 +712,7 @@ static void posixExceptionHandler(int signum)
 #endif // WZ_OS_*
 
 #if defined(WZ_OS_UNIX) && !defined(WZ_OS_MAC)
-static bool fetchProgramPath(char *const programPath, size_t const bufSize, const char *const programCommand)
+static bool fetchProgramPath(char *const output_programPath, size_t const bufSize, const char *const programCommand)
 {
 	FILE *whichProgramStream;
 	size_t bytesRead;
@@ -724,13 +724,13 @@ static bool fetchProgramPath(char *const programPath, size_t const bufSize, cons
 	/* Fill the output buffer with zeroes so that we can rely on the output
 	 * string being NUL-terminated.
 	 */
-	memset(programPath, 0, bufSize);
+	memset(output_programPath, 0, bufSize);
 
 	/* Execute the "which" command (constructed above) and collect its
-	 * output in programPath.
+	 * output in output_programPath.
 	 */
 	whichProgramStream = popen(whichProgramCommand, "r");
-	bytesRead = fread(programPath, 1, bufSize, whichProgramStream);
+	bytesRead = fread(output_programPath, 1, bufSize, whichProgramStream);
 	pclose(whichProgramStream);
 
 	// Check whether our buffer is too small, indicate failure if it is
@@ -740,22 +740,22 @@ static bool fetchProgramPath(char *const programPath, size_t const bufSize, cons
 		return false;
 	}
 
-	programPath[bytesRead] = 0;
+	output_programPath[bytesRead] = 0;
 	// Cut of the linefeed (and everything following it) if it's present.
-	linefeed = strchr(programPath, '\n');
+	linefeed = strchr(output_programPath, '\n');
 	if (linefeed)
 	{
 		*linefeed = '\0';
 	}
 
 	// Check to see whether we retrieved any meaning ful result
-	if (strlen(programPath) == 0)
+	if (strlen(output_programPath) == 0)
 	{
 		debug(LOG_WARNING, "Could not retrieve full path to \"%s\". This may prevent creation of an extended backtrace.", programCommand);
 		return false;
 	}
 
-	debug(LOG_WZ, "Found program \"%s\" at path \"%s\"", programCommand, programPath);
+	debug(LOG_WZ, "Found program \"%s\" at path \"%s\"", programCommand, output_programPath);
 	return true;
 }
 #endif

--- a/lib/exceptionhandler/exchndl_win.cpp
+++ b/lib/exceptionhandler/exchndl_win.cpp
@@ -574,7 +574,7 @@ LONG WINAPI TopLevelExceptionFilter(PEXCEPTION_POINTERS pExceptionInfo)
 			{
 				LPVOID lpMsgBuf;
 				DWORD dw = GetLastError();
-				wchar_t szBuffer[4196];
+				wchar_t szFailureBuffer[4196];
 
 				FormatMessageW(
 				    FORMAT_MESSAGE_ALLOCATE_BUFFER |
@@ -586,8 +586,8 @@ LONG WINAPI TopLevelExceptionFilter(PEXCEPTION_POINTERS pExceptionInfo)
 				    (LPWSTR) &lpMsgBuf,
 				    0, NULL);
 
-				wsprintfW(szBuffer, L"Exception handler failed with error %d: %s\n", dw, lpMsgBuf);
-				MessageBoxW((HWND)MB_ICONEXCLAMATION, szBuffer, L"Error", MB_OK);
+				wsprintfW(szFailureBuffer, L"Exception handler failed with error %d: %s\n", dw, lpMsgBuf);
+				MessageBoxW((HWND)MB_ICONEXCLAMATION, szFailureBuffer, L"Error", MB_OK);
 
 				LocalFree(lpMsgBuf);
 				debug(LOG_ERROR, "Exception handler failed to create file!");

--- a/lib/ivis_opengl/3rdparty/vkh_info.cpp
+++ b/lib/ivis_opengl/3rdparty/vkh_info.cpp
@@ -555,10 +555,10 @@ void VkhInfo::Output_PhysicalDevices(const vk::Instance& inst, const vk::Applica
 		const auto queueFamilies = physicalDevice.getQueueFamilyProperties(vkDynLoader);
 		buf << "VkQueueFamilyProperties:\n";
 		buf << "------------------------\n";
-		for (size_t idx = 0; idx < queueFamilies.size(); ++idx)
+		for (size_t queueIdx = 0; queueIdx < queueFamilies.size(); ++queueIdx)
 		{
-			const auto & queueFamily = queueFamilies[idx];
-			buf << "[Queue Family " << idx << "]\n";
+			const auto & queueFamily = queueFamilies[queueIdx];
+			buf << "[Queue Family " << queueIdx << "]\n";
 			buf << "- queueFlags = " << to_string(queueFamily.queueFlags) << "\n";
 			buf << "- queueCount = " << queueFamily.queueCount << "\n";
 			buf << "- timestampValidBits = " << queueFamily.timestampValidBits << "\n";

--- a/lib/ivis_opengl/3rdparty/vkh_info.hpp
+++ b/lib/ivis_opengl/3rdparty/vkh_info.hpp
@@ -20,9 +20,14 @@
 #ifndef NOMINMAX
     #define NOMINMAX // For windows.h
 #endif
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wshadow"
+#endif
 #if !defined(__clang__) && defined(__GNUC__) && __GNUC__ >= 9
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-copy" // Ignore warnings caused by vulkan.hpp 148
+#pragma GCC diagnostic ignored "-Wshadow"
 #endif
 #include <vulkan/vulkan.hpp>
 #if !defined(__clang__) && defined(__GNUC__) && __GNUC__ >= 9

--- a/lib/ivis_opengl/3rdparty/vkh_renderpasscompat.hpp
+++ b/lib/ivis_opengl/3rdparty/vkh_renderpasscompat.hpp
@@ -19,9 +19,14 @@
 #ifndef NOMINMAX
     #define NOMINMAX // For windows.h
 #endif
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wshadow"
+#endif
 #if !defined(__clang__) && defined(__GNUC__) && __GNUC__ >= 9
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-copy" // Ignore warnings caused by vulkan.hpp 148
+#pragma GCC diagnostic ignored "-Wshadow"
 #endif
 #include <vulkan/vulkan.hpp>
 #if !defined(__clang__) && defined(__GNUC__) && __GNUC__ >= 9

--- a/lib/ivis_opengl/gfx_api_vk.cpp
+++ b/lib/ivis_opengl/gfx_api_vk.cpp
@@ -3441,7 +3441,8 @@ void VkRoot::flip(int clearMode)
 	}
 	catch (vk::SystemError& e)
 	{
-		debug(LOG_ERROR, "vk::Queue::presentKHR: unhandled error: %s", e.what());
+		debug(LOG_FATAL, "vk::Queue::presentKHR: unhandled error: %s", e.what());
+		presentResult = vk::Result::eErrorUnknown;
 	}
 	if(presentResult == vk::Result::eSuboptimalKHR)
 	{

--- a/lib/ivis_opengl/gfx_api_vk.h
+++ b/lib/ivis_opengl/gfx_api_vk.h
@@ -25,9 +25,14 @@
 #pragma warning( push )
 #pragma warning( disable : 4191 ) // warning C4191: '<function-style-cast>': unsafe conversion from 'PFN_vkVoidFunction' to 'PFN_vk<...>'
 #endif
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wshadow"
+#endif
 #if !defined(__clang__) && defined(__GNUC__) && __GNUC__ >= 9
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-copy" // Ignore warnings caused by vulkan.hpp 148
+#pragma GCC diagnostic ignored "-Wshadow"
 #endif
 #define VULKAN_HPP_TYPESAFE_CONVERSION 1
 #include <vulkan/vulkan.hpp>

--- a/lib/ivis_opengl/imdload.cpp
+++ b/lib/ivis_opengl/imdload.cpp
@@ -727,7 +727,7 @@ static iIMDShape *_imd_load_level(const WzString &filename, const char **ppFileD
 {
 	const char *pFileData = *ppFileData;
 	char buffer[PATH_MAX] = {'\0'};
-	int cnt = 0, n = 0, i;
+	int cnt = 0, n = 0, scanResult = 0;
 	float dummy;
 
 	if (nlevels == 0)
@@ -744,15 +744,15 @@ static iIMDShape *_imd_load_level(const WzString &filename, const char **ppFileD
 	ASSERT(models.count(key) == 0, "Duplicate model load for %s!", key.c_str());
 	iIMDShape &s = models[key]; // create entry and return reference
 
-	i = sscanf(pFileData, "%255s %n", buffer, &cnt);
-	ASSERT_OR_RETURN(nullptr, i == 1, "Bad directive following LEVEL");
+	scanResult = sscanf(pFileData, "%255s %n", buffer, &cnt);
+	ASSERT_OR_RETURN(nullptr, scanResult == 1, "Bad directive following LEVEL");
 
 	// Optionally load and ignore deprecated MATERIALS directive
 	if (strcmp(buffer, "MATERIALS") == 0)
 	{
-		i = sscanf(pFileData, "%255s %f %f %f %f %f %f %f %f %f %f%n", buffer, &dummy, &dummy, &dummy, &dummy,
+		scanResult = sscanf(pFileData, "%255s %f %f %f %f %f %f %f %f %f %f%n", buffer, &dummy, &dummy, &dummy, &dummy,
 		           &dummy, &dummy, &dummy, &dummy, &dummy, &dummy, &cnt);
-		ASSERT_OR_RETURN(nullptr, i == 11, "Bad MATERIALS directive");
+		ASSERT_OR_RETURN(nullptr, scanResult == 11, "Bad MATERIALS directive");
 		debug(LOG_WARNING, "MATERIALS directive no longer supported!");
 		pFileData += cnt;
 	}

--- a/lib/ivis_opengl/jpeg_encoder.cpp
+++ b/lib/ivis_opengl/jpeg_encoder.cpp
@@ -23,6 +23,15 @@
 
 // Cleaned up and removed the assembly for use in Warzone.
 
+#if defined( _MSC_VER )
+	#pragma warning( disable : 4459 ) // warning C4459: declaration of 'identifier' hides global declaration
+#endif
+#if defined(__clang__)
+	#pragma clang diagnostic ignored "-Wshadow"
+#elif defined(__GNUC__)
+	#pragma GCC diagnostic ignored "-Wshadow"
+#endif
+
 #include "jpeg_encoder.h"
 
 #include <assert.h>

--- a/lib/ivis_opengl/screen.cpp
+++ b/lib/ivis_opengl/screen.cpp
@@ -104,7 +104,7 @@ void wzPerfStart()
 	perfStarted = gfx_api::context::get().debugPerfStart(perfList.size());
 }
 
-void wzPerfWriteOut(const std::vector<PERF_STORE> &perfList, const WzString &outfile)
+void wzPerfWriteOut(const std::vector<PERF_STORE> &list, const WzString &outfile)
 {
 	PHYSFS_file *fileHandle = PHYSFS_openWrite(outfile.toUtf8().c_str());
 	if (fileHandle)
@@ -117,13 +117,13 @@ void wzPerfWriteOut(const std::vector<PERF_STORE> &perfList, const WzString &out
 			PHYSFS_close(fileHandle);
 			return;
 		}
-		for (size_t i = 0; i < perfList.size(); i++)
+		for (size_t i = 0; i < list.size(); i++)
 		{
 			WzString line;
-			line += WzString::number(perfList[i].counters[PERF_START_FRAME]);
+			line += WzString::number(list[i].counters[PERF_START_FRAME]);
 			for (int j = 1; j < PERF_COUNT; j++)
 			{
-				line += ", " + WzString::number(perfList[i].counters[j]);
+				line += ", " + WzString::number(list[i].counters[j]);
 			}
 			line += "\n";
 			ASSERT(line.toUtf8().length() <= static_cast<size_t>(std::numeric_limits<PHYSFS_uint32>::max()), "Line length exceeds PHYSFS_uint32::max");

--- a/lib/netplay/netplay.cpp
+++ b/lib/netplay/netplay.cpp
@@ -3458,8 +3458,8 @@ bool NETenumerateGames(const std::function<bool (const GAMESTRUCT& game)>& handl
 	// Earlier versions (and earlier lobby servers) restricted this to no more than 11
 	std::vector<GAMESTRUCT> initialBatchOfGameStructs;
 
-	if (!readGameStructsList(tcp_socket, NET_TIMEOUT_DELAY, [&initialBatchOfGameStructs](const GAMESTRUCT &game) -> bool {
-		initialBatchOfGameStructs.push_back(game);
+	if (!readGameStructsList(tcp_socket, NET_TIMEOUT_DELAY, [&initialBatchOfGameStructs](const GAMESTRUCT &lobbyGame) -> bool {
+		initialBatchOfGameStructs.push_back(lobbyGame);
 		return true; // continue enumerating
 	}))
 	{
@@ -3560,7 +3560,7 @@ bool NETfindGames(std::vector<GAMESTRUCT>& results, size_t startingIndex, size_t
 {
 	size_t gamecount = 0;
 	results.clear();
-	bool success = NETenumerateGames([&results, &gamecount, startingIndex, resultsLimit, onlyMatchingLocalVersion](const GAMESTRUCT &game) -> bool {
+	bool success = NETenumerateGames([&results, &gamecount, startingIndex, resultsLimit, onlyMatchingLocalVersion](const GAMESTRUCT &lobbyGame) -> bool {
 		if (gamecount++ < startingIndex)
 		{
 			// skip this item, continue
@@ -3571,12 +3571,12 @@ bool NETfindGames(std::vector<GAMESTRUCT>& results, size_t startingIndex, size_t
 			// stop processing games
 			return false;
 		}
-		if ((onlyMatchingLocalVersion) && ((game.game_version_major != (unsigned)NETGetMajorVersion()) || (game.game_version_minor != (unsigned)NETGetMinorVersion())))
+		if ((onlyMatchingLocalVersion) && ((lobbyGame.game_version_major != (unsigned)NETGetMajorVersion()) || (lobbyGame.game_version_minor != (unsigned)NETGetMinorVersion())))
 		{
 			// skip this non-matching version, continue
 			return true;
 		}
-		results.push_back(game);
+		results.push_back(lobbyGame);
 		return true;
 	});
 
@@ -3587,13 +3587,13 @@ bool NETfindGame(uint32_t gameId, GAMESTRUCT& output)
 {
 	bool foundMatch = false;
 	memset(&output, 0x00, sizeof(output));
-	NETenumerateGames([&foundMatch, &output, gameId](const GAMESTRUCT &game) -> bool {
-		if (game.gameId != gameId)
+	NETenumerateGames([&foundMatch, &output, gameId](const GAMESTRUCT &lobbyGame) -> bool {
+		if (lobbyGame.gameId != gameId)
 		{
 			// not a match - continue enumerating
 			return true;
 		}
-		output = game;
+		output = lobbyGame;
 		foundMatch = true;
 		return false; // stop searching
 	});

--- a/lib/netplay/netsocket.cpp
+++ b/lib/netplay/netsocket.cpp
@@ -436,11 +436,11 @@ static int socketThreadFunction(void *)
 
 				// Write data.
 				// FIXME SOMEHOW AAARGH This send() call can't block, but unless the socket is not set to blocking (setting the socket to nonblocking had better work, or else), does anyway (at least sometimes, when someone quits). Not reproducible except in public releases.
-				ssize_t ret = send(sock->fd[SOCK_CONNECTION], reinterpret_cast<char *>(&writeQueue[0]), writeQueue.size(), MSG_NOSIGNAL);
-				if (ret != SOCKET_ERROR)
+				ssize_t retSent = send(sock->fd[SOCK_CONNECTION], reinterpret_cast<char *>(&writeQueue[0]), writeQueue.size(), MSG_NOSIGNAL);
+				if (retSent != SOCKET_ERROR)
 				{
 					// Erase as much data as written.
-					writeQueue.erase(writeQueue.begin(), writeQueue.begin() + ret);
+					writeQueue.erase(writeQueue.begin(), writeQueue.begin() + retSent);
 					if (writeQueue.empty())
 					{
 						socketThreadWrites.erase(w);  // Nothing left to write, delete from pending list.

--- a/lib/netplay/nettypes.cpp
+++ b/lib/netplay/nettypes.cpp
@@ -381,9 +381,9 @@ void NETinsertRawData(NETQUEUE queue, uint8_t *data, size_t dataLen)
 	receiveQueue(queue)->writeRawData(data, dataLen);
 }
 
-void NETinsertMessageFromNet(NETQUEUE queue, NetMessage const *message)
+void NETinsertMessageFromNet(NETQUEUE queue, NetMessage const *newMessage)
 {
-	receiveQueue(queue)->pushMessage(*message);
+	receiveQueue(queue)->pushMessage(*newMessage);
 }
 
 bool NETisMessageReady(NETQUEUE queue)
@@ -778,18 +778,18 @@ void NETVector2i(Vector2i *vp)
 	queueAuto(*vp);
 }
 
-void NETnetMessage(NetMessage const **message)
+void NETnetMessage(NetMessage const **msg)
 {
 	if (NETgetPacketDir() == PACKET_ENCODE)
 	{
-		queueAuto(*const_cast<NetMessage *>(*message));  // Const cast safe when encoding.
+		queueAuto(*const_cast<NetMessage *>(*msg));  // Const cast safe when encoding.
 	}
 
 	if (NETgetPacketDir() == PACKET_DECODE)
 	{
 		NetMessage *m = new NetMessage;
 		queueAuto(*m);
-		*message = m;
+		*msg = m;
 		return;
 	}
 }

--- a/lib/sdl/main_sdl.cpp
+++ b/lib/sdl/main_sdl.cpp
@@ -1496,29 +1496,29 @@ void wzGetMinimumWindowSizeForDisplayScaleFactor(unsigned int *minWindowWidth, u
 	}
 }
 
-void wzGetMaximumDisplayScaleFactorsForWindowSize(unsigned int windowWidth, unsigned int windowHeight, float *horizScaleFactor, float *vertScaleFactor)
+void wzGetMaximumDisplayScaleFactorsForWindowSize(unsigned int width, unsigned int height, float *horizScaleFactor, float *vertScaleFactor)
 {
 	if (horizScaleFactor != nullptr)
 	{
-		*horizScaleFactor = (float)windowWidth / (float)MIN_WZ_GAMESCREEN_WIDTH;
+		*horizScaleFactor = (float)width / (float)MIN_WZ_GAMESCREEN_WIDTH;
 	}
 	if (vertScaleFactor != nullptr)
 	{
-		*vertScaleFactor = (float)windowHeight / (float)MIN_WZ_GAMESCREEN_HEIGHT;
+		*vertScaleFactor = (float)height / (float)MIN_WZ_GAMESCREEN_HEIGHT;
 	}
 }
 
-float wzGetMaximumDisplayScaleFactorForWindowSize(unsigned int windowWidth, unsigned int windowHeight)
+float wzGetMaximumDisplayScaleFactorForWindowSize(unsigned int width, unsigned int height)
 {
 	float maxHorizScaleFactor = 0.f, maxVertScaleFactor = 0.f;
-	wzGetMaximumDisplayScaleFactorsForWindowSize(windowWidth, windowHeight, &maxHorizScaleFactor, &maxVertScaleFactor);
+	wzGetMaximumDisplayScaleFactorsForWindowSize(width, height, &maxHorizScaleFactor, &maxVertScaleFactor);
 	return std::min(maxHorizScaleFactor, maxVertScaleFactor);
 }
 
 // returns: the maximum display scale percentage (sourced from wzAvailableDisplayScales), or 0 if window is below the minimum required size for the minimum supported display scale
-unsigned int wzGetMaximumDisplayScaleForWindowSize(unsigned int windowWidth, unsigned int windowHeight)
+unsigned int wzGetMaximumDisplayScaleForWindowSize(unsigned int width, unsigned int height)
 {
-	float maxDisplayScaleFactor = wzGetMaximumDisplayScaleFactorForWindowSize(windowWidth, windowHeight);
+	float maxDisplayScaleFactor = wzGetMaximumDisplayScaleFactorForWindowSize(width, height);
 	unsigned int maxDisplayScalePercentage = floor(maxDisplayScaleFactor * 100.f);
 
 	auto availableDisplayScales = wzAvailableDisplayScales();
@@ -1567,11 +1567,11 @@ unsigned int wzGetSuggestedDisplayScaleForCurrentWindowSize(unsigned int desired
 	return maxDisplayScale;
 }
 
-bool wzWindowSizeIsSmallerThanMinimumRequired(unsigned int windowWidth, unsigned int windowHeight, float displayScaleFactor = current_displayScaleFactor)
+bool wzWindowSizeIsSmallerThanMinimumRequired(unsigned int width, unsigned int height, float displayScaleFactor = current_displayScaleFactor)
 {
 	unsigned int minWindowWidth = 0, minWindowHeight = 0;
 	wzGetMinimumWindowSizeForDisplayScaleFactor(&minWindowWidth, &minWindowHeight, displayScaleFactor);
-	return ((windowWidth < minWindowWidth) || (windowHeight < minWindowHeight));
+	return ((width < minWindowWidth) || (height < minWindowHeight));
 }
 
 void processScreenSizeChangeNotificationIfNeeded()
@@ -2560,18 +2560,18 @@ void wzGetWindowToRendererScaleFactor(float *horizScaleFactor, float *vertScaleF
 	SDL_WZBackend_GetDrawableSize(WZwindow, &drawableWidth, &drawableHeight);
 
 	// Obtain the logical window size (in points)
-	int windowWidth, windowHeight = 0;
-	SDL_GetWindowSize(WZwindow, &windowWidth, &windowHeight);
+	int logicalWindowWidth, logicalWindowHeight = 0;
+	SDL_GetWindowSize(WZwindow, &logicalWindowWidth, &logicalWindowHeight);
 
-	debug(LOG_WZ, "Window Logical Size (%d, %d) vs Drawable Size in Pixels (%d, %d)", windowWidth, windowHeight, drawableWidth, drawableHeight);
+	debug(LOG_WZ, "Window Logical Size (%d, %d) vs Drawable Size in Pixels (%d, %d)", logicalWindowWidth, logicalWindowHeight, drawableWidth, drawableHeight);
 
 	if (horizScaleFactor != nullptr)
 	{
-		*horizScaleFactor = ((float)drawableWidth / (float)windowWidth) * current_displayScaleFactor;
+		*horizScaleFactor = ((float)drawableWidth / (float)logicalWindowWidth) * current_displayScaleFactor;
 	}
 	if (vertScaleFactor != nullptr)
 	{
-		*vertScaleFactor = ((float)drawableHeight / (float)windowHeight) * current_displayScaleFactor;
+		*vertScaleFactor = ((float)drawableHeight / (float)logicalWindowHeight) * current_displayScaleFactor;
 	}
 
 	int displayIndex = SDL_GetWindowDisplayIndex(WZwindow);

--- a/lib/sequence/sequence.cpp
+++ b/lib/sequence/sequence.cpp
@@ -620,7 +620,7 @@ bool seq_Play(const char *filename)
 		}
 		else
 		{
-			int ret = buffer_data(fpInfile, &videodata.oy);   /* someone needs more data */
+			ret = buffer_data(fpInfile, &videodata.oy);   /* someone needs more data */
 
 			if (ret == 0)
 			{

--- a/lib/sound/openal_track.cpp
+++ b/lib/sound/openal_track.cpp
@@ -455,7 +455,6 @@ void sound_Update()
 {
 	SAMPLE_LIST *node = active_samples;
 	SAMPLE_LIST *previous = nullptr;
-	ALCenum err;
 	ALfloat gain;
 
 	if (!openal_initialized)
@@ -526,7 +525,7 @@ void sound_Update()
 
 	alcProcessContext(context);
 
-	err = sound_GetContextError(device);
+	ALCenum err = sound_GetContextError(device);
 	if (err != ALC_NO_ERROR)
 	{
 		debug(LOG_ERROR, "Error while processing audio context: %s", alGetString(err));

--- a/lib/widget/jsontable.cpp
+++ b/lib/widget/jsontable.cpp
@@ -788,11 +788,11 @@ std::shared_ptr<JSONTableWidget> JSONTableWidget::make(const std::string& title)
 	result->pathBar = PathBarWidget::make(".");
 	result->pathBar->setGeometry(0, 0, 0, iV_GetTextLineSize(font_regular));
 	result->pathBar->pushPathComponent(" $ ");
-	result->pathBar->setOnClickPath([](PathBarWidget& pathBar, size_t componentIndex) {
-		auto psParent = std::dynamic_pointer_cast<JSONTableWidget>(pathBar.parent());
+	result->pathBar->setOnClickPath([](PathBarWidget& pathBarWidget, size_t componentIndex) {
+		auto psParent = std::dynamic_pointer_cast<JSONTableWidget>(pathBarWidget.parent());
 		ASSERT_OR_RETURN(, psParent != nullptr, "No parent");
 		std::weak_ptr<JSONTableWidget> psWeakJsonTable = psParent;
-		size_t numComponentsToPop = pathBar.numPathComponents() - (componentIndex + 1);
+		size_t numComponentsToPop = pathBarWidget.numPathComponents() - (componentIndex + 1);
 		if (numComponentsToPop == 0) { return; }
 		widgScheduleTask([psWeakJsonTable, numComponentsToPop]{
 			if (auto jsonTable = psWeakJsonTable.lock())

--- a/lib/widget/label.cpp
+++ b/lib/widget/label.cpp
@@ -143,17 +143,17 @@ void W_LABEL::display(int xOffset, int yOffset)
 		col.byte.r = 128 + iSinSR(realTime, 2000, 127); col.byte.g = 128 + iSinSR(realTime + 667, 2000, 127); col.byte.b = 128 + iSinSR(realTime + 1333, 2000, 127); col.byte.a = 128;
 		iV_Box(textBoundingBoxOffset.x + fx, textBoundingBoxOffset.y + jy + baseLineOffset, textBoundingBoxOffset.x + fx + wzTextLine.width() - 1, textBoundingBoxOffset.y + jy + baseLineOffset + wzTextLine.lineSize() - 1, col);
 #endif
-		int maxWidth = -1;
+		int lineWidthLimit = -1;
 		if (canTruncate && (wzTextLine->width() > width()))
 		{
-			// text would render outside the width of the label, so figure out a maxWidth that can be displayed (leaving room for ellipsis)
-			maxWidth = width() - iV_GetEllipsisWidth(FontID) - 2;
+			// text would render outside the width of the label, so figure out a maxLineWidth that can be displayed (leaving room for ellipsis)
+			lineWidthLimit = width() - iV_GetEllipsisWidth(FontID) - 2;
 		}
-		wzTextLine->render(textBoundingBoxOffset.x + fx, fy, fontColour, 0.0f, maxWidth);
-		if (maxWidth > -1)
+		wzTextLine->render(textBoundingBoxOffset.x + fx, fy, fontColour, 0.0f, lineWidthLimit);
+		if (lineWidthLimit > -1)
 		{
 			// Render ellipsis
-			iV_DrawEllipsis(FontID, Vector2i(textBoundingBoxOffset.x + fx + maxWidth + 2, fy), fontColour);
+			iV_DrawEllipsis(FontID, Vector2i(textBoundingBoxOffset.x + fx + lineWidthLimit + 2, fy), fontColour);
 			isTruncated = true;
 		}
 		jy += wzTextLine->lineSize() + lineSpacing;

--- a/src/action.cpp
+++ b/src/action.cpp
@@ -1201,12 +1201,12 @@ void actionUpdateDroid(DROID *psDroid)
 			else
 			{
 				// if the vtol is close to the target, go around again
-				const Vector2i diff = (psDroid->pos - psDroid->psActionTarget[0]->pos).xy();
+				Vector2i diff = (psDroid->pos - psDroid->psActionTarget[0]->pos).xy();
 				const unsigned rangeSq = dot(diff, diff);
 				if (rangeSq < VTOL_ATTACK_TARDIST * VTOL_ATTACK_TARDIST)
 				{
 					// don't do another attack run if already moving away from the target
-					const Vector2i diff = psDroid->sMove.destination - psDroid->psActionTarget[0]->pos.xy();
+					diff = psDroid->sMove.destination - psDroid->psActionTarget[0]->pos.xy();
 					if (dot(diff, diff) < VTOL_ATTACK_TARDIST * VTOL_ATTACK_TARDIST)
 					{
 						actionAddVtolAttackRun(psDroid);
@@ -1220,7 +1220,7 @@ void actionUpdateDroid(DROID *psDroid)
 					if (rangeSq > maxRange * maxRange)
 					{
 						// don't do another attack run if already heading for the target
-						const Vector2i diff = psDroid->sMove.destination - psDroid->psActionTarget[0]->pos.xy();
+						diff = psDroid->sMove.destination - psDroid->psActionTarget[0]->pos.xy();
 						if (dot(diff, diff) > VTOL_ATTACK_TARDIST * VTOL_ATTACK_TARDIST)
 						{
 							moveDroidToDirect(psDroid, psDroid->psActionTarget[0]->pos.x, psDroid->psActionTarget[0]->pos.y);

--- a/src/activity.cpp
+++ b/src/activity.cpp
@@ -474,14 +474,14 @@ void ActivityManager::joinedLobbyQuit()
 }
 
 // for skirmish / multiplayer, provide additional data / state
-void ActivityManager::updateMultiplayGameData(const MULTIPLAYERGAME& game, const MULTIPLAYERINGAME& ingame, optional<bool> privateGame)
+void ActivityManager::updateMultiplayGameData(const MULTIPLAYERGAME& multiGame, const MULTIPLAYERINGAME& multiInGame, optional<bool> privateGame)
 {
-	uint8_t maxPlayers = game.maxPlayers;
+	uint8_t maxPlayers = multiGame.maxPlayers;
 	uint8_t numAIBotPlayers = 0;
 	uint8_t numHumanPlayers = 0;
 	uint8_t numAvailableSlots = 0;
 
-	for (size_t index = 0; index < std::min<size_t>(MAX_PLAYERS, (size_t)game.maxPlayers); ++index)
+	for (size_t index = 0; index < std::min<size_t>(MAX_PLAYERS, (size_t)multiGame.maxPlayers); ++index)
 	{
 		PLAYER const &p = NetPlay.players[index];
 		if (p.ai == AI_CLOSED)
@@ -512,20 +512,20 @@ void ActivityManager::updateMultiplayGameData(const MULTIPLAYERGAME& game, const
 		}
 	}
 
-	ActivitySink::MultiplayerGameInfo::AllianceOption alliances = ActivitySink::MultiplayerGameInfo::AllianceOption::NO_ALLIANCES;
-	if (game.alliance == ::AllianceType::ALLIANCES)
+	ActivitySink::MultiplayerGameInfo::AllianceOption alliancesOpt = ActivitySink::MultiplayerGameInfo::AllianceOption::NO_ALLIANCES;
+	if (multiGame.alliance == ::AllianceType::ALLIANCES)
 	{
-		alliances = ActivitySink::MultiplayerGameInfo::AllianceOption::ALLIANCES;
+		alliancesOpt = ActivitySink::MultiplayerGameInfo::AllianceOption::ALLIANCES;
 	}
-	else if (game.alliance == ::AllianceType::ALLIANCES_TEAMS)
+	else if (multiGame.alliance == ::AllianceType::ALLIANCES_TEAMS)
 	{
-		alliances = ActivitySink::MultiplayerGameInfo::AllianceOption::ALLIANCES_TEAMS;
+		alliancesOpt = ActivitySink::MultiplayerGameInfo::AllianceOption::ALLIANCES_TEAMS;
 	}
-	else if (game.alliance == ::AllianceType::ALLIANCES_UNSHARED)
+	else if (multiGame.alliance == ::AllianceType::ALLIANCES_UNSHARED)
 	{
-		alliances = ActivitySink::MultiplayerGameInfo::AllianceOption::ALLIANCES_UNSHARED;
+		alliancesOpt = ActivitySink::MultiplayerGameInfo::AllianceOption::ALLIANCES_UNSHARED;
 	}
-	currentMultiplayGameInfo.alliances = alliances;
+	currentMultiplayGameInfo.alliances = alliancesOpt;
 
 	currentMultiplayGameInfo.maxPlayers = maxPlayers; // accounts for closed slots
 	currentMultiplayGameInfo.numHumanPlayers = numHumanPlayers;
@@ -537,20 +537,20 @@ void ActivityManager::updateMultiplayGameData(const MULTIPLAYERGAME& game, const
 		currentMultiplayGameInfo.privateGame = privateGame.value();
 	}
 
-	currentMultiplayGameInfo.game = game;
+	currentMultiplayGameInfo.game = multiGame;
 	currentMultiplayGameInfo.numAIBotPlayers = numAIBotPlayers;
 	currentMultiplayGameInfo.currentPlayerIdx = selectedPlayer;
 	currentMultiplayGameInfo.players = NetPlay.players;
-	currentMultiplayGameInfo.players.resize(game.maxPlayers);
+	currentMultiplayGameInfo.players.resize(multiGame.maxPlayers);
 
-	currentMultiplayGameInfo.limit_no_tanks = (ingame.flags & MPFLAGS_NO_TANKS) != 0;
-	currentMultiplayGameInfo.limit_no_cyborgs = (ingame.flags & MPFLAGS_NO_CYBORGS) != 0;
-	currentMultiplayGameInfo.limit_no_vtols = (ingame.flags & MPFLAGS_NO_VTOLS) != 0;
-	currentMultiplayGameInfo.limit_no_uplink = (ingame.flags & MPFLAGS_NO_UPLINK) != 0;
-	currentMultiplayGameInfo.limit_no_lassat = (ingame.flags & MPFLAGS_NO_LASSAT) != 0;
-	currentMultiplayGameInfo.force_structure_limits = (ingame.flags & MPFLAGS_FORCELIMITS) != 0;
+	currentMultiplayGameInfo.limit_no_tanks = (multiInGame.flags & MPFLAGS_NO_TANKS) != 0;
+	currentMultiplayGameInfo.limit_no_cyborgs = (multiInGame.flags & MPFLAGS_NO_CYBORGS) != 0;
+	currentMultiplayGameInfo.limit_no_vtols = (multiInGame.flags & MPFLAGS_NO_VTOLS) != 0;
+	currentMultiplayGameInfo.limit_no_uplink = (multiInGame.flags & MPFLAGS_NO_UPLINK) != 0;
+	currentMultiplayGameInfo.limit_no_lassat = (multiInGame.flags & MPFLAGS_NO_LASSAT) != 0;
+	currentMultiplayGameInfo.force_structure_limits = (multiInGame.flags & MPFLAGS_FORCELIMITS) != 0;
 
-	currentMultiplayGameInfo.structureLimits = ingame.structureLimits;
+	currentMultiplayGameInfo.structureLimits = multiInGame.structureLimits;
 
 	if (currentMode == ActivitySink::GameMode::JOINING_IN_PROGRESS || currentMode == ActivitySink::GameMode::JOINING_IN_LOBBY)
 	{

--- a/src/astar.cpp
+++ b/src/astar.cpp
@@ -400,18 +400,18 @@ static PathCoord fpathAStarExplore(PathfindContext &context, PathCoord tileF)
 			*/
 			if (dir % 2 != 0 && !context.dstIgnore.isNonblocking(node.p.x, node.p.y) && !context.dstIgnore.isNonblocking(x, y))
 			{
-				int x, y;
+				int x2, y2;
 
 				// We cannot cut corners
-				x = node.p.x + aDirOffset[(dir + 1) % 8].x;
-				y = node.p.y + aDirOffset[(dir + 1) % 8].y;
-				if (context.isBlocked(x, y))
+				x2 = node.p.x + aDirOffset[(dir + 1) % 8].x;
+				y2 = node.p.y + aDirOffset[(dir + 1) % 8].y;
+				if (context.isBlocked(x2, y2))
 				{
 					continue;
 				}
-				x = node.p.x + aDirOffset[(dir + 7) % 8].x;
-				y = node.p.y + aDirOffset[(dir + 7) % 8].y;
-				if (context.isBlocked(x, y))
+				x2 = node.p.x + aDirOffset[(dir + 7) % 8].x;
+				y2 = node.p.y + aDirOffset[(dir + 7) % 8].y;
+				if (context.isBlocked(x2, y2))
 				{
 					continue;
 				}

--- a/src/atmos.cpp
+++ b/src/atmos.cpp
@@ -85,25 +85,25 @@ void atmosInitSystem()
 static void testParticleWrap(ATPART *psPart)
 {
 	/* Gone off left side */
-	if (psPart->position.x < player.p.x - world_coord(visibleTiles.x) / 2)
+	if (psPart->position.x < playerPos.p.x - world_coord(visibleTiles.x) / 2)
 	{
 		psPart->position.x += world_coord(visibleTiles.x);
 	}
 
 	/* Gone off right side */
-	else if (psPart->position.x > (player.p.x + world_coord(visibleTiles.x) / 2))
+	else if (psPart->position.x > (playerPos.p.x + world_coord(visibleTiles.x) / 2))
 	{
 		psPart->position.x -= world_coord(visibleTiles.x);
 	}
 
 	/* Gone off top */
-	if (psPart->position.z < player.p.z - world_coord(visibleTiles.y) / 2)
+	if (psPart->position.z < playerPos.p.z - world_coord(visibleTiles.y) / 2)
 	{
 		psPart->position.z += world_coord(visibleTiles.y);
 	}
 
 	/* Gone off bottom */
-	else if (psPart->position.z > (player.p.z + world_coord(visibleTiles.y) / 2))
+	else if (psPart->position.z > (playerPos.p.z + world_coord(visibleTiles.y) / 2))
 	{
 		psPart->position.z -= world_coord(visibleTiles.y);
 	}
@@ -279,8 +279,8 @@ void atmosUpdateSystem()
 		/* Temporary stuff - just adds a few particles! */
 		for (i = 0; i < numberToAdd; i++)
 		{
-			pos.x = player.p.x;
-			pos.z = player.p.z;
+			pos.x = playerPos.p.x;
+			pos.z = playerPos.p.z;
 			pos.x += world_coord(rand() % visibleTiles.x - visibleTiles.x / 2);
 			pos.z += world_coord(rand() % visibleTiles.x - visibleTiles.y / 2);
 			pos.y = 1000;
@@ -336,14 +336,14 @@ void renderParticle(ATPART *psPart, const glm::mat4 &viewMatrix)
 	Vector3i dv;
 
 	/* Transform it */
-	dv.x = psPart->position.x - player.p.x;
+	dv.x = psPart->position.x - playerPos.p.x;
 	dv.y = psPart->position.y;
-	dv.z = -(psPart->position.z - player.p.z);
+	dv.z = -(psPart->position.z - playerPos.p.z);
 	/* Make it face camera */
 	/* Scale it... */
 	const glm::mat4 modelMatrix = glm::translate(glm::vec3(dv)) *
-		glm::rotate(UNDEG(-player.r.y), glm::vec3(0.f, 1.f, 0.f)) *
-		glm::rotate(UNDEG(-player.r.x), glm::vec3(0.f, 1.f, 0.f)) *
+		glm::rotate(UNDEG(-playerPos.r.y), glm::vec3(0.f, 1.f, 0.f)) *
+		glm::rotate(UNDEG(-playerPos.r.x), glm::vec3(0.f, 1.f, 0.f)) *
 		glm::scale(glm::vec3(psPart->size / 100.f));
 	pie_Draw3DShape(psPart->imd, 0, 0, WZCOL_WHITE, 0, 0, viewMatrix * modelMatrix);
 	/* Draw it... */

--- a/src/aud.cpp
+++ b/src/aud.cpp
@@ -57,9 +57,9 @@ Vector3f audio_GetPlayerPos()
 {
 	Vector3f pos;
 
-	pos.x = player.p.x;
-	pos.y = player.p.z;
-	pos.z = player.p.y;
+	pos.x = playerPos.p.x;
+	pos.y = playerPos.p.z;
+	pos.z = playerPos.p.y;
 
 	// Invert Y to match QSOUND axes
 	// @NOTE What is QSOUND? Why invert the Y axis?
@@ -73,7 +73,7 @@ Vector3f audio_GetPlayerPos()
  */
 void audio_Get3DPlayerRotAboutVerticalAxis(float *angle)
 {
-	*angle = ((float) player.r.y / DEG_1) * M_PI / 180.0f;
+	*angle = ((float) playerPos.r.y / DEG_1) * M_PI / 180.0f;
 }
 
 /**

--- a/src/bucket3d.cpp
+++ b/src/bucket3d.cpp
@@ -78,8 +78,8 @@ static SDWORD bucketCalculateZ(RENDER_TYPE objectType, void *pObject, const glm:
 		position.y = ((ATPART *)pObject)->position.y;
 		position.z = ((ATPART *)pObject)->position.z;
 
-		position.x = position.x - player.p.x;
-		position.z = -(position.z - player.p.z);
+		position.x = position.x - playerPos.p.x;
+		position.z = -(position.z - playerPos.p.z);
 
 		/* 16 below is HACK!!! */
 		z = pie_RotateProject(&position, viewMatrix, &pixel) - 16;
@@ -111,8 +111,8 @@ static SDWORD bucketCalculateZ(RENDER_TYPE objectType, void *pObject, const glm:
 			pImd = ((PROJECTILE *)pObject)->psWStats->pInFlightGraphic;
 
 			psSimpObj = (SIMPLE_OBJECT *) pObject;
-			position.x = psSimpObj->pos.x - player.p.x;
-			position.z = -(psSimpObj->pos.y - player.p.z);
+			position.x = psSimpObj->pos.x - playerPos.p.x;
+			position.z = -(psSimpObj->pos.y - playerPos.p.z);
 
 			position.y = psSimpObj->pos.z;
 
@@ -134,8 +134,8 @@ static SDWORD bucketCalculateZ(RENDER_TYPE objectType, void *pObject, const glm:
 		break;
 	case RENDER_STRUCTURE://not depth sorted
 		psSimpObj = (SIMPLE_OBJECT *) pObject;
-		position.x = psSimpObj->pos.x - player.p.x;
-		position.z = -(psSimpObj->pos.y - player.p.z);
+		position.x = psSimpObj->pos.x - playerPos.p.x;
+		position.z = -(psSimpObj->pos.y - playerPos.p.z);
 
 		if ((objectType == RENDER_STRUCTURE) &&
 		    ((((STRUCTURE *)pObject)->pStructureType->type == REF_DEFENSE) ||
@@ -167,8 +167,8 @@ static SDWORD bucketCalculateZ(RENDER_TYPE objectType, void *pObject, const glm:
 		break;
 	case RENDER_FEATURE://not depth sorted
 		psSimpObj = (SIMPLE_OBJECT *) pObject;
-		position.x = psSimpObj->pos.x - player.p.x;
-		position.z = -(psSimpObj->pos.y - player.p.z);
+		position.x = psSimpObj->pos.x - playerPos.p.x;
+		position.z = -(psSimpObj->pos.y - playerPos.p.z);
 
 		position.y = psSimpObj->pos.z + 2;
 
@@ -191,8 +191,8 @@ static SDWORD bucketCalculateZ(RENDER_TYPE objectType, void *pObject, const glm:
 		psDroid = (DROID *) pObject;
 
 		psSimpObj = (SIMPLE_OBJECT *) pObject;
-		position.x = psSimpObj->pos.x - player.p.x;
-		position.z = -(psSimpObj->pos.y - player.p.z);
+		position.x = psSimpObj->pos.x - playerPos.p.x;
+		position.z = -(psSimpObj->pos.y - playerPos.p.z);
 		position.y = psSimpObj->pos.z;
 
 		psBStats = asBodyStats + psDroid->asBits[COMP_BODY];
@@ -216,12 +216,12 @@ static SDWORD bucketCalculateZ(RENDER_TYPE objectType, void *pObject, const glm:
 		if (((PROXIMITY_DISPLAY *)pObject)->type == POS_PROXDATA)
 		{
 			const PROXIMITY_DISPLAY *ptr = (PROXIMITY_DISPLAY *)pObject;
-			position.x = ((VIEW_PROXIMITY *)ptr->psMessage->pViewData->pData)->x - player.p.x;
+			position.x = ((VIEW_PROXIMITY *)ptr->psMessage->pViewData->pData)->x - playerPos.p.x;
 #if defined( _MSC_VER )
 	#pragma warning( push )
 	#pragma warning( disable : 4146 ) // warning C4146: unary minus operator applied to unsigned type, result still unsigned
 #endif
-			position.z = -(((VIEW_PROXIMITY *)ptr->psMessage->pViewData->pData)->y - player.p.z);
+			position.z = -(((VIEW_PROXIMITY *)ptr->psMessage->pViewData->pData)->y - playerPos.p.z);
 #if defined( _MSC_VER )
 	#pragma warning( pop )
 #endif
@@ -230,8 +230,8 @@ static SDWORD bucketCalculateZ(RENDER_TYPE objectType, void *pObject, const glm:
 		else if (((PROXIMITY_DISPLAY *)pObject)->type == POS_PROXOBJ)
 		{
 			const PROXIMITY_DISPLAY *ptr = (PROXIMITY_DISPLAY *)pObject;
-			position.x = ptr->psMessage->psObj->pos.x - player.p.x;
-			position.z = -(ptr->psMessage->psObj->pos.y - player.p.z);
+			position.x = ptr->psMessage->psObj->pos.x - playerPos.p.x;
+			position.z = -(ptr->psMessage->psObj->pos.y - playerPos.p.z);
 			position.y = ptr->psMessage->psObj->pos.z;
 		}
 		z = pie_RotateProject(&position, viewMatrix, &pixel);
@@ -251,8 +251,8 @@ static SDWORD bucketCalculateZ(RENDER_TYPE objectType, void *pObject, const glm:
 		}
 		break;
 	case RENDER_EFFECT:
-		position.x = ((EFFECT *)pObject)->position.x - player.p.x;
-		position.z = -(((EFFECT *)pObject)->position.z - player.p.z);
+		position.x = ((EFFECT *)pObject)->position.x - playerPos.p.x;
+		position.z = -(((EFFECT *)pObject)->position.z - playerPos.p.z);
 		position.y = ((EFFECT *)pObject)->position.y;
 
 		/* 16 below is HACK!!! */
@@ -278,9 +278,9 @@ static SDWORD bucketCalculateZ(RENDER_TYPE objectType, void *pObject, const glm:
 		break;
 
 	case RENDER_DELIVPOINT:
-		position.x = ((FLAG_POSITION *)pObject)->coords.x - player.p.x;
+		position.x = ((FLAG_POSITION *)pObject)->coords.x - playerPos.p.x;
 		position.z = -(((FLAG_POSITION *)pObject)->
-		               coords.y - player.p.z);
+		               coords.y - playerPos.p.z);
 		position.y = ((FLAG_POSITION *)pObject)->coords.z;
 
 		z = pie_RotateProject(&position, viewMatrix, &pixel);

--- a/src/component.cpp
+++ b/src/component.cpp
@@ -733,16 +733,16 @@ static bool displayCompObj(DROID *psDroid, bool bButton, const glm::mat4 &viewMa
 						//rotate Y
 						localModelMatrix *= glm::rotate(UNDEG(rot.direction), glm::vec3(0.f, 1.f, 0.f));
 
-						localModelMatrix *= glm::rotate(UNDEG(-player.r.y), glm::vec3(0.f, 1.f, 0.f));
-						localModelMatrix *= glm::rotate(UNDEG(-player.r.x), glm::vec3(1.f, 0.f, 0.f));
+						localModelMatrix *= glm::rotate(UNDEG(-playerPos.r.y), glm::vec3(0.f, 1.f, 0.f));
+						localModelMatrix *= glm::rotate(UNDEG(-playerPos.r.x), glm::vec3(1.f, 0.f, 0.f));
 
 						if (pie_Draw3DShape(psShape, getModularScaledGraphicsTime(psShape->animInterval, psShape->numFrames), 0, brightness, pie_ADDITIVE, 140, viewMatrix * localModelMatrix))
 						{
 							didDrawSomething = true;
 						}
 
-//						localModelMatrix *= glm::rotate(UNDEG(player.r.x), glm::vec3(1.f, 0.f, 0.f)); // Not used?
-//						localModelMatrix *= glm::rotate(UNDEG(player.r.y), glm::vec3(0.f, 1.f, 0.f)); // Not used?
+//						localModelMatrix *= glm::rotate(UNDEG(playerPos.r.x), glm::vec3(1.f, 0.f, 0.f)); // Not used?
+//						localModelMatrix *= glm::rotate(UNDEG(playerPos.r.y), glm::vec3(0.f, 1.f, 0.f)); // Not used?
 					}
 				}
 				break;
@@ -828,11 +828,11 @@ void displayComponentObject(DROID *psDroid, const glm::mat4 &viewMatrix)
 	Vector3i position, rotation;
 	Spacetime st = interpolateObjectSpacetime(psDroid, graphicsTime);
 
-	leftFirst = angleDelta(player.r.y - st.rot.direction) <= 0;
+	leftFirst = angleDelta(playerPos.r.y - st.rot.direction) <= 0;
 
 	/* Get the real position */
-	position.x = st.pos.x - player.p.x;
-	position.z = -(st.pos.y - player.p.z);
+	position.x = st.pos.x - playerPos.p.x;
+	position.z = -(st.pos.y - playerPos.p.z);
 	position.y = st.pos.z;
 
 	if (isTransporter(psDroid))
@@ -865,14 +865,14 @@ void displayComponentObject(DROID *psDroid, const glm::mat4 &viewMatrix)
 
 	if (psDroid->lastHitWeapon == WSC_EMP && graphicsTime - psDroid->timeLastHit < EMP_DISABLE_TIME)
 	{
-		Vector3i position;
+		Vector3i effectPosition;
 
 		//add an effect on the droid
-		position.x = st.pos.x + DROID_EMP_SPREAD;
-		position.y = st.pos.z + rand() % 8;
-		position.z = st.pos.y + DROID_EMP_SPREAD;
+		effectPosition.x = st.pos.x + DROID_EMP_SPREAD;
+		effectPosition.y = st.pos.z + rand() % 8;
+		effectPosition.z = st.pos.y + DROID_EMP_SPREAD;
 		effectGiveAuxVar(90 + rand() % 20);
-		addEffect(&position, EFFECT_EXPLOSION, EXPLOSION_TYPE_PLASMA, false, nullptr, 0);
+		addEffect(&effectPosition, EFFECT_EXPLOSION, EXPLOSION_TYPE_PLASMA, false, nullptr, 0);
 	}
 
 	if (psDroid->visible[selectedPlayer] == UBYTE_MAX)

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -236,7 +236,7 @@ void shakeStart(unsigned int length)
 void shakeStop()
 {
 	bScreenShakeActive = false;
-	player.r.z = 0;
+	playerPos.r.z = 0;
 }
 
 static void shakeUpdate()
@@ -249,19 +249,19 @@ static void shakeUpdate()
 		screenShakePercentage = PERCENT(gameTime - screenShakeStarted, screenShakeLength);
 		if (screenShakePercentage < 100)
 		{
-			player.r.z = 0 + DEG(screenShakeTable[screenShakePercentage]);
+			playerPos.r.z = 0 + DEG(screenShakeTable[screenShakePercentage]);
 		}
 		if (gameTime > (screenShakeStarted + screenShakeLength))
 		{
 			bScreenShakeActive = false;
-			player.r.z = 0;
+			playerPos.r.z = 0;
 		}
 	}
 	else
 	{
 		if (!getWarCamStatus())
 		{
-			player.r.z = 0;
+			playerPos.r.z = 0;
 		}
 	}
 }
@@ -370,7 +370,7 @@ void ProcessRadarInput()
 				bRadarDragging = true;
 				if (ctrlShiftDown())
 				{
-					player.r.y = 0;
+					playerPos.r.y = 0;
 				}
 			}
 			else if (mousePressed(MOUSE_SELECT))
@@ -715,14 +715,14 @@ void processMouseClickInput()
 	}
 	if (mouseDrag(MOUSE_ROTATE, (UDWORD *)&rotX, (UDWORD *)&rotY) && !rotActive && !bRadarDragging && !getRadarTrackingStatus())
 	{
-		rotationVerticalTracker->startTracking((UWORD)player.r.x);
-		rotationHorizontalTracker->startTracking((UWORD)player.r.y); // negative values caused problems with float conversion
+		rotationVerticalTracker->startTracking((UWORD)playerPos.r.x);
+		rotationHorizontalTracker->startTracking((UWORD)playerPos.r.y); // negative values caused problems with float conversion
 		rotActive = true;
 	}
 	if (mouseDrag(MOUSE_PAN, (UDWORD *)&panMouseX, (UDWORD *)&panMouseY) && !rotActive && !panActive && !bRadarDragging && !getRadarTrackingStatus())
 	{
-		panXTracker->startTracking(player.p.x);
-		panZTracker->startTracking(player.p.z);
+		panXTracker->startTracking(playerPos.p.x);
+		panZTracker->startTracking(playerPos.p.z);
 		panActive = true;
 	}
 
@@ -1075,13 +1075,13 @@ static void handleCameraScrolling()
 	calcScroll(&scrollStepUpDown,    &scrollSpeedUpDown,    scaled_accel, 2 * scaled_accel, scrollDirUpDown    * scaled_max_scroll_speed, (float)timeDiff / GAME_TICKS_PER_SEC);
 
 	/* Get x component of movement */
-	xDif = (int) (cos(-player.r.y * (M_PI / 32768)) * scrollStepLeftRight + sin(-player.r.y * (M_PI / 32768)) * scrollStepUpDown);
+	xDif = (int) (cos(-playerPos.r.y * (M_PI / 32768)) * scrollStepLeftRight + sin(-playerPos.r.y * (M_PI / 32768)) * scrollStepUpDown);
 	/* Get y component of movement */
-	yDif = (int) (sin(-player.r.y * (M_PI / 32768)) * scrollStepLeftRight - cos(-player.r.y * (M_PI / 32768)) * scrollStepUpDown);
+	yDif = (int) (sin(-playerPos.r.y * (M_PI / 32768)) * scrollStepLeftRight - cos(-playerPos.r.y * (M_PI / 32768)) * scrollStepUpDown);
 
 	/* Adjust player's position by these components */
-	player.p.x += xDif;
-	player.p.z += yDif;
+	playerPos.p.x += xDif;
+	playerPos.p.z += yDif;
 
 	CheckScrollLimits();
 
@@ -1152,12 +1152,12 @@ bool CheckInScrollLimits(SDWORD *xPos, SDWORD *zPos)
 //
 bool CheckScrollLimits()
 {
-	SDWORD xp = player.p.x;
-	SDWORD zp = player.p.z;
+	SDWORD xp = playerPos.p.x;
+	SDWORD zp = playerPos.p.z;
 	bool ret = CheckInScrollLimits(&xp, &zp);
 
-	player.p.x = xp;
-	player.p.z = zp;
+	playerPos.p.x = xp;
+	playerPos.p.z = zp;
 
 	return ret;
 }
@@ -1187,12 +1187,12 @@ void displayWorld()
 			float horizontalMovement = panXTracker->setTargetDelta(mouseDeltaX * panningSpeed)->update()->getCurrentDelta();
 			float verticalMovement = -1 * panZTracker->setTargetDelta(mouseDeltaY * panningSpeed)->update()->getCurrentDelta();
 
-			player.p.x = panXTracker->getInitial()
-				+ cos(-player.r.y * (M_PI / 32768)) * horizontalMovement
-				+ sin(-player.r.y * (M_PI / 32768)) * verticalMovement;
-			player.p.z = panZTracker->getInitial()
-				+ sin(-player.r.y * (M_PI / 32768)) * horizontalMovement
-				- cos(-player.r.y * (M_PI / 32768)) * verticalMovement;
+			playerPos.p.x = panXTracker->getInitial()
+				+ cos(-playerPos.r.y * (M_PI / 32768)) * horizontalMovement
+				+ sin(-playerPos.r.y * (M_PI / 32768)) * verticalMovement;
+			playerPos.p.z = panZTracker->getInitial()
+				+ sin(-playerPos.r.y * (M_PI / 32768)) * horizontalMovement
+				- cos(-playerPos.r.y * (M_PI / 32768)) * verticalMovement;
 			CheckScrollLimits();
 		}
 	}
@@ -1202,24 +1202,24 @@ void displayWorld()
 		float mouseDeltaX = mouseX() - rotX;
 		float mouseDeltaY = mouseY() - rotY;
 
-		player.r.y = rotationHorizontalTracker->setTargetDelta(DEG(-mouseDeltaX) / 4)->update()->getCurrent();
+		playerPos.r.y = rotationHorizontalTracker->setTargetDelta(DEG(-mouseDeltaX) / 4)->update()->getCurrent();
 
 		if(bInvertMouse)
 		{
 			mouseDeltaY *= -1;
 		}
 
-		player.r.x = rotationVerticalTracker->setTargetDelta(DEG(mouseDeltaY) / 4)->update()->getCurrent();
-		player.r.x = glm::clamp(player.r.x, DEG(360 + MIN_PLAYER_X_ANGLE), DEG(360 + MAX_PLAYER_X_ANGLE));
+		playerPos.r.x = rotationVerticalTracker->setTargetDelta(DEG(mouseDeltaY) / 4)->update()->getCurrent();
+		playerPos.r.x = glm::clamp(playerPos.r.x, DEG(360 + MIN_PLAYER_X_ANGLE), DEG(360 + MAX_PLAYER_X_ANGLE));
 	}
 
 	if (!mouseDown(MOUSE_ROTATE) && rotActive)
 	{
 		rotActive = false;
 		ignoreRMBC = true;
-		pos.x = player.r.x;
-		pos.y = player.r.y;
-		pos.z = player.r.z;
+		pos.x = playerPos.r.x;
+		pos.y = playerPos.r.y;
+		pos.z = playerPos.r.z;
 		camInformOfRotation(&pos);
 		bRadarDragging = false;
 	}
@@ -1881,7 +1881,7 @@ static void dealWithLMBFeature(FEATURE *psFeature)
 						AddDerrickBurningMessage();
 					}
 
-					sendDroidInfo(psCurr, DroidOrder(DORDER_BUILD, &asStructureStats[i], psFeature->pos.xy(), player.r.y), ctrlShiftDown());
+					sendDroidInfo(psCurr, DroidOrder(DORDER_BUILD, &asStructureStats[i], psFeature->pos.xy(), playerPos.r.y), ctrlShiftDown());
 					FeedbackOrderGiven();
 				}
 			}
@@ -2495,13 +2495,13 @@ static UBYTE DroidSelectionWeights[NUM_DROID_WEIGHTS] =
 /* Only deals with one type of droid being selected!!!! */
 /*	We'll have to make it assess which selection is to be dominant in the case
 	of multiple selections */
-static SELECTION_TYPE	establishSelection(UDWORD selectedPlayer)
+static SELECTION_TYPE	establishSelection(UDWORD _selectedPlayer)
 {
 	DROID *psDominant = nullptr;
 	UBYTE CurrWeight = UBYTE_MAX;
 	SELECTION_TYPE selectionClass = SC_INVALID;
 
-	for (DROID *psDroid = apsDroidLists[selectedPlayer]; psDroid; psDroid = psDroid->psNext)
+	for (DROID *psDroid = apsDroidLists[_selectedPlayer]; psDroid; psDroid = psDroid->psNext)
 	{
 		// This works, uses the DroidSelectionWeights[] table to priorities the different
 		// droid types and find the dominant selection.

--- a/src/display3d.h
+++ b/src/display3d.h
@@ -97,7 +97,7 @@ bool clipStructureOnScreen(STRUCTURE *psStructure, const glm::mat4 &viewModelMat
 
 bool init3DView();
 void shutdown3DView();
-extern iView player;
+extern iView playerPos;
 extern bool selectAttempt;
 
 extern SDWORD scrollSpeed;

--- a/src/droid.cpp
+++ b/src/droid.cpp
@@ -3056,9 +3056,9 @@ DROID *giftSingleDroid(DROID *psD, UDWORD to, bool electronic)
 				orderDroid(psCurr, DORDER_STOP, ModeQueue);
 				break;
 			}
-			for (unsigned i = 0; i < psCurr->numWeaps; ++i)
+			for (unsigned iWeap = 0; iWeap < psCurr->numWeaps; ++iWeap)
 			{
-				if (psCurr->psActionTarget[i] == psD)
+				if (psCurr->psActionTarget[iWeap] == psD)
 				{
 					orderDroid(psCurr, DORDER_STOP, ModeImmediate);
 					break;

--- a/src/edit3d.cpp
+++ b/src/edit3d.cpp
@@ -222,7 +222,7 @@ void incrementBuildingDirection(uint16_t amount)
 
 uint16_t getBuildingDirection()
 {
-	return snapDirection(player.r.y + sBuildDetails.directionShift);
+	return snapDirection(playerPos.r.y + sBuildDetails.directionShift);
 }
 
 /* See if a structure location has been found */

--- a/src/effects.cpp
+++ b/src/effects.cpp
@@ -233,9 +233,9 @@ static glm::mat4 positionEffect(const EFFECT *psEffect)
 {
 	/* Establish world position */
 	glm::vec3 dv(
-	    psEffect->position.x - player.p.x,
+	    psEffect->position.x - playerPos.p.x,
 	    psEffect->position.y,
-	    -(psEffect->position.z - player.p.z)
+	    -(psEffect->position.z - playerPos.p.z)
 	);
 
 	return glm::translate(dv);
@@ -1372,7 +1372,7 @@ static void renderFirework(const EFFECT *psEffect, const glm::mat4 &viewMatrix)
 	}
 
 	glm::mat4 modelMatrix = positionEffect(psEffect);
-	modelMatrix *= glm::rotate(UNDEG(-player.r.y), glm::vec3(0.f, 1.f, 0.f)) * glm::rotate(UNDEG(-player.r.x), glm::vec3(1.f, 0.f, 0.f))
+	modelMatrix *= glm::rotate(UNDEG(-playerPos.r.y), glm::vec3(0.f, 1.f, 0.f)) * glm::rotate(UNDEG(-playerPos.r.x), glm::vec3(1.f, 0.f, 0.f))
 	               * glm::scale(glm::vec3(psEffect->size / 100.f));
 
 	pie_Draw3DShape(psEffect->imd, psEffect->frameNumber, 0, WZCOL_WHITE, pie_ADDITIVE, EFFECT_EXPLOSION_ADDITIVE, viewMatrix * modelMatrix);
@@ -1382,7 +1382,7 @@ static void renderFirework(const EFFECT *psEffect, const glm::mat4 &viewMatrix)
 static void renderBloodEffect(const EFFECT *psEffect, const glm::mat4 &viewMatrix)
 {
 	glm::mat4 modelMatrix = positionEffect(psEffect);
-	modelMatrix *= glm::rotate(UNDEG(-player.r.y), glm::vec3(0.f, 1.f, 0.f)) * glm::rotate(UNDEG(-player.r.x), glm::vec3(1.f, 0.f, 0.f))
+	modelMatrix *= glm::rotate(UNDEG(-playerPos.r.y), glm::vec3(0.f, 1.f, 0.f)) * glm::rotate(UNDEG(-playerPos.r.x), glm::vec3(1.f, 0.f, 0.f))
 	               * glm::scale(glm::vec3(psEffect->size / 100.f));
 
 	pie_Draw3DShape(getImdFromIndex(MI_BLOOD), psEffect->frameNumber, 0, WZCOL_WHITE, pie_TRANSLUCENT, EFFECT_BLOOD_TRANSPARENCY, viewMatrix * modelMatrix);
@@ -1467,8 +1467,8 @@ static void renderExplosionEffect(const EFFECT *psEffect, const glm::mat4 &viewM
 		/* Always face the viewer! */
 		// TODO This only faces towards the viewer, if the effect is in the middle of the screen... It draws the effect parallel with the screens near/far planes.
 		modelMatrix *=
-			glm::rotate(UNDEG(-player.r.y), glm::vec3(0.f, 1.f, 0.f)) *
-			glm::rotate(UNDEG(-player.r.x), glm::vec3(1.f, 0.f, 0.f));
+			glm::rotate(UNDEG(-playerPos.r.y), glm::vec3(0.f, 1.f, 0.f)) *
+			glm::rotate(UNDEG(-playerPos.r.x), glm::vec3(1.f, 0.f, 0.f));
 	}
 
 	/* Tesla explosions diminish in size */
@@ -1553,8 +1553,8 @@ static void renderConstructionEffect(const EFFECT *psEffect, const glm::mat4 &vi
 	if (TEST_FACING(psEffect))
 	{
 		modelMatrix *=
-			glm::rotate(UNDEG(-player.r.y), glm::vec3(0.f, 1.f, 0.f)) *
-			glm::rotate(UNDEG(-player.r.x), glm::vec3(1.f, 0.f, 0.f));
+			glm::rotate(UNDEG(-playerPos.r.y), glm::vec3(0.f, 1.f, 0.f)) *
+			glm::rotate(UNDEG(-playerPos.r.x), glm::vec3(1.f, 0.f, 0.f));
 	}
 
 	/* Scale size according to age */
@@ -1596,8 +1596,8 @@ static void renderSmokeEffect(const EFFECT *psEffect, const glm::mat4 &viewMatri
 	if (TEST_FACING(psEffect))
 	{
 		/* Always face the viewer! */
-		modelMatrix *= glm::rotate(UNDEG(-player.r.y), glm::vec3(0.f, 1.f, 0.f)) *
-			glm::rotate(UNDEG(-player.r.x), glm::vec3(1.f, 0.f, 0.f));
+		modelMatrix *= glm::rotate(UNDEG(-playerPos.r.y), glm::vec3(0.f, 1.f, 0.f)) *
+			glm::rotate(UNDEG(-playerPos.r.x), glm::vec3(1.f, 0.f, 0.f));
 	}
 
 	if (TEST_SCALED(psEffect))

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -3977,10 +3977,10 @@ static bool writeMainFile(const std::string &fileName, SDWORD saveType)
 	}
 	save.endArray();
 
-	iView playerPos;
-	disp3d_getView(&playerPos);
-	save.setVector3i("camera_position", playerPos.p);
-	save.setVector3i("camera_rotation", playerPos.r);
+	iView currPlayerPos;
+	disp3d_getView(&currPlayerPos);
+	save.setVector3i("camera_position", currPlayerPos.p);
+	save.setVector3i("camera_rotation", currPlayerPos.r);
 
 	save.beginArray("landing_zones");
 	for (int i = 0; i < MAX_NOGO_AREAS; ++i)
@@ -4191,7 +4191,7 @@ static bool writeGameFile(const char *fileName, SDWORD saveType)
 	if (saveGame.sGame.type == LEVEL_TYPE::CAMPAIGN)
 	{
 		// player 0 is always a human in campaign games
-		for (int i = 1; i < MAX_PLAYERS; i++)
+		for (i = 1; i < MAX_PLAYERS; i++)
 		{
 			if (saveGame.sNetPlay.players[i].difficulty == AIDifficulty::HUMAN)
 			{
@@ -4440,9 +4440,9 @@ foundDroid:
 		getIniDroidOrder(ini, "order", psDroid->order);
 		psDroid->listSize = clip(ini.value("orderList/size", 0).toInt(), 0, 10000);
 		psDroid->asOrderList.resize(psDroid->listSize);  // Must resize before setting any orders, and must set in-place, since pointers are updated later.
-		for (int i = 0; i < psDroid->listSize; ++i)
+		for (int droidIdx = 0; droidIdx < psDroid->listSize; ++droidIdx)
 		{
-			getIniDroidOrder(ini, "orderList/" + WzString::number(i), psDroid->asOrderList[i]);
+			getIniDroidOrder(ini, "orderList/" + WzString::number(droidIdx), psDroid->asOrderList[droidIdx]);
 		}
 		psDroid->listPendingBegin = 0;
 		for (int j = 0; j < MAX_WEAPONS; j++)
@@ -5318,8 +5318,8 @@ static bool loadSaveStructure2(const char *pFileName, STRUCTURE **ppList)
 		//for modules - need to check the base structure exists
 		if (IsStatExpansionModule(psStats))
 		{
-			STRUCTURE *psStructure = getTileStructure(map_coord(pos.x), map_coord(pos.y));
-			if (psStructure == nullptr)
+			STRUCTURE *psTileStructure = getTileStructure(map_coord(pos.x), map_coord(pos.y));
+			if (psTileStructure == nullptr)
 			{
 				debug(LOG_ERROR, "No owning structure for module - %s for player - %d", name.toUtf8().c_str(), player);
 				ini.endGroup();
@@ -5375,7 +5375,7 @@ static bool loadSaveStructure2(const char *pFileName, STRUCTURE **ppList)
 			{
 				psModule = getModuleStat(psStructure);
 				//build the appropriate number of modules
-				for (int i = 0; i < capacity; i++)
+				for (int moduleIdx = 0; moduleIdx < capacity; moduleIdx++)
 				{
 					buildStructure(psModule, psStructure->pos.x, psStructure->pos.y, psStructure->player, true);
 				}
@@ -6678,10 +6678,10 @@ bool loadSaveMessage(const char* pFileName, LEVEL_TYPE levelType)
 
 						psMessage->pViewData = psViewData;
 						// Check the z value is at least the height of the terrain
-						const int height = map_Height(((VIEW_PROXIMITY*)psViewData->pData)->x, ((VIEW_PROXIMITY*)psViewData->pData)->y);
-						if (((VIEW_PROXIMITY*)psViewData->pData)->z < height)
+						const int terrainHeight = map_Height(((VIEW_PROXIMITY*)psViewData->pData)->x, ((VIEW_PROXIMITY*)psViewData->pData)->y);
+						if (((VIEW_PROXIMITY*)psViewData->pData)->z < terrainHeight)
 						{
-							((VIEW_PROXIMITY*)psViewData->pData)->z = height;
+							((VIEW_PROXIMITY*)psViewData->pData)->z = terrainHeight;
 						}
 					}
 					else

--- a/src/hci.cpp
+++ b/src/hci.cpp
@@ -1270,7 +1270,7 @@ INT_RETVAL intRunWidgets()
 			{
 				if (auto stats = castStructureStats(sBuildDetails.psStats))
 				{
-					size = stats->size(player.r.y);
+					size = stats->size(playerPos.r.y);
 					type = stats->type;
 				}
 				if (pos2.x == INT32_MAX)
@@ -1396,25 +1396,25 @@ INT_RETVAL intRunWidgets()
 /* Set the shadow for the PowerBar */
 static void intRunPower()
 {
-	UDWORD				statID;
+	UDWORD				highlightedStatID;
 	BASE_STATS			*psStat;
 	UDWORD				quantity = 0;
 
 	/* Find out which button was hilited */
-	statID = widgGetMouseOver(psWScreen);
-	if (statID >= IDSTAT_START && statID <= IDSTAT_END)
+	highlightedStatID = widgGetMouseOver(psWScreen);
+	if (highlightedStatID >= IDSTAT_START && highlightedStatID <= IDSTAT_END)
 	{
-		psStat = ppsStatsList[statID - IDSTAT_START];
+		psStat = ppsStatsList[highlightedStatID - IDSTAT_START];
 		if (psStat->hasType(STAT_STRUCTURE))
 		{
 			//get the structure build points
-			quantity = ((STRUCTURE_STATS *)apsStructStatsList[statID -
+			quantity = ((STRUCTURE_STATS *)apsStructStatsList[highlightedStatID -
 			            IDSTAT_START])->powerToBuild;
 		}
 		else if (psStat->hasType(STAT_TEMPLATE))
 		{
 			//get the template build points
-			quantity = calcTemplatePower(apsTemplateList[statID - IDSTAT_START]);
+			quantity = calcTemplatePower(apsTemplateList[highlightedStatID - IDSTAT_START]);
 		}
 
 		//update the power bars
@@ -1769,7 +1769,7 @@ void makeObsoleteButton(const std::shared_ptr<WIDGET> &parent)
 /* Add the stats widgets to the widget screen */
 /* If psSelected != NULL it specifies which stat should be hilited
    psOwner specifies which object is hilighted on the object bar for this stat*/
-static bool intAddDebugStatsForm(BASE_STATS **ppsStatsList, UDWORD numStats)
+static bool intAddDebugStatsForm(BASE_STATS **_ppsStatsList, UDWORD numStats)
 {
 	// should this ever be called with psOwner == NULL?
 
@@ -1850,11 +1850,11 @@ static bool intAddDebugStatsForm(BASE_STATS **ppsStatsList, UDWORD numStats)
 		statList->attach(button);
 		button->id = nextButtonId;
 		button->style |= WFORM_SECONDARY;
-		button->setStats(ppsStatsList[i]);
+		button->setStats(_ppsStatsList[i]);
 		statList->addWidgetToLayout(button);
 
-		BASE_STATS *Stat = ppsStatsList[i];
-		WzString tipString = getStatsName(ppsStatsList[i]);
+		BASE_STATS *Stat = _ppsStatsList[i];
+		WzString tipString = getStatsName(_ppsStatsList[i]);
 		unsigned powerCost = 0;
 		W_BARGRAPH *bar;
 		if (Stat->hasType(STAT_STRUCTURE))  // It's a structure.

--- a/src/hci/build.cpp
+++ b/src/hci/build.cpp
@@ -558,10 +558,10 @@ private:
 		obsoleteButton->addOnClickHandler([weakController](W_BUTTON &button) {
 			if (auto buildController = weakController.lock())
 			{
-				auto &obsoleteButton = static_cast<MultipleChoiceButton &>(button);
-				auto newValue = !obsoleteButton.getChoice();
+				auto &_obsoleteButton = static_cast<MultipleChoiceButton &>(button);
+				auto newValue = !_obsoleteButton.getChoice();
 				buildController->setShouldShowRedundantDesign(newValue);
-				obsoleteButton.setChoice(newValue);
+				_obsoleteButton.setChoice(newValue);
 			}
 		});
 	}
@@ -581,10 +581,10 @@ private:
 		favoriteButton->addOnClickHandler([weakController](W_BUTTON &button) {
 			if (auto buildController = weakController.lock())
 			{
-				auto &favoriteButton = static_cast<MultipleChoiceButton &>(button);
-				auto newValue = !favoriteButton.getChoice();
+				auto &_favoriteButton = static_cast<MultipleChoiceButton &>(button);
+				auto newValue = !_favoriteButton.getChoice();
 				buildController->setShouldShowFavorite(newValue);
-				favoriteButton.setChoice(newValue);
+				_favoriteButton.setChoice(newValue);
 			}
 		});
 	}

--- a/src/hci/objects_stats.cpp
+++ b/src/hci/objects_stats.cpp
@@ -197,12 +197,12 @@ void ObjectsForm::addTabList()
 	attach(objectsList = IntListTabWidget::make());
 	objectsList->id = IDOBJ_TABFORM;
 	objectsList->setCalcLayout(LAMBDA_CALCLAYOUT_SIMPLE({
-		IntListTabWidget *objectsList = static_cast<IntListTabWidget *>(psWidget);
-		assert(objectsList != nullptr);
-		objectsList->setChildSize(OBJ_BUTWIDTH, OBJ_BUTHEIGHT * 2);
-		objectsList->setChildSpacing(OBJ_GAP, OBJ_GAP);
+		IntListTabWidget *pObjectsList = static_cast<IntListTabWidget *>(psWidget);
+		assert(pObjectsList != nullptr);
+		pObjectsList->setChildSize(OBJ_BUTWIDTH, OBJ_BUTHEIGHT * 2);
+		pObjectsList->setChildSpacing(OBJ_GAP, OBJ_GAP);
 		int objListWidth = OBJ_BUTWIDTH * 5 + STAT_GAP * 4;
-		objectsList->setGeometry((OBJ_BACKWIDTH - objListWidth) / 2, OBJ_TABY, objListWidth, OBJ_BACKHEIGHT - OBJ_TABY);
+		pObjectsList->setGeometry((OBJ_BACKWIDTH - objListWidth) / 2, OBJ_TABY, objListWidth, OBJ_BACKHEIGHT - OBJ_TABY);
 	}));
 }
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -131,7 +131,7 @@ static bool InitialiseGlobals()
 }
 
 
-bool loadLevFile(const char *filename, searchPathMode datadir, bool ignoreWrf, char const *realFileName)
+bool loadLevFile(const char *filename, searchPathMode pathMode, bool ignoreWrf, char const *realFileName)
 {
 	char *pBuffer;
 	UDWORD size;
@@ -150,7 +150,7 @@ bool loadLevFile(const char *filename, searchPathMode datadir, bool ignoreWrf, c
 		debug(LOG_ERROR, "File not found: %s\n", filename);
 		return false; // only in NDEBUG case
 	}
-	if (!levParse(pBuffer, size, datadir, ignoreWrf, realFileName))
+	if (!levParse(pBuffer, size, pathMode, ignoreWrf, realFileName))
 	{
 		debug(LOG_ERROR, "Parse error in %s\n", filename);
 		free(pBuffer);

--- a/src/intelmap.cpp
+++ b/src/intelmap.cpp
@@ -273,7 +273,7 @@ bool intAddIntelMap()
 }
 
 /* Add the Message sub form */
-static bool intAddMessageForm(bool playCurrent)
+static bool intAddMessageForm(bool _playCurrent)
 {
 	WIDGET *msgForm = widgGetFromID(psWScreen, IDINTMAP_FORM);
 
@@ -354,7 +354,7 @@ static bool intAddMessageForm(bool playCurrent)
 		}
 	}
 	//check to play current message instantly
-	if (playCurrent)
+	if (_playCurrent)
 	{
 		//is it a proximity message?
 		if (psCurrentMsg->type == MSG_PROXIMITY)

--- a/src/keybind.cpp
+++ b/src/keybind.cpp
@@ -313,7 +313,7 @@ void	kf_FaceNorth()
 // --------------------------------------------------------------------------
 void	kf_FaceSouth()
 {
-	player.r.y = DEG(180);
+	playerPos.r.y = DEG(180);
 	if (getWarCamStatus())
 	{
 		camToggleStatus();
@@ -323,7 +323,7 @@ void	kf_FaceSouth()
 // --------------------------------------------------------------------------
 void	kf_FaceEast()
 {
-	player.r.y = DEG(90);
+	playerPos.r.y = DEG(90);
 	if (getWarCamStatus())
 	{
 		camToggleStatus();
@@ -333,7 +333,7 @@ void	kf_FaceEast()
 // --------------------------------------------------------------------------
 void	kf_FaceWest()
 {
-	player.r.y = DEG(270);
+	playerPos.r.y = DEG(270);
 	if (getWarCamStatus())
 	{
 		camToggleStatus();
@@ -953,7 +953,7 @@ void	kf_RotateLeft()
 {
 	float rotAmount = realTimeAdjustedIncrement(MAP_SPIN_RATE);
 
-	player.r.y += rotAmount;
+	playerPos.r.y += rotAmount;
 }
 
 // --------------------------------------------------------------------------
@@ -962,10 +962,10 @@ void	kf_RotateRight()
 {
 	float rotAmount = realTimeAdjustedIncrement(MAP_SPIN_RATE);
 
-	player.r.y -= rotAmount;
-	if (player.r.y < 0)
+	playerPos.r.y -= rotAmount;
+	if (playerPos.r.y < 0)
 	{
-		player.r.y += DEG(360);
+		playerPos.r.y += DEG(360);
 	}
 }
 
@@ -989,11 +989,11 @@ void	kf_PitchBack()
 {
 	float pitchAmount = realTimeAdjustedIncrement(MAP_PITCH_RATE);
 
-	player.r.x += pitchAmount;
+	playerPos.r.x += pitchAmount;
 
-	if (player.r.x > DEG(360 + MAX_PLAYER_X_ANGLE))
+	if (playerPos.r.x > DEG(360 + MAX_PLAYER_X_ANGLE))
 	{
-		player.r.x = DEG(360 + MAX_PLAYER_X_ANGLE);
+		playerPos.r.x = DEG(360 + MAX_PLAYER_X_ANGLE);
 	}
 }
 
@@ -1003,10 +1003,10 @@ void	kf_PitchForward()
 {
 	float pitchAmount = realTimeAdjustedIncrement(MAP_PITCH_RATE);
 
-	player.r.x -= pitchAmount;
-	if (player.r.x < DEG(360 + MIN_PLAYER_X_ANGLE))
+	playerPos.r.x -= pitchAmount;
+	if (playerPos.r.x < DEG(360 + MIN_PLAYER_X_ANGLE))
 	{
-		player.r.x = DEG(360 + MIN_PLAYER_X_ANGLE);
+		playerPos.r.x = DEG(360 + MIN_PLAYER_X_ANGLE);
 	}
 }
 
@@ -1014,7 +1014,7 @@ void	kf_PitchForward()
 /* Resets pitch to default */
 void	kf_ResetPitch()
 {
-	player.r.x = DEG(360 - 20);
+	playerPos.r.x = DEG(360 - 20);
 	setViewDistance(STARTDISTANCE);
 }
 
@@ -1183,9 +1183,9 @@ void	kf_JumpToMapMarker()
 	{
 		entry = getLastSubKey();
 //		CONPRINTF("Restoring map position %d:%d",getMarkerX(entry),getMarkerY(entry));
-		player.p.x = getMarkerX(entry);
-		player.p.z = getMarkerY(entry);
-		player.r.y = getMarkerSpin(entry);
+		playerPos.p.x = getMarkerX(entry);
+		playerPos.p.z = getMarkerY(entry);
+		playerPos.r.y = getMarkerSpin(entry);
 		/* A fix to stop the camera continuing when marker code is called */
 		if (getWarCamStatus())
 		{
@@ -1269,7 +1269,7 @@ void	kf_ToggleGodMode()
 /* Aligns the view to north - some people can't handle the world spinning */
 void	kf_SeekNorth()
 {
-	player.r.y = 0;
+	playerPos.r.y = 0;
 	if (getWarCamStatus())
 	{
 		camToggleStatus();
@@ -1568,7 +1568,7 @@ void	kf_JumpToResourceExtractor()
 
 	if (psOldRE)
 	{
-		player.r.y = 0; // face north
+		playerPos.r.y = 0; // face north
 		setViewPos(map_coord(psOldRE->pos.x), map_coord(psOldRE->pos.y), true);
 	}
 	else
@@ -2448,9 +2448,9 @@ void	kf_CentreOnBase()
 	if (bGotHQ)
 	{
 		addConsoleMessage(_("Centered on player HQ, direction NORTH"), LEFT_JUSTIFY, SYSTEM_MESSAGE);
-		player.p.x = xJump;
-		player.p.z = yJump;
-		player.r.y = 0; // face north
+		playerPos.p.x = xJump;
+		playerPos.p.z = yJump;
+		playerPos.r.y = 0; // face north
 		/* A fix to stop the camera continuing when marker code is called */
 		if (getWarCamStatus())
 		{

--- a/src/keyedit.cpp
+++ b/src/keyedit.cpp
@@ -71,14 +71,14 @@ class KeyMapForm : public IntFormAnimated
 {
 protected:
 	KeyMapForm(): IntFormAnimated(false) {}
-	void initialize(bool ingame);
+	void initialize(bool isInGame);
 
 public:
-	static std::shared_ptr<KeyMapForm> make(bool ingame)
+	static std::shared_ptr<KeyMapForm> make(bool isInGame)
 	{
 		class make_shared_enabler: public KeyMapForm {};
 		auto widget = std::make_shared<make_shared_enabler>();
-		widget->initialize(ingame);
+		widget->initialize(isInGame);
 		return widget;
 	}
 
@@ -309,14 +309,14 @@ static void displayKeyMap(WIDGET *psWidget, UDWORD xOffset, UDWORD yOffset)
 }
 
 // ////////////////////////////////////////////////////////////////////////////
-static bool keyMapEditor(bool first, WIDGET *parent, bool ingame)
+static bool keyMapEditor(bool first, WIDGET *parent, bool isInGame)
 {
 	if (first)
 	{
 		loadKeyMap();									// get the current mappings.
 	}
 
-	parent->attach(KeyMapForm::make(ingame));
+	parent->attach(KeyMapForm::make(isInGame));
 
 	/* Stop when the right number or when alphabetically last - not sure...! */
 	/* Go home... */
@@ -408,12 +408,12 @@ bool loadKeyMap()
 	return true;
 }
 
-void KeyMapForm::initialize(bool ingame)
+void KeyMapForm::initialize(bool isInGame)
 {
 	id = KM_FORM;
 
 	attach(keyMapList = ScrollableListWidget::make());
-	if (!ingame)
+	if (!isInGame)
 	{
 		setCalcLayout(LAMBDA_CALCLAYOUT_SIMPLE({
 			psWidget->setGeometry(KM_X, KM_Y, KM_W, KM_H);

--- a/src/keymap.cpp
+++ b/src/keymap.cpp
@@ -735,9 +735,9 @@ static bool checkQwertyKeys()
 			aquired = true;
 
 			/* Store away the position and view angle */
-			qwertyKeyMappings[tableEntry].xPos = player.p.x;
-			qwertyKeyMappings[tableEntry].yPos = player.p.z;
-			qwertyKeyMappings[tableEntry].spin = player.r.y;
+			qwertyKeyMappings[tableEntry].xPos = playerPos.p.x;
+			qwertyKeyMappings[tableEntry].yPos = playerPos.p.z;
+			qwertyKeyMappings[tableEntry].spin = playerPos.r.y;
 		}
 	}
 	return aquired;
@@ -818,8 +818,8 @@ void keyProcessMappings(bool bExclude)
 					continue;
 				}
 
-				bool bIsKeyCombination = otherKey->metaKeyCode != KEY_IGNORE;
-				if (bIsKeyCombination && keyPressed(otherKey->subKeyCode))
+				bool bIsOtherKeyCombination = otherKey->metaKeyCode != KEY_IGNORE;
+				if (bIsOtherKeyCombination && keyPressed(otherKey->subKeyCode))
 				{
 					bool bHasAlt = otherKey->altMetaKeyCode != KEY_IGNORE;
 					if (keyDown(otherKey->metaKeyCode) || (bHasAlt && keyDown(otherKey->altMetaKeyCode)))

--- a/src/levels.cpp
+++ b/src/levels.cpp
@@ -189,7 +189,7 @@ Sha256 levGetMapNameHash(char const *mapName)
 // parse a level description data file
 // the ignoreWrf hack is for compatibility with old maps that try to link in various
 // data files that we have removed
-bool levParse(const char *buffer, size_t size, searchPathMode datadir, bool ignoreWrf, char const *realFileName)
+bool levParse(const char *buffer, size_t size, searchPathMode pathMode, bool ignoreWrf, char const *realFileName)
 {
 	lexerinput_t input;
 	LEVELPARSER_STATE state;
@@ -230,7 +230,7 @@ bool levParse(const char *buffer, size_t size, searchPathMode datadir, bool igno
 				memset(psDataSet, 0, sizeof(LEVEL_DATASET));
 				psDataSet->players = 1;
 				psDataSet->game = -1;
-				psDataSet->dataDir = datadir;
+				psDataSet->dataDir = pathMode;
 				psDataSet->realFileName = realFileName != nullptr ? strdup(realFileName) : nullptr;
 				psDataSet->realFileHash.setZero();  // The hash is only calculated on demand; for example, if the map name matches.
 				psLevels.push_back(psDataSet);

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -465,7 +465,7 @@ static void rotFlip(int tile, int *i, int *j)
 {
 	int texture = TileNumber_texture(tile);
 	int rot;
-	int map[2][2], invmap[4][2];
+	int tmpMap[2][2], invmap[4][2];
 
 	if (texture & TILE_XFLIP)
 	{
@@ -476,11 +476,11 @@ static void rotFlip(int tile, int *i, int *j)
 		*j = 1 - *j;
 	}
 
-	map[0][0] = 0; invmap[0][0] = 0; invmap[0][1] = 0;
-	map[1][0] = 1; invmap[1][0] = 1; invmap[1][1] = 0;
-	map[1][1] = 2; invmap[2][0] = 1; invmap[2][1] = 1;
-	map[0][1] = 3; invmap[3][0] = 0; invmap[3][1] = 1;
-	rot = map[*i][*j];
+	tmpMap[0][0] = 0; invmap[0][0] = 0; invmap[0][1] = 0;
+	tmpMap[1][0] = 1; invmap[1][0] = 1; invmap[1][1] = 0;
+	tmpMap[1][1] = 2; invmap[2][0] = 1; invmap[2][1] = 1;
+	tmpMap[0][1] = 3; invmap[3][0] = 0; invmap[3][1] = 1;
+	rot = tmpMap[*i][*j];
 	rot -= (texture & TILE_ROTMASK) >> TILE_ROTSHIFT;
 	while (rot < 0)
 	{
@@ -828,17 +828,17 @@ bool mapLoad(char const *filename, bool preview)
 	/* Load in the map data */
 	for (int i = 0; i < mapWidth * mapHeight; ++i)
 	{
-		UWORD	texture;
-		UBYTE	height;
+		UWORD	tileTexture;
+		UBYTE	tileHeight;
 
-		if (!PHYSFS_readULE16(fp, &texture) || !PHYSFS_readULE8(fp, &height))
+		if (!PHYSFS_readULE16(fp, &tileTexture) || !PHYSFS_readULE8(fp, &tileHeight))
 		{
 			debug(LOG_ERROR, "%s: Error during savegame load", filename);
 			goto failure;
 		}
 
-		psMapTiles[i].texture = texture;
-		psMapTiles[i].height = height * ELEVATION_SCALE;
+		psMapTiles[i].texture = tileTexture;
+		psMapTiles[i].height = tileHeight * ELEVATION_SCALE;
 
 		// Visibility stuff
 		memset(psMapTiles[i].watchers, 0, sizeof(psMapTiles[i].watchers));

--- a/src/message.cpp
+++ b/src/message.cpp
@@ -569,7 +569,7 @@ WzString *loadViewData(const char *pViewMsgData, UDWORD bufferSize)
 			//read in the data for the sequences
 			for (unsigned dataInc = 0; dataInc < psViewReplay->seqList.size(); dataInc++)
 			{
-				int numText = 0;
+				int numSeqText = 0;
 
 				name[0] = '\0';
 				//load extradat for extended type only
@@ -579,7 +579,7 @@ WzString *loadViewData(const char *pViewMsgData, UDWORD bufferSize)
 					pViewMsgData += cnt;
 					//set the flag to default
 					psViewReplay->seqList[dataInc].flag = 0;
-					numText = count;
+					numSeqText = count;
 				}
 				else //extended type
 				{
@@ -587,12 +587,12 @@ WzString *loadViewData(const char *pViewMsgData, UDWORD bufferSize)
 					sscanf(pViewMsgData, ",%255[^,'\r\n],%u,%d%n", name, &count, &count2, &cnt);
 					pViewMsgData += cnt;
 					psViewReplay->seqList[dataInc].flag = (UBYTE)count;
-					numText = count2;
+					numSeqText = count2;
 				}
 				psViewReplay->seqList[dataInc].sequenceName = name;
 
 				//get the text strings for this sequence - if any
-				for (unsigned seqInc = 0; seqInc < numText; seqInc++)
+				for (unsigned seqInc = 0; seqInc < numSeqText; seqInc++)
 				{
 					name[0] = '\0';
 					sscanf(pViewMsgData, ",%255[^,'\r\n]%n", name, &cnt);

--- a/src/mission.cpp
+++ b/src/mission.cpp
@@ -755,8 +755,8 @@ static void saveMissionData()
 	mission.apsSensorList[0] = apsSensorList[0];
 	mission.apsOilList[0] = apsOilList[0];
 
-	mission.playerX = player.p.x;
-	mission.playerY = player.p.z;
+	mission.playerX = playerPos.p.x;
+	mission.playerY = playerPos.p.z;
 
 	//save the power settings
 	saveMissionPower();

--- a/src/multiint.cpp
+++ b/src/multiint.cpp
@@ -910,9 +910,9 @@ std::vector<JoinConnectionDescription> findLobbyGame(const std::string& lobbyAdd
 		setLobbyError(ERROR_NOERROR);
 	}
 
-	GAMESTRUCT game;
-	memset(&game, 0x00, sizeof(game));
-	if (!NETfindGame(lobbyGameId, game))
+	GAMESTRUCT lobbyGame;
+	memset(&lobbyGame, 0x00, sizeof(lobbyGame));
+	if (!NETfindGame(lobbyGameId, lobbyGame))
 	{
 		// failed to get list of games from lobby server
 		debug(LOG_ERROR, "Failed to find gameId in lobby server");
@@ -927,23 +927,23 @@ std::vector<JoinConnectionDescription> findLobbyGame(const std::string& lobbyAdd
 		return {};
 	}
 
-	if (game.desc.dwSize == 0)
+	if (lobbyGame.desc.dwSize == 0)
 	{
 		debug(LOG_ERROR, "Invalid game struct");
 		cleanup();
 		return {};
 	}
 
-	if (game.gameId != lobbyGameId)
+	if (lobbyGame.gameId != lobbyGameId)
 	{
-		ASSERT(game.gameId == lobbyGameId, "NETfindGame returned a non-matching game"); // logic error
+		ASSERT(lobbyGame.gameId == lobbyGameId, "NETfindGame returned a non-matching game"); // logic error
 		cleanup();
 		return {};
 	}
 
 	// found the game id, but is it compatible?
 
-	if (!NETisCorrectVersion(game.game_version_major, game.game_version_minor))
+	if (!NETisCorrectVersion(lobbyGame.game_version_major, lobbyGame.game_version_minor))
 	{
 		// incompatible version
 		debug(LOG_ERROR, "Failed to find a matching + compatible game in the lobby server");
@@ -952,14 +952,14 @@ std::vector<JoinConnectionDescription> findLobbyGame(const std::string& lobbyAdd
 	}
 
 	// found the game
-	if (strlen(game.desc.host) == 0)
+	if (strlen(lobbyGame.desc.host) == 0)
 	{
 		debug(LOG_ERROR, "Found the game, but no host details available");
 		cleanup();
 		return {};
 	}
-	std::string host = game.desc.host;
-	return {JoinConnectionDescription(host, game.hostPort)};
+	std::string host = lobbyGame.desc.host;
+	return {JoinConnectionDescription(host, lobbyGame.hostPort)};
 }
 
 static JoinGameResult joinGameInternal(std::vector<JoinConnectionDescription> connection_list, std::shared_ptr<WzTitleUI> oldUI);

--- a/src/multiint.cpp
+++ b/src/multiint.cpp
@@ -660,6 +660,11 @@ void loadMapPreview(bool hideInterface)
 		plGroundL = WZCOL_TERC3_GROUND_LOW;
 		plGroundH = WZCOL_TERC3_GROUND_HIGH;
 		break;
+	default:
+		debug(LOG_FATAL, "Invalid tileset type");
+		// silence warnings
+		abort();
+		return;
 	}
 
 	oursize = sizeof(char) * BACKDROP_HACK_WIDTH * BACKDROP_HACK_HEIGHT;

--- a/src/multimenu.cpp
+++ b/src/multimenu.cpp
@@ -70,7 +70,7 @@ std::shared_ptr<W_SCREEN> psRScreen = nullptr; // requester stuff.
 extern char	MultiCustomMapsPath[PATH_MAX];
 
 bool	MultiMenuUp			= false;
-static UDWORD	context = 0;
+static UDWORD	current_context = 0;
 UDWORD	current_numplayers = 4;
 static std::string current_searchString;
 
@@ -404,7 +404,7 @@ void addMultiRequest(const char *searchDir, const char *fileExtension, UDWORD mo
 	const size_t extensionLength = strlen(fileExtension);
 	const unsigned int buttonsX = (mode == MULTIOP_MAP) ? 22 : 17;
 
-	context = mode;
+	current_context = mode;
 	if (mode == MULTIOP_MAP)
 	{
 		// only save these when they select MAP button
@@ -576,7 +576,7 @@ bool runMultiRequester(UDWORD id, UDWORD *mode, WzString *chosen, LEVEL_DATASET 
 	}
 
 	bool hoverPreview = false;
-	if (id == 0 && context == MULTIOP_MAP)
+	if (id == 0 && current_context == MULTIOP_MAP)
 	{
 		id = widgGetMouseOver(psRScreen);
 		if (id != hoverId)
@@ -597,7 +597,7 @@ bool runMultiRequester(UDWORD id, UDWORD *mode, WzString *chosen, LEVEL_DATASET 
 		DisplayRequestOptionData * pData = static_cast<DisplayRequestOptionData *>(((W_BUTTON *)widgGetFromID(psRScreen, id))->pUserData);
 		assert(pData != nullptr);
 		*chosenValue = (LEVEL_DATASET *)pData->pMapData;
-		*mode = context;
+		*mode = current_context;
 		*isHoverPreview = hoverPreview;
 		hoverPreviewId = id;
 		if (!hoverPreview)

--- a/src/multiopt.cpp
+++ b/src/multiopt.cpp
@@ -313,13 +313,13 @@ void recvOptions(NETQUEUE queue)
 
 // ////////////////////////////////////////////////////////////////////////////
 // Host Campaign.
-bool hostCampaign(char *sGame, char *sPlayer, bool skipResetAIs)
+bool hostCampaign(const char *SessionName, char *hostPlayerName, bool skipResetAIs)
 {
-	debug(LOG_WZ, "Hosting campaign: '%s', player: '%s'", sGame, sPlayer);
+	debug(LOG_WZ, "Hosting campaign: '%s', player: '%s'", SessionName, hostPlayerName);
 
 	freeMessages();
 
-	if (!NEThostGame(sGame, sPlayer, static_cast<SDWORD>(game.type), 0, 0, 0, game.maxPlayers))
+	if (!NEThostGame(SessionName, hostPlayerName, static_cast<SDWORD>(game.type), 0, 0, 0, game.maxPlayers))
 	{
 		return false;
 	}
@@ -334,7 +334,7 @@ bool hostCampaign(char *sGame, char *sPlayer, bool skipResetAIs)
 	}
 
 	NetPlay.players[selectedPlayer].ready = false;
-	sstrcpy(NetPlay.players[selectedPlayer].name, sPlayer);
+	sstrcpy(NetPlay.players[selectedPlayer].name, hostPlayerName);
 
 	ingame.localJoiningInProgress = true;
 	ingame.JoiningInProgress[selectedPlayer] = true;
@@ -342,7 +342,7 @@ bool hostCampaign(char *sGame, char *sPlayer, bool skipResetAIs)
 	bMultiMessages = true; // enable messages
 
 	PLAYERSTATS playerStats;
-	loadMultiStats(sPlayer, &playerStats);
+	loadMultiStats(hostPlayerName, &playerStats);
 	setMultiStats(selectedPlayer, playerStats, false);
 	setMultiStats(selectedPlayer, playerStats, true);
 	lookupRatingAsync(selectedPlayer);

--- a/src/multiplay.cpp
+++ b/src/multiplay.cpp
@@ -148,7 +148,7 @@ bool multiplayerWinSequence(bool firstCall)
 	if (MissionResUp && !getWarCamStatus())
 	{
 		rotAmount = graphicsTimeAdjustedIncrement(MAP_SPIN_RATE / 12);
-		player.r.y += rotAmount;
+		playerPos.r.y += rotAmount;
 	}
 
 	if (last > gameTime)

--- a/src/multiplay.h
+++ b/src/multiplay.h
@@ -232,7 +232,7 @@ bool sendDroidDisembark(DROID const *psTransporter, DROID const *psDroid);
 bool multiShutdown();
 bool sendLeavingMsg();
 
-bool hostCampaign(char *sGame, char *sPlayer, bool skipResetAIs);
+bool hostCampaign(const char *SessionName, char *hostPlayerName, bool skipResetAIs);
 struct JoinConnectionDescription
 {
 public:

--- a/src/qtscript.cpp
+++ b/src/qtscript.cpp
@@ -2115,9 +2115,9 @@ bool scripting_engine::writeLabels(const char *filename)
 			ini.setValue("triggered", l.triggered);
 			std::vector<WzString> list;
 			list.reserve(l.idlist.size());
-			for (int i : l.idlist)
+			for (int val : l.idlist)
 			{
-				list.push_back(WzString::number(i));
+				list.push_back(WzString::number(val));
 			}
 			ini.setValue("members", list);
 			ini.setValue("label", WzString::fromUtf8(key));

--- a/src/quickjs_backend.cpp
+++ b/src/quickjs_backend.cpp
@@ -2629,22 +2629,22 @@ static JSValue runMap_setMapData(JSContext *ctx, JSValueConst this_val, int argc
 	auto &data = *static_cast<ScriptMapData*>(pOpaque);
 	data.valid = false;
 	SCRIPT_ASSERT_AND_RETURNERROR(ctx, argc == 7, "Must have 7 parameters");
-	auto mapWidth = argv[0];
-	auto mapHeight = argv[1];
+	auto jsVal_mapWidth = argv[0];
+	auto jsVal_mapHeight = argv[1];
 	auto texture = argv[2];
 	auto height = argv[3];
 	auto structures = argv[4];
 	auto droids = argv[5];
 	auto features = argv[6];
-	SCRIPT_ASSERT_AND_RETURNERROR(ctx, JS_IsNumber(mapWidth), "mapWidth must be number");
-	SCRIPT_ASSERT_AND_RETURNERROR(ctx, JS_IsNumber(mapHeight), "mapHeight must be number");
+	SCRIPT_ASSERT_AND_RETURNERROR(ctx, JS_IsNumber(jsVal_mapWidth), "mapWidth must be number");
+	SCRIPT_ASSERT_AND_RETURNERROR(ctx, JS_IsNumber(jsVal_mapHeight), "mapHeight must be number");
 	SCRIPT_ASSERT_AND_RETURNERROR(ctx, JS_IsArray(ctx, texture), "texture must be array");
 	SCRIPT_ASSERT_AND_RETURNERROR(ctx, JS_IsArray(ctx, height), "height must be array");
 	SCRIPT_ASSERT_AND_RETURNERROR(ctx, JS_IsArray(ctx, structures), "structures must be array");
 	SCRIPT_ASSERT_AND_RETURNERROR(ctx, JS_IsArray(ctx, droids), "droids must be array");
 	SCRIPT_ASSERT_AND_RETURNERROR(ctx, JS_IsArray(ctx, features), "features must be array");
-	data.mapWidth = JSValueToInt32(ctx, mapWidth);
-	data.mapHeight = JSValueToInt32(ctx, mapHeight);
+	data.mapWidth = JSValueToInt32(ctx, jsVal_mapWidth);
+	data.mapHeight = JSValueToInt32(ctx, jsVal_mapHeight);
 	SCRIPT_ASSERT_AND_RETURNERROR(ctx, data.mapWidth > 1 && data.mapHeight > 1 && (uint64_t)data.mapWidth*data.mapHeight <= 65536, "Map size out of bounds");
 	size_t N = (size_t)data.mapWidth*data.mapHeight;
 	data.texture.resize(N);
@@ -3116,9 +3116,9 @@ bool quickjs_scripting_instance::debugEvaluateCommand(const std::string &text)
 	return true;
 }
 
-void quickjs_scripting_instance::updateGameTime(uint32_t gameTime)
+void quickjs_scripting_instance::updateGameTime(uint32_t newGameTime)
 {
-	int ret = JS_DefinePropertyValueStr(ctx, global_obj, "gameTime", JS_NewUint32(ctx, gameTime), JS_PROP_WRITABLE | JS_PROP_ENUMERABLE);
+	int ret = JS_DefinePropertyValueStr(ctx, global_obj, "gameTime", JS_NewUint32(ctx, newGameTime), JS_PROP_WRITABLE | JS_PROP_ENUMERABLE);
 	ASSERT(ret >= 1, "Failed to update gameTime");
 }
 

--- a/src/radar.cpp
+++ b/src/radar.cpp
@@ -237,7 +237,7 @@ void CalcRadarPosition(int mX, int mY, int *PosX, int *PosY)
 	pos.y = mY - radarCenterY;
 	if (rotateRadar)
 	{
-		pos = Vector2f_Rotate2f(pos, -player.r.y);
+		pos = Vector2f_Rotate2f(pos, -playerPos.r.y);
 	}
 	pos.x += radarWidth / 2.0;
 	pos.y += radarHeight / 2.0;
@@ -270,7 +270,7 @@ void drawRadar()
 	ASSERT_OR_RETURN(, radarBuffer, "No radar buffer allocated");
 
 	setViewingWindow();
-	playerpos = player.p; // cache position
+	playerpos = playerPos.p; // cache position
 
 	if (frameSkip <= 0)
 	{
@@ -285,7 +285,7 @@ void drawRadar()
 	if (rotateRadar)
 	{
 		// rotate the map
-		radarMatrix *= glm::rotate(UNDEG(player.r.y), glm::vec3(0.f, 0.f, 1.f));
+		radarMatrix *= glm::rotate(UNDEG(playerPos.r.y), glm::vec3(0.f, 0.f, 1.f));
 		if (radarRotationArrow)
 		{
 			DrawNorth(orthoMatrix * radarMatrix);
@@ -302,7 +302,7 @@ static void DrawNorth(const glm::mat4 &modelViewProjectionMatrix)
 	iV_DrawImage(IntImages, RADAR_NORTH, -((radarWidth / 2.0) + iV_GetImageWidth(IntImages, RADAR_NORTH) + 1), -(radarHeight / 2.0), modelViewProjectionMatrix);
 }
 
-static PIELIGHT appliedRadarColour(RADAR_DRAW_MODE radarDrawMode, MAPTILE *WTile)
+static PIELIGHT appliedRadarColour(RADAR_DRAW_MODE drawMode, MAPTILE *WTile)
 {
 	PIELIGHT WScr = WZCOL_BLACK;	// squelch warning
 
@@ -312,7 +312,7 @@ static PIELIGHT appliedRadarColour(RADAR_DRAW_MODE radarDrawMode, MAPTILE *WTile
 		return WZCOL_TRANSPARENT_BOX;
 	}
 
-	switch (radarDrawMode)
+	switch (drawMode)
 	{
 	case RADAR_MODE_TERRAIN:
 		{
@@ -420,7 +420,6 @@ static void DrawRadarObjects()
 	UBYTE				clan;
 	PIELIGHT			playerCol;
 	PIELIGHT			flashCol;
-	int				x, y;
 
 	/* Show droids on map - go through all players */
 	for (clan = 0; clan < MAX_PLAYERS; clan++)
@@ -479,9 +478,9 @@ static void DrawRadarObjects()
 	}
 
 	/* Do the same for structures */
-	for (x = scrollMinX; x < scrollMaxX; x++)
+	for (SDWORD x = scrollMinX; x < scrollMaxX; x++)
 	{
-		for (y = scrollMinY; y < scrollMaxY; y++)
+		for (SDWORD y = scrollMinY; y < scrollMaxY; y++)
 		{
 			MAPTILE		*psTile = mapTile(x, y);
 			STRUCTURE	*psStruct;
@@ -566,7 +565,7 @@ static SDWORD getDistanceAdjust()
 
 static SDWORD getLengthAdjust()
 {
-	const int pitch = 360 - (player.r.x / DEG_1);
+	const int pitch = 360 - (playerPos.r.x / DEG_1);
 
 	// Max at
 	const int lookingDown = (0 - MIN_PLAYER_X_ANGLE);
@@ -591,8 +590,8 @@ static void setViewingWindow()
 	int	dif2 = getLengthAdjust();
 	PIELIGHT colour;
 	CalcRadarPixelSize(&pixSizeH, &pixSizeV);
-	int x = player.p.x * pixSizeH / TILE_UNITS;
-	int y = player.p.z * pixSizeV / TILE_UNITS;
+	int x = playerPos.p.x * pixSizeH / TILE_UNITS;
+	int y = playerPos.p.z * pixSizeV / TILE_UNITS;
 
 	shortX = ((visibleTiles.x / 4) - (dif / 6)) * pixSizeH;
 	longX = ((visibleTiles.x / 2) - (dif / 4)) * pixSizeH;
@@ -614,7 +613,7 @@ static void setViewingWindow()
 	centre.x = x - scrollMinX * pixSizeH;
 	centre.y = y - scrollMinY * pixSizeV;
 
-	RotateVector2D(v, tv, &centre, player.r.y, 4);
+	RotateVector2D(v, tv, &centre, playerPos.r.y, 4);
 
 	switch (getCampaignNumber())
 	{
@@ -658,7 +657,7 @@ bool CoordInRadar(int x, int y)
 	pos.y = y - radarCenterY;
 	if (rotateRadar)
 	{
-		pos = Vector2f_Rotate2f(pos, -player.r.y);
+		pos = Vector2f_Rotate2f(pos, -playerPos.r.y);
 	}
 	pos.x += radarWidth / 2.0;
 	pos.y += radarHeight / 2.0;

--- a/src/seqdisp.cpp
+++ b/src/seqdisp.cpp
@@ -279,7 +279,7 @@ bool seq_UpdateFullScreenVideo(int *pbClear)
 	unsigned int subMax = SUBTITLE_BOX_MIN + D_H2;
 
 	//get any text lines over bottom of the video
-	double realTime = seq_GetFrameTime();
+	double frameTime = seq_GetFrameTime();
 	for (i = 0; i < MAX_TEXT_OVERLAYS; i++)
 	{
 		SEQTEXT seqtext = aSeqList[currentPlaySeq].aText[i];
@@ -287,7 +287,7 @@ bool seq_UpdateFullScreenVideo(int *pbClear)
 		{
 			if (seqtext.bSubtitle)
 			{
-				if (((realTime >= seqtext.startTime) && (realTime <= seqtext.endTime)) ||
+				if (((frameTime >= seqtext.startTime) && (frameTime <= seqtext.endTime)) ||
 				    aSeqList[currentPlaySeq].bSeqLoop) //if its a looped video always draw the text
 				{
 					if (subMin > seqtext.y && seqtext.y > SUBTITLE_BOX_MIN)
@@ -301,7 +301,7 @@ bool seq_UpdateFullScreenVideo(int *pbClear)
 				}
 			}
 
-			if (realTime >= seqtext.endTime && realTime < seqtext.endTime)
+			if (frameTime >= seqtext.endTime && frameTime < seqtext.endTime)
 			{
 				if (pbClear != nullptr)
 				{
@@ -331,14 +331,14 @@ bool seq_UpdateFullScreenVideo(int *pbClear)
 	//call sequence player to download last frame
 	stillPlaying = seq_Update();
 	//print any text over the video
-	realTime = seq_GetFrameTime();
+	frameTime = seq_GetFrameTime();
 
 	for (i = 0; i < MAX_TEXT_OVERLAYS; i++)
 	{
 		SEQTEXT currentText = aSeqList[currentPlaySeq].aText[i];
 		if (currentText.pText[0] != '\0')
 		{
-			if (((realTime >= currentText.startTime) && (realTime <= currentText.endTime)) ||
+			if (((frameTime >= currentText.startTime) && (frameTime <= currentText.endTime)) ||
 			    (aSeqList[currentPlaySeq].bSeqLoop)) //if its a looped video always draw the text
 			{
 				if (i >= wzCachedSeqText.size())

--- a/src/structure.cpp
+++ b/src/structure.cpp
@@ -2563,7 +2563,6 @@ static void aiUpdateStructure(STRUCTURE *psStructure, bool isMission)
 	WEAPON_STATS		*psWStats;
 	bool				bDirect = false;
 	SDWORD				xdiff, ydiff, mindist, currdist;
-	UDWORD				i;
 	TARGET_ORIGIN tmpOrigin = ORIGIN_UNKNOWN;
 
 	CHECK_STRUCTURE(psStructure);
@@ -2586,7 +2585,7 @@ static void aiUpdateStructure(STRUCTURE *psStructure, bool isMission)
 	}
 	psStructure->prevTime = psStructure->time;
 	psStructure->time = gameTime;
-	for (i = 0; i < MAX(1, psStructure->numWeaps); ++i)
+	for (UDWORD i = 0; i < MAX(1, psStructure->numWeaps); ++i)
 	{
 		psStructure->asWeaps[i].prevRot = psStructure->asWeaps[i].rot;
 	}
@@ -2634,7 +2633,7 @@ static void aiUpdateStructure(STRUCTURE *psStructure, bool isMission)
 	if (psStructure->numWeaps > 0)
 	{
 		//structures always update their targets
-		for (i = 0; i < psStructure->numWeaps; i++)
+		for (UDWORD i = 0; i < psStructure->numWeaps; i++)
 		{
 			bDirect = proj_Direct(asWeaponStats + psStructure->asWeaps[i].nStat);
 			if (psStructure->asWeaps[i].nStat > 0 &&
@@ -2909,7 +2908,7 @@ static void aiUpdateStructure(STRUCTURE *psStructure, bool isMission)
 				{
 					mindist = (TILE_UNITS * 5 / 2) * (TILE_UNITS * 5 / 2);
 
-					for (i = 0; i < MAX_PLAYERS; i++)
+					for (uint8_t i = 0; i < MAX_PLAYERS; i++)
 					{
 						if (aiCheckAlliances(i, psStructure->player) && i != psStructure->player)
 						{
@@ -3148,7 +3147,7 @@ static void aiUpdateStructure(STRUCTURE *psStructure, bool isMission)
 				// Update allies research accordingly
 				if (game.type == LEVEL_TYPE::SKIRMISH && alliancesSharedResearch(game.alliance))
 				{
-					for (i = 0; i < MAX_PLAYERS; i++)
+					for (uint8_t i = 0; i < MAX_PLAYERS; i++)
 					{
 						if (alliances[i][psStructure->player] == ALLIANCE_FORMED)
 						{
@@ -3373,7 +3372,7 @@ static void aiUpdateStructure(STRUCTURE *psStructure, bool isMission)
 				if (pointsToAdd >= psDroid->weight) // amount required is a factor of the droid weight
 				{
 					// We should be fully loaded by now.
-					for (i = 0; i < psDroid->numWeaps; i++)
+					for (unsigned i = 0; i < psDroid->numWeaps; i++)
 					{
 						// set rearm value to no runs made
 						psDroid->asWeaps[i].usedAmmo = 0;
@@ -3384,7 +3383,7 @@ static void aiUpdateStructure(STRUCTURE *psStructure, bool isMission)
 				}
 				else
 				{
-					for (i = 0; i < psDroid->numWeaps; i++)		// rearm one weapon at a time
+					for (unsigned i = 0; i < psDroid->numWeaps; i++)		// rearm one weapon at a time
 					{
 						// Make sure it's a rearmable weapon (and so we don't divide by zero)
 						if (psDroid->asWeaps[i].usedAmmo > 0 && asWeaponStats[psDroid->asWeaps[i].nStat].upgrade[psDroid->player].numRounds > 0)
@@ -3552,7 +3551,7 @@ int gateCurrentOpenHeight(const STRUCTURE *psStructure, uint32_t time, int minim
 }
 
 /* The main update routine for all Structures */
-void structureUpdate(STRUCTURE *psBuilding, bool mission)
+void structureUpdate(STRUCTURE *psBuilding, bool bMission)
 {
 	UDWORD widthScatter, breadthScatter;
 	UDWORD emissionInterval, iPointsToAdd, iPointsRequired;
@@ -3561,7 +3560,7 @@ void structureUpdate(STRUCTURE *psBuilding, bool mission)
 
 	syncDebugStructure(psBuilding, '<');
 
-	if (psBuilding->flags.test(OBJECT_FLAG_DIRTY) && !mission)
+	if (psBuilding->flags.test(OBJECT_FLAG_DIRTY) && !bMission)
 	{
 		visTilesUpdate(psBuilding);
 		psBuilding->flags.set(OBJECT_FLAG_DIRTY, false);
@@ -3653,7 +3652,7 @@ void structureUpdate(STRUCTURE *psBuilding, bool mission)
 	//update the manufacture/research of the building once complete
 	if (psBuilding->status == SS_BUILT)
 	{
-		aiUpdateStructure(psBuilding, mission);
+		aiUpdateStructure(psBuilding, bMission);
 	}
 
 	if (psBuilding->status != SS_BUILT)
@@ -3664,7 +3663,7 @@ void structureUpdate(STRUCTURE *psBuilding, bool mission)
 		}
 	}
 
-	if (!mission)
+	if (!bMission)
 	{
 		if (psBuilding->status == SS_BEING_BUILT && psBuilding->buildRate == 0 && !structureHasModules(psBuilding))
 		{
@@ -3684,7 +3683,7 @@ void structureUpdate(STRUCTURE *psBuilding, bool mission)
 	}
 
 	/* Only add smoke if they're visible and they can 'burn' */
-	if (!mission && psBuilding->visible[selectedPlayer] && canSmoke(psBuilding))
+	if (!bMission && psBuilding->visible[selectedPlayer] && canSmoke(psBuilding))
 	{
 		const int32_t damage = getStructureDamage(psBuilding);
 
@@ -3765,7 +3764,7 @@ void structureUpdate(STRUCTURE *psBuilding, bool mission)
 			                                                 aDefaultRepair[psBuilding->player])->time);
 
 			//add the blue flashing effect for multiPlayer
-			if (bMultiPlayer && ONEINTEN && !mission)
+			if (bMultiPlayer && ONEINTEN && !bMission)
 			{
 				Vector3i position;
 				Vector3f *point;
@@ -3832,7 +3831,7 @@ fills the list with Structure that can be built. There is a limit on how many ca
 be built at any one time. Pass back the number available.
 There is now a limit of how many of each type of structure are allowed per mission
 */
-std::vector<STRUCTURE_STATS *> fillStructureList(UDWORD selectedPlayer, UDWORD limit, bool showFavorites)
+std::vector<STRUCTURE_STATS *> fillStructureList(UDWORD _selectedPlayer, UDWORD limit, bool showFavorites)
 {
 	std::vector<STRUCTURE_STATS *> structureList;
 	UDWORD			inc;
@@ -3846,7 +3845,7 @@ std::vector<STRUCTURE_STATS *> fillStructureList(UDWORD selectedPlayer, UDWORD l
 	//if currently on a mission can't build factory/research/power/derricks
 	if (!missionIsOffworld())
 	{
-		for (psCurr = apsStructLists[selectedPlayer]; psCurr != nullptr; psCurr = psCurr->psNext)
+		for (psCurr = apsStructLists[_selectedPlayer]; psCurr != nullptr; psCurr = psCurr->psNext)
 		{
 			if (psCurr->pStructureType->type == REF_RESEARCH && psCurr->status == SS_BUILT)
 			{
@@ -3867,10 +3866,10 @@ std::vector<STRUCTURE_STATS *> fillStructureList(UDWORD selectedPlayer, UDWORD l
 	for (inc = 0; inc < numStructureStats; inc++)
 	{
 		//if the structure is flagged as available, add it to the list
-		if (apStructTypeLists[selectedPlayer][inc] == AVAILABLE || (includeRedundantDesigns && apStructTypeLists[selectedPlayer][inc] == REDUNDANT))
+		if (apStructTypeLists[_selectedPlayer][inc] == AVAILABLE || (includeRedundantDesigns && apStructTypeLists[_selectedPlayer][inc] == REDUNDANT))
 		{
 			//check not built the maximum allowed already
-			if (asStructureStats[inc].curCount[selectedPlayer] < asStructureStats[inc].upgrade[selectedPlayer].limit)
+			if (asStructureStats[inc].curCount[_selectedPlayer] < asStructureStats[inc].upgrade[_selectedPlayer].limit)
 			{
 				psBuilding = asStructureStats + inc;
 
@@ -3934,7 +3933,7 @@ std::vector<STRUCTURE_STATS *> fillStructureList(UDWORD selectedPlayer, UDWORD l
 					continue;
 				}
 
-				debug(LOG_NEVER, "adding %s (%x)", getStatsName(psBuilding), apStructTypeLists[selectedPlayer][inc]);
+				debug(LOG_NEVER, "adding %s (%x)", getStatsName(psBuilding), apStructTypeLists[_selectedPlayer][inc]);
 				structureList.push_back(psBuilding);
 				if (structureList.size() == limit)
 				{
@@ -6087,11 +6086,11 @@ void factoryProdAdjust(STRUCTURE *psStructure, DROID_TEMPLATE *psTemplate, bool 
 	else
 	{
 		//start off a new template
-		ProductionRunEntry entry;
-		entry.psTemplate = psTemplate;
-		entry.quantity = add ? 1 : MAX_IN_RUN; //wrap around to max value
-		entry.built = 0;
-		productionRun.push_back(entry);
+		ProductionRunEntry tmplEntry;
+		tmplEntry.psTemplate = psTemplate;
+		tmplEntry.quantity = add ? 1 : MAX_IN_RUN; //wrap around to max value
+		tmplEntry.built = 0;
+		productionRun.push_back(tmplEntry);
 	}
 	//if nothing is allocated then the current factory may have been cancelled
 	if (productionRun.empty())

--- a/src/structure.h
+++ b/src/structure.h
@@ -106,7 +106,7 @@ STRUCTURE *buildStructureDir(STRUCTURE_STATS *pStructureType, UDWORD x, UDWORD y
 /// Create a blueprint structure, with just enough information to render it
 STRUCTURE *buildBlueprint(STRUCTURE_STATS const *psStats, Vector3i xy, uint16_t direction, unsigned moduleIndex, STRUCT_STATES state);
 /* The main update routine for all Structures */
-void structureUpdate(STRUCTURE *psBuilding, bool mission);
+void structureUpdate(STRUCTURE *psBuilding, bool bMission);
 
 /* Remove a structure and free it's memory */
 bool destroyStruct(STRUCTURE *psDel, unsigned impactTime);

--- a/src/template.cpp
+++ b/src/template.cpp
@@ -438,13 +438,13 @@ bool loadDroidTemplates(const char *filename)
 		design.name = WzString::fromUtf8(droidResourceName != nullptr ? droidResourceName : GetDefaultTemplateName(&design));
 		ini.endGroup();
 
-		for (int i = 0; i < MAX_PLAYERS; ++i)
+		for (int playerIdx = 0; playerIdx < MAX_PLAYERS; ++playerIdx)
 		{
 			// Give those meant for humans to all human players.
-			if (NetPlay.players[i].allocated && available)
+			if (NetPlay.players[playerIdx].allocated && available)
 			{
 				design.prefab = false;
-				copyTemplate(i, &design);
+				copyTemplate(playerIdx, &design);
 
 				// This sets up the UI templates for display purposes ONLY--we still only use droidTemplates for making them.
 				// FIXME: Why are we doing this here, and not on demand ?
@@ -455,20 +455,20 @@ bool loadDroidTemplates(const char *filename)
 					DROID_TEMPLATE *psCurr = &*it;
 					if (psCurr->multiPlayerID == design.multiPlayerID)
 					{
-						debug(LOG_ERROR, "Design id:%d (%s) *NOT* added to UI list (duplicate), player= %d", design.multiPlayerID, getStatsName(&design), i);
+						debug(LOG_ERROR, "Design id:%d (%s) *NOT* added to UI list (duplicate), player= %d", design.multiPlayerID, getStatsName(&design), playerIdx);
 						break;
 					}
 				}
 				if (it == localTemplates.end())
 				{
-					debug(LOG_NEVER, "Design id:%d (%s) added to UI list, player =%d", design.multiPlayerID, getStatsName(&design), i);
+					debug(LOG_NEVER, "Design id:%d (%s) added to UI list, player =%d", design.multiPlayerID, getStatsName(&design), playerIdx);
 					localTemplates.push_back(design);
 				}
 			}
-			else if (!NetPlay.players[i].allocated)	// AI template
+			else if (!NetPlay.players[playerIdx].allocated)	// AI template
 			{
 				design.prefab = true;  // prefabricated templates referenced from VLOs
-				copyTemplate(i, &design);
+				copyTemplate(playerIdx, &design);
 			}
 		}
 		debug(LOG_NEVER, "Droid template found, Name: %s, MP ID: %d, ref: %u, ID: %s, prefab: %s, type:%d (loading)",

--- a/src/terrain.cpp
+++ b/src/terrain.cpp
@@ -1023,8 +1023,8 @@ static void updateLightMap()
 			if (!pie_GetFogStatus())
 			{
 				// fade to black at the edges of the visible terrain area
-				const float playerX = map_coordf(player.p.x);
-				const float playerY = map_coordf(player.p.z);
+				const float playerX = map_coordf(playerPos.p.x);
+				const float playerY = map_coordf(playerPos.p.z);
 
 				const float distA = i - (playerX - visibleTiles.x / 2);
 				const float distB = (playerX + visibleTiles.x / 2) - i;
@@ -1074,7 +1074,7 @@ static void cullTerrain()
 		{
 			float xPos = world_coord(x * sectorSize + sectorSize / 2);
 			float yPos = world_coord(y * sectorSize + sectorSize / 2);
-			float distance = pow(player.p.x - xPos, 2) + pow(player.p.z - yPos, 2);
+			float distance = pow(playerPos.p.x - xPos, 2) + pow(playerPos.p.z - yPos, 2);
 
 			if (distance > pow((double)world_coord(terrainDistance), 2))
 			{

--- a/src/titleui/gamefind.cpp
+++ b/src/titleui/gamefind.cpp
@@ -369,7 +369,6 @@ void WzGameFindTitleUI::addGames()
 		// display lobby message based on results.
 		// This is a 'button', not text so it can be hilighted/centered.
 		const char *txt;
-		W_BUTINIT sButInit;
 
 		switch (getLobbyError())
 		{
@@ -554,10 +553,10 @@ void displayRemoteGame(WIDGET *psWidget, UDWORD xOffset, UDWORD yOffset)
 	if (strlen(gamesList[gameID].modlist))
 	{
 		// FIXME: we really don't have enough space to list all mods
-		char tmp[300];
-		ssprintf(tmp, _("Mods: %s"), gamesList[gameID].modlist);
-		tmp[StringSize] = '\0';
-		sstrcpy(name, tmp);
+		char tmpMods[300];
+		ssprintf(tmpMods, _("Mods: %s"), gamesList[gameID].modlist);
+		tmpMods[StringSize] = '\0';
+		sstrcpy(name, tmpMods);
 	}
 	else
 	{

--- a/src/updatemanager.cpp
+++ b/src/updatemanager.cpp
@@ -101,12 +101,12 @@ std::string WzUpdateManager::configureUpdateLinkURL(const std::string& url, Buil
 
 	std::vector<std::string> tokens;
 	re2::StringPiece input(url);
-	std::string token;
+	std::string tmpToken;
 
 	RE2 re("({{[\\S]+}})");
-	while (RE2::FindAndConsume(&input, re, &token))
+	while (RE2::FindAndConsume(&input, re, &tmpToken))
 	{
-		tokens.push_back(token);
+		tokens.push_back(tmpToken);
 	}
 
 	std::string resultUrl = url;

--- a/src/warcam.cpp
+++ b/src/warcam.cpp
@@ -398,14 +398,14 @@ void	camAlignWithTarget(DROID *psDroid)
 	trackingCamera.target = psDroid;
 
 	/* Save away all the view angles */
-	trackingCamera.oldView.r.x = trackingCamera.rotation.x = (float)player.r.x;
-	trackingCamera.oldView.r.y = trackingCamera.rotation.y = (float)player.r.y;
-	trackingCamera.oldView.r.z = trackingCamera.rotation.z = (float)player.r.z;
+	trackingCamera.oldView.r.x = trackingCamera.rotation.x = (float)playerPos.r.x;
+	trackingCamera.oldView.r.y = trackingCamera.rotation.y = (float)playerPos.r.y;
+	trackingCamera.oldView.r.z = trackingCamera.rotation.z = (float)playerPos.r.z;
 
 	/* Store away the old positions and set the start position too */
-	trackingCamera.oldView.p.x = trackingCamera.position.x = (float)player.p.x;
-	trackingCamera.oldView.p.y = trackingCamera.position.y = (float)player.p.y;
-	trackingCamera.oldView.p.z = trackingCamera.position.z = (float)player.p.z;
+	trackingCamera.oldView.p.x = trackingCamera.position.x = (float)playerPos.p.x;
+	trackingCamera.oldView.p.y = trackingCamera.position.y = (float)playerPos.p.y;
+	trackingCamera.oldView.p.z = trackingCamera.position.z = (float)playerPos.p.z;
 
 	//	trackingCamera.rotation.x = player.r.x = DEG(-90);
 	/* No initial velocity for moving */
@@ -536,7 +536,7 @@ static void updateCameraAcceleration(UBYTE update)
 		that we need to find an offset point from it relative to it's present
 		direction
 	*/
-	const int angle = 90 - abs((player.r.x / 182) % 90);
+	const int angle = 90 - abs((playerPos.r.x / 182) % 90);
 
 	const PROPULSION_STATS *psPropStats = &asPropulsionStats[trackingCamera.target->asBits[COMP_PROPULSION]];
 
@@ -840,19 +840,19 @@ static bool camTrackCamera()
 	}
 
 	/* Update the position that's now stored in trackingCamera.position */
-	player.p.x = trackingCamera.position.x;
-	player.p.y = trackingCamera.position.y;
-	player.p.z = trackingCamera.position.z;
+	playerPos.p.x = trackingCamera.position.x;
+	playerPos.p.y = trackingCamera.position.y;
+	playerPos.p.z = trackingCamera.position.z;
 
 	/* Update the rotations that're now stored in trackingCamera.rotation */
-	player.r.x = trackingCamera.rotation.x;
-	player.r.y = trackingCamera.rotation.y;
-	player.r.z = trackingCamera.rotation.z;
+	playerPos.r.x = trackingCamera.rotation.x;
+	playerPos.r.y = trackingCamera.rotation.y;
+	playerPos.r.z = trackingCamera.rotation.z;
 
 	/* There's a minimum for this - especially when John's VTOL code lets them land vertically on cliffs */
-	if (player.r.x > DEG(360 + MAX_PLAYER_X_ANGLE))
+	if (playerPos.r.x > DEG(360 + MAX_PLAYER_X_ANGLE))
 	{
-		player.r.x = DEG(360 + MAX_PLAYER_X_ANGLE);
+		playerPos.r.x = DEG(360 + MAX_PLAYER_X_ANGLE);
 	}
 
 	/* Clip the position to the edge of the map */
@@ -874,8 +874,8 @@ static void camRadarJump()
 {
 	radarJumpAnimation.position.update();
 	radarJumpAnimation.rotation.update();
-	player.p = radarJumpAnimation.position.getCurrent();
-	player.r = radarJumpAnimation.rotation.getCurrent();
+	playerPos.p = radarJumpAnimation.position.getCurrent();
+	playerPos.r = radarJumpAnimation.rotation.getCurrent();
 
 	if (!radarJumpAnimation.position.isActive() && !radarJumpAnimation.rotation.isActive())
 	{
@@ -949,10 +949,10 @@ void	camToggleInfo()
 /* Informs the tracking camera that we want to start tracking to a new radar target */
 void requestRadarTrack(SDWORD x, SDWORD y)
 {
-	auto initialPosition = Vector3f(player.p);
+	auto initialPosition = Vector3f(playerPos.p);
 	auto targetPosition = Vector3f(x, calculateCameraHeightAt(map_coord(x), map_coord(y)), y);
 	auto animationDuration = glm::log(glm::length(targetPosition - initialPosition)) * 100;
-	auto finalRotation = trackingCamera.status == CAM_TRACK_DROID ? trackingCamera.oldView.r : player.r;
+	auto finalRotation = trackingCamera.status == CAM_TRACK_DROID ? trackingCamera.oldView.r : playerPos.r;
 	finalRotation.z = 0;
 
 	radarJumpAnimation.position
@@ -962,7 +962,7 @@ void requestRadarTrack(SDWORD x, SDWORD y)
 		.start();
 
 	radarJumpAnimation.rotation
-		.setInitialData(player.r)
+		.setInitialData(playerPos.r)
 		.setFinalData(finalRotation)
 		.setDuration(animationDuration)
 		.start();

--- a/src/wavecast.cpp
+++ b/src/wavecast.cpp
@@ -89,7 +89,9 @@ static std::vector<WavecastTile> generateWavecastTable(unsigned radius)
 				case 2: tile.dx = -diamond + s + 1; tile.dy =          - s;     break;
 				case 3: tile.dx =            s + 1; tile.dy = -diamond + s + 1; break;
 				default:
-					debug(LOG_FATAL, "quadrant is unexpected value: %u", quadrant); // Silence later MSVC warning C4701: potentially uninitialized local variable 'tile' used
+					debug(LOG_FATAL, "quadrant is unexpected value: %u", quadrant);
+					// Silence later MSVC warning C4701: potentially uninitialized local variable 'tile' used
+					abort();
 				}
 
 #if defined( _MSC_VER )

--- a/src/wzapi.cpp
+++ b/src/wzapi.cpp
@@ -2604,21 +2604,21 @@ wzapi::no_return_value wzapi::setTutorialMode(WZAPI_PARAMS(bool tutorialMode))
 //--
 //-- Whether to allow player to design stuff.
 //--
-wzapi::no_return_value wzapi::setDesign(WZAPI_PARAMS(bool allowDesign))
+wzapi::no_return_value wzapi::setDesign(WZAPI_PARAMS(bool allowDesignValue))
 {
 	DROID_TEMPLATE *psCurr;
 	// Switch on or off future templates
 	// FIXME: This dual data structure for templates is just plain insane.
-	enumerateTemplates(selectedPlayer, [allowDesign](DROID_TEMPLATE * psTempl) {
+	enumerateTemplates(selectedPlayer, [allowDesignValue](DROID_TEMPLATE * psTempl) {
 		bool researched = researchedTemplate(psTempl, selectedPlayer, true);
-		psTempl->enabled = (researched || allowDesign);
+		psTempl->enabled = (researched || allowDesignValue);
 		return true;
 	});
 	for (auto &localTemplate : localTemplates)
 	{
 		psCurr = &localTemplate;
 		bool researched = researchedTemplate(psCurr, selectedPlayer, true);
-		psCurr->enabled = (researched || allowDesign);
+		psCurr->enabled = (researched || allowDesignValue);
 	}
 	return {};
 }

--- a/src/wzscriptdebug.cpp
+++ b/src/wzscriptdebug.cpp
@@ -673,13 +673,13 @@ public:
 		}
 		panel->aiPlayerDropdown->setSelectedIndex(0);
 		panel->aiPlayerDropdown->setCalcLayout([maxButtonTextWidth](WIDGET *psWidget, unsigned int, unsigned int, unsigned int, unsigned int){
-			auto aiPlayerDropdown = static_cast<DropdownWidget *>(psWidget);
+			auto pAiPlayerDropdown = static_cast<DropdownWidget *>(psWidget);
 			auto psParent = std::dynamic_pointer_cast<WzMainPanel>(psWidget->parent());
 			ASSERT_OR_RETURN(, psParent != nullptr, "No parent");
-			int width = maxButtonTextWidth + aiPlayerDropdown->getScrollbarWidth();
+			int width = maxButtonTextWidth + pAiPlayerDropdown->getScrollbarWidth();
 			int x0 = psParent->aiAttachButton->x() - ACTION_BUTTON_SPACING - width;
 			int bottomOfPowerRow = psParent->powerEditField->y() + psParent->powerEditField->height() + ACTION_BUTTON_ROW_SPACING;
-			aiPlayerDropdown->setGeometry(x0, bottomOfPowerRow, width, TAB_BUTTONS_HEIGHT);
+			pAiPlayerDropdown->setGeometry(x0, bottomOfPowerRow, width, TAB_BUTTONS_HEIGHT);
 		});
 
 		// AI names dropdown
@@ -696,13 +696,13 @@ public:
 		}
 		panel->aiDropdown->setSelectedIndex(0);
 		panel->aiDropdown->setCalcLayout([](WIDGET *psWidget, unsigned int, unsigned int, unsigned int, unsigned int){
-			auto aiDropdown = static_cast<DropdownWidget *>(psWidget);
+			auto pAiDropdown = static_cast<DropdownWidget *>(psWidget);
 			auto psParent = std::dynamic_pointer_cast<WzMainPanel>(psWidget->parent());
 			ASSERT_OR_RETURN(, psParent != nullptr, "No parent");
 			int x0 = psParent->attachAItoPlayerLabel->x() + psParent->attachAItoPlayerLabel->width() + ACTION_BUTTON_SPACING;
 			int bottomOfPowerRow = psParent->powerEditField->y() + psParent->powerEditField->height() + ACTION_BUTTON_ROW_SPACING;
 			int fillWidth = psParent->aiPlayerDropdown->x() - ACTION_BUTTON_SPACING - x0;
-			aiDropdown->setGeometry(x0, bottomOfPowerRow, fillWidth, TAB_BUTTONS_HEIGHT);
+			pAiDropdown->setGeometry(x0, bottomOfPowerRow, fillWidth, TAB_BUTTONS_HEIGHT);
 		});
 
 		// JSONTable for main game state / info / model
@@ -715,8 +715,8 @@ public:
 			psWidget->setGeometry(0, y0, psParent->width(), psParent->height() - y0);
 		}));
 		panel->table->updateData(fillMainModel());
-		panel->table->setUpdateButtonFunc([](JSONTableWidget& table){
-			auto psParent = std::dynamic_pointer_cast<WzMainPanel>(table.parent());
+		panel->table->setUpdateButtonFunc([](JSONTableWidget& tableWidget){
+			auto psParent = std::dynamic_pointer_cast<WzMainPanel>(tableWidget.parent());
 			if (psParent == nullptr)
 			{
 				return;
@@ -875,8 +875,8 @@ public:
 			psWidget->setGeometry(0, y0, psParent->width(), psParent->runCommandButton->y() - ACTION_BUTTON_ROW_SPACING - y0);
 		}));
 
-		result->table->setUpdateButtonFunc([contextButtonMap](JSONTableWidget& table){
-			auto psParent = std::dynamic_pointer_cast<WzScriptContextsPanel>(table.parent());
+		result->table->setUpdateButtonFunc([contextButtonMap](JSONTableWidget& tableWidget){
+			auto psParent = std::dynamic_pointer_cast<WzScriptContextsPanel>(tableWidget.parent());
 			ASSERT_OR_RETURN(, psParent != nullptr, "No parent");
 			if (auto scriptDebuggerStrong = psParent->scriptDebugger.lock())
 			{
@@ -1012,8 +1012,8 @@ public:
 			int y0 = psParent->playersDropdown->y() + psParent->playersDropdown->height() + ACTION_BUTTON_ROW_SPACING;
 			psWidget->setGeometry(0, y0, psParent->width(), psParent->height() - y0);
 		}));
-		result->table->setUpdateButtonFunc([](JSONTableWidget& table){
-			auto psParent = std::dynamic_pointer_cast<WzScriptPlayersPanel>(table.parent());
+		result->table->setUpdateButtonFunc([](JSONTableWidget& tableWidget){
+			auto psParent = std::dynamic_pointer_cast<WzScriptPlayersPanel>(tableWidget.parent());
 			if (psParent == nullptr)
 			{
 				return;


### PR DESCRIPTION
While `-Wshadow` on GCC is currently too noisy, Clang 3.9+ is much more selective. So enable `-Wshadow` on Clang, fix the appropriate warnings, and fix similar issues / warnings on MSVC.

Also fix `C4701: Potentially uninitialized local variable 'name' used` warnings on MSVC.