### PR TITLE
Restore removed binary savegame data (since 3.4.1)

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -386,6 +386,15 @@ static bool serializeMultiplayerGame(PHYSFS_file *fileHandle, const MULTIPLAYERG
 		return false;
 	}
 
+	for (unsigned int i = 0; i < MAX_PLAYERS; ++i)
+	{
+		// dummy, was `skDiff` for each player
+		if (!PHYSFS_writeUBE8(fileHandle, 0))
+		{
+			return false;
+		}
+	}
+
 	return true;
 }
 
@@ -417,6 +426,15 @@ static bool deserializeMultiplayerGame(PHYSFS_file *fileHandle, MULTIPLAYERGAME 
 		return false;
 	}
 	challengeActive = dummy8;	// hack
+
+	for (unsigned int i = 0; i < MAX_PLAYERS; ++i)
+	{
+		// dummy, was `skDiff` for each player
+		if (!PHYSFS_readUBE8(fileHandle, &dummy8))
+		{
+			return false;
+		}
+	}
 
 	return true;
 }


### PR DESCRIPTION
When `skDiff` was removed in 2b3312e3b55714d6fc6da626baea785b4faf15a5, so was reading/writing the value into the binary savegame format.

Restore this with dummy values to try to preserve compatibility with loading saves from 3.4.1.