### PR TITLE
Fix loading progress bar from in-game load

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -951,7 +951,7 @@ static bool initSaveGameLoad()
 {
 	// NOTE: always setGameMode correctly before *any* loading routines!
 	SetGameMode(GS_NORMAL);
-	screen_RestartBackDrop();
+	initLoadingScreen(true);
 
 	// load up a save game
 	if (!loadGameInit(saveGameName))


### PR DESCRIPTION
When loading a game from the in-game "Load Game" menu, the backdrop would display but the progress bar would not.