### PR TITLE
Separate COMPONENT_STATS and STRUCTURE_STATS handling

### DIFF
--- a/src/research.cpp
+++ b/src/research.cpp
@@ -186,7 +186,7 @@ bool loadResearch(WzConfig &ini)
 		if (statID.compare("") != 0)
 		{
 			//try find the structure stat with given name
-			research.psStat = getCompStatsFromName(statID);
+			research.psStat = getStructStatsFromName(statID);
 			ASSERT_OR_RETURN(false, research.psStat, "Could not find stats for %s research %s", statID.toUtf8().c_str(), getStatsName(&research));
 		}
 
@@ -491,12 +491,12 @@ std::vector<uint16_t> fillResearchList(UDWORD playerID, nonstd::optional<UWORD> 
 /* process the results of a completed research topic */
 void researchResult(UDWORD researchIndex, UBYTE player, bool bDisplay, STRUCTURE *psResearchFacility, bool bTrigger)
 {
-	RESEARCH                                       *pResearch = &asResearch[researchIndex];
+	ASSERT_OR_RETURN(, researchIndex < asResearch.size(), "Invalid research index %u", researchIndex);
+
+	RESEARCH                    *pResearch = &asResearch[researchIndex];
 	MESSAGE						*pMessage;
 	//the message gets sent to console
 	char						consoleMsg[MAX_RESEARCH_MSG_SIZE];
-
-	ASSERT_OR_RETURN(, researchIndex < asResearch.size(), "Invalid research index %u", researchIndex);
 
 	syncDebug("researchResult(%u, %u, …)", researchIndex, player);
 

--- a/src/research.cpp
+++ b/src/research.cpp
@@ -185,8 +185,8 @@ bool loadResearch(WzConfig &ini)
 		research.psStat = nullptr;
 		if (statID.compare("") != 0)
 		{
-			//try find the structure stat with given name
-			research.psStat = getStructStatsFromName(statID);
+			//try find the stat with given name
+			research.psStat = getBaseStatsFromName(statID);
 			ASSERT_OR_RETURN(false, research.psStat, "Could not find stats for %s research %s", statID.toUtf8().c_str(), getStatsName(&research));
 		}
 

--- a/src/stats.cpp
+++ b/src/stats.cpp
@@ -1336,7 +1336,7 @@ int getCompFromID(COMPONENT_TYPE compType, const WzString &name)
 	auto it = lookupCompStatPtr.find(WzString::fromUtf8(name.toUtf8().c_str()));
 	if (it != lookupCompStatPtr.end())
 	{
-		psComp = (COMPONENT_STATS *)it->second;
+		psComp = it->second;
 	}
 	ASSERT_OR_RETURN(-1, psComp, "No such component ID [%s] found", name.toUtf8().c_str());
 	ASSERT_OR_RETURN(-1, compType == psComp->compType, "Wrong component type for ID %s", name.toUtf8().c_str());
@@ -1352,7 +1352,7 @@ COMPONENT_STATS *getCompStatsFromName(const WzString &name)
 	auto it = lookupCompStatPtr.find(name);
 	if (it != lookupCompStatPtr.end())
 	{
-		psComp = (COMPONENT_STATS *)it->second;
+		psComp = it->second;
 	}
 	/*if (!psComp)
 	{

--- a/src/stats.cpp
+++ b/src/stats.cpp
@@ -1376,6 +1376,17 @@ STRUCTURE_STATS *getStructStatsFromName(const WzString &name)
 	return psStat;
 }
 
+BASE_STATS *getBaseStatsFromName(const WzString &name)
+{
+	BASE_STATS *psStat = nullptr;
+	auto it = lookupStatPtr.find(name);
+	if (it != lookupStatPtr.end())
+	{
+		psStat = it->second;
+	}
+	return psStat;
+}
+
 /*sets the store to the body size based on the name passed in - returns false
 if doesn't compare with any*/
 bool getBodySize(const WzString &size, BODY_SIZE *pStore)

--- a/src/stats.h
+++ b/src/stats.h
@@ -166,6 +166,9 @@ COMPONENT_STATS *getCompStatsFromName(const WzString &name);
 /// Get the structure pointer for a structure based on the name
 STRUCTURE_STATS *getStructStatsFromName(const WzString &name);
 
+/// Get the base stat pointer for a stat based on the name
+BASE_STATS *getBaseStatsFromName(const WzString &name);
+
 /*returns the weapon sub class based on the string name passed in */
 bool getWeaponSubClass(const char *subClass, WEAPON_SUBCLASS *wclass);
 const char *getWeaponSubClass(WEAPON_SUBCLASS wclass);

--- a/src/stats.h
+++ b/src/stats.h
@@ -105,7 +105,8 @@ bool statsAllocConstruct(UDWORD numEntries);
 /*******************************************************************************
 *		Load stats functions
 *******************************************************************************/
-void loadStats(WzConfig &json, BASE_STATS *psStats, size_t index);
+// Used from structure.cpp
+void loadStructureStats_BaseStats(WzConfig &json, STRUCTURE_STATS *psStats, size_t index);
 
 /*Load the weapon stats from the file exported from Access*/
 bool loadWeaponStats(WzConfig &ini);
@@ -161,6 +162,9 @@ int getCompFromID(COMPONENT_TYPE compType, const WzString &name);
 
 /// Get the component pointer for a component based on the name
 COMPONENT_STATS *getCompStatsFromName(const WzString &name);
+
+/// Get the structure pointer for a structure based on the name
+STRUCTURE_STATS *getStructStatsFromName(const WzString &name);
 
 /*returns the weapon sub class based on the string name passed in */
 bool getWeaponSubClass(const char *subClass, WEAPON_SUBCLASS *wclass);

--- a/src/structure.cpp
+++ b/src/structure.cpp
@@ -441,7 +441,7 @@ bool loadStructureStats(WzConfig &ini)
 	{
 		ini.beginGroup(list[inc]);
 		STRUCTURE_STATS *psStats = &asStructureStats[inc];
-		loadStats(ini, psStats, inc);
+		loadStructureStats_BaseStats(ini, psStats, inc);
 
 		psStats->ref = STAT_STRUCTURE + inc;
 
@@ -4550,7 +4550,7 @@ bool destroyStruct(STRUCTURE *psDel, unsigned impactTime)
 return the first one it finds!! */
 int32_t getStructStatFromName(const WzString &name)
 {
-	BASE_STATS *psStat = getCompStatsFromName(name);
+	STRUCTURE_STATS *psStat = getStructStatsFromName(name);
 	if (psStat)
 	{
 		return psStat->index;


### PR DESCRIPTION
Only components should be returned from `getCompStatsFromName`. Previously, depending on stats files, this could return structures.

This caused issues further down the line as
`struct STRUCTURE_STATS : public BASE_STATS { ... };`
was ultimately being treated as
`struct COMPONENT_STATS : public BASE_STATS { ... };`

Which led to fun memory trampling and other issues, exhibiting unpredictable behavior at run-time (but often leading to an eventual crash - sometimes in the resource manager code, sometimes elsewhere).

(The base / built-in stats files did not trigger this.)

This PR splits things out into three separate functions:
```
/// Get the component pointer for a component based on the name
COMPONENT_STATS *getCompStatsFromName(const WzString &name);

/// Get the structure pointer for a structure based on the name
STRUCTURE_STATS *getStructStatsFromName(const WzString &name);

/// Get the base stat pointer for a stat based on the name
BASE_STATS *getBaseStatsFromName(const WzString &name);
```

The latter searches all stats, the former two search only `COMPONENT_STATS` or `STRUCTURE_STATS` respectively.