### PR TITLE
Implement research cycle detection

### DIFF
--- a/data/mp/stats/research.json
+++ b/data/mp/stats/research.json
@@ -768,7 +768,7 @@
         "msgName": "RES_DEF_EMPM",
         "name": "EMP Mortar Pit",
         "requiredResearch": [
-            "R-Defense-EMPCannon"
+            "R-Wpn-MortarEMP"
         ],
         "researchPoints": 28800,
         "researchPower": 450,
@@ -8280,10 +8280,13 @@
         "msgName": "RES_W_M2",
         "name": "EMP Mortar",
         "requiredResearch": [
-            "R-Wpn-MortarEMP"
+            "R-Wpn-EMPCannon"
         ],
         "researchPoints": 20000,
         "researchPower": 450,
+        "resultComponents": [
+            "MortarEMP"
+        ],
         "statID": "MortarEMP"
     },
     "R-Wpn-PlasmaCannon": {

--- a/data/mp/stats/research.json
+++ b/data/mp/stats/research.json
@@ -67,9 +67,6 @@
         "keyTopic": 1,
         "msgName": "RES_C_SL1",
         "name": "Synaptic Link",
-        "requiredResearch": [
-            "R-Comp-SynapticLink"
-        ],
         "researchPoints": 1200,
         "researchPower": 37
     },
@@ -3489,9 +3486,6 @@
         "id": "R-Sys-Spade1Mk1",
         "keyTopic": 1,
         "name": "Construction Unit",
-        "requiredResearch": [
-            "R-Sys-Spade1Mk1"
-        ],
         "researchPoints": 10,
         "resultComponents": [
             "Spade1Mk1"
@@ -3806,9 +3800,6 @@
         "id": "R-Vehicle-Body01",
         "msgName": "RES_V_B01",
         "name": "Light Body - Viper",
-        "requiredResearch": [
-            "R-Vehicle-Body01"
-        ],
         "researchPoints": 600,
         "researchPower": 18,
         "resultComponents": [
@@ -4582,9 +4573,6 @@
         "id": "R-Vehicle-Prop-Wheels",
         "msgName": "RES_V_P_W1",
         "name": "Wheeled Propulsion",
-        "requiredResearch": [
-            "R-Vehicle-Prop-Wheels"
-        ],
         "researchPoints": 1200,
         "researchPower": 37,
         "resultComponents": [

--- a/src/research.cpp
+++ b/src/research.cpp
@@ -404,7 +404,8 @@ bool loadResearch(WzConfig &ini)
 		}
 	}
 
-	if (auto cycle = CycleDetection::detectCycle()) {
+	if (auto cycle = CycleDetection::detectCycle())
+	{
 		debug(LOG_ERROR, "A cycle was detected in the research dependency graph:");
 		for (auto research: cycle.value())
 		{


### PR DESCRIPTION
Resolves #1522.

When a cycle is detected in the research dependency graph, the game will terminate, and logs like the ones below will be shown:

```
error   |10:26:40: [loadResearch:408] A cycle was detected in the research dependency graph:
error   |10:26:40: [loadResearch:411] 	-> R-Sys-Engineering02
error   |10:26:40: [loadResearch:411] 	-> R-Sys-Resistance-Circuits
error   |10:26:40: [loadResearch:411] 	-> R-Sys-Engineering03
error   |10:26:40: [loadResearch:411] 	-> R-Sys-Engineering02
info    |10:26:40: [resLoadFile:550] The load function for resource type "RESCH" failed for file "research.json"
```
This mod can be used to test: [cycle_mod.wz.zip](https://github.com/Warzone2100/warzone2100/files/5975413/cycle_mod.wz.zip)

After installing it, just start a skirmish game and the game should crash.