### PR TITLE
Fix disappearing researches

### DIFF
--- a/src/hci/research.cpp
+++ b/src/hci/research.cpp
@@ -89,7 +89,7 @@ void ResearchController::refresh()
 	}
 }
 
-void ResearchController::startResearch(RESEARCH *research)
+void ResearchController::startResearch(RESEARCH &research)
 {
 	triggerEvent(TRIGGER_MENU_RESEARCH_SELECTED);
 
@@ -100,16 +100,9 @@ void ResearchController::startResearch(RESEARCH *research)
 
 	if (bMultiMessages)
 	{
-		if (research != nullptr)
-		{
-			// Say that we want to do research [sic].
-			sendResearchStatus(facility, research->ref - STAT_RESEARCH, selectedPlayer, true);
-			setStatusPendingStart(*psResFacilty, research);  // Tell UI that we are going to research.
-		}
-		else
-		{
-			cancelResearch(facility, ModeQueue);
-		}
+		// Say that we want to do research [sic].
+		sendResearchStatus(facility, research.ref - STAT_RESEARCH, selectedPlayer, true);
+		setStatusPendingStart(*psResFacilty, &research);  // Tell UI that we are going to research.
 
 		//stop the button from flashing once a topic has been chosen
 		stopReticuleButtonFlash(IDRET_RESEARCH);
@@ -120,22 +113,19 @@ void ResearchController::startResearch(RESEARCH *research)
 	psResFacilty->psSubject = nullptr;
 
 	//set up the player_research
-	if (research != nullptr)
-	{
-		auto count = research->ref - STAT_RESEARCH;
-		//meant to still be in the list but greyed out
-		auto pPlayerRes = &asPlayerResList[selectedPlayer][count];
+	auto count = research.ref - STAT_RESEARCH;
+	//meant to still be in the list but greyed out
+	auto pPlayerRes = &asPlayerResList[selectedPlayer][count];
 
-		//set the subject up
-		psResFacilty->psSubject = research;
+	//set the subject up
+	psResFacilty->psSubject = &research;
 
-		sendResearchStatus(facility, count, selectedPlayer, true);	// inform others, I'm researching this.
+	sendResearchStatus(facility, count, selectedPlayer, true);	// inform others, I'm researching this.
 
-		MakeResearchStarted(pPlayerRes);
-		psResFacilty->timeStartHold = 0;
-		//stop the button from flashing once a topic has been chosen
-		stopReticuleButtonFlash(IDRET_RESEARCH);
-	}
+	MakeResearchStarted(pPlayerRes);
+	psResFacilty->timeStartHold = 0;
+	//stop the button from flashing once a topic has been chosen
+	stopReticuleButtonFlash(IDRET_RESEARCH);
 }
 
 void ResearchController::setHighlightedObject(BASE_OBJECT *object)
@@ -547,7 +537,7 @@ private:
 
 		if (mouseButton == WKEY_PRIMARY)
 		{
-			controller->startResearch(clickedStats);
+			controller->startResearch(*clickedStats);
 			intRemoveStats();
 		}
 	}

--- a/src/hci/research.h
+++ b/src/hci/research.h
@@ -37,7 +37,7 @@ public:
 	bool showInterface() override;
 	void refresh() override;
 	std::shared_ptr<StatsForm> makeStatsForm() override;
-	void startResearch(RESEARCH *research);
+	void startResearch(RESEARCH &research);
 	void requestResearchCancellation(STRUCTURE *facility);
 
 	STRUCTURE *getHighlightedObject() const override

--- a/src/hci/research.h
+++ b/src/hci/research.h
@@ -38,6 +38,7 @@ public:
 	void refresh() override;
 	std::shared_ptr<StatsForm> makeStatsForm() override;
 	void startResearch(RESEARCH &research);
+	void cancelResearch(STRUCTURE *facility);
 	void requestResearchCancellation(STRUCTURE *facility);
 
 	STRUCTURE *getHighlightedObject() const override


### PR DESCRIPTION
Fixes #1534.

This also fixes some small difference with the previous version, where it was possible to click on the research currently being researched (on the list of research options) to cancel the research.