### PR TITLE
Fix electronic shimmy and color flash

### DIFF
--- a/src/component.cpp
+++ b/src/component.cpp
@@ -393,7 +393,7 @@ static bool displayCompObj(DROID *psDroid, bool bButton, const glm::mat4 &viewMa
 
 	glm::mat4 modelMatrix(1.f);
 
-	if (graphicsTime - psDroid->timeLastHit < GAME_TICKS_PER_SEC / 4 && psDroid->lastHitWeapon == WSC_ELECTRONIC && !gamePaused())
+	if (psDroid->timeLastHit - graphicsTime < ELEC_DAMAGE_DURATION && psDroid->lastHitWeapon == WSC_ELECTRONIC && !gamePaused())
 	{
 		colour = getPlayerColour(rand() % MAX_PLAYERS);
 	}
@@ -852,7 +852,7 @@ void displayComponentObject(DROID *psDroid, const glm::mat4 &viewMatrix)
 		glm::rotate(UNDEG(rotation.x), glm::vec3(1.f, 0.f, 0.f)) *
 		glm::rotate(UNDEG(rotation.z), glm::vec3(0.f, 0.f, 1.f));
 
-	if (graphicsTime - psDroid->timeLastHit < GAME_TICKS_PER_SEC && psDroid->lastHitWeapon == WSC_ELECTRONIC)
+	if (psDroid->timeLastHit - graphicsTime < ELEC_DAMAGE_DURATION && psDroid->lastHitWeapon == WSC_ELECTRONIC)
 	{
 		modelMatrix *= objectShimmy((BASE_OBJECT *) psDroid);
 	}

--- a/src/display3d.cpp
+++ b/src/display3d.cpp
@@ -2424,7 +2424,7 @@ void renderStructure(STRUCTURE *psStructure, const glm::mat4 &viewMatrix)
 	psStructure->sDisplay.frameNumber = currentGameFrame;
 
 	if (!defensive
-	    && graphicsTime - psStructure->timeLastHit < ELEC_DAMAGE_DURATION
+	    && psStructure->timeLastHit - graphicsTime < ELEC_DAMAGE_DURATION
 	    && psStructure->lastHitWeapon == WSC_ELECTRONIC)
 	{
 		bHitByElectronic = true;

--- a/src/structure.cpp
+++ b/src/structure.cpp
@@ -5458,6 +5458,8 @@ bool electronicDamage(BASE_OBJECT *psTarget, UDWORD damage, UBYTE attackPlayer)
 		psDroid = (DROID *)psTarget;
 		bCompleted = false;
 		int lastHit = psDroid->timeLastHit;
+		psDroid->timeLastHit = gameTime;
+		psDroid->lastHitWeapon = WSC_ELECTRONIC;
 
 		//in multiPlayer cannot attack a Transporter with EW
 		if (bMultiPlayer)


### PR DESCRIPTION
`timeLastHit` is set to `gameTime` but the shimmy and color effects compared with `graphicsTime`. Also if hit electronically a droid wasn't being told to track what weapon type and at what `gameTime` it was hit. From what I can tell `graphicsTime` is always less than or equal to `gameTime` and because both are unsigned the result would wrap around to a huge number causing these features to rarely work.


Fixes #1539 