### PR TITLE
Fix crashes related to UI

### DIFF
--- a/src/hci/build.cpp
+++ b/src/hci/build.cpp
@@ -87,7 +87,7 @@ void BuildController::startBuildPosition(STRUCTURE_STATS *buildOption)
 {
 	auto builder = getHighlightedObject();
 	ASSERT_NOT_NULLPTR_OR_RETURN(, builder);
-	
+
 	triggerEvent(TRIGGER_MENU_BUILD_SELECTED);
 
 	if (buildOption == structGetDemolishStat())
@@ -431,22 +431,18 @@ private:
 	void updateLayout() override
 	{
 		BaseWidget::updateLayout();
+
+		if (isMouseOverWidget())
+		{
+			intSetShadowPower(getCost());
+		}
+
 		costBar->majorSize = std::min(100, (int32_t)(getCost() / POWERPOINTS_DROIDDIV));
 	}
 
 	uint32_t getCost() override
 	{
 		return getStats()->powerToBuild;
-	}
-
-	void run(W_CONTEXT *context) override
-	{
-		BaseWidget::run(context);
-
-		if (isMouseOverWidget())
-		{
-			intSetShadowPower(getCost());
-		}
 	}
 
 	void released(W_CONTEXT *context, WIDGET_KEY mouseButton = WKEY_PRIMARY) override

--- a/src/hci/manufacture.cpp
+++ b/src/hci/manufacture.cpp
@@ -426,6 +426,10 @@ private:
 	void updateLayout() override
 	{
 		BaseWidget::updateLayout();
+		if (isMouseOverWidget())
+		{
+			intSetShadowPower(getCost());
+		}
 		costBar->majorSize = std::min(100, (int32_t)(getCost() / POWERPOINTS_DROIDDIV));
 		productionRunSizeLabel.update(controller->getHighlightedObject(), getStats());
 	}
@@ -433,16 +437,6 @@ private:
 	uint32_t getCost() override
 	{
 		return calcTemplatePower(getStats());
-	}
-
-	void run(W_CONTEXT *context) override
-	{
-		BaseWidget::run(context);
-
-		if (isMouseOverWidget())
-		{
-			intSetShadowPower(getCost());
-		}
 	}
 
 	void released(W_CONTEXT *context, WIDGET_KEY mouseButton = WKEY_PRIMARY) override
@@ -641,12 +635,19 @@ private:
 			controller->adjustFactoryLoop(key == WKEY_PRIMARY);
 		}
 
-	private:
-		void run(W_CONTEXT *) override
+protected:
+		void display(int xOffset, int yOffset) override
+		{
+			updateLayout();
+			BaseWidget::display(xOffset, yOffset);
+		}
+
+		void updateLayout()
 		{
 			setState(ManufactureStatsForm::getProductionLoops(controller->getHighlightedObject()) == 0 ? 0: WBUT_CLICKLOCK);
 		}
 
+	private:
 		std::shared_ptr<ManufactureController> controller;
 	};
 
@@ -660,8 +661,14 @@ private:
 		{
 		}
 
-	private:
-		void run(W_CONTEXT *) override
+	protected:
+		void display(int xOffset, int yOffset) override
+		{
+			updateLayout();
+			BaseWidget::display(xOffset, yOffset);
+		}
+
+		void updateLayout()
 		{
 			auto productionLoops = ManufactureStatsForm::getProductionLoops(controller->getHighlightedObject());
 			if (productionLoops != lastProductionLoop)
@@ -671,6 +678,7 @@ private:
 			}
 		}
 
+	private:
 		std::string getNewString()
 		{
 			switch (lastProductionLoop)

--- a/src/hci/research.cpp
+++ b/src/hci/research.cpp
@@ -483,6 +483,11 @@ private:
 		{
 			updateAllyStatus(research);
 		}
+
+		if (isMouseOverWidget())
+		{
+			intSetShadowPower(getCost());
+		}
 	}
 
 	void updateCostBar(RESEARCH *stat)
@@ -518,16 +523,6 @@ private:
 	uint32_t getCost() override
 	{
 		return getStats()->researchPower;
-	}
-
-	void run(W_CONTEXT *context) override
-	{
-		BaseWidget::run(context);
-
-		if (BaseWidget::isMouseOverWidget())
-		{
-			intSetShadowPower(getCost());
-		}
 	}
 
 	void released(W_CONTEXT *context, WIDGET_KEY mouseButton = WKEY_PRIMARY) override


### PR DESCRIPTION
Fixes #1580.

The new UI widgets rely on indices in order to keep track of which
game object they refer to.

The forms are responsible for updating the list of objects, and create
or destroy buttons in order to make the amount of buttons match the
amount of object in the game. The forms are doing this during the
`display` method.

Some children were updating their layout in the `run` method, so, it was
possible for a child to try to update its layout, before the form had
the chance to remove the child.