### PR TITLE
Fixes #1589: Close options menu, when other menu is opened

### DIFF
--- a/src/hci.cpp
+++ b/src/hci.cpp
@@ -762,6 +762,12 @@ void intResetScreen(bool NoAnim)
 			intRemoveOrder();
 		}
 		break;
+	case INT_INGAMEOP:
+		if (NoAnim) // Other menus can be opened when options menu is up, so close the options (issue #1589)
+		{
+			intCloseInGameOptionsNoAnim();
+		}
+		break;
 	case INT_MISSIONRES:
 		intRemoveMissionResultNoAnim();
 		break;

--- a/src/hci.h
+++ b/src/hci.h
@@ -282,6 +282,7 @@ bool intAddReticule();
 bool intAddPower();
 void intRemoveReticule();
 void setReticuleStats(int ButId, std::string tip = std::string(), std::string filename = std::string(), std::string filenameDown = std::string(), const playerCallbackFunc& callbackFunc = nullptr);
+void setReticulesEnabled(bool enabled);
 void setReticuleFlash(int ButId, bool flash);
 
 /* Set the map view point to the world coordinates x,y */

--- a/src/ingameop.cpp
+++ b/src/ingameop.cpp
@@ -199,7 +199,6 @@ static bool _intAddInGameOptions()
 	//clear out any mission widgets - timers etc that may be on the screen
 	clearMissionWidgets();
 
-
 	setWidgetsStatus(true);
 
 	//if already open, then close!
@@ -210,7 +209,7 @@ static bool _intAddInGameOptions()
 	}
 
 	intResetScreen(false);
-
+	setReticulesEnabled(false);
 
 	// Pause the game.
 	if (!gamePaused())
@@ -367,6 +366,8 @@ static void ProcessOptionFinished()
 	{
 		kf_TogglePauseMode();
 	}
+
+	setReticulesEnabled(true);
 }
 
 void intCloseInGameOptionsNoAnim()

--- a/src/ingameop.cpp
+++ b/src/ingameop.cpp
@@ -363,15 +363,23 @@ static void ProcessOptionFinished()
 {
 	intMode		= INT_NORMAL;
 
-
-
-	//unpause.
 	if (gamePaused())
 	{
 		kf_TogglePauseMode();
 	}
+}
 
+void intCloseInGameOptionsNoAnim()
+{
+	if (NetPlay.isHost)
+	{
+		widgDelete(psWScreen, INTINGAMEPOPUP);
+	}
+	widgDelete(psWScreen, INTINGAMEOP);
+	InGameOpUp = false;
 
+	ProcessOptionFinished();
+	resetMissionWidgets();
 }
 
 // ////////////////////////////////////////////////////////////////////////////

--- a/src/ingameop.h
+++ b/src/ingameop.h
@@ -28,6 +28,7 @@
 bool intAddInGameOptions();
 void intReopenMenuWithoutUnPausing();
 bool intCloseInGameOptions(bool bPutUpLoadSave, bool bResetMissionWidgets);
+void intCloseInGameOptionsNoAnim();
 void intProcessInGameOptions(UDWORD);
 void intAddInGamePopup();
 


### PR DESCRIPTION
Apparently there are multiple ways to exit the options menu - not only by using "Resume" and ESC key, but also by opening any other menu, by mouse (in multiplayer) or by keyboard (also in campaign; eg orders menu by using keypad 0).

It seems that the fix does not interfere with "Go back" button, but some more testing from experienced players would be welcome