### PR TITLE
Introduce the ability to specify if a model wants to interpolate frames.

### DIFF
--- a/doc/PIE.md
+++ b/doc/PIE.md
@@ -42,6 +42,12 @@ The following flags are available:
 * 0x01000 -- Specifies that the model should not be stretched to fit terrain. For defensive buildings that have a deep foundation.
 * 0x10000 -- Specifies the usage of the TCMask feature, for which a texture named 'page-N_tcmask.png' (*N* being a number) should be used together with the model's ordinary texture. This flag replaced old team coloration methods (read ticket #851).
 
+### INTERPOLATE
+
+> INTERPOLATE 0
+
+Optional. Specifies if the model wants to have interpolated frames. Default is set to interpolate.
+
 ### TEXTURE
 
 > TEXTURE 0 page-7-barbarians-arizona.png 0 0

--- a/lib/ivis_opengl/ivisdef.h
+++ b/lib/ivis_opengl/ivisdef.h
@@ -149,6 +149,8 @@ struct iIMDShape
 	int objanimcycles = 0; ///< Number of cycles to render, zero means infinitely many
 	iIMDShape *objanimpie[ANIM_EVENT_COUNT] = { nullptr };
 
+	int interpolate = 1; // if the model wants to be interpolated
+
 	iIMDShape *next = nullptr;  // next pie in multilevel pies (NULL for non multilevel !)
 };
 


### PR DESCRIPTION
PIE models can optionally use `INTERPOLATE X` after the flag data to disable animation interpolation, or, if somebody just likes to be explicit about interpolation being on I guess. Previous matrix code in `display3d.cpp` reintroduced from #748. 

Pretty much complete to what I understood in the request. Could probably use a magic speed optimization for avoiding another sscanf().

Tested with ARmod 4.0.0 on the scavenger pie models. Setting interpolation on made the arms spasm out like they do now with interpolation and setting it off made the model appear as intended.

Fixes #1586.