### PR TITLE
Headless mode improvements

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1460,6 +1460,7 @@ int realmain(int argc, char *argv[])
 			fprintf(stdout, " * NOTE: VSYNC IS DISABLED - CPU USAGE MAY BE UNBOUNDED\n");
 		}
 		fprintf(stdout, "--------------------------------------------------------------------------------------\n");
+		fflush(stdout);
 	}
 
 	// Find out where to find the data

--- a/src/scores.cpp
+++ b/src/scores.cpp
@@ -558,7 +558,7 @@ bool readScoreData(const char *fileName)
 	return true;
 }
 
-void stdOutGameSummary(UDWORD realTimeThrottleSeconds)
+void stdOutGameSummary(UDWORD realTimeThrottleSeconds, bool flush_output /* = true */)
 {
 	static UDWORD lastOutputRealTime = 0;
 	if (realTimeThrottleSeconds > 0 && (realTime - lastOutputRealTime < (realTimeThrottleSeconds * GAME_TICKS_PER_SEC)))
@@ -613,5 +613,9 @@ void stdOutGameSummary(UDWORD realTimeThrottleSeconds)
 		}
 	}
 	fprintf(stdout, "--------------------------------------------------------------------------------------\n");
+	if (flush_output)
+	{
+		fflush(stdout);
+	}
 	lastOutputRealTime = realTime;
 }

--- a/src/scores.h
+++ b/src/scores.h
@@ -121,6 +121,6 @@ void getAsciiTime(char *psText, unsigned time);
 bool readScoreData(const char *fileName);
 bool writeScoreData(const char *fileName);
 
-void stdOutGameSummary(UDWORD realTimeThrottleSeconds = 5);
+void stdOutGameSummary(UDWORD realTimeThrottleSeconds = 5, bool flush_output = true);
 
 #endif // __INCLUDED_SRC_SCORES_H__


### PR DESCRIPTION
- Do not attempt to initialize SDL video subsystem when in headless mode
- Flush output in headless mode

Should fix #1617
Improves #1616

@vaut