### PR TITLE
[SDL backend] Ensure text input starts disabled

### DIFF
--- a/lib/sdl/main_sdl.cpp
+++ b/lib/sdl/main_sdl.cpp
@@ -2023,6 +2023,11 @@ static bool wzSDLOneTimeInitSubsystem(uint32_t subsystem_flag)
 		debug(LOG_WZ, "SDL_InitSubSystem(%" PRIu32 ") failed", subsystem_flag);
 		return false;
 	}
+	if ((SDL_IsTextInputActive() != SDL_FALSE) && (GetTextEventsOwner == nullptr))
+	{
+		// start text input disabled
+		SDL_StopTextInput();
+	}
 	return true;
 }
 


### PR DESCRIPTION
Fixes possible assert triggering as a result of changes in #1618