### PR TITLE
Minor shadow-related refactoring, imdload sanity checks

### DIFF
--- a/lib/ivis_opengl/imdload.cpp
+++ b/lib/ivis_opengl/imdload.cpp
@@ -173,7 +173,7 @@ static bool _imd_load_polys(const WzString &filename, const char **ppFileData, i
 
 		poly->flags = flags;
 		ASSERT_OR_RETURN(false, npnts == 3, "Invalid polygon size (%d)", npnts);
-		if (sscanf(pFileData, "%d %d %d%n", &poly->pindex[0], &poly->pindex[1], &poly->pindex[2], &cnt) != 3)
+		if (sscanf(pFileData, "%" PRIu32 "%" PRIu32 "%" PRIu32 "%n", &poly->pindex[0], &poly->pindex[1], &poly->pindex[2], &cnt) != 3)
 		{
 			debug(LOG_ERROR, "failed reading triangle, point %d", i);
 			return false;

--- a/lib/ivis_opengl/ivisdef.h
+++ b/lib/ivis_opengl/ivisdef.h
@@ -67,7 +67,7 @@ struct iSurface
 /// Stores the from and to verticles from an edge
 struct EDGE
 {
-	int from, to;
+	uint32_t from, to;
 };
 
 struct ANIMFRAME
@@ -84,7 +84,7 @@ struct iIMDPoly
 	uint32_t flags = 0;
 	int32_t zcentre = 0;
 	Vector3f normal = Vector3f(0.f, 0.f, 0.f);
-	int pindex[3] = { 0 };
+	uint32_t pindex[3] = { 0 };
 };
 
 enum VBO_TYPE

--- a/lib/ivis_opengl/piedraw.cpp
+++ b/lib/ivis_opengl/piedraw.cpp
@@ -448,9 +448,27 @@ struct ShadowCache {
 
 	void addPremultipliedVertexes(const CachedShadowData& cachedData, const glm::mat4 &modelViewMatrix)
 	{
+		float mat_a = modelViewMatrix[0].x;
+		float mat_b = modelViewMatrix[1].x;
+		float mat_c = modelViewMatrix[2].x;
+		float mat_d = modelViewMatrix[3].x;
+		float mat_e = modelViewMatrix[0].y;
+		float mat_f = modelViewMatrix[1].y;
+		float mat_g = modelViewMatrix[2].y;
+		float mat_h = modelViewMatrix[3].y;
+		float mat_i = modelViewMatrix[0].z;
+		float mat_j = modelViewMatrix[1].z;
+		float mat_k = modelViewMatrix[2].z;
+		float mat_l = modelViewMatrix[3].z;
+		float premult_x;
+		float premult_y;
+		float premult_z;
 		for (auto &vertex : cachedData.vertexes)
 		{
-			vertexes.emplace_back(modelViewMatrix * glm::vec4(vertex, 1.0));
+			premult_x = vertex.x*mat_a + vertex.y*mat_b + vertex.z*mat_c + mat_d;
+			premult_y = vertex.x*mat_e + vertex.y*mat_f + vertex.z*mat_g + mat_h;
+			premult_z = vertex.x*mat_i + vertex.y*mat_j + vertex.z*mat_k + mat_l;
+			vertexes.push_back(Vector3f(premult_x, premult_y, premult_z));
 		}
 	}
 

--- a/lib/ivis_opengl/piedraw.cpp
+++ b/lib/ivis_opengl/piedraw.cpp
@@ -567,7 +567,7 @@ static inline DrawShadowResult pie_DrawShadow(ShadowCache &shadowCache, iIMDShap
 			{
 				for (int j = 0; j < 3; ++j)
 				{
-					int current = poly.pindex[j];
+					uint32_t current = poly.pindex[j];
 					p[j] = glm::vec3(pVertices[current].x, scale_y(pVertices[current].y, flag, flag_data), pVertices[current].z);
 				}
 				if (glm::dot(glm::cross(p[2] - p[0], p[1] - p[0]), glm::vec3(light)) > 0.0f)

--- a/lib/ivis_opengl/piedraw.cpp
+++ b/lib/ivis_opengl/piedraw.cpp
@@ -601,8 +601,7 @@ static inline DrawShadowResult pie_DrawShadow(ShadowCache &shadowCache, iIMDShap
 			}
 		}
 
-		static std::vector<Vector3f> vertexes;
-		vertexes.clear();
+		std::vector<Vector3f> vertexes;
 		vertexes.reserve(edge_count * 6);
 		for (size_t i = 0; i < edge_count; i++)
 		{
@@ -621,7 +620,7 @@ static inline DrawShadowResult pie_DrawShadow(ShadowCache &shadowCache, iIMDShap
 		}
 
 		ShadowCache::CachedShadowData& cache = shadowCache.createCacheForShadowDraw(shape, flag, flag_data, light);
-		cache.vertexes = vertexes;
+		cache.vertexes = std::move(vertexes);
 		result = DRAW_SUCCESS_UNCACHED;
 		pCached = &cache;
 	}


### PR DESCRIPTION
- Tweak addPremultipliedVertexes()
   - Potentially avoids some unnecessary calculations / work, and avoiding glm can improve performance when optimizations are disabled.
- EDGE / pindex: Use uint32_t
- pie_DrawShadow: Move vertexes
   - Avoid a copy