### PR TITLE
Update entries to resmessages3.json for both Base and MP

### DIFF
--- a/data/base/messages/resmessages3.json
+++ b/data/base/messages/resmessages3.json
@@ -797,7 +797,7 @@
         "sequenceName": "res_weapons.ogg",
         "text": [
             "Cannon Upgrade",
-            "High-Velocity Armor-Piercing Fin-Stabilised Discarding Sabot",
+            "Hyper-Velocity Armor-Piercing Fin-Stabilised Discarding Sabot",
             "Increases Cannon damage",
             "All cannons upgraded automatically"
         ]

--- a/data/mp/messages/resmessages3.json
+++ b/data/mp/messages/resmessages3.json
@@ -797,7 +797,7 @@
         "sequenceName": "res_weapons.ogg",
         "text": [
             "Cannon Upgrade",
-            "High-Velocity Armor-Piercing Fin-Stabilised Discarding Sabot",
+            "Hyper-Velocity Armor-Piercing Fin-Stabilised Discarding Sabot",
             "Cannon damage +25%",
             "All cannons upgraded automatically"
         ]


### PR DESCRIPTION
After a quick discussion and vote in the Discord chat, we propose the following:
- the entry for the "**High**" in the "_**High**-Velocity Armor-Piercing Fin-Stabilised Discarding Sabot_" to be changed into "**Hyper**" so it would fit in better as "_**Hyper**-Velocity Armor-Piercing Fin-Stabilised Discarding Sabot_" for both the Campaign and Multiplayer modules.