### PR TITLE
hci: Additional null checks, widgScheduleTask use, debug helper

### DIFF
--- a/src/droid.cpp
+++ b/src/droid.cpp
@@ -2047,6 +2047,7 @@ UDWORD	getNumDroidsForLevel(uint32_t player, UDWORD level)
 //
 const char *droidGetName(const DROID *psDroid)
 {
+	ASSERT_NOT_NULLPTR_OR_RETURN("", psDroid);
 	return psDroid->aName;
 }
 

--- a/src/hci/build.cpp
+++ b/src/hci/build.cpp
@@ -199,7 +199,9 @@ protected:
 
 	std::string getTip() override
 	{
-		return droidGetName(controller->getObjectAt(objectIndex));
+		auto droid = controller->getObjectAt(objectIndex);
+		ASSERT_NOT_NULLPTR_OR_RETURN("", droid);
+		return droidGetName(droid);
 	}
 
 private:
@@ -272,6 +274,7 @@ private:
 	{
 		progressBar->hide();
 
+		ASSERT_NOT_NULLPTR_OR_RETURN(, droid);
 		if (!DroidIsBuilding(droid))
 		{
 			return;
@@ -328,7 +331,7 @@ private:
 			return false;
 		};
 
-		if (processOrder(droid->order))
+		if (droid && processOrder(droid->order))
 		{
 			for (auto const &order: droid->asOrderList)
 			{

--- a/src/hci/build.h
+++ b/src/hci/build.h
@@ -46,7 +46,8 @@ public:
 
 	DROID *getObjectAt(size_t index) const override
 	{
-		return builders.at(index);
+		ASSERT_OR_RETURN(nullptr, index < builders.size(), "Invalid object index (%zu); max: (%zu)", index, builders.size());
+		return builders[index];
 	}
 
 	bool findObject(std::function<bool (BASE_OBJECT *)> iteration) const override

--- a/src/hci/commander.cpp
+++ b/src/hci/commander.cpp
@@ -123,6 +123,7 @@ protected:
 
 	void updateGroupSizeLabel(DROID *droid)
 	{
+		ASSERT_NOT_NULLPTR_OR_RETURN(, droid);
 		auto text = astringf("%u/%u", droid->psGroup ? droid->psGroup->getNumMembers() : 0, cmdDroidMaxGroup(droid));
 		groupSizeLabel->setString(WzString::fromUtf8(text));
 		groupSizeLabel->show();
@@ -130,6 +131,7 @@ protected:
 
 	void updateExperienceStarsLabel(DROID *droid)
 	{
+		ASSERT_NOT_NULLPTR_OR_RETURN(, droid);
 		int numStars = std::max((int)getDroidLevel(droid) - 1, 0);
 		experienceStarsLabel->setString(WzString(numStars, WzUniCodepoint::fromASCII('*')));
 		experienceStarsLabel->show();
@@ -142,7 +144,9 @@ protected:
 
 	std::string getTip() override
 	{
-		return droidGetName(controller->getObjectAt(objectIndex));
+		auto droid = controller->getObjectAt(objectIndex);
+		ASSERT_NOT_NULLPTR_OR_RETURN("", droid);
+		return droidGetName(droid);
 	}
 
 private:
@@ -205,6 +209,7 @@ protected:
 private:
 	void updateAssignedFactoriesLabel(const std::shared_ptr<W_LABEL> &label, DROID *droid, uint32_t factoryTypeShift)
 	{
+		ASSERT_NOT_NULLPTR_OR_RETURN(, droid);
 		/**
 		 * TODO Support up to MAX_FACTORY (which won't fit in the ugly secondaryOrder bitmask hack).
 		 * Comment taken from commit 34d8148e4a
@@ -259,7 +264,7 @@ private:
 		auto highlighted = controller->getHighlightedObject();
 
 		// prevent highlighting a commander when another commander is already selected
-		if (droid == highlighted || !highlighted->selected)
+		if (droid == highlighted || (highlighted && !highlighted->selected))
 		{
 			controller->setHighlightedObject(droid);
 			controller->displayOrderForm();

--- a/src/hci/commander.cpp
+++ b/src/hci/commander.cpp
@@ -330,6 +330,14 @@ bool CommanderController::showInterface()
 
 void CommanderController::displayOrderForm()
 {
-	intAddOrder(getHighlightedObject());
-	intMode = INT_CMDORDER;
+	auto psWeakControllerRef = std::weak_ptr<CommanderController>(shared_from_this());
+	widgScheduleTask([psWeakControllerRef]() {
+		DROID *psDroid = nullptr;
+		if (auto strongControllerRef = psWeakControllerRef.lock())
+		{
+			psDroid = strongControllerRef->getHighlightedObject();
+		}
+		intAddOrder(psDroid);
+		intMode = INT_CMDORDER;
+	});
 }

--- a/src/hci/commander.h
+++ b/src/hci/commander.h
@@ -15,7 +15,8 @@ public:
 
 	DROID *getObjectAt(size_t index) const override
 	{
-		return commanders.at(index);
+		ASSERT_OR_RETURN(nullptr, index < commanders.size(), "Invalid object index (%zu); max: (%zu)", index, commanders.size());
+		return commanders[index];
 	}
 
 	bool findObject(std::function<bool (BASE_OBJECT *)> iteration) const override

--- a/src/hci/manufacture.cpp
+++ b/src/hci/manufacture.cpp
@@ -269,7 +269,7 @@ protected:
 
 		auto factory = controller->getObjectAt(objectIndex);
 		auto production = getStats();
-		auto productionPending = StructureIsManufacturingPending(factory);
+		auto productionPending = factory && StructureIsManufacturingPending(factory);
 		auto objectImage = productionPending && production ? ImdObject::DroidTemplate(production): ImdObject::Component(nullptr);
 
 		displayIMD(Image(), objectImage, xOffset, yOffset);
@@ -313,7 +313,7 @@ private:
 	void updateProductionRunSizeLabel(STRUCTURE *factory, DROID_TEMPLATE *droidTemplate)
 	{
 		auto productionRemaining = getProduction(factory, droidTemplate).numRemaining();
-		if (StructureIsManufacturingPending(factory) && productionRemaining > 0)
+		if (productionRemaining > 0 && factory && StructureIsManufacturingPending(factory))
 		{
 			productionRunSizeLabel->setString(WzString::fromUtf8(astringf("%d", productionRemaining)));
 			productionRunSizeLabel->show();
@@ -328,6 +328,7 @@ private:
 	{
 		progressBar->hide();
 
+		ASSERT_NOT_NULLPTR_OR_RETURN(, factory);
 		ASSERT_OR_RETURN(, !isDead(factory), "Factory is dead");
 
 		if (!StructureIsManufacturingPending(factory))
@@ -336,6 +337,7 @@ private:
 		}
 
 		auto manufacture = StructureGetFactory(factory);
+		ASSERT_NOT_NULLPTR_OR_RETURN(, manufacture);
 
 		if (manufacture->psSubject != nullptr && manufacture->buildPointsRemaining < calcTemplateBuild(manufacture->psSubject))
 		{

--- a/src/hci/manufacture.h
+++ b/src/hci/manufacture.h
@@ -35,7 +35,8 @@ public:
 
 	STRUCTURE *getObjectAt(size_t index) const override
 	{
-		return factories.at(index);
+		ASSERT_OR_RETURN(nullptr, index < factories.size(), "Invalid object index (%zu); max: (%zu)", index, factories.size());
+		return factories[index];
 	}
 
 	bool findObject(std::function<bool (BASE_OBJECT *)> iteration) const override

--- a/src/hci/objects_stats.h
+++ b/src/hci/objects_stats.h
@@ -32,12 +32,16 @@ public:
 
 	void closeInterface()
 	{
-		intResetScreen(false);
+		widgScheduleTask([]() {
+			intResetScreen(false);
+		});
 	}
 
 	void closeInterfaceNoAnim()
 	{
-		intResetScreen(true);
+		widgScheduleTask([]() {
+			intResetScreen(true);
+		});
 	}
 
 protected:

--- a/src/hci/research.cpp
+++ b/src/hci/research.cpp
@@ -552,7 +552,9 @@ private:
 		{
 			controller->startResearch(*clickedStats);
 		}
-		intRemoveStats();
+		widgScheduleTask([]() {
+			intRemoveStats();
+		});
 	}
 
 	std::shared_ptr<ResearchController> controller;

--- a/src/hci/research.cpp
+++ b/src/hci/research.cpp
@@ -334,7 +334,7 @@ protected:
 
 		auto facility = controller->getObjectAt(objectIndex);
 		auto research = controller->getObjectStatsAt(objectIndex);
-		auto researchPending = structureIsResearchingPending(facility);
+		auto researchPending = facility && structureIsResearchingPending(facility);
 		auto objectImage = researchPending && research ? getResearchObjectImage(research) : ImdObject::Component(nullptr);
 
 		displayIMD(Image(), objectImage, xOffset, yOffset);
@@ -368,8 +368,9 @@ private:
 
 	void updateProgressBar()
 	{
-		auto facility = controller->getObjectAt(objectIndex);
 		progressBar->hide();
+		auto facility = controller->getObjectAt(objectIndex);
+		ASSERT_NOT_NULLPTR_OR_RETURN(, facility);
 
 		auto research = StructureGetResearch(facility);
 		if (research->psSubject == nullptr)

--- a/src/hci/research.h
+++ b/src/hci/research.h
@@ -24,7 +24,8 @@ public:
 
 	STRUCTURE *getObjectAt(size_t index) const override
 	{
-		return facilities.at(index);
+		ASSERT_OR_RETURN(nullptr, index < facilities.size(), "Invalid object index (%zu); max: (%zu)", index, facilities.size());
+		return facilities[index];
 	}
 
 	bool findObject(std::function<bool (BASE_OBJECT *)> iteration) const override

--- a/src/intdisplay.cpp
+++ b/src/intdisplay.cpp
@@ -1271,6 +1271,7 @@ void IntFancyButton::displayBlank(int xOffset, int yOffset)
 bool DroidIsBuilding(DROID *Droid)
 {
 	STRUCTURE_STATS	*Stats;
+	ASSERT_NOT_NULLPTR_OR_RETURN(false, Droid);
 
 	if (!(droidType(Droid) == DROID_CONSTRUCT ||
 	      droidType(Droid) == DROID_CYBORG_CONSTRUCT))
@@ -1298,6 +1299,7 @@ bool DroidIsBuilding(DROID *Droid)
 bool DroidGoingToBuild(DROID *Droid)
 {
 	STRUCTURE_STATS	*Stats;
+	ASSERT_NOT_NULLPTR_OR_RETURN(false, Droid);
 
 	if (!(droidType(Droid) == DROID_CONSTRUCT ||
 	      droidType(Droid) == DROID_CYBORG_CONSTRUCT))
@@ -1411,6 +1413,7 @@ static inline bool _structureIsManufacturingPending(Functionality const &functio
 
 bool StructureIsManufacturingPending(STRUCTURE *structure)
 {
+	ASSERT_NOT_NULLPTR_OR_RETURN(false, structure);
 	switch (structure->pStructureType->type)
 	{
 	case REF_FACTORY:
@@ -1424,11 +1427,13 @@ bool StructureIsManufacturingPending(STRUCTURE *structure)
 
 FACTORY *StructureGetFactory(STRUCTURE *Structure)
 {
+	ASSERT_NOT_NULLPTR_OR_RETURN(nullptr, Structure);
 	return &Structure->pFunctionality->factory;
 }
 
 bool structureIsResearchingPending(STRUCTURE *structure)
 {
+	ASSERT_NOT_NULLPTR_OR_RETURN(false, structure);
 	return structure->pStructureType->type == REF_RESEARCH && _structureIsManufacturingPending(structure->pFunctionality->researchFacility);
 }
 
@@ -1466,6 +1471,7 @@ RESEARCH_FACILITY *StructureGetResearch(STRUCTURE *Structure)
 
 DROID_TEMPLATE *FactoryGetTemplate(FACTORY *Factory)
 {
+	ASSERT_NOT_NULLPTR_OR_RETURN(nullptr, Factory);
 	if (Factory->psSubjectPending != nullptr)
 	{
 		return (DROID_TEMPLATE *)Factory->psSubjectPending;


### PR DESCRIPTION
Some of these ASSERTs might be able to be replaced with silent check and return, but being noisy may be useful for now.
`widgScheduleTask` changes should hopefully fix #1635
Added a debug helper (just `#define DEBUG`) to help catch potentially problematic `widgDelete` calls.