### PR TITLE
Unload level data before loading any save data.

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -3080,6 +3080,14 @@ static bool gameLoad(const char *fileName)
 	}
 	else if (fileHeader.version <= CURRENT_VERSION_NUM)
 	{
+		//The in-game load menu was clearing level data AFTER loading in some savegame data.
+		//Hacking this in here so things make a little more sense and so that data loaded
+		//in from main.json is somewhat safe from being reset by mistake.
+		if (!levReleaseAll())
+		{
+			debug(LOG_ERROR, "Failed to unload old data. Attempting to load anyway");
+		}
+
 		//remove the file extension
 		CurrentFileName[strlen(CurrentFileName) - 4] = '\0';
 		loadMainFile(std::string(CurrentFileName) + "/main.json");


### PR DESCRIPTION
Super scary (or not) savegame loading change that attempts to unload level data before `loadMainFile()` and `GameLoadV()` intended for the in-game load menu option. Seems to work but needs rigorous testing or else the game will explode. If unloading fails it will attempt to load the save data anyway.

Fixes #1604. 

The referenced issue was caused by `loadMainFile()` loading in the correct faction, the spaghetti of `gameLoadV()` loading save stuff, later unloading level data and doing data shutdowns midway through if there was a currently loaded level, which thus reset the faction, and then resuming on to load the rest of savegame data.