### PR TITLE
Camera rotation scroll improvements

### DIFF
--- a/src/configuration.cpp
+++ b/src/configuration.cpp
@@ -35,7 +35,6 @@
 #include "component.h"
 #include "configuration.h"
 #include "difficulty.h"
-#include "display3d.h"
 #include "ingameop.h"
 #include "multiint.h"
 #include "multiplay.h"
@@ -48,6 +47,7 @@
 #include "nethelpers.h"
 #include "lib/framework/wzapp.h"
 #include "display3d.h" // for building animation speed
+#include "display.h"
 
 #include <type_traits>
 
@@ -462,6 +462,7 @@ bool loadConfig()
 		}
 	}
 	BlueprintTrackAnimationSpeed = iniGetInteger("BlueprintTrackAnimationSpeed", 20).value();
+	lockCameraScrollWhileRotating = iniGetBool("lockCameraScrollWhileRotating", false).value();
 	ActivityManager::instance().endLoadingSettings();
 	return true;
 }
@@ -597,6 +598,7 @@ bool saveConfig()
 	iniSetString("gfxbackend", to_string(war_getGfxBackend()));
 	iniSetString("jsbackend", to_string(war_getJSBackend()));
 	iniSetInteger("BlueprintTrackAnimationSpeed", BlueprintTrackAnimationSpeed);
+	iniSetBool("lockCameraScrollWhileRotating", lockCameraScrollWhileRotating);
 
 	// write out ini file changes
 	bool result = saveIniFile(file, ini);

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -1029,7 +1029,7 @@ static void handleCameraScrolling()
 		return;
 	}
 
-	if (lockCameraScrollWhileRotating && rotActive)
+	if (lockCameraScrollWhileRotating && rotActive && (scrollDirUpDown == 0 && scrollDirLeftRight == 0))
 	{
 		resetScroll();
 		return;

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -137,6 +137,7 @@ static bool cameraAccel = true;
 
 bool	rotActive = false;
 bool	gameStats = false;
+bool	lockCameraScrollWhileRotating = false;
 
 /* Hackety hack hack hack */
 static int screenShakeTable[100] =
@@ -1028,7 +1029,8 @@ static void handleCameraScrolling()
 		return;
 	}
 
-	if(rotActive){
+	if (lockCameraScrollWhileRotating && rotActive)
+	{
 		resetScroll();
 		return;
 	}

--- a/src/display.h
+++ b/src/display.h
@@ -169,6 +169,7 @@ enum MOUSE_TARGET
 
 extern bool		gameStats;
 extern bool		godMode;
+extern bool		lockCameraScrollWhileRotating;
 
 extern bool getShakeStatus();
 extern void setShakeStatus(bool val);


### PR DESCRIPTION
Restores the previous behavior of scrolling the camera via moving the mouse off the window and enabling the current locking nature of it via a config option named `lockCameraScrollWhileRotating`. I also made sure to break the scroll lock if the player is scrolling the camera via a key press.


Fixes #1599. 