### PR TITLE
[QuickJS] Remove errant JS_FreeValue

### DIFF
--- a/src/quickjs_backend.cpp
+++ b/src/quickjs_backend.cpp
@@ -1327,7 +1327,6 @@ static JSValue callFunction(JSContext *ctx, const std::string &function, std::ve
 				// failed
 				ASSERT(false, "Failed"); // TODO:
 			}
-			JS_FreeValue(ctx, value);
 			return intVal;
 		}
 
@@ -1347,7 +1346,6 @@ static JSValue callFunction(JSContext *ctx, const std::string &function, std::ve
 				// failed
 				ASSERT(false, "Failed"); // TODO:
 			}
-			JS_FreeValue(ctx, value);
 			return uintVal;
 		}
 


### PR DESCRIPTION
`JS_FreeValue` should not be called in these functions on the input value.

This was only an issue in practice if the input value was a reference-counted QuickJS type (`JS_FreeValue` is a no-op otherwise), and so had no effect if the input `JSValue` was an int as expected. Could lead to a double-free later.

Fixes #1641