### PR TITLE
Mouse lock fix

### DIFF
--- a/src/hci.cpp
+++ b/src/hci.cpp
@@ -1138,6 +1138,7 @@ INT_RETVAL intRunWidgets()
 		case IDMISSIONRES_QUIT:			// mission quit
 		case INTINGAMEOP_QUIT:			// esc quit confirm
 		case IDOPT_QUIT:						// options screen quit
+			intCloseInGameOptions(false, false);
 			intResetScreen(false);
 			quitting = true;
 			break;

--- a/src/ingameop.cpp
+++ b/src/ingameop.cpp
@@ -421,21 +421,30 @@ bool intCloseInGameOptions(bool bPutUpLoadSave, bool bResetMissionWidgets)
 	{
 		// close the form.
 		// Start the window close animation.
-		IntFormAnimated *form;
-		if (isInGamePopupUp)	// FIXME: we hijack this routine for the popup close.
+		IntFormAnimated *form = (IntFormAnimated *)widgGetFromID(psWScreen, INTINGAMEPOPUP);
+		if (form)	// FIXME: we hijack this routine for the popup close.
 		{
-			form = (IntFormAnimated *)widgGetFromID(psWScreen, INTINGAMEPOPUP);
+			form->closeAnimateDelete();
 			isInGamePopupUp = false;
 		}
-		else
-		{
-			form = (IntFormAnimated *)widgGetFromID(psWScreen, INTINGAMEOP);
-		}
-
+		form = (IntFormAnimated *)widgGetFromID(psWScreen, INTINGAMEOP_POPUP_QUIT);
 		if (form)
 		{
 			form->closeAnimateDelete();
-			InGameOpUp			 = false;
+			isInGamePopupUp = false;
+		}
+
+		form = (IntFormAnimated *)widgGetFromID(psWScreen, INTINGAMEOP);
+		if (form)
+		{
+			form->closeAnimateDelete();
+			InGameOpUp = false;
+		}
+		form = (IntFormAnimated *)widgGetFromID(psWScreen, INTINGAMEOP_QUIT);
+		if (form)
+		{
+			form->closeAnimateDelete();
+			InGameOpUp = false;
 		}
 	}
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1366,6 +1366,7 @@ bool stageThreeShutDown()
 	challengesUp = false;
 	challengeActive = false;
 	isInGamePopupUp = false;
+	InGameOpUp = false;
 	bInTutorial = false;
 
 	shutdownTemplates();


### PR DESCRIPTION
Cleans up `INTINGAMEOP_POPUP_QUIT` and `INTINGAMEOP_QUIT` in addition to the others. Sets `InGameOpUp` to false at `stageThreeShutdown()` like it does with `isInGamePopupUp`.

Fixes #1657.