### PR TITLE
Retain shared_ptr to reticule buttons

### DIFF
--- a/src/hci.cpp
+++ b/src/hci.cpp
@@ -251,7 +251,7 @@ struct RETBUTSTATS
 	std::string tip;
 	bool flashing = false;
 	int flashTime = 0;
-	W_BUTTON *button = nullptr;
+	std::shared_ptr<W_BUTTON> button = nullptr;
 	playerCallbackFunc callbackFunc = nullptr;
 };
 static RETBUTSTATS retbutstats[NUMRETBUTS];
@@ -368,6 +368,10 @@ void setReticulesEnabled(bool enabled)
 		}
 
 		ReticuleEnabled[i].Enabled = enabled;
+
+		if (!retbutstats[i].button) {
+			continue;
+		}
 		if (enabled)
 		{
 			retbutstats[i].button->unlock();
@@ -1655,7 +1659,8 @@ bool intAddReticule()
 		retbutstats[i].downTime = 0;
 		retbutstats[i].flashing = false;
 		retbutstats[i].flashTime = 0;
-		retbutstats[i].button = widgAddButton(psWScreen, &sButInit);
+		auto pButton = widgAddButton(psWScreen, &sButInit);
+		retbutstats[i].button = (pButton) ? std::dynamic_pointer_cast<W_BUTTON>(pButton->shared_from_this()) : nullptr;
 		if (!retbutstats[i].button)
 		{
 			debug(LOG_ERROR, "Failed to add reticule button");


### PR DESCRIPTION
Should fix #1667

Previously a raw pointer to the `W_BUTTON`s was being stored, and was not cleared when the parent form was destroyed in `intRemoveReticule`. When backing out of (for example) the save menu, `setReticulesEnabled` is called prior to re-creating the reticule form + buttons, so raw pointers to freed `W_BUTTON` instances were being used.

Instead of refactoring the order that all of this happens (and potentially causing more bugs in the beta phase), this minimal fix will ensure that any `W_BUTTON`s in `retbutstats` actually exist as long as they are stored in `retbutstats`.