### PR TITLE
Fix player duplication in skirmish

### DIFF
--- a/src/multiint.cpp
+++ b/src/multiint.cpp
@@ -3323,17 +3323,18 @@ static void swapPlayerColours(uint32_t player1, uint32_t player2)
  */
 static void resetPlayerConfiguration(const bool bShouldResetLocal = false)
 {
+	auto selectedPlayerPosition = bShouldResetLocal? 0: NetPlay.players[selectedPlayer].position;
 	for (unsigned playerIndex = 0; playerIndex < MAX_PLAYERS_IN_GUI; playerIndex++)
 	{
 		setPlayerColour(playerIndex, playerIndex);
 		swapPlayerColours(playerIndex, rand() % (playerIndex + 1));
+		NetPlay.players[playerIndex].position = playerIndex;
 
 		if (!bShouldResetLocal && playerIndex == selectedPlayer)
 		{
 			continue;
 		}
 
-		NetPlay.players[playerIndex].position = playerIndex;
 		NetPlay.players[playerIndex].team = playerIndex / playersPerTeam();
 
 		if (NetPlay.bComms)
@@ -3350,6 +3351,10 @@ static void resetPlayerConfiguration(const bool bShouldResetLocal = false)
 			/* ensure all players have a name in One Player Skirmish games */
 			sstrcpy(NetPlay.players[playerIndex].name, getAIName(playerIndex));
 		}
+	}
+
+	if (!bShouldResetLocal && selectedPlayerPosition < game.maxPlayers && selectedPlayer != selectedPlayerPosition) {
+		std::swap(NetPlay.players[selectedPlayer].position, NetPlay.players[selectedPlayerPosition].position);
 	}
 
 	sstrcpy(NetPlay.players[selectedPlayer].name, sPlayer);


### PR DESCRIPTION
Fixes #1655 

This also fixes the issue in 3.4.1, that happens when the player moves to the last slot, then changes to a smaller map:
<img src="https://user-images.githubusercontent.com/821208/112383110-ff665880-8cec-11eb-8603-432c1fac448e.png" alt="alt text" width="200px">

https://github.com/Warzone2100/warzone2100/pull/994 introduced the
function `resetPlayerConfiguration`, but this function avoids changing
the local player's information.

This causes problems when `NetPlay.players[selectedPlayer].position !=
selectedPlayer`, cause in this case, the position of all other players
is reset to match their index, causing the position of the player with
index `NetPlay.players[selectedPlayer].position` to be the same as the
position of `selectedPlayer`.

The flag `bShouldResetLocal`, introduced in the commit
37f4eb11d352e30b57665a94cf4a7dbba4619e38 tried to fix this and some
related issues, but only in some situations. When `bShouldResetLocal` is
false the problem still happens.

The approach used in this commit causes all players' positions to be
reset, and at the end, if the local player position is supposed to be
kept, the position gets swapped with one of the other players.