### PR TITLE
[QuickJS] Fix unbox<wzapi::va_list<T>>

### DIFF
--- a/src/quickjs_backend.cpp
+++ b/src/quickjs_backend.cpp
@@ -1604,9 +1604,15 @@ static JSValue callFunction(JSContext *ctx, const std::string &function, std::ve
 				if (argc <= idx)
 					return {};
 				wzapi::va_list<ContainedType> result;
-				for (; idx < argc; idx++)
+				size_t before_idx = idx;
+				for (; idx < argc; )
 				{
+					before_idx = idx;
 					result.va_list.push_back(unbox<ContainedType>()(idx, ctx, argc, argv, function));
+					if (before_idx == idx)
+					{
+						idx++;
+					}
 				}
 				return result;
 			}

--- a/src/wzapi.cpp
+++ b/src/wzapi.cpp
@@ -1760,7 +1760,7 @@ static std::unique_ptr<DROID_TEMPLATE> makeTemplate(int player, const std::strin
 	}
 	if (psComp->compType == COMP_WEAPON)
 	{
-		for (int i = 0; i < numTurrets; i++) // may be multi-weapon
+		for (int i = 0; i < std::min(numTurrets, MAX_WEAPONS); i++) // may be multi-weapon
 		{
 			result = get_first_available_component(player, SIZE_NUM, _turrets.va_list[i], COMP_WEAPON, strict);
 			if (result < 0)


### PR DESCRIPTION
The unboxing issue could cause `buildDroid` to only utilize the first turret parameter.