### PR TITLE
Fixes for long nicknames.

### DIFF
--- a/src/multiint.cpp
+++ b/src/multiint.cpp
@@ -2552,7 +2552,8 @@ void WzMultiplayerOptionsTitleUI::addPlayerBox(bool players)
 		psWidget->setGeometry(MULTIOP_PLAYERSX, MULTIOP_PLAYERSY, MULTIOP_PLAYERSW, MULTIOP_PLAYERSH);
 	}));
 
-	addSideText(FRONTEND_SIDETEXT2, MULTIOP_PLAYERSX - 3, MULTIOP_PLAYERSY, _("PLAYERS"));
+	// May be needed in the future.
+	//addSideText(FRONTEND_SIDETEXT2, MULTIOP_PLAYERSX - 3, MULTIOP_PLAYERSY, _("PLAYERS"));
 
 	if (players)
 	{

--- a/src/multiint.h
+++ b/src/multiint.h
@@ -134,11 +134,11 @@ void displayRoomNotifyMessage(char const *text);
 // GAME OPTIONS SCREEN
 
 #define MULTIOP_PLAYERS			10231
-#define MULTIOP_PLAYERSX		360
+#define MULTIOP_PLAYERSX		323
 #define MULTIOP_PLAYERSY		1
 #define MULTIOP_PLAYER_START	10232		//list of players
 #define MULTIOP_PLAYER_END		10249
-#define MULTIOP_PLAYERSW		263
+#define MULTIOP_PLAYERSW		298
 #define MULTIOP_PLAYERSH		380
 
 #define MULTIOP_ROW_WIDTH		246
@@ -163,7 +163,7 @@ void displayRoomNotifyMessage(char const *text);
 #define MULTIOP_READY_WIDTH			41
 #define MULTIOP_READY_HEIGHT		38
 
-#define MULTIOP_PLAYERWIDTH		245
+#define MULTIOP_PLAYERWIDTH		282
 #define	MULTIOP_PLAYERHEIGHT	38
 
 #define MULTIOP_OPTIONS			10250

--- a/src/multimenu.cpp
+++ b/src/multimenu.cpp
@@ -134,7 +134,7 @@ static const unsigned M_REQUEST_NP[] = {M_REQUEST_2P,    M_REQUEST_3P,    M_REQU
 #define M_REQUEST_W		MULTIOP_PLAYERSW
 #define M_REQUEST_H		MULTIOP_PLAYERSH
 
-#define	R_BUT_W			105//112
+#define	R_BUT_W			120//105
 #define R_BUT_H			30
 
 #define HOVER_PREVIEW_TIME 300


### PR DESCRIPTION
There was a problem with long nicknames. #1574 
![in_beta2](https://user-images.githubusercontent.com/50840397/112703414-de963280-8ea7-11eb-8e45-7a14e48560a8.png)
The increase in the length of the nickname occurs due to the shift of the beginning of the form to the left. To get enough space, removed the inscription "PLAYERS". Looks good.
![fix1](https://user-images.githubusercontent.com/50840397/112703449-008fb500-8ea8-11eb-9470-325854485798.png)
I also increased the length in the fields in the list, nicknames and card selection. It was related.
![fix_context](https://user-images.githubusercontent.com/50840397/112703468-14d3b200-8ea8-11eb-96c6-c4638bceb864.png)
