### PR TITLE
Use widgScheduleTask in appropriate callers of displayStatsForm

### DIFF
--- a/src/hci/build.cpp
+++ b/src/hci/build.cpp
@@ -178,7 +178,7 @@ public:
 		controller->selectObject(controller->getObjectAt(objectIndex));
 		jump();
 
-		controller->displayStatsForm();
+		BaseStatsController::scheduleDisplayStatsForm(controller);
 	}
 
 protected:
@@ -378,7 +378,7 @@ private:
 			controller->selectObject(droid);
 		}
 
-		controller->displayStatsForm();
+		BaseStatsController::scheduleDisplayStatsForm(controller);
 	}
 
 	void clickSecondary() override
@@ -391,7 +391,7 @@ private:
 		if (droid == highlighted || !highlighted->selected)
 		{
 			controller->setHighlightedObject(droid);
-			controller->displayStatsForm();
+			BaseStatsController::scheduleDisplayStatsForm(controller);
 		}
 	}
 

--- a/src/hci/manufacture.cpp
+++ b/src/hci/manufacture.cpp
@@ -196,7 +196,7 @@ public:
 		controller->clearStructureSelection();
 		controller->selectObject(controller->getObjectAt(objectIndex));
 		jump();
-		controller->displayStatsForm();
+		BaseStatsController::scheduleDisplayStatsForm(controller);
 	}
 
 protected:
@@ -366,7 +366,7 @@ private:
 		controller->releaseFactoryProduction(factory);
 		controller->clearStructureSelection();
 		controller->selectObject(factory);
-		controller->displayStatsForm();
+		BaseStatsController::scheduleDisplayStatsForm(controller);
 	}
 
 	void clickSecondary() override
@@ -377,7 +377,7 @@ private:
 		controller->cancelFactoryProduction(factory);
 		controller->setHighlightedObject(factory);
 		controller->refresh();
-		controller->displayStatsForm();
+		BaseStatsController::scheduleDisplayStatsForm(controller);
 	}
 
 	std::shared_ptr<ManufactureController> controller;

--- a/src/hci/objects_stats.cpp
+++ b/src/hci/objects_stats.cpp
@@ -85,16 +85,22 @@ void BaseStatsController::displayStatsForm()
 	if (widgGetFromID(psWScreen, IDSTAT_FORM) == nullptr)
 	{
 		auto newStatsForm = makeStatsForm();
-		widgScheduleTask([newStatsForm]() {
-			if (widgGetFromID(psWScreen, IDSTAT_FORM) != nullptr)
-			{
-				return;
-			}
-			psWScreen->psForm->attach(newStatsForm);
-			intMode = INT_STAT;
-			setSecondaryWindowUp(true);
-		});
+		psWScreen->psForm->attach(newStatsForm);
+		intMode = INT_STAT;
+		setSecondaryWindowUp(true);
 	}
+}
+
+// To be called from within widget click & run handlers / functions
+void BaseStatsController::scheduleDisplayStatsForm(const std::shared_ptr<BaseStatsController>& controller)
+{
+	std::weak_ptr<BaseStatsController> psWeakController = controller;
+	widgScheduleTask([psWeakController]() {
+		if (auto psStrongController = psWeakController.lock())
+		{
+			psStrongController->displayStatsForm();
+		}
+	});
 }
 
 void DynamicIntFancyButton::updateLayout()

--- a/src/hci/objects_stats.h
+++ b/src/hci/objects_stats.h
@@ -67,6 +67,7 @@ public:
 	virtual size_t statsSize() const = 0;
 	virtual std::shared_ptr<StatsForm> makeStatsForm() = 0;
 	void displayStatsForm();
+	static void scheduleDisplayStatsForm(const std::shared_ptr<BaseStatsController>& controller);
 	virtual BASE_STATS *getStatsAt(size_t) const = 0;
 };
 

--- a/src/hci/research.cpp
+++ b/src/hci/research.cpp
@@ -262,7 +262,7 @@ protected:
 		controller->clearStructureSelection();
 		controller->selectObject(controller->getObjectAt(objectIndex));
 		jump();
-		controller->displayStatsForm();
+		BaseStatsController::scheduleDisplayStatsForm(controller);
 	}
 
 	void display(int xOffset, int yOffset) override
@@ -425,7 +425,7 @@ private:
 		releaseResearch(facility, ModeQueue);
 		controller->clearStructureSelection();
 		controller->selectObject(facility);
-		controller->displayStatsForm();
+		BaseStatsController::scheduleDisplayStatsForm(controller);
 		controller->refresh();
 	}
 
@@ -436,7 +436,7 @@ private:
 		controller->clearStructureSelection();
 		controller->requestResearchCancellation(facility);
 		controller->setHighlightedObject(facility);
-		controller->displayStatsForm();
+		BaseStatsController::scheduleDisplayStatsForm(controller);
 		controller->refresh();
 	}
 


### PR DESCRIPTION
Instead of inside `BaseStatsController::displayStatsForm()` itself, as it's called from other places where the delay is not wanted / needed.

Hopefully improves / fixes #1685?

@maxsupermanhd