### PR TITLE
manufacture.cpp: Add null checks

### DIFF
--- a/lib/widget/label.cpp
+++ b/lib/widget/label.cpp
@@ -211,6 +211,11 @@ WzString W_LABEL::getString() const
 
 void W_LABEL::setString(WzString string)
 {
+	if ((aTextLines.size() == 1) && (aTextLines.front().text == string.toStdString()))
+	{
+		// no change - skip
+		return;
+	}
 	aTextLines.clear();
 	aTextLines.push_back({string.toStdString(), Vector2i(0,0), Vector2i(0,0)});
 	displayCache.wzText.clear();

--- a/src/hci/manufacture.cpp
+++ b/src/hci/manufacture.cpp
@@ -100,6 +100,8 @@ static inline bool compareFactories(STRUCTURE *a, STRUCTURE *b)
 	ASSERT_NOT_NULLPTR_OR_RETURN(false, x);
 	auto y = getFactoryOrNullptr(b);
 	ASSERT_NOT_NULLPTR_OR_RETURN(false, y);
+	ASSERT_NOT_NULLPTR_OR_RETURN(false, x->psAssemblyPoint);
+	ASSERT_NOT_NULLPTR_OR_RETURN(false, y->psAssemblyPoint);
 	if (x->psAssemblyPoint->factoryType != y->psAssemblyPoint->factoryType)
 	{
 		return x->psAssemblyPoint->factoryType < y->psAssemblyPoint->factoryType;
@@ -221,6 +223,11 @@ protected:
 		BaseWidget::updateLayout();
 		auto factory = getFactoryOrNullptr(controller->getObjectAt(objectIndex));
 		ASSERT_NOT_NULLPTR_OR_RETURN(, factory);
+		if (factory->psAssemblyPoint == nullptr)
+		{
+			factoryNumberLabel->setString("");
+			return;
+		}
 		factoryNumberLabel->setString(WzString::fromUtf8(astringf("%u", factory->psAssemblyPoint->factoryInc + 1)));
 	}
 


### PR DESCRIPTION
Should fix #1688, I believe?

(Based on the logs, I suspect the struct died and its `factory->psAssemblyPoint` is probably `null`.)

Also a drive-by improvement for `W_LABEL::setString` (Shortcut if string is same as existing.)