### PR TITLE
Count gates as blocking walls.

### DIFF
--- a/src/map.h
+++ b/src/map.h
@@ -290,6 +290,7 @@ static inline bool TileHasWall(const MAPTILE *tile)
 {
 	return TileHasStructure(tile)
 	       && (((STRUCTURE *)tile->psObject)->pStructureType->type == REF_WALL
+	           || ((STRUCTURE *)tile->psObject)->pStructureType->type == REF_GATE
 	           || ((STRUCTURE *)tile->psObject)->pStructureType->type == REF_WALLCORNER);
 }
 

--- a/src/visibility.cpp
+++ b/src/visibility.cpp
@@ -367,9 +367,13 @@ static bool rayLOSCallback(Vector2i pos, int32_t dist, void *data)
 			MAPTILE *psTile = mapTile(tile);
 			if (TileHasWall(psTile) && !TileHasSmallStructure(psTile))
 			{
-				help->lastHeight = 2 * UBYTE_MAX * ELEVATION_SCALE;
-				help->wall = pos.xy();
-				help->numWalls++;
+				STRUCTURE *psStruct = (STRUCTURE *)psTile->psObject;
+				if (psStruct->pStructureType->type != REF_GATE || psStruct->state != SAS_OPEN)
+				{
+					help->lastHeight = 2 * UBYTE_MAX * ELEVATION_SCALE;
+					help->wall = pos.xy();
+					help->numWalls++;
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Only when a gate is completely open should they considered not blocking (and thus allow attacking over them).

Added gates to `TileHasWall()` which doesn't appear to affect anything.

Fixes #1482.