### PR TITLE
Fix delay on factory orders

### DIFF
--- a/src/hci/manufacture.cpp
+++ b/src/hci/manufacture.cpp
@@ -440,8 +440,7 @@ private:
 	void updateProductionRunSizeLabel(STRUCTURE *structure, DROID_TEMPLATE *droidTemplate)
 	{
 		auto production = getProduction(structure, droidTemplate);
-		auto factory = getFactoryOrNullptr(structure);
-		if (factory && factory->psSubject && StructureIsManufacturingPending(structure) && production.isValid())
+		if (production.isValid())
 		{
 			auto productionLoops = getProductionLoops(structure);
 			auto labelText = astringf(productionLoops > 0 ? "%d/%d" : "%d", production.numRemaining(), production.quantity);


### PR DESCRIPTION
Fixes #1684.

This condition was simply wrong. It was probably a copy paste mistake.

The original condition was just checking if the production is valid, as can be seen in the original code for the stats button quantity:
https://github.com/Warzone2100/warzone2100/blob/d05ad5273c2e702f961bbd3f9a018b328b050365/src/intdisplay.cpp#L377-L421