### PR TITLE
Hide "PLAYERS" text

### DIFF
--- a/src/multiint.cpp
+++ b/src/multiint.cpp
@@ -2584,8 +2584,8 @@ void WzMultiplayerOptionsTitleUI::addPlayerBox(bool players)
 		psWidget->setGeometry(MULTIOP_PLAYERSX, MULTIOP_PLAYERSY, MULTIOP_PLAYERSW, MULTIOP_PLAYERSH);
 	}));
 
-	// May be needed in the future.
-	//addSideText(FRONTEND_SIDETEXT2, MULTIOP_PLAYERSX - 3, MULTIOP_PLAYERSY, _("PLAYERS"));
+	W_LABEL* pPlayersLabel = addSideText(FRONTEND_SIDETEXT2, MULTIOP_PLAYERSX - 3, MULTIOP_PLAYERSY, _("PLAYERS"));
+	pPlayersLabel->hide(); // hide for now
 
 	if (players)
 	{


### PR DESCRIPTION
Instead of commenting it out, to ensure it's still in the translations file (for future use).