### PR TITLE
Fix broken map zoom cycle.

### DIFF
--- a/src/configuration.cpp
+++ b/src/configuration.cpp
@@ -48,6 +48,7 @@
 #include "lib/framework/wzapp.h"
 #include "display3d.h" // for building animation speed
 #include "display.h"
+#include "keybind.h" // for MAP_ZOOM_RATE_STEP
 
 #include <type_traits>
 
@@ -302,15 +303,18 @@ bool loadConfig()
 	}
 	if (auto value = iniGetIntegerOpt("mapZoom"))
 	{
-		war_SetMapZoom(value.value());
+		int v = value.value();
+		war_SetMapZoom((v % MAP_ZOOM_CONFIG_STEP != 0) ? STARTDISTANCE : v);
 	}
 	if (auto value = iniGetIntegerOpt("mapZoomRate"))
 	{
-		war_SetMapZoomRate(value.value());
+		int v = value.value();
+		war_SetMapZoomRate((v % MAP_ZOOM_RATE_STEP != 0) ? MAP_ZOOM_RATE_DEFAULT : v);
 	}
 	if (auto value = iniGetIntegerOpt("radarZoom"))
 	{
-		war_SetRadarZoom(value.value());
+		int v = value.value();
+		war_SetRadarZoom((v % RADARZOOM_STEP != 0) ? DEFAULT_RADARZOOM : v);
 	}
 	if (iniGeneral.has("language"))
 	{
@@ -325,7 +329,8 @@ bool loadConfig()
 	showUNITCOUNT = iniGetBool("showUNITCOUNT", false).value();
 	if (auto value = iniGetIntegerOpt("cameraSpeed"))
 	{
-		war_SetCameraSpeed(value.value());
+		int v = value.value();
+		war_SetCameraSpeed((v % CAMERASPEED_STEP != 0) ? CAMERASPEED_DEFAULT : v);
 	}
 	setShakeStatus(iniGetBool("shake", false).value());
 	setCameraAccel(iniGetBool("cameraAccel", true).value());

--- a/src/display.h
+++ b/src/display.h
@@ -200,7 +200,7 @@ bool	getRotActive();
 #define MINDISTANCE	(0)
 #define MINDISTANCE_CONFIG (1600)
 #define MAP_ZOOM_CONFIG_STEP (200)
-#define STARTDISTANCE	(2500)
+#define STARTDISTANCE	(2600)
 #define OLD_START_HEIGHT (1500) // only used in savegames <= 10
 
 #define CAMERA_PIVOT_HEIGHT (500)


### PR DESCRIPTION
For real this time.

Initial map zoom is 2500 (`STARTDISTANCE`). 2500 % `MAP_ZOOM_CONFIG_STEP` (200) is definitely not 0 for `war_SetMapZoom()`.

The default is now 2600 so this will work.