### PR TITLE
Various performance improvements for save / autosave

### DIFF
--- a/lib/framework/wzconfig.cpp
+++ b/lib/framework/wzconfig.cpp
@@ -1,7 +1,7 @@
 /*
 	This file is part of Warzone 2100.
 	Copyright (C) 1999-2004  Eidos Interactive
-	Copyright (C) 2005-2020  Warzone 2100 Project
+	Copyright (C) 2005-2021  Warzone 2100 Project
 
 	Warzone 2100 is free software; you can redistribute it and/or modify
 	it under the terms of the GNU General Public License as published by
@@ -491,6 +491,12 @@ void WzConfig::endArray()
 		mObjStack.pop_back();
 	}
 	mArray = nlohmann::json::array();
+}
+
+void WzConfig::setValue(const WzString &key, const nlohmann::json &&value)
+{
+	ASSERT(pCurrentObj != nullptr, "pCurrentObj is null");
+	(*pCurrentObj)[key.toUtf8()] = value;
 }
 
 void WzConfig::setValue(const WzString &key, const nlohmann::json &value)

--- a/lib/framework/wzconfig.h
+++ b/lib/framework/wzconfig.h
@@ -149,6 +149,7 @@ public:
 		return mWarning == ReadAndWrite && mStatus;
 	}
 
+	void setValue(const WzString &key, const nlohmann::json &&value);
 	void setValue(const WzString &key, const nlohmann::json &value);
 	void set(const WzString &key, const nlohmann::json &value);
 

--- a/lib/framework/wzconfig.h
+++ b/lib/framework/wzconfig.h
@@ -1,7 +1,7 @@
 /*
 	This file is part of Warzone 2100.
 	Copyright (C) 1999-2004  Eidos Interactive
-	Copyright (C) 2005-2020  Warzone 2100 Project
+	Copyright (C) 2005-2021  Warzone 2100 Project
 
 	Warzone 2100 is free software; you can redistribute it and/or modify
 	it under the terms of the GNU General Public License as published by
@@ -220,6 +220,28 @@ inline void from_json(const json& j, ivec3& r)
 	}
 	catch (...) {
 		debug(LOG_FATAL, "Unexpected exception encountered in Vector3i");
+	}
+}
+
+// Vector3f
+inline void to_json(json& j, const vec3 &v)
+{
+	j = nlohmann::json::array({ v.x, v.y, v.z });
+}
+
+inline void from_json(const json& j, vec3& r)
+{
+	ASSERT(j.size() == 3, "Bad Vector3f list");
+	try {
+		r.x = j.at(0).get<float>();
+		r.y = j.at(1).get<float>();
+		r.z = j.at(2).get<float>();
+	}
+	catch (const std::exception &e) {
+		ASSERT(false, "Bad Vector3f list; exception: %s", e.what());
+	}
+	catch (...) {
+		debug(LOG_FATAL, "Unexpected exception encountered in Vector3f");
 	}
 }
 } // namespace glm

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -4897,7 +4897,8 @@ static nlohmann::json writeDroid(DROID *psCurr, bool onMission, int &counter)
 	{
 		if (psCurr->asWeaps[i].nStat > 0)
 		{
-			const std::string& numStr = WzString::number(i).toStdString();
+			auto numberWzStr = WzString::number(i);
+			const std::string& numStr = numberWzStr.toStdString();
 			droidObj["ammo/" + numStr] = psCurr->asWeaps[i].ammo;
 			droidObj["lastFired/" + numStr] = psCurr->asWeaps[i].lastFired;
 			droidObj["shotsFired/" + numStr] = psCurr->asWeaps[i].shotsFired;

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1,7 +1,7 @@
 /*
 	This file is part of Warzone 2100.
 	Copyright (C) 1999-2004  Eidos Interactive
-	Copyright (C) 2005-2020  Warzone 2100 Project
+	Copyright (C) 2005-2021  Warzone 2100 Project
 
 	Warzone 2100 is free software; you can redistribute it and/or modify
 	it under the terms of the GNU General Public License as published by
@@ -4872,6 +4872,15 @@ static bool loadSaveDroid(const char *pFileName, DROID **ppsCurrentDroidLists)
 	return true;
 }
 
+static inline bool saveJSONToFile(const nlohmann::json& obj, const char* pFileName)
+{
+	std::ostringstream stream;
+	stream << obj.dump(4) << std::endl;
+	std::string jsonString = stream.str();
+	debug(LOG_SAVE, "%s %s", "Saving", pFileName);
+	return saveFile(pFileName, jsonString.c_str(), jsonString.size());
+}
+
 // -----------------------------------------------------------------------------------------
 /*
 Writes the linked list of droids for each player to a file
@@ -5021,11 +5030,7 @@ static bool writeDroidFile(const char *pFileName, DROID **ppsCurrentDroidLists)
 		}
 	}
 
-	std::ostringstream stream;
-	stream << mRoot.dump(4) << std::endl;
-	std::string jsonString = stream.str();
-	saveFile(pFileName, jsonString.c_str(), jsonString.size());
-	debug(LOG_SAVE, "%s %s", "Saving", pFileName);
+	saveJSONToFile(mRoot, pFileName);
 
 	return true;
 }
@@ -6099,43 +6104,47 @@ bool loadSaveTemplate(const char *pFileName)
 	return true;
 }
 
+static nlohmann::json convGameTemplateToJSON(DROID_TEMPLATE *psCurr)
+{
+	nlohmann::json templateObj = saveTemplateCommon(psCurr);
+	templateObj["ref"] = psCurr->ref;
+	templateObj["multiPlayerID"] = psCurr->multiPlayerID;
+	templateObj["enabled"] = psCurr->enabled;
+	templateObj["stored"] = psCurr->stored;
+	templateObj["prefab"] = psCurr->prefab;
+	return templateObj;
+}
+
 bool writeTemplateFile(const char *pFileName)
 {
-	WzConfig ini(pFileName, WzConfig::ReadAndWrite);
+	nlohmann::json mRoot = nlohmann::json::object();
 
-	auto writeTemplate = [&](DROID_TEMPLATE *psCurr) {
-		saveTemplateCommon(ini, psCurr);
-		ini.setValue("ref", psCurr->ref);
-		ini.setValue("multiPlayerID", psCurr->multiPlayerID);
-		ini.setValue("enabled", psCurr->enabled);
-		ini.setValue("stored", psCurr->stored);
-		ini.setValue("prefab", psCurr->prefab);
-		ini.nextArrayItem();
-	};
-
-	ini.setValue("version", 1);
+	mRoot["version"] = 1;
 	for (int player = 0; player < MAX_PLAYERS; player++)
 	{
 		if (!apsDroidLists[player] && !apsStructLists[player])	// only write out templates of players that are still 'alive'
 		{
 			continue;
 		}
-		ini.beginGroup("player_" + WzString::number(player));
-		setPlayer(ini, player);
-		ini.beginArray("templates");
-		enumerateTemplates(player, [&writeTemplate](DROID_TEMPLATE* psTemplate) {
-			writeTemplate(psTemplate);
+		nlohmann::json playerTemplatesObj = nlohmann::json::object();
+		setPlayerJSON(playerTemplatesObj, player);
+		nlohmann::json templates_array = nlohmann::json::array();
+		enumerateTemplates(player, [&templates_array](DROID_TEMPLATE* psTemplate) {
+			templates_array.push_back(convGameTemplateToJSON(psTemplate));
 			return true;
 		});
-		ini.endArray();
-		ini.endGroup();
+		playerTemplatesObj["templates"] = std::move(templates_array);
+		auto playerKey = "player_" + WzString::number(player);
+		mRoot[playerKey.toUtf8()] = std::move(playerTemplatesObj);
 	}
-	ini.beginArray("localTemplates");
+	nlohmann::json localtemplates_array = nlohmann::json::array();
 	for (auto &psCurr : localTemplates)
 	{
-		writeTemplate(&psCurr);
+		localtemplates_array.push_back(convGameTemplateToJSON(&psCurr));
 	}
-	ini.endArray();
+	mRoot["localTemplates"] = std::move(localtemplates_array);
+
+	saveJSONToFile(mRoot, pFileName);
 	return true;
 }
 

--- a/src/qtscript.cpp
+++ b/src/qtscript.cpp
@@ -1,6 +1,6 @@
 /*
 	This file is part of Warzone 2100.
-	Copyright (C) 2011-2020  Warzone 2100 Project
+	Copyright (C) 2011-2021  Warzone 2100 Project
 
 	Warzone 2100 is free software; you can redistribute it and/or modify
 	it under the terms of the GNU General Public License as published by
@@ -729,7 +729,7 @@ bool scripting_engine::saveScriptStates(const char *filename)
 		saveGroups(groupsResult, instance);
 		groupsResult["me"] = instance->player();
 		groupsResult["scriptName"] = instance->scriptName();
-		ini.setValue("groups_" + WzString::number(i), groupsResult);
+		ini.setValue("groups_" + WzString::number(i), std::move(groupsResult));
 	}
 	size_t timerIdx = 0;
 	for (const auto& node : timers)
@@ -751,7 +751,7 @@ bool scripting_engine::saveScriptStates(const char *filename)
 		nodeInfo["calls"] = node->calls;
 		nodeInfo["type"] = (int)node->type;
 
-		ini.setValue("triggers_" + WzString::number(timerIdx), nodeInfo);
+		ini.setValue("triggers_" + WzString::number(timerIdx), std::move(nodeInfo));
 		++timerIdx;
 	}
 	return true;

--- a/src/template.cpp
+++ b/src/template.cpp
@@ -1,7 +1,7 @@
 /*
 	This file is part of Warzone 2100.
 	Copyright (C) 1999-2004  Eidos Interactive
-	Copyright (C) 2005-2020  Warzone 2100 Project
+	Copyright (C) 2005-2021  Warzone 2100 Project
 
 	Warzone 2100 is free software; you can redistribute it and/or modify
 	it under the terms of the GNU General Public License as published by
@@ -316,58 +316,60 @@ bool initTemplates()
 	return true;
 }
 
-void saveTemplateCommon(WzConfig &ini, const DROID_TEMPLATE *psCurr)
+nlohmann::json saveTemplateCommon(const DROID_TEMPLATE *psCurr)
 {
-	ini.setValue("name", psCurr->name);
+	nlohmann::json templateObj = nlohmann::json::object();
+	templateObj["name"] = psCurr->name;
 	switch (psCurr->droidType)
 	{
-	case DROID_ECM: ini.setValue("type", "ECM"); break;
-	case DROID_SENSOR: ini.setValue("type", "SENSOR"); break;
-	case DROID_CONSTRUCT: ini.setValue("type", "CONSTRUCT"); break;
-	case DROID_WEAPON: ini.setValue("type", "WEAPON"); break;
-	case DROID_PERSON: ini.setValue("type", "PERSON"); break;
-	case DROID_CYBORG: ini.setValue("type", "CYBORG"); break;
-	case DROID_CYBORG_SUPER: ini.setValue("type", "CYBORG_SUPER"); break;
-	case DROID_CYBORG_CONSTRUCT: ini.setValue("type", "CYBORG_CONSTRUCT"); break;
-	case DROID_CYBORG_REPAIR: ini.setValue("type", "CYBORG_REPAIR"); break;
-	case DROID_TRANSPORTER: ini.setValue("type", "TRANSPORTER"); break;
-	case DROID_SUPERTRANSPORTER: ini.setValue("type", "SUPERTRANSPORTER"); break;
-	case DROID_COMMAND: ini.setValue("type", "DROID_COMMAND"); break;
-	case DROID_REPAIR: ini.setValue("type", "REPAIR"); break;
-	case DROID_DEFAULT: ini.setValue("type", "DROID"); break;
+	case DROID_ECM: templateObj["type"] = "ECM"; break;
+	case DROID_SENSOR: templateObj["type"] = "SENSOR"; break;
+	case DROID_CONSTRUCT: templateObj["type"] = "CONSTRUCT"; break;
+	case DROID_WEAPON: templateObj["type"] = "WEAPON"; break;
+	case DROID_PERSON: templateObj["type"] = "PERSON"; break;
+	case DROID_CYBORG: templateObj["type"] = "CYBORG"; break;
+	case DROID_CYBORG_SUPER: templateObj["type"] = "CYBORG_SUPER"; break;
+	case DROID_CYBORG_CONSTRUCT: templateObj["type"] = "CYBORG_CONSTRUCT"; break;
+	case DROID_CYBORG_REPAIR: templateObj["type"] = "CYBORG_REPAIR"; break;
+	case DROID_TRANSPORTER: templateObj["type"] = "TRANSPORTER"; break;
+	case DROID_SUPERTRANSPORTER: templateObj["type"] = "SUPERTRANSPORTER"; break;
+	case DROID_COMMAND: templateObj["type"] = "DROID_COMMAND"; break;
+	case DROID_REPAIR: templateObj["type"] = "REPAIR"; break;
+	case DROID_DEFAULT: templateObj["type"] = "DROID"; break;
 	default: ASSERT(false, "No such droid type \"%d\" for %s", psCurr->droidType, psCurr->name.toUtf8().c_str());
 	}
-	ini.setValue("body", (asBodyStats + psCurr->asParts[COMP_BODY])->id);
-	ini.setValue("propulsion", (asPropulsionStats + psCurr->asParts[COMP_PROPULSION])->id);
+	templateObj["body"] = (asBodyStats + psCurr->asParts[COMP_BODY])->id;
+	templateObj["propulsion"] = (asPropulsionStats + psCurr->asParts[COMP_PROPULSION])->id;
 	if (psCurr->asParts[COMP_BRAIN] != 0)
 	{
-		ini.setValue("brain", (asBrainStats + psCurr->asParts[COMP_BRAIN])->id);
+		templateObj["brain"] = (asBrainStats + psCurr->asParts[COMP_BRAIN])->id;
 	}
 	if ((asRepairStats + psCurr->asParts[COMP_REPAIRUNIT])->location == LOC_TURRET) // avoid auto-repair...
 	{
-		ini.setValue("repair", (asRepairStats + psCurr->asParts[COMP_REPAIRUNIT])->id);
+		templateObj["repair"] = (asRepairStats + psCurr->asParts[COMP_REPAIRUNIT])->id;
 	}
 	if ((asECMStats + psCurr->asParts[COMP_ECM])->location == LOC_TURRET)
 	{
-		ini.setValue("ecm", (asECMStats + psCurr->asParts[COMP_ECM])->id);
+		templateObj["ecm"] = (asECMStats + psCurr->asParts[COMP_ECM])->id;
 	}
 	if ((asSensorStats + psCurr->asParts[COMP_SENSOR])->location == LOC_TURRET)
 	{
-		ini.setValue("sensor", (asSensorStats + psCurr->asParts[COMP_SENSOR])->id);
+		templateObj["sensor"] = (asSensorStats + psCurr->asParts[COMP_SENSOR])->id;
 	}
 	if (psCurr->asParts[COMP_CONSTRUCT] != 0)
 	{
-		ini.setValue("construct", (asConstructStats + psCurr->asParts[COMP_CONSTRUCT])->id);
+		templateObj["construct"] = (asConstructStats + psCurr->asParts[COMP_CONSTRUCT])->id;
 	}
-	std::vector<WzString> weapons;
+	nlohmann::json weapons = nlohmann::json::array();
 	for (int j = 0; j < psCurr->numWeaps; j++)
 	{
 		weapons.push_back((asWeaponStats + psCurr->asWeaps[j])->id);
 	}
 	if (!weapons.empty())
 	{
-		ini.setValue("weapons", weapons);
+		templateObj["weapons"] = std::move(weapons);
 	}
+	return templateObj;
 }
 
 bool storeTemplates()
@@ -386,7 +388,7 @@ bool storeTemplates()
 		const DROID_TEMPLATE *psCurr = keyvaluepair.second.get();
 		if (psCurr->stored)
 		{
-			saveTemplateCommon(ini, psCurr);
+			ini.currentJsonValue() = saveTemplateCommon(psCurr);
 			ini.nextArrayItem();
 		}
 	}

--- a/src/template.h
+++ b/src/template.h
@@ -1,6 +1,6 @@
 /*
 	This file is part of Warzone 2100.
-	Copyright (C) 2011-2020  Warzone 2100 Project
+	Copyright (C) 2011-2021  Warzone 2100 Project
 
 	Warzone 2100 is free software; you can redistribute it and/or modify
 	it under the terms of the GNU General Public License as published by
@@ -66,7 +66,7 @@ bool researchedTemplate(const DROID_TEMPLATE *psCurr, int player, bool allowRedu
 
 void listTemplates();
 
-void saveTemplateCommon(WzConfig &ini, const DROID_TEMPLATE *psCurr);
+nlohmann::json saveTemplateCommon(const DROID_TEMPLATE *psCurr);
 bool loadTemplateCommon(WzConfig &ini, DROID_TEMPLATE &outputTemplate);
 
 void checkPlayerBuiltHQ(const STRUCTURE *psStruct);


### PR DESCRIPTION
Converted several more of the `write<file>` functions to using `nlohmann::json` directly instead of using `WzConfig`.

@KJeff01 If you still have that machine that exhibited slow save performance more readily, would you mind seeing if this makes an impact? (Especially when saving, for example, a 10 player skirmish with some BoneCrusher + Cobra + SemperFi bots that's been left to run until later game with lots of units + templates, etc.)

Also, needs some general solid testing to make sure I didn't break anything.