### PR TITLE
Refactor tip module

### DIFF
--- a/lib/framework/geometry.h
+++ b/lib/framework/geometry.h
@@ -142,6 +142,18 @@ public:
 		return _topLeft.y;
 	}
 
+	// Returns the y-coordinate of the rectangle's bottom edge.
+	int bottom(void) const
+	{
+		return _bottomRight.y;
+	}
+
+	// Returns the x-coordinate of the rectangle's right edge.
+	int right(void) const
+	{
+		return _bottomRight.x;
+	}
+
 	// Returns the x-coordinate of the rectangle's left edge. Equivalent to left().
 	int x(void) const { return left(); }
 

--- a/lib/widget/bar.cpp
+++ b/lib/widget/bar.cpp
@@ -113,26 +113,6 @@ void widgSetBarRange(const std::shared_ptr<W_SCREEN> &psScreen, UDWORD id, UDWOR
 	}
 }
 
-
-/* Respond to a mouse moving over a barGraph */
-void W_BARGRAPH::highlight(W_CONTEXT *psContext)
-{
-	if (!pTip.empty())
-	{
-		if (auto lockedScreen = screenPointer.lock())
-		{
-			tipStart(this, pTip, lockedScreen->TipFontID, x() + psContext->xOffset, y() + psContext->yOffset, width(), height());
-		}
-	}
-}
-
-
-/* Respond to the mouse moving off a barGraph */
-void W_BARGRAPH::highlightLost()
-{
-	tipStop(this);
-}
-
 void W_BARGRAPH::run(W_CONTEXT *context)
 {
 	if (dirty)

--- a/lib/widget/bar.h
+++ b/lib/widget/bar.h
@@ -34,12 +34,15 @@ class W_BARGRAPH : public WIDGET
 public:
 	W_BARGRAPH(W_BARINIT const *init);
 
-	void highlight(W_CONTEXT *psContext) override;
-	void highlightLost() override;
 	void run(W_CONTEXT *) override;
 	void display(int xOffset, int yOffset) override;
 
 	void setTip(std::string string) override;
+
+	std::string getTip() override
+	{
+		return pTip;
+	}
 
 	void setBackgroundColour(PIELIGHT colour)
 	{

--- a/lib/widget/button.cpp
+++ b/lib/widget/button.cpp
@@ -132,12 +132,6 @@ void W_BUTTON::clicked(W_CONTEXT *, WIDGET_KEY key)
 			state |= WBUT_DOWN;
 		}
 	}
-
-	/* Kill the tip if there is one */
-	if (!pTip.empty())
-	{
-		tipStop(this);
-	}
 }
 
 /* Respond to a mouse button up */
@@ -186,15 +180,6 @@ void W_BUTTON::highlight(W_CONTEXT *psContext)
 	{
 		AudioCallback(HilightAudioID);
 	}
-
-	/* If there is a tip string start the tool tip */
-	if (!pTip.empty())
-	{
-		if (auto lockedScreen = screenPointer.lock())
-		{
-			tipStart(this, pTip, lockedScreen->TipFontID, x() + psContext->xOffset, y() + psContext->yOffset, width(), height());
-		}
-	}
 }
 
 
@@ -203,10 +188,6 @@ void W_BUTTON::highlightLost()
 {
 	state &= ~(WBUT_DOWN | WBUT_HIGHLIGHT);
 	dirty = true;
-	if (!pTip.empty())
-	{
-		tipStop(this);
-	}
 }
 
 void W_BUTTON::display(int xOffset, int yOffset)

--- a/lib/widget/button.h
+++ b/lib/widget/button.h
@@ -73,6 +73,11 @@ public:
 	using WIDGET::setString;
 	using WIDGET::setTip;
 
+	std::string getTip() override
+	{
+		return pTip;
+	}
+
 	/* The optional "onClick" callback function */
 	typedef std::function<void (W_BUTTON& button)> W_BUTTON_ONCLICK_FUNC;
 

--- a/lib/widget/form.cpp
+++ b/lib/widget/form.cpp
@@ -105,8 +105,6 @@ bool W_FORM::isUserMovable() const
 
 void W_FORM::clicked(W_CONTEXT *psContext, WIDGET_KEY key)
 {
-	// Stop the tip if there is one.
-	tipStop(this);
 	dirty = true;
 	if (isUserMovable() && key == WKEY_PRIMARY)
 	{
@@ -219,16 +217,6 @@ void W_CLICKFORM::highlight(W_CONTEXT *psContext)
 {
 	state |= WBUT_HIGHLIGHT;
 
-	// If there is a tip string start the tool tip.
-	auto tip = getTip();
-	if (!tip.empty())
-	{
-		if (auto lockedScreen = screenPointer.lock())
-		{
-			tipStart(this, tip, lockedScreen->TipFontID, x() + psContext->xOffset, y() + psContext->yOffset, width(), height());
-		}
-	}
-
 	if (AudioCallback != nullptr)
 	{
 		AudioCallback(HilightAudioID);
@@ -239,8 +227,6 @@ void W_CLICKFORM::highlight(W_CONTEXT *psContext)
 /* Respond to the mouse moving off a form */
 void W_FORM::highlightLost()
 {
-	// Clear the tool tip if there is one.
-	tipStop(this);
 	dirty = true;
 }
 

--- a/lib/widget/form.h
+++ b/lib/widget/form.h
@@ -93,6 +93,10 @@ public:
 	void highlight(W_CONTEXT *psContext) override;
 	void highlightLost() override;
 	void display(int xOffset, int yOffset) override;
+	std::string getTip() override
+	{
+		return pTip;
+	}
 
 	unsigned getState() override;
 	void setState(unsigned state) override;
@@ -106,12 +110,6 @@ public:
 	bool isHighlighted() const;
 
 	unsigned state;                     // Button state of the form
-
-protected:
-	virtual std::string getTip()
-	{
-		return pTip;
-	}
 
 private:
 	std::string pTip;                   // Tip for the form

--- a/lib/widget/label.cpp
+++ b/lib/widget/label.cpp
@@ -29,6 +29,7 @@
 #include "tip.h"
 
 #include <algorithm>
+#include <sstream>
 
 #define LABEL_DEFAULT_CACHE_EXPIRY 250
 
@@ -160,47 +161,28 @@ void W_LABEL::display(int xOffset, int yOffset)
 	}
 }
 
-/* Respond to a mouse moving over a label */
-void W_LABEL::highlight(W_CONTEXT *psContext)
+std::string W_LABEL::getTip()
 {
-	/* If there is a tip string start the tool tip */
-	if (!pTip.empty() || isTruncated)
-	{
-		std::string tipString;
-		if (isTruncated)
-		{
-			for (const auto& line : aTextLines)
-			{
-				tipString += line.text + "\n";
-			}
-		}
-		if (!pTip.empty())
-		{
-			if (isTruncated)
-			{
-				tipString += "\n(";
-			}
-			tipString += pTip;
-			if (isTruncated)
-			{
-				tipString += ")";
-			}
-		}
-		if (auto lockedScreen = screenPointer.lock())
-		{
-			tipStart(this, tipString, lockedScreen->TipFontID, x() + psContext->xOffset, y() + psContext->yOffset, width(), height());
-		}
+	if (pTip.empty() && !isTruncated) {
+		return "";
 	}
-}
 
-
-/* Respond to the mouse moving off a label */
-void W_LABEL::highlightLost()
-{
-	if (!pTip.empty() || isTruncated)
-	{
-		tipStop(this);
+	if (!isTruncated) {
+		return pTip;
 	}
+
+	std::stringstream labelText;
+	for (const auto& line : aTextLines)
+	{
+		labelText << line.text << "\n";
+	}
+
+	if (!pTip.empty())
+	{
+		labelText << "\n(" << pTip << ")";
+	}
+
+	return labelText.str();
 }
 
 WzString W_LABEL::getString() const

--- a/lib/widget/label.h
+++ b/lib/widget/label.h
@@ -41,13 +41,12 @@ public:
 	W_LABEL(W_LABINIT const *init);
 	W_LABEL();
 
-	void highlight(W_CONTEXT *psContext) override;
-	void highlightLost() override;
 	void display(int xOffset, int yOffset) override;
 
 	WzString getString() const override;
 	void setString(WzString string) override;
 	void setTip(std::string string) override;
+	std::string getTip() override;
 
 	void run(W_CONTEXT *) override;
 

--- a/lib/widget/tip.cpp
+++ b/lib/widget/tip.cpp
@@ -1,7 +1,7 @@
 /*
 	This file is part of Warzone 2100.
 	Copyright (C) 1999-2004  Eidos Interactive
-	Copyright (C) 2005-2020  Warzone 2100 Project
+	Copyright (C) 2005-2021  Warzone 2100 Project
 
 	Warzone 2100 is free software; you can redistribute it and/or modify
 	it under the terms of the GNU General Public License as published by
@@ -34,45 +34,38 @@
 #include <vector>
 #include <string>
 
-/* Time delay before showing the tool tip */
+/* Time delay before showing the tool tip in milliseconds */
 #define TIP_PAUSE	200
-
-/* How long to display the tool tip */
-#define TIP_TIME	4000
 
 /* Size of border around tip text */
 #define TIP_HGAP	6
 #define TIP_VGAP	3
 
-
-/* The tool tip state */
-static enum _tip_state
+static enum
 {
-	TIP_NONE,			// No tip, and no button hilited
-	TIP_WAIT,			// A button is hilited, but not yet ready to show the tip
-	TIP_ACTIVE,			// A tip is being displayed
+	TIP_INACTIVE,
+	TIP_ACTIVE,
+	TIP_CLICKED,
 } tipState;
 
 struct TipDisplayCache {
 	std::vector<WzText> wzTip;
 };
 
-static SDWORD		startTime;			// When the tip was created
-static SDWORD		mx, my;				// Last mouse coords
-static SDWORD		wx, wy, ww, wh;		// Position and size of button to place tip by
-static SDWORD		tx, ty, tw, th;		// Position and size of the tip box
-static SDWORD		fx, fy;				// Position of the text
-static int              lineHeight;
-static std::vector<std::string>  pTip;	// Tip text
-static WIDGET		*psWidget;			// The button the tip is for
-static enum iV_fonts FontID = font_regular;	// ID for the Ivis Font.
+static int32_t startTime;
+static Vector2i lastMouseCoords;
+static WzRect tipRect;
+static Vector2i textOffset;
+static int lineHeight;
+static std::string tipText;
+static WIDGET *tipSourceWidget;
 static PIELIGHT TipColour;
 static TipDisplayCache displayCache;
 
 /* Initialise the tool tip module */
 void tipInitialise(void)
 {
-	tipState = TIP_NONE;
+	tipState = TIP_INACTIVE;
 	TipColour = WZCOL_WHITE;
 }
 
@@ -98,124 +91,122 @@ static std::vector<std::string> splitString(const std::string& str, char delimit
 	return strings;
 }
 
-/*
- * Setup a tool tip.
- * The tip module will then wait until the correct points to
- * display and then remove the tool tip.
- * i.e. The tip will not be displayed immediately.
- * Calling this while another tip is being displayed will restart
- * the tip system.
- * psSource is the widget that started the tip.
- * x,y,width,height - specify the position of the button to place the
- * tip by.
- */
-void tipStart(WIDGET *psSource, const std::string& pNewTip, iV_fonts NewFontID, int x, int y, int width, int height)
+static void tipStop()
 {
-	ASSERT(psSource != nullptr, "Invalid widget pointer");
-
-	tipState = TIP_WAIT;
-	startTime = wzGetTicks();
-	mx = mouseX();
-	my = mouseY();
-	wx = x; wy = y;
-	ww = width; wh = height;
-	pTip = splitString(pNewTip, '\n');
-	psWidget = psSource;
-	FontID = NewFontID;
+	tipState = TIP_INACTIVE;
 	displayCache.wzTip.clear();
+	tipText = "";
+	startTime = wzGetTicks();
+	tipSourceWidget = nullptr;
 }
 
-
-/* Stop a tool tip (e.g. if the hilite is lost on a button).
- * psSource should be the same as the widget that started the tip.
- */
-void tipStop(WIDGET *psSource)
+static bool isHighlightedChanged(std::shared_ptr<WIDGET> mouseOverWidget)
 {
-	ASSERT(psSource != nullptr,
-	       "tipStop: Invalid widget pointer");
+	return !mouseOverWidget || tipSourceWidget != mouseOverWidget.get();
+}
 
-	if (tipState != TIP_NONE && psSource == psWidget)
+static void refreshTip(std::shared_ptr<WIDGET> mouseOverWidget)
+{
+	std::string newTip;
+	if (isHighlightedChanged(mouseOverWidget) || (newTip = mouseOverWidget->getTip()).empty())
 	{
-		tipState = TIP_NONE;
-		displayCache.wzTip.clear();
+		tipStop();
+		return;
+	}
+
+	if (newTip == tipText) {
+		return;
+	}
+
+	tipText = newTip;
+	auto fontId = font_regular;
+	if (auto lockedScreen = mouseOverWidget->screenPointer.lock()) {
+		fontId = lockedScreen->TipFontID;
+	}
+	lineHeight = iV_GetTextLineSize(fontId);
+
+	auto maxLineWidth = 0;
+	auto lines = splitString(tipText, '\n');
+	displayCache.wzTip.resize(lines.size());
+	for (size_t n = 0; n < lines.size(); ++n)
+	{
+		displayCache.wzTip[n].setText(lines[n], fontId);
+		maxLineWidth = std::max<int>(maxLineWidth, displayCache.wzTip[n].width());
+	}
+
+	/* Position the tip box */
+	auto width = maxLineWidth + TIP_HGAP * 2;
+	auto height = TIP_VGAP * 2 + lineHeight * static_cast<int32_t>(lines.size()) + iV_GetTextBelowBase(fontId);
+	auto x = clip<SDWORD>(mouseOverWidget->screenPosX() + mouseOverWidget->width() / 2, 0, screenWidth - width - 1);
+	auto y = std::max(mouseOverWidget->screenPosY() + mouseOverWidget->height() + TIP_VGAP, 0);
+	if (y + height >= (int)screenHeight)
+	{
+		/* Position the tip above the button */
+		y = mouseOverWidget->screenPosY() - height - TIP_VGAP;
+	}
+	tipRect = WzRect(x - 1, y - 1, width + 2, height + 2);
+
+	/* Position the text */
+	textOffset = Vector2i(
+		x + TIP_HGAP,
+		y + (height - lineHeight * static_cast<int32_t>(lines.size())) / 2 - iV_GetTextAboveBase(fontId)
+	);
+}
+
+static void handleTipInactive()
+{
+	auto mouseCoords = Vector2i(mouseX(), mouseY());
+	std::shared_ptr<WIDGET> mouseOverWidget;
+	if (mouseCoords != lastMouseCoords || isHighlightedChanged(mouseOverWidget = getMouseOverWidget().lock())) {
+		lastMouseCoords = mouseCoords;
+		startTime = wzGetTicks();
+		tipSourceWidget = mouseOverWidget.get();
+		return;
+	}
+
+	if (wzGetTicks() - startTime > TIP_PAUSE)
+	{
+		tipState = TIP_ACTIVE;
+		refreshTip(mouseOverWidget);
+	}
+}
+
+static void handleTipActive()
+{
+	if (mousePressed(MOUSE_LMB))
+	{
+		tipState = TIP_CLICKED;
+		return;
+	}
+
+	refreshTip(getMouseOverWidget().lock());
+
+	/* Draw the tool tip */
+	iV_ShadowBox(tipRect.x(), tipRect.y(), tipRect.right(), tipRect.bottom(), 1, WZCOL_FORM_LIGHT, WZCOL_FORM_DARK, WZCOL_FORM_TIP_BACKGROUND);
+
+	size_t n = 0;
+	for (auto &line: displayCache.wzTip)
+	{
+		line.render(textOffset.x, textOffset.y + lineHeight * static_cast<int32_t>(n), TipColour);
+		++n;
+	}
+}
+
+static void handleTipClicked()
+{
+	if (isHighlightedChanged(getMouseOverWidget().lock()))
+	{
+		tipStop();
 	}
 }
 
 /* Update and possibly display the tip */
 void tipDisplay()
 {
-	SDWORD		newMX, newMY;
-	SDWORD		currTime;
-	SDWORD		fw, topGap;
-
 	switch (tipState)
 	{
-	case TIP_WAIT:
-		/* See if the tip has to be shown */
-		newMX = mouseX();
-		newMY = mouseY();
-		currTime = wzGetTicks();
-		if (newMX == mx &&
-		    newMY == my &&
-		    (currTime - startTime > TIP_PAUSE))
-		{
-			/* Activate the tip */
-			tipState = TIP_ACTIVE;
-
-			/* Calculate the size of the tip box */
-			topGap = TIP_VGAP;
-
-			lineHeight = iV_GetTextLineSize(FontID);
-
-			fw = 0;
-			displayCache.wzTip.resize(pTip.size());
-			for (size_t n = 0; n < pTip.size(); ++n)
-			{
-				displayCache.wzTip[n].setText(pTip[n], FontID);
-				fw = std::max<int>(fw, displayCache.wzTip[n].width());
-			}
-			tw = fw + TIP_HGAP * 2;
-			th = topGap * 2 + lineHeight * static_cast<int32_t>(pTip.size()) + iV_GetTextBelowBase(FontID);
-
-			/* Position the tip box */
-			tx = clip<SDWORD>(wx + ww / 2, 0, screenWidth - tw - 1);
-			ty = std::max(wy + wh + TIP_VGAP, 0);
-			if (ty + th >= (int)screenHeight)
-			{
-				/* Position the tip above the button */
-				ty = wy - th - TIP_VGAP;
-			}
-
-			/* Position the text */
-			fx = tx + TIP_HGAP;
-			fy = ty + (th - lineHeight * static_cast<int32_t>(pTip.size())) / 2 - iV_GetTextAboveBase(FontID);
-
-			/* Note the time */
-			startTime = wzGetTicks();
-		}
-		else if (newMX != mx ||
-		         newMY != my ||
-		         mousePressed(MOUSE_LMB))
-		{
-			mx = newMX;
-			my = newMY;
-			startTime = currTime;
-		}
-		break;
-	case TIP_ACTIVE:
-		{
-			/* Draw the tool tip */
-			iV_ShadowBox(tx - 2, ty - 2, tx + tw + 2, ty + th + 2, 1, WZCOL_FORM_LIGHT, WZCOL_FORM_DARK, WZCOL_FORM_TIP_BACKGROUND);
-			size_t n = 0;
-			for (auto it = displayCache.wzTip.begin(); it != displayCache.wzTip.end(); ++it)
-			{
-				it->render(fx, fy + lineHeight * static_cast<int32_t>(n), TipColour);
-				++n;
-			}
-		}
-
-		break;
-	default:
-		break;
+	case TIP_INACTIVE: handleTipInactive(); break;
+	case TIP_ACTIVE: handleTipActive(); break;
+	case TIP_CLICKED: handleTipClicked(); break;
 	}
 }

--- a/lib/widget/tip.h
+++ b/lib/widget/tip.h
@@ -30,24 +30,6 @@
 /* Initialise the tool tip module */
 void tipInitialise();
 
-/*
- * Setup a tool tip.
- * The tip module will then wait until the correct points to
- * display and then remove the tool tip.
- * i.e. The tip will not be displayed immediately.
- * Calling this while another tip is being displayed will restart
- * the tip system.
- * psSource is the widget that started the tip.
- * x,y,width,height - specify the position of the button to place the
- * tip by.
- */
-void tipStart(WIDGET *psSource, const std::string& pTip, iV_fonts NewFontID, int x, int y, int width, int height);
-
-/* Stop a tool tip (e.g. if the hilite is lost on a button).
- * psSource should be the same as the widget that started the tip.
- */
-void tipStop(WIDGET *psSource);
-
 /* Update and possibly display the tip */
 void tipDisplay();
 

--- a/lib/widget/widgbase.h
+++ b/lib/widget/widgbase.h
@@ -149,6 +149,10 @@ public:
 
 	virtual void focusLost() {}
 	virtual void clicked(W_CONTEXT *, WIDGET_KEY = WKEY_PRIMARY) {}
+	virtual std::string getTip()
+	{
+		return "";
+	}
 
 protected:
 	virtual void released(W_CONTEXT *, WIDGET_KEY = WKEY_PRIMARY) {}

--- a/lib/widget/widget.cpp
+++ b/lib/widget/widget.cpp
@@ -401,8 +401,6 @@ WIDGET::~WIDGET()
 		onDelete(this);	// Call the onDelete function to handle any extra logic
 	}
 
-	tipStop(this);  // Stop showing tooltip, if we are.
-
 #ifdef DEBUG
 	debugLiveWidgets.erase(this);
 #endif
@@ -1432,4 +1430,9 @@ WidgetGraphicsContext WidgetGraphicsContext::clippedBy(WzRect const &newRect) co
 	newContext.clipped = true;
 
 	return newContext;
+}
+
+std::weak_ptr<WIDGET> getMouseOverWidget()
+{
+	return psMouseOverWidget;
 }

--- a/lib/widget/widget.h
+++ b/lib/widget/widget.h
@@ -387,6 +387,8 @@ void sliderEnableDrag(bool Enable);
 void setWidgetsStatus(bool var);
 bool getWidgetsStatus();
 
+std::weak_ptr<WIDGET> getMouseOverWidget();
+
 /** @} */
 
 #endif // __INCLUDED_LIB_WIDGET_WIDGET_H__


### PR DESCRIPTION
Fixes #1698 

With this approach, the widgets that display tips need only to override getTip and return a non-empty string for the tip to be displayed.

All the triggers for displaying/hiding the tips were moved to the tip module.

The tip module will also try to refresh the tip on every frame, in case there is a tip being shown.