### PR TITLE
add editorconfig for js files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -31,3 +31,9 @@ indent_size = 4
 insert_final_newline = true
 trim_trailing_whitespace = true
 indent_style = tab
+
+# JavaScript
+[*.js]
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = tab

--- a/.editorconfig
+++ b/.editorconfig
@@ -37,3 +37,9 @@ indent_style = tab
 insert_final_newline = true
 trim_trailing_whitespace = true
 indent_style = tab
+
+# JSON
+[*.json]
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = tab


### PR DESCRIPTION
added an editorconfig config for javascript files.

should we also include one for json files?
and i think we should also set `end_of_line = lf`