### PR TITLE
[Vulkan] Adjust VK_SUBOPTIMAL_KHR handling

### DIFF
--- a/lib/ivis_opengl/gfx_api_vk.cpp
+++ b/lib/ivis_opengl/gfx_api_vk.cpp
@@ -3337,12 +3337,7 @@ VkRoot::AcquireNextSwapchainImageResult VkRoot::acquireNextSwapchainImage()
 	}
 	if(acquireNextImageResult.result == vk::Result::eSuboptimalKHR)
 	{
-		debug(LOG_3D, "vk::Device::acquireNextImageKHR returned eSuboptimalKHR - recreate swapchain");
-		if (createNewSwapchainAndSwapchainSpecificStuff(acquireNextImageResult.result))
-		{
-			return AcquireNextSwapchainImageResult::eRecoveredFromError;
-		}
-		return AcquireNextSwapchainImageResult::eUnhandledFailure;
+		debug(LOG_3D, "vk::Device::acquireNextImageKHR returned eSuboptimalKHR - should probably recreate swapchain (in the future)");
 	}
 
 	currentSwapchainIndex = acquireNextImageResult.value;
@@ -3448,9 +3443,7 @@ void VkRoot::flip(int clearMode)
 	}
 	if(presentResult == vk::Result::eSuboptimalKHR)
 	{
-		debug(LOG_3D, "presentKHR returned eSuboptimalKHR (%d) - recreate swapchain", (int)presentResult);
-		createNewSwapchainAndSwapchainSpecificStuff(presentResult);
-		return; // end processing this flip
+		debug(LOG_3D, "presentKHR returned eSuboptimalKHR (%d) - should probably recreate swapchain (in the future)", (int)presentResult);
 	}
 
 	buffering_mechanism::swap(dev, vkDynLoader); // must be called *before* acquireNextSwapchainImage()


### PR DESCRIPTION
Treat this as the success code it is (but log it), and rely on later triggering by other conditions to recreate the swapchain.

Fixes a crash when maximizing using the titlebar button on macOS.

Other semi-related references:

> PSA: If you have garbage Vulkan performance on Android 10, check if WSI returns VK_SUBOPTIMAL_KHR. Just ignore it and treat it as VK_SUCCESS, or deal with PREROTATE transforms

Source: https://twitter.com/themaister/status/1207062674011574273

There's a larger refactoring of how / when we handle swapchain recreation that would be ideal, but hopefully this is "enough" to fix the crash.
