### PR TITLE
Reset ready status in lobby when a player leaves

### DIFF
--- a/lib/netplay/netplay.cpp
+++ b/lib/netplay/netplay.cpp
@@ -684,6 +684,7 @@ static void NETplayerLeaving(UDWORD index)
 	if (ingame.localJoiningInProgress)  // Only if game hasn't actually started yet.
 	{
 		NET_DestroyPlayer(index);       // sets index player's array to false
+		resetReadyStatus(false);		// reset ready status for all players
 	}
 }
 
@@ -712,6 +713,7 @@ static void NETplayerDropped(UDWORD index)
 		NETend();
 		debug(LOG_INFO, "sending NET_PLAYER_DROPPED for player %d", id);
 		NET_DestroyPlayer(id);          // just clears array
+		resetReadyStatus(false);		// reset ready status for all players
 	}
 
 	NETsetPlayerConnectionStatus(CONNECTIONSTATUS_PLAYER_DROPPED, id);

--- a/lib/netplay/netplay.cpp
+++ b/lib/netplay/netplay.cpp
@@ -4447,6 +4447,24 @@ const char *messageTypeToString(unsigned messageType_)
 	return "(UNUSED)";
 }
 
+static bool isLoopbackIP(const char *ip)
+{
+	if (!ip) return false;
+	if (strncmp(ip, "127.", 4) == 0)
+	{
+		return true;
+	}
+	if (strcmp(ip, "::1") == 0)
+	{
+		return true;
+	}
+	if (strcmp(ip, "0000:0000:0000:0000:0000:0000:0000:0001") == 0)
+	{
+		return true;
+	}
+	return false;
+}
+
 /**
  * Check if ip is on the banned list.
  * \param ip IP address converted to text
@@ -4458,6 +4476,10 @@ static bool onBanList(const char *ip)
 	if (!IPlist)
 	{
 		return false;    //if no bans are added, then don't check.
+	}
+	if (isLoopbackIP(ip))
+	{
+		return false;	// ignore loopback IPs
 	}
 	for (i = 0; i < MAX_BANS ; i++)
 	{
@@ -4476,6 +4498,10 @@ static bool onBanList(const char *ip)
  */
 static void addToBanList(const char *ip, const char *name)
 {
+	if (isLoopbackIP(ip))
+	{
+		return;
+	}
 	if (!IPlist)
 	{
 		IPlist = (PLAYER_IP *)malloc(sizeof(PLAYER_IP) * MAX_BANS + 1);


### PR DESCRIPTION
Also, a drive-by fix to prevent adding loopback IPs to the ban list.