### PR TITLE
Detect and link Zlib using pkgconfig

### DIFF
--- a/lib/netplay/CMakeLists.txt
+++ b/lib/netplay/CMakeLists.txt
@@ -30,6 +30,7 @@ file(GLOB HEADERS "*.h")
 file(GLOB SRC "*.cpp")
 
 find_package (Threads REQUIRED)
+pkg_check_modules(ZLIB REQUIRED zlib)
 
 add_library(netplay STATIC ${HEADERS} ${SRC} "${_netplay_config_output_file}")
 add_dependencies(netplay autorevision_netcodeversion)
@@ -48,7 +49,7 @@ endif()
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU")
 	target_link_libraries(netplay PRIVATE pthread)
 endif()
-target_link_libraries(netplay PRIVATE Threads::Threads)
+target_link_libraries(netplay PRIVATE Threads::Threads "${ZLIB_LIBRARIES}")
 if(MSVC)
 	# C4267: 'conversion': conversion from 'type1' to 'type2', possible loss of data // FIXME!!
 	target_compile_options(netplay PRIVATE "/wd4267")


### PR DESCRIPTION
This patch is like #1750 but it uses pkgconfig and does not depend on eny external
cmake modules.