### PR TITLE
Fix function name typo in multiplayer rules.js.

### DIFF
--- a/data/mp/multiplay/script/rules/events/gameinit.js
+++ b/data/mp/multiplay/script/rules/events/gameinit.js
@@ -39,7 +39,7 @@ function eventGameInit()
 		setupBase(playnum);
 		
 		//From script/setup/setuptechlevels.js
-		seupTechLevel(playnum);
+		setupTechLevel(playnum);
 
 	}
 

--- a/data/mp/multiplay/script/rules/setup/techlevel.js
+++ b/data/mp/multiplay/script/rules/setup/techlevel.js
@@ -1,4 +1,4 @@
-function seupTechLevel(player)
+function setupTechLevel(player)
 {
 	
 	//global function, doc/js-functions


### PR DESCRIPTION
A little typo I found in the rules.