### PR TITLE
Fix unclosable panels

### DIFF
--- a/lib/ivis_opengl/screen.cpp
+++ b/lib/ivis_opengl/screen.cpp
@@ -577,3 +577,13 @@ void screenDumpToDisk(const char *path, const char *level)
 	}
 	screendump_required = true;
 }
+
+void screen_FlipIfBackDropTransition()
+{
+	static auto hadBackDrop = false;
+	if (hadBackDrop != screen_GetBackDrop())
+	{
+		pie_ScreenFlip(CLEAR_BLACK);
+		hadBackDrop = screen_GetBackDrop();
+	}
+}

--- a/lib/ivis_opengl/screen.h
+++ b/lib/ivis_opengl/screen.h
@@ -49,6 +49,7 @@ void screen_SetBackDropFromFile(const char *filename);
 void screen_StopBackDrop();
 void screen_RestartBackDrop();
 bool screen_GetBackDrop();
+void screen_FlipIfBackDropTransition();
 void screen_Upload(const char *newBackDropBmp);
 void screen_Display();
 

--- a/src/design.cpp
+++ b/src/design.cpp
@@ -2915,9 +2915,6 @@ static void desCreateDefaultTemplate()
 /* Remove the design widgets from the widget screen */
 void intRemoveDesign()
 {
-	//save the current design on exit if it is valid
-	saveTemplate();
-
 	widgDelete(psWScreen, IDDES_POWERFORM);
 	widgDelete(psWScreen, IDDES_NAMEBOX);
 	widgDelete(psWScreen, IDDES_TEMPLBASE);

--- a/src/design.cpp
+++ b/src/design.cpp
@@ -3886,10 +3886,6 @@ static void resetDesignPauseState()
 		setScrollPause(false);
 		gameTimeStart();
 		screen_StopBackDrop();
-		if (intMode == INT_DESIGN)
-		{
-			pie_ScreenFlip(CLEAR_BLACK);
-		}
 	}
 }
 

--- a/src/design.cpp
+++ b/src/design.cpp
@@ -3886,6 +3886,10 @@ static void resetDesignPauseState()
 		setScrollPause(false);
 		gameTimeStart();
 		screen_StopBackDrop();
+		if (intMode == INT_DESIGN)
+		{
+			pie_ScreenFlip(CLEAR_BLACK);
+		}
 	}
 }
 

--- a/src/design.cpp
+++ b/src/design.cpp
@@ -626,12 +626,6 @@ bool intAddDesign(bool bShowCentreScreen)
 	//set which states are to be paused while design screen is up
 	setDesignPauseState();
 
-	if (GetGameMode() == GS_NORMAL && !bMultiPlayer)
-	{
-		// Just display the 3d, no interface
-		displayWorld();
-	}
-
 	auto const &parent = psWScreen->psForm;
 
 	/* Add the main design form */
@@ -3892,7 +3886,6 @@ static void resetDesignPauseState()
 		setScrollPause(false);
 		gameTimeStart();
 		screen_StopBackDrop();
-		pie_ScreenFlip(CLEAR_BLACK);
 	}
 }
 

--- a/src/hci.cpp
+++ b/src/hci.cpp
@@ -781,6 +781,7 @@ void intOpenDebugMenu(OBJECT_TYPE id)
 		return;
 	}
 
+	intResetScreen(true);
 	switch (id)
 	{
 	case OBJ_DROID:

--- a/src/hci.cpp
+++ b/src/hci.cpp
@@ -726,114 +726,41 @@ void intResetScreen(bool NoAnim)
 		}
 	}
 
+	intStopStructPosition();
+	if (NoAnim)
+	{
+		intRemoveOrderNoAnim();
+		intRemoveStatsNoAnim();
+		intRemoveObjectNoAnim();
+		intCloseInGameOptionsNoAnim();
+		intCloseMultiMenuNoAnim();
+		intRemoveIntelMapNoAnim();
+		intRemoveTransNoAnim();
+	}
+	else
+	{
+		intRemoveOrder();
+		intRemoveStats();
+		intRemoveObject();
+		intCloseMultiMenu();
+		intRemoveIntelMap();
+		intRemoveTrans();
+	}
+	intRemoveMissionResultNoAnim();
+	intRemoveDesign();
+	intHidePowerBar();
+
 	/* Remove whatever extra screen was displayed */
 	switch (intMode)
 	{
-	case INT_EDITSTAT:
-		intStopStructPosition();
-		if (NoAnim)
-		{
-			intRemoveStatsNoAnim();
-		}
-		else
-		{
-			intRemoveStats();
-		}
-		break;
-	case INT_OBJECT:
-		intStopStructPosition();
-		if (NoAnim)
-		{
-			intRemoveObjectNoAnim();
-		}
-		else
-		{
-			intRemoveObject();
-		}
-		break;
-	case INT_STAT:
-		if (NoAnim)
-		{
-			intRemoveStatsNoAnim();
-			intRemoveObjectNoAnim();
-		}
-		else
-		{
-			intRemoveStats();
-			intRemoveObject();
-		}
-		break;
-
-	case INT_CMDORDER:
-		if (NoAnim)
-		{
-			intRemoveOrderNoAnim();
-			intRemoveObjectNoAnim();
-		}
-		else
-		{
-			intRemoveOrder();
-			intRemoveObject();
-		}
-		break;
-	case INT_ORDER:
-		if (NoAnim)
-		{
-			intRemoveOrderNoAnim();
-		}
-		else
-		{
-			intRemoveOrder();
-		}
-		break;
-	case INT_INGAMEOP:
-		if (NoAnim) // Other menus can be opened when options menu is up, so close the options (issue #1589)
-		{
-			intCloseInGameOptionsNoAnim();
-		}
-		break;
-	case INT_MISSIONRES:
-		intRemoveMissionResultNoAnim();
-		break;
-	case INT_MULTIMENU:
-		if (NoAnim)
-		{
-			intCloseMultiMenuNoAnim();
-		}
-		else
-		{
-			intCloseMultiMenu();
-		}
-		break;
 	case INT_DESIGN:
-		intRemoveDesign();
-		intHidePowerBar();
 		gInputManager.contexts().popState();
 		triggerEvent(TRIGGER_DESIGN_QUIT);
 		break;
 	case INT_INTELMAP:
-		if (NoAnim)
-		{
-			intRemoveIntelMapNoAnim();
-		}
-		else
-		{
-			intRemoveIntelMap();
-		}
-		intHidePowerBar();
 		if (!bMultiPlayer)
 		{
 			gameTimeStart();
-		}
-		break;
-	case INT_TRANSPORTER:
-		if (NoAnim)
-		{
-			intRemoveTransNoAnim();
-		}
-		else
-		{
-			intRemoveTrans();
 		}
 		break;
 	default:

--- a/src/hci.cpp
+++ b/src/hci.cpp
@@ -1927,13 +1927,6 @@ void addIntelScreen()
 	//add the power bar - for looks!
 	intShowPowerBar();
 
-	// Only do this in main game.
-	if ((GetGameMode() == GS_NORMAL) && !bMultiPlayer)
-	{
-		// Just display the 3d, no interface
-		displayWorld();
-	}
-
 	//add all the intelligence screen interface
 	(void)intAddIntelMap();
 	intMode = INT_INTELMAP;

--- a/src/hci.cpp
+++ b/src/hci.cpp
@@ -735,7 +735,7 @@ void intResetScreen(bool NoAnim)
 		intCloseInGameOptionsNoAnim();
 		intCloseMultiMenuNoAnim();
 		intRemoveIntelMapNoAnim();
-		intRemoveTransNoAnim();
+		intRemoveTransNoAnim(true);
 	}
 	else
 	{
@@ -744,9 +744,12 @@ void intResetScreen(bool NoAnim)
 		intRemoveObject();
 		intCloseMultiMenu();
 		intRemoveIntelMap();
-		intRemoveTrans();
+		intRemoveTrans(true);
 	}
-	intRemoveMissionResultNoAnim();
+	if (intMode == INT_MISSIONRES)
+	{
+		intRemoveMissionResultNoAnim();
+	}
 	intRemoveDesign();
 	intHidePowerBar();
 

--- a/src/hci.cpp
+++ b/src/hci.cpp
@@ -726,6 +726,22 @@ void intResetScreen(bool NoAnim)
 		}
 	}
 
+	switch (intMode)
+	{
+	case INT_DESIGN:
+		gInputManager.contexts().popState();
+		triggerEvent(TRIGGER_DESIGN_QUIT);
+		break;
+	case INT_INTELMAP:
+		if (!bMultiPlayer)
+		{
+			gameTimeStart();
+		}
+		break;
+	default:
+		break;
+	}
+
 	intStopStructPosition();
 	if (NoAnim)
 	{
@@ -753,22 +769,6 @@ void intResetScreen(bool NoAnim)
 	intRemoveDesign();
 	intHidePowerBar();
 
-	/* Remove whatever extra screen was displayed */
-	switch (intMode)
-	{
-	case INT_DESIGN:
-		gInputManager.contexts().popState();
-		triggerEvent(TRIGGER_DESIGN_QUIT);
-		break;
-	case INT_INTELMAP:
-		if (!bMultiPlayer)
-		{
-			gameTimeStart();
-		}
-		break;
-	default:
-		break;
-	}
 	interfaceController = nullptr;
 	setSecondaryWindowUp(false);
 	intMode = INT_NORMAL;

--- a/src/ingameop.cpp
+++ b/src/ingameop.cpp
@@ -214,7 +214,6 @@ static bool _intAddInGameOptions()
 		return true;
 	}
 
-	intResetScreen(false);
 	setReticulesEnabled(false);
 
 	// Pause the game.

--- a/src/intelmap.cpp
+++ b/src/intelmap.cpp
@@ -1218,6 +1218,10 @@ void resetIntelligencePauseState()
 		setConsolePause(false);
 		gameTimeStart();
 		screen_StopBackDrop();
+		if (intMode == INT_INTELMAP)
+		{
+			pie_ScreenFlip(CLEAR_BLACK);
+		}
 	}
 }
 

--- a/src/intelmap.cpp
+++ b/src/intelmap.cpp
@@ -1218,7 +1218,6 @@ void resetIntelligencePauseState()
 		setConsolePause(false);
 		gameTimeStart();
 		screen_StopBackDrop();
-		pie_ScreenFlip(CLEAR_BLACK);
 	}
 }
 

--- a/src/intelmap.cpp
+++ b/src/intelmap.cpp
@@ -1218,10 +1218,6 @@ void resetIntelligencePauseState()
 		setConsolePause(false);
 		gameTimeStart();
 		screen_StopBackDrop();
-		if (intMode == INT_INTELMAP)
-		{
-			pie_ScreenFlip(CLEAR_BLACK);
-		}
 	}
 }
 

--- a/src/keybind.cpp
+++ b/src/keybind.cpp
@@ -1072,6 +1072,7 @@ void	kf_addInGameOptions()
 	setWidgetsStatus(true);
 	if (!isInGamePopupUp)	// they can *only* quit when popup is up.
 	{
+		intResetScreen(false);
 		intAddInGameOptions();
 	}
 }

--- a/src/loop.cpp
+++ b/src/loop.cpp
@@ -151,6 +151,8 @@ static GAMECODE renderLoop()
 		if (!getRotActive() && getWidgetsStatus() && dragBox3D.status != DRAG_DRAGGING && wallDrag.status != DRAG_DRAGGING)
 		{
 			intRetVal = intRunWidgets();
+			screen_FlipIfBackDropTransition();
+
 			// Send droid orders, if any. (Should do between intRunWidgets() calls, to avoid droid orders getting mixed up, in the case of multiple orders given while the game freezes due to net lag.)
 			sendQueuedDroidInfo();
 		}

--- a/src/mission.cpp
+++ b/src/mission.cpp
@@ -2172,15 +2172,16 @@ static void intDisplayMissionBackDrop(WIDGET *psWidget, UDWORD xOffset, UDWORD y
 
 static void missionResetInGameState()
 {
+	// Add the background
+	// get rid of reticule etc..
+	intResetScreen(false);
+
 	//stop the game if in single player mode
 	setMissionPauseState();
 
 	// reset the input state
 	resetInput();
 
-	// Add the background
-	// get rid of reticule etc..
-	intResetScreen(false);
 	forceHidePowerBar();
 	intRemoveReticule();
 	intRemoveMissionTimer();

--- a/src/transporter.cpp
+++ b/src/transporter.cpp
@@ -761,7 +761,7 @@ void intProcessTransporter(UDWORD id)
 }
 
 /* Remove the Transporter widgets from the screen */
-void intRemoveTrans()
+void intRemoveTrans(bool skipIntModeReset /*= false*/)
 {
 	// Start the window close animation.
 	IntFormAnimated *form = (IntFormAnimated *)widgGetFromID(psWScreen, IDTRANS_FORM);
@@ -772,17 +772,23 @@ void intRemoveTrans()
 
 	intRemoveTransContent();
 	intRemoveTransDroidsAvail();
-	intMode = INT_NORMAL;
+	if (!skipIntModeReset)
+	{
+		intMode = INT_NORMAL;
+	}
 }
 
 /* Remove the Transporter Content widgets from the screen w/o animation!*/
-void intRemoveTransNoAnim()
+void intRemoveTransNoAnim(bool skipIntModeReset /*= false*/)
 {
 	//remove main screen
 	widgDelete(psWScreen, IDTRANS_FORM);
 	intRemoveTransContentNoAnim();
 	intRemoveTransDroidsAvailNoAnim();
-	intMode = INT_NORMAL;
+	if (!skipIntModeReset)
+	{
+		intMode = INT_NORMAL;
+	}
 }
 
 /* Remove the Transporter Content widgets from the screen */

--- a/src/transporter.h
+++ b/src/transporter.h
@@ -45,8 +45,8 @@ bool intRefreshTransporter();
 /*Add the Transporter Interface*/
 bool intAddTransporter(DROID *psSelected, bool offWorld);
 /* Remove the Transporter widgets from the screen */
-void intRemoveTrans();
-void intRemoveTransNoAnim();
+void intRemoveTrans(bool skipIntModeReset = false);
+void intRemoveTransNoAnim(bool skipIntModeReset = false);
 /* Process return codes from the Transporter Screen*/
 void intProcessTransporter(UDWORD id);
 


### PR DESCRIPTION
Fixes https://github.com/Warzone2100/warzone2100/issues/1746. 
Fixes https://github.com/Warzone2100/warzone2100/issues/1520 also.

I left marked as WIP, because it feels like I introduced a small flickering while going from 3D world to campaign design mode (with back screen). 

It feels like the 3D world is rendered once on top of the design screen. Removing the `pie_ScreenFlip(CLEAR_BLACK);` made it visible, but it was necessary to avoid the screen from blinking black every time you click any reticule button.