### PR TITLE
Fix multiplayer power modifier after saveload.

### DIFF
--- a/data/mp/multiplay/script/rules/events/gameloaded.js
+++ b/data/mp/multiplay/script/rules/events/gameloaded.js
@@ -1,4 +1,5 @@
 function eventGameLoaded()
 {
 	setupGame();
+	queue("setupPowerModifierGameLoaded", 100);
 }

--- a/data/mp/multiplay/script/rules/setup/powermodifier.js
+++ b/data/mp/multiplay/script/rules/setup/powermodifier.js
@@ -23,3 +23,12 @@ function setupPowerModifier(player)
 		setPowerModifier(70 + 5 * powerType, player);
 	}
 }
+
+// Power modifier data is currently not saved. Reset it during eventGameLoaded for the moment.
+function setupPowerModifierGameLoaded()
+{
+	for (let i = 0; i < maxPlayers; ++i)
+	{
+		setupPowerModifier(i);
+	}
+}


### PR DESCRIPTION
Should fix #1759. We can explore different options when save file data isn't binary blob junk.

Note that I had to queue it one tick later cause the data checks in setupPowerModifier() aren't setup yet during the immediate event trigger.