### PR TITLE
[WIP] Reduce binary file blobbery

### DIFF
--- a/src/ai.cpp
+++ b/src/ai.cpp
@@ -157,12 +157,6 @@ bool aiInitialise()
 	return true;
 }
 
-/* Shutdown the AI system */
-bool aiShutdown()
-{
-	return true;
-}
-
 /** Search the global list of sensors for a possible target for psObj. */
 static BASE_OBJECT *aiSearchSensorTargets(BASE_OBJECT *psObj, int weapon_slot, WEAPON_STATS *psWStats, TARGET_ORIGIN *targetOrigin)
 {

--- a/src/ai.h
+++ b/src/ai.h
@@ -57,9 +57,6 @@ extern PlayerMask satuplinkbits;
 /* Initialise the AI system */
 bool aiInitialise();
 
-/* Shutdown the AI system */
-bool aiShutdown();
-
 /* Do the AI for a droid */
 void aiUpdateDroid(DROID *psDroid);
 

--- a/src/display.h
+++ b/src/display.h
@@ -201,12 +201,10 @@ bool	getRotActive();
 #define MINDISTANCE_CONFIG (1600)
 #define MAP_ZOOM_CONFIG_STEP (200)
 #define STARTDISTANCE	(2600)
-#define OLD_START_HEIGHT (1500) // only used in savegames <= 10
 
 #define CAMERA_PIVOT_HEIGHT (500)
 
 #define INITIAL_STARTING_PITCH (-40)
-#define OLD_INITIAL_ROTATION (-45) // only used in savegames <= 10
 
 #define	HIDDEN_FRONTEND_WIDTH	(640)
 #define	HIDDEN_FRONTEND_HEIGHT	(480)

--- a/src/display3d.cpp
+++ b/src/display3d.cpp
@@ -1305,13 +1305,6 @@ void disp3d_setView(iView *newView)
 	playerPos = *newView;
 }
 
-/// reset the camera rotation (used for save games <= 10)
-void disp3d_oldView()
-{
-	playerPos.r.y = OLD_INITIAL_ROTATION; // rotation
-	playerPos.p.y = OLD_START_HEIGHT; // height
-}
-
 /// get the view position for save game
 void disp3d_getView(iView *newView)
 {

--- a/src/display3d.h
+++ b/src/display3d.h
@@ -73,7 +73,6 @@ void setViewPos(UDWORD x, UDWORD y, bool Pan);
 Vector2i    getPlayerPos();
 void setPlayerPos(SDWORD x, SDWORD y);
 void disp3d_setView(iView *newView);
-void disp3d_oldView(); // for save games <= 10
 void disp3d_getView(iView *newView);
 
 void draw3DScene();

--- a/src/game.h
+++ b/src/game.h
@@ -43,7 +43,7 @@ bool loadGame(const char *pGameToLoad, bool keepObjects, bool freeMem, bool User
 
 /*This just loads up the .gam file to determine which level data to set up - split up
 so can be called in levLoadData when starting a game from a load save game*/
-bool loadGameInit(const char *fileName);
+bool loadGameInit(const char *fileName, bool fromRealSave);
 
 bool loadMissionExtras(const char* pGameToLoad, LEVEL_TYPE levelType);
 

--- a/src/gamedef.h
+++ b/src/gamedef.h
@@ -44,8 +44,8 @@
 #define VERSION_11              11	        // newstyle save game with extending structure checked in 13 Nov.
 #define VERSION_12              12	        // mission and order stuff checked in 20 Nov.
 //#define VERSION_13            13	        // odds and ends to 24 Nov. and hashed scripts
-#define VERSION_14              14	        // 
-#define VERSION_15              15	        // 
+#define VERSION_14              14	        //
+#define VERSION_15              15	        //
 #define VERSION_16              16	        // beta save game
 #define VERSION_17              17	        // objId and new struct stats included
 #define VERSION_18              18	        // droid name savegame validity stamps
@@ -70,8 +70,9 @@
 //#define VERSION_37            37	        // dpid changes; this had better be the last version
 #define VERSION_38              38	        // mod list!
 #define VERSION_39              39	        // lots of changes, breaking everything
+#define VERSION_40              40			// use main.json instead of loading from .game file blob. Breaks everything even more!
 
-#define CURRENT_VERSION_NUM     VERSION_39
+#define CURRENT_VERSION_NUM     VERSION_40
 
 //used in the loadGame
 #define KEEPOBJECTS				true

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -955,16 +955,6 @@ bool stageOneInitialise()
 		return false;
 	}
 
-	if (!droidInit())
-	{
-		return false;
-	}
-
-	if (!initViewData())
-	{
-		return false;
-	}
-
 	if (!grpInitialise())
 	{
 		return false;
@@ -1028,11 +1018,6 @@ bool stageOneShutDown()
 	proj_Shutdown();
 
 	releaseMission();
-
-	if (!aiShutdown())
-	{
-		return false;
-	}
 
 	if (!objShutdown())
 	{

--- a/src/levels.cpp
+++ b/src/levels.cpp
@@ -614,14 +614,6 @@ const char *getLevelName()
 bool levLoadData(char const *name, Sha256 const *hash, char *pSaveName, GAME_TYPE saveType)
 {
 	debug(LOG_WZ, "Loading level %s hash %s (%s, type %d)", name, hash == nullptr ? "builtin" : hash->toString().c_str(), pSaveName, (int)saveType);
-	if (saveType == GTYPE_SAVE_START || saveType == GTYPE_SAVE_MIDMISSION)
-	{
-		if (!levReleaseAll())
-		{
-			debug(LOG_ERROR, "Failed to unload old data");
-			return false;
-		}
-	}
 
 	// Ensure that the LC_NUMERIC locale setting is "C"
 	ASSERT(strcmp(setlocale(LC_NUMERIC, NULL), "C") == 0, "The LC_NUMERIC locale is not \"C\" - this may break level-data parsing depending on the user's system locale settings");

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -954,7 +954,7 @@ static bool initSaveGameLoad()
 	initLoadingScreen(true);
 
 	// load up a save game
-	if (!loadGameInit(saveGameName))
+	if (!loadGameInit(saveGameName, true))
 	{
 		// FIXME: we really should throw up a error window, but we can't (easily) so I won't.
 		debug(LOG_ERROR, "Trying to load Game %s failed!", saveGameName);

--- a/src/message.cpp
+++ b/src/message.cpp
@@ -248,12 +248,6 @@ bool messageInitVars()
 	return true;
 }
 
-//allocates the viewdata heap
-bool initViewData()
-{
-	return true;
-}
-
 /* Adds a beacon message. A wrapper for addMessage() */
 MESSAGE *addBeaconMessage(MESSAGE_TYPE msgType, bool proxPos, UDWORD player)
 {

--- a/src/message.h
+++ b/src/message.h
@@ -39,9 +39,6 @@ extern iIMDShape	*pProximityMsgIMD;
 /** The list of proximity displays allocated. */
 extern PROXIMITY_DISPLAY *apsProxDisp[MAX_PLAYERS];
 
-/** Allocates the viewdata heap. */
-bool initViewData();
-
 /** Initialise the message heaps. */
 bool initMessage();
 

--- a/src/mission.cpp
+++ b/src/mission.cpp
@@ -409,7 +409,7 @@ bool startMission(LEVEL_TYPE missionType, char *pGame)
 	//load the game file for all types of mission except a Between Mission
 	if (missionType != LEVEL_TYPE::LDS_BETWEEN)
 	{
-		loadGameInit(pGame);
+		loadGameInit(pGame, false);
 	}
 
 	//all proximity messages are removed between missions now

--- a/src/modding.cpp
+++ b/src/modding.cpp
@@ -173,7 +173,7 @@ void printSearchPath()
 	PHYSFS_freeList(searchPath);
 }
 
-void setOverrideMods(char *modlist)
+void setOverrideMods(const char *modlist)
 {
 	override_mods = split(modlist, ", ");
 	override_mod_list = modlist;

--- a/src/modding.h
+++ b/src/modding.h
@@ -31,7 +31,7 @@ void addSubdirs(const char *basedir, const char *subdir, const bool appendToPath
 void removeSubdirs(const char *basedir, const char *subdir);
 void printSearchPath();
 
-void setOverrideMods(char *modlist);
+void setOverrideMods(const char *modlist);
 void clearOverrideMods();
 
 void clearLoadedMods();

--- a/src/multiint.cpp
+++ b/src/multiint.cpp
@@ -369,6 +369,11 @@ const char *getAIName(int player)
 	}
 }
 
+void setAINameFromSave(int player, const char *name)
+{
+	strcpy(aidata[NetPlay.players[player].ai].name, name);
+}
+
 void loadMultiScripts()
 {
 	bool defaultRules = true;
@@ -749,24 +754,6 @@ void loadMapPreview(bool hideInterface)
 
 // ////////////////////////////////////////////////////////////////////////////
 // helper func
-
-int matchAIbyName(const char *name)
-{
-	int i = 0;
-
-	if (name[0] == '\0')
-	{
-		return AI_CLOSED;
-	}
-	for (auto it = aidata.cbegin(); it < aidata.cend(); ++it, i++)
-	{
-		if (strncasecmp(name, (*it).name, MAX_LEN_AI_NAME) == 0)
-		{
-			return i;
-		}
-	}
-	return AI_NOT_FOUND;
-}
 
 void readAIs()
 {

--- a/src/multiint.h
+++ b/src/multiint.h
@@ -45,10 +45,10 @@
 
 void calcBackdropLayoutForMultiplayerOptionsTitleUI(WIDGET *psWidget, unsigned int, unsigned int, unsigned int, unsigned int);
 void readAIs();	///< step 1, load AI definition files
+void setAINameFromSave(int player, const char *name);
 void loadMultiScripts();	///< step 2, load the actual AI scripts
 const char *getAIName(int player);	///< only run this -after- readAIs() is called
 const std::vector<WzString> getAINames();
-int matchAIbyName(const char* name);	///< only run this -after- readAIs() is called
 
 LOBBY_ERROR_TYPES getLobbyError();
 void setLobbyError(LOBBY_ERROR_TYPES error_type);


### PR DESCRIPTION
It's the big one! The baddest, meanest PR you'll ever see this year (bet). My current attempt to remove binary data from the .gam files all into main.json introduced in 6670ce187a559dbed0fcbd7a0b49ee61488801fb (left out the hard part). It's totally invasive and breaks EVERYTHING and, yes, even your saves (not sorry). I may have to restart from the beginning for a second attempt, who knows.

I've relegated the save .gam file to be a mere 4 byte crutch that simply loads into a save game. Other than that it's (hopefully) just a matter of verifying stuff being saved correctly and loaded to fix the current issues.

Current known issues:
1. Visibility data appears in the maximal coordinates of Beta 1 (presumably, other maps as well).
2. Seen data isn't being loaded correctly, minimap and darkness of a campaign map goes back to pitch black.
3. Game Type warning when loading saves from away missions and the transitioning back to the home map. This may be due to getCampaign() loading all the V14 data structure on down just(?) to get the campaign "save key".
4. Skirmish AIs are not loaded.
5. See if we really need to save the map hash or not.

Fixes #1426. 