### PR TITLE
Fix AI messages wrongly targetting players

### DIFF
--- a/src/chat.cpp
+++ b/src/chat.cpp
@@ -154,9 +154,14 @@ void InGameChatMessage::sendToAiPlayers()
 	}
 }
 
-void InGameChatMessage::addPlayerByPosition(uint32_t position)
+void InGameChatMessage::addReceiverByPosition(uint32_t playerPosition)
 {
-	toPlayers.insert(findPlayerIndexByPosition(position));
+	toPlayers.insert(findPlayerIndexByPosition(playerPosition));
+}
+
+void InGameChatMessage::addReceiverByIndex(uint32_t playerIndex)
+{
+	toPlayers.insert(playerIndex);
 }
 
 void InGameChatMessage::send()

--- a/src/chat.h
+++ b/src/chat.h
@@ -33,7 +33,8 @@ struct InGameChatMessage
 
 	InGameChatMessage(uint32_t messageSender, char const *messageText);
 	void send();
-	void addPlayerByPosition(uint32_t position);
+	void addReceiverByPosition(uint32_t playerPosition);
+	void addReceiverByIndex(uint32_t playerIndex);
 
 private:
 	std::set<uint32_t> toPlayers;

--- a/src/hci.cpp
+++ b/src/hci.cpp
@@ -2579,7 +2579,7 @@ static void parseChatMessageModifiers(InGameChatMessage &message)
 
 	for (; *message.text >= '0' && *message.text <= '9'; ++message.text)  // for each 0..9 numeric char encountered
 	{
-		message.addPlayerByPosition(*message.text - '0');
+		message.addReceiverByPosition(*message.text - '0');
 	}
 }
 

--- a/src/wzapi.cpp
+++ b/src/wzapi.cpp
@@ -2020,7 +2020,7 @@ bool wzapi::chat(WZAPI_PARAMS(int target, std::string message))
 	}
 	else if (target != ALL_PLAYERS) // specific player
 	{
-		chatMessage.addPlayerByPosition(target);
+		chatMessage.addReceiverByIndex(target);
 	}
 
 	chatMessage.send();


### PR DESCRIPTION
Fixes #1766 

During the chat refactor, the method for adding players to the message
by position was wrongly used for AIs, cause the AIs refer to the players
directly by their index in `NetPlay.players` array.