### PR TITLE
Allow sharing unit controls with allies

### DIFF
--- a/lib/netplay/netplay.cpp
+++ b/lib/netplay/netplay.cpp
@@ -258,6 +258,26 @@ NETPLAY::NETPLAY()
 	}
 }
 
+void PLAYER::resetAll()
+{
+	name[0] = '\0';
+	position = -1;
+	colour = 0;
+	allocated = false;
+	heartattacktime = 0;
+	heartbeat = false;
+	kick = false;
+	connection = -1;
+	team = -1;
+	ready = false;
+	ai = 0;
+	difficulty = AIDifficulty::DISABLED;
+	autoGame = false;
+	IPtextAddress[0] = '\0';
+	faction = FACTION_NORMAL;
+	std::fill(sharing.begin(), sharing.end(), PlayerShareStatus({ false, false }));
+}
+
 bool PLAYER::isSharingUnitsWith(const unsigned int other) const
 {
 	return sharing[other].bUnits;

--- a/lib/netplay/netplay.cpp
+++ b/lib/netplay/netplay.cpp
@@ -265,6 +265,13 @@ bool PLAYER::isSharingUnitsWith(const unsigned int other) const
 
 void PLAYER::setUnitSharingState(const unsigned int other, const bool bState)
 {
+	const bool bOnSameTeam = NetPlay.players[selectedPlayer].team == NetPlay.players[other].team;
+	if (!bOnSameTeam)
+	{
+		debug(LOG_ERROR, "Cannot share units: %d is not on your team!", other);
+		return;
+	}
+
 	sharing[other].bUnits = bState;
 }
 

--- a/lib/netplay/netplay.cpp
+++ b/lib/netplay/netplay.cpp
@@ -258,6 +258,18 @@ NETPLAY::NETPLAY()
 	}
 }
 
+bool PLAYER::isSharingUnitsWith(const unsigned int other) const
+{
+	// TODO 823-share-unit-controls
+	return true;
+}
+
+void PLAYER::setUnitSharingState(const unsigned int other, const bool bState)
+{
+	// TODO 823-share-unit-controls
+}
+
+
 bool NETisCorrectVersion(uint32_t game_version_major, uint32_t game_version_minor)
 {
 	return (uint32_t)NETCODE_VERSION_MAJOR == game_version_major && (uint32_t)NETCODE_VERSION_MINOR == game_version_minor;

--- a/lib/netplay/netplay.cpp
+++ b/lib/netplay/netplay.cpp
@@ -260,13 +260,12 @@ NETPLAY::NETPLAY()
 
 bool PLAYER::isSharingUnitsWith(const unsigned int other) const
 {
-	// TODO 823-share-unit-controls
-	return true;
+	return sharing[other].bUnits;
 }
 
 void PLAYER::setUnitSharingState(const unsigned int other, const bool bState)
 {
-	// TODO 823-share-unit-controls
+	sharing[other].bUnits = bState;
 }
 
 

--- a/lib/netplay/netplay.h
+++ b/lib/netplay/netplay.h
@@ -275,25 +275,7 @@ struct PLAYER
 
 	std::vector<PlayerShareStatus> sharing = std::vector<PlayerShareStatus>(MAX_PLAYERS, { false, false });
 
-	void resetAll()
-	{
-		name[0] = '\0';
-		position = -1;
-		colour = 0;
-		allocated = false;
-		heartattacktime = 0;
-		heartbeat = false;
-		kick = false;
-		connection = -1;
-		team = -1;
-		ready = false;
-		ai = 0;
-		difficulty = AIDifficulty::DISABLED;
-		autoGame = false;
-		IPtextAddress[0] = '\0';
-		faction = FACTION_NORMAL;
-		std::fill(sharing.begin(), sharing.end(), PlayerShareStatus({ false, false }));
-	}
+	void resetAll();
 
 	bool isSharingUnitsWith(const unsigned int other) const;
 

--- a/lib/netplay/netplay.h
+++ b/lib/netplay/netplay.h
@@ -110,7 +110,8 @@ enum MESSAGE_TYPES
 	GAME_GAME_TIME,                 ///< Game time. Used for synchronising, so that all messages are executed at the same gameTime on all clients.
 	GAME_PLAYER_LEFT,               ///< Player has left or dropped.
 	GAME_DROIDDISEMBARK,            ///< droid disembarked from a Transporter
-	GAME_SYNC_REQUEST,		///< Game event generated from scripts that is meant to be synced
+	GAME_SYNC_REQUEST,              ///< Game event generated from scripts that is meant to be synced
+
 	// The following messages are used for debug mode.
 	GAME_DEBUG_MODE,                ///< Request enable/disable debug mode.
 	GAME_DEBUG_ADD_DROID,           ///< Add droid.
@@ -120,6 +121,11 @@ enum MESSAGE_TYPES
 	GAME_DEBUG_REMOVE_STRUCTURE,    ///< Remove structure.
 	GAME_DEBUG_REMOVE_FEATURE,      ///< Remove feature.
 	GAME_DEBUG_FINISH_RESEARCH,     ///< Research has been completed.
+
+	// Unit/control sharing
+	GAME_UNIT_SHARE,                ///< Player wants to start/stop sharing the unit control with an another player
+	GAME_MANUFACTURE_SHARE,         ///< Player wants to start/stop sharing the factory controls with an another player
+
 	// End of debug messages.
 	GAME_MAX_TYPE                   ///< Maximum+1 valid GAME_ type, *MUST* be last.
 };
@@ -259,7 +265,7 @@ struct PLAYER
 	bool                autoGame;           ///< if we are running a autogame (AI controls us)
 	std::vector<WZFile> wzFiles;            ///< for each player, we keep track of map/mod download progress
 	char                IPtextAddress[40];  ///< IP of this player
-	FactionID			faction;			///< which faction the player has
+	FactionID           faction;            ///< which faction the player has
 
 	void resetAll()
 	{

--- a/lib/netplay/netplay.h
+++ b/lib/netplay/netplay.h
@@ -285,6 +285,10 @@ struct PLAYER
 		IPtextAddress[0] = '\0';
 		faction = FACTION_NORMAL;
 	}
+
+	bool isSharingUnitsWith(const unsigned int other) const;
+
+	void setUnitSharingState(const unsigned int other, const bool bState);
 };
 
 struct PlayerReference;
@@ -314,6 +318,7 @@ struct NETPLAY
 
 	NETPLAY();
 };
+
 
 struct PLAYER_IP
 {

--- a/lib/netplay/netplay.h
+++ b/lib/netplay/netplay.h
@@ -245,6 +245,12 @@ enum class NET_LOBBY_OPT_FIELD
 	MAX
 };
 
+struct PlayerShareStatus
+{
+	bool bUnits;
+	bool bManufacture;
+};
+
 // ////////////////////////////////////////////////////////////////////////
 // Player information. Filled when players join, never re-ordered. selectedPlayer global points to
 // currently controlled player.
@@ -267,6 +273,8 @@ struct PLAYER
 	char                IPtextAddress[40];  ///< IP of this player
 	FactionID           faction;            ///< which faction the player has
 
+	std::vector<PlayerShareStatus> sharing = std::vector<PlayerShareStatus>(MAX_PLAYERS, { true, true});
+
 	void resetAll()
 	{
 		name[0] = '\0';
@@ -284,6 +292,7 @@ struct PLAYER
 		autoGame = false;
 		IPtextAddress[0] = '\0';
 		faction = FACTION_NORMAL;
+		std::fill(sharing.begin(), sharing.end(), PlayerShareStatus({ true, true }));
 	}
 
 	bool isSharingUnitsWith(const unsigned int other) const;

--- a/lib/netplay/netplay.h
+++ b/lib/netplay/netplay.h
@@ -279,7 +279,11 @@ struct PLAYER
 
 	bool isSharingUnitsWith(const unsigned int other) const;
 
+	bool isSharingManufactureWith(const unsigned int other) const;
+
 	void setUnitSharingState(const unsigned int other, const bool bState);
+
+	void setManufactureSharingState(const unsigned int other, const bool bState);
 };
 
 struct PlayerReference;

--- a/lib/netplay/netplay.h
+++ b/lib/netplay/netplay.h
@@ -273,7 +273,7 @@ struct PLAYER
 	char                IPtextAddress[40];  ///< IP of this player
 	FactionID           faction;            ///< which faction the player has
 
-	std::vector<PlayerShareStatus> sharing = std::vector<PlayerShareStatus>(MAX_PLAYERS, { true, true});
+	std::vector<PlayerShareStatus> sharing = std::vector<PlayerShareStatus>(MAX_PLAYERS, { false, false });
 
 	void resetAll()
 	{
@@ -292,7 +292,7 @@ struct PLAYER
 		autoGame = false;
 		IPtextAddress[0] = '\0';
 		faction = FACTION_NORMAL;
-		std::fill(sharing.begin(), sharing.end(), PlayerShareStatus({ true, true }));
+		std::fill(sharing.begin(), sharing.end(), PlayerShareStatus({ false, false }));
 	}
 
 	bool isSharingUnitsWith(const unsigned int other) const;

--- a/src/display3d.cpp
+++ b/src/display3d.cpp
@@ -3086,16 +3086,16 @@ static void	drawDroidSelections()
 	}
 
 	pie_SetFogStatus(false);
-	for (DROID *psDroid = apsDroidLists[selectedPlayer]; psDroid; psDroid = psDroid->psNext)
+	for (auto& droid : Droids::forPlayer(selectedPlayer, true, false))
 	{
 		/* If it's selected and on screen or it's the one the mouse is over */
-		if (eitherSelected(psDroid) ||
-		    (bMouseOverOwnDroid && psDroid == (DROID *) psClickedOn) ||
-		    droidUnderRepair(psDroid) ||
+		if (eitherSelected(&droid) ||
+		    (bMouseOverOwnDroid && &droid == (DROID *) psClickedOn) ||
+		    droidUnderRepair(&droid) ||
 		    barMode == BAR_DROIDS || barMode == BAR_DROIDS_AND_STRUCTURES
 		   )
 		{
-			drawDroidSelection(psDroid, psDroid->selected);
+			drawDroidSelection(&droid, droid.selected);
 		}
 	}
 

--- a/src/display3d.cpp
+++ b/src/display3d.cpp
@@ -3381,10 +3381,11 @@ void calcScreenCoords(DROID *psDroid, const glm::mat4 &viewMatrix)
 		radius = 1; // 1 just in case some other code assumes radius != 0
 	}
 
-	/* Deselect all the droids if we've released the drag box */
+	/* Handle droid selection changes if we've released the drag box */
 	if (dragBox3D.status == DRAG_RELEASED)
 	{
-		if (inQuad(&center, &dragQuad) && NetPlay.players[psDroid->player].isSharingUnitsWith(selectedPlayer))
+		const bool bCanSelectDroid = psDroid->player == selectedPlayer || NetPlay.players[psDroid->player].isSharingUnitsWith(selectedPlayer);
+		if (inQuad(&center, &dragQuad) && bCanSelectDroid)
 		{
 			//don't allow Transporter Droids to be selected here
 			//unless we're in multiPlayer mode!!!!

--- a/src/display3d.cpp
+++ b/src/display3d.cpp
@@ -3384,7 +3384,7 @@ void calcScreenCoords(DROID *psDroid, const glm::mat4 &viewMatrix)
 	/* Deselect all the droids if we've released the drag box */
 	if (dragBox3D.status == DRAG_RELEASED)
 	{
-		if (inQuad(&center, &dragQuad) && psDroid->player == selectedPlayer)
+		if (inQuad(&center, &dragQuad) && NetPlay.players[psDroid->player].isSharingUnitsWith(selectedPlayer))
 		{
 			//don't allow Transporter Droids to be selected here
 			//unless we're in multiPlayer mode!!!!

--- a/src/hci/build.cpp
+++ b/src/hci/build.cpp
@@ -24,11 +24,11 @@ void BuildController::updateBuildersList()
 {
 	builders.clear();
 
-	for (DROID *droid = apsDroidLists[selectedPlayer]; droid; droid = droid->psNext)
+	for (auto& droid : Droids::forPlayer(selectedPlayer, true, false))
 	{
-		if (isConstructionDroid(droid) && droid->died == 0)
+		if (isConstructionDroid(&droid) && droid.died == 0)
 		{
-			builders.push_back(droid);
+			builders.push_back(&droid);
 		}
 	}
 

--- a/src/intorder.cpp
+++ b/src/intorder.cpp
@@ -388,14 +388,9 @@ bool OrderUp = false;
 //
 static bool BuildSelectedDroidList()
 {
-	DROID *psDroid;
-
-	for (psDroid = apsDroidLists[selectedPlayer]; psDroid; psDroid = psDroid->psNext)
+	for (auto& droid : Droids::forPlayer(selectedPlayer, true, true))
 	{
-		if (psDroid->selected)
-		{
-			SelectedDroids.push_back(psDroid);
-		}
+		SelectedDroids.push_back(&droid);
 	}
 
 	return !SelectedDroids.empty();

--- a/src/multibot.cpp
+++ b/src/multibot.cpp
@@ -559,7 +559,7 @@ DROID_ORDER_DATA infoToOrderData(QueuedDroidInfo const &info, STRUCTURE_STATS co
 // Droid update information
 void sendDroidInfo(DROID *psDroid, DroidOrder const &order, bool add)
 {
-	if (!myResponsibility(psDroid->player))
+	if (!myResponsibility(psDroid->player) && !NetPlay.players[psDroid->player].isSharingUnitsWith(selectedPlayer))
 	{
 		return;
 	}
@@ -661,7 +661,7 @@ bool recvDroidInfo(NETQUEUE queue)
 				syncDebug("Droid %d missing", info.droidId);
 				continue;  // Can't find the droid, so skip this droid.
 			}
-			if (!canGiveOrdersFor(queue.index, psDroid->player))
+			if (!canGiveOrdersFor(queue.index, psDroid->player) && !NetPlay.players[psDroid->player].isSharingUnitsWith(queue.index))
 			{
 				debug(LOG_WARNING, "Droid order (by %d) for wrong player (%d).", queue.index, psDroid->player);
 				syncDebug("Wrong player.");

--- a/src/multiint.cpp
+++ b/src/multiint.cpp
@@ -99,6 +99,7 @@
 #include "multimenu.h"
 #include "multilimit.h"
 #include "multigifts.h"
+#include "multishare.h"
 
 #include "titleui/titleui.h"
 
@@ -4131,6 +4132,10 @@ void WzMultiplayerOptionsTitleUI::frontendMultiMessages(bool running)
 
 		case GAME_ALLIANCE:
 			recvAlliance(queue, false);
+			break;
+
+		case MESSAGE_TYPES::GAME_UNIT_SHARE:
+			recvUnitShareStatus(queue);
 			break;
 
 		case NET_COLOURREQUEST:

--- a/src/multiplay.cpp
+++ b/src/multiplay.cpp
@@ -497,7 +497,7 @@ bool isHumanPlayer(int player)
 }
 
 // returns player responsible for 'player'
-int whosResponsible(int player)
+unsigned int whosResponsible(unsigned int player)
 {
 	if (isHumanPlayer(player))
 	{
@@ -513,22 +513,29 @@ int whosResponsible(int player)
 	}
 }
 
-//returns true if selected player is responsible for 'player'
-bool myResponsibility(int player)
+// TODO 823-share-unit-control: Move this to somewhere more sensible
+static bool isHost(unsigned int player)
 {
-	return (whosResponsible(player) == selectedPlayer || whosResponsible(player) == realSelectedPlayer);
+	return player == NET_HOST_ONLY;
+}
+
+//returns true if selected player is responsible for 'player'
+bool myResponsibility(unsigned int player)
+{
+	return isHumanPlayer(player)
+		? (whosResponsible(player) == selectedPlayer || whosResponsible(player) == realSelectedPlayer)
+		: (isHost(selectedPlayer) || isHost(realSelectedPlayer));
 }
 
 //returns true if 'player' is responsible for 'playerinquestion'
-bool responsibleFor(int player, int playerinquestion)
+bool responsibleFor(unsigned int player, unsigned int playerinquestion)
 {
 	return whosResponsible(playerinquestion) == player;
 }
 
-bool canGiveOrdersFor(int player, int playerInQuestion)
+bool canGiveOrdersFor(unsigned int player, unsigned int playerInQuestion)
 {
-	return playerInQuestion >= 0 && playerInQuestion < MAX_PLAYERS &&
-	       (player == playerInQuestion || responsibleFor(player, playerInQuestion) || getDebugMappingStatus());
+	return playerInQuestion < MAX_PLAYERS && (player == playerInQuestion || responsibleFor(player, playerInQuestion) || getDebugMappingStatus());
 }
 
 int scavengerSlot()
@@ -1142,7 +1149,7 @@ bool NetworkTextMessage::receive(NETQUEUE queue)
 	NETstring(text, MAX_CONSOLE_STRING_LENGTH);
 	NETend();
 
-	if (whosResponsible(sender) != queue.index)
+	if (sender < 0 || whosResponsible(sender) != queue.index)
 	{
 		sender = queue.index;  // Fix corrupted sender.
 	}

--- a/src/multiplay.cpp
+++ b/src/multiplay.cpp
@@ -69,6 +69,7 @@
 #include "multirecv.h"								// incoming messages stuff
 #include "multistat.h"
 #include "multigifts.h"								// gifts and alliances.
+#include "multishare.h"								// unit sharing.
 #include "multiint.h"
 #include "keymap.h"
 #include "cheat.h"
@@ -845,6 +846,9 @@ bool recvMessage()
 			break;
 		case GAME_PLAYER_LEFT:
 			recvPlayerLeft(queue);
+			break;
+		case MESSAGE_TYPES::GAME_UNIT_SHARE:
+			recvUnitShareStatus(queue);
 			break;
 		default:
 			processedMessage2 = false;

--- a/src/multiplay.cpp
+++ b/src/multiplay.cpp
@@ -487,7 +487,7 @@ bool setPlayerName(int player, const char *sName)
 
 // ////////////////////////////////////////////////////////////////////////////
 // to determine human/computer players and responsibilities of each..
-bool isHumanPlayer(int player)
+bool isHumanPlayer(unsigned int player)
 {
 	if (player >= MAX_PLAYERS || player < 0)
 	{
@@ -513,8 +513,7 @@ unsigned int whosResponsible(unsigned int player)
 	}
 }
 
-// TODO 823-share-unit-control: Move this to somewhere more sensible
-static bool isHost(unsigned int player)
+bool isHost(unsigned int player)
 {
 	return player == NET_HOST_ONLY;
 }

--- a/src/multiplay.h
+++ b/src/multiplay.h
@@ -187,11 +187,29 @@ WZ_DECL_WARN_UNUSED_RESULT DROID_TEMPLATE	*IdToTemplate(UDWORD tempId, UDWORD pl
 const char *getPlayerName(int player);
 bool setPlayerName(int player, const char *sName);
 const char *getPlayerColourName(int player);
-bool isHumanPlayer(int player);				//to tell if the player is a computer or not.
-bool myResponsibility(int player);
-bool responsibleFor(int player, int playerinquestion);
-int whosResponsible(int player);
-bool canGiveOrdersFor(int player, int playerInQuestion);
+
+/* Checks if the player in given slot is the host. */
+bool isHost(unsigned int player);
+
+/* Checks if the player in given slot is controlled by an AI */
+bool isHumanPlayer(unsigned int player);
+
+/* Checks if the player in given slot is responsibility of the selected player. */
+bool myResponsibility(unsigned int player);
+
+/* Checks if the player `player` is resposible for the player `playerInQuestion`. All human players are
+   responsible for themselves, while all AI players are considered to be the responsibility of the host. */
+bool responsibleFor(unsigned int player, unsigned int playerInQuestion);
+
+/* Returns the player index of the player considered to be responsible for the given player. */
+unsigned int whosResponsible(unsigned int player);
+
+/* Checks if the player `player` may give orders for droids of the player `playerInQuestion`. Normally,
+   players may only give orders to their own units. Host is allowed to command AIs (as they run on their
+   machine, meaning that `selectedPlayer` is always the host player for the AIs, too). However, if debug
+   features are enabled, any player may command any other players' units.                                */
+bool canGiveOrdersFor(unsigned int player, unsigned int playerInQuestion);
+
 int scavengerSlot();    // Returns the player number that scavengers would have if they were enabled.
 int scavengerPlayer();  // Returns the player number that the scavengers have, or -1 if disabled.
 Vector3i cameraToHome(UDWORD player, bool scroll);

--- a/src/multishare.cpp
+++ b/src/multishare.cpp
@@ -25,7 +25,7 @@
 
 void sendUnitShareStatus(uint8_t from, uint8_t to, bool bStatus)
 {
-	NETbeginEncode(NETgameQueue(selectedPlayer), MESSAGE_TYPES::GAME_UNIT_SHARE);
+	NETbeginEncode(NETgameQueue(selectedPlayer), static_cast<uint8_t>(MESSAGE_TYPES::GAME_UNIT_SHARE));
 	NETuint8_t(&from);
 	NETuint8_t(&to);
 	NETbool(&bStatus);
@@ -37,7 +37,7 @@ bool recvUnitShareStatus(NETQUEUE queue)
 	uint8_t from, to;
 	bool bStatus;
 
-	NETbeginDecode(NETgameQueue(selectedPlayer), MESSAGE_TYPES::GAME_UNIT_SHARE);
+	NETbeginDecode(queue, static_cast<uint8_t>(MESSAGE_TYPES::GAME_UNIT_SHARE));
 	NETuint8_t(&from);
 	NETuint8_t(&to);
 	NETbool(&bStatus);

--- a/src/multishare.cpp
+++ b/src/multishare.cpp
@@ -1,0 +1,61 @@
+/*
+	This file is part of Warzone 2100.
+	Copyright (C) 1999-2004  Eidos Interactive
+	Copyright (C) 2005-2020  Warzone 2100 Project
+
+	Warzone 2100 is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+
+	Warzone 2100 is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with Warzone 2100; if not, write to the Free Software
+	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+
+#include "multishare.h"
+
+#include "lib/netplay/netplay.h"
+#include "multiplay.h"
+
+void sendUnitShareStatus(uint8_t from, uint8_t to, bool bStatus)
+{
+	NETbeginEncode(NETgameQueue(selectedPlayer), MESSAGE_TYPES::GAME_UNIT_SHARE);
+	NETuint8_t(&from);
+	NETuint8_t(&to);
+	NETbool(&bStatus);
+	NETend();
+}
+
+bool recvUnitShareStatus(NETQUEUE queue)
+{
+	uint8_t from, to;
+	bool bStatus;
+
+	NETbeginDecode(NETgameQueue(selectedPlayer), MESSAGE_TYPES::GAME_UNIT_SHARE);
+	NETuint8_t(&from);
+	NETuint8_t(&to);
+	NETbool(&bStatus);
+	NETend();
+
+	if (!canGiveOrdersFor(queue.index, from))
+	{
+		return false;
+	}
+
+	NetPlay.players[from].setUnitSharingState(to, bStatus);
+
+
+	return true;
+}
+
+void setUnitShareStatus(const unsigned int from, const unsigned int to, const bool bStatus)
+{
+	syncDebug("Set unit sharing from %d to %d = %s", from, to, bStatus ? "true" : "false");
+	sendUnitShareStatus(static_cast<uint8_t>(from), static_cast<uint8_t>(to), bStatus);
+}

--- a/src/multishare.h
+++ b/src/multishare.h
@@ -25,7 +25,7 @@
 
 void setUnitShareStatus(const unsigned int from, const unsigned int to, const bool bStatus);
 
-void sendUnitShareStatus(const unsigned int from, const unsigned int to, const bool bStatus);
+void sendUnitShareStatus(uint8_t from, uint8_t to, bool bStatus);
 bool recvUnitShareStatus(NETQUEUE queue);
 
 #endif // __INCLUDED_SRC_MULTISHARE_H__

--- a/src/multishare.h
+++ b/src/multishare.h
@@ -1,0 +1,31 @@
+/*
+	This file is part of Warzone 2100.
+	Copyright (C) 1999-2004  Eidos Interactive
+	Copyright (C) 2005-2020  Warzone 2100 Project
+
+	Warzone 2100 is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+
+	Warzone 2100 is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with Warzone 2100; if not, write to the Free Software
+	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+
+#ifndef __INCLUDED_SRC_MULTISHARE_H__
+#define __INCLUDED_SRC_MULTISHARE_H__
+
+#include "lib/netplay/netplay.h"
+
+void setUnitShareStatus(const unsigned int from, const unsigned int to, const bool bStatus);
+
+void sendUnitShareStatus(const unsigned int from, const unsigned int to, const bool bStatus);
+bool recvUnitShareStatus(NETQUEUE queue);
+
+#endif // __INCLUDED_SRC_MULTISHARE_H__

--- a/src/objiter.cpp
+++ b/src/objiter.cpp
@@ -1,0 +1,168 @@
+/*
+	This file is part of Warzone 2100.
+	Copyright (C) 1999-2004  Eidos Interactive
+	Copyright (C) 2005-2020  Warzone 2100 Project
+
+	Warzone 2100 is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+
+	Warzone 2100 is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with Warzone 2100; if not, write to the Free Software
+	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+
+#include "objiter.h"
+#include "droiddef.h"
+
+template class ObjectIterator<DROID>;
+template class PlayerObjectIterator<DROID>;
+
+template<typename T>
+ObjectIterator<T>::ObjectIterator(
+	const bool bSelectedOnly,
+	T* firstObject
+)
+	: currentObject(firstObject)
+	, bSelectedOnly(bSelectedOnly)
+{
+	// Ensure the first object matches the selection filter
+	if (bSelectedOnly && (currentObject && !currentObject->selected))
+	{
+		ObjectIterator<T>& iter = *this;
+		++iter;
+	}
+}
+
+template<typename T>
+ObjectIterator<T>& ObjectIterator<T>::operator++()
+{
+	// Loop through the objects via next ptrs, picking only those matching selection filter
+	while (currentObject)
+	{
+		currentObject = currentObject->psNext;
+		if (!bSelectedOnly || (currentObject && currentObject->selected))
+		{
+			return *this;
+		}
+	}
+
+	// If the current player has no more suitable objects, set the current object to nullptr to signify we are at the end
+	currentObject = nullptr;
+	return *this;
+}
+
+template<typename T>
+ObjectIterator<T> ObjectIterator<T>::operator++(int)
+{
+	ObjectIterator<T> iter = *this;
+	++(*this);
+	return iter;
+}
+
+template<typename T>
+bool ObjectIterator<T>::operator==(ObjectIterator<T> other) const
+{
+	return currentObject == other.currentObject;
+}
+
+template<typename T>
+bool ObjectIterator<T>::operator!=(ObjectIterator<T> other) const
+{
+	return !(*this == other);
+}
+
+template<typename T>
+typename ObjectIterator<T>::reference ObjectIterator<T>::operator*() const
+{
+	ASSERT(currentObject != nullptr, "Attempt to dereference a past-the-end iterator");
+	return *currentObject;
+}
+
+// Verifies that objIter is valid to be used in PlayerObjectIterator
+template<typename T>
+bool PlayerObjectIterator<T>::isObjIterValid()
+{
+	// ObjectIterator is valid if it has an object and the object matches the selection filter.
+	return objIter.currentObject && (!bSelectedOnly || objIter.currentObject->selected);
+}
+
+template<typename T>
+PlayerObjectIterator<T>::PlayerObjectIterator(
+	const unsigned int playerCursor,
+	const std::vector<unsigned int> playerIndices,
+	const bool bSelectedOnly,
+	T** objectList
+)
+	: playerCursor(playerCursor)
+	, playerIndices(playerIndices)
+	, bSelectedOnly(bSelectedOnly)
+	, objectList(objectList)
+	, objIter(playerCursor >= playerIndices.size()
+		? ObjectIterator<T>(bSelectedOnly, nullptr)
+		: ObjectIterator<T>(bSelectedOnly, objectList[playerIndices[playerCursor]]))
+{
+	// Make sure the current player has any objects and those objects match the selection filter.
+	// Iterate players until a player with available objects is found. If none are found, the iterator
+	// becomes past-the-end iterator (playerCursor is past the end and objIter.currentObject is null).
+	while (this->playerCursor < playerIndices.size() && !isObjIterValid())
+	{
+		PlayerObjectIterator<T>& iter = *this;
+		++iter;
+	}
+}
+
+template<typename T>
+PlayerObjectIterator<T>& PlayerObjectIterator<T>::operator++()
+{
+	// Select the next object via the child iterator
+	++objIter;
+
+	// If the child iterator ran out of objects, find next player with more objects.
+	while (!objIter.currentObject && playerCursor < playerIndices.size())
+	{
+		++playerCursor;
+		objIter = playerCursor >= playerIndices.size()
+			? ObjectIterator<T>(bSelectedOnly, nullptr)
+			: ObjectIterator<T>(bSelectedOnly, objectList[playerIndices[playerCursor]]);
+	}
+
+	return *this;
+}
+
+template<typename T>
+PlayerObjectIterator<T> PlayerObjectIterator<T>::operator++(int)
+{
+	PlayerObjectIterator<T> iter = *this;
+	++(*this);
+	return iter;
+}
+
+template<typename T>
+bool PlayerObjectIterator<T>::operator==(PlayerObjectIterator<T> other) const
+{
+	return bSelectedOnly == other.bSelectedOnly
+		&& objectList == other.objectList
+		&& playerCursor == other.playerCursor
+		&& objIter.currentObject == other.objIter.currentObject;
+}
+
+template<typename T>
+bool PlayerObjectIterator<T>::operator!=(PlayerObjectIterator<T> other) const
+{
+	return !(*this == other);
+}
+
+template<typename T>
+typename PlayerObjectIterator<T>::reference PlayerObjectIterator<T>::operator*() const
+{
+	ASSERT(playerCursor < playerIndices.size() && objIter.currentObject, "Attempt to dereference a past-the-end iterator");
+	return *objIter.currentObject;
+}
+

--- a/src/objiter.h
+++ b/src/objiter.h
@@ -1,0 +1,88 @@
+/*
+	This file is part of Warzone 2100.
+	Copyright (C) 1999-2004  Eidos Interactive
+	Copyright (C) 2005-2020  Warzone 2100 Project
+
+	Warzone 2100 is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+
+	Warzone 2100 is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with Warzone 2100; if not, write to the Free Software
+	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+/** @file
+ *  Utilities for iterating over collections of objects
+ */
+
+
+#ifndef __INCLUDED_SRC_OBJITER_H__
+#define __INCLUDED_SRC_OBJITER_H__
+
+#include <iterator>
+#include <vector>
+
+
+/* Abstract base class for iterators over object lists. */
+template<typename T>
+class ObjectIterator : public std::iterator<std::input_iterator_tag, T, T, T*, T&>
+{
+public:
+	explicit ObjectIterator(
+		const bool bSelectedOnly,
+		T* firstObject
+	);
+
+private:
+	T* currentObject;
+	bool bSelectedOnly;
+
+	// Iterator implementation
+public:
+	ObjectIterator<T>& operator++();
+	ObjectIterator<T> operator++(int);
+	bool operator==(ObjectIterator<T> other) const;
+	bool operator!=(ObjectIterator<T> other) const;
+	typename ObjectIterator<T>::reference operator*() const;
+
+	template<typename U>
+	friend class PlayerObjectIterator;
+};
+
+template <typename T>
+class PlayerObjectIterator : public std::iterator<std::input_iterator_tag, T, T, T*, T&>
+{
+public:
+	explicit PlayerObjectIterator(
+		const unsigned int playerCursor,
+		const std::vector<unsigned int> playerIndices,
+		const bool bSelectedOnly,
+		T** objectList
+	);
+
+private:
+	unsigned int playerCursor;
+	ObjectIterator<T> objIter;
+
+	const std::vector<unsigned int> playerIndices;
+	const bool bSelectedOnly;
+	T** objectList;
+
+	bool isObjIterValid();
+
+	// Iterator implementation
+public:
+	PlayerObjectIterator<T>& operator++();
+	PlayerObjectIterator<T> operator++(int);
+	bool operator==(PlayerObjectIterator<T> other) const;
+	bool operator!=(PlayerObjectIterator<T> other) const;
+	typename PlayerObjectIterator<T>::reference operator*() const;
+};
+
+#endif // __INCLUDED_SRC_OBJITER_H__

--- a/src/objmem.cpp
+++ b/src/objmem.cpp
@@ -101,19 +101,16 @@ Droids Droids::forPlayer(const unsigned int playerIndex, const bool bIncludeShar
 	// 	   - bSelectedOnly can be made more efficient by keeping track of selections (in a list) instead of relying on psDroid->selected
 
 	std::vector<unsigned int> playerIndices = { playerIndex };
-	auto& sharing = NetPlay.players[playerIndex].sharing;
-	for (auto it = sharing.begin(); it != sharing.end(); ++it)
+	for (unsigned int other = 0; other < MAX_PLAYERS; ++other)
 	{
-		const unsigned int index = it - sharing.begin();
-		if (index == playerIndex)
+		if (other == playerIndex)
 		{
 			continue;
 		}
 
-		PlayerShareStatus& share = *it;
-		if (share.bUnits)
+		if (NetPlay.players[other].isSharingUnitsWith(playerIndex))
 		{
-			playerIndices.push_back(index);
+			playerIndices.push_back(other);
 		}
 	}
 

--- a/src/objmem.cpp
+++ b/src/objmem.cpp
@@ -43,6 +43,7 @@
 #include "combat.h"
 #include "visibility.h"
 #include "qtscript.h"
+#include "objiter.h"
 
 // the initial value for the object ID
 #define OBJ_ID_INIT 20000
@@ -66,141 +67,6 @@ FLAG_POSITION	*apsFlagPosLists[MAX_PLAYERS];
 
 /* The list of destroyed objects */
 BASE_OBJECT		*psDestroyedObj = nullptr;
-
-template<typename T>
-ObjectIterator<T>::ObjectIterator(
-	const bool bSelectedOnly,
-	T* firstObject
-)
-	: currentObject(firstObject)
-	, bSelectedOnly(bSelectedOnly)
-{
-	// Ensure the first object matches the selection filter
-	if (bSelectedOnly && (currentObject && !currentObject->selected))
-	{
-		ObjectIterator<T>& iter = *this;
-		++iter;
-	}
-}
-
-template<typename T>
-ObjectIterator<T>& ObjectIterator<T>::operator++()
-{
-	// Loop through the objects via next ptrs, picking only those matching selection filter
-	while (currentObject)
-	{
-		currentObject = currentObject->psNext;
-		if (!bSelectedOnly || (currentObject && currentObject->selected))
-		{
-			return *this;
-		}
-	}
-
-	// If the current player has no more suitable objects, set the current object to nullptr to signify we are at the end
-	currentObject = nullptr;
-	return *this;
-}
-
-template<typename T>
-ObjectIterator<T> ObjectIterator<T>::operator++(int)
-{
-	ObjectIterator<T> iter = *this;
-	++(*this);
-	return iter;
-}
-
-template<typename T>
-bool ObjectIterator<T>::operator==(ObjectIterator<T> other) const
-{
-	return currentObject == other.currentObject;
-}
-
-template<typename T>
-bool ObjectIterator<T>::operator!=(ObjectIterator<T> other) const
-{
-	return !(*this == other);
-}
-
-template<typename T>
-typename ObjectIterator<T>::reference ObjectIterator<T>::operator*() const
-{
-	ASSERT(currentObject != nullptr, "Attempt to dereference a past-the-end iterator");
-	return *currentObject;
-}
-
-template<typename T>
-PlayerObjectIterator<T>::PlayerObjectIterator(
-	const unsigned int playerCursor,
-	const std::vector<unsigned int> playerIndices,
-	const bool bSelectedOnly,
-	T** objectList
-)
-	: playerCursor(playerCursor)
-	, playerIndices(playerIndices)
-	, bSelectedOnly(bSelectedOnly)
-	, objectList(objectList)
-	, objIter(playerCursor >= playerIndices.size()
-		? ObjectIterator<T>(bSelectedOnly, nullptr)
-		: ObjectIterator<T>(bSelectedOnly, objectList[playerIndices[playerCursor]]))
-{
-	// Make sure the current player has any objects matching the selection filter
-	while (bSelectedOnly && this->playerCursor < playerIndices.size() && objIter.currentObject == nullptr)
-	{
-		PlayerObjectIterator<T>& iter = *this;
-		++iter;
-	}
-}
-
-template<typename T>
-PlayerObjectIterator<T>& PlayerObjectIterator<T>::operator++()
-{
-	// Select the next object via the child iterator
-	++objIter;
-
-	// If the child iterator ran out of objects, find next player with more objects.
-	while (!objIter.currentObject && playerCursor < playerIndices.size())
-	{
-		++playerCursor;
-		objIter = playerCursor >= playerIndices.size()
-			? ObjectIterator<T>(bSelectedOnly, nullptr)
-			: ObjectIterator<T>(bSelectedOnly, objectList[playerIndices[playerCursor]]);
-	}
-
-	return *this;
-}
-
-template<typename T>
-PlayerObjectIterator<T> PlayerObjectIterator<T>::operator++(int)
-{
-	PlayerObjectIterator<T> iter = *this;
-	++(*this);
-	return iter;
-}
-
-template<typename T>
-bool PlayerObjectIterator<T>::operator==(PlayerObjectIterator<T> other) const
-{
-	return bSelectedOnly == other.bSelectedOnly
-		&& objectList == other.objectList
-		&& playerCursor == other.playerCursor
-		&& objIter.currentObject == other.objIter.currentObject;
-}
-
-template<typename T>
-bool PlayerObjectIterator<T>::operator!=(PlayerObjectIterator<T> other) const
-{
-	return !(*this == other);
-}
-
-template<typename T>
-typename PlayerObjectIterator<T>::reference PlayerObjectIterator<T>::operator*() const
-{
-	ASSERT(playerCursor < playerIndices.size() && objIter.currentObject, "Attempt to dereference a past-the-end iterator");
-	return *objIter.currentObject;
-}
-
-template class ObjectIterator<DROID>;
-template class PlayerObjectIterator<DROID>;
 
 PlayerObjectIterator<DROID> Droids::begin() const
 {
@@ -234,9 +100,22 @@ Droids Droids::forPlayer(const unsigned int playerIndex, const bool bIncludeShar
 	// TODO: The current implementation "hides" the inefficient loop-over-players'-droids implementation. Droid counts are relatively small, so this should not be an issue.
 	// 	   - bSelectedOnly can be made more efficient by keeping track of selections (in a list) instead of relying on psDroid->selected
 
-	//const std::vector<unsigned int> playerIndices = { playerIndex };
-	const std::vector<unsigned int> playerIndices = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
-	// TODO 823-share-unit-controls: obtain a list of share targets to playerIndices
+	std::vector<unsigned int> playerIndices = { playerIndex };
+	auto& sharing = NetPlay.players[playerIndex].sharing;
+	for (auto it = sharing.begin(); it != sharing.end(); ++it)
+	{
+		const unsigned int index = it - sharing.begin();
+		if (index == playerIndex)
+		{
+			continue;
+		}
+
+		PlayerShareStatus& share = *it;
+		if (share.bUnits)
+		{
+			playerIndices.push_back(index);
+		}
+	}
 
 	return Droids(playerIndices, bSelectedOnly);
 }

--- a/src/objmem.h
+++ b/src/objmem.h
@@ -24,10 +24,10 @@
 #ifndef __INCLUDED_SRC_OBJMEM_H__
 #define __INCLUDED_SRC_OBJMEM_H__
 
-#include <iterator>
 #include <vector>
 
 #include "objectdef.h"
+#include "objiter.h"
 
 /* The lists of objects allocated */
 extern DROID			*apsDroidLists[MAX_PLAYERS];
@@ -41,60 +41,6 @@ extern FEATURE			*apsOilList[1];
 /* The list of destroyed objects */
 extern BASE_OBJECT	*psDestroyedObj;
 
-
-/* Abstract base class for iterators over object lists. */
-template<typename T>
-class ObjectIterator : public std::iterator<std::input_iterator_tag, T, T, T*, T&>
-{
-public:
-	explicit ObjectIterator(
-		const bool bSelectedOnly,
-		T* firstObject
-	);
-
-private:
-	T* currentObject;
-	bool bSelectedOnly;
-
-	// Iterator implementation
-public:
-	ObjectIterator<T>& operator++();
-	ObjectIterator<T> operator++(int);
-	bool operator==(ObjectIterator<T> other) const;
-	bool operator!=(ObjectIterator<T> other) const;
-	typename ObjectIterator<T>::reference operator*() const;
-
-	template<typename U>
-	friend class PlayerObjectIterator;
-};
-
-template <typename T>
-class PlayerObjectIterator : public std::iterator<std::input_iterator_tag, T, T, T*, T&>
-{
-public:
-	explicit PlayerObjectIterator(
-		const unsigned int playerCursor,
-		const std::vector<unsigned int> playerIndices,
-		const bool bSelectedOnly,
-		T** objectList
-	);
-
-private:
-	unsigned int playerCursor;
-	ObjectIterator<T> objIter;
-
-	const std::vector<unsigned int> playerIndices;
-	const bool bSelectedOnly;
-	T** objectList;
-
-	// Iterator implementation
-public:
-	PlayerObjectIterator<T>& operator++();
-	PlayerObjectIterator<T> operator++(int);
-	bool operator==(PlayerObjectIterator<T> other) const;
-	bool operator!=(PlayerObjectIterator<T> other) const;
-	typename PlayerObjectIterator<T>::reference operator*() const;
-};
 
 /* Convenient iterator over the droid lists. */
 class Droids

--- a/src/selection.cpp
+++ b/src/selection.cpp
@@ -50,8 +50,7 @@
 // stores combinations of unit components
 static std::vector<std::vector<uint32_t> > combinations;
 
-template <typename T>
-static unsigned selSelectUnitsIf(unsigned player, T condition, bool onlyOnScreen)
+static unsigned selSelectUnitsIf(unsigned player, std::function<bool(DROID*)> condition, bool onlyOnScreen)
 {
 	unsigned count = 0;
 
@@ -76,8 +75,8 @@ static unsigned selSelectUnitsIf(unsigned player, T condition, bool onlyOnScreen
 	return count;
 }
 
-template <typename T, typename U>
-static unsigned selSelectUnitsIf(unsigned player, T condition, U value, bool onlyOnScreen)
+template <typename T>
+static unsigned selSelectUnitsIf(unsigned player, std::function<bool(DROID*, T)> condition, T value, bool onlyOnScreen)
 {
 	return selSelectUnitsIf(player, [condition, value](DROID *psDroid) { return condition(psDroid, value); }, onlyOnScreen);
 }
@@ -570,43 +569,43 @@ unsigned int selDroidSelection(unsigned int player, SELECTION_CLASS droidClass, 
 		switch (droidType)
 		{
 		case DST_VTOL:
-			retVal = selSelectUnitsIf(player, selProp, PROPULSION_TYPE_LIFT, bOnScreen);
+			retVal = selSelectUnitsIf<PROPULSION_TYPE>(player, selProp, PROPULSION_TYPE_LIFT, bOnScreen);
 			break;
 		case DST_VTOL_ARMED:
-			retVal = selSelectUnitsIf(player, selPropArmed, PROPULSION_TYPE_LIFT, bOnScreen);
+			retVal = selSelectUnitsIf<PROPULSION_TYPE>(player, selPropArmed, PROPULSION_TYPE_LIFT, bOnScreen);
 			break;
 		case DST_HOVER:
-			retVal = selSelectUnitsIf(player, selProp, PROPULSION_TYPE_HOVER, bOnScreen);
+			retVal = selSelectUnitsIf<PROPULSION_TYPE>(player, selProp, PROPULSION_TYPE_HOVER, bOnScreen);
 			break;
 		case DST_WHEELED:
-			retVal = selSelectUnitsIf(player, selProp, PROPULSION_TYPE_WHEELED, bOnScreen);
+			retVal = selSelectUnitsIf<PROPULSION_TYPE>(player, selProp, PROPULSION_TYPE_WHEELED, bOnScreen);
 			break;
 		case DST_TRACKED:
-			retVal = selSelectUnitsIf(player, selProp, PROPULSION_TYPE_TRACKED, bOnScreen);
+			retVal = selSelectUnitsIf<PROPULSION_TYPE>(player, selProp, PROPULSION_TYPE_TRACKED, bOnScreen);
 			break;
 		case DST_HALF_TRACKED:
-			retVal = selSelectUnitsIf(player, selProp, PROPULSION_TYPE_HALF_TRACKED, bOnScreen);
+			retVal = selSelectUnitsIf<PROPULSION_TYPE>(player, selProp, PROPULSION_TYPE_HALF_TRACKED, bOnScreen);
 			break;
 		case DST_CYBORG:
-			retVal = selSelectUnitsIf(player, selProp, PROPULSION_TYPE_LEGGED, bOnScreen);
+			retVal = selSelectUnitsIf<PROPULSION_TYPE>(player, selProp, PROPULSION_TYPE_LEGGED, bOnScreen);
 			break;
 		case DST_ENGINEER:
-			retVal = selSelectUnitsIf(player, selType, DROID_CYBORG_CONSTRUCT, bOnScreen);
+			retVal = selSelectUnitsIf<DROID_TYPE>(player, selType, DROID_CYBORG_CONSTRUCT, bOnScreen);
 			break;
 		case DST_MECHANIC:
-			retVal = selSelectUnitsIf(player, selType, DROID_CYBORG_REPAIR, bOnScreen);
+			retVal = selSelectUnitsIf<DROID_TYPE>(player, selType, DROID_CYBORG_REPAIR, bOnScreen);
 			break;
 		case DST_TRANSPORTER:
 			retVal = selSelectUnitsIf(player, selTransporter, bOnScreen);
 			break;
 		case DST_REPAIR_TANK:
-			retVal = selSelectUnitsIf(player, selType, DROID_REPAIR, bOnScreen);
+			retVal = selSelectUnitsIf<DROID_TYPE>(player, selType, DROID_REPAIR, bOnScreen);
 			break;
 		case DST_SENSOR:
-			retVal = selSelectUnitsIf(player, selType, DROID_SENSOR, bOnScreen);
+			retVal = selSelectUnitsIf<DROID_TYPE>(player, selType, DROID_SENSOR, bOnScreen);
 			break;
 		case DST_TRUCK:
-			retVal = selSelectUnitsIf(player, selType, DROID_CONSTRUCT, bOnScreen);
+			retVal = selSelectUnitsIf<DROID_TYPE>(player, selType, DROID_CONSTRUCT, bOnScreen);
 			break;
 		case DST_ALL_COMBAT:
 			retVal = selSelectUnitsIf(player, selCombat, bOnScreen);

--- a/src/selection.cpp
+++ b/src/selection.cpp
@@ -146,17 +146,7 @@ unsigned int selDroidDeselect(unsigned int player)
 // Lets you know how many are selected for a given player
 unsigned int selNumSelected(unsigned int player)
 {
-	unsigned int count = 0;
-
-	for (DROID *psDroid = apsDroidLists[player]; psDroid; psDroid = psDroid->psNext)
-	{
-		if (psDroid->selected)
-		{
-			count++;
-		}
-	}
-
-	return count;
+	return Droids::forPlayer(player, true, true).count();
 }
 
 // Helper function to check whether the component stats of a unit can be found


### PR DESCRIPTION
My interpretation of #828

Proof-of-concept of allowing enabling "unit sharing" with allies in fixed alliance games. When sharing is enabled, players are able to issue commands to the shared units just as they were their own.

There are still _a lot_ of rough edges and TODOs here. I'd describe the current state as "barely functional". From what I've seen thus far with the implementation, this feature seems to be fairly doable with decent amount of effort. I was/am planning on doing factory sharing, too, but I've been focusing on getting unit share functional first.

Implementation-wise this is quite straightforward: Instead of iterating the `apsDroidLists` directly, abstract the iteration to a custom iterator, which is able to iterate over droids from multiple players. Use this custom iterator with some flags in `NetPlay.players` to include allied players' droids when dealing with selection/order logic.

TL;DR:
 - Allows giving allies permission to command your units (only with fixed alliances)
 - Still very much a Proof-of-Concept, but unit sharing parts are actually functional already
 - To enable sharing, there is a button on the multiplayer/alliances menu (which just happens to look just like the form/break alliance button, for now)

Some known issues/TODOs
 - [ ] Enabling unit sharing causes some desync warnings to immediately pop up. Things seem to work just fine afterwards, so likely I've just forgot to add _Some Check™_ to _Some Place™_
 - [ ] Three is still lots of droid iteration code doesn't use the new iterator logic, likely causing all sorts of subtle hard-to-debug issues. Need to go through all droid iteration and figure where shared units are needed.
 - [ ] Cannot command shared units to pick up oil barrels or artefacts
 - [ ] Giving orders to shared units via minimap does not show effects/visual feedback
 - [ ] Hovering cursor over shared units does not change to selection cursor
 - [ ] Factory sharing needs some thought work on how to present shared labs/factories on the UI
 - [ ] Should likely show heart-icons (like those on technologies allies are researching) for shared trucks in the build menu