### PR TITLE
gfx_api: Support multiple uniform sets per PSO, split uniforms for components

### DIFF
--- a/data/base/shaders/button.vert
+++ b/data/base/shaders/button.vert
@@ -3,7 +3,8 @@
 
 //#pragma debug(on)
 
-uniform mat4 ModelViewProjectionMatrix;
+uniform mat4 ProjectionMatrix;
+uniform mat4 ModelViewMatrix;
 
 #if (!defined(GL_ES) && (__VERSION__ >= 130)) || (defined(GL_ES) && (__VERSION__ >= 300))
 in vec4 vertex;
@@ -25,5 +26,6 @@ void main()
 	texCoord = vertexTexCoord;
 
 	// Translate every vertex according to the Model, View and Projection matrices
+	mat4 ModelViewProjectionMatrix = ProjectionMatrix * ModelViewMatrix;
 	gl_Position = ModelViewProjectionMatrix * vertex;
 }

--- a/data/base/shaders/nolight.vert
+++ b/data/base/shaders/nolight.vert
@@ -3,7 +3,8 @@
 
 //#pragma debug(on)
 
-uniform mat4 ModelViewProjectionMatrix;
+uniform mat4 ProjectionMatrix;
+uniform mat4 ModelViewMatrix;
 
 #if (!defined(GL_ES) && (__VERSION__ >= 130)) || (defined(GL_ES) && (__VERSION__ >= 300))
 in vec4 vertex;
@@ -27,6 +28,7 @@ void main()
 	texCoord = vertexTexCoord;
 
 	// Translate every vertex according to the Model View and Projection Matrix
+	mat4 ModelViewProjectionMatrix = ProjectionMatrix * ModelViewMatrix;
 	vec4 gposition = ModelViewProjectionMatrix * vertex;
 	gl_Position = gposition;
 

--- a/data/base/shaders/tcmask.vert
+++ b/data/base/shaders/tcmask.vert
@@ -3,12 +3,12 @@
 
 //#pragma debug(on)
 
-uniform float stretch;
+uniform mat4 ProjectionMatrix;
 uniform mat4 ModelViewMatrix;
-uniform mat4 ModelViewProjectionMatrix;
 uniform mat4 NormalMatrix;
 uniform int hasTangents; // whether tangents were calculated for model
 uniform vec4 lightPosition;
+uniform float stretch;
 
 #if (!defined(GL_ES) && (__VERSION__ >= 130)) || (defined(GL_ES) && (__VERSION__ >= 300))
 in vec4 vertex;
@@ -68,6 +68,7 @@ void main()
 	}
 
 	// Translate every vertex according to the Model View and Projection Matrix
+	mat4 ModelViewProjectionMatrix = ProjectionMatrix * ModelViewMatrix;
 	vec4 gposition = ModelViewProjectionMatrix * position;
 	gl_Position = gposition;
 

--- a/data/base/shaders/vk/button.frag
+++ b/data/base/shaders/vk/button.frag
@@ -1,23 +1,11 @@
 #version 450
 //#pragma debug(on)
 
-layout(set = 1, binding = 0) uniform sampler2D Texture;
-layout(set = 1, binding = 1) uniform sampler2D TextureTcmask;
-layout(std140, set = 0, binding = 0) uniform cbuffer
+layout(set = 3, binding = 0) uniform sampler2D Texture;
+layout(set = 3, binding = 1) uniform sampler2D TextureTcmask;
+layout(std140, set = 0, binding = 0) uniform globaluniforms
 {
-	vec4 colour;
-	vec4 teamcolour; // the team colour of the model
-	float stretch;
-	int tcmask; // whether a tcmask texture exists for the model
-	int fogEnabled; // whether fog is enabled
-	int normalmap; // whether a normal map exists for the model
-	int specularmap; // whether a specular map exists for the model
-	int ecmEffect; // whether ECM special effect is enabled
-	int alphaTest;
-	float graphicsCycle; // a periodically cycling value for special effects
-	mat4 ModelViewMatrix;
-	mat4 ModelViewProjectionMatrix;
-	mat4 NormalMatrix;
+	mat4 ProjectionMatrix;
 	vec4 lightPosition;
 	vec4 sceneColor;
 	vec4 ambient;
@@ -26,7 +14,27 @@ layout(std140, set = 0, binding = 0) uniform cbuffer
 	vec4 fogColor;
 	float fogEnd;
 	float fogStart;
+	float graphicsCycle;
+	int fogEnabled;
+};
+
+layout(std140, set = 1, binding = 0) uniform meshuniforms
+{
+	int tcmask;
+	int normalmap;
+	int specularmap;
 	int hasTangents;
+};
+
+layout(std140, set = 2, binding = 0) uniform instanceuniforms
+{
+	mat4 ModelViewMatrix;
+	mat4 NormalMatrix;
+	vec4 colour;
+	vec4 teamcolour;
+	float stretch;
+	int ecmEffect;
+	int alphaTest;
 };
 
 layout(location = 0) in vec2 texCoord;

--- a/data/base/shaders/vk/button.vert
+++ b/data/base/shaders/vk/button.vert
@@ -1,21 +1,9 @@
 #version 450
 //#pragma debug(on)
 
-layout(std140, set = 0, binding = 0) uniform cbuffer
+layout(std140, set = 0, binding = 0) uniform globaluniforms
 {
-	vec4 colour;
-	vec4 teamcolour; // the team colour of the model
-	float stretch;
-	int tcmask; // whether a tcmask texture exists for the model
-	int fogEnabled; // whether fog is enabled
-	int normalmap; // whether a normal map exists for the model
-	int specularmap; // whether a specular map exists for the model
-	int ecmEffect; // whether ECM special effect is enabled
-	int alphaTest;
-	float graphicsCycle; // a periodically cycling value for special effects
-	mat4 ModelViewMatrix;
-	mat4 ModelViewProjectionMatrix;
-	mat4 NormalMatrix;
+	mat4 ProjectionMatrix;
 	vec4 lightPosition;
 	vec4 sceneColor;
 	vec4 ambient;
@@ -24,7 +12,27 @@ layout(std140, set = 0, binding = 0) uniform cbuffer
 	vec4 fogColor;
 	float fogEnd;
 	float fogStart;
+	float graphicsCycle;
+	int fogEnabled;
+};
+
+layout(std140, set = 1, binding = 0) uniform meshuniforms
+{
+	int tcmask;
+	int normalmap;
+	int specularmap;
 	int hasTangents;
+};
+
+layout(std140, set = 2, binding = 0) uniform instanceuniforms
+{
+	mat4 ModelViewMatrix;
+	mat4 NormalMatrix;
+	vec4 colour;
+	vec4 teamcolour;
+	float stretch;
+	int ecmEffect;
+	int alphaTest;
 };
 
 layout(location = 0) in vec4 vertex;
@@ -38,6 +46,7 @@ void main()
 	texCoord = vertexTexCoord;
 
 	// Translate every vertex according to the Model, View and Projection matrices
+	mat4 ModelViewProjectionMatrix = ProjectionMatrix * ModelViewMatrix;
 	gl_Position = ModelViewProjectionMatrix * vertex;
 	gl_Position.y *= -1.;
 	gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0;

--- a/data/base/shaders/vk/nolight.frag
+++ b/data/base/shaders/vk/nolight.frag
@@ -1,22 +1,10 @@
 #version 450
 //#pragma debug(on)
 
-layout(set = 1, binding = 0) uniform sampler2D Texture;
-layout(std140, set = 0, binding = 0) uniform cbuffer
+layout(set = 3, binding = 0) uniform sampler2D Texture;
+layout(std140, set = 0, binding = 0) uniform globaluniforms
 {
-	vec4 colour;
-	vec4 teamcolour; // the team colour of the model
-	float stretch;
-	int tcmask; // whether a tcmask texture exists for the model
-	int fogEnabled; // whether fog is enabled
-	int normalmap; // whether a normal map exists for the model
-	int specularmap; // whether a specular map exists for the model
-	int ecmEffect; // whether ECM special effect is enabled
-	int alphaTest;
-	float graphicsCycle; // a periodically cycling value for special effects
-	mat4 ModelViewMatrix;
-	mat4 ModelViewProjectionMatrix;
-	mat4 NormalMatrix;
+	mat4 ProjectionMatrix;
 	vec4 lightPosition;
 	vec4 sceneColor;
 	vec4 ambient;
@@ -25,7 +13,27 @@ layout(std140, set = 0, binding = 0) uniform cbuffer
 	vec4 fogColor;
 	float fogEnd;
 	float fogStart;
+	float graphicsCycle;
+	int fogEnabled;
+};
+
+layout(std140, set = 1, binding = 0) uniform meshuniforms
+{
+	int tcmask;
+	int normalmap;
+	int specularmap;
 	int hasTangents;
+};
+
+layout(std140, set = 2, binding = 0) uniform instanceuniforms
+{
+	mat4 ModelViewMatrix;
+	mat4 NormalMatrix;
+	vec4 colour;
+	vec4 teamcolour;
+	float stretch;
+	int ecmEffect;
+	int alphaTest;
 };
 
 layout(location = 0) in vec2 texCoord;

--- a/data/base/shaders/vk/nolight.vert
+++ b/data/base/shaders/vk/nolight.vert
@@ -1,21 +1,9 @@
 #version 450
 //#pragma debug(on)
 
-layout(std140, set = 0, binding = 0) uniform cbuffer
+layout(std140, set = 0, binding = 0) uniform globaluniforms
 {
-	vec4 colour;
-	vec4 teamcolour; // the team colour of the model
-	float stretch;
-	int tcmask; // whether a tcmask texture exists for the model
-	int fogEnabled; // whether fog is enabled
-	int normalmap; // whether a normal map exists for the model
-	int specularmap; // whether a specular map exists for the model
-	int ecmEffect; // whether ECM special effect is enabled
-	int alphaTest;
-	float graphicsCycle; // a periodically cycling value for special effects
-	mat4 ModelViewMatrix;
-	mat4 ModelViewProjectionMatrix;
-	mat4 NormalMatrix;
+	mat4 ProjectionMatrix;
 	vec4 lightPosition;
 	vec4 sceneColor;
 	vec4 ambient;
@@ -24,7 +12,27 @@ layout(std140, set = 0, binding = 0) uniform cbuffer
 	vec4 fogColor;
 	float fogEnd;
 	float fogStart;
+	float graphicsCycle;
+	int fogEnabled;
+};
+
+layout(std140, set = 1, binding = 0) uniform meshuniforms
+{
+	int tcmask;
+	int normalmap;
+	int specularmap;
 	int hasTangents;
+};
+
+layout(std140, set = 2, binding = 0) uniform instanceuniforms
+{
+	mat4 ModelViewMatrix;
+	mat4 NormalMatrix;
+	vec4 colour;
+	vec4 teamcolour;
+	float stretch;
+	int ecmEffect;
+	int alphaTest;
 };
 
 layout(location = 0) in vec4 vertex;
@@ -38,6 +46,7 @@ void main()
 	texCoord = vertexTexCoord;
 
 	// Translate every vertex according to the Model, View and Projection matrices
+	mat4 ModelViewProjectionMatrix = ProjectionMatrix * ModelViewMatrix;
 	gl_Position = ModelViewProjectionMatrix * vertex;
 	gl_Position.y *= -1.;
 	gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0;

--- a/data/base/shaders/vk/tcmask.frag
+++ b/data/base/shaders/vk/tcmask.frag
@@ -1,26 +1,14 @@
 #version 450
 //#pragma debug(on)
 
-layout(set = 1, binding = 0) uniform sampler2D Texture; // diffuse
-layout(set = 1, binding = 1) uniform sampler2D TextureTcmask; // tcmask
-layout(set = 1, binding = 2) uniform sampler2D TextureNormal; // normal map
-layout(set = 1, binding = 3) uniform sampler2D TextureSpecular; // specular map
+layout(set = 3, binding = 0) uniform sampler2D Texture; // diffuse
+layout(set = 3, binding = 1) uniform sampler2D TextureTcmask; // tcmask
+layout(set = 3, binding = 2) uniform sampler2D TextureNormal; // normal map
+layout(set = 3, binding = 3) uniform sampler2D TextureSpecular; // specular map
 
-layout(std140, set = 0, binding = 0) uniform cbuffer
+layout(std140, set = 0, binding = 0) uniform globaluniforms
 {
-	vec4 colour;
-	vec4 teamcolour; // the team colour of the model
-	float stretch;
-	int tcmask; // whether a tcmask texture exists for the model
-	int fogEnabled; // whether fog is enabled
-	int normalmap; // whether a normal map exists for the model
-	int specularmap; // whether a specular map exists for the model
-	int ecmEffect; // whether ECM special effect is enabled
-	int alphaTest;
-	float graphicsCycle; // a periodically cycling value for special effects
-	mat4 ModelViewMatrix;
-	mat4 ModelViewProjectionMatrix;
-	mat4 NormalMatrix;
+	mat4 ProjectionMatrix;
 	vec4 lightPosition;
 	vec4 sceneColor;
 	vec4 ambient;
@@ -29,7 +17,27 @@ layout(std140, set = 0, binding = 0) uniform cbuffer
 	vec4 fogColor;
 	float fogEnd;
 	float fogStart;
+	float graphicsCycle;
+	int fogEnabled;
+};
+
+layout(std140, set = 1, binding = 0) uniform meshuniforms
+{
+	int tcmask;
+	int normalmap;
+	int specularmap;
 	int hasTangents;
+};
+
+layout(std140, set = 2, binding = 0) uniform instanceuniforms
+{
+	mat4 ModelViewMatrix;
+	mat4 NormalMatrix;
+	vec4 colour;
+	vec4 teamcolour;
+	float stretch;
+	int ecmEffect;
+	int alphaTest;
 };
 
 layout(location  = 0) in float vertexDistance;

--- a/data/base/shaders/vk/tcmask.vert
+++ b/data/base/shaders/vk/tcmask.vert
@@ -1,21 +1,9 @@
 #version 450
 //#pragma debug(on)
 
-layout(std140, set = 0, binding = 0) uniform cbuffer
+layout(std140, set = 0, binding = 0) uniform globaluniforms
 {
-	vec4 colour;
-	vec4 teamcolour; // the team colour of the model
-	float stretch;
-	int tcmask; // whether a tcmask texture exists for the model
-	int fogEnabled; // whether fog is enabled
-	int normalmap; // whether a normal map exists for the model
-	int specularmap; // whether a specular map exists for the model
-	int ecmEffect; // whether ECM special effect is enabled
-	int alphaTest;
-	float graphicsCycle; // a periodically cycling value for special effects
-	mat4 ModelViewMatrix;
-	mat4 ModelViewProjectionMatrix;
-	mat4 NormalMatrix;
+	mat4 ProjectionMatrix;
 	vec4 lightPosition;
 	vec4 sceneColor;
 	vec4 ambient;
@@ -24,7 +12,27 @@ layout(std140, set = 0, binding = 0) uniform cbuffer
 	vec4 fogColor;
 	float fogEnd;
 	float fogStart;
+	float graphicsCycle;
+	int fogEnabled;
+};
+
+layout(std140, set = 1, binding = 0) uniform meshuniforms
+{
+	int tcmask;
+	int normalmap;
+	int specularmap;
 	int hasTangents;
+};
+
+layout(std140, set = 2, binding = 0) uniform instanceuniforms
+{
+	mat4 ModelViewMatrix;
+	mat4 NormalMatrix;
+	vec4 colour;
+	vec4 teamcolour;
+	float stretch;
+	int ecmEffect;
+	int alphaTest;
 };
 
 layout(location = 0) in vec4 vertex;
@@ -74,6 +82,7 @@ void main()
 	}
 
 	// Translate every vertex according to the Model View and Projection Matrix
+	mat4 ModelViewProjectionMatrix = ProjectionMatrix * ModelViewMatrix;
 	vec4 gposition = ModelViewProjectionMatrix * position;
 	gl_Position = gposition;
 

--- a/lib/ivis_opengl/gfx_api.h
+++ b/lib/ivis_opengl/gfx_api.h
@@ -560,9 +560,50 @@ namespace gfx_api
 		int hasTangents;
 	};
 
+	// Only change once per frame
+	struct Draw3DShapeGlobalUniforms
+	{
+		glm::mat4 ProjectionMatrix;
+		glm::vec4 sunPos;
+		glm::vec4 sceneColor;
+		glm::vec4 ambient;
+		glm::vec4 diffuse;
+		glm::vec4 specular;
+		glm::vec4 fogColour;
+		float fogEnd;
+		float fogBegin;
+		float timeState;
+		int fogEnabled;
+	};
+
+	// Only change per mesh
+	struct Draw3DShapePerMeshUniforms
+	{
+		int tcmask;
+		int normalMap;
+		int specularMap;
+		int hasTangents;
+	};
+
+	// Change per instance of mesh
+	struct Draw3DShapePerInstanceUniforms
+	{
+		glm::mat4 ModelViewMatrix;
+		glm::mat4 NormalMatrix; // can be calculated in the shader
+		glm::vec4 colour;
+		glm::vec4 teamcolour;
+		float shaderStretch;
+		int ecmState;
+		int alphaTest;
+	};
+
 	template<REND_MODE render_mode, SHADER_MODE shader>
 	using Draw3DShape = typename gfx_api::pipeline_state_helper<rasterizer_state<render_mode, DEPTH_CMP_LEQ_WRT_ON, 255, polygon_offset::disabled, stencil_mode::stencil_disabled, cull_mode::back>, primitive_type::triangles, index_type::u16,
-	std::tuple<constant_buffer_type<shader>>,
+	std::tuple<
+	Draw3DShapeGlobalUniforms,
+	Draw3DShapePerMeshUniforms,
+	Draw3DShapePerInstanceUniforms
+	>,
 	std::tuple<
 	vertex_buffer_description<12, vertex_attribute_description<position, gfx_api::vertex_attribute_type::float3, 0>>,
 	vertex_buffer_description<12, vertex_attribute_description<normal, gfx_api::vertex_attribute_type::float3, 0>>,

--- a/lib/ivis_opengl/gfx_api_gl.cpp
+++ b/lib/ivis_opengl/gfx_api_gl.cpp
@@ -284,17 +284,33 @@ struct program_data
 static const std::map<SHADER_MODE, program_data> shader_to_file_table =
 {
 	std::make_pair(SHADER_COMPONENT, program_data{ "Component program", "shaders/tcmask.vert", "shaders/tcmask.frag",
-		{ "colour", "teamcolour", "stretch", "tcmask", "fogEnabled", "normalmap", "specularmap", "ecmEffect", "alphaTest", "graphicsCycle",
-			"ModelViewMatrix", "ModelViewProjectionMatrix", "NormalMatrix", "lightPosition", "sceneColor", "ambient", "diffuse", "specular",
-			"fogColor", "fogEnd", "fogStart", "hasTangents" } }),
+		{
+			// per-frame global uniforms
+			"ProjectionMatrix", "lightPosition", "sceneColor", "ambient", "diffuse", "specular", "fogColor", "fogEnd", "fogStart", "graphicsCycle", "fogEnabled",
+			// per-mesh uniforms
+			"tcmask", "normalmap", "specularmap", "hasTangents",
+			// per-instance uniforms
+			"ModelViewMatrix", "NormalMatrix", "colour", "teamcolour", "stretch", "ecmEffect", "alphaTest"
+		} }),
+
 	std::make_pair(SHADER_BUTTON, program_data{ "Button program", "shaders/button.vert", "shaders/button.frag",
-		{ "colour", "teamcolour", "stretch", "tcmask", "fogEnabled", "normalmap", "specularmap", "ecmEffect", "alphaTest", "graphicsCycle",
-			"ModelViewMatrix", "ModelViewProjectionMatrix", "NormalMatrix", "lightPosition", "sceneColor", "ambient", "diffuse", "specular",
-			"fogColor", "fogEnd", "fogStart", "hasTangents" } }),
+		{
+			// per-frame global uniforms
+			"ProjectionMatrix", "lightPosition", "sceneColor", "ambient", "diffuse", "specular", "fogColor", "fogEnd", "fogStart", "graphicsCycle", "fogEnabled",
+			// per-mesh uniforms
+			"tcmask", "normalmap", "specularmap", "hasTangents",
+			// per-instance uniforms
+			"ModelViewMatrix", "NormalMatrix", "colour", "teamcolour", "stretch", "ecmEffect", "alphaTest"
+		} }),
 	std::make_pair(SHADER_NOLIGHT, program_data{ "Plain program", "shaders/nolight.vert", "shaders/nolight.frag",
-		{ "colour", "teamcolour", "stretch", "tcmask", "fogEnabled", "normalmap", "specularmap", "ecmEffect", "alphaTest", "graphicsCycle",
-			"ModelViewMatrix", "ModelViewProjectionMatrix", "NormalMatrix", "lightPosition", "sceneColor", "ambient", "diffuse", "specular",
-			"fogColor", "fogEnd", "fogStart", "hasTangents" } }),
+		{
+			// per-frame global uniforms
+			"ProjectionMatrix", "lightPosition", "sceneColor", "ambient", "diffuse", "specular", "fogColor", "fogEnd", "fogStart", "graphicsCycle", "fogEnabled",
+			// per-mesh uniforms
+			"tcmask", "normalmap", "specularmap", "hasTangents",
+			// per-instance uniforms
+			"ModelViewMatrix", "NormalMatrix", "colour", "teamcolour", "stretch", "ecmEffect", "alphaTest"
+		} }),
 	std::make_pair(SHADER_TERRAIN, program_data{ "terrain program", "shaders/terrain_water.vert", "shaders/terrain.frag",
 		{ "ModelViewProjectionMatrix", "paramx1", "paramy1", "paramx2", "paramy2", "tex", "lightmap_tex", "textureMatrix1", "textureMatrix2",
 			"fogColor", "fogEnabled", "fogEnd", "fogStart" } }),
@@ -564,9 +580,9 @@ desc(_desc), vertex_buffer_desc(_vertex_buffer_desc)
 
 	const std::unordered_map < std::type_index, std::function<void(const void*, size_t)>> uniforms_bind_table =
 	{
-		uniform_binding_entry<SHADER_COMPONENT>(),
-		uniform_binding_entry<SHADER_BUTTON>(),
-		uniform_binding_entry<SHADER_NOLIGHT>(),
+		uniform_setting_func<gfx_api::Draw3DShapeGlobalUniforms>(),
+		uniform_setting_func<gfx_api::Draw3DShapePerMeshUniforms>(),
+		uniform_setting_func<gfx_api::Draw3DShapePerInstanceUniforms>(),
 		uniform_binding_entry<SHADER_TERRAIN>(),
 		uniform_binding_entry<SHADER_TERRAIN_DEPTH>(),
 		uniform_binding_entry<SHADER_DECALS>(),
@@ -1125,19 +1141,38 @@ void gl_pipeline_state_object::setUniforms(size_t uniformIdx, const float &v)
 //	setUniforms(obj->locations[20], cbuf.fogColour);
 //}
 
-void gl_pipeline_state_object::set_constants(const gfx_api::constant_buffer_type<SHADER_BUTTON>& cbuf)
+void gl_pipeline_state_object::set_constants(const gfx_api::Draw3DShapeGlobalUniforms& cbuf)
 {
-	set_constants_for_component(cbuf);
+	setUniforms(0, cbuf.ProjectionMatrix);
+	setUniforms(1, cbuf.sunPos);
+	setUniforms(2, cbuf.sceneColor);
+	setUniforms(3, cbuf.ambient);
+	setUniforms(4, cbuf.diffuse);
+	setUniforms(5, cbuf.specular);
+	setUniforms(6, cbuf.fogColour);
+	setUniforms(7, cbuf.fogEnd);
+	setUniforms(8, cbuf.fogBegin);
+	setUniforms(9, cbuf.timeState);
+	setUniforms(10, cbuf.fogEnabled);
 }
 
-void gl_pipeline_state_object::set_constants(const gfx_api::constant_buffer_type<SHADER_COMPONENT>& cbuf)
+void gl_pipeline_state_object::set_constants(const gfx_api::Draw3DShapePerMeshUniforms& cbuf)
 {
-	set_constants_for_component(cbuf);
+	setUniforms(11, cbuf.tcmask);
+	setUniforms(12, cbuf.normalMap);
+	setUniforms(13, cbuf.specularMap);
+	setUniforms(14, cbuf.hasTangents);
 }
 
-void gl_pipeline_state_object::set_constants(const gfx_api::constant_buffer_type<SHADER_NOLIGHT>& cbuf)
+void gl_pipeline_state_object::set_constants(const gfx_api::Draw3DShapePerInstanceUniforms& cbuf)
 {
-	set_constants_for_component(cbuf);
+	setUniforms(15, cbuf.ModelViewMatrix);
+	setUniforms(16, cbuf.NormalMatrix);
+	setUniforms(17, cbuf.colour);
+	setUniforms(18, cbuf.teamcolour);
+	setUniforms(19, cbuf.shaderStretch);
+	setUniforms(20, cbuf.ecmState);
+	setUniforms(21, cbuf.alphaTest);
 }
 
 void gl_pipeline_state_object::set_constants(const gfx_api::constant_buffer_type<SHADER_TERRAIN>& cbuf)

--- a/lib/ivis_opengl/gfx_api_gl.h
+++ b/lib/ivis_opengl/gfx_api_gl.h
@@ -25,6 +25,7 @@
 #include <algorithm>
 #include <cmath>
 #include <functional>
+#include <typeindex>
 
 namespace gfx_api
 {
@@ -93,13 +94,17 @@ struct gl_pipeline_state_object final : public gfx_api::pipeline_state_object
 	std::vector<GLint> locations;
 	std::vector<GLint> duplicateFragmentUniformLocations;
 
-	std::function<void(const void*)> uniform_bind_function;
+	std::vector<std::function<void(const void*, size_t)>> uniform_bind_functions;
 
 	template<SHADER_MODE shader>
-	typename std::pair<SHADER_MODE, std::function<void(const void*)>> uniform_binding_entry();
+	typename std::pair<std::type_index, std::function<void(const void*, size_t)>> uniform_binding_entry();
 
-	gl_pipeline_state_object(bool gles, bool fragmentHighpFloatAvailable, bool fragmentHighpIntAvailable, const gfx_api::state_description& _desc, const SHADER_MODE& shader, const std::vector<gfx_api::vertex_buffer>& vertex_buffer_desc);
-	void set_constants(const void* buffer);
+	template<typename T>
+	typename std::pair<std::type_index, std::function<void(const void*, size_t)>> uniform_setting_func();
+
+	gl_pipeline_state_object(bool gles, bool fragmentHighpFloatAvailable, bool fragmentHighpIntAvailable, const gfx_api::state_description& _desc, const SHADER_MODE& shader, const std::vector<std::type_index>& uniform_blocks, const std::vector<gfx_api::vertex_buffer>& vertex_buffer_desc);
+	void set_constants(const void* buffer, const size_t& size);
+	void set_uniforms(const size_t& first, const std::vector<std::tuple<const void*, size_t>>& uniform_blocks);
 
 	void bind();
 
@@ -203,6 +208,7 @@ struct gl_context final : public gfx_api::context
 	virtual gfx_api::pipeline_state_object * build_pipeline(const gfx_api::state_description &state_desc,
 															const SHADER_MODE& shader_mode,
 															const gfx_api::primitive_type& primitive,
+															const std::vector<std::type_index>& uniform_blocks,
 															const std::vector<gfx_api::texture_input>& texture_desc,
 															const std::vector<gfx_api::vertex_buffer>& attribute_descriptions) override;
 	virtual void bind_pipeline(gfx_api::pipeline_state_object* pso, bool notextures) override;
@@ -214,6 +220,7 @@ struct gl_context final : public gfx_api::context
 	virtual void bind_streamed_vertex_buffers(const void* data, const std::size_t size) override;
 	virtual void bind_textures(const std::vector<gfx_api::texture_input>& texture_descriptions, const std::vector<gfx_api::texture*>& textures) override;
 	virtual void set_constants(const void* buffer, const size_t& size) override;
+	virtual void set_uniforms(const size_t& first, const std::vector<std::tuple<const void*, size_t>>& uniform_blocks) override;
 	virtual void draw(const size_t& offset, const size_t &count, const gfx_api::primitive_type &primitive) override;
 	virtual void draw_elements(const size_t& offset, const size_t &count, const gfx_api::primitive_type &primitive, const gfx_api::index_type& index) override;
 	virtual void set_polygon_offset(const float& offset, const float& slope) override;

--- a/lib/ivis_opengl/gfx_api_gl.h
+++ b/lib/ivis_opengl/gfx_api_gl.h
@@ -142,36 +142,10 @@ private:
 
 
 	// Wish there was static reflection in C++...
-	template<typename T>
-	void set_constants_for_component(const T& cbuf)
-	{
-		setUniforms(0, cbuf.colour);
-		setUniforms(1, cbuf.teamcolour);
-		setUniforms(2, cbuf.shaderStretch);
-		setUniforms(3, cbuf.tcmask);
-		setUniforms(4, cbuf.fogEnabled);
-		setUniforms(5, cbuf.normalMap);
-		setUniforms(6, cbuf.specularMap);
-		setUniforms(7, cbuf.ecmState);
-		setUniforms(8, cbuf.alphaTest);
-		setUniforms(9, cbuf.timeState);
-		setUniforms(10, cbuf.ModelViewMatrix);
-		setUniforms(11, cbuf.ModelViewProjectionMatrix);
-		setUniforms(12, cbuf.NormalMatrix);
-		setUniforms(13, cbuf.sunPos);
-		setUniforms(14, cbuf.sceneColor);
-		setUniforms(15, cbuf.ambient);
-		setUniforms(16, cbuf.diffuse);
-		setUniforms(17, cbuf.specular);
-		setUniforms(18, cbuf.fogColour);
-		setUniforms(19, cbuf.fogEnd);
-		setUniforms(20, cbuf.fogBegin);
-		setUniforms(21, cbuf.hasTangents);
-	}
+	void set_constants(const gfx_api::Draw3DShapeGlobalUniforms& cbuf);
+	void set_constants(const gfx_api::Draw3DShapePerMeshUniforms& cbuf);
+	void set_constants(const gfx_api::Draw3DShapePerInstanceUniforms& cbuf);
 
-	void set_constants(const gfx_api::constant_buffer_type<SHADER_BUTTON>& cbuf);
-	void set_constants(const gfx_api::constant_buffer_type<SHADER_COMPONENT>& cbuf);
-	void set_constants(const gfx_api::constant_buffer_type<SHADER_NOLIGHT>& cbuf);
 	void set_constants(const gfx_api::constant_buffer_type<SHADER_TERRAIN>& cbuf);
 	void set_constants(const gfx_api::constant_buffer_type<SHADER_TERRAIN_DEPTH>& cbuf);
 	void set_constants(const gfx_api::constant_buffer_type<SHADER_DECALS>& cbuf);

--- a/lib/ivis_opengl/gfx_api_null.cpp
+++ b/lib/ivis_opengl/gfx_api_null.cpp
@@ -133,6 +133,7 @@ gfx_api::buffer * null_context::create_buffer_object(const gfx_api::buffer::usag
 gfx_api::pipeline_state_object * null_context::build_pipeline(const gfx_api::state_description &state_desc,
 															const SHADER_MODE& shader_mode,
 															const gfx_api::primitive_type& primitive,
+															const std::vector<std::type_index>& uniform_blocks,
 															const std::vector<gfx_api::texture_input>& texture_desc,
 															const std::vector<gfx_api::vertex_buffer>& attribute_descriptions)
 {
@@ -202,6 +203,12 @@ void null_context::bind_textures(const std::vector<gfx_api::texture_input>& text
 }
 
 void null_context::set_constants(const void* buffer, const size_t& size)
+{
+	ASSERT_OR_RETURN(, current_program != nullptr, "current_program == NULL");
+	// no-op
+}
+
+void null_context::set_uniforms(const size_t& first, const std::vector<std::tuple<const void*, size_t>>& uniform_blocks)
 {
 	ASSERT_OR_RETURN(, current_program != nullptr, "current_program == NULL");
 	// no-op

--- a/lib/ivis_opengl/gfx_api_null.h
+++ b/lib/ivis_opengl/gfx_api_null.h
@@ -91,6 +91,7 @@ public:
 	virtual gfx_api::pipeline_state_object * build_pipeline(const gfx_api::state_description &state_desc,
 															const SHADER_MODE& shader_mode,
 															const gfx_api::primitive_type& primitive,
+															const std::vector<std::type_index>& uniform_blocks,
 															const std::vector<gfx_api::texture_input>& texture_desc,
 															const std::vector<gfx_api::vertex_buffer>& attribute_descriptions) override;
 	virtual void bind_pipeline(gfx_api::pipeline_state_object* pso, bool notextures) override;
@@ -102,6 +103,7 @@ public:
 	virtual void bind_streamed_vertex_buffers(const void* data, const std::size_t size) override;
 	virtual void bind_textures(const std::vector<gfx_api::texture_input>& texture_descriptions, const std::vector<gfx_api::texture*>& textures) override;
 	virtual void set_constants(const void* buffer, const size_t& size) override;
+	virtual void set_uniforms(const size_t& first, const std::vector<std::tuple<const void*, size_t>>& uniform_blocks) override;
 	virtual void draw(const size_t& offset, const size_t &count, const gfx_api::primitive_type &primitive) override;
 	virtual void draw_elements(const size_t& offset, const size_t &count, const gfx_api::primitive_type &primitive, const gfx_api::index_type& index) override;
 	virtual void set_polygon_offset(const float& offset, const float& slope) override;

--- a/lib/ivis_opengl/piedraw.cpp
+++ b/lib/ivis_opengl/piedraw.cpp
@@ -40,6 +40,7 @@
 #include <string.h>
 #include <vector>
 #include <algorithm>
+#include <unordered_set>
 
 #include <glm/glm.hpp>
 #include <glm/gtc/matrix_transform.hpp>
@@ -154,10 +155,25 @@ static void pie_Draw3DButton(iIMDShape *shape, PIELIGHT teamcolour, const glm::m
 
 	const PIELIGHT colour = WZCOL_WHITE;
 	gfx_api::Draw3DButtonPSO::get().bind();
-	gfx_api::constant_buffer_type<SHADER_BUTTON> cbuf{
-		pal_PIELIGHTtoVec4(colour), pal_PIELIGHTtoVec4(teamcolour), 0.f, tcmask ? 1 : 0, 0, normalmap != nullptr, specularmap != nullptr, 0, 0, 0.f, matrix, pie_PerspectiveGet() * matrix, glm::transpose(glm::inverse(matrix)),
-		glm::vec4(0.f), glm::vec4(0.f), glm::vec4(0.f), glm::vec4(0.f), glm::vec4(0.f), glm::vec4(0.f), 0.f, 0.f, shape->buffers[VBO_TANGENT] != nullptr };
-	gfx_api::Draw3DButtonPSO::get().bind_constants(cbuf);
+
+	gfx_api::Draw3DShapeGlobalUniforms globalUniforms {
+		pie_PerspectiveGet(),
+		glm::vec4(0.f), glm::vec4(0.f), glm::vec4(0.f), glm::vec4(0.f), glm::vec4(0.f), glm::vec4(0.f),
+		0.f, 0.f, 0.f, 0
+	};
+
+	gfx_api::Draw3DShapePerMeshUniforms meshUniforms {
+		tcmask ? 1 : 0, normalmap != nullptr, specularmap != nullptr, shape->buffers[VBO_TANGENT] != nullptr
+	};
+
+	gfx_api::Draw3DShapePerInstanceUniforms instanceUniforms {
+		matrix,
+		glm::transpose(glm::inverse(matrix)),
+		pal_PIELIGHTtoVec4(colour), pal_PIELIGHTtoVec4(teamcolour),
+		0.f, 0, 0
+	};
+
+	gfx_api::Draw3DButtonPSO::get().set_uniforms(globalUniforms, meshUniforms, instanceUniforms);
 
 	gfx_api::Draw3DButtonPSO::get().bind_textures(&pie_Texture(shape->texpage), tcmask, normalmap, specularmap);
 	gfx_api::Draw3DButtonPSO::get().bind_vertex_buffers(shape->buffers[VBO_VERTEX], shape->buffers[VBO_NORMAL], shape->buffers[VBO_TEXCOORD], pTangentBuffer);
@@ -194,8 +210,33 @@ struct templatedState
 	}
 };
 
+// Ensure the uniforms are set for a shader once until reset
+struct ShaderOnce
+{
+public:
+	template<typename T>
+	void perform_once(const std::function<void (void)>& func)
+	{
+		auto type = std::type_index(typeid(T));
+		if (performed_once.count(type) > 0)
+		{
+			return;
+		}
+		func();
+		performed_once.insert(type);
+	}
+
+	void reset()
+	{
+		performed_once.clear();
+	}
+
+private:
+	std::unordered_set<std::type_index> performed_once;
+};
+
 template<SHADER_MODE shader, typename AdditivePSO, typename AlphaPSO, typename PremultipliedPSO, typename OpaquePSO>
-static void draw3dShapeTemplated(const templatedState &lastState, const PIELIGHT &colour, const PIELIGHT &teamcolour, const float& stretch, const int& ecmState, const float& timestate, const glm::mat4 & matrix, glm::vec4 &sceneColor, glm::vec4 &ambient, glm::vec4 &diffuse, glm::vec4 &specular, const iIMDShape * shape, int pieFlag, int frame)
+static void draw3dShapeTemplated(const templatedState &lastState, ShaderOnce& globalsOnce, const PIELIGHT &colour, const PIELIGHT &teamcolour, const float& stretch, const int& ecmState, const float& timestate, const glm::mat4 & matrix, glm::vec4 &sceneColor, glm::vec4 &ambient, glm::vec4 &diffuse, glm::vec4 &specular, const iIMDShape * shape, int pieFlag, int frame)
 {
 	templatedState currentState = templatedState(shader, shape, pieFlag);
 
@@ -211,9 +252,22 @@ static void draw3dShapeTemplated(const templatedState &lastState, const PIELIGHT
 		renderState.fogColour.vector[3] / 255.f
 	) : glm::vec4(0.f);
 
-	gfx_api::constant_buffer_type<shader> cbuf{
-		pal_PIELIGHTtoVec4(colour), pal_PIELIGHTtoVec4(teamcolour), stretch, tcmask ? 1 : 0, renderState.fogEnabled, normalmap != nullptr, specularmap != nullptr, ecmState, !(pieFlag & pie_PREMULTIPLIED), timestate, matrix, pie_PerspectiveGet() * matrix, glm::transpose(glm::inverse(matrix)),
-		glm::vec4(currentSunPosition, 0.f), sceneColor, ambient, diffuse, specular, fogColor, renderState.fogBegin, renderState.fogEnd, shape->buffers[VBO_TANGENT] != nullptr };
+	gfx_api::Draw3DShapeGlobalUniforms globalUniforms {
+		pie_PerspectiveGet(),
+		glm::vec4(currentSunPosition, 0.f), sceneColor, ambient, diffuse, specular, fogColor,
+		renderState.fogBegin, renderState.fogEnd, timestate, renderState.fogEnabled
+	};
+
+	gfx_api::Draw3DShapePerMeshUniforms meshUniforms {
+		tcmask ? 1 : 0, normalmap != nullptr, specularmap != nullptr, shape->buffers[VBO_TANGENT] != nullptr
+	};
+
+	gfx_api::Draw3DShapePerInstanceUniforms instanceUniforms {
+		matrix,
+		glm::transpose(glm::inverse(matrix)),
+		pal_PIELIGHTtoVec4(colour), pal_PIELIGHTtoVec4(teamcolour),
+		stretch, ecmState, !(pieFlag & pie_PREMULTIPLIED)
+	};
 
 	gfx_api::buffer* pTangentBuffer = (shape->buffers[VBO_TANGENT] != nullptr) ? shape->buffers[VBO_TANGENT] : getZeroedVertexBuffer(shape->vertexCount * 4 * sizeof(gfx_api::gfxFloat));
 
@@ -221,54 +275,70 @@ static void draw3dShapeTemplated(const templatedState &lastState, const PIELIGHT
 	if (pieFlag & pie_ADDITIVE)
 	{
 		AdditivePSO::get().bind();
-		AdditivePSO::get().bind_constants(cbuf);
+		globalsOnce.perform_once<AdditivePSO>([&globalUniforms]{
+			AdditivePSO::get().set_uniforms_at(0, globalUniforms);
+		});
 		if (currentState != lastState)
 		{
+			AdditivePSO::get().set_uniforms_at(1, meshUniforms);
 			AdditivePSO::get().bind_vertex_buffers(shape->buffers[VBO_VERTEX], shape->buffers[VBO_NORMAL], shape->buffers[VBO_TEXCOORD], pTangentBuffer);
 			AdditivePSO::get().bind_textures(&pie_Texture(shape->texpage), tcmask, normalmap, specularmap);
 		}
+		AdditivePSO::get().set_uniforms_at(2, instanceUniforms);
 		AdditivePSO::get().draw_elements(shape->polys.size() * 3, frame * shape->polys.size() * 3 * sizeof(uint16_t));
 //		AdditivePSO::get().unbind_vertex_buffers(shape->buffers[VBO_VERTEX], shape->buffers[VBO_NORMAL], shape->buffers[VBO_TEXCOORD]);
 	}
 	else if (pieFlag & pie_TRANSLUCENT)
 	{
 		AlphaPSO::get().bind();
-		AlphaPSO::get().bind_constants(cbuf);
+		globalsOnce.perform_once<AlphaPSO>([&globalUniforms]{
+			AlphaPSO::get().set_uniforms_at(0, globalUniforms);
+		});
 		if (currentState != lastState)
 		{
+			AlphaPSO::get().set_uniforms_at(1, meshUniforms);
 			AlphaPSO::get().bind_vertex_buffers(shape->buffers[VBO_VERTEX], shape->buffers[VBO_NORMAL], shape->buffers[VBO_TEXCOORD], pTangentBuffer);
 			AlphaPSO::get().bind_textures(&pie_Texture(shape->texpage), tcmask, normalmap, specularmap);
 		}
+		AlphaPSO::get().set_uniforms_at(2, instanceUniforms);
 		AlphaPSO::get().draw_elements(shape->polys.size() * 3, frame * shape->polys.size() * 3 * sizeof(uint16_t));
 //		AlphaPSO::get().unbind_vertex_buffers(shape->buffers[VBO_VERTEX], shape->buffers[VBO_NORMAL], shape->buffers[VBO_TEXCOORD]);
 	}
 	else if (pieFlag & pie_PREMULTIPLIED)
 	{
 		PremultipliedPSO::get().bind();
-		PremultipliedPSO::get().bind_constants(cbuf);
+		globalsOnce.perform_once<PremultipliedPSO>([&globalUniforms]{
+			PremultipliedPSO::get().set_uniforms_at(0, globalUniforms);
+		});
 		if (currentState != lastState)
 		{
+			PremultipliedPSO::get().set_uniforms_at(1, meshUniforms);
 			PremultipliedPSO::get().bind_vertex_buffers(shape->buffers[VBO_VERTEX], shape->buffers[VBO_NORMAL], shape->buffers[VBO_TEXCOORD], pTangentBuffer);
 			PremultipliedPSO::get().bind_textures(&pie_Texture(shape->texpage), tcmask, normalmap, specularmap);
 		}
+		PremultipliedPSO::get().set_uniforms_at(2, instanceUniforms);
 		PremultipliedPSO::get().draw_elements(shape->polys.size() * 3, frame * shape->polys.size() * 3 * sizeof(uint16_t));
 //		PremultipliedPSO::get().unbind_vertex_buffers(shape->buffers[VBO_VERTEX], shape->buffers[VBO_NORMAL], shape->buffers[VBO_TEXCOORD]);
 	}
 	else
 	{
 		OpaquePSO::get().bind();
-		OpaquePSO::get().bind_constants(cbuf);
+		globalsOnce.perform_once<OpaquePSO>([&globalUniforms]{
+			OpaquePSO::get().set_uniforms_at(0, globalUniforms);
+		});
 		if (currentState != lastState)
 		{
+			OpaquePSO::get().set_uniforms_at(1, meshUniforms);
 			OpaquePSO::get().bind_vertex_buffers(shape->buffers[VBO_VERTEX], shape->buffers[VBO_NORMAL], shape->buffers[VBO_TEXCOORD], pTangentBuffer);
 			OpaquePSO::get().bind_textures(&pie_Texture(shape->texpage), tcmask, normalmap, specularmap);
 		}
+		OpaquePSO::get().set_uniforms_at(2, instanceUniforms);
 		OpaquePSO::get().draw_elements(shape->polys.size() * 3, frame * shape->polys.size() * 3 * sizeof(uint16_t));
 //		OpaquePSO::get().unbind_vertex_buffers(shape->buffers[VBO_VERTEX], shape->buffers[VBO_NORMAL], shape->buffers[VBO_TEXCOORD]);
 	}
 }
 
-static templatedState pie_Draw3DShape2(const templatedState &lastState, const iIMDShape *shape, int frame, PIELIGHT colour, PIELIGHT teamcolour, int pieFlag, int pieFlagData, glm::mat4 const &matrix)
+static templatedState pie_Draw3DShape2(const templatedState &lastState, ShaderOnce& globalsOnce, const iIMDShape *shape, int frame, PIELIGHT colour, PIELIGHT teamcolour, int pieFlag, int pieFlagData, glm::mat4 const &matrix)
 {
 	bool light = true;
 
@@ -319,11 +389,11 @@ static templatedState pie_Draw3DShape2(const templatedState &lastState, const iI
 
 	if (light)
 	{
-		draw3dShapeTemplated<SHADER_COMPONENT, gfx_api::Draw3DShapeAdditive, gfx_api::Draw3DShapeAlpha, gfx_api::Draw3DShapePremul, gfx_api::Draw3DShapeOpaque>(lastState, colour, teamcolour, pie_GetShaderStretchDepth(), pie_GetShaderEcmEffect(), pie_GetShaderTime(), matrix, sceneColor, ambient, diffuse, specular, shape, pieFlag, frame);
+		draw3dShapeTemplated<SHADER_COMPONENT, gfx_api::Draw3DShapeAdditive, gfx_api::Draw3DShapeAlpha, gfx_api::Draw3DShapePremul, gfx_api::Draw3DShapeOpaque>(lastState, globalsOnce, colour, teamcolour, pie_GetShaderStretchDepth(), pie_GetShaderEcmEffect(), pie_GetShaderTime(), matrix, sceneColor, ambient, diffuse, specular, shape, pieFlag, frame);
 	}
 	else
 	{
-		draw3dShapeTemplated<SHADER_NOLIGHT, gfx_api::Draw3DShapeNoLightAdditive, gfx_api::Draw3DShapeNoLightAlpha, gfx_api::Draw3DShapeNoLightPremul, gfx_api::Draw3DShapeNoLightOpaque>(lastState, colour, teamcolour, pie_GetShaderStretchDepth(), pie_GetShaderEcmEffect(), pie_GetShaderTime(), matrix, sceneColor, ambient, diffuse, specular, shape, pieFlag, frame);
+		draw3dShapeTemplated<SHADER_NOLIGHT, gfx_api::Draw3DShapeNoLightAdditive, gfx_api::Draw3DShapeNoLightAlpha, gfx_api::Draw3DShapeNoLightPremul, gfx_api::Draw3DShapeNoLightOpaque>(lastState, globalsOnce, colour, teamcolour, pie_GetShaderStretchDepth(), pie_GetShaderEcmEffect(), pie_GetShaderTime(), matrix, sceneColor, ambient, diffuse, specular, shape, pieFlag, frame);
 	}
 
 	polyCount += shape->polys.size();
@@ -796,8 +866,12 @@ struct less_than_shape
 	}
 };
 
+static ShaderOnce perFrameUniformsShaderOnce;
+
 void pie_RemainingPasses(uint64_t currentGameFrame)
 {
+	perFrameUniformsShaderOnce.reset();
+
 	// Draw models
 	// sort list to reduce state changes
 	std::sort(shapes.begin(), shapes.end(), less_than_shape());
@@ -806,7 +880,7 @@ void pie_RemainingPasses(uint64_t currentGameFrame)
 	for (SHAPE const &shape : shapes)
 	{
 		pie_SetShaderStretchDepth(shape.stretch);
-		lastState = pie_Draw3DShape2(lastState, shape.shape, shape.frame, shape.colour, shape.teamcolour, shape.flag, shape.flag_data, shape.matrix);
+		lastState = pie_Draw3DShape2(lastState, perFrameUniformsShaderOnce, shape.shape, shape.frame, shape.colour, shape.teamcolour, shape.flag, shape.flag_data, shape.matrix);
 	}
 	gfx_api::context::get().disable_all_vertex_buffers();
 	if (!shapes.empty())
@@ -827,7 +901,7 @@ void pie_RemainingPasses(uint64_t currentGameFrame)
 	for (SHAPE const &shape : tshapes)
 	{
 		pie_SetShaderStretchDepth(shape.stretch);
-		lastState = pie_Draw3DShape2(lastState, shape.shape, shape.frame, shape.colour, shape.teamcolour, shape.flag, shape.flag_data, shape.matrix);
+		lastState = pie_Draw3DShape2(lastState, perFrameUniformsShaderOnce, shape.shape, shape.frame, shape.colour, shape.teamcolour, shape.flag, shape.flag_data, shape.matrix);
 	}
 	gfx_api::context::get().disable_all_vertex_buffers();
 	if (!tshapes.empty())


### PR DESCRIPTION
- gfx_api: Refactor to support multiple uniform sets per PSO
- Split uniforms for SHADER_COMPONENT / BUTTON / NOLIGHT

Previously we were setting all uniforms for every instance of every mesh, even though only a relatively small fraction of those actually change per mesh instance, only another small fraction change per mesh, and a bunch only change once per frame (at most).