### PR TITLE
Fix design stats numbers and power bar

### DIFF
--- a/lib/widget/bar.cpp
+++ b/lib/widget/bar.cpp
@@ -49,7 +49,8 @@ W_BARGRAPH::W_BARGRAPH(W_BARINIT const *init)
 	, majorSize(init->size)
 	, minorSize(init->minorSize)
 	, iRange(init->iRange)
-	, majorValue(0)
+	, majorValue(majorSize * iRange / WBAR_SCALE)
+	, minorValue(minorSize * iRange / WBAR_SCALE)
 	, denominator(MAX(init->denominator, 1))
 	, precision(init->precision)
 	, majorCol(init->sCol)
@@ -87,7 +88,7 @@ void widgSetBarSize(const std::shared_ptr<W_SCREEN> &psScreen, UDWORD id, UDWORD
 	if (auto psBGraph = getBarGraph(psScreen, id))
 	{
 		psBGraph->majorValue = iValue;
-		psBGraph->dirty = true;
+		psBGraph->sizesDirty = true;
 	}
 }
 
@@ -98,7 +99,7 @@ void widgSetMinorBarSize(const std::shared_ptr<W_SCREEN> &psScreen, UDWORD id, U
 	if (auto psBGraph = getBarGraph(psScreen, id))
 	{
 		psBGraph->minorValue = iValue;
-		psBGraph->dirty = true;
+		psBGraph->sizesDirty = true;
 	}
 }
 
@@ -109,7 +110,7 @@ void widgSetBarRange(const std::shared_ptr<W_SCREEN> &psScreen, UDWORD id, UDWOR
 	if (auto psBGraph = getBarGraph(psScreen, id))
 	{
 		psBGraph->iRange = iValue;
-		psBGraph->dirty = true;
+		psBGraph->sizesDirty = true;
 	}
 }
 
@@ -135,10 +136,11 @@ void W_BARGRAPH::highlightLost()
 
 void W_BARGRAPH::run(W_CONTEXT *context)
 {
-	if (dirty)
+	if (sizesDirty)
 	{
 		majorSize = WBAR_SCALE * MIN(majorValue, iRange) / MAX(iRange, 1);
 		minorSize = MIN(WBAR_SCALE * minorValue / MAX(iRange, 1), WBAR_SCALE);
+		sizesDirty = false;
 	}
 }
 

--- a/lib/widget/bar.h
+++ b/lib/widget/bar.h
@@ -63,6 +63,8 @@ public:
 //private:
 	PIELIGHT backgroundColour;
 	WzText	 wzCachedText;
+
+	bool sizesDirty = false;
 };
 
 /* The trough bar graph display function */

--- a/src/design.cpp
+++ b/src/design.cpp
@@ -374,13 +374,13 @@ protected:
 		auto filledWidth = MIN(majorSize * barWidth / 100, barWidth);
 		iV_DrawImageRepeatX(IntImages, IMAGE_DES_STATSCURR, iX, y0, filledWidth, defaultProjectionMatrix(), true);
 
+		valueText.setText(astringf("%.*f", precision, majorValue / (float)denominator), font_regular);
+		valueText.render(x0, iY, WZCOL_TEXT_BRIGHT);
+
 		if (minorValue == 0)
 		{
 			return;
 		}
-
-		valueText.setText(astringf("%.*f", precision, majorValue / (float)denominator), font_regular);
-		valueText.render(x0, iY, WZCOL_TEXT_BRIGHT);
 
 		//draw the comparison value - only if not zero
 		updateAnimation();
@@ -3631,14 +3631,14 @@ void intRunDesign()
 		case IDES_TURRET:
 		case IDES_TURRET_A:
 		case IDES_TURRET_B:
-			intSetSystemShadowStats(psStats);
 			intSetBodyShadowStats(nullptr);
 			intSetPropulsionShadowStats(nullptr);
+			intSetSystemShadowStats(psStats);
 			break;
 		case IDES_BODY:
 			intSetSystemShadowStats(nullptr);
-			intSetBodyShadowStats((BODY_STATS *)psStats);
 			intSetPropulsionShadowStats(nullptr);
+			intSetBodyShadowStats((BODY_STATS *)psStats);
 			break;
 		case IDES_PROPULSION:
 			intSetSystemShadowStats(nullptr);


### PR DESCRIPTION
Fixes regression bugs from https://github.com/Warzone2100/warzone2100/pull/1781.

@KJeff01 reported these bugs:
- Power bar was disappearing after one frame on the templates list
- Stats numbers were appearing only while hovering component buttons