### PR TITLE
Fix health in skirmish

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -4774,6 +4774,7 @@ static bool loadSaveDroid(const char *pFileName, DROID **ppsCurrentDroidLists)
 		}
 		ASSERT(id != 0, "Droid ID should never be zero here");
 		// conditional check so that existing saved games don't break
+		// TODO remove conditional someplace in future
 		if (ini.contains("originalBody"))
 		{
 			// we need to set "originalBody" before setting "body", otherwise CHECK_DROID throws assertion errors
@@ -5505,7 +5506,14 @@ static bool loadSaveStructure2(const char *pFileName, STRUCTURE **ppList)
 		default:
 			break;
 		}
-		psStructure->body = healthValue(ini, structureBody(psStructure));
+		// conditionally check so we don't break existnig saves
+		// TODO remove conditional someplace in future
+		if (ini.contains("upgradeHitpoints"))
+		{
+			psStructure->pStructureType->upgrade[psStructure->player].hitpoints = ini.value("upgradeHitpoints").toInt();
+		}
+		
+		psStructure->body =  healthValue(ini, structureBody(psStructure));
 		psStructure->currentBuildPts = ini.value("currentBuildPts", structureBuildPointsToCompletion(*psStructure)).toInt();
 		if (psStructure->status == SS_BUILT)
 		{
@@ -5597,7 +5605,7 @@ bool writeStructFile(const char *pFileName)
 		{
 			ini.beginGroup("structure_" + (WzString::number(counter++).leftPadToMinimumLength(WzUniCodepoint::fromASCII('0'), 10)));  // Zero padded so that alphabetical sort works.
 			ini.setValue("name", psCurr->pStructureType->id);
-
+			ini.setValue("upgradeHitpoints", psCurr->pStructureType->upgrade[psCurr->player].hitpoints);
 			writeSaveObject(ini, psCurr);
 
 			if (psCurr->resistance > 0)

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -4773,6 +4773,14 @@ static bool loadSaveDroid(const char *pFileName, DROID **ppsCurrentDroidLists)
 			psDroid->id = id; // force correct ID, unless ID is set to eg -1, in which case we should keep new ID (useful for starting units in campaign)
 		}
 		ASSERT(id != 0, "Droid ID should never be zero here");
+		// conditional check so that existing saved games don't break
+		if (ini.contains("originalBody"))
+		{
+			// we need to set "originalBody" before setting "body", otherwise CHECK_DROID throws assertion errors
+			// we cannot use droidUpgradeBody here to calculate "originalBody", because upgrades aren't loaded yet
+			// so it's much simplier just store/retrieve originalBody value
+			psDroid->originalBody = ini.value("originalBody").toInt();
+		}
 		psDroid->body = healthValue(ini, psDroid->originalBody);
 		ASSERT(psDroid->body != 0, "%s : %d has zero hp!", pFileName, i);
 		psDroid->experience = ini.value("experience", 0).toInt();
@@ -4899,7 +4907,7 @@ static nlohmann::json writeDroid(DROID *psCurr, bool onMission, int &counter)
 {
 	nlohmann::json droidObj = nlohmann::json::object();
 	droidObj["name"] = psCurr->aName;
-
+	droidObj["originalBody"] = psCurr->originalBody;
 	// write common BASE_OBJECT info
 	writeSaveObjectJSON(droidObj, psCurr);
 


### PR DESCRIPTION
This fixes https://github.com/Warzone2100/warzone2100/issues/1814
Saving `body` isn't enough to restore the state, the bug happened only when units being save have health less than `originalBody` value, so for example, units with yellow health-bar would be loaded with full health-bar, but heavily damaged units are correctly loaded.

*EDIT*: I haven't tested the structure hitpoints, maybe the bug needs to be fixed there too
*EDIT-2* Fixed for structures too
