### PR TITLE
Ensure intDoScreenRefresh is called when needed

### DIFF
--- a/src/hci.cpp
+++ b/src/hci.cpp
@@ -593,7 +593,7 @@ static FLAG_POSITION *intFindSelectedDelivPoint()
 
 // Refresh widgets once per game cycle if pending flag is set.
 //
-static void intDoScreenRefresh()
+void intDoScreenRefresh()
 {
 	if (!IntRefreshPending)
 	{
@@ -939,8 +939,6 @@ static void reticuleCallback(int retbut)
 INT_RETVAL intRunWidgets()
 {
 	bool			quitting = false;
-
-	intDoScreenRefresh();
 
 	if (bLoadSaveUp && runLoadSave(true) && strlen(sRequestResult) > 0)
 	{

--- a/src/hci.h
+++ b/src/hci.h
@@ -271,6 +271,8 @@ enum INT_RETVAL
 	INT_QUIT,		// The game should quit
 };
 
+void intDoScreenRefresh();
+
 /* Run the widgets for the in game interface */
 INT_RETVAL intRunWidgets();
 

--- a/src/hci/build.cpp
+++ b/src/hci/build.cpp
@@ -187,7 +187,13 @@ protected:
 		updateLayout();
 		auto droid = controller->getObjectAt(objectIndex);
 		ASSERT_NOT_NULLPTR_OR_RETURN(, droid);
-		ASSERT_OR_RETURN(, !isDead(droid), "Droid is dead");
+		if (isDead(droid))
+		{
+			ASSERT_FAILURE(!isDead(droid), "!isDead(droid)", AT_MACRO, __FUNCTION__, "Droid is dead");
+			// ensure the backing information is refreshed before the next draw
+			intRefreshScreen();
+			return;
+		}
 		displayIMD(Image(), ImdObject::Droid(droid), xOffset, yOffset);
 		displayIfHighlight(xOffset, yOffset);
 	}

--- a/src/hci/commander.cpp
+++ b/src/hci/commander.cpp
@@ -111,7 +111,13 @@ protected:
 		updateLayout();
 		auto droid = controller->getObjectAt(objectIndex);
 		ASSERT_NOT_NULLPTR_OR_RETURN(, droid);
-		ASSERT_OR_RETURN(, !isDead(droid), "Droid is dead");
+		if (isDead(droid))
+		{
+			ASSERT_FAILURE(!isDead(droid), "!isDead(droid)", AT_MACRO, __FUNCTION__, "Droid is dead");
+			// ensure the backing information is refreshed before the next draw
+			intRefreshScreen();
+			return;
+		}
 		displayIMD(Image(), ImdObject::Droid(droid), xOffset, yOffset);
 		displayIfHighlight(xOffset, yOffset);
 	}

--- a/src/hci/manufacture.cpp
+++ b/src/hci/manufacture.cpp
@@ -213,7 +213,13 @@ protected:
 		updateLayout();
 		auto factory = controller->getObjectAt(objectIndex);
 		ASSERT_NOT_NULLPTR_OR_RETURN(, factory);
-		ASSERT_OR_RETURN(, !isDead(factory), "Factory is dead");
+		if (isDead(factory))
+		{
+			ASSERT_FAILURE(!isDead(factory), "!isDead(factory)", AT_MACRO, __FUNCTION__, "Factory is dead");
+			// ensure the backing information is refreshed before the next draw
+			intRefreshScreen();
+			return;
+		}
 		displayIMD(Image(), ImdObject::Structure(factory), xOffset, yOffset);
 		displayIfHighlight(xOffset, yOffset);
 	}

--- a/src/hci/research.cpp
+++ b/src/hci/research.cpp
@@ -270,7 +270,13 @@ protected:
 		updateLayout();
 		auto facility = controller->getObjectAt(objectIndex);
 		ASSERT_NOT_NULLPTR_OR_RETURN(, facility);
-		ASSERT_OR_RETURN(, !isDead(facility), "Facility is dead");
+		if (isDead(facility))
+		{
+			ASSERT_FAILURE(!isDead(facility), "!isDead(facility)", AT_MACRO, __FUNCTION__, "Facility is dead");
+			// ensure the backing information is refreshed before the next draw
+			intRefreshScreen();
+			return;
+		}
 		displayIMD(Image(), ImdObject::Structure(facility), xOffset, yOffset);
 		displayIfHighlight(xOffset, yOffset);
 	}

--- a/src/loop.cpp
+++ b/src/loop.cpp
@@ -144,6 +144,9 @@ static GAMECODE renderLoop()
 	INT_RETVAL intRetVal = INT_NONE;
 	if (!paused)
 	{
+		/* Always refresh the widgets' backing stores if needed, even if we don't process clicks below */
+		intDoScreenRefresh();
+
 		/* Run the in game interface and see if it grabbed any mouse clicks */
 		if (!getRotActive() && getWidgetsStatus() && dragBox3D.status != DRAG_DRAGGING && wallDrag.status != DRAG_DRAGGING)
 		{


### PR DESCRIPTION
There were previously certain edge conditions in which `intDoScreenRefresh()` would not be called (as it was only called inside `intRunWidgets()` and *that* was not called when certain other UI interactions were taking place). When a game object dies, it is added to the "dead objects list" for that frame (and so pointers to it are still valid temporarily), but is fully deleted later. If `intDoScreenRefresh()` was not properly called in time, the game object could be removed from the "dead objects list" (and fully deleted) but still be referenced inside the interface code, and a use-after-free situation could occur inside the interface code, leading to a crash.

This PR pulls `intDoScreenRefresh()` outside of `intRunWidgets()`, and adds some defense-in-depth calls to `intRefreshScreen()` if the interface code detects a dead object. (These may not be strictly necessary, but should not hurt anything, as they simply set a flag to ensure a screen refresh is processed with the next call to `intDoScreenRefresh()`.)

Hopefully this will fix #1817

