### PR TITLE
scripting_engine::loadLabels: Fixes for uninitialized values

### DIFF
--- a/src/qtscript.cpp
+++ b/src/qtscript.cpp
@@ -1956,9 +1956,9 @@ bool scripting_engine::loadLabels(const char *filename)
 			p.type = SCRIPT_POSITION;
 			p.player = ALL_PLAYERS;
 			p.id = -1;
-			p.triggered = -1; // always deactivated
-			labels[label] = p;
 			p.triggered = ini.value("triggered", -1).toInt(); // deactivated by default
+			p.subscriber = ALL_PLAYERS;
+			labels[label] = p;
 		}
 		else if (list[i].startsWith("area"))
 		{
@@ -1982,16 +1982,15 @@ bool scripting_engine::loadLabels(const char *filename)
 			p.subscriber = ini.value("subscriber", ALL_PLAYERS).toInt();
 			p.id = -1;
 			labels[label] = p;
-			p.triggered = ini.value("triggered", -1).toInt(); // deactivated by default
 		}
 		else if (list[i].startsWith("object"))
 		{
 			p.id = ini.value("id").toInt();
 			p.type = ini.value("type").toInt();
 			p.player = ini.value("player").toInt();
-			labels[label] = p;
 			p.triggered = ini.value("triggered", -1).toInt(); // deactivated by default
 			p.subscriber = ini.value("subscriber", ALL_PLAYERS).toInt();
+			labels[label] = p;
 		}
 		else if (list[i].startsWith("group"))
 		{
@@ -2007,8 +2006,9 @@ bool scripting_engine::loadLabels(const char *filename)
 				       id, p.player, list[i].toUtf8().c_str());
 				p.idlist.push_back(id);
 			}
-			labels[label] = p;
 			p.triggered = ini.value("triggered", -1).toInt(); // deactivated by default
+			p.subscriber = ini.value("subscriber", ALL_PLAYERS).toInt();
+			labels[label] = p;
 		}
 		else
 		{

--- a/src/qtscript.h
+++ b/src/qtscript.h
@@ -164,7 +164,8 @@ void jsDebugMessageUpdate();
 
 struct LABEL
 {
-	Vector2i p1, p2;	// world coordinates
+	Vector2i p1 = Vector2i(0, 0);	// world coordinates
+	Vector2i p2 = Vector2i(0, 0);	// world coordinates
 	int id;
 	int type;
 	int player;


### PR DESCRIPTION
Latest GCC finally warned about some quirks in `loadLabels` (these presumably have existed for a while).

@KJeff01 See anything here that will break campaign? (Or that was relying on the prior broken behavior?) Shall we merge this before you do another run-through?