### PR TITLE
Do not handle RMB click while panning the camera

### DIFF
--- a/src/display.cpp
+++ b/src/display.cpp
@@ -642,7 +642,7 @@ void processMouseClickInput()
 		dealWithLMBDClick();
 	}
 
-	if (mouseReleased(MOUSE_RMB) && !rotActive && !ignoreRMBC)
+	if (mouseReleased(MOUSE_RMB) && !rotActive && !panActive && !ignoreRMBC)
 	{
 		dragBox3D.status = DRAG_INACTIVE;
 		// Pretty sure we wan't set walldrag status here aswell.


### PR DESCRIPTION
Avoids accidental clicking the right mouse button when panning the camera. 
The current implementation  results in unwanted ordering or deselecting units depending on the mouse binding (e.g. RMB for panning).

Camera rotation was already correclty handled the same way in that regard.

Solves the "accidental clicking" part of this forum topic: https://forums.wz2100.net/viewtopic.php?f=4&t=16167