### PR TITLE
Suggestion: return to nearest repair droid when no repair facility

### DIFF
--- a/src/droid.cpp
+++ b/src/droid.cpp
@@ -1176,7 +1176,6 @@ static bool droidUpdateDroidRepairBase(DROID *psRepairDroid, DROID *psDroidToRep
 	}
 
 	CHECK_DROID(psRepairDroid);
-
 	/* if not finished repair return true else complete repair and return false */
 	return psDroidToRepair->body < psDroidToRepair->originalBody;
 }
@@ -1188,8 +1187,13 @@ bool droidUpdateDroidRepair(DROID *psRepairDroid)
 
 	DROID *psDroidToRepair = (DROID *)psRepairDroid->psActionTarget[0];
 	ASSERT_OR_RETURN(false, psDroidToRepair->type == OBJ_DROID, "Target is not a unit");
-
-	return droidUpdateDroidRepairBase(psRepairDroid, psDroidToRepair);
+	bool needMoreRepair = droidUpdateDroidRepairBase(psRepairDroid, psDroidToRepair);
+	if (!needMoreRepair && psDroidToRepair->order.type == DORDER_RTR)
+	{
+		// stop following me!
+		psDroidToRepair->order = DroidOrder(DORDER_NONE);	
+	}
+	return needMoreRepair;
 }
 
 static void droidUpdateDroidSelfRepair(DROID *psRepairDroid)


### PR DESCRIPTION
It's quite frustrating to see damaged droid speeding through a barrage of mobile repair turrets, heading to HQ, only to stay there still.

This PR orders damaged droid to move to nearest repair droid, or repair cyborg (but still prefer Repair Facility, it's checked first).
This logic doesn't apply to transporters (they behave as previously)