### PR TITLE
Avoid mutual block: move the whole group to the target location, not only the command droid

### DIFF
--- a/src/order.cpp
+++ b/src/order.cpp
@@ -1252,8 +1252,7 @@ void orderDroidBase(DROID *psDroid, DROID_ORDER_DATA *psOrder)
 	    (psDroid->psGroup->type == GT_COMMAND) &&
 	    (psOrder->type != DORDER_GUARD) &&  //(psOrder->psObj == NULL)) &&
 	    (psOrder->type != DORDER_RTR) &&
-	    (psOrder->type != DORDER_RECYCLE) &&
-	    (psOrder->type != DORDER_MOVE))
+	    (psOrder->type != DORDER_RECYCLE))
 	{
 		if (psOrder->type == DORDER_ATTACK)
 		{


### PR DESCRIPTION
When droids are blocking the route to commander, the whole group is stuck (under fire!)

There was an explicit filter in the code which prevents moving the group as a whole, and I think it's useless and frustrating

Here is an example of current behaviour: notice how droids are blocking the way to commander, and no one is moving 
![current_behaviour](https://user-images.githubusercontent.com/25161465/118403792-5eeb3f80-b670-11eb-9257-834fd289b187.gif)

This is the behaviour after this PR applied. Notice how the whole group is moving to the new destination:
![with_fix](https://user-images.githubusercontent.com/25161465/118403839-a1148100-b670-11eb-8f9c-318f97f038f2.gif)
