### PR TITLE
Terrain normalmapping

### DIFF
--- a/data/base/shaders/decals.frag
+++ b/data/base/shaders/decals.frag
@@ -28,6 +28,7 @@ uniform vec4 fogColor;
 in vec2 uv_tex;
 in vec2 uv_lightmap;
 in float vertexDistance;
+//flat in int tile;
 // Light in tangent space:
 in vec3 lightDir;
 in vec3 halfVec;
@@ -35,6 +36,7 @@ in vec3 halfVec;
 varying vec2 uv_tex;
 varying vec2 uv_lightmap;
 varying float vertexDistance;
+//flat varying int tile;
 // Light in tangent space:
 varying vec3 lightDir;
 varying vec3 halfVec;

--- a/data/base/shaders/decals.frag
+++ b/data/base/shaders/decals.frag
@@ -61,8 +61,7 @@ void main()
 	vec4 gloss = texture(TextureSpecular, uv_tex);
 
 	vec4 texColor = texture(tex, uv_tex);
-	vec4 texAlpha = vec4(1,1,1,texColor.a);
-	vec4 fragColor = texColor*(ambientLight + diffuseLight*lambertTerm) + texAlpha*specularLight*gloss*gaussianTerm;
+	vec4 fragColor = texColor*(ambientLight + diffuseLight*lambertTerm) + vec4(1,1,1,texColor.a)*specularLight*gloss*gaussianTerm;
 	fragColor *= texture(lightmap_tex, uv_lightmap);
 
 	if (fogEnabled > 0)

--- a/data/base/shaders/decals.frag
+++ b/data/base/shaders/decals.frag
@@ -61,8 +61,9 @@ void main()
 	vec4 gloss = texture(TextureSpecular, uv_tex);
 
 	vec4 texColor = texture(tex, uv_tex);
-	vec4 fragColor = texColor*(ambientLight + diffuseLight*lambertTerm) + vec4(1,1,1,texColor.a)*specularLight*gloss*gaussianTerm;
+	vec4 fragColor = texColor*(ambientLight + diffuseLight*lambertTerm) + specularLight*gloss*gaussianTerm;
 	fragColor *= texture(lightmap_tex, uv_lightmap);
+	fragColor.a = texColor.a;
 
 	if (fogEnabled > 0)
 	{

--- a/data/base/shaders/decals.frag
+++ b/data/base/shaders/decals.frag
@@ -5,6 +5,7 @@ uniform sampler2D tex;
 uniform sampler2D lightmap_tex;
 uniform sampler2D TextureNormal;
 uniform sampler2D TextureSpecular;
+uniform sampler2D TextureHeight;
 
 // sun light colors/intensity:
 uniform vec4 emissiveLight;

--- a/data/base/shaders/decals.frag
+++ b/data/base/shaders/decals.frag
@@ -48,7 +48,6 @@ out vec4 FragColor;
 void main()
 {
 	vec3 N = normalize(texture(TextureNormal, uv_tex).xyz * 2.0 - 1.0);
-	N.y = -N.y;
 	vec3 L = normalize(lightDir);
 	float lambertTerm = max(dot(N, L), 0.0); // diffuse lighting
 
@@ -57,7 +56,7 @@ void main()
 	float angle = acos(dot(H, N));
 	float exponent = angle / 0.2;
 	exponent = -(exponent * exponent);
-	float gaussianTerm = exp(exponent);
+	float gaussianTerm = exp(exponent) * float(lambertTerm > 0);
 	vec4 gloss = texture(TextureSpecular, uv_tex);
 
 	vec4 texColor = texture(tex, uv_tex);

--- a/data/base/shaders/decals.frag
+++ b/data/base/shaders/decals.frag
@@ -3,6 +3,14 @@
 
 uniform sampler2D tex;
 uniform sampler2D lightmap_tex;
+uniform sampler2D TextureNormal;
+uniform sampler2D TextureSpecular;
+
+// sun light colors/intensity:
+uniform vec4 emissiveLight;
+uniform vec4 ambientLight;
+uniform vec4 diffuseLight;
+uniform vec4 specularLight;
 
 uniform int fogEnabled; // whether fog is enabled
 uniform float fogEnd;
@@ -10,29 +18,53 @@ uniform float fogStart;
 uniform vec4 fogColor;
 
 #if (!defined(GL_ES) && (__VERSION__ >= 130)) || (defined(GL_ES) && (__VERSION__ >= 300))
+#define NEWGL
+#else
+#define texture(tex,uv) texture2D(tex,uv)
+#endif
+
+#ifdef NEWGL
 in vec2 uv_tex;
 in vec2 uv_lightmap;
 in float vertexDistance;
+// Light in tangent space:
+in vec3 lightDir;
+in vec3 halfVec;
 #else
 varying vec2 uv_tex;
 varying vec2 uv_lightmap;
 varying float vertexDistance;
+// Light in tangent space:
+varying vec3 lightDir;
+varying vec3 halfVec;
 #endif
 
-#if (!defined(GL_ES) && (__VERSION__ >= 130)) || (defined(GL_ES) && (__VERSION__ >= 300))
+#ifdef NEWGL
 out vec4 FragColor;
 #else
-// Uses gl_FragColor
+#define FragColor gl_FragColor
 #endif
 
 void main()
 {
-	#if (!defined(GL_ES) && (__VERSION__ >= 130)) || (defined(GL_ES) && (__VERSION__ >= 300))
-	vec4 fragColor = texture(tex, uv_tex) * texture(lightmap_tex, uv_lightmap);
-	#else
-	vec4 fragColor = texture2D(tex, uv_tex) * texture2D(lightmap_tex, uv_lightmap);
-	#endif
-	
+	vec3 N = normalize(texture(TextureNormal, uv_tex).xyz * 2.0 - 1.0);
+	N.y = -N.y;
+	vec3 L = normalize(lightDir);
+	float lambertTerm = max(dot(N, L), 0.0); // diffuse lighting
+
+	// Gaussian specular term computation
+	vec3 H = normalize(halfVec);
+	float angle = acos(dot(H, N));
+	float exponent = angle / 0.2;
+	exponent = -(exponent * exponent);
+	float gaussianTerm = exp(exponent);
+	vec4 gloss = texture(TextureSpecular, uv_tex);
+
+	vec4 texColor = texture(tex, uv_tex);
+	vec4 texAlpha = vec4(1,1,1,texColor.a);
+	vec4 fragColor = texColor*(ambientLight + diffuseLight*lambertTerm) + texAlpha*specularLight*gloss*gaussianTerm;
+	fragColor *= texture(lightmap_tex, uv_lightmap);
+
 	if (fogEnabled > 0)
 	{
 		// Calculate linear fog
@@ -42,10 +74,5 @@ void main()
 		// Return fragment color
 		fragColor = mix(fragColor, vec4(fogColor.xyz, fragColor.w), fogFactor);
 	}
-
-	#if (!defined(GL_ES) && (__VERSION__ >= 130)) || (defined(GL_ES) && (__VERSION__ >= 300))
 	FragColor = fragColor;
-	#else
-	gl_FragColor = fragColor;
-	#endif
 }

--- a/data/base/shaders/decals.vert
+++ b/data/base/shaders/decals.vert
@@ -16,17 +16,20 @@ in vec4 vertex;
 in vec2 vertexTexCoord;
 in vec3 vertexNormal;
 in vec4 vertexTangent;
+in int tileNo;
 #else
 attribute vec4 vertex;
 attribute vec2 vertexTexCoord;
 attribute vec3 vertexNormal;
 attribute vec4 vertexTangent;
+attribute int tileNo;
 #endif
 
 #ifdef NEWGL
 out vec2 uv_tex;
 out vec2 uv_lightmap;
 out float vertexDistance;
+//flat out int tile;
 // In tangent space
 out vec3 lightDir;
 out vec3 halfVec;
@@ -34,6 +37,7 @@ out vec3 halfVec;
 varying vec2 uv_tex;
 varying vec2 uv_lightmap;
 varying float vertexDistance;
+//flat varying int tile;
 // In tangent space
 varying vec3 lightDir;
 varying vec3 halfVec;
@@ -41,6 +45,7 @@ varying vec3 halfVec;
 
 void main()
 {
+	//tile = tileNo;
 	uv_tex = vertexTexCoord;
 	uv_lightmap = (ModelUVLightmapMatrix * vertex).xy;
 

--- a/data/base/shaders/decals.vert
+++ b/data/base/shaders/decals.vert
@@ -1,12 +1,11 @@
 // Version directive is set by Warzone when loading the shader
 // (This shader supports GLSL 1.20 - 1.50 core.)
 
-uniform mat4 ModelViewMatrix;
-uniform mat4 ModelViewNormalMatrix;
 uniform mat4 ModelViewProjectionMatrix;
 uniform mat4 ModelUVLightmapMatrix;
 
-uniform vec4 sunPosition; // in View space
+uniform vec3 cameraPos; // in modelSpace
+uniform vec3 sunPos; // in modelSpace, normalized
 
 #if (!defined(GL_ES) && (__VERSION__ >= 130)) || (defined(GL_ES) && (__VERSION__ >= 300))
 #define NEWGL
@@ -46,15 +45,12 @@ void main()
 	uv_lightmap = (ModelUVLightmapMatrix * vertex).xy;
 
 	// constructing ModelSpace -> TangentSpace mat3
-	mat3 normalMat = mat3(ModelViewNormalMatrix);
-	vec3 normal = normalize(normalMat * vertexNormal);
-	vec3 tangent = normalize(normalMat * vertexTangent.xyz);
-	vec3 bitangent = cross(normal, tangent) * vertexTangent.w;
-	mat3 ViewTangentMatrix = mat3(tangent, bitangent, normal);
+	vec3 bitangent = cross(vertexNormal, vertexTangent.xyz) * vertexTangent.w;
+	mat3 ModelTangentMatrix = mat3(vertexTangent.xyz, bitangent, vertexNormal);
 	// transform light from ModelSpace to TangentSpace:
-	vec3 eyeVec = normalize(-(ModelViewMatrix * vertex).xyz * ViewTangentMatrix);
-	lightDir = normalize(-sunPosition.xyz * ViewTangentMatrix);
-	halfVec = normalize(lightDir + eyeVec);
+	vec3 eyeVec = normalize((cameraPos - vertex.xyz) * ModelTangentMatrix);
+	lightDir = sunPos * ModelTangentMatrix;
+	halfVec = lightDir + eyeVec;
 
 	vec4 position = ModelViewProjectionMatrix * vertex;
 	gl_Position = position;

--- a/data/base/shaders/decals.vert
+++ b/data/base/shaders/decals.vert
@@ -35,6 +35,9 @@ out vec3 halfVec;
 varying vec2 uv_tex;
 varying vec2 uv_lightmap;
 varying float vertexDistance;
+// In tangent space
+out vec3 lightDir;
+out vec3 halfVec;
 #endif
 
 void main()

--- a/data/base/shaders/decals.vert
+++ b/data/base/shaders/decals.vert
@@ -4,8 +4,8 @@
 uniform mat4 ModelViewProjectionMatrix;
 uniform mat4 ModelUVLightmapMatrix;
 
-uniform vec3 cameraPos; // in modelSpace
-uniform vec3 sunPos; // in modelSpace, normalized
+uniform vec4 cameraPos; // in modelSpace
+uniform vec4 sunPos; // in modelSpace, normalized
 
 #if (!defined(GL_ES) && (__VERSION__ >= 130)) || (defined(GL_ES) && (__VERSION__ >= 300))
 #define NEWGL
@@ -35,8 +35,8 @@ varying vec2 uv_tex;
 varying vec2 uv_lightmap;
 varying float vertexDistance;
 // In tangent space
-out vec3 lightDir;
-out vec3 halfVec;
+varying vec3 lightDir;
+varying vec3 halfVec;
 #endif
 
 void main()
@@ -48,8 +48,8 @@ void main()
 	vec3 bitangent = cross(vertexNormal, vertexTangent.xyz) * vertexTangent.w;
 	mat3 ModelTangentMatrix = mat3(vertexTangent.xyz, bitangent, vertexNormal);
 	// transform light from ModelSpace to TangentSpace:
-	vec3 eyeVec = normalize((cameraPos - vertex.xyz) * ModelTangentMatrix);
-	lightDir = sunPos * ModelTangentMatrix;
+	vec3 eyeVec = normalize((cameraPos.xyz - vertex.xyz) * ModelTangentMatrix);
+	lightDir = sunPos.xyz * ModelTangentMatrix;
 	halfVec = lightDir + eyeVec;
 
 	vec4 position = ModelViewProjectionMatrix * vertex;

--- a/data/base/shaders/decals.vert
+++ b/data/base/shaders/decals.vert
@@ -50,7 +50,7 @@ void main()
 	uv_lightmap = (ModelUVLightmapMatrix * vertex).xy;
 
 	// constructing ModelSpace -> TangentSpace mat3
-	vec3 bitangent = cross(vertexNormal, vertexTangent.xyz) * vertexTangent.w;
+	vec3 bitangent = -cross(vertexNormal, vertexTangent.xyz) * vertexTangent.w;
 	mat3 ModelTangentMatrix = mat3(vertexTangent.xyz, bitangent, vertexNormal);
 	// transform light from ModelSpace to TangentSpace:
 	vec3 eyeVec = normalize((cameraPos.xyz - vertex.xyz) * ModelTangentMatrix);

--- a/data/base/shaders/decals.vert
+++ b/data/base/shaders/decals.vert
@@ -49,8 +49,8 @@ void main()
 	vec3 bitangent = cross(normal, tangent) * vertexTangent.w;
 	mat3 ViewTangentMatrix = mat3(tangent, bitangent, normal);
 	// transform light from ModelSpace to TangentSpace:
-	vec3 eyeVec = normalize((ModelViewMatrix * vertex).xyz * ViewTangentMatrix);
-	lightDir = normalize(sunPosition.xyz * ViewTangentMatrix);
+	vec3 eyeVec = normalize(-(ModelViewMatrix * vertex).xyz * ViewTangentMatrix);
+	lightDir = normalize(-sunPosition.xyz * ViewTangentMatrix);
 	halfVec = normalize(lightDir + eyeVec);
 
 	vec4 position = ModelViewProjectionMatrix * vertex;

--- a/data/base/shaders/decals.vert
+++ b/data/base/shaders/decals.vert
@@ -1,24 +1,36 @@
 // Version directive is set by Warzone when loading the shader
 // (This shader supports GLSL 1.20 - 1.50 core.)
 
+uniform mat4 ModelViewMatrix;
+uniform mat4 ModelViewNormalMatrix;
 uniform mat4 ModelViewProjectionMatrix;
+uniform mat4 ModelUVLightmapMatrix;
 
-uniform mat4 lightTextureMatrix;
-uniform vec4 paramxlight;
-uniform vec4 paramylight;
+uniform vec4 sunPosition; // in View space
 
 #if (!defined(GL_ES) && (__VERSION__ >= 130)) || (defined(GL_ES) && (__VERSION__ >= 300))
+#define NEWGL
+#endif
+
+#ifdef NEWGL
 in vec4 vertex;
 in vec2 vertexTexCoord;
+in vec3 vertexNormal;
+in vec4 vertexTangent;
 #else
 attribute vec4 vertex;
 attribute vec2 vertexTexCoord;
+attribute vec3 vertexNormal;
+attribute vec4 vertexTangent;
 #endif
 
-#if (!defined(GL_ES) && (__VERSION__ >= 130)) || (defined(GL_ES) && (__VERSION__ >= 300))
+#ifdef NEWGL
 out vec2 uv_tex;
 out vec2 uv_lightmap;
 out float vertexDistance;
+// In tangent space
+out vec3 lightDir;
+out vec3 halfVec;
 #else
 varying vec2 uv_tex;
 varying vec2 uv_lightmap;
@@ -27,10 +39,21 @@ varying float vertexDistance;
 
 void main()
 {
+	uv_tex = vertexTexCoord;
+	uv_lightmap = (ModelUVLightmapMatrix * vertex).xy;
+
+	// constructing ModelSpace -> TangentSpace mat3
+	mat3 normalMat = mat3(ModelViewNormalMatrix);
+	vec3 normal = normalize(normalMat * vertexNormal);
+	vec3 tangent = normalize(normalMat * vertexTangent.xyz);
+	vec3 bitangent = cross(normal, tangent) * vertexTangent.w;
+	mat3 ViewTangentMatrix = mat3(tangent, bitangent, normal);
+	// transform light from ModelSpace to TangentSpace:
+	vec3 eyeVec = normalize((ModelViewMatrix * vertex).xyz * ViewTangentMatrix);
+	lightDir = normalize(sunPosition.xyz * ViewTangentMatrix);
+	halfVec = normalize(lightDir + eyeVec);
+
 	vec4 position = ModelViewProjectionMatrix * vertex;
 	gl_Position = position;
-	uv_tex = vertexTexCoord;
-	vec4 uv_lightmap_tmp = lightTextureMatrix * vec4(dot(paramxlight, vertex), dot(paramylight, vertex), 0.0, 1.0);
-	uv_lightmap = uv_lightmap_tmp.xy / uv_lightmap_tmp.w;
 	vertexDistance = position.z;
 }

--- a/data/base/shaders/terrain.frag
+++ b/data/base/shaders/terrain.frag
@@ -3,11 +3,15 @@
 
 uniform sampler2D tex;
 uniform sampler2D lightmap_tex;
+uniform sampler2D TextureNormal; // normal map
+uniform sampler2D TextureSpecular; // specular map
 
 uniform int fogEnabled; // whether fog is enabled
 uniform float fogEnd;
 uniform float fogStart;
 uniform vec4 fogColor;
+uniform int hasNormalmap; // whether a normal map exists for the model
+uniform int hasSpecularmap; // whether a specular map exists for the model
 
 #if (!defined(GL_ES) && (__VERSION__ >= 130)) || (defined(GL_ES) && (__VERSION__ >= 300))
 in vec4 color;

--- a/data/base/shaders/terrain.frag
+++ b/data/base/shaders/terrain.frag
@@ -19,6 +19,7 @@ uniform float fogStart;
 uniform vec4 fogColor;
 uniform int hasNormalmap; // whether a normal map exists for the model
 uniform int hasSpecularmap; // whether a specular map exists for the model
+uniform int hasHeightmap;
 
 #if (!defined(GL_ES) && (__VERSION__ >= 130)) || (defined(GL_ES) && (__VERSION__ >= 300))
 in vec4 color;

--- a/data/base/shaders/terrain.frag
+++ b/data/base/shaders/terrain.frag
@@ -54,6 +54,7 @@ void main()
 	if (hasNormalmap != 0) {
 		vec3 normalFromMap = texture(TextureNormal, uv).xyz;
 		N = normalize(normalFromMap * 2.0 - 1.0);
+		N.y = -N.y;
 	} else {
 		N = vec3(0,0,1); // in tangent space so normal to xy plane
 	}

--- a/data/base/shaders/terrain.frag
+++ b/data/base/shaders/terrain.frag
@@ -17,12 +17,17 @@ uniform int fogEnabled; // whether fog is enabled
 uniform float fogEnd;
 uniform float fogStart;
 uniform vec4 fogColor;
+uniform int quality; // 0-classic, 1-bumpmapping
 uniform int hasNormalmap; // whether a normal map exists for the model
 uniform int hasSpecularmap; // whether a specular map exists for the model
 uniform int hasHeightmap;
 
 #if (!defined(GL_ES) && (__VERSION__ >= 130)) || (defined(GL_ES) && (__VERSION__ >= 300))
-in vec4 color;
+#define NEWGL
+#endif
+
+#ifdef NEWGL
+in float colora;
 in vec2 uv;
 in vec2 uvLight;
 in float vertexDistance;
@@ -30,7 +35,7 @@ in float vertexDistance;
 in vec3 lightDir;
 in vec3 halfVec;
 #else
-varying vec4 color;
+varying float colora;
 varying vec2 uv;
 varying vec2 uvLight;
 varying float vertexDistance;
@@ -39,18 +44,19 @@ varying vec3 lightDir;
 varying vec3 halfVec;
 #endif
 
-#if (!defined(GL_ES) && (__VERSION__ >= 130)) || (defined(GL_ES) && (__VERSION__ >= 300))
+#ifdef NEWGL
 out vec4 FragColor;
 #else
-// Uses gl_FragColor
-#endif
-
-#if (!defined(GL_ES) && (__VERSION__ >= 130)) || (defined(GL_ES) && (__VERSION__ >= 300))
-#else
+#define FragColor gl_FragColor
 #define texture(tex,uv) texture2D(tex,uv)
 #endif
 
-void main()
+vec4 main_classic()
+{
+	return texture(tex, uv) * texture(lightmap_tex, uvLight);
+}
+
+vec4 main_bumpMapping()
 {
 	vec3 N;
 	if (hasNormalmap != 0) {
@@ -65,10 +71,8 @@ void main()
 
 	// Gaussian specular term computation
 	vec3 H = normalize(halfVec);
-	float angle = acos(dot(H, N));
-	float exponent = angle / 0.5; // shininess 0.2 is too small for dry and dirty terrain
-	exponent = -(exponent * exponent);
-	float gaussianTerm = exp(exponent) * float(lambertTerm > 0);
+	float exponent = acos(dot(H, N)) / 0.5;
+	float gaussianTerm = exp(-(exponent * exponent)) * float(lambertTerm > 0);
 
 	vec4 gloss;
 	if (hasSpecularmap != 0) {
@@ -77,9 +81,20 @@ void main()
 		gloss = vec4(vec3(0.1), 1);
 	}
 
-	vec4 fragColor = texture(tex, uv)*(ambientLight + diffuseLight*lambertTerm) + specularLight*gloss*gaussianTerm;
+	vec4 fragColor = texture(tex, uv)*(ambientLight*0.5 + diffuseLight*lambertTerm) + specularLight*gloss*gaussianTerm;
 	fragColor *= texture(lightmap_tex, uvLight);
-	fragColor.a = color.a;
+	return fragColor;
+}
+
+void main()
+{
+	vec4 fragColor;
+	if (quality == 1) {
+		fragColor = main_bumpMapping();
+	} else {
+		fragColor = main_classic();
+	}
+	fragColor.a = colora;
 
 	if (fogEnabled > 0)
 	{
@@ -95,9 +110,5 @@ void main()
 		fragColor = mix(fragColor, vec4(fogColor.xyz, fragColor.w), clamp(fogFactor, 0.0, 1.0));
 	}
 
-	#if (!defined(GL_ES) && (__VERSION__ >= 130)) || (defined(GL_ES) && (__VERSION__ >= 300))
 	FragColor = fragColor;
-	#else
-	gl_FragColor = fragColor;
-	#endif
 }

--- a/data/base/shaders/terrain.frag
+++ b/data/base/shaders/terrain.frag
@@ -75,7 +75,7 @@ void main()
 	}
 
 	vec4 fragColor = texture(tex, uv)*(ambientLight + diffuseLight*lambertTerm) + specularLight*gloss*gaussianTerm;
-	fragColor *= color * texture(lightmap_tex, uvLight);
+	fragColor = vec4(fragColor.rgb * texture(lightmap_tex, uvLight).rgb, color.a);
 
 	if (fogEnabled > 0)
 	{

--- a/data/base/shaders/terrain.frag
+++ b/data/base/shaders/terrain.frag
@@ -62,7 +62,6 @@ vec4 main_bumpMapping()
 	if (hasNormalmap != 0) {
 		vec3 normalFromMap = texture(TextureNormal, uv).xyz;
 		N = normalize(normalFromMap * 2.0 - 1.0);
-		N.y = -N.y;
 	} else {
 		N = vec3(0,0,1); // in tangent space so normal to xy plane
 	}

--- a/data/base/shaders/terrain.frag
+++ b/data/base/shaders/terrain.frag
@@ -54,7 +54,6 @@ void main()
 	if (hasNormalmap != 0) {
 		vec3 normalFromMap = texture(TextureNormal, uv).xyz;
 		N = normalize(normalFromMap * 2.0 - 1.0);
-		N.y = -N.y;
 	} else {
 		N = vec3(0,0,1); // in tangent space so normal to xy plane
 	}
@@ -64,9 +63,10 @@ void main()
 	// Gaussian specular term computation
 	vec3 H = normalize(halfVec);
 	float angle = acos(dot(H, N));
-	float exponent = angle / 0.2;
+	float exponent = angle / 0.5; // shininess 0.2 is too small for dry and dirty terrain
 	exponent = -(exponent * exponent);
-	float gaussianTerm = exp(exponent);
+	float gaussianTerm = exp(exponent) * float(lambertTerm > 0);
+
 	vec4 gloss;
 	if (hasSpecularmap != 0) {
 		gloss = texture(TextureSpecular, uv);

--- a/data/base/shaders/terrain.frag
+++ b/data/base/shaders/terrain.frag
@@ -75,7 +75,8 @@ void main()
 	}
 
 	vec4 fragColor = texture(tex, uv)*(ambientLight + diffuseLight*lambertTerm) + specularLight*gloss*gaussianTerm;
-	fragColor = vec4(fragColor.rgb * texture(lightmap_tex, uvLight).rgb, color.a);
+	fragColor *= texture(lightmap_tex, uvLight);
+	fragColor.a = color.a;
 
 	if (fogEnabled > 0)
 	{

--- a/data/base/shaders/terrain.frag
+++ b/data/base/shaders/terrain.frag
@@ -5,6 +5,7 @@ uniform sampler2D tex;
 uniform sampler2D lightmap_tex;
 uniform sampler2D TextureNormal; // normal map
 uniform sampler2D TextureSpecular; // specular map
+uniform sampler2D TextureHeight;
 
 // light colors/intensity:
 uniform vec4 emissiveLight;

--- a/data/base/shaders/terrain.frag
+++ b/data/base/shaders/terrain.frag
@@ -18,11 +18,17 @@ in vec4 color;
 in vec2 uv1;
 in vec2 uv2;
 in float vertexDistance;
+// Light in tangent space:
+in vec3 lightDir;
+in vec3 halfVec;
 #else
 varying vec4 color;
 varying vec2 uv1;
 varying vec2 uv2;
 varying float vertexDistance;
+// Light in tangent space:
+varying vec3 lightDir;
+varying vec3 halfVec;
 #endif
 
 #if (!defined(GL_ES) && (__VERSION__ >= 130)) || (defined(GL_ES) && (__VERSION__ >= 300))
@@ -31,14 +37,40 @@ out vec4 FragColor;
 // Uses gl_FragColor
 #endif
 
+#if (!defined(GL_ES) && (__VERSION__ >= 130)) || (defined(GL_ES) && (__VERSION__ >= 300))
+#else
+#define texture(tex,uv) texture2D(tex,uv)
+#endif
+
 void main()
 {
-	#if (!defined(GL_ES) && (__VERSION__ >= 130)) || (defined(GL_ES) && (__VERSION__ >= 300))
-	vec4 fragColor = color * texture(tex, uv1) * texture(lightmap_tex, uv2);
-	#else
-	vec4 fragColor = color * texture2D(tex, uv1) * texture2D(lightmap_tex, uv2);
-	#endif
-	
+	vec4 mask = color * texture(lightmap_tex, uv2);
+	vec4 fragColor = mask * texture(tex, uv1);
+
+	vec3 N;
+	if (hasNormalmap != 0) {
+		vec3 normalFromMap = texture(TextureNormal, uv1).xyz;
+		N = normalize(normalFromMap * 2.0 - 1.0);
+	} else {
+		N = vec3(0,0,1); // in tangent space so normal to xy plane
+	}
+	vec3 L = normalize(lightDir);
+	float lambertTerm = max(dot(N, L), 0.0); // diffuse lighting
+
+	// Gaussian specular term computation
+	vec3 H = normalize(halfVec);
+	float angle = acos(dot(H, N));
+	float exponent = angle / 0.2;
+	exponent = -(exponent * exponent);
+	vec4 gaussianTerm = mask*exp(exponent);
+	if (hasSpecularmap != 0) {
+		gaussianTerm *= texture(TextureSpecular, uv1);
+	} else {
+		gaussianTerm *= 0.4;
+	}
+
+	fragColor = fragColor*(lambertTerm*0.4 + 0.3) + gaussianTerm;
+
 	if (fogEnabled > 0)
 	{
 		// Calculate linear fog

--- a/data/base/shaders/terrain.frag
+++ b/data/base/shaders/terrain.frag
@@ -75,7 +75,7 @@ vec4 main_bumpMapping()
 
 	vec4 gloss;
 	if (hasSpecularmap != 0) {
-		gloss = texture(TextureSpecular, uv);
+		gloss = vec4(vec3(texture(TextureSpecular, uv).r), 1);
 	} else {
 		gloss = vec4(vec3(0.1), 1);
 	}

--- a/data/base/shaders/terrain.vert
+++ b/data/base/shaders/terrain.vert
@@ -1,0 +1,47 @@
+// Version directive is set by Warzone when loading the shader
+// (This shader supports GLSL 1.20 - 1.50 core.)
+
+uniform mat4 ModelViewMatrix;
+uniform mat4 ModelViewProjectionMatrix;
+
+uniform vec4 sunPosition;
+
+uniform vec4 paramx1;
+uniform vec4 paramy1;
+uniform vec4 paramx2;
+uniform vec4 paramy2;
+
+uniform mat4 textureMatrix1;
+uniform mat4 textureMatrix2;
+
+#if (!defined(GL_ES) && (__VERSION__ >= 130)) || (defined(GL_ES) && (__VERSION__ >= 300))
+in vec4 vertex;
+in vec4 vertexColor;
+#else
+attribute vec4 vertex;
+attribute vec4 vertexColor;
+#endif
+
+#if (!defined(GL_ES) && (__VERSION__ >= 130)) || (defined(GL_ES) && (__VERSION__ >= 300))
+out vec4 color;
+out vec2 uv1;
+out vec2 uv2;
+out float vertexDistance;
+#else
+varying vec4 color;
+varying vec2 uv1;
+varying vec2 uv2;
+varying float vertexDistance;
+#endif
+
+void main()
+{
+	color = vertexColor;
+	vec4 position = ModelViewProjectionMatrix * vertex;
+	gl_Position = position;
+	vec4 uv1_tmp = textureMatrix1 * vec4(dot(paramx1, vertex), dot(paramy1, vertex), 0., 1.);
+	uv1 = uv1_tmp.xy / uv1_tmp.w;
+	vec4 uv2_tmp = textureMatrix2 * vec4(dot(paramx2, vertex), dot(paramy2, vertex), 0., 1.);
+	uv2 = uv2_tmp.xy / uv2_tmp.w;
+	vertexDistance = position.z;
+}

--- a/data/base/shaders/terrain.vert
+++ b/data/base/shaders/terrain.vert
@@ -3,17 +3,12 @@
 
 uniform mat4 ModelViewMatrix;
 uniform mat4 ModelViewProjectionMatrix;
-uniform mat4 NormalMatrix;
+uniform mat4 ModelViewNormalMatrix;
 
 uniform vec4 sunPosition;
 
-uniform vec4 paramx1;
-uniform vec4 paramy1;
-uniform vec4 paramx2;
-uniform vec4 paramy2;
-
-uniform mat4 textureMatrix1;
-uniform mat4 textureMatrix2;
+uniform mat4 ModelUVMatrix;
+uniform mat4 ModelUVLightMatrix;
 
 #if (!defined(GL_ES) && (__VERSION__ >= 130)) || (defined(GL_ES) && (__VERSION__ >= 300))
 in vec4 vertex;
@@ -27,16 +22,16 @@ attribute vec3 vertexNormal;
 
 #if (!defined(GL_ES) && (__VERSION__ >= 130)) || (defined(GL_ES) && (__VERSION__ >= 300))
 out vec4 color;
-out vec2 uv1;
-out vec2 uv2;
+out vec2 uv;
+out vec2 uvLight;
 out float vertexDistance;
 // In tangent space
 out vec3 lightDir;
 out vec3 halfVec;
 #else
 varying vec4 color;
-varying vec2 uv1;
-varying vec2 uv2;
+varying vec2 uv;
+varying vec2 uvLight;
 varying float vertexDistance;
 // In tangent space
 varying vec3 lightDir;
@@ -46,22 +41,23 @@ varying vec3 halfVec;
 void main()
 {
 	color = vertexColor;
-	vec4 position = ModelViewProjectionMatrix * vertex;
-	gl_Position = position;
-	vec4 uv1_tmp = textureMatrix1 * vec4(dot(paramx1, vertex), dot(paramy1, vertex), 0., 1.);
-	uv1 = uv1_tmp.xy / uv1_tmp.w;
-	vec4 uv2_tmp = textureMatrix2 * vec4(dot(paramx2, vertex), dot(paramy2, vertex), 0., 1.);
-	uv2 = uv2_tmp.xy / uv2_tmp.w;
-	vertexDistance = position.z;
+
+	uv = (ModelUVMatrix * vertex).xy;
+	uvLight = (ModelUVLightMatrix * vertex).xy;
 
 	// constructing EyeSpace -> TangentSpace mat3
-	mat3 normalMat = mat3(NormalMatrix);
+	mat3 normalMat = mat3(ModelViewNormalMatrix);
 	vec3 normal = normalize(normalMat * vertexNormal);
-	vec3 tangent = normalize(cross(normal, normalMat * paramy1.xyz));
+	vec3 vaxis = transpose(ModelUVMatrix)[1].xyz;
+	vec3 tangent = normalize(cross(normal, normalMat * vaxis));
 	vec3 bitangent = cross(normal, tangent);
 	mat3 eyeTangentMatrix = mat3(tangent, bitangent, normal); // aka TBN-matrix
 	// transform light to TangentSpace:
 	vec3 eyeVec = normalize((ModelViewMatrix * vertex).xyz * eyeTangentMatrix);
 	lightDir = normalize(sunPosition.xyz * eyeTangentMatrix);
 	halfVec = lightDir + eyeVec;
+
+	vec4 position = ModelViewProjectionMatrix * vertex;
+	vertexDistance = position.z;
+	gl_Position = position;
 }

--- a/data/base/shaders/terrain.vert
+++ b/data/base/shaders/terrain.vert
@@ -4,8 +4,8 @@ uniform mat4 ModelViewProjectionMatrix;
 uniform mat4 ModelUVMatrix;
 uniform mat4 ModelUVLightMatrix;
 
-uniform vec3 cameraPos; // in modelSpace
-uniform vec3 sunPos; // in modelSpace, normalized
+uniform vec4 cameraPos; // in modelSpace
+uniform vec4 sunPos; // in modelSpace, normalized
 
 #if (!defined(GL_ES) && (__VERSION__ >= 130)) || (defined(GL_ES) && (__VERSION__ >= 300))
 in vec4 vertex;
@@ -48,8 +48,8 @@ void main()
 	vec3 bitangent = cross(vertexNormal, tangent);
 	mat3 ModelTangentMatrix = mat3(tangent, bitangent, vertexNormal); // aka TBN-matrix
 	// transform light to TangentSpace:
-	vec3 eyeVec = normalize((cameraPos - vertex.xyz) * ModelTangentMatrix);
-	lightDir = normalize(sunPos * ModelTangentMatrix);
+	vec3 eyeVec = normalize((cameraPos.xyz - vertex.xyz) * ModelTangentMatrix);
+	lightDir = sunPos.xyz * ModelTangentMatrix; // already normalized
 	halfVec = lightDir + eyeVec;
 
 	vec4 position = ModelViewProjectionMatrix * vertex;

--- a/data/base/shaders/terrain.vert
+++ b/data/base/shaders/terrain.vert
@@ -53,8 +53,8 @@ void main()
 	vec3 bitangent = cross(normal, tangent);
 	mat3 eyeTangentMatrix = mat3(tangent, bitangent, normal); // aka TBN-matrix
 	// transform light to TangentSpace:
-	vec3 eyeVec = normalize((ModelViewMatrix * vertex).xyz * eyeTangentMatrix);
-	lightDir = normalize(sunPosition.xyz * eyeTangentMatrix);
+	vec3 eyeVec = normalize(-(ModelViewMatrix * vertex).xyz * eyeTangentMatrix);
+	lightDir = normalize(-sunPosition.xyz * eyeTangentMatrix);
 	halfVec = lightDir + eyeVec;
 
 	vec4 position = ModelViewProjectionMatrix * vertex;

--- a/data/base/shaders/terrain.vert
+++ b/data/base/shaders/terrain.vert
@@ -18,7 +18,7 @@ attribute vec3 vertexNormal;
 #endif
 
 #if (!defined(GL_ES) && (__VERSION__ >= 130)) || (defined(GL_ES) && (__VERSION__ >= 300))
-out vec4 color;
+out float colora;
 out vec2 uv;
 out vec2 uvLight;
 out float vertexDistance;
@@ -26,7 +26,7 @@ out float vertexDistance;
 out vec3 lightDir;
 out vec3 halfVec;
 #else
-varying vec4 color;
+varying float colora;
 varying vec2 uv;
 varying vec2 uvLight;
 varying float vertexDistance;
@@ -37,7 +37,7 @@ varying vec3 halfVec;
 
 void main()
 {
-	color = vertexColor;
+	colora = vertexColor.a;
 
 	uv = (ModelUVMatrix * vertex).xy;
 	uvLight = (ModelUVLightMatrix * vertex).xy;

--- a/data/base/shaders/terrain_depth.vert
+++ b/data/base/shaders/terrain_depth.vert
@@ -1,0 +1,44 @@
+// Version directive is set by Warzone when loading the shader
+// (This shader supports GLSL 1.20 - 1.50 core.)
+
+uniform mat4 ModelViewProjectionMatrix;
+
+uniform vec4 paramx1;
+uniform vec4 paramy1;
+uniform vec4 paramx2;
+uniform vec4 paramy2;
+
+uniform mat4 textureMatrix1;
+uniform mat4 textureMatrix2;
+
+#if (!defined(GL_ES) && (__VERSION__ >= 130)) || (defined(GL_ES) && (__VERSION__ >= 300))
+in vec4 vertex;
+in vec4 vertexColor;
+#else
+attribute vec4 vertex;
+attribute vec4 vertexColor;
+#endif
+
+#if (!defined(GL_ES) && (__VERSION__ >= 130)) || (defined(GL_ES) && (__VERSION__ >= 300))
+out vec4 color;
+out vec2 uv1;
+out vec2 uv2;
+out float vertexDistance;
+#else
+varying vec4 color;
+varying vec2 uv1;
+varying vec2 uv2;
+varying float vertexDistance;
+#endif
+
+void main()
+{
+	color = vertexColor;
+	vec4 position = ModelViewProjectionMatrix * vertex;
+	gl_Position = position;
+	vec4 uv1_tmp = textureMatrix1 * vec4(dot(paramx1, vertex), dot(paramy1, vertex), 0., 1.);
+	uv1 = uv1_tmp.xy / uv1_tmp.w;
+	vec4 uv2_tmp = textureMatrix2 * vec4(dot(paramx2, vertex), dot(paramy2, vertex), 0., 1.);
+	uv2 = uv2_tmp.xy / uv2_tmp.w;
+	vertexDistance = position.z;
+}

--- a/data/base/shaders/terrain_water.vert
+++ b/data/base/shaders/terrain_water.vert
@@ -40,8 +40,8 @@ void main()
 	gl_Position = position;
 	vertexDistance = position.z;
 
-	uv1 = vec2(vertex.x/512 + time/10, -vertex.z/512); // (ModelUV1 * vertex).xy;
-	uv2 = vec2(vertex.x/1024, -vertex.z/1024); // (ModelUV2 * vertex).xy;
+	uv1 = vec2(vertex.x/4/128 + time/10, -vertex.z/4/128); // (ModelUV1Matrix * vertex).xy;
+	uv2 = vec2(vertex.x/5/128, -vertex.z/5/128); // (ModelUV2Matrix * vertex).xy;
 
 	vec3 eyeVec = normalize(cameraPos - vertex.xyz);
 	lightDir = sunPos;

--- a/data/base/shaders/terrain_water.vert
+++ b/data/base/shaders/terrain_water.vert
@@ -5,7 +5,7 @@ uniform mat4 ModelViewProjectionMatrix;
 uniform mat4 ModelUV1Matrix;
 uniform mat4 ModelUV2Matrix;
 
-uniform float time; // in seconds
+uniform float timeSec;
 
 uniform vec4 cameraPos; // in modelSpace
 uniform vec4 sunPos; // in modelSpace, normalized
@@ -40,7 +40,7 @@ void main()
 	gl_Position = position;
 	vertexDistance = position.z;
 
-	uv1 = vec2(vertex.x/4/128 + time/10, -vertex.z/4/128); // (ModelUV1Matrix * vertex).xy;
+	uv1 = vec2(vertex.x/4/128 + timeSec/10, -vertex.z/4/128); // (ModelUV1Matrix * vertex).xy;
 	uv2 = vec2(vertex.x/5/128, -vertex.z/5/128); // (ModelUV2Matrix * vertex).xy;
 
 	vec3 eyeVec = normalize(cameraPos.xyz - vertex.xyz);

--- a/data/base/shaders/terrain_water.vert
+++ b/data/base/shaders/terrain_water.vert
@@ -2,12 +2,16 @@
 // (This shader supports GLSL 1.20 - 1.50 core.)
 
 uniform mat4 ModelViewProjectionMatrix;
-uniform mat3 ModelTangentMatrix;
-uniform mat4 ModelUV1;
-uniform mat4 ModelUV2;
+uniform mat3 ModelViewMatrix;
+uniform mat3 ModelViewNormalMatrix;
+uniform mat4 ModelUV1Matrix;
+uniform mat4 ModelUV2Matrix;
 
-uniform vec3 cameraPos;
-uniform vec3 lightDirInTangent;
+uniform float time; // in seconds
+
+uniform vec3 cameraPos; // in modelSpace
+uniform vec3 sunPos; // in modelSpace, normalized
+uniform vec3 sunPosInView;
 
 #if (!defined(GL_ES) && (__VERSION__ >= 130)) || (defined(GL_ES) && (__VERSION__ >= 300))
 in vec4 vertex;
@@ -19,7 +23,7 @@ attribute vec4 vertex;
 out vec2 uv1;
 out vec2 uv2;
 out float vertexDistance;
-// light in tangent space:
+// light in modelSpace:
 out vec3 lightDir;
 out vec3 halfVec;
 #else
@@ -34,12 +38,12 @@ void main()
 {
 	vec4 position = ModelViewProjectionMatrix * vertex;
 	gl_Position = position;
-	uv1 = (ModelUV1 * vertex).xy;
-	uv2 = (ModelUV2 * vertex).xy;
 	vertexDistance = position.z;
 
-	// transform light to TangentSpace:
-	vec3 eyeVec = normalize(ModelTangentMatrix * (cameraPos - vertex.xyz));
-	lightDir = lightDirInTangent;
+	uv1 = vec2(vertex.x/512 + time/10, -vertex.z/512); // (ModelUV1 * vertex).xy;
+	uv2 = vec2(vertex.x/1024, -vertex.z/1024); // (ModelUV2 * vertex).xy;
+
+	vec3 eyeVec = normalize(cameraPos - vertex.xyz);
+	lightDir = sunPos;
 	halfVec = lightDir + eyeVec;
 }

--- a/data/base/shaders/terrain_water.vert
+++ b/data/base/shaders/terrain_water.vert
@@ -2,8 +2,6 @@
 // (This shader supports GLSL 1.20 - 1.50 core.)
 
 uniform mat4 ModelViewProjectionMatrix;
-uniform mat3 ModelViewMatrix;
-uniform mat3 ModelViewNormalMatrix;
 uniform mat4 ModelUV1Matrix;
 uniform mat4 ModelUV2Matrix;
 
@@ -11,7 +9,6 @@ uniform float time; // in seconds
 
 uniform vec3 cameraPos; // in modelSpace
 uniform vec3 sunPos; // in modelSpace, normalized
-uniform vec3 sunPosInView;
 
 #if (!defined(GL_ES) && (__VERSION__ >= 130)) || (defined(GL_ES) && (__VERSION__ >= 300))
 in vec4 vertex; // w is depth

--- a/data/base/shaders/terrain_water.vert
+++ b/data/base/shaders/terrain_water.vert
@@ -2,43 +2,44 @@
 // (This shader supports GLSL 1.20 - 1.50 core.)
 
 uniform mat4 ModelViewProjectionMatrix;
+uniform mat3 ModelTangentMatrix;
+uniform mat4 ModelUV1;
+uniform mat4 ModelUV2;
 
-uniform vec4 paramx1;
-uniform vec4 paramy1;
-uniform vec4 paramx2;
-uniform vec4 paramy2;
-
-uniform mat4 textureMatrix1;
-uniform mat4 textureMatrix2;
+uniform vec3 cameraPos;
+uniform vec3 lightDirInTangent;
 
 #if (!defined(GL_ES) && (__VERSION__ >= 130)) || (defined(GL_ES) && (__VERSION__ >= 300))
 in vec4 vertex;
-in vec4 vertexColor;
 #else
 attribute vec4 vertex;
-attribute vec4 vertexColor;
 #endif
 
 #if (!defined(GL_ES) && (__VERSION__ >= 130)) || (defined(GL_ES) && (__VERSION__ >= 300))
-out vec4 color;
 out vec2 uv1;
 out vec2 uv2;
 out float vertexDistance;
+// light in tangent space:
+out vec3 lightDir;
+out vec3 halfVec;
 #else
-varying vec4 color;
 varying vec2 uv1;
 varying vec2 uv2;
 varying float vertexDistance;
+varying vec3 lightDir;
+varying vec3 halfVec;
 #endif
 
 void main()
 {
-	color = vertexColor;
 	vec4 position = ModelViewProjectionMatrix * vertex;
 	gl_Position = position;
-	vec4 uv1_tmp = textureMatrix1 * vec4(dot(paramx1, vertex), dot(paramy1, vertex), 0., 1.);
-	uv1 = uv1_tmp.xy / uv1_tmp.w;
-	vec4 uv2_tmp = textureMatrix2 * vec4(dot(paramx2, vertex), dot(paramy2, vertex), 0., 1.);
-	uv2 = uv2_tmp.xy / uv2_tmp.w;
+	uv1 = (ModelUV1 * vertex).xy;
+	uv2 = (ModelUV2 * vertex).xy;
 	vertexDistance = position.z;
+
+	// transform light to TangentSpace:
+	vec3 eyeVec = normalize(ModelTangentMatrix * (cameraPos - vertex.xyz));
+	lightDir = lightDirInTangent;
+	halfVec = lightDir + eyeVec;
 }

--- a/data/base/shaders/terrain_water.vert
+++ b/data/base/shaders/terrain_water.vert
@@ -14,7 +14,7 @@ uniform vec3 sunPos; // in modelSpace, normalized
 uniform vec3 sunPosInView;
 
 #if (!defined(GL_ES) && (__VERSION__ >= 130)) || (defined(GL_ES) && (__VERSION__ >= 300))
-in vec4 vertex;
+in vec4 vertex; // w is depth
 #else
 attribute vec4 vertex;
 #endif
@@ -22,6 +22,7 @@ attribute vec4 vertex;
 #if (!defined(GL_ES) && (__VERSION__ >= 130)) || (defined(GL_ES) && (__VERSION__ >= 300))
 out vec2 uv1;
 out vec2 uv2;
+out float depth;
 out float vertexDistance;
 // light in modelSpace:
 out vec3 lightDir;
@@ -29,6 +30,7 @@ out vec3 halfVec;
 #else
 varying vec2 uv1;
 varying vec2 uv2;
+varying float depth;
 varying float vertexDistance;
 varying vec3 lightDir;
 varying vec3 halfVec;
@@ -36,7 +38,8 @@ varying vec3 halfVec;
 
 void main()
 {
-	vec4 position = ModelViewProjectionMatrix * vertex;
+	depth = vertex.w;
+	vec4 position = ModelViewProjectionMatrix * vec4(vertex.xyz, 1);
 	gl_Position = position;
 	vertexDistance = position.z;
 

--- a/data/base/shaders/terrain_water.vert
+++ b/data/base/shaders/terrain_water.vert
@@ -7,8 +7,8 @@ uniform mat4 ModelUV2Matrix;
 
 uniform float time; // in seconds
 
-uniform vec3 cameraPos; // in modelSpace
-uniform vec3 sunPos; // in modelSpace, normalized
+uniform vec4 cameraPos; // in modelSpace
+uniform vec4 sunPos; // in modelSpace, normalized
 
 #if (!defined(GL_ES) && (__VERSION__ >= 130)) || (defined(GL_ES) && (__VERSION__ >= 300))
 in vec4 vertex; // w is depth
@@ -43,7 +43,7 @@ void main()
 	uv1 = vec2(vertex.x/4/128 + time/10, -vertex.z/4/128); // (ModelUV1Matrix * vertex).xy;
 	uv2 = vec2(vertex.x/5/128, -vertex.z/5/128); // (ModelUV2Matrix * vertex).xy;
 
-	vec3 eyeVec = normalize(cameraPos - vertex.xyz);
-	lightDir = sunPos;
+	vec3 eyeVec = normalize(cameraPos.xyz - vertex.xyz);
+	lightDir = sunPos.xyz;
 	halfVec = lightDir + eyeVec;
 }

--- a/data/base/shaders/vk/decals.frag
+++ b/data/base/shaders/vk/decals.frag
@@ -26,6 +26,7 @@ layout(location = 1) in vec2 uv_lightmap;
 layout(location = 2) in float vertexDistance;
 layout(location = 3) in vec3 lightDir;
 layout(location = 4) in vec3 halfVec;
+//layout(location = 5) flat in int tile;
 
 layout(location = 0) out vec4 FragColor;
 

--- a/data/base/shaders/vk/decals.frag
+++ b/data/base/shaders/vk/decals.frag
@@ -2,12 +2,19 @@
 
 layout(set = 1, binding = 0) uniform sampler2D tex;
 layout(set = 1, binding = 1) uniform sampler2D lightmap_tex;
+layout(set = 1, binding = 2) uniform sampler2D TextureNormal;
+layout(set = 1, binding = 3) uniform sampler2D TextureSpecular;
+layout(set = 1, binding = 4) uniform sampler2D TextureHeight;
 
 layout(std140, set = 0, binding = 0) uniform cbuffer {
 	mat4 ModelViewProjectionMatrix;
-	mat4 lightTextureMatrix;
-	vec4 paramxlight;
-	vec4 paramylight;
+	mat4 ModelUVLightmapMatrix;
+	vec4 cameraPos; // in modelSpace
+	vec4 sunPos; // in modelSpace, normalized
+	vec4 emissiveLight; // light colors/intensity
+	vec4 ambientLight;
+	vec4 diffuseLight;
+	vec4 specularLight;
 	vec4 fogColor;
 	int fogEnabled; // whether fog is enabled
 	float fogEnd;
@@ -17,13 +24,29 @@ layout(std140, set = 0, binding = 0) uniform cbuffer {
 layout(location = 0) in vec2 uv_tex;
 layout(location = 1) in vec2 uv_lightmap;
 layout(location = 2) in float vertexDistance;
+layout(location = 3) in vec3 lightDir;
+layout(location = 4) in vec3 halfVec;
 
 layout(location = 0) out vec4 FragColor;
 
 void main()
 {
-	vec4 fragColor = texture(tex, uv_tex) * texture(lightmap_tex, uv_lightmap);
-	
+	vec3 N = normalize(texture(TextureNormal, uv_tex).xyz * 2.0 - 1.0);
+	vec3 L = normalize(lightDir);
+	float lambertTerm = max(dot(N, L), 0.0); // diffuse lighting
+
+	// Gaussian specular term computation
+	vec3 H = normalize(halfVec);
+	float angle = acos(dot(H, N));
+	float exponent = angle / 0.2;
+	exponent = -(exponent * exponent);
+	float gaussianTerm = exp(exponent) * float(lambertTerm > 0);
+	vec4 gloss = texture(TextureSpecular, uv_tex);
+
+	vec4 texColor = texture(tex, uv_tex);
+	vec4 fragColor = texColor*(ambientLight + diffuseLight*lambertTerm) + vec4(1,1,1,texColor.a)*specularLight*gloss*gaussianTerm;
+	fragColor *= texture(lightmap_tex, uv_lightmap);
+
 	if (fogEnabled > 0)
 	{
 		// Calculate linear fog

--- a/data/base/shaders/vk/decals.vert
+++ b/data/base/shaders/vk/decals.vert
@@ -19,15 +19,18 @@ layout(location = 0) in vec4 vertex;
 layout(location = 1) in vec2 vertexTexCoord;
 layout(location = 3) in vec3 vertexNormal;
 layout(location = 4) in vec4 vertexTangent;
+layout(location = 5) in int tileNo;
 
 layout(location = 0) out vec2 uv_tex;
 layout(location = 1) out vec2 uv_lightmap;
 layout(location = 2) out float vertexDistance;
 layout(location = 3) out vec3 lightDir;
 layout(location = 4) out vec3 halfVec;
+//layout(location = 5) flat out int tile;
 
 void main()
 {
+	//tile = tileNo;
 	uv_tex = vertexTexCoord;
 	uv_lightmap = (ModelUVLightmapMatrix * vertex).xy;
 

--- a/data/base/shaders/vk/decals.vert
+++ b/data/base/shaders/vk/decals.vert
@@ -2,9 +2,13 @@
 
 layout(std140, set = 0, binding = 0) uniform cbuffer {
 	mat4 ModelViewProjectionMatrix;
-	mat4 lightTextureMatrix;
-	vec4 paramxlight;
-	vec4 paramylight;
+	mat4 ModelUVLightmapMatrix;
+	vec4 cameraPos; // in modelSpace
+	vec4 sunPos; // in modelSpace, normalized
+	vec4 emissiveLight; // light colors/intensity
+	vec4 ambientLight;
+	vec4 diffuseLight;
+	vec4 specularLight;
 	vec4 fogColor;
 	int fogEnabled; // whether fog is enabled
 	float fogEnd;
@@ -13,19 +17,31 @@ layout(std140, set = 0, binding = 0) uniform cbuffer {
 
 layout(location = 0) in vec4 vertex;
 layout(location = 1) in vec2 vertexTexCoord;
+layout(location = 3) in vec3 vertexNormal;
+layout(location = 4) in vec4 vertexTangent;
 
 layout(location = 0) out vec2 uv_tex;
 layout(location = 1) out vec2 uv_lightmap;
 layout(location = 2) out float vertexDistance;
+layout(location = 3) out vec3 lightDir;
+layout(location = 4) out vec3 halfVec;
 
 void main()
 {
-	vec4 position = ModelViewProjectionMatrix * vertex;
-	gl_Position = position;
 	uv_tex = vertexTexCoord;
-	vec4 uv_lightmap_tmp = lightTextureMatrix * vec4(dot(paramxlight, vertex), dot(paramylight, vertex), 0.0, 1.0);
-	uv_lightmap = uv_lightmap_tmp.xy / uv_lightmap_tmp.w;
+	uv_lightmap = (ModelUVLightmapMatrix * vertex).xy;
+
+	// constructing ModelSpace -> TangentSpace mat3
+	vec3 bitangent = cross(vertexNormal, vertexTangent.xyz) * vertexTangent.w;
+	mat3 ModelTangentMatrix = mat3(vertexTangent.xyz, bitangent, vertexNormal);
+	// transform light from ModelSpace to TangentSpace:
+	vec3 eyeVec = normalize((cameraPos.xyz - vertex.xyz) * ModelTangentMatrix);
+	lightDir = sunPos.xyz * ModelTangentMatrix;
+	halfVec = lightDir + eyeVec;
+
+	vec4 position = ModelViewProjectionMatrix * vertex;
 	vertexDistance = position.z;
+	gl_Position = position;
 	gl_Position.y *= -1.;
 	gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0;
 }

--- a/data/base/shaders/vk/decals.vert
+++ b/data/base/shaders/vk/decals.vert
@@ -13,6 +13,7 @@ layout(std140, set = 0, binding = 0) uniform cbuffer {
 	int fogEnabled; // whether fog is enabled
 	float fogEnd;
 	float fogStart;
+	int quality;
 };
 
 layout(location = 0) in vec4 vertex;

--- a/data/base/shaders/vk/terrain.frag
+++ b/data/base/shaders/vk/terrain.frag
@@ -2,19 +2,27 @@
 
 layout(set = 1, binding = 0) uniform sampler2D tex;
 layout(set = 1, binding = 1) uniform sampler2D lightmap_tex;
+layout(set = 1, binding = 2) uniform sampler2D TextureNormal; // normal map
+layout(set = 1, binding = 3) uniform sampler2D TextureSpecular; // specular map
 
 layout(std140, set = 0, binding = 0) uniform cbuffer {
+	mat4 textureMatrix1;
+	mat4 textureMatrix2;
+	mat4 ModelViewMatrix;
 	mat4 ModelViewProjectionMatrix;
+	vec4 sunPosition;
 	vec4 paramx1;
 	vec4 paramy1;
 	vec4 paramx2;
 	vec4 paramy2;
-	mat4 textureMatrix1;
-	mat4 textureMatrix2;
 	vec4 fogColor;
 	int fogEnabled; // whether fog is enabled
 	float fogEnd;
 	float fogStart;
+	int texture0;
+	int texture1;
+	int hasNormalmap;
+	int hasSpecularmap;
 };
 
 layout(location = 0) in vec4 color;

--- a/data/base/shaders/vk/terrain.frag
+++ b/data/base/shaders/vk/terrain.frag
@@ -29,10 +29,9 @@ layout(location = 0) in vec4 color;
 layout(location = 1) in vec2 uv1;
 layout(location = 2) in vec2 uv2;
 layout(location = 3) in float vertexDistance;
-// TODO: in tangent space:
-layout(location = 4) in vec3 normal;
-layout(location = 5) in vec3 lightDir;
-layout(location = 6) in vec3 halfVec;
+// Light in tangent space:
+layout(location = 4) in vec3 lightDir;
+layout(location = 5) in vec3 halfVec;
 
 layout(location = 0) out vec4 FragColor;
 
@@ -42,10 +41,10 @@ void main()
 	vec4 fragColor = mask * texture(tex, uv1);
 	vec3 N;
 	if (hasNormalmap != 0) {
-		// TODO: N = texture(lightmap_tex, uv2).xzy * 2 - 1;
-		N = normalize(normal);
+		vec3 normalFromMap = texture(TextureNormal, uv1).xyz;
+		N = normalize(normalFromMap * 2.0 - 1.0);
 	} else {
-		N = normalize(normal);
+		N = vec3(0,0,1); // in tangent space so normal to xy plane
 	}
 	vec3 L = normalize(lightDir);
 	float lambertTerm = max(dot(N, L), 0.0); // diffuse lighting
@@ -57,7 +56,7 @@ void main()
 	exponent = -(exponent * exponent);
 	float gaussianTerm = exp(exponent);
 
-	fragColor = fragColor*(lambertTerm*0.4 + 0.5) + mask*gaussianTerm*0.3;
+	fragColor = fragColor*(lambertTerm*0.4 + 0.3) + mask*gaussianTerm*0.4;
 
 	if (fogEnabled > 0)
 	{

--- a/data/base/shaders/vk/terrain.frag
+++ b/data/base/shaders/vk/terrain.frag
@@ -10,6 +10,7 @@ layout(std140, set = 0, binding = 0) uniform cbuffer {
 	mat4 textureMatrix2;
 	mat4 ModelViewMatrix;
 	mat4 ModelViewProjectionMatrix;
+	mat4 NormalMatrix;
 	vec4 sunPosition;
 	vec4 paramx1;
 	vec4 paramy1;

--- a/data/base/shaders/vk/terrain.frag
+++ b/data/base/shaders/vk/terrain.frag
@@ -55,9 +55,14 @@ void main()
 	float angle = acos(dot(H, N));
 	float exponent = angle / 0.2;
 	exponent = -(exponent * exponent);
-	float gaussianTerm = exp(exponent);
+	vec4 gaussianTerm = mask*exp(exponent);
+	if (hasSpecularmap != 0) {
+		gaussianTerm *= texture(TextureSpecular, uv1);
+	} else {
+		gaussianTerm *= 0.4;
+	}
 
-	fragColor = fragColor*(lambertTerm*0.4 + 0.3) + mask*gaussianTerm*0.4;
+	fragColor = fragColor*(lambertTerm*0.4 + 0.3) + gaussianTerm;
 
 	if (fogEnabled > 0)
 	{

--- a/data/base/shaders/vk/terrain.frag
+++ b/data/base/shaders/vk/terrain.frag
@@ -20,12 +20,13 @@ layout(std140, set = 0, binding = 0) uniform cbuffer {
 	int fogEnabled; // whether fog is enabled
 	float fogEnd;
 	float fogStart;
+	int quality;
 	int hasNormalmap;
 	int hasSpecularmap;
 	int hasHeightmap;
 };
 
-layout(location = 0) in vec4 color;
+layout(location = 0) in float colora;
 layout(location = 1) in vec2 uv;
 layout(location = 2) in vec2 uvLight;
 layout(location = 3) in float vertexDistance;
@@ -35,7 +36,12 @@ layout(location = 5) in vec3 halfVec;
 
 layout(location = 0) out vec4 FragColor;
 
-void main()
+vec4 main_classic()
+{
+	return texture(tex, uv) * texture(lightmap_tex, uvLight);
+}
+
+vec4 main_bumpMapping()
 {
 	vec3 N;
 	if (hasNormalmap != 0) {
@@ -50,10 +56,8 @@ void main()
 
 	// Gaussian specular term computation
 	vec3 H = normalize(halfVec);
-	float angle = acos(dot(H, N));
-	float exponent = angle / 0.5;
-	exponent = -(exponent * exponent);
-	float gaussianTerm = exp(exponent) * float(lambertTerm > 0);
+	float exponent = acos(dot(H, N)) / 0.5;
+	float gaussianTerm = exp(-(exponent * exponent)) * float(lambertTerm > 0);
 
 	vec4 gloss;
 	if (hasSpecularmap != 0) {
@@ -62,9 +66,20 @@ void main()
 		gloss = vec4(vec3(0.1), 1);
 	}
 
-	vec4 fragColor = texture(tex, uv)*(ambientLight + diffuseLight*lambertTerm) + specularLight*gloss*gaussianTerm;
+	vec4 fragColor = texture(tex, uv)*(ambientLight*0.5 + diffuseLight*lambertTerm) + specularLight*gloss*gaussianTerm;
 	fragColor *= texture(lightmap_tex, uvLight);
-	fragColor.a = color.a;
+	return fragColor;
+}
+
+void main()
+{
+	vec4 fragColor;
+	if (quality == 1) {
+		fragColor = main_bumpMapping();
+	} else {
+		fragColor = main_classic();
+	}
+	fragColor.a = colora;
 
 	if (fogEnabled > 0)
 	{
@@ -79,6 +94,6 @@ void main()
 		// Return fragment color
 		fragColor = mix(fragColor, vec4(fogColor.xyz, fragColor.w), clamp(fogFactor, 0.0, 1.0));
 	}
-	
+
 	FragColor = fragColor;
 }

--- a/data/base/shaders/vk/terrain.frag
+++ b/data/base/shaders/vk/terrain.frag
@@ -21,6 +21,7 @@ layout(std140, set = 0, binding = 0) uniform cbuffer {
 	float fogStart;
 	int hasNormalmap;
 	int hasSpecularmap;
+	int hasHeightmap;
 };
 
 layout(location = 0) in vec4 color;

--- a/data/base/shaders/vk/terrain.frag
+++ b/data/base/shaders/vk/terrain.frag
@@ -4,6 +4,7 @@ layout(set = 1, binding = 0) uniform sampler2D tex;
 layout(set = 1, binding = 1) uniform sampler2D lightmap_tex;
 layout(set = 1, binding = 2) uniform sampler2D TextureNormal; // normal map
 layout(set = 1, binding = 3) uniform sampler2D TextureSpecular; // specular map
+layout(set = 1, binding = 4) uniform sampler2D TextureHeight;
 
 layout(std140, set = 0, binding = 0) uniform cbuffer {
 	mat4 ModelViewProjectionMatrix;

--- a/data/base/shaders/vk/terrain.frag
+++ b/data/base/shaders/vk/terrain.frag
@@ -29,13 +29,36 @@ layout(location = 0) in vec4 color;
 layout(location = 1) in vec2 uv1;
 layout(location = 2) in vec2 uv2;
 layout(location = 3) in float vertexDistance;
+// TODO: in tangent space:
+layout(location = 4) in vec3 normal;
+layout(location = 5) in vec3 lightDir;
+layout(location = 6) in vec3 halfVec;
 
 layout(location = 0) out vec4 FragColor;
 
 void main()
 {
-	vec4 fragColor = color * texture(tex, uv1) * texture(lightmap_tex, uv2);
-	
+	vec4 mask = color * texture(lightmap_tex, uv2);
+	vec4 fragColor = mask * texture(tex, uv1);
+	vec3 N;
+	if (hasNormalmap != 0) {
+		// TODO: N = texture(lightmap_tex, uv2).xzy * 2 - 1;
+		N = normalize(normal);
+	} else {
+		N = normalize(normal);
+	}
+	vec3 L = normalize(lightDir);
+	float lambertTerm = max(dot(N, L), 0.0); // diffuse lighting
+
+	// Gaussian specular term computation
+	vec3 H = normalize(halfVec);
+	float angle = acos(dot(H, N));
+	float exponent = angle / 0.2;
+	exponent = -(exponent * exponent);
+	float gaussianTerm = exp(exponent);
+
+	fragColor = fragColor*(lambertTerm*0.4 + 0.5) + mask*gaussianTerm*0.3;
+
 	if (fogEnabled > 0)
 	{
 		// Calculate linear fog

--- a/data/base/shaders/vk/terrain.frag
+++ b/data/base/shaders/vk/terrain.frag
@@ -61,7 +61,7 @@ vec4 main_bumpMapping()
 
 	vec4 gloss;
 	if (hasSpecularmap != 0) {
-		gloss = texture(TextureSpecular, uv);
+		gloss = vec4(vec3(texture(TextureSpecular, uv).r), 1);
 	} else {
 		gloss = vec4(vec3(0.1), 1);
 	}

--- a/data/base/shaders/vk/terrain.vert
+++ b/data/base/shaders/vk/terrain.vert
@@ -1,17 +1,23 @@
 #version 450
 
 layout(std140, set = 0, binding = 0) uniform cbuffer {
+	mat4 textureMatrix1;
+	mat4 textureMatrix2;
+	mat4 ModelViewMatrix;
 	mat4 ModelViewProjectionMatrix;
+	vec4 sunPosition;
 	vec4 paramx1;
 	vec4 paramy1;
 	vec4 paramx2;
 	vec4 paramy2;
-	mat4 textureMatrix1;
-	mat4 textureMatrix2;
 	vec4 fogColor;
 	int fogEnabled; // whether fog is enabled
 	float fogEnd;
 	float fogStart;
+	int texture0;
+	int texture1;
+	int hasNormalmap;
+	int hasSpecularmap;
 };
 
 layout(location = 0) in vec4 vertex;

--- a/data/base/shaders/vk/terrain.vert
+++ b/data/base/shaders/vk/terrain.vert
@@ -5,7 +5,7 @@ layout(std140, set = 0, binding = 0) uniform cbuffer {
 	mat4 textureMatrix2;
 	mat4 ModelViewMatrix;
 	mat4 ModelViewProjectionMatrix;
-	vec4 sunPosition;
+	vec4 sunPosition; // In view space
 	vec4 paramx1;
 	vec4 paramy1;
 	vec4 paramx2;
@@ -22,11 +22,16 @@ layout(std140, set = 0, binding = 0) uniform cbuffer {
 
 layout(location = 0) in vec4 vertex;
 layout(location = 2) in vec4 vertexColor;
+layout(location = 3) in vec3 vertexNormal;
 
 layout(location = 0) out vec4 color;
 layout(location = 1) out vec2 uv1;
 layout(location = 2) out vec2 uv2;
 layout(location = 3) out float vertexDistance;
+// TODO: in tangent space
+layout(location = 4) out vec3 normal;
+layout(location = 5) out vec3 lightDir;
+layout(location = 6) out vec3 halfVec;
 
 void main()
 {
@@ -37,6 +42,12 @@ void main()
 	uv1 = uv1_tmp.xy / uv1_tmp.w;
 	vec4 uv2_tmp = textureMatrix2 * vec4(dot(paramx2, vertex), dot(paramy2, vertex), 0., 1.);
 	uv2 = uv2_tmp.xy / uv2_tmp.w;
+
+	normal = normalize(mat3(transpose(inverse(ModelViewMatrix))) * vertexNormal); // TODO: NormalMatrix
+	vec3 eyeVec = normalize((ModelViewMatrix * vertex).xyz);
+	lightDir = normalize(sunPosition.xyz);
+	halfVec = lightDir + eyeVec;
+
 	vertexDistance = position.z;
 	gl_Position.y *= -1.;
 	gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0;

--- a/data/base/shaders/vk/terrain.vert
+++ b/data/base/shaders/vk/terrain.vert
@@ -14,6 +14,7 @@ layout(std140, set = 0, binding = 0) uniform cbuffer {
 	int fogEnabled; // whether fog is enabled
 	float fogEnd;
 	float fogStart;
+	int quality;
 	int hasNormalmap;
 	int hasSpecularmap;
 	int hasHeightmap;
@@ -23,7 +24,7 @@ layout(location = 0) in vec4 vertex;
 layout(location = 2) in vec4 vertexColor;
 layout(location = 3) in vec3 vertexNormal;
 
-layout(location = 0) out vec4 color;
+layout(location = 0) out float colora;
 layout(location = 1) out vec2 uv;
 layout(location = 2) out vec2 uvLight;
 layout(location = 3) out float vertexDistance;
@@ -33,7 +34,7 @@ layout(location = 5) out vec3 halfVec;
 
 void main()
 {
-	color = vertexColor;
+	colora = vertexColor.a;
 
 	uv = (ModelUVMatrix * vertex).xy;
 	uvLight = (ModelUVLightMatrix * vertex).xy;

--- a/data/base/shaders/vk/terrain.vert
+++ b/data/base/shaders/vk/terrain.vert
@@ -16,6 +16,7 @@ layout(std140, set = 0, binding = 0) uniform cbuffer {
 	float fogStart;
 	int hasNormalmap;
 	int hasSpecularmap;
+	int hasHeightmap;
 };
 
 layout(location = 0) in vec4 vertex;

--- a/data/base/shaders/vk/terrain.vert
+++ b/data/base/shaders/vk/terrain.vert
@@ -5,6 +5,7 @@ layout(std140, set = 0, binding = 0) uniform cbuffer {
 	mat4 textureMatrix2;
 	mat4 ModelViewMatrix;
 	mat4 ModelViewProjectionMatrix;
+	mat4 NormalMatrix;
 	vec4 sunPosition; // In EyeSpace
 	vec4 paramx1; // for textures
 	vec4 paramy1;
@@ -42,10 +43,10 @@ void main()
 	vec4 uv2_tmp = textureMatrix2 * vec4(dot(paramx2, vertex), dot(paramy2, vertex), 0., 1.);
 	uv2 = uv2_tmp.xy / uv2_tmp.w;
 
-	mat3 NormalMatrix = mat3(transpose(inverse(ModelViewMatrix))); // TODO: NormalMatrix
 	// constructing EyeSpace -> TangentSpace mat3
-	vec3 normal = normalize(NormalMatrix * vertexNormal);
-	vec3 tangent = normalize(cross(normal, NormalMatrix * paramy1.xyz));
+	mat3 normalMat = mat3(NormalMatrix);
+	vec3 normal = normalize(normalMat * vertexNormal);
+	vec3 tangent = normalize(cross(normal, normalMat * paramy1.xyz));
 	vec3 bitangent = cross(normal, tangent);
 	mat3 eyeTangentMatrix = mat3(tangent, bitangent, normal); // aka TBN-matrix
 	// transform light to TangentSpace:

--- a/data/base/shaders/vk/terrain_water.vert
+++ b/data/base/shaders/vk/terrain_water.vert
@@ -14,7 +14,7 @@ layout(std140, set = 0, binding = 0) uniform cbuffer {
 	int fogEnabled; // whether fog is enabled
 	float fogEnd;
 	float fogStart;
-	float time; // in seconds
+	float timeSec;
 };
 
 layout(location = 0) in vec4 vertex; // .w is depth
@@ -30,7 +30,7 @@ void main()
 {
 	depth = vertex.w;
 
-	uv1 = vec2(vertex.x/4/128 + time/10, -vertex.z/4/128); // (ModelUV1Matrix * vertex).xy;
+	uv1 = vec2(vertex.x/4/128 + timeSec/10, -vertex.z/4/128); // (ModelUV1Matrix * vertex).xy;
 	uv2 = vec2(vertex.x/5/128, -vertex.z/5/128); // (ModelUV2Matrix * vertex).xy;
 
 	vec3 eyeVec = normalize(cameraPos.xyz - vertex.xyz);

--- a/data/base/shaders/vk/terrain_water.vert
+++ b/data/base/shaders/vk/terrain_water.vert
@@ -15,6 +15,7 @@ layout(std140, set = 0, binding = 0) uniform cbuffer {
 	float fogEnd;
 	float fogStart;
 	float timeSec;
+	int quality;
 };
 
 layout(location = 0) in vec4 vertex; // .w is depth

--- a/data/base/shaders/vk/terrain_water.vert
+++ b/data/base/shaders/vk/terrain_water.vert
@@ -2,36 +2,44 @@
 
 layout(std140, set = 0, binding = 0) uniform cbuffer {
 	mat4 ModelViewProjectionMatrix;
-	vec4 paramx1;
-	vec4 paramy1;
-	vec4 paramx2;
-	vec4 paramy2;
-	mat4 textureMatrix1;
-	mat4 textureMatrix2;
+	mat4 ModelUV1Matrix;
+	mat4 ModelUV2Matrix;
+	vec4 cameraPos; // in modelSpace
+	vec4 sunPos; // in modelSpace, normalized
+	vec4 emissiveLight; // light colors/intensity
+	vec4 ambientLight;
+	vec4 diffuseLight;
+	vec4 specularLight;
 	vec4 fogColor;
 	int fogEnabled; // whether fog is enabled
 	float fogEnd;
 	float fogStart;
+	float time; // in seconds
 };
 
-layout(location = 0) in vec4 vertex;
-//layout(location = 2) in vec4 vertexColor;
+layout(location = 0) in vec4 vertex; // .w is depth
 
-//layout(location = 0) out vec4 color;
 layout(location = 1) out vec2 uv1;
 layout(location = 2) out vec2 uv2;
 layout(location = 3) out float vertexDistance;
+layout(location = 4) out vec3 lightDir;
+layout(location = 5) out vec3 halfVec;
+layout(location = 6) out float depth;
 
 void main()
 {
-//	color = vertexColor;
-	vec4 position = ModelViewProjectionMatrix * vertex;
-	gl_Position = position;
-	vec4 uv1_tmp = textureMatrix1 * vec4(dot(paramx1, vertex), dot(paramy1, vertex), 0., 1.);
-	uv1 = uv1_tmp.xy / uv1_tmp.w;
-	vec4 uv2_tmp = textureMatrix2 * vec4(dot(paramx2, vertex), dot(paramy2, vertex), 0., 1.);
-	uv2 = uv2_tmp.xy / uv2_tmp.w;
+	depth = vertex.w;
+
+	uv1 = vec2(vertex.x/4/128 + time/10, -vertex.z/4/128); // (ModelUV1Matrix * vertex).xy;
+	uv2 = vec2(vertex.x/5/128, -vertex.z/5/128); // (ModelUV2Matrix * vertex).xy;
+
+	vec3 eyeVec = normalize(cameraPos.xyz - vertex.xyz);
+	lightDir = sunPos.xyz;
+	halfVec = lightDir + eyeVec;
+
+	vec4 position = ModelViewProjectionMatrix * vec4(vertex.xyz, 1);
 	vertexDistance = position.z;
+	gl_Position = position;
 	gl_Position.y *= -1.;
 	gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0;
 }

--- a/data/base/shaders/vk/water.frag
+++ b/data/base/shaders/vk/water.frag
@@ -2,32 +2,61 @@
 
 layout(set = 1, binding = 0) uniform sampler2D tex1;
 layout(set = 1, binding = 1) uniform sampler2D tex2;
+layout(set = 1, binding = 2) uniform sampler2D tex1_nm;
+layout(set = 1, binding = 3) uniform sampler2D tex2_nm;
+layout(set = 1, binding = 4) uniform sampler2D tex1_sm;
+layout(set = 1, binding = 5) uniform sampler2D tex2_sm;
 
 layout(std140, set = 0, binding = 0) uniform cbuffer {
 	mat4 ModelViewProjectionMatrix;
-	vec4 paramx1;
-	vec4 paramy1;
-	vec4 paramx2;
-	vec4 paramy2;
-	mat4 textureMatrix1;
-	mat4 textureMatrix2;
+	mat4 ModelUV1Matrix;
+	mat4 ModelUV2Matrix;
+	vec4 cameraPos; // in modelSpace
+	vec4 sunPos; // in modelSpace, normalized
+	vec4 emissiveLight; // light colors/intensity
+	vec4 ambientLight;
+	vec4 diffuseLight;
+	vec4 specularLight;
 	vec4 fogColor;
 	int fogEnabled; // whether fog is enabled
 	float fogEnd;
 	float fogStart;
+	float time; // in seconds
 };
 
-//layout(location = 0) in vec4 color;
 layout(location = 1) in vec2 uv1;
 layout(location = 2) in vec2 uv2;
 layout(location = 3) in float vertexDistance;
+layout(location = 4) in vec3 lightDir;
+layout(location = 5) in vec3 halfVec;
+layout(location = 6) in float depth;
 
 layout(location = 0) out vec4 FragColor;
 
 void main()
 {
 	vec4 fragColor = texture(tex1, uv1) * texture(tex2, uv2);
-	
+
+	vec3 N = texture(tex1_nm, uv1).xzy; // y is up in modelSpace
+	if (N == vec3(0,0,0)) {
+		N = vec3(0,1,0);
+	} else {
+		N = normalize(N * 2.0 - 1.0);
+	}
+	vec3 L = normalize(lightDir);
+	float lambertTerm = max(dot(N, L), 0.0); // diffuse lighting
+
+	// Gaussian specular term computation
+	vec3 H = normalize(halfVec);
+	float angle = acos(dot(H, N));
+	float exponent = angle / 0.2;
+	exponent = -(exponent * exponent);
+	float gaussianTerm = exp(exponent) * float(lambertTerm > 0);
+
+	vec4 gloss = texture(tex1_sm, uv1) * texture(tex2_sm, uv2);
+
+	fragColor = fragColor*(ambientLight + diffuseLight*lambertTerm) + specularLight*gloss*gaussianTerm;
+
 	if (fogEnabled > 0)
 	{
 		// Calculate linear fog

--- a/data/base/shaders/vk/water.frag
+++ b/data/base/shaders/vk/water.frag
@@ -23,7 +23,7 @@ layout(std140, set = 0, binding = 0) uniform cbuffer {
 	int fogEnabled; // whether fog is enabled
 	float fogEnd;
 	float fogStart;
-	float time; // in seconds
+	float timeSec;
 };
 
 layout(location = 1) in vec2 uv1;
@@ -45,8 +45,7 @@ void main()
 	} else {
 		N = normalize(N * 2.0 - 1.0);
 	}
-	vec3 L = normalize(lightDir);
-	float lambertTerm = max(dot(N, L), 0.0); // diffuse lighting
+	float lambertTerm = max(dot(N, lightDir), 0.0); // diffuse lighting
 
 	// Gaussian specular term computation
 	vec3 H = normalize(halfVec);

--- a/data/base/shaders/vk/water.frag
+++ b/data/base/shaders/vk/water.frag
@@ -6,6 +6,8 @@ layout(set = 1, binding = 2) uniform sampler2D tex1_nm;
 layout(set = 1, binding = 3) uniform sampler2D tex2_nm;
 layout(set = 1, binding = 4) uniform sampler2D tex1_sm;
 layout(set = 1, binding = 5) uniform sampler2D tex2_sm;
+layout(set = 1, binding = 6) uniform sampler2D tex1_hm;
+layout(set = 1, binding = 7) uniform sampler2D tex2_hm;
 
 layout(std140, set = 0, binding = 0) uniform cbuffer {
 	mat4 ModelViewProjectionMatrix;

--- a/data/base/shaders/vk/water.frag
+++ b/data/base/shaders/vk/water.frag
@@ -58,7 +58,7 @@ vec4 main_bumpMapping()
 	float exponent = acos(dot(H, N)) / 0.2;
 	float gaussianTerm = exp(-(exponent * exponent)) * float(lambertTerm > 0);
 
-	vec4 gloss = texture(tex1_sm, uv1) * texture(tex2_sm, uv2);
+	vec4 gloss = vec4(vec3(texture(tex1_sm, uv1).r), 1) * vec4(vec3(texture(tex2_sm, uv2).r), 1);
 
 	return fragColor*(ambientLight*0.5 + diffuseLight*lambertTerm) + specularLight*gloss*gaussianTerm;
 }

--- a/data/base/shaders/water.frag
+++ b/data/base/shaders/water.frag
@@ -60,8 +60,7 @@ void main()
 	} else {
 		N = normalize(N * 2.0 - 1.0);
 	}
-	vec3 L = normalize(lightDir);
-	float lambertTerm = max(dot(N, L), 0.0); // diffuse lighting
+	float lambertTerm = max(dot(N, lightDir), 0.0); // diffuse lighting
 
 	// Gaussian specular term computation
 	vec3 H = normalize(halfVec);

--- a/data/base/shaders/water.frag
+++ b/data/base/shaders/water.frag
@@ -7,6 +7,8 @@ uniform sampler2D tex1_nm;
 uniform sampler2D tex2_nm;
 uniform sampler2D tex1_sm;
 uniform sampler2D tex2_sm;
+uniform sampler2D tex1_hm;
+uniform sampler2D tex2_hm;
 
 // light colors/intensity:
 uniform vec4 emissiveLight;

--- a/data/base/shaders/water.frag
+++ b/data/base/shaders/water.frag
@@ -29,7 +29,7 @@ uniform vec4 fogColor;
 in vec2 uv1;
 in vec2 uv2;
 in float vertexDistance;
-// light in tangent space:
+// light in modelSpace:
 in vec3 lightDir;
 in vec3 halfVec;
 #else
@@ -50,9 +50,11 @@ void main()
 {
 	vec4 fragColor = texture(tex1, uv1) * texture(tex2, uv2);
 
-	vec3 N = normalize(texture(tex1_nm, uv1).xyz * 2.0 - 1.0);
-	if (N == vec3(-1,-1,-1)) {
-		N = vec3(0,0,1);
+	vec3 N = texture(tex1_nm, uv1).xzy; // y is up in modelSpace
+	if (N == vec3(0,0,0)) {
+		N = vec3(0,1,0);
+	} else {
+		N = normalize(N * 2.0 - 1.0);
 	}
 	vec3 L = normalize(lightDir);
 	float lambertTerm = max(dot(N, L), 0.0); // diffuse lighting
@@ -64,7 +66,7 @@ void main()
 	exponent = -(exponent * exponent);
 	float gaussianTerm = exp(exponent) * float(lambertTerm > 0);
 
-	vec4 gloss = texture(tex1_sm, uv1);
+	vec4 gloss = texture(tex1_sm, uv1) * texture(tex2_sm, uv2);
 
 	fragColor = fragColor*(ambientLight + diffuseLight*lambertTerm) + specularLight*gloss*gaussianTerm;
 

--- a/data/base/shaders/water.frag
+++ b/data/base/shaders/water.frag
@@ -28,6 +28,7 @@ uniform vec4 fogColor;
 #ifdef NEWGL
 in vec2 uv1;
 in vec2 uv2;
+in float depth;
 in float vertexDistance;
 // light in modelSpace:
 in vec3 lightDir;
@@ -35,6 +36,7 @@ in vec3 halfVec;
 #else
 varying vec2 uv1;
 varying vec2 uv2;
+varying float depth;
 varying float vertexDistance;
 varying vec3 lightDir;
 varying vec3 halfVec;

--- a/data/base/shaders/water.frag
+++ b/data/base/shaders/water.frag
@@ -74,7 +74,7 @@ vec4 main_bumpMapping()
 	float exponent = acos(dot(H, N)) / 0.2;
 	float gaussianTerm = exp(-(exponent * exponent)) * float(lambertTerm > 0);
 
-	vec4 gloss = texture(tex1_sm, uv1) * texture(tex2_sm, uv2);
+	vec4 gloss = vec4(vec3(texture(tex1_sm, uv1).r), 1) * vec4(vec3(texture(tex2_sm, uv2).r), 1);
 
 	return fragColor*(ambientLight*0.5 + diffuseLight*lambertTerm) + specularLight*gloss*gaussianTerm;
 }

--- a/lib/ivis_opengl/gfx_api.h
+++ b/lib/ivis_opengl/gfx_api.h
@@ -689,8 +689,8 @@ namespace gfx_api
 		glm::mat4 ModelViewProjectionMatrix;
 		glm::mat4 ModelUVMatrix;
 		glm::mat4 ModelUVLightMatrix;
-		glm::vec3 cameraPos; // in modelSpace
-		glm::vec3 sunPos; // in modelSpace
+		glm::vec4 cameraPos; // in modelSpace
+		glm::vec4 sunPos; // in modelSpace
 		glm::vec4 emissiveLight; // light colors/intensity
 		glm::vec4 ambientLight;
 		glm::vec4 diffuseLight;
@@ -721,8 +721,8 @@ namespace gfx_api
 	{
 		glm::mat4 ModelViewProjectionMatrix;
 		glm::mat4 ModelUVLightmapMatrix;
-		glm::vec3 cameraPos; // in modelSpace
-		glm::vec3 sunPos; // in modelSpace
+		glm::vec4 cameraPos; // in modelSpace
+		glm::vec4 sunPos; // in modelSpace
 		glm::vec4 emissiveLight; // light colors/intensity
 		glm::vec4 ambientLight;
 		glm::vec4 diffuseLight;
@@ -756,9 +756,8 @@ namespace gfx_api
 		glm::mat4 ModelViewProjectionMatrix;
 		glm::mat4 ModelUV1Matrix;
 		glm::mat4 ModelUV2Matrix;
-		float time; // in seconds
-		glm::vec3 cameraPos; // in modelSpace
-		glm::vec3 sunPos; // in modelSpace
+		glm::vec4 cameraPos; // in modelSpace
+		glm::vec4 sunPos; // in modelSpace
 		glm::vec4 emissiveLight; // light colors/intensity
 		glm::vec4 ambientLight;
 		glm::vec4 diffuseLight;
@@ -767,6 +766,7 @@ namespace gfx_api
 		int fog_enabled;
 		float fog_begin;
 		float fog_end;
+		float time; // in seconds
 	};
 
 	using WaterPSO = typename gfx_api::pipeline_state_helper<rasterizer_state<REND_MULTIPLICATIVE, DEPTH_CMP_LEQ_WRT_OFF, 255, polygon_offset::disabled, stencil_mode::stencil_disabled, cull_mode::back>, primitive_type::triangles, index_type::u32,

--- a/lib/ivis_opengl/gfx_api.h
+++ b/lib/ivis_opengl/gfx_api.h
@@ -781,7 +781,7 @@ namespace gfx_api
 	using WaterPSO = typename gfx_api::pipeline_state_helper<rasterizer_state<REND_MULTIPLICATIVE, DEPTH_CMP_LEQ_WRT_OFF, 255, polygon_offset::disabled, stencil_mode::stencil_disabled, cull_mode::back>, primitive_type::triangles, index_type::u32,
 	std::tuple<constant_buffer_type<SHADER_WATER>>,
 	std::tuple<
-	vertex_buffer_description<12, vertex_attribute_description<position, gfx_api::vertex_attribute_type::float3, 0>>
+	vertex_buffer_description<sizeof(glm::vec4), vertex_attribute_description<position, gfx_api::vertex_attribute_type::float4, 0>> // WaterVertex, w is depth
 	>, std::tuple<
 	texture_description<0, sampler_type::anisotropic_repeat>, // tex1
 	texture_description<1, sampler_type::anisotropic_repeat>, // tex2

--- a/lib/ivis_opengl/gfx_api.h
+++ b/lib/ivis_opengl/gfx_api.h
@@ -381,6 +381,11 @@ namespace gfx_api
 
 		void bind()
 		{
+			if (this->nextpso != nullptr) {
+				delete this->pso;
+				this->pso = this->nextpso;
+				this->nextpso = nullptr;
+			}
 			gfx_api::context::get().bind_pipeline(pso, std::tuple_size<texture_inputs>::value == 0);
 		}
 
@@ -436,8 +441,14 @@ namespace gfx_api
 		{
 			context::get().draw_elements(offset, count, primitive, index);
 		}
+
+		void recompile()
+		{
+			this->nextpso = gfx_api::context::get().build_pipeline(rasterizer::get(), shader, primitive, untuple_typeinfo(uniform_inputs{}), untuple<texture_input>(texture_inputs{}), untuple<vertex_buffer>(vertex_buffer_inputs{}));
+		}
 	private:
 		pipeline_state_object* pso;
+		pipeline_state_object* nextpso = nullptr;
 		pipeline_state_helper()
 		{
 			pso = gfx_api::context::get().build_pipeline(rasterizer::get(), shader, primitive, untuple_typeinfo(uniform_inputs{}), untuple<texture_input>(texture_inputs{}), untuple<vertex_buffer>(vertex_buffer_inputs{}));

--- a/lib/ivis_opengl/gfx_api.h
+++ b/lib/ivis_opengl/gfx_api.h
@@ -686,12 +686,11 @@ namespace gfx_api
 	template<>
 	struct constant_buffer_type<SHADER_TERRAIN>
 	{
+		glm::mat4 ModelViewProjectionMatrix;
 		glm::mat4 ModelUVMatrix;
 		glm::mat4 ModelUVLightMatrix;
-		glm::mat4 ModelViewMatrix;
-		glm::mat4 ModelViewProjectionMatrix;
-		glm::mat4 ModelViewNormalMatrix; // ModelViewMatrix for normals
-		glm::vec4 sunPosition;
+		glm::vec3 cameraPos; // in modelSpace
+		glm::vec3 sunPos; // in modelSpace
 		glm::vec4 emissiveLight; // light colors/intensity
 		glm::vec4 ambientLight;
 		glm::vec4 diffuseLight;
@@ -700,8 +699,6 @@ namespace gfx_api
 		int fog_enabled;
 		float fog_begin;
 		float fog_end;
-		int texture0;
-		int texture1;
 		int hasNormalmap;
 		int hasSpecularmap;
 	};
@@ -722,11 +719,10 @@ namespace gfx_api
 	template<>
 	struct constant_buffer_type<SHADER_DECALS>
 	{
-		glm::mat4 ModelViewMatrix;
-		glm::mat4 ModelViewNormalMatrix; // ModelViewMatrix for normals
 		glm::mat4 ModelViewProjectionMatrix;
 		glm::mat4 ModelUVLightmapMatrix;
-		glm::vec4 sunPosition;
+		glm::vec3 cameraPos; // in modelSpace
+		glm::vec3 sunPos; // in modelSpace
 		glm::vec4 emissiveLight; // light colors/intensity
 		glm::vec4 ambientLight;
 		glm::vec4 diffuseLight;
@@ -735,8 +731,6 @@ namespace gfx_api
 		int fog_enabled;
 		float fog_begin;
 		float fog_end;
-		int texture0;
-		int texture1;
 	};
 
 	using TerrainDecals = typename gfx_api::pipeline_state_helper<rasterizer_state<REND_ALPHA, DEPTH_CMP_LEQ_WRT_OFF, 255, polygon_offset::disabled, stencil_mode::stencil_disabled, cull_mode::back>, primitive_type::triangles, index_type::u16,
@@ -760,14 +754,11 @@ namespace gfx_api
 	struct constant_buffer_type<SHADER_WATER>
 	{
 		glm::mat4 ModelViewProjectionMatrix;
-		glm::mat4 ModelViewMatrix;
-		glm::mat4 ModelViewNormalMatrix;
 		glm::mat4 ModelUV1Matrix;
 		glm::mat4 ModelUV2Matrix;
 		float time; // in seconds
 		glm::vec3 cameraPos; // in modelSpace
 		glm::vec3 sunPos; // in modelSpace
-		glm::vec3 sunPosInView; // in viewSpace
 		glm::vec4 emissiveLight; // light colors/intensity
 		glm::vec4 ambientLight;
 		glm::vec4 diffuseLight;

--- a/lib/ivis_opengl/gfx_api.h
+++ b/lib/ivis_opengl/gfx_api.h
@@ -383,7 +383,7 @@ namespace gfx_api
 		void bind()
 		{
 			if (this->nextpso != nullptr) {
-				delete this->pso;
+				if (this->pso != nullptr) delete this->pso;
 				this->pso = this->nextpso;
 				this->nextpso = nullptr;
 			}
@@ -448,11 +448,11 @@ namespace gfx_api
 			this->nextpso = gfx_api::context::get().build_pipeline(rasterizer::get(), shader, primitive, untuple_typeinfo(uniform_inputs{}), untuple<texture_input>(texture_inputs{}), untuple<vertex_buffer>(vertex_buffer_inputs{}));
 		}
 	private:
-		pipeline_state_object* pso;
+		pipeline_state_object* pso = nullptr;
 		pipeline_state_object* nextpso = nullptr;
 		pipeline_state_helper()
 		{
-			pso = gfx_api::context::get().build_pipeline(rasterizer::get(), shader, primitive, untuple_typeinfo(uniform_inputs{}), untuple<texture_input>(texture_inputs{}), untuple<vertex_buffer>(vertex_buffer_inputs{}));
+			recompile();
 		}
 
 //		// Requires C++14 (+)
@@ -771,7 +771,7 @@ namespace gfx_api
 		int fog_enabled;
 		float fog_begin;
 		float fog_end;
-		float time; // in seconds
+		float timeSec;
 	};
 
 	using WaterPSO = typename gfx_api::pipeline_state_helper<rasterizer_state<REND_MULTIPLICATIVE, DEPTH_CMP_LEQ_WRT_OFF, 255, polygon_offset::disabled, stencil_mode::stencil_disabled, cull_mode::back>, primitive_type::triangles, index_type::u32,

--- a/lib/ivis_opengl/gfx_api.h
+++ b/lib/ivis_opengl/gfx_api.h
@@ -711,10 +711,15 @@ namespace gfx_api
 	template<>
 	struct constant_buffer_type<SHADER_DECALS>
 	{
-		glm::mat4 transform_matrix;
-		glm::mat4 texture_matrix;
-		glm::vec4 param1;
-		glm::vec4 param2;
+		glm::mat4 ModelViewMatrix;
+		glm::mat4 ModelViewNormalMatrix; // ModelViewMatrix for normals
+		glm::mat4 ModelViewProjectionMatrix;
+		glm::mat4 ModelUVLightmapMatrix;
+		glm::vec4 sunPosition;
+		glm::vec4 emissiveLight; // light colors/intensity
+		glm::vec4 ambientLight;
+		glm::vec4 diffuseLight;
+		glm::vec4 specularLight;
 		glm::vec4 fog_colour;
 		int fog_enabled;
 		float fog_begin;
@@ -726,11 +731,18 @@ namespace gfx_api
 	using TerrainDecals = typename gfx_api::pipeline_state_helper<rasterizer_state<REND_ALPHA, DEPTH_CMP_LEQ_WRT_OFF, 255, polygon_offset::disabled, stencil_mode::stencil_disabled, cull_mode::back>, primitive_type::triangles, index_type::u16,
 	std::tuple<constant_buffer_type<SHADER_DECALS>>,
 	std::tuple<
-	vertex_buffer_description<sizeof(glm::vec3) + sizeof(glm::vec2),
+	vertex_buffer_description<2*sizeof(glm::vec3) + sizeof(glm::vec2) + sizeof(glm::vec4), // DecalVertex struct
 	vertex_attribute_description<position, gfx_api::vertex_attribute_type::float3, 0>,
-	vertex_attribute_description<texcoord, gfx_api::vertex_attribute_type::float2, sizeof(glm::vec3)>
+	vertex_attribute_description<texcoord, gfx_api::vertex_attribute_type::float2, sizeof(glm::vec3)>,
+	vertex_attribute_description<normal,   gfx_api::vertex_attribute_type::float3, sizeof(glm::vec3) + sizeof(glm::vec2)>,
+	vertex_attribute_description<tangent,  gfx_api::vertex_attribute_type::float4, 2*sizeof(glm::vec3) + sizeof(glm::vec2)>
 	>
-	>, std::tuple<texture_description<0, sampler_type::anisotropic>, texture_description<1, sampler_type::bilinear>>, SHADER_DECALS>;
+	>, std::tuple<
+	texture_description<0, sampler_type::anisotropic>,
+	texture_description<1, sampler_type::bilinear>,
+	texture_description<2, sampler_type::anisotropic>, // normal map
+	texture_description<3, sampler_type::anisotropic>  // specular map
+	>, SHADER_DECALS>;
 
 	template<>
 	struct constant_buffer_type<SHADER_WATER>

--- a/lib/ivis_opengl/gfx_api.h
+++ b/lib/ivis_opengl/gfx_api.h
@@ -675,16 +675,16 @@ namespace gfx_api
 	template<>
 	struct constant_buffer_type<SHADER_TERRAIN>
 	{
-		glm::mat4 textureMatrix1;
-		glm::mat4 textureMatrix2;
+		glm::mat4 ModelUVMatrix;
+		glm::mat4 ModelUVLightMatrix;
 		glm::mat4 ModelViewMatrix;
 		glm::mat4 ModelViewProjectionMatrix;
-		glm::mat4 NormalMatrix; // ModelViewMatrix for normals
+		glm::mat4 ModelViewNormalMatrix; // ModelViewMatrix for normals
 		glm::vec4 sunPosition;
-		glm::vec4 paramX;
-		glm::vec4 paramY;
-		glm::vec4 paramXLight;
-		glm::vec4 paramYLight;
+		glm::vec4 emissiveLight; // light colors/intensity
+		glm::vec4 ambientLight;
+		glm::vec4 diffuseLight;
+		glm::vec4 specularLight;
 		glm::vec4 fog_colour;
 		int fog_enabled;
 		float fog_begin;

--- a/lib/ivis_opengl/gfx_api.h
+++ b/lib/ivis_opengl/gfx_api.h
@@ -701,6 +701,7 @@ namespace gfx_api
 		int fog_enabled;
 		float fog_begin;
 		float fog_end;
+		int quality;
 		int hasNormalmap;
 		int hasSpecularmap;
 		int hasHeightmap;
@@ -735,6 +736,7 @@ namespace gfx_api
 		int fog_enabled;
 		float fog_begin;
 		float fog_end;
+		int quality;
 	};
 
 	using TerrainDecals = typename gfx_api::pipeline_state_helper<rasterizer_state<REND_ALPHA, DEPTH_CMP_LEQ_WRT_OFF, 255, polygon_offset::disabled, stencil_mode::stencil_disabled, cull_mode::back>, primitive_type::triangles, index_type::u16,
@@ -772,6 +774,7 @@ namespace gfx_api
 		float fog_begin;
 		float fog_end;
 		float timeSec;
+		int quality;
 	};
 
 	using WaterPSO = typename gfx_api::pipeline_state_helper<rasterizer_state<REND_MULTIPLICATIVE, DEPTH_CMP_LEQ_WRT_OFF, 255, polygon_offset::disabled, stencil_mode::stencil_disabled, cull_mode::back>, primitive_type::triangles, index_type::u32,

--- a/lib/ivis_opengl/gfx_api.h
+++ b/lib/ivis_opengl/gfx_api.h
@@ -741,7 +741,8 @@ namespace gfx_api
 	texture_description<0, sampler_type::anisotropic>,
 	texture_description<1, sampler_type::bilinear>,
 	texture_description<2, sampler_type::anisotropic>, // normal map
-	texture_description<3, sampler_type::anisotropic>  // specular map
+	texture_description<3, sampler_type::anisotropic>, // specular map
+	texture_description<4, sampler_type::anisotropic>  // height map
 	>, SHADER_DECALS>;
 
 	template<>

--- a/lib/ivis_opengl/gfx_api.h
+++ b/lib/ivis_opengl/gfx_api.h
@@ -679,6 +679,7 @@ namespace gfx_api
 		glm::mat4 textureMatrix2;
 		glm::mat4 ModelViewMatrix;
 		glm::mat4 ModelViewProjectionMatrix;
+		glm::mat4 NormalMatrix; // ModelViewMatrix for normals
 		glm::vec4 sunPosition;
 		glm::vec4 paramX;
 		glm::vec4 paramY;

--- a/lib/ivis_opengl/gfx_api.h
+++ b/lib/ivis_opengl/gfx_api.h
@@ -748,26 +748,34 @@ namespace gfx_api
 	template<>
 	struct constant_buffer_type<SHADER_WATER>
 	{
-		glm::mat4 transform_matrix;
-		glm::vec4 param1;
-		glm::vec4 param2;
-		glm::vec4 param3;
-		glm::vec4 param4;
-		glm::mat4 translation;
-		glm::mat4 texture_matrix;
+		glm::mat4 ModelViewProjectionMatrix;
+		glm::mat3 ModelTangentMatrix;
+		glm::mat4 ModelUV1Matrix;
+		glm::mat4 ModelUV2Matrix;
+		glm::vec3 cameraPos; // in modelSpace
+		glm::vec3 lightDirInTangent; // in tangentSpace
+		glm::vec4 emissiveLight; // light colors/intensity
+		glm::vec4 ambientLight;
+		glm::vec4 diffuseLight;
+		glm::vec4 specularLight;
 		glm::vec4 fog_colour;
 		int fog_enabled;
 		float fog_begin;
 		float fog_end;
-		int texture0;
-		int texture1;
 	};
 
 	using WaterPSO = typename gfx_api::pipeline_state_helper<rasterizer_state<REND_MULTIPLICATIVE, DEPTH_CMP_LEQ_WRT_OFF, 255, polygon_offset::disabled, stencil_mode::stencil_disabled, cull_mode::back>, primitive_type::triangles, index_type::u32,
 	std::tuple<constant_buffer_type<SHADER_WATER>>,
 	std::tuple<
 	vertex_buffer_description<12, vertex_attribute_description<position, gfx_api::vertex_attribute_type::float3, 0>>
-	>, std::tuple<texture_description<0, sampler_type::anisotropic_repeat>, texture_description<1, sampler_type::anisotropic_repeat>>, SHADER_WATER>;
+	>, std::tuple<
+	texture_description<0, sampler_type::anisotropic_repeat>, // tex1
+	texture_description<1, sampler_type::anisotropic_repeat>, // tex2
+	texture_description<2, sampler_type::anisotropic_repeat>, // normal map1
+	texture_description<3, sampler_type::anisotropic_repeat>, // normal map2
+	texture_description<4, sampler_type::anisotropic_repeat>, // specular map1
+	texture_description<5, sampler_type::anisotropic_repeat>  // specular map2
+	>, SHADER_WATER>;
 
 	using gfx_tc = vertex_buffer_description<8, vertex_attribute_description<texcoord, gfx_api::vertex_attribute_type::float2, 0>>;
 	using gfx_colour = vertex_buffer_description<4, vertex_attribute_description<color, gfx_api::vertex_attribute_type::u8x4_norm, 0>>;

--- a/lib/ivis_opengl/gfx_api.h
+++ b/lib/ivis_opengl/gfx_api.h
@@ -701,6 +701,7 @@ namespace gfx_api
 		float fog_end;
 		int hasNormalmap;
 		int hasSpecularmap;
+		int hasHeightmap;
 	};
 
 	using TerrainLayer = typename gfx_api::pipeline_state_helper<rasterizer_state<REND_ADDITIVE, DEPTH_CMP_LEQ_WRT_OFF, 255, polygon_offset::disabled, stencil_mode::stencil_disabled, cull_mode::back>, primitive_type::triangles, index_type::u32,
@@ -713,7 +714,8 @@ namespace gfx_api
 	texture_description<0, sampler_type::anisotropic_repeat>,
 	texture_description<1, sampler_type::bilinear>,
 	texture_description<2, sampler_type::anisotropic_repeat>, // normal map
-	texture_description<3, sampler_type::anisotropic_repeat> // specular map
+	texture_description<3, sampler_type::anisotropic_repeat>, // specular map
+	texture_description<4, sampler_type::anisotropic_repeat> // height map
 	>, SHADER_TERRAIN>;
 
 	template<>

--- a/lib/ivis_opengl/gfx_api.h
+++ b/lib/ivis_opengl/gfx_api.h
@@ -698,12 +698,13 @@ namespace gfx_api
 	std::tuple<constant_buffer_type<SHADER_TERRAIN>>,
 	std::tuple<
 	vertex_buffer_description<12, vertex_attribute_description<position, gfx_api::vertex_attribute_type::float3, 0>>,
-	vertex_buffer_description<4, vertex_attribute_description<color, gfx_api::vertex_attribute_type::u8x4_norm, 0>>
+	vertex_buffer_description<4, vertex_attribute_description<color, gfx_api::vertex_attribute_type::u8x4_norm, 0>>,
+	vertex_buffer_description<12, vertex_attribute_description<normal, gfx_api::vertex_attribute_type::float3, 0>>
 	>, std::tuple<
 	texture_description<0, sampler_type::anisotropic_repeat>,
 	texture_description<1, sampler_type::bilinear>,
-	texture_description<2, sampler_type::anisotropic>, // normal map
-	texture_description<3, sampler_type::anisotropic> // specular map
+	texture_description<2, sampler_type::anisotropic_repeat>, // normal map
+	texture_description<3, sampler_type::anisotropic_repeat> // specular map
 	>, SHADER_TERRAIN>;
 
 	template<>

--- a/lib/ivis_opengl/gfx_api.h
+++ b/lib/ivis_opengl/gfx_api.h
@@ -204,6 +204,7 @@ namespace gfx_api
 		float3,
 		float4,
 		u8x4_norm,
+		int1,
 	};
 
 	struct vertex_buffer_input
@@ -486,6 +487,7 @@ namespace gfx_api
 	constexpr std::size_t color = 2;
 	constexpr std::size_t normal = 3;
 	constexpr std::size_t tangent = 4;
+	constexpr std::size_t tileNo = 5;
 
 	using notexture = std::tuple<>;
 
@@ -738,11 +740,12 @@ namespace gfx_api
 	using TerrainDecals = typename gfx_api::pipeline_state_helper<rasterizer_state<REND_ALPHA, DEPTH_CMP_LEQ_WRT_OFF, 255, polygon_offset::disabled, stencil_mode::stencil_disabled, cull_mode::back>, primitive_type::triangles, index_type::u16,
 	std::tuple<constant_buffer_type<SHADER_DECALS>>,
 	std::tuple<
-	vertex_buffer_description<2*sizeof(glm::vec3) + sizeof(glm::vec2) + sizeof(glm::vec4), // DecalVertex struct
+	vertex_buffer_description<2*sizeof(glm::vec3) + sizeof(glm::vec2) + sizeof(glm::vec4) + sizeof(int32_t), // DecalVertex struct
 	vertex_attribute_description<position, gfx_api::vertex_attribute_type::float3, 0>,
 	vertex_attribute_description<texcoord, gfx_api::vertex_attribute_type::float2, sizeof(glm::vec3)>,
 	vertex_attribute_description<normal,   gfx_api::vertex_attribute_type::float3, sizeof(glm::vec3) + sizeof(glm::vec2)>,
-	vertex_attribute_description<tangent,  gfx_api::vertex_attribute_type::float4, 2*sizeof(glm::vec3) + sizeof(glm::vec2)>
+	vertex_attribute_description<tangent,  gfx_api::vertex_attribute_type::float4, 2*sizeof(glm::vec3) + sizeof(glm::vec2)>,
+	vertex_attribute_description<tileNo,   gfx_api::vertex_attribute_type::int1,   2*sizeof(glm::vec3) + sizeof(glm::vec2) + sizeof(glm::vec4)>
 	>
 	>, std::tuple<
 	texture_description<0, sampler_type::anisotropic>,

--- a/lib/ivis_opengl/gfx_api.h
+++ b/lib/ivis_opengl/gfx_api.h
@@ -675,19 +675,23 @@ namespace gfx_api
 	template<>
 	struct constant_buffer_type<SHADER_TERRAIN>
 	{
-		glm::mat4 transform_matrix;
+		glm::mat4 textureMatrix1;
+		glm::mat4 textureMatrix2;
+		glm::mat4 ModelViewMatrix;
+		glm::mat4 ModelViewProjectionMatrix;
+		glm::vec4 sunPosition;
 		glm::vec4 paramX;
 		glm::vec4 paramY;
 		glm::vec4 paramXLight;
 		glm::vec4 paramYLight;
-		glm::mat4 unused;
-		glm::mat4 texture_matrix;
 		glm::vec4 fog_colour;
 		int fog_enabled;
 		float fog_begin;
 		float fog_end;
 		int texture0;
 		int texture1;
+		int hasNormalmap;
+		int hasSpecularmap;
 	};
 
 	using TerrainLayer = typename gfx_api::pipeline_state_helper<rasterizer_state<REND_ADDITIVE, DEPTH_CMP_LEQ_WRT_OFF, 255, polygon_offset::disabled, stencil_mode::stencil_disabled, cull_mode::back>, primitive_type::triangles, index_type::u32,
@@ -695,7 +699,12 @@ namespace gfx_api
 	std::tuple<
 	vertex_buffer_description<12, vertex_attribute_description<position, gfx_api::vertex_attribute_type::float3, 0>>,
 	vertex_buffer_description<4, vertex_attribute_description<color, gfx_api::vertex_attribute_type::u8x4_norm, 0>>
-	>, std::tuple<texture_description<0, sampler_type::anisotropic_repeat>, texture_description<1, sampler_type::bilinear>>, SHADER_TERRAIN>;
+	>, std::tuple<
+	texture_description<0, sampler_type::anisotropic_repeat>,
+	texture_description<1, sampler_type::bilinear>,
+	texture_description<2, sampler_type::anisotropic>, // normal map
+	texture_description<3, sampler_type::anisotropic> // specular map
+	>, SHADER_TERRAIN>;
 
 	template<>
 	struct constant_buffer_type<SHADER_DECALS>

--- a/lib/ivis_opengl/gfx_api.h
+++ b/lib/ivis_opengl/gfx_api.h
@@ -749,11 +749,14 @@ namespace gfx_api
 	struct constant_buffer_type<SHADER_WATER>
 	{
 		glm::mat4 ModelViewProjectionMatrix;
-		glm::mat3 ModelTangentMatrix;
+		glm::mat4 ModelViewMatrix;
+		glm::mat4 ModelViewNormalMatrix;
 		glm::mat4 ModelUV1Matrix;
 		glm::mat4 ModelUV2Matrix;
+		float time; // in seconds
 		glm::vec3 cameraPos; // in modelSpace
-		glm::vec3 lightDirInTangent; // in tangentSpace
+		glm::vec3 sunPos; // in modelSpace
+		glm::vec3 sunPosInView; // in viewSpace
 		glm::vec4 emissiveLight; // light colors/intensity
 		glm::vec4 ambientLight;
 		glm::vec4 diffuseLight;

--- a/lib/ivis_opengl/gfx_api.h
+++ b/lib/ivis_opengl/gfx_api.h
@@ -781,7 +781,9 @@ namespace gfx_api
 	texture_description<2, sampler_type::anisotropic_repeat>, // normal map1
 	texture_description<3, sampler_type::anisotropic_repeat>, // normal map2
 	texture_description<4, sampler_type::anisotropic_repeat>, // specular map1
-	texture_description<5, sampler_type::anisotropic_repeat>  // specular map2
+	texture_description<5, sampler_type::anisotropic_repeat>, // specular map2
+	texture_description<6, sampler_type::anisotropic_repeat>, // height map1
+	texture_description<7, sampler_type::anisotropic_repeat>  // height map2
 	>, SHADER_WATER>;
 
 	using gfx_tc = vertex_buffer_description<8, vertex_attribute_description<texcoord, gfx_api::vertex_attribute_type::float2, 0>>;

--- a/lib/ivis_opengl/gfx_api_gl.cpp
+++ b/lib/ivis_opengl/gfx_api_gl.cpp
@@ -331,7 +331,7 @@ static const std::map<SHADER_MODE, program_data> shader_to_file_table =
 			"fogColor", "fogEnabled", "fogEnd", "fogStart", "quality", "hasNormalmap", "hasSpecularmap", "hasHeightmap",
 			"tex", "lightmap_tex", "TextureNormal", "TextureSpecular", "TextureHeight"} }),
 	std::make_pair(SHADER_TERRAIN_DEPTH, program_data{ "terrain_depth program", "shaders/terrain_depth.vert", "shaders/terraindepth.frag",
-		{ "ModelViewProjectionMatrix", "paramx2", "paramy2", "lightmap_tex", "paramx2", "paramy2" } }),
+		{ "ModelViewProjectionMatrix", "paramx2", "paramy2", "lightmap_tex", "paramx2", "paramy2", "fogEnabled", "fogEnd", "fogStart" } }),
 	std::make_pair(SHADER_DECALS, program_data{ "decals program", "shaders/decals.vert", "shaders/decals.frag",
 		{ "ModelViewProjectionMatrix", "ModelUVLightmapMatrix",
 			"cameraPos", "sunPos", "emissiveLight", "ambientLight", "diffuseLight", "specularLight",

--- a/lib/ivis_opengl/gfx_api_gl.cpp
+++ b/lib/ivis_opengl/gfx_api_gl.cpp
@@ -637,6 +637,13 @@ desc(_desc), vertex_buffer_desc(_vertex_buffer_desc)
 	}
 }
 
+gl_pipeline_state_object::~gl_pipeline_state_object()
+{
+	if (this->vertexShader) glDeleteShader(this->vertexShader);
+	if (this->fragmentShader) glDeleteShader(this->fragmentShader);
+	glDeleteProgram(this->program);
+}
+
 void gl_pipeline_state_object::set_constants(const void* buffer, const size_t& size)
 {
 	uniform_bind_functions[0](buffer, size);
@@ -941,6 +948,7 @@ void gl_pipeline_state_object::build_program(bool fragmentHighpFloatAvailable, b
 		if ((vertexShaderContents = readShaderBuf(vertexPath)))
 		{
 			GLuint shader = glCreateShader(GL_VERTEX_SHADER);
+			vertexShader = shader;
 
 			const char* ShaderStrings[2] = { vertex_header, vertexShaderContents };
 
@@ -977,6 +985,7 @@ void gl_pipeline_state_object::build_program(bool fragmentHighpFloatAvailable, b
 		if ((fragmentShaderContents = readShaderBuf(fragmentPath)))
 		{
 			GLuint shader = glCreateShader(GL_FRAGMENT_SHADER);
+			fragmentShader = shader;
 
 			std::string fragmentShaderStr = fragmentShaderContents;
 			free(fragmentShaderContents);

--- a/lib/ivis_opengl/gfx_api_gl.cpp
+++ b/lib/ivis_opengl/gfx_api_gl.cpp
@@ -327,7 +327,7 @@ static const std::map<SHADER_MODE, program_data> shader_to_file_table =
 		} }),
 	std::make_pair(SHADER_TERRAIN, program_data{ "terrain program", "shaders/terrain.vert", "shaders/terrain.frag",
 		{ "textureMatrix1", "textureMatrix2",
-			"ModelViewMatrix", "ModelViewProjectionMatrix", "sunPosition", "paramx1", "paramy1", "paramx2", "paramy2", "tex", "lightmap_tex",
+			"ModelViewMatrix", "ModelViewProjectionMatrix", "NormalMatrix", "sunPosition", "paramx1", "paramy1", "paramx2", "paramy2", "tex", "lightmap_tex",
 			"fogColor", "fogEnabled", "fogEnd", "fogStart", "hasNormalmap", "hasSpecularmap" } }),
 	std::make_pair(SHADER_TERRAIN_DEPTH, program_data{ "terrain_depth program", "shaders/terrain_depth.vert", "shaders/terraindepth.frag",
 		{ "ModelViewProjectionMatrix", "paramx2", "paramy2", "lightmap_tex", "paramx2", "paramy2" } }),
@@ -1204,19 +1204,20 @@ void gl_pipeline_state_object::set_constants(const gfx_api::constant_buffer_type
 	setUniforms(1, cbuf.textureMatrix2);
 	setUniforms(2, cbuf.ModelViewMatrix);
 	setUniforms(3, cbuf.ModelViewProjectionMatrix);
-	setUniforms(4, cbuf.sunPosition);
-	setUniforms(5, cbuf.paramX);
-	setUniforms(6, cbuf.paramY);
-	setUniforms(7, cbuf.paramXLight);
-	setUniforms(8, cbuf.paramYLight);
-	setUniforms(9, cbuf.texture0);
-	setUniforms(10, cbuf.texture1);
-	setUniforms(11, cbuf.fog_colour);
-	setUniforms(12, cbuf.fog_enabled);
-	setUniforms(13, cbuf.fog_begin);
-	setUniforms(14, cbuf.fog_end);
-	setUniforms(15, cbuf.hasNormalmap);
-	setUniforms(16, cbuf.hasSpecularmap);
+	setUniforms(4, cbuf.NormalMatrix);
+	setUniforms(5, cbuf.sunPosition);
+	setUniforms(6, cbuf.paramX);
+	setUniforms(7, cbuf.paramY);
+	setUniforms(8, cbuf.paramXLight);
+	setUniforms(9, cbuf.paramYLight);
+	setUniforms(10, cbuf.texture0);
+	setUniforms(11, cbuf.texture1);
+	setUniforms(12, cbuf.fog_colour);
+	setUniforms(13, cbuf.fog_enabled);
+	setUniforms(14, cbuf.fog_begin);
+	setUniforms(15, cbuf.fog_end);
+	setUniforms(16, cbuf.hasNormalmap);
+	setUniforms(17, cbuf.hasSpecularmap);
 }
 
 void gl_pipeline_state_object::set_constants(const gfx_api::constant_buffer_type<SHADER_TERRAIN_DEPTH>& cbuf)

--- a/lib/ivis_opengl/gfx_api_gl.cpp
+++ b/lib/ivis_opengl/gfx_api_gl.cpp
@@ -336,8 +336,9 @@ static const std::map<SHADER_MODE, program_data> shader_to_file_table =
 			"sunPosition", "emissiveLight", "ambientLight", "diffuseLight", "specularLight",
 			"fogColor", "fogEnabled", "fogEnd", "fogStart", "tex", "lightmap_tex" } }),
 	std::make_pair(SHADER_WATER, program_data{ "water program", "shaders/terrain_water.vert", "shaders/water.frag",
-		{ "ModelViewProjectionMatrix", "ModelTangentMatrix", "ModelUV1", "ModelUV2",
-			"cameraPos", "lightDirInTangent", "emissiveLight", "ambientLight", "diffuseLight", "specularLight",
+		{ "ModelViewProjectionMatrix", "ModelViewMatrix", "ModelViewNormalMatrix", "ModelUV1Matrix", "ModelUV2Matrix",
+			"time", "cameraPos", "sunPos", "sunPosInView",
+			"emissiveLight", "ambientLight", "diffuseLight", "specularLight",
 			"fogColor", "fogEnabled", "fogEnd", "fogStart",
 			"tex1", "tex2", "tex1_nm", "tex2_nm", "tex1_sm", "tex2_sm" } }),
 	std::make_pair(SHADER_RECT, program_data{ "Rect program", "shaders/rect.vert", "shaders/rect.frag",
@@ -1279,11 +1280,14 @@ void gl_pipeline_state_object::set_constants(const gfx_api::constant_buffer_type
 {
 	int i = 0;
 	setUniforms(i++, cbuf.ModelViewProjectionMatrix);
-	setUniforms(i++, cbuf.ModelTangentMatrix);
+	setUniforms(i++, cbuf.ModelViewMatrix);
+	setUniforms(i++, cbuf.ModelViewNormalMatrix);
 	setUniforms(i++, cbuf.ModelUV1Matrix);
 	setUniforms(i++, cbuf.ModelUV2Matrix);
+	setUniforms(i++, cbuf.time);
 	setUniforms(i++, cbuf.cameraPos);
-	setUniforms(i++, cbuf.lightDirInTangent);
+	setUniforms(i++, cbuf.sunPos);
+	setUniforms(i++, cbuf.sunPosInView);
 	setUniforms(i++, cbuf.emissiveLight);
 	setUniforms(i++, cbuf.ambientLight);
 	setUniforms(i++, cbuf.diffuseLight);

--- a/lib/ivis_opengl/gfx_api_gl.cpp
+++ b/lib/ivis_opengl/gfx_api_gl.cpp
@@ -937,6 +937,7 @@ void gl_pipeline_state_object::build_program(bool fragmentHighpFloatAvailable, b
 	glBindAttribLocation(program, 2, "vertexColor");
 	glBindAttribLocation(program, 3, "vertexNormal");
 	glBindAttribLocation(program, 4, "vertexTangent");
+	glBindAttribLocation(program, 5, "tileNo");
 	ASSERT_OR_RETURN(, program, "Could not create shader program!");
 
 	char* vertexShaderContents = nullptr;
@@ -1364,6 +1365,8 @@ GLint get_size(const gfx_api::vertex_attribute_type& type)
 {
 	switch (type)
 	{
+		case gfx_api::vertex_attribute_type::int1:
+			return 1;
 		case gfx_api::vertex_attribute_type::float2:
 			return 2;
 		case gfx_api::vertex_attribute_type::float3:
@@ -1386,6 +1389,8 @@ GLenum get_type(const gfx_api::vertex_attribute_type& type)
 			return GL_FLOAT;
 		case gfx_api::vertex_attribute_type::u8x4_norm:
 			return GL_UNSIGNED_BYTE;
+		case gfx_api::vertex_attribute_type::int1:
+			return GL_INT;
 	}
 	debug(LOG_FATAL, "get_type(%d) failed", (int)type);
 	return GL_INVALID_ENUM; // silence warning
@@ -1398,6 +1403,7 @@ GLboolean get_normalisation(const gfx_api::vertex_attribute_type& type)
 		case gfx_api::vertex_attribute_type::float2:
 		case gfx_api::vertex_attribute_type::float3:
 		case gfx_api::vertex_attribute_type::float4:
+		case gfx_api::vertex_attribute_type::int1:
 			return GL_FALSE;
 		case gfx_api::vertex_attribute_type::u8x4_norm:
 			return true;
@@ -1493,7 +1499,11 @@ void gl_context::bind_vertex_buffers(const std::size_t& first, const std::vector
 		for (const auto& attribute : buffer_desc.attributes)
 		{
 			enableVertexAttribArray(static_cast<GLuint>(attribute.id));
-			glVertexAttribPointer(static_cast<GLuint>(attribute.id), get_size(attribute.type), get_type(attribute.type), get_normalisation(attribute.type), static_cast<GLsizei>(buffer_desc.stride), reinterpret_cast<void*>(attribute.offset + std::get<1>(vertex_buffers_offset[i])));
+			if (get_type(attribute.type) == GL_INT) {
+				glVertexAttribIPointer(static_cast<GLuint>(attribute.id), get_size(attribute.type), get_type(attribute.type), static_cast<GLsizei>(buffer_desc.stride), reinterpret_cast<void*>(attribute.offset + std::get<1>(vertex_buffers_offset[i])));
+			} else {
+				glVertexAttribPointer(static_cast<GLuint>(attribute.id), get_size(attribute.type), get_type(attribute.type), get_normalisation(attribute.type), static_cast<GLsizei>(buffer_desc.stride), reinterpret_cast<void*>(attribute.offset + std::get<1>(vertex_buffers_offset[i])));
+			}
 		}
 	}
 }

--- a/lib/ivis_opengl/gfx_api_gl.cpp
+++ b/lib/ivis_opengl/gfx_api_gl.cpp
@@ -336,8 +336,10 @@ static const std::map<SHADER_MODE, program_data> shader_to_file_table =
 			"sunPosition", "emissiveLight", "ambientLight", "diffuseLight", "specularLight",
 			"fogColor", "fogEnabled", "fogEnd", "fogStart", "tex", "lightmap_tex" } }),
 	std::make_pair(SHADER_WATER, program_data{ "water program", "shaders/terrain_water.vert", "shaders/water.frag",
-		{ "ModelViewProjectionMatrix", "paramx1", "paramy1", "paramx2", "paramy2", "tex1", "tex2", "textureMatrix1", "textureMatrix2",
-			"fogColor", "fogEnabled", "fogEnd", "fogStart" } }),
+		{ "ModelViewProjectionMatrix", "ModelTangentMatrix", "ModelUV1", "ModelUV2",
+			"cameraPos", "lightDirInTangent", "emissiveLight", "ambientLight", "diffuseLight", "specularLight",
+			"fogColor", "fogEnabled", "fogEnd", "fogStart",
+			"tex1", "tex2", "tex1_nm", "tex2_nm", "tex1_sm", "tex2_sm" } }),
 	std::make_pair(SHADER_RECT, program_data{ "Rect program", "shaders/rect.vert", "shaders/rect.frag",
 		{ "transformationMatrix", "color" } }),
 	std::make_pair(SHADER_TEXRECT, program_data{ "Textured rect program", "shaders/rect.vert", "shaders/texturedrect.frag",
@@ -586,7 +588,7 @@ desc(_desc), vertex_buffer_desc(_vertex_buffer_desc)
 		vertexShaderHeader = shaderVersionStr;
 		// OpenGL ES Shading Language - 4. Variables and Types - pp. 35-36
 		// https://www.khronos.org/registry/gles/specs/2.0/GLSL_ES_Specification_1.0.17.pdf?#page=41
-		// 
+		//
 		// > The fragment language has no default precision qualifier for floating point types.
 		// > Hence for float, floating point vector and matrix variable declarations, either the
 		// > declaration must include a precision qualifier or the default float precision must
@@ -1085,12 +1087,30 @@ void gl_pipeline_state_object::fetch_uniforms(const std::vector<std::string>& un
 	}
 }
 
+void gl_pipeline_state_object::setUniforms(size_t uniformIdx, const ::glm::vec3 &v)
+{
+	glUniform3f(locations[uniformIdx], v.x, v.y, v.z);
+	if (duplicateFragmentUniformLocations[uniformIdx] != -1)
+	{
+		glUniform3f(duplicateFragmentUniformLocations[uniformIdx], v.x, v.y, v.z);
+	}
+}
+
 void gl_pipeline_state_object::setUniforms(size_t uniformIdx, const ::glm::vec4 &v)
 {
 	glUniform4f(locations[uniformIdx], v.x, v.y, v.z, v.w);
 	if (duplicateFragmentUniformLocations[uniformIdx] != -1)
 	{
 		glUniform4f(duplicateFragmentUniformLocations[uniformIdx], v.x, v.y, v.z, v.w);
+	}
+}
+
+void gl_pipeline_state_object::setUniforms(size_t uniformIdx, const ::glm::mat3 &m)
+{
+	glUniformMatrix3fv(locations[uniformIdx], 1, GL_FALSE, glm::value_ptr(m));
+	if (duplicateFragmentUniformLocations[uniformIdx] != -1)
+	{
+		glUniformMatrix3fv(duplicateFragmentUniformLocations[uniformIdx], 1, GL_FALSE, glm::value_ptr(m));
 	}
 }
 
@@ -1257,19 +1277,27 @@ void gl_pipeline_state_object::set_constants(const gfx_api::constant_buffer_type
 
 void gl_pipeline_state_object::set_constants(const gfx_api::constant_buffer_type<SHADER_WATER>& cbuf)
 {
-	setUniforms(0, cbuf.transform_matrix);
-	setUniforms(1, cbuf.param1);
-	setUniforms(2, cbuf.param2);
-	setUniforms(3, cbuf.param3);
-	setUniforms(4, cbuf.param4);
-	setUniforms(5, cbuf.texture0);
-	setUniforms(6, cbuf.texture1);
-	setUniforms(7, cbuf.translation);
-	setUniforms(8, cbuf.texture_matrix);
-	setUniforms(9, cbuf.fog_colour);
-	setUniforms(10, cbuf.fog_enabled);
-	setUniforms(11, cbuf.fog_begin);
-	setUniforms(12, cbuf.fog_end);
+	int i = 0;
+	setUniforms(i++, cbuf.ModelViewProjectionMatrix);
+	setUniforms(i++, cbuf.ModelTangentMatrix);
+	setUniforms(i++, cbuf.ModelUV1Matrix);
+	setUniforms(i++, cbuf.ModelUV2Matrix);
+	setUniforms(i++, cbuf.cameraPos);
+	setUniforms(i++, cbuf.lightDirInTangent);
+	setUniforms(i++, cbuf.emissiveLight);
+	setUniforms(i++, cbuf.ambientLight);
+	setUniforms(i++, cbuf.diffuseLight);
+	setUniforms(i++, cbuf.specularLight);
+	setUniforms(i++, cbuf.fog_colour);
+	setUniforms(i++, cbuf.fog_enabled);
+	setUniforms(i++, cbuf.fog_begin);
+	setUniforms(i++, cbuf.fog_end);
+	setUniforms(i++, 0);
+	setUniforms(i++, 1);
+	setUniforms(i++, 2);
+	setUniforms(i++, 3);
+	setUniforms(i++, 4);
+	setUniforms(i++, 5);
 }
 
 void gl_pipeline_state_object::set_constants(const gfx_api::constant_buffer_type<SHADER_RECT>& cbuf)

--- a/lib/ivis_opengl/gfx_api_gl.cpp
+++ b/lib/ivis_opengl/gfx_api_gl.cpp
@@ -326,8 +326,8 @@ static const std::map<SHADER_MODE, program_data> shader_to_file_table =
 			"ModelViewMatrix", "NormalMatrix", "colour", "teamcolour", "stretch", "ecmEffect", "alphaTest"
 		} }),
 	std::make_pair(SHADER_TERRAIN, program_data{ "terrain program", "shaders/terrain.vert", "shaders/terrain.frag",
-		{ "textureMatrix1", "textureMatrix2",
-			"ModelViewMatrix", "ModelViewProjectionMatrix", "NormalMatrix", "sunPosition", "paramx1", "paramy1", "paramx2", "paramy2", "tex", "lightmap_tex",
+		{ "ModelUVMatrix", "ModelUVLightMatrix", "ModelViewMatrix", "ModelViewProjectionMatrix", "ModelViewNormalMatrix",
+			"sunPosition", "emissiveLight", "ambientLight", "diffuseLight", "specularLight", "tex", "lightmap_tex",
 			"fogColor", "fogEnabled", "fogEnd", "fogStart", "hasNormalmap", "hasSpecularmap" } }),
 	std::make_pair(SHADER_TERRAIN_DEPTH, program_data{ "terrain_depth program", "shaders/terrain_depth.vert", "shaders/terraindepth.frag",
 		{ "ModelViewProjectionMatrix", "paramx2", "paramy2", "lightmap_tex", "paramx2", "paramy2" } }),
@@ -1200,16 +1200,16 @@ void gl_pipeline_state_object::set_constants(const gfx_api::Draw3DShapePerInstan
 
 void gl_pipeline_state_object::set_constants(const gfx_api::constant_buffer_type<SHADER_TERRAIN>& cbuf)
 {
-	setUniforms(0, cbuf.textureMatrix1);
-	setUniforms(1, cbuf.textureMatrix2);
+	setUniforms(0, cbuf.ModelUVMatrix);
+	setUniforms(1, cbuf.ModelUVLightMatrix);
 	setUniforms(2, cbuf.ModelViewMatrix);
 	setUniforms(3, cbuf.ModelViewProjectionMatrix);
-	setUniforms(4, cbuf.NormalMatrix);
+	setUniforms(4, cbuf.ModelViewNormalMatrix);
 	setUniforms(5, cbuf.sunPosition);
-	setUniforms(6, cbuf.paramX);
-	setUniforms(7, cbuf.paramY);
-	setUniforms(8, cbuf.paramXLight);
-	setUniforms(9, cbuf.paramYLight);
+	setUniforms(6, cbuf.emissiveLight);
+	setUniforms(7, cbuf.ambientLight);
+	setUniforms(8, cbuf.diffuseLight);
+	setUniforms(9, cbuf.specularLight);
 	setUniforms(10, cbuf.texture0);
 	setUniforms(11, cbuf.texture1);
 	setUniforms(12, cbuf.fog_colour);

--- a/lib/ivis_opengl/gfx_api_gl.cpp
+++ b/lib/ivis_opengl/gfx_api_gl.cpp
@@ -326,18 +326,20 @@ static const std::map<SHADER_MODE, program_data> shader_to_file_table =
 			"ModelViewMatrix", "NormalMatrix", "colour", "teamcolour", "stretch", "ecmEffect", "alphaTest"
 		} }),
 	std::make_pair(SHADER_TERRAIN, program_data{ "terrain program", "shaders/terrain.vert", "shaders/terrain.frag",
-		{ "ModelUVMatrix", "ModelUVLightMatrix", "ModelViewMatrix", "ModelViewProjectionMatrix", "ModelViewNormalMatrix",
-			"sunPosition", "emissiveLight", "ambientLight", "diffuseLight", "specularLight", "tex", "lightmap_tex",
-			"fogColor", "fogEnabled", "fogEnd", "fogStart", "hasNormalmap", "hasSpecularmap" } }),
+		{ "ModelViewProjectionMatrix", "ModelUVMatrix", "ModelUVLightMatrix",
+			"cameraPos", "sunPos", "emissiveLight", "ambientLight", "diffuseLight", "specularLight",
+			"fogColor", "fogEnabled", "fogEnd", "fogStart", "hasNormalmap", "hasSpecularmap",
+			"tex", "lightmap_tex", "TextureNormal", "TextureSpecular"} }),
 	std::make_pair(SHADER_TERRAIN_DEPTH, program_data{ "terrain_depth program", "shaders/terrain_depth.vert", "shaders/terraindepth.frag",
 		{ "ModelViewProjectionMatrix", "paramx2", "paramy2", "lightmap_tex", "paramx2", "paramy2" } }),
 	std::make_pair(SHADER_DECALS, program_data{ "decals program", "shaders/decals.vert", "shaders/decals.frag",
-		{ "ModelViewMatrix", "ModelViewNormalMatrix", "ModelViewProjectionMatrix", "ModelUVLightmapMatrix",
-			"sunPosition", "emissiveLight", "ambientLight", "diffuseLight", "specularLight",
-			"fogColor", "fogEnabled", "fogEnd", "fogStart", "tex", "lightmap_tex" } }),
+		{ "ModelViewProjectionMatrix", "ModelUVLightmapMatrix",
+			"cameraPos", "sunPos", "emissiveLight", "ambientLight", "diffuseLight", "specularLight",
+			"fogColor", "fogEnabled", "fogEnd", "fogStart",
+			"tex", "lightmap_tex", "TextureNormal", "TextureSpecular", "TextureHeight" } }),
 	std::make_pair(SHADER_WATER, program_data{ "water program", "shaders/terrain_water.vert", "shaders/water.frag",
-		{ "ModelViewProjectionMatrix", "ModelViewMatrix", "ModelViewNormalMatrix", "ModelUV1Matrix", "ModelUV2Matrix",
-			"time", "cameraPos", "sunPos", "sunPosInView",
+		{ "ModelViewProjectionMatrix", "ModelUV1Matrix", "ModelUV2Matrix",
+			"time", "cameraPos", "sunPos",
 			"emissiveLight", "ambientLight", "diffuseLight", "specularLight",
 			"fogColor", "fogEnabled", "fogEnd", "fogStart",
 			"tex1", "tex2", "tex1_nm", "tex2_nm", "tex1_sm", "tex2_sm" } }),
@@ -1233,24 +1235,26 @@ void gl_pipeline_state_object::set_constants(const gfx_api::Draw3DShapePerInstan
 
 void gl_pipeline_state_object::set_constants(const gfx_api::constant_buffer_type<SHADER_TERRAIN>& cbuf)
 {
-	setUniforms(0, cbuf.ModelUVMatrix);
-	setUniforms(1, cbuf.ModelUVLightMatrix);
-	setUniforms(2, cbuf.ModelViewMatrix);
-	setUniforms(3, cbuf.ModelViewProjectionMatrix);
-	setUniforms(4, cbuf.ModelViewNormalMatrix);
-	setUniforms(5, cbuf.sunPosition);
-	setUniforms(6, cbuf.emissiveLight);
-	setUniforms(7, cbuf.ambientLight);
-	setUniforms(8, cbuf.diffuseLight);
-	setUniforms(9, cbuf.specularLight);
-	setUniforms(10, cbuf.texture0);
-	setUniforms(11, cbuf.texture1);
-	setUniforms(12, cbuf.fog_colour);
-	setUniforms(13, cbuf.fog_enabled);
-	setUniforms(14, cbuf.fog_begin);
-	setUniforms(15, cbuf.fog_end);
-	setUniforms(16, cbuf.hasNormalmap);
-	setUniforms(17, cbuf.hasSpecularmap);
+	int i = 0;
+	setUniforms(i++, cbuf.ModelViewProjectionMatrix);
+	setUniforms(i++, cbuf.ModelUVMatrix);
+	setUniforms(i++, cbuf.ModelUVLightMatrix);
+	setUniforms(i++, cbuf.cameraPos);
+	setUniforms(i++, cbuf.sunPos);
+	setUniforms(i++, cbuf.emissiveLight);
+	setUniforms(i++, cbuf.ambientLight);
+	setUniforms(i++, cbuf.diffuseLight);
+	setUniforms(i++, cbuf.specularLight);
+	setUniforms(i++, cbuf.fog_colour);
+	setUniforms(i++, cbuf.fog_enabled);
+	setUniforms(i++, cbuf.fog_begin);
+	setUniforms(i++, cbuf.fog_end);
+	setUniforms(i++, cbuf.hasNormalmap);
+	setUniforms(i++, cbuf.hasSpecularmap);
+	setUniforms(i++, 0); // tex
+	setUniforms(i++, 1); // lightmap_tex
+	setUniforms(i++, 2); // TextureNormal
+	setUniforms(i++, 3); // TextureSpecular
 }
 
 void gl_pipeline_state_object::set_constants(const gfx_api::constant_buffer_type<SHADER_TERRAIN_DEPTH>& cbuf)
@@ -1268,35 +1272,11 @@ void gl_pipeline_state_object::set_constants(const gfx_api::constant_buffer_type
 
 void gl_pipeline_state_object::set_constants(const gfx_api::constant_buffer_type<SHADER_DECALS>& cbuf)
 {
-	setUniforms(0, cbuf.ModelViewMatrix);
-	setUniforms(1, cbuf.ModelViewNormalMatrix);
-	setUniforms(2, cbuf.ModelViewProjectionMatrix);
-	setUniforms(3, cbuf.ModelUVLightmapMatrix);
-	setUniforms(4, cbuf.sunPosition);
-	setUniforms(5, cbuf.emissiveLight);
-	setUniforms(6, cbuf.ambientLight);
-	setUniforms(7, cbuf.diffuseLight);
-	setUniforms(8, cbuf.specularLight);
-	setUniforms(9, cbuf.fog_colour);
-	setUniforms(10, cbuf.fog_enabled);
-	setUniforms(11, cbuf.fog_begin);
-	setUniforms(12, cbuf.fog_end);
-	setUniforms(13, cbuf.texture0);
-	setUniforms(14, cbuf.texture1);
-}
-
-void gl_pipeline_state_object::set_constants(const gfx_api::constant_buffer_type<SHADER_WATER>& cbuf)
-{
 	int i = 0;
 	setUniforms(i++, cbuf.ModelViewProjectionMatrix);
-	setUniforms(i++, cbuf.ModelViewMatrix);
-	setUniforms(i++, cbuf.ModelViewNormalMatrix);
-	setUniforms(i++, cbuf.ModelUV1Matrix);
-	setUniforms(i++, cbuf.ModelUV2Matrix);
-	setUniforms(i++, cbuf.time);
+	setUniforms(i++, cbuf.ModelUVLightmapMatrix);
 	setUniforms(i++, cbuf.cameraPos);
 	setUniforms(i++, cbuf.sunPos);
-	setUniforms(i++, cbuf.sunPosInView);
 	setUniforms(i++, cbuf.emissiveLight);
 	setUniforms(i++, cbuf.ambientLight);
 	setUniforms(i++, cbuf.diffuseLight);
@@ -1305,6 +1285,31 @@ void gl_pipeline_state_object::set_constants(const gfx_api::constant_buffer_type
 	setUniforms(i++, cbuf.fog_enabled);
 	setUniforms(i++, cbuf.fog_begin);
 	setUniforms(i++, cbuf.fog_end);
+	setUniforms(i++, 0); // tex
+	setUniforms(i++, 1); // lightmap_tex
+	setUniforms(i++, 2); // TextureNormal
+	setUniforms(i++, 3); // TextureSpecular
+	setUniforms(i++, 4); // TextureHeight
+}
+
+void gl_pipeline_state_object::set_constants(const gfx_api::constant_buffer_type<SHADER_WATER>& cbuf)
+{
+	int i = 0;
+	setUniforms(i++, cbuf.ModelViewProjectionMatrix);
+	setUniforms(i++, cbuf.ModelUV1Matrix);
+	setUniforms(i++, cbuf.ModelUV2Matrix);
+	setUniforms(i++, cbuf.time);
+	setUniforms(i++, cbuf.cameraPos);
+	setUniforms(i++, cbuf.sunPos);
+	setUniforms(i++, cbuf.emissiveLight);
+	setUniforms(i++, cbuf.ambientLight);
+	setUniforms(i++, cbuf.diffuseLight);
+	setUniforms(i++, cbuf.specularLight);
+	setUniforms(i++, cbuf.fog_colour);
+	setUniforms(i++, cbuf.fog_enabled);
+	setUniforms(i++, cbuf.fog_begin);
+	setUniforms(i++, cbuf.fog_end);
+	 // textures:
 	setUniforms(i++, 0);
 	setUniforms(i++, 1);
 	setUniforms(i++, 2);

--- a/lib/ivis_opengl/gfx_api_gl.cpp
+++ b/lib/ivis_opengl/gfx_api_gl.cpp
@@ -342,7 +342,7 @@ static const std::map<SHADER_MODE, program_data> shader_to_file_table =
 			"cameraPos", "sunPos",
 			"emissiveLight", "ambientLight", "diffuseLight", "specularLight",
 			"fogColor", "fogEnabled", "fogEnd", "fogStart", "time",
-			"tex1", "tex2", "tex1_nm", "tex2_nm", "tex1_sm", "tex2_sm" } }),
+			"tex1", "tex2", "tex1_nm", "tex2_nm", "tex1_sm", "tex2_sm", "tex1_hm", "tex2_hm" } }),
 	std::make_pair(SHADER_RECT, program_data{ "Rect program", "shaders/rect.vert", "shaders/rect.frag",
 		{ "transformationMatrix", "color" } }),
 	std::make_pair(SHADER_TEXRECT, program_data{ "Textured rect program", "shaders/rect.vert", "shaders/texturedrect.frag",
@@ -1300,6 +1300,8 @@ void gl_pipeline_state_object::set_constants(const gfx_api::constant_buffer_type
 	setUniforms(i++, 3);
 	setUniforms(i++, 4);
 	setUniforms(i++, 5);
+	setUniforms(i++, 6);
+	setUniforms(i++, 7);
 }
 
 void gl_pipeline_state_object::set_constants(const gfx_api::constant_buffer_type<SHADER_RECT>& cbuf)

--- a/lib/ivis_opengl/gfx_api_gl.cpp
+++ b/lib/ivis_opengl/gfx_api_gl.cpp
@@ -853,12 +853,10 @@ void gl_pipeline_state_object::getLocs()
 	GLint locTex1 = glGetUniformLocation(program, "TextureTcmask");
 	GLint locTex2 = glGetUniformLocation(program, "TextureNormal");
 	GLint locTex3 = glGetUniformLocation(program, "TextureSpecular");
-	GLint locTex4 = glGetUniformLocation(program, "TextureHeight");
 	glUniform1i(locTex0, 0);
 	glUniform1i(locTex1, 1);
 	glUniform1i(locTex2, 2);
 	glUniform1i(locTex3, 3);
-	glUniform1i(locTex4, 4);
 }
 
 static std::unordered_set<std::string> getUniformNamesFromSource(const char* shaderContents)

--- a/lib/ivis_opengl/gfx_api_gl.cpp
+++ b/lib/ivis_opengl/gfx_api_gl.cpp
@@ -341,7 +341,7 @@ static const std::map<SHADER_MODE, program_data> shader_to_file_table =
 		{ "ModelViewProjectionMatrix", "ModelUV1Matrix", "ModelUV2Matrix",
 			"cameraPos", "sunPos",
 			"emissiveLight", "ambientLight", "diffuseLight", "specularLight",
-			"fogColor", "fogEnabled", "fogEnd", "fogStart", "time",
+			"fogColor", "fogEnabled", "fogEnd", "fogStart", "timeSec",
 			"tex1", "tex2", "tex1_nm", "tex2_nm", "tex1_sm", "tex2_sm", "tex1_hm", "tex2_hm" } }),
 	std::make_pair(SHADER_RECT, program_data{ "Rect program", "shaders/rect.vert", "shaders/rect.frag",
 		{ "transformationMatrix", "color" } }),
@@ -1291,7 +1291,7 @@ void gl_pipeline_state_object::set_constants(const gfx_api::constant_buffer_type
 	setUniforms(i++, cbuf.fog_enabled);
 	setUniforms(i++, cbuf.fog_begin);
 	setUniforms(i++, cbuf.fog_end);
-	setUniforms(i++, cbuf.time);
+	setUniforms(i++, cbuf.timeSec);
 	 // textures:
 	setUniforms(i++, 0);
 	setUniforms(i++, 1);

--- a/lib/ivis_opengl/gfx_api_gl.cpp
+++ b/lib/ivis_opengl/gfx_api_gl.cpp
@@ -328,8 +328,8 @@ static const std::map<SHADER_MODE, program_data> shader_to_file_table =
 	std::make_pair(SHADER_TERRAIN, program_data{ "terrain program", "shaders/terrain.vert", "shaders/terrain.frag",
 		{ "ModelViewProjectionMatrix", "ModelUVMatrix", "ModelUVLightMatrix",
 			"cameraPos", "sunPos", "emissiveLight", "ambientLight", "diffuseLight", "specularLight",
-			"fogColor", "fogEnabled", "fogEnd", "fogStart", "hasNormalmap", "hasSpecularmap",
-			"tex", "lightmap_tex", "TextureNormal", "TextureSpecular"} }),
+			"fogColor", "fogEnabled", "fogEnd", "fogStart", "hasNormalmap", "hasSpecularmap", "hasHeightmap",
+			"tex", "lightmap_tex", "TextureNormal", "TextureSpecular", "TextureHeight"} }),
 	std::make_pair(SHADER_TERRAIN_DEPTH, program_data{ "terrain_depth program", "shaders/terrain_depth.vert", "shaders/terraindepth.frag",
 		{ "ModelViewProjectionMatrix", "paramx2", "paramy2", "lightmap_tex", "paramx2", "paramy2" } }),
 	std::make_pair(SHADER_DECALS, program_data{ "decals program", "shaders/decals.vert", "shaders/decals.frag",
@@ -1233,10 +1233,12 @@ void gl_pipeline_state_object::set_constants(const gfx_api::constant_buffer_type
 	setUniforms(i++, cbuf.fog_end);
 	setUniforms(i++, cbuf.hasNormalmap);
 	setUniforms(i++, cbuf.hasSpecularmap);
+	setUniforms(i++, cbuf.hasHeightmap);
 	setUniforms(i++, 0); // tex
 	setUniforms(i++, 1); // lightmap_tex
 	setUniforms(i++, 2); // TextureNormal
 	setUniforms(i++, 3); // TextureSpecular
+	setUniforms(i++, 4); // TextureHeight
 }
 
 void gl_pipeline_state_object::set_constants(const gfx_api::constant_buffer_type<SHADER_TERRAIN_DEPTH>& cbuf)

--- a/lib/ivis_opengl/gfx_api_gl.cpp
+++ b/lib/ivis_opengl/gfx_api_gl.cpp
@@ -328,20 +328,20 @@ static const std::map<SHADER_MODE, program_data> shader_to_file_table =
 	std::make_pair(SHADER_TERRAIN, program_data{ "terrain program", "shaders/terrain.vert", "shaders/terrain.frag",
 		{ "ModelViewProjectionMatrix", "ModelUVMatrix", "ModelUVLightMatrix",
 			"cameraPos", "sunPos", "emissiveLight", "ambientLight", "diffuseLight", "specularLight",
-			"fogColor", "fogEnabled", "fogEnd", "fogStart", "hasNormalmap", "hasSpecularmap", "hasHeightmap",
+			"fogColor", "fogEnabled", "fogEnd", "fogStart", "quality", "hasNormalmap", "hasSpecularmap", "hasHeightmap",
 			"tex", "lightmap_tex", "TextureNormal", "TextureSpecular", "TextureHeight"} }),
 	std::make_pair(SHADER_TERRAIN_DEPTH, program_data{ "terrain_depth program", "shaders/terrain_depth.vert", "shaders/terraindepth.frag",
 		{ "ModelViewProjectionMatrix", "paramx2", "paramy2", "lightmap_tex", "paramx2", "paramy2" } }),
 	std::make_pair(SHADER_DECALS, program_data{ "decals program", "shaders/decals.vert", "shaders/decals.frag",
 		{ "ModelViewProjectionMatrix", "ModelUVLightmapMatrix",
 			"cameraPos", "sunPos", "emissiveLight", "ambientLight", "diffuseLight", "specularLight",
-			"fogColor", "fogEnabled", "fogEnd", "fogStart",
+			"fogColor", "fogEnabled", "fogEnd", "fogStart", "quality",
 			"tex", "lightmap_tex", "TextureNormal", "TextureSpecular", "TextureHeight" } }),
 	std::make_pair(SHADER_WATER, program_data{ "water program", "shaders/terrain_water.vert", "shaders/water.frag",
 		{ "ModelViewProjectionMatrix", "ModelUV1Matrix", "ModelUV2Matrix",
 			"cameraPos", "sunPos",
 			"emissiveLight", "ambientLight", "diffuseLight", "specularLight",
-			"fogColor", "fogEnabled", "fogEnd", "fogStart", "timeSec",
+			"fogColor", "fogEnabled", "fogEnd", "fogStart", "timeSec", "quality",
 			"tex1", "tex2", "tex1_nm", "tex2_nm", "tex1_sm", "tex2_sm", "tex1_hm", "tex2_hm" } }),
 	std::make_pair(SHADER_RECT, program_data{ "Rect program", "shaders/rect.vert", "shaders/rect.frag",
 		{ "transformationMatrix", "color" } }),
@@ -1230,6 +1230,7 @@ void gl_pipeline_state_object::set_constants(const gfx_api::constant_buffer_type
 	setUniforms(i++, cbuf.fog_enabled);
 	setUniforms(i++, cbuf.fog_begin);
 	setUniforms(i++, cbuf.fog_end);
+	setUniforms(i++, cbuf.quality);
 	setUniforms(i++, cbuf.hasNormalmap);
 	setUniforms(i++, cbuf.hasSpecularmap);
 	setUniforms(i++, cbuf.hasHeightmap);
@@ -1268,6 +1269,7 @@ void gl_pipeline_state_object::set_constants(const gfx_api::constant_buffer_type
 	setUniforms(i++, cbuf.fog_enabled);
 	setUniforms(i++, cbuf.fog_begin);
 	setUniforms(i++, cbuf.fog_end);
+	setUniforms(i++, cbuf.quality);
 	setUniforms(i++, 0); // tex
 	setUniforms(i++, 1); // lightmap_tex
 	setUniforms(i++, 2); // TextureNormal
@@ -1292,6 +1294,7 @@ void gl_pipeline_state_object::set_constants(const gfx_api::constant_buffer_type
 	setUniforms(i++, cbuf.fog_begin);
 	setUniforms(i++, cbuf.fog_end);
 	setUniforms(i++, cbuf.timeSec);
+	setUniforms(i++, cbuf.quality);
 	 // textures:
 	setUniforms(i++, 0);
 	setUniforms(i++, 1);

--- a/lib/ivis_opengl/gfx_api_gl.cpp
+++ b/lib/ivis_opengl/gfx_api_gl.cpp
@@ -325,11 +325,12 @@ static const std::map<SHADER_MODE, program_data> shader_to_file_table =
 			// per-instance uniforms
 			"ModelViewMatrix", "NormalMatrix", "colour", "teamcolour", "stretch", "ecmEffect", "alphaTest"
 		} }),
-	std::make_pair(SHADER_TERRAIN, program_data{ "terrain program", "shaders/terrain_water.vert", "shaders/terrain.frag",
-		{ "ModelViewProjectionMatrix", "paramx1", "paramy1", "paramx2", "paramy2", "tex", "lightmap_tex", "textureMatrix1", "textureMatrix2",
-			"fogColor", "fogEnabled", "fogEnd", "fogStart" } }),
-	std::make_pair(SHADER_TERRAIN_DEPTH, program_data{ "terrain_depth program", "shaders/terrain_water.vert", "shaders/terraindepth.frag",
-		{ "ModelViewProjectionMatrix", "paramx2", "paramy2", "lightmap_tex", "paramx2", "paramy2", "fogEnabled", "fogEnd", "fogStart" } }),
+	std::make_pair(SHADER_TERRAIN, program_data{ "terrain program", "shaders/terrain.vert", "shaders/terrain.frag",
+		{ "textureMatrix1", "textureMatrix2",
+			"ModelViewMatrix", "ModelViewProjectionMatrix", "sunPosition", "paramx1", "paramy1", "paramx2", "paramy2", "tex", "lightmap_tex",
+			"fogColor", "fogEnabled", "fogEnd", "fogStart", "hasNormalmap", "hasSpecularmap" } }),
+	std::make_pair(SHADER_TERRAIN_DEPTH, program_data{ "terrain_depth program", "shaders/terrain_depth.vert", "shaders/terraindepth.frag",
+		{ "ModelViewProjectionMatrix", "paramx2", "paramy2", "lightmap_tex", "paramx2", "paramy2" } }),
 	std::make_pair(SHADER_DECALS, program_data{ "decals program", "shaders/decals.vert", "shaders/decals.frag",
 		{ "ModelViewProjectionMatrix", "lightTextureMatrix", "paramxlight", "paramylight",
 			"fogColor", "fogEnabled", "fogEnd", "fogStart", "tex", "lightmap_tex" } }),
@@ -1199,19 +1200,23 @@ void gl_pipeline_state_object::set_constants(const gfx_api::Draw3DShapePerInstan
 
 void gl_pipeline_state_object::set_constants(const gfx_api::constant_buffer_type<SHADER_TERRAIN>& cbuf)
 {
-	setUniforms(0, cbuf.transform_matrix);
-	setUniforms(1, cbuf.paramX);
-	setUniforms(2, cbuf.paramY);
-	setUniforms(3, cbuf.paramXLight);
-	setUniforms(4, cbuf.paramYLight);
-	setUniforms(5, cbuf.texture0);
-	setUniforms(6, cbuf.texture1);
-	setUniforms(7, cbuf.unused);
-	setUniforms(8, cbuf.texture_matrix);
-	setUniforms(9, cbuf.fog_colour);
-	setUniforms(10, cbuf.fog_enabled);
-	setUniforms(11, cbuf.fog_begin);
-	setUniforms(12, cbuf.fog_end);
+	setUniforms(0, cbuf.textureMatrix1);
+	setUniforms(1, cbuf.textureMatrix2);
+	setUniforms(2, cbuf.ModelViewMatrix);
+	setUniforms(3, cbuf.ModelViewProjectionMatrix);
+	setUniforms(4, cbuf.sunPosition);
+	setUniforms(5, cbuf.paramX);
+	setUniforms(6, cbuf.paramY);
+	setUniforms(7, cbuf.paramXLight);
+	setUniforms(8, cbuf.paramYLight);
+	setUniforms(9, cbuf.texture0);
+	setUniforms(10, cbuf.texture1);
+	setUniforms(11, cbuf.fog_colour);
+	setUniforms(12, cbuf.fog_enabled);
+	setUniforms(13, cbuf.fog_begin);
+	setUniforms(14, cbuf.fog_end);
+	setUniforms(15, cbuf.hasNormalmap);
+	setUniforms(16, cbuf.hasSpecularmap);
 }
 
 void gl_pipeline_state_object::set_constants(const gfx_api::constant_buffer_type<SHADER_TERRAIN_DEPTH>& cbuf)

--- a/lib/ivis_opengl/gfx_api_gl.cpp
+++ b/lib/ivis_opengl/gfx_api_gl.cpp
@@ -332,7 +332,8 @@ static const std::map<SHADER_MODE, program_data> shader_to_file_table =
 	std::make_pair(SHADER_TERRAIN_DEPTH, program_data{ "terrain_depth program", "shaders/terrain_depth.vert", "shaders/terraindepth.frag",
 		{ "ModelViewProjectionMatrix", "paramx2", "paramy2", "lightmap_tex", "paramx2", "paramy2" } }),
 	std::make_pair(SHADER_DECALS, program_data{ "decals program", "shaders/decals.vert", "shaders/decals.frag",
-		{ "ModelViewProjectionMatrix", "lightTextureMatrix", "paramxlight", "paramylight",
+		{ "ModelViewMatrix", "ModelViewNormalMatrix", "ModelViewProjectionMatrix", "ModelUVLightmapMatrix",
+			"sunPosition", "emissiveLight", "ambientLight", "diffuseLight", "specularLight",
 			"fogColor", "fogEnabled", "fogEnd", "fogStart", "tex", "lightmap_tex" } }),
 	std::make_pair(SHADER_WATER, program_data{ "water program", "shaders/terrain_water.vert", "shaders/water.frag",
 		{ "ModelViewProjectionMatrix", "paramx1", "paramy1", "paramx2", "paramy2", "tex1", "tex2", "textureMatrix1", "textureMatrix2",
@@ -1235,16 +1236,21 @@ void gl_pipeline_state_object::set_constants(const gfx_api::constant_buffer_type
 
 void gl_pipeline_state_object::set_constants(const gfx_api::constant_buffer_type<SHADER_DECALS>& cbuf)
 {
-	setUniforms(0, cbuf.transform_matrix);
-	setUniforms(1, cbuf.texture_matrix);
-	setUniforms(2, cbuf.param1);
-	setUniforms(3, cbuf.param2);
-	setUniforms(4, cbuf.fog_colour);
-	setUniforms(5, cbuf.fog_enabled);
-	setUniforms(6, cbuf.fog_begin);
-	setUniforms(7, cbuf.fog_end);
-	setUniforms(8, cbuf.texture0);
-	setUniforms(9, cbuf.texture1);
+	setUniforms(0, cbuf.ModelViewMatrix);
+	setUniforms(1, cbuf.ModelViewNormalMatrix);
+	setUniforms(2, cbuf.ModelViewProjectionMatrix);
+	setUniforms(3, cbuf.ModelUVLightmapMatrix);
+	setUniforms(4, cbuf.sunPosition);
+	setUniforms(5, cbuf.emissiveLight);
+	setUniforms(6, cbuf.ambientLight);
+	setUniforms(7, cbuf.diffuseLight);
+	setUniforms(8, cbuf.specularLight);
+	setUniforms(9, cbuf.fog_colour);
+	setUniforms(10, cbuf.fog_enabled);
+	setUniforms(11, cbuf.fog_begin);
+	setUniforms(12, cbuf.fog_end);
+	setUniforms(13, cbuf.texture0);
+	setUniforms(14, cbuf.texture1);
 }
 
 void gl_pipeline_state_object::set_constants(const gfx_api::constant_buffer_type<SHADER_WATER>& cbuf)

--- a/lib/ivis_opengl/gfx_api_gl.cpp
+++ b/lib/ivis_opengl/gfx_api_gl.cpp
@@ -841,10 +841,12 @@ void gl_pipeline_state_object::getLocs()
 	GLint locTex1 = glGetUniformLocation(program, "TextureTcmask");
 	GLint locTex2 = glGetUniformLocation(program, "TextureNormal");
 	GLint locTex3 = glGetUniformLocation(program, "TextureSpecular");
+	GLint locTex4 = glGetUniformLocation(program, "TextureHeight");
 	glUniform1i(locTex0, 0);
 	glUniform1i(locTex1, 1);
 	glUniform1i(locTex2, 2);
 	glUniform1i(locTex3, 3);
+	glUniform1i(locTex4, 4);
 }
 
 static std::unordered_set<std::string> getUniformNamesFromSource(const char* shaderContents)

--- a/lib/ivis_opengl/gfx_api_gl.cpp
+++ b/lib/ivis_opengl/gfx_api_gl.cpp
@@ -339,9 +339,9 @@ static const std::map<SHADER_MODE, program_data> shader_to_file_table =
 			"tex", "lightmap_tex", "TextureNormal", "TextureSpecular", "TextureHeight" } }),
 	std::make_pair(SHADER_WATER, program_data{ "water program", "shaders/terrain_water.vert", "shaders/water.frag",
 		{ "ModelViewProjectionMatrix", "ModelUV1Matrix", "ModelUV2Matrix",
-			"time", "cameraPos", "sunPos",
+			"cameraPos", "sunPos",
 			"emissiveLight", "ambientLight", "diffuseLight", "specularLight",
-			"fogColor", "fogEnabled", "fogEnd", "fogStart",
+			"fogColor", "fogEnabled", "fogEnd", "fogStart", "time",
 			"tex1", "tex2", "tex1_nm", "tex2_nm", "tex1_sm", "tex2_sm" } }),
 	std::make_pair(SHADER_RECT, program_data{ "Rect program", "shaders/rect.vert", "shaders/rect.frag",
 		{ "transformationMatrix", "color" } }),
@@ -1099,30 +1099,12 @@ void gl_pipeline_state_object::fetch_uniforms(const std::vector<std::string>& un
 	}
 }
 
-void gl_pipeline_state_object::setUniforms(size_t uniformIdx, const ::glm::vec3 &v)
-{
-	glUniform3f(locations[uniformIdx], v.x, v.y, v.z);
-	if (duplicateFragmentUniformLocations[uniformIdx] != -1)
-	{
-		glUniform3f(duplicateFragmentUniformLocations[uniformIdx], v.x, v.y, v.z);
-	}
-}
-
 void gl_pipeline_state_object::setUniforms(size_t uniformIdx, const ::glm::vec4 &v)
 {
 	glUniform4f(locations[uniformIdx], v.x, v.y, v.z, v.w);
 	if (duplicateFragmentUniformLocations[uniformIdx] != -1)
 	{
 		glUniform4f(duplicateFragmentUniformLocations[uniformIdx], v.x, v.y, v.z, v.w);
-	}
-}
-
-void gl_pipeline_state_object::setUniforms(size_t uniformIdx, const ::glm::mat3 &m)
-{
-	glUniformMatrix3fv(locations[uniformIdx], 1, GL_FALSE, glm::value_ptr(m));
-	if (duplicateFragmentUniformLocations[uniformIdx] != -1)
-	{
-		glUniformMatrix3fv(duplicateFragmentUniformLocations[uniformIdx], 1, GL_FALSE, glm::value_ptr(m));
 	}
 }
 
@@ -1298,7 +1280,6 @@ void gl_pipeline_state_object::set_constants(const gfx_api::constant_buffer_type
 	setUniforms(i++, cbuf.ModelViewProjectionMatrix);
 	setUniforms(i++, cbuf.ModelUV1Matrix);
 	setUniforms(i++, cbuf.ModelUV2Matrix);
-	setUniforms(i++, cbuf.time);
 	setUniforms(i++, cbuf.cameraPos);
 	setUniforms(i++, cbuf.sunPos);
 	setUniforms(i++, cbuf.emissiveLight);
@@ -1309,6 +1290,7 @@ void gl_pipeline_state_object::set_constants(const gfx_api::constant_buffer_type
 	setUniforms(i++, cbuf.fog_enabled);
 	setUniforms(i++, cbuf.fog_begin);
 	setUniforms(i++, cbuf.fog_end);
+	setUniforms(i++, cbuf.time);
 	 // textures:
 	setUniforms(i++, 0);
 	setUniforms(i++, 1);

--- a/lib/ivis_opengl/gfx_api_gl.h
+++ b/lib/ivis_opengl/gfx_api_gl.h
@@ -139,9 +139,7 @@ private:
 	 * accepting glm structures.
 	 * Please do not use directly, use pie_ActivateShader below.
 	 */
-	void setUniforms(size_t uniformIdx, const ::glm::vec3 &v);
 	void setUniforms(size_t uniformIdx, const ::glm::vec4 &v);
-	void setUniforms(size_t uniformIdx, const ::glm::mat3 &m);
 	void setUniforms(size_t uniformIdx, const ::glm::mat4 &m);
 	void setUniforms(size_t uniformIdx, const Vector2i &v);
 	void setUniforms(size_t uniformIdx, const Vector2f &v);

--- a/lib/ivis_opengl/gfx_api_gl.h
+++ b/lib/ivis_opengl/gfx_api_gl.h
@@ -93,6 +93,8 @@ struct gl_pipeline_state_object final : public gfx_api::pipeline_state_object
 {
 	gfx_api::state_description desc;
 	GLuint program;
+	GLuint vertexShader = 0;
+	GLuint fragmentShader = 0;
 	std::vector<gfx_api::vertex_buffer> vertex_buffer_desc;
 	std::vector<GLint> locations;
 	std::vector<GLint> duplicateFragmentUniformLocations;
@@ -106,6 +108,7 @@ struct gl_pipeline_state_object final : public gfx_api::pipeline_state_object
 	typename std::pair<std::type_index, std::function<void(const void*, size_t)>> uniform_setting_func();
 
 	gl_pipeline_state_object(bool gles, bool fragmentHighpFloatAvailable, bool fragmentHighpIntAvailable, const gfx_api::state_description& _desc, const SHADER_MODE& shader, const std::vector<std::type_index>& uniform_blocks, const std::vector<gfx_api::vertex_buffer>& vertex_buffer_desc);
+	~gl_pipeline_state_object();
 	void set_constants(const void* buffer, const size_t& size);
 	void set_uniforms(const size_t& first, const std::vector<std::tuple<const void*, size_t>>& uniform_blocks);
 

--- a/lib/ivis_opengl/gfx_api_gl.h
+++ b/lib/ivis_opengl/gfx_api_gl.h
@@ -136,7 +136,9 @@ private:
 	 * accepting glm structures.
 	 * Please do not use directly, use pie_ActivateShader below.
 	 */
+	void setUniforms(size_t uniformIdx, const ::glm::vec3 &v);
 	void setUniforms(size_t uniformIdx, const ::glm::vec4 &v);
+	void setUniforms(size_t uniformIdx, const ::glm::mat3 &m);
 	void setUniforms(size_t uniformIdx, const ::glm::mat4 &m);
 	void setUniforms(size_t uniformIdx, const Vector2i &v);
 	void setUniforms(size_t uniformIdx, const Vector2f &v);

--- a/lib/ivis_opengl/gfx_api_vk.cpp
+++ b/lib/ivis_opengl/gfx_api_vk.cpp
@@ -1066,6 +1066,8 @@ vk::Format VkPSO::to_vk(const gfx_api::vertex_attribute_type& type)
 		return vk::Format::eR32G32Sfloat;
 	case gfx_api::vertex_attribute_type::u8x4_norm:
 		return vk::Format::eR8G8B8A8Unorm;
+	case gfx_api::vertex_attribute_type::int1:
+		return vk::Format::eR32Sint;
 	}
 	debug(LOG_FATAL, "Unsupported vertex_attribute_type");
 	return vk::Format::eUndefined;

--- a/lib/ivis_opengl/gfx_api_vk.cpp
+++ b/lib/ivis_opengl/gfx_api_vk.cpp
@@ -1648,7 +1648,7 @@ void VkTexture::upload_and_generate_mipmaps(const size_t& offset_x, const size_t
 //								   STBIR_COLORSPACE_LINEAR,
 //								   nullptr);
 
-		upload(i, offset_x, offset_y, output_w, output_h, buffer_format, (const void*)output_pixels);
+		upload(i, offset_x >> i, offset_y >> i, output_w, output_h, buffer_format, (const void*)output_pixels);
 
 		if (prev_input_pixels_malloc)
 		{

--- a/lib/ivis_opengl/piedef.h
+++ b/lib/ivis_opengl/piedef.h
@@ -54,6 +54,7 @@ void pie_setShadows(bool drawShadows);
 /** Set light parameters */
 void pie_InitLighting();
 void pie_Lighting0(LIGHTING_TYPE entry, const float value[4]);
+glm::vec4 pie_GetLighting0(LIGHTING_TYPE entry);
 
 void pie_RemainingPasses(uint64_t currentGameFrame);
 

--- a/lib/ivis_opengl/piedraw.cpp
+++ b/lib/ivis_opengl/piedraw.cpp
@@ -76,6 +76,12 @@ void pie_InitLighting()
 	memcpy(lightingDefault, defaultLight, sizeof(lightingDefault));
 }
 
+glm::vec4 pie_GetLighting0(LIGHTING_TYPE entry)
+{
+	auto c = lighting0[entry];
+	return glm::vec4(c[0], c[1], c[2], c[3]);
+}
+
 void pie_Lighting0(LIGHTING_TYPE entry, const float value[4])
 {
 	lighting0[entry][0] = value[0];

--- a/lib/ivis_opengl/tex.cpp
+++ b/lib/ivis_opengl/tex.cpp
@@ -175,11 +175,6 @@ std::string pie_MakeTexPageName(const std::string& filename)
 	{
 		return filename.substr(0, c + 7);
 	}
-	c = filename.find('-', 5);
-	if (c != std::string::npos)
-	{
-		return filename.substr(0, c);
-	}
 	return filename;
 }
 

--- a/lib/ivis_opengl/tex.h
+++ b/lib/ivis_opengl/tex.h
@@ -46,11 +46,12 @@ void pie_AssignTexture(size_t page, gfx_api::texture* texture);
 bool scaleImageMaxSize(iV_Image *s, int maxWidth, int maxHeight);
 
 optional<size_t> iV_GetTexture(const char *filename, bool compression = true, int maxWidth = -1, int maxHeight = -1);
-optional<size_t> iV_GetTransformTexture(const char *filename, std::function<void (iV_Image&)> transformImageData = nullptr, bool compression = true, int maxWidth = -1, int maxHeight = -1);
+optional<size_t> iV_GetTransformTexture(const char *filename, std::function<void (iV_Image&, const char *filename)> transformImageData = nullptr, bool compression = true, int maxWidth = -1, int maxHeight = -1);
+void iV_TransformSpecularTextureFunction(iV_Image& image, const char *filename);
 void iV_unloadImage(iV_Image *image);
 gfx_api::pixel_format iV_getPixelFormat(const iV_Image *image);
 
-bool replaceTexture(const WzString &oldfile, const WzString &newfile);
+bool replaceTexture(const WzString &oldfile, const WzString &newfile, std::function<void (iV_Image&, const char *filename)> transformImageData = nullptr);
 size_t pie_AddTexPage(iV_Image *s, const char *filename, bool gameTexture);
 size_t pie_AddTexPage(iV_Image *s, const char *filename, bool gameTexture, size_t page);
 void pie_TexInit();

--- a/src/advvis.cpp
+++ b/src/advvis.cpp
@@ -40,7 +40,7 @@ static bool bRevealActive = true;
 inline float getTileIllumination(const MAPTILE *psTile)
 {
 	switch (terrainShaderQuality) {
-		case TerrainShaderQuality::BUMP_MAPPING: return psTile->ambientOcclusion; // sunlight is handled by shaders so only AO needed for lightmap
+		case TerrainShaderQuality::NORMAL_MAPPING: return psTile->ambientOcclusion; // sunlight is handled by shaders so only AO needed for lightmap
 		default: return psTile->illumination;
 	}
 }

--- a/src/advvis.cpp
+++ b/src/advvis.cpp
@@ -50,7 +50,7 @@ void	avUpdateTiles()
 	for (; i < len; i++)
 	{
 		psTile = &psMapTiles[i];
-		maxLevel = psTile->illumination;
+		maxLevel = psTile->ambientOcclusion; // sunlight is handled by shaders so only AO needed for lightmap
 
 		if (psTile->level > MIN_ILLUM || psTile->tileExploredBits & playermask)	// seen
 		{
@@ -107,11 +107,11 @@ void	preProcessVisibility()
 		for (int j = 0; j < mapHeight; j++)
 		{
 			MAPTILE *psTile = mapTile(i, j);
-			psTile->level = bRevealActive ? MIN(MIN_ILLUM, psTile->illumination / 4.0f) : 0;
+			psTile->level = bRevealActive ? MIN(MIN_ILLUM, psTile->ambientOcclusion / 4.0f) : 0;
 
 			if (TEST_TILE_VISIBLE_TO_SELECTEDPLAYER(psTile))
 			{
-				psTile->level = psTile->illumination;
+				psTile->level = psTile->ambientOcclusion;
 			}
 		}
 	}

--- a/src/advvis.cpp
+++ b/src/advvis.cpp
@@ -37,6 +37,14 @@
 /// for scripts, since campaign may still want total darkness on unexplored tiles.
 static bool bRevealActive = true;
 
+inline float getTileIllumination(const MAPTILE *psTile)
+{
+	switch (terrainShaderQuality) {
+		case TerrainShaderQuality::BUMP_MAPPING: return psTile->ambientOcclusion; // sunlight is handled by shaders so only AO needed for lightmap
+		default: return psTile->illumination;
+	}
+}
+
 // ------------------------------------------------------------------------------------
 void	avUpdateTiles()
 {
@@ -50,7 +58,7 @@ void	avUpdateTiles()
 	for (; i < len; i++)
 	{
 		psTile = &psMapTiles[i];
-		maxLevel = psTile->ambientOcclusion; // sunlight is handled by shaders so only AO needed for lightmap
+		maxLevel = getTileIllumination(psTile);
 
 		if (psTile->level > MIN_ILLUM || psTile->tileExploredBits & playermask)	// seen
 		{
@@ -107,11 +115,11 @@ void	preProcessVisibility()
 		for (int j = 0; j < mapHeight; j++)
 		{
 			MAPTILE *psTile = mapTile(i, j);
-			psTile->level = bRevealActive ? MIN(MIN_ILLUM, psTile->ambientOcclusion / 4.0f) : 0;
+			psTile->level = bRevealActive ? MIN(MIN_ILLUM, getTileIllumination(psTile) / 4.0f) : 0;
 
 			if (TEST_TILE_VISIBLE_TO_SELECTEDPLAYER(psTile))
 			{
-				psTile->level = psTile->ambientOcclusion;
+				psTile->level = getTileIllumination(psTile);
 			}
 		}
 	}

--- a/src/configuration.cpp
+++ b/src/configuration.cpp
@@ -52,6 +52,7 @@
 #include "keybind.h" // for MAP_ZOOM_RATE_STEP
 #include "loadsave.h" // for autosaveEnabled
 #include "clparse.h" // for autoratingUrl
+#include "terrain.h"
 
 #include <type_traits>
 
@@ -483,6 +484,18 @@ bool loadConfig()
 	}
 	war_setAutoLagKickSeconds(iniGetInteger("hostAutoLagKickSeconds", war_getAutoLagKickSeconds()).value());
 	war_setDisableReplayRecording(iniGetBool("disableReplayRecord", war_getDisableReplayRecording()).value());
+	if (auto value = iniGetIntegerOpt("terrainShaderQuality"))
+	{
+		auto intValue = value.value();
+		if (intValue >= 0 && intValue < TerrainShaderQuality::END)
+		{
+			terrainShaderQuality = static_cast<TerrainShaderQuality>(intValue);
+		}
+		else
+		{
+			debug(LOG_WARNING, "Unsupported / invalid terrainShaderQuality value: %d; defaulting to: %d", intValue, static_cast<int>(terrainShaderQuality));
+		}
+	}
 	ActivityManager::instance().endLoadingSettings();
 	return true;
 }
@@ -624,6 +637,7 @@ bool saveConfig()
 	iniSetBool("fog", pie_GetFogEnabled());
 	iniSetInteger("hostAutoLagKickSeconds", war_getAutoLagKickSeconds());
 	iniSetBool("disableReplayRecord", war_getDisableReplayRecording());
+	iniSetInteger("terrainShaderQuality", terrainShaderQuality);
 
 	// write out ini file changes
 	bool result = saveIniFile(file, ini);

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -2060,10 +2060,10 @@ void	dealWithLMB()
 		MAPTILE *psTile = mapTile(mouseTileX, mouseTileY);
 		uint8_t aux = auxTile(mouseTileX, mouseTileY, selectedPlayer);
 
-		console("%s tile %d, %d [%d, %d] continent(l%d, h%d) level %g illum %d %s %s w=%d s=%d j=%d",
+		console("%s tile %d, %d [%d, %d] continent(l%d, h%d) level %g illum %d ao %g col %x %s %s w=%d s=%d j=%d",
 		        tileIsExplored(psTile) ? "Explored" : "Unexplored",
 		        mouseTileX, mouseTileY, world_coord(mouseTileX), world_coord(mouseTileY),
-		        (int)psTile->limitedContinent, (int)psTile->hoverContinent, psTile->level, (int)psTile->illumination,
+		        (int)psTile->limitedContinent, (int)psTile->hoverContinent, psTile->level, (int)psTile->illumination, psTile->ambientOcclusion, psTile->colour.rgba,
 		        aux & AUXBITS_DANGER ? "danger" : "", aux & AUXBITS_THREAT ? "threat" : "",
 		        (int)psTile->watchers[selectedPlayer], (int)psTile->sensors[selectedPlayer], (int)psTile->jammers[selectedPlayer]);
 	}

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -2060,12 +2060,12 @@ void	dealWithLMB()
 		MAPTILE *psTile = mapTile(mouseTileX, mouseTileY);
 		uint8_t aux = auxTile(mouseTileX, mouseTileY, selectedPlayer);
 
-		console("%s tile %d, %d [%d, %d] continent(l%d, h%d) level %g illum %d ao %g col %x %s %s w=%d s=%d j=%d",
+		console("%s tile %d, %d [%d, %d] continent(l%d, h%d) level %g illum %d ao %g col %x %s %s w=%d s=%d j=%d tile#%d",
 		        tileIsExplored(psTile) ? "Explored" : "Unexplored",
 		        mouseTileX, mouseTileY, world_coord(mouseTileX), world_coord(mouseTileY),
 		        (int)psTile->limitedContinent, (int)psTile->hoverContinent, psTile->level, (int)psTile->illumination, psTile->ambientOcclusion, psTile->colour.rgba,
 		        aux & AUXBITS_DANGER ? "danger" : "", aux & AUXBITS_THREAT ? "threat" : "",
-		        (int)psTile->watchers[selectedPlayer], (int)psTile->sensors[selectedPlayer], (int)psTile->jammers[selectedPlayer]);
+		        (int)psTile->watchers[selectedPlayer], (int)psTile->sensors[selectedPlayer], (int)psTile->jammers[selectedPlayer], TileNumber_tile(psTile->texture));
 	}
 }
 

--- a/src/display3d.cpp
+++ b/src/display3d.cpp
@@ -1196,7 +1196,7 @@ static void drawTiles(iView *player)
 
 	// draw it
 	// and draw it
-	drawTerrain(pie_PerspectiveGet() * viewMatrix * glm::translate(glm::vec3(-player->p.x, 0, player->p.z)));
+	drawTerrain(viewMatrix * glm::translate(glm::vec3(-player->p.x, 0, player->p.z)), pie_PerspectiveGet(), theSun);
 
 	wzPerfEnd(PERF_TERRAIN);
 

--- a/src/display3d.cpp
+++ b/src/display3d.cpp
@@ -1108,6 +1108,7 @@ static void drawTiles(iView *player)
 		glm::rotate(UNDEG(player->r.y), glm::vec3(0.f, 1.f, 0.f)) *
 		glm::translate(glm::vec3(0, -player->p.y, 0));
 	const glm::mat4 &modelViewMatrix = viewMatrix * glm::translate(glm::vec3(-player->p.x, 0, player->p.z));
+	const glm::mat4 &projectionMatrix = pie_PerspectiveGet();
 
 	actualCameraPosition = Vector3i(0, 0, 0);
 
@@ -1197,7 +1198,7 @@ static void drawTiles(iView *player)
 
 	// draw it
 	// and draw it
-	drawTerrain(modelViewMatrix, pie_PerspectiveGet(), theSun);
+	drawTerrain(modelViewMatrix, projectionMatrix, theSun);
 
 	wzPerfEnd(PERF_TERRAIN);
 
@@ -1232,7 +1233,8 @@ static void drawTiles(iView *player)
 	pie_SetFogStatus(true);
 
 	// also, make sure we can use world coordinates directly
-	drawWater(pie_PerspectiveGet() * modelViewMatrix, getTheSun(), glm::vec3(actualCameraPosition - Vector3i(-player->p.x, 0, player->p.z)));
+	auto cameraPos = glm::inverse(modelViewMatrix) * glm::vec4(0,0,0,1);
+	drawWater(modelViewMatrix, projectionMatrix, cameraPos, -getTheSun(), theSun);
 	wzPerfEnd(PERF_WATER);
 
 	wzPerfBegin(PERF_MODELS, "3D scene - models");

--- a/src/display3d.cpp
+++ b/src/display3d.cpp
@@ -1108,8 +1108,9 @@ static void drawTiles(iView *player)
 		glm::rotate(UNDEG(player->r.y), glm::vec3(0.f, 1.f, 0.f)) *
 		glm::translate(glm::vec3(0, -player->p.y, 0));
 	const glm::mat4 &modelViewMatrix = viewMatrix * glm::translate(glm::vec3(-player->p.x, 0, player->p.z));
-	const glm::mat4 &projectionMatrix = pie_PerspectiveGet();
+	const glm::mat4 &mvpMatrix = pie_PerspectiveGet() * modelViewMatrix;
 
+	auto cameraPos = glm::inverse(modelViewMatrix) * glm::vec4(0,0,0,1); // `actualCameraPosition` is not accurate enough due to int calc
 	actualCameraPosition = Vector3i(0, 0, 0);
 
 	/* Set the camera position */
@@ -1198,7 +1199,7 @@ static void drawTiles(iView *player)
 
 	// draw it
 	// and draw it
-	drawTerrain(modelViewMatrix, projectionMatrix, theSun);
+	drawTerrain(mvpMatrix, cameraPos, -getTheSun());
 
 	wzPerfEnd(PERF_TERRAIN);
 
@@ -1233,8 +1234,7 @@ static void drawTiles(iView *player)
 	pie_SetFogStatus(true);
 
 	// also, make sure we can use world coordinates directly
-	auto cameraPos = glm::inverse(modelViewMatrix) * glm::vec4(0,0,0,1);
-	drawWater(modelViewMatrix, projectionMatrix, cameraPos, -getTheSun(), theSun);
+	drawWater(mvpMatrix, cameraPos, -getTheSun());
 	wzPerfEnd(PERF_WATER);
 
 	wzPerfBegin(PERF_MODELS, "3D scene - models");

--- a/src/display3d.cpp
+++ b/src/display3d.cpp
@@ -1107,6 +1107,7 @@ static void drawTiles(iView *player)
 		glm::rotate(UNDEG(player->r.x), glm::vec3(1.f, 0.f, 0.f)) *
 		glm::rotate(UNDEG(player->r.y), glm::vec3(0.f, 1.f, 0.f)) *
 		glm::translate(glm::vec3(0, -player->p.y, 0));
+	const glm::mat4 &modelViewMatrix = viewMatrix * glm::translate(glm::vec3(-player->p.x, 0, player->p.z));
 
 	actualCameraPosition = Vector3i(0, 0, 0);
 
@@ -1196,7 +1197,7 @@ static void drawTiles(iView *player)
 
 	// draw it
 	// and draw it
-	drawTerrain(viewMatrix * glm::translate(glm::vec3(-player->p.x, 0, player->p.z)), pie_PerspectiveGet(), theSun);
+	drawTerrain(modelViewMatrix, pie_PerspectiveGet(), theSun);
 
 	wzPerfEnd(PERF_TERRAIN);
 
@@ -1231,7 +1232,7 @@ static void drawTiles(iView *player)
 	pie_SetFogStatus(true);
 
 	// also, make sure we can use world coordinates directly
-	drawWater(pie_PerspectiveGet() * viewMatrix * glm::translate(glm::vec3(-player->p.x, 0, player->p.z)));
+	drawWater(pie_PerspectiveGet() * modelViewMatrix, getTheSun(), glm::vec3(actualCameraPosition - Vector3i(-player->p.x, 0, player->p.z)));
 	wzPerfEnd(PERF_WATER);
 
 	wzPerfBegin(PERF_MODELS, "3D scene - models");

--- a/src/display3d.cpp
+++ b/src/display3d.cpp
@@ -1110,7 +1110,7 @@ static void drawTiles(iView *player)
 	const glm::mat4 &modelViewMatrix = viewMatrix * glm::translate(glm::vec3(-player->p.x, 0, player->p.z));
 	const glm::mat4 &mvpMatrix = pie_PerspectiveGet() * modelViewMatrix;
 
-	auto cameraPos = glm::inverse(modelViewMatrix) * glm::vec4(0,0,0,1); // `actualCameraPosition` is not accurate enough due to int calc
+	const glm::vec3 cameraPos = (glm::inverse(modelViewMatrix) * glm::vec4(0,0,0,1)).xyz(); // `actualCameraPosition` is not accurate enough due to int calc
 	actualCameraPosition = Vector3i(0, 0, 0);
 
 	/* Set the camera position */

--- a/src/droid.cpp
+++ b/src/droid.cpp
@@ -565,6 +565,7 @@ bool destroyDroid(DROID *psDel, unsigned impactTime)
 				if (TEST_TILE_VISIBLE_TO_SELECTEDPLAYER(psTile))
 				{
 					psTile->illumination /= 2;
+					psTile->ambientOcclusion /= 2;
 				}
 			}
 		}

--- a/src/frontend.cpp
+++ b/src/frontend.cpp
@@ -1749,7 +1749,7 @@ bool runVideoOptionsMenu()
 	case FRONTEND_TEXTURESZ:
 	case FRONTEND_TEXTURESZ_R:
 		{
-			int newTexSize = pow2Cycle(getTextureSize(), 128, 2048);
+			int newTexSize = pow2Cycle(getTextureSize(), 128, 4*2048);
 
 			// Set the new size
 			setTextureSize(newTexSize);

--- a/src/frontend.cpp
+++ b/src/frontend.cpp
@@ -1749,7 +1749,7 @@ bool runVideoOptionsMenu()
 	case FRONTEND_TEXTURESZ:
 	case FRONTEND_TEXTURESZ_R:
 		{
-			int newTexSize = pow2Cycle(getTextureSize(), 128, 4*2048);
+			int newTexSize = pow2Cycle(getTextureSize(), 128, 2048);
 
 			// Set the new size
 			setTextureSize(newTexSize);

--- a/src/lighting.cpp
+++ b/src/lighting.cpp
@@ -207,7 +207,9 @@ static void calcTileIllum(UDWORD tileX, UDWORD tileY)
 		finalVector += normals[i];
 	}
 
-	float dotProduct = glm::dot(normalise(finalVector), theSun_ForTileIllumination)/16;
+	//float dotProduct = glm::dot(normalise(finalVector), theSun_ForTileIllumination)/16;
+	// we do this diffuse lighting in the shader now, so set dotProduct = max light = |theSun_ForTileIllumination/16| = 256
+	float dotProduct = glm::length(theSun_ForTileIllumination)/16;
 
 	// Primitive ambient occlusion calculation.
 	float ao = 0;

--- a/src/lighting.cpp
+++ b/src/lighting.cpp
@@ -98,6 +98,7 @@ void initLighting(UDWORD x1, UDWORD y1, UDWORD x2, UDWORD y2)
 			if (i == 0 || j == 0 || i >= mapWidth - 1 || j >= mapHeight - 1)
 			{
 				psTile->illumination = 16;
+				psTile->ambientOcclusion = 16.0;
 			}
 			else
 			{
@@ -207,9 +208,7 @@ static void calcTileIllum(UDWORD tileX, UDWORD tileY)
 		finalVector += normals[i];
 	}
 
-	//float dotProduct = glm::dot(normalise(finalVector), theSun_ForTileIllumination)/16;
-	// we do this diffuse lighting in the shader now, so set dotProduct = max light = |theSun_ForTileIllumination/16| = 256
-	float dotProduct = glm::length(theSun_ForTileIllumination)/16;
+	float dotProduct = glm::dot(normalise(finalVector), theSun_ForTileIllumination)/16;
 
 	// Primitive ambient occlusion calculation.
 	float ao = 0;
@@ -233,7 +232,9 @@ static void calcTileIllum(UDWORD tileX, UDWORD tileY)
 	}
 	ao *= 1.f/Dirs;
 
-	mapTile(tileX, tileY)->illumination = static_cast<uint8_t>(clip<int>(static_cast<int>(abs(dotProduct*ao)), 1, 254));
+	MAPTILE *tile = mapTile(tileX, tileY);
+	tile->illumination = static_cast<uint8_t>(clip<int>(static_cast<int>(abs(dotProduct*ao)), 1, 254));
+	tile->ambientOcclusion = clip<float>(254.f*ao, 1.f, 254.f);
 }
 
 static void colourTile(SDWORD xIndex, SDWORD yIndex, PIELIGHT light_colour, double fraction)

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -264,12 +264,9 @@ static std::string getTextureVariant(const std::string &origTextureFilename, con
 	return "";
 }
 
-// This is the main loading routine to get all the map's parameters set.
-// Once it figures out what tileset we need, we then parse the files for that tileset.
-// Currently, we only support 3 tilesets.  Arizona, Urban, and Rockie
-static bool mapLoadGroundTypes(bool preview)
+static void mapLoadTertiles(bool preview, unsigned int tileSet, const char* tertilesFile)
 {
-	char	*pFileData = nullptr;
+	char	*pFileData = fileLoadBuffer;
 	char	tilename[MAX_STR_LENGTH] = {'\0'};
 	char	textureName[MAX_STR_LENGTH] = {'\0'};
 	char	textureType[MAX_STR_LENGTH] = {'\0'};
@@ -277,146 +274,72 @@ static bool mapLoadGroundTypes(bool preview)
 	int		numlines = 0;
 	int		cnt = 0, i = 0;
 	uint32_t	fileSize = 0;
+	// load the override terrain types
+	if (!preview && builtInMap && !loadTerrainTypeMapOverride(tileSet))
+	{
+		debug(LOG_POPUP, "Failed to load terrain type override");
+	}
+	init_tileNames(tileSet);
+	if (!loadFileToBuffer(tertilesFile, pFileData, FILE_LOAD_BUFFER_SIZE, &fileSize))
+	{
+		debug(LOG_FATAL, "%s not found, aborting.", tertilesFile);
+		abort();
+	}
 
-	pFileData = fileLoadBuffer;
+	sscanf(pFileData, "%255[^,'\r\n],%d%n", tilename, &numlines, &cnt);
+	pFileData += cnt;
 
+	if (!strstr(tertilesFile, tilename))
+	{
+		debug(LOG_FATAL, "%s found, but was expecting %s!  Aborting.", tilename, tertilesFile);
+		abort();
+	}
+
+	debug(LOG_TERRAIN, "tilename: %s, with %d entries", tilename, numlines);
+	//increment the pointer to the start of the next record
+	pFileData = strchr(pFileData, '\n') + 1;
+	groundTypes.resize(numlines);
+
+	for (i = 0; i < numlines; i++)
+	{
+		sscanf(pFileData, "%255[^,'\r\n],%255[^,'\r\n],%lf%n", textureType, textureName, &textureSize, &cnt);
+		pFileData += cnt;
+		//increment the pointer to the start of the next record
+		pFileData = strchr(pFileData, '\n') + 1;
+
+		int textureTypeIdx = getTextureType(textureType);
+		groundTypes[textureTypeIdx].textureName = textureName;
+		groundTypes[textureTypeIdx].textureSize = static_cast<float>(textureSize);
+		groundTypes[textureTypeIdx].normalMapTextureName = getTextureVariant(textureName, "_nm");
+		groundTypes[textureTypeIdx].specularMapTextureName = getTextureVariant(textureName, "_sm");
+	}
+}
+
+// This is the main loading routine to get all the map's parameters set.
+// Once it figures out what tileset we need, we then parse the files for that tileset.
+// Currently, we only support 3 tilesets.  Arizona, Urban, and Rockie
+static bool mapLoadGroundTypes(bool preview)
+{
 	debug(LOG_TERRAIN, "tileset: %s", tilesetDir);
 	// For Arizona
 	if (strcmp(tilesetDir, "texpages/tertilesc1hw") == 0)
 	{
 fallback:
-		// load the override terrain types
-		if (!preview && builtInMap && !loadTerrainTypeMapOverride(ARIZONA))
-		{
-			debug(LOG_POPUP, "Failed to load terrain type override");
-		}
-		init_tileNames(ARIZONA);
-		if (!loadFileToBuffer("tileset/tertilesc1hwGtype.txt", pFileData, FILE_LOAD_BUFFER_SIZE, &fileSize))
-		{
-			debug(LOG_FATAL, "tileset/tertilesc1hwGtype.txt not found, aborting.");
-			abort();
-		}
-
-		sscanf(pFileData, "%255[^,'\r\n],%d%n", tilename, &numlines, &cnt);
-		pFileData += cnt;
-
-		if (strcmp(tilename, "tertilesc1hw"))
-		{
-			debug(LOG_FATAL, "%s found, but was expecting tertilesc1hw!  Aborting.", tilename);
-			abort();
-		}
-
-		debug(LOG_TERRAIN, "tilename: %s, with %d entries", tilename, numlines);
-		//increment the pointer to the start of the next record
-		pFileData = strchr(pFileData, '\n') + 1;
-		groundTypes.resize(numlines);
-
-		for (i = 0; i < numlines; i++)
-		{
-			sscanf(pFileData, "%255[^,'\r\n],%255[^,'\r\n],%lf%n", textureType, textureName, &textureSize, &cnt);
-			pFileData += cnt;
-			//increment the pointer to the start of the next record
-			pFileData = strchr(pFileData, '\n') + 1;
-
-			int textureTypeIdx = getTextureType(textureType);
-			groundTypes[textureTypeIdx].textureName = textureName;
-			groundTypes[textureTypeIdx].textureSize = static_cast<float>(textureSize);
-			groundTypes[textureTypeIdx].normalMapTextureName = getTextureVariant(textureName, "_nm");
-			groundTypes[textureTypeIdx].specularMapTextureName = getTextureVariant(textureName, "_sm");
-		}
-
+		mapLoadTertiles(preview, ARIZONA, "tileset/tertilesc1hwGtype.txt");
 		SetGroundForTile("tileset/arizonaground.txt", "arizona_ground");
 		SetDecals("tileset/arizonadecals.txt", "arizona_decals");
 	}
 	// for Urban
 	else if (strcmp(tilesetDir, "texpages/tertilesc2hw") == 0)
 	{
-		// load the override terrain types
-		if (!preview && builtInMap && !loadTerrainTypeMapOverride(URBAN))
-		{
-			debug(LOG_POPUP, "Failed to load terrain type override");
-		}
-		init_tileNames(URBAN);
-		if (!loadFileToBuffer("tileset/tertilesc2hwGtype.txt", pFileData, FILE_LOAD_BUFFER_SIZE, &fileSize))
-		{
-			debug(LOG_POPUP, "tileset/tertilesc2hwGtype.txt not found, using default terrain ground types.");
-			goto fallback;
-		}
-
-		sscanf(pFileData, "%255[^,'\r\n],%d%n", tilename, &numlines, &cnt);
-		pFileData += cnt;
-
-		if (strcmp(tilename, "tertilesc2hw"))
-		{
-			debug(LOG_POPUP, "%s found, but was expecting tertilesc2hw!", tilename);
-			goto fallback;
-		}
-
-		debug(LOG_TERRAIN, "tilename: %s, with %d entries", tilename, numlines);
-		//increment the pointer to the start of the next record
-		pFileData = strchr(pFileData, '\n') + 1;
-		groundTypes.resize(numlines);
-
-		for (i = 0; i < numlines; i++)
-		{
-			sscanf(pFileData, "%255[^,'\r\n],%255[^,'\r\n],%lf%n", textureType, textureName, &textureSize, &cnt);
-			pFileData += cnt;
-			//increment the pointer to the start of the next record
-			pFileData = strchr(pFileData, '\n') + 1;
-
-			int textureTypeIdx = getTextureType(textureType);
-			groundTypes[textureTypeIdx].textureName = textureName;
-			groundTypes[textureTypeIdx].textureSize = static_cast<float>(textureSize);
-			groundTypes[textureTypeIdx].normalMapTextureName = getTextureVariant(textureName, "_nm");
-			groundTypes[textureTypeIdx].specularMapTextureName = getTextureVariant(textureName, "_sm");
-		}
-
+		mapLoadTertiles(preview, URBAN, "tileset/tertilesc2hwGtype.txt");
 		SetGroundForTile("tileset/urbanground.txt", "urban_ground");
 		SetDecals("tileset/urbandecals.txt", "urban_decals");
 	}
 	// for Rockie
 	else if (strcmp(tilesetDir, "texpages/tertilesc3hw") == 0)
 	{
-		// load the override terrain types
-		if (!preview && builtInMap && !loadTerrainTypeMapOverride(ROCKIE))
-		{
-			debug(LOG_POPUP, "Failed to load terrain type override");
-		}
-		init_tileNames(ROCKIE);
-		if (!loadFileToBuffer("tileset/tertilesc3hwGtype.txt", pFileData, FILE_LOAD_BUFFER_SIZE, &fileSize))
-		{
-			debug(LOG_POPUP, "tileset/tertilesc3hwGtype.txt not found, using default terrain ground types.");
-			goto fallback;
-		}
-
-		sscanf(pFileData, "%255[^,'\r\n],%d%n", tilename, &numlines, &cnt);
-		pFileData += cnt;
-
-		if (strcmp(tilename, "tertilesc3hw"))
-		{
-			debug(LOG_POPUP, "%s found, but was expecting tertilesc3hw!", tilename);
-			goto fallback;
-		}
-
-		debug(LOG_TERRAIN, "tilename: %s, with %d entries", tilename, numlines);
-		//increment the pointer to the start of the next record
-		pFileData = strchr(pFileData, '\n') + 1;
-		groundTypes.resize(numlines);
-
-		for (i = 0; i < numlines; i++)
-		{
-			sscanf(pFileData, "%255[^,'\r\n],%255[^,'\r\n],%lf%n", textureType, textureName, &textureSize, &cnt);
-			pFileData += cnt;
-			//increment the pointer to the start of the next record
-			pFileData = strchr(pFileData, '\n') + 1;
-
-			int textureTypeIdx = getTextureType(textureType);
-			groundTypes[textureTypeIdx].textureName = textureName;
-			groundTypes[textureTypeIdx].textureSize = static_cast<float>(textureSize);
-			groundTypes[textureTypeIdx].normalMapTextureName = getTextureVariant(textureName, "_nm");
-			groundTypes[textureTypeIdx].specularMapTextureName = getTextureVariant(textureName, "_sm");
-		}
-
+		mapLoadTertiles(preview, ROCKIE, "tileset/tertilesc3hwGtype.txt");
 		SetGroundForTile("tileset/rockieground.txt", "rockie_ground");
 		SetDecals("tileset/rockiedecals.txt", "rockie_decals");
 	}

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -312,6 +312,7 @@ static void mapLoadTertiles(bool preview, unsigned int tileSet, const char* tert
 		groundTypes[textureTypeIdx].textureSize = static_cast<float>(textureSize);
 		groundTypes[textureTypeIdx].normalMapTextureName = getTextureVariant(textureName, "_nm");
 		groundTypes[textureTypeIdx].specularMapTextureName = getTextureVariant(textureName, "_sm");
+		groundTypes[textureTypeIdx].heightMapTextureName = getTextureVariant(textureName, "_hm");
 	}
 }
 

--- a/src/map.h
+++ b/src/map.h
@@ -58,9 +58,9 @@ struct GROUND_TYPE
 {
 	std::string textureName;
 	float textureSize;
-	std::string normalMapTextureName;
-	std::string specularMapTextureName;
-	std::string heightMapTextureName;
+	std::string normalMapTextureName = "";
+	std::string specularMapTextureName = "";
+	std::string heightMapTextureName = "";
 };
 
 /* Information stored with each tile */

--- a/src/map.h
+++ b/src/map.h
@@ -60,6 +60,7 @@ struct GROUND_TYPE
 	float textureSize;
 	std::string normalMapTextureName;
 	std::string specularMapTextureName;
+	std::string heightMapTextureName;
 };
 
 /* Information stored with each tile */

--- a/src/map.h
+++ b/src/map.h
@@ -68,13 +68,14 @@ struct MAPTILE
 	uint8_t         tileInfoBits;
 	PlayerMask      tileExploredBits;
 	PlayerMask      sensorBits;             ///< bit per player, who can see tile with sensor
-	uint8_t         illumination;           // How bright is this tile?
+	uint8_t         illumination;           // How bright is this tile? = diffuseSunLight * ambientOcclusion
+	float           ambientOcclusion;       // ambient occlusion. from 1 (max occlusion) to 254 (no occlusion), similary to illumination.
 	uint8_t         watchers[MAX_PLAYERS];  // player sees through fog of war here with this many objects
 	uint16_t        texture;                // Which graphics texture is on this tile
 	int32_t         height;                 ///< The height at the top left of the tile
-	float           level;                  ///< The visibility level of the top left of the tile, for this client.
+	float           level;                  ///< The visibility level of the top left of the tile, for this client. for terrain lightmap
 	BASE_OBJECT *   psObject;               // Any object sitting on the location (e.g. building)
-	PIELIGHT        colour;
+	PIELIGHT        colour;                 // color in terrain lightmap, based on tile.level and near light sources
 	uint16_t        limitedContinent;       ///< For land or sea limited propulsion types
 	uint16_t        hoverContinent;         ///< For hover type propulsions
 	uint8_t         ground;                 ///< The ground type used for the terrain renderer

--- a/src/map.h
+++ b/src/map.h
@@ -56,8 +56,10 @@ enum MAP_TILESET_TYPE
 
 struct GROUND_TYPE
 {
-	const char *textureName;
+	std::string textureName;
 	float textureSize;
+	std::string normalMapTextureName;
+	std::string specularMapTextureName;
 };
 
 /* Information stored with each tile */
@@ -88,9 +90,10 @@ extern SDWORD	mapWidth, mapHeight;
 
 extern std::unique_ptr<MAPTILE[]> psMapTiles;
 extern float waterLevel;
-extern std::unique_ptr<GROUND_TYPE[]> psGroundTypes;
-extern int numGroundTypes;
 extern char *tilesetDir;
+
+const GROUND_TYPE& getGroundType(size_t idx);
+size_t getNumGroundTypes();
 
 #define AIR_BLOCKED		0x01	///< Aircraft cannot pass tile
 #define FEATURE_BLOCKED		0x02	///< Ground units cannot pass tile due to item in the way
@@ -335,7 +338,7 @@ static inline unsigned char terrainType(const MAPTILE *tile)
 
 /* The size and contents of the map */
 extern SDWORD	mapWidth, mapHeight;
-extern int numGroundTypes;
+extern std::unique_ptr<MAPTILE[]> psMapTiles;
 
 /* Additional tile <-> world coordinate overloads */
 

--- a/src/structure.cpp
+++ b/src/structure.cpp
@@ -4563,6 +4563,7 @@ bool destroyStruct(STRUCTURE *psDel, unsigned impactTime)
 				if (TEST_TILE_VISIBLE_TO_SELECTEDPLAYER(psTile))
 				{
 					psTile->illumination /= 2;
+					psTile->ambientOcclusion /= 2;
 				}
 			}
 		}

--- a/src/terrain.cpp
+++ b/src/terrain.cpp
@@ -233,7 +233,6 @@ void setTileColour(int x, int y, PIELIGHT colour)
 
 // NOTE:  The current (max) texture size of a tile is 128x128.  We allow up to a user defined texture size
 // of 2048.  This will cause ugly seams for the decals, if user picks a texture size bigger than the tile!
-#define MAX_TILE_TEXTURE_SIZE 128.0f
 /// Set up the texture coordinates for a tile
 static Vector2f getTileTexCoords(Vector2f *uv, unsigned int tileNumber)
 {
@@ -247,9 +246,9 @@ static Vector2f getTileTexCoords(Vector2f *uv, unsigned int tileNumber)
 	float texsize = (float)getTextureSize();
 
 	// the decals are 128x128 (at this time), we should not go above this value.  See note above
-	if (texsize > MAX_TILE_TEXTURE_SIZE)
+	if (texsize > getCurrentTileTextureSize())
 	{
-		texsize = MAX_TILE_TEXTURE_SIZE;
+		texsize = getCurrentTileTextureSize();
 	}
 	const float centertile = 0.5f / texsize;	// compute center of tile
 	const float shiftamount = (texsize - 1.0f) / texsize;	// 1 pixel border

--- a/src/terrain.cpp
+++ b/src/terrain.cpp
@@ -368,7 +368,7 @@ static Vector3f getGridNormal(int x, int y, bool center = false) {
 			float ang = acos(glm::dot(e1, e2) / glm::length(e1) / glm::length(e2));
 			res += glm::cross(e1, e2) * ang; // += normal * (2*area) * angle
 		}
-		return glm::normalize(res);
+		return -glm::normalize(res);
 	};
 	if (center) {
 		return calcNormal(getGridPosf(x, y, true), {

--- a/src/terrain.cpp
+++ b/src/terrain.cpp
@@ -361,24 +361,22 @@ static Vector3f getGridNormal(int x, int y, bool center) {
 	auto posCenter = [pos](int x, int y) {
 		return (pos(x, y) + pos(x+1, y) + pos(x+1, y+1) + pos(x, y+1))/4.0f;
 	};
-	auto res = Vector3f(0.0);
-	if (center) {
-		Vector3f p[] = {pos(x,y), pos(x+1, y), pos(x+1, y+1), pos(x, y+1)};
-		auto pc = posCenter(x, y);
-		for (int i = 0; i < 4; i++) {
-			res += glm::cross(p[(i+1)%4] - pc, p[i] - pc);
+	auto calcNormal = [](Vector3f pc, std::vector<Vector3f> p) {
+		auto res = Vector3f(0.0);
+		for (int i = 0; i < p.size(); i++) {
+			auto e1 = p[(i+1)%p.size()] - pc, e2 = p[i] - pc;
+			float ang = acos(glm::dot(e1, e2) / glm::length(e1) / glm::length(e2));
+			res += glm::cross(e1, e2) * ang; // += normal * (2*area) * angle
 		}
 		return glm::normalize(res);
+	};
+	if (center) {
+		return calcNormal(posCenter(x, y), {pos(x,y), pos(x+1, y), pos(x+1, y+1), pos(x, y+1)});
 	} else {
-		Vector3f p[] = {
+		return calcNormal(pos(x, y), {
 			pos(x+1, y), posCenter(x, y),     pos(x, y+1), posCenter(x-1, y),
 			pos(x-1, y), posCenter(x-1, y-1), pos(x, y-1), posCenter(x, y-1)
-		};
-		auto pc = pos(x, y);
-		for (int i = 0; i < 8; i++) {
-			res += glm::cross(p[(i+1)%8] - pc, p[i] - pc);
-		}
-		return glm::normalize(res);
+		});
 	}
 }
 

--- a/src/terrain.cpp
+++ b/src/terrain.cpp
@@ -97,6 +97,7 @@ struct DecalVertex
 	Vector2f uv = Vector2f(0.f, 0.f);
 	Vector3f normal = Vector3f(0.f, 1.f, 0.f);
 	glm::vec4 tangent = glm::vec4(1.f, 0.f, 0.f, 1.f);
+	int32_t tile = 0;
 };
 
 using WaterVertex = glm::vec4; // w is depth
@@ -455,6 +456,7 @@ static void setSectorDecals(int x, int y, DecalVertex *decaldata, int *decalSize
 			if (TILE_HAS_DECAL(mapTile(i, j)))
 			{
 				center = getTileTexCoords(*uv, mapTile(i, j)->texture);
+				const auto tile = TileNumber_tile(mapTile(i, j)->texture);
 
 				getGridPos(&pos, i, j, true, false);
 				decaldata[*decalSize].pos = pos;
@@ -546,6 +548,7 @@ static void setSectorDecals(int x, int y, DecalVertex *decaldata, int *decalSize
 							w = -1.0f; // we're mirrored
 						}
 						p[k].tangent = glm::vec4(t, w);
+						p[k].tile = tile;
 					}
 				}
 			}

--- a/src/terrain.cpp
+++ b/src/terrain.cpp
@@ -1212,6 +1212,7 @@ static void drawTerrainLayers(const glm::mat4 &ModelView, const glm::mat4 &Model
 		renderState.fogColour.vector[2] / 255.f,
 		renderState.fogColour.vector[3] / 255.f
 	);
+	const auto NormalMatrix = glm::transpose(glm::inverse(ModelView));
 
 	// load the vertex (geometry) buffer
 	gfx_api::TerrainLayer::get().bind();
@@ -1239,7 +1240,7 @@ static void drawTerrainLayers(const glm::mat4 &ModelView, const glm::mat4 &Model
 		gfx_api::texture* pSpecularMapTexture = texPage_specularmap.has_value() ? &pie_Texture(texPage_specularmap.value()) : nullptr;
 
 		gfx_api::TerrainLayer::get().bind_constants({ glm::mat4(1.f), textureMatrix,
-			ModelView, ModelViewProjection, glm::vec4(currentSunPos, 0.f), paramsX, paramsY, paramsXLight, paramsYLight,
+			ModelView, ModelViewProjection, NormalMatrix, glm::vec4(currentSunPos, 0.f), paramsX, paramsY, paramsXLight, paramsYLight,
 			fogColor, renderState.fogEnabled, renderState.fogBegin, renderState.fogEnd, 0, 1, pNormalMapTexture != nullptr, pSpecularMapTexture != nullptr});
 
 		// load the textures

--- a/src/terrain.cpp
+++ b/src/terrain.cpp
@@ -1211,7 +1211,7 @@ static void drawTerrainLayers(const glm::mat4 &ModelView, const glm::mat4 &Model
 		renderState.fogColour.vector[3] / 255.f
 	);
 	const auto ModelViewNormal = glm::transpose(glm::inverse(ModelView));
-	const auto ModelUVLight = lightTextureMatrix * glm::transpose(glm::mat4(paramsXLight, paramsYLight, glm::vec4(0), glm::vec4(0)));
+	const auto ModelUVLight = lightTextureMatrix * glm::transpose(glm::mat4(paramsXLight, paramsYLight, glm::vec4(0,0,1,0), glm::vec4(0,0,0,1)));
 
 	// load the vertex (geometry) buffer
 	gfx_api::TerrainLayer::get().bind();
@@ -1229,7 +1229,7 @@ static void drawTerrainLayers(const glm::mat4 &ModelView, const glm::mat4 &Model
 		const auto& groundType = getGroundType(layer);
 		const glm::vec4 paramsX(0, 0, -1.0f / world_coord(groundType.textureSize), 0 );
 		const glm::vec4 paramsY(1.0f / world_coord(groundType.textureSize), 0, 0, 0 );
-		auto ModelUV = glm::transpose(glm::mat4(paramsX, paramsY, glm::vec4(0), glm::vec4(0)));
+		auto ModelUV = glm::transpose(glm::mat4(paramsX, paramsY, glm::vec4(0,0,1,0), glm::vec4(0,0,0,1)));
 
 		// load the texture
 		optional<size_t> texPage = iV_GetTexture(groundType.textureName.c_str(), true, maxTerrainTextureSize, maxTerrainTextureSize);

--- a/src/terrain.cpp
+++ b/src/terrain.cpp
@@ -591,17 +591,18 @@ void markTileDirty(int i, int j)
 
 void loadTerrainTextures()
 {
-	ASSERT_OR_RETURN(, psGroundTypes.get(), "Ground type was not set, no textures will be seen.");
+	ASSERT_OR_RETURN(, getNumGroundTypes(), "Ground type was not set, no textures will be seen.");
 
 	int32_t maxGfxTextureSize = gfx_api::context::get().get_context_value(gfx_api::context::context_value::MAX_TEXTURE_SIZE);
 	int maxTerrainTextureSize = std::max(std::min({getTextureSize(), maxGfxTextureSize}), MIN_TERRAIN_TEXTURE_SIZE);
 
 	// for each terrain layer
-	for (int layer = 0; layer < numGroundTypes; layer++)
+	for (int layer = 0; layer < getNumGroundTypes(); layer++)
 	{
 		// pre-load the texture
-		optional<size_t> texPage = iV_GetTexture(psGroundTypes[layer].textureName, true, maxTerrainTextureSize, maxTerrainTextureSize);
-		ASSERT(texPage.has_value(), "Failed to pre-load terrain texture: %s", psGroundTypes[layer].textureName);
+		const auto groundType = getGroundType(layer);
+		optional<size_t> texPage = iV_GetTexture(groundType.textureName.c_str(), true, maxTerrainTextureSize, maxTerrainTextureSize);
+		ASSERT(texPage.has_value(), "Failed to pre-load terrain texture: %s", groundType.textureName.c_str());
 	}
 }
 
@@ -811,6 +812,7 @@ bool initTerrain()
 
 	////////////////////
 	// fill the texture part of the sectors
+	const size_t numGroundTypes = getNumGroundTypes();
 	texture = (PIELIGHT *)malloc(sizeof(PIELIGHT) * xSectors * ySectors * (sectorSize + 1) * (sectorSize + 1) * 2 * numGroundTypes);
 	textureIndex = (GLuint *)malloc(sizeof(GLuint) * xSectors * ySectors * sectorSize * sectorSize * 12 * numGroundTypes);
 	textureSize = 0;
@@ -1118,12 +1120,12 @@ static void cullTerrain()
 static void drawDepthOnly(const glm::mat4 &ModelViewProjection, const glm::vec4 &paramsXLight, const glm::vec4 &paramsYLight)
 {
 	const auto &renderState = getCurrentRenderState();
-	
+
 	// bind the vertex buffer
 	gfx_api::TerrainDepth::get().bind();
 	gfx_api::TerrainDepth::get().bind_textures(lightmap_texture);
 	gfx_api::TerrainDepth::get().bind_vertex_buffers(geometryVBO);
-	gfx_api::TerrainDepth::get().bind_constants({ ModelViewProjection, paramsXLight, paramsYLight, glm::vec4(0.f), glm::vec4(0.f), glm::mat4(1.f), glm::mat4(1.f), 
+	gfx_api::TerrainDepth::get().bind_constants({ ModelViewProjection, paramsXLight, paramsYLight, glm::vec4(0.f), glm::vec4(0.f), glm::mat4(1.f), glm::mat4(1.f),
 	glm::vec4(0.f), renderState.fogEnabled, renderState.fogBegin, renderState.fogEnd, 0, 0 });
 	gfx_api::context::get().bind_index_buffer(*geometryIndexVBO, gfx_api::index_type::u32);
 
@@ -1151,7 +1153,7 @@ static void drawDepthOnly(const glm::mat4 &ModelViewProjection, const glm::vec4 
 	gfx_api::context::get().unbind_index_buffer(*geometryIndexVBO);
 }
 
-static void drawTerrainLayers(const glm::mat4 &ModelViewProjection, const glm::vec4 &paramsXLight, const glm::vec4 &paramsYLight, const glm::mat4 &textureMatrix)
+static void drawTerrainLayers(const glm::mat4 &ModelView, const glm::mat4 &ModelViewProjection, const Vector3f &currentSunPos, const glm::vec4 &paramsXLight, const glm::vec4 &paramsYLight, const glm::mat4 &textureMatrix)
 {
 	const auto &renderState = getCurrentRenderState();
 	const glm::vec4 fogColor(
@@ -1165,7 +1167,8 @@ static void drawTerrainLayers(const glm::mat4 &ModelViewProjection, const glm::v
 	gfx_api::TerrainLayer::get().bind();
 	gfx_api::TerrainLayer::get().bind_vertex_buffers(geometryVBO, textureVBO);
 	gfx_api::context::get().bind_index_buffer(*textureIndexVBO, gfx_api::index_type::u32);
-	ASSERT_OR_RETURN(, psGroundTypes.get(), "Ground type was not set, no textures will be seen.");
+	const size_t numGroundTypes = getNumGroundTypes();
+	ASSERT_OR_RETURN(, numGroundTypes, "Ground type was not set, no textures will be seen.");
 
 	int32_t maxGfxTextureSize = gfx_api::context::get().get_context_value(gfx_api::context::context_value::MAX_TEXTURE_SIZE);
 	int maxTerrainTextureSize = std::max(std::min({getTextureSize(), maxGfxTextureSize}), MIN_TERRAIN_TEXTURE_SIZE);
@@ -1173,15 +1176,24 @@ static void drawTerrainLayers(const glm::mat4 &ModelViewProjection, const glm::v
 	// draw each layer separately
 	for (int layer = 0; layer < numGroundTypes; layer++)
 	{
-		const glm::vec4 paramsX(0, 0, -1.0f / world_coord(psGroundTypes[layer].textureSize), 0 );
-		const glm::vec4 paramsY(1.0f / world_coord(psGroundTypes[layer].textureSize), 0, 0, 0 );
-		gfx_api::TerrainLayer::get().bind_constants({ ModelViewProjection, paramsX, paramsY, paramsXLight, paramsYLight, glm::mat4(1.f), textureMatrix,
-			fogColor, renderState.fogEnabled, renderState.fogBegin, renderState.fogEnd, 0, 1 });
+		const auto& groundType = getGroundType(layer);
+		const glm::vec4 paramsX(0, 0, -1.0f / world_coord(groundType.textureSize), 0 );
+		const glm::vec4 paramsY(1.0f / world_coord(groundType.textureSize), 0, 0, 0 );
 
 		// load the texture
-		optional<size_t> texPage = iV_GetTexture(psGroundTypes[layer].textureName, true, maxTerrainTextureSize, maxTerrainTextureSize);
-		ASSERT_OR_RETURN(, texPage.has_value(), "Failed to retrieve terrain texture: %s", psGroundTypes[layer].textureName);
-		gfx_api::TerrainLayer::get().bind_textures(&pie_Texture(texPage.value()), lightmap_texture);
+		optional<size_t> texPage = iV_GetTexture(groundType.textureName.c_str(), true, maxTerrainTextureSize, maxTerrainTextureSize);
+		ASSERT_OR_RETURN(, texPage.has_value(), "Failed to retrieve terrain texture: %s", groundType.textureName.c_str());
+		optional<size_t> texPage_normalmap = !groundType.normalMapTextureName.empty() ? iV_GetTexture(groundType.normalMapTextureName.c_str()) : nullopt;
+		optional<size_t> texPage_specularmap = !groundType.specularMapTextureName.empty() ? iV_GetTexture(groundType.specularMapTextureName.c_str()) : nullopt;
+		gfx_api::texture* pNormalMapTexture = texPage_normalmap.has_value() ? &pie_Texture(texPage_normalmap.value()) : nullptr;
+		gfx_api::texture* pSpecularMapTexture = texPage_specularmap.has_value() ? &pie_Texture(texPage_specularmap.value()) : nullptr;
+
+		gfx_api::TerrainLayer::get().bind_constants({ glm::mat4(1.f), textureMatrix,
+			ModelView, ModelViewProjection, glm::vec4(currentSunPos, 0.f), paramsX, paramsY, paramsXLight, paramsYLight,
+			fogColor, renderState.fogEnabled, renderState.fogBegin, renderState.fogEnd, 0, 1, pNormalMapTexture != nullptr, pSpecularMapTexture != nullptr});
+
+		// load the textures
+		gfx_api::TerrainLayer::get().bind_textures(&pie_Texture(texPage.value()), lightmap_texture, pNormalMapTexture, pSpecularMapTexture);
 
 		// load the color buffer
 		gfx_api::context::get().bind_vertex_buffers(1, { std::make_tuple(textureVBO, static_cast<size_t>(sizeof(PIELIGHT)*xSectors * ySectors * (sectorSize + 1) * (sectorSize + 1) * 2 * layer)) });
@@ -1260,8 +1272,9 @@ static void drawDecals(const glm::mat4 &ModelViewProjection, const glm::vec4 &pa
  * This function first draws the terrain in black, and then uses additive blending to put the terrain layers
  * on it one by one. Finally the decals are drawn.
  */
-void drawTerrain(const glm::mat4 &mvp)
+void drawTerrain(const glm::mat4 &ModelView, const glm::mat4 &Protection, const Vector3f &currentSunPos)
 {
+	const glm::mat4 mvp = Protection * ModelView;
 	const glm::vec4 paramsXLight(1.0f / world_coord(mapWidth) *((float)mapWidth / (float)lightmapWidth), 0, 0, 0);
 	const glm::vec4 paramsYLight(0, 0, -1.0f / world_coord(mapHeight) *((float)mapHeight / (float)lightmapHeight), 0);
 
@@ -1290,7 +1303,7 @@ void drawTerrain(const glm::mat4 &mvp)
 
 	///////////////////////////////////
 	// terrain
-	drawTerrainLayers(mvp, paramsXLight, paramsYLight, lightMatrix);
+	drawTerrainLayers(ModelView, mvp, currentSunPos, paramsXLight, paramsYLight, lightMatrix);
 
 	//////////////////////////////////
 	// decals

--- a/src/terrain.cpp
+++ b/src/terrain.cpp
@@ -118,6 +118,8 @@ static std::string waterTexture1_nm;
 static std::string waterTexture2_nm;
 static std::string waterTexture1_sm;
 static std::string waterTexture2_sm;
+static std::string waterTexture1_hm;
+static std::string waterTexture2_hm;
 
 /// VBOs
 static gfx_api::buffer *geometryVBO = nullptr, *geometryIndexVBO = nullptr, *textureVBO = nullptr, *textureIndexVBO = nullptr, *decalVBO = nullptr;
@@ -684,6 +686,8 @@ void loadTerrainTextures()
 	waterTexture2_nm = checkTex("page-81-water-2_nm.png");
 	waterTexture1_sm = checkTex("page-80-water-1_sm.png");
 	waterTexture2_sm = checkTex("page-81-water-2_sm.png");
+	waterTexture1_hm = checkTex("page-80-water-1_hm.png");
+	waterTexture2_hm = checkTex("page-81-water-2_hm.png");
 }
 
 /**
@@ -1443,7 +1447,8 @@ void drawWater(const glm::mat4 &ModelViewProjection, const Vector3f &cameraPos, 
 	gfx_api::WaterPSO::get().bind_textures(
 		&pie_Texture(water1_texPage.value()), &pie_Texture(water2_texPage.value()),
 		getOptTex(waterTexture1_nm), getOptTex(waterTexture2_nm),
-		getOptTex(waterTexture1_sm), getOptTex(waterTexture2_sm));
+		getOptTex(waterTexture1_sm), getOptTex(waterTexture2_sm),
+		getOptTex(waterTexture1_hm), getOptTex(waterTexture2_hm));
 	gfx_api::WaterPSO::get().bind_vertex_buffers(waterVBO);
 	gfx_api::WaterPSO::get().bind_constants({
 		ModelViewProjection, ModelUV1, ModelUV2,
@@ -1493,6 +1498,8 @@ void reloadTerrainTextures()
 	reloadTex(waterTexture2_nm);
 	reloadTex(waterTexture1_sm);
 	reloadTex(waterTexture2_sm);
+	reloadTex(waterTexture1_hm);
+	reloadTex(waterTexture2_hm);
 	for (int g=0; g < getNumGroundTypes(); g++) {
 		auto ground = getGroundType(g);
 		reloadTex(ground.textureName);

--- a/src/terrain.cpp
+++ b/src/terrain.cpp
@@ -1491,3 +1491,25 @@ void drawWater(const glm::mat4 &ModelView, const glm::mat4 &Projection, const Ve
 		waterOffset += graphicsTimeAdjustedIncrement(0.1f);
 	}
 }
+
+void reloadTerrainTextures()
+{
+	auto reloadTex = [&](const std::string &tex) {
+		if (!tex.empty()) {
+			WzString wzTex = WzString::fromUtf8(tex);
+			replaceTexture(wzTex, wzTex);
+		}
+	};
+	reloadTex("page-80-water-1.png");
+	reloadTex("page-81-water-2.png");
+	reloadTex(waterTexture1_nm);
+	reloadTex(waterTexture2_nm);
+	reloadTex(waterTexture1_sm);
+	reloadTex(waterTexture2_sm);
+	for (int g=0; g < getNumGroundTypes(); g++) {
+		auto ground = getGroundType(g);
+		reloadTex(ground.textureName);
+		reloadTex(ground.normalMapTextureName);
+		reloadTex(ground.specularMapTextureName);
+	}
+}

--- a/src/terrain.cpp
+++ b/src/terrain.cpp
@@ -663,18 +663,21 @@ void loadTerrainTextures()
 	int32_t maxGfxTextureSize = gfx_api::context::get().get_context_value(gfx_api::context::context_value::MAX_TEXTURE_SIZE);
 	int maxTerrainTextureSize = std::max(std::min({getTextureSize(), maxGfxTextureSize}), MIN_TERRAIN_TEXTURE_SIZE);
 
+	auto preload = [&](const char *type, std::string texName) {
+		if (texName.empty()) return;
+		optional<size_t> texPage = iV_GetTexture(texName.c_str(), true, maxTerrainTextureSize, maxTerrainTextureSize);
+		ASSERT(texPage.has_value(), "Failed to pre-load terrain %s texture: %s", type, texName.c_str());
+	};
+
 	// for each terrain layer
 	for (int layer = 0; layer < getNumGroundTypes(); layer++)
 	{
 		// pre-load the texture
 		const auto groundType = getGroundType(layer);
-		optional<size_t> texPage = iV_GetTexture(groundType.textureName.c_str(), true, maxTerrainTextureSize, maxTerrainTextureSize);
-		ASSERT(texPage.has_value(), "Failed to pre-load terrain texture: %s", groundType.textureName.c_str());
-
-		if (!groundType.normalMapTextureName.empty()) {
-			optional<size_t> texPageNormal = iV_GetTexture(groundType.normalMapTextureName.c_str(), true, maxTerrainTextureSize, maxTerrainTextureSize);
-			ASSERT(texPageNormal.has_value(), "Failed to pre-load terrain normal texture: %s", groundType.normalMapTextureName.c_str());
-		}
+		preload("", groundType.textureName);
+		preload("normapmap", groundType.normalMapTextureName);
+		preload("specmap", groundType.specularMapTextureName);
+		preload("heightmap", groundType.heightMapTextureName);
 	}
 
 	// check water optional textures

--- a/src/terrain.cpp
+++ b/src/terrain.cpp
@@ -351,17 +351,15 @@ static void getGridPos(Vector3i *result, int x, int y, bool center, bool water)
 	}
 }
 
+static Vector3f getGridPosf(int x, int y, bool center = false, bool water = false) {
+	Vector3i r;
+	getGridPos(&r, x, y, center, water);
+	return Vector3f(r);
+}
+
 /// Get normal vector of grid point
 static Vector3f getGridNormal(int x, int y, bool center) {
-	auto pos = [](int x, int y) {
-		Vector3i r;
-		getGridPos(&r, x, y, false, false);
-		return Vector3f(r);
-	};
-	auto posCenter = [pos](int x, int y) {
-		return (pos(x, y) + pos(x+1, y) + pos(x+1, y+1) + pos(x, y+1))/4.0f;
-	};
-	auto calcNormal = [](Vector3f pc, std::vector<Vector3f> p) {
+	auto calcNormal = [](const Vector3f &pc, const std::vector<Vector3f> &p) {
 		auto res = Vector3f(0.0);
 		for (int i = 0; i < p.size(); i++) {
 			auto e1 = p[(i+1)%p.size()] - pc, e2 = p[i] - pc;
@@ -371,11 +369,13 @@ static Vector3f getGridNormal(int x, int y, bool center) {
 		return glm::normalize(res);
 	};
 	if (center) {
-		return calcNormal(posCenter(x, y), {pos(x,y), pos(x+1, y), pos(x+1, y+1), pos(x, y+1)});
+		return calcNormal(getGridPosf(x, y, true), {
+			getGridPosf(x,y), getGridPosf(x+1, y), getGridPosf(x+1, y+1), getGridPosf(x, y+1)
+		});
 	} else {
-		return calcNormal(pos(x, y), {
-			pos(x+1, y), posCenter(x, y),     pos(x, y+1), posCenter(x-1, y),
-			pos(x-1, y), posCenter(x-1, y-1), pos(x, y-1), posCenter(x, y-1)
+		return calcNormal(getGridPosf(x, y), {
+			getGridPosf(x+1, y), getGridPosf(x, y, true),     getGridPosf(x, y+1), getGridPosf(x-1, y, true),
+			getGridPosf(x-1, y), getGridPosf(x-1, y-1, true), getGridPosf(x, y-1), getGridPosf(x, y-1, true)
 		});
 	}
 }
@@ -1201,7 +1201,7 @@ static void drawDepthOnly(const glm::mat4 &ModelViewProjection, const glm::vec4 
 	gfx_api::context::get().unbind_index_buffer(*geometryIndexVBO);
 }
 
-static void drawTerrainLayers(const glm::mat4 &ModelView, const glm::mat4 &ModelViewProjection, const Vector3f &currentSunPos, const glm::vec4 &paramsXLight, const glm::vec4 &paramsYLight, const glm::mat4 &textureMatrix)
+static void drawTerrainLayers(const glm::mat4 &ModelView, const glm::mat4 &ModelViewProjection, const Vector3f &currentSunPos, const glm::vec4 &paramsXLight, const glm::vec4 &paramsYLight, const glm::mat4 &lightTextureMatrix)
 {
 	const auto &renderState = getCurrentRenderState();
 	const glm::vec4 fogColor(
@@ -1210,7 +1210,8 @@ static void drawTerrainLayers(const glm::mat4 &ModelView, const glm::mat4 &Model
 		renderState.fogColour.vector[2] / 255.f,
 		renderState.fogColour.vector[3] / 255.f
 	);
-	const auto NormalMatrix = glm::transpose(glm::inverse(ModelView));
+	const auto ModelViewNormal = glm::transpose(glm::inverse(ModelView));
+	const auto ModelUVLight = lightTextureMatrix * glm::transpose(glm::mat4(paramsXLight, paramsYLight, glm::vec4(0), glm::vec4(0)));
 
 	// load the vertex (geometry) buffer
 	gfx_api::TerrainLayer::get().bind();
@@ -1228,6 +1229,7 @@ static void drawTerrainLayers(const glm::mat4 &ModelView, const glm::mat4 &Model
 		const auto& groundType = getGroundType(layer);
 		const glm::vec4 paramsX(0, 0, -1.0f / world_coord(groundType.textureSize), 0 );
 		const glm::vec4 paramsY(1.0f / world_coord(groundType.textureSize), 0, 0, 0 );
+		auto ModelUV = glm::transpose(glm::mat4(paramsX, paramsY, glm::vec4(0), glm::vec4(0)));
 
 		// load the texture
 		optional<size_t> texPage = iV_GetTexture(groundType.textureName.c_str(), true, maxTerrainTextureSize, maxTerrainTextureSize);
@@ -1237,8 +1239,10 @@ static void drawTerrainLayers(const glm::mat4 &ModelView, const glm::mat4 &Model
 		gfx_api::texture* pNormalMapTexture = texPage_normalmap.has_value() ? &pie_Texture(texPage_normalmap.value()) : nullptr;
 		gfx_api::texture* pSpecularMapTexture = texPage_specularmap.has_value() ? &pie_Texture(texPage_specularmap.value()) : nullptr;
 
-		gfx_api::TerrainLayer::get().bind_constants({ glm::mat4(1.f), textureMatrix,
-			ModelView, ModelViewProjection, NormalMatrix, glm::vec4(currentSunPos, 0.f), paramsX, paramsY, paramsXLight, paramsYLight,
+		gfx_api::TerrainLayer::get().bind_constants({
+			ModelUV, ModelUVLight, ModelView, ModelViewProjection, ModelViewNormal,
+			glm::vec4(currentSunPos, 0.f),
+			pie_GetLighting0(LIGHT_EMISSIVE), pie_GetLighting0(LIGHT_AMBIENT), pie_GetLighting0(LIGHT_DIFFUSE), pie_GetLighting0(LIGHT_SPECULAR),
 			fogColor, renderState.fogEnabled, renderState.fogBegin, renderState.fogEnd, 0, 1, pNormalMapTexture != nullptr, pSpecularMapTexture != nullptr});
 
 		// load the textures

--- a/src/terrain.cpp
+++ b/src/terrain.cpp
@@ -1320,7 +1320,8 @@ static void drawDecals(const glm::mat4 &ModelView, const glm::mat4 &ModelViewNor
 		renderState.fogColour.vector[3] / 255.f
 	);
 	gfx_api::TerrainDecals::get().bind();
-	gfx_api::TerrainDecals::get().bind_textures(&pie_Texture(terrainPage), lightmap_texture, &pie_Texture(terrainNormalPage), &pie_Texture(terrainSpecularPage));
+	gfx_api::TerrainDecals::get().bind_textures(&pie_Texture(terrainPage), lightmap_texture,
+		&pie_Texture(terrainNormalPage), &pie_Texture(terrainSpecularPage), &pie_Texture(terrainHeightPage));
 	gfx_api::TerrainDecals::get().bind_vertex_buffers(decalVBO);
 	gfx_api::TerrainDecals::get().bind_constants({
 		ModelView, ModelViewNormal, ModelViewProjection, ModelUVLightmap,

--- a/src/terrain.cpp
+++ b/src/terrain.cpp
@@ -1453,8 +1453,8 @@ void drawWater(const glm::mat4 &ModelViewProjection, const Vector3f &sunPos, con
 	optional<size_t> water2_texPage = iV_GetTexture("page-81-water-2.png", true, maxTerrainTextureSize, maxTerrainTextureSize);
 	ASSERT_OR_RETURN(, water1_texPage.has_value() && water2_texPage.has_value(), "Failed to load water texture");
 	gfx_api::WaterPSO::get().bind();
-	auto getOptTex = [](const std::string &fileName) {
-		return fileName.empty() ? nullptr : &pie_Texture(iV_GetTexture(fileName.c_str()).value());
+	auto getOptTex = [&maxTerrainTextureSize](const std::string &fileName) {
+		return fileName.empty() ? nullptr : &pie_Texture(iV_GetTexture(fileName.c_str(), true, maxTerrainTextureSize, maxTerrainTextureSize).value());
 	};
 	gfx_api::WaterPSO::get().bind_textures(
 		&pie_Texture(water1_texPage.value()), &pie_Texture(water2_texPage.value()),

--- a/src/terrain.cpp
+++ b/src/terrain.cpp
@@ -154,7 +154,7 @@ GLsizei dreCount;
 /// Are we actually drawing something using the DrawRangeElements functions?
 bool drawRangeElementsStarted = false;
 
-TerrainShaderQuality terrainShaderQuality = TerrainShaderQuality::CLASSIC;
+TerrainShaderQuality terrainShaderQuality = TerrainShaderQuality::NORMAL_MAPPING;
 
 #define MIN_TERRAIN_TEXTURE_SIZE 512
 
@@ -1275,7 +1275,8 @@ static void drawTerrainLayers(const glm::mat4 &ModelViewProjection, const glm::m
 	int32_t maxGfxTextureSize = gfx_api::context::get().get_context_value(gfx_api::context::context_value::MAX_TEXTURE_SIZE);
 	int maxTerrainTextureSize = std::max(std::min({getTextureSize(), maxGfxTextureSize}), MIN_TERRAIN_TEXTURE_SIZE);
 	auto getOptTex = [&maxTerrainTextureSize](const std::string &fileName) {
-		return fileName.empty() ? nullptr : &pie_Texture(iV_GetTexture(fileName.c_str(), true, maxTerrainTextureSize, maxTerrainTextureSize).value());
+		if (fileName.empty() || terrainShaderQuality == TerrainShaderQuality::CLASSIC) return (gfx_api::texture*)nullptr;
+		return &pie_Texture(iV_GetTexture(fileName.c_str(), true, maxTerrainTextureSize, maxTerrainTextureSize).value());
 	};
 
 	// draw each layer separately
@@ -1451,7 +1452,8 @@ void drawWater(const glm::mat4 &ModelViewProjection, const Vector3f &cameraPos, 
 	ASSERT_OR_RETURN(, water1_texPage.has_value() && water2_texPage.has_value(), "Failed to load water texture");
 	gfx_api::WaterPSO::get().bind();
 	auto getOptTex = [&maxTerrainTextureSize](const std::string &fileName) {
-		return fileName.empty() ? nullptr : &pie_Texture(iV_GetTexture(fileName.c_str(), true, maxTerrainTextureSize, maxTerrainTextureSize).value());
+		if (fileName.empty() || terrainShaderQuality == TerrainShaderQuality::CLASSIC) return (gfx_api::texture*)nullptr;
+		return &pie_Texture(iV_GetTexture(fileName.c_str(), true, maxTerrainTextureSize, maxTerrainTextureSize).value());
 	};
 	gfx_api::WaterPSO::get().bind_textures(
 		&pie_Texture(water1_texPage.value()), &pie_Texture(water2_texPage.value()),

--- a/src/terrain.cpp
+++ b/src/terrain.cpp
@@ -1425,25 +1425,22 @@ void drawTerrain(const glm::mat4 &ModelView, const glm::mat4 &Protection, const 
  * Draw the water.
  * sunPos and cameraPos in Model=WorldSpace
  */
-void drawWater(const glm::mat4 &ModelViewProjection, const Vector3f &sunPos, const Vector3f &cameraPos)
+void drawWater(const glm::mat4 &ModelView, const glm::mat4 &Projection, const Vector3f &cameraPos, const Vector3f &sunPos, const Vector3f &sunPosInView)
 {
 	if (!waterIndexVBO)
 	{
 		return; // no water
 	}
+	const auto ModelViewProjection = Projection * ModelView;
+	const auto ModelViewNormal = glm::transpose(glm::inverse(ModelView));
 
-	int x, y;
 	const glm::vec4 paramsX(0, 0, -1.0f / world_coord(4), 0);
 	const glm::vec4 paramsY(1.0f / world_coord(4), 0, 0, 0);
 	const glm::vec4 paramsX2(0, 0, -1.0f / world_coord(5), 0);
 	const glm::vec4 paramsY2(1.0f / world_coord(5), 0, 0, 0);
 	const auto ModelUV1 = glm::translate(glm::vec3(waterOffset, 0.f, 0.f)) * glm::transpose(glm::mat4(paramsX, paramsY, glm::vec4(0,0,1,0), glm::vec4(0,0,0,1)));
 	const auto ModelUV2 = glm::transpose(glm::mat4(paramsX2, paramsY2, glm::vec4(0,0,1,0), glm::vec4(0,0,0,1)));
-	const auto normal = glm::vec3(0,1,0); // y
-	const auto tangent = glm::normalize(paramsY.xyz()); // x
-	const auto bitangent = glm::cross(normal, tangent); // z
-	const auto ModelTangent = glm::transpose(glm::mat3(tangent, bitangent, normal)); // xzy
-	const auto lightDirInTangent = glm::normalize(- ModelTangent * sunPos);
+
 	const auto &renderState = getCurrentRenderState();
 
 	int32_t maxGfxTextureSize = gfx_api::context::get().get_context_value(gfx_api::context::context_value::MAX_TEXTURE_SIZE);
@@ -1462,16 +1459,17 @@ void drawWater(const glm::mat4 &ModelViewProjection, const Vector3f &sunPos, con
 		getOptTex(waterTexture1_sm), getOptTex(waterTexture2_sm));
 	gfx_api::WaterPSO::get().bind_vertex_buffers(waterVBO);
 	gfx_api::WaterPSO::get().bind_constants({
-		ModelViewProjection, ModelTangent, ModelUV1, ModelUV2,
-		cameraPos, lightDirInTangent,
+		ModelViewProjection, ModelView, ModelViewNormal, ModelUV1, ModelUV2,
+		waterOffset*10,
+		cameraPos, glm::normalize(sunPos), sunPosInView,
 		pie_GetLighting0(LIGHT_EMISSIVE), pie_GetLighting0(LIGHT_AMBIENT), pie_GetLighting0(LIGHT_DIFFUSE), pie_GetLighting0(LIGHT_SPECULAR),
 		glm::vec4(0.f), renderState.fogEnabled, renderState.fogBegin, renderState.fogEnd
 	});
 	gfx_api::context::get().bind_index_buffer(*waterIndexVBO, gfx_api::index_type::u32);
 
-	for (x = 0; x < xSectors; x++)
+	for (int x = 0; x < xSectors; x++)
 	{
-		for (y = 0; y < ySectors; y++)
+		for (int y = 0; y < ySectors; y++)
 		{
 			if (sectors[x * ySectors + y].draw)
 			{

--- a/src/terrain.cpp
+++ b/src/terrain.cpp
@@ -1283,7 +1283,7 @@ static void drawTerrainLayers(const glm::mat4 &ModelViewProjection, const glm::m
 
 		gfx_api::TerrainLayer::get().bind_constants({
 			ModelViewProjection, ModelUV, ModelUVLightmap,
-			cameraPos, glm::normalize(sunPos),
+			glm::vec4(cameraPos, 0), glm::vec4(glm::normalize(sunPos), 0),
 			pie_GetLighting0(LIGHT_EMISSIVE), pie_GetLighting0(LIGHT_AMBIENT), pie_GetLighting0(LIGHT_DIFFUSE), pie_GetLighting0(LIGHT_SPECULAR),
 			fogColor, renderState.fogEnabled, renderState.fogBegin, renderState.fogEnd, pNormalMapTexture != nullptr, pSpecularMapTexture != nullptr});
 
@@ -1333,7 +1333,7 @@ static void drawDecals(const glm::mat4 &ModelViewProjection, const glm::mat4 &Mo
 	gfx_api::TerrainDecals::get().bind_vertex_buffers(decalVBO);
 	gfx_api::TerrainDecals::get().bind_constants({
 		ModelViewProjection, ModelUVLightmap,
-		cameraPos, glm::normalize(sunPos),
+		glm::vec4(cameraPos, 0), glm::vec4(glm::normalize(sunPos), 0),
 		pie_GetLighting0(LIGHT_EMISSIVE), pie_GetLighting0(LIGHT_AMBIENT), pie_GetLighting0(LIGHT_DIFFUSE), pie_GetLighting0(LIGHT_SPECULAR),
 		fogColor, renderState.fogEnabled, renderState.fogBegin, renderState.fogEnd });
 
@@ -1446,10 +1446,10 @@ void drawWater(const glm::mat4 &ModelViewProjection, const Vector3f &cameraPos, 
 	gfx_api::WaterPSO::get().bind_vertex_buffers(waterVBO);
 	gfx_api::WaterPSO::get().bind_constants({
 		ModelViewProjection, ModelUV1, ModelUV2,
-		waterOffset*10,
-		cameraPos, glm::normalize(sunPos),
+		glm::vec4(cameraPos, 0), glm::vec4(glm::normalize(sunPos), 0),
 		pie_GetLighting0(LIGHT_EMISSIVE), pie_GetLighting0(LIGHT_AMBIENT), pie_GetLighting0(LIGHT_DIFFUSE), pie_GetLighting0(LIGHT_SPECULAR),
-		glm::vec4(0.f), renderState.fogEnabled, renderState.fogBegin, renderState.fogEnd
+		glm::vec4(0.f), renderState.fogEnabled, renderState.fogBegin, renderState.fogEnd,
+		waterOffset*10,
 	});
 	gfx_api::context::get().bind_index_buffer(*waterIndexVBO, gfx_api::index_type::u32);
 

--- a/src/terrain.cpp
+++ b/src/terrain.cpp
@@ -99,6 +99,8 @@ struct DecalVertex
 	glm::vec4 tangent = glm::vec4(1.f, 0.f, 0.f, 1.f);
 };
 
+using WaterVertex = glm::vec4; // w is depth
+
 /// The lightmap texture
 static gfx_api::texture* lightmap_texture = nullptr;
 /// When are we going to update the lightmap next?
@@ -402,41 +404,30 @@ static inline void averageColour(PIELIGHT *average, PIELIGHT a, PIELIGHT b,
 /**
  * Set the terrain and water geometry for the specified sector
  */
-static void setSectorGeometry(int x, int y,
-                              RenderVertex *geometry, RenderVertex *normals, RenderVertex *water,
+static void setSectorGeometry(int sx, int sy,
+                              RenderVertex *geometry, RenderVertex *normals, WaterVertex *water,
                               int *geometrySize, int *waterSize)
 {
-	Vector3i pos;
-	int i, j;
-	for (i = 0; i < sectorSize + 1; i++)
+	for (int x = sx*sectorSize; x < (sx+1)*sectorSize + 1; x++)
 	{
-		for (j = 0; j < sectorSize + 1; j++)
+		for (int y = sy * sectorSize; y < (sy+1) * sectorSize + 1; y++)
 		{
 			// set up geometry
-			getGridPos(&pos, i + x * sectorSize, j + y * sectorSize, false, false);
-			geometry[*geometrySize].x = pos.x;
-			geometry[*geometrySize].y = pos.y;
-			geometry[*geometrySize].z = pos.z;
-			normals[*geometrySize] = getGridNormal(i + x * sectorSize, j + y * sectorSize, false);
+			auto pos = getGridPosf(x, y, false, false);
+			geometry[*geometrySize] = pos;
+			normals[*geometrySize] = getGridNormal(x, y, false);
 			(*geometrySize)++;
 
-			getGridPos(&pos, i + x * sectorSize, j + y * sectorSize, true, false);
-			geometry[*geometrySize].x = pos.x;
-			geometry[*geometrySize].y = pos.y;
-			geometry[*geometrySize].z = pos.z;
-			normals[*geometrySize] = getGridNormal(i + x * sectorSize, j + y * sectorSize, true);
-			(*geometrySize)++;
-
-			getGridPos(&pos, i + x * sectorSize, j + y * sectorSize, false, true);
-			water[*waterSize].x = pos.x;
-			water[*waterSize].y = pos.y;
-			water[*waterSize].z = pos.z;
+			float waterHeight = map_WaterHeight(x, y);
+			water[*waterSize] = glm::vec4(pos.x, waterHeight, pos.z, waterHeight - pos.y);
 			(*waterSize)++;
 
-			getGridPos(&pos, i + x * sectorSize, j + y * sectorSize, true, true);
-			water[*waterSize].x = pos.x;
-			water[*waterSize].y = pos.y;
-			water[*waterSize].z = pos.z;
+			pos = getGridPosf(x, y, true, false);
+			geometry[*geometrySize] = pos;
+			normals[*geometrySize] = getGridNormal(x, y, true);
+			(*geometrySize)++;
+
+			water[*waterSize] = glm::vec4(pos.x, waterHeight, pos.z, waterHeight - pos.y);
 			(*waterSize)++;
 		}
 	}
@@ -567,7 +558,7 @@ static void setSectorDecals(int x, int y, DecalVertex *decaldata, int *decalSize
 static void updateSectorGeometry(int x, int y)
 {
 	RenderVertex *geometry, *normals;
-	RenderVertex *water;
+	WaterVertex *water;
 	DecalVertex *decaldata;
 	int geometrySize = 0;
 	int waterSize = 0;
@@ -575,7 +566,7 @@ static void updateSectorGeometry(int x, int y)
 
 	geometry  = (RenderVertex *)malloc(sizeof(RenderVertex) * sectors[x * ySectors + y].geometrySize);
 	normals   = (RenderVertex *)malloc(sizeof(RenderVertex) * sectors[x * ySectors + y].geometrySize);
-	water     = (RenderVertex *)malloc(sizeof(RenderVertex) * sectors[x * ySectors + y].waterSize);
+	water     = (WaterVertex *)malloc(sizeof(WaterVertex) * sectors[x * ySectors + y].waterSize);
 
 	setSectorGeometry(x, y, geometry, normals, water, &geometrySize, &waterSize);
 	ASSERT(geometrySize == sectors[x * ySectors + y].geometrySize, "something went seriously wrong updating the terrain");
@@ -584,8 +575,8 @@ static void updateSectorGeometry(int x, int y)
 	geometryVBO->update(sizeof(RenderVertex)*sectors[x * ySectors + y].geometryOffset,
 	                    sizeof(RenderVertex)*sectors[x * ySectors + y].geometrySize, geometry,
 						gfx_api::buffer::update_flag::non_overlapping_updates_promise);
-	waterVBO->update(sizeof(RenderVertex)*sectors[x * ySectors + y].waterOffset,
-	                 sizeof(RenderVertex)*sectors[x * ySectors + y].waterSize, water,
+	waterVBO->update(sizeof(WaterVertex)*sectors[x * ySectors + y].waterOffset,
+	                 sizeof(WaterVertex)*sectors[x * ySectors + y].waterSize, water,
 					 gfx_api::buffer::update_flag::non_overlapping_updates_promise);
 
 	free(geometry);
@@ -707,7 +698,7 @@ bool initTerrain()
 	int layer = 0;
 
 	RenderVertex *geometry, *normals;
-	RenderVertex *water;
+	WaterVertex *water;
 	DecalVertex *decaldata;
 	int geometrySize, geometryIndexSize;
 	int waterSize, waterIndexSize;
@@ -783,7 +774,7 @@ bool initTerrain()
 	geometrySize = 0;
 	geometryIndexSize = 0;
 
-	water = (RenderVertex *)malloc(sizeof(RenderVertex) * vertSize);
+	water = (WaterVertex *)malloc(sizeof(WaterVertex) * vertSize);
 	waterIndex = (GLuint *)malloc(sizeof(GLuint) * xSectors * ySectors * sectorSize * sectorSize * 12);
 	waterSize = 0;
 	waterIndexSize = 0;
@@ -891,7 +882,7 @@ bool initTerrain()
 	if (waterVBO)
 		delete waterVBO;
 	waterVBO = gfx_api::context::get().create_buffer_object(gfx_api::buffer::usage::vertex_buffer, gfx_api::context::buffer_storage_hint::dynamic_draw);
-	waterVBO->upload(sizeof(RenderVertex)*waterSize, water);
+	waterVBO->upload(sizeof(WaterVertex)*waterSize, water);
 	free(water);
 
 	if (waterIndexVBO)

--- a/src/terrain.cpp
+++ b/src/terrain.cpp
@@ -680,9 +680,11 @@ void loadTerrainTextures()
 		// pre-load the texture
 		const auto groundType = getGroundType(layer);
 		preload("", groundType.textureName);
-		preload("normapmap", groundType.normalMapTextureName);
-		preload("specmap", groundType.specularMapTextureName);
-		preload("heightmap", groundType.heightMapTextureName);
+		if (terrainShaderQuality != TerrainShaderQuality::CLASSIC) {
+			preload("normapmap", groundType.normalMapTextureName);
+			preload("specmap", groundType.specularMapTextureName);
+			preload("heightmap", groundType.heightMapTextureName);
+		}
 	}
 
 	// check water optional textures

--- a/src/terrain.cpp
+++ b/src/terrain.cpp
@@ -154,6 +154,8 @@ GLsizei dreCount;
 /// Are we actually drawing something using the DrawRangeElements functions?
 bool drawRangeElementsStarted = false;
 
+TerrainShaderQuality terrainShaderQuality = TerrainShaderQuality::CLASSIC;
+
 #define MIN_TERRAIN_TEXTURE_SIZE 512
 
 /// Pass all remaining triangles to OpenGL
@@ -1296,7 +1298,8 @@ static void drawTerrainLayers(const glm::mat4 &ModelViewProjection, const glm::m
 			ModelViewProjection, ModelUV, ModelUVLightmap,
 			glm::vec4(cameraPos, 0), glm::vec4(glm::normalize(sunPos), 0),
 			pie_GetLighting0(LIGHT_EMISSIVE), pie_GetLighting0(LIGHT_AMBIENT), pie_GetLighting0(LIGHT_DIFFUSE), pie_GetLighting0(LIGHT_SPECULAR),
-			fogColor, renderState.fogEnabled, renderState.fogBegin, renderState.fogEnd, pNormalMapTexture != nullptr, pSpecularMapTexture != nullptr, pHeightMapTexture != nullptr});
+			fogColor, renderState.fogEnabled, renderState.fogBegin, renderState.fogEnd,
+			terrainShaderQuality, pNormalMapTexture != nullptr, pSpecularMapTexture != nullptr, pHeightMapTexture != nullptr});
 
 		// load the textures
 		gfx_api::TerrainLayer::get().bind_textures(&pie_Texture(texPage.value()), lightmap_texture, pNormalMapTexture, pSpecularMapTexture, pHeightMapTexture);
@@ -1346,7 +1349,7 @@ static void drawDecals(const glm::mat4 &ModelViewProjection, const glm::mat4 &Mo
 		ModelViewProjection, ModelUVLightmap,
 		glm::vec4(cameraPos, 0), glm::vec4(glm::normalize(sunPos), 0),
 		pie_GetLighting0(LIGHT_EMISSIVE), pie_GetLighting0(LIGHT_AMBIENT), pie_GetLighting0(LIGHT_DIFFUSE), pie_GetLighting0(LIGHT_SPECULAR),
-		fogColor, renderState.fogEnabled, renderState.fogBegin, renderState.fogEnd });
+		fogColor, renderState.fogEnabled, renderState.fogBegin, renderState.fogEnd, terrainShaderQuality });
 
 	int size = 0;
 	int offset = 0;
@@ -1461,7 +1464,7 @@ void drawWater(const glm::mat4 &ModelViewProjection, const Vector3f &cameraPos, 
 		glm::vec4(cameraPos, 0), glm::vec4(glm::normalize(sunPos), 0),
 		pie_GetLighting0(LIGHT_EMISSIVE), pie_GetLighting0(LIGHT_AMBIENT), pie_GetLighting0(LIGHT_DIFFUSE), pie_GetLighting0(LIGHT_SPECULAR),
 		glm::vec4(0.f), renderState.fogEnabled, renderState.fogBegin, renderState.fogEnd,
-		waterOffset*10,
+		waterOffset*10, terrainShaderQuality
 	});
 	gfx_api::context::get().bind_index_buffer(*waterIndexVBO, gfx_api::index_type::u32);
 

--- a/src/terrain.cpp
+++ b/src/terrain.cpp
@@ -110,6 +110,7 @@ static const unsigned int LIGHTMAP_REFRESH = 80;
 
 /// VBOs
 static gfx_api::buffer *geometryVBO = nullptr, *geometryIndexVBO = nullptr, *textureVBO = nullptr, *textureIndexVBO = nullptr, *decalVBO = nullptr;
+static gfx_api::buffer *normalVBO = nullptr;
 /// VBOs
 static gfx_api::buffer *waterVBO = nullptr, *waterIndexVBO = nullptr;
 /// The amount we shift the water textures so the waves appear to be moving
@@ -350,6 +351,37 @@ static void getGridPos(Vector3i *result, int x, int y, bool center, bool water)
 	}
 }
 
+/// Get normal vector of grid point
+static Vector3f getGridNormal(int x, int y, bool center) {
+	auto pos = [](int x, int y) {
+		Vector3i r;
+		getGridPos(&r, x, y, false, false);
+		return Vector3f(r);
+	};
+	auto posCenter = [pos](int x, int y) {
+		return (pos(x, y) + pos(x+1, y) + pos(x+1, y+1) + pos(x, y+1))/4.0f;
+	};
+	auto res = Vector3f(0.0);
+	if (center) {
+		Vector3f p[] = {pos(x,y), pos(x+1, y), pos(x+1, y+1), pos(x, y+1)};
+		auto pc = posCenter(x, y);
+		for (int i = 0; i < 4; i++) {
+			res += glm::cross(p[(i+1)%4] - pc, p[i] - pc);
+		}
+		return glm::normalize(res);
+	} else {
+		Vector3f p[] = {
+			pos(x+1, y), posCenter(x, y),     pos(x, y+1), posCenter(x-1, y),
+			pos(x-1, y), posCenter(x-1, y-1), pos(x, y-1), posCenter(x, y-1)
+		};
+		auto pc = pos(x, y);
+		for (int i = 0; i < 8; i++) {
+			res += glm::cross(p[(i+1)%8] - pc, p[i] - pc);
+		}
+		return glm::normalize(res);
+	}
+}
+
 /// Calculate the average colour of 4 points
 static inline void averageColour(PIELIGHT *average, PIELIGHT a, PIELIGHT b,
                                  PIELIGHT c, PIELIGHT d)
@@ -364,7 +396,7 @@ static inline void averageColour(PIELIGHT *average, PIELIGHT a, PIELIGHT b,
  * Set the terrain and water geometry for the specified sector
  */
 static void setSectorGeometry(int x, int y,
-                              RenderVertex *geometry, RenderVertex *water,
+                              RenderVertex *geometry, RenderVertex *normals, RenderVertex *water,
                               int *geometrySize, int *waterSize)
 {
 	Vector3i pos;
@@ -378,12 +410,14 @@ static void setSectorGeometry(int x, int y,
 			geometry[*geometrySize].x = pos.x;
 			geometry[*geometrySize].y = pos.y;
 			geometry[*geometrySize].z = pos.z;
+			normals[*geometrySize] = getGridNormal(i + x * sectorSize, j + y * sectorSize, false);
 			(*geometrySize)++;
 
 			getGridPos(&pos, i + x * sectorSize, j + y * sectorSize, true, false);
 			geometry[*geometrySize].x = pos.x;
 			geometry[*geometrySize].y = pos.y;
 			geometry[*geometrySize].z = pos.z;
+			normals[*geometrySize] = getGridNormal(i + x * sectorSize, j + y * sectorSize, true);
 			(*geometrySize)++;
 
 			getGridPos(&pos, i + x * sectorSize, j + y * sectorSize, false, true);
@@ -492,7 +526,7 @@ static void setSectorDecals(int x, int y, DecalVertex *decaldata, int *decalSize
  */
 static void updateSectorGeometry(int x, int y)
 {
-	RenderVertex *geometry;
+	RenderVertex *geometry, *normals;
 	RenderVertex *water;
 	DecalVertex *decaldata;
 	int geometrySize = 0;
@@ -500,9 +534,10 @@ static void updateSectorGeometry(int x, int y)
 	int decalSize = 0;
 
 	geometry  = (RenderVertex *)malloc(sizeof(RenderVertex) * sectors[x * ySectors + y].geometrySize);
+	normals   = (RenderVertex *)malloc(sizeof(RenderVertex) * sectors[x * ySectors + y].geometrySize);
 	water     = (RenderVertex *)malloc(sizeof(RenderVertex) * sectors[x * ySectors + y].waterSize);
 
-	setSectorGeometry(x, y, geometry, water, &geometrySize, &waterSize);
+	setSectorGeometry(x, y, geometry, normals, water, &geometrySize, &waterSize);
 	ASSERT(geometrySize == sectors[x * ySectors + y].geometrySize, "something went seriously wrong updating the terrain");
 	ASSERT(waterSize    == sectors[x * ySectors + y].waterSize   , "something went seriously wrong updating the terrain");
 
@@ -603,6 +638,11 @@ void loadTerrainTextures()
 		const auto groundType = getGroundType(layer);
 		optional<size_t> texPage = iV_GetTexture(groundType.textureName.c_str(), true, maxTerrainTextureSize, maxTerrainTextureSize);
 		ASSERT(texPage.has_value(), "Failed to pre-load terrain texture: %s", groundType.textureName.c_str());
+
+		if (!groundType.normalMapTextureName.empty()) {
+			optional<size_t> texPageNormal = iV_GetTexture(groundType.normalMapTextureName.c_str(), true, maxTerrainTextureSize, maxTerrainTextureSize);
+			ASSERT(texPageNormal.has_value(), "Failed to pre-load terrain normal texture: %s", groundType.normalMapTextureName.c_str());
+		}
 	}
 }
 
@@ -616,7 +656,7 @@ bool initTerrain()
 	PIELIGHT colour[2][2], centerColour;
 	int layer = 0;
 
-	RenderVertex *geometry;
+	RenderVertex *geometry, *normals;
 	RenderVertex *water;
 	DecalVertex *decaldata;
 	int geometrySize, geometryIndexSize;
@@ -686,12 +726,14 @@ bool initTerrain()
 
 	////////////////////
 	// fill the geometry part of the sectors
-	geometry = (RenderVertex *)malloc(sizeof(RenderVertex) * xSectors * ySectors * (sectorSize + 1) * (sectorSize + 1) * 2);
+	const int vertSize = xSectors * ySectors * (sectorSize + 1) * (sectorSize + 1) * 2;
+	geometry = (RenderVertex *)malloc(sizeof(RenderVertex) * vertSize);
+	normals  = (RenderVertex *)malloc(sizeof(RenderVertex) * vertSize);
 	geometryIndex = (GLuint *)malloc(sizeof(GLuint) * xSectors * ySectors * sectorSize * sectorSize * 12);
 	geometrySize = 0;
 	geometryIndexSize = 0;
 
-	water = (RenderVertex *)malloc(sizeof(RenderVertex) * xSectors * ySectors * (sectorSize + 1) * (sectorSize + 1) * 2);
+	water = (RenderVertex *)malloc(sizeof(RenderVertex) * vertSize);
 	waterIndex = (GLuint *)malloc(sizeof(GLuint) * xSectors * ySectors * sectorSize * sectorSize * 12);
 	waterSize = 0;
 	waterIndexSize = 0;
@@ -705,7 +747,7 @@ bool initTerrain()
 			sectors[x * ySectors + y].waterOffset = waterSize;
 			sectors[x * ySectors + y].waterSize = 0;
 
-			setSectorGeometry(x, y, geometry, water, &geometrySize, &waterSize);
+			setSectorGeometry(x, y, geometry, normals, water, &geometrySize, &waterSize);
 
 			sectors[x * ySectors + y].geometrySize = geometrySize - sectors[x * ySectors + y].geometryOffset;
 			sectors[x * ySectors + y].waterSize = waterSize - sectors[x * ySectors + y].waterOffset;
@@ -783,6 +825,12 @@ bool initTerrain()
 	geometryVBO = gfx_api::context::get().create_buffer_object(gfx_api::buffer::usage::vertex_buffer, gfx_api::context::buffer_storage_hint::dynamic_draw);
 	geometryVBO->upload(sizeof(RenderVertex)*geometrySize, geometry);
 	free(geometry);
+
+	if (normalVBO)
+		delete normalVBO;
+	normalVBO = gfx_api::context::get().create_buffer_object(gfx_api::buffer::usage::vertex_buffer, gfx_api::context::buffer_storage_hint::dynamic_draw);
+	normalVBO->upload(sizeof(RenderVertex)*geometrySize, normals);
+	free(normals);
 
 	if (geometryIndexVBO)
 		delete geometryIndexVBO;
@@ -990,6 +1038,8 @@ void shutdownTerrain()
 	}
 	delete geometryVBO;
 	geometryVBO = nullptr;
+	delete normalVBO;
+	normalVBO = nullptr;
 	delete geometryIndexVBO;
 	geometryIndexVBO = nullptr;
 	delete waterVBO;
@@ -1165,7 +1215,7 @@ static void drawTerrainLayers(const glm::mat4 &ModelView, const glm::mat4 &Model
 
 	// load the vertex (geometry) buffer
 	gfx_api::TerrainLayer::get().bind();
-	gfx_api::TerrainLayer::get().bind_vertex_buffers(geometryVBO, textureVBO);
+	gfx_api::TerrainLayer::get().bind_vertex_buffers(geometryVBO, textureVBO, normalVBO);
 	gfx_api::context::get().bind_index_buffer(*textureIndexVBO, gfx_api::index_type::u32);
 	const size_t numGroundTypes = getNumGroundTypes();
 	ASSERT_OR_RETURN(, numGroundTypes, "Ground type was not set, no textures will be seen.");
@@ -1214,7 +1264,7 @@ static void drawTerrainLayers(const glm::mat4 &ModelView, const glm::mat4 &Model
 		}
 		finishDrawRangeElements<gfx_api::TerrainLayer>();
 	}
-	gfx_api::TerrainLayer::get().unbind_vertex_buffers(geometryVBO, textureVBO);
+	gfx_api::TerrainLayer::get().unbind_vertex_buffers(geometryVBO, textureVBO, normalVBO);
 	gfx_api::context::get().unbind_index_buffer(*textureIndexVBO);
 }
 

--- a/src/terrain.cpp
+++ b/src/terrain.cpp
@@ -1244,7 +1244,7 @@ static void drawDepthOnly(const glm::mat4 &ModelViewProjection, const glm::vec4 
 	gfx_api::context::get().unbind_index_buffer(*geometryIndexVBO);
 }
 
-static void drawTerrainLayers(const glm::mat4 &ModelView, const glm::mat4 &ModelViewNormal, const glm::mat4 &ModelViewProjection, const Vector3f &currentSunPos, const glm::mat4 &ModelUVLightmap)
+static void drawTerrainLayers(const glm::mat4 &ModelViewProjection, const glm::mat4 &ModelUVLightmap, const Vector3f &cameraPos, const Vector3f &sunPos)
 {
 	const auto &renderState = getCurrentRenderState();
 	const glm::vec4 fogColor(
@@ -1282,10 +1282,10 @@ static void drawTerrainLayers(const glm::mat4 &ModelView, const glm::mat4 &Model
 		gfx_api::texture* pSpecularMapTexture = texPage_specularmap.has_value() ? &pie_Texture(texPage_specularmap.value()) : nullptr;
 
 		gfx_api::TerrainLayer::get().bind_constants({
-			ModelUV, ModelUVLightmap, ModelView, ModelViewProjection, ModelViewNormal,
-			glm::vec4(currentSunPos, 0.f),
+			ModelViewProjection, ModelUV, ModelUVLightmap,
+			cameraPos, glm::normalize(sunPos),
 			pie_GetLighting0(LIGHT_EMISSIVE), pie_GetLighting0(LIGHT_AMBIENT), pie_GetLighting0(LIGHT_DIFFUSE), pie_GetLighting0(LIGHT_SPECULAR),
-			fogColor, renderState.fogEnabled, renderState.fogBegin, renderState.fogEnd, 0, 1, pNormalMapTexture != nullptr, pSpecularMapTexture != nullptr});
+			fogColor, renderState.fogEnabled, renderState.fogBegin, renderState.fogEnd, pNormalMapTexture != nullptr, pSpecularMapTexture != nullptr});
 
 		// load the textures
 		gfx_api::TerrainLayer::get().bind_textures(&pie_Texture(texPage.value()), lightmap_texture, pNormalMapTexture, pSpecularMapTexture);
@@ -1313,7 +1313,7 @@ static void drawTerrainLayers(const glm::mat4 &ModelView, const glm::mat4 &Model
 	gfx_api::context::get().unbind_index_buffer(*textureIndexVBO);
 }
 
-static void drawDecals(const glm::mat4 &ModelView, const glm::mat4 &ModelViewNormal, const glm::mat4 &ModelViewProjection, const Vector3f &currentSunPos, const glm::mat4 &ModelUVLightmap)
+static void drawDecals(const glm::mat4 &ModelViewProjection, const glm::mat4 &ModelUVLightmap, const Vector3f &cameraPos, const Vector3f &sunPos)
 {
 	if (!decalVBO)
 	{
@@ -1332,10 +1332,10 @@ static void drawDecals(const glm::mat4 &ModelView, const glm::mat4 &ModelViewNor
 		&pie_Texture(terrainNormalPage), &pie_Texture(terrainSpecularPage), &pie_Texture(terrainHeightPage));
 	gfx_api::TerrainDecals::get().bind_vertex_buffers(decalVBO);
 	gfx_api::TerrainDecals::get().bind_constants({
-		ModelView, ModelViewNormal, ModelViewProjection, ModelUVLightmap,
-		glm::vec4(currentSunPos, 0.f),
+		ModelViewProjection, ModelUVLightmap,
+		cameraPos, glm::normalize(sunPos),
 		pie_GetLighting0(LIGHT_EMISSIVE), pie_GetLighting0(LIGHT_AMBIENT), pie_GetLighting0(LIGHT_DIFFUSE), pie_GetLighting0(LIGHT_SPECULAR),
-		fogColor, renderState.fogEnabled, renderState.fogBegin, renderState.fogEnd, 0, 1 });
+		fogColor, renderState.fogEnabled, renderState.fogBegin, renderState.fogEnd });
 
 	int size = 0;
 	int offset = 0;
@@ -1371,9 +1371,8 @@ static void drawDecals(const glm::mat4 &ModelView, const glm::mat4 &ModelViewNor
  * This function first draws the terrain in black, and then uses additive blending to put the terrain layers
  * on it one by one. Finally the decals are drawn.
  */
-void drawTerrain(const glm::mat4 &ModelView, const glm::mat4 &Protection, const Vector3f &currentSunPos)
+void drawTerrain(const glm::mat4 &mvp, const Vector3f &cameraPos, const Vector3f &sunPos)
 {
-	const glm::mat4 mvp = Protection * ModelView;
 	const glm::vec4 paramsXLight(1.0f / world_coord(mapWidth) *((float)mapWidth / (float)lightmapWidth), 0, 0, 0);
 	const glm::vec4 paramsYLight(0, 0, -1.0f / world_coord(mapHeight) *((float)mapHeight / (float)lightmapHeight), 0);
 
@@ -1395,8 +1394,6 @@ void drawTerrain(const glm::mat4 &ModelView, const glm::mat4 &Protection, const 
 
 	// shift the lightmap half a tile as lights are supposed to be placed at the center of a tile
 	const glm::mat4 lightMatrix = glm::translate(glm::vec3(1.f / (float)lightmapWidth / 2, 1.f / (float)lightmapHeight / 2, 0.f));
-
-	const auto ModelViewNormal = glm::transpose(glm::inverse(ModelView));
 	const auto ModelUVLightmap = lightMatrix * glm::transpose(glm::mat4(paramsXLight, paramsYLight, glm::vec4(0,0,1,0), glm::vec4(0,0,0,1)));
 
 	//////////////////////////////////////
@@ -1405,25 +1402,23 @@ void drawTerrain(const glm::mat4 &ModelView, const glm::mat4 &Protection, const 
 
 	///////////////////////////////////
 	// terrain
-	drawTerrainLayers(ModelView, ModelViewNormal, mvp, currentSunPos, ModelUVLightmap);
+	drawTerrainLayers(mvp, ModelUVLightmap, cameraPos, sunPos);
 
 	//////////////////////////////////
 	// decals
-	drawDecals(ModelView, ModelViewNormal, mvp, currentSunPos, ModelUVLightmap);
+	drawDecals(mvp, ModelUVLightmap, cameraPos, sunPos);
 }
 
 /**
  * Draw the water.
  * sunPos and cameraPos in Model=WorldSpace
  */
-void drawWater(const glm::mat4 &ModelView, const glm::mat4 &Projection, const Vector3f &cameraPos, const Vector3f &sunPos, const Vector3f &sunPosInView)
+void drawWater(const glm::mat4 &ModelViewProjection, const Vector3f &cameraPos, const Vector3f &sunPos)
 {
 	if (!waterIndexVBO)
 	{
 		return; // no water
 	}
-	const auto ModelViewProjection = Projection * ModelView;
-	const auto ModelViewNormal = glm::transpose(glm::inverse(ModelView));
 
 	const glm::vec4 paramsX(0, 0, -1.0f / world_coord(4), 0);
 	const glm::vec4 paramsY(1.0f / world_coord(4), 0, 0, 0);
@@ -1450,9 +1445,9 @@ void drawWater(const glm::mat4 &ModelView, const glm::mat4 &Projection, const Ve
 		getOptTex(waterTexture1_sm), getOptTex(waterTexture2_sm));
 	gfx_api::WaterPSO::get().bind_vertex_buffers(waterVBO);
 	gfx_api::WaterPSO::get().bind_constants({
-		ModelViewProjection, ModelView, ModelViewNormal, ModelUV1, ModelUV2,
+		ModelViewProjection, ModelUV1, ModelUV2,
 		waterOffset*10,
-		cameraPos, glm::normalize(sunPos), sunPosInView,
+		cameraPos, glm::normalize(sunPos),
 		pie_GetLighting0(LIGHT_EMISSIVE), pie_GetLighting0(LIGHT_AMBIENT), pie_GetLighting0(LIGHT_DIFFUSE), pie_GetLighting0(LIGHT_SPECULAR),
 		glm::vec4(0.f), renderState.fogEnabled, renderState.fogBegin, renderState.fogEnd
 	});

--- a/src/terrain.cpp
+++ b/src/terrain.cpp
@@ -1262,6 +1262,9 @@ static void drawTerrainLayers(const glm::mat4 &ModelViewProjection, const glm::m
 
 	int32_t maxGfxTextureSize = gfx_api::context::get().get_context_value(gfx_api::context::context_value::MAX_TEXTURE_SIZE);
 	int maxTerrainTextureSize = std::max(std::min({getTextureSize(), maxGfxTextureSize}), MIN_TERRAIN_TEXTURE_SIZE);
+	auto getOptTex = [&maxTerrainTextureSize](const std::string &fileName) {
+		return fileName.empty() ? nullptr : &pie_Texture(iV_GetTexture(fileName.c_str(), true, maxTerrainTextureSize, maxTerrainTextureSize).value());
+	};
 
 	// draw each layer separately
 	for (int layer = 0; layer < numGroundTypes; layer++)
@@ -1275,19 +1278,18 @@ static void drawTerrainLayers(const glm::mat4 &ModelViewProjection, const glm::m
 		// load the texture
 		optional<size_t> texPage = iV_GetTexture(groundType.textureName.c_str(), true, maxTerrainTextureSize, maxTerrainTextureSize);
 		ASSERT_OR_RETURN(, texPage.has_value(), "Failed to retrieve terrain texture: %s", groundType.textureName.c_str());
-		optional<size_t> texPage_normalmap = !groundType.normalMapTextureName.empty() ? iV_GetTexture(groundType.normalMapTextureName.c_str()) : nullopt;
-		optional<size_t> texPage_specularmap = !groundType.specularMapTextureName.empty() ? iV_GetTexture(groundType.specularMapTextureName.c_str()) : nullopt;
-		gfx_api::texture* pNormalMapTexture = texPage_normalmap.has_value() ? &pie_Texture(texPage_normalmap.value()) : nullptr;
-		gfx_api::texture* pSpecularMapTexture = texPage_specularmap.has_value() ? &pie_Texture(texPage_specularmap.value()) : nullptr;
+		gfx_api::texture* pNormalMapTexture = getOptTex(groundType.normalMapTextureName);
+		gfx_api::texture* pSpecularMapTexture = getOptTex(groundType.specularMapTextureName);
+		gfx_api::texture* pHeightMapTexture = getOptTex(groundType.heightMapTextureName);
 
 		gfx_api::TerrainLayer::get().bind_constants({
 			ModelViewProjection, ModelUV, ModelUVLightmap,
 			glm::vec4(cameraPos, 0), glm::vec4(glm::normalize(sunPos), 0),
 			pie_GetLighting0(LIGHT_EMISSIVE), pie_GetLighting0(LIGHT_AMBIENT), pie_GetLighting0(LIGHT_DIFFUSE), pie_GetLighting0(LIGHT_SPECULAR),
-			fogColor, renderState.fogEnabled, renderState.fogBegin, renderState.fogEnd, pNormalMapTexture != nullptr, pSpecularMapTexture != nullptr});
+			fogColor, renderState.fogEnabled, renderState.fogBegin, renderState.fogEnd, pNormalMapTexture != nullptr, pSpecularMapTexture != nullptr, pHeightMapTexture != nullptr});
 
 		// load the textures
-		gfx_api::TerrainLayer::get().bind_textures(&pie_Texture(texPage.value()), lightmap_texture, pNormalMapTexture, pSpecularMapTexture);
+		gfx_api::TerrainLayer::get().bind_textures(&pie_Texture(texPage.value()), lightmap_texture, pNormalMapTexture, pSpecularMapTexture, pHeightMapTexture);
 
 		// load the color buffer
 		gfx_api::context::get().bind_vertex_buffers(1, { std::make_tuple(textureVBO, static_cast<size_t>(sizeof(PIELIGHT)*xSectors * ySectors * (sectorSize + 1) * (sectorSize + 1) * 2 * layer)) });
@@ -1496,5 +1498,6 @@ void reloadTerrainTextures()
 		reloadTex(ground.textureName);
 		reloadTex(ground.normalMapTextureName);
 		reloadTex(ground.specularMapTextureName);
+		reloadTex(ground.heightMapTextureName);
 	}
 }

--- a/src/terrain.cpp
+++ b/src/terrain.cpp
@@ -89,11 +89,13 @@ struct Sector
 
 using RenderVertex = Vector3f;
 
-/// A vertex with a position and texture coordinates
+/// A vertex with a position and texture coordinates. see gfx_api::TerrainDecals
 struct DecalVertex
 {
 	Vector3f pos = Vector3f(0.f, 0.f, 0.f);
 	Vector2f uv = Vector2f(0.f, 0.f);
+	Vector3f normal = Vector3f(0.f, 1.f, 0.f);
+	glm::vec4 tangent = glm::vec4(1.f, 0.f, 0.f, 1.f);
 };
 
 /// The lightmap texture
@@ -358,7 +360,7 @@ static Vector3f getGridPosf(int x, int y, bool center = false, bool water = fals
 }
 
 /// Get normal vector of grid point
-static Vector3f getGridNormal(int x, int y, bool center) {
+static Vector3f getGridNormal(int x, int y, bool center = false) {
 	auto calcNormal = [](const Vector3f &pc, const std::vector<Vector3f> &p) {
 		auto res = Vector3f(0.0);
 		for (int i = 0; i < p.size(); i++) {
@@ -458,62 +460,95 @@ static void setSectorDecals(int x, int y, DecalVertex *decaldata, int *decalSize
 				getGridPos(&pos, i, j, true, false);
 				decaldata[*decalSize].pos = pos;
 				decaldata[*decalSize].uv = center;
+				decaldata[*decalSize].normal = getGridNormal(i, j, true);
 				(*decalSize)++;
 				a = 0; b = 1;
 				getGridPos(&pos, i + a, j + b, false, false);
 				decaldata[*decalSize].pos = pos;
 				decaldata[*decalSize].uv = uv[a][b];
+				decaldata[*decalSize].normal = getGridNormal(i + a, j + b);
 				(*decalSize)++;
 				a = 0; b = 0;
 				getGridPos(&pos, i + a, j + b, false, false);
 				decaldata[*decalSize].pos = pos;
 				decaldata[*decalSize].uv = uv[a][b];
+				decaldata[*decalSize].normal = getGridNormal(i + a, j + b);
 				(*decalSize)++;
 
 				getGridPos(&pos, i, j, true, false);
 				decaldata[*decalSize].pos = pos;
 				decaldata[*decalSize].uv = center;
+				decaldata[*decalSize].normal = getGridNormal(i, j, true);
 				(*decalSize)++;
 				a = 1; b = 1;
 				getGridPos(&pos, i + a, j + b, false, false);
 				decaldata[*decalSize].pos = pos;
 				decaldata[*decalSize].uv = uv[a][b];
+				decaldata[*decalSize].normal = getGridNormal(i + a, j + b);
 				(*decalSize)++;
 				a = 0; b = 1;
 				getGridPos(&pos, i + a, j + b, false, false);
 				decaldata[*decalSize].pos = pos;
 				decaldata[*decalSize].uv = uv[a][b];
+				decaldata[*decalSize].normal = getGridNormal(i + a, j + b);
 				(*decalSize)++;
 
 				getGridPos(&pos, i, j, true, false);
 				decaldata[*decalSize].pos = pos;
 				decaldata[*decalSize].uv = center;
+				decaldata[*decalSize].normal = getGridNormal(i, j, true);
 				(*decalSize)++;
 				a = 1; b = 0;
 				getGridPos(&pos, i + a, j + b, false, false);
 				decaldata[*decalSize].pos = pos;
 				decaldata[*decalSize].uv = uv[a][b];
+				decaldata[*decalSize].normal = getGridNormal(i + a, j + b);
 				(*decalSize)++;
 				a = 1; b = 1;
 				getGridPos(&pos, i + a, j + b, false, false);
 				decaldata[*decalSize].pos = pos;
 				decaldata[*decalSize].uv = uv[a][b];
+				decaldata[*decalSize].normal = getGridNormal(i + a, j + b);
 				(*decalSize)++;
 
 				getGridPos(&pos, i, j, true, false);
 				decaldata[*decalSize].pos = pos;
 				decaldata[*decalSize].uv = center;
+				decaldata[*decalSize].normal = getGridNormal(i, j, true);
 				(*decalSize)++;
 				a = 0; b = 0;
 				getGridPos(&pos, i + a, j + b, false, false);
 				decaldata[*decalSize].pos = pos;
 				decaldata[*decalSize].uv = uv[a][b];
+				decaldata[*decalSize].normal = getGridNormal(i + a, j + b);
 				(*decalSize)++;
 				a = 1; b = 0;
 				getGridPos(&pos, i + a, j + b, false, false);
 				decaldata[*decalSize].pos = pos;
 				decaldata[*decalSize].uv = uv[a][b];
+				decaldata[*decalSize].normal = getGridNormal(i + a, j + b);
 				(*decalSize)++;
+
+				// calc tangents
+				for (int idx = *decalSize - 3*4; idx < *decalSize; idx+=3) {
+					auto p = decaldata + idx;
+					auto e1 = p[1].pos - p[0].pos;
+					auto e2 = p[2].pos - p[0].pos;
+					auto uv1 = p[1].uv - p[0].uv;
+					auto uv2 = p[2].uv - p[0].uv;
+					float r = 1.0f / (uv1.x * uv2.y - uv2.x * uv1.y);
+					Vector3f tangent = glm::normalize(r * (uv2.y * e1 - uv1.y * e2));
+					Vector3f bitangent = glm::normalize(r * (-uv2.x * e1 + uv1.x * e2));
+					for (int k=0; k<3; k++) {
+						auto &n = p[k].normal;
+						const auto t = glm::normalize(tangent - (n * glm::dot(tangent, n)));
+						float w = 1.0f; // not mirrored
+						if (glm::dot(glm::cross(n, t), bitangent) < 0.0f) {
+							w = -1.0f; // we're mirrored
+						}
+						p[k].tangent = glm::vec4(t, w);
+					}
+				}
 			}
 		}
 	}
@@ -1201,7 +1236,7 @@ static void drawDepthOnly(const glm::mat4 &ModelViewProjection, const glm::vec4 
 	gfx_api::context::get().unbind_index_buffer(*geometryIndexVBO);
 }
 
-static void drawTerrainLayers(const glm::mat4 &ModelView, const glm::mat4 &ModelViewProjection, const Vector3f &currentSunPos, const glm::vec4 &paramsXLight, const glm::vec4 &paramsYLight, const glm::mat4 &lightTextureMatrix)
+static void drawTerrainLayers(const glm::mat4 &ModelView, const glm::mat4 &ModelViewNormal, const glm::mat4 &ModelViewProjection, const Vector3f &currentSunPos, const glm::mat4 &ModelUVLightmap)
 {
 	const auto &renderState = getCurrentRenderState();
 	const glm::vec4 fogColor(
@@ -1210,8 +1245,6 @@ static void drawTerrainLayers(const glm::mat4 &ModelView, const glm::mat4 &Model
 		renderState.fogColour.vector[2] / 255.f,
 		renderState.fogColour.vector[3] / 255.f
 	);
-	const auto ModelViewNormal = glm::transpose(glm::inverse(ModelView));
-	const auto ModelUVLight = lightTextureMatrix * glm::transpose(glm::mat4(paramsXLight, paramsYLight, glm::vec4(0,0,1,0), glm::vec4(0,0,0,1)));
 
 	// load the vertex (geometry) buffer
 	gfx_api::TerrainLayer::get().bind();
@@ -1240,7 +1273,7 @@ static void drawTerrainLayers(const glm::mat4 &ModelView, const glm::mat4 &Model
 		gfx_api::texture* pSpecularMapTexture = texPage_specularmap.has_value() ? &pie_Texture(texPage_specularmap.value()) : nullptr;
 
 		gfx_api::TerrainLayer::get().bind_constants({
-			ModelUV, ModelUVLight, ModelView, ModelViewProjection, ModelViewNormal,
+			ModelUV, ModelUVLightmap, ModelView, ModelViewProjection, ModelViewNormal,
 			glm::vec4(currentSunPos, 0.f),
 			pie_GetLighting0(LIGHT_EMISSIVE), pie_GetLighting0(LIGHT_AMBIENT), pie_GetLighting0(LIGHT_DIFFUSE), pie_GetLighting0(LIGHT_SPECULAR),
 			fogColor, renderState.fogEnabled, renderState.fogBegin, renderState.fogEnd, 0, 1, pNormalMapTexture != nullptr, pSpecularMapTexture != nullptr});
@@ -1271,7 +1304,7 @@ static void drawTerrainLayers(const glm::mat4 &ModelView, const glm::mat4 &Model
 	gfx_api::context::get().unbind_index_buffer(*textureIndexVBO);
 }
 
-static void drawDecals(const glm::mat4 &ModelViewProjection, const glm::vec4 &paramsXLight, const glm::vec4 &paramsYLight, const glm::mat4 &textureMatrix)
+static void drawDecals(const glm::mat4 &ModelView, const glm::mat4 &ModelViewNormal, const glm::mat4 &ModelViewProjection, const Vector3f &currentSunPos, const glm::mat4 &ModelUVLightmap)
 {
 	if (!decalVBO)
 	{
@@ -1286,9 +1319,12 @@ static void drawDecals(const glm::mat4 &ModelViewProjection, const glm::vec4 &pa
 		renderState.fogColour.vector[3] / 255.f
 	);
 	gfx_api::TerrainDecals::get().bind();
-	gfx_api::TerrainDecals::get().bind_textures(&pie_Texture(terrainPage), lightmap_texture);
+	gfx_api::TerrainDecals::get().bind_textures(&pie_Texture(terrainPage), lightmap_texture, &pie_Texture(terrainNormalPage), &pie_Texture(terrainSpecularPage));
 	gfx_api::TerrainDecals::get().bind_vertex_buffers(decalVBO);
-	gfx_api::TerrainDecals::get().bind_constants({ ModelViewProjection, textureMatrix, paramsXLight, paramsYLight,
+	gfx_api::TerrainDecals::get().bind_constants({
+		ModelView, ModelViewNormal, ModelViewProjection, ModelUVLightmap,
+		glm::vec4(currentSunPos, 0.f),
+		pie_GetLighting0(LIGHT_EMISSIVE), pie_GetLighting0(LIGHT_AMBIENT), pie_GetLighting0(LIGHT_DIFFUSE), pie_GetLighting0(LIGHT_SPECULAR),
 		fogColor, renderState.fogEnabled, renderState.fogBegin, renderState.fogEnd, 0, 1 });
 
 	int size = 0;
@@ -1350,17 +1386,20 @@ void drawTerrain(const glm::mat4 &ModelView, const glm::mat4 &Protection, const 
 	// shift the lightmap half a tile as lights are supposed to be placed at the center of a tile
 	const glm::mat4 lightMatrix = glm::translate(glm::vec3(1.f / (float)lightmapWidth / 2, 1.f / (float)lightmapHeight / 2, 0.f));
 
+	const auto ModelViewNormal = glm::transpose(glm::inverse(ModelView));
+	const auto ModelUVLightmap = lightMatrix * glm::transpose(glm::mat4(paramsXLight, paramsYLight, glm::vec4(0,0,1,0), glm::vec4(0,0,0,1)));
+
 	//////////////////////////////////////
 	// canvas to draw on
 	drawDepthOnly(mvp, paramsXLight, paramsYLight);
 
 	///////////////////////////////////
 	// terrain
-	drawTerrainLayers(ModelView, mvp, currentSunPos, paramsXLight, paramsYLight, lightMatrix);
+	drawTerrainLayers(ModelView, ModelViewNormal, mvp, currentSunPos, ModelUVLightmap);
 
 	//////////////////////////////////
 	// decals
-	drawDecals(mvp, paramsXLight, paramsYLight, lightMatrix);
+	drawDecals(ModelView, ModelViewNormal, mvp, currentSunPos, ModelUVLightmap);
 }
 
 /**

--- a/src/terrain.cpp
+++ b/src/terrain.cpp
@@ -1260,8 +1260,9 @@ static void drawTerrainLayers(const glm::mat4 &ModelView, const glm::mat4 &Model
 	for (int layer = 0; layer < numGroundTypes; layer++)
 	{
 		const auto& groundType = getGroundType(layer);
-		const glm::vec4 paramsX(0, 0, -1.0f / world_coord(groundType.textureSize), 0 );
-		const glm::vec4 paramsY(1.0f / world_coord(groundType.textureSize), 0, 0, 0 );
+		const float texScale = 1.0f / (groundType.textureSize * world_coord(1));
+		const glm::vec4 paramsX(0, 0, -texScale, 0 );
+		const glm::vec4 paramsY(texScale, 0, 0, 0 );
 		auto ModelUV = glm::transpose(glm::mat4(paramsX, paramsY, glm::vec4(0,0,1,0), glm::vec4(0,0,0,1)));
 
 		// load the texture

--- a/src/terrain.cpp
+++ b/src/terrain.cpp
@@ -33,6 +33,7 @@
 
 #include "lib/framework/frame.h"
 #include "lib/framework/opengl.h"
+#include "lib/framework/physfs_ext.h"
 #include "lib/ivis_opengl/ivisdef.h"
 #include "lib/ivis_opengl/imd.h"
 #include "lib/ivis_opengl/piefunc.h"
@@ -109,6 +110,12 @@ static size_t lightmapHeight;
 static std::unique_ptr<gfx_api::gfxUByte[]> lightmapPixmap;
 /// Ticks per lightmap refresh
 static const unsigned int LIGHTMAP_REFRESH = 80;
+
+// water optional texture names. empty if none
+static std::string waterTexture1_nm;
+static std::string waterTexture2_nm;
+static std::string waterTexture1_sm;
+static std::string waterTexture2_sm;
 
 /// VBOs
 static gfx_api::buffer *geometryVBO = nullptr, *geometryIndexVBO = nullptr, *textureVBO = nullptr, *textureIndexVBO = nullptr, *decalVBO = nullptr;
@@ -677,6 +684,16 @@ void loadTerrainTextures()
 			ASSERT(texPageNormal.has_value(), "Failed to pre-load terrain normal texture: %s", groundType.normalMapTextureName.c_str());
 		}
 	}
+
+	// check water optional textures
+	auto checkTex = [](const std::string &fileName) {
+		std::string fullName = "texpages/"+fileName;
+		return PHYSFS_exists(fullName.c_str()) ? fileName : "";
+	};
+	waterTexture1_nm = checkTex("page-80-water-1_nm.png");
+	waterTexture2_nm = checkTex("page-81-water-2_nm.png");
+	waterTexture1_sm = checkTex("page-80-water-1_sm.png");
+	waterTexture2_sm = checkTex("page-81-water-2_sm.png");
 }
 
 /**
@@ -1406,8 +1423,9 @@ void drawTerrain(const glm::mat4 &ModelView, const glm::mat4 &Protection, const 
 
 /**
  * Draw the water.
+ * sunPos and cameraPos in Model=WorldSpace
  */
-void drawWater(const glm::mat4 &viewMatrix)
+void drawWater(const glm::mat4 &ModelViewProjection, const Vector3f &sunPos, const Vector3f &cameraPos)
 {
 	if (!waterIndexVBO)
 	{
@@ -1419,6 +1437,13 @@ void drawWater(const glm::mat4 &viewMatrix)
 	const glm::vec4 paramsY(1.0f / world_coord(4), 0, 0, 0);
 	const glm::vec4 paramsX2(0, 0, -1.0f / world_coord(5), 0);
 	const glm::vec4 paramsY2(1.0f / world_coord(5), 0, 0, 0);
+	const auto ModelUV1 = glm::translate(glm::vec3(waterOffset, 0.f, 0.f)) * glm::transpose(glm::mat4(paramsX, paramsY, glm::vec4(0,0,1,0), glm::vec4(0,0,0,1)));
+	const auto ModelUV2 = glm::transpose(glm::mat4(paramsX2, paramsY2, glm::vec4(0,0,1,0), glm::vec4(0,0,0,1)));
+	const auto normal = glm::vec3(0,1,0); // y
+	const auto tangent = glm::normalize(paramsY.xyz()); // x
+	const auto bitangent = glm::cross(normal, tangent); // z
+	const auto ModelTangent = glm::transpose(glm::mat3(tangent, bitangent, normal)); // xzy
+	const auto lightDirInTangent = glm::normalize(- ModelTangent * sunPos);
 	const auto &renderState = getCurrentRenderState();
 
 	int32_t maxGfxTextureSize = gfx_api::context::get().get_context_value(gfx_api::context::context_value::MAX_TEXTURE_SIZE);
@@ -1428,10 +1453,19 @@ void drawWater(const glm::mat4 &viewMatrix)
 	optional<size_t> water2_texPage = iV_GetTexture("page-81-water-2.png", true, maxTerrainTextureSize, maxTerrainTextureSize);
 	ASSERT_OR_RETURN(, water1_texPage.has_value() && water2_texPage.has_value(), "Failed to load water texture");
 	gfx_api::WaterPSO::get().bind();
-	gfx_api::WaterPSO::get().bind_textures(&pie_Texture(water1_texPage.value()), &pie_Texture(water2_texPage.value()));
+	auto getOptTex = [](const std::string &fileName) {
+		return fileName.empty() ? nullptr : &pie_Texture(iV_GetTexture(fileName.c_str()).value());
+	};
+	gfx_api::WaterPSO::get().bind_textures(
+		&pie_Texture(water1_texPage.value()), &pie_Texture(water2_texPage.value()),
+		getOptTex(waterTexture1_nm), getOptTex(waterTexture2_nm),
+		getOptTex(waterTexture1_sm), getOptTex(waterTexture2_sm));
 	gfx_api::WaterPSO::get().bind_vertex_buffers(waterVBO);
-	gfx_api::WaterPSO::get().bind_constants({ viewMatrix, paramsX, paramsY, paramsX2, paramsY2,
-		glm::translate(glm::vec3(waterOffset, 0.f, 0.f)), glm::mat4(1.f), glm::vec4(0.f), renderState.fogEnabled, renderState.fogBegin, renderState.fogEnd, 0, 1
+	gfx_api::WaterPSO::get().bind_constants({
+		ModelViewProjection, ModelTangent, ModelUV1, ModelUV2,
+		cameraPos, lightDirInTangent,
+		pie_GetLighting0(LIGHT_EMISSIVE), pie_GetLighting0(LIGHT_AMBIENT), pie_GetLighting0(LIGHT_DIFFUSE), pie_GetLighting0(LIGHT_SPECULAR),
+		glm::vec4(0.f), renderState.fogEnabled, renderState.fogBegin, renderState.fogEnd
 	});
 	gfx_api::context::get().bind_index_buffer(*waterIndexVBO, gfx_api::index_type::u32);
 

--- a/src/terrain.h
+++ b/src/terrain.h
@@ -29,7 +29,7 @@ void loadTerrainTextures();
 bool initTerrain();
 void shutdownTerrain();
 
-void drawTerrain(const glm::mat4 &ModelViewProjection);
+void drawTerrain(const glm::mat4 &ModelView, const glm::mat4 &Projection, const Vector3f &currentSunPos);
 void drawWater(const glm::mat4 &viewMatrix);
 
 PIELIGHT getTileColour(int x, int y);

--- a/src/terrain.h
+++ b/src/terrain.h
@@ -40,7 +40,7 @@ void markTileDirty(int i, int j);
 enum TerrainShaderQuality
 {
 	CLASSIC = 0,
-	BUMP_MAPPING = 1,
+	NORMAL_MAPPING = 1,
 	END = 2
 };
 

--- a/src/terrain.h
+++ b/src/terrain.h
@@ -37,6 +37,15 @@ void setTileColour(int x, int y, PIELIGHT colour);
 
 void markTileDirty(int i, int j);
 
+enum TerrainShaderQuality
+{
+	CLASSIC = 0,
+	BUMP_MAPPING = 1,
+	END = 2
+};
+
+extern TerrainShaderQuality terrainShaderQuality;
+
 // for debug
 void reloadTerrainTextures();
 

--- a/src/terrain.h
+++ b/src/terrain.h
@@ -30,7 +30,7 @@ bool initTerrain();
 void shutdownTerrain();
 
 void drawTerrain(const glm::mat4 &ModelView, const glm::mat4 &Projection, const Vector3f &currentSunPos);
-void drawWater(const glm::mat4 &ModelViewProjection, const Vector3f &sunPos, const Vector3f &cameraPos);
+void drawWater(const glm::mat4 &ModelView, const glm::mat4 &Projection, const Vector3f &cameraPos, const Vector3f &sunPos, const Vector3f &sunPosInView);
 
 PIELIGHT getTileColour(int x, int y);
 void setTileColour(int x, int y, PIELIGHT colour);

--- a/src/terrain.h
+++ b/src/terrain.h
@@ -29,8 +29,8 @@ void loadTerrainTextures();
 bool initTerrain();
 void shutdownTerrain();
 
-void drawTerrain(const glm::mat4 &ModelView, const glm::mat4 &Projection, const Vector3f &currentSunPos);
-void drawWater(const glm::mat4 &ModelView, const glm::mat4 &Projection, const Vector3f &cameraPos, const Vector3f &sunPos, const Vector3f &sunPosInView);
+void drawTerrain(const glm::mat4 &ModelViewProjection, const Vector3f &cameraPos, const Vector3f &sunPos);
+void drawWater(const glm::mat4 &ModelViewProjection, const Vector3f &cameraPos, const Vector3f &sunPos);
 
 PIELIGHT getTileColour(int x, int y);
 void setTileColour(int x, int y, PIELIGHT colour);

--- a/src/terrain.h
+++ b/src/terrain.h
@@ -30,7 +30,7 @@ bool initTerrain();
 void shutdownTerrain();
 
 void drawTerrain(const glm::mat4 &ModelView, const glm::mat4 &Projection, const Vector3f &currentSunPos);
-void drawWater(const glm::mat4 &viewMatrix);
+void drawWater(const glm::mat4 &ModelViewProjection, const Vector3f &sunPos, const Vector3f &cameraPos);
 
 PIELIGHT getTileColour(int x, int y);
 void setTileColour(int x, int y, PIELIGHT colour);

--- a/src/terrain.h
+++ b/src/terrain.h
@@ -37,4 +37,7 @@ void setTileColour(int x, int y, PIELIGHT colour);
 
 void markTileDirty(int i, int j);
 
+// for debug
+void reloadTerrainTextures();
+
 #endif

--- a/src/texture.cpp
+++ b/src/texture.cpp
@@ -308,3 +308,11 @@ bool texLoad(const char *fileName)
 	}
 	return true;
 }
+
+void reloadTileTextures()
+{
+	// TODO: remove/replace old textures
+	char *dir = strdup(tilesetDir);
+	texLoad(dir);
+	free(dir);
+}

--- a/src/texture.cpp
+++ b/src/texture.cpp
@@ -228,6 +228,9 @@ bool texLoad(const char *fileName)
 		} else {
 			debug(LOG_TEXTURE, "texLoad: Spec maps not found");
 			terrainSpecularPage = pie_ReserveTexture(fullPath, 1, 1);
+			pie_AssignTexture(terrainSpecularPage, gfx_api::context::get().create_texture(1, 1, 1, gfx_api::pixel_format::FORMAT_RGB8_UNORM_PACK8));
+			unsigned char spec[] = {25, 25, 25};
+			pie_Texture(terrainSpecularPage).upload_and_generate_mipmaps(0, 0, 1, 1, gfx_api::pixel_format::FORMAT_RGB8_UNORM_PACK8, spec);
 		}
 
 		snprintf(fullPath, sizeof(fullPath), "%s-hm", fileName);

--- a/src/texture.cpp
+++ b/src/texture.cpp
@@ -163,7 +163,7 @@ bool texLoad(const char *fileName)
 	/* Now load the actual tiles */
 	terrainNormalPage = terrainSpecularPage = terrainHeightPage = 0;
 	i = mipmap_max; // i is used to keep track of the tile dimensions
-	for (j = 0; j < mipmap_levels; j++)
+	for (j = 0; j < 1; j++)
 	{
 		int xOffset = 0, yOffset = 0; // offsets into the texture atlas
 		int xSize = 1;
@@ -219,7 +219,7 @@ bool texLoad(const char *fileName)
 				break;
 			}
 			// Insert into texture page
-			pie_Texture(texPage).upload(j, xOffset, yOffset, tile.width, tile.height, gfx_api::pixel_format::FORMAT_RGBA8_UNORM_PACK8, tile.bmp);
+			pie_Texture(texPage).upload_and_generate_mipmaps(xOffset, yOffset, tile.width, tile.height, gfx_api::pixel_format::FORMAT_RGBA8_UNORM_PACK8, tile.bmp);
 			free(tile.bmp);
 			if (i == mipmap_max) // dealing with main texture page; so register coordinates
 			{
@@ -246,7 +246,7 @@ bool texLoad(const char *fileName)
 				for (int b=0; b<filesize; b+=4) tile.bmp[b+2] = 0xff; // blue=z
 			}
 			// Insert into normal texture page
-			pie_Texture(terrainNormalPage).upload(j, xOffset, yOffset, tile.width, tile.height, gfx_api::pixel_format::FORMAT_RGBA8_UNORM_PACK8, tile.bmp);
+			pie_Texture(terrainNormalPage).upload_and_generate_mipmaps(xOffset, yOffset, tile.width, tile.height, gfx_api::pixel_format::FORMAT_RGBA8_UNORM_PACK8, tile.bmp);
 			free(tile.bmp);
 
 			// loading specularmap
@@ -262,7 +262,7 @@ bool texLoad(const char *fileName)
 				tile.bmp = (unsigned char*)calloc(i*i, 4);
 			}
 			// Insert into specular texture page
-			pie_Texture(terrainSpecularPage).upload(j, xOffset, yOffset, tile.width, tile.height, gfx_api::pixel_format::FORMAT_RGBA8_UNORM_PACK8, tile.bmp);
+			pie_Texture(terrainSpecularPage).upload_and_generate_mipmaps(xOffset, yOffset, tile.width, tile.height, gfx_api::pixel_format::FORMAT_RGBA8_UNORM_PACK8, tile.bmp);
 			free(tile.bmp);
 
 			// loading heightmap
@@ -278,7 +278,7 @@ bool texLoad(const char *fileName)
 				tile.bmp = (unsigned char*)calloc(i*i, 4);
 			}
 			// Insert into height texture page
-			pie_Texture(terrainHeightPage).upload(j, xOffset, yOffset, tile.width, tile.height, gfx_api::pixel_format::FORMAT_RGBA8_UNORM_PACK8, tile.bmp);
+			pie_Texture(terrainHeightPage).upload_and_generate_mipmaps(xOffset, yOffset, tile.width, tile.height, gfx_api::pixel_format::FORMAT_RGBA8_UNORM_PACK8, tile.bmp);
 			free(tile.bmp);
 
 			xOffset += i; // i is width of tile

--- a/src/texture.cpp
+++ b/src/texture.cpp
@@ -79,10 +79,10 @@ int getCurrentTileTextureSize()
 	return mipmap_max;
 }
 
-int getMaxTileTextureSize(std::string tilesetDir)
+int getMaxTileTextureSize(std::string dir)
 {
 	int res = MIPMAP_MAX;
-	while (res > 0 && !PHYSFS_exists(WzString::fromUtf8(tilesetDir + "-" + std::to_string(res) + "/tile-00.png")))
+	while (res > 0 && !PHYSFS_exists(WzString::fromUtf8(dir + "-" + std::to_string(res) + "/tile-00.png")))
 		res /= 2;
 	return res;
 }

--- a/src/texture.cpp
+++ b/src/texture.cpp
@@ -258,9 +258,8 @@ bool texLoad(const char *fileName)
 				debug(LOG_TEXTURE, "texLoad: Found specular map %s", fullPath);
 			}
 			else
-			{	// default specular map: 7f7f7f7f for now
+			{	// default specular map: 0
 				tile.bmp = (unsigned char*)calloc(i*i, 4);
-				memset(tile.bmp, 0x7f, i*i*4);
 			}
 			// Insert into specular texture page
 			pie_Texture(terrainSpecularPage).upload(j, xOffset, yOffset, tile.width, tile.height, gfx_api::pixel_format::FORMAT_RGBA8_UNORM_PACK8, tile.bmp);

--- a/src/texture.cpp
+++ b/src/texture.cpp
@@ -73,6 +73,11 @@ int getTextureSize()
 	return maxTextureSize;
 }
 
+int getCurrentTileTextureSize()
+{
+	return mipmap_max;
+}
+
 // Generate a new texture page both in the texture page table, and on the graphics card
 static size_t newPage(const char *name, int level, int width, int height, int count)
 {

--- a/src/texture.cpp
+++ b/src/texture.cpp
@@ -43,8 +43,8 @@
 #include "map.h"
 
 
-#define MIPMAP_LEVELS		4
-#define MIPMAP_MAX		128
+#define MIPMAP_LEVELS		6
+#define MIPMAP_MAX		512
 
 /* Texture page and coordinates for each tile */
 TILE_TEX_INFO tileTexInfo[MAX_TILES];
@@ -97,7 +97,7 @@ bool texLoad(const char *fileName)
 
 	firstPage = pie_NumberOfPages();
 
-	ASSERT_OR_RETURN(false, MIPMAP_MAX == TILE_WIDTH && MIPMAP_MAX == TILE_HEIGHT, "Bad tile sizes");
+	//ASSERT_OR_RETURN(false, MIPMAP_MAX == TILE_WIDTH && MIPMAP_MAX == TILE_HEIGHT, "Bad tile sizes");
 
 	// store the filename so we can later determine which tileset we are using
 	if (tilesetDir)

--- a/src/texture.cpp
+++ b/src/texture.cpp
@@ -161,7 +161,7 @@ bool texLoad(const char *fileName)
 	free(buffer);
 
 	/* Now load the actual tiles */
-
+	terrainNormalPage = terrainSpecularPage = terrainHeightPage = 0;
 	i = mipmap_max; // i is used to keep track of the tile dimensions
 	for (j = 0; j < mipmap_levels; j++)
 	{

--- a/src/texture.cpp
+++ b/src/texture.cpp
@@ -112,6 +112,7 @@ bool texLoad(const char *fileName)
 	mipmap_levels = MIPMAP_LEVELS;
 
 	int32_t max_texture_size = gfx_api::context::get().get_context_value(gfx_api::context::context_value::MAX_TEXTURE_SIZE);
+	max_texture_size = std::min(max_texture_size, getTextureSize());
 
 	while (max_texture_size < mipmap_max * TILES_IN_PAGE_COLUMN)
 	{

--- a/src/texture.cpp
+++ b/src/texture.cpp
@@ -122,7 +122,7 @@ bool texLoad(const char *fileName)
 	// reset defaults
 	const int maxTileTexSize = getMaxTileTextureSize(fileName);
 	mipmap_max = maxTileTexSize;
-	mipmap_levels = log2(mipmap_max / 8); // 4 for 128
+	mipmap_levels = (int)log2(mipmap_max / 8); // 4 for 128
 
 	int32_t max_texture_size = gfx_api::context::get().get_context_value(gfx_api::context::context_value::MAX_TEXTURE_SIZE);
 

--- a/src/texture.cpp
+++ b/src/texture.cpp
@@ -191,17 +191,19 @@ bool texLoad(const char *fileName)
 		sprintf(partialPath, "%s-%d", fileName, maxTileTexSize);
 
 		bool has_nm = false, has_sm = false, has_hm = false;
-		WZ_PHYSFS_enumerateFiles(partialPath, [&](const char *fileName) -> bool {
-			size_t len = strlen(fileName);
-			auto hasSuffix = [&](const char *suf) -> bool {
-				size_t l = strlen(suf);
-				return strncmp(fileName + len - l, suf, l) == 0;
-			};
-			has_nm |= hasSuffix("_nm.png");
-			has_sm |= hasSuffix("_sm.png");
-			has_hm |= hasSuffix("_hm.png");
-			return !has_nm || !has_sm || !has_hm;
-		});
+		if (terrainShaderQuality != TerrainShaderQuality::CLASSIC) {
+			WZ_PHYSFS_enumerateFiles(partialPath, [&](const char *fileName) -> bool {
+				size_t len = strlen(fileName);
+				auto hasSuffix = [&](const char *suf) -> bool {
+					size_t l = strlen(suf);
+					return strncmp(fileName + len - l, suf, l) == 0;
+				};
+				has_nm |= hasSuffix("_nm.png");
+				has_sm |= hasSuffix("_sm.png");
+				has_hm |= hasSuffix("_hm.png");
+				return !has_nm || !has_sm || !has_hm;
+			});
+		}
 
 		snprintf(fullPath, sizeof(fullPath), "%s-nm", fileName);
 		if (has_nm) {

--- a/src/texture.h
+++ b/src/texture.h
@@ -51,4 +51,6 @@ int getTextureSize();
 // decal size
 int getCurrentTileTextureSize();
 
+void reloadTileTextures();
+
 #endif // __INCLUDED_SRC_TEXTURE_H__

--- a/src/texture.h
+++ b/src/texture.h
@@ -48,4 +48,7 @@ extern size_t terrainHeightPage;
 void setTextureSize(int texSize);
 int getTextureSize();
 
+// decal size
+int getCurrentTileTextureSize();
+
 #endif // __INCLUDED_SRC_TEXTURE_H__

--- a/src/texture.h
+++ b/src/texture.h
@@ -43,6 +43,7 @@ extern TILE_TEX_INFO	tileTexInfo[MAX_TILES];
 extern size_t terrainPage;
 extern size_t terrainNormalPage;
 extern size_t terrainSpecularPage;
+extern size_t terrainHeightPage;
 
 void setTextureSize(int texSize);
 int getTextureSize();

--- a/src/texture.h
+++ b/src/texture.h
@@ -41,6 +41,8 @@ struct TILE_TEX_INFO
 
 extern TILE_TEX_INFO	tileTexInfo[MAX_TILES];
 extern size_t terrainPage;
+extern size_t terrainNormalPage;
+extern size_t terrainSpecularPage;
 
 void setTextureSize(int texSize);
 int getTextureSize();

--- a/src/wzscriptdebug.cpp
+++ b/src/wzscriptdebug.cpp
@@ -900,6 +900,10 @@ public:
 			setTheSun(newSun);
 			debug(LOG_INFO, "Sun at %f,%f,%f", newSun.x, newSun.y, newSun.z);
 		});
+		prevButton = panel->createButton(2, "Change terrain quality", [](){ // TODO: move to config
+			terrainShaderQuality = static_cast<TerrainShaderQuality>((terrainShaderQuality + 1) % TerrainShaderQuality::END);
+			debug(LOG_INFO, "terrainShaderQuality=%d", (int)terrainShaderQuality);
+		}, prevButton);
 		return panel;
 	}
 private:

--- a/src/wzscriptdebug.cpp
+++ b/src/wzscriptdebug.cpp
@@ -37,6 +37,7 @@
 	#define GLM_ENABLE_EXPERIMENTAL
 #endif
 #include <glm/gtx/string_cast.hpp>
+#include <glm/gtx/rotate_vector.hpp>
 
 #if defined(_wz_restore_libintl_vsprintf)
 #  undef _wz_restore_libintl_vsprintf
@@ -74,6 +75,7 @@
 #include "template.h"
 #include "multiint.h"
 #include "challenge.h"
+#include "lighting.h"
 
 #include "wzapi.h"
 #include "qtscript.h"
@@ -852,6 +854,66 @@ public:
 	std::shared_ptr<W_BUTTON> aiAttachButton;
 	std::shared_ptr<JSONTableWidget> table;
 	bool readOnly = false;
+};
+
+class WzGraphicsPanel : public W_FORM
+{
+public:
+	WzGraphicsPanel(): W_FORM() {}
+	~WzGraphicsPanel() {}
+public:
+	virtual void display(int xOffset, int yOffset) override { }
+	virtual void geometryChanged() override {}
+public:
+	static std::shared_ptr<WzGraphicsPanel> make()
+	{
+		auto panel = std::make_shared<WzGraphicsPanel>();
+
+		panel->createButton(0, "Reload terrain and water textures", [](){
+			reloadTerrainTextures();
+			debug(LOG_INFO, "Done");
+		});
+
+		auto prevButton = panel->createButton(1, "Recompile terrain", [](){
+			debug(LOG_INFO, "Recompiling terrain");
+			gfx_api::TerrainLayer::get().recompile();
+			debug(LOG_INFO, "Done");
+		});
+		prevButton =panel->createButton(1, "Recompile decals", [](){
+			debug(LOG_INFO, "Recompiling decals");
+			gfx_api::TerrainDecals::get().recompile();
+			debug(LOG_INFO, "Done");
+		}, prevButton);
+		prevButton = panel->createButton(1, "Recompile water", [](){
+			debug(LOG_INFO, "Recompiling water");
+			gfx_api::WaterPSO::get().recompile();
+			debug(LOG_INFO, "Done");
+		}, prevButton);
+
+		prevButton = panel->createButton(2, "Rotate sun", [](){
+			auto newSun = glm::rotate(getTheSun(), glm::pi<float>()/10.f, glm::vec3(0,1,0));
+			setTheSun(newSun);
+			debug(LOG_INFO, "Sun at %f,%f,%f", newSun.x, newSun.y, newSun.z);
+		});
+		return panel;
+	}
+private:
+	std::shared_ptr<W_BUTTON> createButton(int row, const std::string &text, const std::function<void ()>& onClickFunc, const std::shared_ptr<W_BUTTON>& previousButton = nullptr)
+	{
+		auto button = makeDebugButton(text.c_str());
+		button->setGeometry(button->x(), button->y(), button->width() + 10, button->height());
+		attach(button);
+		button->addOnClickHandler([onClickFunc](W_BUTTON& button) {
+			widgScheduleTask([onClickFunc](){
+				onClickFunc();
+			});
+		});
+
+		int previousButtonRight = (previousButton) ? previousButton->x() + previousButton->width() : 0;
+		button->move((previousButtonRight > 0) ? previousButtonRight + ACTION_BUTTON_SPACING : 0, (row * (button->height() + ACTION_BUTTON_ROW_SPACING)));
+
+		return button;
+	}
 };
 
 // MARK: - WzScriptContextsPanel
@@ -1855,6 +1917,9 @@ void WZScriptDebugger::switchPanel(WZScriptDebugger::ScriptDebuggerPanel newPane
 		case ScriptDebuggerPanel::Labels:
 			psPanel = createLabelsPanel();
 			break;
+		case ScriptDebuggerPanel::Graphics:
+			psPanel = createGraphicsPanel();
+			break;
 		default:
 			debug(LOG_ERROR, "Panel not implemented yet");
 			break;
@@ -1916,6 +1981,11 @@ void WZScriptDebugger::display(int xOffset, int yOffset)
 std::shared_ptr<W_FORM> WZScriptDebugger::createMainPanel()
 {
 	return WzMainPanel::make(readOnly);
+}
+
+std::shared_ptr<W_FORM> WZScriptDebugger::createGraphicsPanel()
+{
+	return WzGraphicsPanel::make();
 }
 
 std::shared_ptr<WIDGET> WZScriptDebugger::createSelectedPanel()
@@ -2024,6 +2094,7 @@ std::shared_ptr<WZScriptDebugger> WZScriptDebugger::make(const std::shared_ptr<s
 	addTextTabButton(result->pageTabs, ScriptDebuggerPanel::Triggers, "Triggers");
 	addTextTabButton(result->pageTabs, ScriptDebuggerPanel::Messages, "Messages");
 	addTextTabButton(result->pageTabs, ScriptDebuggerPanel::Labels, "Labels");
+	addTextTabButton(result->pageTabs, ScriptDebuggerPanel::Graphics, "Graphics");
 	result->pageTabs->addOnChooseHandler([](MultibuttonWidget& widget, int newValue){
 		// Switch actively-displayed "tab"
 		widgScheduleTask([newValue](){

--- a/src/wzscriptdebug.cpp
+++ b/src/wzscriptdebug.cpp
@@ -76,6 +76,7 @@
 #include "multiint.h"
 #include "challenge.h"
 #include "lighting.h"
+#include "texture.h"
 
 #include "wzapi.h"
 #include "qtscript.h"
@@ -869,12 +870,16 @@ public:
 	{
 		auto panel = std::make_shared<WzGraphicsPanel>();
 
-		panel->createButton(0, "Reload terrain and water textures", [](){
+		auto prevButton = panel->createButton(0, "Reload terrain and water textures", [](){
 			reloadTerrainTextures();
 			debug(LOG_INFO, "Done");
 		});
+		panel->createButton(0, "Reload decal textures", [](){
+			reloadTileTextures();
+			debug(LOG_INFO, "Done");
+		}, prevButton);
 
-		auto prevButton = panel->createButton(1, "Recompile terrain", [](){
+		prevButton = panel->createButton(1, "Recompile terrain", [](){
 			debug(LOG_INFO, "Recompiling terrain");
 			gfx_api::TerrainLayer::get().recompile();
 			debug(LOG_INFO, "Done");

--- a/src/wzscriptdebug.h
+++ b/src/wzscriptdebug.h
@@ -82,6 +82,7 @@ private:
 	std::shared_ptr<WIDGET> createTriggersPanel();
 	std::shared_ptr<WIDGET> createMessagesPanel();
 	std::shared_ptr<WIDGET> createLabelsPanel();
+	std::shared_ptr<W_FORM> createGraphicsPanel();
 
 private:
 	enum class ScriptDebuggerPanel {
@@ -91,7 +92,8 @@ private:
 		Players,
 		Triggers,
 		Messages,
-		Labels
+		Labels,
+		Graphics
 	};
 	static void addTextTabButton(const std::shared_ptr<MultibuttonWidget>& mbw, ScriptDebuggerPanel value, const char* text);
 	void switchPanel(ScriptDebuggerPanel newPanel);


### PR DESCRIPTION
This is continuation of https://github.com/Warzone2100/warzone2100/pull/643

* Adds optional support of normalmaps (_nm.png), specularmaps (_sm.png) and heightmaps (_hm.png) for terrain, decals(tiles) and water.
  * Expect opengl format normalmaps with y=up.
  * Heightmaps are for future use and mods, not used in shaders for now.
* New config option "terrainShaderQuality" to control new rendering/shaders. By **default it is on** (=1=NORMAL_MAPPING). There is a button in debug window to switch it for now. Will add it to Video options after https://github.com/Warzone2100/warzone2100/pull/1823
* New rendering use optional maps, but works fine without them (with minimal performance hit vs original rendering).
* Added decals automipmap. Only highest available resolution decals (upto 512) are used. Lower resolutions can be deleted now.
* New Graphics tab in Debug window for modders. Speedup texture and shaders testing.

Demo with @MaNGusT-'s textures: https://www.youtube.com/watch?v=NjzMcK9Oqmk
Thanks @MaNGusT- for help.

in new rendering:
 - diffuse lighting moved from lightmap to the shaders. lightmap still has ambient occlusion.
 - terrain shaders use light intensities from piedraw.cpp. With default light intensities the result is brighter than original terrain. I use `ambientLight*0.5` in shaders to compensate.

There is a minor performance impact. Benchmarks:
Standard textures without optional maps. cam_1a, first alpha mission. resolution=**4k**, gpu=GF 1060 3G
tsq - this PR with specified terrainShaderQuality.
```
       | opengl | vk
ubuntu 20.10    |
 master| 498fps | 328fps
 tsq=0 | 485fps | 325fps
 tsq=1 | 445fps | 310fps
```
I got similar results on win10 (opengl worse, vk better).

Possible future work (out of scope of this PR):
 - pack normalmaps in videomemory to 2 channels (grey+alpha). specular and height maps to just 1 channel (grey)?
 - move decals rendering from texture atlas to texture array?
 - terrainShaderQuality switch in shaders can be optimized if needed. by different shaders entry points or different shader files. probably not worth it.
 - separate fog of war, AO and lights from lightmap.