### PR TITLE
Fix deactivation of research/manufacture buttons

### DIFF
--- a/data/base/script/rules.js
+++ b/data/base/script/rules.js
@@ -385,6 +385,14 @@ function eventStructureDemolish(struct, droid)
 	}
 }
 
+function eventStructureUpgradeStarted(struct)
+{
+	if (struct.player === selectedPlayer)
+	{
+		reticuleUpdate(struct, TRANSFER_LIKE_EVENT);
+	}
+}
+
 function eventDestroyed(victim)
 {
 	if (victim.player === selectedPlayer)

--- a/data/mp/multiplay/script/rules/events/upgrade.js
+++ b/data/mp/multiplay/script/rules/events/upgrade.js
@@ -1,0 +1,7 @@
+function eventStructureUpgradeStarted(struct)
+{
+	if (struct.player === selectedPlayer)
+	{
+		reticuleUpdate(struct, TRANSFER_LIKE_EVENT);
+	}
+}

--- a/data/mp/multiplay/script/rules/includes.js
+++ b/data/mp/multiplay/script/rules/includes.js
@@ -52,6 +52,7 @@ include("multiplay/script/rules/events/demolish.js");
 include("multiplay/script/rules/events/destroyed.js");
 include("multiplay/script/rules/events/transfer.js");
 include("multiplay/script/rules/events/research.js");
+include("multiplay/script/rules/events/upgrade.js");
 include("multiplay/script/rules/events/cheat.js");
 include("multiplay/script/rules/events/chat.js");
 

--- a/src/qtscript.cpp
+++ b/src/qtscript.cpp
@@ -1252,6 +1252,25 @@ bool triggerEventStructureReady(STRUCTURE *psStruct)
 	return true;
 }
 
+//__ ## eventStructureUpgradeStarted(structure)
+//__
+//__ An event that is run every time a structure starts to be upgraded.
+//__
+bool triggerEventStructureUpgradeStarted(STRUCTURE *psStruct)
+{
+	ASSERT(scriptsReady, "Scripts not initialized yet");
+	for (auto *instance : scripts)
+	{
+		int player = instance->player();
+		bool receiveAll = instance->isReceivingAllEvents();
+		if (player == psStruct->player || receiveAll)
+		{
+			instance->handle_eventStructureUpgradeStarted(psStruct);
+		}
+	}
+	return true;
+}
+
 //__ ## eventAttacked(victim, attacker)
 //__
 //__ An event that is run when an object belonging to the script's controlling player is

--- a/src/qtscript.h
+++ b/src/qtscript.h
@@ -135,6 +135,7 @@ bool triggerEventStructDemolish(STRUCTURE *psStruct, DROID *psDroid);
 bool triggerEventDroidIdle(DROID *psDroid);
 bool triggerEventDestroyed(BASE_OBJECT *psVictim);
 bool triggerEventStructureReady(STRUCTURE *psStruct);
+bool triggerEventStructureUpgradeStarted(STRUCTURE *psStruct);
 bool triggerEventSeen(BASE_OBJECT *psViewer, BASE_OBJECT *psSeen);
 bool triggerEventObjectTransfer(BASE_OBJECT *psObj, int from);
 bool triggerEventChat(int from, int to, const char *message);
@@ -349,7 +350,7 @@ public:
 		}
 		return removedTimerIDs;
 	}
-	
+
 	bool removeTimer(uniqueTimerID timerID);
 public:
 	// Monitoring performance of function calls
@@ -498,7 +499,7 @@ protected:
 	std::unordered_map<wzapi::scripting_instance *, nlohmann::json> debug_GetGlobalsSnapshot() const;
 	std::vector<scripting_engine::timerNodeSnapshot> debug_GetTimersSnapshot() const;
 	std::vector<scripting_engine::LabelInfo> debug_GetLabelInfo() const;
-	
+
 	/// Show all labels or all currently active labels
 	void markAllLabels(bool only_active);
 	/// Mark and show label

--- a/src/quickjs_backend.cpp
+++ b/src/quickjs_backend.cpp
@@ -469,6 +469,12 @@ public:
 	//__
 	virtual bool handle_eventStructureReady(const STRUCTURE *psStruct) override;
 
+	//__ ## eventStructureUpgradeStarted(structure)
+	//__
+	//__ An event that is run every time a structure starts to be upgraded.
+	//__
+	virtual bool handle_eventStructureUpgradeStarted(const STRUCTURE *psStruct) override;
+
 	//__ ## eventAttacked(victim, attacker)
 	//__
 	//__ An event that is run when an object belonging to the script's controlling player is
@@ -2932,6 +2938,7 @@ IMPL_EVENT_HANDLER(eventDroidBuilt, const DROID *, optional<const STRUCTURE *>)
 IMPL_EVENT_HANDLER(eventStructureBuilt, const STRUCTURE *, optional<const DROID *>)
 IMPL_EVENT_HANDLER(eventStructureDemolish, const STRUCTURE *, optional<const DROID *>)
 IMPL_EVENT_HANDLER(eventStructureReady, const STRUCTURE *)
+IMPL_EVENT_HANDLER(eventStructureUpgradeStarted, const STRUCTURE *)
 IMPL_EVENT_HANDLER(eventAttacked, const BASE_OBJECT *, const BASE_OBJECT *)
 IMPL_EVENT_HANDLER(eventResearched, const wzapi::researchResult&, wzapi::event_nullable_ptr<const STRUCTURE>, int)
 IMPL_EVENT_HANDLER(eventDestroyed, const BASE_OBJECT *)

--- a/src/structure.cpp
+++ b/src/structure.cpp
@@ -854,14 +854,12 @@ void structureBuild(STRUCTURE *psStruct, DROID *psDroid, int buildPoints, int bu
 		if (prevStatus == SS_BUILT)
 		{
 			// Starting to demolish.
-			if (psDroid)
+			triggerEventStructDemolish(psStruct, psDroid);
+			if (psStruct->player == selectedPlayer)
 			{
-				triggerEventStructDemolish(psStruct, psDroid);
+				intRefreshScreen();
 			}
-			else
-			{
-				triggerEventStructDemolish(psStruct, nullptr);
-			}
+
 			switch (psStruct->pStructureType->type)
 			{
 			case REF_POWER_GEN:
@@ -1722,9 +1720,15 @@ STRUCTURE *buildStructureDir(STRUCTURE_STATS *pStructureType, UDWORD x, UDWORD y
 			//start building again
 			psBuilding->status = SS_BEING_BUILT;
 			psBuilding->buildRate = 1;  // Don't abandon the structure first tick, so set to nonzero.
-			if (psBuilding->player == selectedPlayer && !FromSave)
+
+			if (!FromSave)
 			{
-				intRefreshScreen();
+				triggerEventStructureUpgradeStarted(psBuilding);
+
+				if (psBuilding->player == selectedPlayer)
+				{
+					intRefreshScreen();
+				}
 			}
 		}
 		intNotifyResearchButton(prevResearchState);

--- a/src/wzapi.h
+++ b/src/wzapi.h
@@ -384,6 +384,12 @@ namespace wzapi
 		//__
 		virtual bool handle_eventStructureReady(const STRUCTURE *psStruct) = 0;
 
+		//__ ## eventStructureUpgradeStarted(structure)
+		//__
+		//__ An event that is run every time a structure starts to be upgraded.
+		//__
+		virtual bool handle_eventStructureUpgradeStarted(const STRUCTURE *psStruct) = 0;
+
 		//__ ## eventAttacked(victim, attacker)
 		//__
 		//__ An event that is run when an object belonging to the script's controlling player is


### PR DESCRIPTION
Fixes #1834 

A new event `eventStructureUpgradeStarted` was added. When this event is triggered for a structure owned by `selectedPlayer`, `reticuleUpdate` will be called, which will cause the reticule buttons to be deactivated, in case the upgraded building was the only research facility/factory the player had.

A call to `intRefreshScreen` was added after a structure starts being demolished, to update the list of research facilities/factories in the interface.