### PR TITLE
fix: cannot trigger more specific mappings with lower priority

### DIFF
--- a/src/cheat.cpp
+++ b/src/cheat.cpp
@@ -221,11 +221,13 @@ void recvProcessDebugMappings(NETQUEUE queue)
 	{
 		addConsoleMessage(_("Debug mode now enabled!"), DEFAULT_JUSTIFY,  SYSTEM_MESSAGE);
 		Cheated = true;
+		gInputManager.contexts().set(InputContext::__DEBUG, InputContext::State::ACTIVE);
 		triggerEventCheatMode(true);
 	}
 	else if (oldDebugMode && !newDebugMode)
 	{
 		addConsoleMessage(_("Debug mode now disabled!"), DEFAULT_JUSTIFY,  SYSTEM_MESSAGE);
+		gInputManager.contexts().set(InputContext::__DEBUG, InputContext::State::INACTIVE);
 		triggerEventCheatMode(false);
 	}
 }

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -443,15 +443,7 @@ void processInput()
 		}
 	}
 
-	if (intMode != INTMODE::INT_DESIGN)
-	{
-		gInputManager.contexts().set(
-			InputContext::RADAR,
-			isMouseOverRadar()
-				? InputContext::State::PRIORITIZED
-				: InputContext::State::ACTIVE
-		);
-	}
+	gInputManager.contexts().updatePriorityStatus();
 
 	if (!isInTextInputMode())
 	{

--- a/src/hci.cpp
+++ b/src/hci.cpp
@@ -808,7 +808,7 @@ void intResetScreen(bool NoAnim)
 	case INT_DESIGN:
 		intRemoveDesign();
 		intHidePowerBar();
-		gInputManager.contexts().resetStates();
+		gInputManager.contexts().popState();
 		triggerEvent(TRIGGER_DESIGN_QUIT);
 		break;
 	case INT_INTELMAP:
@@ -1113,6 +1113,7 @@ INT_RETVAL intRunWidgets()
 			intShowPowerBar();
 			intAddDesign(false);
 			intMode = INT_DESIGN;
+			gInputManager.contexts().pushState();
 			gInputManager.contexts().makeAllInactive();
 			reticuleCallback(RETBUT_DESIGN);
 			triggerEvent(TRIGGER_MENU_DESIGN_UP);
@@ -2091,6 +2092,7 @@ void intShowWidget(int buttonID)
 		intShowPowerBar();
 		intAddDesign(false);
 		intMode = INT_DESIGN;
+		gInputManager.contexts().pushState();
 		gInputManager.contexts().makeAllInactive();
 		reticuleCallback(RETBUT_DESIGN);
 		triggerEvent(TRIGGER_MENU_DESIGN_UP);

--- a/src/input/context.cpp
+++ b/src/input/context.cpp
@@ -69,7 +69,7 @@ const std::string InputContext::getDisplayName() const
 	return displayName;
 }
 
-const bool InputContext::isAlwaysActive() const
+bool InputContext::isAlwaysActive() const
 {
 	return bIsAlwaysActive;
 }

--- a/src/input/context.h
+++ b/src/input/context.h
@@ -22,6 +22,7 @@
 #define __INCLUDED_SRC_INPUT_CONTEXT_H__
 
 #include <string>
+#include <list>
 #include <vector>
 
 struct ContextPriority

--- a/src/input/context.h
+++ b/src/input/context.h
@@ -88,7 +88,7 @@ struct InputContext
 	   cannot be disabled e.g. via `ContextManager::makeAllInactive()`. This also means that any mappings
 	   in always active contexts will conflict with mappings from other contexts (as they would override
 	   them anyway). */
-	const bool isAlwaysActive() const;
+	bool isAlwaysActive() const;
 
 private:
 	static InputContexts contexts;

--- a/src/input/mapping.cpp
+++ b/src/input/mapping.cpp
@@ -286,20 +286,19 @@ void KeyMappings::clear(nonstd::optional<KeyMappingType> filter)
 void KeyMappings::sort(const ContextManager& contexts)
 {
 	keyMappings.sort([&contexts](const KeyMapping& a, const KeyMapping& b) {
-		// Primary sort by priority
-		const unsigned int priorityA = contexts.getPriority(a.info.context);
-		const unsigned int priorityB = contexts.getPriority(b.info.context);
-		if (priorityA != priorityB)
-		{
-			return priorityA > priorityB;
-		}
-
 		// Sort by meta. This causes all mappings with meta to be checked before non-meta mappings,
 		// avoiding having to check for meta-conflicts in the processing loop. (e.g. if we should execute
 		// a mapping with right arrow key, depending on if another binding on shift+right-arrow is executed
 		// or not). In other words, if any mapping with meta is executed, it will consume the respective input,
 		// preventing any non-meta mappings with the same input from being executed.
-		return a.hasMeta() && !b.hasMeta();
+		if (a.hasMeta() != b.hasMeta()) {
+			return a.hasMeta() && !b.hasMeta();
+		}
+
+		// Sort by priority
+		const unsigned int priorityA = contexts.getPriority(a.info.context);
+		const unsigned int priorityB = contexts.getPriority(b.info.context);
+		return priorityA > priorityB;
 	});
 	bDirty = false;
 }

--- a/src/input/mapping.cpp
+++ b/src/input/mapping.cpp
@@ -233,8 +233,8 @@ std::vector<std::reference_wrapper<KeyMapping>> KeyMappings::findConflicting(con
 	std::vector<std::reference_wrapper<KeyMapping>> conflicts;
 	for (KeyMapping& mapping : matches)
 	{
-		/* Keys conflict if they are for the same context. ALWAYS_ACTIVE is special (always has highest priority), so those keys will always conflict. */
-		const bool bConflicts = mapping.info.context == InputContext::ALWAYS_ACTIVE || mapping.info.context == context;
+		/* Keys conflict if they are for the same context. Always active contexts are special (always have highest priority), so those keys will always conflict. */
+		const bool bConflicts = mapping.info.context.isAlwaysActive() || mapping.info.context == context;
 		if (bConflicts)
 		{
 			conflicts.push_back(mapping);

--- a/src/keyedit.cpp
+++ b/src/keyedit.cpp
@@ -730,7 +730,7 @@ bool KeyMapForm::pushedKeyCombo(const KeyMappingInput input)
 	   any conflicting keys from triggering. */
 	for (const KeyMapping& mapping : inputManager.mappings().findConflicting(metakey, input, selectedInfo->context))
 	{
-		if (mapping.info.context == InputContext::ALWAYS_ACTIVE)
+		if (mapping.info.context.isAlwaysActive())
 		{
 			audio_PlayTrack(ID_SOUND_BUILD_FAIL);
 			unhighlightSelected();

--- a/src/musicmanager.cpp
+++ b/src/musicmanager.cpp
@@ -849,6 +849,7 @@ static bool musicManager(WIDGET *parent, bool ingame)
 
 bool startInGameMusicManager(InputManager& inputManager)
 {
+	inputManager.contexts().pushState();
 	inputManager.contexts().makeAllInactive();
 	return musicManager(psWScreen->psForm.get(), true);
 }
@@ -881,14 +882,14 @@ bool runInGameMusicManager(unsigned id, InputManager& inputManager)
 {
 	if (id == MM_RETURN)			// return
 	{
-		inputManager.contexts().resetStates();
+		inputManager.contexts().popState();
 		widgDelete(psWScreen, MM_FORM);
 		inputLoseFocus();
 		return true;
 	}
 	else if (id == MM_GO_BACK)
 	{
-		inputManager.contexts().resetStates();
+		inputManager.contexts().popState();
 		widgDelete(psWScreen, MM_FORM);
 		intReopenMenuWithoutUnPausing();
 	}


### PR DESCRIPTION
Resolves #1850 

I had got the mapping sorting logic flipped in my head somehow. Primarily sorting by meta prevents more specific mappings with meta keys triggering if they have lower priority, even if the higher priority mappings do not have meta keys assigned.

Fix seems to be to simply just flip the sorting logic, so that the primary sort is over `hasMeta` and secondary over `getPriority`. This allows triggering mappings with meta keys, while prioritizing by context.