### PR TITLE
Use a single-component texture for the tcmask

### DIFF
--- a/data/base/shaders/button.frag
+++ b/data/base/shaders/button.frag
@@ -36,13 +36,13 @@ void main()
 	{
 		// Get tcmask information from texture unit 1
 		#if (!defined(GL_ES) && (__VERSION__ >= 130)) || (defined(GL_ES) && (__VERSION__ >= 300))
-		vec4 mask = texture(TextureTcmask, texCoord);
+		float maskAlpha = texture(TextureTcmask, texCoord).r;
 		#else
-		vec4 mask = texture2D(TextureTcmask, texCoord);
+		float maskAlpha = texture2D(TextureTcmask, texCoord).r;
 		#endif
 
 		// Apply colour using grain merge with tcmask
-		fragColour = (texColour + (teamcolour - 0.5) * mask.a) * colour;
+		fragColour = (texColour + (teamcolour - 0.5) * maskAlpha) * colour;
 	}
 	else
 	{

--- a/data/base/shaders/tcmask.frag
+++ b/data/base/shaders/tcmask.frag
@@ -123,13 +123,13 @@ void main()
 	{
 		// Get mask for team colors from texture
 		#if (!defined(GL_ES) && (__VERSION__ >= 130)) || (defined(GL_ES) && (__VERSION__ >= 300))
-		vec4 mask = texture(TextureTcmask, texCoord);
+		float maskAlpha = texture(TextureTcmask, texCoord).r;
 		#else
-		vec4 mask = texture2D(TextureTcmask, texCoord);
+		float maskAlpha = texture2D(TextureTcmask, texCoord).r;
 		#endif
 
 		// Apply color using grain merge with tcmask
-		fragColour = (light + (teamcolour - 0.5) * mask.a) * colour;
+		fragColour = (light + (teamcolour - 0.5) * maskAlpha) * colour;
 	}
 	else
 	{

--- a/data/base/shaders/vk/button.frag
+++ b/data/base/shaders/vk/button.frag
@@ -50,10 +50,10 @@ void main()
 	if (tcmask == 1)
 	{
 		// Get tcmask information from texture unit 1
-		vec4 mask = texture(TextureTcmask, texCoord);
+		float maskAlpha = texture(TextureTcmask, texCoord).r;
 
 		// Apply colour using grain merge with tcmask
-		fragColour = (texColour + (teamcolour - 0.5) * mask.a) * colour;
+		fragColour = (texColour + (teamcolour - 0.5) * maskAlpha) * colour;
 	}
 	else
 	{

--- a/data/base/shaders/vk/tcmask.frag
+++ b/data/base/shaders/vk/tcmask.frag
@@ -114,10 +114,10 @@ void main()
 	if (tcmask != 0)
 	{
 		// Get mask for team colors from texture
-		vec4 mask = texture(TextureTcmask, texCoord);
+		float maskAlpha = texture(TextureTcmask, texCoord).r;
 
 		// Apply color using grain merge with tcmask
-		fragColour = (light + (teamcolour - 0.5) * mask.a) * colour;
+		fragColour = (light + (teamcolour - 0.5) * maskAlpha) * colour;
 	}
 	else
 	{

--- a/lib/ivis_opengl/gfx_api.h
+++ b/lib/ivis_opengl/gfx_api.h
@@ -83,6 +83,7 @@ namespace gfx_api
 		FORMAT_RGBA8_UNORM_PACK8,
 		FORMAT_BGRA8_UNORM_PACK8,
 		FORMAT_RGB8_UNORM_PACK8,
+		FORMAT_R8_UNORM,
 	};
 
 	struct texture

--- a/lib/ivis_opengl/gfx_api_gl.cpp
+++ b/lib/ivis_opengl/gfx_api_gl.cpp
@@ -61,6 +61,8 @@ static std::pair<GLenum, GLenum> to_gl(const gfx_api::pixel_format& format)
 			return std::make_pair(GL_RGBA8, GL_BGRA);
 		case gfx_api::pixel_format::FORMAT_RGB8_UNORM_PACK8:
 			return std::make_pair(GL_RGB8, GL_RGB);
+		case gfx_api::pixel_format::FORMAT_R8_UNORM:
+			return std::make_pair(GL_R8, GL_RED);
 		default:
 			debug(LOG_FATAL, "Unrecognised pixel format");
 	}

--- a/lib/ivis_opengl/gfx_api_vk.cpp
+++ b/lib/ivis_opengl/gfx_api_vk.cpp
@@ -1424,6 +1424,8 @@ size_t VkTexture::format_size(const gfx_api::pixel_format& format)
 			return 4;
 		case gfx_api::pixel_format::FORMAT_RGB8_UNORM_PACK8:
 			return 3;
+		case gfx_api::pixel_format::FORMAT_R8_UNORM:
+			return 1;
 		default:
 			debug(LOG_FATAL, "Unrecognized pixel format");
 	}
@@ -1434,6 +1436,7 @@ size_t VkTexture::format_size(const vk::Format& format)
 {
 	switch (format)
 	{
+	case vk::Format::eR8Unorm: return sizeof(uint8_t);
 	case vk::Format::eR8G8B8Unorm: return 3 * sizeof(uint8_t);
 	case vk::Format::eB8G8R8A8Unorm:
 	case vk::Format::eR8G8B8A8Unorm: return 4 * sizeof(uint8_t);
@@ -3176,6 +3179,8 @@ vk::Format VkRoot::get_format(const gfx_api::pixel_format& format)
 	{
 	case gfx_api::pixel_format::FORMAT_RGB8_UNORM_PACK8:
 		return supports_rgb ? vk::Format::eR8G8B8Unorm : vk::Format::eR8G8B8A8Unorm;
+	case gfx_api::pixel_format::FORMAT_R8_UNORM:
+		return vk::Format::eR8Unorm;
 	case gfx_api::pixel_format::FORMAT_RGBA8_UNORM_PACK8:
 		return vk::Format::eR8G8B8A8Unorm;
 	case gfx_api::pixel_format::FORMAT_BGRA8_UNORM_PACK8:

--- a/lib/ivis_opengl/tex.cpp
+++ b/lib/ivis_opengl/tex.cpp
@@ -248,7 +248,7 @@ bool scaleImageMaxSize(iV_Image *s, int maxWidth, int maxHeight)
  *  @return a non-negative index number for the texture, negative if no texture
  *          with the given filename could be found
  */
-optional<size_t> iV_GetTexture(const char *filename, bool compression, int maxWidth /*= -1*/, int maxHeight /*= -1*/)
+optional<size_t> iV_GetTransformTexture(const char *filename, std::function<void (iV_Image&)> transformImageData, bool compression, int maxWidth /*= -1*/, int maxHeight /*= -1*/)
 {
 	ASSERT(filename != nullptr, "filename must not be null");
 	iV_Image sSprite;
@@ -270,9 +270,18 @@ optional<size_t> iV_GetTexture(const char *filename, bool compression, int maxWi
 		return nullopt;
 	}
 	scaleImageMaxSize(&sSprite, maxWidth, maxHeight);
+	if (transformImageData)
+	{
+		transformImageData(sSprite);
+	}
 	size_t page = pie_AddTexPage(&sSprite, path.c_str(), compression);
 	resDoResLoadCallback(); // ensure loading screen doesn't freeze when loading large images
 	return optional<size_t>(page);
+}
+
+optional<size_t> iV_GetTexture(const char *filename, bool compression, int maxWidth /*= -1*/, int maxHeight /*= -1*/)
+{
+	return iV_GetTransformTexture(filename, nullptr, compression, maxWidth, maxHeight);
 }
 
 bool replaceTexture(const WzString &oldfile, const WzString &newfile)
@@ -335,6 +344,8 @@ gfx_api::pixel_format iV_getPixelFormat(const iV_Image *image)
 {
 	switch (image->depth)
 	{
+	case 1:
+		return gfx_api::pixel_format::FORMAT_R8_UNORM;
 	case 3:
 		return gfx_api::pixel_format::FORMAT_RGB8_UNORM_PACK8;
 	case 4:

--- a/lib/ivis_opengl/tex.h
+++ b/lib/ivis_opengl/tex.h
@@ -24,6 +24,7 @@
 #include "gfx_api.h"
 #include "png_util.h"
 
+#include <functional>
 #include <optional-lite/optional.hpp>
 using nonstd::optional;
 using nonstd::nullopt;
@@ -45,6 +46,7 @@ void pie_AssignTexture(size_t page, gfx_api::texture* texture);
 bool scaleImageMaxSize(iV_Image *s, int maxWidth, int maxHeight);
 
 optional<size_t> iV_GetTexture(const char *filename, bool compression = true, int maxWidth = -1, int maxHeight = -1);
+optional<size_t> iV_GetTransformTexture(const char *filename, std::function<void (iV_Image&)> transformImageData = nullptr, bool compression = true, int maxWidth = -1, int maxHeight = -1);
 void iV_unloadImage(iV_Image *image);
 gfx_api::pixel_format iV_getPixelFormat(const iV_Image *image);
 


### PR DESCRIPTION
Avoid wasting space by storing a bunch of unused channels in video memory.