### PR TITLE
fix: close WzConfig group when skipping unknown research from savegame

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -6468,6 +6468,8 @@ bool loadSaveResearch(const char *pFileName)
 		if (!found)
 		{
 			//ignore this record
+			debug(LOG_SAVE, "Skipping unknown research named '%s'", name.toStdString().c_str());
+			ini.endGroup();
 			continue;
 		}
 		auto researchedList = ini.value("researched").jsonValue();


### PR DESCRIPTION
This caused a problem where the rest of the research would not be
processed, because the WzConfig group would return empty names.

I encountered a problem with older savegames, which contained research that is no longer in the campaign. Some research stats are applied, until the first unknown research is skipped and the rest of the research in the file is ignored.