### PR TITLE
Use a single-component texture for specular maps

### DIFF
--- a/data/base/shaders/tcmask.frag
+++ b/data/base/shaders/tcmask.frag
@@ -94,10 +94,11 @@ void main()
 		if (specularmap != 0)
 		{
 			#if (!defined(GL_ES) && (__VERSION__ >= 130)) || (defined(GL_ES) && (__VERSION__ >= 300))
-			vec4 specularFromMap = texture(TextureSpecular, texCoord);
+			float specularMapValue = texture(TextureSpecular, texCoord).r;
 			#else
-			vec4 specularFromMap = texture2D(TextureSpecular, texCoord);
+			float specularMapValue = texture2D(TextureSpecular, texCoord).r;
 			#endif
+			vec4 specularFromMap = vec4(specularMapValue, specularMapValue, specularMapValue, 1.0);
 
 			// Gaussian specular term computation
 			vec3 H = normalize(halfVec);

--- a/data/base/shaders/vk/tcmask.frag
+++ b/data/base/shaders/vk/tcmask.frag
@@ -89,7 +89,8 @@ void main()
 
 		if (specularmap != 0)
 		{
-			vec4 specularFromMap = texture(TextureSpecular, texCoord);
+			float specularMapValue = texture(TextureSpecular, texCoord).r;
+			vec4 specularFromMap = vec4(specularMapValue, specularMapValue, specularMapValue, 1.0);
 
 			// Gaussian specular term computation
 			vec3 H = normalize(halfVec);


### PR DESCRIPTION
@MaNGusT- Would appreciate your feedback. I have tested this using the latest ArtRev and the results look reasonable.

Windows build artifacts are available here: https://github.com/Warzone2100/warzone2100/actions/runs/893489849

As a note, the following ArtRev files have non-matching RGB channels (and thus will use an approximate weighted RGB -> Luma calculation):
- page-116_spec.png
- blWare1_spec.png
- blWare2_spec.png
- blWare3_spec.png
- miCrane_spec.png
- miOil_spec.png
- miJeep_spec.png
- miTanker_sm.png
- miCamper_spec.png

All the others appear to have matching RGB channels.

Also - even before this PR - the tcmask coloring of some of the ArtRev unit bodies appears to be noticeably "brighter" than the tcmask coloring on walls / buildings / etc. (This is more noticeable with "bright" player colors like orange / yellow / pink, etc.)