### PR TITLE
Clean up option menus that are open when a host quits.

### DIFF
--- a/src/ingameop.cpp
+++ b/src/ingameop.cpp
@@ -364,6 +364,8 @@ void intAddInGamePopup()
 		return;
 	}
 
+	intCloseInGameOptions(false, false); //clear out option-like menus
+
 	audio_StopAll();
 
 	if (!gamePaused())


### PR DESCRIPTION
A cheap and effective way to handle another edge case softlock. Tests sufficiently demonstrate the removal of option menus, keymap, and the music manager by acting like the "close" option was pressed just before this special popup begins to exist.

Fixes #1793.