### PR TITLE
Take away speed from campaign transporters moving out to away mission map

### DIFF
--- a/src/order.cpp
+++ b/src/order.cpp
@@ -402,6 +402,8 @@ void orderUpdateDroid(DROID *psDroid)
 					/* clear order */
 					psDroid->order = DroidOrder(DORDER_NONE);
 				}
+
+				psDroid->sMove.speed = 0; // Prevent radical movement vector when adjusting from home to away map exit and entry coordinates.
 			}
 		}
 		break;


### PR DESCRIPTION
Otherwise they will carry their speed over to the away mission and could waste a lot of time watching it decelerate depending on the entry/exit points from home to away mission.

Fixes #1644.