### PR TITLE
Fix New Paradigm LZ area on Alpha 9

### DIFF
--- a/data/base/script/campaign/cam1-5.js
+++ b/data/base/script/campaign/cam1-5.js
@@ -96,8 +96,8 @@ camAreaEvent("NPFactoryTrigger", function(droid)
 //Land New Paradigm transport in the LZ area (protected by four hardpoints in the New Paradigm base)
 camAreaEvent("NPLZTrigger", function()
 {
-	sendNPTransport();
 	setTimer("sendNPTransport", camChangeOnDiff(camMinutesToMilliseconds(3)));
+	sendNPTransport();
 });
 
 function sendNPTransport()

--- a/data/base/wrf/cam1/sub1-5/labels.json
+++ b/data/base/wrf/cam1/sub1-5/labels.json
@@ -48,8 +48,8 @@
 	},
 	"area_2": {
 		"label": "LandingZone2",
-		"pos1": [6016, 2688],
-		"pos2": [6272, 2432]
+		"pos1": [5760, 2176],
+		"pos2": [6528, 2944]
 	},
 	"area_3": {
 		"label": "ScavNorth",


### PR DESCRIPTION
Was meant to be big enough to encompass the four hardpoints. No idea why this recent change didn't trigger an assert in the camBalance mod.

Refs #1857.