### PR TITLE
Fix vtol collision with ground units #1873

### DIFF
--- a/lib/gamelib/gtime.cpp
+++ b/lib/gamelib/gtime.cpp
@@ -213,8 +213,8 @@ void gameTimeUpdate(bool mayUpdate)
 		updateLatency();
 		if (crcError)
 		{
-			//debug(LOG_ERROR, "Synch error, gameTimes were: {%s}", listToString("%7u", ", ", gameQueueCheckTime, gameQueueCheckTime + game.maxPlayers).c_str());
-			//debug(LOG_ERROR, "Synch error, CRCs were:      {%s}", listToString(" 0x%04X", ", ", gameQueueCheckCrc, gameQueueCheckCrc + game.maxPlayers).c_str());
+			debug(LOG_ERROR, "Synch error, gameTimes were: {%s}", listToString("%7u", ", ", gameQueueCheckTime, gameQueueCheckTime + game.maxPlayers).c_str());
+			debug(LOG_ERROR, "Synch error, CRCs were:      {%s}", listToString(" 0x%04X", ", ", gameQueueCheckCrc, gameQueueCheckCrc + game.maxPlayers).c_str());
 			crcError = false;
 		}
 	}

--- a/lib/gamelib/gtime.cpp
+++ b/lib/gamelib/gtime.cpp
@@ -213,8 +213,8 @@ void gameTimeUpdate(bool mayUpdate)
 		updateLatency();
 		if (crcError)
 		{
-			debug(LOG_ERROR, "Synch error, gameTimes were: {%s}", listToString("%7u", ", ", gameQueueCheckTime, gameQueueCheckTime + game.maxPlayers).c_str());
-			debug(LOG_ERROR, "Synch error, CRCs were:      {%s}", listToString(" 0x%04X", ", ", gameQueueCheckCrc, gameQueueCheckCrc + game.maxPlayers).c_str());
+			//debug(LOG_ERROR, "Synch error, gameTimes were: {%s}", listToString("%7u", ", ", gameQueueCheckTime, gameQueueCheckTime + game.maxPlayers).c_str());
+			//debug(LOG_ERROR, "Synch error, CRCs were:      {%s}", listToString(" 0x%04X", ", ", gameQueueCheckCrc, gameQueueCheckCrc + game.maxPlayers).c_str());
 			crcError = false;
 		}
 	}

--- a/src/move.cpp
+++ b/src/move.cpp
@@ -1051,7 +1051,7 @@ static void moveCalcDroidSlide(DROID *psDroid, int *pmx, int *pmy)
 		if (psObj->type == OBJ_DROID)
 		{
 			DROID * psObjcast = static_cast<DROID*> (psObj);
-			int32_t objR = moveObjRadius(psObj);
+			objR = moveObjRadius(psObj);
 			if (isTransporter(psObjcast))
 			{
 				// ignore transporters

--- a/src/move.cpp
+++ b/src/move.cpp
@@ -1051,13 +1051,14 @@ static void moveCalcDroidSlide(DROID *psDroid, int *pmx, int *pmy)
 		if (psObj->type == OBJ_DROID)
 		{
 			DROID * psObjcast = static_cast<DROID*> (psObj);
+			int32_t objR = moveObjRadius(psObj);
 			if (isTransporter(psObjcast))
 			{
 				// ignore transporters
 				continue;
 			}
-			if ((!isFlying(psDroid) && isFlying(psObjcast) && psObjcast->pos.z > psDroid->pos.z) || 
-			    (!isFlying(psObjcast) && isFlying(psDroid) && psDroid->pos.z > psObjcast->pos.z))
+			if ((!isFlying(psDroid) && isFlying(psObjcast) && psObjcast->pos.z > (psDroid->pos.z + droidR)) || 
+			    (!isFlying(psObjcast) && isFlying(psDroid) && psDroid->pos.z > (psObjcast->pos.z + objR)))
 			{
 				// ground unit can't bump into a flying saucer..
 				continue;

--- a/src/move.cpp
+++ b/src/move.cpp
@@ -1050,22 +1050,25 @@ static void moveCalcDroidSlide(DROID *psDroid, int *pmx, int *pmy)
 		}
 		if (psObj->type == OBJ_DROID)
 		{
-			if (isTransporter((DROID *)psObj))
+			DROID * psObjcast = static_cast<DROID*> (psObj);
+			if (isTransporter(psObjcast))
 			{
 				// ignore transporters
 				continue;
 			}
-			if ((!isFlying(psDroid) && isFlying((DROID *)psObj)) || (!isFlying((DROID *) psObj) && isFlying(psDroid)))
+			if ((!isFlying(psDroid) && isFlying(psObjcast) && psObjcast->pos.z > psDroid->pos.z) || 
+			    (!isFlying(psObjcast) && isFlying(psDroid) && psDroid->pos.z > psObjcast->pos.z))
 			{
 				// ground unit can't bump into a flying saucer..
 				continue;
+
 			}
-			if (!bLegs && ((DROID *)psObj)->droidType == DROID_PERSON)
+			if (!bLegs && (psObjcast)->droidType == DROID_PERSON)
 			{
 				// everything else doesn't avoid people
 				continue;
 			}
-			if (psObj->player == psDroid->player
+			if (psObjcast->player == psDroid->player
 			    && psDroid->lastFrustratedTime > 0
 			    && gameTime - psDroid->lastFrustratedTime < FRUSTRATED_TIME)
 			{

--- a/src/move.cpp
+++ b/src/move.cpp
@@ -1055,6 +1055,11 @@ static void moveCalcDroidSlide(DROID *psDroid, int *pmx, int *pmy)
 				// ignore transporters
 				continue;
 			}
+			if ((!isFlying(psDroid) && isFlying((DROID *)psObj)) || (!isFlying((DROID *) psObj) && isFlying(psDroid)))
+			{
+				// ground unit can't bump into a flying saucer..
+				continue;
+			}
 			if (!bLegs && ((DROID *)psObj)->droidType == DROID_PERSON)
 			{
 				// everything else doesn't avoid people

--- a/src/multimenu.cpp
+++ b/src/multimenu.cpp
@@ -711,15 +711,15 @@ static void displayExtraGubbins(UDWORD height, ExtraGubbinsCache& cache)
 		iV_DrawText(str, MULTIMENU_FORM_X + xPos, MULTIMENU_FORM_Y + height + yPos, font_small);
 		xPos += iV_GetTextWidth(str, font_small) + 20;
 
-		snprintf(str, sizeof(str), _("Traf: %u/%u"), NETgetStatistic(NetStatisticRawBytes, true, isTotal), NETgetStatistic(NetStatisticRawBytes, false, isTotal));
+		snprintf(str, sizeof(str), _("Traf: %lu/%lu"), NETgetStatistic(NetStatisticRawBytes, true, isTotal), NETgetStatistic(NetStatisticRawBytes, false, isTotal));
 		iV_DrawText(str, MULTIMENU_FORM_X + xPos, MULTIMENU_FORM_Y + height + yPos, font_small);
 		xPos += iV_GetTextWidth(str, font_small) + 20;
 
-		snprintf(str, sizeof(str), _("Uncompressed: %u/%u"), NETgetStatistic(NetStatisticUncompressedBytes, true, isTotal), NETgetStatistic(NetStatisticUncompressedBytes, false, isTotal));
+		snprintf(str, sizeof(str), _("Uncompressed: %lu/%lu"), NETgetStatistic(NetStatisticUncompressedBytes, true, isTotal), NETgetStatistic(NetStatisticUncompressedBytes, false, isTotal));
 		iV_DrawText(str, MULTIMENU_FORM_X + xPos, MULTIMENU_FORM_Y + height + yPos, font_small);
 		xPos += iV_GetTextWidth(str, font_small) + 20;
 
-		snprintf(str, sizeof(str), _("Pack: %u/%u"), NETgetStatistic(NetStatisticPackets, true, isTotal), NETgetStatistic(NetStatisticPackets, false, isTotal));
+		snprintf(str, sizeof(str), _("Pack: %lu/%lu"), NETgetStatistic(NetStatisticPackets, true, isTotal), NETgetStatistic(NetStatisticPackets, false, isTotal));
 		iV_DrawText(str, MULTIMENU_FORM_X + xPos, MULTIMENU_FORM_Y + height + yPos, font_small);
 	}
 #endif

--- a/src/objmem.cpp
+++ b/src/objmem.cpp
@@ -977,7 +977,7 @@ static void objListIntegCheck()
 			ASSERT(psCurr->type == OBJ_STRUCTURE &&
 			       (SDWORD)psCurr->player == player,
 			       "objListIntegCheck: misplaced %s(%p) in the structure list for player %d, is owned by %d",
-			       objInfo(psCurr), psCurr, player, (int)psCurr->player);
+			       objInfo(psCurr), (void*) psCurr, player, (int)psCurr->player);
 		}
 	}
 	for (psCurr = (BASE_OBJECT *)apsFeatureLists[0]; psCurr; psCurr = psCurr->psNext)


### PR DESCRIPTION
This fixes the problem when flying VTOLs made ground units stop
 in https://github.com/Warzone2100/warzone2100/issues/1873. (reproduced on master)

after applying this:
![fix-vtol](https://user-images.githubusercontent.com/25161465/122682203-5ef2d800-d1f8-11eb-8b37-8246a804e2ee.gif)

P.S I also fixed some warnings between `#ifndef DEBUG` because it prevents compilation

Fixes #1873.