### PR TITLE
Improve handling of corrupt map archives

### DIFF
--- a/lib/netplay/netplay.cpp
+++ b/lib/netplay/netplay.cpp
@@ -2333,6 +2333,7 @@ int NETrecvFile(NETQUEUE queue)
 			debug(LOG_ERROR, "Could not close file handle after trying to terminate download: %s", WZ_PHYSFS_getLastError());
 		}
 		file->handle = nullptr;
+		PHYSFS_delete(file->filename.c_str());
 		sendCancelFileDownload(file->hash);
 		NetPlay.wzFiles.erase(file);
 	};

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -515,7 +515,7 @@ static MapFileList listMapFiles()
 		if (PHYSFS_mount(realFilePathAndName.c_str(), NULL, PHYSFS_APPEND))
 		{
 			int unsafe = 0;
-			WZ_PHYSFS_enumerateFiles("multiplay/maps", [&unsafe, &realFilePathAndName](const char *file) -> bool {
+			bool enumSuccess = WZ_PHYSFS_enumerateFiles("multiplay/maps", [&unsafe, &realFilePathAndName](const char *file) -> bool {
 				std::string isDir = std::string("multiplay/maps/") + file;
 				if (WZ_PHYSFS_isDirectory(isDir.c_str()))
 				{
@@ -533,6 +533,12 @@ static MapFileList listMapFiles()
 				}
 				return true; // continue
 			});
+			if (!enumSuccess)
+			{
+				// Failed to enumerate contents - corrupt map archive (ignore it)
+				debug(LOG_ERROR, "Failed to enumerate - ignoring corrupt map file: %s", realFilePathAndName.c_str());
+				unsafe = std::numeric_limits<int>::max() - 1;
+			}
 			if (unsafe < 2)
 			{
 				filtered.push_back(realFileName);
@@ -685,9 +691,13 @@ bool buildMapList()
 		}
 		std::string realFilePathAndName = pRealDirStr + realFileName.platformDependent;
 
-		PHYSFS_mount(realFilePathAndName.c_str(), NULL, PHYSFS_APPEND);
+		if (PHYSFS_mount(realFilePathAndName.c_str(), NULL, PHYSFS_APPEND) == 0)
+		{
+			debug(LOG_POPUP, "Could not mount %s, because: %s.\nPlease delete or move the file specified.", realFilePathAndName.c_str(), WZ_PHYSFS_getLastError());
+			continue; // skip
+		}
 
-		WZ_PHYSFS_enumerateFiles("", [&](const char *file) -> bool {
+		bool enumSuccess = WZ_PHYSFS_enumerateFiles("", [&](const char *file) -> bool {
 			size_t len = strlen(file);
 			if (len > 10 && !strcasecmp(file + (len - 10), ".addon.lev"))  // Do not add addon.lev again
 			{
@@ -704,6 +714,11 @@ bool buildMapList()
 		if (WZ_PHYSFS_unmount(realFilePathAndName.c_str()) == 0)
 		{
 			debug(LOG_ERROR, "Could not unmount %s, %s", realFilePathAndName.c_str(), WZ_PHYSFS_getLastError());
+		}
+		if (!enumSuccess)
+		{
+			// Failed to enumerate contents - corrupt map archive
+			debug(LOG_ERROR, "Failed to enumerate - corrupt map file: %s", realFilePathAndName.c_str());
 		}
 
 		auto chk = CheckInMap(realFilePathAndName.c_str(), "WZMap", lookin_list);


### PR DESCRIPTION
`PHYSFS_mount` may succeed for corrupt map archives, but a later call to `PHYSFS_enumerateFiles` may fail.