### PR TITLE
Fix updating certain key mappings making the keys unusable

### DIFF
--- a/src/input/keyconfig.cpp
+++ b/src/input/keyconfig.cpp
@@ -453,7 +453,11 @@ KeyCombination::KeyCombination(
 )
 	: meta(meta)
 	, input(input)
-	, action(action)
+	, action(
+		input.is(MOUSE_KEY_CODE::MOUSE_WUP) || input.is(MOUSE_KEY_CODE::MOUSE_WDN)
+			? KeyAction::PRESSED
+			: action
+	)
 {
 }
 

--- a/src/keyedit.cpp
+++ b/src/keyedit.cpp
@@ -762,11 +762,21 @@ bool KeyMapForm::pushedKeyCombo(const KeyMappingInput input)
 		return defaultMapping.first == KeyMappingSlot::PRIMARY;
 	});
 
+	const auto foundMatch = std::find_if(selectedInfo->defaultMappings.cbegin(), selectedInfo->defaultMappings.cend(), [&input](const std::pair<KeyMappingSlot, KeyCombination>& defaultMapping) {
+		const KeyCombination combination = defaultMapping.second;
+		return combination.input == input;
+	});
+
 	KeyAction action = KeyAction::PRESSED;
-	if (foundPrimary != selectedInfo->defaultMappings.cend())
+	if (foundMatch != selectedInfo->defaultMappings.cend())
+	{
+		action = foundMatch->second.action;
+	}
+	else if (foundPrimary != selectedInfo->defaultMappings.cend())
 	{
 		action = foundPrimary->second.action;
 	}
+
 
 	/* Finally, create the new mapping */
 	KeyMapping& newMapping = inputManager.mappings().add({ metakey, input, action }, *selectedInfo, keyMapSelection.slot);


### PR DESCRIPTION
Resolves #1910 

As discussed in the issue linked, it turned out that `KeyAction`s from the default mappings bound to the keys were not being respected. 

Fixing the issue was quite straightforward: just make sure we use the same key action as the default mappings use. Furthermore, as scrollwheel can never trigger on `KeyAction::DOWN`, I added an additional check to make sure the scroll wheel always uses `KeyAction::PRESSED`.