### PR TITLE
Handle research upgrade calculations in C++, add "research" debug logging

### DIFF
--- a/data/base/script/rules.js
+++ b/data/base/script/rules.js
@@ -420,28 +420,7 @@ function eventTransporterLanded(transport)
 
 function eventResearched(research, structure, player)
 {
-	//debug("RESEARCH : " + research.fullname + "(" + research.name + ") for " + player);
-	// iterate over all results
-	for (var i = 0; i < research.results.length; i++)
-	{
-		var v = research.results[i];
-		//debug("    RESULT : class=" + v['class'] + " parameter=" + v['parameter'] + " value=" + v['value'] + " filter=" + v['filterParameter'] + " filterparam=" + v['filterParameter']);
-		for (var cname in Upgrades[player][v['class']]) // iterate over all components of this type
-		{
-			var parameter = v['parameter'];
-			var ctype = v['class'];
-			var filterparam = v['filterParameter'];
-			if ('filterParameter' in v && Stats[ctype][cname][filterparam] != v['filterValue']) // more specific filter
-			{
-				continue;
-			}
-			if (Stats[ctype][cname][parameter] > 0) // only applies if stat has above zero value already
-			{
-				Upgrades[player][ctype][cname][parameter] += Math.ceil(Stats[ctype][cname][parameter] * v['value'] / 100);
-				//debug("      upgraded " + cname + " to " + Upgrades[player][ctype][cname][parameter] + " by " + Math.ceil(Stats[ctype][cname][parameter] * v['value'] / 100));
-			}
-		}
-	}
+	// NOTE: Research upgrades are handled by the C++ core game engine since 4.1.0
 }
 
 var lastHitTime = 0;

--- a/data/mp/multiplay/script/rules/events/research.js
+++ b/data/mp/multiplay/script/rules/events/research.js
@@ -1,37 +1,4 @@
 function eventResearched(research, structure, player)
 {
-	//if (research.name == "") debug("RESEARCH : " + research.fullname + "(" + research.name + ") for " + player);
-	// iterate over all results
-	for (var i = 0; i < research.results.length; i++)
-	{
-		var v = research.results[i];
-		//if (research.name == "") debug("    RESULT : class=" + v['class'] + " parameter=" + v['parameter'] + " value=" + v['value'] + " filter=" + v['filterParameter'] + " filterval=" + v['filterValue']);
-		for (var cname in Upgrades[player][v['class']]) // iterate over all components of this type
-		{
-			var parameter = v['parameter'];
-			var ctype = v['class'];
-			var filterparam = v['filterParameter'];
-			if ('filterParameter' in v && Stats[ctype][cname][filterparam] != v['filterValue']) // more specific filter
-			{
-				//if (research.name == "") debug("    skipped param=" + parameter + " cname=" + cname);
-				continue;
-			}
-			if (Stats[ctype][cname][parameter] instanceof Array)
-			{
-				var dst = Upgrades[player][ctype][cname][parameter].slice();
-				for (var x = 0; x < dst.length; x++)
-				{
-					dst[x] += Math.ceil(Stats[ctype][cname][parameter][x] * v['value'] / 100);
-				}
-				Upgrades[player][ctype][cname][parameter] = dst;
-				//debug("    upgraded to " + dst);
-			}
-			else if (Stats[ctype][cname][parameter] > 0) // only applies if stat has above zero value already
-			{
-				Upgrades[player][ctype][cname][parameter] += Math.ceil(Stats[ctype][cname][parameter] * v['value'] / 100);
-				//if (research.name == "") debug("      upgraded " + cname + " to " + Upgrades[player][ctype][cname][parameter] + " by " + Math.ceil(Stats[ctype][cname][parameter] * v['value'] / 100));
-			}
-			//else if (research.name == "") debug("    passed " + Stats[ctype][cname][parameter] + " param=" + parameter + " cname=" + cname);
-		}
-	}
+	// NOTE: Research upgrades are handled by the C++ core game engine since 4.1.0
 }

--- a/data/mp/stats/research.json
+++ b/data/mp/stats/research.json
@@ -5075,7 +5075,7 @@
 				"class": "Weapon",
 				"filterParameter": "ImpactClass",
 				"filterValue": "A-A GUN",
-				"parameter": "Reload",
+				"parameter": "ReloadTime",
 				"value": -10
 			}
 		],
@@ -6215,7 +6215,7 @@
 				"class": "Weapon",
 				"filterParameter": "ImpactClass",
 				"filterValue": "ENERGY",
-				"parameter": "Reload",
+				"parameter": "ReloadTime",
 				"value": -15
 			}
 		],

--- a/lib/framework/debug.cpp
+++ b/lib/framework/debug.cpp
@@ -107,6 +107,7 @@ static const char *code_part_names[] =
 	"popup",
 	"console",
 	"activity",
+	"research",
 	"last"
 };
 

--- a/lib/framework/debug.h
+++ b/lib/framework/debug.h
@@ -195,6 +195,7 @@ enum code_part
 	LOG_POPUP,	// special, on by default, for both debug & release builds (used for OS dependent popup code)
 	LOG_CONSOLE,	// send console messages to file
 	LOG_ACTIVITY,
+	LOG_RESEARCH,
 	LOG_LAST /**< _must_ be last! */
 };
 

--- a/src/wzapi.cpp
+++ b/src/wzapi.cpp
@@ -201,6 +201,8 @@ void wzapi::scripting_instance::dumpScriptLog(const std::string &info, int me)
 	}
 }
 
+wzapi::execution_context_base::~execution_context_base()
+{ }
 wzapi::execution_context::~execution_context()
 { }
 int wzapi::execution_context::player() const
@@ -3279,7 +3281,7 @@ enum Scrcb {
 	SCRCB_LAST = SCRCB_LIMIT
 };
 
-bool wzapi::setUpgradeStats(WZAPI_PARAMS(int player, const std::string& name, int type, unsigned index, const nlohmann::json& newValue))
+bool wzapi::setUpgradeStats(WZAPI_BASE_PARAMS(int player, const std::string& name, int type, unsigned index, const nlohmann::json& newValue))
 {
 	int value = json_variant(newValue).toInt();
 	syncDebug("stats[p%d,t%d,%s,i%d] = %d", player, type, name.c_str(), index, value);
@@ -3623,7 +3625,7 @@ bool wzapi::setUpgradeStats(WZAPI_PARAMS(int player, const std::string& name, in
 	return true;
 }
 
-nlohmann::json wzapi::getUpgradeStats(WZAPI_PARAMS(int player, const std::string& name, int type, unsigned index))
+nlohmann::json wzapi::getUpgradeStats(WZAPI_BASE_PARAMS(int player, const std::string& name, int type, unsigned index))
 {
 	if (type == COMP_BODY)
 	{
@@ -3901,7 +3903,7 @@ nlohmann::json wzapi::getUpgradeStats(WZAPI_PARAMS(int player, const std::string
 }
 
 
-wzapi::GameEntityRules::value_type wzapi::GameEntityRules::getPropertyValue(const wzapi::execution_context& context, const std::string& name) const
+wzapi::GameEntityRules::value_type wzapi::GameEntityRules::getPropertyValue(const wzapi::execution_context_base& context, const std::string& name) const
 {
 	auto it = propertyNameToTypeMap.find(name);
 	if (it == propertyNameToTypeMap.end())
@@ -3913,7 +3915,7 @@ wzapi::GameEntityRules::value_type wzapi::GameEntityRules::getPropertyValue(cons
 	return wzapi::getUpgradeStats(context, getPlayer(), name, type, getIndex());
 }
 
-wzapi::GameEntityRules::value_type wzapi::GameEntityRules::setPropertyValue(const wzapi::execution_context& context, const std::string& name, const value_type& newValue)
+wzapi::GameEntityRules::value_type wzapi::GameEntityRules::setPropertyValue(const wzapi::execution_context_base& context, const std::string& name, const value_type& newValue)
 {
 	auto it = propertyNameToTypeMap.find(name);
 	if (it == propertyNameToTypeMap.end())

--- a/src/wzapi.h
+++ b/src/wzapi.h
@@ -110,6 +110,7 @@ namespace wzapi
 #define WZAPI_NO_PARAMS_NO_CONTEXT
 #define WZAPI_NO_PARAMS const wzapi::execution_context& context
 #define WZAPI_PARAMS(...) const wzapi::execution_context& context, __VA_ARGS__
+#define WZAPI_BASE_PARAMS(...) const wzapi::execution_context_base& context, __VA_ARGS__
 
 #define SCRIPTING_EVENT_NON_REQUIRED { return false; }
 
@@ -657,7 +658,15 @@ namespace wzapi
 		bool m_isReceivingAllEvents = false;
 	};
 
-	class execution_context
+	class execution_context_base
+	{
+	public:
+		virtual ~execution_context_base();
+	public:
+		virtual void throwError(const char *expr, int line, const char *function) const = 0;
+	};
+
+	class execution_context : public execution_context_base
 	{
 	public:
 		virtual ~execution_context();
@@ -666,7 +675,6 @@ namespace wzapi
 		int player() const;
 		void set_isReceivingAllEvents(bool value) const;
 		bool get_isReceivingAllEvents() const;
-		virtual void throwError(const char *expr, int line, const char *function) const = 0;
 		virtual playerCallbackFunc getNamedScriptCallback(const WzString& func) const = 0;
 		virtual void doNotSaveGlobal(const std::string &global) const = 0;
 	};
@@ -847,8 +855,8 @@ namespace wzapi
 		{ }
 	public:
 		using value_type = nlohmann::json;
-		value_type getPropertyValue(const wzapi::execution_context& context, const std::string& name) const;
-		value_type setPropertyValue(const wzapi::execution_context& context, const std::string& name, const value_type& newValue);
+		value_type getPropertyValue(const wzapi::execution_context_base& context, const std::string& name) const;
+		value_type setPropertyValue(const wzapi::execution_context_base& context, const std::string& name, const value_type& newValue);
 	public:
 		inline NameToTypeMap::const_iterator begin() const
 		{
@@ -1078,8 +1086,8 @@ namespace wzapi
 	no_return_value setObjectFlag(WZAPI_PARAMS(BASE_OBJECT *psObj, int _flag, bool value)) MULTIPLAY_SYNCREQUEST_REQUIRED;
 	no_return_value fireWeaponAtLoc(WZAPI_PARAMS(std::string weaponName, int x, int y, optional<int> _player));
 	no_return_value fireWeaponAtObj(WZAPI_PARAMS(std::string weaponName, BASE_OBJECT *psObj, optional<int> _player));
-	bool setUpgradeStats(WZAPI_PARAMS(int player, const std::string& name, int type, unsigned index, const nlohmann::json& newValue));
-	nlohmann::json getUpgradeStats(WZAPI_PARAMS(int player, const std::string& name, int type, unsigned index));
+	bool setUpgradeStats(WZAPI_BASE_PARAMS(int player, const std::string& name, int type, unsigned index, const nlohmann::json& newValue));
+	nlohmann::json getUpgradeStats(WZAPI_BASE_PARAMS(int player, const std::string& name, int type, unsigned index));
 
 	// MARK: - Used for retrieving information to set up script instance environments
 	nlohmann::json constructStatsObject();

--- a/src/wzapi.h
+++ b/src/wzapi.h
@@ -923,6 +923,15 @@ namespace wzapi
 		{
 			return upgrades[entityClass];
 		}
+		inline const GameEntityRuleContainer* find(const GameEntityClass& entityClass) const
+		{
+			auto it = upgrades.find(entityClass);
+			if (it == upgrades.end())
+			{
+				return nullptr;
+			}
+			return &(it->second);
+		}
 		inline int getPlayer() const { return player; }
 		inline std::map<GameEntityClass, GameEntityRuleContainer>::const_iterator begin() const
 		{


### PR DESCRIPTION
Ensure that stat modifications from research upgrades are calculated using integer arithmetic.

Can now pass `--debug=research` as a command-line option to get detailed output about the effects of research upgrades.

Possibly fixes #1918 and #509