### PR TITLE
Various release automation improvements

### DIFF
--- a/.ci/githubactions/checkout_config.sh
+++ b/.ci/githubactions/checkout_config.sh
@@ -1,0 +1,53 @@
+#!/bin/sh
+
+# To use this, the following environment variables must first be manually set in the workflow step that runs it:
+# env:
+#   WORKFLOW_RUN_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
+#   WORKFLOW_RUN_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+
+if [ "${GITHUB_EVENT_NAME}" = "workflow_run" ]; then
+  echo "GITHUB_EVENT_NAME = ${GITHUB_EVENT_NAME}"
+  # Verify it succeeded
+  if [ "${WORKFLOW_RUN_CONCLUSION}" != "success" ]; then
+    echo "::error ::GITHUB_EVENT_NAME is ${GITHUB_EVENT_NAME}, but the WORKFLOW_RUN_CONCLUSION was: ${WORKFLOW_RUN_CONCLUSION}"
+    exit 1
+  fi
+  if [ -z "${WORKFLOW_RUN_HEAD_SHA}" ]; then
+    echo "::error ::WORKFLOW_RUN_HEAD_SHA is not set or is empty"
+    exit 1
+  fi
+  # Use the context of the workflow_run
+  echo "WORKFLOW_RUN_HEAD_SHA=${WORKFLOW_RUN_HEAD_SHA}"
+  WZ_GITHUB_SHA="${WORKFLOW_RUN_HEAD_SHA}"
+  # Get the tag name
+  COMMIT_ASSOCIATED_TAG="$(git describe --tags --exact-match --abbrev=0 "${WZ_GITHUB_SHA}")"
+  RESULT=$?
+  if [ $RESULT -ne 0 ]; then
+    echo "::error ::workflow_run trigger does not appear to have run on a tag? (sha: ${WZ_GITHUB_SHA} doesn't match a tag')"
+    exit 1
+  fi
+  WZ_GITHUB_REF="refs/tags/${COMMIT_ASSOCIATED_TAG}"
+  WZ_GITHUB_HEAD_REF="" # since it should be a tag, these should always be empty
+  WZ_GITHUB_BASE_REF=""
+  # Switch to the desired tag ref
+  echo "Checking out ref: ${WZ_GITHUB_REF}"
+  git checkout "${WZ_GITHUB_REF}"
+else
+  # Normal case: just use the GITHUB_ variables, and do not override the current checkout
+  WZ_GITHUB_SHA="${GITHUB_SHA}"
+  WZ_GITHUB_REF="${GITHUB_REF}"
+  WZ_GITHUB_HEAD_REF="${GITHUB_HEAD_REF}"
+  WZ_GITHUB_BASE_REF="${GITHUB_BASE_REF}"
+fi
+echo "WZ_GITHUB_SHA=${WZ_GITHUB_SHA}"
+echo "WZ_GITHUB_REF=${WZ_GITHUB_REF}"
+echo "WZ_GITHUB_HEAD_REF=${WZ_GITHUB_HEAD_REF}"
+echo "WZ_GITHUB_BASE_REF=${WZ_GITHUB_BASE_REF}"
+echo "::set-output name=WZ_GITHUB_SHA::${WZ_GITHUB_SHA}"
+echo "::set-output name=WZ_GITHUB_REF::${WZ_GITHUB_REF}"
+echo "::set-output name=WZ_GITHUB_HEAD_REF::${WZ_GITHUB_HEAD_REF}"
+echo "::set-output name=WZ_GITHUB_BASE_REF::${WZ_GITHUB_BASE_REF}"
+echo "WZ_GITHUB_SHA=${WZ_GITHUB_SHA}" >> $GITHUB_ENV
+echo "WZ_GITHUB_REF=${WZ_GITHUB_REF}" >> $GITHUB_ENV
+echo "WZ_GITHUB_HEAD_REF=${WZ_GITHUB_HEAD_REF}" >> $GITHUB_ENV
+echo "WZ_GITHUB_BASE_REF=${WZ_GITHUB_BASE_REF}" >> $GITHUB_ENV

--- a/.ci/githubactions/export_build_output_desc.sh
+++ b/.ci/githubactions/export_build_output_desc.sh
@@ -14,14 +14,17 @@
 # License: MIT License ( https://opensource.org/licenses/MIT )
 #
 
-if [ -z "${GITHUB_REF}" ]; then
+if [ -z "${WZ_GITHUB_REF}" ] && [ -z "${GITHUB_REF}" ]; then
 	echo "Missing expected GITHUB_REF environment variable"
 	exit 1
+fi
+if [ -z "${WZ_GITHUB_REF}" ]; then
+  WZ_GITHUB_REF="${GITHUB_REF}"
 fi
 
 # Extract branch / tag from GITHUB_REF
 # (examples: GITHUB_REF=refs/heads/master, GITHUB_REF=refs/tags/v3.3.0, GITHUB_REF=refs/pull/3/merge (for a pull_request event))
-ref_tmp=${GITHUB_REF#*/} ## throw away the first part of the ref
+ref_tmp=${WZ_GITHUB_REF#*/} ## throw away the first part of the ref
 ref_type=${ref_tmp%%/*} ## extract the second element of the ref (heads or tags)
 ref_value=${ref_tmp#*/} ## extract the third+ elements of the ref (master or v3.3.0)
 
@@ -32,7 +35,10 @@ if [ "$ref_type" == "tags" ]; then
 else
 	GIT_BRANCH="${ref_value}"
 
-	if [ -n "${GITHUB_HEAD_REF}" ]; then
+	if [ -n "${WZ_GITHUB_HEAD_REF}" ]; then
+		# Use the head ref's branch name
+		GIT_BRANCH="${WZ_GITHUB_HEAD_REF}"
+	elif [ -n "${GITHUB_HEAD_REF}" ]; then
 		# Use the head ref's branch name
 		GIT_BRANCH="${GITHUB_HEAD_REF}"
 	fi

--- a/.github/workflows/CI_alpine.yml
+++ b/.github/workflows/CI_alpine.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - name: ":LATEST (CMake) [GCC]"
+          - name: "Alpine :LATEST [GCC]"
             compiler: 'gcc'
             cc: '/usr/bin/gcc'
             cxx: '/usr/bin/g++'

--- a/.github/workflows/CI_alpine.yml
+++ b/.github/workflows/CI_alpine.yml
@@ -4,9 +4,6 @@ on:
   push:
     branches-ignore:
       - 'l10n_**' # Push events to translation service branches (that begin with "l10n_")
-    # Sequence of patterns matched against refs/tags
-    tags:
-      - '*'
   pull_request:
     # Match all pull requests
 

--- a/.github/workflows/CI_archlinux.yml
+++ b/.github/workflows/CI_archlinux.yml
@@ -15,11 +15,11 @@ jobs:
     strategy:
       matrix:
         include:
-          - name: ":LATEST (CMake) [GCC]"
+          - name: "Arch :LATEST [GCC]"
             compiler: 'gcc'
             cc: '/usr/bin/gcc'
             cxx: '/usr/bin/g++'
-          - name: ":LATEST (CMake) [Clang]"
+          - name: "Arch :LATEST [Clang]"
             compiler: 'clang'
             cc: '/usr/bin/clang'
             cxx: '/usr/bin/clang++'

--- a/.github/workflows/CI_archlinux.yml
+++ b/.github/workflows/CI_archlinux.yml
@@ -4,9 +4,6 @@ on:
   push:
     branches-ignore:
       - 'l10n_**' # Push events to translation service branches (that begin with "l10n_")
-    # Sequence of patterns matched against refs/tags
-    tags:
-      - '*'
   pull_request:
     # Match all pull requests
 

--- a/.github/workflows/CI_fedora.yml
+++ b/.github/workflows/CI_fedora.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   fedora-latest-gcc:
-    name: :LATEST (CMake) [GCC]
+    name: Fedora :LATEST [GCC]
     runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, '[ci skip]')"
     steps:
@@ -47,7 +47,7 @@ jobs:
         echo "::remove-matcher owner=gcc::"
 
   fedora-latest-gcc-m32:
-    name: :LATEST (CMake) [GCC -m32]
+    name: Fedora :LATEST [GCC -m32]
     runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, '[ci skip]')"
     steps:

--- a/.github/workflows/CI_fedora.yml
+++ b/.github/workflows/CI_fedora.yml
@@ -4,9 +4,6 @@ on:
   push:
     branches-ignore:
       - 'l10n_**' # Push events to translation service branches (that begin with "l10n_")
-    # Sequence of patterns matched against refs/tags
-    tags:
-      - '*'
   pull_request:
     # Match all pull requests
 

--- a/.github/workflows/CI_macos.yml
+++ b/.github/workflows/CI_macos.yml
@@ -4,11 +4,16 @@ on:
   push:
     branches-ignore:
       - 'l10n_**' # Push events to translation service branches (that begin with "l10n_")
-    # Sequence of patterns matched against refs/tags
-    tags:
-      - '*'
   pull_request:
     # Match all pull requests
+  # Support running after "Draft Tag Release" workflow completes, as part of automated release process
+  workflow_run:
+    workflows: ["Draft Tag Release"]
+    push:
+      tags:
+        - '*'
+    types: 
+      - completed
 
 jobs:
   macos-build:
@@ -56,6 +61,14 @@ jobs:
       with:
         fetch-depth: 0
         path: 'src'
+    - name: Configure Repo Checkout
+      id: checkout-config
+      working-directory: ./src
+      env:
+        WORKFLOW_RUN_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
+        WORKFLOW_RUN_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+      run: |
+        . .ci/githubactions/checkout_config.sh
     - name: Prepare Git Repo for autorevision
       working-directory: ./src
       run: cmake -P .ci/githubactions/prepare_git_repo.cmake
@@ -173,7 +186,16 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
+          fetch-depth: 0
           path: 'src'
+      - name: Configure Repo Checkout
+        id: checkout-config
+        working-directory: ./src
+        env:
+          WORKFLOW_RUN_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
+          WORKFLOW_RUN_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          . .ci/githubactions/checkout_config.sh
       - name: Prep Environment
         run: |
           mkdir dl-artifacts
@@ -243,8 +265,18 @@ jobs:
       - uses: actions/upload-artifact@v2
         with:
           name: "warzone2100_macOS_universal"
-          path: ${{ env.OUTPUT_DIR }}
+          path: ${{ env.WZ_FULL_OUTPUT_ZIP_PATH }}
           if-no-files-found: 'error'
+      - name: Upload "universal" to release
+        if: success() && (github.event_name == 'workflow_run' && github.event.workflow_run.name == 'Draft Tag Release') && (github.repository == 'Warzone2100/warzone2100')
+        run: |
+          SOURCE_TAG="${WZ_GITHUB_REF#refs/tags/}"
+          echo "Uploading: ${WZ_FULL_OUTPUT_ZIP_PATH}"
+          gh release upload "${SOURCE_TAG}" "${WZ_FULL_OUTPUT_ZIP_PATH}"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          WZ_GITHUB_REF: ${{ steps.checkout-config.outputs.WZ_GITHUB_REF }}
       - name: Clear OUTPUT_DIR
         run: |
           echo "OUTPUT_DIR=${OUTPUT_DIR}"
@@ -284,39 +316,22 @@ jobs:
           ZIP_SIZE="$(stat -f '%z' "${OUTPUT_DIR}/${DESIRED_ZIP_NAME}")"
           echo "  -> SHA512: ${ZIP_HASH}"
           echo "  -> Size (bytes): ${ZIP_SIZE}"
+          
+          echo "WZ_FULL_OUTPUT_ZIP_PATH=${OUTPUT_DIR}/${DESIRED_ZIP_NAME}" >> $GITHUB_ENV
 
           exit 0
       - uses: actions/upload-artifact@v2
         with:
           name: "warzone2100_macOS_universal_novideos"
-          path: ${{ env.OUTPUT_DIR }}
+          path: ${{ env.WZ_FULL_OUTPUT_ZIP_PATH }}
           if-no-files-found: 'error'
-
-  upload_release_artifacts:
-    if: startsWith(github.ref, 'refs/tags/') && (github.repository == 'Warzone2100/warzone2100')
-    name: Upload Release Artifacts
-    needs: macos_universal_combine
-    runs-on: ubuntu-latest
-    steps:
-      - name: Download macOS universal artifact
-        uses: actions/download-artifact@v2
-        with:
-          name: warzone2100_macOS_universal
-          path: warzone2100_macOS_universal
-      - name: Download macOS universal (no videos) artifact
-        uses: actions/download-artifact@v2
-        with:
-          name: warzone2100_macOS_universal_novideos
-          path: warzone2100_macOS_universal_novideos
-      - name: Rename artifact zips
-        run: |
-          mv "./warzone2100_macOS_universal/warzone2100_macOS_universal.zip" "./warzone2100_macOS.zip"
-          mv "./warzone2100_macOS_universal_novideos/warzone2100_macOS_universal_novideos.zip" "./warzone2100_macOS_novideos.zip"
-      - name: Upload to release
+      - name: Upload "universal_novideos" to release
+        if: success() && (github.event_name == 'workflow_run' && github.event.workflow_run.name == 'Draft Tag Release') && (github.repository == 'Warzone2100/warzone2100')
         run: |
           SOURCE_TAG="${WZ_GITHUB_REF#refs/tags/}"
-          gh release upload "${SOURCE_TAG}" "./warzone2100_macOS.zip" "./warzone2100_macOS_novideos.zip"
+          echo "Uploading: ${WZ_FULL_OUTPUT_ZIP_PATH}"
+          gh release upload "${SOURCE_TAG}" "${WZ_FULL_OUTPUT_ZIP_PATH}"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
-          WZ_GITHUB_REF: ${{ github.ref }}
+          WZ_GITHUB_REF: ${{ steps.checkout-config.outputs.WZ_GITHUB_REF }}

--- a/.github/workflows/CI_macos.yml
+++ b/.github/workflows/CI_macos.yml
@@ -313,12 +313,10 @@ jobs:
           mv "./warzone2100_macOS_universal/warzone2100_macOS_universal.zip" "./warzone2100_macOS.zip"
           mv "./warzone2100_macOS_universal_novideos/warzone2100_macOS_universal_novideos.zip" "./warzone2100_macOS_novideos.zip"
       - name: Upload to release
-        uses: past-due/action-gh-release@master
-        with:
-          # Do not explicitly specify a tag_name, so this action takes the github.ref and parses it for just the tag
-          files: |
-            ./warzone2100_macOS.zip
-            ./warzone2100_macOS_novideos.zip
-          draft: true
+        run: |
+          SOURCE_TAG="${WZ_GITHUB_REF#refs/tags/}"
+          gh release upload "${SOURCE_TAG}" "./warzone2100_macOS.zip" "./warzone2100_macOS_novideos.zip"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          WZ_GITHUB_REF: ${{ github.ref }}

--- a/.github/workflows/CI_snapcraft.yml
+++ b/.github/workflows/CI_snapcraft.yml
@@ -4,11 +4,16 @@ on:
   push:
     branches-ignore:
       - 'l10n_**' # Push events to translation service branches (that begin with "l10n_")
-    # Sequence of patterns matched against refs/tags
-    tags:
-      - '*'
   pull_request:
     # Match all pull requests
+  # Support running after "Draft Tag Release" workflow completes, as part of automated release process
+  workflow_run:
+    workflows: ["Draft Tag Release"]
+    push:
+      tags:
+        - '*'
+    types: 
+      - completed
 
 jobs:
   snapcraft:
@@ -24,6 +29,13 @@ jobs:
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0
+    - name: Configure Repo Checkout
+      id: checkout-config
+      env:
+        WORKFLOW_RUN_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
+        WORKFLOW_RUN_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+      run: |
+        . .ci/githubactions/checkout_config.sh
     - name: Prepare Git Repo for autorevision
       run: cmake -P .ci/githubactions/prepare_git_repo.cmake
     - name: Init Git Submodules
@@ -66,10 +78,10 @@ jobs:
         GITHUB_ACTIONS="$GITHUB_ACTIONS"
         GITHUB_REPOSITORY="$GITHUB_REPOSITORY"
         GITHUB_WORKSPACE="$GITHUB_WORKSPACE"
-        GITHUB_SHA="$GITHUB_SHA"
-        GITHUB_REF="$GITHUB_REF"
-        GITHUB_HEAD_REF="$GITHUB_HEAD_REF"
-        GITHUB_BASE_REF="$GITHUB_BASE_REF"
+        GITHUB_SHA="$WZ_GITHUB_SHA"
+        GITHUB_REF="$WZ_GITHUB_REF"
+        GITHUB_HEAD_REF="$WZ_GITHUB_HEAD_REF"
+        GITHUB_BASE_REF="$WZ_GITHUB_BASE_REF"
         MAKEFLAGS="$MAKEFLAGS"
         SNAP_VERSION_SAFE_DESC_PREFIX="$SNAP_VERSION_SAFE_DESC_PREFIX"
         WZ_SHORT_SHA="$WZ_SHORT_SHA"
@@ -98,11 +110,11 @@ jobs:
         path: '${{ env.WZ_FULL_OUTPUT_SNAP_PATH }}'
         if-no-files-found: 'error'
     - name: Upload artifact to release
-      if: success() && startsWith(github.ref, 'refs/tags/')
+      if: success() && (github.event_name == 'workflow_run' && github.event.workflow_run.name == 'Draft Tag Release')
       run: |
         SOURCE_TAG="${WZ_GITHUB_REF#refs/tags/}"
         gh release upload "${SOURCE_TAG}" "${{ env.WZ_FULL_OUTPUT_SNAP_PATH }}"
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         GH_REPO: ${{ github.repository }}
-        WZ_GITHUB_REF: ${{ github.ref }}
+        WZ_GITHUB_REF: ${{ steps.checkout-config.outputs.WZ_GITHUB_REF }}

--- a/.github/workflows/CI_snapcraft.yml
+++ b/.github/workflows/CI_snapcraft.yml
@@ -99,10 +99,10 @@ jobs:
         if-no-files-found: 'error'
     - name: Upload artifact to release
       if: success() && startsWith(github.ref, 'refs/tags/')
-      uses: past-due/action-gh-release@master
-      with:
-        # Do not explicitly specify a tag_name, so this action takes the github.ref and parses it for just the tag
-        files: ${{ env.WZ_FULL_OUTPUT_SNAP_PATH }}
-        draft: true
+      run: |
+        SOURCE_TAG="${WZ_GITHUB_REF#refs/tags/}"
+        gh release upload "${SOURCE_TAG}" "${{ env.WZ_FULL_OUTPUT_SNAP_PATH }}"
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GH_REPO: ${{ github.repository }}
+        WZ_GITHUB_REF: ${{ github.ref }}

--- a/.github/workflows/CI_ubuntu.yml
+++ b/.github/workflows/CI_ubuntu.yml
@@ -16,14 +16,14 @@ jobs:
       matrix:
         include:
           # Builds with GCC (uploaded as artifacts, and published as release DEBs)
-          - name: "Ubuntu 18.04 (CMake) [GCC]"
+          - name: "Ubuntu 18.04 [GCC]"
             docker: "ubuntu-18.04"
             arch: "amd64"
             output-suffix: "ubuntu18.04"
             compiler: gcc
             publish_artifact: true
             deploy_release: true
-          - name: "Ubuntu 20.04 (CMake) [GCC]"
+          - name: "Ubuntu 20.04 [GCC]"
             docker: "ubuntu-20.04"
             arch: "amd64"
             compiler: gcc
@@ -31,7 +31,7 @@ jobs:
             publish_artifact: true
             deploy_release: true
           # Older builds with GCC (not uploaded)
-          - name: "Ubuntu 16.04 (CMake) [GCC]"
+          - name: "Ubuntu 16.04 [GCC]"
             docker: "ubuntu-16.04"
             arch: "amd64"
             output-suffix: "ubuntu16.04"
@@ -39,14 +39,14 @@ jobs:
             publish_artifact: false
             deploy_release: false
           # Builds with Clang (not uploaded)
-          - name: "Ubuntu 18.04 (CMake) [Clang]"
+          - name: "Ubuntu 18.04 [Clang]"
             docker: "ubuntu-18.04"
             arch: "amd64"
             output-suffix: "ubuntu18.04"
             compiler: clang
             publish_artifact: false
             deploy_release: false
-          - name: "Ubuntu 20.04 (CMake) [Clang]"
+          - name: "Ubuntu 20.04 [Clang]"
             docker: "ubuntu-20.04"
             arch: "amd64"
             compiler: clang
@@ -161,7 +161,7 @@ jobs:
         WZ_GITHUB_REF: ${{ github.ref }}
 
   package-source:
-    name: Package Source (Ubuntu 18.04, CMake) [GCC]
+    name: Package Source (Ubuntu 18.04) [GCC]
     runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, '[ci skip]')"
     steps:

--- a/.github/workflows/CI_ubuntu.yml
+++ b/.github/workflows/CI_ubuntu.yml
@@ -11,57 +11,48 @@ on:
     # Match all pull requests
 
 jobs:
-  ubuntu-16-04-gcc:
-    name: Ubuntu 16.04 (CMake) [GCC]
-    runs-on: ubuntu-latest
-    if: "!contains(github.event.head_commit.message, '[ci skip]')"
-    steps:
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
-        path: 'src'
-    - name: Prepare Git Repo for autorevision
-      working-directory: '${{ github.workspace }}/src'
-      run: cmake -P .ci/githubactions/prepare_git_repo.cmake
-    - name: Init Git Submodules
-      working-directory: '${{ github.workspace }}/src'
-      run: git submodule update --init --recursive
-    - name: Debug Output
-      run: |
-        echo "GITHUB_REF=${GITHUB_REF}"
-        echo "GITHUB_HEAD_REF=${GITHUB_HEAD_REF}"
-    - name: Build the Docker image
-      working-directory: '${{ github.workspace }}/src'
-      run: |
-        docker build -f docker/ubuntu-16.04/Dockerfile -t ubuntu .
-    - name: Prep Directories
-      run: |
-        mkdir -p "${{ github.workspace }}/build"
-    - name: CMake Configure
-      working-directory: '${{ github.workspace }}/build'
-      run: |
-        echo "::add-matcher::${GITHUB_WORKSPACE}/src/.ci/githubactions/pattern_matchers/cmake.json"
-        docker run --rm -w "${GITHUB_WORKSPACE}/build" -e "CI=true" -e GITHUB_WORKFLOW -e GITHUB_ACTIONS -e GITHUB_REPOSITORY -e GITHUB_WORKSPACE -e GITHUB_SHA -e GITHUB_REF -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e MAKEFLAGS -v "${GITHUB_WORKSPACE}:${GITHUB_WORKSPACE}" ubuntu cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DWZ_ENABLE_WARNINGS:BOOL=ON -G"Ninja" "${{ github.workspace }}/src"
-        echo "::remove-matcher owner=cmake::"
-    - name: CMake Build
-      working-directory: '${{ github.workspace }}/build'
-      run: |
-        echo "::add-matcher::${GITHUB_WORKSPACE}/src/.ci/githubactions/pattern_matchers/gcc.json"
-        docker run --rm -w "${GITHUB_WORKSPACE}/build" -e "CI=true" -e GITHUB_WORKFLOW -e GITHUB_ACTIONS -e GITHUB_REPOSITORY -e GITHUB_WORKSPACE -e GITHUB_SHA -e GITHUB_REF -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e MAKEFLAGS -v "${GITHUB_WORKSPACE}:${GITHUB_WORKSPACE}" ubuntu cmake --build .
-        echo "::remove-matcher owner=gcc::"
-
-  ubuntu-gcc-build-and-package:
+  ubuntu-build:
     strategy:
       matrix:
         include:
+          # Builds with GCC (uploaded as artifacts, and published as release DEBs)
           - name: "Ubuntu 18.04 (CMake) [GCC]"
             docker: "ubuntu-18.04"
             arch: "amd64"
             output-suffix: "ubuntu18.04"
+            compiler: gcc
+            publish_artifact: true
+            deploy_release: true
           - name: "Ubuntu 20.04 (CMake) [GCC]"
             docker: "ubuntu-20.04"
             arch: "amd64"
+            compiler: gcc
             output-suffix: "ubuntu20.04"
+            publish_artifact: true
+            deploy_release: true
+          # Older builds with GCC (not uploaded)
+          - name: "Ubuntu 16.04 (CMake) [GCC]"
+            docker: "ubuntu-16.04"
+            arch: "amd64"
+            output-suffix: "ubuntu16.04"
+            compiler: gcc
+            publish_artifact: false
+            deploy_release: false
+          # Builds with Clang (not uploaded)
+          - name: "Ubuntu 18.04 (CMake) [Clang]"
+            docker: "ubuntu-18.04"
+            arch: "amd64"
+            output-suffix: "ubuntu18.04"
+            compiler: clang
+            publish_artifact: false
+            deploy_release: false
+          - name: "Ubuntu 20.04 (CMake) [Clang]"
+            docker: "ubuntu-20.04"
+            arch: "amd64"
+            compiler: clang
+            output-suffix: "ubuntu20.04"
+            publish_artifact: false
+            deploy_release: false
       fail-fast: false
     name: '${{ matrix.name }}'
     runs-on: ubuntu-latest
@@ -103,6 +94,20 @@ jobs:
         fi
         echo "WZ_DISTRIBUTOR=${WZ_DISTRIBUTOR}"
         echo "WZ_DISTRIBUTOR=${WZ_DISTRIBUTOR}" >> $GITHUB_ENV
+        
+        if [ "${{ matrix.compiler }}" == "gcc" ]; then
+          WZ_CC="/usr/bin/gcc"
+          WZ_CXX="/usr/bin/g++"
+        elif [ "${{ matrix.compiler }}" == "clang" ]; then
+          WZ_CC="/usr/bin/clang"
+          WZ_CXX="/usr/bin/clang++"
+        else
+          echo "Unknown / invalid matrix.compiler: \"${{ matrix.compiler }}\""
+        fi
+        echo "WZ_CC=${WZ_CC}"
+        echo "WZ_CC=${WZ_CC}" >> $GITHUB_ENV
+        echo "WZ_CXX=${WZ_CXX}"
+        echo "WZ_CXX=${WZ_CXX}" >> $GITHUB_ENV
     - name: Prep Directories
       run: |
         mkdir -p "${{ github.workspace }}/build"
@@ -110,14 +115,14 @@ jobs:
       working-directory: '${{ github.workspace }}/build'
       run: |
         echo "::add-matcher::${GITHUB_WORKSPACE}/src/.ci/githubactions/pattern_matchers/cmake.json"
-        docker run --rm -w "${GITHUB_WORKSPACE}/build" -e "CI=true" -e GITHUB_WORKFLOW -e GITHUB_ACTIONS -e GITHUB_REPOSITORY -e GITHUB_WORKSPACE -e GITHUB_SHA -e GITHUB_REF -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e MAKEFLAGS -v "${GITHUB_WORKSPACE}:${GITHUB_WORKSPACE}" ubuntu cmake -DCMAKE_BUILD_TYPE=Release -DWZ_ENABLE_WARNINGS:BOOL=ON -DWZ_DISTRIBUTOR:STRING="${WZ_DISTRIBUTOR}" -DWZ_OUTPUT_NAME_SUFFIX="${WZ_OUTPUT_NAME_SUFFIX}" -DWZ_NAME_SUFFIX="${WZ_NAME_SUFFIX}" -G"Ninja" "${{ github.workspace }}/src"
+        docker run --rm -w "${GITHUB_WORKSPACE}/build" -e "CC=${WZ_CC}" -e "CXX=${WZ_CXX}" -e "CI=true" -e GITHUB_WORKFLOW -e GITHUB_ACTIONS -e GITHUB_REPOSITORY -e GITHUB_WORKSPACE -e GITHUB_SHA -e GITHUB_REF -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e MAKEFLAGS -v "${GITHUB_WORKSPACE}:${GITHUB_WORKSPACE}" ubuntu cmake -DCMAKE_BUILD_TYPE=Release -DWZ_ENABLE_WARNINGS:BOOL=ON -DWZ_DISTRIBUTOR:STRING="${WZ_DISTRIBUTOR}" -DWZ_OUTPUT_NAME_SUFFIX="${WZ_OUTPUT_NAME_SUFFIX}" -DWZ_NAME_SUFFIX="${WZ_NAME_SUFFIX}" -G"Ninja" "${{ github.workspace }}/src"
         echo "::remove-matcher owner=cmake::"
     - name: CMake Build
       working-directory: '${{ github.workspace }}/build'
       run: |
-        echo "::add-matcher::${GITHUB_WORKSPACE}/src/.ci/githubactions/pattern_matchers/gcc.json"
-        docker run --rm -w "${GITHUB_WORKSPACE}/build" -e "CI=true" -e GITHUB_WORKFLOW -e GITHUB_ACTIONS -e GITHUB_REPOSITORY -e GITHUB_WORKSPACE -e GITHUB_SHA -e GITHUB_REF -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e MAKEFLAGS -v "${GITHUB_WORKSPACE}:${GITHUB_WORKSPACE}" ubuntu cmake --build .
-        echo "::remove-matcher owner=gcc::"
+        echo "::add-matcher::${GITHUB_WORKSPACE}/src/.ci/githubactions/pattern_matchers/${{ matrix.compiler }}.json"
+        docker run --rm -w "${GITHUB_WORKSPACE}/build" -e "CC=${WZ_CC}" -e "CXX=${WZ_CXX}" -e "CI=true" -e GITHUB_WORKFLOW -e GITHUB_ACTIONS -e GITHUB_REPOSITORY -e GITHUB_WORKSPACE -e GITHUB_SHA -e GITHUB_REF -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e MAKEFLAGS -v "${GITHUB_WORKSPACE}:${GITHUB_WORKSPACE}" ubuntu cmake --build .
+        echo "::remove-matcher owner=${{ matrix.compiler }}::"
     - name: Package .DEB
       working-directory: '${{ github.workspace }}/build'
       run: |
@@ -140,13 +145,13 @@ jobs:
         echo "  -> Size (bytes): $(stat -c %s "${OUTPUT_DIR}/${OUTPUT_FILE_NAME}")"
         echo "WZ_FULL_OUTPUT_DEB_PATH=${OUTPUT_DIR}/${OUTPUT_FILE_NAME}" >> $GITHUB_ENV
     - uses: actions/upload-artifact@v2
-      if: success()
+      if: success() && (matrix.publish_artifact == true)
       with:
         name: "warzone2100_${{ matrix.output-suffix }}_${{ matrix.arch }}_deb"
         path: ${{ env.OUTPUT_DIR }}
         if-no-files-found: 'error'
     - name: Upload artifact to release
-      if: success() && startsWith(github.ref, 'refs/tags/')
+      if: success() && startsWith(github.ref, 'refs/tags/') && (matrix.deploy_release == true)
       run: |
         SOURCE_TAG="${WZ_GITHUB_REF#refs/tags/}"
         gh release upload "${SOURCE_TAG}" "${{ env.WZ_FULL_OUTPUT_DEB_PATH }}"
@@ -160,6 +165,10 @@ jobs:
     runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, '[ci skip]')"
     steps:
+    - name: Debug Output
+      run: |
+        echo "GITHUB_REF=${GITHUB_REF}"
+        echo "GITHUB_HEAD_REF=${GITHUB_HEAD_REF}"
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0
@@ -215,96 +224,6 @@ jobs:
         name: warzone2100_src
         path: ${{ env.OUTPUT_DIR }}
         if-no-files-found: 'error'
-
-  ubuntu-18-04-clang:
-    name: Ubuntu 18.04 (CMake) [Clang]
-    runs-on: ubuntu-latest
-    if: "!contains(github.event.head_commit.message, '[ci skip]')"
-    steps:
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
-        path: 'src'
-    - name: Prepare Git Repo for autorevision
-      working-directory: '${{ github.workspace }}/src'
-      run: cmake -P .ci/githubactions/prepare_git_repo.cmake
-    - name: Init Git Submodules
-      working-directory: '${{ github.workspace }}/src'
-      run: git submodule update --init --recursive
-    - name: Build the Docker image
-      working-directory: '${{ github.workspace }}/src'
-      run: |
-        docker build -f docker/ubuntu-18.04/Dockerfile -t ubuntu .
-    - name: Prep Directories
-      run: |
-        mkdir -p "${{ github.workspace }}/build"
-    - name: CMake Configure
-      working-directory: '${{ github.workspace }}/build'
-      run: |
-        echo "::add-matcher::${GITHUB_WORKSPACE}/src/.ci/githubactions/pattern_matchers/cmake.json"
-        docker run --rm -w "${GITHUB_WORKSPACE}/build" -e "CC=/usr/bin/clang" -e "CXX=/usr/bin/clang++" -e "CI=true" -e GITHUB_WORKFLOW -e GITHUB_ACTIONS -e GITHUB_REPOSITORY -e GITHUB_WORKSPACE -e GITHUB_SHA -e GITHUB_REF -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e MAKEFLAGS -v "${GITHUB_WORKSPACE}:${GITHUB_WORKSPACE}" ubuntu cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DWZ_ENABLE_WARNINGS:BOOL=ON -G"Ninja" "${{ github.workspace }}/src"
-        echo "::remove-matcher owner=cmake::"
-    - name: CMake Build
-      working-directory: '${{ github.workspace }}/build'
-      run: |
-        echo "::add-matcher::${GITHUB_WORKSPACE}/src/.ci/githubactions/pattern_matchers/clang.json"
-        docker run --rm -w "${GITHUB_WORKSPACE}/build" -e "CC=/usr/bin/clang" -e "CXX=/usr/bin/clang++" -e "CI=true" -e GITHUB_WORKFLOW -e GITHUB_ACTIONS -e GITHUB_REPOSITORY -e GITHUB_WORKSPACE -e GITHUB_SHA -e GITHUB_REF -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e MAKEFLAGS -v "${GITHUB_WORKSPACE}:${GITHUB_WORKSPACE}" ubuntu cmake --build .
-        echo "::remove-matcher owner=clang::"
-
-  # ubuntu-20-04-gcc:
-  #   name: Ubuntu 20.04 (CMake) [GCC]
-  #   runs-on: ubuntu-latest
-  #   if: "!contains(github.event.head_commit.message, '[ci skip]')"
-  #   steps:
-  #   - uses: actions/checkout@v2
-  #     with:
-  #       fetch-depth: 0
-  #   - name: Prepare Git Repo for autorevision
-  #     run: cmake -P .ci/githubactions/prepare_git_repo.cmake
-  #   - name: Init Git Submodules
-  #     run: git submodule update --init --recursive
-  #   - name: Build the Docker image
-  #     run: |
-  #       docker build -f docker/ubuntu-20.04/Dockerfile -t ubuntu .
-  #   - name: CMake Configure
-  #     run: docker run --rm -e "CI=true" -e GITHUB_WORKFLOW -e GITHUB_ACTIONS -e GITHUB_REPOSITORY -e "GITHUB_WORKSPACE=/code" -e GITHUB_SHA -e GITHUB_REF -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e MAKEFLAGS -v $(pwd):/code ubuntu cmake '-H.' -Bbuild -DCMAKE_BUILD_TYPE=RelWithDebInfo -DWZ_ENABLE_WARNINGS:BOOL=ON -G"Ninja"
-  #   - name: CMake Build
-  #     run: docker run --rm -e "CI=true" -e GITHUB_WORKFLOW -e GITHUB_ACTIONS -e GITHUB_REPOSITORY -e "GITHUB_WORKSPACE=/code" -e GITHUB_SHA -e GITHUB_REF -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e MAKEFLAGS -v $(pwd):/code ubuntu cmake --build build
-
-  ubuntu-20-04-clang:
-    name: Ubuntu 20.04 (CMake) [Clang]
-    runs-on: ubuntu-latest
-    if: "!contains(github.event.head_commit.message, '[ci skip]')"
-    steps:
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
-        path: 'src'
-    - name: Prepare Git Repo for autorevision
-      working-directory: '${{ github.workspace }}/src'
-      run: cmake -P .ci/githubactions/prepare_git_repo.cmake
-    - name: Init Git Submodules
-      working-directory: '${{ github.workspace }}/src'
-      run: git submodule update --init --recursive
-    - name: Build the Docker image
-      working-directory: '${{ github.workspace }}/src'
-      run: |
-        docker build -f docker/ubuntu-20.04/Dockerfile -t ubuntu .
-    - name: Prep Directories
-      run: |
-        mkdir -p "${{ github.workspace }}/build"
-    - name: CMake Configure
-      working-directory: '${{ github.workspace }}/build'
-      run: |
-        echo "::add-matcher::${GITHUB_WORKSPACE}/src/.ci/githubactions/pattern_matchers/cmake.json"
-        docker run --rm -w "${GITHUB_WORKSPACE}/build" -e "CC=/usr/bin/clang" -e "CXX=/usr/bin/clang++" -e "CI=true" -e GITHUB_WORKFLOW -e GITHUB_ACTIONS -e GITHUB_REPOSITORY -e GITHUB_WORKSPACE -e GITHUB_SHA -e GITHUB_REF -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e MAKEFLAGS -v "${GITHUB_WORKSPACE}:${GITHUB_WORKSPACE}" ubuntu cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DWZ_ENABLE_WARNINGS:BOOL=ON -G"Ninja" "${{ github.workspace }}/src"
-        echo "::remove-matcher owner=cmake::"
-    - name: CMake Build
-      working-directory: '${{ github.workspace }}/build'
-      run: |
-        echo "::add-matcher::${GITHUB_WORKSPACE}/src/.ci/githubactions/pattern_matchers/clang.json"
-        docker run --rm -w "${GITHUB_WORKSPACE}/build" -e "CC=/usr/bin/clang" -e "CXX=/usr/bin/clang++" -e "CI=true" -e GITHUB_WORKFLOW -e GITHUB_ACTIONS -e GITHUB_REPOSITORY -e GITHUB_WORKSPACE -e GITHUB_SHA -e GITHUB_REF -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e MAKEFLAGS -v "${GITHUB_WORKSPACE}:${GITHUB_WORKSPACE}" ubuntu cmake --build .
-        echo "::remove-matcher owner=clang::"
 
   # # NOTE: This uses qemu, and is much slower than a native ARM64 build
   # ubuntu-20-04-gcc-arm64:

--- a/.github/workflows/CI_ubuntu.yml
+++ b/.github/workflows/CI_ubuntu.yml
@@ -147,13 +147,13 @@ jobs:
         if-no-files-found: 'error'
     - name: Upload artifact to release
       if: success() && startsWith(github.ref, 'refs/tags/')
-      uses: past-due/action-gh-release@master
-      with:
-        # Do not explicitly specify a tag_name, so this action takes the github.ref and parses it for just the tag
-        files: ${{ env.WZ_FULL_OUTPUT_DEB_PATH }}
-        draft: true
+      run: |
+        SOURCE_TAG="${WZ_GITHUB_REF#refs/tags/}"
+        gh release upload "${SOURCE_TAG}" "${{ env.WZ_FULL_OUTPUT_DEB_PATH }}"
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GH_REPO: ${{ github.repository }}
+        WZ_GITHUB_REF: ${{ github.ref }}
 
   package-source:
     name: Package Source (Ubuntu 18.04, CMake) [GCC]
@@ -343,10 +343,10 @@ jobs:
           name: warzone2100_src
           path: warzone2100_src
       - name: Upload source tarball to release
-        uses: past-due/action-gh-release@master
-        with:
-          # Do not explicitly specify a tag_name, so this action takes the github.ref and parses it for just the tag
-          files: ./warzone2100_src/warzone2100_src.tar.xz
-          draft: true
+        run: |
+          SOURCE_TAG="${WZ_GITHUB_REF#refs/tags/}"
+          gh release upload "${SOURCE_TAG}" "./warzone2100_src/warzone2100_src.tar.xz"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          WZ_GITHUB_REF: ${{ github.ref }}

--- a/.github/workflows/CI_ubuntu.yml
+++ b/.github/workflows/CI_ubuntu.yml
@@ -4,11 +4,16 @@ on:
   push:
     branches-ignore:
       - 'l10n_**' # Push events to translation service branches (that begin with "l10n_")
-    # Sequence of patterns matched against refs/tags
-    tags:
-      - '*'
   pull_request:
     # Match all pull requests
+  # Support running after "Draft Tag Release" workflow completes, as part of automated release process
+  workflow_run:
+    workflows: ["Draft Tag Release"]
+    push:
+      tags:
+        - '*'
+    types: 
+      - completed
 
 jobs:
   ubuntu-build:
@@ -62,6 +67,14 @@ jobs:
       with:
         fetch-depth: 0
         path: 'src'
+    - name: Configure Repo Checkout
+      id: checkout-config
+      working-directory: ./src
+      env:
+        WORKFLOW_RUN_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
+        WORKFLOW_RUN_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+      run: |
+        . .ci/githubactions/checkout_config.sh
     - name: Prepare Git Repo for autorevision
       working-directory: '${{ github.workspace }}/src'
       run: cmake -P .ci/githubactions/prepare_git_repo.cmake
@@ -115,13 +128,13 @@ jobs:
       working-directory: '${{ github.workspace }}/build'
       run: |
         echo "::add-matcher::${GITHUB_WORKSPACE}/src/.ci/githubactions/pattern_matchers/cmake.json"
-        docker run --rm -w "${GITHUB_WORKSPACE}/build" -e "CC=${WZ_CC}" -e "CXX=${WZ_CXX}" -e "CI=true" -e GITHUB_WORKFLOW -e GITHUB_ACTIONS -e GITHUB_REPOSITORY -e GITHUB_WORKSPACE -e GITHUB_SHA -e GITHUB_REF -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e MAKEFLAGS -v "${GITHUB_WORKSPACE}:${GITHUB_WORKSPACE}" ubuntu cmake -DCMAKE_BUILD_TYPE=Release -DWZ_ENABLE_WARNINGS:BOOL=ON -DWZ_DISTRIBUTOR:STRING="${WZ_DISTRIBUTOR}" -DWZ_OUTPUT_NAME_SUFFIX="${WZ_OUTPUT_NAME_SUFFIX}" -DWZ_NAME_SUFFIX="${WZ_NAME_SUFFIX}" -G"Ninja" "${{ github.workspace }}/src"
+        docker run --rm -w "${GITHUB_WORKSPACE}/build" -e "CC=${WZ_CC}" -e "CXX=${WZ_CXX}" -e "CI=true" -e GITHUB_WORKFLOW -e GITHUB_ACTIONS -e GITHUB_REPOSITORY -e GITHUB_WORKSPACE -e "GITHUB_SHA=${WZ_GITHUB_SHA}" -e "GITHUB_REF=${WZ_GITHUB_REF}" -e "GITHUB_HEAD_REF=${WZ_GITHUB_HEAD_REF}" -e "GITHUB_BASE_REF=${WZ_GITHUB_BASE_REF}" -e MAKEFLAGS -v "${GITHUB_WORKSPACE}:${GITHUB_WORKSPACE}" ubuntu cmake -DCMAKE_BUILD_TYPE=Release -DWZ_ENABLE_WARNINGS:BOOL=ON -DWZ_DISTRIBUTOR:STRING="${WZ_DISTRIBUTOR}" -DWZ_OUTPUT_NAME_SUFFIX="${WZ_OUTPUT_NAME_SUFFIX}" -DWZ_NAME_SUFFIX="${WZ_NAME_SUFFIX}" -G"Ninja" "${{ github.workspace }}/src"
         echo "::remove-matcher owner=cmake::"
     - name: CMake Build
       working-directory: '${{ github.workspace }}/build'
       run: |
         echo "::add-matcher::${GITHUB_WORKSPACE}/src/.ci/githubactions/pattern_matchers/${{ matrix.compiler }}.json"
-        docker run --rm -w "${GITHUB_WORKSPACE}/build" -e "CC=${WZ_CC}" -e "CXX=${WZ_CXX}" -e "CI=true" -e GITHUB_WORKFLOW -e GITHUB_ACTIONS -e GITHUB_REPOSITORY -e GITHUB_WORKSPACE -e GITHUB_SHA -e GITHUB_REF -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e MAKEFLAGS -v "${GITHUB_WORKSPACE}:${GITHUB_WORKSPACE}" ubuntu cmake --build .
+        docker run --rm -w "${GITHUB_WORKSPACE}/build" -e "CC=${WZ_CC}" -e "CXX=${WZ_CXX}" -e "CI=true" -e GITHUB_WORKFLOW -e GITHUB_ACTIONS -e GITHUB_REPOSITORY -e GITHUB_WORKSPACE -e "GITHUB_SHA=${WZ_GITHUB_SHA}" -e "GITHUB_REF=${WZ_GITHUB_REF}" -e "GITHUB_HEAD_REF=${WZ_GITHUB_HEAD_REF}" -e "GITHUB_BASE_REF=${WZ_GITHUB_BASE_REF}" -e MAKEFLAGS -v "${GITHUB_WORKSPACE}:${GITHUB_WORKSPACE}" ubuntu cmake --build .
         echo "::remove-matcher owner=${{ matrix.compiler }}::"
     - name: Package .DEB
       working-directory: '${{ github.workspace }}/build'
@@ -151,14 +164,14 @@ jobs:
         path: ${{ env.OUTPUT_DIR }}
         if-no-files-found: 'error'
     - name: Upload artifact to release
-      if: success() && startsWith(github.ref, 'refs/tags/') && (matrix.deploy_release == true)
+      if: success() && (github.event_name == 'workflow_run' && github.event.workflow_run.name == 'Draft Tag Release') && (matrix.deploy_release == true)
       run: |
         SOURCE_TAG="${WZ_GITHUB_REF#refs/tags/}"
         gh release upload "${SOURCE_TAG}" "${{ env.WZ_FULL_OUTPUT_DEB_PATH }}"
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         GH_REPO: ${{ github.repository }}
-        WZ_GITHUB_REF: ${{ github.ref }}
+        WZ_GITHUB_REF: ${{ steps.checkout-config.outputs.WZ_GITHUB_REF }}
 
   package-source:
     name: Package Source (Ubuntu 18.04) [GCC]
@@ -173,6 +186,14 @@ jobs:
       with:
         fetch-depth: 0
         path: 'src'
+    - name: Configure Repo Checkout
+      id: checkout-config
+      working-directory: ./src
+      env:
+        WORKFLOW_RUN_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
+        WORKFLOW_RUN_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+      run: |
+        . .ci/githubactions/checkout_config.sh
     - name: Prepare Git Repo for autorevision
       working-directory: '${{ github.workspace }}/src'
       run: cmake -P .ci/githubactions/prepare_git_repo.cmake
@@ -190,11 +211,11 @@ jobs:
       working-directory: '${{ github.workspace }}/build'
       run: |
         echo "::add-matcher::${GITHUB_WORKSPACE}/src/.ci/githubactions/pattern_matchers/cmake.json"
-        docker run --rm -w "${GITHUB_WORKSPACE}/build" -e "CI=true" -e GITHUB_WORKFLOW -e GITHUB_ACTIONS -e GITHUB_REPOSITORY -e GITHUB_WORKSPACE -e GITHUB_SHA -e GITHUB_REF -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e MAKEFLAGS -v "${GITHUB_WORKSPACE}:${GITHUB_WORKSPACE}" ubuntu cmake -DCMAKE_BUILD_TYPE=Debug -G"Ninja" "${{ github.workspace }}/src"
+        docker run --rm -w "${GITHUB_WORKSPACE}/build" -e "CI=true" -e GITHUB_WORKFLOW -e GITHUB_ACTIONS -e GITHUB_REPOSITORY -e GITHUB_WORKSPACE -e "GITHUB_SHA=${WZ_GITHUB_SHA}" -e "GITHUB_REF=${WZ_GITHUB_REF}" -e "GITHUB_HEAD_REF=${WZ_GITHUB_HEAD_REF}" -e "GITHUB_BASE_REF=${WZ_GITHUB_BASE_REF}" -e MAKEFLAGS -v "${GITHUB_WORKSPACE}:${GITHUB_WORKSPACE}" ubuntu cmake -DCMAKE_BUILD_TYPE=Debug -G"Ninja" "${{ github.workspace }}/src"
         echo "::remove-matcher owner=cmake::"
     - name: CMake Package Source
       working-directory: '${{ github.workspace }}/build'
-      run: docker run --rm -w "${GITHUB_WORKSPACE}/build" -e "CI=true" -e GITHUB_WORKFLOW -e GITHUB_ACTIONS -e GITHUB_REPOSITORY -e GITHUB_WORKSPACE -e GITHUB_SHA -e GITHUB_REF -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e MAKEFLAGS -v "${GITHUB_WORKSPACE}:${GITHUB_WORKSPACE}" ubuntu cmake --build . --target package_source
+      run: docker run --rm -w "${GITHUB_WORKSPACE}/build" -e "CI=true" -e GITHUB_WORKFLOW -e GITHUB_ACTIONS -e GITHUB_REPOSITORY -e GITHUB_WORKSPACE -e "GITHUB_SHA=${WZ_GITHUB_SHA}" -e "GITHUB_REF=${WZ_GITHUB_REF}" -e "GITHUB_HEAD_REF=${WZ_GITHUB_HEAD_REF}" -e "GITHUB_BASE_REF=${WZ_GITHUB_BASE_REF}" -e MAKEFLAGS -v "${GITHUB_WORKSPACE}:${GITHUB_WORKSPACE}" ubuntu cmake --build . --target package_source
     - name: Extract & Build Packaged Source
       working-directory: '${{ github.workspace }}/build'
       run: |
@@ -224,6 +245,15 @@ jobs:
         name: warzone2100_src
         path: ${{ env.OUTPUT_DIR }}
         if-no-files-found: 'error'
+    - name: Upload source tarball to release
+      if: success() && (github.event_name == 'workflow_run' && github.event.workflow_run.name == 'Draft Tag Release')
+      run: |
+        SOURCE_TAG="${WZ_GITHUB_REF#refs/tags/}"
+        gh release upload "${SOURCE_TAG}" "${OUTPUT_DIR}/warzone2100_src.tar.xz"
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GH_REPO: ${{ github.repository }}
+        WZ_GITHUB_REF: ${{ steps.checkout-config.outputs.WZ_GITHUB_REF }}
 
   # # NOTE: This uses qemu, and is much slower than a native ARM64 build
   # ubuntu-20-04-gcc-arm64:
@@ -250,22 +280,3 @@ jobs:
   #   - name: CMake Build
   #     run: docker run --rm -e "CI=true" -e GITHUB_WORKFLOW -e GITHUB_ACTIONS -e GITHUB_REPOSITORY -e "GITHUB_WORKSPACE=/code" -e GITHUB_SHA -e GITHUB_REF -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e MAKEFLAGS -v $(pwd):/code ubuntu cmake --build build
 
-  upload_release_artifacts:
-    if: startsWith(github.ref, 'refs/tags/')
-    name: Upload Release Artifacts
-    needs: package-source
-    runs-on: ubuntu-latest
-    steps:
-      - name: Download source tarball
-        uses: actions/download-artifact@v2
-        with:
-          name: warzone2100_src
-          path: warzone2100_src
-      - name: Upload source tarball to release
-        run: |
-          SOURCE_TAG="${WZ_GITHUB_REF#refs/tags/}"
-          gh release upload "${SOURCE_TAG}" "./warzone2100_src/warzone2100_src.tar.xz"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GH_REPO: ${{ github.repository }}
-          WZ_GITHUB_REF: ${{ github.ref }}

--- a/.github/workflows/CI_windows.yml
+++ b/.github/workflows/CI_windows.yml
@@ -4,11 +4,16 @@ on:
   push:
     branches-ignore:
       - 'l10n_**' # Push events to translation service branches (that begin with "l10n_")
-    # Sequence of patterns matched against refs/tags
-    tags:
-      - '*'
   pull_request:
     # Match all pull requests
+  # Support running after "Draft Tag Release" workflow completes, as part of automated release process
+  workflow_run:
+    workflows: ["Draft Tag Release"]
+    push:
+      tags:
+        - '*'
+    types: 
+      - completed
 
 jobs:
   windows-build:
@@ -44,6 +49,15 @@ jobs:
       with:
         fetch-depth: 0
         path: 'src'
+    - name: Configure Repo Checkout
+      id: checkout-config
+      working-directory: '${{ github.workspace }}\src'
+      shell: bash
+      env:
+        WORKFLOW_RUN_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
+        WORKFLOW_RUN_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+      run: |
+        . .ci/githubactions/checkout_config.sh
     - name: Prepare Git Repo for autorevision
       working-directory: '${{ github.workspace }}\src'
       run: cmake -P .ci/githubactions/prepare_git_repo.cmake
@@ -324,7 +338,7 @@ jobs:
         echo "::set-output name=WZ_MINGW_ENV_PATH::${WZ_MINGW_ENV_PATH}"
     - name: Cache vcpkg dependencies
       id: vcpkg-cache
-      if: success() && !(github.event_name == 'push' && contains(github.ref, 'refs/tags/'))
+      if: success() && !(github.event_name == 'workflow_run' && github.event.workflow_run.name == 'Draft Tag Release')
       uses: actions/cache@v2
       with:
         path: ${{ steps.settings.outputs.VCPKG_BINARYCACHE_DIR }}
@@ -497,7 +511,7 @@ jobs:
         if-no-files-found: 'error'
     - name: 'Upload Artifact - (Archive)'
       uses: actions/upload-artifact@v2
-      if: success() && startsWith(github.ref, 'refs/tags/') && (matrix.deploy_release == true) && (github.repository == 'Warzone2100/warzone2100')
+      if: success() && (github.event_name == 'workflow_run' && github.event.workflow_run.name == 'Draft Tag Release') && (matrix.deploy_release == true) && (github.repository == 'Warzone2100/warzone2100')
       with:
         name: warzone2100_${{ steps.settings.outputs.WZ_BUILD_DESC }}_archive
         path: '${{ github.workspace }}\output\archive'
@@ -506,14 +520,14 @@ jobs:
     # Upload Release assets (if a release tag)
     #####################################################
     - name: Upload Release Assets
-      if: success() && startsWith(github.ref, 'refs/tags/') && (matrix.deploy_release == true) && (github.repository == 'Warzone2100/warzone2100')
+      if: success() && (github.event_name == 'workflow_run' && github.event.workflow_run.name == 'Draft Tag Release') && (matrix.deploy_release == true) && (github.repository == 'Warzone2100/warzone2100')
       run: |
         $SOURCE_TAG = "$($env:WZ_GITHUB_REF -replace "refs/tags/")"
         gh release upload "${SOURCE_TAG}" "${{ github.workspace }}\output\portable\warzone2100_$($env:WZ_BUILD_DESC)_portable.exe" "${{ github.workspace }}\output\installer\warzone2100_$($env:WZ_BUILD_DESC)_installer.exe" "${{ github.workspace }}\output\debugsymbols\warzone2100_$($env:WZ_BUILD_DESC).DEBUGSYMBOLS.7z" "${{ github.workspace }}\output\archive\warzone2100_$($env:WZ_BUILD_DESC)_archive.zip"
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         GH_REPO: ${{ github.repository }}
-        WZ_GITHUB_REF: ${{ github.ref }}
+        WZ_GITHUB_REF: ${{ steps.checkout-config.outputs.WZ_GITHUB_REF }}
   trigger-updates-json:
     # For this job to work, the following secrets must be set:
     # SITE_DISPATCH_ACCESS_TOKEN

--- a/.github/workflows/CI_windows.yml
+++ b/.github/workflows/CI_windows.yml
@@ -507,17 +507,13 @@ jobs:
     #####################################################
     - name: Upload Release Assets
       if: success() && startsWith(github.ref, 'refs/tags/') && (matrix.deploy_release == true) && (github.repository == 'Warzone2100/warzone2100')
-      uses: past-due/action-gh-release@master
-      with:
-        # Do not explicitly specify a tag_name, so this action takes the github.ref and parses it for just the tag
-        files: |
-          ${{ github.workspace }}\output\portable\*.exe
-          ${{ github.workspace }}\output\installer\*.exe
-          ${{ github.workspace }}\output\debugsymbols\*.7z
-          ${{ github.workspace }}\output\archive\*.zip
-        draft: true
+      run: |
+        $SOURCE_TAG = "$($env:WZ_GITHUB_REF -replace "refs/tags/")"
+        gh release upload "${SOURCE_TAG}" "${{ github.workspace }}\output\portable\warzone2100_$($env:WZ_BUILD_DESC)_portable.exe" "${{ github.workspace }}\output\installer\warzone2100_$($env:WZ_BUILD_DESC)_installer.exe" "${{ github.workspace }}\output\debugsymbols\warzone2100_$($env:WZ_BUILD_DESC).DEBUGSYMBOLS.7z" "${{ github.workspace }}\output\archive\warzone2100_$($env:WZ_BUILD_DESC)_archive.zip"
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GH_REPO: ${{ github.repository }}
+        WZ_GITHUB_REF: ${{ github.ref }}
   trigger-updates-json:
     # For this job to work, the following secrets must be set:
     # SITE_DISPATCH_ACCESS_TOKEN

--- a/.github/workflows/draft_tag_release.yml
+++ b/.github/workflows/draft_tag_release.yml
@@ -23,8 +23,8 @@ jobs:
         run: |
           # Take the github.ref and parse it for just the tag
           SOURCE_TAG="${GITHUB_REF#refs/tags/}"
-          # Verify tag format (three-component version + optional trailing qualifier like "-beta1" or "-rc1")          
-          regex="^([0-9][0-9]*\\.[0-9][0-9]*\\.[0-9][0-9]*)([\-_].*)?$";
+          # Verify tag format (three-component version + optional trailing qualifier like "-beta1" or "-rc1")
+          regex="^([0-9][0-9]*\\.[0-9][0-9]*\\.[0-9][0-9]*)([\-][A-Za-z0-9]+)?$";
           if [[ ! "${SOURCE_TAG}" =~ $regex ]]; then
             echo "Invalid tag version format: \"${SOURCE_TAG}\""
             exit 1

--- a/.github/workflows/draft_tag_release.yml
+++ b/.github/workflows/draft_tag_release.yml
@@ -18,13 +18,37 @@ jobs:
           persist-credentials: false
           fetch-depth: 1
           lfs: false
+      - name: Get Tag Version
+        id: tag_version
+        run: |
+          # Take the github.ref and parse it for just the tag
+          SOURCE_TAG="${GITHUB_REF#refs/tags/}"
+          # Verify tag format (three-component version + optional trailing qualifier like "-beta1" or "-rc1")          
+          regex="^([0-9][0-9]*\\.[0-9][0-9]*\\.[0-9][0-9]*)([\-_].*)?$";
+          if [[ ! "${SOURCE_TAG}" =~ $regex ]]; then
+            echo "Invalid tag version format: \"${SOURCE_TAG}\""
+            exit 1
+          fi
+          SOURCE_TAG_VERSION="${BASH_REMATCH[1]}"
+          SOURCE_TAG_QUALIFIER="${BASH_REMATCH[2]:1}"
+          echo "SOURCE_TAG_VERSION=\"${SOURCE_TAG_VERSION}\""
+          echo "SOURCE_TAG_QUALIFIER=\"${SOURCE_TAG_QUALIFIER}\""
+          
+          if [ ! -z "${SOURCE_TAG_QUALIFIER}" ]; then
+            SOURCE_TAG_IS_PRERELEASE="true"
+          else
+            SOURCE_TAG_IS_PRERELEASE="false"
+          fi
+          
+          echo "::set-output name=SOURCE_TAG::${SOURCE_TAG}"
+          echo "::set-output name=SOURCE_TAG_IS_PRERELEASE::${SOURCE_TAG_IS_PRERELEASE}"
       - name: Create Draft Release
-        uses: past-due/action-gh-release@v1
-        with:
-          # Do not explicitly specify a tag_name, so this action takes the github.ref and parses it for just the tag
-          body_path: .github/wz/templates/draft_release_body_template.md
-          draft: true
-          prerelease: false
+        run: |
+          ADDITIONAL_GH_OPTIONS=""
+          if [ "${{ steps.tag_version.outputs.SOURCE_TAG_IS_PRERELEASE }}" = "true" ]; then
+            ADDITIONAL_GH_OPTIONS="--prerelease"
+          fi
+          gh release create "${{ steps.tag_version.outputs.SOURCE_TAG }}" -F ".github/wz/templates/draft_release_body_template.md" -t "${{ steps.tag_version.outputs.SOURCE_TAG }}" --draft ${ADDITIONAL_GH_OPTIONS}
         env:
-          # This token is provided by Actions, you do not need to create your own token
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}

--- a/.snapcraft.yaml
+++ b/.snapcraft.yaml
@@ -156,7 +156,8 @@ parts:
       - usr/share/metainfo/warzone2100.appdata.xml
     override-pull: |
       snapcraftctl pull
-      snapcraftctl set-version "$(git describe --always)"
+      SNAP_VERSION_DESC=$(git describe --always | sed 's/[^a-zA-Z0-9\.\:\+\~\-]/~/g')
+      snapcraftctl set-version "${SNAP_VERSION_DESC}"
       git submodule update --init
     override-build: |
       echo "SNAPCRAFT_TARGET_ARCH=${SNAPCRAFT_TARGET_ARCH}"

--- a/doc/Release.md
+++ b/doc/Release.md
@@ -10,7 +10,7 @@ Of course, it is always nice to gather up enough volunteers to test before you a
 
 Starting off
 ------------
-We currently do releases off git master.
+We do releases off of the git `master` branch.
 
     git pull origin master
 
@@ -103,6 +103,17 @@ Since everything works (since you tested it), it is time to make the **annotated
 
 Where `4.0.0` is the name of the tag.
 
+> ### Expected tag version format
+> The expected tag version format is: `<SEMVER>(<prereleaseversion>)`
+>
+> Where `<SEMVER>` is `#.#.#` (examples: `4.0.0`, `4.0.1`, `4.9.12`)
+> 
+> And the _optional_ `<prereleaseversion>` is a hyphen-prefixed pre-release identifier + version like: `-beta1` or `-rc1`
+>
+> #### Valid tag examples:
+> - Normal releases: `4.0.0`, `4.0.1`, `4.0.22`
+> - Pre-releases: `4.0.1-beta1`, `4.0.1-rc2`
+
 > ### Always forwards
 > _Do **NOT** re-use an existing tag / tag that was previously used!_
 > If you make a mistake, or a bug is found, (etc), increment the version _again_.
@@ -113,7 +124,8 @@ Where `4.0.0` is the name of the tag.
 GitHub will then **automatically**:
 - create a Draft release in **[GitHub Releases](https://github.com/Warzone2100/warzone2100/releases)** for the new tag
    - (may take a minute or so to complete)
-- trigger the CI builds
+   - (uses [/.github/workflows/draft_tag_release.yml](/.github/workflows/draft_tag_release.yml))
+- trigger the CI builds (as `workflow_run` event runs, after the "Draft Tag Release" workflow completes)
 
 
 Download & verify the tag / release builds
@@ -128,7 +140,7 @@ Download & verify the tag / release builds
 download the appropriate artifact(s) following the same instructions you used to download the master
 branch artifacts above.
 <br />
-- Just make sure you download artifacts from the CI runs for the <b>tag</b> you created.
+- Just make sure you download artifacts from the CI runs for the <b>tag</b> you created. This will be in "[`workflow_run`](https://github.com/Warzone2100/warzone2100/actions?query=branch%3Amaster+event%3Aworkflow_run)" event CI runs.
 <br />
 <b>You should <i>NOT</i> have to manually upload artifacts to the GitHub Release</b> (unless
 the CI -> GitHub integration breaks).
@@ -145,19 +157,19 @@ the CI -> GitHub integration breaks).
       - [x] `warzone2100_win_x64.DEBUGSYMBOLS.7z`
       - [x] `warzone2100_win_x64_installer.exe`
       - [x] `warzone2100_win_x64_portable.exe`
-   - [x] Verify the SHA512 hashes towards the end of the [Windows workflow's](https://github.com/Warzone2100/warzone2100/actions?query=workflow%3AWindows+event%3Apush) log match the files you downloaded.
+   - [x] Verify the SHA512 hashes towards the end of the most recent [`workflow_run` Windows workflow's](https://github.com/Warzone2100/warzone2100/actions?query=workflow%3AWindows+event%3Aworkflow_run) log match the files you downloaded.
       - [x] **Make sure you are viewing the build for the _tag_ you just made**
       - [x] Select the appropriate job (x86, x64, etc).
       - [x] Expand the "Compare Build Outputs" step, which outputs the SHA512 hashes at the bottom of its output.
    - [x] Download the macOS build from the draft release:
       - [x] `warzone2100_macOS.zip`
-   - [x] Verify the SHA512 hash towards the end of the [macOS workflow's](https://github.com/Warzone2100/warzone2100/actions?query=workflow%3AmacOS+event%3Apush) log matches the file you downloaded.
+   - [x] Verify the SHA512 hash towards the end of the most recent [`workflow_run` macOS workflow's](https://github.com/Warzone2100/warzone2100/actions?query=workflow%3AmacOS+event%3Aworkflow_run) log matches the file you downloaded.
       - [x] **Make sure you are viewing the build for the _tag_ you just made**
       - [x] Select the `Package Universal Binary` job
       - [x] Scroll down to the `Output Build Info` step(s), which output the SHA512 at the bottom of their output.
    - [x] Download the tag's source tarball from the draft release:
       - [x] `warzone2100_src.tar.xz`
-   - [x] Verify the SHA512 hash towards the end of the [Ubuntu workflow's](https://github.com/Warzone2100/warzone2100/actions?query=workflow%3AUbuntu+event%3Apush+) ("Package Source" job) log matches the file you downloaded.
+   - [x] Verify the SHA512 hash towards the end of the most recent [`workflow_run` Ubuntu workflow's](https://github.com/Warzone2100/warzone2100/actions?query=workflow%3AUbuntu+event%3Aworkflow_run) ("Package Source" job) log matches the file you downloaded.
       - [x] **Make sure you are viewing the build for the _tag_ you just made**
       - [x] Select the "Package Source" job
       - [x] Expand the "Rename Tarball & Output Info" step, which outputs the SHA512 at the bottom of its output.


### PR DESCRIPTION
The big changes are:
- Replace use of [`action-gh-release`](https://github.com/softprops/action-gh-release) (which may not be actively maintained anymore) with [GitHub CLI](https://cli.github.com) (`gh` commands).
- Use the GitHub [`workflow_run` event](https://docs.github.com/en/actions/reference/events-that-trigger-workflows#workflow_run) to trigger the actual tagged build CI runs *after* the "Draft Tag Release" workflow completes.

Some notes:
- As it is not possible to override the `GITHUB_*` environment variables, new `WZ_`-prefixed variables were introduced to handle these `workflow_run` event builds. (Specifically: `WZ_GITHUB_SHA`, `WZ_GITHUB_REF`, `WZ_GITHUB_HEAD_REF`,
`WZ_GITHUB_BASE_REF`)
- (The `workflow_run` event builds run in the context of the latest default (`master`) branch commit, so the details of the associated `Draft Tag Release` workflow run (ex: `github.event.workflow_run.head_sha`) are obtained and used instead to determine the tag / ref to make sure the actual tag is being built.)