### PR TITLE
Fix engine upgrade / unit speeds

### DIFF
--- a/src/droid.cpp
+++ b/src/droid.cpp
@@ -129,6 +129,10 @@ static void droidBodyUpgrade(DROID *psDroid)
 	psDroid->originalBody = calcDroidBaseBody(psDroid);
 	int increase = psDroid->originalBody * factor / prev;
 	psDroid->body = MIN(psDroid->originalBody, (psDroid->body * increase) / factor + 1);
+	DROID_TEMPLATE sTemplate;
+	templateSetParts(psDroid, &sTemplate);
+	// update engine too
+	psDroid->baseSpeed = calcDroidBaseSpeed(&sTemplate, psDroid->weight, psDroid->player);
 	if (isTransporter(psDroid))
 	{
 		for (DROID *psCurr = psDroid->psGroup->psList; psCurr != nullptr; psCurr = psCurr->psGrpNext)

--- a/src/levels.cpp
+++ b/src/levels.cpp
@@ -1024,7 +1024,7 @@ bool levLoadData(char const *name, Sha256 const *hash, char *pSaveName, GAME_TYP
 			return false;
 		}
 	}
-
+	// this will trigger upgrades
 	if (!stageThreeInitialise())
 	{
 		debug(LOG_ERROR, "Failed stageThreeInitialise()!");

--- a/src/levels.cpp
+++ b/src/levels.cpp
@@ -80,7 +80,7 @@ static LEVEL_DATASET	sSingleWRF = { LEVEL_TYPE::LDS_COMPLETE, 0, 0, nullptr, mod
 char *pLevToken;
 LEVEL_TYPE levVal;
 static GAME_TYPE levelLoadType;
-static inline void recalcDroidBaseSpeed(DROID *psCurr, int player);
+
 // modes for the parser
 enum LEVELPARSER_STATE
 {
@@ -1024,65 +1024,13 @@ bool levLoadData(char const *name, Sha256 const *hash, char *pSaveName, GAME_TYP
 			return false;
 		}
 	}
-	// this will trigger upgrades 
+
 	if (!stageThreeInitialise())
 	{
 		debug(LOG_ERROR, "Failed stageThreeInitialise()!");
 		return false;
 	}
 
-	// droids were actually loaded before (during stageThreeInitialise) upgrades.
-	// So to actually apply them, we'll iterate over all droids, and re-calculate, once again,
-	// their upgradable parts.
-	// Without that, both Campaign and Skirmish saves are broken.
-	for (int player=0; player < MAX_PLAYERS; player++)
-	{
-		// those are droids present on the map
-		for (DROID *psCurr = apsDroidLists[player]; psCurr != nullptr; psCurr = psCurr->psNext)
-		{
-			if (isTransporter(psCurr) && psCurr->psGroup)
-			{
-				// and those within a transporter...
-				for (DROID *psDroidInTransport = psCurr->psGroup->psList; psDroidInTransport != nullptr; psDroidInTransport = psDroidInTransport->psGrpNext)
-				{
-					recalcDroidBaseSpeed(psDroidInTransport, player);
-				}
-			} else
-			{
-				recalcDroidBaseSpeed(psCurr, player);
-			}
-		}
-		// those are droids stuck at base, if any ("away" missions)
-		for (DROID *psCurr = mission.apsDroidLists[player]; psCurr != nullptr; psCurr = psCurr->psNext)
-		{
-			if (isTransporter(psCurr) && psCurr->psGroup)
-			{
-				// and those within a transporter...
-				for (DROID *psDroidInTransport = psCurr->psGroup->psList; psDroidInTransport != nullptr; psDroidInTransport = psDroidInTransport->psGrpNext)
-				{
-					recalcDroidBaseSpeed(psDroidInTransport, player);
-				}
-			} else
-			{
-				recalcDroidBaseSpeed(psCurr, player);
-			}
-		}
-		// also limbo droids
-		for (DROID *psCurr = apsLimboDroids[player]; psCurr != nullptr; psCurr = psCurr->psNext)
-		{
-			if (isTransporter(psCurr) && psCurr->psGroup)
-			{
-				// and those within a transporter... is this even possible?..
-				for (DROID *psDroidInTransport = psCurr->psGroup->psList; psDroidInTransport != nullptr; psDroidInTransport = psDroidInTransport->psGrpNext)
-				{
-					recalcDroidBaseSpeed(psDroidInTransport, player);
-				}
-			} else
-			{
-				recalcDroidBaseSpeed(psCurr, player);
-			}
-		}
-	}
 	dataClearSaveFlag();
 
 	//restore the level name for comparisons on next mission load up
@@ -1114,14 +1062,7 @@ bool levLoadData(char const *name, Sha256 const *hash, char *pSaveName, GAME_TYP
 
 	return true;
 }
-static inline void recalcDroidBaseSpeed(DROID *psCurr, int player)
-{
 
-	DROID_TEMPLATE sTemplate;
-	templateSetParts(psCurr, &sTemplate);
-	psCurr->baseSpeed = calcDroidBaseSpeed(&sTemplate, psCurr->weight, player);
-
-}
 std::string mapNameWithoutTechlevel(const char *mapName)
 {
 	ASSERT_OR_RETURN("", mapName != nullptr, "null mapName provided");

--- a/src/wzapi.cpp
+++ b/src/wzapi.cpp
@@ -3318,6 +3318,7 @@ bool wzapi::setUpgradeStats(WZAPI_BASE_PARAMS(int player, const std::string& nam
 		else if (name == "Power")
 		{
 			psStats->upgrade[player].power = value;
+			dirtyAllDroids(player);
 		}
 		else if (name == "Resistance")
 		{


### PR DESCRIPTION
This reverts changes made in https://github.com/Warzone2100/warzone2100/pull/1812 (related bug report #1803), but **still** fixes the unit speed for saved units. I have ran the sames tests (campaign + skirmish + saved with/inside transport)

Current PR has the advantage it also fixes another bug, when engine upgrades did not affect existing units, only those ~~already~~ newly built. 