### PR TITLE
Increase the power output of the Leopard and Panther

### DIFF
--- a/data/mp/stats/body.json
+++ b/data/mp/stats/body.json
@@ -377,7 +377,7 @@
 		"id": "Body2SUP",
 		"model": "drlbod02.pie",
 		"name": "Leopard",
-		"powerOutput": 4000,
+		"powerOutput": 6500,
 		"propulsionExtraModels": {
 			"HalfTrack": {
 				"left": "prllhtr1.pie",
@@ -561,7 +561,7 @@
 		"id": "Body6SUPP",
 		"model": "drmbod06.pie",
 		"name": "Panther",
-		"powerOutput": 13000,
+		"powerOutput": 18000,
 		"propulsionExtraModels": {
 			"HalfTrack": {
 				"left": "prmlhtr2.pie",


### PR DESCRIPTION
This increase is necessary to allow players to use these bodies not only on VTOL but also on the ground with half-tracks and other walkers. The problem is that the power of 4000 and 13000 is not enough for normal movement of units. For example, when coupling leopard + half-tracks + lancer, with the fact that the lancer is extremely lightweight turret and lighter turrets in the game does not exist, the unit will move like a turtle. Also, the leopard and panther lose on the dynamics of any body that is available before their appearance, that is, any yellow or gray body will be much faster in conjunction with many turrets and running. So I decided to make a leopard equal to the dynamics of the bug. Panther will be similar in dynamics to scorpion or python.