### PR TITLE
Opening a map and minimap after a victory/defeat

### DIFF
--- a/data/mp/multiplay/script/rules/endconditions.js
+++ b/data/mp/multiplay/script/rules/endconditions.js
@@ -1,62 +1,281 @@
-// /////////////////////////////////////////////////////////////////
-// END CONDITIONS
-function checkEndConditions()
-{
-	var factories = countStruct("A0LightFactory") + countStruct("A0CyborgFactory");
-	var droids = countDroid(DROID_ANY);
+// registrate events conditions_eventGameInit, conditions_eventDroidBuilt, conditions_eventStructureBuil, conditions_eventResearched, conditions_eventAttacked
+namespace("conditions_");
 
-	// Losing Conditions
-	if (droids == 0 && factories == 0)
-	{
-		var gameLost = true;
+const STATE_contender = "contender";
+const STATE_winner = "winner";
+const STATE_loser = "loser";
 
-		/* If teams enabled check if all team members have lost  */
-		if (alliancesType == ALLIANCES_TEAMS || alliancesType == ALLIANCES_UNSHARED)
-		{
-			for (var playnum = 0; playnum < maxPlayers; playnum++)
-			{
-				if (playnum != selectedPlayer && allianceExistsBetween(selectedPlayer, playnum))
-				{
-					factories = countStruct("A0LightFactory", playnum) + countStruct("A0CyborgFactory", playnum);
-					droids = countDroid(DROID_ANY, playnum);
-					if (droids > 0 || factories > 0)
-					{
-						gameLost = false;	// someone from our team still alive
-						break;
-					}
+const STRUCTS = [FACTORY, CYBORG_FACTORY, VTOL_FACTORY]; // structures in which you can continue to play
+// TODO remove HQ. The destruction of the HQ will hide the minimap.
+
+
+// The time that the player's inactivity is allowed. Actions are considered
+// - unit building
+// - completion of the research
+// - construction of base structures (factories, power plants, laboratories, modules and oil rigs)
+// - dealing damage
+const IDLETIME = 5 * 60 * 1000;
+const BASESTRUCTS = {[FACTORY]: true, [CYBORG_FACTORY]: true, [VTOL_FACTORY]: true, [HQ]: true, [RESOURCE_EXTRACTOR]: true, [POWER_GEN]: true, [RESEARCH_LAB]: true};
+
+const SPOTTER = {
+	x: mapWidth / 2,
+	y: mapHeight / 2,
+	radius: (Math.sqrt(mapWidth * mapWidth + mapHeight * mapHeight) / 2) * 128,
+};
+
+var teams = []; // array class instance Team
+var playersTeam = new Array(maxPlayers); // array class instancePlayer
+
+class Player {
+	constructor(playNum) {
+		this.playNum = playNum;
+	}
+
+	hasFactory() {
+		for (let i = 0; i < STRUCTS.length; ++i) {
+			const onMapStructss = enumStruct(this.playNum, STRUCTS[i]);
+			for (let j = 0; j < onMapStructss.length; ++j) {
+				if (onMapStructss[j].status === BUILT) {
+					return true;
 				}
 			}
 		}
-
-		if (gameLost)
-		{
-			gameOverMessage(false);
-			removeTimer("checkEndConditions");
-			return;
-		}
+		return false;
 	}
 
-	// Winning Conditions
-	var gamewon = true;
+	hasDroid() {
+		if (countDroid(DROID_ANY, this.playNum) > 0) {
+			return true;
+		}
+		return false;
+	}
 
-	// check if all enemies defeated
-	for (var playnum = 0; playnum < maxPlayers; playnum++)
-	{
-		if (playnum != selectedPlayer && !allianceExistsBetween(selectedPlayer, playnum))	// checking enemy player
-		{
-			factories = countStruct("A0LightFactory", playnum) + countStruct("A0CyborgFactory", playnum); // nope
-			droids = countDroid(DROID_ANY, playnum);
-			if (droids > 0 || factories > 0)
-			{
-				gamewon = false;	//one of the enemies still alive
-				break;
+	hasOnlyConstructor() {
+		if (countDroid(DROID_ANY, this.playNum) - countDroid(DROID_CONSTRUCT, this.playNum) === 0) {
+			return true;
+		}
+		return false;
+	}
+
+	canReachOil() {
+		if (enumStruct(this.playNum, RESOURCE_EXTRACTOR).length != 0) {
+			return true;
+		}
+
+		let oils = enumFeature(ALL_PLAYERS).filter(function(e) {
+			return e.stattype === OIL_RESOURCE;
+		});
+		for (let playnum = 0; playnum < maxPlayers; playnum++) {
+			oils = oils.concat(enumStruct(playnum, "A0ResourceExtractor"));
+		}
+
+		const trucks = enumDroid(this.playNum, DROID_CONSTRUCT);
+		for (let i = 0, len = trucks.length; i < len; ++i) {
+			const truck = trucks[i];
+			for (let j = 0, len2 = oils.length; j < len2; ++j) {
+				const oil = oils[j];
+				if (droidCanReach(truck, oil.x, oil.y)) {
+					return true;
+				}
 			}
 		}
+		return false;
 	}
 
-	if (gamewon)
-	{
-		gameOverMessage(true);
-		removeTimer("checkEndConditions");
+	openMap() {
+		hackNetOff();
+		addSpotter(SPOTTER.x, SPOTTER.y, this.playNum, SPOTTER.radius, 0, 0);
+		hackNetOn();
+	}
+
+	hud(state) {
+		if (this.playNum != selectedPlayer) {
+			return;
+		}
+		if (state === STATE_loser) {
+			gameOverMessage(false);
+		}
+		if (state === STATE_winner) {
+			gameOverMessage(true);
+		}
+		setMiniMap(true); //minimap close after demolition HQ
+	}
+}
+
+
+class Team {
+	constructor(playerPlayNums) {
+		this.players = playerPlayNums.map(function(playNum) {
+			return new Player(playNum);
+		}); // array class instance  Player
+		this.state = STATE_contender; // We don't have observers, so all teams have regular players.
+		this.lastActivity = gameTime;
+		playerPlayNums.forEach(
+			(playerNum) => {
+				playersTeam[playerNum]= this;
+			}
+		);
+	}
+
+	activeGame() {
+		if (this.lastActivity + IDLETIME >= gameTime) {
+			return true;
+		}
+		return false;
+	}
+
+	hasFactory() {
+		return this.players.some(
+			(player) => {return player.hasFactory();}
+		);
+	}
+
+	hasDroid() {
+		return this.players.some(
+			(player) => {return player.hasDroid();}
+		);
+	}
+
+	hasOnlyConstructor() {
+		return this.players.some(
+			(player) => {return player.hasOnlyConstructor();}
+		);
+	}
+
+	canReachOil() {
+		return this.players.some(
+			(player) => {return player.canReachOil();}
+		);
+	}
+
+	canPlay() { // TODO skip check if no new events.
+		if (!this.activeGame()) {
+			return false;
+		}
+		if (!this.hasFactory() && !this.hasDroid()) {
+			return false;
+		}
+		if (!this.hasFactory() && this.hasOnlyConstructor() && !this.canReachOil()) {
+			return false;
+		}
+		return true;
+	}
+
+	updateState() {
+		if (this.state == STATE_contender && !this.canPlay()) {
+			this.setState(STATE_loser);
+		}
+	}
+
+	setState(state) {
+		this.state = state;
+		this.players.forEach(
+			(player) => {
+				player.hud(this.state);
+				player.openMap();
+			}
+		);
+	}
+
+	isContender() {
+		return this.state == STATE_contender;
+	}
+}
+
+function checkEndConditions() {
+	teams.forEach((team) => {
+		team.updateState();
+	});
+	const numTeamContender = teams.filter((team) => {
+		return team.isContender();
+	}).length;
+	if (numTeamContender == 1) {// game end
+		teams.find((team) => {
+			return team.isContender();
+		}).setState(STATE_winner);
+	}
+}
+
+
+function inOneTeam(playnum, splaynum) {
+//	FIXME allianceExistsBetween dont correct if leave player in ALLIANCES_UNSHARED, ALLIANCES_TEAMS mode
+//	and  team is garbage in NO_ALLIANCES, ALLIANCES mode
+	if (
+		(alliancesType == ALLIANCES_UNSHARED || alliancesType == ALLIANCES_TEAMS) &&
+    playerData[playnum].team != playerData[splaynum].team
+	) {
+		return false;
+	} else if (alliancesType == NO_ALLIANCES && playnum != splaynum) {
+		return false;
+	} else if (
+		alliancesType == ALLIANCES &&
+    !allianceExistsBetween(playnum, splaynum)
+	) {
+		return false;
+	}
+
+	return true;
+}
+
+
+function conditions_eventGameInit() {
+	const inTeamPlayNums = new Array(maxPlayers).fill(false);
+	for (let playNum = 0; playNum < maxPlayers; playNum++) {
+		if (inTeamPlayNums[playNum] != false) {
+			continue;
+		}
+		inTeamPlayNums[playNum] = true;
+		const members =[playNum];
+		for (let splayNum = 0; splayNum < maxPlayers; splayNum++) {
+			if ( inTeamPlayNums[splayNum] == false && inOneTeam(playNum, splayNum) == true) {
+				members.push(splayNum);
+				inTeamPlayNums[splayNum] = true;
+			}
+		}
+		teams.push(new Team(members));
+	}
+
+	setTimer("activityAlert", 10*1000);
+}
+
+function activityAlert() {
+	if (playersTeam[selectedPlayer].state != STATE_contender) {
+		setMissionTime(-1);
+		removeTimer("activityAlert");
+		return;
+	}
+	if (playersTeam[selectedPlayer].lastActivity + IDLETIME / 2 < gameTime) {
+		console(
+			_(
+				"Playing passively will lead to defeat. Actions that are considered: - unit building - research completion - construction of base structures (factories, power plants, laboratories, modules and oil derricks) - dealing damage")
+		);
+		if (getMissionTime() > IDLETIME) {
+			setMissionTime(
+				(playersTeam[selectedPlayer].lastActivity + IDLETIME - gameTime) / 1000);
+		}
+	}
+	if (playersTeam[selectedPlayer].lastActivity + IDLETIME / 2 > gameTime) {
+		setMissionTime(-1); // remove timer widget
+	}
+}
+
+function conditions_eventDroidBuilt(droid) {
+	if (droid.player != scavengerPlayer) {
+		playersTeam[droid.player].lastActivity = gameTime;
+	}
+}
+function conditions_eventStructureBuilt(structure) {
+	if (structure.player != scavengerPlayer && BASESTRUCTS[structure.stattype] == true) {
+		playersTeam[structure.player].lastActivity = gameTime;
+	}
+}
+function conditions_eventResearched(research, structure, player) {
+	if (player != scavengerPlayer) {
+		playersTeam[player].lastActivity = gameTime;
+	}
+}
+function conditions_eventAttacked(victim, attacker) {
+	if (attacker.player != scavengerPlayer) {
+		playersTeam[attacker.player].lastActivity = gameTime;
 	}
 }

--- a/data/mp/multiplay/script/rules/endconditions.js
+++ b/data/mp/multiplay/script/rules/endconditions.js
@@ -26,16 +26,22 @@ const SPOTTER = {
 var teams = []; // array class instance Team
 var playersTeam = new Array(maxPlayers); // array class instancePlayer
 
-class Player {
-	constructor(playNum) {
+class Player
+{
+	constructor(playNum)
+	{
 		this.playNum = playNum;
 	}
 
-	hasFactory() {
-		for (let i = 0; i < STRUCTS.length; ++i) {
+	hasFactory()
+	{
+		for (let i = 0; i < STRUCTS.length; ++i)
+		{
 			const onMapStructss = enumStruct(this.playNum, STRUCTS[i]);
-			for (let j = 0; j < onMapStructss.length; ++j) {
-				if (onMapStructss[j].status === BUILT) {
+			for (let j = 0; j < onMapStructss.length; ++j)
+			{
+				if (onMapStructss[j].status === BUILT)
+				{
 					return true;
 				}
 			}
@@ -43,38 +49,49 @@ class Player {
 		return false;
 	}
 
-	hasDroid() {
-		if (countDroid(DROID_ANY, this.playNum) > 0) {
+	hasDroid()
+	{
+		if (countDroid(DROID_ANY, this.playNum) > 0)
+		{
 			return true;
 		}
 		return false;
 	}
 
-	hasOnlyConstructor() {
-		if (countDroid(DROID_ANY, this.playNum) - countDroid(DROID_CONSTRUCT, this.playNum) === 0) {
+	hasOnlyConstructor()
+	{
+		if (countDroid(DROID_ANY, this.playNum) - countDroid(DROID_CONSTRUCT, this.playNum) === 0)
+		{
 			return true;
 		}
 		return false;
 	}
 
-	canReachOil() {
-		if (enumStruct(this.playNum, RESOURCE_EXTRACTOR).length != 0) {
+	canReachOil()
+	{
+		if (enumStruct(this.playNum, RESOURCE_EXTRACTOR).length != 0)
+		{
 			return true;
 		}
 
-		let oils = enumFeature(ALL_PLAYERS).filter(function(e) {
+		let oils = enumFeature(ALL_PLAYERS).filter(function(e)
+		{
 			return e.stattype === OIL_RESOURCE;
 		});
-		for (let playnum = 0; playnum < maxPlayers; playnum++) {
+		for (let playnum = 0; playnum < maxPlayers; playnum++)
+		{
 			oils = oils.concat(enumStruct(playnum, "A0ResourceExtractor"));
 		}
 
 		const trucks = enumDroid(this.playNum, DROID_CONSTRUCT);
-		for (let i = 0, len = trucks.length; i < len; ++i) {
+		for (let i = 0, len = trucks.length; i < len; ++i)
+		{
 			const truck = trucks[i];
-			for (let j = 0, len2 = oils.length; j < len2; ++j) {
+			for (let j = 0, len2 = oils.length; j < len2; ++j)
+			{
 				const oil = oils[j];
-				if (droidCanReach(truck, oil.x, oil.y)) {
+				if (droidCanReach(truck, oil.x, oil.y))
+				{
 					return true;
 				}
 			}
@@ -82,20 +99,25 @@ class Player {
 		return false;
 	}
 
-	openMap() {
+	openMap()
+	{
 		hackNetOff();
 		addSpotter(SPOTTER.x, SPOTTER.y, this.playNum, SPOTTER.radius, 0, 0);
 		hackNetOn();
 	}
 
-	hud(state) {
-		if (this.playNum != selectedPlayer) {
+	hud(state)
+	{
+		if (this.playNum != selectedPlayer)
+		{
 			return;
 		}
-		if (state === STATE_loser) {
+		if (state === STATE_loser)
+		{
 			gameOverMessage(false);
 		}
-		if (state === STATE_winner) {
+		if (state === STATE_winner)
+		{
 			gameOverMessage(true);
 		}
 		setMiniMap(true); //minimap close after demolition HQ
@@ -103,114 +125,144 @@ class Player {
 }
 
 
-class Team {
-	constructor(playerPlayNums) {
-		this.players = playerPlayNums.map(function(playNum) {
+class Team
+{
+	constructor(playerPlayNums)
+	{
+		this.players = playerPlayNums.map(function(playNum)
+		{
 			return new Player(playNum);
 		}); // array class instance  Player
 		this.state = STATE_contender; // We don't have observers, so all teams have regular players.
 		this.lastActivity = gameTime;
 		playerPlayNums.forEach(
-			(playerNum) => {
+			(playerNum) =>
+			{
 				playersTeam[playerNum]= this;
 			}
 		);
 	}
 
-	activeGame() {
-		if (this.lastActivity + IDLETIME >= gameTime) {
+	activeGame()
+	{
+		if (this.lastActivity + IDLETIME >= gameTime)
+		{
 			return true;
 		}
 		return false;
 	}
 
-	hasFactory() {
+	hasFactory()
+	{
 		return this.players.some(
 			(player) => {return player.hasFactory();}
 		);
 	}
 
-	hasDroid() {
+	hasDroid()
+	{
 		return this.players.some(
 			(player) => {return player.hasDroid();}
 		);
 	}
 
-	hasOnlyConstructor() {
+	hasOnlyConstructor()
+	{
 		return this.players.some(
 			(player) => {return player.hasOnlyConstructor();}
 		);
 	}
 
-	canReachOil() {
+	canReachOil()
+	{
 		return this.players.some(
 			(player) => {return player.canReachOil();}
 		);
 	}
 
-	canPlay() { // TODO skip check if no new events.
-		if (!this.activeGame()) {
+	canPlay()
+	{ // TODO skip check if no new events.
+		if (!this.activeGame())
+		{
 			return false;
 		}
-		if (!this.hasFactory() && !this.hasDroid()) {
+		if (!this.hasFactory() && !this.hasDroid())
+		{
 			return false;
 		}
-		if (!this.hasFactory() && this.hasOnlyConstructor() && !this.canReachOil()) {
+		if (!this.hasFactory() && this.hasOnlyConstructor() && !this.canReachOil())
+		{
 			return false;
 		}
 		return true;
 	}
 
-	updateState() {
-		if (this.state == STATE_contender && !this.canPlay()) {
+	updateState()
+	{
+		if (this.state == STATE_contender && !this.canPlay())
+		{
 			this.setState(STATE_loser);
 		}
 	}
 
-	setState(state) {
+	setState(state)
+	{
 		this.state = state;
 		this.players.forEach(
-			(player) => {
+			(player) =>
+			{
 				player.hud(this.state);
 				player.openMap();
 			}
 		);
 	}
 
-	isContender() {
+	isContender()
+	{
 		return this.state == STATE_contender;
 	}
 }
 
-function checkEndConditions() {
-	teams.forEach((team) => {
+function checkEndConditions()
+{
+	teams.forEach((team) =>
+	{
 		team.updateState();
 	});
-	const numTeamContender = teams.filter((team) => {
+	const numTeamContender = teams.filter((team) =>
+	{
 		return team.isContender();
 	}).length;
-	if (numTeamContender == 1) {// game end
-		teams.find((team) => {
+	if (numTeamContender == 1)
+	{// game end
+		teams.find((team) =>
+		{
 			return team.isContender();
 		}).setState(STATE_winner);
 	}
 }
 
 
-function inOneTeam(playnum, splaynum) {
+function inOneTeam(playnum, splaynum)
+{
 //	FIXME allianceExistsBetween dont correct if leave player in ALLIANCES_UNSHARED, ALLIANCES_TEAMS mode
 //	and  team is garbage in NO_ALLIANCES, ALLIANCES mode
 	if (
 		(alliancesType == ALLIANCES_UNSHARED || alliancesType == ALLIANCES_TEAMS) &&
     playerData[playnum].team != playerData[splaynum].team
-	) {
+	)
+	{
 		return false;
-	} else if (alliancesType == NO_ALLIANCES && playnum != splaynum) {
+	}
+	else if (alliancesType == NO_ALLIANCES && playnum != splaynum)
+	{
 		return false;
-	} else if (
+	}
+	else if (
 		alliancesType == ALLIANCES &&
     !allianceExistsBetween(playnum, splaynum)
-	) {
+	)
+	{
 		return false;
 	}
 
@@ -218,16 +270,21 @@ function inOneTeam(playnum, splaynum) {
 }
 
 
-function conditions_eventGameInit() {
+function conditions_eventGameInit()
+{
 	const inTeamPlayNums = new Array(maxPlayers).fill(false);
-	for (let playNum = 0; playNum < maxPlayers; playNum++) {
-		if (inTeamPlayNums[playNum] != false) {
+	for (let playNum = 0; playNum < maxPlayers; playNum++)
+	{
+		if (inTeamPlayNums[playNum] != false)
+		{
 			continue;
 		}
 		inTeamPlayNums[playNum] = true;
 		const members =[playNum];
-		for (let splayNum = 0; splayNum < maxPlayers; splayNum++) {
-			if ( inTeamPlayNums[splayNum] == false && inOneTeam(playNum, splayNum) == true) {
+		for (let splayNum = 0; splayNum < maxPlayers; splayNum++)
+		{
+			if ( inTeamPlayNums[splayNum] == false && inOneTeam(playNum, splayNum) == true)
+			{
 				members.push(splayNum);
 				inTeamPlayNums[splayNum] = true;
 			}
@@ -238,44 +295,57 @@ function conditions_eventGameInit() {
 	setTimer("activityAlert", 10*1000);
 }
 
-function activityAlert() {
-	if (playersTeam[selectedPlayer].state != STATE_contender) {
+function activityAlert()
+{
+	if (playersTeam[selectedPlayer].state != STATE_contender)
+	{
 		setMissionTime(-1);
 		removeTimer("activityAlert");
 		return;
 	}
-	if (playersTeam[selectedPlayer].lastActivity + IDLETIME / 2 < gameTime) {
+	if (playersTeam[selectedPlayer].lastActivity + IDLETIME / 2 < gameTime)
+	{
 		console(
 			_(
 				"Playing passively will lead to defeat. Actions that are considered: - unit building - research completion - construction of base structures (factories, power plants, laboratories, modules and oil derricks) - dealing damage")
 		);
-		if (getMissionTime() > IDLETIME) {
+		if (getMissionTime() > IDLETIME)
+		{
 			setMissionTime(
 				(playersTeam[selectedPlayer].lastActivity + IDLETIME - gameTime) / 1000);
 		}
 	}
-	if (playersTeam[selectedPlayer].lastActivity + IDLETIME / 2 > gameTime) {
+	if (playersTeam[selectedPlayer].lastActivity + IDLETIME / 2 > gameTime)
+	{
 		setMissionTime(-1); // remove timer widget
 	}
 }
 
-function conditions_eventDroidBuilt(droid) {
-	if (droid.player != scavengerPlayer) {
+function conditions_eventDroidBuilt(droid)
+{
+	if (droid.player != scavengerPlayer)
+	{
 		playersTeam[droid.player].lastActivity = gameTime;
 	}
 }
-function conditions_eventStructureBuilt(structure) {
-	if (structure.player != scavengerPlayer && BASESTRUCTS[structure.stattype] == true) {
+function conditions_eventStructureBuilt(structure)
+{
+	if (structure.player != scavengerPlayer && BASESTRUCTS[structure.stattype] == true)
+	{
 		playersTeam[structure.player].lastActivity = gameTime;
 	}
 }
-function conditions_eventResearched(research, structure, player) {
-	if (player != scavengerPlayer) {
+function conditions_eventResearched(research, structure, player)
+{
+	if (player != scavengerPlayer)
+	{
 		playersTeam[player].lastActivity = gameTime;
 	}
 }
-function conditions_eventAttacked(victim, attacker) {
-	if (attacker.player != scavengerPlayer) {
+function conditions_eventAttacked(victim, attacker)
+{
+	if (attacker.player != scavengerPlayer)
+	{
 		playersTeam[attacker.player].lastActivity = gameTime;
 	}
 }

--- a/data/mp/multiplay/script/rules/endconditions.js
+++ b/data/mp/multiplay/script/rules/endconditions.js
@@ -23,8 +23,8 @@ const SPOTTER = {
 	radius: (Math.sqrt(mapWidth * mapWidth + mapHeight * mapHeight) / 2) * 128,
 };
 
-var teams = []; // array class instance Team
-var playersTeam = new Array(maxPlayers); // array class instancePlayer
+var teams; // array class instance Team
+var playersTeam; // array class instancePlayer
 
 class Player
 {
@@ -276,6 +276,7 @@ function inOneTeam(playnum, splaynum)
 function createTeams()
 {
 	teams = [];
+	playersTeam = new Array(maxPlayers);
 	const inTeamPlayNums = new Array(maxPlayers).fill(false);
 	for (let playNum = 0; playNum < maxPlayers; playNum++)
 	{

--- a/data/mp/multiplay/script/rules/endconditions.js
+++ b/data/mp/multiplay/script/rules/endconditions.js
@@ -180,8 +180,8 @@ class Team
 		);
 	}
 
-	canPlay()
-	{ // TODO skip check if no new events.
+	canPlay() // TODO skip check if no new events.
+	{
 		if (!this.activeGame())
 		{
 			return false;
@@ -237,8 +237,8 @@ function checkEndConditions()
 	{
 		return team.isContender();
 	}).length;
-	if (numTeamContender === 1)
-	{// game end
+	if (numTeamContender === 1) // game end
+	{
 		teams.find((team) =>
 		{
 			return team.isContender();
@@ -246,11 +246,11 @@ function checkEndConditions()
 	}
 }
 
-
-function inOneTeam(playnum, splaynum)
-{
 //	FIXME allianceExistsBetween dont correct if leave player in ALLIANCES_UNSHARED, ALLIANCES_TEAMS mode
 //	and  team is garbage in NO_ALLIANCES, ALLIANCES mode
+function inOneTeam(playnum, splaynum)
+{
+
 	if (
 		(alliancesType === ALLIANCES_UNSHARED || alliancesType === ALLIANCES_TEAMS) &&
     playerData[playnum].team != playerData[splaynum].team
@@ -330,7 +330,7 @@ function conditions_eventGameInit()
 	setTimer("activityAlert", 10*1000);
 	if (alliancesType === ALLIANCES)
 	{
-		setTimer("createTeams", 60*1000); //rebild teams with ALLIANCES mode
+		setTimer("createTeams", 10*1000); //rebild teams with ALLIANCES mode
 	}
 }
 

--- a/data/mp/multiplay/script/rules/endconditions.js
+++ b/data/mp/multiplay/script/rules/endconditions.js
@@ -4,9 +4,7 @@ namespace("conditions_");
 const STATE_contender = "contender";
 const STATE_winner = "winner";
 const STATE_loser = "loser";
-const ENABLE_activity = (challenge != true && isMultiplayer === true); //The prohibition on passive play can interfere when playing against bots. There is no reason to end a fight earlier in PVE.
 const STRUCTS = [FACTORY, CYBORG_FACTORY, VTOL_FACTORY]; // structures in which you can continue to play
-// TODO remove HQ. The destruction of the HQ will hide the minimap.
 
 
 // The time that the player's inactivity is allowed. Actions are considered
@@ -16,6 +14,7 @@ const STRUCTS = [FACTORY, CYBORG_FACTORY, VTOL_FACTORY]; // structures in which 
 // - dealing damage
 const IDLETIME = 5 * 60 * 1000;
 const BASESTRUCTS = [FACTORY, CYBORG_FACTORY, VTOL_FACTORY, HQ, RESOURCE_EXTRACTOR, POWER_GEN, RESEARCH_LAB];
+const ENABLE_activity = (challenge != true && isMultiplayer === true); //The prohibition on passive play can interfere when playing against bots. There is no reason to end a fight earlier in PVE.
 
 const SPOTTER = {
 	x: mapWidth / 2,
@@ -182,7 +181,7 @@ class Team
 
 	canPlay() // TODO skip check if no new events.
 	{
-		if (!this.activeGame() && challenge != true)
+		if (!this.activeGame() && ENABLE_activity)
 		{
 			return false;
 		}

--- a/data/mp/multiplay/script/rules/endconditions.js
+++ b/data/mp/multiplay/script/rules/endconditions.js
@@ -208,6 +208,10 @@ class Team
 	setState(state)
 	{
 		this.state = state;
+		if (alliancesType == ALLIANCES)
+		{
+			return; // dont open map in ALLIANCES mode
+		}
 		this.players.forEach(
 			(player) =>
 			{
@@ -269,9 +273,9 @@ function inOneTeam(playnum, splaynum)
 	return true;
 }
 
-
-function conditions_eventGameInit()
+function createTeams()
 {
+	teams = [];
 	const inTeamPlayNums = new Array(maxPlayers).fill(false);
 	for (let playNum = 0; playNum < maxPlayers; playNum++)
 	{
@@ -292,7 +296,6 @@ function conditions_eventGameInit()
 		teams.push(new Team(members));
 	}
 
-	setTimer("activityAlert", 10*1000);
 }
 
 function activityAlert()
@@ -317,6 +320,16 @@ function activityAlert()
 	if (playersTeam[selectedPlayer].lastActivity + IDLETIME / 2 > gameTime)
 	{
 		setMissionTime(-1); // remove timer widget
+	}
+}
+
+function conditions_eventGameInit()
+{
+	createTeams();
+	setTimer("activityAlert", 10*1000);
+	if (alliancesType == ALLIANCES)
+	{
+		setTimer("createTeams", 60*1000); //rebild teams with ALLIANCES mode
 	}
 }
 

--- a/data/mp/multiplay/script/rules/endconditions.js
+++ b/data/mp/multiplay/script/rules/endconditions.js
@@ -182,7 +182,7 @@ class Team
 
 	canPlay() // TODO skip check if no new events.
 	{
-		if (!this.activeGame())
+		if (!this.activeGame() && challenge != true)
 		{
 			return false;
 		}
@@ -327,7 +327,10 @@ function activityAlert()
 function conditions_eventGameInit()
 {
 	createTeams();
-	setTimer("activityAlert", 10*1000);
+	if  (challenge != true)
+	{
+		setTimer("activityAlert", 10*1000);
+	}
 	if (alliancesType === ALLIANCES)
 	{
 		setTimer("createTeams", 10*1000); //rebild teams with ALLIANCES mode
@@ -341,28 +344,28 @@ function conditions_eventGameLoaded()
 
 function conditions_eventDroidBuilt(droid)
 {
-	if (droid.player != scavengerPlayer)
+	if (droid.player != scavengerPlayer && challenge != true)
 	{
 		playersTeam[droid.player].lastActivity = gameTime;
 	}
 }
 function conditions_eventStructureBuilt(structure)
 {
-	if (structure.player != scavengerPlayer && BASESTRUCTS.includes(structure.stattype) === true)
+	if (structure.player != scavengerPlayer && challenge != true && BASESTRUCTS.includes(structure.stattype) === true)
 	{
 		playersTeam[structure.player].lastActivity = gameTime;
 	}
 }
 function conditions_eventResearched(research, structure, player)
 {
-	if (player != scavengerPlayer)
+	if (player != scavengerPlayer && challenge != true)
 	{
 		playersTeam[player].lastActivity = gameTime;
 	}
 }
 function conditions_eventAttacked(victim, attacker)
 {
-	if (attacker.player != scavengerPlayer)
+	if (attacker.player != scavengerPlayer && challenge != true)
 	{
 		playersTeam[attacker.player].lastActivity = gameTime;
 	}

--- a/data/mp/multiplay/script/rules/endconditions.js
+++ b/data/mp/multiplay/script/rules/endconditions.js
@@ -334,6 +334,11 @@ function conditions_eventGameInit()
 	}
 }
 
+function conditions_eventGameLoaded()
+{
+	createTeams();
+}
+
 function conditions_eventDroidBuilt(droid)
 {
 	if (droid.player != scavengerPlayer)

--- a/data/mp/multiplay/script/rules/endconditions.js
+++ b/data/mp/multiplay/script/rules/endconditions.js
@@ -246,31 +246,30 @@ function checkEndConditions()
 	}
 }
 
-//	FIXME allianceExistsBetween dont correct if leave player in ALLIANCES_UNSHARED, ALLIANCES_TEAMS mode
+//	FIXME allianceExistsBetween() dont correct if leave player in ALLIANCES_UNSHARED, ALLIANCES_TEAMS mode
 //	and  team is garbage in NO_ALLIANCES, ALLIANCES mode
 function inOneTeam(playnum, splaynum)
 {
 
 	if (
 		(alliancesType === ALLIANCES_UNSHARED || alliancesType === ALLIANCES_TEAMS) &&
-    playerData[playnum].team != playerData[splaynum].team
+    playerData[playnum].team === playerData[splaynum].team
 	)
 	{
-		return false;
+		return true;
 	}
-	else if (alliancesType === NO_ALLIANCES && playnum != splaynum)
+	else if (alliancesType === NO_ALLIANCES && playnum === splaynum)
 	{
-		return false;
+		return true;
 	}
-	else if (
-		alliancesType === ALLIANCES &&
-    !allianceExistsBetween(playnum, splaynum)
-	)
+	//Victory in alliance mode is also personal.
+	//Alliances do not affect victory.
+	//allianceExistsBetween() is not used.
+	else if (alliancesType === ALLIANCES && playnum === splaynum)
 	{
-		return false;
+		return true;
 	}
-
-	return true;
+	return false;
 }
 
 function createTeams()
@@ -330,10 +329,6 @@ function conditions_eventGameInit()
 	if  (challenge != true)
 	{
 		setTimer("activityAlert", 10*1000);
-	}
-	if (alliancesType === ALLIANCES)
-	{
-		setTimer("createTeams", 10*1000); //rebild teams with ALLIANCES mode
 	}
 }
 

--- a/data/mp/multiplay/script/rules/endconditions.js
+++ b/data/mp/multiplay/script/rules/endconditions.js
@@ -4,7 +4,7 @@ namespace("conditions_");
 const STATE_contender = "contender";
 const STATE_winner = "winner";
 const STATE_loser = "loser";
-
+const ENABLE_activity = (challenge != true && isMultiplayer === true); //The prohibition on passive play can interfere when playing against bots. There is no reason to end a fight earlier in PVE.
 const STRUCTS = [FACTORY, CYBORG_FACTORY, VTOL_FACTORY]; // structures in which you can continue to play
 // TODO remove HQ. The destruction of the HQ will hide the minimap.
 
@@ -106,7 +106,7 @@ class Player
 		hackNetOn();
 	}
 
-	hud(state)
+	setState(state)
 	{
 		if (this.playNum != selectedPlayer)
 		{
@@ -215,7 +215,7 @@ class Team
 		this.players.forEach(
 			(player) =>
 			{
-				player.hud(this.state);
+				player.setState(this.state);
 				player.openMap();
 			}
 		);
@@ -326,7 +326,7 @@ function activityAlert()
 function conditions_eventGameInit()
 {
 	createTeams();
-	if  (challenge != true)
+	if  (ENABLE_activity)
 	{
 		setTimer("activityAlert", 10*1000);
 	}
@@ -339,29 +339,62 @@ function conditions_eventGameLoaded()
 
 function conditions_eventDroidBuilt(droid)
 {
-	if (droid.player != scavengerPlayer && challenge != true)
+	if (droid.player === scavengerPlayer || !ENABLE_activity)
+	{
+		return;
+	}
+	if (playersTeam[droid.player])
 	{
 		playersTeam[droid.player].lastActivity = gameTime;
 	}
+	else
+	{
+		debug ("Player", droid.player, "has no team");
+	}
+
 }
 function conditions_eventStructureBuilt(structure)
 {
-	if (structure.player != scavengerPlayer && challenge != true && BASESTRUCTS.includes(structure.stattype) === true)
+	if (structure.player === scavengerPlayer || !ENABLE_activity)
+	{
+		return;
+	}
+	if (BASESTRUCTS.includes(structure.stattype) === true && playersTeam[structure.player])
 	{
 		playersTeam[structure.player].lastActivity = gameTime;
+	}
+	else
+	{
+		debug ("Player", structure.player, "has no team");
 	}
 }
 function conditions_eventResearched(research, structure, player)
 {
-	if (player != scavengerPlayer && challenge != true)
+	if (player === scavengerPlayer || !ENABLE_activity)
+	{
+		return;
+	}
+	if (playersTeam[player])
 	{
 		playersTeam[player].lastActivity = gameTime;
+	}
+	else
+	{
+		debug ("Player", player, "has no team");
 	}
 }
 function conditions_eventAttacked(victim, attacker)
 {
-	if (attacker.player != scavengerPlayer && challenge != true)
+	if (attacker.player === scavengerPlayer || !ENABLE_activity)
+	{
+		return;
+	}
+	if (playersTeam[attacker.player])
 	{
 		playersTeam[attacker.player].lastActivity = gameTime;
+	}
+	else
+	{
+		debug ("Player", attacker.player, "has no team");
 	}
 }

--- a/data/mp/multiplay/script/rules/endconditions.js
+++ b/data/mp/multiplay/script/rules/endconditions.js
@@ -306,8 +306,7 @@ function activityAlert()
 	if (playersTeam[selectedPlayer].lastActivity + IDLETIME / 2 < gameTime)
 	{
 		console(
-			_(
-				"Playing passively will lead to defeat. Actions that are considered: - unit building - research completion - construction of base structures (factories, power plants, laboratories, modules and oil derricks) - dealing damage")
+			_("Playing passively will lead to defeat. Actions that are considered: - unit building - research completion - construction of base structures (factories, power plants, laboratories, modules and oil derricks) - dealing damage")
 		);
 		if (getMissionTime() > IDLETIME)
 		{

--- a/data/mp/multiplay/script/rules/endconditions.js
+++ b/data/mp/multiplay/script/rules/endconditions.js
@@ -15,7 +15,7 @@ const STRUCTS = [FACTORY, CYBORG_FACTORY, VTOL_FACTORY]; // structures in which 
 // - construction of base structures (factories, power plants, laboratories, modules and oil rigs)
 // - dealing damage
 const IDLETIME = 5 * 60 * 1000;
-const BASESTRUCTS = {[FACTORY]: true, [CYBORG_FACTORY]: true, [VTOL_FACTORY]: true, [HQ]: true, [RESOURCE_EXTRACTOR]: true, [POWER_GEN]: true, [RESEARCH_LAB]: true};
+const BASESTRUCTS = [FACTORY, CYBORG_FACTORY, VTOL_FACTORY, HQ, RESOURCE_EXTRACTOR, POWER_GEN, RESEARCH_LAB];
 
 const SPOTTER = {
 	x: mapWidth / 2,
@@ -199,7 +199,7 @@ class Team
 
 	updateState()
 	{
-		if (this.state == STATE_contender && !this.canPlay())
+		if (this.state === STATE_contender && !this.canPlay())
 		{
 			this.setState(STATE_loser);
 		}
@@ -208,7 +208,7 @@ class Team
 	setState(state)
 	{
 		this.state = state;
-		if (alliancesType == ALLIANCES)
+		if (alliancesType === ALLIANCES)
 		{
 			return; // dont open map in ALLIANCES mode
 		}
@@ -223,7 +223,7 @@ class Team
 
 	isContender()
 	{
-		return this.state == STATE_contender;
+		return this.state === STATE_contender;
 	}
 }
 
@@ -237,7 +237,7 @@ function checkEndConditions()
 	{
 		return team.isContender();
 	}).length;
-	if (numTeamContender == 1)
+	if (numTeamContender === 1)
 	{// game end
 		teams.find((team) =>
 		{
@@ -252,18 +252,18 @@ function inOneTeam(playnum, splaynum)
 //	FIXME allianceExistsBetween dont correct if leave player in ALLIANCES_UNSHARED, ALLIANCES_TEAMS mode
 //	and  team is garbage in NO_ALLIANCES, ALLIANCES mode
 	if (
-		(alliancesType == ALLIANCES_UNSHARED || alliancesType == ALLIANCES_TEAMS) &&
+		(alliancesType === ALLIANCES_UNSHARED || alliancesType === ALLIANCES_TEAMS) &&
     playerData[playnum].team != playerData[splaynum].team
 	)
 	{
 		return false;
 	}
-	else if (alliancesType == NO_ALLIANCES && playnum != splaynum)
+	else if (alliancesType === NO_ALLIANCES && playnum != splaynum)
 	{
 		return false;
 	}
 	else if (
-		alliancesType == ALLIANCES &&
+		alliancesType === ALLIANCES &&
     !allianceExistsBetween(playnum, splaynum)
 	)
 	{
@@ -280,7 +280,7 @@ function createTeams()
 	const inTeamPlayNums = new Array(maxPlayers).fill(false);
 	for (let playNum = 0; playNum < maxPlayers; playNum++)
 	{
-		if (inTeamPlayNums[playNum] != false)
+		if (inTeamPlayNums[playNum] === true)
 		{
 			continue;
 		}
@@ -288,7 +288,7 @@ function createTeams()
 		const members =[playNum];
 		for (let splayNum = 0; splayNum < maxPlayers; splayNum++)
 		{
-			if ( inTeamPlayNums[splayNum] == false && inOneTeam(playNum, splayNum) == true)
+			if ( inTeamPlayNums[splayNum] === false && inOneTeam(playNum, splayNum) === true)
 			{
 				members.push(splayNum);
 				inTeamPlayNums[splayNum] = true;
@@ -328,7 +328,7 @@ function conditions_eventGameInit()
 {
 	createTeams();
 	setTimer("activityAlert", 10*1000);
-	if (alliancesType == ALLIANCES)
+	if (alliancesType === ALLIANCES)
 	{
 		setTimer("createTeams", 60*1000); //rebild teams with ALLIANCES mode
 	}
@@ -343,7 +343,7 @@ function conditions_eventDroidBuilt(droid)
 }
 function conditions_eventStructureBuilt(structure)
 {
-	if (structure.player != scavengerPlayer && BASESTRUCTS[structure.stattype] == true)
+	if (structure.player != scavengerPlayer && BASESTRUCTS.includes(structure.stattype) === true)
 	{
 		playersTeam[structure.player].lastActivity = gameTime;
 	}


### PR DESCRIPTION
Giving visibility after defeat or victory requires synchronization.
To do this, I had to write a deterministic definition of the player's status.

At the same time, the following rules for determining the loser have been added.
- not an active game. If within 5 minutes the team does not perform useful actions, the team is considered a loser. (multiplayer only)
- there are no oil rigs available.
If the player does not have factories, only builders have units, the availability of an oil derrick is required.
- VTOL factories are enough to continue the game 

Notable features:
- the minimap will close after the destruction of the HQ
- the timer ```checkEndConditions()```  is started in another file
- victory in the "alliance" mode is personal

UPD
The changes will become part #2143. 