### PR TITLE
Fix names sometimes being set to "Commander".

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2425,7 +2425,7 @@ static void allocatePlayers()
 		NetPlay.players[i].ai = saveGameData.sNetPlay.players[i].ai;
 		NetPlay.players[i].difficulty = saveGameData.sNetPlay.players[i].difficulty;
 //		NetPlay.players[i].faction; // read and initialized by loadMainFile
-		sstrcpy(NetPlay.players[i].name, saveGameData.sNetPlay.players[i].name);
+		setPlayerName(i, saveGameData.sNetPlay.players[i].name);
 		NetPlay.players[i].position = saveGameData.sNetPlay.players[i].position;
 		if (NetPlay.players[i].difficulty == AIDifficulty::HUMAN || (game.type == LEVEL_TYPE::CAMPAIGN && i == 0))
 		{
@@ -4896,7 +4896,7 @@ static bool writeGameFile(const char *fileName, SDWORD saveType)
 	//version 34
 	for (i = 0; i < MAX_PLAYERS; ++i)
 	{
-		sstrcpy(saveGame.sPlayerName[i], getPlayerName(i));
+		sstrcpy(saveGame.sPlayerName[i], (!challengeActive && NetPlay.players[i].ai >= 0 && !NetPlay.players[i].allocated) ? getAIName(i) : getPlayerName(i));
 	}
 
 	//version 38

--- a/src/ingameop.cpp
+++ b/src/ingameop.cpp
@@ -485,6 +485,11 @@ bool intCloseInGameOptions(bool bPutUpLoadSave, bool bResetMissionWidgets)
 		widgDelete(psWScreen, INTINGAMEPOPUP);
 	}
 
+	if (!bPutUpLoadSave && !bResetMissionWidgets)
+	{
+		clearPlayerName(CLEAR_ALL_NAMES);
+	}
+
 	if (bPutUpLoadSave || keymapWasUp)
 	{
 		WIDGET *widg = widgGetFromID(psWScreen, INTINGAMEOP);

--- a/src/multiint.cpp
+++ b/src/multiint.cpp
@@ -1914,7 +1914,7 @@ void WzMultiplayerOptionsTitleUI::openAiChooser(uint32_t player)
 				ASSERT_OR_RETURN(, pStrongPtr.operator bool(), "WzMultiplayerOptionsTitleUI no longer exists");
 				NetPlay.players[player].isSpectator = false;
 				NetPlay.players[player].ai = aiIdx;
-				sstrcpy(NetPlay.players[player].name, getAIName(player));
+				setPlayerName(player, getAIName(player));
 				NetPlay.players[player].difficulty = AIDifficulty::MEDIUM;
 				NETBroadcastPlayerInfo(player);
 				resetReadyStatus(false);
@@ -3288,7 +3288,7 @@ static SwapPlayerIndexesResult recvSwapPlayerIndexes(NETQUEUE queue, const std::
 		debug(LOG_NET, "NET_PLAYER_SWAP_INDEX received for me. Switching from player %" PRIu32 " to player %" PRIu32 "", oldPlayerIndex,newPlayerIndex);
 
 		NetPlay.players[selectedPlayer].allocated = true;
-		sstrcpy(NetPlay.players[selectedPlayer].name, sPlayer);
+		setPlayerName(selectedPlayer, sPlayer);
 		NetPlay.players[selectedPlayer].heartbeat = true;
 
 		// Ensure name is set properly (and re-send to host)
@@ -4149,7 +4149,7 @@ public:
 								NetPlay.players[i].ai = NetPlay.players[player].ai;
 								NetPlay.players[i].isSpectator = NetPlay.players[player].isSpectator;
 								NetPlay.players[i].difficulty = NetPlay.players[player].difficulty;
-								sstrcpy(NetPlay.players[i].name, getAIName(player));
+								setPlayerName(i, getAIName(player));
 								NETBroadcastPlayerInfo(i);
 							}
 						}
@@ -5430,11 +5430,11 @@ static void loadMapPlayerSettings(WzConfig& ini)
 		/* Try finding a name field, if not found use AI names for AI players if in SP skirmish */
 		if (ini.contains("name"))
 		{
-			sstrcpy(NetPlay.players[i].name, ini.value("name").toWzString().toUtf8().c_str());
+			setPlayerName(i, ini.value("name").toWzString().toUtf8().c_str());
 		}
 		else if (!NetPlay.bComms && i != selectedPlayer)
 		{
-			sstrcpy(NetPlay.players[i].name, getAIName(i));
+			setPlayerName(i, getAIName(i));
 		}
 
 		NetPlay.players[i].position = MAX_PLAYERS;  // Invalid value, fix later.
@@ -5556,7 +5556,7 @@ static void resetPlayerConfiguration(const bool bShouldResetLocal = false)
 		{
 			NetPlay.players[playerIndex].difficulty =  AIDifficulty::DISABLED;
 			NetPlay.players[playerIndex].ai = AI_OPEN;
-			NetPlay.players[playerIndex].name[0] = '\0';
+			clearPlayerName(playerIndex);
 			if (playerIndex == PLAYER_FEATURE)
 			{
 				NetPlay.players[playerIndex].ai = AI_CLOSED;
@@ -5568,7 +5568,7 @@ static void resetPlayerConfiguration(const bool bShouldResetLocal = false)
 			NetPlay.players[playerIndex].ai = 0;
 
 			/* ensure all players have a name in One Player Skirmish games */
-			sstrcpy(NetPlay.players[playerIndex].name, getAIName(playerIndex));
+			setPlayerName(playerIndex, getAIName(playerIndex));
 		}
 	}
 
@@ -5576,7 +5576,7 @@ static void resetPlayerConfiguration(const bool bShouldResetLocal = false)
 		std::swap(NetPlay.players[selectedPlayer].position, NetPlay.players[selectedPlayerPosition].position);
 	}
 
-	sstrcpy(NetPlay.players[selectedPlayer].name, sPlayer);
+	setPlayerName(selectedPlayer, sPlayer);
 
 	if (selectedPlayer < MAX_PLAYERS)
 	{
@@ -7572,7 +7572,7 @@ void displayPlayer(WIDGET *psWidget, UDWORD xOffset, UDWORD yOffset)
 			}
 			break;
 		case AI_CLOSED: sstrcpy(aitext, _("Closed")); break;
-		default: sstrcpy(aitext, NetPlay.players[j].name ); break;
+		default: sstrcpy(aitext, getPlayerName(j)); break;
 		}
 		cache.wzMainText.setText(aitext, font_regular);
 		cache.wzMainText.render(x + nameX, y + 22, textColor);
@@ -8459,7 +8459,7 @@ bool WZGameReplayOptionsHandler::restoreOptions(const nlohmann::json& object, Em
 	size_t replaySpectatorIndex = NetPlay.players.size() - 1;
 	NET_InitPlayer(replaySpectatorIndex, false);  // re-init everything
 	NetPlay.players[replaySpectatorIndex].allocated = true;
-	sstrcpy(NetPlay.players[replaySpectatorIndex].name, "Replay Viewer");
+	setPlayerName(replaySpectatorIndex, "Replay Viewer");
 	NetPlay.players[replaySpectatorIndex].isSpectator = true;
 
 	selectedPlayer = replaySpectatorIndex;

--- a/src/multimenu.cpp
+++ b/src/multimenu.cpp
@@ -837,7 +837,7 @@ private:
 	{
 		auto nameGrid = std::make_shared<GridLayout>();
 		char name[128];
-		ssprintf(name, "%d: %s", NetPlay.players[player].position, getPlayerName(player));
+		ssprintf(name, "%d: %s", NetPlay.players[player].position, getPlayerName(player, true));
 		nameGrid->place({0, 1, false}, {0}, std::make_shared<MultiMenuDroidView>(player));
 		auto nameLabel = makeLabel(name);
 		nameGrid->place({1}, {0}, nameLabel);

--- a/src/multiopt.cpp
+++ b/src/multiopt.cpp
@@ -473,7 +473,7 @@ bool hostCampaign(const char *SessionName, char *hostPlayerName, bool spectatorH
 	}
 
 	NetPlay.players[selectedPlayer].ready = false;
-	sstrcpy(NetPlay.players[selectedPlayer].name, hostPlayerName);
+	setPlayerName(selectedPlayer, hostPlayerName);
 
 	ingame.localJoiningInProgress = true;
 	ingame.JoiningInProgress[selectedPlayer] = true;

--- a/src/multiplay.h
+++ b/src/multiplay.h
@@ -203,6 +203,8 @@ extern UBYTE bDisplayMultiJoiningStatus;	// draw load progress?
 #define TECH_4					4
 
 #define MAX_KICK_REASON			80			// max array size for the reason your kicking someone
+
+#define CLEAR_ALL_NAMES         -1
 // functions
 
 WZ_DECL_WARN_UNUSED_RESULT BASE_OBJECT		*IdToPointer(UDWORD id, UDWORD player);
@@ -212,8 +214,9 @@ WZ_DECL_WARN_UNUSED_RESULT DROID			*IdToMissionDroid(UDWORD id, UDWORD player);
 WZ_DECL_WARN_UNUSED_RESULT FEATURE		*IdToFeature(UDWORD id, UDWORD player);
 WZ_DECL_WARN_UNUSED_RESULT DROID_TEMPLATE	*IdToTemplate(UDWORD tempId, UDWORD player);
 
-const char *getPlayerName(int player);
+const char *getPlayerName(int player, bool storedName = false);
 bool setPlayerName(int player, const char *sName);
+void clearPlayerName(unsigned int player);
 const char *getPlayerColourName(int player);
 bool isHumanPlayer(int player);				//to tell if the player is a computer or not.
 bool myResponsibility(int player);


### PR DESCRIPTION
This should prevent player names being displayed "commander" after games end via kicking or them leaving. I also made sure to carefully restore the names of AI in skirmish/challenges.

Only problem is that the player display (`displayMultiPlayer()`) of the Intel map on multiplayer will now have a kicked/disconnected player/bot name disappear because we are now resetting the _real_ name. Need some way to store the name or cache it somehow until the Intel map gets closed. :thinking: 

Should also fix #1161
And fix #2635 