### PR TITLE
Respect Hold & Fire at will

### DIFF
--- a/src/action.cpp
+++ b/src/action.cpp
@@ -1132,9 +1132,14 @@ void actionUpdateDroid(DROID *psDroid)
 					psDroid->action = DACTION_NONE;
 				}
 			}
-			else
+			else if (secondaryGetState(psDroid, DSO_HALTTYPE) != DSS_HALT_HOLD)
 			{
 				psDroid->action = DACTION_MOVETOATTACK;	// out of range - chase it
+			}
+			else
+			{
+				psDroid->order.psObj = nullptr;
+				psDroid->action = DACTION_NONE;
 			}
 		}
 
@@ -2222,11 +2227,10 @@ static void actionDroidBase(DROID *psDroid, DROID_ACTION_DATA *psAction)
 					moveTurnDroid(psDroid, psDroid->psActionTarget[0]->pos.x, psDroid->psActionTarget[0]->pos.y);
 				}
 			}
-			else if (order->type != DORDER_HOLD)
+			else if (order->type != DORDER_HOLD && secondaryGetState(psDroid, DSO_HALTTYPE) != DSS_HALT_HOLD)
 			{
 				int pbx = 0;
 				int pby = 0;
-
 				/* direct fire - try and extend the range */
 				psDroid->action = DACTION_MOVETOATTACK;
 				actionCalcPullBackPoint(psDroid, psAction->psObj, &pbx, &pby);
@@ -2236,12 +2240,16 @@ static void actionDroidBase(DROID *psDroid, DROID_ACTION_DATA *psAction)
 				turnOffMultiMsg(false);
 			}
 		}
-		else if (order->type != DORDER_HOLD) // approach closer?
+		else if (order->type != DORDER_HOLD && secondaryGetState(psDroid, DSO_HALTTYPE) != DSS_HALT_HOLD) // approach closer?
 		{
 			psDroid->action = DACTION_MOVETOATTACK;
 			turnOffMultiMsg(true);
 			moveDroidTo(psDroid, psAction->psObj->pos.x, psAction->psObj->pos.y);
 			turnOffMultiMsg(false);
+		}
+		else if (order->type != DORDER_HOLD && secondaryGetState(psDroid, DSO_HALTTYPE) == DSS_HALT_HOLD)
+		{
+			psDroid->action = DACTION_ATTACK;
 		}
 		break;
 

--- a/src/ai.cpp
+++ b/src/ai.cpp
@@ -831,11 +831,6 @@ bool aiChooseTarget(BASE_OBJECT *psObj, BASE_OBJECT **ppsTarget, int weapon_slot
 		*targetOrigin = ORIGIN_UNKNOWN;
 	}
 
-	if (psObj->type == OBJ_DROID && secondaryGetState((DROID *)psObj, DSO_HALTTYPE) == DSS_HALT_HOLD)
-	{
-		return false;	// Not sure why we check this here...
-	}
-
 	ASSERT_OR_RETURN(false, (unsigned)weapon_slot < psObj->numWeaps, "Invalid weapon selected");
 
 	/* See if there is a something in range */


### PR DESCRIPTION
This PR better separates movement control from fire control.

Before changes:
- unit is "Hold Position":
	- when a target was designated, units will follow if the target goes out of sight.
	- when designating an out of reach target, units will start moving closer.
- unit is "Hold Fire:"
	- when attacking a target, pressing "Hold Fire" will not stop attack, but pressing first "Hold fire" and then "Hold Position" *will* stop shooting. 
	- when attacking a target choosen automatically, like above, pressing "Hold Position" will stop shooting
- unit is "Fire at will":
	- when ennemy units appear, indirect fire unit will not attack, despite "Fire at will" order.


After applying this PR:
- unit is "Hold Position":
	- if target is lost out of sight/never was in sight, unit will *not* move, unless an explicit move/GUARD/PURSUE order has been given
- unit is "Fire at will": 
	- when ennemy units appear, indirect fire unit will start shooting, just like with GUARD order, or like direct fire units.
- unit is anything but "Hold fire":
	- pressing "Hold fire" will actually stop fire

EDIT: 
- PR applied: https://youtu.be/ZNjo2_UuX3M
- Master: https://youtu.be/cG86AwjPcM0