### PR TITLE
refresh intorder on hotkey press

### DIFF
--- a/src/keybind.cpp
+++ b/src/keybind.cpp
@@ -1878,6 +1878,7 @@ MappableFunction kf_OrderDroid(const DroidOrderType order)
 				orderDroid(psDroid, order, ModeQueue);
 			}
 		}
+		intRefreshOrder();
 	};
 }
 
@@ -1914,6 +1915,7 @@ static void kfsf_SetSelectedDroidsState(SECONDARY_ORDER sec, SECONDARY_STATE sta
 			secondarySetState(psDroid, sec, state);
 		}
 	}
+	intRefreshOrder();
 }
 
 // --------------------------------------------------------------------------


### PR DESCRIPTION
This little menu is not updated when using hotkeys, one needs to re-select
This PR makes it refresh automatically [*].

[*] EXCEPT when setting HOLD POSITION with hotkeys : it's still impossible to set it PURSUE/GUARD (mouse works fine).
This is because HOLD_POSITION actually creates a primary order instead of secondary (`keyconfig.cpp:  line 143`) 

Quite weird, I see no reason it has been implemented this way. I am not changing it now, but this whole DORDER_HOLD looks fishy.. DSS_HALT_HOLD should be enough

![image](https://user-images.githubusercontent.com/25161465/126397917-f29de680-c91b-4f7a-8be3-96c463d6f8a1.png)
