### PR TITLE
Add a small delay for video skipping

### DIFF
--- a/src/loop.cpp
+++ b/src/loop.cpp
@@ -105,6 +105,7 @@ size_t loopPolyCount;
  */
 static bool paused = false;
 static bool video = false;
+static unsigned short int skipCounter = 0;
 
 //holds which pause is valid at any one time
 struct PAUSE_STATE
@@ -679,8 +680,13 @@ void videoLoop()
 	videoFinished = !seq_UpdateFullScreenVideo(nullptr);
 	pie_ScreenFlip(CLEAR_BLACK);
 
+	if (skipCounter <= SEQUENCE_MIN_SKIP_DELAY)
+	{
+		skipCounter += 1; // "time" is stopped so we will count via loop iterations.
+	}
+
 	// should we stop playing?
-	if (videoFinished || keyPressed(KEY_ESC) || mouseReleased(MOUSE_LMB))
+	if (videoFinished || (skipCounter > SEQUENCE_MIN_SKIP_DELAY && (keyPressed(KEY_ESC) || mouseReleased(MOUSE_LMB))))
 	{
 		seq_StopFullScreenVideo();
 
@@ -709,6 +715,7 @@ void videoLoop()
 
 void loop_SetVideoPlaybackMode()
 {
+	skipCounter = 0;
 	videoMode += 1;
 	paused = true;
 	video = true;
@@ -723,6 +730,7 @@ void loop_SetVideoPlaybackMode()
 
 void loop_ClearVideoPlaybackMode()
 {
+	skipCounter = 0;
 	videoMode -= 1;
 	paused = false;
 	video = false;

--- a/src/seqdisp.h
+++ b/src/seqdisp.h
@@ -35,6 +35,8 @@
 #define  SEQUENCE_KILL 3//stop
 #define  SEQUENCE_HOLD 4//play once and hold last frame
 
+#define  SEQUENCE_MIN_SKIP_DELAY 75 //amount of loops before skipping is allowed
+
 enum SEQ_TEXT_POSITIONING
 {
 	/**


### PR DESCRIPTION
So somebody does not skip a video by accident. The time constraint is short enough to not be bothersome if one wishes to skip.

Closes #1858.

This does NOT account for somebody chowing down on chips at their computer and furiously clicking the mouse and not paying too much attention after a little over 1 second of a video starting.