### PR TITLE
fix some memleaks

### DIFF
--- a/src/advvis.cpp
+++ b/src/advvis.cpp
@@ -47,8 +47,9 @@ void	avUpdateTiles()
 	MAPTILE *psTile;
 
 	/* Go through the tiles */
-	for (psTile = psMapTiles; i < len; i++)
+	for (; i < len; i++)
 	{
+		psTile = &psMapTiles[i];
 		maxLevel = psTile->illumination;
 
 		if (psTile->level > MIN_ILLUM || psTile->tileExploredBits & playermask)	// seen
@@ -67,7 +68,6 @@ void	avUpdateTiles()
 				psTile->level = MIN(psTile->level + increment, maxLevel);
 			}
 		}
-		psTile++;
 	}
 }
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2269,7 +2269,7 @@ bool loadGame(const char *pGameToLoad, bool keepObjects, bool freeMem, bool User
 			syncDebug("crc(droids) = 0x%08x", data->crcSumDroids(0));
 			syncDebug("crc(features) = 0x%08x", data->crcSumFeatures(0));
 		}
-		if (!mapLoadFromWzMapData(*(mapData.get())))
+		if (!mapLoadFromWzMapData(mapData))
 		{
 			debug(LOG_ERROR, "Failed to process map data from path: %s", aFileName);
 			return false;

--- a/src/map.h
+++ b/src/map.h
@@ -85,9 +85,10 @@ struct MAPTILE
 
 /* The size and contents of the map */
 extern SDWORD	mapWidth, mapHeight;
-extern MAPTILE *psMapTiles;
+
+extern std::unique_ptr<MAPTILE[]> psMapTiles;
 extern float waterLevel;
-extern GROUND_TYPE *psGroundTypes;
+extern std::unique_ptr<GROUND_TYPE[]> psGroundTypes;
 extern int numGroundTypes;
 extern char *tilesetDir;
 
@@ -111,8 +112,8 @@ extern char *tilesetDir;
 #define AUX_DANGERMAP	2
 #define AUX_MAX		3
 
-extern uint8_t *psBlockMap[AUX_MAX];
-extern uint8_t *psAuxMap[MAX_PLAYERS + AUX_MAX];	// yes, we waste one element... eyes wide open... makes API nicer
+extern std::unique_ptr<uint8_t[]> psBlockMap[AUX_MAX];
+extern std::unique_ptr<uint8_t[]> psAuxMap[MAX_PLAYERS + AUX_MAX];	// yes, we waste one element... eyes wide open... makes API nicer
 
 /// Find aux bitfield for a given tile
 WZ_DECL_ALWAYS_INLINE static inline uint8_t auxTile(int x, int y, int player)
@@ -129,8 +130,8 @@ WZ_DECL_ALWAYS_INLINE static inline uint8_t blockTile(int x, int y, int slot)
 /// Store a shadow copy of a player's aux map for use in threaded calculations
 static inline void auxMapStore(int player, int slot)
 {
-	memcpy(psBlockMap[slot], psBlockMap[0], sizeof(*psBlockMap[player]) * mapWidth * mapHeight);
-	memcpy(psAuxMap[MAX_PLAYERS + slot], psAuxMap[player], sizeof(*psAuxMap[player]) * mapWidth * mapHeight);
+	memcpy(psBlockMap[slot].get(), psBlockMap[0].get(), sizeof(uint8_t) * mapWidth * mapHeight);
+	memcpy(psAuxMap[MAX_PLAYERS + slot].get(), psAuxMap[player].get(), sizeof(uint8_t) * mapWidth * mapHeight);
 }
 
 /// Restore selected fields from the shadow copy of a player's aux map (ignoring the block map)
@@ -307,9 +308,6 @@ static inline unsigned char terrainType(const MAPTILE *tile)
 
 /* The size and contents of the map */
 extern SDWORD	mapWidth, mapHeight;
-extern MAPTILE *psMapTiles;
-
-extern GROUND_TYPE *psGroundTypes;
 extern int numGroundTypes;
 
 /* Additional tile <-> world coordinate overloads */
@@ -351,7 +349,7 @@ bool mapShutdown();
 /* Load the map data */
 bool mapLoad(char const *filename);
 struct ScriptMapData;
-bool mapLoadFromWzMapData(WzMap::MapData& mapData);
+bool mapLoadFromWzMapData(std::shared_ptr<WzMap::MapData> mapData);
 
 class WzMapPhysFSIO : public WzMap::IOProvider
 {

--- a/src/mission.cpp
+++ b/src/mission.cpp
@@ -254,11 +254,11 @@ void initMission()
 	mission.mapWidth = 0;
 	for (auto &i : mission.psBlockMap)
 	{
-		i = nullptr;
+		i.reset();
 	}
 	for (auto &i : mission.psAuxMap)
 	{
-		i = nullptr;
+		i.reset();
 	}
 
 	//init all the landing zones
@@ -317,20 +317,16 @@ bool missionShutDown()
 		mission.apsSensorList[0] = nullptr;
 		mission.apsOilList[0] = nullptr;
 
-		psMapTiles = mission.psMapTiles;
+		psMapTiles = std::move(mission.psMapTiles);
 		mapWidth = mission.mapWidth;
 		mapHeight = mission.mapHeight;
 		for (int i = 0; i < ARRAY_SIZE(mission.psBlockMap); ++i)
 		{
-			free(psBlockMap[i]);
-			psBlockMap[i] = mission.psBlockMap[i];
-			mission.psBlockMap[i] = nullptr;
+			psBlockMap[i] = std::move(mission.psBlockMap[i]);
 		}
 		for (int i = 0; i < ARRAY_SIZE(mission.psAuxMap); ++i)
 		{
-			free(psAuxMap[i]);
-			psAuxMap[i] = mission.psAuxMap[i];
-			mission.psAuxMap[i] = nullptr;
+			psAuxMap[i] = std::move(mission.psAuxMap[i]);
 		}
 		std::swap(mission.psGateways, gwGetGateways());
 	}
@@ -669,16 +665,16 @@ static void saveMissionData()
 	audio_StopAll();
 
 	//save the mission data
-	mission.psMapTiles = psMapTiles;
+	mission.psMapTiles = std::move(psMapTiles);
 	mission.mapWidth = mapWidth;
 	mission.mapHeight = mapHeight;
 	for (int i = 0; i < ARRAY_SIZE(mission.psBlockMap); ++i)
 	{
-		mission.psBlockMap[i] = psBlockMap[i];
+		mission.psBlockMap[i] = std::move(psBlockMap[i]);
 	}
 	for (int i = 0; i < ARRAY_SIZE(mission.psAuxMap); ++i)
 	{
-		mission.psAuxMap[i] = psAuxMap[i];
+		mission.psAuxMap[i] = std::move(psAuxMap[i]);
 	}
 	mission.scrollMinX = scrollMinX;
 	mission.scrollMinY = scrollMinY;
@@ -824,19 +820,17 @@ void restoreMissionData()
 	mission.apsSensorList[0] = nullptr;
 	//swap mission data over
 
-	psMapTiles = mission.psMapTiles;
+	psMapTiles = std::move(mission.psMapTiles);
 
 	mapWidth = mission.mapWidth;
 	mapHeight = mission.mapHeight;
 	for (int i = 0; i < ARRAY_SIZE(mission.psBlockMap); ++i)
 	{
-		psBlockMap[i] = mission.psBlockMap[i];
-		mission.psBlockMap[i] = nullptr;
+		psBlockMap[i] = std::move(mission.psBlockMap[i]);
 	}
 	for (int i = 0; i < ARRAY_SIZE(mission.psAuxMap); ++i)
 	{
-		psAuxMap[i] = mission.psAuxMap[i];
-		mission.psAuxMap[i] = nullptr;
+		psAuxMap[i] = std::move(mission.psAuxMap[i]);
 	}
 	scrollMinX = mission.scrollMinX;
 	scrollMinY = mission.scrollMinY;
@@ -1332,6 +1326,7 @@ void swapMissionPointers()
 	}
 	for (int i = 0; i < ARRAY_SIZE(mission.psAuxMap); ++i)
 	{
+		
 		std::swap(psAuxMap[i],   mission.psAuxMap[i]);
 	}
 	//swap gateway zones

--- a/src/missiondef.h
+++ b/src/missiondef.h
@@ -53,11 +53,11 @@ struct LANDING_ZONE
 struct MISSION
 {
 	LEVEL_TYPE			type;							//defines which start and end functions to use - see levels_type in levels.h
-	MAPTILE				*psMapTiles;					//the original mapTiles
+	std::unique_ptr<MAPTILE[]>		psMapTiles;					//the original mapTiles
 	int32_t                         mapWidth;                       //the original mapWidth
 	int32_t                         mapHeight;                      //the original mapHeight
-	uint8_t                        *psBlockMap[AUX_MAX];
-	uint8_t                        *psAuxMap[MAX_PLAYERS + AUX_MAX];
+	std::unique_ptr<uint8_t[]>      psBlockMap[AUX_MAX];
+	std::unique_ptr<uint8_t[]>		psAuxMap[MAX_PLAYERS + AUX_MAX];
 	GATEWAY_LIST                    psGateways;                     //the gateway list
 	int32_t                         scrollMinX;                     //scroll coords for original map
 	int32_t                         scrollMinY;

--- a/src/projectile.cpp
+++ b/src/projectile.cpp
@@ -97,7 +97,7 @@ static const uint32_t ProjectileTrackerID = 0xdead0000;
 static uint32_t projectileTrackerIDIncrement = 0;
 
 /* The list of projectiles in play */
-static std::vector<PROJECTILE *> psProjectileList;
+static std::vector<PROJECTILE*> psProjectileList;
 
 /* The next projectile to give out in the proj_First / proj_Next methods */
 static ProjectileIterator psProjectileNext;
@@ -211,6 +211,10 @@ proj_InitSystem()
 void
 proj_FreeAllProjectiles()
 {
+	for (auto proj: psProjectileList)
+	{
+		delete proj;
+	}
 	psProjectileList.clear();
 	psProjectileNext = psProjectileList.end();
 }


### PR DESCRIPTION
Fixes some of (many) memory leaks, detected by address sanitizer. 
Some of them happen when you keep (re)loading a save, or just going from one level to the next on campaign, one happened with every projectile fired

Mostly just converts c-style arrays into managed `unique_ptr<.. []>`