### PR TITLE
Fix -Wmaybe-uninitialized

### DIFF
--- a/src/astar.cpp
+++ b/src/astar.cpp
@@ -57,7 +57,7 @@
 /// A coordinate.
 struct PathCoord
 {
-	PathCoord() {}
+	PathCoord(): x(0), y(0) {}
 	PathCoord(int16_t x_, int16_t y_) : x(x_), y(y_) {}
 	bool operator ==(PathCoord const &z) const
 	{


### PR DESCRIPTION
Not sure what happened now, somehow this wasn't caught before

This only fails on Release builds, because `... otherwise GCC does not keep track of the state of variables. ` (https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html)
EDIT: using g++ (SUSE Linux) 11.1.1 20210625 [revision 62bbb113ae68a7e724255e17143520735bcb9ec9]