### PR TITLE
openURLInBrowser improvements

### DIFF
--- a/lib/framework/wzapp.h
+++ b/lib/framework/wzapp.h
@@ -117,6 +117,10 @@ void wzDelay(unsigned int delay);	//delay in ms
 void StartTextInput(void* pTextInputRequester);
 void StopTextInput(void* pTextInputResigner);
 bool isInTextInputMode();
+
+// NOTE: wzBackendAttemptOpenURL should *not* be called directly - instead, call openURLInBrowser() from urlhelpers.h
+bool wzBackendAttemptOpenURL(const char *url);
+
 // Thread related
 WZ_THREAD *wzThreadCreate(int (*threadFunc)(void *), void *data);
 unsigned long wzThreadID(WZ_THREAD *thread);

--- a/lib/sdl/main_sdl.cpp
+++ b/lib/sdl/main_sdl.cpp
@@ -2922,3 +2922,19 @@ void wzShutdown()
 		copied_argc = 0;
 	}
 }
+
+// NOTE: wzBackendAttemptOpenURL should *not* be called directly - instead, call openURLInBrowser() from urlhelpers.h
+bool wzBackendAttemptOpenURL(const char *url)
+{
+#if SDL_VERSION_ATLEAST(2, 0, 14) // SDL >= 2.0.14
+	// Can use SDL_OpenURL to support many (not all) platforms if run-time SDL library is also >= 2.0.14
+	SDL_version linked_sdl_version;
+	SDL_GetVersion(&linked_sdl_version);
+	if ((linked_sdl_version.major > 2) || (linked_sdl_version.major == 2 && (linked_sdl_version.minor > 0 || (linked_sdl_version.minor == 0 && linked_sdl_version.patch >= 14))))
+	{
+		return (SDL_OpenURL(url) == 0);
+	}
+#endif
+	// SDL_OpenURL requires SDL >= 2.0.14
+	return false;
+}

--- a/src/updatemanager.cpp
+++ b/src/updatemanager.cpp
@@ -232,7 +232,7 @@ WzUpdateManager::ProcessResult WzUpdateManager::processUpdateJSONFile(const json
 							updateLink = updateLinkJson.get<std::string>();
 						}
 					}
-					bool hasValidURLPrefix = urlHasHTTPorHTTPSPrefix(updateLink.c_str());
+					bool hasValidURLPrefix = urlHasAcceptableProtocol(updateLink.c_str());
 					if (!validSignature || !validExpiry || updateLink.empty() || !hasValidURLPrefix)
 					{
 						// use default update link

--- a/src/urlhelpers.cpp
+++ b/src/urlhelpers.cpp
@@ -59,11 +59,15 @@
 
 #include <vector>
 
+#if defined(WZ_OS_WIN)
+static const std::vector<std::string> validLinkPrefixes = { "http://", "https://", "ms-windows-store://" };
+#else
 static const std::vector<std::string> validLinkPrefixes = { "http://", "https://" };
+#endif
 
-bool urlHasHTTPorHTTPSPrefix(char const *url)
+bool urlHasAcceptableProtocol(char const *url)
 {
-	// Verify URL starts with http:// or https://
+	// Verify URL starts with a validLinkPrefixes (examples: http:// or https:// )
 	bool bValidLinkPrefix = false;
 	for (const auto& validLinkPrefix : validLinkPrefixes)
 	{
@@ -127,8 +131,8 @@ bool openURLInBrowser(char const *url)
 {
 	if (!url || !*url) return false;
 
-	// Verify URL starts with http:// or https://
-	if (!urlHasHTTPorHTTPSPrefix(url))
+	// Verify URL starts with an acceptable protocol - ex: http:// or https://
+	if (!urlHasAcceptableProtocol(url))
 	{
 		debug(LOG_ERROR, "Rejecting attempt to open link with URL: %s", url);
 		return false;

--- a/src/urlhelpers.h
+++ b/src/urlhelpers.h
@@ -25,7 +25,7 @@
 
 bool openURLInBrowser(char const *url);
 std::string urlEncode(const char* urlFragment);
-bool urlHasHTTPorHTTPSPrefix(char const *url);
+bool urlHasAcceptableProtocol(char const *url);
 
 bool openFolderInDefaultFileManager(const char* path);
 


### PR DESCRIPTION
- Attempt using `SDL_OpenURL` if SDL >= 2.0.14 (this API supports additional platforms)
- Accept `ms-windows-store` protocol on Windows