### PR TITLE
Fix statistic table overflow

### DIFF
--- a/lib/widget/alignment.cpp
+++ b/lib/widget/alignment.cpp
@@ -1,0 +1,76 @@
+/*
+	This file is part of Warzone 2100.
+	Copyright (C) 2021  Warzone 2100 Project
+
+	Warzone 2100 is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+
+	Warzone 2100 is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with Warzone 2100; if not, write to the Free Software
+	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+
+#include "lib/ivis_opengl/bitimage.h"
+#include "lib/ivis_opengl/pieblitfunc.h"
+#include "widget.h"
+#include "alignment.h"
+
+std::shared_ptr<AlignmentWidget> Alignment::wrap(std::shared_ptr<WIDGET> widget)
+{
+    auto wrap = std::make_shared<AlignmentWidget>(*this);
+    wrap->attach(widget);
+    return wrap;
+}
+
+void AlignmentWidget::geometryChanged()
+{
+    if (children().empty())
+    {
+        return;
+    }
+
+    auto &child = children().front();
+    auto childLeft = 0;
+    if (alignment.horizontal == Alignment::Horizontal::Center)
+    {
+        childLeft = std::max(0, width() - child->idealWidth()) / 2;
+    }
+    else if (alignment.horizontal == Alignment::Horizontal::Right)
+    {
+        childLeft = std::max(0, width() - child->idealWidth());
+    }
+
+    auto childTop = 0;
+    if (alignment.vertical == Alignment::Vertical::Center)
+    {
+        childTop = std::max(0, height() - child->idealHeight()) / 2;
+    }
+    else if (alignment.vertical == Alignment::Vertical::Bottom)
+    {
+        childTop = std::max(0, height() - child->idealHeight());
+    }
+
+    child->setGeometry(
+        childLeft,
+        childTop,
+        std::min(width(), child->idealWidth()),
+        std::min(height(), child->idealHeight())
+    );
+}
+
+int32_t AlignmentWidget::idealWidth()
+{
+    return children().empty() ? WIDGET::idealWidth(): children().front()->idealWidth();
+}
+
+int32_t AlignmentWidget::idealHeight()
+{
+    return children().empty() ? WIDGET::idealHeight(): children().front()->idealHeight();
+}

--- a/lib/widget/gridlayout.cpp
+++ b/lib/widget/gridlayout.cpp
@@ -52,9 +52,10 @@ nonstd::optional<std::vector<uint32_t>> GridLayout::getScrollSnapOffsets()
 	return scrollSnapOffsets;
 }
 
-void GridLayout::run(W_CONTEXT *context)
+void GridLayout::displayRecursive(WidgetGraphicsContext const &context)
 {
 	updateLayout();
+	WIDGET::displayRecursive(context);
 }
 
 void GridLayout::geometryChanged()
@@ -71,8 +72,8 @@ void GridLayout::updateLayout()
 
 	layoutDirty = false;
 
-	auto columnOffsets = getColumnAllocator().calculate_offsets(width());
-	auto rowOffsets = getRowAllocator().calculate_offsets(height());
+	columnOffsets = getColumnAllocator().calculate_offsets(width());
+	rowOffsets = getRowAllocator().calculate_offsets(height());
 	scrollSnapOffsets.resize(rowOffsets.size());
 	size_t i = 0;
 	for (auto offset: rowOffsets)
@@ -88,6 +89,18 @@ void GridLayout::updateLayout()
 		auto bottom = rowOffsets[placement.row.start + placement.row.span];
 		placement.widget->setGeometry(left, top, right - left, bottom - top);
 	}
+}
+
+const std::map<uint32_t, int32_t> &GridLayout::getColumnOffsets()
+{
+	updateLayout();
+	return columnOffsets;
+}
+
+const std::map<uint32_t, int32_t> &GridLayout::getRowOffsets()
+{
+	updateLayout();
+	return rowOffsets;
 }
 
 void GridLayout::invalidateLayout()

--- a/lib/widget/gridlayout.h
+++ b/lib/widget/gridlayout.h
@@ -43,9 +43,11 @@ public:
 	int32_t idealWidth() override;
 	int32_t idealHeight() override;
 	nonstd::optional<std::vector<uint32_t>> getScrollSnapOffsets() override;
+	const std::map<uint32_t, int32_t> &getColumnOffsets();
+	const std::map<uint32_t, int32_t> &getRowOffsets();
 
 protected:
-	void run(W_CONTEXT *context) override;
+	void displayRecursive(WidgetGraphicsContext const &context) override;
 	void geometryChanged() override;
 
 private:
@@ -66,6 +68,8 @@ private:
 	std::vector<Placement> placements;
 	bool layoutDirty = false;
 	std::vector<uint32_t> scrollSnapOffsets;
+	std::map<uint32_t, int32_t> columnOffsets;
+	std::map<uint32_t, int32_t> rowOffsets;
 };
 
 #endif // __INCLUDED_LIB_WIDGET_GRIDLAYOUT_H__

--- a/lib/widget/jsontable.cpp
+++ b/lib/widget/jsontable.cpp
@@ -643,20 +643,20 @@ void JSONTableWidget::displayOptionsOverlay(const std::shared_ptr<WIDGET>& psPar
 
 	// Position the pop-over form
 	std::weak_ptr<WIDGET> weakParent = psParent;
-	optionsPopOver->setCalcLayout([weakParent](WIDGET *psWidget, unsigned int, unsigned int, unsigned int newScreenWidth, unsigned int newScreenHeight){
+	optionsPopOver->setCalcLayout([weakParent](WIDGET *psWidget) {
 		auto psParent = weakParent.lock();
 		ASSERT_OR_RETURN(, psParent != nullptr, "parent is null");
 		// (Ideally, with its left aligned with the left side of the "parent" widget, but ensure full visibility on-screen)
 		int popOverX0 = psParent->screenPosX();
-		if (popOverX0 + psWidget->width() > newScreenWidth)
+		if (popOverX0 + psWidget->width() > screenWidth)
 		{
-			popOverX0 = newScreenWidth - psWidget->width();
+			popOverX0 = screenWidth - psWidget->width();
 		}
 		// (Ideally, with its top aligned with the bottom of the "parent" widget, but ensure full visibility on-screen)
 		int popOverY0 = psParent->screenPosY() + psParent->height();
-		if (popOverY0 + psWidget->height() > newScreenHeight)
+		if (popOverY0 + psWidget->height() > screenHeight)
 		{
-			popOverY0 = newScreenHeight - psWidget->height();
+			popOverY0 = screenHeight - psWidget->height();
 		}
 		psWidget->move(popOverX0, popOverY0);
 	});

--- a/lib/widget/margin.cpp
+++ b/lib/widget/margin.cpp
@@ -1,0 +1,53 @@
+/*
+	This file is part of Warzone 2100.
+	Copyright (C) 2021  Warzone 2100 Project
+
+	Warzone 2100 is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+
+	Warzone 2100 is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with Warzone 2100; if not, write to the Free Software
+	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+
+#include "lib/widget/margin.h"
+
+std::shared_ptr<MarginWidget> Margin::wrap(std::shared_ptr<WIDGET> widget)
+{
+    auto wrap = std::make_shared<MarginWidget>(*this);
+    wrap->attach(widget);
+    return wrap;
+}
+
+void MarginWidget::geometryChanged()
+{
+	if (!children().empty())
+	{
+		auto &child = children().front();
+		child->setGeometry(
+			margin.left,
+			margin.top,
+			std::max(0, width() - margin.left - margin.right),
+			std::max(0, height() - margin.top - margin.bottom)
+		);
+	}
+}
+
+int32_t MarginWidget::idealWidth()
+{
+	auto innerWidth = children().empty() ? 0: children().front()->idealWidth();
+	return innerWidth + margin.left + margin.right;
+}
+
+int32_t MarginWidget::idealHeight()
+{
+	auto innerHeight = children().empty() ? 0: children().front()->idealHeight();
+	return innerHeight + margin.top + margin.bottom;
+}

--- a/lib/widget/margin.h
+++ b/lib/widget/margin.h
@@ -22,53 +22,40 @@
 
 #include "lib/widget/widget.h"
 
+class MarginWidget;
+struct Margin
+{
+public:
+    Margin(int32_t top, int32_t right, int32_t bottom, int32_t left)
+        : top(top)
+        , right(right)
+        , bottom(bottom)
+        , left(left)
+        {}
+
+    Margin(int32_t vertical, int32_t horizontal): Margin(vertical, horizontal, vertical, horizontal) {}
+    explicit Margin(int32_t value): Margin(value, value) {}
+
+    std::shared_ptr<MarginWidget> wrap(std::shared_ptr<WIDGET> widget);
+
+    int32_t top;
+    int32_t right;
+    int32_t bottom;
+    int32_t left;
+};
+
 class MarginWidget: public WIDGET
 {
-private:
-    struct Margin
-    {
-        int32_t top;
-        int32_t right;
-        int32_t bottom;
-        int32_t left;
-    };
-
 public:
-	MarginWidget(int32_t top, int32_t right, int32_t bottom, int32_t left)
-		: WIDGET()
-        , margin({top, right, bottom, left})
+	explicit MarginWidget(Margin margin): WIDGET(), margin(margin)
 	{
         setTransparentToClicks(true);
 	}
 
-	MarginWidget(uint32_t value): MarginWidget(value, value, value, value) {}
-
 protected:
-    void geometryChanged() override
-    {
-        if (!children().empty())
-        {
-            auto &child = children().front();
-            child->setGeometry(
-                margin.left,
-                margin.top,
-                std::max(0, width() - margin.left - margin.right),
-                std::max(0, height() - margin.top - margin.bottom)
-            );
-        }
-    }
-
-    int32_t idealWidth() override
-    {
-        auto innerWidth = children().empty() ? 0: children().front()->idealWidth();
-        return innerWidth + margin.left + margin.right;
-    }
-
-    int32_t idealHeight() override
-    {
-        auto innerHeight = children().empty() ? 0: children().front()->idealHeight();
-        return innerHeight + margin.top + margin.bottom;
-    }
+    void geometryChanged() override;
+    int32_t idealWidth() override;
+    int32_t idealHeight() override;
 
 private:
     Margin margin;

--- a/lib/widget/minsize.cpp
+++ b/lib/widget/minsize.cpp
@@ -1,0 +1,54 @@
+/*
+	This file is part of Warzone 2100.
+	Copyright (C) 2021  Warzone 2100 Project
+
+	Warzone 2100 is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+
+	Warzone 2100 is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with Warzone 2100; if not, write to the Free Software
+	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+
+#include "lib/ivis_opengl/bitimage.h"
+#include "lib/ivis_opengl/pieblitfunc.h"
+#include "widget.h"
+#include "minsize.h"
+
+std::shared_ptr<MinSizeWidget> MinSize::wrap(std::shared_ptr<WIDGET> widget)
+{
+    auto wrap = std::make_shared<MinSizeWidget>(*this);
+    wrap->attach(widget);
+    return wrap;
+}
+
+void MinSizeWidget::geometryChanged()
+{
+    if (!children().empty())
+    {
+        children().front()->setGeometry(0, 0, width(), height());
+    }
+}
+
+int32_t MinSizeWidget::idealWidth()
+{
+    return std::max(
+		minSize.width.value_or(0),
+		children().empty() ? 0 : children().front()->idealWidth()
+	);
+}
+
+int32_t MinSizeWidget::idealHeight()
+{
+    return std::max(
+		minSize.height.value_or(0),
+		children().empty() ? 0 : children().front()->idealHeight()
+	);
+}

--- a/lib/widget/minsize.h
+++ b/lib/widget/minsize.h
@@ -17,50 +17,42 @@
 	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
 */
 
-#ifndef __INCLUDED_LIB_WIDGET_ALIGNMENT_H__
-#define __INCLUDED_LIB_WIDGET_ALIGNMENT_H__
+#ifndef __INCLUDED_LIB_WIDGET_MINSIZE_H__
+#define __INCLUDED_LIB_WIDGET_MINSIZE_H__
 
 #include "lib/ivis_opengl/bitimage.h"
 #include "lib/ivis_opengl/pieblitfunc.h"
 #include "widget.h"
+#include <optional-lite/optional.hpp>
 
-class AlignmentWidget;
-struct Alignment
+class MinSizeWidget;
+struct MinSize
 {
-    enum class Vertical
-    {
-        Top,
-        Center,
-        Bottom
-    };
-
-    enum class Horizontal
-    {
-        Left,
-        Center,
-        Right
-    };
-
-    Alignment(Vertical vertical, Horizontal horizontal)
-        : vertical(vertical)
-        , horizontal(horizontal)
+    MinSize(nonstd::optional<int32_t> width, nonstd::optional<int32_t> height)
+        : width(width)
+        , height(height)
         {}
 
-    static Alignment center()
-    {
-        return { Vertical::Center, Horizontal::Center };
-    }
+	static MinSize minWidth(int32_t width)
+	{
+		return MinSize(width, nonstd::nullopt);
+	}
 
-    std::shared_ptr<AlignmentWidget> wrap(std::shared_ptr<WIDGET> widget);
+	static MinSize minHeight(int32_t height)
+	{
+		return MinSize(nonstd::nullopt, height);
+	}
 
-    Vertical vertical;
-    Horizontal horizontal;
+    std::shared_ptr<MinSizeWidget> wrap(std::shared_ptr<WIDGET> widget);
+
+    nonstd::optional<int32_t> width;
+    nonstd::optional<int32_t> height;
 };
 
-class AlignmentWidget: public WIDGET
+class MinSizeWidget: public WIDGET
 {
 public:
-    explicit AlignmentWidget(Alignment alignment): alignment(alignment) {}
+    explicit MinSizeWidget(MinSize minSize): minSize(minSize) {}
 
 protected:
     void geometryChanged() override;
@@ -68,7 +60,7 @@ protected:
     int32_t idealHeight() override;
 
 private:
-    Alignment alignment;
+    MinSize minSize;
 };
 
-#endif // __INCLUDED_LIB_WIDGET_ALIGNMENT_H__
+#endif // __INCLUDED_LIB_WIDGET_MINSIZE_H__

--- a/lib/widget/widgbase.h
+++ b/lib/widget/widgbase.h
@@ -58,12 +58,12 @@ typedef void (*WIDGET_CALLBACK)(WIDGET *psWidget, W_CONTEXT *psContext);
 typedef void (*WIDGET_AUDIOCALLBACK)(int AudioID);
 
 /* The optional "calc layout" callback function, to support runtime layout recalculation */
-typedef std::function<void (WIDGET *psWidget, unsigned int oldScreenWidth, unsigned int oldScreenHeight, unsigned int newScreenWidth, unsigned int newScreenHeight)> WIDGET_CALCLAYOUT_FUNC;
+typedef std::function<void (WIDGET *psWidget)> WIDGET_CALCLAYOUT_FUNC;
 
 // To avoid typing, use the following define to construct a lambda for WIDGET_CALCLAYOUT_FUNC
 // psWidget is the widget
 // The { } are still required (for clarity).
-#define LAMBDA_CALCLAYOUT_SIMPLE(x) [](WIDGET *psWidget, unsigned int, unsigned int, unsigned int, unsigned int) x
+#define LAMBDA_CALCLAYOUT_SIMPLE(x) [](WIDGET *psWidget) x
 
 /* The optional "onDelete" callback function */
 typedef std::function<void (WIDGET *psWidget)> WIDGET_ONDELETE_FUNC;

--- a/lib/widget/widget.cpp
+++ b/lib/widget/widget.cpp
@@ -446,7 +446,7 @@ void WIDGET::callCalcLayout()
 {
 	if (calcLayout)
 	{
-		calcLayout(this, screenWidth, screenHeight, screenWidth, screenHeight);
+		calcLayout(this);
 	}
 #ifdef DEBUG
 //	// FOR DEBUGGING:

--- a/src/frontend.cpp
+++ b/src/frontend.cpp
@@ -981,9 +981,8 @@ void startAudioAndZoomOptionsMenu()
 	WIDGET *parent = widgGetFromID(psWScreen, FRONTEND_BOTFORM);
 
 	auto addSliderWrap = [](std::shared_ptr<WIDGET> widget) {
-		auto alignment = std::make_shared<AlignmentWidget>(VerticalAlignment::Center, HorizontalAlignment::Left);
-		alignment->attach(addMargin(widget));
-		return alignment;
+		Alignment sliderAlignment(Alignment::Vertical::Center, Alignment::Horizontal::Left);
+		return sliderAlignment.wrap(addMargin(widget));
 	};
 
 	auto grid = std::make_shared<GridLayout>();
@@ -1436,9 +1435,7 @@ static std::shared_ptr<WIDGET> makeResolutionDropdown()
 	for (auto resolution: screenResolutionsModel)
 	{
 		auto item = makeTextButton(0, ScreenResolutionsModel::resolutionString(resolution), 0);
-		auto padding = std::make_shared<MarginWidget>(0, paddingSize, 0, paddingSize);
-		padding->attach(item);
-		dropdown->addItem(padding);
+		dropdown->addItem(Margin(0, paddingSize).wrap(item));
 	}
 
 	auto closestResolution = screenResolutionsModel.findResolutionClosestToCurrent();
@@ -1454,9 +1451,7 @@ static std::shared_ptr<WIDGET> makeResolutionDropdown()
 		}
 	});
 
-	auto margin = std::make_shared<MarginWidget>(0, -paddingSize, 0, -paddingSize);
-	margin->attach(dropdown);
-	return margin;
+	return Margin(0, -paddingSize).wrap(dropdown);
 }
 
 void startVideoOptionsMenu()
@@ -2462,9 +2457,7 @@ static std::shared_ptr<W_BUTTON> makeTextButton(UDWORD id, const std::string &tx
 
 static std::shared_ptr<WIDGET> addMargin(std::shared_ptr<WIDGET> widget)
 {
-	auto margin = std::make_shared<MarginWidget>(0, 20, 0, 20);
-	margin->attach(widget);
-	return margin;
+	return Margin(0, 20).wrap(widget);
 }
 
 void addTextButton(UDWORD id,  UDWORD PosX, UDWORD PosY, const std::string &txt, unsigned int style)

--- a/src/ingameop.cpp
+++ b/src/ingameop.cpp
@@ -188,7 +188,7 @@ static bool addAudioOptions()
 
 	addIGTextButton(INTINGAMEOP_RESUME, INTINGAMEOP_1_X, INTINGAMEOPAUTO_Y_LINE(row), INTINGAMEOP_SW_W, _("Resume Game"), OPALIGN);
 
-	ingameOp->setCalcLayout([row](WIDGET *psWidget, unsigned int, unsigned int, unsigned int, unsigned int){
+	ingameOp->setCalcLayout([row](WIDGET *psWidget) {
 		psWidget->setGeometry(INTINGAMEOP2_X, INTINGAMEOPAUTO_Y(row), INTINGAMEOP2_W, INTINGAMEOPAUTO_H(row));
 	});
 
@@ -322,7 +322,7 @@ static bool startInGameConfirmQuit()
 	row++;
 	addIGTextButton(INTINGAMEOP_GO_BACK, INTINGAMEOP_2_X, INTINGAMEOPAUTO_Y_LINE(row), INTINGAMEOP4_OP_W, _("Back"), OPALIGN);
 
-	ingameOp->setCalcLayout([row](WIDGET* psWidget, unsigned int, unsigned int, unsigned int, unsigned int) {
+	ingameOp->setCalcLayout([row](WIDGET* psWidget) {
 		psWidget->setGeometry(INTINGAMEOP4_X, INTINGAMEOPAUTO_Y(row), INTINGAMEOP4_W, INTINGAMEOPAUTO_H(row));
 	});
 
@@ -584,7 +584,7 @@ static bool startIGOptionsMenu()
 
 	addIGTextButton(INTINGAMEOP_RESUME, INTINGAMEOP_1_X, INTINGAMEOPAUTO_Y_LINE(row), INTINGAMEOP_OP_W, _("Resume Game"), OPALIGN);
 
-	ingameOp->setCalcLayout([row](WIDGET *psWidget, unsigned int, unsigned int, unsigned int, unsigned int){
+	ingameOp->setCalcLayout([row](WIDGET *psWidget) {
 		psWidget->setGeometry(INTINGAMEOP_X, INTINGAMEOPAUTO_Y(row), INTINGAMEOP_W, INTINGAMEOPAUTO_H(row));
 	});
 
@@ -638,7 +638,7 @@ static bool startIGGraphicsOptionsMenu()
 
 	addIGTextButton(INTINGAMEOP_RESUME, INTINGAMEOP_1_X, INTINGAMEOPAUTO_Y_LINE(row), INTINGAMEOP_SW_W, _("Resume Game"), OPALIGN);
 
-	ingameOp->setCalcLayout([row](WIDGET *psWidget, unsigned int, unsigned int, unsigned int, unsigned int){
+	ingameOp->setCalcLayout([row](WIDGET *psWidget) {
 		psWidget->setGeometry(INTINGAMEOP2_X, INTINGAMEOPAUTO_Y(row), INTINGAMEOP2_W, INTINGAMEOPAUTO_H(row));
 	});
 
@@ -745,7 +745,7 @@ static bool startIGVideoOptionsMenu()
 	// Quit/return
 	addIGTextButton(INTINGAMEOP_RESUME, INTINGAMEOP_1_X, INTINGAMEOPAUTO_Y_LINE(row), INTINGAMEOP_SW_W, _("Resume Game"), OPALIGN);
 
-	ingameOp->setCalcLayout([row](WIDGET *psWidget, unsigned int, unsigned int, unsigned int, unsigned int){
+	ingameOp->setCalcLayout([row](WIDGET *psWidget) {
 		psWidget->setGeometry(INTINGAMEOP2_X, INTINGAMEOPAUTO_Y(row), INTINGAMEOP2_W, INTINGAMEOPAUTO_H(row));
 	});
 
@@ -833,7 +833,7 @@ static bool startIGMouseOptionsMenu()
 	// Quit/return
 	addIGTextButton(INTINGAMEOP_RESUME, INTINGAMEOP_1_X, INTINGAMEOPAUTO_Y_LINE(row), INTINGAMEOP_SW_W, _("Resume Game"), OPALIGN);
 
-	ingameOp->setCalcLayout([row](WIDGET *psWidget, unsigned int, unsigned int, unsigned int, unsigned int){
+	ingameOp->setCalcLayout([row](WIDGET *psWidget) {
 		psWidget->setGeometry(INTINGAMEOP2_X, INTINGAMEOPAUTO_Y(row), INTINGAMEOP2_W, INTINGAMEOPAUTO_H(row));
 	});
 

--- a/src/intorder.cpp
+++ b/src/intorder.cpp
@@ -811,7 +811,7 @@ bool intAddOrder(BASE_OBJECT *psObj)
 
 	// Now we know how many orders there are we can resize the form accordingly.
 	int newHeight = Height + CLOSE_HEIGHT + ORDER_BUTGAP;
-	orderForm->setCalcLayout([newHeight](WIDGET *psWidget, unsigned int, unsigned int, unsigned int, unsigned int) {
+	orderForm->setCalcLayout([newHeight](WIDGET *psWidget) {
 		psWidget->setGeometry(psWidget->x(), ORDER_BOTTOMY - newHeight, psWidget->width(), newHeight);
 	});
 

--- a/src/multiint.cpp
+++ b/src/multiint.cpp
@@ -1080,7 +1080,7 @@ static void addInlineChooserBlueForm(const std::shared_ptr<W_SCREEN> &psScreen, 
 	sFormInit.pDisplay =  intDisplayFeBox;
 
 	std::weak_ptr<WIDGET> psWeakParent(psParent->shared_from_this());
-	sFormInit.calcLayout = [x, y, psWeakParent](WIDGET *psWidget, unsigned int, unsigned int, unsigned int, unsigned int){
+	sFormInit.calcLayout = [x, y, psWeakParent](WIDGET *psWidget) {
 		if (auto psParent = psWeakParent.lock())
 		{
 			psWidget->move(psParent->screenPosX() + x, psParent->screenPosY() + y);
@@ -1608,7 +1608,7 @@ IntFormAnimated* WzMultiplayerOptionsTitleUI::initRightSideChooser(const char* s
 	auto aiForm = std::make_shared<IntFormAnimated>(false);
 	chooserParent->attach(aiForm);
 	aiForm->id = MULTIOP_AI_FORM;
-	aiForm->setCalcLayout([psWeakParent](WIDGET *psWidget, unsigned int, unsigned int, unsigned int, unsigned int){
+	aiForm->setCalcLayout([psWeakParent](WIDGET *psWidget) {
 		if (auto psParent = psWeakParent.lock())
 		{
 			psWidget->setGeometry(psParent->screenPosX() + MULTIOP_PLAYERSX, psParent->screenPosY() + MULTIOP_PLAYERSY, MULTIOP_PLAYERSW, MULTIOP_PLAYERSH);
@@ -1618,7 +1618,7 @@ IntFormAnimated* WzMultiplayerOptionsTitleUI::initRightSideChooser(const char* s
 	W_LABEL *psSideTextLabel = addSideText(psInlineChooserOverlayScreen, MULTIOP_INLINE_OVERLAY_ROOT_FRM, FRONTEND_SIDETEXT2, MULTIOP_PLAYERSX - 3, MULTIOP_PLAYERSY, sideText);
 	if (psSideTextLabel)
 	{
-		psSideTextLabel->setCalcLayout([psWeakParent](WIDGET *psWidget, unsigned int, unsigned int, unsigned int, unsigned int){
+		psSideTextLabel->setCalcLayout([psWeakParent](WIDGET *psWidget) {
 			if (auto psParent = psWeakParent.lock())
 			{
 				psWidget->setGeometry(psParent->screenPosX() + MULTIOP_PLAYERSX - 3, psParent->screenPosY() + MULTIOP_PLAYERSY, MULTIOP_PLAYERSW, MULTIOP_PLAYERSH);
@@ -1796,7 +1796,7 @@ void WzMultiplayerOptionsTitleUI::openAiChooser(uint32_t player)
 	int aiListEntryHeight = sButInit.height;
 	int aiListEntryWidth = sButInit.width;
 	int aiListHeight = aiListEntryHeight * (NetPlay.bComms ? 7 : 8);
-	pAIScrollableList->setCalcLayout([aiListStartXPos, aiListStartYPos, aiListEntryWidth, aiListHeight](WIDGET *psWidget, unsigned int, unsigned int, unsigned int, unsigned int){
+	pAIScrollableList->setCalcLayout([aiListStartXPos, aiListStartYPos, aiListEntryWidth, aiListHeight](WIDGET *psWidget) {
 		psWidget->setGeometry(aiListStartXPos, aiListStartYPos, aiListEntryWidth, aiListHeight);
 	});
 
@@ -4634,14 +4634,14 @@ static void printHostHelpMessagesToConsole()
 	displayRoomNotifyMessage(buf);
 }
 
-void calcBackdropLayoutForMultiplayerOptionsTitleUI(WIDGET *psWidget, unsigned int, unsigned int, unsigned int newScreenWidth, unsigned int newScreenHeight)
+void calcBackdropLayoutForMultiplayerOptionsTitleUI(WIDGET *psWidget)
 {
-	auto height = newScreenHeight - 80;
+	auto height = screenHeight - 80;
 	CLIP(height, HIDDEN_FRONTEND_HEIGHT, HIDDEN_FRONTEND_WIDTH);
 
 	psWidget->setGeometry(
-		((newScreenWidth - HIDDEN_FRONTEND_WIDTH) / 2),
-		((newScreenHeight - height) / 2),
+		((screenWidth - HIDDEN_FRONTEND_WIDTH) / 2),
+		((screenHeight - height) / 2),
 		HIDDEN_FRONTEND_WIDTH - 1,
 		height
 	);

--- a/src/multiint.h
+++ b/src/multiint.h
@@ -43,7 +43,7 @@
 
 // WzMultiplayerOptionsTitleUI is in titleui.h to prevent dependency explosions
 
-void calcBackdropLayoutForMultiplayerOptionsTitleUI(WIDGET *psWidget, unsigned int, unsigned int, unsigned int, unsigned int);
+void calcBackdropLayoutForMultiplayerOptionsTitleUI(WIDGET *psWidget);
 void readAIs();	///< step 1, load AI definition files
 void loadMultiScripts();	///< step 2, load the actual AI scripts
 const char *getAIName(int player);	///< only run this -after- readAIs() is called

--- a/src/musicmanager.cpp
+++ b/src/musicmanager.cpp
@@ -696,7 +696,7 @@ static void addTrackList(WIDGET *parent, bool ingame)
 	auto pTracksScrollableList = ScrollableListWidget::make();
 	parent->attach(pTracksScrollableList);
 	pTracksScrollableList->setBackgroundColor(WZCOL_TRANSPARENT_BOX);
-	pTracksScrollableList->setCalcLayout([ingame](WIDGET *psWidget, unsigned int, unsigned int, unsigned int, unsigned int){
+	pTracksScrollableList->setCalcLayout([ingame](WIDGET *psWidget) {
 		psWidget->setGeometry(GetTrackListStartXPos(ingame), TL_Y, TL_ENTRYW, GetNumVisibleTracks() * TL_ENTRYH);
 	});
 
@@ -813,7 +813,7 @@ protected:
 		sButInit.id			= id;
 		sButInit.y			= y;
 		sButInit.pText		= text;
-		sButInit.calcLayout = [y] (WIDGET *psWidget, unsigned int, unsigned int, unsigned int, unsigned int) {
+		sButInit.calcLayout = [y] (WIDGET *psWidget) {
 			psWidget->move(0, y);
 		};
 

--- a/src/wzscriptdebug.cpp
+++ b/src/wzscriptdebug.cpp
@@ -452,7 +452,7 @@ nlohmann::ordered_json componentToString(const COMPONENT_STATS *psStats, int pla
 	case COMP_NUMCOMPONENTS:
 		ASSERT_OR_RETURN(key, "%s", "Invalid component: COMP_NUMCOMPONENTS!");
 		break;
-		// no "default" case because modern compiler plus "-Werror" 
+		// no "default" case because modern compiler plus "-Werror"
 		// will raise error if a switch is forgotten
 	}
 	return key;
@@ -611,7 +611,7 @@ public:
 			}
 		});
 		int contextDropdownX0 = selectedPlayerLabel->x() + selectedPlayerLabel->width() + ACTION_BUTTON_SPACING;
-		panel->playersDropdown->setCalcLayout([contextDropdownX0, bottomOfButtonRows](WIDGET *psWidget, unsigned int, unsigned int, unsigned int, unsigned int){
+		panel->playersDropdown->setCalcLayout([contextDropdownX0, bottomOfButtonRows](WIDGET *psWidget) {
 			auto psParent = psWidget->parent();
 			ASSERT_OR_RETURN(, psParent != nullptr, "No parent");
 			psWidget->setGeometry(contextDropdownX0, bottomOfButtonRows, psParent->width() - contextDropdownX0 - ACTION_BUTTON_SPACING, TAB_BUTTONS_HEIGHT);
@@ -722,7 +722,7 @@ public:
 			panel->aiPlayerDropdown->addItem(button);
 		}
 		panel->aiPlayerDropdown->setSelectedIndex(0);
-		panel->aiPlayerDropdown->setCalcLayout([maxButtonTextWidth](WIDGET *psWidget, unsigned int, unsigned int, unsigned int, unsigned int){
+		panel->aiPlayerDropdown->setCalcLayout([maxButtonTextWidth](WIDGET *psWidget) {
 			auto pAiPlayerDropdown = static_cast<DropdownWidget *>(psWidget);
 			auto psParent = std::dynamic_pointer_cast<WzMainPanel>(psWidget->parent());
 			ASSERT_OR_RETURN(, psParent != nullptr, "No parent");
@@ -745,7 +745,7 @@ public:
 			panel->aiDropdown->addItem(button);
 		}
 		panel->aiDropdown->setSelectedIndex(0);
-		panel->aiDropdown->setCalcLayout([](WIDGET *psWidget, unsigned int, unsigned int, unsigned int, unsigned int){
+		panel->aiDropdown->setCalcLayout([](WIDGET *psWidget) {
 			auto pAiDropdown = static_cast<DropdownWidget *>(psWidget);
 			auto psParent = std::dynamic_pointer_cast<WzMainPanel>(psWidget->parent());
 			ASSERT_OR_RETURN(, psParent != nullptr, "No parent");
@@ -878,7 +878,7 @@ public:
 			}
 		});
 		int contextDropdownX0 = contextLabel->x() + contextLabel->width();
-		result->contextDropdown->setCalcLayout([contextDropdownX0](WIDGET *psWidget, unsigned int, unsigned int, unsigned int, unsigned int){
+		result->contextDropdown->setCalcLayout([contextDropdownX0](WIDGET *psWidget) {
 			auto psParent = std::dynamic_pointer_cast<WzScriptContextsPanel>(psWidget->parent());
 			ASSERT_OR_RETURN(, psParent != nullptr, "No parent");
 			psWidget->setGeometry(contextDropdownX0, 0, psParent->width() - contextDropdownX0, TAB_BUTTONS_HEIGHT);
@@ -1047,7 +1047,7 @@ public:
 			}
 		});
 		int contextDropdownX0 = contextLabel->x() + contextLabel->width();
-		result->playersDropdown->setCalcLayout([contextDropdownX0](WIDGET *psWidget, unsigned int, unsigned int, unsigned int, unsigned int){
+		result->playersDropdown->setCalcLayout([contextDropdownX0](WIDGET *psWidget) {
 			auto psParent = std::dynamic_pointer_cast<WzScriptPlayersPanel>(psWidget->parent());
 			ASSERT_OR_RETURN(, psParent != nullptr, "No parent");
 			psWidget->setGeometry(contextDropdownX0, 0, psParent->width() - contextDropdownX0, TAB_BUTTONS_HEIGHT);
@@ -1176,7 +1176,7 @@ public:
 			}
 		});
 		int contextDropdownX0 = contextLabel->x() + contextLabel->width();
-		result->contextDropdown->setCalcLayout([contextDropdownX0](WIDGET *psWidget, unsigned int, unsigned int, unsigned int, unsigned int){
+		result->contextDropdown->setCalcLayout([contextDropdownX0](WIDGET *psWidget) {
 			auto psParent = std::dynamic_pointer_cast<WzScriptTriggersPanel>(psWidget->parent());
 			ASSERT_OR_RETURN(, psParent != nullptr, "No parent");
 			psWidget->setGeometry(contextDropdownX0, 0, psParent->updateButton->x() - contextDropdownX0 - ACTION_BUTTON_SPACING, TAB_BUTTONS_HEIGHT);
@@ -1713,7 +1713,7 @@ private:
 		});
 		int previousButtonRight = (previousButton) ? previousButton->x() + previousButton->width() : 0;
 		button->move((previousButtonRight > 0) ? previousButtonRight + ACTION_BUTTON_SPACING : 0, height() - button->height());
-		button->setCalcLayout([](WIDGET *psWidget, unsigned int, unsigned int, unsigned int, unsigned int){
+		button->setCalcLayout([](WIDGET *psWidget) {
 			auto psParent = std::dynamic_pointer_cast<WzScriptLabelsPanel>(psWidget->parent());
 			ASSERT_OR_RETURN(, psParent != nullptr, "No parent");
 			psWidget->move(psWidget->x(), psParent->height() - psWidget->height());
@@ -1821,7 +1821,7 @@ void WZScriptDebugger::switchPanel(WZScriptDebugger::ScriptDebuggerPanel newPane
 	if (psPanel)
 	{
 		attach(psPanel);
-		psPanel->setCalcLayout([pageTabsBottom](WIDGET *psWidget, unsigned int, unsigned int, unsigned int, unsigned int) {
+		psPanel->setCalcLayout([pageTabsBottom](WIDGET *psWidget) {
 			auto psParent = psWidget->parent();
 			ASSERT_OR_RETURN(, psParent != nullptr, "No parent");
 			int y0 = pageTabsBottom + 20;


### PR DESCRIPTION
Fixes #1988 

The table is now dynamic, so it will adjust to fit the longer column names. Besides that some other adjustments were made:
- The buttons under "Alliances" will be displayed (and use space) only when applicable
- The number columns are displayed right aligned
- The table will shrink if the screen resolution is not big enough to display the entire table
- The labels will be trimmed if there is not enough space to show them
![image](https://user-images.githubusercontent.com/821208/126882056-9d5134ac-5c35-4a43-b3e2-fe78c2897262.png)
![image](https://user-images.githubusercontent.com/821208/126882095-6d04074b-9674-4fa3-9a38-6a63646282d8.png)
![image](https://user-images.githubusercontent.com/821208/126882155-b9ab9cb4-9c51-431b-8e00-7aa89c6efec3.png)
