### PR TITLE
gamefind.cpp: Refactor game list header

### DIFF
--- a/src/multiint.h
+++ b/src/multiint.h
@@ -120,6 +120,7 @@ void displayRoomNotifyMessage(char const *text);
 // ////////////////////////////////////////////////////////////////
 // GAME FIND SCREEN
 
+#define GAMES_GAMEHEADER	10200
 #define GAMES_GAMESTART		10201
 #define GAMES_GAMEEND		GAMES_GAMESTART+20
 #define GAMES_GAMEWIDTH		540


### PR DESCRIPTION
Destructing the previously global static `remoteGameListHeaderCache` could result in errors on exit (as the graphics backend may have already been shutdown).

Instead, wrap the header drawing logic (+ cache) in a proper `WIDGET` subclass, so everything gets destructed at an appropriate time.

(In the future, this screen is definitely in need of a larger refactor / refresh. But that's another PR.)