### PR TITLE
writeDroid: Use psCurr->numWeaps as bounds for psActionTarget

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -4859,7 +4859,7 @@ static nlohmann::json writeDroid(DROID *psCurr, bool onMission, int &counter)
 	// write common BASE_OBJECT info
 	writeSaveObjectJSON(droidObj, psCurr);
 
-	for (int i = 0; i < psCurr->numWeaps; i++)
+	for (unsigned i = 0; i < psCurr->numWeaps; i++)
 	{
 		if (psCurr->asWeaps[i].nStat > 0)
 		{
@@ -4871,7 +4871,7 @@ static nlohmann::json writeDroid(DROID *psCurr, bool onMission, int &counter)
 			droidObj["rotation/" + numStr] = toVector(psCurr->asWeaps[i].rot);
 		}
 	}
-	for (int i = 0; i < MAX_WEAPONS; i++)
+	for (unsigned i = 0; i < psCurr->numWeaps; i++)
 	{
 		setIniBaseObject(droidObj, "actionTarget/" + WzString::number(i), psCurr->psActionTarget[i]);
 	}


### PR DESCRIPTION
The previous code looped through `MAX_WEAPONS`, but we have a crash report that strongly suggests an invalid `psCurr->psActionTarget[I]` was passed to `setIniBaseObject`, and the most readily apparent possibility is that there were invalid `psActionTarget` values (non-initialized?) beyond `psCurr->numWeaps` passed to that function.

(The culprit was an autosave attempt on `Alpha Campaign/CAM_1C`, for what that's worth.)

@KJeff01 Does this break anything related to saves for you? Seems like it should be fine...