### PR TITLE
Don't deselect droids when pressing RMB over something

### DIFF
--- a/src/display.cpp
+++ b/src/display.cpp
@@ -2138,14 +2138,10 @@ static void dealWithRMB()
 					}
 				}
 			}
-			else
+			else if (bMultiPlayer && isHumanPlayer(psDroid->player))
 			{
-				handleDeselectionClick();
-				if (bMultiPlayer && isHumanPlayer(psDroid->player))
-				{
-					console("%s", droidGetName(psDroid));
-					FeedbackOrderGiven();
-				}
+				console("%s", droidGetName(psDroid));
+				FeedbackOrderGiven();
 			}
 		}	// end if its a droid
 		else if (psClickedOn->type == OBJ_STRUCTURE)
@@ -2208,13 +2204,10 @@ static void dealWithRMB()
 						intObjectSelected((BASE_OBJECT *)psStructure);
 					}
 				}
-			} else {
-				handleDeselectionClick();
 			}
 		}	// end if its a structure
 		else
 		{
-			handleDeselectionClick();
 			/* And if it's not a feature, then we're in trouble! */
 			ASSERT(psClickedOn->type == OBJ_FEATURE, "Weird selection from RMB - type of clicked object is %d", (int)psClickedOn->type);
 		}


### PR DESCRIPTION
#1181 Reported this as a bug but upon further inspection after merging #1204 it was useful to check enemy health with RMB without deselecting things (this is _very old_ behavior). As such, this is a partial revert of #1204 for the reason the original bug report itself was a case of a non-bug being treated as a bug.

Fixes #1715. All 3 issues are either resolved now or invalid.