### PR TITLE
Partial revert "writeDroid: Use psCurr->numWeaps as bounds for psActionTarget

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -4871,7 +4871,7 @@ static nlohmann::json writeDroid(DROID *psCurr, bool onMission, int &counter)
 			droidObj["rotation/" + numStr] = toVector(psCurr->asWeaps[i].rot);
 		}
 	}
-	for (unsigned i = 0; i < psCurr->numWeaps; i++)
+	for (unsigned i = 0; i < MAX_WEAPONS; i++)
 	{
 		setIniBaseObject(droidObj, "actionTarget/" + WzString::number(i), psCurr->psActionTarget[i]);
 	}


### PR DESCRIPTION
psActionTarget isn't just used for weapons (ex. trucks)

Fixes: #2055 (for new, non-borked saves)