### PR TITLE
Cleanup challenges screen if needed

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -922,6 +922,10 @@ bool frontendShutdown()
 	}
 
 	changeTitleUI(nullptr);
+	if (challengesUp)
+	{
+		closeChallenges(); // TODO: Ideally this would not be required here (refactor challenge.cpp / frontend.cpp?)
+	}
 	interfaceShutDown();
 
 	//do this before shutting down the iV library


### PR DESCRIPTION
@thiagorb Long-term, some of these screens (the load/save screen too?) could probably be added as full-screen "overlay screens" and avoid these workarounds. But this minimal fix should clean it up for now.