### PR TITLE
Update notification tweaks

### DIFF
--- a/src/version.cpp
+++ b/src/version.cpp
@@ -189,44 +189,23 @@ const char *version_getVersionString()
 	return version_string;
 }
 
-static std::pair<std::string, std::string> version_getBuildReleaseData()
-{
-	static std::string buildReleaseStr;
-	static std::string buildReleaseEnvironmentStr;
-	if (buildReleaseStr.empty() || buildReleaseEnvironmentStr.empty())
-	{
-		buildReleaseStr = "warzone2100@";
-		if (strlen(vcs_tag))
-		{
-			optional<TagVer> tagVersion = extractVersionNumberFromTag(vcs_tag);
-			if (tagVersion.has_value() && !tagVersion.value().qualifier.empty())
-			{
-				buildReleaseEnvironmentStr = "preview";
-			}
-			else
-			{
-				buildReleaseEnvironmentStr = "release";
-			}
-			// always use the tag directlry
-			buildReleaseStr += vcs_tag;
-		}
-		else
-		{
-			// if not a tag, use the full commit hash
-			buildReleaseStr += VCS_FULL_HASH;
-			buildReleaseEnvironmentStr = "development";
-		}
-	}
-	return std::pair<std::string, std::string>(buildReleaseStr, buildReleaseEnvironmentStr);
-}
-
 // Should follow the form:
 // - warzone2100@TAG_NAME (for tagged builds)
 // - warzone2100@FULL_COMMIT_HASH (for other builds)
 std::string version_getBuildIdentifierReleaseString()
 {
-	auto result = version_getBuildReleaseData();
-	return result.first;
+	std::string buildReleaseStr = "warzone2100@";
+	if (strlen(vcs_tag))
+	{
+		// always use the tag directly
+		buildReleaseStr += vcs_tag;
+	}
+	else
+	{
+		// if not a tag, use the full commit hash
+		buildReleaseStr += VCS_FULL_HASH;
+	}
+	return buildReleaseStr;
 }
 
 // For tagged builds this will return either:
@@ -236,8 +215,25 @@ std::string version_getBuildIdentifierReleaseString()
 //	- "development"
 std::string version_getBuildIdentifierReleaseEnvironment()
 {
-	auto result = version_getBuildReleaseData();
-	return result.second;
+	std::string buildReleaseEnvironmentStr;
+	if (strlen(vcs_tag))
+	{
+		optional<TagVer> tagVersion = extractVersionNumberFromTag(vcs_tag);
+		if (tagVersion.has_value() && !tagVersion.value().qualifier.empty())
+		{
+			buildReleaseEnvironmentStr = "preview";
+		}
+		else
+		{
+			buildReleaseEnvironmentStr = "release";
+		}
+	}
+	else
+	{
+		// if not a tag, "development" environment
+		buildReleaseEnvironmentStr = "development";
+	}
+	return buildReleaseEnvironmentStr;
 }
 
 /** Composes a nicely formatted version string.

--- a/src/version.h
+++ b/src/version.h
@@ -25,7 +25,7 @@
 #include <string>
 
 const char *version_getVersionString();
-const char *version_getFormattedVersionString(bool translated = true);
+const char *version_getFormattedVersionString(bool translated = true); // not thread-safe
 std::string version_getVersionedAppDirFolderName();
 
 std::string version_getBuildIdentifierReleaseString();


### PR DESCRIPTION
- Version function thread-safety
- updatemanager.cpp: Only use cache if written by same version of WZ

Should fix #2060