### PR TITLE
Prevent calling ClipRectWidget::runRecursive twice

### DIFF
--- a/lib/widget/cliprect.cpp
+++ b/lib/widget/cliprect.cpp
@@ -26,7 +26,7 @@
 #include "cliprect.h"
 #include "lib/ivis_opengl/pieblitfunc.h"
 
-void ClipRectWidget::run(W_CONTEXT *psContext)
+void ClipRectWidget::runRecursive(W_CONTEXT *psContext)
 {
 	W_CONTEXT newContext(psContext);
 	newContext.xOffset = psContext->xOffset + x();
@@ -34,7 +34,7 @@ void ClipRectWidget::run(W_CONTEXT *psContext)
 	newContext.mx = psContext->mx - x();
 	newContext.my = psContext->my - y() + offset.y;
 
-	runRecursive(&newContext);
+	WIDGET::runRecursive(&newContext);
 }
 
 bool ClipRectWidget::processClickRecursive(W_CONTEXT *psContext, WIDGET_KEY key, bool wasPressed)

--- a/lib/widget/cliprect.h
+++ b/lib/widget/cliprect.h
@@ -33,7 +33,7 @@ class ClipRectWidget : public WIDGET
 public:
 	ClipRectWidget() : WIDGET() {}
 
-	void run(W_CONTEXT *psContext) override;
+	void runRecursive(W_CONTEXT *psContext) override;
 	bool processClickRecursive(W_CONTEXT *psContext, WIDGET_KEY key, bool wasPressed) override;
 	void displayRecursive(WidgetGraphicsContext const &context) override;
 	void setTopOffset(uint16_t value);

--- a/lib/widget/widgbase.h
+++ b/lib/widget/widgbase.h
@@ -341,7 +341,7 @@ private:
 	void setScreenPointer(const std::shared_ptr<W_SCREEN> &screen); ///< Set screen pointer for us and all children.
 public:
 	virtual bool processClickRecursive(W_CONTEXT *psContext, WIDGET_KEY key, bool wasPressed);
-	void runRecursive(W_CONTEXT *psContext);
+	virtual void runRecursive(W_CONTEXT *psContext);
 	void processCallbacksRecursive(W_CONTEXT *psContext);
 	virtual void displayRecursive(WidgetGraphicsContext const &context);  ///< Display this widget, and all visible children.
 	void displayRecursive()


### PR DESCRIPTION
`WIDGET::runRecursive` calls the child widgets' `runRecursive` and then calls the child widgets' `run`.

With the previous implementation, `ClipRectWidget::runRecursive` was being called once from `WIDGET::runRecursive` (with the untrasformed context), and once from `ClipRectWidget::run` (with the transformed context).

This was causing the `run` of the entire subtree of a `ClipRectWidget` to be called twice for every frame. If a `WIDGET` had `n` `ClipRectWidget`s as ancestor, its `run` method would be called 2ⁿ times.