### PR TITLE
Fix crash caused by saveMissionData()

### DIFF
--- a/src/mission.cpp
+++ b/src/mission.cpp
@@ -664,27 +664,6 @@ static void saveMissionData()
 	//clear out the audio
 	audio_StopAll();
 
-	//save the mission data
-	mission.psMapTiles = std::move(psMapTiles);
-	mission.mapWidth = mapWidth;
-	mission.mapHeight = mapHeight;
-	for (int i = 0; i < ARRAY_SIZE(mission.psBlockMap); ++i)
-	{
-		mission.psBlockMap[i] = std::move(psBlockMap[i]);
-	}
-	for (int i = 0; i < ARRAY_SIZE(mission.psAuxMap); ++i)
-	{
-		mission.psAuxMap[i] = std::move(psAuxMap[i]);
-	}
-	mission.scrollMinX = scrollMinX;
-	mission.scrollMinY = scrollMinY;
-	mission.scrollMaxX = scrollMaxX;
-	mission.scrollMaxY = scrollMaxY;
-	std::swap(mission.psGateways, gwGetGateways());
-	// save the selectedPlayer's LZ
-	mission.homeLZ_X = getLandingX(selectedPlayer);
-	mission.homeLZ_Y = getLandingY(selectedPlayer);
-
 	bRepairExists = false;
 	//set any structures currently being built to completed for the selected player
 	for (psStruct = apsStructLists[selectedPlayer]; psStruct; psStruct = psStruct->psNext)
@@ -738,6 +717,27 @@ static void saveMissionData()
 			orderDroid(psDroid, DORDER_STOP, ModeImmediate);
 		}
 	}
+
+	//save the mission data
+	mission.psMapTiles = std::move(psMapTiles);
+	mission.mapWidth = mapWidth;
+	mission.mapHeight = mapHeight;
+	for (int i = 0; i < ARRAY_SIZE(mission.psBlockMap); ++i)
+	{
+		mission.psBlockMap[i] = std::move(psBlockMap[i]);
+	}
+	for (int i = 0; i < ARRAY_SIZE(mission.psAuxMap); ++i)
+	{
+		mission.psAuxMap[i] = std::move(psAuxMap[i]);
+	}
+	mission.scrollMinX = scrollMinX;
+	mission.scrollMinY = scrollMinY;
+	mission.scrollMaxX = scrollMaxX;
+	mission.scrollMaxY = scrollMaxY;
+	std::swap(mission.psGateways, gwGetGateways());
+	// save the selectedPlayer's LZ
+	mission.homeLZ_X = getLandingX(selectedPlayer);
+	mission.homeLZ_Y = getLandingY(selectedPlayer);
 
 	for (inc = 0; inc < MAX_PLAYERS; inc++)
 	{


### PR DESCRIPTION
`structureBuild()`, which is called to complete any in-progress structures, uses data such as `psMapTiles`. Previously, this did not cause any issue because raw pointers were used - setting `mission.psMapTiles = psMapTiles;` beforehand wouldn't change `psMapTiles` as well.

But after the `unique_ptr` refactoring in https://github.com/Warzone2100/warzone2100/commit/a08b23f040b1d84398c40168c33f3eac008c458f, `mission.psMapTiles = std::move(psMapTiles);` resets `psMapTiles` to `nullptr`. This would then lead to a crash in functions that `structureBuild()` calls that access the map tiles.

Moving the saving of the mission data pointers *afterwards* fixes the issue in my tests, and doesn't seem to have any unexpected side-effects.

To test (triggers the crash prior to this PR):
- Load `Alpha`/`SUB_1_1S`
- Load up the transporter with droids
- Use your trucks to begin building structure(s)
- Immediately launch the transporter, triggering the level transition (before the structure build completes)