### PR TITLE
Fix double host exit screen

### DIFF
--- a/lib/netplay/netplay.cpp
+++ b/lib/netplay/netplay.cpp
@@ -393,7 +393,7 @@ static size_t NET_fillBuffer(Socket **pSocket, SocketSet *pSocketSet, uint8_t *b
 			//Game is pretty much over --should just end everything when HOST dies.
 			NetPlay.isHostAlive = false;
 			ingame.localJoiningInProgress = false;
-			setLobbyError(ERROR_HOSTDROPPED);
+			setLobbyError(ERROR_NOERROR);
 			NETclose();
 			return 0;
 		}


### PR DESCRIPTION
Fixes #2097.

Obs: This double exit screen was only visible when you join the game through the lobby. Joining by entering the IP doesn't cause the issue.

To test the changes locally (without having to host the game publicly) I used the following patch, so that a game is always shown in the lobby for the localhost: 
[mock.patch.gz](https://github.com/Warzone2100/warzone2100/files/6964048/mock.patch.gz)
