### PR TITLE
MP: dont show ennemy building repairs

### DIFF
--- a/src/droid.cpp
+++ b/src/droid.cpp
@@ -415,8 +415,13 @@ void recycleDroid(DROID *psDroid)
 	vanishDroid(psDroid);
 
 	Vector3i position = psDroid->pos.xzy();
-	addEffect(&position, EFFECT_EXPLOSION, EXPLOSION_TYPE_DISCOVERY, false, nullptr, false, gameTime - deltaGameTime + 1);
-
+	const auto mapCoord = map_coord({psDroid->pos.x, psDroid->pos.y});
+	const auto psTile = mapTile(mapCoord);
+	if (tileIsClearlyVisible(psTile))
+	{
+		addEffect(&position, EFFECT_EXPLOSION, EXPLOSION_TYPE_DISCOVERY, false, nullptr, false, gameTime - deltaGameTime + 1);
+	}
+	
 	CHECK_DROID(psDroid);
 }
 

--- a/src/map.h
+++ b/src/map.h
@@ -272,6 +272,17 @@ static inline bool tileIsExplored(const MAPTILE *psTile)
 	return psTile->tileExploredBits & (1 << selectedPlayer);
 }
 
+/** Is the tile ACTUALLY, 100% visible? 
+ * This is not the same as for ex. psStructure->visible[selectedPlayer],
+ * because that would only mean the psStructure is in *explored Tile*
+ * psDroid->visible on the other hand, works correctly,
+ * because its visibility fades away in fog of war
+*/
+static inline bool tileIsClearlyVisible(const MAPTILE *psTile)
+{
+	return psTile->sensorBits & (1 << selectedPlayer);
+}
+
 /** Check if tile contains a small structure. Function is NOT thread-safe. */
 static inline bool TileHasSmallStructure(const MAPTILE *tile)
 {

--- a/src/structure.cpp
+++ b/src/structure.cpp
@@ -2294,8 +2294,9 @@ static bool structPlaceDroid(STRUCTURE *psStructure, DROID_TEMPLATE *psTempl, DR
 		}
 
 		setFactorySecondaryState(psNewDroid, psStructure);
-
-		if (psStructure->visible[selectedPlayer])
+		const auto mapCoord = map_coord({x, y});
+		const auto psTile = mapTile(mapCoord);
+		if (tileIsClearlyVisible(psTile))
 		{
 			/* add smoke effect to cover the droid's emergence from the factory */
 			iVecEffect.x = psNewDroid->pos.x;
@@ -3780,9 +3781,12 @@ void structureUpdate(STRUCTURE *psBuilding, bool bMission)
 				realY = static_cast<SDWORD>(structHeightScale(psBuilding) * point->y);
 				position.y = psBuilding->pos.z + realY;
 				position.z = static_cast<int>(psBuilding->pos.y - point->z);
-
-				effectSetSize(30);
-				addEffect(&position, EFFECT_EXPLOSION, EXPLOSION_TYPE_SPECIFIED, true, getImdFromIndex(MI_PLASMA), 0, gameTime - deltaGameTime + rand() % deltaGameTime);
+				const auto psTile = mapTile(map_coord({position.x, position.y}));
+				if (tileIsClearlyVisible(psTile))
+				{
+					effectSetSize(30);
+					addEffect(&position, EFFECT_EXPLOSION, EXPLOSION_TYPE_SPECIFIED, true, getImdFromIndex(MI_PLASMA), 0, gameTime - deltaGameTime + rand() % deltaGameTime);
+				}
 			}
 
 			if (iPointsToAdd)


### PR DESCRIPTION
- Droids being self-repaired in enemy's territory aren't visible, so there is no reason why building should be 
- Don't show recycled droids effects to enemies
- Don't show effect of newly built droid to enemies
