### PR TITLE
fix sensors logic under commander

### DIFF
--- a/src/ai.cpp
+++ b/src/ai.cpp
@@ -1143,7 +1143,9 @@ void aiUpdateDroid(DROID *psDroid)
 	}
 
 	// don't allow units to start attacking if they will switch to guarding the commander
-	if (hasCommander(psDroid))
+	// except for sensors: they still look for targets themselves, because
+	// they have wider view
+	if (hasCommander(psDroid) && psDroid->droidType != DROID_SENSOR)
 	{
 		lookForTarget = false;
 		updateTarget = false;

--- a/src/order.cpp
+++ b/src/order.cpp
@@ -1147,7 +1147,16 @@ static void orderCmdGroupBase(DROID_GROUP *psGroup, DROID_ORDER_DATA *psData)
 			syncDebug("command %d", psCurr->id);
 			if (!orderState(psCurr, DORDER_RTR))		// if you change this, youll need to change sendcmdgroup()
 			{
-				orderDroidBase(psCurr, psData);
+				if ((psData->type == DORDER_ATTACKTARGET || psData->type == DORDER_ATTACK) && psCurr->droidType == DROID_SENSOR && psData->psObj)
+				{
+					// sensors must observe, not attack
+					auto observeOrder = DroidOrder(DORDER_OBSERVE, psData->psObj);
+					orderDroidBase(psCurr, &observeOrder);
+				}
+				else
+				{
+					orderDroidBase(psCurr, psData);
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Right now it's practically useless to attach sensors with artillery to a commander, they don't even fire.

This PR makes them behave correctly: attack approaching enemy and attack when designated a target manually
https://youtu.be/nVpWONreT5A