### PR TITLE
Disable lobby refresh in only the most extreme case

### DIFF
--- a/src/multiint.cpp
+++ b/src/multiint.cpp
@@ -848,7 +848,7 @@ LOBBY_ERROR_TYPES getLobbyError()
 void setLobbyError(LOBBY_ERROR_TYPES error_type)
 {
 	LobbyError = error_type;
-	if (LobbyError <= ERROR_FULL)
+	if (LobbyError != ERROR_INVALID)
 	{
 		multiintDisableLobbyRefresh = false;
 	}


### PR DESCRIPTION
Should fix #2086.

`ERROR_WRONGPASSWORD` has a value greater than `ERROR_FULL` thus hiding refresh and filter icons due to `multiintDisableLobbyRefresh` being set to `true`.

I only opted to set it to `true` if `ERROR_INVALID` is the error... implying something _very_ funny is going on. Though maybe we really don't need this behavior at all and we can delete `multiintDisableLobbyRefresh` entirely.