### PR TITLE
initialize arrays

### DIFF
--- a/src/multiint.cpp
+++ b/src/multiint.cpp
@@ -247,7 +247,7 @@ static struct
 
 struct AIDATA
 {
-	AIDATA() : assigned(0) {}
+	AIDATA() : name{0}, js{0}, tip{0}, difficultyTips{0}, assigned(0) {}
 	char name[MAX_LEN_AI_NAME];
 	char js[MAX_LEN_AI_NAME];
 	char tip[255 + 128];            ///< may contain optional AI tournament data


### PR DESCRIPTION
Those arrays definitely contain garbage. 
Given the fact that `PLAYER.name` is larger than `AIDATA.name` AND `AIDATA.name` is not zero-initialized, `sstrcpy` could potentially try to copy beyond `AIDATA.name`'s size, at `multiint.cpp: 3358`
```
    sstrcpy(NetPlay.players[playerIndex].name, getAIName(playerIndex));
```
**maybe** solves https://sentry.io/organizations/warzone2100/issues/2587249100/events/1c0edd1eb5274f108040d3a06c16a368/?project=5174820, but wouldn't bet my hand on it