### PR TITLE
(MP)Make Heavy Laser playable.

### DIFF
--- a/data/mp/stats/weapons.json
+++ b/data/mp/stats/weapons.json
@@ -2000,7 +2000,7 @@
 		"weaponEffect": "ANTI PERSONNEL",
 		"weaponSubClass": "ENERGY",
 		"weaponWav": "hevlsr.ogg",
-		"weight": 20000
+		"weight": 5000
 	},
 	"HeavyLaser-VTOL": {
 		"buildPoints": 1000,


### PR DESCRIPTION
By request of MP players
Heavy Laser weight reduction from 20,000 to 5,000. Restoring the playability of this turret.