### PR TITLE
Fix (minor) bugs

### DIFF
--- a/src/action.cpp
+++ b/src/action.cpp
@@ -2189,7 +2189,7 @@ static void actionDroidBase(DROID *psDroid, DROID_ACTION_DATA *psAction)
 		if (!hasValidWeapon)
 		{
 			// continuing is pointless, we were given an invalid target
-			// for ex. AA gun can't atack ground unit
+			// for ex. AA gun can't attack ground unit
 			break;
 		}
 		if (electronicDroid(psDroid))


### PR DESCRIPTION
Fixes bunch of annoying bugs:

- AA droids under Commander will **not** ram into designated ground enemy, and will simply ignore order, as it doesn't make sense
- When asking to pick up an artifact, Commander will **not** send droid that already has a RETURN TO REPAIR order
- When building Wyvern droids with 2 turrets of different type, it was impossible to attack ground units if first turret is AA gun (because only first turret was checked for compatibility); Same when Wyvern under Commander

Fixes #1033