### PR TITLE
Major revision to the Blender 2.9x pie addon

### DIFF
--- a/tools/blender/2.9x/pie_addon/README.md
+++ b/tools/blender/2.9x/pie_addon/README.md
@@ -34,17 +34,14 @@ The scripts in this addon currently support importing and exporting the followin
     * PIE Points
     * PIE Polygons*
         * PIE Textured Polygons
-        * PIE Animated Polygons*
+        * PIE Animated Polygons
     * PIE Connectors
     * PIE Anim Objects*
     * PIE Shadow Points
     * PIE Shadow Polygons
 
 *1: N-gons should not be used in exported meshes due to UV corruption. Quads will be triangulated correctly and are acceptable for export from Blender to PIE.
-
-*2: Mesh objects with active modifiers will not export this feature to new faces in the case of mirrored/arrayed geometry.
-
-*3: There may be some cases Blender will not interpret rotation keys in the same manner as the game.
+*2: There may be some cases Blender will not interpret rotation keys in the same manner as the game.
 
 ## Usage
 
@@ -66,7 +63,7 @@ The following panel can be found in the Object tab of the properties editor:
         1. `None`:
             * Objects with this type will be ignored when exporting, but they may still be used in the Blender scene to manipulate objects which are eligable for PIE exporting.
         2. `Root`:
-            * This type is used to define the generic values of a PIE model, such as its rendering flags, textures, and events.
+            * This type is used to define the generic values of a PIE model, such as its version, rendering flags, textures, and events.
         3. `Level`:
             * This type is used to define the mesh and animation properties which are specific to each level such as animation rate/cycles and texture animation data for particular sets of faces. These should always be mesh objects, and also should always be within the heirarchy of a `Root` PIE object.
         4. `Shadow`:

--- a/tools/blender/2.9x/pie_addon/TODO.txt
+++ b/tools/blender/2.9x/pie_addon/TODO.txt
@@ -1,3 +1,3 @@
 - Figure out how to support the import/export of PIE normal data
 - Figure out why ngons cause corruption in the UV data
-- Figure out how to apply texture animation groups to mirrored/arrayed geometry
+- Adjust bone matrix transformations from animation to center on the level mesh

--- a/tools/blender/2.9x/pie_addon/__init__.py
+++ b/tools/blender/2.9x/pie_addon/__init__.py
@@ -19,34 +19,42 @@
 #
 # ##### END GPL LICENSE BLOCK #####
 
-from . import pie_export
-from . import pie_import
 import bpy
 import bmesh
+from . import pie_export
+from . import pie_import
+from .shared import getTexAnimGrp
+from bpy.types import Scene, Object
+from bpy.props import \
+    BoolProperty as BoolProp, \
+    PointerProperty as PointerProp, \
+    IntProperty as IntProp, \
+    EnumProperty as EnumProp, \
+    StringProperty as StrProp, \
+    CollectionProperty as ColProp
 
 
 bl_info = {
     'name': 'pie_addon for .pie format: used by Warzone 2100',
     'author': 'John Wharton',
-    'version': (1, 0, 0),
+    'version': (1, 1, 0),
     'blender': (2, 90, 0),
-    'description': 'Allows Blender to import and export models in the .pie format',
+    'description': 'Allows Blender to import/export models in the .pie format',
     'category': 'Import-Export',
 }
 
 
-class PIE_TextureAnimationGroupOptions(bpy.types.PropertyGroup):
-    name : bpy.props.StringProperty(name='name', default='Texture Animation Group', options=set())
+class PIE_TexAnimGrpOptions(bpy.types.PropertyGroup):
+    name: StrProp(name='name', default='Texture Animation Group')
 
-    texAnimImages: bpy.props.IntProperty(options=set(), min=0)
-    texAnimRate:   bpy.props.IntProperty(options=set(), min=0)
-    texAnimWidth:  bpy.props.IntProperty(options=set(), min=1, max=256)
-    texAnimHeight: bpy.props.IntProperty(options=set(), min=0, max=256)
-    texAnimFaces:  bpy.props.StringProperty(options=set())
+    texAnimImages: IntProp(options=set(), min=0)
+    texAnimRate: IntProp(options=set(), min=0, default=1)
+    texAnimWidth: IntProp(options=set(), min=1, max=256, default=256)
+    texAnimHeight: IntProp(options=set(), min=0, max=256, default=256)
 
 
-class PIE_TextureAnimationGroupPanel(bpy.types.Panel):
-    bl_idname = 'OBJECT_PT_PIE_TextureAnimationGroupPanel'
+class PIE_TexAnimGrpPanel(bpy.types.Panel):
+    bl_idname = 'OBJECT_PT_PIE_TexAnimGrpPanel'
     bl_label = 'PIE Texture Animation Groups'
     bl_space_type = 'PROPERTIES'
     bl_region_type = 'WINDOW'
@@ -57,158 +65,221 @@ class PIE_TextureAnimationGroupPanel(bpy.types.Panel):
     @classmethod
     def poll(cls, context):
         ob = context.object
-        return ob and (ob.pie_object_prop.pieType == 'LEVEL') and (ob.type == "MESH")
+        return ob and (
+            ob.pie_object_prop.pieType == 'LEVEL' and 
+            ob.type == "MESH"
+        )
 
     def draw(self, context):
         layout = self.layout
         ob = context.object
 
         if context.object.type == 'MESH':
+
+            length = len(ob.pie_tex_anim_grps)
+
+            rows = 2
+            if length > 1:
+                rows = 4
+
             row = layout.row()
             col = row.column()
-            col.template_list('UI_UL_list', 'pie_texture_animation_groups', ob, 'pie_texture_animation_groups', ob, 'pie_texture_animation_group_index', rows=3)
-            col = row.column()
-            col.operator('pie.texture_animation_group_add', icon='ADD', text='')
-            col.operator('pie.texture_animation_group_remove', icon='REMOVE', text='')
+            col.template_list(
+                'UI_UL_list', 'pie_tex_anim_grps', ob, 'pie_tex_anim_grps',
+                ob, 'pie_tex_anim_grp_index', rows=rows
+            )
+            col = row.column(align=True)
+            col.operator('pie.tex_anim_grp_add', icon='ADD', text='')
 
-            texAnimGroupIndex = ob.pie_texture_animation_group_index
+            if length > 0:
+                col.operator('pie.tex_anim_grp_remove', icon='REMOVE', text='')
+            if length > 1:
+                s = 'pie.tex_anim_grp_move'
+                col.separator()
+                col.operator(s, icon='TRIA_UP', text='').shift = -1
+                col.operator(s, icon='TRIA_DOWN', text='').shift = 1
 
-            if texAnimGroupIndex >= 0 and texAnimGroupIndex < len(ob.pie_texture_animation_groups):
-                texAnimGroup = ob.pie_texture_animation_groups[texAnimGroupIndex]
+            texAnimGrpIndex = ob.pie_tex_anim_grp_index
 
-                layout.prop(texAnimGroup, 'name', text='Name')
+            if texAnimGrpIndex >= 0 and texAnimGrpIndex < length:
+                texAnimGrp = ob.pie_tex_anim_grps[texAnimGrpIndex]
+
+                layout.prop(texAnimGrp, 'name', text='Name')
                 layout.use_property_split = True
 
                 if ob.mode == 'EDIT':
                     split = layout.split()
                     row = split.row()
                     col = row.column()
-                    col.operator('pie.texture_animation_group_set', text='Set')
+                    col.operator('pie.tex_anim_grp_set', text='Set')
                     row = split.row()
                     col = row.column()
-                    col.operator('pie.texture_animation_group_select', text='Select')
+                    col.operator('pie.tex_anim_grp_select', text='Select')
                     layout.separator()
 
-                layout.prop(texAnimGroup, 'texAnimImages', text='Texture Animation Images')
-                layout.prop(texAnimGroup, 'texAnimRate',   text='Texture Animation Rate')
+                s = 'Texture Animation '
+                layout.prop(texAnimGrp, 'texAnimImages', text=s + 'Images')
+                layout.prop(texAnimGrp, 'texAnimRate', text=s + 'Rate')
                 layout.separator()
-                layout.prop(texAnimGroup, 'texAnimWidth',  text='Texture Animation Width')
-                layout.prop(texAnimGroup, 'texAnimHeight', text='Texture Animation Height')
+                layout.prop(texAnimGrp, 'texAnimWidth', text=s + 'Width')
+                layout.prop(texAnimGrp, 'texAnimHeight', text=s + 'Height')
 
 
-class PIE_TextureAnimationGroupOperationAdd(bpy.types.Operator):
-    bl_idname      = 'pie.texture_animation_group_add'
-    bl_label       = 'Add texture animation group'
+class PIE_TexAnimGrpOperationAdd(bpy.types.Operator):
+    bl_idname = 'pie.tex_anim_grp_add'
+    bl_label = 'Add texture animation group'
     bl_description = 'Adds a texture animation group for the .pie model'
 
     def invoke(self, context, event):
         ob = context.object
+        name = 'Texture Animation Group ' + str(len(ob.pie_tex_anim_grps))
 
-        texAnimGroup = ob.pie_texture_animation_groups.add()
-        texAnimGroup.name = 'Texture Animation Group ' + str(len(ob.pie_texture_animation_groups))
-        texAnimGroup.texAnimImages = 0
-        texAnimGroup.texAnimRate = 1
-        texAnimGroup.texAnimWidth = 256
-        texAnimGroup.texAnimHeight = 256
-
-        ob.pie_texture_animation_group_index = len(ob.pie_texture_animation_groups) - 1
+        texAnimGrp = ob.pie_tex_anim_grps.add()
+        texAnimGrp.name = name
 
         return {'FINISHED'}
 
 
-class PIE_TextureAnimationGroupOperationRemove(bpy.types.Operator):
-    bl_idname      = 'pie.texture_animation_group_remove'
-    bl_label       = 'Remove texture animation group'
+class PIE_TexAnimGrpOperationRemove(bpy.types.Operator):
+    bl_idname = 'pie.tex_anim_grp_remove'
+    bl_label = 'Remove texture animation group'
     bl_description = 'Removes the active texture animation group'
 
     def invoke(self, context, event):
         ob = context.object
+        obMode = ob.mode == 'OBJECT'
+        bpy.ops.object.mode_set(mode='EDIT', toggle=False)
+        bm = bmesh.from_edit_mesh(ob.data)
+        faces = bm.faces
 
-        if ob.pie_texture_animation_group_index >= 0:
-            ob.pie_texture_animation_groups.remove(ob.pie_texture_animation_group_index)
+        grpIndex = ob.pie_tex_anim_grp_index
 
-            if ob.pie_texture_animation_group_index is not 0:
-                ob.pie_texture_animation_group_index -= 1
+        for face in faces:
+            for ii in range(len(ob.pie_tex_anim_grps)):
+                if ii == grpIndex:
+                    layer = getTexAnimGrp(bm, str(ii))
+                    face[layer] = 0
+                elif ii > grpIndex:
+                    layer = getTexAnimGrp(bm, str(ii))
+                    layerVal = face[layer]
+                    layerShift = getTexAnimGrp(bm, str(ii - 1))
+                    face[layerShift] = layerVal
+
+        ob.pie_tex_anim_grps.remove(grpIndex)
+
+        if ob.pie_tex_anim_grp_index != 0:
+            ob.pie_tex_anim_grp_index -= 1
+
+        if obMode:
+            bpy.ops.object.mode_set(mode='OBJECT', toggle=False)
 
         return {'FINISHED'}
 
 
-class PIE_TextureAnimationGroupOperationSelect(bpy.types.Operator):
-    bl_idname      = 'pie.texture_animation_group_select'
-    bl_label       = 'Select texture animation group'
-    bl_description = 'Selects the faces assigned to the active texture animation group'
+class PIE_TexAnimGrpOperationMove(bpy.types.Operator):
+    bl_idname = 'pie.tex_anim_grp_move'
+    bl_label = 'Move texture animation group'
+    bl_description = 'Moves the active texture animation group'
+
+    shift: IntProp(name='shift', default=0)
 
     def invoke(self, context, event):
         ob = context.object
+        ii = ob.pie_tex_anim_grp_index
+        iiShift = ii + self.shift
 
-        if ob.pie_texture_animation_groups[ob.pie_texture_animation_group_index].texAnimFaces is '':
-            return {'FINISHED'}
+        if iiShift < len(ob.pie_tex_anim_grps) and iiShift >= 0:
+            obMode = ob.mode == 'OBJECT'
+            bpy.ops.object.mode_set(mode='EDIT', toggle=False)
+            bm = bmesh.from_edit_mesh(ob.data)
+            faces = bm.faces
 
+            ob.pie_tex_anim_grps.move(ii, iiShift)
+
+            layer = getTexAnimGrp(bm, str(ii))
+            layerShift = getTexAnimGrp(bm, str(iiShift))
+            for face in faces:
+                temp = face[layer]
+                tempShift = face[layerShift]
+                face[layer] = tempShift
+                face[layerShift] = temp
+
+            ob.pie_tex_anim_grp_index += self.shift
+
+            if obMode:
+                bpy.ops.object.mode_set(mode='OBJECT', toggle=False)
+
+        return {'FINISHED'}
+
+
+class PIE_TexAnimGrpOperationSelect(bpy.types.Operator):
+    bl_idname = 'pie.tex_anim_grp_select'
+    bl_label = 'Select texture animation group'
+    bl_description = 'Selects faces assigned to the texture animation group'
+
+    def invoke(self, context, event):
+        ob = context.object
         bm = bmesh.from_edit_mesh(ob.data)
+        layer = getTexAnimGrp(bm, str(ob.pie_tex_anim_grp_index))
         faces = bm.faces
-        faceSetStr = ob.pie_texture_animation_groups[ob.pie_texture_animation_group_index].texAnimFaces
-        faceSetInt = []
 
         for face in faces:
-            face.select = False
-
-        for face in faceSetStr.split():
-            faceSetInt.append(int(face))
-
-        ii = 0
-        while ii < len(faceSetInt):
-            bm.faces[int(faceSetInt[ii])].select = True
-            ii += 1
+            face.select = True if face[layer] == 1 else False
 
         bmesh.update_edit_mesh(ob.data)
 
         return {'FINISHED'}
 
 
-class PIE_TextureAnimationGroupOperationSet(bpy.types.Operator):
-    bl_idname      = 'pie.texture_animation_group_set'
-    bl_label       = 'Set texture animation group'
-    bl_description = 'Sets the active texture animation group to the currently selected faces'
+class PIE_TexAnimGrpOperationSet(bpy.types.Operator):
+    bl_idname = 'pie.tex_anim_grp_set'
+    bl_label = 'Set texture animation group'
+    bl_description = 'Sets the texture animation group to the selected faces'
 
     def invoke(self, context, event):
         ob = context.object
         bm = bmesh.from_edit_mesh(ob.data)
-
         faces = bm.faces
-        faceSet = ''
 
-        ii = 0
-        while ii < len(faces):
-            if faces[ii].select is True:
-                faceSet += ' {str} '.format(str=str(ii))
-
-                jj = 0
-                while jj < len(ob.pie_texture_animation_groups):
-                    if jj is not ob.pie_texture_animation_group_index:
-                        newFaceSet = ob.pie_texture_animation_groups[jj].texAnimFaces.replace(' {str} '.format(str=str(ii)), '')
-                        ob.pie_texture_animation_groups[jj].texAnimFaces = newFaceSet
-                    jj += 1
-
-            ii += 1
-
-        ob.pie_texture_animation_groups[ob.pie_texture_animation_group_index].texAnimFaces = faceSet
+        for ii in range(len(ob.pie_tex_anim_grps)):
+            layer = getTexAnimGrp(bm, str(ii))
+            for face in faces:
+                if ii == ob.pie_tex_anim_grp_index:
+                    face[layer] = 1 if face.select else 0
+                elif face.select:
+                    face[layer] = 0
 
         return {'FINISHED'}
 
 
-pie_object_enum = [
+pie_ob_enum = [
     ('NONE', 'None', 'None'),
     ('ROOT', 'Root', 'PIE root object'),
-    ('LEVEL', 'Level', 'PIE level. These must always be a mesh and parented to a "Root" PIE object'),
-    ('SHADOW', 'Shadow (WZ2100 4.0+)', 'PIE level shadow. These must always be a mesh and parented to a "Level" PIE object'),
-    ('CONNECTOR', 'Connector', 'PIE level connector. These must always be parented to a "Level" PIE object')
+    ('LEVEL', 'Level', (
+        'PIE level. These must always be a mesh '
+        'and parented to a "Root" PIE object'
+        )),
+    ('SHADOW', 'Shadow (WZ2100 4.0+)', (
+        'PIE level shadow. These must always be a '
+        'mesh and parented to a "Level" PIE object'
+        )),
+    ('CONNECTOR', 'Connector', (
+        'PIE level connector. These must always '
+        'be parented to a "Level" PIE object'
+        )),
 ]
 
 pie_shadow_enum = [
     ('DEFAULT', 'Default', 'The shadow will default to the level mesh'),
-    ('CUSTOM', 'Custom', 'Define the level shadow with a PIE "Shadow" mesh object. This object must be parented to the level object'),
-    #('CONVEXHULL', 'Convex Hull', 'Define the level shadow with a convex hull of the level mesh'),
+    ('CUSTOM', 'Custom', (
+        'Define the level shadow with a PIE "Shadow" mesh object. '
+        'This object must be parented to the level object'
+        )),
+    # ('CONVEXHULL', 'Convex Hull', (
+    #     'Define the level shadow with a convex hull of the level mesh'
+    #     )),
 ]
+
 
 class PIE_ObjectPanel(bpy.types.Panel):
     bl_idname = 'OBJECT_PT_PIE_ObjectPanel'
@@ -225,16 +296,13 @@ class PIE_ObjectPanel(bpy.types.Panel):
         layout.prop(field, 'pieType', text='PIE Object Type')
 
         if field.pieType == 'ROOT':
+            layout.prop(field, 'pieVersion', text='PIE Version')
             box = layout.box()
-            split = box.split()
-            row = split.row()
-            col = row.column()
+            col = box.column_flow(columns=2)
             col.prop(field, 'adrOff', text='Additive rendering off')
             col.prop(field, 'adrOn', text='Additive rendering on')
             col.prop(field, 'pmr', text='Premultiplied rendering')
             col.prop(field, 'roll', text='Roll to face camera')
-            row = split.row()
-            col = row.column()
             col.prop(field, 'pitch', text='Pitch to face camera')
             col.prop(field, 'reserved', text='Reserved (Compatibility)')
             col.prop(field, 'stretch', text='Stretch to terrain')
@@ -248,37 +316,60 @@ class PIE_ObjectPanel(bpy.types.Panel):
         elif field.pieType == 'LEVEL':
             layout.prop(field, 'shadowType', text='Shadow Type')
             layout.use_property_split = True
-            #layout.prop(field, 'exportNormal', text='Export vertex normals')
+            # layout.prop(field, 'exportNormal', text='Export vertex normals')
             layout.prop(field, 'animTime', text='Animation Time')
             layout.prop(field, 'animCycle', text='Animation Cycles')
 
 
+pie_version_enum = [
+    ('2', 'PIE 2', 'Not generally recommended.'),
+    ('3', 'PIE 3', 'The latest PIE version.'),
+]
+
+
 class PIE_ObjectOptions(bpy.types.PropertyGroup):
 
-    pieType: bpy.props.EnumProperty(items=pie_object_enum, options=set(), default='NONE')
-    shadowType: bpy.props.EnumProperty(items=pie_shadow_enum, options=set(), default='DEFAULT')
+    pieType: EnumProp(options=set(), items=pie_ob_enum, default='NONE')
+    pieVersion: EnumProp(options=set(), items=pie_version_enum, default='3')
+    shadowType: EnumProp(
+        options=set(), items=pie_shadow_enum, default='DEFAULT'
+    )
 
-    adrOff: bpy.props.BoolProperty(name='adrOff', options=set())
-    adrOn: bpy.props.BoolProperty(name='adrOn', options=set())
-    pmr: bpy.props.BoolProperty(name='pmr', options=set())
-    roll: bpy.props.BoolProperty(name='roll', options=set())
-    pitch: bpy.props.BoolProperty(name='pitch', options=set())
-    reserved: bpy.props.BoolProperty(name='reserved', options=set())
-    stretch: bpy.props.BoolProperty(name='stretch', options=set())
-    tcMask: bpy.props.BoolProperty(name='tcMask', options=set())
-    texture: bpy.props.StringProperty(name='texture', options=set())
-    normal: bpy.props.StringProperty(name='normal', options=set())
-    specular: bpy.props.StringProperty(name='specular', options=set())
-    event1: bpy.props.StringProperty(name='event1', options=set(), description='Active animation event')
-    event2: bpy.props.StringProperty(name='event2', options=set(), description='Firing animation event')
-    event3: bpy.props.StringProperty(name='event3', options=set(), description='Death animation event')
+    adrOff: BoolProp(options=set())
+    adrOn: BoolProp(options=set())
+    pmr: BoolProp(options=set())
+    roll: BoolProp(options=set())
+    pitch: BoolProp(options=set())
+    reserved: BoolProp(options=set())
+    stretch: BoolProp(options=set())
+    tcMask: BoolProp(options=set())
+    texture: StrProp(options=set())
+    normal: StrProp(options=set())
+    specular: StrProp(options=set())
+    event1: StrProp(options=set(), description='Active animation event')
+    event2: StrProp(options=set(), description='Firing animation event')
+    event3: StrProp(options=set(), description='Death animation event')
 
-    #exportNormal: bpy.props.BoolProperty(name='exportNormal', options=set(), description='Indicates if the vertex normals of this mesh should be exported')
-    animTime: bpy.props.IntProperty(name='animTime', options=set(), description='Indicates the amount of time each animation cycle should take to complete')
-    animCycle: bpy.props.IntProperty(name='animCycle', options=set(), description='Indicates the number of times an animation should repeat. "0" indicates that the animation should loop indefinitely')
+    # exportNormal: BoolProp(
+    #     name='exportNormal', 
+    #     description='Indicates if the mesh's vertex normals are exported'
+    # )
+    animTime: IntProp(
+        name='animTime', 
+        description='Amount of time each animation cycle takes to complete'
+    )
+    animCycle: IntProp(
+        name='animCycle', 
+        description=(
+            'Number of times an animation will repeat. '
+            '"0" indicates that the animation will loop indefinitely'
+        )
+    )
 
 
 exporter = pie_export.Exporter()
+
+
 class PIE_ExportPanel(bpy.types.Panel):
     bl_idname = 'OBJECT_PT_PIE_ExportPanel'
     bl_label = 'PIE Export'
@@ -295,7 +386,7 @@ class PIE_ExportPanel(bpy.types.Panel):
 
 
 class PIE_ExportOptions(bpy.types.PropertyGroup):
-    rootDir: bpy.props.StringProperty(name='rootDir', default='', options=set())
+    rootDir: StrProp(name='Root Directory', default='')
 
 
 class PIE_ExportOperationQuick(bpy.types.Operator):
@@ -305,24 +396,31 @@ class PIE_ExportOperationQuick(bpy.types.Operator):
 
     def invoke(self, context, event):
         scene = context.scene
+        rootDir = scene.pie_export_prop.rootDir
         
-        if scene.pie_export_prop.rootDir[len(scene.pie_export_prop.rootDir) - 1] is not '\\':
+        if rootDir[len(rootDir) - 1] != '\\':
             scene.pie_export_prop.rootDir += '\\' 
 
         obs = []
 
         for ob in bpy.context.selected_objects:
-            while ob.parent is not None and ob.pie_object_prop.pieType != "ROOT":
+            pieType = ob.pie_object_prop.pieType
+            while ob.parent is not None and pieType != "ROOT":
                 ob = ob.parent
             if ob.pie_object_prop.pieType == "ROOT":
                 if ob not in obs:
                     obs.append(ob)
                     ob.select_set(False)
 
-        if len(obs) is 0:
-            self.report({'ERROR'}, 'You must select at least 1 "Root" PIE object or an object which is parented to one before exporting')
+        if len(obs) == 0:
+            self.report(
+                {'ERROR'}, (
+                    'You must select at least 1 "Root" PIE object or an '
+                    'object which is parented to one before exporting'
+                )
+            )
         else:
-            exporter.pie_export(scene, scene.pie_export_prop.rootDir, obs)
+            exporter.pie_export(scene, rootDir, obs)
 
         return {'FINISHED'}
 
@@ -334,13 +432,12 @@ class PIE_ExportOperation(bpy.types.Operator):
     bl_options = {'UNDO'}
 
     filename_ext = '.pie'
-    filter_glob: bpy.props.StringProperty(default='*.pie', options={'HIDDEN'})
-
-    directory: bpy.props.StringProperty(
-        name = 'File Directory',
-        description = 'File directory used for exporting .pie files',
-        maxlen = 1023,
-        default = ''
+    filter_glob: StrProp(default='*.pie', options={'HIDDEN'})
+    directory: StrProp(
+        name='File Directory',
+        description='File directory used for exporting .pie files',
+        maxlen=1023,
+        default=''
     )
 
     def execute(self, context):
@@ -349,15 +446,21 @@ class PIE_ExportOperation(bpy.types.Operator):
         obs = []
 
         for ob in bpy.context.selected_objects:
-            while ob.parent is not None and ob.pie_object_prop.pieType != "ROOT":
+            pieType = ob.pie_object_prop.pieType
+            while ob.parent is not None and pieType != "ROOT":
                 ob = ob.parent
             if ob.pie_object_prop.pieType == "ROOT":
                 if ob not in obs:
                     obs.append(ob)
                     ob.select_set(False)
 
-        if len(obs) is 0:
-            self.report({'ERROR'}, 'You must select at least 1 "Root" PIE object or an object which is parented to one before exporting')
+        if len(obs) == 0:
+            self.report(
+                {'ERROR'}, (
+                    'You must select at least 1 "Root" PIE object or an '
+                    'object which is parented to one before exporting'
+                )
+            )
         else:
             exporter.pie_export(scene, self.properties.directory, obs)
 
@@ -370,6 +473,8 @@ class PIE_ExportOperation(bpy.types.Operator):
 
 
 importer = pie_import.Importer()
+
+
 class PIE_ImportPanel(bpy.types.Panel):
     bl_idname = 'OBJECT_PT_PIE_ImportPanel'
     bl_label = 'PIE Import'
@@ -387,8 +492,8 @@ class PIE_ImportPanel(bpy.types.Panel):
 
 
 class PIE_ImportOptions(bpy.types.PropertyGroup):
-    pieFile: bpy.props.StringProperty(name='pieFile', default='', options=set())
-    rootDir: bpy.props.StringProperty(name='rootDir', default='', options=set())
+    pieFile: StrProp(name='pieFile', default='')
+    rootDir: StrProp(name='rootDir', default='')
 
 
 class PIE_ImportOperationQuick(bpy.types.Operator):
@@ -398,17 +503,21 @@ class PIE_ImportOperationQuick(bpy.types.Operator):
 
     def invoke(self, context, event):
         scene = context.scene
+        fileName = scene.pie_import_prop.pieFile
+        rootDir = scene.pie_import_prop.rootDir
 
         for ob in bpy.data.objects:
-            if scene.pie_import_prop.pieFile == ob.name:
-                self.report({'ERROR'}, 'There is already an object which matches the filename "{file}"'.format(file=scene.pie_import_prop.pieFile))
-                return {'FINISHED'}
-            #else:
-            #    for action in bpy.data.actions:
-            #        if scene.pie_import_prop.pieFile + ' Anim' in action.name:
-            #            self.report({'ERROR'}, 'There is already an animation which matches filename "{file}"'.format(file=scene.pie_import_prop.pieFile))
+            if fileName != ob.name:
+                continue
+            self.report(
+                {'ERROR'}, (
+                    'There is already an object which matches the filename '
+                    + fileName
+                )
+            )
+            return {'FINISHED'}
 
-        importer.pie_import_quick(scene, scene.pie_import_prop.rootDir, scene.pie_import_prop.pieFile)
+        importer.pie_import_quick(scene, rootDir, fileName)
 
         return {'FINISHED'}
 
@@ -420,13 +529,13 @@ class PIE_ImportOperation(bpy.types.Operator):
     bl_options = {'UNDO'}
 
     filename_ext = '.pie'
-    filter_glob: bpy.props.StringProperty(default='*.pie', options={'HIDDEN'})
+    filter_glob: StrProp(default='*.pie', options={'HIDDEN'})
 
-    filepath: bpy.props.StringProperty(
-        name = 'File Path',
-        description = 'File path used for importing a .pie file',
-        maxlen = 1023,
-        default = ''
+    filepath: StrProp(
+        name='File Path',
+        description='File path used for importing a .pie file',
+        maxlen=1023,
+        default=''
     )
 
     def execute(self, context):
@@ -453,34 +562,42 @@ classes = (
     PIE_ImportPanel,
     PIE_ObjectOptions,
     PIE_ObjectPanel,
-    PIE_TextureAnimationGroupOptions,
-    PIE_TextureAnimationGroupOperationAdd,
-    PIE_TextureAnimationGroupOperationRemove,
-    PIE_TextureAnimationGroupOperationSelect,
-    PIE_TextureAnimationGroupOperationSet,
-    PIE_TextureAnimationGroupPanel,
+    PIE_TexAnimGrpOptions,
+    PIE_TexAnimGrpOperationAdd,
+    PIE_TexAnimGrpOperationRemove,
+    PIE_TexAnimGrpOperationMove,
+    PIE_TexAnimGrpOperationSelect,
+    PIE_TexAnimGrpOperationSet,
+    PIE_TexAnimGrpPanel,
 )
 
+
 def menu_pie_import(self, context):
-    self.layout.operator(PIE_ImportOperation.bl_idname, text='Warzone 2100 Model (.pie)')
+    self.layout.operator('pie.import', text='Warzone 2100 Model (.pie)')
+
 
 def menu_pie_export(self, context):
-    self.layout.operator(PIE_ExportOperation.bl_idname, text='Warzone 2100 Model (.pie)')
+    self.layout.operator('pie.export', text='Warzone 2100 Model (.pie)')
+
 
 def register():
-    for cls in classes: bpy.utils.register_class(cls)
-    bpy.types.Scene.pie_export_prop                    = bpy.props.PointerProperty(type=PIE_ExportOptions)
-    bpy.types.Scene.pie_import_prop                    = bpy.props.PointerProperty(type=PIE_ImportOptions)
-    bpy.types.Object.pie_object_prop                   = bpy.props.PointerProperty(type=PIE_ObjectOptions)
-    bpy.types.Object.pie_texture_animation_groups      = bpy.props.CollectionProperty(type=PIE_TextureAnimationGroupOptions)
-    bpy.types.Object.pie_texture_animation_group_index = bpy.props.IntProperty(options=set())
+    for cls in classes: 
+        bpy.utils.register_class(cls)
+    Scene.pie_export_prop = PointerProp(type=PIE_ExportOptions)
+    Scene.pie_import_prop = PointerProp(type=PIE_ImportOptions)
+    Object.pie_object_prop = PointerProp(type=PIE_ObjectOptions)
+    Object.pie_tex_anim_grps = ColProp(type=PIE_TexAnimGrpOptions)
+    Object.pie_tex_anim_grp_index = IntProp()
     bpy.types.TOPBAR_MT_file_export.append(menu_pie_export)
     bpy.types.TOPBAR_MT_file_import.append(menu_pie_import)
 
+
 def unregister():
-    for cls in reversed(classes): bpy.utils.unregister_class(cls)
+    for cls in reversed(classes): 
+        bpy.utils.unregister_class(cls)
     bpy.types.TOPBAR_MT_file_export.remove(menu_pie_export)
     bpy.types.TOPBAR_MT_file_import.remove(menu_pie_import)
+
 
 if __name__ == '__main__':
     register()

--- a/tools/blender/2.9x/pie_addon/pie_export.py
+++ b/tools/blender/2.9x/pie_addon/pie_export.py
@@ -22,6 +22,7 @@
 
 import bpy
 import bmesh
+from .shared import getTexAnimGrp
 
 
 class Exporter():
@@ -31,13 +32,8 @@ class Exporter():
 
         for ob in obs:
 
-            nameStr = ''
+            nameStr = ob.name if '.pie' in ob.name else ob.name + '.pie'
 
-            if '.pie' in ob.name:
-                nameStr = ob.name
-            else:
-                nameStr = ob.name + '.pie'
-            
             pieFile = open(path + nameStr, 'w')
 
             print('Exporting {pie} to {path}'.format(pie=nameStr, path=path))
@@ -46,88 +42,114 @@ class Exporter():
 
             obProp = ob.pie_object_prop
 
-            pieFile.write('PIE 3')
+            version = obProp.pieVersion
+
+            pieFile.write('PIE ' + version)
 
             objType = 0
 
             if obProp.adrOff:
-                objType +=     1
+                objType += 1
             if obProp.adrOn:
-                objType +=     2
+                objType += 2
             if obProp.pmr:
-                objType +=     4
+                objType += 4
             if obProp.roll:
-                objType +=    10
+                objType += 10
             if obProp.pitch:
-                objType +=    20
+                objType += 20
             if obProp.reserved:
-                objType +=   200
+                objType += 200
             if obProp.stretch:
-                objType +=  1000
+                objType += 1000
             if obProp.tcMask:
                 objType += 10000
 
-            pieFile.write('\nTYPE {num}'.format(num=objType))
+            pieFile.write(
+                '\nTYPE {num}'.format(num=objType)
+            )
 
-            if obProp.texture != '':
-                pieFile.write('\nTEXTURE 0 {str} 0 0'.format(str=obProp.texture))
+            if obProp.texture:
+                pieFile.write(
+                    '\nTEXTURE 0 {str} 0 0'.format(str=obProp.texture)
+                )
 
-            if obProp.normal != '':
-                pieFile.write('\nNORMALMAP 0 {str}'.format(str=obProp.normal))
+            if obProp.normal:
+                pieFile.write(
+                    '\nNORMALMAP 0 {str}'.format(str=obProp.normal)
+                )
 
-            if obProp.specular != '':
-                pieFile.write('\nSPECULARMAP 0 {str}'.format(str=obProp.specular))
+            if obProp.specular:
+                pieFile.write(
+                    '\nSPECULARMAP 0 {str}'.format(str=obProp.specular)
+                )
 
-            if obProp.event1 != '':
-                pieFile.write('\nEVENT 1 {str}'.format(str=obProp.event1))
+            if obProp.event1:
+                pieFile.write(
+                    '\nEVENT 1 {str}'.format(str=obProp.event1)
+                )
 
-            if obProp.event2 != '':
-                pieFile.write('\nEVENT 2 {str}'.format(str=obProp.event2))
+            if obProp.event2:
+                pieFile.write(
+                    '\nEVENT 2 {str}'.format(str=obProp.event2)
+                )
 
-            if obProp.event3 != '':
-                pieFile.write('\nEVENT 3 {str}'.format(str=obProp.event3))
+            if obProp.event3:
+                pieFile.write(
+                    '\nEVENT 3 {str}'.format(str=obProp.event3)
+                )
 
             if ob.children:
 
-                level = 0
+                lvl = 0
 
-                levelObjects = []
-                
-                for child in ob.children:
-                    for child2 in child.children:
-                        for child3 in child2.children:
-                            if child3.pie_object_prop.pieType == 'LEVEL' and child3.type == "MESH":
-                                levelObjects.append(child3)
-                        if child2.pie_object_prop.pieType == 'LEVEL' and child2.type == "MESH":
-                            levelObjects.append(child2)
-                    if child.pie_object_prop.pieType == 'LEVEL' and child.type == "MESH":
-                        levelObjects.append(child)
+                def getDescendantObs(parent):
+                    arr = []
+                    for child in parent.children:
+                        if (child.pie_object_prop.pieType == 'LEVEL'
+                                and child.type == 'MESH'):
+                            arr.append(child)
+                            childDescendants = getDescendantObs(child)
+                            arr.extend(childDescendants)
+                    return arr
 
-                if len(levelObjects) > 0:
+                lvlObs = getDescendantObs(ob)
+
+                if lvlObs:
                     print('Exporting {pie} levels'.format(pie=nameStr))
-                    pieFile.write('\nLEVELS {num}'.format(num=len(levelObjects)))
+                    pieFile.write('\nLEVELS {num}'.format(num=len(lvlObs)))
 
-
-                for child in levelObjects:
+                for child in lvlObs:
                     childProp = child.pie_object_prop
 
                     depsgraph = bpy.context.evaluated_depsgraph_get()
+                    depOb = child.evaluated_get(depsgraph)
+                    evalMe = bpy.data.meshes.new_from_object(depOb)
+                    evalOb = bpy.data.objects.new(nameStr + ' eval', evalMe)
+                    bpy.context.collection.objects.link(evalOb)
 
-                    meshOb = child.evaluated_get(depsgraph)
-                    mesh = meshOb.data
+                    bpy.context.view_layer.objects.active = evalOb
+                    bpy.ops.object.mode_set(mode='EDIT', toggle=False)
+                    bm = bmesh.from_edit_mesh(evalMe)
 
-                    bm = bmesh.new()
-                    bm.from_mesh(mesh)
-                    bmesh.ops.triangulate(bm, faces=bm.faces)
+                    lvl += 1
 
-                    level += 1
-
-                    print('Exporting {pie} level {num}'.format(pie=nameStr, num=level))
-                    pieFile.write('\nLEVEL {num}'.format(num=level))
+                    print(
+                        'Exporting {pie} level {num}'
+                        .format(pie=nameStr, num=lvl)
+                    )
+                    pieFile.write(
+                        '\nLEVEL {num}'.format(num=lvl)
+                    )
 
                     if bm.verts:
-                        print('Exporting {pie} level {num} points'.format(pie=nameStr, num=level))
-                        pieFile.write('\nPOINTS {num}'.format(num=len(bm.verts)))
+                        print(
+                            'Exporting {pie} level {num} points'
+                            .format(pie=nameStr, num=lvl)
+                        )
+                        pieFile.write(
+                            '\nPOINTS {num}'.format(num=len(bm.verts))
+                        )
 
                         for vertice in bm.verts:
                             val = []
@@ -140,86 +162,118 @@ class Exporter():
 
                                 val.append(num)
 
-                            pieFile.write('\n\t{x} {z} {y}'.format(x=val[0], y=val[1], z=val[2]))
+                            pieFile.write(
+                                '\n\t{x} {z} {y}'
+                                .format(x=val[0], y=val[1], z=val[2])
+                            )
 
                     if bm.faces:
                         faceStr = ''
-                        #normalStr = '
-                        #print('Exporting {pie} level {num} normals = {prop}'.format(pie=nameStr, num=level, prop=child.pie_object_prop.exportNormal))
-                        print('Exporting {pie} level {num} polygons'.format(pie=nameStr, num=level))
+                        print(
+                            'Exporting {pie} level {num} polygons'
+                            .format(pie=nameStr, num=lvl)
+                        )
 
                         faceStr += '\nPOLYGONS {num}'.format(num=len(bm.faces))
 
-                        #if child.pie_object_prop.exportNormal is True:
-                        #    normalStr += '\nNORMALS {num}'.format(num=len(child.data.polygons))
+                        def adjustToIntUv(num):
+                            result = num * 256
+                            while result < 0:
+                                result += 256
+                            while result > 256:
+                                result -= 256
+                            return round(result)
                         
-                        ii = 0
                         for face in bm.faces:
 
-                            #if child.pie_object_prop.exportNormal is True:
-                            #    verticeNormals = []
-                            #    for vertex in poly.vertices:
-                            #        verticeNormals.append(child.data.vertices[vertex].normal)
-                            #        #print('vertex: {normal}'.format(normal=child.data.vertices[vertex].normal))
-                            #    #print('face: {normal}'.format(normal=poly.normal))
-                            #    normalStr += '\n\t{x1} {y2} {z1} {x2} {y2} {z2} {x3} {y3} {z3}'.format(
-                            #        x1=round(verticeNormals[0][0], 4), y1=round(verticeNormals[0][1], 4), z1=round(verticeNormals[0][2], 4),
-                            #        x2=round(verticeNormals[1][0], 4), y2=round(verticeNormals[1][1], 4), z2=round(verticeNormals[1][2], 4),
-                            #        x3=round(verticeNormals[2][0], 4), y3=round(verticeNormals[2][1], 4), z3=round(verticeNormals[2][2], 4),
-                            #    )
-
-                            uv_layer = bm.loops.layers.uv.verify()
+                            uvLayer = bm.loops.layers.uv.verify()
                             uvOut = [[], [], []]
                             
-                            jj = 0
-                            for loop in face.loops:
-                                uvOut[jj].append(round(loop[uv_layer].uv[0], 6))
-                                uvOut[jj].append(round(loop[uv_layer].uv[1], 6))
-                                jj += 1
+                            for ii, loop in enumerate(face.loops):
+                                uvOut[ii].append(round(loop[uvLayer].uv[0], 6))
+                                uvOut[ii].append(round(loop[uvLayer].uv[1], 6))
+
+                            uvx1 = round(uvOut[0][0], 4)
+                            uvy1 = round(-uvOut[0][1] + 1, 4)
+                            uvx2 = round(uvOut[1][0], 4)
+                            uvy2 = round(-uvOut[1][1] + 1, 4)
+                            uvx3 = round(uvOut[2][0], 4)
+                            uvy3 = round(-uvOut[2][1] + 1, 4)
+
+                            if version == '2':
+                                uvx1 = adjustToIntUv(uvx1)
+                                uvy1 = adjustToIntUv(uvy1)
+                                uvx2 = adjustToIntUv(uvx2)
+                                uvy2 = adjustToIntUv(uvy2)
+                                uvx3 = adjustToIntUv(uvx3)
+                                uvy3 = adjustToIntUv(uvy3)
 
                             success = False
-                            for texAnimGroup in child.pie_texture_animation_groups:
-                                if str(ii) in texAnimGroup.texAnimFaces:
+
+                            for ii, tag in enumerate(child.pie_tex_anim_grps):
+                                layer = getTexAnimGrp(bm, str(ii))
+                                if face[layer] == 1:
                                     success = True
-                                    faceStr += '\n\t{type} 3 {v1} {v2} {v3} {tagImg} {tagRate} {tagW} {tagH} {uvx1} {uvy1} {uvx2} {uvy2} {uvx3} {uvy3}'.format(
+                                    faceStr += ('\n\t{type} 3 {v1} {v2} {v3} '
+                                                '{tagImg} {tagRate} {tagW} '
+                                                '{tagH} {uvx1} {uvy1} {uvx2} '
+                                                '{uvy2} {uvx3} {uvy3}').format(
                                         type=4200,
-                                        v1=face.verts[0].index, v2=face.verts[1].index, v3=face.verts[2].index,
-                                        tagImg=texAnimGroup.texAnimImages, tagRate=texAnimGroup.texAnimRate,
-                                        tagW=texAnimGroup.texAnimWidth, tagH=texAnimGroup.texAnimHeight,
-                                        uvx1=round(uvOut[0][0], 4), uvy1=-round(uvOut[0][1], 4) + 1,
-                                        uvx2=round(uvOut[1][0], 4), uvy2=-round(uvOut[1][1], 4) + 1,
-                                        uvx3=round(uvOut[2][0], 4), uvy3=-round(uvOut[2][1], 4) + 1,
+                                        v1=face.verts[0].index,
+                                        v2=face.verts[1].index,
+                                        v3=face.verts[2].index,
+                                        tagImg=tag.texAnimImages,
+                                        tagRate=tag.texAnimRate,
+                                        tagW=tag.texAnimWidth,
+                                        tagH=tag.texAnimHeight,
+                                        uvx1=uvx1,
+                                        uvy1=uvy1,
+                                        uvx2=uvx2,
+                                        uvy2=uvy2,
+                                        uvx3=uvx3,
+                                        uvy3=uvy3,
                                     )
                                     break
                             if success is False:
-                                faceStr += '\n\t{type} 3 {v1} {v2} {v3} {uvx1} {uvy1} {uvx2} {uvy2} {uvx3} {uvy3}'.format(
+                                faceStr += ('\n\t{type} 3 {v1} {v2} {v3} '
+                                            '{uvx1} {uvy1} {uvx2} {uvy2} '
+                                            '{uvx3} {uvy3}').format(
                                     type=200,
-                                    v1=face.verts[0].index, v2=face.verts[1].index, v3=face.verts[2].index,
-                                    uvx1=round(uvOut[0][0], 4), uvy1=-round(uvOut[0][1], 4) + 1,
-                                    uvx2=round(uvOut[1][0], 4), uvy2=-round(uvOut[1][1], 4) + 1,
-                                    uvx3=round(uvOut[2][0], 4), uvy3=-round(uvOut[2][1], 4) + 1,
+                                    v1=face.verts[0].index,
+                                    v2=face.verts[1].index,
+                                    v3=face.verts[2].index,
+                                    uvx1=uvx1,
+                                    uvy1=uvy1,
+                                    uvx2=uvx2,
+                                    uvy2=uvy2,
+                                    uvx3=uvx3,
+                                    uvy3=uvy3,
                                 )
 
-                            ii += 1
-
-                        #if child.pie_object_prop.exportNormal is True:
-                        #    pieFile.write(normalStr)
+                        # if child.pie_object_prop.exportNormal is True:
+                        #     pieFile.write(normalStr)
 
                         pieFile.write(faceStr)
 
-                    connectorObjects = []
+                    connectorObs = []
                     for connector in child.children:
                         if connector.pie_object_prop.pieType == 'CONNECTOR':
-                            connectorObjects.append(connector)
+                            connectorObs.append(connector)
 
-                    if connectorObjects:
-                        print('Exporting {pie} level {num} connectors'.format(pie=nameStr, num=level))
-                        pieFile.write('\nCONNECTORS {num}'.format(num=len(connectorObjects)))
-                        for connector in connectorObjects:
+                    if connectorObs:
+                        print(
+                            'Exporting {pie} level {num} connectors'
+                            .format(pie=nameStr, num=lvl)
+                        )
+                        pieFile.write(
+                            '\nCONNECTORS {num}'.format(num=len(connectorObs))
+                        )
+                        for connector in connectorObs:
 
                             val = []
+                            loc = connector.location
 
-                            for num in [connector.location.x * 100, connector.location.y * 100, connector.location.z * 100]:
+                            for num in [loc.x * 100, loc.y * 100, loc.z * 100]:
                                 num = round(num, 4)
 
                                 if abs(num - round(num)) <= 0.0001:
@@ -227,9 +281,11 @@ class Exporter():
 
                                 val.append(num)
 
-                            pieFile.write('\n\t{x} {y} {z}'.format(x=val[0], y=val[1], z=val[2]))
-
-                    print(ob.animation_data)
+                            pieFile.write(
+                                '\n\t{x} {y} {z}'.format(
+                                    x=val[0], y=val[1], z=val[2]
+                                )
+                            )
 
                     if ob.animation_data:
 
@@ -238,104 +294,131 @@ class Exporter():
                         success = False
                         for fcurve in ob.animation_data.action.fcurves:
 
-                            if '["{name}"]'.format(name=child.name) in fcurve.data_path or '["{name}"]'.format(name=child.parent) in fcurve.data_path or '["{name}"]'.format(name=child.parent_bone) in fcurve.data_path:
-                                success = True
-                                if fcurve.keyframe_points[-1].co[0] > endFrame:
-                                    endFrame = int(round(fcurve.keyframe_points[-1].co[0]))
+                            cName = '["{name}"]'.format(name=child.name)
+                            pName = '["{name}"]'.format(name=child.parent)
+                            bName = '["{name}"]'.format(name=child.parent_bone)
 
-                        if success == True:
+                            if (cName in fcurve.data_path or
+                                    pName in fcurve.data_path or
+                                    bName in fcurve.data_path):
+                                success = True
+                                kp = fcurve.keyframe_points
+                                if kp[-1].co[0] > endFrame:
+                                    endFrame = int(round(kp[-1].co[0])) + 1
+
+                        if success:
 
                             restFrame = bpy.context.scene.frame_current
 
-                            print('Exporting {pie} level {num} animation = True'.format(pie=nameStr, num=level))
-                            pieFile.write('\nANIMOBJECT {time} {cycles} {frames}'.format(time=childProp.animTime, cycles=childProp.animCycle, frames=endFrame + 1))
+                            print(
+                                'Exporting {pie} level {num} animation = True'
+                                .format(pie=nameStr, num=lvl)
+                            )
+                            pieFile.write(
+                                '\nANIMOBJECT {time} {cycles} {frames}'.format(
+                                    time=childProp.animTime,
+                                    cycles=childProp.animCycle,
+                                    frames=endFrame
+                                )
+                            )
 
-                            ii = 0
-                            while ii <= endFrame:
+                            for ii in range(endFrame):
                                 bpy.context.scene.frame_set(ii)
 
                                 childMatrix = child.matrix_world.decompose()
-                                exportMatrix = child.matrix_world - ob.matrix_world
+                                exMatrix = child.matrix_world - ob.matrix_world
 
-                                mLoc = exportMatrix.decompose()[0]
+                                mLoc = exMatrix.decompose()[0]
                                 mRot = childMatrix[1]
                                 mRot = mRot.to_euler('YZX')
                                 mScl = childMatrix[2]
-                                loc, rot, scl = [[], [], []]
+                                L, r, s = [[], [], []]
 
-                                for val in [mLoc[0], mLoc[1], mLoc[2]]:
-                                    loc.append(round(val * 100000))
+                                for val in mLoc:
+                                    L.append(str(round(val * 100000)))
 
-                                for val in [mRot[0], mRot[1], mRot[2]]:
-                                    rot.append(round(val * 57295.755))
+                                for val in mRot:
+                                    r.append(str(round(val * 57295.755)))
 
-                                for val in [mScl[0], mScl[1], mScl[2]]:
+                                for val in mScl:
                                     if abs(val - round(val)) < 0.000149:
-                                        scl.append(round(val, 1))
+                                        s.append(str(round(val, 1)))
                                     else:
-                                        scl.append(round(val, 4))
+                                        s.append(str(round(val, 4)))
 
-                                sFrame = ''.ljust(abs(len(str(    ii)) - 3) + 8, ' ')
-                                sLocX  = ''.ljust(abs(len(str(loc[0])) - 8) + 4, ' ')
-                                sLocY  = ''.ljust(abs(len(str(loc[1])) - 8),     ' ')
-                                sLocZ  = ''.ljust(abs(len(str(loc[2])) - 8),     ' ')
-                                sRotX  = ''.ljust(abs(len(str(rot[0])) - 8),     ' ')
-                                sRotY  = ''.ljust(abs(len(str(rot[1])) - 8),     ' ')
-                                sRotZ  = ''.ljust(abs(len(str(rot[2])) - 8),     ' ')
-                                sSclX  = ''.ljust(abs(len(str(scl[0])) - 8),     ' ')
-                                sSclY  = ''.ljust(abs(len(str(scl[1])) - 8),     ' ')
-                                sSclZ  = ''.ljust(abs(len(str(scl[2])) - 8),     ' ')
+                                def formSpaces(num, spaces):
+                                    return abs(len(num) - spaces)
 
-                                pieFile.write('\n{sFrame}{frame}{sLocX}{locX}{sLocY}{locY}{sLocZ}{locZ}{sRotX}{rotX}{sRotY}{rotY}{sRotZ}{rotZ}{sSclX}{sclX}{sSclY}{sclY}{sSclZ}{sclZ}'
-                                .format(
-                                    sFrame=sFrame, frame=ii,
-                                    sLocX=sLocX, sLocY=sLocY, sLocZ=sLocZ,
-                                    locX=loc[0], locY=loc[1], locZ=loc[2],
-                                    sRotX=sRotX, sRotY=sRotY, sRotZ=sRotZ,
-                                    rotX=rot[0], rotY=rot[1], rotZ=rot[2],
-                                    sSclX=sSclX, sSclY=sSclY, sSclZ=sSclZ,
-                                    sclX=scl[0], sclY=scl[1], sclZ=scl[2],
-                                    )
+                                sFr = ''.ljust(formSpaces(str(ii), 3) + 8)
+                                sLX = ''.ljust(formSpaces(L[0], 8) + 4)
+                                sLY = ''.ljust(formSpaces(L[1], 8))
+                                sLZ = ''.ljust(formSpaces(L[2], 8))
+                                sRX = ''.ljust(formSpaces(r[0], 8))
+                                sRY = ''.ljust(formSpaces(r[1], 8))
+                                sRZ = ''.ljust(formSpaces(r[2], 8))
+                                sSX = ''.ljust(formSpaces(s[0], 8))
+                                sSY = ''.ljust(formSpaces(s[1], 8))
+                                sSZ = ''.ljust(formSpaces(s[2], 8))
+
+                                pieFile.write(
+                                    '\n' + sFr + str(ii) +
+                                    sLX + L[0] + sLY +
+                                    L[1] + sLZ + L[2] +
+                                    sRX + r[0] + sRY +
+                                    r[1] + sRZ + r[2] +
+                                    sSX + s[0] + sSY +
+                                    s[1] + sSZ + s[2]
                                 )
-
-                                ii += 1
 
                             bpy.context.scene.frame_set(restFrame)
                         else:
-                            print('Exporting {pie} level {num} animation = False'.format(pie=nameStr, num=level))
+                            print(
+                                'Exporting {pie} level {num} animation = False'
+                                .format(pie=nameStr, num=lvl)
+                            )
                     else:
-                            print('Exporting {pie} level {num} animation = False'.format(pie=nameStr, num=level))
+                        print(
+                            'Exporting {pie} level {num} animation = False'
+                            .format(pie=nameStr, num=lvl)
+                        )
 
                     exportShadow = False
                     if childProp.shadowType == 'CUSTOM':
-                        for shadow in child.children:
-                            if shadow.pie_object_prop.pieType == 'SHADOW':
-                                exportShadow = True
-                                shadowBm = bmesh.new()
-                                shadowBm.from_mesh(shadow.evaluated_get(depsgraph).data)
-                                bmesh.ops.triangulate(shadowBm, faces=shadowBm.faces)
-                                break
+                        for sh in child.children:
+                            if sh.pie_object_prop.pieType != 'SHADOW':
+                                continue
+                            exportShadow = True
+                            shBm = bmesh.new()
+                            shBm.from_mesh(sh.evaluated_get(depsgraph).data)
+                            bmesh.ops.triangulate(shBm, faces=shBm.faces)
+                            break
 
-                    #elif childProp.shadowType == 'CONVEXHULL':
-                        #exportShadow = True
-                        #shadowBm = bmesh.new()
-                        #shadowBm.from_mesh(mesh)
-                        #bmesh.ops.convex_hull(shadowBm, input=shadowBm.verts)
-
-                        #copyData = bpy.data.meshes.new('test')
-
-                        #shadowBm.to_mesh(copyData)
-
-                        #copy = bpy.data.objects.new('test', copyData)
-                        #bpy.context.collection.objects.link(copy)
+                    # elif childProp.shadowType == 'CONVEXHULL':
+                    #     exportShadow = True
+                    #     shadowBm = bmesh.new()
+                    #     shadowBm.from_mesh(mesh)
+                    #     bmesh.ops.convex_hull(shadowBm, input=shadowBm.verts)
+                    #
+                    #     copyData = bpy.data.meshes.new('test')
+                    #
+                    #     shadowBm.to_mesh(copyData)
+                    #
+                    #     copy = bpy.data.objects.new('test', copyData)
+                    #     bpy.context.collection.objects.link(copy)
 
                     if exportShadow is not False:
 
-                        if shadowBm.verts:
-                            print('Exporting {pie} level {num} shadow points'.format(pie=nameStr, num=level))
-                            pieFile.write('\nSHADOWPOINTS {num}'.format(num=len(shadowBm.verts)))
+                        if shBm.verts:
+                            print(
+                                'Exporting {pie} level {num} shadow points'
+                                .format(pie=nameStr, num=lvl)
+                            )
+                            pieFile.write(
+                                '\nSHADOWPOINTS {num}'
+                                .format(num=len(shBm.verts))
+                            )
 
-                            for vertice in shadowBm.verts:
+                            for vertice in shBm.verts:
                                 val = []
 
                                 for num in vertice.co:
@@ -346,18 +429,31 @@ class Exporter():
 
                                     val.append(num)
 
-                                pieFile.write('\n\t{x} {z} {y}'.format(x=val[0], y=val[1], z=val[2]))
+                                pieFile.write('\n\t{x} {z} {y}'.format(
+                                    x=val[0], y=val[1], z=val[2])
+                                )
 
-                        if shadowBm.faces:
-                            print('Exporting {pie} level {num} shadow polygons'.format(pie=nameStr, num=level))
-                            pieFile.write('\nSHADOWPOLYGONS {num}'.format(num=len(shadowBm.faces)))
+                        if shBm.faces:
+                            print(
+                                'Exporting {pie} level {num} shadow polygons'
+                                .format(pie=nameStr, num=lvl)
+                            )
+                            pieFile.write('\nSHADOWPOLYGONS {num}'.format(
+                                num=len(shBm.faces))
+                            )
 
-                            for face in shadowBm.faces:
-                                pieFile.write('\n\t0 3 {v1} {v2} {v3}'.format(v1=face.verts[0].index, v2=face.verts[1].index, v3=face.verts[2].index,))
+                            for face in shBm.faces:
+                                pieFile.write('\n\t0 3 {v1} {v2} {v3}'.format(
+                                    v1=face.verts[0].index,
+                                    v2=face.verts[1].index,
+                                    v3=face.verts[2].index,)
+                                )
 
-                        shadowBm.free()
+                        shBm.free()
 
-                    bm.free()
+                    bpy.ops.object.mode_set(mode='OBJECT', toggle=False)
+                    bpy.data.objects.remove(evalOb)
 
+                    pieFile.write('\n')
 
             pieFile.close()

--- a/tools/blender/2.9x/pie_addon/pie_import.py
+++ b/tools/blender/2.9x/pie_addon/pie_import.py
@@ -373,9 +373,9 @@ class Importer():
     def pie_import_quick(self, scene, pieDir, pieMesh):
         self.scene = scene
 
-        pieParse = self.pie_parse(pieDir + '\\\\' + pieMesh, pieMesh)
+        pieParse = self.pie_parse(pieDir + '\\\\' + pieMesh)
 
-        self.pie_generateBlenderObjects(pieParse)
+        self.pie_generateBlenderObjects(pieParse, pieMesh)
 
     def pie_import(self, scene, pieDir):
         self.scene = scene

--- a/tools/blender/2.9x/pie_addon/pie_import.py
+++ b/tools/blender/2.9x/pie_addon/pie_import.py
@@ -19,41 +19,35 @@
 #
 # ##### END GPL LICENSE BLOCK #####
 
-
 import bpy
+import bmesh
+from .shared import getTexAnimGrp
 
-
-def getNumbers(string):
-    numbers = []
-    for word in string.split():
-        if word.isdigit():
-            numbers.append(int(word))
-
-    return numbers
 
 def convertStrListToNumList(ls):
-    val = []
+    return [float(word) for word in ls]
 
-    for word in ls:
-        val.append(float(word))
 
-    return val
+def newTexAnimGroup(ob, poly):
+    ob.pie_tex_anim_grps.add()
+    ob.pie_tex_anim_grp_index = len(ob.pie_tex_anim_grps) - 1
+    grpII = ob.pie_tex_anim_grp_index
+    grpName = 'Texture Animation Group {n}'.format(n=grpII + 1)
 
-def newTexAnimGroup(ob, polygon, index):
-    ob.pie_texture_animation_groups.add()
-    ob.pie_texture_animation_group_index = len(ob.pie_texture_animation_groups) - 1
-    texAnimGroupindex = ob.pie_texture_animation_group_index
-
-    ob.pie_texture_animation_groups[texAnimGroupindex].name = 'Texture Animation Group {num}'.format(num=texAnimGroupindex + 1)
-    ob.pie_texture_animation_groups[texAnimGroupindex].texAnimImages = int(polygon[5])
-    ob.pie_texture_animation_groups[texAnimGroupindex].texAnimRate = int(polygon[6])
-    ob.pie_texture_animation_groups[texAnimGroupindex].texAnimWidth = int(polygon[7])
-    ob.pie_texture_animation_groups[texAnimGroupindex].texAnimHeight = int(polygon[8])
-
-    ob.pie_texture_animation_groups[texAnimGroupindex].texAnimFaces += ' {str} '.format(str=str(index))
+    ob.pie_tex_anim_grps[grpII].name = grpName
+    ob.pie_tex_anim_grps[grpII].texAnimImages = int(poly[5])
+    ob.pie_tex_anim_grps[grpII].texAnimRate = int(poly[6])
+    ob.pie_tex_anim_grps[grpII].texAnimWidth = int(poly[7])
+    ob.pie_tex_anim_grps[grpII].texAnimHeight = int(poly[8])
 
 
 class Importer():
+
+    headers = [
+        'PIE', 'TYPE', 'TEXTURE', 'NORMALMAP', 'SPECULARMAP', 'EVENT', 
+        'LEVELS', 'LEVEL', 'POINTS', 'NORMALS', 'POLYGONS', 'CONNECTORS', 
+        'ANIMOBJECT', 'SHADOWPOINTS', 'SHADOWPOLYGONS',
+    ]
 
     def pie_parse(self, pieFile):
         pie = open(pieFile, 'r')
@@ -68,159 +62,83 @@ class Importer():
             'LEVELS': [],
         }
 
-        currentLevel = -1
-        currentlyReading = ''
+        lvl = -1
+        reading = ''
 
         for line in pie:
 
-            ls = line.split()
-
             if len(line) <= 1:
-                    continue
-
-            if 'PIE' in line:
-                currentlyReading = 'PIE'
-                pie_info['PIE'] = getNumbers(line)[0]
                 continue
 
-            elif 'TYPE' in line:
-                currentlyReading = 'TYPE'
-                pie_info['TYPE'] = getNumbers(line)[0]
-                continue
+            ls = line.split()
+            fl = ls[0]
 
-            elif 'TEXTURE' in line:
-                currentlyReading = 'TEXTURE'
-                pie_info['TEXTURE'] = line.split()[2]
-                continue
+            if fl in self.headers:
+                reading = fl
 
-            elif 'NORMALMAP' in line:
-                currentlyReading = 'NORMALMAP'
-                pie_info['NORMALMAP'] = line.split()[2]
-                continue
+                if fl in ['PIE', 'TYPE']:
+                    pie_info[fl] = ls[1]
 
-            elif 'SPECULARMAP' in line:
-                currentlyReading = 'SPECULARMAP'
-                pie_info['SPECULARMAP'] = line.split()[2]
-                continue
+                elif fl in ['TEXTURE', 'NORMALMAP', 'SPECULARMAP']:
+                    pie_info[fl] = ls[2]
 
-            elif 'EVENT' in line:
-                currentlyReading = 'EVENT'
-                ls = line.split()
-                pie_info['EVENT'].append([ls[1], ls[2]])
-                continue
+                elif fl == 'EVENT':
+                    pie_info[fl].append([ls[1], ls[2]])
 
-            elif 'LEVELS' in line:
-                currentlyReading = 'LEVELS'
-                continue
+                elif fl == 'LEVEL':
+                    pie_info['LEVELS'].append({
+                      'POINTS': [],
+                      'NORMALS': [],
+                      'POLYGONS': [],
+                      'CONNECTORS': [],
+                      'ANIMOBJECT': [],
+                      'SHADOWPOINTS': [],
+                      'SHADOWPOLYGONS': [],
+                    })
+                    lvl += 1
 
-            elif 'LEVEL' in line:
-                currentlyReading = 'LEVEL'
-                pie_info['LEVELS'].append({
-                'POINTS': [],
-                'NORMALS': [],
-                'POLYGONS': [],
-                'CONNECTORS': [],
-                'ANIMOBJECT': [],
-                'SHADOWPOINTS': [],
-                'SHADOWPOLYGONS': [],
-                })
-                currentLevel += 1
-                continue
-
-            elif ls[0] == 'POINTS':
-                currentlyReading = 'POINTS'
-                continue
-
-            elif ls[0] == 'NORMALS':
-                currentlyReading = 'NORMALS'
-                continue
-
-            elif ls[0] == 'POLYGONS':
-                currentlyReading = 'POLYGONS'
-                continue
-
-            elif ls[0] == 'CONNECTORS':
-                currentlyReading = 'CONNECTORS'
-                continue
-
-            elif ls[0] == 'ANIMOBJECT':
-                currentlyReading = 'ANIMOBJECT'
-                pie_info['LEVELS'][currentLevel]['ANIMOBJECT'].append(tuple([float(ls[1]), float(ls[2])]))
-                continue
-
-            elif ls[0] == 'SHADOWPOINTS':
-                print('currently reading = SHADOWPOINTS')
-                currentlyReading = 'SHADOWPOINTS'
-                continue
-
-            elif ls[0] == 'SHADOWPOLYGONS':
-                print('currently reading = SHADOWPOLYGONS')
-                currentlyReading = 'SHADOWPOLYGONS'
-                continue
+                elif fl == 'ANIMOBJECT':
+                    pie_info['LEVELS'][lvl][fl].append(
+                        ([float(ls[1]), float(ls[2])])
+                    )
 
             else:
 
-                if currentlyReading is 'POINTS':
-                    l = convertStrListToNumList(ls)
-                    v = (l[0] * 0.01, l[2] * 0.01, l[1] * 0.01)
+                if reading in ['POINTS', 'SHADOWPOINTS', 'CONNECTORS']:
+                    li = convertStrListToNumList(ls)
+                    
+                    if reading == 'CONNECTORS':
+                        result = (li[0] * 0.01, li[1] * 0.01, li[2] * 0.01)
+                    else:
+                        result = (li[0] * 0.01, li[2] * 0.01, li[1] * 0.01)
 
-                    pie_info['LEVELS'][currentLevel]['POINTS'].append(v)
-                    continue
+                elif reading in [
+                    'POLYGONS', 'NORMALS', 'ANIMOBJECT', 'SHADOWPOLYGONS'
+                ]:
+                    result = tuple(convertStrListToNumList(ls))
 
-                elif currentlyReading is 'NORMALS':
-                    pie_info['LEVELS'][currentLevel]['NORMALS'].append(tuple(convertStrListToNumList(ls)))
-                    continue
-
-                elif currentlyReading is 'POLYGONS':
-                    pie_info['LEVELS'][currentLevel]['POLYGONS'].append(tuple(convertStrListToNumList(ls)))
-                    continue
-
-                elif currentlyReading is 'CONNECTORS':
-                    l = convertStrListToNumList(ls)
-                    v = (l[0] * 0.01, l[1] * 0.01, l[2] * 0.01)
-
-                    pie_info['LEVELS'][currentLevel]['CONNECTORS'].append(v)
-                    continue
-
-                elif currentlyReading is 'ANIMOBJECT':
-                    pie_info['LEVELS'][currentLevel]['ANIMOBJECT'].append(tuple(convertStrListToNumList(ls)))
-                    continue
-
-                elif currentlyReading is 'SHADOWPOINTS':
-                    l = convertStrListToNumList(ls)
-                    v = (l[0] * 0.01, l[2] * 0.01, l[1] * 0.01)
-
-                    pie_info['LEVELS'][currentLevel]['SHADOWPOINTS'].append(v)
-                    continue
-
-                elif currentlyReading is 'SHADOWPOLYGONS':
-                    pie_info['LEVELS'][currentLevel]['SHADOWPOLYGONS'].append(tuple(convertStrListToNumList(ls)))
-                    continue
+                pie_info['LEVELS'][lvl][reading].append(result)
 
         return pie_info
 
-    def pie_generateBlenderObjects(self, pieParse):
-
-        pieFile = self.scene.pie_import_prop.pieFile
-
-        armature = bpy.data.armatures.new(pieFile)
-        armatureObject = bpy.data.objects.new(pieFile, armature)
+    def pie_generateBlenderObjects(self, pieParse, pieName):
+        armature = bpy.data.armatures.new(pieName)
+        armatureObject = bpy.data.objects.new(pieName, armature)
         bpy.context.collection.objects.link(armatureObject)
 
         armatureObject.pie_object_prop.pieType = 'ROOT'
-
         armatureObject.show_in_front = True
 
-        currentLevel = 0
+        currentLvl = 0
 
         for action in bpy.data.actions:
-            if action.name == pieFile + ' Anim':
+            if action.name == pieName + ' Anim':
                 bpy.data.actions.remove(action)
 
         for level in pieParse['LEVELS']:
-            currentLevel += 1
+            currentLvl += 1
 
-            nameStr = '{name} Level{num}'.format(name=pieFile, num=currentLevel)
+            nameStr = '{n} Level{ii}'.format(n=pieName, ii=currentLvl)
 
             bpy.context.view_layer.objects.active = armatureObject
             bpy.ops.object.mode_set(mode='EDIT', toggle=False)
@@ -238,144 +156,129 @@ class Importer():
             mesh = bpy.data.meshes.new(nameStr)
             mesh.uv_layers.new()
 
-            meshObject = bpy.data.objects.new(nameStr , mesh)
-            meshObject.parent = armatureObject
-            meshObject.parent_type = 'BONE'
-            meshObject.parent_bone = nameStr
-            bpy.context.collection.objects.link(meshObject)
+            meshOb = bpy.data.objects.new(nameStr, mesh)
+            meshOb.parent = armatureObject
+            meshOb.parent_type = 'BONE'
+            meshOb.parent_bone = nameStr
+            bpy.context.collection.objects.link(meshOb)
 
-            meshObject.pie_object_prop.pieType = 'LEVEL'
+            meshOb.pie_object_prop.pieType = 'LEVEL'
 
-            bpy.context.view_layer.objects.active = meshObject
+            bpy.context.view_layer.objects.active = meshOb
 
-            #* POINTS/POLYGONS *#
+            # * POINTS/POLYGONS * #
 
             pie_points = level['POINTS']
             pie_polygons = []
             
-            for poly in level['POLYGONS']:
-                pie_polygons.append((poly[2], poly[3], poly[4]))
-
+            for p in level['POLYGONS']:
+                pie_polygons.append((p[2], p[3], p[4]))
 
             mesh.from_pydata(pie_points, [], pie_polygons)
 
-            ii = 0
-            for poly in level['POLYGONS']:
-                loop = ii * 3
+            animatedPolygons = []
+            for ii, p in enumerate(level['POLYGONS']):
+                L = ii * 3
 
-                if int(poly[0]) == 200:
+                uvData = meshOb.data.uv_layers.active.data
 
-                    if pieParse['PIE'] is 3:
-                        meshObject.data.uv_layers.active.data[loop + 0].uv = ((poly[5], -poly[6] + 1))
-                        meshObject.data.uv_layers.active.data[loop + 1].uv = ((poly[7], -poly[8] + 1))
-                        meshObject.data.uv_layers.active.data[loop + 2].uv = ((poly[9], -poly[10] + 1))
-                    elif pieParse['PIE'] is 2:
-                        meshObject.data.uv_layers.active.data[loop + 0].uv = ((poly[5] / 256, (-poly[6] / 256) + 1))
-                        meshObject.data.uv_layers.active.data[loop + 1].uv = ((poly[7] / 256, (-poly[8] / 256) + 1))
-                        meshObject.data.uv_layers.active.data[loop + 2].uv = ((poly[9] / 256, (-poly[10] / 256) + 1))
+                n = 256
+                # m is for modifying the index taken as UV data
+                # depending on if the PIE polygon is animated.
+                m = 0
+                if int(p[0] == 4200):
+                    animatedPolygons.append(ii)
+                    m = 4
 
-                elif int(poly[0]) == 4200:
-
-                    if meshObject.pie_texture_animation_groups is None:
-                        newTexAnimGroup(meshObject, poly, ii)
-                    else:
-                        success = False
-                        for texAnimGroup in meshObject.pie_texture_animation_groups:
+                if pieParse['PIE'] == '3':
+                    uvData[L + 0].uv = ((p[5 + m], -p[6 + m] + 1))
+                    uvData[L + 1].uv = ((p[7 + m], -p[8 + m] + 1))
+                    uvData[L + 2].uv = ((p[9 + m], -p[10 + m] + 1))
+                elif pieParse['PIE'] == '2':
+                    uvData[L + 0].uv = ((p[5 + m] / n, (-p[6 + m] / n) + 1))
+                    uvData[L + 1].uv = ((p[7 + m] / n, (-p[8 + m] / n) + 1))
+                    uvData[L + 2].uv = ((p[9 + m] / n, (-p[10 + m] / n) + 1))
                     
-                            if (int(poly[5]) == texAnimGroup.texAnimImages and int(poly[6]) == texAnimGroup.texAnimRate and int(poly[7]) == texAnimGroup.texAnimWidth and int(poly[8]) == texAnimGroup.texAnimHeight):
-                                texAnimGroup.texAnimFaces += ' {str} '.format(str=str(ii))
-                                success = True
-                                break
-                    
-                        if success is False:
-                            newTexAnimGroup(meshObject, poly, ii)
-                            
+            bpy.ops.object.mode_set(mode='EDIT', toggle=False)
+            bm = bmesh.from_edit_mesh(mesh)
+            faces = bm.faces
 
-                    if pieParse['PIE'] is 3:
-                        meshObject.data.uv_layers.active[loop + 0].uv = ((poly[9], -poly[10] + 1))
-                        meshObject.data.uv_layers.active[loop + 1].uv = ((poly[11], -poly[12] + 1))
-                        meshObject.data.uv_layers.active[loop + 2].uv = ((poly[13], -poly[14] + 1))
-                    elif pieParse['PIE'] is 2:
-                        meshObject.data.uv_layers.active[loop + 0].uv = ((poly[9] / 256, (-poly[10] / 256) + 1))
-                        meshObject.data.uv_layers.active[loop + 1].uv = ((poly[11] / 256, (-poly[12] / 256) + 1))
-                        meshObject.data.uv_layers.active[loop + 2].uv = ((poly[13] / 256, (-poly[14] / 256) + 1))
-                    
-                ii += 1
+            for ii in animatedPolygons:
+                p = level['POLYGONS'][ii]
 
-            #* SHADOW POINTS/POLYGONS *#
+                if meshOb.pie_tex_anim_grps is None:
+                    newTexAnimGroup(meshOb, p)
+                    layer = getTexAnimGrp(
+                        bm, str(len(meshOb.pie_tex_anim_grps) - 1)
+                    )
+                    faces.ensure_lookup_table()
+                    faces[ii][layer] = 1
+                else:
+                    success = False
+                    for jj, tAnimGp in enumerate(meshOb.pie_tex_anim_grps):
+                
+                        if (int(p[5]) == tAnimGp.texAnimImages and 
+                                int(p[6]) == tAnimGp.texAnimRate and 
+                                int(p[7]) == tAnimGp.texAnimWidth and 
+                                int(p[8]) == tAnimGp.texAnimHeight):
 
-            print(level['SHADOWPOINTS'])
-            print(level['SHADOWPOLYGONS'])
-            print(len(level['POLYGONS']))
+                            layer = getTexAnimGrp(bm, str(jj))
+                            # faces.ensure_lookup_table()
+                            faces[ii][layer] = 1
+                            success = True
+                            break
+                
+                    if success is False:
+                        newTexAnimGroup(meshOb, p)
+                        layer = getTexAnimGrp(
+                            bm, str(len(meshOb.pie_tex_anim_grps) - 1)
+                        )
+                        faces.ensure_lookup_table()
+                        faces[ii][layer] = 1
+
+            bpy.ops.object.mode_set(mode='OBJECT', toggle=False)
+
+            # * SHADOW POINTS/POLYGONS * #
 
             if level['SHADOWPOINTS'] and level['SHADOWPOLYGONS']:
 
-                meshObject.pie_object_prop.shadowType = 'CUSTOM'
+                meshOb.pie_object_prop.shadowType = 'CUSTOM'
             
-                shadowMesh = bpy.data.meshes.new(nameStr + ' Shadow')
-                shadowMeshObject = bpy.data.objects.new(nameStr + ' Shadow' , shadowMesh)
-                shadowMeshObject.parent = meshObject
+                shMesh = bpy.data.meshes.new(nameStr + ' Shadow')
+                shMeshOb = bpy.data.objects.new(nameStr + ' Shadow', shMesh)
+                shMeshOb.parent = meshOb
 
-                shadowMeshObject.pie_object_prop.pieType = 'SHADOW'
+                shMeshOb.pie_object_prop.pieType = 'SHADOW'
 
-                bpy.context.collection.objects.link(shadowMeshObject)
+                bpy.context.collection.objects.link(shMeshOb)
 
-                shadow_points = level['SHADOWPOINTS']
-                shadow_polygons = []
+                sh_points = level['SHADOWPOINTS']
+                sh_polygons = []
                 
-                for poly in level['SHADOWPOLYGONS']:
-                    shadow_polygons.append((poly[2], poly[3], poly[4]))
+                for p in level['SHADOWPOLYGONS']:
+                    sh_polygons.append((p[2], p[3], p[4]))
 
-                shadowMesh.from_pydata(shadow_points, [], shadow_polygons)
+                shMesh.from_pydata(sh_points, [], sh_polygons)
 
-            #* NORMALS *#
-
-            #if level['NORMALS']:
-                #meshObject.pie_object_prop.exportNormals = True
-
-                #normals = []
-                #verts = []
-                #ii = 0
-                #for poly in mesh.polygons:
-                #    jj = 0
-                #    poly.use_smooth = True
-                #    print(poly.normal)
-                #    for vertex in poly.vertices:
-                #        if vertex not in verts:
-                #            verts.append(vertex)
-                #            meshObject.data.vertices[vertex].normal = (level['NORMALS'][ii][jj], level['NORMALS'][ii][jj + 1], level['NORMALS'][ii][jj + 2])
-                #            #print(*(level['NORMALS'][ii][jj], level['NORMALS'][ii][jj + 1], level['NORMALS'][ii][jj + 2]))
-                #            #print(meshObject.data.vertices[vertex].normal)
-                #            normals.append(meshObject.data.vertices[vertex].normal)
-                #        jj += 3
-                #    ii += 1
-
-                #mesh.create_normals_split()
-
-                #mesh.calc_normals_split()
-
-                #mesh.show_normal_vertex = mesh.show_normal_loop = True
-
-                #mesh.normals_split_custom_set([(0,0,0) for l in mesh.loops])
-                #mesh.normals_split_custom_set_from_vertices(normals)
-
-            #* CONNECTORS *#
+            # * CONNECTORS * #
 
             ii = 1
             for connector in level['CONNECTORS']:
-                connectorObject = bpy.data.objects.new('{name} Connector{num}'.format(name=nameStr, num=ii), None)
-                connectorObject.empty_display_size = 0.125
-                connectorObject.empty_display_type = 'ARROWS'
-                connectorObject.location = connector
-                connectorObject.parent = meshObject
+                connectorOb = bpy.data.objects.new(
+                    '{name} Connector{num}'.format(name=nameStr, num=ii), None
+                )
+                connectorOb.empty_display_size = 0.125
+                connectorOb.empty_display_type = 'ARROWS'
+                connectorOb.location = connector
+                connectorOb.parent = meshOb
 
-                connectorObject.pie_object_prop.pieType = 'CONNECTOR'
+                connectorOb.pie_object_prop.pieType = 'CONNECTOR'
 
-                bpy.context.collection.objects.link(connectorObject)
+                bpy.context.collection.objects.link(connectorOb)
 
                 ii += 1
 
-            #* ANIMOBJECT *#
+            # * ANIMOBJECT * #
 
             bpy.context.view_layer.objects.active = armatureObject
             bpy.ops.object.mode_set(mode='POSE', toggle=False)
@@ -386,23 +289,23 @@ class Importer():
 
                 if armatureObject.animation_data is None:
                     armatureObject.animation_data_create()
-                    action = bpy.data.actions.new(pieFile + ' Anim')
+                    action = bpy.data.actions.new(pieName + ' Anim')
 
                 armatureObject.animation_data.action = action
 
-                locAnimPath = 'pose.bones["{name}"].location'.format(name=nameStr)
-                rotAnimPath = 'pose.bones["{name}"].rotation_euler'.format(name=nameStr)
-                sclAnimPath = 'pose.bones["{name}"].scale'.format(name=nameStr)
+                lAP = 'pose.bones["{n}"].location'.format(n=nameStr)
+                rAP = 'pose.bones["{n}"].rotation_euler'.format(n=nameStr)
+                sAP = 'pose.bones["{n}"].scale'.format(n=nameStr)
 
-                locXCurve = action.fcurves.new(locAnimPath, index=0, action_group=nameStr)
-                locYCurve = action.fcurves.new(locAnimPath, index=1, action_group=nameStr)
-                locZCurve = action.fcurves.new(locAnimPath, index=2, action_group=nameStr)
-                rotXCurve = action.fcurves.new(rotAnimPath, index=0, action_group=nameStr)
-                rotYCurve = action.fcurves.new(rotAnimPath, index=1, action_group=nameStr)
-                rotZCurve = action.fcurves.new(rotAnimPath, index=2, action_group=nameStr)
-                sclXCurve = action.fcurves.new(sclAnimPath, index=0, action_group=nameStr)
-                sclYCurve = action.fcurves.new(sclAnimPath, index=1, action_group=nameStr)
-                sclZCurve = action.fcurves.new(sclAnimPath, index=2, action_group=nameStr)
+                lXCrv = action.fcurves.new(lAP, index=0, action_group=nameStr)
+                lYCrv = action.fcurves.new(lAP, index=1, action_group=nameStr)
+                lZCrv = action.fcurves.new(lAP, index=2, action_group=nameStr)
+                rXCrv = action.fcurves.new(rAP, index=0, action_group=nameStr)
+                rYCrv = action.fcurves.new(rAP, index=1, action_group=nameStr)
+                rZCrv = action.fcurves.new(rAP, index=2, action_group=nameStr)
+                sXCrv = action.fcurves.new(sAP, index=0, action_group=nameStr)
+                sYCrv = action.fcurves.new(sAP, index=1, action_group=nameStr)
+                sZCrv = action.fcurves.new(sAP, index=2, action_group=nameStr)
 
                 if len(level['ANIMOBJECT']) > 1:
                     self.scene.frame_start = level['ANIMOBJECT'][1][0]
@@ -410,23 +313,22 @@ class Importer():
                 for key in level['ANIMOBJECT']:
                     
                     if len(key) < 10:
-                        meshObject.pie_object_prop.animTime = key[0]
-                        meshObject.pie_object_prop.animCycle = key[1]
+                        meshOb.pie_object_prop.animTime = key[0]
+                        meshOb.pie_object_prop.animCycle = key[1]
                         continue
 
-                    locXCurve.keyframe_points.insert(key[0], key[1] * 0.00001)
-                    locYCurve.keyframe_points.insert(key[0], key[2] * 0.00001)
-                    locZCurve.keyframe_points.insert(key[0], key[3] * 0.00001)
-                    rotXCurve.keyframe_points.insert(key[0], key[4] * 0.0000174533)
-                    rotYCurve.keyframe_points.insert(key[0], key[5] * 0.0000174533)
-                    rotZCurve.keyframe_points.insert(key[0], key[6] * 0.0000174533)
-                    sclXCurve.keyframe_points.insert(key[0], key[7])
-                    sclYCurve.keyframe_points.insert(key[0], key[8])
-                    sclZCurve.keyframe_points.insert(key[0], key[9])
+                    lXCrv.keyframe_points.insert(key[0], key[1] * 0.00001)
+                    lYCrv.keyframe_points.insert(key[0], key[2] * 0.00001)
+                    lZCrv.keyframe_points.insert(key[0], key[3] * 0.00001)
+                    rXCrv.keyframe_points.insert(key[0], key[4] * 0.0000174533)
+                    rYCrv.keyframe_points.insert(key[0], key[5] * 0.0000174533)
+                    rZCrv.keyframe_points.insert(key[0], key[6] * 0.0000174533)
+                    sXCrv.keyframe_points.insert(key[0], key[7])
+                    sYCrv.keyframe_points.insert(key[0], key[8])
+                    sZCrv.keyframe_points.insert(key[0], key[9])
 
                     if self.scene.frame_end < key[0]:
                         self.scene.frame_end = key[0]
-
 
             armatureObject.select_set(True)
             bpy.context.view_layer.objects.active = armatureObject
@@ -435,105 +337,43 @@ class Importer():
 
             bpy.ops.object.mode_set(mode='OBJECT', toggle=False)
 
-            self.pie_loadProperties(pieParse, armatureObject, pieFile)
+            self.pie_loadProperties(pieParse, armatureObject)
 
-    
-    def pie_loadProperties(self, pieParse, pieObject, pieName):
-
+    def pie_loadProperties(self, pieParse, pieObject):
         objProp = pieObject.pie_object_prop
 
-        objProp.pieName = pieName.rsplit('.pie', 1)[0]
-
-        def getTypeFlags(num):
-            flags = []
-            while num != 0:
-                flags.append(num % 10)
-                num = num // 10
-            return flags
-
+        objProp.pieVersion = pieParse['PIE']
         objProp.texture = pieParse['TEXTURE']
         objProp.normal = pieParse['NORMALMAP']
         objProp.specular = pieParse['SPECULARMAP']
 
         for event in pieParse['EVENT']:
-            if event[0] is '1':
+            if event[0] == '1':
                 objProp.event1 = event[1]
-            elif event[0] is '2':
+            elif event[0] == '2':
                 objProp.event2 = event[1]
-            elif event[0] is '3':
+            elif event[0] == '3':
                 objProp.event3 = event[1]
 
-        flags = getTypeFlags(pieParse['TYPE'])
+        def getMaskArray(pieType, len):
+            flagsStr = str(bin(int(pieType, 16)))[2:][::-1].ljust(len, '0')
+            return [int(ii) for ii in flagsStr]
 
-        if flags[0] is 1:
-            objProp.adrOff = True
-            objProp.adrOn = False
-            objProp.pmr = False
-        elif flags[0] is 2:
-            objProp.adrOff = False
-            objProp.adrOn = True
-            objProp.pmr = False
-        elif flags[0] is 3:
-            objProp.adrOff = True
-            objProp.adrOn = True
-            objProp.pmr = False
-        elif flags[0] is 4:
-            objProp.adrOff = False
-            objProp.adrOn = False
-            objProp.pmr = True
-        elif flags[0] is 5:
-            objProp.adrOff = True
-            objProp.adrOn = False
-            objProp.pmr = True
-        elif flags[0] is 6:
-            objProp.adrOff = False
-            objProp.adrOn = True
-            objProp.pmr = True
-        elif flags[0] is 7:
-            objProp.adrOff = True
-            objProp.adrOn = True
-            objProp.pmr = True
-        else:
-            objProp.adrOff = False
-            objProp.adrOn = False
-            objProp.pmr = False
-        
-        if len(flags) > 1:
-            if flags[1] is 1:
-                objProp.roll = True
-                objProp.pitch = False
-            elif flags[1] is 2:
-                objProp.roll = False
-                objProp.pitch = True
-            elif flags[1] is 3:
-                objProp.roll = True
-                objProp.pitch = True
-            else:
-                objProp.roll = False
-                objProp.pitch = False
-        
-        if len(flags) > 2:
-            if flags[2] is 2:
-                objProp.reserved = True
-            else:
-                objProp.reserved = False
-        
-        if len(flags) > 3:
-            if flags[3] is 1:
-                objProp.stretch = True
-            else:
-                objProp.stretch = False
-        
-        if len(flags) > 4:
-            if flags[4] is 1:
-                objProp.tcMask = True
-            else:
-                objProp.tcMask = False
+        flags = getMaskArray(pieParse['TYPE'], 17)
+
+        objProp.adrOff = flags[0]
+        objProp.adrOn = flags[1]
+        objProp.pmr = flags[2]
+        objProp.pitch = flags[4]
+        objProp.roll = flags[5]
+        objProp.reserved = flags[9]
+        objProp.stretch = flags[12]
+        objProp.tcMask = flags[16]
 
     def pie_import_quick(self, scene, pieDir, pieMesh):
         self.scene = scene
 
-        pieParse = self.pie_parse(pieDir + '\\\\' + pieMesh)
+        pieParse = self.pie_parse(pieDir + '\\\\' + pieMesh, pieMesh)
 
         self.pie_generateBlenderObjects(pieParse)
 
@@ -542,4 +382,6 @@ class Importer():
 
         pieParse = self.pie_parse(pieDir)
 
-        self.pie_generateBlenderObjects(pieParse)
+        self.pie_generateBlenderObjects(
+            pieParse, pieDir.rsplit('.', 1)[0].rsplit('\\', 1)[1]
+        )

--- a/tools/blender/2.9x/pie_addon/shared.py
+++ b/tools/blender/2.9x/pie_addon/shared.py
@@ -1,0 +1,2 @@
+def getTexAnimGrp(bm, layer):
+    return bm.faces.layers.int.get(layer) or bm.faces.layers.int.new(layer)


### PR DESCRIPTION
Improved functionality of texture animations groups. They should now work well with modified geometry.

Added the ability to export PIE 2 models.

Tightened up the code in various areas and also made it more compliant with PEP8 standards.