### PR TITLE
Fix crash: calling front() on empty array is undefined behavior

### DIFF
--- a/lib/framework/wzconfig.cpp
+++ b/lib/framework/wzconfig.cpp
@@ -417,6 +417,10 @@ void WzConfig::beginArray(const WzString &name)
 		}
 		ASSERT(it.value().is_array(), "%s: beginArray() on non-array key \"%s\"", mFilename.toUtf8().c_str(), name.toUtf8().c_str());
 		mArray = it.value();
+		if (mArray.size() == 0)
+		{
+			return;
+		}
 		ASSERT(mArray.front().is_object(), "%s: beginArray() on non-object array \"%s\"", mFilename.toUtf8().c_str(), name.toUtf8().c_str());
 		pCurrentObj = &mArray.front();
 	}


### PR DESCRIPTION
I believe this fixes https://sentry.io/organizations/warzone2100/issues/2605274273/events/0cb438ff78034deeb7351748742c068f/?project=5174820

Easily reproducible, store a template, then manually delete it from `templates.json`, leaving only empty array, obtain a crash