### PR TITLE
Improve the "Campaign message" title

### DIFF
--- a/src/intelmap.cpp
+++ b/src/intelmap.cpp
@@ -1084,7 +1084,7 @@ static const char* getMessageTitle(const MESSAGE& message)
 		research = getResearchForMsg(message.pViewData);
 		return research ? _(research->name.toUtf8().c_str()) : _("Research Update");
 	case MSG_CAMPAIGN:
-		return _("Project Goals");
+		return _("Project Goals and Updates");
 	case MSG_MISSION:
 		return _("Current Objective");
 	default:


### PR DESCRIPTION
Will be needed for a future camBalance update where I specify the message type via the scripts since almost all are classified as objectives cause nobody noticed `CAMP_MSG` is a thing when creating the new scripts.

A lot of campaign descriptions that could use the goal title (and definitely are not objectives) really are a mixture of goals and what I'm calling "Project Updates" which fits with the `CAMP_MSG` "info" button image.