### PR TITLE
Campaign tweaks

### DIFF
--- a/data/base/messages/strings/cam1strings.txt
+++ b/data/base/messages/strings/cam1strings.txt
@@ -46,8 +46,8 @@ SUB1_8_MSG3			_("Eradicate the base and secure the area.")
 
 /* Campaign Mission briefing additional */
 CAM1CA_MSG1			_("ALPHA BASE MISSION: Establish a Forward Base")
-CAM1CA_MSG2			_("Establish a forward base on the plateau.")
-CAM1CA_MSG3			_("Build defensive structures.")
+CAM1CA_MSG2			_("Establish a forward base on the plateau and fend off the New Paradigm.")
+CAM1CA_MSG3			_("Build defensive structures until the green objective blip disappears.")
 
 CAM1A-C_MSG1			_("ALPHA BASE MISSION: Counter Attack")
 CAM1A-C_MSG2			_("Enemy forces are approaching from the east and north.")

--- a/src/console.cpp
+++ b/src/console.cpp
@@ -46,7 +46,8 @@
 
 // FIXME: When we switch over to full JS, use class version of this file
 
-#define	DEFAULT_MESSAGE_DURATION	GAME_TICKS_PER_SEC * 4
+#define	DEFAULT_MESSAGE_DURATION			GAME_TICKS_PER_SEC * 4
+#define	DEFAULT_MESSAGE_DURATION_CAMPAIGN	GAME_TICKS_PER_SEC * 12
 // Chat/history "window"
 #define CON_BORDER_WIDTH			4
 #define CON_BORDER_HEIGHT			4
@@ -137,9 +138,10 @@ void setConsoleCalcLayout(const CONSOLE_CALC_LAYOUT_FUNC& layoutFunc)
 /** Sets the system up */
 void	initConsoleMessages()
 {
+	unsigned int duration = (game.type == LEVEL_TYPE::SKIRMISH) ? DEFAULT_MESSAGE_DURATION : DEFAULT_MESSAGE_DURATION_CAMPAIGN;
 	linePitch = iV_GetTextLineSize(font_regular);
 	bConsoleDropped = false;
-	setConsoleMessageDuration(DEFAULT_MESSAGE_DURATION);	// Setup how long messages are displayed for
+	setConsoleMessageDuration(duration);					// Setup how long messages are displayed for
 	setConsoleBackdropStatus(true);							// No box under the text
 	enableConsoleDisplay(true);								// Turn on the console display
 
@@ -475,7 +477,7 @@ void	displayConsoleMessages()
 		tmp -= i->display.width();
 		console_drawtext(i->display, getConsoleTextColor(i->player), tmp - 6, linePitch - 2, i->JustifyType, i->display.width());
 	}
-	
+
 	if (!ActiveMessages.empty())
 	{
 		int TextYpos = mainConsole.topY;


### PR DESCRIPTION
Increases console message duration for campaign/tutorial and improves the Intel menu text for Alpha 7. I also increased the build area significantly for where structures are checked on the plateau, however, this part will come when I send the next camBalance update for Gamma changes.

Fixes #2195.