### PR TITLE
(MP)Some changes in howitzer parameters

### DIFF
--- a/data/mp/stats/research.json
+++ b/data/mp/stats/research.json
@@ -1306,6 +1306,7 @@
 			"Emplacement-Howitzer105"
 		],
 		"requiredResearch": [
+			"R-Defense-Howitzer",
 			"R-Wpn-Howitzer03-Rot"
 		],
 		"researchPoints": 5000,
@@ -7073,7 +7074,6 @@
 		"name": "Howitzer",
 		"requiredResearch": [
 			"R-Wpn-Mortar-Damage04",
-			"R-Wpn-Cannon-Accuracy02",
 			"R-Wpn-Cannon-Damage05",
 			"R-Sys-Sensor-Upgrade01"
 		],

--- a/data/mp/stats/weapons.json
+++ b/data/mp/stats/weapons.json
@@ -2071,7 +2071,7 @@
 		"muzzleGfx": "FxCan75m.PIE",
 		"name": "Incendiary Howitzer",
 		"numExplosions": 12,
-		"periodicalDamage": 100,
+		"periodicalDamage": 90,
 		"periodicalDamageRadius": 192,
 		"periodicalDamageTime": 60,
 		"periodicalDamageWeaponClass": "HEAT",
@@ -2173,7 +2173,7 @@
 		"weight": 10000
 	},
 	"Howitzer150Mk1": {
-		"buildPoints": 1600,
+		"buildPoints": 1800,
 		"buildPower": 450,
 		"damage": 350,
 		"designable": 1,


### PR DESCRIPTION
Binding Hellstorm Emplacement to Howitzer Emplacement.
Of the necessary research to obtain a howitzer, the Cannon Laser Designator is removed.
Slightly increased the production time of Ground Shaker.
Slightly decreased Incendiary Howitzer's periodic damage.