### PR TITLE
[GitHub Actions] Explicitly bump snapcore/action-build to v1.0.9

### DIFF
--- a/.github/workflows/CI_snapcraft.yml
+++ b/.github/workflows/CI_snapcraft.yml
@@ -90,7 +90,7 @@ jobs:
         EOENV
     - name: Build .SNAP
       id: snapcraft
-      uses: snapcore/action-build@v1
+      uses: snapcore/action-build@v1.0.9
     - name: Gather .SNAP
       run: |
         OUTPUT_DIR="${HOME}/output"

--- a/.github/workflows/generate_snap_stable_config.yml
+++ b/.github/workflows/generate_snap_stable_config.yml
@@ -148,7 +148,7 @@ jobs:
         id: build-stable
         if: success() && (steps.commit-snap-changes.outputs.PROCESS_DEPLOYMENT == 'true')
         continue-on-error: true
-        uses: snapcore/action-build@v1
+        uses: snapcore/action-build@v1.0.9
         with:
           path: ${{ github.workspace }}/snap-stable-build
       - name: Fail-check


### PR DESCRIPTION
To fix an issue: https://github.com/snapcore/action-build/releases/tag/v1.0.9