### PR TITLE
Support non-0-index hostPlayer, configuring "spectatorHost" from autohost json

### DIFF
--- a/lib/netplay/netplay.cpp
+++ b/lib/netplay/netplay.cpp
@@ -4032,7 +4032,7 @@ bool NEThostGame(const char *SessionName, const char *PlayerName, bool spectator
 	MultiPlayerJoin(selectedPlayer);
 
 	// Now switch player color of the host to what they normally use for SP games
-	if (war_getMPcolour() >= 0)
+	if (NetPlay.hostPlayer < MAX_PLAYERS && war_getMPcolour() >= 0)
 	{
 		changeColour(NetPlay.hostPlayer, war_getMPcolour(), true);
 	}

--- a/lib/netplay/netplay.h
+++ b/lib/netplay/netplay.h
@@ -425,7 +425,7 @@ bool NETenumerateGames(const std::function<bool (const GAMESTRUCT& game)>& handl
 bool NETfindGames(std::vector<GAMESTRUCT>& results, size_t startingIndex, size_t resultsLimit, bool onlyMatchingLocalVersion = false);
 bool NETfindGame(uint32_t gameId, GAMESTRUCT& output);
 bool NETjoinGame(const char *host, uint32_t port, const char *playername, bool asSpectator = false); // join game given with playername
-bool NEThostGame(const char *SessionName, const char *PlayerName,// host a game
+bool NEThostGame(const char *SessionName, const char *PlayerName, bool spectatorHost, // host a game
                  uint32_t gameType, uint32_t two, uint32_t three, uint32_t four, UDWORD plyrs);
 bool NETchangePlayerName(UDWORD player, char *newName);// change a players name.
 void NETfixDuplicatePlayerNames();  // Change a player's name automatically, if there are duplicates.

--- a/src/multiint.cpp
+++ b/src/multiint.cpp
@@ -5331,7 +5331,7 @@ static void loadMapPlayerSettings(WzConfig& ini)
 			havePosition |= PlayerMask(1) << NetPlay.players[i].position;
 			if (havePosition == old)
 			{
-				ASSERT(false, "Duplicate position %d", NetPlay.players[i].position);
+				ASSERT(false, "Duplicate position %d at index: %d", NetPlay.players[i].position, i);
 				NetPlay.players[i].position = MAX_PLAYERS;
 			}
 		}

--- a/src/multiint.cpp
+++ b/src/multiint.cpp
@@ -5192,6 +5192,9 @@ static void loadMapChallengeSettings(WzConfig& ini)
 			sstrcpy(game.name, ini.value("name").toWzString().toUtf8().c_str());
 			game.techLevel = ini.value("techLevel", game.techLevel).toInt();
 
+			// Allow making the host a spectator (for MP games)
+			spectatorHost = ini.value("spectatorHost", false).toBool();
+
 			// DEPRECATED: This seems to have been odd workaround for not having the locked group handled.
 			//             Keeping it around in case mods use it.
 			locked.position = !ini.value("allowPositionChange", !locked.position).toBool();

--- a/src/multiint.cpp
+++ b/src/multiint.cpp
@@ -1088,7 +1088,7 @@ static JoinGameResult joinGameInternalConnect(const char *host, uint32_t port, s
 
 	changeTitleUI(std::make_shared<WzMultiplayerOptionsTitleUI>(oldUI));
 
-	if (war_getMPcolour() >= 0)
+	if (selectedPlayer < MAX_PLAYERS && war_getMPcolour() >= 0)
 	{
 		SendColourRequest(selectedPlayer, war_getMPcolour());
 	}
@@ -2721,6 +2721,11 @@ bool changeColour(unsigned player, int col, bool isHost)
 		return true;
 	}
 
+	if (player >= MAX_PLAYERS)
+	{
+		return true;
+	}
+
 	if (getPlayerColour(player) == col)
 	{
 		return true;  // Nothing to do.
@@ -3277,7 +3282,7 @@ static SwapPlayerIndexesResult recvSwapPlayerIndexes(NETQUEUE queue, const std::
 		setMultiStats(selectedPlayer, playerStats, false);
 		setMultiStats(selectedPlayer, playerStats, true);
 
-		if (war_getMPcolour() >= 0)
+		if (selectedPlayer < MAX_PLAYERS && war_getMPcolour() >= 0)
 		{
 			SendColourRequest(selectedPlayer, war_getMPcolour());
 		}
@@ -5365,6 +5370,7 @@ static int playersPerTeam()
 
 static void swapPlayerColours(uint32_t player1, uint32_t player2)
 {
+	ASSERT_OR_RETURN(, player1 < MAX_PLAYERS && player2 < MAX_PLAYERS, "player1 (%" PRIu32 ") & player2 (%" PRIu32 ") must be < MAX_PLAYERS", player1, player2);
 	auto player1Colour = getPlayerColour(player1);
 	setPlayerColour(player1, getPlayerColour(player2));
 	setPlayerColour(player2, player1Colour);
@@ -5415,12 +5421,15 @@ static void resetPlayerConfiguration(const bool bShouldResetLocal = false)
 
 	sstrcpy(NetPlay.players[selectedPlayer].name, sPlayer);
 
-	for (unsigned playerIndex = 0; playerIndex < MAX_PLAYERS; playerIndex++)
+	if (selectedPlayer < MAX_PLAYERS)
 	{
-		if (getPlayerColour(playerIndex) == war_getMPcolour())
+		for (unsigned playerIndex = 0; playerIndex < MAX_PLAYERS; playerIndex++)
 		{
-			swapPlayerColours(selectedPlayer, playerIndex);
-			break;
+			if (getPlayerColour(playerIndex) == war_getMPcolour())
+			{
+				swapPlayerColours(selectedPlayer, playerIndex);
+				break;
+			}
 		}
 	}
 }

--- a/src/multijoin.cpp
+++ b/src/multijoin.cpp
@@ -430,7 +430,7 @@ bool sendDataCheck()
 {
 	int i = 0;
 
-	NETbeginEncode(NETnetQueue(NET_HOST_ONLY), NET_DATA_CHECK);		// only need to send to HOST
+	NETbeginEncode(NETnetQueue(NetPlay.hostPlayer), NET_DATA_CHECK);		// only need to send to HOST
 	for (i = 0; i < DATA_MAXDATA; i++)
 	{
 		NETuint32_t(&DataHash[i]);

--- a/src/multimenu.cpp
+++ b/src/multimenu.cpp
@@ -911,9 +911,9 @@ private:
 	{
 		for (auto &playerWidget: playersWidgets)
 		{
-			const auto color = GetPlayerTextColor((selectedPlayer < MAX_PLAYERS) ? alliances[selectedPlayer][playerWidget.player] : 0, playerWidget.player);
+			const auto color = GetPlayerTextColor((selectedPlayer < MAX_PLAYERS && playerWidget.player < MAX_PLAYERS) ? alliances[selectedPlayer][playerWidget.player] : 0, playerWidget.player);
 			const bool isHuman = isHumanPlayer(playerWidget.player);
-			const bool isAlly = (selectedPlayer < MAX_PLAYERS) && aiCheckAlliances(selectedPlayer, playerWidget.player);
+			const bool isAlly = (selectedPlayer < MAX_PLAYERS && playerWidget.player < MAX_PLAYERS) && aiCheckAlliances(selectedPlayer, playerWidget.player);
 			const bool isSelectedPlayer = playerWidget.player == selectedPlayer;
 
 			playerWidget.name->setFontColour(color);
@@ -921,6 +921,11 @@ private:
 			playerWidget.kills->setFontColour(color);
 			playerWidget.units->setFontColour(color);
 			playerWidget.lastColumn->setFontColour(color);
+
+			if (playerWidget.player >= MAX_PLAYERS)
+			{
+				continue;
+			}
 
 			char scoreString[128];
 			char killsString[20];

--- a/src/multiopt.cpp
+++ b/src/multiopt.cpp
@@ -258,7 +258,7 @@ void recvOptions(NETQUEUE queue)
 		NetPlay.wzFiles.emplace_back(pFileHandle, filename, hash);
 
 		// Request the map/mod from the host
-		NETbeginEncode(NETnetQueue(NET_HOST_ONLY), NET_FILE_REQUESTED);
+		NETbeginEncode(NETnetQueue(NetPlay.hostPlayer), NET_FILE_REQUESTED);
 		NETbin(hash.bytes, hash.Bytes);
 		NETend();
 
@@ -349,13 +349,13 @@ void recvOptions(NETQUEUE queue)
 
 // ////////////////////////////////////////////////////////////////////////////
 // Host Campaign.
-bool hostCampaign(const char *SessionName, char *hostPlayerName, bool skipResetAIs)
+bool hostCampaign(const char *SessionName, char *hostPlayerName, bool spectatorHost, bool skipResetAIs)
 {
 	debug(LOG_WZ, "Hosting campaign: '%s', player: '%s'", SessionName, hostPlayerName);
 
 	freeMessages();
 
-	if (!NEThostGame(SessionName, hostPlayerName, static_cast<uint32_t>(game.type), 0, 0, 0, game.maxPlayers))
+	if (!NEThostGame(SessionName, hostPlayerName, spectatorHost, static_cast<uint32_t>(game.type), 0, 0, 0, game.maxPlayers))
 	{
 		return false;
 	}
@@ -393,7 +393,7 @@ bool hostCampaign(const char *SessionName, char *hostPlayerName, bool skipResetA
 bool sendLeavingMsg()
 {
 	debug(LOG_NET, "We are leaving 'nicely'");
-	NETbeginEncode(NETnetQueue(NET_HOST_ONLY), NET_PLAYER_LEAVING);
+	NETbeginEncode(NETnetQueue(NetPlay.hostPlayer), NET_PLAYER_LEAVING);
 	{
 		bool host = NetPlay.isHost;
 		uint32_t id = selectedPlayer;

--- a/src/multiplay.cpp
+++ b/src/multiplay.cpp
@@ -260,7 +260,7 @@ bool multiPlayerLoop()
 				int index;
 				for (index = 0; index < MAX_CONNECTED_PLAYERS; index++)
 				{
-					if (ingame.DataIntegrity[index] == false && isHumanPlayer(index) && index != NET_HOST_ONLY)
+					if (ingame.DataIntegrity[index] == false && isHumanPlayer(index) && index != NetPlay.hostPlayer)
 					{
 						char msg[256] = {'\0'};
 
@@ -512,7 +512,7 @@ int whosResponsible(int player)
 	}
 	else
 	{
-		return NET_HOST_ONLY;	// host responsible for all AIs
+		return NetPlay.hostPlayer;	// host responsible for all AIs
 	}
 }
 
@@ -900,7 +900,7 @@ bool recvMessage()
 				}
 				NETend();
 
-				if (whosResponsible(player_id) != queue.index && queue.index != NET_HOST_ONLY)
+				if (whosResponsible(player_id) != queue.index && queue.index != NetPlay.hostPlayer)
 				{
 					HandleBadParam("NET_PLAYER_DROPPED given incorrect params.", player_id, queue.index);
 					break;
@@ -955,7 +955,7 @@ bool recvMessage()
 				NETenum(&KICK_TYPE);
 				NETend();
 
-				if (player_id == NET_HOST_ONLY)
+				if (player_id == NetPlay.hostPlayer)
 				{
 					char buf[250] = {'\0'};
 

--- a/src/multiplay.cpp
+++ b/src/multiplay.cpp
@@ -122,7 +122,10 @@ bool multiplayerWinSequence(bool firstCall)
 	float		rotAmount;
 	STRUCTURE	*psStruct;
 
-	ASSERT_OR_RETURN(false, selectedPlayer < MAX_PLAYERS, "selectedPlayer is %" PRIu32 " - how did it win?!?", selectedPlayer);
+	if (selectedPlayer >= MAX_PLAYERS)
+	{
+		return false;
+	}
 
 	if (firstCall)
 	{

--- a/src/multiplay.h
+++ b/src/multiplay.h
@@ -254,7 +254,7 @@ bool sendDroidDisembark(DROID const *psTransporter, DROID const *psDroid);
 bool multiShutdown();
 bool sendLeavingMsg();
 
-bool hostCampaign(const char *SessionName, char *hostPlayerName, bool skipResetAIs);
+bool hostCampaign(const char *SessionName, char *hostPlayerName, bool spectatorHost, bool skipResetAIs);
 struct JoinConnectionDescription
 {
 public:

--- a/src/multistat.cpp
+++ b/src/multistat.cpp
@@ -378,29 +378,31 @@ bool saveMultiStats(const char *sFileName, const char *sPlayerName, const PLAYER
 // update players damage stats.
 void updateMultiStatsDamage(UDWORD attacker, UDWORD defender, UDWORD inflicted)
 {
+	if (defender == PLAYER_FEATURE)
+	{
+		// damaging features like skyscrapers does not count
+		return;
+	}
+
 	ASSERT_OR_RETURN(, attacker < MAX_PLAYERS, "invalid attacker: %" PRIu32 "", attacker);
 	ASSERT_OR_RETURN(, defender < MAX_PLAYERS, "invalid defender: %" PRIu32 "", defender);
 
-	// damaging features like skyscrapers does not count
-	if (defender != PLAYER_FEATURE)
+	if (NetPlay.bComms)
 	{
-		if (NetPlay.bComms)
+		// killing and getting killed by scavengers does not influence scores in MP games
+		if (attacker != scavengerSlot() && defender != scavengerSlot())
 		{
-			// killing and getting killed by scavengers does not influence scores in MP games
-			if (attacker != scavengerSlot() && defender != scavengerSlot())
-			{
-				// FIXME: Why in the world are we using two different structs for stats when we can use only one?
-				playerStats[attacker].totalScore  += 2 * inflicted;
-				playerStats[attacker].recentScore += 2 * inflicted;
-				playerStats[defender].totalScore  -= inflicted;
-				playerStats[defender].recentScore -= inflicted;
-			}
+			// FIXME: Why in the world are we using two different structs for stats when we can use only one?
+			playerStats[attacker].totalScore  += 2 * inflicted;
+			playerStats[attacker].recentScore += 2 * inflicted;
+			playerStats[defender].totalScore  -= inflicted;
+			playerStats[defender].recentScore -= inflicted;
 		}
-		else
-		{
-			ingame.skScores[attacker][0] += 2 * inflicted;  // increment skirmish players rough score.
-			ingame.skScores[defender][0] -= inflicted;  // increment skirmish players rough score.
-		}
+	}
+	else
+	{
+		ingame.skScores[attacker][0] += 2 * inflicted;  // increment skirmish players rough score.
+		ingame.skScores[defender][0] -= inflicted;  // increment skirmish players rough score.
 	}
 }
 

--- a/src/multistat.cpp
+++ b/src/multistat.cpp
@@ -212,7 +212,7 @@ void recvMultiStats(NETQUEUE queue)
 	}
 
 
-	if (playerIndex != queue.index && queue.index != NET_HOST_ONLY)
+	if (playerIndex != queue.index && queue.index != NetPlay.hostPlayer)
 	{
 		HandleBadParam("NET_PLAYER_STATS given incorrect params.", playerIndex, queue.index);
 		NETend();

--- a/src/wzapi.cpp
+++ b/src/wzapi.cpp
@@ -2405,6 +2405,11 @@ bool wzapi::gameOverMessage(WZAPI_PARAMS(bool gameWon, optional<bool> _showBackD
 		}
 		exit(0);
 	}
+	else if (headlessGameMode())
+	{
+		debug(LOG_WARNING, "Headless game completed successfully!");
+		exit(0); // FUTURE TODO: We could be nicer about this and trigger a *graceful* shutdown
+	}
 	return true;
 }
 


### PR DESCRIPTION
- Support non-0-index hostPlayer
   - Replace almost all `NET_HOST_ONLY` with `NetPlay.hostPlayer`
   - Send `NetPlay.hostPlayer` index to clients on accept
   - `NEThostGame` now supports `spectatorHost` parameter, acquires a spectator slot for the host (if set) for multiplayer games
- Support `spectatorHost` option in autohost json
   - Causes the host to be assigned to a spectator slot
- Support `openSpectatorSlots` option in autohost json
   - Opens up to this # of spectator slots (if possible) when hosting is started

<details>
<summary>Expand example autohost config json</summary>
<p>

```json
{
  "challenge": {
    "alliances": 3,
    "bases": "3",
    "map": "Emergence",
    "maxPlayers": 10,
    "powerLevel": 2,
    "scavengers": 2,
    "version": 2,
    "name": "test spec",
    "spectatorHost": true,
    "openSpectatorSlots": 5
  },
  "locked": {
    "power": true,
    "alliances": false,
    "teams": false,
    "difficulty": true,
    "ai": true,
    "scavengers": true,
    "bases": true,
    "position": false
  },
  "player_0": {
    "position": 0,
    "team": 0
  },
  "player_1": {
    "position": 1,
    "team": 0
  },
  "player_2": {
    "position": 2,
    "team": 0
  },
  "player_3": {
    "position": 3,
    "team": 0
  },
  "player_4": {
    "position": 4,
    "team": 0
  },
  "player_5": {
    "position": 5,
    "team": 1
  },
  "player_6": {
    "position": 6,
    "team": 1
  },
  "player_7": {
    "position": 7,
    "team": 1
  },
  "player_8": {
    "position": 8,
    "team": 1
  },
  "player_9": {
    "position": 9,
    "team": 1
  }
}
```
</p>