### PR TITLE
Technology start tweak.

### DIFF
--- a/data/mp/multiplay/script/rules/variables.js
+++ b/data/mp/multiplay/script/rules/variables.js
@@ -12,7 +12,7 @@ const DESTROY_LIKE_EVENT = 1;
 const TRANSFER_LIKE_EVENT = 2;
 
 const cleanTech = 1;
-const timeBaseTech = 4.5*60;		// after Power Module
-const timeAdvancedBaseTech = 7.9*60;	// after Mortar and Repair Facility
+const timeBaseTech = 3*60;		// after Half-tracked Propulsion and Light Cannon
+const timeAdvancedBaseTech = 6.5*60;	// after Factory Module and HEAT Cannon Shells Mk2
 const timeT2 = 17*60;
 const timeT3 = 26*60;			// after Needle Gun and Scourge Missile


### PR DESCRIPTION
Changes in available technologies when starting with a small and advanced base.
I propose to reduce the number of available technologies when starting from the base.
~ 3m for a small base.
Will become unavailable:
- Cyborg factory
- Heavy machinegun bunker
- Improved Hardcrete
- Command Relay Post
- Hardened Sensor Tower
- Twin machinegun
- Flamer Bunker
- Power Module


~ 6:30 for advanced base.
Will become unavailable:
- Mini-Rocket Tower
- Reinforced Base Structure Materials Mk2
- Hurricane AA Turret
- HE Rockets Mk2
- Cyborg Composite Alloys
- Medium Body - Cobra
- Synaptic Link Data Analysis Mk2
- Heavy machinegun
- Composite Alloys
- Mortar
- Automated Manufacturing
- Repair facility 

Check out the past discussion of available technologies here. 
https://github.com/Warzone2100/warzone2100/pull/720
