### PR TITLE
Add additional research messages for Nexus Resistance Circuits

### DIFF
--- a/data/base/messages/resmessages3.json
+++ b/data/base/messages/resmessages3.json
@@ -490,8 +490,41 @@
 		"text": [
 			"Computer Technology Breakthrough",
 			"Improved NEXUS resistance circuitry",
-			"Computer systems can now be 'ring-fenced' from NEXUS",
-			"Reduced chance of NEXUS take-over"
+			"Reduced chance of NEXUS take-over",
+			"Hero and Special rank units are protected"
+		]
+	},
+	"RES_SY_RESU3": {
+		"id": "RES_SY_RESU3",
+		"imdName": "MICAPSUL.PIE",
+		"sequenceName": "res_systech.ogg",
+		"text": [
+			"Computer Technology Breakthrough",
+			"Improved NEXUS resistance circuitry",
+			"Reduced chance of NEXUS take-over",
+			"Elite and Veteran rank units and Factories are protected"
+		]
+	},
+	"RES_SY_RESU4": {
+		"id": "RES_SY_RESU4",
+		"imdName": "MICAPSUL.PIE",
+		"sequenceName": "res_systech.ogg",
+		"text": [
+			"Computer Technology Breakthrough",
+			"Improved NEXUS resistance circuitry",
+			"Reduced chance of NEXUS take-over",
+			"Professional and Regular rank units are protected"
+		]
+	},
+	"RES_SY_RESU5": {
+		"id": "RES_SY_RESU5",
+		"imdName": "MICAPSUL.PIE",
+		"sequenceName": "res_systech.ogg",
+		"text": [
+			"Computer Technology Breakthrough",
+			"Improved NEXUS resistance circuitry",
+			"Computer systems are now 'ring-fenced' from NEXUS",
+			"Stops NEXUS take-over"
 		]
 	},
 	"RES_SY_ST1": {

--- a/data/base/script/campaign/cam3-ab.js
+++ b/data/base/script/campaign/cam3-ab.js
@@ -199,7 +199,12 @@ function eventResearched(research, structure, player)
 	}
 	else if (research.name === "R-Sys-Resistance-Upgrade03")
 	{
+		hackFailChance = 97;
+	}
+	else if (research.name === "R-Sys-Resistance-Upgrade04")
+	{
 		winFlag = true;
+		hackFailChance = 100;
 		camSetNexusState(false);
 	}
 }

--- a/data/base/script/campaign/libcampaign_includes/nexus.js
+++ b/data/base/script/campaign/libcampaign_includes/nexus.js
@@ -181,6 +181,10 @@ function __camChooseNexusTarget(player)
 			{
 				return true; //Final mission has a static fail chance to hack everything.
 			}
+			else if (getResearch("R-Sys-Resistance-Upgrade04").done)
+			{
+				return false; //Everything is safe
+			}
 			else if (getResearch("R-Sys-Resistance-Upgrade03").done)
 			{
 				if (d.droidType === DROID_CONSTRUCT && camRand(100) < 66)

--- a/data/base/script/campaign/transitionTech.js
+++ b/data/base/script/campaign/transitionTech.js
@@ -168,6 +168,8 @@ const GAMMA_RESEARCH_NEW = [
 	"R-Wpn-RocketSlow-ROF06",
 
 	// 5
+	"R-Sys-Resistance-Upgrade01", "R-Sys-Resistance-Upgrade02", "R-Sys-Resistance-Upgrade03",
+	"R-Sys-Resistance-Upgrade04",
 
 	// 6
 	"R-Vehicle-Body07", "R-Wpn-RailGun01", "R-Struc-VTOLPad-Upgrade04", "R-Wpn-Missile-LtSAM",
@@ -187,6 +189,7 @@ const GAMMA_RESEARCH_NEW = [
 	"R-Wpn-Rail-Damage02", "R-Wpn-Rail-ROF02",
 
 	// 8
+	"R-Sys-Resistance", "R-Comp-MissileCodes01", "R-Comp-MissileCodes02", "R-Comp-MissileCodes03",
 
 	// 9
 	"R-Wpn-RailGun03", "R-Vehicle-Body10", "R-Wpn-HvArtMissile",

--- a/data/base/stats/research.json
+++ b/data/base/stats/research.json
@@ -7217,6 +7217,7 @@
 		"iconID": "IMAGE_RES_SYSTEMTECH",
 		"id": "R-Sys-Resistance-Upgrade02",
 		"imdName": "ICCCCONS.PIE",
+		"msgName": "RES_SY_RESU3",
 		"name": "NEXUS Resistance Circuits Mk2",
 		"requiredResearch": [
 			"R-Sys-Resistance-Upgrade01"
@@ -7239,13 +7240,13 @@
 				"value": 60
 			}
 		],
-		"subgroupIconID": "IMAGE_RES_GRPUPG",
-		"techCode": 1
+		"subgroupIconID": "IMAGE_RES_GRPUPG"
 	},
 	"R-Sys-Resistance-Upgrade03": {
 		"iconID": "IMAGE_RES_SYSTEMTECH",
 		"id": "R-Sys-Resistance-Upgrade03",
 		"imdName": "ICCCCONS.PIE",
+		"msgName": "RES_SY_RESU4",
 		"name": "NEXUS Resistance Circuits Mk3",
 		"requiredResearch": [
 			"R-Sys-Resistance-Upgrade02"
@@ -7268,8 +7269,36 @@
 				"value": 60
 			}
 		],
-		"subgroupIconID": "IMAGE_RES_GRPUPG",
-		"techCode": 1
+		"subgroupIconID": "IMAGE_RES_GRPUPG"
+	},
+	"R-Sys-Resistance-Upgrade04": {
+		"iconID": "IMAGE_RES_SYSTEMTECH",
+		"id": "R-Sys-Resistance-Upgrade04",
+		"imdName": "ICCCCONS.PIE",
+		"msgName": "RES_SY_RESU5",
+		"name": "NEXUS Resistance Circuits Mk4",
+		"requiredResearch": [
+			"R-Sys-Resistance-Upgrade03"
+		],
+		"researchPoints": 35000,
+		"researchPower": 450,
+		"results": [
+			{
+				"class": "Building",
+				"filterParameter": "Type",
+				"filterValue": "Structure",
+				"parameter": "Resistance",
+				"value": 5
+			},
+			{
+				"class": "Body",
+				"filterParameter": "BodyClass",
+				"filterValue": "Droids",
+				"parameter": "Resistance",
+				"value": 5
+			}
+		],
+		"subgroupIconID": "IMAGE_RES_GRPUPG"
 	},
 	"R-Sys-SpyTurret": {
 		"iconID": "IMAGE_RES_SYSTEMTECH",


### PR DESCRIPTION
Seeing as the third resistance upgrade library code was never used in Gamma 5, it will now be of use. alfred007 wanted another resistance upgrade so I added another and beat the mission on Insane to test if it works.

New Intel research messages that describe the generalized benefit of what the resistance upgrades do has been added for all of them.