### PR TITLE
Don't load map preview twice for the host.

### DIFF
--- a/src/multiint.cpp
+++ b/src/multiint.cpp
@@ -5863,10 +5863,6 @@ void WzMultiplayerOptionsTitleUI::processMultiopWidgets(UDWORD id)
 				NETregisterServer(WZ_SERVER_UPDATE);
 			}
 			break;
-
-		case MULTIOP_MAP_PREVIEW:
-			loadMapPreview(true);
-			break;
 		}
 	}
 


### PR DESCRIPTION
The map preview button click was processed twice: once for hosts,
once for all players. Such double load may be particularly costly
if the map is autogenerated.

Remove the host-only case.