### PR TITLE
Prevent transporter on Beta-end from appearing too late when the timer is almost at zero

### DIFF
--- a/src/action.cpp
+++ b/src/action.cpp
@@ -778,7 +778,8 @@ void actionUpdateDroid(DROID *psDroid)
 		//if we're moving droids to safety and currently waiting to fly back in, see if time is up
 		if (psDroid->player == selectedPlayer && getDroidsToSafetyFlag())
 		{
-			if ((SDWORD)(mission.ETA - (gameTime - missionGetReinforcementTime())) <= 0)
+			bool enoughTimeRemaining = (mission.time - (gameTime - mission.startTime)) >= (60 * GAME_TICKS_PER_SEC);
+			if (((SDWORD)(mission.ETA - (gameTime - missionGetReinforcementTime())) <= 0) && enoughTimeRemaining)
 			{
 				UDWORD droidX, droidY;
 


### PR DESCRIPTION
Launching a transporter with around ~7:00-8:00 on the timer would cause it to come back and get blown up by the missile with mere seconds left on the timer.

Down goes another ancient bug.