### PR TITLE
Super Auto-Cannon Cyborg Change

### DIFF
--- a/data/mp/stats/weapons.json
+++ b/data/mp/stats/weapons.json
@@ -1229,7 +1229,7 @@
 	"Cyb-Hvywpn-Acannon": {
 		"buildPoints": 400,
 		"buildPower": 125,
-		"damage": 35,
+		"damage": 40,
 		"effectSize": 25,
 		"explosionWav": "smlexpl.ogg",
 		"facePlayer": 1,
@@ -1253,7 +1253,7 @@
 		"name": "Super Auto-Cannon Cyborg",
 		"numExplosions": 1,
 		"radius": 96,
-		"radiusDamage": 25,
+		"radiusDamage": 30,
 		"recoilValue": 25,
 		"rotate": 180,
 		"shortHit": 60,


### PR DESCRIPTION
Super Auto-Cannon Cyborgs were too weak after the last rollback of their damage values to version 3.4.1. Before the rollback, we increased their damage by 10 and it was too much. This time increasing their damage by 5 will be just fine