### PR TITLE
Further OpenGL init tweaks

### DIFF
--- a/lib/ivis_opengl/gfx_api_gl.cpp
+++ b/lib/ivis_opengl/gfx_api_gl.cpp
@@ -2151,6 +2151,22 @@ bool gl_context::initGLContext()
 	}
 	enabledVertexAttribIndexes.resize(static_cast<size_t>(glmaxVertexAttribs), false);
 
+	if (khr_debug)
+	{
+		if (glDebugMessageCallback && glDebugMessageControl)
+		{
+			glDebugMessageCallback(khr_callback, nullptr);
+			glEnable(GL_DEBUG_OUTPUT);
+			// Do not want to output notifications. Some drivers spam them too much.
+			glDebugMessageControl(GL_DONT_CARE, GL_DONT_CARE, GL_DEBUG_SEVERITY_NOTIFICATION, 0, nullptr, GL_FALSE);
+			debug(LOG_3D, "Enabling KHR_debug message callback");
+		}
+		else
+		{
+			debug(LOG_3D, "Failed to enable KHR_debug message callback");
+		}
+	}
+
 	if (GLAD_GL_VERSION_3_0) // if context is OpenGL 3.0+
 	{
 		// Very simple VAO code - just bind a single global VAO (this gets things working, but is not optimal)
@@ -2167,22 +2183,6 @@ bool gl_context::initGLContext()
 	if (GLAD_GL_ARB_timer_query)
 	{
 		glGenQueries(PERF_COUNT, perfpos);
-	}
-
-	if (khr_debug)
-	{
-		if (glDebugMessageCallback && glDebugMessageControl)
-		{
-			glDebugMessageCallback(khr_callback, nullptr);
-			glEnable(GL_DEBUG_OUTPUT);
-			// Do not want to output notifications. Some drivers spam them too much.
-			glDebugMessageControl(GL_DONT_CARE, GL_DONT_CARE, GL_DEBUG_SEVERITY_NOTIFICATION, 0, nullptr, GL_FALSE);
-			debug(LOG_3D, "Enabling KHR_debug message callback");
-		}
-		else
-		{
-			debug(LOG_3D, "Failed to enable KHR_debug message callback");
-		}
 	}
 
 	glGenBuffers(1, &scratchbuffer);

--- a/lib/ivis_opengl/gfx_api_gl.cpp
+++ b/lib/ivis_opengl/gfx_api_gl.cpp
@@ -2164,8 +2164,6 @@ bool gl_context::initGLContext()
 		glBindVertexArray(vaoId);
 	}
 
-	glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT | GL_STENCIL_BUFFER_BIT);
-
 	if (GLAD_GL_ARB_timer_query)
 	{
 		glGenQueries(PERF_COUNT, perfpos);

--- a/lib/sdl/gfx_api_sdl.cpp
+++ b/lib/sdl/gfx_api_sdl.cpp
@@ -37,14 +37,14 @@ std::unique_ptr<gfx_api::backend_Null_Impl> SDL_gfx_api_Impl_Factory::createNull
 
 std::unique_ptr<gfx_api::backend_OpenGL_Impl> SDL_gfx_api_Impl_Factory::createOpenGLBackendImpl() const
 {
-	ASSERT(window != nullptr, "Invalid SDL_Window*");
+	ASSERT_OR_RETURN(nullptr, window != nullptr, "Invalid SDL_Window*");
 	return std::unique_ptr<gfx_api::backend_OpenGL_Impl>(new sdl_OpenGL_Impl(window, config.useOpenGLES, config.useOpenGLESLibrary));
 }
 
 #if defined(WZ_VULKAN_ENABLED)
 std::unique_ptr<gfx_api::backend_Vulkan_Impl> SDL_gfx_api_Impl_Factory::createVulkanBackendImpl() const
 {
-	ASSERT(window != nullptr, "Invalid SDL_Window*");
+	ASSERT_OR_RETURN(nullptr, window != nullptr, "Invalid SDL_Window*");
 #if defined(HAVE_SDL_VULKAN_H)
 	return std::unique_ptr<gfx_api::backend_Vulkan_Impl>(new sdl_Vulkan_Impl(window));
 #else // !defined(HAVE_SDL_VULKAN_H)


### PR DESCRIPTION
See if we can't avoid (or at least get more information on) a crash with older AMD graphics cards / drivers.

(There are some indications that calling `glClear()` too early might be problematic? See: https://developer.blender.org/rBbaf84ecbe4910d91a7e1586f207c575992f582a5 )