### PR TITLE
check for null

### DIFF
--- a/src/challenge.cpp
+++ b/src/challenge.cpp
@@ -107,6 +107,12 @@ void updateChallenge(bool gameWon)
 	WzConfig scores(CHALLENGE_SCORES, WzConfig::ReadAndWrite);
 
 	fStr = strrchr(sRequestResult, '/');
+	if (!fStr)
+	{
+		// strrchr may return NULL
+		debug(LOG_ERROR, "Challenge file path doesn't contain '/'? (%s)", sRequestResult);
+		return;
+	}
 	fStr++;	// skip slash
 	if (*fStr == '\0')
 	{


### PR DESCRIPTION
I believe this will prevent crash (https://sentry.io/organizations/warzone2100/issues/2751152609/?environment=release&project=5174820&query=is%3Aunresolved), but doesn't solve the eventual underlying problem