### PR TITLE
Handle frontend.img / intfac.img load failure explicitly

### DIFF
--- a/src/hci.cpp
+++ b/src/hci.cpp
@@ -895,7 +895,11 @@ bool intInitialise()
 
 	psSelectedBuilder = nullptr;
 
-	intInitialiseGraphics();
+	if (!intInitialiseGraphics())
+	{
+		debug(LOG_ERROR, "Failed to initialize interface graphics");
+		return false;
+	}
 
 	psWScreen = W_SCREEN::make();
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -935,6 +935,18 @@ bool frontendInitialise(const char *ResourceFile)
 	}
 
 	FrontImages = (IMAGEFILE *)resGetData("IMG", "frontend.img");
+	if (FrontImages == nullptr)
+	{
+		std::string errorMessage = astringf(_("Unable to load: %s."), "frontend.img");
+		if (!getLoadedMods().empty())
+		{
+			errorMessage += " ";
+			errorMessage += _("Please remove all incompatible mods.");
+		}
+		debug(LOG_FATAL, "%s", errorMessage.c_str());
+		return false;
+	}
+
 	/* Shift the interface initialisation here temporarily so that it
 		can pick up the stats after they have been loaded */
 	if (!intInitialise())

--- a/src/intdisplay.cpp
+++ b/src/intdisplay.cpp
@@ -926,10 +926,15 @@ void intDisplayEditBox(WIDGET *psWidget, UDWORD xOffset, UDWORD yOffset)
 
 // Initialise all the surfaces,graphics etc. used by the interface.
 //
-void intInitialiseGraphics()
+bool intInitialiseGraphics()
 {
 	// Initialise any bitmaps used by the interface.
-	imageInitBitmaps();
+	if (!imageInitBitmaps())
+	{
+		return false;
+	}
+
+	return true;
 }
 
 // Clear a button bitmap. ( copy the button background ).

--- a/src/intdisplay.h
+++ b/src/intdisplay.h
@@ -99,7 +99,7 @@ private:
 void SetFormAudioIDs(int OpenID, int CloseID);
 
 // Initialise interface graphics.
-void intInitialiseGraphics();
+bool intInitialiseGraphics();
 
 class PowerBar: public W_BARGRAPH
 {

--- a/src/intimage.cpp
+++ b/src/intimage.cpp
@@ -29,6 +29,7 @@
 #include "lib/ivis_opengl/bitimage.h"
 #include "lib/ivis_opengl/piepalette.h"
 #include "lib/ivis_opengl/piestate.h"
+#include "modding.h"
 
 #include "intimage.h"
 
@@ -121,6 +122,17 @@ IMAGEFRAME FrameRadar =
 bool imageInitBitmaps()
 {
 	IntImages = (IMAGEFILE *)resGetData("IMG", "intfac.img");
+	if (IntImages == nullptr)
+	{
+		std::string errorMessage = astringf(_("Unable to load: %s."), "intfac.img");
+		if (!getLoadedMods().empty())
+		{
+			errorMessage += " ";
+			errorMessage += _("Please remove all incompatible mods.");
+		}
+		debug(LOG_FATAL, "%s", errorMessage.c_str());
+		return false;
+	}
 
 	return true;
 }


### PR DESCRIPTION
Almost always due to broken mods, or a broken install.