### PR TITLE
Alpha 09 tweaks

### DIFF
--- a/data/base/script/campaign/cam1-5.js
+++ b/data/base/script/campaign/cam1-5.js
@@ -25,50 +25,50 @@ var useHeavyReinforcement;
 //Get some droids for the New Paradigm transport
 function getDroidsForNPLZ(args)
 {
-    var lightAttackerLimit = 8;
-    var heavyAttackerLimit = 3;
-    var unitTemplates;
-    var list = [];
+	var lightAttackerLimit = 8;
+	var heavyAttackerLimit = 3;
+	var unitTemplates;
+	var list = [];
 
-    if (difficulty === HARD)
-    {
-        lightAttackerLimit = 9;
-        heavyAttackerLimit = 4;
-    }
-    else if (difficulty === INSANE)
-    {
-        lightAttackerLimit = 10;
-        heavyAttackerLimit = 5;
-    }
+	if (difficulty === HARD)
+	{
+		lightAttackerLimit = 9;
+		heavyAttackerLimit = 4;
+	}
+	else if (difficulty === INSANE)
+	{
+		lightAttackerLimit = 10;
+		heavyAttackerLimit = 5;
+	}
 
-    if (useHeavyReinforcement)
-    {
-        var artillery = [cTempl.npmor];
-        var other = [cTempl.npmmct];
-        if (camRand(2) > 0)
-        {
-            //Add a sensor if artillery was chosen for the heavy units
-            list.push(cTempl.npsens);
-            unitTemplates = artillery;
-        }
-        else
-        {
-            unitTemplates = other;
-        }
-    }
-    else
-    {
-        unitTemplates = [cTempl.nppod, cTempl.npmrl, cTempl.nphmgt];
-    }
+	if (useHeavyReinforcement)
+	{
+		var artillery = [cTempl.npmor];
+		var other = [cTempl.npmmct];
+		if (camRand(2) > 0)
+		{
+			//Add a sensor if artillery was chosen for the heavy units
+			list.push(cTempl.npsens);
+			unitTemplates = artillery;
+		}
+		else
+		{
+			unitTemplates = other;
+		}
+	}
+	else
+	{
+		unitTemplates = [cTempl.nppod, cTempl.npmrl, cTempl.nphmgt];
+	}
 
-    var lim = useHeavyReinforcement ? heavyAttackerLimit : lightAttackerLimit;
-    for (var i = 0; i < lim; ++i)
-    {
-        list.push(unitTemplates[camRand(unitTemplates.length)]);
-    }
+	var lim = useHeavyReinforcement ? heavyAttackerLimit : lightAttackerLimit;
+	for (var i = 0; i < lim; ++i)
+	{
+		list.push(unitTemplates[camRand(unitTemplates.length)]);
+	}
 
-    useHeavyReinforcement = !useHeavyReinforcement; //switch it
-    return list;
+	useHeavyReinforcement = !useHeavyReinforcement; //switch it
+	return list;
 }
 
 //These enable Scav and NP factories when close enough
@@ -107,18 +107,18 @@ camAreaEvent("NPFactoryTrigger", function(droid)
 //Land New Paradigm transport in the LZ area (protected by four hardpoints in the New Paradigm base)
 camAreaEvent("NPLZTriggerEast", function()
 {
-    camCallOnce("activateNPLZTransporter");
+	camCallOnce("activateNPLZTransporter");
 });
 
 camAreaEvent("NPLZTrigger", function()
 {
-    camCallOnce("activateNPLZTransporter");
+	camCallOnce("activateNPLZTransporter");
 });
 
 function activateNPLZTransporter()
 {
-    setTimer("sendNPTransport", camChangeOnDiff(camMinutesToMilliseconds(3)));
-    sendNPTransport();
+	setTimer("sendNPTransport", camChangeOnDiff(camMinutesToMilliseconds(3)));
+	sendNPTransport();
 }
 
 function sendNPTransport()

--- a/data/base/script/campaign/cam1-5.js
+++ b/data/base/script/campaign/cam1-5.js
@@ -105,11 +105,21 @@ camAreaEvent("NPFactoryTrigger", function(droid)
 });
 
 //Land New Paradigm transport in the LZ area (protected by four hardpoints in the New Paradigm base)
+camAreaEvent("NPLZTriggerEast", function()
+{
+    camCallOnce("activateNPLZTransporter");
+});
+
 camAreaEvent("NPLZTrigger", function()
 {
-	setTimer("sendNPTransport", camChangeOnDiff(camMinutesToMilliseconds(3)));
-	sendNPTransport();
+    camCallOnce("activateNPLZTransporter");
 });
+
+function activateNPLZTransporter()
+{
+    setTimer("sendNPTransport", camChangeOnDiff(camMinutesToMilliseconds(3)));
+    sendNPTransport();
+}
 
 function sendNPTransport()
 {

--- a/data/base/script/campaign/cam1-5.js
+++ b/data/base/script/campaign/cam1-5.js
@@ -25,39 +25,50 @@ var useHeavyReinforcement;
 //Get some droids for the New Paradigm transport
 function getDroidsForNPLZ(args)
 {
-	const LIGHT_ATTACKER_LIMIT = 8;
-	const HEAVY_ATTACKER_LIMIT = 3;
-	var unitTemplates;
-	var list = [];
+    var lightAttackerLimit = 8;
+    var heavyAttackerLimit = 3;
+    var unitTemplates;
+    var list = [];
 
-	if (useHeavyReinforcement)
-	{
-		var artillery = [cTempl.npmor];
-		var other = [cTempl.npmmct];
-		if (camRand(2) > 0)
-		{
-			//Add a sensor if artillery was chosen for the heavy units
-			list.push(cTempl.npsens);
-			unitTemplates = artillery;
-		}
-		else
-		{
-			unitTemplates = other;
-		}
-	}
-	else
-	{
-		unitTemplates = [cTempl.nppod, cTempl.npmrl, cTempl.nphmgt];
-	}
+    if (difficulty === HARD)
+    {
+        lightAttackerLimit = 9;
+        heavyAttackerLimit = 4;
+    }
+    else if (difficulty === INSANE)
+    {
+        lightAttackerLimit = 10;
+        heavyAttackerLimit = 5;
+    }
 
-	var lim = useHeavyReinforcement ? HEAVY_ATTACKER_LIMIT : LIGHT_ATTACKER_LIMIT;
-	for (var i = 0; i < lim; ++i)
-	{
-		list.push(unitTemplates[camRand(unitTemplates.length)]);
-	}
+    if (useHeavyReinforcement)
+    {
+        var artillery = [cTempl.npmor];
+        var other = [cTempl.npmmct];
+        if (camRand(2) > 0)
+        {
+            //Add a sensor if artillery was chosen for the heavy units
+            list.push(cTempl.npsens);
+            unitTemplates = artillery;
+        }
+        else
+        {
+            unitTemplates = other;
+        }
+    }
+    else
+    {
+        unitTemplates = [cTempl.nppod, cTempl.npmrl, cTempl.nphmgt];
+    }
 
-	useHeavyReinforcement = !useHeavyReinforcement; //switch it
-	return list;
+    var lim = useHeavyReinforcement ? heavyAttackerLimit : lightAttackerLimit;
+    for (var i = 0; i < lim; ++i)
+    {
+        list.push(unitTemplates[camRand(unitTemplates.length)]);
+    }
+
+    useHeavyReinforcement = !useHeavyReinforcement; //switch it
+    return list;
 }
 
 //These enable Scav and NP factories when close enough

--- a/data/base/wrf/cam1/sub1-5/labels.json
+++ b/data/base/wrf/cam1/sub1-5/labels.json
@@ -148,25 +148,25 @@
 	"radius_0": {
 		"label": "NorthScavFactoryTrigger",
 		"subscriber": 0,
-		"pos": [3200, 900],
+		"pos": [3200, 896],
 		"radius": 1280
 	},
 	"radius_1": {
 		"label": "SouthWestScavFactoryTrigger",
 		"subscriber": 0,
-		"pos": [4200, 7500],
+		"pos": [4224, 7424],
 		"radius": 1024
 	},
 	"radius_2": {
 		"label": "SouthEastScavFactoryTrigger",
 		"subscriber": 0,
-		"pos": [5600, 7500],
+		"pos": [5504, 7424],
 		"radius": 1024
 	},
 	"radius_3": {
 		"label": "NPLZTrigger",
 		"subscriber": 0,
 		"pos": [4288, 4160],
-		"radius": 1100
+		"radius": 1088
 	}
 }

--- a/data/base/wrf/cam1/sub1-5/labels.json
+++ b/data/base/wrf/cam1/sub1-5/labels.json
@@ -77,6 +77,12 @@
 		"pos1": [3776, 5568],
 		"pos2": [4800, 6080]
 	},
+	"area_8": {
+		"label": "NPLZTriggerEast",
+		"subscriber": 0,
+		"pos1": [6976, 4928],
+		"pos2": [7616, 5312]
+	},
 
 	"object_0": {
 		"label": "NPLeftFactory",


### PR DESCRIPTION
Adding a new trigger area to avoid a tactic that bypasses the NP air reinforcement activation
Making the number of units in the NP air reinforcements depending on the difficulty (makes the level harder for Hard and Insane difficulty)
Setting some trigger values to .0 or .5 tiles.