### PR TITLE
Campaign tweaks

### DIFF
--- a/data/base/script/campaign/cam3-ab.js
+++ b/data/base/script/campaign/cam3-ab.js
@@ -199,7 +199,7 @@ function eventResearched(research, structure, player)
 	}
 	else if (research.name === "R-Sys-Resistance-Upgrade03")
 	{
-		hackFailChance = 97;
+		hackFailChance = 95;
 	}
 	else if (research.name === "R-Sys-Resistance-Upgrade04")
 	{

--- a/data/base/script/rules.js
+++ b/data/base/script/rules.js
@@ -283,7 +283,7 @@ function eventGameInit()
 
 function setLimits()
 {
-	setDroidLimit(selectedPlayer, 100, DROID_ANY);
+	setDroidLimit(selectedPlayer, 101, DROID_ANY); //note: the transporter is a unit you own
 	setDroidLimit(selectedPlayer, 10, DROID_COMMAND);
 	setDroidLimit(selectedPlayer, 15, DROID_CONSTRUCT);
 

--- a/data/base/stats/research.json
+++ b/data/base/stats/research.json
@@ -7276,7 +7276,7 @@
 		"id": "R-Sys-Resistance-Upgrade04",
 		"imdName": "ICCCCONS.PIE",
 		"msgName": "RES_SY_RESU5",
-		"name": "NEXUS Resistance Circuits Mk4",
+		"name": "NEXUS Immunization System",
 		"requiredResearch": [
 			"R-Sys-Resistance-Upgrade03"
 		],


### PR DESCRIPTION
Increase unit limits to 101 cause you technically own transporters (and I don't think it's a good idea to mess with counts in the source).

Change the name of the NEXUS Resistance Circuits Mk4 new research item to "NEXUS Immunization System". Idea came from Discord.

Decrease hack fail chance of NEXUS Resistance Circuits Mk3 to 95% just to make things a little more exciting late into Gamma 5.