### PR TITLE
Host: Remember number of spectator slots in MP games

### DIFF
--- a/src/configuration.cpp
+++ b/src/configuration.cpp
@@ -483,6 +483,8 @@ bool loadConfig()
 	}
 	war_setAutoLagKickSeconds(iniGetInteger("hostAutoLagKickSeconds", war_getAutoLagKickSeconds()).value());
 	war_setDisableReplayRecording(iniGetBool("disableReplayRecord", war_getDisableReplayRecording()).value());
+	int openSpecSlotsIntValue = iniGetInteger("openSpectatorSlotsMP", war_getMPopenSpectatorSlots()).value();
+	war_setMPopenSpectatorSlots(static_cast<uint16_t>(std::max<int>(0, std::min<int>(openSpecSlotsIntValue, MAX_SPECTATOR_SLOTS))));
 	ActivityManager::instance().endLoadingSettings();
 	return true;
 }
@@ -603,6 +605,11 @@ bool saveConfig()
 			{
 				iniSetString("gameName", game.name);			//  last hosted game
 				iniSetInteger("inactivityMinutesMP", game.inactivityMinutes);
+
+				// remember number of spectator slots in MP games
+				auto currentSpectatorSlotInfo = SpectatorInfo::currentNetPlayState();
+				war_setMPopenSpectatorSlots(currentSpectatorSlotInfo.totalSpectatorSlots);
+				iniSetInteger("openSpectatorSlotsMP", (int)currentSpectatorSlotInfo.totalSpectatorSlots);
 			}
 			iniSetString("mapName", game.map);				//  map name
 			iniSetString("mapHash", game.hash.toString());          //  map hash

--- a/src/multiint.cpp
+++ b/src/multiint.cpp
@@ -7069,7 +7069,7 @@ void WzMultiplayerOptionsTitleUI::start()
 		resetPlayerConfiguration(true);
 		memset(&locked, 0, sizeof(locked));
 		spectatorHost = false;
-		defaultOpenSpectatorSlots = 0;
+		defaultOpenSpectatorSlots = war_getMPopenSpectatorSlots();
 		loadMapChallengeAndPlayerSettings(true);
 		game.isMapMod = false;
 		game.isRandom = false;

--- a/src/warzoneconfig.cpp
+++ b/src/warzoneconfig.cpp
@@ -67,6 +67,7 @@ struct WARZONE_GLOBALS
 	int autoLagKickSeconds = 60;
 	bool disableReplayRecording = false;
 	uint32_t MPinactivityMinutes = 4;
+	uint8_t MPopenSpectatorSlots = 0;
 };
 
 static WARZONE_GLOBALS warGlobs;
@@ -442,4 +443,15 @@ void war_setMPInactivityMinutes(uint32_t minutes)
 		minutes = MIN_MPINACTIVITY_MINUTES;
 	}
 	warGlobs.MPinactivityMinutes = minutes;
+}
+
+uint16_t war_getMPopenSpectatorSlots()
+{
+	return warGlobs.MPopenSpectatorSlots;
+}
+
+void war_setMPopenSpectatorSlots(uint16_t spectatorSlots)
+{
+	spectatorSlots = std::min<uint16_t>(spectatorSlots, MAX_SPECTATOR_SLOTS);
+	warGlobs.MPopenSpectatorSlots = spectatorSlots;
 }

--- a/src/warzoneconfig.h
+++ b/src/warzoneconfig.h
@@ -122,6 +122,8 @@ bool war_getDisableReplayRecording();
 void war_setDisableReplayRecording(bool disable);
 uint32_t war_getMPInactivityMinutes();
 void war_setMPInactivityMinutes(uint32_t minutes);
+uint16_t war_getMPopenSpectatorSlots();
+void war_setMPopenSpectatorSlots(uint16_t spectatorSlots);
 
 /**
  * Enable or disable sound initialization


### PR DESCRIPTION
If a host checks the "Enable Spectator Join" option, or otherwise adds spectator slots, remember that for the next time that they host.