### PR TITLE
Stop RTR droids from dropping group and accepting orders

### DIFF
--- a/src/order.cpp
+++ b/src/order.cpp
@@ -1242,8 +1242,18 @@ static void orderPlayFireSupportAudio(BASE_OBJECT *psObj)
 	}
 }
 
-inline bool isRetreating(const DROID *psDroid) {
-	return(psDroid->order.type == DORDER_RTR || psDroid->order.type == DORDER_RTB || psDroid->order.type == DORDER_RTR_SPECIFIED);
+/** Returns true if the Droid has been ordered to retreat
+ *  and is assigned to a group.
+ */
+inline bool isRetreatingInGroup(const DROID *psDroid) {
+	if(psDroid->psGroup == nullptr)
+	{
+		return(false);
+	}
+	else
+	{
+	  return(psDroid->order.type == DORDER_RTR || psDroid->order.type == DORDER_RTB || psDroid->order.type == DORDER_RTR_SPECIFIED);
+	}
 }
 
 /** This function actually tells the droid to perform the psOrder.
@@ -1347,7 +1357,7 @@ void orderDroidBase(DROID *psDroid, DROID_ORDER_DATA *psOrder)
 		break;
 	case DORDER_MOVE:
 	case DORDER_SCOUT:
-		if(isRetreating(psDroid)){
+		if(isRetreatingInGroup(psDroid)){
 			break;
 		}
 		// can't move vtols to blocking tiles
@@ -1368,7 +1378,7 @@ void orderDroidBase(DROID *psDroid, DROID_ORDER_DATA *psOrder)
 		actionDroid(psDroid, DACTION_MOVE, psOrder->pos.x, psOrder->pos.y);
 		break;
 	case DORDER_PATROL:
-	  if(isRetreating(psDroid)){
+	  if(isRetreatingInGroup(psDroid)){
 		  break;
 	  }
 		psDroid->order = *psOrder;
@@ -1376,7 +1386,7 @@ void orderDroidBase(DROID *psDroid, DROID_ORDER_DATA *psOrder)
 		actionDroid(psDroid, DACTION_MOVE, psOrder->pos.x, psOrder->pos.y);
 		break;
 	case DORDER_RECOVER:
-		if(isRetreating(psDroid)){
+		if(isRetreatingInGroup(psDroid)){
       break;
 	  }
 		psDroid->order = *psOrder;
@@ -1402,7 +1412,7 @@ void orderDroidBase(DROID *psDroid, DROID_ORDER_DATA *psOrder)
 		if (psDroid->numWeaps == 0
 		    || psDroid->asWeaps[0].nStat == 0
 		    || isTransporter(psDroid)
-			  || isRetreating(psDroid))
+			  || isRetreatingInGroup(psDroid))
 		{
 			break;
 		}
@@ -1437,7 +1447,7 @@ void orderDroidBase(DROID *psDroid, DROID_ORDER_DATA *psOrder)
 		break;
 	case DORDER_BUILD:
 	case DORDER_LINEBUILD:
-	  if(isRetreating(psDroid)){
+	  if(isRetreatingInGroup(psDroid)){
 		  break;
 	  }
 		// build a new structure or line of structures
@@ -1449,7 +1459,7 @@ void orderDroidBase(DROID *psDroid, DROID_ORDER_DATA *psOrder)
 		objTrace(psDroid->id, "Starting new construction effort of %s", psOrder->psStats ? getStatsName(psOrder->psStats) : "NULL");
 		break;
 	case DORDER_BUILDMODULE:
-	  if(isRetreating(psDroid)){
+	  if(isRetreatingInGroup(psDroid)){
 		  break;
 	  }
 		//build a module onto the structure
@@ -1464,7 +1474,7 @@ void orderDroidBase(DROID *psDroid, DROID_ORDER_DATA *psOrder)
 		objTrace(psDroid->id, "Starting new upgrade of %s", psOrder->psStats ? getStatsName(psOrder->psStats) : "NULL");
 		break;
 	case DORDER_HELPBUILD:
-	  if(isRetreating(psDroid)){
+	  if(isRetreatingInGroup(psDroid)){
 		  break;
 	  }
 		// help to build a structure that is starting to be built
@@ -1478,7 +1488,7 @@ void orderDroidBase(DROID *psDroid, DROID_ORDER_DATA *psOrder)
 		objTrace(psDroid->id, "Helping construction of %s", psOrder->psStats ? getStatsName(psDroid->order.psStats) : "NULL");
 		break;
 	case DORDER_DEMOLISH:
-		if(isRetreating(psDroid)){
+		if(isRetreatingInGroup(psDroid)){
 		  break;
 	  }
 		if (!(psDroid->droidType == DROID_CONSTRUCT || psDroid->droidType == DROID_CYBORG_CONSTRUCT))
@@ -1507,7 +1517,7 @@ void orderDroidBase(DROID *psDroid, DROID_ORDER_DATA *psOrder)
 		actionDroid(psDroid, DACTION_DROIDREPAIR, psOrder->psObj);
 		break;
 	case DORDER_OBSERVE:
-	  if(isRetreating(psDroid)){
+	  if(isRetreatingInGroup(psDroid)){
 		  break;
 	  }
 		// keep an object within sensor view
@@ -1724,7 +1734,7 @@ void orderDroidBase(DROID *psDroid, DROID_ORDER_DATA *psOrder)
 		}
 		break;
 	case DORDER_GUARD:
-	  if(isRetreating(psDroid)){
+	  if(isRetreatingInGroup(psDroid)){
 		  break;
 	  }
 		psDroid->order = *psOrder;
@@ -1759,7 +1769,7 @@ void orderDroidBase(DROID *psDroid, DROID_ORDER_DATA *psOrder)
 		assignVTOLPad(psDroid, (STRUCTURE *)psOrder->psObj);
 		break;
 	case DORDER_CIRCLE:
-	  if(isRetreating(psDroid)){
+	  if(isRetreatingInGroup(psDroid)){
 		  break;
 	  }
 		if (!isVtolDroid(psDroid))

--- a/src/order.cpp
+++ b/src/order.cpp
@@ -1381,18 +1381,18 @@ void orderDroidBase(DROID *psDroid, DROID_ORDER_DATA *psOrder)
 		break;
 	case DORDER_PATROL:
 	  if (isRetreatingInGroup(psDroid))
-	  {
+		{
 		  break;
-    }
+		}
 		psDroid->order = *psOrder;
 		psDroid->order.pos2 = psDroid->pos.xy();
 		actionDroid(psDroid, DACTION_MOVE, psOrder->pos.x, psOrder->pos.y);
 		break;
 	case DORDER_RECOVER:
 	  if (isRetreatingInGroup(psDroid))
-	  {
+		{
 		  break;
-    }
+		}
 		psDroid->order = *psOrder;
 		actionDroid(psDroid, DACTION_MOVE, psOrder->psObj->pos.x, psOrder->psObj->pos.y);
 		break;
@@ -1454,7 +1454,7 @@ void orderDroidBase(DROID *psDroid, DROID_ORDER_DATA *psOrder)
 	  if (isRetreatingInGroup(psDroid))
 		{
 		  break;
-    }
+		}
 		// build a new structure or line of structures
 		ASSERT_OR_RETURN(, isConstructionDroid(psDroid), "%s cannot construct things!", objInfo(psDroid));
 		ASSERT_OR_RETURN(, psOrder->psStats != nullptr, "invalid structure stats pointer");
@@ -1467,7 +1467,7 @@ void orderDroidBase(DROID *psDroid, DROID_ORDER_DATA *psOrder)
 	  if (isRetreatingInGroup(psDroid))
 		{
 		  break;
-    }
+		}
 		//build a module onto the structure
 		if (!isConstructionDroid(psDroid) || psOrder->index < nextModuleToBuild((STRUCTURE *)psOrder->psObj, -1))
 		{
@@ -1483,7 +1483,7 @@ void orderDroidBase(DROID *psDroid, DROID_ORDER_DATA *psOrder)
 	  if (isRetreatingInGroup(psDroid))
 		{
 		  break;
-    }
+		}
 		// help to build a structure that is starting to be built
 		ASSERT_OR_RETURN(, isConstructionDroid(psDroid), "Not a constructor droid");
 		ASSERT_OR_RETURN(, psOrder->psObj != nullptr, "Help to build a NULL pointer?");
@@ -1498,7 +1498,7 @@ void orderDroidBase(DROID *psDroid, DROID_ORDER_DATA *psOrder)
 		if (isRetreatingInGroup(psDroid))
 		{
 		  break;
-    }
+		}
 		if (!(psDroid->droidType == DROID_CONSTRUCT || psDroid->droidType == DROID_CYBORG_CONSTRUCT))
 		{
 			break;
@@ -1528,7 +1528,7 @@ void orderDroidBase(DROID *psDroid, DROID_ORDER_DATA *psOrder)
 	  if (isRetreatingInGroup(psDroid))
 		{
 		  break;
-    }
+		}
 		// keep an object within sensor view
 		psDroid->order = *psOrder;
 		actionDroid(psDroid, DACTION_OBSERVE, psOrder->psObj);
@@ -1746,7 +1746,7 @@ void orderDroidBase(DROID *psDroid, DROID_ORDER_DATA *psOrder)
 	  if (isRetreatingInGroup(psDroid))
 		{
 		  break;
-    }
+		}
 		psDroid->order = *psOrder;
 		if (psOrder->psObj != nullptr)
 		{
@@ -1782,7 +1782,7 @@ void orderDroidBase(DROID *psDroid, DROID_ORDER_DATA *psOrder)
 	  if (isRetreatingInGroup(psDroid))
 		{
 		  break;
-    }
+		}
 		if (!isVtolDroid(psDroid))
 		{
 			break;

--- a/src/order.cpp
+++ b/src/order.cpp
@@ -1245,14 +1245,15 @@ static void orderPlayFireSupportAudio(BASE_OBJECT *psObj)
 /** Returns true if the Droid has been ordered to retreat
  *  and is assigned to a group.
  */
-inline bool isRetreatingInGroup(const DROID *psDroid) {
-	if(psDroid->group == UBYTE_MAX)
+inline bool isRetreatingInGroup(const DROID *psDroid)
+{
+	if (psDroid->group == UBYTE_MAX)
 	{
-    return(false);
+    return false;
 	}
 	else
 	{
-	  return(psDroid->order.type == DORDER_RTR || psDroid->order.type == DORDER_RTB || psDroid->order.type == DORDER_RTR_SPECIFIED);
+	  return psDroid->order.type == DORDER_RTR || psDroid->order.type == DORDER_RTB || psDroid->order.type == DORDER_RTR_SPECIFIED;
 	}
 }
 
@@ -1357,7 +1358,8 @@ void orderDroidBase(DROID *psDroid, DROID_ORDER_DATA *psOrder)
 		break;
 	case DORDER_MOVE:
 	case DORDER_SCOUT:
-		if(isRetreatingInGroup(psDroid)){
+		if (isRetreatingInGroup(psDroid))
+		{
 			break;
 		}
 		// can't move vtols to blocking tiles
@@ -1378,7 +1380,8 @@ void orderDroidBase(DROID *psDroid, DROID_ORDER_DATA *psOrder)
 		actionDroid(psDroid, DACTION_MOVE, psOrder->pos.x, psOrder->pos.y);
 		break;
 	case DORDER_PATROL:
-	  if(isRetreatingInGroup(psDroid)){
+	  if (isRetreatingInGroup(psDroid))
+	  {
 		  break;
 	  }
 		psDroid->order = *psOrder;
@@ -1386,8 +1389,9 @@ void orderDroidBase(DROID *psDroid, DROID_ORDER_DATA *psOrder)
 		actionDroid(psDroid, DACTION_MOVE, psOrder->pos.x, psOrder->pos.y);
 		break;
 	case DORDER_RECOVER:
-		if(isRetreatingInGroup(psDroid)){
-      break;
+	  if (isRetreatingInGroup(psDroid))
+	  {
+		  break;
 	  }
 		psDroid->order = *psOrder;
 		actionDroid(psDroid, DACTION_MOVE, psOrder->psObj->pos.x, psOrder->psObj->pos.y);
@@ -1447,7 +1451,8 @@ void orderDroidBase(DROID *psDroid, DROID_ORDER_DATA *psOrder)
 		break;
 	case DORDER_BUILD:
 	case DORDER_LINEBUILD:
-	  if(isRetreatingInGroup(psDroid)){
+	  if (isRetreatingInGroup(psDroid))
+		{
 		  break;
 	  }
 		// build a new structure or line of structures
@@ -1459,7 +1464,8 @@ void orderDroidBase(DROID *psDroid, DROID_ORDER_DATA *psOrder)
 		objTrace(psDroid->id, "Starting new construction effort of %s", psOrder->psStats ? getStatsName(psOrder->psStats) : "NULL");
 		break;
 	case DORDER_BUILDMODULE:
-	  if(isRetreatingInGroup(psDroid)){
+	  if (isRetreatingInGroup(psDroid))
+		{
 		  break;
 	  }
 		//build a module onto the structure
@@ -1474,7 +1480,8 @@ void orderDroidBase(DROID *psDroid, DROID_ORDER_DATA *psOrder)
 		objTrace(psDroid->id, "Starting new upgrade of %s", psOrder->psStats ? getStatsName(psOrder->psStats) : "NULL");
 		break;
 	case DORDER_HELPBUILD:
-	  if(isRetreatingInGroup(psDroid)){
+	  if (isRetreatingInGroup(psDroid))
+		{
 		  break;
 	  }
 		// help to build a structure that is starting to be built
@@ -1488,7 +1495,8 @@ void orderDroidBase(DROID *psDroid, DROID_ORDER_DATA *psOrder)
 		objTrace(psDroid->id, "Helping construction of %s", psOrder->psStats ? getStatsName(psDroid->order.psStats) : "NULL");
 		break;
 	case DORDER_DEMOLISH:
-		if(isRetreatingInGroup(psDroid)){
+		if (isRetreatingInGroup(psDroid))
+		{
 		  break;
 	  }
 		if (!(psDroid->droidType == DROID_CONSTRUCT || psDroid->droidType == DROID_CYBORG_CONSTRUCT))
@@ -1517,7 +1525,8 @@ void orderDroidBase(DROID *psDroid, DROID_ORDER_DATA *psOrder)
 		actionDroid(psDroid, DACTION_DROIDREPAIR, psOrder->psObj);
 		break;
 	case DORDER_OBSERVE:
-	  if(isRetreatingInGroup(psDroid)){
+	  if (isRetreatingInGroup(psDroid))
+		{
 		  break;
 	  }
 		// keep an object within sensor view
@@ -1734,7 +1743,8 @@ void orderDroidBase(DROID *psDroid, DROID_ORDER_DATA *psOrder)
 		}
 		break;
 	case DORDER_GUARD:
-	  if(isRetreatingInGroup(psDroid)){
+	  if (isRetreatingInGroup(psDroid))
+		{
 		  break;
 	  }
 		psDroid->order = *psOrder;
@@ -1769,7 +1779,8 @@ void orderDroidBase(DROID *psDroid, DROID_ORDER_DATA *psOrder)
 		assignVTOLPad(psDroid, (STRUCTURE *)psOrder->psObj);
 		break;
 	case DORDER_CIRCLE:
-	  if(isRetreatingInGroup(psDroid)){
+	  if (isRetreatingInGroup(psDroid))
+		{
 		  break;
 	  }
 		if (!isVtolDroid(psDroid))

--- a/src/order.cpp
+++ b/src/order.cpp
@@ -1246,9 +1246,9 @@ static void orderPlayFireSupportAudio(BASE_OBJECT *psObj)
  *  and is assigned to a group.
  */
 inline bool isRetreatingInGroup(const DROID *psDroid) {
-	if(psDroid->psGroup == nullptr)
+	if(psDroid->group == UBYTE_MAX)
 	{
-		return(false);
+    return(false);
 	}
 	else
 	{

--- a/src/order.cpp
+++ b/src/order.cpp
@@ -1380,7 +1380,7 @@ void orderDroidBase(DROID *psDroid, DROID_ORDER_DATA *psOrder)
 		actionDroid(psDroid, DACTION_MOVE, psOrder->pos.x, psOrder->pos.y);
 		break;
 	case DORDER_PATROL:
-	  if (isRetreatingInGroup(psDroid))
+		if (isRetreatingInGroup(psDroid))
 		{
 		  break;
 		}
@@ -1389,7 +1389,7 @@ void orderDroidBase(DROID *psDroid, DROID_ORDER_DATA *psOrder)
 		actionDroid(psDroid, DACTION_MOVE, psOrder->pos.x, psOrder->pos.y);
 		break;
 	case DORDER_RECOVER:
-	  if (isRetreatingInGroup(psDroid))
+		if (isRetreatingInGroup(psDroid))
 		{
 		  break;
 		}
@@ -1414,9 +1414,9 @@ void orderDroidBase(DROID *psDroid, DROID_ORDER_DATA *psOrder)
 	case DORDER_ATTACK:
 	case DORDER_ATTACKTARGET:
 		if (psDroid->numWeaps == 0
-		    || psDroid->asWeaps[0].nStat == 0
-		    || isTransporter(psDroid)
-			  || isRetreatingInGroup(psDroid))
+			|| psDroid->asWeaps[0].nStat == 0
+			|| isTransporter(psDroid)
+			|| isRetreatingInGroup(psDroid))
 		{
 			break;
 		}
@@ -1451,7 +1451,7 @@ void orderDroidBase(DROID *psDroid, DROID_ORDER_DATA *psOrder)
 		break;
 	case DORDER_BUILD:
 	case DORDER_LINEBUILD:
-	  if (isRetreatingInGroup(psDroid))
+		if (isRetreatingInGroup(psDroid))
 		{
 		  break;
 		}
@@ -1464,7 +1464,7 @@ void orderDroidBase(DROID *psDroid, DROID_ORDER_DATA *psOrder)
 		objTrace(psDroid->id, "Starting new construction effort of %s", psOrder->psStats ? getStatsName(psOrder->psStats) : "NULL");
 		break;
 	case DORDER_BUILDMODULE:
-	  if (isRetreatingInGroup(psDroid))
+		if (isRetreatingInGroup(psDroid))
 		{
 		  break;
 		}
@@ -1480,7 +1480,7 @@ void orderDroidBase(DROID *psDroid, DROID_ORDER_DATA *psOrder)
 		objTrace(psDroid->id, "Starting new upgrade of %s", psOrder->psStats ? getStatsName(psOrder->psStats) : "NULL");
 		break;
 	case DORDER_HELPBUILD:
-	  if (isRetreatingInGroup(psDroid))
+		if (isRetreatingInGroup(psDroid))
 		{
 		  break;
 		}
@@ -1525,7 +1525,7 @@ void orderDroidBase(DROID *psDroid, DROID_ORDER_DATA *psOrder)
 		actionDroid(psDroid, DACTION_DROIDREPAIR, psOrder->psObj);
 		break;
 	case DORDER_OBSERVE:
-	  if (isRetreatingInGroup(psDroid))
+		if (isRetreatingInGroup(psDroid))
 		{
 		  break;
 		}
@@ -1743,7 +1743,7 @@ void orderDroidBase(DROID *psDroid, DROID_ORDER_DATA *psOrder)
 		}
 		break;
 	case DORDER_GUARD:
-	  if (isRetreatingInGroup(psDroid))
+		if (isRetreatingInGroup(psDroid))
 		{
 		  break;
 		}
@@ -1779,7 +1779,7 @@ void orderDroidBase(DROID *psDroid, DROID_ORDER_DATA *psOrder)
 		assignVTOLPad(psDroid, (STRUCTURE *)psOrder->psObj);
 		break;
 	case DORDER_CIRCLE:
-	  if (isRetreatingInGroup(psDroid))
+		if (isRetreatingInGroup(psDroid))
 		{
 		  break;
 		}

--- a/src/order.cpp
+++ b/src/order.cpp
@@ -1383,7 +1383,7 @@ void orderDroidBase(DROID *psDroid, DROID_ORDER_DATA *psOrder)
 	  if (isRetreatingInGroup(psDroid))
 	  {
 		  break;
-	  }
+    }
 		psDroid->order = *psOrder;
 		psDroid->order.pos2 = psDroid->pos.xy();
 		actionDroid(psDroid, DACTION_MOVE, psOrder->pos.x, psOrder->pos.y);
@@ -1392,7 +1392,7 @@ void orderDroidBase(DROID *psDroid, DROID_ORDER_DATA *psOrder)
 	  if (isRetreatingInGroup(psDroid))
 	  {
 		  break;
-	  }
+    }
 		psDroid->order = *psOrder;
 		actionDroid(psDroid, DACTION_MOVE, psOrder->psObj->pos.x, psOrder->psObj->pos.y);
 		break;
@@ -1454,7 +1454,7 @@ void orderDroidBase(DROID *psDroid, DROID_ORDER_DATA *psOrder)
 	  if (isRetreatingInGroup(psDroid))
 		{
 		  break;
-	  }
+    }
 		// build a new structure or line of structures
 		ASSERT_OR_RETURN(, isConstructionDroid(psDroid), "%s cannot construct things!", objInfo(psDroid));
 		ASSERT_OR_RETURN(, psOrder->psStats != nullptr, "invalid structure stats pointer");
@@ -1467,7 +1467,7 @@ void orderDroidBase(DROID *psDroid, DROID_ORDER_DATA *psOrder)
 	  if (isRetreatingInGroup(psDroid))
 		{
 		  break;
-	  }
+    }
 		//build a module onto the structure
 		if (!isConstructionDroid(psDroid) || psOrder->index < nextModuleToBuild((STRUCTURE *)psOrder->psObj, -1))
 		{
@@ -1483,7 +1483,7 @@ void orderDroidBase(DROID *psDroid, DROID_ORDER_DATA *psOrder)
 	  if (isRetreatingInGroup(psDroid))
 		{
 		  break;
-	  }
+    }
 		// help to build a structure that is starting to be built
 		ASSERT_OR_RETURN(, isConstructionDroid(psDroid), "Not a constructor droid");
 		ASSERT_OR_RETURN(, psOrder->psObj != nullptr, "Help to build a NULL pointer?");
@@ -1498,7 +1498,7 @@ void orderDroidBase(DROID *psDroid, DROID_ORDER_DATA *psOrder)
 		if (isRetreatingInGroup(psDroid))
 		{
 		  break;
-	  }
+    }
 		if (!(psDroid->droidType == DROID_CONSTRUCT || psDroid->droidType == DROID_CYBORG_CONSTRUCT))
 		{
 			break;
@@ -1528,7 +1528,7 @@ void orderDroidBase(DROID *psDroid, DROID_ORDER_DATA *psOrder)
 	  if (isRetreatingInGroup(psDroid))
 		{
 		  break;
-	  }
+    }
 		// keep an object within sensor view
 		psDroid->order = *psOrder;
 		actionDroid(psDroid, DACTION_OBSERVE, psOrder->psObj);
@@ -1746,7 +1746,7 @@ void orderDroidBase(DROID *psDroid, DROID_ORDER_DATA *psOrder)
 	  if (isRetreatingInGroup(psDroid))
 		{
 		  break;
-	  }
+    }
 		psDroid->order = *psOrder;
 		if (psOrder->psObj != nullptr)
 		{
@@ -1782,7 +1782,7 @@ void orderDroidBase(DROID *psDroid, DROID_ORDER_DATA *psOrder)
 	  if (isRetreatingInGroup(psDroid))
 		{
 		  break;
-	  }
+    }
 		if (!isVtolDroid(psDroid))
 		{
 			break;


### PR DESCRIPTION
This changes the behaviour of retreating droids. They retain their group but will ignore most orders except hold until they are repaired. 

https://github.com/Warzone2100/warzone2100/issues/2330

