### PR TITLE
Repairs & Builders: don't move needlessly

### DIFF
--- a/src/action.cpp
+++ b/src/action.cpp
@@ -1981,7 +1981,7 @@ void actionUpdateDroid(DROID *psDroid)
 	case DACTION_MOVETODROIDREPAIR:
 		{
 			BASE_OBJECT* actionTargetObj = psDroid->psActionTarget[0];
-			ASSERT_OR_RETURN(, actionTargetObj->type == OBJ_DROID, "unexpected repair target");
+			ASSERT_OR_RETURN(, actionTargetObj != nullptr && actionTargetObj->type == OBJ_DROID, "unexpected repair target");
 			const DROID* actionTarget = (const DROID *) actionTargetObj;
 			if (actionTarget->body == actionTarget->originalBody)
 			{


### PR DESCRIPTION
This implements https://github.com/Warzone2100/warzone2100/issues/2385 and extends it to Repair Turrets:
- Trucks and RT will now stop  moving if repair target has been completely repaired 
- When a unit is damaged within radius of RT, it will simply start repairing, without trying to move closer

Now:
![rt-stop-when-completed](https://user-images.githubusercontent.com/25161465/141296726-22cc25c0-0950-4908-93e9-9cfb483fda30.gif)

Before:
![master-rt-dont-stop](https://user-images.githubusercontent.com/25161465/141296808-0b9f6cfa-86c5-4be0-bfa8-80c823de1baa.gif)

