### PR TITLE
Fix: additional checks for physfs

### DIFF
--- a/lib/framework/physfs_ext.cpp
+++ b/lib/framework/physfs_ext.cpp
@@ -29,11 +29,17 @@ using nonstd::nullopt;
 bool WZ_PHYSFS_enumerateFiles(const char *dir, const std::function<bool (char* file)>& enumFunc)
 {
 	char **files = PHYSFS_enumerateFiles(dir);
-	if (!*files)
+	if (!files)
 	{
 		// some folders/files are expected to *not* exist, so technically 
 		// it's up to the caller to decide whether it's an error or not 
 		debug(LOG_WARNING, "PHYSFS_enumerateFiles(\"%s\") failed: %s", dir, WZ_PHYSFS_getLastError());
+		return false;
+	}
+	// "files" is not null when directory doesn't exist, so check that explicitely
+	if (!WZ_PHYSFS_isDirectory(dir))
+	{
+		debug(LOG_WARNING, "Directory didn't exist [%s]", dir);
 		return false;
 	}
 	for (char **i = files; *i != nullptr; ++i)
@@ -50,11 +56,17 @@ bool WZ_PHYSFS_enumerateFiles(const char *dir, const std::function<bool (char* f
 bool WZ_PHYSFS_enumerateFolders(const std::string &dir, const std::function<bool (char* folder)>& enumFunc)
 {
 	char **files = PHYSFS_enumerateFiles(dir.c_str());
-	if (!*files)
+	if (!files)
 	{
 		// some folders/files are expected to *not* exist, so technically 
 		// it's up to the caller to decide whether it's an error or not 
 		debug(LOG_WARNING, "PHYSFS_enumerateFiles(\"%s\") failed: %s", dir.c_str(), WZ_PHYSFS_getLastError());
+		return false;
+	}
+	// "files" is not null when directory doesn't exist, so check that explicitely
+	if (!WZ_PHYSFS_isDirectory(dir.c_str()))
+	{
+		debug(LOG_WARNING, "Directory didn't exist [%s]", dir.c_str());
 		return false;
 	}
 	std::string baseDir = dir;

--- a/src/loadsave.cpp
+++ b/src/loadsave.cpp
@@ -540,8 +540,8 @@ void deleteSaveGame(const char *fileName)
 	strncpy(tmp, fileName, PATH_MAX - 1);
 	tmp[strlen(tmp) - 4] = '\0'; // strip extension
 
-	strcat(tmp, ".es");					// remove script data if it exists.
-	PHYSFS_delete(tmp);
+	strcat(tmp, ".es");					
+	PHYSFS_delete(tmp); // remove script data if it exists or error
 	tmp[strlen(tmp) - 3] = '\0'; // strip extension
 
 	// check for a directory and remove that too.
@@ -555,16 +555,15 @@ void deleteSaveGame(const char *fileName)
 		debug(LOG_SAVE, "Deleting [%s].", del_file);
 
 		// Delete the file
-		if (!PHYSFS_delete(del_file))
+		if (PHYSFS_exists(del_file) && !PHYSFS_delete(del_file))
 		{
 			debug(LOG_ERROR, "Warning [%s] could not be deleted due to PhysicsFS error: %s", del_file, WZ_PHYSFS_getLastError());
 		}
 		return true; // continue
 	});
-
-	if (!PHYSFS_delete(tmp))		// now (should be)empty directory
+	if (PHYSFS_exists(tmp) && !PHYSFS_delete(tmp))		// now (should be)empty directory
 	{
-		debug(LOG_ERROR, "Warning directory[%s] could not be deleted because %s", fileName, WZ_PHYSFS_getLastError());
+		debug(LOG_ERROR, "Warning directory[%s] could not be deleted because %s", tmp, WZ_PHYSFS_getLastError());
 	}
 }
 
@@ -1005,7 +1004,7 @@ void drawBlueBox(UDWORD x, UDWORD y, UDWORD w, UDWORD h)
 // returns true if something was deleted
 static bool freeAutoSaveSlot_old(const char *path)
 {
-	return WZ_PHYSFS_cleanupOldFilesInFolder(path, sSaveGameExtension, -1, [](const char *fileName){ deleteSaveGame(fileName); return true; }) > 0;
+	return WZ_PHYSFS_cleanupOldFilesInFolder(path, sSaveGameExtension, 35, [](const char *fileName){ deleteSaveGame(fileName); return true; }) > 0;
 }
 
 static void freeAutoSaveSlot(SAVEGAME_LOC loc)

--- a/src/loadsave.cpp
+++ b/src/loadsave.cpp
@@ -561,7 +561,7 @@ void deleteSaveGame(const char *fileName)
 		}
 		return true; // continue
 	});
-	if (PHYSFS_exists(tmp) && !PHYSFS_delete(tmp))		// now (should be)empty directory
+	if (WZ_PHYSFS_isDirectory(tmp) && !PHYSFS_delete(tmp))		// now (should be)empty directory
 	{
 		debug(LOG_ERROR, "Warning directory[%s] could not be deleted because %s", tmp, WZ_PHYSFS_getLastError());
 	}


### PR DESCRIPTION
- Replaced -1 in `WZ_PHYSFS_cleanupOldFilesInFolder(path, sSaveGameExtension, -1, [](const char *fileName)` with 35, because that looked a debug version that hasn't been removed. Setting it to -1 artificially prevents from having more than 1 Autosave. 35 is the max numbers of slots for saved games supported by UI today
- ~~Replaced `if (!files)` with `f (!*files)`~~ Added checks `WZ_PHYSFS_isDirectory`, because `PHYSFS_enumerateFiles` doesn't return NULL on non-existent directory. According to documentation (https://icculus.org/physfs/docs/html/physfs_8h.html#a0f4ae950c2dae0735a91263ddd20fbf4), it *should* return NULL on any failure though. I believe this is the main reason why people kept seeing errors: because `if (!files)` never failed, we erroneously assumed a directory existed and we should delete it. It wasn't there in the first place.
- Added actual checks for `PHYSFS_exists(...)` and `WZ_PHYSFS_isDirectory(...)`before complaining and scare people that we couldn't delete something. 

Need @past-due to review this he ll be available (i am still puzzled about `PHYSFS_enumerateFiles` )
Related bug reports:
https://github.com/Warzone2100/warzone2100/issues/2343
https://github.com/Warzone2100/warzone2100/issues/2388