### PR TITLE
Fix: dont show modules when cant build more buildings of that type

### DIFF
--- a/src/structure.cpp
+++ b/src/structure.cpp
@@ -3941,7 +3941,7 @@ std::vector<STRUCTURE_STATS *> fillStructureList(UDWORD _selectedPlayer, UDWORD 
 				continue;
 			}
 			counter[0] = asStructureStats[inc].curCount[_selectedPlayer];
-		    	counter[1] = asStructureStats[inc].upgrade[_selectedPlayer].limit;
+			counter[1] = asStructureStats[inc].upgrade[_selectedPlayer].limit;
 
 		}
 	}

--- a/src/structure.cpp
+++ b/src/structure.cpp
@@ -3941,7 +3941,7 @@ std::vector<STRUCTURE_STATS *> fillStructureList(UDWORD _selectedPlayer, UDWORD 
 				continue;
 			}
 			counter[0] = asStructureStats[inc].curCount[_selectedPlayer];
-		    counter[1] = asStructureStats[inc].upgrade[_selectedPlayer].limit;
+		    	counter[1] = asStructureStats[inc].upgrade[_selectedPlayer].limit;
 
 		}
 	}

--- a/src/structuredef.h
+++ b/src/structuredef.h
@@ -284,7 +284,7 @@ struct STRUCTURE : public BASE_OBJECT
 	///< but shouldn't make a difference unless 3 mutual enemies happen to be fighting each other at the same time.
 	uint32_t prevTime;               ///< Time of structure's previous tick.
 	float foundationDepth;           ///< Depth of structure's foundation
-	uint8_t capacity;                ///< Number of module upgrades
+	uint8_t capacity;                ///< Lame name: current number of module upgrades (*not* maximum nb of upgrades)
 	STRUCT_ANIM_STATES	state;
 	UDWORD lastStateTime;
 	iIMDShape *prebuiltImd;


### PR DESCRIPTION
Fixes https://github.com/Warzone2100/warzone2100/issues/2127

Modules won't appear in buildlist when no more corresponding structure can be built