### PR TITLE
Perf: improve general rendering performace a bit by avoiding same matrix calculations in loops

### DIFF
--- a/lib/ivis_opengl/imdload.cpp
+++ b/lib/ivis_opengl/imdload.cpp
@@ -48,7 +48,6 @@ using Vector4f = glm::vec4;
 #define INT_SCALE       1000
 
 static std::unordered_map<std::string, iIMDShape> models;
-static std::unordered_map<iIMDShape*, std::string> modelsReverse;
 
 static void iV_ProcessIMD(const WzString &filename, const char **ppFileData, const char *FileDataEnd);
 
@@ -65,7 +64,6 @@ iIMDShape::~iIMDShape()
 void modelShutdown()
 {
 	models.clear();
-	modelsReverse.clear();
 }
 
 void enumerateLoadedModels(const std::function<void (const std::string& modelName, iIMDShape& model)>& func)
@@ -98,12 +96,12 @@ static bool tryLoad(const WzString &path, const WzString &filename)
 
 const std::string &modelName(iIMDShape *model)
 {
-	auto it = modelsReverse.find(model);
-	if (it != modelsReverse.end())
+	if (model != nullptr)
 	{
-		return it->second;
+		ASSERT(!model->modelName.empty(), "An IMD pointer could not be backtraced to a filename!");
+		return model->modelName;
 	}
-	ASSERT(false, "An IMD pointer could not be backtraced to a filename!");
+	ASSERT(false, "Null IMD pointer??");
 	static std::string error;
 	return error;
 }
@@ -749,7 +747,7 @@ static iIMDShape *_imd_load_level(const WzString &filename, const char **ppFileD
 	}
 	ASSERT(models.count(key) == 0, "Duplicate model load for %s!", key.c_str());
 	iIMDShape &s = models[key]; // create entry and return reference
-	modelsReverse[&s] = key;
+	s.modelName = key;
 	s.pShadowPoints = &s.points;
 	s.pShadowPolys = &s.polys;
 

--- a/lib/ivis_opengl/imdload.cpp
+++ b/lib/ivis_opengl/imdload.cpp
@@ -48,6 +48,7 @@ using Vector4f = glm::vec4;
 #define INT_SCALE       1000
 
 static std::unordered_map<std::string, iIMDShape> models;
+static std::unordered_map<iIMDShape*, std::string> modelsReverse;
 
 static void iV_ProcessIMD(const WzString &filename, const char **ppFileData, const char *FileDataEnd);
 
@@ -64,6 +65,7 @@ iIMDShape::~iIMDShape()
 void modelShutdown()
 {
 	models.clear();
+	modelsReverse.clear();
 }
 
 void enumerateLoadedModels(const std::function<void (const std::string& modelName, iIMDShape& model)>& func)
@@ -96,12 +98,10 @@ static bool tryLoad(const WzString &path, const WzString &filename)
 
 const std::string &modelName(iIMDShape *model)
 {
-	for (const auto &pair : models)
+	auto it = modelsReverse.find(model);
+	if (it != modelsReverse.end())
 	{
-		if (&pair.second == model)
-		{
-			return pair.first;
-		}
+		return it->second;
 	}
 	ASSERT(false, "An IMD pointer could not be backtraced to a filename!");
 	static std::string error;
@@ -749,6 +749,7 @@ static iIMDShape *_imd_load_level(const WzString &filename, const char **ppFileD
 	}
 	ASSERT(models.count(key) == 0, "Duplicate model load for %s!", key.c_str());
 	iIMDShape &s = models[key]; // create entry and return reference
+	modelsReverse[&s] = key;
 	s.pShadowPoints = &s.points;
 	s.pShadowPolys = &s.polys;
 

--- a/lib/ivis_opengl/ivisdef.h
+++ b/lib/ivis_opengl/ivisdef.h
@@ -158,6 +158,8 @@ struct iIMDShape
 
 	int interpolate = 1; // if the model wants to be interpolated
 
+	std::string modelName;
+
 	iIMDShape *next = nullptr;  // next pie in multilevel pies (NULL for non multilevel !)
 };
 

--- a/lib/ivis_opengl/piematrix.cpp
+++ b/lib/ivis_opengl/piematrix.cpp
@@ -56,17 +56,18 @@ static PerspectiveCache perspectiveCache;
  * 3D vector perspective projection
  * Projects 3D vector into 2D screen space
  * \param v3d       3D vector to project
+ * \param perspectiveViewMatrix		precomputed perspective multipled by view matrix
  * \param[out] v2d  resulting 2D vector
  * \return projected z component of v2d
  */
-int32_t pie_RotateProject(const Vector3i *v3d, const glm::mat4& matrix, Vector2i *v2d)
+int32_t pie_RotateProjectWithPerspective(const Vector3i *v3d, const glm::mat4 &perspectiveViewMatrix, Vector2i *v2d)
 {
 	float hackScaleFactor = 1.0f / (3 * 330);  // HACK: This seems to work by experimentation, not sure why.
 
 	/*
 	 * v = curMatrix . v3d
 	 */
-	glm::vec4 v(pie_PerspectiveGet() * matrix * glm::vec4(*v3d, 1.f));
+	glm::vec4 v(perspectiveViewMatrix * glm::vec4(*v3d, 1.f));
 
 	const float xx = v.x / v.w;
 	const float yy = v.y / v.w;

--- a/lib/ivis_opengl/piematrix.h
+++ b/lib/ivis_opengl/piematrix.h
@@ -24,7 +24,7 @@
 #include "lib/ivis_opengl/piedef.h"
 #include <glm/fwd.hpp>
 
-int32_t pie_RotateProject(const Vector3i *src, const glm::mat4& matrix, Vector2i *dest);
+int32_t pie_RotateProjectWithPerspective(const Vector3i *v3d, const glm::mat4 &perspectiveViewMatrix, Vector2i *v2d);
 const glm::mat4& pie_PerspectiveGet();
 void pie_SetGeometricOffset(int x, int y);
 void pie_Begin3DScene();

--- a/src/atmos.cpp
+++ b/src/atmos.cpp
@@ -307,7 +307,7 @@ void atmosUpdateSystem()
 	}
 }
 
-void atmosDrawParticles(const glm::mat4 &viewMatrix)
+void atmosDrawParticles(const glm::mat4 &viewMatrix, const glm::mat4 &perspectiveViewMatrix)
 {
 	UDWORD	i;
 
@@ -323,7 +323,7 @@ void atmosDrawParticles(const glm::mat4 &viewMatrix)
 		if (asAtmosParts[i].status == APS_ACTIVE)
 		{
 			/* Is it visible on the screen? */
-			if (clipXYZ(static_cast<int>(asAtmosParts[i].position.x), static_cast<int>(asAtmosParts[i].position.z), static_cast<int>(asAtmosParts[i].position.y), viewMatrix))
+			if (clipXYZ(static_cast<int>(asAtmosParts[i].position.x), static_cast<int>(asAtmosParts[i].position.z), static_cast<int>(asAtmosParts[i].position.y), perspectiveViewMatrix))
 			{
 				renderParticle(&asAtmosParts[i], viewMatrix);
 			}

--- a/src/atmos.h
+++ b/src/atmos.h
@@ -43,8 +43,8 @@ enum WT_CLASS
 
 void atmosInitSystem();
 void atmosUpdateSystem();
-void renderParticle(ATPART *psPart, const glm::mat4 &viewMatrix);
-void atmosDrawParticles(const glm::mat4 &viewMatrix);
+void renderParticle(ATPART *psPart, const glm::mat4 &perspectiveViewMatrix);
+void atmosDrawParticles(const glm::mat4 &viewMatrix, const glm::mat4 &perspectiveViewMatrix);
 void atmosSetWeatherType(WT_CLASS type);
 WT_CLASS atmosGetWeatherType();
 

--- a/src/bucket3d.cpp
+++ b/src/bucket3d.cpp
@@ -59,7 +59,7 @@ struct BUCKET_TAG
 
 static std::vector<BUCKET_TAG> bucketArray;
 
-static SDWORD bucketCalculateZ(RENDER_TYPE objectType, void *pObject, const glm::mat4 &viewMatrix)
+static SDWORD bucketCalculateZ(RENDER_TYPE objectType, void *pObject, const glm::mat4 &perspectiveViewMatrix)
 {
 	SDWORD				z = 0, radius;
 	Vector2i				pixel(0, 0);
@@ -82,7 +82,7 @@ static SDWORD bucketCalculateZ(RENDER_TYPE objectType, void *pObject, const glm:
 		position.z = -(position.z - playerPos.p.z);
 
 		/* 16 below is HACK!!! */
-		z = pie_RotateProject(&position, viewMatrix, &pixel) - 16;
+		z = pie_RotateProjectWithPerspective(&position, perspectiveViewMatrix, &pixel) - 16;
 		if (z > 0)
 		{
 			//particle use the image radius
@@ -116,7 +116,7 @@ static SDWORD bucketCalculateZ(RENDER_TYPE objectType, void *pObject, const glm:
 
 			position.y = psSimpObj->pos.z;
 
-			z = pie_RotateProject(&position, viewMatrix, &pixel);
+			z = pie_RotateProjectWithPerspective(&position, perspectiveViewMatrix, &pixel);
 
 			if (z > 0)
 			{
@@ -151,7 +151,7 @@ static SDWORD bucketCalculateZ(RENDER_TYPE objectType, void *pObject, const glm:
 			radius = (((STRUCTURE *)pObject)->sDisplay.imd->radius);
 		}
 
-		z = pie_RotateProject(&position, viewMatrix, &pixel);
+		z = pie_RotateProjectWithPerspective(&position, perspectiveViewMatrix, &pixel);
 
 		if (z > 0)
 		{
@@ -172,7 +172,7 @@ static SDWORD bucketCalculateZ(RENDER_TYPE objectType, void *pObject, const glm:
 
 		position.y = psSimpObj->pos.z + 2;
 
-		z = pie_RotateProject(&position, viewMatrix, &pixel);
+		z = pie_RotateProjectWithPerspective(&position, perspectiveViewMatrix, &pixel);
 
 		if (z > 0)
 		{
@@ -197,7 +197,7 @@ static SDWORD bucketCalculateZ(RENDER_TYPE objectType, void *pObject, const glm:
 
 		psBStats = asBodyStats + psDroid->asBits[COMP_BODY];
 		droidSize = psBStats->pIMD->radius;
-		z = pie_RotateProject(&position, viewMatrix, &pixel) - (droidSize * 2);
+		z = pie_RotateProjectWithPerspective(&position, perspectiveViewMatrix, &pixel) - (droidSize * 2);
 
 		if (z > 0)
 		{
@@ -234,7 +234,7 @@ static SDWORD bucketCalculateZ(RENDER_TYPE objectType, void *pObject, const glm:
 			position.z = -(ptr->psMessage->psObj->pos.y - playerPos.p.z);
 			position.y = ptr->psMessage->psObj->pos.z;
 		}
-		z = pie_RotateProject(&position, viewMatrix, &pixel);
+		z = pie_RotateProjectWithPerspective(&position, perspectiveViewMatrix, &pixel);
 
 		if (z > 0)
 		{
@@ -256,7 +256,7 @@ static SDWORD bucketCalculateZ(RENDER_TYPE objectType, void *pObject, const glm:
 		position.y = static_cast<int>(((EFFECT *)pObject)->position.y);
 
 		/* 16 below is HACK!!! */
-		z = pie_RotateProject(&position, viewMatrix, &pixel) - 16;
+		z = pie_RotateProjectWithPerspective(&position, perspectiveViewMatrix, &pixel) - 16;
 
 		if (z > 0)
 		{
@@ -283,7 +283,7 @@ static SDWORD bucketCalculateZ(RENDER_TYPE objectType, void *pObject, const glm:
 		               coords.y - playerPos.p.z);
 		position.y = ((FLAG_POSITION *)pObject)->coords.z;
 
-		z = pie_RotateProject(&position, viewMatrix, &pixel);
+		z = pie_RotateProjectWithPerspective(&position, perspectiveViewMatrix, &pixel);
 
 		if (z > 0)
 		{
@@ -308,11 +308,11 @@ static SDWORD bucketCalculateZ(RENDER_TYPE objectType, void *pObject, const glm:
 }
 
 /* add an object to the current render list */
-void bucketAddTypeToList(RENDER_TYPE objectType, void *pObject, const glm::mat4 &viewMatrix)
+void bucketAddTypeToList(RENDER_TYPE objectType, void *pObject, const glm::mat4 &perspectiveViewMatrix)
 {
 	const iIMDShape *pie;
 	BUCKET_TAG	newTag;
-	int32_t		z = bucketCalculateZ(objectType, pObject, viewMatrix);
+	int32_t		z = bucketCalculateZ(objectType, pObject, perspectiveViewMatrix);
 
 	if (z < 0)
 	{
@@ -383,11 +383,11 @@ void bucketAddTypeToList(RENDER_TYPE objectType, void *pObject, const glm::mat4 
 }
 
 /* render Objects in list */
-void bucketRenderCurrentList(const glm::mat4 &viewMatrix)
+void bucketRenderCurrentList(const glm::mat4 &viewMatrix, const glm::mat4 &perspectiveViewMatrix)
 {
 	std::sort(bucketArray.begin(), bucketArray.end());
 
-	for (std::vector<BUCKET_TAG>::const_iterator thisTag = bucketArray.begin(); thisTag != bucketArray.end(); ++thisTag)
+	for (auto thisTag = bucketArray.cbegin(); thisTag != bucketArray.cend(); ++thisTag)
 	{
 		switch (thisTag->objectType)
 		{
@@ -398,22 +398,22 @@ void bucketRenderCurrentList(const glm::mat4 &viewMatrix)
 			renderEffect((EFFECT *)thisTag->pObject, viewMatrix);
 			break;
 		case RENDER_DROID:
-			displayComponentObject((DROID *)thisTag->pObject, viewMatrix);
+			displayComponentObject((DROID *)thisTag->pObject, viewMatrix, perspectiveViewMatrix);
 			break;
 		case RENDER_STRUCTURE:
-			renderStructure((STRUCTURE *)thisTag->pObject, viewMatrix);
+			renderStructure((STRUCTURE *)thisTag->pObject, viewMatrix, perspectiveViewMatrix);
 			break;
 		case RENDER_FEATURE:
-			renderFeature((FEATURE *)thisTag->pObject, viewMatrix);
+			renderFeature((FEATURE *)thisTag->pObject, viewMatrix, perspectiveViewMatrix);
 			break;
 		case RENDER_PROXMSG:
-			renderProximityMsg((PROXIMITY_DISPLAY *)thisTag->pObject, viewMatrix);
+			renderProximityMsg((PROXIMITY_DISPLAY *)thisTag->pObject, viewMatrix, perspectiveViewMatrix);
 			break;
 		case RENDER_PROJECTILE:
-			renderProjectile((PROJECTILE *)thisTag->pObject, viewMatrix);
+			renderProjectile((PROJECTILE *)thisTag->pObject, viewMatrix, perspectiveViewMatrix);
 			break;
 		case RENDER_DELIVPOINT:
-			renderDeliveryPoint((FLAG_POSITION *)thisTag->pObject, false, viewMatrix);
+			renderDeliveryPoint((FLAG_POSITION *)thisTag->pObject, false, viewMatrix, perspectiveViewMatrix);
 			break;
 		}
 	}

--- a/src/bucket3d.h
+++ b/src/bucket3d.h
@@ -36,9 +36,9 @@ enum RENDER_TYPE
 //function prototypes
 
 /* add an object to the current render list */
-void bucketAddTypeToList(RENDER_TYPE objectType, void *object, const glm::mat4 &viewMatrix);
+void bucketAddTypeToList(RENDER_TYPE objectType, void *object, const glm::mat4 &perspectiveViewMatrix);
 
 /* render Objects in list */
-void bucketRenderCurrentList(const glm::mat4 &viewMatrix);
+void bucketRenderCurrentList(const glm::mat4 &viewMatrix, const glm::mat4 &perspectiveViewMatrix);
 
 #endif // __INCLUDED_SRC_BUCKET3D_H__

--- a/src/component.cpp
+++ b/src/component.cpp
@@ -394,7 +394,7 @@ void drawMuzzleFlash(WEAPON sWeap, iIMDShape *weaponImd, iIMDShape *flashImd, PI
 /* Assumes matrix context is already set */
 // this is able to handle multiple weapon graphics now
 // removed mountRotation,they get such stuff from psObj directly now
-static bool displayCompObj(DROID *psDroid, bool bButton, const glm::mat4 &viewMatrix)
+static bool displayCompObj(DROID *psDroid, bool bButton, const glm::mat4 &viewMatrix, const glm::mat4 &perspectiveViewModelMatrix)
 {
 	iIMDShape *psMoveAnim, *psStillAnim;
 	SDWORD				iConnector;
@@ -526,7 +526,7 @@ static bool displayCompObj(DROID *psDroid, bool bButton, const glm::mat4 &viewMa
 	if (!bButton)
 	{
 		/* set up all the screen coords stuff - need to REMOVE FROM THIS LOOP */
-		calcScreenCoords(psDroid, viewModelMatrix);
+		calcScreenCoords(psDroid, perspectiveViewModelMatrix);
 	}
 
 	/* set default components transparent */
@@ -813,7 +813,7 @@ void displayComponentButtonTemplate(DROID_TEMPLATE *psTemplate, const Vector3i *
 	Droid.rot = Vector3i(0, 0, 0);
 
 	//draw multi component object as a button object
-	displayCompObj(&Droid, true, matrix);
+	displayCompObj(&Droid, true, matrix, pie_PerspectiveGet() * matrix);
 }
 
 
@@ -832,12 +832,12 @@ void displayComponentButtonObject(DROID *psDroid, const Vector3i *Rotation, cons
 
 	// And render the composite object.
 	//draw multi component object as a button object
-	displayCompObj(psDroid, true, matrix);
+	displayCompObj(psDroid, true, matrix, pie_PerspectiveGet() * matrix);
 }
 
 /* Assumes matrix context is already set */
 // multiple turrets display removed the pointless mountRotation
-void displayComponentObject(DROID *psDroid, const glm::mat4 &viewMatrix)
+void displayComponentObject(DROID *psDroid, const glm::mat4 &viewMatrix, const glm::mat4 &perspectiveViewMatrix)
 {
 	Vector3i position, rotation;
 	Spacetime st = interpolateObjectSpacetime(psDroid, graphicsTime);
@@ -872,7 +872,7 @@ void displayComponentObject(DROID *psDroid, const glm::mat4 &viewMatrix)
 	}
 
 	// now check if the projected circle is within the screen boundaries
-	if(!clipDroidOnScreen(psDroid, viewMatrix * modelMatrix))
+	if(!clipDroidOnScreen(psDroid, perspectiveViewMatrix * modelMatrix))
 	{
 		return;
 	}
@@ -893,7 +893,7 @@ void displayComponentObject(DROID *psDroid, const glm::mat4 &viewMatrix)
 	{
 		//ingame not button object
 		//should render 3 mounted weapons now
-		if (displayCompObj(psDroid, false, viewMatrix * modelMatrix))
+		if (displayCompObj(psDroid, false, viewMatrix * modelMatrix, perspectiveViewMatrix * modelMatrix))
 		{
 			// did draw something to the screen - update the framenumber
 			psDroid->sDisplay.frameNumber = frameGetFrameNumber();

--- a/src/component.h
+++ b/src/component.h
@@ -68,7 +68,7 @@ void displayComponentButton(BASE_STATS *Stat, const Vector3i *Rotation, const Ve
 void displayResearchButton(BASE_STATS *Stat, const Vector3i *Rotation, const Vector3i *Position, int scale);
 void displayComponentButtonTemplate(DROID_TEMPLATE *psTemplate, const Vector3i *Rotation, const Vector3i *Position, int scale);
 void displayComponentButtonObject(DROID *psDroid, const Vector3i *Rotation, const Vector3i *Position, int scale);
-void displayComponentObject(DROID *psDroid, const glm::mat4 &viewMatrix);
+void displayComponentObject(DROID *psDroid, const glm::mat4 &viewMatrix, const glm::mat4 &perspectiveViewMatrix);
 
 void compPersonToBits(DROID *psDroid);
 

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -1492,11 +1492,11 @@ void cancelDeliveryRepos()
 	flagReposVarsValid = false;
 }
 
-void renderDeliveryRepos(const glm::mat4 &viewMatrix)
+void renderDeliveryRepos(const glm::mat4 &viewMatrix, const glm::mat4 &perspectiveViewMatrix)
 {
 	if (flagReposVarsValid)
 	{
-		renderDeliveryPoint(&flagPos, true, viewMatrix);
+		renderDeliveryPoint(&flagPos, true, viewMatrix, perspectiveViewMatrix);
 	}
 }
 

--- a/src/display.h
+++ b/src/display.h
@@ -193,7 +193,7 @@ void cancelDeliveryRepos();
 void startDeliveryPosition(FLAG_POSITION *psFlag);
 bool deliveryReposValid();
 void processDeliveryRepos();
-void renderDeliveryRepos(const glm::mat4 &viewMatrix);
+void renderDeliveryRepos(const glm::mat4 &viewMatrix, const glm::mat4 &perspectiveViewMatrix);
 bool deliveryReposFinished(FLAG_POSITION *psFlag = nullptr);
 
 bool	getRotActive();
@@ -230,7 +230,7 @@ bool ctrlShiftDown();
 void animateToViewDistance(float target, float speed = DEFAULT_VIEW_DISTANCE_ANIMATION_SPEED);
 void incrementViewDistance(float amount);
 void displayRenderLoop();
-bool clipXYZ(int x, int y, int z, const glm::mat4 &viewMatrix);
-bool clipXYZNormalized(const Vector3i &normalizedPosition, const glm::mat4 &viewMatrix);
+bool clipXYZ(int x, int y, int z, const glm::mat4 &perspectiveViewMatrix);
+bool clipXYZNormalized(const Vector3i &normalizedPosition, const glm::mat4 &perspectiveViewMatrix);
 
 #endif // __INCLUDED_SRC_DISPLAY_H__

--- a/src/display3d.h
+++ b/src/display3d.h
@@ -77,13 +77,13 @@ void disp3d_oldView(); // for save games <= 10
 void disp3d_getView(iView *newView);
 void screenCoordToWorld(const Vector2i, Vector2i&, SDWORD&, SDWORD&);
 void draw3DScene();
-void renderStructure(STRUCTURE *psStructure, const glm::mat4 &viewMatrix);
-void renderFeature(FEATURE *psFeature, const glm::mat4 &viewMatrix);
-void renderProximityMsg(PROXIMITY_DISPLAY	*psProxDisp, const glm::mat4 &viewMatrix);
-void renderProjectile(PROJECTILE *psCurr, const glm::mat4 &viewMatrix);
-void renderDeliveryPoint(FLAG_POSITION *psPosition, bool blueprint, const glm::mat4 &viewMatrix);
+void renderStructure(STRUCTURE *psStructure, const glm::mat4 &viewMatrix, const glm::mat4 &perspectiveViewMatrix);
+void renderFeature(FEATURE *psFeature, const glm::mat4 &viewMatrix, const glm::mat4 &perspectiveViewMatrix);
+void renderProximityMsg(PROXIMITY_DISPLAY	*psProxDisp, const glm::mat4 &viewMatrix, const glm::mat4 &perspectiveViewMatrix);
+void renderProjectile(PROJECTILE *psCurr, const glm::mat4 &viewMatrix, const glm::mat4 &perspectiveViewMatrix);
+void renderDeliveryPoint(FLAG_POSITION *psPosition, bool blueprint, const glm::mat4 &viewMatrix, const glm::mat4 &perspectiveViewMatrix);
 
-void calcScreenCoords(DROID *psDroid, const glm::mat4 &viewMatrix);
+void calcScreenCoords(DROID *psDroid, const glm::mat4 &perspectiveViewMatrix);
 ENERGY_BAR toggleEnergyBars();
 void drawDroidSelection(DROID *psDroid, bool drawBox);
 
@@ -91,9 +91,9 @@ bool doWeDrawProximitys();
 void setProximityDraw(bool val);
 
 bool	clipXY(SDWORD x, SDWORD y);
-inline bool clipShapeOnScreen(const iIMDShape *pIMD, const glm::mat4& viewModelMatrix, int overdrawScreenPoints = 10);
-bool clipDroidOnScreen(DROID *psDroid, const glm::mat4& viewModelMatrix, int overdrawScreenPoints = 25);
-bool clipStructureOnScreen(STRUCTURE *psStructure, const glm::mat4 &viewModelMatrix, int overdrawScreenPoints = 0);
+inline bool clipShapeOnScreen(const iIMDShape *pIMD, const glm::mat4 &perspectiveViewModelMatrix, int overdrawScreenPoints = 10);
+bool clipDroidOnScreen(DROID *psDroid, const glm::mat4 &perspectiveViewModelMatrix, int overdrawScreenPoints = 25);
+bool clipStructureOnScreen(STRUCTURE *psStructure);
 
 bool init3DView();
 void shutdown3DView();

--- a/src/effects.cpp
+++ b/src/effects.cpp
@@ -405,7 +405,7 @@ void addEffect(const Vector3i *pos, EFFECT_GROUP group, EFFECT_TYPE type, bool s
 
 
 /* Calls all the update functions for each different currently active effect */
-void processEffects(const glm::mat4 &viewMatrix)
+void processEffects(const glm::mat4 &perspectiveViewMatrix)
 {
 	for (auto it = activeList.begin(); it != activeList.end(); )
 	{
@@ -421,7 +421,7 @@ void processEffects(const glm::mat4 &viewMatrix)
 			}
 			if (psEffect->group != EFFECT_FREED && clipXY(static_cast<SDWORD>(psEffect->position.x), static_cast<SDWORD>(psEffect->position.z)))
 			{
-				bucketAddTypeToList(RENDER_EFFECT, psEffect, viewMatrix);
+				bucketAddTypeToList(RENDER_EFFECT, psEffect, perspectiveViewMatrix);
 			}
 		}
 		++it;

--- a/src/effects.h
+++ b/src/effects.h
@@ -153,7 +153,7 @@ void	effectGiveAuxVarSec(UDWORD var);	// and so's this
 
 void	initEffectsSystem();
 void	shutdownEffectsSystem();
-void	processEffects(const glm::mat4 &viewMatrix);
+void	processEffects(const glm::mat4 &perspectiveViewMatrix);
 void 	addEffect(const Vector3i *pos, EFFECT_GROUP group, EFFECT_TYPE type, bool specified, iIMDShape *imd, int lit);
 void    addEffect(const Vector3i *pos, EFFECT_GROUP group, EFFECT_TYPE type, bool specified, iIMDShape *imd, int lit, unsigned effectTime);
 void    addMultiEffect(const Vector3i *basePos, Vector3i *scatter, EFFECT_GROUP group, EFFECT_TYPE type, bool specified, iIMDShape *imd, unsigned int number, bool lit, unsigned int size, unsigned effectTime);


### PR DESCRIPTION
Also improves performance of `imdload`'s `modelName` by creating second, reverse mapping for amortized constant time searching. This method is called multiple times every frame and was doing linear lookup in a map of over 500 elements.

It is hard to measure performance gains, because FPS vary wildly on my PC across the same play. However, it seems that I gained about 10% more FPS. The matrix-matrix multiply operator is now lower in the list of functions taking the most time, so it was improved.