### PR TITLE
(MP)Incendiary Mortar Res Change

### DIFF
--- a/data/mp/stats/research.json
+++ b/data/mp/stats/research.json
@@ -8192,11 +8192,11 @@
 		"msgName": "RES_IMORT",
 		"name": "Incendiary Mortar",
 		"requiredResearch": [
-			"R-Wpn-Mortar-Damage03",
+			"R-Wpn-Mortar-Damage02",
 			"R-Wpn-Flame2"
 		],
-		"researchPoints": 3600,
-		"researchPower": 112,
+		"researchPoints": 4800,
+		"researchPower": 150,
 		"resultComponents": [
 			"Mortar-Incendiary"
 		],


### PR DESCRIPTION
After there was a rollback of IM damage values, in 4.2.1 version it became uninteresting in No Shared Res mode. So I decided to roll back its necessary research to make it easier to access in No Shared Res mode. Also, I was asked to make these changes by some multiplayer players.
Changing the necessary research for Incendiary Mortar and changing the cost to keep the timeline the same - 914 sec
HE Mortar Shells Mk3 -> HE Mortar Shells Mk2
"researchPoints": 3600 -> 4800
"researchPower": 112 -> 150