### PR TITLE
[WIP] Feature/1238 aligned building selection

### DIFF
--- a/src/display3d.cpp
+++ b/src/display3d.cpp
@@ -101,12 +101,11 @@ static void	locateMouse();
 static bool	renderWallSection(STRUCTURE *psStructure, const glm::mat4 &viewMatrix);
 static void	drawDragBox();
 static void	calcFlagPosScreenCoords(SDWORD *pX, SDWORD *pY, SDWORD *pR, const glm::mat4 &modelViewMatrix);
-static void calcStructureScreenCoords(STRUCTURE *psStructure, const glm::mat4 &modelViewMatrix);
 static void	drawTiles(iView *player);
 static void	display3DProjectiles(const glm::mat4 &viewMatrix);
 static void	drawDroidSelections();
 static void	drawStructureSelections();
-static void drawStructureSelectedBox(STRUCTURE *psStructure);
+static void drawStructureSelectedBox(STRUCTURE *psStructure, const glm::mat4 &modelViewMatrix);
 static void displayBlueprints(const glm::mat4 &viewMatrix);
 static void	processSensorTarget();
 static void	processDestinationTarget();
@@ -2512,12 +2511,6 @@ void renderStructure(STRUCTURE *psStructure, const glm::mat4 &viewMatrix)
 				viewMatrix * modelMatrix);
 		}
 
-		if (psStructure->selected)
-		{
-			calcStructureScreenCoords(psStructure, viewMatrix * modelMatrix);
-			drawStructureSelectedBox(psStructure);
-		}
-
 		// override
 		if (bHitByElectronic)
 		{
@@ -2579,6 +2572,11 @@ void renderStructure(STRUCTURE *psStructure, const glm::mat4 &viewMatrix)
 		strImd = strImd->next;
 	}
 	setScreenDisp(&psStructure->sDisplay, viewModelMatrix);
+
+	if (psStructure->selected)
+	{
+	  drawStructureSelectedBox(psStructure, viewModelMatrix);
+	}
 }
 
 /// draw the delivery points
@@ -2846,77 +2844,35 @@ static void drawStructureTargetOriginIcon(STRUCTURE *psStruct, int weapon_slot)
 	}
 }
 
-static void drawStructureSelectedBox(STRUCTURE *psStruct)
+static void drawStructureSelectedBox(STRUCTURE *psStruct, const glm::mat4 &modelViewMatrix)
 {
-	int bracketLength = 15;
-	int bracketThickness = 2;
+	Vector2i a(0,0);
+	Vector2i b(0,0);
+	Vector2i c(0,0);
+	Vector2i d(0,0);
+
+	int scaleFactor = 70;
+	int boxHeight = 0;
+
+	int width = psStruct->pStructureType->baseWidth * scaleFactor;
+	int height = psStruct->pStructureType->baseBreadth * scaleFactor;
+
+	Vector3i a_s(-width,boxHeight, -height);
+	Vector3i b_s(width, boxHeight, -height);
+	Vector3i c_s(width, boxHeight,  height);
+	Vector3i d_s(-width,boxHeight,  height);
+
+	pie_RotateProject(&a_s, modelViewMatrix, &a);
+	pie_RotateProject(&b_s, modelViewMatrix, &b);
+	pie_RotateProject(&c_s, modelViewMatrix, &c);
+	pie_RotateProject(&d_s, modelViewMatrix, &d);
+
+	debug(LOG_WZ, "drawStructureSelectedBox: min(%d, %d)  max(%d, %d)", a.x, a.y, b.x, b.y);
 	std::vector<PIERECT_DrawRequest> rectsToDraw;
-
-	rectsToDraw.push_back(PIERECT_DrawRequest(
-		psStruct->sDisplay.screenX - psStruct->sDisplay.screenR,
-		psStruct->sDisplay.screenY + psStruct->sDisplay.screenR - bracketLength,
-		psStruct->sDisplay.screenX - psStruct->sDisplay.screenR + bracketThickness,
-		psStruct->sDisplay.screenY + psStruct->sDisplay.screenR,
-		WZCOL_WHITE)
-	);
-
-	rectsToDraw.push_back(PIERECT_DrawRequest(
-		psStruct->sDisplay.screenX - psStruct->sDisplay.screenR,
-		psStruct->sDisplay.screenY + psStruct->sDisplay.screenR,
-		psStruct->sDisplay.screenX - psStruct->sDisplay.screenR + bracketLength,
-		psStruct->sDisplay.screenY + psStruct->sDisplay.screenR + bracketThickness,
-		WZCOL_WHITE)
-	);
-
-	rectsToDraw.push_back(PIERECT_DrawRequest(
-		psStruct->sDisplay.screenX + psStruct->sDisplay.screenR - bracketLength,
-		psStruct->sDisplay.screenY + psStruct->sDisplay.screenR,
-		psStruct->sDisplay.screenX + psStruct->sDisplay.screenR,
-		psStruct->sDisplay.screenY + psStruct->sDisplay.screenR + bracketThickness,
-		WZCOL_WHITE)
-	);
-
-	rectsToDraw.push_back(PIERECT_DrawRequest(
-		psStruct->sDisplay.screenX + psStruct->sDisplay.screenR,
-		psStruct->sDisplay.screenY + psStruct->sDisplay.screenR - bracketLength,
-		psStruct->sDisplay.screenX + psStruct->sDisplay.screenR + bracketThickness,
-		 psStruct->sDisplay.screenY + psStruct->sDisplay.screenR + bracketThickness,
-		 WZCOL_WHITE)
-	);
-
-	//BACK
-	rectsToDraw.push_back(PIERECT_DrawRequest(
-		psStruct->sDisplay.screenX - psStruct->sDisplay.screenR,
-		psStruct->sDisplay.screenY - psStruct->sDisplay.screenR + bracketLength,
-		psStruct->sDisplay.screenX - psStruct->sDisplay.screenR + bracketThickness,
-		psStruct->sDisplay.screenY - psStruct->sDisplay.screenR,
-		WZCOL_WHITE)
-	);
-
-	rectsToDraw.push_back(PIERECT_DrawRequest(
-		psStruct->sDisplay.screenX - psStruct->sDisplay.screenR,
-		psStruct->sDisplay.screenY - psStruct->sDisplay.screenR,
-		psStruct->sDisplay.screenX - psStruct->sDisplay.screenR + bracketLength,
-		psStruct->sDisplay.screenY - psStruct->sDisplay.screenR - bracketThickness,
-		WZCOL_WHITE)
-	);
-
-	rectsToDraw.push_back(PIERECT_DrawRequest(
-		psStruct->sDisplay.screenX + psStruct->sDisplay.screenR - bracketLength,
-		psStruct->sDisplay.screenY - psStruct->sDisplay.screenR,
-		psStruct->sDisplay.screenX + psStruct->sDisplay.screenR,
-		psStruct->sDisplay.screenY - psStruct->sDisplay.screenR + bracketThickness,
-		WZCOL_WHITE)
-	);
-
-	rectsToDraw.push_back(PIERECT_DrawRequest(
-		psStruct->sDisplay.screenX + psStruct->sDisplay.screenR,
-		psStruct->sDisplay.screenY - psStruct->sDisplay.screenR + bracketLength,
-		psStruct->sDisplay.screenX + psStruct->sDisplay.screenR + bracketThickness,
-		 psStruct->sDisplay.screenY - psStruct->sDisplay.screenR - bracketThickness,
-		 WZCOL_WHITE)
-	);
-	pie_DrawMultiRect(rectsToDraw);
+	iV_Line(a.x, a.y, (a.x + b.x)/3, (a.y + b.y)/3, WZCOL_WHITE);
+	iV_Line(b.x, b.y, c.x, c.y, WZCOL_WHITE);
+	iV_Line(c.x, c.y, d.x, d.y, WZCOL_WHITE);
+	iV_Line(d.x, d.y, a.x, a.y, WZCOL_WHITE);
 }
 
 /// draw the health bar for the specified structure
@@ -3530,37 +3486,6 @@ void calcScreenCoords(DROID *psDroid, const glm::mat4 &viewMatrix)
 	psDroid->sDisplay.screenX = center.x;
 	psDroid->sDisplay.screenY = center.y;
 	psDroid->sDisplay.screenR = static_cast<UDWORD>(radius);
-}
-
-static void calcStructureScreenCoords(STRUCTURE *psStructure, const glm::mat4 &viewMatrix)
-{
-	/* Get it's absolute dimensions */
-	Vector3i origin;
-	Vector2i center(0, 0);
-	int wsRadius = 1;
-	float radius;
-
-	wsRadius = MAX(psStructure->pStructureType->baseWidth, psStructure->pStructureType->baseBreadth) * 64;
-
-	origin = Vector3i(0, 0, 0); // take the center of the object
-
-	/* get the screen coordinates */
-	const float cZ = pie_RotateProject(&origin, viewMatrix, &center) * 0.1f;
-
-	// avoid division by zero
-	if (cZ > 0)
-	{
-		radius = wsRadius / cZ * pie_GetResScalingFactor();
-	}
-	else
-	{
-		radius = 1; // 1 just in case some other code assumes radius != 0
-	}
-
-	/* Store away the screen coordinates so we can select the droids without doing a transform */
-	psStructure->sDisplay.screenX = center.x;
-	psStructure->sDisplay.screenY = center.y;
-	psStructure->sDisplay.screenR = static_cast<UDWORD>(radius);
 }
 
 void screenCoordToWorld(Vector2i screenCoord, Vector2i &worldCoord, SDWORD &tileX, SDWORD &tileY)


### PR DESCRIPTION
This is just a bit of proof of concept code. I'm experimenting with aligned selection boxes for buildings. 
Will make them into the bracket form like droids have but aligned to the building base instead of always facing the camera.
![Screenshot from 2021-11-17 08 05 23](https://user-images.githubusercontent.com/1387/142074117-78d92f06-29d1-40a1-ba98-dcee2f3555a6.png)
![Screenshot from 2021-11-17 08 05 36](https://user-images.githubusercontent.com/1387/142074146-a9cf5f3e-2110-4dd1-ad0f-bda28bf21441.png)
![Screenshot from 2021-11-17 08 05 44](https://user-images.githubusercontent.com/1387/142074174-e2761503-046e-47ef-8ce7-bc9407754829.png)

