### PR TITLE
Remove Command Relay structure requirement for Command Turret research

### DIFF
--- a/data/base/stats/research.json
+++ b/data/base/stats/research.json
@@ -126,9 +126,6 @@
 		"requiredResearch": [
 			"R-Struc-CommandRelay"
 		],
-		"requiredStructures": [
-			"A0ComDroidControl"
-		],
 		"researchPoints": 1200,
 		"researchPower": 37,
 		"resultComponents": [

--- a/data/mp/stats/research.json
+++ b/data/mp/stats/research.json
@@ -7,9 +7,6 @@
 		"requiredResearch": [
 			"R-Struc-CommandRelay"
 		],
-		"requiredStructures": [
-			"A0ComDroidControl"
-		],
 		"researchPoints": 1200,
 		"researchPower": 37,
 		"resultComponents": [
@@ -26,9 +23,6 @@
 		"requiredResearch": [
 			"R-Comp-CommandTurret01",
 			"R-Struc-Research-Upgrade07"
-		],
-		"requiredStructures": [
-			"A0ComDroidControl"
 		],
 		"researchPoints": 5000,
 		"researchPower": 450,


### PR DESCRIPTION
Since we now have console messages reminding the player they need it to manufacture Command Turrets.

Closes #2401.