### PR TITLE
Fix Ultimate Scavengers building an absurd amount of factories

### DIFF
--- a/data/mp/multiplay/script/scavengers/ultimateScavengers.js
+++ b/data/mp/multiplay/script/scavengers/ultimateScavengers.js
@@ -166,8 +166,8 @@ function mapLimits(x, y, num1, num2, xOffset, yOffset)
 //Return a closeby enemy object. Will be undefined if none.
 function rangeStep(obj, visibility)
 {
-    const MAX_TILE_LIMIT = 260;
-    const STEP = 5;
+    const MAX_TILE_LIMIT = 250;
+    const STEP = 25;
     var target;
 
     for (var i = 0; i <= MAX_TILE_LIMIT; i += STEP)
@@ -343,7 +343,7 @@ function buildTower(droid)
 
 function buildThingsWithDroid(droid)
 {
-    const MAX_FACTORY_COUNT = 200;
+    const MAX_FACTORY_COUNT = 100;
 
     switch (random(7))
     {
@@ -800,8 +800,10 @@ function cleanupBaseInfo()
     for (var i = 0, len = units.length; i < len; ++i)
     {
         var droid = units[i];
-        eventDroidBuilt(droid, null);
+        groupAddDroid(needToPickGroup, droid);
     }
+
+    reviseGroups();
 }
 
 function eventStartLevel()
@@ -827,5 +829,5 @@ function eventStartLevel()
     setTimer("buildThings", 900);
     setTimer("groundAttackStuff", 1200);
     setTimer("helicopterAttack", 2900);
-    setTimer("cleanupBaseInfo", 30000);
+    setTimer("cleanupBaseInfo", 8000);
 }


### PR DESCRIPTION
Missing parentheses caused a power check to be true on large maps most of the time resulting in games that
could freeze waiting for the script to finish looping through every growing base information.

Set factory limit to 100 (same tick counts of factory limit can cause it to spill over the limit a bit).

Cleanup baseInfo array every 8 seconds and push units managed by a factory to another one.

Fix coordinates in baseInfo array for newly built factories.

Fixes #2413.