### PR TITLE
Fix partial UI soft-lock with certain in-game menus

### DIFF
--- a/src/ingameop.cpp
+++ b/src/ingameop.cpp
@@ -437,6 +437,17 @@ static void ProcessOptionFinished()
 
 void intCloseInGameOptionsNoAnim()
 {
+	if (isKeyMapEditorUp)
+	{
+		runInGameKeyMapEditor(gInputManager, gKeyFuncConfig, KM_RETURN);
+	}
+	isKeyMapEditorUp = false;
+	if (isMusicManagerUp)
+	{
+		runInGameMusicManager(MM_RETURN, gInputManager);
+	}
+	isMusicManagerUp = false;
+
 	if (NetPlay.isHost)
 	{
 		widgDelete(psWScreen, INTINGAMEPOPUP);
@@ -541,6 +552,7 @@ void intReopenMenuWithoutUnPausing()
 		widgDelete(psWScreen, INTINGAMEPOPUP);
 	}
 	widgDelete(psWScreen, INTINGAMEOP);
+	widgDelete(psWScreen, MM_FORM); // hack: There's a soft-lock somewhere with the music manager UI. Ensure it gets closed here since we're setting isMusicManagerUp = false above
 	intAddInGameOptions();
 }
 
@@ -553,6 +565,7 @@ static bool startIGOptionsMenu()
 	isMouseOptionsUp = false;
 	isKeyMapEditorUp = false;
 	isMusicManagerUp = false;
+	widgDelete(psWScreen, MM_FORM); // hack: There's a soft-lock somewhere with the music manager UI. Ensure it gets closed here since we're setting isMusicManagerUp = false above
 	isInGameConfirmQuitUp = false;
 
 	// add form


### PR DESCRIPTION
Probably reproducible in several ways, but here's one:

1. Start a multiplayer game
2. Enable debug mode
3. Open the Script Debugger (but collapse / minimize it for now)
4. Press "ESC" to open the in-game menus
5. Open either the Keymap Viewer or the Music Manager
6. Restore the Script Debugger and click the "Add Structures" button
7. See the UI lockup

This whole section of the UI could use a rewrite / modern use of "overlay screens" and such. But a quick fix is to actually clean up those special in-game menus in `intCloseInGameOptionsNoAnim()`