### PR TITLE
(MP)Cannon Fortress Change

### DIFF
--- a/data/mp/stats/structure.json
+++ b/data/mp/stats/structure.json
@@ -2770,7 +2770,7 @@
 		"armour": 15,
 		"breadth": 2,
 		"buildPoints": 1600,
-		"buildPower": 900,
+		"buildPower": 1200,
 		"combinesWithWall": true,
 		"height": 2,
 		"hitpoints": 3200,

--- a/data/mp/stats/weapons.json
+++ b/data/mp/stats/weapons.json
@@ -1113,7 +1113,7 @@
 	"CannonSuper": {
 		"buildPoints": 2000,
 		"buildPower": 800,
-		"damage": 380,
+		"damage": 320,
 		"effectSize": 100,
 		"explosionWav": "lrgexpl.ogg",
 		"faceInFlight": 1,
@@ -1139,7 +1139,7 @@
 		"name": "Cannon Fortress",
 		"numExplosions": 1,
 		"radius": 256,
-		"radiusDamage": 260,
+		"radiusDamage": 160,
 		"recoilValue": 150,
 		"shortHit": 80,
 		"shortRange": 128,


### PR DESCRIPTION
Some multiplayer players came to the conclusion that Cannon Fortress is too strong, even superior to Heavy Rocket Bastion because the former is very effective against any type of unit except VTOL and at a low cost compared to other defensive bastions and available before the appearance of T3 weapons. I agree and propose the following changes to the Cannon Fortress options:

"damage": 380 -> 320
"radiusDamage": 260 -> 160
"buildPower": 900 -> 1200