### PR TITLE
Cleanup loadSave screen in systemShutdown()

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1043,6 +1043,11 @@ bool systemInitialise(float horizScaleFactor, float vertScaleFactor)
 //
 void systemShutdown()
 {
+	if (bLoadSaveUp)
+	{
+		closeLoadSaveOnShutdown(); // TODO: Ideally this would not be required here (refactor loadsave.cpp / frontend.cpp?)
+	}
+
 	seqReleaseAll();
 
 	pie_ShutdownRadar();


### PR DESCRIPTION
If the player was in-game with the load/save screen open, and then fully quit the game directly (for example, by pressing the "X" in the window decorations), this cleanup function would not previously get called.