### PR TITLE
Ensure invalid UTF-8 does not cause a crash in json.dump()

### DIFF
--- a/lib/netplay/netreplay.cpp
+++ b/lib/netplay/netreplay.cpp
@@ -144,7 +144,7 @@ bool NETreplaySaveStart(std::string const& subdir, ReplayOptionsHandler const &o
 	optionsHandler.saveOptions(gameOptions);
 	settings["gameOptions"] = gameOptions;
 
-	auto data = settings.dump();
+	auto data = settings.dump(-1, ' ', false, nlohmann::json::error_handler_t::replace);
 	PHYSFS_writeUBE32(replaySaveHandle, data.size());
 	WZ_PHYSFS_writeBytes(replaySaveHandle, data.data(), data.size());
 

--- a/src/multiint.cpp
+++ b/src/multiint.cpp
@@ -7920,9 +7920,9 @@ inline void to_json(nlohmann::json& j, const MULTIPLAYERGAME& p) {
 	j = nlohmann::json::object();
 	j["type"] = p.type;
 	j["scavengers"] = p.scavengers;
-	j["map"] = p.map;
+	j["map"] = WzString::fromUtf8(p.map).toStdString(); // Wrap this in WzString to handle invalid UTF-8 before adding to json object
 	j["maxPlayers"] = p.maxPlayers;
-	j["name"] = p.name;
+	j["name"] = WzString::fromUtf8(p.name).toStdString(); // Wrap this in WzString to handle invalid UTF-8 before adding to json object
 	j["hash"] = p.hash;
 	j["modHashes"] = p.modHashes;
 	j["power"] = p.power;
@@ -8018,7 +8018,7 @@ inline void from_json(const nlohmann::json& j, MULTIPLAYERINGAME& p) {
 inline void to_json(nlohmann::json& j, const PLAYER& p) {
 
 	j = nlohmann::json::object();
-	j["name"] = p.name;
+	j["name"] = WzString::fromUtf8(p.name).toStdString(); // Wrap this in WzString to handle invalid UTF-8 before adding to json object
 	j["position"] = p.position;
 	j["colour"] = p.colour;
 	j["allocated"] = p.allocated;


### PR DESCRIPTION
Invalid UTF-8 in specific strings (that were later added to a json object) could cause a crash when trying to dump the json object.