### PR TITLE
Fix: Drop pending structures on first click

### DIFF
--- a/src/order.cpp
+++ b/src/order.cpp
@@ -1448,7 +1448,11 @@ void orderDroidBase(DROID *psDroid, DROID_ORDER_DATA *psOrder)
 		// help to build a structure that is starting to be built
 		ASSERT_OR_RETURN(, isConstructionDroid(psDroid), "Not a constructor droid");
 		ASSERT_OR_RETURN(, psOrder->psObj != nullptr, "Help to build a NULL pointer?");
-		if (psDroid->action == DACTION_BUILD && psOrder->psObj == psDroid->psActionTarget[0])
+		if (psDroid->action == DACTION_BUILD && psOrder->psObj == psDroid->psActionTarget[0] 
+			// skip DORDER_LINEBUILD -> we still want to drop pending structure blueprints
+			// this isn't a perfect solution, because ordering a LINEBUILD with negative energy, and then clicking
+			// on first structure being built, will remove it, as we change order from DORDR_LINEBUILD to DORDER_BUILD
+			&& (psDroid->order.type != DORDER_LINEBUILD))
 		{
 			// we are already building it, nothing to do
 			objTrace(psDroid->id, "Ignoring DORDER_HELPBUILD because already buildig object %i", psOrder->psObj->id);


### PR DESCRIPTION
Fixes https://github.com/Warzone2100/warzone2100/issues/2448
Note, this behaviour and https://github.com/Warzone2100/warzone2100/issues/2148 (fixed in https://github.com/Warzone2100/warzone2100/pull/2395) are incompatible, and i don't see how to manage both of them.
So I can only favor one or the other in different situations. (_In my opinion_, the root issue is DORDER_LINEBUILD being different from DORDER_BUILD: former should have been implemented in terms of the latter, but no way I am touching that)