### PR TITLE
fixed sticking of autohost rooms

### DIFF
--- a/data/mp/multiplay/script/rules/endconditions.js
+++ b/data/mp/multiplay/script/rules/endconditions.js
@@ -248,7 +248,7 @@ function checkEndConditions()
 	{
 		return team.isContender();
 	});
-	if (contenderTeams.length === 1) // game end
+	if (contenderTeams.length <= 1) // game end
 	{
 		contenderTeams.forEach((team) =>
 		{


### PR DESCRIPTION
Both players can exit at the same time (at the same check interval).
This leads to the fact that all teams are "losers". The end of the battle did not occur.