### PR TITLE
Fix prebuilt ally gates not being passable

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -91,6 +91,7 @@
 #include <ctime>
 #include "multimenu.h"
 #include "console.h"
+#include "multigifts.h"
 #include "wzscriptdebug.h"
 #include "build_tools/autorevision.h"
 
@@ -2698,6 +2699,37 @@ bool loadGame(const char *pGameToLoad, bool keepObjects, bool freeMem, bool User
 		{
 			debug(LOG_ERROR, "Failed with: %s", aFileName);
 			goto error;
+		}
+	}
+
+	/* decide if we have to create teams, ONLY in multiplayer mode!*/
+	if (bMultiPlayer && alliancesSharedVision(game.alliance))
+	{
+		createTeamAlliances();
+
+		/* Update ally vision for pre-placed structures and droids */
+		for (unsigned int pl = 0; pl < MAX_PLAYERS; pl++)
+		{
+			if (pl != selectedPlayer)
+			{
+				/* Structures */
+				for (STRUCTURE *psStr = apsStructLists[pl]; psStr; psStr = psStr->psNext)
+				{
+					if (selectedPlayer < MAX_PLAYERS && aiCheckAlliances(psStr->player, selectedPlayer))
+					{
+						visTilesUpdate((BASE_OBJECT *)psStr);
+					}
+				}
+
+				/* Droids */
+				for (DROID *psDroid = apsDroidLists[pl]; psDroid; psDroid = psDroid->psNext)
+				{
+					if (selectedPlayer < MAX_PLAYERS && aiCheckAlliances(psDroid->player, selectedPlayer))
+					{
+						visTilesUpdate((BASE_OBJECT *)psDroid);
+					}
+				}
+			}
 		}
 	}
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1523,9 +1523,6 @@ bool stageTwoShutDown()
 
 bool stageThreeInitialise()
 {
-	STRUCTURE *psStr;
-	UDWORD i;
-	DROID *psDroid;
 	bool fromSave = (getSaveGameType() == GTYPE_SAVE_START || getSaveGameType() == GTYPE_SAVE_MIDMISSION);
 
 	debug(LOG_WZ, "== stageThreeInitialise ==");
@@ -1595,37 +1592,6 @@ bool stageThreeInitialise()
 	resizeRadar();
 
 	setAllPauseStates(false);
-
-	/* decide if we have to create teams, ONLY in multiplayer mode!*/
-	if (bMultiPlayer && alliancesSharedVision(game.alliance))
-	{
-		createTeamAlliances();
-
-		/* Update ally vision for pre-placed structures and droids */
-		for (i = 0; i < MAX_PLAYERS; i++)
-		{
-			if (i != selectedPlayer)
-			{
-				/* Structures */
-				for (psStr = apsStructLists[i]; psStr; psStr = psStr->psNext)
-				{
-					if (selectedPlayer < MAX_PLAYERS && aiCheckAlliances(psStr->player, selectedPlayer))
-					{
-						visTilesUpdate((BASE_OBJECT *)psStr);
-					}
-				}
-
-				/* Droids */
-				for (psDroid = apsDroidLists[i]; psDroid; psDroid = psDroid->psNext)
-				{
-					if (selectedPlayer < MAX_PLAYERS && aiCheckAlliances(psDroid->player, selectedPlayer))
-					{
-						visTilesUpdate((BASE_OBJECT *)psDroid);
-					}
-				}
-			}
-		}
-	}
 
 	countUpdate();
 

--- a/src/multigifts.cpp
+++ b/src/multigifts.cpp
@@ -234,7 +234,7 @@ void giftRadar(uint8_t from, uint8_t to, bool send)
 	else
 	{
 		hqReward(from, to);
-		if (to == selectedPlayer)
+		if (to == selectedPlayer && loopMissionState == LMS_NORMAL)
 		{
 			CONPRINTF(_("%s Gives You A Visibility Report"), getPlayerName(from));
 		}

--- a/src/qtscript.cpp
+++ b/src/qtscript.cpp
@@ -1584,7 +1584,10 @@ bool triggerEventAllianceOffer(uint8_t from, uint8_t to)
 //__
 bool triggerEventAllianceAccepted(uint8_t from, uint8_t to)
 {
-	ASSERT(scriptsReady, "Scripts not initialized yet");
+	if (!scriptsReady)
+	{
+		return false; //silently ignore
+	}
 	for (auto *instance : scripts)
 	{
 		instance->handle_eventAllianceAccepted(from, to);
@@ -1598,7 +1601,10 @@ bool triggerEventAllianceAccepted(uint8_t from, uint8_t to)
 //__
 bool triggerEventAllianceBroken(uint8_t from, uint8_t to)
 {
-	ASSERT(scriptsReady, "Scripts not initialized yet");
+	if (!scriptsReady)
+	{
+		return false; //silently ignore
+	}
 	for (auto *instance : scripts)
 	{
 		instance->handle_eventAllianceBroken(from, to);


### PR DESCRIPTION
The initial loading of maps didn't set alliances soon enough. This meant ally players would get the AUX_NONPASSABLE movement flag until the game was either reloaded through a save or that gate was destroyed and another put in its place.

Not seeing anything strange with saveload so far.

Fixes #2471.