### PR TITLE
Make some AIs easier when using Easy difficulty

### DIFF
--- a/data/mp/multiplay/skirmish/cobra_includes/build.js
+++ b/data/mp/multiplay/skirmish/cobra_includes/build.js
@@ -378,6 +378,42 @@ function checkUnfinishedStructures(group)
 	return false;
 }
 
+function holdAllOilTrucks()
+{
+	var oilGrabbers = enumGroup(oilGrabberGroup);
+
+	for (var i = 0, len = oilGrabbers.length; i < len; ++i)
+	{
+		if (oilGrabbers[i].order !== DORDER_RECYCLE &&
+			oilGrabbers[i].order !== DORDER_HOLD)
+		{
+			orderDroid(oilGrabbers[i], DORDER_HOLD);
+		}
+	}
+}
+
+function skipOilGrabIfEasy()
+{
+	if (difficulty === EASY)
+	{
+		var myDerrickCount = enumStruct(me, structures.derrick).filter(function(obj) {
+			return obj.status === BUILT;
+		}).length;
+		var enemies = findLivingEnemies();
+
+		for (var i = 0, len = enemies.length; i < len; ++i)
+		{
+			if (myDerrickCount >= 5 && myDerrickCount >= countStruct(structures.derrick, enemies[i]))
+			{
+				holdAllOilTrucks();
+				return true;
+			}
+		}
+	}
+
+	return false;
+}
+
 function lookForOil()
 {
 	if (currently_dead)
@@ -399,6 +435,10 @@ function lookForOil()
 	}
 
 	if (oils.length === 0 && highOilMap() && maintenance(oilGrabberGroup))
+	{
+		return;
+	}
+	if (skipOilGrabIfEasy())
 	{
 		return;
 	}

--- a/data/mp/multiplay/skirmish/cobra_includes/events.js
+++ b/data/mp/multiplay/skirmish/cobra_includes/events.js
@@ -24,7 +24,7 @@ function eventStartLevel()
 	setTimer("retreatTactics", 500 + delay);
 	setTimer("checkAllForRepair", 600 + delay + (4 * easyTimeDelay));
 	setTimer("research", 800 + delay + (3 * easyTimeDelay));
-	setTimer("lookForOil", 1000 + delay + (2 * easyTimeDelay));
+	setTimer("lookForOil", 1000 + delay);
 	setTimer("artilleryTactics", 1400 + delay);
 	setTimer("vtolTactics", 1600 + delay);
 	setTimer("groundTactics", 2000 + delay);
@@ -46,7 +46,7 @@ function eventStructureBuilt(structure, droid)
 		return (obj.type === FEATURE) && (obj.stattype === OIL_RESOURCE);
 	}).sort(distanceToBase);
 
-	if (nearbyOils.length > 0)
+	if (nearbyOils.length > 0 && !skipOilGrabIfEasy())
 	{
 		orderDroidBuild(droid, DORDER_BUILD, structures.derrick, nearbyOils[0].x, nearbyOils[0].y);
 		return;

--- a/data/mp/multiplay/skirmish/nexus_includes/build.js
+++ b/data/mp/multiplay/skirmish/nexus_includes/build.js
@@ -228,8 +228,49 @@ function grabTrucksAndBuild(stat, location, tileRange, maxBlockingTiles, group)
 	return (numHelpDroids > 0);
 }
 
+function bringBackOilTrucks()
+{
+	var builders = enumGroup(groups.oilBuilders);
+
+	for (var i = 0, len = builders.length; i < len; ++i)
+	{
+		if (builders[i].order !== DORDER_RECYCLE &&
+			builders[i].order !== DORDER_RTB)
+		{
+			orderDroid(builders[i], DORDER_RTB);
+		}
+	}
+}
+
+function skipOilGrabIfEasy()
+{
+	if (difficulty === EASY)
+	{
+		var myDerrickCount = enumStruct(me, BASE_STRUCTURES.derricks).filter(function(obj) {
+			return obj.status === BUILT;
+		}).length;
+		var enemies = getAliveEnemyPlayers();
+
+		for (var i = 0, len = enemies.length; i < len; ++i)
+		{
+			if (myDerrickCount >= 3 && (myDerrickCount + 1) >= countStruct(BASE_STRUCTURES.derricks, enemies[i]) && enemies[i] !== scavengerPlayer)
+			{
+				bringBackOilTrucks();
+				return true;
+			}
+		}
+	}
+
+	return false;
+}
+
 function buildDerrick()
 {
+	if (skipOilGrabIfEasy())
+	{
+		return;
+	}
+
 	var numBusy = 0;
 	var droids = enumGroup(groups.oilBuilders);
 	var drLen = droids.length;

--- a/data/mp/multiplay/skirmish/nexus_includes/events.js
+++ b/data/mp/multiplay/skirmish/nexus_includes/events.js
@@ -287,7 +287,7 @@ function eventStructureBuilt(structure, droid)
 			return (o.type === FEATURE && o.stattype === OIL_RESOURCE);
 		});
 
-		if (oils.length > 0)
+		if (oils.length > 0 && !skipOilGrabIfEasy())
 		{
 			orderDroidBuild(droid, DORDER_BUILD, BASE_STRUCTURES.derricks, oils[0].x, oils[0].y);
 		}

--- a/data/mp/multiplay/skirmish/semperfi_includes/build.js
+++ b/data/mp/multiplay/skirmish/semperfi_includes/build.js
@@ -191,8 +191,50 @@ function scanAndDefendPosition(structure, droid)
 	}
 }
 
+function bringBackOilBuilders()
+{
+	var builders = enumGroup(oilBuilders);
+
+	for (var i = 0, len = builders.length; i < len; ++i)
+	{
+		if (builders[i].order !== DORDER_BUILD &&
+			builders[i].order !== DORDER_RTB &&
+			builders[i].order !== DORDER_RECYCLE)
+		{
+			orderDroid(builders[i], DORDER_RTB);
+		}
+	}
+}
+
+function skipOilGrabIfEasy()
+{
+	if (difficulty === EASY)
+	{
+		var myDerrickCount = enumStruct(me, DERRICK_STAT).filter(function(obj) {
+			return obj.status === BUILT;
+		}).length;
+		var enemies = getAliveEnemyPlayers();
+
+		for (var i = 0, len = enemies.length; i < len; ++i)
+		{
+			if (myDerrickCount >= 5 && myDerrickCount >= countStruct(DERRICK_STAT, enemies[i]) && enemies[i] !== scavengerPlayer)
+			{
+				bringBackOilBuilders();
+				return true;
+			}
+		}
+	}
+
+	return false;
+}
+
 function lookForOil()
 {
+	if (skipOilGrabIfEasy())
+	{
+		return;
+	}
+
 	const UNSAFE_AREA_RANGE = 7;
 	var droids = enumGroup(oilBuilders);
 	var oils = enumFeature(ALL_PLAYERS, OIL_RES_STAT).sort(sortByDistToBase); // grab closer oils first;


### PR DESCRIPTION
Nexus, SemperFi, and Cobra will limit their oil derrick amounts depending on what another player has.

Nexus will try to be 1 oil behind and order trucks to immediately return to base, SemperFi will only tell trucks to grab oil if >= and will return trucks to base, however, trucks may still defend the derrick with defenses temporarily, and Cobra will immediately halt other trucks when it is >= to another player, potentially camping a nearby oil resource.

NullBot seems sufficiently slow already and BoneCrusher I'll leave as the challenging easy bot.