### PR TITLE
Making the winning requirements for Beta end more clear

### DIFF
--- a/data/base/script/campaign/cam2-end.js
+++ b/data/base/script/campaign/cam2-end.js
@@ -187,7 +187,7 @@ function checkIfLaunched()
 //Everything in this level mostly just requeues itself until the mission ends.
 function eventStartLevel()
 {
-	camSetExtraObjectiveMessage(_("Send off at least one transporter with a truck and survive The Collective assault"));
+	camSetExtraObjectiveMessage(_("Send off at least one transporter with a truck and survive The Collective assault until the timer ends"));
 
 	var lz = {x: 86, y: 99, x2: 88, y2: 101};
 	var tCoords = {xStart: 87, yStart: 100, xOut: 0, yOut: 55};


### PR DESCRIPTION
Some discussions on Discord showed that the winning requirements for Beta end are not precise enough for players that are used to not playing the level until the timer ends. Therefore the Extra Objective Message includes now the requirement to survive until the timer ends.