### PR TITLE
Headless spectator performance improvements

### DIFF
--- a/src/advvis.cpp
+++ b/src/advvis.cpp
@@ -46,6 +46,8 @@ void	avUpdateTiles()
 	float maxLevel, increment = graphicsTimeAdjustedIncrement(FADE_IN_TIME);	// call once per frame
 	MAPTILE *psTile;
 
+	PlayerMask playerAllianceBits = (selectedPlayer < MAX_PLAYER_SLOTS) ? alliancebits[selectedPlayer] : 0;
+
 	/* Go through the tiles */
 	for (; i < len; i++)
 	{
@@ -55,7 +57,7 @@ void	avUpdateTiles()
 		if (psTile->level > MIN_ILLUM || psTile->tileExploredBits & playermask)	// seen
 		{
 			// If we are not omniscient, and we are not seeing the tile, and none of our allies see the tile...
-			if (!godMode && !(alliancebits[selectedPlayer] & (satuplinkbits | psTile->sensorBits)))
+			if (!godMode && !(playerAllianceBits & (satuplinkbits | psTile->sensorBits)))
 			{
 				maxLevel /= 2;
 			}

--- a/src/map.h
+++ b/src/map.h
@@ -314,7 +314,10 @@ static inline bool TEST_TILE_VISIBLE_TO_SELECTEDPLAYER(MAPTILE *pTile)
 		// always visible
 		return true;
 	}
-	ASSERT_OR_RETURN(false, selectedPlayer < MAX_PLAYERS, "Players should always have a selectedPlayer / player index < MAX_PLAYERS; non-players are always expected to have godMode enabled; selectedPlayer: %" PRIu32 "", selectedPlayer);
+	if (selectedPlayer >= MAX_PLAYERS)
+	{
+		return false;
+	}
 	return TEST_TILE_VISIBLE(selectedPlayer, pTile);
 }
 

--- a/src/multiplay.cpp
+++ b/src/multiplay.cpp
@@ -2399,8 +2399,11 @@ bool makePlayerSpectator(uint32_t playerIndex, bool removeAllStructs, bool quiet
 		// hide the power bar
 		forceHidePowerBar(true);
 
-		// enable "god mode" for map + object visibility (+ minimap)
-		enableGodMode();
+		if (!headlessGameMode())
+		{
+			// enable "god mode" for map + object visibility (+ minimap)
+			enableGodMode();
+		}
 
 		// add spectator mode message
 		bool lowUISpectatorMode = streamer_spectator_mode() || NETisReplay();


### PR DESCRIPTION
- Do not enable "godMode" for headless spectators

This prevents a bunch of wasteful particle / effect / other graphical-related calculations for headless spectator hosts.