### PR TITLE
Allow sequence file to be loaded from ~/.local/share/warzone2100-4.1

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -757,6 +757,15 @@ static void scanDataDirs()
 	registerSearchPath("/Library/Application Support/Warzone 2100/", 1);
 #endif
 
+	const char *homeEnv = getenv("HOME");
+	const char *homeDir = "/.local/share/warzone2100-4.1";
+	if (homeEnv != nullptr) {
+		char* homeFull{ new char[strlen(homeEnv) + strlen(homeDir) + 1] };
+		homeFull = strcpy(homeFull, homeEnv);
+		homeFull = strcat(homeFull, homeDir);
+		registerSearchPath(homeFull, 1);
+	}
+
 	// Commandline supplied datadir
 	if (strlen(datadir) != 0)
 	{


### PR DESCRIPTION
Hello,
I'd like to be able to load the sequence file from the home directory.  This PR is a quick hack, which works for me. I think the patch to this directory must be present in some variable already.

The reason why this is useful is, that /usr is often under control of a package manager. It's bad practice to manually put files there.

It would be nice if this would not be necessary. Thus this PR.