### PR TITLE
Balance Mini-Rocket Pod against Light Cannon better

### DIFF
--- a/data/mp/stats/weapons.json
+++ b/data/mp/stats/weapons.json
@@ -4063,7 +4063,7 @@
 	},
 	"Rocket-Pod": {
 		"buildPoints": 375,
-		"buildPower": 75,
+		"buildPower": 70,
 		"damage": 22,
 		"designable": 1,
 		"effectSize": 25,


### PR DESCRIPTION
As per discussions stemming from me, Max, iLuvalar, Kracker, and Iris.

It was decided we need to try to act on this situation as Light Cannon simply outclasses Rocket Pod in almost every way stat-wise. With no splash damage unlike Light Cannon (which helps with additional damage against cyborgs too), taking many seconds longer to manufacture, and having 12% of the HP compared to Light Cannon, these two weapons were not balanced in a good way against each other. So much so Light Cannon usually 1v1's MRP with ease.

Changes to MRP are as follows: 7% reduction in original power cost (75 -> 70).

If I read everything right. Edit: nope lol.