### PR TITLE
Don't move after attack 2

### DIFF
--- a/src/action.cpp
+++ b/src/action.cpp
@@ -2341,6 +2341,7 @@ static void actionDroidBase(DROID *psDroid, DROID_ACTION_DATA *psAction)
 		}
 		else if (actionIsInRange ||(order->type != DORDER_HOLD && secondaryGetState(psDroid, DSO_HALTTYPE) == DSS_HALT_HOLD))
 		{
+			moveStopDroid(psDroid);
 			psDroid->action = DACTION_ATTACK;
 		}
 		break;


### PR DESCRIPTION
reset droid movement when target is reached. Otherwise, it keeps moving
goes with https://github.com/Warzone2100/warzone2100/pull/2518