### PR TITLE
Increase cost of Cannon Fortress

### DIFF
--- a/data/mp/stats/structure.json
+++ b/data/mp/stats/structure.json
@@ -3408,7 +3408,7 @@
 		"armour": 15,
 		"breadth": 2,
 		"buildPoints": 1600,
-		"buildPower": 900,
+		"buildPower": 1000,
 		"combinesWithWall": true,
 		"height": 2,
 		"hitpoints": 3200,


### PR DESCRIPTION
Incredibly cheap compared to other fortress defenses.

This is my take on Tipchik's Cannon Fortress PR. These defenses should at a minimum cost in the thousands.