### PR TITLE
Campaign updates

### DIFF
--- a/data/base/script/campaign/cam1-3.js
+++ b/data/base/script/campaign/cam1-3.js
@@ -163,6 +163,7 @@ function camEnemyBaseDetected_ScavBaseGroupSouth()
 		pos: camMakePos("SouthConvoyLoc"),
 		regroup: false, //true when movement gets better. Very big group this one is.
 	});
+	queue("camCallOnce", camSecondsToMilliseconds(1), "enableReinforcements");
 }
 
 function camEnemyBaseEliminated_ScavBaseGroup()

--- a/data/base/script/campaign/cam1-5.js
+++ b/data/base/script/campaign/cam1-5.js
@@ -135,7 +135,7 @@ function sendNPTransport()
 			exit: { x: 2, y: 42 },
 			order: CAM_ORDER_ATTACK,
 			data: {
-				regroup: true,
+				regroup: false,
 				count: -1,
 				pos: camMakePos("NPBase"),
 				repair: 66,

--- a/data/base/script/campaign/cam3-4.js
+++ b/data/base/script/campaign/cam3-4.js
@@ -187,7 +187,7 @@ function eventStartLevel()
 	var tpos = getObject("transportEntryExit");
 	var lz = getObject("landingZone");
 
-	camSetStandardWinLossConditions(CAM_VICTORY_OFFWORLD, "GAMMA_OUT", {
+	camSetStandardWinLossConditions(CAM_VICTORY_OFFWORLD, CAM_GAMMA_OUT, {
 		area: "RTLZ",
 		reinforcements: camMinutesToSeconds(1),
 		annihilate: true

--- a/data/base/script/campaign/cam3-a.js
+++ b/data/base/script/campaign/cam3-a.js
@@ -46,10 +46,10 @@ camAreaEvent("westFactoryTrigger", function(droid)
 	enableAllFactories();
 });
 
-//make the first batch or extra transport droids hero rank.
+//make the first batch of extra transport droids hero rank.
 function setHeroUnits()
 {
-	const DROID_EXP = 512;
+	const DROID_EXP = 1024; //Can make Hero Commanders if recycled.
 	var droids = enumDroid(CAM_HUMAN_PLAYER).filter(function(dr) {
 		return (!camIsSystemDroid(dr) && !camIsTransporter(dr));
 	});
@@ -79,6 +79,9 @@ function enableAllFactories()
 	{
 		camEnableFactory(FACTORY_NAMES[j]);
 	}
+
+	//If they go really fast, adapt the alloy research to come sooner
+	queue("improveNexusAlloys", camChangeOnDiff(camMinutesToMilliseconds(10)));
 }
 
 function truckDefense()
@@ -189,8 +192,8 @@ function cam3Setup()
 		"R-Struc-VTOLPad-Upgrade06", "R-Wpn-Bomb-Damage03", "R-Sys-NEXUSrepair",
 		"R-Vehicle-Prop-Hover02", "R-Vehicle-Prop-VTOL02", "R-Cyborg-Legs02",
 		"R-Wpn-Mortar-Acc03", "R-Wpn-MG-Damage08", "R-Wpn-Mortar-ROF04",
-		"R-Vehicle-Engine07", "R-Vehicle-Metals07", "R-Vehicle-Armor-Heat04",
-		"R-Cyborg-Metals07", "R-Cyborg-Armor-Heat04", "R-Wpn-RocketSlow-ROF04",
+		"R-Vehicle-Engine07", "R-Vehicle-Metals06", "R-Vehicle-Armor-Heat03",
+		"R-Cyborg-Metals06", "R-Cyborg-Armor-Heat03", "R-Wpn-RocketSlow-ROF04",
 		"R-Wpn-AAGun-Damage05", "R-Wpn-AAGun-ROF04", "R-Wpn-Howitzer-Damage09",
 		"R-Wpn-Cannon-Damage07", "R-Wpn-Cannon-ROF04",
 		"R-Wpn-Missile-Damage01", "R-Wpn-Missile-ROF01", "R-Wpn-Missile-Accuracy01",
@@ -207,10 +210,24 @@ function cam3Setup()
 	camCompleteRequiredResearch(GAMMA_ALLY_RES, NEXUS);
 	camCompleteRequiredResearch(NEXUS_RES, NEXUS);
 
+	if (difficulty >= HARD)
+	{
+		improveNexusAlloys();
+	}
+
 	enableResearch("R-Wpn-Howitzer03-Rot", CAM_HUMAN_PLAYER);
 	enableResearch("R-Wpn-MG-Damage08", CAM_HUMAN_PLAYER);
 }
 
+//Easy and Normal difficulty has Nexus start off a little bit weaker
+function improveNexusAlloys()
+{
+	var alloys = [
+		"R-Vehicle-Metals07", "R-Cyborg-Metals07",
+		"R-Vehicle-Armor-Heat04", "R-Cyborg-Armor-Heat04"
+	];
+	camCompleteRequiredResearch(alloys, NEXUS);
+}
 
 function eventStartLevel()
 {
@@ -372,4 +389,5 @@ function eventStartLevel()
 	groupPatrolNoTrigger();
 	queue("vtolAttack", camChangeOnDiff(camMinutesToMilliseconds(8)));
 	queue("enableAllFactories", camChangeOnDiff(camMinutesToMilliseconds(20)));
+	queue("improveNexusAlloys", camChangeOnDiff(camMinutesToMilliseconds(25)));
 }

--- a/data/base/script/campaign/cam3-a.js
+++ b/data/base/script/campaign/cam3-a.js
@@ -2,7 +2,7 @@ include("script/campaign/transitionTech.js");
 include("script/campaign/libcampaign.js");
 include("script/campaign/templates.js");
 
-var index; //Number of bonus transports that have flown in.
+var transporterIndex; //Number of bonus transports that have flown in.
 var startedFromMenu;
 var truckLocCounter;
 
@@ -46,17 +46,18 @@ camAreaEvent("westFactoryTrigger", function(droid)
 	enableAllFactories();
 });
 
-//make the first batch of extra transport droids hero rank.
-function setHeroUnits()
+function setUnitRank(transport)
 {
-	const DROID_EXP = 1024; //Can make Hero Commanders if recycled.
-	var droids = enumDroid(CAM_HUMAN_PLAYER).filter(function(dr) {
-		return (!camIsSystemDroid(dr) && !camIsTransporter(dr));
-	});
+	const DROID_EXP = [1024, 128, 64, 32]; //Can make Hero Commanders if recycled.
+	var droids = enumCargo(transport);
 
-	for (var j = 0, i = droids.length; j < i; ++j)
+	for (var i = 0, len = droids.length; i < len; ++i)
 	{
-		setDroidExperience(droids[j], DROID_EXP);
+		var droid = droids[i];
+		if (!camIsSystemDroid(droid))
+		{
+			setDroidExperience(droid, DROID_EXP[transporterIndex - 1]);
+		}
 	}
 }
 
@@ -64,7 +65,7 @@ function eventTransporterLanded(transport)
 {
 	if (startedFromMenu)
 	{
-		camCallOnce("setHeroUnits");
+		setUnitRank(transport);
 	}
 }
 
@@ -114,12 +115,12 @@ function truckDefense()
 function sendPlayerTransporter()
 {
 	const transportLimit = 4; //Max of four transport loads if starting from menu.
-	if (!camDef(index))
+	if (!camDef(transporterIndex))
 	{
-		index = 0;
+		transporterIndex = 0;
 	}
 
-	if (index === transportLimit)
+	if (transporterIndex === transportLimit)
 	{
 		removeTimer("sendPlayerTransporter");
 		return;
@@ -141,7 +142,7 @@ function sendPlayerTransporter()
 		}
 	);
 
-	index = index + 1;
+	transporterIndex = transporterIndex + 1;
 }
 
 //Setup Nexus VTOL hit and runners.

--- a/data/base/script/campaign/libcampaign.js
+++ b/data/base/script/campaign/libcampaign.js
@@ -90,6 +90,27 @@ const CAM_TICKS_PER_FRAME = 100;
 const AI_POWER = 999999;
 const INCLUDE_PATH = "script/campaign/libcampaign_includes/";
 
+//level load codes here for reference. Might be useful for later code.
+const ALPHA_CAMPAIGN_NUMBER = 1;
+const BETA_CAMPAIGN_NUMBER = 2;
+const GAMMA_CAMPAIGN_NUMBER = 3;
+const CAM_GAMMA_OUT = "GAMMA_OUT"; //Fake next level for the final Gamma mission.
+const UNKNOWN_CAMPAIGN_NUMBER = 1000;
+const ALPHA_LEVELS = [
+    "CAM_1A", "CAM_1B", "SUB_1_1S", "SUB_1_1", "SUB_1_2S", "SUB_1_2", "SUB_1_3S",
+    "SUB_1_3", "CAM_1C", "CAM_1CA", "SUB_1_4AS", "SUB_1_4A", "SUB_1_5S", "SUB_1_5",
+    "CAM_1A-C", "SUB_1_7S", "SUB_1_7", "SUB_1_DS", "SUB_1_D", "CAM_1END"
+];
+const BETA_LEVELS = [
+    "CAM_2A", "SUB_2_1S", "SUB_2_1", "CAM_2B", "SUB_2_2S", "SUB_2_2", "CAM_2C",
+    "SUB_2_5S", "SUB_2_5", "SUB_2DS", "SUB_2D", "SUB_2_6S", "SUB_2_6", "SUB_2_7S",
+    "SUB_2_7", "SUB_2_8S", "SUB_2_8", "CAM_2END"
+];
+const GAMMA_LEVELS = [
+    "CAM_3A", "SUB_3_1S", "SUB_3_1", "CAM_3B", "SUB_3_2S", "SUB_3_2", "CAM3A-B",
+    "CAM3C", "CAM3A-D1", "CAM3A-D2", "CAM_3_4S", "CAM_3_4"
+];
+
 //artifact
 var __camArtifacts;
 var __camNumArtifacts;

--- a/data/base/script/campaign/libcampaign_includes/events.js
+++ b/data/base/script/campaign/libcampaign_includes/events.js
@@ -296,7 +296,7 @@ function cam_eventAttacked(victim, attacker)
 				__camGroupInfo[victim.group].lastHit = gameTime;
 
 				//Increased Nexus intelligence if struck on cam3-4
-				if (__camNextLevel === "GAMMA_OUT")
+				if (__camNextLevel === CAM_GAMMA_OUT)
 				{
 					if (__camGroupInfo[victim.group].order === CAM_ORDER_PATROL)
 					{

--- a/data/base/script/campaign/libcampaign_includes/misc.js
+++ b/data/base/script/campaign/libcampaign_includes/misc.js
@@ -455,6 +455,34 @@ function camGenerateRandomMapCoordinate(reachPosition, distFromReach, scanObject
 	return pos;
 }
 
+// Figures out what campaign we are in without reliance on the source at all.
+function camDiscoverCampaign()
+{
+	for (var i = 0, len = ALPHA_LEVELS.length; i < len; ++i)
+	{
+		if (__camNextLevel === ALPHA_LEVELS[i] || __camNextLevel === BETA_LEVELS[0])
+		{
+			return ALPHA_CAMPAIGN_NUMBER;
+		}
+	}
+	for (var i = 0, len = BETA_LEVELS.length; i < len; ++i)
+	{
+		if (__camNextLevel === BETA_LEVELS[i] || __camNextLevel === GAMMA_LEVELS[0])
+		{
+			return BETA_CAMPAIGN_NUMBER;
+		}
+	}
+	for (var i = 0, len = GAMMA_LEVELS.length; i < len; ++i)
+	{
+		if (__camNextLevel === GAMMA_LEVELS[i] || __camNextLevel === CAM_GAMMA_OUT)
+		{
+			return GAMMA_CAMPAIGN_NUMBER;
+		}
+	}
+
+	return UNKNOWN_CAMPAIGN_NUMBER;
+}
+
 //////////// privates
 
 function __camGlobalContext()

--- a/data/base/script/campaign/libcampaign_includes/nexus.js
+++ b/data/base/script/campaign/libcampaign_includes/nexus.js
@@ -177,7 +177,7 @@ function __camChooseNexusTarget(player)
 		//As the player researches more resistance upgrades their higher exp units will become more safe
 		//Trucks get a little more safe with each upgrade also.
 		objects = objects.filter(function(d) {
-			if (__camNextLevel === "GAMMA_OUT")
+			if (__camNextLevel === CAM_GAMMA_OUT)
 			{
 				return true; //Final mission has a static fail chance to hack everything.
 			}

--- a/data/base/script/campaign/libcampaign_includes/victory.js
+++ b/data/base/script/campaign/libcampaign_includes/victory.js
@@ -488,6 +488,11 @@ function __camShowVictoryConditions(forceMessage)
 		}
 		if (__camWinLossCallback === CAM_VICTORY_PRE_OFFWORLD)
 		{
+			if ((camDiscoverCampaign() === BETA_CAMPAIGN_NUMBER) && (difficulty === HARD || difficulty === INSANE))
+			{
+				console(_("Hard / Insane difficulty hint:"));
+				console(_("Fortify a strong base across the map to protect yourself from the Collective"));
+			}
 			return; // do not need this on these missions.
 		}
 	}

--- a/data/base/script/campaign/libcampaign_includes/victory.js
+++ b/data/base/script/campaign/libcampaign_includes/victory.js
@@ -180,7 +180,7 @@ function __camGameWon()
 	if (camDef(__camNextLevel))
 	{
 		camTrace(__camNextLevel);
-		if (__camNextLevel === "GAMMA_OUT")
+		if (__camNextLevel === CAM_GAMMA_OUT)
 		{
 			gameOverMessage(true, false, true);
 			return;

--- a/data/base/script/campaign/libcampaign_includes/victory.js
+++ b/data/base/script/campaign/libcampaign_includes/victory.js
@@ -258,10 +258,16 @@ function __camPlayerDead()
 		//Make the mission fail if no units are alive on map while having no factories.
 		var droidCount = 0;
 		enumDroid(CAM_HUMAN_PLAYER).forEach(function(obj) {
-			droidCount += 1;
 			if (obj.droidType === DROID_SUPERTRANSPORTER)
 			{
+				//Don't count the transporter itself. This is for the case where
+				//they have no units and no factories and have the transporter
+				//sitting at base unable to launch.
 				droidCount += enumCargo(obj).length;
+			}
+			else
+			{
+				droidCount += 1;
 			}
 		});
 		dead = droidCount <= 0 && !haveFactories;

--- a/data/base/script/campaign/libcampaign_includes/victory.js
+++ b/data/base/script/campaign/libcampaign_includes/victory.js
@@ -265,6 +265,13 @@ function __camPlayerDead()
 			}
 		});
 		dead = droidCount <= 0 && !haveFactories;
+
+		//Finish Beta-end early if they have no units and factories on Easy/Normal.
+		if (dead && (difficulty <= MEDIUM) && (__camNextLevel === "CAM_3A"))
+		{
+			cam_eventMissionTimeout(); //Early victory trigger
+			return false;
+		}
 	}
 
 	return dead;

--- a/data/base/wrf/cam3/cam3a/labels.json
+++ b/data/base/wrf/cam3/cam3a/labels.json
@@ -109,7 +109,7 @@
 		"label": "cybAttackers",
 		"subscriber": 0,
 		"pos1": [6976, 12480],
-		"pos2": [7360, 12864]
+		"pos2": [7424, 12864]
 	},
 	"area_2": {
 		"label": "hoverPatrolGrp",
@@ -159,8 +159,8 @@
 	"area_11": {
 		"label": "westFactoryTrigger",
 		"subscriber": 0,
-		"pos1": [5312, 13632],
-		"pos2": [6080, 14656]
+		"pos1": [5632, 13312],
+		"pos2": [6144, 14592]
 	},
 	"area_12": {
 		"label": "NXlandingZone",


### PR DESCRIPTION
To address a few concerns from the forum.

Alpha 9: Don't group the NP transporter group, maybe preventing a inner base clog if the regrouping algorithm fails. Though alfred007 thinks it's probably the mortar unit piling up and blocking the inner-base for people who take a long time to destroy the inner-base area.

Beta-end: Restore a new version of the early exit feature of Beta-end, for Easy and Normal when they "die": have no factories and no units on map. Closes #1043.

Players who only take one transporter may find Gamma 1 a bit too hard so they will likely try again and bring more units.

Gamma 1: Delay alloy research for a bit if a new player tries to poorly defend the LZ and attack too soon, or sometimes after crossing the factory triggers.