### PR TITLE
Fix #2540: Making a mod with gamedesc.lev crashes the game

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -757,16 +757,6 @@ static void scanDataDirs()
 	registerSearchPath("/Library/Application Support/Warzone 2100/", 1);
 #endif
 
-	// Commandline supplied datadir
-	if (strlen(datadir) != 0)
-	{
-		registerSearchPath(datadir, 1);
-	}
-
-	// User's home dir
-	registerSearchPath(PHYSFS_getWriteDir(), 2);
-	rebuildSearchPath(mod_multiplay, true);
-
 #if !defined(WZ_OS_MAC)
 	// Check PREFIX-based paths
 	std::string tmpstr;
@@ -852,6 +842,16 @@ static void scanDataDirs()
 		}
 	}
 #endif
+
+	// Commandline supplied datadir
+	if (strlen(datadir) != 0)
+	{
+		registerSearchPath(datadir, 1);
+	}
+
+	// User's home dir
+	registerSearchPath(PHYSFS_getWriteDir(), 2);
+	rebuildSearchPath(mod_multiplay, true);
 
 	/** Debugging and sanity checks **/
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -828,7 +828,7 @@ static void scanDataDirs()
 		{
 			WzString resourceDataPath(resourcePath);
 			resourceDataPath += "/data";
-			registerSearchPath(resourceDataPath.toUtf8().c_str(), 8);
+			registerSearchPath(resourceDataPath.toUtf8().c_str(), 3);
 			rebuildSearchPath(mod_multiplay, true);
 		}
 		else


### PR DESCRIPTION
This PR fixes #2540.

This is due to the fact that loading a mod with a `gamedesc.lev` file causes `base.wz` to not get added to the `PHYSFS` search paths. I think this is why:

1. On startup, [`scanDataDirs`](https://github.com/Warzone2100/warzone2100/blob/fcf9c5ccd00deda1b04c71d7a0df75daf4917f89/src/main.cpp#L753) runs.
2. [`scanDataDirs`](https://github.com/Warzone2100/warzone2100/blob/fcf9c5ccd00deda1b04c71d7a0df75daf4917f89/src/main.cpp#L753) calls `registerSearchPath(PHYSFS_getWriteDir(), 2)` and then `rebuildSearchPath(mod_multiplay, true)` on [line 767](https://github.com/Warzone2100/warzone2100/blob/master/src/main.cpp#L767).
3. [The call to `rebuildSearchPath`](https://github.com/Warzone2100/warzone2100/blob/master/src/main.cpp#L768) with `PHYSFS_getWriteDir()` in the search path [ends up adding `mods/autoload` and all of the mods inside it](https://github.com/Warzone2100/warzone2100/blob/fcf9c5ccd00deda1b04c71d7a0df75daf4917f89/src/init.cpp#L565) to the `PHYSFS` search path.
4. Later in [`scanDataDirs`](https://github.com/Warzone2100/warzone2100/blob/fcf9c5ccd00deda1b04c71d7a0df75daf4917f89/src/main.cpp#L753), we want to add the path to `base.wz` to the `PHYSFS` search path. There are many locations where `base.wz` could be, so we try each location until we can find `gamedesc.lev` in the `PHYSFS` search path. However, because we loaded a mod with `gamedesc.lev`, `gamedesc.lev` is in the `PHYSFS` search path right when we start looking to add `base.wz`, so we assume that `base.wz` is already in the `PHYSFS` search path, even though it isn't!
5. On startup, the game looks for the cursor image, but because `base.wz` is not in the `PHYSFS` search path, it cannot find it.
6. Because the game cannot find the cursor image, it crashes.

To fix the issue, I moved step 2 later, so that it only happens after `base.wz` gets loaded.

# PLEASE NOTE
I do not completely understand the purpose of the code I am dealing with here. I would recommend that you do not merge this unless you understand this code and have confidence that changing the search path order will not cause bugs.