### PR TITLE
Move Fog color to palette and move fog start/end to config

### DIFF
--- a/data/base/palette.txt
+++ b/data/base/palette.txt
@@ -96,3 +96,6 @@ b0,b0,ff,ff	// Server knows this player.
 10,10,80,80	// Default filled GUI box colour
 1b,ff,5f,ff // Info messages text color
 10,10,80,bb	// Default notification box colour
+b0,8f,5f,ff	// Arizona fog
+10,10,40,ff	// Urban fog
+b6,e1,ec,ff	// Rockie fog

--- a/lib/ivis_opengl/piepalette.h
+++ b/lib/ivis_opengl/piepalette.h
@@ -121,8 +121,11 @@
 #define WZCOL_TRANSPARENT_BOX						psPalette[95]
 #define WZCOL_CONS_TEXT_INFO						psPalette[96]
 #define WZCOL_NOTIFICATION_BOX						psPalette[97]
+#define WZCOL_FOG_ARIZONA							psPalette[98]
+#define WZCOL_FOG_URBAN								psPalette[99]
+#define WZCOL_FOG_ROCKIE							psPalette[100]
 
-#define WZCOL_MAX									98
+#define WZCOL_MAX									101
 
 //*************************************************************************
 

--- a/src/configuration.cpp
+++ b/src/configuration.cpp
@@ -485,6 +485,8 @@ bool loadConfig()
 	war_setDisableReplayRecording(iniGetBool("disableReplayRecord", war_getDisableReplayRecording()).value());
 	int openSpecSlotsIntValue = iniGetInteger("openSpectatorSlotsMP", war_getMPopenSpectatorSlots()).value();
 	war_setMPopenSpectatorSlots(static_cast<uint16_t>(std::max<int>(0, std::min<int>(openSpecSlotsIntValue, MAX_SPECTATOR_SLOTS))));
+	war_setFogEnd(iniGetInteger("fogEnd", 8000).value());
+	war_setFogStart(iniGetInteger("fogStart", 4000).value());
 	ActivityManager::instance().endLoadingSettings();
 	return true;
 }
@@ -632,6 +634,8 @@ bool saveConfig()
 	iniSetBool("fog", pie_GetFogEnabled());
 	iniSetInteger("hostAutoLagKickSeconds", war_getAutoLagKickSeconds());
 	iniSetBool("disableReplayRecord", war_getDisableReplayRecording());
+	iniSetInteger("fogEnd", war_getFogEnd());
+	iniSetInteger("fogStart", war_getFogStart());
 
 	// write out ini file changes
 	bool result = saveIniFile(file, ini);

--- a/src/display3d.cpp
+++ b/src/display3d.cpp
@@ -1282,29 +1282,14 @@ bool init3DView()
 
 	if (strcmp(tilesetDir, "texpages/tertilesc2hw") == 0) // Urban = 0x101040 (or, 0xc9920f)
 	{
-		PIELIGHT WZCOL_FOG_URBAN;
-		WZCOL_FOG_URBAN.vector[0] = 0x10;
-		WZCOL_FOG_URBAN.vector[1] = 0x10;
-		WZCOL_FOG_URBAN.vector[2] = 0x40;
-		WZCOL_FOG_URBAN.vector[3] = 0xff;
 		pie_SetFogColour(WZCOL_FOG_URBAN);
 	}
 	else if (strcmp(tilesetDir, "texpages/tertilesc3hw") == 0) // Rockies = 0xb6e1ec
 	{
-		PIELIGHT WZCOL_FOG_ROCKIE;
-		WZCOL_FOG_ROCKIE.vector[0] = 0xb6;
-		WZCOL_FOG_ROCKIE.vector[1] = 0xe1;
-		WZCOL_FOG_ROCKIE.vector[2] = 0xec;
-		WZCOL_FOG_ROCKIE.vector[3] = 0xff;
 		pie_SetFogColour(WZCOL_FOG_ROCKIE);
 	}
 	else // Arizona, eg. strcmp(tilesetDir, "texpages/tertilesc1hw") == 0, and default. = b08f5f (or, 0x78684f)
 	{
-		PIELIGHT WZCOL_FOG_ARIZONA;
-		WZCOL_FOG_ARIZONA.vector[0] = 0xb0;
-		WZCOL_FOG_ARIZONA.vector[1] = 0x8f;
-		WZCOL_FOG_ARIZONA.vector[2] = 0x5f;
-		WZCOL_FOG_ARIZONA.vector[3] = 0xff;
 		pie_SetFogColour(WZCOL_FOG_ARIZONA);
 	}
 

--- a/src/display3d.cpp
+++ b/src/display3d.cpp
@@ -1280,18 +1280,7 @@ bool init3DView()
 	// Set the initial fog distance
 	updateFogDistance(distance);
 
-	if (strcmp(tilesetDir, "texpages/tertilesc2hw") == 0) // Urban = 0x101040 (or, 0xc9920f)
-	{
-		pie_SetFogColour(WZCOL_FOG_URBAN);
-	}
-	else if (strcmp(tilesetDir, "texpages/tertilesc3hw") == 0) // Rockies = 0xb6e1ec
-	{
-		pie_SetFogColour(WZCOL_FOG_ROCKIE);
-	}
-	else // Arizona, eg. strcmp(tilesetDir, "texpages/tertilesc1hw") == 0, and default. = b08f5f (or, 0x78684f)
-	{
-		pie_SetFogColour(WZCOL_FOG_ARIZONA);
-	}
+	setDefaultFogColour();
 
 	playerPos.r.z = 0; // roll
 	playerPos.r.y = 0; // rotation

--- a/src/lighting.cpp
+++ b/src/lighting.cpp
@@ -42,8 +42,6 @@
 #include "warzoneconfig.h"
 
 // These magic values determine the fog
-#define FOG_BEGIN 4000
-#define FOG_END 8000
 #define FOG_ALTITUDE_COEFFICIENT 1.3f
 
 /*	The vector that holds the sun's lighting direction - planar */
@@ -306,7 +304,7 @@ static UDWORD calcDistToTile(UDWORD tileX, UDWORD tileY, Vector3i *pos)
 /// "popping" tiles
 void updateFogDistance(float distance)
 {
-	pie_UpdateFogDistance(FOG_BEGIN + (distance - war_GetMapZoom()) * FOG_ALTITUDE_COEFFICIENT, FOG_END + (distance - war_GetMapZoom()) * FOG_ALTITUDE_COEFFICIENT);
+	pie_UpdateFogDistance(war_getFogStart() + (distance - war_GetMapZoom()) * FOG_ALTITUDE_COEFFICIENT, war_getFogEnd() + (distance - war_GetMapZoom()) * FOG_ALTITUDE_COEFFICIENT);
 }
 
 void setDefaultFogColour()

--- a/src/lighting.cpp
+++ b/src/lighting.cpp
@@ -309,6 +309,27 @@ void updateFogDistance(float distance)
 	pie_UpdateFogDistance(FOG_BEGIN + (distance - war_GetMapZoom()) * FOG_ALTITUDE_COEFFICIENT, FOG_END + (distance - war_GetMapZoom()) * FOG_ALTITUDE_COEFFICIENT);
 }
 
+void setDefaultFogColour()
+{
+	if (strcmp(tilesetDir, "texpages/tertilesc2hw") == 0) // Urban = 0x101040 (or, 0xc9920f)
+	{
+		pie_SetFogColour(WZCOL_FOG_URBAN);
+	}
+	else if (strcmp(tilesetDir, "texpages/tertilesc3hw") == 0) // Rockies = 0xb6e1ec
+	{
+		pie_SetFogColour(WZCOL_FOG_ROCKIE);
+	}
+	else // Arizona, eg. strcmp(tilesetDir, "texpages/tertilesc1hw") == 0, and default. = b08f5f (or, 0x78684f)
+	{
+		pie_SetFogColour(WZCOL_FOG_ARIZONA);
+	}
+}
+
+void reInitPaletteAndFog()
+{
+	pal_Init();
+	setDefaultFogColour();
+}
 
 #define MIN_DROID_LIGHT_LEVEL	96
 #define	DROID_SEEK_LIGHT_SPEED	2

--- a/src/lighting.h
+++ b/src/lighting.h
@@ -37,6 +37,8 @@ void processLight(LIGHT *psLight);
 void initLighting(UDWORD x1, UDWORD y1, UDWORD x2, UDWORD y2);
 void doBuildingLights();
 void updateFogDistance(float distance);
+void setDefaultFogColour();
+void reInitPaletteAndFog();
 void calcDroidIllumination(DROID *psDroid);
 
 #endif // __INCLUDED_SRC_LIGHTNING_H__

--- a/src/multiint.cpp
+++ b/src/multiint.cpp
@@ -93,6 +93,7 @@
 #include "notifications.h"
 #include "radar.h"
 #include "lib/framework/wztime.h"
+#include "lighting.h" // for reInitPaletteAndFog()
 
 #include "multiplay.h"
 #include "multiint.h"
@@ -8337,7 +8338,7 @@ bool WZGameReplayOptionsHandler::restoreOptions(const nlohmann::json& object, Em
 	levShutDown();
 	levInitialise();
 	rebuildSearchPath(mod_multiplay, true);	// MUST rebuild search path for the new maps we just got!
-	pal_Init(); //Update palettes.
+	reInitPaletteAndFog(); //Update palettes.
 	if (!buildMapList())
 	{
 		debug(LOG_ERROR, "Failed to build map list");

--- a/src/multiopt.cpp
+++ b/src/multiopt.cpp
@@ -30,7 +30,6 @@
 #include "lib/framework/wzapp.h"
 #include "lib/framework/physfs_ext.h"
 
-#include "lib/ivis_opengl/piepalette.h" // for pal_Init()
 #include "lib/ivis_opengl/piestate.h"
 
 #include "map.h"
@@ -46,6 +45,7 @@
 #include "configuration.h"			// lobby cfg.
 #include "clparse.h"
 
+#include "lighting.h" // for reInitPaletteAndFog()
 #include "component.h"
 #include "console.h"
 #include "multiplay.h"
@@ -260,7 +260,7 @@ bool recvOptions(NETQUEUE queue)
 		}
 		else
 		{
-			pal_Init(); // Palette could be modded. // Why is this here - isn't there a better place for it?
+			reInitPaletteAndFog(); // Palette could be modded. // Why is this here - isn't there a better place for it?
 			return FileRequestResult::FileExists;  // Have the file already.
 		}
 

--- a/src/multiplay.cpp
+++ b/src/multiplay.cpp
@@ -29,7 +29,6 @@
 #include <chrono>
 
 #include "lib/framework/frame.h"
-#include "lib/ivis_opengl/piepalette.h" // for pal_Init()
 #include "lib/framework/input.h"
 #include "lib/framework/strres.h"
 #include "lib/framework/physfs_ext.h"
@@ -63,6 +62,7 @@
 #include "qtscript.h"
 #include "design.h"
 #include "advvis.h"
+#include "lighting.h" // for reInitPaletteAndFog()
 
 #include "template.h"
 #include "lib/netplay/netplay.h"								// the netplay library.
@@ -2017,7 +2017,7 @@ bool recvMapFileData(NETQUEUE queue)
 		levShutDown();
 		levInitialise();
 		rebuildSearchPath(mod_multiplay, true);	// MUST rebuild search path for the new maps we just got!
-		pal_Init(); //Update palettes.
+		reInitPaletteAndFog(); //Update palettes.
 		if (!buildMapList())
 		{
 			return false;

--- a/src/quickjs_backend.cpp
+++ b/src/quickjs_backend.cpp
@@ -3150,6 +3150,7 @@ IMPL_JS_FUNC_DEBUGMSGUPDATE(hackAddMessage, wzapi::hackAddMessage)
 IMPL_JS_FUNC_DEBUGMSGUPDATE(hackRemoveMessage, wzapi::hackRemoveMessage)
 IMPL_JS_FUNC(setSunPosition, wzapi::setSunPosition)
 IMPL_JS_FUNC(setSunIntensity, wzapi::setSunIntensity)
+IMPL_JS_FUNC(setFogColour, wzapi::setFogColour)
 IMPL_JS_FUNC(setWeather, wzapi::setWeather)
 IMPL_JS_FUNC(setSky, wzapi::setSky)
 IMPL_JS_FUNC(hackDoNotSave, wzapi::hackDoNotSave)
@@ -3322,6 +3323,7 @@ bool quickjs_scripting_instance::registerFunctions(const std::string& scriptName
 	JS_REGISTER_FUNC(setAssemblyPoint, 3); // WZAPI
 	JS_REGISTER_FUNC(setSunPosition, 3); // WZAPI
 	JS_REGISTER_FUNC(setSunIntensity, 9); // WZAPI
+	JS_REGISTER_FUNC(setFogColour, 3); // WZAPI
 	JS_REGISTER_FUNC(setWeather, 1); // WZAPI
 	JS_REGISTER_FUNC(setSky, 3); // WZAPI
 	JS_REGISTER_FUNC(cameraSlide, 2); // WZAPI

--- a/src/warzoneconfig.cpp
+++ b/src/warzoneconfig.cpp
@@ -68,6 +68,8 @@ struct WARZONE_GLOBALS
 	bool disableReplayRecording = false;
 	uint32_t MPinactivityMinutes = 5;
 	uint8_t MPopenSpectatorSlots = 0;
+	int fogStart = 4000;
+	int fogEnd = 8000;
 };
 
 static WARZONE_GLOBALS warGlobs;
@@ -454,4 +456,24 @@ void war_setMPopenSpectatorSlots(uint16_t spectatorSlots)
 {
 	spectatorSlots = std::min<uint16_t>(spectatorSlots, MAX_SPECTATOR_SLOTS);
 	warGlobs.MPopenSpectatorSlots = spectatorSlots;
+}
+
+int war_getFogEnd()
+{
+	return warGlobs.fogEnd;
+}
+
+int war_getFogStart()
+{
+	return warGlobs.fogStart;
+}
+
+void war_setFogEnd(int end)
+{
+	 warGlobs.fogEnd = end;
+}
+
+void war_setFogStart(int start)
+{
+	 warGlobs.fogStart = start;
 }

--- a/src/warzoneconfig.h
+++ b/src/warzoneconfig.h
@@ -124,6 +124,10 @@ uint32_t war_getMPInactivityMinutes();
 void war_setMPInactivityMinutes(uint32_t minutes);
 uint16_t war_getMPopenSpectatorSlots();
 void war_setMPopenSpectatorSlots(uint16_t spectatorSlots);
+int war_getFogEnd();
+int war_getFogStart();
+void war_setFogEnd(int end);
+void war_setFogStart(int start);
 
 /**
  * Enable or disable sound initialization

--- a/src/wzapi.cpp
+++ b/src/wzapi.cpp
@@ -32,6 +32,7 @@
 #include "lib/netplay/netplay.h"
 #include "qtscript.h"
 #include "lib/ivis_opengl/tex.h"
+#include "lib/ivis_opengl/piestate.h"
 
 #include "action.h"
 #include "clparse.h"
@@ -428,6 +429,17 @@ bool wzapi::setSunIntensity(WZAPI_PARAMS(float ambient_r, float ambient_g, float
 	pie_Lighting0(LIGHT_AMBIENT, ambient);
 	pie_Lighting0(LIGHT_DIFFUSE, diffuse);
 	pie_Lighting0(LIGHT_SPECULAR, specular);
+	return true;
+}
+
+//-- ## setFogColour(r, g, b)
+//--
+//-- Set the colour of the fog (4.2.5+ only)
+//--
+bool wzapi::setFogColour(WZAPI_PARAMS(int r, int g, int b))
+{
+	PIELIGHT newFogColour = pal_RGBA(r, g, b, 255);
+	pie_SetFogColour(newFogColour);
 	return true;
 }
 

--- a/src/wzapi.h
+++ b/src/wzapi.h
@@ -961,6 +961,7 @@ namespace wzapi
 	bool setAssemblyPoint(WZAPI_PARAMS(STRUCTURE *psStruct, int x, int y));
 	bool setSunPosition(WZAPI_PARAMS(float x, float y, float z));
 	bool setSunIntensity(WZAPI_PARAMS(float ambient_r, float ambient_g, float ambient_b, float diffuse_r, float diffuse_g, float diffuse_b, float specular_r, float specular_g, float specular_b));
+	bool setFogColour(WZAPI_PARAMS(int r, int g, int b));
 	bool setWeather(WZAPI_PARAMS(int weatherType));
 	bool setSky(WZAPI_PARAMS(std::string textureFilename, float windSpeed, float scale));
 	bool cameraSlide(WZAPI_PARAMS(float x, float y));


### PR DESCRIPTION
Does what it says in the title. Fog can be modded in all tilesets in the palette file, you can change fog color by script with `setFogColour(r,g,b)`, and experiment with the fog start/end distances in the config files' `fogStart` and `fogEnd` values.

(It appears there is an transparency issue with the landing zone lights... easy to see with a start distance of 0. Shows squares around the image unlike the Oil Resource blip).

Closes #1960

Below are the results of me randomly inputting values in the palette files... so enjoy:

![Screenshot at 2022-01-17 11-41-43](https://user-images.githubusercontent.com/22485442/149834471-b5b61ee7-6fb9-4ebe-b46f-ea31cede641a.png)

![Screenshot at 2022-01-17 11-42-25](https://user-images.githubusercontent.com/22485442/149834489-5af8e558-de08-46ed-9c00-452bc166c5a9.png)

![Screenshot at 2022-01-17 11-42-59](https://user-images.githubusercontent.com/22485442/149834499-2d4cd68e-8a12-4dfc-9f53-6e482764defd.png)
