### PR TITLE
Update minimum bit depth to prevent black screen on Arm64 device (Linux)

### DIFF
--- a/lib/sdl/main_sdl.cpp
+++ b/lib/sdl/main_sdl.cpp
@@ -2136,7 +2136,7 @@ void wzSDLPreWindowCreate_InitOpenGLAttributes(bool antialiasing, bool useOpenGL
 
 	// Set minimum number of bits for the RGB channels of the color buffer
 	SDL_GL_SetAttribute(SDL_GL_RED_SIZE, 5);
-	SDL_GL_SetAttribute(SDL_GL_GREEN_SIZE, 5);
+	SDL_GL_SetAttribute(SDL_GL_GREEN_SIZE, 6);
 	SDL_GL_SetAttribute(SDL_GL_BLUE_SIZE, 5);
 #if defined(WZ_OS_WIN)
 	if (useOpenGLES)


### PR DESCRIPTION
**Environment**

Processor: NXP i.MX 8QuadXPlus
CPU cores: 4x Arm Cortex-A35 @ 1.2GHz
GPU: Vivante GC7000Lite (OpenGL ES 3.1)
OS: Linux (Wayland/Weston)

For added context, this is not a desktop/laptop PC, it's an embedded device, similar to Raspberry Pi. Trying to run WZ on it mostly for fun.

**Investigation**

When cross-compiling Warzone 2100 from source and trying to run on a 64-bit Arm device equipped with an embedded GPU that supports OpenGL ES 3.1, on Linux, the screen goes black. I can still see the cursor and even interact with the game menu (e.g. by clicking the place on the screen where the "Quit Game" is, it quits, etc.). This is a silent failure, there is no output that indicates an error, even with 3D debug messages turned on.

After some debugging, it was noticed that the cause of this is the RGB color depth of 555 set on `lib/sdl/main_sdl.cpp`:

```
    SDL_GL_SetAttribute(SDL_GL_RED_SIZE, 5);
    SDL_GL_SetAttribute(SDL_GL_GREEN_SIZE, 5);
    SDL_GL_SetAttribute(SDL_GL_BLUE_SIZE, 5);
```

I've tried some permutations (not all possible ones), and here are some highlights:

- Commenting those lines makes it work. On the 3D debug logs, it defaults to 444.
- Any combination less or equal to 444 defaults to 444 and it works.
- Any combination greater than 444 and less or equal to 555 does not work.
- Any combination greater than 555 and less or equal to 888 works. Some of them as 565 is used by the GPU, others as 666 default to 888.
- Many of the failing combinations do work if setting `SDL_GL_SetAttribute(SDL_GL_ALPHA_SIZE, 1)`

The source-code changes that introduced the minimum values seem to be https://github.com/Warzone2100/warzone2100/commit/57fbe490ecd2c83f618c69ba0de27333a3682357 (commit) and https://github.com/Warzone2100/warzone2100/pull/489 (pull request).

I've been able to reproduce the same issue on a smaller source code unrelated to WZ, meaning this is either an SDL2 bug or a hardware limitation. I've searched on the SDL2 issue tracker, but the closest I found is https://github.com/libsdl-org/SDL/issues/4041, which is not my case because I'm not switching context and after reading that thread it seems it was an application-level issue, due to misuse of SDL2.

**Proposed Fix**

During some search to find reasons for the issue, it was noticed that RGB_565 is often mentioned, it seems to be a popular color depth format. Also mentioned on https://en.wikipedia.org/wiki/Color_depth#High_color_(15/16-bit). It is a lower minimum value than e.g. 888, that's why my initial suggestion in this PR is to use 565 and not something else.

I didn't find out why a color depth of 555 was chosen initially, and as I'm not very used to SDL2 and OpenGL any input is welcome. Is there any strong reason to use 555 as default? Is there any high risk of changing to 565 as default?

For completeness, here is the output of the 3D debug messages:

```
3d      |17:58:27: [createGLContext:178] Requested OpenGL ES 3.0 context
3d      |17:58:27: [createGLContext:204] SDL_GL_GetAttribute failed to get value for SDL_GL_DOUBLEBUFFER (OpenGL error: GL_INVALID_ENUM)
3d      |17:58:27: [createGLContext:205] Double buffering is required for this game - if it isn't actually enabled, things will fail!
3d      |17:58:27: [createGLContext:218] Current values for: SDL_GL_RED_SIZE (5), SDL_GL_GREEN_SIZE (5), SDL_GL_BLUE_SIZE (5), SDL_GL_ALPHA_SIZE (0)
3d      |17:58:27: [createGLContext:224] Current value for SDL_GL_DEPTH_SIZE: (24)
3d      |17:58:27: [createGLContext:230] Current value for SDL_GL_STENCIL_SIZE: (8)
3d      |17:58:27: [initGLContext:2050] OpenGL Vendor: Vivante Corporation
3d      |17:58:27: [initGLContext:2053] OpenGL Renderer: Vivante GC7000L
3d      |17:58:27: [initGLContext:2056] OpenGL Version: OpenGL ES 3.1 V6.4.3.p1.305572
3d      |17:58:27: [isBlocklistedGraphicsDriver:1973] Checking: Renderer: "Vivante GC7000L", Version: "OpenGL ES 3.1 V6.4.3.p1.305572"
3d      |17:58:27: [initGLContext:2093] OpenGL Extensions: GL_OES_vertex_type_10_10_10_2, GL_OES_vertex_half_float, GL_OES_element_index_uint, GL_OES_mapbuffer, GL_OES_vertex_array_object,
3d      |17:58:27: [initGLContext:2093] OpenGL Extensions: GL_OES_compressed_ETC1_RGB8_texture, GL_OES_compressed_paletted_texture, GL_OES_texture_npot, GL_OES_rgb8_rgba8, GL_OES_depth_texture,
3d      |17:58:27: [initGLContext:2093] OpenGL Extensions: GL_OES_depth_texture_cube_map, GL_OES_depth24, GL_OES_depth32, GL_OES_packed_depth_stencil, GL_OES_fbo_render_mipmap, GL_OES_get_program_binary,
3d      |17:58:27: [initGLContext:2093] OpenGL Extensions: GL_OES_fragment_precision_high, GL_OES_standard_derivatives, GL_OES_EGL_image, GL_OES_EGL_image_external, GL_OES_EGL_image_external_essl3, GL_OES_EGL_sync,
3d      |17:58:27: [initGLContext:2093] OpenGL Extensions: GL_OES_texture_stencil8, GL_OES_shader_image_atomic, GL_OES_texture_storage_multisample_2d_array, GL_OES_required_internalformat, GL_OES_surfaceless_context,
3d      |17:58:27: [initGLContext:2093] OpenGL Extensions: GL_OES_copy_image, GL_OES_draw_buffers_indexed, GL_OES_texture_border_clamp, GL_OES_texture_buffer, GL_OES_texture_cube_map_array,
3d      |17:58:27: [initGLContext:2093] OpenGL Extensions: GL_OES_draw_elements_base_vertex, GL_OES_texture_half_float, GL_OES_texture_float, GL_KHR_blend_equation_advanced, GL_KHR_debug, GL_KHR_robustness,
3d      |17:58:27: [initGLContext:2093] OpenGL Extensions: GL_KHR_robust_buffer_access_behavior, GL_EXT_texture_type_2_10_10_10_REV, GL_EXT_texture_filter_anisotropic, GL_EXT_texture_compression_dxt1,
3d      |17:58:27: [initGLContext:2093] OpenGL Extensions: GL_EXT_texture_format_BGRA8888, GL_EXT_texture_compression_s3tc, GL_EXT_read_format_bgra, GL_EXT_multi_draw_arrays, GL_EXT_frag_depth,
3d      |17:58:27: [initGLContext:2093] OpenGL Extensions: GL_EXT_discard_framebuffer, GL_EXT_blend_minmax, GL_EXT_multisampled_render_to_texture, GL_EXT_color_buffer_half_float, GL_EXT_color_buffer_float,
3d      |17:58:27: [initGLContext:2093] OpenGL Extensions: GL_EXT_robustness, GL_EXT_texture_sRGB_decode, GL_EXT_draw_buffers_indexed, GL_EXT_texture_border_clamp, GL_EXT_texture_buffer, GL_EXT_copy_image,
3d      |17:58:27: [initGLContext:2093] OpenGL Extensions: GL_EXT_texture_cube_map_array, GL_EXT_multi_draw_indirect, GL_EXT_draw_elements_base_vertex, GL_EXT_texture_rg, GL_EXT_protected_textures, GL_EXT_sRGB,
3d      |17:58:27: [initGLContext:2098] OpenGL Extensions: GL_VIV_direct_texture
3d      |17:58:27: [initGLContext:2138]   * OpenGL ES 2.0 is supported!
3d      |17:58:27: [initGLContext:2143]   * Anisotropic filtering is supported.
3d      |17:58:27: [initGLContext:2144]   * KHR_DEBUG support was detected
3d      |17:58:27: [initGLContext:2145]   * glGenerateMipmap support was detected
3d      |17:58:27: [initGLContext:2189]   * OpenGL GLSL Version : OpenGL ES GLSL ES 3.10
3d      |17:58:27: [initGLContext:2194]   * Total number of Texture Image Units (TIUs) supported is 16.
3d      |17:58:27: [initGLContext:2196]   * Total number of Texture Image Units ARB(TIUAs) supported is 48.
3d      |17:58:27: [initGLContext:2198]   * (current) Max Sample buffer is 0.
3d      |17:58:27: [initGLContext:2200]   * (current) Max Sample level is 0.
3d      |17:58:27: [initGLContext:2202]   * (current) Max vertex attribute locations is 16.
3d      |17:58:27: [initGLContext:2220] Enabling KHR_debug message callback
3d      |17:58:28: [pie_Initialise:81] xcentre 400; ycentre 240
3d      |17:58:29: [readShaderBuf:785] Reading...[directory: /warzone2100/share/warzone2100/base.wz] shaders/gfx.vert
3d      |17:58:29: [readShaderBuf:785] Reading...[directory: /warzone2100/share/warzone2100/base.wz] shaders/texturedrect.frag
3d      |17:58:29: [readShaderBuf:785] Reading...[directory: /warzone2100/share/warzone2100/base.wz] shaders/rect.vert
3d      |17:58:29: [readShaderBuf:785] Reading...[directory: /warzone2100/share/warzone2100/base.wz] shaders/rect.frag
3d      |17:58:30: [readShaderBuf:785] Reading...[directory: /warzone2100/share/warzone2100/base.wz] shaders/rect.vert
3d      |17:58:30: [readShaderBuf:785] Reading...[directory: /warzone2100/share/warzone2100/base.wz] shaders/text.frag
3d      |17:58:30: [readShaderBuf:785] Reading...[directory: /warzone2100/share/warzone2100/base.wz] shaders/rect.vert
3d      |17:58:30: [readShaderBuf:785] Reading...[directory: /warzone2100/share/warzone2100/base.wz] shaders/texturedrect.frag
3d      |17:58:31: [readShaderBuf:785] Reading...[directory: /warzone2100/share/warzone2100/base.wz] shaders/line.vert
3d      |17:58:31: [readShaderBuf:785] Reading...[directory: /warzone2100/share/warzone2100/base.wz] shaders/rect.frag
3d      |17:58:31: [readShaderBuf:785] Reading...[directory: /warzone2100/share/warzone2100/base.wz] shaders/rect.vert
3d      |17:58:31: [readShaderBuf:785] Reading...[directory: /warzone2100/share/warzone2100/base.wz] shaders/texturedrect.frag
```

**Testing**

In addition to the affected system, tried the changes on a laptop PC as well:

OS: Ubuntu 20.04 LTS
OpenGL Vendor: Intel
OpenGL Renderer: Mesa Intel(R) UHD Graphics 630 (CFL GT2)
OpenGL Version: OpenGL ES 3.2 Mesa 21.0.3