### PR TITLE
Fixing Rocket Rapid Loader Mk2 prerequisite

### DIFF
--- a/data/base/stats/research.json
+++ b/data/base/stats/research.json
@@ -7904,7 +7904,7 @@
 		"id": "R-Wpn-RocketSlow-ROF05",
 		"name": "Rocket Rapid Loader Mk2",
 		"requiredResearch": [
-			"R-Wpn-Cannon-ROF05"
+			"R-Wpn-RocketSlow-ROF04"
 		],
 		"researchPoints": 12000,
 		"researchPower": 375,

--- a/data/base/stats/research.json
+++ b/data/base/stats/research.json
@@ -7904,6 +7904,7 @@
 		"id": "R-Wpn-RocketSlow-ROF05",
 		"name": "Rocket Rapid Loader Mk2",
 		"requiredResearch": [
+			"R-Wpn-Cannon-ROF05",
 			"R-Wpn-RocketSlow-ROF04"
 		],
 		"researchPoints": 12000,


### PR DESCRIPTION
Making Rocket Rapid Loader Mk1 instead of the Cannon Rapid Loader Mk2 is the prerequisite of the Rocket Rapid Loader Mk2.