### PR TITLE
Clear console when displaying victory reminders

### DIFF
--- a/data/base/script/campaign/libcampaign.js
+++ b/data/base/script/campaign/libcampaign.js
@@ -210,7 +210,7 @@ var __camLZCompromisedTicker;
 var __camLastAttackTriggered;
 var __camLevelEnded;
 var __camExtraObjectiveMessage;
-var __camVictoryMessageThrottle;
+var __camAllowVictoryMsgClear;
 
 //video
 var __camVideoSequences;

--- a/data/base/script/campaign/libcampaign_includes/artifact.js
+++ b/data/base/script/campaign/libcampaign_includes/artifact.js
@@ -171,7 +171,7 @@ function __camPickupArtifact(artifact)
 		callback();
 	}
 
-	queue("__camShowVictoryConditions", camSecondsToMilliseconds(1));
+	__camSetupConsoleForVictoryConditions();
 }
 
 function __camLetMeWinArtifacts()

--- a/data/base/script/campaign/libcampaign_includes/base.js
+++ b/data/base/script/campaign/libcampaign_includes/base.js
@@ -312,7 +312,7 @@ function __camCheckBaseEliminated(group)
 			callback();
 		}
 
-		queue("__camShowVictoryConditions", camSecondsToMilliseconds(1));
+		__camSetupConsoleForVictoryConditions();
 	}
 }
 

--- a/data/base/script/campaign/libcampaign_includes/events.js
+++ b/data/base/script/campaign/libcampaign_includes/events.js
@@ -46,7 +46,7 @@ function cam_eventChat(from, to, message)
 {
 	if (message === "win info")
 	{
-		__camShowVictoryConditions(true);
+		__camShowVictoryConditions();
 	}
 	if (!camIsCheating())
 	{
@@ -128,7 +128,7 @@ function cam_eventStartLevel()
 	__camSaveLoading = false;
 	__camNeverGroupDroids = [];
 	__camNumTransporterExits = 0;
-	__camVictoryMessageThrottle = 0;
+	__camAllowVictoryMsgClear = true;
 	camSetPropulsionTypeLimit(); //disable the propulsion changer by default
 	__camAiPowerReset(); //grant power to the AI
 	setTimer("__checkEnemyFactoryProductionTick", camSecondsToMilliseconds(0.8));

--- a/data/base/script/campaign/libcampaign_includes/victory.js
+++ b/data/base/script/campaign/libcampaign_includes/victory.js
@@ -157,6 +157,12 @@ function camSetExtraObjectiveMessage(message)
 	__camExtraObjectiveMessage = message;
 }
 
+//If the script wants to allow __camSetupConsoleForVictoryConditions() to clear the console.
+function camClearConsoleOnVictoryMessage(clear)
+{
+	__camAllowVictoryMsgClear = clear;
+}
+
 //////////// privates
 
 function __camGameLostCB()
@@ -474,27 +480,32 @@ function __camVictoryOffworld()
 	}
 }
 
-function __camShowVictoryConditions(forceMessage)
+function __camSetupConsoleForVictoryConditions()
 {
-	if (!camDef(forceMessage))
+	// Console clears are only done when collecting artifacts or destroying bases.
+	if (__camAllowVictoryMsgClear)
 	{
-		if (__camVictoryMessageThrottle + camSecondsToMilliseconds(10) > gameTime)
+		clearConsole();
+	}
+
+	queue("__camShowVictoryConditions", camSecondsToMilliseconds(0.5));
+}
+
+function __camShowVictoryConditions()
+{
+	if (!camDef(__camNextLevel))
+	{
+		return; // fastplay / tutorial. Should be a better identifier for this.
+	}
+
+	if (__camWinLossCallback === CAM_VICTORY_PRE_OFFWORLD)
+	{
+		if ((camDiscoverCampaign() === BETA_CAMPAIGN_NUMBER) && (difficulty === HARD || difficulty === INSANE))
 		{
-			return;
+			console(_("Hard / Insane difficulty hint:"));
+			console(_("Fortify a strong base across the map to protect yourself from the Collective"));
 		}
-		if (!camDef(__camNextLevel))
-		{
-			return; // fastplay / tutorial. Should be a better identifier for this.
-		}
-		if (__camWinLossCallback === CAM_VICTORY_PRE_OFFWORLD)
-		{
-			if ((camDiscoverCampaign() === BETA_CAMPAIGN_NUMBER) && (difficulty === HARD || difficulty === INSANE))
-			{
-				console(_("Hard / Insane difficulty hint:"));
-				console(_("Fortify a strong base across the map to protect yourself from the Collective"));
-			}
-			return; // do not need this on these missions.
-		}
+		return; // do not need this on these missions.
 	}
 
 	const ANNIHILATE_MESSAGE = _("Destroy all enemy units and structures");
@@ -560,6 +571,4 @@ function __camShowVictoryConditions(forceMessage)
 			console(__camExtraObjectiveMessage);
 		}
 	}
-
-	__camVictoryMessageThrottle = gameTime;
 }


### PR DESCRIPTION
This has the benefit of keeping the messages updated when collection of artifacts and base destruction happens closely together.

Adds function `camClearConsoleOnVictoryMessage()` to allow the automatic messages to clear the console or not.