### PR TITLE
Check for electronic research rewards already researched

### DIFF
--- a/src/research.cpp
+++ b/src/research.cpp
@@ -1506,7 +1506,7 @@ void researchReward(UBYTE losingPlayer, UBYTE rewardPlayer)
 			if (psFacility->psBestTopic)
 			{
 				topicIndex = ((RESEARCH *)psFacility->psBestTopic)->ref - STAT_RESEARCH;
-				if (topicIndex)
+				if (topicIndex && !IsResearchCompleted(&asPlayerResList[rewardPlayer][topicIndex]))
 				{
 					//if it cost more - it is better (or should be)
 					if (researchPoints < asResearch[topicIndex].researchPoints)


### PR DESCRIPTION
Do not want to give the player about to be given a research reward stacked research of the same topic.

Fixes #2598.