### PR TITLE
make SIMPLE_OBJECT.id const

### DIFF
--- a/data/base/script/campaign/libcampaign_includes/artifact.js
+++ b/data/base/script/campaign/libcampaign_includes/artifact.js
@@ -109,7 +109,7 @@ function __camCheckPlaceArtifact(obj)
 	}
 	if (ai.placed)
 	{
-		camDebug("Object to which artifact", alabel, "is bound has died twice");
+		camDebug("Object to which artifact", alabel, "is bound, has died twice");
 		return;
 	}
 	if (ai.tech instanceof Array)

--- a/data/base/script/campaign/libcampaign_includes/base.js
+++ b/data/base/script/campaign/libcampaign_includes/base.js
@@ -66,7 +66,7 @@ function camSetEnemyBases(bases)
 					}
 					if (!camDef(bi.player) || camPlayerMatchesFilter(s.player, bi.player))
 					{
-						camTrace("Auto-adding", s.id, "to base", blabel);
+						//camTrace("Auto-adding", s.id, "to base", blabel);
 						groupAdd(bi.group, s);
 					}
 				}
@@ -117,21 +117,21 @@ function camSetEnemyBases(bases)
 				}
 				if (!camDef(bi.player) || camPlayerMatchesFilter(s.player, bi.player))
 				{
-					camTrace("Auto-adding", s.id, "to base", blabel);
+					//camTrace("Auto-adding", s.id, "to base", blabel);
 					groupAdd(bi.group, s);
 				}
 			}
 		}
 		if (groupSize(bi.group) === 0)
 		{
-			camDebug("Base", blabel, "defined as empty group");
+			//camDebug("Base", blabel, "defined as empty group");
 		}
 		if(!reload)
 		{
 			bi.detected = false;
 			bi.eliminated = false;
 		}
-		camTrace("Resetting label", blabel);
+		//camTrace("Resetting label", blabel);
 		resetLabel(blabel, CAM_HUMAN_PLAYER); // subscribe for eventGroupSeen
 	}
 }

--- a/data/base/script/campaign/libcampaign_includes/debug.js
+++ b/data/base/script/campaign/libcampaign_includes/debug.js
@@ -160,7 +160,7 @@ function __camGenericDebug(flag, func, args, err, bt)
 	{
 		for (var i = bt.length - 1; i >= 0; --i)
 		{
-			debug("STACK: from", [bt[i]]);
+			debug("STACK: from", JSON.stringify([bt[i]]));
 		}
 	}
 	if (!func)

--- a/lib/netplay/nettypes.cpp
+++ b/lib/netplay/nettypes.cpp
@@ -676,6 +676,12 @@ void NETuint32_t(uint32_t *ip)
 	queueAuto(*ip);
 }
 
+void NETuint32_t(const uint32_t *ip)
+{
+	uint32_t ip_ = *ip;
+	queueAuto(ip_);
+}
+
 void NETint64_t(int64_t *ip)
 {
 	queueAuto(*ip);

--- a/lib/netplay/nettypes.h
+++ b/lib/netplay/nettypes.h
@@ -91,6 +91,7 @@ void NETint16_t(int16_t *ip);
 void NETuint16_t(uint16_t *ip);
 void NETint32_t(int32_t *ip);         ///< Encodes small values (< 836 288) in at most 3 bytes, large values (≥ 22 888 448) in 5 bytes.
 void NETuint32_t(uint32_t *ip);       ///< Encodes small values (< 1 672 576) in at most 3 bytes, large values (≥ 45 776 896) in 5 bytes.
+void NETuint32_t(const uint32_t *ip);
 void NETint64_t(int64_t *ip);
 void NETuint64_t(uint64_t *ip);
 void NETbool(bool *bp);

--- a/src/basedef.h
+++ b/src/basedef.h
@@ -86,7 +86,7 @@ struct SIMPLE_OBJECT
 	virtual ~SIMPLE_OBJECT();
 
 	const OBJECT_TYPE type;                         ///< The type of object
-	uint32_t        id;                             ///< ID number of the object
+	const uint32_t  id;                             ///< ID number of the object
 	Position        pos = Position(0, 0, 0);        ///< Position of the object
 	Rotation        rot;                            ///< Object's yaw +ve rotation around up-axis
 	uint8_t         player;                         ///< Which player the object belongs to

--- a/src/cheat.cpp
+++ b/src/cheat.cpp
@@ -90,6 +90,7 @@ static CHEAT_ENTRY cheatCodes[] =
 	{"autogame on", kf_AutoGame},
 	{"autogame off", kf_AutoGame},
 	{"shakey", kf_ToggleShakeStatus}, //shakey
+	{"list droids", kf_ListDroids},
 
 };
 

--- a/src/droid.cpp
+++ b/src/droid.cpp
@@ -959,7 +959,8 @@ DroidStartBuild droidStartBuild(DROID *psDroid)
 			return DroidStartBuildPending;
 		}
 		//ok to build
-		psStruct = buildStructureDir(psStructStat, psDroid->order.pos.x, psDroid->order.pos.y, psDroid->order.direction, psDroid->player, false);
+		const auto id = generateSynchronisedObjectId();
+		psStruct = buildStructureDir(psStructStat, psDroid->order.pos.x, psDroid->order.pos.y, psDroid->order.direction, psDroid->player, false, id);
 		if (!psStruct)
 		{
 			cancelBuild(psDroid);
@@ -1564,7 +1565,7 @@ UDWORD calcDroidPower(const DROID *psDroid)
 }
 
 //Builds an instance of a Droid - the x/y passed in are in world coords.
-DROID *reallyBuildDroid(const DROID_TEMPLATE *pTemplate, Position pos, UDWORD player, bool onMission, Rotation rot)
+DROID *reallyBuildDroid(const DROID_TEMPLATE *pTemplate, Position pos, UDWORD player, bool onMission, Rotation rot, uint32_t id)
 {
 	// Don't use this assertion in single player, since droids can finish building while on an away mission
 	ASSERT(!bMultiPlayer || worldOnMap(pos.x, pos.y), "the build locations are not on the map");
@@ -1669,6 +1670,12 @@ DROID *reallyBuildDroid(const DROID_TEMPLATE *pTemplate, Position pos, UDWORD pl
 	debug(LOG_LIFE, "created droid for player %d, droid = %p, id=%d (%s): position: x(%d)y(%d)z(%d)", player, static_cast<void *>(psDroid), (int)psDroid->id, psDroid->aName, psDroid->pos.x, psDroid->pos.y, psDroid->pos.z);
 
 	return psDroid;
+}
+
+DROID *reallyBuildDroid(const DROID_TEMPLATE *pTemplate, Position pos, UDWORD player, bool onMission, Rotation rot)
+{
+	const auto id = generateSynchronisedObjectId();
+	return reallyBuildDroid(pTemplate, pos, player, onMission, rot, id);
 }
 
 DROID *buildDroid(DROID_TEMPLATE *pTemplate, UDWORD x, UDWORD y, UDWORD player, bool onMission, const INITIAL_DROID_ORDERS *initialOrders, Rotation rot)

--- a/src/droid.cpp
+++ b/src/droid.cpp
@@ -1572,7 +1572,7 @@ DROID *reallyBuildDroid(const DROID_TEMPLATE *pTemplate, Position pos, UDWORD pl
 
 	ASSERT_OR_RETURN(nullptr, player < MAX_PLAYERS, "Invalid player: %" PRIu32 "", player);
 
-	DROID *psDroid = new DROID(generateSynchronisedObjectId(), player);
+	DROID *psDroid = new DROID(id, player);
 	droidSetName(psDroid, getStatsName(pTemplate));
 
 	// Set the droids type

--- a/src/droid.h
+++ b/src/droid.h
@@ -81,6 +81,7 @@ struct INITIAL_DROID_ORDERS
 DROID *buildDroid(DROID_TEMPLATE *pTemplate, UDWORD x, UDWORD y, UDWORD player, bool onMission, const INITIAL_DROID_ORDERS *initialOrders, Rotation rot = Rotation());
 /// Creates a droid locally, instead of sending a message, even if the bMultiMessages HACK is set to true.
 DROID *reallyBuildDroid(const DROID_TEMPLATE *pTemplate, Position pos, UDWORD player, bool onMission, Rotation rot = Rotation());
+DROID *reallyBuildDroid(const DROID_TEMPLATE *pTemplate, Position pos, UDWORD player, bool onMission, Rotation rot, uint32_t id);
 
 /* Set the asBits in a DROID structure given it's template. */
 void droidSetBits(const DROID_TEMPLATE *pTemplate, DROID *psDroid);

--- a/src/feature.cpp
+++ b/src/feature.cpp
@@ -179,12 +179,17 @@ int32_t featureDamage(FEATURE *psFeature, unsigned damage, WEAPON_CLASS weaponCl
 	}
 }
 
-
-/* Create a feature on the map */
 FEATURE *buildFeature(FEATURE_STATS *psStats, UDWORD x, UDWORD y, bool FromSave)
 {
+	const auto id = generateSynchronisedObjectId();
+	return buildFeature(psStats, x, y, FromSave, id);
+}
+
+/* Create a feature on the map */
+FEATURE *buildFeature(FEATURE_STATS *psStats, UDWORD x, UDWORD y, bool FromSave, uint32_t id)
+{
 	//try and create the Feature
-	FEATURE *psFeature = new FEATURE(generateSynchronisedObjectId(), psStats);
+	FEATURE *psFeature = new FEATURE(id, psStats);
 
 	if (psFeature == nullptr)
 	{

--- a/src/feature.h
+++ b/src/feature.h
@@ -42,6 +42,7 @@ void featureStatsShutDown();
 
 /* Create a feature on the map */
 FEATURE *buildFeature(FEATURE_STATS *psStats, UDWORD x, UDWORD y, bool FromSave);
+FEATURE *buildFeature(FEATURE_STATS *psStats, UDWORD x, UDWORD y, bool FromSave, uint32_t id);
 
 /* Update routine for features */
 void featureUpdate(FEATURE *psFeat);

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2217,7 +2217,7 @@ static bool loadSaveDroidPointers(const WzString &pFileName, DROID **ppsCurrentD
 static bool writeDroidFile(const char *pFileName, DROID **ppsCurrentDroidLists);
 
 static bool loadSaveStructure(char *pFileData, UDWORD filesize);
-static bool loadSaveStructure2(const char *pFileName, STRUCTURE **ppList);
+static bool loadSaveStructure2(const char *pFileName);
 static bool loadWzMapStructure(WzMap::Map& wzMap);
 static bool loadSaveStructurePointers(const WzString& filename, STRUCTURE **ppList);
 static bool writeStructFile(const char *pFileName);
@@ -2817,7 +2817,7 @@ bool loadGame(const char *pGameToLoad, bool keepObjects, bool freeMem, bool User
 		strcat(aFileName, "mstruct.json");
 
 		//load in the mission structures
-		if (!loadSaveStructure2(aFileName, apsStructLists))
+		if (!loadSaveStructure2(aFileName))
 		{
 			aFileName[fileExten] = '\0';
 			strcat(aFileName, "mstruct.bjo");
@@ -3099,7 +3099,7 @@ bool loadGame(const char *pGameToLoad, bool keepObjects, bool freeMem, bool User
 			resetFactoryNumFlag();	//reset flags into the masks
 		}
 	}
-	else if (!loadSaveStructure2(aFileName, apsStructLists))
+	else if (!loadSaveStructure2(aFileName))
 	{
 		debug(LOG_ERROR, "Failed with: %s", aFileName);
 		goto error;
@@ -5036,16 +5036,19 @@ static bool loadWzMapDroidInit(WzMap::Map &wzMap)
 			continue;
 		}
 		turnOffMultiMsg(true);
-		auto psDroid = reallyBuildDroid(psTemplate, Position(droid.position.x, droid.position.y, 0), player, false, {droid.direction, 0, 0});
+		DROID *psDroid = nullptr;
+		if (droid.id.has_value() && droid.id.value() > 0)
+		{
+			psDroid = reallyBuildDroid(psTemplate, Position(droid.position.x, droid.position.y, 0), player, false, {droid.direction, 0, 0}, droid.id.value());
+		} else
+		{
+			psDroid = reallyBuildDroid(psTemplate, Position(droid.position.x, droid.position.y, 0), player, false, {droid.direction, 0, 0});
+		}
 		turnOffMultiMsg(false);
 		if (psDroid == nullptr)
 		{
 			debug(LOG_ERROR, "Failed to build unit %s", droid.name.c_str());
 			continue;
-		}
-		if (droid.id.has_value())
-		{
-			psDroid->id = droid.id.value() > 0 ? droid.id.value() : 0xFEDBCA98;	// hack to remove droid id zero
 		}
 		ASSERT(psDroid->id != 0, "Droid ID should never be zero here");
 
@@ -5482,15 +5485,16 @@ static bool loadSaveDroid(const char *pFileName, DROID **ppsCurrentDroidLists)
 
 		/* Create the Droid */
 		turnOffMultiMsg(true);
-		psDroid = reallyBuildDroid(psTemplate, pos, player, onMission, rot);
-		ASSERT_OR_RETURN(false, psDroid != nullptr, "Failed to build unit %s", sortedList[i].second.toUtf8().c_str());
-		turnOffMultiMsg(false);
-
-		// Copy the values across
 		if (id > 0)
 		{
-			psDroid->id = id; // force correct ID, unless ID is set to eg -1, in which case we should keep new ID (useful for starting units in campaign)
+			psDroid = reallyBuildDroid(psTemplate, pos, player, onMission, rot, id);
+		} else
+		{
+			// will generate a new id
+			psDroid = reallyBuildDroid(psTemplate, pos, player, onMission, rot);
 		}
+		ASSERT_OR_RETURN(false, psDroid != nullptr, "Failed to build unit %s", sortedList[i].second.toUtf8().c_str());
+		turnOffMultiMsg(false);
 		ASSERT(id != 0, "Droid ID should never be zero here");
 		// conditional check so that existing saved games don't break
 		if (ini.contains("originalBody"))
@@ -5908,9 +5912,7 @@ bool loadSaveStructure(char *pFileData, UDWORD filesize)
 		{
 			continue;
 		}
-		// The original code here didn't work and so the scriptwriters worked round it by using the module ID - so making it work now will screw up
-		// the scripts -so in ALL CASES overwrite the ID!
-		psStructure->id = psSaveStructure->id > 0 ? psSaveStructure->id : 0xFEDBCA98; // hack to remove struct id zero
+
 		psStructure->periodicalDamage = psSaveStructure->periodicalDamage;
 		periodicalDamageTime = psSaveStructure->periodicalDamageStart;
 		psStructure->periodicalDamageStart = periodicalDamageTime;
@@ -5992,18 +5994,26 @@ static bool loadWzMapStructure(WzMap::Map& wzMap)
 			player = MAX_PLAYERS - 1;
 			NumberOfSkippedStructures++;
 		}
-		STRUCTURE *psStructure = buildStructureDir(psStats, structure.position.x, structure.position.y, structure.direction, player, true);
+		STRUCTURE *psStructure = nullptr;
+		debug(LOG_NEVER, "trying to build structure %i;%i;%s;%i;%i", structure.id.value(), player, 
+				structure.name.c_str(), map_coord(structure.position.x), map_coord(structure.position.y));
+		if (structure.id.has_value() && structure.id.value() > 0)
+		{
+			psStructure = buildStructureDir(psStats, structure.position.x, structure.position.y, structure.direction, player, true, structure.id.value());
+		} else
+		{
+			// generate new synchronised id
+			psStructure = buildStructureDir(psStats, structure.position.x, structure.position.y, structure.direction, player, true);
+		}
+		
 		if (psStructure == nullptr)
 		{
 			debug(LOG_ERROR, "Structure %s couldn't be built (probably on top of another structure).", structure.name.c_str());
 			continue;
 		}
-		if (structure.id.has_value())
-		{
-			// The original code here didn't work and so the scriptwriters worked round it by using the module ID - so making it work now will screw up
-			// the scripts -so in ALL CASES overwrite the ID!
-			psStructure->id = structure.id.value() > 0 ? structure.id.value() : 0xFEDBCA98; // hack to remove struct id zero
-		}
+		// Previously, we would override building's ID with module's ID
+		// now, "id" is const, we can't do that. 
+		// this may break some mods which look up structures by theirs module id.
 		if (structure.modules > 0)
 		{
 			auto moduleStat = getModuleStat(psStructure);
@@ -6039,7 +6049,7 @@ static bool loadWzMapStructure(WzMap::Map& wzMap)
 
 // -----------------------------------------------------------------------------------------
 /* code for versions after version 20 of a save structure */
-static bool loadSaveStructure2(const char *pFileName, STRUCTURE **ppList)
+static bool loadSaveStructure2(const char *pFileName)
 {
 	if (!PHYSFS_exists(pFileName))
 	{
@@ -6097,18 +6107,18 @@ static bool loadSaveStructure2(const char *pFileName, STRUCTURE **ppList)
 			ini.endGroup();
 			continue; // skip it
 		}
-		psStructure = buildStructureDir(psStats, pos.x, pos.y, rot.direction, player, true);
+		if (id <= 0)
+		{
+			id = generateSynchronisedObjectId();
+		}
+		debug(LOG_NEVER, "trying to build structure %i;%i;%s;%i;%i", id, player, psStats->name.toUtf8().c_str(), map_coord(pos.y), map_coord(pos.y));
+		psStructure = buildStructureDir(psStats, pos.x, pos.y, rot.direction, player, true, id);
 		ASSERT(psStructure, "Unable to create structure");
 		if (!psStructure)
 		{
 			ini.endGroup();
 			continue;
 		}
-		if (id > 0)
-		{
-			psStructure->id = id;	// force correct ID
-		}
-
 		// common BASE_OBJECT info
 		loadSaveObject(ini, psStructure);
 
@@ -6141,6 +6151,7 @@ static bool loadSaveStructure2(const char *pFileName, STRUCTURE **ppList)
 				for (int moduleIdx = 0; moduleIdx < capacity; moduleIdx++)
 				{
 					buildStructure(psModule, psStructure->pos.x, psStructure->pos.y, psStructure->player, true);
+					
 				}
 			}
 			if (ini.contains("Factory/template"))
@@ -6637,12 +6648,12 @@ bool loadSaveFeature(char *pFileData, UDWORD filesize)
 		//if haven't found the feature - ignore this record!
 		if (!found)
 		{
-			debug(LOG_ERROR, "This feature no longer exists - %s", psSaveFeature->name);
+			debug(LOG_ERROR, "This feature no longer exists - %s;%i", psSaveFeature->name, psSaveFeature->id);
 			//ignore this
 			continue;
 		}
 		//create the Feature
-		pFeature = buildFeature(psStats, psSaveFeature->x, psSaveFeature->y, true);
+		pFeature = buildFeature(psStats, psSaveFeature->x, psSaveFeature->y, true, psSaveFeature->id);
 		if (!pFeature)
 		{
 			debug(LOG_ERROR, "Unable to create feature %s", psSaveFeature->name);
@@ -6653,7 +6664,6 @@ bool loadSaveFeature(char *pFileData, UDWORD filesize)
 			scriptSetDerrickPos(pFeature->pos.x, pFeature->pos.y);
 		}
 		//restore values
-		pFeature->id = psSaveFeature->id;
 		pFeature->rot.direction = DEG(psSaveFeature->direction);
 		pFeature->periodicalDamage = psSaveFeature->periodicalDamage;
 		if (psHeader->version >= VERSION_14)
@@ -6685,7 +6695,15 @@ static bool loadWzMapFeature(WzMap::Map &wzMap)
 			continue;  // ignore this
 		}
 		// Create the Feature
-		auto pFeature = buildFeature(psStats, feature.position.x, feature.position.y, true);
+		FEATURE *pFeature = nullptr;
+		//restore values && create Feature
+		if (feature.id.has_value())
+		{
+			pFeature = buildFeature(psStats, feature.position.x, feature.position.y, true, feature.id.value());
+		} else
+		{
+			pFeature = buildFeature(psStats, feature.position.x, feature.position.y, true);
+		}
 		if (!pFeature)
 		{
 			debug(LOG_ERROR, "Unable to create feature %s", feature.name.c_str());
@@ -6695,15 +6713,7 @@ static bool loadWzMapFeature(WzMap::Map &wzMap)
 		{
 			scriptSetDerrickPos(pFeature->pos.x, pFeature->pos.y);
 		}
-		//restore values
-		if (feature.id.has_value())
-		{
-			pFeature->id = feature.id.value();
-		}
-		else
-		{
-			pFeature->id = generateSynchronisedObjectId();
-		}
+
 		pFeature->rot.direction = feature.direction;
 		pFeature->player = (feature.player.has_value()) ? feature.player.value() : PLAYER_FEATURE;
 	}
@@ -6751,7 +6761,15 @@ bool loadSaveFeature2(const char *pFileName)
 			continue;
 		}
 		//create the Feature
-		pFeature = buildFeature(psStats, pos.x, pos.y, true);
+		int id = ini.value("id", -1).toInt();
+		if (id > 0)
+		{
+			pFeature = buildFeature(psStats, pos.x, pos.y, true, id);
+		}
+		else
+		{
+			pFeature = buildFeature(psStats, pos.x, pos.y, true);
+		}
 		if (!pFeature)
 		{
 			debug(LOG_ERROR, "Unable to create feature %s", name.toUtf8().c_str());
@@ -6762,15 +6780,6 @@ bool loadSaveFeature2(const char *pFileName)
 			scriptSetDerrickPos(pFeature->pos.x, pFeature->pos.y);
 		}
 		//restore values
-		int id = ini.value("id", -1).toInt();
-		if (id > 0)
-		{
-			pFeature->id = id;
-		}
-		else
-		{
-			pFeature->id = generateSynchronisedObjectId();
-		}
 		pFeature->rot = ini.vector3i("rotation");
 		pFeature->player = ini.value("player", PLAYER_FEATURE).toInt();
 

--- a/src/hci.cpp
+++ b/src/hci.cpp
@@ -1699,10 +1699,10 @@ INT_RETVAL intRunWidgets()
 					auto psBuilding = castStructureStats(psPositionStats);
 					if (psBuilding && selectedPlayer < MAX_PLAYERS)
 					{
-						STRUCTURE tmp(0, selectedPlayer);
 
 						if (psBuilding->type == REF_DEMOLISH)
 						{
+							STRUCTURE tmp(0, selectedPlayer);
 							MAPTILE *psTile = mapTile(map_coord(pos.x), map_coord(pos.y));
 							FEATURE *psFeature = (FEATURE *)psTile->psObject;
 							STRUCTURE *psStructure = (STRUCTURE *)psTile->psObject;
@@ -1719,8 +1719,8 @@ INT_RETVAL intRunWidgets()
 						}
 						else
 						{
+							STRUCTURE tmp(generateNewObjectId(), selectedPlayer);
 							STRUCTURE *psStructure = &tmp;
-							tmp.id = generateNewObjectId();
 							tmp.pStructureType = (STRUCTURE_STATS *)psPositionStats;
 							tmp.pos = {pos.x, pos.y, map_Height(pos.x, pos.y) + world_coord(1) / 10};
 

--- a/src/keybind.cpp
+++ b/src/keybind.cpp
@@ -730,6 +730,29 @@ void kf_ShowNumObjects()
 	sendInGameSystemMessage(cmsg.c_str());
 }
 
+
+void kf_ListDroids()
+{
+	// Bail out if we're running a _true_ multiplayer game (to prevent MP cheating)
+	debug(LOG_INFO, "list droids:");
+	if (runningMultiplayer())
+	{
+		noMPCheatMsg();
+		return;
+	}
+	for (int i = 0; i < MAX_PLAYERS; i++)
+	{
+		for (DROID *psDroid = apsDroidLists[i]; psDroid; psDroid = psDroid->psNext)
+		{
+			const auto x = map_coord(psDroid->pos.x);
+			const auto y = map_coord(psDroid->pos.y);
+			debug(LOG_INFO, "droid %i;%s;%i;%i;%i", i, psDroid->aName, psDroid->droidType, x, y);
+		}
+	}
+	
+}
+
+
 // --------------------------------------------------------------------------
 
 /* Toggles radar on off */

--- a/src/keybind.h
+++ b/src/keybind.h
@@ -46,6 +46,7 @@ void kf_ToggleSamples();		// Displays # of sound samples in Queue/list.
 void kf_ToggleOrders();		//displays unit's Order/action state.
 void kf_FrameRate();
 void kf_ShowNumObjects();
+void kf_ListDroids();
 void kf_ToggleRadar();
 void kf_TogglePower();
 void kf_RecalcLighting();

--- a/src/multibot.cpp
+++ b/src/multibot.cpp
@@ -431,12 +431,12 @@ bool recvDroid(NETQUEUE queue)
 	}
 
 	// Create that droid on this machine.
-	psDroid = reallyBuildDroid(pT, pos, player, false);
+	const auto r = Rotation();
+	psDroid = reallyBuildDroid(pT, pos, player, false, r, id);
 
 	// If we were able to build the droid set it up
 	if (psDroid)
 	{
-		psDroid->id = id;
 		addDroid(psDroid, apsDroidLists);
 
 		if (haveInitialOrders)

--- a/src/multigifts.cpp
+++ b/src/multigifts.cpp
@@ -726,7 +726,7 @@ void recvMultiPlayerFeature(NETQUEUE queue)
 		if (asFeatureStats[i].ref == ref)
 		{
 			// Create a feature of the specified type at the given location
-			buildFeature(&asFeatureStats[i], x, y, false);
+			buildFeature(&asFeatureStats[i], x, y, false, id);
 			break;
 		}
 	}

--- a/src/multigifts.cpp
+++ b/src/multigifts.cpp
@@ -726,8 +726,7 @@ void recvMultiPlayerFeature(NETQUEUE queue)
 		if (asFeatureStats[i].ref == ref)
 		{
 			// Create a feature of the specified type at the given location
-			FEATURE *result = buildFeature(&asFeatureStats[i], x, y, false);
-			result->id = id;
+			buildFeature(&asFeatureStats[i], x, y, false);
 			break;
 		}
 	}

--- a/src/multiplay.cpp
+++ b/src/multiplay.cpp
@@ -454,16 +454,8 @@ DROID *IdToMissionDroid(UDWORD id, UDWORD player)
 	return nullptr;
 }
 
-// ////////////////////////////////////////////////////////////////////////////
-// find a structure
-STRUCTURE *IdToStruct(UDWORD id, UDWORD player)
+static STRUCTURE* _IdToStruct(UDWORD id, UDWORD beginPlayer, UDWORD endPlayer)
 {
-	int beginPlayer = 0, endPlayer = MAX_PLAYERS;
-	if (player != ANYPLAYER)
-	{
-		beginPlayer = player;
-		endPlayer = std::min<int>(player + 1, MAX_PLAYERS);
-	}
 	STRUCTURE **lists[2] = {apsStructLists, mission.apsStructLists};
 	for (int j = 0; j < 2; ++j)
 	{
@@ -477,6 +469,24 @@ STRUCTURE *IdToStruct(UDWORD id, UDWORD player)
 				}
 			}
 		}
+	}
+	return nullptr;
+}
+// ////////////////////////////////////////////////////////////////////////////
+// find a structure
+STRUCTURE *IdToStruct(UDWORD id, UDWORD player)
+{
+	int beginPlayer = 0, endPlayer = MAX_PLAYERS;
+	if (player != ANYPLAYER)
+	{
+		beginPlayer = player;
+		endPlayer = std::min<int>(player + 1, MAX_PLAYERS);
+	}
+	STRUCTURE *out = nullptr;
+	out = _IdToStruct(id, beginPlayer, endPlayer);
+	if (out)
+	{
+		return out;
 	}
 	return nullptr;
 }

--- a/src/multistruct.cpp
+++ b/src/multistruct.cpp
@@ -120,30 +120,11 @@ bool recvBuildFinished(NETQUEUE queue)
 	// Find the structures stats
 	for (typeindex = 0; typeindex < numStructureStats && asStructureStats[typeindex].ref != type; typeindex++) {}	// Find structure target
 
-	// Check for similar buildings, to avoid overlaps
-	if (TileHasStructure(mapTile(map_coord(pos.x), map_coord(pos.y))))
-	{
-		// Get the current structure
-		psStruct = getTileStructure(map_coord(pos.x), map_coord(pos.y));
-		if (asStructureStats[typeindex].type == psStruct->pStructureType->type)
-		{
-			// Correct type, correct location, just rename the id's to sync it.. (urgh)
-			psStruct->id = structId;
-			psStruct->status = SS_BUILT;
-			buildingComplete(psStruct);
-			debug(LOG_SYNC, "Created modified building %u for player %u", psStruct->id, player);
-#if defined (DEBUG)
-			NETlogEntry("structure id modified", SYNC_FLAG, player);
-#endif
-			return true;
-		}
-	}
 	// Build the structure
-	psStruct = buildStructure(&(asStructureStats[typeindex]), pos.x, pos.y, player, true);
-
+	debug(LOG_INFO, "trying to build received structure %i;%i;%s", structId, player, psStruct->pStructureType->name.toUtf8().c_str());
+	psStruct = buildStructureDir(&(asStructureStats[typeindex]), pos.x, pos.y, 0, player, true, structId);
 	if (psStruct)
 	{
-		psStruct->id		= structId;
 		psStruct->status	= SS_BUILT;
 		buildingComplete(psStruct);
 		debug(LOG_SYNC, "Huge synch error, forced to create building %u for player %u", psStruct->id, player);

--- a/src/multistruct.cpp
+++ b/src/multistruct.cpp
@@ -121,7 +121,6 @@ bool recvBuildFinished(NETQUEUE queue)
 	for (typeindex = 0; typeindex < numStructureStats && asStructureStats[typeindex].ref != type; typeindex++) {}	// Find structure target
 
 	// Build the structure
-	debug(LOG_INFO, "trying to build received structure %i;%i;%s", structId, player, psStruct->pStructureType->name.toUtf8().c_str());
 	psStruct = buildStructureDir(&(asStructureStats[typeindex]), pos.x, pos.y, 0, player, true, structId);
 	if (psStruct)
 	{

--- a/src/quickjs_backend.cpp
+++ b/src/quickjs_backend.cpp
@@ -794,7 +794,6 @@ JSValue convStructure(const STRUCTURE *psStruct, JSContext *ctx)
 		}
 	}
 	JSValue value = convObj(psStruct, ctx);
-	//QuickJS_DefinePropertyValue(ctx, value, "objectId", JS_NewUint32(ctx, psStruct->id), JS_PROP_ENUMERABLE);
 	QuickJS_DefinePropertyValue(ctx, value, "isCB", JS_NewBool(ctx, structCBSensor(psStruct)), JS_PROP_ENUMERABLE);
 	QuickJS_DefinePropertyValue(ctx, value, "isSensor", JS_NewBool(ctx, structStandardSensor(psStruct)), JS_PROP_ENUMERABLE);
 	QuickJS_DefinePropertyValue(ctx, value, "canHitAir", JS_NewBool(ctx, aa), JS_PROP_ENUMERABLE);

--- a/src/quickjs_backend.cpp
+++ b/src/quickjs_backend.cpp
@@ -794,6 +794,7 @@ JSValue convStructure(const STRUCTURE *psStruct, JSContext *ctx)
 		}
 	}
 	JSValue value = convObj(psStruct, ctx);
+	//QuickJS_DefinePropertyValue(ctx, value, "objectId", JS_NewUint32(ctx, psStruct->id), JS_PROP_ENUMERABLE);
 	QuickJS_DefinePropertyValue(ctx, value, "isCB", JS_NewBool(ctx, structCBSensor(psStruct)), JS_PROP_ENUMERABLE);
 	QuickJS_DefinePropertyValue(ctx, value, "isSensor", JS_NewBool(ctx, structStandardSensor(psStruct)), JS_PROP_ENUMERABLE);
 	QuickJS_DefinePropertyValue(ctx, value, "canHitAir", JS_NewBool(ctx, aa), JS_PROP_ENUMERABLE);

--- a/src/structure.h
+++ b/src/structure.h
@@ -50,6 +50,7 @@
 #define ACTION_START_TIME	0
 
 extern std::vector<ProductionRun> asProductionRun[NUM_FACTORY_TYPES];
+extern std::unordered_map<UDWORD, UDWORD> moduleToBuilding[MAX_PLAYER_SLOTS];
 
 //Value is stored for easy access to this structure stat
 extern UDWORD	factoryModuleStat;
@@ -102,6 +103,7 @@ float structureCompletionProgress(const STRUCTURE & structure);
 
 //builds a specified structure at a given location
 STRUCTURE *buildStructure(STRUCTURE_STATS *pStructureType, UDWORD x, UDWORD y, UDWORD player, bool FromSave);
+STRUCTURE *buildStructureDir(STRUCTURE_STATS *pStructureType, UDWORD x, UDWORD y, uint16_t direction, UDWORD player, bool FromSave, uint32_t id);
 STRUCTURE *buildStructureDir(STRUCTURE_STATS *pStructureType, UDWORD x, UDWORD y, uint16_t direction, UDWORD player, bool FromSave);
 /// Create a blueprint structure, with just enough information to render it
 STRUCTURE *buildBlueprint(STRUCTURE_STATS const *psStats, Vector3i xy, uint16_t direction, unsigned moduleIndex, STRUCT_STATES state, uint8_t ownerPlayer);


### PR DESCRIPTION
That was a pretty painful refactoring but SIMPLE_OBJECT.id is now `const`
What broke:
1. Campaign scripts use modules instead of buildings to place artifacts. This was a problem because we can't modify a building's id anymore, so artifacts wouldn't drop when it's destroyed. Missions known to be broken (was used to test): CAM_1B & CAM_3A.
2. `src/multistruct.cpp`: When desync happens we would first check that a building of same type already exists in the same position, in case if only `psStruct->id` is inconsistent. If it is, then we would modify the `structure_id` only to fix desync.

This was fixed by 
1. 
- remember which module maps to which building
- check `label.id` in `loadLabels`: if it's a module, then replace it with corresponding building
I don't think Skirmish (and MP) are affected by this in any way, BUT mods could be affected, if somehow, they rely on getting module id instead of parent structure id.

2.
- I threw away that part, and now simply build a new structure with correct id. This only affects MP. I don't think that's a problem, because this only changes behaviour when desync *already happened*, and I don't think players care in what manner desync has been fixed. 
 *EDIT*: this code path is only active when cheating is active in MP, and when a player adds himself a list of structures in a row. So this is of a very limited scope. No desync detected when doing that.

TODO: ~~for Campaign, I only tested `CAM_1B & CAM_3A`, because I believe my fix is general enough, but just to be sure, we need to test the whole Campaign (=all missions can be completed, saving/reloadng doesn't swcrew up artifacts)~~ The whole Campaign has been successfully passed