### PR TITLE
Fix Optimum range not moving past long range when clicking a target

### DIFF
--- a/src/action.cpp
+++ b/src/action.cpp
@@ -217,7 +217,7 @@ bool actionInRange(const DROID *psDroid, const BASE_OBJECT *psObj, int weapon_sl
 }
 
 /**
- * Retuns true if distance from psDroid to target is less than, or equal to droid's 
+ * Retuns true if distance from psDroid to target is less than, or equal to droid's
  * minimum range
 */
 static bool actionInsideMinRange(DROID *psDroid, BASE_OBJECT *psObj, WEAPON_STATS *psStats)
@@ -2297,7 +2297,7 @@ static void actionDroidBase(DROID *psDroid, DROID_ACTION_DATA *psAction)
 		// slightly strange place to store this I know, but I didn't want to add any more to the droid
 		psDroid->actionPos = psDroid->pos.xy();
 		setDroidActionTarget(psDroid, psAction->psObj, 0);
-		actionIsInRange = actionInRange(psDroid, psDroid->psActionTarget[0], 0);
+		actionIsInRange = actionInRange(psDroid, psDroid->psActionTarget[0], 0, false);
 		if (((order->type == DORDER_ATTACKTARGET
 		   || order->type == DORDER_NONE
 		   || order->type == DORDER_HOLD
@@ -2335,7 +2335,7 @@ static void actionDroidBase(DROID *psDroid, DROID_ACTION_DATA *psAction)
 				turnOffMultiMsg(false);
 			}
 		}
-		else if (order->type != DORDER_HOLD 
+		else if (order->type != DORDER_HOLD
 				&& secondaryGetState(psDroid, DSO_HALTTYPE) != DSS_HALT_HOLD
 				&& !actionIsInRange) // approach closer?
 		{
@@ -2344,7 +2344,7 @@ static void actionDroidBase(DROID *psDroid, DROID_ACTION_DATA *psAction)
 			moveDroidTo(psDroid, psAction->psObj->pos.x, psAction->psObj->pos.y);
 			turnOffMultiMsg(false);
 		}
-		else if (actionIsInRange ||(order->type != DORDER_HOLD && secondaryGetState(psDroid, DSO_HALTTYPE) == DSS_HALT_HOLD))
+		else if (actionIsInRange || (order->type != DORDER_HOLD && secondaryGetState(psDroid, DSO_HALTTYPE) == DSS_HALT_HOLD))
 		{
 			if (!isVtolDroid(psDroid))
 			{


### PR DESCRIPTION
Fixes #2619.

`actionInRange()` defaults to long range for "could I actually hit this if I wanted to". I forced the new check to consider short range on Optimum range for the movement related bits in the attack action.

Should be good enough unless I'm missing something obvious?