### PR TITLE
Fastplay balance changes

### DIFF
--- a/data/base/script/fastplay/fastdemo.js
+++ b/data/base/script/fastplay/fastdemo.js
@@ -191,7 +191,7 @@ function eventStartLevel()
 			order: CAM_ORDER_ATTACK,
 			groupSize: 5,
 			throttle: camChangeOnDiff(camSecondsToMilliseconds(15)),
-			templates: [cTempl.rbjeep, cTempl.trike, cTempl.buggy, cTempl.rbjeep]
+			templates: [cTempl.rbjeep, cTempl.trike, cTempl.buggy, cTempl.rbjeep, cTempl.bjeep]
 		}
 	});
 

--- a/data/base/script/fastplay/fastdemo.js
+++ b/data/base/script/fastplay/fastdemo.js
@@ -169,7 +169,7 @@ function eventStartLevel()
 		"artifactPos": { tech: "R-Wpn-Flamer01Mk1" },
 		"radarTower": { tech: "R-Sys-Sensor-Turret01" },
 		"base2Factory": { tech: "R-Vehicle-Prop-Halftracks" },
-		"bunkerArti": { tech: "R-Sys-Engineering01", "R-Sys-MobileRepairTurret01" },
+		"bunkerArti": { tech: ["R-Sys-Engineering01", "R-Sys-MobileRepairTurret01" ]},
 	});
 
 	camSetFactories({

--- a/data/base/script/fastplay/fastdemo.js
+++ b/data/base/script/fastplay/fastdemo.js
@@ -165,10 +165,11 @@ function eventStartLevel()
 	camSafeRemoveObject("flamerArti", false);
 	camSetArtifacts({
 		"base1Factory": { tech: "R-Defense-Tower01" },
+		"base1PowerGenerator": { tech: "R-Struc-PowerModuleMk1" },
 		"artifactPos": { tech: "R-Wpn-Flamer01Mk1" },
 		"radarTower": { tech: "R-Sys-Sensor-Turret01" },
 		"base2Factory": { tech: "R-Vehicle-Prop-Halftracks" },
-		"bunkerArti": { tech: "R-Sys-Engineering01" },
+		"bunkerArti": { tech: "R-Sys-Engineering01", "R-Sys-MobileRepairTurret01" },
 	});
 
 	camSetFactories({

--- a/data/base/wrf/fastplay/fastdemo/labels.json
+++ b/data/base/wrf/fastplay/fastdemo/labels.json
@@ -151,6 +151,12 @@
 		"player": 0,
 		"type": 2
 	},
+	"object_6": {
+		"label": "base1PowerGenerator",
+		"id": 229,
+		"player": 7,
+		"type": 1
+	},
 
 	"radius_0": {
 		"label": "removeObjectiveBlip",


### PR DESCRIPTION
Discord member Dziq noticed that the repair turret is no longer available in the Fastplay. The reason is the changes in the research path of the campaign for the rebalancing of the campaign. Therefore the repair turret artifact is added to the bunker with the engineering artifact and also the power module is added to the base one power generator.