### PR TITLE
QuickJS additional logging, JS API: Add countStructEx / countDroidEx

### DIFF
--- a/src/quickjs_backend.cpp
+++ b/src/quickjs_backend.cpp
@@ -1953,8 +1953,12 @@ static JSValue callFunction(JSContext *ctx, const std::string &function, std::ve
 			JSValue result = JS_NewArray(ctx);
 			for (uint32_t i = 0; i < value.size(); i++)
 			{
-				VectorType item = value.at(i);
-				JS_DefinePropertyValueUint32(ctx, result, i, box(item, ctx), JS_PROP_C_W_E); // TODO: Check return value?
+				int ret = JS_DefinePropertyValueUint32(ctx, result, i, box(value.at(i), ctx), JS_PROP_C_W_E);
+				if (ret != 1)
+				{
+					// Failed to define property value??
+					debug(LOG_ERROR, "Failed to define property value vector[%" PRIu32 "]", i);
+				}
 			}
 			return result;
 		}
@@ -1966,7 +1970,12 @@ static JSValue callFunction(JSContext *ctx, const std::string &function, std::ve
 			uint32_t i = 0;
 			for (auto item : value)
 			{
-				JS_DefinePropertyValueUint32(ctx, result, i, box(item, ctx), JS_PROP_C_W_E); // TODO: Check return value?
+				int ret = JS_DefinePropertyValueUint32(ctx, result, i, box(item, ctx), JS_PROP_C_W_E);
+				if (ret != 1)
+				{
+					// Failed to define property value??
+					debug(LOG_ERROR, "Failed to define property value list[%" PRIu32 "]", i);
+				}
 				i++;
 			}
 			return result;

--- a/src/quickjs_backend.cpp
+++ b/src/quickjs_backend.cpp
@@ -3037,10 +3037,12 @@ IMPL_JS_FUNC(addDroidToTransporter, wzapi::addDroidToTransporter)
 IMPL_JS_FUNC(makeTemplate, wzapi::makeTemplate)
 IMPL_JS_FUNC(buildDroid, wzapi::buildDroid)
 IMPL_JS_FUNC(enumStruct, wzapi::enumStruct)
+IMPL_JS_FUNC(countStructEx, wzapi::countStructEx)
 IMPL_JS_FUNC(enumStructOffWorld, wzapi::enumStructOffWorld)
 IMPL_JS_FUNC(enumFeature, wzapi::enumFeature)
 IMPL_JS_FUNC(enumCargo, wzapi::enumCargo)
 IMPL_JS_FUNC(enumDroid, wzapi::enumDroid)
+IMPL_JS_FUNC(countDroidEx, wzapi::countDroidEx)
 IMPL_JS_FUNC(dump, wzapi::dump)
 IMPL_JS_FUNC(debug, wzapi::debugOutputStrings)
 IMPL_JS_FUNC(pickStructLocation, wzapi::pickStructLocation)
@@ -3375,8 +3377,10 @@ bool quickjs_scripting_instance::registerFunctions(const std::string& scriptName
 	JS_REGISTER_FUNC(clearConsole, 0); // WZAPI
 	JS_REGISTER_FUNC(structureIdle, 1); // WZAPI
 	JS_REGISTER_FUNC2(enumStruct, 0, 3); // WZAPI
+	JS_REGISTER_FUNC2(countStructEx, 0, 3); // WZAPI
 	JS_REGISTER_FUNC2(enumStructOffWorld, 0, 3); // WZAPI
 	JS_REGISTER_FUNC2(enumDroid, 0, 3); // WZAPI
+	JS_REGISTER_FUNC2(countDroidEx, 0, 3); // WZAPI
 	JS_REGISTER_FUNC(enumGroup, 1); // scripting_engine
 	JS_REGISTER_FUNC2(enumFeature, 1, 2); // WZAPI
 	JS_REGISTER_FUNC(enumBlips, 1); // WZAPI

--- a/src/wzapi.h
+++ b/src/wzapi.h
@@ -1002,8 +1002,10 @@ namespace wzapi
 	bool clearConsole(WZAPI_NO_PARAMS);
 	bool structureIdle(WZAPI_PARAMS(const STRUCTURE *psStruct));
 	std::vector<const STRUCTURE *> enumStruct(WZAPI_PARAMS(optional<int> _player, optional<STRUCTURE_TYPE_or_statsName_string> _structureType, optional<int> _playerFilter));
+	int countStructEx(WZAPI_PARAMS(optional<int> _player, optional<STRUCTURE_TYPE_or_statsName_string> _structureType, optional<int> _playerFilter));
 	std::vector<const STRUCTURE *> enumStructOffWorld(WZAPI_PARAMS(optional<int> _player, optional<STRUCTURE_TYPE_or_statsName_string> _structureType, optional<int> _playerFilter));
 	std::vector<const DROID *> enumDroid(WZAPI_PARAMS(optional<int> _player, optional<int> _droidType, optional<int> _playerFilter));
+	int countDroidEx(WZAPI_PARAMS(optional<int> _player, optional<int> _droidType, optional<int> _playerFilter));
 	std::vector<const FEATURE *> enumFeature(WZAPI_PARAMS(int playerFilter, optional<std::string> _featureName));
 	std::vector<scr_position> enumBlips(WZAPI_PARAMS(int player));
 	std::vector<const BASE_OBJECT *> enumSelected(WZAPI_NO_PARAMS_NO_CONTEXT);


### PR DESCRIPTION
JS API: Add countStructEx / countDroidEx
- These functions are just like `enumStruct` / `enumDroid`, except they only return a count of the number of (matching) structures / droids.
- (Useful if all you need is the count - avoid creating lots of JS temporaries.)