### PR TITLE
Disable ground retexture after destroying skyscrapers on non-Urban maps

### DIFF
--- a/src/feature.cpp
+++ b/src/feature.cpp
@@ -496,6 +496,7 @@ bool destroyFeature(FEATURE *psDel, unsigned impactTime)
 		// ----- Flip all the tiles under the skyscraper to a rubble tile
 		// smoke effect should disguise this happening
 		StructureBounds b = getStructureBounds(psDel);
+		bool isUrban = tilesetDir && strcmp(tilesetDir, "texpages/tertilesc2hw") == 0;
 		for (int breadth = 0; breadth < b.size.y; ++breadth)
 		{
 			for (int width = 0; width < b.size.x; ++width)
@@ -507,7 +508,10 @@ bool destroyFeature(FEATURE *psDel, unsigned impactTime)
 					if (terrainType(psTile) != TER_CLIFFFACE)
 					{
 						/* Clear feature bits */
-						psTile->texture = TileNumber_texture(psTile->texture) | RUBBLE_TILE;
+						if (isUrban)
+						{
+							psTile->texture = TileNumber_texture(psTile->texture) | RUBBLE_TILE;
+						}
 						auxClearBlocking(b.map.x + width, b.map.y + breadth, AUXBITS_ALL);
 					}
 					else
@@ -515,7 +519,10 @@ bool destroyFeature(FEATURE *psDel, unsigned impactTime)
 						/* This remains a blocking tile */
 						psTile->psObject = nullptr;
 						auxClearBlocking(b.map.x + width, b.map.y + breadth, AIR_BLOCKED);  // Shouldn't remain blocking for air units, however.
-						psTile->texture = TileNumber_texture(psTile->texture) | BLOCKING_RUBBLE_TILE;
+						if (isUrban)
+						{
+							psTile->texture = TileNumber_texture(psTile->texture) | BLOCKING_RUBBLE_TILE;
+						}
 					}
 				}
 			}


### PR DESCRIPTION
Arizona and Rockies tilesets do not have good replacement textures for this feature.

Refs #2544.