### PR TITLE
Do not form alliances with scavenger player when starting games

### DIFF
--- a/src/multigifts.cpp
+++ b/src/multigifts.cpp
@@ -787,6 +787,8 @@ void createTeamAlliances()
 		for (unsigned j = 0; j < MAX_PLAYERS; j++)
 		{
 			if (i != j														// two different players
+			    && i != scavengerSlot()										// ...not scavenger player
+			    && j != scavengerSlot()
 			    && NetPlay.players[i].team == NetPlay.players[j].team		// ...belonging to the same team
 			    && !aiCheckAlliances(i, j)									// ...not allied and not ignoring teams
 			    && NetPlay.players[i].difficulty != AIDifficulty::DISABLED


### PR DESCRIPTION
We don't want to be automatically forming alliances with the scavenger player. I suppose one could look into the team assignment in `resetPlayerConfiguration()` but I'm not messing with slot behavior.

Closes #2157.