### PR TITLE
fix typos reported by Debian CI

### DIFF
--- a/lib/exceptionhandler/exchndl_mingw.cpp
+++ b/lib/exceptionhandler/exchndl_mingw.cpp
@@ -119,7 +119,7 @@ slurp_symtab(bfd *abfd, asymbol ***syms, long *symcount)
 	return TRUE;
 }
 
-// This stucture is used to pass information between translate_addresses and find_address_in_section.
+// This structure is used to pass information between translate_addresses and find_address_in_section.
 struct find_handle
 {
 	asymbol **syms;

--- a/lib/framework/frameresource.cpp
+++ b/lib/framework/frameresource.cpp
@@ -524,7 +524,7 @@ bool resLoadFile(const char *pType, const char *pFile)
 		// Load the file in a buffer
 		if (!RetreiveResourceFile(aFileName, &Resource))
 		{
-			debug(LOG_ERROR, "resLoadFile: Unable to retreive resource - %s", aFileName);
+			debug(LOG_ERROR, "resLoadFile: Unable to retrieve resource - %s", aFileName);
 			return false;
 		}
 

--- a/src/levels.cpp
+++ b/src/levels.cpp
@@ -788,7 +788,7 @@ bool levLoadData(char const *name, Sha256 const *hash, char *pSaveName, GAME_TYP
 	// reset the old mission data if necessary
 	if (psCurrLevel != nullptr)
 	{
-		debug(LOG_WZ, "Reseting old mission data");
+		debug(LOG_WZ, "Resetting old mission data");
 		if (!levReleaseMissionData())
 		{
 			debug(LOG_ERROR, "Failed to unload old mission data");

--- a/src/loadsave.cpp
+++ b/src/loadsave.cpp
@@ -611,7 +611,7 @@ static bool findLastSaveFrom(SAVEGAME_LOC loc)
 				const auto saveInfoDataOpt = parseJsonFile(pathToSaveInfo.c_str());
 				if (!saveInfoDataOpt.has_value())
 				{
-					debug(LOG_SAVEGAME, "wierd directory without save-info.json: %s", dirName);
+					debug(LOG_SAVEGAME, "weird directory without save-info.json: %s", dirName);
 					return true;
 				}
 				const auto saveInfo = saveInfoDataOpt.value();

--- a/src/objmem.cpp
+++ b/src/objmem.cpp
@@ -511,7 +511,7 @@ void killStruct(STRUCTURE *psBuilding)
 	ASSERT(psBuilding->type == OBJ_STRUCTURE,
 	       "killStruct: pointer is not a droid");
 	ASSERT(psBuilding->player < MAX_PLAYERS,
-	       "killStruct: invalid player for stucture");
+	       "killStruct: invalid player for structure");
 
 	if (psBuilding->pStructureType->pSensor
 	    && psBuilding->pStructureType->pSensor->location == LOC_TURRET)

--- a/src/spectatorwidgets.cpp
+++ b/src/spectatorwidgets.cpp
@@ -903,7 +903,7 @@ std::pair<std::vector<size_t>, size_t> SpectatorStatsView::getMaxTableColumnData
 	size_t totalNeededColumnWidth = 0;
 	std::vector<size_t> maxColumnDataWidths;
 	auto& minimumColumnWidths = table->getMinimumColumnWidths();
-	ASSERT(minimumColumnWidths.size() == table->getNumColumns(), "Number of minimum column widths does not match number of colums!");
+	ASSERT(minimumColumnWidths.size() == table->getNumColumns(), "Number of minimum column widths does not match number of columns!");
 	for (size_t colIdx = 0; colIdx < table->getNumColumns(); ++colIdx)
 	{
 		int32_t maxIdealContentWidth = table->getColumnMaxContentIdealWidth(colIdx);

--- a/src/wzscriptdebug.cpp
+++ b/src/wzscriptdebug.cpp
@@ -651,7 +651,7 @@ public:
 				powerValue = std::stoi(powerString.toStdString());
 			}
 			catch (const std::exception&) {
-				debug(LOG_ERROR, "Invalid power value (not convertable to an integer - use numbers only): %s", powerString.toUtf8().c_str());
+				debug(LOG_ERROR, "Invalid power value (not convertible to an integer - use numbers only): %s", powerString.toUtf8().c_str());
 				return;
 			}
 			auto selectedPlayerCopy = selectedPlayer;


### PR DESCRIPTION
if anyone wants to have fun, run `codespell` on top of whole codebase. This PR fixes just stuff reported by Debian found in binaries.