### PR TITLE
Tweak to campaign no go areas

### DIFF
--- a/data/base/script/campaign/cam1-5.js
+++ b/data/base/script/campaign/cam1-5.js
@@ -186,7 +186,7 @@ function eventStartLevel()
 	var tent = getObject("TransporterEntry");
 	var text = getObject("TransporterExit");
 	setNoGoArea(lz.x, lz.y, lz.x2, lz.y2, CAM_HUMAN_PLAYER);
-	setNoGoArea(lz2.x, lz2.y, lz2.x2, lz2.y2, NEW_PARADIGM);
+	setNoGoArea(lz2.x, lz2.y, lz2.x2, lz2.y2, 5);
 	startTransporterEntry(tent.x, tent.y, CAM_HUMAN_PLAYER);
 	setTransporterExit(text.x, text.y, CAM_HUMAN_PLAYER);
 

--- a/data/base/script/campaign/cam1a-c.js
+++ b/data/base/script/campaign/cam1a-c.js
@@ -152,7 +152,7 @@ function eventStartLevel()
 	for (let i = 6; i <= 10; ++i)
 	{
 		var ph = getObject("NPLZ" + i);
-		setNoGoArea(ph.x, ph.y, ph.x2, ph.y2, NEW_PARADIGM);
+		setNoGoArea(ph.x, ph.y, ph.x2, ph.y2, i - 4);
 	}
 
 	camCompleteRequiredResearch(NEW_PARADIGM_RES, NEW_PARADIGM);

--- a/data/base/script/campaign/cam1ca.js
+++ b/data/base/script/campaign/cam1ca.js
@@ -158,7 +158,7 @@ function eventStartLevel()
 		var ph = getObject("PhantomLZ" + i);
 		// HACK: set LZs of bad players, namely 2...6,
 		// note: player 1 is NP
-		setNoGoArea(ph.x, ph.y, ph.x2, ph.y2, i + 1);
+		setNoGoArea(ph.x, ph.y, ph.x2, ph.y2, i + 2);
 	}
 
 	setMissionTime(camChangeOnDiff(camMinutesToSeconds(30)));

--- a/data/base/script/campaign/cam2-1x.js
+++ b/data/base/script/campaign/cam2-1x.js
@@ -123,7 +123,7 @@ function eventStartLevel()
 	var tent = getObject("transporterEntry");
 	var text = getObject("transporterExit");
 	centreView(startpos.x, startpos.y);
-	setNoGoArea(subLandingZone.x, subLandingZone.y, subLandingZone.x2, subLandingZone.y2);
+	setNoGoArea(subLandingZone.x, subLandingZone.y, subLandingZone.x2, subLandingZone.y2, CAM_HUMAN_PLAYER);
 	startTransporterEntry(tent.x, tent.y, CAM_HUMAN_PLAYER);
 	setTransporterExit(text.x, text.y, CAM_HUMAN_PLAYER);
 
@@ -140,7 +140,7 @@ function eventStartLevel()
 	camCompleteRequiredResearch(COLLECTIVE_RES, THE_COLLECTIVE);
 	camCompleteRequiredResearch(ALPHA_RESEARCH_NEW, TRANSPORT_TEAM);
 	camCompleteRequiredResearch(PLAYER_RES_BETA, TRANSPORT_TEAM);
-	
+
 	camUpgradeOnMapTemplates(cTempl.commc, cTempl.commrp, THE_COLLECTIVE);
 
 	camSetEnemyBases({

--- a/data/base/script/campaign/cam2-a.js
+++ b/data/base/script/campaign/cam2-a.js
@@ -208,7 +208,7 @@ function cam2Setup()
 	camCompleteRequiredResearch(ALPHA_RESEARCH_NEW, THE_COLLECTIVE);
 	camCompleteRequiredResearch(COLLECTIVE_RES, THE_COLLECTIVE);
 	camCompleteRequiredResearch(ALPHA_RESEARCH_NEW, CAM_HUMAN_PLAYER);
-	
+
 	camUpgradeOnMapTemplates(cTempl.commc, cTempl.commrp, THE_COLLECTIVE);
 
 	enableResearch("R-Wpn-Cannon-Damage04", CAM_HUMAN_PLAYER);
@@ -314,7 +314,7 @@ function eventStartLevel()
 
 	centreView(startpos.x, startpos.y);
 	setNoGoArea(lz.x, lz.y, lz.x2, lz.y2, CAM_HUMAN_PLAYER);
-	setNoGoArea(enemyLz.x, enemyLz.y, enemyLz.x2, enemyLz.y2, THE_COLLECTIVE);
+	setNoGoArea(enemyLz.x, enemyLz.y, enemyLz.x2, enemyLz.y2, 5);
 	startTransporterEntry(tent.x, tent.y, CAM_HUMAN_PLAYER);
 	setTransporterExit(text.x, text.y, CAM_HUMAN_PLAYER);
 

--- a/data/base/script/campaign/cam2-c.js
+++ b/data/base/script/campaign/cam2-c.js
@@ -285,7 +285,7 @@ function eventStartLevel()
 	setNoGoArea(lz.x, lz.y, lz.x2, lz.y2, CAM_HUMAN_PLAYER);
 
 	var enemyLz = getObject("COLandingZone");
-	setNoGoArea(enemyLz.x, enemyLz.y, enemyLz.x2, enemyLz.y2, THE_COLLECTIVE);
+	setNoGoArea(enemyLz.x, enemyLz.y, enemyLz.x2, enemyLz.y2, 5);
 
 	camSetArtifacts({
 		"rippleRocket": { tech: "R-Wpn-Rocket06-IDF" },
@@ -302,7 +302,7 @@ function eventStartLevel()
 	setAlliance(THE_COLLECTIVE, SCAV_7, true);
 	setAlliance(CAM_HUMAN_PLAYER, SCAV_7, true);
 	camCompleteRequiredResearch(COLLECTIVE_RES, THE_COLLECTIVE);
-	
+
 	camUpgradeOnMapTemplates(cTempl.commc, cTempl.commrp, THE_COLLECTIVE);
 
 	camSetEnemyBases({

--- a/data/base/script/campaign/cam3-ad1.js
+++ b/data/base/script/campaign/cam3-ad1.js
@@ -260,7 +260,7 @@ function eventStartLevel()
 
 	centreView(startpos.x, startpos.y);
 	setNoGoArea(lz.x, lz.y, lz.x2, lz.y2, CAM_HUMAN_PLAYER);
-	setNoGoArea(lz2.x, lz2.y, lz2.x2, lz2.y2, CAM_HUMAN_PLAYER);
+	setNoGoArea(lz2.x, lz2.y, lz2.x2, lz2.y2, 5);
 	setNoGoArea(lz2.x, lz2.y, lz2.x2, lz2.y2, NEXUS);
 	setNoGoArea(siloZone.x, siloZone.y, siloZone.x2, siloZone.y2, SILO_PLAYER);
 	setMissionTime(camChangeOnDiff(camHoursToSeconds(2)));

--- a/data/base/script/campaign/libcampaign_includes/transport.js
+++ b/data/base/script/campaign/libcampaign_includes/transport.js
@@ -60,7 +60,7 @@ function __camDispatchTransporterUnsafe()
 		camDebug("Transporter queue empty!");
 		return false;
 	}
-	const OFFSET = 2; //Increaze LZ "no go" zone area a bit
+	const OFFSET = 1; //Increaze LZ "no go" zone area a bit
 	var args = __camTransporterQueue[0];
 	var player = args.player;
 	var pos = args.position;


### PR DESCRIPTION
Libcampaign controlled transporter drops would automatically set a no-go area for the position the transporter is about to land on for the owning player. This isn't really necessary at this time and was resulting in an extra tile of LZ area the player couldn't build on if they started Beta or Gamma from the main menu.

Fixes #2244.