### PR TITLE
show rank for next droid

### DIFF
--- a/src/display3d.cpp
+++ b/src/display3d.cpp
@@ -3935,47 +3935,49 @@ void showRangeAtPos(SDWORD centerX, SDWORD centerY, SDWORD radius)
 		bRangeDisplay = false;
 	}
 }
+UDWORD  getDroidRankGraphicFromLevel(unsigned int level)
+{
+	UDWORD gfxId = UDWORD_MAX;
+	switch (level)
+		{
+		case 0:
+			break;
+		case 1:
+			gfxId = IMAGE_LEV_0;
+			break;
+		case 2:
+			gfxId = IMAGE_LEV_1;
+			break;
+		case 3:
+			gfxId = IMAGE_LEV_2;
+			break;
+		case 4:
+			gfxId = IMAGE_LEV_3;
+			break;
+		case 5:
+			gfxId = IMAGE_LEV_4;
+			break;
+		case 6:
+			gfxId = IMAGE_LEV_5;
+			break;
+		case 7:
+			gfxId = IMAGE_LEV_6;
+			break;
+		case 8:
+			gfxId = IMAGE_LEV_7;
+			break;
+		default:
+			ASSERT(!"out of range droid rank", "Weird droid level in drawDroidRank");
+			break;
+		}
 
+	return gfxId;
+}
 /// Get the graphic ID for a droid rank
 UDWORD  getDroidRankGraphic(DROID *psDroid)
 {
-	UDWORD gfxId = UDWORD_MAX;
-
 	/* Establish the numerical value of the droid's rank */
-	switch (getDroidLevel(psDroid))
-	{
-	case 0:
-		break;
-	case 1:
-		gfxId = IMAGE_LEV_0;
-		break;
-	case 2:
-		gfxId = IMAGE_LEV_1;
-		break;
-	case 3:
-		gfxId = IMAGE_LEV_2;
-		break;
-	case 4:
-		gfxId = IMAGE_LEV_3;
-		break;
-	case 5:
-		gfxId = IMAGE_LEV_4;
-		break;
-	case 6:
-		gfxId = IMAGE_LEV_5;
-		break;
-	case 7:
-		gfxId = IMAGE_LEV_6;
-		break;
-	case 8:
-		gfxId = IMAGE_LEV_7;
-		break;
-	default:
-		ASSERT(!"out of range droid rank", "Weird droid level in drawDroidRank");
-		break;
-	}
-
-	return gfxId;
+	return getDroidRankGraphicFromLevel(getDroidLevel(psDroid));
 }
 
 /**	Will render a graphic depiction of the droid's present rank.

--- a/src/display3d.h
+++ b/src/display3d.h
@@ -125,7 +125,7 @@ extern const Vector2i visibleTiles;
 
 /*returns the graphic ID for a droid rank*/
 UDWORD  getDroidRankGraphic(DROID *psDroid);
-UDWORD  getDroidRankGraphicFromLevel(unsigned);
+UDWORD  getDroidRankGraphicFromLevel(unsigned int level);
 
 void setSkyBox(const char *page, float mywind, float myscale);
 

--- a/src/display3d.h
+++ b/src/display3d.h
@@ -125,6 +125,7 @@ extern const Vector2i visibleTiles;
 
 /*returns the graphic ID for a droid rank*/
 UDWORD  getDroidRankGraphic(DROID *psDroid);
+UDWORD  getDroidRankGraphicFromLevel(unsigned);
 
 void setSkyBox(const char *page, float mywind, float myscale);
 

--- a/src/droid.h
+++ b/src/droid.h
@@ -62,6 +62,7 @@ enum PICKTILE
 extern DROID	*psLastDroidHit;
 
 std::priority_queue<int> copy_experience_queue(int player);
+int getTopExperience(int player);
 void add_to_experience_queue(int player, int value);
 
 // initialise droid module
@@ -183,6 +184,7 @@ bool calcDroidMuzzleBaseLocation(const DROID *psDroid, Vector3i *muzzle, int wea
 
 /* Droid experience stuff */
 unsigned int getDroidLevel(const DROID *psDroid);
+unsigned int getDroidLevel(unsigned int experience, uint8_t player, uint8_t brainComponent);
 UDWORD getDroidEffectiveLevel(const DROID *psDroid);
 const char *getDroidLevelName(const DROID *psDroid);
 

--- a/src/hci/manufacture.cpp
+++ b/src/hci/manufacture.cpp
@@ -312,7 +312,7 @@ protected:
 	void drawNextDroidRank(int xOffset, int yOffset)
 	{
 		const auto factory = controller->getObjectAt(objectIndex);
-		if (!factory) 
+		if (!factory)
 		{
 			return;
 		}
@@ -337,15 +337,15 @@ protected:
 		{
 			lvl = 0;
 		}
-		else 
+		else
 		{
 			lvl = getDroidLevel(exp, player, nullBrainComponent);
 		}
 		const auto expgfx = getDroidRankGraphicFromLevel(lvl);
 		if (expgfx != UDWORD_MAX)
 		{
-   		// FIXME: use offsets relative to template positon, not hardcoded values ?
-   		iV_DrawImage(IntImages, (UWORD)expgfx, xOffset + 45, yOffset + 4);	
+			// FIXME: use offsets relative to template positon, not hardcoded values ?
+			iV_DrawImage(IntImages, (UWORD)expgfx, xOffset + 45, yOffset + 4);	
 		}
 	}
 

--- a/src/hci/manufacture.cpp
+++ b/src/hci/manufacture.cpp
@@ -328,6 +328,15 @@ protected:
 		{
 			lvl = getDroidLevel(exp, player, commandBrainComponent);
 		}
+		else if (factory->pFunctionality->factory.psSubject->droidType == DROID_CONSTRUCT
+		|| factory->pFunctionality->factory.psSubject->droidType == DROID_CYBORG_CONSTRUCT
+		|| factory->pFunctionality->factory.psSubject->droidType == DROID_CYBORG_REPAIR
+		|| factory->pFunctionality->factory.psSubject->droidType == DROID_REPAIR
+		|| factory->pFunctionality->factory.psSubject->droidType == DROID_TRANSPORTER
+		|| factory->pFunctionality->factory.psSubject->droidType == DROID_SUPERTRANSPORTER)
+		{
+			lvl = 0;
+		}
 		else 
 		{
 			lvl = getDroidLevel(exp, player, nullBrainComponent);
@@ -335,7 +344,7 @@ protected:
 		const auto expgfx = getDroidRankGraphicFromLevel(lvl);
 		if (expgfx != UDWORD_MAX)
 		{
-			// FIXME: use offsets relative to template positon, not hardcoded values ?
+   		// FIXME: use offsets relative to template positon, not hardcoded values ?
    		iV_DrawImage(IntImages, (UWORD)expgfx, xOffset + 45, yOffset + 4);	
 		}
 	}

--- a/src/hci/manufacture.cpp
+++ b/src/hci/manufacture.cpp
@@ -312,6 +312,10 @@ protected:
 	void drawNextDroidRank(int xOffset, int yOffset)
 	{
 		const auto factory = controller->getObjectAt(objectIndex);
+		if (!factory) 
+		{
+			return;
+		}
 		const auto player = factory->player;
 		const auto exp = getTopExperience(player);
 		unsigned int lvl = 0;


### PR DESCRIPTION
Show the icon for the next droid.
Some UI bike-shedding:
- should it be shown when nothing is being built? If it's not, then I have to start building something to know what rank it will be. If it is, then it's kinda awkard showing a rank icon over an empty queue
![empty-queue-icon](https://user-images.githubusercontent.com/25161465/172046610-62512842-64e2-4660-bb1d-91156a8464e1.png)

![image](https://user-images.githubusercontent.com/25161465/172046694-d4022c33-4ca2-4c11-943c-f39d007edec6.png)
