### PR TITLE
Make sliders look like more than 2 rectangles

### DIFF
--- a/lib/widget/scrollbar.cpp
+++ b/lib/widget/scrollbar.cpp
@@ -24,6 +24,7 @@
 #include <memory>
 #include "scrollbar.h"
 #include "lib/ivis_opengl/pieblitfunc.h"
+#include "src/intimage.h"
 
 static void displayScrollBar(WIDGET *widget, UDWORD xOffset, UDWORD yOffset)
 {
@@ -32,10 +33,11 @@ static void displayScrollBar(WIDGET *widget, UDWORD xOffset, UDWORD yOffset)
 	int x0 = slider->x() + xOffset;
 	int y0 = slider->y() + yOffset;
 
-	pie_UniTransBoxFill(x0, y0, x0 + slider->width(), y0 + slider->height(), WZCOL_DBLUE);
+	RenderWindowFrame(FRAME_NORMAL, x0, y0, slider->width(), slider->height());
+	// pie_UniTransBoxFill(x0, y0, x0 + slider->width(), y0 + slider->height(), WZCOL_DBLUE);
 
 	auto sliderY = slider->numStops > 0 ? (slider->height() - slider->barSize) * slider->pos / slider->numStops: 0;
-	pie_UniTransBoxFill(x0, y0 + sliderY, x0 + slider->width(), y0 + sliderY + slider->barSize, slider->isEnabled() ? WZCOL_LBLUE : WZCOL_FORM_DISABLE);
+	pie_UniTransBoxFill(x0+2, y0 + sliderY+2, x0 + slider->width()-2, y0 + sliderY + slider->barSize-2, slider->isEnabled() ? WZCOL_LBLUE : WZCOL_FORM_DISABLE);
 }
 
 void ScrollBarWidget::initialize()


### PR DESCRIPTION
Was it that hard to do?

Potentially this should be done with sprites that we have in UI textures but why not use a box that we have for main menu?

| Before | After |
| ----- | ---- |
| ![image](https://user-images.githubusercontent.com/20772987/175604380-7aee71d9-143a-4917-a9ce-295b0ed94932.png) ![image](https://user-images.githubusercontent.com/20772987/175604846-f926b3bc-b165-417b-8cee-ad03f94117e7.png) | ![image](https://user-images.githubusercontent.com/20772987/175603863-8b5d45f0-db67-4cb4-86d8-fb9d43eb2f74.png) ![image](https://user-images.githubusercontent.com/20772987/175604648-d08a0e30-6f40-4ab7-8ba7-e5e00017616e.png) |

Something also has to be done to improve dropdowns, those are literal rectangles right now too.