### PR TITLE
Improve default suggestion save names

### DIFF
--- a/src/loadsave.cpp
+++ b/src/loadsave.cpp
@@ -746,15 +746,7 @@ static WzString suggestSaveName(const char *saveGamePath)
 	}
 	else
 	{
-		int humanPlayers = 0;
-		for (int i = 0; i < MAX_PLAYERS; i++)
-		{
-			if (isHumanPlayer(i))
-			{
-				humanPlayers++;
-			}
-		}
-		ssprintf(saveNamePartial, "%s %dp %s", mapNameWithoutTechlevel(levelNameStr.c_str()).c_str(), humanPlayers, cheatedSuffix.c_str());
+		ssprintf(saveNamePartial, "%s %s", mapNameWithoutTechlevel(levelNameStr.c_str()).c_str(), cheatedSuffix.c_str());
 	}
 
 	WzString saveName = WzString(saveNamePartial).trimmed();

--- a/src/loadsave.cpp
+++ b/src/loadsave.cpp
@@ -683,7 +683,7 @@ static WzString suggestSaveName(const char *saveGamePath)
 	const std::string cheatedSuffix = Cheated ? _("cheated") : "";
 	char saveNamePartial[64] = "\0";
 
-	if (bLoadSaveMode == SAVE_MISSIONEND || bLoadSaveMode == SAVE_INGAME_MISSION)
+	if (!bMultiPlayer)
 	{
 		std::string campaignName;
 		std::string missionName = levelName.toStdString();
@@ -744,7 +744,7 @@ static WzString suggestSaveName(const char *saveGamePath)
 
 		ssprintf(saveNamePartial, "%s %s %s", campaignName.c_str(), missionName.c_str(), cheatedSuffix.c_str());
 	}
-	else if (bLoadSaveMode == SAVE_INGAME_SKIRMISH)
+	else
 	{
 		int humanPlayers = 0;
 		for (int i = 0; i < MAX_PLAYERS; i++)
@@ -754,7 +754,7 @@ static WzString suggestSaveName(const char *saveGamePath)
 				humanPlayers++;
 			}
 		}
-		ssprintf(saveNamePartial, "%s %dp %s", levelName.toStdString().c_str(), humanPlayers, cheatedSuffix.c_str());
+		ssprintf(saveNamePartial, "%s %dp %s", mapNameWithoutTechlevel(levelNameStr.c_str()).c_str(), humanPlayers, cheatedSuffix.c_str());
 	}
 
 	WzString saveName = WzString(saveNamePartial).trimmed();
@@ -1144,9 +1144,9 @@ bool autoSave()
 	char savedate[PATH_MAX];
 	strftime(savedate, sizeof(savedate), "%F_%H%M%S", &timeinfo);
 
-	std::string withoutTechlevel = mapNameWithoutTechlevel(getLevelName());
+	std::string suggestedName = suggestSaveName(dir).toStdString();
 	char savefile[PATH_MAX];
-	snprintf(savefile, sizeof(savefile), "%s/%s_%s.gam", dir, withoutTechlevel.c_str(), savedate);
+	snprintf(savefile, sizeof(savefile), "%s/%s_%s.gam", dir, suggestedName.c_str(), savedate);
 	if (saveGame(savefile, GTYPE_SAVE_MIDMISSION))
 	{
 		console(_("AutoSave %s"), savegameWithoutExtension(savefile));

--- a/src/loadsave.cpp
+++ b/src/loadsave.cpp
@@ -679,26 +679,70 @@ bool findLastSave()
 static WzString suggestSaveName(const char *saveGamePath)
 {
 	const WzString levelName = getLevelName();
+	const std::string levelNameStr = levelName.toStdString();
 	const std::string cheatedSuffix = Cheated ? _("cheated") : "";
 	char saveNamePartial[64] = "\0";
 
 	if (bLoadSaveMode == SAVE_MISSIONEND || bLoadSaveMode == SAVE_INGAME_MISSION)
 	{
 		std::string campaignName;
+		std::string missionName = levelName.toStdString();
+		std::string endName = "End"; //last mission for one the campaigns
+		std::vector<std::string> levelNames = {};
+
 		if (levelName.startsWith("CAM_1") || levelName.startsWith("SUB_1"))
 		{
 			campaignName = "Alpha";
+			levelNames = {
+				"CAM_1A", "CAM_1B", "SUB_1_1", "SUB_1_2", "SUB_1_3", "CAM_1C",
+				"CAM_1CA", "SUB_1_4A", "SUB_1_5", "CAM_1A-C", "SUB_1_7", "SUB_1_D", "CAM_1END"
+			};
 		}
 		else if (levelName.startsWith("CAM_2") || levelName.startsWith("SUB_2"))
 		{
 			campaignName = "Beta";
+			levelNames = {
+				"CAM_2A", "SUB_2_1", "CAM_2B", "SUB_2_2", "CAM_2C", "SUB_2_5",
+				"SUB_2D", "SUB_2_6", "SUB_2_7", "SUB_2_8", "CAM_2END"
+			};
 		}
-		else if (levelName.startsWith("CAM_3") || levelName.startsWith("SUB_3"))
+		else if (levelName.startsWith("CAM_3") || levelName.startsWith("CAM3") || levelName.startsWith("SUB_3"))
 		{
 			campaignName = "Gamma";
+			levelNames = {
+				"CAM_3A", "SUB_3_1", "CAM_3B", "SUB_3_2", "CAM3A-B",
+				"CAM3C", "CAM3A-D1", "CAM3A-D2", "CAM_3_4"
+			};
 		}
-		ssprintf(saveNamePartial, "%s %s %s", campaignName.c_str(), levelName.toStdString().c_str(),
-				 cheatedSuffix.c_str());
+
+		for (size_t i = 0; i < levelNames.size(); ++i)
+		{
+			std::string fullMapName = levelNames[i];
+			if (levelNameStr.find(fullMapName) != std::string::npos)
+			{
+				bool endsWithS = levelNameStr[levelNameStr.length() - 1] == 'S';
+				if (!endsWithS && (levelNameStr.compare(fullMapName) != 0))
+				{
+					continue;
+				}
+				missionName = std::to_string(i + 1);
+				if ((i + 1) == levelNames.size())
+				{
+					missionName = endName;
+				}
+				if ((missionName.compare(endName) == 0) && !levelName.startsWith("CAM_3")) //Gamma end is an exception
+				{
+					break;
+				}
+				if (endsWithS)
+				{
+					missionName += " Base"; // The Project's base for the campaign map.
+				}
+				break;
+			}
+		}
+
+		ssprintf(saveNamePartial, "%s %s %s", campaignName.c_str(), missionName.c_str(), cheatedSuffix.c_str());
 	}
 	else if (bLoadSaveMode == SAVE_INGAME_SKIRMISH)
 	{


### PR DESCRIPTION
Assuming I didn't mess something up, this seems to work now. Someone else should help test this...

No more campaign map names anymore as the suggestion, now it will show them in this form:

```
Alpha 1
Alpha 4 Base
Alpha 4
Beta 7
Beta 8 Base
Beta End
Gamma 2
Gamma End Base
Gamma End
...
```
- `Base` signifies a pre-away mission, `End` for the final mission.
- Gamma 5, 6, 7, and 8 now have their Gamma prefix as they should.
- Skirmish no longer saves the amount of human players into the name (which is always 1).
- Autosave names reflect this simple form too.


There is still one issue I found many releases ago I didn't fix, and is outside the scope of this PR. If a very clever person games the system, like making a save named `Alpha 1 3` before the suggestion would get to it, the suggestion will attempt that same name and you'll have to manually enter something else.