### PR TITLE
(MP)HVC ROF Rollback

### DIFF
--- a/data/mp/stats/weapons.json
+++ b/data/mp/stats/weapons.json
@@ -1272,7 +1272,7 @@
 		"effectSize": 25,
 		"explosionWav": "smlexpl.ogg",
 		"facePlayer": 1,
-		"firePause": 36,
+		"firePause": 40,
 		"flags": "ShootAir",
 		"flightGfx": "FXTracer.PIE",
 		"flightSpeed": 2250,


### PR DESCRIPTION
Created at the request of ★Evolution★
According to his feedback my manipulations with HVC last year did not give the proper result, so I suggest to do a rollback ROF for HVC Super Cyborg. If this is not enough in the future I will make rollback and for HVC turrets.