### PR TITLE
Command Relay Post research message update

### DIFF
--- a/data/base/messages/resmessages1.json
+++ b/data/base/messages/resmessages1.json
@@ -258,7 +258,7 @@
 		"sequenceName": "res_struttech.ogg",
 		"text": [
 			"New Base Structure Available",
-			"Must be build to produce commanders",
+			"Must be built to produce commanders",
 			"Directs and collates information for command turrets",
 			"Controls up to ten commanders"
 		]

--- a/data/base/messages/resmessages1.json
+++ b/data/base/messages/resmessages1.json
@@ -258,7 +258,7 @@
 		"sequenceName": "res_struttech.ogg",
 		"text": [
 			"New Base Structure Available",
-			"Enables command turret research",
+			"Must be build to produce commanders",
 			"Directs and collates information for command turrets",
 			"Controls up to ten commanders"
 		]

--- a/data/mp/messages/resmessages1.json
+++ b/data/mp/messages/resmessages1.json
@@ -258,7 +258,7 @@
 		"sequenceName": "res_struttech.ogg",
 		"text": [
 			"New Base Structure Available",
-			"Enables command turret research",
+			"Must be built to produce commanders",
 			"Directs and collates information for command turrets",
 			"Controls up to ten commanders"
 		]


### PR DESCRIPTION
It's no longer necessary to build the Command Relay Post to research the Command Turret artifact but to build commanders in a factory. Therefore the research message is changed.