### PR TITLE
Assert fix

### DIFF
--- a/src/loadsave.cpp
+++ b/src/loadsave.cpp
@@ -779,7 +779,7 @@ bool runLoadSave(bool bResetMissionWidgets)
 		return true;
 	}
 	NewSaveGamePath = getNewSaveGamePathFromMode(bLoadSaveMode);
-	if (id == LOADENTRY_START && modeLoad) // [auto] or [..], ignore click for saves
+	if (id == LOADENTRY_START && modeLoad && !modeReplay) // [auto] or [..], ignore click for saves
 	{
 		int iLoadSaveMode = (int)bLoadSaveMode; // for evil integer arithmetics
 		bLoadSaveMode = (enum LOADSAVE_MODE)(iLoadSaveMode ^ 16); // toggle _AUTO bit

--- a/src/multiint.cpp
+++ b/src/multiint.cpp
@@ -8397,7 +8397,7 @@ bool WZGameReplayOptionsHandler::restoreOptions(const nlohmann::json& object, Em
 	size_t replaySpectatorIndex = NetPlay.players.size() - 1;
 	NET_InitPlayer(replaySpectatorIndex, false);  // re-init everything
 	NetPlay.players[replaySpectatorIndex].allocated = true;
-	setPlayerName(replaySpectatorIndex, "Replay Viewer");
+	sstrcpy(NetPlay.players[replaySpectatorIndex].name, "Replay Viewer"); //setPlayerName() asserts cause this index is now equal to MAX_CONNECTED_PLAYERS
 	NetPlay.players[replaySpectatorIndex].isSpectator = true;
 
 	selectedPlayer = replaySpectatorIndex;


### PR DESCRIPTION
Fixes a harmless assert triggered from setPlayerName() after #1983 since the replay viewer index is now equal to MAX_CONNECTED_PLAYERS. We don't get to see that name anyway.

Also adds a drive-by commit for disabling the [auto] button when in a replay load menu.