### PR TITLE
[Cirrus CI] Tweak dependency packages

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -15,7 +15,7 @@ freebsd_build_task:
   install_script:
     - pkg update -f
     - pkg clean -a -y
-    - pkg install -y git cmake ninja p7zip gettext pkgconf png sdl2 openal-soft physfs libvorbis libogg opus libtheora freetype2 fribidi harfbuzz curl libsodium sqlite3 rubygem-asciidoctor
+    - pkg install -y git cmake ninja 7-zip gettext pkgconf png sdl2 openal-soft physfs libvorbis libogg opus libtheora freetype2 fribidi harfbuzz curl libsodium sqlite3 rubygem-asciidoctor
 
   init_git_submodules_script: git submodule update --init --recursive
 


### PR DESCRIPTION
FreeBSD's `p7zip` package is now deprecated / removed, and `7-zip` should be used instead.