### PR TITLE
produce into groups

### DIFF
--- a/src/basedef.h
+++ b/src/basedef.h
@@ -112,7 +112,7 @@ struct BASE_OBJECT : public SIMPLE_OBJECT
 	~BASE_OBJECT();
 
 	SCREEN_DISP_DATA    sDisplay;                   ///< screen coordinate details
-	UBYTE               group = 0;                  ///< Which group selection is the droid currently in?
+	UBYTE               group = UBYTE_MAX;          ///< Which group selection is the droid currently in?
 	UBYTE               selected;                   ///< Whether the object is selected (might want this elsewhere)
 	UBYTE               visible[MAX_PLAYERS];       ///< Whether object is visible to specific player
 	UBYTE               seenThisTick[MAX_PLAYERS];  ///< Whether object has been seen this tick by the specific player.

--- a/src/display3d.cpp
+++ b/src/display3d.cpp
@@ -94,7 +94,7 @@ static void displayDynamicObjects(const glm::mat4 &viewMatrix, const glm::mat4 &
 static void displayStaticObjects(const glm::mat4 &viewMatrix, const glm::mat4 &perspectiveViewMatrix);
 static void displayFeatures(const glm::mat4 &viewMatrix, const glm::mat4 &perspectiveViewMatrix);
 static UDWORD	getTargettingGfx();
-static void	drawDroidGroupNumber(DROID *psDroid);
+static void	drawDroidGroupNumber(const DROID *psDroid);
 static void	trackHeight(int desiredHeight);
 static void	renderSurroundings(const glm::mat4 &viewMatrix);
 static void	locateMouse();
@@ -3286,12 +3286,12 @@ static void	drawDroidSelections()
 /* ---------------------------------------------------------------------------- */
 /// X offset to display the group number at
 #define GN_X_OFFSET	(8)
-/// Draw the number of the group the droid is in next to the droid
-static void	drawDroidGroupNumber(DROID *psDroid)
+
+UWORD droidGroupNumberToImageId (UDWORD groupNum)
 {
 	UWORD id = UWORD_MAX;
 
-	switch (psDroid->group)
+	switch (groupNum)
 	{
 	case 0:
 		id = IMAGE_GN_0;
@@ -3326,7 +3326,13 @@ static void	drawDroidGroupNumber(DROID *psDroid)
 	default:
 		break;
 	}
+	return id;
+}
 
+/// Draw the number of the group the droid is in next to the droid
+static void	drawDroidGroupNumber(const DROID *psDroid)
+{
+	UWORD id = droidGroupNumberToImageId(psDroid->group);
 	if (id != UWORD_MAX)
 	{
 		int xShift = psDroid->sDisplay.screenR + GN_X_OFFSET;
@@ -3974,7 +3980,7 @@ UDWORD  getDroidRankGraphicFromLevel(unsigned int level)
 	return gfxId;
 }
 /// Get the graphic ID for a droid rank
-UDWORD  getDroidRankGraphic(DROID *psDroid)
+UDWORD  getDroidRankGraphic(const DROID *psDroid)
 {
 	/* Establish the numerical value of the droid's rank */
 	return getDroidRankGraphicFromLevel(getDroidLevel(psDroid));

--- a/src/display3d.h
+++ b/src/display3d.h
@@ -124,8 +124,9 @@ extern bool showPath;
 extern const Vector2i visibleTiles;
 
 /*returns the graphic ID for a droid rank*/
-UDWORD  getDroidRankGraphic(DROID *psDroid);
+UDWORD  getDroidRankGraphic(const DROID *psDroid);
 UDWORD  getDroidRankGraphicFromLevel(unsigned int level);
+UWORD droidGroupNumberToImageId (UDWORD groupNum);
 
 void setSkyBox(const char *page, float mywind, float myscale);
 

--- a/src/hci/manufacture.cpp
+++ b/src/hci/manufacture.cpp
@@ -199,11 +199,15 @@ public:
 	void drawFactoryGroup(int xOffset, int yOffset)
 	{
 		const auto factory = controller->getObjectAt(objectIndex);
-		UWORD groupNumImage = droidGroupNumberToImageId(factory->group);
-		if (groupNumImage != UWORD_MAX)
+		if (factory)
 		{
-			iV_DrawImage(IntImages, groupNumImage, xOffset , yOffset );
+			UWORD groupNumImage = droidGroupNumberToImageId(factory->group);
+			if (groupNumImage != UWORD_MAX)
+			{
+				iV_DrawImage(IntImages, groupNumImage, xOffset , yOffset );
+			}
 		}
+
 	}
 	void jump() override
 	{

--- a/src/hci/manufacture.cpp
+++ b/src/hci/manufacture.cpp
@@ -165,6 +165,47 @@ void ManufactureController::clearData()
 	stats.clear();
 }
 
+UWORD groupNumImage (UDWORD groupNum)
+{
+	UWORD id = UWORD_MAX;
+	switch (groupNum)
+	{
+	case 0:
+		id = IMAGE_0;
+		break;
+	case 1:
+		id = IMAGE_1;
+		break;
+	case 2:
+		id = IMAGE_2;
+		break;
+	case 3:
+		id = IMAGE_3;
+		break;
+	case 4:
+		id = IMAGE_4;
+		break;
+	case 5:
+		id = IMAGE_5;
+		break;
+	case 6:
+		id = IMAGE_GN_6;
+		break;
+	case 7:
+		id = IMAGE_GN_7;
+		break;
+	case 8:
+		id = IMAGE_GN_8;
+		break;
+	case 9:
+		id = IMAGE_GN_9;
+		break;
+	default:
+		break;
+	}
+	return id;
+}
+
 void ManufactureController::setHighlightedObject(BASE_OBJECT *object)
 {
 	if (object == nullptr)
@@ -201,10 +242,10 @@ public:
 		const auto factory = controller->getObjectAt(objectIndex);
 		if (factory)
 		{
-			UWORD groupNumImage = droidGroupNumberToImageId(factory->group);
-			if (groupNumImage != UWORD_MAX)
+			UWORD img = groupNumImage(factory->group);
+			if (img != UWORD_MAX)
 			{
-				iV_DrawImage(IntImages, groupNumImage, xOffset , yOffset );
+				iV_DrawImage(IntImages, img, xOffset , yOffset );
 			}
 		}
 

--- a/src/hci/manufacture.cpp
+++ b/src/hci/manufacture.cpp
@@ -196,7 +196,15 @@ public:
 		widget->initialize();
 		return widget;
 	}
-
+	void drawFactoryGroup(int xOffset, int yOffset)
+	{
+		const auto factory = controller->getObjectAt(objectIndex);
+		UWORD groupNumImage = droidGroupNumberToImageId(factory->group);
+		if (groupNumImage != UWORD_MAX)
+		{
+			iV_DrawImage(IntImages, groupNumImage, xOffset , yOffset );
+		}
+	}
 	void jump() override
 	{
 		if (!offWorldKeepLists)
@@ -234,6 +242,7 @@ protected:
 		}
 		displayIMD(AtlasImage(), ImdObject::Structure(factory), xOffset, yOffset);
 		displayIfHighlight(xOffset, yOffset);
+		drawFactoryGroup(xOffset+45, yOffset+55);
 	}
 
 	void updateLayout() override
@@ -306,7 +315,6 @@ protected:
 		}
 		drawNextDroidRank(xOffset, yOffset);
 	}
-
 	// show a little icon on the bottom, indicating what rank next unit will be
 	// remember that when it's a commander, same rank will require twice experience
 	void drawNextDroidRank(int xOffset, int yOffset)

--- a/src/keybind.cpp
+++ b/src/keybind.cpp
@@ -1135,7 +1135,8 @@ MappableFunction kf_AssignGrouping_N(const unsigned int n)
 		/* not supported if a spectator */
 		SPECTATOR_NO_OP();
 
-		assignDroidsToGroup(selectedPlayer, n, true);
+		int selected = assignFactoryToGroup(selectedPlayer, n);
+		if (selected == 0) assignDroidsToGroup(selectedPlayer, n, true);
 	};
 }
 
@@ -1145,7 +1146,8 @@ MappableFunction kf_AddGrouping_N(const unsigned int n)
 		/* not supported if a spectator */
 		SPECTATOR_NO_OP();
 
-		assignDroidsToGroup(selectedPlayer, n, false);
+		int selected = assignFactoryToGroup(selectedPlayer, n);
+		if (selected == 0) assignDroidsToGroup(selectedPlayer, n, false);
 	};
 }
 

--- a/src/order.cpp
+++ b/src/order.cpp
@@ -1169,6 +1169,7 @@ static void orderCmdGroupBase(DROID_GROUP *psGroup, DROID_ORDER_DATA *psData)
 				{
 					// sensors must observe, not attack
 					auto observeOrder = DroidOrder(DORDER_OBSERVE, psData->psObj);
+					debug(LOG_INFO, "group order: %i", psCurr->id);
 					orderDroidBase(psCurr, &observeOrder);
 				}
 				else
@@ -1185,6 +1186,9 @@ static void orderCmdGroupBase(DROID_GROUP *psGroup, DROID_ORDER_DATA *psData)
 						}
 					}
 				}
+			} else
+			{
+				debug(LOG_INFO, "ignoring order, because %i currently RTR", psCurr->id);
 			}
 		}
 	}

--- a/src/structure.h
+++ b/src/structure.h
@@ -188,6 +188,9 @@ void checkForPowerGen(STRUCTURE *psPowerGen);
 
 uint16_t countPlayerUnusedDerricks();
 
+// Assign all production from this factory a group number.
+int assignFactoryToGroup(UDWORD player, UBYTE groupNumber);
+
 // Set the command droid that factory production should go to struct _command_droid;
 void assignFactoryCommandDroid(STRUCTURE *psStruct, struct DROID *psCommander);
 


### PR DESCRIPTION
Implements https://github.com/Warzone2100/warzone2100/issues/2787

Hold "LEFT CTRL" + number when a factory is selected will assign a Group to that factory. All produced units from that factory will be automatically added into the Group.
Re-clicking "left ctrl + number" will un-assign it.  This is independent from units group assignement (un-assigning a factory number *5*" will *not* destroy group number *5*)

![unknown](https://user-images.githubusercontent.com/25161465/183650098-20aea5b0-3c8d-47c6-a46e-d9aaa611f161.png)

