### PR TITLE
backtrace: show demangled function names in debug builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -159,6 +159,8 @@ if("${CMAKE_CXX_COMPILER_ID}" MATCHES "MSVC")
 elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU|Clang" AND NOT APPLE)
 	# Ensure all builds always have debug info built (Xcode is handled separately below)
 	set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -g")
+	# Ensure symbols can be demangled on Linux Debug builds
+	set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -rdynamic")
 endif()
 if(MINGW AND ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang"))
 	# Ensure LLVM/Clang-based MINGW produces debug info in codeview format (for PDB)


### PR DESCRIPTION
obtain human readable names:
```
terrain |19:12:55: [BT:0] loadTerrainTypeMapOverride(MAP_TILESET)
terrain |19:12:55: [BT:0] mapLoadFromWzMapData(std::shared_ptr<WzMap::MapData>)
terrain |19:12:55: [BT:0] loadGame(char const*, bool, bool, bool)
terrain |19:12:55: [BT:0] startMission(LEVEL_TYPE, char*)
terrain |19:12:55: [BT:0] levLoadData(char const*, Sha256 const*, char*, GAME_TYPE)
```