### PR TITLE
Fix type of the wrecked tanker feature

### DIFF
--- a/data/base/stats/features.json
+++ b/data/base/stats/features.json
@@ -946,7 +946,7 @@
 		"name": "Wrecked Tanker",
 		"startVisible": 0,
 		"tileDraw": 1,
-		"type": "TANK WRECK",
+		"type": "VEHICLE",
 		"width": 1
 	},
 	"WreckedVertCampVan": {


### PR DESCRIPTION
Should be vehicle so now it will cast a shadow.