### PR TITLE
animation.cpp: Prevent (potentially endless) "over-shooting" in ValueTracker

### DIFF
--- a/src/animation.cpp
+++ b/src/animation.cpp
@@ -77,7 +77,22 @@ ValueTracker* ValueTracker::update()
 		return this;
 	}
 
-	this->current = (this->initial + this->targetDelta - this->current) * realTimeAdjustedIncrement(this->speed) + this->current;
+	auto deltaRemaining = (this->initial + this->targetDelta - this->current);
+	auto adjustedChange = deltaRemaining * realTimeAdjustedIncrement(this->speed);
+
+	// prevent "over-shooting" / rubber-banding
+	if (deltaRemaining >= 0.f && adjustedChange > deltaRemaining)
+	{
+		adjustedChange = deltaRemaining;
+		this->_reachedTarget = true;
+	}
+	else if (deltaRemaining < 0.f && adjustedChange < deltaRemaining)
+	{
+		adjustedChange = deltaRemaining;
+		this->_reachedTarget = true;
+	}
+
+	this->current = adjustedChange + this->current;
 	return this;
 }
 int ValueTracker::getCurrent()


### PR DESCRIPTION
Which can occur on low performance systems, or in certain other situations.

This could affect things like placing blueprints, rotating the camera, etc.

NOTE: This does *not* fully fix issue 1578, but should eliminate ValueTracker as the underlying cause / exacerbating factor. (There still seem to be some edge cases with how `sBuildDetails` values are set, presumably in `edit3d.cpp`?)

---

If you want to simulate the prior issue that can occur on low performance systems (and the difference this PR makes), add `usleep`:
```diff
  unsigned before = wzGetTicks();
  GAMECODE renderReturn = renderLoop();
  pie_ScreenFrameRenderEnd(); // must happen here for proper renderBudget calculation
+ usleep(100000);
  unsigned after = wzGetTicks();
```
After `pie_ScreenFrameRenderEnd()` in `gameLoop()`: https://github.com/Warzone2100/warzone2100/blob/5b9044a3f5fc98e857da540aece3289d7e60f931/src/loop.cpp#L684

Then load Alpha-1, and try moving the mouse around rapidly when placing a structure on the left side of the starting screen.