### PR TITLE
Autorating tweaks 2

### DIFF
--- a/src/configuration.cpp
+++ b/src/configuration.cpp
@@ -385,7 +385,7 @@ bool loadConfig()
 	radarRotationArrow = iniGetBool("radarRotationArrow", true).value();
 	hostQuitConfirmation = iniGetBool("hostQuitConfirmation", true).value();
 	war_SetPauseOnFocusLoss(iniGetBool("PauseOnFocusLoss", false).value());
-	setAutoratingUrl(iniGetString("autoratingUrl", WZ_DEFAULT_PUBLIC_RATING_LOOKUP_SERVICE_URL).value());
+	setAutoratingUrl(iniGetString("autoratingUrlV2", WZ_DEFAULT_PUBLIC_RATING_LOOKUP_SERVICE_URL).value());
 	setAutoratingEnable(iniGetBool("autorating", false).value());
 	NETsetMasterserverName(iniGetString("masterserver_name", "lobby.wz2100.net").value().c_str());
 	mpSetServerName(iniGetString("server_name", "").value().c_str());
@@ -634,7 +634,7 @@ bool saveConfig()
 	iniSetBool("radarRotationArrow", radarRotationArrow);
 	iniSetBool("hostQuitConfirmation", hostQuitConfirmation);
 	iniSetBool("PauseOnFocusLoss", war_GetPauseOnFocusLoss());
-	iniSetString("autoratingUrl", getAutoratingUrl());
+	iniSetString("autoratingUrlV2", getAutoratingUrl());
 	iniSetBool("autorating", getAutoratingEnable());
 	iniSetString("masterserver_name", NETgetMasterserverName());
 	iniSetInteger("masterserver_port", (int)NETgetMasterserverPort());

--- a/src/multiint.cpp
+++ b/src/multiint.cpp
@@ -4214,7 +4214,12 @@ public:
 				{
 					playerInfoTooltip += "\n";
 				}
-				playerInfoTooltip += std::string(_("Rating information: ")) + "\n" + stats.autorating.details + "\n";
+				std::string detailsstr = stats.autorating.details;
+				if (detailsstr.size() > 512)
+				{
+					detailsstr = detailsstr.substr(0, 512);
+				}
+				playerInfoTooltip += std::string(_("Rating information: ")) + "\n" + detailsstr + "\n";
 				if (stats.autoratingFrom == RATING_SOURCE_HOST && !NetPlay.isHost)
 				{
 					playerInfoTooltip += _("(Host provided)");

--- a/src/multiint.cpp
+++ b/src/multiint.cpp
@@ -4230,7 +4230,8 @@ public:
 				playerInfoTooltip += _("Player ID: ");
 				playerInfoTooltip += hash.empty()? _("(none)") : hash;
 			}
-			if (stats.autorating.valid && stats.autorating.details != "")
+			if (stats.autorating.valid && !stats.autorating.details.empty()
+				&& !(stats.autoratingFrom == RATING_SOURCE_HOST && !NetPlay.isHost)) // do not display host-provided details (for now)
 			{
 				if (!playerInfoTooltip.empty())
 				{

--- a/src/multiint.cpp
+++ b/src/multiint.cpp
@@ -4214,9 +4214,15 @@ public:
 				{
 					playerInfoTooltip += "\n";
 				}
-				playerInfoTooltip += _("Rating information: ");
-				playerInfoTooltip += "\n";
-				playerInfoTooltip += stats.autorating.details;
+				playerInfoTooltip += std::string(_("Rating information: ")) + "\n" + stats.autorating.details + "\n";
+				if (stats.autoratingFrom == RATING_SOURCE_HOST && !NetPlay.isHost)
+				{
+					playerInfoTooltip += _("(Host provided)");
+				}
+				else
+				{
+					playerInfoTooltip += _("Rating information from: ") + getAutoratingUrl();
+				}
 			}
 		}
 		playerInfo->setTip(playerInfoTooltip);

--- a/src/multiint.cpp
+++ b/src/multiint.cpp
@@ -4212,22 +4212,23 @@ public:
 			{
 				if (!playerInfoTooltip.empty())
 				{
-					playerInfoTooltip += "\n";
+					playerInfoTooltip += "\n\n";
 				}
 				std::string detailsstr = stats.autorating.details;
 				if (detailsstr.size() > 512)
 				{
 					detailsstr = detailsstr.substr(0, 512);
 				}
-				playerInfoTooltip += std::string(_("Rating information: ")) + "\n" + detailsstr + "\n";
+				playerInfoTooltip += std::string(_("Player rating:")) + "\n";
 				if (stats.autoratingFrom == RATING_SOURCE_HOST && !NetPlay.isHost)
 				{
-					playerInfoTooltip += _("(Host provided)");
+					playerInfoTooltip += std::string("(") + _("Host provided") + ")";
 				}
 				else
 				{
-					playerInfoTooltip += _("Rating information from: ") + getAutoratingUrl();
+					playerInfoTooltip += std::string("(") + astringf(_("From: %s"), getAutoratingUrl().c_str()) + ")";
 				}
+				playerInfoTooltip += "\n" + detailsstr;
 			}
 		}
 		playerInfo->setTip(playerInfoTooltip);

--- a/src/multiint.cpp
+++ b/src/multiint.cpp
@@ -3981,6 +3981,28 @@ void WzPlayerBoxTabs::displayOptionsOverlay(const std::shared_ptr<WIDGET>& psPar
 // ////////////////////////////////////////////////////////////////////////////
 // player row widgets
 
+static size_t nthOccurrenceOfChar(const std::string& str, const char c, size_t n)
+{
+	size_t pos = 0;
+	size_t count = 0;
+
+	while (count < n)
+	{
+		pos = str.find(c, (count > 0) ? pos + 1 : pos);
+		if (pos == std::string::npos)
+		{
+			return std::string::npos;
+		}
+		++count;
+		if (pos == str.length() - 1)
+		{
+			return std::string::npos;
+		}
+	}
+
+	return pos;
+}
+
 class WzPlayerRow : public WIDGET
 {
 protected:
@@ -4218,6 +4240,11 @@ public:
 				if (detailsstr.size() > 512)
 				{
 					detailsstr = detailsstr.substr(0, 512);
+				}
+				size_t maxLinePos = nthOccurrenceOfChar(detailsstr, '\n', 10);
+				if (maxLinePos != std::string::npos)
+				{
+					detailsstr = detailsstr.substr(0, maxLinePos);
 				}
 				playerInfoTooltip += std::string(_("Player rating:")) + "\n";
 				if (stats.autoratingFrom == RATING_SOURCE_HOST && !NetPlay.isHost)

--- a/src/multistat.cpp
+++ b/src/multistat.cpp
@@ -235,8 +235,8 @@ void recvMultiStats(NETQUEUE queue)
 		return;
 	}
 
-	PLAYERSTATS dummyVariable;
-	NETauto(dummyVariable.autorating);
+	PLAYERSTATS::Autorating receivedAutorating;
+	NETauto(receivedAutorating);
 
 	// we don't what to update ourselves, we already know our score (FIXME: rewrite setMultiStats())
 	if (!myResponsibility(playerIndex))
@@ -291,7 +291,7 @@ void recvMultiStats(NETQUEUE queue)
 			}
 			else
 			{
-				playerStats[playerIndex].autorating = dummyVariable.autorating;
+				playerStats[playerIndex].autorating = receivedAutorating;
 				playerStats[playerIndex].autoratingFrom = RATING_SOURCE_HOST;
 			}
 		}

--- a/src/multistat.cpp
+++ b/src/multistat.cpp
@@ -235,7 +235,8 @@ void recvMultiStats(NETQUEUE queue)
 		return;
 	}
 
-	NETauto(playerStats[playerIndex].autorating);
+	PLAYERSTATS dummyVariable;
+	NETauto(dummyVariable.autorating);
 
 	// we don't what to update ourselves, we already know our score (FIXME: rewrite setMultiStats())
 	if (!myResponsibility(playerIndex))
@@ -281,20 +282,21 @@ void recvMultiStats(NETQUEUE queue)
 			std::string senderPublicKeyB64 = base64Encode(playerStats[playerIndex].identity.toBytes(EcKey::Public));
 			std::string senderIdentityHash = playerStats[playerIndex].identity.publicHashString();
 			wz_command_interface_output("WZEVENT: player identity UNVERIFIED: %" PRIu32 " %s %s\n", playerIndex, senderPublicKeyB64.c_str(), senderIdentityHash.c_str());
+
+			if (getAutoratingEnable())
+			{
+				playerStats[playerIndex].autorating.valid = false;
+				playerStats[playerIndex].autoratingFrom = RATING_SOURCE_LOCAL;
+				lookupRatingAsync(playerIndex);
+			}
+			else
+			{
+				playerStats[playerIndex].autorating = dummyVariable.autorating;
+				playerStats[playerIndex].autoratingFrom = RATING_SOURCE_HOST;
+			}
 		}
 	}
 	NETend();
-
-	if (getAutoratingEnable())
-	{
-		playerStats[playerIndex].autorating.valid = false;
-		playerStats[playerIndex].autoratingFrom = RATING_SOURCE_LOCAL;
-		lookupRatingAsync(playerIndex);
-	}
-	else
-	{
-		playerStats[playerIndex].autoratingFrom = RATING_SOURCE_HOST;
-	}
 }
 
 // ////////////////////////////////////////////////////////////////////////////

--- a/src/multistat.cpp
+++ b/src/multistat.cpp
@@ -146,7 +146,7 @@ void lookupRatingAsync(uint32_t playerIndex)
 				playerStats[playerIndex].autorating = nlohmann::json::parse(dataCopy->memory, dataCopy->memory + dataCopy->size);
 				if (playerStats[playerIndex].autorating.valid)
 				{
-					setMultiStats(playerIndex, playerStats[playerIndex], false);
+					setMultiStats(playerIndex, playerStats[playerIndex], !NetPlay.isHost);
 					netPlayersUpdated = true;
 				}
 			}
@@ -285,9 +285,15 @@ void recvMultiStats(NETQUEUE queue)
 	}
 	NETend();
 
-	if (NetPlay.isHost && !playerStats[playerIndex].autorating.valid)
+	if (getAutoratingEnable())
 	{
+		playerStats[playerIndex].autorating.valid = false;
+		playerStats[playerIndex].autoratingFrom = RATING_SOURCE_LOCAL;
 		lookupRatingAsync(playerIndex);
+	}
+	else
+	{
+		playerStats[playerIndex].autoratingFrom = RATING_SOURCE_HOST;
 	}
 }
 

--- a/src/multistat.h
+++ b/src/multistat.h
@@ -35,6 +35,11 @@ using nonstd::nullopt;
 
 #define WZ_DEFAULT_PUBLIC_RATING_LOOKUP_SERVICE_URL "https://wz2100-autohost.net/rating/"
 
+enum RATING_SOURCE {
+	RATING_SOURCE_LOCAL,
+	RATING_SOURCE_HOST
+};
+
 struct PLAYERSTATS
 {
 	uint32_t played = 0;  /// propagated stats.
@@ -62,6 +67,7 @@ struct PLAYERSTATS
 		std::string details;
 	};
 	Autorating autorating;
+	RATING_SOURCE autoratingFrom = RATING_SOURCE_HOST;
 
 	EcKey identity;
 };


### PR DESCRIPTION
This pull request does 2 things:
1. Change configuration file field for rating lookup URL so old ones are dropped (we no longer use `{HASH}`)
2. Introduces new policy to rating lookup and improves clarity of rating origin. (now displays that info was requested from set URL or provided from host in case lookup is disabled)

New lookup policy is following:
| Lookup | Host ON | Host OFF |
| ----- | ---- | ---- |
| Client ON | Client invalidates host's info and requests it's own | Only client has rating info |
| Client OFF | Client has host's info and it is marked as host provided | Both have no info |

Host does not "pass along" any rating information anymore. Host replaces rating information if lookup is enabled on the host.

New policy was introduced to prevent malicious clients from pretending that they are someone else or faking their rating information.

Testing&feedback welcome.