### PR TITLE
simplify repairs logic

### DIFF
--- a/src/droid.h
+++ b/src/droid.h
@@ -481,5 +481,9 @@ static inline DROID const *castDroid(SIMPLE_OBJECT const *psObject)
 	return isDroid(psObject) ? (DROID const *)psObject : (DROID const *)nullptr;
 }
 
+/** \brief sends droid to delivery point, or back to commander. psRepairFac maybe nullptr when
+ * repairs were made by a mobile repair turret
+ */
+void droidWasFullyRepaired(DROID *psDroid, const REPAIR_FACILITY *psRepairFac);
 
 #endif // __INCLUDED_SRC_DROID_H__

--- a/src/mapgrid.cpp
+++ b/src/mapgrid.cpp
@@ -35,6 +35,7 @@
 static PointTree *gridPointTree = nullptr;  // A quad-tree-like object.
 static PointTree::Filter *gridFiltersUnseen;
 static PointTree::Filter *gridFiltersDroidsByPlayer;
+static PointTree::Filter *gridFiltersDroidsRepairCandidates;
 
 // initialise the grid system
 bool gridInitialise()
@@ -43,6 +44,7 @@ bool gridInitialise()
 	gridPointTree = new PointTree;
 	gridFiltersUnseen = new PointTree::Filter[MAX_PLAYERS];
 	gridFiltersDroidsByPlayer = new PointTree::Filter[MAX_PLAYERS];
+	gridFiltersDroidsRepairCandidates = new PointTree::Filter[MAX_PLAYERS];
 
 	return true;  // Yay, nothing failed!
 }
@@ -78,6 +80,7 @@ void gridReset()
 	{
 		gridFiltersUnseen[player].reset(*gridPointTree);
 		gridFiltersDroidsByPlayer[player].reset(*gridPointTree);
+		gridFiltersDroidsRepairCandidates[player].reset(*gridPointTree);
 	}
 }
 
@@ -126,10 +129,10 @@ static GridList const &gridStartIterateFiltered(int32_t x, int32_t y, uint32_t r
 		}
 	}
 	gridPointTree->lastQueryResults.erase(w, i);  // Erase all points that were a bit too far.
-	/*
+
 	// In case you are curious.
-	debug(LOG_WARNING, "gridStartIterateFiltered(%d, %d, %u) found %u objects", x, y, radius, (unsigned)gridPointTree->lastQueryResults.size());
-	*/
+	//debug(LOG_WARNING, "gridStartIterateFiltered(%d, %d, %u) found %u objects", x, y, radius, (unsigned)gridPointTree->lastQueryResults.size());
+	
 	static GridList gridList;
 	gridList.resize(gridPointTree->lastQueryResults.size());
 	for (unsigned n = 0; n < gridList.size(); ++n)
@@ -184,6 +187,28 @@ struct ConditionDroidsByPlayer
 GridList const &gridStartIterateDroidsByPlayer(int32_t x, int32_t y, uint32_t radius, int player)
 {
 	return gridStartIterateFiltered(x, y, radius, &gridFiltersDroidsByPlayer[player], ConditionDroidsByPlayer(player));
+}
+
+struct ConditionDroidCandidateForRepair
+{
+	ConditionDroidCandidateForRepair(int32_t player_) : player(player_) {}
+	bool test(BASE_OBJECT *obj) const
+	{
+		if (obj->type != OBJ_DROID) return false;
+		const DROID *psDroid = (const DROID*) obj;
+		const bool isOwnOrAlly = psDroid->player == player && aiCheckAlliances(psDroid->player, player);
+		const bool isVTOL = asPropulsionStats[psDroid->asBits[COMP_PROPULSION]].propulsionType == PROPULSION_TYPE_LIFT;
+		// either it's a ground unit, or it's a VTOL on ground
+		const bool isOnGround = (!isVTOL) || (isVTOL && (psDroid->sMove.Status == MOVEINACTIVE && psDroid->sMove.iVertSpeed == 0));
+		// Note: no check for droidIsDamaged(psDroid) this is intentional
+		return !psDroid->died && isOwnOrAlly && isOnGround;
+	}
+	int player;
+};
+
+GridList const &gridStartIterateRepairCandidates(int32_t x, int32_t y, uint32_t radius, int player)
+{
+	return gridStartIterateFiltered(x, y, radius, &gridFiltersDroidsRepairCandidates[player], ConditionDroidCandidateForRepair(player));
 }
 
 struct ConditionUnseen

--- a/src/mapgrid.h
+++ b/src/mapgrid.h
@@ -46,6 +46,9 @@ GridList const &gridStartIterateArea(int32_t x, int32_t y, uint32_t x2, uint32_t
 /// Find all objects within radius where object->type == OBJ_DROID && object->player == player.
 GridList const &gridStartIterateDroidsByPlayer(int32_t x, int32_t y, uint32_t radius, int player);
 
+/// Find all objects within radius where (object->type == OBJ_DROID && !object->died)
+GridList const &gridStartIterateRepairCandidates(int32_t x, int32_t y, uint32_t radius, int player);
+
 // Used for visibility.
 /// Find all objects within radius where object->seenThisTick[player] != 255.
 GridList const &gridStartIterateUnseen(int32_t x, int32_t y, uint32_t radius, int player);

--- a/src/order.h
+++ b/src/order.h
@@ -29,6 +29,14 @@
 
 #include "orderdef.h"
 
+/** Find some droid to repair, starting at (x, y) within some radius, given a player, or return nullptr.
+ * Droids having full HP with order = DORDER_RTR or RTR_SPECIFIED will automatically
+ * be sent to delivery point, or back to commander 
+ */
+
+DROID *findSomeoneToRepair(const STRUCTURE *obj, int radius);
+DROID *findSomeoneToRepair(const DROID *psTurret, int radius);
+
 /** \brief Gives the droid an order. */
 void orderDroidBase(DROID *psDroid, DROID_ORDER_DATA *psOrder);
 
@@ -60,7 +68,7 @@ bool orderStateLoc(DROID *psDroid, DROID_ORDER order, UDWORD *pX, UDWORD *pY);
 void orderDroidObj(DROID *psDroid, DROID_ORDER order, BASE_OBJECT *psObj, QUEUE_MODE mode);
 
 /** \brief Gets the state of a droid's order with an object. */
-BASE_OBJECT *orderStateObj(DROID *psDroid, DROID_ORDER order);
+BASE_OBJECT *orderStateObj(const DROID *psDroid, DROID_ORDER order);
 
 /** \brief Sends an order with a location and a stat to a droid. */
 void orderDroidStatsLocDir(DROID *psDroid, DROID_ORDER order, STRUCTURE_STATS *psStats, UDWORD x, UDWORD y, uint16_t direction, QUEUE_MODE mode);

--- a/src/structuredef.h
+++ b/src/structuredef.h
@@ -227,13 +227,29 @@ struct POWER_GEN
 
 class DROID_GROUP;
 
+enum class RepairEvents
+{
+	NoEvents,
+	RepairTargetFound,
+	UnitReachedMaxHP,
+	UnitDied,
+	UnitMovedAway
+};
+
+enum class RepairState 
+{
+	Invalid = -1,
+	Idle,
+	Repairing
+};
+
 struct REPAIR_FACILITY
 {
 	BASE_OBJECT *psObj;                /* Object being repaired */
 	FLAG_POSITION *psDeliveryPoint;    /* Place for the repaired droids to assemble at */
 	// The group the droids to be repaired by this facility belong to
 	DROID_GROUP *psGroup;
-	int droidQueue;                    ///< Last count of droid queue for this facility
+	RepairState state;
 };
 
 struct REARM_PAD


### PR DESCRIPTION
- This makes impossible for a repair station to be stuck while waiting for a unit: there is no more such thing as "order the droid to repair to come closer and wait for it".
- Removes "work stealing" between repair stations, we already have randomized repair station assignment
- Previous logic was iterating over all the droids for the selected player (+ eventually through all the droids of all allies). Now we only iterate once over droids in some specified area.
- fixes inconsistencies between Repair Station and Mobile Repair Turret: both are now using the same logic 
- makes https://github.com/Warzone2100/warzone2100/pull/2823 obsolete

TODO in later pull requests: 
- `DACTION_WAITFORREPAIR` is useless. Just use `DACTION_NONE`. 
- Could be simplified a little further if droids were able to handle their own `DORDER_RTR` when their HP is already full.