### PR TITLE
Flatpak: Use inproc crash handler

### DIFF
--- a/.ci/flatpak/net.wz2100.wz2100.yaml.in
+++ b/.ci/flatpak/net.wz2100.wz2100.yaml.in
@@ -155,7 +155,8 @@ modules:
       - -DWZ_APPSTREAM_ID=net.wz2100.wz2100
       - -DWZ_BUILD_SENTRY:BOOL=ON
       - -DWZ_SENTRY_PREDOWNLOADED_SENTRY_ARCHIVE=/app/prestaged-dl/sentry-native.zip
-      - -DSENTRY_BACKEND=crashpad
+      # Have to use inproc for now - breakpad / crashpad do not work in the Flatpak sandbox
+      - -DSENTRY_BACKEND=inproc
       @WZ_CMAKE_CROSS_CONFIG_OPTIONS@
     secret-opts:
       - -DWZ_DISTRIBUTOR:STRING=$WZ_DISTRIBUTOR


### PR DESCRIPTION
At the moment, neither breakpad nor crashpad work in the Flatpak sandbox.

(This might be resolved in the future, see: https://bugzilla.mozilla.org/show_bug.cgi?id=1653852 )