### PR TITLE
[GitHub Actions] Windows: Remove libssp package from mingw builds

### DIFF
--- a/.github/workflows/CI_windows.yml
+++ b/.github/workflows/CI_windows.yml
@@ -355,7 +355,6 @@ jobs:
         update: true
         install: >-
           ${{ steps.settings.outputs.WZ_MINGW_PKG_PREFIX }}-toolchain
-          ${{ steps.settings.outputs.WZ_MINGW_PKG_PREFIX }}-libssp
     - name: Prep MINGW Environment
       id: mingwsettings
       if: success() && (steps.settings.outputs.WZ_USING_MINGW == 'true')


### PR DESCRIPTION
See: https://www.msys2.org/news/#2022-10-10-libssp-is-no-longer-required