### PR TITLE
Make rotary artillery more desirable

### DIFF
--- a/data/mp/stats/weapons.json
+++ b/data/mp/stats/weapons.json
@@ -2109,7 +2109,7 @@
 	},
 	"Howitzer03-Rot": {
 		"buildPoints": 1600,
-		"buildPower": 450,
+		"buildPower": 400,
 		"damage": 200,
 		"designable": 1,
 		"effectSize": 225,
@@ -2146,7 +2146,7 @@
 		"weaponEffect": "ARTILLERY ROUND",
 		"weaponSubClass": "HOWITZERS",
 		"weaponWav": "lrgcan.ogg",
-		"weight": 20000
+		"weight": 10000
 	},
 	"Howitzer105Mk1": {
 		"buildPoints": 1000,
@@ -3422,8 +3422,8 @@
 		"weight": 5000
 	},
 	"Mortar3ROTARYMk1": {
-		"buildPoints": 900,
-		"buildPower": 200,
+		"buildPoints": 800,
+		"buildPower": 175,
 		"damage": 60,
 		"designable": 1,
 		"effectSize": 100,


### PR DESCRIPTION
Suggestion from Fenrir:

```
Please, make rotary mortar and rotary howitzer (Hellstorm) more useful in game:
reduce 40% time of weapon research
reduce weight for hellstorm - 10%
reduce price: rotary mortar - 10%, hellstorm - 20%
```