### PR TITLE
Reduce effectiveness of artillery modifier on bunkers and tracked

### DIFF
--- a/data/mp/stats/structuremodifier.json
+++ b/data/mp/stats/structuremodifier.json
@@ -18,7 +18,7 @@
 		"SOFT": 75
 	},
 	"ARTILLERY ROUND": {
-		"BUNKER": 40,
+		"BUNKER": 20,
 		"HARD": 100,
 		"MEDIUM": 120,
 		"SOFT": 200

--- a/data/mp/stats/weaponmodifier.json
+++ b/data/mp/stats/weaponmodifier.json
@@ -28,7 +28,7 @@
 		"Hover": 110,
 		"Legged": 130,
 		"Lift": 25,
-		"Tracked": 40,
+		"Tracked": 30,
 		"Wheeled": 90
 	},
 	"BUNKER BUSTER": {


### PR DESCRIPTION
Original idea by Fenrir.

Edit:
Includes Tipchik's suggestion of reducing artillery modifier against tracked from 40% to 30%.