### PR TITLE
Auto-adjust menu item font size to better fit long strings

### DIFF
--- a/lib/ivis_opengl/textdraw.cpp
+++ b/lib/ivis_opengl/textdraw.cpp
@@ -1031,6 +1031,7 @@ public:
 	std::unique_ptr<FTFace> regularBold;
 	std::unique_ptr<FTFace> bold;
 	std::unique_ptr<FTFace> medium;
+	std::unique_ptr<FTFace> mediumBold;
 	std::unique_ptr<FTFace> small;
 	std::unique_ptr<FTFace> smallBold;
 };
@@ -1062,6 +1063,7 @@ static bool inline initializeCJKFontsIfNeeded()
 		cjkFonts->regularBold = std::unique_ptr<FTFace>(new FTFace(getGlobalFTlib().lib, CJK_FONT_PATH, 12 * 64, horizDPI, vertDPI, 700));
 		cjkFonts->bold = std::unique_ptr<FTFace>(new FTFace(getGlobalFTlib().lib, CJK_FONT_PATH, 21 * 64, horizDPI, vertDPI, 400));
 		cjkFonts->medium = std::unique_ptr<FTFace>(new FTFace(getGlobalFTlib().lib, CJK_FONT_PATH, 16 * 64, horizDPI, vertDPI, 400));
+		cjkFonts->mediumBold = std::unique_ptr<FTFace>(new FTFace(getGlobalFTlib().lib, CJK_FONT_PATH, 16 * 64, horizDPI, vertDPI, 700));
 		cjkFonts->small = std::unique_ptr<FTFace>(new FTFace(getGlobalFTlib().lib, CJK_FONT_PATH, 9 * 64, horizDPI, vertDPI, 400));
 		cjkFonts->smallBold = std::unique_ptr<FTFace>(new FTFace(getGlobalFTlib().lib, CJK_FONT_PATH, 9 * 64, horizDPI, vertDPI, 700));
 	}
@@ -1097,6 +1099,8 @@ static FTFace &getFTFace(iV_fonts FontID, hb_script_t script)
 					return *(cjkFonts->bold);
 				case font_medium:
 					return *(cjkFonts->medium);
+				case font_medium_bold:
+					return *(cjkFonts->mediumBold);
 				case font_small:
 					return *(cjkFonts->small);
 				case font_bar:
@@ -1118,6 +1122,8 @@ static FTFace &getFTFace(iV_fonts FontID, hb_script_t script)
 		return *(baseFonts.bold);
 	case font_medium:
 		return *(baseFonts.medium);
+	case font_medium_bold:
+		return *(baseFonts.mediumBold);
 	case font_small:
 		return *(baseFonts.small);
 	case font_bar:
@@ -1154,6 +1160,7 @@ void iV_TextInit(unsigned int horizScalePercentage, unsigned int vertScalePercen
 		baseFonts.regularBold = std::unique_ptr<FTFace>(new FTFace(getGlobalFTlib().lib, "fonts/DejaVuSans-Bold.ttf", 12 * 64, horizDPI, vertDPI));
 		baseFonts.bold = std::unique_ptr<FTFace>(new FTFace(getGlobalFTlib().lib, "fonts/DejaVuSans-Bold.ttf", 21 * 64, horizDPI, vertDPI));
 		baseFonts.medium = std::unique_ptr<FTFace>(new FTFace(getGlobalFTlib().lib, "fonts/DejaVuSans.ttf", 16 * 64, horizDPI, vertDPI));
+		baseFonts.mediumBold = std::unique_ptr<FTFace>(new FTFace(getGlobalFTlib().lib, "fonts/DejaVuSans-Bold.ttf", 16 * 64, horizDPI, vertDPI));
 		baseFonts.small = std::unique_ptr<FTFace>(new FTFace(getGlobalFTlib().lib, "fonts/DejaVuSans.ttf", 9 * 64, horizDPI, vertDPI));
 		baseFonts.smallBold = std::unique_ptr<FTFace>(new FTFace(getGlobalFTlib().lib, "fonts/DejaVuSans-Bold.ttf", 9 * 64, horizDPI, vertDPI));
 	}

--- a/lib/ivis_opengl/textdraw.cpp
+++ b/lib/ivis_opengl/textdraw.cpp
@@ -1286,6 +1286,36 @@ void iV_SetTextColour(PIELIGHT colour)
 	font_colour[3] = colour.byte.a / 255.0f;
 }
 
+optional<iV_fonts> iV_ShrinkFont(iV_fonts fontID)
+{
+	switch (fontID)
+	{
+		// bold fonts
+		case font_large: // is actually bold
+			return font_medium_bold;
+		case font_medium_bold:
+			return font_regular_bold;
+		case font_regular_bold:
+			return font_bar; // small_bold
+		case font_bar:	// small_bold
+			return nullopt;
+
+		// regular fonts
+		case font_medium:
+			return font_regular;
+		case font_scaled: // treated the same as font_regular
+		case font_regular:
+			return font_small;
+		case font_small:
+			return nullopt;
+
+		case font_count:
+			return nullopt;
+	}
+
+	return nullopt; // silence compiler warning
+}
+
 static bool breaksLine(char const c)
 {
 	return c == ASCII_NEWLINE || c == '\n';

--- a/lib/ivis_opengl/textdraw.h
+++ b/lib/ivis_opengl/textdraw.h
@@ -38,6 +38,7 @@ enum iV_fonts
 	font_bar,
 	font_scaled,
 	font_regular_bold,
+	font_medium_bold,
 	font_count
 };
 

--- a/lib/ivis_opengl/textdraw.h
+++ b/lib/ivis_opengl/textdraw.h
@@ -29,6 +29,10 @@
 #include "gfx_api.h"
 #include "pietypes.h"
 
+#include <nonstd/optional.hpp>
+using nonstd::optional;
+using nonstd::nullopt;
+
 enum iV_fonts
 {
 	font_regular,
@@ -67,7 +71,7 @@ public:
 	WzText(WzText&& other);
 
 public:
-	const std::string& getText() const { return mText.toUtf8(); }
+	const WzString& getText() const { return mText; }
 	iV_fonts getFontID() const { return mFontID; }
 
 private:
@@ -142,6 +146,8 @@ unsigned int iV_GetCharWidth(uint32_t charCode, iV_fonts fontID);
 
 unsigned int iV_GetTextHeight(const char *string, iV_fonts fontID);
 void iV_SetTextColour(PIELIGHT colour);
+
+optional<iV_fonts> iV_ShrinkFont(iV_fonts fontID);
 
 /// Valid values for "Justify" argument of iV_FormatText().
 enum

--- a/src/frontend.h
+++ b/src/frontend.h
@@ -131,6 +131,13 @@ void seqScrollEvent();
 
 struct DisplayTextOptionCache
 {
+	enum class OverflowBehavior
+	{
+		None,
+		ShrinkFont
+	};
+	OverflowBehavior overflowBehavior = OverflowBehavior::None;
+	int lastWidgetWidth = 0;
 	WzText wzText;
 };
 


### PR DESCRIPTION
Useful for certain languages that tend towards very long strings.

There are few minor quirks with this, and we'd benefit from:
- Switching more of those "toggling" options over to proper dropdown widgets (_probably the ideal option_)
or
- Providing a custom W_BUTTON subclass that actually implements idealWidth properly (and handles drawing, caching text, etc)

But this seems overall like a positive improvement