### PR TITLE
Reduce price of Hover in MP

### DIFF
--- a/data/mp/stats/propulsion.json
+++ b/data/mp/stats/propulsion.json
@@ -97,7 +97,7 @@
 	},
 	"hover01": {
 		"buildPoints": 100,
-		"buildPower": 150,
+		"buildPower": 125,
 		"designable": 1,
 		"hitpointPctOfBody": 100,
 		"id": "hover01",


### PR DESCRIPTION
Tipchik suggested making Hover made less expensive. Cost went from 150 to 125 power making it tie VTOL and Tracked in terms of cost.