### PR TITLE
(MP)EMP Cannon Tweak

### DIFF
--- a/data/mp/stats/weapons.json
+++ b/data/mp/stats/weapons.json
@@ -1887,7 +1887,7 @@
 		"muzzleGfx": "FXHBLas.PIE",
 		"name": "EMP Cannon",
 		"numExplosions": 1,
-		"radius": 256,
+		"radius": 192,
 		"recoilValue": 150,
 		"rotate": 180,
 		"shortHit": 70,


### PR DESCRIPTION
Often in battles one EMP tank one shot can freeze about 10 other tanks and this can also happen if you miss, so I decided to reduce the radius of freezing from 2 cells to 1.5, because there were complaints from players about this turret
I tested this in debug mode and with confidence I say that the difference will be tangible

Mod: [EMP_Can_Tweak_Mod.zip](https://github.com/Warzone2100/warzone2100/files/9946199/EMP_Can_Tweak_Mod.zip)

Replay: [20221105_225850_multiplay_p14.zip](https://github.com/Warzone2100/warzone2100/files/9946284/20221105_225850_multiplay_p14.zip)
