### PR TITLE
Various window restoring / drawing / backend drawable handling fixes

### DIFF
--- a/lib/ivis_opengl/gfx_api.cpp
+++ b/lib/ivis_opengl/gfx_api.cpp
@@ -179,6 +179,9 @@ bool gfx_api::loadTextureCompressionOverrides()
 		return false;
 	}
 
+	// Remove all \r from the string
+	loadedTexConfigData.erase(std::remove(loadedTexConfigData.begin(), loadedTexConfigData.end(), '\r'), loadedTexConfigData.end());
+
 	auto it_previous = loadedTexConfigData.begin();
 	auto it = std::find(loadedTexConfigData.begin(), loadedTexConfigData.end(), '\n');
 	auto it_end = loadedTexConfigData.end();

--- a/lib/ivis_opengl/gfx_api.cpp
+++ b/lib/ivis_opengl/gfx_api.cpp
@@ -238,14 +238,21 @@ static std::string imageLoadFilenameFromInputFilename(const WzString& filename)
 	// For backwards-compatibility support, filenames that end in ".png" are used as "keys" and we first check for a .ktx2 file with the same filename
 	if (filename.endsWith(wz_png_extension))
 	{
+		// First, check if the .png file exists
+		// (.png files take precedence, so that existing mods work - and only have to include png files)
+		if (PHYSFS_exists(filename))
+		{
+			return filename.toUtf8();
+		}
+
+		// Check for presence of .ktx2 file
 		WzString ktx2Filename = filename.substr(0, filename.size() - wz_png_extension.length());
 		ktx2Filename.append(".ktx2");
-		// Check for presence of .ktx2 file
 		if (PHYSFS_exists(ktx2Filename))
 		{
 			return ktx2Filename.toUtf8();
 		}
-		// Fall-back to .png file
+		// Fall-back to the .png file (which presumably doesn't exist because of the first check above, but this will cause it to be named as such in the later error message)
 	}
 #endif
 	return filename.toUtf8();

--- a/lib/ivis_opengl/gfx_api.h
+++ b/lib/ivis_opengl/gfx_api.h
@@ -321,6 +321,7 @@ namespace gfx_api
 		virtual const std::string& getFormattedRendererInfoString() const = 0;
 		virtual bool getScreenshot(std::function<void (std::unique_ptr<iV_Image>)> callback) = 0;
 		virtual void handleWindowSizeChange(unsigned int oldWidth, unsigned int oldHeight, unsigned int newWidth, unsigned int newHeight) = 0;
+		virtual std::pair<uint32_t, uint32_t> getDrawableDimensions() = 0;
 		virtual void shutdown() = 0;
 		virtual const size_t& current_FrameNum() const = 0;
 		virtual bool setSwapInterval(swap_interval_mode mode) = 0;

--- a/lib/ivis_opengl/gfx_api.h
+++ b/lib/ivis_opengl/gfx_api.h
@@ -322,6 +322,7 @@ namespace gfx_api
 		virtual bool getScreenshot(std::function<void (std::unique_ptr<iV_Image>)> callback) = 0;
 		virtual void handleWindowSizeChange(unsigned int oldWidth, unsigned int oldHeight, unsigned int newWidth, unsigned int newHeight) = 0;
 		virtual std::pair<uint32_t, uint32_t> getDrawableDimensions() = 0;
+		virtual bool shouldDraw() = 0;
 		virtual void shutdown() = 0;
 		virtual const size_t& current_FrameNum() const = 0;
 		virtual bool setSwapInterval(swap_interval_mode mode) = 0;

--- a/lib/ivis_opengl/gfx_api_gl.cpp
+++ b/lib/ivis_opengl/gfx_api_gl.cpp
@@ -2111,6 +2111,8 @@ bool gl_context::_initialize(const gfx_api::backend_Impl_Factory& impl, int32_t 
 	debug(LOG_WZ, "Drawable Size: %d x %d", width, height);
 
 	glViewport(0, 0, width, height);
+	viewportWidth = static_cast<uint32_t>(width);
+	viewportHeight = static_cast<uint32_t>(height);
 	glCullFace(GL_FRONT);
 	//	glEnable(GL_CULL_FACE);
 
@@ -2707,8 +2709,15 @@ void gl_context::handleWindowSizeChange(unsigned int oldWidth, unsigned int oldH
 	debug(LOG_WZ, "Logical Size: %d x %d; Drawable Size: %d x %d", screenWidth, screenHeight, drawableWidth, drawableHeight);
 
 	glViewport(0, 0, drawableWidth, drawableHeight);
+	viewportWidth = static_cast<uint32_t>(drawableWidth);
+	viewportHeight = static_cast<uint32_t>(drawableHeight);
 	glCullFace(GL_FRONT);
 	//	glEnable(GL_CULL_FACE);
+}
+
+std::pair<uint32_t, uint32_t> gl_context::getDrawableDimensions()
+{
+	return {viewportWidth, viewportHeight};
 }
 
 void gl_context::shutdown()

--- a/lib/ivis_opengl/gfx_api_gl.cpp
+++ b/lib/ivis_opengl/gfx_api_gl.cpp
@@ -2720,6 +2720,11 @@ std::pair<uint32_t, uint32_t> gl_context::getDrawableDimensions()
 	return {viewportWidth, viewportHeight};
 }
 
+bool gl_context::shouldDraw()
+{
+	return viewportWidth > 0 && viewportHeight > 0;
+}
+
 void gl_context::shutdown()
 {
 	if(glClear) glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT | GL_STENCIL_BUFFER_BIT);

--- a/lib/ivis_opengl/gfx_api_gl.h
+++ b/lib/ivis_opengl/gfx_api_gl.h
@@ -228,6 +228,7 @@ struct gl_context final : public gfx_api::context
 	virtual const std::string& getFormattedRendererInfoString() const override;
 	virtual bool getScreenshot(std::function<void (std::unique_ptr<iV_Image>)> callback) override;
 	virtual void handleWindowSizeChange(unsigned int oldWidth, unsigned int oldHeight, unsigned int newWidth, unsigned int newHeight) override;
+	virtual std::pair<uint32_t, uint32_t> getDrawableDimensions() override;
 	virtual void shutdown() override;
 	virtual const size_t& current_FrameNum() const override;
 	virtual bool setSwapInterval(gfx_api::context::swap_interval_mode mode) override;
@@ -245,6 +246,8 @@ private:
 	std::string calculateFormattedRendererInfoString() const;
 	bool isBlocklistedGraphicsDriver() const;
 
+	uint32_t viewportWidth = 0;
+	uint32_t viewportHeight = 0;
 	std::vector<bool> enabledVertexAttribIndexes;
 	size_t frameNum = 0;
 	std::string formattedRendererInfoString;

--- a/lib/ivis_opengl/gfx_api_gl.h
+++ b/lib/ivis_opengl/gfx_api_gl.h
@@ -229,6 +229,7 @@ struct gl_context final : public gfx_api::context
 	virtual bool getScreenshot(std::function<void (std::unique_ptr<iV_Image>)> callback) override;
 	virtual void handleWindowSizeChange(unsigned int oldWidth, unsigned int oldHeight, unsigned int newWidth, unsigned int newHeight) override;
 	virtual std::pair<uint32_t, uint32_t> getDrawableDimensions() override;
+	virtual bool shouldDraw() override;
 	virtual void shutdown() override;
 	virtual const size_t& current_FrameNum() const override;
 	virtual bool setSwapInterval(gfx_api::context::swap_interval_mode mode) override;

--- a/lib/ivis_opengl/gfx_api_null.cpp
+++ b/lib/ivis_opengl/gfx_api_null.cpp
@@ -375,6 +375,11 @@ std::pair<uint32_t, uint32_t> null_context::getDrawableDimensions()
 	return {0,0};
 }
 
+bool null_context::shouldDraw()
+{
+	return false;
+}
+
 void null_context::shutdown()
 {
 	// no-op

--- a/lib/ivis_opengl/gfx_api_null.cpp
+++ b/lib/ivis_opengl/gfx_api_null.cpp
@@ -370,6 +370,11 @@ void null_context::handleWindowSizeChange(unsigned int oldWidth, unsigned int ol
 	// no-op
 }
 
+std::pair<uint32_t, uint32_t> null_context::getDrawableDimensions()
+{
+	return {0,0};
+}
+
 void null_context::shutdown()
 {
 	// no-op

--- a/lib/ivis_opengl/gfx_api_null.h
+++ b/lib/ivis_opengl/gfx_api_null.h
@@ -128,6 +128,7 @@ public:
 	virtual bool getScreenshot(std::function<void (std::unique_ptr<iV_Image>)> callback) override;
 	virtual void handleWindowSizeChange(unsigned int oldWidth, unsigned int oldHeight, unsigned int newWidth, unsigned int newHeight) override;
 	virtual std::pair<uint32_t, uint32_t> getDrawableDimensions() override;
+	virtual bool shouldDraw() override;
 	virtual void shutdown() override;
 	virtual const size_t& current_FrameNum() const override;
 	virtual bool setSwapInterval(gfx_api::context::swap_interval_mode mode) override;

--- a/lib/ivis_opengl/gfx_api_null.h
+++ b/lib/ivis_opengl/gfx_api_null.h
@@ -127,6 +127,7 @@ public:
 	virtual const std::string& getFormattedRendererInfoString() const override;
 	virtual bool getScreenshot(std::function<void (std::unique_ptr<iV_Image>)> callback) override;
 	virtual void handleWindowSizeChange(unsigned int oldWidth, unsigned int oldHeight, unsigned int newWidth, unsigned int newHeight) override;
+	virtual std::pair<uint32_t, uint32_t> getDrawableDimensions() override;
 	virtual void shutdown() override;
 	virtual const size_t& current_FrameNum() const override;
 	virtual bool setSwapInterval(gfx_api::context::swap_interval_mode mode) override;

--- a/lib/ivis_opengl/gfx_api_vk.cpp
+++ b/lib/ivis_opengl/gfx_api_vk.cpp
@@ -2294,6 +2294,11 @@ void VkRoot::handleWindowSizeChange(unsigned int oldWidth, unsigned int oldHeigh
 	}
 }
 
+std::pair<uint32_t, uint32_t> VkRoot::getDrawableDimensions()
+{
+	return {swapchainSize.width, swapchainSize.height};
+}
+
 void VkRoot::shutdown()
 {
 	destroySwapchainAndSwapchainSpecificStuff(true);

--- a/lib/ivis_opengl/gfx_api_vk.cpp
+++ b/lib/ivis_opengl/gfx_api_vk.cpp
@@ -2299,6 +2299,12 @@ std::pair<uint32_t, uint32_t> VkRoot::getDrawableDimensions()
 	return {swapchainSize.width, swapchainSize.height};
 }
 
+bool VkRoot::shouldDraw()
+{
+	return swapchainSize.width > 1 && swapchainSize.height > 1; // check for > 1 here because we use 1,1 in place of a 0,0 swapchain size to avoid other issues
+}
+
+
 void VkRoot::shutdown()
 {
 	destroySwapchainAndSwapchainSpecificStuff(true);

--- a/lib/ivis_opengl/gfx_api_vk.h
+++ b/lib/ivis_opengl/gfx_api_vk.h
@@ -660,6 +660,7 @@ public:
 	virtual bool getScreenshot(std::function<void (std::unique_ptr<iV_Image>)> callback) override;
 	virtual void handleWindowSizeChange(unsigned int oldWidth, unsigned int oldHeight, unsigned int newWidth, unsigned int newHeight) override;
 	virtual std::pair<uint32_t, uint32_t> getDrawableDimensions() override;
+	virtual bool shouldDraw() override;
 	virtual void shutdown() override;
 	virtual const size_t& current_FrameNum() const override;
 	virtual bool setSwapInterval(gfx_api::context::swap_interval_mode mode) override;

--- a/lib/ivis_opengl/gfx_api_vk.h
+++ b/lib/ivis_opengl/gfx_api_vk.h
@@ -659,6 +659,7 @@ public:
 	virtual const std::string& getFormattedRendererInfoString() const override;
 	virtual bool getScreenshot(std::function<void (std::unique_ptr<iV_Image>)> callback) override;
 	virtual void handleWindowSizeChange(unsigned int oldWidth, unsigned int oldHeight, unsigned int newWidth, unsigned int newHeight) override;
+	virtual std::pair<uint32_t, uint32_t> getDrawableDimensions() override;
 	virtual void shutdown() override;
 	virtual const size_t& current_FrameNum() const override;
 	virtual bool setSwapInterval(gfx_api::context::swap_interval_mode mode) override;

--- a/lib/sdl/main_sdl.cpp
+++ b/lib/sdl/main_sdl.cpp
@@ -682,8 +682,18 @@ bool wzChangeWindowMode(WINDOW_MODE mode)
 			sdl_result = SDL_SetWindowFullscreen(WZwindow, 0);
 			if (sdl_result != 0) { return false; }
 			wzSetWindowIsResizable(true);
-			// restore the old windowed size
+			// Determine the maximum usable windowed size for this display/screen, and cap the desired window size at that
 			int desiredWidth = war_GetWidth(), desiredHeight = war_GetHeight();
+			SDL_Rect displayUsableBounds = { 0, 0, 0, 0 };
+			if (SDL_GetDisplayUsableBounds(currDisplayIndex, &displayUsableBounds) == 0)
+			{
+				if (displayUsableBounds.w > 0 && displayUsableBounds.h > 0)
+				{
+					desiredWidth = std::min(displayUsableBounds.w, desiredWidth);
+					desiredHeight = std::min(displayUsableBounds.h, desiredHeight);
+				}
+			}
+			// restore the old windowed size
 			SDL_SetWindowSize(WZwindow, desiredWidth, desiredHeight);
 			// Position the window (centered) on the screen (for its new size)
 			SDL_SetWindowPosition(WZwindow, SDL_WINDOWPOS_CENTERED_DISPLAY(currDisplayIndex), SDL_WINDOWPOS_CENTERED_DISPLAY(currDisplayIndex));

--- a/lib/sdl/main_sdl.cpp
+++ b/lib/sdl/main_sdl.cpp
@@ -3240,6 +3240,24 @@ static void handleActiveEvent(SDL_Event *event)
 			break;
 		case SDL_WINDOWEVENT_RESTORED:
 			debug(LOG_WZ, "Window %d restored", event->window.windowID);
+			{
+				unsigned int oldWindowWidth = windowWidth;
+				unsigned int oldWindowHeight = windowHeight;
+
+				int newWindowWidth = 0, newWindowHeight = 0;
+				SDL_GetWindowSize(WZwindow, &newWindowWidth, &newWindowHeight);
+
+				int newDrawableWidth = 0, newDrawableHeight = 0;
+				SDL_WZBackend_GetDrawableSize(WZwindow, &newDrawableWidth, &newDrawableHeight);
+				auto oldDrawableDimensions = gfx_api::context::get().getDrawableDimensions();
+
+				if (oldWindowWidth != newWindowWidth || oldWindowHeight != newWindowHeight
+					|| oldDrawableDimensions.first != newDrawableWidth || oldDrawableDimensions.second != newDrawableHeight)
+				{
+					debug(LOG_WZ, "Triggering handleWindowSizeChange from window restore event");
+					handleWindowSizeChange(oldWindowWidth, oldWindowHeight, newWindowWidth, newWindowHeight);
+				}
+			}
 			break;
 		case SDL_WINDOWEVENT_ENTER:
 			debug(LOG_WZ, "Mouse entered window %d", event->window.windowID);

--- a/lib/widget/widget.cpp
+++ b/lib/widget/widget.cpp
@@ -1411,11 +1411,7 @@ void widgDisplayScreen(const std::shared_ptr<W_SCREEN> &psScreen)
 	debugLoc = debugLoc[1] == -1 ? debugSequence : debugLoc[0] == debugCode ? debugLoc : debugLoc[1] == debugCode ? debugLoc + 1 : debugSequence;
 	debugBoundingBoxes = debugBoundingBoxes ^ (debugLoc[1] == -1);
 
-	bool skipDrawing = false;
-	if (gfx_api::context::get().getDrawableDimensions() == std::pair<uint32_t,uint32_t>(0,0))
-	{
-		skipDrawing = true;
-	}
+	bool skipDrawing = !gfx_api::context::get().shouldDraw();
 
 	cleanupDeletedOverlays();
 

--- a/src/activity.cpp
+++ b/src/activity.cpp
@@ -389,7 +389,7 @@ void ActivityManager::addActivitySink(std::shared_ptr<ActivitySink> sink)
 
 void ActivityManager::removeActivitySink(const std::shared_ptr<ActivitySink>& sink)
 {
-	activitySinks.erase(std::remove(activitySinks.begin(), activitySinks.end(), sink));
+	activitySinks.erase(std::remove(activitySinks.begin(), activitySinks.end(), sink), activitySinks.end());
 }
 
 ActivitySink::GameMode ActivityManager::getCurrentGameMode() const

--- a/src/configuration.cpp
+++ b/src/configuration.cpp
@@ -493,10 +493,11 @@ bool loadConfig()
 	int fullscreenWidth = iniGetInteger("fullscreenWidth", war_GetFullscreenModeWidth()).value();
 	int fullscreenHeight = iniGetInteger("fullscreenHeight", war_GetFullscreenModeHeight()).value();
 	int fullscreenScreen = iniGetInteger("fullscreenScreen", 0).value();
-	if (fullscreenWidth < 640 || fullscreenHeight < 480)	// sanity check
+	if ((fullscreenWidth != 0 && fullscreenWidth < 640) || (fullscreenHeight != 0 && fullscreenHeight < 480))	// sanity check
 	{
-		fullscreenWidth = 640;
-		fullscreenHeight = 480;
+		// set to special value (0x0) that reverts to the default for this display
+		fullscreenWidth = 0;
+		fullscreenHeight = 0;
 	}
 	war_SetFullscreenModeWidth(fullscreenWidth);
 	war_SetFullscreenModeHeight(fullscreenHeight);

--- a/src/frontend.cpp
+++ b/src/frontend.cpp
@@ -3031,6 +3031,12 @@ static void displayTitleBitmap(WZ_DECL_UNUSED WIDGET *psWidget, WZ_DECL_UNUSED U
 		sstrcat(modListText, getModList().c_str());
 	}
 
+	if (pie_GetVideoBufferWidth() <= 0 || pie_GetVideoBufferHeight() <= 0)
+	{
+		// don't bother drawing when the dimensions are <= 0,0
+		return;
+	}
+
 	assert(psWidget->pUserData != nullptr);
 	TitleBitmapCache& cache = *static_cast<TitleBitmapCache*>(psWidget->pUserData);
 

--- a/src/loop.cpp
+++ b/src/loop.cpp
@@ -140,6 +140,12 @@ static GAMECODE renderLoop()
 		intAddInGamePopup();
 	}
 
+	bool skipDrawing = false;
+	if (gfx_api::context::get().getDrawableDimensions() == std::pair<uint32_t,uint32_t>(0,0))
+	{
+		skipDrawing = true;
+	}
+
 	audio_Update();
 
 	wzShowMouse(true);
@@ -298,7 +304,7 @@ static GAMECODE renderLoop()
 			pie_LoadBackDrop(SCREEN_RANDOMBDROP);
 		}
 	}
-	if (!loop_GetVideoStatus() && !quitting && !headlessGameMode())
+	if (!loop_GetVideoStatus() && !quitting && !headlessGameMode() && !skipDrawing)
 	{
 		if (!gameUpdatePaused())
 		{

--- a/src/loop.cpp
+++ b/src/loop.cpp
@@ -140,11 +140,7 @@ static GAMECODE renderLoop()
 		intAddInGamePopup();
 	}
 
-	bool skipDrawing = false;
-	if (gfx_api::context::get().getDrawableDimensions() == std::pair<uint32_t,uint32_t>(0,0))
-	{
-		skipDrawing = true;
-	}
+	bool skipDrawing = !gfx_api::context::get().shouldDraw();
 
 	audio_Update();
 


### PR DESCRIPTION
- Trigger window size change handler from window restore event
- Skip various types of drawing if drawable / swapchain dimensions are (effectively) 0,0