### PR TITLE
[CI] Snap: Use ubuntu-20.04 image until snapcore/action-build fixes an issue with newer images

### DIFF
--- a/.github/workflows/CI_snapcraft.yml
+++ b/.github/workflows/CI_snapcraft.yml
@@ -32,7 +32,7 @@ jobs:
     name: '${{ matrix.name }}'
     permissions:
       contents: write # Needed to upload to releases
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04 # Use instead of ubuntu-latest until https://github.com/snapcore/action-build/issues/42 is resolved
     if: "!contains(github.event.head_commit.message, '[ci skip]')"
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/generate_snap_stable_config.yml
+++ b/.github/workflows/generate_snap_stable_config.yml
@@ -38,7 +38,7 @@ jobs:
     name: 'Generate Snap Stable Config'
     permissions:
       contents: read
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04 # Use instead of ubuntu-latest until https://github.com/snapcore/action-build/issues/42 is resolved
     steps:
       - name: Generate Config
         id: config


### PR DESCRIPTION
See: https://github.com/snapcore/action-build/issues/42