### PR TITLE
Multiplayer: *Cyb-Wpn-Atmiss* tweak

### DIFF
--- a/data/mp/stats/weapons.json
+++ b/data/mp/stats/weapons.json
@@ -1466,7 +1466,7 @@
 	},
 	"Cyb-Wpn-Atmiss": {
 		"buildPoints": 1000,
-		"buildPower": 250,
+		"buildPower": 233,
 		"damage": 460,
 		"effectSize": 50,
 		"explosionWav": "smlexpl.ogg",
@@ -1479,7 +1479,7 @@
 		"hitpoints": 60,
 		"id": "Cyb-Wpn-Atmiss",
 		"lightWorld": 1,
-		"longRange": 1536,
+		"longRange": 1664,
 		"longHit": 80,
 		"maxElevation": 90,
 		"minElevation": -60,


### PR DESCRIPTION
These cyborgs are not popular and have the same range as the laser ones, so there is a need to improve *Cyb-Wpn-Atmiss* by adding one cell of range and slightly lowering the price by 17 units.
As a result, we get a range of 13 cells and the cost of 260 energy units. In this case Super Scourge Cyborg will remain the best solution - more range and faster reload
@KJeff01 Please add these changes to the autohost balance mod
[Cyb-Wpn-Atmiss.zip](https://github.com/Warzone2100/warzone2100/files/10022621/Cyb-Wpn-Atmiss.zip)
