### PR TITLE
[GitHub Actions] Flatpak: Initial publishing support

### DIFF
--- a/.ci/flatpak/publish_to_flathub.sh
+++ b/.ci/flatpak/publish_to_flathub.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+# This requires a bunch of environment variables to be set:
+# - WZ_FLATPAK_LOCAL_REPO_NAME
+# - FH_TOKEN
+# - FLAT_MANAGER_URL
+# - FH_REPOSITORY
+
+if [ -z "$WZ_FLATPAK_LOCAL_REPO_NAME" ]; then
+  echo "Missing WZ_FLATPAK_LOCAL_REPO_NAME environment variable"
+  exit 1
+fi
+if [ -z "$FH_TOKEN" ]; then
+  echo "Missing FH_TOKEN environment variable"
+  exit 1
+fi
+if [ -z "$FLAT_MANAGER_URL" ]; then
+  echo "Missing FLAT_MANAGER_URL environment variable"
+  exit 1
+fi
+if [ -z "$FH_REPOSITORY" ]; then
+  echo "Missing FH_REPOSITORY environment variable"
+  exit 1
+fi
+
+echo "::group::flatpak build-update-repo"
+flatpak build-update-repo --generate-static-deltas "${WZ_FLATPAK_LOCAL_REPO_NAME}"
+exit_status=$?
+if [ $exit_status -ne 0 ]; then
+  echo "build-update-repo failed: ${exit_status}"
+  exit ${exit_status}
+fi
+echo "::endgroup::"
+
+BUILD_ID="$(flat-manager-client --token "${FH_TOKEN}" create "${FLAT_MANAGER_URL}" ${FH_REPOSITORY})"
+if [ $? -ne 0 ]; then
+  echo "ERROR: flat-manager-client failed to create a build id"
+  exit 1
+fi
+BUILD_ID="$(echo -e "${BUILD_ID}" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
+echo "Created build id: \"${BUILD_ID}\""
+
+flat-manager-client --token "${FH_TOKEN}" push --commit --publish --wait "${BUILD_ID}" "${WZ_FLATPAK_LOCAL_REPO_NAME}"
+exit_status=$?
+if [ $exit_status -ne 0 ]; then
+  echo "ERROR: Pushing / publishing failed?"
+fi
+
+flat-manager-client --token "${FH_TOKEN}" purge "${BUILD_ID}"
+if [ $? -ne 0 ]; then
+  echo "ERROR: Purging failed"
+  exit_status=1
+fi
+exit ${exit_status}

--- a/.github/workflows/CI_flatpak.yml
+++ b/.github/workflows/CI_flatpak.yml
@@ -21,6 +21,10 @@ on:
         - '*'
     types: 
       - completed
+  # Support running on Release "publish" event to build and publish to Flathub
+  release:
+    types:
+      - published
 
 jobs:
   build-flatpak:
@@ -49,6 +53,8 @@ jobs:
     outputs:
       # Needed by the release job - despite this being a matrix job, this should be the same for all, so we can allow whatever is last to persist it
       WZ_GITHUB_REF: ${{ steps.checkout-config.outputs.WZ_GITHUB_REF }}
+      WZ_FLATPAK_BRANCH: ${{ steps.settings.outputs.WZ_FLATPAK_BRANCH }}
+      WZ_FLATPAK_APPID: ${{ steps.settings.outputs.WZ_FLATPAK_APPID }}
     steps:
     - name: Install Dependencies
       run: |
@@ -169,6 +175,7 @@ jobs:
         
         WZ_FLATPAK_APPID="net.wz2100.wz2100${WZ_OUTPUT_NAME_SUFFIX}"
         echo "WZ_FLATPAK_APPID=${WZ_FLATPAK_APPID}" >> $GITHUB_ENV
+        echo "WZ_FLATPAK_APPID=${WZ_FLATPAK_APPID}" >> $GITHUB_OUTPUT
         WZ_FLATPAK_BUNDLE="warzone2100${WZ_OUTPUT_FLATPAK_BUNDLE_SUFFIX}_linux_${WZ_TARGET_ARCH}.flatpak"
         echo "WZ_FLATPAK_BUNDLE=${WZ_FLATPAK_BUNDLE}" >> $GITHUB_ENV
         echo "WZ_FLATPAK_BUNDLE=${WZ_FLATPAK_BUNDLE}" >> $GITHUB_OUTPUT
@@ -215,6 +222,8 @@ jobs:
         . src/.ci/flatpak/build.sh
         echo "WZ_FLATPAK_LOCAL_REPO_NAME=${WZ_FLATPAK_LOCAL_REPO_NAME}"
         echo "WZ_FLATPAK_LOCAL_REPO_NAME=${WZ_FLATPAK_LOCAL_REPO_NAME}" >> $GITHUB_OUTPUT
+    ###############################################################
+    # Upload the .flatpak and debugsymbols artifacts
     - name: Upload Artifact
       uses: actions/upload-artifact@v3
       with:
@@ -233,35 +242,28 @@ jobs:
           flatpak_app/files/lib/debug/bin
           flatpak_app/files/lib/debug/lib
         if-no-files-found: 'error'
-    - name: Prep for separate beta branch build
-      if: success() && steps.settings.outputs.publish-to-flathub == 'true' && steps.settings.outputs.WZ_FLATPAK_BRANCH == 'stable'
+    ###############################################################
+    # Package the ostree repo (for use in later publish-release-to-flathub job)
+    - name: Tar ostree repo
+      if: success() && (github.event_name == 'release' && github.event.action == 'published')
+      id: repo-tar
       shell: bash
       env:
         WZ_FLATPAK_LOCAL_REPO_NAME: ${{ steps.build.outputs.WZ_FLATPAK_LOCAL_REPO_NAME }}
+        WZ_FLATPAK_BRANCH: ${{ steps.settings.outputs.WZ_FLATPAK_BRANCH }}
       run: |
-        # Remove the existing repo(s)
-        if [ ! -d "repo" ]; then
-          echo "::error ::Missing expected repo directory"
-          exit 1
-        fi
-        rm -rf repo
-        if [ -d "${WZ_FLATPAK_LOCAL_REPO_NAME}" ]; then
-          rm -rf ${WZ_FLATPAK_LOCAL_REPO_NAME}
-        fi
-    - name: Build (additional) beta branch for stable versions
-      if: success() && steps.settings.outputs.publish-to-flathub == 'true' && steps.settings.outputs.WZ_FLATPAK_BRANCH == 'stable'
-      continue-on-error: true
-      id: build-beta
-      env:
-        WZ_FLATPAK_MANIFEST_PATH: src/.ci/flatpak/net.wz2100.wz2100.yaml
-        WZ_FLATPAK_LOCAL_REPO_NAME: repo
-        WZ_FLATPAK_BRANCH: beta
-        SENTRY_IO_DSN: '${{ secrets.CRASHREPORTING_SENTRY_IO_DSN }}'
-        DISCORD_RPC_APPID: '${{ secrets.DISCORD_RPC_APPID }}'
-      run: |
-        . src/.ci/flatpak/build.sh
-        echo "WZ_FLATPAK_LOCAL_REPO_NAME=${WZ_FLATPAK_LOCAL_REPO_NAME}"
-        echo "WZ_FLATPAK_LOCAL_REPO_NAME=${WZ_FLATPAK_LOCAL_REPO_NAME}" >> $GITHUB_OUTPUT
+        REPO_TAR_FILE="repo_${WZ_FLATPAK_BRANCH}.tar"
+        tar cvf "${REPO_TAR_FILE}" "${WZ_FLATPAK_LOCAL_REPO_NAME}"
+        echo "REPO_TAR_FILE=${REPO_TAR_FILE}" >> $GITHUB_OUTPUT
+        echo "Generated: \"${REPO_TAR_FILE}\""
+        echo "  -> SHA512: $(sha512sum "${REPO_TAR_FILE}")"
+        echo "  -> Size (bytes): $(stat -c %s "${REPO_TAR_FILE}")"
+    - name: Upload ostree repo
+      if: success() && (github.event_name == 'release' && github.event.action == 'published')
+      uses: actions/upload-artifact@v3
+      with:
+        name: 'ostree_repo_flatpak_${{ matrix.arch }}_${{ steps.settings.outputs.WZ_FLATPAK_BRANCH }}'
+        path: '${{ steps.repo-tar.outputs.REPO_TAR_FILE }}'
 
   upload-debug-symbols:
     strategy:
@@ -269,12 +271,13 @@ jobs:
         include:
           - arch: "x86_64"
           - arch: "arm64"
+      fail-fast: false
     name: 'Upload Debug Symbols (${{ matrix.arch }})'
     permissions:
       contents: read
     runs-on: ubuntu-latest
-    # Run on push to master branch (development build), or tag release automation build
-    if: (github.repository == 'Warzone2100/warzone2100') && ((github.event_name == 'push' && github.ref == 'refs/heads/master') || (github.event_name == 'workflow_run' && github.event.workflow_run.name == 'Draft Tag Release'))
+    # Run on push to master branch (development build), or tag release automation build, or release publish event
+    if: (github.repository == 'Warzone2100/warzone2100') && ((github.event_name == 'push' && github.ref == 'refs/heads/master') || (github.event_name == 'workflow_run' && github.event.workflow_run.name == 'Draft Tag Release') || (github.event_name == 'release' && github.event.action == 'published'))
     needs: build-flatpak
     environment: upload_symbols
     # For this job to work, the following secrets must be set in the 'upload_symbols' environment:
@@ -311,6 +314,7 @@ jobs:
         include:
           - arch: "x86_64"
           - arch: "arm64"
+      fail-fast: false
     name: 'Upload Release Build (${{ matrix.arch }})'
     permissions:
       contents: write # Needed to upload to releases
@@ -343,3 +347,145 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
           WZ_GITHUB_REF: ${{needs.build-flatpak.outputs.WZ_GITHUB_REF}}
+
+  publish-release-to-flathub:
+    strategy:
+      matrix:
+        include:
+          - arch: "x86_64"
+            flatpak-arch: "x86_64"
+          - arch: "arm64"
+            flatpak-arch: "aarch64"
+      fail-fast: false
+    name: 'Publish Release to Flathub (${{ matrix.arch }})'
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    # For this job to work, the following secrets must be set in the 'flathub_publish_release' environment:
+    # FLATHUB_TOKEN
+    # FLATHUB_BETA_TOKEN
+    environment: flathub_publish_release
+    # Run on release publish event
+    if: (github.event_name == 'release' && github.event.action == 'published') && (github.repository == 'Warzone2100/warzone2100')
+    needs: build-flatpak
+    env:
+      WZ_GITHUB_REF: ${{needs.build-flatpak.outputs.WZ_GITHUB_REF}}
+      WZ_FLATPAK_BRANCH: ${{needs.build-flatpak.outputs.WZ_FLATPAK_BRANCH}}
+      WZ_FLATPAK_APPID: ${{needs.build-flatpak.outputs.WZ_FLATPAK_APPID}}
+      WZ_TARGET_ARCH: ${{ matrix.arch }}
+      WZ_FLATPAK_TARGET_ARCH: ${{ matrix.flatpak-arch }}
+    container:
+      image: fedora:latest
+      options: --privileged
+    steps:
+      - name: Install Dependencies
+        run: |
+          cat /etc/fedora-release
+        
+          echo "::group::dnf update"
+          dnf update -y
+          echo "::endgroup::"
+          echo "::group::dnf install dependencies"
+          dnf install -y cmake git git-lfs dbus-daemon flatpak flatpak-builder python3-aiohttp python3-tenacity python3-gobject ccache zstd curl appstream
+          echo "::endgroup::"
+        
+          echo "::group::flatpak remote-add"
+          flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
+          flatpak remote-add --if-not-exists flathub-beta https://flathub.org/beta-repo/flathub-beta.flatpakrepo
+          flatpak remote-add --if-not-exists gnome-nightly https://nightly.gnome.org/gnome-nightly.flatpakrepo
+          echo "::endgroup::"
+        
+          echo "::group::fetch flat-manager-client"
+          curl -Lf https://raw.githubusercontent.com/flatpak/flat-manager/master/flat-manager-client --output /usr/bin/flat-manager-client
+          chmod +x /usr/bin/flat-manager-client
+          echo "::endgroup::"
+      - uses: actions/checkout@v3
+        with:
+          path: 'src'
+          set-safe-directory: true
+      - name: Prep Environment
+        run: |
+          mkdir dl-artifacts
+      - name: Download Artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: 'ostree_repo_flatpak_${{ matrix.arch }}_${{ needs.build-flatpak.outputs.WZ_FLATPAK_BRANCH }}'
+          path: ./dl-artifacts
+      - name: Display structure of downloaded files
+        run: ls -R
+        working-directory: ./dl-artifacts
+      - name: Untar repo .tar
+        shell: bash
+        id: untar-repo
+        run: |
+          REPO_TAR_FILE="repo_${WZ_FLATPAK_BRANCH}.tar"
+          WZ_FLATPAK_LOCAL_REPO_NAME="repo_${WZ_FLATPAK_BRANCH}"
+          mkdir "${WZ_FLATPAK_LOCAL_REPO_NAME}"
+          echo "Retrieved: \"${REPO_TAR_FILE}\""
+          echo "  -> SHA512: $(sha512sum "./dl-artifacts/${REPO_TAR_FILE}")"
+          echo "  -> Size (bytes): $(stat -c %s "./dl-artifacts/${REPO_TAR_FILE}")"
+          echo "::group::tar extract"
+          tar --strip-components 1 -xvf "./dl-artifacts/${REPO_TAR_FILE}" -C "${WZ_FLATPAK_LOCAL_REPO_NAME}"
+          echo "::endgroup::"
+          echo "WZ_FLATPAK_LOCAL_REPO_NAME=${WZ_FLATPAK_LOCAL_REPO_NAME}"
+          echo "WZ_FLATPAK_LOCAL_REPO_NAME=${WZ_FLATPAK_LOCAL_REPO_NAME}" >> $GITHUB_ENV
+          echo "WZ_FLATPAK_LOCAL_REPO_NAME=${WZ_FLATPAK_LOCAL_REPO_NAME}" >> $GITHUB_OUTPUT
+      - name: Display structure of extracted files
+        run: ls -R
+        working-directory: ./
+      - name: Upload Flatpak repo to Flathub
+        env:
+          FLAT_MANAGER_URL: 'https://hub.flathub.org/'
+          FH_REPOSITORY: '${{ env.WZ_FLATPAK_BRANCH }}'
+          FH_STABLE_TOKEN: ${{ secrets.FLATHUB_TOKEN }}
+          FH_BETA_TOKEN: ${{ secrets.FLATHUB_BETA_TOKEN }}
+        shell: bash --noprofile --norc {0} # no pipefail
+        run: |
+          # choose which token to use, based on the WZ_FLATPAK_BRANCH
+          if [[ "$WZ_FLATPAK_BRANCH" == "stable" ]]; then
+            FH_TOKEN="${FH_STABLE_TOKEN}"
+          elif [[ "$WZ_FLATPAK_BRANCH" == "beta" ]]; then
+            FH_TOKEN="${FH_BETA_TOKEN}"
+          else
+            echo "ERROR: Invalid branch: ${WZ_FLATPAK_BRANCH}"
+            exit 1
+          fi
+          . src/.ci/flatpak/publish_to_flathub.sh
+      ###############################################################
+      # If stable release: Also publish to the beta branch
+      - name: Build separate beta branch repo from stable repo
+        id: build-beta
+        if: success() && (needs.build-flatpak.outputs.WZ_FLATPAK_BRANCH == 'stable')
+        shell: bash
+        env:
+          SRC_LOCAL_REPO_NAME: ${{ steps.untar-repo.outputs.WZ_FLATPAK_LOCAL_REPO_NAME }}
+        run: |
+          # Create a new repository for the beta branch
+          echo "::group::Creating new local repo for beta branch"
+          WZ_FLATPAK_LOCAL_REPO_NAME="${WZ_FLATPAK_TARGET_ARCH}-repo-beta"
+          ostree init --mode archive-z2 --repo=${WZ_FLATPAK_LOCAL_REPO_NAME}
+          echo "::endgroup::"
+  
+          echo "::group::Build commit from stable repo"
+          for i in app/${WZ_FLATPAK_APPID} \
+                   runtime/${WZ_FLATPAK_APPID}.Debug
+          do
+             # Move the commits to the beta repo
+             echo "Processing: --src-ref=${i}/${WZ_FLATPAK_TARGET_ARCH}/${WZ_FLATPAK_BRANCH}"
+             flatpak build-commit-from --update-appstream --no-update-summary --src-ref=${i}/${WZ_FLATPAK_TARGET_ARCH}/${WZ_FLATPAK_BRANCH} --src-repo=${SRC_LOCAL_REPO_NAME} \
+                ${WZ_FLATPAK_LOCAL_REPO_NAME} ${i}/${WZ_FLATPAK_TARGET_ARCH}/beta
+          done
+          echo "::endgroup::"
+          echo "WZ_FLATPAK_LOCAL_REPO_NAME=${WZ_FLATPAK_LOCAL_REPO_NAME}"
+          echo "WZ_FLATPAK_LOCAL_REPO_NAME=${WZ_FLATPAK_LOCAL_REPO_NAME}" >> $GITHUB_OUTPUT
+      - name: Upload additional beta Flatpak repo to Flathub
+        if: success() && (needs.build-flatpak.outputs.WZ_FLATPAK_BRANCH == 'stable')
+        env:
+          FLAT_MANAGER_URL: 'https://hub.flathub.org/'
+          FH_REPOSITORY: '${{ env.WZ_FLATPAK_BRANCH }}'
+          FH_TOKEN: ${{ secrets.FLATHUB_BETA_TOKEN }}
+          WZ_FLATPAK_LOCAL_REPO_NAME: ${{ steps.build-beta.outputs.WZ_FLATPAK_LOCAL_REPO_NAME }}
+          WZ_FLATPAK_BRANCH: beta
+        shell: bash --noprofile --norc {0} # no pipefail
+        run: |
+          . src/.ci/flatpak/publish_to_flathub.sh


### PR DESCRIPTION
Initial support for publishing to Flathub.

Future TODO:
For this to *actually* work, the following tokens must be obtained and set in the `flathub_publish_release` environment:
- `FLATHUB_TOKEN`
- `FLATHUB_BETA_TOKEN`