### PR TITLE
Fix reverting campaign chosen color

### DIFF
--- a/src/configuration.cpp
+++ b/src/configuration.cpp
@@ -683,7 +683,7 @@ bool saveConfig()
 	iniSetString("publicIPv6LookupService_JSONKey", getPublicIPv6LookupServiceJSONKey());
 	if (!bMultiPlayer)
 	{
-		iniSetInteger("colour", (int)getPlayerColour(0));			// favourite colour.
+		iniSetInteger("colour", (int)war_GetSPcolor());			// favourite colour.
 	}
 	else
 	{


### PR DESCRIPTION
Init code somewhere is setting color back to the default green and we should save the SP color instead of the current one.

Fixes #3036.