### PR TITLE
(MP)Rocket Tweak

### DIFF
--- a/data/mp/stats/research.json
+++ b/data/mp/stats/research.json
@@ -8265,7 +8265,7 @@
 		"name": "Improved Rocket Wire Guidance",
 		"requiredResearch": [
 			"R-Wpn-Rocket-Damage04",
-			"R-Struc-Research-Upgrade02"
+			"R-Wpn-Rocket-Accuracy01"
 		],
 		"researchPoints": 4800,
 		"researchPower": 150,
@@ -8649,8 +8649,7 @@
 			"Rocket-VTOL-Pod"
 		],
 		"requiredResearch": [
-			"R-Wpn-Rocket-Damage03",
-			"R-Wpn-Rocket-Accuracy01"
+			"R-Wpn-Rocket-Damage03"
 		],
 		"researchPoints": 3600,
 		"researchPower": 112,

--- a/data/mp/stats/research.json
+++ b/data/mp/stats/research.json
@@ -8238,8 +8238,8 @@
 			"R-Struc-Research-Upgrade01",
 			"R-Wpn-Rocket-Damage02"
 		],
-		"researchPoints": 3600,
-		"researchPower": 112,
+		"researchPoints": 2400,
+		"researchPower": 75,
 		"results": [
 			{
 				"class": "Weapon",
@@ -8354,8 +8354,8 @@
 		"requiredResearch": [
 			"R-Wpn-Rocket-Damage02"
 		],
-		"researchPoints": 3600,
-		"researchPower": 112,
+		"researchPoints": 2400,
+		"researchPower": 75,
 		"results": [
 			{
 				"class": "Weapon",

--- a/data/mp/stats/weapons.json
+++ b/data/mp/stats/weapons.json
@@ -4096,7 +4096,7 @@
 		"id": "Rocket-Pod",
 		"lightWorld": 1,
 		"longRange": 1088,
-		"longHit": 45,
+		"longHit": 50,
 		"maxElevation": 90,
 		"minElevation": -60,
 		"minRange": 128,

--- a/data/mp/stats/weapons.json
+++ b/data/mp/stats/weapons.json
@@ -3940,7 +3940,7 @@
 		"numExplosions": 1,
 		"numRounds": 2,
 		"radiusLife": 10,
-		"reloadTime": 180,
+		"reloadTime": 160,
 		"rotate": 180,
 		"shortHit": 30,
 		"shortRange": 512,


### PR DESCRIPTION
Results:
Reduced the research time of HE Rockets Mk3 and Stabilized Rockets by 34%
Reduced the reload time of the Tank Killer AT and now it is the same as the Super Tank-Killer Cyborg or Lancer AT
Improved accuracy of Rocket Pod at long range from 45% to 50% 