### PR TITLE
(MP)Needle Gun Tweak

### DIFF
--- a/data/mp/stats/weapons.json
+++ b/data/mp/stats/weapons.json
@@ -3711,7 +3711,7 @@
 		"weight": 600
 	},
 	"RailGun1Mk1": {
-		"buildPoints": 1000,
+		"buildPoints": 800,
 		"buildPower": 250,
 		"damage": 160,
 		"designable": 1,


### PR DESCRIPTION
Results:
Needle Gun Turret production time has been reduced and is now the same as the Twin Assault Cannon or Heavy Cannon