### PR TITLE
vk_mem_alloc: Ignore -Wcast-align on GCC on all architectures

### DIFF
--- a/lib/ivis_opengl/3rdparty/vk_mem_alloc.cpp
+++ b/lib/ivis_opengl/3rdparty/vk_mem_alloc.cpp
@@ -44,9 +44,7 @@
 # pragma GCC diagnostic ignored "-Wunused-variable"
 # pragma GCC diagnostic ignored "-Wmissing-field-initializers"
 # pragma GCC diagnostic ignored "-Wmissing-noreturn"
-#  if (defined(__arm__) || defined(__thumb__)) && !defined(__aarch64__)
-#    pragma GCC diagnostic ignored "-Wcast-align"
-#  endif
+# pragma GCC diagnostic ignored "-Wcast-align"
 #elif defined(_MSC_VER)
 # pragma warning( push )
 # pragma warning( disable : 4189 ) // warning C4189: 'identifier' : local variable is initialized but not referenced


### PR DESCRIPTION
The warning is not only on ARM, in Debian it has also appeared on mipsel/riscv64/sparc64:
https://buildd.debian.org/status/fetch.php?pkg=warzone2100&arch=mipsel&ver=4.3.3-2&stamp=1673283805&raw=0
https://buildd.debian.org/status/fetch.php?pkg=warzone2100&arch=riscv64&ver=4.3.3-2&stamp=1673283800&raw=0
https://buildd.debian.org/status/fetch.php?pkg=warzone2100&arch=sparc64&ver=4.3.3-2&stamp=1673282438&raw=0