### PR TITLE
(MP)Mortar Tweak

### DIFF
--- a/data/mp/stats/research.json
+++ b/data/mp/stats/research.json
@@ -6452,10 +6452,11 @@
 		"name": "Howitzer",
 		"requiredResearch": [
 			"R-Wpn-Mortar-Damage04",
-			"R-Sys-Sensor-Upgrade01"
+			"R-Sys-Sensor-Upgrade01",
+			"R-Struc-Research-Upgrade06"
 		],
-		"researchPoints": 9000,
-		"researchPower": 281,
+		"researchPoints": 9640,
+		"researchPower": 300,
 		"resultComponents": [
 			"Howitzer105Mk1"
 		],
@@ -7858,8 +7859,7 @@
 		"msgName": "RES_MORTA1",
 		"name": "Mortar",
 		"requiredResearch": [
-			"R-Wpn-Cannon-Damage01",
-			"R-Struc-Factory-Module"
+			"R-Wpn-Cannon-Damage01"
 		],
 		"researchPoints": 2400,
 		"researchPower": 75,

--- a/data/mp/stats/weapons.json
+++ b/data/mp/stats/weapons.json
@@ -3340,7 +3340,7 @@
 		"weight": 2000
 	},
 	"Mortar1Mk1": {
-		"buildPoints": 500,
+		"buildPoints": 400,
 		"buildPower": 100,
 		"damage": 60,
 		"designable": 1,
@@ -3381,7 +3381,7 @@
 		"weight": 2000
 	},
 	"Mortar2Mk1": {
-		"buildPoints": 900,
+		"buildPoints": 1000,
 		"buildPower": 200,
 		"damage": 120,
 		"designable": 1,


### PR DESCRIPTION
Removed the required Factory Module research for Mortar. As a result, the mortar will be available 1.5 min earlier from start without a base or with an incomplete base. From the start with a full base the mortar will be available immediately. This change is made in order to balance the Mortar branch with the other branches.