### PR TITLE
Fix build with GCC 13 (add missing <cstdint> include)

### DIFF
--- a/lib/framework/wzstring.h
+++ b/lib/framework/wzstring.h
@@ -20,6 +20,7 @@
 #ifndef _LIB_FRAMEWORK_WZSTRING_H
 #define _LIB_FRAMEWORK_WZSTRING_H
 
+#include <cstdint>
 #include <string>
 #include <vector>
 #include <locale>


### PR DESCRIPTION
GCC 13 (as usual for new compiler releases) shuffles around some internal includes and so <cstdint> is no longer transitively included.

Explicitly include <cstdint> for uint32_t.

Signed-off-by: Sam James <sam@gentoo.org>