### PR TITLE
Make easier campaign difficulties easier

### DIFF
--- a/src/difficulty.cpp
+++ b/src/difficulty.cpp
@@ -53,10 +53,10 @@ void setDifficultyLevel(DIFFICULTY_LEVEL lev)
 	switch (lev)
 	{
 	case DL_SUPER_EASY:
-		setDamageModifiers(150, 70);
+		setDamageModifiers(200, 50);
 		break;
 	case DL_EASY:
-		setDamageModifiers(125, 85);
+		setDamageModifiers(150, 70);
 		break;
 	case DL_NORMAL:
 		setDamageModifiers(100, 100);


### PR DESCRIPTION
For anyone playing on easier difficulties, the difficulty should match it's name.

- The Easy difficulty damage modifiers with this change matches the damage modifiers of Super easy difficulty before this change.
- You take 50% damage and deal 200% damage with Super easy difficulty after this change compared to Normal.
