### PR TITLE
PIE format & model level enhancements

### DIFF
--- a/doc/PIE_old.md
+++ b/doc/PIE_old.md
@@ -1,15 +1,12 @@
-PIE 4
+PIE 2/3
 =======
 
 Description
 -----------
 
-The PIE format is a custom model format originally created by Pumpkin.
+The PIE format is a custom model format created by Pumpkin.
 
-It has gone through three iterations since the original commercial release:
-- PIE 2 was used until version 2.3, and is still supported
-- PIE 3 was the standard from version 2.3 through 4.3, and is still supported
-- PIE 4 was introduced in Warzone 2100 version 4.4, and is the recommended format for new models
+It has gone through two iterations since the original commercial release. PIE 2 was used until version 2.3 and is still supported. PIE 3 is the de facto standard now, and newer models should use it.
 
 PIE 2 uses integer coordinate values ranging from 0 to 256, corresponding to 1024 pixels for texture pages.
 For example, the coordinates 128,256 refer to pixel coordinates 512,1024.
@@ -18,18 +15,14 @@ PIE 3 uses floating point UV coordinates which range from 0 to 1, usually with s
 Thus, the coordinates 0.111111,1.000000 represent offset 113.777777,256 for a picture 1024x1024 pixels large.
 For texture repetition, UV coordinates can be negative numbers. Only Helicopter models currently contain those, with a precision of eight digits.
 
-PIE 4 adds level overrides for global directives, the TCMASK directive, support for in-file comments (denoted by #), and removes some old (deprecated) functionality.
-
 Format
 ------
 
-## GLOBAL DIRECTIVES
-
 ### PIE
 
-> PIE 4
+> PIE 3
 
-The first line specifies the version number.
+The first line specifies the version number -- either 2 or 3.
 
 ### TYPE
 
@@ -57,7 +50,7 @@ Optional. Specifies if the model wants to have interpolated frames. Default is s
 
 ### TEXTURE
 
-> TEXTURE 0 page-7-barbarians-arizona.png
+> TEXTURE 0 page-7-barbarians-arizona.png 0 0
 
 This sets the texture page for the model. Each file must contain exactly one such line.
 In theory you could leave out this line, but in practice that makes your models useless.
@@ -70,11 +63,8 @@ The second gives you the filename of the texture page, which
 * should start with "page-NN-" for correct handling of dynamic texture replacement.
 * should end with the letters ".png".
 
-### TCMASK
-
-> TCMASK 0 page-7_tcmask.png
-
-Optional. As above, but this sets the tcmask texture page for this model.
+The third and fourth parameters give the size of the texture, and are also ignored, since we can just read that info from the texture page itself.
+You may fill them out with the correct values for backward compatibility.
 
 ### NORMALMAP
 
@@ -106,25 +96,27 @@ replaced with the specified model for the duration of the event. The following e
 
 This gives the number of meshes that are contained in this model. Each mesh can be animated separately in ANI files.
 
-## LEVEL DIRECTIVES
-
 ### LEVEL
 
 > LEVEL 1
 
 This starts the model description for mesh 1. Repeat the below as necessary while incrementing the value above as needed.
 
-### (OPTIONAL) PER-LEVEL OVERRIDES
+### MATERIALS (disabled)
 
-The following global directives can be specified at the LEVEL scope to override the associated global directive for the level:
-- TYPE
-- INTERPOLATE
-- TEXTURE
-- TCMASK
-- NORMALMAP
-- SPECULARMAP
+This feature was removed in commit 823cf08bb18cf24852bac8595b3899aca12d4f7b.
 
-They should be specified in the order listed above. All are optional and, if omitted, the associated global directive will be used (if set).
+> MATERIALS 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 20
+
+Optional. Specifies the material properties of a mesh. The nine first values give the RGB values for ambient, diffuse and specular lighting, respectively. The last value sets shininess.
+
+### SHADERS (disabled)
+
+This feature is currently unsupported.
+
+> SHADERS 2 vertex.vert fragment.vert
+
+Optional. Create a specific shader program for this mesh. The number 2 is not parsed but should always be 2.
 
 ### POINTS
 
@@ -154,7 +146,8 @@ Each line *must* be indented with a tab. It *must* contain exactly 3 normals (on
 
 > POLYGONS n
 
-This starts a list of polygon faces with the number of lines *n*.
+
+This starts a list of polygon faces with the number of lines *n*, which must be less than or equal to 512.
 
 #### Polygon lines
 

--- a/lib/ivis_opengl/imd.h
+++ b/lib/ivis_opengl/imd.h
@@ -28,6 +28,10 @@ struct iIMDShape;
 #define PIE_NAME				"PIE"  // Pumpkin image export data file
 #define PIE_VER				2
 #define PIE_FLOAT_VER		3
+#define PIE_VER_4			4
+
+#define PIE_MIN_VER			PIE_VER
+#define PIE_MAX_VER			4
 
 //*************************************************************************
 

--- a/lib/ivis_opengl/imdload.cpp
+++ b/lib/ivis_opengl/imdload.cpp
@@ -1366,18 +1366,19 @@ static iIMDShape *_imd_load_level(const WzString &filename, const char **ppFileD
 
 		ASSERT_OR_RETURN(nullptr, texpage.has_value(), "%s could not load tex page %s", filename.toUtf8().c_str(), pLevelSettingsToUseForTextures->texfile.c_str());
 
-		if (!pLevelSettingsToUseForTextures->tcmaskfile.empty())
+		const LevelSettings* pLevelSettingsToUseForTCMask = (!levelSettings.tcmaskfile.empty()) ? &levelSettings : &globalLevelSettings;
+		if (!pLevelSettingsToUseForTCMask->tcmaskfile.empty())
 		{
 			// load explicitly specified tcmask file
-			debug(LOG_TEXTURE, "Loading tcmask %s for %s", pLevelSettingsToUseForTextures->tcmaskfile.c_str(), filename.toUtf8().c_str());
-			tcmaskpage = iV_GetTexture(pLevelSettingsToUseForTextures->tcmaskfile.c_str(), gfx_api::texture_type::alpha_mask);
-			ASSERT_OR_RETURN(nullptr, tcmaskpage.has_value(), "%s could not load tcmask %s", filename.toUtf8().c_str(), pLevelSettingsToUseForTextures->tcmaskfile.c_str());
+			debug(LOG_TEXTURE, "Loading tcmask %s for %s", pLevelSettingsToUseForTCMask->tcmaskfile.c_str(), filename.toUtf8().c_str());
+			tcmaskpage = iV_GetTexture(pLevelSettingsToUseForTCMask->tcmaskfile.c_str(), gfx_api::texture_type::alpha_mask);
+			ASSERT_OR_RETURN(nullptr, tcmaskpage.has_value(), "%s could not load tcmask %s", filename.toUtf8().c_str(), pLevelSettingsToUseForTCMask->tcmaskfile.c_str());
 		}
 		else
 		{
 			// BACKWARDS-COMPATIBILITY (PIE 2/3 compatibility)
 			// check if model should use team colour mask
-			if (pLevelSettingsToUseForTextures->imd_flags.value_or(0) & iV_IMD_TCMASK)
+			if (flags & iV_IMD_TCMASK)
 			{
 				std::string tcmask_name = pie_MakeTexPageTCMaskName(pLevelSettingsToUseForTextures->texfile.c_str());
 				tcmask_name += ".png";
@@ -1386,18 +1387,20 @@ static iIMDShape *_imd_load_level(const WzString &filename, const char **ppFileD
 			}
 		}
 
-		if (!pLevelSettingsToUseForTextures->normalfile.empty())
+		const LevelSettings* pLevelSettingsToUseForNormals = (!levelSettings.normalfile.empty()) ? &levelSettings : &globalLevelSettings;
+		if (!pLevelSettingsToUseForNormals->normalfile.empty())
 		{
-			debug(LOG_TEXTURE, "Loading normal map %s for %s", pLevelSettingsToUseForTextures->normalfile.c_str(), filename.toUtf8().c_str());
-			normalpage = iV_GetTexture(pLevelSettingsToUseForTextures->normalfile.c_str(), gfx_api::texture_type::normal_map);
-			ASSERT_OR_RETURN(nullptr, normalpage.has_value(), "%s could not load tex page %s", filename.toUtf8().c_str(), pLevelSettingsToUseForTextures->normalfile.c_str());
+			debug(LOG_TEXTURE, "Loading normal map %s for %s", pLevelSettingsToUseForNormals->normalfile.c_str(), filename.toUtf8().c_str());
+			normalpage = iV_GetTexture(pLevelSettingsToUseForNormals->normalfile.c_str(), gfx_api::texture_type::normal_map);
+			ASSERT_OR_RETURN(nullptr, normalpage.has_value(), "%s could not load tex page %s", filename.toUtf8().c_str(), pLevelSettingsToUseForNormals->normalfile.c_str());
 		}
 
-		if (!pLevelSettingsToUseForTextures->specfile.empty())
+		const LevelSettings* pLevelSettingsToUseForSpecular = (!levelSettings.specfile.empty()) ? &levelSettings : &globalLevelSettings;
+		if (!pLevelSettingsToUseForSpecular->specfile.empty())
 		{
-			debug(LOG_TEXTURE, "Loading specular map %s for %s", pLevelSettingsToUseForTextures->specfile.c_str(), filename.toUtf8().c_str());
-			specpage = iV_GetTexture(pLevelSettingsToUseForTextures->specfile.c_str(), gfx_api::texture_type::specular_map);
-			ASSERT_OR_RETURN(nullptr, specpage.has_value(), "%s could not load tex page %s", filename.toUtf8().c_str(), pLevelSettingsToUseForTextures->specfile.c_str());
+			debug(LOG_TEXTURE, "Loading specular map %s for %s", pLevelSettingsToUseForSpecular->specfile.c_str(), filename.toUtf8().c_str());
+			specpage = iV_GetTexture(pLevelSettingsToUseForSpecular->specfile.c_str(), gfx_api::texture_type::specular_map);
+			ASSERT_OR_RETURN(nullptr, specpage.has_value(), "%s could not load tex page %s", filename.toUtf8().c_str(), pLevelSettingsToUseForSpecular->specfile.c_str());
 		}
 
 		// assign tex pages and flags for this level

--- a/lib/ivis_opengl/ivisdef.h
+++ b/lib/ivis_opengl/ivisdef.h
@@ -160,7 +160,7 @@ struct iIMDShape
 	int interpolate = 1; // if the model wants to be interpolated
 
 	std::string modelName;
-	int modelLevel = 0;
+	uint32_t modelLevel = 0;
 
 	iIMDShape *next = nullptr;  // next pie in multilevel pies (NULL for non multilevel !)
 };

--- a/lib/ivis_opengl/piedef.h
+++ b/lib/ivis_opengl/piedef.h
@@ -43,7 +43,7 @@ struct iIMDShape;
  *	Global ProtoTypes
  */
 /***************************************************************************/
-bool pie_Draw3DShape(iIMDShape *shape, int frame, int team, PIELIGHT colour, int pieFlag, int pieFlagData, const glm::mat4 &modelView, float stretchDepth = 0.f);
+bool pie_Draw3DShape(iIMDShape *shape, int frame, int team, PIELIGHT colour, int pieFlag, int pieFlagData, const glm::mat4 &modelView, float stretchDepth = 0.f, bool onlySingleLevel = false);
 void pie_Draw3DButton(iIMDShape *shape, PIELIGHT teamcolour, const glm::mat4 &matrix);
 
 void pie_GetResetCounts(size_t *pPieCount, size_t *pPolyCount);

--- a/lib/ivis_opengl/piedraw.cpp
+++ b/lib/ivis_opengl/piedraw.cpp
@@ -982,21 +982,35 @@ void pie_CleanUp()
 	}
 }
 
-bool pie_Draw3DShape(iIMDShape *shape, int frame, int team, PIELIGHT colour, int pieFlag, int pieFlagData, const glm::mat4 &modelView, float stretchDepth)
+bool pie_Draw3DShape(iIMDShape *shape, int frame, int team, PIELIGHT colour, int pieFlag, int pieFlagData, const glm::mat4 &modelView, float stretchDepth, bool onlySingleLevel)
 {
 	pieCount++;
 
 	ASSERT(frame >= 0, "Negative frame %d", frame);
 	ASSERT(team >= 0, "Negative team %d", team);
 
+	bool retVal = false;
+	const bool drawAllLevels = (shape->modelLevel == 0) && !onlySingleLevel;
 	const PIELIGHT teamcolour = pal_GetTeamColour(team);
-	if (pieFlag & pie_BUTTON)
-	{
-		pie_Draw3DButton(shape, teamcolour, modelView);
-		return true;
-	}
 
-	return instancedMeshRenderer.Draw3DShape(shape, frame, teamcolour, colour, pieFlag, pieFlagData, modelView, stretchDepth);
+	iIMDShape *pCurrShape = shape;
+	do
+	{
+		if (pieFlag & pie_BUTTON)
+		{
+			pie_Draw3DButton(pCurrShape, teamcolour, modelView);
+			retVal = true;
+		}
+		else
+		{
+			retVal = instancedMeshRenderer.Draw3DShape(pCurrShape, frame, teamcolour, colour, pieFlag, pieFlagData, modelView, stretchDepth);
+		}
+
+		pCurrShape = pCurrShape->next;
+
+	} while (drawAllLevels && pCurrShape && retVal);
+
+	return retVal;
 }
 
 static void pie_ShadowDrawLoop(ShadowCache &shadowCache)

--- a/src/component.cpp
+++ b/src/component.cpp
@@ -504,9 +504,13 @@ static bool displayCompObj(DROID *psDroid, bool bButton, const glm::mat4 &viewMa
 			strImd = psShapeBody->objanimpie[psDroid->animationEvent];
 		}
 		glm::mat4 viewModelMatrix = viewMatrix * modelMatrix;
-		if (drawShape(psDroid, strImd, colour, brightness, pieFlag, iPieData, viewModelMatrix))
+		while (strImd)
 		{
-			didDrawSomething = true;
+			if (drawShape(psDroid, strImd, colour, brightness, pieFlag, iPieData, viewModelMatrix))
+			{
+				didDrawSomething = true;
+			}
+			strImd = strImd->next;
 		}
 	}
 

--- a/src/component.cpp
+++ b/src/component.cpp
@@ -504,13 +504,9 @@ static bool displayCompObj(DROID *psDroid, bool bButton, const glm::mat4 &viewMa
 			strImd = psShapeBody->objanimpie[psDroid->animationEvent];
 		}
 		glm::mat4 viewModelMatrix = viewMatrix * modelMatrix;
-		while (strImd)
+		if (drawShape(psDroid, strImd, colour, brightness, pieFlag, iPieData, viewModelMatrix))
 		{
-			if (drawShape(psDroid, strImd, colour, brightness, pieFlag, iPieData, viewModelMatrix))
-			{
-				didDrawSomething = true;
-			}
-			strImd = strImd->next;
+			didDrawSomething = true;
 		}
 	}
 

--- a/src/display3d.cpp
+++ b/src/display3d.cpp
@@ -1735,6 +1735,33 @@ void	renderProjectile(PROJECTILE *psCurr, const glm::mat4 &viewMatrix, const glm
 	{
 		return; // Projectile is not on the screen (Note: This uses the position point of the projectile, not a full shape clipping check, for speed.)
 	}
+
+	/* Get bullet's x coord */
+	dv.x = st.pos.x - playerPos.p.x;
+
+	/* Get it's y coord (z coord in the 3d world */
+	dv.z = -(st.pos.y - playerPos.p.z);
+
+	/* What's the present height of the bullet? */
+	dv.y = st.pos.z;
+
+	/* Set up the matrix */
+	Vector3i camera_base = actualCameraPosition;
+
+	/* Translate to the correct position */
+	camera_base -= dv;
+
+	/* Rotate it to the direction it's facing */
+	rotateSomething(camera_base.z, camera_base.x, -(-st.rot.direction));
+
+	/* pitch it */
+	rotateSomething(camera_base.y, camera_base.z, -st.rot.pitch);
+
+	const glm::mat4 modelMatrix_base =
+		glm::translate(glm::vec3(dv)) *
+		glm::rotate(UNDEG(-st.rot.direction), glm::vec3(0.f, 1.f, 0.f)) *
+		glm::rotate(UNDEG(st.rot.pitch), glm::vec3(1.f, 0.f, 0.f));
+
 	for (; pIMD != nullptr; pIMD = pIMD->next)
 	{
 		bool rollToCamera = false;
@@ -1765,30 +1792,8 @@ void	renderProjectile(PROJECTILE *psCurr, const glm::mat4 &viewMatrix, const glm
 			premultiplied = true;
 		}
 
-		/* Get bullet's x coord */
-		dv.x = st.pos.x - playerPos.p.x;
-
-		/* Get it's y coord (z coord in the 3d world */
-		dv.z = -(st.pos.y - playerPos.p.z);
-
-		/* What's the present height of the bullet? */
-		dv.y = st.pos.z;
-		/* Set up the matrix */
-		Vector3i camera = actualCameraPosition;
-
-		/* Translate to the correct position */
-		camera -= dv;
-
-		/* Rotate it to the direction it's facing */
-		rotateSomething(camera.z, camera.x, -(-st.rot.direction));
-
-		/* pitch it */
-		rotateSomething(camera.y, camera.z, -st.rot.pitch);
-
-		glm::mat4 modelMatrix =
-			glm::translate(glm::vec3(dv)) *
-			glm::rotate(UNDEG(-st.rot.direction), glm::vec3(0.f, 1.f, 0.f)) *
-			glm::rotate(UNDEG(st.rot.pitch), glm::vec3(1.f, 0.f, 0.f));
+		Vector3i camera = camera_base;
+		glm::mat4 modelMatrix = modelMatrix_base;
 
 		if (pitchToCamera || rollToCamera)
 		{

--- a/src/display3d.cpp
+++ b/src/display3d.cpp
@@ -585,7 +585,7 @@ float interpolateAngleDegrees(int a, int b, float t)
 	return a + d * t;
 }
 
-bool drawShape(BASE_OBJECT *psObj, iIMDShape *strImd, int colour, PIELIGHT buildingBrightness, int pieFlag, int pieFlagData, const glm::mat4& viewMatrix, float stretchDepth, bool onlySingleLevel)
+bool drawShape(BASE_OBJECT *psObj, iIMDShape *strImd, int colour, PIELIGHT buildingBrightness, int pieFlag, int pieFlagData, const glm::mat4& viewMatrix, float stretchDepth)
 {
 	glm::mat4 modelMatrix(1.f);
 	int animFrame = 0; // for texture animation
@@ -634,7 +634,7 @@ bool drawShape(BASE_OBJECT *psObj, iIMDShape *strImd, int colour, PIELIGHT build
 		}
 	}
 
-	return pie_Draw3DShape(strImd, animFrame, colour, buildingBrightness, pieFlag, pieFlagData, viewMatrix * modelMatrix, stretchDepth, onlySingleLevel);
+	return pie_Draw3DShape(strImd, animFrame, colour, buildingBrightness, pieFlag, pieFlagData, viewMatrix * modelMatrix, stretchDepth, true);
 }
 
 static void setScreenDispWithPerspective(SCREEN_DISP_DATA *sDisplay, const glm::mat4 &perspectiveViewModelMatrix)
@@ -2748,7 +2748,7 @@ void renderStructure(STRUCTURE *psStructure, const glm::mat4 &viewMatrix, const 
 		{
 			stretch = psStructure->pos.z - psStructure->foundationDepth;
 		}
-		drawShape(psStructure, getFactionIMD(faction, strImd), colour, buildingBrightness, pieFlag, pieFlagData, viewModelMatrix, stretch, true);
+		drawShape(psStructure, getFactionIMD(faction, strImd), colour, buildingBrightness, pieFlag, pieFlagData, viewModelMatrix, stretch);
 		if (psStructure->sDisplay.imd->nconnectors > 0)
 		{
 			renderStructureTurrets(psStructure, getFactionIMD(faction, strImd), buildingBrightness, pieFlag, pieFlagData, ecmFlag, viewModelMatrix);

--- a/src/display3d.h
+++ b/src/display3d.h
@@ -138,7 +138,7 @@ extern bool CauseCrash;
 extern bool tuiTargetOrigin;
 
 /// Draws using the animation systems. Usually want to use in a while loop to get all model levels.
-bool drawShape(BASE_OBJECT *psObj, iIMDShape *strImd, int colour, PIELIGHT buildingBrightness, int pieFlag, int pieFlagData, const glm::mat4& viewMatrix, float stretchDepth = 0.f, bool onlySingleLevel = false);
+bool drawShape(BASE_OBJECT *psObj, iIMDShape *strImd, int colour, PIELIGHT buildingBrightness, int pieFlag, int pieFlagData, const glm::mat4& viewMatrix, float stretchDepth = 0.f);
 
 int calculateCameraHeightAt(int tileX, int tileY);
 

--- a/src/display3d.h
+++ b/src/display3d.h
@@ -138,7 +138,7 @@ extern bool CauseCrash;
 extern bool tuiTargetOrigin;
 
 /// Draws using the animation systems. Usually want to use in a while loop to get all model levels.
-bool drawShape(BASE_OBJECT *psObj, iIMDShape *strImd, int colour, PIELIGHT buildingBrightness, int pieFlag, int pieFlagData, const glm::mat4& viewMatrix, float stretchDepth = 0.f);
+bool drawShape(BASE_OBJECT *psObj, iIMDShape *strImd, int colour, PIELIGHT buildingBrightness, int pieFlag, int pieFlagData, const glm::mat4& viewMatrix, float stretchDepth = 0.f, bool onlySingleLevel = false);
 
 int calculateCameraHeightAt(int tileX, int tileY);
 

--- a/src/feature.cpp
+++ b/src/feature.cpp
@@ -496,7 +496,7 @@ bool destroyFeature(FEATURE *psDel, unsigned impactTime)
 		// ----- Flip all the tiles under the skyscraper to a rubble tile
 		// smoke effect should disguise this happening
 		StructureBounds b = getStructureBounds(psDel);
-		bool isUrban = tilesetDir && strcmp(tilesetDir, "texpages/tertilesc2hw") == 0;
+		bool isUrban = (currentMapTileset == MAP_TILESET::URBAN);
 		for (int breadth = 0; breadth < b.size.y; ++breadth)
 		{
 			for (int width = 0; width < b.size.x; ++width)

--- a/src/lighting.cpp
+++ b/src/lighting.cpp
@@ -310,17 +310,20 @@ void updateFogDistance(float distance)
 void setDefaultFogColour()
 {
 	ASSERT(tilesetDir != nullptr, "Uninitialized tilesetDir");
-	if (tilesetDir && strcmp(tilesetDir, "texpages/tertilesc2hw") == 0) // Urban = 0x101040 (or, 0xc9920f)
+	switch (currentMapTileset)
 	{
-		pie_SetFogColour(WZCOL_FOG_URBAN);
-	}
-	else if (tilesetDir && strcmp(tilesetDir, "texpages/tertilesc3hw") == 0) // Rockies = 0xb6e1ec
-	{
-		pie_SetFogColour(WZCOL_FOG_ROCKIE);
-	}
-	else // Arizona, eg. strcmp(tilesetDir, "texpages/tertilesc1hw") == 0, and default. = b08f5f (or, 0x78684f)
-	{
-		pie_SetFogColour(WZCOL_FOG_ARIZONA);
+		case MAP_TILESET::ARIZONA:
+			// Arizona, and default. = b08f5f (or, 0x78684f)
+			pie_SetFogColour(WZCOL_FOG_ARIZONA);
+			break;
+		case MAP_TILESET::URBAN:
+			// Urban = 0x101040 (or, 0xc9920f)
+			pie_SetFogColour(WZCOL_FOG_URBAN);
+			break;
+		case MAP_TILESET::ROCKIES:
+			// Rockies = 0xb6e1ec
+			pie_SetFogColour(WZCOL_FOG_ROCKIE);
+			break;
 	}
 }
 

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -126,6 +126,7 @@ static void init_tileNames(MAP_TILESET type);
 std::unique_ptr<GROUND_TYPE[]> psGroundTypes;
 int numGroundTypes;
 char *tilesetDir = nullptr;
+MAP_TILESET currentMapTileset = MAP_TILESET::ARIZONA;
 static int numTile_names;
 static std::unique_ptr<char[]> Tile_names = nullptr;
 	
@@ -224,6 +225,31 @@ static void init_tileNames(MAP_TILESET type)
 	}
 }
 
+static MAP_TILESET mapTilesetDirToTileset(const char *dir)
+{
+	// For Arizona
+	if (strcmp(dir, "texpages/tertilesc1hw") == 0)
+	{
+		return MAP_TILESET::ARIZONA;
+	}
+	// for Urban
+	else if (strcmp(dir, "texpages/tertilesc2hw") == 0)
+	{
+		return MAP_TILESET::URBAN;
+	}
+	// for Rockie
+	else if (strcmp(dir, "texpages/tertilesc3hw") == 0)
+	{
+		return MAP_TILESET::ROCKIES;
+	}
+	else
+	{
+		debug(LOG_ERROR, "unsupported tileset: %s", dir);
+		debug(LOG_POPUP, "This is a UNSUPPORTED map with a custom tileset.\nDefaulting to tertilesc1hw -- map may look strange!");
+	}
+	return MAP_TILESET::ARIZONA; // fallback
+}
+
 // This is the main loading routine to get all the map's parameters set.
 // Once it figures out what tileset we need, we then parse the files for that tileset.
 // Currently, we only support 3 tilesets.  Arizona, Urban, and Rockie
@@ -242,7 +268,7 @@ static bool mapLoadGroundTypes(bool preview)
 
 	debug(LOG_TERRAIN, "tileset: %s", tilesetDir);
 	// For Arizona
-	if (strcmp(tilesetDir, "texpages/tertilesc1hw") == 0)
+	if (currentMapTileset == MAP_TILESET::ARIZONA)
 	{
 fallback:
 		// load the override terrain types
@@ -287,7 +313,7 @@ fallback:
 		SetDecals("tileset/arizonadecals.txt", "arizona_decals");
 	}
 	// for Urban
-	else if (strcmp(tilesetDir, "texpages/tertilesc2hw") == 0)
+	else if (currentMapTileset == MAP_TILESET::URBAN)
 	{
 		// load the override terrain types
 		if (!preview && builtInMap && !loadTerrainTypeMapOverride(MAP_TILESET::URBAN))
@@ -331,7 +357,7 @@ fallback:
 		SetDecals("tileset/urbandecals.txt", "urban_decals");
 	}
 	// for Rockie
-	else if (strcmp(tilesetDir, "texpages/tertilesc3hw") == 0)
+	else if (currentMapTileset == MAP_TILESET::ROCKIES)
 	{
 		// load the override terrain types
 		if (!preview && builtInMap && !loadTerrainTypeMapOverride(MAP_TILESET::ROCKIES))
@@ -944,6 +970,8 @@ bool mapLoadFromWzMapData(std::shared_ptr<WzMap::MapData> loadedMap)
 		tilesetDir = strdup("texpages/tertilesc1hw");
 	}
 
+	currentMapTileset = mapTilesetDirToTileset(tilesetDir);
+
 	// load the ground types
 	if (!mapLoadGroundTypes(preview))
 	{
@@ -953,7 +981,7 @@ bool mapLoadFromWzMapData(std::shared_ptr<WzMap::MapData> loadedMap)
 	if (!preview)
 	{
 		//preload the terrain textures
-		loadTerrainTextures();
+		loadTerrainTextures(currentMapTileset);
 	}
 
 	//load in the map data itself

--- a/src/map.h
+++ b/src/map.h
@@ -80,6 +80,7 @@ extern float waterLevel;
 extern std::unique_ptr<GROUND_TYPE[]> psGroundTypes;
 extern int numGroundTypes;
 extern char *tilesetDir;
+extern MAP_TILESET currentMapTileset;
 
 #define AIR_BLOCKED		0x01	///< Aircraft cannot pass tile
 #define FEATURE_BLOCKED		0x02	///< Ground units cannot pass tile due to item in the way

--- a/src/qtscript.cpp
+++ b/src/qtscript.cpp
@@ -570,17 +570,17 @@ wzapi::scripting_instance* scripting_engine::loadPlayerScript(const WzString& pa
 	globalVars["mapName"] = game.map;
 	//== * ```tilesetType``` The area name of the map.
 	std::string tilesetType("CUSTOM");
-	if (strcmp(tilesetDir, "texpages/tertilesc1hw") == 0)
+	switch (currentMapTileset)
 	{
-		tilesetType = "ARIZONA";
-	}
-	else if (strcmp(tilesetDir, "texpages/tertilesc2hw") == 0)
-	{
-		tilesetType = "URBAN";
-	}
-	else if (strcmp(tilesetDir, "texpages/tertilesc3hw") == 0)
-	{
-		tilesetType = "ROCKIES";
+		case MAP_TILESET::ARIZONA:
+			tilesetType = "ARIZONA";
+			break;
+		case MAP_TILESET::URBAN:
+			tilesetType = "URBAN";
+			break;
+		case MAP_TILESET::ROCKIES:
+			tilesetType = "ROCKIES";
+			break;
 	}
 	globalVars["tilesetType"] = tilesetType;
 	//== * ```baseType``` The type of base that the game starts with. It will be one of ```CAMP_CLEAN```, ```CAMP_BASE``` or ```CAMP_WALLS```.

--- a/src/terrain.cpp
+++ b/src/terrain.cpp
@@ -589,7 +589,7 @@ void markTileDirty(int i, int j)
 	}
 }
 
-void loadTerrainTextures()
+void loadTerrainTextures(MAP_TILESET mapTileset)
 {
 	ASSERT_OR_RETURN(, psGroundTypes.get(), "Ground type was not set, no textures will be seen.");
 

--- a/src/terrain.h
+++ b/src/terrain.h
@@ -23,8 +23,9 @@
 
 #include <glm/fwd.hpp>
 #include "lib/ivis_opengl/pietypes.h"
+#include <wzmaplib/terrain_type.h>
 
-void loadTerrainTextures();
+void loadTerrainTextures(MAP_TILESET mapTileset);
 
 bool initTerrain();
 void shutdownTerrain();


### PR DESCRIPTION
Requires: #3114

PIE format enhancements:
- Add support for _per-level_ `TYPE`, `INTERPOLATE`, `TEXTURE`, `NORMALMAP`, `SPECULARMAP` overrides
   - These go right after the `LEVEL <num>` directive
   - All are optional - if unspecified, the global versions of these directives take precedence
   - Fixes: #893
- Add `TCMASK` global / level directive to explicitly specify the tcmask texture filename
   - Optional. If unspecified, the old behavior is used (which derives an expected tcmask filename from the texture filename, if the appropriate `TYPE` flag is set)
   - Fixes: #2941
- Add support for comments 
   - `#` is used to denote the beginning of a comment, which extends until the end of the line
   - Fixes: #2946

Additionally this PR should fix:
- Drawing all levels of all types of models

Remaining TODOs:
- [x] More testing (especially comments)
- [x] Potentially bump these features to PIE version 4?
- [x] Documentation