### PR TITLE
Gamma improvements

### DIFF
--- a/data/base/script/campaign/libcampaign_includes/nexus.js
+++ b/data/base/script/campaign/libcampaign_includes/nexus.js
@@ -106,7 +106,7 @@ function camHackIntoPlayer(player, to)
 	__camLastNexusAttack = gameTime;
 	target = objects[camRand(objects.length)];
 
-	if (camRand(100) < GIFT_CHANCE)
+	if ((camRand(100) < GIFT_CHANCE) && !(target.type === STRUCTURE && target.stattype === WALL))
 	{
 		camTrace("Hacking " + target.name + " at (x,y): " + target.x + " " + target.y);
 		//Gift sounds are done in eventObjectTransfer.


### PR DESCRIPTION
Force Nexus absorb attempts to always destroy walls and tank traps (luckily Nexus Links don't target wall objects for some reason as otherwise this would have been a lot worse to deal with). Fixes #3115.

Improve upon Gamma 9 scenario even more by introducing hack failure chances depending on difficulty, destroy only some VTOLs for Normal and above, as well as offload the initial first hack attempt to Hard and above. Note that the timings of hack attempts are still slower on Normal and below as before.