### PR TITLE
Reduce time and cost for Command Turret research

### DIFF
--- a/data/mp/stats/research.json
+++ b/data/mp/stats/research.json
@@ -7,8 +7,8 @@
 		"requiredResearch": [
 			"R-Struc-CommandRelay"
 		],
-		"researchPoints": 1200,
-		"researchPower": 37,
+		"researchPoints": 600,
+		"researchPower": 18,
 		"resultComponents": [
 			"CommandBrain01",
 			"CommandTurret1"
@@ -25,8 +25,8 @@
 			"R-Sys-Sensor-Upgrade02",
 			"R-Struc-Research-Upgrade07"
 		],
-		"researchPoints": 5000,
-		"researchPower": 450,
+		"researchPoints": 2500,
+		"researchPower": 78,
 		"results": [
 			{
 				"class": "Brain",


### PR DESCRIPTION
Wanted via balance poll in mp-balance.

Guess this is a fix too as the Command Turret Upgrade had a cost of 450 power for some reason...