### PR TITLE
Performance improvement: throttle / spread-out additional calls to aiBestNearestTarget

### DIFF
--- a/src/action.cpp
+++ b/src/action.cpp
@@ -741,6 +741,10 @@ void actionUpdateDroid(DROID *psDroid)
 					WEAPON_STATS *const psWeapStats = &asWeaponStats[psDroid->asWeaps[i].nStat];
 					if (psDroid->asWeaps[i].nStat > 0
 					    && psWeapStats->rotate
+						&& IS_TIME_TO_CHECK_FOR_NEW_TARGET(psDroid)
+						// don't bother doing this costly calculation again if aiUpdateDroid already checked this tick
+						// (aiUpdateDroid would have set an attack target if one was available)
+						&& psDroid->lastCheckNearestTarget[i] != gameTime
 					    && aiBestNearestTarget(psDroid, &psTemp, i) >= 0)
 					{
 						if (secondaryGetState(psDroid, DSO_ATTACK_LEVEL) == DSS_ALEV_ALWAYS)
@@ -839,6 +843,7 @@ void actionUpdateDroid(DROID *psDroid)
 					    && psDroid->asWeaps[i].nStat > 0
 					    && psWeapStats->rotate
 					    && psWeapStats->fireOnMove
+						&& IS_TIME_TO_CHECK_FOR_NEW_TARGET(psDroid)
 					    && aiBestNearestTarget(psDroid, &psTemp, i) >= 0)
 					{
 						if (secondaryGetState(psDroid, DSO_ATTACK_LEVEL) == DSS_ALEV_ALWAYS)
@@ -1030,8 +1035,9 @@ void actionUpdateDroid(DROID *psDroid)
 				// If we still don't have a target, try to find one
 				else
 				{
-					if (psDroid->psActionTarget[i] == nullptr &&
-					    aiChooseTarget(psDroid, &psTargets[i], i, false, nullptr))  // Can probably just use psTarget instead of psTargets[i], and delete the psTargets variable.
+					if (psDroid->psActionTarget[i] == nullptr
+						&& IS_TIME_TO_CHECK_FOR_NEW_TARGET(psDroid)
+					    && aiChooseTarget(psDroid, &psTargets[i], i, false, nullptr))  // Can probably just use psTarget instead of psTargets[i], and delete the psTargets variable.
 					{
 						setDroidActionTarget(psDroid, psTargets[i], i);
 					}
@@ -2036,6 +2042,7 @@ void actionUpdateDroid(DROID *psDroid)
 						WEAPON_STATS *const psWeapStats = &asWeaponStats[psDroid->asWeaps[i].nStat];
 						if (psDroid->asWeaps[i].nStat > 0 && psWeapStats->rotate
 						    && secondaryGetState(psDroid, DSO_ATTACK_LEVEL) == DSS_ALEV_ALWAYS
+							&& IS_TIME_TO_CHECK_FOR_NEW_TARGET(psDroid)
 						    && aiBestNearestTarget(psDroid, &psTemp, i) >= 0 && psTemp)
 						{
 							psDroid->action = DACTION_ATTACK;

--- a/src/action.h
+++ b/src/action.h
@@ -104,8 +104,14 @@ void moveToRearm(DROID *psDroid);
 /** Choose a landing position for a VTOL when it goes to rearm. */
 bool actionVTOLLandingPos(DROID const *psDroid, Vector2i *p);
 
-/** How many frames to skip before looking for a better target. */
+/** How many ticks to skip before looking for a better target. */
 #define TARGET_UPD_SKIP_FRAMES 1000
+#define TARGET_CHECK_NEW_SKIP_TICKS 500
+
+// Throttle how often we look for a new target
+// Notes: deltaGameTime is either 0 (if no gameTime update was processed) or GAME_TICKS_PER_UPDATE
+#define IS_TIME_TO_CHECK_FOR_NEW_TARGET(psDroid) \
+(psDroid->id + gameTime) / TARGET_CHECK_NEW_SKIP_TICKS != (psDroid->id + gameTime - deltaGameTime) / TARGET_CHECK_NEW_SKIP_TICKS
 
 /** @} */
 

--- a/src/ai.h
+++ b/src/ai.h
@@ -111,4 +111,6 @@ static inline bool alliancesCanGiveAnything(int t)
 	return t != NO_ALLIANCES;
 }
 
+size_t getCountNearestTargetChecks();
+
 #endif // __INCLUDED_SRC_AI_H__

--- a/src/droiddef.h
+++ b/src/droiddef.h
@@ -143,6 +143,7 @@ struct DROID : public BASE_OBJECT
 	DROID_ACTION    action;
 	Vector2i        actionPos;
 	BASE_OBJECT    *psActionTarget[MAX_WEAPONS] = {}; ///< Action target object
+	UDWORD			lastCheckNearestTarget[MAX_WEAPONS] = {};	///< Set to the last gameTime that aiBestNearestTarget was called on for each weapon slot for this droid - compare only == / != gameTime
 	UDWORD          actionStarted;                  ///< Game time action started
 	UDWORD          actionPoints;                   ///< number of points done by action since start
 	UDWORD          expectedDamageDirect;                 ///< Expected damage to be caused by all currently incoming direct projectiles. This info is shared between all players,


### PR DESCRIPTION
Previously `aiBestNearestTarget` was called for every droid that didn't have a target (and sometimes multiple times per droid, duplicating work), every single tick. This could have a substantial performance impact in scenarios with many units fairly close together.

Instead, throttle calls slightly, avoid some duplicates, and split up checks between different ticks based on droid ID (this was already done in some other circumstances) to further spread out the work.