### PR TITLE
Rebalance player flamer for #3132

### DIFF
--- a/data/base/script/campaign/cam1-1.js
+++ b/data/base/script/campaign/cam1-1.js
@@ -124,7 +124,7 @@ function eventStartLevel()
 	//Get rid of the already existing crate and replace with another
 	camSafeRemoveObject("artifact1", false);
 	camSetArtifacts({
-		"scavFactory1": { tech: "R-Wpn-MG3Mk1" }, //Heavy machine gun
+		"scavFactory1": { tech: ["R-Wpn-MG3Mk1", "R-Wpn-Flamer-Range01"] }, //Heavy machine gun & flamer range upgrade
 	});
 
 	camSetFactories({

--- a/data/base/script/campaign/cam1-2.js
+++ b/data/base/script/campaign/cam1-2.js
@@ -105,7 +105,7 @@ function eventStartLevel()
 	camDetectEnemyBase("ScavLabGroup");
 
 	camSetArtifacts({
-		"ScavLab": { tech: "R-Wpn-Mortar01Lt" },
+		"ScavLab": { tech: ["R-Wpn-Mortar01Lt", "R-Wpn-Flamer-Damage02"] },
 		"NorthFactory": { tech: ["R-Vehicle-Prop-Halftracks", "R-Wpn-Cannon1Mk1"] },
 	});
 

--- a/data/base/script/campaign/cam1b.js
+++ b/data/base/script/campaign/cam1b.js
@@ -1,4 +1,3 @@
-
 include("script/campaign/libcampaign.js");
 include("script/campaign/templates.js");
 
@@ -98,7 +97,7 @@ function eventStartLevel()
 		completeResearch("R-Wpn-Flamer-Range01-ScavReduce-Undo", SCAV_7);
 	}
 	camSetArtifacts({
-		"base1factory": { tech: "R-Wpn-Flamer-Damage02" },
+		"base1factory": { tech: "R-Wpn-Flamer-Damage01" },
 		"base2factory": { tech: "R-Wpn-MG2Mk1" },
 		"base3sensor": { tech: "R-Sys-Sensor-Turret01" },
 		"base4gen": { tech: "R-Struc-PowerModuleMk1" },

--- a/data/base/stats/research.json
+++ b/data/base/stats/research.json
@@ -2535,10 +2535,11 @@
 	"R-Wpn-Flamer-Range01": {
 		"iconID": "IMAGE_RES_WEAPONTECH",
 		"id": "R-Wpn-Flamer-Range01",
+                "keyTopic": 1,
 		"msgName": "RES_W_FL_R1",
 		"name": "High-Pressure Gas Container",
 		"requiredResearch": [
-			"R-Wpn-Flamer-Damage02"
+			"R-Wpn-Flamer-Damage01"
 		],
 		"researchPoints": 1000,
 		"researchPower": 85,
@@ -2595,6 +2596,7 @@
 	"R-Wpn-Flamer-Damage01": {
 		"iconID": "IMAGE_RES_WEAPONTECH",
 		"id": "R-Wpn-Flamer-Damage01",
+                "keyTopic": 1,
 		"msgName": "RES_W_FL_D1",
 		"name": "High Temperature Flamer Gel",
 		"requiredResearch": [
@@ -2687,7 +2689,7 @@
 		"msgName": "RES_W_FL_ROF1",
 		"name": "Flamer Autoloader",
 		"requiredResearch": [
-			"R-Wpn-Flamer-Damage02"
+			"R-Wpn-Flamer-Damage01"
 		],
 		"researchPoints": 1100,
 		"researchPower": 95,

--- a/data/base/stats/structuremodifier.json
+++ b/data/base/stats/structuremodifier.json
@@ -30,9 +30,9 @@
 		"SOFT": 100
 	},
 	"FLAMER": {
-		"BUNKER": 300,
+		"BUNKER": 250,
 		"HARD": 40,
-		"MEDIUM": 140,
-		"SOFT": 160
+		"MEDIUM": 120,
+		"SOFT": 130
 	}
 }


### PR DESCRIPTION
Make the player flamer in #3132 weaker so it wouldn't become ultimate after the three upgrades from Alpha 2.
Changes:
- Reverted the flamer damage upgrades back to their original locations.
- Moved the flamer range upgrade to the same artifact as the HMG
- Make flamers slightly weaker against structures 
  (BUNKER: 300 -> 250  MEDIUM 140 -> 120  SOFT 160 -> 130)

Hopefully this isn't too much.
Mod to test it out: 
[flamertweaks.zip](https://github.com/Warzone2100/warzone2100/files/10947950/flamertweaks.zip)
