### PR TITLE
Do not truncate spectator labels

### DIFF
--- a/src/spectatorwidgets.cpp
+++ b/src/spectatorwidgets.cpp
@@ -232,7 +232,7 @@ public:
 	{
 		auto newLabel = std::make_shared<WzThrottledUpdateLabel>(updateFunc, updateInterval);
 		newLabel->setFont(font_regular, WZCOL_FORM_LIGHT);
-		newLabel->setCanTruncate(true);
+		newLabel->setCanTruncate(false);
 		newLabel->setTransparentToClicks(true);
 		if (updateFunc)
 		{


### PR DESCRIPTION
Stop showing something like this under armor: `4/...`

This prevents truncation for name, power, power lost, kinetic/thermal armor values.