### PR TITLE
Time fixes

### DIFF
--- a/src/display3d.cpp
+++ b/src/display3d.cpp
@@ -934,7 +934,8 @@ void draw3DScene()
 	if (getWidgetsStatus() && !gamePaused())
 	{
 		char buildInfo[255];
-		getAsciiTime(buildInfo, graphicsTime);
+		bool showMs = (gameTimeGetMod() < Rational(1, 4));
+		getAsciiTime(buildInfo, showMs ? graphicsTime : gameTime, showMs);
 		txtLevelName.render(RET_X + 134, 410 + E_H, WZCOL_TEXT_MEDIUM);
 		const DebugInputManager& dbgInputManager = gInputManager.debugManager();
 		if (dbgInputManager.debugMappingsAllowed())

--- a/src/mission.cpp
+++ b/src/mission.cpp
@@ -2222,6 +2222,7 @@ static void intDestroyMissionResultWidgets()
 static bool _intAddMissionResult(bool result, bool bPlaySuccess, bool showBackDrop)
 {
 	missionResetInGameState();
+	scoreUpdateVar(WD_MISSION_ENDED); //Store completion time for this mission
 
 	W_FORMINIT sFormInit;
 

--- a/src/scores.cpp
+++ b/src/scores.cpp
@@ -258,14 +258,13 @@ void	scoreUpdateVar(DATA_INDEX var)
 }
 
 // Builds an ascii string for the passed in components 4:02:23 for example.
-void getAsciiTime(char *psText, unsigned time)
+void getAsciiTime(char *psText, unsigned time, bool showMs /*= false*/)
 {
 	int hours, minutes, seconds, milliseconds;
 	getTimeComponents(time, &hours, &minutes, &seconds, &milliseconds);
 
 	char const *hourColon = hours != 0 ? ":" : "";
 
-	bool showMs = gameTimeGetMod() < Rational(1, 4);
 	if (showMs)
 	{
 		sprintf(psText, "%.0d%s%02d:%02d.%03d", hours, hourColon, minutes, seconds, milliseconds);

--- a/src/scores.cpp
+++ b/src/scores.cpp
@@ -202,7 +202,8 @@ bool	scoreInitSystem()
 	missionData.strLost			= 0;
 
 	missionData.artefactsFound	= 0;
-	missionData.missionStarted	= gameTime; // total game time is just gameTime
+	scoreUpdateVar(WD_MISSION_STARTED); // total game time is just gameTime
+	missionData.missionEnded	= 0;
 	missionData.shotsOnTarget	= 0;
 	missionData.shotsOffTarget	= 0;
 	missionData.babasMowedDown	= 0;
@@ -241,6 +242,9 @@ void	scoreUpdateVar(DATA_INDEX var)
 	case	WD_MISSION_STARTED:
 		missionData.missionStarted = gameTime;	// Init the mission start time
 		break;									// Should be called once per mission
+	case	WD_MISSION_ENDED:
+		missionData.missionEnded = gameTime - missionData.missionStarted;	// Mission ended
+		break;
 	case	WD_SHOTS_ON_TARGET:
 		missionData.shotsOnTarget++;	// We hit something
 		break;
@@ -398,7 +402,7 @@ void scoreDataToScreen(WIDGET *psWidget, ScoreDataToScreenCache& cache)
 	cache.wzInfoText_ArtifactsFound.render((pie_GetVideoBufferWidth() - cache.wzInfoText_ArtifactsFound.width()) / 2, 300 + D_H, WZCOL_FORM_TEXT);
 
 	/* Get the mission result time in a string - and write it out */
-	getAsciiTime((char *)&text2, gameTime - missionData.missionStarted);
+	getAsciiTime((char *)&text2, missionData.missionEnded);
 	snprintf(text, sizeof(text), _("Mission Time - %s"), text2);
 	cache.wzInfoText_MissionTime.setText(text, font_regular);
 	cache.wzInfoText_MissionTime.render((pie_GetVideoBufferWidth() - cache.wzInfoText_MissionTime.width()) / 2, 320 + D_H, WZCOL_FORM_TEXT);
@@ -529,6 +533,7 @@ bool writeScoreData(const char *fileName)
 	ini.setValue("strLost", missionData.strLost);
 	ini.setValue("artefactsFound", missionData.artefactsFound);
 	ini.setValue("missionStarted", missionData.missionStarted);
+	ini.setValue("missionEnded", missionData.missionEnded);
 	ini.setValue("shotsOnTarget", missionData.shotsOnTarget);
 	ini.setValue("shotsOffTarget", missionData.shotsOffTarget);
 	ini.setValue("babasMowedDown", missionData.babasMowedDown);
@@ -552,6 +557,7 @@ bool readScoreData(const char *fileName)
 	missionData.strLost = ini.value("strLost").toInt();
 	missionData.artefactsFound = ini.value("artefactsFound").toInt();
 	missionData.missionStarted = ini.value("missionStarted").toInt();
+	missionData.missionEnded = ini.value("missionEnded").toInt();
 	missionData.shotsOnTarget = ini.value("shotsOnTarget").toInt();
 	missionData.shotsOffTarget = ini.value("shotsOffTarget").toInt();
 	missionData.babasMowedDown = ini.value("babasMowedDown").toInt();

--- a/src/scores.h
+++ b/src/scores.h
@@ -117,7 +117,7 @@ bool scoreInitSystem();
 void scoreUpdateVar(DATA_INDEX var);
 END_GAME_STATS_DATA	collectEndGameStatsData();
 void scoreDataToScreen(WIDGET *psWidget, ScoreDataToScreenCache& cache);
-void getAsciiTime(char *psText, unsigned time);
+void getAsciiTime(char *psText, unsigned time, bool showMs = false);
 bool readScoreData(const char *fileName);
 bool writeScoreData(const char *fileName);
 

--- a/src/scores.h
+++ b/src/scores.h
@@ -35,6 +35,7 @@ enum DATA_INDEX
 	WD_STR_LOST,
 	WD_ARTEFACTS_FOUND,
 	WD_MISSION_STARTED,
+	WD_MISSION_ENDED,
 	WD_SHOTS_ON_TARGET,
 	WD_SHOTS_OFF_TARGET,
 	WD_BARBARIANS_MOWED_DOWN
@@ -52,6 +53,7 @@ struct MISSION_DATA
 	uint32_t    strLost;		// How many structures were lost
 	uint32_t    artefactsFound;	// How many artefacts were found
 	uint32_t    missionStarted;	// When was the mission started
+	uint32_t    missionEnded;	// When was the mission ended
 	uint32_t    shotsOnTarget;	// How many hits
 	uint32_t    shotsOffTarget;	// How many misses
 	uint32_t    babasMowedDown; // How many barbarians did we mow down?


### PR DESCRIPTION
- Reduce M:SS time display being perceived as different between the lower left corner and the results screens.
- Stop Mission Time when the results screen gets initialized by storing it somewhere (finally).

Fixes #3133.