### PR TITLE
Fix default name "Commander" overriding player names

### DIFF
--- a/src/ingameop.cpp
+++ b/src/ingameop.cpp
@@ -485,11 +485,6 @@ bool intCloseInGameOptions(bool bPutUpLoadSave, bool bResetMissionWidgets)
 		widgDelete(psWScreen, INTINGAMEPOPUP);
 	}
 
-	if (!bPutUpLoadSave && !bResetMissionWidgets)
-	{
-		clearPlayerName(CLEAR_ALL_NAMES);
-	}
-
 	if (bPutUpLoadSave || keymapWasUp)
 	{
 		WIDGET *widg = widgGetFromID(psWScreen, INTINGAMEOP);

--- a/src/multijoin.cpp
+++ b/src/multijoin.cpp
@@ -198,8 +198,6 @@ void clearPlayer(UDWORD player, bool quietly)
 		return; // no more to do
 	}
 
-	(void)setPlayerName(player, "");				//clear custom player name (will use default instead)
-
 	for (i = 0; i < MAX_PLAYERS; i++)				// remove alliances
 	{
 		// Never remove a player's self-alliance, as the player can be selected and units added via the debug menu

--- a/src/multimenu.cpp
+++ b/src/multimenu.cpp
@@ -845,7 +845,7 @@ private:
 	{
 		auto nameGrid = std::make_shared<GridLayout>();
 		char name[128];
-		ssprintf(name, "%d: %s", NetPlay.players[player].position, getPlayerName(player, true));
+		ssprintf(name, "%d: %s", NetPlay.players[player].position, getPlayerName(player));
 		nameGrid->place({0, 1, false}, {0}, std::make_shared<MultiMenuDroidView>(player));
 		auto nameLabel = makeLabel(name);
 		nameGrid->place({1}, {0}, nameLabel);

--- a/src/multiplay.cpp
+++ b/src/multiplay.cpp
@@ -614,17 +614,8 @@ bool isHumanPlayer(int player)
 // Clear player name data after game quit.
 void clearPlayerName(unsigned int player)
 {
-	if (player == CLEAR_ALL_NAMES)
-	{
-		for (unsigned int i = 0; i < MAX_CONNECTED_PLAYERS; ++i)
-		{
-			NetPlay.players[i].name[0] = '\0';
-		}
-	}
-	else
-	{
-		NetPlay.players[player].name[0] = '\0';
-	}
+	ASSERT_OR_RETURN(, player < MAX_CONNECTED_PLAYERS, "Player index (%u) out of range", player);
+	NetPlay.players[player].name[0] = '\0';
 }
 
 // returns player responsible for 'player'

--- a/src/multiplay.cpp
+++ b/src/multiplay.cpp
@@ -97,7 +97,6 @@ MULTIPLAYERGAME				game;									//info to describe game.
 MULTIPLAYERINGAME			ingame;
 
 char						beaconReceiveMsg[MAX_PLAYERS][MAX_CONSOLE_STRING_LENGTH];	//beacon msg for each player
-char						playerName[MAX_CONNECTED_PLAYERS][MAX_STR_LENGTH];	//Array to store all player names (humans and AIs)
 
 #define DATACHECK2_INTERVAL_MS 10000
 
@@ -568,17 +567,11 @@ BASE_OBJECT *IdToPointer(UDWORD id, UDWORD player)
 
 // ////////////////////////////////////////////////////////////////////////////
 // return a players name.
-const char *getPlayerName(int player, bool storedName /*= false*/)
+const char *getPlayerName(int player)
 {
 	ASSERT_OR_RETURN(nullptr, player >= 0, "Wrong player index: %d", player);
 
 	const bool aiPlayer = (static_cast<size_t>(player) < NetPlay.players.size()) && (NetPlay.players[player].ai >= 0) && !NetPlay.players[player].allocated;
-
-	// playerName is created through setPlayerName()
-	if (storedName && !aiPlayer && player < MAX_CONNECTED_PLAYERS && strcmp(playerName[player], "") != 0)
-	{
-		return (char *)&playerName[player];
-	}
 
 	if (aiPlayer && GetGameMode() == GS_NORMAL && !challengeActive)
 	{
@@ -603,7 +596,6 @@ const char *getPlayerName(int player, bool storedName /*= false*/)
 bool setPlayerName(int player, const char *sName)
 {
 	ASSERT_OR_RETURN(false, player < MAX_CONNECTED_PLAYERS && player >= 0, "Player index (%u) out of range", player);
-	sstrcpy(playerName[player], sName); // Intended for long time storage of player name for Intel menu viewing.
 	sstrcpy(NetPlay.players[player].name, sName);
 	return true;
 }
@@ -626,13 +618,11 @@ void clearPlayerName(unsigned int player)
 	{
 		for (unsigned int i = 0; i < MAX_CONNECTED_PLAYERS; ++i)
 		{
-			playerName[i][0] = '\0';
 			NetPlay.players[i].name[0] = '\0';
 		}
 	}
 	else
 	{
-		playerName[player][0] = '\0';
 		NetPlay.players[player].name[0] = '\0';
 	}
 }

--- a/src/multiplay.h
+++ b/src/multiplay.h
@@ -213,7 +213,7 @@ WZ_DECL_WARN_UNUSED_RESULT DROID			*IdToMissionDroid(UDWORD id, UDWORD player);
 WZ_DECL_WARN_UNUSED_RESULT FEATURE		*IdToFeature(UDWORD id, UDWORD player);
 WZ_DECL_WARN_UNUSED_RESULT DROID_TEMPLATE	*IdToTemplate(UDWORD tempId, UDWORD player);
 
-const char *getPlayerName(int player, bool storedName = false);
+const char *getPlayerName(int player);
 bool setPlayerName(int player, const char *sName);
 void clearPlayerName(unsigned int player);
 const char *getPlayerColourName(int player);

--- a/src/multiplay.h
+++ b/src/multiplay.h
@@ -203,7 +203,6 @@ extern UBYTE bDisplayMultiJoiningStatus;	// draw load progress?
 
 #define MAX_KICK_REASON			80			// max array size for the reason your kicking someone
 
-#define CLEAR_ALL_NAMES         -1
 // functions
 
 WZ_DECL_WARN_UNUSED_RESULT BASE_OBJECT		*IdToPointer(UDWORD id, UDWORD player);


### PR DESCRIPTION
"Commander" shouldn't replace names In the Intel / Replay widget menus when hosts exit, when players leave, kicking, etc. anymore.

Needs lot of testing.