### PR TITLE
Campaign tweaks

### DIFF
--- a/data/base/script/campaign/cam3-a.js
+++ b/data/base/script/campaign/cam3-a.js
@@ -20,11 +20,12 @@ camAreaEvent("vtolRemoveZone", function(droid)
 	resetLabel("vtolRemoveZone", NEXUS);
 });
 
-//Order base three groups to do stuff.
-camAreaEvent("cybAttackers", function(droid)
+//Order base three groups to do stuff and enable cyborg factories in the north
+camAreaEvent("northFactoryTrigger", function(droid)
 {
-	enableAllFactories();
-
+	camEnableFactory("NXcybFac-b3");
+	camEnableFactory("NXcybFac-b4");
+	
 	camManageGroup(camMakeGroup("NEAttackerGroup"), CAM_ORDER_ATTACK, {
 		regroup: true,
 		morale: 90,
@@ -41,7 +42,16 @@ camAreaEvent("cybAttackers", function(droid)
 	});
 });
 
+//Enable factories in the SW base
 camAreaEvent("westFactoryTrigger", function(droid)
+{
+	camEnableFactory("NXcybFac-b2-1");
+	camEnableFactory("NXcybFac-b2-2");
+	camEnableFactory("NXHvyFac-b2");
+});
+
+//Enable all factories if the player tries to bypass a trigger area
+camAreaEvent ("middleTrigger", function(droid)
 {
 	enableAllFactories();
 });
@@ -220,7 +230,7 @@ function cam3Setup()
 	enableResearch("R-Wpn-MG-Damage08", CAM_HUMAN_PLAYER);
 }
 
-//Easy and Normal difficulty has Nexus start off a little bit weaker
+//Normal and lower difficulties has Nexus start off a little bit weaker
 function improveNexusAlloys()
 {
 	var alloys = [

--- a/data/base/stats/research.json
+++ b/data/base/stats/research.json
@@ -8516,7 +8516,7 @@
 				"filterParameter": "ImpactClass",
 				"filterValue": "MACHINE GUN",
 				"parameter": "Damage",
-				"value": 10
+				"value": 20
 			}
 		],
 		"statID": "MG1Mk1",
@@ -8538,7 +8538,7 @@
 				"filterParameter": "ImpactClass",
 				"filterValue": "MACHINE GUN",
 				"parameter": "Damage",
-				"value": 10
+				"value": 20
 			}
 		],
 		"statID": "MG1Mk1",

--- a/data/base/stats/weapons.json
+++ b/data/base/stats/weapons.json
@@ -1660,7 +1660,7 @@
 	"Flame2": {
 		"buildPoints": 400,
 		"buildPower": 80,
-		"damage": 50,
+		"damage": 40,
 		"designable": 1,
 		"effectSize": 100,
 		"facePlayer": 1,

--- a/data/base/wrf/cam3/cam3a/labels.json
+++ b/data/base/wrf/cam3/cam3a/labels.json
@@ -107,7 +107,6 @@
 	},
 	"area_1": {
 		"label": "cybAttackers",
-		"subscriber": 0,
 		"pos1": [6976, 12480],
 		"pos2": [7424, 12864]
 	},
@@ -160,12 +159,24 @@
 		"label": "westFactoryTrigger",
 		"subscriber": 0,
 		"pos1": [5632, 13312],
-		"pos2": [6144, 14592]
+		"pos2": [6144, 14720]
 	},
 	"area_12": {
 		"label": "NXlandingZone",
 		"pos1": [896, 6656],
 		"pos2": [1152, 6912]
+	},
+	"area_13": {
+		"label": "middleTrigger",
+		"subscriber": 0,
+		"pos1": [128, 12672],
+		"pos2": [6272, 13312]
+	},
+	"area_14": {
+		"label": "northFactoryTrigger",
+		"subscriber": 0,
+		"pos1": [6592, 11840],
+		"pos2": [7424, 12224]
 	},
 
 	"object_0": {


### PR DESCRIPTION
Some tweaks to the campaign

- Decreased the Inferno base damage to 40 from 50 due to being a bit overpowered after its range buff
- Increased the MG damage upgrades to 20% from 10% in Gamma 1 and 2 to better fight the cyborgs
- Move the north trigger area in Gamma 1 five tiles north to give the player more space in the valley
- Let the north trigger area in Gamma 1 only activate the north cyborgs factories
- Let the west trigger area in Gamma 1 only activate the SW base factories
- Add a new trigger area in Gamma 1 to avoid a bypassing of the two trigger areas above