### PR TITLE
Preserve artillery weapon pitch after firing

### DIFF
--- a/src/action.cpp
+++ b/src/action.cpp
@@ -392,7 +392,7 @@ bool actionTargetTurret(BASE_OBJECT *psAttacker, BASE_OBJECT *psTarget, WEAPON *
 
 	/* Set muzzle pitch if not repairing or outside minimum range */
 	const int minRange = proj_GetMinRange(psWeapStats, psAttacker->player);
-	if (!bRepair && (unsigned)objPosDiffSq(psAttacker, psTarget) > minRange * minRange)
+	if (!bRepair && (unsigned)objPosDiffSq(psAttacker, psTarget) > minRange * minRange && proj_Direct(psWeapStats))
 	{
 		/* get target distance */
 		Vector3i delta = psTarget->pos - attackerMuzzlePos;


### PR DESCRIPTION
Fixes #1133
Artillery structures now properly maintain their weapon pitch when attacking, and will lower their weapons only when idle.
![image](https://user-images.githubusercontent.com/28832631/229020013-a69fecf3-1385-4acb-8eeb-34fcf5f20a27.png)
