### PR TITLE
Don't assign trucks from factories to commanders

### DIFF
--- a/src/structure.cpp
+++ b/src/structure.cpp
@@ -2441,7 +2441,7 @@ static bool structPlaceDroid(STRUCTURE *psStructure, DROID_TEMPLATE *psTempl, DR
 				orderDroidObj(psNewDroid, DORDER_FIRESUPPORT, psFact->psCommander, ModeQueue);
 				//moveToRearm(psNewDroid);
 			}
-			else
+			else if (!isConstructionDroid(psNewDroid))
 			{
 				orderDroidObj(psNewDroid, DORDER_COMMANDERSUPPORT, psFact->psCommander, ModeQueue);
 			}


### PR DESCRIPTION
Prevents trucks produced from factories assigned to commanders from being assigned to the commander.