### PR TITLE
Properly update obstacle maps for allies

### DIFF
--- a/src/map.h
+++ b/src/map.h
@@ -162,7 +162,7 @@ WZ_DECL_ALWAYS_INLINE static inline void auxSetAllied(int x, int y, int player, 
 
 	for (i = 0; i < MAX_PLAYERS; i++)
 	{
-		if (alliancebits[player] & (1 << i))
+		if (aiCheckAlliances(player, i))
 		{
 			psAuxMap[i][x + y * mapWidth] |= state;
 		}
@@ -176,7 +176,7 @@ WZ_DECL_ALWAYS_INLINE static inline void auxSetEnemy(int x, int y, int player, i
 
 	for (i = 0; i < MAX_PLAYERS; i++)
 	{
-		if (!(alliancebits[player] & (1 << i)))
+		if (!aiCheckAlliances(player, i))
 		{
 			psAuxMap[i][x + y * mapWidth] |= state;
 		}


### PR DESCRIPTION
Fixes #2775 
Allied structures are now correctly mapped to all allies, regardless if vision is shared or not. (_Why was it set up like that???_)

![image](https://user-images.githubusercontent.com/28832631/229729501-3794ec26-6cdb-49d7-8cd7-dc76cb18d917.png)
An allied Nexus AI correctly navigates a small tank trap maze set up by the player in an open-alliance game.

![image](https://user-images.githubusercontent.com/28832631/229729437-85cc35b2-d021-4a67-8bf8-be11f9ded00f.png)
An allied faction correctly navigates a maze in a modded campaign (Fractured Kingdom).