### PR TITLE
Properly render unit electronic health bars

### DIFF
--- a/src/display3d.cpp
+++ b/src/display3d.cpp
@@ -2741,7 +2741,7 @@ static void drawWeaponReloadBar(BASE_OBJECT *psObj, WEAPON *psWeap, int weapon_s
 		}
 		if (psDroid->resistance)
 		{
-			mulH = (float)psDroid->resistance / (float)droidResistance(psDroid);
+			mulH = (float)PERCENT(psDroid->resistance, droidResistance(psDroid));
 		}
 		else
 		{


### PR DESCRIPTION
Fixes #1136 
The electronic health bars of the player's own units (viewed over the reload/ammo bar when holding Shift or Control) now correctly displays the unit's electronic resistance.