### PR TITLE
Fix: Desync with losing player-turned-spectator when defensive structures (with turrets) remain

### DIFF
--- a/src/visibility.cpp
+++ b/src/visibility.cpp
@@ -692,11 +692,11 @@ static void processVisibilitySelf(BASE_OBJECT *psObj)
 		setSeenBy(psObj, psObj->player, UBYTE_MAX);
 	}
 
-	// if a player has a SAT_UPLINK structure, or has godMode enabled,
+	// if a player has a SAT_UPLINK structure, or has godMode enabled (and is not a spectator!!),
 	// they can see everything!
 	for (unsigned viewer = 0; viewer < MAX_PLAYERS; viewer++)
 	{
-		if (getSatUplinkExists(viewer) || (viewer == selectedPlayer && godMode))
+		if (getSatUplinkExists(viewer) || (viewer == selectedPlayer && godMode && !NetPlay.players[viewer].isSpectator))
 		{
 			setSeenBy(psObj, viewer, UBYTE_MAX);
 		}


### PR DESCRIPTION
In a multiplayer game:
- If a player loses (and thus turns into a spectator)
- _AND_ has structures with turrets / weapons remaining

There could potentially be a de-sync due to non-matching visibility calculations, once an adversary's unit(s) approached a remaining structure of the losing player that had turrets / weapons.