### PR TITLE
Slightly increase the build cost of initial Mortar weapon (Mortar1Mk1)

### DIFF
--- a/data/mp/stats/weapons.json
+++ b/data/mp/stats/weapons.json
@@ -3340,8 +3340,8 @@
 		"weight": 2000
 	},
 	"Mortar1Mk1": {
-		"buildPoints": 400,
-		"buildPower": 100,
+		"buildPoints": 440,
+		"buildPower": 105,
 		"damage": 60,
 		"designable": 1,
 		"effectSize": 100,


### PR DESCRIPTION
To try to address concerns that recent changes that made the Mortar come sooner (#3089) contributed to an undesirable imbalance between MG and Mortar, implement a suggestion from `RBMW-Fenrir` on Discord to slightly increase the cost of the Mortar.

Reasoning (paraphrased from discussion):
> Because of the now-earlier Mortar, MG is even more useless in shared research games than before. (In no-shared-research, MG and Mortars can compete as support weapons, in the hands of high-level players.)

This proposal slightly increases cost of `Mortar1Mk1` (the initial Mortar weapon):
- buildPower: 100 -> 105 (+5%)
- buildPoints: 400 -> 440 (+10%)