### PR TITLE
Fix repairs

### DIFF
--- a/src/structure.cpp
+++ b/src/structure.cpp
@@ -2763,8 +2763,12 @@ RepairState aiUpdateRepair_handleEvents(STRUCTURE &station, RepairEvents ev, DRO
 		objTrace(psStructure->id, "Repair complete of droid %d", (int)psDroid->id);
 		psDroid->body = psDroid->originalBody;
 		// if completely repaired reset order
-		secondarySetState(psDroid, DSO_RETURN_TO_LOC, DSS_NONE);
+		objTrace(psDroid->id, "was fully repaired by RF");
 		droidWasFullyRepaired(psDroid, psRepairFac);
+		// only call "secondarySetState" *after* triggering "droidWasFullyRepaired"
+		// because in some cases calling it would modify primary order
+		// thus, loosing information that we actually had a RTR|RTR_SPECIFIED before
+		secondarySetState(psDroid, DSO_RETURN_TO_LOC, DSS_NONE);
 		return RepairState::Idle;
 	};
 	case RepairEvents::UnitDied:


### PR DESCRIPTION
Fixes bug reported by @KJeff01 :
- in Campaign, a unit which just finished repairs would not go to rally point. Only campaign was affected, because of this bit:
```
	if (bMultiMessages && mode == ModeQueue)
	{
		CurrState = psDroid->secondaryOrderPending;
	}
```

Fixes another unreported (at my knowledge) bug
- When manually specifying Repair Station, damaged unit would refuse to go to specified location in case if another repair station/ mobile repair unit is near. So I simply separated RTR_SPECIFIED from RTR, so that `decideWhereToRepairAndBalance` is not called. This fix doesn't affect the case when context menu "Go To Repair" is used