### PR TITLE
Revert "Reduce effectiveness of artillery modifiers against Tracked"

### DIFF
--- a/data/mp/stats/weaponmodifier.json
+++ b/data/mp/stats/weaponmodifier.json
@@ -28,7 +28,7 @@
 		"Hover": 110,
 		"Legged": 130,
 		"Lift": 25,
-		"Tracked": 30,
+		"Tracked": 40,
 		"Wheeled": 90
 	},
 	"BUNKER BUSTER": {


### PR DESCRIPTION
To address concerns that mobile unit artillery is now too valuable over defensive artillery emplacements.

From Tipchik:
"There are test results for artillery damage modifier reduction against Tracked Propulsion. Mobile artillery using Tracked Propulsion is now more survivable against itself. Mobile artillery now has even higher priority than stationary artillery. Stationary artillery now needs more to destroy mobile artillery."

If this is merged, the artillery modifier against Tracks will change as follows:
30% -> 40%
And be like it was in 4.3.3.