### PR TITLE
(MP) Make ripple rocket opening closer to howitzer

### DIFF
--- a/data/mp/stats/research.json
+++ b/data/mp/stats/research.json
@@ -8644,7 +8644,8 @@
 		"name": "Ripple Rockets",
 		"requiredResearch": [
 			"R-Wpn-Rocket02-MRL",
-			"R-Sys-CBSensor-Turret01"
+			"R-Sys-CBSensor-Turret01",
+			"R-Struc-Research-Upgrade06"
 		],
 		"researchPoints": 7200,
 		"researchPower": 225,


### PR DESCRIPTION
Implementation of adding Dedicated Synaptic Link Data Analysis Mk3 to research requirements of Ripple Rockets.

Requested by Evolution.

![image](https://user-images.githubusercontent.com/20772987/231571972-2bb325ef-805f-45ef-b843-98436912c8a7.png)
