### PR TITLE
Expand addStructure() and changePlayerColour() functions

### DIFF
--- a/doc/js-functions.md
+++ b/doc/js-functions.md
@@ -775,6 +775,7 @@ Get the limits of the scrollable area of the map as an area object. (3.2+ only)
 Create a structure on the given position. Returns the structure on success, null otherwise.
 Position uses world coordinates, if you want use position based on Map Tiles, then
 use as addStructure(structureName, players, x*128, y*128)
+Direction is optional, and is specified in degrees.
 
 ## getStructureLimit(structureName[, player])
 

--- a/doc/js-functions.md
+++ b/doc/js-functions.md
@@ -268,8 +268,9 @@ looks, or to add variety to the looks of droids in campaign missions. (3.2+ only
 
 ## changePlayerColour(player, colour)
 
-Change a player's colour slot. The current player colour can be read from the ```playerData``` array. There are as many
-colour slots as the maximum number of players. (3.2.3+ only)
+Change a player's colour slot. The current player colour can be read from the ```playerData``` array. Available colours
+are green, orange, gray, black, red, blue, pink, cyan, yellow, purple, white, bright blue, neon green, infrared,
+ultraviolet, and brown, represented by the integers 0 - 15 respectively.
 
 ## setHealth(object, health)
 
@@ -769,7 +770,7 @@ Limit the scrollable area of the map to the given rectangle. (3.2+ only)
 
 Get the limits of the scrollable area of the map as an area object. (3.2+ only)
 
-## addStructure(structureName, player, x, y)
+## addStructure(structureName, player, x, y[, direction])
 
 Create a structure on the given position. Returns the structure on success, null otherwise.
 Position uses world coordinates, if you want use position based on Map Tiles, then

--- a/src/component.cpp
+++ b/src/component.cpp
@@ -63,7 +63,7 @@ bool setPlayerColour(UDWORD player, UDWORD col)
 		NetPlay.players[player].colour = MAX_PLAYERS;
 		return true;
 	}
-	ASSERT_OR_RETURN(false, col < MAX_PLAYERS, "Bad colour setting");
+	ASSERT_OR_RETURN(false, col < 16, "Bad colour setting");
 	NetPlay.players[player].colour = col;
 	return true;
 }

--- a/src/component.cpp
+++ b/src/component.cpp
@@ -63,6 +63,7 @@ bool setPlayerColour(UDWORD player, UDWORD col)
 		NetPlay.players[player].colour = MAX_PLAYERS;
 		return true;
 	}
+	// Allow color values from 0 to 15
 	ASSERT_OR_RETURN(false, col < 16, "Bad colour setting");
 	NetPlay.players[player].colour = col;
 	return true;

--- a/src/wzapi.cpp
+++ b/src/wzapi.cpp
@@ -567,8 +567,9 @@ bool wzapi::replaceTexture(WZAPI_PARAMS(std::string oldFilename, std::string new
 
 //-- ## changePlayerColour(player, colour)
 //--
-//-- Change a player's colour slot. The current player colour can be read from the ```playerData``` array. There are as many
-//-- colour slots as the maximum number of players. (3.2.3+ only)
+//-- Change a player's colour slot. The current player colour can be read from the ```playerData``` array. Available colours
+//-- are green, orange, gray, black, red, blue, pink, cyan, yellow, purple, white, bright blue, neon green, infrared,
+//-- ultraviolet, and brown, represented by the integers 0 - 15 respectively.
 //--
 bool wzapi::changePlayerColour(WZAPI_PARAMS(int player, int colour))
 {
@@ -2975,20 +2976,22 @@ scr_area wzapi::getScrollLimits(WZAPI_NO_PARAMS)
 	return limits;
 }
 
-//-- ## addStructure(structureName, player, x, y)
+//-- ## addStructure(structureName, player, x, y[, direction])
 //--
 //-- Create a structure on the given position. Returns the structure on success, null otherwise.
 //-- Position uses world coordinates, if you want use position based on Map Tiles, then
 //-- use as addStructure(structureName, players, x*128, y*128)
 //--
-wzapi::returned_nullable_ptr<const STRUCTURE> wzapi::addStructure(WZAPI_PARAMS(std::string structureName, int player, int x, int y))
+wzapi::returned_nullable_ptr<const STRUCTURE> wzapi::addStructure(WZAPI_PARAMS(std::string structureName, int player, int x, int y, optional<float> _direction))
 {
 	int structureIndex = getStructStatFromName(WzString::fromUtf8(structureName.c_str()));
 	SCRIPT_ASSERT(nullptr, context, structureIndex >= 0 && structureIndex < numStructureStats, "Structure %s not found", structureName.c_str());
 	SCRIPT_ASSERT_PLAYER(nullptr, context, player);
 
+	uint16_t direction = static_cast<uint16_t>(DEG(_direction.value_or(0)));
+
 	STRUCTURE_STATS *psStat = &asStructureStats[structureIndex];
-	STRUCTURE *psStruct = buildStructure(psStat, x, y, player, false);
+	STRUCTURE *psStruct = buildStructureDir(psStat, x, y, direction, player, false);
 	if (psStruct)
 	{
 		psStruct->status = SS_BUILT;

--- a/src/wzapi.cpp
+++ b/src/wzapi.cpp
@@ -2981,8 +2981,9 @@ scr_area wzapi::getScrollLimits(WZAPI_NO_PARAMS)
 //-- Create a structure on the given position. Returns the structure on success, null otherwise.
 //-- Position uses world coordinates, if you want use position based on Map Tiles, then
 //-- use as addStructure(structureName, players, x*128, y*128)
+//-- Direction is optional, and is specified in degrees.
 //--
-wzapi::returned_nullable_ptr<const STRUCTURE> wzapi::addStructure(WZAPI_PARAMS(std::string structureName, int player, int x, int y, optional<float> _direction))
+wzapi::returned_nullable_ptr<const STRUCTURE> wzapi::addStructure(WZAPI_PARAMS(std::string structureName, int player, int x, int y, optional<int> _direction))
 {
 	int structureIndex = getStructStatFromName(WzString::fromUtf8(structureName.c_str()));
 	SCRIPT_ASSERT(nullptr, context, structureIndex >= 0 && structureIndex < numStructureStats, "Structure %s not found", structureName.c_str());

--- a/src/wzapi.h
+++ b/src/wzapi.h
@@ -1084,7 +1084,7 @@ namespace wzapi
 	bool removeObject(WZAPI_PARAMS(BASE_OBJECT *psObj, optional<bool> _sfx));
 	no_return_value setScrollLimits(WZAPI_PARAMS(int x1, int y1, int x2, int y2));
 	scr_area getScrollLimits(WZAPI_NO_PARAMS);
-	returned_nullable_ptr<const STRUCTURE> addStructure(WZAPI_PARAMS(std::string structureName, int player, int x, int y, optional<float> _direction));
+	returned_nullable_ptr<const STRUCTURE> addStructure(WZAPI_PARAMS(std::string structureName, int player, int x, int y, optional<int> _direction));
 	unsigned int getStructureLimit(WZAPI_PARAMS(std::string structureName, optional<int> _player));
 	int countStruct(WZAPI_PARAMS(std::string structureName, optional<int> _playerFilter));
 	int countDroid(WZAPI_PARAMS(optional<int> _droidType, optional<int> _playerFilter));

--- a/src/wzapi.h
+++ b/src/wzapi.h
@@ -1084,7 +1084,7 @@ namespace wzapi
 	bool removeObject(WZAPI_PARAMS(BASE_OBJECT *psObj, optional<bool> _sfx));
 	no_return_value setScrollLimits(WZAPI_PARAMS(int x1, int y1, int x2, int y2));
 	scr_area getScrollLimits(WZAPI_NO_PARAMS);
-	returned_nullable_ptr<const STRUCTURE> addStructure(WZAPI_PARAMS(std::string structureName, int player, int x, int y));
+	returned_nullable_ptr<const STRUCTURE> addStructure(WZAPI_PARAMS(std::string structureName, int player, int x, int y, optional<float> _direction));
 	unsigned int getStructureLimit(WZAPI_PARAMS(std::string structureName, optional<int> _player));
 	int countStruct(WZAPI_PARAMS(std::string structureName, optional<int> _playerFilter));
 	int countDroid(WZAPI_PARAMS(optional<int> _droidType, optional<int> _playerFilter));


### PR DESCRIPTION
Allows `addStructure` to accept an additional `direction` argument, which specifies the direction (in degrees) the new structure will face.
![image](https://user-images.githubusercontent.com/28832631/231616370-b1ac23f1-d666-422b-b4e4-71523569f350.png)

Allows `changePlayerColour` to set color values up to 15, utilizing the previously unused(?) team colors specified in pallete.txt.
The colors available to be assigned are now: 
green, orange, gray, black, 
red, blue, pink, cyan, 
yellow, purple, white, bright blue,
neon green, infrared, ultraviolet, and brown.
![playerColours](https://user-images.githubusercontent.com/28832631/231618893-3ed90ad1-500e-4c71-9bed-143a4fffe5a8.png)