### PR TITLE
Revert Tank Killer reloadTime from 160 -> 180

### DIFF
--- a/data/mp/stats/weapons.json
+++ b/data/mp/stats/weapons.json
@@ -3940,7 +3940,7 @@
 		"numExplosions": 1,
 		"numRounds": 2,
 		"radiusLife": 10,
-		"reloadTime": 160,
+		"reloadTime": 180,
 		"rotate": 180,
 		"shortHit": 30,
 		"shortRange": 512,


### PR DESCRIPTION
**Proposal:** Revert the "Tank Killer" weapon's `reloadTime` back to the pre-4.3.3 value (from `160` -> `180`).

**Reasoning**: This was changed (among other changes) in https://github.com/Warzone2100/warzone2100/pull/3080 for 4.3.3, but opinions seem to be that it went too far, and advantaged rockets too much over cannons.

This PR would revert the `reloadTime` back to its pre-4.3.3 value, providing a better balance between rockets and cannons.