### PR TITLE
(MP)Sunburst AA Tweak

### DIFF
--- a/data/mp/stats/weapons.json
+++ b/data/mp/stats/weapons.json
@@ -4199,7 +4199,7 @@
 		"radiusDamage": 50,
 		"radiusLife": 10,
 		"recoilValue": 10,
-		"reloadTime": 58,
+		"reloadTime": 90,
 		"rotate": 180,
 		"shortHit": 45,
 		"shortRange": 1024,


### PR DESCRIPTION
Some players have noticed that the Sunburst AA is an order of magnitude more effective than the Cyclone Flak, and in fact it is.
The thing is that Sunburst has three ROF buffs before the first VTOL (beginning of the T2 stage), which together reduce the reload between shots by 45%, and Cyclone has 20%. Also, Sunburst fires six rounds at a time while Cyclone has only one.
Also, if we compare the basic reload (without the buffs) between shots of these two AAs, the difference is not great at all: Sunburst 58 and Cyclone 43, and now apply the buffs to these values and we get that Sunburst is faster than Cyclone.
So I decided to increase the Sunburst reload time from 58 to 90