### PR TITLE
(MP)Changing obsolete technology

### DIFF
--- a/data/mp/stats/research.json
+++ b/data/mp/stats/research.json
@@ -7326,8 +7326,6 @@
 		"id": "R-Wpn-Missile2A-T",
 		"name": "Scourge Missile",
 		"redComponents": [
-			"Rocket-LtA-T",
-			"Rocket-VTOL-LtA-T",
 			"CyborgRocket",
 			"Rocket-HvyA-T",
 			"Rocket-VTOL-HvyA-T"
@@ -8674,6 +8672,10 @@
 		"id": "R-Wpn-Rocket07-Tank-Killer",
 		"msgName": "RES_W_RK_HvAT",
 		"name": "Tank Killer Rocket",
+		"redComponents": [
+			"Rocket-LtA-T",
+			"Rocket-VTOL-LtA-T"
+		],
 		"requiredResearch": [
 			"R-Wpn-RocketSlow-Accuracy01",
 			"R-Wpn-Rocket-Damage05"

--- a/data/mp/stats/research.json
+++ b/data/mp/stats/research.json
@@ -5219,6 +5219,9 @@
 		"id": "R-Wpn-Cannon2Mk1",
 		"msgName": "RES_CN2MK1",
 		"name": "Medium Cannon",
+		"redComponents": [
+			"Cannon1Mk1"
+		],
 		"requiredResearch": [
 			"R-Struc-Factory-Module",
 			"R-Wpn-Cannon-Damage01"
@@ -6235,6 +6238,9 @@
 		"id": "R-Wpn-Howitzer-Incendiary",
 		"msgName": "RES_W_INH",
 		"name": "Incendiary Howitzer",
+		"redComponents": [
+			"Mortar-Incendiary"
+		],
 		"requiredResearch": [
 			"R-Wpn-Mortar-Incendiary",
 			"R-Wpn-HowitzerMk1"
@@ -6368,7 +6374,8 @@
 		"msgName": "RES_W_RHOW",
 		"name": "Rotary Howitzer - Hellstorm",
 		"redComponents": [
-			"Howitzer105Mk1"
+			"Howitzer105Mk1",
+			"Mortar3ROTARYMk1"
 		],
 		"requiredResearch": [
 			"R-Wpn-HowitzerMk1",
@@ -6386,6 +6393,9 @@
 		"id": "R-Wpn-HowitzerMk1",
 		"msgName": "RES_W_HMK1",
 		"name": "Howitzer",
+		"redComponents": [
+			"Mortar2Mk1"
+		],
 		"requiredResearch": [
 			"R-Wpn-Mortar-Damage04",
 			"R-Sys-Sensor-Upgrade01",
@@ -7210,6 +7220,9 @@
 		"id": "R-Wpn-Missile-LtSAM",
 		"msgName": "RES_W_MS_LtSAM1",
 		"name": "Avenger SAM",
+		"redComponents": [
+			"Rocket-Sunburst"
+		],
 		"requiredResearch": [
 			"R-Sys-Sensor-Upgrade02",
 			"R-Wpn-Missile2A-T"
@@ -7791,6 +7804,9 @@
 		"id": "R-Wpn-Mortar02Hvy",
 		"msgName": "RES_W_M2",
 		"name": "Heavy Mortar - Bombard",
+		"redComponents": [
+			"Mortar1Mk1"
+		],
 		"requiredResearch": [
 			"R-Vehicle-Metals01",
 			"R-Wpn-Mortar-Damage02"


### PR DESCRIPTION
The listed turrets will now become obsolete when their improved version appears in the design menu
I don't see the point in producing the turrets listed below when more powerful ones are available

Sunburst ->Avenger
Light Cannon ->Medium Cannon
Mortar ->Bombard
Bombard ->Howitzer
Pepperpot ->Hellstorm
Incendiary Mortar ->Incendiary Howitzer
Lancer ->Tank Killer
