### PR TITLE
(MP) Change Heavy Plasma Launcher to require Superhot Plasmite Gel Mk3

### DIFF
--- a/data/mp/stats/research.json
+++ b/data/mp/stats/research.json
@@ -5916,7 +5916,7 @@
 		"msgName": "RES_W_PLASLAUNCH",
 		"name": "Heavy Plasma Launcher",
 		"requiredResearch": [
-			"R-Wpn-Flamer-Damage08",
+			"R-Wpn-Flamer-Damage09",
 			"R-Wpn-PlasmaCannon"
 		],
 		"researchPoints": 28800,


### PR DESCRIPTION
- Change one of the prerequisites of the Heavy Plasmite Launcher from Superhot Plasmite Gel Mk2 to Mk3, unlocking the weapon roughly ~4min later.

While archangels are in a general sense still better(a lot of it due to range and the ability to spam them near the rear of the base, out-ranging everything), the plasma launcher is still a competitor to the archangels, and in some scenarios the plasma launcher can perform better. Currently, the Heavy Plasma Launcher unlocks at 35:09, while the Archangel Missile unlocks at 44:12 - almost 10min, which is too far apart considering they can be competitors.