### PR TITLE
EMP mortar change

### DIFF
--- a/data/mp/stats/weapons.json
+++ b/data/mp/stats/weapons.json
@@ -3468,7 +3468,7 @@
 		"effectSize": 100,
 		"facePlayer": 1,
 		"fireOnMove": 0,
-		"firePause": 130,
+		"firePause": 90,
 		"flightGfx": "FXSFlms.PIE",
 		"flightSpeed": 1500,
 		"hitGfx": "FXSFlms.PIE",


### PR DESCRIPTION
RBMW-Fenrir offers a change to the EMP mortar reload. FirePause was 130, became 90. Due to poor reloads, very few players use EMP mortar.