### PR TITLE
EMP cannon weight change

### DIFF
--- a/data/mp/stats/weapons.json
+++ b/data/mp/stats/weapons.json
@@ -1897,7 +1897,7 @@
 		"weaponEffect": "ALL ROUNDER",
 		"weaponSubClass": "EMP",
 		"weaponWav": "emp.ogg",
-		"weight": 10000
+		"weight": 8000
 	},
 	"Flame1Mk1": {
 		"buildPoints": 200,


### PR DESCRIPTION
EMP Cannon weight 10000 ->8000.
Players rarely use the EMP cannon. Perhaps by lowering the weight a bit, the EMP cannon will be used more often