### PR TITLE
Heavy cannon weight change

### DIFF
--- a/data/mp/stats/weapons.json
+++ b/data/mp/stats/weapons.json
@@ -907,7 +907,7 @@
 		"weaponEffect": "ALL ROUNDER",
 		"weaponSubClass": "CANNON",
 		"weaponWav": "lrgcan.ogg",
-		"weight": 10000
+		"weight": 8000
 	},
 	"Cannon4AUTO-VTOL": {
 		"buildPoints": 700,


### PR DESCRIPTION
Heavy cannon weight change 10000 -> 8000. Very slow, rarely used. Mostly used for defense. Twin Assault Cannon is better for attacking