### PR TITLE
Howitzer-Incendiary change

### DIFF
--- a/data/mp/stats/research.json
+++ b/data/mp/stats/research.json
@@ -8149,7 +8149,7 @@
 			"R-Struc-Research-Upgrade01",
 			"R-Wpn-Rocket-Damage02"
 		],
-		"researchPoints": 3600,
+		"researchPoints": 2400,
 		"researchPower": 112,
 		"results": [
 			{

--- a/data/mp/stats/research.json
+++ b/data/mp/stats/research.json
@@ -8149,7 +8149,7 @@
 			"R-Struc-Research-Upgrade01",
 			"R-Wpn-Rocket-Damage02"
 		],
-		"researchPoints": 2400,
+		"researchPoints": 3600,
 		"researchPower": 112,
 		"results": [
 			{

--- a/data/mp/stats/weapons.json
+++ b/data/mp/stats/weapons.json
@@ -2095,7 +2095,7 @@
 		"periodicalDamageWeaponEffect": "FLAMER",
 		"periodicalDamageWeaponSubClass": "HOWITZERS",
 		"radius": 192,
-		"radiusDamage": 200,
+		"radiusDamage": 100,
 		"radiusLife": 10,
 		"recoilValue": 250,
 		"shortHit": 40,

--- a/data/mp/stats/weapons.json
+++ b/data/mp/stats/weapons.json
@@ -2063,7 +2063,7 @@
 	"Howitzer-Incendiary": {
 		"buildPoints": 1600,
 		"buildPower": 450,
-		"damage": 200,
+		"damage": 100,
 		"designable": 1,
 		"effectSize": 150,
 		"explosionWav": "lrgexpl.ogg",


### PR DESCRIPTION
Howitzer-Incendiary damage 200 -> 100/ splash damage 100. The incendiary howitzer replaces the others and there is no point in using the regular howitzer and hellstorm. By changing the damage, the Incendiary Howitzer will be effective against tanks, hellstorm and howitzer to destroy the defense.