### PR TITLE
Cannon Autoloader change

### DIFF
--- a/data/mp/stats/research.json
+++ b/data/mp/stats/research.json
@@ -5055,7 +5055,6 @@
 		"id": "R-Wpn-Cannon-ROF02",
 		"name": "Cannon Autoloader Mk2",
 		"requiredResearch": [
-			"R-Struc-Factory-Upgrade04",
 			"R-Wpn-Cannon-ROF01"
 		],
 		"researchPoints": 6000,


### PR DESCRIPTION
Cancel "Robotic Manufacturing" requirement for Cannon Autoloader Mk2. There are no requirements for rockets.