### PR TITLE
Сhange in Scourge Missile research

### DIFF
--- a/data/mp/stats/research.json
+++ b/data/mp/stats/research.json
@@ -7322,7 +7322,8 @@
 		"requiredResearch": [
 			"R-Wpn-Rocket07-Tank-Killer",
 			"R-Wpn-RocketSlow-Accuracy02",
-			"R-Struc-Research-Upgrade07"
+			"R-Struc-Research-Upgrade07",
+			"R-Wpn-Rocket-Damage06"
 		],
 		"researchPoints": 16600,
 		"researchPower": 450,


### PR DESCRIPTION
Add rocket damage 06 (Rocket Warhead Mk3) to open Scourge Missile. Cannons can't quit "damage" research and get Needle Gun in time. To even up the balance, let's add this change. In any case, you will get the Rocket Warhead Mk3 before you get the Neural Synapse.