### PR TITLE
(MP)Adjusting the sensors of AA structures

### DIFF
--- a/data/mp/stats/structure.json
+++ b/data/mp/stats/structure.json
@@ -2270,7 +2270,7 @@
 		"id": "P0-AASite-Laser",
 		"name": "Stormbringer Emplacement",
 		"resistance": 150,
-		"sensorID": "NavGunSensor",
+		"sensorID": "DefaultSensor1Mk1",
 		"strength": "HARD",
 		"structureModel": [
 			"Blaamnt2.PIE"
@@ -2292,7 +2292,7 @@
 		"id": "P0-AASite-SAM1",
 		"name": "Avenger SAM Site",
 		"resistance": 150,
-		"sensorID": "NavGunSensor",
+		"sensorID": "DefaultSensor1Mk1",
 		"strength": "HARD",
 		"structureModel": [
 			"Blaamnt1.PIE"
@@ -2314,7 +2314,7 @@
 		"id": "P0-AASite-SAM2",
 		"name": "Vindicator SAM Site",
 		"resistance": 150,
-		"sensorID": "NavGunSensor",
+		"sensorID": "DefaultSensor1Mk1",
 		"strength": "HARD",
 		"structureModel": [
 			"Blaamnt2.PIE"
@@ -2336,7 +2336,7 @@
 		"id": "P0-AASite-Sunburst",
 		"name": "Sunburst AA Site",
 		"resistance": 150,
-		"sensorID": "NavGunSensor",
+		"sensorID": "DefaultSensor1Mk1",
 		"strength": "MEDIUM",
 		"structureModel": [
 			"Blaamnt1.PIE"


### PR DESCRIPTION
Currently all combat units and defensive structures have the "DefaultSensor1Mk1" sensor except the following AA positions and this needs to be fixed because it breaks the balance

Replace NavGunSensor with DefaultSensor1Mk1 for the following structures:
Sunburst AA Site
Avenger SAM Site
Vindicator SAM Site
Stormbringer Emplacement

For reference: 
NavGunSensor has a radius of 16 tiles (like the Hardened Sensor Tower)
DefaultSensor1Mk1 has a radius of 8 tiles