### PR TITLE
Make sensor units use the Commander rank thresholds

### DIFF
--- a/src/droid.cpp
+++ b/src/droid.cpp
@@ -2146,7 +2146,8 @@ unsigned int getDroidLevel(unsigned int experience, uint8_t player, uint8_t brai
 
 unsigned int getDroidLevel(const DROID *psDroid)
 {
-	return getDroidLevel(psDroid->experience, psDroid->player, psDroid->asBits[COMP_BRAIN]);
+	// Sensors will use the first non-null brain component for ranks
+	return getDroidLevel(psDroid->experience, psDroid->player, (psDroid->droidType != DROID_SENSOR) ? psDroid->asBits[COMP_BRAIN] : 1);
 }
 
 UDWORD getDroidEffectiveLevel(const DROID *psDroid)

--- a/src/hci/manufacture.cpp
+++ b/src/hci/manufacture.cpp
@@ -324,7 +324,7 @@ protected:
 			// not showing icon when nothing is being built
 			return;
 		}
-		if (factory->pFunctionality->factory.psSubject->droidType == DROID_COMMAND)
+		if (factory->pFunctionality->factory.psSubject->droidType == DROID_COMMAND || factory->pFunctionality->factory.psSubject->droidType == DROID_SENSOR)
 		{
 			lvl = getDroidLevel(exp, player, commandBrainComponent);
 		}


### PR DESCRIPTION
Due to MP sensor units having the ability to dodge bullets and artillery like Neo in The Matrix when they quickly ascend to Hero rank, I am flipping the tables and making them follow the Commander rank thresholds again. This used to be the way a long time ago but it got switched to the normal combat unit ranks after some point.

This will help alleviate the OPness of sensor units in mp substantially. It will mean campaign sensors will be more vulnerable in campaign again (not reaching Hero by Alpha / early Beta) though they don't face anywhere near as much danger in campaign.

We currently just assume the first non-znull brain component is the standard Commander brain for rank thresholds but I'm not touching that here.