### PR TITLE
Fix saved coordinates for units inside transporters

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -5819,7 +5819,7 @@ static bool writeDroidFile(const char *pFileName, DROID **ppsCurrentDroidLists)
 				//always save transporter droids that are in the mission list with an invalid value
 				if (ppsCurrentDroidLists[player] == mission.apsDroidLists[player])
 				{
-					mRoot[droidKey.toStdString()]["position"] = Vector3i(-1, -1, -1); // was INVALID_XY
+					mRoot[droidKey.toStdString()]["position"] = Vector3i(INVALID_XY, INVALID_XY, -1); // Must be INVALID_XY or else unit placement could get messed up in missionResetDroids().
 				}
 			}
 		}


### PR DESCRIPTION
If a unit produced offworld was inside a transporter, and a save was created, it would override the expected coordinates.

Because the (x, y) coordinates are no longer both INVALID_XY, it would mess up unit placement in this scenario if that unit did not make it off the transporter when a mission gets completed.

Fixes #3050 (from my guess this has been happening since 2011).