### PR TITLE
Show reinforcement timer upon exit

### DIFF
--- a/data/base/script/campaign/cam1c.js
+++ b/data/base/script/campaign/cam1c.js
@@ -207,7 +207,6 @@ function eventStartLevel()
 		setMissionTime(camChangeOnDiff(camHoursToSeconds(2)));
 	}
 
-	setReinforcementTime(-1);
 	setAlliance(NEW_PARADIGM, SCAV_7, true);
 	camCompleteRequiredResearch(NEW_PARADIGM_RES, NEW_PARADIGM);
 	camCompleteRequiredResearch(SCAVENGER_RES, SCAV_7);

--- a/data/base/script/campaign/libcampaign_includes/events.js
+++ b/data/base/script/campaign/libcampaign_includes/events.js
@@ -214,6 +214,11 @@ function cam_eventTransporterExit(transport)
 		{
 			const REINFORCEMENTS_AVAILABLE_SOUND = "pcv440.ogg";
 			playSound(REINFORCEMENTS_AVAILABLE_SOUND);
+			//Show the transporter reinforcement timer when it leaves for the first time.
+			if (__camWinLossCallback === CAM_VICTORY_OFFWORLD)
+			{
+				setReinforcementTime(__camVictoryData.reinforcements);
+			}
 		}
 	}
 

--- a/data/base/script/campaign/libcampaign_includes/victory.js
+++ b/data/base/script/campaign/libcampaign_includes/victory.js
@@ -103,7 +103,7 @@ function camSetStandardWinLossConditions(kind, nextLevel, data)
 			__camNeedBonusTime = true;
 			__camDefeatOnTimeout = true;
 			__camVictoryData = data;
-			setReinforcementTime(__camVictoryData.reinforcements);
+			setReinforcementTime((__camVictoryData.reinforcements > -1) ? __camVictoryData.reinforcements : -1);
 			useSafetyTransport(false);
 			break;
 		case CAM_VICTORY_TIMEOUT:
@@ -111,7 +111,7 @@ function camSetStandardWinLossConditions(kind, nextLevel, data)
 			__camNeedBonusTime = false;
 			__camDefeatOnTimeout = false;
 			__camVictoryData = data;
-			setReinforcementTime(__camVictoryData.reinforcements);
+			setReinforcementTime((__camVictoryData.reinforcements > -1) ? __camVictoryData.reinforcements : -1);
 			useSafetyTransport(true);
 			break;
 		default:


### PR DESCRIPTION
The sometimes very wrong ETA was annoying me so I'm setting this widget to only show up shortly after landing for missions that automatically have reinforcements available.

Technically I'm just hiding this bug with the timer again after automating the "reinforcements are available" message maybe 4 years ago. As I don't feel like messing with how the ETA timer works before the first drop off.