### PR TITLE
(MP)Gauss Cannon change

### DIFF
--- a/data/mp/multiplay/script/functions/camTechEnabler.js
+++ b/data/mp/multiplay/script/functions/camTechEnabler.js
@@ -385,15 +385,15 @@ var allRes = {
 	"R-Wpn-Energy-ROF03": 3233,
 	"R-Wpn-Rail-ROF03": 3243,
 	"R-Wpn-Rail-Damage03": 3251,
+	"R-Wpn-RailGun03": 3251,
 	"R-Defense-HvyArtMissile": 3266,
+	"R-Defense-Rail3": 3327,
+	"R-Defense-WallTower-Rail3": 3360,
 	"R-Wpn-Missile-HvSAM": 3484,
 	"R-Defense-Super-Missile": 3597,
 	"R-Defense-SamSite2": 3703,
 	"R-Defense-WallTower-SamHvy": 3757,
 	"R-Vehicle-Body14": 3846,
 	"R-Wpn-Howitzer-ROF04": 3861,
-	"R-Wpn-RailGun03": 3906,
-	"R-Defense-Rail3": 3982,
-	"R-Defense-WallTower-Rail3": 4015,
-	"R-Defense-MassDriver": 4664
+	"R-Defense-MassDriver": 4009
 };

--- a/data/mp/stats/research.json
+++ b/data/mp/stats/research.json
@@ -8133,7 +8133,7 @@
 			"RailGun2Mk1"
 		],
 		"requiredResearch": [
-			"R-Wpn-Rail-Damage03"
+			"R-Wpn-RailGun02"
 		],
 		"researchPoints": 43200,
 		"researchPower": 450,


### PR DESCRIPTION
required Research: Hardened Rail Dart Mk3 ->Rail Gun

This change will not spoil the balance because Scourge Missile already has all buffs and all artillery is also available (see images below).
Also, this change is necessary because of the 1.5 hour autohost time limit, which means that the gauss cannot reach its full potential in time, and the gun needs to be moved 10 minutes earlier
Moving GC will result in a very acceptable time gap for T4 between Rail Gun and GS of 10 minutes
Because of the GC move, Mass Driver will also move by 10 minutes, which will be a plus for balance because Missile Fortress is so far the best and is available before Mass Driver 

![1](https://github.com/Warzone2100/warzone2100/assets/50970280/cb445e85-de17-443c-8c55-607f213a5b7c)

![2](https://github.com/Warzone2100/warzone2100/assets/50970280/3412f48f-32b5-42e1-95fb-11e6b99fd235)

![3](https://github.com/Warzone2100/warzone2100/assets/50970280/f017e7a1-d869-4444-8f68-1325ef85bc92)
