### PR TITLE
Cancel research inside labs when changing campaigns

### DIFF
--- a/src/mission.cpp
+++ b/src/mission.cpp
@@ -1169,6 +1169,9 @@ bool startMissionCampaignChange(char *pGame)
 	// Clear out all intelligence screen messages
 	freeMessages();
 
+	// Cancel any research active in a lab
+	CancelAllResearch(selectedPlayer);
+
 	// Check no units left with any settings that are invalid
 	clearCampaignUnits();
 


### PR DESCRIPTION
Prevent invalid research states for research topics being pursued or on hold in a lab during a campaign change. May be a better way to do this.

For example, have the Mantis body in a research lab during Alpha End and then go off to Beta. The player will not have access to Mantis for the rest of that campaign.