### PR TITLE
Increase minimum vertical ascension speed for slower VTOLs

### DIFF
--- a/src/move.cpp
+++ b/src/move.cpp
@@ -1667,7 +1667,10 @@ static void moveUpdatePersonModel(DROID *psDroid, SDWORD speed, uint16_t directi
 	CHECK_DROID(psDroid);
 }
 
-#define	VTOL_VERTICAL_SPEED		(((psDroid->baseSpeed / 4) > 60) ? ((SDWORD)psDroid->baseSpeed / 4) : 60)
+#define	VTOL_VERTICAL_SPEED_OLD		(((psDroid->baseSpeed / 4) > 60) ? ((SDWORD)psDroid->baseSpeed / 4) : 60)
+//Slower VTOLs need to increase height faster than the above or else they hover too close to the ground
+//during flight paths that feature increasing terrain height. Resulting in poor attack angles in some cases.
+#define	VTOL_VERTICAL_SPEED		(((psDroid->baseSpeed / 4) > 160) ? ((SDWORD)psDroid->baseSpeed / 4) : 160)
 
 /* primitive 'bang-bang' vtol height controller */
 static void moveAdjustVtolHeight(DROID *psDroid, int32_t iMapHeight)
@@ -1688,11 +1691,18 @@ static void moveAdjustVtolHeight(DROID *psDroid, int32_t iMapHeight)
 
 	if (psDroid->pos.z >= (iMapHeight + iMaxHeight))
 	{
-		psDroid->sMove.iVertSpeed = (SWORD) - VTOL_VERTICAL_SPEED;
+		psDroid->sMove.iVertSpeed = (SWORD) - VTOL_VERTICAL_SPEED_OLD;
 	}
 	else if (psDroid->pos.z < (iMapHeight + iMinHeight))
 	{
-		psDroid->sMove.iVertSpeed = (SWORD)VTOL_VERTICAL_SPEED;
+		if (isTransporter(psDroid))
+		{
+			psDroid->sMove.iVertSpeed = (SWORD)VTOL_VERTICAL_SPEED_OLD;
+		}
+		else
+		{
+			psDroid->sMove.iVertSpeed = (SWORD)VTOL_VERTICAL_SPEED;
+		}
 	}
 	else if ((psDroid->pos.z < iLevelHeight) &&
 	         (psDroid->sMove.iVertSpeed < 0))
@@ -1805,7 +1815,7 @@ static void moveDescending(DROID *psDroid)
 	if (psDroid->pos.z > iMapHeight)
 	{
 		/* descending */
-		psDroid->sMove.iVertSpeed = (SWORD) - VTOL_VERTICAL_SPEED;
+		psDroid->sMove.iVertSpeed = (SWORD) - VTOL_VERTICAL_SPEED_OLD;
 	}
 	else
 	{


### PR DESCRIPTION
This seems nice enough to get VTOLs up to the intended level height when moving over terrain with extreme height differences along a flight path.

Probably will reduce or eliminate VTOLs appearing to crash and scrape into very tall hills along their way too.