### PR TITLE
Use the game queues in campaign mode

### DIFF
--- a/src/order.cpp
+++ b/src/order.cpp
@@ -1897,7 +1897,7 @@ void orderDroid(DROID *psDroid, DROID_ORDER order, QUEUE_MODE mode)
 	       "orderUnit: Invalid order");
 
 	DROID_ORDER_DATA sOrder(order);
-	if (mode == ModeQueue && bMultiPlayer)
+	if (mode == ModeQueue)
 	{
 		sendDroidInfo(psDroid, sOrder, false);
 	}
@@ -2110,7 +2110,7 @@ void orderDroidStatsLocDir(DROID *psDroid, DROID_ORDER order, STRUCTURE_STATS *p
 	ASSERT(order == DORDER_BUILD, "Invalid order for location");
 
 	DroidOrder sOrder(order, psStats, Vector2i(x, y), direction);
-	if (mode == ModeQueue && bMultiPlayer)
+	if (mode == ModeQueue)
 	{
 		sendDroidInfo(psDroid, sOrder, false);
 		return;  // Wait for our order before changing the droid.
@@ -2145,7 +2145,7 @@ void orderDroidStatsTwoLocDir(DROID *psDroid, DROID_ORDER order, STRUCTURE_STATS
 	ASSERT(order == DORDER_LINEBUILD, "Invalid order for location");
 
 	DroidOrder sOrder(order, psStats, Vector2i(x1, y1), Vector2i(x2, y2), direction);
-	if (mode == ModeQueue && bMultiPlayer)
+	if (mode == ModeQueue)
 	{
 		sendDroidInfo(psDroid, sOrder, false);
 		return;  // Wait for our order before changing the droid.


### PR DESCRIPTION
The game queues are partially used in campaign mode, but some special cases exist. Let's see if removing them is a problem.

Current changes:
- order.cpp: Remove special case for campaign
   - In orderDroid, orderDroidStatsLocDir, orderDroidStatsTwoLocDir

----

Some other suspicious things that need investigation:

https://github.com/Warzone2100/warzone2100/blob/60d4ebc06b4337d61b3ce730c5720a390238d818/src/droid.cpp#L292-L303

(Possibly because of `removeDroidBase`->`assignFactoryCommandDroid`->`secondarySetState`, which has a `if (bMultiMessages && mode == ModeQueue)` check?)