### PR TITLE
Thread-safety improvements for debug()

### DIFF
--- a/lib/framework/debug.cpp
+++ b/lib/framework/debug.cpp
@@ -458,8 +458,8 @@ void _realObjTrace(int id, const char *function, const char *str, ...)
 // Thread local to prevent a race condition on read and write to this buffer if multiple
 // threads log errors. This means we will not be reporting any errors to console from threads
 // other than main. If we want to fix this, make sure accesses are protected by a mutex.
-static WZ_DECL_THREAD char errorStore[512];
-static WZ_DECL_THREAD bool errorWaiting = false;
+static thread_local char errorStore[512];
+static thread_local bool errorWaiting = false;
 const char *debugLastError()
 {
 	if (errorWaiting)

--- a/lib/framework/wzglobal.h
+++ b/lib/framework/wzglobal.h
@@ -520,19 +520,6 @@
 #endif
 
 
-/*! \def WZ_DECL_THREAD
- * Declares a variable to be local to the running thread, and not shared between threads.
- */
-#if defined(__MACOSX__)
-#  define WZ_DECL_THREAD // nothing, MacOSX does not yet support this
-#elif defined(WZ_CC_GNU) || defined(WZ_CC_INTEL)
-#  define WZ_DECL_THREAD __thread
-#elif defined(WZ_CC_MSVC)
-#  define WZ_DECL_THREAD __declspec(thread)
-#else
-#  error "Thread local storage attribute required"
-#endif
-
 /* ---- Platform specific setup ---- */
 
 #if defined(WZ_OS_WIN)


### PR DESCRIPTION
Use `thread_local` variables for buffers + deduplication.
Use a `mutex` to guard `warning_list` access.