### PR TITLE
Fix loadSaveFeature2 for spectator-assigned features

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -6927,7 +6927,7 @@ bool loadSaveFeature2(const char *pFileName)
 		}
 		//restore values
 		pFeature->rot = ini.vector3i("rotation");
-		pFeature->player = ini.value("player", PLAYER_FEATURE).toInt();
+		pFeature->player = getPlayer(ini);
 
 		// common BASE_OBJECT info
 		loadSaveObject(ini, pFeature);


### PR DESCRIPTION
Previously this would log a warning and default-assign them to player 0