### PR TITLE
Improve map hard-coded id handling, fixes for save game queued droid orders

### DIFF
--- a/lib/wzmaplib/CMakeLists.txt
+++ b/lib/wzmaplib/CMakeLists.txt
@@ -3,7 +3,7 @@
 
 set(WZMAPLIB_VERSION_MAJOR 1)
 set(WZMAPLIB_VERSION_MINOR 1)
-set(WZMAPLIB_VERSION_REV 0)
+set(WZMAPLIB_VERSION_REV 1)
 
 ###################
 # Determine minimum CMake version

--- a/lib/wzmaplib/src/map.cpp
+++ b/lib/wzmaplib/src/map.cpp
@@ -597,13 +597,14 @@ static inline bool jsonGetBaseMapObjectInfo(T& mapObj, uint32_t jsonFileVersion,
 			return false;
 		}
 		uint32_t id = jsonObj["id"].get<uint32_t>();
-		if (id == 0)
+		if (id > 0)
 		{
-			// Invalid droid id - cannot be 0
-			debug(pCustomLogger, LOG_ERROR, "%s: Invalid \"id\" = 0 for: %s", jsonContext.filename, jsonContext.jsonPath);
-			return false;
+			mapObj.id = id;
 		}
-		mapObj.id = id;
+		else
+		{
+			debug(pCustomLogger, LOG_WARNING, "%s: Invalid \"id\" = 0 for: %s - ignoring id value", jsonContext.filename, jsonContext.jsonPath);
+		}
 	}
 	// "position" must contain at least two components [x, y]
 	auto position = jsonGetListOfType<uint32_t>(jsonObj, "position", 2, maxComponentsPosition, jsonContext, pCustomLogger);
@@ -799,7 +800,14 @@ static optional<FileLoadResult<Structure>> loadBJOStructureInit(const std::strin
 		}
 
 		Structure structure;
-		structure.id = id;
+		if (id > 0)
+		{
+			structure.id = id;
+		}
+		else
+		{
+			debug(pCustomLogger, LOG_WARNING, "%s: Structure %" PRIu32 " has id = 0 - ignoring id value", path, i);
+		}
 		structure.name.assign(nameBuff.begin(), std::find(nameBuff.begin(), nameBuff.end(), '\0'));
 		// TODO: Possibly handle collecting modules?
 		structure.position.x = x;
@@ -1191,7 +1199,14 @@ static optional<FileLoadResult<Droid>> loadBJODroidInit(const std::string& filen
 			return nullopt;
 		}
 		Droid droid;
-		droid.id = id;
+		if (id > 0)
+		{
+			droid.id = id;
+		}
+		else
+		{
+			debug(pCustomLogger, LOG_WARNING, "%s: Droid %" PRIu32 " has id = 0 - ignoring id value", path, i);
+		}
 		droid.name.assign(nameBuff.begin(), std::find(nameBuff.begin(), nameBuff.end(), '\0'));
 		droid.position.x = (x & ~TILE_MASK) + TILE_UNITS / 2;
 		droid.position.y = (y & ~TILE_MASK) + TILE_UNITS / 2;
@@ -1544,7 +1559,14 @@ static optional<FileLoadResult<Feature>> loadBJOFeatureInit(const std::string& f
 		}
 
 		Feature feature;
-		feature.id = id;
+		if (id > 0)
+		{
+			feature.id = id;
+		}
+		else
+		{
+			debug(pCustomLogger, LOG_WARNING, "%s: Feature %" PRIu32 " has id = 0 - ignoring id value", path, i);
+		}
 		feature.name.assign(nameBuff.begin(), std::find(nameBuff.begin(), nameBuff.end(), '\0'));
 		feature.position.x = x;
 		feature.position.y = y;

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -3018,7 +3018,7 @@ bool loadGame(const char *pGameToLoad, bool keepObjects, bool freeMem, bool User
 			if (loadWzMapDroidInit(*(data.get()), fixedMapIdToGeneratedId))
 			{
 				debug(LOG_SAVE, "Loaded new style droids");
-				droidMap[aFileName] = apsDroidLists;	// load pointers later
+				// *maps* should not be added to droidMap to have loadSaveDroidPointers called later
 			}
 			else
 			{
@@ -3136,12 +3136,15 @@ bool loadGame(const char *pGameToLoad, bool keepObjects, bool freeMem, bool User
 			resetFactoryNumFlag();	//reset flags into the masks
 		}
 	}
-	else if (!loadSaveStructure2(aFileName))
+	else
 	{
-		debug(LOG_ERROR, "Failed with: %s", aFileName);
-		goto error;
+		if (!loadSaveStructure2(aFileName))
+		{
+			debug(LOG_ERROR, "Failed with: %s", aFileName);
+			goto error;
+		}
+		structMap[aFileName] = apsStructLists;
 	}
-	structMap[aFileName] = apsStructLists;
 
 	//if user save game then load up the current level for structs and components
 	if (gameType == GTYPE_SAVE_START || gameType == GTYPE_SAVE_MIDMISSION)
@@ -3237,6 +3240,7 @@ bool loadGame(const char *pGameToLoad, bool keepObjects, bool freeMem, bool User
 	if (!keepObjects)//only reset the pointers if they were set
 	{
 		// Reset the object pointers in the droid target lists
+		// Should only be called for savegames
 		for (auto it = droidMap.begin(); it != droidMap.end(); ++it)
 		{
 			const WzString& key = it->first;

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -6843,7 +6843,7 @@ static bool loadWzMapFeature(WzMap::Map &wzMap)
 		// Create the Feature
 		FEATURE *pFeature = nullptr;
 		//restore values && create Feature
-		if (feature.id.has_value())
+		if (feature.id.has_value() && feature.id.value() > 0)
 		{
 			pFeature = buildFeature(psStats, feature.position.x, feature.position.y, true, feature.id.value());
 		} else

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2387,6 +2387,8 @@ static void getIniDroidOrder(WzConfig &ini, WzString const &key, DroidOrder &ord
 	order.pos = ini.vector2i(key + "/pos");
 	order.pos2 = ini.vector2i(key + "/pos2");
 	order.direction = ini.value(key + "/direction").toInt();
+	order.index = ini.value(key + "/index").toUInt();
+	order.rtrType = (RTR_DATA_TYPE)ini.value(key + "/rtrType", RTR_TYPE_NO_RESULT).toInt();
 	getIniBaseObject(ini, key + "/obj", order.psObj);
 	getIniStructureStats(ini, key + "/stats", order.psStats);
 }
@@ -2421,6 +2423,8 @@ static inline void setIniDroidOrder(nlohmann::json &jsonObj, WzString const &key
 	jsonObj[keyStr + "/pos"] = order.pos;
 	jsonObj[keyStr + "/pos2"] = order.pos2;
 	jsonObj[keyStr + "/direction"] = order.direction;
+	jsonObj[keyStr + "/index"] = order.index;
+	jsonObj[keyStr + "/rtrType"] = order.rtrType;
 	setIniBaseObject(jsonObj, key + "/obj", order.psObj);
 	setIniStructureStats(jsonObj, key + "/stats", order.psStats);
 }

--- a/src/orderdef.h
+++ b/src/orderdef.h
@@ -158,6 +158,7 @@ enum RTR_DATA_TYPE
 	RTR_TYPE_REPAIR_FACILITY,
 	RTR_TYPE_DROID,
 	RTR_TYPE_HQ,
+	// If modifying, only *add* entries at end! (or savegame loading will break)
 };
 
 /** Struct that stores data of an order.

--- a/src/qtscript.h
+++ b/src/qtscript.h
@@ -216,7 +216,7 @@ public:
 };
 
 /// Load map labels
-bool loadLabels(const char *filename);
+bool loadLabels(const char *filename, const std::unordered_map<UDWORD, UDWORD>& fixedMapIdToGeneratedId);
 
 /// Write map labels to savegame
 bool writeLabels(const char *filename);
@@ -314,7 +314,7 @@ public:
 // MARK: LABELS
 public:
 	/// Load map labels
-	bool loadLabels(const char *filename);
+	bool loadLabels(const char *filename, const std::unordered_map<UDWORD, UDWORD>& fixedMapIdToGeneratedId);
 
 	/// Write map labels to savegame
 	bool writeLabels(const char *filename);


### PR DESCRIPTION
Behavior changes:
- Use hard-coded map object ids *only* for matching up with `labels.json` info (mapping them to the new generated id on `labels.json` load).
   - (Does not impact savegames, which obviously must preserve the ids on loading.)

Backwards-compatibility impact:
- Only if scripts _hard-code_ an object id (that they are expecting will match the one hard-coded in the map droids/structures/features.json file) should this be a problem. (And they shouldn't be doing this!)
   - Solution (if impacted): 
      - Do not hard-code object ids in scripts.
      - In one of the script init events, get the actual object ids by enumerating (via `enumDroid`/`enumStruct`/`enumFeature`, or via area labels w/ `enumArea`, etc), or by using object / group labels in `labels.json` (which will properly map to the hard-coded map object ids).
      - Any object ids properly obtained via API functions in the script can then be stored / saved (and persisted through savegames).

Also:
Fixes: #2227
Fixes: #1160