### PR TITLE
Cmake debug option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,8 @@ OPTION(WZ_ENABLE_BACKEND_VULKAN "Enable Vulkan backend" ON)
 OPTION(WZ_ENABLE_BASIS_UNIVERSAL "Enable Basis Universal texture support" ON)
 OPTION(WZ_DEBUG_GFX_API_LEAKS "Enable debugging for graphics API leaks" ON)
 OPTION(WZ_FORCE_MINIMAL_OPUSFILE "Force a minimal build of Opusfile, since WZ does not need (or want) HTTP stream support" ON)
+OPTION(WZ_MORE_DEBUG "Enable additional debug code" OFF)
+mark_as_advanced(WZ_MORE_DEBUG)
 
 # Dev options
 OPTION(WZ_PROFILING_NVTX "Add NVTX-based profiling instrumentation to the code" OFF)

--- a/lib/framework/debug.cpp
+++ b/lib/framework/debug.cpp
@@ -56,6 +56,19 @@
 # include <stdio.h>
 #endif
 
+#ifdef _MSC_VER
+#define DEBUG_BREAK __debugbreak()
+#elif defined(WZ_OS_UNIX)
+#include <signal.h>
+#ifdef SIGTRAP
+#define DEBUG_BREAK raise(SIGTRAP)
+#else
+#define DEBUG_BREAK raise(SIGABRT)
+#endif
+#else
+#define DEBUG_BREAK
+#endif
+
 #define MAX_LEN_LOG_LINE 1024
 
 char last_called_script_event[MAX_EVENT_NAME_LEN];
@@ -685,6 +698,10 @@ bool debugPartEnabled(code_part codePart)
 void debugDisableAssert()
 {
 	assertEnabled = false;
+}
+
+void debugBreak() {
+	DEBUG_BREAK;
 }
 
 #include <sstream>

--- a/lib/framework/debug.h
+++ b/lib/framework/debug.h
@@ -328,4 +328,7 @@ bool debugPartEnabled(code_part codePart);
 
 void debugDisableAssert();
 
+/** Issue breakpoint in the debugger. */
+void debugBreak();
+
 #endif // __INCLUDED_LIB_FRAMEWORK_DEBUG_H__

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -183,4 +183,11 @@
 /* Enables usage of VTune-based instrumentation backend. */
 #cmakedefine WZ_PROFILING_VTUNE
 
+/* Enables additional debug code. */
+#cmakedefine WZ_MORE_DEBUG
+#ifdef WZ_MORE_DEBUG
+// Remapping cmake variable into internal one. DEBUG is too popular name to be used as a variable in cmake.
+#define DEBUG
+#endif
+
 #endif // __INCLUDED_WZ_GENERATED_CONFIG_H__

--- a/src/console.h
+++ b/src/console.h
@@ -115,10 +115,19 @@ void console(const char *pFormat, ...); /// Print always to the ingame console
 	CONPRINTF("Hello %d", 123);
 */
 template <typename... P>
-static inline void CONPRINTF(P &&... params)
+static inline void CONPRINTF(const char* format, P &&... params)
 {
-	snprintf(ConsoleString, sizeof(ConsoleString), std::forward<P>(params)...);
+	/** Modern compilers can issue a warning/error if format is not string literal and there are no arguments.
+	 * CONPRINTF overload with a single argument prevents that.
+	 */
+	std::snprintf(ConsoleString, sizeof(ConsoleString), format, std::forward<P>(params)...);
 	addConsoleMessage(ConsoleString, DEFAULT_JUSTIFY, INFO_MESSAGE);
+}
+
+
+static inline void CONPRINTF(const char* string)
+{
+	addConsoleMessage(string, DEFAULT_JUSTIFY, INFO_MESSAGE);
 }
 
 


### PR DESCRIPTION
DEBUG macro was not properly defined through cmake, though it was used a lot in the code. Now this macro can be enabled if 
WZ_MORE_DEBUG cmake option is set.