### PR TITLE
Fix terrain vertex normals

### DIFF
--- a/src/terrain.cpp
+++ b/src/terrain.cpp
@@ -426,9 +426,8 @@ static Vector3f getGridNormal(int x, int y, bool center = false)
 		return -glm::normalize(res);
 	};
 	if (center) {
-		return calcNormal(getGridPosf(x, y, true), {
-			getGridPosf(x,y), getGridPosf(x+1, y), getGridPosf(x+1, y+1), getGridPosf(x, y+1)
-		});
+		// avg nearest normals provide better results
+		return (getGridNormal(x, y) + getGridNormal(x+1, y) + getGridNormal(x+1, y+1) + getGridNormal(x, y+1)) / 4.f;
 	} else {
 		return calcNormal(getGridPosf(x, y), {
 			getGridPosf(x+1, y), getGridPosf(x, y, true),     getGridPosf(x, y+1), getGridPosf(x-1, y, true),


### PR DESCRIPTION
It seems there is some bug in the vertex normal calculation, `getGridNormal`. The normal vector for the center of a tile does not correspond to near normals. You can see it if you draw only `light` in `terrain_combined_medium.frag`:
![image](https://github.com/Warzone2100/warzone2100/assets/57016/d2ca0b1f-787e-45f7-b2b0-e40f83f5400d)

I'm looking into the issue. 
For now, I have one workaround - to average tile normals for the center point. Since the center point is the average of tile points. Looks better:
![image](https://github.com/Warzone2100/warzone2100/assets/57016/ca4533c3-a8c3-48ff-bf80-df621dce1948)
