### PR TITLE
More Libcampaign chat commands

### DIFF
--- a/data/base/script/campaign/libcampaign.js
+++ b/data/base/script/campaign/libcampaign.js
@@ -140,6 +140,7 @@ var __camOriginalEvents = {};
 
 //misc
 var __camCalledOnce = {};
+var __camExpLevel;
 
 //nexus
 const DEFENSE_ABSORBED = "defabsrd.ogg";

--- a/data/base/script/campaign/libcampaign_includes/events.js
+++ b/data/base/script/campaign/libcampaign_includes/events.js
@@ -53,6 +53,10 @@ function cam_eventChat(from, to, message)
 		camSetExpLevel(Number(message.substring(5)));
 		camSetOnMapEnemyUnitExp();
 	}
+	if (message.lastIndexOf("prop ", 0) === 0)
+	{
+		camSetPropulsionTypeLimit(Number(message.substring(5)));
+	}
 	if (!camIsCheating())
 	{
 		return;

--- a/data/base/script/campaign/libcampaign_includes/events.js
+++ b/data/base/script/campaign/libcampaign_includes/events.js
@@ -48,6 +48,11 @@ function cam_eventChat(from, to, message)
 	{
 		__camShowVictoryConditions();
 	}
+	if (message.lastIndexOf("rank ", 0) === 0)
+	{
+		camSetExpLevel(Number(message.substring(5)));
+		camSetOnMapEnemyUnitExp();
+	}
 	if (!camIsCheating())
 	{
 		return;
@@ -124,6 +129,7 @@ function cam_eventStartLevel()
 	__camNeverGroupDroids = [];
 	__camNumTransporterExits = 0;
 	__camAllowVictoryMsgClear = true;
+	__camExpLevel = 0;
 	camSetPropulsionTypeLimit(); //disable the propulsion changer by default
 	__camAiPowerReset(); //grant power to the AI
 	setTimer("__camSpawnVtols", camSecondsToMilliseconds(0.5));
@@ -157,6 +163,7 @@ function cam_eventDroidBuilt(droid, structure)
 	{
 		return;
 	}
+	camSetDroidExperience(droid);
 	__camAddDroidToFactoryGroup(droid, structure);
 }
 

--- a/data/base/script/campaign/libcampaign_includes/production.js
+++ b/data/base/script/campaign/libcampaign_includes/production.js
@@ -237,8 +237,9 @@ function camUpgradeOnMapTemplates(template1, template2, playerId, excluded)
 			//Replace it
 			let droidInfo = {x: dr.x, y: dr.y, name: dr.name};
 			camSafeRemoveObject(dr, false);
-			addDroid(playerId, droidInfo.x, droidInfo.y, droidInfo.name, template2.body,
+			let droid = addDroid(playerId, droidInfo.x, droidInfo.y, droidInfo.name, template2.body,
 				__camChangePropulsionOnDiff(template2.prop), "", "", template2.weap);
+			camSetDroidExperience(droid);
 		}
 	}
 }

--- a/data/base/script/campaign/libcampaign_includes/production.js
+++ b/data/base/script/campaign/libcampaign_includes/production.js
@@ -160,7 +160,7 @@ function camQueueDroidProduction(playerId, template)
 //;;
 function camSetPropulsionTypeLimit(limit)
 {
-	if (!camDef(limit))
+	if (!camDef(limit) || !limit)
 	{
 		__camPropulsionTypeLimit = "NO_USE";
 	}
@@ -298,17 +298,12 @@ function __camAddDroidToFactoryGroup(droid, structure)
 
 function __camChangePropulsionOnDiff(propulsion)
 {
-	if (difficulty <= MEDIUM)
-	{
-		return propulsion;
-	}
-	if (camDef(__camPropulsionTypeLimit) && __camPropulsionTypeLimit === "NO_USE")
+	if (__camPropulsionTypeLimit === "NO_USE")
 	{
 		return propulsion; //this mission don't want this feature then
 	}
 
 	var name = propulsion;
-	var typeModifier = difficulty === HARD ? "02" : "03";
 	const VALID_PROPS = [
 		"CyborgLegs", "HalfTrack", "V-Tol", "hover", "tracked", "wheeled",
 	];
@@ -324,18 +319,16 @@ function __camChangePropulsionOnDiff(propulsion)
 		var currentProp = VALID_PROPS[i];
 		if (name === currentProp)
 		{
-			//if hard difficulty and a future template has a type III then this will
-			//ensure it stays type III.
-			if (difficulty === HARD && lastTwo === "02")
+			var typeModifier;
+			//if a future template has a type III and the limit is type II then this will ensure it stays type III.
+			if (__camPropulsionTypeLimit === "02" && lastTwo === "03")
 			{
 				typeModifier = "03";
 			}
-			//maybe a mission wants to set a limit on the highest propulsion type
-			if (camDef(__camPropulsionTypeLimit))
+			else
 			{
 				typeModifier = __camPropulsionTypeLimit;
 			}
-			//return a stronger propulsion based on difficulty
 			return currentProp.concat(typeModifier);
 		}
 	}

--- a/data/base/script/campaign/libcampaign_includes/reinforcements.js
+++ b/data/base/script/campaign/libcampaign_includes/reinforcements.js
@@ -47,7 +47,9 @@ function camSendReinforcement(playerId, position, templates, kind, data)
 			{
 				var template = templates[i];
 				var prop = __camChangePropulsionOnDiff(template.prop);
-				droids.push(addDroid(playerId, pos.x, pos.y, "Reinforcement", template.body, prop, "", "", template.weap));
+				var droid = addDroid(playerId, pos.x, pos.y, "Reinforcement", template.body, prop, "", "", template.weap);
+				camSetDroidExperience(droid);
+				droids.push(droid);
 			}
 			camManageGroup(camMakeGroup(droids), order, order_data);
 			break;

--- a/data/base/script/campaign/libcampaign_includes/reinforcements.js
+++ b/data/base/script/campaign/libcampaign_includes/reinforcements.js
@@ -46,7 +46,7 @@ function camSendReinforcement(playerId, position, templates, kind, data)
 			for (let i = 0, l = templates.length; i < l; ++i)
 			{
 				var template = templates[i];
-				var prop = __camChangePropulsionOnDiff(template.prop);
+				var prop = __camChangePropulsion(template.prop, playerId);
 				var droid = addDroid(playerId, pos.x, pos.y, "Reinforcement", template.body, prop, "", "", template.weap);
 				camSetDroidExperience(droid);
 				droids.push(droid);

--- a/data/base/script/campaign/libcampaign_includes/transport.js
+++ b/data/base/script/campaign/libcampaign_includes/transport.js
@@ -158,6 +158,13 @@ function __camLandTransporter(player, pos)
 	camTrace("Landing transport for player", player);
 	playSound("pcv395.ogg", pos.x, pos.y, 0); //Incoming enemy transport.
 	camManageGroup(camMakeGroup(ti.droids), ti.order, ti.data);
+	if (player !== CAM_HUMAN_PLAYER)
+	{
+		for (var i = 0, len = ti.droids.length; i < len; ++i)
+		{
+			camSetDroidExperience(ti.droids[i]);
+		}
+	}
 }
 
 function __camRemoveIncomingTransporter(player)

--- a/data/base/script/campaign/libcampaign_includes/transport.js
+++ b/data/base/script/campaign/libcampaign_includes/transport.js
@@ -96,7 +96,7 @@ function __camDispatchTransporterUnsafe()
 	for (let i = 0, l = list.length; i < l; ++i)
 	{
 		var template = list[i];
-		var prop = __camChangePropulsionOnDiff(template.prop);
+		var prop = __camChangePropulsion(template.prop, player);
 		var droid = addDroid(player, -1, -1, "Reinforcement", template.body, prop, "", "", template.weap);
 		droids.push(droid);
 		addDroidToTransporter(trans, droid);


### PR DESCRIPTION
Just adding some fixes I made some time ago. Fixed up the basically dead propulsion changer function that makes newly built enemy units use either Type I/II/III propulsions automatically (including transporter loads/spawns too).

Add an experience system that gives all AI units a certain range of ranks instantly + when they get created.

These both require a chat command to setup as they are unexplored ideas and may be helpful for testing purposes. They can be enabled/disabled at any time without cheat mode being active by typing "prop [0-3]" or "rank [0-9]" for those that wish to experiment with it.