### PR TITLE
Improve starting units

### DIFF
--- a/data/base/script/campaign/cam2-a.js
+++ b/data/base/script/campaign/cam2-a.js
@@ -111,12 +111,18 @@ function sendPlayerTransporter()
 		return;
 	}
 
-	var droids = [];
-	var list = [cTempl.prhct, cTempl.prhct, cTempl.prhct, cTempl.prltat, cTempl.prltat, cTempl.npcybr, cTempl.prrept];
+	let droids = [];
+	let bodyList = ["Body11ABT", "Body11ABT", "Body12SUP"];
+	let propulsionList = ["tracked01", "tracked01", "tracked01", "hover01", "HalfTrack"];
+	let weaponList = ["Cannon375mmMk1", "Cannon375mmMk1", "Cannon375mmMk1", "Rocket-LtA-T", "Rocket-LtA-T", "Mortar2Mk1", "Rocket-MRL"];
+	let specialList = ["SensorTurret1Mk1", "CommandBrain01"];
 
 	for (let i = 0; i < 10; ++i)
 	{
-		droids.push(list[camRand(list.length)]);
+		let body = bodyList[camRand(bodyList.length)];
+		let weap = (!transporterIndex && (i < specialList.length)) ? specialList[i] : weaponList[camRand(weaponList.length)];
+		let prop = propulsionList[camRand(propulsionList.length - ((weap === "Cannon375mmMk1") ? 1 : 0))]; //Ignore halftracks for Heavy Cannon.
+		droids.push({ body: body, prop: prop, weap: weap });
 	}
 
 	camSendReinforcement(CAM_HUMAN_PLAYER, camMakePos("landingZone"), droids,
@@ -223,8 +229,8 @@ function cam2Setup()
 function setUnitRank(transport)
 {
 	const DROID_EXP = [128, 64, 32, 16];
-	var droids;
-	var mapRun = false;
+	let droids;
+	let mapRun = false;
 
 	if (transport)
 	{
@@ -239,10 +245,11 @@ function setUnitRank(transport)
 
 	for (let i = 0, len = droids.length; i < len; ++i)
 	{
-		var droid = droids[i];
-		if (!camIsSystemDroid(droid))
+		let droid = droids[i];
+		if (droid.droidType !== DROID_CONSTRUCT && droid.droidType !== DROID_REPAIR)
 		{
-			setDroidExperience(droid, DROID_EXP[mapRun ? 0 : (transporterIndex - 1)]);
+			let mod = (droid.droidType === DROID_COMMAND || droid.droidType === DROID_SENSOR) ? 2 : 1;
+			setDroidExperience(droid, mod * DROID_EXP[mapRun ? 0 : (transporterIndex - 1)]);
 		}
 	}
 }

--- a/data/base/script/campaign/cam3-a.js
+++ b/data/base/script/campaign/cam3-a.js
@@ -58,13 +58,13 @@ camAreaEvent ("middleTrigger", function(droid)
 
 function setUnitRank(transport)
 {
-	const DROID_EXP = [1024, 128, 64, 32]; //Can make Hero Commanders if recycled.
+	const DROID_EXP = [1024, 256, 128, 64]; //Can make Hero Commanders if recycled.
 	var droids = enumCargo(transport);
 
 	for (let i = 0, len = droids.length; i < len; ++i)
 	{
 		var droid = droids[i];
-		if (!camIsSystemDroid(droid))
+		if (droid.droidType !== DROID_CONSTRUCT && droid.droidType !== DROID_REPAIR)
 		{
 			setDroidExperience(droid, DROID_EXP[transporterIndex - 1]);
 		}
@@ -136,13 +136,22 @@ function sendPlayerTransporter()
 		return;
 	}
 
-	var droids = [];
-	var list = [cTempl.prhasgnt, cTempl.prhhpvt, cTempl.prhaawwt, cTempl.prtruck];
+	let droids = [];
+	let bodyList = ["Body9REC", "Body9REC", "Body9REC", "Body11ABT", "Body12SUP"];
+	let propulsionList = ["tracked01", "tracked01", "hover01"];
+	let weaponList = ["Cannon5VulcanMk1", "Cannon5VulcanMk1", "Flame2", "Flame2", "MG4ROTARYMk1", "MG4ROTARYMk1", "Cannon4AUTOMk1", "Rocket-HvyA-T"];
+	let specialList = ["Spade1Mk1", "Spade1Mk1", "CommandBrain01", "CommandBrain01"];
 
-	// send 4 Assault Guns, 2 Hyper Velocity Cannons, 2 Whirlwind AA Turrets and 2 Trucks
-	for (let i = 0, d = list.length; i < 10; ++i)
+	for (let i = 0; i < 10; ++i)
 	{
-		droids.push(i < d * 2 ? list[i % 4] : list[0]);
+		let body = bodyList[camRand(bodyList.length)];
+		let weap = (!transporterIndex && (i < specialList.length)) ? specialList[i] : weaponList[camRand(weaponList.length)];
+		if (transporterIndex === 1 && i < 4)
+		{
+			weap = "QuadRotAAGun";
+		}
+		let prop = propulsionList[camRand(propulsionList.length)];
+		droids.push({ body: body, prop: prop, weap: weap });
 	}
 
 	camSendReinforcement(CAM_HUMAN_PLAYER, camMakePos("landingZone"), droids,

--- a/src/mission.cpp
+++ b/src/mission.cpp
@@ -1731,13 +1731,6 @@ void unloadTransporter(DROID *psTransporter, UDWORD x, UDWORD y, bool goingHome)
 			}
 			droidSetPosition(psDroid, world_coord(droidX), world_coord(droidY));
 			updateDroidOrientation(psDroid);
-			// a commander needs to get it's group back
-			if (psDroid->droidType == DROID_COMMAND)
-			{
-				psGroup = grpCreate();
-				psGroup->add(psDroid);
-				clearCommandDroidFactory(psDroid);
-			}
 
 			//reset droid orders
 			orderDroid(psDroid, DORDER_STOP, ModeImmediate);
@@ -1764,6 +1757,14 @@ void unloadTransporter(DROID *psTransporter, UDWORD x, UDWORD y, bool goingHome)
 		     && psDroid != psTransporter; psDroid = psNext)
 		{
 			psNext = psDroid->psGrpNext;
+			// a commander needs to get it's group back
+			if (psDroid->droidType == DROID_COMMAND)
+			{
+				psGroup = grpCreate();
+				psGroup->add(psDroid);
+				clearCommandDroidFactory(psDroid);
+				continue;
+			}
 			psTransporter->psGroup->remove(psDroid);
 		}
 	}


### PR DESCRIPTION
Implement a randomized assortment of some of the best unit designs possible when starting Beta and Gamma from the main menu as part of a suggestion. To my surprise I discovered Commanders can't be seen in `eventTransporterLanded` with `enumCargo()` because they get pulled out of the transporter's group a little bit before hand (recreating a Commander group with `add()` removes a unit from another droid's group when called--in this case the transporter). I moved it after the script event to fix this as the whole process should be the same essentially. 

Beta gets a ranked sensor and a commander in the first drop and Gamma gets 2 Hero commanders at the start over the AA tanks (4 whirlwinds come in the second drop only as they aren't useful in the first drop and I'll let the player decide if they want to recycle units for more mobile AA).