### PR TITLE
Show total ranks/units correctly for LDS_MKEEP_LIMBO missions

### DIFF
--- a/src/droid.cpp
+++ b/src/droid.cpp
@@ -2178,16 +2178,26 @@ const char *getDroidLevelName(const DROID *psDroid)
 UDWORD	getNumDroidsForLevel(uint32_t player, UDWORD level)
 {
 	DROID	*psDroid;
-	UDWORD	count;
+	UDWORD	count = 0;
 
 	if (player >= MAX_PLAYERS) { return 0; }
 
-	for (psDroid = apsDroidLists[player], count = 0;
-		 psDroid; psDroid = psDroid->psNext)
+	for (psDroid = apsDroidLists[player]; psDroid; psDroid = psDroid->psNext)
 	{
 		if (getDroidLevel(psDroid) == level)
 		{
 			count++;
+		}
+	}
+
+	if (prevMissionType == LEVEL_TYPE::LDS_MKEEP_LIMBO)
+	{
+		for (psDroid = apsLimboDroids[player]; psDroid; psDroid = psDroid->psNext)
+		{
+			if (getDroidLevel(psDroid) == level)
+			{
+				count++;
+			}
 		}
 	}
 

--- a/src/loop.cpp
+++ b/src/loop.cpp
@@ -134,6 +134,7 @@ LOOP_MISSION_STATE		loopMissionState = LMS_NORMAL;
 
 // this is set by scrStartMission to say what type of new level is to be started
 LEVEL_TYPE nextMissionType = LEVEL_TYPE::LDS_NONE;
+LEVEL_TYPE prevMissionType = LEVEL_TYPE::LDS_NONE;
 
 static GAMECODE renderLoop()
 {

--- a/src/loop.h
+++ b/src/loop.h
@@ -56,6 +56,7 @@ extern LOOP_MISSION_STATE		loopMissionState;
 
 // this is set by scrStartMission to say what type of new level is to be started
 extern LEVEL_TYPE nextMissionType;
+extern LEVEL_TYPE prevMissionType;
 
 extern size_t loopPieCount;
 extern size_t loopPolyCount;

--- a/src/scores.cpp
+++ b/src/scores.cpp
@@ -53,6 +53,7 @@
 #include "lib/sound/audio.h"
 #include "lib/sound/audio_id.h"
 #include "intimage.h"
+#include "loop.h" //for prevMissionType
 
 #include "activity.h"
 #include "multistat.h"
@@ -294,6 +295,7 @@ END_GAME_STATS_DATA	collectEndGameStatsData()
 	{
 		for (DROID *psDroid = apsDroidLists[selectedPlayer]; psDroid; psDroid = psDroid->psNext, fullStats.numUnits++) {}
 		for (DROID *psDroid = mission.apsDroidLists[selectedPlayer]; psDroid; psDroid = psDroid->psNext, fullStats.numUnits++) {}
+		if (prevMissionType == LEVEL_TYPE::LDS_MKEEP_LIMBO) { for (DROID *psDroid = apsLimboDroids[selectedPlayer]; psDroid; psDroid = psDroid->psNext, fullStats.numUnits++) {} }
 	}
 
 	return fullStats;

--- a/src/wzapi.cpp
+++ b/src/wzapi.cpp
@@ -3094,6 +3094,7 @@ wzapi::no_return_value wzapi::loadLevel(WZAPI_PARAMS(std::string levelName))
 	SCRIPT_ASSERT({}, context, psNewLevel, "Could not find level data for %s", levelName.c_str());
 
 	// Get the mission rolling...
+	prevMissionType = mission.type;
 	nextMissionType = psNewLevel->type;
 	loopMissionState = LMS_CLEAROBJECTS;
 	return {};


### PR DESCRIPTION
The limbo list wasn't looped through at the end of these missions to count the true total units and ranks for the end game stats screen.

This closes #3338.