### PR TITLE
Display remaining feature HP correctly in the console

### DIFF
--- a/src/display.cpp
+++ b/src/display.cpp
@@ -1982,7 +1982,7 @@ debugOuput:
 	const DebugInputManager& dbgInputManager = gInputManager.debugManager();
 	if (dbgInputManager.debugMappingsAllowed())
 	{
-		console("(Feature) %s ID: %d ref: %d Hitpoints: %d/%d", getID(psFeature->psStats), psFeature->id, psFeature->psStats->ref, psFeature->psStats->body, psFeature->body);
+		console("(Feature) %s ID: %d ref: %d Hitpoints: %d/%d", getID(psFeature->psStats), psFeature->id, psFeature->psStats->ref, psFeature->body, psFeature->psStats->body);
 	}
 }
 


### PR DESCRIPTION
It was backwards, ie. `200/63` instead of `63/200` when clicking on features while in debug mode.