### PR TITLE
var to let/const conversion and standardization for campaign

### DIFF
--- a/data/base/script/campaign/cam1-1.js
+++ b/data/base/script/campaign/cam1-1.js
@@ -9,7 +9,7 @@ const SCAVENGER_RES = [
 //Ambush player from scav base - triggered from middle path
 camAreaEvent("scavBaseTrigger", function()
 {
-	var ambushGroup = camMakeGroup(enumArea("eastScavsNorth", SCAV_7, false));
+	let ambushGroup = camMakeGroup(enumArea("eastScavsNorth", SCAV_7, false));
 	camManageGroup(ambushGroup, CAM_ORDER_ATTACK, {
 		count: -1,
 		regroup: false
@@ -35,7 +35,7 @@ camAreaEvent("factoryTrigger", function()
 
 function westScavAction()
 {
-	var ambushGroup = camMakeGroup(enumArea("westScavs", SCAV_7, false));
+	let ambushGroup = camMakeGroup(enumArea("westScavs", SCAV_7, false));
 	camManageGroup(ambushGroup, CAM_ORDER_DEFEND, {
 		pos: camMakePos("ambush1")
 	});
@@ -43,7 +43,7 @@ function westScavAction()
 
 function northwestScavAction()
 {
-	var ambushGroup = camMakeGroup(enumArea("northWestScavs", SCAV_7, false));
+	let ambushGroup = camMakeGroup(enumArea("northWestScavs", SCAV_7, false));
 	camManageGroup(ambushGroup, CAM_ORDER_DEFEND, {
 		pos: camMakePos("ambush2")
 	});
@@ -79,7 +79,7 @@ function checkFrontBunkers()
 {
 	if (getObject("frontBunkerLeft") === null && getObject("frontBunkerRight") === null)
 	{
-		var ambushGroup = camMakeGroup(enumArea("eastScavsSouth", SCAV_7, false));
+		let ambushGroup = camMakeGroup(enumArea("eastScavsSouth", SCAV_7, false));
 		camManageGroup(ambushGroup, CAM_ORDER_ATTACK, {
 			count: -1,
 			regroup: false
@@ -101,10 +101,10 @@ function eventStartLevel()
 		retlz: true
 	});
 
-	var startpos = getObject("startPosition");
-	var lz = getObject("landingZone"); //player lz
-	var tent = getObject("transporterEntry");
-	var text = getObject("transporterExit");
+	let startpos = getObject("startPosition");
+	let lz = getObject("landingZone"); //player lz
+	let tent = getObject("transporterEntry");
+	let text = getObject("transporterExit");
 	centreView(startpos.x, startpos.y);
 	setNoGoArea(lz.x, lz.y, lz.x2, lz.y2, CAM_HUMAN_PLAYER);
 	startTransporterEntry(tent.x, tent.y, CAM_HUMAN_PLAYER);

--- a/data/base/script/campaign/cam1-1.js
+++ b/data/base/script/campaign/cam1-1.js
@@ -2,15 +2,15 @@
 include("script/campaign/libcampaign.js");
 include("script/campaign/templates.js");
 
-const SCAVENGER_RES = [
+const mis_scavengerRes = [
 	"R-Wpn-Flamer-Damage01", "R-Wpn-MG-Damage02", "R-Wpn-MG-ROF01",
 ];
 
 //Ambush player from scav base - triggered from middle path
 camAreaEvent("scavBaseTrigger", function()
 {
-	let ambushGroup = camMakeGroup(enumArea("eastScavsNorth", SCAV_7, false));
-	camManageGroup(ambushGroup, CAM_ORDER_ATTACK, {
+	const AMBUSH_GROUP = camMakeGroup(enumArea("eastScavsNorth", CAM_SCAV_7, false));
+	camManageGroup(AMBUSH_GROUP, CAM_ORDER_ATTACK, {
 		count: -1,
 		regroup: false
 	});
@@ -35,16 +35,16 @@ camAreaEvent("factoryTrigger", function()
 
 function westScavAction()
 {
-	let ambushGroup = camMakeGroup(enumArea("westScavs", SCAV_7, false));
-	camManageGroup(ambushGroup, CAM_ORDER_DEFEND, {
+	const AMBUSH_GROUP = camMakeGroup(enumArea("westScavs", CAM_SCAV_7, false));
+	camManageGroup(AMBUSH_GROUP, CAM_ORDER_DEFEND, {
 		pos: camMakePos("ambush1")
 	});
 }
 
 function northwestScavAction()
 {
-	let ambushGroup = camMakeGroup(enumArea("northWestScavs", SCAV_7, false));
-	camManageGroup(ambushGroup, CAM_ORDER_DEFEND, {
+	const AMBUSH_GROUP = camMakeGroup(enumArea("northWestScavs", CAM_SCAV_7, false));
+	camManageGroup(AMBUSH_GROUP, CAM_ORDER_DEFEND, {
 		pos: camMakePos("ambush2")
 	});
 }
@@ -79,8 +79,8 @@ function checkFrontBunkers()
 {
 	if (getObject("frontBunkerLeft") === null && getObject("frontBunkerRight") === null)
 	{
-		let ambushGroup = camMakeGroup(enumArea("eastScavsSouth", SCAV_7, false));
-		camManageGroup(ambushGroup, CAM_ORDER_ATTACK, {
+		const AMBUSH_GROUP = camMakeGroup(enumArea("eastScavsSouth", CAM_SCAV_7, false));
+		camManageGroup(AMBUSH_GROUP, CAM_ORDER_ATTACK, {
 			count: -1,
 			regroup: false
 		});
@@ -101,25 +101,25 @@ function eventStartLevel()
 		retlz: true
 	});
 
-	let startpos = getObject("startPosition");
-	let lz = getObject("landingZone"); //player lz
-	let tent = getObject("transporterEntry");
-	let text = getObject("transporterExit");
-	centreView(startpos.x, startpos.y);
+	const startPos = getObject("startPosition");
+	const lz = getObject("landingZone"); //player lz
+	const tEnt = getObject("transporterEntry");
+	const tExt = getObject("transporterExit");
+	centreView(startPos.x, startPos.y);
 	setNoGoArea(lz.x, lz.y, lz.x2, lz.y2, CAM_HUMAN_PLAYER);
-	startTransporterEntry(tent.x, tent.y, CAM_HUMAN_PLAYER);
-	setTransporterExit(text.x, text.y, CAM_HUMAN_PLAYER);
+	startTransporterEntry(tEnt.x, tEnt.y, CAM_HUMAN_PLAYER);
+	setTransporterExit(tExt.x, tExt.y, CAM_HUMAN_PLAYER);
 
-	camCompleteRequiredResearch(SCAVENGER_RES, SCAV_7);
+	camCompleteRequiredResearch(mis_scavengerRes, CAM_SCAV_7);
 	if (difficulty >= HARD)
 	{
-		completeResearch("R-Wpn-Flamer-Range01", SCAV_7);
+		completeResearch("R-Wpn-Flamer-Range01", CAM_SCAV_7);
 	}
 
-	camUpgradeOnMapTemplates(cTempl.bloke, cTempl.blokeheavy, SCAV_7);
-	camUpgradeOnMapTemplates(cTempl.trike, cTempl.triketwin, SCAV_7);
-	camUpgradeOnMapTemplates(cTempl.buggy, cTempl.buggytwin, SCAV_7);
-	camUpgradeOnMapTemplates(cTempl.bjeep, cTempl.bjeeptwin, SCAV_7);
+	camUpgradeOnMapTemplates(cTempl.bloke, cTempl.blokeheavy, CAM_SCAV_7);
+	camUpgradeOnMapTemplates(cTempl.trike, cTempl.triketwin, CAM_SCAV_7);
+	camUpgradeOnMapTemplates(cTempl.buggy, cTempl.buggytwin, CAM_SCAV_7);
+	camUpgradeOnMapTemplates(cTempl.bjeep, cTempl.bjeeptwin, CAM_SCAV_7);
 
 	//Get rid of the already existing crate and replace with another
 	camSafeRemoveObject("artifact1", false);

--- a/data/base/script/campaign/cam1-1s.js
+++ b/data/base/script/campaign/cam1-1s.js
@@ -27,7 +27,7 @@ function secondVideo()
 //Has player built the power module?
 function powerModuleBuilt()
 {
-	let gens = enumStruct(CAM_HUMAN_PLAYER, POWER_GEN, false);
+	const gens = enumStruct(CAM_HUMAN_PLAYER, POWER_GEN, false);
 	for (let x = 0, l = gens.length; x < l; ++x)
 	{
 		if ((gens[x].modules > 0) && (gens[x].status === BUILT))

--- a/data/base/script/campaign/cam1-1s.js
+++ b/data/base/script/campaign/cam1-1s.js
@@ -27,7 +27,7 @@ function secondVideo()
 //Has player built the power module?
 function powerModuleBuilt()
 {
-	var gens = enumStruct(CAM_HUMAN_PLAYER, POWER_GEN, false);
+	let gens = enumStruct(CAM_HUMAN_PLAYER, POWER_GEN, false);
 	for (let x = 0, l = gens.length; x < l; ++x)
 	{
 		if ((gens[x].modules > 0) && (gens[x].status === BUILT))

--- a/data/base/script/campaign/cam1-2.js
+++ b/data/base/script/campaign/cam1-2.js
@@ -67,10 +67,10 @@ function eventStartLevel()
 		retlz: true
 	});
 
-	var startpos = getObject("StartPosition");
-	var lz = getObject("LandingZone");
-	var tent = getObject("TransporterEntry");
-	var text = getObject("TransporterExit");
+	let startpos = getObject("StartPosition");
+	let lz = getObject("LandingZone");
+	let tent = getObject("TransporterEntry");
+	let text = getObject("TransporterExit");
 	centreView(startpos.x, startpos.y);
 	setNoGoArea(lz.x, lz.y, lz.x2, lz.y2, CAM_HUMAN_PLAYER);
 	startTransporterEntry(tent.x, tent.y, CAM_HUMAN_PLAYER);

--- a/data/base/script/campaign/cam1-2.js
+++ b/data/base/script/campaign/cam1-2.js
@@ -2,7 +2,7 @@
 include("script/campaign/libcampaign.js");
 include("script/campaign/templates.js");
 
-const SCAVENGER_RES = [
+const mis_scavengerRes = [
 	"R-Wpn-Flamer-Damage02", "R-Wpn-Flamer-Range01", "R-Wpn-Flamer-ROF01",
 	"R-Wpn-MG-Damage02", "R-Wpn-MG-ROF01", "R-Wpn-Mortar-Damage02",
 	"R-Wpn-Mortar-ROF01", "R-Wpn-Rocket-ROF03",
@@ -67,21 +67,21 @@ function eventStartLevel()
 		retlz: true
 	});
 
-	let startpos = getObject("StartPosition");
-	let lz = getObject("LandingZone");
-	let tent = getObject("TransporterEntry");
-	let text = getObject("TransporterExit");
-	centreView(startpos.x, startpos.y);
+	const startPos = getObject("StartPosition");
+	const lz = getObject("LandingZone");
+	const tEnt = getObject("TransporterEntry");
+	const tExt = getObject("TransporterExit");
+	centreView(startPos.x, startPos.y);
 	setNoGoArea(lz.x, lz.y, lz.x2, lz.y2, CAM_HUMAN_PLAYER);
-	startTransporterEntry(tent.x, tent.y, CAM_HUMAN_PLAYER);
-	setTransporterExit(text.x, text.y, CAM_HUMAN_PLAYER);
+	startTransporterEntry(tEnt.x, tEnt.y, CAM_HUMAN_PLAYER);
+	setTransporterExit(tExt.x, tExt.y, CAM_HUMAN_PLAYER);
 
-	camCompleteRequiredResearch(SCAVENGER_RES, SCAV_7);
+	camCompleteRequiredResearch(mis_scavengerRes, CAM_SCAV_7);
 
-	camUpgradeOnMapTemplates(cTempl.bloke, cTempl.blokeheavy, SCAV_7);
-	camUpgradeOnMapTemplates(cTempl.trike, cTempl.triketwin, SCAV_7);
-	camUpgradeOnMapTemplates(cTempl.buggy, cTempl.buggytwin, SCAV_7);
-	camUpgradeOnMapTemplates(cTempl.bjeep, cTempl.bjeeptwin, SCAV_7);
+	camUpgradeOnMapTemplates(cTempl.bloke, cTempl.blokeheavy, CAM_SCAV_7);
+	camUpgradeOnMapTemplates(cTempl.trike, cTempl.triketwin, CAM_SCAV_7);
+	camUpgradeOnMapTemplates(cTempl.buggy, cTempl.buggytwin, CAM_SCAV_7);
+	camUpgradeOnMapTemplates(cTempl.bjeep, cTempl.bjeeptwin, CAM_SCAV_7);
 
 	camSetEnemyBases({
 		"NorthGroup": {

--- a/data/base/script/campaign/cam1-3.js
+++ b/data/base/script/campaign/cam1-3.js
@@ -34,11 +34,11 @@ camAreaEvent("NorthConvoyTrigger", function(droid)
 
 camAreaEvent("SouthConvoyTrigger", function(droid)
 {
-	var scout = getObject("ScoutDroid");
+	let scout = getObject("ScoutDroid");
 	if (camDef(scout) && scout)
 	{
 		camTrace("New Paradigm sensor scout retreating");
-		var pos = camMakePos("ScoutDroidTarget");
+		let pos = camMakePos("ScoutDroidTarget");
 		orderDroidLoc(scout, DORDER_MOVE, pos.x, pos.y);
 	}
 });
@@ -86,9 +86,9 @@ function NPReinforce()
 {
 	if (getObject("NPHQ") !== null)
 	{
-		var list = [];
-		var count = 5 + camRand(5);
-		var scouts = [cTempl.nphmg, cTempl.npblc, cTempl.nppod, cTempl.nphmg, cTempl.npblc];
+		let list = [];
+		let count = 5 + camRand(5);
+		let scouts = [cTempl.nphmg, cTempl.npblc, cTempl.nppod, cTempl.nphmg, cTempl.npblc];
 
 		for (let i = 0; i < count; ++i)
 		{
@@ -130,7 +130,7 @@ function eventAttacked(victim, attacker) {
 	if (victim.player === NEW_PARADIGM)
 	{
 		camCallOnce("enableNP");
-		var commander = getObject("NPCommander");
+		let commander = getObject("NPCommander");
 		if (camDef(attacker) && attacker && camDef(commander) && commander &&
 			commander.order !== DORDER_SCOUT && commander.order !== DORDER_RTR)
 		{
@@ -210,10 +210,10 @@ function eventStartLevel()
 		annihilate: true
 	});
 
-	var startpos = getObject("StartPosition");
-	var lz = getObject("LandingZone");
-	var tent = getObject("TransporterEntry");
-	var text = getObject("TransporterExit");
+	let startpos = getObject("StartPosition");
+	let lz = getObject("LandingZone");
+	let tent = getObject("TransporterEntry");
+	let text = getObject("TransporterExit");
 	centreView(startpos.x, startpos.y);
 	setNoGoArea(lz.x, lz.y, lz.x2, lz.y2, CAM_HUMAN_PLAYER);
 	startTransporterEntry(tent.x, tent.y, CAM_HUMAN_PLAYER);

--- a/data/base/script/campaign/cam1-3.js
+++ b/data/base/script/campaign/cam1-3.js
@@ -4,7 +4,7 @@ include("script/campaign/templates.js");
 
 //New base blip, new base area, new factory data
 
-const NEW_PARADIGM_RES = [
+const mis_newParadigmRes = [
 	"R-Wpn-MG1Mk1", "R-Vehicle-Body01", "R-Sys-Spade1Mk1", "R-Vehicle-Prop-Wheels",
 	"R-Sys-Engineering01", "R-Wpn-MG-Damage03", "R-Wpn-MG-ROF01", "R-Wpn-Cannon-Damage01",
 	"R-Wpn-Flamer-Damage03", "R-Wpn-Flamer-Range01", "R-Wpn-Flamer-ROF01",
@@ -12,7 +12,7 @@ const NEW_PARADIGM_RES = [
 	"R-Struc-RprFac-Upgrade01", "R-Wpn-Rocket-Damage01", "R-Wpn-Rocket-ROF02",
 	"R-Wpn-Mortar-Damage02", "R-Wpn-Mortar-ROF01",
 ];
-const SCAVENGER_RES = [
+const mis_scavengerRes = [
 	"R-Wpn-Flamer-Damage02", "R-Wpn-Flamer-Range01", "R-Wpn-Flamer-ROF01",
 	"R-Wpn-MG-Damage03", "R-Wpn-MG-ROF01", "R-Wpn-Cannon-Damage01",
 	"R-Wpn-Mortar-Damage02", "R-Wpn-Mortar-ROF01", "R-Wpn-Rocket-ROF03",
@@ -34,11 +34,11 @@ camAreaEvent("NorthConvoyTrigger", function(droid)
 
 camAreaEvent("SouthConvoyTrigger", function(droid)
 {
-	let scout = getObject("ScoutDroid");
+	const scout = getObject("ScoutDroid");
 	if (camDef(scout) && scout)
 	{
 		camTrace("New Paradigm sensor scout retreating");
-		let pos = camMakePos("ScoutDroidTarget");
+		const pos = camMakePos("ScoutDroidTarget");
 		orderDroidLoc(scout, DORDER_MOVE, pos.x, pos.y);
 	}
 });
@@ -86,15 +86,15 @@ function NPReinforce()
 {
 	if (getObject("NPHQ") !== null)
 	{
-		let list = [];
-		let count = 5 + camRand(5);
-		let scouts = [cTempl.nphmg, cTempl.npblc, cTempl.nppod, cTempl.nphmg, cTempl.npblc];
+		const list = [];
+		const COUNT = 5 + camRand(5);
+		const scouts = [cTempl.nphmg, cTempl.npblc, cTempl.nppod, cTempl.nphmg, cTempl.npblc];
 
-		for (let i = 0; i < count; ++i)
+		for (let i = 0; i < COUNT; ++i)
 		{
 			list.push(scouts[camRand(scouts.length)]);
 		}
-		camSendReinforcement(NEW_PARADIGM, camMakePos("NPReinforcementPos"), list, CAM_REINFORCE_GROUND, {
+		camSendReinforcement(CAM_NEW_PARADIGM, camMakePos("NPReinforcementPos"), list, CAM_REINFORCE_GROUND, {
 			data: {
 				regroup: false,
 				repair: 66,
@@ -127,10 +127,10 @@ function eventAttacked(victim, attacker) {
 	{
 		return;
 	}
-	if (victim.player === NEW_PARADIGM)
+	if (victim.player === CAM_NEW_PARADIGM)
 	{
 		camCallOnce("enableNP");
-		let commander = getObject("NPCommander");
+		const commander = getObject("NPCommander");
 		if (camDef(attacker) && attacker && camDef(commander) && commander &&
 			commander.order !== DORDER_SCOUT && commander.order !== DORDER_RTR)
 		{
@@ -170,7 +170,7 @@ function camEnemyBaseEliminated_ScavBaseGroup()
 {
 	//make enemy easier to find if all his buildings destroyed
 	camManageGroup(
-		camMakeGroup(enumArea(0, 0, mapWidth, mapHeight, SCAV_7, false)),
+		camMakeGroup(enumArea(0, 0, mapWidth, mapHeight, CAM_SCAV_7, false)),
 		CAM_ORDER_ATTACK
 	);
 }
@@ -210,18 +210,18 @@ function eventStartLevel()
 		annihilate: true
 	});
 
-	let startpos = getObject("StartPosition");
-	let lz = getObject("LandingZone");
-	let tent = getObject("TransporterEntry");
-	let text = getObject("TransporterExit");
-	centreView(startpos.x, startpos.y);
+	const startPos = getObject("StartPosition");
+	const lz = getObject("LandingZone");
+	const tEnt = getObject("TransporterEntry");
+	const tExt = getObject("TransporterExit");
+	centreView(startPos.x, startPos.y);
 	setNoGoArea(lz.x, lz.y, lz.x2, lz.y2, CAM_HUMAN_PLAYER);
-	startTransporterEntry(tent.x, tent.y, CAM_HUMAN_PLAYER);
-	setTransporterExit(text.x, text.y, CAM_HUMAN_PLAYER);
+	startTransporterEntry(tEnt.x, tEnt.y, CAM_HUMAN_PLAYER);
+	setTransporterExit(tExt.x, tExt.y, CAM_HUMAN_PLAYER);
 
-	camCompleteRequiredResearch(NEW_PARADIGM_RES, NEW_PARADIGM);
-	camCompleteRequiredResearch(SCAVENGER_RES, SCAV_7);
-	setAlliance(NEW_PARADIGM, SCAV_7, true);
+	camCompleteRequiredResearch(mis_newParadigmRes, CAM_NEW_PARADIGM);
+	camCompleteRequiredResearch(mis_scavengerRes, CAM_SCAV_7);
+	setAlliance(CAM_NEW_PARADIGM, CAM_SCAV_7, true);
 
 	camUpgradeOnMapTemplates(cTempl.bloke, cTempl.blokeheavy, 7);
 	camUpgradeOnMapTemplates(cTempl.trike, cTempl.trikeheavy, 7);

--- a/data/base/script/campaign/cam1-4a.js
+++ b/data/base/script/campaign/cam1-4a.js
@@ -51,7 +51,7 @@ camAreaEvent("LandingZoneTrigger", function()
 	camPlayVideos(["pcv456.ogg", {video: "SB1_4_B", type: MISS_MSG}]);
 	hackRemoveMessage("C1-4_LZ", PROX_MSG, CAM_HUMAN_PLAYER); //Remove LZ 2 blip.
 
-	var lz = getObject("LandingZone2"); // will override later
+	let lz = getObject("LandingZone2"); // will override later
 	setNoGoArea(lz.x, lz.y, lz.x2, lz.y2, CAM_HUMAN_PLAYER);
 
 	// Give extra 40 minutes.
@@ -113,10 +113,10 @@ function eventStartLevel()
 		retlz: true
 	});
 
-	var startpos = getObject("StartPosition");
-	var lz = getObject("LandingZone1"); // will override later
-	var tent = getObject("TransporterEntry");
-	var text = getObject("TransporterExit");
+	let startpos = getObject("StartPosition");
+	let lz = getObject("LandingZone1"); // will override later
+	let tent = getObject("TransporterEntry");
+	let text = getObject("TransporterExit");
 
 	centreView(startpos.x, startpos.y);
 	setNoGoArea(lz.x, lz.y, lz.x2, lz.y2, CAM_HUMAN_PLAYER);

--- a/data/base/script/campaign/cam1-4a.js
+++ b/data/base/script/campaign/cam1-4a.js
@@ -2,7 +2,7 @@
 include("script/campaign/libcampaign.js");
 include("script/campaign/templates.js");
 
-const NEW_PARADIGM_RES = [
+const mis_newParadigmRes = [
 	"R-Wpn-MG1Mk1", "R-Vehicle-Body01", "R-Sys-Spade1Mk1", "R-Vehicle-Prop-Wheels",
 	"R-Sys-Engineering01", "R-Wpn-MG-Damage04", "R-Wpn-MG-ROF01", "R-Wpn-Cannon-Damage03",
 	"R-Wpn-Flamer-Damage03", "R-Wpn-Flamer-Range01", "R-Wpn-Flamer-ROF01",
@@ -11,7 +11,7 @@ const NEW_PARADIGM_RES = [
 	"R-Vehicle-Metals02", "R-Wpn-Mortar-Damage03", "R-Wpn-Rocket-Accuracy01",
 	"R-Wpn-RocketSlow-Damage02", "R-Wpn-Mortar-ROF01",
 ];
-const SCAVENGER_RES = [
+const mis_scavengerRes = [
 	"R-Wpn-Flamer-Damage03", "R-Wpn-Flamer-Range01", "R-Wpn-Flamer-ROF01",
 	"R-Wpn-MG-Damage04", "R-Wpn-MG-ROF01", "R-Wpn-Rocket-Damage02",
 	"R-Wpn-Cannon-Damage02", "R-Wpn-Mortar-Damage03", "R-Wpn-Mortar-ROF01",
@@ -51,7 +51,7 @@ camAreaEvent("LandingZoneTrigger", function()
 	camPlayVideos(["pcv456.ogg", {video: "SB1_4_B", type: MISS_MSG}]);
 	hackRemoveMessage("C1-4_LZ", PROX_MSG, CAM_HUMAN_PLAYER); //Remove LZ 2 blip.
 
-	let lz = getObject("LandingZone2"); // will override later
+	const lz = getObject("LandingZone2"); // will override later
 	setNoGoArea(lz.x, lz.y, lz.x2, lz.y2, CAM_HUMAN_PLAYER);
 
 	// Give extra 40 minutes.
@@ -90,18 +90,18 @@ function NPBaseDetect()
 function buildDefenses()
 {
 	// First wave of trucks
-	camQueueBuilding(NEW_PARADIGM, "GuardTower6", "BuildTower0");
-	camQueueBuilding(NEW_PARADIGM, "PillBox1",    "BuildTower3");
-	camQueueBuilding(NEW_PARADIGM, "PillBox1",    "BuildTower6");
+	camQueueBuilding(CAM_NEW_PARADIGM, "GuardTower6", "BuildTower0");
+	camQueueBuilding(CAM_NEW_PARADIGM, "PillBox1",    "BuildTower3");
+	camQueueBuilding(CAM_NEW_PARADIGM, "PillBox1",    "BuildTower6");
 
 	// Second wave of trucks
-	camQueueBuilding(NEW_PARADIGM, "GuardTower3", "BuildTower1");
-	camQueueBuilding(NEW_PARADIGM, "GuardTower6", "BuildTower2");
-	camQueueBuilding(NEW_PARADIGM, "GuardTower6", "BuildTower4");
+	camQueueBuilding(CAM_NEW_PARADIGM, "GuardTower3", "BuildTower1");
+	camQueueBuilding(CAM_NEW_PARADIGM, "GuardTower6", "BuildTower2");
+	camQueueBuilding(CAM_NEW_PARADIGM, "GuardTower6", "BuildTower4");
 
 	// Third wave of trucks
-	camQueueBuilding(NEW_PARADIGM, "GuardTower3", "BuildTower5");
-	camQueueBuilding(NEW_PARADIGM, "GuardTower6", "BuildTower7");
+	camQueueBuilding(CAM_NEW_PARADIGM, "GuardTower3", "BuildTower5");
+	camQueueBuilding(CAM_NEW_PARADIGM, "GuardTower6", "BuildTower7");
 }
 
 function eventStartLevel()
@@ -113,25 +113,25 @@ function eventStartLevel()
 		retlz: true
 	});
 
-	let startpos = getObject("StartPosition");
-	let lz = getObject("LandingZone1"); // will override later
-	let tent = getObject("TransporterEntry");
-	let text = getObject("TransporterExit");
+	const startPos = getObject("StartPosition");
+	const lz = getObject("LandingZone1"); // will override later
+	const tEnt = getObject("TransporterEntry");
+	const tExt = getObject("TransporterExit");
 
-	centreView(startpos.x, startpos.y);
+	centreView(startPos.x, startPos.y);
 	setNoGoArea(lz.x, lz.y, lz.x2, lz.y2, CAM_HUMAN_PLAYER);
-	startTransporterEntry(tent.x, tent.y, CAM_HUMAN_PLAYER);
-	setTransporterExit(text.x, text.y, CAM_HUMAN_PLAYER);
+	startTransporterEntry(tEnt.x, tEnt.y, CAM_HUMAN_PLAYER);
+	setTransporterExit(tExt.x, tExt.y, CAM_HUMAN_PLAYER);
 
-	camCompleteRequiredResearch(NEW_PARADIGM_RES, NEW_PARADIGM);
-	camCompleteRequiredResearch(SCAVENGER_RES, SCAV_7);
-	setAlliance(NEW_PARADIGM, SCAV_7, true);
+	camCompleteRequiredResearch(mis_newParadigmRes, CAM_NEW_PARADIGM);
+	camCompleteRequiredResearch(mis_scavengerRes, CAM_SCAV_7);
+	setAlliance(CAM_NEW_PARADIGM, CAM_SCAV_7, true);
 
-	camUpgradeOnMapTemplates(cTempl.bloke, cTempl.blokeheavy, SCAV_7);
-	camUpgradeOnMapTemplates(cTempl.trike, cTempl.trikeheavy, SCAV_7);
-	camUpgradeOnMapTemplates(cTempl.buggy, cTempl.buggyheavy, SCAV_7);
-	camUpgradeOnMapTemplates(cTempl.bjeep, cTempl.bjeepheavy, SCAV_7);
-	camUpgradeOnMapTemplates(cTempl.rbjeep, cTempl.rbjeep8, SCAV_7);
+	camUpgradeOnMapTemplates(cTempl.bloke, cTempl.blokeheavy, CAM_SCAV_7);
+	camUpgradeOnMapTemplates(cTempl.trike, cTempl.trikeheavy, CAM_SCAV_7);
+	camUpgradeOnMapTemplates(cTempl.buggy, cTempl.buggyheavy, CAM_SCAV_7);
+	camUpgradeOnMapTemplates(cTempl.bjeep, cTempl.bjeepheavy, CAM_SCAV_7);
+	camUpgradeOnMapTemplates(cTempl.rbjeep, cTempl.rbjeep8, CAM_SCAV_7);
 
 	camSetEnemyBases({
 		"SouthScavBaseGroup": {
@@ -204,7 +204,7 @@ function eventStartLevel()
 
 	// To be able to use camEnqueueBuilding() later,
 	// and also to rebuild dead trucks.
-	camManageTrucks(NEW_PARADIGM);
+	camManageTrucks(CAM_NEW_PARADIGM);
 
 	queue("enableSouthScavFactory", camChangeOnDiff(camSecondsToMilliseconds(10)));
 }

--- a/data/base/script/campaign/cam1-5.js
+++ b/data/base/script/campaign/cam1-5.js
@@ -25,10 +25,10 @@ var useHeavyReinforcement;
 //Get some droids for the New Paradigm transport
 function getDroidsForNPLZ(args)
 {
-	var lightAttackerLimit = 8;
-	var heavyAttackerLimit = 3;
-	var unitTemplates;
-	var list = [];
+	let lightAttackerLimit = 8;
+	let heavyAttackerLimit = 3;
+	let unitTemplates;
+	let list = [];
 
 	if (difficulty === HARD)
 	{
@@ -43,8 +43,8 @@ function getDroidsForNPLZ(args)
 
 	if (useHeavyReinforcement)
 	{
-		var artillery = [cTempl.npmor];
-		var other = [cTempl.npmmct];
+		let artillery = [cTempl.npmor];
+		let other = [cTempl.npmmct];
 		if (camRand(2) > 0)
 		{
 			//Add a sensor if artillery was chosen for the heavy units
@@ -61,7 +61,7 @@ function getDroidsForNPLZ(args)
 		unitTemplates = [cTempl.nppod, cTempl.npmrl, cTempl.nphmgt];
 	}
 
-	var lim = useHeavyReinforcement ? heavyAttackerLimit : lightAttackerLimit;
+	let lim = useHeavyReinforcement ? heavyAttackerLimit : lightAttackerLimit;
 	for (let i = 0; i < lim; ++i)
 	{
 		list.push(unitTemplates[camRand(unitTemplates.length)]);
@@ -123,13 +123,13 @@ function activateNPLZTransporter()
 
 function sendNPTransport()
 {
-	var nearbyDefense = enumArea("LandingZone2", NEW_PARADIGM, false).filter((obj) => (
+	let nearbyDefense = enumArea("LandingZone2", NEW_PARADIGM, false).filter((obj) => (
 		obj.type === STRUCTURE && obj.stattype === DEFENSE
 	));
 
 	if (nearbyDefense.length > 0)
 	{
-		var list = getDroidsForNPLZ();
+		let list = getDroidsForNPLZ();
 		camSendReinforcement(NEW_PARADIGM, camMakePos("NPTransportPos"), list, CAM_REINFORCE_TRANSPORT, {
 			entry: { x: 2, y: 42 },
 			exit: { x: 2, y: 42 },
@@ -181,17 +181,17 @@ function eventStartLevel()
 	});
 
 	useHeavyReinforcement = false; //Start with a light unit reinforcement first
-	var lz = getObject("LandingZone1"); //player lz
-	var lz2 = getObject("LandingZone2"); //new paradigm lz
-	var tent = getObject("TransporterEntry");
-	var text = getObject("TransporterExit");
+	let lz = getObject("LandingZone1"); //player lz
+	let lz2 = getObject("LandingZone2"); //new paradigm lz
+	let tent = getObject("TransporterEntry");
+	let text = getObject("TransporterExit");
 	setNoGoArea(lz.x, lz.y, lz.x2, lz.y2, CAM_HUMAN_PLAYER);
 	setNoGoArea(lz2.x, lz2.y, lz2.x2, lz2.y2, 5);
 	startTransporterEntry(tent.x, tent.y, CAM_HUMAN_PLAYER);
 	setTransporterExit(text.x, text.y, CAM_HUMAN_PLAYER);
 
 	//Transporter is the only droid of the player's on the map
-	var transporter = enumDroid();
+	let transporter = enumDroid();
 	cameraTrack(transporter[0]);
 
 	//Make sure the New Paradigm and Scavs are allies

--- a/data/base/script/campaign/cam1-5.js
+++ b/data/base/script/campaign/cam1-5.js
@@ -2,7 +2,7 @@
 include("script/campaign/libcampaign.js");
 include("script/campaign/templates.js");
 
-const NEW_PARADIGM_RES = [
+const mis_newParadigmRes = [
 	"R-Wpn-MG1Mk1", "R-Vehicle-Body01", "R-Sys-Spade1Mk1", "R-Vehicle-Prop-Wheels",
 	"R-Sys-Engineering01", "R-Wpn-MG-Damage04", "R-Wpn-MG-ROF02", "R-Wpn-Cannon-Damage03",
 	"R-Wpn-Flamer-Damage03", "R-Wpn-Flamer-Range01", "R-Wpn-Flamer-ROF01",
@@ -12,7 +12,7 @@ const NEW_PARADIGM_RES = [
 	"R-Wpn-RocketSlow-Damage02", "R-Wpn-Mortar-ROF01", "R-Cyborg-Metals03",
 	"R-Wpn-Mortar-Acc01", "R-Wpn-RocketSlow-Accuracy01", "R-Wpn-Cannon-Accuracy01",
 ];
-const SCAVENGER_RES = [
+const mis_scavengerRes = [
 	"R-Wpn-Flamer-Damage03", "R-Wpn-Flamer-Range01", "R-Wpn-Flamer-ROF01",
 	"R-Wpn-MG-Damage04", "R-Wpn-MG-ROF01", "R-Wpn-Rocket-Damage02",
 	"R-Wpn-Cannon-Damage03", "R-Wpn-Mortar-Damage03", "R-Wpn-Mortar-ROF01",
@@ -28,7 +28,7 @@ function getDroidsForNPLZ(args)
 	let lightAttackerLimit = 8;
 	let heavyAttackerLimit = 3;
 	let unitTemplates;
-	let list = [];
+	const list = [];
 
 	if (difficulty === HARD)
 	{
@@ -43,8 +43,8 @@ function getDroidsForNPLZ(args)
 
 	if (useHeavyReinforcement)
 	{
-		let artillery = [cTempl.npmor];
-		let other = [cTempl.npmmct];
+		const artillery = [cTempl.npmor];
+		const other = [cTempl.npmmct];
 		if (camRand(2) > 0)
 		{
 			//Add a sensor if artillery was chosen for the heavy units
@@ -61,8 +61,8 @@ function getDroidsForNPLZ(args)
 		unitTemplates = [cTempl.nppod, cTempl.npmrl, cTempl.nphmgt];
 	}
 
-	let lim = useHeavyReinforcement ? heavyAttackerLimit : lightAttackerLimit;
-	for (let i = 0; i < lim; ++i)
+	const LIM = useHeavyReinforcement ? heavyAttackerLimit : lightAttackerLimit;
+	for (let i = 0; i < LIM; ++i)
 	{
 		list.push(unitTemplates[camRand(unitTemplates.length)]);
 	}
@@ -123,14 +123,14 @@ function activateNPLZTransporter()
 
 function sendNPTransport()
 {
-	let nearbyDefense = enumArea("LandingZone2", NEW_PARADIGM, false).filter((obj) => (
+	const nearbyDefense = enumArea("LandingZone2", CAM_NEW_PARADIGM, false).filter((obj) => (
 		obj.type === STRUCTURE && obj.stattype === DEFENSE
 	));
 
 	if (nearbyDefense.length > 0)
 	{
-		let list = getDroidsForNPLZ();
-		camSendReinforcement(NEW_PARADIGM, camMakePos("NPTransportPos"), list, CAM_REINFORCE_TRANSPORT, {
+		const list = getDroidsForNPLZ();
+		camSendReinforcement(CAM_NEW_PARADIGM, camMakePos("NPTransportPos"), list, CAM_REINFORCE_TRANSPORT, {
 			entry: { x: 2, y: 42 },
 			exit: { x: 2, y: 42 },
 			order: CAM_ORDER_ATTACK,
@@ -166,7 +166,7 @@ function camEnemyBaseEliminated_NPBaseGroup()
 
 	//Make all scavengers on map attack
 	camManageGroup(
-		camMakeGroup(enumArea(0, 0, mapWidth, mapHeight, SCAV_7, false)),
+		camMakeGroup(enumArea(0, 0, mapWidth, mapHeight, CAM_SCAV_7, false)),
 		CAM_ORDER_ATTACK
 	);
 }
@@ -181,30 +181,30 @@ function eventStartLevel()
 	});
 
 	useHeavyReinforcement = false; //Start with a light unit reinforcement first
-	let lz = getObject("LandingZone1"); //player lz
-	let lz2 = getObject("LandingZone2"); //new paradigm lz
-	let tent = getObject("TransporterEntry");
-	let text = getObject("TransporterExit");
+	const lz = getObject("LandingZone1"); //player lz
+	const lz2 = getObject("LandingZone2"); //new paradigm lz
+	const tEnt = getObject("TransporterEntry");
+	const tExt = getObject("TransporterExit");
 	setNoGoArea(lz.x, lz.y, lz.x2, lz.y2, CAM_HUMAN_PLAYER);
 	setNoGoArea(lz2.x, lz2.y, lz2.x2, lz2.y2, 5);
-	startTransporterEntry(tent.x, tent.y, CAM_HUMAN_PLAYER);
-	setTransporterExit(text.x, text.y, CAM_HUMAN_PLAYER);
+	startTransporterEntry(tEnt.x, tEnt.y, CAM_HUMAN_PLAYER);
+	setTransporterExit(tExt.x, tExt.y, CAM_HUMAN_PLAYER);
 
 	//Transporter is the only droid of the player's on the map
-	let transporter = enumDroid();
+	const transporter = enumDroid();
 	cameraTrack(transporter[0]);
 
 	//Make sure the New Paradigm and Scavs are allies
-	setAlliance(NEW_PARADIGM, SCAV_7, true);
+	setAlliance(CAM_NEW_PARADIGM, CAM_SCAV_7, true);
 
-	camCompleteRequiredResearch(NEW_PARADIGM_RES, NEW_PARADIGM);
-	camCompleteRequiredResearch(SCAVENGER_RES, SCAV_7);
+	camCompleteRequiredResearch(mis_newParadigmRes, CAM_NEW_PARADIGM);
+	camCompleteRequiredResearch(mis_scavengerRes, CAM_SCAV_7);
 
-	camUpgradeOnMapTemplates(cTempl.bloke, cTempl.blokeheavy, SCAV_7);
-	camUpgradeOnMapTemplates(cTempl.trike, cTempl.trikeheavy, SCAV_7);
-	camUpgradeOnMapTemplates(cTempl.buggy, cTempl.buggyheavy, SCAV_7);
-	camUpgradeOnMapTemplates(cTempl.bjeep, cTempl.bjeepheavy, SCAV_7);
-	camUpgradeOnMapTemplates(cTempl.rbjeep, cTempl.rbjeep8, SCAV_7);
+	camUpgradeOnMapTemplates(cTempl.bloke, cTempl.blokeheavy, CAM_SCAV_7);
+	camUpgradeOnMapTemplates(cTempl.trike, cTempl.trikeheavy, CAM_SCAV_7);
+	camUpgradeOnMapTemplates(cTempl.buggy, cTempl.buggyheavy, CAM_SCAV_7);
+	camUpgradeOnMapTemplates(cTempl.bjeep, cTempl.bjeepheavy, CAM_SCAV_7);
+	camUpgradeOnMapTemplates(cTempl.rbjeep, cTempl.rbjeep8, CAM_SCAV_7);
 
 	camSetEnemyBases({
 		"ScavNorthGroup": {
@@ -230,7 +230,7 @@ function eventStartLevel()
 			detectMsg: "C1-5_OBJ1",
 			detectSnd: "pcv379.ogg",
 			eliminateSnd: "pcv394.ogg",
-			player: NEW_PARADIGM
+			player: CAM_NEW_PARADIGM
 		},
 	});
 

--- a/data/base/script/campaign/cam1-7.js
+++ b/data/base/script/campaign/cam1-7.js
@@ -54,7 +54,7 @@ camAreaEvent("NPTransportTrigger", function(droid)
 {
 	if (enemyHasArtifact && droid.group === artiGroup)
 	{
-		var list = [cTempl.npmrl, cTempl.npmrl];
+		let list = [cTempl.npmrl, cTempl.npmrl];
 		camSendReinforcement(NEW_PARADIGM, camMakePos("NPTransportPos"), list, CAM_REINFORCE_TRANSPORT, {
 			entry: { x: 39, y: 2 },
 			exit: { x: 32, y: 60 }
@@ -81,7 +81,7 @@ function eventTransporterLanded(transport)
 	if (transport.player === NEW_PARADIGM && enemyHasArtifact)
 	{
 		enemyStoleArtifact = true;
-		var crew = enumRange(transport.x, transport.y, 6, NEW_PARADIGM, false).filter((obj) => (
+		let crew = enumRange(transport.x, transport.y, 6, NEW_PARADIGM, false).filter((obj) => (
 			obj.type === DROID && obj.group === artiGroup
 		));
 		for (let i = 0, l = crew.length; i < l; ++i)
@@ -98,7 +98,7 @@ function eventGroupLoss(obj, group, newsize)
 	{
 		if (obj.id === droidWithArtiID)
 		{
-			var acrate = addFeature("Crate", obj.x, obj.y);
+			let acrate = addFeature("Crate", obj.x, obj.y);
 			addLabel(acrate, "newArtiLabel");
 
 			camSetArtifacts({
@@ -127,15 +127,15 @@ function getArtifact()
 	}
 
 	const GRAB_RADIUS = 2;
-	var artifact = camGetArtifacts().filter((label) => (
+	let artifact = camGetArtifacts().filter((label) => (
 		enemyCanTakeArtifact(label) && getObject(label) !== null
 	));
-	var artiLoc = artiMovePos;
+	let artiLoc = artiMovePos;
 
 	if (!enemyHasArtifact && !enemyStoleArtifact && artifact.length > 0)
 	{
 		//Go to the artifact instead.
-		var realCrate = artifact[0];
+		let realCrate = artifact[0];
 		artiLoc = camMakePos(realCrate);
 		if (!camDef(artiLoc))
 		{
@@ -143,13 +143,13 @@ function getArtifact()
 		}
 
 		//Find the one closest to the artifact so that one can "hold" it
-		var artiMembers = enumGroup(artiGroup);
-		var idx = 0;
-		var dist = Infinity;
+		let artiMembers = enumGroup(artiGroup);
+		let idx = 0;
+		let dist = Infinity;
 
 		for (let i = 0, l = artiMembers.length; i < l; ++i)
 		{
-			var drDist = camDist(artiMembers[i], artiLoc);
+			let drDist = camDist(artiMembers[i], artiLoc);
 			if (drDist < dist)
 			{
 				idx = i;
@@ -190,7 +190,7 @@ function buildLancers()
 //Must destroy all of the New Paradigm droids and make sure the artifact is safe.
 function extraVictory()
 {
-	var npTransportFound = false;
+	let npTransportFound = false;
 	enumDroid(NEW_PARADIGM).forEach((dr) => {
 		if (camIsTransporter(dr))
 		{
@@ -244,10 +244,10 @@ function eventStartLevel()
 	enemyHasArtifact = false;
 	enemyStoleArtifact = false;
 	artiMovePos = "NPWayPoint";
-	var startpos = getObject("startPosition");
-	var lz = getObject("landingZone"); //player lz
-	var tent = getObject("transporterEntry");
-	var text = getObject("transporterExit");
+	let startpos = getObject("startPosition");
+	let lz = getObject("landingZone"); //player lz
+	let tent = getObject("transporterEntry");
+	let text = getObject("transporterExit");
 	centreView(startpos.x, startpos.y);
 	setNoGoArea(lz.x, lz.y, lz.x2, lz.y2, CAM_HUMAN_PLAYER);
 	startTransporterEntry(tent.x, tent.y, CAM_HUMAN_PLAYER);

--- a/data/base/script/campaign/cam1-7.js
+++ b/data/base/script/campaign/cam1-7.js
@@ -2,7 +2,7 @@
 include("script/campaign/libcampaign.js");
 include("script/campaign/templates.js");
 
-const NEW_PARADIGM_RES = [
+const mis_newParadigmRes = [
 	"R-Wpn-MG1Mk1", "R-Vehicle-Body01", "R-Sys-Spade1Mk1", "R-Vehicle-Prop-Wheels",
 	"R-Sys-Engineering01", "R-Wpn-MG-Damage04", "R-Wpn-MG-ROF02", "R-Wpn-Cannon-Damage03",
 	"R-Wpn-Flamer-Damage03", "R-Wpn-Flamer-Range01", "R-Wpn-Flamer-ROF01",
@@ -12,7 +12,7 @@ const NEW_PARADIGM_RES = [
 	"R-Wpn-RocketSlow-Damage03", "R-Wpn-Mortar-ROF01", "R-Cyborg-Metals03",
 	"R-Wpn-Mortar-Acc01", "R-Wpn-RocketSlow-Accuracy01", "R-Wpn-Cannon-Accuracy01",
 ];
-const SCAVENGER_RES = [
+const mis_scavengerRes = [
 	"R-Wpn-Flamer-Damage03", "R-Wpn-Flamer-Range01", "R-Wpn-Flamer-ROF01",
 	"R-Wpn-MG-Damage04", "R-Wpn-MG-ROF01", "R-Wpn-Rocket-Damage03",
 	"R-Wpn-Cannon-Damage03", "R-Wpn-Mortar-Damage03", "R-Wpn-Mortar-ROF01",
@@ -54,8 +54,8 @@ camAreaEvent("NPTransportTrigger", function(droid)
 {
 	if (enemyHasArtifact && droid.group === artiGroup)
 	{
-		let list = [cTempl.npmrl, cTempl.npmrl];
-		camSendReinforcement(NEW_PARADIGM, camMakePos("NPTransportPos"), list, CAM_REINFORCE_TRANSPORT, {
+		const list = [cTempl.npmrl, cTempl.npmrl];
+		camSendReinforcement(CAM_NEW_PARADIGM, camMakePos("NPTransportPos"), list, CAM_REINFORCE_TRANSPORT, {
 			entry: { x: 39, y: 2 },
 			exit: { x: 32, y: 60 }
 		});
@@ -63,7 +63,7 @@ camAreaEvent("NPTransportTrigger", function(droid)
 	}
 	else
 	{
-		resetLabel("NPTransportTrigger", NEW_PARADIGM);
+		resetLabel("NPTransportTrigger", CAM_NEW_PARADIGM);
 	}
 });
 
@@ -78,10 +78,10 @@ function artifactVideoSetup()
 //by the time it lands.
 function eventTransporterLanded(transport)
 {
-	if (transport.player === NEW_PARADIGM && enemyHasArtifact)
+	if (transport.player === CAM_NEW_PARADIGM && enemyHasArtifact)
 	{
 		enemyStoleArtifact = true;
-		let crew = enumRange(transport.x, transport.y, 6, NEW_PARADIGM, false).filter((obj) => (
+		const crew = enumRange(transport.x, transport.y, 6, CAM_NEW_PARADIGM, false).filter((obj) => (
 			obj.type === DROID && obj.group === artiGroup
 		));
 		for (let i = 0, l = crew.length; i < l; ++i)
@@ -98,7 +98,7 @@ function eventGroupLoss(obj, group, newsize)
 	{
 		if (obj.id === droidWithArtiID)
 		{
-			let acrate = addFeature("Crate", obj.x, obj.y);
+			const acrate = addFeature("Crate", obj.x, obj.y);
 			addLabel(acrate, "newArtiLabel");
 
 			camSetArtifacts({
@@ -127,7 +127,7 @@ function getArtifact()
 	}
 
 	const GRAB_RADIUS = 2;
-	let artifact = camGetArtifacts().filter((label) => (
+	const artifact = camGetArtifacts().filter((label) => (
 		enemyCanTakeArtifact(label) && getObject(label) !== null
 	));
 	let artiLoc = artiMovePos;
@@ -135,7 +135,7 @@ function getArtifact()
 	if (!enemyHasArtifact && !enemyStoleArtifact && artifact.length > 0)
 	{
 		//Go to the artifact instead.
-		let realCrate = artifact[0];
+		const realCrate = artifact[0];
 		artiLoc = camMakePos(realCrate);
 		if (!camDef(artiLoc))
 		{
@@ -143,17 +143,17 @@ function getArtifact()
 		}
 
 		//Find the one closest to the artifact so that one can "hold" it
-		let artiMembers = enumGroup(artiGroup);
+		const artiMembers = enumGroup(artiGroup);
 		let idx = 0;
 		let dist = Infinity;
 
 		for (let i = 0, l = artiMembers.length; i < l; ++i)
 		{
-			let drDist = camDist(artiMembers[i], artiLoc);
-			if (drDist < dist)
+			const DR_DIST = camDist(artiMembers[i], artiLoc);
+			if (DR_DIST < dist)
 			{
 				idx = i;
-				dist = drDist;
+				dist = DR_DIST;
 			}
 		}
 
@@ -183,7 +183,7 @@ function buildLancers()
 {
 	for (let i = 1; i <= 6; ++i)
 	{
-		camQueueBuilding(NEW_PARADIGM, "WallTower06", "hardPoint" + i);
+		camQueueBuilding(CAM_NEW_PARADIGM, "WallTower06", "hardPoint" + i);
 	}
 }
 
@@ -191,7 +191,7 @@ function buildLancers()
 function extraVictory()
 {
 	let npTransportFound = false;
-	enumDroid(NEW_PARADIGM).forEach((dr) => {
+	enumDroid(CAM_NEW_PARADIGM).forEach((dr) => {
 		if (camIsTransporter(dr))
 		{
 			npTransportFound = true;
@@ -204,7 +204,7 @@ function extraVictory()
 		return false;
 	}
 
-	if (!enumDroid(NEW_PARADIGM).length)
+	if (!enumDroid(CAM_NEW_PARADIGM).length)
 	{
 		return true;
 	}
@@ -244,14 +244,14 @@ function eventStartLevel()
 	enemyHasArtifact = false;
 	enemyStoleArtifact = false;
 	artiMovePos = "NPWayPoint";
-	let startpos = getObject("startPosition");
-	let lz = getObject("landingZone"); //player lz
-	let tent = getObject("transporterEntry");
-	let text = getObject("transporterExit");
-	centreView(startpos.x, startpos.y);
+	const startPos = getObject("startPosition");
+	const lz = getObject("landingZone"); //player lz
+	const tEnt = getObject("transporterEntry");
+	const tExt = getObject("transporterExit");
+	centreView(startPos.x, startPos.y);
 	setNoGoArea(lz.x, lz.y, lz.x2, lz.y2, CAM_HUMAN_PLAYER);
-	startTransporterEntry(tent.x, tent.y, CAM_HUMAN_PLAYER);
-	setTransporterExit(text.x, text.y, CAM_HUMAN_PLAYER);
+	startTransporterEntry(tEnt.x, tEnt.y, CAM_HUMAN_PLAYER);
+	setTransporterExit(tExt.x, tExt.y, CAM_HUMAN_PLAYER);
 
 	camSetStandardWinLossConditions(CAM_VICTORY_OFFWORLD, "SUB_1_DS", {
 		area: "RTLZ",
@@ -262,7 +262,7 @@ function eventStartLevel()
 	});
 
 	//Make sure the New Paradigm and Scavs are allies
-	setAlliance(NEW_PARADIGM, SCAV_7, true);
+	setAlliance(CAM_NEW_PARADIGM, CAM_SCAV_7, true);
 
 	//Get rid of the already existing crate and replace with another
 	camSafeRemoveObject("artifact1", false);
@@ -270,19 +270,19 @@ function eventStartLevel()
 		"artifactLocation": { tech: ["R-Wpn-Cannon3Mk1", "R-Wpn-RocketSlow-Damage03"] },
 	});
 
-	camCompleteRequiredResearch(NEW_PARADIGM_RES, NEW_PARADIGM);
-	camCompleteRequiredResearch(SCAVENGER_RES, SCAV_7);
+	camCompleteRequiredResearch(mis_newParadigmRes, CAM_NEW_PARADIGM);
+	camCompleteRequiredResearch(mis_scavengerRes, CAM_SCAV_7);
 
-	camUpgradeOnMapTemplates(cTempl.bloke, cTempl.blokeheavy, SCAV_7);
-	camUpgradeOnMapTemplates(cTempl.trike, cTempl.trikeheavy, SCAV_7);
-	camUpgradeOnMapTemplates(cTempl.buggy, cTempl.buggyheavy, SCAV_7);
-	camUpgradeOnMapTemplates(cTempl.bjeep, cTempl.bjeepheavy, SCAV_7);
-	camUpgradeOnMapTemplates(cTempl.rbjeep, cTempl.rbjeep8, SCAV_7);
+	camUpgradeOnMapTemplates(cTempl.bloke, cTempl.blokeheavy, CAM_SCAV_7);
+	camUpgradeOnMapTemplates(cTempl.trike, cTempl.trikeheavy, CAM_SCAV_7);
+	camUpgradeOnMapTemplates(cTempl.buggy, cTempl.buggyheavy, CAM_SCAV_7);
+	camUpgradeOnMapTemplates(cTempl.bjeep, cTempl.bjeepheavy, CAM_SCAV_7);
+	camUpgradeOnMapTemplates(cTempl.rbjeep, cTempl.rbjeep8, CAM_SCAV_7);
 
 	// New MRA Mantis Tracks units on the hill
-	addDroid(NEW_PARADIGM, 29, 16, "MRA Mantis Tracks", "Body12SUP", "tracked01", "", "", "Rocket-MRL");
-	addDroid(NEW_PARADIGM, 29, 17, "MRA Mantis Tracks", "Body12SUP", "tracked01", "", "", "Rocket-MRL");
-	addDroid(NEW_PARADIGM, 29, 18, "MRA Mantis Tracks", "Body12SUP", "tracked01", "", "", "Rocket-MRL");
+	addDroid(CAM_NEW_PARADIGM, 29, 16, "MRA Mantis Tracks", "Body12SUP", "tracked01", "", "", "Rocket-MRL");
+	addDroid(CAM_NEW_PARADIGM, 29, 17, "MRA Mantis Tracks", "Body12SUP", "tracked01", "", "", "Rocket-MRL");
+	addDroid(CAM_NEW_PARADIGM, 29, 18, "MRA Mantis Tracks", "Body12SUP", "tracked01", "", "", "Rocket-MRL");
 
 	camSetEnemyBases({
 		"ScavMiddleGroup": {
@@ -341,9 +341,9 @@ function eventStartLevel()
 		},
 	});
 
-	artiGroup = camMakeGroup(enumArea("NPArtiGroup", NEW_PARADIGM, false));
+	artiGroup = camMakeGroup(enumArea("NPArtiGroup", CAM_NEW_PARADIGM, false));
 	droidWithArtiID = 0;
-	camManageTrucks(NEW_PARADIGM);
+	camManageTrucks(CAM_NEW_PARADIGM);
 	buildLancers();
 
 	hackAddMessage("C1-7_OBJ1", PROX_MSG, CAM_HUMAN_PLAYER, false); //Canyon

--- a/data/base/script/campaign/cam1-d.js
+++ b/data/base/script/campaign/cam1-d.js
@@ -2,7 +2,7 @@
 include("script/campaign/libcampaign.js");
 include("script/campaign/templates.js");
 
-const NEW_PARADIGM_RES = [
+const mis_newParadigmRes = [
 	"R-Wpn-MG1Mk1", "R-Vehicle-Body01", "R-Sys-Spade1Mk1", "R-Vehicle-Prop-Wheels",
 	"R-Sys-Engineering01", "R-Wpn-MG-Damage04", "R-Wpn-MG-ROF02", "R-Wpn-Cannon-Damage03",
 	"R-Wpn-Flamer-Damage03", "R-Wpn-Flamer-Range01", "R-Wpn-Flamer-ROF01",
@@ -61,9 +61,9 @@ function transportBaseSetup()
 function getDroidsForNPLZ()
 {
 	const LIM = 8; //Last alpha mission always has 8 transport units
-	let templates = [ cTempl.nphct, cTempl.nphct, cTempl.npmorb, cTempl.npmorb, cTempl.npsbb ];
+	const templates = [ cTempl.nphct, cTempl.nphct, cTempl.npmorb, cTempl.npmorb, cTempl.npsbb ];
 
-	let droids = [];
+	const droids = [];
 	for (let i = 0; i < LIM; ++i)
 	{
 		droids.push(templates[camRand(templates.length)]);
@@ -148,14 +148,14 @@ function eventStartLevel()
 		eliminateBases: true
 	});
 
-	let startpos = getObject("startPosition");
-	let lz = getObject("landingZone"); //player lz
-	let tent = getObject("transporterEntry");
-	let text = getObject("transporterExit");
-	centreView(startpos.x, startpos.y);
+	const startPos = getObject("startPosition");
+	const lz = getObject("landingZone"); //player lz
+	const tEnt = getObject("transporterEntry");
+	const tExt = getObject("transporterExit");
+	centreView(startPos.x, startPos.y);
 	setNoGoArea(lz.x, lz.y, lz.x2, lz.y2, CAM_HUMAN_PLAYER);
-	startTransporterEntry(tent.x, tent.y, CAM_HUMAN_PLAYER);
-	setTransporterExit(text.x, text.y, CAM_HUMAN_PLAYER);
+	startTransporterEntry(tEnt.x, tEnt.y, CAM_HUMAN_PLAYER);
+	setTransporterExit(tExt.x, tExt.y, CAM_HUMAN_PLAYER);
 
 	//Get rid of the already existing crate and replace with another
 	camSafeRemoveObject("artifact1", false);
@@ -165,7 +165,7 @@ function eventStartLevel()
 		"NPFactoryNE": { tech: "R-Vehicle-Body12" }, //Main base factory
 	});
 
-	camCompleteRequiredResearch(NEW_PARADIGM_RES, NEW_PARADIGM);
+	camCompleteRequiredResearch(mis_newParadigmRes, CAM_NEW_PARADIGM);
 
 	camSetEnemyBases({
 		"NPSouthEastGroup": {
@@ -190,7 +190,7 @@ function eventStartLevel()
 			cleanup: "NPLZ1",
 			detectMsg: "C1D_LZ2",
 			eliminateSnd: "pcv394.ogg",
-			player: NEW_PARADIGM // required for LZ-type bases
+			player: CAM_NEW_PARADIGM // required for LZ-type bases
 		},
 	});
 

--- a/data/base/script/campaign/cam1-d.js
+++ b/data/base/script/campaign/cam1-d.js
@@ -61,9 +61,9 @@ function transportBaseSetup()
 function getDroidsForNPLZ()
 {
 	const LIM = 8; //Last alpha mission always has 8 transport units
-	var templates = [ cTempl.nphct, cTempl.nphct, cTempl.npmorb, cTempl.npmorb, cTempl.npsbb ];
+	let templates = [ cTempl.nphct, cTempl.nphct, cTempl.npmorb, cTempl.npmorb, cTempl.npsbb ];
 
-	var droids = [];
+	let droids = [];
 	for (let i = 0; i < LIM; ++i)
 	{
 		droids.push(templates[camRand(templates.length)]);
@@ -148,10 +148,10 @@ function eventStartLevel()
 		eliminateBases: true
 	});
 
-	var startpos = getObject("startPosition");
-	var lz = getObject("landingZone"); //player lz
-	var tent = getObject("transporterEntry");
-	var text = getObject("transporterExit");
+	let startpos = getObject("startPosition");
+	let lz = getObject("landingZone"); //player lz
+	let tent = getObject("transporterEntry");
+	let text = getObject("transporterExit");
 	centreView(startpos.x, startpos.y);
 	setNoGoArea(lz.x, lz.y, lz.x2, lz.y2, CAM_HUMAN_PLAYER);
 	startTransporterEntry(tent.x, tent.y, CAM_HUMAN_PLAYER);

--- a/data/base/script/campaign/cam1a-c.js
+++ b/data/base/script/campaign/cam1a-c.js
@@ -27,7 +27,7 @@ var switchLZ; //Counter for incrementing index every third landing
 //Check if all enemies are gone and win after 15 transports
 function extraVictoryCondition()
 {
-	var enemies = enumArea(0, 0, mapWidth, mapHeight, ENEMIES, false);
+	let enemies = enumArea(0, 0, mapWidth, mapHeight, ENEMIES, false);
 	if (index === 5 && enemies.length === 0)
 	{
 		return true;
@@ -43,9 +43,9 @@ function checkForGroundForces()
 		const maxTanks = 16;
 		const firstAmount = 10;
 
-		var droidGroup1 = []; //Heavy cannon mantis track units
-		var droidGroup2 = []; //Sensor and heavy mortar units
-		var templates = [ cTempl.nphct, cTempl.npmsens, cTempl.npmorb ];
+		let droidGroup1 = []; //Heavy cannon mantis track units
+		let droidGroup2 = []; //Sensor and heavy mortar units
+		let templates = [ cTempl.nphct, cTempl.npmsens, cTempl.npmorb ];
 
 		for (let i = 0; i <= maxTanks; ++i)
 		{
@@ -64,7 +64,7 @@ function checkForGroundForces()
 		}
 
 		//What part of map to appear at
-		var pos = (index === 0) ? camMakePos("reinforceSouthEast") : camMakePos("reinforceNorth");
+		let pos = (index === 0) ? camMakePos("reinforceSouthEast") : camMakePos("reinforceNorth");
 		camSendReinforcement(NEW_PARADIGM, pos, droidGroup1, CAM_REINFORCE_GROUND, {
 			data: {regroup: false, count: -1,},
 		});
@@ -76,19 +76,19 @@ function checkForGroundForces()
 //New Paradigm transport appears fifteen times before mission win
 function sendTransport()
 {
-	var position = camMakePos(landingZoneList[index]);
+	let position = camMakePos(landingZoneList[index]);
 	switchLZ += 1;
 
 	// (2 or 3 or 4) pairs of each droid template.
 	// This emulates wzcam's droid count distribution.
-	var count = [ 2, 3, 4, 4, 4, 4, 4, 4, 4 ][camRand(9)];
+	let count = [ 2, 3, 4, 4, 4, 4, 4, 4, 4 ][camRand(9)];
 
-	var templates = [ cTempl.npcybc, cTempl.npcybf, cTempl.npcybm ];
+	let templates = [ cTempl.npcybc, cTempl.npcybf, cTempl.npcybm ];
 
-	var droids = [];
+	let droids = [];
 	for (let i = 0; i < count; ++i)
 	{
-		var t = templates[camRand(templates.length)];
+		let t = templates[camRand(templates.length)];
 		// two droids of each template
 		droids[droids.length] = t;
 		droids[droids.length] = t;
@@ -141,8 +141,8 @@ function eventStartLevel()
 		callback: "extraVictoryCondition"
 	});
 
-	var startpos = getObject("startPosition");
-	var lz = getObject("landingZone");
+	let startpos = getObject("startPosition");
+	let lz = getObject("landingZone");
 	centreView(startpos.x, startpos.y);
 	setNoGoArea(lz.x, lz.y, lz.x2, lz.y2, CAM_HUMAN_PLAYER);
 
@@ -151,7 +151,7 @@ function eventStartLevel()
 	// make sure player doesn't build on enemy LZs
 	for (let i = 6; i <= 10; ++i)
 	{
-		var ph = getObject("NPLZ" + i);
+		let ph = getObject("NPLZ" + i);
 		setNoGoArea(ph.x, ph.y, ph.x2, ph.y2, i - 4);
 	}
 

--- a/data/base/script/campaign/cam1a-c.js
+++ b/data/base/script/campaign/cam1a-c.js
@@ -2,16 +2,16 @@
 include("script/campaign/libcampaign.js");
 include("script/campaign/templates.js");
 
-const landingZoneList = [ "npPos1", "npPos2", "npPos3", "npPos4", "npPos5" ];
-const landingZoneMessages = [ "C1A-C_LZ1", "C1A-C_LZ2", "C1A-C_LZ3", "C1A-C_LZ4", "C1A-C_LZ5" ];
-const cyborgPatrolList = [
+const mis_landingZoneList = [ "npPos1", "npPos2", "npPos3", "npPos4", "npPos5" ];
+const mis_landingZoneMessages = [ "C1A-C_LZ1", "C1A-C_LZ2", "C1A-C_LZ3", "C1A-C_LZ4", "C1A-C_LZ5" ];
+const mis_cyborgPatrolList = [
 	"seCybPos1", "seCybPos2", "seCybPos3", "northCybPos1",
 	"northCybPos2", "northCybPos3", "canyonCybPos1",
 	"canyonCybPos2", "canyonCybPos3", "hillCybPos1",
 	"hillCybPos2", "hillCybPos3", "1aCybPos1",
 	"1aCybPos2", "1aCybPos3",
 ];
-const NEW_PARADIGM_RES = [
+const mis_newParadigmRes = [
 	"R-Wpn-MG1Mk1", "R-Vehicle-Body01", "R-Sys-Spade1Mk1", "R-Vehicle-Prop-Wheels",
 	"R-Sys-Engineering01", "R-Wpn-MG-Damage04", "R-Wpn-MG-ROF02", "R-Wpn-Cannon-Damage03",
 	"R-Wpn-Flamer-Damage03", "R-Wpn-Flamer-Range01", "R-Wpn-Flamer-ROF01",
@@ -27,7 +27,7 @@ var switchLZ; //Counter for incrementing index every third landing
 //Check if all enemies are gone and win after 15 transports
 function extraVictoryCondition()
 {
-	let enemies = enumArea(0, 0, mapWidth, mapHeight, ENEMIES, false);
+	const enemies = enumArea(0, 0, mapWidth, mapHeight, ENEMIES, false);
 	if (index === 5 && enemies.length === 0)
 	{
 		return true;
@@ -40,35 +40,35 @@ function checkForGroundForces()
 	if (index < 2 && switchLZ === 3)
 	{
 		//Amounts for the ground force
-		const maxTanks = 16;
-		const firstAmount = 10;
+		const MAX_TANKS = 16;
+		const FIRST_AMOUNT = 10;
 
-		let droidGroup1 = []; //Heavy cannon mantis track units
-		let droidGroup2 = []; //Sensor and heavy mortar units
-		let templates = [ cTempl.nphct, cTempl.npmsens, cTempl.npmorb ];
+		const droidGroup1 = []; //Heavy cannon mantis track units
+		const droidGroup2 = []; //Sensor and heavy mortar units
+		const templates = [ cTempl.nphct, cTempl.npmsens, cTempl.npmorb ];
 
-		for (let i = 0; i <= maxTanks; ++i)
+		for (let i = 0; i <= MAX_TANKS; ++i)
 		{
-			if (i <= firstAmount)
+			if (i <= FIRST_AMOUNT)
 			{
 				droidGroup1[i] = templates[0];
 			}
-			if (i === firstAmount + 1)
+			if (i === FIRST_AMOUNT + 1)
 			{
-				droidGroup2[i - 1 - firstAmount] = templates[1];
+				droidGroup2[i - 1 - FIRST_AMOUNT] = templates[1];
 			}
 			else
 			{
-				droidGroup2[i - 1 - firstAmount] = templates[2];
+				droidGroup2[i - 1 - FIRST_AMOUNT] = templates[2];
 			}
 		}
 
 		//What part of map to appear at
-		let pos = (index === 0) ? camMakePos("reinforceSouthEast") : camMakePos("reinforceNorth");
-		camSendReinforcement(NEW_PARADIGM, pos, droidGroup1, CAM_REINFORCE_GROUND, {
+		const pos = (index === 0) ? camMakePos("reinforceSouthEast") : camMakePos("reinforceNorth");
+		camSendReinforcement(CAM_NEW_PARADIGM, pos, droidGroup1, CAM_REINFORCE_GROUND, {
 			data: {regroup: false, count: -1,},
 		});
-		camSendReinforcement(NEW_PARADIGM, pos, droidGroup2, CAM_REINFORCE_GROUND);
+		camSendReinforcement(CAM_NEW_PARADIGM, pos, droidGroup2, CAM_REINFORCE_GROUND);
 	}
 }
 
@@ -76,34 +76,34 @@ function checkForGroundForces()
 //New Paradigm transport appears fifteen times before mission win
 function sendTransport()
 {
-	let position = camMakePos(landingZoneList[index]);
+	const position = camMakePos(mis_landingZoneList[index]);
 	switchLZ += 1;
 
 	// (2 or 3 or 4) pairs of each droid template.
 	// This emulates wzcam's droid count distribution.
-	let count = [ 2, 3, 4, 4, 4, 4, 4, 4, 4 ][camRand(9)];
+	const COUNT = [ 2, 3, 4, 4, 4, 4, 4, 4, 4 ][camRand(9)];
 
-	let templates = [ cTempl.npcybc, cTempl.npcybf, cTempl.npcybm ];
+	const templates = [ cTempl.npcybc, cTempl.npcybf, cTempl.npcybm ];
 
-	let droids = [];
-	for (let i = 0; i < count; ++i)
+	const droids = [];
+	for (let i = 0; i < COUNT; ++i)
 	{
-		let t = templates[camRand(templates.length)];
+		const t = templates[camRand(templates.length)];
 		// two droids of each template
 		droids[droids.length] = t;
 		droids[droids.length] = t;
 	}
 
-	camSendReinforcement(NEW_PARADIGM, position, droids, CAM_REINFORCE_TRANSPORT, {
+	camSendReinforcement(CAM_NEW_PARADIGM, position, droids, CAM_REINFORCE_TRANSPORT, {
 		entry: { x: 126, y: 36 },
 		exit: { x: 126, y: 76 },
-		message: landingZoneMessages[index],
+		message: mis_landingZoneMessages[index],
 		order: CAM_ORDER_PATROL,
 		data: {
 			pos:[
-				camMakePos(cyborgPatrolList[(3 * index)]),
-				camMakePos(cyborgPatrolList[(3 * index) + 1]),
-				camMakePos(cyborgPatrolList[(3 * index) + 2]),
+				camMakePos(mis_cyborgPatrolList[(3 * index)]),
+				camMakePos(mis_cyborgPatrolList[(3 * index) + 1]),
+				camMakePos(mis_cyborgPatrolList[(3 * index) + 2]),
 			],
 			radius: 8,
 			interval: camMinutesToMilliseconds(1),
@@ -141,9 +141,9 @@ function eventStartLevel()
 		callback: "extraVictoryCondition"
 	});
 
-	let startpos = getObject("startPosition");
-	let lz = getObject("landingZone");
-	centreView(startpos.x, startpos.y);
+	const startPos = getObject("startPosition");
+	const lz = getObject("landingZone");
+	centreView(startPos.x, startPos.y);
 	setNoGoArea(lz.x, lz.y, lz.x2, lz.y2, CAM_HUMAN_PLAYER);
 
 	setMissionTime(camChangeOnDiff(camHoursToSeconds(1)));
@@ -151,11 +151,11 @@ function eventStartLevel()
 	// make sure player doesn't build on enemy LZs
 	for (let i = 6; i <= 10; ++i)
 	{
-		let ph = getObject("NPLZ" + i);
+		const ph = getObject("NPLZ" + i);
 		setNoGoArea(ph.x, ph.y, ph.x2, ph.y2, i - 4);
 	}
 
-	camCompleteRequiredResearch(NEW_PARADIGM_RES, NEW_PARADIGM);
+	camCompleteRequiredResearch(mis_newParadigmRes, CAM_NEW_PARADIGM);
 	camPlayVideos([{video: "MB1A-C_MSG", type: CAMP_MSG}, {video: "MB1A-C_MSG2", type: MISS_MSG}]);
 
 	index = 0;

--- a/data/base/script/campaign/cam1a.js
+++ b/data/base/script/campaign/cam1a.js
@@ -29,8 +29,8 @@ camAreaEvent("launchScavAttack", function(droid)
 
 function runAway()
 {
-	var oilPatch = getObject("oilPatch");
-	var droids = enumRange(oilPatch.x, oilPatch.y, 7, SCAV_7, false);
+	let oilPatch = getObject("oilPatch");
+	let droids = enumRange(oilPatch.x, oilPatch.y, 7, SCAV_7, false);
 	camManageGroup(camMakeGroup(droids), CAM_ORDER_ATTACK, {
 		pos: camMakePos("scavAttack1"),
 		fallback: camMakePos("retreat1"),
@@ -88,10 +88,10 @@ function eventStructureBuilt(structure, droid)
 	if (structure.player === CAM_HUMAN_PLAYER && structure.stattype === RESOURCE_EXTRACTOR)
 	{
 		// Is it in the base two area?
-		var objs = enumArea("scavBase2Cleanup", CAM_HUMAN_PLAYER);
+		let objs = enumArea("scavBase2Cleanup", CAM_HUMAN_PLAYER);
 		for (let i = 0, l = objs.length; i < l; ++i)
 		{
-			var obj = objs[i];
+			let obj = objs[i];
 			if (obj.type === STRUCTURE && obj.stattype === RESOURCE_EXTRACTOR)
 			{
 				camCallOnce("raidAttack");
@@ -132,8 +132,8 @@ function enableBaseStructures()
 function eventStartLevel()
 {
 	const PLAYER_POWER = 1300;
-	var startpos = getObject("startPosition");
-	var lz = getObject("landingZone");
+	let startpos = getObject("startPosition");
+	let lz = getObject("landingZone");
 
 	camSetStandardWinLossConditions(CAM_VICTORY_STANDARD, "CAM_1B");
 

--- a/data/base/script/campaign/cam1a.js
+++ b/data/base/script/campaign/cam1a.js
@@ -1,11 +1,11 @@
 include("script/campaign/libcampaign.js");
 include("script/campaign/templates.js");
 
-const PLAYER_RES = [
+const mis_playerRes = [
 	"R-Wpn-MG1Mk1", "R-Vehicle-Body01", "R-Sys-Spade1Mk1", "R-Vehicle-Prop-Wheels",
 ];
 
-const SCAVENGER_RES = [
+const mis_scavengerRes = [
 	"R-Wpn-MG-Damage01", "R-Wpn-MG-ROF01", "R-Wpn-Flamer-Range01-ScavReduce",
 ];
 
@@ -29,8 +29,8 @@ camAreaEvent("launchScavAttack", function(droid)
 
 function runAway()
 {
-	let oilPatch = getObject("oilPatch");
-	let droids = enumRange(oilPatch.x, oilPatch.y, 7, SCAV_7, false);
+	const oilPatch = getObject("oilPatch");
+	const droids = enumRange(oilPatch.x, oilPatch.y, 7, CAM_SCAV_7, false);
 	camManageGroup(camMakeGroup(droids), CAM_ORDER_ATTACK, {
 		pos: camMakePos("scavAttack1"),
 		fallback: camMakePos("retreat1"),
@@ -88,10 +88,10 @@ function eventStructureBuilt(structure, droid)
 	if (structure.player === CAM_HUMAN_PLAYER && structure.stattype === RESOURCE_EXTRACTOR)
 	{
 		// Is it in the base two area?
-		let objs = enumArea("scavBase2Cleanup", CAM_HUMAN_PLAYER);
+		const objs = enumArea("scavBase2Cleanup", CAM_HUMAN_PLAYER);
 		for (let i = 0, l = objs.length; i < l; ++i)
 		{
-			let obj = objs[i];
+			const obj = objs[i];
 			if (obj.type === STRUCTURE && obj.stattype === RESOURCE_EXTRACTOR)
 			{
 				camCallOnce("raidAttack");
@@ -118,26 +118,26 @@ function camEnemyBaseEliminated_scavGroup2()
 
 function enableBaseStructures()
 {
-	const STRUCTS = [
+	const structs = [
 		"A0CommandCentre", "A0PowerGenerator", "A0ResourceExtractor",
 		"A0ResearchFacility", "A0LightFactory",
 	];
 
-	for (let i = 0; i < STRUCTS.length; ++i)
+	for (let i = 0; i < structs.length; ++i)
 	{
-		enableStructure(STRUCTS[i], CAM_HUMAN_PLAYER);
+		enableStructure(structs[i], CAM_HUMAN_PLAYER);
 	}
 }
 
 function eventStartLevel()
 {
 	const PLAYER_POWER = 1300;
-	let startpos = getObject("startPosition");
-	let lz = getObject("landingZone");
+	const startPos = getObject("startPosition");
+	const lz = getObject("landingZone");
 
 	camSetStandardWinLossConditions(CAM_VICTORY_STANDARD, "CAM_1B");
 
-	centreView(startpos.x, startpos.y);
+	centreView(startPos.x, startPos.y);
 	setNoGoArea(lz.x, lz.y, lz.x2, lz.y2, CAM_HUMAN_PLAYER);
 
 	if (difficulty === HARD)
@@ -153,16 +153,16 @@ function eventStartLevel()
 		setPower(PLAYER_POWER, CAM_HUMAN_PLAYER);
 	}
 
-	setAlliance(SCAV_6, SCAV_7, true);
+	setAlliance(CAM_SCAV_6, CAM_SCAV_7, true);
 
 	enableBaseStructures();
-	camCompleteRequiredResearch(PLAYER_RES, CAM_HUMAN_PLAYER);
-	camCompleteRequiredResearch(SCAVENGER_RES, 6);
-	camCompleteRequiredResearch(SCAVENGER_RES, 7);
+	camCompleteRequiredResearch(mis_playerRes, CAM_HUMAN_PLAYER);
+	camCompleteRequiredResearch(mis_scavengerRes, 6);
+	camCompleteRequiredResearch(mis_scavengerRes, 7);
 	if (difficulty === INSANE)
 	{
-		completeResearch("R-Wpn-Flamer-Range01-ScavReduce-Undo", SCAV_6);
-		completeResearch("R-Wpn-Flamer-Range01-ScavReduce-Undo", SCAV_7);
+		completeResearch("R-Wpn-Flamer-Range01-ScavReduce-Undo", CAM_SCAV_6);
+		completeResearch("R-Wpn-Flamer-Range01-ScavReduce-Undo", CAM_SCAV_7);
 	}
 
 	// Give player briefing.

--- a/data/base/script/campaign/cam1b.js
+++ b/data/base/script/campaign/cam1b.js
@@ -3,14 +3,14 @@ include("script/campaign/libcampaign.js");
 include("script/campaign/templates.js");
 
 var NPScout; // Sensor scout
-const SCAVENGER_RES = [
+const mis_scavengerRes = [
 	"R-Wpn-Flamer-Damage01", "R-Wpn-MG-Damage01", "R-Wpn-MG-ROF01", "R-Wpn-Flamer-Range01-ScavReduce",
 ];
 
 camAreaEvent("AttackArea1", function(droid)
 {
 	queue("camCallOnce", camSecondsToMilliseconds(2), "doNPRetreat");
-	camManageGroup(camMakeGroup("enemy1Force1", SCAV_6), CAM_ORDER_ATTACK, {
+	camManageGroup(camMakeGroup("enemy1Force1", CAM_SCAV_6), CAM_ORDER_ATTACK, {
 		pos: camMakePos("enemy1Force1Pos"),
 		fallback: camMakePos("enemy1Force1Fallback"),
 		morale: 50
@@ -37,7 +37,7 @@ camAreaEvent("AttackArea2", function(droid)
 
 function doNPRetreat()
 {
-	let pos = camMakePos("NPSensorTurn");
+	const pos = camMakePos("NPSensorTurn");
 	if (NPScout)
 	{
 		camTrace("New Paradigm sensor droid is retreating");
@@ -61,7 +61,7 @@ function eventDestroyed(obj)
 
 camAreaEvent("NPSensorTurn", function(droid)
 {
-	let pos = camMakePos("NPSensorRemove");
+	const pos = camMakePos("NPSensorRemove");
 	orderDroidLoc(NPScout, DORDER_MOVE, pos.x, pos.y);
 });
 
@@ -73,29 +73,29 @@ camAreaEvent("NPSensorRemove", function(droid)
 function eventStartLevel()
 {
 	camSetStandardWinLossConditions(CAM_VICTORY_STANDARD, "SUB_1_1S");
-	let startpos = getObject("startPosition");
-	let lz = getObject("landingZone");
-	centreView(startpos.x, startpos.y);
+	const startPos = getObject("startPosition");
+	const lz = getObject("landingZone");
+	centreView(startPos.x, startPos.y);
 	setNoGoArea(lz.x, lz.y, lz.x2, lz.y2, CAM_HUMAN_PLAYER);
 
 	setMissionTime(camChangeOnDiff(camHoursToSeconds(1)));
-	setAlliance(NEW_PARADIGM, SCAV_6, true);
-	setAlliance(NEW_PARADIGM, SCAV_7, true);
-	setAlliance(SCAV_6, SCAV_7, true);
+	setAlliance(CAM_NEW_PARADIGM, CAM_SCAV_6, true);
+	setAlliance(CAM_NEW_PARADIGM, CAM_SCAV_7, true);
+	setAlliance(CAM_SCAV_6, CAM_SCAV_7, true);
 
-	camCompleteRequiredResearch(SCAVENGER_RES, 6);
-	camCompleteRequiredResearch(SCAVENGER_RES, 7);
+	camCompleteRequiredResearch(mis_scavengerRes, 6);
+	camCompleteRequiredResearch(mis_scavengerRes, 7);
 	if (difficulty === HARD)
 	{
-		completeResearch("R-Wpn-Flamer-Range01-ScavReduce-Undo", SCAV_6);
-		completeResearch("R-Wpn-Flamer-Range01-ScavReduce-Undo", SCAV_7);
+		completeResearch("R-Wpn-Flamer-Range01-ScavReduce-Undo", CAM_SCAV_6);
+		completeResearch("R-Wpn-Flamer-Range01-ScavReduce-Undo", CAM_SCAV_7);
 	}
 	else if (difficulty === INSANE)
 	{
-		completeResearch("R-Wpn-Flamer-Range01", SCAV_6);
-		completeResearch("R-Wpn-Flamer-Range01", SCAV_7);
-		completeResearch("R-Wpn-Flamer-Range01-ScavReduce-Undo", SCAV_6);
-		completeResearch("R-Wpn-Flamer-Range01-ScavReduce-Undo", SCAV_7);
+		completeResearch("R-Wpn-Flamer-Range01", CAM_SCAV_6);
+		completeResearch("R-Wpn-Flamer-Range01", CAM_SCAV_7);
+		completeResearch("R-Wpn-Flamer-Range01-ScavReduce-Undo", CAM_SCAV_6);
+		completeResearch("R-Wpn-Flamer-Range01-ScavReduce-Undo", CAM_SCAV_7);
 	}
 	camSetArtifacts({
 		"base1factory": { tech: "R-Wpn-Flamer-Damage02" },
@@ -175,6 +175,6 @@ function eventStartLevel()
 	// New Paradigm sensor scout. Now comes with the map!
 	NPScout = getObject("npscout");
 	camNeverGroupDroid(NPScout);
-	let pos = getObject("NPSensorWatch");
+	const pos = getObject("NPSensorWatch");
 	orderDroidLoc(NPScout, DORDER_MOVE, pos.x, pos.y);
 }

--- a/data/base/script/campaign/cam1b.js
+++ b/data/base/script/campaign/cam1b.js
@@ -37,7 +37,7 @@ camAreaEvent("AttackArea2", function(droid)
 
 function doNPRetreat()
 {
-	var pos = camMakePos("NPSensorTurn");
+	let pos = camMakePos("NPSensorTurn");
 	if (NPScout)
 	{
 		camTrace("New Paradigm sensor droid is retreating");
@@ -61,7 +61,7 @@ function eventDestroyed(obj)
 
 camAreaEvent("NPSensorTurn", function(droid)
 {
-	var pos = camMakePos("NPSensorRemove");
+	let pos = camMakePos("NPSensorRemove");
 	orderDroidLoc(NPScout, DORDER_MOVE, pos.x, pos.y);
 });
 
@@ -73,8 +73,8 @@ camAreaEvent("NPSensorRemove", function(droid)
 function eventStartLevel()
 {
 	camSetStandardWinLossConditions(CAM_VICTORY_STANDARD, "SUB_1_1S");
-	var startpos = getObject("startPosition");
-	var lz = getObject("landingZone");
+	let startpos = getObject("startPosition");
+	let lz = getObject("landingZone");
 	centreView(startpos.x, startpos.y);
 	setNoGoArea(lz.x, lz.y, lz.x2, lz.y2, CAM_HUMAN_PLAYER);
 
@@ -175,6 +175,6 @@ function eventStartLevel()
 	// New Paradigm sensor scout. Now comes with the map!
 	NPScout = getObject("npscout");
 	camNeverGroupDroid(NPScout);
-	var pos = getObject("NPSensorWatch");
+	let pos = getObject("NPSensorWatch");
 	orderDroidLoc(NPScout, DORDER_MOVE, pos.x, pos.y);
 }

--- a/data/base/script/campaign/cam1c.js
+++ b/data/base/script/campaign/cam1c.js
@@ -120,13 +120,13 @@ function camEnemyBaseEliminated_NPCentralFactory()
 
 function getDroidsForNPLZ(args)
 {
-	var scouts = [ cTempl.nppod, cTempl.nphmg ];
-	var heavies = [ cTempl.npslc, cTempl.npsmct ];
-	var useArtillery = (camRand(100) < 50);
+	let scouts = [ cTempl.nppod, cTempl.nphmg ];
+	let heavies = [ cTempl.npslc, cTempl.npsmct ];
+	let useArtillery = (camRand(100) < 50);
 
-	var numScouts = camRand(5) + 1;
-	var heavy = heavies[camRand(heavies.length)];
-	var list = [];
+	let numScouts = camRand(5) + 1;
+	let heavy = heavies[camRand(heavies.length)];
+	let list = [];
 
 	if (useArtillery)
 	{
@@ -180,15 +180,15 @@ camAreaEvent("NPLZ2Trigger", function()
 function eventStartLevel()
 {
 	camSetStandardWinLossConditions(CAM_VICTORY_STANDARD, "CAM_1CA");
-	var startpos = getObject("startPosition");
-	var lz = getObject("landingZone");
+	let startpos = getObject("startPosition");
+	let lz = getObject("landingZone");
 	centreView(startpos.x, startpos.y);
 	setNoGoArea(lz.x, lz.y, lz.x2, lz.y2, CAM_HUMAN_PLAYER);
 
 	// make sure player doesn't build on enemy LZs of the next level
 	for (let i = 1; i <= 5; ++i)
 	{
-		var ph = getObject("PhantomLZ" + i);
+		let ph = getObject("PhantomLZ" + i);
 		// HACK: set LZs of bad players, namely 2...6,
 		// note: player 1 is NP, player 7 is scavs
 		setNoGoArea(ph.x, ph.y, ph.x2, ph.y2, i + 1);

--- a/data/base/script/campaign/cam1c.js
+++ b/data/base/script/campaign/cam1c.js
@@ -2,7 +2,7 @@
 include("script/campaign/libcampaign.js");
 include("script/campaign/templates.js");
 
-const NEW_PARADIGM_RES = [
+const mis_newParadigmRes = [
 	"R-Wpn-MG1Mk1", "R-Vehicle-Body01", "R-Sys-Spade1Mk1", "R-Vehicle-Prop-Wheels",
 	"R-Sys-Engineering01", "R-Wpn-MG-Damage03", "R-Wpn-MG-ROF01", "R-Wpn-Cannon-Damage02",
 	"R-Wpn-Flamer-Damage03", "R-Wpn-Flamer-Range01", "R-Wpn-Flamer-ROF01",
@@ -11,7 +11,7 @@ const NEW_PARADIGM_RES = [
 	"R-Vehicle-Metals01", "R-Wpn-Mortar-Damage02", "R-Wpn-Rocket-Accuracy01",
 	"R-Wpn-RocketSlow-Damage01", "R-Wpn-Mortar-ROF01",
 ];
-const SCAVENGER_RES = [
+const mis_scavengerRes = [
 	"R-Wpn-Flamer-Damage02", "R-Wpn-Flamer-Range01", "R-Wpn-Flamer-ROF01",
 	"R-Wpn-MG-Damage03", "R-Wpn-MG-ROF01", "R-Wpn-Rocket-Damage01",
 	"R-Wpn-Cannon-Damage02", "R-Wpn-Mortar-Damage02", "R-Wpn-Mortar-ROF01",
@@ -120,15 +120,14 @@ function camEnemyBaseEliminated_NPCentralFactory()
 
 function getDroidsForNPLZ(args)
 {
-	let scouts = [ cTempl.nppod, cTempl.nphmg ];
-	let heavies = [ cTempl.npslc, cTempl.npsmct ];
-	let useArtillery = (camRand(100) < 50);
-
+	const scouts = [ cTempl.nppod, cTempl.nphmg ];
+	const heavies = [ cTempl.npslc, cTempl.npsmct ];
+	const USE_ARTILLERY = (camRand(100) < 50);
+	const list = [];
 	let numScouts = camRand(5) + 1;
 	let heavy = heavies[camRand(heavies.length)];
-	let list = [];
 
-	if (useArtillery)
+	if (USE_ARTILLERY)
 	{
 		list[list.length] = cTempl.npsens; //sensor will count towards scout total
 		numScouts -= 1;
@@ -180,15 +179,15 @@ camAreaEvent("NPLZ2Trigger", function()
 function eventStartLevel()
 {
 	camSetStandardWinLossConditions(CAM_VICTORY_STANDARD, "CAM_1CA");
-	let startpos = getObject("startPosition");
-	let lz = getObject("landingZone");
-	centreView(startpos.x, startpos.y);
+	const startPos = getObject("startPosition");
+	const lz = getObject("landingZone");
+	centreView(startPos.x, startPos.y);
 	setNoGoArea(lz.x, lz.y, lz.x2, lz.y2, CAM_HUMAN_PLAYER);
 
 	// make sure player doesn't build on enemy LZs of the next level
 	for (let i = 1; i <= 5; ++i)
 	{
-		let ph = getObject("PhantomLZ" + i);
+		const ph = getObject("PhantomLZ" + i);
 		// HACK: set LZs of bad players, namely 2...6,
 		// note: player 1 is NP, player 7 is scavs
 		setNoGoArea(ph.x, ph.y, ph.x2, ph.y2, i + 1);
@@ -207,14 +206,14 @@ function eventStartLevel()
 		setMissionTime(camChangeOnDiff(camHoursToSeconds(2)));
 	}
 
-	setAlliance(NEW_PARADIGM, SCAV_7, true);
-	camCompleteRequiredResearch(NEW_PARADIGM_RES, NEW_PARADIGM);
-	camCompleteRequiredResearch(SCAVENGER_RES, SCAV_7);
+	setAlliance(CAM_NEW_PARADIGM, CAM_SCAV_7, true);
+	camCompleteRequiredResearch(mis_newParadigmRes, CAM_NEW_PARADIGM);
+	camCompleteRequiredResearch(mis_scavengerRes, CAM_SCAV_7);
 
-	camUpgradeOnMapTemplates(cTempl.bloke, cTempl.blokeheavy, SCAV_7);
-	camUpgradeOnMapTemplates(cTempl.trike, cTempl.trikeheavy, SCAV_7);
-	camUpgradeOnMapTemplates(cTempl.buggy, cTempl.buggyheavy, SCAV_7);
-	camUpgradeOnMapTemplates(cTempl.bjeep, cTempl.bjeepheavy, SCAV_7);
+	camUpgradeOnMapTemplates(cTempl.bloke, cTempl.blokeheavy, CAM_SCAV_7);
+	camUpgradeOnMapTemplates(cTempl.trike, cTempl.trikeheavy, CAM_SCAV_7);
+	camUpgradeOnMapTemplates(cTempl.buggy, cTempl.buggyheavy, CAM_SCAV_7);
+	camUpgradeOnMapTemplates(cTempl.bjeep, cTempl.bjeepheavy, CAM_SCAV_7);
 
 	camSetEnemyBases({
 		"ScavSouthDerrickGroup": {
@@ -246,7 +245,7 @@ function eventStartLevel()
 			detectMsg: "C1C_BASE5",
 			detectSnd: "pcv374.ogg",
 			eliminateSnd: "pcv391.ogg",
-			player: SCAV_7 // hence discriminate by player filter
+			player: CAM_SCAV_7 // hence discriminate by player filter
 		},
 		"NPEastBaseGroup": {
 			cleanup: "NPEastBase",
@@ -271,19 +270,19 @@ function eventStartLevel()
 			detectMsg: "C1C_BASE10",
 			detectSnd: "pcv379.ogg",
 			eliminateSnd: "pcv394.ogg",
-			player: NEW_PARADIGM // hence discriminate by player filter
+			player: CAM_NEW_PARADIGM // hence discriminate by player filter
 		},
 		"NPLZ1Group": {
 			cleanup: "NPLZ1", // kill the four towers to disable LZ
 			detectMsg: "C1C_LZ1",
 			eliminateSnd: "pcv394.ogg",
-			player: NEW_PARADIGM // required for LZ-type bases
+			player: CAM_NEW_PARADIGM // required for LZ-type bases
 		},
 		"NPLZ2Group": {
 			cleanup: "NPLZ2", // kill the four towers to disable LZ
 			detectMsg: "C1C_LZ2",
 			eliminateSnd: "pcv394.ogg",
-			player: NEW_PARADIGM // required for LZ-type bases
+			player: CAM_NEW_PARADIGM // required for LZ-type bases
 		},
 	});
 
@@ -345,7 +344,7 @@ function eventStartLevel()
 		},
 	});
 
-	camManageTrucks(NEW_PARADIGM);
+	camManageTrucks(CAM_NEW_PARADIGM);
 	replaceTexture("page-7-barbarians-arizona.png", "page-7-barbarians-kevlar.png");
 
 	camEnableFactory("ScavSouthFactory");

--- a/data/base/script/campaign/cam1ca.js
+++ b/data/base/script/campaign/cam1ca.js
@@ -2,7 +2,7 @@
 include("script/campaign/libcampaign.js");
 include("script/campaign/templates.js");
 
-const NEW_PARADIGM_RES = [
+const mis_newParadigmRes = [
 	"R-Wpn-MG1Mk1", "R-Vehicle-Body01", "R-Sys-Spade1Mk1", "R-Vehicle-Prop-Wheels",
 	"R-Sys-Engineering01", "R-Wpn-MG-Damage03", "R-Wpn-MG-ROF01", "R-Wpn-Cannon-Damage02",
 	"R-Wpn-Flamer-Damage03", "R-Wpn-Flamer-Range01", "R-Wpn-Flamer-ROF01",
@@ -11,8 +11,8 @@ const NEW_PARADIGM_RES = [
 	"R-Vehicle-Metals01", "R-Wpn-Mortar-Damage02", "R-Wpn-Rocket-Accuracy01",
 	"R-Wpn-RocketSlow-Damage01", "R-Wpn-Mortar-ROF01",
 ];
-const landingZoneList = [ "NPLZ1", "NPLZ2", "NPLZ3", "NPLZ4", "NPLZ5" ];
-const landingZoneMessages = [ "C1CA_LZ1", "C1CA_LZ2", "C1CA_LZ3", "C1CA_LZ4", "C1CA_LZ5" ];
+const mis_landingZoneList = [ "NPLZ1", "NPLZ2", "NPLZ3", "NPLZ4", "NPLZ5" ];
+const mis_landingZoneMessages = [ "C1CA_LZ1", "C1CA_LZ2", "C1CA_LZ3", "C1CA_LZ4", "C1CA_LZ5" ];
 var blipActive;
 var lastLZ, lastHeavy;
 var totalTransportLoads;
@@ -22,12 +22,12 @@ var totalTransportLoads;
 function baseEstablished()
 {
 	//Now we check if there is stuff built here already from cam1-C.
-	let total = camCountStructuresInArea("buildArea") +
+	const TOTAL = camCountStructuresInArea("buildArea") +
 				camCountStructuresInArea("buildArea2") +
 				camCountStructuresInArea("buildArea3") +
 				camCountStructuresInArea("buildArea4") +
 				camCountStructuresInArea("buildArea5");
-	if (total >= 7)
+	if (TOTAL >= 7)
 	{
 		if (blipActive)
 		{
@@ -51,7 +51,7 @@ function baseEstablished()
 function extraVictoryCondition()
 {
 	const MIN_TRANSPORT_RUNS = 10;
-	let enemies = enumArea(0, 0, mapWidth, mapHeight, ENEMIES, false);
+	const enemies = enumArea(0, 0, mapWidth, mapHeight, ENEMIES, false);
 	// No enemies on map and at least eleven New Paradigm transport runs.
 	if (baseEstablished() && (totalTransportLoads > MIN_TRANSPORT_RUNS) && !enemies.length)
 	{
@@ -68,16 +68,16 @@ function sendTransport()
 	{
 		lastHeavy = true;
 	}
-	let list = [];
+	const list = [];
 	// Randomly find an LZ that is not compromised
 	if (camRand(100) < 10)
 	{
-		for (let i = 0; i < landingZoneList.length; ++i)
+		for (let i = 0; i < mis_landingZoneList.length; ++i)
 		{
-			let lz = landingZoneList[i];
-			if (enumArea(lz, CAM_HUMAN_PLAYER, false).length === 0)
+			const LZ = mis_landingZoneList[i];
+			if (enumArea(LZ, CAM_HUMAN_PLAYER, false).length === 0)
 			{
-				list.push({ idx: i, label: lz });
+				list.push({ idx: i, label: LZ });
 			}
 		}
 	}
@@ -86,17 +86,17 @@ function sendTransport()
 	{
 		for (let i = 0; i < 2; ++i)
 		{
-			let rnd = camRand(landingZoneList.length);
-			list.push({ idx: rnd, label: landingZoneList[rnd] });
+			const RND = camRand(mis_landingZoneList.length);
+			list.push({ idx: RND, label: mis_landingZoneList[RND] });
 		}
 	}
-	let picked = list[camRand(list.length)];
+	const picked = list[camRand(list.length)];
 	lastLZ = picked.idx;
-	let pos = camMakePos(picked.label);
+	const pos = camMakePos(picked.label);
 
 	// (2 or 3 or 4) pairs of each droid template.
 	// This emulates wzcam's droid count distribution.
-	let count = [ 2, 3, 4, 4, 4, 4, 4, 4, 4 ][camRand(9)];
+	const COUNT = [ 2, 3, 4, 4, 4, 4, 4, 4, 4 ][camRand(9)];
 
 	let templates;
 	if (lastHeavy)
@@ -110,19 +110,19 @@ function sendTransport()
 		templates = [ cTempl.npsmct, cTempl.npmor, cTempl.npsmc, cTempl.npmmct, cTempl.npmrl, cTempl.nphmg, cTempl.npsbb, cTempl.npltat ];
 	}
 
-	let droids = [];
-	for (let i = 0; i < count; ++i)
+	const droids = [];
+	for (let i = 0; i < COUNT; ++i)
 	{
-		let t = templates[camRand(templates.length)];
+		const t = templates[camRand(templates.length)];
 		// two droids of each template
 		droids[droids.length] = t;
 		droids[droids.length] = t;
 	}
 
-	camSendReinforcement(NEW_PARADIGM, pos, droids, CAM_REINFORCE_TRANSPORT, {
+	camSendReinforcement(CAM_NEW_PARADIGM, pos, droids, CAM_REINFORCE_TRANSPORT, {
 		entry: { x: 126, y: 36 },
 		exit: { x: 126, y: 76 },
-		message: landingZoneMessages[lastLZ],
+		message: mis_landingZoneMessages[lastLZ],
 		order: CAM_ORDER_ATTACK,
 		data: { regroup: true, count: -1, pos: "buildArea" }
 	});
@@ -151,15 +151,16 @@ function eventStartLevel()
 	camSetStandardWinLossConditions(CAM_VICTORY_STANDARD, "SUB_1_4AS", {
 		callback: "extraVictoryCondition"
 	});
-	let startpos = getObject("startPosition");
-	let lz = getObject("landingZone");
-	centreView(startpos.x, startpos.y);
+	const startPos = getObject("startPosition");
+	const lz = getObject("landingZone");
+	centreView(startPos.x, startPos.y);
 	setNoGoArea(lz.x, lz.y, lz.x2, lz.y2, CAM_HUMAN_PLAYER);
+	camCompleteRequiredResearch(mis_newParadigmRes, CAM_NEW_PARADIGM);
 
 	// make sure player doesn't build on enemy LZs
 	for (let i = 1; i <= 5; ++i)
 	{
-		let ph = getObject("PhantomLZ" + i);
+		const ph = getObject("PhantomLZ" + i);
 		// HACK: set LZs of bad players, namely 2...6,
 		// note: player 1 is NP
 		setNoGoArea(ph.x, ph.y, ph.x2, ph.y2, i + 2);

--- a/data/base/script/campaign/cam1ca.js
+++ b/data/base/script/campaign/cam1ca.js
@@ -22,7 +22,7 @@ var totalTransportLoads;
 function baseEstablished()
 {
 	//Now we check if there is stuff built here already from cam1-C.
-	var total = camCountStructuresInArea("buildArea") +
+	let total = camCountStructuresInArea("buildArea") +
 				camCountStructuresInArea("buildArea2") +
 				camCountStructuresInArea("buildArea3") +
 				camCountStructuresInArea("buildArea4") +
@@ -51,7 +51,7 @@ function baseEstablished()
 function extraVictoryCondition()
 {
 	const MIN_TRANSPORT_RUNS = 10;
-	var enemies = enumArea(0, 0, mapWidth, mapHeight, ENEMIES, false);
+	let enemies = enumArea(0, 0, mapWidth, mapHeight, ENEMIES, false);
 	// No enemies on map and at least eleven New Paradigm transport runs.
 	if (baseEstablished() && (totalTransportLoads > MIN_TRANSPORT_RUNS) && !enemies.length)
 	{
@@ -68,14 +68,13 @@ function sendTransport()
 	{
 		lastHeavy = true;
 	}
-	var list = [];
-	var i = 0;
+	let list = [];
 	// Randomly find an LZ that is not compromised
 	if (camRand(100) < 10)
 	{
-		for (i = 0; i < landingZoneList.length; ++i)
+		for (let i = 0; i < landingZoneList.length; ++i)
 		{
-			var lz = landingZoneList[i];
+			let lz = landingZoneList[i];
 			if (enumArea(lz, CAM_HUMAN_PLAYER, false).length === 0)
 			{
 				list.push({ idx: i, label: lz });
@@ -85,21 +84,21 @@ function sendTransport()
 	//If all are compromised (or not checking for compromised LZs) then choose the LZ randomly
 	if (list.length === 0)
 	{
-		for (i = 0; i < 2; ++i)
+		for (let i = 0; i < 2; ++i)
 		{
-			var rnd = camRand(landingZoneList.length);
+			let rnd = camRand(landingZoneList.length);
 			list.push({ idx: rnd, label: landingZoneList[rnd] });
 		}
 	}
-	var picked = list[camRand(list.length)];
+	let picked = list[camRand(list.length)];
 	lastLZ = picked.idx;
-	var pos = camMakePos(picked.label);
+	let pos = camMakePos(picked.label);
 
 	// (2 or 3 or 4) pairs of each droid template.
 	// This emulates wzcam's droid count distribution.
-	var count = [ 2, 3, 4, 4, 4, 4, 4, 4, 4 ][camRand(9)];
+	let count = [ 2, 3, 4, 4, 4, 4, 4, 4, 4 ][camRand(9)];
 
-	var templates;
+	let templates;
 	if (lastHeavy)
 	{
 		lastHeavy = false;
@@ -111,10 +110,10 @@ function sendTransport()
 		templates = [ cTempl.npsmct, cTempl.npmor, cTempl.npsmc, cTempl.npmmct, cTempl.npmrl, cTempl.nphmg, cTempl.npsbb, cTempl.npltat ];
 	}
 
-	var droids = [];
-	for (i = 0; i < count; ++i)
+	let droids = [];
+	for (let i = 0; i < count; ++i)
 	{
-		var t = templates[camRand(templates.length)];
+		let t = templates[camRand(templates.length)];
 		// two droids of each template
 		droids[droids.length] = t;
 		droids[droids.length] = t;
@@ -152,15 +151,15 @@ function eventStartLevel()
 	camSetStandardWinLossConditions(CAM_VICTORY_STANDARD, "SUB_1_4AS", {
 		callback: "extraVictoryCondition"
 	});
-	var startpos = getObject("startPosition");
-	var lz = getObject("landingZone");
+	let startpos = getObject("startPosition");
+	let lz = getObject("landingZone");
 	centreView(startpos.x, startpos.y);
 	setNoGoArea(lz.x, lz.y, lz.x2, lz.y2, CAM_HUMAN_PLAYER);
 
 	// make sure player doesn't build on enemy LZs
 	for (let i = 1; i <= 5; ++i)
 	{
-		var ph = getObject("PhantomLZ" + i);
+		let ph = getObject("PhantomLZ" + i);
 		// HACK: set LZs of bad players, namely 2...6,
 		// note: player 1 is NP
 		setNoGoArea(ph.x, ph.y, ph.x2, ph.y2, i + 2);

--- a/data/base/script/campaign/cam2-1s.js
+++ b/data/base/script/campaign/cam2-1s.js
@@ -14,7 +14,7 @@ function eventStartLevel()
 	centreView(88, 101);
 	//Setup Landing Zone
 	setNoGoArea(86, 99, 88, 101, CAM_HUMAN_PLAYER);
-	setNoGoArea(49, 83, 51, 85, THE_COLLECTIVE);
+	setNoGoArea(49, 83, 51, 85, CAM_THE_COLLECTIVE);
 	//Set Mission Time
 	setMissionTime(camChangeOnDiff(camMinutesToSeconds(30)));
 	//Give player briefings

--- a/data/base/script/campaign/cam2-1x.js
+++ b/data/base/script/campaign/cam2-1x.js
@@ -8,8 +8,8 @@ include("script/campaign/transitionTech.js");
 
 var victoryFlag;
 
-const TRANSPORT_TEAM = 1;
-const COLLECTIVE_RES = [
+const MIS_TRANSPORT_TEAM_PLAYER = 1;
+const mis_collectiveRes = [
 	"R-Defense-WallUpgrade06", "R-Struc-Materials06", "R-Sys-Engineering02",
 	"R-Vehicle-Engine03", "R-Vehicle-Metals03", "R-Cyborg-Metals03",
 	"R-Wpn-Cannon-Accuracy02", "R-Wpn-Cannon-Damage04",
@@ -25,7 +25,7 @@ const COLLECTIVE_RES = [
 camAreaEvent("crashSite", function(droid)
 {
 	//Unlikely to happen.
-	if (!enumDroid(TRANSPORT_TEAM).length)
+	if (!enumDroid(MIS_TRANSPORT_TEAM_PLAYER).length)
 	{
 		gameOverMessage(false);
 		return;
@@ -36,7 +36,7 @@ camAreaEvent("crashSite", function(droid)
 
 	hackRemoveMessage("C21_OBJECTIVE", PROX_MSG, CAM_HUMAN_PLAYER);
 
-	let droids = enumDroid(TRANSPORT_TEAM);
+	const droids = enumDroid(MIS_TRANSPORT_TEAM_PLAYER);
 	for (let i = 0; i < droids.length; ++i)
 	{
 		donateObject(droids[i], CAM_HUMAN_PLAYER);
@@ -51,7 +51,7 @@ camAreaEvent("crashSite", function(droid)
 function preDamageUnits()
 {
 	setHealth(getObject("transporter"), 40);
-	let droids = enumDroid(TRANSPORT_TEAM);
+	const droids = enumDroid(MIS_TRANSPORT_TEAM_PLAYER);
 	for (let j = 0; j < droids.length; ++j)
 	{
 		setHealth(droids[j], 40 + camRand(20));
@@ -80,13 +80,13 @@ function setupCyborgGroups()
 function setCrashedTeamExp()
 {
 	const DROID_EXP = 32;
-	let droids = enumDroid(TRANSPORT_TEAM).filter((dr) => (
+	const droids = enumDroid(MIS_TRANSPORT_TEAM_PLAYER).filter((dr) => (
 		!camIsSystemDroid(dr) && !camIsTransporter(dr)
 	));
 
 	for (let i = 0; i < droids.length; ++i)
 	{
-		let droid = droids[i];
+		const droid = droids[i];
 		setDroidExperience(droid, DROID_EXP);
 	}
 
@@ -118,32 +118,32 @@ function eventStartLevel()
 		callback: "checkCrashedTeam"
 	});
 
-	let subLandingZone = getObject("landingZone");
-	let startpos = getObject("startingPosition");
-	let tent = getObject("transporterEntry");
-	let text = getObject("transporterExit");
-	centreView(startpos.x, startpos.y);
+	const subLandingZone = getObject("landingZone");
+	const startPos = getObject("startingPosition");
+	const tEnt = getObject("transporterEntry");
+	const tExt = getObject("transporterExit");
+	centreView(startPos.x, startPos.y);
 	setNoGoArea(subLandingZone.x, subLandingZone.y, subLandingZone.x2, subLandingZone.y2, CAM_HUMAN_PLAYER);
-	startTransporterEntry(tent.x, tent.y, CAM_HUMAN_PLAYER);
-	setTransporterExit(text.x, text.y, CAM_HUMAN_PLAYER);
+	startTransporterEntry(tEnt.x, tEnt.y, CAM_HUMAN_PLAYER);
+	setTransporterExit(tExt.x, tExt.y, CAM_HUMAN_PLAYER);
 
-	let enemyLz = getObject("COLandingZone");
-	setNoGoArea(enemyLz.x, enemyLz.y, enemyLz.x2, enemyLz.y2, THE_COLLECTIVE);
+	const enemyLz = getObject("COLandingZone");
+	setNoGoArea(enemyLz.x, enemyLz.y, enemyLz.x2, enemyLz.y2, CAM_THE_COLLECTIVE);
 
 	//Add crash site blip and from an alliance with the crashed team.
 	hackAddMessage("C21_OBJECTIVE", PROX_MSG, CAM_HUMAN_PLAYER, false);
-	setAlliance(CAM_HUMAN_PLAYER, TRANSPORT_TEAM, true);
+	setAlliance(CAM_HUMAN_PLAYER, MIS_TRANSPORT_TEAM_PLAYER, true);
 
 	//set downed transport team colour to be Project Green.
-	changePlayerColour(TRANSPORT_TEAM, 0);
+	changePlayerColour(MIS_TRANSPORT_TEAM_PLAYER, 0);
 
-	camCompleteRequiredResearch(COLLECTIVE_RES, THE_COLLECTIVE);
-	camCompleteRequiredResearch(ALPHA_RESEARCH_NEW, TRANSPORT_TEAM);
-	camCompleteRequiredResearch(PLAYER_RES_BETA, TRANSPORT_TEAM);
+	camCompleteRequiredResearch(mis_collectiveRes, CAM_THE_COLLECTIVE);
+	camCompleteRequiredResearch(mis_alphaResearchNew, MIS_TRANSPORT_TEAM_PLAYER);
+	camCompleteRequiredResearch(mis_playerResBeta, MIS_TRANSPORT_TEAM_PLAYER);
 
 	if (difficulty >= HARD)
 	{
-		camUpgradeOnMapTemplates(cTempl.commc, cTempl.commrp, THE_COLLECTIVE);
+		camUpgradeOnMapTemplates(cTempl.commc, cTempl.commrp, CAM_THE_COLLECTIVE);
 	}
 
 	camSetEnemyBases({

--- a/data/base/script/campaign/cam2-1x.js
+++ b/data/base/script/campaign/cam2-1x.js
@@ -36,7 +36,7 @@ camAreaEvent("crashSite", function(droid)
 
 	hackRemoveMessage("C21_OBJECTIVE", PROX_MSG, CAM_HUMAN_PLAYER);
 
-	var droids = enumDroid(TRANSPORT_TEAM);
+	let droids = enumDroid(TRANSPORT_TEAM);
 	for (let i = 0; i < droids.length; ++i)
 	{
 		donateObject(droids[i], CAM_HUMAN_PLAYER);
@@ -51,7 +51,7 @@ camAreaEvent("crashSite", function(droid)
 function preDamageUnits()
 {
 	setHealth(getObject("transporter"), 40);
-	var droids = enumDroid(TRANSPORT_TEAM);
+	let droids = enumDroid(TRANSPORT_TEAM);
 	for (let j = 0; j < droids.length; ++j)
 	{
 		setHealth(droids[j], 40 + camRand(20));
@@ -80,13 +80,13 @@ function setupCyborgGroups()
 function setCrashedTeamExp()
 {
 	const DROID_EXP = 32;
-	var droids = enumDroid(TRANSPORT_TEAM).filter((dr) => (
+	let droids = enumDroid(TRANSPORT_TEAM).filter((dr) => (
 		!camIsSystemDroid(dr) && !camIsTransporter(dr)
 	));
 
 	for (let i = 0; i < droids.length; ++i)
 	{
-		var droid = droids[i];
+		let droid = droids[i];
 		setDroidExperience(droid, DROID_EXP);
 	}
 
@@ -118,16 +118,16 @@ function eventStartLevel()
 		callback: "checkCrashedTeam"
 	});
 
-	var subLandingZone = getObject("landingZone");
-	var startpos = getObject("startingPosition");
-	var tent = getObject("transporterEntry");
-	var text = getObject("transporterExit");
+	let subLandingZone = getObject("landingZone");
+	let startpos = getObject("startingPosition");
+	let tent = getObject("transporterEntry");
+	let text = getObject("transporterExit");
 	centreView(startpos.x, startpos.y);
 	setNoGoArea(subLandingZone.x, subLandingZone.y, subLandingZone.x2, subLandingZone.y2, CAM_HUMAN_PLAYER);
 	startTransporterEntry(tent.x, tent.y, CAM_HUMAN_PLAYER);
 	setTransporterExit(text.x, text.y, CAM_HUMAN_PLAYER);
 
-	var enemyLz = getObject("COLandingZone");
+	let enemyLz = getObject("COLandingZone");
 	setNoGoArea(enemyLz.x, enemyLz.y, enemyLz.x2, enemyLz.y2, THE_COLLECTIVE);
 
 	//Add crash site blip and from an alliance with the crashed team.

--- a/data/base/script/campaign/cam2-2.js
+++ b/data/base/script/campaign/cam2-2.js
@@ -62,8 +62,8 @@ camAreaEvent("wayPoint2Rad", function(droid)
 		return;
 	}
 
-	var point = getObject("wayPoint3");
-	var defGroup = enumRange(point.x, point.y, 10, THE_COLLECTIVE, false).filter((obj) => (
+	let point = getObject("wayPoint3");
+	let defGroup = enumRange(point.x, point.y, 10, THE_COLLECTIVE, false).filter((obj) => (
 		obj.droidType === DROID_WEAPON
 	));
 
@@ -98,7 +98,7 @@ camAreaEvent("failZone", function(droid)
 
 function vtolAttack()
 {
-	var list = [cTempl.colatv, cTempl.colatv];
+	let list = [cTempl.colatv, cTempl.colatv];
 	camSetVtolData(THE_COLLECTIVE, "vtolAppearPoint", "vtolRemovePoint", list, camChangeOnDiff(camMinutesToMilliseconds(5)), "COCommandCenter");
 }
 
@@ -117,7 +117,7 @@ function truckDefense()
 
 function showGameOver()
 {
-	var arti = camGetArtifacts();
+	let arti = camGetArtifacts();
 	camSafeRemoveObject(arti[0], false);
 	gameOverMessage(false);
 }
@@ -158,16 +158,16 @@ function eventStartLevel()
 		retlz: true
 	});
 
-	var startpos = getObject("startPosition");
-	var lz = getObject("landingZone"); //player lz
-	var tent = getObject("transporterEntry");
-	var text = getObject("transporterExit");
+	let startpos = getObject("startPosition");
+	let lz = getObject("landingZone"); //player lz
+	let tent = getObject("transporterEntry");
+	let text = getObject("transporterExit");
 	centreView(startpos.x, startpos.y);
 	setNoGoArea(lz.x, lz.y, lz.x2, lz.y2, CAM_HUMAN_PLAYER);
 	startTransporterEntry(tent.x, tent.y, CAM_HUMAN_PLAYER);
 	setTransporterExit(text.x, text.y, CAM_HUMAN_PLAYER);
 
-	var enemyLz = getObject("COLandingZone");
+	let enemyLz = getObject("COLandingZone");
 	setNoGoArea(enemyLz.x, enemyLz.y, enemyLz.x2, enemyLz.y2, THE_COLLECTIVE);
 
 	camSetArtifacts({

--- a/data/base/script/campaign/cam2-2.js
+++ b/data/base/script/campaign/cam2-2.js
@@ -2,8 +2,7 @@
 include("script/campaign/libcampaign.js");
 include("script/campaign/templates.js");
 
-const warning = "pcv632.ogg"; // Collective commander escaping
-const COLLEVTIVE_RES = [
+const mis_collectiveRes = [
 	"R-Defense-WallUpgrade06", "R-Struc-Materials06", "R-Sys-Engineering02",
 	"R-Vehicle-Engine04", "R-Vehicle-Metals04", "R-Cyborg-Metals04",
 	"R-Wpn-Cannon-Accuracy02", "R-Wpn-Cannon-Damage05",
@@ -23,7 +22,7 @@ camAreaEvent("vtolRemoveZone", function(droid)
 		camSafeRemoveObject(droid, false);
 	}
 
-	resetLabel("vtolRemoveZone", THE_COLLECTIVE);
+	resetLabel("vtolRemoveZone", CAM_THE_COLLECTIVE);
 });
 
 camAreaEvent("group1Trigger", function(droid)
@@ -42,7 +41,7 @@ camAreaEvent("wayPoint1Rad", function(droid)
 {
 	if (isVTOL(droid))
 	{
-		resetLabel("wayPoint1Rad", THE_COLLECTIVE);
+		resetLabel("wayPoint1Rad", CAM_THE_COLLECTIVE);
 		return;
 	}
 	camManageGroup(commandGroup, CAM_ORDER_DEFEND, {
@@ -58,12 +57,12 @@ camAreaEvent("wayPoint2Rad", function(droid)
 {
 	if (droid.droidType !== DROID_COMMAND)
 	{
-		resetLabel("wayPoint2Rad", THE_COLLECTIVE);
+		resetLabel("wayPoint2Rad", CAM_THE_COLLECTIVE);
 		return;
 	}
 
-	let point = getObject("wayPoint3");
-	let defGroup = enumRange(point.x, point.y, 10, THE_COLLECTIVE, false).filter((obj) => (
+	const point = getObject("wayPoint3");
+	const defGroup = enumRange(point.x, point.y, 10, CAM_THE_COLLECTIVE, false).filter((obj) => (
 		obj.droidType === DROID_WEAPON
 	));
 
@@ -80,7 +79,8 @@ camAreaEvent("wayPoint2Rad", function(droid)
 		repair: 67,
 	});
 
-	playSound(warning);
+	const WARN_MESSAGE = "pcv632.ogg"; // Collective commander escaping
+	playSound(WARN_MESSAGE);
 });
 
 camAreaEvent("failZone", function(droid)
@@ -92,32 +92,32 @@ camAreaEvent("failZone", function(droid)
 	}
 	else
 	{
-		resetLabel("failZone", THE_COLLECTIVE);
+		resetLabel("failZone", CAM_THE_COLLECTIVE);
 	}
 });
 
 function vtolAttack()
 {
-	let list = [cTempl.colatv, cTempl.colatv];
-	camSetVtolData(THE_COLLECTIVE, "vtolAppearPoint", "vtolRemovePoint", list, camChangeOnDiff(camMinutesToMilliseconds(5)), "COCommandCenter");
+	const list = [cTempl.colatv, cTempl.colatv];
+	camSetVtolData(CAM_THE_COLLECTIVE, "vtolAppearPoint", "vtolRemovePoint", list, camChangeOnDiff(camMinutesToMilliseconds(5)), "COCommandCenter");
 }
 
 //Order the truck to build some defenses.
 function truckDefense()
 {
-	if (enumDroid(THE_COLLECTIVE, DROID_CONSTRUCT).length === 0)
+	if (enumDroid(CAM_THE_COLLECTIVE, DROID_CONSTRUCT).length === 0)
 	{
 		removeTimer("truckDefense");
 		return;
 	}
 
 	const list = ["CO-Tower-LtATRkt", "PillBox1", "CO-WallTower-HvCan"];
-	camQueueBuilding(THE_COLLECTIVE, list[camRand(list.length)]);
+	camQueueBuilding(CAM_THE_COLLECTIVE, list[camRand(list.length)]);
 }
 
 function showGameOver()
 {
-	let arti = camGetArtifacts();
+	const arti = camGetArtifacts();
 	camSafeRemoveObject(arti[0], false);
 	gameOverMessage(false);
 }
@@ -141,7 +141,7 @@ function retreatCommander()
 function eventAttacked(victim, attacker)
 {
 	if (camDef(victim) &&
-		victim.player === THE_COLLECTIVE &&
+		victim.player === CAM_THE_COLLECTIVE &&
 		victim.y > Math.floor(mapHeight / 3) && //only if the commander is escaping to the south
 		victim.group === commandGroup)
 	{
@@ -158,27 +158,27 @@ function eventStartLevel()
 		retlz: true
 	});
 
-	let startpos = getObject("startPosition");
-	let lz = getObject("landingZone"); //player lz
-	let tent = getObject("transporterEntry");
-	let text = getObject("transporterExit");
-	centreView(startpos.x, startpos.y);
+	const startPos = getObject("startPosition");
+	const lz = getObject("landingZone"); //player lz
+	const tEnt = getObject("transporterEntry");
+	const tExt = getObject("transporterExit");
+	centreView(startPos.x, startPos.y);
 	setNoGoArea(lz.x, lz.y, lz.x2, lz.y2, CAM_HUMAN_PLAYER);
-	startTransporterEntry(tent.x, tent.y, CAM_HUMAN_PLAYER);
-	setTransporterExit(text.x, text.y, CAM_HUMAN_PLAYER);
+	startTransporterEntry(tEnt.x, tEnt.y, CAM_HUMAN_PLAYER);
+	setTransporterExit(tExt.x, tExt.y, CAM_HUMAN_PLAYER);
 
-	let enemyLz = getObject("COLandingZone");
-	setNoGoArea(enemyLz.x, enemyLz.y, enemyLz.x2, enemyLz.y2, THE_COLLECTIVE);
+	const enemyLz = getObject("COLandingZone");
+	setNoGoArea(enemyLz.x, enemyLz.y, enemyLz.x2, enemyLz.y2, CAM_THE_COLLECTIVE);
 
 	camSetArtifacts({
 		"COCommander": { tech: "R-Wpn-RocketSlow-Accuracy03" },
 	});
 
-	camCompleteRequiredResearch(COLLEVTIVE_RES, THE_COLLECTIVE);
+	camCompleteRequiredResearch(mis_collectiveRes, CAM_THE_COLLECTIVE);
 
 	if (difficulty >= MEDIUM)
 	{
-		camUpgradeOnMapTemplates(cTempl.commc, cTempl.commrp, THE_COLLECTIVE);
+		camUpgradeOnMapTemplates(cTempl.commc, cTempl.commrp, CAM_THE_COLLECTIVE);
 	}
 
 	camSetEnemyBases({
@@ -226,7 +226,7 @@ function eventStartLevel()
 	});
 
 	commandGroup = camMakeGroup("group1NBase");
-	camManageTrucks(THE_COLLECTIVE);
+	camManageTrucks(CAM_THE_COLLECTIVE);
 	camEnableFactory("COFactoryWest");
 
 	hackAddMessage("C22_OBJ1", PROX_MSG, CAM_HUMAN_PLAYER, false);

--- a/data/base/script/campaign/cam2-2s.js
+++ b/data/base/script/campaign/cam2-2s.js
@@ -5,7 +5,7 @@ function eventStartLevel()
 	camSetupTransporter(87, 100, 70, 1);
 	centreView(88, 101);
 	setNoGoArea(86, 99, 88, 101, CAM_HUMAN_PLAYER);
-	setNoGoArea(49, 83, 51, 85, THE_COLLECTIVE);
+	setNoGoArea(49, 83, 51, 85, CAM_THE_COLLECTIVE);
 	setMissionTime(camChangeOnDiff(camMinutesToSeconds(70)));
 	camPlayVideos([{video: "MB2_2_MSG", type: CAMP_MSG}, {video:"MB2_2_MSG2", type: CAMP_MSG}, {video: "MB2_2_MSG3", type: MISS_MSG}]);
 	camSetStandardWinLossConditions(CAM_VICTORY_PRE_OFFWORLD, "SUB_2_2");

--- a/data/base/script/campaign/cam2-5.js
+++ b/data/base/script/campaign/cam2-5.js
@@ -1,7 +1,7 @@
 include("script/campaign/libcampaign.js");
 include("script/campaign/templates.js");
 
-const COLLECTIVE_RES = [
+const mis_collectiveRes = [
 	"R-Defense-WallUpgrade06", "R-Struc-Materials06", "R-Sys-Engineering02",
 	"R-Vehicle-Engine04", "R-Vehicle-Metals05", "R-Cyborg-Metals05",
 	"R-Wpn-Cannon-Accuracy02", "R-Wpn-Cannon-Damage05", "R-Wpn-Cannon-ROF02",
@@ -34,7 +34,7 @@ function camEnemyBaseEliminated_COEastBase()
 //Tell everything not grouped on map to attack
 function camEnemyBaseDetected_COEastBase()
 {
-	let droids = enumArea(0, 0, mapWidth, mapHeight, THE_COLLECTIVE, false).filter((obj) => (
+	const droids = enumArea(0, 0, mapWidth, mapHeight, CAM_THE_COLLECTIVE, false).filter((obj) => (
 		obj.type === DROID && obj.group === null && obj.canHitGround
 	));
 
@@ -96,17 +96,17 @@ function eventStartLevel()
 		reinforcements: camMinutesToSeconds(3)
 	});
 
-	let startpos = getObject("startPosition");
-	let lz = getObject("landingZone"); //player lz
-	let tent = getObject("transporterEntry");
-	let text = getObject("transporterExit");
-	centreView(startpos.x, startpos.y);
+	const startPos = getObject("startPosition");
+	const lz = getObject("landingZone"); //player lz
+	const tEnt = getObject("transporterEntry");
+	const tExt = getObject("transporterExit");
+	centreView(startPos.x, startPos.y);
 	setNoGoArea(lz.x, lz.y, lz.x2, lz.y2, CAM_HUMAN_PLAYER);
-	startTransporterEntry(tent.x, tent.y, CAM_HUMAN_PLAYER);
-	setTransporterExit(text.x, text.y, CAM_HUMAN_PLAYER);
+	startTransporterEntry(tEnt.x, tEnt.y, CAM_HUMAN_PLAYER);
+	setTransporterExit(tExt.x, tExt.y, CAM_HUMAN_PLAYER);
 
-	let enemyLz = getObject("COLandingZone");
-	setNoGoArea(enemyLz.x, enemyLz.y, enemyLz.x2, enemyLz.y2, THE_COLLECTIVE);
+	const enemyLz = getObject("COLandingZone");
+	setNoGoArea(enemyLz.x, enemyLz.y, enemyLz.x2, enemyLz.y2, CAM_THE_COLLECTIVE);
 
 	camSetArtifacts({
 		"NuclearReactor": { tech: "R-Struc-Power-Upgrade01" },
@@ -115,11 +115,11 @@ function eventStartLevel()
 		"COTankKillerHardpoint": { tech: "R-Wpn-RocketSlow-ROF02" },
 	});
 
-	camCompleteRequiredResearch(COLLECTIVE_RES, THE_COLLECTIVE);
+	camCompleteRequiredResearch(mis_collectiveRes, CAM_THE_COLLECTIVE);
 
 	if (difficulty >= MEDIUM)
 	{
-		camUpgradeOnMapTemplates(cTempl.commc, cTempl.commrp, THE_COLLECTIVE);
+		camUpgradeOnMapTemplates(cTempl.commc, cTempl.commrp, CAM_THE_COLLECTIVE);
 	}
 
 	camSetEnemyBases({

--- a/data/base/script/campaign/cam2-5.js
+++ b/data/base/script/campaign/cam2-5.js
@@ -34,7 +34,7 @@ function camEnemyBaseEliminated_COEastBase()
 //Tell everything not grouped on map to attack
 function camEnemyBaseDetected_COEastBase()
 {
-	var droids = enumArea(0, 0, mapWidth, mapHeight, THE_COLLECTIVE, false).filter((obj) => (
+	let droids = enumArea(0, 0, mapWidth, mapHeight, THE_COLLECTIVE, false).filter((obj) => (
 		obj.type === DROID && obj.group === null && obj.canHitGround
 	));
 
@@ -96,16 +96,16 @@ function eventStartLevel()
 		reinforcements: camMinutesToSeconds(3)
 	});
 
-	var startpos = getObject("startPosition");
-	var lz = getObject("landingZone"); //player lz
-	var tent = getObject("transporterEntry");
-	var text = getObject("transporterExit");
+	let startpos = getObject("startPosition");
+	let lz = getObject("landingZone"); //player lz
+	let tent = getObject("transporterEntry");
+	let text = getObject("transporterExit");
 	centreView(startpos.x, startpos.y);
 	setNoGoArea(lz.x, lz.y, lz.x2, lz.y2, CAM_HUMAN_PLAYER);
 	startTransporterEntry(tent.x, tent.y, CAM_HUMAN_PLAYER);
 	setTransporterExit(text.x, text.y, CAM_HUMAN_PLAYER);
 
-	var enemyLz = getObject("COLandingZone");
+	let enemyLz = getObject("COLandingZone");
 	setNoGoArea(enemyLz.x, enemyLz.y, enemyLz.x2, enemyLz.y2, THE_COLLECTIVE);
 
 	camSetArtifacts({

--- a/data/base/script/campaign/cam2-5s.js
+++ b/data/base/script/campaign/cam2-5s.js
@@ -5,7 +5,7 @@ function eventStartLevel()
 	camSetupTransporter(87, 100, 32, 1);
 	centreView(88, 101);
 	setNoGoArea(86, 99, 88, 101, CAM_HUMAN_PLAYER);
-	setNoGoArea(49, 83, 51, 85, THE_COLLECTIVE);
+	setNoGoArea(49, 83, 51, 85, CAM_THE_COLLECTIVE);
 	setMissionTime(camChangeOnDiff(camHoursToSeconds(1)));
 	camPlayVideos([{video: "MB2_5_MSG", type: CAMP_MSG}, {video: "MB2_5_MSG2", type: MISS_MSG}]);
 	camSetStandardWinLossConditions(CAM_VICTORY_PRE_OFFWORLD, "SUB_2_5");

--- a/data/base/script/campaign/cam2-6.js
+++ b/data/base/script/campaign/cam2-6.js
@@ -1,7 +1,7 @@
 include("script/campaign/libcampaign.js");
 include("script/campaign/templates.js");
 
-const COLLECTIVE_RES = [
+const mis_collectiveRes = [
 	"R-Defense-WallUpgrade06", "R-Struc-Materials06", "R-Sys-Engineering02",
 	"R-Vehicle-Engine04", "R-Vehicle-Metals05", "R-Cyborg-Metals05",
 	"R-Wpn-Cannon-Accuracy02", "R-Wpn-Cannon-Damage05", "R-Wpn-Cannon-ROF02",
@@ -46,7 +46,7 @@ function camEnemyBaseEliminated_COUplinkBase()
 //Group together attack droids in this base that are not already in a group
 function camEnemyBaseDetected_COMediumBase()
 {
-	let droids = enumArea("mediumBaseCleanup", THE_COLLECTIVE, false).filter((obj) => (
+	const droids = enumArea("mediumBaseCleanup", CAM_THE_COLLECTIVE, false).filter((obj) => (
 		obj.type === DROID && obj.group === null && obj.canHitGround
 	));
 
@@ -57,15 +57,15 @@ function camEnemyBaseDetected_COMediumBase()
 
 function truckDefense()
 {
-	if (enumDroid(THE_COLLECTIVE, DROID_CONSTRUCT).length === 0)
+	if (enumDroid(CAM_THE_COLLECTIVE, DROID_CONSTRUCT).length === 0)
 	{
 		removeTimer("truckDefense");
 		return;
 	}
 
-	let list = ["Emplacement-Howitzer105", "Emplacement-Rocket06-IDF", "Sys-CB-Tower01", "Emplacement-Howitzer105", "Emplacement-Rocket06-IDF", "Sys-SensoTower02"];
-	camQueueBuilding(THE_COLLECTIVE, list[camRand(list.length)], camMakePos("buildPos1"));
-	camQueueBuilding(THE_COLLECTIVE, list[camRand(list.length)], camMakePos("buildPos2"));
+	const list = ["Emplacement-Howitzer105", "Emplacement-Rocket06-IDF", "Sys-CB-Tower01", "Emplacement-Howitzer105", "Emplacement-Rocket06-IDF", "Sys-SensoTower02"];
+	camQueueBuilding(CAM_THE_COLLECTIVE, list[camRand(list.length)], camMakePos("buildPos1"));
+	camQueueBuilding(CAM_THE_COLLECTIVE, list[camRand(list.length)], camMakePos("buildPos2"));
 }
 
 function southEastAttack()
@@ -117,17 +117,17 @@ function eventStartLevel()
 		reinforcements: camMinutesToSeconds(3)
 	});
 
-	let startpos = getObject("startPosition");
-	let lz = getObject("landingZone"); //player lz
-	let tent = getObject("transporterEntry");
-	let text = getObject("transporterExit");
-	centreView(startpos.x, startpos.y);
+	const startPos = getObject("startPosition");
+	const lz = getObject("landingZone"); //player lz
+	const tEnt = getObject("transporterEntry");
+	const tExt = getObject("transporterExit");
+	centreView(startPos.x, startPos.y);
 	setNoGoArea(lz.x, lz.y, lz.x2, lz.y2, CAM_HUMAN_PLAYER);
-	startTransporterEntry(tent.x, tent.y, CAM_HUMAN_PLAYER);
-	setTransporterExit(text.x, text.y, CAM_HUMAN_PLAYER);
+	startTransporterEntry(tEnt.x, tEnt.y, CAM_HUMAN_PLAYER);
+	setTransporterExit(tExt.x, tExt.y, CAM_HUMAN_PLAYER);
 
-	let enemyLz = getObject("COLandingZone");
-	setNoGoArea(enemyLz.x, enemyLz.y, enemyLz.x2, enemyLz.y2, THE_COLLECTIVE);
+	const enemyLz = getObject("COLandingZone");
+	setNoGoArea(enemyLz.x, enemyLz.y, enemyLz.x2, enemyLz.y2, CAM_THE_COLLECTIVE);
 
 	camSetArtifacts({
 		"COCyborgFactory-Arti": { tech: "R-Wpn-Rocket07-Tank-Killer" },
@@ -137,7 +137,7 @@ function eventStartLevel()
 		"COWhirlwindSite": { tech: "R-Wpn-AAGun04" },
 	});
 
-	camCompleteRequiredResearch(COLLECTIVE_RES, THE_COLLECTIVE);
+	camCompleteRequiredResearch(mis_collectiveRes, CAM_THE_COLLECTIVE);
 
 	camSetEnemyBases({
 		"COUplinkBase": {
@@ -239,9 +239,9 @@ function eventStartLevel()
 
 	if (difficulty >= HARD)
 	{
-		addDroid(THE_COLLECTIVE, 26, 27, "Truck Panther Tracks", "Body6SUPP", "tracked01", "", "", "Spade1Mk1");
-		addDroid(THE_COLLECTIVE, 42, 4, "Truck Panther Tracks", "Body6SUPP", "tracked01", "", "", "Spade1Mk1");
-		camManageTrucks(THE_COLLECTIVE);
+		addDroid(CAM_THE_COLLECTIVE, 26, 27, "Truck Panther Tracks", "Body6SUPP", "tracked01", "", "", "Spade1Mk1");
+		addDroid(CAM_THE_COLLECTIVE, 42, 4, "Truck Panther Tracks", "Body6SUPP", "tracked01", "", "", "Spade1Mk1");
+		camManageTrucks(CAM_THE_COLLECTIVE);
 		setTimer("truckDefense", camChangeOnDiff(camMinutesToMilliseconds(6)));
 	}
 

--- a/data/base/script/campaign/cam2-6.js
+++ b/data/base/script/campaign/cam2-6.js
@@ -46,7 +46,7 @@ function camEnemyBaseEliminated_COUplinkBase()
 //Group together attack droids in this base that are not already in a group
 function camEnemyBaseDetected_COMediumBase()
 {
-	var droids = enumArea("mediumBaseCleanup", THE_COLLECTIVE, false).filter((obj) => (
+	let droids = enumArea("mediumBaseCleanup", THE_COLLECTIVE, false).filter((obj) => (
 		obj.type === DROID && obj.group === null && obj.canHitGround
 	));
 
@@ -63,7 +63,7 @@ function truckDefense()
 		return;
 	}
 
-	var list = ["Emplacement-Howitzer105", "Emplacement-Rocket06-IDF", "Sys-CB-Tower01", "Emplacement-Howitzer105", "Emplacement-Rocket06-IDF", "Sys-SensoTower02"];
+	let list = ["Emplacement-Howitzer105", "Emplacement-Rocket06-IDF", "Sys-CB-Tower01", "Emplacement-Howitzer105", "Emplacement-Rocket06-IDF", "Sys-SensoTower02"];
 	camQueueBuilding(THE_COLLECTIVE, list[camRand(list.length)], camMakePos("buildPos1"));
 	camQueueBuilding(THE_COLLECTIVE, list[camRand(list.length)], camMakePos("buildPos2"));
 }
@@ -117,16 +117,16 @@ function eventStartLevel()
 		reinforcements: camMinutesToSeconds(3)
 	});
 
-	var startpos = getObject("startPosition");
-	var lz = getObject("landingZone"); //player lz
-	var tent = getObject("transporterEntry");
-	var text = getObject("transporterExit");
+	let startpos = getObject("startPosition");
+	let lz = getObject("landingZone"); //player lz
+	let tent = getObject("transporterEntry");
+	let text = getObject("transporterExit");
 	centreView(startpos.x, startpos.y);
 	setNoGoArea(lz.x, lz.y, lz.x2, lz.y2, CAM_HUMAN_PLAYER);
 	startTransporterEntry(tent.x, tent.y, CAM_HUMAN_PLAYER);
 	setTransporterExit(text.x, text.y, CAM_HUMAN_PLAYER);
 
-	var enemyLz = getObject("COLandingZone");
+	let enemyLz = getObject("COLandingZone");
 	setNoGoArea(enemyLz.x, enemyLz.y, enemyLz.x2, enemyLz.y2, THE_COLLECTIVE);
 
 	camSetArtifacts({

--- a/data/base/script/campaign/cam2-6s.js
+++ b/data/base/script/campaign/cam2-6s.js
@@ -5,7 +5,7 @@ function eventStartLevel()
 	camSetupTransporter(87, 100, 16, 126);
 	centreView(88, 101);
 	setNoGoArea(86, 99, 88, 101, CAM_HUMAN_PLAYER);
-	setNoGoArea(49, 83, 51, 85, THE_COLLECTIVE);
+	setNoGoArea(49, 83, 51, 85, CAM_THE_COLLECTIVE);
 	setMissionTime(camChangeOnDiff(camHoursToSeconds(1)));
 	camPlayVideos([{video: "MB2_6_MSG", type: CAMP_MSG}, {video: "MB2_6_MSG2", type: CAMP_MSG}, {video: "MB2_6_MSG3", type: MISS_MSG}]);
 	camSetStandardWinLossConditions(CAM_VICTORY_PRE_OFFWORLD, "SUB_2_6");

--- a/data/base/script/campaign/cam2-7.js
+++ b/data/base/script/campaign/cam2-7.js
@@ -1,7 +1,7 @@
 include("script/campaign/libcampaign.js");
 include("script/campaign/templates.js");
 
-const COLLECTIVE_RES = [
+const mis_collectiveRes = [
 	"R-Defense-WallUpgrade06", "R-Struc-Materials06", "R-Sys-Engineering02",
 	"R-Vehicle-Engine05", "R-Vehicle-Metals05", "R-Cyborg-Metals05",
 	"R-Wpn-Cannon-Accuracy02", "R-Wpn-Cannon-Damage06", "R-Wpn-Cannon-ROF03",
@@ -24,7 +24,7 @@ function camEnemyBaseDetected_COBase2()
 {
 	hackRemoveMessage("C27_OBJECTIVE2", PROX_MSG, CAM_HUMAN_PLAYER);
 
-	let vt = enumArea("COBase2Cleanup", THE_COLLECTIVE, false).filter((obj) => (
+	const vt = enumArea("COBase2Cleanup", CAM_THE_COLLECTIVE, false).filter((obj) => (
 		obj.type === DROID && isVTOL(obj)
 	));
 	camManageGroup(camMakeGroup(vt), CAM_ORDER_ATTACK, {
@@ -44,7 +44,7 @@ function camEnemyBaseDetected_COBase4()
 
 function baseThreeVtolAttack()
 {
-	let vt = enumArea("vtolGroupBase3", THE_COLLECTIVE, false).filter((obj) => (
+	const vt = enumArea("vtolGroupBase3", CAM_THE_COLLECTIVE, false).filter((obj) => (
 		obj.type === DROID && isVTOL(obj)
 	));
 	camManageGroup(camMakeGroup(vt), CAM_ORDER_ATTACK, {
@@ -54,7 +54,7 @@ function baseThreeVtolAttack()
 
 function baseFourVtolAttack()
 {
-	let vt = enumArea("vtolGroupBase4", THE_COLLECTIVE, false).filter((obj) => (
+	const vt = enumArea("vtolGroupBase4", CAM_THE_COLLECTIVE, false).filter((obj) => (
 		obj.type === DROID && isVTOL(obj)
 	));
 	camManageGroup(camMakeGroup(vt), CAM_ORDER_ATTACK, {
@@ -86,15 +86,15 @@ function enableFactoriesAndHovers()
 
 function truckDefense()
 {
-	if (enumDroid(THE_COLLECTIVE, DROID_CONSTRUCT).length === 0)
+	if (enumDroid(CAM_THE_COLLECTIVE, DROID_CONSTRUCT).length === 0)
 	{
 		removeTimer("truckDefense");
 		return;
 	}
 
-	let list = ["Emplacement-Howitzer105", "Emplacement-Rocket06-IDF", "Sys-CB-Tower01", "Emplacement-Howitzer105", "Emplacement-Rocket06-IDF", "Sys-SensoTower02"];
-	camQueueBuilding(THE_COLLECTIVE, list[camRand(list.length)], camMakePos("buildPos1"));
-	camQueueBuilding(THE_COLLECTIVE, list[camRand(list.length)], camMakePos("buildPos2"));
+	const list = ["Emplacement-Howitzer105", "Emplacement-Rocket06-IDF", "Sys-CB-Tower01", "Emplacement-Howitzer105", "Emplacement-Rocket06-IDF", "Sys-SensoTower02"];
+	camQueueBuilding(CAM_THE_COLLECTIVE, list[camRand(list.length)], camMakePos("buildPos1"));
+	camQueueBuilding(CAM_THE_COLLECTIVE, list[camRand(list.length)], camMakePos("buildPos2"));
 }
 
 function eventStartLevel()
@@ -106,17 +106,17 @@ function eventStartLevel()
 		reinforcements: camMinutesToSeconds(3)
 	});
 
-	let startpos = getObject("startPosition");
-	let lz = getObject("landingZone"); //player lz
-	let tent = getObject("transporterEntry");
-	let text = getObject("transporterExit");
-	centreView(startpos.x, startpos.y);
+	const startPos = getObject("startPosition");
+	const lz = getObject("landingZone"); //player lz
+	const tEnt = getObject("transporterEntry");
+	const tExt = getObject("transporterExit");
+	centreView(startPos.x, startPos.y);
 	setNoGoArea(lz.x, lz.y, lz.x2, lz.y2, CAM_HUMAN_PLAYER);
-	startTransporterEntry(tent.x, tent.y, CAM_HUMAN_PLAYER);
-	setTransporterExit(text.x, text.y, CAM_HUMAN_PLAYER);
+	startTransporterEntry(tEnt.x, tEnt.y, CAM_HUMAN_PLAYER);
+	setTransporterExit(tExt.x, tExt.y, CAM_HUMAN_PLAYER);
 
-	let enemyLz = getObject("COLandingZone");
-	setNoGoArea(enemyLz.x, enemyLz.y, enemyLz.x2, enemyLz.y2, THE_COLLECTIVE);
+	const enemyLz = getObject("COLandingZone");
+	setNoGoArea(enemyLz.x, enemyLz.y, enemyLz.x2, enemyLz.y2, CAM_THE_COLLECTIVE);
 
 	camSetArtifacts({
 		"COHeavyFac-Arti-b2": { tech: "R-Wpn-Cannon5" },
@@ -124,9 +124,9 @@ function eventStartLevel()
 		"COVtolFactory-b4": { tech: "R-Wpn-Bomb-Damage02" },
 	});
 
-	camCompleteRequiredResearch(COLLECTIVE_RES, THE_COLLECTIVE);
+	camCompleteRequiredResearch(mis_collectiveRes, CAM_THE_COLLECTIVE);
 
-	camUpgradeOnMapTemplates(cTempl.commc, cTempl.cohact, THE_COLLECTIVE);
+	camUpgradeOnMapTemplates(cTempl.commc, cTempl.cohact, CAM_THE_COLLECTIVE);
 
 	camSetEnemyBases({
 		"COBase1": {
@@ -239,9 +239,9 @@ function eventStartLevel()
 
 	if (difficulty >= MEDIUM)
 	{
-		addDroid(THE_COLLECTIVE, 55, 25, "Truck Panther Tracks", "Body6SUPP", "tracked01", "", "", "Spade1Mk1");
+		addDroid(CAM_THE_COLLECTIVE, 55, 25, "Truck Panther Tracks", "Body6SUPP", "tracked01", "", "", "Spade1Mk1");
 
-		camManageTrucks(THE_COLLECTIVE);
+		camManageTrucks(CAM_THE_COLLECTIVE);
 
 		setTimer("truckDefense", camChangeOnDiff(camMinutesToMilliseconds(4.5)));
 	}

--- a/data/base/script/campaign/cam2-7.js
+++ b/data/base/script/campaign/cam2-7.js
@@ -24,7 +24,7 @@ function camEnemyBaseDetected_COBase2()
 {
 	hackRemoveMessage("C27_OBJECTIVE2", PROX_MSG, CAM_HUMAN_PLAYER);
 
-	var vt = enumArea("COBase2Cleanup", THE_COLLECTIVE, false).filter((obj) => (
+	let vt = enumArea("COBase2Cleanup", THE_COLLECTIVE, false).filter((obj) => (
 		obj.type === DROID && isVTOL(obj)
 	));
 	camManageGroup(camMakeGroup(vt), CAM_ORDER_ATTACK, {
@@ -44,7 +44,7 @@ function camEnemyBaseDetected_COBase4()
 
 function baseThreeVtolAttack()
 {
-	var vt = enumArea("vtolGroupBase3", THE_COLLECTIVE, false).filter((obj) => (
+	let vt = enumArea("vtolGroupBase3", THE_COLLECTIVE, false).filter((obj) => (
 		obj.type === DROID && isVTOL(obj)
 	));
 	camManageGroup(camMakeGroup(vt), CAM_ORDER_ATTACK, {
@@ -54,7 +54,7 @@ function baseThreeVtolAttack()
 
 function baseFourVtolAttack()
 {
-	var vt = enumArea("vtolGroupBase4", THE_COLLECTIVE, false).filter((obj) => (
+	let vt = enumArea("vtolGroupBase4", THE_COLLECTIVE, false).filter((obj) => (
 		obj.type === DROID && isVTOL(obj)
 	));
 	camManageGroup(camMakeGroup(vt), CAM_ORDER_ATTACK, {
@@ -92,7 +92,7 @@ function truckDefense()
 		return;
 	}
 
-	var list = ["Emplacement-Howitzer105", "Emplacement-Rocket06-IDF", "Sys-CB-Tower01", "Emplacement-Howitzer105", "Emplacement-Rocket06-IDF", "Sys-SensoTower02"];
+	let list = ["Emplacement-Howitzer105", "Emplacement-Rocket06-IDF", "Sys-CB-Tower01", "Emplacement-Howitzer105", "Emplacement-Rocket06-IDF", "Sys-SensoTower02"];
 	camQueueBuilding(THE_COLLECTIVE, list[camRand(list.length)], camMakePos("buildPos1"));
 	camQueueBuilding(THE_COLLECTIVE, list[camRand(list.length)], camMakePos("buildPos2"));
 }
@@ -106,16 +106,16 @@ function eventStartLevel()
 		reinforcements: camMinutesToSeconds(3)
 	});
 
-	var startpos = getObject("startPosition");
-	var lz = getObject("landingZone"); //player lz
-	var tent = getObject("transporterEntry");
-	var text = getObject("transporterExit");
+	let startpos = getObject("startPosition");
+	let lz = getObject("landingZone"); //player lz
+	let tent = getObject("transporterEntry");
+	let text = getObject("transporterExit");
 	centreView(startpos.x, startpos.y);
 	setNoGoArea(lz.x, lz.y, lz.x2, lz.y2, CAM_HUMAN_PLAYER);
 	startTransporterEntry(tent.x, tent.y, CAM_HUMAN_PLAYER);
 	setTransporterExit(text.x, text.y, CAM_HUMAN_PLAYER);
 
-	var enemyLz = getObject("COLandingZone");
+	let enemyLz = getObject("COLandingZone");
 	setNoGoArea(enemyLz.x, enemyLz.y, enemyLz.x2, enemyLz.y2, THE_COLLECTIVE);
 
 	camSetArtifacts({

--- a/data/base/script/campaign/cam2-7s.js
+++ b/data/base/script/campaign/cam2-7s.js
@@ -5,7 +5,7 @@ function eventStartLevel()
 	camSetupTransporter(87, 100, 100, 1);
 	centreView(88, 101);
 	setNoGoArea(86, 99, 88, 101, CAM_HUMAN_PLAYER);
-	setNoGoArea(49, 83, 51, 85, THE_COLLECTIVE);
+	setNoGoArea(49, 83, 51, 85, CAM_THE_COLLECTIVE);
 	setMissionTime(camChangeOnDiff(camHoursToSeconds(1.5)));
 	camPlayVideos([{video: "MB2_7_MSG", type: CAMP_MSG}, {video: "MB2_7_MSG2", type: MISS_MSG}]);
 	camSetStandardWinLossConditions(CAM_VICTORY_PRE_OFFWORLD, "SUB_2_7");

--- a/data/base/script/campaign/cam2-8.js
+++ b/data/base/script/campaign/cam2-8.js
@@ -24,10 +24,10 @@ function vtolAttack()
 
 function setupLandGroups()
 {
-	var hovers = enumArea("NWTankGroup", THE_COLLECTIVE, false).filter((obj) => (
+	let hovers = enumArea("NWTankGroup", THE_COLLECTIVE, false).filter((obj) => (
 		obj.type === DROID && obj.propulsion === "hover01"
 	));
-	var tanks = enumArea("NWTankGroup", THE_COLLECTIVE, false).filter((obj) => (
+	let tanks = enumArea("NWTankGroup", THE_COLLECTIVE, false).filter((obj) => (
 		obj.type === DROID && obj.propulsion !== "hover01"
 	));
 
@@ -81,7 +81,7 @@ function truckDefense()
 		return;
 	}
 
-	var list = ["Emplacement-Rocket06-IDF", "Emplacement-Howitzer150", "CO-Tower-HvATRkt", "CO-Tower-HVCan", "Sys-CB-Tower01"];
+	let list = ["Emplacement-Rocket06-IDF", "Emplacement-Howitzer150", "CO-Tower-HvATRkt", "CO-Tower-HVCan", "Sys-CB-Tower01"];
 	camQueueBuilding(THE_COLLECTIVE, list[camRand(list.length)], camMakePos("buildPos1"));
 	camQueueBuilding(THE_COLLECTIVE, list[camRand(list.length)], camMakePos("buildPos2"));
 	camQueueBuilding(THE_COLLECTIVE, list[camRand(list.length)], camMakePos("buildPos3"));
@@ -95,16 +95,16 @@ function eventStartLevel()
 		annihilate: true
 	});
 
-	var startpos = getObject("startPosition");
-	var lz = getObject("landingZone"); //player lz
-	var tent = getObject("transporterEntry");
-	var text = getObject("transporterExit");
+	let startpos = getObject("startPosition");
+	let lz = getObject("landingZone"); //player lz
+	let tent = getObject("transporterEntry");
+	let text = getObject("transporterExit");
 	centreView(startpos.x, startpos.y);
 	setNoGoArea(lz.x, lz.y, lz.x2, lz.y2, CAM_HUMAN_PLAYER);
 	startTransporterEntry(tent.x, tent.y, CAM_HUMAN_PLAYER);
 	setTransporterExit(text.x, text.y, CAM_HUMAN_PLAYER);
 
-	var enemyLz = getObject("COLandingZone");
+	let enemyLz = getObject("COLandingZone");
 	setNoGoArea(enemyLz.x, enemyLz.y, enemyLz.x2, enemyLz.y2, THE_COLLECTIVE);
 
 	camSetArtifacts({

--- a/data/base/script/campaign/cam2-8.js
+++ b/data/base/script/campaign/cam2-8.js
@@ -1,7 +1,7 @@
 include("script/campaign/libcampaign.js");
 include("script/campaign/templates.js");
 
-const COLLECTIVE_RES = [
+const mis_collectiveRes = [
 	"R-Defense-WallUpgrade06", "R-Struc-Materials06", "R-Sys-Engineering02",
 	"R-Vehicle-Engine06", "R-Vehicle-Metals06", "R-Cyborg-Metals06",
 	"R-Wpn-Cannon-Accuracy02", "R-Wpn-Cannon-Damage06", "R-Wpn-Cannon-ROF03",
@@ -24,10 +24,10 @@ function vtolAttack()
 
 function setupLandGroups()
 {
-	let hovers = enumArea("NWTankGroup", THE_COLLECTIVE, false).filter((obj) => (
+	const hovers = enumArea("NWTankGroup", CAM_THE_COLLECTIVE, false).filter((obj) => (
 		obj.type === DROID && obj.propulsion === "hover01"
 	));
-	let tanks = enumArea("NWTankGroup", THE_COLLECTIVE, false).filter((obj) => (
+	const tanks = enumArea("NWTankGroup", CAM_THE_COLLECTIVE, false).filter((obj) => (
 		obj.type === DROID && obj.propulsion !== "hover01"
 	));
 
@@ -75,16 +75,16 @@ function enableFactories()
 
 function truckDefense()
 {
-	if (enumDroid(THE_COLLECTIVE, DROID_CONSTRUCT).length === 0)
+	if (enumDroid(CAM_THE_COLLECTIVE, DROID_CONSTRUCT).length === 0)
 	{
 		removeTimer("truckDefense");
 		return;
 	}
 
-	let list = ["Emplacement-Rocket06-IDF", "Emplacement-Howitzer150", "CO-Tower-HvATRkt", "CO-Tower-HVCan", "Sys-CB-Tower01"];
-	camQueueBuilding(THE_COLLECTIVE, list[camRand(list.length)], camMakePos("buildPos1"));
-	camQueueBuilding(THE_COLLECTIVE, list[camRand(list.length)], camMakePos("buildPos2"));
-	camQueueBuilding(THE_COLLECTIVE, list[camRand(list.length)], camMakePos("buildPos3"));
+	const list = ["Emplacement-Rocket06-IDF", "Emplacement-Howitzer150", "CO-Tower-HvATRkt", "CO-Tower-HVCan", "Sys-CB-Tower01"];
+	camQueueBuilding(CAM_THE_COLLECTIVE, list[camRand(list.length)], camMakePos("buildPos1"));
+	camQueueBuilding(CAM_THE_COLLECTIVE, list[camRand(list.length)], camMakePos("buildPos2"));
+	camQueueBuilding(CAM_THE_COLLECTIVE, list[camRand(list.length)], camMakePos("buildPos3"));
 }
 
 function eventStartLevel()
@@ -95,35 +95,35 @@ function eventStartLevel()
 		annihilate: true
 	});
 
-	let startpos = getObject("startPosition");
-	let lz = getObject("landingZone"); //player lz
-	let tent = getObject("transporterEntry");
-	let text = getObject("transporterExit");
-	centreView(startpos.x, startpos.y);
+	const startPos = getObject("startPosition");
+	const lz = getObject("landingZone"); //player lz
+	const tEnt = getObject("transporterEntry");
+	const tExt = getObject("transporterExit");
+	centreView(startPos.x, startPos.y);
 	setNoGoArea(lz.x, lz.y, lz.x2, lz.y2, CAM_HUMAN_PLAYER);
-	startTransporterEntry(tent.x, tent.y, CAM_HUMAN_PLAYER);
-	setTransporterExit(text.x, text.y, CAM_HUMAN_PLAYER);
+	startTransporterEntry(tEnt.x, tEnt.y, CAM_HUMAN_PLAYER);
+	setTransporterExit(tExt.x, tExt.y, CAM_HUMAN_PLAYER);
 
-	let enemyLz = getObject("COLandingZone");
-	setNoGoArea(enemyLz.x, enemyLz.y, enemyLz.x2, enemyLz.y2, THE_COLLECTIVE);
+	const enemyLz = getObject("COLandingZone");
+	setNoGoArea(enemyLz.x, enemyLz.y, enemyLz.x2, enemyLz.y2, CAM_THE_COLLECTIVE);
 
 	camSetArtifacts({
 		"COVtolFac-b3": { tech: "R-Vehicle-Body09" }, //Tiger body
 		"COHeavyFacL-b2": { tech: "R-Wpn-HvyHowitzer" },
 	});
 
-	camCompleteRequiredResearch(COLLECTIVE_RES, THE_COLLECTIVE);
+	camCompleteRequiredResearch(mis_collectiveRes, CAM_THE_COLLECTIVE);
 
-	camUpgradeOnMapTemplates(cTempl.commc, cTempl.cohhpv, THE_COLLECTIVE);
-	camUpgradeOnMapTemplates(cTempl.comtath, cTempl.comltath, THE_COLLECTIVE);
+	camUpgradeOnMapTemplates(cTempl.commc, cTempl.cohhpv, CAM_THE_COLLECTIVE);
+	camUpgradeOnMapTemplates(cTempl.comtath, cTempl.comltath, CAM_THE_COLLECTIVE);
 
 	//New AC Tiger tracked units for Hard and Insane difficulty
 	if (difficulty >= HARD)
 	{
-		addDroid(THE_COLLECTIVE, 30, 22, "AC Tiger Tracks", "Body9REC", "tracked01", "", "", "Cannon5VulcanMk1");
-		addDroid(THE_COLLECTIVE, 30, 23, "AC Tiger Tracks", "Body9REC", "tracked01", "", "", "Cannon5VulcanMk1");
-		addDroid(THE_COLLECTIVE, 31, 22, "AC Tiger Tracks", "Body9REC", "tracked01", "", "", "Cannon5VulcanMk1");
-		addDroid(THE_COLLECTIVE, 31, 23, "AC Tiger Tracks", "Body9REC", "tracked01", "", "", "Cannon5VulcanMk1");
+		addDroid(CAM_THE_COLLECTIVE, 30, 22, "AC Tiger Tracks", "Body9REC", "tracked01", "", "", "Cannon5VulcanMk1");
+		addDroid(CAM_THE_COLLECTIVE, 30, 23, "AC Tiger Tracks", "Body9REC", "tracked01", "", "", "Cannon5VulcanMk1");
+		addDroid(CAM_THE_COLLECTIVE, 31, 22, "AC Tiger Tracks", "Body9REC", "tracked01", "", "", "Cannon5VulcanMk1");
+		addDroid(CAM_THE_COLLECTIVE, 31, 23, "AC Tiger Tracks", "Body9REC", "tracked01", "", "", "Cannon5VulcanMk1");
 	}
 
 	camSetEnemyBases({
@@ -196,7 +196,7 @@ function eventStartLevel()
 		},
 	});
 
-	camManageTrucks(THE_COLLECTIVE);
+	camManageTrucks(CAM_THE_COLLECTIVE);
 
 	queue("setupLandGroups", camSecondsToMilliseconds(60));
 	queue("vtolAttack", camChangeOnDiff(camSecondsToMilliseconds((difficulty <= MEDIUM) ? 80 : 90)));

--- a/data/base/script/campaign/cam2-8s.js
+++ b/data/base/script/campaign/cam2-8s.js
@@ -5,7 +5,7 @@ function eventStartLevel()
 	camSetupTransporter(87, 100, 126, 60);
 	centreView(88, 101);
 	setNoGoArea(86, 99, 88, 101, CAM_HUMAN_PLAYER);
-	setNoGoArea(49, 83, 51, 85, THE_COLLECTIVE);
+	setNoGoArea(49, 83, 51, 85, CAM_THE_COLLECTIVE);
 	setMissionTime(camChangeOnDiff(camHoursToSeconds(1)));
 	camPlayVideos([{video: "MB2_8_MSG", type: CAMP_MSG}, {video: "MB2_8_MSG2", type: MISS_MSG}]);
 	camSetStandardWinLossConditions(CAM_VICTORY_PRE_OFFWORLD, "SUB_2_8");

--- a/data/base/script/campaign/cam2-a.js
+++ b/data/base/script/campaign/cam2-a.js
@@ -21,33 +21,32 @@ function secondVideo()
 //Damage the base and droids for the player
 function preDamageStuff()
 {
-	var droids = enumDroid(CAM_HUMAN_PLAYER);
-	var structures = enumStruct(CAM_HUMAN_PLAYER);
-	var x = 0;
+	let droids = enumDroid(CAM_HUMAN_PLAYER);
+	let structures = enumStruct(CAM_HUMAN_PLAYER);
 
-	for (x = 0; x < droids.length; ++x)
+	for (let x = 0; x < droids.length; ++x)
 	{
-		var droid = droids[x];
+		let droid = droids[x];
 		if (!camIsTransporter(droid))
 		{
 			setHealth(droid, 45 + camRand(20));
 		}
 	}
 
-	for (x = 0; x < structures.length; ++x)
+	for (let x = 0; x < structures.length; ++x)
 	{
-		var struc = structures[x];
+		let struc = structures[x];
 		setHealth(struc, 45 + camRand(45));
 	}
 }
 
 function getDroidsForCOLZ()
 {
-	var droids = [];
-	var count = 6 + camRand(5);
-	var templates;
-	var sensors = [cTempl.comsens, cTempl.comsens];
-	var usingHeavy = false;
+	let droids = [];
+	let count = 6 + camRand(5);
+	let templates;
+	let sensors = [cTempl.comsens, cTempl.comsens];
+	let usingHeavy = false;
 
 	if (camRand(100) < 50)
 	{
@@ -77,12 +76,12 @@ function getDroidsForCOLZ()
 //Send Collective transport units
 function sendCOTransporter()
 {
-	var tPos = getObject("COTransportPos");
-	var nearbyDefense = enumRange(tPos.x, tPos.y, 15, THE_COLLECTIVE, false);
+	let tPos = getObject("COTransportPos");
+	let nearbyDefense = enumRange(tPos.x, tPos.y, 15, THE_COLLECTIVE, false);
 
 	if (nearbyDefense.length > 0)
 	{
-		var list = getDroidsForCOLZ();
+		let list = getDroidsForCOLZ();
 		camSendReinforcement(THE_COLLECTIVE, camMakePos("COTransportPos"), list,
 			CAM_REINFORCE_TRANSPORT, {
 				entry: { x: 125, y: 100 },
@@ -136,10 +135,10 @@ function sendPlayerTransporter()
 //Continuously spawns heavy units on the north part of the map every 7 minutes
 function mapEdgeDroids()
 {
-	var TankNum = 8 + camRand(6);
-	var list = [cTempl.npcybm, cTempl.npcybr, cTempl.commrp, cTempl.cohct];
+	let TankNum = 8 + camRand(6);
+	let list = [cTempl.npcybm, cTempl.npcybr, cTempl.commrp, cTempl.cohct];
 
-	var droids = [];
+	let droids = [];
 	for (let i = 0; i < TankNum; ++i)
 	{
 		droids.push(list[camRand(list.length)]);
@@ -150,7 +149,7 @@ function mapEdgeDroids()
 
 function vtolAttack()
 {
-	var list = [cTempl.colcbv];
+	let list = [cTempl.colcbv];
 	camSetVtolData(THE_COLLECTIVE, "vtolAppearPos", "vtolRemoveZone", list, camChangeOnDiff(camMinutesToMilliseconds(3)), "COCommandCenter");
 }
 
@@ -313,11 +312,11 @@ function eventGameLoaded()
 function eventStartLevel()
 {
 	const PLAYER_POWER = 5000;
-	var startpos = getObject("startPosition");
-	var lz = getObject("landingZone"); //player lz
-	var enemyLz = getObject("COLandingZone");
-	var tent = getObject("transporterEntry");
-	var text = getObject("transporterExit");
+	let startpos = getObject("startPosition");
+	let lz = getObject("landingZone"); //player lz
+	let enemyLz = getObject("COLandingZone");
+	let tent = getObject("transporterEntry");
+	let text = getObject("transporterExit");
 
 	camSetStandardWinLossConditions(CAM_VICTORY_STANDARD, "SUB_2_1S");
 	setReinforcementTime(LZ_COMPROMISED_TIME);

--- a/data/base/script/campaign/cam2-a.js
+++ b/data/base/script/campaign/cam2-a.js
@@ -2,14 +2,14 @@ include("script/campaign/transitionTech.js");
 include("script/campaign/libcampaign.js");
 include("script/campaign/templates.js");
 
-const TRANSPORT_LIMIT = 4;
+const MIS_TRANSPORT_LIMIT = 4;
 var transporterIndex; //Number of transport loads sent into the level
 var startedFromMenu;
 
 camAreaEvent("vtolRemoveZone", function(droid)
 {
 	camSafeRemoveObject(droid, false);
-	resetLabel("vtolRemoveZone", THE_COLLECTIVE);
+	resetLabel("vtolRemoveZone", CAM_THE_COLLECTIVE);
 });
 
 //Attack and destroy all those who resist the Machine! -The Collective
@@ -21,12 +21,12 @@ function secondVideo()
 //Damage the base and droids for the player
 function preDamageStuff()
 {
-	let droids = enumDroid(CAM_HUMAN_PLAYER);
-	let structures = enumStruct(CAM_HUMAN_PLAYER);
+	const droids = enumDroid(CAM_HUMAN_PLAYER);
+	const structures = enumStruct(CAM_HUMAN_PLAYER);
 
 	for (let x = 0; x < droids.length; ++x)
 	{
-		let droid = droids[x];
+		const droid = droids[x];
 		if (!camIsTransporter(droid))
 		{
 			setHealth(droid, 45 + camRand(20));
@@ -35,17 +35,17 @@ function preDamageStuff()
 
 	for (let x = 0; x < structures.length; ++x)
 	{
-		let struc = structures[x];
+		const struc = structures[x];
 		setHealth(struc, 45 + camRand(45));
 	}
 }
 
 function getDroidsForCOLZ()
 {
-	let droids = [];
-	let count = 6 + camRand(5);
+	const droids = [];
+	const sensors = [cTempl.comsens, cTempl.comsens];
+	const COUNT = 6 + camRand(5);
 	let templates;
-	let sensors = [cTempl.comsens, cTempl.comsens];
 	let usingHeavy = false;
 
 	if (camRand(100) < 50)
@@ -58,7 +58,7 @@ function getDroidsForCOLZ()
 		usingHeavy = true;
 	}
 
-	for (let i = 0; i < count; ++i)
+	for (let i = 0; i < COUNT; ++i)
 	{
 		if (!i && usingHeavy)
 		{
@@ -76,13 +76,13 @@ function getDroidsForCOLZ()
 //Send Collective transport units
 function sendCOTransporter()
 {
-	let tPos = getObject("COTransportPos");
-	let nearbyDefense = enumRange(tPos.x, tPos.y, 15, THE_COLLECTIVE, false);
+	const tPos = getObject("COTransportPos");
+	const nearbyDefense = enumRange(tPos.x, tPos.y, 15, CAM_THE_COLLECTIVE, false);
 
 	if (nearbyDefense.length > 0)
 	{
-		let list = getDroidsForCOLZ();
-		camSendReinforcement(THE_COLLECTIVE, camMakePos("COTransportPos"), list,
+		const list = getDroidsForCOLZ();
+		camSendReinforcement(CAM_THE_COLLECTIVE, camMakePos("COTransportPos"), list,
 			CAM_REINFORCE_TRANSPORT, {
 				entry: { x: 125, y: 100 },
 				exit: { x: 125, y: 70 }
@@ -104,24 +104,24 @@ function sendPlayerTransporter()
 		transporterIndex = 0;
 	}
 
-	if (transporterIndex === TRANSPORT_LIMIT)
+	if (transporterIndex === MIS_TRANSPORT_LIMIT)
 	{
 		downTransporter();
 		return;
 	}
 
-	let droids = [];
-	let bodyList = ["Body11ABT", "Body11ABT", "Body12SUP"];
-	let propulsionList = ["tracked01", "tracked01", "tracked01", "hover01", "HalfTrack"];
-	let weaponList = ["Cannon375mmMk1", "Cannon375mmMk1", "Cannon375mmMk1", "Rocket-LtA-T", "Rocket-LtA-T", "Mortar2Mk1", "Rocket-MRL"];
-	let specialList = ["SensorTurret1Mk1", "CommandBrain01"];
+	const droids = [];
+	const bodyList = ["Body11ABT", "Body11ABT", "Body12SUP"];
+	const propulsionList = ["tracked01", "tracked01", "tracked01", "hover01", "HalfTrack"];
+	const weaponList = ["Cannon375mmMk1", "Cannon375mmMk1", "Cannon375mmMk1", "Rocket-LtA-T", "Rocket-LtA-T", "Mortar2Mk1", "Rocket-MRL"];
+	const specialList = ["SensorTurret1Mk1", "CommandBrain01"];
 
 	for (let i = 0; i < 10; ++i)
 	{
-		let body = bodyList[camRand(bodyList.length)];
-		let weap = (!transporterIndex && (i < specialList.length)) ? specialList[i] : weaponList[camRand(weaponList.length)];
-		let prop = propulsionList[camRand(propulsionList.length - ((weap === "Cannon375mmMk1") ? 1 : 0))]; //Ignore halftracks for Heavy Cannon.
-		droids.push({ body: body, prop: prop, weap: weap });
+		const BODY = bodyList[camRand(bodyList.length)];
+		const WEAP = (!transporterIndex && (i < specialList.length)) ? specialList[i] : weaponList[camRand(weaponList.length)];
+		const PROP = propulsionList[camRand(propulsionList.length - ((WEAP === "Cannon375mmMk1") ? 1 : 0))]; //Ignore halftracks for Heavy Cannon.
+		droids.push({ body: BODY, prop: PROP, weap: WEAP });
 	}
 
 	camSendReinforcement(CAM_HUMAN_PLAYER, camMakePos("landingZone"), droids,
@@ -135,22 +135,22 @@ function sendPlayerTransporter()
 //Continuously spawns heavy units on the north part of the map every 7 minutes
 function mapEdgeDroids()
 {
-	let TankNum = 8 + camRand(6);
-	let list = [cTempl.npcybm, cTempl.npcybr, cTempl.commrp, cTempl.cohct];
+	const TANK_NUM = 8 + camRand(6);
+	const list = [cTempl.npcybm, cTempl.npcybr, cTempl.commrp, cTempl.cohct];
 
-	let droids = [];
-	for (let i = 0; i < TankNum; ++i)
+	const droids = [];
+	for (let i = 0; i < TANK_NUM; ++i)
 	{
 		droids.push(list[camRand(list.length)]);
 	}
 
-	camSendReinforcement(THE_COLLECTIVE, camMakePos("groundUnitPos"), droids, CAM_REINFORCE_GROUND);
+	camSendReinforcement(CAM_THE_COLLECTIVE, camMakePos("groundUnitPos"), droids, CAM_REINFORCE_GROUND);
 }
 
 function vtolAttack()
 {
-	let list = [cTempl.colcbv];
-	camSetVtolData(THE_COLLECTIVE, "vtolAppearPos", "vtolRemoveZone", list, camChangeOnDiff(camMinutesToMilliseconds(3)), "COCommandCenter");
+	const list = [cTempl.colcbv];
+	camSetVtolData(CAM_THE_COLLECTIVE, "vtolAppearPos", "vtolRemoveZone", list, camChangeOnDiff(camMinutesToMilliseconds(3)), "COCommandCenter");
 }
 
 function groupPatrol()
@@ -178,20 +178,20 @@ function groupPatrol()
 //Build defenses around oil resource
 function truckDefense()
 {
-	if (enumDroid(THE_COLLECTIVE, DROID_CONSTRUCT).length === 0)
+	if (enumDroid(CAM_THE_COLLECTIVE, DROID_CONSTRUCT).length === 0)
 	{
 		removeTimer("truckDefense");
 		return;
 	}
 
-	const DEFENSES = ["CO-Tower-LtATRkt", "PillBox1", "CO-WallTower-HvCan"];
-	camQueueBuilding(THE_COLLECTIVE, DEFENSES[camRand(DEFENSES.length)]);
+	const defenses = ["CO-Tower-LtATRkt", "PillBox1", "CO-WallTower-HvCan"];
+	camQueueBuilding(CAM_THE_COLLECTIVE, defenses[camRand(defenses.length)]);
 }
 
 //Gives starting tech and research.
 function cam2Setup()
 {
-	const COLLECTIVE_RES = [
+	const collectiveRes = [
 		"R-Wpn-MG1Mk1", "R-Sys-Engineering02",
 		"R-Defense-WallUpgrade06", "R-Struc-Materials06",
 		"R-Vehicle-Engine03", "R-Vehicle-Metals03", "R-Cyborg-Metals03",
@@ -204,19 +204,19 @@ function cam2Setup()
 		"R-Wpn-RocketSlow-Damage04", "R-Sys-Sensor-Upgrade01"
 	];
 
-	for (let x = 0, l = STRUCTS_ALPHA.length; x < l; ++x)
+	for (let x = 0, l = mis_structsAlpha.length; x < l; ++x)
 	{
-		enableStructure(STRUCTS_ALPHA[x], CAM_HUMAN_PLAYER);
+		enableStructure(mis_structsAlpha[x], CAM_HUMAN_PLAYER);
 	}
 
-	camCompleteRequiredResearch(PLAYER_RES_BETA, CAM_HUMAN_PLAYER);
-	camCompleteRequiredResearch(ALPHA_RESEARCH_NEW, THE_COLLECTIVE);
-	camCompleteRequiredResearch(COLLECTIVE_RES, THE_COLLECTIVE);
-	camCompleteRequiredResearch(ALPHA_RESEARCH_NEW, CAM_HUMAN_PLAYER);
+	camCompleteRequiredResearch(mis_playerResBeta, CAM_HUMAN_PLAYER);
+	camCompleteRequiredResearch(mis_alphaResearchNew, CAM_THE_COLLECTIVE);
+	camCompleteRequiredResearch(collectiveRes, CAM_THE_COLLECTIVE);
+	camCompleteRequiredResearch(mis_alphaResearchNew, CAM_HUMAN_PLAYER);
 
 	if (difficulty >= HARD)
 	{
-		camUpgradeOnMapTemplates(cTempl.commc, cTempl.commrp, THE_COLLECTIVE);
+		camUpgradeOnMapTemplates(cTempl.commc, cTempl.commrp, CAM_THE_COLLECTIVE);
 	}
 
 	enableResearch("R-Wpn-Cannon-Damage04", CAM_HUMAN_PLAYER);
@@ -227,7 +227,7 @@ function cam2Setup()
 //Get some higher rank droids.
 function setUnitRank(transport)
 {
-	const DROID_EXP = [128, 64, 32, 16];
+	const droidExp = [128, 64, 32, 16];
 	let droids;
 	let mapRun = false;
 
@@ -244,11 +244,11 @@ function setUnitRank(transport)
 
 	for (let i = 0, len = droids.length; i < len; ++i)
 	{
-		let droid = droids[i];
+		const droid = droids[i];
 		if (droid.droidType !== DROID_CONSTRUCT && droid.droidType !== DROID_REPAIR)
 		{
-			let mod = (droid.droidType === DROID_COMMAND || droid.droidType === DROID_SENSOR) ? 2 : 1;
-			setDroidExperience(droid, mod * DROID_EXP[mapRun ? 0 : (transporterIndex - 1)]);
+			const MOD = (droid.droidType === DROID_COMMAND || droid.droidType === DROID_SENSOR) ? 2 : 1;
+			setDroidExperience(droid, MOD * droidExp[mapRun ? 0 : (transporterIndex - 1)]);
 		}
 	}
 }
@@ -270,7 +270,7 @@ function eventTransporterLanded(transport)
 			setUnitRank(transport);
 		}
 
-		if (transporterIndex >= TRANSPORT_LIMIT)
+		if (transporterIndex >= MIS_TRANSPORT_LIMIT)
 		{
 			queue("downTransporter", camMinutesToMilliseconds(1));
 		}
@@ -295,7 +295,7 @@ function downTransporter()
 
 function eventTransporterLaunch(transport)
 {
-	if (transporterIndex >= TRANSPORT_LIMIT)
+	if (transporterIndex >= MIS_TRANSPORT_LIMIT)
 	{
 		queue("downTransporter", camMinutesToMilliseconds(1));
 	}
@@ -303,7 +303,7 @@ function eventTransporterLaunch(transport)
 
 function eventGameLoaded()
 {
-	if (transporterIndex >= TRANSPORT_LIMIT)
+	if (transporterIndex >= MIS_TRANSPORT_LIMIT)
 	{
 		setReinforcementTime(LZ_COMPROMISED_TIME);
 	}
@@ -312,20 +312,20 @@ function eventGameLoaded()
 function eventStartLevel()
 {
 	const PLAYER_POWER = 5000;
-	let startpos = getObject("startPosition");
-	let lz = getObject("landingZone"); //player lz
-	let enemyLz = getObject("COLandingZone");
-	let tent = getObject("transporterEntry");
-	let text = getObject("transporterExit");
+	const startPos = getObject("startPosition");
+	const lz = getObject("landingZone"); //player lz
+	const enemyLz = getObject("COLandingZone");
+	const tEnt = getObject("transporterEntry");
+	const tExt = getObject("transporterExit");
 
 	camSetStandardWinLossConditions(CAM_VICTORY_STANDARD, "SUB_2_1S");
 	setReinforcementTime(LZ_COMPROMISED_TIME);
 
-	centreView(startpos.x, startpos.y);
+	centreView(startPos.x, startPos.y);
 	setNoGoArea(lz.x, lz.y, lz.x2, lz.y2, CAM_HUMAN_PLAYER);
 	setNoGoArea(enemyLz.x, enemyLz.y, enemyLz.x2, enemyLz.y2, 5);
-	startTransporterEntry(tent.x, tent.y, CAM_HUMAN_PLAYER);
-	setTransporterExit(text.x, text.y, CAM_HUMAN_PLAYER);
+	startTransporterEntry(tEnt.x, tEnt.y, CAM_HUMAN_PLAYER);
+	setTransporterExit(tExt.x, tExt.y, CAM_HUMAN_PLAYER);
 
 	camSetArtifacts({
 		"COCommandCenter": { tech: "R-Sys-Engineering02" },
@@ -353,7 +353,7 @@ function eventStartLevel()
 		},
 	});
 
-	camManageTrucks(THE_COLLECTIVE);
+	camManageTrucks(CAM_THE_COLLECTIVE);
 	setUnitRank(); //All pre-placed player droids are ranked.
 	camPlayVideos({video: "MB2A_MSG", type: MISS_MSG});
 	startedFromMenu = false;

--- a/data/base/script/campaign/cam2-b.js
+++ b/data/base/script/campaign/cam2-b.js
@@ -34,7 +34,7 @@ function camEnemyBaseDetected_COMiddleBase()
 {
 	hackRemoveMessage("C2B_OBJ1", PROX_MSG, CAM_HUMAN_PLAYER);
 
-	var droids = enumArea("base4Cleanup", THE_COLLECTIVE, false).filter((obj) => (
+	let droids = enumArea("base4Cleanup", THE_COLLECTIVE, false).filter((obj) => (
 		obj.type === DROID && obj.group === null
 	));
 
@@ -84,8 +84,8 @@ function ambushPlayer()
 
 function vtolAttack()
 {
-	var list = [cTempl.colcbv, cTempl.colatv];
-	var ext = {
+	let list = [cTempl.colcbv, cTempl.colatv];
+	let ext = {
 		limit: [4, 4], //paired with list array
 		alternate: true,
 		altIdx: 0
@@ -116,12 +116,12 @@ function eventStartLevel()
 {
 	camSetStandardWinLossConditions(CAM_VICTORY_STANDARD, "SUB_2_2S");
 
-	var startpos = getObject("startPosition");
-	var lz = getObject("landingZone"); //player lz
+	let startpos = getObject("startPosition");
+	let lz = getObject("landingZone"); //player lz
 	centreView(startpos.x, startpos.y);
 	setNoGoArea(lz.x, lz.y, lz.x2, lz.y2, CAM_HUMAN_PLAYER);
 
-	var enemyLz = getObject("COLandingZone");
+	let enemyLz = getObject("COLandingZone");
 	setNoGoArea(enemyLz.x, enemyLz.y, enemyLz.x2, enemyLz.y2, THE_COLLECTIVE);
 
 	setMissionTime(camChangeOnDiff(camHoursToSeconds(2)));

--- a/data/base/script/campaign/cam2-b.js
+++ b/data/base/script/campaign/cam2-b.js
@@ -1,7 +1,7 @@
 include("script/campaign/libcampaign.js");
 include("script/campaign/templates.js");
 
-const COLLECTIVE_RES = [
+const mis_collectiveRes = [
 	"R-Defense-WallUpgrade06", "R-Struc-Materials06", "R-Sys-Engineering02",
 	"R-Vehicle-Engine04", "R-Vehicle-Metals04", "R-Cyborg-Metals04",
 	"R-Wpn-Cannon-Accuracy02", "R-Wpn-Cannon-Damage05",
@@ -19,7 +19,7 @@ camAreaEvent("vtolRemoveZone", function(droid)
 	{
 		camSafeRemoveObject(droid, false);
 	}
-	resetLabel("vtolRemoveZone", THE_COLLECTIVE);
+	resetLabel("vtolRemoveZone", CAM_THE_COLLECTIVE);
 });
 
 camAreaEvent("factoryTrigger", function(droid)
@@ -34,7 +34,7 @@ function camEnemyBaseDetected_COMiddleBase()
 {
 	hackRemoveMessage("C2B_OBJ1", PROX_MSG, CAM_HUMAN_PLAYER);
 
-	let droids = enumArea("base4Cleanup", THE_COLLECTIVE, false).filter((obj) => (
+	const droids = enumArea("base4Cleanup", CAM_THE_COLLECTIVE, false).filter((obj) => (
 		obj.type === DROID && obj.group === null
 	));
 
@@ -84,25 +84,25 @@ function ambushPlayer()
 
 function vtolAttack()
 {
-	let list = [cTempl.colcbv, cTempl.colatv];
-	let ext = {
+	const list = [cTempl.colcbv, cTempl.colatv];
+	const ext = {
 		limit: [4, 4], //paired with list array
 		alternate: true,
 		altIdx: 0
 	};
-	camSetVtolData(THE_COLLECTIVE, "vtolAppearPos", "vtolRemove", list, camChangeOnDiff(camMinutesToMilliseconds(5)), "COCommandCenter", ext);
+	camSetVtolData(CAM_THE_COLLECTIVE, "vtolAppearPos", "vtolRemove", list, camChangeOnDiff(camMinutesToMilliseconds(5)), "COCommandCenter", ext);
 }
 
 function truckDefense()
 {
-	if (enumDroid(THE_COLLECTIVE, DROID_CONSTRUCT).length === 0)
+	if (enumDroid(CAM_THE_COLLECTIVE, DROID_CONSTRUCT).length === 0)
 	{
 		removeTimer("truckDefense");
 		return;
 	}
 
 	const list = ["CO-Tower-MG3", "CO-Tower-LtATRkt", "CO-WallTower-HvCan", "CO-Tower-LtATRkt"];
-	camQueueBuilding(THE_COLLECTIVE, list[camRand(list.length)]);
+	camQueueBuilding(CAM_THE_COLLECTIVE, list[camRand(list.length)]);
 }
 
 function transferPower()
@@ -116,13 +116,13 @@ function eventStartLevel()
 {
 	camSetStandardWinLossConditions(CAM_VICTORY_STANDARD, "SUB_2_2S");
 
-	let startpos = getObject("startPosition");
-	let lz = getObject("landingZone"); //player lz
-	centreView(startpos.x, startpos.y);
+	const startPos = getObject("startPosition");
+	const lz = getObject("landingZone"); //player lz
+	centreView(startPos.x, startPos.y);
 	setNoGoArea(lz.x, lz.y, lz.x2, lz.y2, CAM_HUMAN_PLAYER);
 
-	let enemyLz = getObject("COLandingZone");
-	setNoGoArea(enemyLz.x, enemyLz.y, enemyLz.x2, enemyLz.y2, THE_COLLECTIVE);
+	const enemyLz = getObject("COLandingZone");
+	setNoGoArea(enemyLz.x, enemyLz.y, enemyLz.x2, enemyLz.y2, CAM_THE_COLLECTIVE);
 
 	setMissionTime(camChangeOnDiff(camHoursToSeconds(2)));
 	camPlayVideos([{video: "MB2_B_MSG", type: CAMP_MSG}, {video: "MB2_B_MSG2", type: MISS_MSG}]);
@@ -136,17 +136,17 @@ function eventStartLevel()
 		"COBombardPit": { tech: "R-Wpn-Mortar-Damage04" },
 	});
 
-	camCompleteRequiredResearch(COLLECTIVE_RES, THE_COLLECTIVE);
+	camCompleteRequiredResearch(mis_collectiveRes, CAM_THE_COLLECTIVE);
 
 	if (difficulty >= MEDIUM)
 	{
-		camUpgradeOnMapTemplates(cTempl.commc, cTempl.commrp, THE_COLLECTIVE);
+		camUpgradeOnMapTemplates(cTempl.commc, cTempl.commrp, CAM_THE_COLLECTIVE);
 	}
 
 	// New HMG Tiger Tracks units in first attack group
-	addDroid(THE_COLLECTIVE, 92, 59, "Heavy Machinegun Tiger Tracks", "Body9REC", "tracked01", "", "", "MG3Mk1");
-	addDroid(THE_COLLECTIVE, 96, 59, "Heavy Machinegun Tiger Tracks", "Body9REC", "tracked01", "", "", "MG3Mk1");
-	addDroid(THE_COLLECTIVE, 97, 59, "Heavy Machinegun Tiger Tracks", "Body9REC", "tracked01", "", "", "MG3Mk1");
+	addDroid(CAM_THE_COLLECTIVE, 92, 59, "Heavy Machinegun Tiger Tracks", "Body9REC", "tracked01", "", "", "MG3Mk1");
+	addDroid(CAM_THE_COLLECTIVE, 96, 59, "Heavy Machinegun Tiger Tracks", "Body9REC", "tracked01", "", "", "MG3Mk1");
+	addDroid(CAM_THE_COLLECTIVE, 97, 59, "Heavy Machinegun Tiger Tracks", "Body9REC", "tracked01", "", "", "MG3Mk1");
 
 	camSetEnemyBases({
 		"CONorthBase": {
@@ -244,7 +244,7 @@ function eventStartLevel()
 		},
 	});
 
-	camManageTrucks(THE_COLLECTIVE);
+	camManageTrucks(CAM_THE_COLLECTIVE);
 	hackAddMessage("C2B_OBJ1", PROX_MSG, CAM_HUMAN_PLAYER, false);
 
 	camEnableFactory("COHeavyFac-b4");

--- a/data/base/script/campaign/cam2-c.js
+++ b/data/base/script/campaign/cam2-c.js
@@ -50,7 +50,7 @@ camAreaEvent("base3Trigger", function(droid)
 //Send idle droids in this base to attack when the player spots the base
 function camEnemyBaseDetected_COAirBase()
 {
-	var droids = enumArea("airBaseCleanup", THE_COLLECTIVE, false).filter((obj) => (
+	let droids = enumArea("airBaseCleanup", THE_COLLECTIVE, false).filter((obj) => (
 		obj.type === DROID && obj.group === null
 	));
 
@@ -134,35 +134,34 @@ function truckDefense()
 //when all of the shepard group members are destroyed).
 function captureCivilians()
 {
-	var wayPoints = [
+	let wayPoints = [
 		"civPoint1", "civPoint2", "civPoint3", "civPoint4",
 		"civPoint5", "civPoint6", "civPoint7", "civCapturePos"
 	];
-	var currPos = getObject(wayPoints[civilianPosIndex]);
-	var shepardDroids = enumGroup(shepardGroup);
+	let currPos = getObject(wayPoints[civilianPosIndex]);
+	let shepardDroids = enumGroup(shepardGroup);
 
 	if (shepardDroids.length > 0)
 	{
 		//add some civs
-		var i = 0;
-		var num = 1 + camRand(3);
-		for (i = 0; i < num; ++i)
+		let num = 1 + camRand(3);
+		for (let i = 0; i < num; ++i)
 		{
 			addDroid(SCAV_7, currPos.x, currPos.y, "Civilian",
 					"B1BaBaPerson01", "BaBaLegs", "", "", "BabaMG");
 		}
 
 		//Only count civilians that are not in the the transporter base.
-		var civs = enumArea(0, 0, 35, mapHeight, SCAV_7, false);
+		let civs = enumArea(0, 0, 35, mapHeight, SCAV_7, false);
 		//Move them
-		for (i = 0; i < civs.length; ++i)
+		for (let i = 0; i < civs.length; ++i)
 		{
 			orderDroidLoc(civs[i], DORDER_MOVE, currPos.x, currPos.y);
 		}
 
 		if (civilianPosIndex <= 5)
 		{
-			for (i = 0; i < shepardDroids.length; ++i)
+			for (let i = 0; i < shepardDroids.length; ++i)
 			{
 				orderDroidLoc(shepardDroids[i], DORDER_MOVE, currPos.x, currPos.y);
 			}
@@ -184,15 +183,15 @@ function captureCivilians()
 //before removal.
 function civilianOrders()
 {
-	var lz = getObject("startPosition");
-	var rescueSound = "pcv612.ogg";	//"Civilian Rescued".
-	var civs = enumDroid(SCAV_7);
-	var rescued = false;
+	let lz = getObject("startPosition");
+	let rescueSound = "pcv612.ogg";	//"Civilian Rescued".
+	let civs = enumDroid(SCAV_7);
+	let rescued = false;
 
 	//Check if a civilian is close to a player droid.
 	for (let i = 0; i < civs.length; ++i)
 	{
-		var objs = enumRange(civs[i].x, civs[i].y, 6, CAM_HUMAN_PLAYER, false);
+		let objs = enumRange(civs[i].x, civs[i].y, 6, CAM_HUMAN_PLAYER, false);
 		for (let j = 0; j < objs.length; ++j)
 		{
 			if (objs[j].type === DROID)
@@ -215,9 +214,9 @@ function civilianOrders()
 //Capture civilans.
 function eventTransporterLanded(transport)
 {
-	var escaping = "pcv632.ogg"; //"Enemy escaping".
-	var position = getObject("COTransportPos");
-	var civs = enumRange(position.x, position.y, 15, SCAV_7, false);
+	let escaping = "pcv632.ogg"; //"Enemy escaping".
+	let position = getObject("COTransportPos");
+	let civs = enumRange(position.x, position.y, 15, SCAV_7, false);
 
 	if (civs.length)
 	{
@@ -233,9 +232,9 @@ function eventTransporterLanded(transport)
 //Send Collective transport as long as the player has not entered the base.
 function sendCOTransporter()
 {
-	var list = [cTempl.npcybr, cTempl.npcybr];
-	var tPos = getObject("COTransportPos");
-	var pDroid = enumRange(tPos.x, tPos.y, 6, CAM_HUMAN_PLAYER, false);
+	let list = [cTempl.npcybr, cTempl.npcybr];
+	let tPos = getObject("COTransportPos");
+	let pDroid = enumRange(tPos.x, tPos.y, 6, CAM_HUMAN_PLAYER, false);
 
 	if (!pDroid.length)
 	{
@@ -260,8 +259,8 @@ function extraVictoryCondition()
 	}
 	else
 	{
-		var lz = getObject("startPosition");
-		var civs = enumRange(lz.x, lz.y, 30, SCAV_7, false);
+		let lz = getObject("startPosition");
+		let civs = enumRange(lz.x, lz.y, 30, SCAV_7, false);
 
 		for (let i = 0; i < civs.length; ++i)
 		{
@@ -279,12 +278,12 @@ function eventStartLevel()
 		callback: "extraVictoryCondition"
 	});
 
-	var startpos = getObject("startPosition");
-	var lz = getObject("landingZone"); //player lz
+	let startpos = getObject("startPosition");
+	let lz = getObject("landingZone"); //player lz
 	centreView(startpos.x, startpos.y);
 	setNoGoArea(lz.x, lz.y, lz.x2, lz.y2, CAM_HUMAN_PLAYER);
 
-	var enemyLz = getObject("COLandingZone");
+	let enemyLz = getObject("COLandingZone");
 	setNoGoArea(enemyLz.x, enemyLz.y, enemyLz.x2, enemyLz.y2, 5);
 
 	camSetArtifacts({

--- a/data/base/script/campaign/cam2-c.js
+++ b/data/base/script/campaign/cam2-c.js
@@ -6,7 +6,7 @@ var capturedCivCount; //How many civilians have been captured. 59 for defeat.
 var civilianPosIndex; //Current location of civilian groups.
 var shepardGroup; //Enemy group that protects civilians.
 var lastSoundTime; //Only play the "civilian rescued" sound every so often.
-const COLLECTIVE_RES = [
+const mis_collectiveRes = [
 	"R-Defense-WallUpgrade06", "R-Struc-Materials06", "R-Sys-Engineering02",
 	"R-Vehicle-Engine04", "R-Vehicle-Metals05", "R-Cyborg-Metals05",
 	"R-Wpn-Cannon-Accuracy02", "R-Wpn-Cannon-Damage05", "R-Wpn-Cannon-ROF01",
@@ -50,7 +50,7 @@ camAreaEvent("base3Trigger", function(droid)
 //Send idle droids in this base to attack when the player spots the base
 function camEnemyBaseDetected_COAirBase()
 {
-	let droids = enumArea("airBaseCleanup", THE_COLLECTIVE, false).filter((obj) => (
+	const droids = enumArea("airBaseCleanup", CAM_THE_COLLECTIVE, false).filter((obj) => (
 		obj.type === DROID && obj.group === null
 	));
 
@@ -119,14 +119,14 @@ function activateGroups()
 
 function truckDefense()
 {
-	if (enumDroid(THE_COLLECTIVE, DROID_CONSTRUCT).length === 0)
+	if (enumDroid(CAM_THE_COLLECTIVE, DROID_CONSTRUCT).length === 0)
 	{
 		removeTimer("truckDefense");
 		return;
 	}
 
-	const LIST = ["CO-Tower-LtATRkt", "PillBox1", "CO-WallTower-HvCan"];
-	camQueueBuilding(THE_COLLECTIVE, LIST[camRand(LIST.length)]);
+	const list = ["CO-Tower-LtATRkt", "PillBox1", "CO-WallTower-HvCan"];
+	camQueueBuilding(CAM_THE_COLLECTIVE, list[camRand(list.length)]);
 }
 
 //This controls the collective cyborg shepard groups and moving civilians
@@ -134,25 +134,25 @@ function truckDefense()
 //when all of the shepard group members are destroyed).
 function captureCivilians()
 {
-	let wayPoints = [
+	const wayPoints = [
 		"civPoint1", "civPoint2", "civPoint3", "civPoint4",
 		"civPoint5", "civPoint6", "civPoint7", "civCapturePos"
 	];
-	let currPos = getObject(wayPoints[civilianPosIndex]);
-	let shepardDroids = enumGroup(shepardGroup);
+	const currPos = getObject(wayPoints[civilianPosIndex]);
+	const shepardDroids = enumGroup(shepardGroup);
 
 	if (shepardDroids.length > 0)
 	{
 		//add some civs
-		let num = 1 + camRand(3);
-		for (let i = 0; i < num; ++i)
+		const NUM = 1 + camRand(3);
+		for (let i = 0; i < NUM; ++i)
 		{
-			addDroid(SCAV_7, currPos.x, currPos.y, "Civilian",
+			addDroid(CAM_SCAV_7, currPos.x, currPos.y, "Civilian",
 					"B1BaBaPerson01", "BaBaLegs", "", "", "BabaMG");
 		}
 
 		//Only count civilians that are not in the the transporter base.
-		let civs = enumArea(0, 0, 35, mapHeight, SCAV_7, false);
+		const civs = enumArea(0, 0, 35, mapHeight, CAM_SCAV_7, false);
 		//Move them
 		for (let i = 0; i < civs.length; ++i)
 		{
@@ -183,15 +183,14 @@ function captureCivilians()
 //before removal.
 function civilianOrders()
 {
-	let lz = getObject("startPosition");
-	let rescueSound = "pcv612.ogg";	//"Civilian Rescued".
-	let civs = enumDroid(SCAV_7);
+	const lz = getObject("startPosition");
+	const civs = enumDroid(CAM_SCAV_7);
 	let rescued = false;
 
 	//Check if a civilian is close to a player droid.
 	for (let i = 0; i < civs.length; ++i)
 	{
-		let objs = enumRange(civs[i].x, civs[i].y, 6, CAM_HUMAN_PLAYER, false);
+		const objs = enumRange(civs[i].x, civs[i].y, 6, CAM_HUMAN_PLAYER, false);
 		for (let j = 0; j < objs.length; ++j)
 		{
 			if (objs[j].type === DROID)
@@ -206,21 +205,22 @@ function civilianOrders()
 	//Play the "Civilian rescued" sound and throttle it.
 	if (rescued && ((lastSoundTime + camSecondsToMilliseconds(30)) < gameTime))
 	{
+		const RESCUE_SND = "pcv612.ogg";	//"Civilian Rescued".
 		lastSoundTime = gameTime;
-		playSound(rescueSound);
+		playSound(RESCUE_SND);
 	}
 }
 
 //Capture civilans.
 function eventTransporterLanded(transport)
 {
-	let escaping = "pcv632.ogg"; //"Enemy escaping".
-	let position = getObject("COTransportPos");
-	let civs = enumRange(position.x, position.y, 15, SCAV_7, false);
+	const position = getObject("COTransportPos");
+	const civs = enumRange(position.x, position.y, 15, CAM_SCAV_7, false);
 
 	if (civs.length)
 	{
-		playSound(escaping);
+		const ESCAPE_SND = "pcv632.ogg"; //"Enemy escaping".
+		playSound(ESCAPE_SND);
 		capturedCivCount += civs.length - 1;
 		for (let i = 0; i < civs.length; ++i)
 		{
@@ -232,13 +232,13 @@ function eventTransporterLanded(transport)
 //Send Collective transport as long as the player has not entered the base.
 function sendCOTransporter()
 {
-	let list = [cTempl.npcybr, cTempl.npcybr];
-	let tPos = getObject("COTransportPos");
-	let pDroid = enumRange(tPos.x, tPos.y, 6, CAM_HUMAN_PLAYER, false);
+	const list = [cTempl.npcybr, cTempl.npcybr];
+	const tPos = getObject("COTransportPos");
+	const pDroid = enumRange(tPos.x, tPos.y, 6, CAM_HUMAN_PLAYER, false);
 
 	if (!pDroid.length)
 	{
-		camSendReinforcement(THE_COLLECTIVE, camMakePos("COTransportPos"), list,
+		camSendReinforcement(CAM_THE_COLLECTIVE, camMakePos("COTransportPos"), list,
 			CAM_REINFORCE_TRANSPORT, {
 				entry: { x: 2, y: 80 },
 				exit: { x: 2, y: 80 }
@@ -259,8 +259,8 @@ function extraVictoryCondition()
 	}
 	else
 	{
-		let lz = getObject("startPosition");
-		let civs = enumRange(lz.x, lz.y, 30, SCAV_7, false);
+		const lz = getObject("startPosition");
+		const civs = enumRange(lz.x, lz.y, 30, CAM_SCAV_7, false);
 
 		for (let i = 0; i < civs.length; ++i)
 		{
@@ -278,12 +278,12 @@ function eventStartLevel()
 		callback: "extraVictoryCondition"
 	});
 
-	let startpos = getObject("startPosition");
-	let lz = getObject("landingZone"); //player lz
-	centreView(startpos.x, startpos.y);
+	const startPos = getObject("startPosition");
+	const lz = getObject("landingZone"); //player lz
+	centreView(startPos.x, startPos.y);
 	setNoGoArea(lz.x, lz.y, lz.x2, lz.y2, CAM_HUMAN_PLAYER);
 
-	let enemyLz = getObject("COLandingZone");
+	const enemyLz = getObject("COLandingZone");
 	setNoGoArea(enemyLz.x, enemyLz.y, enemyLz.x2, enemyLz.y2, 5);
 
 	camSetArtifacts({
@@ -298,13 +298,13 @@ function eventStartLevel()
 
 	setMissionTime(camChangeOnDiff(camHoursToSeconds(2)));
 
-	setAlliance(THE_COLLECTIVE, SCAV_7, true);
-	setAlliance(CAM_HUMAN_PLAYER, SCAV_7, true);
-	camCompleteRequiredResearch(COLLECTIVE_RES, THE_COLLECTIVE);
+	setAlliance(CAM_THE_COLLECTIVE, CAM_SCAV_7, true);
+	setAlliance(CAM_HUMAN_PLAYER, CAM_SCAV_7, true);
+	camCompleteRequiredResearch(mis_collectiveRes, CAM_THE_COLLECTIVE);
 
 	if (difficulty >= MEDIUM)
 	{
-		camUpgradeOnMapTemplates(cTempl.commc, cTempl.commrp, THE_COLLECTIVE);
+		camUpgradeOnMapTemplates(cTempl.commc, cTempl.commrp, CAM_THE_COLLECTIVE);
 	}
 
 	camSetEnemyBases({
@@ -399,7 +399,7 @@ function eventStartLevel()
 		},
 	});
 
-	camManageTrucks(THE_COLLECTIVE);
+	camManageTrucks(CAM_THE_COLLECTIVE);
 	capturedCivCount = 0;
 	civilianPosIndex = 0;
 	lastSoundTime = 0;

--- a/data/base/script/campaign/cam2-d.js
+++ b/data/base/script/campaign/cam2-d.js
@@ -35,14 +35,14 @@ function truckDefense()
 		return;
 	}
 
-	var list = ["AASite-QuadBof", "CO-WallTower-HvCan", "CO-Tower-RotMG", "CO-Tower-HvFlame"];
+	let list = ["AASite-QuadBof", "CO-WallTower-HvCan", "CO-Tower-RotMG", "CO-Tower-HvFlame"];
 	camQueueBuilding(THE_COLLECTIVE, list[camRand(list.length)], camMakePos("uplinkPos"));
 }
 
 //Attacks every 2 minutes until HQ is destroyed.
 function vtolAttack()
 {
-	var list = [cTempl.colatv, cTempl.commorvt];
+	let list = [cTempl.colatv, cTempl.commorvt];
 	camSetVtolData(THE_COLLECTIVE, "vtolAppearPos", "vtolRemovePos", list, camChangeOnDiff(camMinutesToMilliseconds(2)), "COCommandCenter");
 }
 
@@ -82,16 +82,16 @@ function eventStartLevel()
 		retlz: true
 	});
 
-	var startpos = getObject("startPosition");
-	var lz = getObject("landingZone"); //player lz
-	var tent = getObject("transporterEntry");
-	var text = getObject("transporterExit");
+	let startpos = getObject("startPosition");
+	let lz = getObject("landingZone"); //player lz
+	let tent = getObject("transporterEntry");
+	let text = getObject("transporterExit");
 	centreView(startpos.x, startpos.y);
 	setNoGoArea(lz.x, lz.y, lz.x2, lz.y2, CAM_HUMAN_PLAYER);
 	startTransporterEntry(tent.x, tent.y, CAM_HUMAN_PLAYER);
 	setTransporterExit(text.x, text.y, CAM_HUMAN_PLAYER);
 
-	var enemyLz = getObject("COLandingZone");
+	let enemyLz = getObject("COLandingZone");
 	setNoGoArea(enemyLz.x, enemyLz.y, enemyLz.x2, enemyLz.y2, THE_COLLECTIVE);
 
 	camSetArtifacts({

--- a/data/base/script/campaign/cam2-d.js
+++ b/data/base/script/campaign/cam2-d.js
@@ -1,8 +1,8 @@
 include("script/campaign/libcampaign.js");
 include("script/campaign/templates.js");
 
-const UPLINK = 1; //The satellite uplink player number.
-const COLLECTIVE_RES = [
+const MIS_UPLINK_PLAYER = 1; //The satellite uplink player number.
+const mis_collectiveRes = [
 	"R-Defense-WallUpgrade06", "R-Struc-Materials06", "R-Sys-Engineering02",
 	"R-Vehicle-Engine04", "R-Vehicle-Metals05", "R-Cyborg-Metals05",
 	"R-Wpn-Cannon-Accuracy02", "R-Wpn-Cannon-Damage05", "R-Wpn-Cannon-ROF02",
@@ -18,32 +18,32 @@ const COLLECTIVE_RES = [
 
 camAreaEvent("vtolRemoveZone", function(droid)
 {
-	if ((droid.player === THE_COLLECTIVE) && isVTOL(droid))
+	if ((droid.player === CAM_THE_COLLECTIVE) && isVTOL(droid))
 	{
 		camSafeRemoveObject(droid, false);
 	}
 
-	resetLabel("vtolRemoveZone", THE_COLLECTIVE);
+	resetLabel("vtolRemoveZone", CAM_THE_COLLECTIVE);
 });
 
 //Order the truck to build some defenses.
 function truckDefense()
 {
-	if (enumDroid(THE_COLLECTIVE, DROID_CONSTRUCT).length === 0)
+	if (enumDroid(CAM_THE_COLLECTIVE, DROID_CONSTRUCT).length === 0)
 	{
 		removeTimer("truckDefense");
 		return;
 	}
 
-	let list = ["AASite-QuadBof", "CO-WallTower-HvCan", "CO-Tower-RotMG", "CO-Tower-HvFlame"];
-	camQueueBuilding(THE_COLLECTIVE, list[camRand(list.length)], camMakePos("uplinkPos"));
+	const list = ["AASite-QuadBof", "CO-WallTower-HvCan", "CO-Tower-RotMG", "CO-Tower-HvFlame"];
+	camQueueBuilding(CAM_THE_COLLECTIVE, list[camRand(list.length)], camMakePos("uplinkPos"));
 }
 
 //Attacks every 2 minutes until HQ is destroyed.
 function vtolAttack()
 {
-	let list = [cTempl.colatv, cTempl.commorvt];
-	camSetVtolData(THE_COLLECTIVE, "vtolAppearPos", "vtolRemovePos", list, camChangeOnDiff(camMinutesToMilliseconds(2)), "COCommandCenter");
+	const list = [cTempl.colatv, cTempl.commorvt];
+	camSetVtolData(CAM_THE_COLLECTIVE, "vtolAppearPos", "vtolRemovePos", list, camChangeOnDiff(camMinutesToMilliseconds(2)), "COCommandCenter");
 }
 
 //The project captured the uplink.
@@ -62,7 +62,7 @@ function checkNASDACentral()
 		return false; //It was destroyed
 	}
 
-	if (camCountStructuresInArea("uplinkClearArea", THE_COLLECTIVE) === 0)
+	if (camCountStructuresInArea("uplinkClearArea", CAM_THE_COLLECTIVE) === 0)
 	{
 		camCallOnce("captureUplink");
 		return true;
@@ -82,17 +82,17 @@ function eventStartLevel()
 		retlz: true
 	});
 
-	let startpos = getObject("startPosition");
-	let lz = getObject("landingZone"); //player lz
-	let tent = getObject("transporterEntry");
-	let text = getObject("transporterExit");
-	centreView(startpos.x, startpos.y);
+	const startPos = getObject("startPosition");
+	const lz = getObject("landingZone"); //player lz
+	const tEnt = getObject("transporterEntry");
+	const tExt = getObject("transporterExit");
+	centreView(startPos.x, startPos.y);
 	setNoGoArea(lz.x, lz.y, lz.x2, lz.y2, CAM_HUMAN_PLAYER);
-	startTransporterEntry(tent.x, tent.y, CAM_HUMAN_PLAYER);
-	setTransporterExit(text.x, text.y, CAM_HUMAN_PLAYER);
+	startTransporterEntry(tEnt.x, tEnt.y, CAM_HUMAN_PLAYER);
+	setTransporterExit(tExt.x, tExt.y, CAM_HUMAN_PLAYER);
 
-	let enemyLz = getObject("COLandingZone");
-	setNoGoArea(enemyLz.x, enemyLz.y, enemyLz.x2, enemyLz.y2, THE_COLLECTIVE);
+	const enemyLz = getObject("COLandingZone");
+	setNoGoArea(enemyLz.x, enemyLz.y, enemyLz.x2, enemyLz.y2, CAM_THE_COLLECTIVE);
 
 	camSetArtifacts({
 		"COCommandCenter": { tech: "R-Struc-VTOLPad-Upgrade01" },
@@ -102,10 +102,10 @@ function eventStartLevel()
 		"COHowitzerEmplacement": { tech: "R-Wpn-Howitzer-Damage02" },
 	});
 
-	setAlliance(CAM_HUMAN_PLAYER, UPLINK, true);
-	setAlliance(THE_COLLECTIVE, UPLINK, true);
+	setAlliance(CAM_HUMAN_PLAYER, MIS_UPLINK_PLAYER, true);
+	setAlliance(CAM_THE_COLLECTIVE, MIS_UPLINK_PLAYER, true);
 
-	camCompleteRequiredResearch(COLLECTIVE_RES, THE_COLLECTIVE);
+	camCompleteRequiredResearch(mis_collectiveRes, CAM_THE_COLLECTIVE);
 
 	camSetEnemyBases({
 		"COSouthEastBase": {
@@ -143,7 +143,7 @@ function eventStartLevel()
 		},
 	});
 
-	camManageTrucks(THE_COLLECTIVE);
+	camManageTrucks(CAM_THE_COLLECTIVE);
 	hackAddMessage("C2D_OBJ1", PROX_MSG, CAM_HUMAN_PLAYER, false);
 
 	camEnableFactory("COHeavyFactory");

--- a/data/base/script/campaign/cam2-ds.js
+++ b/data/base/script/campaign/cam2-ds.js
@@ -5,7 +5,7 @@ function eventStartLevel()
 	camSetupTransporter(87, 100, 1, 100);
 	centreView(88, 101);
 	setNoGoArea(86, 99, 88, 101, CAM_HUMAN_PLAYER);
-	setNoGoArea(49, 83, 51, 85, THE_COLLECTIVE);
+	setNoGoArea(49, 83, 51, 85, CAM_THE_COLLECTIVE);
 	setMissionTime(camChangeOnDiff(camMinutesToSeconds(75)));
 	camPlayVideos([{video: "MB2_DI_MSG", type: MISS_MSG}, {video: "MB2_DI_MSG2", type: CAMP_MSG}]);
 	camSetStandardWinLossConditions(CAM_VICTORY_PRE_OFFWORLD, "SUB_2D");

--- a/data/base/script/campaign/cam2-end.js
+++ b/data/base/script/campaign/cam2-end.js
@@ -2,7 +2,7 @@ include("script/campaign/libcampaign.js");
 include("script/campaign/templates.js");
 
 var allowWin;
-const COLLECTIVE_RES = [
+const mis_collectiveRes = [
 	"R-Defense-WallUpgrade06", "R-Struc-Materials06", "R-Sys-Engineering02",
 	"R-Vehicle-Engine06", "R-Vehicle-Metals06", "R-Cyborg-Metals06",
 	"R-Wpn-Cannon-Accuracy02", "R-Wpn-Cannon-Damage06", "R-Wpn-Cannon-ROF03",
@@ -15,13 +15,13 @@ const COLLECTIVE_RES = [
 	"R-Wpn-Bomb-Damage02", "R-Wpn-AAGun-Damage03", "R-Wpn-AAGun-ROF03",
 	"R-Wpn-AAGun-Accuracy02", "R-Wpn-Howitzer-Accuracy02", "R-Struc-VTOLPad-Upgrade03",
 ];
-const startpos = {x: 92, y: 99};
+const mis_startPos = {x: 92, y: 99};
 
 //Remove enemy vtols when in the remove zone area.
 function checkEnemyVtolArea()
 {
-	let pos = {x: 127, y: 64};
-	let vtols = enumRange(pos.x, pos.y, 2, THE_COLLECTIVE, false).filter((obj) => (isVTOL(obj)));
+	const pos = {x: 127, y: 64};
+	const vtols = enumRange(pos.x, pos.y, 2, CAM_THE_COLLECTIVE, false).filter((obj) => (isVTOL(obj)));
 
 	for (let i = 0, l = vtols.length; i < l; ++i)
 	{
@@ -43,11 +43,11 @@ function eventTransporterLaunch(transporter)
 {
 	if (!allowWin && transporter.player === CAM_HUMAN_PLAYER)
 	{
-		let cargoDroids = enumCargo(transporter);
+		const cargoDroids = enumCargo(transporter);
 
 		for (let i = 0, len = cargoDroids.length; i < len; ++i)
 		{
-			let virDroid = cargoDroids[i];
+			const virDroid = cargoDroids[i];
 
 			if (virDroid && virDroid.droidType === DROID_CONSTRUCT)
 			{
@@ -62,7 +62,7 @@ function eventTransporterLaunch(transporter)
 function randomTemplates(list, transporterAmount, useWhirlwinds)
 {
 	const WHIRLWIND_AMOUNT = 2;
-	let droids = [];
+	const droids = [];
 	let size;
 
 	if (camDef(transporterAmount) && transporterAmount)
@@ -101,40 +101,40 @@ function vtolAttack()
 		{x: 36, y: 1},
 		{x: 1, y: 28},
 	];
-	let vtolRemovePos = {x: 127, y: 64};
+	const vtolRemovePos = {x: 127, y: 64};
 
 	if (difficulty === INSANE)
 	{
 		vtolPositions = undefined; //to randomize the spawns each time
 	}
 
-	let list = [
+	const list = [
 		cTempl.commorv, cTempl.commorv, cTempl.comhvat, cTempl.commorvt
 	];
-	let extras = {
+	const extras = {
 		minVTOLs: (difficulty >= HARD) ? 5 : 4,
 		maxRandomVTOLs: (difficulty >= HARD) ? 2 : 1
 	};
 
-	camSetVtolData(THE_COLLECTIVE, vtolPositions, vtolRemovePos, list, camChangeOnDiff(camSecondsToMilliseconds(30)), undefined, extras);
+	camSetVtolData(CAM_THE_COLLECTIVE, vtolPositions, vtolRemovePos, list, camChangeOnDiff(camSecondsToMilliseconds(30)), undefined, extras);
 }
 
 //SouthEast attackers which are mostly cyborgs.
 function cyborgAttack()
 {
-	let southCyborgAssembly = {x: 123, y: 125};
-	let list = [cTempl.npcybr, cTempl.cocybag, cTempl.npcybc, cTempl.comhltat, cTempl.cohhpv];
+	const southCyborgAssembly = {x: 123, y: 125};
+	const list = [cTempl.npcybr, cTempl.cocybag, cTempl.npcybc, cTempl.comhltat, cTempl.cohhpv];
 
-	camSendReinforcement(THE_COLLECTIVE, camMakePos(southCyborgAssembly), randomTemplates(list, false, true), CAM_REINFORCE_GROUND, {
+	camSendReinforcement(CAM_THE_COLLECTIVE, camMakePos(southCyborgAssembly), randomTemplates(list, false, true), CAM_REINFORCE_GROUND, {
 		data: { regroup: false, count: -1 }
 	});
 }
 
 function cyborgAttackRandom()
 {
-	let list = [cTempl.npcybr, cTempl.cocybag, cTempl.npcybc, cTempl.npcybc, cTempl.comrotm]; //favor cannon cyborg
+	const list = [cTempl.npcybr, cTempl.cocybag, cTempl.npcybc, cTempl.npcybc, cTempl.comrotm]; //favor cannon cyborg
 
-	camSendReinforcement(THE_COLLECTIVE, camMakePos(camGenerateRandomMapEdgeCoordinate(startpos)), randomTemplates(list, false, true).concat(cTempl.comsens), CAM_REINFORCE_GROUND, {
+	camSendReinforcement(CAM_THE_COLLECTIVE, camMakePos(camGenerateRandomMapEdgeCoordinate(mis_startPos)), randomTemplates(list, false, true).concat(cTempl.comsens), CAM_REINFORCE_GROUND, {
 		data: { regroup: false, count: -1 }
 	});
 }
@@ -142,29 +142,29 @@ function cyborgAttackRandom()
 //North road attacker consisting of powerful weaponry.
 function tankAttack()
 {
-	let northTankAssembly = {x: 95, y: 3};
-	let list = [cTempl.comhltat, cTempl.cohact, cTempl.cohhpv, cTempl.comagt, cTempl.cohbbt];
+	const northTankAssembly = {x: 95, y: 3};
+	const list = [cTempl.comhltat, cTempl.cohact, cTempl.cohhpv, cTempl.comagt, cTempl.cohbbt];
 
-	camSendReinforcement(THE_COLLECTIVE, camMakePos(northTankAssembly), randomTemplates(list, false, true), CAM_REINFORCE_GROUND, {
+	camSendReinforcement(CAM_THE_COLLECTIVE, camMakePos(northTankAssembly), randomTemplates(list, false, true), CAM_REINFORCE_GROUND, {
 		data: { regroup: false, count: -1, },
 	});
 }
 
 function tankAttackWest()
 {
-	let westTankAssembly = {x: 3, y: 112}; //This was unused. Now part of Hard/Insane playthroughs.
-	let list = [cTempl.comhltat, cTempl.cohact, cTempl.cohhpv, cTempl.comagt, cTempl.cohbbt];
+	const westTankAssembly = {x: 3, y: 112}; //This was unused. Now part of Hard/Insane playthroughs.
+	const list = [cTempl.comhltat, cTempl.cohact, cTempl.cohhpv, cTempl.comagt, cTempl.cohbbt];
 
-	camSendReinforcement(THE_COLLECTIVE, camMakePos(westTankAssembly), randomTemplates(list, true, true), CAM_REINFORCE_GROUND, {
+	camSendReinforcement(CAM_THE_COLLECTIVE, camMakePos(westTankAssembly), randomTemplates(list, true, true), CAM_REINFORCE_GROUND, {
 		data: { regroup: false, count: -1, },
 	});
 }
 
 function transporterAttack()
 {
-	let droids = [cTempl.cohact, cTempl.comhltat, cTempl.cohbbt, cTempl.cohhpv];
+	const droids = [cTempl.cohact, cTempl.comhltat, cTempl.cohbbt, cTempl.cohhpv];
 
-	camSendReinforcement(THE_COLLECTIVE, camMakePos(camGenerateRandomMapCoordinate(startpos, 10, 1)), randomTemplates(droids, true, false),
+	camSendReinforcement(CAM_THE_COLLECTIVE, camMakePos(camGenerateRandomMapCoordinate(mis_startPos, 10, 1)), randomTemplates(droids, true, false),
 		CAM_REINFORCE_TRANSPORT, {
 			entry: camGenerateRandomMapEdgeCoordinate(),
 			exit: camGenerateRandomMapEdgeCoordinate()
@@ -175,7 +175,7 @@ function transporterAttack()
 //NOTE: this is only called once from the library's eventMissionTimeout().
 function checkIfLaunched()
 {
-	let transporters = enumArea(0, 0, mapWidth, mapHeight, CAM_HUMAN_PLAYER, false).filter((obj) => (
+	const transporters = enumArea(0, 0, mapWidth, mapHeight, CAM_HUMAN_PLAYER, false).filter((obj) => (
 		obj.type === DROID && camIsTransporter(obj)
 	));
 	if (transporters.length > 0)
@@ -203,22 +203,22 @@ function eventStartLevel()
 		camSetExtraObjectiveMessage(_("Send off as many transporters as you can and bring at least one truck"));
 	}
 
-	let lz = {x: 86, y: 99, x2: 88, y2: 101};
-	let tCoords = {xStart: 87, yStart: 100, xOut: 0, yOut: 55};
+	const lz = {x: 86, y: 99, x2: 88, y2: 101};
+	const tCoords = {xStart: 87, yStart: 100, xOut: 0, yOut: 55};
 
 	camSetStandardWinLossConditions(CAM_VICTORY_TIMEOUT, "CAM_3A", {
 		reinforcements: camMinutesToSeconds(7), //Duration the transport "leaves" map.
 		callback: "checkIfLaunched"
 	});
-	centreView(startpos.x, startpos.y);
+	centreView(mis_startPos.x, mis_startPos.y);
 	setNoGoArea(lz.x, lz.y, lz.x2, lz.y2, CAM_HUMAN_PLAYER);
 	camSetupTransporter(tCoords.xStart, tCoords.yStart, tCoords.xOut, tCoords.yOut);
 
-	let enemyLz = {x: 49, y: 83, x2: 51, y2: 85};
-	setNoGoArea(enemyLz.x, enemyLz.y, enemyLz.x2, enemyLz.y2, THE_COLLECTIVE);
+	const enemyLz = {x: 49, y: 83, x2: 51, y2: 85};
+	setNoGoArea(enemyLz.x, enemyLz.y, enemyLz.x2, enemyLz.y2, CAM_THE_COLLECTIVE);
 
 	setMissionTime(camMinutesToSeconds(30));
-	camCompleteRequiredResearch(COLLECTIVE_RES, THE_COLLECTIVE);
+	camCompleteRequiredResearch(mis_collectiveRes, CAM_THE_COLLECTIVE);
 
 	allowWin = false;
 	camPlayVideos([{video: "MB2_DII_MSG", type: CAMP_MSG}, {video: "MB2_DII_MSG2", type: MISS_MSG}]);

--- a/data/base/script/campaign/cam2-end.js
+++ b/data/base/script/campaign/cam2-end.js
@@ -20,8 +20,8 @@ const startpos = {x: 92, y: 99};
 //Remove enemy vtols when in the remove zone area.
 function checkEnemyVtolArea()
 {
-	var pos = {x: 127, y: 64};
-	var vtols = enumRange(pos.x, pos.y, 2, THE_COLLECTIVE, false).filter((obj) => (isVTOL(obj)));
+	let pos = {x: 127, y: 64};
+	let vtols = enumRange(pos.x, pos.y, 2, THE_COLLECTIVE, false).filter((obj) => (isVTOL(obj)));
 
 	for (let i = 0, l = vtols.length; i < l; ++i)
 	{
@@ -43,11 +43,11 @@ function eventTransporterLaunch(transporter)
 {
 	if (!allowWin && transporter.player === CAM_HUMAN_PLAYER)
 	{
-		var cargoDroids = enumCargo(transporter);
+		let cargoDroids = enumCargo(transporter);
 
 		for (let i = 0, len = cargoDroids.length; i < len; ++i)
 		{
-			var virDroid = cargoDroids[i];
+			let virDroid = cargoDroids[i];
 
 			if (virDroid && virDroid.droidType === DROID_CONSTRUCT)
 			{
@@ -62,8 +62,8 @@ function eventTransporterLaunch(transporter)
 function randomTemplates(list, transporterAmount, useWhirlwinds)
 {
 	const WHIRLWIND_AMOUNT = 2;
-	var droids = [];
-	var size;
+	let droids = [];
+	let size;
 
 	if (camDef(transporterAmount) && transporterAmount)
 	{
@@ -94,24 +94,24 @@ function randomTemplates(list, transporterAmount, useWhirlwinds)
 //Attack every 30 seconds.
 function vtolAttack()
 {
-	var vtolPositions = [
+	let vtolPositions = [
 		{x: 99, y: 1},
 		{x: 127, y: 65},
 		{x: 127, y: 28},
 		{x: 36, y: 1},
 		{x: 1, y: 28},
 	];
-	var vtolRemovePos = {x: 127, y: 64};
+	let vtolRemovePos = {x: 127, y: 64};
 
 	if (difficulty === INSANE)
 	{
 		vtolPositions = undefined; //to randomize the spawns each time
 	}
 
-	var list = [
+	let list = [
 		cTempl.commorv, cTempl.commorv, cTempl.comhvat, cTempl.commorvt
 	];
-	var extras = {
+	let extras = {
 		minVTOLs: (difficulty >= HARD) ? 5 : 4,
 		maxRandomVTOLs: (difficulty >= HARD) ? 2 : 1
 	};
@@ -122,8 +122,8 @@ function vtolAttack()
 //SouthEast attackers which are mostly cyborgs.
 function cyborgAttack()
 {
-	var southCyborgAssembly = {x: 123, y: 125};
-	var list = [cTempl.npcybr, cTempl.cocybag, cTempl.npcybc, cTempl.comhltat, cTempl.cohhpv];
+	let southCyborgAssembly = {x: 123, y: 125};
+	let list = [cTempl.npcybr, cTempl.cocybag, cTempl.npcybc, cTempl.comhltat, cTempl.cohhpv];
 
 	camSendReinforcement(THE_COLLECTIVE, camMakePos(southCyborgAssembly), randomTemplates(list, false, true), CAM_REINFORCE_GROUND, {
 		data: { regroup: false, count: -1 }
@@ -132,7 +132,7 @@ function cyborgAttack()
 
 function cyborgAttackRandom()
 {
-	var list = [cTempl.npcybr, cTempl.cocybag, cTempl.npcybc, cTempl.npcybc, cTempl.comrotm]; //favor cannon cyborg
+	let list = [cTempl.npcybr, cTempl.cocybag, cTempl.npcybc, cTempl.npcybc, cTempl.comrotm]; //favor cannon cyborg
 
 	camSendReinforcement(THE_COLLECTIVE, camMakePos(camGenerateRandomMapEdgeCoordinate(startpos)), randomTemplates(list, false, true).concat(cTempl.comsens), CAM_REINFORCE_GROUND, {
 		data: { regroup: false, count: -1 }
@@ -142,8 +142,8 @@ function cyborgAttackRandom()
 //North road attacker consisting of powerful weaponry.
 function tankAttack()
 {
-	var northTankAssembly = {x: 95, y: 3};
-	var list = [cTempl.comhltat, cTempl.cohact, cTempl.cohhpv, cTempl.comagt, cTempl.cohbbt];
+	let northTankAssembly = {x: 95, y: 3};
+	let list = [cTempl.comhltat, cTempl.cohact, cTempl.cohhpv, cTempl.comagt, cTempl.cohbbt];
 
 	camSendReinforcement(THE_COLLECTIVE, camMakePos(northTankAssembly), randomTemplates(list, false, true), CAM_REINFORCE_GROUND, {
 		data: { regroup: false, count: -1, },
@@ -152,8 +152,8 @@ function tankAttack()
 
 function tankAttackWest()
 {
-	var westTankAssembly = {x: 3, y: 112}; //This was unused. Now part of Hard/Insane playthroughs.
-	var list = [cTempl.comhltat, cTempl.cohact, cTempl.cohhpv, cTempl.comagt, cTempl.cohbbt];
+	let westTankAssembly = {x: 3, y: 112}; //This was unused. Now part of Hard/Insane playthroughs.
+	let list = [cTempl.comhltat, cTempl.cohact, cTempl.cohhpv, cTempl.comagt, cTempl.cohbbt];
 
 	camSendReinforcement(THE_COLLECTIVE, camMakePos(westTankAssembly), randomTemplates(list, true, true), CAM_REINFORCE_GROUND, {
 		data: { regroup: false, count: -1, },
@@ -162,7 +162,7 @@ function tankAttackWest()
 
 function transporterAttack()
 {
-	var droids = [cTempl.cohact, cTempl.comhltat, cTempl.cohbbt, cTempl.cohhpv];
+	let droids = [cTempl.cohact, cTempl.comhltat, cTempl.cohbbt, cTempl.cohhpv];
 
 	camSendReinforcement(THE_COLLECTIVE, camMakePos(camGenerateRandomMapCoordinate(startpos, 10, 1)), randomTemplates(droids, true, false),
 		CAM_REINFORCE_TRANSPORT, {
@@ -175,7 +175,7 @@ function transporterAttack()
 //NOTE: this is only called once from the library's eventMissionTimeout().
 function checkIfLaunched()
 {
-	var transporters = enumArea(0, 0, mapWidth, mapHeight, CAM_HUMAN_PLAYER, false).filter((obj) => (
+	let transporters = enumArea(0, 0, mapWidth, mapHeight, CAM_HUMAN_PLAYER, false).filter((obj) => (
 		obj.type === DROID && camIsTransporter(obj)
 	));
 	if (transporters.length > 0)
@@ -203,8 +203,8 @@ function eventStartLevel()
 		camSetExtraObjectiveMessage(_("Send off as many transporters as you can and bring at least one truck"));
 	}
 
-	var lz = {x: 86, y: 99, x2: 88, y2: 101};
-	var tCoords = {xStart: 87, yStart: 100, xOut: 0, yOut: 55};
+	let lz = {x: 86, y: 99, x2: 88, y2: 101};
+	let tCoords = {xStart: 87, yStart: 100, xOut: 0, yOut: 55};
 
 	camSetStandardWinLossConditions(CAM_VICTORY_TIMEOUT, "CAM_3A", {
 		reinforcements: camMinutesToSeconds(7), //Duration the transport "leaves" map.
@@ -214,7 +214,7 @@ function eventStartLevel()
 	setNoGoArea(lz.x, lz.y, lz.x2, lz.y2, CAM_HUMAN_PLAYER);
 	camSetupTransporter(tCoords.xStart, tCoords.yStart, tCoords.xOut, tCoords.yOut);
 
-	var enemyLz = {x: 49, y: 83, x2: 51, y2: 85};
+	let enemyLz = {x: 49, y: 83, x2: 51, y2: 85};
 	setNoGoArea(enemyLz.x, enemyLz.y, enemyLz.x2, enemyLz.y2, THE_COLLECTIVE);
 
 	setMissionTime(camMinutesToSeconds(30));

--- a/data/base/script/campaign/cam3-1.js
+++ b/data/base/script/campaign/cam3-1.js
@@ -63,7 +63,7 @@ camAreaEvent("hillTriggerZone", function(droid)
 //Setup Nexus VTOL hit and runners.
 function vtolAttack()
 {
-	var list = [cTempl.nxlscouv, cTempl.nxmtherv];
+	let list = [cTempl.nxlscouv, cTempl.nxmtherv];
 	camSetVtolData(NEXUS, "vtolAppearPos", "vtolRemovePos", list, camChangeOnDiff(camMinutesToMilliseconds(5)), "NXCommandCenter");
 }
 
@@ -105,7 +105,7 @@ function missileSilosDestroyed()
 {
 	const SILO_COUNT = 4;
 	const SILO_ALIAS = "NXMissileSilo";
-	var destroyed = 0;
+	let destroyed = 0;
 
 	for (let i = 0; i < SILO_COUNT; ++i)
 	{
@@ -119,22 +119,22 @@ function missileSilosDestroyed()
 function nukeAndCountSurvivors()
 {
 	//Avoid destroying the one base if the player opted not to destroy it themselves.
-	var nuked = enumArea(0, 0, mapWidth, mapHeight, ALL_PLAYERS, false).filter((obj) => (
+	let nuked = enumArea(0, 0, mapWidth, mapHeight, ALL_PLAYERS, false).filter((obj) => (
 		obj.type !== STRUCTURE || (obj.type === STRUCTURE && obj.group === null)
 	));
-	var safeZone = enumArea("valleySafeZone", CAM_HUMAN_PLAYER, false);
-	var foundUnit = false;
+	let safeZone = enumArea("valleySafeZone", CAM_HUMAN_PLAYER, false);
+	let foundUnit = false;
 
 	//Make em' explode!
 	for (let i = 0, len = nuked.length; i < len; ++i)
 	{
-		var nukeIt = true;
-		var obj1 = nuked[i];
+		let nukeIt = true;
+		let obj1 = nuked[i];
 
 		//Check if it's in the safe area.
 		for (let j = 0, len2 = safeZone.length; j < len2; ++j)
 		{
-			var obj2 = safeZone[j];
+			let obj2 = safeZone[j];
 
 			if (obj1.id === obj2.id)
 			{
@@ -181,13 +181,13 @@ function setupNextMission()
 function getCountdown()
 {
 	const ACCEPTABLE_TIME_DIFF = 2;
-	var silosDestroyed = missileSilosDestroyed();
-	var countdownObject = silosDestroyed ? detonateInfo : launchInfo;
-	var skip = false;
+	let silosDestroyed = missileSilosDestroyed();
+	let countdownObject = silosDestroyed ? detonateInfo : launchInfo;
+	let skip = false;
 
 	for (let i = 0, len = countdownObject.length; i < len; ++i)
 	{
-		var currentTime = getMissionTime();
+		let currentTime = getMissionTime();
 		if (currentTime <= countdownObject[0].time)
 		{
 			if (currentTime < (countdownObject[0].time - ACCEPTABLE_TIME_DIFF))
@@ -223,10 +223,10 @@ function enableAllFactories()
 //For now just make sure we have all the droids in the canyon.
 function unitsInValley()
 {
-	var safeZone = enumArea("valleySafeZone", CAM_HUMAN_PLAYER, false).filter((obj) => (
+	let safeZone = enumArea("valleySafeZone", CAM_HUMAN_PLAYER, false).filter((obj) => (
 		obj.type === DROID
 	));
-	var allDroids = enumArea(0, 0, mapWidth, mapHeight, CAM_HUMAN_PLAYER, false).filter((obj) => (
+	let allDroids = enumArea(0, 0, mapWidth, mapHeight, CAM_HUMAN_PLAYER, false).filter((obj) => (
 		obj.type === DROID
 	));
 
@@ -247,10 +247,10 @@ function eventStartLevel()
 {
 	camSetExtraObjectiveMessage(_("Destroy the missile silos"));
 
-	var startpos = getObject("startPosition");
-	var lz = getObject("landingZone");
-	var tent = getObject("transporterEntry");
-	var text = getObject("transporterExit");
+	let startpos = getObject("startPosition");
+	let lz = getObject("landingZone");
+	let tent = getObject("transporterEntry");
+	let text = getObject("transporterExit");
 
 	//Time is in seconds.
 	launchInfo = [
@@ -299,7 +299,7 @@ function eventStartLevel()
 	setTransporterExit(text.x, text.y, CAM_HUMAN_PLAYER);
 	setScrollLimits(0, 32, 64, 64);
 
-	var enemyLz = getObject("NXlandingZone");
+	let enemyLz = getObject("NXlandingZone");
 	setNoGoArea(enemyLz.x, enemyLz.y, enemyLz.x2, enemyLz.y2, NEXUS);
 
 	camCompleteRequiredResearch(NEXUS_RES, NEXUS);

--- a/data/base/script/campaign/cam3-1.js
+++ b/data/base/script/campaign/cam3-1.js
@@ -1,7 +1,7 @@
 include("script/campaign/libcampaign.js");
 include("script/campaign/templates.js");
 
-const NEXUS_RES = [
+const mis_nexusRes = [
 	"R-Sys-Engineering03", "R-Defense-WallUpgrade07", "R-Struc-Materials07",
 	"R-Struc-VTOLPad-Upgrade06", "R-Wpn-Bomb-Damage03", "R-Sys-NEXUSrepair",
 	"R-Vehicle-Prop-Hover02", "R-Vehicle-Prop-VTOL02", "R-Cyborg-Legs02",
@@ -28,7 +28,7 @@ camAreaEvent("vtolRemoveZone", function(droid)
 		}
 	}
 
-	resetLabel("vtolRemoveZone", NEXUS);
+	resetLabel("vtolRemoveZone", CAM_NEXUS);
 });
 
 camAreaEvent("hillTriggerZone", function(droid)
@@ -63,8 +63,8 @@ camAreaEvent("hillTriggerZone", function(droid)
 //Setup Nexus VTOL hit and runners.
 function vtolAttack()
 {
-	let list = [cTempl.nxlscouv, cTempl.nxmtherv];
-	camSetVtolData(NEXUS, "vtolAppearPos", "vtolRemovePos", list, camChangeOnDiff(camMinutesToMilliseconds(5)), "NXCommandCenter");
+	const list = [cTempl.nxlscouv, cTempl.nxmtherv];
+	camSetVtolData(CAM_NEXUS, "vtolAppearPos", "vtolRemovePos", list, camChangeOnDiff(camMinutesToMilliseconds(5)), "NXCommandCenter");
 }
 
 //These groups are active immediately.
@@ -119,22 +119,22 @@ function missileSilosDestroyed()
 function nukeAndCountSurvivors()
 {
 	//Avoid destroying the one base if the player opted not to destroy it themselves.
-	let nuked = enumArea(0, 0, mapWidth, mapHeight, ALL_PLAYERS, false).filter((obj) => (
+	const nuked = enumArea(0, 0, mapWidth, mapHeight, ALL_PLAYERS, false).filter((obj) => (
 		obj.type !== STRUCTURE || (obj.type === STRUCTURE && obj.group === null)
 	));
-	let safeZone = enumArea("valleySafeZone", CAM_HUMAN_PLAYER, false);
+	const safeZone = enumArea("valleySafeZone", CAM_HUMAN_PLAYER, false);
 	let foundUnit = false;
 
 	//Make em' explode!
 	for (let i = 0, len = nuked.length; i < len; ++i)
 	{
 		let nukeIt = true;
-		let obj1 = nuked[i];
+		const obj1 = nuked[i];
 
 		//Check if it's in the safe area.
 		for (let j = 0, len2 = safeZone.length; j < len2; ++j)
 		{
-			let obj2 = safeZone[j];
+			const obj2 = safeZone[j];
 
 			if (obj1.id === obj2.id)
 			{
@@ -181,16 +181,16 @@ function setupNextMission()
 function getCountdown()
 {
 	const ACCEPTABLE_TIME_DIFF = 2;
-	let silosDestroyed = missileSilosDestroyed();
-	let countdownObject = silosDestroyed ? detonateInfo : launchInfo;
+	const SILOS_DESTROYED = missileSilosDestroyed();
+	const countdownObject = SILOS_DESTROYED ? detonateInfo : launchInfo;
 	let skip = false;
 
 	for (let i = 0, len = countdownObject.length; i < len; ++i)
 	{
-		let currentTime = getMissionTime();
-		if (currentTime <= countdownObject[0].time)
+		const CURRENT_TIME = getMissionTime();
+		if (CURRENT_TIME <= countdownObject[0].time)
 		{
-			if (currentTime < (countdownObject[0].time - ACCEPTABLE_TIME_DIFF))
+			if (CURRENT_TIME < (countdownObject[0].time - ACCEPTABLE_TIME_DIFF))
 			{
 				skip = true; //Huge time jump?
 			}
@@ -199,7 +199,7 @@ function getCountdown()
 				playSound(countdownObject[0].sound, CAM_HUMAN_PLAYER);
 			}
 
-			if (silosDestroyed)
+			if (SILOS_DESTROYED)
 			{
 				detonateInfo.shift();
 			}
@@ -223,10 +223,10 @@ function enableAllFactories()
 //For now just make sure we have all the droids in the canyon.
 function unitsInValley()
 {
-	let safeZone = enumArea("valleySafeZone", CAM_HUMAN_PLAYER, false).filter((obj) => (
+	const safeZone = enumArea("valleySafeZone", CAM_HUMAN_PLAYER, false).filter((obj) => (
 		obj.type === DROID
 	));
-	let allDroids = enumArea(0, 0, mapWidth, mapHeight, CAM_HUMAN_PLAYER, false).filter((obj) => (
+	const allDroids = enumArea(0, 0, mapWidth, mapHeight, CAM_HUMAN_PLAYER, false).filter((obj) => (
 		obj.type === DROID
 	));
 
@@ -247,10 +247,10 @@ function eventStartLevel()
 {
 	camSetExtraObjectiveMessage(_("Destroy the missile silos"));
 
-	let startpos = getObject("startPosition");
-	let lz = getObject("landingZone");
-	let tent = getObject("transporterEntry");
-	let text = getObject("transporterExit");
+	const startPos = getObject("startPosition");
+	const lz = getObject("landingZone");
+	const tEnt = getObject("transporterEntry");
+	const tExt = getObject("transporterExit");
 
 	//Time is in seconds.
 	launchInfo = [
@@ -293,16 +293,16 @@ function eventStartLevel()
 		callback: "unitsInValley"
 	});
 
-	centreView(startpos.x, startpos.y);
+	centreView(startPos.x, startPos.y);
 	setNoGoArea(lz.x, lz.y, lz.x2, lz.y2, CAM_HUMAN_PLAYER);
-	startTransporterEntry(tent.x, tent.y, CAM_HUMAN_PLAYER);
-	setTransporterExit(text.x, text.y, CAM_HUMAN_PLAYER);
+	startTransporterEntry(tEnt.x, tEnt.y, CAM_HUMAN_PLAYER);
+	setTransporterExit(tExt.x, tExt.y, CAM_HUMAN_PLAYER);
 	setScrollLimits(0, 32, 64, 64);
 
-	let enemyLz = getObject("NXlandingZone");
-	setNoGoArea(enemyLz.x, enemyLz.y, enemyLz.x2, enemyLz.y2, NEXUS);
+	const enemyLz = getObject("NXlandingZone");
+	setNoGoArea(enemyLz.x, enemyLz.y, enemyLz.x2, enemyLz.y2, CAM_NEXUS);
 
-	camCompleteRequiredResearch(NEXUS_RES, NEXUS);
+	camCompleteRequiredResearch(mis_nexusRes, CAM_NEXUS);
 
 	camSetArtifacts({
 		"NXMediumFac": { tech: "R-Wpn-MG-Damage09" },

--- a/data/base/script/campaign/cam3-1s.js
+++ b/data/base/script/campaign/cam3-1s.js
@@ -5,7 +5,7 @@ function eventStartLevel()
 	camSetupTransporter(56, 120, 25, 87);
 	centreView(57, 119);
 	setNoGoArea(55, 119, 57, 121, CAM_HUMAN_PLAYER);
-	setNoGoArea(7, 52, 9, 54, NEXUS);
+	setNoGoArea(7, 52, 9, 54, CAM_NEXUS);
 	setMissionTime(camChangeOnDiff(camMinutesToSeconds(75)));
 	camPlayVideos([{video: "MB3_1A_MSG", type: CAMP_MSG}, {video: "MB3_1A_MSG2", type: MISS_MSG}]);
 	camSetStandardWinLossConditions(CAM_VICTORY_PRE_OFFWORLD, "SUB_3_1");

--- a/data/base/script/campaign/cam3-2.js
+++ b/data/base/script/campaign/cam3-2.js
@@ -67,13 +67,13 @@ camAreaEvent("phantomFacTrigger", function(droid)
 function setAlphaExp()
 {
 	const DROID_EXP = 512; //Hero rank.
-	var alphaDroids = enumArea("alphaPit", ALPHA, false).filter((obj) => (
+	let alphaDroids = enumArea("alphaPit", ALPHA, false).filter((obj) => (
 		obj.type === DROID
 	));
 
 	for (let i = 0, l = alphaDroids.length; i < l; ++i)
 	{
-		var dr = alphaDroids[i];
+		let dr = alphaDroids[i];
 		if (!camIsSystemDroid(dr))
 		{
 			setDroidExperience(dr, DROID_EXP);
@@ -85,13 +85,13 @@ function setAlphaExp()
 function getAlphaUnitIDs()
 {
 	alphaUnitIDs = [];
-	var alphaDroids = enumArea("alphaPit", CAM_HUMAN_PLAYER, false).filter((obj) => (
+	let alphaDroids = enumArea("alphaPit", CAM_HUMAN_PLAYER, false).filter((obj) => (
 		obj.type === DROID && obj.experience === 512
 	));
 
 	for (let i = 0, l = alphaDroids.length; i < l; ++i)
 	{
-		var dr = alphaDroids[i];
+		let dr = alphaDroids[i];
 		alphaUnitIDs.push(dr.id);
 	}
 	startExtraLoss = true;
@@ -99,25 +99,25 @@ function getAlphaUnitIDs()
 
 function phantomFactoryNE()
 {
-	var list = [cTempl.nxcyrail, cTempl.nxcyscou, cTempl.nxcylas];
+	let list = [cTempl.nxcyrail, cTempl.nxcyscou, cTempl.nxcylas];
 	sendEdgeMapDroids(6, "NE-PhantomFactory", list);
 }
 
 function phantomFactorySW()
 {
-	var list = [cTempl.nxcyrail, cTempl.nxcyscou, cTempl.nxcylas];
+	let list = [cTempl.nxcyrail, cTempl.nxcyscou, cTempl.nxcylas];
 	sendEdgeMapDroids(8, "SW-PhantomFactory", list);
 }
 
 function phantomFactorySE()
 {
-	var list = [cTempl.nxcyrail, cTempl.nxcyscou, cTempl.nxcylas, cTempl.nxlflash, cTempl.nxmrailh, cTempl.nxmlinkh];
+	let list = [cTempl.nxcyrail, cTempl.nxcyscou, cTempl.nxcylas, cTempl.nxlflash, cTempl.nxmrailh, cTempl.nxmlinkh];
 	sendEdgeMapDroids(10 + camRand(6), "SE-PhantomFactory", list); //10-15 units
 }
 
 function sendEdgeMapDroids(droidCount, location, list)
 {
-	var droids = [];
+	let droids = [];
 	for (let i = 0; i < droidCount; ++i)
 	{
 		droids.push(list[camRand(list.length)]);
@@ -200,8 +200,8 @@ function setupPatrolGroups()
 //Setup Nexus VTOL hit and runners.
 function vtolAttack()
 {
-	var list = [cTempl.nxlscouv, cTempl.nxmtherv];
-	var ext = {
+	let list = [cTempl.nxlscouv, cTempl.nxmtherv];
+	let ext = {
 		limit: [2, 4], //paired with template list
 		alternate: true,
 		altIdx: 0
@@ -226,8 +226,8 @@ function alphaTeamAlive()
 {
 	if (camDef(alphaUnitIDs) && startExtraLoss)
 	{
-		var alphaAlive = false;
-		var alive = enumArea(0, 0, mapWidth, mapHeight, CAM_HUMAN_PLAYER, false).filter((obj) => (
+		let alphaAlive = false;
+		let alive = enumArea(0, 0, mapWidth, mapHeight, CAM_HUMAN_PLAYER, false).filter((obj) => (
 			obj.type === DROID
 		));
 
@@ -259,10 +259,10 @@ function eventStartLevel()
 {
 	camSetExtraObjectiveMessage(_("Rescue Alpha team from Nexus"));
 
-	var startpos = getObject("startPosition");
-	var lz = getObject("landingZone");
-	var tent = getObject("transporterEntry");
-	var text = getObject("transporterExit");
+	let startpos = getObject("startPosition");
+	let lz = getObject("landingZone");
+	let tent = getObject("transporterEntry");
+	let text = getObject("transporterExit");
 	startExtraLoss = false;
 
 	camSetStandardWinLossConditions(CAM_VICTORY_OFFWORLD, "CAM3A-B", {
@@ -282,7 +282,7 @@ function eventStartLevel()
 	startTransporterEntry(tent.x, tent.y, CAM_HUMAN_PLAYER);
 	setTransporterExit(text.x, text.y, CAM_HUMAN_PLAYER);
 
-	var enemyLz = getObject("NXlandingZone");
+	let enemyLz = getObject("NXlandingZone");
 	setNoGoArea(enemyLz.x, enemyLz.y, enemyLz.x2, enemyLz.y2, NEXUS);
 
 	camCompleteRequiredResearch(NEXUS_RES, NEXUS);

--- a/data/base/script/campaign/cam3-2.js
+++ b/data/base/script/campaign/cam3-2.js
@@ -2,8 +2,8 @@ include("script/campaign/libcampaign.js");
 include("script/campaign/templates.js");
 include("script/campaign/transitionTech.js");
 
-const ALPHA = 1; //Team alpha units belong to player 1.
-const NEXUS_RES = [
+const MIS_ALPHA_PLAYER = 1; //Team alpha units belong to player 1.
+const mis_nexusRes = [
 	"R-Sys-Engineering03", "R-Defense-WallUpgrade08", "R-Struc-Materials08",
 	"R-Struc-VTOLPad-Upgrade06", "R-Wpn-Bomb-Damage03", "R-Sys-NEXUSrepair",
 	"R-Vehicle-Prop-Hover02", "R-Vehicle-Prop-VTOL02", "R-Cyborg-Legs02",
@@ -31,7 +31,7 @@ camAreaEvent("vtolRemoveZone", function(droid)
 		}
 	}
 
-	resetLabel("vtolRemoveZone", NEXUS);
+	resetLabel("vtolRemoveZone", CAM_NEXUS);
 });
 
 //This is an area just below the "doorway" into the alpha team pit. Activates
@@ -47,8 +47,8 @@ camAreaEvent("rescueTrigger", function(droid)
 	});
 	//Activate edge map queue and donate all of alpha to the player.
 	phantomFactorySE();
-	setAlliance(ALPHA, NEXUS, false);
-	camAbsorbPlayer(ALPHA, CAM_HUMAN_PLAYER);
+	setAlliance(MIS_ALPHA_PLAYER, CAM_NEXUS, false);
+	camAbsorbPlayer(MIS_ALPHA_PLAYER, CAM_HUMAN_PLAYER);
 
 	queue("getAlphaUnitIDs", camSecondsToMilliseconds(0.5));
 	setTimer("phantomFactorySE", camChangeOnDiff(camMinutesToMilliseconds(4)));
@@ -67,13 +67,13 @@ camAreaEvent("phantomFacTrigger", function(droid)
 function setAlphaExp()
 {
 	const DROID_EXP = 512; //Hero rank.
-	let alphaDroids = enumArea("alphaPit", ALPHA, false).filter((obj) => (
+	const alphaDroids = enumArea("alphaPit", MIS_ALPHA_PLAYER, false).filter((obj) => (
 		obj.type === DROID
 	));
 
 	for (let i = 0, l = alphaDroids.length; i < l; ++i)
 	{
-		let dr = alphaDroids[i];
+		const dr = alphaDroids[i];
 		if (!camIsSystemDroid(dr))
 		{
 			setDroidExperience(dr, DROID_EXP);
@@ -85,13 +85,13 @@ function setAlphaExp()
 function getAlphaUnitIDs()
 {
 	alphaUnitIDs = [];
-	let alphaDroids = enumArea("alphaPit", CAM_HUMAN_PLAYER, false).filter((obj) => (
+	const alphaDroids = enumArea("alphaPit", CAM_HUMAN_PLAYER, false).filter((obj) => (
 		obj.type === DROID && obj.experience === 512
 	));
 
 	for (let i = 0, l = alphaDroids.length; i < l; ++i)
 	{
-		let dr = alphaDroids[i];
+		const dr = alphaDroids[i];
 		alphaUnitIDs.push(dr.id);
 	}
 	startExtraLoss = true;
@@ -99,31 +99,31 @@ function getAlphaUnitIDs()
 
 function phantomFactoryNE()
 {
-	let list = [cTempl.nxcyrail, cTempl.nxcyscou, cTempl.nxcylas];
+	const list = [cTempl.nxcyrail, cTempl.nxcyscou, cTempl.nxcylas];
 	sendEdgeMapDroids(6, "NE-PhantomFactory", list);
 }
 
 function phantomFactorySW()
 {
-	let list = [cTempl.nxcyrail, cTempl.nxcyscou, cTempl.nxcylas];
+	const list = [cTempl.nxcyrail, cTempl.nxcyscou, cTempl.nxcylas];
 	sendEdgeMapDroids(8, "SW-PhantomFactory", list);
 }
 
 function phantomFactorySE()
 {
-	let list = [cTempl.nxcyrail, cTempl.nxcyscou, cTempl.nxcylas, cTempl.nxlflash, cTempl.nxmrailh, cTempl.nxmlinkh];
+	const list = [cTempl.nxcyrail, cTempl.nxcyscou, cTempl.nxcylas, cTempl.nxlflash, cTempl.nxmrailh, cTempl.nxmlinkh];
 	sendEdgeMapDroids(10 + camRand(6), "SE-PhantomFactory", list); //10-15 units
 }
 
 function sendEdgeMapDroids(droidCount, location, list)
 {
-	let droids = [];
+	const droids = [];
 	for (let i = 0; i < droidCount; ++i)
 	{
 		droids.push(list[camRand(list.length)]);
 	}
 
-	camSendReinforcement(NEXUS, camMakePos(location), droids, CAM_REINFORCE_GROUND, {
+	camSendReinforcement(CAM_NEXUS, camMakePos(location), droids, CAM_REINFORCE_GROUND, {
 		data: {regroup: true, count: -1}
 	});
 }
@@ -200,13 +200,13 @@ function setupPatrolGroups()
 //Setup Nexus VTOL hit and runners.
 function vtolAttack()
 {
-	let list = [cTempl.nxlscouv, cTempl.nxmtherv];
-	let ext = {
+	const list = [cTempl.nxlscouv, cTempl.nxmtherv];
+	const ext = {
 		limit: [2, 4], //paired with template list
 		alternate: true,
 		altIdx: 0
 	};
-	camSetVtolData(NEXUS, "vtolAppearPos", "vtolRemovePos", list, camChangeOnDiff(camMinutesToMilliseconds(2)), undefined, ext);
+	camSetVtolData(CAM_NEXUS, "vtolAppearPos", "vtolRemovePos", list, camChangeOnDiff(camMinutesToMilliseconds(2)), undefined, ext);
 }
 
 //Reinforcements not available until team Alpha brief about VTOLS.
@@ -227,7 +227,7 @@ function alphaTeamAlive()
 	if (camDef(alphaUnitIDs) && startExtraLoss)
 	{
 		let alphaAlive = false;
-		let alive = enumArea(0, 0, mapWidth, mapHeight, CAM_HUMAN_PLAYER, false).filter((obj) => (
+		const alive = enumArea(0, 0, mapWidth, mapHeight, CAM_HUMAN_PLAYER, false).filter((obj) => (
 			obj.type === DROID
 		));
 
@@ -259,10 +259,10 @@ function eventStartLevel()
 {
 	camSetExtraObjectiveMessage(_("Rescue Alpha team from Nexus"));
 
-	let startpos = getObject("startPosition");
-	let lz = getObject("landingZone");
-	let tent = getObject("transporterEntry");
-	let text = getObject("transporterExit");
+	const startPos = getObject("startPosition");
+	const lz = getObject("landingZone");
+	const tEnt = getObject("transporterEntry");
+	const tExt = getObject("transporterExit");
 	startExtraLoss = false;
 
 	camSetStandardWinLossConditions(CAM_VICTORY_OFFWORLD, "CAM3A-B", {
@@ -277,19 +277,19 @@ function eventStartLevel()
 		"NXartiCyborg": { tech: "R-Wpn-Cannon-ROF05" },
 	});
 
-	centreView(startpos.x, startpos.y);
+	centreView(startPos.x, startPos.y);
 	setNoGoArea(lz.x, lz.y, lz.x2, lz.y2, CAM_HUMAN_PLAYER);
-	startTransporterEntry(tent.x, tent.y, CAM_HUMAN_PLAYER);
-	setTransporterExit(text.x, text.y, CAM_HUMAN_PLAYER);
+	startTransporterEntry(tEnt.x, tEnt.y, CAM_HUMAN_PLAYER);
+	setTransporterExit(tExt.x, tExt.y, CAM_HUMAN_PLAYER);
 
-	let enemyLz = getObject("NXlandingZone");
-	setNoGoArea(enemyLz.x, enemyLz.y, enemyLz.x2, enemyLz.y2, NEXUS);
+	const enemyLz = getObject("NXlandingZone");
+	setNoGoArea(enemyLz.x, enemyLz.y, enemyLz.x2, enemyLz.y2, CAM_NEXUS);
 
-	camCompleteRequiredResearch(NEXUS_RES, NEXUS);
-	camCompleteRequiredResearch(GAMMA_ALLY_RES, ALPHA);
-	setAlliance(ALPHA, NEXUS, true);
-	setAlliance(ALPHA, CAM_HUMAN_PLAYER, true);
-	changePlayerColour(ALPHA, 0);
+	camCompleteRequiredResearch(mis_nexusRes, CAM_NEXUS);
+	camCompleteRequiredResearch(mis_gammaAllyRes, MIS_ALPHA_PLAYER);
+	setAlliance(MIS_ALPHA_PLAYER, CAM_NEXUS, true);
+	setAlliance(MIS_ALPHA_PLAYER, CAM_HUMAN_PLAYER, true);
+	changePlayerColour(MIS_ALPHA_PLAYER, 0);
 
 	hackAddMessage("C3-2_OBJ1", PROX_MSG, CAM_HUMAN_PLAYER);
 	queue("setAlphaExp", camSecondsToMilliseconds(2));

--- a/data/base/script/campaign/cam3-2s.js
+++ b/data/base/script/campaign/cam3-2s.js
@@ -5,7 +5,7 @@ function eventStartLevel()
 	camSetupTransporter(56, 120, 25, 87);
 	centreView(57, 119);
 	setNoGoArea(55, 119, 57, 121, CAM_HUMAN_PLAYER);
-	setNoGoArea(7, 52, 9, 54, NEXUS);
+	setNoGoArea(7, 52, 9, 54, CAM_NEXUS);
 	setMissionTime(camChangeOnDiff(camHoursToSeconds(1)));
 	camPlayVideos([{video: "MB3_2_MSG", type: CAMP_MSG}, {video: "MB3_2_MSG2", type: MISS_MSG}]);
 	camSetStandardWinLossConditions(CAM_VICTORY_PRE_OFFWORLD, "SUB_3_2");

--- a/data/base/script/campaign/cam3-4.js
+++ b/data/base/script/campaign/cam3-4.js
@@ -204,10 +204,10 @@ function enableAllFactories()
 
 function truckDefense()
 {
-	var truckNum = countDroid(NEXUS, DROID_CONSTRUCT);
+	let truckNum = countDroid(NEXUS, DROID_CONSTRUCT);
 	if (truckNum > 0)
 	{
-		var list = [
+		let list = [
 			"Sys-NEXUSLinkTOW", "P0-AASite-SAM2", "Emplacement-PrisLas",
 			"NX-Tower-ATMiss", "Sys-NX-CBTower", "Emplacement-HvART-pit",
 			"Sys-SensoTower02"
@@ -226,9 +226,9 @@ function truckDefense()
 
 function eventStartLevel()
 {
-	var startpos = getObject("startPosition");
-	var tpos = getObject("transportEntryExit");
-	var lz = getObject("landingZone");
+	let startpos = getObject("startPosition");
+	let tpos = getObject("transportEntryExit");
+	let lz = getObject("landingZone");
 
 	camSetStandardWinLossConditions(CAM_VICTORY_OFFWORLD, CAM_GAMMA_OUT, {
 		area: "RTLZ",
@@ -242,7 +242,7 @@ function eventStartLevel()
 	setTransporterExit(tpos.x, tpos.y, CAM_HUMAN_PLAYER);
 	setMissionTime(-1); //Infinite time
 
-	var enemyLz = getObject("NXlandingZone");
+	let enemyLz = getObject("NXlandingZone");
 	setNoGoArea(enemyLz.x, enemyLz.y, enemyLz.x2, enemyLz.y2, NEXUS);
 
 	camCompleteRequiredResearch(NEXUS_RES, NEXUS);

--- a/data/base/script/campaign/cam3-4.js
+++ b/data/base/script/campaign/cam3-4.js
@@ -1,7 +1,7 @@
 include("script/campaign/libcampaign.js");
 include("script/campaign/templates.js");
 
-const NEXUS_RES = [
+const mis_nexusRes = [
 	"R-Sys-Engineering03", "R-Defense-WallUpgrade11", "R-Struc-Materials11",
 	"R-Struc-VTOLPad-Upgrade06", "R-Wpn-Bomb-Damage03", "R-Sys-NEXUSrepair",
 	"R-Vehicle-Prop-Hover02", "R-Vehicle-Prop-VTOL02", "R-Cyborg-Legs02",
@@ -18,7 +18,7 @@ const NEXUS_RES = [
 
 function eventDestroyed(obj)
 {
-	if (obj.player === NEXUS && obj.type === STRUCTURE && obj.stattype === HQ)
+	if (obj.player === CAM_NEXUS && obj.type === STRUCTURE && obj.stattype === HQ)
 	{
 		camSetNexusState(false);
 		removeTimer("nexusHackFeature");
@@ -60,27 +60,27 @@ function nexusHackFeature()
 		return;
 	}
 
-	camHackIntoPlayer(CAM_HUMAN_PLAYER, NEXUS);
+	camHackIntoPlayer(CAM_HUMAN_PLAYER, CAM_NEXUS);
 }
 
 // A little suprise absorbption attack when discovering the SW base.
 function takeoverChanceAttack()
 {
-	let chance = (difficulty === INSANE) ? 10 : 5;
-	let objects = enumArea(0, 0, mapWidth, mapHeight, CAM_HUMAN_PLAYER, false).filter((obj) => (
+	const CHANCE = (difficulty === INSANE) ? 10 : 5;
+	const objects = enumArea(0, 0, mapWidth, mapHeight, CAM_HUMAN_PLAYER, false).filter((obj) => (
 		(obj.type !== DROID) || (obj.type === DROID && obj.droidType !== DROID_SUPERTRANSPORTER)
 	));
 
 	for (let i = 0, len = objects.length; i < len; ++i)
 	{
-		let obj = objects[i];
-		if (camRand(100) < chance)
+		const obj = objects[i];
+		if (camRand(100) < CHANCE)
 		{
 			if (obj.type === STRUCTURE && obj.stattype === WALL)
 			{
 				camSafeRemoveObject(obj, true); // Just remove walls and tank traps.
 			}
-			else if (!donateObject(obj, NEXUS))
+			else if (!donateObject(obj, CAM_NEXUS))
 			{
 				camSafeRemoveObject(obj, true); // If can't transfer then get rid of it too.
 			}
@@ -92,7 +92,7 @@ function takeoverChanceAttack()
 function destroyPlayerVtols()
 {
 	let vtolBlowupAmount = 0;
-	let vtols = enumArea(0, 0, mapWidth, mapHeight, CAM_HUMAN_PLAYER, false).filter((obj) => (
+	const vtols = enumArea(0, 0, mapWidth, mapHeight, CAM_HUMAN_PLAYER, false).filter((obj) => (
 		(obj.type === DROID) && (obj.droidType !== DROID_SUPERTRANSPORTER) && isVTOL(obj)
 	));
 
@@ -106,7 +106,7 @@ function destroyPlayerVtols()
 
 	for (let i = 0, len = Math.floor(vtolBlowupAmount * vtols.length); i < len; ++i)
 	{
-		let vtol = vtols[i];
+		const vtol = vtols[i];
 		camSafeRemoveObject(vtol, true);
 	}
 }
@@ -114,7 +114,7 @@ function destroyPlayerVtols()
 function activateNexus()
 {
 	camSetExtraObjectiveMessage(_("Destroy the Nexus HQ to disable the Nexus Intruder Program"));
-	playSound(SYNAPTICS_ACTIVATED);
+	playSound(CAM_SYNAPTICS_ACTIVATED_SND);
 	camSetNexusState(true);
 	setTimer("nexusHackFeature", camSecondsToMilliseconds((difficulty <= MEDIUM) ? 20 : 10));
 }
@@ -185,15 +185,15 @@ function setupNexusPatrols()
 
 function enableAllFactories()
 {
-	const FACTORY_LIST = [
+	const factoryList = [
 		"NX-NWFactory1", "NX-NWFactory2", "NX-NEFactory", "NX-SWFactory",
 		"NX-SEFactory", "NX-VtolFactory1", "NX-NWCyborgFactory",
 		"NX-VtolFactory2", "NX-SWCyborgFactory1", "NX-SWCyborgFactory2",
 	];
 
-	for (let i = 0, l = FACTORY_LIST.length; i < l; ++i)
+	for (let i = 0, l = factoryList.length; i < l; ++i)
 	{
-		camEnableFactory(FACTORY_LIST[i]);
+		camEnableFactory(factoryList[i]);
 	}
 
 	//Set the already placed VTOL fighters into action
@@ -204,18 +204,18 @@ function enableAllFactories()
 
 function truckDefense()
 {
-	let truckNum = countDroid(NEXUS, DROID_CONSTRUCT);
-	if (truckNum > 0)
+	const TRUCK_NUM = countDroid(CAM_NEXUS, DROID_CONSTRUCT);
+	if (TRUCK_NUM > 0)
 	{
-		let list = [
+		const list = [
 			"Sys-NEXUSLinkTOW", "P0-AASite-SAM2", "Emplacement-PrisLas",
 			"NX-Tower-ATMiss", "Sys-NX-CBTower", "Emplacement-HvART-pit",
 			"Sys-SensoTower02"
 		];
 
-		for (let i = 0; i < truckNum; ++i)
+		for (let i = 0; i < TRUCK_NUM; ++i)
 		{
-			camQueueBuilding(NEXUS, list[camRand(list.length)]);
+			camQueueBuilding(CAM_NEXUS, list[camRand(list.length)]);
 		}
 	}
 	else
@@ -226,9 +226,9 @@ function truckDefense()
 
 function eventStartLevel()
 {
-	let startpos = getObject("startPosition");
-	let tpos = getObject("transportEntryExit");
-	let lz = getObject("landingZone");
+	const startPos = getObject("startPosition");
+	const tpos = getObject("transportEntryExit");
+	const lz = getObject("landingZone");
 
 	camSetStandardWinLossConditions(CAM_VICTORY_OFFWORLD, CAM_GAMMA_OUT, {
 		area: "RTLZ",
@@ -236,18 +236,18 @@ function eventStartLevel()
 		annihilate: true
 	});
 
-	centreView(startpos.x, startpos.y);
+	centreView(startPos.x, startPos.y);
 	setNoGoArea(lz.x, lz.y, lz.x2, lz.y2, CAM_HUMAN_PLAYER);
 	startTransporterEntry(tpos.x, tpos.y, CAM_HUMAN_PLAYER);
 	setTransporterExit(tpos.x, tpos.y, CAM_HUMAN_PLAYER);
 	setMissionTime(-1); //Infinite time
 
-	let enemyLz = getObject("NXlandingZone");
-	setNoGoArea(enemyLz.x, enemyLz.y, enemyLz.x2, enemyLz.y2, NEXUS);
+	const enemyLz = getObject("NXlandingZone");
+	setNoGoArea(enemyLz.x, enemyLz.y, enemyLz.x2, enemyLz.y2, CAM_NEXUS);
 
-	camCompleteRequiredResearch(NEXUS_RES, NEXUS);
+	camCompleteRequiredResearch(mis_nexusRes, CAM_NEXUS);
 	setupNexusPatrols();
-	camManageTrucks(NEXUS);
+	camManageTrucks(CAM_NEXUS);
 
 	camSetArtifacts({
 		"NX-NWCyborgFactory": { tech: "R-Wpn-RailGun03" },

--- a/data/base/script/campaign/cam3-4s.js
+++ b/data/base/script/campaign/cam3-4s.js
@@ -5,7 +5,7 @@ function eventStartLevel()
 	camSetupTransporter(50, 245, 63, 118);
 	centreView(50, 245);
 	setNoGoArea(49, 244, 51, 246, CAM_HUMAN_PLAYER);
-	setNoGoArea(7, 52, 9, 54, NEXUS);
+	setNoGoArea(7, 52, 9, 54, CAM_NEXUS);
 	setScrollLimits(0, 137, 64, 256);
 	setMissionTime(camMinutesToSeconds(30));
 	setPower(playerPower(CAM_HUMAN_PLAYER) + 50000, CAM_HUMAN_PLAYER);

--- a/data/base/script/campaign/cam3-a.js
+++ b/data/base/script/campaign/cam3-a.js
@@ -59,11 +59,11 @@ camAreaEvent ("middleTrigger", function(droid)
 function setUnitRank(transport)
 {
 	const DROID_EXP = [1024, 256, 128, 64]; //Can make Hero Commanders if recycled.
-	var droids = enumCargo(transport);
+	let droids = enumCargo(transport);
 
 	for (let i = 0, len = droids.length; i < len; ++i)
 	{
-		var droid = droids[i];
+		let droid = droids[i];
 		if (droid.droidType !== DROID_CONSTRUCT && droid.droidType !== DROID_REPAIR)
 		{
 			setDroidExperience(droid, DROID_EXP[transporterIndex - 1]);
@@ -103,8 +103,8 @@ function truckDefense()
 		return;
 	}
 
-	var list = ["Emplacement-Howitzer150", "Emplacement-MdART-pit", "Emplacement-RotHow"];
-	var position;
+	let list = ["Emplacement-Howitzer150", "Emplacement-MdART-pit", "Emplacement-RotHow"];
+	let position;
 
 	if (truckLocCounter === 0)
 	{
@@ -167,7 +167,7 @@ function sendPlayerTransporter()
 //Setup Nexus VTOL hit and runners.
 function vtolAttack()
 {
-	var list = [cTempl.nxlneedv, cTempl.nxlscouv, cTempl.nxmtherv];
+	let list = [cTempl.nxlneedv, cTempl.nxlscouv, cTempl.nxmtherv];
 	camSetVtolData(NEXUS, "vtolAppearPos", "vtolRemovePos", list, camChangeOnDiff(camMinutesToMilliseconds(5)), "NXCommandCenter");
 }
 
@@ -242,7 +242,7 @@ function cam3Setup()
 //Normal and lower difficulties has Nexus start off a little bit weaker
 function improveNexusAlloys()
 {
-	var alloys = [
+	let alloys = [
 		"R-Vehicle-Metals07", "R-Cyborg-Metals07",
 		"R-Vehicle-Armor-Heat04", "R-Cyborg-Armor-Heat04"
 	];
@@ -252,10 +252,10 @@ function improveNexusAlloys()
 function eventStartLevel()
 {
 	const PLAYER_POWER = 16000;
-	var startpos = getObject("startPosition");
-	var lz = getObject("landingZone");
-	var tent = getObject("transporterEntry");
-	var text = getObject("transporterExit");
+	let startpos = getObject("startPosition");
+	let lz = getObject("landingZone");
+	let tent = getObject("transporterEntry");
+	let text = getObject("transporterExit");
 
 	camSetStandardWinLossConditions(CAM_VICTORY_STANDARD, "SUB_3_1S");
 	setMissionTime(camChangeOnDiff(camHoursToSeconds(2)));
@@ -265,7 +265,7 @@ function eventStartLevel()
 	startTransporterEntry(tent.x, tent.y, CAM_HUMAN_PLAYER);
 	setTransporterExit(text.x, text.y, CAM_HUMAN_PLAYER);
 
-	var enemyLz = getObject("NXlandingZone");
+	let enemyLz = getObject("NXlandingZone");
 	setNoGoArea(enemyLz.x, enemyLz.y, enemyLz.x2, enemyLz.y2, NEXUS);
 
 	camSetArtifacts({

--- a/data/base/script/campaign/cam3-a.js
+++ b/data/base/script/campaign/cam3-a.js
@@ -17,7 +17,7 @@ camAreaEvent("vtolRemoveZone", function(droid)
 		}
 	}
 
-	resetLabel("vtolRemoveZone", NEXUS);
+	resetLabel("vtolRemoveZone", CAM_NEXUS);
 });
 
 //Order base three groups to do stuff and enable cyborg factories in the north
@@ -58,15 +58,15 @@ camAreaEvent ("middleTrigger", function(droid)
 
 function setUnitRank(transport)
 {
-	const DROID_EXP = [1024, 256, 128, 64]; //Can make Hero Commanders if recycled.
-	let droids = enumCargo(transport);
+	const droidExp = [1024, 256, 128, 64]; //Can make Hero Commanders if recycled.
+	const droids = enumCargo(transport);
 
 	for (let i = 0, len = droids.length; i < len; ++i)
 	{
-		let droid = droids[i];
+		const droid = droids[i];
 		if (droid.droidType !== DROID_CONSTRUCT && droid.droidType !== DROID_REPAIR)
 		{
-			setDroidExperience(droid, DROID_EXP[transporterIndex - 1]);
+			setDroidExperience(droid, droidExp[transporterIndex - 1]);
 		}
 	}
 }
@@ -82,13 +82,13 @@ function eventTransporterLanded(transport)
 //Enable all factories.
 function enableAllFactories()
 {
-	const FACTORY_NAMES = [
+	const factoryNames = [
 		"NXcybFac-b3", "NXcybFac-b2-1", "NXcybFac-b2-2", "NXHvyFac-b2", "NXcybFac-b4",
 	];
 
-	for (let j = 0, i = FACTORY_NAMES.length; j < i; ++j)
+	for (let j = 0, i = factoryNames.length; j < i; ++j)
 	{
-		camEnableFactory(FACTORY_NAMES[j]);
+		camEnableFactory(factoryNames[j]);
 	}
 
 	//If they go really fast, adapt the alloy research to come sooner
@@ -97,13 +97,13 @@ function enableAllFactories()
 
 function truckDefense()
 {
-	if (enumDroid(NEXUS, DROID_CONSTRUCT).length === 0)
+	if (enumDroid(CAM_NEXUS, DROID_CONSTRUCT).length === 0)
 	{
 		removeTimer("truckDefense");
 		return;
 	}
 
-	let list = ["Emplacement-Howitzer150", "Emplacement-MdART-pit", "Emplacement-RotHow"];
+	const list = ["Emplacement-Howitzer150", "Emplacement-MdART-pit", "Emplacement-RotHow"];
 	let position;
 
 	if (truckLocCounter === 0)
@@ -117,7 +117,7 @@ function truckDefense()
 		truckLocCounter = 0;
 	}
 
-	camQueueBuilding(NEXUS, list[camRand(list.length)], position);
+	camQueueBuilding(CAM_NEXUS, list[camRand(list.length)], position);
 }
 
 //Extra transport units are only awarded to those who start Gamma campaign
@@ -136,22 +136,22 @@ function sendPlayerTransporter()
 		return;
 	}
 
-	let droids = [];
-	let bodyList = ["Body9REC", "Body9REC", "Body9REC", "Body11ABT", "Body12SUP"];
-	let propulsionList = ["tracked01", "tracked01", "hover01"];
-	let weaponList = ["Cannon5VulcanMk1", "Cannon5VulcanMk1", "Flame2", "Flame2", "MG4ROTARYMk1", "MG4ROTARYMk1", "Cannon4AUTOMk1", "Rocket-HvyA-T"];
-	let specialList = ["Spade1Mk1", "Spade1Mk1", "CommandBrain01", "CommandBrain01"];
+	const droids = [];
+	const bodyList = ["Body9REC", "Body9REC", "Body9REC", "Body11ABT", "Body12SUP"];
+	const propulsionList = ["tracked01", "tracked01", "hover01"];
+	const weaponList = ["Cannon5VulcanMk1", "Cannon5VulcanMk1", "Flame2", "Flame2", "MG4ROTARYMk1", "MG4ROTARYMk1", "Cannon4AUTOMk1", "Rocket-HvyA-T"];
+	const specialList = ["Spade1Mk1", "Spade1Mk1", "CommandBrain01", "CommandBrain01"];
 
 	for (let i = 0; i < 10; ++i)
 	{
-		let body = bodyList[camRand(bodyList.length)];
+		const BODY = bodyList[camRand(bodyList.length)];
 		let weap = (!transporterIndex && (i < specialList.length)) ? specialList[i] : weaponList[camRand(weaponList.length)];
 		if (transporterIndex === 1 && i < 4)
 		{
 			weap = "QuadRotAAGun";
 		}
-		let prop = propulsionList[camRand(propulsionList.length)];
-		droids.push({ body: body, prop: prop, weap: weap });
+		const PROP = propulsionList[camRand(propulsionList.length)];
+		droids.push({ body: BODY, prop: PROP, weap: weap });
 	}
 
 	camSendReinforcement(CAM_HUMAN_PLAYER, camMakePos("landingZone"), droids,
@@ -167,8 +167,8 @@ function sendPlayerTransporter()
 //Setup Nexus VTOL hit and runners.
 function vtolAttack()
 {
-	let list = [cTempl.nxlneedv, cTempl.nxlscouv, cTempl.nxmtherv];
-	camSetVtolData(NEXUS, "vtolAppearPos", "vtolRemovePos", list, camChangeOnDiff(camMinutesToMilliseconds(5)), "NXCommandCenter");
+	const list = [cTempl.nxlneedv, cTempl.nxlscouv, cTempl.nxmtherv];
+	camSetVtolData(CAM_NEXUS, "vtolAppearPos", "vtolRemovePos", list, camChangeOnDiff(camMinutesToMilliseconds(5)), "NXCommandCenter");
 }
 
 //These groups are active immediately.
@@ -207,7 +207,7 @@ function groupPatrolNoTrigger()
 //Gives starting tech and research.
 function cam3Setup()
 {
-	const NEXUS_RES = [
+	const nexusRes = [
 		"R-Sys-Engineering03", "R-Defense-WallUpgrade07", "R-Struc-Materials07",
 		"R-Struc-VTOLPad-Upgrade06", "R-Wpn-Bomb-Damage03", "R-Sys-NEXUSrepair",
 		"R-Vehicle-Prop-Hover02", "R-Vehicle-Prop-VTOL02", "R-Cyborg-Legs02",
@@ -221,14 +221,14 @@ function cam3Setup()
 		"R-Wpn-Energy-Damage02", "R-Wpn-Energy-ROF01", "R-Wpn-Energy-Accuracy01",
 	];
 
-	for (let x = 0, l = STRUCTS_ALPHA.length; x < l; ++x)
+	for (let x = 0, l = mis_structsAlpha.length; x < l; ++x)
 	{
-		enableStructure(STRUCTS_ALPHA[x], CAM_HUMAN_PLAYER);
+		enableStructure(mis_structsAlpha[x], CAM_HUMAN_PLAYER);
 	}
 
-	camCompleteRequiredResearch(GAMMA_ALLY_RES, CAM_HUMAN_PLAYER);
-	camCompleteRequiredResearch(GAMMA_ALLY_RES, NEXUS);
-	camCompleteRequiredResearch(NEXUS_RES, NEXUS);
+	camCompleteRequiredResearch(mis_gammaAllyRes, CAM_HUMAN_PLAYER);
+	camCompleteRequiredResearch(mis_gammaAllyRes, CAM_NEXUS);
+	camCompleteRequiredResearch(nexusRes, CAM_NEXUS);
 
 	if (difficulty >= HARD)
 	{
@@ -242,31 +242,31 @@ function cam3Setup()
 //Normal and lower difficulties has Nexus start off a little bit weaker
 function improveNexusAlloys()
 {
-	let alloys = [
+	const alloys = [
 		"R-Vehicle-Metals07", "R-Cyborg-Metals07",
 		"R-Vehicle-Armor-Heat04", "R-Cyborg-Armor-Heat04"
 	];
-	camCompleteRequiredResearch(alloys, NEXUS);
+	camCompleteRequiredResearch(alloys, CAM_NEXUS);
 }
 
 function eventStartLevel()
 {
 	const PLAYER_POWER = 16000;
-	let startpos = getObject("startPosition");
-	let lz = getObject("landingZone");
-	let tent = getObject("transporterEntry");
-	let text = getObject("transporterExit");
+	const startPos = getObject("startPosition");
+	const lz = getObject("landingZone");
+	const tEnt = getObject("transporterEntry");
+	const tExt = getObject("transporterExit");
 
 	camSetStandardWinLossConditions(CAM_VICTORY_STANDARD, "SUB_3_1S");
 	setMissionTime(camChangeOnDiff(camHoursToSeconds(2)));
 
-	centreView(startpos.x, startpos.y);
+	centreView(startPos.x, startPos.y);
 	setNoGoArea(lz.x, lz.y, lz.x2, lz.y2, CAM_HUMAN_PLAYER);
-	startTransporterEntry(tent.x, tent.y, CAM_HUMAN_PLAYER);
-	setTransporterExit(text.x, text.y, CAM_HUMAN_PLAYER);
+	startTransporterEntry(tEnt.x, tEnt.y, CAM_HUMAN_PLAYER);
+	setTransporterExit(tExt.x, tExt.y, CAM_HUMAN_PLAYER);
 
-	let enemyLz = getObject("NXlandingZone");
-	setNoGoArea(enemyLz.x, enemyLz.y, enemyLz.x2, enemyLz.y2, NEXUS);
+	const enemyLz = getObject("NXlandingZone");
+	setNoGoArea(enemyLz.x, enemyLz.y, enemyLz.x2, enemyLz.y2, CAM_NEXUS);
 
 	camSetArtifacts({
 		"NXPowerGenArti": { tech: "R-Struc-Power-Upgrade02" },
@@ -382,9 +382,9 @@ function eventStartLevel()
 
 	if (difficulty >= HARD)
 	{
-		addDroid(NEXUS, 8, 112, "Truck Retribution Hover", "Body7ABT", "hover02", "", "", "Spade1Mk1");
+		addDroid(CAM_NEXUS, 8, 112, "Truck Retribution Hover", "Body7ABT", "hover02", "", "", "Spade1Mk1");
 
-		camManageTrucks(NEXUS);
+		camManageTrucks(CAM_NEXUS);
 
 		setTimer("truckDefense", camChangeOnDiff(camMinutesToMilliseconds(4.5)));
 	}

--- a/data/base/script/campaign/cam3-ab.js
+++ b/data/base/script/campaign/cam3-ab.js
@@ -1,7 +1,7 @@
 include("script/campaign/libcampaign.js");
 include("script/campaign/templates.js");
 
-const NEXUS_RES = [
+const mis_nexusRes = [
 	"R-Sys-Engineering03", "R-Defense-WallUpgrade09", "R-Struc-Materials09",
 	"R-Struc-VTOLPad-Upgrade06", "R-Wpn-Bomb-Damage03", "R-Sys-NEXUSrepair",
 	"R-Vehicle-Prop-Hover02", "R-Vehicle-Prop-VTOL02", "R-Cyborg-Legs02",
@@ -30,7 +30,7 @@ camAreaEvent("vtolRemoveZone", function(droid)
 		}
 	}
 
-	resetLabel("vtolRemoveZone", NEXUS);
+	resetLabel("vtolRemoveZone", CAM_NEXUS);
 });
 
 function sendEdgeMapDroids()
@@ -40,7 +40,7 @@ function sendEdgeMapDroids()
 	{
 		unitCount = 14 + camRand(3); // 14 - 16.
 	}
-	const EDGE = ["SWPhantomFactory", "NWPhantomFactory"];
+	const edge = ["SWPhantomFactory", "NWPhantomFactory"];
 	let list = [
 		cTempl.nxcyrail, cTempl.nxcyscou, cTempl.nxcylas,
 		cTempl.nxlflash, cTempl.nxmrailh, cTempl.nxmlinkh,
@@ -64,7 +64,7 @@ function sendEdgeMapDroids()
 
 	droids = droids.concat(cTempl.nxmsens);
 
-	camSendReinforcement(NEXUS, camMakePos(EDGE[camRand(EDGE.length)]), droids,
+	camSendReinforcement(CAM_NEXUS, camMakePos(edge[camRand(edge.length)]), droids,
 		CAM_REINFORCE_GROUND, {
 			data: {regroup: false, count: -1}
 		}
@@ -76,35 +76,35 @@ function sendEdgeMapDroids()
 //Setup Nexus VTOL hit and runners. NOTE: These do not go away in this mission.
 function vtolAttack()
 {
-	let list = [cTempl.nxlscouv, cTempl.nxmtherv, cTempl.nxlscouv, cTempl.nxmheapv];
-	let ext = {
+	const list = [cTempl.nxlscouv, cTempl.nxmtherv, cTempl.nxlscouv, cTempl.nxmheapv];
+	const ext = {
 		limit: [2, 4, 2, 4],
 		alternate: true,
 		altIdx: 0
 	};
-	camSetVtolData(NEXUS, (difficulty === INSANE) ? undefined : "vtolAppearPos", "vtolRemovePos", list, camChangeOnDiff(camMinutesToMilliseconds(2)), undefined, ext);
+	camSetVtolData(CAM_NEXUS, (difficulty === INSANE) ? undefined : "vtolAppearPos", "vtolRemovePos", list, camChangeOnDiff(camMinutesToMilliseconds(2)), undefined, ext);
 }
 
 // Order any absorbed trucks to start building defenses near themselves.
 function truckDefense()
 {
-	let droids = enumDroid(NEXUS, DROID_CONSTRUCT);
-	let defenses = [
+	const droids = enumDroid(CAM_NEXUS, DROID_CONSTRUCT);
+	const defenses = [
 		"Sys-NEXUSLinkTOW", "P0-AASite-SAM2", "Emplacement-PrisLas",
 		"NX-Tower-ATMiss", "Sys-NX-CBTower",
 	];
 
 	for (let i = 0, len = droids.length; i < len; ++i)
 	{
-		let truck = droids[i];
+		const truck = droids[i];
 		if (truck.order !== DORDER_BUILD)
 		{
-			let defense = defenses[camRand(defenses.length)];
-			let loc = pickStructLocation(truck, defense, truck.x, truck.y);
-			enableStructure(defense, NEXUS);
+			const _DEFENSE = defenses[camRand(defenses.length)];
+			const loc = pickStructLocation(truck, _DEFENSE, truck.x, truck.y);
+			enableStructure(_DEFENSE, CAM_NEXUS);
 			if (camDef(loc))
 			{
-				orderDroidBuild(truck, DORDER_BUILD, defense, truck.x, truck.y);
+				orderDroidBuild(truck, DORDER_BUILD, _DEFENSE, truck.x, truck.y);
 			}
 		}
 	}
@@ -120,11 +120,11 @@ function hackManufacture(structure, template)
 
 function nexusManufacture()
 {
-	if (countDroid(DROID_ANY, NEXUS) > 100)
+	if (countDroid(DROID_ANY, CAM_NEXUS) > 100)
 	{
 		return;
 	}
-	let factoryType = [
+	const factoryType = [
 		{structure: FACTORY, temps: [cTempl.nxmrailh, cTempl.nxmlinkh, cTempl.nxmscouh, cTempl.nxlflash,]},
 		{structure: CYBORG_FACTORY, temps: [cTempl.nxcyrail, cTempl.nxcyscou, cTempl.nxcylas,]},
 		{structure: VTOL_FACTORY, temps: [cTempl.nxlscouv, cTempl.nxmtherv, cTempl.nxmheapv,]},
@@ -132,12 +132,12 @@ function nexusManufacture()
 
 	for (let i = 0; i < factoryType.length; ++i)
 	{
-		let factories = enumStruct(NEXUS, factoryType[i].structure);
-		let templs = factoryType[i].temps;
+		const factories = enumStruct(CAM_NEXUS, factoryType[i].structure);
+		const templs = factoryType[i].temps;
 
 		for (let j = 0, len = factories.length; j < len; ++j)
 		{
-			let fac = factories[j];
+			const fac = factories[j];
 			if (fac.status !== BUILT || !structureIdle(fac))
 			{
 				return;
@@ -151,8 +151,8 @@ function nexusManufacture()
 
 function manualGrouping()
 {
-	let vtols = enumDroid(NEXUS).filter((obj) => (obj.group === null && isVTOL(obj)));
-	let nonVtols = enumDroid(NEXUS).filter((obj) => (obj.group === null && !isVTOL(obj)));
+	const vtols = enumDroid(CAM_NEXUS).filter((obj) => (obj.group === null && isVTOL(obj)));
+	const nonVtols = enumDroid(CAM_NEXUS).filter((obj) => (obj.group === null && !isVTOL(obj)));
 	if (vtols.length)
 	{
 		camManageGroup(camMakeGroup(vtols), CAM_ORDER_ATTACK, { regroup: false, count: -1 });
@@ -165,7 +165,7 @@ function manualGrouping()
 
 function eventObjectTransfer(obj, from)
 {
-	if (obj.player === NEXUS && from === CAM_HUMAN_PLAYER)
+	if (obj.player === CAM_NEXUS && from === CAM_HUMAN_PLAYER)
 	{
 		if (obj.type === STRUCTURE)
 		{
@@ -217,20 +217,20 @@ function hackPlayer()
 		return;
 	}
 
-	camHackIntoPlayer(CAM_HUMAN_PLAYER, NEXUS);
+	camHackIntoPlayer(CAM_HUMAN_PLAYER, CAM_NEXUS);
 }
 
 function synapticsSound()
 {
-	playSound(SYNAPTICS_ACTIVATED);
-	camHackIntoPlayer(CAM_HUMAN_PLAYER, NEXUS);
+	playSound(CAM_SYNAPTICS_ACTIVATED_SND);
+	camHackIntoPlayer(CAM_HUMAN_PLAYER, CAM_NEXUS);
 }
 
 //winFlag is set in eventResearched.
 function resistanceResearched()
 {
-	let mapEdgeCount = (difficulty >= MEDIUM) ? 15 : 8;
-	if (winFlag && edgeMapCounter >= mapEdgeCount)
+	const MAP_EDGE_COUNT = (difficulty >= MEDIUM) ? 15 : 8;
+	if (winFlag && edgeMapCounter >= MAP_EDGE_COUNT)
 	{
 		return true;
 	}
@@ -240,8 +240,8 @@ function eventStartLevel()
 {
 	camSetExtraObjectiveMessage(_("Research resistance circuits and survive the assault from Nexus"));
 
-	let startpos = getObject("startPosition");
-	let lz = getObject("landingZone");
+	const startPos = getObject("startPosition");
+	const lz = getObject("landingZone");
 
 	camSetStandardWinLossConditions(CAM_VICTORY_STANDARD, "CAM3C", {
 		callback: "resistanceResearched"
@@ -250,14 +250,14 @@ function eventStartLevel()
 	camSetNexusState(true);
 	camPlayVideos([{video: "MB3_AB_MSG", type: CAMP_MSG}, {video: "MB3_AB_MSG2", type: CAMP_MSG}, {video: "MB3_AB_MSG3", type: MISS_MSG}]);
 
-	centreView(startpos.x, startpos.y);
+	centreView(startPos.x, startPos.y);
 	setNoGoArea(lz.x, lz.y, lz.x2, lz.y2, CAM_HUMAN_PLAYER);
 	setMissionTime(camChangeOnDiff(camHoursToSeconds(1)));
 
-	let enemyLz = getObject("NXlandingZone");
-	setNoGoArea(enemyLz.x, enemyLz.y, enemyLz.x2, enemyLz.y2, NEXUS);
+	const enemyLz = getObject("NXlandingZone");
+	setNoGoArea(enemyLz.x, enemyLz.y, enemyLz.x2, enemyLz.y2, CAM_NEXUS);
 
-	camCompleteRequiredResearch(NEXUS_RES, NEXUS);
+	camCompleteRequiredResearch(mis_nexusRes, CAM_NEXUS);
 
 	enableResearch("R-Sys-Resistance-Upgrade01", CAM_HUMAN_PLAYER);
 	winFlag = false;

--- a/data/base/script/campaign/cam3-ab.js
+++ b/data/base/script/campaign/cam3-ab.js
@@ -35,13 +35,13 @@ camAreaEvent("vtolRemoveZone", function(droid)
 
 function sendEdgeMapDroids()
 {
-	var unitCount = 16 + camRand(5); // 16 - 20.
+	let unitCount = 16 + camRand(5); // 16 - 20.
 	if (difficulty === INSANE)
 	{
 		unitCount = 14 + camRand(3); // 14 - 16.
 	}
 	const EDGE = ["SWPhantomFactory", "NWPhantomFactory"];
-	var list = [
+	let list = [
 		cTempl.nxcyrail, cTempl.nxcyscou, cTempl.nxcylas,
 		cTempl.nxlflash, cTempl.nxmrailh, cTempl.nxmlinkh,
 		cTempl.nxmscouh, cTempl.nxmsamh,
@@ -50,7 +50,7 @@ function sendEdgeMapDroids()
 	{
 		list = list.concat(cTempl.nxmangel);
 	}
-	var droids = [];
+	let droids = [];
 
 	if (!camDef(edgeMapCounter))
 	{
@@ -76,8 +76,8 @@ function sendEdgeMapDroids()
 //Setup Nexus VTOL hit and runners. NOTE: These do not go away in this mission.
 function vtolAttack()
 {
-	var list = [cTempl.nxlscouv, cTempl.nxmtherv, cTempl.nxlscouv, cTempl.nxmheapv];
-	var ext = {
+	let list = [cTempl.nxlscouv, cTempl.nxmtherv, cTempl.nxlscouv, cTempl.nxmheapv];
+	let ext = {
 		limit: [2, 4, 2, 4],
 		alternate: true,
 		altIdx: 0
@@ -88,19 +88,19 @@ function vtolAttack()
 // Order any absorbed trucks to start building defenses near themselves.
 function truckDefense()
 {
-	var droids = enumDroid(NEXUS, DROID_CONSTRUCT);
-	var defenses = [
+	let droids = enumDroid(NEXUS, DROID_CONSTRUCT);
+	let defenses = [
 		"Sys-NEXUSLinkTOW", "P0-AASite-SAM2", "Emplacement-PrisLas",
 		"NX-Tower-ATMiss", "Sys-NX-CBTower",
 	];
 
 	for (let i = 0, len = droids.length; i < len; ++i)
 	{
-		var truck = droids[i];
+		let truck = droids[i];
 		if (truck.order !== DORDER_BUILD)
 		{
-			var defense = defenses[camRand(defenses.length)];
-			var loc = pickStructLocation(truck, defense, truck.x, truck.y);
+			let defense = defenses[camRand(defenses.length)];
+			let loc = pickStructLocation(truck, defense, truck.x, truck.y);
 			enableStructure(defense, NEXUS);
 			if (camDef(loc))
 			{
@@ -124,7 +124,7 @@ function nexusManufacture()
 	{
 		return;
 	}
-	var factoryType = [
+	let factoryType = [
 		{structure: FACTORY, temps: [cTempl.nxmrailh, cTempl.nxmlinkh, cTempl.nxmscouh, cTempl.nxlflash,]},
 		{structure: CYBORG_FACTORY, temps: [cTempl.nxcyrail, cTempl.nxcyscou, cTempl.nxcylas,]},
 		{structure: VTOL_FACTORY, temps: [cTempl.nxlscouv, cTempl.nxmtherv, cTempl.nxmheapv,]},
@@ -132,12 +132,12 @@ function nexusManufacture()
 
 	for (let i = 0; i < factoryType.length; ++i)
 	{
-		var factories = enumStruct(NEXUS, factoryType[i].structure);
-		var templs = factoryType[i].temps;
+		let factories = enumStruct(NEXUS, factoryType[i].structure);
+		let templs = factoryType[i].temps;
 
 		for (let j = 0, len = factories.length; j < len; ++j)
 		{
-			var fac = factories[j];
+			let fac = factories[j];
 			if (fac.status !== BUILT || !structureIdle(fac))
 			{
 				return;
@@ -151,8 +151,8 @@ function nexusManufacture()
 
 function manualGrouping()
 {
-	var vtols = enumDroid(NEXUS).filter((obj) => (obj.group === null && isVTOL(obj)));
-	var nonVtols = enumDroid(NEXUS).filter((obj) => (obj.group === null && !isVTOL(obj)));
+	let vtols = enumDroid(NEXUS).filter((obj) => (obj.group === null && isVTOL(obj)));
+	let nonVtols = enumDroid(NEXUS).filter((obj) => (obj.group === null && !isVTOL(obj)));
 	if (vtols.length)
 	{
 		camManageGroup(camMakeGroup(vtols), CAM_ORDER_ATTACK, { regroup: false, count: -1 });
@@ -240,8 +240,8 @@ function eventStartLevel()
 {
 	camSetExtraObjectiveMessage(_("Research resistance circuits and survive the assault from Nexus"));
 
-	var startpos = getObject("startPosition");
-	var lz = getObject("landingZone");
+	let startpos = getObject("startPosition");
+	let lz = getObject("landingZone");
 
 	camSetStandardWinLossConditions(CAM_VICTORY_STANDARD, "CAM3C", {
 		callback: "resistanceResearched"
@@ -254,7 +254,7 @@ function eventStartLevel()
 	setNoGoArea(lz.x, lz.y, lz.x2, lz.y2, CAM_HUMAN_PLAYER);
 	setMissionTime(camChangeOnDiff(camHoursToSeconds(1)));
 
-	var enemyLz = getObject("NXlandingZone");
+	let enemyLz = getObject("NXlandingZone");
 	setNoGoArea(enemyLz.x, enemyLz.y, enemyLz.x2, enemyLz.y2, NEXUS);
 
 	camCompleteRequiredResearch(NEXUS_RES, NEXUS);

--- a/data/base/script/campaign/cam3-ad1.js
+++ b/data/base/script/campaign/cam3-ad1.js
@@ -1,9 +1,8 @@
 include("script/campaign/libcampaign.js");
 include("script/campaign/templates.js");
 
-const SILO_PLAYER = 1;
-const LASSAT_FIRING = "pcv650.ogg"; // LASER SATELLITE FIRING!!!
-const NEXUS_RES = [
+const MIS_SILO_PLAYER = 1;
+const mis_nexusRes = [
 	"R-Sys-Engineering03", "R-Defense-WallUpgrade10", "R-Struc-Materials10",
 	"R-Struc-VTOLPad-Upgrade06", "R-Wpn-Bomb-Damage03", "R-Sys-NEXUSrepair",
 	"R-Vehicle-Prop-Hover02", "R-Vehicle-Prop-VTOL02", "R-Cyborg-Legs02",
@@ -84,13 +83,13 @@ function enableAllFactories()
 
 function truckDefense()
 {
-	if (enumDroid(NEXUS, DROID_CONSTRUCT).length === 0)
+	if (enumDroid(CAM_NEXUS, DROID_CONSTRUCT).length === 0)
 	{
 		removeTimer("truckDefense");
 		return;
 	}
 
-	let list = ["Emplacement-Howitzer150", "Emplacement-MdART-pit"];
+	const list = ["Emplacement-Howitzer150", "Emplacement-MdART-pit"];
 	let position;
 
 	if (truckLocCounter === 0)
@@ -104,7 +103,7 @@ function truckDefense()
 		truckLocCounter = 0;
 	}
 
-	camQueueBuilding(NEXUS, list[camRand(list.length)], position);
+	camQueueBuilding(CAM_NEXUS, list[camRand(list.length)], position);
 }
 
 //Choose a target to fire the LasSat at. Automatically increases the limits
@@ -112,7 +111,7 @@ function truckDefense()
 function vaporizeTarget()
 {
 	let target;
-	let targets = enumArea(0, 0, mapWidth, Math.floor(mapLimit), CAM_HUMAN_PLAYER, false).filter((obj) => (
+	const targets = enumArea(0, 0, mapWidth, Math.floor(mapLimit), CAM_HUMAN_PLAYER, false).filter((obj) => (
 		obj.type === DROID || obj.type === STRUCTURE
 	));
 
@@ -126,9 +125,9 @@ function vaporizeTarget()
 	}
 	else
 	{
-		let dr = targets.filter((obj) => (obj.type === DROID && !isVTOL(obj)));
-		let vt = targets.filter((obj) => (obj.type === DROID && isVTOL(obj)));
-		let st = targets.filter((obj) => (obj.type === STRUCTURE));
+		const dr = targets.filter((obj) => (obj.type === DROID && !isVTOL(obj)));
+		const vt = targets.filter((obj) => (obj.type === DROID && isVTOL(obj)));
+		const st = targets.filter((obj) => (obj.type === STRUCTURE));
 
 		if (dr.length)
 		{
@@ -163,18 +162,18 @@ function vaporizeTarget()
 //A simple way to fire the LasSat with a chance of missing.
 function laserSatFuzzyStrike(obj)
 {
-	const LOC = camMakePos(obj);
+	const loc = camMakePos(obj);
 	//Initially lock onto target
-	let xCoord = LOC.x;
-	let yCoord = LOC.y;
+	let xCoord = loc.x;
+	let yCoord = loc.y;
 
 	//Introduce some randomness
 	if (camRand(101) < 67)
 	{
-		let xRand = camRand(3);
-		let yRand = camRand(3);
-		xCoord = camRand(2) ? LOC.x - xRand : LOC.x + xRand;
-		yCoord = camRand(2) ? LOC.y - yRand : LOC.y + yRand;
+		const X_RAND = camRand(3);
+		const Y_RAND = camRand(3);
+		xCoord = camRand(2) ? loc.x - X_RAND : loc.x + X_RAND;
+		yCoord = camRand(2) ? loc.y - Y_RAND : loc.y + Y_RAND;
 	}
 
 	if (xCoord < 0)
@@ -197,11 +196,12 @@ function laserSatFuzzyStrike(obj)
 
 	if (camRand(101) < 40)
 	{
+		const LASSAT_FIRING = "pcv650.ogg"; // LASER SATELLITE FIRING!!!
 		playSound(LASSAT_FIRING, xCoord, yCoord);
 	}
 
 	//Missed it so hit close to target.
-	if (LOC.x !== xCoord || LOC.y !== yCoord || !camDef(obj.id))
+	if (loc.x !== xCoord || loc.y !== yCoord || !camDef(obj.id))
 	{
 		fireWeaponAtLoc("LasSat", xCoord, yCoord, CAM_HUMAN_PLAYER);
 	}
@@ -217,14 +217,14 @@ function allySiloWithPlayer()
 {
 	playSound("pcv621.ogg"); //Objective captured
 	hackRemoveMessage("CM3D1_OBJ1", PROX_MSG, CAM_HUMAN_PLAYER);
-	camAbsorbPlayer(SILO_PLAYER, CAM_HUMAN_PLAYER);
+	camAbsorbPlayer(MIS_SILO_PLAYER, CAM_HUMAN_PLAYER);
 	capturedSilos = true;
 }
 
 //Check if the silos still exist and only allow winning if the player captured them.
 function checkMissileSilos()
 {
-	if (!countStruct("NX-ANTI-SATSite", CAM_HUMAN_PLAYER) && !countStruct("NX-ANTI-SATSite", SILO_PLAYER))
+	if (!countStruct("NX-ANTI-SATSite", CAM_HUMAN_PLAYER) && !countStruct("NX-ANTI-SATSite", MIS_SILO_PLAYER))
 	{
 		return false;
 	}
@@ -232,7 +232,7 @@ function checkMissileSilos()
 	if (capturedSilos)
 	{
 		const Y_SCROLL_LIMIT = 140; // About the same number as the one in the Gamma 8 script.
-		let safeToWinObjs = enumArea(0, Y_SCROLL_LIMIT, mapWidth, mapHeight, CAM_HUMAN_PLAYER, false).filter((obj) => (
+		const safeToWinObjs = enumArea(0, Y_SCROLL_LIMIT, mapWidth, mapHeight, CAM_HUMAN_PLAYER, false).filter((obj) => (
 			((obj.type === DROID && obj.droidType === DROID_CONSTRUCT) || (obj.type === STRUCTURE && obj.stattype === FACTORY && obj.status === BUILT))
 		));
 
@@ -242,10 +242,10 @@ function checkMissileSilos()
 		}
 	}
 
-	let siloArea = camMakePos(getObject("missileSilos"));
-	let safe = enumRange(siloArea.x, siloArea.y, 10, ALL_PLAYERS, false);
-	let enemies = safe.filter((obj) => (obj.player === NEXUS));
-	let player = safe.filter((obj) => (obj.player === CAM_HUMAN_PLAYER));
+	const siloArea = camMakePos(getObject("missileSilos"));
+	const safe = enumRange(siloArea.x, siloArea.y, 10, ALL_PLAYERS, false);
+	const enemies = safe.filter((obj) => (obj.player === CAM_NEXUS));
+	const player = safe.filter((obj) => (obj.player === CAM_HUMAN_PLAYER));
 	if (!enemies.length && player.length)
 	{
 		camCallOnce("allySiloWithPlayer");
@@ -256,27 +256,27 @@ function eventStartLevel()
 {
 	camSetExtraObjectiveMessage(_("Build a forward base at the silos"));
 
-	let siloZone = getObject("missileSilos");
-	let startpos = getObject("startPosition");
-	let lz = getObject("landingZone");
-	let lz2 = getObject("landingZone2"); //LZ for cam3-4s.
+	const siloZone = getObject("missileSilos");
+	const startPos = getObject("startPosition");
+	const lz = getObject("landingZone");
+	const lz2 = getObject("landingZone2"); //LZ for cam3-4s.
 	mapLimit = 1.0;
 
 	camSetStandardWinLossConditions(CAM_VICTORY_STANDARD, "CAM3A-D2", {
 		callback: "checkMissileSilos"
 	});
 
-	centreView(startpos.x, startpos.y);
+	centreView(startPos.x, startPos.y);
 	setNoGoArea(lz.x, lz.y, lz.x2, lz.y2, CAM_HUMAN_PLAYER);
 	setNoGoArea(lz2.x, lz2.y, lz2.x2, lz2.y2, 5);
-	setNoGoArea(lz2.x, lz2.y, lz2.x2, lz2.y2, NEXUS);
-	setNoGoArea(siloZone.x, siloZone.y, siloZone.x2, siloZone.y2, SILO_PLAYER);
+	setNoGoArea(lz2.x, lz2.y, lz2.x2, lz2.y2, CAM_NEXUS);
+	setNoGoArea(siloZone.x, siloZone.y, siloZone.x2, siloZone.y2, MIS_SILO_PLAYER);
 	setMissionTime(camChangeOnDiff(camHoursToSeconds(2)));
 
-	camCompleteRequiredResearch(NEXUS_RES, NEXUS);
+	camCompleteRequiredResearch(mis_nexusRes, CAM_NEXUS);
 
-	setAlliance(CAM_HUMAN_PLAYER, SILO_PLAYER, true);
-	setAlliance(NEXUS, SILO_PLAYER, true);
+	setAlliance(CAM_HUMAN_PLAYER, MIS_SILO_PLAYER, true);
+	setAlliance(CAM_NEXUS, MIS_SILO_PLAYER, true);
 
 	camSetArtifacts({
 		"NXbase1VtolFacArti": { tech: "R-Wpn-MdArtMissile" },
@@ -352,9 +352,9 @@ function eventStartLevel()
 
 	if (difficulty >= HARD)
 	{
-		addDroid(NEXUS, 15, 234, "Truck Retribution Hover", "Body7ABT", "hover02", "", "", "Spade1Mk1");
+		addDroid(CAM_NEXUS, 15, 234, "Truck Retribution Hover", "Body7ABT", "hover02", "", "", "Spade1Mk1");
 
-		camManageTrucks(NEXUS);
+		camManageTrucks(CAM_NEXUS);
 
 		setTimer("truckDefense", camChangeOnDiff(camMinutesToMilliseconds(4.5)));
 	}

--- a/data/base/script/campaign/cam3-ad1.js
+++ b/data/base/script/campaign/cam3-ad1.js
@@ -90,8 +90,8 @@ function truckDefense()
 		return;
 	}
 
-	var list = ["Emplacement-Howitzer150", "Emplacement-MdART-pit"];
-	var position;
+	let list = ["Emplacement-Howitzer150", "Emplacement-MdART-pit"];
+	let position;
 
 	if (truckLocCounter === 0)
 	{
@@ -111,8 +111,8 @@ function truckDefense()
 //when no target is found in the area.
 function vaporizeTarget()
 {
-	var target;
-	var targets = enumArea(0, 0, mapWidth, Math.floor(mapLimit), CAM_HUMAN_PLAYER, false).filter((obj) => (
+	let target;
+	let targets = enumArea(0, 0, mapWidth, Math.floor(mapLimit), CAM_HUMAN_PLAYER, false).filter((obj) => (
 		obj.type === DROID || obj.type === STRUCTURE
 	));
 
@@ -126,9 +126,9 @@ function vaporizeTarget()
 	}
 	else
 	{
-		var dr = targets.filter((obj) => (obj.type === DROID && !isVTOL(obj)));
-		var vt = targets.filter((obj) => (obj.type === DROID && isVTOL(obj)));
-		var st = targets.filter((obj) => (obj.type === STRUCTURE));
+		let dr = targets.filter((obj) => (obj.type === DROID && !isVTOL(obj)));
+		let vt = targets.filter((obj) => (obj.type === DROID && isVTOL(obj)));
+		let st = targets.filter((obj) => (obj.type === STRUCTURE));
 
 		if (dr.length)
 		{
@@ -165,14 +165,14 @@ function laserSatFuzzyStrike(obj)
 {
 	const LOC = camMakePos(obj);
 	//Initially lock onto target
-	var xCoord = LOC.x;
-	var yCoord = LOC.y;
+	let xCoord = LOC.x;
+	let yCoord = LOC.y;
 
 	//Introduce some randomness
 	if (camRand(101) < 67)
 	{
-		var xRand = camRand(3);
-		var yRand = camRand(3);
+		let xRand = camRand(3);
+		let yRand = camRand(3);
 		xCoord = camRand(2) ? LOC.x - xRand : LOC.x + xRand;
 		yCoord = camRand(2) ? LOC.y - yRand : LOC.y + yRand;
 	}
@@ -242,10 +242,10 @@ function checkMissileSilos()
 		}
 	}
 
-	var siloArea = camMakePos(getObject("missileSilos"));
-	var safe = enumRange(siloArea.x, siloArea.y, 10, ALL_PLAYERS, false);
-	var enemies = safe.filter((obj) => (obj.player === NEXUS));
-	var player = safe.filter((obj) => (obj.player === CAM_HUMAN_PLAYER));
+	let siloArea = camMakePos(getObject("missileSilos"));
+	let safe = enumRange(siloArea.x, siloArea.y, 10, ALL_PLAYERS, false);
+	let enemies = safe.filter((obj) => (obj.player === NEXUS));
+	let player = safe.filter((obj) => (obj.player === CAM_HUMAN_PLAYER));
 	if (!enemies.length && player.length)
 	{
 		camCallOnce("allySiloWithPlayer");
@@ -256,10 +256,10 @@ function eventStartLevel()
 {
 	camSetExtraObjectiveMessage(_("Build a forward base at the silos"));
 
-	var siloZone = getObject("missileSilos");
-	var startpos = getObject("startPosition");
-	var lz = getObject("landingZone");
-	var lz2 = getObject("landingZone2"); //LZ for cam3-4s.
+	let siloZone = getObject("missileSilos");
+	let startpos = getObject("startPosition");
+	let lz = getObject("landingZone");
+	let lz2 = getObject("landingZone2"); //LZ for cam3-4s.
 	mapLimit = 1.0;
 
 	camSetStandardWinLossConditions(CAM_VICTORY_STANDARD, "CAM3A-D2", {

--- a/data/base/script/campaign/cam3-ad2.js
+++ b/data/base/script/campaign/cam3-ad2.js
@@ -41,18 +41,17 @@ camAreaEvent("vtolRemoveZone", function(droid)
 //Return a random assortment of droids with the given templates.
 function randomTemplates(list)
 {
-	var i = 0;
-	var extras = [cTempl.nxmsens, cTempl.nxmsamh];
-	var droids = [];
-	var size = 12 + camRand(4); //Max of 15.
+	let extras = [cTempl.nxmsens, cTempl.nxmsamh];
+	let droids = [];
+	let size = 12 + camRand(4); //Max of 15.
 
-	for (i = 0; i < size; ++i)
+	for (let i = 0; i < size; ++i)
 	{
 		droids.push(list[camRand(list.length)]);
 	}
 
 	//Sensor and vindicator hovers.
-	for (i = 0; i < 4; ++i)
+	for (let i = 0; i < 4; ++i)
 	{
 		droids.push(extras[camRand(extras.length)]);
 	}
@@ -63,15 +62,15 @@ function randomTemplates(list)
 //Chose a random spawn point for the VTOLs.
 function vtolAttack()
 {
-	var list = [cTempl.nxmheapv, cTempl.nxlpulsev];
+	let list = [cTempl.nxmheapv, cTempl.nxlpulsev];
 	camSetVtolData(NEXUS, VTOL_POSITIONS, "vtolRemovePos", list, camChangeOnDiff(camMinutesToMilliseconds(3)));
 }
 
 //Chose a random spawn point to send ground reinforcements.
 function phantomFactorySpawn()
 {
-	var list;
-	var chosenFactory;
+	let list;
+	let chosenFactory;
 
 	switch (camRand(3))
 	{
@@ -104,8 +103,8 @@ function phantomFactorySpawn()
 //when no target is found in the area.
 function vaporizeTarget()
 {
-	var target;
-	var targets = enumArea(0, Y_SCROLL_LIMIT, mapWidth, Math.floor(mapLimit), CAM_HUMAN_PLAYER, false).filter((obj) => (
+	let target;
+	let targets = enumArea(0, Y_SCROLL_LIMIT, mapWidth, Math.floor(mapLimit), CAM_HUMAN_PLAYER, false).filter((obj) => (
 		obj.type === DROID || obj.type === STRUCTURE
 	));
 
@@ -124,9 +123,9 @@ function vaporizeTarget()
 	}
 	else
 	{
-		var dr = targets.filter((obj) => (obj.type === DROID && !isVTOL(obj)));
-		var vt = targets.filter((obj) => (obj.type === DROID && isVTOL(obj)));
-		var st = targets.filter((obj) => (obj.type === STRUCTURE));
+		let dr = targets.filter((obj) => (obj.type === DROID && !isVTOL(obj)));
+		let vt = targets.filter((obj) => (obj.type === DROID && isVTOL(obj)));
+		let st = targets.filter((obj) => (obj.type === STRUCTURE));
 
 		if (dr.length)
 		{
@@ -172,14 +171,14 @@ function laserSatFuzzyStrike(obj)
 {
 	const LOC = camMakePos(obj);
 	//Initially lock onto target
-	var xCoord = LOC.x;
-	var yCoord = LOC.y;
+	let xCoord = LOC.x;
+	let yCoord = LOC.y;
 
 	//Introduce some randomness. More accurate than last mission.
 	if (camRand(101) < 33)
 	{
-		var xRand = camRand(2);
-		var yRand = camRand(2);
+		let xRand = camRand(2);
+		let yRand = camRand(2);
 		xCoord = camRand(2) ? LOC.x - xRand : LOC.x + xRand;
 		yCoord = camRand(2) ? LOC.y - yRand : LOC.y + yRand;
 	}
@@ -278,8 +277,8 @@ function eventStartLevel()
 {
 	camSetExtraObjectiveMessage(_("Protect the missile silos and research for the missile codes"));
 
-	var startpos = getObject("startPosition");
-	var lz = getObject("landingZone");
+	let startpos = getObject("startPosition");
+	let lz = getObject("landingZone");
 	mapLimit = 137.0;
 	winFlag = false;
 	videoInfo = [
@@ -296,7 +295,7 @@ function eventStartLevel()
 	setScrollLimits(0, Y_SCROLL_LIMIT, 64, 256);
 
 	//Destroy everything above limits
-	var destroyZone = enumArea(0, 0, 64, Y_SCROLL_LIMIT, CAM_HUMAN_PLAYER, false);
+	let destroyZone = enumArea(0, 0, 64, Y_SCROLL_LIMIT, CAM_HUMAN_PLAYER, false);
 	for (let i = 0, l = destroyZone.length; i < l; ++i)
 	{
 		camSafeRemoveObject(destroyZone[i], false);

--- a/data/base/script/campaign/cam3-ad2.js
+++ b/data/base/script/campaign/cam3-ad2.js
@@ -1,9 +1,8 @@
 include("script/campaign/libcampaign.js");
 include("script/campaign/templates.js");
 
-const Y_SCROLL_LIMIT = 137;
-const LASSAT_FIRING = "pcv650.ogg"; // LASER SATELLITE FIRING!!!
-const NEXUS_RES = [
+const MIS_Y_SCROLL_LIMIT = 137;
+const mis_nexusRes = [
 	"R-Sys-Engineering03", "R-Defense-WallUpgrade10", "R-Struc-Materials10",
 	"R-Struc-VTOLPad-Upgrade06", "R-Wpn-Bomb-Damage03", "R-Sys-NEXUSrepair",
 	"R-Vehicle-Prop-Hover02", "R-Vehicle-Prop-VTOL02", "R-Cyborg-Legs02",
@@ -17,7 +16,7 @@ const NEXUS_RES = [
 	"R-Wpn-Energy-Damage03", "R-Wpn-Energy-ROF03", "R-Wpn-Energy-Accuracy01",
 	"R-Wpn-AAGun-Accuracy03", "R-Wpn-Howitzer-Accuracy03",
 ];
-const VTOL_POSITIONS = [
+const mis_vtolPositions = [
 	"vtolAppearPosW", "vtolAppearPosE",
 ];
 var winFlag;
@@ -35,17 +34,17 @@ camAreaEvent("vtolRemoveZone", function(droid)
 		}
 	}
 
-	resetLabel("vtolRemoveZone", NEXUS);
+	resetLabel("vtolRemoveZone", CAM_NEXUS);
 });
 
 //Return a random assortment of droids with the given templates.
 function randomTemplates(list)
 {
-	let extras = [cTempl.nxmsens, cTempl.nxmsamh];
-	let droids = [];
-	let size = 12 + camRand(4); //Max of 15.
+	const extras = [cTempl.nxmsens, cTempl.nxmsamh];
+	const droids = [];
+	const SIZE = 12 + camRand(4); //Max of 15.
 
-	for (let i = 0; i < size; ++i)
+	for (let i = 0; i < SIZE; ++i)
 	{
 		droids.push(list[camRand(list.length)]);
 	}
@@ -62,8 +61,8 @@ function randomTemplates(list)
 //Chose a random spawn point for the VTOLs.
 function vtolAttack()
 {
-	let list = [cTempl.nxmheapv, cTempl.nxlpulsev];
-	camSetVtolData(NEXUS, VTOL_POSITIONS, "vtolRemovePos", list, camChangeOnDiff(camMinutesToMilliseconds(3)));
+	const list = [cTempl.nxmheapv, cTempl.nxlpulsev];
+	camSetVtolData(CAM_NEXUS, mis_vtolPositions, "vtolRemovePos", list, camChangeOnDiff(camMinutesToMilliseconds(3)));
 }
 
 //Chose a random spawn point to send ground reinforcements.
@@ -91,9 +90,9 @@ function phantomFactorySpawn()
 			chosenFactory = "phantomFacWest";
 	}
 
-	if (countDroid(DROID_ANY, NEXUS) < 80)
+	if (countDroid(DROID_ANY, CAM_NEXUS) < 80)
 	{
-		camSendReinforcement(NEXUS, camMakePos(chosenFactory), randomTemplates(list), CAM_REINFORCE_GROUND, {
+		camSendReinforcement(CAM_NEXUS, camMakePos(chosenFactory), randomTemplates(list), CAM_REINFORCE_GROUND, {
 			data: { regroup: false, count: -1, },
 		});
 	}
@@ -104,7 +103,7 @@ function phantomFactorySpawn()
 function vaporizeTarget()
 {
 	let target;
-	let targets = enumArea(0, Y_SCROLL_LIMIT, mapWidth, Math.floor(mapLimit), CAM_HUMAN_PLAYER, false).filter((obj) => (
+	const targets = enumArea(0, MIS_Y_SCROLL_LIMIT, mapWidth, Math.floor(mapLimit), CAM_HUMAN_PLAYER, false).filter((obj) => (
 		obj.type === DROID || obj.type === STRUCTURE
 	));
 
@@ -113,7 +112,7 @@ function vaporizeTarget()
 		//Choose random coordinate within the limits.
 		target = {
 			x: camRand(mapWidth),
-			y: Y_SCROLL_LIMIT + camRand(mapHeight - Math.floor(mapLimit)),
+			y: MIS_Y_SCROLL_LIMIT + camRand(mapHeight - Math.floor(mapLimit)),
 		};
 
 		if (target.y > Math.floor(mapLimit))
@@ -123,9 +122,9 @@ function vaporizeTarget()
 	}
 	else
 	{
-		let dr = targets.filter((obj) => (obj.type === DROID && !isVTOL(obj)));
-		let vt = targets.filter((obj) => (obj.type === DROID && isVTOL(obj)));
-		let st = targets.filter((obj) => (obj.type === STRUCTURE));
+		const dr = targets.filter((obj) => (obj.type === DROID && !isVTOL(obj)));
+		const vt = targets.filter((obj) => (obj.type === DROID && isVTOL(obj)));
+		const st = targets.filter((obj) => (obj.type === STRUCTURE));
 
 		if (dr.length)
 		{
@@ -169,18 +168,18 @@ function vaporizeTarget()
 //A simple way to fire the LasSat with a chance of missing.
 function laserSatFuzzyStrike(obj)
 {
-	const LOC = camMakePos(obj);
+	const loc = camMakePos(obj);
 	//Initially lock onto target
-	let xCoord = LOC.x;
-	let yCoord = LOC.y;
+	let xCoord = loc.x;
+	let yCoord = loc.y;
 
 	//Introduce some randomness. More accurate than last mission.
 	if (camRand(101) < 33)
 	{
-		let xRand = camRand(2);
-		let yRand = camRand(2);
-		xCoord = camRand(2) ? LOC.x - xRand : LOC.x + xRand;
-		yCoord = camRand(2) ? LOC.y - yRand : LOC.y + yRand;
+		const X_RAND = camRand(2);
+		const Y_RAND = camRand(2);
+		xCoord = camRand(2) ? loc.x - X_RAND : loc.x + X_RAND;
+		yCoord = camRand(2) ? loc.y - Y_RAND : loc.y + Y_RAND;
 	}
 
 	if (xCoord < 0)
@@ -205,11 +204,12 @@ function laserSatFuzzyStrike(obj)
 	{
 		if (camRand(101) < 40)
 		{
+			const LASSAT_FIRING = "pcv650.ogg"; // LASER SATELLITE FIRING!!!
 			playSound(LASSAT_FIRING, xCoord, yCoord);
 		}
 
 		//Missed it so hit close to target
-		if (LOC.x !== xCoord || LOC.y !== yCoord || !camDef(obj.id))
+		if (loc.x !== xCoord || loc.y !== yCoord || !camDef(obj.id))
 		{
 			fireWeaponAtLoc("LasSat", xCoord, yCoord, CAM_HUMAN_PLAYER);
 		}
@@ -277,8 +277,8 @@ function eventStartLevel()
 {
 	camSetExtraObjectiveMessage(_("Protect the missile silos and research for the missile codes"));
 
-	let startpos = getObject("startPosition");
-	let lz = getObject("landingZone");
+	const startPos = getObject("startPosition");
+	const lz = getObject("landingZone");
 	mapLimit = 137.0;
 	winFlag = false;
 	videoInfo = [
@@ -292,21 +292,21 @@ function eventStartLevel()
 		callback: "checkMissileSilos"
 	});
 
-	setScrollLimits(0, Y_SCROLL_LIMIT, 64, 256);
+	setScrollLimits(0, MIS_Y_SCROLL_LIMIT, 64, 256);
 
 	//Destroy everything above limits
-	let destroyZone = enumArea(0, 0, 64, Y_SCROLL_LIMIT, CAM_HUMAN_PLAYER, false);
+	const destroyZone = enumArea(0, 0, 64, MIS_Y_SCROLL_LIMIT, CAM_HUMAN_PLAYER, false);
 	for (let i = 0, l = destroyZone.length; i < l; ++i)
 	{
 		camSafeRemoveObject(destroyZone[i], false);
 	}
 
-	centreView(startpos.x, startpos.y);
+	centreView(startPos.x, startPos.y);
 	setNoGoArea(lz.x, lz.y, lz.x2, lz.y2, CAM_HUMAN_PLAYER);
 	setMissionTime(camMinutesToSeconds(5));
 	enableResearch("R-Sys-Resistance", CAM_HUMAN_PLAYER);
 
-	camCompleteRequiredResearch(NEXUS_RES, NEXUS);
+	camCompleteRequiredResearch(mis_nexusRes, CAM_NEXUS);
 	camPlayVideos({video: "MB3_AD2_MSG", type: MISS_MSG});
 
 	setTimer("checkTime", camSecondsToMilliseconds(0.2));

--- a/data/base/script/campaign/cam3-b.js
+++ b/data/base/script/campaign/cam3-b.js
@@ -58,8 +58,8 @@ function camEnemyBaseEliminated_NXWestBase()
 //Setup Nexus VTOL hit and runners.
 function vtolAttack()
 {
-	var list = [cTempl.nxmheapv, cTempl.nxlscouv, cTempl.nxmtherv, cTempl.nxlscouv];
-	var ext = {
+	let list = [cTempl.nxmheapv, cTempl.nxlscouv, cTempl.nxmtherv, cTempl.nxlscouv];
+	let ext = {
 		limit: [5, 2, 5, 2], //paired with template list
 		alternate: true,
 		altIdx: 0
@@ -83,9 +83,9 @@ function getDroidsForNXLZ(isTransport)
 	}
 
 	const COUNT = isTransport ? 10 : 10 + camRand(6);
-	var units = [cTempl.nxcyrail, cTempl.nxcyscou, cTempl.nxcylas, cTempl.nxmlinkh, cTempl.nxmrailh, cTempl.nxmsamh];
+	let units = [cTempl.nxcyrail, cTempl.nxcyscou, cTempl.nxcylas, cTempl.nxmlinkh, cTempl.nxmrailh, cTempl.nxmsamh];
 
-	var droids = [];
+	let droids = [];
 	for (let i = 0; i < COUNT; ++i)
 	{
 		droids.push(units[camRand(units.length)]);
@@ -104,9 +104,9 @@ function sendNXTransporter()
 	}
 
 	const LZ_ALIAS = "CM3B_TRANS"; //1 and 2
-	var list = getDroidsForNXLZ(true);
-	var lzNum;
-	var pos;
+	let list = getDroidsForNXLZ(true);
+	let lzNum;
+	let pos;
 
 	if (camCountStructuresInArea("NXEastBaseCleanup", NEXUS) > 0)
 	{
@@ -153,7 +153,7 @@ function sendNXlandReinforcements()
 function transferPower()
 {
 	const AWARD = 5000;
-	var powerTransferSound = "power-transferred.ogg";
+	let powerTransferSound = "power-transferred.ogg";
 	setPower(playerPower(CAM_HUMAN_PLAYER) + AWARD, CAM_HUMAN_PLAYER);
 	playSound(powerTransferSound);
 }
@@ -206,8 +206,8 @@ function truckDefense()
 		return;
 	}
 
-	var list = ["Emplacement-Howitzer105", "Emplacement-MdART-pit", "Emplacement-RotHow"];
-	var position;
+	let list = ["Emplacement-Howitzer105", "Emplacement-MdART-pit", "Emplacement-RotHow"];
+	let position;
 
 	if (truckLocCounter === 0)
 	{
@@ -271,8 +271,8 @@ function eventStartLevel()
 	trapActive = false;
 	gammaAttackCount = 0;
 	truckLocCounter = 0;
-	var startpos = getObject("startPosition");
-	var lz = getObject("landingZone");
+	let startpos = getObject("startPosition");
+	let lz = getObject("landingZone");
 
 	camSetStandardWinLossConditions(CAM_VICTORY_STANDARD, "SUB_3_2S");
 	setMissionTime(camChangeOnDiff(camMinutesToSeconds(30))); // For the rescue mission.
@@ -280,8 +280,8 @@ function eventStartLevel()
 	centreView(startpos.x, startpos.y);
 	setNoGoArea(lz.x, lz.y, lz.x2, lz.y2, CAM_HUMAN_PLAYER);
 
-	var enemyLz = getObject("NXlandingZone");
-	var enemyLz2 = getObject("NXlandingZone2");
+	let enemyLz = getObject("NXlandingZone");
+	let enemyLz2 = getObject("NXlandingZone2");
 	setNoGoArea(enemyLz.x, enemyLz.y, enemyLz.x2, enemyLz.y2, NEXUS);
 	setNoGoArea(enemyLz2.x, enemyLz2.y, enemyLz2.x2, enemyLz2.y2, 5);
 

--- a/data/base/script/campaign/cam3-b.js
+++ b/data/base/script/campaign/cam3-b.js
@@ -5,8 +5,8 @@ include("script/campaign/transitionTech.js");
 var trapActive;
 var gammaAttackCount;
 var truckLocCounter;
-const GAMMA = 1; // Player 1 is Gamma team.
-const NEXUS_RES = [
+const MIS_GAMMA_PLAYER = 1; // Player 1 is Gamma team.
+const mis_nexusRes = [
 	"R-Sys-Engineering03", "R-Defense-WallUpgrade08", "R-Struc-Materials08",
 	"R-Struc-VTOLPad-Upgrade06", "R-Wpn-Bomb-Damage03", "R-Sys-NEXUSrepair",
 	"R-Vehicle-Prop-Hover02", "R-Vehicle-Prop-VTOL02", "R-Cyborg-Legs02",
@@ -31,7 +31,7 @@ camAreaEvent("vtolRemoveZone", function(droid)
 		}
 	}
 
-	resetLabel("vtolRemoveZone", NEXUS);
+	resetLabel("vtolRemoveZone", CAM_NEXUS);
 });
 
 camAreaEvent("trapTrigger", function(droid)
@@ -41,7 +41,7 @@ camAreaEvent("trapTrigger", function(droid)
 
 camAreaEvent("mockBattleTrigger", function(droid)
 {
-	setAlliance(GAMMA, NEXUS, false); //brief mockup battle
+	setAlliance(MIS_GAMMA_PLAYER, CAM_NEXUS, false); //brief mockup battle
 	camCallOnce("activateNexusGroups"); //help destroy Gamma base
 });
 
@@ -58,14 +58,14 @@ function camEnemyBaseEliminated_NXWestBase()
 //Setup Nexus VTOL hit and runners.
 function vtolAttack()
 {
-	let list = [cTempl.nxmheapv, cTempl.nxlscouv, cTempl.nxmtherv, cTempl.nxlscouv];
-	let ext = {
+	const list = [cTempl.nxmheapv, cTempl.nxlscouv, cTempl.nxmtherv, cTempl.nxlscouv];
+	const ext = {
 		limit: [5, 2, 5, 2], //paired with template list
 		alternate: true,
 		altIdx: 0
 	};
 
-	camSetVtolData(NEXUS, "vtolAppearPos", "vtolRemovePos", list, camChangeOnDiff(camMinutesToMilliseconds(2)), "NXCommandCenter", ext);
+	camSetVtolData(CAM_NEXUS, "vtolAppearPos", "vtolRemovePos", list, camChangeOnDiff(camMinutesToMilliseconds(2)), "NXCommandCenter", ext);
 }
 
 function enableAllFactories()
@@ -83,9 +83,9 @@ function getDroidsForNXLZ(isTransport)
 	}
 
 	const COUNT = isTransport ? 10 : 10 + camRand(6);
-	let units = [cTempl.nxcyrail, cTempl.nxcyscou, cTempl.nxcylas, cTempl.nxmlinkh, cTempl.nxmrailh, cTempl.nxmsamh];
+	const units = [cTempl.nxcyrail, cTempl.nxcyscou, cTempl.nxcylas, cTempl.nxmlinkh, cTempl.nxmrailh, cTempl.nxmsamh];
 
-	let droids = [];
+	const droids = [];
 	for (let i = 0; i < COUNT; ++i)
 	{
 		droids.push(units[camRand(units.length)]);
@@ -97,24 +97,24 @@ function getDroidsForNXLZ(isTransport)
 //Send Nexus transport units
 function sendNXTransporter()
 {
-	if (camCountStructuresInArea("NXEastBaseCleanup", NEXUS) === 0 &&
-		camCountStructuresInArea("NXWestBaseCleanup", NEXUS) === 0)
+	if (camCountStructuresInArea("NXEastBaseCleanup", CAM_NEXUS) === 0 &&
+		camCountStructuresInArea("NXWestBaseCleanup", CAM_NEXUS) === 0)
 	{
 		return; //Call off transport when both west and east Nexus bases are destroyed.
 	}
 
 	const LZ_ALIAS = "CM3B_TRANS"; //1 and 2
-	let list = getDroidsForNXLZ(true);
+	const list = getDroidsForNXLZ(true);
 	let lzNum;
 	let pos;
 
-	if (camCountStructuresInArea("NXEastBaseCleanup", NEXUS) > 0)
+	if (camCountStructuresInArea("NXEastBaseCleanup", CAM_NEXUS) > 0)
 	{
 		lzNum = 1;
 		pos = "nexusEastTransportPos";
 	}
 
-	if (camCountStructuresInArea("NXWestBaseCleanup", NEXUS) > 0 && (camRand(2) || !camDef(pos)))
+	if (camCountStructuresInArea("NXWestBaseCleanup", CAM_NEXUS) > 0 && (camRand(2) || !camDef(pos)))
 	{
 		lzNum = 2;
 		pos = "nexusWestTransportPos";
@@ -122,7 +122,7 @@ function sendNXTransporter()
 
 	if (camDef(pos))
 	{
-		camSendReinforcement(NEXUS, camMakePos(pos), list, CAM_REINFORCE_TRANSPORT, {
+		camSendReinforcement(CAM_NEXUS, camMakePos(pos), list, CAM_REINFORCE_TRANSPORT, {
 			message: LZ_ALIAS + lzNum,
 			entry: { x: 62, y: 4 },
 			exit: { x: 62, y: 4 }
@@ -137,13 +137,13 @@ function sendNXTransporter()
 //Send Nexus land units
 function sendNXlandReinforcements()
 {
-	if (!enumArea("NXWestBaseCleanup", NEXUS, false).length)
+	if (!enumArea("NXWestBaseCleanup", CAM_NEXUS, false).length)
 	{
 		removeTimer("sendNXlandReinforcements");
 		return;
 	}
 
-	camSendReinforcement(NEXUS, camMakePos("westPhantomFactory"), getDroidsForNXLZ(),
+	camSendReinforcement(CAM_NEXUS, camMakePos("westPhantomFactory"), getDroidsForNXLZ(),
 		CAM_REINFORCE_GROUND, {
 			data: {regroup: true, count: -1,},
 		}
@@ -153,9 +153,9 @@ function sendNXlandReinforcements()
 function transferPower()
 {
 	const AWARD = 5000;
-	let powerTransferSound = "power-transferred.ogg";
+	const POWER_TRANSFER_SND = "power-transferred.ogg";
 	setPower(playerPower(CAM_HUMAN_PLAYER) + AWARD, CAM_HUMAN_PLAYER);
-	playSound(powerTransferSound);
+	playSound(POWER_TRANSFER_SND);
 }
 
 function activateNexusGroups()
@@ -200,13 +200,13 @@ function activateNexusGroups()
 
 function truckDefense()
 {
-	if (enumDroid(GAMMA, DROID_CONSTRUCT).length === 0)
+	if (enumDroid(MIS_GAMMA_PLAYER, DROID_CONSTRUCT).length === 0)
 	{
 		removeTimer("truckDefense");
 		return;
 	}
 
-	let list = ["Emplacement-Howitzer105", "Emplacement-MdART-pit", "Emplacement-RotHow"];
+	const list = ["Emplacement-Howitzer105", "Emplacement-MdART-pit", "Emplacement-RotHow"];
 	let position;
 
 	if (truckLocCounter === 0)
@@ -220,14 +220,14 @@ function truckDefense()
 		truckLocCounter = 0;
 	}
 
-	camQueueBuilding(GAMMA, list[camRand(list.length)], position);
+	camQueueBuilding(MIS_GAMMA_PLAYER, list[camRand(list.length)], position);
 }
 
 //Take everything Gamma has and donate to Nexus.
 function trapSprung()
 {
-	setAlliance(GAMMA, NEXUS, true);
-	setAlliance(GAMMA, CAM_HUMAN_PLAYER, false);
+	setAlliance(MIS_GAMMA_PLAYER, CAM_NEXUS, true);
+	setAlliance(MIS_GAMMA_PLAYER, CAM_HUMAN_PLAYER, false);
 	camPlayVideos({video: "MB3_B_MSG3", type: CAMP_MSG});
 	hackRemoveMessage("CM3B_GAMMABASE", PROX_MSG, CAM_HUMAN_PLAYER);
 
@@ -236,8 +236,8 @@ function trapSprung()
 	enableAllFactories();
 
 	sendNXTransporter();
-	changePlayerColour(GAMMA, NEXUS); // Black painting.
-	playSound(SYNAPTICS_ACTIVATED);
+	changePlayerColour(MIS_GAMMA_PLAYER, CAM_NEXUS); // Black painting.
+	playSound(CAM_SYNAPTICS_ACTIVATED_SND);
 
 	setTimer("sendNXTransporter", camChangeOnDiff(camMinutesToMilliseconds(3)));
 	setTimer("sendNXlandReinforcements", camChangeOnDiff(camMinutesToMilliseconds(4)));
@@ -248,7 +248,7 @@ function setupCapture()
 {
 	trapActive = true;
 	playSound("pcv455.ogg"); //Incoming message.
-	setAlliance(GAMMA, NEXUS, false);
+	setAlliance(MIS_GAMMA_PLAYER, CAM_NEXUS, false);
 
 	queue("trapSprung", camSecondsToMilliseconds(2)); //call this a few seconds later
 }
@@ -260,7 +260,7 @@ function eventAttacked(victim, attacker)
 		camCallOnce("setupCapture");
 	}
 
-	if (victim.player === GAMMA && attacker.player === NEXUS)
+	if (victim.player === MIS_GAMMA_PLAYER && attacker.player === CAM_NEXUS)
 	{
 		gammaAttackCount += 1;
 	}
@@ -271,26 +271,26 @@ function eventStartLevel()
 	trapActive = false;
 	gammaAttackCount = 0;
 	truckLocCounter = 0;
-	let startpos = getObject("startPosition");
-	let lz = getObject("landingZone");
+	const startPos = getObject("startPosition");
+	const lz = getObject("landingZone");
 
 	camSetStandardWinLossConditions(CAM_VICTORY_STANDARD, "SUB_3_2S");
 	setMissionTime(camChangeOnDiff(camMinutesToSeconds(30))); // For the rescue mission.
 
-	centreView(startpos.x, startpos.y);
+	centreView(startPos.x, startPos.y);
 	setNoGoArea(lz.x, lz.y, lz.x2, lz.y2, CAM_HUMAN_PLAYER);
 
-	let enemyLz = getObject("NXlandingZone");
-	let enemyLz2 = getObject("NXlandingZone2");
-	setNoGoArea(enemyLz.x, enemyLz.y, enemyLz.x2, enemyLz.y2, NEXUS);
+	const enemyLz = getObject("NXlandingZone");
+	const enemyLz2 = getObject("NXlandingZone2");
+	setNoGoArea(enemyLz.x, enemyLz.y, enemyLz.x2, enemyLz.y2, CAM_NEXUS);
 	setNoGoArea(enemyLz2.x, enemyLz2.y, enemyLz2.x2, enemyLz2.y2, 5);
 
-	camCompleteRequiredResearch(NEXUS_RES, NEXUS);
-	camCompleteRequiredResearch(GAMMA_ALLY_RES, GAMMA);
-	camCompleteRequiredResearch(NEXUS_RES, GAMMA); //They get even more research.
+	camCompleteRequiredResearch(mis_nexusRes, CAM_NEXUS);
+	camCompleteRequiredResearch(mis_gammaAllyRes, MIS_GAMMA_PLAYER);
+	camCompleteRequiredResearch(mis_nexusRes, MIS_GAMMA_PLAYER); //They get even more research.
 
-	setAlliance(GAMMA, CAM_HUMAN_PLAYER, false);
-	setAlliance(GAMMA, NEXUS, true);
+	setAlliance(MIS_GAMMA_PLAYER, CAM_HUMAN_PLAYER, false);
+	setAlliance(MIS_GAMMA_PLAYER, CAM_NEXUS, true);
 
 	camSetArtifacts({
 		"NXCommandCenter": { tech: "R-Struc-Research-Upgrade07" },
@@ -352,23 +352,23 @@ function eventStartLevel()
 	//In the event they put all trucks into Gamma 2 and have no completed factories on map...
 	if (enumStruct(CAM_HUMAN_PLAYER, FACTORY).filter((obj) => (obj.status === BUILT)).length === 0 && enumDroid(CAM_HUMAN_PLAYER, DROID_CONSTRUCT).length === 0)
 	{
-		let failSafeTruck = addDroid(GAMMA, lz.x, lz.y, "Truck Python Tracks", "Body11ABT", "tracked01", "", "", "Spade1Mk1");
+		const failSafeTruck = addDroid(MIS_GAMMA_PLAYER, lz.x, lz.y, "Truck Python Tracks", "Body11ABT", "tracked01", "", "", "Spade1Mk1");
 		donateObject(failSafeTruck, CAM_HUMAN_PLAYER); //So the reticules update for the next tick.
 	}
 
 	if (difficulty >= HARD)
 	{
-		addDroid(GAMMA, 28, 5, "Truck Python Tracks", "Body11ABT", "tracked01", "", "", "Spade1Mk1");
+		addDroid(MIS_GAMMA_PLAYER, 28, 5, "Truck Python Tracks", "Body11ABT", "tracked01", "", "", "Spade1Mk1");
 
-		camManageTrucks(GAMMA);
+		camManageTrucks(MIS_GAMMA_PLAYER);
 	}
 
-	setAlliance(GAMMA, CAM_HUMAN_PLAYER, true);
+	setAlliance(MIS_GAMMA_PLAYER, CAM_HUMAN_PLAYER, true);
 	hackAddMessage("CM3B_GAMMABASE", PROX_MSG, CAM_HUMAN_PLAYER, false);
 	camPlayVideos([{video: "MB3_B_MSG", type: CAMP_MSG}, {video: "MB3_B_MSG2", type: MISS_MSG}]);
 
-	changePlayerColour(GAMMA, 0);
-	setAlliance(GAMMA, CAM_HUMAN_PLAYER, true);
+	changePlayerColour(MIS_GAMMA_PLAYER, 0);
+	setAlliance(MIS_GAMMA_PLAYER, CAM_HUMAN_PLAYER, true);
 
 	queue("transferPower", camSecondsToMilliseconds(3));
 	queue("vtolAttack", camChangeOnDiff(camMinutesToMilliseconds(5)));

--- a/data/base/script/campaign/cam3-c.js
+++ b/data/base/script/campaign/cam3-c.js
@@ -79,8 +79,8 @@ function truckDefense()
 		return;
 	}
 
-	var list = ["Emplacement-Howitzer150", "Emplacement-MdART-pit"];
-	var position;
+	let list = ["Emplacement-Howitzer150", "Emplacement-MdART-pit"];
+	let position;
 
 	if (truckLocCounter === 0)
 	{
@@ -99,7 +99,7 @@ function truckDefense()
 function discoverGammaBase()
 {
 	reunited = true;
-	var lz = getObject("landingZone");
+	let lz = getObject("landingZone");
 	setScrollLimits(0, 0, 64, 192); //top and middle portion.
 	restoreLimboMissionData();
 	setNoGoArea(lz.x, lz.y, lz.x2, lz.y2, CAM_HUMAN_PLAYER);
@@ -122,7 +122,7 @@ function discoverGammaBase()
 
 function findBetaUnitIds()
 {
-	var droids = enumArea("betaUnits", CAM_HUMAN_PLAYER, false).filter((obj) => (
+	let droids = enumArea("betaUnits", CAM_HUMAN_PLAYER, false).filter((obj) => (
 		obj.type === DROID
 	));
 
@@ -139,8 +139,8 @@ function betaAlive()
 		return true; //Don't need to see if Beta is still alive if reunited with base.
 	}
 
-	var alive = false;
-	var myDroids = enumDroid(CAM_HUMAN_PLAYER);
+	let alive = false;
+	let myDroids = enumDroid(CAM_HUMAN_PLAYER);
 
 	for (let i = 0, l = betaUnitIds.length; i < l; ++i)
 	{
@@ -169,8 +169,8 @@ function eventStartLevel()
 {
 	camSetExtraObjectiveMessage(_("Reunite a part of Beta team with a Gamma team outpost"));
 
-	var startpos = getObject("startPosition");
-	var limboLZ = getObject("limboDroidLZ");
+	let startpos = getObject("startPosition");
+	let limboLZ = getObject("limboDroidLZ");
 	reunited = false;
 	betaUnitIds = [];
 	truckLocCounter = 0;
@@ -185,7 +185,7 @@ function eventStartLevel()
 	setNoGoArea(limboLZ.x, limboLZ.y, limboLZ.x2, limboLZ.y2, -1);
 	setMissionTime(camChangeOnDiff(camMinutesToSeconds(10)));
 
-	var enemyLz = getObject("NXlandingZone");
+	let enemyLz = getObject("NXlandingZone");
 	setNoGoArea(enemyLz.x, enemyLz.y, enemyLz.x2, enemyLz.y2, NEXUS);
 
 	camCompleteRequiredResearch(NEXUS_RES, NEXUS);

--- a/data/base/script/campaign/cam3-c.js
+++ b/data/base/script/campaign/cam3-c.js
@@ -2,8 +2,8 @@ include("script/campaign/libcampaign.js");
 include("script/campaign/templates.js");
 include("script/campaign/transitionTech.js");
 
-const GAMMA = 1; //Gamma is player one.
-const NEXUS_RES = [
+const MIS_GAMMA_PLAYER = 1; //Gamma is player one.
+const mis_nexusRes = [
 	"R-Sys-Engineering03", "R-Defense-WallUpgrade09", "R-Struc-Materials09",
 	"R-Struc-VTOLPad-Upgrade06", "R-Wpn-Bomb-Damage03", "R-Sys-NEXUSrepair",
 	"R-Vehicle-Prop-Hover02", "R-Vehicle-Prop-VTOL02", "R-Cyborg-Legs02",
@@ -73,13 +73,13 @@ function enableAllFactories()
 
 function truckDefense()
 {
-	if (enumDroid(NEXUS, DROID_CONSTRUCT).length === 0)
+	if (enumDroid(CAM_NEXUS, DROID_CONSTRUCT).length === 0)
 	{
 		removeTimer("truckDefense");
 		return;
 	}
 
-	let list = ["Emplacement-Howitzer150", "Emplacement-MdART-pit"];
+	const list = ["Emplacement-Howitzer150", "Emplacement-MdART-pit"];
 	let position;
 
 	if (truckLocCounter === 0)
@@ -93,13 +93,13 @@ function truckDefense()
 		truckLocCounter = 0;
 	}
 
-	camQueueBuilding(NEXUS, list[camRand(list.length)], position);
+	camQueueBuilding(CAM_NEXUS, list[camRand(list.length)], position);
 }
 
 function discoverGammaBase()
 {
 	reunited = true;
-	let lz = getObject("landingZone");
+	const lz = getObject("landingZone");
 	setScrollLimits(0, 0, 64, 192); //top and middle portion.
 	restoreLimboMissionData();
 	setNoGoArea(lz.x, lz.y, lz.x2, lz.y2, CAM_HUMAN_PLAYER);
@@ -109,8 +109,8 @@ function discoverGammaBase()
 	playSound("power-transferred.ogg");
 	playSound("pcv616.ogg"); //Group rescued.
 
-	camAbsorbPlayer(GAMMA, CAM_HUMAN_PLAYER); //Take everything they got!
-	setAlliance(NEXUS, GAMMA, false);
+	camAbsorbPlayer(MIS_GAMMA_PLAYER, CAM_HUMAN_PLAYER); //Take everything they got!
+	setAlliance(CAM_NEXUS, MIS_GAMMA_PLAYER, false);
 
 	hackRemoveMessage("CM3C_GAMMABASE", PROX_MSG, CAM_HUMAN_PLAYER);
 	hackRemoveMessage("CM3C_BETATEAM", PROX_MSG, CAM_HUMAN_PLAYER);
@@ -122,7 +122,7 @@ function discoverGammaBase()
 
 function findBetaUnitIds()
 {
-	let droids = enumArea("betaUnits", CAM_HUMAN_PLAYER, false).filter((obj) => (
+	const droids = enumArea("betaUnits", CAM_HUMAN_PLAYER, false).filter((obj) => (
 		obj.type === DROID
 	));
 
@@ -140,7 +140,7 @@ function betaAlive()
 	}
 
 	let alive = false;
-	let myDroids = enumDroid(CAM_HUMAN_PLAYER);
+	const myDroids = enumDroid(CAM_HUMAN_PLAYER);
 
 	for (let i = 0, l = betaUnitIds.length; i < l; ++i)
 	{
@@ -169,8 +169,8 @@ function eventStartLevel()
 {
 	camSetExtraObjectiveMessage(_("Reunite a part of Beta team with a Gamma team outpost"));
 
-	let startpos = getObject("startPosition");
-	let limboLZ = getObject("limboDroidLZ");
+	const startPos = getObject("startPosition");
+	const limboLZ = getObject("limboDroidLZ");
 	reunited = false;
 	betaUnitIds = [];
 	truckLocCounter = 0;
@@ -181,20 +181,20 @@ function eventStartLevel()
 		callback: "betaAlive"
 	});
 
-	centreView(startpos.x, startpos.y);
+	centreView(startPos.x, startPos.y);
 	setNoGoArea(limboLZ.x, limboLZ.y, limboLZ.x2, limboLZ.y2, -1);
 	setMissionTime(camChangeOnDiff(camMinutesToSeconds(10)));
 
-	let enemyLz = getObject("NXlandingZone");
-	setNoGoArea(enemyLz.x, enemyLz.y, enemyLz.x2, enemyLz.y2, NEXUS);
+	const enemyLz = getObject("NXlandingZone");
+	setNoGoArea(enemyLz.x, enemyLz.y, enemyLz.x2, enemyLz.y2, CAM_NEXUS);
 
-	camCompleteRequiredResearch(NEXUS_RES, NEXUS);
-	camCompleteRequiredResearch(GAMMA_ALLY_RES, GAMMA);
+	camCompleteRequiredResearch(mis_nexusRes, CAM_NEXUS);
+	camCompleteRequiredResearch(mis_gammaAllyRes, MIS_GAMMA_PLAYER);
 	hackAddMessage("CM3C_GAMMABASE", PROX_MSG, CAM_HUMAN_PLAYER, false);
 	hackAddMessage("CM3C_BETATEAM", PROX_MSG, CAM_HUMAN_PLAYER, false);
 
-	setAlliance(CAM_HUMAN_PLAYER, GAMMA, true);
-	setAlliance(NEXUS, GAMMA, true);
+	setAlliance(CAM_HUMAN_PLAYER, MIS_GAMMA_PLAYER, true);
+	setAlliance(CAM_NEXUS, MIS_GAMMA_PLAYER, true);
 
 	camSetArtifacts({
 		"NXbase1HeavyFacArti": { tech: "R-Vehicle-Body07" }, //retribution
@@ -277,13 +277,13 @@ function eventStartLevel()
 
 	if (difficulty >= HARD)
 	{
-		addDroid(NEXUS, 31, 185, "Truck Retribution Hover", "Body7ABT", "hover02", "", "", "Spade1Mk1");
-		camManageTrucks(NEXUS);
+		addDroid(CAM_NEXUS, 31, 185, "Truck Retribution Hover", "Body7ABT", "hover02", "", "", "Spade1Mk1");
+		camManageTrucks(CAM_NEXUS);
 	}
 
 	camPlayVideos([{video: "MB3_C_MSG", type: CAMP_MSG}, {video: "MB3_C_MSG2", type: MISS_MSG}]);
 	setScrollLimits(0, 137, 64, 192); //Show the middle section of the map.
-	changePlayerColour(GAMMA, 0);
+	changePlayerColour(MIS_GAMMA_PLAYER, 0);
 
 	queue("setupPatrolGroups", camSecondsToMilliseconds(10));
 	queue("enableAllFactories", camChangeOnDiff(camMinutesToMilliseconds(3)));

--- a/data/base/script/campaign/libcampaign.js
+++ b/data/base/script/campaign/libcampaign.js
@@ -22,8 +22,24 @@
 //;;
 
 /*
-	Private vars and functions are prefixed with `__cam'.
+	Private vars and functions are prefixed with `__cam`.
+	Private consts are prefixed with `__CAM_` or `__cam_`.
+	Public vars/functions are prefixed with `cam`, consts with `CAM_` or `cam_`.
 	Please do not use private stuff in scenario code, use only public API.
+
+	It is encouraged to prefix any local consts with `__` in any function in the
+	library if they are not objects/arrays. Mission scripts may use a `_` but
+	only if the name seems like it could clash with a JS API global.
+
+	Please CAPITALIZE const names for consistency for most of everything.
+	The only exception to these rules is when the const is declared in a loop
+	initialization or will be assigned as a global-context callback function,
+	or if it will be a JS object/array as these aren't truly immutable. Follow
+	standard camel case style as usual.
+
+	Also, in the event you want a top level const for a mission script
+	(and any include file) please prefix it with `MIS_` or `mis_` depending on
+	if it's an object/array or not.
 
 	We CANNOT put our private vars into an anonymous namespace, even though
 	it's a common JS trick -
@@ -77,34 +93,34 @@ namespace("cam_");
 //////////global vars start
 //These are campaign player numbers.
 const CAM_HUMAN_PLAYER = 0;
-const NEW_PARADIGM = 1;
-const THE_COLLECTIVE = 2;
-const NEXUS = 3;
-const SCAV_6 = 6;
-const SCAV_7 = 7;
+const CAM_NEW_PARADIGM = 1;
+const CAM_THE_COLLECTIVE = 2;
+const CAM_NEXUS = 3;
+const CAM_SCAV_6 = 6;
+const CAM_SCAV_7 = 7;
 
-const CAM_MAX_PLAYERS = 8;
-const CAM_TICKS_PER_FRAME = 100;
-const AI_POWER = 999999;
-const INCLUDE_PATH = "script/campaign/libcampaign_includes/";
+const __CAM_MAX_PLAYERS = 8;
+const __CAM_TICKS_PER_FRAME = 100;
+const __CAM_AI_POWER = 999999;
+const __CAM_INCLUDE_PATH = "script/campaign/libcampaign_includes/";
 
 //level load codes here for reference. Might be useful for later code.
-const ALPHA_CAMPAIGN_NUMBER = 1;
-const BETA_CAMPAIGN_NUMBER = 2;
-const GAMMA_CAMPAIGN_NUMBER = 3;
 const CAM_GAMMA_OUT = "GAMMA_OUT"; //Fake next level for the final Gamma mission.
-const UNKNOWN_CAMPAIGN_NUMBER = 1000;
-const ALPHA_LEVELS = [
+const __CAM_ALPHA_CAMPAIGN_NUMBER = 1;
+const __CAM_BETA_CAMPAIGN_NUMBER = 2;
+const __CAM_GAMMA_CAMPAIGN_NUMBER = 3;
+const __CAM_UNKNOWN_CAMPAIGN_NUMBER = 1000;
+const __cam_alphaLevels = [
 	"CAM_1A", "CAM_1B", "SUB_1_1S", "SUB_1_1", "SUB_1_2S", "SUB_1_2", "SUB_1_3S",
 	"SUB_1_3", "CAM_1C", "CAM_1CA", "SUB_1_4AS", "SUB_1_4A", "SUB_1_5S", "SUB_1_5",
 	"CAM_1A-C", "SUB_1_7S", "SUB_1_7", "SUB_1_DS", "SUB_1_D", "CAM_1END"
 ];
-const BETA_LEVELS = [
+const __cam_betaLevels = [
 	"CAM_2A", "SUB_2_1S", "SUB_2_1", "CAM_2B", "SUB_2_2S", "SUB_2_2", "CAM_2C",
 	"SUB_2_5S", "SUB_2_5", "SUB_2DS", "SUB_2D", "SUB_2_6S", "SUB_2_6", "SUB_2_7S",
 	"SUB_2_7", "SUB_2_8S", "SUB_2_8", "CAM_2END"
 ];
-const GAMMA_LEVELS = [
+const __cam_gammaLevels = [
 	"CAM_3A", "SUB_3_1S", "SUB_3_1", "CAM_3B", "SUB_3_2S", "SUB_3_2", "CAM3A-B",
 	"CAM3C", "CAM3A-D1", "CAM3A-D2", "CAM_3_4S", "CAM_3_4"
 ];
@@ -143,18 +159,18 @@ var __camCalledOnce = {};
 var __camExpLevel;
 
 //nexus
-const DEFENSE_ABSORBED = "defabsrd.ogg";
-const DEFENSE_NEUTRALIZE = "defnut.ogg";
-const LAUGH1 = "laugh1.ogg";
-const LAUGH2 = "laugh2.ogg";
-const LAUGH3 = "laugh3.ogg";
-const PRODUCTION_COMPLETE = "pordcomp.ogg";
-const RES_ABSORBED = "resabsrd.ogg";
-const STRUCTURE_ABSORBED = "strutabs.ogg";
-const STRUCTURE_NEUTRALIZE = "strutnut.ogg";
-const SYNAPTICS_ACTIVATED = "synplnk.ogg";
-const UNIT_ABSORBED = "untabsrd.ogg";
-const UNIT_NEUTRALIZE = "untnut.ogg";
+const CAM_DEFENSE_ABSORBED_SND = "defabsrd.ogg";
+const CAM_DEFENSE_NEUTRALIZE_SND = "defnut.ogg";
+const CAM_LAUGH1_SND = "laugh1.ogg";
+const CAM_LAUGH2_SND = "laugh2.ogg";
+const CAM_LAUGH3_SND = "laugh3.ogg";
+const CAM_PRODUCTION_COMPLETE_SND = "pordcomp.ogg";
+const CAM_RES_ABSORBED_SND = "resabsrd.ogg";
+const CAM_STRUCTURE_ABSORBED_SND = "strutabs.ogg";
+const CAM_STRUCTURE_NEUTRALIZE_SND = "strutnut.ogg";
+const CAM_SYNAPTICS_ACTIVATED_SND = "synplnk.ogg";
+const CAM_UNIT_ABSORBED_SND = "untabsrd.ogg";
+const CAM_UNIT_NEUTRALIZE_SND = "untnut.ogg";
 var __camLastNexusAttack;
 var __camNexusActivated;
 
@@ -179,9 +195,9 @@ const __CAM_FALLBACK_TIME_ON_REGROUP = 5000;
 var __camGroupAvgCoord = {x: 0, y: 0};
 
 //time
-const MILLISECONDS_IN_SECOND = 1000;
-const SECONDS_IN_MINUTE = 60;
-const MINUTES_IN_HOUR = 60;
+const CAM_MILLISECONDS_IN_SECOND = 1000;
+const CAM_SECONDS_IN_MINUTE = 60;
+const CAM_MINUTES_IN_HOUR = 60;
 
 //transport
 var __camNumTransporterExits;
@@ -224,22 +240,22 @@ var __camVtolDataSystem;
 // yet at the time scripts are loaded. (Yes, function name needs to be quoted.)
 hackDoNotSave("__camOriginalEvents");
 
-include(INCLUDE_PATH + "misc.js");
-include(INCLUDE_PATH + "debug.js");
-include(INCLUDE_PATH + "hook.js");
-include(INCLUDE_PATH + "events.js");
+include(__CAM_INCLUDE_PATH + "misc.js");
+include(__CAM_INCLUDE_PATH + "debug.js");
+include(__CAM_INCLUDE_PATH + "hook.js");
+include(__CAM_INCLUDE_PATH + "events.js");
 
-include(INCLUDE_PATH + "time.js");
-include(INCLUDE_PATH + "research.js");
-include(INCLUDE_PATH + "artifact.js");
-include(INCLUDE_PATH + "base.js");
-include(INCLUDE_PATH + "reinforcements.js");
-include(INCLUDE_PATH + "tactics.js");
-include(INCLUDE_PATH + "production.js");
-include(INCLUDE_PATH + "truck.js");
-include(INCLUDE_PATH + "victory.js");
-include(INCLUDE_PATH + "transport.js");
-include(INCLUDE_PATH + "vtol.js");
-include(INCLUDE_PATH + "nexus.js");
-include(INCLUDE_PATH + "group.js");
-include(INCLUDE_PATH + "video.js");
+include(__CAM_INCLUDE_PATH + "time.js");
+include(__CAM_INCLUDE_PATH + "research.js");
+include(__CAM_INCLUDE_PATH + "artifact.js");
+include(__CAM_INCLUDE_PATH + "base.js");
+include(__CAM_INCLUDE_PATH + "reinforcements.js");
+include(__CAM_INCLUDE_PATH + "tactics.js");
+include(__CAM_INCLUDE_PATH + "production.js");
+include(__CAM_INCLUDE_PATH + "truck.js");
+include(__CAM_INCLUDE_PATH + "victory.js");
+include(__CAM_INCLUDE_PATH + "transport.js");
+include(__CAM_INCLUDE_PATH + "vtol.js");
+include(__CAM_INCLUDE_PATH + "nexus.js");
+include(__CAM_INCLUDE_PATH + "group.js");
+include(__CAM_INCLUDE_PATH + "video.js");

--- a/data/base/script/campaign/libcampaign_includes/artifact.js
+++ b/data/base/script/campaign/libcampaign_includes/artifact.js
@@ -27,8 +27,8 @@ function camSetArtifacts(artifacts)
 	__camArtifacts = artifacts;
 	for (const alabel in __camArtifacts)
 	{
-		var ai = __camArtifacts[alabel];
-		var pos = camMakePos(alabel);
+		let ai = __camArtifacts[alabel];
+		let pos = camMakePos(alabel);
 		if (camDef(pos.id))
 		{
 			// will place when object with this id is destroyed
@@ -38,7 +38,7 @@ function camSetArtifacts(artifacts)
 		else
 		{
 			// received position or area, place immediately
-			var acrate = addFeature("Crate", pos.x, pos.y);
+			let acrate = addFeature("Crate", pos.x, pos.y);
 			addLabel(acrate, __camGetArtifactLabel(alabel));
 			ai.placed = true;
 		}
@@ -65,11 +65,11 @@ function camAllArtifactsPickedUp()
 //;;
 function camGetArtifacts()
 {
-	var camArti = [];
+	let camArti = [];
 	for (const alabel in __camArtifacts)
 	{
-		var artifact = __camArtifacts[alabel];
-		var libLabel = __camGetArtifactLabel(alabel);
+		let artifact = __camArtifacts[alabel];
+		let libLabel = __camGetArtifactLabel(alabel);
 		//libcampaign managed artifact that was placed on the map.
 		if (artifact.placed && getObject(libLabel) !== null)
 		{
@@ -77,7 +77,7 @@ function camGetArtifacts()
 		}
 		//Label for artifacts that will drop after an object gets destroyed. Or is manually managed.
 		//NOTE: Must check for ID since "alabel" could be a AREA/POSITION label.
-		var obj = getObject(alabel);
+		let obj = getObject(alabel);
 		if (obj !== null && camDef(obj.id))
 		{
 			camArti.push(alabel);
@@ -102,12 +102,12 @@ function __camGetArtifactKey(objlabel)
 function __camCheckPlaceArtifact(obj)
 {
 	// FIXME: O(n) lookup here
-	var alabel = getLabel(obj);
+	let alabel = getLabel(obj);
 	if (!camDef(alabel) || !alabel)
 	{
 		return;
 	}
-	var ai = __camArtifacts[alabel];
+	let ai = __camArtifacts[alabel];
 	if (!camDef(ai))
 	{
 		return;
@@ -122,7 +122,7 @@ function __camCheckPlaceArtifact(obj)
 		camTrace("Placing multi-tech granting artifact");
 		for (let i = 0; i < ai.tech.length; ++i)
 		{
-			var techString = ai.tech[i];
+			let techString = ai.tech[i];
 			camTrace(i, ":", techString);
 		}
 	}
@@ -130,7 +130,7 @@ function __camCheckPlaceArtifact(obj)
 	{
 		camTrace("Placing", ai.tech);
 	}
-	var acrate = addFeature("Crate", obj.x, obj.y);
+	let acrate = addFeature("Crate", obj.x, obj.y);
 	addLabel(acrate, __camGetArtifactLabel(alabel));
 	ai.placed = true;
 }
@@ -143,8 +143,8 @@ function __camPickupArtifact(artifact)
 		return;
 	}
 	// FIXME: O(n) lookup here
-	var alabel = __camGetArtifactKey(getLabel(artifact));
-	var ai = __camArtifacts[alabel];
+	let alabel = __camGetArtifactKey(getLabel(artifact));
+	let ai = __camArtifacts[alabel];
 	if (!camDef(alabel) || !alabel || !camDef(ai))
 	{
 		camTrace("Artifact", artifact.id, "is not managed");
@@ -159,7 +159,7 @@ function __camPickupArtifact(artifact)
 	{
 		for (let i = 0; i < ai.tech.length; ++i)
 		{
-			var techString = ai.tech[i];
+			let techString = ai.tech[i];
 			enableResearch(techString);
 		}
 	}
@@ -170,7 +170,7 @@ function __camPickupArtifact(artifact)
 	// bump counter before the callback, so that it was
 	// actual during the callback
 	++__camNumArtifacts;
-	var callback = __camGlobalContext()["camArtifactPickup_" + alabel];
+	let callback = __camGlobalContext()["camArtifactPickup_" + alabel];
 	if (camDef(callback))
 	{
 		callback();
@@ -183,11 +183,11 @@ function __camLetMeWinArtifacts()
 {
 	for (const alabel in __camArtifacts)
 	{
-		var ai = __camArtifacts[alabel];
+		let ai = __camArtifacts[alabel];
 		if (ai.placed)
 		{
-			var label = __camGetArtifactLabel(alabel);
-			var artifact = getObject(label);
+			let label = __camGetArtifactLabel(alabel);
+			let artifact = getObject(label);
 			if (!camDef(artifact) || !artifact)
 			{
 				continue;
@@ -200,7 +200,7 @@ function __camLetMeWinArtifacts()
 			{
 				for (let i = 0; i < ai.tech.length; ++i)
 				{
-					var techString = ai.tech[i];
+					let techString = ai.tech[i];
 					enableResearch(techString);
 				}
 			}

--- a/data/base/script/campaign/libcampaign_includes/artifact.js
+++ b/data/base/script/campaign/libcampaign_includes/artifact.js
@@ -27,8 +27,8 @@ function camSetArtifacts(artifacts)
 	__camArtifacts = artifacts;
 	for (const alabel in __camArtifacts)
 	{
-		let ai = __camArtifacts[alabel];
-		let pos = camMakePos(alabel);
+		const ai = __camArtifacts[alabel];
+		const pos = camMakePos(alabel);
 		if (camDef(pos.id))
 		{
 			// will place when object with this id is destroyed
@@ -38,7 +38,7 @@ function camSetArtifacts(artifacts)
 		else
 		{
 			// received position or area, place immediately
-			let acrate = addFeature("Crate", pos.x, pos.y);
+			const acrate = addFeature("Crate", pos.x, pos.y);
 			addLabel(acrate, __camGetArtifactLabel(alabel));
 			ai.placed = true;
 		}
@@ -65,19 +65,19 @@ function camAllArtifactsPickedUp()
 //;;
 function camGetArtifacts()
 {
-	let camArti = [];
+	const camArti = [];
 	for (const alabel in __camArtifacts)
 	{
-		let artifact = __camArtifacts[alabel];
-		let libLabel = __camGetArtifactLabel(alabel);
+		const artifact = __camArtifacts[alabel];
+		const __LIB_LABEL = __camGetArtifactLabel(alabel);
 		//libcampaign managed artifact that was placed on the map.
-		if (artifact.placed && getObject(libLabel) !== null)
+		if (artifact.placed && getObject(__LIB_LABEL) !== null)
 		{
-			camArti.push(libLabel);
+			camArti.push(__LIB_LABEL);
 		}
 		//Label for artifacts that will drop after an object gets destroyed. Or is manually managed.
 		//NOTE: Must check for ID since "alabel" could be a AREA/POSITION label.
-		let obj = getObject(alabel);
+		const obj = getObject(alabel);
 		if (obj !== null && camDef(obj.id))
 		{
 			camArti.push(alabel);
@@ -102,19 +102,19 @@ function __camGetArtifactKey(objlabel)
 function __camCheckPlaceArtifact(obj)
 {
 	// FIXME: O(n) lookup here
-	let alabel = getLabel(obj);
-	if (!camDef(alabel) || !alabel)
+	const __ALABEL = getLabel(obj);
+	if (!camDef(__ALABEL) || !__ALABEL)
 	{
 		return;
 	}
-	let ai = __camArtifacts[alabel];
+	const ai = __camArtifacts[__ALABEL];
 	if (!camDef(ai))
 	{
 		return;
 	}
 	if (ai.placed)
 	{
-		camDebug("Object to which artifact", alabel, "is bound, has died twice");
+		camDebug("Object to which artifact", __ALABEL, "is bound, has died twice");
 		return;
 	}
 	if (ai.tech instanceof Array)
@@ -122,16 +122,16 @@ function __camCheckPlaceArtifact(obj)
 		camTrace("Placing multi-tech granting artifact");
 		for (let i = 0; i < ai.tech.length; ++i)
 		{
-			let techString = ai.tech[i];
-			camTrace(i, ":", techString);
+			const __TECH_STRING = ai.tech[i];
+			camTrace(i, ":", __TECH_STRING);
 		}
 	}
 	else
 	{
 		camTrace("Placing", ai.tech);
 	}
-	let acrate = addFeature("Crate", obj.x, obj.y);
-	addLabel(acrate, __camGetArtifactLabel(alabel));
+	const acrate = addFeature("Crate", obj.x, obj.y);
+	addLabel(acrate, __camGetArtifactLabel(__ALABEL));
 	ai.placed = true;
 }
 
@@ -143,9 +143,9 @@ function __camPickupArtifact(artifact)
 		return;
 	}
 	// FIXME: O(n) lookup here
-	let alabel = __camGetArtifactKey(getLabel(artifact));
-	let ai = __camArtifacts[alabel];
-	if (!camDef(alabel) || !alabel || !camDef(ai))
+	const __ALABEL = __camGetArtifactKey(getLabel(artifact));
+	const ai = __camArtifacts[__ALABEL];
+	if (!camDef(__ALABEL) || !__ALABEL || !camDef(ai))
 	{
 		camTrace("Artifact", artifact.id, "is not managed");
 		return;
@@ -159,8 +159,8 @@ function __camPickupArtifact(artifact)
 	{
 		for (let i = 0; i < ai.tech.length; ++i)
 		{
-			let techString = ai.tech[i];
-			enableResearch(techString);
+			const __TECH_STRING = ai.tech[i];
+			enableResearch(__TECH_STRING);
 		}
 	}
 	else
@@ -170,7 +170,7 @@ function __camPickupArtifact(artifact)
 	// bump counter before the callback, so that it was
 	// actual during the callback
 	++__camNumArtifacts;
-	let callback = __camGlobalContext()["camArtifactPickup_" + alabel];
+	const callback = __camGlobalContext()["camArtifactPickup_" + __ALABEL];
 	if (camDef(callback))
 	{
 		callback();
@@ -183,11 +183,11 @@ function __camLetMeWinArtifacts()
 {
 	for (const alabel in __camArtifacts)
 	{
-		let ai = __camArtifacts[alabel];
+		const ai = __camArtifacts[alabel];
 		if (ai.placed)
 		{
-			let label = __camGetArtifactLabel(alabel);
-			let artifact = getObject(label);
+			const __LABEL = __camGetArtifactLabel(alabel);
+			const artifact = getObject(__LABEL);
 			if (!camDef(artifact) || !artifact)
 			{
 				continue;
@@ -200,8 +200,8 @@ function __camLetMeWinArtifacts()
 			{
 				for (let i = 0; i < ai.tech.length; ++i)
 				{
-					let techString = ai.tech[i];
-					enableResearch(techString);
+					const __TECH_STRING = ai.tech[i];
+					enableResearch(__TECH_STRING);
 				}
 			}
 			else

--- a/data/base/script/campaign/libcampaign_includes/base.js
+++ b/data/base/script/campaign/libcampaign_includes/base.js
@@ -33,7 +33,7 @@
 //;;
 function camSetEnemyBases(bases)
 {
-	var reload = !camDef(bases);
+	let reload = !camDef(bases);
 	if (!reload)
 	{
 		__camEnemyBases = bases;
@@ -42,8 +42,8 @@ function camSetEnemyBases(bases)
 	// convert label strings to groups and store
 	for (const baseLabel in __camEnemyBases)
 	{
-		var bi = __camEnemyBases[baseLabel];
-		var obj = getObject(baseLabel);
+		let bi = __camEnemyBases[baseLabel];
+		let obj = getObject(baseLabel);
 		if (camDef(obj) && obj) // group already defined
 		{
 			if (!camDef(bi.group))
@@ -52,11 +52,11 @@ function camSetEnemyBases(bases)
 			}
 			else
 			{
-				var structures = enumGroup(bi.group);
+				let structures = enumGroup(bi.group);
 				addLabel({ type: GROUP, id: bi.group }, baseLabel);
 				for (let idx = 0, len = structures.length; idx < len; ++idx)
 				{
-					var s = structures[idx];
+					let s = structures[idx];
 					if (s.type !== STRUCTURE || __camIsValidLeftover(s))
 					{
 						continue;
@@ -70,11 +70,11 @@ function camSetEnemyBases(bases)
 			}
 			if (!camDef(bi.cleanup)) // auto-detect cleanup area
 			{
-				var objs = enumGroup(bi.group);
+				let objs = enumGroup(bi.group);
 				if (objs.length > 0)
 				{
 					const OFFSET = 2; // increases size of the auto-detected base area a bit
-					var a = {
+					let a = {
 						type: AREA,
 						x: mapWidth, y: mapHeight,
 						x2: 0, y2: 0
@@ -82,7 +82,7 @@ function camSetEnemyBases(bases)
 					// smallest rectangle to contain all objects
 					for (let idx = 0, len = objs.length; idx < len; ++idx)
 					{
-						var o = objs[idx];
+						let o = objs[idx];
 						if (o.x < a.x) a.x = o.x;
 						if (o.y < a.y) a.y = o.y;
 						if (o.x > a.x2) a.x2 = o.x;
@@ -104,10 +104,10 @@ function camSetEnemyBases(bases)
 			}
 			bi.group = camNewGroup();
 			addLabel({ type: GROUP, id: bi.group }, baseLabel);
-			var structs = enumArea(bi.cleanup, ENEMIES, false);
+			let structs = enumArea(bi.cleanup, ENEMIES, false);
 			for (let idx = 0, len = structs.length; idx < len; ++idx)
 			{
-				var s = structs[idx];
+				let s = structs[idx];
 				if (s.type !== STRUCTURE || __camIsValidLeftover(s))
 				{
 					continue;
@@ -143,7 +143,7 @@ function camSetEnemyBases(bases)
 //;;
 function camDetectEnemyBase(baseLabel)
 {
-	var bi = __camEnemyBases[baseLabel];
+	let bi = __camEnemyBases[baseLabel];
 	if (bi.detected || bi.eliminated)
 	{
 		return;
@@ -152,13 +152,13 @@ function camDetectEnemyBase(baseLabel)
 	bi.detected = true;
 	if (camDef(bi.detectSnd))
 	{
-		var pos = camMakePos(bi.cleanup);
+		let pos = camMakePos(bi.cleanup);
 		if (!camDef(pos)) // auto-detect sound position by group object pos
 		{
-			var objs = enumGroup(bi.group);
+			let objs = enumGroup(bi.group);
 			if (objs.length > 0)
 			{
-				var firstObject = objs[0];
+				let firstObject = objs[0];
 				pos = camMakePos(firstObject);
 			}
 		}
@@ -171,7 +171,7 @@ function camDetectEnemyBase(baseLabel)
 	{
 		hackAddMessage(bi.detectMsg, PROX_MSG, CAM_HUMAN_PLAYER, false);
 	}
-	var callback = __camGlobalContext()["camEnemyBaseDetected_" + baseLabel];
+	let callback = __camGlobalContext()["camEnemyBaseDetected_" + baseLabel];
 	if (camDef(callback))
 	{
 		callback();
@@ -194,7 +194,7 @@ function camAllEnemyBasesEliminated()
 
 function __camCheckBaseSeen(seen)
 {
-	var group = seen; // group?
+	let group = seen; // group?
 	if (camDef(seen.group)) // object?
 	{
 		group = seen.group;
@@ -206,7 +206,7 @@ function __camCheckBaseSeen(seen)
 	// FIXME: O(n) lookup here
 	for (const baseLabel in __camEnemyBases)
 	{
-		var bi = __camEnemyBases[baseLabel];
+		let bi = __camEnemyBases[baseLabel];
 		if (bi.group !== group)
 		{
 			continue;
@@ -236,7 +236,7 @@ function __camIsValidLeftover(obj)
 
 function __camShouldDestroyLeftover(objInfo, basePlayer)
 {
-	var object = getObject(objInfo.type, objInfo.player, objInfo.id);
+	let object = getObject(objInfo.type, objInfo.player, objInfo.id);
 	if (object === null)
 	{
 		return false;
@@ -253,8 +253,8 @@ function __camCheckBaseEliminated(group)
 	// FIXME: O(n) lookup here
 	for (const baseLabel in __camEnemyBases)
 	{
-		var bi = __camEnemyBases[baseLabel];
-		var leftovers = [];
+		let bi = __camEnemyBases[baseLabel];
+		let leftovers = [];
 		if (bi.eliminated || (bi.group !== group))
 		{
 			continue;
@@ -265,11 +265,11 @@ function __camCheckBaseEliminated(group)
 		}
 		if (camDef(bi.cleanup))
 		{
-			var objects = enumArea(bi.cleanup, ENEMIES, false);
+			let objects = enumArea(bi.cleanup, ENEMIES, false);
 			for (let i = 0, len = objects.length; i < len; ++i)
 			{
-				var object = objects[i];
-				var objInfo = {
+				let object = objects[i];
+				let objInfo = {
 					type: object.type,
 					player: object.player,
 					id: object.id
@@ -282,13 +282,13 @@ function __camCheckBaseEliminated(group)
 			for (let i = 0, len = leftovers.length; i < len; ++i)
 			{
 				// remove with special effect
-				var leftover = leftovers[i];
+				let leftover = leftovers[i];
 				camSafeRemoveObject(leftover, true);
 			}
 			if (camDef(bi.eliminateSnd))
 			{
 				// play sound
-				var pos = camMakePos(bi.cleanup);
+				let pos = camMakePos(bi.cleanup);
 				playSound(bi.eliminateSnd, pos.x, pos.y, 0);
 			}
 		}
@@ -306,7 +306,7 @@ function __camCheckBaseEliminated(group)
 		// bump counter before the callback, so that it was
 		// actual during the callback
 		++__camNumEnemyBases;
-		var callback = __camGlobalContext()["camEnemyBaseEliminated_" + baseLabel];
+		let callback = __camGlobalContext()["camEnemyBaseEliminated_" + baseLabel];
 		if (camDef(callback))
 		{
 			callback();
@@ -320,7 +320,7 @@ function __camBasesTick()
 {
 	for (const baseLabel in __camEnemyBases)
 	{
-		var bi = __camEnemyBases[baseLabel];
+		let bi = __camEnemyBases[baseLabel];
 		if (bi.eliminated || !camDef(bi.reinforce_kind))
 		{
 			continue;
@@ -340,8 +340,8 @@ function __camBasesTick()
 			return;
 		}
 		bi.reinforce_last = gameTime;
-		var list = profile(bi.reinforce_callback);
-		var pos = camMakePos(bi.cleanup);
+		let list = profile(bi.reinforce_callback);
+		let pos = camMakePos(bi.cleanup);
 		camSendReinforcement(bi.player, pos, list, bi.reinforce_kind, bi.reinforce_data);
 	}
 }

--- a/data/base/script/campaign/libcampaign_includes/base.js
+++ b/data/base/script/campaign/libcampaign_includes/base.js
@@ -33,8 +33,8 @@
 //;;
 function camSetEnemyBases(bases)
 {
-	let reload = !camDef(bases);
-	if (!reload)
+	const __RELOAD = !camDef(bases);
+	if (!__RELOAD)
 	{
 		__camEnemyBases = bases;
 		__camNumEnemyBases = 0;
@@ -42,8 +42,8 @@ function camSetEnemyBases(bases)
 	// convert label strings to groups and store
 	for (const baseLabel in __camEnemyBases)
 	{
-		let bi = __camEnemyBases[baseLabel];
-		let obj = getObject(baseLabel);
+		const bi = __camEnemyBases[baseLabel];
+		const obj = getObject(baseLabel);
 		if (camDef(obj) && obj) // group already defined
 		{
 			if (!camDef(bi.group))
@@ -52,11 +52,11 @@ function camSetEnemyBases(bases)
 			}
 			else
 			{
-				let structures = enumGroup(bi.group);
+				const structures = enumGroup(bi.group);
 				addLabel({ type: GROUP, id: bi.group }, baseLabel);
 				for (let idx = 0, len = structures.length; idx < len; ++idx)
 				{
-					let s = structures[idx];
+					const s = structures[idx];
 					if (s.type !== STRUCTURE || __camIsValidLeftover(s))
 					{
 						continue;
@@ -70,11 +70,11 @@ function camSetEnemyBases(bases)
 			}
 			if (!camDef(bi.cleanup)) // auto-detect cleanup area
 			{
-				let objs = enumGroup(bi.group);
+				const objs = enumGroup(bi.group);
 				if (objs.length > 0)
 				{
-					const OFFSET = 2; // increases size of the auto-detected base area a bit
-					let a = {
+					const __OFFSET = 2; // increases size of the auto-detected base area a bit
+					const a = {
 						type: AREA,
 						x: mapWidth, y: mapHeight,
 						x2: 0, y2: 0
@@ -82,13 +82,13 @@ function camSetEnemyBases(bases)
 					// smallest rectangle to contain all objects
 					for (let idx = 0, len = objs.length; idx < len; ++idx)
 					{
-						let o = objs[idx];
+						const o = objs[idx];
 						if (o.x < a.x) a.x = o.x;
 						if (o.y < a.y) a.y = o.y;
 						if (o.x > a.x2) a.x2 = o.x;
 						if (o.y > a.y2) a.y2 = o.y;
 					}
-					a.x -= OFFSET; a.y -= OFFSET; a.x2 += OFFSET; a.y2 += OFFSET;
+					a.x -= __OFFSET; a.y -= __OFFSET; a.x2 += __OFFSET; a.y2 += __OFFSET;
 					camTrace("Auto-detected cleanup area for", baseLabel, ":", a.x, a.y, a.x2, a.y2);
 					bi.cleanup = "__cam_enemy_base_cleanup__" + baseLabel;
 					addLabel(a, bi.cleanup);
@@ -104,10 +104,10 @@ function camSetEnemyBases(bases)
 			}
 			bi.group = camNewGroup();
 			addLabel({ type: GROUP, id: bi.group }, baseLabel);
-			let structs = enumArea(bi.cleanup, ENEMIES, false);
+			const structs = enumArea(bi.cleanup, ENEMIES, false);
 			for (let idx = 0, len = structs.length; idx < len; ++idx)
 			{
-				let s = structs[idx];
+				const s = structs[idx];
 				if (s.type !== STRUCTURE || __camIsValidLeftover(s))
 				{
 					continue;
@@ -123,7 +123,7 @@ function camSetEnemyBases(bases)
 		{
 			//camDebug("Base", baseLabel, "defined as empty group");
 		}
-		if (!reload)
+		if (!__RELOAD)
 		{
 			bi.detected = false;
 			bi.eliminated = false;
@@ -143,7 +143,7 @@ function camSetEnemyBases(bases)
 //;;
 function camDetectEnemyBase(baseLabel)
 {
-	let bi = __camEnemyBases[baseLabel];
+	const bi = __camEnemyBases[baseLabel];
 	if (bi.detected || bi.eliminated)
 	{
 		return;
@@ -155,10 +155,10 @@ function camDetectEnemyBase(baseLabel)
 		let pos = camMakePos(bi.cleanup);
 		if (!camDef(pos)) // auto-detect sound position by group object pos
 		{
-			let objs = enumGroup(bi.group);
+			const objs = enumGroup(bi.group);
 			if (objs.length > 0)
 			{
-				let firstObject = objs[0];
+				const firstObject = objs[0];
 				pos = camMakePos(firstObject);
 			}
 		}
@@ -171,7 +171,7 @@ function camDetectEnemyBase(baseLabel)
 	{
 		hackAddMessage(bi.detectMsg, PROX_MSG, CAM_HUMAN_PLAYER, false);
 	}
-	let callback = __camGlobalContext()["camEnemyBaseDetected_" + baseLabel];
+	const callback = __camGlobalContext()["camEnemyBaseDetected_" + baseLabel];
 	if (camDef(callback))
 	{
 		callback();
@@ -206,7 +206,7 @@ function __camCheckBaseSeen(seen)
 	// FIXME: O(n) lookup here
 	for (const baseLabel in __camEnemyBases)
 	{
-		let bi = __camEnemyBases[baseLabel];
+		const bi = __camEnemyBases[baseLabel];
 		if (bi.group !== group)
 		{
 			continue;
@@ -236,7 +236,7 @@ function __camIsValidLeftover(obj)
 
 function __camShouldDestroyLeftover(objInfo, basePlayer)
 {
-	let object = getObject(objInfo.type, objInfo.player, objInfo.id);
+	const object = getObject(objInfo.type, objInfo.player, objInfo.id);
 	if (object === null)
 	{
 		return false;
@@ -253,8 +253,8 @@ function __camCheckBaseEliminated(group)
 	// FIXME: O(n) lookup here
 	for (const baseLabel in __camEnemyBases)
 	{
-		let bi = __camEnemyBases[baseLabel];
-		let leftovers = [];
+		const bi = __camEnemyBases[baseLabel];
+		const leftovers = [];
 		if (bi.eliminated || (bi.group !== group))
 		{
 			continue;
@@ -265,11 +265,11 @@ function __camCheckBaseEliminated(group)
 		}
 		if (camDef(bi.cleanup))
 		{
-			let objects = enumArea(bi.cleanup, ENEMIES, false);
+			const objects = enumArea(bi.cleanup, ENEMIES, false);
 			for (let i = 0, len = objects.length; i < len; ++i)
 			{
-				let object = objects[i];
-				let objInfo = {
+				const object = objects[i];
+				const objInfo = {
 					type: object.type,
 					player: object.player,
 					id: object.id
@@ -282,13 +282,13 @@ function __camCheckBaseEliminated(group)
 			for (let i = 0, len = leftovers.length; i < len; ++i)
 			{
 				// remove with special effect
-				let leftover = leftovers[i];
+				const leftover = leftovers[i];
 				camSafeRemoveObject(leftover, true);
 			}
 			if (camDef(bi.eliminateSnd))
 			{
 				// play sound
-				let pos = camMakePos(bi.cleanup);
+				const pos = camMakePos(bi.cleanup);
 				playSound(bi.eliminateSnd, pos.x, pos.y, 0);
 			}
 		}
@@ -306,7 +306,7 @@ function __camCheckBaseEliminated(group)
 		// bump counter before the callback, so that it was
 		// actual during the callback
 		++__camNumEnemyBases;
-		let callback = __camGlobalContext()["camEnemyBaseEliminated_" + baseLabel];
+		const callback = __camGlobalContext()["camEnemyBaseEliminated_" + baseLabel];
 		if (camDef(callback))
 		{
 			callback();
@@ -320,7 +320,7 @@ function __camBasesTick()
 {
 	for (const baseLabel in __camEnemyBases)
 	{
-		let bi = __camEnemyBases[baseLabel];
+		const bi = __camEnemyBases[baseLabel];
 		if (bi.eliminated || !camDef(bi.reinforce_kind))
 		{
 			continue;
@@ -340,8 +340,8 @@ function __camBasesTick()
 			return;
 		}
 		bi.reinforce_last = gameTime;
-		let list = profile(bi.reinforce_callback);
-		let pos = camMakePos(bi.cleanup);
+		const list = profile(bi.reinforce_callback);
+		const pos = camMakePos(bi.cleanup);
 		camSendReinforcement(bi.player, pos, list, bi.reinforce_kind, bi.reinforce_data);
 	}
 }

--- a/data/base/script/campaign/libcampaign_includes/debug.js
+++ b/data/base/script/campaign/libcampaign_includes/debug.js
@@ -78,12 +78,12 @@ function camDebug(...args)
 //;;
 function camDebugOnce(...args)
 {
-	let str = debugGetCallerFuncName() + ": " + args.join(" ");
-	if (camDef(__camDebuggedOnce[str]))
+	const __STR = debugGetCallerFuncName() + ": " + args.join(" ");
+	if (camDef(__camDebuggedOnce[__STR]))
 	{
 		return;
 	}
-	__camDebuggedOnce[str] = true;
+	__camDebuggedOnce[__STR] = true;
 	__camGenericDebug("DEBUG", debugGetCallerFuncName(), args, true, __camBacktrace());
 }
 
@@ -117,12 +117,12 @@ function camTraceOnce(...args)
 	{
 		return;
 	}
-	let str = debugGetCallerFuncName() + ": " + args.join(" ");
-	if (camDef(__camTracedOnce[str]))
+	const __STR = debugGetCallerFuncName() + ": " + args.join(" ");
+	if (camDef(__camTracedOnce[__STR]))
 	{
 		return;
 	}
-	__camTracedOnce[str] = true;
+	__camTracedOnce[__STR] = true;
 	__camGenericDebug("TRACE", debugGetCallerFuncName(), args);
 }
 
@@ -171,11 +171,11 @@ function __camGenericDebug(flag, functionName, args, err, backtrace)
 	{
 		functionName = "<anonymous>";
 	}
-	let str = flag + ": " + functionName + ": " + Array.prototype.join.call(args, " ");
-	debug(str);
+	const __STR = flag + ": " + functionName + ": " + Array.prototype.join.call(args, " ");
+	debug(__STR);
 	if (camDef(err) && err)
 	{
-		dump(str);
+		dump(__STR);
 	}
 }
 

--- a/data/base/script/campaign/libcampaign_includes/debug.js
+++ b/data/base/script/campaign/libcampaign_includes/debug.js
@@ -78,7 +78,7 @@ function camDebug(...args)
 //;;
 function camDebugOnce(...args)
 {
-	var str = debugGetCallerFuncName() + ": " + args.join(" ");
+	let str = debugGetCallerFuncName() + ": " + args.join(" ");
 	if (camDef(__camDebuggedOnce[str]))
 	{
 		return;
@@ -117,7 +117,7 @@ function camTraceOnce(...args)
 	{
 		return;
 	}
-	var str = debugGetCallerFuncName() + ": " + args.join(" ");
+	let str = debugGetCallerFuncName() + ": " + args.join(" ");
 	if (camDef(__camTracedOnce[str]))
 	{
 		return;
@@ -171,7 +171,7 @@ function __camGenericDebug(flag, functionName, args, err, backtrace)
 	{
 		functionName = "<anonymous>";
 	}
-	var str = flag + ": " + functionName + ": " + Array.prototype.join.call(args, " ");
+	let str = flag + ": " + functionName + ": " + Array.prototype.join.call(args, " ");
 	debug(str);
 	if (camDef(err) && err)
 	{

--- a/data/base/script/campaign/libcampaign_includes/events.js
+++ b/data/base/script/campaign/libcampaign_includes/events.js
@@ -87,14 +87,14 @@ function cam_eventChat(from, to, message)
 	{
 		while (true) // eslint-disable-line no-constant-condition
 		{
-			var research = enumResearch();
+			let research = enumResearch();
 			if (research.length === 0)
 			{
 				break;
 			}
 			for (let i = 0, len = research.length; i < len; ++i)
 			{
-				var researchName = research[i].name;
+				let researchName = research[i].name;
 				completeResearch(researchName, CAM_HUMAN_PLAYER);
 			}
 		}
@@ -263,7 +263,7 @@ function cam_eventMissionTimeout()
 	}
 	else
 	{
-		var won = camCheckExtraObjective();
+		let won = camCheckExtraObjective();
 		if (!won)
 		{
 			__camGameLost();
@@ -284,8 +284,8 @@ function cam_eventAttacked(victim, attacker)
 			if (victim.group === null)
 			{
 				const DEFAULT_RADIUS = 6;
-				var loc = {x: victim.x, y: victim.y};
-				var droids = enumRange(loc.x, loc.y, DEFAULT_RADIUS, victim.player, false).filter((obj) => (
+				let loc = {x: victim.x, y: victim.y};
+				let droids = enumRange(loc.x, loc.y, DEFAULT_RADIUS, victim.player, false).filter((obj) => (
 					obj.type === DROID &&
 					obj.group === null &&
 					(obj.canHitGround || obj.isSensor) &&
@@ -335,7 +335,7 @@ function cam_eventGameLoaded()
 	//missions or else it reverts to the original texture.
 	for (let i = 0, l = SCAV_KEVLAR_MISSIONS.length; i < l; ++i)
 	{
-		var mission = SCAV_KEVLAR_MISSIONS[i];
+		let mission = SCAV_KEVLAR_MISSIONS[i];
 		if (__camNextLevel === mission)
 		{
 			if (tilesetType === "ARIZONA")
@@ -366,7 +366,7 @@ function cam_eventObjectTransfer(obj, from)
 {
 	if (from === CAM_HUMAN_PLAYER && obj.player === NEXUS && __camNexusActivated === true)
 	{
-		var snd;
+		let snd;
 		if (obj.type === STRUCTURE)
 		{
 			if (obj.stattype === DEFENSE)

--- a/data/base/script/campaign/libcampaign_includes/events.js
+++ b/data/base/script/campaign/libcampaign_includes/events.js
@@ -87,15 +87,15 @@ function cam_eventChat(from, to, message)
 	{
 		while (true) // eslint-disable-line no-constant-condition
 		{
-			let research = enumResearch();
+			const research = enumResearch();
 			if (research.length === 0)
 			{
 				break;
 			}
 			for (let i = 0, len = research.length; i < len; ++i)
 			{
-				let researchName = research[i].name;
-				completeResearch(researchName, CAM_HUMAN_PLAYER);
+				const __RESEARCH_NAME = research[i].name;
+				completeResearch(__RESEARCH_NAME, CAM_HUMAN_PLAYER);
 			}
 		}
 	}
@@ -223,8 +223,8 @@ function cam_eventTransporterExit(transport)
 			__camVictoryData.reinforcements > -1) ||
 			__camWinLossCallback === CAM_VICTORY_STANDARD))
 		{
-			const REINFORCEMENTS_AVAILABLE_SOUND = "pcv440.ogg";
-			playSound(REINFORCEMENTS_AVAILABLE_SOUND);
+			const __REINFORCEMENTS_AVAILABLE_SOUND = "pcv440.ogg";
+			playSound(__REINFORCEMENTS_AVAILABLE_SOUND);
 			//Show the transporter reinforcement timer when it leaves for the first time.
 			if (__camWinLossCallback === CAM_VICTORY_OFFWORLD)
 			{
@@ -263,8 +263,8 @@ function cam_eventMissionTimeout()
 	}
 	else
 	{
-		let won = camCheckExtraObjective();
-		if (!won)
+		const __WON = camCheckExtraObjective();
+		if (!__WON)
 		{
 			__camGameLost();
 			return;
@@ -283,9 +283,9 @@ function cam_eventAttacked(victim, attacker)
 			//of a group. Only supports those who can hit ground units.
 			if (victim.group === null)
 			{
-				const DEFAULT_RADIUS = 6;
-				let loc = {x: victim.x, y: victim.y};
-				let droids = enumRange(loc.x, loc.y, DEFAULT_RADIUS, victim.player, false).filter((obj) => (
+				const __DEFAULT_RADIUS = 6;
+				const loc = {x: victim.x, y: victim.y};
+				const droids = enumRange(loc.x, loc.y, __DEFAULT_RADIUS, victim.player, false).filter((obj) => (
 					obj.type === DROID &&
 					obj.group === null &&
 					(obj.canHitGround || obj.isSensor) &&
@@ -326,17 +326,17 @@ function cam_eventGameLoaded()
 {
 	receiveAllEvents(true);
 	__camSaveLoading = true;
-	const SCAV_KEVLAR_MISSIONS = [
+	const scavKevlarMissions = [
 		"CAM_1CA", "SUB_1_4AS", "SUB_1_4A", "SUB_1_5S", "SUB_1_5",
 		"CAM_1A-C", "SUB_1_7S", "SUB_1_7", "SUB_1_DS", "CAM_1END", "SUB_2_5S"
 	];
 
 	//Need to set the scavenger kevlar vests when loading a save from later Alpha
 	//missions or else it reverts to the original texture.
-	for (let i = 0, l = SCAV_KEVLAR_MISSIONS.length; i < l; ++i)
+	for (let i = 0, l = scavKevlarMissions.length; i < l; ++i)
 	{
-		let mission = SCAV_KEVLAR_MISSIONS[i];
-		if (__camNextLevel === mission)
+		const __MISSION = scavKevlarMissions[i];
+		if (__camNextLevel === __MISSION)
 		{
 			if (tilesetType === "ARIZONA")
 			{
@@ -364,27 +364,27 @@ function cam_eventGameLoaded()
 //Plays Nexus sounds if nexusActivated is true.
 function cam_eventObjectTransfer(obj, from)
 {
-	if (from === CAM_HUMAN_PLAYER && obj.player === NEXUS && __camNexusActivated === true)
+	if (from === CAM_HUMAN_PLAYER && obj.player === CAM_NEXUS && __camNexusActivated === true)
 	{
 		let snd;
 		if (obj.type === STRUCTURE)
 		{
 			if (obj.stattype === DEFENSE)
 			{
-				snd = DEFENSE_ABSORBED;
+				snd = CAM_DEFENSE_ABSORBED_SND;
 			}
 			else if (obj.stattype === RESEARCH_LAB)
 			{
-				snd = RES_ABSORBED;
+				snd = CAM_RES_ABSORBED_SND;
 			}
 			else
 			{
-				snd = STRUCTURE_ABSORBED;
+				snd = CAM_STRUCTURE_ABSORBED_SND;
 			}
 		}
 		else if (obj.type === DROID)
 		{
-			snd = UNIT_ABSORBED;
+			snd = CAM_UNIT_ABSORBED_SND;
 		}
 
 		if (camDef(snd))

--- a/data/base/script/campaign/libcampaign_includes/group.js
+++ b/data/base/script/campaign/libcampaign_includes/group.js
@@ -35,8 +35,8 @@ function camInNeverGroup(droid)
 	}
 	for (let i = 0, l = __camNeverGroupDroids.length; i < l; ++i)
 	{
-		let neverDroidID = __camNeverGroupDroids[i];
-		if (droid.id === neverDroidID)
+		const __NEVERDROID_ID = __camNeverGroupDroids[i];
+		if (droid.id === __NEVERDROID_ID)
 		{
 			return true;
 		}
@@ -101,7 +101,7 @@ function camNeverGroupDroid(what, playerFilter)
 	{
 		for (let i = 0, l = array.length; i < l; ++i)
 		{
-			let o = array[i];
+			const o = array[i];
 			if (!camDef(o) || !o)
 			{
 				continue;

--- a/data/base/script/campaign/libcampaign_includes/group.js
+++ b/data/base/script/campaign/libcampaign_includes/group.js
@@ -35,7 +35,7 @@ function camInNeverGroup(droid)
 	}
 	for (let i = 0, l = __camNeverGroupDroids.length; i < l; ++i)
 	{
-		var neverDroidID = __camNeverGroupDroids[i];
+		let neverDroidID = __camNeverGroupDroids[i];
 		if (droid.id === neverDroidID)
 		{
 			return true;
@@ -59,8 +59,8 @@ function camNeverGroupDroid(what, playerFilter)
 	{
 		playerFilter = ENEMIES;
 	}
-	var array;
-	var obj;
+	let array;
+	let obj;
 	if (camIsString(what)) // label
 	{
 		obj = getObject(what);
@@ -101,7 +101,7 @@ function camNeverGroupDroid(what, playerFilter)
 	{
 		for (let i = 0, l = array.length; i < l; ++i)
 		{
-			var o = array[i];
+			let o = array[i];
 			if (!camDef(o) || !o)
 			{
 				continue;

--- a/data/base/script/campaign/libcampaign_includes/hook.js
+++ b/data/base/script/campaign/libcampaign_includes/hook.js
@@ -18,9 +18,9 @@
 //;;
 function camAreaEvent(label, callback)
 {
-	let eventName = "eventArea" + label;
+	const __EVENT_NAME = "eventArea" + label;
 	camMarkTiles(label);
-	__camPreHookEvent(eventName, function(droid)
+	__camPreHookEvent(__EVENT_NAME, function(droid)
 	{
 		if (camDef(droid))
 		{

--- a/data/base/script/campaign/libcampaign_includes/hook.js
+++ b/data/base/script/campaign/libcampaign_includes/hook.js
@@ -18,7 +18,7 @@
 //;;
 function camAreaEvent(label, callback)
 {
-	var eventName = "eventArea" + label;
+	let eventName = "eventArea" + label;
 	camMarkTiles(label);
 	__camPreHookEvent(eventName, function(droid)
 	{

--- a/data/base/script/campaign/libcampaign_includes/misc.js
+++ b/data/base/script/campaign/libcampaign_includes/misc.js
@@ -105,7 +105,7 @@ function camMakePos(x, y)
 	{
 		return undefined;
 	}
-	var obj = x;
+	let obj = x;
 	if (camIsString(x))
 	{
 		obj = getObject(x);
@@ -162,7 +162,7 @@ function camDist(x1, y1, x2, y2)
 	{
 		return distBetweenTwoPoints(x1.x, x1.y, y1.x, y1.y);
 	}
-	var pos2 = camMakePos(x2);
+	let pos2 = camMakePos(x2);
 	if (camDef(pos2.x)) // x2 is pos2
 	{
 		return distBetweenTwoPoints(x1, y1, pos2.x, pos2.y);
@@ -204,11 +204,11 @@ function camPlayerMatchesFilter(playerId, playerFilter)
 //;;
 function camRemoveDuplicates(items)
 {
-	var prims = {"boolean":{}, "number":{}, "string":{}};
-	var objs = [];
+	let prims = {"boolean":{}, "number":{}, "string":{}};
+	let objs = [];
 
 	return items.filter((item) => {
-		var type = typeof item;
+		let type = typeof item;
 		if (type in prims)
 		{
 			return prims[type].hasOwnProperty(item) ? false : (prims[type][item] = true);
@@ -234,11 +234,11 @@ function camCountStructuresInArea(label, playerFilter)
 	{
 		playerFilter = CAM_HUMAN_PLAYER;
 	}
-	var list = enumArea(label, playerFilter, false);
-	var ret = 0;
+	let list = enumArea(label, playerFilter, false);
+	let ret = 0;
 	for (let i = 0, l = list.length; i < l; ++i)
 	{
-		var object = list[i];
+		let object = list[i];
 		if (object.type === STRUCTURE && object.stattype !== WALL && object.status === BUILT)
 		{
 			++ret;
@@ -256,7 +256,7 @@ function camCountStructuresInArea(label, playerFilter)
 //;;
 function camChangeOnDiff(numericValue)
 {
-	var modifier = 0;
+	let modifier = 0;
 
 	switch (difficulty)
 	{
@@ -323,8 +323,8 @@ function camMakeGroup(what, playerFilter)
 	{
 		playerFilter = ENEMIES;
 	}
-	var array;
-	var obj;
+	let array;
+	let obj;
 	if (camIsString(what)) // label
 	{
 		obj = getObject(what);
@@ -363,10 +363,10 @@ function camMakeGroup(what, playerFilter)
 	}
 	if (camDef(array))
 	{
-		var group = camNewGroup();
+		let group = camNewGroup();
 		for (let i = 0, l = array.length; i < l; ++i)
 		{
-			var o = array[i];
+			let o = array[i];
 			if (!camDef(o) || !o)
 			{
 				camDebug("Trying to add", o);
@@ -579,13 +579,13 @@ function __camGlobalContext()
 function __camFindClusters(list, size)
 {
 	// The good old cluster analysis algorithm taken from NullBot AI.
-	var ret = { clusters: [], xav: [], yav: [], maxIdx: 0, maxCount: 0 };
+	let ret = { clusters: [], xav: [], yav: [], maxIdx: 0, maxCount: 0 };
 	for (let i = list.length - 1; i >= 0; --i)
 	{
-		var x = list[i].x;
-		var y = list[i].y;
-		var found = false;
-		var n = 0;
+		let x = list[i].x;
+		let y = list[i].y;
+		let found = false;
+		let n = 0;
 		for (let j = 0; j < ret.clusters.length; ++j)
 		{
 			if (camDist(ret.xav[j], ret.yav[j], x, y) < size)

--- a/data/base/script/campaign/libcampaign_includes/misc.js
+++ b/data/base/script/campaign/libcampaign_includes/misc.js
@@ -162,7 +162,7 @@ function camDist(x1, y1, x2, y2)
 	{
 		return distBetweenTwoPoints(x1.x, x1.y, y1.x, y1.y);
 	}
-	let pos2 = camMakePos(x2);
+	const pos2 = camMakePos(x2);
 	if (camDef(pos2.x)) // x2 is pos2
 	{
 		return distBetweenTwoPoints(x1, y1, pos2.x, pos2.y);
@@ -189,7 +189,7 @@ function camPlayerMatchesFilter(playerId, playerFilter)
 		case ALLIES:
 			return playerId === CAM_HUMAN_PLAYER;
 		case ENEMIES:
-			return playerId >= 0 && playerId < CAM_MAX_PLAYERS && playerId !== CAM_HUMAN_PLAYER;
+			return playerId >= 0 && playerId < __CAM_MAX_PLAYERS && playerId !== CAM_HUMAN_PLAYER;
 		default:
 			return playerId === playerFilter;
 	}
@@ -205,10 +205,10 @@ function camPlayerMatchesFilter(playerId, playerFilter)
 function camRemoveDuplicates(items)
 {
 	let prims = {"boolean":{}, "number":{}, "string":{}};
-	let objs = [];
+	const objs = [];
 
 	return items.filter((item) => {
-		let type = typeof item;
+		const type = typeof item;
 		if (type in prims)
 		{
 			return prims[type].hasOwnProperty(item) ? false : (prims[type][item] = true);
@@ -234,11 +234,11 @@ function camCountStructuresInArea(label, playerFilter)
 	{
 		playerFilter = CAM_HUMAN_PLAYER;
 	}
-	let list = enumArea(label, playerFilter, false);
+	const list = enumArea(label, playerFilter, false);
 	let ret = 0;
 	for (let i = 0, l = list.length; i < l; ++i)
 	{
-		let object = list[i];
+		const object = list[i];
 		if (object.type === STRUCTURE && object.stattype !== WALL && object.status === BUILT)
 		{
 			++ret;
@@ -363,10 +363,10 @@ function camMakeGroup(what, playerFilter)
 	}
 	if (camDef(array))
 	{
-		let group = camNewGroup();
+		const group = camNewGroup();
 		for (let i = 0, l = array.length; i < l; ++i)
 		{
-			let o = array[i];
+			const o = array[i];
 			if (!camDef(o) || !o)
 			{
 				camDebug("Trying to add", o);
@@ -390,9 +390,9 @@ function camMakeGroup(what, playerFilter)
 //;;
 function camBreakAlliances()
 {
-	for (let i = 0; i < CAM_MAX_PLAYERS; ++i)
+	for (let i = 0; i < __CAM_MAX_PLAYERS; ++i)
 	{
-		for (let c = 0; c < CAM_MAX_PLAYERS; ++c)
+		for (let c = 0; c < __CAM_MAX_PLAYERS; ++c)
 		{
 			if (i !== c && allianceExistsBetween(i, c) === true)
 			{
@@ -411,12 +411,12 @@ function camBreakAlliances()
 //;;
 function camGenerateRandomMapEdgeCoordinate(reachPosition)
 {
-	let limits = getScrollLimits();
+	const limits = getScrollLimits();
 	let loc;
 
 	do
 	{
-		let location = {x: 0, y: 0};
+		const location = {x: 0, y: 0};
 		let xWasRandom = false;
 
 		if (camRand(100) < 50)
@@ -478,7 +478,7 @@ function camGenerateRandomMapCoordinate(reachPosition, distFromReach, scanObject
 		scanObjectRadius = 2;
 	}
 
-	let limits = getScrollLimits();
+	const limits = getScrollLimits();
 	let pos;
 
 	do
@@ -521,29 +521,29 @@ function camGenerateRandomMapCoordinate(reachPosition, distFromReach, scanObject
 //;;
 function camDiscoverCampaign()
 {
-	for (let i = 0, len = ALPHA_LEVELS.length; i < len; ++i)
+	for (let i = 0, len = __cam_alphaLevels.length; i < len; ++i)
 	{
-		if (__camNextLevel === ALPHA_LEVELS[i] || __camNextLevel === BETA_LEVELS[0])
+		if (__camNextLevel === __cam_alphaLevels[i] || __camNextLevel === __cam_betaLevels[0])
 		{
-			return ALPHA_CAMPAIGN_NUMBER;
+			return __CAM_ALPHA_CAMPAIGN_NUMBER;
 		}
 	}
-	for (let i = 0, len = BETA_LEVELS.length; i < len; ++i)
+	for (let i = 0, len = __cam_betaLevels.length; i < len; ++i)
 	{
-		if (__camNextLevel === BETA_LEVELS[i] || __camNextLevel === GAMMA_LEVELS[0])
+		if (__camNextLevel === __cam_betaLevels[i] || __camNextLevel === __cam_gammaLevels[0])
 		{
-			return BETA_CAMPAIGN_NUMBER;
+			return __CAM_BETA_CAMPAIGN_NUMBER;
 		}
 	}
-	for (let i = 0, len = GAMMA_LEVELS.length; i < len; ++i)
+	for (let i = 0, len = __cam_gammaLevels.length; i < len; ++i)
 	{
-		if (__camNextLevel === GAMMA_LEVELS[i] || __camNextLevel === CAM_GAMMA_OUT)
+		if (__camNextLevel === __cam_gammaLevels[i] || __camNextLevel === CAM_GAMMA_OUT)
 		{
-			return GAMMA_CAMPAIGN_NUMBER;
+			return __CAM_GAMMA_CAMPAIGN_NUMBER;
 		}
 	}
 
-	return UNKNOWN_CAMPAIGN_NUMBER;
+	return __CAM_UNKNOWN_CAMPAIGN_NUMBER;
 }
 
 function camSetExpLevel(number)
@@ -553,11 +553,11 @@ function camSetExpLevel(number)
 
 function camSetOnMapEnemyUnitExp()
 {
-	enumDroid(NEW_PARADIGM)
-	.concat(enumDroid(THE_COLLECTIVE))
-	.concat(enumDroid(NEXUS))
-	.concat(enumDroid(SCAV_6))
-	.concat(enumDroid(SCAV_7))
+	enumDroid(CAM_NEW_PARADIGM)
+	.concat(enumDroid(CAM_THE_COLLECTIVE))
+	.concat(enumDroid(CAM_NEXUS))
+	.concat(enumDroid(CAM_SCAV_6))
+	.concat(enumDroid(CAM_SCAV_7))
 	.forEach(function(obj) {
 		if (!allianceExistsBetween(CAM_HUMAN_PLAYER, obj.player) && //may have friendly units as other player
 			!camIsTransporter(obj) &&
@@ -579,21 +579,21 @@ function __camGlobalContext()
 function __camFindClusters(list, size)
 {
 	// The good old cluster analysis algorithm taken from NullBot AI.
-	let ret = { clusters: [], xav: [], yav: [], maxIdx: 0, maxCount: 0 };
+	const ret = { clusters: [], xav: [], yav: [], maxIdx: 0, maxCount: 0 };
 	for (let i = list.length - 1; i >= 0; --i)
 	{
-		let x = list[i].x;
-		let y = list[i].y;
+		const __X = list[i].x;
+		const __Y = list[i].y;
 		let found = false;
 		let n = 0;
 		for (let j = 0; j < ret.clusters.length; ++j)
 		{
-			if (camDist(ret.xav[j], ret.yav[j], x, y) < size)
+			if (camDist(ret.xav[j], ret.yav[j], __X, __Y) < size)
 			{
 				n = ret.clusters[j].length;
 				ret.clusters[j][n] = list[i];
-				ret.xav[j] = Math.floor((n * ret.xav[j] + x) / (n + 1));
-				ret.yav[j] = Math.floor((n * ret.yav[j] + y) / (n + 1));
+				ret.xav[j] = Math.floor((n * ret.xav[j] + __X) / (n + 1));
+				ret.yav[j] = Math.floor((n * ret.yav[j] + __Y) / (n + 1));
 				if (ret.clusters[j].length > ret.maxCount)
 				{
 					ret.maxIdx = j;
@@ -607,8 +607,8 @@ function __camFindClusters(list, size)
 		{
 			n = ret.clusters.length;
 			ret.clusters[n] = [list[i]];
-			ret.xav[n] = x;
-			ret.yav[n] = y;
+			ret.xav[n] = __X;
+			ret.yav[n] = __Y;
 			if (1 > ret.maxCount)
 			{
 				ret.maxIdx = n;
@@ -632,15 +632,15 @@ function __camTick()
 //Reset AI power back to highest storage possible.
 function __camAiPowerReset()
 {
-	for (let i = 1; i < CAM_MAX_PLAYERS; ++i)
+	for (let i = 1; i < __CAM_MAX_PLAYERS; ++i)
 	{
-		setPower(AI_POWER, i);
+		setPower(__CAM_AI_POWER, i);
 	}
 }
 
 function __camGetExpRangeLevel()
 {
-	let ranks = {
+	const ranks = {
 		rookie: 0,
 		green: 4,
 		trained: 8,
@@ -702,7 +702,7 @@ function camSetDroidExperience(droid)
 		return;
 	}
 
-	let expRange = __camGetExpRangeLevel();
+	const expRange = __camGetExpRangeLevel();
 	let exp = expRange[camRand(expRange.length)];
 
 	if (droid.droidType === DROID_COMMAND || droid.droidType === DROID_SENSOR)

--- a/data/base/script/campaign/libcampaign_includes/nexus.js
+++ b/data/base/script/campaign/libcampaign_includes/nexus.js
@@ -39,21 +39,21 @@ function camAbsorbPlayer(who, to)
 		to = NEXUS;
 	}
 
-	var units = enumDroid(who);
+	let units = enumDroid(who);
 
 	for (let i = 0, len = units.length; i < len; ++i)
 	{
-		var droid = units[i];
+		let droid = units[i];
 		if (!donateObject(droid, to))
 		{
 			camSafeRemoveObject(droid, false);
 		}
 	}
 
-	var structs = enumStruct(who);
+	let structs = enumStruct(who);
 	for (let i = 0, len = structs.length; i < len; ++i)
 	{
-		var structure = structs[i];
+		let structure = structs[i];
 		if (!donateObject(structure, to))
 		{
 			camSafeRemoveObject(structure, false);
@@ -81,8 +81,8 @@ function camHackIntoPlayer(player, to)
 	}
 
 	const GIFT_CHANCE = 70; //Else neutralized
-	var target;
-	var objects;
+	let target;
+	let objects;
 
 	if (!camDef(player))
 	{
@@ -97,7 +97,7 @@ function camHackIntoPlayer(player, to)
 		__camLastNexusAttack = 0;
 	}
 
-	var objects = __camChooseNexusTarget(player);
+	objects = __camChooseNexusTarget(player);
 	if (objects.length === 0)
 	{
 		return;
@@ -120,7 +120,7 @@ function camHackIntoPlayer(player, to)
 		camTrace("Neutralized " + target.name + " at (x,y): " + target.x + " " + target.y);
 		if (target.player === CAM_HUMAN_PLAYER)
 		{
-			var sound;
+			let sound;
 			//Nexus neutralize sounds
 			if (target.type === STRUCTURE)
 			{
@@ -189,7 +189,7 @@ function __camChooseNexusTarget(player)
 	}
 
 	const TARGET_UNIT_CHANCE = (getResearch("R-Sys-Resistance-Upgrade01").done) ? 40 : 20;
-	var objects = [];
+	let objects = [];
 
 	if (camRand(100) < TARGET_UNIT_CHANCE)
 	{

--- a/data/base/script/campaign/libcampaign_includes/nexus.js
+++ b/data/base/script/campaign/libcampaign_includes/nexus.js
@@ -11,18 +11,18 @@
 //;;
 function camNexusLaugh()
 {
-	const LAUGH_CHANCE = 45;
-	if (camRand(100) < LAUGH_CHANCE)
+	const __LAUGH_CHANCE = 45;
+	if (camRand(100) < __LAUGH_CHANCE)
 	{
-		const LAUGHS = [LAUGH1, LAUGH2, LAUGH3];
-		playSound(LAUGHS[camRand(LAUGHS.length)]);
+		const laughs = [CAM_LAUGH1_SND, CAM_LAUGH2_SND, CAM_LAUGH3_SND];
+		playSound(laughs[camRand(laughs.length)]);
 	}
 }
 
 //;; ## camAbsorbPlayer([who[, to]])
 //;;
 //;; Completely give all of player `who` droids and structures to player `to`.
-//;; Will default to `CAM_HUMAN_PLAYER` and `NEXUS` respectively.
+//;; Will default to `CAM_HUMAN_PLAYER` and `CAM_NEXUS` respectively.
 //;;
 //;; @param {number} [who]
 //;; @param {number} [to]
@@ -36,24 +36,24 @@ function camAbsorbPlayer(who, to)
 	}
 	if (!camDef(to))
 	{
-		to = NEXUS;
+		to = CAM_NEXUS;
 	}
 
-	let units = enumDroid(who);
+	const units = enumDroid(who);
 
 	for (let i = 0, len = units.length; i < len; ++i)
 	{
-		let droid = units[i];
+		const droid = units[i];
 		if (!donateObject(droid, to))
 		{
 			camSafeRemoveObject(droid, false);
 		}
 	}
 
-	let structs = enumStruct(who);
+	const structs = enumStruct(who);
 	for (let i = 0, len = structs.length; i < len; ++i)
 	{
-		let structure = structs[i];
+		const structure = structs[i];
 		if (!donateObject(structure, to))
 		{
 			camSafeRemoveObject(structure, false);
@@ -67,7 +67,7 @@ function camAbsorbPlayer(who, to)
 //;; ## camHackIntoPlayer([player[, to]])
 //;;
 //;; Steal a droid or structure from a player if the NEXUS hack state is active.
-//;; Will default to `CAM_HUMAN_PLAYER` and `NEXUS` respectively.
+//;; Will default to `CAM_HUMAN_PLAYER` and `CAM_NEXUS` respectively.
 //;;
 //;; @param {number} [player]
 //;; @param {number} [to]
@@ -80,7 +80,7 @@ function camHackIntoPlayer(player, to)
 		return;
 	}
 
-	const GIFT_CHANCE = 70; //Else neutralized
+	const __GIFT_CHANCE = 70; //Else neutralized
 	let target;
 	let objects;
 
@@ -90,7 +90,7 @@ function camHackIntoPlayer(player, to)
 	}
 	if (!camDef(to))
 	{
-		to = NEXUS;
+		to = CAM_NEXUS;
 	}
 	if (!camDef(__camLastNexusAttack))
 	{
@@ -106,7 +106,7 @@ function camHackIntoPlayer(player, to)
 	__camLastNexusAttack = gameTime;
 	target = objects[camRand(objects.length)];
 
-	if ((camRand(100) < GIFT_CHANCE) && !(target.type === STRUCTURE && target.stattype === WALL))
+	if ((camRand(100) < __GIFT_CHANCE) && !(target.type === STRUCTURE && target.stattype === WALL))
 	{
 		camTrace("Hacking " + target.name + " at (x,y): " + target.x + " " + target.y);
 		//Gift sounds are done in eventObjectTransfer.
@@ -126,16 +126,16 @@ function camHackIntoPlayer(player, to)
 			{
 				if (target.stattype === DEFENSE)
 				{
-					sound = DEFENSE_NEUTRALIZE;
+					sound = CAM_DEFENSE_NEUTRALIZE_SND;
 				}
 				else
 				{
-					sound = STRUCTURE_NEUTRALIZE;
+					sound = CAM_STRUCTURE_NEUTRALIZE_SND;
 				}
 			}
 			else if (target.type === DROID)
 			{
-				sound = UNIT_NEUTRALIZE;
+				sound = CAM_UNIT_NEUTRALIZE_SND;
 			}
 
 			if (camDef(sound))
@@ -188,14 +188,14 @@ function __camChooseNexusTarget(player)
 		return enumStruct(player, HQ);
 	}
 
-	const TARGET_UNIT_CHANCE = (getResearch("R-Sys-Resistance-Upgrade01").done) ? 40 : 20;
+	const __TARGET_UNIT_CHANCE = (getResearch("R-Sys-Resistance-Upgrade01").done) ? 40 : 20;
 	let objects = [];
 
-	if (camRand(100) < TARGET_UNIT_CHANCE)
+	if (camRand(100) < __TARGET_UNIT_CHANCE)
 	{
 		objects = enumDroid(player).filter((d) => (!camIsTransporter(d)));
 
-		const EXP = {
+		const exp = {
 			rookie: 0,
 			green: 4,
 			trained: 8,
@@ -224,7 +224,7 @@ function __camChooseNexusTarget(player)
 				{
 					return false;
 				}
-				return d.experience < EXP.regular;
+				return d.experience < exp.regular;
 			}
 			else if (getResearch("R-Sys-Resistance-Upgrade02").done)
 			{
@@ -232,7 +232,7 @@ function __camChooseNexusTarget(player)
 				{
 					return false;
 				}
-				return d.experience < EXP.veteran;
+				return d.experience < exp.veteran;
 			}
 			else if (getResearch("R-Sys-Resistance-Upgrade01").done)
 			{
@@ -240,7 +240,7 @@ function __camChooseNexusTarget(player)
 				{
 					return false;
 				}
-				return d.experience < EXP.special;
+				return d.experience < exp.special;
 			}
 			else
 			{

--- a/data/base/script/campaign/libcampaign_includes/production.js
+++ b/data/base/script/campaign/libcampaign_includes/production.js
@@ -59,7 +59,7 @@ function camSetFactories(factories)
 //;;
 function camSetFactoryData(factoryLabel, factoryData)
 {
-	let structure = getObject(factoryLabel);
+	const structure = getObject(factoryLabel);
 	if (!camDef(structure) || !structure)
 	{
 		// Not an error! It's ok if the factory is already destroyed
@@ -74,7 +74,7 @@ function camSetFactoryData(factoryLabel, factoryData)
 		droids = enumGroup(__camFactoryInfo[factoryLabel].group);
 	}
 	__camFactoryInfo[factoryLabel] = factoryData;
-	let fi = __camFactoryInfo[factoryLabel];
+	const fi = __camFactoryInfo[factoryLabel];
 	if (!camDef(fi.data))
 	{
 		fi.data = {};
@@ -87,7 +87,7 @@ function camSetFactoryData(factoryLabel, factoryData)
 	}
 	for (let i = 0, l = droids.length; i < l; ++i)
 	{
-		let droid = droids[i];
+		const droid = droids[i];
 		groupAdd(fi.group, droid);
 	}
 	if (!camDef(fi.data.count))
@@ -106,7 +106,7 @@ function camSetFactoryData(factoryLabel, factoryData)
 //;;
 function camEnableFactory(factoryLabel)
 {
-	let fi = __camFactoryInfo[factoryLabel];
+	const fi = __camFactoryInfo[factoryLabel];
 	if (!camDef(fi) || !fi)
 	{
 		camDebug("Factory not managed", factoryLabel);
@@ -120,7 +120,7 @@ function camEnableFactory(factoryLabel)
 	}
 	camTrace("Enabling", factoryLabel);
 	fi.enabled = true;
-	let obj = getObject(factoryLabel);
+	const obj = getObject(factoryLabel);
 	if (!camDef(obj) || !obj)
 	{
 		camTrace("Factory", factoryLabel, "not found, probably already dead");
@@ -202,20 +202,20 @@ function camUpgradeOnMapTemplates(template1, template2, playerId, excluded)
 		return;
 	}
 
-	let droidsOnMap = enumDroid(playerId);
+	const droidsOnMap = enumDroid(playerId);
 
 	for (let i = 0, l = droidsOnMap.length; i < l; ++i)
 	{
-		let dr = droidsOnMap[i];
+		const dr = droidsOnMap[i];
 		if (!camDef(dr.weapons[0]))
 		{
 			continue; //don't handle systems
 		}
-		let body = dr.body;
-		let prop = dr.propulsion;
-		let weap = dr.weapons[0].name;
+		const __BODY = dr.body;
+		const __PROP = dr.propulsion;
+		const __WEAP = dr.weapons[0].name;
 		let skip = false;
-		if (body === template1.body && prop === template1.prop && weap === template1.weap)
+		if (__BODY === template1.body && __PROP === template1.prop && __WEAP === template1.weap)
 		{
 			//Check if this object should be excluded from the upgrades
 			if (camDef(excluded))
@@ -242,9 +242,9 @@ function camUpgradeOnMapTemplates(template1, template2, playerId, excluded)
 			}
 
 			//Replace it
-			let droidInfo = {x: dr.x, y: dr.y, name: dr.name};
+			const droidInfo = {x: dr.x, y: dr.y, name: dr.name};
 			camSafeRemoveObject(dr, false);
-			let droid = addDroid(playerId, droidInfo.x, droidInfo.y, droidInfo.name, template2.body,
+			const droid = addDroid(playerId, droidInfo.x, droidInfo.y, droidInfo.name, template2.body,
 				__camChangePropulsion(template2.prop, playerId), "", "", template2.weap);
 			camSetDroidExperience(droid);
 		}
@@ -255,13 +255,13 @@ function camUpgradeOnMapTemplates(template1, template2, playerId, excluded)
 
 function __camFactoryUpdateTactics(flabel)
 {
-	let fi = __camFactoryInfo[flabel];
+	const fi = __camFactoryInfo[flabel];
 	if (!fi.enabled)
 	{
 		camDebug("Factory", flabel, "was not enabled");
 		return;
 	}
-	let droids = enumGroup(fi.group);
+	const droids = enumGroup(fi.group);
 	if (droids.length >= fi.groupSize)
 	{
 		camManageGroup(fi.group, fi.order, fi.data);
@@ -286,22 +286,22 @@ function __camAddDroidToFactoryGroup(droid, structure)
 		return;
 	}
 	// FIXME: O(n) lookup here
-	let flabel = getLabel(structure);
-	if (!camDef(flabel) || !flabel)
+	const __FLABEL = getLabel(structure);
+	if (!camDef(__FLABEL) || !__FLABEL)
 	{
 		return;
 	}
-	let fi = __camFactoryInfo[flabel];
+	const fi = __camFactoryInfo[__FLABEL];
 	groupAdd(fi.group, droid);
 	if (camDef(fi.assembly))
 	{
 		// this is necessary in case droid is regrouped manually
 		// in the scenario code, and thus DORDER_DEFEND for assembly
 		// will not be applied in __camFactoryUpdateTactics()
-		let pos = camMakePos(fi.assembly);
+		const pos = camMakePos(fi.assembly);
 		orderDroidLoc(droid, DORDER_MOVE, pos.x, pos.y);
 	}
-	__camFactoryUpdateTactics(flabel);
+	__camFactoryUpdateTactics(__FLABEL);
 }
 
 function __camChangePropulsion(propulsion, playerId)
@@ -312,25 +312,25 @@ function __camChangePropulsion(propulsion, playerId)
 	}
 
 	let name = propulsion;
-	const VALID_PROPS = ["CyborgLegs", "HalfTrack", "V-Tol", "hover", "tracked", "wheeled"];
-	const SPECPROPS = ["CyborgLegs", "HalfTrack", "V-Tol"]; //Some have "01" at the end and others don't for the base ones.
+	const validProp = ["CyborgLegs", "HalfTrack", "V-Tol", "hover", "tracked", "wheeled"];
+	const specProps = ["CyborgLegs", "HalfTrack", "V-Tol"]; //Some have "01" at the end and others don't for the base ones.
 
-	let lastTwo = name.substring(name.length - 2);
-	if (lastTwo === "01" || lastTwo === "02" || lastTwo === "03")
+	const __LAST_TWO = name.substring(name.length - 2);
+	if (__LAST_TWO === "01" || __LAST_TWO === "02" || __LAST_TWO === "03")
 	{
 		name = name.substring(0, name.length - 2);
 	}
 
-	for (let i = 0, l = VALID_PROPS.length; i < l; ++i)
+	for (let i = 0, l = validProp.length; i < l; ++i)
 	{
-		let currentProp = VALID_PROPS[i];
-		if (name === currentProp)
+		const __CURRENT_PROP = validProp[i];
+		if (name === __CURRENT_PROP)
 		{
-			if ((__camPropulsionTypeLimit === "01") && (SPECPROPS.indexOf(currentProp) !== -1))
+			if ((__camPropulsionTypeLimit === "01") && (specProps.indexOf(__CURRENT_PROP) !== -1))
 			{
-				return currentProp;
+				return __CURRENT_PROP;
 			}
-			return currentProp.concat(__camPropulsionTypeLimit);
+			return __CURRENT_PROP.concat(__camPropulsionTypeLimit);
 		}
 	}
 
@@ -350,13 +350,13 @@ function __camBuildDroid(template, structure)
 	{
 		return false;
 	}
-	let prop = __camChangePropulsion(template.prop, structure.player);
+	const __PROP = __camChangePropulsion(template.prop, structure.player);
 	makeComponentAvailable(template.body, structure.player);
-	makeComponentAvailable(prop, structure.player);
+	makeComponentAvailable(__PROP, structure.player);
 	makeComponentAvailable(template.weap, structure.player);
-	let n = [ structure.name, structure.id, template.body, prop, template.weap ].join(" ");
+	const __NAME = [ structure.name, structure.id, template.body, __PROP, template.weap ].join(" ");
 	// multi-turret templates are not supported yet
-	return buildDroid(structure, n, template.body, prop, "", "", template.weap);
+	return buildDroid(structure, __NAME, template.body, __PROP, "", "", template.weap);
 }
 
 //Check if an enabled factory can begin manufacturing something. Doing this
@@ -401,7 +401,7 @@ function __camContinueProduction(structure)
 	{
 		return;
 	}
-	let fi = __camFactoryInfo[flabel];
+	const fi = __camFactoryInfo[flabel];
 	if (camDef(fi.maxSize) && groupSize(fi.group) >= fi.maxSize)
 	{
 		// retry later
@@ -409,8 +409,8 @@ function __camContinueProduction(structure)
 	}
 	if (camDef(fi.throttle) && camDef(fi.lastprod))
 	{
-		let throttle = gameTime - fi.lastprod;
-		if (throttle < fi.throttle)
+		const __THROTTLE = gameTime - fi.lastprod;
+		if (__THROTTLE < fi.throttle)
 		{
 			// do throttle
 			return;
@@ -420,12 +420,12 @@ function __camContinueProduction(structure)
 	if (fi.state === -1)
 	{
 		fi.state = 0;
-		let p = struct.player;
-		if (camDef(__camFactoryQueue[p]) && __camFactoryQueue[p].length > 0)
+		const __PL = struct.player;
+		if (camDef(__camFactoryQueue[__PL]) && __camFactoryQueue[__PL].length > 0)
 		{
-			if (__camBuildDroid(__camFactoryQueue[p][0], struct))
+			if (__camBuildDroid(__camFactoryQueue[__PL][0], struct))
 			{
-				__camFactoryQueue[p].shift();
+				__camFactoryQueue[__PL].shift();
 				return;
 			}
 		}

--- a/data/base/script/campaign/libcampaign_includes/production.js
+++ b/data/base/script/campaign/libcampaign_includes/production.js
@@ -59,7 +59,7 @@ function camSetFactories(factories)
 //;;
 function camSetFactoryData(factoryLabel, factoryData)
 {
-	var structure = getObject(factoryLabel);
+	let structure = getObject(factoryLabel);
 	if (!camDef(structure) || !structure)
 	{
 		// Not an error! It's ok if the factory is already destroyed
@@ -68,13 +68,13 @@ function camSetFactoryData(factoryLabel, factoryData)
 		return;
 	}
 	// remember the old factory group, if any
-	var droids = [];
+	let droids = [];
 	if (camDef(__camFactoryInfo[factoryLabel]))
 	{
 		droids = enumGroup(__camFactoryInfo[factoryLabel].group);
 	}
 	__camFactoryInfo[factoryLabel] = factoryData;
-	var fi = __camFactoryInfo[factoryLabel];
+	let fi = __camFactoryInfo[factoryLabel];
 	if (!camDef(fi.data))
 	{
 		fi.data = {};
@@ -87,7 +87,7 @@ function camSetFactoryData(factoryLabel, factoryData)
 	}
 	for (let i = 0, l = droids.length; i < l; ++i)
 	{
-		var droid = droids[i];
+		let droid = droids[i];
 		groupAdd(fi.group, droid);
 	}
 	if (!camDef(fi.data.count))
@@ -106,7 +106,7 @@ function camSetFactoryData(factoryLabel, factoryData)
 //;;
 function camEnableFactory(factoryLabel)
 {
-	var fi = __camFactoryInfo[factoryLabel];
+	let fi = __camFactoryInfo[factoryLabel];
 	if (!camDef(fi) || !fi)
 	{
 		camDebug("Factory not managed", factoryLabel);
@@ -120,7 +120,7 @@ function camEnableFactory(factoryLabel)
 	}
 	camTrace("Enabling", factoryLabel);
 	fi.enabled = true;
-	var obj = getObject(factoryLabel);
+	let obj = getObject(factoryLabel);
 	if (!camDef(obj) || !obj)
 	{
 		camTrace("Factory", factoryLabel, "not found, probably already dead");
@@ -202,19 +202,19 @@ function camUpgradeOnMapTemplates(template1, template2, playerId, excluded)
 		return;
 	}
 
-	var droidsOnMap = enumDroid(playerId);
+	let droidsOnMap = enumDroid(playerId);
 
 	for (let i = 0, l = droidsOnMap.length; i < l; ++i)
 	{
-		var dr = droidsOnMap[i];
+		let dr = droidsOnMap[i];
 		if (!camDef(dr.weapons[0]))
 		{
 			continue; //don't handle systems
 		}
-		var body = dr.body;
-		var prop = dr.propulsion;
-		var weap = dr.weapons[0].name;
-		var skip = false;
+		let body = dr.body;
+		let prop = dr.propulsion;
+		let weap = dr.weapons[0].name;
+		let skip = false;
 		if (body === template1.body && prop === template1.prop && weap === template1.weap)
 		{
 			//Check if this object should be excluded from the upgrades
@@ -255,13 +255,13 @@ function camUpgradeOnMapTemplates(template1, template2, playerId, excluded)
 
 function __camFactoryUpdateTactics(flabel)
 {
-	var fi = __camFactoryInfo[flabel];
+	let fi = __camFactoryInfo[flabel];
 	if (!fi.enabled)
 	{
 		camDebug("Factory", flabel, "was not enabled");
 		return;
 	}
-	var droids = enumGroup(fi.group);
+	let droids = enumGroup(fi.group);
 	if (droids.length >= fi.groupSize)
 	{
 		camManageGroup(fi.group, fi.order, fi.data);
@@ -269,7 +269,7 @@ function __camFactoryUpdateTactics(flabel)
 	}
 	else
 	{
-		var pos = camMakePos(fi.assembly);
+		let pos = camMakePos(fi.assembly);
 		if (!camDef(pos))
 		{
 			pos = camMakePos(flabel);
@@ -286,19 +286,19 @@ function __camAddDroidToFactoryGroup(droid, structure)
 		return;
 	}
 	// FIXME: O(n) lookup here
-	var flabel = getLabel(structure);
+	let flabel = getLabel(structure);
 	if (!camDef(flabel) || !flabel)
 	{
 		return;
 	}
-	var fi = __camFactoryInfo[flabel];
+	let fi = __camFactoryInfo[flabel];
 	groupAdd(fi.group, droid);
 	if (camDef(fi.assembly))
 	{
 		// this is necessary in case droid is regrouped manually
 		// in the scenario code, and thus DORDER_DEFEND for assembly
 		// will not be applied in __camFactoryUpdateTactics()
-		var pos = camMakePos(fi.assembly);
+		let pos = camMakePos(fi.assembly);
 		orderDroidLoc(droid, DORDER_MOVE, pos.x, pos.y);
 	}
 	__camFactoryUpdateTactics(flabel);
@@ -350,11 +350,11 @@ function __camBuildDroid(template, structure)
 	{
 		return false;
 	}
-	var prop = __camChangePropulsion(template.prop, structure.player);
+	let prop = __camChangePropulsion(template.prop, structure.player);
 	makeComponentAvailable(template.body, structure.player);
 	makeComponentAvailable(prop, structure.player);
 	makeComponentAvailable(template.weap, structure.player);
-	var n = [ structure.name, structure.id, template.body, prop, template.weap ].join(" ");
+	let n = [ structure.name, structure.id, template.body, prop, template.weap ].join(" ");
 	// multi-turret templates are not supported yet
 	return buildDroid(structure, n, template.body, prop, "", "", template.weap);
 }
@@ -375,8 +375,8 @@ function __checkEnemyFactoryProductionTick()
 
 function __camContinueProduction(structure)
 {
-	var flabel;
-	var struct;
+	let flabel;
+	let struct;
 	if (camIsString(structure))
 	{
 		flabel = structure;
@@ -401,7 +401,7 @@ function __camContinueProduction(structure)
 	{
 		return;
 	}
-	var fi = __camFactoryInfo[flabel];
+	let fi = __camFactoryInfo[flabel];
 	if (camDef(fi.maxSize) && groupSize(fi.group) >= fi.maxSize)
 	{
 		// retry later
@@ -409,7 +409,7 @@ function __camContinueProduction(structure)
 	}
 	if (camDef(fi.throttle) && camDef(fi.lastprod))
 	{
-		var throttle = gameTime - fi.lastprod;
+		let throttle = gameTime - fi.lastprod;
 		if (throttle < fi.throttle)
 		{
 			// do throttle
@@ -420,7 +420,7 @@ function __camContinueProduction(structure)
 	if (fi.state === -1)
 	{
 		fi.state = 0;
-		var p = struct.player;
+		let p = struct.player;
 		if (camDef(__camFactoryQueue[p]) && __camFactoryQueue[p].length > 0)
 		{
 			if (__camBuildDroid(__camFactoryQueue[p][0], struct))

--- a/data/base/script/campaign/libcampaign_includes/reinforcements.js
+++ b/data/base/script/campaign/libcampaign_includes/reinforcements.js
@@ -28,9 +28,9 @@
 //;;
 function camSendReinforcement(playerId, position, templates, kind, data)
 {
-	var pos = camMakePos(position);
-	var order = CAM_ORDER_ATTACK;
-	var order_data = { regroup: false, count: -1 };
+	let pos = camMakePos(position);
+	let order = CAM_ORDER_ATTACK;
+	let order_data = { regroup: false, count: -1 };
 	if (camDef(data) && camDef(data.order))
 	{
 		order = data.order;
@@ -42,18 +42,21 @@ function camSendReinforcement(playerId, position, templates, kind, data)
 	switch (kind)
 	{
 		case CAM_REINFORCE_GROUND:
-			var droids = [];
+		{
+			let droids = [];
 			for (let i = 0, l = templates.length; i < l; ++i)
 			{
-				var template = templates[i];
-				var prop = __camChangePropulsion(template.prop, playerId);
-				var droid = addDroid(playerId, pos.x, pos.y, "Reinforcement", template.body, prop, "", "", template.weap);
+				let template = templates[i];
+				let prop = __camChangePropulsion(template.prop, playerId);
+				let droid = addDroid(playerId, pos.x, pos.y, "Reinforcement", template.body, prop, "", "", template.weap);
 				camSetDroidExperience(droid);
 				droids.push(droid);
 			}
 			camManageGroup(camMakeGroup(droids), order, order_data);
 			break;
+		}
 		case CAM_REINFORCE_TRANSPORT:
+		{
 			__camTransporterQueue.push({
 				player: playerId,
 				position: position,
@@ -64,9 +67,12 @@ function camSendReinforcement(playerId, position, templates, kind, data)
 			});
 			__camDispatchTransporterSafe();
 			break;
+		}
 		default:
+		{
 			camTrace("Unknown reinforcement type");
 			break;
+		}
 	}
 }
 
@@ -91,7 +97,7 @@ function camSetBaseReinforcements(baseLabel, interval, callbackName, kind, data)
 	{
 		camDebug("Callback name must be a string (received", callbackName, ")");
 	}
-	var bi = __camEnemyBases[baseLabel];
+	let bi = __camEnemyBases[baseLabel];
 	bi.reinforce_kind = kind;
 	bi.reinforce_interval = interval;
 	bi.reinforce_callback = callbackName;

--- a/data/base/script/campaign/libcampaign_includes/reinforcements.js
+++ b/data/base/script/campaign/libcampaign_includes/reinforcements.js
@@ -28,7 +28,7 @@
 //;;
 function camSendReinforcement(playerId, position, templates, kind, data)
 {
-	let pos = camMakePos(position);
+	const pos = camMakePos(position);
 	let order = CAM_ORDER_ATTACK;
 	let order_data = { regroup: false, count: -1 };
 	if (camDef(data) && camDef(data.order))
@@ -43,12 +43,12 @@ function camSendReinforcement(playerId, position, templates, kind, data)
 	{
 		case CAM_REINFORCE_GROUND:
 		{
-			let droids = [];
+			const droids = [];
 			for (let i = 0, l = templates.length; i < l; ++i)
 			{
-				let template = templates[i];
-				let prop = __camChangePropulsion(template.prop, playerId);
-				let droid = addDroid(playerId, pos.x, pos.y, "Reinforcement", template.body, prop, "", "", template.weap);
+				const template = templates[i];
+				const __PROP = __camChangePropulsion(template.prop, playerId);
+				const droid = addDroid(playerId, pos.x, pos.y, "Reinforcement", template.body, __PROP, "", "", template.weap);
 				camSetDroidExperience(droid);
 				droids.push(droid);
 			}
@@ -97,7 +97,7 @@ function camSetBaseReinforcements(baseLabel, interval, callbackName, kind, data)
 	{
 		camDebug("Callback name must be a string (received", callbackName, ")");
 	}
-	let bi = __camEnemyBases[baseLabel];
+	const bi = __camEnemyBases[baseLabel];
 	bi.reinforce_kind = kind;
 	bi.reinforce_interval = interval;
 	bi.reinforce_callback = callbackName;

--- a/data/base/script/campaign/libcampaign_includes/research.js
+++ b/data/base/script/campaign/libcampaign_includes/research.js
@@ -15,9 +15,9 @@ function camEnableRes(researchIds, playerId)
 {
 	for (let i = 0, l = researchIds.length; i < l; ++i)
 	{
-		let researchId = researchIds[i];
-		enableResearch(researchId, playerId);
-		completeResearch(researchId, playerId);
+		const __RESEARCH_ID = researchIds[i];
+		enableResearch(__RESEARCH_ID, playerId);
+		completeResearch(__RESEARCH_ID, playerId);
 	}
 }
 
@@ -35,16 +35,16 @@ function camCompleteRequiredResearch(researchIds, playerId)
 
 	for (let i = 0, l = researchIds.length; i < l; ++i)
 	{
-		let researchId = researchIds[i];
-		dump("Searching for required research of item: " + researchId);
-		let reqRes = findResearch(researchId, playerId).reverse();
+		const __RESEARCH_ID = researchIds[i];
+		dump("Searching for required research of item: " + __RESEARCH_ID);
+		let reqRes = findResearch(__RESEARCH_ID, playerId).reverse();
 
 		if (reqRes.length === 0)
 		{
 			//HACK: autorepair like upgrades don't work after mission transition.
-			if (researchId === "R-Sys-NEXUSrepair")
+			if (__RESEARCH_ID === "R-Sys-NEXUSrepair")
 			{
-				completeResearch(researchId, playerId, true);
+				completeResearch(__RESEARCH_ID, playerId, true);
 			}
 			continue;
 		}
@@ -52,10 +52,10 @@ function camCompleteRequiredResearch(researchIds, playerId)
 		reqRes = camRemoveDuplicates(reqRes);
 		for (let s = 0, r = reqRes.length; s < r; ++s)
 		{
-			let researchReq = reqRes[s].name;
-			dump("	Found: " + researchReq);
-			enableResearch(researchReq, playerId);
-			completeResearch(researchReq, playerId);
+			const __RESEARCH_REQ = reqRes[s].name;
+			dump("	Found: " + __RESEARCH_REQ);
+			enableResearch(__RESEARCH_REQ, playerId);
+			completeResearch(__RESEARCH_REQ, playerId);
 		}
 	}
 }
@@ -65,7 +65,7 @@ function camCompleteRequiredResearch(researchIds, playerId)
 //granted shortly after mission start to give enemy players instant droid production.
 function __camGrantSpecialResearch()
 {
-	for (let i = 1; i < CAM_MAX_PLAYERS; ++i)
+	for (let i = 1; i < __CAM_MAX_PLAYERS; ++i)
 	{
 		if (!allianceExistsBetween(CAM_HUMAN_PLAYER, i) && (countDroid(DROID_ANY, i) > 0 || enumStruct(i).length > 0))
 		{

--- a/data/base/script/campaign/libcampaign_includes/research.js
+++ b/data/base/script/campaign/libcampaign_includes/research.js
@@ -15,7 +15,7 @@ function camEnableRes(researchIds, playerId)
 {
 	for (let i = 0, l = researchIds.length; i < l; ++i)
 	{
-		var researchId = researchIds[i];
+		let researchId = researchIds[i];
 		enableResearch(researchId, playerId);
 		completeResearch(researchId, playerId);
 	}
@@ -35,9 +35,9 @@ function camCompleteRequiredResearch(researchIds, playerId)
 
 	for (let i = 0, l = researchIds.length; i < l; ++i)
 	{
-		var researchId = researchIds[i];
+		let researchId = researchIds[i];
 		dump("Searching for required research of item: " + researchId);
-		var reqRes = findResearch(researchId, playerId).reverse();
+		let reqRes = findResearch(researchId, playerId).reverse();
 
 		if (reqRes.length === 0)
 		{
@@ -52,7 +52,7 @@ function camCompleteRequiredResearch(researchIds, playerId)
 		reqRes = camRemoveDuplicates(reqRes);
 		for (let s = 0, r = reqRes.length; s < r; ++s)
 		{
-			var researchReq = reqRes[s].name;
+			let researchReq = reqRes[s].name;
 			dump("	Found: " + researchReq);
 			enableResearch(researchReq, playerId);
 			completeResearch(researchReq, playerId);

--- a/data/base/script/campaign/libcampaign_includes/tactics.js
+++ b/data/base/script/campaign/libcampaign_includes/tactics.js
@@ -94,11 +94,11 @@ function camManageGroup(group, order, data)
 	};
 	if (order === CAM_ORDER_FOLLOW)
 	{
-		let commanderGroup = camMakeGroup([getObject(data.droid)]);
-		camManageGroup(commanderGroup, data.order, data.data);
+		const __COMMANDER_GROUP = camMakeGroup([getObject(data.droid)]);
+		camManageGroup(__COMMANDER_GROUP, data.order, data.data);
 	}
 	// apply orders instantly
-	queue("__camTacticsTickForGroup", CAM_TICKS_PER_FRAME, group);
+	queue("__camTacticsTickForGroup", __CAM_TICKS_PER_FRAME, group);
 }
 
 //;; ## camStopManagingGroup(group)
@@ -155,39 +155,39 @@ function camOrderToString(order)
 //////////// privates
 function __camFindGroupAvgCoordinate(groupID)
 {
-	let droids = enumGroup(groupID);
-	let len = droids.length;
-	let avgCoord = {x: 0, y: 0};
+	const droids = enumGroup(groupID);
+	const __LEN = droids.length;
+	const avgCoord = {x: 0, y: 0};
 
 	if (droids.length === 0)
 	{
 		return null;
 	}
 
-	for (let i = 0; i < len; ++i)
+	for (let i = 0; i < __LEN; ++i)
 	{
-		let droid = droids[i];
+		const droid = droids[i];
 		avgCoord.x += droid.x;
 		avgCoord.y += droid.y;
 	}
 
 	// This global is constantly changing for the tactics code per group
-	__camGroupAvgCoord.x = Math.floor(avgCoord.x / len);
-	__camGroupAvgCoord.y = Math.floor(avgCoord.y / len);
+	__camGroupAvgCoord.x = Math.floor(avgCoord.x / __LEN);
+	__camGroupAvgCoord.y = Math.floor(avgCoord.y / __LEN);
 }
 
 function __camDistToGroupAverage(obj1, obj2)
 {
-	let dist1 = distBetweenTwoPoints(__camGroupAvgCoord.x, __camGroupAvgCoord.y, obj1.x, obj1.y);
-	let dist2 = distBetweenTwoPoints(__camGroupAvgCoord.x, __camGroupAvgCoord.y, obj2.x, obj2.y);
-	return (dist1 - dist2);
+	const __DIST1 = distBetweenTwoPoints(__camGroupAvgCoord.x, __camGroupAvgCoord.y, obj1.x, obj1.y);
+	const __DIST2 = distBetweenTwoPoints(__camGroupAvgCoord.x, __camGroupAvgCoord.y, obj2.x, obj2.y);
+	return (__DIST1 - __DIST2);
 }
 
 function __camPickTarget(group)
 {
 	let targets = [];
-	let gi = __camGroupInfo[group];
-	let droids = enumGroup(group);
+	const gi = __camGroupInfo[group];
+	const droids = enumGroup(group);
 	__camFindGroupAvgCoordinate(group);
 	switch (gi.order)
 	{
@@ -207,7 +207,7 @@ function __camPickTarget(group)
 			{
 				for (let i = 0; i < gi.data.pos.length; ++i)
 				{
-					let compromisePos = gi.data.pos[i];
+					const compromisePos = gi.data.pos[i];
 					if (targets.length > 0)
 					{
 						break;
@@ -232,7 +232,7 @@ function __camPickTarget(group)
 					targets = [ gi.data.pos[gi.data.pos.length - 1] ];
 				}
 			}
-			let dr = droids[0];
+			const dr = droids[0];
 			targets = targets.filter((obj) => (
 				propulsionCanReach(dr.propulsion, dr.x, dr.y, obj.x, obj.y)
 			));
@@ -264,7 +264,7 @@ function __camPickTarget(group)
 				camDebug("'pos' is required for DEFEND order");
 				return undefined;
 			}
-			let defendPos = gi.data.pos[0];
+			const defendPos = gi.data.pos[0];
 			let radius = gi.data.radius;
 			if (!camDef(radius))
 			{
@@ -297,7 +297,7 @@ function __camPickTarget(group)
 		return undefined;
 	}
 	targets.sort(__camDistToGroupAverage);
-	let target = targets[0];
+	const target = targets[0];
 	if (camDef(target) && camDef(target.type) && target.type === DROID && camIsTransporter(target))
 	{
 		return undefined;
@@ -308,16 +308,16 @@ function __camPickTarget(group)
 
 function __camTacticsTick()
 {
-	let dt = CAM_TICKS_PER_FRAME;
+	let dt = __CAM_TICKS_PER_FRAME;
 	for (const group in __camGroupInfo)
 	{
 		//Remove groups with no droids.
 		if (groupSize(group) === 0)
 		{
 			let remove = true;
-			let removable = __camGroupInfo[group].data.removable;
+			const __REMOVABLE = __camGroupInfo[group].data.removable;
 			//Useful if the group has manual management (seen in cam1-3 script).
-			if (camDef(removable) && !removable)
+			if (camDef(__REMOVABLE) && !__REMOVABLE)
 			{
 				remove = false;
 			}
@@ -328,7 +328,7 @@ function __camTacticsTick()
 			}
 		}
 		queue("__camTacticsTickForGroup", dt, group);
-		dt += CAM_TICKS_PER_FRAME;
+		dt += __CAM_TICKS_PER_FRAME;
 	}
 	//Emulate a queue...
 	removeTimer("__camTacticsTick");
@@ -366,20 +366,20 @@ function __camScanRange(order, drType)
 
 function __camTacticsTickForGroup(group)
 {
-	let gi = __camGroupInfo[group];
+	const gi = __camGroupInfo[group];
 	if (!camDef(gi))
 	{
 		return;
 	}
-	let rawDroids = enumGroup(group);
+	const rawDroids = enumGroup(group);
 	if (rawDroids.length === 0)
 	{
 		return;
 	}
 
-	const CLOSE_Z = 1;
+	const __CLOSE_Z = 1;
 	let healthyDroids = [];
-	let repair = {
+	const repair = {
 		hasFacility: enumStruct(rawDroids[0].player, REPAIR_FACILITY).length > 0,
 		pos: camDef(gi.data.repairPos) ? gi.data.repairPos : undefined,
 		percent: camDef(gi.data.repair) ? gi.data.repair : 66,
@@ -390,7 +390,7 @@ function __camTacticsTickForGroup(group)
 	{
 		for (let i = 0, len = rawDroids.length; i < len; ++i)
 		{
-			let droid = rawDroids[i];
+			const droid = rawDroids[i];
 			let repairLikeAction = false;
 
 			if (droid.order === DORDER_RTR)
@@ -412,7 +412,7 @@ function __camTacticsTickForGroup(group)
 			{
 				if (droid.health < repair.percent)
 				{
-					let loc = camMakePos(repair.pos);
+					const loc = camMakePos(repair.pos);
 					orderDroidLoc(droid, DORDER_MOVE, loc.x, loc.y);
 					repairLikeAction = true;
 				}
@@ -431,10 +431,10 @@ function __camTacticsTickForGroup(group)
 
 	if (camDef(gi.data.regroup) && gi.data.regroup && healthyDroids.length > 0)
 	{
-		let ret = __camFindClusters(healthyDroids, __CAM_CLUSTER_SIZE);
-		let groupX = ret.xav[ret.maxIdx];
-		let groupY = ret.yav[ret.maxIdx];
-		let droids = ret.clusters[ret.maxIdx];
+		const ret = __camFindClusters(healthyDroids, __CAM_CLUSTER_SIZE);
+		const groupX = ret.xav[ret.maxIdx];
+		const groupY = ret.yav[ret.maxIdx];
+		const droids = ret.clusters[ret.maxIdx];
 
 		for (let i = 0, len = ret.clusters.length; i < len; ++i)
 		{
@@ -442,7 +442,7 @@ function __camTacticsTickForGroup(group)
 			{
 				for (let j = 0, len2 = ret.clusters[i].length; j < len2; ++j)
 				{
-					let droid = ret.clusters[i][j];
+					const droid = ret.clusters[i][j];
 					if (droid.order !== DORDER_RTR)
 					{
 						orderDroidLoc(droid, DORDER_MOVE, groupX, groupY);
@@ -451,19 +451,19 @@ function __camTacticsTickForGroup(group)
 			}
 		}
 
-		let hitRecently = (gameTime - gi.lastHit < __CAM_FALLBACK_TIME_ON_REGROUP);
+		const __HIT_RECENTLY = (gameTime - gi.lastHit < __CAM_FALLBACK_TIME_ON_REGROUP);
 		// not enough droids grouped?
 		if (gi.count < 0 ? (ret.maxCount < groupSize(group) * 0.66) : (ret.maxCount < gi.count))
 		{
 			for (let i = 0, len = droids.length; i < len; ++i)
 			{
-				let droid = droids[i];
+				const droid = droids[i];
 				if (droid.order === DORDER_RTR)
 				{
 					continue;
 				}
 
-				if (hitRecently && enumStruct(droid.player, HQ).length > 0)
+				if (__HIT_RECENTLY && enumStruct(droid.player, HQ).length > 0)
 				{
 					if (droid.order !== DORDER_RTB)
 					{
@@ -503,13 +503,13 @@ function __camTacticsTickForGroup(group)
 			return;
 	}
 
-	let defending = (gi.order === CAM_ORDER_DEFEND);
-	let track = (gi.order === CAM_ORDER_COMPROMISE);
+	const __DEFENDING = (gi.order === CAM_ORDER_DEFEND);
+	const __TRACK = (gi.order === CAM_ORDER_COMPROMISE);
 
 	for (let i = 0, len = healthyDroids.length; i < len; ++i)
 	{
-		let droid = healthyDroids[i];
-		let vtolUnit = (droid.type === DROID && isVTOL(droid));
+		const droid = healthyDroids[i];
+		const __VTOL_UNIT = (droid.type === DROID && isVTOL(droid));
 
 		if (droid.player === CAM_HUMAN_PLAYER)
 		{
@@ -517,15 +517,15 @@ function __camTacticsTickForGroup(group)
 		}
 
 		//Rearm vtols.
-		if (vtolUnit)
+		if (__VTOL_UNIT)
 		{
-			let arm = droid.weapons[0].armed;
-			let isRearming = droid.order === DORDER_REARM;
+			const __ARM = droid.weapons[0].armed;
+			const __IS_REARMING = droid.order === DORDER_REARM;
 
-			if ((arm < 1) || (isRearming && (arm < 100 || droid.health < 100)))
+			if ((__ARM < 1) || (__IS_REARMING && (__ARM < 100 || droid.health < 100)))
 			{
-				let havePads = enumStruct(droid.player, REARM_PAD).length > 0;
-				if (havePads && !isRearming)
+				const __HAVE_PADS = enumStruct(droid.player, REARM_PAD).length > 0;
+				if (__HAVE_PADS && !__IS_REARMING)
 				{
 					orderDroid(droid, DORDER_REARM);
 				}
@@ -535,7 +535,7 @@ function __camTacticsTickForGroup(group)
 
 		if (gi.order === CAM_ORDER_FOLLOW)
 		{
-			let commander = getObject(gi.data.droid);
+			const commander = getObject(gi.data.droid);
 			if (commander === null)
 			{
 				// the commander is dead? let the group execute his last will.
@@ -552,14 +552,14 @@ function __camTacticsTickForGroup(group)
 		if (gi.order === CAM_ORDER_DEFEND)
 		{
 			// fall back to defense position
-			let dPos = gi.data.pos[0];
-			let dist = camDist(droid.x, droid.y, dPos.x, dPos.y);
+			const dPos = gi.data.pos[0];
+			const __DIST = camDist(droid.x, droid.y, dPos.x, dPos.y);
 			let radius = gi.data.radius;
 			if (!camDef(radius))
 			{
 				radius = __CAM_DEFENSE_RADIUS;
 			}
-			if (dist > radius)
+			if (__DIST > radius)
 			{
 				orderDroidLoc(droid, DORDER_MOVE, target.x, target.y);
 				continue;
@@ -582,7 +582,7 @@ function __camTacticsTickForGroup(group)
 				if (gameTime - gi.lastmove > gi.data.interval)
 				{
 					// find random new position to visit
-					let list = [];
+					const list = [];
 					for (let j = 0, len2 = gi.data.pos.length; j < len2; ++j)
 					{
 						if (j !== gi.lastspot)
@@ -606,8 +606,8 @@ function __camTacticsTickForGroup(group)
 		if (camDef(target) && camDist(droid.x, droid.y, target.x, target.y) >= __CAM_CLOSE_RADIUS)
 		{
 			let closeByObj;
-			let artilleryLike = (droid.isCB || droid.hasIndirect || droid.isSensor);
-			let closeBy = enumRange(droid.x, droid.y, __camScanRange(gi.order, droid.droidType), CAM_HUMAN_PLAYER, track);
+			const __ARTILLERY_LIKE = (droid.isCB || droid.hasIndirect || droid.isSensor);
+			let closeBy = enumRange(droid.x, droid.y, __camScanRange(gi.order, droid.droidType), CAM_HUMAN_PLAYER, __TRACK);
 
 			if (closeBy.length > 0)
 			{
@@ -619,9 +619,9 @@ function __camTacticsTickForGroup(group)
 			//We only care about explicit observe/attack if the object is close
 			//on the z coordinate. We should not chase things up or down hills
 			//that may be far away, at least path-wise.
-			if (closeByObj && !vtolUnit && !artilleryLike)
+			if (closeByObj && !__VTOL_UNIT && !__ARTILLERY_LIKE)
 			{
-				if (Math.abs(droid.z - closeByObj.z) > CLOSE_Z)
+				if (Math.abs(droid.z - closeByObj.z) > __CLOSE_Z)
 				{
 					closeByObj = undefined;
 				}
@@ -632,7 +632,7 @@ function __camTacticsTickForGroup(group)
 				closeByObj = undefined;
 			}
 
-			if (!defending && closeByObj)
+			if (!__DEFENDING && closeByObj)
 			{
 				if (droid.droidType === DROID_SENSOR)
 				{
@@ -645,7 +645,7 @@ function __camTacticsTickForGroup(group)
 			}
 			else
 			{
-				if (defending || !(artilleryLike || vtolUnit))
+				if (__DEFENDING || !(__ARTILLERY_LIKE || __VTOL_UNIT))
 				{
 					orderDroidLoc(droid, DORDER_MOVE, target.x, target.y);
 				}
@@ -660,46 +660,46 @@ function __camTacticsTickForGroup(group)
 
 function __camCheckGroupMorale(group)
 {
-	let gi = __camGroupInfo[group];
+	const gi = __camGroupInfo[group];
 	if (!camDef(gi.data.morale))
 	{
 		return;
 	}
 	// morale is %.
-	let msize = Math.floor((100 - gi.data.morale) * gi.count / 100);
-	let gsize = groupSize(group);
+	const __MSIZE = Math.floor((100 - gi.data.morale) * gi.count / 100);
+	const __GSIZE = groupSize(group);
 	switch (gi.order)
 	{
 		case CAM_ORDER_ATTACK:
 		{
-			if (gsize > msize)
+			if (__GSIZE > __MSIZE)
 			{
 				break;
 			}
 			camTrace("Group", group, "falls back");
 			gi.order = CAM_ORDER_DEFEND;
 			// swap pos and fallback
-			let temp = gi.data.pos;
+			const temp = gi.data.pos;
 			gi.data.pos = [ camMakePos(gi.data.fallback) ];
 			gi.data.fallback = temp;
 			// apply orders instantly
-			queue("__camTacticsTickForGroup", CAM_TICKS_PER_FRAME, group);
+			queue("__camTacticsTickForGroup", __CAM_TICKS_PER_FRAME, group);
 			break;
 		}
 		case CAM_ORDER_DEFEND:
 		{
-			if (gsize <= msize)
+			if (__GSIZE <= __MSIZE)
 			{
 				break;
 			}
 			camTrace("Group", group, "restores");
 			gi.order = CAM_ORDER_ATTACK;
 			// swap pos and fallback
-			let temp = gi.data.pos;
+			const temp = gi.data.pos;
 			gi.data.pos = gi.data.fallback;
 			gi.data.fallback = temp[0];
 			// apply orders instantly
-			queue("__camTacticsTickForGroup", CAM_TICKS_PER_FRAME, group);
+			queue("__camTacticsTickForGroup", __CAM_TICKS_PER_FRAME, group);
 			break;
 		}
 		default:

--- a/data/base/script/campaign/libcampaign_includes/tactics.js
+++ b/data/base/script/campaign/libcampaign_includes/tactics.js
@@ -62,7 +62,7 @@
 //;;
 function camManageGroup(group, order, data)
 {
-	var saneData = data;
+	let saneData = data;
 	if (!camDef(saneData))
 	{
 		saneData = {};
@@ -94,7 +94,7 @@ function camManageGroup(group, order, data)
 	};
 	if (order === CAM_ORDER_FOLLOW)
 	{
-		var commanderGroup = camMakeGroup([getObject(data.droid)]);
+		let commanderGroup = camMakeGroup([getObject(data.droid)]);
 		camManageGroup(commanderGroup, data.order, data.data);
 	}
 	// apply orders instantly
@@ -128,7 +128,7 @@ function camStopManagingGroup(group)
 //;;
 function camOrderToString(order)
 {
-	var orderString;
+	let orderString;
 	switch (order)
 	{
 		case CAM_ORDER_ATTACK:
@@ -155,9 +155,9 @@ function camOrderToString(order)
 //////////// privates
 function __camFindGroupAvgCoordinate(groupID)
 {
-	var droids = enumGroup(groupID);
-	var len = droids.length;
-	var avgCoord = {x: 0, y: 0};
+	let droids = enumGroup(groupID);
+	let len = droids.length;
+	let avgCoord = {x: 0, y: 0};
 
 	if (droids.length === 0)
 	{
@@ -166,7 +166,7 @@ function __camFindGroupAvgCoordinate(groupID)
 
 	for (let i = 0; i < len; ++i)
 	{
-		var droid = droids[i];
+		let droid = droids[i];
 		avgCoord.x += droid.x;
 		avgCoord.y += droid.y;
 	}
@@ -178,38 +178,41 @@ function __camFindGroupAvgCoordinate(groupID)
 
 function __camDistToGroupAverage(obj1, obj2)
 {
-	var dist1 = distBetweenTwoPoints(__camGroupAvgCoord.x, __camGroupAvgCoord.y, obj1.x, obj1.y);
-	var dist2 = distBetweenTwoPoints(__camGroupAvgCoord.x, __camGroupAvgCoord.y, obj2.x, obj2.y);
+	let dist1 = distBetweenTwoPoints(__camGroupAvgCoord.x, __camGroupAvgCoord.y, obj1.x, obj1.y);
+	let dist2 = distBetweenTwoPoints(__camGroupAvgCoord.x, __camGroupAvgCoord.y, obj2.x, obj2.y);
 	return (dist1 - dist2);
 }
 
 function __camPickTarget(group)
 {
-	var targets = [];
-	var gi = __camGroupInfo[group];
-	var droids = enumGroup(group);
+	let targets = [];
+	let gi = __camGroupInfo[group];
+	let droids = enumGroup(group);
 	__camFindGroupAvgCoordinate(group);
 	switch (gi.order)
 	{
 		case CAM_ORDER_ATTACK:
+		{
 			if (camDef(gi.target))
 			{
 				targets = enumRange(gi.target.x, gi.target.y,__CAM_TARGET_TRACKING_RADIUS, CAM_HUMAN_PLAYER, false).filter((obj) => (
 					obj.type === STRUCTURE || (obj.type === DROID && !isVTOL(obj))
 				));
 			}
+		}
 			// fall-through! we just don't track targets on COMPROMISE
 		case CAM_ORDER_COMPROMISE:
+		{
 			if (camDef(gi.data.pos))
 			{
 				for (let i = 0; i < gi.data.pos.length; ++i)
 				{
-					var compromisePos = gi.data.pos[i];
+					let compromisePos = gi.data.pos[i];
 					if (targets.length > 0)
 					{
 						break;
 					}
-					var radius = gi.data.radius;
+					let radius = gi.data.radius;
 					if (!camDef(radius))
 					{
 						radius = __CAM_PLAYER_BASE_RADIUS;
@@ -229,7 +232,7 @@ function __camPickTarget(group)
 					targets = [ gi.data.pos[gi.data.pos.length - 1] ];
 				}
 			}
-			var dr = droids[0];
+			let dr = droids[0];
 			targets = targets.filter((obj) => (
 				propulsionCanReach(dr.propulsion, dr.x, dr.y, obj.x, obj.y)
 			));
@@ -253,14 +256,16 @@ function __camPickTarget(group)
 				}
 			}
 			break;
+		}
 		case CAM_ORDER_DEFEND:
+		{
 			if (!camDef(gi.data.pos))
 			{
 				camDebug("'pos' is required for DEFEND order");
 				return undefined;
 			}
-			var defendPos = gi.data.pos[0];
-			var radius = gi.data.radius;
+			let defendPos = gi.data.pos[0];
+			let radius = gi.data.radius;
 			if (!camDef(radius))
 			{
 				radius = __CAM_DEFENSE_RADIUS;
@@ -280,16 +285,19 @@ function __camPickTarget(group)
 				targets = [ defendPos ];
 			}
 			break;
+		}
 		default:
+		{
 			camDebug("Unsupported group order", gi.order, camOrderToString(gi.order));
 			break;
+		}
 	}
 	if (targets.length === 0)
 	{
 		return undefined;
 	}
 	targets.sort(__camDistToGroupAverage);
-	var target = targets[0];
+	let target = targets[0];
 	if (camDef(target) && camDef(target.type) && target.type === DROID && camIsTransporter(target))
 	{
 		return undefined;
@@ -300,14 +308,14 @@ function __camPickTarget(group)
 
 function __camTacticsTick()
 {
-	var dt = CAM_TICKS_PER_FRAME;
+	let dt = CAM_TICKS_PER_FRAME;
 	for (const group in __camGroupInfo)
 	{
 		//Remove groups with no droids.
 		if (groupSize(group) === 0)
 		{
-			var remove = true;
-			var removable = __camGroupInfo[group].data.removable;
+			let remove = true;
+			let removable = __camGroupInfo[group].data.removable;
 			//Useful if the group has manual management (seen in cam1-3 script).
 			if (camDef(removable) && !removable)
 			{
@@ -330,7 +338,7 @@ function __camTacticsTick()
 //Return the range (in tiles) a droid will scout for stuff to attack around it.
 function __camScanRange(order, drType)
 {
-	var rng = __CAM_TARGET_TRACKING_RADIUS; //default
+	let rng = __CAM_TARGET_TRACKING_RADIUS; //default
 	switch (order)
 	{
 		case CAM_ORDER_ATTACK:
@@ -358,20 +366,20 @@ function __camScanRange(order, drType)
 
 function __camTacticsTickForGroup(group)
 {
-	var gi = __camGroupInfo[group];
+	let gi = __camGroupInfo[group];
 	if (!camDef(gi))
 	{
 		return;
 	}
-	var rawDroids = enumGroup(group);
+	let rawDroids = enumGroup(group);
 	if (rawDroids.length === 0)
 	{
 		return;
 	}
 
 	const CLOSE_Z = 1;
-	var healthyDroids = [];
-	var repair = {
+	let healthyDroids = [];
+	let repair = {
 		hasFacility: enumStruct(rawDroids[0].player, REPAIR_FACILITY).length > 0,
 		pos: camDef(gi.data.repairPos) ? gi.data.repairPos : undefined,
 		percent: camDef(gi.data.repair) ? gi.data.repair : 66,
@@ -382,8 +390,8 @@ function __camTacticsTickForGroup(group)
 	{
 		for (let i = 0, len = rawDroids.length; i < len; ++i)
 		{
-			var droid = rawDroids[i];
-			var repairLikeAction = false;
+			let droid = rawDroids[i];
+			let repairLikeAction = false;
 
 			if (droid.order === DORDER_RTR)
 			{
@@ -404,7 +412,7 @@ function __camTacticsTickForGroup(group)
 			{
 				if (droid.health < repair.percent)
 				{
-					var loc = camMakePos(repair.pos);
+					let loc = camMakePos(repair.pos);
 					orderDroidLoc(droid, DORDER_MOVE, loc.x, loc.y);
 					repairLikeAction = true;
 				}
@@ -423,10 +431,10 @@ function __camTacticsTickForGroup(group)
 
 	if (camDef(gi.data.regroup) && gi.data.regroup && healthyDroids.length > 0)
 	{
-		var ret = __camFindClusters(healthyDroids, __CAM_CLUSTER_SIZE);
-		var groupX = ret.xav[ret.maxIdx];
-		var groupY = ret.yav[ret.maxIdx];
-		var droids = ret.clusters[ret.maxIdx];
+		let ret = __camFindClusters(healthyDroids, __CAM_CLUSTER_SIZE);
+		let groupX = ret.xav[ret.maxIdx];
+		let groupY = ret.yav[ret.maxIdx];
+		let droids = ret.clusters[ret.maxIdx];
 
 		for (let i = 0, len = ret.clusters.length; i < len; ++i)
 		{
@@ -434,7 +442,7 @@ function __camTacticsTickForGroup(group)
 			{
 				for (let j = 0, len2 = ret.clusters[i].length; j < len2; ++j)
 				{
-					var droid = ret.clusters[i][j];
+					let droid = ret.clusters[i][j];
 					if (droid.order !== DORDER_RTR)
 					{
 						orderDroidLoc(droid, DORDER_MOVE, groupX, groupY);
@@ -443,13 +451,13 @@ function __camTacticsTickForGroup(group)
 			}
 		}
 
-		var hitRecently = (gameTime - gi.lastHit < __CAM_FALLBACK_TIME_ON_REGROUP);
+		let hitRecently = (gameTime - gi.lastHit < __CAM_FALLBACK_TIME_ON_REGROUP);
 		// not enough droids grouped?
 		if (gi.count < 0 ? (ret.maxCount < groupSize(group) * 0.66) : (ret.maxCount < gi.count))
 		{
 			for (let i = 0, len = droids.length; i < len; ++i)
 			{
-				var droid = droids[i];
+				let droid = droids[i];
 				if (droid.order === DORDER_RTR)
 				{
 					continue;
@@ -472,8 +480,8 @@ function __camTacticsTickForGroup(group)
 	}
 
 	//Target choosing
-	var target;
-	var patrolPos;
+	let target;
+	let patrolPos;
 
 	switch (gi.order)
 	{
@@ -495,13 +503,13 @@ function __camTacticsTickForGroup(group)
 			return;
 	}
 
-	var defending = (gi.order === CAM_ORDER_DEFEND);
-	var track = (gi.order === CAM_ORDER_COMPROMISE);
+	let defending = (gi.order === CAM_ORDER_DEFEND);
+	let track = (gi.order === CAM_ORDER_COMPROMISE);
 
 	for (let i = 0, len = healthyDroids.length; i < len; ++i)
 	{
-		var droid = healthyDroids[i];
-		var vtolUnit = (droid.type === DROID && isVTOL(droid));
+		let droid = healthyDroids[i];
+		let vtolUnit = (droid.type === DROID && isVTOL(droid));
 
 		if (droid.player === CAM_HUMAN_PLAYER)
 		{
@@ -511,12 +519,12 @@ function __camTacticsTickForGroup(group)
 		//Rearm vtols.
 		if (vtolUnit)
 		{
-			var arm = droid.weapons[0].armed;
-			var isRearming = droid.order === DORDER_REARM;
+			let arm = droid.weapons[0].armed;
+			let isRearming = droid.order === DORDER_REARM;
 
 			if ((arm < 1) || (isRearming && (arm < 100 || droid.health < 100)))
 			{
-				var havePads = enumStruct(droid.player, REARM_PAD).length > 0;
+				let havePads = enumStruct(droid.player, REARM_PAD).length > 0;
 				if (havePads && !isRearming)
 				{
 					orderDroid(droid, DORDER_REARM);
@@ -527,7 +535,7 @@ function __camTacticsTickForGroup(group)
 
 		if (gi.order === CAM_ORDER_FOLLOW)
 		{
-			var commander = getObject(gi.data.droid);
+			let commander = getObject(gi.data.droid);
 			if (commander === null)
 			{
 				// the commander is dead? let the group execute his last will.
@@ -544,9 +552,9 @@ function __camTacticsTickForGroup(group)
 		if (gi.order === CAM_ORDER_DEFEND)
 		{
 			// fall back to defense position
-			var dPos = gi.data.pos[0];
-			var dist = camDist(droid.x, droid.y, dPos.x, dPos.y);
-			var radius = gi.data.radius;
+			let dPos = gi.data.pos[0];
+			let dist = camDist(droid.x, droid.y, dPos.x, dPos.y);
+			let radius = gi.data.radius;
 			if (!camDef(radius))
 			{
 				radius = __CAM_DEFENSE_RADIUS;
@@ -574,7 +582,7 @@ function __camTacticsTickForGroup(group)
 				if (gameTime - gi.lastmove > gi.data.interval)
 				{
 					// find random new position to visit
-					var list = [];
+					let list = [];
 					for (let j = 0, len2 = gi.data.pos.length; j < len2; ++j)
 					{
 						if (j !== gi.lastspot)
@@ -597,9 +605,9 @@ function __camTacticsTickForGroup(group)
 
 		if (camDef(target) && camDist(droid.x, droid.y, target.x, target.y) >= __CAM_CLOSE_RADIUS)
 		{
-			var closeByObj;
-			var artilleryLike = (droid.isCB || droid.hasIndirect || droid.isSensor);
-			var closeBy = enumRange(droid.x, droid.y, __camScanRange(gi.order, droid.droidType), CAM_HUMAN_PLAYER, track);
+			let closeByObj;
+			let artilleryLike = (droid.isCB || droid.hasIndirect || droid.isSensor);
+			let closeBy = enumRange(droid.x, droid.y, __camScanRange(gi.order, droid.droidType), CAM_HUMAN_PLAYER, track);
 
 			if (closeBy.length > 0)
 			{
@@ -652,17 +660,18 @@ function __camTacticsTickForGroup(group)
 
 function __camCheckGroupMorale(group)
 {
-	var gi = __camGroupInfo[group];
+	let gi = __camGroupInfo[group];
 	if (!camDef(gi.data.morale))
 	{
 		return;
 	}
 	// morale is %.
-	var msize = Math.floor((100 - gi.data.morale) * gi.count / 100);
-	var gsize = groupSize(group);
+	let msize = Math.floor((100 - gi.data.morale) * gi.count / 100);
+	let gsize = groupSize(group);
 	switch (gi.order)
 	{
 		case CAM_ORDER_ATTACK:
+		{
 			if (gsize > msize)
 			{
 				break;
@@ -670,13 +679,15 @@ function __camCheckGroupMorale(group)
 			camTrace("Group", group, "falls back");
 			gi.order = CAM_ORDER_DEFEND;
 			// swap pos and fallback
-			var temp = gi.data.pos;
+			let temp = gi.data.pos;
 			gi.data.pos = [ camMakePos(gi.data.fallback) ];
 			gi.data.fallback = temp;
 			// apply orders instantly
 			queue("__camTacticsTickForGroup", CAM_TICKS_PER_FRAME, group);
 			break;
+		}
 		case CAM_ORDER_DEFEND:
+		{
 			if (gsize <= msize)
 			{
 				break;
@@ -684,14 +695,17 @@ function __camCheckGroupMorale(group)
 			camTrace("Group", group, "restores");
 			gi.order = CAM_ORDER_ATTACK;
 			// swap pos and fallback
-			var temp = gi.data.pos;
+			let temp = gi.data.pos;
 			gi.data.pos = gi.data.fallback;
 			gi.data.fallback = temp[0];
 			// apply orders instantly
 			queue("__camTacticsTickForGroup", CAM_TICKS_PER_FRAME, group);
 			break;
+		}
 		default:
+		{
 			camDebug("Group order doesn't support morale", camOrderToString(gi.order));
 			break;
+		}
 	}
 }

--- a/data/base/script/campaign/libcampaign_includes/time.js
+++ b/data/base/script/campaign/libcampaign_includes/time.js
@@ -13,7 +13,7 @@
 //;;
 function camSecondsToMilliseconds(seconds)
 {
-	return seconds * MILLISECONDS_IN_SECOND;
+	return seconds * CAM_MILLISECONDS_IN_SECOND;
 }
 
 //;; ## camMinutesToMilliseconds(minutes)
@@ -25,7 +25,7 @@ function camSecondsToMilliseconds(seconds)
 //;;
 function camMinutesToMilliseconds(minutes)
 {
-	return minutes * camSecondsToMilliseconds(SECONDS_IN_MINUTE);
+	return minutes * camSecondsToMilliseconds(CAM_SECONDS_IN_MINUTE);
 }
 
 //;; ## camMinutesToSeconds(minutes)
@@ -37,7 +37,7 @@ function camMinutesToMilliseconds(minutes)
 //;;
 function camMinutesToSeconds(minutes)
 {
-	return minutes * SECONDS_IN_MINUTE;
+	return minutes * CAM_SECONDS_IN_MINUTE;
 }
 
 //;; ## camHoursToSeconds(hours)
@@ -49,5 +49,5 @@ function camMinutesToSeconds(minutes)
 //;;
 function camHoursToSeconds(hours)
 {
-	return hours * camMinutesToSeconds(MINUTES_IN_HOUR);
+	return hours * camMinutesToSeconds(CAM_MINUTES_IN_HOUR);
 }

--- a/data/base/script/campaign/libcampaign_includes/transport.js
+++ b/data/base/script/campaign/libcampaign_includes/transport.js
@@ -71,11 +71,11 @@ function __camDispatchTransporterUnsafe()
 		return false;
 	}
 	const OFFSET = 1; //Increaze LZ "no go" zone area a bit
-	var args = __camTransporterQueue[0];
-	var player = args.player;
-	var pos = args.position;
-	var list = args.list;
-	var data = args.data;
+	let args = __camTransporterQueue[0];
+	let player = args.player;
+	let pos = args.position;
+	let list = args.list;
+	let data = args.data;
 	if (camDef(__camIncomingTransports[player]))
 	{
 		camTrace("Transporter already on map for player", player + ", delaying.");
@@ -91,13 +91,13 @@ function __camDispatchTransporterUnsafe()
 		                                         "V-Tol", "", "",
 		                                         "MG3-VTOL");
 	}
-	var trans = __camPlayerTransports[player];
-	var droids = [];
+	let trans = __camPlayerTransports[player];
+	let droids = [];
 	for (let i = 0, l = list.length; i < l; ++i)
 	{
-		var template = list[i];
-		var prop = __camChangePropulsion(template.prop, player);
-		var droid = addDroid(player, -1, -1, "Reinforcement", template.body, prop, "", "", template.weap);
+		let template = list[i];
+		let prop = __camChangePropulsion(template.prop, player);
+		let droid = addDroid(player, -1, -1, "Reinforcement", template.body, prop, "", "", template.weap);
 		droids.push(droid);
 		addDroidToTransporter(trans, droid);
 	}
@@ -140,7 +140,7 @@ function __camDispatchTransporterSafe(player, position, list, data)
 
 function __camLandTransporter(player, pos)
 {
-	var ti = __camIncomingTransports[player];
+	let ti = __camIncomingTransports[player];
 	if (!camDef(ti))
 	{
 		camDebug("Unhandled transporter for player", player);
@@ -160,7 +160,7 @@ function __camLandTransporter(player, pos)
 	camManageGroup(camMakeGroup(ti.droids), ti.order, ti.data);
 	if (player !== CAM_HUMAN_PLAYER)
 	{
-		for (var i = 0, len = ti.droids.length; i < len; ++i)
+		for (let i = 0, len = ti.droids.length; i < len; ++i)
 		{
 			camSetDroidExperience(ti.droids[i]);
 		}

--- a/data/base/script/campaign/libcampaign_includes/transport.js
+++ b/data/base/script/campaign/libcampaign_includes/transport.js
@@ -70,63 +70,63 @@ function __camDispatchTransporterUnsafe()
 		camDebug("Transporter queue empty!");
 		return false;
 	}
-	const OFFSET = 1; //Increaze LZ "no go" zone area a bit
-	let args = __camTransporterQueue[0];
-	let player = args.player;
-	let pos = args.position;
-	let list = args.list;
-	let data = args.data;
-	if (camDef(__camIncomingTransports[player]))
+	const __OFFSET = 1; //Increaze LZ "no go" zone area a bit
+	const args = __camTransporterQueue[0];
+	const __PLAYER = args.player;
+	const pos = args.position;
+	const list = args.list;
+	const data = args.data;
+	if (camDef(__camIncomingTransports[__PLAYER]))
 	{
-		camTrace("Transporter already on map for player", player + ", delaying.");
+		camTrace("Transporter already on map for player", __PLAYER + ", delaying.");
 		return false;
 	}
 	__camTransporterQueue.shift(); // what could possibly go wrong?
-	if (!camDef(__camPlayerTransports[player]))
+	if (!camDef(__camPlayerTransports[__PLAYER]))
 	{
-		camTrace("Creating a transporter for player", player);
-		__camPlayerTransports[player] = addDroid(player, -1, -1,
+		camTrace("Creating a transporter for player", __PLAYER);
+		__camPlayerTransports[__PLAYER] = addDroid(__PLAYER, -1, -1,
 		                                         "Transporter",
 		                                         "TransporterBody",
 		                                         "V-Tol", "", "",
 		                                         "MG3-VTOL");
 	}
-	let trans = __camPlayerTransports[player];
-	let droids = [];
+	const transporter = __camPlayerTransports[__PLAYER];
+	const droids = [];
 	for (let i = 0, l = list.length; i < l; ++i)
 	{
-		let template = list[i];
-		let prop = __camChangePropulsion(template.prop, player);
-		let droid = addDroid(player, -1, -1, "Reinforcement", template.body, prop, "", "", template.weap);
+		const template = list[i];
+		const __PROP = __camChangePropulsion(template.prop, __PLAYER);
+		const droid = addDroid(__PLAYER, -1, -1, "Reinforcement", template.body, __PROP, "", "", template.weap);
 		droids.push(droid);
-		addDroidToTransporter(trans, droid);
+		addDroidToTransporter(transporter, droid);
 	}
-	__camIncomingTransports[player] = {
+	__camIncomingTransports[__PLAYER] = {
 		droids: droids,
 		message: args.data.message,
 		order: args.order,
 		data: args.order_data,
 	};
 	camTrace("Incoming transport with", droids.length,
-	         "droids for player", player +
+	         "droids for player", __PLAYER +
 	         ", queued transports", __camTransporterQueue.length);
 
-	setNoGoArea(pos.x - OFFSET, pos.y - OFFSET, pos.x + OFFSET, pos.y + OFFSET, player);
+	setNoGoArea(pos.x - __OFFSET, pos.y - __OFFSET, pos.x + __OFFSET, pos.y + __OFFSET, __PLAYER);
 
 	//Delete previous enemy reinforcement transport blip
-	if (player !== CAM_HUMAN_PLAYER)
+	if (__PLAYER !== CAM_HUMAN_PLAYER)
 	{
 		camRemoveEnemyTransporterBlip();
 	}
 
-	if (player !== CAM_HUMAN_PLAYER)
+	if (__PLAYER !== CAM_HUMAN_PLAYER)
 	{
 		playSound("pcv381.ogg"); //Enemy transport detected.
 	}
 
-	setTransporterExit(data.exit.x, data.exit.y, player);
+	setTransporterExit(data.exit.x, data.exit.y, __PLAYER);
 	// will guess which transporter to start, automagically
-	startTransporterEntry(data.entry.x, data.entry.y, player);
+	startTransporterEntry(data.entry.x, data.entry.y, __PLAYER);
 	return true;
 }
 
@@ -140,7 +140,7 @@ function __camDispatchTransporterSafe(player, position, list, data)
 
 function __camLandTransporter(player, pos)
 {
-	let ti = __camIncomingTransports[player];
+	const ti = __camIncomingTransports[player];
 	if (!camDef(ti))
 	{
 		camDebug("Unhandled transporter for player", player);

--- a/data/base/script/campaign/libcampaign_includes/truck.js
+++ b/data/base/script/campaign/libcampaign_includes/truck.js
@@ -31,7 +31,7 @@ function camManageTrucks(playerId)
 //;;
 function camQueueBuilding(playerId, stat, position)
 {
-	let ti = __camTruckInfo[playerId];
+	const ti = __camTruckInfo[playerId];
 	ti.queue.push({ stat: stat, pos: camMakePos(position) });
 }
 
@@ -39,11 +39,11 @@ function camQueueBuilding(playerId, stat, position)
 
 function __camEnumFreeTrucks(player)
 {
-	let rawDroids = enumDroid(player, DROID_CONSTRUCT);
-	let droids = [];
+	const rawDroids = enumDroid(player, DROID_CONSTRUCT);
+	const droids = [];
 	for (let i = 0, l = rawDroids.length; i < l; ++i)
 	{
-		let droid = rawDroids[i];
+		const droid = rawDroids[i];
 		if (droid.order !== DORDER_BUILD && droid.order !== DORDER_HELPBUILD && droid.order !== DORDER_LINEBUILD)
 		{
 			droids.push(droid);
@@ -54,7 +54,7 @@ function __camEnumFreeTrucks(player)
 
 function __camGetClosestTruck(player, pos)
 {
-	let droids = __camEnumFreeTrucks(player);
+	const droids = __camEnumFreeTrucks(player);
 	if (droids.length <= 0)
 	{
 		return undefined;
@@ -65,15 +65,15 @@ function __camGetClosestTruck(player, pos)
 	let minDist = camDist(minDroid, pos);
 	for (let i = 1, l = droids.length; i < l; ++i)
 	{
-		let droid = droids[i];
+		const droid = droids[i];
 		if (!droidCanReach(droid, pos.x, pos.y))
 		{
 			continue;
 		}
-		let dist = camDist(droid, pos);
-		if (dist < minDist)
+		const __DIST = camDist(droid, pos);
+		if (__DIST < minDist)
 		{
-			minDist = dist;
+			minDist = __DIST;
 			minDroid = droid;
 		}
 	}
@@ -86,22 +86,22 @@ function __camTruckTick()
 	// See comments inside the loop to understand priority.
 	for (const playerObj in __camTruckInfo)
 	{
-		let ti = __camTruckInfo[playerObj];
-		let player = ti.player;
+		const ti = __camTruckInfo[playerObj];
+		const __PLAYER = ti.player;
 		let truck;
 
 		// First, build things that were explicitly ordered.
 		while (ti.queue.length > 0)
 		{
-			let qi = ti.queue[0];
-			let pos = qi.pos;
+			const __QI = ti.queue[0];
+			let pos = __QI.pos;
 			let randx = 0;
 			let randy = 0;
 
 			if (camDef(pos))
 			{
 				// Find the truck most suitable for the job.
-				truck = __camGetClosestTruck(player, pos);
+				truck = __camGetClosestTruck(__PLAYER, pos);
 				if (!camDef(truck))
 				{
 					break;
@@ -110,7 +110,7 @@ function __camTruckTick()
 			else
 			{
 				// Build near any truck if pos was not specified.
-				let droids = __camEnumFreeTrucks(player);
+				const droids = __camEnumFreeTrucks(__PLAYER);
 				if (droids.length <= 0)
 				{
 					break;
@@ -121,11 +121,11 @@ function __camTruckTick()
 				randy = (camRand(100) < 50) ? -camRand(2) : camRand(2);
 			}
 
-			enableStructure(qi.stat, player);
-			let loc = pickStructLocation(truck, qi.stat, pos.x, pos.y);
+			enableStructure(__QI.stat, __PLAYER);
+			const loc = pickStructLocation(truck, __QI.stat, pos.x, pos.y);
 			if (camDef(loc) && camDef(truck))
 			{
-				if (orderDroidBuild(truck, DORDER_BUILD, qi.stat, loc.x + randx, loc.y + randy))
+				if (orderDroidBuild(truck, DORDER_BUILD, __QI.stat, loc.x + randx, loc.y + randy))
 				{
 					ti.queue.shift(); // consider it handled
 				}
@@ -133,16 +133,16 @@ function __camTruckTick()
 		}
 
 		// Then, capture free oils.
-		let oils = enumFeature(ALL_PLAYERS, "OilResource");
+		const oils = enumFeature(ALL_PLAYERS, "OilResource");
 		if (oils.length === 0)
 		{
 			continue;
 		}
-		let oil = oils[0];
-		truck = __camGetClosestTruck(player, oil);
-		if (camDef(truck) && player !== NEXUS)
+		const oil = oils[0];
+		truck = __camGetClosestTruck(__PLAYER, oil);
+		if (camDef(truck) && __PLAYER !== CAM_NEXUS)
 		{
-			enableStructure("A0ResourceExtractor", player);
+			enableStructure("A0ResourceExtractor", __PLAYER);
 			orderDroidBuild(truck, DORDER_BUILD, "A0ResourceExtractor", oil.x, oil.y);
 			continue;
 		}

--- a/data/base/script/campaign/libcampaign_includes/truck.js
+++ b/data/base/script/campaign/libcampaign_includes/truck.js
@@ -31,7 +31,7 @@ function camManageTrucks(playerId)
 //;;
 function camQueueBuilding(playerId, stat, position)
 {
-	var ti = __camTruckInfo[playerId];
+	let ti = __camTruckInfo[playerId];
 	ti.queue.push({ stat: stat, pos: camMakePos(position) });
 }
 
@@ -39,11 +39,11 @@ function camQueueBuilding(playerId, stat, position)
 
 function __camEnumFreeTrucks(player)
 {
-	var rawDroids = enumDroid(player, DROID_CONSTRUCT);
-	var droids = [];
+	let rawDroids = enumDroid(player, DROID_CONSTRUCT);
+	let droids = [];
 	for (let i = 0, l = rawDroids.length; i < l; ++i)
 	{
-		var droid = rawDroids[i];
+		let droid = rawDroids[i];
 		if (droid.order !== DORDER_BUILD && droid.order !== DORDER_HELPBUILD && droid.order !== DORDER_LINEBUILD)
 		{
 			droids.push(droid);
@@ -54,23 +54,23 @@ function __camEnumFreeTrucks(player)
 
 function __camGetClosestTruck(player, pos)
 {
-	var droids = __camEnumFreeTrucks(player);
+	let droids = __camEnumFreeTrucks(player);
 	if (droids.length <= 0)
 	{
 		return undefined;
 	}
 
 	// Find out which one is the closest.
-	var minDroid = droids[0];
-	var minDist = camDist(minDroid, pos);
+	let minDroid = droids[0];
+	let minDist = camDist(minDroid, pos);
 	for (let i = 1, l = droids.length; i < l; ++i)
 	{
-		var droid = droids[i];
+		let droid = droids[i];
 		if (!droidCanReach(droid, pos.x, pos.y))
 		{
 			continue;
 		}
-		var dist = camDist(droid, pos);
+		let dist = camDist(droid, pos);
 		if (dist < minDist)
 		{
 			minDist = dist;
@@ -86,17 +86,17 @@ function __camTruckTick()
 	// See comments inside the loop to understand priority.
 	for (const playerObj in __camTruckInfo)
 	{
-		var ti = __camTruckInfo[playerObj];
-		var player = ti.player;
-		var truck;
+		let ti = __camTruckInfo[playerObj];
+		let player = ti.player;
+		let truck;
 
 		// First, build things that were explicitly ordered.
 		while (ti.queue.length > 0)
 		{
-			var qi = ti.queue[0];
-			var pos = qi.pos;
-			var randx = 0;
-			var randy = 0;
+			let qi = ti.queue[0];
+			let pos = qi.pos;
+			let randx = 0;
+			let randy = 0;
 
 			if (camDef(pos))
 			{
@@ -110,7 +110,7 @@ function __camTruckTick()
 			else
 			{
 				// Build near any truck if pos was not specified.
-				var droids = __camEnumFreeTrucks(player);
+				let droids = __camEnumFreeTrucks(player);
 				if (droids.length <= 0)
 				{
 					break;
@@ -122,7 +122,7 @@ function __camTruckTick()
 			}
 
 			enableStructure(qi.stat, player);
-			var loc = pickStructLocation(truck, qi.stat, pos.x, pos.y);
+			let loc = pickStructLocation(truck, qi.stat, pos.x, pos.y);
 			if (camDef(loc) && camDef(truck))
 			{
 				if (orderDroidBuild(truck, DORDER_BUILD, qi.stat, loc.x + randx, loc.y + randy))
@@ -133,12 +133,12 @@ function __camTruckTick()
 		}
 
 		// Then, capture free oils.
-		var oils = enumFeature(ALL_PLAYERS, "OilResource");
+		let oils = enumFeature(ALL_PLAYERS, "OilResource");
 		if (oils.length === 0)
 		{
 			continue;
 		}
-		var oil = oils[0];
+		let oil = oils[0];
 		truck = __camGetClosestTruck(player, oil);
 		if (camDef(truck) && player !== NEXUS)
 		{

--- a/data/base/script/campaign/libcampaign_includes/victory.js
+++ b/data/base/script/campaign/libcampaign_includes/victory.js
@@ -14,14 +14,14 @@ function camNextLevel(nextLevel)
 {
 	if (__camNeedBonusTime)
 	{
-		var bonusTime = getMissionTime();
+		let bonusTime = getMissionTime();
 		if (difficulty <= MEDIUM)
 		{
 			bonusTime = Math.floor(bonusTime * 0.75);
 		}
 		if (bonusTime > 0)
 		{
-			var bonus = 110;
+			let bonus = 110;
 			if (difficulty === HARD)
 			{
 				bonus = 105;
@@ -129,10 +129,10 @@ function camSetStandardWinLossConditions(kind, nextLevel, data)
 //;;
 function camCheckExtraObjective()
 {
-	var extraObjMet = true;
+	let extraObjMet = true;
 	if (camDef(__camVictoryData) && camDef(__camVictoryData.callback))
 	{
-		var result = __camGlobalContext()[__camVictoryData.callback]();
+		let result = __camGlobalContext()[__camVictoryData.callback]();
 		if (camDef(result))
 		{
 			if (!result)
@@ -217,8 +217,8 @@ function __camGameWon()
 //in campaign at the moment.
 function __camPlayerDead()
 {
-	var dead = true;
-	var haveFactories = enumStruct(CAM_HUMAN_PLAYER, FACTORY).filter((obj) => (
+	let dead = true;
+	let haveFactories = enumStruct(CAM_HUMAN_PLAYER, FACTORY).filter((obj) => (
 		obj.status === BUILT
 	)).length > 0;
 
@@ -255,13 +255,13 @@ function __camPlayerDead()
 	else
 	{
 		//Check the transporter.
-		var transporter = enumDroid(CAM_HUMAN_PLAYER, DROID_SUPERTRANSPORTER);
+		let transporter = enumDroid(CAM_HUMAN_PLAYER, DROID_SUPERTRANSPORTER);
 		if (transporter.length > 0)
 		{
-			var cargoDroids = enumCargo(transporter[0]);
+			let cargoDroids = enumCargo(transporter[0]);
 			for (let i = 0, len = cargoDroids.length; i < len; ++i)
 			{
-				var virDroid = cargoDroids[i];
+				let virDroid = cargoDroids[i];
 				if (camDef(virDroid) && virDroid && virDroid.droidType === DROID_CONSTRUCT)
 				{
 					dead = false;
@@ -274,7 +274,7 @@ function __camPlayerDead()
 	if (__camWinLossCallback === CAM_VICTORY_TIMEOUT)
 	{
 		//Make the mission fail if no units are alive on map while having no factories.
-		var droidCount = 0;
+		let droidCount = 0;
 		enumDroid(CAM_HUMAN_PLAYER).forEach((obj) => {
 			if (obj.droidType === DROID_SUPERTRANSPORTER)
 			{
@@ -305,7 +305,7 @@ function __camTriggerLastAttack()
 {
 	if (!__camLastAttackTriggered)
 	{
-		var enemies = enumArea(0, 0, mapWidth, mapHeight, ENEMIES, false);
+		let enemies = enumArea(0, 0, mapWidth, mapHeight, ENEMIES, false);
 		// Do not order systems (sensor/trucks/repairs) to attack stuff.
 		enemies = enemies.filter((obj) => (
 			obj.type === DROID && !camIsTransporter(obj) && !camIsSystemDroid(obj)
@@ -318,7 +318,7 @@ function __camTriggerLastAttack()
 
 function __camVictoryStandard()
 {
-	var extraObj = camCheckExtraObjective();
+	let extraObj = camCheckExtraObjective();
 	// check if game is lost
 	if (__camPlayerDead())
 	{
@@ -359,21 +359,21 @@ function __camVictoryTimeout()
 
 function __camVictoryOffworld()
 {
-	var lz = __camVictoryData.area;
+	let lz = __camVictoryData.area;
 	if (!camDef(lz))
 	{
 		camDebug("Landing zone area is required for OFFWORLD");
 		return;
 	}
-	var total = countDroid(DROID_ANY, CAM_HUMAN_PLAYER); // for future use
+	let total = countDroid(DROID_ANY, CAM_HUMAN_PLAYER); // for future use
 	if (total === 0)
 	{
 		__camGameLost();
 		return;
 	}
-	var forceLZ = camDef(__camVictoryData.retlz) ? __camVictoryData.retlz : false;
-	var destroyAll = camDef(__camVictoryData.annihilate) ? __camVictoryData.annihilate : false;
-	var elimBases = camDef(__camVictoryData.eliminateBases) ? __camVictoryData.eliminateBases : false;
+	let forceLZ = camDef(__camVictoryData.retlz) ? __camVictoryData.retlz : false;
+	let destroyAll = camDef(__camVictoryData.annihilate) ? __camVictoryData.annihilate : false;
+	let elimBases = camDef(__camVictoryData.eliminateBases) ? __camVictoryData.eliminateBases : false;
 
 	if (camCheckExtraObjective() && camAllArtifactsPickedUp())
 	{
@@ -381,7 +381,7 @@ function __camVictoryOffworld()
 		{
 			if (camAllEnemyBasesEliminated())
 			{
-				var enemyDroids = enumArea(0, 0, mapWidth, mapHeight, ENEMIES, false).filter((obj) => (
+				let enemyDroids = enumArea(0, 0, mapWidth, mapHeight, ENEMIES, false).filter((obj) => (
 					obj.type === DROID
 				)).length;
 
@@ -398,7 +398,7 @@ function __camVictoryOffworld()
 		}
 		else
 		{
-			var enemyLen = enumArea(0, 0, mapWidth, mapHeight, ENEMIES, false).length;
+			let enemyLen = enumArea(0, 0, mapWidth, mapHeight, ENEMIES, false).length;
 			if (!forceLZ && !enemyLen)
 			{
 				//if there are no more enemies, win instantly unless forced to go
@@ -416,7 +416,7 @@ function __camVictoryOffworld()
 			}
 
 			//Make sure to only count droids here.
-			var atlz = enumArea(lz, CAM_HUMAN_PLAYER, false).filter((obj) => (
+			let atlz = enumArea(lz, CAM_HUMAN_PLAYER, false).filter((obj) => (
 				obj.type === DROID && !camIsTransporter(obj)
 			)).length;
 			if (((!forceLZ && !destroyAll) || (forceLZ && destroyAll && !enemyLen) || (forceLZ && !destroyAll)) && (atlz === total))
@@ -443,7 +443,7 @@ function __camVictoryOffworld()
 				}
 				if (__camRTLZTicker % REMIND_RETURN === 0)
 				{
-					var pos = camMakePos(lz);
+					let pos = camMakePos(lz);
 					playSound("pcv427.ogg", pos.x, pos.y, 0);
 					console(_("Return to LZ"));
 				}
@@ -465,7 +465,7 @@ function __camVictoryOffworld()
 		}
 		if (__camLZCompromisedTicker % REMIND_COMPROMISED === 1)
 		{
-			var pos = camMakePos(lz);
+			let pos = camMakePos(lz);
 			playSound("pcv445.ogg", pos.x, pos.y, 0);
 		}
 		++__camLZCompromisedTicker;
@@ -477,7 +477,7 @@ function __camVictoryOffworld()
 	else if (__camLZCompromisedTicker > 0)
 	{
 		camTrace("LZ clear");
-		var pos = camMakePos(lz);
+		let pos = camMakePos(lz);
 		playSound("lz-clear.ogg", pos.x, pos.y, 0);
 		setReinforcementTime(__camVictoryData.reinforcements);
 		__camLZCompromisedTicker = 0;
@@ -536,8 +536,8 @@ function __camShowVictoryConditions()
 
 	const ANNIHILATE_MESSAGE = _("Destroy all enemy units and structures");
 
-	var unitsOnMap = 0;
-	var structuresOnMap = 0;
+	let unitsOnMap = 0;
+	let structuresOnMap = 0;
 
 	enumArea(0, 0, mapWidth, mapHeight, ENEMIES, false).forEach((obj) => {
 		if (obj.type === DROID)
@@ -588,7 +588,7 @@ function __camShowVictoryConditions()
 		{
 			for (let i = 0, len = __camExtraObjectiveMessage.length; i < len; ++i)
 			{
-				var mes = __camExtraObjectiveMessage[i];
+				let mes = __camExtraObjectiveMessage[i];
 				console(mes);
 			}
 		}

--- a/data/base/script/campaign/libcampaign_includes/victory.js
+++ b/data/base/script/campaign/libcampaign_includes/victory.js
@@ -132,10 +132,10 @@ function camCheckExtraObjective()
 	let extraObjMet = true;
 	if (camDef(__camVictoryData) && camDef(__camVictoryData.callback))
 	{
-		let result = __camGlobalContext()[__camVictoryData.callback]();
-		if (camDef(result))
+		const __RESULT = __camGlobalContext()[__camVictoryData.callback]();
+		if (camDef(__RESULT))
 		{
-			if (!result)
+			if (!__RESULT)
 			{
 				__camGameLost();
 				return;
@@ -218,11 +218,11 @@ function __camGameWon()
 function __camPlayerDead()
 {
 	let dead = true;
-	let haveFactories = enumStruct(CAM_HUMAN_PLAYER, FACTORY).filter((obj) => (
+	const __HAVE_FACTORIES = enumStruct(CAM_HUMAN_PLAYER, FACTORY).filter((obj) => (
 		obj.status === BUILT
 	)).length > 0;
 
-	if (haveFactories)
+	if (__HAVE_FACTORIES)
 	{
 		dead = false;
 	}
@@ -244,10 +244,10 @@ function __camPlayerDead()
 	}
 	else if (__camNextLevel === "CAM3A-D1")
 	{
-		const GAMMA_PLAYER = 1;
+		const __GAMMA_PLAYER = 1;
 
 		//Care about all units and not just trucks at the start of cam3-c.
-		if (allianceExistsBetween(GAMMA_PLAYER, NEXUS) && enumDroid(CAM_HUMAN_PLAYER).length > 0)
+		if (allianceExistsBetween(__GAMMA_PLAYER, CAM_NEXUS) && enumDroid(CAM_HUMAN_PLAYER).length > 0)
 		{
 			dead = false;
 		}
@@ -255,13 +255,13 @@ function __camPlayerDead()
 	else
 	{
 		//Check the transporter.
-		let transporter = enumDroid(CAM_HUMAN_PLAYER, DROID_SUPERTRANSPORTER);
+		const transporter = enumDroid(CAM_HUMAN_PLAYER, DROID_SUPERTRANSPORTER);
 		if (transporter.length > 0)
 		{
-			let cargoDroids = enumCargo(transporter[0]);
+			const cargoDroids = enumCargo(transporter[0]);
 			for (let i = 0, len = cargoDroids.length; i < len; ++i)
 			{
-				let virDroid = cargoDroids[i];
+				const virDroid = cargoDroids[i];
 				if (camDef(virDroid) && virDroid && virDroid.droidType === DROID_CONSTRUCT)
 				{
 					dead = false;
@@ -288,7 +288,7 @@ function __camPlayerDead()
 				droidCount += 1;
 			}
 		});
-		dead = droidCount <= 0 && !haveFactories;
+		dead = droidCount <= 0 && !__HAVE_FACTORIES;
 
 		//Finish Beta-end early if they have no units and factories on Easy/Normal.
 		if (dead && (difficulty <= MEDIUM) && (__camNextLevel === "CAM_3A"))
@@ -305,9 +305,8 @@ function __camTriggerLastAttack()
 {
 	if (!__camLastAttackTriggered)
 	{
-		let enemies = enumArea(0, 0, mapWidth, mapHeight, ENEMIES, false);
 		// Do not order systems (sensor/trucks/repairs) to attack stuff.
-		enemies = enemies.filter((obj) => (
+		const enemies = enumArea(0, 0, mapWidth, mapHeight, ENEMIES, false).filter((obj) => (
 			obj.type === DROID && !camIsTransporter(obj) && !camIsSystemDroid(obj)
 		));
 		camTrace(enemies.length, "enemy droids remaining");
@@ -318,7 +317,7 @@ function __camTriggerLastAttack()
 
 function __camVictoryStandard()
 {
-	let extraObj = camCheckExtraObjective();
+	const __EXTRA_OBJ = camCheckExtraObjective();
 	// check if game is lost
 	if (__camPlayerDead())
 	{
@@ -326,7 +325,7 @@ function __camVictoryStandard()
 		return;
 	}
 	// check if game is won
-	if (camAllArtifactsPickedUp() && camAllEnemyBasesEliminated() && extraObj)
+	if (camAllArtifactsPickedUp() && camAllEnemyBasesEliminated() && __EXTRA_OBJ)
 	{
 		if (enumArea(0, 0, mapWidth, mapHeight, ENEMIES, false).length === 0)
 		{
@@ -359,29 +358,29 @@ function __camVictoryTimeout()
 
 function __camVictoryOffworld()
 {
-	let lz = __camVictoryData.area;
+	const lz = __camVictoryData.area;
 	if (!camDef(lz))
 	{
 		camDebug("Landing zone area is required for OFFWORLD");
 		return;
 	}
-	let total = countDroid(DROID_ANY, CAM_HUMAN_PLAYER); // for future use
-	if (total === 0)
+	const __TOTAL = countDroid(DROID_ANY, CAM_HUMAN_PLAYER); // for future use
+	if (__TOTAL === 0)
 	{
 		__camGameLost();
 		return;
 	}
-	let forceLZ = camDef(__camVictoryData.retlz) ? __camVictoryData.retlz : false;
-	let destroyAll = camDef(__camVictoryData.annihilate) ? __camVictoryData.annihilate : false;
-	let elimBases = camDef(__camVictoryData.eliminateBases) ? __camVictoryData.eliminateBases : false;
+	const __FORCE_LZ = camDef(__camVictoryData.retlz) ? __camVictoryData.retlz : false;
+	const __DESTROY_ALL = camDef(__camVictoryData.annihilate) ? __camVictoryData.annihilate : false;
+	const __ELIM_BASES = camDef(__camVictoryData.eliminateBases) ? __camVictoryData.eliminateBases : false;
 
 	if (camCheckExtraObjective() && camAllArtifactsPickedUp())
 	{
-		if (elimBases)
+		if (__ELIM_BASES)
 		{
 			if (camAllEnemyBasesEliminated())
 			{
-				let enemyDroids = enumArea(0, 0, mapWidth, mapHeight, ENEMIES, false).filter((obj) => (
+				const enemyDroids = enumArea(0, 0, mapWidth, mapHeight, ENEMIES, false).filter((obj) => (
 					obj.type === DROID
 				)).length;
 
@@ -398,8 +397,8 @@ function __camVictoryOffworld()
 		}
 		else
 		{
-			let enemyLen = enumArea(0, 0, mapWidth, mapHeight, ENEMIES, false).length;
-			if (!forceLZ && !enemyLen)
+			const __ENEMY_LEN = enumArea(0, 0, mapWidth, mapHeight, ENEMIES, false).length;
+			if (!__FORCE_LZ && !__ENEMY_LEN)
 			{
 				//if there are no more enemies, win instantly unless forced to go
 				//back to the LZ.
@@ -408,18 +407,18 @@ function __camVictoryOffworld()
 			}
 
 			//Missions that are not won based on artifact count (see missions 2-1 and 3-2).
-			//If either forceLZ or destroyAll is true then ignore this.
-			if (__camNumArtifacts === 0 && !forceLZ && !destroyAll)
+			//If either __FORCE_LZ or __DESTROY_ALL is true then ignore this.
+			if (__camNumArtifacts === 0 && !__FORCE_LZ && !__DESTROY_ALL)
 			{
 				__camGameWon();
 				return;
 			}
 
 			//Make sure to only count droids here.
-			let atlz = enumArea(lz, CAM_HUMAN_PLAYER, false).filter((obj) => (
+			const __TOTAL_AT_LZ = enumArea(lz, CAM_HUMAN_PLAYER, false).filter((obj) => (
 				obj.type === DROID && !camIsTransporter(obj)
 			)).length;
-			if (((!forceLZ && !destroyAll) || (forceLZ && destroyAll && !enemyLen) || (forceLZ && !destroyAll)) && (atlz === total))
+			if (((!__FORCE_LZ && !__DESTROY_ALL) || (__FORCE_LZ && __DESTROY_ALL && !__ENEMY_LEN) || (__FORCE_LZ && !__DESTROY_ALL)) && (__TOTAL_AT_LZ === __TOTAL))
 			{
 				__camGameWon();
 				return;
@@ -429,9 +428,9 @@ function __camVictoryOffworld()
 				__camTriggerLastAttack();
 			}
 
-			if (!destroyAll || (forceLZ && !enemyLen))
+			if (!__DESTROY_ALL || (__FORCE_LZ && !__ENEMY_LEN))
 			{
-				const REMIND_RETURN = 30; // every X seconds
+				const __REMIND_RETURN = 30; // every X seconds
 				if (__camRTLZTicker === 0 && camDef(__camVictoryData.message))
 				{
 					camTrace("Return to LZ message displayed");
@@ -441,9 +440,9 @@ function __camVictoryOffworld()
 						hackAddMessage(__camVictoryData.message, PROX_MSG, CAM_HUMAN_PLAYER, false);
 					}
 				}
-				if (__camRTLZTicker % REMIND_RETURN === 0)
+				if (__camRTLZTicker % __REMIND_RETURN === 0)
 				{
-					let pos = camMakePos(lz);
+					const pos = camMakePos(lz);
 					playSound("pcv427.ogg", pos.x, pos.y, 0);
 					console(_("Return to LZ"));
 				}
@@ -453,7 +452,7 @@ function __camVictoryOffworld()
 	}
 	if (enumArea(lz, ENEMIES, false).length > 0)
 	{
-		const REMIND_COMPROMISED = 30; // every X seconds
+		const __REMIND_COMPROMISED = 30; // every X seconds
 		//Protect against early access to reinforcements GUI if it shouldn't be available yet
 		if (__camVictoryData.reinforcements >= 0)
 		{
@@ -463,9 +462,9 @@ function __camVictoryOffworld()
 		{
 			camTrace("LZ compromised");
 		}
-		if (__camLZCompromisedTicker % REMIND_COMPROMISED === 1)
+		if (__camLZCompromisedTicker % __REMIND_COMPROMISED === 1)
 		{
-			let pos = camMakePos(lz);
+			const pos = camMakePos(lz);
 			playSound("pcv445.ogg", pos.x, pos.y, 0);
 		}
 		++__camLZCompromisedTicker;
@@ -477,7 +476,7 @@ function __camVictoryOffworld()
 	else if (__camLZCompromisedTicker > 0)
 	{
 		camTrace("LZ clear");
-		let pos = camMakePos(lz);
+		const pos = camMakePos(lz);
 		playSound("lz-clear.ogg", pos.x, pos.y, 0);
 		setReinforcementTime(__camVictoryData.reinforcements);
 		__camLZCompromisedTicker = 0;
@@ -501,7 +500,7 @@ function __camSetupConsoleForVictoryConditions()
 
 function __camShowBetaHint()
 {
-	return ((camDiscoverCampaign() === BETA_CAMPAIGN_NUMBER) && (difficulty === HARD || difficulty === INSANE));
+	return ((camDiscoverCampaign() === __CAM_BETA_CAMPAIGN_NUMBER) && (difficulty === HARD || difficulty === INSANE));
 }
 
 function __camShowBetaHintEarly()
@@ -534,7 +533,7 @@ function __camShowVictoryConditions()
 		return; // do not need this on these missions.
 	}
 
-	const ANNIHILATE_MESSAGE = _("Destroy all enemy units and structures");
+	const __ANNIHILATE_MESSAGE = _("Destroy all enemy units and structures");
 
 	let unitsOnMap = 0;
 	let structuresOnMap = 0;
@@ -564,7 +563,7 @@ function __camShowVictoryConditions()
 
 		if (camDef(__camVictoryData.annihilate) && __camVictoryData.annihilate)
 		{
-			console(ANNIHILATE_MESSAGE);
+			console(__ANNIHILATE_MESSAGE);
 		}
 
 		if (camDef(__camVictoryData.eliminateBases) && __camVictoryData.eliminateBases)
@@ -578,7 +577,7 @@ function __camShowVictoryConditions()
 	}
 	else if (__camWinLossCallback === CAM_VICTORY_STANDARD)
 	{
-		console(ANNIHILATE_MESSAGE);
+		console(__ANNIHILATE_MESSAGE);
 	}
 
 	//More specific messages set through the mission scripts.
@@ -588,8 +587,8 @@ function __camShowVictoryConditions()
 		{
 			for (let i = 0, len = __camExtraObjectiveMessage.length; i < len; ++i)
 			{
-				let mes = __camExtraObjectiveMessage[i];
-				console(mes);
+				const __MES = __camExtraObjectiveMessage[i];
+				console(__MES);
 			}
 		}
 		else

--- a/data/base/script/campaign/libcampaign_includes/video.js
+++ b/data/base/script/campaign/libcampaign_includes/video.js
@@ -61,11 +61,11 @@ function __camEnqueueVideos()
 		return; //Nothing to play
 	}
 
-	const SOUND_IDENTIFER = ".ogg";
-	let what = __camVideoSequences[0];
+	const __SOUND_IDENTIFER = ".ogg";
+	const what = __camVideoSequences[0];
 
 	// Check if this is a sound to play before some sequence.
-	if (typeof what === "string" && what.indexOf(SOUND_IDENTIFER) !== -1)
+	if (typeof what === "string" && what.indexOf(__SOUND_IDENTIFER) !== -1)
 	{
 		playSound(what);
 		queue("__camEnqueueVideos", camSecondsToMilliseconds(3.2)); //more than enough for most sounds.

--- a/data/base/script/campaign/libcampaign_includes/video.js
+++ b/data/base/script/campaign/libcampaign_includes/video.js
@@ -62,7 +62,7 @@ function __camEnqueueVideos()
 	}
 
 	const SOUND_IDENTIFER = ".ogg";
-	var what = __camVideoSequences[0];
+	let what = __camVideoSequences[0];
 
 	// Check if this is a sound to play before some sequence.
 	if (typeof what === "string" && what.indexOf(SOUND_IDENTIFER) !== -1)
@@ -72,7 +72,7 @@ function __camEnqueueVideos()
 	}
 	else if (typeof what === "object")
 	{
-		var play = true;
+		let play = true;
 
 		if (!camDef(what.video) || !camIsString(what.video))
 		{

--- a/data/base/script/campaign/libcampaign_includes/vtol.js
+++ b/data/base/script/campaign/libcampaign_includes/vtol.js
@@ -177,8 +177,8 @@ function __camSpawnVtols()
 		}
 		else
 		{
-			var lim = amount;
-			var alternate = false;
+			let lim = amount;
+			let alternate = false;
 			if (camDef(__camVtolDataSystem[idx].extras.alternate))
 			{
 				alternate = __camVtolDataSystem[idx].extras.alternate; //Only use one template type

--- a/data/base/script/campaign/libcampaign_includes/vtol.js
+++ b/data/base/script/campaign/libcampaign_includes/vtol.js
@@ -149,8 +149,8 @@ function __camSpawnVtols()
 			}
 		}
 
-		let amount = minVtolAmount + camRand(maxRandomAdditions + 1);
-		let droids = [];
+		const __AMOUNT = minVtolAmount + camRand(maxRandomAdditions + 1);
+		const droids = [];
 		let pos;
 
 		//Make sure to catch multiple start positions also.
@@ -170,14 +170,14 @@ function __camSpawnVtols()
 		if (!camDef(__camVtolDataSystem[idx].extras))
 		{
 			//Pick some droids randomly.
-			for (let i = 0; i < amount; ++i)
+			for (let i = 0; i < __AMOUNT; ++i)
 			{
 				droids.push(__camVtolDataSystem[idx].templates[camRand(__camVtolDataSystem[idx].templates.length)]);
 			}
 		}
 		else
 		{
-			let lim = amount;
+			let lim = __AMOUNT;
 			let alternate = false;
 			if (camDef(__camVtolDataSystem[idx].extras.alternate))
 			{
@@ -238,16 +238,16 @@ function __camRetreatVtols()
 			camDef(__camVtolDataSystem[idx].exitPosition.y) &&
 			enumStruct(__camVtolDataSystem[idx].player, REARM_PAD).length === 0)
 		{
-			const VTOL_RETURN_HEALTH = 40; // run-away if health is less than...
-			const VTOL_RETURN_ARMED = 1; // run-away if weapon ammo is less than...
-			let vtols = enumDroid(__camVtolDataSystem[idx].player).filter((obj) => (isVTOL(obj)));
+			const __VTOL_RETURN_HEALTH = 40; // run-away if health is less than...
+			const __VTOL_RETURN_ARMED = 1; // run-away if weapon ammo is less than...
+			const vtols = enumDroid(__camVtolDataSystem[idx].player).filter((obj) => (isVTOL(obj)));
 
 			for (let i = 0, len = vtols.length; i < len; ++i)
 			{
-				let vt = vtols[i];
+				const vt = vtols[i];
 				for (let c = 0, len2 = vt.weapons.length; c < len2; ++c)
 				{
-					if ((vt.order === DORDER_RTB) || (vt.weapons[c].armed < VTOL_RETURN_ARMED) || (vt.health < VTOL_RETURN_HEALTH))
+					if ((vt.order === DORDER_RTB) || (vt.weapons[c].armed < __VTOL_RETURN_ARMED) || (vt.health < __VTOL_RETURN_HEALTH))
 					{
 						orderDroidLoc(vt, DORDER_MOVE, __camVtolDataSystem[idx].exitPosition.x, __camVtolDataSystem[idx].exitPosition.y);
 						break;

--- a/data/base/script/campaign/transitionTech.js
+++ b/data/base/script/campaign/transitionTech.js
@@ -1,7 +1,7 @@
 //Contains the campaign transition technology definitions.
 
 //This array should give a player all the research from Alpha.
-const ALPHA_RESEARCH_NEW = [
+const mis_alphaResearchNew = [
 	// 1
 	"R-Wpn-MG1Mk1", "R-Vehicle-Body01", "R-Sys-Spade1Mk1", "R-Vehicle-Prop-Wheels",
 	"R-Sys-MobileRepairTurret01", "R-Sys-Engineering01", "R-Wpn-Flamer01Mk1", "R-Wpn-Flamer-Damage01",
@@ -64,7 +64,7 @@ const ALPHA_RESEARCH_NEW = [
 ];
 
 //Basic base structures.
-const STRUCTS_ALPHA = [
+const mis_structsAlpha = [
 	"A0CommandCentre",
 	"A0PowerGenerator",
 	"A0ResourceExtractor",
@@ -73,13 +73,13 @@ const STRUCTS_ALPHA = [
 ];
 
 //BETA 2-A bonus research
-const PLAYER_RES_BETA = [
+const mis_playerResBeta = [
 	"R-Wpn-AAGun03",
 	"R-Defense-AASite-QuadMg1",
 ];
 
 //This array should give a player all the research from Beta.
-const BETA_RESEARCH_NEW = [
+const mis_betaResearchNew = [
 	// 1
 	"R-Sys-Engineering02", "R-Sys-Sensor-Upgrade01", "R-Wpn-AAGun-Damage03",
 	"R-Wpn-Cannon-Damage04", "R-Wpn-MG-ROF02", "R-Wpn-Rocket-Damage04",
@@ -138,9 +138,9 @@ const BETA_RESEARCH_NEW = [
 ];
 
 //This is used for giving allies in Gamma technology (3-b/3-2/3-c)
-const GAMMA_ALLY_RES = ALPHA_RESEARCH_NEW.concat(PLAYER_RES_BETA).concat(BETA_RESEARCH_NEW);
+const mis_gammaAllyRes = mis_alphaResearchNew.concat(mis_playerResBeta).concat(mis_betaResearchNew);
 
-const GAMMA_RESEARCH_NEW = [
+const mis_gammaResearchNew = [
 	// 1
 	"R-Wpn-Howitzer03-Rot", "R-Wpn-MG-Damage08", "R-Struc-Power-Upgrade02", "R-Sys-Engineering03",
 	"R-Wpn-Cannon-Damage07", "R-Wpn-AAGun-Damage04", "R-Defense-WallUpgrade07", "R-Defense-WallUpgrade08",

--- a/data/base/script/fastplay/fastdemo.js
+++ b/data/base/script/fastplay/fastdemo.js
@@ -137,8 +137,8 @@ function activateDefenders()
 function eventStartLevel()
 {
 	camSetStandardWinLossConditions(CAM_VICTORY_STANDARD, undefined);
-	var startpos = getObject("startPosition");
-	var lz = getObject("landingZone");
+	let startpos = getObject("startPosition");
+	let lz = getObject("landingZone");
 	centreView(startpos.x, startpos.y);
 	setNoGoArea(lz.x, lz.y, lz.x2, lz.y2, CAM_HUMAN_PLAYER);
 

--- a/data/base/script/fastplay/fastdemo.js
+++ b/data/base/script/fastplay/fastdemo.js
@@ -1,8 +1,6 @@
 include("script/campaign/libcampaign.js");
 include("script/campaign/templates.js");
 
-const SCAVENGER_PLAYER = 7;
-
 camAreaEvent("removeObjectiveBlip", function()
 {
 	hackRemoveMessage("FAST_OBJ1", PROX_MSG, CAM_HUMAN_PLAYER);
@@ -47,18 +45,18 @@ camAreaEvent("factory3TriggerInstant", function()
 
 function grantStartTech()
 {
-	const TECH = [
+	const tech = [
 		"R-Wpn-MG1Mk1","R-Vehicle-Body01", "R-Sys-Spade1Mk1", "R-Vehicle-Prop-Wheels"
 	];
-	const STRUCTS = [
+	const structs = [
 		"A0CommandCentre", "A0PowerGenerator", "A0ResourceExtractor",
 		"A0ResearchFacility", "A0LightFactory"
 	];
 
-	camCompleteRequiredResearch(TECH, CAM_HUMAN_PLAYER);
-	for (let i = 0, l = STRUCTS.length; i < l; ++i)
+	camCompleteRequiredResearch(tech, CAM_HUMAN_PLAYER);
+	for (let i = 0, l = structs.length; i < l; ++i)
 	{
-		enableStructure(STRUCTS[i], CAM_HUMAN_PLAYER);
+		enableStructure(structs[i], CAM_HUMAN_PLAYER);
 	}
 
 	enableResearch("R-Wpn-MG-Damage01", CAM_HUMAN_PLAYER);
@@ -137,9 +135,9 @@ function activateDefenders()
 function eventStartLevel()
 {
 	camSetStandardWinLossConditions(CAM_VICTORY_STANDARD, undefined);
-	let startpos = getObject("startPosition");
-	let lz = getObject("landingZone");
-	centreView(startpos.x, startpos.y);
+	const startPos = getObject("startPosition");
+	const lz = getObject("landingZone");
+	centreView(startPos.x, startPos.y);
 	setNoGoArea(lz.x, lz.y, lz.x2, lz.y2, CAM_HUMAN_PLAYER);
 
 	setReinforcementTime(-1);

--- a/data/base/script/rules.js
+++ b/data/base/script/rules.js
@@ -14,13 +14,13 @@ const TRANSFER_LIKE_EVENT = 2;
 function reticuleManufactureCheck()
 {
 	let structureComplete = false;
-	let facs = [FACTORY, CYBORG_FACTORY, VTOL_FACTORY,];
+	const facs = [FACTORY, CYBORG_FACTORY, VTOL_FACTORY,];
 
 	for (let i = 0, len = facs.length; i < len; ++i)
 	{
-		let facType = facs[i];
-		let offWorldFacs = enumStructOffWorld(selectedPlayer, facType);
-		let onMapFacs = enumStruct(selectedPlayer, facType);
+		const facType = facs[i];
+		const offWorldFacs = enumStructOffWorld(selectedPlayer, facType);
+		const onMapFacs = enumStruct(selectedPlayer, facType);
 
 		if (offWorldFacs !== null)
 		{
@@ -64,13 +64,13 @@ function reticuleManufactureCheck()
 function reticuleResearchCheck()
 {
 	let structureComplete = false;
-	let labs = [RESEARCH_LAB,];
+	const labs = [RESEARCH_LAB,];
 
 	for (let i = 0, len = labs.length; i < len; ++i)
 	{
-		let resType = labs[i];
-		let offWorldLabs = enumStructOffWorld(selectedPlayer, resType);
-		let onMapLabs = enumStruct(selectedPlayer, resType);
+		const resType = labs[i];
+		const offWorldLabs = enumStructOffWorld(selectedPlayer, resType);
+		const onMapLabs = enumStruct(selectedPlayer, resType);
 
 		if (offWorldLabs !== null)
 		{
@@ -126,13 +126,13 @@ function reticuleBuildCheck()
 function reticuleDesignCheck()
 {
 	let structureComplete = false;
-	let hqs = [HQ,];
+	const hqs = [HQ,];
 
 	for (let i = 0, len = hqs.length; i < len; ++i)
 	{
-		let hqType = hqs[i];
-		let offWorldHq = enumStructOffWorld(selectedPlayer, hqType);
-		let onMapHq = enumStruct(selectedPlayer, hqType);
+		const hqType = hqs[i];
+		const offWorldHq = enumStructOffWorld(selectedPlayer, hqType);
+		const onMapHq = enumStruct(selectedPlayer, hqType);
 
 		if (offWorldHq !== null)
 		{

--- a/data/base/script/rules.js
+++ b/data/base/script/rules.js
@@ -6,20 +6,21 @@ receiveAllEvents(true); //Needed to allow enemy research to apply to them
 include("script/weather.js");
 
 var mainReticule = false;
+var lastHitTime = 0;
 const CREATE_LIKE_EVENT = 0;
 const DESTROY_LIKE_EVENT = 1;
 const TRANSFER_LIKE_EVENT = 2;
 
 function reticuleManufactureCheck()
 {
-	var structureComplete = false;
-	var facs = [FACTORY, CYBORG_FACTORY, VTOL_FACTORY,];
+	let structureComplete = false;
+	let facs = [FACTORY, CYBORG_FACTORY, VTOL_FACTORY,];
 
 	for (let i = 0, len = facs.length; i < len; ++i)
 	{
-		var facType = facs[i];
-		var offWorldFacs = enumStructOffWorld(selectedPlayer, facType);
-		var onMapFacs = enumStruct(selectedPlayer, facType);
+		let facType = facs[i];
+		let offWorldFacs = enumStructOffWorld(selectedPlayer, facType);
+		let onMapFacs = enumStruct(selectedPlayer, facType);
 
 		if (offWorldFacs !== null)
 		{
@@ -62,14 +63,14 @@ function reticuleManufactureCheck()
 
 function reticuleResearchCheck()
 {
-	var structureComplete = false;
-	var labs = [RESEARCH_LAB,];
+	let structureComplete = false;
+	let labs = [RESEARCH_LAB,];
 
 	for (let i = 0, len = labs.length; i < len; ++i)
 	{
-		var resType = labs[i];
-		var offWorldLabs = enumStructOffWorld(selectedPlayer, resType);
-		var onMapLabs = enumStruct(selectedPlayer, resType);
+		let resType = labs[i];
+		let offWorldLabs = enumStructOffWorld(selectedPlayer, resType);
+		let onMapLabs = enumStruct(selectedPlayer, resType);
 
 		if (offWorldLabs !== null)
 		{
@@ -124,14 +125,14 @@ function reticuleBuildCheck()
 
 function reticuleDesignCheck()
 {
-	var structureComplete = false;
-	var hqs = [HQ,];
+	let structureComplete = false;
+	let hqs = [HQ,];
 
 	for (let i = 0, len = hqs.length; i < len; ++i)
 	{
-		var hqType = hqs[i];
-		var offWorldHq = enumStructOffWorld(selectedPlayer, hqType);
-		var onMapHq = enumStruct(selectedPlayer, hqType);
+		let hqType = hqs[i];
+		let offWorldHq = enumStructOffWorld(selectedPlayer, hqType);
+		let onMapHq = enumStruct(selectedPlayer, hqType);
 
 		if (offWorldHq !== null)
 		{
@@ -199,7 +200,7 @@ function setMainReticule()
 
 function reticuleUpdate(obj, eventType)
 {
-	var update_reticule = false;
+	let update_reticule = false;
 
 	if (eventType === TRANSFER_LIKE_EVENT)
 	{
@@ -306,8 +307,8 @@ function setLimits()
 
 function resetPower()
 {
-	var powerLimit = 999999;
-	var powerProductionRate = 100;
+	let powerLimit = 999999;
+	let powerProductionRate = 100;
 
 	// set income modifier/power storage for player 0 (human)
 	if (difficulty <= EASY)
@@ -423,7 +424,6 @@ function eventResearched(research, structure, player)
 	// NOTE: Research upgrades are handled by the C++ core game engine since 4.1.0
 }
 
-var lastHitTime = 0;
 function eventAttacked(victim, attacker)
 {
 	if ((victim.player === selectedPlayer) && (attacker.player !== selectedPlayer) && (gameTime > (lastHitTime + 5000)))

--- a/data/base/script/tutorial.js
+++ b/data/base/script/tutorial.js
@@ -285,10 +285,10 @@ function checkForPowGen()
 			increaseTutorialState();
 
 			//Get the truck that is building the generator and store its ID.
-			var trucks = enumDroid(CAM_HUMAN_PLAYER, DROID_CONSTRUCT);
+			let trucks = enumDroid(CAM_HUMAN_PLAYER, DROID_CONSTRUCT);
 			for (let i = 0, len = trucks.length; i < len; ++i)
 			{
-				var truck = trucks[i];
+				let truck = trucks[i];
 				if (truck.order === DORDER_BUILD)
 				{
 					firstTruckID = truck.id;
@@ -328,10 +328,10 @@ function checkHelpBuild()
 {
 	if (tutState === 6)
 	{
-		var objects = enumDroid(CAM_HUMAN_PLAYER);
+		let objects = enumDroid(CAM_HUMAN_PLAYER);
 		for (let i = 0, l = objects.length; i < l; ++i)
 		{
-			var obj = objects[i];
+			let obj = objects[i];
 			if (obj.type === DROID &&
 				obj.droidType === DROID_CONSTRUCT &&
 				(obj.order === DORDER_HELPBUILD || obj.order === DORDER_BUILD) &&
@@ -370,7 +370,7 @@ function addToConsole()
 {
 	if (consoleVar.length)
 	{
-		var tutPhase = consoleVar[0];
+		let tutPhase = consoleVar[0];
 		if (tutPhase.state <= tutState)
 		{
 			//Check if we need to wait
@@ -411,15 +411,15 @@ function addToConsole()
 
 function eventSelectionChanged(objects)
 {
-	var tut0 = tutState === 0 && consoleVar.length;
-	var tut5 = tutState === 5 && consoleVar.length;
+	let tut0 = tutState === 0 && consoleVar.length;
+	let tut5 = tutState === 5 && consoleVar.length;
 
 	if (tut0 || tut5)
 	{
 		//Check if they selected a truck.
 		for (let i = 0, l = objects.length; i < l; ++i)
 		{
-			var obj = objects[i];
+			let obj = objects[i];
 			if (obj.type === DROID && obj.droidType === DROID_CONSTRUCT)
 			{
 				if (tut0)
@@ -487,7 +487,7 @@ function eventStartLevel()
 	camSetStandardWinLossConditions(CAM_VICTORY_STANDARD, undefined, {
 		callback: "noWinningForYou"
 	});
-	var startpos = getObject("startPosition");
+	let startpos = getObject("startPosition");
 	tutState = 0;
 	didTheyHelpBuildGen = false;
 	firstTruckID = 0;

--- a/data/base/script/tutorial.js
+++ b/data/base/script/tutorial.js
@@ -8,13 +8,13 @@ var producedUnits;
 var firstTruckID;
 
 //Alias for button
-const CLOSE_BUTTON = 0;
-const PRODUCTION_BUTTON = 1;
-const RESEARCH_BUTTON = 2;
-const BUILD_BUTTON = 3;
-const DESIGN_BUTTON = 4;
-const INTEL_BUTTON = 5;
-const COMMAND_BUTTON = 6;
+const MIS_CLOSE_BUTTON = 0;
+const MIS_PRODUCTION_BUTTON = 1;
+const MIS_RESEARCH_BUTTON = 2;
+const MIS_BUILD_BUTTON = 3;
+const MIS_DESIGN_BUTTON = 4;
+const MIS_INTEL_BUTTON = 5;
+const MIS_COMMAND_BUTTON = 6;
 
 //consoleVar is an array of objects used to hold information about the following:
 //1. audio: What sound file to play.
@@ -87,11 +87,11 @@ function increaseTutorialState()
 
 function grantStartTech()
 {
-	const TECH = [
+	const tech = [
 		"R-Vehicle-Body01", "R-Vehicle-Prop-Wheels"
 	];
 
-	camCompleteRequiredResearch(TECH, CAM_HUMAN_PLAYER);
+	camCompleteRequiredResearch(tech, CAM_HUMAN_PLAYER);
 }
 
 function playFactoryViperBuildVideo()
@@ -116,7 +116,7 @@ function eventDroidBuilt(droid, structure)
 		if (producedUnits.truck === true && producedUnits.tank === true)
 		{
 			increaseTutorialState();
-			setReticuleButton(PRODUCTION_BUTTON, _("Manufacture - build factory first"), "", "");
+			setReticuleButton(MIS_PRODUCTION_BUTTON, _("Manufacture - build factory first"), "", "");
 		}
 	}
 }
@@ -126,10 +126,10 @@ function eventDeliveryPointMoved()
 	if (tutState === 23)
 	{
 		increaseTutorialState();
-		setReticuleButton(PRODUCTION_BUTTON, _("Manufacture (F1)"), "image_manufacture_up.png", "image_manufacture_down.png");
+		setReticuleButton(MIS_PRODUCTION_BUTTON, _("Manufacture (F1)"), "image_manufacture_up.png", "image_manufacture_down.png");
 		// Change: Allow player to produce the truck.
 		completeResearch("R-Sys-Spade1Mk1", CAM_HUMAN_PLAYER);
-		setReticuleFlash(PRODUCTION_BUTTON, true);
+		setReticuleFlash(MIS_PRODUCTION_BUTTON, true);
 	}
 }
 
@@ -138,23 +138,23 @@ function eventMenuManufacture()
 	if (tutState === 24)
 	{
 		increaseTutorialState();
-		setReticuleFlash(PRODUCTION_BUTTON, false);
+		setReticuleFlash(MIS_PRODUCTION_BUTTON, false);
 	}
 }
 
 //show the build button
 function enableBuild()
 {
-	setReticuleButton(BUILD_BUTTON, _("Build (F3)"), "image_build_up.png", "image_build_down.png");
-	setReticuleFlash(BUILD_BUTTON, true);
+	setReticuleButton(MIS_BUILD_BUTTON, _("Build (F3)"), "image_build_up.png", "image_build_down.png");
+	setReticuleFlash(MIS_BUILD_BUTTON, true);
 	enableStructure("A0PowerGenerator", CAM_HUMAN_PLAYER);
 }
 
 //show the research button
 function enableRes()
 {
-	setReticuleButton(RESEARCH_BUTTON, _("Research (F2)"), "image_research_up.png", "image_research_down.png");
-	setReticuleFlash(RESEARCH_BUTTON, true);
+	setReticuleButton(MIS_RESEARCH_BUTTON, _("Research (F2)"), "image_research_up.png", "image_research_down.png");
+	setReticuleFlash(MIS_RESEARCH_BUTTON, true);
 	enableStructure("A0ResearchFacility", CAM_HUMAN_PLAYER);
 }
 
@@ -164,17 +164,17 @@ function eventMenuBuild()
 	if (tutState === 2) //power generator
 	{
 		increaseTutorialState();
-		setReticuleFlash(BUILD_BUTTON, false);
+		setReticuleFlash(MIS_BUILD_BUTTON, false);
 	}
 	else if (tutState === 9) // research facility
 	{
 		increaseTutorialState();
-		setReticuleFlash(BUILD_BUTTON, false);
+		setReticuleFlash(MIS_BUILD_BUTTON, false);
 	}
 	else if (tutState === 20)
 	{
 		increaseTutorialState();
-		setReticuleFlash(BUILD_BUTTON, false);
+		setReticuleFlash(MIS_BUILD_BUTTON, false);
 	}
 }
 
@@ -184,7 +184,7 @@ function eventMenuResearch()
 	if (tutState === 12)
 	{
 		increaseTutorialState();
-		setReticuleFlash(RESEARCH_BUTTON, false);
+		setReticuleFlash(MIS_RESEARCH_BUTTON, false);
 	}
 }
 
@@ -211,8 +211,8 @@ function eventResearched(research)
 	if (tutState === 14)
 	{
 		increaseTutorialState();
-		setReticuleButton(DESIGN_BUTTON, _("Design (F4)"), "image_design_up.png", "image_design_down.png");
-		setReticuleFlash(DESIGN_BUTTON, true);
+		setReticuleButton(MIS_DESIGN_BUTTON, _("Design (F4)"), "image_design_up.png", "image_design_down.png");
+		setReticuleFlash(MIS_DESIGN_BUTTON, true);
 	}
 }
 
@@ -221,7 +221,7 @@ function eventMenuResearchSelected()
 	if (tutState === 13)
 	{
 		increaseTutorialState();
-		setReticuleButton(RESEARCH_BUTTON, _("Research - build research facility first"), "", "");
+		setReticuleButton(MIS_RESEARCH_BUTTON, _("Research - build research facility first"), "", "");
 	}
 }
 
@@ -230,7 +230,7 @@ function eventMenuDesign()
 	if (tutState === 15)
 	{
 		increaseTutorialState();
-		setReticuleFlash(DESIGN_BUTTON, false);
+		setReticuleFlash(MIS_DESIGN_BUTTON, false);
 	}
 }
 
@@ -255,8 +255,8 @@ function eventDesignWeapon()
 	if (tutState === 18)
 	{
 		increaseTutorialState();
-		setReticuleButton(CLOSE_BUTTON, _("Close"), "image_cancel_up.png", "image_cancel_down.png");
-		setReticuleFlash(CLOSE_BUTTON, true);
+		setReticuleButton(MIS_CLOSE_BUTTON, _("Close"), "image_cancel_up.png", "image_cancel_down.png");
+		setReticuleFlash(MIS_CLOSE_BUTTON, true);
 	}
 }
 
@@ -265,11 +265,11 @@ function eventDesignQuit()
 	if (tutState === 19)
 	{
 		increaseTutorialState();
-		setReticuleButton(DESIGN_BUTTON, _("Design - construct HQ first"), "", "");
+		setReticuleButton(MIS_DESIGN_BUTTON, _("Design - construct HQ first"), "", "");
 		enableStructure("A0LightFactory", CAM_HUMAN_PLAYER);
-		setReticuleFlash(CLOSE_BUTTON, false);
-		setReticuleButton(BUILD_BUTTON, _("Build (F3)"), "image_build_up.png", "image_build_down.png");
-		setReticuleFlash(BUILD_BUTTON, true);
+		setReticuleFlash(MIS_CLOSE_BUTTON, false);
+		setReticuleButton(MIS_BUILD_BUTTON, _("Build (F3)"), "image_build_up.png", "image_build_down.png");
+		setReticuleFlash(MIS_BUILD_BUTTON, true);
 		enableTemplate("ConstructionDroid");
 	}
 }
@@ -281,14 +281,14 @@ function checkForPowGen()
 	{
 		if (countStruct("A0PowerGenerator", CAM_HUMAN_PLAYER) > 0)
 		{
-			setReticuleButton(BUILD_BUTTON, _("Build - manufacture constructor droids first"), "", "");
+			setReticuleButton(MIS_BUILD_BUTTON, _("Build - manufacture constructor droids first"), "", "");
 			increaseTutorialState();
 
 			//Get the truck that is building the generator and store its ID.
-			let trucks = enumDroid(CAM_HUMAN_PLAYER, DROID_CONSTRUCT);
+			const trucks = enumDroid(CAM_HUMAN_PLAYER, DROID_CONSTRUCT);
 			for (let i = 0, len = trucks.length; i < len; ++i)
 			{
-				let truck = trucks[i];
+				const truck = trucks[i];
 				if (truck.order === DORDER_BUILD)
 				{
 					firstTruckID = truck.id;
@@ -314,7 +314,7 @@ function checkResFac()
 	{
 		if (countStruct("A0ResearchFacility", CAM_HUMAN_PLAYER) > 0)
 		{
-			setReticuleButton(BUILD_BUTTON, _("Build - manufacture constructor droids first"), "", "");
+			setReticuleButton(MIS_BUILD_BUTTON, _("Build - manufacture constructor droids first"), "", "");
 		}
 		else
 		{
@@ -328,10 +328,10 @@ function checkHelpBuild()
 {
 	if (tutState === 6)
 	{
-		let objects = enumDroid(CAM_HUMAN_PLAYER);
+		const objects = enumDroid(CAM_HUMAN_PLAYER);
 		for (let i = 0, l = objects.length; i < l; ++i)
 		{
-			let obj = objects[i];
+			const obj = objects[i];
 			if (obj.type === DROID &&
 				obj.droidType === DROID_CONSTRUCT &&
 				(obj.order === DORDER_HELPBUILD || obj.order === DORDER_BUILD) &&
@@ -358,8 +358,8 @@ function eventPickup(feature, droid)
 	if (tutState === 8)
 	{
 		increaseTutorialState();
-		setReticuleButton(BUILD_BUTTON, _("Build (F3)"), "image_build_up.png", "image_build_down.png");
-		setReticuleFlash(BUILD_BUTTON, true);
+		setReticuleButton(MIS_BUILD_BUTTON, _("Build (F3)"), "image_build_up.png", "image_build_down.png");
+		setReticuleFlash(MIS_BUILD_BUTTON, true);
 		enableStructure("A0ResearchFacility", CAM_HUMAN_PLAYER);
 	}
 }
@@ -370,7 +370,7 @@ function addToConsole()
 {
 	if (consoleVar.length)
 	{
-		let tutPhase = consoleVar[0];
+		const tutPhase = consoleVar[0];
 		if (tutPhase.state <= tutState)
 		{
 			//Check if we need to wait
@@ -411,15 +411,15 @@ function addToConsole()
 
 function eventSelectionChanged(objects)
 {
-	let tut0 = tutState === 0 && consoleVar.length;
-	let tut5 = tutState === 5 && consoleVar.length;
+	const tut0 = tutState === 0 && consoleVar.length;
+	const tut5 = tutState === 5 && consoleVar.length;
 
 	if (tut0 || tut5)
 	{
 		//Check if they selected a truck.
 		for (let i = 0, l = objects.length; i < l; ++i)
 		{
-			let obj = objects[i];
+			const obj = objects[i];
 			if (obj.type === DROID && obj.droidType === DROID_CONSTRUCT)
 			{
 				if (tut0)
@@ -469,7 +469,7 @@ function eventStructureBuilt(structure, droid)
 	else if (tutState === 22 && structure.stattype === FACTORY)
 	{
 		increaseTutorialState();
-		setReticuleButton(BUILD_BUTTON, _("Build - manufacture constructor droids first"), "", "");
+		setReticuleButton(MIS_BUILD_BUTTON, _("Build - manufacture constructor droids first"), "", "");
 	}
 }
 
@@ -487,7 +487,7 @@ function eventStartLevel()
 	camSetStandardWinLossConditions(CAM_VICTORY_STANDARD, undefined, {
 		callback: "noWinningForYou"
 	});
-	let startpos = getObject("startPosition");
+	const startPos = getObject("startPosition");
 	tutState = 0;
 	didTheyHelpBuildGen = false;
 	firstTruckID = 0;
@@ -497,7 +497,7 @@ function eventStartLevel()
 	};
 	setUpConsoleAndAudioVar();
 
-	centreView(startpos.x, startpos.y);
+	centreView(startPos.x, startPos.y);
 	setMissionTime(-1);
 	setPower(500, CAM_HUMAN_PLAYER);
 	hackStopIngameAudio();
@@ -515,13 +515,13 @@ function eventStartLevel()
 	setDesign(false);
 
 	showInterface(); // init buttons. This MUST come before setting the reticule button data
-	setReticuleButton(CLOSE_BUTTON, _("Close"), "", "");
-	setReticuleButton(PRODUCTION_BUTTON, _("Manufacture - build factory first"), "", "");
-	setReticuleButton(RESEARCH_BUTTON, _("Research - build research facility first"), "", "");
-	setReticuleButton(BUILD_BUTTON, _("Build - manufacture constructor droids first"), "", "");
-	setReticuleButton(DESIGN_BUTTON, _("Design - construct HQ first"), "", "");
-	setReticuleButton(INTEL_BUTTON, _("Intelligence Display (F5)"), "", "");
-	setReticuleButton(COMMAND_BUTTON, _("Commanders - manufacture commanders first"), "", "");
+	setReticuleButton(MIS_CLOSE_BUTTON, _("Close"), "", "");
+	setReticuleButton(MIS_PRODUCTION_BUTTON, _("Manufacture - build factory first"), "", "");
+	setReticuleButton(MIS_RESEARCH_BUTTON, _("Research - build research facility first"), "", "");
+	setReticuleButton(MIS_BUILD_BUTTON, _("Build - manufacture constructor droids first"), "", "");
+	setReticuleButton(MIS_DESIGN_BUTTON, _("Design - construct HQ first"), "", "");
+	setReticuleButton(MIS_INTEL_BUTTON, _("Intelligence Display (F5)"), "", "");
+	setReticuleButton(MIS_COMMAND_BUTTON, _("Commanders - manufacture commanders first"), "", "");
 
 	queue("addToConsole", camSecondsToMilliseconds(2));
 }


### PR DESCRIPTION
Might as well get this over with. This PR introduces a vast `var` to `let`/`const` conversion for the entire data/base structure. This work is primarily for preparing to support the packaged mod loading feature for ~4.5/4.6, and I don't want a double work load for any that take place before this.

So, what does this do?

1. All `var`s were first converted to let besides those in the global scope. vars are now completely isolated at the top level "root" of the scripts for the express purpose to clarify what will get saved for savegames.

2. `Let`s were then converted to `const` to further isolate away truly what gets re-assigned or not. While...

3. ALL `const`s were standardized to a new naming convention; Some were slightly renamed to clarify their purpose if necessary. Details can be found in the new comments lines in libcampaign.js.

The change isn't as scary as it looks. Everything was linted and reviewed line by line by me.
