### PR TITLE
Various small fixes

### DIFF
--- a/data/base/script/campaign/libcampaign_includes/events.js
+++ b/data/base/script/campaign/libcampaign_includes/events.js
@@ -163,6 +163,11 @@ function cam_eventDroidBuilt(droid, structure)
 	{
 		return;
 	}
+	if (camGetNexusState() && droid.player === CAM_NEXUS && __camNextLevel === "CAM3C" && camRand(100) < 7)
+	{
+		// Occasionally hint that NEXUS is producing units on Gamma 5.
+		playSound(CAM_PRODUCTION_COMPLETE_SND);
+	}
 	if (!camDef(__camFactoryInfo))
 	{
 		return;
@@ -364,7 +369,7 @@ function cam_eventGameLoaded()
 //Plays Nexus sounds if nexusActivated is true.
 function cam_eventObjectTransfer(obj, from)
 {
-	if (from === CAM_HUMAN_PLAYER && obj.player === CAM_NEXUS && __camNexusActivated === true)
+	if (camGetNexusState() && from === CAM_HUMAN_PLAYER && obj.player === CAM_NEXUS)
 	{
 		let snd;
 		if (obj.type === STRUCTURE)

--- a/data/base/script/campaign/libcampaign_includes/nexus.js
+++ b/data/base/script/campaign/libcampaign_includes/nexus.js
@@ -75,7 +75,7 @@ function camAbsorbPlayer(who, to)
 //;;
 function camHackIntoPlayer(player, to)
 {
-	if (__camNexusActivated === false)
+	if (!camGetNexusState())
 	{
 		return;
 	}

--- a/data/base/script/campaign/libcampaign_includes/truck.js
+++ b/data/base/script/campaign/libcampaign_includes/truck.js
@@ -52,9 +52,9 @@ function __camEnumFreeTrucks(player)
 	return droids;
 }
 
-function __camGetClosestTruck(player, pos)
+function __camGetClosestTruck(player, pos, list)
 {
-	const droids = __camEnumFreeTrucks(player);
+	const droids = (camDef(list) && list !== null) ? list : __camEnumFreeTrucks(player);
 	if (droids.length <= 0)
 	{
 		return undefined;
@@ -88,6 +88,7 @@ function __camTruckTick()
 	{
 		const ti = __camTruckInfo[playerObj];
 		const __PLAYER = ti.player;
+		let freeTrucks = __camEnumFreeTrucks(__PLAYER);
 		let truck;
 
 		// First, build things that were explicitly ordered.
@@ -101,7 +102,7 @@ function __camTruckTick()
 			if (camDef(pos))
 			{
 				// Find the truck most suitable for the job.
-				truck = __camGetClosestTruck(__PLAYER, pos);
+				truck = __camGetClosestTruck(__PLAYER, pos, freeTrucks);
 				if (!camDef(truck))
 				{
 					break;
@@ -110,12 +111,11 @@ function __camTruckTick()
 			else
 			{
 				// Build near any truck if pos was not specified.
-				const droids = __camEnumFreeTrucks(__PLAYER);
-				if (droids.length <= 0)
+				if (freeTrucks.length <= 0)
 				{
 					break;
 				}
-				truck = droids[0];
+				truck = freeTrucks[0];
 				pos = truck;
 				randx = (camRand(100) < 50) ? -camRand(2) : camRand(2);
 				randy = (camRand(100) < 50) ? -camRand(2) : camRand(2);
@@ -127,6 +127,7 @@ function __camTruckTick()
 			{
 				if (orderDroidBuild(truck, DORDER_BUILD, __QI.stat, loc.x + randx, loc.y + randy))
 				{
+					freeTrucks = freeTrucks.filter((tr) => (tr.id !== truck.id));
 					ti.queue.shift(); // consider it handled
 				}
 			}
@@ -139,7 +140,7 @@ function __camTruckTick()
 			continue;
 		}
 		const oil = oils[0];
-		truck = __camGetClosestTruck(__PLAYER, oil);
+		truck = __camGetClosestTruck(__PLAYER, oil, freeTrucks);
 		if (camDef(truck) && __PLAYER !== CAM_NEXUS)
 		{
 			enableStructure("A0ResourceExtractor", __PLAYER);

--- a/data/base/script/campaign/libcampaign_includes/vtol.js
+++ b/data/base/script/campaign/libcampaign_includes/vtol.js
@@ -68,7 +68,6 @@ function camSetVtolSpawnState(state, identifier)
 			if (__camVtolDataSystem[idx].spawnStopObject === identifier)
 			{
 				__camVtolDataSystem[idx].active = state;
-				break;
 			}
 		}
 	}

--- a/src/wzapi.cpp
+++ b/src/wzapi.cpp
@@ -2378,8 +2378,11 @@ bool wzapi::gameOverMessage(WZAPI_PARAMS(bool gameWon, optional<bool> _showBackD
 		if (gameWon && showOutro)
 		{
 			showBackDrop = false;
-			seq_AddSeqToList("outro.ogg", nullptr, "outro.txa", false);
-			seq_StartNextFullScreenVideo();
+			if (seq_hasVideos())
+			{
+				seq_AddSeqToList("outro.ogg", nullptr, "outro.txa", false);
+				seq_StartNextFullScreenVideo();
+			}
 		}
 		else
 		{


### PR DESCRIPTION
While doing the convert var to let/const work I discovered a few things:

1. camSetVtolSpawnState() wouldn't work entirely right when object labels were passed and it would exit early.
2. NEXUS originally didn't use too many sound effects on Gamma 5, so I added yet another unused one for production.
3. The outro would force a skip if sequences weren't installed (obviously don't attempt to play if none are installed).
4. Fallout from the ModeQueue patch rendered libcampaign truck building broken for those that required positions.