### PR TITLE
Support cmd interface with unix socket

### DIFF
--- a/src/clparse.cpp
+++ b/src/clparse.cpp
@@ -44,6 +44,7 @@
 #include "wrappers.h"
 #include "multilobbycommands.h"
 #include "gamehistorylogger.h"
+#include "stdinreader.h"
 
 #include <cwchar>
 
@@ -88,7 +89,6 @@ static bool wz_autoratingEnable = false;
 static bool wz_cli_headless = false;
 static bool wz_streamer_spectator_mode = false;
 static bool wz_lobby_slashcommands = false;
-static WZ_Command_Interface wz_cmd_interface = WZ_Command_Interface::None;
 static int wz_min_autostart_players = -1;
 
 #if defined(WZ_OS_WIN)
@@ -433,7 +433,7 @@ static const struct poptOption *getOptionsTable()
 		{ "enablelobbyslashcmd", POPT_ARG_NONE, CLI_LOBBY_SLASHCOMMANDS, N_("Enable lobby slash commands (for connecting clients)"), nullptr},
 		{ "addlobbyadminhash", POPT_ARG_STRING, CLI_ADD_LOBBY_ADMINHASH, N_("Add a lobby admin identity hash (for slash commands)"), _("hash string")},
 		{ "addlobbyadminpublickey", POPT_ARG_STRING, CLI_ADD_LOBBY_ADMINPUBLICKEY, N_("Add a lobby admin public key (for slash commands)"), N_("b64-pub-key")},
-		{ "enablecmdinterface", POPT_ARG_STRING, CLI_COMMAND_INTERFACE, N_("Enable command interface"), N_("(stdin)")},
+		{ "enablecmdinterface", POPT_ARG_STRING, CLI_COMMAND_INTERFACE, N_("Enable command interface"), N_("(stdin, unixsocket:path)")},
 		{ "startplayers", POPT_ARG_STRING, CLI_STARTPLAYERS, N_("Minimum required players to auto-start game"), N_("startplayers")},
 		{ "gamelog-output", POPT_ARG_STRING, CLI_GAMELOG_OUTPUTMODES, N_("Game history log output mode(s)"), "(log,cmdinterface)"},
 		{ "gamelog-outputkey", POPT_ARG_STRING, CLI_GAMELOG_OUTPUTKEY, N_("Game history log output key"), "[playerindex, playerposition]"},
@@ -1015,20 +1015,42 @@ bool ParseCommandLine(int argc, const char * const *argv)
 			break;
 
 		case CLI_COMMAND_INTERFACE:
-			token = poptGetOptArg(poptCon);
-			if (token == nullptr || strlen(token) == 0)
 			{
-				// use default, which is currently "stdin"
-				token = "stdin";
-			}
-			if (strcmp(token, "stdin") == 0)
-			{
-				// enable stdin
-				wz_cmd_interface = WZ_Command_Interface::StdIn_Interface;
-			}
-			else
-			{
-				qFatal("Unsupported / invalid enablecmdinterface value");
+				token = poptGetOptArg(poptCon);
+				if (token == nullptr || strlen(token) == 0)
+				{
+					// use default, which is currently "stdin"
+					token = "stdin";
+				}
+				WZ_Command_Interface mode = WZ_Command_Interface::None;
+				std::string value;
+				if (strcmp(token, "stdin") == 0)
+				{
+					mode = WZ_Command_Interface::StdIn_Interface;
+				}
+				else if (strncmp(token, "unixsocket", strlen("unixsocket")) == 0)
+				{
+					mode = WZ_Command_Interface::Unix_Socket;
+					// expected form is "unixsocket:path" - parse for the path
+					if (strlen(token) > strlen("unixsocket"))
+					{
+						size_t delimeterIdx = strlen("unixsocket");
+						if (token[delimeterIdx] == ':' && token[delimeterIdx+1] != '\0')
+						{
+							// grab the rest of the string as the path value
+							value = &token[delimeterIdx+1];
+						}
+						else
+						{
+							qFatal("Invalid enablecmdinterface unixsocket value (expecting unixsocket:path)");
+						}
+					}
+				}
+				else
+				{
+					qFatal("Unsupported / invalid enablecmdinterface value");
+				}
+				configSetCmdInterface(mode, value);
 			}
 			break;
 		case CLI_STARTPLAYERS:
@@ -1199,11 +1221,6 @@ bool streamer_spectator_mode()
 bool lobby_slashcommands_enabled()
 {
 	return wz_lobby_slashcommands;
-}
-
-WZ_Command_Interface wz_command_interface()
-{
-	return wz_cmd_interface;
 }
 
 int min_autostart_player_count()

--- a/src/clparse.h
+++ b/src/clparse.h
@@ -39,13 +39,6 @@ bool getAutoratingEnable();
 bool streamer_spectator_mode();
 bool lobby_slashcommands_enabled();
 
-enum class WZ_Command_Interface
-{
-	None,
-	StdIn_Interface,
-};
-WZ_Command_Interface wz_command_interface();
-
 int min_autostart_player_count();
 
 #endif // __INCLUDED_SRC_CLPARSE_H__

--- a/src/gamehistorylogger.cpp
+++ b/src/gamehistorylogger.cpp
@@ -367,7 +367,7 @@ void GameStoryLogger::logGameFrame()
 		// output frame
 		auto reportJSON = genFrameReport(gameFrames.back(), outputKey, outputNaming);
 		std::string reportJSONStr = std::string("__REPORT__") + reportJSON.dump(-1, ' ', false, nlohmann::ordered_json::error_handler_t::replace) + "__ENDREPORT__";
-		outputLine(reportJSONStr);
+		outputLine(std::move(reportJSONStr));
 	}
 }
 
@@ -402,7 +402,7 @@ void GameStoryLogger::logDebugModeChange(bool enabled)
 	if (outputModes.anyEnabled())
 	{
 		std::string reportJSONStr = std::string("__DEBUGMODE__") + ((enabled) ? "true" : "false") + "__ENDDEBUGMODE__";
-		outputLine(reportJSONStr);
+		outputLine(std::move(reportJSONStr));
 	}
 }
 
@@ -421,7 +421,7 @@ void GameStoryLogger::logGameOver()
 		bool hitTimeout = (game.gameTimeLimitMinutes > 0) ? (gameTime >= (game.gameTimeLimitMinutes * 60 * 1000)) : false;
 		auto reportJSON = genEndOfGameReport(outputKey, outputNaming, hitTimeout);
 		std::string reportJSONStr = std::string("__REPORTextended__") + reportJSON.dump(-1, ' ', false, nlohmann::ordered_json::error_handler_t::replace) + "__ENDREPORTextended__";
-		outputLine(reportJSONStr);
+		outputLine(std::move(reportJSONStr));
 	}
 
 	if (fileHandle)
@@ -643,11 +643,12 @@ inline void from_json(const nlohmann::json& j, GameStoryLogger::DebugModeEvent& 
 	p.gameTime = j.at("gameTime").get<uint32_t>();
 }
 
-void GameStoryLogger::outputLine(const std::string &line)
+void GameStoryLogger::outputLine(std::string &&line)
 {
+	line.append("\n");
 	if (outputModes.cmdInterface)
 	{
-		wz_command_interface_output("%s\n", line.c_str());
+		wz_command_interface_output_str(line.c_str());
 	}
 	if (outputModes.logFile)
 	{
@@ -655,15 +656,8 @@ void GameStoryLogger::outputLine(const std::string &line)
 		{
 			if (WZ_PHYSFS_writeBytes(fileHandle, line.c_str(), line.size()) != line.size())
 			{
-				// Failed to write data to file
+				// Failed to write line to file
 				debug(LOG_ERROR, "Could not write to output file; PHYSFS error: %s", WZ_PHYSFS_getLastError());
-				PHYSFS_close(fileHandle);
-				fileHandle = nullptr;
-			}
-			if (WZ_PHYSFS_writeBytes(fileHandle, "\n", 1) != 1)
-			{
-				// Failed to write newline to file
-				debug(LOG_ERROR, "Could not write newline to output file; PHYSFS error: %s", WZ_PHYSFS_getLastError());
 				PHYSFS_close(fileHandle);
 				fileHandle = nullptr;
 			}

--- a/src/gamehistorylogger.h
+++ b/src/gamehistorylogger.h
@@ -150,7 +150,7 @@ private:
 	nlohmann::json genEndOfGameReport(OutputKey key, OutputNaming naming, bool timeout) const;
 	std::string getLogOutputFilename() const;
 
-	void outputLine(const std::string& line);
+	void outputLine(std::string&& line);
 
 private:
 	OutputModes outputModes;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1685,19 +1685,15 @@ static bool initializeCrashHandlingContext(optional<video_backend> gfxbackend)
 
 static void wzCmdInterfaceInit()
 {
-	switch (wz_command_interface())
+	if (wz_command_interface_enabled())
 	{
-		case WZ_Command_Interface::None:
-			return;
-		case WZ_Command_Interface::StdIn_Interface:
-			stdInThreadInit();
-			break;
+		cmdInterfaceThreadInit();
 	}
 }
 
 static void wzCmdInterfaceShutdown()
 {
-	stdInThreadShutdown();
+	cmdInterfaceThreadShutdown();
 }
 
 static void cleanupOldLogFiles()

--- a/src/stdinreader.cpp
+++ b/src/stdinreader.cpp
@@ -423,19 +423,16 @@ int cmdOutputThreadFunc(void *)
 		bool successfullyWroteMsg = false;
 		do {
 			// Wait to be ready to write
-			auto result = cmdIOIsReady(nullopt, writeFd, quitSignalFd);
+			auto result = cmdIOIsReady(nullopt, writeFd, -1); // do not wait on the quit signal fd here - all messages must be sent!
 			if (result == CmdIOReadyStatus::Exit)
 			{
-				// quit thread
-				return 0;
+				// ignore, and retry
+				continue;
 			}
 			else if (result == CmdIOReadyStatus::NotReady)
 			{
-				if (cmdOutputThreadQuit.load())
-				{
-					// quit thread
-					return 0;
-				}
+				// retry
+				continue;
 			}
 			else if (result == CmdIOReadyStatus::ReadyWrite)
 			{

--- a/src/stdinreader.cpp
+++ b/src/stdinreader.cpp
@@ -829,7 +829,7 @@ static void sockBlockSIGPIPE(const int fd, bool block_sigpipe)
 
 	if (setsockopt(fd, SOL_SOCKET, SO_NOSIGPIPE, &no_sigpipe, sizeof(no_sigpipe)) != 0)
 	{
-		errlog("WZCMD INFO: Failed to set SO_NOSIGPIPE on socket, SIGPIPE might be raised when connection gets broken.");
+		errlog("WZCMD INFO: Failed to set SO_NOSIGPIPE on socket, SIGPIPE might be raised when connection gets broken.\n");
 	}
 #else
 	// Prevent warnings
@@ -1151,7 +1151,7 @@ void wz_command_interface_output(const char *str, ...)
 		if (ret < 0)
 		{
 			// some ancient implementations of vsnprintf return -1 instead of the needed buffer length...
-			errlog("WZCMD ERROR: Failed to output truncated string - check vsnprintf implementation");
+			errlog("WZCMD ERROR: Failed to output truncated string - check vsnprintf implementation\n");
 			return;
 		}
 		size_t neededBufferSize = static_cast<size_t>(ret);
@@ -1161,7 +1161,7 @@ void wz_command_interface_output(const char *str, ...)
 		va_end(ap);
 		if (ret < 0 || ret >= neededBufferSize + 1)
 		{
-			errlog("WZCMD ERROR: Failed to output truncated string");
+			errlog("WZCMD ERROR: Failed to output truncated string\n");
 			free(tmpBuffer);
 			return;
 		}

--- a/src/stdinreader.h
+++ b/src/stdinreader.h
@@ -43,3 +43,5 @@ void wz_command_interface_output(const char *str, ...) WZ_DECL_FORMAT(__MINGW_PR
 #else
 void wz_command_interface_output(const char *str, ...) WZ_DECL_FORMAT(printf, 1, 2);
 #endif
+
+void wz_command_interface_output_str(const char *str);

--- a/src/stdinreader.h
+++ b/src/stdinreader.h
@@ -19,10 +19,21 @@
 
 #pragma once
 
-void stdInThreadInit();
-void stdInThreadShutdown();
-
+#include <string>
 #include "lib/framework/wzglobal.h"
+
+enum class WZ_Command_Interface
+{
+	None,
+	StdIn_Interface,
+	Unix_Socket,
+};
+
+// used from clparse:
+void configSetCmdInterface(WZ_Command_Interface mode, std::string value);
+
+void cmdInterfaceThreadInit();
+void cmdInterfaceThreadShutdown();
 
 bool wz_command_interface_enabled();
 


### PR DESCRIPTION
Use command-line option:
`--enablecmdinterface=unixsocket:path`
to specify a path for the sock file.

Or:
`--enablecmdinterface=unixsocket`
to have WZ use a `wz2100.cmd.sock` file in the current working directory