### PR TITLE
Split iIMDShape, separate game state data from display data, + initial graphics overrides support

### DIFF
--- a/.github/workflows/CI_alpine.yml
+++ b/.github/workflows/CI_alpine.yml
@@ -27,6 +27,9 @@ jobs:
     name: '${{ matrix.name }}'
     permissions:
       contents: read
+    env:
+      # Since this workflow doesn't build any artifacts for distribution, set WZ_CI_DISABLE_BASIS_COMPRESS_TEXTURES to speed up the job
+      WZ_CI_DISABLE_BASIS_COMPRESS_TEXTURES: ON
     runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, '[ci skip]')"
     steps:
@@ -54,7 +57,7 @@ jobs:
         CXX: ${{ matrix.cxx }}
       run: |
         echo "::add-matcher::${GITHUB_WORKSPACE}/src/.ci/githubactions/pattern_matchers/cmake.json"
-        docker run --rm -w "${GITHUB_WORKSPACE}/build" -e CC -e CXX -e "CI=true" -e GITHUB_WORKFLOW -e GITHUB_ACTIONS -e GITHUB_REPOSITORY -e GITHUB_WORKSPACE -e GITHUB_SHA -e GITHUB_REF -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e MAKEFLAGS -v "${GITHUB_WORKSPACE}:${GITHUB_WORKSPACE}" alpine cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DWZ_ENABLE_WARNINGS:BOOL=OFF -DWZ_FINDSDL2_NOCONFIG:BOOL=ON "${{ github.workspace }}/src"
+        docker run --rm -w "${GITHUB_WORKSPACE}/build" -e WZ_CI_DISABLE_BASIS_COMPRESS_TEXTURES -e CC -e CXX -e "CI=true" -e GITHUB_WORKFLOW -e GITHUB_ACTIONS -e GITHUB_REPOSITORY -e GITHUB_WORKSPACE -e GITHUB_SHA -e GITHUB_REF -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e MAKEFLAGS -v "${GITHUB_WORKSPACE}:${GITHUB_WORKSPACE}" alpine cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DWZ_ENABLE_WARNINGS:BOOL=OFF -DWZ_FINDSDL2_NOCONFIG:BOOL=ON "${{ github.workspace }}/src"
         echo "::remove-matcher owner=cmake::"
     - name: CMake Build
       working-directory: '${{ github.workspace }}/build'
@@ -68,7 +71,7 @@ jobs:
         else
           echo "::add-matcher::${GITHUB_WORKSPACE}/src/.ci/githubactions/pattern_matchers/gcc.json"
         fi
-        docker run --rm -w "${GITHUB_WORKSPACE}/build" -e CC -e CXX -e "CI=true" -e GITHUB_WORKFLOW -e GITHUB_ACTIONS -e GITHUB_REPOSITORY -e GITHUB_WORKSPACE -e GITHUB_SHA -e GITHUB_REF -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e MAKEFLAGS -v "${GITHUB_WORKSPACE}:${GITHUB_WORKSPACE}" alpine cmake --build .
+        docker run --rm -w "${GITHUB_WORKSPACE}/build" -e WZ_CI_DISABLE_BASIS_COMPRESS_TEXTURES -e CC -e CXX -e "CI=true" -e GITHUB_WORKFLOW -e GITHUB_ACTIONS -e GITHUB_REPOSITORY -e GITHUB_WORKSPACE -e GITHUB_SHA -e GITHUB_REF -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e MAKEFLAGS -v "${GITHUB_WORKSPACE}:${GITHUB_WORKSPACE}" alpine cmake --build .
         if [ "$WZ_COMPILER" == "clang" ]; then
           echo "::remove-matcher owner=clang::"
         else

--- a/.github/workflows/CI_archlinux.yml
+++ b/.github/workflows/CI_archlinux.yml
@@ -31,6 +31,9 @@ jobs:
     name: '${{ matrix.name }}'
     permissions:
       contents: read
+    env:
+      # Since this workflow doesn't build any artifacts for distribution, set WZ_CI_DISABLE_BASIS_COMPRESS_TEXTURES to speed up the job
+      WZ_CI_DISABLE_BASIS_COMPRESS_TEXTURES: ON
     runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, '[ci skip]')"
     steps:
@@ -58,7 +61,7 @@ jobs:
         CXX: ${{ matrix.cxx }}
       run: |
         echo "::add-matcher::${GITHUB_WORKSPACE}/src/.ci/githubactions/pattern_matchers/cmake.json"
-        docker run --rm -w "${GITHUB_WORKSPACE}/build" -e CC -e CXX -e "CI=true" -e GITHUB_WORKFLOW -e GITHUB_ACTIONS -e GITHUB_REPOSITORY -e GITHUB_WORKSPACE -e GITHUB_SHA -e GITHUB_REF -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e MAKEFLAGS -v "${GITHUB_WORKSPACE}:${GITHUB_WORKSPACE}" archlinux cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DWZ_ENABLE_WARNINGS:BOOL=ON -G"Ninja" "${{ github.workspace }}/src"
+        docker run --rm -w "${GITHUB_WORKSPACE}/build" -e WZ_CI_DISABLE_BASIS_COMPRESS_TEXTURES -e CC -e CXX -e "CI=true" -e GITHUB_WORKFLOW -e GITHUB_ACTIONS -e GITHUB_REPOSITORY -e GITHUB_WORKSPACE -e GITHUB_SHA -e GITHUB_REF -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e MAKEFLAGS -v "${GITHUB_WORKSPACE}:${GITHUB_WORKSPACE}" archlinux cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DWZ_ENABLE_WARNINGS:BOOL=ON -G"Ninja" "${{ github.workspace }}/src"
         echo "::remove-matcher owner=cmake::"
     - name: CMake Build
       working-directory: '${{ github.workspace }}/build'
@@ -71,7 +74,7 @@ jobs:
         else
           echo "::add-matcher::${GITHUB_WORKSPACE}/src/.ci/githubactions/pattern_matchers/gcc.json"
         fi
-        docker run --rm -w "${GITHUB_WORKSPACE}/build" -e CC -e CXX -e "CI=true" -e GITHUB_WORKFLOW -e GITHUB_ACTIONS -e GITHUB_REPOSITORY -e GITHUB_WORKSPACE -e GITHUB_SHA -e GITHUB_REF -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e MAKEFLAGS -v "${GITHUB_WORKSPACE}:${GITHUB_WORKSPACE}" archlinux cmake --build .
+        docker run --rm -w "${GITHUB_WORKSPACE}/build" -e WZ_CI_DISABLE_BASIS_COMPRESS_TEXTURES -e CC -e CXX -e "CI=true" -e GITHUB_WORKFLOW -e GITHUB_ACTIONS -e GITHUB_REPOSITORY -e GITHUB_WORKSPACE -e GITHUB_SHA -e GITHUB_REF -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e MAKEFLAGS -v "${GITHUB_WORKSPACE}:${GITHUB_WORKSPACE}" archlinux cmake --build .
         if [ "$WZ_COMPILER" == "clang" ]; then
           echo "::remove-matcher owner=clang::"
         else

--- a/.github/workflows/CI_fedora.yml
+++ b/.github/workflows/CI_fedora.yml
@@ -19,6 +19,9 @@ jobs:
     name: Fedora :LATEST [GCC]
     permissions:
       contents: read
+    env:
+      # Since this workflow doesn't build any artifacts for distribution, set WZ_CI_DISABLE_BASIS_COMPRESS_TEXTURES to speed up the job
+      WZ_CI_DISABLE_BASIS_COMPRESS_TEXTURES: ON
     runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, '[ci skip]')"
     steps:
@@ -43,13 +46,13 @@ jobs:
       working-directory: '${{ github.workspace }}/build'
       run: |
         echo "::add-matcher::${GITHUB_WORKSPACE}/src/.ci/githubactions/pattern_matchers/cmake.json"
-        docker run --rm -w "${GITHUB_WORKSPACE}/build" -e "CI=true" -e GITHUB_WORKFLOW -e GITHUB_ACTIONS -e GITHUB_REPOSITORY -e GITHUB_WORKSPACE -e GITHUB_SHA -e GITHUB_REF -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e MAKEFLAGS -v "${GITHUB_WORKSPACE}:${GITHUB_WORKSPACE}" fedora cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DWZ_ENABLE_WARNINGS:BOOL=ON -G"Ninja" "${{ github.workspace }}/src"
+        docker run --rm -w "${GITHUB_WORKSPACE}/build" -e WZ_CI_DISABLE_BASIS_COMPRESS_TEXTURES -e "CI=true" -e GITHUB_WORKFLOW -e GITHUB_ACTIONS -e GITHUB_REPOSITORY -e GITHUB_WORKSPACE -e GITHUB_SHA -e GITHUB_REF -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e MAKEFLAGS -v "${GITHUB_WORKSPACE}:${GITHUB_WORKSPACE}" fedora cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DWZ_ENABLE_WARNINGS:BOOL=ON -G"Ninja" "${{ github.workspace }}/src"
         echo "::remove-matcher owner=cmake::"
     - name: CMake Build
       working-directory: '${{ github.workspace }}/build'
       run: |
         echo "::add-matcher::${GITHUB_WORKSPACE}/src/.ci/githubactions/pattern_matchers/gcc.json"
-        docker run --rm -w "${GITHUB_WORKSPACE}/build" -e "CI=true" -e GITHUB_WORKFLOW -e GITHUB_ACTIONS -e GITHUB_REPOSITORY -e GITHUB_WORKSPACE -e GITHUB_SHA -e GITHUB_REF -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e MAKEFLAGS -v "${GITHUB_WORKSPACE}:${GITHUB_WORKSPACE}" fedora cmake --build .
+        docker run --rm -w "${GITHUB_WORKSPACE}/build" -e WZ_CI_DISABLE_BASIS_COMPRESS_TEXTURES -e "CI=true" -e GITHUB_WORKFLOW -e GITHUB_ACTIONS -e GITHUB_REPOSITORY -e GITHUB_WORKSPACE -e GITHUB_SHA -e GITHUB_REF -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e MAKEFLAGS -v "${GITHUB_WORKSPACE}:${GITHUB_WORKSPACE}" fedora cmake --build .
         echo "::remove-matcher owner=gcc::"
 
   fedora-latest-gcc-m32:
@@ -80,11 +83,11 @@ jobs:
       working-directory: '${{ github.workspace }}/build'
       run: |
         echo "::add-matcher::${GITHUB_WORKSPACE}/src/.ci/githubactions/pattern_matchers/cmake.json"
-        docker run --rm -w "${GITHUB_WORKSPACE}/build" -e "CI=true" -e GITHUB_WORKFLOW -e GITHUB_ACTIONS -e GITHUB_REPOSITORY -e GITHUB_WORKSPACE -e GITHUB_SHA -e GITHUB_REF -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e MAKEFLAGS -v "${GITHUB_WORKSPACE}:${GITHUB_WORKSPACE}" fedora cmake -DCMAKE_TOOLCHAIN_FILE=.ci/cmake/Toolchain-Linux-cross-m32.cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DWZ_ENABLE_WARNINGS:BOOL=ON -G"Ninja" "${{ github.workspace }}/src"
+        docker run --rm -w "${GITHUB_WORKSPACE}/build" -e WZ_CI_DISABLE_BASIS_COMPRESS_TEXTURES -e "CI=true" -e GITHUB_WORKFLOW -e GITHUB_ACTIONS -e GITHUB_REPOSITORY -e GITHUB_WORKSPACE -e GITHUB_SHA -e GITHUB_REF -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e MAKEFLAGS -v "${GITHUB_WORKSPACE}:${GITHUB_WORKSPACE}" fedora cmake -DCMAKE_TOOLCHAIN_FILE=.ci/cmake/Toolchain-Linux-cross-m32.cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DWZ_ENABLE_WARNINGS:BOOL=ON -G"Ninja" "${{ github.workspace }}/src"
         echo "::remove-matcher owner=cmake::"
     - name: CMake Build
       working-directory: '${{ github.workspace }}/build'
       run: |
         echo "::add-matcher::${GITHUB_WORKSPACE}/src/.ci/githubactions/pattern_matchers/gcc.json"
-        docker run --rm -w "${GITHUB_WORKSPACE}/build" -e "CI=true" -e GITHUB_WORKFLOW -e GITHUB_ACTIONS -e GITHUB_REPOSITORY -e GITHUB_WORKSPACE -e GITHUB_SHA -e GITHUB_REF -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e MAKEFLAGS -v "${GITHUB_WORKSPACE}:${GITHUB_WORKSPACE}" fedora cmake --build .
+        docker run --rm -w "${GITHUB_WORKSPACE}/build" -e WZ_CI_DISABLE_BASIS_COMPRESS_TEXTURES -e "CI=true" -e GITHUB_WORKFLOW -e GITHUB_ACTIONS -e GITHUB_REPOSITORY -e GITHUB_WORKSPACE -e GITHUB_SHA -e GITHUB_REF -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e MAKEFLAGS -v "${GITHUB_WORKSPACE}:${GITHUB_WORKSPACE}" fedora cmake --build .
         echo "::remove-matcher owner=gcc::"

--- a/.gitmodules
+++ b/.gitmodules
@@ -62,3 +62,6 @@
 [submodule "data/terrain_overrides/classic"]
 	path = data/terrain_overrides/classic
 	url = https://github.com/Warzone2100/data-terrain-classic.git
+[submodule "data/terrain_overrides/high"]
+	path = data/terrain_overrides/high
+	url = https://github.com/Warzone2100/data-terrain-high.git

--- a/cmake/WZBasisEncode.cmake
+++ b/cmake/WZBasisEncode.cmake
@@ -1,0 +1,172 @@
+#
+# _WZ_BASIS_ENCODE_GET_UNIQUE_TARGET_NAME is adapted from
+# _GETTEXT_GET_UNIQUE_TARGET_NAME in: https://github.com/Kitware/CMake/blob/master/Modules/FindGettext.cmake
+#
+# Original license:
+# -------------------------------------------------------------------
+# CMake - Cross Platform Makefile Generator
+# Copyright 2000-2023 Kitware, Inc. and Contributors
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# * Redistributions of source code must retain the above copyright
+#   notice, this list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright
+#   notice, this list of conditions and the following disclaimer in the
+#   documentation and/or other materials provided with the distribution.
+#
+# * Neither the name of Kitware, Inc. nor the names of Contributors
+#   may be used to endorse or promote products derived from this
+#   software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+# -------------------------------------------------------------------
+
+function(_WZ_BASIS_ENCODE_GET_UNIQUE_TARGET_NAME _name _unique_name)
+	set(propertyName "_WZ_BASIS_ENCODE_UNIQUE_COUNTER_${_name}")
+	get_property(currentCounter GLOBAL PROPERTY "${propertyName}")
+	if(NOT currentCounter)
+		set(currentCounter 1)
+	endif()
+	set(${_unique_name} "${_name}_${currentCounter}" PARENT_SCOPE)
+	math(EXPR currentCounter "${currentCounter} + 1")
+	set_property(GLOBAL PROPERTY ${propertyName} ${currentCounter} )
+endfunction()
+
+########################################################################
+#
+# WZ_BASIS_ENCODE_TEXTURES(OUTPUT_DIR outputDir
+#			   TYPE <TEXTURE, NORMALMAP, SPECULARMAP, ALPHAMASK>
+#			   [RESIZE <512 | 1024 | 2048 ...>]
+#			   [UASTC_LEVEL <0 | 1 | 2 | 3 | 4> = 2]
+#			   [RDO]
+#			   FILES [files...]
+#			   ENCODING_TARGET [target name]
+#			   [TARGET_FOLDER <folder>]
+#			   [ALL])
+#
+# Basis-encode a list of texture files, into the output folder <outputDir>.
+#
+# TYPE must be specified, and must be one of "TEXTURE", "NORMALMAP", "SPECULARMAP", or "ALPHAMASK".
+#
+# Notes on expected input formats:
+# - For "SPECULARMAP": a single-channel (grayscale) PNG. Only the first channel is extracted and used.
+# - For "ALPHAMASK": an RGBA PNG. Only the alpha channel is extracted and used.
+#
+# If RESIZE is specified, the texture images will be resized to RESIZE x RESIZE dimensions (if they aren't already) as a first step.
+#
+# If UASTC_LEVEL is specified, the -uastc_level parameter will be specified to set the UASTC encoding level:
+# > Range is [0,4], default is 2, higher=slower but higher quality.
+# > 0=fastest/lowest quality, 3=slowest practical option, 4=impractically slow/highest achievable quality
+#
+function(WZ_BASIS_ENCODE_TEXTURES)
+
+	if(NOT DEFINED BASIS_UNIVERSAL_CLI)
+		message(FATAL_ERROR "No basisu tool has been provided - set BASIS_UNIVERSAL_CLI to the path to basisu or disable WZ_ENABLE_BASIS_UNIVERSAL!")
+	endif()
+
+	set(_options ALL RDO)
+	set(_oneValueArgs OUTPUT_DIR TYPE RESIZE ENCODING_TARGET TARGET_FOLDER UASTC_LEVEL)
+	set(_multiValueArgs FILES)
+
+	CMAKE_PARSE_ARGUMENTS(_parsedArguments "${_options}" "${_oneValueArgs}" "${_multiValueArgs}" ${ARGN})
+
+	# Check that mandatory parameters were provided
+	if(NOT _parsedArguments_OUTPUT_DIR)
+		message( FATAL_ERROR "Missing required OUTPUT_DIR parameter" )
+	endif()
+	if(NOT _parsedArguments_TYPE OR NOT _parsedArguments_TYPE MATCHES "^(TEXTURE|NORMALMAP|SPECULARMAP|ALPHAMASK)$")
+		message( FATAL_ERROR "Missing valid TYPE parameter" )
+	endif()
+	if(NOT _parsedArguments_ENCODING_TARGET)
+		message( FATAL_ERROR "Missing required ENCODING_TARGET parameter" )
+	endif()
+	if(NOT _parsedArguments_FILES)
+		message( FATAL_ERROR "Missing required FILES parameter" )
+	endif()
+
+	# Optional arguments with defaults
+	if(DEFINED _parsedArguments_UASTC_LEVEL)
+		if (NOT _parsedArguments_UASTC_LEVEL MATCHES "^(0|1|2|3|4)$")
+			message( FATAL_ERROR "Invalid UASTC_LEVEL value: ${_parsedArguments_UASTC_LEVEL}" )
+		endif()
+		set(_uastc_level ${_parsedArguments_UASTC_LEVEL})
+	else()
+		set(_uastc_level 2)
+	endif()
+
+	# Construct variable encoding arguments
+	unset(_resample_arguments)
+	if(_parsedArguments_RESIZE)
+		set(_resample_arguments "-resample" "${_parsedArguments_RESIZE}" "${_parsedArguments_RESIZE}")
+	endif()
+	unset(_rdo_arguments)
+	unset(_type_dependent_arguments)
+	if(_parsedArguments_TYPE STREQUAL "TEXTURE")
+		set(_type_dependent_arguments -mipmap)
+		if (_parsedArguments_RDO)
+			set(_rdo_arguments -uastc_rdo_l 1.0)
+		endif()
+	elseif(_parsedArguments_TYPE STREQUAL "NORMALMAP")
+		set(_type_dependent_arguments -mipmap -normal_map -mip_filter mitchell)
+		if (_parsedArguments_RDO)
+			set(_rdo_arguments -uastc_rdo_l 1.0)
+		endif()
+	elseif(_parsedArguments_TYPE STREQUAL "SPECULARMAP")
+		set(_type_dependent_arguments -mipmap -linear -mip_linear -no_selector_rdo -no_endpoint_rdo -swizzle rrra -no_alpha -mip_filter mitchell)
+		if (_parsedArguments_RDO)
+			set(_rdo_arguments -uastc_rdo_l 1.0)
+		endif()
+	elseif(_parsedArguments_TYPE STREQUAL "ALPHAMASK")
+		set(_type_dependent_arguments -mipmap -linear -mip_linear -no_selector_rdo -no_endpoint_rdo -swizzle aaaa -no_alpha)
+	endif()
+
+	file(MAKE_DIRECTORY "${_parsedArguments_OUTPUT_DIR}")
+
+	foreach(TEXTURE ${_parsedArguments_FILES})
+		get_filename_component(TEXTURE_FILE_PATH ${TEXTURE} DIRECTORY)
+		get_filename_component(TEXTURE_FILE_NAME_WE ${TEXTURE} NAME_WE)
+		set(_output_name "${TEXTURE_FILE_NAME_WE}.ktx2")
+		add_custom_command(OUTPUT "${_parsedArguments_OUTPUT_DIR}/${_output_name}"
+			COMMAND "${BASIS_UNIVERSAL_CLI}"
+			ARGS -ktx2 -uastc -uastc_level ${_uastc_level} ${_rdo_arguments} -uastc_rdo_m ${_type_dependent_arguments} ${_resample_arguments} -output_file "${_parsedArguments_OUTPUT_DIR}/${_output_name}" -file "${TEXTURE}"
+			DEPENDS "${TEXTURE}"
+			VERBATIM
+		)
+		list(APPEND TEXTURE_LIST "${_parsedArguments_OUTPUT_DIR}/${_output_name}")
+	endforeach()
+
+	if(NOT TARGET ${_parsedArguments_ENCODING_TARGET})
+		add_custom_target(${_parsedArguments_ENCODING_TARGET})
+		set_property(TARGET ${_parsedArguments_ENCODING_TARGET} PROPERTY FOLDER "data")
+	endif()
+
+	_WZ_BASIS_ENCODE_GET_UNIQUE_TARGET_NAME("${_parsedArguments_ENCODING_TARGET}" uniqueTargetName)
+
+	if(_parsedArguments_ALL)
+		add_custom_target(${uniqueTargetName} ALL DEPENDS ${TEXTURE_LIST})
+	else()
+		add_custom_target(${uniqueTargetName} DEPENDS ${TEXTURE_LIST})
+	endif()
+
+	if (DEFINED _parsedArguments_TARGET_FOLDER)
+		set_property(TARGET ${uniqueTargetName} PROPERTY FOLDER "${_parsedArguments_TARGET_FOLDER}")
+	endif()
+
+	add_dependencies(${_parsedArguments_ENCODING_TARGET} ${uniqueTargetName})
+
+endfunction()

--- a/data/CMakeLists.txt
+++ b/data/CMakeLists.txt
@@ -152,6 +152,7 @@ if(WZ_ENABLE_BASIS_UNIVERSAL AND NOT WZ_CI_DISABLE_BASIS_COMPRESS_TEXTURES)
 	set(PROCESSED_TEXTURE_FILES ${TEXPAGES_TERRAIN})
 
 	file(GLOB_RECURSE ALL_TEXPAGES LIST_DIRECTORIES false CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/base/texpages/*.png" "${CMAKE_CURRENT_SOURCE_DIR}/base/texpages/compression_overrides.txt" "${CMAKE_CURRENT_SOURCE_DIR}/base/texpages/*.radar")
+	unset(ALL_TEXPAGES_unprocessed)
 	list(APPEND ALL_TEXPAGES_unprocessed ${ALL_TEXPAGES})
 	list(REMOVE_ITEM ALL_TEXPAGES_unprocessed ${PROCESSED_TEXTURE_FILES})
 	foreach(TEXPAGE_FILE ${ALL_TEXPAGES_unprocessed})
@@ -176,6 +177,11 @@ if(WZ_ENABLE_BASIS_UNIVERSAL AND NOT WZ_CI_DISABLE_BASIS_COMPRESS_TEXTURES)
 			"texpages"
 		WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/base"
 	)
+
+	unset(PROCESSED_TEXTURE_FILES)
+	unset(ALL_TEXPAGES)
+	unset(TEXTURE_UNPROCESSED_LIST)
+	unset(ALL_TEXPAGES_unprocessed)
 
 else()
 	if(WZ_ENABLE_BASIS_UNIVERSAL AND WZ_CI_DISABLE_BASIS_COMPRESS_TEXTURES)
@@ -203,6 +209,102 @@ COMPRESS_ZIP(OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/terrain_overrides/classic.wz"
 	QUIET
 )
 set_property(TARGET data_terrain_overrides_classic PROPERTY FOLDER "data")
+
+## High terrain overrides
+
+set(_terrain_overrides_high_base_path "${CMAKE_CURRENT_SOURCE_DIR}/terrain_overrides/high")
+
+if(WZ_ENABLE_BASIS_UNIVERSAL AND NOT WZ_CI_DISABLE_BASIS_COMPRESS_TEXTURES)
+	if(NOT DEFINED BASIS_UNIVERSAL_CLI)
+		message(FATAL_ERROR "No basisu tool has been provided - set BASIS_UNIVERSAL_CLI to the path to basisu or disable WZ_ENABLE_BASIS_UNIVERSAL!")
+	endif()
+
+	file(REMOVE_RECURSE "${CMAKE_CURRENT_BINARY_DIR}/terrain_overrides/high")
+
+	set(high_texture_folders "texpages")
+	file(GLOB tertiles_dirs LIST_DIRECTORIES true RELATIVE "${_terrain_overrides_high_base_path}" CONFIGURE_DEPENDS "${_terrain_overrides_high_base_path}/texpages/tertilesc*hw-*")
+	list(APPEND high_texture_folders ${tertiles_dirs})
+
+	foreach(tex_folder ${high_texture_folders})
+
+		file(GLOB ALL_TEXPAGES LIST_DIRECTORIES false CONFIGURE_DEPENDS "${_terrain_overrides_high_base_path}/${tex_folder}/*.png")
+		# Split into _nm, _sm, and everything else (regular texpages)
+		file(GLOB TEXPAGES_NM LIST_DIRECTORIES false CONFIGURE_DEPENDS "${_terrain_overrides_high_base_path}/${tex_folder}/*_nm.png")
+		file(GLOB TEXPAGES_SM LIST_DIRECTORIES false CONFIGURE_DEPENDS "${_terrain_overrides_high_base_path}/${tex_folder}/*_sm.png")
+		unset(TEXPAGES_TEX)
+		list(APPEND TEXPAGES_TEX ${ALL_TEXPAGES})
+		list(REMOVE_ITEM TEXPAGES_TEX ${TEXPAGES_NM} ${TEXPAGES_SM})
+
+		set(_output_dir "${CMAKE_CURRENT_BINARY_DIR}/terrain_overrides/high/${tex_folder}")
+		if (tex_folder STREQUAL "texpages")
+			set(_terrain_high_max_size 1024)
+		else()
+			set(_terrain_high_max_size 256) # decals are 256x256
+		endif()
+
+		WZ_BASIS_ENCODE_TEXTURES(OUTPUT_DIR "${_output_dir}" TYPE "TEXTURE" RESIZE "${_terrain_high_max_size}" UASTC_LEVEL 3 ENCODING_TARGET texture_encoding_high TARGET_FOLDER data ALL FILES ${TEXPAGES_TEX})
+		list(APPEND PROCESSED_TEXTURE_FILES ${TEXPAGES_TEX})
+		WZ_BASIS_ENCODE_TEXTURES(OUTPUT_DIR "${_output_dir}" TYPE "NORMALMAP" RESIZE "${_terrain_high_max_size}" UASTC_LEVEL 3 ENCODING_TARGET texture_encoding_high TARGET_FOLDER data ALL FILES ${TEXPAGES_NM})
+		list(APPEND PROCESSED_TEXTURE_FILES ${TEXPAGES_NM})
+		WZ_BASIS_ENCODE_TEXTURES(OUTPUT_DIR "${_output_dir}" TYPE "SPECULARMAP" RESIZE "${_terrain_high_max_size}" UASTC_LEVEL 3 ENCODING_TARGET texture_encoding_high TARGET_FOLDER data ALL FILES ${TEXPAGES_SM})
+		list(APPEND PROCESSED_TEXTURE_FILES ${TEXPAGES_SM})
+
+	endforeach()
+
+	set(_base_output_dir "${CMAKE_CURRENT_BINARY_DIR}/terrain_overrides/high")
+	file(GLOB_RECURSE ALL_TEXPAGES LIST_DIRECTORIES false CONFIGURE_DEPENDS "${_terrain_overrides_high_base_path}/texpages/*.*" "${_terrain_overrides_high_base_path}/tileset/*.*")
+	list(APPEND ALL_TEXPAGES_unprocessed ${ALL_TEXPAGES})
+	list(REMOVE_ITEM ALL_TEXPAGES_unprocessed ${PROCESSED_TEXTURE_FILES})
+	foreach(TEXPAGE_FILE ${ALL_TEXPAGES_unprocessed})
+		file(RELATIVE_PATH _output_name "${_terrain_overrides_high_base_path}" "${TEXPAGE_FILE}")
+		message(STATUS "Copy unprocessed image file: ${_output_name}")
+		add_custom_command(OUTPUT "${_base_output_dir}/${_output_name}"
+			COMMAND "${CMAKE_COMMAND}"
+			ARGS -E copy_if_different "${TEXPAGE_FILE}" "${_base_output_dir}/${_output_name}"
+			WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/base/texpages"
+			DEPENDS "${TEXPAGE_FILE}"
+			VERBATIM
+		)
+		list(APPEND TEXTURE_UNPROCESSED_LIST "${_base_output_dir}/${_output_name}")
+	endforeach()
+
+	add_custom_target(texture_staging_high DEPENDS ${TEXTURE_UNPROCESSED_LIST})
+	set_property(TARGET texture_staging_high PROPERTY FOLDER "data")
+
+	unset(PROCESSED_TEXTURE_FILES)
+	unset(ALL_TEXPAGES)
+	unset(TEXTURE_UNPROCESSED_LIST)
+	unset(ALL_TEXPAGES_unprocessed)
+
+	COMPRESS_ZIP(OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/terrain_overrides/high.wz"
+		COMPRESSION_LEVEL 0
+		PATHS
+			"texpages"
+			"tileset"
+		WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/terrain_overrides/high"
+		BUILD_ALWAYS_TARGET data_terrain_overrides_high
+		IGNORE_GIT
+		QUIET
+	)
+	add_dependencies(data_terrain_overrides_high texture_encoding_high texture_staging_high)
+
+else()
+	if(WZ_ENABLE_BASIS_UNIVERSAL AND WZ_CI_DISABLE_BASIS_COMPRESS_TEXTURES)
+		message(STATUS "WZ_CI_DISABLE_BASIS_COMPRESS_TEXTURES is set, textures will not be compressed as part of build. This should only be used for selected CI runs.")
+	endif()
+
+	COMPRESS_ZIP(OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/terrain_overrides/high.wz"
+		COMPRESSION_LEVEL 0
+		PATHS
+			"texpages"
+			"tileset"
+		WORKING_DIRECTORY "${_terrain_overrides_high_base_path}"
+		BUILD_ALWAYS_TARGET data_terrain_overrides_high
+		IGNORE_GIT
+		QUIET
+	)
+	set_property(TARGET data_terrain_overrides_high PROPERTY FOLDER "data")
+endif()
 
 #########################
 # Compress data archives
@@ -296,6 +398,9 @@ ADD_CUSTOM_TARGET(data ALL
 if(TARGET data_terrain_overrides_classic)
 	add_dependencies(data_base data_terrain_overrides_classic)
 endif()
+if(TARGET data_terrain_overrides_high)
+	add_dependencies(data_base data_terrain_overrides_high)
+endif()
 if(TARGET glsl_compilation)
 	add_dependencies(data_base glsl_compilation)
 endif()
@@ -334,6 +439,9 @@ install(FILES ${DATA_FILES}
 set(DATA_TERRAIN_OVERRIDES_FILES
 	"${CMAKE_CURRENT_BINARY_DIR}/terrain_overrides/classic.wz"
 )
+if(TARGET data_terrain_overrides_high)
+	list(APPEND DATA_TERRAIN_OVERRIDES_FILES "${CMAKE_CURRENT_BINARY_DIR}/terrain_overrides/high.wz")
+endif()
 install(FILES ${DATA_TERRAIN_OVERRIDES_FILES}
 	DESTINATION "${WZ_DATADIR}/terrain_overrides"
 	COMPONENT Data

--- a/data/CMakeLists.txt
+++ b/data/CMakeLists.txt
@@ -223,9 +223,11 @@ if (WZ_INCLUDE_TERRAIN_HIGH)
 		endif()
 
 		file(REMOVE_RECURSE "${CMAKE_CURRENT_BINARY_DIR}/terrain_overrides/high")
+		file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/terrain_overrides/high/texpages")
+		file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/terrain_overrides/high/tileset")
 
 		set(high_texture_folders "texpages")
-		file(GLOB tertiles_dirs LIST_DIRECTORIES true RELATIVE "${_terrain_overrides_high_base_path}" "${_terrain_overrides_high_base_path}/texpages/tertilesc*hw-*")
+		file(GLOB tertiles_dirs LIST_DIRECTORIES true RELATIVE "${_terrain_overrides_high_base_path}" CONFIGURE_DEPENDS "${_terrain_overrides_high_base_path}/texpages/tertilesc*hw-*")
 		list(APPEND high_texture_folders ${tertiles_dirs})
 
 		foreach(tex_folder ${high_texture_folders})
@@ -255,7 +257,7 @@ if (WZ_INCLUDE_TERRAIN_HIGH)
 		endforeach()
 
 		set(_base_output_dir "${CMAKE_CURRENT_BINARY_DIR}/terrain_overrides/high")
-		file(GLOB_RECURSE ALL_TEXPAGES LIST_DIRECTORIES false "${_terrain_overrides_high_base_path}/texpages/*.*" "${_terrain_overrides_high_base_path}/tileset/*.*")
+		file(GLOB_RECURSE ALL_TEXPAGES LIST_DIRECTORIES false CONFIGURE_DEPENDS "${_terrain_overrides_high_base_path}/texpages/*.*" "${_terrain_overrides_high_base_path}/tileset/*.*")
 		list(APPEND ALL_TEXPAGES_unprocessed ${ALL_TEXPAGES})
 		list(REMOVE_ITEM ALL_TEXPAGES_unprocessed ${PROCESSED_TEXTURE_FILES})
 		foreach(TEXPAGE_FILE ${ALL_TEXPAGES_unprocessed})

--- a/data/CMakeLists.txt
+++ b/data/CMakeLists.txt
@@ -5,6 +5,7 @@ endif()
 if(CMAKE_SYSTEM_NAME MATCHES "Darwin")
 	OPTION(WZ_INCLUDE_VIDEOS "Download & include videos in the application package" OFF)
 endif()
+OPTION(WZ_INCLUDE_TERRAIN_HIGH "Include high terrain texture pack" ON)
 
 find_package(ZIP REQUIRED)
 
@@ -212,99 +213,105 @@ set_property(TARGET data_terrain_overrides_classic PROPERTY FOLDER "data")
 
 ## High terrain overrides
 
-set(_terrain_overrides_high_base_path "${CMAKE_CURRENT_SOURCE_DIR}/terrain_overrides/high")
+if (WZ_INCLUDE_TERRAIN_HIGH)
 
-if(WZ_ENABLE_BASIS_UNIVERSAL AND NOT WZ_CI_DISABLE_BASIS_COMPRESS_TEXTURES)
-	if(NOT DEFINED BASIS_UNIVERSAL_CLI)
-		message(FATAL_ERROR "No basisu tool has been provided - set BASIS_UNIVERSAL_CLI to the path to basisu or disable WZ_ENABLE_BASIS_UNIVERSAL!")
-	endif()
+	set(_terrain_overrides_high_base_path "${CMAKE_CURRENT_SOURCE_DIR}/terrain_overrides/high")
 
-	file(REMOVE_RECURSE "${CMAKE_CURRENT_BINARY_DIR}/terrain_overrides/high")
-
-	set(high_texture_folders "texpages")
-	file(GLOB tertiles_dirs LIST_DIRECTORIES true RELATIVE "${_terrain_overrides_high_base_path}" "${_terrain_overrides_high_base_path}/texpages/tertilesc*hw-*")
-	list(APPEND high_texture_folders ${tertiles_dirs})
-
-	foreach(tex_folder ${high_texture_folders})
-
-		file(GLOB ALL_TEXPAGES LIST_DIRECTORIES false CONFIGURE_DEPENDS "${_terrain_overrides_high_base_path}/${tex_folder}/*.png")
-		# Split into _nm, _sm, and everything else (regular texpages)
-		file(GLOB TEXPAGES_NM LIST_DIRECTORIES false CONFIGURE_DEPENDS "${_terrain_overrides_high_base_path}/${tex_folder}/*_nm.png")
-		file(GLOB TEXPAGES_SM LIST_DIRECTORIES false CONFIGURE_DEPENDS "${_terrain_overrides_high_base_path}/${tex_folder}/*_sm.png")
-		unset(TEXPAGES_TEX)
-		list(APPEND TEXPAGES_TEX ${ALL_TEXPAGES})
-		list(REMOVE_ITEM TEXPAGES_TEX ${TEXPAGES_NM} ${TEXPAGES_SM})
-
-		set(_output_dir "${CMAKE_CURRENT_BINARY_DIR}/terrain_overrides/high/${tex_folder}")
-		if (tex_folder STREQUAL "texpages")
-			set(_terrain_high_max_size 1024)
-		else()
-			set(_terrain_high_max_size 256) # decals are 256x256
+	if(WZ_ENABLE_BASIS_UNIVERSAL AND NOT WZ_CI_DISABLE_BASIS_COMPRESS_TEXTURES)
+		if(NOT DEFINED BASIS_UNIVERSAL_CLI)
+			message(FATAL_ERROR "No basisu tool has been provided - set BASIS_UNIVERSAL_CLI to the path to basisu or disable WZ_ENABLE_BASIS_UNIVERSAL!")
 		endif()
 
-		WZ_BASIS_ENCODE_TEXTURES(OUTPUT_DIR "${_output_dir}" TYPE "TEXTURE" RESIZE "${_terrain_high_max_size}" UASTC_LEVEL 3 ENCODING_TARGET texture_encoding_high TARGET_FOLDER data ALL FILES ${TEXPAGES_TEX})
-		list(APPEND PROCESSED_TEXTURE_FILES ${TEXPAGES_TEX})
-		WZ_BASIS_ENCODE_TEXTURES(OUTPUT_DIR "${_output_dir}" TYPE "NORMALMAP" RESIZE "${_terrain_high_max_size}" UASTC_LEVEL 3 ENCODING_TARGET texture_encoding_high TARGET_FOLDER data ALL FILES ${TEXPAGES_NM})
-		list(APPEND PROCESSED_TEXTURE_FILES ${TEXPAGES_NM})
-		WZ_BASIS_ENCODE_TEXTURES(OUTPUT_DIR "${_output_dir}" TYPE "SPECULARMAP" RESIZE "${_terrain_high_max_size}" UASTC_LEVEL 3 ENCODING_TARGET texture_encoding_high TARGET_FOLDER data ALL FILES ${TEXPAGES_SM})
-		list(APPEND PROCESSED_TEXTURE_FILES ${TEXPAGES_SM})
+		file(REMOVE_RECURSE "${CMAKE_CURRENT_BINARY_DIR}/terrain_overrides/high")
 
-	endforeach()
+		set(high_texture_folders "texpages")
+		file(GLOB tertiles_dirs LIST_DIRECTORIES true RELATIVE "${_terrain_overrides_high_base_path}" "${_terrain_overrides_high_base_path}/texpages/tertilesc*hw-*")
+		list(APPEND high_texture_folders ${tertiles_dirs})
 
-	set(_base_output_dir "${CMAKE_CURRENT_BINARY_DIR}/terrain_overrides/high")
-	file(GLOB_RECURSE ALL_TEXPAGES LIST_DIRECTORIES false "${_terrain_overrides_high_base_path}/texpages/*.*" "${_terrain_overrides_high_base_path}/tileset/*.*")
-	list(APPEND ALL_TEXPAGES_unprocessed ${ALL_TEXPAGES})
-	list(REMOVE_ITEM ALL_TEXPAGES_unprocessed ${PROCESSED_TEXTURE_FILES})
-	foreach(TEXPAGE_FILE ${ALL_TEXPAGES_unprocessed})
-		file(RELATIVE_PATH _output_name "${_terrain_overrides_high_base_path}" "${TEXPAGE_FILE}")
-		message(STATUS "Copy unprocessed image file: ${_output_name}")
-		add_custom_command(OUTPUT "${_base_output_dir}/${_output_name}"
-			COMMAND "${CMAKE_COMMAND}"
-			ARGS -E copy_if_different "${TEXPAGE_FILE}" "${_base_output_dir}/${_output_name}"
-			WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/base/texpages"
-			DEPENDS "${TEXPAGE_FILE}"
-			VERBATIM
+		foreach(tex_folder ${high_texture_folders})
+
+			file(GLOB ALL_TEXPAGES LIST_DIRECTORIES false CONFIGURE_DEPENDS "${_terrain_overrides_high_base_path}/${tex_folder}/*.png")
+			# Split into _nm, _sm, and everything else (regular texpages)
+			file(GLOB TEXPAGES_NM LIST_DIRECTORIES false CONFIGURE_DEPENDS "${_terrain_overrides_high_base_path}/${tex_folder}/*_nm.png")
+			file(GLOB TEXPAGES_SM LIST_DIRECTORIES false CONFIGURE_DEPENDS "${_terrain_overrides_high_base_path}/${tex_folder}/*_sm.png")
+			unset(TEXPAGES_TEX)
+			list(APPEND TEXPAGES_TEX ${ALL_TEXPAGES})
+			list(REMOVE_ITEM TEXPAGES_TEX ${TEXPAGES_NM} ${TEXPAGES_SM})
+
+			set(_output_dir "${CMAKE_CURRENT_BINARY_DIR}/terrain_overrides/high/${tex_folder}")
+			if (tex_folder STREQUAL "texpages")
+				set(_terrain_high_max_size 1024)
+			else()
+				set(_terrain_high_max_size 256) # decals are 256x256
+			endif()
+
+			WZ_BASIS_ENCODE_TEXTURES(OUTPUT_DIR "${_output_dir}" TYPE "TEXTURE" RESIZE "${_terrain_high_max_size}" UASTC_LEVEL 3 ENCODING_TARGET texture_encoding_high TARGET_FOLDER data ALL FILES ${TEXPAGES_TEX})
+			list(APPEND PROCESSED_TEXTURE_FILES ${TEXPAGES_TEX})
+			WZ_BASIS_ENCODE_TEXTURES(OUTPUT_DIR "${_output_dir}" TYPE "NORMALMAP" RESIZE "${_terrain_high_max_size}" UASTC_LEVEL 3 ENCODING_TARGET texture_encoding_high TARGET_FOLDER data ALL FILES ${TEXPAGES_NM})
+			list(APPEND PROCESSED_TEXTURE_FILES ${TEXPAGES_NM})
+			WZ_BASIS_ENCODE_TEXTURES(OUTPUT_DIR "${_output_dir}" TYPE "SPECULARMAP" RESIZE "${_terrain_high_max_size}" UASTC_LEVEL 3 ENCODING_TARGET texture_encoding_high TARGET_FOLDER data ALL FILES ${TEXPAGES_SM})
+			list(APPEND PROCESSED_TEXTURE_FILES ${TEXPAGES_SM})
+
+		endforeach()
+
+		set(_base_output_dir "${CMAKE_CURRENT_BINARY_DIR}/terrain_overrides/high")
+		file(GLOB_RECURSE ALL_TEXPAGES LIST_DIRECTORIES false "${_terrain_overrides_high_base_path}/texpages/*.*" "${_terrain_overrides_high_base_path}/tileset/*.*")
+		list(APPEND ALL_TEXPAGES_unprocessed ${ALL_TEXPAGES})
+		list(REMOVE_ITEM ALL_TEXPAGES_unprocessed ${PROCESSED_TEXTURE_FILES})
+		foreach(TEXPAGE_FILE ${ALL_TEXPAGES_unprocessed})
+			file(RELATIVE_PATH _output_name "${_terrain_overrides_high_base_path}" "${TEXPAGE_FILE}")
+			message(STATUS "Copy unprocessed image file: ${_output_name}")
+			add_custom_command(OUTPUT "${_base_output_dir}/${_output_name}"
+				COMMAND "${CMAKE_COMMAND}"
+				ARGS -E copy_if_different "${TEXPAGE_FILE}" "${_base_output_dir}/${_output_name}"
+				WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/base/texpages"
+				DEPENDS "${TEXPAGE_FILE}"
+				VERBATIM
+			)
+			list(APPEND TEXTURE_UNPROCESSED_LIST "${_base_output_dir}/${_output_name}")
+		endforeach()
+
+		add_custom_target(texture_staging_high DEPENDS ${TEXTURE_UNPROCESSED_LIST})
+		set_property(TARGET texture_staging_high PROPERTY FOLDER "data")
+
+		unset(PROCESSED_TEXTURE_FILES)
+		unset(ALL_TEXPAGES)
+		unset(TEXTURE_UNPROCESSED_LIST)
+		unset(ALL_TEXPAGES_unprocessed)
+
+		COMPRESS_ZIP(OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/terrain_overrides/high.wz"
+			COMPRESSION_LEVEL 0
+			PATHS
+				"texpages"
+				"tileset"
+			WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/terrain_overrides/high"
+			BUILD_ALWAYS_TARGET data_terrain_overrides_high
+			IGNORE_GIT
+			QUIET
 		)
-		list(APPEND TEXTURE_UNPROCESSED_LIST "${_base_output_dir}/${_output_name}")
-	endforeach()
+		add_dependencies(data_terrain_overrides_high texture_encoding_high texture_staging_high)
 
-	add_custom_target(texture_staging_high DEPENDS ${TEXTURE_UNPROCESSED_LIST})
-	set_property(TARGET texture_staging_high PROPERTY FOLDER "data")
+	else()
+		if(WZ_ENABLE_BASIS_UNIVERSAL AND WZ_CI_DISABLE_BASIS_COMPRESS_TEXTURES)
+			message(STATUS "WZ_CI_DISABLE_BASIS_COMPRESS_TEXTURES is set, textures will not be compressed as part of build. This should only be used for selected CI runs.")
+		endif()
 
-	unset(PROCESSED_TEXTURE_FILES)
-	unset(ALL_TEXPAGES)
-	unset(TEXTURE_UNPROCESSED_LIST)
-	unset(ALL_TEXPAGES_unprocessed)
-
-	COMPRESS_ZIP(OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/terrain_overrides/high.wz"
-		COMPRESSION_LEVEL 0
-		PATHS
-			"texpages"
-			"tileset"
-		WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/terrain_overrides/high"
-		BUILD_ALWAYS_TARGET data_terrain_overrides_high
-		IGNORE_GIT
-		QUIET
-	)
-	add_dependencies(data_terrain_overrides_high texture_encoding_high texture_staging_high)
-
-else()
-	if(WZ_ENABLE_BASIS_UNIVERSAL AND WZ_CI_DISABLE_BASIS_COMPRESS_TEXTURES)
-		message(STATUS "WZ_CI_DISABLE_BASIS_COMPRESS_TEXTURES is set, textures will not be compressed as part of build. This should only be used for selected CI runs.")
+		COMPRESS_ZIP(OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/terrain_overrides/high.wz"
+			COMPRESSION_LEVEL 0
+			PATHS
+				"texpages"
+				"tileset"
+			WORKING_DIRECTORY "${_terrain_overrides_high_base_path}"
+			BUILD_ALWAYS_TARGET data_terrain_overrides_high
+			IGNORE_GIT
+			QUIET
+		)
+		set_property(TARGET data_terrain_overrides_high PROPERTY FOLDER "data")
 	endif()
 
-	COMPRESS_ZIP(OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/terrain_overrides/high.wz"
-		COMPRESSION_LEVEL 0
-		PATHS
-			"texpages"
-			"tileset"
-		WORKING_DIRECTORY "${_terrain_overrides_high_base_path}"
-		BUILD_ALWAYS_TARGET data_terrain_overrides_high
-		IGNORE_GIT
-		QUIET
-	)
-	set_property(TARGET data_terrain_overrides_high PROPERTY FOLDER "data")
-endif()
+else()
+	message(STATUS "WZ_INCLUDE_TERRAIN_HIGH is OFF. High terrain texture pack will not be part of build.")
+endif(WZ_INCLUDE_TERRAIN_HIGH)
 
 #########################
 # Compress data archives

--- a/data/CMakeLists.txt
+++ b/data/CMakeLists.txt
@@ -222,7 +222,7 @@ if(WZ_ENABLE_BASIS_UNIVERSAL AND NOT WZ_CI_DISABLE_BASIS_COMPRESS_TEXTURES)
 	file(REMOVE_RECURSE "${CMAKE_CURRENT_BINARY_DIR}/terrain_overrides/high")
 
 	set(high_texture_folders "texpages")
-	file(GLOB tertiles_dirs LIST_DIRECTORIES true RELATIVE "${_terrain_overrides_high_base_path}" CONFIGURE_DEPENDS "${_terrain_overrides_high_base_path}/texpages/tertilesc*hw-*")
+	file(GLOB tertiles_dirs LIST_DIRECTORIES true RELATIVE "${_terrain_overrides_high_base_path}" "${_terrain_overrides_high_base_path}/texpages/tertilesc*hw-*")
 	list(APPEND high_texture_folders ${tertiles_dirs})
 
 	foreach(tex_folder ${high_texture_folders})
@@ -252,7 +252,7 @@ if(WZ_ENABLE_BASIS_UNIVERSAL AND NOT WZ_CI_DISABLE_BASIS_COMPRESS_TEXTURES)
 	endforeach()
 
 	set(_base_output_dir "${CMAKE_CURRENT_BINARY_DIR}/terrain_overrides/high")
-	file(GLOB_RECURSE ALL_TEXPAGES LIST_DIRECTORIES false CONFIGURE_DEPENDS "${_terrain_overrides_high_base_path}/texpages/*.*" "${_terrain_overrides_high_base_path}/tileset/*.*")
+	file(GLOB_RECURSE ALL_TEXPAGES LIST_DIRECTORIES false "${_terrain_overrides_high_base_path}/texpages/*.*" "${_terrain_overrides_high_base_path}/tileset/*.*")
 	list(APPEND ALL_TEXPAGES_unprocessed ${ALL_TEXPAGES})
 	list(REMOVE_ITEM ALL_TEXPAGES_unprocessed ${PROCESSED_TEXTURE_FILES})
 	foreach(TEXPAGE_FILE ${ALL_TEXPAGES_unprocessed})

--- a/data/CMakeLists.txt
+++ b/data/CMakeLists.txt
@@ -99,6 +99,8 @@ endif()
 #########################################
 # Texture pages basis-universal encoding
 
+include(WZBasisEncode)
+
 # default texpages path
 set(_texpages_PATHS
 	PATHS
@@ -145,22 +147,8 @@ if(WZ_ENABLE_BASIS_UNIVERSAL AND NOT WZ_CI_DISABLE_BASIS_COMPRESS_TEXTURES)
 	set(_output_dir "${CMAKE_CURRENT_BINARY_DIR}/base/texpages")
 	file(MAKE_DIRECTORY "${_output_dir}")
 	set(_terrain_max_size 1024)
-	foreach(TEXTURE ${TEXPAGES_TERRAIN})
-		get_filename_component(TEXTURE_FILE_PATH ${TEXTURE} DIRECTORY)
-		get_filename_component(TEXTURE_FILE_NAME_WE ${TEXTURE} NAME_WE)
-		set(_output_name "${TEXTURE_FILE_NAME_WE}.ktx2")
-		add_custom_command(OUTPUT "${_output_dir}/${_output_name}"
-			COMMAND "${BASIS_UNIVERSAL_CLI}"
-			ARGS -ktx2 -uastc -uastc_level 2 -uastc_rdo_l 1.0 -uastc_rdo_m -mipmap -resample ${_terrain_max_size} ${_terrain_max_size} -output_file "${_output_dir}/${_output_name}" -file "${TEXTURE}"
-			WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/base/texpages"
-			DEPENDS "${TEXTURE}"
-			VERBATIM
-		)
-		list(APPEND TEXTURE_LIST "${_output_dir}/${_output_name}")
-	endforeach()
-	add_custom_target(texture_encoding DEPENDS ${TEXTURE_LIST})
-	set_property(TARGET texture_encoding PROPERTY FOLDER "data")
 
+	WZ_BASIS_ENCODE_TEXTURES(OUTPUT_DIR "${_output_dir}" TYPE "TEXTURE" RESIZE "${_terrain_max_size}" RDO ENCODING_TARGET texture_encoding TARGET_FOLDER data ALL FILES ${TEXPAGES_TERRAIN})
 	set(PROCESSED_TEXTURE_FILES ${TEXPAGES_TERRAIN})
 
 	file(GLOB_RECURSE ALL_TEXPAGES LIST_DIRECTORIES false CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/base/texpages/*.png" "${CMAKE_CURRENT_SOURCE_DIR}/base/texpages/compression_overrides.txt" "${CMAKE_CURRENT_SOURCE_DIR}/base/texpages/*.radar")

--- a/doc/PIE.md
+++ b/doc/PIE.md
@@ -63,7 +63,12 @@ This sets the texture page for the model. Each file must contain exactly one suc
 In theory you could leave out this line, but in practice that makes your models useless.
 Note that the exact texture page file may be modified by WRF files during level loading, so that the texture matches the tileset.
 
-The first parameter (the zero) is ignored.
+The first parameter (the zero) specifies the tileset:
+* `0` -- default, arizona
+* `1` -- urban
+* `2` -- rockies
+
+In general, you should _always_ specify a TEXTURE for tileset 0, and optionally include additional TEXTURE directives if overrides for the urban or rockies tilesets are desired.
 
 The second gives you the filename of the texture page, which
 * must only contain the characters [a-zA-Z0-9.\_\\-] ([a-z] is not meant to include any lowercase character not found in the English alphabet).
@@ -124,7 +129,8 @@ The following global directives can be specified at the LEVEL scope to override 
 - NORMALMAP
 - SPECULARMAP
 
-They should be specified in the order listed above. All are optional and, if omitted, the associated global directive will be used (if set).
+`TYPE` and `INTERPOLATE` should come first, and be specified in that order. The `TEXTURE`, `TCMASK`, `NORMALMAP`, and `SPECULARMAP` follow, but can be present in any order.
+All are optional and, if omitted, the associated global directive will be used (if set).
 
 ### POINTS
 

--- a/lib/ivis_opengl/gfx_api.cpp
+++ b/lib/ivis_opengl/gfx_api.cpp
@@ -221,13 +221,13 @@ optional<gfx_api::max_texture_compression_level> gfx_api::getMaxTextureCompressi
 
 #include "png_util.h"
 
-static gfx_api::texture* loadImageTextureFromFile_PNG(const std::string& filename, gfx_api::texture_type textureType, int maxWidth /*= -1*/, int maxHeight /*= -1*/)
+static gfx_api::texture* loadImageTextureFromFile_PNG(const std::string& filename, gfx_api::texture_type textureType, int maxWidth /*= -1*/, int maxHeight /*= -1*/, bool quiet)
 {
 	iV_Image loadedUncompressedImage;
 
 	// 1.) Load the PNG into an iV_Image
 	bool forceRGB = (textureType == gfx_api::texture_type::game_texture) || (textureType == gfx_api::texture_type::user_interface);
-	if (!iV_loadImage_PNG2(filename.c_str(), loadedUncompressedImage, forceRGB))
+	if (!iV_loadImage_PNG2(filename.c_str(), loadedUncompressedImage, forceRGB, quiet))
 	{
 		// Failed to load the image
 		return nullptr;
@@ -301,7 +301,7 @@ bool gfx_api::checkImageFilesWouldLoadFromSameParentMountPath(const std::vector<
 
 // Load a texture from a file
 // (which loads straight to a texture based on the appropriate texture_type, handling mip_maps, compression, etc)
-gfx_api::texture* gfx_api::context::loadTextureFromFile(const char *filename, gfx_api::texture_type textureType, int maxWidth /*= -1*/, int maxHeight /*= -1*/)
+gfx_api::texture* gfx_api::context::loadTextureFromFile(const char *filename, gfx_api::texture_type textureType, int maxWidth /*= -1*/, int maxHeight /*= -1*/, bool quiet /*= false*/)
 {
 	auto imageLoadFilename = imageLoadFilenameFromInputFilename(filename);
 
@@ -314,7 +314,7 @@ gfx_api::texture* gfx_api::context::loadTextureFromFile(const char *filename, gf
 #endif
 	if (imageLoadFilename.endsWith(".png"))
 	{
-		return loadImageTextureFromFile_PNG(imageLoadFilename.toUtf8(), textureType, maxWidth, maxHeight);
+		return loadImageTextureFromFile_PNG(imageLoadFilename.toUtf8(), textureType, maxWidth, maxHeight, quiet);
 	}
 	else
 	{

--- a/lib/ivis_opengl/gfx_api.cpp
+++ b/lib/ivis_opengl/gfx_api.cpp
@@ -854,7 +854,7 @@ static std::vector<std::unique_ptr<iV_BaseImage>> loadUncompressedImageWithMips(
 #if defined(BASIS_ENABLED)
 	if (strEndsWith(imageLoadFilename, ".ktx2"))
 	{
-		results = gfx_api::loadiVImagesFromFile_Basis(imageLoadFilename, textureType, gfx_api::pixel_format_target::texture_2d_array, WZ_BASIS_UNCOMPRESSED_FORMAT, std::max(0, maxWidth), std::max(0, maxHeight));
+		results = gfx_api::loadiVImagesFromFile_Basis(imageLoadFilename, textureType, gfx_api::pixel_format_target::texture_2d_array, (forceRGBA8) ? WZ_BASIS_UNCOMPRESSED_FORMAT : gfx_api::context::get().bestUncompressedPixelFormat(gfx_api::pixel_format_target::texture_2d_array, textureType), std::max(0, maxWidth), std::max(0, maxHeight));
 
 		if (forceRGBA8)
 		{
@@ -905,7 +905,7 @@ gfx_api::texture_array* gfx_api::context::loadTextureArrayFromFiles(const std::v
 		return imageLoadFilenameFromInputFilename(filename);
 	});
 
-	bool allFilesAreKTX2 = std::all_of(imageLoadFilenames.cbegin(), imageLoadFilenames.cend(), [](const WzString& imageLoadFilename) { return imageLoadFilename.endsWith(".ktx2"); });
+	bool allFilesAreKTX2 = std::all_of(imageLoadFilenames.cbegin(), imageLoadFilenames.cend(), [](const WzString& imageLoadFilename) { return imageLoadFilename.isEmpty() || imageLoadFilename.endsWith(".ktx2"); });
 	bool anyFileIsKTX2 = allFilesAreKTX2 || std::any_of(imageLoadFilenames.cbegin(), imageLoadFilenames.cend(), [](const WzString& imageLoadFilename) { return imageLoadFilename.endsWith(".ktx2"); });
 
 #if !defined(BASIS_ENABLED)

--- a/lib/ivis_opengl/gfx_api.h
+++ b/lib/ivis_opengl/gfx_api.h
@@ -427,7 +427,7 @@ namespace gfx_api
 		virtual void draw_elements_instanced(const std::size_t& offset, const std::size_t& count, const primitive_type& primitive, const index_type& index, std::size_t instance_count) = 0;
 	public:
 		// High-level API for getting a texture object from file / uncompressed bitmap
-		gfx_api::texture* loadTextureFromFile(const char *filename, gfx_api::texture_type textureType, int maxWidth = -1, int maxHeight = -1);
+		gfx_api::texture* loadTextureFromFile(const char *filename, gfx_api::texture_type textureType, int maxWidth = -1, int maxHeight = -1, bool quiet = false);
 		gfx_api::texture* loadTextureFromUncompressedImage(iV_Image&& image, gfx_api::texture_type textureType, const std::string& filename, int maxWidth = -1, int maxHeight = -1);
 		typedef std::function<std::unique_ptr<iV_Image> (int width, int height, int channels)> GenerateDefaultTextureFunc;
 		gfx_api::texture_array* loadTextureArrayFromFiles(const std::vector<WzString>& filenames, gfx_api::texture_type textureType, int maxWidth = -1, int maxHeight = -1, const GenerateDefaultTextureFunc& defaultTextureGenerator = nullptr, const std::function<void ()>& progressCallback = nullptr, const std::string& debugName = "");

--- a/lib/ivis_opengl/imd.h
+++ b/lib/ivis_opengl/imd.h
@@ -24,6 +24,7 @@
 #include <functional>
 
 struct iIMDShape;
+struct iIMDBaseShape;
 
 #define PIE_NAME				"PIE"  // Pumpkin image export data file
 #define PIE_VER				2
@@ -56,12 +57,12 @@ struct iIMDShape;
 void modelShutdown();
 
 // Enumerate over loaded models
-void enumerateLoadedModels(const std::function<void (const std::string& modelName, iIMDShape& model)>& func);
+void enumerateLoadedModels(const std::function<void (const std::string& modelName, iIMDBaseShape& model)>& func);
 
 /// Get filename of model pointer. This is really slow, so do not abuse for logging
 /// purposes, for example.
-const WzString &modelName(iIMDShape *model);
+const WzString &modelName(const iIMDShape *model);
 
-iIMDShape *modelGet(const WzString &filename);
+iIMDBaseShape *modelGet(const WzString &filename);
 
 #endif

--- a/lib/ivis_opengl/imd.h
+++ b/lib/ivis_opengl/imd.h
@@ -56,6 +56,8 @@ struct iIMDBaseShape;
 
 void modelShutdown();
 
+void modelUpdateTilesetIdx(size_t tilesetIdx);
+
 // Enumerate over loaded models
 void enumerateLoadedModels(const std::function<void (const std::string& modelName, iIMDBaseShape& model)>& func);
 

--- a/lib/ivis_opengl/ivisdef.h
+++ b/lib/ivis_opengl/ivisdef.h
@@ -111,11 +111,13 @@ enum ANIMATION_EVENTS
 	ANIM_EVENT_COUNT
 };
 
+#define WZ_CURRENT_GRAPHICS_OVERRIDES_PREFIX "graphics_overrides/curr"
+
 // A game model will have (potentially) two sets of information:
 // 1. Information used for game state calculations (this is always from the "base" / core model file)
+//		- This is accessible in the `iIMDBaseShape`
 // 2. Information used for display (this may be from the "base" / core model, or a graphics mod overlay display-only model replacement)
-
-#define WZ_CURRENT_GRAPHICS_OVERRIDES_PREFIX "graphics_overrides/curr"
+//		- This is accessible in the `iIMDShape` that can be obtained via `iIMDBaseShape::displayModel()`
 
 struct iIMDShape;
 
@@ -127,15 +129,14 @@ struct iIMDBaseShape
 
 	// SAFE FOR USE IN GAME STATE CALCULATIONS
 
-	Vector3i min = Vector3i(0, 0, 0); // used by: establishTargetHeight (game state calculation), alignStructure (game state calculation), (and then a bunch of display only stuff in effects.cpp and component.cpp)
+	Vector3i min = Vector3i(0, 0, 0); // used by: establishTargetHeight (game state calculation), alignStructure (game state calculation), etc
 	Vector3i max = Vector3i(0, 0, 0);
-	int sradius = 0; // seemingly? display only
-	int radius = 0; // used in game state calculations!!!
+	int sradius = 0;
+	int radius = 0;
 
-	Vector3f ocen = Vector3f(0.f, 0.f, 0.f); // not actually used by anything right now...
+	Vector3f ocen = Vector3f(0.f, 0.f, 0.f);
 
-	// used by game state calculations! (muzzle base location, fire line, actionVisibleTarget, etc)
-	std::vector<Vector3i> connectors;
+	std::vector<Vector3i> connectors; // used by: muzzle base location, fire line, actionVisibleTarget, etc)
 
 	// the display shape used for rendering (*NOT* for any game state calculations!)
 	inline iIMDShape* displayModel() { return m_displayModel.get(); }
@@ -163,23 +164,22 @@ struct TilesetTextureFiles
 	std::string specfile;
 };
 
+// DISPLAY-ONLY
+// NOTE: Do *NOT* use any data from iIMDShape in game state calculations - instead, use the data in an iIMDBaseShape
 struct iIMDShape
 {
 	~iIMDShape();
 
-	Vector3i min = Vector3i(0, 0, 0); // used by: establishTargetHeight (game state calculation), alignStructure (game state calculation), (and then a bunch of display only stuff in effects.cpp and component.cpp)
+	Vector3i min = Vector3i(0, 0, 0);
 	Vector3i max = Vector3i(0, 0, 0);
-	int sradius = 0; // seemingly? display only
-	int radius = 0; // used in game state calculations!!!
+	int sradius = 0;
+	int radius = 0;
 
-	Vector3f ocen = Vector3f(0.f, 0.f, 0.f); // not actually used by anything right now...
+	Vector3f ocen = Vector3f(0.f, 0.f, 0.f);
 
 	std::vector<Vector3i> connectors;
 
-	// DISPLAY-ONLY
-	// do not use any of these variables for game state calculations!
-
-	unsigned int flags = 0; // display only
+	unsigned int flags = 0;
 
 	const iIMDShapeTextures& getTextures() const;
 
@@ -190,7 +190,7 @@ struct iIMDShape
 	size_t nShadowEdges = 0;
 
 	// The old rendering data
-	std::vector<Vector3f> points; // !!! NOTE: THIS IS USED TO *CALCULATE* some of the game state values above on imd load (in _imd_calc_bounds) !!!
+	std::vector<Vector3f> points; // NOTE: This is used to calculate some of the values above on imd load (in _imd_calc_bounds)
 	std::vector<iIMDPoly> polys;
 
 	// Data used for stencil shadows
@@ -218,8 +218,6 @@ struct iIMDShape
 	uint32_t modelLevel = 0;
 
 	std::array<TilesetTextureFiles, 3> tilesetTextureFiles;
-
-	// BOTH:
 
 	std::unique_ptr<iIMDShape> next = nullptr;  // next pie in multilevel pies (NULL for non multilevel !)
 

--- a/lib/ivis_opengl/piedef.h
+++ b/lib/ivis_opengl/piedef.h
@@ -48,7 +48,7 @@ struct iIMDShape;
  */
 /***************************************************************************/
 bool pie_Draw3DShape(iIMDShape *shape, int frame, int team, PIELIGHT colour, int pieFlag, int pieFlagData, const glm::mat4 &modelMatrix, const glm::mat4 &viewMatrix, float stretchDepth = 0.f, bool onlySingleLevel = false);
-void pie_Draw3DButton(iIMDShape *shape, PIELIGHT teamcolour, const glm::mat4 &modelMatrix, const glm::mat4 &viewMatrix);
+void pie_Draw3DButton(const iIMDShape *shape, PIELIGHT teamcolour, const glm::mat4 &modelMatrix, const glm::mat4 &viewMatrix);
 
 void pie_GetResetCounts(size_t *pPieCount, size_t *pPolyCount);
 

--- a/lib/ivis_opengl/piedraw.cpp
+++ b/lib/ivis_opengl/piedraw.cpp
@@ -243,11 +243,12 @@ static gfx_api::buffer* getZeroedVertexBuffer(size_t size)
 	return pZeroedVertexBuffer;
 }
 
-void pie_Draw3DButton(iIMDShape *shape, PIELIGHT teamcolour, const glm::mat4 &modelMatrix, const glm::mat4 &viewMatrix)
+void pie_Draw3DButton(const iIMDShape *shape, PIELIGHT teamcolour, const glm::mat4 &modelMatrix, const glm::mat4 &viewMatrix)
 {
-	auto* tcmask = shape->tcmaskpage != iV_TEX_INVALID ? &pie_Texture(shape->tcmaskpage) : nullptr;
-	auto* normalmap = shape->normalpage != iV_TEX_INVALID ? &pie_Texture(shape->normalpage) : nullptr;
-	auto* specularmap = shape->specularpage != iV_TEX_INVALID ? &pie_Texture(shape->specularpage) : nullptr;
+	const auto& textures = shape->getTextures();
+	auto* tcmask = textures.tcmaskpage != iV_TEX_INVALID ? &pie_Texture(textures.tcmaskpage) : nullptr;
+	auto* normalmap = textures.normalpage != iV_TEX_INVALID ? &pie_Texture(textures.normalpage) : nullptr;
+	auto* specularmap = textures.specularpage != iV_TEX_INVALID ? &pie_Texture(textures.specularpage) : nullptr;
 
 	gfx_api::buffer* pTangentBuffer = (shape->buffers[VBO_TANGENT] != nullptr) ? shape->buffers[VBO_TANGENT] : getZeroedVertexBuffer(shape->vertexCount * 4 * sizeof(gfx_api::gfxFloat));
 
@@ -280,7 +281,7 @@ void pie_Draw3DButton(iIMDShape *shape, PIELIGHT teamcolour, const glm::mat4 &mo
 
 	gfx_api::Draw3DShapeOpaque::get().set_uniforms(globalUniforms, meshUniforms, instanceUniforms);
 
-	gfx_api::Draw3DShapeOpaque::get().bind_textures(&pie_Texture(shape->texpage), tcmask, normalmap, specularmap);
+	gfx_api::Draw3DShapeOpaque::get().bind_textures(&pie_Texture(textures.texpage), tcmask, normalmap, specularmap);
 	gfx_api::Draw3DShapeOpaque::get().bind_vertex_buffers(shape->buffers[VBO_VERTEX], shape->buffers[VBO_NORMAL], shape->buffers[VBO_TEXCOORD], pTangentBuffer);
 	gfx_api::context::get().bind_index_buffer(*shape->buffers[VBO_INDEX], gfx_api::index_type::u16);
 	gfx_api::Draw3DShapeOpaque::get().draw_elements(shape->polys.size() * 3, 0);
@@ -370,9 +371,10 @@ static void draw3dShapeTemplated(const templatedState &lastState, ShaderOnce& gl
 {
 	templatedState currentState = templatedState(shader, shape, pieFlag);
 
-	auto* tcmask = shape->tcmaskpage != iV_TEX_INVALID ? &pie_Texture(shape->tcmaskpage) : nullptr;
-	auto* normalmap = shape->normalpage != iV_TEX_INVALID ? &pie_Texture(shape->normalpage) : nullptr;
-	auto* specularmap = shape->specularpage != iV_TEX_INVALID ? &pie_Texture(shape->specularpage) : nullptr;
+	const auto& textures = shape->getTextures();
+	auto* tcmask = textures.tcmaskpage != iV_TEX_INVALID ? &pie_Texture(textures.tcmaskpage) : nullptr;
+	auto* normalmap = textures.normalpage != iV_TEX_INVALID ? &pie_Texture(textures.normalpage) : nullptr;
+	auto* specularmap = textures.specularpage != iV_TEX_INVALID ? &pie_Texture(textures.specularpage) : nullptr;
 
 	gfx_api::Draw3DShapePerMeshUniforms meshUniforms {
 		tcmask ? 1 : 0, normalmap != nullptr, specularmap != nullptr, shape->buffers[VBO_TANGENT] != nullptr
@@ -398,7 +400,7 @@ static void draw3dShapeTemplated(const templatedState &lastState, ShaderOnce& gl
 		{
 			AdditivePSO::get().set_uniforms_at(1, meshUniforms);
 			AdditivePSO::get().bind_vertex_buffers(shape->buffers[VBO_VERTEX], shape->buffers[VBO_NORMAL], shape->buffers[VBO_TEXCOORD], pTangentBuffer);
-			AdditivePSO::get().bind_textures(&pie_Texture(shape->texpage), tcmask, normalmap, specularmap);
+			AdditivePSO::get().bind_textures(&pie_Texture(textures.texpage), tcmask, normalmap, specularmap);
 		}
 		AdditivePSO::get().set_uniforms_at(2, instanceUniforms);
 		AdditivePSO::get().draw_elements(shape->polys.size() * 3, 0);
@@ -416,7 +418,7 @@ static void draw3dShapeTemplated(const templatedState &lastState, ShaderOnce& gl
 			{
 				AlphaPSO::get().set_uniforms_at(1, meshUniforms);
 				AlphaPSO::get().bind_vertex_buffers(shape->buffers[VBO_VERTEX], shape->buffers[VBO_NORMAL], shape->buffers[VBO_TEXCOORD], pTangentBuffer);
-				AlphaPSO::get().bind_textures(&pie_Texture(shape->texpage), tcmask, normalmap, specularmap);
+				AlphaPSO::get().bind_textures(&pie_Texture(textures.texpage), tcmask, normalmap, specularmap);
 			}
 			AlphaPSO::get().set_uniforms_at(2, instanceUniforms);
 			AlphaPSO::get().draw_elements(shape->polys.size() * 3, 0);
@@ -432,7 +434,7 @@ static void draw3dShapeTemplated(const templatedState &lastState, ShaderOnce& gl
 			{
 				AlphaNoDepthWRTPSO::get().set_uniforms_at(1, meshUniforms);
 				AlphaNoDepthWRTPSO::get().bind_vertex_buffers(shape->buffers[VBO_VERTEX], shape->buffers[VBO_NORMAL], shape->buffers[VBO_TEXCOORD], pTangentBuffer);
-				AlphaNoDepthWRTPSO::get().bind_textures(&pie_Texture(shape->texpage), tcmask, normalmap, specularmap);
+				AlphaNoDepthWRTPSO::get().bind_textures(&pie_Texture(textures.texpage), tcmask, normalmap, specularmap);
 			}
 			AlphaNoDepthWRTPSO::get().set_uniforms_at(2, instanceUniforms);
 			AlphaNoDepthWRTPSO::get().draw_elements(shape->polys.size() * 3, 0);
@@ -449,7 +451,7 @@ static void draw3dShapeTemplated(const templatedState &lastState, ShaderOnce& gl
 		{
 			PremultipliedPSO::get().set_uniforms_at(1, meshUniforms);
 			PremultipliedPSO::get().bind_vertex_buffers(shape->buffers[VBO_VERTEX], shape->buffers[VBO_NORMAL], shape->buffers[VBO_TEXCOORD], pTangentBuffer);
-			PremultipliedPSO::get().bind_textures(&pie_Texture(shape->texpage), tcmask, normalmap, specularmap);
+			PremultipliedPSO::get().bind_textures(&pie_Texture(textures.texpage), tcmask, normalmap, specularmap);
 		}
 		PremultipliedPSO::get().set_uniforms_at(2, instanceUniforms);
 		PremultipliedPSO::get().draw_elements(shape->polys.size() * 3, 0);
@@ -465,7 +467,7 @@ static void draw3dShapeTemplated(const templatedState &lastState, ShaderOnce& gl
 		{
 			OpaquePSO::get().set_uniforms_at(1, meshUniforms);
 			OpaquePSO::get().bind_vertex_buffers(shape->buffers[VBO_VERTEX], shape->buffers[VBO_NORMAL], shape->buffers[VBO_TEXCOORD], pTangentBuffer);
-			OpaquePSO::get().bind_textures(&pie_Texture(shape->texpage), tcmask, normalmap, specularmap);
+			OpaquePSO::get().bind_textures(&pie_Texture(textures.texpage), tcmask, normalmap, specularmap);
 		}
 		OpaquePSO::get().set_uniforms_at(2, instanceUniforms);
 		OpaquePSO::get().draw_elements(shape->polys.size() * 3, 0);
@@ -1342,9 +1344,10 @@ bool InstancedMeshRenderer::DrawAll(uint64_t currentGameFrame, const glm::mat4& 
 template<SHADER_MODE shader, typename Draw3DInstancedPSO>
 static void drawInstanced3dShapeTemplated_Inner(ShaderOnce& globalsOnce, const gfx_api::Draw3DShapeInstancedGlobalUniforms& globalUniforms, const iIMDShape * shape, gfx_api::buffer* instanceDataBuffer, size_t instanceBufferOffset, size_t instance_count)
 {
-	auto* tcmask = shape->tcmaskpage != iV_TEX_INVALID ? &pie_Texture(shape->tcmaskpage) : nullptr;
-	auto* normalmap = shape->normalpage != iV_TEX_INVALID ? &pie_Texture(shape->normalpage) : nullptr;
-	auto* specularmap = shape->specularpage != iV_TEX_INVALID ? &pie_Texture(shape->specularpage) : nullptr;
+	const auto& textures = shape->getTextures();
+	auto* tcmask = textures.tcmaskpage != iV_TEX_INVALID ? &pie_Texture(textures.tcmaskpage) : nullptr;
+	auto* normalmap = textures.normalpage != iV_TEX_INVALID ? &pie_Texture(textures.normalpage) : nullptr;
+	auto* specularmap = textures.specularpage != iV_TEX_INVALID ? &pie_Texture(textures.specularpage) : nullptr;
 
 	gfx_api::Draw3DShapeInstancedPerMeshUniforms meshUniforms {
 		tcmask ? 1 : 0, normalmap != nullptr, specularmap != nullptr, shape->buffers[VBO_TANGENT] != nullptr
@@ -1365,7 +1368,7 @@ static void drawInstanced3dShapeTemplated_Inner(ShaderOnce& globalsOnce, const g
 		std::make_tuple(shape->buffers[VBO_TEXCOORD], 0),
 		std::make_tuple(pTangentBuffer, 0),
 		std::make_tuple(instanceDataBuffer, instanceBufferOffset) });
-	Draw3DInstancedPSO::get().bind_textures(&pie_Texture(shape->texpage), tcmask, normalmap, specularmap, gfx_api::context::get().getDepthTexture());
+	Draw3DInstancedPSO::get().bind_textures(&pie_Texture(textures.texpage), tcmask, normalmap, specularmap, gfx_api::context::get().getDepthTexture());
 
 	Draw3DInstancedPSO::get().draw_elements_instanced(shape->polys.size() * 3, 0, instance_count);
 //	Draw3DInstancedPSO::get().unbind_vertex_buffers(shape->buffers[VBO_VERTEX], shape->buffers[VBO_NORMAL], shape->buffers[VBO_TEXCOORD]);

--- a/lib/ivis_opengl/piedraw.cpp
+++ b/lib/ivis_opengl/piedraw.cpp
@@ -641,9 +641,9 @@ struct ShadowCache {
 	};
 
 	typedef std::unordered_map<ShadowDrawParameters, CachedShadowData> ShadowDrawParametersToCachedDataMap;
-	typedef std::unordered_map<iIMDShape *, ShadowDrawParametersToCachedDataMap, std::hash<iIMDShape *>> ShapeMap;
+	typedef std::unordered_map<const iIMDShape *, ShadowDrawParametersToCachedDataMap, std::hash<const iIMDShape *>> ShapeMap;
 
-	const CachedShadowData* findCacheForShadowDraw(iIMDShape *shape, int flag, int flag_data, const glm::vec4 &light)
+	const CachedShadowData* findCacheForShadowDraw(const iIMDShape *shape, int flag, int flag_data, const glm::vec4 &light)
 	{
 		auto it = shapeMap.find(shape);
 		if (it == shapeMap.end()) {
@@ -1131,7 +1131,7 @@ bool pie_Draw3DShape(iIMDShape *shape, int frame, int team, PIELIGHT colour, int
 			retVal = instancedMeshRenderer.Draw3DShape(pCurrShape, frame, teamcolour, colour, pieFlag, pieFlagData, modelMatrix, viewMatrix, stretchDepth);
 		}
 
-		pCurrShape = pCurrShape->next;
+		pCurrShape = pCurrShape->next.get();
 
 	} while (drawAllLevels && pCurrShape && retVal);
 

--- a/lib/ivis_opengl/pieimage.cpp
+++ b/lib/ivis_opengl/pieimage.cpp
@@ -561,3 +561,22 @@ bool iV_Image::convert_color_order(ColorOrder newOrder)
 	m_colorOrder = newOrder;
 	return true;
 }
+
+bool iV_Image::compare_equal(const iV_Image& other)
+{
+	if (m_width != other.m_width || m_height != other.m_height || m_channels != other.m_channels)
+	{
+		return false;
+	}
+	if (m_colorOrder != other.m_colorOrder)
+	{
+		return false;
+	}
+	if ((m_bmp == nullptr || other.m_bmp == nullptr) && (m_bmp != other.m_bmp))
+	{
+		return false;
+	}
+
+	const size_t sizeOfBuffers = sizeof(unsigned char) * m_width * m_height * m_channels;
+	return memcmp(m_bmp, other.m_bmp, sizeOfBuffers) == 0;
+}

--- a/lib/ivis_opengl/pietypes.h
+++ b/lib/ivis_opengl/pietypes.h
@@ -243,6 +243,8 @@ public:
 
 	bool convert_color_order(ColorOrder newOrder);
 
+	bool compare_equal(const iV_Image& other);
+
 private:
 	bool resizeInternal(const iV_Image& source, int output_w, int output_h, optional<int> alphaChannelOverride = nullopt);
 

--- a/lib/ivis_opengl/png_util.cpp
+++ b/lib/ivis_opengl/png_util.cpp
@@ -214,7 +214,7 @@ bool iV_loadImage_PNG(const char *fileName, iV_Image *image)
 	return true;
 }
 
-bool iV_loadImage_PNG2(const char *fileName, iV_Image& image, bool forceRGBA8 /*= false*/)
+bool iV_loadImage_PNG2(const char *fileName, iV_Image& image, bool forceRGBA8 /*= false*/, bool quietOnOpenFail /*= false*/)
 {
 	unsigned char PNGheader[PNG_BYTES_TO_CHECK];
 	PHYSFS_sint64 readSize;
@@ -234,7 +234,17 @@ bool iV_loadImage_PNG2(const char *fileName, iV_Image& image, bool forceRGBA8 /*
 
 	// Open file
 	PHYSFS_file *fileHandle = PHYSFS_openRead(fileName);
-	ASSERT_OR_RETURN(false, fileHandle != nullptr, "Could not open %s: %s", fileName, WZ_PHYSFS_getLastError());
+	if (fileHandle == nullptr)
+	{
+		if (!quietOnOpenFail)
+		{
+			ASSERT_OR_RETURN(false, fileHandle != nullptr, "Could not open %s: %s", fileName, WZ_PHYSFS_getLastError());
+		}
+		else
+		{
+			return false;
+		}
+	}
 	WZ_PHYSFS_SETBUFFER(fileHandle, 4096)//;
 
 	// Read PNG header from file

--- a/lib/ivis_opengl/png_util.h
+++ b/lib/ivis_opengl/png_util.h
@@ -51,7 +51,7 @@ struct IMGSaveError
  */
 bool iV_loadImage_PNG(const char *fileName, iV_Image *image);
 
-bool iV_loadImage_PNG2(const char *fileName, iV_Image& image, bool forceRGBA8 = false);
+bool iV_loadImage_PNG2(const char *fileName, iV_Image& image, bool forceRGBA8 = false, bool quietOnOpenFail = false);
 
 /*!
  * Load a PNG from a memory buffer into an image

--- a/lib/ivis_opengl/png_util.h
+++ b/lib/ivis_opengl/png_util.h
@@ -86,4 +86,7 @@ IMGSaveError iV_saveImage_PNG_Gray(const char *fileName, const iV_Image *image);
 
 void iV_saveImage_JPEG(const char *fileName, const iV_Image *image);
 
+// For loading and outputting multi-channel (ex. RGB) specular maps as WZ-converted single-channel luma grayscale PNGs
+bool iV_LoadAndSavePNG_AsLumaSingleChannel(const std::string &inputFilename, const std::string &outputFilename, bool check = false);
+
 #endif // _LIBIVIS_COMMON_PNG_H_

--- a/lib/ivis_opengl/tex.cpp
+++ b/lib/ivis_opengl/tex.cpp
@@ -207,14 +207,21 @@ optional<size_t> iV_GetTexture(const char *filename, gfx_api::texture_type textu
 		return it->second;
 	}
 
-	// Try to load it
-	std::string loadPath = "texpages/";
+	// First, try to load from the current graphics_overrides (if enabled)
+	std::string loadPath = WZ_CURRENT_GRAPHICS_OVERRIDES_PREFIX "/texpages/";
 	loadPath += filename;
-	gfx_api::texture *pTexture = gfx_api::context::get().loadTextureFromFile(loadPath.c_str(), textureType, maxWidth, maxHeight);
+	gfx_api::texture *pTexture = gfx_api::context::get().loadTextureFromFile(loadPath.c_str(), textureType, maxWidth, maxHeight, true);
 	if (!pTexture)
 	{
-		debug(LOG_ERROR, "Failed to load %s", loadPath.c_str());
-		return nullopt;
+		// Try to load it from the regular path
+		loadPath = "texpages/";
+		loadPath += filename;
+		pTexture = gfx_api::context::get().loadTextureFromFile(loadPath.c_str(), textureType, maxWidth, maxHeight);
+		if (!pTexture)
+		{
+			debug(LOG_ERROR, "Failed to load %s", loadPath.c_str());
+			return nullopt;
+		}
 	}
 
 	size_t page = pie_AddTexPage(pTexture, path.c_str(), textureType);

--- a/src/atmos.cpp
+++ b/src/atmos.cpp
@@ -161,7 +161,7 @@ static void processParticle(ATPART *psPart)
 						pos.z = static_cast<int>(psPart->position.z);
 						pos.y = groundHeight;
 						effectSetSize(60);
-						addEffect(&pos, EFFECT_EXPLOSION, EXPLOSION_TYPE_SPECIFIED, true, getImdFromIndex(MI_SPLASH), 0);
+						addEffect(&pos, EFFECT_EXPLOSION, EXPLOSION_TYPE_SPECIFIED, true, getImdFromIndex(MI_SPLASH)->displayModel(), 0);
 					}
 				}
 				return;
@@ -318,7 +318,7 @@ static inline void renderParticleInternal(ATPART *psPart, const glm::mat4 &viewM
 	/* Make it face camera */
 	/* Scale it... */
 	const glm::mat4 modelMatrix = glm::translate(dv) * rotateScaleMatrix;
-	pie_Draw3DShape(psPart->imd, 0, 0, WZCOL_WHITE, 0, 0, modelMatrix, viewMatrix);
+	pie_Draw3DShape(psPart->imd->displayModel(), 0, 0, WZCOL_WHITE, 0, 0, modelMatrix, viewMatrix);
 	/* Draw it... */
 }
 

--- a/src/atmos.h
+++ b/src/atmos.h
@@ -31,7 +31,7 @@ struct ATPART
 	UDWORD		size;
 	Vector3f	position;
 	Vector3f	velocity;
-	iIMDShape	*imd;
+	iIMDBaseShape	*imd;
 };
 
 enum WT_CLASS

--- a/src/basedef.h
+++ b/src/basedef.h
@@ -124,8 +124,10 @@ struct BASE_OBJECT : public SIMPLE_OBJECT
 	UDWORD              periodicalDamage;                 ///< How much damage has been done since the object entered the fire
 	std::vector<TILEPOS> watchedTiles;              ///< Variable size array of watched tiles, empty for features
 
+	// DISPLAY-ONLY (*NOT* for game state calculations)
 	UDWORD              timeAnimationStarted;       ///< Animation start time, zero for do not animate
 	UBYTE               animationEvent;             ///< If animation start time > 0, this points to which animation to run
+	//
 
 	unsigned            numWeaps;
 	WEAPON              asWeaps[MAX_WEAPONS];

--- a/src/bucket3d.cpp
+++ b/src/bucket3d.cpp
@@ -108,7 +108,7 @@ static SDWORD bucketCalculateZ(RENDER_TYPE objectType, void *pObject, const glm:
 		{
 
 			//the weapon stats holds the reference to which graphic to use
-			pImd = ((PROJECTILE *)pObject)->psWStats->pInFlightGraphic;
+			pImd = ((PROJECTILE *)pObject)->psWStats->pInFlightGraphic->displayModel();
 
 			psSimpObj = (SIMPLE_OBJECT *) pObject;
 			position.x = psSimpObj->pos.x;
@@ -239,7 +239,7 @@ static SDWORD bucketCalculateZ(RENDER_TYPE objectType, void *pObject, const glm:
 		if (z > 0)
 		{
 			//particle use the image radius
-			pImd = getImdFromIndex(MI_BLIP_ENEMY);//use MI_BLIP_ENEMY as all are same radius
+			pImd = getDisplayImdFromIndex(MI_BLIP_ENEMY);//use MI_BLIP_ENEMY as all are same radius
 			radius = pImd->radius;
 			radius *= SCALE_DEPTH;
 			radius /= z;
@@ -348,20 +348,20 @@ void bucketAddTypeToList(RENDER_TYPE objectType, void *pObject, const glm::mat4 
 		}
 		break;
 	case RENDER_DROID:
-		pie = BODY_IMD(((DROID *)pObject), 0);
+		pie = BODY_IMD(((DROID *)pObject), 0)->displayModel();
 		z = INT32_MAX - pie->texpage;
 		break;
 	case RENDER_STRUCTURE:
-		pie = ((STRUCTURE *)pObject)->sDisplay.imd;
+		pie = ((STRUCTURE *)pObject)->sDisplay.imd->displayModel();
 		z = INT32_MAX - pie->texpage;
 		break;
 	case RENDER_FEATURE:
-		pie = ((FEATURE *)pObject)->sDisplay.imd;
+		pie = ((FEATURE *)pObject)->sDisplay.imd->displayModel();
 		z = INT32_MAX - pie->texpage;
 		break;
 	case RENDER_DELIVPOINT:
 		pie = pAssemblyPointIMDs[((FLAG_POSITION *)pObject)->
-		                         factoryType][((FLAG_POSITION *)pObject)->factoryInc];
+		                         factoryType][((FLAG_POSITION *)pObject)->factoryInc]->displayModel();
 		z = INT32_MAX - pie->texpage;
 		break;
 	case RENDER_PARTICLE:

--- a/src/bucket3d.cpp
+++ b/src/bucket3d.cpp
@@ -339,7 +339,7 @@ void bucketAddTypeToList(RENDER_TYPE objectType, void *pObject, const glm::mat4 
 
 		case EFFECT_WAYPOINT:
 			pie = ((EFFECT *)pObject)->imd;
-			z = INT32_MAX - pie->texpage;
+			z = INT32_MAX - pie->getTextures().texpage;
 			break;
 
 		default:
@@ -349,20 +349,20 @@ void bucketAddTypeToList(RENDER_TYPE objectType, void *pObject, const glm::mat4 
 		break;
 	case RENDER_DROID:
 		pie = BODY_IMD(((DROID *)pObject), 0)->displayModel();
-		z = INT32_MAX - pie->texpage;
+		z = INT32_MAX - pie->getTextures().texpage;
 		break;
 	case RENDER_STRUCTURE:
 		pie = ((STRUCTURE *)pObject)->sDisplay.imd->displayModel();
-		z = INT32_MAX - pie->texpage;
+		z = INT32_MAX - pie->getTextures().texpage;
 		break;
 	case RENDER_FEATURE:
 		pie = ((FEATURE *)pObject)->sDisplay.imd->displayModel();
-		z = INT32_MAX - pie->texpage;
+		z = INT32_MAX - pie->getTextures().texpage;
 		break;
 	case RENDER_DELIVPOINT:
 		pie = pAssemblyPointIMDs[((FLAG_POSITION *)pObject)->
 		                         factoryType][((FLAG_POSITION *)pObject)->factoryInc]->displayModel();
-		z = INT32_MAX - pie->texpage;
+		z = INT32_MAX - pie->getTextures().texpage;
 		break;
 	case RENDER_PARTICLE:
 		z = 0;

--- a/src/component.h
+++ b/src/component.h
@@ -26,6 +26,8 @@
 #include "structuredef.h"
 #include <glm/fwd.hpp>
 
+struct iIMDShape;
+
 /*
 	Header file for component.c
 	Pumpkin Studios, EIDOS Interactive.

--- a/src/displaydef.h
+++ b/src/displaydef.h
@@ -24,7 +24,7 @@
 #ifndef __INCLUDED_DISPLAYDEF_H__
 #define __INCLUDED_DISPLAYDEF_H__
 
-struct iIMDShape;
+struct iIMDBaseShape;
 
 // for mouse scrolling. (how many pixels from the edge before pointer scrolls the screen in a direction)
 #define	BOUNDARY_X	(2)
@@ -32,10 +32,10 @@ struct iIMDShape;
 
 struct SCREEN_DISP_DATA
 {
-	iIMDShape	*imd;
-	UDWORD		frameNumber;		// last frame it was drawn
-	UDWORD		screenX, screenY;
-	UDWORD		screenR;
+	iIMDBaseShape	*imd;
+	UDWORD			frameNumber;		// last frame it was drawn
+	UDWORD			screenX, screenY;
+	UDWORD			screenR;
 };
 
 #endif // __INCLUDED_DISPLAYDEF_H__

--- a/src/effects.cpp
+++ b/src/effects.cpp
@@ -350,7 +350,7 @@ static void renderDroidDeathAnimationEffect(const EFFECT *psEffect, const glm::m
 	while (strImd)
 	{
 		drawShape(strImd, timeAnimationStarted, psEffect->player, brightness, pieFlag, iPieData, modelMatrix, viewMatrix);
-		strImd = strImd->next;
+		strImd = strImd->next.get();
 	}
 }
 
@@ -1212,11 +1212,11 @@ static bool updateDestruction(EFFECT *psEffect)
 		case 10:
 			if (psEffect->type == DESTRUCTION_TYPE_STRUCTURE)
 			{
-				addEffect(&pos, EFFECT_GRAVITON, GRAVITON_TYPE_EMITTING_ST, true, getRandomDebrisImd(), 0);
+				addEffect(&pos, EFFECT_GRAVITON, GRAVITON_TYPE_EMITTING_ST, true, getRandomDebrisImd()->displayModel(), 0);
 			}
 			else
 			{
-				addEffect(&pos, EFFECT_GRAVITON, GRAVITON_TYPE_EMITTING_DR, true, getRandomDebrisImd(), 0);
+				addEffect(&pos, EFFECT_GRAVITON, GRAVITON_TYPE_EMITTING_DR, true, getRandomDebrisImd()->displayModel(), 0);
 			}
 			break;
 		case 11:
@@ -1460,7 +1460,7 @@ static void renderBloodEffect(const EFFECT *psEffect, const glm::mat4 &viewMatri
 	modelMatrix *= glm::rotate(UNDEG(-playerPos.r.y), glm::vec3(0.f, 1.f, 0.f)) * glm::rotate(UNDEG(-playerPos.r.x), glm::vec3(1.f, 0.f, 0.f))
 	               * glm::scale(glm::vec3(psEffect->size / 100.f));
 
-	pie_Draw3DShape(getImdFromIndex(MI_BLOOD), psEffect->frameNumber, 0, WZCOL_WHITE, pie_TRANSLUCENT | pie_NODEPTHWRITE, EFFECT_BLOOD_TRANSPARENCY, modelMatrix, viewMatrix);
+	pie_Draw3DShape(getDisplayImdFromIndex(MI_BLOOD), psEffect->frameNumber, 0, WZCOL_WHITE, pie_TRANSLUCENT | pie_NODEPTHWRITE, EFFECT_BLOOD_TRANSPARENCY, modelMatrix, viewMatrix);
 }
 
 static void renderDestructionEffect(const EFFECT *psEffect, const glm::mat4 &viewMatrix)
@@ -1738,7 +1738,7 @@ void	effectSetupFirework(EFFECT *psEffect)
 		psEffect->lifeSpan = GAME_TICKS_PER_SEC * 3;
 		psEffect->radius = 80 + rand() % 150;
 		psEffect->size = 300 + rand() % 300;	//height it goes off
-		psEffect->imd = getImdFromIndex(MI_FIREWORK); // not actually drawn
+		psEffect->imd = getDisplayImdFromIndex(MI_FIREWORK); // not actually drawn
 	}
 	else
 	{
@@ -1751,17 +1751,17 @@ void	effectSetupFirework(EFFECT *psEffect)
 		switch (rand() % 3)
 		{
 		case 0:
-			psEffect->imd = getImdFromIndex(MI_FIREWORK);
+			psEffect->imd = getDisplayImdFromIndex(MI_FIREWORK);
 			psEffect->size = 45;	//size of graphic
 			break;
 		case 1:
-			psEffect->imd = getImdFromIndex(MI_SNOW);
+			psEffect->imd = getDisplayImdFromIndex(MI_SNOW);
 			SET_CYCLIC(psEffect);
 			psEffect->size = 60;	//size of graphic
 
 			break;
 		default:
-			psEffect->imd = getImdFromIndex(MI_FLAME);
+			psEffect->imd = getDisplayImdFromIndex(MI_FLAME);
 			psEffect->size = 40;	//size of graphic
 
 
@@ -1802,35 +1802,35 @@ void	effectSetupSmoke(EFFECT *psEffect)
 	switch (psEffect->type)
 	{
 	case SMOKE_TYPE_DRIFTING:
-		psEffect->imd = getImdFromIndex(MI_SMALL_SMOKE);
+		psEffect->imd = getDisplayImdFromIndex(MI_SMALL_SMOKE);
 		psEffect->lifeSpan = (UWORD)NORMAL_SMOKE_LIFESPAN;
 		psEffect->velocity.y = (float)(35 + rand() % 30);
 		psEffect->baseScale = 40;
 		break;
 	case SMOKE_TYPE_DRIFTING_HIGH:
-		psEffect->imd = getImdFromIndex(MI_SMALL_SMOKE);
+		psEffect->imd = getDisplayImdFromIndex(MI_SMALL_SMOKE);
 		psEffect->lifeSpan = (UWORD)NORMAL_SMOKE_LIFESPAN;
 		psEffect->velocity.y = (float)(40 + rand() % 45);
 		psEffect->baseScale = 25;
 		break;
 	case SMOKE_TYPE_DRIFTING_SMALL:
-		psEffect->imd = getImdFromIndex(MI_SMALL_SMOKE);
+		psEffect->imd = getDisplayImdFromIndex(MI_SMALL_SMOKE);
 		psEffect->lifeSpan = (UWORD)SMALL_SMOKE_LIFESPAN;
 		psEffect->velocity.y = (float)(25 + rand() % 35);
 		psEffect->baseScale = 17;
 		break;
 	case SMOKE_TYPE_BILLOW:
-		psEffect->imd = getImdFromIndex(MI_SMALL_SMOKE);
+		psEffect->imd = getDisplayImdFromIndex(MI_SMALL_SMOKE);
 		psEffect->lifeSpan = (UWORD)SMALL_SMOKE_LIFESPAN;
 		psEffect->velocity.y = (float)(10 + rand() % 20);
 		psEffect->baseScale = 80;
 		break;
 	case SMOKE_TYPE_STEAM:
-		psEffect->imd = getImdFromIndex(MI_SMALL_STEAM);
+		psEffect->imd = getDisplayImdFromIndex(MI_SMALL_STEAM);
 		psEffect->velocity.y = (float)(rand() % 5);
 		break;
 	case SMOKE_TYPE_TRAIL:
-		psEffect->imd = getImdFromIndex(MI_TRAIL);
+		psEffect->imd = getDisplayImdFromIndex(MI_TRAIL);
 		psEffect->lifeSpan = TRAIL_SMOKE_LIFESPAN;
 		psEffect->velocity.y = (float)(5 + rand() % 10);
 		psEffect->baseScale = 25;
@@ -1918,61 +1918,61 @@ void effectSetupExplosion(EFFECT *psEffect)
 		switch (psEffect->type)
 		{
 		case EXPLOSION_TYPE_SMALL:
-			psEffect->imd = getImdFromIndex(MI_EXPLOSION_SMALL);
+			psEffect->imd = getDisplayImdFromIndex(MI_EXPLOSION_SMALL);
 			psEffect->size = (UBYTE)((6 * EXPLOSION_SIZE) / 5);
 			break;
 		case EXPLOSION_TYPE_VERY_SMALL:
-			psEffect->imd = getImdFromIndex(MI_EXPLOSION_SMALL);
+			psEffect->imd = getDisplayImdFromIndex(MI_EXPLOSION_SMALL);
 			psEffect->size = (UBYTE)(BASE_FLAME_SIZE + auxVar);
 			break;
 		case EXPLOSION_TYPE_MEDIUM:
-			psEffect->imd = getImdFromIndex(MI_EXPLOSION_MEDIUM);
+			psEffect->imd = getDisplayImdFromIndex(MI_EXPLOSION_MEDIUM);
 			psEffect->size = (UBYTE)EXPLOSION_SIZE;
 			break;
 		case EXPLOSION_TYPE_LARGE:
-			psEffect->imd = getImdFromIndex(MI_EXPLOSION_MEDIUM);
+			psEffect->imd = getDisplayImdFromIndex(MI_EXPLOSION_MEDIUM);
 			psEffect->size = (UBYTE)EXPLOSION_SIZE * 2;
 			break;
 		case EXPLOSION_TYPE_FLAMETHROWER:
-			psEffect->imd = getImdFromIndex(MI_FLAME);
+			psEffect->imd = getDisplayImdFromIndex(MI_FLAME);
 			psEffect->size = (UBYTE)(BASE_FLAME_SIZE + auxVar);
 			break;
 		case EXPLOSION_TYPE_LASER:
-			psEffect->imd = getImdFromIndex(MI_FLAME);	// change this
+			psEffect->imd = getDisplayImdFromIndex(MI_FLAME);	// change this
 			psEffect->size = (UBYTE)(BASE_LASER_SIZE + auxVar);
 			break;
 		case EXPLOSION_TYPE_DISCOVERY:
-			psEffect->imd = getImdFromIndex(MI_TESLA);	// change this
+			psEffect->imd = getDisplayImdFromIndex(MI_TESLA);	// change this
 			psEffect->size = DISCOVERY_SIZE;
 			break;
 		case EXPLOSION_TYPE_FLARE:
-			psEffect->imd = getImdFromIndex(MI_MFLARE);
+			psEffect->imd = getDisplayImdFromIndex(MI_MFLARE);
 			psEffect->size = FLARE_SIZE;
 			break;
 		case EXPLOSION_TYPE_TESLA:
-			psEffect->imd = getImdFromIndex(MI_TESLA);
+			psEffect->imd = getDisplayImdFromIndex(MI_TESLA);
 			psEffect->size = TESLA_SIZE;
 			psEffect->velocity.y = (float)TESLA_SPEED;
 			break;
 
 		case EXPLOSION_TYPE_KICKUP:
-			psEffect->imd = getImdFromIndex(MI_KICK);
+			psEffect->imd = getDisplayImdFromIndex(MI_KICK);
 			psEffect->size = 100;
 			break;
 		case EXPLOSION_TYPE_PLASMA:
-			psEffect->imd = getImdFromIndex(MI_PLASMA);
+			psEffect->imd = getDisplayImdFromIndex(MI_PLASMA);
 			psEffect->size = BASE_PLASMA_SIZE;
 			psEffect->velocity.y = 0.0f;
 			break;
 		case EXPLOSION_TYPE_LAND_LIGHT:
-			psEffect->imd = getImdFromIndex(MI_LANDING);
+			psEffect->imd = getDisplayImdFromIndex(MI_LANDING);
 			psEffect->size = 120;
 			psEffect->specific = ellSpec;
 			psEffect->velocity.y = 0.0f;
 			SET_ESSENTIAL(psEffect);		// Landing lights are permanent and cyclic
 			break;
 		case EXPLOSION_TYPE_SHOCKWAVE:
-			psEffect->imd = getImdFromIndex(MI_SHOCK);
+			psEffect->imd = getDisplayImdFromIndex(MI_SHOCK);
 			psEffect->size = 50;
 			psEffect->velocity.y = 0.0f;
 			break;
@@ -2042,7 +2042,7 @@ void	effectSetupConstruction(EFFECT *psEffect)
 	psEffect->velocity.z = 0.f;//(1-rand()%3);
 	psEffect->velocity.y = (float)(0 - rand() % 3);
 	psEffect->frameDelay = (UWORD)CONSTRUCTION_FRAME_DELAY;
-	psEffect->imd = getImdFromIndex(MI_CONSTRUCTION);
+	psEffect->imd = getDisplayImdFromIndex(MI_CONSTRUCTION);
 	psEffect->lifeSpan = CONSTRUCTION_LIFESPAN;
 
 	/* These effects always face you */
@@ -2074,7 +2074,7 @@ void	effectSetupFire(EFFECT *psEffect)
 
 void	effectSetupWayPoint(EFFECT *psEffect)
 {
-	psEffect->imd = pProximityMsgIMD;
+	psEffect->imd = (pProximityMsgIMD) ? pProximityMsgIMD->displayModel() : nullptr;
 
 	/* These effects musnt make way for others */
 	SET_ESSENTIAL(psEffect);
@@ -2085,7 +2085,7 @@ static void effectSetupBlood(EFFECT *psEffect)
 {
 	psEffect->frameDelay = BLOOD_FRAME_DELAY;
 	psEffect->velocity.y = (float)BLOOD_FALL_SPEED;
-	psEffect->imd = getImdFromIndex(MI_BLOOD);
+	psEffect->imd = getDisplayImdFromIndex(MI_BLOOD);
 	psEffect->size = (UBYTE)BLOOD_SIZE;
 }
 
@@ -2245,6 +2245,8 @@ static void effectStructureUpdates()
 				continue;
 			}
 
+			iIMDShape *pDisplayModel = psStructure->sDisplay.imd->displayModel();
+
 			/* Factories puff out smoke, power stations puff out tesla stuff */
 			switch (psStructure->pStructureType->type)
 			{
@@ -2255,21 +2257,23 @@ static void effectStructureUpdates()
 					We're a factory, so better puff out a bit of steam
 					Complete hack with the magic numbers - just for IAN demo
 				*/
-				if (psStructure->sDisplay.imd->nconnectors > 0)
+				// Display only - use the display model
+				if (pDisplayModel->connectors.size() > 0)
 				{
-					unsigned int orderAdjustment = frameNumber % psStructure->sDisplay.imd->nconnectors;
-					for (unsigned int idx = 0; idx < psStructure->sDisplay.imd->nconnectors; ++idx)
+					unsigned int numConnectors = static_cast<unsigned int>(pDisplayModel->connectors.size());;
+					unsigned int orderAdjustment = frameNumber % numConnectors;
+					for (unsigned int idx = 0; idx < numConnectors; ++idx)
 					{
 						Vector3i eventPos = psStructure->pos.xzy() + Affine3F().RotY(psStructure->rot.direction)*Vector3i(
-												psStructure->sDisplay.imd->connectors[idx].x,
-												psStructure->sDisplay.imd->connectors[idx].z,
-												-psStructure->sDisplay.imd->connectors[idx].y
+												pDisplayModel->connectors[idx].x,
+												pDisplayModel->connectors[idx].z,
+												-pDisplayModel->connectors[idx].y
 											);
 
 						unsigned int orderIdx = idx + orderAdjustment;
-						if (orderIdx >= psStructure->sDisplay.imd->nconnectors)
+						if (orderIdx >= numConnectors)
 						{
-							orderIdx = orderIdx - psStructure->sDisplay.imd->nconnectors;
+							orderIdx = orderIdx - numConnectors;
 						}
 						unsigned effectStartTime = graphicsTime + static_cast<UDWORD>(150 * orderIdx);
 						addEffect(&eventPos, EFFECT_SMOKE, SMOKE_TYPE_STEAM, false, nullptr, 0, effectStartTime);
@@ -2385,7 +2389,8 @@ bool readFXData(const char *fileName)
 			WzString imd_name = ini.value("imd_name").toWzString();
 			if (!imd_name.isEmpty())
 			{
-				curEffect->imd = modelGet(imd_name);
+				auto baseImd = modelGet(imd_name);
+				curEffect->imd = (baseImd) ? baseImd->displayModel() : nullptr;
 			}
 		}
 		else

--- a/src/faction.cpp
+++ b/src/faction.cpp
@@ -23,6 +23,7 @@
 #include "faction.h"
 #include "lib/framework/frame.h"
 #include "lib/netplay/netplay.h"
+#include "lib/ivis_opengl/ivisdef.h"
 #include <array>
 
 std::array<FACTION, NUM_FACTIONS> getInitialFactionsMappingTable()
@@ -142,7 +143,7 @@ optional<WzString> getFactionModelName(const FactionID faction, const WzString& 
 	return getFactionModelName(getFactionByID(faction), normalFactionName);
 }
 
-iIMDShape* getFactionIMD(const FACTION *faction, iIMDShape* imd)
+iIMDShape* getFactionDisplayIMD(const FACTION *faction, iIMDShape* imd)
 {
 	auto factionModelName = getFactionModelName(faction, modelName(imd));
 	if (!factionModelName.has_value())
@@ -151,7 +152,8 @@ iIMDShape* getFactionIMD(const FACTION *faction, iIMDShape* imd)
 	}
 	else
 	{
-		return modelGet(factionModelName.value());
+		auto baseModel = modelGet(factionModelName.value());
+		return (baseModel) ? baseModel->displayModel() : imd;
 	}
 }
 

--- a/src/faction.h
+++ b/src/faction.h
@@ -44,7 +44,7 @@ struct FACTION {
 void reinitFactionsMapping();
 
 optional<WzString> getFactionModelName(const FactionID faction, const WzString& normalFactionName);
-iIMDShape* getFactionIMD(const FACTION *faction, iIMDShape* imd);
+iIMDShape* getFactionDisplayIMD(const FACTION *faction, iIMDShape* imd); // DISPLAY ONLY
 
 const FACTION* getPlayerFaction(uint8_t player);
 const FACTION* getFactionByID(FactionID faction);

--- a/src/feature.cpp
+++ b/src/feature.cpp
@@ -467,8 +467,8 @@ bool destroyFeature(FEATURE *psDel, unsigned impactTime)
 			pos.x = psDel->pos.x;
 			pos.z = psDel->pos.y;
 			pos.y = psDel->pos.z;
-			addEffect(&pos, EFFECT_DESTRUCTION, DESTRUCTION_TYPE_SKYSCRAPER, true, psDel->sDisplay.imd, 0, impactTime);
-			initPerimeterSmoke(psDel->sDisplay.imd, pos);
+			addEffect(&pos, EFFECT_DESTRUCTION, DESTRUCTION_TYPE_SKYSCRAPER, true, psDel->sDisplay.imd->displayModel(), 0, impactTime);
+			initPerimeterSmoke(psDel->sDisplay.imd->displayModel(), pos);
 
 			shakeStart(250); // small shake
 		}

--- a/src/featuredef.h
+++ b/src/featuredef.h
@@ -50,7 +50,7 @@ struct FEATURE_STATS : public BASE_STATS
 
 	FEATURE_TYPE    subType = FEAT_COUNT;   ///< type of feature
 
-	iIMDShape      *psImd = nullptr;        ///< Graphic for the feature
+	iIMDBaseShape   *psImd = nullptr;        ///< Graphic for the feature
 	UWORD           baseWidth = 0;          ///< The width of the base in tiles
 	UWORD           baseBreadth = 0;        ///< The breadth of the base in tiles
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1795,6 +1795,17 @@ bool stageThreeInitialise()
 
 	loopMissionState = LMS_NORMAL;
 
+	// preload model textures for current tileset
+	size_t modelTilesetIdx = static_cast<size_t>(currentMapTileset);
+	modelUpdateTilesetIdx(modelTilesetIdx);
+	enumerateLoadedModels([](const std::string &modelName, iIMDBaseShape &s){
+		for (iIMDShape *pDisplayShape = s.displayModel(); pDisplayShape != nullptr; pDisplayShape = pDisplayShape->next.get())
+		{
+			pDisplayShape->getTextures();
+		}
+	});
+	resDoResLoadCallback();		// do callback.
+
 	if (!InitRadar()) 	// After resLoad cause it needs the game palette initialised.
 	{
 		return false;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -690,13 +690,17 @@ bool rebuildSearchPath(searchPathMode mode, bool force, const char *current_map,
 				// Add plain dir
 				WZ_PHYSFS_MountSearchPathWrapper(curSearchPath->path.c_str(), NULL, PHYSFS_APPEND);
 
-				if (terrainQualityOverrideBasePath.has_value())
+				if (terrainQualityOverrideBasePath.has_value() && !loadedTerrainTextureOverrides)
 				{
 					// Add terrain quality override files
 					tmpstr = curSearchPath->path + terrainQualityOverrideBasePath.value();
 					loadedTerrainTextureOverrides = WZ_PHYSFS_MountSearchPathWrapper(tmpstr.c_str(), NULL, PHYSFS_APPEND) || loadedTerrainTextureOverrides;
 					tmpstr += ".wz";
 					loadedTerrainTextureOverrides = WZ_PHYSFS_MountSearchPathWrapper(tmpstr.c_str(), NULL, PHYSFS_APPEND) || loadedTerrainTextureOverrides;
+					if (loadedTerrainTextureOverrides)
+					{
+						debug(LOG_INFO, "Loaded terrain overrides from: %s", curSearchPath->path.c_str());
+					}
 				}
 
 				// Add base files
@@ -775,13 +779,17 @@ bool rebuildSearchPath(searchPathMode mode, bool force, const char *current_map,
 				// Add plain dir
 				WZ_PHYSFS_MountSearchPathWrapper(curSearchPath->path.c_str(), NULL, PHYSFS_APPEND);
 
-				if (terrainQualityOverrideBasePath.has_value())
+				if (terrainQualityOverrideBasePath.has_value() && !loadedTerrainTextureOverrides)
 				{
 					// Add terrain quality override files
 					tmpstr = curSearchPath->path + terrainQualityOverrideBasePath.value();
 					loadedTerrainTextureOverrides = WZ_PHYSFS_MountSearchPathWrapper(tmpstr.c_str(), NULL, PHYSFS_APPEND) || loadedTerrainTextureOverrides;
 					tmpstr += ".wz";
 					loadedTerrainTextureOverrides = WZ_PHYSFS_MountSearchPathWrapper(tmpstr.c_str(), NULL, PHYSFS_APPEND) || loadedTerrainTextureOverrides;
+					if (loadedTerrainTextureOverrides)
+					{
+						debug(LOG_INFO, "Loaded terrain overrides from: %s", curSearchPath->path.c_str());
+					}
 				}
 
 				// Add base files

--- a/src/intdisplay.cpp
+++ b/src/intdisplay.cpp
@@ -1427,7 +1427,7 @@ BASE_STATS *DroidGetBuildStats(DROID *Droid)
 	return nullptr;
 }
 
-iIMDShape *DroidGetIMD(DROID *Droid)
+iIMDBaseShape *DroidGetIMD(DROID *Droid)
 {
 	return Droid->sDisplay.imd;
 }
@@ -1524,7 +1524,7 @@ bool StatIsFeature(BASE_STATS const *Stat)
 	return Stat->hasType(STAT_FEATURE);
 }
 
-iIMDShape *StatGetStructureIMD(BASE_STATS *Stat, UDWORD Player)
+iIMDBaseShape *StatGetStructureIMD(BASE_STATS *Stat, UDWORD Player)
 {
 	(void)Player;
 	return ((STRUCTURE_STATS *)Stat)->pIMD[0];
@@ -1551,7 +1551,7 @@ COMPONENT_TYPE StatIsComponent(BASE_STATS *Stat)
 	}
 }
 
-bool StatGetComponentIMD(BASE_STATS *Stat, SDWORD compID, iIMDShape **CompIMD, iIMDShape **MountIMD)
+bool StatGetComponentIMD(BASE_STATS *Stat, SDWORD compID, iIMDShape **CompIMD, iIMDShape **MountIMD) // DISPLAY ONLY
 {
 	WEAPON_STATS		*psWStat;
 
@@ -1561,42 +1561,42 @@ bool StatGetComponentIMD(BASE_STATS *Stat, SDWORD compID, iIMDShape **CompIMD, i
 	switch (compID)
 	{
 	case COMP_BODY:
-		*CompIMD = ((COMPONENT_STATS *)Stat)->pIMD;
+		*CompIMD = ((COMPONENT_STATS *)Stat)->pIMD->displayModel();
 		return true;
 
 	case COMP_BRAIN:
 		psWStat = ((BRAIN_STATS *)Stat)->psWeaponStat;
-		*MountIMD = psWStat->pMountGraphic;
-		*CompIMD = psWStat->pIMD;
+		*MountIMD = psWStat->pMountGraphic->displayModel();
+		*CompIMD = psWStat->pIMD->displayModel();
 		return true;
 
 	case COMP_WEAPON:
-		*MountIMD = ((WEAPON_STATS *)Stat)->pMountGraphic;
-		*CompIMD = ((COMPONENT_STATS *)Stat)->pIMD;
+		*MountIMD = ((WEAPON_STATS *)Stat)->pMountGraphic->displayModel();
+		*CompIMD = ((COMPONENT_STATS *)Stat)->pIMD->displayModel();
 		return true;
 
 	case COMP_SENSOR:
-		*MountIMD = ((SENSOR_STATS *)Stat)->pMountGraphic;
-		*CompIMD = ((COMPONENT_STATS *)Stat)->pIMD;
+		*MountIMD = ((SENSOR_STATS *)Stat)->pMountGraphic->displayModel();
+		*CompIMD = ((COMPONENT_STATS *)Stat)->pIMD->displayModel();
 		return true;
 
 	case COMP_ECM:
-		*MountIMD = ((ECM_STATS *)Stat)->pMountGraphic;
-		*CompIMD = ((COMPONENT_STATS *)Stat)->pIMD;
+		*MountIMD = ((ECM_STATS *)Stat)->pMountGraphic->displayModel();
+		*CompIMD = ((COMPONENT_STATS *)Stat)->pIMD->displayModel();
 		return true;
 
 	case COMP_CONSTRUCT:
-		*MountIMD = ((CONSTRUCT_STATS *)Stat)->pMountGraphic;
-		*CompIMD = ((COMPONENT_STATS *)Stat)->pIMD;
+		*MountIMD = ((CONSTRUCT_STATS *)Stat)->pMountGraphic->displayModel();
+		*CompIMD = ((COMPONENT_STATS *)Stat)->pIMD->displayModel();
 		return true;
 
 	case COMP_PROPULSION:
-		*CompIMD = ((COMPONENT_STATS *)Stat)->pIMD;
+		*CompIMD = ((COMPONENT_STATS *)Stat)->pIMD->displayModel();
 		return true;
 
 	case COMP_REPAIRUNIT:
-		*MountIMD = ((REPAIR_STATS *)Stat)->pMountGraphic;
-		*CompIMD = ((COMPONENT_STATS *)Stat)->pIMD;
+		*MountIMD = ((REPAIR_STATS *)Stat)->pMountGraphic->displayModel();
+		*CompIMD = ((COMPONENT_STATS *)Stat)->pIMD->displayModel();
 		return true;
 
 	case COMP_NUMCOMPONENTS:
@@ -1612,7 +1612,7 @@ bool StatIsResearch(BASE_STATS *Stat)
 	return Stat->hasType(STAT_RESEARCH);
 }
 
-static void StatGetResearchImage(BASE_STATS *psStat, AtlasImage *image, iIMDShape **Shape, BASE_STATS **ppGraphicData, bool drawTechIcon)
+static void StatGetResearchImage(BASE_STATS *psStat, AtlasImage *image, iIMDShape **Shape, BASE_STATS **ppGraphicData, bool drawTechIcon) // DISPLAY ONLY
 {
 	if (drawTechIcon && ((RESEARCH *)psStat)->iconID != NO_RESEARCH_ICON)
 	{
@@ -1628,7 +1628,7 @@ static void StatGetResearchImage(BASE_STATS *psStat, AtlasImage *image, iIMDShap
 	else
 	{
 		//no stat so just just the IMD associated with the research
-		*Shape = ((RESEARCH *)psStat)->pIMD;
+		*Shape = ((RESEARCH *)psStat)->pIMD->displayModel();
 		//make sure the stat is initialised
 		*ppGraphicData = nullptr;
 	}

--- a/src/intdisplay.h
+++ b/src/intdisplay.h
@@ -80,7 +80,7 @@ struct ImdObject
 	static ImdObject Feature(BASE_STATS *p)
 	{
 		FEATURE_STATS *fStat = (FEATURE_STATS *)p;
-		return ImdObject(fStat->psImd, IMDTYPE_FEATURE);
+		return ImdObject((fStat->psImd) ? fStat->psImd->displayModel() : nullptr, IMDTYPE_FEATURE);
 	}
 
 	bool empty() const
@@ -251,7 +251,7 @@ bool DroidIsBuilding(DROID *Droid);
 STRUCTURE *DroidGetBuildStructure(DROID *Droid);
 bool DroidGoingToBuild(DROID *Droid);
 BASE_STATS *DroidGetBuildStats(DROID *Droid);
-iIMDShape *DroidGetIMD(DROID *Droid);
+iIMDBaseShape *DroidGetIMD(DROID *Droid);
 
 bool StructureIsManufacturingPending(STRUCTURE *structure);   ///< Returns true iff the structure is either manufacturing or on hold (even if not yet synchronised). (But ignores research.)
 bool structureIsResearchingPending(STRUCTURE *structure);     ///< Returns true iff the structure is either researching or on hold (even if not yet synchronised). (But ignores manufacturing.)
@@ -262,7 +262,7 @@ RESEARCH_FACILITY *StructureGetResearch(STRUCTURE *Structure);
 FACTORY *StructureGetFactory(STRUCTURE *Structure);
 
 bool StatIsStructure(BASE_STATS const *Stat);
-iIMDShape *StatGetStructureIMD(BASE_STATS *Stat, UDWORD Player);
+iIMDBaseShape *StatGetStructureIMD(BASE_STATS *Stat, UDWORD Player);
 bool StatIsTemplate(BASE_STATS *Stat);
 bool StatIsFeature(BASE_STATS const *Stat);
 

--- a/src/mapdisplay.cpp
+++ b/src/mapdisplay.cpp
@@ -74,7 +74,8 @@ void renderResearchToBuffer(RESEARCH *psResearch, UDWORD OriginX, UDWORD OriginY
 				/*HACK HACK HACK!
 				if its a 'tall thin (ie tower)' structure stat with something on
 				the top - offset the position to show the object on top*/
-				if (((STRUCTURE_STATS *)psResearch->psStat)->pIMD[0]->nconnectors &&
+				const iIMDShape *pDisplayModel = ((STRUCTURE_STATS *)psResearch->psStat)->pIMD[0]->displayModel();
+				if (!pDisplayModel->connectors.empty() &&
 				    getStructureStatHeight((STRUCTURE_STATS *)psResearch->psStat) > TOWER_HEIGHT)
 				{
 					Position.y -= 30;

--- a/src/message.cpp
+++ b/src/message.cpp
@@ -54,7 +54,7 @@ MESSAGE *apsMessages[MAX_PLAYERS];
 PROXIMITY_DISPLAY *apsProxDisp[MAX_PLAYERS];
 
 /* The IMD to use for the proximity messages */
-iIMDShape	*pProximityMsgIMD;
+iIMDBaseShape	*pProximityMsgIMD;
 
 bool releaseObjectives = true;
 

--- a/src/message.h
+++ b/src/message.h
@@ -34,7 +34,7 @@
 extern MESSAGE		*apsMessages[MAX_PLAYERS];
 
 /** The IMD to use for the proximity messages. */
-extern iIMDShape	*pProximityMsgIMD;
+extern iIMDBaseShape	*pProximityMsgIMD;
 
 /** The list of proximity displays allocated. */
 extern PROXIMITY_DISPLAY *apsProxDisp[MAX_PLAYERS];

--- a/src/messagedef.h
+++ b/src/messagedef.h
@@ -70,8 +70,8 @@ struct VIEW_BASE
 // info required to view an object in Intelligence screen
 struct VIEW_RESEARCH : VIEW_BASE
 {
-	iIMDShape	*pIMD = nullptr;
-	iIMDShape	*pIMD2 = nullptr;	// allows base plates and turrets to be drawn as well
+	iIMDBaseShape	*pIMD = nullptr;
+	iIMDBaseShape	*pIMD2 = nullptr;	// allows base plates and turrets to be drawn as well
 	WzString		sequenceName;	// which windowed flic to display
 	WzString		audio;			// name of audio track to play (for this seq)
 };

--- a/src/miscimd.cpp
+++ b/src/miscimd.cpp
@@ -23,6 +23,7 @@
 #include "lib/framework/frame.h"
 #include "lib/framework/frameresource.h"
 #include "lib/ivis_opengl/imd.h"
+#include "lib/ivis_opengl/ivisdef.h"
 #include "effects.h"
 #include "structure.h"
 #include "messagedef.h"
@@ -119,20 +120,24 @@ static bool multiLoadMiscImds()
 }
 // -------------------------------------------------------------------------------
 // Returns a pointer to the imd from a #define number passed in - see above
-iIMDShape	*getImdFromIndex(UDWORD	index)
+iIMDBaseShape	*getImdFromIndex(UDWORD	index)
 {
 	ASSERT(index < MI_TOO_MANY, "Out of range index in getImdFromIndex");
 
 	return (miscImds[index].pImd);
 }
-// -------------------------------------------------------------------------------
-
-// -------------------------------------------------------------------------------
-iIMDShape	*getRandomDebrisImd()
+// DISPLAY-ONLY
+iIMDShape *getDisplayImdFromIndex(UDWORD index)
 {
-	iIMDShape *DebrisIMD;
+	iIMDBaseShape *pBaseIMD = getImdFromIndex(index);
+	return ((pBaseIMD) ? pBaseIMD->displayModel() : nullptr);
+}
+// -------------------------------------------------------------------------------
 
-	DebrisIMD = getImdFromIndex(MI_DEBRIS0 + rand() % ((MI_DEBRIS4 - MI_DEBRIS0) + 1));
+// -------------------------------------------------------------------------------
+iIMDBaseShape	*getRandomDebrisImd()
+{
+	iIMDBaseShape *DebrisIMD = getImdFromIndex(MI_DEBRIS0 + rand() % ((MI_DEBRIS4 - MI_DEBRIS0) + 1));
 
 	ASSERT(DebrisIMD != nullptr, "getRandomDebrisImd : NULL PIE");
 
@@ -140,7 +145,7 @@ iIMDShape	*getRandomDebrisImd()
 }
 // -------------------------------------------------------------------------------
 
-iIMDShape	*pAssemblyPointIMDs[NUM_FLAG_TYPES][MAX_FACTORY_FLAG_IMDS];
+iIMDBaseShape	*pAssemblyPointIMDs[NUM_FLAG_TYPES][MAX_FACTORY_FLAG_IMDS];
 
 static bool initMiscImd(unsigned i, unsigned n, const char *nameFormat, unsigned flagType)
 {

--- a/src/miscimd.h
+++ b/src/miscimd.h
@@ -26,8 +26,9 @@
 #include "messagedef.h"
 
 bool initMiscImds();
-iIMDShape *getImdFromIndex(UDWORD index);
-iIMDShape *getRandomDebrisImd();
+iIMDBaseShape *getImdFromIndex(UDWORD index);
+iIMDShape *getDisplayImdFromIndex(UDWORD index);
+iIMDBaseShape *getRandomDebrisImd();
 
 #define	MAX_DEBRIS		5
 #define	MAX_WRECKAGE	5
@@ -49,7 +50,7 @@ extern iIMDShape	*droidDamageImd;
 extern iIMDShape	*smallSteamImd;
 extern iIMDShape	*plasmaImd;
 #define MAX_FACTORY_FLAG_IMDS 32
-extern iIMDShape	*pAssemblyPointIMDs[NUM_FLAG_TYPES][MAX_FACTORY_FLAG_IMDS];
+extern iIMDBaseShape	*pAssemblyPointIMDs[NUM_FLAG_TYPES][MAX_FACTORY_FLAG_IMDS];
 extern iIMDShape	*blipImd;
 extern iIMDShape	*shadowImd;
 extern iIMDShape	*transporterShadowImd;
@@ -72,7 +73,7 @@ extern iIMDShape	*shockImd;
 /* An imd entry */
 struct MISC_IMD
 {
-	iIMDShape	*pImd;
+	iIMDBaseShape	*pImd;
 	const char	*pName;
 };
 

--- a/src/projectile.cpp
+++ b/src/projectile.cpp
@@ -1049,7 +1049,7 @@ static void proj_ImpactFunc(PROJECTILE *psObj)
 	SDWORD          iAudioImpactID;
 	int32_t         relativeDamage;
 	Vector3i        position, scatter;
-	iIMDShape       *imd;
+	iIMDBaseShape   *imd;
 	BASE_OBJECT     *temp;
 	bool            hasRadius, hasEMPRadius;
 
@@ -1138,7 +1138,7 @@ static void proj_ImpactFunc(PROJECTILE *psObj)
 				imd = psStats->pTargetMissGraphic;
 			}
 
-			addMultiEffect(&position, &scatter, EFFECT_EXPLOSION, facing, true, imd, psStats->numExplosions, psStats->lightWorld, psStats->effectSize, psObj->time);
+			addMultiEffect(&position, &scatter, EFFECT_EXPLOSION, facing, true, (imd) ? imd->displayModel() : nullptr, psStats->numExplosions, psStats->lightWorld, psStats->effectSize, psObj->time);
 
 			// If the target was a VTOL hit in the air add smoke
 			if ((psStats->surfaceToAir & SHOOT_IN_AIR)
@@ -1180,7 +1180,7 @@ static void proj_ImpactFunc(PROJECTILE *psObj)
 				imd = psStats->pTargetHitGraphic;
 			}
 
-			addMultiEffect(&position, &scatter, EFFECT_EXPLOSION, facing, true, imd, psStats->numExplosions, psStats->lightWorld, psStats->effectSize, psObj->time);
+			addMultiEffect(&position, &scatter, EFFECT_EXPLOSION, facing, true, (imd) ? imd->displayModel() : nullptr, psStats->numExplosions, psStats->lightWorld, psStats->effectSize, psObj->time);
 		}
 
 		// Check for electronic warfare damage where we know the subclass and source

--- a/src/researchdef.h
+++ b/src/researchdef.h
@@ -65,8 +65,8 @@ struct RESEARCH : public BASE_STATS
 	VIEWDATA                *pViewData;             ///< Data used to display a message in the Intelligence Screen
 	UWORD			iconID;				/* the ID from 'Framer' for which graphic to draw in interface*/
 	BASE_STATS      *psStat;   /* A stat used to define which graphic is drawn instead of the two fields below */
-	iIMDShape		*pIMD;		/* the IMD to draw for this research topic */
-	iIMDShape		*pIMD2;		/* the 2nd IMD for base plates/turrets*/
+	iIMDBaseShape		*pIMD;		/* the IMD to draw for this research topic */
+	iIMDBaseShape		*pIMD2;		/* the 2nd IMD for base plates/turrets*/
 	int index;		///< Unique index for this research, set incrementally
 
 	RESEARCH() : pViewData(nullptr), iconID(0), psStat(nullptr), pIMD(nullptr), pIMD2(nullptr) {}

--- a/src/stats.cpp
+++ b/src/stats.cpp
@@ -264,9 +264,9 @@ static optional<WzString> deprecatedModelUpgrade(WzString& filename)
 	return nullopt;
 }
 
-static iIMDShape *statsGetIMD(WzConfig &json, BASE_STATS *psStats, const WzString& key, const WzString& key2 = WzString())
+static iIMDBaseShape *statsGetIMD(WzConfig &json, BASE_STATS *psStats, const WzString& key, const WzString& key2 = WzString())
 {
-	iIMDShape *retval = nullptr;
+	iIMDBaseShape *retval = nullptr;
 	if (json.contains(key))
 	{
 		auto value = json.json(key);

--- a/src/statsdef.h
+++ b/src/statsdef.h
@@ -24,7 +24,7 @@
 #ifndef __INCLUDED_STATSDEF_H__
 #define __INCLUDED_STATSDEF_H__
 
-struct iIMDShape;
+struct iIMDBaseShape;
 
 #include <vector>
 #include <algorithm>
@@ -314,7 +314,7 @@ struct COMPONENT_STATS : public BASE_STATS
 	virtual UPGRADE const &getUpgrade(unsigned player) const = 0;
 	UPGRADE &getBase() { return const_cast<UPGRADE &>(const_cast<COMPONENT_STATS const *>(this)->getBase()); }
 
-	iIMDShape *pIMD = nullptr;				/**< The IMD to draw for this component */
+	iIMDBaseShape *pIMD = nullptr;				/**< The IMD to draw for this component */
 	unsigned buildPower = 0;			/**< Power required to build the component */
 	unsigned buildPoints = 0;		/**< Time required to build the component */
 	unsigned weight = 0;				/**< Component's weight */
@@ -350,7 +350,7 @@ struct SENSOR_STATS : public COMPONENT_STATS
 	UPGRADE const &getBase() const override { return base; }
 	UPGRADE const &getUpgrade(unsigned player) const override { return upgrade[player]; }
 
-	iIMDShape *pMountGraphic = nullptr;     ///< The turret mount to use
+	iIMDBaseShape *pMountGraphic = nullptr;     ///< The turret mount to use
 	unsigned location = 0;                  ///< specifies whether the Sensor is default or for the Turret
 	SENSOR_TYPE type = STANDARD_SENSOR;     ///< used for combat
 
@@ -365,7 +365,7 @@ struct ECM_STATS : public COMPONENT_STATS
 	UPGRADE const &getBase() const override { return base; }
 	UPGRADE const &getUpgrade(unsigned player) const override { return upgrade[player]; }
 
-	iIMDShape *pMountGraphic = nullptr;   ///< The turret mount to use
+	iIMDBaseShape *pMountGraphic = nullptr;   ///< The turret mount to use
 	unsigned location = 0;                ///< Specifies whether the ECM is default or for the Turret
 
 	struct : UPGRADE
@@ -379,7 +379,7 @@ struct REPAIR_STATS : public COMPONENT_STATS
 	UPGRADE const &getBase() const override { return base; }
 	UPGRADE const &getUpgrade(unsigned player) const override { return upgrade[player]; }
 
-	iIMDShape *pMountGraphic = nullptr;	///< The turret mount to use
+	iIMDBaseShape *pMountGraphic = nullptr;	///< The turret mount to use
 	unsigned location = 0;			///< Specifies whether the Repair is default or for the Turret
 	unsigned time = 0;			///< Time delay for repair cycle
 
@@ -445,13 +445,13 @@ struct WEAPON_STATS : public COMPONENT_STATS
 	unsigned numExplosions = 0;			///< The number of explosions per shot
 
 	/* Graphics used for the weapon */
-	iIMDShape *pMountGraphic = nullptr;		///< The turret mount to use
-	iIMDShape *pMuzzleGraphic = nullptr;		///< The muzzle flash
-	iIMDShape *pInFlightGraphic = nullptr;		///< The ammo in flight
-	iIMDShape *pTargetHitGraphic = nullptr;		///< The ammo hitting a target
-	iIMDShape *pTargetMissGraphic = nullptr;	///< The ammo missing a target
-	iIMDShape *pWaterHitGraphic = nullptr;		///< The ammo hitting water
-	iIMDShape *pTrailGraphic = nullptr;		///< The trail used for in flight
+	iIMDBaseShape *pMountGraphic = nullptr;		///< The turret mount to use
+	iIMDBaseShape *pMuzzleGraphic = nullptr;		///< The muzzle flash
+	iIMDBaseShape *pInFlightGraphic = nullptr;		///< The ammo in flight
+	iIMDBaseShape *pTargetHitGraphic = nullptr;		///< The ammo hitting a target
+	iIMDBaseShape *pTargetMissGraphic = nullptr;	///< The ammo missing a target
+	iIMDBaseShape *pWaterHitGraphic = nullptr;		///< The ammo hitting water
+	iIMDBaseShape *pTrailGraphic = nullptr;		///< The trail used for in flight
 
 	/* Audio */
 	int iAudioFireID = 0;
@@ -463,7 +463,7 @@ struct CONSTRUCT_STATS : public COMPONENT_STATS
 	UPGRADE const &getBase() const override { return base; }
 	UPGRADE const &getUpgrade(unsigned player) const override { return upgrade[player]; }
 
-	iIMDShape *pMountGraphic = nullptr;      ///< The turret mount to use
+	iIMDBaseShape *pMountGraphic = nullptr;      ///< The turret mount to use
 
 	struct : UPGRADE
 	{
@@ -501,9 +501,9 @@ struct BODY_STATS : public COMPONENT_STATS
 	BODY_SIZE size = SIZE_NUM;      ///< How big the body is - affects how hit
 	unsigned weaponSlots = 0;       ///< The number of weapon slots on the body
 
-	std::vector<iIMDShape *> ppIMDList;	///< list of IMDs to use for propulsion unit - up to numPropulsionStats
-	std::vector<iIMDShape *> ppMoveIMDList;	///< list of IMDs to use when droid is moving - up to numPropulsionStats
-	std::vector<iIMDShape *> ppStillIMDList;///< list of IMDs to use when droid is still - up to numPropulsionStats
+	std::vector<iIMDBaseShape *> ppIMDList;	///< list of IMDs to use for propulsion unit - up to numPropulsionStats
+	std::vector<iIMDBaseShape *> ppMoveIMDList;	///< list of IMDs to use when droid is moving - up to numPropulsionStats
+	std::vector<iIMDBaseShape *> ppStillIMDList;///< list of IMDs to use when droid is still - up to numPropulsionStats
 	WzString         bodyClass;		///< rules hint to script about its classification
 
 	struct UPGRADE : COMPONENT_STATS::UPGRADE

--- a/src/structuredef.h
+++ b/src/structuredef.h
@@ -299,7 +299,7 @@ struct STRUCTURE : public BASE_OBJECT
 	UDWORD expectedDamage;           ///< Expected damage to be caused by all currently incoming projectiles. This info is shared between all players,
 	///< but shouldn't make a difference unless 3 mutual enemies happen to be fighting each other at the same time.
 	uint32_t prevTime;               ///< Time of structure's previous tick.
-	float foundationDepth;           ///< Depth of structure's foundation
+	float foundationDepth;           ///< Depth of structure's foundation		// DISPLAY-ONLY
 	uint8_t capacity;                ///< Lame name: current number of module upgrades (*not* maximum nb of upgrades)
 	STRUCT_ANIM_STATES	state;
 	UDWORD lastStateTime;

--- a/src/structuredef.h
+++ b/src/structuredef.h
@@ -114,8 +114,8 @@ struct STRUCTURE_STATS : public BASE_STATS
 	UDWORD buildPoints;             /*The number of build points required to build the structure*/
 	UDWORD height;                  /*The height above/below the terrain - negative values denote below the terrain*/
 	UDWORD powerToBuild;            /*How much power the structure requires to build*/
-	std::vector<iIMDShape *> pIMD;  // The IMDs to draw for this structure, for each possible number of modules.
-	iIMDShape *pBaseIMD;            /*The base IMD to draw for this structure */
+	std::vector<iIMDBaseShape *> pIMD;  // The IMDs to draw for this structure, for each possible number of modules.
+	iIMDBaseShape *pBaseIMD;            /*The base IMD to draw for this structure */
 	struct ECM_STATS *pECM;         /*Which ECM is standard for the structure -if any*/
 	struct SENSOR_STATS *pSensor;   /*Which Sensor is standard for the structure -if any*/
 	UDWORD weaponSlots;             /*Number of weapons that can be attached to the building*/
@@ -303,7 +303,7 @@ struct STRUCTURE : public BASE_OBJECT
 	uint8_t capacity;                ///< Lame name: current number of module upgrades (*not* maximum nb of upgrades)
 	STRUCT_ANIM_STATES	state;
 	UDWORD lastStateTime;
-	iIMDShape *prebuiltImd;
+	iIMDBaseShape *prebuiltImd;
 
 	inline Vector2i size() const { return pStructureType->size(rot.direction); }
 };

--- a/src/texture.cpp
+++ b/src/texture.cpp
@@ -81,7 +81,7 @@ int getCurrentTileTextureSize()
 int getMaxTileTextureSize(std::string dir)
 {
 	int res = MIPMAP_MAX;
-	while (res > 0 && !PHYSFS_exists(WzString::fromUtf8(dir + "-" + std::to_string(res) + "/tile-00.png")))
+	while (res > 0 && !PHYSFS_exists(WzString::fromUtf8(dir + "-" + std::to_string(res) + "/tile-00.ktx2")) && !PHYSFS_exists(WzString::fromUtf8(dir + "-" + std::to_string(res) + "/tile-00.png")))
 		res /= 2;
 	return res;
 }
@@ -310,7 +310,7 @@ bool texLoad(const char *fileName)
 				std::vector<WzString> usedFilenames_tmp;
 				for (k = 0; k <= maxTileNo; ++k)
 				{
-					auto fullPath_base = WzString::fromUtf8(astringf("%s/tile-%02d.png", partialPath, k));
+					auto fullPath_base = gfx_api::imageLoadFilenameFromInputFilename(WzString::fromUtf8(astringf("%s/tile-%02d.png", partialPath, k)));
 					tile_base_filepaths.push_back(fullPath_base);
 					usedFilenames_tmp.push_back(fullPath_base);
 


### PR DESCRIPTION
Requires: #3307

This draft PR implements several key core changes:
1. Split `iIMDShape`, separate game state data from display data
   - iIMDBaseShape is the base data that can be safely used for game state calculations, and is always derived from the base model data. It contains a pointer to the *display* iIMDShape data (used for display purposes only), which may be loaded from a different place (i.e. graphics overrides).
2. Support tileset TEXTURE overrides in PIE 4
3. Basic under-the-hood support for new "graphics overrides" support
4. Refactoring of how textures are compressed as part of the build process

## Graphics Overrides

This PR implements the basics to support graphics overrides.

The goal: Use the same (base) game data for all game state calculations / the simulation, but support using a different set of data for rendering / display purposes.

Use-case: To allow future bundling of ARMod / high quality models, and allow players to play versus each other while independently deciding whether to use classic, normal, or ARMod/HQ models for the visual appearance of the game.

To test this right now:
- Extract ARMod, and place in `<config dir>/graphics_overrides/curr` (this may change before this PR is ultimately ready for merging)
   - This should cause ARMod models and textures to be rendered, however all game state calculations should use data extracted from the base (default) models.

### Future TODOs (in a subsequent PR):

- Similar to terrain overrides, provide configuration in Options (and enumeration of graphics_overrides). (Presumably allow these to be packaged, like terrain overrides?)