### PR TITLE
Snap improvements

### DIFF
--- a/.snapcraft.yaml
+++ b/.snapcraft.yaml
@@ -16,18 +16,14 @@ architectures:
   - build-on: armhf
 
 layout:
-  /usr/share/vulkan:
-    symlink: $SNAP/usr/share/vulkan
-  /usr/lib/$CRAFT_ARCH_TRIPLET/libvulkan_intel.so:
-    symlink: $SNAP/usr/lib/$CRAFT_ARCH_TRIPLET/libvulkan_intel.so
-  /usr/lib/$CRAFT_ARCH_TRIPLET/libvulkan_radeon.so:
-    symlink: $SNAP/usr/lib/$CRAFT_ARCH_TRIPLET/libvulkan_radeon.so
-  /usr/lib/$CRAFT_ARCH_TRIPLET/libvulkan_broadcom.so:
-    symlink: $SNAP/usr/lib/$CRAFT_ARCH_TRIPLET/libvulkan_broadcom.so
-  /usr/lib/$CRAFT_ARCH_TRIPLET/libvulkan_freedreno.so:
-    symlink: $SNAP/usr/lib/$CRAFT_ARCH_TRIPLET/libvulkan_freedreno.so
-  /usr/lib/$CRAFT_ARCH_TRIPLET/libvulkan_lvp.so:
-    symlink: $SNAP/usr/lib/$CRAFT_ARCH_TRIPLET/libvulkan_lvp.so
+  /usr/share/libdrm:
+    bind: $SNAP/graphics/libdrm
+  /usr/share/drirc.d:
+    symlink: $SNAP/graphics/drirc.d
+  /usr/share/X11/XErrorDB:
+    symlink: $SNAP/graphics/X11/XErrorDB
+  /usr/share/X11/locale:
+    symlink: $SNAP/graphics/X11/locale
 
 plugs:
   wz2100-sequences:
@@ -35,10 +31,16 @@ plugs:
     content: wz2100-sequences
     target: $SNAP/usr/share/warzone2100/sequences
     default-provider: warzone2100-videos
+  graphics-core22:
+      interface: content
+      target: $SNAP/graphics
+      default-provider: mesa-core22
 
 apps:
   warzone2100:
     extensions: [gnome]
+    command-chain:
+      - bin/graphics-core22-wrapper
     command: usr/bin/warzone2100-launcher.sh warzone2100
     common-id: net.wz2100.warzone2100 # should match the appdata/metainfo file's <id> field
     desktop: usr/share/applications/net.wz2100.warzone2100.desktop
@@ -218,9 +220,19 @@ parts:
       - libsodium23
       - libsqlite3-0
       - libglu1-mesa
-      - mesa-vulkan-drivers
+      # - mesa-vulkan-drivers # provided by graphics-core22 / mesa-core22
       - unzip
       - zip
+
+  graphics-core22:
+    after: [warzone2100]
+    source: https://github.com/MirServer/graphics-core22.git
+    plugin: dump
+    override-prime: |
+      craftctl default
+      ${CRAFT_PART_SRC}/bin/graphics-core22-cleanup mesa-core22 nvidia-core22
+    prime:
+    - bin/graphics-core22-wrapper
 
   # This part removes all the files in this snap which already exist in
   # connected content and base snaps. Since these files will be available
@@ -233,6 +245,7 @@ parts:
     after:  # Make this part run last; list all your other parts here
       - sdl
       - warzone2100
+      - graphics-core22
     plugin: nil
     build-snaps:  # List all content-snaps and base snaps you're using here
       - core22

--- a/.snapcraft.yaml
+++ b/.snapcraft.yaml
@@ -77,12 +77,14 @@ parts:
     - libdbus-1-dev
     - libudev-dev
     - fcitx-libs-dev
+    - libdecor-0-dev
     - libegl1-mesa-dev
     - libgl1-mesa-dev
     - libgles2-mesa-dev
     - libibus-1.0-dev
     - libjack-dev
     - libpulse-dev
+    - libpipewire-0.3-dev
     - libsamplerate0-dev
     - libsndfile1-dev
     - libts-dev
@@ -101,6 +103,8 @@ parts:
     - libxxf86vm-dev
     - libgbm-dev
     stage-packages:
+    - libdecor-0-0
+    - libdecor-0-plugin-1
     - libdbus-1-3
     - libudev1
     - fcitx-libs
@@ -112,6 +116,7 @@ parts:
     - libibus-1.0-5
     - libjack0
     - libpulse0
+    - libpipewire-0.3-0
     - libsamplerate0
     - libts0
     - libsndfile1

--- a/.snapcraft.yaml
+++ b/.snapcraft.yaml
@@ -168,14 +168,17 @@ parts:
       # Include the icon's path in the desktop file, not just the name.
       # This needs to happen post-build or the build versioning will show as "modified locally"
       sed -i -E 's|Icon=(.*)|Icon=/usr/share/icons/\1.png|' $CRAFT_PART_INSTALL/usr/share/applications/net.wz2100.warzone2100.desktop
+    # Note: Some packages are provided by the gnome extension, and are commented out below
+    # See: https://snapcraft.io/docs/gnome-extension#heading--packages
+    # And: https://github.com/ubuntu/gnome-sdk/blob/gnome-42-2204-sdk/snapcraft.yaml, https://github.com/ubuntu/gnome-sdk/blob/gnome-42-2204/snapcraft.yaml
     build-packages:
       - asciidoctor
-      - g++
+      #- g++
       - gettext
-      - libfontconfig1-dev
+      #- libfontconfig1-dev
       - libfreetype-dev
-      - libfribidi-dev
-      - libharfbuzz-dev
+      #- libfribidi-dev
+      #- libharfbuzz-dev
       - libopenal-dev
       - libphysfs-dev
       - libpng-dev
@@ -192,10 +195,10 @@ parts:
       - wget
       - zip
     stage-packages:
-      - libfontconfig1
+      #- libfontconfig1
       - libfreetype6
-      - libfribidi0
-      - libharfbuzz0b
+      #- libfribidi0
+      #- libharfbuzz0b
       - libogg0
       - libopenal1
       - libopus0
@@ -235,3 +238,8 @@ parts:
       for snap in "core22" "gtk-common-themes" "gnome-42-2204"; do  # List all content-snaps and base snaps you're using here
           cd "/snap/$snap/current" && find . -type f,l -exec rm -f "$CRAFT_PRIME/{}" \;
       done
+      # The following is required while using core18 + gnome-3-34
+      # See: https://forum.snapcraft.io/t/undefined-symbol-hb-buffer-set-invisible-glyph-with-gnome-3-34/24287
+      rm -f $SNAPCRAFT_PRIME/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/libharfbuzz.so.0*
+      rm -f $SNAPCRAFT_PRIME/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/libgio-2.0.so.0*
+      rm -f $SNAPCRAFT_PRIME/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/libglib-2.0.so.0*

--- a/.snapcraft.yaml
+++ b/.snapcraft.yaml
@@ -47,6 +47,7 @@ apps:
     environment:
       XDG_DATA_HOME: $SNAP_USER_COMMON
       XDG_CONFIG_HOME: $SNAP_USER_COMMON
+      LIBDECOR_PLUGIN_DIR: $SNAP/usr/lib/$CRAFT_ARCH_TRIPLET/libdecor/plugins-1
     plugs:
       - audio-playback
       - desktop

--- a/.snapcraft.yaml
+++ b/.snapcraft.yaml
@@ -62,8 +62,8 @@ apps:
 
 parts:
   sdl:
-    source: https://github.com/libsdl-org/SDL/releases/download/release-2.26.4/SDL2-2.26.4.tar.gz
-    source-checksum: sha512/138f52a23d796803c450722c8a4db8226214522e99f1e5ae657e2b28eb45abf0c81c9c3df9ab16f1a07d59722ed9415d64dd04332ff040cdfbbc0329f0d05ce4
+    source: https://github.com/libsdl-org/SDL/releases/download/release-2.28.2/SDL2-2.28.2.tar.gz
+    source-checksum: sha512/2c5559c4ec2a71bb89b3fc6e9d0a2b206b8cc1021dfa4ad328aab9a931757ed5fac5ec76d4966dccf81bd861de20963e2013bac62be9ef75ebe1c08678999c39
     plugin: cmake
     cmake-parameters:
     - -DCMAKE_INSTALL_PREFIX=/usr

--- a/.snapcraft.yaml
+++ b/.snapcraft.yaml
@@ -63,17 +63,16 @@ parts:
   sdl:
     source: https://github.com/libsdl-org/SDL/releases/download/release-2.26.4/SDL2-2.26.4.tar.gz
     source-checksum: sha512/138f52a23d796803c450722c8a4db8226214522e99f1e5ae657e2b28eb45abf0c81c9c3df9ab16f1a07d59722ed9415d64dd04332ff040cdfbbc0329f0d05ce4
-    plugin: autotools
-    autotools-configure-parameters:
-    - --prefix=/usr
-    - --disable-alsa
-    - --disable-arts
-    - --disable-esd
-    - --disable-nas
-    - --disable-oss
+    plugin: cmake
+    cmake-parameters:
+    - -DCMAKE_INSTALL_PREFIX=/usr
+    - -DSDL_ALSA=OFF
+    - -DSDL_ARTS=OFF
+    - -DSDL_ESD=OFF
+    - -DSDL_NAS=OFF
+    - -DSDL_OSS=OFF
     override-build: |
       craftctl default
-      sed -i 's|"/usr"|"'"$CRAFT_STAGE/usr"'"|g' "$CRAFT_PART_INSTALL/usr/lib/cmake/SDL2/sdl2-config.cmake"
     build-packages:
     - git
     - libdbus-1-dev

--- a/pkg/snap/warzone2100-launcher.sh
+++ b/pkg/snap/warzone2100-launcher.sh
@@ -8,4 +8,7 @@ if [ ! -d "$SNAP_USER_COMMON/warzone2100" ]; then
   fi
 fi
 
-exec env "XDG_DATA_HOME=$SNAP_USER_COMMON" env "XDG_CONFIG_HOME=$SNAP_USER_COMMON" "$@"
+export XDG_DATA_HOME="${SNAP_USER_COMMON}"
+export XDG_CONFIG_HOME="${SNAP_USER_COMMON}"
+
+exec "$@"

--- a/pkg/snap/warzone2100-launcher.sh
+++ b/pkg/snap/warzone2100-launcher.sh
@@ -11,4 +11,9 @@ fi
 export XDG_DATA_HOME="${SNAP_USER_COMMON}"
 export XDG_CONFIG_HOME="${SNAP_USER_COMMON}"
 
+# default SDL_VIDEODRIVER if unset (prefer wayland)
+if [ -z "${SDL_VIDEODRIVER}" ]; then
+	export SDL_VIDEODRIVER="wayland,x11"
+fi
+
 exec "$@"


### PR DESCRIPTION
- Switch to `graphics-core22` plug (with default provider `mesa-core22`)
- Use CMake to build SDL2
- Add `libdecor` so SDL2 actually supports window decorations on Wayland (and configure `LIBDECOR_PLUGIN_DIR` properly so the default plugin can be found)
- Update SDL2 to 2.28.2

Additional notes:
- SDL2 defaults to X11 before Wayland - it may be worth setting the Snap to default to Wayland before X11 (as Wayland actually supports high-DPI)
   - Can do this in code via `SDL_SetHint(SDL_HINT_VIDEODRIVER, "wayland,x11")`, or via environment variables (`SDL_VIDEODRIVER=wayland,x11`)
      - Use the launcher to set the environment variable