### PR TITLE
Widgets: Initial clickHeld event support, DynamicIntFancyButton: Add synthesized secondary click support

### DIFF
--- a/lib/widget/form.cpp
+++ b/lib/widget/form.cpp
@@ -100,6 +100,34 @@ void W_CLICKFORM::setFlash(bool enable)
 	dirty = true;
 }
 
+void W_CLICKFORM::run(W_CONTEXT *psContext)
+{
+	W_FORM::run(psContext);
+
+	if (clickDownStart.has_value())
+	{
+		const std::chrono::steady_clock::time_point now = std::chrono::steady_clock::now();
+		if (std::chrono::duration_cast<std::chrono::milliseconds>(now - clickDownStart.value()) >= widgGetClickHoldMS())
+		{
+			if (clickDownKey.has_value())
+			{
+				if (clickHeld(psContext, clickDownKey.value()))
+				{
+					// clear button down state, as the clickHeld event "consumed" this click
+					state &= ~WBUT_DOWN;
+				}
+			}
+			clickDownStart.reset();
+		}
+	}
+}
+
+// Returns true if "consumed" held click
+bool W_CLICKFORM::clickHeld(W_CONTEXT *psContext, WIDGET_KEY key)
+{
+	return false;
+}
+
 bool W_FORM::isUserMovable() const
 {
 	return userMovable || formState == FormState::MINIMIZED;
@@ -185,6 +213,8 @@ void W_CLICKFORM::clicked(W_CONTEXT *psContext, WIDGET_KEY key)
 		{
 			state &= ~WBUT_FLASH;  // Stop it flashing
 			state |= WBUT_DOWN;
+			clickDownStart = std::chrono::steady_clock::now();
+			clickDownKey = key;
 			dirty = true;
 
 			if (AudioCallback != nullptr)
@@ -211,6 +241,9 @@ void W_CLICKFORM::released(W_CONTEXT *, WIDGET_KEY key)
 			dirty = true;
 		}
 	}
+
+	clickDownStart = nullopt;
+	clickDownKey = nullopt;
 }
 
 
@@ -237,6 +270,8 @@ void W_CLICKFORM::highlightLost()
 	W_FORM::highlightLost();
 
 	state &= ~(WBUT_DOWN | WBUT_HIGHLIGHT);
+	clickDownStart = nullopt;
+	clickDownKey = nullopt;
 	dirty = true;
 }
 

--- a/lib/widget/form.h
+++ b/lib/widget/form.h
@@ -89,9 +89,11 @@ public:
 	W_CLICKFORM();
 
 	void clicked(W_CONTEXT *psContext, WIDGET_KEY key) override;
+	virtual bool clickHeld(W_CONTEXT *psContext, WIDGET_KEY key);
 	void released(W_CONTEXT *psContext, WIDGET_KEY key) override;
 	void highlight(W_CONTEXT *psContext) override;
 	void highlightLost() override;
+	void run(W_CONTEXT *psContext) override;
 	void display(int xOffset, int yOffset) override;
 	std::string getTip() override
 	{
@@ -116,6 +118,8 @@ private:
 	SWORD HilightAudioID;				// Audio ID for form clicked sound
 	SWORD ClickedAudioID;				// Audio ID for form hilighted sound
 	WIDGET_AUDIOCALLBACK AudioCallback;	// Pointer to audio callback function
+	optional<std::chrono::steady_clock::time_point> clickDownStart; // the start time of click down on this form
+	optional<WIDGET_KEY> clickDownKey;
 };
 
 class W_FULLSCREENOVERLAY_CLICKFORM : public W_CLICKFORM

--- a/lib/widget/widget.cpp
+++ b/lib/widget/widget.cpp
@@ -1540,3 +1540,8 @@ std::weak_ptr<WIDGET> getMouseOverWidget()
 {
 	return psMouseOverWidget;
 }
+
+std::chrono::milliseconds widgGetClickHoldMS()
+{
+	return std::chrono::milliseconds(2000); // TODO: Make this configurable?
+}

--- a/lib/widget/widget.h
+++ b/lib/widget/widget.h
@@ -34,6 +34,7 @@
 #include "lib/ivis_opengl/piepalette.h"
 #include "widgbase.h"
 #include <string>
+#include <chrono>
 
 /***********************************************************************************
  *
@@ -391,6 +392,8 @@ void setWidgetsStatus(bool var);
 bool getWidgetsStatus();
 
 std::weak_ptr<WIDGET> getMouseOverWidget();
+
+std::chrono::milliseconds widgGetClickHoldMS();
 
 /** @} */
 

--- a/src/configuration.cpp
+++ b/src/configuration.cpp
@@ -390,7 +390,8 @@ bool loadConfig()
 		war_SetCameraSpeed((v % CAMERASPEED_STEP != 0) ? CAMERASPEED_DEFAULT : v);
 	}
 	setShakeStatus(iniGetBool("shake", false).value());
-	setGroupButtonEnabled(iniGetBool("groupmenu", true).value());
+	war_setGroupsMenuEnabled(iniGetBool("groupmenu", true).value());
+	setGroupButtonEnabled(war_getGroupsMenuEnabled());
 	setCameraAccel(iniGetBool("cameraAccel", true).value());
 	setDrawShadows(iniGetBool("shadows", true).value());
 	war_setSoundEnabled(iniGetBool("sound", true).value());
@@ -691,7 +692,7 @@ bool saveConfig()
 	iniSetInteger("lodDistanceBias", war_getLODDistanceBiasPercentage());
 	iniSetBool("cameraAccel", getCameraAccel());		// camera acceleration
 	iniSetInteger("shake", (int)getShakeStatus());		// screenshake
-	iniSetInteger("groupmenu", (int)getGroupButtonEnabled());		// screenshake
+	iniSetInteger("groupmenu", (int)war_getGroupsMenuEnabled());		// groups menu
 	iniSetInteger("mouseflip", (int)(getInvertMouseStatus()));	// flipmouse
 	iniSetInteger("nomousewarp", (int)getMouseWarp());		// mouse warp
 	iniSetInteger("coloredCursor", (int)war_GetColouredCursor());
@@ -930,6 +931,9 @@ bool reloadMPConfig()
 	game.inactivityMinutes = war_getMPInactivityMinutes();
 	game.gameTimeLimitMinutes = war_getMPGameTimeLimitMinutes();
 	game.playerLeaveMode = war_getMPPlayerLeaveMode();
+
+	// restore group menus enabled setting (as tutorial may override it)
+	setGroupButtonEnabled(war_getGroupsMenuEnabled());
 
 	return true;
 }

--- a/src/frontend.cpp
+++ b/src/frontend.cpp
@@ -331,6 +331,7 @@ bool runTutorialMenu()
 	case FRONTEND_TUTORIAL:
 		SPinit(LEVEL_TYPE::CAMPAIGN);
 		sstrcpy(aLevelName, TUTORIAL_LEVEL);
+		setGroupButtonEnabled(false); // hack to disable the groups UI for the tutorial
 		changeTitleMode(STARTGAME);
 		break;
 
@@ -1263,6 +1264,7 @@ bool runGraphicsOptionsMenu()
 	case FRONTEND_GROUPS:
 	case FRONTEND_GROUPS_R:
 		setGroupButtonEnabled(!getGroupButtonEnabled());
+		war_setGroupsMenuEnabled(getGroupButtonEnabled()); // persist
 		widgSetString(psWScreen, FRONTEND_GROUPS_R, graphicsOptionsGroupsMenuEnabled());
 		break;
 

--- a/src/hci/build.cpp
+++ b/src/hci/build.cpp
@@ -403,7 +403,7 @@ private:
 		BaseStatsController::scheduleDisplayStatsForm(controller);
 	}
 
-	void clickSecondary() override
+	void clickSecondary(bool synthesizedFromHold) override
 	{
 		auto droid = controller->getObjectAt(objectIndex);
 		ASSERT_NOT_NULLPTR_OR_RETURN(, droid);
@@ -495,7 +495,7 @@ private:
 		});
 	}
 
-	void clickSecondary() override
+	void clickSecondary(bool synthesizedFromHold) override
 	{
 		auto clickedStats = controller->getStatsAt(buildOptionIndex);
 		ASSERT_NOT_NULLPTR_OR_RETURN(, clickedStats);

--- a/src/hci/commander.cpp
+++ b/src/hci/commander.cpp
@@ -294,7 +294,7 @@ private:
 		controller->displayOrderForm();
 	}
 
-	void clickSecondary() override
+	void clickSecondary(bool synthesizedFromHold) override
 	{
 		auto droid = controller->getObjectAt(objectIndex);
 		ASSERT_NOT_NULLPTR_OR_RETURN(, droid);

--- a/src/hci/groups.cpp
+++ b/src/hci/groups.cpp
@@ -132,7 +132,7 @@ public:
 		controller->selectGroup(groupNumber);
 	}
 
-	void clickSecondary() override
+	void clickSecondary(bool synthesizedFromHold) override
 	{
 		controller->assignSelectedDroidsToGroup(groupNumber);
 	}

--- a/src/hci/manufacture.cpp
+++ b/src/hci/manufacture.cpp
@@ -455,7 +455,7 @@ private:
 		BaseStatsController::scheduleDisplayStatsForm(controller);
 	}
 
-	void clickSecondary() override
+	void clickSecondary(bool synthesizedFromHold) override
 	{
 		auto factory = controller->getObjectAt(objectIndex);
 		ASSERT_NOT_NULLPTR_OR_RETURN(, factory);
@@ -559,7 +559,7 @@ private:
 		adjustFactoryProduction(true);
 	}
 
-	void clickSecondary() override
+	void clickSecondary(bool synthesizedFromHold) override
 	{
 		adjustFactoryProduction(false);
 	}

--- a/src/hci/objects_stats.cpp
+++ b/src/hci/objects_stats.cpp
@@ -156,8 +156,18 @@ void DynamicIntFancyButton::released(W_CONTEXT *context, WIDGET_KEY mouseButton)
 	}
 	else if (mouseButton == WKEY_SECONDARY)
 	{
-		clickSecondary();
+		clickSecondary(false);
 	}
+}
+
+bool DynamicIntFancyButton::clickHeld(W_CONTEXT *psContext, WIDGET_KEY key)
+{
+	if (key == WKEY_PRIMARY)
+	{
+		clickSecondary(true);
+		return true;
+	}
+	return false;
 }
 
 void StatsButton::addProgressBar()

--- a/src/hci/objects_stats.cpp
+++ b/src/hci/objects_stats.cpp
@@ -128,6 +128,11 @@ void BaseStatsController::scheduleDisplayStatsForm(const std::shared_ptr<BaseSta
 	});
 }
 
+DynamicIntFancyButton::DynamicIntFancyButton()
+{
+	style |= WFORM_SECONDARY;
+}
+
 void DynamicIntFancyButton::updateLayout()
 {
 	updateHighlight();
@@ -136,7 +141,14 @@ void DynamicIntFancyButton::updateLayout()
 
 void DynamicIntFancyButton::released(W_CONTEXT *context, WIDGET_KEY mouseButton)
 {
+	bool clickAndReleaseOnThisButton = ((state & WBUT_DOWN) != 0); // relies on W_CLICKFORM handling to properly set WBUT_DOWN
+
 	IntFancyButton::released(context, mouseButton);
+
+	if (!clickAndReleaseOnThisButton)
+	{
+		return; // do nothing
+	}
 
 	if (mouseButton == WKEY_PRIMARY)
 	{

--- a/src/hci/objects_stats.h
+++ b/src/hci/objects_stats.h
@@ -118,8 +118,9 @@ protected:
 	virtual void updateLayout();
 	void updateHighlight();
 	virtual void clickPrimary() {}
-	virtual void clickSecondary() {}
+	virtual void clickSecondary(bool synthesizedFromHold) {}
 	void released(W_CONTEXT *context, WIDGET_KEY mouseButton = WKEY_PRIMARY) override;
+	bool clickHeld(W_CONTEXT *psContext, WIDGET_KEY key) override;
 public:
 	DynamicIntFancyButton();
 };
@@ -156,7 +157,7 @@ protected:
 	virtual BaseObjectsController &getController() const = 0;
 	virtual void jump();
 
-	void clickSecondary() override
+	void clickSecondary(bool synthesizedFromHold) override
 	{
 		jump();
 	}

--- a/src/hci/objects_stats.h
+++ b/src/hci/objects_stats.h
@@ -120,6 +120,8 @@ protected:
 	virtual void clickPrimary() {}
 	virtual void clickSecondary() {}
 	void released(W_CONTEXT *context, WIDGET_KEY mouseButton = WKEY_PRIMARY) override;
+public:
+	DynamicIntFancyButton();
 };
 
 class StatsButton: public DynamicIntFancyButton

--- a/src/hci/research.cpp
+++ b/src/hci/research.cpp
@@ -470,7 +470,7 @@ private:
 		controller->refresh();
 	}
 
-	void clickSecondary() override
+	void clickSecondary(bool synthesizedFromHold) override
 	{
 		auto facility = controller->getObjectAt(objectIndex);
 		ASSERT_NOT_NULLPTR_OR_RETURN(, facility);

--- a/src/ingameop.cpp
+++ b/src/ingameop.cpp
@@ -711,6 +711,7 @@ static bool runIGGraphicsOptionsMenu(UDWORD id)
 	case INTINGAMEOP_GROUPS:
 	case INTINGAMEOP_GROUPS_R:
 		setGroupButtonEnabled(!getGroupButtonEnabled());
+		war_setGroupsMenuEnabled(getGroupButtonEnabled()); // persist
 		widgSetString(psWScreen, INTINGAMEOP_GROUPS_R, graphicsOptionsGroupsMenuEnabled());
 		break;
 

--- a/src/warzoneconfig.cpp
+++ b/src/warzoneconfig.cpp
@@ -89,6 +89,8 @@ struct WARZONE_GLOBALS
 	uint32_t shadowFilteringMode = 1;
 	uint32_t shadowFilterSize = 5;
 	uint32_t shadowMapResolution = 0; // this defaults to 0, which causes the gfx backend to figure out a recommended default based on the system properties
+	// groups UI
+	bool groupsMenuEnabled = true;
 };
 
 static WARZONE_GLOBALS warGlobs;
@@ -645,3 +647,12 @@ void war_setShadowMapResolution(uint32_t resolution)
 	warGlobs.shadowMapResolution = resolution;
 }
 
+bool war_getGroupsMenuEnabled()
+{
+	return warGlobs.groupsMenuEnabled;
+}
+
+void war_setGroupsMenuEnabled(bool enabled)
+{
+	warGlobs.groupsMenuEnabled = enabled;
+}

--- a/src/warzoneconfig.h
+++ b/src/warzoneconfig.h
@@ -162,6 +162,9 @@ void war_setShadowFilterSize(uint32_t filterSize);
 uint32_t war_getShadowMapResolution();
 void war_setShadowMapResolution(uint32_t resolution);
 
+bool war_getGroupsMenuEnabled();
+void war_setGroupsMenuEnabled(bool enabled);
+
 /**
  * Enable or disable sound initialization
  *


### PR DESCRIPTION
DynamicIntFancyButton: Add synthesized secondary click on primary click-and-hold
- Exposes the ability to access the secondary click functionality even when a right mouse button might not be available (for example, when using a touch screen)
- `clickSecondary()` can handle this differently from a true secondary click, if desired