### PR TITLE
Remove returning transporters on Beta/Gamma 1

### DIFF
--- a/src/mission.cpp
+++ b/src/mission.cpp
@@ -3240,6 +3240,11 @@ void emptyTransporters(bool bOffWorld)
 				//now kill off the Transporter
 				vanishDroid(psDroid);
 			}
+			else if (!bOffWorld && orderState(psTransporter, DORDER_TRANSPORTRETURN))
+			{
+				//also destroy transporters in the process of flying back and we're not offWorld
+				vanishDroid(psTransporter);
+			}
 		}
 	}
 	//deal with any transporters that are waiting to come over


### PR DESCRIPTION
And any more potential mission like these in the future.

Transporters that dropped off units, and are still flying back to go off map, would persist through the end of the mission and cause an unavoidable early exit trigger to load the next mission.

fixes #3362.