### PR TITLE
Flatpak: Workaround to use crashpad / breakpad handler

### DIFF
--- a/.ci/flatpak/net.wz2100.wz2100.yaml.in
+++ b/.ci/flatpak/net.wz2100.wz2100.yaml.in
@@ -176,8 +176,8 @@ modules:
       - -DWZ_BUILD_SENTRY:BOOL=ON
       - -DWZ_SENTRY_PREDOWNLOADED_SENTRY_ARCHIVE=/app/prestaged-dl/sentry-native.zip
       - -DWZ_DOWNLOAD_PREBUILT_PACKAGES_ASSET_DIR=/app/prestaged-dl
-      # Crashpad works in the Flatpak sandbox *if* --allow=devel is set above. Otherwise, this must be: inproc
-      - -DSENTRY_BACKEND=crashpad
+      # Crashpad/breakpad works in the Flatpak sandbox *if* --allow=devel is set above. Otherwise, this must be: inproc
+      - -DSENTRY_BACKEND=breakpad
       @WZ_CMAKE_CROSS_CONFIG_OPTIONS@
     secret-opts:
       - -DWZ_DISTRIBUTOR:STRING=$WZ_DISTRIBUTOR

--- a/.ci/flatpak/net.wz2100.wz2100.yaml.in
+++ b/.ci/flatpak/net.wz2100.wz2100.yaml.in
@@ -14,6 +14,13 @@ finish-args:
   - --device=dri
   - --socket=pulseaudio
   - --share=network
+  # Use features=devel to enable ptrace, which is needed for the crash reporter
+  # (breakpad and crashpad - only "inproc" works w/out this, and is much more limited).
+  # This same workaround is used by Firefox, and:
+  # > The application is still confined in a pid namespace, so that won't let us
+  # > escape the flatpak sandbox.
+  # Reference: https://bugzilla.mozilla.org/show_bug.cgi?id=1653852#c23
+  - --allow=devel
 cleanup:
   - /include
   - /lib/cmake
@@ -169,8 +176,8 @@ modules:
       - -DWZ_BUILD_SENTRY:BOOL=ON
       - -DWZ_SENTRY_PREDOWNLOADED_SENTRY_ARCHIVE=/app/prestaged-dl/sentry-native.zip
       - -DWZ_DOWNLOAD_PREBUILT_PACKAGES_ASSET_DIR=/app/prestaged-dl
-      # Have to use inproc for now - breakpad / crashpad do not work in the Flatpak sandbox
-      - -DSENTRY_BACKEND=inproc
+      # Crashpad works in the Flatpak sandbox *if* --allow=devel is set above. Otherwise, this must be: inproc
+      - -DSENTRY_BACKEND=crashpad
       @WZ_CMAKE_CROSS_CONFIG_OPTIONS@
     secret-opts:
       - -DWZ_DISTRIBUTOR:STRING=$WZ_DISTRIBUTOR

--- a/icons/net.wz2100.warzone2100.appdata.xml.in
+++ b/icons/net.wz2100.warzone2100.appdata.xml.in
@@ -56,6 +56,21 @@
 		<content_attribute id="violence-bloodshed">mild</content_attribute>
 		<content_attribute id="social-chat">intense</content_attribute>
 	</content_rating>
+	<categories>
+		<category>Game</category>
+		<category>StrategyGame</category>
+	</categories>
+	<keywords>
+		<keyword>game</keyword>
+		<keyword>play</keyword>
+		<keyword>rts</keyword>
+		<keyword>real-time strategy</keyword>
+		<keyword>realtime strategy</keyword>
+		<keyword>strategy</keyword>
+		<keyword translate="no">warzone 2100</keyword>
+		<keyword translate="no">warzone2100</keyword>
+		<keyword translate="no">wz2100</keyword>
+	</keywords>
 	<custom>
 		<value key="flathub::manifest">https://github.com/Warzone2100/warzone2100/blob/master/.github/workflows/CI_flatpak.yml</value>
 	</custom>

--- a/icons/net.wz2100.warzone2100.appdata.xml.in
+++ b/icons/net.wz2100.warzone2100.appdata.xml.in
@@ -8,14 +8,25 @@
 	<launchable type="desktop-id">@WZ_APPSTREAM_ID@@WZ_OUTPUT_NAME_SUFFIX@.desktop</launchable>
 	<description>
 		<p>
-			In Warzone 2100, you command the forces of The Project in a battle to rebuild the world after mankind has almost been destroyed by nuclear missiles.
+			The classic 3D real-time strategy game from 1999 has been updated, upgraded, and modernized for the very latest platforms!
 		</p>
 		<p>
-			The game offers campaign, multi-player, and single-player skirmish modes. An extensive tech tree with over 400 different technologies, combined with the unit design system, allows for a wide variety of possible units and tactics.
+			Command the forces of The Project in a battle to rebuild the world after mankind has been nearly destroyed by nuclear missiles.
 		</p>
 		<p>
-			Warzone 2100 was originally developed as a commercial game by Pumpkin Studios and published in 1999, and was released as open source by them in 2004. It has been developed, maintained, and improved by the community ever since, under the banner of the "Warzone 2100 Project".
+			Warzone 2100 offers a story-driven single-player campaign, online multi-player, and single-player skirmish modes. An extensive tech tree with over 400 different technologies, combined with the unit design system, allows for a wide variety of possible units and tactics.
 		</p>
+		<p>Highlights:</p>
+		<ul>
+			<li>Remastered single-player campaign with expanding persistent bases, away missions, and more</li>
+			<li>Online multiplayer with up to 10 players, free-for-all or team-play, for massive battles</li>
+			<li>Local skirmish with AI bots, for endless replayability</li>
+			<li>Extensive tech tree with over 400 different technologies</li>
+			<li>Customizable units with a flexible design system that enables a wide variety of possible tactics</li>
+			<li>Cross-platform multiplayer</li>
+			<li>Support for multiple graphics backends (OpenGL, OpenGL ES, Vulkan)</li>
+			<li>100% free and open source</li>
+		</ul>
 	</description>
 	<url type="homepage">https://wz2100.net/</url>
 	<url type="bugtracker">https://github.com/Warzone2100/warzone2100/issues/new</url>
@@ -49,7 +60,12 @@
 	</screenshots>
 	<developer_name>Warzone 2100 Project</developer_name>
 	<releases>
-	  <release version="@WZ_METAINFO_RELEASE_VERSION@" type="@WZ_METAINFO_RELEASE_TYPE@" date="@WZ_METAINFO_RELEASE_DATE@"></release>
+	  <release version="@WZ_METAINFO_RELEASE_VERSION@" type="@WZ_METAINFO_RELEASE_TYPE@" date="@WZ_METAINFO_RELEASE_DATE@">
+			<description>
+				<p>Bug fixes and improvements</p>
+			</description>
+			<url>https://github.com/Warzone2100/warzone2100/blob/master/ChangeLog</url>
+		</release>
 	</releases>
 	<content_rating type="oars-1.1">
 		<content_attribute id="violence-fantasy">moderate</content_attribute>


### PR DESCRIPTION
Use `features=devel` to enable ptrace, which is needed for breakpad / crashpad.

This same workaround is used by Firefox, and:
> The application is still confined in a pid namespace, so that won't let us escape the flatpak sandbox.

Reference: https://bugzilla.mozilla.org/show_bug.cgi?id=1653852#c23