### PR TITLE
[Vulkan] Fix pipeline rasterizationSamples mismatch with renderpass

### DIFF
--- a/lib/ivis_opengl/gfx_api_vk.h
+++ b/lib/ivis_opengl/gfx_api_vk.h
@@ -668,6 +668,7 @@ struct VkRoot final : gfx_api::context
 		vk::RenderPass rp;
 		std::shared_ptr<VkhRenderPassCompat> rp_compat_info;
 		std::vector<vk::Framebuffer> fbo;
+		vk::SampleCountFlagBits msaaSamples = vk::SampleCountFlagBits::e1;
 		size_t identifier;
 
 		RenderPassDetails(size_t _identifier)


### PR DESCRIPTION
Fixes validation layers error (and possible crash) when antialiasing is enabled.

Should fix #3383