### PR TITLE
Resolve #3011 -- Fixing the suggested save names

### DIFF
--- a/lib/framework/crc.cpp
+++ b/lib/framework/crc.cpp
@@ -182,7 +182,7 @@ void Sha256::fromString(std::string const &s)
 	}
 }
 
-void to_json(nlohmann::json& j, const Sha256& k)
+inline void to_json(nlohmann::json& j, const Sha256& k)
 {
 	if (k.isZero())
 	{

--- a/lib/framework/geometry.h
+++ b/lib/framework/geometry.h
@@ -22,6 +22,7 @@
 
 #include "frame.h"
 #include "vector.h"
+#include <algorithm>
 #include <limits>
 
 /**

--- a/lib/framework/wzglobal.h
+++ b/lib/framework/wzglobal.h
@@ -553,6 +553,7 @@
 #  undef NOMINMAX
 #  define NOMINMAX 1		// disable the min / max macros
 #  include <windows.h>
+#  include <algorithm>
 
 #  if defined(WZ_CC_MSVC)
 


### PR DESCRIPTION
This PR fixes #3011.

The saving mechanism works as follows:
1. If the normal saved name doesn't exist it uses it.
2. If it exist, it searches all the integer suffixes and chooses the least integer that is greater than 1 that is not already used.

This fixes the problem where the suggested names have already existed sometimes.

**I added a commit at the start that resolves many compilation errors of std::min/max not found and a linking issue with to_json function when trying to compile on Windows using CMake on VS2019. Please let me know if I should remove this commit.**