### PR TITLE
Prevent repairs from highlighting their own commander

### DIFF
--- a/src/droid.cpp
+++ b/src/droid.cpp
@@ -2753,6 +2753,15 @@ bool droidUnderRepair(const DROID *psDroid)
 				 DROID_CYBORG_REPAIR) && psCurr->action ==
 				DACTION_DROIDREPAIR && psCurr->order.psObj == psDroid)
 			{
+				BASE_OBJECT *psLeader = nullptr;
+				if (hasCommander(psCurr))
+				{
+					psLeader = (BASE_OBJECT *)psCurr->psGroup->psCommander;
+				}
+				if (psLeader && psLeader->id == psDroid->id)
+				{
+					continue;
+				}
 				return true;
 			}
 		}


### PR DESCRIPTION
If the Commander is damaged a little bit and a repair is under its control, and said repair is repairing something, it would cause various selection boxes to get drawn.

Closes #3332.