### PR TITLE
Prevent Commander list scrambling on save-load

### DIFF
--- a/src/hci/commander.cpp
+++ b/src/hci/commander.cpp
@@ -46,7 +46,10 @@ void CommanderController::updateCommandersList()
 		}
 	}
 
-	std::reverse(commanders.begin(), commanders.end());
+	// Sort the list of commanders from lowest to highest id (using a lambda function defined within the sort call)
+	std::sort(commanders.begin(), commanders.end(), [](DROID *droid1, DROID *droid2) {
+		return droid1->id < droid2->id;
+	});
 }
 
 STRUCTURE_STATS *CommanderController::getObjectStatsAt(size_t objectIndex) const


### PR DESCRIPTION
Prevents the list of commanders in the command tab from being jumbled up when loading a save by sorting the list by droid ID.
Currently, save-loading the game causes the order of the commanders in the commander menu to be changed, which can be seen here (screenshots taken in master build):
Before save-load:
![image](https://github.com/Warzone2100/warzone2100/assets/28832631/c6f74afe-eca5-418f-b64e-0c5175cf1477)
After save-load:
![image](https://github.com/Warzone2100/warzone2100/assets/28832631/5aa1ded3-c738-44f9-96b3-55266781ab45)
Notice how the order of the commanders in the menu have been reversed.

With this PR, the commander menu order is preserved on save-load.
Before save-load:
![image](https://github.com/Warzone2100/warzone2100/assets/28832631/66616432-d29d-48fb-8659-a48067db48ac)
After save-load:
![image](https://github.com/Warzone2100/warzone2100/assets/28832631/7987e3c2-9f3b-42d7-8caf-36bc7ef4fbe2)
