### PR TITLE
Fix crash test

### DIFF
--- a/src/clparse.cpp
+++ b/src/clparse.cpp
@@ -739,6 +739,7 @@ bool ParseCommandLine(int argc, const char * const *argv)
 		case CLI_CRASH:
 			CauseCrash = true;
 			NetPlay.bComms = false;
+			SPinit(LEVEL_TYPE::CAMPAIGN);
 			sstrcpy(aLevelName, "CAM_3A");
 			SetGameMode(GS_NORMAL);
 			break;

--- a/src/display3d.cpp
+++ b/src/display3d.cpp
@@ -1175,7 +1175,7 @@ void draw3DScene()
 # pragma GCC diagnostic pop
 #endif
 		}
-		exit(-1);	// will never reach this, but just in case...
+		exit(-1);	// should never reach this, but just in case...
 	}
 	//visualize radius if needed
 	if (bRangeDisplay)

--- a/src/wzcrashhandlingproviders.cpp
+++ b/src/wzcrashhandlingproviders.cpp
@@ -475,7 +475,15 @@ bool crashHandlingProviderTestCrash()
 	RaiseException(0xE000DEAD, EXCEPTION_NONCONTINUABLE, 0, 0);
 	return false;
 # else
-	// future todo: implement for other platforms
+#  if defined(WZ_CC_GNU) && !defined(WZ_CC_INTEL) && !defined(WZ_CC_CLANG) && (7 <= __GNUC__)
+#   pragma GCC diagnostic push
+#   pragma GCC diagnostic ignored "-Wstringop-overflow"
+#endif
+	static void *invalid_mem = (void *)1;
+	memset((char *)invalid_mem, 1, 100);
+#  if defined(WZ_CC_GNU) && !defined(WZ_CC_INTEL) && !defined(WZ_CC_CLANG) && (7 <= __GNUC__)
+#   pragma GCC diagnostic pop
+#  endif
 	return false;
 # endif
 #else


### PR DESCRIPTION
Amusingly, the crash test was never getting to the point of actually triggering a crash, because an earlier failure in the loading process now results in a graceful shutdown. 