### PR TITLE
Various netplay tweaks

### DIFF
--- a/lib/netplay/netplay.h
+++ b/lib/netplay/netplay.h
@@ -392,6 +392,8 @@ size_t NETgetStatistic(NetStatisticType type, bool sent, bool isTotal = false); 
 
 void NETplayerKicked(UDWORD index);			// Cleanup after player has been kicked
 
+bool NETplayerHasConnection(uint32_t index);
+
 bool NETcanOpenNewSpectatorSlot();
 bool NETopenNewSpectatorSlot();
 bool NETmovePlayerToSpectatorOnlySlot(uint32_t playerIdx, bool hostOverride = false);

--- a/lib/netplay/netplay.h
+++ b/lib/netplay/netplay.h
@@ -371,6 +371,7 @@ extern bool netGameserverPortOverride; // = false; (for cli override)
 // functions available to you.
 int NETinit(bool bFirstCall);
 WZ_DECL_NONNULL(2) bool NETsend(NETQUEUE queue, NetMessage const *message);   ///< send to player, or broadcast if player == NET_ALL_PLAYERS.
+void NETsendProcessDelayedActions();
 WZ_DECL_NONNULL(1, 2) bool NETrecvNet(NETQUEUE *queue, uint8_t *type);        ///< recv a message from the net queues if possible.
 WZ_DECL_NONNULL(1, 2) bool NETrecvGame(NETQUEUE *queue, uint8_t *type);       ///< recv a message from the game queues which is sceduled to execute by time, if possible.
 void NETflush();                                                              ///< Flushes any data stuck in compression buffers.

--- a/lib/netplay/nettypes.cpp
+++ b/lib/netplay/nettypes.cpp
@@ -727,6 +727,9 @@ bool NETend()
 		// We have ended the serialisation, so mark the direction invalid
 		NETsetPacketDir(PACKET_INVALID);
 
+		// Process any delayed actions from the NETsend call
+		NETsendProcessDelayedActions();
+
 		if (queueInfo.queueType == QUEUE_GAME_FORCED)  // If true, we must be the host, inserting a GAME_PLAYER_LEFT into the other player's game queue. Since they left, they're not around to complain about us messing with their queue, which would normally cause a desynch.
 		{
 			// Almost duplicate code from NETflushGameQueues() in here.

--- a/src/hci/quickchat.cpp
+++ b/src/hci/quickchat.cpp
@@ -3001,7 +3001,7 @@ void sendQuickChat(WzQuickChatMessage message, uint32_t fromPlayer, WzQuickChatT
 		NETend();
 	}
 
-	if (fromPlayer == selectedPlayer && (!recipients.empty() || !isInGame))
+	if (fromPlayer == selectedPlayer && (!recipients.empty() || !isInGame) && !internalMessage)
 	{
 		if (isInGame)
 		{

--- a/src/multiplay.cpp
+++ b/src/multiplay.cpp
@@ -1394,8 +1394,11 @@ void HandleBadParam(const char *msg, const int from, const int actual)
 	NETlogEntry(buf, SYNC_FLAG, actual);
 	if (NetPlay.isHost)
 	{
-		ssprintf(buf, _("Auto kicking player %s, invalid command received."), NetPlay.players[actual].name);
-		sendInGameSystemMessage(buf);
+		if (NETplayerHasConnection(actual))
+		{
+			ssprintf(buf, _("Auto kicking player %s, invalid command received."), NetPlay.players[actual].name);
+			sendInGameSystemMessage(buf);
+		}
 		kickPlayer(actual, buf, KICK_TYPE, false);
 	}
 }


### PR DESCRIPTION
If the original message that failed to deliver was a broadcast message, NETsend would end up modifying the broadcast queue while a message from the broadcast queue was being processed, and we'd end up with "Queue not empty" errors (etc). This PR delays the processing of this failure until a bit later (i.e. after the message that encountered failures has been properly popped from the queue).