### PR TITLE
Utilize the transport timer on Beta End

### DIFF
--- a/data/base/script/campaign/libcampaign_includes/events.js
+++ b/data/base/script/campaign/libcampaign_includes/events.js
@@ -236,6 +236,11 @@ function cam_eventTransporterExit(transport)
 				setReinforcementTime(__camVictoryData.reinforcements);
 			}
 		}
+		// Show how long until the transporter comes back on Beta End.
+		if (__camWinLossCallback === CAM_VICTORY_TIMEOUT)
+		{
+			setReinforcementTime(__camVictoryData.reinforcements);
+		}
 	}
 
 	if (transport.player !== CAM_HUMAN_PLAYER ||
@@ -256,6 +261,13 @@ function cam_eventTransporterLanded(transport)
 	if (transport.player !== CAM_HUMAN_PLAYER)
 	{
 		__camLandTransporter(transport.player, camMakePos(transport));
+	}
+	else
+	{
+		// Make the transporter timer on Beta End disappear, since the transporter has arrived.
+		if (__camWinLossCallback === CAM_VICTORY_TIMEOUT) {
+			setReinforcementTime(-1);
+		}
 	}
 }
 
@@ -355,6 +367,13 @@ function cam_eventGameLoaded()
 			}
 			break;
 		}
+	}
+
+	if (__camWinLossCallback === CAM_VICTORY_TIMEOUT
+		&& enumDroid(CAM_HUMAN_PLAYER, DROID_SUPERTRANSPORTER).length === 0)
+	{
+		// If the transport is gone on Beta End, put a timer up to show when it'll be back
+		setReinforcementTime(__camVictoryData.reinforcements);
 	}
 
 	//Subscribe to eventGroupSeen again.

--- a/src/mission.cpp
+++ b/src/mission.cpp
@@ -543,8 +543,8 @@ void addTransporterTimerInterface()
 		{
 			bAddInterface = true;
 
-			//check timer is not already on the screen
-			if (!widgGetFromID(psWScreen, IDTRANTIMER_BUTTON))
+			// Check that neither the timer nor the launch button are on screen
+			if (!widgGetFromID(psWScreen, IDTRANTIMER_BUTTON) && !widgGetFromID(psWScreen, IDTRANS_LAUNCH))
 			{
 				intAddTransporterTimer();
 			}
@@ -3140,7 +3140,11 @@ void resetMissionWidgets()
 	{
 		if (auto transporter = find_transporter())
 		{
-			intAddTransporterLaunch(transporter);
+			// Show launch button if the transporter has not already been launched
+			if (!transporterFlying(transporter))
+			{
+				intAddTransporterLaunch(transporter);
+			}
 		}
 	}
 

--- a/src/order.cpp
+++ b/src/order.cpp
@@ -484,11 +484,11 @@ void orderUpdateDroid(DROID *psDroid)
 				}
 				else
 				{
-					//the script can call startMission for this callback for offworld missions
-					triggerEvent(TRIGGER_TRANSPORTER_EXIT, psDroid);
 					/* clear order */
 					psDroid->order = DroidOrder(DORDER_NONE);
 				}
+				//the script can call startMission for this callback for offworld missions (if we want to change level)
+				triggerEvent(TRIGGER_TRANSPORTER_EXIT, psDroid);
 
 				psDroid->sMove.speed = 0; // Prevent radical movement vector when adjusting from home to away map exit and entry coordinates.
 			}
@@ -525,6 +525,7 @@ void orderUpdateDroid(DROID *psDroid)
 			    missionDroidsRemaining(selectedPlayer))
 			{
 				resetTransporter();
+				triggerEvent(TRIGGER_TRANSPORTER_LANDED, psDroid);
 			}
 			else
 			{

--- a/src/transporter.cpp
+++ b/src/transporter.cpp
@@ -336,8 +336,9 @@ bool intAddTransporterLaunch(DROID *psDroid)
 	//set up the static transporter
 	psCurrTransporter = psDroid;
 
-	//check the button is not already up
-	if (widgGetFromID(psWScreen, IDTRANS_LAUNCH) != nullptr)
+	// Check that neither the launch button nor the transport timer are currently up
+	if (widgGetFromID(psWScreen, IDTRANS_LAUNCH) != nullptr
+		|| widgGetFromID(psWScreen, IDTRANTIMER_BUTTON) != nullptr)
 	{
 		return true;
 	}

--- a/src/wzapi.cpp
+++ b/src/wzapi.cpp
@@ -2491,30 +2491,29 @@ wzapi::no_return_value wzapi::setReinforcementTime(WZAPI_PARAMS(int _time))
 	              "The transport timer cannot be set to more than 1 hour!");
 	SCRIPT_ASSERT({}, context, selectedPlayer < MAX_PLAYERS, "Invalid selectedPlayer for current client: %" PRIu32 "", selectedPlayer);
 	mission.ETA = time;
-	if (missionCanReEnforce())
-	{
-		addTransporterTimerInterface();
-	}
+	
 	if (time < 0)
 	{
-		DROID *psDroid;
-
 		intRemoveTransporterTimer();
-		/* Only remove the launch if haven't got a transporter droid since the scripts set the
-		 * time to -1 at the between stage if there are not going to be reinforcements on the submap  */
-		for (psDroid = apsDroidLists[selectedPlayer]; psDroid != nullptr; psDroid = psDroid->psNext)
+	}
+	DROID* psDroid;
+
+	/* Search for a transport that is idle; if we can't find any, remove the launch button
+	 * since there's no transport to launch */
+	for (psDroid = apsDroidLists[selectedPlayer]; psDroid != nullptr; psDroid = psDroid->psNext)
+	{
+		if (isTransporter(psDroid) && !transporterFlying(psDroid))
 		{
-			if (isTransporter(psDroid))
-			{
-				break;
-			}
-		}
-		// if not found a transporter, can remove the launch button
-		if (psDroid ==  nullptr)
-		{
-			intRemoveTransporterLaunch();
+			break;
 		}
 	}
+	// Didn't find an idle transporter, we can remove the launch button
+	if (psDroid == nullptr)
+	{
+		intRemoveTransporterLaunch();
+	}
+	resetMissionWidgets();
+	addTransporterTimerInterface();
 	return {};
 }
 


### PR DESCRIPTION
Closes #3418
When the transport on Beta End exits the map, the launch button is replaced by the transport timer usually seen on off-world missions, which gives the time until the transport returns.

![image](https://github.com/Warzone2100/warzone2100/assets/28832631/780ac1f3-b9dd-4610-a9ab-5084a72e5132)
![image](https://github.com/Warzone2100/warzone2100/assets/28832631/04d766ca-4523-4ee2-802d-a3626a670350)

Note: in order to make this work cleanly, this PR also makes `eventTransporterExit()` and `eventTransporterLanded()` occur whenever the transporter lands with a transport exits/lands with `DORDER_TRANSPORTOUT`/`DORDER_TRANSPORTIN` (respectively). Normally, these would occur only when transitioning levels or unloading units with a transport.