### PR TITLE
Fix moduleToBuilding / label mapping for loaded maps, additional debugging

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -5201,7 +5201,11 @@ static bool loadWzMapDroidInit(WzMap::Map &wzMap, std::unordered_map<UDWORD, UDW
 		if (droid.id.has_value() && droid.id.value() > 0)
 		{
 			bool addedMapping = fixedMapIdToGeneratedId.insert(std::unordered_map<UDWORD, UDWORD>::value_type(droid.id.value(), newID)).second;
-			if (!addedMapping)
+			if (addedMapping)
+			{
+				debug(LOG_MAP, "Fixed map object ID: %" PRIu32 " -> generated id: %" PRIu32, droid.id.value(), newID);
+			}
+			else
 			{
 				debug(LOG_ERROR, "Found duplicate hard-coded object ID in map data: %" PRIu32 "", droid.id.value());
 			}
@@ -6141,7 +6145,11 @@ static bool loadWzMapStructure(WzMap::Map& wzMap, std::unordered_map<UDWORD, UDW
 		if (structure.id.has_value() && structure.id.value() > 0)
 		{
 			bool addedMapping = fixedMapIdToGeneratedId.insert(std::unordered_map<UDWORD, UDWORD>::value_type(structure.id.value(), newID)).second;
-			if (!addedMapping)
+			if (addedMapping)
+			{
+				debug(LOG_MAP, "Fixed map object ID: %" PRIu32 " -> generated id: %" PRIu32, structure.id.value(), newID);
+			}
+			else
 			{
 				debug(LOG_ERROR, "Found duplicate hard-coded object ID in map data: %" PRIu32 "", structure.id.value());
 			}
@@ -6891,7 +6899,11 @@ static bool loadWzMapFeature(WzMap::Map &wzMap, std::unordered_map<UDWORD, UDWOR
 		if (feature.id.has_value() && feature.id.value() > 0)
 		{
 			bool addedMapping = fixedMapIdToGeneratedId.insert(std::unordered_map<UDWORD, UDWORD>::value_type(feature.id.value(), newID)).second;
-			if (!addedMapping)
+			if (addedMapping)
+			{
+				debug(LOG_MAP, "Fixed map object ID: %" PRIu32 " -> generated id: %" PRIu32, feature.id.value(), newID);
+			}
+			else
 			{
 				debug(LOG_ERROR, "Found duplicate hard-coded object ID in map data: %" PRIu32 "", feature.id.value());
 			}

--- a/src/qtscript.cpp
+++ b/src/qtscript.cpp
@@ -2019,13 +2019,13 @@ bool scripting_engine::saveGroups(nlohmann::json &result, wzapi::scripting_insta
 // Label system (function defined in qtscript.h header)
 //
 
-bool loadLabels(const char *filename, const std::unordered_map<UDWORD, UDWORD>& fixedMapIdToGeneratedId)
+bool loadLabels(const char *filename, const std::unordered_map<UDWORD, UDWORD>& fixedMapIdToGeneratedId, std::array<std::unordered_map<UDWORD, UDWORD>, MAX_PLAYER_SLOTS>& moduleToBuilding)
 {
-	return scripting_engine::instance().loadLabels(filename, fixedMapIdToGeneratedId);
+	return scripting_engine::instance().loadLabels(filename, fixedMapIdToGeneratedId, moduleToBuilding);
 }
 
 // Load labels
-bool scripting_engine::loadLabels(const char *filename, const std::unordered_map<UDWORD, UDWORD>& fixedMapIdToGeneratedId)
+bool scripting_engine::loadLabels(const char *filename, const std::unordered_map<UDWORD, UDWORD>& fixedMapIdToGeneratedId, std::array<std::unordered_map<UDWORD, UDWORD>, MAX_PLAYER_SLOTS>& moduleToBuilding)
 {
 	int groupidx = -1;
 

--- a/src/qtscript.cpp
+++ b/src/qtscript.cpp
@@ -2037,7 +2037,7 @@ bool scripting_engine::loadLabels(const char *filename, const std::unordered_map
 	WzConfig ini(filename, WzConfig::ReadOnly);
 	labels.clear();
 	std::vector<WzString> list = ini.childGroups();
-	debug(LOG_SAVE, "Loading %zu labels...", list.size());
+	debug(LOG_SAVE, "Loading %zu labels... (fixedMapToGeneratedId.count = %zu)", list.size(), fixedMapIdToGeneratedId.size());
 	for (int i = 0; i < list.size(); ++i)
 	{
 		ini.beginGroup(list[i]);
@@ -2090,7 +2090,7 @@ bool scripting_engine::loadLabels(const char *filename, const std::unordered_map
 			{
 				// replace fixed hard-coded map-load id with its new generated (synchronized) id
 				// note: must come *before* the moduleToBuilding call below
-				debug(LOG_NEVER, "replaced fixed map id %d with %d", id, it->second);
+				debug(LOG_MAP, "replaced fixed map id %d with %d", id, it->second);
 				id = it->second;
 			}
 			const auto player = ini.value("player").toInt();
@@ -2098,7 +2098,7 @@ bool scripting_engine::loadLabels(const char *filename, const std::unordered_map
 			if (it_modulemap != moduleToBuilding[player].end())
 			{
 				// replace moduleId with its building id
-				debug(LOG_NEVER, "replaced with %i;%i", id, it_modulemap->second);
+				debug(LOG_MAP, "replaced with %i;%i", id, it_modulemap->second);
 				id = it_modulemap->second;
 			}
 			p.id = id;
@@ -2106,6 +2106,7 @@ bool scripting_engine::loadLabels(const char *filename, const std::unordered_map
 			p.player = player;
 			p.triggered = ini.value("triggered", -1).toInt(); // deactivated by default
 			p.subscriber = ini.value("subscriber", ALL_PLAYERS).toInt();
+			ASSERT(IdToObject((OBJECT_TYPE)p.type, p.id, p.player) != nullptr, "Failed to find object that label references: %s", label.c_str());
 			labels[label] = p;
 		}
 		else if (list[i].startsWith("group"))

--- a/src/qtscript.h
+++ b/src/qtscript.h
@@ -28,6 +28,7 @@
 #include <memory>
 #include <unordered_set>
 #include <unordered_map>
+#include <array>
 
 class QString;
 class WzString;
@@ -220,7 +221,7 @@ public:
 };
 
 /// Load map labels
-bool loadLabels(const char *filename, const std::unordered_map<UDWORD, UDWORD>& fixedMapIdToGeneratedId);
+bool loadLabels(const char *filename, const std::unordered_map<UDWORD, UDWORD>& fixedMapIdToGeneratedId, std::array<std::unordered_map<UDWORD, UDWORD>, MAX_PLAYER_SLOTS>& moduleToBuilding);
 
 /// Write map labels to savegame
 bool writeLabels(const char *filename);
@@ -318,7 +319,7 @@ public:
 // MARK: LABELS
 public:
 	/// Load map labels
-	bool loadLabels(const char *filename, const std::unordered_map<UDWORD, UDWORD>& fixedMapIdToGeneratedId);
+	bool loadLabels(const char *filename, const std::unordered_map<UDWORD, UDWORD>& fixedMapIdToGeneratedId, std::array<std::unordered_map<UDWORD, UDWORD>, MAX_PLAYER_SLOTS>& moduleToBuilding);
 
 	/// Write map labels to savegame
 	bool writeLabels(const char *filename);

--- a/src/structure.cpp
+++ b/src/structure.cpp
@@ -155,12 +155,6 @@ static int commanderLimit[MAX_PLAYERS];
 // max number of constructors
 static int constructorLimit[MAX_PLAYERS];
 
-// JS compatibility: remembers which module_id maps to which building
-// - why "MAX_PLAYER_SLOTS" instead of "MAX_PLAYERS"?
-// 	 because in Campaign, we have objects with player==12
-//   I don't what's the reason but we definitely need to handle more than MAX_PLAYERS 
-std::unordered_map<UDWORD, UDWORD> moduleToBuilding[MAX_PLAYER_SLOTS];
-
 static std::vector<WzString> favoriteStructs;
 
 #define MAX_UNIT_MESSAGE_PAUSE 40000
@@ -1779,15 +1773,6 @@ STRUCTURE *buildStructureDir(STRUCTURE_STATS *pStructureType, UDWORD x, UDWORD y
 				releasePowerGen(psBuilding);
 			}
 		}
-
-		// backward compatibility:
-		// JS scripts try to find buildings by their modules ids, which isn't possible anymore
-		// (because SIMPLE_OBJECT.id is const),
-		// so we maintain a map from module_id to buildings, so that qtscripts.cpp::loadLabels
-		// can replace module_id with building_id
-		// *Not* doing so will break campaign (no artifacts being spawned from modules)
-		auto mappingInsertionResult = moduleToBuilding[player].emplace(id, psBuilding->id);
-		ASSERT(mappingInsertionResult.second, "Duplicate input module id: %" PRIu32 " - ignoring mapping module to building", id);
 
 		if (bUpgraded)
 		{

--- a/src/structure.h
+++ b/src/structure.h
@@ -50,7 +50,6 @@
 #define ACTION_START_TIME	0
 
 extern std::vector<ProductionRun> asProductionRun[NUM_FACTORY_TYPES];
-extern std::unordered_map<UDWORD, UDWORD> moduleToBuilding[MAX_PLAYER_SLOTS];
 
 //Value is stored for easy access to this structure stat
 extern UDWORD	factoryModuleStat;


### PR DESCRIPTION
Previously, `moduleToBuilding` was not being cleared (either between loading different levels, different savegames, etc).
Refactored this to be handled inside `loadGame()`.

Also added a lot of additional debugging to help track down related map / campaign issues.