### PR TITLE
Obsolete some more tech in Gamma campaign

### DIFF
--- a/data/base/stats/research.json
+++ b/data/base/stats/research.json
@@ -1236,6 +1236,10 @@
 		"id": "R-Cyborg-Wpn-Laser1",
 		"msgName": "RES_CYW_LS1",
 		"name": "Flashlight Gunner Cyborg",
+		"replacedComponents": [
+			"CyborgRotMG:Cyb-Wpn-Laser",
+			"CyborgFlamer01:Cyb-Wpn-Laser"
+		],
 		"requiredResearch": [
 			"R-Wpn-Laser01"
 		],
@@ -1251,6 +1255,9 @@
 		"id": "R-Cyborg-Wpn-Rail1",
 		"msgName": "RES_CYW_RL1",
 		"name": "Needle Gunner Cyborg",
+		"replacedComponents": [
+			"CyborgCannon:Cyb-Wpn-Rail1"
+		],
 		"requiredResearch": [
 			"R-Wpn-RailGun01"
 		],
@@ -6738,6 +6745,9 @@
 		"id": "R-Defense-WallTower-PulseLas",
 		"msgName": "RES_WT14_PLS",
 		"name": "Flashlight Hardpoint",
+		"redStructures": [
+			"Wall-RotMg"
+		],
 		"requiredResearch": [
 			"R-Wpn-Laser01"
 		],
@@ -8511,6 +8521,10 @@
 		"keyTopic": 1,
 		"msgName": "RES_W_LAS1",
 		"name": "Laser - Flashlight",
+		"redComponents": [
+			"MG4ROTARY-VTOL",
+			"MG4ROTARYMk1"
+		],
 		"researchPoints": 14400,
 		"researchPower": 450,
 		"resultComponents": [

--- a/data/base/stats/research.json
+++ b/data/base/stats/research.json
@@ -3693,7 +3693,8 @@
 		"msgName": "RES_EMP_HVFL",
 		"name": "Inferno Emplacement",
 		"redStructures": [
-			"PillBox5"
+			"PillBox5",
+			"GuardTower4H"
 		],
 		"requiredResearch": [
 			"R-Wpn-Flame2",


### PR DESCRIPTION
Flashlight obsoletes Assault Gun weapons. Flashlight Hardpoint obsoletes Assault Gun defenses. Make all Gamma cyborgs obsolete their older Alpha/Beta predecessors.

---

It has come to my attention that people think the Assault Gun is a good choice beyond laser weapons. This is not correct and lasers have always been a pure upgrade from MGs, they are both long range anti-personnel weapons. MGs have a good run from Alpha 1 all the way to Gamma 3 (you can even use them until Gamma 6 even if you really want).

So I will be setting Flashlight tech, which you get on Gamma 3, to obsolete Assault Gun weapons/cyborgs/structures in the next release to prevent any confusion. Pulse Laser itself is also 2.5x more efficient than AG at handling cyborgs on Gamma End by knocking out cyborgs in 18 seconds with just 1. Add two more and cyborgs will literally melt before your very eyes.