### PR TITLE
Fix the horrid VTOL Strike/CB rearming behavior

### DIFF
--- a/src/order.cpp
+++ b/src/order.cpp
@@ -1046,7 +1046,11 @@ void orderUpdateDroid(DROID *psDroid)
 				bAttack = false;
 				if (isVtolDroid(psDroid))
 				{
-					if (!vtolEmpty(psDroid) &&
+					if (psDroid->action == DACTION_WAITDURINGREARM)
+					{
+						// Calm down. It's not that serious.
+					}
+					else if (!vtolEmpty(psDroid) &&
 					    ((psDroid->action == DACTION_MOVETOREARM) ||
 					     (psDroid->action == DACTION_WAITFORREARM)) &&
 					    (psDroid->sMove.Status != MOVEINACTIVE))
@@ -1055,7 +1059,7 @@ void orderUpdateDroid(DROID *psDroid)
 						// get them to attack the new target rather than returning to rearm
 						bAttack = true;
 					}
-					else if (allVtolsRearmed(psDroid))
+					else if (!vtolEmpty(psDroid))
 					{
 						bAttack = true;
 					}


### PR DESCRIPTION
While using a single VTOL is fine on these sensors, problems arise when there are multiple.

If multiple VTOLs are assigned to the VTOL sensors they would only attack if full as a group if the target didn't die. Causing 1 attack per VTOL of the whole group on the target.

---

Perhaps not perfect but at least makes these VTOL sensors feel a lot better to use. There is another line with allVtolsRearmed() elsewhere but I have no idea how that gets triggered, if ever.

Closes Trac ticket 4135 I suppose (10 year old bug report!).