### PR TITLE
Updating Factory Sensor

### DIFF
--- a/data/base/stats/structure.json
+++ b/data/base/stats/structure.json
@@ -488,7 +488,7 @@
 		"productionPoints": 10,
 		"moduleProductionPoints": 10,
 		"resistance": 150,
-		"sensorID": "BaBaSensor",
+		"sensorID": "DefaultSensor1Mk1",
 		"strength": "MEDIUM",
 		"structureModel": [
 			"blfact0.pie",


### PR DESCRIPTION
Factory sensor is BabaSensor for some reason, when it should be DefaultSensor1Mk1, like other base buildings.