### PR TITLE
giftSingleStructure: Fixup functionality when transferring

### DIFF
--- a/src/objmem.h
+++ b/src/objmem.h
@@ -97,6 +97,8 @@ bool createFlagPosition(FLAG_POSITION **ppsNew, UDWORD player);
 void addFlagPosition(FLAG_POSITION *psFlagPosToAdd);
 /* Remove a Flag Position from the Lists */
 void removeFlagPosition(FLAG_POSITION *psDel);
+/* Transfer a Flag Position to a new player */
+void transferFlagPositionToPlayer(FLAG_POSITION *psFlagPos, UDWORD originalPlayer, UDWORD newPlayer);
 // free all flag positions
 void freeAllFlagPositions();
 


### PR DESCRIPTION
`giftSingleStructure`, in skirmish / multiplayer, didn't handle the structure functionality / delivery points. Thus, gifting a structure could lead to duplicate structure numbers and other issues.