### PR TITLE
[GitHub Actions] Windows: Update to llvm-mingw 20231031 with LLVM 17.0.4

### DIFF
--- a/.github/workflows/CI_windows.yml
+++ b/.github/workflows/CI_windows.yml
@@ -386,10 +386,10 @@ jobs:
         $VerbosePreference = "Continue"
         . "${env:WZ_REPO_PATH}\.ci\powershell\request.ps1"
 
-        $LLVM_MINGW_RELEASE = "20231017";
+        $LLVM_MINGW_RELEASE = "20231031";
         $LLVM_MINGW_PKG = "llvm-mingw-${LLVM_MINGW_RELEASE}-ucrt-x86_64"
         $LLVM_MINGW_DL_URL = "https://github.com/mstorsjo/llvm-mingw/releases/download/${LLVM_MINGW_RELEASE}/${LLVM_MINGW_PKG}.zip"
-        $LLVM_MINGW_DL_SHA512 = "1dd3b107e58d7757f176eec7e5d4079ee63543153f2c1327c9b46e86eb9989271757977b9c88a74af57b70007edfe5e2365787e2a057af27656d66ba72e2fb28"
+        $LLVM_MINGW_DL_SHA512 = "3173b7a9b7836adce0fa5a59b13a01fa7707d1fc5be27606e779cca853b4452571ab37a1d5d6b3fd2ca067f58aa6011b121ba4f29b9b0eaaa1de2679d6b55af9"
 
         $LLVM_MINGW_DL_BASEDIR = "${{ github.workspace }}\dl"
         $LLVM_MINGW_DL_PATH = "${LLVM_MINGW_DL_BASEDIR}\llvm-mingw.zip"


### PR DESCRIPTION
Includes new mingw-w64, which:
> [...] prefers the UCRT version over the builtin one from libmingwex.a for a number of math functions

Reference: https://github.com/mstorsjo/llvm-mingw/issues/361