### PR TITLE
Prevent campaign difficulty influencing skirmish in-game saveload

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -4644,6 +4644,10 @@ static bool loadMainFile(const std::string &fileName)
 	{
 		game.playerLeaveMode = static_cast<PLAYER_LEAVE_MODE>(save.value("playerLeaveMode").toInt());
 	}
+	if (save.contains("multiplayer"))
+	{
+		bMultiPlayer = save.value("multiplayer").toBool();
+	}
 
 	save.beginArray("players");
 	while (save.remainingArrayItems() > 0)


### PR DESCRIPTION
Loading skirmish saves from in-game would have bMultiPlayer as false before resetDamageModifiers() was encountered. Thus resulting in the campaign difficulty modifiers the player currently has set to override the expected damage modifiers for skirmish/mp.