### PR TITLE
Remove artifact label from Alpha 3

### DIFF
--- a/data/base/script/campaign/cam1-1.js
+++ b/data/base/script/campaign/cam1-1.js
@@ -122,8 +122,6 @@ function eventStartLevel()
 	camUpgradeOnMapTemplates(cTempl.buggy, cTempl.buggytwin, CAM_SCAV_7);
 	camUpgradeOnMapTemplates(cTempl.bjeep, cTempl.bjeeptwin, CAM_SCAV_7);
 
-	//Get rid of the already existing crate and replace with another
-	camSafeRemoveObject("artifact1", false);
 	camSetArtifacts({
 		"scavFactory1": { tech: "R-Wpn-MG3Mk1" }, //Heavy machine gun
 	});

--- a/data/base/wrf/cam1/sub1-1/labels.json
+++ b/data/base/wrf/cam1/sub1-1/labels.json
@@ -100,23 +100,18 @@
 	},
 
 	"object_0": {
-		"label": "artifact1",
-		"id": 160831,
-		"type": 2
-	},
-	"object_1": {
 		"label": "scavFactory1",
 		"id": 146,
 		"player": 7,
 		"type": 1
 	},
-	"object_2": {
+	"object_1": {
 		"label": "frontBunkerLeft",
 		"id": 142,
 		"player": 7,
 		"type": 1
 	},
-	"object_3": {
+	"object_2": {
 		"label": "frontBunkerRight",
 		"id": 143,
 		"player": 7,


### PR DESCRIPTION
Recent improvements to label loading showed an assert for a no longer existing artifact. Delete any traces of it.