### PR TITLE
Fix a Repair Facility ID on Alpha 9

### DIFF
--- a/data/base/wrf/cam1/sub1-5/labels.json
+++ b/data/base/wrf/cam1/sub1-5/labels.json
@@ -122,7 +122,7 @@
 	},
 	"object_6": {
 		"label": "NPRepairFacility",
-		"id": 486,
+		"id": 513,
 		"player": 1,
 		"type": 1
 	},


### PR DESCRIPTION
For the New Paradigm Repair Facility.

Should be the last one as I saw nothing complain on Beta or Gamma campaign.