### PR TITLE
Fix spawn position of first clone in clone cheat

### DIFF
--- a/src/keybind.cpp
+++ b/src/keybind.cpp
@@ -412,7 +412,7 @@ void kf_CloneSelected(int limit)
 			// create a new droid army
 			for (int i = 0; i < limit; i++)
 			{
-				Vector2i pos = psDroid->pos.xy() + iSinCosR(40503 * i, iSqrt(50 * 50 * i));  // 40503 = 65536/φ
+				Vector2i pos = psDroid->pos.xy() + iSinCosR(40503 * i, iSqrt(50 * 50 * (i + 1)));  // 40503 = 65536/φ (A bit more than a right angle)
 				DROID *psNewDroid = buildDroid(sTemplate, pos.x, pos.y, psDroid->player, false, nullptr);
 				if (psNewDroid)
 				{


### PR DESCRIPTION
The first clone in the "clone wars" cheat was placed on top of the selected unit - push all droids out by one position when cloning.