### PR TITLE
Fix for text input handling of virtual key codes, CTRL+V paste, and displaying *virtual* key names

### DIFF
--- a/lib/sdl/main_sdl.cpp
+++ b/lib/sdl/main_sdl.cpp
@@ -1468,14 +1468,19 @@ static void inputHandleKeyEvent(SDL_KeyboardEvent *keyEvent)
 			break;
 		}
 
-		SDL_Scancode currentKey = keyEvent->keysym.scancode;
 		if (vk)
 		{
 			// Take care of adding 'editing' keys that were pressed to the input buffer (for text editing control handling)
 			inputAddBuffer(vk, 0);
 			debug(LOG_INPUT, "Editing key: 0x%x, %d SDLkey=[%s] pressed", vk, vk, SDL_GetKeyName(keyEvent->keysym.sym));
 		}
+		else
+		{
+			// add everything else
+			inputAddBuffer(keyEvent->keysym.sym, 0);
+		}
 
+		SDL_Scancode currentKey = keyEvent->keysym.scancode;
 		debug(LOG_INPUT, "Key Code (pressed): 0x%x, %d, SDLscancode=[%s]", currentKey, currentKey, SDL_GetScancodeName(currentKey));
 
 		KEY_CODE code = sdlScancodeToKeyCode(currentKey);

--- a/lib/sdl/main_sdl.cpp
+++ b/lib/sdl/main_sdl.cpp
@@ -1413,49 +1413,49 @@ static void inputHandleKeyEvent(SDL_KeyboardEvent *keyEvent)
 	case SDL_KEYDOWN:
 	{
 		unsigned vk = 0;
-		switch (keyEvent->keysym.scancode)
+		switch (keyEvent->keysym.sym)
 		{
 		// our "editing" keys for text
-		case SDL_SCANCODE_LEFT:
+		case SDLK_LEFT:
 			vk = INPBUF_LEFT;
 			break;
-		case SDL_SCANCODE_RIGHT:
+		case SDLK_RIGHT:
 			vk = INPBUF_RIGHT;
 			break;
-		case SDL_SCANCODE_UP:
+		case SDLK_UP:
 			vk = INPBUF_UP;
 			break;
-		case SDL_SCANCODE_DOWN:
+		case SDLK_DOWN:
 			vk = INPBUF_DOWN;
 			break;
-		case SDL_SCANCODE_HOME:
+		case SDLK_HOME:
 			vk = INPBUF_HOME;
 			break;
-		case SDL_SCANCODE_END:
+		case SDLK_END:
 			vk = INPBUF_END;
 			break;
-		case SDL_SCANCODE_INSERT:
+		case SDLK_INSERT:
 			vk = INPBUF_INS;
 			break;
-		case SDL_SCANCODE_DELETE:
+		case SDLK_DELETE:
 			vk = INPBUF_DEL;
 			break;
-		case SDL_SCANCODE_PAGEUP:
+		case SDLK_PAGEUP:
 			vk = INPBUF_PGUP;
 			break;
-		case SDL_SCANCODE_PAGEDOWN:
+		case SDLK_PAGEDOWN:
 			vk = INPBUF_PGDN;
 			break;
-		case SDL_SCANCODE_BACKSPACE:
+		case SDLK_BACKSPACE:
 			vk = INPBUF_BKSPACE;
 			break;
-		case SDL_SCANCODE_TAB:
+		case SDLK_TAB:
 			vk = INPBUF_TAB;
 			break;
-		case SDL_SCANCODE_RETURN:
+		case SDLK_RETURN:
 			vk = INPBUF_CR;
 			break;
-		case SDL_SCANCODE_ESCAPE:
+		case SDLK_ESCAPE:
 			vk = INPBUF_ESC;
 			break;
 		default:
@@ -1467,7 +1467,7 @@ static void inputHandleKeyEvent(SDL_KeyboardEvent *keyEvent)
 		{
 			// Take care of adding 'editing' keys that were pressed to the input buffer (for text editing control handling)
 			inputAddBuffer(vk, 0);
-			debug(LOG_INPUT, "Editing key: 0x%x, %d SDLkey=[%s] pressed", vk, vk, SDL_GetScancodeName(currentKey));
+			debug(LOG_INPUT, "Editing key: 0x%x, %d SDLkey=[%s] pressed", vk, vk, SDL_GetKeyName(keyEvent->keysym.sym));
 		}
 
 		debug(LOG_INPUT, "Key Code (pressed): 0x%x, %d, SDLscancode=[%s]", currentKey, currentKey, SDL_GetScancodeName(currentKey));

--- a/lib/sdl/main_sdl.cpp
+++ b/lib/sdl/main_sdl.cpp
@@ -1093,6 +1093,12 @@ static InputKey *inputPointerNext(InputKey *p)
 /* add count copies of the characater code to the input buffer */
 static void inputAddBuffer(UDWORD key, utf_32_char unicode)
 {
+	if (!GetTextEventsOwner)
+	{
+		// Text input events aren't enabled
+		return;
+	}
+
 	/* Calculate what pEndBuffer will be set to next */
 	InputKey	*pNext = inputPointerNext(pEndBuffer);
 

--- a/lib/sdl/main_sdl.cpp
+++ b/lib/sdl/main_sdl.cpp
@@ -1113,6 +1113,7 @@ static void inputAddBuffer(UDWORD key, utf_32_char unicode)
 	pEndBuffer = pNext;
 }
 
+// Returns the human-readable name for the key *in the current keyboard layout*
 void keyScanToString(KEY_CODE code, char *ascii, UDWORD maxStringSize)
 {
 	if (code == KEY_LCTRL)
@@ -1146,7 +1147,7 @@ void keyScanToString(KEY_CODE code, char *ascii, UDWORD maxStringSize)
 
 	if (code < KEY_MAXSCAN)
 	{
-		snprintf(ascii, maxStringSize, "%s", SDL_GetScancodeName(keyCodeToSDLScancode(code)));
+		snprintf(ascii, maxStringSize, "%s", SDL_GetKeyName(SDL_GetKeyFromScancode(keyCodeToSDLScancode(code))));
 		if (ascii[0] >= 'a' && ascii[0] <= 'z' && ascii[1] != 0)
 		{
 			// capitalize


### PR DESCRIPTION
Even if we use scan codes internally for keybinds (since #3470), we should _display_ the virtual key names to the user for clarity.