### PR TITLE
Fix: Non-builtin map replay desync

### DIFF
--- a/src/multiint.cpp
+++ b/src/multiint.cpp
@@ -8757,7 +8757,7 @@ bool WZGameReplayOptionsHandler::restoreOptions(const nlohmann::json& object, Em
 	}
 	// Must restore `useTerrainOverrides` (this matters for re-loading the map!) - see loadMapPreview() in multiint.cpp
 	builtInMap = (mapData->realFileName == nullptr);
-	useTerrainOverrides = shouldLoadTerrainTypeOverrides(mapData->pName);
+	useTerrainOverrides = builtInMap && shouldLoadTerrainTypeOverrides(mapData->pName);
 
 	for (Sha256 &hash : game.modHashes)
 	{


### PR DESCRIPTION
Fixes: #3496 

(Reproducing this desync required a non-builtin map with properties that would be modified by errantly applying terrain type overrides.)