### PR TITLE
Add "direction" JS field to Structure objects

### DIFF
--- a/doc/js-objects.md
+++ b/doc/js-objects.md
@@ -25,6 +25,7 @@ In addition, the following properties are defined:
 * ```status``` The completeness status of the structure. It will be one of ```BEING_BUILT``` and ```BUILT```.
 * ```type``` The type will always be ```STRUCTURE```.
 * ```cost``` What it would cost to build this structure. (3.2+ only)
+* ```direction``` The direction the structure is facing. (4.4+ only)
 * ```stattype``` The stattype defines the type of structure. It will be one of ```HQ```, ```FACTORY```, ```POWER_GEN```,
 ```RESOURCE_EXTRACTOR```, ```LASSAT```, ```DEFENSE```, ```WALL```, ```RESEARCH_LAB```, ```REPAIR_FACILITY```,
 ```CYBORG_FACTORY```, ```VTOL_FACTORY```, ```REARM_PAD```, ```SAT_UPLINK```, ```GATE``` and ```COMMAND_CONTROL```.
@@ -93,6 +94,7 @@ the action directly, but it may be interesting to look at what it currently is.
 * ```experience``` Amount of experience this droid has, based on damage it has dealt to enemies.
 * ```cost``` What it would cost to build the droid. (3.2+ only)
 * ```isVTOL``` True if the droid is VTOL. (3.2+ only)
+* ```isFlying``` True if the droid is currently flying. (4.4+ only)
 * ```canHitAir``` True if the droid has anti-air capabilities. (3.2+ only)
 * ```canHitGround``` True if the droid has anti-ground capabilities. (3.2+ only)
 * ```isSensor``` True if the droid has sensor ability. (3.2+ only)

--- a/doc/js-objects.md
+++ b/doc/js-objects.md
@@ -25,7 +25,7 @@ In addition, the following properties are defined:
 * ```status``` The completeness status of the structure. It will be one of ```BEING_BUILT``` and ```BUILT```.
 * ```type``` The type will always be ```STRUCTURE```.
 * ```cost``` What it would cost to build this structure. (3.2+ only)
-* ```direction``` The direction the structure is facing. (4.4+ only)
+* ```direction``` The direction the structure is facing. (4.5+ only)
 * ```stattype``` The stattype defines the type of structure. It will be one of ```HQ```, ```FACTORY```, ```POWER_GEN```,
 ```RESOURCE_EXTRACTOR```, ```LASSAT```, ```DEFENSE```, ```WALL```, ```RESEARCH_LAB```, ```REPAIR_FACILITY```,
 ```CYBORG_FACTORY```, ```VTOL_FACTORY```, ```REARM_PAD```, ```SAT_UPLINK```, ```GATE``` and ```COMMAND_CONTROL```.
@@ -94,7 +94,6 @@ the action directly, but it may be interesting to look at what it currently is.
 * ```experience``` Amount of experience this droid has, based on damage it has dealt to enemies.
 * ```cost``` What it would cost to build the droid. (3.2+ only)
 * ```isVTOL``` True if the droid is VTOL. (3.2+ only)
-* ```isFlying``` True if the droid is currently flying. (4.4+ only)
 * ```canHitAir``` True if the droid has anti-air capabilities. (3.2+ only)
 * ```canHitGround``` True if the droid has anti-ground capabilities. (3.2+ only)
 * ```isSensor``` True if the droid has sensor ability. (3.2+ only)

--- a/src/droid.cpp
+++ b/src/droid.cpp
@@ -2810,7 +2810,7 @@ bool isVtolDroid(const DROID *psDroid)
 bool isFlying(const DROID *psDroid)
 {
 	return (asPropulsionStats + psDroid->asBits[COMP_PROPULSION])->propulsionType == PROPULSION_TYPE_LIFT
-		   && (psDroid->sMove.Status != MOVEINACTIVE || isTransporter(psDroid));
+		   && psDroid->sMove.Status != MOVEINACTIVE;
 }
 
 /* returns true if it's a VTOL weapon droid which has completed all runs */

--- a/src/droid.cpp
+++ b/src/droid.cpp
@@ -2810,7 +2810,7 @@ bool isVtolDroid(const DROID *psDroid)
 bool isFlying(const DROID *psDroid)
 {
 	return (asPropulsionStats + psDroid->asBits[COMP_PROPULSION])->propulsionType == PROPULSION_TYPE_LIFT
-		   && psDroid->sMove.Status != MOVEINACTIVE;
+		   && (psDroid->sMove.Status != MOVEINACTIVE || isTransporter(psDroid));
 }
 
 /* returns true if it's a VTOL weapon droid which has completed all runs */

--- a/src/quickjs_backend.cpp
+++ b/src/quickjs_backend.cpp
@@ -788,6 +788,7 @@ JSValue convResearch(const RESEARCH *psResearch, JSContext *ctx, int player)
 //;; * ```status``` The completeness status of the structure. It will be one of ```BEING_BUILT``` and ```BUILT```.
 //;; * ```type``` The type will always be ```STRUCTURE```.
 //;; * ```cost``` What it would cost to build this structure. (3.2+ only)
+//;; * ```direction``` The direction the structure is facing. (4.4+ only)
 //;; * ```stattype``` The stattype defines the type of structure. It will be one of ```HQ```, ```FACTORY```, ```POWER_GEN```,
 //;; ```RESOURCE_EXTRACTOR```, ```LASSAT```, ```DEFENSE```, ```WALL```, ```RESEARCH_LAB```, ```REPAIR_FACILITY```,
 //;; ```CYBORG_FACTORY```, ```VTOL_FACTORY```, ```REARM_PAD```, ```SAT_UPLINK```, ```GATE``` and ```COMMAND_CONTROL```.
@@ -829,6 +830,7 @@ JSValue convStructure(const STRUCTURE *psStruct, JSContext *ctx)
 	QuickJS_DefinePropertyValue(ctx, value, "status", JS_NewInt32(ctx, (int)psStruct->status), JS_PROP_ENUMERABLE);
 	QuickJS_DefinePropertyValue(ctx, value, "health", JS_NewInt32(ctx, 100 * psStruct->body / MAX(1, structureBody(psStruct))), JS_PROP_ENUMERABLE);
 	QuickJS_DefinePropertyValue(ctx, value, "cost", JS_NewInt32(ctx, psStruct->pStructureType->powerToBuild), JS_PROP_ENUMERABLE);
+	QuickJS_DefinePropertyValue(ctx, value, "direction", JS_NewInt32(ctx, UNDEG(psStruct->rot.direction)), JS_PROP_ENUMERABLE);
 	int stattype = 0;
 	switch (psStruct->pStructureType->type) // don't bleed our source insanities into the scripting world
 	{
@@ -937,6 +939,7 @@ JSValue convFeature(const FEATURE *psFeature, JSContext *ctx)
 //;; * ```experience``` Amount of experience this droid has, based on damage it has dealt to enemies.
 //;; * ```cost``` What it would cost to build the droid. (3.2+ only)
 //;; * ```isVTOL``` True if the droid is VTOL. (3.2+ only)
+//;; * ```isFlying``` True if the droid is currently flying. (4.4+ only)
 //;; * ```canHitAir``` True if the droid has anti-air capabilities. (3.2+ only)
 //;; * ```canHitGround``` True if the droid has anti-ground capabilities. (3.2+ only)
 //;; * ```isSensor``` True if the droid has sensor ability. (3.2+ only)
@@ -1012,6 +1015,7 @@ JSValue convDroid(const DROID *psDroid, JSContext *ctx)
 	QuickJS_DefinePropertyValue(ctx, value, "canHitAir", JS_NewBool(ctx, aa), JS_PROP_ENUMERABLE);
 	QuickJS_DefinePropertyValue(ctx, value, "canHitGround", JS_NewBool(ctx, ga), JS_PROP_ENUMERABLE);
 	QuickJS_DefinePropertyValue(ctx, value, "isVTOL", JS_NewBool(ctx, isVtolDroid(psDroid)), JS_PROP_ENUMERABLE);
+	QuickJS_DefinePropertyValue(ctx, value, "isFlying", JS_NewBool(ctx, isFlying(psDroid)), JS_PROP_ENUMERABLE);
 	QuickJS_DefinePropertyValue(ctx, value, "droidType", JS_NewInt32(ctx, (int)type), JS_PROP_ENUMERABLE);
 	QuickJS_DefinePropertyValue(ctx, value, "experience", JS_NewFloat64(ctx, (double)psDroid->experience / 65536.0), JS_PROP_ENUMERABLE);
 	QuickJS_DefinePropertyValue(ctx, value, "health", JS_NewFloat64(ctx, 100.0 / (double)psDroid->originalBody * (double)psDroid->body), JS_PROP_ENUMERABLE);

--- a/src/quickjs_backend.cpp
+++ b/src/quickjs_backend.cpp
@@ -788,7 +788,7 @@ JSValue convResearch(const RESEARCH *psResearch, JSContext *ctx, int player)
 //;; * ```status``` The completeness status of the structure. It will be one of ```BEING_BUILT``` and ```BUILT```.
 //;; * ```type``` The type will always be ```STRUCTURE```.
 //;; * ```cost``` What it would cost to build this structure. (3.2+ only)
-//;; * ```direction``` The direction the structure is facing. (4.4+ only)
+//;; * ```direction``` The direction the structure is facing. (4.5+ only)
 //;; * ```stattype``` The stattype defines the type of structure. It will be one of ```HQ```, ```FACTORY```, ```POWER_GEN```,
 //;; ```RESOURCE_EXTRACTOR```, ```LASSAT```, ```DEFENSE```, ```WALL```, ```RESEARCH_LAB```, ```REPAIR_FACILITY```,
 //;; ```CYBORG_FACTORY```, ```VTOL_FACTORY```, ```REARM_PAD```, ```SAT_UPLINK```, ```GATE``` and ```COMMAND_CONTROL```.
@@ -939,7 +939,6 @@ JSValue convFeature(const FEATURE *psFeature, JSContext *ctx)
 //;; * ```experience``` Amount of experience this droid has, based on damage it has dealt to enemies.
 //;; * ```cost``` What it would cost to build the droid. (3.2+ only)
 //;; * ```isVTOL``` True if the droid is VTOL. (3.2+ only)
-//;; * ```isFlying``` True if the droid is currently flying. (4.4+ only)
 //;; * ```canHitAir``` True if the droid has anti-air capabilities. (3.2+ only)
 //;; * ```canHitGround``` True if the droid has anti-ground capabilities. (3.2+ only)
 //;; * ```isSensor``` True if the droid has sensor ability. (3.2+ only)
@@ -1015,7 +1014,6 @@ JSValue convDroid(const DROID *psDroid, JSContext *ctx)
 	QuickJS_DefinePropertyValue(ctx, value, "canHitAir", JS_NewBool(ctx, aa), JS_PROP_ENUMERABLE);
 	QuickJS_DefinePropertyValue(ctx, value, "canHitGround", JS_NewBool(ctx, ga), JS_PROP_ENUMERABLE);
 	QuickJS_DefinePropertyValue(ctx, value, "isVTOL", JS_NewBool(ctx, isVtolDroid(psDroid)), JS_PROP_ENUMERABLE);
-	QuickJS_DefinePropertyValue(ctx, value, "isFlying", JS_NewBool(ctx, isFlying(psDroid)), JS_PROP_ENUMERABLE);
 	QuickJS_DefinePropertyValue(ctx, value, "droidType", JS_NewInt32(ctx, (int)type), JS_PROP_ENUMERABLE);
 	QuickJS_DefinePropertyValue(ctx, value, "experience", JS_NewFloat64(ctx, (double)psDroid->experience / 65536.0), JS_PROP_ENUMERABLE);
 	QuickJS_DefinePropertyValue(ctx, value, "health", JS_NewFloat64(ctx, 100.0 / (double)psDroid->originalBody * (double)psDroid->body), JS_PROP_ENUMERABLE);


### PR DESCRIPTION
Adds a `direction` field to JS Structure objects, which represents the direction the structure is facing (from 0 to 3, representing 90 degree increments). 
~~Adds an `isFlying` field to JS Droid objects, which is true if the droid (VTOL or Transport) is currently in the air, false otherwise.~~
See #3830 for the `isFlying` field.