### PR TITLE
[Vulkan] Default-disable additional problematic layers

### DIFF
--- a/lib/ivis_opengl/gfx_api_vk.h
+++ b/lib/ivis_opengl/gfx_api_vk.h
@@ -98,6 +98,8 @@ namespace gfx_api
 
 		// Use this function to get the size of the window's underlying drawable dimensions in pixels. This is used for setting viewport sizes, scissor rectangles, and other places where the a VkExtent might show up in relation to the window.
 		virtual void getDrawableSize(int* w, int* h) = 0;
+
+		virtual bool allowImplicitLayers() const = 0;
 	};
 }
 

--- a/lib/sdl/gfx_api_sdl.cpp
+++ b/lib/sdl/gfx_api_sdl.cpp
@@ -46,7 +46,7 @@ std::unique_ptr<gfx_api::backend_Vulkan_Impl> SDL_gfx_api_Impl_Factory::createVu
 {
 	ASSERT_OR_RETURN(nullptr, window != nullptr, "Invalid SDL_Window*");
 #if defined(HAVE_SDL_VULKAN_H)
-	return std::unique_ptr<gfx_api::backend_Vulkan_Impl>(new sdl_Vulkan_Impl(window));
+	return std::unique_ptr<gfx_api::backend_Vulkan_Impl>(new sdl_Vulkan_Impl(window, config.allowImplicitLayers));
 #else // !defined(HAVE_SDL_VULKAN_H)
 	SDL_version compiled_version;
 	SDL_VERSION(&compiled_version);

--- a/lib/sdl/gfx_api_sdl.h
+++ b/lib/sdl/gfx_api_sdl.h
@@ -30,8 +30,11 @@ class SDL_gfx_api_Impl_Factory final : public gfx_api::backend_Impl_Factory
 public:
 	struct Configuration
 	{
+		// OpenGL
 		bool useOpenGLES = false;
 		bool useOpenGLESLibrary = false;
+		// Vulkan
+		bool allowImplicitLayers = false;
 	};
 public:
 	SDL_gfx_api_Impl_Factory(SDL_Window* window, Configuration config);

--- a/lib/sdl/gfx_api_vk_sdl.cpp
+++ b/lib/sdl/gfx_api_vk_sdl.cpp
@@ -24,10 +24,11 @@
 #include <SDL_vulkan.h>
 #include <SDL_version.h>
 
-sdl_Vulkan_Impl::sdl_Vulkan_Impl(SDL_Window* _window)
+sdl_Vulkan_Impl::sdl_Vulkan_Impl(SDL_Window* _window, bool _allowImplicitLayers)
 {
 	ASSERT(_window != nullptr, "Invalid SDL_Window*");
 	window = _window;
+	m_allowImplicitLayers = _allowImplicitLayers;
 }
 
 PFN_vkGetInstanceProcAddr sdl_Vulkan_Impl::getVkGetInstanceProcAddr()
@@ -77,6 +78,11 @@ bool sdl_Vulkan_Impl::createWindowSurface(VkInstance instance, VkSurfaceKHR* sur
 void sdl_Vulkan_Impl::getDrawableSize(int* w, int* h)
 {
 	SDL_Vulkan_GetDrawableSize(window, w, h);
+}
+
+bool sdl_Vulkan_Impl::allowImplicitLayers() const
+{
+	return m_allowImplicitLayers;
 }
 
 #endif // defined(WZ_VULKAN_ENABLED) && defined(HAVE_SDL_VULKAN_H)

--- a/lib/sdl/gfx_api_vk_sdl.h
+++ b/lib/sdl/gfx_api_vk_sdl.h
@@ -30,7 +30,7 @@
 class sdl_Vulkan_Impl final : public gfx_api::backend_Vulkan_Impl
 {
 public:
-	sdl_Vulkan_Impl(SDL_Window* window);
+	sdl_Vulkan_Impl(SDL_Window* window, bool allowImplicitLayers);
 
 	virtual PFN_vkGetInstanceProcAddr getVkGetInstanceProcAddr() override;
 	virtual bool getRequiredInstanceExtensions(std::vector<const char*> &output) override;
@@ -39,8 +39,11 @@ public:
 	// Use this function to get the size of the window's underlying drawable dimensions in pixels. This is used for setting viewport sizes, scissor rectangles, and other places where a VkExtent might show up in relation to the window.
 	virtual void getDrawableSize(int* w, int* h) override;
 
+	virtual bool allowImplicitLayers() const override;
+
 private:
 	SDL_Window* window;
+	bool m_allowImplicitLayers = false;
 };
 
 #endif // defined(WZ_VULKAN_ENABLED) && defined(HAVE_SDL_VULKAN_H)

--- a/lib/sdl/main_sdl.cpp
+++ b/lib/sdl/main_sdl.cpp
@@ -2973,6 +2973,10 @@ optional<SDL_gfx_api_Impl_Factory::Configuration> wzMainScreenSetup_CreateVideoW
 	SDL_gfx_api_Impl_Factory::Configuration sdl_impl_config;
 	sdl_impl_config.useOpenGLES = useOpenGLES;
 	sdl_impl_config.useOpenGLESLibrary = useOpenGLESLibrary;
+	if (backend == video_backend::vulkan)
+	{
+		sdl_impl_config.allowImplicitLayers = war_getAllowVulkanImplicitLayers();
+	}
 	return sdl_impl_config;
 }
 

--- a/src/clparse.cpp
+++ b/src/clparse.cpp
@@ -358,7 +358,8 @@ typedef enum
 	CLI_GAMELOG_FRAMEINTERVAL,
 	CLI_GAMETIMELIMITMINUTES,
 	CLI_CONVERT_SPECULAR_MAP,
-	CLI_DEBUG_VERBOSE_SYNCLOG_OUTPUT
+	CLI_DEBUG_VERBOSE_SYNCLOG_OUTPUT,
+	CLI_ALLOW_VULKAN_IMPLICIT_LAYERS
 } CLI_OPTIONS;
 
 // Separate table that avoids *any* translated strings, to avoid any risk of gettext / libintl function calls
@@ -445,6 +446,7 @@ static const struct poptOption *getOptionsTable()
 		{ "gametimelimit", POPT_ARG_STRING, CLI_GAMETIMELIMITMINUTES, N_("Multiplayer game time limit (in minutes)"), N_("number of minutes")},
 		{ "convert-specular-map", POPT_ARG_STRING, CLI_CONVERT_SPECULAR_MAP, N_("Convert a specular-map .png to a luma, single-channel, grayscale .png (and exit)"), "inputpath/filename.png:outputpath/filename.png" },
 		{ "debug-verbose-sync-logs-until", POPT_ARG_STRING, CLI_DEBUG_VERBOSE_SYNCLOG_OUTPUT, nullptr, nullptr },
+		{ "allow-vulkan-implicit-layers", POPT_ARG_NONE, CLI_ALLOW_VULKAN_IMPLICIT_LAYERS, N_("Allow Vulkan implicit layers (that may be default-disabled due to potential crashes or bugs)"), nullptr },
 
 		// Terminating entry
 		{ nullptr, 0, 0,              nullptr,                                    nullptr },
@@ -1271,6 +1273,10 @@ bool ParseCommandLine(int argc, const char * const *argv)
 				qFatal("Bad debug verbose synclog output gametime limit");
 			}
 			NET_setDebuggingModeVerboseOutputAllSyncLogs(atoi(token));
+			break;
+
+		case CLI_ALLOW_VULKAN_IMPLICIT_LAYERS:
+			war_runtimeOnlySetAllowVulkanImplicitLayers(true);
 			break;
 
 		} // switch (option)

--- a/src/warzoneconfig.cpp
+++ b/src/warzoneconfig.cpp
@@ -91,6 +91,9 @@ struct WARZONE_GLOBALS
 	uint32_t shadowMapResolution = 0; // this defaults to 0, which causes the gfx backend to figure out a recommended default based on the system properties
 	// groups UI
 	bool groupsMenuEnabled = true;
+
+	// run-time only settings (not persisted to config!)
+	bool allowVulkanImplicitLayers = false;
 };
 
 static WARZONE_GLOBALS warGlobs;
@@ -655,4 +658,14 @@ bool war_getGroupsMenuEnabled()
 void war_setGroupsMenuEnabled(bool enabled)
 {
 	warGlobs.groupsMenuEnabled = enabled;
+}
+
+void war_runtimeOnlySetAllowVulkanImplicitLayers(bool allowed) // not persisted to config
+{
+	warGlobs.allowVulkanImplicitLayers = allowed;
+}
+
+bool war_getAllowVulkanImplicitLayers()
+{
+	return warGlobs.allowVulkanImplicitLayers;
 }

--- a/src/warzoneconfig.h
+++ b/src/warzoneconfig.h
@@ -165,6 +165,9 @@ void war_setShadowMapResolution(uint32_t resolution);
 bool war_getGroupsMenuEnabled();
 void war_setGroupsMenuEnabled(bool enabled);
 
+void war_runtimeOnlySetAllowVulkanImplicitLayers(bool allowed); // not persisted to config
+bool war_getAllowVulkanImplicitLayers();
+
 /**
  * Enable or disable sound initialization
  *


### PR DESCRIPTION
Add `--allow-vulkan-implicit-layers` CLI option, to allow default-disabled layers.