### PR TITLE
Check for non-default sensor/ecm stats like with repair

### DIFF
--- a/src/design.cpp
+++ b/src/design.cpp
@@ -2870,8 +2870,8 @@ bool intValidTemplate(DROID_TEMPLATE *psTempl, const char *newName, bool complai
 
 	// Check no mixing of systems and weapons
 	if (psTempl->numWeaps != 0 &&
-	    (psTempl->asParts[COMP_SENSOR] ||
-	     psTempl->asParts[COMP_ECM] ||
+	    ((psTempl->asParts[COMP_SENSOR] && psTempl->asParts[COMP_SENSOR] != aDefaultSensor[player]) ||
+	     (psTempl->asParts[COMP_ECM] && psTempl->asParts[COMP_ECM] != aDefaultECM[player]) ||
 	     (psTempl->asParts[COMP_REPAIRUNIT] && psTempl->asParts[COMP_REPAIRUNIT] != aDefaultRepair[player]) ||
 	     psTempl->asParts[COMP_CONSTRUCT]))
 	{


### PR DESCRIPTION
It is not possible to replace the default sensor/ECM unlike the repair component. This will allow more modding potential and eventually allow me to give Nexus spawns and manufactured units the default NavGunSensor through research in Gamma campaign like prior to 3.3.0. Eventually, the JS API should have a way to specify these components when building units/structures.