### PR TITLE
Revert "[Snap] Default SDL_VIDEODRIVER in warzone2100-launcher.sh"

### DIFF
--- a/pkg/snap/warzone2100-launcher.sh
+++ b/pkg/snap/warzone2100-launcher.sh
@@ -11,9 +11,4 @@ fi
 export XDG_DATA_HOME="${SNAP_USER_COMMON}"
 export XDG_CONFIG_HOME="${SNAP_USER_COMMON}"
 
-# default SDL_VIDEODRIVER if unset (prefer wayland)
-if [ -z "${SDL_VIDEODRIVER}" ]; then
-	export SDL_VIDEODRIVER="wayland,x11"
-fi
-
 exec "$@"


### PR DESCRIPTION
This reverts commit 10d244555f0401f89d14f73fef5e5c1b52f4c82b.

The Snap seems to currently work better with various graphics cards and drivers when defaulting to X11 (unfortunately).

For future investigation:
https://bugs.launchpad.net/snapd/+bug/2037544