### PR TITLE
Radar moves camera at a speed indepenent on game speed

### DIFF
--- a/src/warcam.cpp
+++ b/src/warcam.cpp
@@ -981,7 +981,8 @@ void requestRadarTrack(SDWORD x, SDWORD y)
 {
 	auto initialPosition = Vector3f(playerPos.p);
 	auto targetPosition = Vector3f(x, calculateCameraHeightAt(map_coord(x), map_coord(y)), y);
-	auto animationDuration = static_cast<uint32_t>(glm::log(glm::length(targetPosition - initialPosition)) * 100);
+	auto currentGameSpeed = static_cast<float>(gameTimeGetMod().asDouble());
+	auto animationDuration = static_cast<uint32_t>(glm::log(glm::length(targetPosition - initialPosition)) * 100 * currentGameSpeed);
 	auto finalRotation = trackingCamera.status == CAM_TRACK_DROID ? trackingCamera.oldView.r : playerPos.r;
 	finalRotation.z = 0;
 


### PR DESCRIPTION
The speed of the rader moves camera is not adjusted according to the speed of the game, and it is operated at a consistent speed. 
In a simple way, the current game speed was multiplied by the calculation formula of the camera's animation duration.
I expect that this will allow the camera to perform radar functions at a stable speed, even if the game speed is extremely slow or increased.

The related issue numbers are as follows. #3388 