### PR TITLE
Clear active console messages when resuming from paused state

### DIFF
--- a/src/keybind.cpp
+++ b/src/keybind.cpp
@@ -1476,6 +1476,8 @@ void	kf_TogglePauseMode()
 			wzGrabMouse();
 		}
 
+		clearActiveConsole();
+
 		/* And start the clock again */
 		gameTimeStart();
 	}


### PR DESCRIPTION
Wipes the "blue text box" area after resuming the game.

Fixes #3531.