### PR TITLE
Use `std::make_{unique,shared}` instead of raw `new`

### DIFF
--- a/lib/ivis_opengl/gfx_api_gl.cpp
+++ b/lib/ivis_opengl/gfx_api_gl.cpp
@@ -3075,7 +3075,7 @@ bool gl_context::getScreenshot(std::function<void (std::unique_ptr<iV_Image>)> c
 		return false;
 	}
 
-	auto image = std::unique_ptr<iV_Image>(new iV_Image());
+	auto image = std::make_unique<iV_Image>();
 	auto width = m_viewport[2];
 	auto height = m_viewport[3];
 	bool allocateResult = image->allocate(width, height, channelsPerPixel); // RGB

--- a/lib/ivis_opengl/gfx_api_image_basis_priv.cpp
+++ b/lib/ivis_opengl/gfx_api_image_basis_priv.cpp
@@ -409,7 +409,7 @@ static std::vector<std::unique_ptr<iV_BaseImage>> loadiVImagesFromFile_Basis_Dat
 			ASSERT_OR_RETURN({}, format == basist::transcoder_texture_format::cTFRGBA32, "Unsupported uncompressed format: %u", (unsigned)format);
 			numBlocksOrPixels = level_info.m_orig_width * level_info.m_orig_height;
 
-			uncompressedOutput = std::unique_ptr<iV_Image>(new iV_Image());
+			uncompressedOutput = std::make_unique<iV_Image>();
 			if (!uncompressedOutput->allocate(level_info.m_orig_width, level_info.m_orig_height, 4, false)) // hard-coded for RGBA32 for now
 			{
 				debug(LOG_ERROR, "Failed to allocate memory for uncompressed image buffer");
@@ -421,7 +421,7 @@ static std::vector<std::unique_ptr<iV_BaseImage>> loadiVImagesFromFile_Basis_Dat
 			numBlocksOrPixels = level_info.m_total_blocks;
 			uint32_t outputSize = numBlocksOrPixels * bytes_per_block_or_pixel;
 
-			compressedOutput = std::unique_ptr<iV_CompressedImage>(new iV_CompressedImage());
+			compressedOutput = std::make_unique<iV_CompressedImage>();
 			if (!compressedOutput->allocate(internalFormat, outputSize, level_info.m_width, level_info.m_height, level_info.m_orig_width, level_info.m_orig_height, false))
 			{
 				debug(LOG_ERROR, "Failed to allocate memory for buffer");

--- a/lib/ivis_opengl/gfx_api_image_compress_priv.cpp
+++ b/lib/ivis_opengl/gfx_api_image_compress_priv.cpp
@@ -286,7 +286,7 @@ static std::unique_ptr<iV_CompressedImage> compressImageEtcPak(const iV_Image& i
 
 	size_t outputSize = gfx_api::format_memory_size(desiredFormat, originalWidth, originalHeight);
 
-	std::unique_ptr<iV_CompressedImage> compressedOutput = std::unique_ptr<iV_CompressedImage>(new iV_CompressedImage());
+	std::unique_ptr<iV_CompressedImage> compressedOutput = std::make_unique<iV_CompressedImage>();
 	if (!compressedOutput->allocate(desiredFormat, outputSize, alignedWidth, alignedHeight, originalWidth, originalHeight, false))
 	{
 		debug(LOG_ERROR, "Failed to allocate memory for buffer");

--- a/lib/ivis_opengl/textdraw.cpp
+++ b/lib/ivis_opengl/textdraw.cpp
@@ -1067,13 +1067,13 @@ static bool inline initializeCJKFontsIfNeeded()
 	uint32_t horizDPI = static_cast<uint32_t>(DEFAULT_DPI * _horizScaleFactor);
 	uint32_t vertDPI = static_cast<uint32_t>(DEFAULT_DPI * _vertScaleFactor);
 	try {
-		cjkFonts->regular = std::unique_ptr<FTFace>(new FTFace(getGlobalFTlib().lib, CJK_FONT_PATH, 12 * 64, horizDPI, vertDPI, 400));
-		cjkFonts->regularBold = std::unique_ptr<FTFace>(new FTFace(getGlobalFTlib().lib, CJK_FONT_PATH, 12 * 64, horizDPI, vertDPI, 700));
-		cjkFonts->bold = std::unique_ptr<FTFace>(new FTFace(getGlobalFTlib().lib, CJK_FONT_PATH, 21 * 64, horizDPI, vertDPI, 400));
-		cjkFonts->medium = std::unique_ptr<FTFace>(new FTFace(getGlobalFTlib().lib, CJK_FONT_PATH, 16 * 64, horizDPI, vertDPI, 400));
-		cjkFonts->mediumBold = std::unique_ptr<FTFace>(new FTFace(getGlobalFTlib().lib, CJK_FONT_PATH, 16 * 64, horizDPI, vertDPI, 700));
-		cjkFonts->small = std::unique_ptr<FTFace>(new FTFace(getGlobalFTlib().lib, CJK_FONT_PATH, 9 * 64, horizDPI, vertDPI, 400));
-		cjkFonts->smallBold = std::unique_ptr<FTFace>(new FTFace(getGlobalFTlib().lib, CJK_FONT_PATH, 9 * 64, horizDPI, vertDPI, 700));
+		cjkFonts->regular = std::make_unique<FTFace>(getGlobalFTlib().lib, CJK_FONT_PATH, 12 * 64, horizDPI, vertDPI, 400);
+		cjkFonts->regularBold = std::make_unique<FTFace>(getGlobalFTlib().lib, CJK_FONT_PATH, 12 * 64, horizDPI, vertDPI, 700);
+		cjkFonts->bold = std::make_unique<FTFace>(getGlobalFTlib().lib, CJK_FONT_PATH, 21 * 64, horizDPI, vertDPI, 400);
+		cjkFonts->medium = std::make_unique<FTFace>(getGlobalFTlib().lib, CJK_FONT_PATH, 16 * 64, horizDPI, vertDPI, 400);
+		cjkFonts->mediumBold = std::make_unique<FTFace>(getGlobalFTlib().lib, CJK_FONT_PATH, 16 * 64, horizDPI, vertDPI, 700);
+		cjkFonts->small = std::make_unique<FTFace>(getGlobalFTlib().lib, CJK_FONT_PATH, 9 * 64, horizDPI, vertDPI, 400);
+		cjkFonts->smallBold = std::make_unique<FTFace>(getGlobalFTlib().lib, CJK_FONT_PATH, 9 * 64, horizDPI, vertDPI, 700);
 	}
 	catch (const std::exception &e) {
 		debug(LOG_ERROR, "Failed to load font:\n%s", e.what());
@@ -1175,13 +1175,13 @@ void iV_TextInit(unsigned int horizScalePercentage, unsigned int vertScalePercen
 	}
 
 	try {
-		baseFonts->regular = std::unique_ptr<FTFace>(new FTFace(getGlobalFTlib().lib, "fonts/DejaVuSans.ttf", 12 * 64, horizDPI, vertDPI));
-		baseFonts->regularBold = std::unique_ptr<FTFace>(new FTFace(getGlobalFTlib().lib, "fonts/DejaVuSans-Bold.ttf", 12 * 64, horizDPI, vertDPI));
-		baseFonts->bold = std::unique_ptr<FTFace>(new FTFace(getGlobalFTlib().lib, "fonts/DejaVuSans-Bold.ttf", 21 * 64, horizDPI, vertDPI));
-		baseFonts->medium = std::unique_ptr<FTFace>(new FTFace(getGlobalFTlib().lib, "fonts/DejaVuSans.ttf", 16 * 64, horizDPI, vertDPI));
-		baseFonts->mediumBold = std::unique_ptr<FTFace>(new FTFace(getGlobalFTlib().lib, "fonts/DejaVuSans-Bold.ttf", 16 * 64, horizDPI, vertDPI));
-		baseFonts->small = std::unique_ptr<FTFace>(new FTFace(getGlobalFTlib().lib, "fonts/DejaVuSans.ttf", 9 * 64, horizDPI, vertDPI));
-		baseFonts->smallBold = std::unique_ptr<FTFace>(new FTFace(getGlobalFTlib().lib, "fonts/DejaVuSans-Bold.ttf", 9 * 64, horizDPI, vertDPI));
+		baseFonts->regular = std::make_unique<FTFace>(getGlobalFTlib().lib, "fonts/DejaVuSans.ttf", 12 * 64, horizDPI, vertDPI);
+		baseFonts->regularBold = std::make_unique<FTFace>(getGlobalFTlib().lib, "fonts/DejaVuSans-Bold.ttf", 12 * 64, horizDPI, vertDPI);
+		baseFonts->bold = std::make_unique<FTFace>(getGlobalFTlib().lib, "fonts/DejaVuSans-Bold.ttf", 21 * 64, horizDPI, vertDPI);
+		baseFonts->medium = std::make_unique<FTFace>(getGlobalFTlib().lib, "fonts/DejaVuSans.ttf", 16 * 64, horizDPI, vertDPI);
+		baseFonts->mediumBold = std::make_unique<FTFace>(getGlobalFTlib().lib, "fonts/DejaVuSans-Bold.ttf", 16 * 64, horizDPI, vertDPI);
+		baseFonts->small = std::make_unique<FTFace>(getGlobalFTlib().lib, "fonts/DejaVuSans.ttf", 9 * 64, horizDPI, vertDPI);
+		baseFonts->smallBold = std::make_unique<FTFace>(getGlobalFTlib().lib, "fonts/DejaVuSans-Bold.ttf", 9 * 64, horizDPI, vertDPI);
 	}
 	catch (const std::exception &e) {
 		// Log lots of details:

--- a/lib/netplay/netplay.h
+++ b/lib/netplay/netplay.h
@@ -552,7 +552,7 @@ struct PlayerReference
 
 	void disconnect()
 	{
-		detached = std::unique_ptr<PLAYER>(new PLAYER(NetPlay.players[index]));
+		detached = std::make_unique<PLAYER>(NetPlay.players[index]);
 		detached->wzFiles = std::make_shared<std::vector<WZFile>>();
 	}
 

--- a/lib/netplay/netreplay.cpp
+++ b/lib/netplay/netreplay.cpp
@@ -189,7 +189,7 @@ bool NETreplaySaveStart(std::string const& subdir, ReplayOptionsHandler const &o
 	latestWriteBuffer.reserve(minBufferSizeToQueue);
 	if (desiredBufferSize != std::numeric_limits<size_t>::max())
 	{
-		saveThread = std::unique_ptr<wz::thread>(new wz::thread(replaySaveThreadFunc, replaySaveHandle));
+		saveThread = std::make_unique<wz::thread>(replaySaveThreadFunc, replaySaveHandle);
 	}
 	else
 	{
@@ -415,7 +415,7 @@ bool NETreplayLoadNetMessage(std::unique_ptr<NetMessage> &message, uint8_t &play
 		return false;
 	}
 
-	message = std::unique_ptr<NetMessage>(new NetMessage(type));
+	message = std::make_unique<NetMessage>(type);
 	message->data.resize(len);
 	size_t messageRead = WZ_PHYSFS_readBytes(replayLoadHandle, message->data.data(), message->data.size());
 	if (messageRead != message->data.size())

--- a/lib/netplay/nettypes.cpp
+++ b/lib/netplay/nettypes.cpp
@@ -1064,7 +1064,7 @@ bool NETloadReplay(std::string const &filename, ReplayOptionsHandler& optionsHan
 		return false;
 	}
 	// Add special REPLAY_ENDED message to the end of the host's gameQueue
-	newMessage = std::unique_ptr<NetMessage>(new NetMessage(REPLAY_ENDED));
+	newMessage = std::make_unique<NetMessage>(REPLAY_ENDED);
 	gameQueues[NetPlay.hostPlayer]->pushMessage(*newMessage);
 	NETreplayLoadStop();
 	bIsReplay = true;

--- a/lib/sdl/gfx_api_sdl.cpp
+++ b/lib/sdl/gfx_api_sdl.cpp
@@ -32,13 +32,13 @@ SDL_gfx_api_Impl_Factory::SDL_gfx_api_Impl_Factory(SDL_Window* _window, SDL_gfx_
 
 std::unique_ptr<gfx_api::backend_Null_Impl> SDL_gfx_api_Impl_Factory::createNullBackendImpl() const
 {
-	return std::unique_ptr<gfx_api::backend_Null_Impl>(new sdl_Null_Impl());
+	return std::make_unique<sdl_Null_Impl>();
 }
 
 std::unique_ptr<gfx_api::backend_OpenGL_Impl> SDL_gfx_api_Impl_Factory::createOpenGLBackendImpl() const
 {
 	ASSERT_OR_RETURN(nullptr, window != nullptr, "Invalid SDL_Window*");
-	return std::unique_ptr<gfx_api::backend_OpenGL_Impl>(new sdl_OpenGL_Impl(window, config.useOpenGLES, config.useOpenGLESLibrary));
+	return std::make_unique<sdl_OpenGL_Impl>(window, config.useOpenGLES, config.useOpenGLESLibrary);
 }
 
 #if defined(WZ_VULKAN_ENABLED)
@@ -46,7 +46,7 @@ std::unique_ptr<gfx_api::backend_Vulkan_Impl> SDL_gfx_api_Impl_Factory::createVu
 {
 	ASSERT_OR_RETURN(nullptr, window != nullptr, "Invalid SDL_Window*");
 #if defined(HAVE_SDL_VULKAN_H)
-	return std::unique_ptr<gfx_api::backend_Vulkan_Impl>(new sdl_Vulkan_Impl(window, config.allowImplicitLayers));
+	return std::make_unique<sdl_Vulkan_Impl>(window, config.allowImplicitLayers);
 #else // !defined(HAVE_SDL_VULKAN_H)
 	SDL_version compiled_version;
 	SDL_VERSION(&compiled_version);

--- a/lib/sound/oggvorbis.cpp
+++ b/lib/sound/oggvorbis.cpp
@@ -145,7 +145,7 @@ WZVorbisDecoder* WZVorbisDecoder::fromFilename(const char* fileName)
 		debug(LOG_ERROR, "sound_LoadTrackFromFile: PHYSFS_openRead(\"%s\") failed with error: %s\n", fileName, WZ_PHYSFS_getLastError());
 		return nullptr;
 	}
-	std::unique_ptr<OggVorbis_File> ovf = std::unique_ptr<OggVorbis_File>(new OggVorbis_File());
+	std::unique_ptr<OggVorbis_File> ovf = std::make_unique<OggVorbis_File>();
 	// https://xiph.org/vorbis/doc/vorbisfile/ov_open_callbacks.html
 	const int error = ov_open_callbacks(fileHandle, ovf.get(), nullptr, 0, wz_oggVorbis_callbacks);
 	if (error != 0)

--- a/lib/widget/paragraph.cpp
+++ b/lib/widget/paragraph.cpp
@@ -480,14 +480,14 @@ std::vector<std::vector<FlowLayoutFragment>> Paragraph::calculateLinesLayout()
 void Paragraph::addText(std::string const &text)
 {
 	layoutDirty = true;
-	elements.push_back(std::unique_ptr<ParagraphTextElement>(new ParagraphTextElement(text, textStyle)));
+	elements.push_back(std::make_unique<ParagraphTextElement>(text, textStyle));
 }
 
 void Paragraph::addWidget(const std::shared_ptr<WIDGET> &widget, int32_t aboveBase)
 {
 	layoutDirty = true;
 	attach(widget);
-	elements.push_back(std::unique_ptr<ParagraphWidgetElement>(new ParagraphWidgetElement(widget, aboveBase)));
+	elements.push_back(std::make_unique<ParagraphWidgetElement>(widget, aboveBase));
 }
 
 void Paragraph::geometryChanged()

--- a/lib/widget/paragraph.h
+++ b/lib/widget/paragraph.h
@@ -72,7 +72,7 @@ public:
 	{
 		if (!cachedText)
 		{
-			cachedText = std::unique_ptr<WzText>(new WzText(text, font));
+			cachedText = std::make_unique<WzText>(text, font);
 		}
 
 		cacheExpireAt = realTime + (cacheDurationMs * GAME_TICKS_PER_SEC) / 1000;

--- a/lib/wzmaplib/CMakeLists.txt
+++ b/lib/wzmaplib/CMakeLists.txt
@@ -45,7 +45,7 @@ set_target_properties(wzmaplib PROPERTIES VERSION "${WZMAPLIB_VERSION_STRING}")
 
 set_target_properties(wzmaplib
 	PROPERTIES
-		CXX_STANDARD 11
+		CXX_STANDARD 14
 		CXX_STANDARD_REQUIRED YES
 		CXX_EXTENSIONS NO
 )
@@ -170,7 +170,7 @@ if (libzip_FOUND AND libzip_LINK_TEST)
 	set_property(TARGET ZipIOProvider PROPERTY FOLDER "lib")
 	set_target_properties(ZipIOProvider
 		PROPERTIES
-			CXX_STANDARD 11
+			CXX_STANDARD 14
 			CXX_STANDARD_REQUIRED YES
 			CXX_EXTENSIONS NO
 	)

--- a/lib/wzmaplib/include/wzmaplib/map.h
+++ b/lib/wzmaplib/include/wzmaplib/map.h
@@ -128,7 +128,7 @@ std::string to_string(MapType mapType);
 class Map
 {
 private:
-	Map(const std::string& mapFolderPath, MapType mapType, uint32_t mapMaxPlayers, std::shared_ptr<LoggingProtocol> logger, std::shared_ptr<IOProvider> mapIO = std::shared_ptr<IOProvider>(new StdIOProvider()));
+	Map(const std::string& mapFolderPath, MapType mapType, uint32_t mapMaxPlayers, std::shared_ptr<LoggingProtocol> logger, std::shared_ptr<IOProvider> mapIO = std::make_shared<StdIOProvider>());
 
 public:
 	// Construct an empty Map, for modification
@@ -138,10 +138,10 @@ public:
 	// - seed (a seed used for random script-based maps generation)
 	// - a logger
 	// - a WzMap::IOProvider
-	static std::shared_ptr<Map> loadFromPath(const std::string& mapFolderPath, MapType mapType, uint32_t mapMaxPlayers, uint32_t seed, std::shared_ptr<LoggingProtocol> logger = nullptr, std::shared_ptr<IOProvider> mapIO = std::shared_ptr<IOProvider>(new StdIOProvider()));
+	static std::shared_ptr<Map> loadFromPath(const std::string& mapFolderPath, MapType mapType, uint32_t mapMaxPlayers, uint32_t seed, std::shared_ptr<LoggingProtocol> logger = nullptr, std::shared_ptr<IOProvider> mapIO = std::make_shared<StdIOProvider>());
 
 	// Export a map to a specified folder path in a specified output format (version)
-	static bool exportMapToPath(Map& map, const std::string& mapFolderPath, MapType mapType, uint32_t mapMaxPlayers, OutputFormat format, std::shared_ptr<LoggingProtocol> logger = nullptr, std::shared_ptr<IOProvider> mapIO = std::shared_ptr<IOProvider>(new StdIOProvider()));
+	static bool exportMapToPath(Map& map, const std::string& mapFolderPath, MapType mapType, uint32_t mapMaxPlayers, OutputFormat format, std::shared_ptr<LoggingProtocol> logger = nullptr, std::shared_ptr<IOProvider> mapIO = std::make_shared<StdIOProvider>());
 
 	// High-level data loading functions
 

--- a/lib/wzmaplib/include/wzmaplib/map_package.h
+++ b/lib/wzmaplib/include/wzmaplib/map_package.h
@@ -115,7 +115,7 @@ public:
 	// The default StdIOProvider will assume pathToMapPackage is a path to an extracted map package (i.e. standard filesystem I/O)
 	//
 	// To load from an archive (.zip/.wz), create a custom implementation of WzMap::IOProvider that supports compressed archive files that you initialize with the path to the zip. An example of this (which uses libzip) is available in `plugins/ZipIOProvider`. You would then set `pathToMapPackage` to be the root path inside the zip. (In the case of plugins\ZipIOProvider, literally "/" or "").
-	static std::unique_ptr<MapPackage> loadPackage(const std::string& pathToMapPackage, std::shared_ptr<LoggingProtocol> logger = nullptr, std::shared_ptr<IOProvider> mapIO = std::shared_ptr<IOProvider>(new StdIOProvider()));
+	static std::unique_ptr<MapPackage> loadPackage(const std::string& pathToMapPackage, std::shared_ptr<LoggingProtocol> logger = nullptr, std::shared_ptr<IOProvider> mapIO = std::make_shared<StdIOProvider>());
 
 	// Construct a new MapPackage object (which can then be exported)
 	MapPackage(const LevelDetails& levelDetails, MapType mapType, std::shared_ptr<Map> map);
@@ -123,7 +123,7 @@ public:
 	// Export the currently-loaded map package to a specified path in a specified format
 	// Can convert both the LevelFormat and the WzMap::OutputFormat
 	bool exportMapPackageFiles(std::string basePath, LevelFormat levelFormat, WzMap::OutputFormat mapOutputFormat,
-							   optional<std::string> mapFolderRelativePathOverride = nullopt, bool copyAdditionalFilesFromOriginalLoadedPackage = false, std::shared_ptr<LoggingProtocol> logger = nullptr, std::shared_ptr<IOProvider> exportIO = std::shared_ptr<IOProvider>(new StdIOProvider()));
+							   optional<std::string> mapFolderRelativePathOverride = nullopt, bool copyAdditionalFilesFromOriginalLoadedPackage = false, std::shared_ptr<LoggingProtocol> logger = nullptr, std::shared_ptr<IOProvider> exportIO = std::make_shared<StdIOProvider>());
 
 	// High-level data loading functions
 

--- a/lib/wzmaplib/src/map_package.cpp
+++ b/lib/wzmaplib/src/map_package.cpp
@@ -1115,7 +1115,7 @@ MapPackage::MapPackage()
 // The default StdIOProvider will assume pathToMapPackage is a path to an extracted map package (i.e. standard filesystem I/O)
 //
 // To load from an archive (.zip/.wz), create a custom implementation of WzMap::IOProvider that supports compressed archive files that you initialize with the path to the zip. An example of this (which uses libzip) is available in `plugins/ZipIOProvider`. You would then set `pathToMapPackage` to be the root path inside the zip. (In the case of plugins\ZipIOProvider, literally `/`).
-std::unique_ptr<MapPackage> MapPackage::loadPackage(const std::string& pathToMapPackage, std::shared_ptr<LoggingProtocol> logger /*= nullptr*/, std::shared_ptr<IOProvider> pMapIO /*= std::shared_ptr<IOProvider>(new StdIOProvider())*/)
+std::unique_ptr<MapPackage> MapPackage::loadPackage(const std::string& pathToMapPackage, std::shared_ptr<LoggingProtocol> logger /*= nullptr*/, std::shared_ptr<IOProvider> pMapIO /*= std::make_shared<StdIOProvider>()*/)
 {
 	LoggingProtocol* pCustomLogger = logger.get();
 	if (!pMapIO)
@@ -1287,7 +1287,7 @@ static bool copyFile_IOProviders(const std::string& readPath, const std::string&
 // Export the currently-loaded map package to a specified path in a specified format
 // Can convert both the LevelFormat and the WzMap::OutputFormat
 bool MapPackage::exportMapPackageFiles(std::string basePath, LevelFormat levelFormat, WzMap::OutputFormat mapOutputFormat,
-									   optional<std::string> mapFolderRelativePathOverride /*= nullopt*/, bool copyAdditionalFilesFromOriginalLoadedPackage /*= false*/, std::shared_ptr<LoggingProtocol> logger /*= nullptr*/, std::shared_ptr<IOProvider> exportIO /*= std::shared_ptr<IOProvider>(new StdIOProvider())*/)
+									   optional<std::string> mapFolderRelativePathOverride /*= nullopt*/, bool copyAdditionalFilesFromOriginalLoadedPackage /*= false*/, std::shared_ptr<LoggingProtocol> logger /*= nullptr*/, std::shared_ptr<IOProvider> exportIO /*= std::make_shared<StdIOProvider>()*/)
 {
 	LoggingProtocol* pCustomLogger = logger.get();
 	if (!exportIO)

--- a/lib/wzmaplib/src/map_preview.cpp
+++ b/lib/wzmaplib/src/map_preview.cpp
@@ -239,7 +239,7 @@ bool plotStructurePreviewWzMap(Map &wzMap, const MapPreviewColorScheme& colorSch
 	MapPlayerColorProvider* pPlayerColorProvider = colorScheme.playerColorProvider.get();
 	if (!pPlayerColorProvider)
 	{
-		defaultPlayerColorProvider = std::unique_ptr<MapPlayerColorProvider>(new MapPlayerColorProvider());
+		defaultPlayerColorProvider = std::make_unique<MapPlayerColorProvider>();
 		pPlayerColorProvider = defaultPlayerColorProvider.get();
 	}
 
@@ -295,7 +295,7 @@ std::unique_ptr<MapPreviewImage> generate2DMapPreview(Map& wzMap, const MapPrevi
 
 	const TilesetColorScheme& clrSch = colorScheme.tilesetColors;
 
-	std::unique_ptr<MapPreviewImage> result = std::unique_ptr<MapPreviewImage>(new MapPreviewImage());
+	std::unique_ptr<MapPreviewImage> result = std::make_unique<MapPreviewImage>();
 	result->width = mapData->width;
 	result->height = mapData->height;
 	result->channels = 3;

--- a/src/activity.cpp
+++ b/src/activity.cpp
@@ -220,12 +220,12 @@ public:
 	// Caller is expected to handle thrown exceptions
 	ActivityDatabase(const std::string& activityDatabasePath)
 	{
-		db = std::unique_ptr<SQLite::Database>(new SQLite::Database(activityDatabasePath, SQLite::OPEN_READWRITE | SQLite::OPEN_CREATE));
+		db = std::make_unique<SQLite::Database>(activityDatabasePath, SQLite::OPEN_READWRITE | SQLite::OPEN_CREATE);
 		db->exec("PRAGMA journal_mode=WAL");
 		createTables();
-		query_findValueByName = std::unique_ptr<SQLite::Statement>(new SQLite::Statement(*db, "SELECT value FROM general_kv_storage WHERE name = ?"));
-		query_insertValueForName = std::unique_ptr<SQLite::Statement>(new SQLite::Statement(*db, "INSERT OR IGNORE INTO general_kv_storage(name, value) VALUES(?, ?)"));
-		query_updateValueForName = std::unique_ptr<SQLite::Statement>(new SQLite::Statement(*db, "UPDATE general_kv_storage SET value = ? WHERE name = ?"));
+		query_findValueByName = std::make_unique<SQLite::Statement>(*db, "SELECT value FROM general_kv_storage WHERE name = ?");
+		query_insertValueForName = std::make_unique<SQLite::Statement>(*db, "INSERT OR IGNORE INTO general_kv_storage(name, value) VALUES(?, ?)");
+		query_updateValueForName = std::make_unique<SQLite::Statement>(*db, "UPDATE general_kv_storage SET value = ? WHERE name = ?");
 	}
 public:
 	// Must be thread-safe

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -123,8 +123,8 @@ static UDWORD	currentFrame;
 static UDWORD StartOfLastFrame;
 static SDWORD	rotX;
 static SDWORD	rotY;
-std::unique_ptr<ValueTracker> rotationHorizontalTracker = std::unique_ptr<ValueTracker>(new ValueTracker());
-std::unique_ptr<ValueTracker> rotationVerticalTracker = std::unique_ptr<ValueTracker>(new ValueTracker());
+std::unique_ptr<ValueTracker> rotationHorizontalTracker = std::make_unique<ValueTracker>();
+std::unique_ptr<ValueTracker> rotationVerticalTracker = std::make_unique<ValueTracker>();
 static uint32_t scrollRefTime;
 static float	scrollSpeedLeftRight; //use two directions and add them because its simple
 static float	scrollStepLeftRight;
@@ -648,8 +648,8 @@ static void HandleDrag()
 UDWORD panMouseX;
 // Mouse Y coordinate at start of panning.
 UDWORD panMouseY;
-std::unique_ptr<ValueTracker> panXTracker = std::unique_ptr<ValueTracker>(new ValueTracker());
-std::unique_ptr<ValueTracker> panZTracker = std::unique_ptr<ValueTracker>(new ValueTracker());
+std::unique_ptr<ValueTracker> panXTracker = std::make_unique<ValueTracker>();
+std::unique_ptr<ValueTracker> panZTracker = std::make_unique<ValueTracker>();
 bool panActive;
 
 //don't want to do any of these whilst in the Intelligence Screen

--- a/src/display3d.cpp
+++ b/src/display3d.cpp
@@ -2065,11 +2065,11 @@ static void renderBuildOrder(uint8_t droidPlayer, DroidOrder const &order, STRUC
 	}
 }
 
-std::unique_ptr<Blueprint> playerBlueprint = std::unique_ptr<Blueprint>(new Blueprint());
-std::unique_ptr<ValueTracker> playerBlueprintX = std::unique_ptr<ValueTracker>(new ValueTracker());
-std::unique_ptr<ValueTracker> playerBlueprintY = std::unique_ptr<ValueTracker>(new ValueTracker());
-std::unique_ptr<ValueTracker> playerBlueprintZ = std::unique_ptr<ValueTracker>(new ValueTracker());
-std::unique_ptr<ValueTracker> playerBlueprintDirection = std::unique_ptr<ValueTracker>(new ValueTracker());
+std::unique_ptr<Blueprint> playerBlueprint = std::make_unique<Blueprint>();
+std::unique_ptr<ValueTracker> playerBlueprintX = std::make_unique<ValueTracker>();
+std::unique_ptr<ValueTracker> playerBlueprintY = std::make_unique<ValueTracker>();
+std::unique_ptr<ValueTracker> playerBlueprintZ = std::make_unique<ValueTracker>();
+std::unique_ptr<ValueTracker> playerBlueprintDirection = std::make_unique<ValueTracker>();
 
 void displayBlueprints(const glm::mat4 &viewMatrix, const glm::mat4 &perspectiveViewMatrix)
 {

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -7059,7 +7059,7 @@ bool loadSaveTemplate(const char *pFileName)
 		ini.beginArray("templates");
 		while (ini.remainingArrayItems() > 0)
 		{
-			addTemplate(player, std::unique_ptr<DROID_TEMPLATE>(new DROID_TEMPLATE(loadTemplate())));
+			addTemplate(player, std::make_unique<DROID_TEMPLATE>(loadTemplate()));
 		}
 		ini.endArray();
 		ini.endGroup();

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -273,7 +273,7 @@ static void cleanSearchPath()
 void registerSearchPath(const std::string& newPath, unsigned int priority)
 {
 	ASSERT_OR_RETURN(, !newPath.empty(), "Calling registerSearchPath with empty path, priority %u", priority);
-	std::unique_ptr<wzSearchPath> tmpSearchPath = std::unique_ptr<wzSearchPath>(new wzSearchPath());
+	std::unique_ptr<wzSearchPath> tmpSearchPath = std::make_unique<wzSearchPath>();
 	tmpSearchPath->path = newPath;
 	if (!strEndsWith(tmpSearchPath->path, PHYSFS_getDirSeparator()))
 	{

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -674,7 +674,7 @@ static void SetDecals(const char *filename, const char *decal_type)
 	pFileData = strchr(pFileData, '\n') + 1;
 	// value initialization sets everything to false.
 	mapDecals = std::make_unique<bool[]>(MAX_TERRAIN_TILES);
-	
+
 	for (i = 0; i < numlines; i++)
 	{
 		tiledecal = -1;
@@ -1011,7 +1011,7 @@ bool mapLoadFromWzMapData(std::shared_ptr<WzMap::MapData> loadedMap)
 	ASSERT(psMapTiles == nullptr, "Map has not been cleared before calling mapLoad()!");
 
 	/* Allocate the memory for the map */
-	psMapTiles = std::make_unique<MAPTILE[]>(width * height);
+	psMapTiles = std::make_unique<MAPTILE[]>(static_cast<size_t>(width) * height);
 	ASSERT(psMapTiles != nullptr, "Out of memory");
 
 	mapWidth = width;

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -261,7 +261,7 @@ static void init_tileNames(MAP_TILESET type)
 	numTile_names = numlines;
 	//increment the pointer to the start of the next record
 	pFileData = strchr(pFileData, '\n') + 1;
-	Tile_names = std::unique_ptr<char[]>(new char[numlines * MAX_STR_LENGTH]());
+	Tile_names = std::make_unique<char[]>(numlines * MAX_STR_LENGTH);
 
 	for (i = 0; i < numlines; i++)
 	{
@@ -673,7 +673,7 @@ static void SetDecals(const char *filename, const char *decal_type)
 	//increment the pointer to the start of the next record
 	pFileData = strchr(pFileData, '\n') + 1;
 	// value initialization sets everything to false.
-	mapDecals = std::unique_ptr<bool[]>(new bool[MAX_TERRAIN_TILES]());
+	mapDecals = std::make_unique<bool[]>(MAX_TERRAIN_TILES);
 	
 	for (i = 0; i < numlines; i++)
 	{
@@ -1011,7 +1011,7 @@ bool mapLoadFromWzMapData(std::shared_ptr<WzMap::MapData> loadedMap)
 	ASSERT(psMapTiles == nullptr, "Map has not been cleared before calling mapLoad()!");
 
 	/* Allocate the memory for the map */
-	psMapTiles = std::unique_ptr<MAPTILE[]>(new MAPTILE[width * height]());
+	psMapTiles = std::make_unique<MAPTILE[]>(width * height);
 	ASSERT(psMapTiles != nullptr, "Out of memory");
 
 	mapWidth = width;
@@ -1104,12 +1104,12 @@ static bool afterMapLoad()
 	/* Allocate aux maps */
 	ASSERT(mapWidth >= 0 && mapHeight >= 0, "Invalid mapWidth or mapHeight (%d x %d)", mapWidth, mapHeight);
 	const size_t mapSize = static_cast<size_t>(mapWidth) * static_cast<size_t>(mapHeight);
-	psBlockMap[AUX_MAP] = std::unique_ptr<uint8_t[]>(new uint8_t[mapSize]());
-	psBlockMap[AUX_ASTARMAP] =  std::unique_ptr<uint8_t[]>(new uint8_t[mapSize]());
-	psBlockMap[AUX_DANGERMAP] = std::unique_ptr<uint8_t[]>(new uint8_t[mapSize]());
+	psBlockMap[AUX_MAP] = std::make_unique<uint8_t[]>(mapSize);
+	psBlockMap[AUX_ASTARMAP] =  std::make_unique<uint8_t[]>(mapSize);
+	psBlockMap[AUX_DANGERMAP] = std::make_unique<uint8_t[]>(mapSize);
 	for (int x = 0; x < MAX_PLAYERS + AUX_MAX; ++x)
 	{
-		psAuxMap[x] = std::unique_ptr<uint8_t[]> (new uint8_t[mapSize]());
+		psAuxMap[x] = std::make_unique<uint8_t[]> (mapSize);
 	}
 
 	// Set our blocking bits

--- a/src/multiint.cpp
+++ b/src/multiint.cpp
@@ -754,7 +754,7 @@ void loadMapPreview(bool hideInterface)
 	previewColorScheme.hqColor = PIELIGHT_to_MapPreviewColor(WZCOL_MAP_PREVIEW_HQ);
 	previewColorScheme.oilResourceColor = PIELIGHT_to_MapPreviewColor(WZCOL_MAP_PREVIEW_OIL);
 	previewColorScheme.oilBarrelColor = PIELIGHT_to_MapPreviewColor(WZCOL_MAP_PREVIEW_BARREL);
-	previewColorScheme.playerColorProvider = std::unique_ptr<WzMap::MapPlayerColorProvider>(new WzLobbyPreviewPlayerColorProvider());
+	previewColorScheme.playerColorProvider = std::make_unique<WzLobbyPreviewPlayerColorProvider>();
 	switch (guessMapTilesetType(psLevel))
 	{
 	case MAP_TILESET::ARIZONA:

--- a/src/multistat.cpp
+++ b/src/multistat.cpp
@@ -821,15 +821,15 @@ public:
 	// Caller is expected to handle thrown exceptions
 	KnownPlayersDB(const std::string& knownPlayersDBPath)
 	{
-		db = std::unique_ptr<SQLite::Database>(new SQLite::Database(knownPlayersDBPath, SQLite::OPEN_READWRITE | SQLite::OPEN_CREATE));
+		db = std::make_unique<SQLite::Database>(knownPlayersDBPath, SQLite::OPEN_READWRITE | SQLite::OPEN_CREATE);
 		db->exec("PRAGMA journal_mode=WAL");
 		createKnownPlayersDBTables();
-		query_findPlayerIdentityByName = std::unique_ptr<SQLite::Statement>(new SQLite::Statement(*db, "SELECT local_id, name, pk FROM known_players WHERE name = ?"));
-		query_insertNewKnownPlayer = std::unique_ptr<SQLite::Statement>(new SQLite::Statement(*db, "INSERT OR IGNORE INTO known_players(name, pk) VALUES(?, ?)"));
-		query_updateKnownPlayerKey = std::unique_ptr<SQLite::Statement>(new SQLite::Statement(*db, "UPDATE known_players SET pk = ? WHERE name = ?"));
-		query_findPlayerOptionsByPK = std::unique_ptr<SQLite::Statement>(new SQLite::Statement(*db, "SELECT name, muted, banned FROM player_options WHERE pk = ?"));
-		query_insertNewPlayerOptions = std::unique_ptr<SQLite::Statement>(new SQLite::Statement(*db, "INSERT OR IGNORE INTO player_options(pk, name, muted, banned) VALUES(?, ?, ?, ?)"));
-		query_updatePlayerOptionsMuted = std::unique_ptr<SQLite::Statement>(new SQLite::Statement(*db, "UPDATE player_options SET muted = ? WHERE pk = ? AND name = ?"));
+		query_findPlayerIdentityByName = std::make_unique<SQLite::Statement>(*db, "SELECT local_id, name, pk FROM known_players WHERE name = ?");
+		query_insertNewKnownPlayer = std::make_unique<SQLite::Statement>(*db, "INSERT OR IGNORE INTO known_players(name, pk) VALUES(?, ?)");
+		query_updateKnownPlayerKey = std::make_unique<SQLite::Statement>(*db, "UPDATE known_players SET pk = ? WHERE name = ?");
+		query_findPlayerOptionsByPK = std::make_unique<SQLite::Statement>(*db, "SELECT name, muted, banned FROM player_options WHERE pk = ?");
+		query_insertNewPlayerOptions = std::make_unique<SQLite::Statement>(*db, "INSERT OR IGNORE INTO player_options(pk, name, muted, banned) VALUES(?, ?, ?, ?)");
+		query_updatePlayerOptionsMuted = std::make_unique<SQLite::Statement>(*db, "UPDATE player_options SET muted = ? WHERE pk = ? AND name = ?");
 	}
 
 public:
@@ -1054,7 +1054,7 @@ void initKnownPlayers()
 		ASSERT_OR_RETURN(, pWriteDir, "PHYSFS_getWriteDir returned null");
 		std::string knownPlayersDBPath = std::string(pWriteDir) + "/" + "knownPlayers.db";
 		try {
-			knownPlayersDB = std::unique_ptr<KnownPlayersDB>(new KnownPlayersDB(knownPlayersDBPath));
+			knownPlayersDB = std::make_unique<KnownPlayersDB>(knownPlayersDBPath);
 		}
 		catch (std::exception& e) {
 			// error loading SQLite database

--- a/src/notifications.cpp
+++ b/src/notifications.cpp
@@ -1305,7 +1305,7 @@ void addNotification(const WZ_Notification& notification, const WZ_Notification_
 	}
 
 	// Add the notification to the notification system's queue
-	notificationQueue.push_back(std::unique_ptr<WZ_Queued_Notification>(new WZ_Queued_Notification(notification, WZ_Notification_Status(realTime), trigger)));
+	notificationQueue.push_back(std::make_unique<WZ_Queued_Notification>(notification, WZ_Notification_Status(realTime), trigger));
 }
 
 bool removeNotificationPreferencesIf(const std::function<bool (const std::string& uniqueNotificationIdentifier)>& matchIdentifierFunc)

--- a/src/quickjs_backend.cpp
+++ b/src/quickjs_backend.cpp
@@ -2430,7 +2430,7 @@ static uniqueTimerID SetQuickJSTimer(JSContext *ctx, int player, const std::stri
 	}
 	, player, ms, funcName, psObj, type
 	// additionalParams
-	, std::unique_ptr<timerAdditionalData>(new quickjs_timer_additionaldata(stringArg)));
+	, std::make_unique<quickjs_timer_additionaldata>(stringArg));
 }
 
 //-- ## setTimer(functionName, milliseconds[, object])
@@ -2845,7 +2845,7 @@ std::tuple<TimerFunc, std::unique_ptr<timerAdditionalData>> quickjs_scripting_in
 			std::for_each(args.begin(), args.end(), [pContext](JSValue& val) { JS_FreeValue(pContext, val); });
 		}
 		// additionalParams
-		, std::unique_ptr<timerAdditionalData>(new quickjs_timer_additionaldata(stringArg))
+		, std::make_unique<quickjs_timer_additionaldata>(stringArg)
 	};
 }
 

--- a/src/template.cpp
+++ b/src/template.cpp
@@ -558,7 +558,7 @@ bool loadDroidTemplates(const char *filename)
 
 DROID_TEMPLATE *copyTemplate(int player, DROID_TEMPLATE *psTemplate)
 {
-	auto dup = std::unique_ptr<DROID_TEMPLATE>(new DROID_TEMPLATE(*psTemplate));
+	auto dup = std::make_unique<DROID_TEMPLATE>(*psTemplate);
 	return addTemplate(player, std::move(dup));
 }
 

--- a/src/terrain.cpp
+++ b/src/terrain.cpp
@@ -945,7 +945,7 @@ void loadWaterTextures(int maxTerrainTextureSize, optional<int> maxTerrainAuxTex
 		}))
 		{
 			waterTexturesHigh.tex_nm = gfx_api::context::get().loadTextureArrayFromFiles(waterTextureFilenames_nm, gfx_api::texture_type::normal_map, maxTerrainAuxTextureSize, maxTerrainAuxTextureSize, [](int width, int height, int channels) -> std::unique_ptr<iV_Image> {
-				std::unique_ptr<iV_Image> pDefaultNormalMap = std::unique_ptr<iV_Image>(new iV_Image);
+				std::unique_ptr<iV_Image> pDefaultNormalMap = std::make_unique<iV_Image>();
 				pDefaultNormalMap->allocate(width, height, channels, true);
 				// default normal map: (0,0,1)
 				unsigned char* pBmpWrite = pDefaultNormalMap->bmp_w();
@@ -967,7 +967,7 @@ void loadWaterTextures(int maxTerrainTextureSize, optional<int> maxTerrainAuxTex
 		}))
 		{
 			waterTexturesHigh.tex_sm = gfx_api::context::get().loadTextureArrayFromFiles(waterTextureFilenames_sm, gfx_api::texture_type::specular_map, maxTerrainAuxTextureSize, maxTerrainAuxTextureSize, [](int width, int height, int channels) -> std::unique_ptr<iV_Image> {
-				std::unique_ptr<iV_Image> pDefaultSpecularMap = std::unique_ptr<iV_Image>(new iV_Image);
+				std::unique_ptr<iV_Image> pDefaultSpecularMap = std::make_unique<iV_Image>();
 				// default specular map: 0
 				pDefaultSpecularMap->allocate(width, height, channels, true);
 				return pDefaultSpecularMap;
@@ -1036,7 +1036,7 @@ void loadTerrainTextures_SinglePass(MAP_TILESET mapTileset)
 		}))
 		{
 			groundNormalArr = gfx_api::context::get().loadTextureArrayFromFiles(groundTextureFilenames_nm, gfx_api::texture_type::normal_map, maxTerrainAuxTextureSize, maxTerrainAuxTextureSize, [](int width, int height, int channels) -> std::unique_ptr<iV_Image> {
-				std::unique_ptr<iV_Image> pDefaultNormalMap = std::unique_ptr<iV_Image>(new iV_Image);
+				std::unique_ptr<iV_Image> pDefaultNormalMap = std::make_unique<iV_Image>();
 				pDefaultNormalMap->allocate(width, height, channels, true);
 				// default normal map: (0,0,1)
 				unsigned char* pBmpWrite = pDefaultNormalMap->bmp_w();
@@ -1058,7 +1058,7 @@ void loadTerrainTextures_SinglePass(MAP_TILESET mapTileset)
 		}))
 		{
 			groundSpecularArr = gfx_api::context::get().loadTextureArrayFromFiles(groundTextureFilenames_spec, gfx_api::texture_type::specular_map, maxTerrainAuxTextureSize, maxTerrainAuxTextureSize, [](int width, int height, int channels) -> std::unique_ptr<iV_Image> {
-				std::unique_ptr<iV_Image> pDefaultSpecularMap = std::unique_ptr<iV_Image>(new iV_Image);
+				std::unique_ptr<iV_Image> pDefaultSpecularMap = std::make_unique<iV_Image>();
 				// default specular map: 0
 				pDefaultSpecularMap->allocate(width, height, channels, true);
 				return pDefaultSpecularMap;
@@ -1070,7 +1070,7 @@ void loadTerrainTextures_SinglePass(MAP_TILESET mapTileset)
 		}))
 		{
 			groundHeightArr = gfx_api::context::get().loadTextureArrayFromFiles(groundTextureFilenames_height, gfx_api::texture_type::height_map, maxTerrainAuxTextureSize, maxTerrainAuxTextureSize, [](int width, int height, int channels) -> std::unique_ptr<iV_Image> {
-				std::unique_ptr<iV_Image> pDefaultHeightMap = std::unique_ptr<iV_Image>(new iV_Image);
+				std::unique_ptr<iV_Image> pDefaultHeightMap = std::make_unique<iV_Image>();
 				// default height map: 0
 				pDefaultHeightMap->allocate(width, height, channels, true);
 				return pDefaultHeightMap;
@@ -1517,7 +1517,7 @@ bool initTerrain()
 	lightmapValues.ModelUVLightmap = lightmapValues.lightMatrix * glm::transpose(glm::mat4(lightmapValues.paramsXLight, lightmapValues.paramsYLight, glm::vec4(0,0,1,0), glm::vec4(0,0,0,1)));
 
 	// Prepare the lightmap pixmap and texture
-	lightmapPixmap = std::unique_ptr<iV_Image>(new iV_Image());
+	lightmapPixmap = std::make_unique<iV_Image>();
 
 	unsigned int lightmapChannels = 4; // always use 4-channel (RGBA)
 	if (lightmapPixmap == nullptr || !lightmapPixmap->allocate(lightmapWidth, lightmapHeight, lightmapChannels, true))
@@ -1703,12 +1703,12 @@ static void cullTerrain()
 static void drawDepthOnly(const glm::mat4 &ModelViewProjection, const glm::vec4 &paramsXLight, const glm::vec4 &paramsYLight, bool withOffset)
 {
 	const auto &renderState = getCurrentRenderState();
-	
+
 	// bind the vertex buffer
 	gfx_api::TerrainDepth::get().bind();
 	gfx_api::TerrainDepth::get().bind_textures(lightmap_texture);
 	gfx_api::TerrainDepth::get().bind_vertex_buffers(geometryVBO);
-	gfx_api::TerrainDepth::get().bind_constants({ ModelViewProjection, paramsXLight, paramsYLight, glm::vec4(0.f), glm::vec4(0.f), glm::mat4(1.f), glm::mat4(1.f), 
+	gfx_api::TerrainDepth::get().bind_constants({ ModelViewProjection, paramsXLight, paramsYLight, glm::vec4(0.f), glm::vec4(0.f), glm::mat4(1.f), glm::mat4(1.f),
 	glm::vec4(0.f), renderState.fogEnabled, renderState.fogBegin, renderState.fogEnd, 0, 0 });
 	gfx_api::context::get().bind_index_buffer(*geometryIndexVBO, gfx_api::index_type::u32);
 

--- a/src/texture.cpp
+++ b/src/texture.cpp
@@ -377,7 +377,7 @@ bool texLoad(const char *fileName)
 					if (has_nm)
 					{
 						decalNormalArr = gfx_api::context::get().loadTextureArrayFromFiles(tile_nm_filepaths, gfx_api::texture_type::normal_map, mipmap_max, mipmap_max, [](int width, int height, int channels) -> std::unique_ptr<iV_Image> {
-							std::unique_ptr<iV_Image> pDefaultNormalMap = std::unique_ptr<iV_Image>(new iV_Image);
+							std::unique_ptr<iV_Image> pDefaultNormalMap = std::make_unique<iV_Image>();
 							pDefaultNormalMap->allocate(width, height, channels, true);
 							// default normal map: (0,0,1)
 							unsigned char* pBmpWrite = pDefaultNormalMap->bmp_w();
@@ -397,7 +397,7 @@ bool texLoad(const char *fileName)
 					if (has_sm)
 					{
 						decalSpecularArr = gfx_api::context::get().loadTextureArrayFromFiles(tile_sm_filepaths, gfx_api::texture_type::specular_map, mipmap_max, mipmap_max, [](int width, int height, int channels) -> std::unique_ptr<iV_Image> {
-							std::unique_ptr<iV_Image> pDefaultSpecularMap = std::unique_ptr<iV_Image>(new iV_Image);
+							std::unique_ptr<iV_Image> pDefaultSpecularMap = std::make_unique<iV_Image>();
 							// default specular map: 0
 							pDefaultSpecularMap->allocate(width, height, channels, true);
 							return pDefaultSpecularMap;
@@ -407,7 +407,7 @@ bool texLoad(const char *fileName)
 					if (has_hm)
 					{
 						decalHeightArr = gfx_api::context::get().loadTextureArrayFromFiles(tile_hm_filepaths, gfx_api::texture_type::height_map, mipmap_max, mipmap_max, [](int width, int height, int channels) -> std::unique_ptr<iV_Image> {
-							std::unique_ptr<iV_Image> pDefaultHeightMap = std::unique_ptr<iV_Image>(new iV_Image);
+							std::unique_ptr<iV_Image> pDefaultHeightMap = std::make_unique<iV_Image>();
 							// default height map: 0
 							pDefaultHeightMap->allocate(width, height, channels, true);
 							return pDefaultHeightMap;

--- a/src/wzapi.cpp
+++ b/src/wzapi.cpp
@@ -1732,7 +1732,7 @@ static int get_first_available_component(int player, int capacity, const wzapi::
 
 static std::unique_ptr<DROID_TEMPLATE> makeTemplate(int player, const std::string &templateName, const wzapi::string_or_string_list& _body, const wzapi::string_or_string_list& _propulsion, const wzapi::va_list<wzapi::string_or_string_list>& _turrets, int capacity, bool strict)
 {
-	std::unique_ptr<DROID_TEMPLATE> psTemplate = std::unique_ptr<DROID_TEMPLATE>(new DROID_TEMPLATE);
+	std::unique_ptr<DROID_TEMPLATE> psTemplate = std::make_unique<DROID_TEMPLATE>();
 	size_t numTurrets = _turrets.va_list.size();
 	int result;
 


### PR DESCRIPTION
This is one of the first steps to improve memory management in the Warzone 2100 project.

There are many places which use raw `new/delete` allocations along with extensive usage of raw pointers.

This changeset aims to replace raw allocations with `std::make_unique` and `std::make_shared` instead of the `std::unique_ptr<...>(new ...)` and `std::shared_ptr<...>(new ...)` constructs, respectively.

Since the project-wide C++ standard defaults to C++14, we should be able to use `std::make_{unique,shared}` without problem.

Among others, `std::make_{unique,shared}` has the following advantages over using raw `new/delete` with `std::{unique,shared}_ptr` constructors:

 * Provides terser syntax without an additional repetition of the constructed type.
 * Provides stronger exception-safety guarantees.

No impact on any of the existing functionality is expected.