### PR TITLE
Calculate weapon pitch from turret base

### DIFF
--- a/src/action.cpp
+++ b/src/action.cpp
@@ -335,12 +335,12 @@ bool actionTargetTurret(BASE_OBJECT *psAttacker, BASE_OBJECT *psTarget, WEAPON *
 
 	//set the pitch limits based on the weapon stats of the attacker
 	pitchLowerLimit = pitchUpperLimit = 0;
-	Vector3i attackerMuzzlePos = psAttacker->pos;  // Using for calculating the pitch, but not the direction, in case using the exact direction causes bugs somewhere.
+	Vector3i attackerTurretPos = psAttacker->pos;  // Using for calculating the pitch, but not the direction, in case using the exact direction causes bugs somewhere.
 	if (psAttacker->type == OBJ_STRUCTURE)
 	{
 		STRUCTURE *psStructure = (STRUCTURE *)psAttacker;
 		int weapon_slot = psWeapon - psStructure->asWeaps;  // Should probably be passed weapon_slot instead of psWeapon.
-		calcStructureMuzzleLocation(psStructure, &attackerMuzzlePos, weapon_slot);
+		calcStructureMuzzleBaseLocation(psStructure, &attackerTurretPos, weapon_slot);
 		pitchLowerLimit = DEG(psWeapStats->minElevation);
 		pitchUpperLimit = DEG(psWeapStats->maxElevation);
 	}
@@ -348,7 +348,7 @@ bool actionTargetTurret(BASE_OBJECT *psAttacker, BASE_OBJECT *psTarget, WEAPON *
 	{
 		DROID *psDroid = (DROID *)psAttacker;
 		int weapon_slot = psWeapon - psDroid->asWeaps;  // Should probably be passed weapon_slot instead of psWeapon.
-		calcDroidMuzzleLocation(psDroid, &attackerMuzzlePos, weapon_slot);
+		calcDroidMuzzleBaseLocation(psDroid, &attackerTurretPos, weapon_slot);
 
 		if (psDroid->droidType == DROID_WEAPON || isTransporter(psDroid)
 		    || psDroid->droidType == DROID_COMMAND || psDroid->droidType == DROID_CYBORG
@@ -395,7 +395,7 @@ bool actionTargetTurret(BASE_OBJECT *psAttacker, BASE_OBJECT *psTarget, WEAPON *
 	if (!bRepair && (unsigned)objPosDiffSq(psAttacker, psTarget) > minRange * minRange && proj_Direct(psWeapStats))
 	{
 		/* get target distance */
-		Vector3i delta = psTarget->pos - attackerMuzzlePos;
+		Vector3i delta = psTarget->pos - attackerTurretPos;
 		int32_t dxy = iHypot(delta.x, delta.y);
 
 		uint16_t targetPitch = iAtan2(delta.z, dxy);


### PR DESCRIPTION
This PR changes weapon pitch calculation to run relative to the turret's base/pivot point instead of its muzzle. Currently, how much the weapon should raise or lower is determined based on the target's position and the end of the turret's muzzle (where the bullet comes out). In most cases, this doesn't cause any issues. But in cases where the distance between the turret base and the muzzle is comparable to the distance between the muzzle and the target, then weird stuff starts to happen when the weapon tries to aim.
![image](https://github.com/Warzone2100/warzone2100/assets/28832631/026af147-c742-450a-82fc-9919bde8155c)

This causes a discrepancy between the angle the turret wants to aim towards and the actual angle towards the enemy. This can lead to a barrel "wobbling" effect as the turret keeps overcompensating when pitching the turret up or down, which can even lead to the weapon not firing at all, since the weapon isn't aimed "close" enough. This is most commonly noticeable when attacking from _very_ close range and/or with weapons with relatively long weapon barrels (such as the Heavy Cannon).

In the screenshots below, the Heavy Cannons either fire only once or not at all, before "wobbling" up and down since their muzzles keep telling the turret to pitch way up or way down.
![image](https://github.com/Warzone2100/warzone2100/assets/28832631/ac5a0c7f-e4d9-43cd-88a1-950d5f99f61b)
![image](https://github.com/Warzone2100/warzone2100/assets/28832631/1e9b90a6-3049-449f-b9f3-5759de1fdc42)

In the next screenshots, this PR is applied. The Heavy Cannons now calculate their weapon pitches from their turret bases (the location where the muzzle pivots from), removing the barrel wobbling and letting them fire properly.
![image](https://github.com/Warzone2100/warzone2100/assets/28832631/5c355c86-74a6-4f19-a441-7c227b09b78f)
![image](https://github.com/Warzone2100/warzone2100/assets/28832631/0b243dfd-4c42-4547-a149-65ce2cf93b68)