### PR TITLE
netreplay: Use wzThread* functions instead of std::thread

### DIFF
--- a/lib/netplay/netreplay.cpp
+++ b/lib/netplay/netreplay.cpp
@@ -59,14 +59,15 @@ typedef std::vector<uint8_t> SerializedNetMessagesBuffer;
 static moodycamel::BlockingReaderWriterQueue<SerializedNetMessagesBuffer> serializedBufferWriteQueue(256);
 static SerializedNetMessagesBuffer latestWriteBuffer;
 static size_t minBufferSizeToQueue = DefaultReplayBufferSize;
-static std::unique_ptr<wz::thread> saveThread;
+static WZ_THREAD *saveThread = nullptr;
 
 // This function is run in its own thread! Do not call any non-threadsafe functions!
-static void replaySaveThreadFunc(PHYSFS_file *pSaveHandle)
+static int replaySaveThreadFunc(void *data)
 {
+	PHYSFS_file *pSaveHandle = (PHYSFS_file *)data;
 	if (pSaveHandle == nullptr)
 	{
-		return;
+		return 1;
 	}
 	SerializedNetMessagesBuffer item;
 	while (true)
@@ -79,6 +80,7 @@ static void replaySaveThreadFunc(PHYSFS_file *pSaveHandle)
 		}
 		WZ_PHYSFS_writeBytes(pSaveHandle, item.data(), item.size());
 	}
+	return 0;
 }
 
 bool NETreplaySaveStart(std::string const& subdir, ReplayOptionsHandler const &optionsHandler, int maxReplaysSaved, bool appendPlayerToFilename)
@@ -185,11 +187,12 @@ bool NETreplaySaveStart(std::string const& subdir, ReplayOptionsHandler const &o
 	debug(LOG_INFO, "Started writing replay file \"%s\".", filename.c_str());
 
 	// Create a background thread and hand off all responsibility for writing to the file handle to it
-	ASSERT(saveThread.get() == nullptr, "Failed to release prior thread");
+	ASSERT(saveThread == nullptr, "Failed to release prior thread");
 	latestWriteBuffer.reserve(minBufferSizeToQueue);
 	if (desiredBufferSize != std::numeric_limits<size_t>::max())
 	{
-		saveThread = std::make_unique<wz::thread>(replaySaveThreadFunc, replaySaveHandle);
+		saveThread = wzThreadCreate(replaySaveThreadFunc, replaySaveHandle, "replaySaveThread");
+		wzThreadStart(saveThread);
 	}
 	else
 	{
@@ -225,8 +228,8 @@ bool NETreplaySaveStop()
 	// Wait for writing thread to finish
 	if (saveThread)
 	{
-		saveThread->join();
-		saveThread.reset();
+		wzThreadJoin(saveThread);
+		saveThread = nullptr;
 	}
 	else
 	{


### PR DESCRIPTION
To avoid `std::thread::~thread()` calling `std::terminate()` upon non-graceful shutdown.