### PR TITLE
Increase track.cpp's max_tracks to allow for more sounds to be added in game

### DIFF
--- a/lib/sound/track.cpp
+++ b/lib/sound/track.cpp
@@ -27,7 +27,7 @@
 //*
 //
 // defines
-#define MAX_TRACKS	( 600 )
+#define MAX_TRACKS	( 65536 )
 
 //*
 //


### PR DESCRIPTION
Just a simple change, changing the original max value of 600 to 65536. I found the original value was much too low seeing that if you wanted to flesh out a mod with sounds(which I was doing myself), you'd very quickly slam into the limit seeing how the original game has about 400 used already.

In my testing, increasing the value didn't seem to increase loading times at all or have other adverse effects. Though, if a mod somehow managed to cram in over 60k sounds, id imagine that would make loading take a little longer.