### PR TITLE
[OpenGL] Some shader compilers complain about using uint for mat4 array indexes

### DIFF
--- a/data/base/shaders/terrain_combined_high.frag
+++ b/data/base/shaders/terrain_combined_high.frag
@@ -91,7 +91,7 @@ out vec4 FragColor;
 
 vec3 getGroundUv(int i) {
 	uint groundNo = fgrounds[i];
-	return vec3(uvGround * groundScale[groundNo/4u][groundNo%4u], groundNo);
+	return vec3(uvGround * groundScale[int(groundNo/4u)][int(groundNo%4u)], groundNo);
 }
 
 vec3 getGround(int i) {

--- a/data/base/shaders/terrain_combined_medium.frag
+++ b/data/base/shaders/terrain_combined_medium.frag
@@ -91,7 +91,7 @@ out vec4 FragColor;
 
 vec3 getGroundUv(int i) {
 	uint groundNo = fgrounds[i];
-	return vec3(uvGround * groundScale[groundNo/4u][groundNo%4u], groundNo);
+	return vec3(uvGround * groundScale[int(groundNo/4u)][int(groundNo%4u)], groundNo);
 }
 
 vec3 getGround(int i) {


### PR DESCRIPTION
> error C7011: implicit cast from "uint" to "int"

So use an explicit cast.