### PR TITLE
Teleport units next to Nexus Links

### DIFF
--- a/src/droid.h
+++ b/src/droid.h
@@ -277,7 +277,7 @@ bool cbSensorDroid(const DROID *psDroid);
 bool standardSensorDroid(const DROID *psDroid);
 
 // give a droid from one player to another - used in Electronic Warfare and multiplayer
- DROID *giftSingleDroid(DROID *psD, UDWORD to, bool electronic = false);
+ DROID *giftSingleDroid(DROID *psD, UDWORD to, bool electronic = false, Vector2i pos = {0, 0});
 
 /// Calculates the electronic resistance of a droid based on its experience level
 SWORD droidResistance(const DROID *psDroid);

--- a/src/structure.cpp
+++ b/src/structure.cpp
@@ -5685,7 +5685,7 @@ bool electronicDamage(BASE_OBJECT *psTarget, UDWORD damage, UBYTE attackPlayer)
 						addEffect(&pos, EFFECT_EXPLOSION, EXPLOSION_TYPE_FLAMETHROWER, false, nullptr, 0, gameTime - deltaGameTime);
 					}
 				}
-				if (!isDead(psDroid) && !giftSingleDroid(psDroid, attackPlayer, true))
+				if (!isDead(psDroid) && !giftSingleDroid(psDroid, attackPlayer, true, g_pProjLastAttacker->pos.xy()))
 				{
 					// droid limit reached, recycle
 					// don't check for transporter/mission coz multiplayer only issue.


### PR DESCRIPTION
We have the technology to transmit vehicles and people through electronic data streams. Lets place them next to the attacker so absorbed units don't get blown up instantly from former friends.

Lightly tested but seems to work.