### PR TITLE
Always retreat units back to LZ or starting position

### DIFF
--- a/src/order.cpp
+++ b/src/order.cpp
@@ -3302,6 +3302,11 @@ void secondaryCheckDamageLevel(DROID *psDroid)
 					orderDroid(psDroid, DORDER_RTB, ModeImmediate);
 					return;
 				}
+				else if (result.type == RTR_TYPE_NO_RESULT)
+				{
+					orderDroid(psDroid, DORDER_RTB, ModeImmediate);
+					return;
+				}
 				else if (result.type == RTR_TYPE_DROID)
 				{
 					ASSERT(result.psObj != nullptr, "RTR_DROID but target is null");

--- a/src/order.cpp
+++ b/src/order.cpp
@@ -1667,11 +1667,17 @@ void orderDroidBase(DROID *psDroid, DROID_ORDER_DATA *psOrder)
 			// see if the LZ has been set up
 			int iDX = getLandingX(psDroid->player);
 			int iDY = getLandingY(psDroid->player);
+			Vector2i startPos = getPlayerStartPosition(psDroid->player);
 
 			if (iDX && iDY)
 			{
 				psDroid->order = *psOrder;
 				actionDroid(psDroid, DACTION_MOVE, iDX, iDY);
+			}
+			else if (bMultiPlayer && (startPos.x != 0 && startPos.y != 0))
+			{
+				psDroid->order = *psOrder;
+				actionDroid(psDroid, DACTION_MOVE, startPos.x, startPos.y);
 			}
 			else
 			{


### PR DESCRIPTION
Prior to 4.2.0-beta1 a unit set to retreat at X damage would go back to the LZ in the campaign when damaged enough if no HQ was around. This got broken during repair improvements though the fix is simple: if no repair targets around, and the HQ is missing on the map, just issue a return to base order and the unit will find the LZ automatically.

Since a lot of missions take place on offworld maps where no HQ is present, it can get some players caught off guard. This fix will make saving units easier.

Similarly, mp/skirmish can benefit from this. Because RTB relies on LZ coordinates as a fail-safe, and because LZs do not exist outside campaign, the current behavior is to do nothing. I have set units to seek out the starting position coordinates in mp/skirmish to fix this. VTOLs will benefit from this should the player have no rearming pads or an HQ if they run out of ammo.