### PR TITLE
Remove transport timer when mission results trigger

### DIFF
--- a/src/mission.cpp
+++ b/src/mission.cpp
@@ -2219,6 +2219,7 @@ static void missionResetInGameState()
 	forceHidePowerBar();
 	intRemoveReticule();
 	intRemoveMissionTimer();
+	intRemoveTransporterTimer();
 	intHideGroupSelectionMenu();
 }
 


### PR DESCRIPTION
I believe this will stop the transporter timer from persisting onto mission results screens if the player loses on an offworld mission, or when beating Gamma End (this screenshot was after beating Gamma End).

![gamma](https://github.com/Warzone2100/warzone2100/assets/22485442/20269ee4-687e-43d4-b9b9-c9671eac0aa9)
