### PR TITLE
Refactor global object lists to use `std::list` instead of C-style intrusive single-linked lists

### DIFF
--- a/src/action.cpp
+++ b/src/action.cpp
@@ -2822,7 +2822,7 @@ bool actionVTOLLandingPos(DROID const *psDroid, Vector2i *p)
 	}
 
 	// clear blocking flags for all the other droids
-	for (DROID *psCurr : apsDroidLists[psDroid->player])
+	for (const DROID *psCurr : apsDroidLists[psDroid->player])
 	{
 		Vector2i t(0, 0);
 		if (DROID_STOPPED(psCurr))

--- a/src/action.cpp
+++ b/src/action.cpp
@@ -2790,7 +2790,7 @@ bool actionVTOLLandingPos(DROID const *psDroid, Vector2i *p)
 	int startY = map_coord(p->y);
 
 	// set blocking flags for all the other droids
-	for (const DROID *psCurr = apsDroidLists[psDroid->player]; psCurr; psCurr = psCurr->psNext)
+	for (const DROID *psCurr : apsDroidLists[psDroid->player])
 	{
 		Vector2i t(0, 0);
 		if (DROID_STOPPED(psCurr))
@@ -2822,7 +2822,7 @@ bool actionVTOLLandingPos(DROID const *psDroid, Vector2i *p)
 	}
 
 	// clear blocking flags for all the other droids
-	for (DROID *psCurr = apsDroidLists[psDroid->player]; psCurr; psCurr = psCurr->psNext)
+	for (DROID *psCurr : apsDroidLists[psDroid->player])
 	{
 		Vector2i t(0, 0);
 		if (DROID_STOPPED(psCurr))

--- a/src/ai.cpp
+++ b/src/ai.cpp
@@ -177,7 +177,7 @@ static BASE_OBJECT *aiSearchSensorTargets(BASE_OBJECT *psObj, int weapon_slot, W
 		*targetOrigin = ORIGIN_UNKNOWN;
 	}
 
-	for (BASE_OBJECT *psSensor = apsSensorList[0]; psSensor; psSensor = psSensor->psNextFunc)
+	for (BASE_OBJECT* psSensor : apsSensorList[0])
 	{
 		BASE_OBJECT	*psTemp = nullptr;
 		bool		isCB = false;

--- a/src/basedef.h
+++ b/src/basedef.h
@@ -58,28 +58,6 @@ struct TILEPOS
   For explanation of yaw/pitch/roll look for "flight dynamics" in your encyclopedia.
 */
 
-/// NEXTOBJ is an ugly hack to avoid having to fix all occurrences of psNext and psNextFunc. The use of the original NEXTOBJ(pointerType) hack wasn't valid C, so in that sense, it's an improvement.
-/// NEXTOBJ is a BASE_OBJECT *, which can automatically be cast to DROID *, STRUCTURE * and FEATURE *...
-
-struct BASE_OBJECT;
-
-struct NEXTOBJ
-{
-	NEXTOBJ(BASE_OBJECT *ptr_ = nullptr) : ptr(ptr_) {}
-	NEXTOBJ &operator =(BASE_OBJECT *ptr_)
-	{
-		ptr = ptr_;
-		return *this;
-	}
-	template<class T>
-	operator T *() const
-	{
-		return static_cast<T *>(ptr);
-	}
-
-	BASE_OBJECT *ptr;
-};
-
 struct SIMPLE_OBJECT
 {
 	SIMPLE_OBJECT(OBJECT_TYPE type, uint32_t id, unsigned player);
@@ -134,7 +112,6 @@ struct BASE_OBJECT : public SIMPLE_OBJECT
 
 	std::bitset<OBJECT_FLAG_COUNT> flags;
 
-	//NEXTOBJ             psNext;                     ///< Pointer to the next object in the object list
 	bool                hasExtraFunction = false;   ///< Does this object include some extra functionality?
 
 public:

--- a/src/basedef.h
+++ b/src/basedef.h
@@ -135,7 +135,7 @@ struct BASE_OBJECT : public SIMPLE_OBJECT
 	std::bitset<OBJECT_FLAG_COUNT> flags;
 
 	NEXTOBJ             psNext;                     ///< Pointer to the next object in the object list
-	NEXTOBJ             psNextFunc;                 ///< Pointer to the next object in the function list
+	bool                hasExtraFunction = false;   ///< Does this object include some extra functionality?
 
 public:
 	// Query visibility for display purposes (i.e. for `selectedPlayer`)

--- a/src/basedef.h
+++ b/src/basedef.h
@@ -134,7 +134,7 @@ struct BASE_OBJECT : public SIMPLE_OBJECT
 
 	std::bitset<OBJECT_FLAG_COUNT> flags;
 
-	NEXTOBJ             psNext;                     ///< Pointer to the next object in the object list
+	//NEXTOBJ             psNext;                     ///< Pointer to the next object in the object list
 	bool                hasExtraFunction = false;   ///< Does this object include some extra functionality?
 
 public:

--- a/src/baseobject.cpp
+++ b/src/baseobject.cpp
@@ -115,10 +115,6 @@ BASE_OBJECT::BASE_OBJECT(OBJECT_TYPE type, uint32_t id, unsigned player)
 BASE_OBJECT::~BASE_OBJECT()
 {
 	visRemoveVisibility(this);
-
-#ifdef DEBUG
-	psNext = this;                                                       // Hopefully this will trigger an infinite loop       if someone uses the freed object.
-#endif //DEBUG
 }
 
 // Query visibility for display purposes (i.e. for `selectedPlayer`)

--- a/src/baseobject.cpp
+++ b/src/baseobject.cpp
@@ -118,7 +118,6 @@ BASE_OBJECT::~BASE_OBJECT()
 
 #ifdef DEBUG
 	psNext = this;                                                       // Hopefully this will trigger an infinite loop       if someone uses the freed object.
-	psNextFunc = this;                                                   // Hopefully this will trigger an infinite loop       if someone uses the freed object.
 #endif //DEBUG
 }
 

--- a/src/cmddroid.cpp
+++ b/src/cmddroid.cpp
@@ -159,14 +159,13 @@ void cmdDroidClearDesignator(UDWORD player)
 SDWORD cmdDroidGetIndex(DROID *psCommander)
 {
 	SDWORD	index = 1;
-	DROID	*psCurr;
 
 	if (psCommander->droidType != DROID_COMMAND)
 	{
 		return 0;
 	}
 
-	for (psCurr = apsDroidLists[psCommander->player]; psCurr; psCurr = psCurr->psNext)
+	for (DROID* psCurr : apsDroidLists[psCommander->player])
 	{
 		if (psCurr->droidType == DROID_COMMAND &&
 		    psCurr->id < psCommander->id)

--- a/src/cmddroid.cpp
+++ b/src/cmddroid.cpp
@@ -165,7 +165,7 @@ SDWORD cmdDroidGetIndex(DROID *psCommander)
 		return 0;
 	}
 
-	for (DROID* psCurr : apsDroidLists[psCommander->player])
+	for (const DROID* psCurr : apsDroidLists[psCommander->player])
 	{
 		if (psCurr->droidType == DROID_COMMAND &&
 		    psCurr->id < psCommander->id)

--- a/src/combat.cpp
+++ b/src/combat.cpp
@@ -340,7 +340,7 @@ void counterBatteryFire(BASE_OBJECT *psAttacker, BASE_OBJECT *psTarget)
 
 	CHECK_OBJECT(psTarget);
 
-	for (BASE_OBJECT *psViewer = apsSensorList[0]; psViewer; psViewer = psViewer->psNextFunc)
+	for (BASE_OBJECT* psViewer : apsSensorList[0])
 	{
 		if (aiCheckAlliances(psTarget->player, psViewer->player))
 		{

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -417,7 +417,7 @@ static bool localPlayerHasSelection()
 		return false;
 	}
 
-	for (DROID* psDroid = apsDroidLists[selectedPlayer]; psDroid; psDroid = psDroid->psNext)
+	for (DROID* psDroid : apsDroidLists[selectedPlayer])
 	{
 		if (psDroid->selected)
 		{
@@ -806,7 +806,7 @@ void processMouseClickInput()
 			else if (selection == SC_DROID_REPAIR)
 			{
 				// We can't repair ourselves, so change it to a blocking cursor
-				for (DROID *psCurr = apsDroidLists[selectedPlayer]; psCurr != nullptr; psCurr = psCurr->psNext)
+				for (DROID *psCurr : apsDroidLists[selectedPlayer])
 				{
 					if (psCurr->selected)
 					{
@@ -1314,8 +1314,7 @@ BASE_OBJECT *mouseTarget()
 	/* First have a look through the droid lists */
 	for (int i = 0; i < MAX_PLAYERS; i++)
 	{
-		/* Note the !psObject check isn't really necessary as the goto will jump out */
-		for (DROID *psDroid = apsDroidLists[i]; psDroid && !psReturn; psDroid = psDroid->psNext)
+		for (DROID *psDroid : apsDroidLists[i])
 		{
 			dispX = psDroid->sDisplay.screenX;
 			dispY = psDroid->sDisplay.screenY;
@@ -1715,10 +1714,8 @@ static void dealWithLMBDroid(DROID *psDroid, SELECTION_TYPE selection)
 	// Clicked on a sensor? Will assign to it.
 	else if (psDroid->droidType == DROID_SENSOR)
 	{
-		DROID *psCurr;
-
 		bSensorAssigned = false;
-		for (psCurr = apsDroidLists[selectedPlayer]; psCurr; psCurr = psCurr->psNext)
+		for (DROID* psCurr : apsDroidLists[selectedPlayer])
 		{
 			//must be indirect weapon droid or VTOL weapon droid
 			if ((psCurr->droidType == DROID_WEAPON) &&
@@ -1933,10 +1930,8 @@ static void dealWithLMBFeature(FEATURE *psFeature)
 		if ((i < numStructureStats) &&
 		    (apStructTypeLists[selectedPlayer][i] == AVAILABLE))	// don't go any further if no derrick stat found.
 		{
-			DROID *psCurr;
-
 			// for each droid
-			for (psCurr = apsDroidLists[selectedPlayer]; psCurr; psCurr = psCurr->psNext)
+			for (DROID* psCurr : apsDroidLists[selectedPlayer])
 			{
 				if ((droidType(psCurr) == DROID_CONSTRUCT ||
 				     droidType(psCurr) == DROID_CYBORG_CONSTRUCT) && (psCurr->selected))
@@ -2355,7 +2350,6 @@ static MOUSE_TARGET	itemUnderMouse(BASE_OBJECT **ppObjectUnderMouse)
 	UDWORD		i;
 	MOUSE_TARGET retVal;
 	BASE_OBJECT	 *psNotDroid;
-	DROID		*psDroid;
 	UDWORD		dispX, dispY, dispR;
 	STRUCTURE	*psStructure;
 
@@ -2373,9 +2367,7 @@ static MOUSE_TARGET	itemUnderMouse(BASE_OBJECT **ppObjectUnderMouse)
 	/* First have a look through the droid lists */
 	for (i = 0; i < MAX_PLAYERS; i++)
 	{
-		/* Note the !psObject check isn't really necessary as the goto will jump out */
-		for (psDroid = apsDroidLists[i]; psDroid && retVal == MT_NOTARGET;
-		     psDroid = psDroid->psNext)
+		for (DROID* psDroid : apsDroidLists[i])
 		{
 			dispX = psDroid->sDisplay.screenX;
 			dispY = psDroid->sDisplay.screenY;
@@ -2594,7 +2586,7 @@ static SELECTION_TYPE	establishSelection(UDWORD _selectedPlayer)
 		return SC_INVALID;
 	}
 
-	for (DROID *psDroid = apsDroidLists[_selectedPlayer]; psDroid; psDroid = psDroid->psNext)
+	for (DROID *psDroid : apsDroidLists[_selectedPlayer])
 	{
 		// This works, uses the DroidSelectionWeights[] table to priorities the different
 		// droid types and find the dominant selection.
@@ -2684,9 +2676,7 @@ bool	repairDroidSelected(UDWORD player)
 {
 	ASSERT_OR_RETURN(false, player < MAX_PLAYERS, "Invalid player (%" PRIu32 ")", player);
 
-	DROID	*psCurr;
-
-	for (psCurr = apsDroidLists[player]; psCurr != nullptr; psCurr = psCurr->psNext)
+	for (DROID* psCurr : apsDroidLists[player])
 	{
 		if (psCurr->selected && (
 		        psCurr->droidType == DROID_REPAIR ||
@@ -2705,9 +2695,7 @@ bool	vtolDroidSelected(UDWORD player)
 {
 	ASSERT_OR_RETURN(false, player < MAX_PLAYERS, "player: %" PRIu32 "", player);
 
-	DROID	*psCurr;
-
-	for (psCurr = apsDroidLists[player]; psCurr != nullptr; psCurr = psCurr->psNext)
+	for (DROID* psCurr : apsDroidLists[player])
 	{
 		if (psCurr->selected && isVtolDroid(psCurr))
 		{
@@ -2726,9 +2714,7 @@ bool	anyDroidSelected(UDWORD player)
 {
 	ASSERT_OR_RETURN(false, player < MAX_PLAYERS, "Invalid player (%" PRIu32 ")", player);
 
-	DROID	*psCurr;
-
-	for (psCurr = apsDroidLists[player]; psCurr != nullptr; psCurr = psCurr->psNext)
+	for (DROID* psCurr : apsDroidLists[player])
 	{
 		if (psCurr->selected)
 		{
@@ -2745,9 +2731,7 @@ bool cyborgDroidSelected(UDWORD player)
 {
 	ASSERT_OR_RETURN(false, player < MAX_PLAYERS, "Invalid player (%" PRIu32 ")", player);
 
-	DROID	*psCurr;
-
-	for (psCurr = apsDroidLists[player]; psCurr != nullptr; psCurr = psCurr->psNext)
+	for (DROID* psCurr : apsDroidLists[player])
 	{
 		if (psCurr->selected && cyborgDroid(psCurr))
 		{
@@ -2762,8 +2746,6 @@ bool cyborgDroidSelected(UDWORD player)
 /* Clear the selection flag for a player */
 void clearSelection()
 {
-	DROID			*psCurrDroid;
-
 	memset(DROIDDOING, 0x0 , sizeof(DROIDDOING));	// clear string when deselected
 
 	if (selectedPlayer >= MAX_PLAYERS)
@@ -2771,7 +2753,7 @@ void clearSelection()
 		return;
 	}
 
-	for (psCurrDroid = apsDroidLists[selectedPlayer]; psCurrDroid; psCurrDroid = psCurrDroid->psNext)
+	for (DROID* psCurrDroid : apsDroidLists[selectedPlayer])
 	{
 		psCurrDroid->selected = false;
 	}

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -1357,8 +1357,6 @@ static bool flagReposFinished;
 
 void startDeliveryPosition(FLAG_POSITION *psFlag)
 {
-	FLAG_POSITION	*psFlagPos;
-
 	if (tryingToGetLocation()) // if we're placing a building don't place
 	{
 		return;
@@ -1367,7 +1365,7 @@ void startDeliveryPosition(FLAG_POSITION *psFlag)
 	ASSERT_OR_RETURN(, selectedPlayer < MAX_PLAYERS, "Invalid player (selectedPlayer: %" PRIu32 ")", selectedPlayer);
 
 	//clear the selected delivery point
-	for (psFlagPos = apsFlagPosLists[selectedPlayer]; psFlagPos; psFlagPos = psFlagPos->psNext)
+	for (auto& psFlagPos : apsFlagPosLists[selectedPlayer])
 	{
 		psFlagPos->selected = false;
 	}
@@ -1418,9 +1416,9 @@ void finishDeliveryPosition()
 			}
 		}
 		//deselect once moved
-		for (FLAG_POSITION *psFlagPos = apsFlagPosLists[selectedPlayer]; psFlagPos; psFlagPos = psFlagPos->psNext)
+		for (auto& psFlag : apsFlagPosLists[selectedPlayer])
 		{
-			psFlagPos->selected = false;
+			psFlag->selected = false;
 		}
 	}
 	triggerEvent(TRIGGER_DELIVERY_POINT_MOVED, psStruct);
@@ -1447,9 +1445,9 @@ bool deliveryReposValid()
 	}
 
 	// cant place on top of a delivery point...
-	for (FLAG_POSITION const *psCurrFlag = apsFlagPosLists[selectedPlayer]; psCurrFlag; psCurrFlag = psCurrFlag->psNext)
+	for (const auto& psFlag : apsFlagPosLists[selectedPlayer])
 	{
-		Vector2i flagTile = map_coord(psCurrFlag->coords.xy());
+		Vector2i flagTile = map_coord(psFlag->coords.xy());
 		if (flagTile == map)
 		{
 			return false;
@@ -2164,7 +2162,7 @@ static FLAG_POSITION *findMouseDeliveryPoint()
 		return nullptr;
 	}
 
-	for (auto psPoint = apsFlagPosLists[selectedPlayer]; psPoint; psPoint = psPoint->psNext)
+	for (const auto& psPoint : apsFlagPosLists[selectedPlayer])
 	{
 		if (psPoint->type != POS_DELIVERY) {
 			continue;
@@ -2770,7 +2768,6 @@ void clearSelection()
 {
 	DROID			*psCurrDroid;
 	STRUCTURE		*psStruct;
-	FLAG_POSITION	*psFlagPos;
 
 	memset(DROIDDOING, 0x0 , sizeof(DROIDDOING));	// clear string when deselected
 
@@ -2789,9 +2786,9 @@ void clearSelection()
 	}
 	bLasSatStruct = false;
 	//clear the Deliv Point if one
-	for (psFlagPos = apsFlagPosLists[selectedPlayer]; psFlagPos; psFlagPos = psFlagPos->psNext)
+	for (auto& psFlag : apsFlagPosLists[selectedPlayer])
 	{
-		psFlagPos->selected = false;
+		psFlag->selected = false;
 	}
 
 	intRefreshScreen();

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -425,7 +425,7 @@ static bool localPlayerHasSelection()
 		}
 	}
 
-	for (STRUCTURE* psStruct = apsStructLists[selectedPlayer]; psStruct; psStruct = psStruct->psNext)
+	for (STRUCTURE* psStruct : apsStructLists[selectedPlayer])
 	{
 		if (psStruct->selected)
 		{
@@ -1845,10 +1845,8 @@ static void dealWithLMBStructure(STRUCTURE *psStructure, SELECTION_TYPE selectio
 			auto shouldDisplayInterface = !anyDroidSelected(selectedPlayer);
 			if (selection == SC_INVALID)
 			{
-				STRUCTURE *psCurr;
-
 				/* Clear old building selection(s) - should only be one */
-				for (psCurr = apsStructLists[selectedPlayer]; psCurr; psCurr = psCurr->psNext)
+				for (STRUCTURE* psCurr : apsStructLists[selectedPlayer])
 				{
 					psCurr->selected = false;
 				}
@@ -1872,10 +1870,8 @@ static void dealWithLMBStructure(STRUCTURE *psStructure, SELECTION_TYPE selectio
 	         (psStructure->pStructureType->type == REF_RESOURCE_EXTRACTOR) &&
 	         selection == SC_INVALID && ownStruct)
 	{
-		STRUCTURE *psCurr;
-
 		/* Clear old building selection(s) - should only be one */
-		for (psCurr = apsStructLists[selectedPlayer]; psCurr; psCurr = psCurr->psNext)
+		for (STRUCTURE* psCurr : apsStructLists[selectedPlayer])
 		{
 			psCurr->selected = false;
 		}
@@ -2767,7 +2763,6 @@ bool cyborgDroidSelected(UDWORD player)
 void clearSelection()
 {
 	DROID			*psCurrDroid;
-	STRUCTURE		*psStruct;
 
 	memset(DROIDDOING, 0x0 , sizeof(DROIDDOING));	// clear string when deselected
 
@@ -2780,7 +2775,7 @@ void clearSelection()
 	{
 		psCurrDroid->selected = false;
 	}
-	for (psStruct = apsStructLists[selectedPlayer]; psStruct; psStruct = psStruct->psNext)
+	for (STRUCTURE* psStruct : apsStructLists[selectedPlayer])
 	{
 		psStruct->selected = false;
 	}

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -417,7 +417,7 @@ static bool localPlayerHasSelection()
 		return false;
 	}
 
-	for (DROID* psDroid : apsDroidLists[selectedPlayer])
+	for (const DROID* psDroid : apsDroidLists[selectedPlayer])
 	{
 		if (psDroid->selected)
 		{
@@ -425,7 +425,7 @@ static bool localPlayerHasSelection()
 		}
 	}
 
-	for (STRUCTURE* psStruct : apsStructLists[selectedPlayer])
+	for (const STRUCTURE* psStruct : apsStructLists[selectedPlayer])
 	{
 		if (psStruct->selected)
 		{
@@ -806,7 +806,7 @@ void processMouseClickInput()
 			else if (selection == SC_DROID_REPAIR)
 			{
 				// We can't repair ourselves, so change it to a blocking cursor
-				for (DROID *psCurr : apsDroidLists[selectedPlayer])
+				for (const DROID *psCurr : apsDroidLists[selectedPlayer])
 				{
 					if (psCurr->selected)
 					{
@@ -2676,7 +2676,7 @@ bool	repairDroidSelected(UDWORD player)
 {
 	ASSERT_OR_RETURN(false, player < MAX_PLAYERS, "Invalid player (%" PRIu32 ")", player);
 
-	for (DROID* psCurr : apsDroidLists[player])
+	for (const DROID* psCurr : apsDroidLists[player])
 	{
 		if (psCurr->selected && (
 		        psCurr->droidType == DROID_REPAIR ||
@@ -2714,7 +2714,7 @@ bool	anyDroidSelected(UDWORD player)
 {
 	ASSERT_OR_RETURN(false, player < MAX_PLAYERS, "Invalid player (%" PRIu32 ")", player);
 
-	for (DROID* psCurr : apsDroidLists[player])
+	for (const DROID* psCurr : apsDroidLists[player])
 	{
 		if (psCurr->selected)
 		{
@@ -2731,7 +2731,7 @@ bool cyborgDroidSelected(UDWORD player)
 {
 	ASSERT_OR_RETURN(false, player < MAX_PLAYERS, "Invalid player (%" PRIu32 ")", player);
 
-	for (DROID* psCurr : apsDroidLists[player])
+	for (const DROID* psCurr : apsDroidLists[player])
 	{
 		if (psCurr->selected && cyborgDroid(psCurr))
 		{

--- a/src/display3d.cpp
+++ b/src/display3d.cpp
@@ -525,7 +525,7 @@ public:
 			SDWORD scrX, scrY;
 			for (uint32_t i = 0; i < MAX_PLAYERS; i++)
 			{
-				for (STRUCTURE* psStruct : apsStructLists[i])
+				for (const STRUCTURE* psStruct : apsStructLists[i])
 				{
 					/* If it's targetted and on-screen */
 					if (psStruct->flags.test(OBJECT_FLAG_TARGETED)
@@ -784,7 +784,7 @@ static void showDroidPaths()
 		return; // no-op for now
 	}
 
-	for (DROID *psDroid : apsDroidLists[selectedPlayer])
+	for (const DROID *psDroid : apsDroidLists[selectedPlayer])
 	{
 		if (psDroid->selected && psDroid->sMove.Status != MOVEINACTIVE)
 		{
@@ -1098,7 +1098,7 @@ void draw3DScene()
 	{
 		int visibleDroids = 0;
 		int undrawnDroids = 0;
-		for (DROID *psDroid : apsDroidLists[selectedPlayer])
+		for (const DROID *psDroid : apsDroidLists[selectedPlayer])
 		{
 			if (psDroid->sDisplay.frameNumber != currentGameFrame)
 			{
@@ -2183,7 +2183,7 @@ void displayBlueprints(const glm::mat4 &viewMatrix, const glm::mat4 &perspective
 			continue;
 		}
 		STRUCT_STATES state = player == selectedPlayer ? SS_BLUEPRINT_PLANNED : SS_BLUEPRINT_PLANNED_BY_ALLY;
-		for (DROID *psDroid : apsDroidLists[player])
+		for (const DROID *psDroid : apsDroidLists[player])
 		{
 			if (psDroid->droidType == DROID_CONSTRUCT || psDroid->droidType == DROID_CYBORG_CONSTRUCT)
 			{
@@ -4009,7 +4009,7 @@ static void structureEffectsPlayer(UDWORD player)
 		return;  // Don't add effects this frame.
 	}
 
-	for (STRUCTURE *psStructure : apsStructLists[player])
+	for (const STRUCTURE *psStructure : apsStructLists[player])
 	{
 		if (psStructure->status != SS_BUILT)
 		{

--- a/src/display3d.cpp
+++ b/src/display3d.cpp
@@ -2196,7 +2196,7 @@ void displayBlueprints(const glm::mat4 &viewMatrix, const glm::mat4 &perspective
 static void displayDelivPoints(const glm::mat4& viewMatrix, const glm::mat4 &perspectiveViewMatrix)
 {
 	if (selectedPlayer >= MAX_PLAYERS) { return; /* no-op */ }
-	for (FLAG_POSITION *psDelivPoint = apsFlagPosLists[selectedPlayer]; psDelivPoint != nullptr; psDelivPoint = psDelivPoint->psNext)
+	for (const auto& psDelivPoint : apsFlagPosLists[selectedPlayer])
 	{
 		if (clipXY(psDelivPoint->coords.x, psDelivPoint->coords.y))
 		{

--- a/src/display3d.cpp
+++ b/src/display3d.cpp
@@ -2232,13 +2232,13 @@ static void displayFeatures(const glm::mat4 &viewMatrix, const glm::mat4 &perspe
 	// player can only be 0 for the features.
 
 	/* Go through all the features */
-	for (BASE_OBJECT* list = apsFeatureLists[0]; list != nullptr; list = list->psNext)
+	for (BASE_OBJECT* obj : apsFeatureLists[0])
 	{
-		if (list->type == OBJ_FEATURE
-			&& (list->died == 0 || list->died > graphicsTime)
-			&& clipXY(list->pos.x, list->pos.y))
+		if (obj->type == OBJ_FEATURE
+			&& (obj->died == 0 || obj->died > graphicsTime)
+			&& clipXY(obj->pos.x, obj->pos.y))
 		{
-			FEATURE* psFeature = castFeature(list);
+			FEATURE* psFeature = castFeature(obj);
 			renderFeature(psFeature, viewMatrix, perspectiveViewMatrix);
 		}
 	}
@@ -3549,7 +3549,7 @@ static void	drawDroidSelections()
 		}
 	}
 
-	for (const FEATURE *psFeature = apsFeatureLists[0]; psFeature; psFeature = psFeature->psNext)
+	for (const FEATURE *psFeature : apsFeatureLists[0])
 	{
 		if (!psFeature->died && psFeature->sDisplay.frameNumber == currentGameFrame)
 		{

--- a/src/display3d.cpp
+++ b/src/display3d.cpp
@@ -448,7 +448,7 @@ public:
 	void addStructureSelectionsToRender(uint32_t player, BASE_OBJECT *psClickedOn, bool bMouseOverOwnStructure)
 	{
 		/* Go thru' all the buildings */
-		for (STRUCTURE *psStruct = apsStructLists[player]; psStruct; psStruct = psStruct->psNext)
+		for (STRUCTURE *psStruct : apsStructLists[player])
 		{
 			if (psStruct->sDisplay.frameNumber == currentGameFrame)
 			{
@@ -522,11 +522,10 @@ public:
 
 		if (renderStructureTargetingGfx)
 		{
-			STRUCTURE *psStruct = nullptr;
 			SDWORD scrX, scrY;
 			for (uint32_t i = 0; i < MAX_PLAYERS; i++)
 			{
-				for (psStruct = apsStructLists[i]; psStruct; psStruct = psStruct->psNext)
+				for (STRUCTURE* psStruct : apsStructLists[i])
 				{
 					/* If it's targetted and on-screen */
 					if (psStruct->flags.test(OBJECT_FLAG_TARGETED)
@@ -1953,17 +1952,15 @@ static void displayStaticObjects(const glm::mat4 &viewMatrix, const glm::mat4 &p
 	/* Go through all the players */
 	for (unsigned aPlayer = 0; aPlayer < MAX_PLAYERS; ++aPlayer)
 	{
-		BASE_OBJECT *list = apsStructLists[aPlayer];
-
 		/* Now go all buildings for that player */
-		for (; list != nullptr; list = list->psNext)
+		for (BASE_OBJECT* obj : apsStructLists[aPlayer])
 		{
 			/* Worth rendering the structure? */
-			if (list->type != OBJ_STRUCTURE || (list->died != 0 && list->died < graphicsTime))
+			if (obj->type != OBJ_STRUCTURE || (obj->died != 0 && obj->died < graphicsTime))
 			{
 				continue;
 			}
-			STRUCTURE *psStructure = castStructure(list);
+			STRUCTURE *psStructure = castStructure(obj);
 
 			if (!clipStructureOnScreen(psStructure))
 			{
@@ -4015,7 +4012,7 @@ static void structureEffectsPlayer(UDWORD player)
 		return;  // Don't add effects this frame.
 	}
 
-	for (STRUCTURE *psStructure = apsStructLists[player]; psStructure; psStructure = psStructure->psNext)
+	for (STRUCTURE *psStructure : apsStructLists[player])
 	{
 		if (psStructure->status != SS_BUILT)
 		{
@@ -4109,7 +4106,7 @@ static void structureEffects()
 {
 	for (unsigned i = 0; i < MAX_PLAYERS; i++)
 	{
-		if (apsStructLists[i])
+		if (!apsStructLists[i].empty())
 		{
 			structureEffectsPlayer(i);
 		}
@@ -4122,7 +4119,6 @@ static void	showDroidSensorRanges()
 	static uint32_t lastRangeUpdateTime = 0;
 
 	DROID		*psDroid;
-	STRUCTURE	*psStruct;
 
 	if (selectedPlayer >= MAX_PLAYERS) { return; /* no-op */ }
 
@@ -4137,7 +4133,7 @@ static void	showDroidSensorRanges()
 			}
 		}
 
-		for (psStruct = apsStructLists[selectedPlayer]; psStruct; psStruct = psStruct->psNext)
+		for (STRUCTURE* psStruct : apsStructLists[selectedPlayer])
 		{
 			if (psStruct->selected)
 			{

--- a/src/display3d.cpp
+++ b/src/display3d.cpp
@@ -407,7 +407,7 @@ public:
 		bool bDrawAll = barMode == BAR_DROIDS || barMode == BAR_DROIDS_AND_STRUCTURES;
 
 		// first, for all droids, queue the various rects
-		for (DROID *psDroid = apsDroidLists[player]; psDroid; psDroid = psDroid->psNext)
+		for (DROID *psDroid : apsDroidLists[player])
 		{
 			if (psDroid->sDisplay.frameNumber == currentGameFrame)
 			{
@@ -784,7 +784,7 @@ static void showDroidPaths()
 		return; // no-op for now
 	}
 
-	for (DROID *psDroid = apsDroidLists[selectedPlayer]; psDroid; psDroid = psDroid->psNext)
+	for (DROID *psDroid : apsDroidLists[selectedPlayer])
 	{
 		if (psDroid->selected && psDroid->sMove.Status != MOVEINACTIVE)
 		{
@@ -1098,7 +1098,7 @@ void draw3DScene()
 	{
 		int visibleDroids = 0;
 		int undrawnDroids = 0;
-		for (DROID *psDroid = apsDroidLists[selectedPlayer]; psDroid; psDroid = psDroid->psNext)
+		for (DROID *psDroid : apsDroidLists[selectedPlayer])
 		{
 			if (psDroid->sDisplay.frameNumber != currentGameFrame)
 			{
@@ -2183,7 +2183,7 @@ void displayBlueprints(const glm::mat4 &viewMatrix, const glm::mat4 &perspective
 			continue;
 		}
 		STRUCT_STATES state = player == selectedPlayer ? SS_BLUEPRINT_PLANNED : SS_BLUEPRINT_PLANNED_BY_ALLY;
-		for (DROID *psDroid = apsDroidLists[player]; psDroid; psDroid = psDroid->psNext)
+		for (DROID *psDroid : apsDroidLists[player])
 		{
 			if (psDroid->droidType == DROID_CONSTRUCT || psDroid->droidType == DROID_CYBORG_CONSTRUCT)
 			{
@@ -2296,13 +2296,10 @@ static void displayDynamicObjects(const glm::mat4 &viewMatrix, const glm::mat4 &
 	/* Need to go through all the droid lists */
 	for (unsigned player = 0; player < MAX_PLAYERS; ++player)
 	{
-		BASE_OBJECT *list = apsDroidLists[player];
-
-		for (; list != nullptr; list = list->psNext)
+		for (DROID* psDroid : apsDroidLists[player])
 		{
-			DROID *psDroid = castDroid(list);
-			if (!psDroid || (list->died != 0 && list->died < graphicsTime)
-			    || !quickClipXYToMaximumTilesFromCurrentPosition(list->pos.x, list->pos.y))
+			if (!psDroid || (psDroid->died != 0 && psDroid->died < graphicsTime)
+			    || !quickClipXYToMaximumTilesFromCurrentPosition(psDroid->pos.x, psDroid->pos.y))
 			{
 				continue;
 			}
@@ -3527,8 +3524,8 @@ static void	drawDroidSelections()
 
 	for (int i = 0; i < MAX_PLAYERS; i++)
 	{
-		/* Go thru' all the droidss */
-		for (const DROID *psDroid = apsDroidLists[i]; psDroid; psDroid = psDroid->psNext)
+		/* Go thru' all the droids */
+		for (const DROID *psDroid : apsDroidLists[i])
 		{
 			if (showORDERS)
 			{
@@ -4118,14 +4115,12 @@ static void	showDroidSensorRanges()
 {
 	static uint32_t lastRangeUpdateTime = 0;
 
-	DROID		*psDroid;
-
 	if (selectedPlayer >= MAX_PLAYERS) { return; /* no-op */ }
 
 	if (rangeOnScreen
 		&& (graphicsTime - lastRangeUpdateTime) >= 50)		// note, we still have to decide what to do with multiple units selected, since it will draw it for all of them! -Q 5-10-05
 	{
-		for (psDroid = apsDroidLists[selectedPlayer]; psDroid; psDroid = psDroid->psNext)
+		for (DROID* psDroid : apsDroidLists[selectedPlayer])
 		{
 			if (psDroid->selected)
 			{
@@ -4304,7 +4299,7 @@ static void doConstructionLines(const glm::mat4 &viewMatrix)
 {
 	for (unsigned i = 0; i < MAX_PLAYERS; i++)
 	{
-		for (DROID *psDroid = apsDroidLists[i]; psDroid; psDroid = psDroid->psNext)
+		for (DROID *psDroid : apsDroidLists[i])
 		{
 			if (clipXY(psDroid->pos.x, psDroid->pos.y)
 			    && psDroid->visibleForLocalDisplay() == UBYTE_MAX

--- a/src/droid.cpp
+++ b/src/droid.cpp
@@ -675,7 +675,7 @@ void vanishDroid(DROID *psDel)
 /* Remove a droid from the List so doesn't update or get drawn etc
 TAKE CARE with removeDroid() - usually want droidRemove since it deal with grid code*/
 //returns false if the droid wasn't removed - because it died!
-bool droidRemove(DROID *psDroid, PerPlayerDroidList& pList)
+bool droidRemove(DROID *psDroid, PerPlayerDroidLists& pList)
 {
 	CHECK_DROID(psDroid);
 

--- a/src/droid.cpp
+++ b/src/droid.cpp
@@ -748,16 +748,8 @@ void droidUpdate(DROID *psDroid)
 	// Check that we are (still) in the sensor list
 	if (psDroid->droidType == DROID_SENSOR)
 	{
-		BASE_OBJECT	*psSensor;
-
-		for (psSensor = apsSensorList[0]; psSensor; psSensor = psSensor->psNextFunc)
-		{
-			if (psSensor == (BASE_OBJECT *)psDroid)
-			{
-				break;
-			}
-		}
-		ASSERT(psSensor == (BASE_OBJECT *)psDroid, "%s(%p) not in sensor list!",
+		const auto sensor = std::find(apsSensorList[0].begin(), apsSensorList[0].end(), (BASE_OBJECT*)psDroid);
+		ASSERT(sensor != apsSensorList[0].end(), "%s(%p) not in sensor list!",
 			   droidGetName(psDroid), static_cast<void *>(psDroid));
 	}
 #endif

--- a/src/droid.cpp
+++ b/src/droid.cpp
@@ -552,7 +552,7 @@ bool removeDroidBase(DROID *psDel)
 	/* Put Deliv. Pts back into world when a command droid dies */
 	if (psDel->droidType == DROID_COMMAND)
 	{
-		for (auto psStruct = apsStructLists[psDel->player]; psStruct; psStruct = psStruct->psNext)
+		for (auto psStruct : apsStructLists[psDel->player])
 		{
 			// alexl's stab at a right answer.
 			if (StructIsFactory(psStruct)
@@ -2425,7 +2425,6 @@ bool pickATileGen(Vector2i *pos, unsigned numIterations, bool (*function)(UDWORD
 static bool ThreatInRange(SDWORD player, SDWORD range, SDWORD rangeX, SDWORD rangeY, bool bVTOLs)
 {
 	UDWORD				i, structType;
-	STRUCTURE			*psStruct;
 	DROID				*psDroid;
 
 	const int tx = map_coord(rangeX);
@@ -2439,7 +2438,7 @@ static bool ThreatInRange(SDWORD player, SDWORD range, SDWORD rangeX, SDWORD ran
 		}
 
 		//check structures
-		for (psStruct = apsStructLists[i]; psStruct; psStruct = psStruct->psNext)
+		for (STRUCTURE* psStruct : apsStructLists[i])
 		{
 			if (psStruct->visible[player] || psStruct->born == 2)	// if can see it or started there
 			{
@@ -3359,7 +3358,7 @@ DROID *giftSingleDroid(DROID *psD, UDWORD to, bool electronic, Vector2i pos)
 		}
 
 		// check through the players list, and our allies, of structures to see if any are targetting it
-		for (STRUCTURE *psStruct = apsStructLists[i]; psStruct != nullptr; psStruct = psStruct->psNext)
+		for (STRUCTURE *psStruct : apsStructLists[i])
 		{
 			if (psStruct->psTarget[0] == psD)
 			{

--- a/src/droid.cpp
+++ b/src/droid.cpp
@@ -570,7 +570,7 @@ bool removeDroidBase(DROID *psDel)
 		if (tryingToGetLocation())
 		{
 			int numSelectedConstructors = 0;
-			for (DROID *psDroid : apsDroidLists[psDel->player])
+			for (const DROID *psDroid : apsDroidLists[psDel->player])
 			{
 				numSelectedConstructors += psDroid->selected && isConstructionDroid(psDroid);
 			}
@@ -1341,7 +1341,7 @@ bool idfDroid(DROID *psDroid)
 }
 
 /* Return the type of a droid */
-DROID_TYPE droidType(DROID *psDroid)
+DROID_TYPE droidType(const DROID *psDroid)
 {
 	return psDroid->droidType;
 }
@@ -2284,7 +2284,7 @@ UDWORD	getNumDroidsForLevel(uint32_t player, UDWORD level)
 		{
 			continue;
 		}
-		for (DROID* psDroid : *dList)
+		for (const DROID* psDroid : *dList)
 		{
 			if (getDroidLevel(psDroid) == level)
 			{
@@ -2354,7 +2354,7 @@ static bool oneDroidMax(UDWORD x, UDWORD y)
 	// check each droid list
 	for (i = 0; i < MAX_PLAYERS; i++)
 	{
-		for (DROID* pD : apsDroidLists[i])
+		for (const DROID* pD : apsDroidLists[i])
 		{
 			if (map_coord(pD->pos.x) == x
 				&& map_coord(pD->pos.y) == y)
@@ -2435,7 +2435,7 @@ static bool ThreatInRange(SDWORD player, SDWORD range, SDWORD rangeX, SDWORD ran
 		}
 
 		//check structures
-		for (STRUCTURE* psStruct : apsStructLists[i])
+		for (const STRUCTURE* psStruct : apsStructLists[i])
 		{
 			if (psStruct->visible[player] || psStruct->born == 2)	// if can see it or started there
 			{
@@ -2464,11 +2464,11 @@ static bool ThreatInRange(SDWORD player, SDWORD range, SDWORD rangeX, SDWORD ran
 		}
 
 		//check droids
-		for (DROID* psDroid : apsDroidLists[i])
+		for (const DROID* psDroid : apsDroidLists[i])
 		{
 			if (psDroid->visible[player])		//can see this droid?
 			{
-				if (!objHasWeapon((BASE_OBJECT *)psDroid))
+				if (!objHasWeapon(psDroid))
 				{
 					continue;
 				}
@@ -2554,7 +2554,7 @@ PICKTILE pickHalfATile(UDWORD *x, UDWORD *y, UBYTE numIterations)
 building the specified structure - returns true if finds one*/
 bool checkDroidsBuilding(STRUCTURE *psStructure)
 {
-	for (DROID* psDroid : apsDroidLists[psStructure->player])
+	for (const DROID* psDroid : apsDroidLists[psStructure->player])
 	{
 		//check DORDER_BUILD, HELP_BUILD is handled the same
 		BASE_OBJECT *const psStruct = orderStateObj(psDroid, DORDER_BUILD);
@@ -2570,7 +2570,7 @@ bool checkDroidsBuilding(STRUCTURE *psStructure)
 demolishing the specified structure - returns true if finds one*/
 bool checkDroidsDemolishing(STRUCTURE *psStructure)
 {
-	for (DROID* psDroid : apsDroidLists[psStructure->player])
+	for (const DROID* psDroid : apsDroidLists[psStructure->player])
 	{
 		//check DORDER_DEMOLISH
 		BASE_OBJECT *const psStruct = orderStateObj(psDroid, DORDER_DEMOLISH);
@@ -2756,7 +2756,7 @@ UBYTE checkCommandExist(UBYTE player)
 {
 	UBYTE	quantity = 0;
 
-	for (DROID *psDroid : apsDroidLists[player])
+	for (const DROID *psDroid : apsDroidLists[player])
 	{
 		if (psDroid->droidType == DROID_COMMAND)
 		{

--- a/src/droid.cpp
+++ b/src/droid.cpp
@@ -1846,7 +1846,6 @@ void assignDroidsToGroup(UDWORD	playerNumber, UDWORD groupNumber, bool clearGrou
 	DROID	*psDroid;
 	bool	bAtLeastOne = false;
 	size_t  numCleared = 0;
-	FLAG_POSITION	*psFlagPos;
 
 	ASSERT_OR_RETURN(, playerNumber < MAX_PLAYERS, "Invalid player: %" PRIu32 "", playerNumber);
 
@@ -1875,10 +1874,9 @@ void assignDroidsToGroup(UDWORD	playerNumber, UDWORD groupNumber, bool clearGrou
 	{
 		//clear the Deliv Point if one
 		ASSERT_OR_RETURN(, selectedPlayer < MAX_PLAYERS, "Unsupported selectedPlayer: %" PRIu32 "", selectedPlayer);
-		for (psFlagPos = apsFlagPosLists[selectedPlayer]; psFlagPos;
-			 psFlagPos = psFlagPos->psNext)
+		for (auto& psFlag : apsFlagPosLists[selectedPlayer])
 		{
-			psFlagPos->selected = false;
+			psFlag->selected = false;
 		}
 		groupConsoleInformOfCreation(groupNumber);
 		secondarySetAverageGroupState(selectedPlayer, groupNumber);
@@ -1922,7 +1920,6 @@ bool activateGroupAndMove(UDWORD playerNumber, UDWORD groupNumber)
 	DROID	*psDroid, *psCentreDroid = nullptr;
 	bool selected = false;
 	size_t numDeselected = 0;
-	FLAG_POSITION	*psFlagPos;
 
 	ASSERT_OR_RETURN(false, playerNumber < MAX_PLAYERS, "Invalid player: %" PRIu32 "", playerNumber);
 
@@ -1951,10 +1948,9 @@ bool activateGroupAndMove(UDWORD playerNumber, UDWORD groupNumber)
 			ASSERT(selectedPlayer < MAX_PLAYERS, "Unsupported selectedPlayer: %" PRIu32 "", selectedPlayer);
 			if (selectedPlayer < MAX_PLAYERS)
 			{
-				for (psFlagPos = apsFlagPosLists[selectedPlayer]; psFlagPos;
-					 psFlagPos = psFlagPos->psNext)
+				for (auto& psFlag : apsFlagPosLists[selectedPlayer])
 				{
-					psFlagPos->selected = false;
+					psFlag->selected = false;
 				}
 			}
 
@@ -1989,7 +1985,6 @@ bool activateGroupAndMove(UDWORD playerNumber, UDWORD groupNumber)
 bool activateNoGroup(UDWORD playerNumber, const SELECTIONTYPE selectionType, const SELECTION_CLASS selectionClass, const bool bOnScreen) {
 	DROID	*psDroid;
 	bool selected = false;
-	FLAG_POSITION	*psFlagPos;
 	SELECTIONTYPE dselectionType = selectionType;
 	SELECTION_CLASS dselectionClass = selectionClass;
 	unsigned selectionCount = 0;
@@ -2011,10 +2006,9 @@ bool activateNoGroup(UDWORD playerNumber, const SELECTIONTYPE selectionType, con
 	{
 		//clear the Deliv Point if one
 		ASSERT_OR_RETURN(false, selectedPlayer < MAX_PLAYERS, "Unsupported selectedPlayer: %" PRIu32 "", selectedPlayer);
-		for (psFlagPos = apsFlagPosLists[selectedPlayer]; psFlagPos;
-			 psFlagPos = psFlagPos->psNext)
+		for (auto& psFlag : apsFlagPosLists[selectedPlayer])
 		{
-			psFlagPos->selected = false;
+			psFlag->selected = false;
 		}
 	}
 	intGroupsChanged(UBYTE_MAX);
@@ -2027,7 +2021,6 @@ bool activateGroup(UDWORD playerNumber, UDWORD groupNumber)
 	DROID	*psDroid;
 	bool selected = false;
 	size_t numDeselected = 0;
-	FLAG_POSITION	*psFlagPos;
 
 	ASSERT_OR_RETURN(false, playerNumber < MAX_PLAYERS, "Invalid player: %" PRIu32 "", playerNumber);
 
@@ -2054,10 +2047,9 @@ bool activateGroup(UDWORD playerNumber, UDWORD groupNumber)
 	{
 		//clear the Deliv Point if one
 		ASSERT_OR_RETURN(false, selectedPlayer < MAX_PLAYERS, "Unsupported selectedPlayer: %" PRIu32 "", selectedPlayer);
-		for (psFlagPos = apsFlagPosLists[selectedPlayer]; psFlagPos;
-			 psFlagPos = psFlagPos->psNext)
+		for (auto& psFlag : apsFlagPosLists[selectedPlayer])
 		{
-			psFlagPos->selected = false;
+			psFlag->selected = false;
 		}
 		groupConsoleInformOfSelection(groupNumber);
 	}

--- a/src/droid.h
+++ b/src/droid.h
@@ -157,7 +157,7 @@ void vanishDroid(DROID *psDel);
 
 /* Remove a droid from the apsDroidLists so doesn't update or get drawn etc*/
 //returns true if successfully removed from the list
-bool droidRemove(DROID *psDroid, PerPlayerDroidList& pList);
+bool droidRemove(DROID *psDroid, PerPlayerDroidLists& pList);
 
 //free the storage for the droid templates
 bool droidTemplateShutDown();

--- a/src/droid.h
+++ b/src/droid.h
@@ -163,7 +163,7 @@ bool droidRemove(DROID *psDroid, PerPlayerDroidLists& pList);
 bool droidTemplateShutDown();
 
 /* Return the type of a droid */
-DROID_TYPE droidType(DROID *psDroid);
+DROID_TYPE droidType(const DROID *psDroid);
 
 /* Return the type of a droid from it's template */
 DROID_TYPE droidTemplateType(const DROID_TEMPLATE *psTemplate);

--- a/src/droid.h
+++ b/src/droid.h
@@ -31,6 +31,7 @@
 #include "stats.h"
 #include "visibility.h"
 #include "selection.h"
+#include "objmem.h"
 
 #include <queue>
 
@@ -156,7 +157,7 @@ void vanishDroid(DROID *psDel);
 
 /* Remove a droid from the apsDroidLists so doesn't update or get drawn etc*/
 //returns true if successfully removed from the list
-bool droidRemove(DROID *psDroid, DROID *pList[MAX_PLAYERS]);
+bool droidRemove(DROID *psDroid, PerPlayerDroidList& pList);
 
 //free the storage for the droid templates
 bool droidTemplateShutDown();

--- a/src/effects.cpp
+++ b/src/effects.cpp
@@ -2229,7 +2229,7 @@ static void effectStructureUpdates()
 	/* Go thru' all players */
 	for (unsigned player = 0; player < MAX_PLAYERS; ++player)
 	{
-		for (STRUCTURE *psStructure = apsStructLists[player]; psStructure != nullptr; psStructure = psStructure->psNext)
+		for (STRUCTURE *psStructure : apsStructLists[player])
 		{
 			// Find its group.
 			unsigned int partition = psStructure->id % EFFECT_STRUCTURE_DIVISION;

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2536,7 +2536,7 @@ bool loadGame(const char *pGameToLoad, bool keepObjects, bool freeMem, bool User
 			apsDroidLists[player] = nullptr;
 			apsStructLists[player] = nullptr;
 			apsFeatureLists[player] = nullptr;
-			apsFlagPosLists[player] = nullptr;
+			apsFlagPosLists[player].clear();
 			//clear all the messages?
 			apsProxDisp[player] = nullptr;
 			apsSensorList[0] = nullptr;
@@ -2555,7 +2555,7 @@ bool loadGame(const char *pGameToLoad, bool keepObjects, bool freeMem, bool User
 			mission.apsDroidLists[player] = nullptr;
 			mission.apsStructLists[player] = nullptr;
 			mission.apsFeatureLists[player] = nullptr;
-			mission.apsFlagPosLists[player] = nullptr;
+			mission.apsFlagPosLists[player].clear();
 			mission.apsExtractorLists[player] = nullptr;
 		}
 		mission.apsOilList[0] = nullptr;

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2222,14 +2222,14 @@ static bool writeMapFile(const char *fileName);
 
 static bool loadWzMapDroidInit(WzMap::Map &wzMap, std::unordered_map<UDWORD, UDWORD>& fixedMapIdToGeneratedId);
 
-static bool loadSaveDroid(const char *pFileName, PerPlayerDroidList& ppsCurrentDroidLists);
-static bool loadSaveDroidPointers(const WzString &pFileName, PerPlayerDroidList* ppsCurrentDroidLists);
-static bool writeDroidFile(const char *pFileName, const PerPlayerDroidList& ppsCurrentDroidLists);
+static bool loadSaveDroid(const char *pFileName, PerPlayerDroidLists& ppsCurrentDroidLists);
+static bool loadSaveDroidPointers(const WzString &pFileName, PerPlayerDroidLists* ppsCurrentDroidLists);
+static bool writeDroidFile(const char *pFileName, const PerPlayerDroidLists& ppsCurrentDroidLists);
 
 static bool loadSaveStructure(char *pFileData, UDWORD filesize);
 static bool loadSaveStructure2(const char *pFileName);
 static bool loadWzMapStructure(WzMap::Map& wzMap, std::unordered_map<UDWORD, UDWORD>& fixedMapIdToGeneratedId, std::array<std::unordered_map<UDWORD, UDWORD>, MAX_PLAYER_SLOTS>& moduleToBuilding);
-static bool loadSaveStructurePointers(const WzString& filename, PerPlayerStructureList *ppList);
+static bool loadSaveStructurePointers(const WzString& filename, PerPlayerStructureLists *ppList);
 static bool writeStructFile(const char *pFileName);
 
 static bool loadSaveTemplate(const char *pFileName);
@@ -2483,8 +2483,8 @@ static WzMap::MapType getWzMapType(bool UserSaveGame)
 bool loadGame(const char *pGameToLoad, bool keepObjects, bool freeMem, bool UserSaveGame)
 {
 	std::shared_ptr<WzMap::Map> data;
-	std::map<WzString, PerPlayerDroidList *> droidMap;
-	std::map<WzString, PerPlayerStructureList *> structMap;
+	std::map<WzString, PerPlayerDroidLists *> droidMap;
+	std::map<WzString, PerPlayerStructureLists *> structMap;
 
 	// only populated when loading maps, *not* savegames
 	std::unordered_map<UDWORD, UDWORD> fixedMapIdToGeneratedId;
@@ -3256,13 +3256,13 @@ bool loadGame(const char *pGameToLoad, bool keepObjects, bool freeMem, bool User
 		for (auto it = droidMap.begin(); it != droidMap.end(); ++it)
 		{
 			const WzString& key = it->first;
-			PerPlayerDroidList* pList = it->second;
+			PerPlayerDroidLists* pList = it->second;
 			loadSaveDroidPointers(key, pList);
 		}
 		for (auto it = structMap.begin(); it != structMap.end(); ++it)
 		{
 			const WzString& key = it->first;
-			PerPlayerStructureList* pList = it->second;
+			PerPlayerStructureLists* pList = it->second;
 			loadSaveStructurePointers(key, pList);
 		}
 	}
@@ -5312,7 +5312,7 @@ static inline void setPlayerJSON(nlohmann::json &jsonObj, int player)
 	}
 }
 
-static bool loadSaveDroidPointers(const WzString &pFileName, PerPlayerDroidList* ppsCurrentDroidLists)
+static bool loadSaveDroidPointers(const WzString &pFileName, PerPlayerDroidLists* ppsCurrentDroidLists)
 {
 	WzConfig ini(pFileName, WzConfig::ReadOnly);
 	std::vector<WzString> list = ini.childGroups();
@@ -5545,7 +5545,7 @@ inline T getCompFromName_NullCompOnFail(COMPONENT_TYPE compType, const WzString 
 	return (index >= 0) ? static_cast<T>(index) : 0; // 0 to reference the null weapon / body / etc
 }
 
-static bool loadSaveDroid(const char *pFileName, PerPlayerDroidList& ppsCurrentDroidLists)
+static bool loadSaveDroid(const char *pFileName, PerPlayerDroidLists& ppsCurrentDroidLists)
 {
 	if (!PHYSFS_exists(pFileName))
 	{
@@ -5905,7 +5905,7 @@ static nlohmann::json writeDroid(DROID *psCurr, bool onMission, int &counter)
 	return droidObj;
 }
 
-static bool writeDroidFile(const char *pFileName, const PerPlayerDroidList& ppsCurrentDroidLists)
+static bool writeDroidFile(const char *pFileName, const PerPlayerDroidLists& ppsCurrentDroidLists)
 {
 	nlohmann::json mRoot = nlohmann::json::object();
 	int counter = 0;
@@ -6685,7 +6685,7 @@ bool writeStructFile(const char *pFileName)
 }
 
 // -----------------------------------------------------------------------------------------
-bool loadSaveStructurePointers(const WzString& filename, PerPlayerStructureList *ppList)
+bool loadSaveStructurePointers(const WzString& filename, PerPlayerStructureLists *ppList)
 {
 	WzConfig ini(filename, WzConfig::ReadOnly);
 	std::vector<WzString> list = ini.childGroups();

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2539,10 +2539,10 @@ bool loadGame(const char *pGameToLoad, bool keepObjects, bool freeMem, bool User
 			apsFlagPosLists[player].clear();
 			//clear all the messages?
 			apsProxDisp[player] = nullptr;
-			apsSensorList[0] = nullptr;
-			apsExtractorLists[player] = nullptr;
+			apsSensorList[0].clear();
+			apsExtractorLists[player].clear();
 		}
-		apsOilList[0] = nullptr;
+		apsOilList[0].clear();
 		initFactoryNumFlag();
 	}
 
@@ -2556,10 +2556,10 @@ bool loadGame(const char *pGameToLoad, bool keepObjects, bool freeMem, bool User
 			mission.apsStructLists[player] = nullptr;
 			mission.apsFeatureLists[player] = nullptr;
 			mission.apsFlagPosLists[player].clear();
-			mission.apsExtractorLists[player] = nullptr;
+			mission.apsExtractorLists[player].clear();
 		}
-		mission.apsOilList[0] = nullptr;
-		mission.apsSensorList[0] = nullptr;
+		mission.apsOilList[0].clear();
+		mission.apsSensorList[0].clear();
 
 		// Stuff added after level load to avoid being reset or initialised during load
 		// always !keepObjects

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -5355,14 +5355,11 @@ static bool loadSaveDroidPointers(const WzString &pFileName, PerPlayerDroidLists
 foundDroid:
 		if (!psDroid)
 		{
-			auto missionDroidIt = std::find_if(mission.apsDroidLists[player].begin(), mission.apsDroidLists[player].end(), [id](DROID* d)
-			{
-				return d->id == id;
-			});
+			DROID* d = (DROID*)getBaseObjFromId(mission.apsDroidLists[player], id);
 			// FIXME
-			if (missionDroidIt != mission.apsDroidLists[player].end())
+			if (d)
 			{
-				debug(LOG_ERROR, "Droid %s (%d) was in wrong file/list (was in %s)...", objInfo(*missionDroidIt), id, pFileName.toUtf8().c_str());
+				debug(LOG_ERROR, "Droid %s (%d) was in wrong file/list (was in %s)...", objInfo(d), id, pFileName.toUtf8().c_str());
 			}
 		}
 		ASSERT_OR_RETURN(false, psDroid, "Droid %d not found", id);
@@ -5438,7 +5435,7 @@ static void loadSaveObject(WzConfig &ini, BASE_OBJECT *psObj)
 	psObj->born = ini.value("born", 2).toInt();
 }
 
-static void writeSaveObject(WzConfig &ini, BASE_OBJECT *psObj)
+static void writeSaveObject(WzConfig &ini, const BASE_OBJECT *psObj)
 {
 	ini.setValue("id", psObj->id);
 	setPlayer(ini, psObj->player);
@@ -6528,7 +6525,7 @@ bool writeStructFile(const char *pFileName)
 
 	for (int player = 0; player < MAX_PLAYERS; player++)
 	{
-		for (STRUCTURE *psCurr : apsStructLists[player])
+		for (const STRUCTURE *psCurr : apsStructLists[player])
 		{
 			if (!psCurr->pStructureType)
 			{
@@ -6696,14 +6693,7 @@ bool loadSaveStructurePointers(const WzString& filename, PerPlayerStructureLists
 		STRUCTURE *psStruct = nullptr;
 		int player = getPlayer(ini);
 		int id = ini.value("id", -1).toInt();
-		auto structIt = std::find_if((*ppList)[player].begin(), (*ppList)[player].end(), [id](STRUCTURE* str)
-		{
-			return str->id == id;
-		});
-		if (structIt != (*ppList)[player].end())
-		{
-			psStruct = *structIt;
-		}
+		psStruct = (STRUCTURE*)getBaseObjFromId((*ppList)[player], id);
 		if (!psStruct)
 		{
 			ini.endGroup();
@@ -7036,7 +7026,7 @@ bool writeFeatureFile(const char *pFileName)
 	WzConfig ini(WzString::fromUtf8(pFileName), WzConfig::ReadAndWrite);
 	int counter = 0;
 
-	for (FEATURE *psCurr : apsFeatureLists[0])
+	for (const FEATURE *psCurr : apsFeatureLists[0])
 	{
 		ini.beginGroup("feature_" + (WzString::number(counter++).leftPadToMinimumLength(WzUniCodepoint::fromASCII('0'), 10)));  // Zero padded so that alphabetical sort works.
 		ini.setValue("name", psCurr->psStats->id);

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2535,7 +2535,7 @@ bool loadGame(const char *pGameToLoad, bool keepObjects, bool freeMem, bool User
 		{
 			apsDroidLists[player] = nullptr;
 			apsStructLists[player] = nullptr;
-			apsFeatureLists[player] = nullptr;
+			apsFeatureLists[player].clear();
 			apsFlagPosLists[player].clear();
 			//clear all the messages?
 			apsProxDisp[player] = nullptr;
@@ -2554,7 +2554,7 @@ bool loadGame(const char *pGameToLoad, bool keepObjects, bool freeMem, bool User
 			apsLimboDroids[player] = nullptr;
 			mission.apsDroidLists[player] = nullptr;
 			mission.apsStructLists[player] = nullptr;
-			mission.apsFeatureLists[player] = nullptr;
+			mission.apsFeatureLists[player].clear();
 			mission.apsFlagPosLists[player].clear();
 			mission.apsExtractorLists[player].clear();
 		}
@@ -7021,7 +7021,7 @@ bool writeFeatureFile(const char *pFileName)
 	WzConfig ini(WzString::fromUtf8(pFileName), WzConfig::ReadAndWrite);
 	int counter = 0;
 
-	for (FEATURE *psCurr = apsFeatureLists[0]; psCurr != nullptr; psCurr = psCurr->psNext)
+	for (FEATURE *psCurr : apsFeatureLists[0])
 	{
 		ini.beginGroup("feature_" + (WzString::number(counter++).leftPadToMinimumLength(WzUniCodepoint::fromASCII('0'), 10)));  // Zero padded so that alphabetical sort works.
 		ini.setValue("name", psCurr->psStats->id);

--- a/src/gamehistorylogger.cpp
+++ b/src/gamehistorylogger.cpp
@@ -64,7 +64,7 @@ static std::tuple<uint32_t, uint32_t> getDroidHPPercentageAndExperience(uint32_t
 	uint64_t totalHP = 0;
 	uint64_t totalExp = 0;
 	uint64_t numDroids = 0;
-	for (const DROID *psDroid = apsDroidLists[player]; psDroid; psDroid = psDroid->psNext)
+	for (const DROID *psDroid : apsDroidLists[player])
 	{
 		if (psDroid->died)
 		{

--- a/src/gamehistorylogger.cpp
+++ b/src/gamehistorylogger.cpp
@@ -88,7 +88,7 @@ static uint32_t getNumOilRigs(uint32_t player)
 	}
 
 	uint32_t result = 0;
-	for (STRUCTURE *psStruct : apsStructLists[player])
+	for (const STRUCTURE *psStruct : apsStructLists[player])
 	{
 		if (!psStruct->died
 			&& (REF_RESOURCE_EXTRACTOR == psStruct->pStructureType->type))

--- a/src/gamehistorylogger.cpp
+++ b/src/gamehistorylogger.cpp
@@ -88,7 +88,7 @@ static uint32_t getNumOilRigs(uint32_t player)
 	}
 
 	uint32_t result = 0;
-	for (STRUCTURE *psStruct = apsStructLists[player]; psStruct; psStruct = psStruct->psNext)
+	for (STRUCTURE *psStruct : apsStructLists[player])
 	{
 		if (!psStruct->died
 			&& (REF_RESOURCE_EXTRACTOR == psStruct->pStructureType->type))

--- a/src/geometry.cpp
+++ b/src/geometry.cpp
@@ -137,7 +137,7 @@ Vector2i positionInQuad(Vector2i const &pt, QUAD const &quad)
 }
 
 //-----------------------------------------------------------------------------------
-bool objectOnScreen(BASE_OBJECT *object, SDWORD tolerance)
+bool objectOnScreen(const BASE_OBJECT *object, SDWORD tolerance)
 {
 	if (DrawnInLastFrame(object->sDisplay.frameNumber) == true)
 	{

--- a/src/geometry.cpp
+++ b/src/geometry.cpp
@@ -53,7 +53,7 @@ DROID	*getNearestDroid(UDWORD x, UDWORD y, bool bSelected)
 	ASSERT_OR_RETURN(nullptr, selectedPlayer < MAX_PLAYERS, "Not supported selectedPlayer: %" PRIu32 "", selectedPlayer);
 
 	/* Go thru' all the droids  - how often have we seen this - a MACRO maybe? */
-	for (DROID *psDroid = apsDroidLists[selectedPlayer]; psDroid; psDroid = psDroid->psNext)
+	for (DROID *psDroid : apsDroidLists[selectedPlayer])
 	{
 		if (!isVtolDroid(psDroid))
 		{

--- a/src/geometry.h
+++ b/src/geometry.h
@@ -32,7 +32,7 @@ uint16_t calcDirection(int32_t x0, int32_t y0, int32_t x1, int32_t y1);
 bool inQuad(const Vector2i *pt, const QUAD *quad);
 Vector2i positionInQuad(Vector2i const &pt, QUAD const &quad);
 DROID *getNearestDroid(UDWORD x, UDWORD y, bool bSelected);
-bool objectOnScreen(BASE_OBJECT *object, SDWORD tolerance);
+bool objectOnScreen(const BASE_OBJECT *object, SDWORD tolerance);
 
 static inline STRUCTURE *getTileStructure(UDWORD x, UDWORD y)
 {

--- a/src/hci.cpp
+++ b/src/hci.cpp
@@ -1028,16 +1028,13 @@ void intRefreshGroupsUI()
 // see if a delivery point is selected
 static FLAG_POSITION *intFindSelectedDelivPoint()
 {
-	FLAG_POSITION *psFlagPos;
-
 	ASSERT_OR_RETURN(nullptr, selectedPlayer < MAX_PLAYERS, "Not supported selectedPlayer: %" PRIu32 "", selectedPlayer);
 
-	for (psFlagPos = apsFlagPosLists[selectedPlayer]; psFlagPos;
-	     psFlagPos = psFlagPos->psNext)
+	for (const auto& psFlag : apsFlagPosLists[selectedPlayer])
 	{
-		if (psFlagPos->selected && (psFlagPos->type == POS_DELIVERY))
+		if (psFlag->selected && psFlag->type == POS_DELIVERY)
 		{
-			return psFlagPos;
+			return psFlag;
 		}
 	}
 

--- a/src/hci.cpp
+++ b/src/hci.cpp
@@ -266,8 +266,6 @@ static void intStopStructPosition();
 
 static optional<StructureList::iterator> CurrentStruct;
 static SWORD CurrentStructType = 0;
-static DROID *CurrentDroid = nullptr;
-static DROID_TYPE CurrentDroidType = DROID_ANY;
 
 /******************Power Bar Stuff!**************/
 
@@ -2752,7 +2750,6 @@ void	setKeyButtonMapping(UDWORD	val)
 // count the number of selected droids of a type
 static SDWORD intNumSelectedDroids(UDWORD droidType)
 {
-	DROID	*psDroid;
 	SDWORD	num;
 
 	if (selectedPlayer >= MAX_PLAYERS)
@@ -2761,7 +2758,7 @@ static SDWORD intNumSelectedDroids(UDWORD droidType)
 	}
 
 	num = 0;
-	for (psDroid = apsDroidLists[selectedPlayer]; psDroid; psDroid = psDroid->psNext)
+	for (DROID* psDroid : apsDroidLists[selectedPlayer])
 	{
 		if (psDroid->selected && psDroid->droidType == droidType)
 		{
@@ -2932,89 +2929,6 @@ STRUCTURE *intFindAStructure()
 	}
 
 	return Struct;
-}
-
-// Look through the players droids and find the next one of type droidType.
-// If Current=NULL then start at the beginning overwise start at Current.
-//
-DROID *intGotoNextDroidType(DROID *CurrDroid, DROID_TYPE droidType, bool AllowGroup)
-{
-	DROID *psDroid;
-	bool Found = false;
-
-	if (selectedPlayer >= MAX_PLAYERS)
-	{
-		return nullptr;
-	}
-
-	if (CurrDroid != nullptr)
-	{
-		CurrentDroid = CurrDroid;
-	}
-
-	if (droidType != CurrentDroidType && droidType != DROID_ANY)
-	{
-		CurrentDroid = nullptr;
-		CurrentDroidType = droidType;
-	}
-
-	if (CurrentDroid != nullptr)
-	{
-		psDroid = CurrentDroid;
-	}
-	else
-	{
-		psDroid = apsDroidLists[selectedPlayer];
-	}
-
-	for (; psDroid != nullptr; psDroid = psDroid->psNext)
-	{
-		if ((psDroid->droidType == droidType
-		     || (droidType == DROID_ANY && !isTransporter(psDroid)))
-		    && (psDroid->group == UBYTE_MAX || AllowGroup))
-		{
-			if (psDroid != CurrentDroid)
-			{
-				clearSelection();
-				SelectDroid(psDroid);
-				CurrentDroid = psDroid;
-				Found = true;
-				break;
-			}
-		}
-	}
-
-	// Start back at the beginning?
-	if ((!Found) && (CurrentDroid != nullptr))
-	{
-		for (psDroid = apsDroidLists[selectedPlayer]; (psDroid != CurrentDroid) && (psDroid != nullptr); psDroid = psDroid->psNext)
-		{
-			if ((psDroid->droidType == droidType ||
-			     ((droidType == DROID_ANY) && !isTransporter(psDroid))) &&
-			    ((psDroid->group == UBYTE_MAX) || AllowGroup))
-			{
-				if (psDroid != CurrentDroid)
-				{
-					clearSelection();
-					SelectDroid(psDroid);
-					CurrentDroid = psDroid;
-					Found = true;
-					break;
-				}
-			}
-		}
-	}
-
-	if (Found == true)
-	{
-		// Center it on screen.
-		if (CurrentDroid)
-		{
-			intSetMapPos(CurrentDroid->pos.x, CurrentDroid->pos.y);
-		}
-		return CurrentDroid;
-	}
-	return nullptr;
 }
 
 // Checks if a coordinate is over the build menu

--- a/src/hci.cpp
+++ b/src/hci.cpp
@@ -2758,7 +2758,7 @@ static SDWORD intNumSelectedDroids(UDWORD droidType)
 	}
 
 	num = 0;
-	for (DROID* psDroid : apsDroidLists[selectedPlayer])
+	for (const DROID* psDroid : apsDroidLists[selectedPlayer])
 	{
 		if (psDroid->selected && psDroid->droidType == droidType)
 		{

--- a/src/hci.cpp
+++ b/src/hci.cpp
@@ -264,9 +264,6 @@ static bool intAddCommand();
 /* Stop looking for a structure location */
 static void intStopStructPosition();
 
-static optional<StructureList::iterator> CurrentStruct;
-static SWORD CurrentStructType = 0;
-
 /******************Power Bar Stuff!**************/
 
 /* Set the shadow for the PowerBar */
@@ -2841,94 +2838,6 @@ bool intCheckReticuleButEnabled(UDWORD id)
 		}
 	}
 	return false;
-}
-
-// Look through the players structures and find the next one of type structType.
-//
-static STRUCTURE *intGotoNextStructureType(UDWORD structType)
-{
-	StructureList::iterator psStructIt;
-	bool Found = false;
-
-	if ((SWORD)structType != CurrentStructType)
-	{
-		CurrentStruct.reset();
-		CurrentStructType = (SWORD)structType;
-	}
-
-	auto* intStrList = interfaceStructList();
-	if (CurrentStruct.has_value())
-	{
-		psStructIt = *CurrentStruct;
-	}
-	else
-	{
-		if (intStrList)
-		{
-			psStructIt = intStrList->begin();
-		}
-	}
-
-	while (psStructIt != intStrList->end())
-	{
-		if (((*psStructIt)->pStructureType->type == structType || structType == REF_ANY) && (*psStructIt)->status == SS_BUILT)
-		{
-			if (!CurrentStruct || psStructIt != CurrentStruct)
-			{
-				clearSelection();
-				(*psStructIt)->selected = true;
-				CurrentStruct = psStructIt;
-				Found = true;
-				break;
-			}
-		}
-	}
-
-	// Start back at the beginning?
-	if ((!Found) && CurrentStruct.has_value())
-	{
-		psStructIt = intStrList->begin();
-		while (psStructIt != intStrList->end() && psStructIt != CurrentStruct)
-		{
-			if (((*psStructIt)->pStructureType->type == structType || structType == REF_ANY) && (*psStructIt)->status == SS_BUILT)
-			{
-				if (psStructIt != CurrentStruct)
-				{
-					clearSelection();
-					(*psStructIt)->selected = true;
-					jsDebugSelected((*psStructIt));
-					CurrentStruct = psStructIt;
-					break;
-				}
-			}
-		}
-	}
-
-	triggerEventSelected();
-
-	return CurrentStruct.has_value() ? **CurrentStruct : nullptr;
-}
-
-// Find any structure. Returns NULL if none found.
-//
-STRUCTURE *intFindAStructure()
-{
-	STRUCTURE *Struct;
-
-	// First try and find a factory.
-	Struct = intGotoNextStructureType(REF_FACTORY);
-	if (Struct == nullptr)
-	{
-		// If that fails then look for a command center.
-		Struct = intGotoNextStructureType(REF_HQ);
-		if (Struct == nullptr)
-		{
-			// If that fails then look for a any structure.
-			Struct = intGotoNextStructureType(REF_ANY);
-		}
-	}
-
-	return Struct;
 }
 
 // Checks if a coordinate is over the build menu

--- a/src/hci.h
+++ b/src/hci.h
@@ -33,6 +33,7 @@ typedef std::function<void (const int)> playerCallbackFunc; // callback function
 #include "lib/ivis_opengl/pieclip.h"
 
 #include "message.h"
+#include "objmem.h"
 
 #include <nonstd/optional.hpp>
 using nonstd::optional;
@@ -345,7 +346,7 @@ void intRemoveStatsNoAnim();
 void intRemoveObjectNoAnim();
 
 /*sets which list of structures to use for the interface*/
-STRUCTURE *interfaceStructList();
+StructureList *interfaceStructList();
 
 //sets up the Transporter Screen as far as the interface is concerned
 void addTransporterInterface(DROID *psSelected, bool onMission);

--- a/src/hci.h
+++ b/src/hci.h
@@ -378,7 +378,6 @@ void intRemoveProximityButton(PROXIMITY_DISPLAY *psProxDisp);
 /* Allows us to fool the widgets with a keypress */
 void	setKeyButtonMapping(UDWORD	val);
 
-STRUCTURE *intFindAStructure();
 DROID *intGotoNextDroidType(DROID *CurrDroid, DROID_TYPE droidType, bool AllowGroup);
 
 /// Returns the number of researches that selectedPlayer is not already researching, or 0 if there are no free laboratories.

--- a/src/hci/build.cpp
+++ b/src/hci/build.cpp
@@ -45,7 +45,7 @@ void BuildController::updateBuildersList()
 
 	ASSERT_OR_RETURN(, selectedPlayer < MAX_PLAYERS, "selectedPlayer = %" PRIu32 "", selectedPlayer);
 
-	for (DROID *droid = apsDroidLists[selectedPlayer]; droid; droid = droid->psNext)
+	for (DROID *droid : apsDroidLists[selectedPlayer])
 	{
 		if (isConstructionDroid(droid) && droid->died == 0)
 		{

--- a/src/hci/commander.cpp
+++ b/src/hci/commander.cpp
@@ -38,7 +38,7 @@ void CommanderController::updateCommandersList()
 
 	ASSERT_OR_RETURN(, selectedPlayer < MAX_PLAYERS, "selectedPlayer = %" PRIu32 "", selectedPlayer);
 
-	for (DROID *droid = apsDroidLists[selectedPlayer]; droid; droid = droid->psNext)
+	for (DROID *droid : apsDroidLists[selectedPlayer])
 	{
 		if (droid->droidType == DROID_COMMAND && droid->died == 0)
 		{

--- a/src/hci/groups.cpp
+++ b/src/hci/groups.cpp
@@ -278,7 +278,7 @@ void GroupsUIController::updateData()
 	};
 
 	std::array<AccumulatedGroupInfo, 10> calculatedGroupInfo;
-	for (DROID *psDroid = apsDroidLists[selectedPlayer]; psDroid != nullptr; psDroid = psDroid->psNext)
+	for (DROID *psDroid : apsDroidLists[selectedPlayer])
 	{
 		auto groupIdx = psDroid->group;
 		if (psDroid->group >= calculatedGroupInfo.size())

--- a/src/hci/manufacture.cpp
+++ b/src/hci/manufacture.cpp
@@ -138,11 +138,15 @@ void ManufactureController::updateFactoriesList()
 {
 	factories.clear();
 
-	for (auto structure = interfaceStructList(); structure != nullptr; structure = structure->psNext)
+	auto* intStrList = interfaceStructList();
+	if (intStrList)
 	{
-		if (structure->status == SS_BUILT && structure->died == 0 && StructIsFactory(structure))
+		for (auto structure : *intStrList)
 		{
-			factories.push_back(structure);
+			if (structure->status == SS_BUILT && structure->died == 0 && StructIsFactory(structure))
+			{
+				factories.push_back(structure);
+			}
 		}
 	}
 

--- a/src/hci/objects_stats.cpp
+++ b/src/hci/objects_stats.cpp
@@ -33,9 +33,13 @@ void BaseObjectsController::clearSelection()
 
 void BaseObjectsController::clearStructureSelection()
 {
-	for (auto structure = interfaceStructList(); structure != nullptr; structure = structure->psNext)
+	StructureList* intStrList = interfaceStructList();
+	if (intStrList)
 	{
-		structure->selected = false;
+		for (auto structure : *intStrList)
+		{
+			structure->selected = false;
+		}
 	}
 }
 

--- a/src/hci/research.cpp
+++ b/src/hci/research.cpp
@@ -42,11 +42,15 @@ void ResearchController::updateFacilitiesList()
 {
 	facilities.clear();
 
-	for (auto psStruct = interfaceStructList(); psStruct != nullptr; psStruct = psStruct->psNext)
+	auto* intStrList = interfaceStructList();
+	if (intStrList)
 	{
-		if (psStruct->pStructureType->type == REF_RESEARCH && psStruct->status == SS_BUILT && psStruct->died == 0)
+		for (auto psStruct : *intStrList)
 		{
-			facilities.push_back(psStruct);
+			if (psStruct->pStructureType->type == REF_RESEARCH && psStruct->status == SS_BUILT && psStruct->died == 0)
+			{
+				facilities.push_back(psStruct);
+			}
 		}
 	}
 

--- a/src/intdisplay.cpp
+++ b/src/intdisplay.cpp
@@ -1372,14 +1372,13 @@ STRUCTURE *DroidGetBuildStructure(DROID *Droid)
 STRUCTURE *droidGetCommandFactory(DROID *psDroid)
 {
 	SDWORD		inc;
-	STRUCTURE	*psCurr;
 
 	for (inc = 0; inc < MAX_FACTORY; inc++)
 	{
 		if (psDroid->secondaryOrder & (1 << (inc + DSS_ASSPROD_SHIFT)))
 		{
 			// found an assigned factory - look for it in the lists
-			for (psCurr = apsStructLists[psDroid->player]; psCurr; psCurr = psCurr->psNext)
+			for (STRUCTURE* psCurr : apsStructLists[psDroid->player])
 			{
 				if ((psCurr->pStructureType->type == REF_FACTORY) &&
 				    (((FACTORY *)psCurr->pFunctionality)->
@@ -1392,7 +1391,7 @@ STRUCTURE *droidGetCommandFactory(DROID *psDroid)
 		if (psDroid->secondaryOrder & (1 << (inc + DSS_ASSPROD_CYBORG_SHIFT)))
 		{
 			// found an assigned factory - look for it in the lists
-			for (psCurr = apsStructLists[psDroid->player]; psCurr; psCurr = psCurr->psNext)
+			for (STRUCTURE* psCurr : apsStructLists[psDroid->player])
 			{
 				if ((psCurr->pStructureType->type == REF_CYBORG_FACTORY) &&
 				    (((FACTORY *)psCurr->pFunctionality)->
@@ -1405,7 +1404,7 @@ STRUCTURE *droidGetCommandFactory(DROID *psDroid)
 		if (psDroid->secondaryOrder & (1 << (inc + DSS_ASSPROD_VTOL_SHIFT)))
 		{
 			// found an assigned factory - look for it in the lists
-			for (psCurr = apsStructLists[psDroid->player]; psCurr; psCurr = psCurr->psNext)
+			for (STRUCTURE* psCurr : apsStructLists[psDroid->player])
 			{
 				if ((psCurr->pStructureType->type == REF_VTOL_FACTORY) &&
 				    (((FACTORY *)psCurr->pFunctionality)->

--- a/src/intorder.cpp
+++ b/src/intorder.cpp
@@ -410,7 +410,7 @@ static bool BuildSelectedDroidList()
 		return false;
 	}
 
-	for (DROID *psDroid = apsDroidLists[selectedPlayer]; psDroid; psDroid = psDroid->psNext)
+	for (DROID *psDroid : apsDroidLists[selectedPlayer])
 	{
 		if (psDroid->selected)
 		{

--- a/src/keybind.cpp
+++ b/src/keybind.cpp
@@ -2155,6 +2155,7 @@ void	kf_CentreOnBase()
 			yJump = (*structIt)->pos.y;
 			break;
 		}
+		++structIt;
 	}
 
 	/* If we found it, then jump to it! */

--- a/src/keybind.cpp
+++ b/src/keybind.cpp
@@ -907,7 +907,6 @@ void kf_MapCheck()
 
 	DROID		*psDroid;
 	STRUCTURE	*psStruct;
-	FLAG_POSITION	*psCurrFlag;
 
 	if (selectedPlayer >= MAX_PLAYERS) { return; }
 
@@ -921,9 +920,9 @@ void kf_MapCheck()
 		alignStructure(psStruct);
 	}
 
-	for (psCurrFlag = apsFlagPosLists[selectedPlayer]; psCurrFlag; psCurrFlag = psCurrFlag->psNext)
+	for (auto& psFlag : apsFlagPosLists[selectedPlayer])
 	{
-		psCurrFlag->coords.z = map_Height(psCurrFlag->coords.x, psCurrFlag->coords.y) + ASSEMBLY_POINT_Z_PADDING;
+		psFlag->coords.z = map_Height(psFlag->coords.x, psFlag->coords.y) + ASSEMBLY_POINT_Z_PADDING;
 	}
 }
 

--- a/src/keybind.cpp
+++ b/src/keybind.cpp
@@ -1302,15 +1302,12 @@ void	kf_ToggleGodMode()
 	{
 		ASSERT_OR_RETURN(, selectedPlayer < MAX_PLAYERS, "Cannot disable godMode for spectator-only slots");
 
-		FEATURE	*psFeat = apsFeatureLists[0];
-
 		godMode = false;
 		setRevealStatus(pastReveal);
 		// now hide the features
-		while (psFeat)
+		for (BASE_OBJECT* psFeat : apsFeatureLists[0])
 		{
 			psFeat->visible[selectedPlayer] = 0;
-			psFeat = psFeat->psNext;
 		}
 
 		// and the structures

--- a/src/keybind.cpp
+++ b/src/keybind.cpp
@@ -1625,16 +1625,23 @@ void	kf_JumpToResourceExtractor()
 	/* not supported if a spectator */
 	SPECTATOR_NO_OP();
 
-	if (psOldRE.has_value() && *psOldRE != apsExtractorLists[selectedPlayer].end())
+	if (apsExtractorLists[selectedPlayer].empty())
 	{
-		++(*psOldRE);
+		addConsoleMessage(_("Unable to locate any oil derricks!"), LEFT_JUSTIFY, SYSTEM_MESSAGE);
+		return;
+	}
+
+	if (!psOldRE.has_value() || std::next(*psOldRE) == apsExtractorLists[selectedPlayer].end())
+	{
+		// Reset the pointer if `psOldRE` is either not initialized yet or points to the last element.
+		psOldRE.emplace(apsExtractorLists[selectedPlayer].begin());
 	}
 	else
 	{
-		psOldRE.emplace(apsExtractorLists[selectedPlayer].begin());
+		++(*psOldRE);
 	}
 
-	if (*psOldRE != apsExtractorLists[selectedPlayer].end() && **psOldRE != nullptr)
+	if (**psOldRE != nullptr)
 	{
 		playerPos.r.y = 0; // face north
 		setViewPos(map_coord((**psOldRE)->pos.x), map_coord((**psOldRE)->pos.y), true);
@@ -1643,7 +1650,6 @@ void	kf_JumpToResourceExtractor()
 	{
 		addConsoleMessage(_("Unable to locate any oil derricks!"), LEFT_JUSTIFY, SYSTEM_MESSAGE);
 	}
-
 }
 
 void keybindInformResourceExtractorRemoved(const STRUCTURE* psResourceExtractor)

--- a/src/keybind.cpp
+++ b/src/keybind.cpp
@@ -252,7 +252,7 @@ void	kf_TraceObject()
 		return; // no-op
 	}
 
-	for (DROID* psCDroid : apsDroidLists[selectedPlayer])
+	for (const DROID* psCDroid : apsDroidLists[selectedPlayer])
 	{
 		if (psCDroid->selected)
 		{
@@ -261,7 +261,7 @@ void	kf_TraceObject()
 			return;
 		}
 	}
-	for (STRUCTURE* psCStruct : apsStructLists[selectedPlayer])
+	for (const STRUCTURE* psCStruct : apsStructLists[selectedPlayer])
 	{
 		if (psCStruct->selected)
 		{
@@ -359,7 +359,7 @@ void	kf_DebugDroidInfo()
 		return; // no-op
 	}
 
-	for (DROID* psDroid : apsDroidLists[selectedPlayer])
+	for (const DROID* psDroid : apsDroidLists[selectedPlayer])
 	{
 		if (psDroid->selected)
 		{
@@ -740,7 +740,7 @@ void kf_ListDroids()
 	}
 	for (int i = 0; i < MAX_PLAYERS; i++)
 	{
-		for (DROID *psDroid : apsDroidLists[i])
+		for (const DROID *psDroid : apsDroidLists[i])
 		{
 			const auto x = map_coord(psDroid->pos.x);
 			const auto y = map_coord(psDroid->pos.y);
@@ -1921,7 +1921,7 @@ void	kf_KillEnemy()
 		if (playerId != selectedPlayer && !aiCheckAlliances(selectedPlayer, playerId))
 		{
 			// wipe out all the droids
-			for (DROID* psCDroid : apsDroidLists[playerId])
+			for (const DROID* psCDroid : apsDroidLists[playerId])
 			{
 				SendDestroyDroid(psCDroid);
 			}
@@ -1957,7 +1957,7 @@ void kf_KillSelected()
 	audio_PlayTrack(ID_SOUND_COLL_DIE);
 	Cheated = true;
 
-	for (DROID* psCDroid : apsDroidLists[selectedPlayer])
+	for (const DROID* psCDroid : apsDroidLists[selectedPlayer])
 	{
 		if (psCDroid->selected)
 		{
@@ -2144,18 +2144,16 @@ void	kf_CentreOnBase()
 	SPECTATOR_NO_OP();
 
 	/* Got through our buildings */
-	auto structIt = apsStructLists[selectedPlayer].begin();
-	while (structIt != apsStructLists[selectedPlayer].end())
+	for (const STRUCTURE* pStruct : apsStructLists[selectedPlayer])
 	{
 		/* Have we got a HQ? */
-		if ((*structIt)->pStructureType->type == REF_HQ)
+		if (pStruct->pStructureType->type == REF_HQ)
 		{
 			bGotHQ = true;
-			xJump = (*structIt)->pos.x;
-			yJump = (*structIt)->pos.y;
+			xJump = pStruct->pos.x;
+			yJump = pStruct->pos.y;
 			break;
 		}
-		++structIt;
 	}
 
 	/* If we found it, then jump to it! */

--- a/src/lighting.cpp
+++ b/src/lighting.cpp
@@ -382,13 +382,12 @@ void calcDroidIllumination(DROID *psDroid)
 
 void doBuildingLights()
 {
-	STRUCTURE	*psStructure;
 	UDWORD	i;
 	LIGHT	light;
 
 	for (i = 0; i < MAX_PLAYERS; i++)
 	{
-		for (psStructure = apsStructLists[i]; psStructure; psStructure = psStructure->psNext)
+		for (STRUCTURE* psStructure : apsStructLists[i])
 		{
 			light.range = psStructure->pStructureType->baseWidth * TILE_UNITS;
 			light.position.x = psStructure->pos.x;

--- a/src/loop.cpp
+++ b/src/loop.cpp
@@ -578,10 +578,8 @@ static void gameStateUpdate()
 
 	proj_UpdateAll();
 
-	FEATURE *psNFeat;
-	for (FEATURE *psCFeat = apsFeatureLists[0]; psCFeat; psCFeat = psNFeat)
+	for (FEATURE *psCFeat : apsFeatureLists[0])
 	{
-		psNFeat = psCFeat->psNext;
 		featureUpdate(psCFeat);
 	}
 

--- a/src/loop.cpp
+++ b/src/loop.cpp
@@ -194,7 +194,7 @@ static GAMECODE renderLoop()
 
 			for (unsigned i = 0; i < MAX_PLAYERS; i++)
 			{
-				for (DROID *psCurr = apsDroidLists[i]; psCurr; psCurr = psCurr->psNext)
+				for (DROID *psCurr : apsDroidLists[i])
 				{
 					// Don't copy the next pointer - if droids somehow get destroyed in the graphics rendering loop, who cares if we crash.
 					calcDroidIllumination(psCurr);
@@ -399,7 +399,7 @@ void countUpdate(bool synch)
 		numMissionDroids[i] = 0;
 		numTransporterDroids[i] = 0;
 
-		for (DROID *psCurr = apsDroidLists[i]; psCurr != nullptr; psCurr = psCurr->psNext)
+		for (DROID *psCurr : apsDroidLists[i])
 		{
 			numDroids[i]++;
 			switch (psCurr->droidType)
@@ -419,7 +419,7 @@ void countUpdate(bool synch)
 				break;
 			}
 		}
-		for (DROID *psCurr = mission.apsDroidLists[i]; psCurr != nullptr; psCurr = psCurr->psNext)
+		for (DROID *psCurr : mission.apsDroidLists[i])
 		{
 			numMissionDroids[i]++;
 			switch (psCurr->droidType)
@@ -439,7 +439,7 @@ void countUpdate(bool synch)
 				break;
 			}
 		}
-		for (DROID *psCurr = apsLimboDroids[i]; psCurr != nullptr; psCurr = psCurr->psNext)
+		for (DROID *psCurr : apsLimboDroids[i])
 		{
 			// count the type of units
 			switch (psCurr->droidType)
@@ -542,20 +542,23 @@ static void gameStateUpdate()
 		//update the current power available for a player
 		updatePlayerPower(i);
 
-		DROID *psNext;
-		for (DROID *psCurr = apsDroidLists[i]; psCurr != nullptr; psCurr = psNext)
+		DroidList::iterator droidIt = apsDroidLists[i].begin(), droidItNext;
+		while (droidIt != apsDroidLists[i].end())
 		{
 			// Copy the next pointer - not 100% sure if the droid could get destroyed but this covers us anyway
-			psNext = psCurr->psNext;
-			droidUpdate(psCurr);
+			droidItNext = std::next(droidIt);
+			droidUpdate(*droidIt);
+			droidIt = droidItNext;
 		}
 
-		for (DROID *psCurr = mission.apsDroidLists[i]; psCurr != nullptr; psCurr = psNext)
+		droidIt = mission.apsDroidLists[i].begin();
+		while (droidIt != mission.apsDroidLists[i].end())
 		{
 			/* Copy the next pointer - not 100% sure if the droid could
 			get destroyed but this covers us anyway */
-			psNext = psCurr->psNext;
-			missionDroidUpdate(psCurr);
+			droidItNext = std::next(droidIt);
+			missionDroidUpdate(*droidIt);
+			droidIt = droidItNext;
 		}
 
 		// FIXME: These for-loops are code duplicationo

--- a/src/loop.cpp
+++ b/src/loop.cpp
@@ -457,7 +457,7 @@ void countUpdate(bool synch)
 		}
 		// FIXME: These for-loops are code duplicationo
 		setLasSatExists(false, i);
-		for (STRUCTURE *psCBuilding = apsStructLists[i]; psCBuilding != nullptr; psCBuilding = psCBuilding->psNext)
+		for (STRUCTURE *psCBuilding : apsStructLists[i])
 		{
 			if (psCBuilding->pStructureType->type == REF_SAT_UPLINK && psCBuilding->status == SS_BUILT)
 			{
@@ -469,7 +469,7 @@ void countUpdate(bool synch)
 				setLasSatExists(true, i);
 			}
 		}
-		for (STRUCTURE *psCBuilding = mission.apsStructLists[i]; psCBuilding != nullptr; psCBuilding = psCBuilding->psNext)
+		for (STRUCTURE *psCBuilding : mission.apsStructLists[i])
 		{
 			if (psCBuilding->pStructureType->type == REF_SAT_UPLINK && psCBuilding->status == SS_BUILT)
 			{
@@ -559,17 +559,12 @@ static void gameStateUpdate()
 		}
 
 		// FIXME: These for-loops are code duplicationo
-		STRUCTURE *psNBuilding;
-		for (STRUCTURE *psCBuilding = apsStructLists[i]; psCBuilding != nullptr; psCBuilding = psNBuilding)
+		for (STRUCTURE *psCBuilding : apsStructLists[i])
 		{
-			/* Copy the next pointer - not 100% sure if the structure could get destroyed but this covers us anyway */
-			psNBuilding = psCBuilding->psNext;
 			structureUpdate(psCBuilding, false);
 		}
-		for (STRUCTURE *psCBuilding = mission.apsStructLists[i]; psCBuilding != nullptr; psCBuilding = psNBuilding)
+		for (STRUCTURE *psCBuilding : mission.apsStructLists[i])
 		{
-			/* Copy the next pointer - not 100% sure if the structure could get destroyed but this covers us anyway. It shouldn't do since its not even on the map!*/
-			psNBuilding = psCBuilding->psNext;
 			structureUpdate(psCBuilding, true); // update for mission
 		}
 	}

--- a/src/loop.cpp
+++ b/src/loop.cpp
@@ -439,7 +439,7 @@ void countUpdate(bool synch)
 				break;
 			}
 		}
-		for (DROID *psCurr : apsLimboDroids[i])
+		for (const DROID *psCurr : apsLimboDroids[i])
 		{
 			// count the type of units
 			switch (psCurr->droidType)
@@ -457,7 +457,7 @@ void countUpdate(bool synch)
 		}
 		// FIXME: These for-loops are code duplicationo
 		setLasSatExists(false, i);
-		for (STRUCTURE *psCBuilding : apsStructLists[i])
+		for (const STRUCTURE *psCBuilding : apsStructLists[i])
 		{
 			if (psCBuilding->pStructureType->type == REF_SAT_UPLINK && psCBuilding->status == SS_BUILT)
 			{
@@ -469,7 +469,7 @@ void countUpdate(bool synch)
 				setLasSatExists(true, i);
 			}
 		}
-		for (STRUCTURE *psCBuilding : mission.apsStructLists[i])
+		for (const STRUCTURE *psCBuilding : mission.apsStructLists[i])
 		{
 			if (psCBuilding->pStructureType->type == REF_SAT_UPLINK && psCBuilding->status == SS_BUILT)
 			{

--- a/src/loop.cpp
+++ b/src/loop.cpp
@@ -562,13 +562,19 @@ static void gameStateUpdate()
 		}
 
 		// FIXME: These for-loops are code duplicationo
-		for (STRUCTURE *psCBuilding : apsStructLists[i])
+		StructureList::iterator structIt = apsStructLists[i].begin(), structItNext;
+		while (structIt != apsStructLists[i].end())
 		{
-			structureUpdate(psCBuilding, false);
+			structItNext = std::next(structIt);
+			structureUpdate(*structIt, false);
+			structIt = structItNext;
 		}
-		for (STRUCTURE *psCBuilding : mission.apsStructLists[i])
+		structIt = mission.apsStructLists[i].begin();
+		while (structIt != mission.apsStructLists[i].end())
 		{
-			structureUpdate(psCBuilding, true); // update for mission
+			structItNext = std::next(structIt);
+			structureUpdate(*structIt, true); // update for mission
+			structIt = structItNext;
 		}
 	}
 

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -2074,15 +2074,13 @@ static void threatUpdate(int player)
 	// Step 2: Set threat bits
 	for (i = 0; i < MAX_PLAYERS; i++)
 	{
-		DROID *psDroid;
-
 		if (aiCheckAlliances(player, i))
 		{
 			// No need to iterate friendly objects
 			continue;
 		}
 
-		for (psDroid = apsDroidLists[i]; psDroid; psDroid = psDroid->psNext)
+		for (DROID* psDroid : apsDroidLists[i])
 		{
 			UBYTE mode = 0;
 

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -2075,7 +2075,6 @@ static void threatUpdate(int player)
 	for (i = 0; i < MAX_PLAYERS; i++)
 	{
 		DROID *psDroid;
-		STRUCTURE *psStruct;
 
 		if (aiCheckAlliances(player, i))
 		{
@@ -2106,7 +2105,7 @@ static void threatUpdate(int player)
 			}
 		}
 
-		for (psStruct = apsStructLists[i]; psStruct; psStruct = psStruct->psNext)
+		for (STRUCTURE* psStruct : apsStructLists[i])
 		{
 			UBYTE mode = 0;
 

--- a/src/mapgrid.cpp
+++ b/src/mapgrid.cpp
@@ -57,7 +57,7 @@ void gridReset()
 	// Put all existing objects into the point tree.
 	for (unsigned player = 0; player < MAX_PLAYERS; player++)
 	{
-		BASE_OBJECT *start[2] = {(BASE_OBJECT *)apsDroidLists[player], (BASE_OBJECT *)apsStructLists[player]};
+		BASE_OBJECT *start[1] = {(BASE_OBJECT *)apsDroidLists[player]};
 		for (unsigned type = 0; type != sizeof(start) / sizeof(*start); ++type)
 		{
 			for (BASE_OBJECT *psObj = start[type]; psObj != nullptr; psObj = psObj->psNext)
@@ -69,6 +69,17 @@ void gridReset()
 					{
 						viewer = 0;
 					}
+				}
+			}
+		}
+		for (BASE_OBJECT* psObj : apsStructLists[player])
+		{
+			if (!psObj->died)
+			{
+				gridPointTree->insert(psObj, psObj->pos.x, psObj->pos.y);
+				for (unsigned char& viewer : psObj->seenThisTick)
+				{
+					viewer = 0;
 				}
 			}
 		}

--- a/src/mapgrid.cpp
+++ b/src/mapgrid.cpp
@@ -57,18 +57,14 @@ void gridReset()
 	// Put all existing objects into the point tree.
 	for (unsigned player = 0; player < MAX_PLAYERS; player++)
 	{
-		BASE_OBJECT *start[1] = {(BASE_OBJECT *)apsDroidLists[player]};
-		for (unsigned type = 0; type != sizeof(start) / sizeof(*start); ++type)
+		for (BASE_OBJECT* psObj : apsDroidLists[player])
 		{
-			for (BASE_OBJECT *psObj = start[type]; psObj != nullptr; psObj = psObj->psNext)
+			if (!psObj->died)
 			{
-				if (!psObj->died)
+				gridPointTree->insert(psObj, psObj->pos.x, psObj->pos.y);
+				for (unsigned char& viewer : psObj->seenThisTick)
 				{
-					gridPointTree->insert(psObj, psObj->pos.x, psObj->pos.y);
-					for (unsigned char &viewer : psObj->seenThisTick)
-					{
-						viewer = 0;
-					}
+					viewer = 0;
 				}
 			}
 		}

--- a/src/mapgrid.cpp
+++ b/src/mapgrid.cpp
@@ -57,7 +57,7 @@ void gridReset()
 	// Put all existing objects into the point tree.
 	for (unsigned player = 0; player < MAX_PLAYERS; player++)
 	{
-		BASE_OBJECT *start[3] = {(BASE_OBJECT *)apsDroidLists[player], (BASE_OBJECT *)apsStructLists[player], (BASE_OBJECT *)apsFeatureLists[player]};
+		BASE_OBJECT *start[2] = {(BASE_OBJECT *)apsDroidLists[player], (BASE_OBJECT *)apsStructLists[player]};
 		for (unsigned type = 0; type != sizeof(start) / sizeof(*start); ++type)
 		{
 			for (BASE_OBJECT *psObj = start[type]; psObj != nullptr; psObj = psObj->psNext)
@@ -69,6 +69,17 @@ void gridReset()
 					{
 						viewer = 0;
 					}
+				}
+			}
+		}
+		for (BASE_OBJECT* psObj : apsFeatureLists[player])
+		{
+			if (!psObj->died)
+			{
+				gridPointTree->insert(psObj, psObj->pos.x, psObj->pos.y);
+				for (unsigned char& viewer : psObj->seenThisTick)
+				{
+					viewer = 0;
 				}
 			}
 		}

--- a/src/mechanics.cpp
+++ b/src/mechanics.cpp
@@ -37,14 +37,11 @@
 /* Shutdown the mechanics system */
 bool mechanicsShutdown()
 {
-	BASE_OBJECT *psObj, *psNext;
-
-	for (psObj = psDestroyedObj; psObj != nullptr; psObj = psNext)
+	for (BASE_OBJECT* psObj : psDestroyedObj)
 	{
-		psNext = psObj->psNext;
 		delete psObj;
 	}
-	psDestroyedObj = nullptr;
+	psDestroyedObj.clear();
 
 	return true;
 }

--- a/src/mission.cpp
+++ b/src/mission.cpp
@@ -670,8 +670,11 @@ static void saveMissionData()
 
 	bRepairExists = false;
 	//set any structures currently being built to completed for the selected player
-	for (STRUCTURE* psStruct : apsStructLists[selectedPlayer])
+	StructureList::iterator structIt = apsStructLists[selectedPlayer].begin(), structItNext;
+	while (structIt != apsStructLists[selectedPlayer].end())
 	{
+		structItNext = std::next(structIt);
+		STRUCTURE* psStruct = *structIt;
 		if (psStruct->status == SS_BEING_BUILT)
 		{
 			//find a droid working on it
@@ -692,6 +695,7 @@ static void saveMissionData()
 		{
 			bRepairExists = true;
 		}
+		structIt = structItNext;
 	}
 
 	//repair all droids back at home base if have a repair facility
@@ -2934,9 +2938,12 @@ void missionDestroyObjects()
 			}
 			mission.apsDroidLists[Player].clear();
 
-			for (STRUCTURE* psStruct : apsStructLists[Player])
+			StructureList::iterator structIt = apsStructLists[Player].begin(), structItNext;
+			while (structIt != apsStructLists[Player].end())
 			{
-				removeStruct(psStruct, true);
+				structItNext = std::next(structIt);
+				removeStruct(*structIt, true);
+				structIt = structItNext;
 			}
 		}
 	}

--- a/src/mission.cpp
+++ b/src/mission.cpp
@@ -131,7 +131,7 @@ bool		offWorldKeepLists;
 /*lists of droids that are held separate over several missions. There should
 only be selectedPlayer's droids but have possibility for MAX_PLAYERS -
 also saves writing out list functions to cater for just one player*/
-PerPlayerDroidList apsLimboDroids;
+PerPlayerDroidLists apsLimboDroids;
 
 //Where the Transporter lands for player 0 (sLandingZone[0]), and the rest are
 //a list of areas that cannot be built on, used for landing the enemy transporters
@@ -1713,7 +1713,7 @@ goingHome = true when returning from an off World mission*/
 void unloadTransporter(DROID *psTransporter, UDWORD x, UDWORD y, bool goingHome)
 {
 	DROID		*psDroid, *psNext;
-	PerPlayerDroidList* ppCurrentList;
+	PerPlayerDroidLists* ppCurrentList;
 	UDWORD		droidX, droidY;
 	DROID_GROUP	*psGroup;
 

--- a/src/mission.cpp
+++ b/src/mission.cpp
@@ -239,11 +239,11 @@ void initMission()
 		mission.apsDroidLists[inc] = nullptr;
 		mission.apsFeatureLists[inc] = nullptr;
 		mission.apsFlagPosLists[inc].clear();
-		mission.apsExtractorLists[inc] = nullptr;
+		mission.apsExtractorLists[inc].clear();
 		apsLimboDroids[inc] = nullptr;
 	}
-	mission.apsSensorList[0] = nullptr;
-	mission.apsOilList[0] = nullptr;
+	mission.apsSensorList[0].clear();
+	mission.apsOilList[0].clear();
 	offWorldKeepLists = false;
 	mission.time = -1;
 	setMissionCountDown();
@@ -311,13 +311,13 @@ bool missionShutDown()
 			mission.apsFeatureLists[inc] = nullptr;
 			apsFlagPosLists[inc] = std::move(mission.apsFlagPosLists[inc]);
 			mission.apsFlagPosLists[inc].clear();
-			apsExtractorLists[inc] = mission.apsExtractorLists[inc];
-			mission.apsExtractorLists[inc] = nullptr;
+			apsExtractorLists[inc] = std::move(mission.apsExtractorLists[inc]);
+			mission.apsExtractorLists[inc].clear();
 		}
-		apsSensorList[0] = mission.apsSensorList[0];
-		apsOilList[0] = mission.apsOilList[0];
-		mission.apsSensorList[0] = nullptr;
-		mission.apsOilList[0] = nullptr;
+		apsSensorList[0] = std::move(mission.apsSensorList[0]);
+		apsOilList[0] = std::move(mission.apsOilList[0]);
+		mission.apsSensorList[0].clear();
+		mission.apsOilList[0].clear();
 
 		psMapTiles = std::move(mission.psMapTiles);
 		mapWidth = mission.mapWidth;
@@ -817,12 +817,13 @@ void restoreMissionData()
 		apsFlagPosLists[inc] = std::move(mission.apsFlagPosLists[inc]);
 		mission.apsFlagPosLists[inc].clear();
 
-		apsExtractorLists[inc] = mission.apsExtractorLists[inc];
-		mission.apsExtractorLists[inc] = nullptr;
+		apsExtractorLists[inc] = std::move(mission.apsExtractorLists[inc]);
+		mission.apsExtractorLists[inc].clear();
 	}
-	apsSensorList[0] = mission.apsSensorList[0];
-	apsOilList[0] = mission.apsOilList[0];
-	mission.apsSensorList[0] = nullptr;
+	apsSensorList[0] = std::move(mission.apsSensorList[0]);
+	apsOilList[0] = std::move(mission.apsOilList[0]);
+	mission.apsSensorList[0].clear();
+	apsOilList[0].clear();
 	//swap mission data over
 
 	psMapTiles = std::move(mission.psMapTiles);

--- a/src/mission.cpp
+++ b/src/mission.cpp
@@ -2970,7 +2970,6 @@ void missionDestroyObjects()
 		{
 			setDroidTarget(psDroid, nullptr);
 		}
-		psDroid = psDroid->psNext;
 	}
 
 	for (STRUCTURE* psStruct : apsStructLists[Player])

--- a/src/mission.cpp
+++ b/src/mission.cpp
@@ -238,7 +238,7 @@ void initMission()
 		mission.apsStructLists[inc] = nullptr;
 		mission.apsDroidLists[inc] = nullptr;
 		mission.apsFeatureLists[inc] = nullptr;
-		mission.apsFlagPosLists[inc] = nullptr;
+		mission.apsFlagPosLists[inc].clear();
 		mission.apsExtractorLists[inc] = nullptr;
 		apsLimboDroids[inc] = nullptr;
 	}
@@ -309,8 +309,8 @@ bool missionShutDown()
 			mission.apsStructLists[inc] = nullptr;
 			apsFeatureLists[inc] = mission.apsFeatureLists[inc];
 			mission.apsFeatureLists[inc] = nullptr;
-			apsFlagPosLists[inc] = mission.apsFlagPosLists[inc];
-			mission.apsFlagPosLists[inc] = nullptr;
+			apsFlagPosLists[inc] = std::move(mission.apsFlagPosLists[inc]);
+			mission.apsFlagPosLists[inc].clear();
 			apsExtractorLists[inc] = mission.apsExtractorLists[inc];
 			mission.apsExtractorLists[inc] = nullptr;
 		}
@@ -814,8 +814,8 @@ void restoreMissionData()
 		apsFeatureLists[inc] = mission.apsFeatureLists[inc];
 		mission.apsFeatureLists[inc] = nullptr;
 
-		apsFlagPosLists[inc] = mission.apsFlagPosLists[inc];
-		mission.apsFlagPosLists[inc] = nullptr;
+		apsFlagPosLists[inc] = std::move(mission.apsFlagPosLists[inc]);
+		mission.apsFlagPosLists[inc].clear();
 
 		apsExtractorLists[inc] = mission.apsExtractorLists[inc];
 		mission.apsExtractorLists[inc] = nullptr;

--- a/src/mission.cpp
+++ b/src/mission.cpp
@@ -678,7 +678,7 @@ static void saveMissionData()
 		if (psStruct->status == SS_BEING_BUILT)
 		{
 			//find a droid working on it
-			for (DROID* psDroid : apsDroidLists[selectedPlayer])
+			for (const DROID* psDroid : apsDroidLists[selectedPlayer])
 			{
 				if ((psStructBeingBuilt = (STRUCTURE *)orderStateObj(psDroid, DORDER_BUILD))
 				    && psStructBeingBuilt == psStruct)
@@ -1637,7 +1637,6 @@ static void missionResetDroids()
 				if (pickRes == NO_FREE_TILE)
 				{
 					ASSERT(false, "missionResetUnits: Unable to find a free location");
-					psStruct = nullptr;
 				}
 				else
 				{
@@ -1650,7 +1649,7 @@ static void missionResetDroids()
 			}
 			else // if couldn't find the factory - try to place near HQ instead
 			{
-				for (STRUCTURE* psStructure : apsStructLists[psDroid->player])
+				for (const STRUCTURE* psStructure : apsStructLists[psDroid->player])
 				{
 					if (psStructure->pStructureType->type == REF_HQ)
 					{
@@ -1661,7 +1660,6 @@ static void missionResetDroids()
 						if (pickRes == NO_FREE_TILE)
 						{
 							ASSERT(false, "missionResetUnits: Unable to find a free location");
-							psStructure = nullptr;
 						}
 						else
 						{
@@ -3048,7 +3046,7 @@ bool getPlayCountDown()
 bool missionDroidsRemaining(UDWORD player)
 {
 	ASSERT_OR_RETURN(false, player < MAX_PLAYERS, "invalid player: %" PRIu32 "", player);
-	for (DROID *psDroid : apsDroidLists[player])
+	for (const DROID *psDroid : apsDroidLists[player])
 	{
 		if (!isTransporter(psDroid))
 		{

--- a/src/mission.cpp
+++ b/src/mission.cpp
@@ -237,7 +237,7 @@ void initMission()
 	{
 		mission.apsStructLists[inc] = nullptr;
 		mission.apsDroidLists[inc] = nullptr;
-		mission.apsFeatureLists[inc] = nullptr;
+		mission.apsFeatureLists[inc].clear();
 		mission.apsFlagPosLists[inc].clear();
 		mission.apsExtractorLists[inc].clear();
 		apsLimboDroids[inc] = nullptr;
@@ -307,8 +307,8 @@ bool missionShutDown()
 			mission.apsDroidLists[inc] = nullptr;
 			apsStructLists[inc] = mission.apsStructLists[inc];
 			mission.apsStructLists[inc] = nullptr;
-			apsFeatureLists[inc] = mission.apsFeatureLists[inc];
-			mission.apsFeatureLists[inc] = nullptr;
+			apsFeatureLists[inc] = std::move(mission.apsFeatureLists[inc]);
+			mission.apsFeatureLists[inc].clear();
 			apsFlagPosLists[inc] = std::move(mission.apsFlagPosLists[inc]);
 			mission.apsFlagPosLists[inc].clear();
 			apsExtractorLists[inc] = std::move(mission.apsExtractorLists[inc]);
@@ -811,8 +811,8 @@ void restoreMissionData()
 		apsStructLists[inc] = mission.apsStructLists[inc];
 		mission.apsStructLists[inc] = nullptr;
 
-		apsFeatureLists[inc] = mission.apsFeatureLists[inc];
-		mission.apsFeatureLists[inc] = nullptr;
+		apsFeatureLists[inc] = std::move(mission.apsFeatureLists[inc]);
+		mission.apsFeatureLists[inc].clear();
 
 		apsFlagPosLists[inc] = std::move(mission.apsFlagPosLists[inc]);
 		mission.apsFlagPosLists[inc].clear();

--- a/src/mission.h
+++ b/src/mission.h
@@ -39,7 +39,7 @@
 
 extern MISSION		mission;
 extern bool			offWorldKeepLists;
-extern DROID       *apsLimboDroids[MAX_PLAYERS];
+extern PerPlayerDroidList apsLimboDroids;
 
 extern bool Cheated;
 

--- a/src/mission.h
+++ b/src/mission.h
@@ -39,7 +39,7 @@
 
 extern MISSION		mission;
 extern bool			offWorldKeepLists;
-extern PerPlayerDroidList apsLimboDroids;
+extern PerPlayerDroidLists apsLimboDroids;
 
 extern bool Cheated;
 

--- a/src/missiondef.h
+++ b/src/missiondef.h
@@ -63,11 +63,14 @@ struct MISSION
 	int32_t                         scrollMinY;
 	int32_t                         scrollMaxX;
 	int32_t                         scrollMaxY;
-	STRUCTURE			*apsStructLists[MAX_PLAYERS], *apsExtractorLists[MAX_PLAYERS];	//original object lists
+	//original object lists
+	STRUCTURE* apsStructLists[MAX_PLAYERS];
+	PerPlayerExtractorLists apsExtractorLists;
+
 	DROID						*apsDroidLists[MAX_PLAYERS];
 	FEATURE						*apsFeatureLists[MAX_PLAYERS];
-	BASE_OBJECT			*apsSensorList[1];
-	FEATURE				*apsOilList[1];
+	GlobalSensorList                apsSensorList;
+	GlobalOilList                   apsOilList;
 	PerPlayerFlagPositionLists      apsFlagPosLists;
 	int32_t                         asCurrentPower[MAX_PLAYERS];
 

--- a/src/missiondef.h
+++ b/src/missiondef.h
@@ -68,7 +68,7 @@ struct MISSION
 	PerPlayerExtractorLists apsExtractorLists;
 
 	DROID						*apsDroidLists[MAX_PLAYERS];
-	FEATURE						*apsFeatureLists[MAX_PLAYERS];
+	PerPlayerFeatureLists           apsFeatureLists;
 	GlobalSensorList                apsSensorList;
 	GlobalOilList                   apsOilList;
 	PerPlayerFlagPositionLists      apsFlagPosLists;

--- a/src/missiondef.h
+++ b/src/missiondef.h
@@ -67,7 +67,7 @@ struct MISSION
 	PerPlayerStructureList apsStructLists;
 	PerPlayerExtractorLists apsExtractorLists;
 
-	DROID						*apsDroidLists[MAX_PLAYERS];
+	PerPlayerDroidList              apsDroidLists;
 	PerPlayerFeatureLists           apsFeatureLists;
 	GlobalSensorList                apsSensorList;
 	GlobalOilList                   apsOilList;

--- a/src/missiondef.h
+++ b/src/missiondef.h
@@ -64,7 +64,7 @@ struct MISSION
 	int32_t                         scrollMaxX;
 	int32_t                         scrollMaxY;
 	//original object lists
-	STRUCTURE* apsStructLists[MAX_PLAYERS];
+	PerPlayerStructureList apsStructLists;
 	PerPlayerExtractorLists apsExtractorLists;
 
 	DROID						*apsDroidLists[MAX_PLAYERS];

--- a/src/missiondef.h
+++ b/src/missiondef.h
@@ -68,7 +68,7 @@ struct MISSION
 	FEATURE						*apsFeatureLists[MAX_PLAYERS];
 	BASE_OBJECT			*apsSensorList[1];
 	FEATURE				*apsOilList[1];
-	FLAG_POSITION				*apsFlagPosLists[MAX_PLAYERS];
+	PerPlayerFlagPositionLists      apsFlagPosLists;
 	int32_t                         asCurrentPower[MAX_PLAYERS];
 
 	UDWORD				startTime;			//time the mission started

--- a/src/missiondef.h
+++ b/src/missiondef.h
@@ -64,10 +64,10 @@ struct MISSION
 	int32_t                         scrollMaxX;
 	int32_t                         scrollMaxY;
 	//original object lists
-	PerPlayerStructureList apsStructLists;
+	PerPlayerStructureLists apsStructLists;
 	PerPlayerExtractorLists apsExtractorLists;
 
-	PerPlayerDroidList              apsDroidLists;
+	PerPlayerDroidLists              apsDroidLists;
 	PerPlayerFeatureLists           apsFeatureLists;
 	GlobalSensorList                apsSensorList;
 	GlobalOilList                   apsOilList;

--- a/src/multigifts.cpp
+++ b/src/multigifts.cpp
@@ -474,7 +474,6 @@ void requestAlliance(uint8_t from, uint8_t to, bool prop, bool allowAudio)
 void breakAlliance(uint8_t p1, uint8_t p2, bool prop, bool allowAudio)
 {
 	char	tm1[128];
-	STRUCTURE* psStructure;
 
 	if (prop && bMultiMessages)
 	{
@@ -502,7 +501,7 @@ void breakAlliance(uint8_t p1, uint8_t p2, bool prop, bool allowAudio)
 
 	// Make sure p1's structures are no longer considered "our buildings" to their former allies
 	// For unit pathing
-	for (psStructure = apsStructLists[p1]; psStructure; psStructure = psStructure->psNext)
+	for (STRUCTURE* psStructure : apsStructLists[p1])
 	{
 		StructureBounds b = getStructureBounds(psStructure);
 
@@ -516,7 +515,7 @@ void breakAlliance(uint8_t p1, uint8_t p2, bool prop, bool allowAudio)
 		}
 	}
 	// Do the same for p2's stuff
-	for (psStructure = apsStructLists[p2]; psStructure; psStructure = psStructure->psNext)
+	for (STRUCTURE* psStructure : apsStructLists[p2])
 	{
 		StructureBounds b = getStructureBounds(psStructure);
 
@@ -534,7 +533,6 @@ void breakAlliance(uint8_t p1, uint8_t p2, bool prop, bool allowAudio)
 void formAlliance(uint8_t p1, uint8_t p2, bool prop, bool allowAudio, bool allowNotification)
 {
 	DROID	*psDroid;
-	STRUCTURE	*psStructure;
 	char	tm1[128];
 
 	if (bMultiMessages && prop)
@@ -593,7 +591,7 @@ void formAlliance(uint8_t p1, uint8_t p2, bool prop, bool allowAudio, bool allow
 	}
 
 	// Properly mark all of p1's structures as allied buildings for unit pathing
-	for (psStructure = apsStructLists[p1]; psStructure; psStructure = psStructure->psNext)
+	for (STRUCTURE* psStructure : apsStructLists[p1])
 	{
 		StructureBounds b = getStructureBounds(psStructure);
 
@@ -615,7 +613,7 @@ void formAlliance(uint8_t p1, uint8_t p2, bool prop, bool allowAudio, bool allow
 		}
 	}
 	// Do the same for p2's stuff
-	for (psStructure = apsStructLists[p2]; psStructure; psStructure = psStructure->psNext)
+	for (STRUCTURE* psStructure : apsStructLists[p2])
 	{
 		StructureBounds b = getStructureBounds(psStructure);
 

--- a/src/multigifts.cpp
+++ b/src/multigifts.cpp
@@ -294,7 +294,7 @@ static void recvGiftDroids(uint8_t from, uint8_t to, uint32_t droidID)
 // \param to    :player that should be getting the droid
 static void sendGiftDroids(uint8_t from, uint8_t to)
 {
-	DroidList::iterator psD;
+	DroidList::const_iterator psD;
 	uint8_t      giftType = DROID_GIFT;
 	uint8_t      totalToSend;
 
@@ -501,7 +501,7 @@ void breakAlliance(uint8_t p1, uint8_t p2, bool prop, bool allowAudio)
 
 	// Make sure p1's structures are no longer considered "our buildings" to their former allies
 	// For unit pathing
-	for (STRUCTURE* psStructure : apsStructLists[p1])
+	for (const STRUCTURE* psStructure : apsStructLists[p1])
 	{
 		StructureBounds b = getStructureBounds(psStructure);
 
@@ -515,7 +515,7 @@ void breakAlliance(uint8_t p1, uint8_t p2, bool prop, bool allowAudio)
 		}
 	}
 	// Do the same for p2's stuff
-	for (STRUCTURE* psStructure : apsStructLists[p2])
+	for (const STRUCTURE* psStructure : apsStructLists[p2])
 	{
 		StructureBounds b = getStructureBounds(psStructure);
 
@@ -590,7 +590,7 @@ void formAlliance(uint8_t p1, uint8_t p2, bool prop, bool allowAudio, bool allow
 	}
 
 	// Properly mark all of p1's structures as allied buildings for unit pathing
-	for (STRUCTURE* psStructure : apsStructLists[p1])
+	for (const STRUCTURE* psStructure : apsStructLists[p1])
 	{
 		StructureBounds b = getStructureBounds(psStructure);
 
@@ -612,7 +612,7 @@ void formAlliance(uint8_t p1, uint8_t p2, bool prop, bool allowAudio, bool allow
 		}
 	}
 	// Do the same for p2's stuff
-	for (STRUCTURE* psStructure : apsStructLists[p2])
+	for (const STRUCTURE* psStructure : apsStructLists[p2])
 	{
 		StructureBounds b = getStructureBounds(psStructure);
 

--- a/src/multijoin.cpp
+++ b/src/multijoin.cpp
@@ -134,16 +134,19 @@ void destroyPlayerResources(UDWORD player, bool quietly)
 	}
 
 	debug(LOG_DEATH, "killing off all droids for player %d", player);
-	while (apsDroidLists[player])				// delete all droids
+	DroidList::iterator droidIt = apsDroidLists[player].begin(), droidItNext;
+	while (droidIt != apsDroidLists[player].end())				// delete all droids
 	{
+		droidItNext = std::next(droidIt);
 		if (quietly)			// don't show effects
 		{
-			killDroid(apsDroidLists[player]);
+			killDroid(*droidIt);
 		}
 		else				// show effects
 		{
-			destroyDroid(apsDroidLists[player], gameTime);
+			destroyDroid(*droidIt, gameTime);
 		}
+		droidIt = droidItNext;
 	}
 
 	debug(LOG_DEATH, "killing off all structures for player %d", player);
@@ -258,15 +261,16 @@ bool splitResourcesAmongTeam(UDWORD player)
 			return a.itemsRecv < b.itemsRecv;
 		});
 	};
-	while (apsDroidLists[player])
+	DroidList::iterator droidIt = apsDroidLists[player].begin(), droidItNext;
+	while (droidIt != apsDroidLists[player].end())
 	{
-		auto psDroid = apsDroidLists[player];
+		droidItNext = std::next(droidIt);
 		bool transferredDroid = false;
-		if (!isDead(psDroid))
+		if (!isDead(*droidIt))
 		{
 			for (size_t i = 0; i < droidsGiftedPerTarget.size(); ++i)
 			{
-				if (giftSingleDroid(psDroid, droidsGiftedPerTarget[i].player, false))
+				if (giftSingleDroid(*droidIt, droidsGiftedPerTarget[i].player, false))
 				{
 					transferredDroid = true;
 					incrRecvItem(i);
@@ -278,8 +282,9 @@ bool splitResourcesAmongTeam(UDWORD player)
 
 		if (!transferredDroid)
 		{
-			destroyDroid(apsDroidLists[player], gameTime);
+			destroyDroid(*droidIt, gameTime);
 		}
+		droidIt = droidItNext;
 	}
 
 	auto distributeMatchingStructs = [&](std::function<bool (STRUCTURE *)> cmp)
@@ -371,7 +376,6 @@ void handlePlayerLeftInGame(UDWORD player)
 static void resetMultiVisibility(UDWORD player)
 {
 	UDWORD		owned;
-	DROID		*pDroid;
 
 	if (player >= MAX_PLAYERS)
 	{
@@ -383,7 +387,7 @@ static void resetMultiVisibility(UDWORD player)
 		if (owned != player)								// done reset own stuff..
 		{
 			//droids
-			for (pDroid = apsDroidLists[owned]; pDroid; pDroid = pDroid->psNext)
+			for (DROID* pDroid : apsDroidLists[owned])
 			{
 				pDroid->visible[player] = false;
 			}

--- a/src/multijoin.cpp
+++ b/src/multijoin.cpp
@@ -114,7 +114,6 @@ void clearPlayer(UDWORD player, bool quietly)
 void destroyPlayerResources(UDWORD player, bool quietly)
 {
 	UDWORD			i;
-	STRUCTURE		*psStruct, *psNext;
 
 	if (player >= MAX_PLAYERS)
 	{
@@ -148,22 +147,22 @@ void destroyPlayerResources(UDWORD player, bool quietly)
 	}
 
 	debug(LOG_DEATH, "killing off all structures for player %d", player);
-	psStruct = apsStructLists[player];
-	while (psStruct)				// delete all structs
+	StructureList::iterator psStructIt = apsStructLists[player].begin(), psNextIt;
+	while (psStructIt != apsStructLists[player].end())				// delete all structs
 	{
-		psNext = psStruct->psNext;
+		psNextIt = std::next(psStructIt);
 
 		// FIXME: look why destroyStruct() doesn't put back the feature like removeStruct() does
-		if (quietly || psStruct->pStructureType->type == REF_RESOURCE_EXTRACTOR)		// don't show effects
+		if (quietly || (*psStructIt)->pStructureType->type == REF_RESOURCE_EXTRACTOR)		// don't show effects
 		{
-			removeStruct(psStruct, true);
+			removeStruct(*psStructIt, true);
 		}
 		else			// show effects
 		{
-			destroyStruct(psStruct, gameTime);
+			destroyStruct(*psStructIt, gameTime);
 		}
 
-		psStruct = psNext;
+		psStructIt = psNextIt;
 	}
 
 	return;
@@ -172,26 +171,26 @@ void destroyPlayerResources(UDWORD player, bool quietly)
 static bool destroyMatchingStructs(UDWORD player, std::function<bool (STRUCTURE *)> cmp, bool quietly)
 {
 	bool destroyedAnyStructs = false;
-	STRUCTURE *psStruct = apsStructLists[player];
-	while (psStruct)
+	StructureList::iterator psStructIt = apsStructLists[player].begin(), psNextIt;
+	while (psStructIt != apsStructLists[player].end())
 	{
-		STRUCTURE * psNext = psStruct->psNext;
+		psNextIt = std::next(psStructIt);
 
-		if (cmp(psStruct))
+		if (cmp(*psStructIt))
 		{
 			// FIXME: look why destroyStruct() doesn't put back the feature like removeStruct() does
-			if (quietly || psStruct->pStructureType->type == REF_RESOURCE_EXTRACTOR)		// don't show effects
+			if (quietly || (*psStructIt)->pStructureType->type == REF_RESOURCE_EXTRACTOR)		// don't show effects
 			{
-				removeStruct(psStruct, true);
+				removeStruct(*psStructIt, true);
 			}
 			else			// show effects
 			{
-				destroyStruct(psStruct, gameTime);
+				destroyStruct(*psStructIt, gameTime);
 			}
 			destroyedAnyStructs = true;
 		}
 
-		psStruct = psNext;
+		psStructIt = psNextIt;
 	}
 	return destroyedAnyStructs;
 }
@@ -297,18 +296,18 @@ bool splitResourcesAmongTeam(UDWORD player)
 			});
 		};
 
-		STRUCTURE *psStruct = apsStructLists[player];
-		while (psStruct)
+		StructureList::iterator psStructIt = apsStructLists[player].begin(), psNextIt;
+		while (psStructIt != apsStructLists[player].end())
 		{
-			STRUCTURE * psNext = psStruct->psNext;
+			psNextIt = std::next(psStructIt);
 
-			if (cmp(psStruct))
+			if (cmp(*psStructIt))
 			{
-				giftSingleStructure(psStruct, structsGiftedPerTarget.front().player, false);
+				giftSingleStructure(*psStructIt, structsGiftedPerTarget.front().player, false);
 				incrRecvStruct(0);
 			}
 
-			psStruct = psNext;
+			psStructIt = psNextIt;
 		}
 	};
 
@@ -373,7 +372,6 @@ static void resetMultiVisibility(UDWORD player)
 {
 	UDWORD		owned;
 	DROID		*pDroid;
-	STRUCTURE	*pStruct;
 
 	if (player >= MAX_PLAYERS)
 	{
@@ -391,7 +389,7 @@ static void resetMultiVisibility(UDWORD player)
 			}
 
 			//structures
-			for (pStruct = apsStructLists[owned]; pStruct; pStruct = pStruct->psNext)
+			for (STRUCTURE* pStruct : apsStructLists[owned])
 			{
 				pStruct->visible[player] = false;
 			}

--- a/src/multilimit.cpp
+++ b/src/multilimit.cpp
@@ -380,13 +380,17 @@ bool applyLimitSet()
 				{
 					while (asStructureStats[id].curCount[player] > asStructureStats[id].upgrade[player].limit)
 					{
-						for (STRUCTURE *psStruct : apsStructLists[player])
+						StructureList::iterator structIt = apsStructLists[player].begin(), structItNext;
+						while (structIt != apsStructLists[player].end())
 						{
+							structItNext = std::next(structIt);
+							STRUCTURE* psStruct = *structIt;
 							if (psStruct->pStructureType->type == asStructureStats[id].type)
 							{
 								removeStruct(psStruct, true);
 								break;
 							}
+							structIt = structItNext;
 						}
 
 					}

--- a/src/multilimit.cpp
+++ b/src/multilimit.cpp
@@ -380,7 +380,7 @@ bool applyLimitSet()
 				{
 					while (asStructureStats[id].curCount[player] > asStructureStats[id].upgrade[player].limit)
 					{
-						for (STRUCTURE *psStruct = apsStructLists[player]; psStruct; psStruct = psStruct->psNext)
+						for (STRUCTURE *psStruct : apsStructLists[player])
 						{
 							if (psStruct->pStructureType->type == asStructureStats[id].type)
 							{

--- a/src/multimenu.cpp
+++ b/src/multimenu.cpp
@@ -145,7 +145,7 @@ static bool		giftsUp[MAX_PLAYERS] = {true};		//gift buttons for player are up.
 static PIELIGHT GetPlayerTextColor(int mode, UDWORD player)
 {
 	// override color if they are dead...
-	if (player >= MAX_PLAYERS || (!apsDroidLists[player] && !apsStructLists[player]))
+	if (player >= MAX_PLAYERS || (!apsDroidLists[player] && apsStructLists[player].empty()))
 	{
 		return WZCOL_GREY;			// dead text color
 	}
@@ -1100,11 +1100,7 @@ private:
 				if (isAlly || gInputManager.debugManager().debugMappingsAllowed())
 				{
 					// NOTE, This tallys up *all* the structures you have. Test out via 'start with no base'.
-					int num = 0;
-					for (STRUCTURE *temp = apsStructLists[playerWidget.player]; temp != nullptr; temp = temp->psNext)
-					{
-						++num;
-					}
+					int num = apsStructLists[playerWidget.player].size();
 					ssprintf(lastString, "%d", num);
 				}
 			}

--- a/src/multiplay.cpp
+++ b/src/multiplay.cpp
@@ -490,14 +490,11 @@ STRUCTURE *IdToStruct(UDWORD id, UDWORD player)
 FEATURE *IdToFeature(UDWORD id, UDWORD player)
 {
 	(void)player;	// unused, all features go into player 0
-	for (FEATURE *d : apsFeatureLists[0])
+	auto feat = std::find_if(apsFeatureLists[0].begin(), apsFeatureLists[0].end(), [id](FEATURE* f)
 	{
-		if (d->id == id)
-		{
-			return d;
-		}
-	}
-	return nullptr;
+		return f->id == id;
+	});
+	return feat != apsFeatureLists[0].end() ? *feat : nullptr;
 }
 
 // ////////////////////////////////////////////////////////////////////////////

--- a/src/multiplay.cpp
+++ b/src/multiplay.cpp
@@ -392,23 +392,19 @@ DROID *IdToDroid(UDWORD id, UDWORD player)
 	{
 		for (int i = 0; i < MAX_PLAYERS; i++)
 		{
-			for (DROID *d : apsDroidLists[i])
+			DROID* d = (DROID*)getBaseObjFromId(apsDroidLists[i], id);
+			if (d)
 			{
-				if (d->id == id)
-				{
-					return d;
-				}
+				return d;
 			}
 		}
 	}
 	else if (player < MAX_PLAYERS)
 	{
-		for (DROID *d : apsDroidLists[player])
+		DROID* d = (DROID*)getBaseObjFromId(apsDroidLists[player], id);
+		if (d)
 		{
-			if (d->id == id)
-			{
-				return d;
-			}
+			return d;
 		}
 	}
 	return nullptr;
@@ -421,23 +417,19 @@ DROID *IdToMissionDroid(UDWORD id, UDWORD player)
 	{
 		for (int i = 0; i < MAX_PLAYERS; i++)
 		{
-			for (DROID *d : mission.apsDroidLists[i])
+			DROID* d = (DROID*)getBaseObjFromId(mission.apsDroidLists[i], id);
+			if (d)
 			{
-				if (d->id == id)
-				{
-					return d;
-				}
+				return d;
 			}
 		}
 	}
 	else if (player < MAX_PLAYERS)
 	{
-		for (DROID *d : mission.apsDroidLists[player])
+		DROID* d = (DROID*)getBaseObjFromId(mission.apsDroidLists[player], id);
+		if (d)
 		{
-			if (d->id == id)
-			{
-				return d;
-			}
+			return d;
 		}
 	}
 	return nullptr;
@@ -447,21 +439,15 @@ static STRUCTURE* _IdToStruct(UDWORD id, UDWORD beginPlayer, UDWORD endPlayer)
 {
 	for (int i = beginPlayer; i < endPlayer; ++i)
 	{
-		auto it = std::find_if(apsStructLists[i].begin(), apsStructLists[i].end(), [id](STRUCTURE* s)
+		STRUCTURE* s = (STRUCTURE*)getBaseObjFromId(apsStructLists[i], id);
+		if (s)
 		{
-			return s->id == id;
-		});
-		if (it != apsStructLists[i].end())
-		{
-			return *it;
+			return s;
 		}
-		it = std::find_if(mission.apsStructLists[i].begin(), mission.apsStructLists[i].end(), [id](STRUCTURE* s)
+		s = (STRUCTURE*)getBaseObjFromId(mission.apsStructLists[i], id);
+		if (s)
 		{
-			return s->id == id;
-		});
-		if (it != mission.apsStructLists[i].end())
-		{
-			return *it;
+			return s;
 		}
 	}
 	return nullptr;
@@ -490,11 +476,7 @@ STRUCTURE *IdToStruct(UDWORD id, UDWORD player)
 FEATURE *IdToFeature(UDWORD id, UDWORD player)
 {
 	(void)player;	// unused, all features go into player 0
-	auto feat = std::find_if(apsFeatureLists[0].begin(), apsFeatureLists[0].end(), [id](FEATURE* f)
-	{
-		return f->id == id;
-	});
-	return feat != apsFeatureLists[0].end() ? *feat : nullptr;
+	return (FEATURE*)getBaseObjFromId(apsFeatureLists[0], id);
 }
 
 // ////////////////////////////////////////////////////////////////////////////

--- a/src/multiplay.cpp
+++ b/src/multiplay.cpp
@@ -486,7 +486,7 @@ STRUCTURE *IdToStruct(UDWORD id, UDWORD player)
 FEATURE *IdToFeature(UDWORD id, UDWORD player)
 {
 	(void)player;	// unused, all features go into player 0
-	for (FEATURE *d = apsFeatureLists[0]; d; d = d->psNext)
+	for (FEATURE *d : apsFeatureLists[0])
 	{
 		if (d->id == id)
 		{

--- a/src/multiplay.cpp
+++ b/src/multiplay.cpp
@@ -392,7 +392,7 @@ DROID *IdToDroid(UDWORD id, UDWORD player)
 	{
 		for (int i = 0; i < MAX_PLAYERS; i++)
 		{
-			for (DROID *d = apsDroidLists[i]; d; d = d->psNext)
+			for (DROID *d : apsDroidLists[i])
 			{
 				if (d->id == id)
 				{
@@ -403,7 +403,7 @@ DROID *IdToDroid(UDWORD id, UDWORD player)
 	}
 	else if (player < MAX_PLAYERS)
 	{
-		for (DROID *d = apsDroidLists[player]; d; d = d->psNext)
+		for (DROID *d : apsDroidLists[player])
 		{
 			if (d->id == id)
 			{
@@ -421,7 +421,7 @@ DROID *IdToMissionDroid(UDWORD id, UDWORD player)
 	{
 		for (int i = 0; i < MAX_PLAYERS; i++)
 		{
-			for (DROID *d = mission.apsDroidLists[i]; d; d = d->psNext)
+			for (DROID *d : mission.apsDroidLists[i])
 			{
 				if (d->id == id)
 				{
@@ -432,7 +432,7 @@ DROID *IdToMissionDroid(UDWORD id, UDWORD player)
 	}
 	else if (player < MAX_PLAYERS)
 	{
-		for (DROID *d = mission.apsDroidLists[player]; d; d = d->psNext)
+		for (DROID *d : mission.apsDroidLists[player])
 		{
 			if (d->id == id)
 			{
@@ -683,10 +683,10 @@ Vector3i cameraToHome(UDWORD player, bool scroll, bool fromSave)
 		x = map_coord(psBuilding->pos.x);
 		y = map_coord(psBuilding->pos.y);
 	}
-	else if ((player < MAX_PLAYERS) && apsDroidLists[player])				// or first droid
+	else if ((player < MAX_PLAYERS) && !apsDroidLists[player].empty())				// or first droid
 	{
-		x = map_coord(apsDroidLists[player]->pos.x);
-		y =	map_coord(apsDroidLists[player]->pos.y);
+		x = map_coord(apsDroidLists[player].front()->pos.x);
+		y =	map_coord(apsDroidLists[player].front()->pos.y);
 	}
 	else if ((player < MAX_PLAYERS) && !apsStructLists[player].empty())				// center on first struct
 	{
@@ -2452,16 +2452,19 @@ bool makePlayerSpectator(uint32_t playerIndex, bool removeAllStructs, bool quiet
 
 		// Destroy all droids
 		debug(LOG_DEATH, "killing off all droids for player %d", playerIndex);
-		while (apsDroidLists[playerIndex])				// delete all droids
+		DroidList::iterator droidIt = apsDroidLists[playerIndex].begin(), droidItNext;
+		while (droidIt != apsDroidLists[playerIndex].end())				// delete all droids
 		{
+			droidItNext = std::next(droidIt);
 			if (quietly)			// don't show effects
 			{
-				killDroid(apsDroidLists[playerIndex]);
+				killDroid(*droidIt);
 			}
 			else				// show effects
 			{
-				destroyDroid(apsDroidLists[playerIndex], gameTime);
+				destroyDroid(*droidIt, gameTime);
 			}
+			droidIt = droidItNext;
 		}
 
 		// Destroy structs

--- a/src/objects.cpp
+++ b/src/objects.cpp
@@ -49,25 +49,6 @@ bool objShutdown()
 	return true;
 }
 
-
-/*goes thru' the list passed in reversing the order so the first entry becomes
-the last and the last entry becomes the first!*/
-void reverseObjectList(BASE_OBJECT **ppsList)
-{
-	BASE_OBJECT *psPrev = nullptr;
-	BASE_OBJECT *psCurrent = *ppsList;
-
-	while (psCurrent != nullptr)
-	{
-		BASE_OBJECT *psNext = psCurrent->psNext;
-		psCurrent->psNext = psPrev;
-		psPrev = psCurrent;
-		psCurrent = psNext;
-	}
-	//set the list passed in to point to the new top
-	*ppsList = psPrev;
-}
-
 const char *objInfo(const BASE_OBJECT *psObj)
 {
 	static char	info[PATH_MAX];

--- a/src/objects.h
+++ b/src/objects.h
@@ -36,17 +36,6 @@ bool objInitialise();
 /* Shutdown the object system */
 bool objShutdown();
 
-/// Goes through the list passed in reversing the order so the first entry becomes the last and the last entry becomes the first!
-void reverseObjectList(BASE_OBJECT **ppsList);
-
-template <typename OBJECT>
-void reverseObjectList(OBJECT **ppsList)
-{
-	BASE_OBJECT *baseList = *ppsList;
-	reverseObjectList(&baseList);
-	*ppsList = static_cast<OBJECT *>(baseList);
-}
-
 /** Output an informative string about this object. For debugging. */
 const char *objInfo(const BASE_OBJECT *psObj);
 

--- a/src/objmem.cpp
+++ b/src/objmem.cpp
@@ -98,7 +98,7 @@ static bool checkReferences(BASE_OBJECT *psVictim)
 {
 	for (int plr = 0; plr < MAX_PLAYERS; ++plr)
 	{
-		for (STRUCTURE *psStruct : apsStructLists[plr])
+		for (const STRUCTURE *psStruct : apsStructLists[plr])
 		{
 			if (psStruct == psVictim)
 			{
@@ -110,7 +110,7 @@ static bool checkReferences(BASE_OBJECT *psVictim)
 				ASSERT_OR_RETURN(false, psStruct->psTarget[i] != psVictim, BADREF(psStruct->targetFunc[i], psStruct->targetLine[i]));
 			}
 		}
-		for (DROID *psDroid : apsDroidLists[plr])
+		for (const DROID *psDroid : apsDroidLists[plr])
 		{
 			if (psDroid == psVictim)
 			{
@@ -699,16 +699,6 @@ void checkFactoryFlags()
 
 /**************************  OBJECT ACCESS FUNCTIONALITY ********************************/
 
-template <typename ObjectType>
-BASE_OBJECT* getBaseObjFromId(const std::list<ObjectType*>& list, unsigned id)
-{
-	auto objIt = std::find_if(list.begin(), list.end(), [id](ObjectType* obj)
-	{
-		return obj->id == id;
-	});
-	return objIt != list.end() ? *objIt : nullptr;
-}
-
 static BASE_OBJECT* getBaseObjFromDroidId(const DroidList& list, unsigned id)
 {
 	for (DROID* psObj : list)
@@ -886,7 +876,7 @@ static void objListIntegCheck()
 
 	for (player = 0; player < MAX_PLAYERS; player += 1)
 	{
-		for (DROID* psCurr : apsDroidLists[player])
+		for (const DROID* psCurr : apsDroidLists[player])
 		{
 			ASSERT(psCurr->type == OBJ_DROID &&
 			       (SDWORD)psCurr->player == player,
@@ -896,7 +886,7 @@ static void objListIntegCheck()
 	}
 	for (player = 0; player < MAX_PLAYERS; player += 1)
 	{
-		for (STRUCTURE* psStruct : apsStructLists[player])
+		for (const STRUCTURE* psStruct : apsStructLists[player])
 		{
 			ASSERT(psStruct->type == OBJ_STRUCTURE &&
 			       (SDWORD)psStruct->player == player,
@@ -904,7 +894,7 @@ static void objListIntegCheck()
 			       objInfo(psStruct), (void*)psStruct, player, (int)psStruct->player);
 		}
 	}
-	for (BASE_OBJECT* obj : apsFeatureLists[0])
+	for (const BASE_OBJECT* obj : apsFeatureLists[0])
 	{
 		ASSERT(obj->type == OBJ_FEATURE,
 		       "objListIntegCheck: misplaced object in the feature list");
@@ -924,12 +914,12 @@ void objCount(int *droids, int *structures, int *features)
 
 	for (int i = 0; i < MAX_PLAYERS; i++)
 	{
-		for (DROID *psDroid : apsDroidLists[i])
+		for (const DROID *psDroid : apsDroidLists[i])
 		{
 			(*droids)++;
 			if (isTransporter(psDroid) && psDroid->psGroup && psDroid->psGroup->psList)
 			{
-				DROID *psTrans = psDroid->psGroup->psList;
+				const DROID *psTrans = psDroid->psGroup->psList;
 
 				for (psTrans = psTrans->psGrpNext; psTrans != nullptr; psTrans = psTrans->psGrpNext)
 				{

--- a/src/objmem.cpp
+++ b/src/objmem.cpp
@@ -54,8 +54,8 @@ uint32_t                unsynchObjID;
 uint32_t                synchObjID;
 
 /* The lists of objects allocated */
-PerPlayerDroidList apsDroidLists;
-PerPlayerStructureList apsStructLists;
+PerPlayerDroidLists apsDroidLists;
+PerPlayerStructureLists apsStructLists;
 PerPlayerFeatureLists apsFeatureLists;		///< Only player zero is valid for features. TODO: Reduce to single list.
 PerPlayerExtractorLists apsExtractorLists;
 GlobalOilList apsOilList;
@@ -209,7 +209,7 @@ uint32_t generateSynchronisedObjectId()
  * \param list is a pointer to the object list
  */
 template <typename OBJECT>
-static inline void addObjectToList(PerPlayerObjectList<OBJECT, MAX_PLAYERS>& list, OBJECT* object, int player)
+static inline void addObjectToList(PerPlayerObjectLists<OBJECT, MAX_PLAYERS>& list, OBJECT* object, int player)
 {
 	ASSERT_OR_RETURN(, object != nullptr, "Invalid pointer");
 
@@ -236,7 +236,7 @@ static inline void addObjectToFuncList(FunctionList& list, OBJECT *object, int p
  * \param del is a pointer to the object to remove
  */
 template <typename OBJECT>
-static inline void destroyObject(PerPlayerObjectList<OBJECT, MAX_PLAYERS>& list, OBJECT* object)
+static inline void destroyObject(PerPlayerObjectLists<OBJECT, MAX_PLAYERS>& list, OBJECT* object)
 {
 	ASSERT_OR_RETURN(, object != nullptr, "Invalid pointer");
 	ASSERT(gameTime - deltaGameTime <= gameTime || gameTime == 2, "Expected %u <= %u, bad time", gameTime - deltaGameTime, gameTime);
@@ -273,7 +273,7 @@ static inline void destroyObject(PerPlayerObjectList<OBJECT, MAX_PLAYERS>& list,
  * \param type is the type of the object
  */
 template <typename OBJECT>
-static inline void removeObjectFromList(PerPlayerObjectList<OBJECT, MAX_PLAYERS>& list, OBJECT* object, int player)
+static inline void removeObjectFromList(PerPlayerObjectLists<OBJECT, MAX_PLAYERS>& list, OBJECT* object, int player)
 {
 	ASSERT_OR_RETURN(, object != nullptr, "Invalid pointer");
 
@@ -314,7 +314,7 @@ static inline void removeObjectFromFuncList(FunctionList& list, OBJECT *object, 
 }
 
 template <typename OBJECT>
-static inline void releaseAllObjectsInList(PerPlayerObjectList<OBJECT, MAX_PLAYERS>& list)
+static inline void releaseAllObjectsInList(PerPlayerObjectLists<OBJECT, MAX_PLAYERS>& list)
 {
 	// Iterate through all players' object lists
 	for (unsigned i = 0; i < MAX_PLAYERS; ++i)
@@ -340,7 +340,7 @@ static inline void releaseAllObjectsInList(PerPlayerObjectList<OBJECT, MAX_PLAYE
 /***************************  DROID  *********************************/
 
 /* add the droid to the Droid Lists */
-void addDroid(DROID *psDroidToAdd, PerPlayerDroidList& pList)
+void addDroid(DROID *psDroidToAdd, PerPlayerDroidLists& pList)
 {
 	DROID_GROUP	*psGroup;
 
@@ -404,7 +404,7 @@ void freeAllDroids()
 }
 
 /*Remove a single Droid from a list*/
-void removeDroid(DROID* psDroidToRemove, PerPlayerDroidList& pList)
+void removeDroid(DROID* psDroidToRemove, PerPlayerDroidLists& pList)
 {
 	ASSERT_OR_RETURN(, psDroidToRemove->type == OBJ_DROID, "Pointer is not a unit");
 	ASSERT_OR_RETURN(, psDroidToRemove->player < MAX_PLAYERS, "Invalid player for unit");
@@ -526,7 +526,7 @@ void freeAllStructs()
 }
 
 /*Remove a single Structure from a list*/
-void removeStructureFromList(STRUCTURE *psStructToRemove, PerPlayerStructureList& pList)
+void removeStructureFromList(STRUCTURE *psStructToRemove, PerPlayerStructureLists& pList)
 {
 	ASSERT(psStructToRemove->type == OBJ_STRUCTURE,
 	       "removeStructureFromList: pointer is not a structure");

--- a/src/objmem.cpp
+++ b/src/objmem.cpp
@@ -768,20 +768,17 @@ BASE_OBJECT *getBaseObjFromData(unsigned id, unsigned player, OBJECT_TYPE type)
 		}
 	case OBJ_FEATURE:
 		{
-			if (player == 0)
+			auto pFeat = getBaseObjFromId(apsFeatureLists[0], id);
+			if (pFeat)
 			{
-				auto pFeat = getBaseObjFromId(apsFeatureLists[0], id);
-				if (pFeat)
-				{
-					return pFeat;
-				}
-				pFeat = getBaseObjFromId(mission.apsFeatureLists[0], id);
-				if (pFeat)
-				{
-					return pFeat;
-				}
-				break;
+				return pFeat;
 			}
+			pFeat = getBaseObjFromId(mission.apsFeatureLists[0], id);
+			if (pFeat)
+			{
+				return pFeat;
+			}
+			break;
 		}
 	default:
 		break;
@@ -792,7 +789,8 @@ BASE_OBJECT *getBaseObjFromData(unsigned id, unsigned player, OBJECT_TYPE type)
 // Find a base object from it's id
 BASE_OBJECT *getBaseObjFromId(UDWORD id)
 {
-	for (size_t type = OBJ_DROID; type != OBJ_NUM_TYPES; ++type)
+	// Only cover OBJ_DROID, OBJ_STRUCTURE and OBJ_FEATURE types
+	for (size_t type = OBJ_DROID; type != OBJ_PROJECTILE; ++type)
 	{
 		for (size_t player = 0; player != MAX_PLAYERS; ++player)
 		{

--- a/src/objmem.cpp
+++ b/src/objmem.cpp
@@ -311,7 +311,6 @@ static inline void destroyObject(std::array<std::list<OBJECT*>, MAX_PLAYERS>& li
 	if (!list[object->player].empty() && list[object->player].front() == object)
 	{
 		list[object->player].pop_front();
-		object->psNext = nullptr;
 		psDestroyedObj.emplace_front((BASE_OBJECT*)object);
 		object->died = gameTime;
 		scriptRemoveObject(object);
@@ -326,7 +325,6 @@ static inline void destroyObject(std::array<std::list<OBJECT*>, MAX_PLAYERS>& li
 		list[object->player].erase(it);
 
 		// Prepend the object to the destruction list
-		object->psNext = nullptr;
 		psDestroyedObj.emplace_front((BASE_OBJECT*)object);
 
 		// Set destruction time
@@ -1188,8 +1186,6 @@ UDWORD getRepairIdFromFlag(FLAG_POSITION *psFlag)
 {
 	unsigned int i;
 	UDWORD			player;
-	STRUCTURE		*psObj;
-	REPAIR_FACILITY	*psRepair;
 
 
 	player = psFlag->player;
@@ -1206,10 +1202,6 @@ UDWORD getRepairIdFromFlag(FLAG_POSITION *psFlag)
 			{
 				return id;
 			}
-			else
-			{
-				psObj = nullptr;
-			}
 			break;
 		}
 		case 1:
@@ -1219,32 +1211,10 @@ UDWORD getRepairIdFromFlag(FLAG_POSITION *psFlag)
 			{
 				return id;
 			}
-			else
-			{
-				psObj = nullptr;
-			}
 			break;
 		}
 		default:
-			psObj = nullptr;
 			break;
-		}
-
-		while (psObj)
-		{
-			if (psObj->pFunctionality)
-			{
-				if	(psObj->pStructureType->type == REF_REPAIR_FACILITY)
-				{
-					//check for matching delivery point
-					psRepair = ((REPAIR_FACILITY *)psObj->pFunctionality);
-					if (psRepair->psDeliveryPoint == psFlag)
-					{
-						return psObj->id;
-					}
-				}
-			}
-			psObj = psObj->psNext;
 		}
 	}
 	ASSERT(!"unable to find repair id for FLAG_POSITION", "getRepairIdFromFlag() failed");

--- a/src/objmem.h
+++ b/src/objmem.h
@@ -51,7 +51,8 @@ using GlobalOilList = std::array<OilList, 1>;
 extern GlobalOilList apsOilList;
 
 /* The list of destroyed objects */
-extern BASE_OBJECT	*psDestroyedObj;
+using DestroyedObjectsList = std::list<BASE_OBJECT*>;
+extern DestroyedObjectsList psDestroyedObj;
 
 /* Initialise the object heaps */
 bool objmemInitialise();

--- a/src/objmem.h
+++ b/src/objmem.h
@@ -30,7 +30,9 @@
 #include <list>
 
 /* The lists of objects allocated */
-extern DROID			*apsDroidLists[MAX_PLAYERS];
+using DroidList = std::list<DROID*>;
+using PerPlayerDroidList = std::array<DroidList, MAX_PLAYERS>;
+extern PerPlayerDroidList apsDroidLists;
 
 using StructureList = std::list<STRUCTURE*>;
 using PerPlayerStructureList = std::array<StructureList, MAX_PLAYERS>;
@@ -75,7 +77,7 @@ uint32_t generateNewObjectId();
 uint32_t generateSynchronisedObjectId();
 
 /* add the droid to the Droid Lists */
-void addDroid(DROID *psDroidToAdd, DROID *pList[MAX_PLAYERS]);
+void addDroid(DROID *psDroidToAdd, PerPlayerDroidList& pList);
 
 /*destroy a droid */
 void killDroid(DROID *psDel);
@@ -84,7 +86,7 @@ void killDroid(DROID *psDel);
 void freeAllDroids();
 
 /*Remove a single Droid from its list*/
-void removeDroid(DROID *psDroidToRemove, DROID *pList[MAX_PLAYERS]);
+void removeDroid(DROID *psDroidToRemove, PerPlayerDroidList& pList);
 
 /*Removes all droids that may be stored in the mission lists*/
 void freeAllMissionDroids();

--- a/src/objmem.h
+++ b/src/objmem.h
@@ -31,7 +31,10 @@
 
 /* The lists of objects allocated */
 extern DROID			*apsDroidLists[MAX_PLAYERS];
-extern STRUCTURE		*apsStructLists[MAX_PLAYERS];
+
+using StructureList = std::list<STRUCTURE*>;
+using PerPlayerStructureList = std::array<StructureList, MAX_PLAYERS>;
+extern PerPlayerStructureList apsStructLists;
 
 using FeatureList = std::list<FEATURE*>;
 using PerPlayerFeatureLists = std::array<FeatureList, MAX_PLAYERS>;
@@ -99,7 +102,7 @@ void killStruct(STRUCTURE *psDel);
 void freeAllStructs();
 
 /*Remove a single Structure from a list*/
-void removeStructureFromList(STRUCTURE *psStructToRemove, STRUCTURE *pList[MAX_PLAYERS]);
+void removeStructureFromList(STRUCTURE *psStructToRemove, PerPlayerStructureList& pList);
 
 /* add the feature to the Feature Lists */
 void addFeature(FEATURE *psFeatureToAdd);

--- a/src/objmem.h
+++ b/src/objmem.h
@@ -31,33 +31,33 @@
 
 /* The lists of objects allocated */
 template <typename ObjectType, unsigned PlayerCount>
-using PerPlayerObjectList = std::array<std::list<ObjectType*>, PlayerCount>;
+using PerPlayerObjectLists = std::array<std::list<ObjectType*>, PlayerCount>;
 
-using PerPlayerDroidList = PerPlayerObjectList<DROID, MAX_PLAYERS>;
-using DroidList = typename PerPlayerDroidList::value_type;
-extern PerPlayerDroidList apsDroidLists;
+using PerPlayerDroidLists = PerPlayerObjectLists<DROID, MAX_PLAYERS>;
+using DroidList = typename PerPlayerDroidLists::value_type;
+extern PerPlayerDroidLists apsDroidLists;
 
-using PerPlayerStructureList = PerPlayerObjectList<STRUCTURE, MAX_PLAYERS>;
-using StructureList = typename PerPlayerStructureList::value_type;
-extern PerPlayerStructureList apsStructLists;
+using PerPlayerStructureLists = PerPlayerObjectLists<STRUCTURE, MAX_PLAYERS>;
+using StructureList = typename PerPlayerStructureLists::value_type;
+extern PerPlayerStructureLists apsStructLists;
 
-using PerPlayerFeatureLists = PerPlayerObjectList<FEATURE, MAX_PLAYERS>;
+using PerPlayerFeatureLists = PerPlayerObjectLists<FEATURE, MAX_PLAYERS>;
 using FeatureList = typename PerPlayerFeatureLists::value_type;
 extern PerPlayerFeatureLists apsFeatureLists;
 
-using PerPlayerFlagPositionLists = PerPlayerObjectList<FLAG_POSITION, MAX_PLAYERS>;
+using PerPlayerFlagPositionLists = PerPlayerObjectLists<FLAG_POSITION, MAX_PLAYERS>;
 using FlagPositionList = typename PerPlayerFlagPositionLists::value_type;
 extern PerPlayerFlagPositionLists apsFlagPosLists;
 
-using PerPlayerExtractorLists = PerPlayerStructureList;
+using PerPlayerExtractorLists = PerPlayerStructureLists;
 using ExtractorList = typename PerPlayerExtractorLists::value_type;
 extern PerPlayerExtractorLists apsExtractorLists;
 
-using GlobalSensorList = PerPlayerObjectList<BASE_OBJECT, 1>;
+using GlobalSensorList = PerPlayerObjectLists<BASE_OBJECT, 1>;
 using SensorList = typename GlobalSensorList::value_type;
 extern GlobalSensorList apsSensorList;
 
-using GlobalOilList = PerPlayerObjectList<FEATURE, 1>;
+using GlobalOilList = PerPlayerObjectLists<FEATURE, 1>;
 using OilList = typename GlobalOilList::value_type;
 extern GlobalOilList apsOilList;
 
@@ -80,7 +80,7 @@ uint32_t generateNewObjectId();
 uint32_t generateSynchronisedObjectId();
 
 /* add the droid to the Droid Lists */
-void addDroid(DROID *psDroidToAdd, PerPlayerDroidList& pList);
+void addDroid(DROID *psDroidToAdd, PerPlayerDroidLists& pList);
 
 /*destroy a droid */
 void killDroid(DROID *psDel);
@@ -89,7 +89,7 @@ void killDroid(DROID *psDel);
 void freeAllDroids();
 
 /*Remove a single Droid from its list*/
-void removeDroid(DROID *psDroidToRemove, PerPlayerDroidList& pList);
+void removeDroid(DROID *psDroidToRemove, PerPlayerDroidLists& pList);
 
 /*Removes all droids that may be stored in the mission lists*/
 void freeAllMissionDroids();
@@ -107,7 +107,7 @@ void killStruct(STRUCTURE *psDel);
 void freeAllStructs();
 
 /*Remove a single Structure from a list*/
-void removeStructureFromList(STRUCTURE *psStructToRemove, PerPlayerStructureList& pList);
+void removeStructureFromList(STRUCTURE *psStructToRemove, PerPlayerStructureLists& pList);
 
 /* add the feature to the Feature Lists */
 void addFeature(FEATURE *psFeatureToAdd);

--- a/src/objmem.h
+++ b/src/objmem.h
@@ -32,7 +32,10 @@
 /* The lists of objects allocated */
 extern DROID			*apsDroidLists[MAX_PLAYERS];
 extern STRUCTURE		*apsStructLists[MAX_PLAYERS];
-extern FEATURE			*apsFeatureLists[MAX_PLAYERS];
+
+using FeatureList = std::list<FEATURE*>;
+using PerPlayerFeatureLists = std::array<FeatureList, MAX_PLAYERS>;
+extern PerPlayerFeatureLists apsFeatureLists;
 
 using FlagPositionList = std::list<FLAG_POSITION*>;
 using PerPlayerFlagPositionLists = std::array<FlagPositionList, MAX_PLAYERS>;

--- a/src/objmem.h
+++ b/src/objmem.h
@@ -36,11 +36,19 @@ extern FEATURE			*apsFeatureLists[MAX_PLAYERS];
 
 using FlagPositionList = std::list<FLAG_POSITION*>;
 using PerPlayerFlagPositionLists = std::array<FlagPositionList, MAX_PLAYERS>;
-
 extern PerPlayerFlagPositionLists apsFlagPosLists;
-extern STRUCTURE		*apsExtractorLists[MAX_PLAYERS];
-extern BASE_OBJECT		*apsSensorList[1];
-extern FEATURE			*apsOilList[1];
+
+using ExtractorList = std::list<STRUCTURE*>;
+using PerPlayerExtractorLists = std::array<ExtractorList, MAX_PLAYERS>;
+extern PerPlayerExtractorLists apsExtractorLists;
+
+using SensorList = std::list<BASE_OBJECT*>;
+using GlobalSensorList = std::array<SensorList, 1>;
+extern GlobalSensorList apsSensorList;
+
+using OilList = std::list<FEATURE*>;
+using GlobalOilList = std::array<OilList, 1>;
+extern GlobalOilList apsOilList;
 
 /* The list of destroyed objects */
 extern BASE_OBJECT	*psDestroyedObj;

--- a/src/objmem.h
+++ b/src/objmem.h
@@ -132,6 +132,16 @@ void freeAllFlagPositions();
 void addFlagPositionToList(FLAG_POSITION* psFlagPosToAdd, PerPlayerFlagPositionLists& list);
 
 // Find a base object from it's id
+template <typename ObjectType>
+BASE_OBJECT* getBaseObjFromId(const std::list<ObjectType*>& list, unsigned id)
+{
+	auto objIt = std::find_if(list.begin(), list.end(), [id](ObjectType* obj)
+	{
+		return obj->id == id;
+	});
+	return objIt != list.end() ? *objIt : nullptr;
+}
+
 BASE_OBJECT *getBaseObjFromData(unsigned id, unsigned player, OBJECT_TYPE type);
 BASE_OBJECT *getBaseObjFromId(UDWORD id);
 

--- a/src/objmem.h
+++ b/src/objmem.h
@@ -30,32 +30,35 @@
 #include <list>
 
 /* The lists of objects allocated */
-using DroidList = std::list<DROID*>;
-using PerPlayerDroidList = std::array<DroidList, MAX_PLAYERS>;
+template <typename ObjectType, unsigned PlayerCount>
+using PerPlayerObjectList = std::array<std::list<ObjectType*>, PlayerCount>;
+
+using PerPlayerDroidList = PerPlayerObjectList<DROID, MAX_PLAYERS>;
+using DroidList = typename PerPlayerDroidList::value_type;
 extern PerPlayerDroidList apsDroidLists;
 
-using StructureList = std::list<STRUCTURE*>;
-using PerPlayerStructureList = std::array<StructureList, MAX_PLAYERS>;
+using PerPlayerStructureList = PerPlayerObjectList<STRUCTURE, MAX_PLAYERS>;
+using StructureList = typename PerPlayerStructureList::value_type;
 extern PerPlayerStructureList apsStructLists;
 
-using FeatureList = std::list<FEATURE*>;
-using PerPlayerFeatureLists = std::array<FeatureList, MAX_PLAYERS>;
+using PerPlayerFeatureLists = PerPlayerObjectList<FEATURE, MAX_PLAYERS>;
+using FeatureList = typename PerPlayerFeatureLists::value_type;
 extern PerPlayerFeatureLists apsFeatureLists;
 
-using FlagPositionList = std::list<FLAG_POSITION*>;
-using PerPlayerFlagPositionLists = std::array<FlagPositionList, MAX_PLAYERS>;
+using PerPlayerFlagPositionLists = PerPlayerObjectList<FLAG_POSITION, MAX_PLAYERS>;
+using FlagPositionList = typename PerPlayerFlagPositionLists::value_type;
 extern PerPlayerFlagPositionLists apsFlagPosLists;
 
-using ExtractorList = std::list<STRUCTURE*>;
-using PerPlayerExtractorLists = std::array<ExtractorList, MAX_PLAYERS>;
+using PerPlayerExtractorLists = PerPlayerStructureList;
+using ExtractorList = typename PerPlayerExtractorLists::value_type;
 extern PerPlayerExtractorLists apsExtractorLists;
 
-using SensorList = std::list<BASE_OBJECT*>;
-using GlobalSensorList = std::array<SensorList, 1>;
+using GlobalSensorList = PerPlayerObjectList<BASE_OBJECT, 1>;
+using SensorList = typename GlobalSensorList::value_type;
 extern GlobalSensorList apsSensorList;
 
-using OilList = std::list<FEATURE*>;
-using GlobalOilList = std::array<OilList, 1>;
+using GlobalOilList = PerPlayerObjectList<FEATURE, 1>;
+using OilList = typename GlobalOilList::value_type;
 extern GlobalOilList apsOilList;
 
 /* The list of destroyed objects */

--- a/src/objmem.h
+++ b/src/objmem.h
@@ -26,11 +26,18 @@
 
 #include "objectdef.h"
 
+#include <array>
+#include <list>
+
 /* The lists of objects allocated */
 extern DROID			*apsDroidLists[MAX_PLAYERS];
 extern STRUCTURE		*apsStructLists[MAX_PLAYERS];
 extern FEATURE			*apsFeatureLists[MAX_PLAYERS];
-extern FLAG_POSITION	*apsFlagPosLists[MAX_PLAYERS];
+
+using FlagPositionList = std::list<FLAG_POSITION*>;
+using PerPlayerFlagPositionLists = std::array<FlagPositionList, MAX_PLAYERS>;
+
+extern PerPlayerFlagPositionLists apsFlagPosLists;
 extern STRUCTURE		*apsExtractorLists[MAX_PLAYERS];
 extern BASE_OBJECT		*apsSensorList[1];
 extern FEATURE			*apsOilList[1];
@@ -102,7 +109,7 @@ void transferFlagPositionToPlayer(FLAG_POSITION *psFlagPos, UDWORD originalPlaye
 // free all flag positions
 void freeAllFlagPositions();
 // used to add flag position to a specific list (ex. from assignFactoryCommandDroid)
-void addFlagPositionToList(FLAG_POSITION *psFlagPosToAdd, FLAG_POSITION *list[MAX_PLAYERS]);
+void addFlagPositionToList(FLAG_POSITION* psFlagPosToAdd, PerPlayerFlagPositionLists& list);
 
 // Find a base object from it's id
 BASE_OBJECT *getBaseObjFromData(unsigned id, unsigned player, OBJECT_TYPE type);

--- a/src/order.cpp
+++ b/src/order.cpp
@@ -1645,7 +1645,7 @@ void orderDroidBase(DROID *psDroid, DROID_ORDER_DATA *psOrder)
 		}
 		break;
 	case DORDER_RTB:
-		for (STRUCTURE* psStruct : apsStructLists[psDroid->player])
+		for (const STRUCTURE* psStruct : apsStructLists[psDroid->player])
 		{
 			if (psStruct->pStructureType->type == REF_HQ)
 			{
@@ -2832,7 +2832,7 @@ static void orderPlayOrderObjAudio(UDWORD player, BASE_OBJECT *psObj)
 	ASSERT_PLAYER_OR_RETURN(, player);
 
 	/* loop over selected droids */
-	for (DROID *psDroid : apsDroidLists[player])
+	for (const DROID *psDroid : apsDroidLists[player])
 	{
 		if (psDroid->selected)
 		{
@@ -3941,7 +3941,7 @@ static SECONDARY_STATE secondaryGetAverageGroupState(UDWORD player, UDWORD group
 	// count the number of units for each state
 	numStates = 0;
 	memset(aStateCount, 0, sizeof(aStateCount));
-	for (DROID* psCurr : apsDroidLists[player])
+	for (const DROID* psCurr : apsDroidLists[player])
 	{
 		if (psCurr->group == group)
 		{

--- a/src/order.cpp
+++ b/src/order.cpp
@@ -1352,7 +1352,7 @@ static void orderPlayFireSupportAudio(BASE_OBJECT *psObj)
 void orderDroidBase(DROID *psDroid, DROID_ORDER_DATA *psOrder)
 {
 	UDWORD		iFactoryDistSq;
-	STRUCTURE	*psStruct, *psFactory;
+	STRUCTURE	*psFactory;
 	const PROPULSION_STATS *psPropStats = asPropulsionStats + psDroid->asBits[COMP_PROPULSION];
 	const Vector3i rPos(psOrder->pos, 0);
 	syncDebugDroid(psDroid, '-');
@@ -1645,7 +1645,7 @@ void orderDroidBase(DROID *psDroid, DROID_ORDER_DATA *psOrder)
 		}
 		break;
 	case DORDER_RTB:
-		for (psStruct = apsStructLists[psDroid->player]; psStruct; psStruct = psStruct->psNext)
+		for (STRUCTURE* psStruct : apsStructLists[psDroid->player])
 		{
 			if (psStruct->pStructureType->type == REF_HQ)
 			{
@@ -1828,7 +1828,7 @@ void orderDroidBase(DROID *psDroid, DROID_ORDER_DATA *psOrder)
 	case DORDER_RECYCLE:
 		psFactory = nullptr;
 		iFactoryDistSq = 0;
-		for (psStruct = apsStructLists[psDroid->player]; psStruct; psStruct = psStruct->psNext)
+		for (STRUCTURE* psStruct : apsStructLists[psDroid->player])
 		{
 			// Look for nearest factory or repair facility
 			if (psStruct->pStructureType->type == REF_FACTORY || psStruct->pStructureType->type == REF_CYBORG_FACTORY
@@ -3001,7 +3001,7 @@ static STRUCTURE *FindAFactory(UDWORD player, UDWORD factoryType)
 {
 	ASSERT_PLAYER_OR_RETURN(nullptr, player);
 
-	for (STRUCTURE *psStruct = apsStructLists[player]; psStruct != nullptr; psStruct = psStruct->psNext)
+	for (STRUCTURE *psStruct : apsStructLists[player])
 	{
 		if (psStruct->pStructureType->type == factoryType)
 		{
@@ -3018,7 +3018,7 @@ static STRUCTURE *FindARepairFacility(unsigned player)
 {
 	ASSERT_PLAYER_OR_RETURN(nullptr, player);
 
-	for (STRUCTURE *psStruct = apsStructLists[player]; psStruct != nullptr; psStruct = psStruct->psNext)
+	for (STRUCTURE *psStruct : apsStructLists[player])
 	{
 		if (psStruct->pStructureType->type == REF_REPAIR_FACILITY)
 		{
@@ -3346,7 +3346,7 @@ static inline RtrBestResult decideWhereToRepairAndBalance(DROID *psDroid)
 	vDroidPos.clear();
 	vDroid.clear();
 
-	for (STRUCTURE *psStruct = apsStructLists[psDroid->player]; psStruct; psStruct = psStruct->psNext)
+	for (STRUCTURE *psStruct : apsStructLists[psDroid->player])
 	{
 		if (psStruct->pStructureType->type == REF_HQ)
 		{
@@ -3462,7 +3462,6 @@ static inline RtrBestResult decideWhereToRepairAndBalance(DROID *psDroid)
 bool secondarySetState(DROID *psDroid, SECONDARY_ORDER sec, SECONDARY_STATE State, QUEUE_MODE mode)
 {
 	UDWORD		CurrState, factType, prodType;
-	STRUCTURE	*psStruct;
 	SDWORD		factoryInc;
 	bool		retVal;
 	DROID		*psTransport, *psCurr, *psNext;
@@ -3667,8 +3666,7 @@ bool secondarySetState(DROID *psDroid, SECONDARY_ORDER sec, SECONDARY_STATE Stat
 		if (psDroid->droidType == DROID_COMMAND)
 		{
 			// look for the factories
-			for (psStruct = apsStructLists[psDroid->player]; psStruct;
-			     psStruct = psStruct->psNext)
+			for (STRUCTURE* psStruct : apsStructLists[psDroid->player])
 			{
 				factType = psStruct->pStructureType->type;
 				if (factType == REF_FACTORY ||
@@ -4124,9 +4122,7 @@ void orderStructureObj(UDWORD player, BASE_OBJECT *psObj)
 {
 	ASSERT_PLAYER_OR_RETURN(, player);
 
-	STRUCTURE   *psStruct;
-
-	for (psStruct = apsStructLists[player]; psStruct; psStruct = psStruct->psNext)
+	for (STRUCTURE* psStruct : apsStructLists[player])
 	{
 		if (lasSatStructSelected(psStruct))
 		{

--- a/src/order.cpp
+++ b/src/order.cpp
@@ -2516,7 +2516,6 @@ DROID_ORDER chooseOrderLoc(DROID *psDroid, UDWORD x, UDWORD y, bool altOrder)
  */
 void orderSelectedLoc(uint32_t player, uint32_t x, uint32_t y, bool add)
 {
-	DROID			*psCurr;
 	DROID_ORDER		order;
 
 	//if were in build select mode ignore all other clicking
@@ -2530,7 +2529,7 @@ void orderSelectedLoc(uint32_t player, uint32_t x, uint32_t y, bool add)
 	// note that an order list graphic needs to be displayed
 	bOrderEffectDisplayed = false;
 
-	for (psCurr = apsDroidLists[player]; psCurr; psCurr = psCurr->psNext)
+	for (DROID* psCurr : apsDroidLists[player])
 	{
 		if (psCurr->selected)
 		{
@@ -2833,7 +2832,7 @@ static void orderPlayOrderObjAudio(UDWORD player, BASE_OBJECT *psObj)
 	ASSERT_PLAYER_OR_RETURN(, player);
 
 	/* loop over selected droids */
-	for (DROID *psDroid = apsDroidLists[player]; psDroid; psDroid = psDroid->psNext)
+	for (DROID *psDroid : apsDroidLists[player])
 	{
 		if (psDroid->selected)
 		{
@@ -2868,7 +2867,7 @@ void orderSelectedObjAdd(UDWORD player, BASE_OBJECT *psObj, bool add)
 	// note that an order list graphic needs to be displayed
 	bOrderEffectDisplayed = false;
 
-	for (DROID *psCurr = apsDroidLists[player]; psCurr; psCurr = psCurr->psNext)
+	for (DROID *psCurr : apsDroidLists[player])
 	{
 		if (psCurr->selected)
 		{
@@ -2926,7 +2925,7 @@ void orderSelectedStatsLocDir(UDWORD player, DROID_ORDER order, STRUCTURE_STATS 
 {
 	ASSERT_PLAYER_OR_RETURN(, player);
 
-	for (DROID *psCurr = apsDroidLists[player]; psCurr; psCurr = psCurr->psNext)
+	for (DROID *psCurr : apsDroidLists[player])
 	{
 		if (psCurr->selected && isConstructionDroid(psCurr))
 		{
@@ -2950,7 +2949,7 @@ void orderSelectedStatsTwoLocDir(UDWORD player, DROID_ORDER order, STRUCTURE_STA
 {
 	ASSERT_PLAYER_OR_RETURN(, player);
 
-	for (DROID *psCurr = apsDroidLists[player]; psCurr; psCurr = psCurr->psNext)
+	for (DROID *psCurr : apsDroidLists[player])
 	{
 		if (psCurr->selected)
 		{
@@ -2975,7 +2974,7 @@ DROID *FindATransporter(DROID const *embarkee)
 	DROID *bestDroid = nullptr;
 	unsigned bestDist = ~0u;
 
-	for (DROID *psDroid = apsDroidLists[embarkee->player]; psDroid != nullptr; psDroid = psDroid->psNext)
+	for (DROID *psDroid : apsDroidLists[embarkee->player])
 	{
 		if ((isCyborg && psDroid->droidType == DROID_TRANSPORTER) || psDroid->droidType == DROID_SUPERTRANSPORTER)
 		{
@@ -3258,8 +3257,7 @@ static bool secondaryCheckDamageLevelDeselect(DROID *psDroid, SECONDARY_STATE re
 		// Only deselect the droid if there is another droid selected.
 		if (psDroid->selected && selectedPlayer < MAX_PLAYERS)
 		{
-			DROID *psTempDroid;
-			for (psTempDroid = apsDroidLists[selectedPlayer]; psTempDroid; psTempDroid = psTempDroid->psNext)
+			for (DROID* psTempDroid : apsDroidLists[selectedPlayer])
 			{
 				if (psTempDroid != psDroid && psTempDroid->selected)
 				{
@@ -3378,24 +3376,27 @@ static inline RtrBestResult decideWhereToRepairAndBalance(DROID *psDroid)
 		&& secondaryGetState(psDroid, DSO_ACCEPT_RETREP)))
 	{
 		// one of these lists is empty when on mission
-		DROID* psdroidList = apsDroidLists[psDroid->player] != nullptr ? apsDroidLists[psDroid->player] : mission.apsDroidLists[psDroid->player];
-		for (DROID* psCurr = psdroidList; psCurr != nullptr; psCurr = psCurr->psNext)
+		DroidList* psdroidList = !apsDroidLists[psDroid->player].empty() ? &apsDroidLists[psDroid->player] : &mission.apsDroidLists[psDroid->player];
+		if (!psdroidList->empty())
 		{
-			// Accept any repair droids that accept retreating units
-			if ((psCurr->droidType == DROID_REPAIR || psCurr->droidType == DROID_CYBORG_REPAIR)
-				&& secondaryGetState(psCurr, DSO_ACCEPT_RETREP))
+			for (DROID* psCurr : *psdroidList)
 			{
-				thisDistToRepair = droidSqDist(psDroid, psCurr);
-				if (thisDistToRepair <= 0)
+				// Accept any repair droids that accept retreating units
+				if ((psCurr->droidType == DROID_REPAIR || psCurr->droidType == DROID_CYBORG_REPAIR)
+					&& secondaryGetState(psCurr, DSO_ACCEPT_RETREP))
 				{
-					continue; // unreachable
-				}
-				vDroidPos.push_back(psCurr->pos);
-				vDroid.push_back(psCurr);
-				if (bestDistToRepairDroid > thisDistToRepair)
-				{
-					bestDistToRepairDroid = thisDistToRepair;
-					bestDroidPos = psCurr->pos;
+					thisDistToRepair = droidSqDist(psDroid, psCurr);
+					if (thisDistToRepair <= 0)
+					{
+						continue; // unreachable
+					}
+					vDroidPos.push_back(psCurr->pos);
+					vDroid.push_back(psCurr);
+					if (bestDistToRepairDroid > thisDistToRepair)
+					{
+						bestDistToRepairDroid = thisDistToRepair;
+						bestDroidPos = psCurr->pos;
+					}
 				}
 			}
 		}
@@ -3911,7 +3912,7 @@ static void secondarySetGroupState(UDWORD player, UDWORD group, SECONDARY_ORDER 
 {
 	ASSERT_PLAYER_OR_RETURN(, player);
 
-	for (DROID *psCurr = apsDroidLists[player]; psCurr; psCurr = psCurr->psNext)
+	for (DROID *psCurr : apsDroidLists[player])
 	{
 		if (psCurr->group == group &&
 		    secondaryGetState(psCurr, sec) != state)
@@ -3936,12 +3937,11 @@ static SECONDARY_STATE secondaryGetAverageGroupState(UDWORD player, UDWORD group
 		UDWORD state, num;
 	} aStateCount[MAX_STATES];
 	SDWORD	i, numStates, max;
-	DROID	*psCurr;
 
 	// count the number of units for each state
 	numStates = 0;
 	memset(aStateCount, 0, sizeof(aStateCount));
-	for (psCurr = apsDroidLists[player]; psCurr; psCurr = psCurr->psNext)
+	for (DROID* psCurr : apsDroidLists[player])
 	{
 		if (psCurr->group == group)
 		{

--- a/src/power.cpp
+++ b/src/power.cpp
@@ -144,7 +144,7 @@ void delPowerRequest(STRUCTURE *psStruct)
 	}
 }
 
-static int64_t checkPrecisePowerRequest(STRUCTURE *psStruct)
+static int64_t checkPrecisePowerRequest(const STRUCTURE *psStruct)
 {
 	ASSERT_NOT_NULLPTR_OR_RETURN(-1, psStruct);
 	PlayerPower const *p = &asPower[psStruct->player];
@@ -166,7 +166,7 @@ static int64_t checkPrecisePowerRequest(STRUCTURE *psStruct)
 	return -1;
 }
 
-int32_t checkPowerRequest(STRUCTURE *psStruct)
+int32_t checkPowerRequest(const STRUCTURE *psStruct)
 {
 	int64_t power = checkPrecisePowerRequest(psStruct);
 	return power != -1 ? power / FP_ONE : -1;

--- a/src/power.cpp
+++ b/src/power.cpp
@@ -53,7 +53,7 @@ static void updateCurrentPower(STRUCTURE *psStruct, UDWORD player, int ticks);
 static int64_t updateExtractedPower(STRUCTURE *psBuilding);
 
 //returns the relevant list based on OffWorld or OnWorld
-static STRUCTURE *powerStructList(int player);
+static StructureList* powerStructList(int player);
 
 struct PowerRequest
 {
@@ -250,34 +250,37 @@ static int64_t updateExtractedPower(STRUCTURE *psBuilding)
 }
 
 //returns the relevant list based on OffWorld or OnWorld
-STRUCTURE *powerStructList(int player)
+StructureList* powerStructList(int player)
 {
 	ASSERT_OR_RETURN(nullptr, player < MAX_PLAYERS, "Invalid player %d", player);
 	if (offWorldKeepLists)
 	{
-		return (mission.apsStructLists[player]);
+		return &mission.apsStructLists[player];
 	}
 	else
 	{
-		return (apsStructLists[player]);
+		return &apsStructLists[player];
 	}
 }
 
 /* Update current power based on what Power Generators exist */
 void updatePlayerPower(int player, int ticks)
 {
-	STRUCTURE		*psStruct;//, *psList;
 	int64_t powerBefore = asPower[player].currentPower;
 
 	ASSERT_OR_RETURN(, player < MAX_PLAYERS, "Invalid player %d", player);
 
 	syncDebugEconomy(player, '<');
 
-	for (psStruct = powerStructList(player); psStruct != nullptr; psStruct = psStruct->psNext)
+	auto* powerStrList = powerStructList(player);
+	if (powerStrList)
 	{
-		if (psStruct->pStructureType->type == REF_POWER_GEN && psStruct->status == SS_BUILT)
+		for (STRUCTURE* psStruct : *powerStrList)
 		{
-			updateCurrentPower(psStruct, player, ticks);
+			if (psStruct->pStructureType->type == REF_POWER_GEN && psStruct->status == SS_BUILT)
+			{
+				updateCurrentPower(psStruct, player, ticks);
+			}
 		}
 	}
 	syncDebug("updatePlayerPower%u %" PRId64"->%" PRId64"", player, powerBefore, asPower[player].currentPower);

--- a/src/power.h
+++ b/src/power.h
@@ -38,7 +38,7 @@ void delPowerRequest(STRUCTURE *psStruct);
 
 /// Checks how much power must be accumulated, before the power request from this structure can be satisfied.
 /// Returns -1 if there is no power request or if there is enough power already.
-int32_t checkPowerRequest(STRUCTURE *psStruct);
+int32_t checkPowerRequest(const STRUCTURE *psStruct);
 
 bool requestPowerFor(STRUCTURE *psStruct, int32_t amount);
 bool requestPrecisePowerFor(STRUCTURE *psStruct, int64_t amount);

--- a/src/qtscript.cpp
+++ b/src/qtscript.cpp
@@ -2692,7 +2692,7 @@ wzapi::no_return_value scripting_engine::groupAddArea(WZAPI_PARAMS(int groupId, 
 	int x2 = world_coord(_x2);
 	int y2 = world_coord(_y2);
 
-	for (DROID *psDroid = apsDroidLists[player]; psDroid; psDroid = psDroid->psNext)
+	for (DROID *psDroid : apsDroidLists[player])
 	{
 		if (psDroid->pos.x >= x1 && psDroid->pos.x <= x2 && psDroid->pos.y >= y1 && psDroid->pos.y <= y2)
 		{

--- a/src/radar.cpp
+++ b/src/radar.cpp
@@ -514,7 +514,7 @@ static void DrawRadarObjects()
 		flashCol = flashColours[getPlayerColour(clan)];
 
 		/* Go through all droids */
-		for (DROID* psDroid : apsDroidLists[clan])
+		for (const DROID* psDroid : apsDroidLists[clan])
 		{
 			if (psDroid->pos.x < world_coord(scrollMinX) || psDroid->pos.y < world_coord(scrollMinY)
 			    || psDroid->pos.x >= world_coord(scrollMaxX) || psDroid->pos.y >= world_coord(scrollMaxY))

--- a/src/radar.cpp
+++ b/src/radar.cpp
@@ -491,8 +491,6 @@ static void DrawRadarObjects()
 	/* Show droids on map - go through all players */
 	for (clan = 0; clan < MAX_PLAYERS; clan++)
 	{
-		DROID		*psDroid;
-
 		//see if have to draw enemy/ally color
 		if (bEnemyAllyRadarColor)
 		{
@@ -516,7 +514,7 @@ static void DrawRadarObjects()
 		flashCol = flashColours[getPlayerColour(clan)];
 
 		/* Go through all droids */
-		for (psDroid = apsDroidLists[clan]; psDroid != nullptr; psDroid = psDroid->psNext)
+		for (DROID* psDroid : apsDroidLists[clan])
 		{
 			if (psDroid->pos.x < world_coord(scrollMinX) || psDroid->pos.y < world_coord(scrollMinY)
 			    || psDroid->pos.x >= world_coord(scrollMaxX) || psDroid->pos.y >= world_coord(scrollMaxY))

--- a/src/research.cpp
+++ b/src/research.cpp
@@ -1519,7 +1519,7 @@ void researchReward(UBYTE losingPlayer, UBYTE rewardPlayer)
 	UDWORD topicIndex = 0, researchPoints = 0, rewardID = 0;
 
 	//look through the losing players structures to find a research facility
-	for (STRUCTURE *psStruct : apsStructLists[losingPlayer])
+	for (const STRUCTURE *psStruct : apsStructLists[losingPlayer])
 	{
 		if (psStruct->pStructureType->type == REF_RESEARCH)
 		{
@@ -1728,7 +1728,7 @@ std::vector<AllyResearch> const &listAllyResearch(unsigned ref)
 			}
 
 			// Check each research facility to see if they are doing this topic. (As opposed to having started the topic, but stopped researching it.)
-			for (STRUCTURE *psStruct : apsStructLists[player])
+			for (const STRUCTURE *psStruct : apsStructLists[player])
 			{
 				RESEARCH_FACILITY *res = (RESEARCH_FACILITY *)psStruct->pFunctionality;
 				if (psStruct->pStructureType->type != REF_RESEARCH || res->psSubject == nullptr)

--- a/src/research.cpp
+++ b/src/research.cpp
@@ -90,7 +90,7 @@ static bool checkResearchName(RESEARCH *psRes, UDWORD numStats);
 static UBYTE bSelfRepair[MAX_PLAYERS];
 static void replaceDroidComponent(DROID *pList, UDWORD oldType, UDWORD oldCompInc,
                                   UDWORD newCompInc);
-static void replaceStructureComponent(STRUCTURE *pList, UDWORD oldType, UDWORD oldCompInc,
+static void replaceStructureComponent(StructureList& pList, UDWORD oldType, UDWORD oldCompInc,
                                       UDWORD newCompInc, UBYTE player);
 static void switchComponent(DROID *psDroid, UDWORD oldType, UDWORD oldCompInc,
                             UDWORD newCompInc);
@@ -1131,10 +1131,9 @@ void releaseResearch(STRUCTURE *psBuilding, QUEUE_MODE mode)
 */
 void CancelAllResearch(UDWORD pl)
 {
-	STRUCTURE	*psCurr;
 	if (pl >= MAX_PLAYERS) { return; }
 
-	for (psCurr = apsStructLists[pl]; psCurr != nullptr; psCurr = psCurr->psNext)
+	for (STRUCTURE* psCurr : apsStructLists[pl])
 	{
 		if (psCurr->pStructureType->type == REF_RESEARCH)
 		{
@@ -1456,11 +1455,8 @@ static void replaceComponent(COMPONENT_STATS *pNewComponent, COMPONENT_STATS *pO
 	//check thru the templates
 	enumerateTemplates(player, replaceComponentInTemplate);
 	// also check build queues
-	STRUCTURE *psNBuilding = nullptr;
-	for (STRUCTURE *psCBuilding = apsStructLists[player]; psCBuilding != nullptr; psCBuilding = psNBuilding)
+	for (STRUCTURE *psCBuilding : apsStructLists[player])
 	{
-		/* Copy the next pointer - not 100% sure if the structure could get destroyed but this covers us anyway */
-		psNBuilding = psCBuilding->psNext;
 		if ((psCBuilding->pStructureType->type == STRUCTURE_TYPE::REF_FACTORY ||
 			psCBuilding->pStructureType->type == STRUCTURE_TYPE::REF_CYBORG_FACTORY ||
 			psCBuilding->pStructureType->type == STRUCTURE_TYPE::REF_VTOL_FACTORY) &&
@@ -1523,7 +1519,7 @@ void researchReward(UBYTE losingPlayer, UBYTE rewardPlayer)
 	UDWORD topicIndex = 0, researchPoints = 0, rewardID = 0;
 
 	//look through the losing players structures to find a research facility
-	for (STRUCTURE *psStruct = apsStructLists[losingPlayer]; psStruct != nullptr; psStruct = psStruct->psNext)
+	for (STRUCTURE *psStruct : apsStructLists[losingPlayer])
 	{
 		if (psStruct->pStructureType->type == REF_RESEARCH)
 		{
@@ -1616,10 +1612,9 @@ void replaceTransDroidComponents(DROID *psTransporter, UDWORD oldType,
 	}
 }
 
-void replaceStructureComponent(STRUCTURE *pList, UDWORD oldType, UDWORD oldCompInc,
+void replaceStructureComponent(StructureList& pList, UDWORD oldType, UDWORD oldCompInc,
                                UDWORD newCompInc, UBYTE player)
 {
-	STRUCTURE   *psStructure;
 	int			inc;
 
 	// If the type is not one we are interested in, then don't bother checking
@@ -1629,7 +1624,7 @@ void replaceStructureComponent(STRUCTURE *pList, UDWORD oldType, UDWORD oldCompI
 	}
 
 	//check thru the structures
-	for (psStructure = pList; psStructure != nullptr; psStructure = psStructure->psNext)
+	for (STRUCTURE* psStructure : pList)
 	{
 		switch (oldType)
 		{
@@ -1735,7 +1730,7 @@ std::vector<AllyResearch> const &listAllyResearch(unsigned ref)
 			}
 
 			// Check each research facility to see if they are doing this topic. (As opposed to having started the topic, but stopped researching it.)
-			for (STRUCTURE *psStruct = apsStructLists[player]; psStruct != nullptr; psStruct = psStruct->psNext)
+			for (STRUCTURE *psStruct : apsStructLists[player])
 			{
 				RESEARCH_FACILITY *res = (RESEARCH_FACILITY *)psStruct->pFunctionality;
 				if (psStruct->pStructureType->type != REF_RESEARCH || res->psSubject == nullptr)

--- a/src/research.cpp
+++ b/src/research.cpp
@@ -88,7 +88,7 @@ static bool checkResearchName(RESEARCH *psRes, UDWORD numStats);
 
 //flag that indicates whether the player can self repair
 static UBYTE bSelfRepair[MAX_PLAYERS];
-static void replaceDroidComponent(DROID *pList, UDWORD oldType, UDWORD oldCompInc,
+static void replaceDroidComponent(DroidList& pList, UDWORD oldType, UDWORD oldCompInc,
                                   UDWORD newCompInc);
 static void replaceStructureComponent(StructureList& pList, UDWORD oldType, UDWORD oldCompInc,
                                       UDWORD newCompInc, UBYTE player);
@@ -1577,13 +1577,11 @@ bool selfRepairEnabled(UBYTE player)
 }
 
 /*for a given list of droids, replace the old component if exists*/
-void replaceDroidComponent(DROID *pList, UDWORD oldType, UDWORD oldCompInc,
+void replaceDroidComponent(DroidList& pList, UDWORD oldType, UDWORD oldCompInc,
                            UDWORD newCompInc)
 {
-	DROID   *psDroid;
-
 	//check thru the droids
-	for (psDroid = pList; psDroid != nullptr; psDroid = psDroid->psNext)
+	for (DROID* psDroid : pList)
 	{
 		switchComponent(psDroid, oldType, oldCompInc, newCompInc);
 		// Need to replace the units inside the transporter

--- a/src/scores.cpp
+++ b/src/scores.cpp
@@ -308,7 +308,7 @@ END_GAME_STATS_DATA	collectEndGameStatsData()
 			{
 				continue;
 			}
-			for (DROID* psDroid : *dList)
+			for (const DROID* psDroid : *dList)
 			{
 				if (isTransporter(psDroid))
 				{
@@ -621,7 +621,7 @@ void stdOutGameSummary(UDWORD realTimeThrottleSeconds, bool flush_output /* = tr
 			uint32_t numFactories = 0;
 			uint32_t numResearch = 0;
 			uint32_t numFactoriesThatCanProduceConstructionUnits = 0;
-			for (STRUCTURE *psStruct : apsStructLists[n])
+			for (const STRUCTURE *psStruct : apsStructLists[n])
 			{
 				if (psStruct->status != SS_BUILT || psStruct->died != 0)
 				{

--- a/src/scores.cpp
+++ b/src/scores.cpp
@@ -613,11 +613,11 @@ void stdOutGameSummary(UDWORD realTimeThrottleSeconds, bool flush_output /* = tr
 			uint32_t unitsKilled = getMultiPlayUnitsKilled(n);
 			uint32_t numUnits = 0;
 			for (DROID *psDroid = apsDroidLists[n]; psDroid; psDroid = psDroid->psNext, numUnits++) {}
-			uint32_t numStructs = 0;
+			uint32_t numStructs = apsStructLists[n].size();
 			uint32_t numFactories = 0;
 			uint32_t numResearch = 0;
 			uint32_t numFactoriesThatCanProduceConstructionUnits = 0;
-			for (STRUCTURE *psStruct = apsStructLists[n]; psStruct; psStruct = psStruct->psNext, numStructs++)
+			for (STRUCTURE *psStruct : apsStructLists[n])
 			{
 				if (psStruct->status != SS_BUILT || psStruct->died != 0)
 				{

--- a/src/scores.cpp
+++ b/src/scores.cpp
@@ -296,15 +296,19 @@ END_GAME_STATS_DATA	collectEndGameStatsData()
 		unsigned int idx = 0;
 		do
 		{
-			DROID *psDroid = nullptr;
+			DroidList* dList = nullptr;
 			switch (idx)
 			{
-				case 0: psDroid = apsDroidLists[selectedPlayer]; break;
-				case 1: psDroid = mission.apsDroidLists[selectedPlayer]; break;
-				case 2: if (prevMissionType == LEVEL_TYPE::LDS_MKEEP_LIMBO) { psDroid = apsLimboDroids[selectedPlayer]; } break;
-				default: psDroid = nullptr;
+				case 0: dList = &apsDroidLists[selectedPlayer]; break;
+				case 1: dList = &mission.apsDroidLists[selectedPlayer]; break;
+				case 2: if (prevMissionType == LEVEL_TYPE::LDS_MKEEP_LIMBO) { dList = &apsLimboDroids[selectedPlayer]; } break;
+				default: dList = nullptr;
 			}
-			for (; psDroid; psDroid = psDroid->psNext, ++fullStats.numUnits)
+			if (!dList)
+			{
+				continue;
+			}
+			for (DROID* psDroid : *dList)
 			{
 				if (isTransporter(psDroid))
 				{
@@ -316,6 +320,7 @@ END_GAME_STATS_DATA	collectEndGameStatsData()
 						}
 					}
 				}
+				++fullStats.numUnits;
 			}
 		} while (++idx < 3);
 	}
@@ -611,8 +616,7 @@ void stdOutGameSummary(UDWORD realTimeThrottleSeconds, bool flush_output /* = tr
 				continue;
 			}
 			uint32_t unitsKilled = getMultiPlayUnitsKilled(n);
-			uint32_t numUnits = 0;
-			for (DROID *psDroid = apsDroidLists[n]; psDroid; psDroid = psDroid->psNext, numUnits++) {}
+			uint32_t numUnits = apsDroidLists[n].size();
 			uint32_t numStructs = apsStructLists[n].size();
 			uint32_t numFactories = 0;
 			uint32_t numResearch = 0;

--- a/src/selection.cpp
+++ b/src/selection.cpp
@@ -161,7 +161,7 @@ unsigned int selNumSelected(unsigned int player)
 	unsigned int count = 0;
 	if (player >= MAX_PLAYERS) { return 0; }
 
-	for (DROID *psDroid : apsDroidLists[player])
+	for (const DROID *psDroid : apsDroidLists[player])
 	{
 		if (psDroid->selected)
 		{
@@ -173,7 +173,7 @@ unsigned int selNumSelected(unsigned int player)
 }
 
 
-std::vector<uint32_t> buildComponentsFromDroid(DROID* psDroid)
+std::vector<uint32_t> buildComponentsFromDroid(const DROID* psDroid)
 {
 	std::vector<uint32_t> components;
 	uint32_t stat = 0;
@@ -532,7 +532,7 @@ static bool droidIsCommanderNum(DROID *psDroid, SDWORD n)
 	}
 
 	int numLess = 0;
-	for (DROID *psCurr : apsDroidLists[psDroid->player])
+	for (const DROID *psCurr : apsDroidLists[psDroid->player])
 	{
 		if ((psCurr->droidType == DROID_COMMAND) && (psCurr->id < psDroid->id))
 		{

--- a/src/selection.cpp
+++ b/src/selection.cpp
@@ -468,7 +468,7 @@ void selNextSpecifiedBuilding(STRUCTURE_TYPE structType, bool jump)
 	/* Firstly, start coughing if the type is invalid */
 	ASSERT(structType <= NUM_DIFF_BUILDINGS, "Invalid structure type %u", structType);
 
-	for (STRUCTURE *psCurr = apsStructLists[selectedPlayer]; psCurr && !psResult; psCurr = psCurr->psNext)
+	for (STRUCTURE *psCurr : apsStructLists[selectedPlayer])
 	{
 		if (psCurr->pStructureType->type == structType && psCurr->status == SS_BUILT)
 		{

--- a/src/selection.cpp
+++ b/src/selection.cpp
@@ -60,7 +60,7 @@ static unsigned selSelectUnitsIf(unsigned player, T condition, bool onlyOnScreen
 	selDroidDeselect(player);
 
 	// Go through all.
-	for (DROID *psDroid = apsDroidLists[player]; psDroid != nullptr; psDroid = psDroid->psNext)
+	for (DROID *psDroid : apsDroidLists[player])
 	{
 		bool shouldSelect = (!onlyOnScreen || objectOnScreen(psDroid, 0)) &&
 		                    condition(psDroid);
@@ -142,7 +142,7 @@ unsigned int selDroidDeselect(unsigned int player)
 	unsigned int count = 0;
 	if (player >= MAX_PLAYERS) { return 0; }
 
-	for (DROID *psDroid = apsDroidLists[player]; psDroid; psDroid = psDroid->psNext)
+	for (DROID* psDroid : apsDroidLists[player])
 	{
 		if (psDroid->selected)
 		{
@@ -161,7 +161,7 @@ unsigned int selNumSelected(unsigned int player)
 	unsigned int count = 0;
 	if (player >= MAX_PLAYERS) { return 0; }
 
-	for (DROID *psDroid = apsDroidLists[player]; psDroid; psDroid = psDroid->psNext)
+	for (DROID *psDroid : apsDroidLists[player])
 	{
 		if (psDroid->selected)
 		{
@@ -239,7 +239,7 @@ static unsigned int selSelectAllSame(unsigned int player, bool bOnScreen)
 	if (player >= MAX_PLAYERS) { return 0; }
 
 	// find out which units will need to be compared to which component combinations
-	for (DROID *psDroid = apsDroidLists[player]; psDroid; psDroid = psDroid->psNext)
+	for (DROID *psDroid : apsDroidLists[player])
 	{
 		if (bOnScreen && !objectOnScreen(psDroid, 0))
 		{
@@ -260,7 +260,7 @@ static unsigned int selSelectAllSame(unsigned int player, bool bOnScreen)
 	{
 		// reset unit counter
 		i = 0;
-		for (DROID *psDroid = apsDroidLists[player]; psDroid; psDroid = psDroid->psNext)
+		for (DROID *psDroid : apsDroidLists[player])
 		{
 			if (excluded.empty() || *excluded.begin() != i)
 			{
@@ -290,7 +290,7 @@ void selNextSpecifiedUnit(DROID_TYPE unitType)
 
 	ASSERT_OR_RETURN(, selectedPlayer < MAX_PLAYERS, "invalid selectedPlayer: %" PRIu32 "", selectedPlayer);
 
-	for (DROID *psCurr = apsDroidLists[selectedPlayer]; psCurr && !psResult; psCurr = psCurr->psNext)
+	for (DROID *psCurr : apsDroidLists[selectedPlayer])
 	{
 		//exceptions - as always...
 		bool bMatch = false;
@@ -331,12 +331,14 @@ void selNextSpecifiedUnit(DROID_TYPE unitType)
 			if (!psOldRD)
 			{
 				psResult = psCurr;
+				break;
 			}
 
 			/* Only select is this isn't the old one and it's further on in list */
 			else if (psCurr != psOldRD && bLaterInList)
 			{
 				psResult = psCurr;
+				break;
 			}
 		}
 	}
@@ -396,7 +398,7 @@ void selNextUnassignedUnit()
 
 	ASSERT_OR_RETURN(, selectedPlayer < MAX_PLAYERS, "invalid selectedPlayer: %" PRIu32 "", selectedPlayer);
 
-	for (DROID *psCurr = apsDroidLists[selectedPlayer]; psCurr && !psResult; psCurr = psCurr->psNext)
+	for (DROID *psCurr : apsDroidLists[selectedPlayer])
 	{
 		/* Only look at unselected ones */
 		if (psCurr->group == UBYTE_MAX)
@@ -416,12 +418,14 @@ void selNextUnassignedUnit()
 			if (!psOldNS)
 			{
 				psResult = psCurr;
+				break;
 			}
 
 			/* Dont choose same one again */
 			else if (psCurr != psOldNS && bLaterInList)
 			{
 				psResult = psCurr;
+				break;
 			}
 		}
 	}
@@ -528,7 +532,7 @@ static bool droidIsCommanderNum(DROID *psDroid, SDWORD n)
 	}
 
 	int numLess = 0;
-	for (DROID *psCurr = apsDroidLists[psDroid->player]; psCurr; psCurr = psCurr->psNext)
+	for (DROID *psCurr : apsDroidLists[psDroid->player])
 	{
 		if ((psCurr->droidType == DROID_COMMAND) && (psCurr->id < psDroid->id))
 		{
@@ -544,7 +548,7 @@ void selCommander(int n)
 {
 	ASSERT_OR_RETURN(, selectedPlayer < MAX_PLAYERS, "invalid selectedPlayer: %" PRIu32 "", selectedPlayer);
 
-	for (DROID *psCurr = apsDroidLists[selectedPlayer]; psCurr; psCurr = psCurr->psNext)
+	for (DROID *psCurr : apsDroidLists[selectedPlayer])
 	{
 		if (droidIsCommanderNum(psCurr, n))
 		{

--- a/src/selection.h
+++ b/src/selection.h
@@ -62,6 +62,6 @@ void selNextSpecifiedBuilding(STRUCTURE_TYPE structType, bool jump);
 void selNextSpecifiedUnit(DROID_TYPE unitType);
 // select the n'th command droid
 void selCommander(int n);
-std::vector<uint32_t> buildComponentsFromDroid(DROID* psDroid);
+std::vector<uint32_t> buildComponentsFromDroid(const DROID* psDroid);
 
 #endif // __INCLUDED_SRC_SELECTION_H__

--- a/src/structure.cpp
+++ b/src/structure.cpp
@@ -321,7 +321,7 @@ void resetFactoryNumFlag()
 			factoryNumFlag[i][type].clear();
 		}
 		//look through the list of structures to see which have been used
-		for (STRUCTURE *psStruct : apsStructLists[i])
+		for (const STRUCTURE *psStruct : apsStructLists[i])
 		{
 			FLAG_TYPE type;
 			switch (psStruct->pStructureType->type)
@@ -829,7 +829,7 @@ void structureBuild(STRUCTURE *psStruct, DROID *psDroid, int buildPoints, int bu
 	{
 		for (unsigned player = 0; player < MAX_PLAYERS; player++)
 		{
-			for (DROID *psCurr : apsDroidLists[player])
+			for (const DROID *psCurr : apsDroidLists[player])
 			{
 				// An enemy droid is blocking it
 				if ((STRUCTURE *) orderStateObj(psCurr, DORDER_BUILD) == psStruct
@@ -1665,7 +1665,7 @@ STRUCTURE *buildStructureDir(STRUCTURE_STATS *pStructureType, UDWORD x, UDWORD y
 		StructureBounds bounds = getStructureBounds(psBuilding);
 		for (unsigned playerNum = 0; playerNum < MAX_PLAYERS; ++playerNum)
 		{
-			for (STRUCTURE *psStruct : apsStructLists[playerNum])
+			for (const STRUCTURE *psStruct : apsStructLists[playerNum])
 			{
 				FLAG_POSITION *fp = nullptr;
 				if (StructIsFactory(psStruct))
@@ -2301,7 +2301,7 @@ static bool structClearTile(UWORD x, UWORD y)
 	/* Check for a droid */
 	for (player = 0; player < MAX_PLAYERS; player++)
 	{
-		for (DROID* psCurr : apsDroidLists[player])
+		for (const DROID* psCurr : apsDroidLists[player])
 		{
 			if (map_coord(psCurr->pos.x) == x
 			    && map_coord(psCurr->pos.y) == y)
@@ -2641,7 +2641,7 @@ bool structureExists(int player, STRUCTURE_TYPE type, bool built, bool isMission
 	}
 
 	StructureList* pList = isMission ? &mission.apsStructLists[player] : &apsStructLists[player];
-	for (STRUCTURE *psCurr : *pList)
+	for (const STRUCTURE *psCurr : *pList)
 	{
 		if (psCurr->pStructureType->type == type && (!built || (built && psCurr->status == SS_BUILT)))
 		{
@@ -2918,11 +2918,11 @@ static void aiUpdateStructure(STRUCTURE *psStructure, bool isMission)
 	{
 		// This isn't supposed to happen, and really shouldn't be possible - if this happens, maybe a structure is being updated twice?
 		int count1 = 0, count2 = 0;
-		for (STRUCTURE* s : apsStructLists[psStructure->player])
+		for (const STRUCTURE* s : apsStructLists[psStructure->player])
 		{
 			count1 += s == psStructure;
 		}
-		for (STRUCTURE* s : mission.apsStructLists[psStructure->player])
+		for (const STRUCTURE* s : mission.apsStructLists[psStructure->player])
 		{
 			count2 += s == psStructure;
 		}
@@ -3920,7 +3920,7 @@ std::vector<STRUCTURE_STATS *> fillStructureList(UDWORD _selectedPlayer, UDWORD 
 	//if currently on a mission can't build factory/research/power/derricks
 	if (!missionIsOffworld())
 	{
-		for (STRUCTURE* psCurr : apsStructLists[_selectedPlayer])
+		for (const STRUCTURE* psCurr : apsStructLists[_selectedPlayer])
 		{
 			if (psCurr->pStructureType->type == REF_RESEARCH && psCurr->status == SS_BUILT)
 			{
@@ -4749,7 +4749,7 @@ bool checkSpecificStructExists(UDWORD structInc, UDWORD player)
 {
 	ASSERT_OR_RETURN(false, structInc < numStructureStats, "Invalid structure inc");
 
-	for (STRUCTURE *psStructure : apsStructLists[player])
+	for (const STRUCTURE *psStructure : apsStructLists[player])
 	{
 		if (psStructure->status == SS_BUILT)
 		{
@@ -5080,7 +5080,7 @@ uint16_t countPlayerUnusedDerricks()
 
 	if (selectedPlayer >= MAX_PLAYERS) { return 0; }
 
-	for (STRUCTURE *psStruct : apsExtractorLists[selectedPlayer])
+	for (const STRUCTURE *psStruct : apsExtractorLists[selectedPlayer])
 	{
 		if (psStruct->status == SS_BUILT && psStruct->pStructureType->type == REF_RESOURCE_EXTRACTOR)
 		{
@@ -6714,14 +6714,14 @@ void ensureRearmPadClear(STRUCTURE *psStruct, DROID *psDroid)
 
 
 // return whether a rearm pad has a vtol on it
-bool vtolOnRearmPad(STRUCTURE *psStruct, DROID *psDroid)
+bool vtolOnRearmPad(const STRUCTURE *psStruct, DROID *psDroid)
 {
 	SDWORD	tx, ty;
 
 	tx = map_coord(psStruct->pos.x);
 	ty = map_coord(psStruct->pos.y);
 
-	for (DROID* psCurr : apsDroidLists[psStruct->player])
+	for (const DROID* psCurr : apsDroidLists[psStruct->player])
 	{
 		if (psCurr != psDroid
 		    && map_coord(psCurr->pos.x) == tx

--- a/src/structure.cpp
+++ b/src/structure.cpp
@@ -321,7 +321,7 @@ void resetFactoryNumFlag()
 			factoryNumFlag[i][type].clear();
 		}
 		//look through the list of structures to see which have been used
-		for (STRUCTURE *psStruct = apsStructLists[i]; psStruct != nullptr; psStruct = psStruct->psNext)
+		for (STRUCTURE *psStruct : apsStructLists[i])
 		{
 			FLAG_TYPE type;
 			switch (psStruct->pStructureType->type)
@@ -654,7 +654,7 @@ void setCurrentStructQuantity(bool displayError)
 		{
 			asStructureStats[inc].curCount[player] = 0;
 		}
-		for (const STRUCTURE *psCurr = apsStructLists[player]; psCurr != nullptr; psCurr = psCurr->psNext)
+		for (const STRUCTURE *psCurr : apsStructLists[player])
 		{
 			unsigned inc = psCurr->pStructureType - asStructureStats;
 			asStructureStats[inc].curCount[player]++;
@@ -1667,7 +1667,7 @@ STRUCTURE *buildStructureDir(STRUCTURE_STATS *pStructureType, UDWORD x, UDWORD y
 		StructureBounds bounds = getStructureBounds(psBuilding);
 		for (unsigned playerNum = 0; playerNum < MAX_PLAYERS; ++playerNum)
 		{
-			for (STRUCTURE *psStruct = apsStructLists[playerNum]; psStruct != nullptr; psStruct = psStruct->psNext)
+			for (STRUCTURE *psStruct : apsStructLists[playerNum])
 			{
 				FLAG_POSITION *fp = nullptr;
 				if (StructIsFactory(psStruct))
@@ -2256,11 +2256,9 @@ void assignFactoryCommandDroid(STRUCTURE *psStruct, DROID *psCommander)
 // remove all factories from a command droid
 void clearCommandDroidFactory(DROID *psDroid)
 {
-	STRUCTURE	*psCurr;
-
 	ASSERT_OR_RETURN(, selectedPlayer < MAX_PLAYERS, "invalid selectedPlayer: %" PRIu32 "", selectedPlayer);
 
-	for (psCurr = apsStructLists[selectedPlayer]; psCurr; psCurr = psCurr->psNext)
+	for (STRUCTURE* psCurr : apsStructLists[selectedPlayer])
 	{
 		if ((psCurr->pStructureType->type == REF_FACTORY) ||
 		    (psCurr->pStructureType->type == REF_CYBORG_FACTORY) ||
@@ -2272,7 +2270,7 @@ void clearCommandDroidFactory(DROID *psDroid)
 			}
 		}
 	}
-	for (psCurr = mission.apsStructLists[selectedPlayer]; psCurr; psCurr = psCurr->psNext)
+	for (STRUCTURE* psCurr : mission.apsStructLists[selectedPlayer])
 	{
 		if ((psCurr->pStructureType->type == REF_FACTORY) ||
 		    (psCurr->pStructureType->type == REF_CYBORG_FACTORY) ||
@@ -2641,7 +2639,8 @@ bool structureExists(int player, STRUCTURE_TYPE type, bool built, bool isMission
 		return false;
 	}
 
-	for (STRUCTURE *psCurr = isMission ? mission.apsStructLists[player] : apsStructLists[player]; psCurr; psCurr = psCurr->psNext)
+	StructureList* pList = isMission ? &mission.apsStructLists[player] : &apsStructLists[player];
+	for (STRUCTURE *psCurr : *pList)
 	{
 		if (psCurr->pStructureType->type == type && (!built || (built && psCurr->status == SS_BUILT)))
 		{
@@ -2918,12 +2917,11 @@ static void aiUpdateStructure(STRUCTURE *psStructure, bool isMission)
 	{
 		// This isn't supposed to happen, and really shouldn't be possible - if this happens, maybe a structure is being updated twice?
 		int count1 = 0, count2 = 0;
-		STRUCTURE *s;
-		for (s =         apsStructLists[psStructure->player]; s != nullptr; s = s->psNext)
+		for (STRUCTURE* s : apsStructLists[psStructure->player])
 		{
 			count1 += s == psStructure;
 		}
-		for (s = mission.apsStructLists[psStructure->player]; s != nullptr; s = s->psNext)
+		for (STRUCTURE* s : mission.apsStructLists[psStructure->player])
 		{
 			count2 += s == psStructure;
 		}
@@ -3905,7 +3903,6 @@ std::vector<STRUCTURE_STATS *> fillStructureList(UDWORD _selectedPlayer, UDWORD 
 {
 	std::vector<STRUCTURE_STATS *> structureList;
 	UDWORD			inc;
-	STRUCTURE		*psCurr;
 	STRUCTURE_STATS	*psBuilding;
 
 	ASSERT_OR_RETURN(structureList, _selectedPlayer < MAX_PLAYERS, "_selectedPlayer = %" PRIu32 "", _selectedPlayer);
@@ -3922,7 +3919,7 @@ std::vector<STRUCTURE_STATS *> fillStructureList(UDWORD _selectedPlayer, UDWORD 
 	//if currently on a mission can't build factory/research/power/derricks
 	if (!missionIsOffworld())
 	{
-		for (psCurr = apsStructLists[_selectedPlayer]; psCurr != nullptr; psCurr = psCurr->psNext)
+		for (STRUCTURE* psCurr : apsStructLists[_selectedPlayer])
 		{
 			if (psCurr->pStructureType->type == REF_RESEARCH && psCurr->status == SS_BUILT)
 			{
@@ -4751,7 +4748,7 @@ bool checkSpecificStructExists(UDWORD structInc, UDWORD player)
 {
 	ASSERT_OR_RETURN(false, structInc < numStructureStats, "Invalid structure inc");
 
-	for (STRUCTURE *psStructure = apsStructLists[player]; psStructure != nullptr; psStructure = psStructure->psNext)
+	for (STRUCTURE *psStructure : apsStructLists[player])
 	{
 		if (psStructure->status == SS_BUILT)
 		{
@@ -5110,7 +5107,7 @@ void checkForPowerGen(STRUCTURE *psBuilding)
 	// Find a power generator, if possible with a power module.
 	STRUCTURE *bestPowerGen = nullptr;
 	int bestSlot = 0;
-	for (STRUCTURE *psCurr = apsStructLists[psBuilding->player]; psCurr != nullptr; psCurr = psCurr->psNext)
+	for (STRUCTURE *psCurr : apsStructLists[psBuilding->player])
 	{
 		if (psCurr->pStructureType->type == REF_POWER_GEN && psCurr->status == SS_BUILT)
 		{
@@ -5207,7 +5204,6 @@ adjusts the associated Res Extractors so that they can link to different Power
 Gens if any are available*/
 void releasePowerGen(STRUCTURE *psRelease)
 {
-	STRUCTURE	*psCurr;
 	POWER_GEN	*psPowerGen;
 	UDWORD		i;
 
@@ -5228,8 +5224,7 @@ void releasePowerGen(STRUCTURE *psRelease)
 		}
 	}
 	//may have a power gen with spare capacity
-	for (psCurr = apsStructLists[psRelease->player]; psCurr != nullptr; psCurr =
-	         psCurr->psNext)
+	for (STRUCTURE* psCurr : apsStructLists[psRelease->player])
 	{
 		if (psCurr->pStructureType->type == REF_POWER_GEN &&
 		    psCurr != psRelease && psCurr->status == SS_BUILT)
@@ -5934,7 +5929,7 @@ void hqReward(UBYTE losingPlayer, UBYTE rewardPlayer)
 	//struct
 	for (int i = 0; i < MAX_PLAYERS; ++i)
 	{
-		for (STRUCTURE *psStruct = apsStructLists[i]; psStruct != nullptr; psStruct = psStruct->psNext)
+		for (STRUCTURE *psStruct : apsStructLists[i])
 		{
 			if (psStruct->visible[losingPlayer] && !psStruct->died)
 			{
@@ -6017,12 +6012,10 @@ FLAG_POSITION *FindFactoryDelivery(const STRUCTURE *Struct)
 //Find the factory associated with the delivery point - returns NULL if none exist
 STRUCTURE	*findDeliveryFactory(FLAG_POSITION *psDelPoint)
 {
-	STRUCTURE	*psCurr;
 	FACTORY		*psFactory;
 	REPAIR_FACILITY *psRepair;
 
-	for (psCurr = apsStructLists[psDelPoint->player]; psCurr != nullptr; psCurr =
-	         psCurr->psNext)
+	for (STRUCTURE* psCurr : apsStructLists[psDelPoint->player])
 	{
 		if (StructIsFactory(psCurr))
 		{
@@ -6390,7 +6383,6 @@ bool checkFactoryExists(UDWORD player, UDWORD factoryType, UDWORD inc)
 void checkDeliveryPoints(UDWORD version)
 {
 	UBYTE			inc;
-	STRUCTURE		*psStruct;
 	FACTORY			*psFactory;
 	REPAIR_FACILITY	*psRepair;
 	UDWORD					x, y;
@@ -6403,8 +6395,7 @@ void checkDeliveryPoints(UDWORD version)
 		//will have been called to put in down in the first place
 		if (inc != selectedPlayer)
 		{
-			for (psStruct = apsStructLists[inc]; psStruct != nullptr; psStruct =
-			         psStruct->psNext)
+			for (STRUCTURE* psStruct : apsStructLists[inc])
 			{
 				if (StructIsFactory(psStruct))
 				{
@@ -6660,7 +6651,7 @@ STRUCTURE *findNearestReArmPad(DROID *psDroid, STRUCTURE *psTarget, bool bClear)
 	totallyDist = SDWORD_MAX;
 	psNearest = nullptr;
 	psTotallyClear = nullptr;
-	for (STRUCTURE *psStruct = apsStructLists[psDroid->player]; psStruct; psStruct = psStruct->psNext)
+	for (STRUCTURE *psStruct : apsStructLists[psDroid->player])
 	{
 		if (psStruct->pStructureType->type == REF_REARM_PAD && (!bClear || clearRearmPad(psStruct)))
 		{
@@ -6755,7 +6746,7 @@ bool	structIsDamaged(STRUCTURE *psStruct)
 //returns pointer to the new structure
 STRUCTURE *giftSingleStructure(STRUCTURE *psStructure, UBYTE attackPlayer, bool electronic_warfare)
 {
-	STRUCTURE           *psNewStruct, *psStruct;
+	STRUCTURE           *psNewStruct;
 	DROID               *psCurr;
 	STRUCTURE_STATS     *psType, *psModule;
 	UDWORD              x, y;
@@ -6815,7 +6806,7 @@ STRUCTURE *giftSingleStructure(STRUCTURE *psStructure, UBYTE attackPlayer, bool 
 			}
 
 			//check through the 'attackPlayer' players list of structures to see if any are targetting it
-			for (psStruct = apsStructLists[attackPlayer]; psStruct != nullptr; psStruct = psStruct->psNext)
+			for (STRUCTURE* psStruct : apsStructLists[attackPlayer])
 			{
 				if (psStruct->psTarget[0] == psStructure)
 				{

--- a/src/structure.cpp
+++ b/src/structure.cpp
@@ -5943,7 +5943,7 @@ void hqReward(UBYTE losingPlayer, UBYTE rewardPlayer)
 		}
 
 		//feature
-		for (FEATURE *psFeat = apsFeatureLists[i]; psFeat != nullptr; psFeat = psFeat->psNext)
+		for (FEATURE *psFeat : apsFeatureLists[i])
 		{
 			if (psFeat->visible[losingPlayer])
 			{

--- a/src/structure.cpp
+++ b/src/structure.cpp
@@ -5027,7 +5027,7 @@ void checkForResExtractors(STRUCTURE *psBuilding)
 	typedef std::vector<Derrick> Derricks;
 	Derricks derricks;
 	derricks.reserve(NUM_POWER_MODULES + 1);
-	for (STRUCTURE *currExtractor = apsExtractorLists[psBuilding->player]; currExtractor != nullptr; currExtractor = currExtractor->psNextFunc)
+	for (STRUCTURE *currExtractor : apsExtractorLists[psBuilding->player])
 	{
 		RES_EXTRACTOR *resExtractor = &currExtractor->pFunctionality->resourceExtractor;
 
@@ -5082,7 +5082,7 @@ uint16_t countPlayerUnusedDerricks()
 
 	if (selectedPlayer >= MAX_PLAYERS) { return 0; }
 
-	for (STRUCTURE *psStruct = apsExtractorLists[selectedPlayer]; psStruct; psStruct = psStruct->psNext)
+	for (STRUCTURE *psStruct : apsExtractorLists[selectedPlayer])
 	{
 		if (psStruct->status == SS_BUILT && psStruct->pStructureType->type == REF_RESOURCE_EXTRACTOR)
 		{
@@ -5176,8 +5176,6 @@ adjusts the owning Power Gen so that it can link to a different Res Extractor if
 is available*/
 void releaseResExtractor(STRUCTURE *psRelease)
 {
-	STRUCTURE	*psCurr;
-
 	if (psRelease->pStructureType->type != REF_RESOURCE_EXTRACTOR)
 	{
 		ASSERT(!"invalid structure type", "Invalid structure type");
@@ -5193,7 +5191,7 @@ void releaseResExtractor(STRUCTURE *psRelease)
 	psRelease->pFunctionality->resourceExtractor.psPowerGen = nullptr;
 
 	//there may be spare resource extractors
-	for (psCurr = apsExtractorLists[psRelease->player]; psCurr != nullptr; psCurr = psCurr->psNextFunc)
+	for (STRUCTURE* psCurr : apsExtractorLists[psRelease->player])
 	{
 		//check not connected and power left and built!
 		if (psCurr != psRelease && psCurr->pFunctionality->resourceExtractor.psPowerGen == nullptr && psCurr->status == SS_BUILT)

--- a/src/structure.cpp
+++ b/src/structure.cpp
@@ -2228,22 +2228,26 @@ void assignFactoryCommandDroid(STRUCTURE *psStruct, DROID *psCommander)
 		factoryInc = psFact->psAssemblyPoint->factoryInc;
 
 		auto& flagPosList = apsFlagPosLists[psStruct->player];
-		for (auto it = flagPosList.begin(); it != flagPosList.end(); ++it)
+		FlagPositionList::iterator flagPosIt = flagPosList.begin(), flagPosItNext;
+		while (flagPosIt != flagPosList.end())
 		{
-			if ((*it)->factoryInc == factoryInc && (*it)->factoryType == typeFlag)
+			flagPosItNext = std::next(flagPosIt);
+			FLAG_POSITION* flagPos = *flagPosIt;
+			if (flagPos->factoryInc == factoryInc && flagPos->factoryType == typeFlag)
 			{
-				if (*it != psFact->psAssemblyPoint)
+				if (flagPos != psFact->psAssemblyPoint)
 				{
-					removeFlagPosition(*it);
+					removeFlagPosition(flagPos);
 				}
 				else
 				{
 					// need to keep the assembly point(s) for the factory
 					// but remove it(the primary) from the list so it doesn't get
 					// displayed
-					it = flagPosList.erase(it);
+					flagPosList.erase(flagPosIt);
 				}
 			}
+			flagPosIt = flagPosItNext;
 		}
 		psFact->psCommander = psCommander;
 		syncDebug("Assigned commander %d to factory %d", psCommander->id, psStruct->id);

--- a/src/structure.h
+++ b/src/structure.h
@@ -311,7 +311,7 @@ bool clearRearmPad(const STRUCTURE *psStruct);
 void ensureRearmPadClear(STRUCTURE *psStruct, DROID *psDroid);
 
 // return whether a rearm pad has a vtol on it
-bool vtolOnRearmPad(STRUCTURE *psStruct, DROID *psDroid);
+bool vtolOnRearmPad(const STRUCTURE *psStruct, DROID *psDroid);
 
 /* Just returns true if the structure's present body points aren't as high as the original*/
 bool	structIsDamaged(STRUCTURE *psStruct);
@@ -462,9 +462,9 @@ static inline STRUCTURE const *castStructure(SIMPLE_OBJECT const *psObject)
 	return isStructure(psObject) ? (STRUCTURE const *)psObject : (STRUCTURE const *)nullptr;
 }
 
-static inline int getBuildingResearchPoints(STRUCTURE *psStruct)
+static inline int getBuildingResearchPoints(const STRUCTURE *psStruct)
 {
-	auto &upgrade = psStruct->pStructureType->upgrade[psStruct->player];
+	const auto &upgrade = psStruct->pStructureType->upgrade[psStruct->player];
 	return upgrade.research + upgrade.moduleResearch * psStruct->capacity;
 }
 

--- a/src/template.cpp
+++ b/src/template.cpp
@@ -666,26 +666,27 @@ DROID_TEMPLATE *getTemplateFromMultiPlayerID(UDWORD multiPlayerID)
 /*called when a Template is deleted in the Design screen*/
 void deleteTemplateFromProduction(DROID_TEMPLATE *psTemplate, unsigned player, QUEUE_MODE mode)
 {
-	STRUCTURE   *psStruct;
-	STRUCTURE	*psList;
-
 	ASSERT_OR_RETURN(, psTemplate != nullptr, "Null psTemplate");
 	ASSERT_OR_RETURN(, player < MAX_PLAYERS, "Invalid player: %u", player);
 
 	//see if any factory is currently using the template
 	for (unsigned i = 0; i < 2; ++i)
 	{
-		psList = nullptr;
+		StructureList* psList = nullptr;
 		switch (i)
 		{
 		case 0:
-			psList = apsStructLists[player];
+			psList = &apsStructLists[player];
 			break;
 		case 1:
-			psList = mission.apsStructLists[player];
+			psList = &mission.apsStructLists[player];
 			break;
 		}
-		for (psStruct = psList; psStruct != nullptr; psStruct = psStruct->psNext)
+		if (!psList)
+		{
+			continue;
+		}
+		for (STRUCTURE* psStruct : *psList)
 		{
 			if (StructIsFactory(psStruct))
 			{

--- a/src/transporter.cpp
+++ b/src/transporter.cpp
@@ -1007,6 +1007,7 @@ static void intTransporterAddDroid(UDWORD id)
 			}
 			currID++;
 		}
+		++droidIt;
 	}
 	if (droidIt != transIntDroidList->end())
 	{

--- a/src/visibility.cpp
+++ b/src/visibility.cpp
@@ -633,9 +633,7 @@ STRUCTURE *visGetBlockingWall(const BASE_OBJECT *psViewer, const BASE_OBJECT *ps
 
 		for (player = 0; player < MAX_PLAYERS; player++)
 		{
-			STRUCTURE *psWall;
-
-			for (psWall = apsStructLists[player]; psWall; psWall = psWall->psNext)
+			for (STRUCTURE* psWall : apsStructLists[player])
 			{
 				if (map_coord(psWall->pos) == tile)
 				{
@@ -838,7 +836,7 @@ void processVisibility()
 	updateSpotters();
 	for (int player = 0; player < MAX_PLAYERS; ++player)
 	{
-		BASE_OBJECT *lists[] = {apsDroidLists[player], apsStructLists[player]};
+		BASE_OBJECT *lists[] = {apsDroidLists[player]};
 		unsigned list;
 		for (list = 0; list < sizeof(lists) / sizeof(*lists); ++list)
 		{
@@ -847,6 +845,10 @@ void processVisibility()
 				processVisibilitySelf(psObj);
 			}
 		}
+		for (BASE_OBJECT* psObj : apsStructLists[player])
+		{
+			processVisibilitySelf(psObj);
+		}
 		for (BASE_OBJECT* psObj : apsFeatureLists[player])
 		{
 			processVisibilitySelf(psObj);
@@ -854,7 +856,7 @@ void processVisibility()
 	}
 	for (int player = 0; player < MAX_PLAYERS; ++player)
 	{
-		BASE_OBJECT *lists[] = {apsDroidLists[player], apsStructLists[player]};
+		BASE_OBJECT *lists[] = {apsDroidLists[player]};
 		unsigned list;
 		for (list = 0; list < sizeof(lists) / sizeof(*lists); ++list)
 		{
@@ -862,6 +864,10 @@ void processVisibility()
 			{
 				processVisibilityVision(psObj);
 			}
+		}
+		for (BASE_OBJECT* psObj : apsStructLists[player])
+		{
+			processVisibilityVision(psObj);
 		}
 	}
 	for (BASE_OBJECT *psObj : apsSensorList[0])
@@ -882,7 +888,7 @@ void processVisibility()
 	bool addedMessage = false;
 	for (int player = 0; player < MAX_PLAYERS; ++player)
 	{
-		BASE_OBJECT *lists[] = {apsDroidLists[player], apsStructLists[player]};
+		BASE_OBJECT *lists[] = {apsDroidLists[player]};
 		unsigned list;
 		for (list = 0; list < sizeof(lists) / sizeof(*lists); ++list)
 		{
@@ -890,6 +896,10 @@ void processVisibility()
 			{
 				processVisibilityLevel(psObj, addedMessage);
 			}
+		}
+		for (BASE_OBJECT* psObj : apsStructLists[player])
+		{
+			processVisibilityLevel(psObj, addedMessage);
 		}
 		for (BASE_OBJECT* psObj : apsFeatureLists[player])
 		{

--- a/src/visibility.cpp
+++ b/src/visibility.cpp
@@ -860,11 +860,11 @@ void processVisibility()
 			}
 		}
 	}
-	for (BASE_OBJECT *psObj = apsSensorList[0]; psObj != nullptr; psObj = psObj->psNextFunc)
+	for (BASE_OBJECT *psObj : apsSensorList[0])
 	{
 		if (objRadarDetector(psObj))
 		{
-			for (BASE_OBJECT *psTarget = apsSensorList[0]; psTarget != nullptr; psTarget = psTarget->psNextFunc)
+			for (BASE_OBJECT *psTarget : apsSensorList[0])
 			{
 				if (psObj != psTarget && psTarget->visible[psObj->player] < UBYTE_MAX / 2
 				    && objActiveRadar(psTarget)

--- a/src/visibility.cpp
+++ b/src/visibility.cpp
@@ -838,7 +838,7 @@ void processVisibility()
 	updateSpotters();
 	for (int player = 0; player < MAX_PLAYERS; ++player)
 	{
-		BASE_OBJECT *lists[] = {apsDroidLists[player], apsStructLists[player], apsFeatureLists[player]};
+		BASE_OBJECT *lists[] = {apsDroidLists[player], apsStructLists[player]};
 		unsigned list;
 		for (list = 0; list < sizeof(lists) / sizeof(*lists); ++list)
 		{
@@ -846,6 +846,10 @@ void processVisibility()
 			{
 				processVisibilitySelf(psObj);
 			}
+		}
+		for (BASE_OBJECT* psObj : apsFeatureLists[player])
+		{
+			processVisibilitySelf(psObj);
 		}
 	}
 	for (int player = 0; player < MAX_PLAYERS; ++player)
@@ -878,7 +882,7 @@ void processVisibility()
 	bool addedMessage = false;
 	for (int player = 0; player < MAX_PLAYERS; ++player)
 	{
-		BASE_OBJECT *lists[] = {apsDroidLists[player], apsStructLists[player], apsFeatureLists[player]};
+		BASE_OBJECT *lists[] = {apsDroidLists[player], apsStructLists[player]};
 		unsigned list;
 		for (list = 0; list < sizeof(lists) / sizeof(*lists); ++list)
 		{
@@ -886,6 +890,10 @@ void processVisibility()
 			{
 				processVisibilityLevel(psObj, addedMessage);
 			}
+		}
+		for (BASE_OBJECT* psObj : apsFeatureLists[player])
+		{
+			processVisibilityLevel(psObj, addedMessage);
 		}
 	}
 	if (addedMessage)

--- a/src/visibility.cpp
+++ b/src/visibility.cpp
@@ -836,14 +836,9 @@ void processVisibility()
 	updateSpotters();
 	for (int player = 0; player < MAX_PLAYERS; ++player)
 	{
-		BASE_OBJECT *lists[] = {apsDroidLists[player]};
-		unsigned list;
-		for (list = 0; list < sizeof(lists) / sizeof(*lists); ++list)
+		for (BASE_OBJECT* psObj : apsDroidLists[player])
 		{
-			for (BASE_OBJECT *psObj = lists[list]; psObj != nullptr; psObj = psObj->psNext)
-			{
-				processVisibilitySelf(psObj);
-			}
+			processVisibilitySelf(psObj);
 		}
 		for (BASE_OBJECT* psObj : apsStructLists[player])
 		{
@@ -856,14 +851,9 @@ void processVisibility()
 	}
 	for (int player = 0; player < MAX_PLAYERS; ++player)
 	{
-		BASE_OBJECT *lists[] = {apsDroidLists[player]};
-		unsigned list;
-		for (list = 0; list < sizeof(lists) / sizeof(*lists); ++list)
+		for (BASE_OBJECT* psObj : apsDroidLists[player])
 		{
-			for (BASE_OBJECT *psObj = lists[list]; psObj != nullptr; psObj = psObj->psNext)
-			{
-				processVisibilityVision(psObj);
-			}
+			processVisibilityVision(psObj);
 		}
 		for (BASE_OBJECT* psObj : apsStructLists[player])
 		{
@@ -888,14 +878,9 @@ void processVisibility()
 	bool addedMessage = false;
 	for (int player = 0; player < MAX_PLAYERS; ++player)
 	{
-		BASE_OBJECT *lists[] = {apsDroidLists[player]};
-		unsigned list;
-		for (list = 0; list < sizeof(lists) / sizeof(*lists); ++list)
+		for (BASE_OBJECT* psObj : apsDroidLists[player])
 		{
-			for (BASE_OBJECT *psObj = lists[list]; psObj != nullptr; psObj = psObj->psNext)
-			{
-				processVisibilityLevel(psObj, addedMessage);
-			}
+			processVisibilityLevel(psObj, addedMessage);
 		}
 		for (BASE_OBJECT* psObj : apsStructLists[player])
 		{

--- a/src/visibility.cpp
+++ b/src/visibility.cpp
@@ -860,7 +860,7 @@ void processVisibility()
 			processVisibilityVision(psObj);
 		}
 	}
-	for (BASE_OBJECT *psObj : apsSensorList[0])
+	for (const BASE_OBJECT *psObj : apsSensorList[0])
 	{
 		if (objRadarDetector(psObj))
 		{

--- a/src/warcam.cpp
+++ b/src/warcam.cpp
@@ -136,7 +136,6 @@ void	initWarCam()
 
 static void processLeaderSelection()
 {
-	DROID *psDroid;
 	DROID *psNew = nullptr;
 	UDWORD leaderClass;
 	bool bSuccess;
@@ -184,7 +183,7 @@ static void processLeaderSelection()
 	switch (leaderClass)
 	{
 	case	LEADER_LEFT:
-		for (psDroid = apsDroidLists[selectedPlayer]; psDroid; psDroid = psDroid->psNext)
+		for (DROID* psDroid : apsDroidLists[selectedPlayer])
 		{
 			/* Is it even on the sscreen? */
 			if (DrawnInLastFrame(psDroid->sDisplay.frameNumber) && psDroid->selected && psDroid != trackingCamera.target)
@@ -203,7 +202,7 @@ static void processLeaderSelection()
 		}
 		break;
 	case	LEADER_RIGHT:
-		for (psDroid = apsDroidLists[selectedPlayer]; psDroid; psDroid = psDroid->psNext)
+		for (DROID* psDroid : apsDroidLists[selectedPlayer])
 		{
 			/* Is it even on the sscreen? */
 			if (DrawnInLastFrame(psDroid->sDisplay.frameNumber) && psDroid->selected && psDroid != trackingCamera.target)
@@ -222,7 +221,7 @@ static void processLeaderSelection()
 		}
 		break;
 	case	LEADER_UP:
-		for (psDroid = apsDroidLists[selectedPlayer]; psDroid; psDroid = psDroid->psNext)
+		for (DROID* psDroid : apsDroidLists[selectedPlayer])
 		{
 			/* Is it even on the sscreen? */
 			if (DrawnInLastFrame(psDroid->sDisplay.frameNumber) && psDroid->selected && psDroid != trackingCamera.target)
@@ -241,7 +240,7 @@ static void processLeaderSelection()
 		}
 		break;
 	case	LEADER_DOWN:
-		for (psDroid = apsDroidLists[selectedPlayer]; psDroid; psDroid = psDroid->psNext)
+		for (DROID* psDroid : apsDroidLists[selectedPlayer])
 		{
 			/* Is it even on the sscreen? */
 			if (DrawnInLastFrame(psDroid->sDisplay.frameNumber) && psDroid->selected && psDroid != trackingCamera.target)
@@ -379,15 +378,13 @@ void	setWarCamActive(bool status)
 
 DROID *camFindDroidTarget()
 {
-	DROID	*psDroid;
-
 	if (selectedPlayer >= MAX_PLAYERS)
 	{
 		// Not currently supported when selectedPlayer >= MAX_PLAYERS
 		return nullptr;
 	}
 
-	for (psDroid = apsDroidLists[selectedPlayer]; psDroid; psDroid = psDroid->psNext)
+	for (DROID* psDroid : apsDroidLists[selectedPlayer])
 	{
 		if (psDroid->selected)
 		{
@@ -447,7 +444,6 @@ void	camAlignWithTarget(DROID *psDroid)
 //-----------------------------------------------------------------------------------
 static uint16_t getAverageTrackAngle(unsigned groupNumber, bool bCheckOnScreen)
 {
-	DROID *psDroid;
 	int32_t xTotal = 0, yTotal = 0;
 
 	if (selectedPlayer >= MAX_PLAYERS)
@@ -457,7 +453,7 @@ static uint16_t getAverageTrackAngle(unsigned groupNumber, bool bCheckOnScreen)
 	}
 
 	/* Got thru' all droids */
-	for (psDroid = apsDroidLists[selectedPlayer]; psDroid; psDroid = psDroid->psNext)
+	for (DROID* psDroid : apsDroidLists[selectedPlayer])
 	{
 		/* Is he worth selecting? */
 		if (groupNumber == GROUP_SELECTED ? psDroid->selected : psDroid->group == groupNumber)
@@ -478,8 +474,7 @@ static uint16_t getAverageTrackAngle(unsigned groupNumber, bool bCheckOnScreen)
 static void getTrackingConcerns(SDWORD *x, SDWORD *y, SDWORD *z, UDWORD groupNumber, bool bOnScreen)
 {
 	SDWORD xTotals = 0, yTotals = 0, zTotals = 0;
-	DROID *psDroid;
-	UDWORD count;
+	UDWORD count = 0;
 
 	if (selectedPlayer >= MAX_PLAYERS)
 	{
@@ -487,7 +482,7 @@ static void getTrackingConcerns(SDWORD *x, SDWORD *y, SDWORD *z, UDWORD groupNum
 		return;
 	}
 
-	for (count = 0, psDroid = apsDroidLists[selectedPlayer]; psDroid; psDroid = psDroid->psNext)
+	for (DROID* psDroid : apsDroidLists[selectedPlayer])
 	{
 		if (groupNumber == GROUP_SELECTED ? psDroid->selected : psDroid->group == groupNumber)
 		{

--- a/src/warcam.cpp
+++ b/src/warcam.cpp
@@ -453,7 +453,7 @@ static uint16_t getAverageTrackAngle(unsigned groupNumber, bool bCheckOnScreen)
 	}
 
 	/* Got thru' all droids */
-	for (DROID* psDroid : apsDroidLists[selectedPlayer])
+	for (const DROID* psDroid : apsDroidLists[selectedPlayer])
 	{
 		/* Is he worth selecting? */
 		if (groupNumber == GROUP_SELECTED ? psDroid->selected : psDroid->group == groupNumber)
@@ -482,7 +482,7 @@ static void getTrackingConcerns(SDWORD *x, SDWORD *y, SDWORD *z, UDWORD groupNum
 		return;
 	}
 
-	for (DROID* psDroid : apsDroidLists[selectedPlayer])
+	for (const DROID* psDroid : apsDroidLists[selectedPlayer])
 	{
 		if (groupNumber == GROUP_SELECTED ? psDroid->selected : psDroid->group == groupNumber)
 		{

--- a/src/wzapi.cpp
+++ b/src/wzapi.cpp
@@ -1142,7 +1142,7 @@ std::vector<scr_position> wzapi::enumBlips(WZAPI_PARAMS(int player))
 {
 	SCRIPT_ASSERT_PLAYER({}, context, player);
 	std::vector<scr_position> matches;
-	for (BASE_OBJECT *psSensor = apsSensorList[0]; psSensor; psSensor = psSensor->psNextFunc)
+	for (BASE_OBJECT *psSensor : apsSensorList[0])
 	{
 		if (psSensor->visible[player] > 0 && psSensor->visible[player] < UBYTE_MAX)
 		{

--- a/src/wzapi.cpp
+++ b/src/wzapi.cpp
@@ -1000,7 +1000,7 @@ bool wzapi::structureIdle(WZAPI_PARAMS(const STRUCTURE *psStruct))
 	return ::structureIdle(psStruct);
 }
 
-std::vector<const STRUCTURE *> _enumStruct_fromList(WZAPI_PARAMS(optional<int> _player, optional<wzapi::STRUCTURE_TYPE_or_statsName_string> _structureType, optional<int> _playerFilter), STRUCTURE **psStructLists)
+std::vector<const STRUCTURE *> _enumStruct_fromList(WZAPI_PARAMS(optional<int> _player, optional<wzapi::STRUCTURE_TYPE_or_statsName_string> _structureType, optional<int> _playerFilter), const PerPlayerStructureList& psStructLists)
 {
 	std::vector<const STRUCTURE *> matches;
 	WzString statsName;
@@ -1017,7 +1017,7 @@ std::vector<const STRUCTURE *> _enumStruct_fromList(WZAPI_PARAMS(optional<int> _
 
 	SCRIPT_ASSERT_PLAYER({}, context, player);
 	SCRIPT_ASSERT({}, context, (playerFilter >= 0 && playerFilter < MAX_PLAYERS) || playerFilter == ALL_PLAYERS, "Player filter index out of range: %d", playerFilter);
-	for (STRUCTURE *psStruct = psStructLists[player]; psStruct; psStruct = psStruct->psNext)
+	for (STRUCTURE *psStruct : psStructLists[player])
 	{
 		if ((playerFilter == ALL_PLAYERS || psStruct->visible[playerFilter])
 		    && !psStruct->died
@@ -1170,7 +1170,7 @@ std::vector<const BASE_OBJECT *> wzapi::enumSelected(WZAPI_NO_PARAMS_NO_CONTEXT)
 			matches.push_back(psDroid);
 		}
 	}
-	for (STRUCTURE *psStruct = apsStructLists[selectedPlayer]; psStruct; psStruct = psStruct->psNext)
+	for (STRUCTURE *psStruct : apsStructLists[selectedPlayer])
 	{
 		if (psStruct->selected)
 		{
@@ -3367,11 +3367,11 @@ static void dirtyAllDroids(int player)
 
 static void dirtyAllStructures(int player)
 {
-	for (STRUCTURE *psCurr = apsStructLists[player]; psCurr; psCurr = psCurr->psNext)
+	for (STRUCTURE *psCurr : apsStructLists[player])
 	{
 		psCurr->flags.set(OBJECT_FLAG_DIRTY);
 	}
-	for (STRUCTURE *psCurr = mission.apsStructLists[player]; psCurr; psCurr = psCurr->psNext)
+	for (STRUCTURE *psCurr : mission.apsStructLists[player])
 	{
 		psCurr->flags.set(OBJECT_FLAG_DIRTY);
 	}
@@ -3696,14 +3696,14 @@ bool wzapi::setUpgradeStats(WZAPI_BASE_PARAMS(int player, const std::string& nam
 		case SCRCB_ELW:
 			// Update resistance points for all structures, to avoid making them damaged
 			// FIXME - this is _really_ slow! we could be doing this for dozens of buildings one at a time!
-			for (STRUCTURE *psCurr = apsStructLists[player]; psCurr; psCurr = psCurr->psNext)
+			for (STRUCTURE *psCurr : apsStructLists[player])
 			{
 				if (psStats == psCurr->pStructureType && psStats->upgrade[player].resistance < value)
 				{
 					psCurr->resistance = value;
 				}
 			}
-			for (STRUCTURE *psCurr = mission.apsStructLists[player]; psCurr; psCurr = psCurr->psNext)
+			for (STRUCTURE *psCurr : mission.apsStructLists[player])
 			{
 				if (psStats == psCurr->pStructureType && psStats->upgrade[player].resistance < value)
 				{
@@ -3716,14 +3716,14 @@ bool wzapi::setUpgradeStats(WZAPI_BASE_PARAMS(int player, const std::string& nam
 			// Update body points for all structures, to avoid making them damaged
 			// FIXME - this is _really_ slow! we could be doing this for
 			// dozens of buildings one at a time!
-			for (STRUCTURE *psCurr = apsStructLists[player]; psCurr; psCurr = psCurr->psNext)
+			for (STRUCTURE *psCurr : apsStructLists[player])
 			{
 				if (psStats == psCurr->pStructureType && psStats->upgrade[player].hitpoints < value)
 				{
 					psCurr->body = (psCurr->body * value) / psStats->upgrade[player].hitpoints;
 				}
 			}
-			for (STRUCTURE *psCurr = mission.apsStructLists[player]; psCurr; psCurr = psCurr->psNext)
+			for (STRUCTURE *psCurr : mission.apsStructLists[player])
 			{
 				if (psStats == psCurr->pStructureType && psStats->upgrade[player].hitpoints < value)
 				{

--- a/src/wzapi.cpp
+++ b/src/wzapi.cpp
@@ -1000,7 +1000,7 @@ bool wzapi::structureIdle(WZAPI_PARAMS(const STRUCTURE *psStruct))
 	return ::structureIdle(psStruct);
 }
 
-std::vector<const STRUCTURE *> _enumStruct_fromList(WZAPI_PARAMS(optional<int> _player, optional<wzapi::STRUCTURE_TYPE_or_statsName_string> _structureType, optional<int> _playerFilter), const PerPlayerStructureList& psStructLists)
+std::vector<const STRUCTURE *> _enumStruct_fromList(WZAPI_PARAMS(optional<int> _player, optional<wzapi::STRUCTURE_TYPE_or_statsName_string> _structureType, optional<int> _playerFilter), const PerPlayerStructureLists& psStructLists)
 {
 	std::vector<const STRUCTURE *> matches;
 	WzString statsName;

--- a/src/wzapi.cpp
+++ b/src/wzapi.cpp
@@ -1120,7 +1120,7 @@ std::vector<const FEATURE *> wzapi::enumFeature(WZAPI_PARAMS(int playerFilter, o
 	}
 
 	std::vector<const FEATURE *> matches;
-	for (FEATURE *psFeat : apsFeatureLists[0])
+	for (const FEATURE *psFeat : apsFeatureLists[0])
 	{
 		if ((playerFilter == ALL_PLAYERS || psFeat->visible[playerFilter])
 		    && !psFeat->died
@@ -1142,7 +1142,7 @@ std::vector<scr_position> wzapi::enumBlips(WZAPI_PARAMS(int player))
 {
 	SCRIPT_ASSERT_PLAYER({}, context, player);
 	std::vector<scr_position> matches;
-	for (BASE_OBJECT *psSensor : apsSensorList[0])
+	for (const BASE_OBJECT *psSensor : apsSensorList[0])
 	{
 		if (psSensor->visible[player] > 0 && psSensor->visible[player] < UBYTE_MAX)
 		{
@@ -1965,7 +1965,7 @@ wzapi::returned_nullable_ptr<const FEATURE> wzapi::addFeature(WZAPI_PARAMS(std::
 {
 	int feature = getFeatureStatFromName(WzString::fromUtf8(featureName));
 	FEATURE_STATS *psStats = &asFeatureStats[feature];
-	for (FEATURE *psFeat : apsFeatureLists[0])
+	for (const FEATURE *psFeat : apsFeatureLists[0])
 	{
 		SCRIPT_ASSERT(nullptr, context, map_coord(psFeat->pos.x) != x || map_coord(psFeat->pos.y) != y,
 		              "Building feature on tile already occupied");

--- a/src/wzapi.cpp
+++ b/src/wzapi.cpp
@@ -498,7 +498,7 @@ bool wzapi::cameraTrack(WZAPI_PARAMS(optional<DROID *> _droid))
 		DROID *droid = _droid.value();
 		SCRIPT_ASSERT(false, context, droid, "No valid droid provided");
 		SCRIPT_ASSERT(false, context, selectedPlayer < MAX_PLAYERS, "Invalid selectedPlayer for current client: %" PRIu32 "", selectedPlayer);
-		for (DROID *psDroid = apsDroidLists[selectedPlayer]; psDroid != nullptr; psDroid = psDroid->psNext)
+		for (DROID *psDroid : apsDroidLists[selectedPlayer])
 		{
 			psDroid->selected = psDroid == droid; // select only the target droid
 		}
@@ -1092,7 +1092,7 @@ std::vector<const DROID *> wzapi::enumDroid(WZAPI_PARAMS(optional<int> _player, 
 	}
 	SCRIPT_ASSERT_PLAYER({}, context, player);
 	SCRIPT_ASSERT({}, context, (playerFilter >= 0 && playerFilter < MAX_PLAYERS) || playerFilter == ALL_PLAYERS, "Player filter index out of range: %d", playerFilter);
-	for (DROID *psDroid = apsDroidLists[player]; psDroid; psDroid = psDroid->psNext)
+	for (DROID *psDroid : apsDroidLists[player])
 	{
 		if ((playerFilter == ALL_PLAYERS || psDroid->visible[playerFilter])
 		    && !psDroid->died
@@ -1163,7 +1163,7 @@ std::vector<const BASE_OBJECT *> wzapi::enumSelected(WZAPI_NO_PARAMS_NO_CONTEXT)
 	{
 		return matches;
 	}
-	for (DROID *psDroid = apsDroidLists[selectedPlayer]; psDroid; psDroid = psDroid->psNext)
+	for (DROID *psDroid : apsDroidLists[selectedPlayer])
 	{
 		if (psDroid->selected)
 		{
@@ -2531,17 +2531,14 @@ wzapi::no_return_value wzapi::setReinforcementTime(WZAPI_PARAMS(int _time))
 	{
 		intRemoveTransporterTimer();
 	}
-	DROID* psDroid;
-
 	/* Search for a transport that is idle; if we can't find any, remove the launch button
 	 * since there's no transport to launch */
-	for (psDroid = apsDroidLists[selectedPlayer]; psDroid != nullptr; psDroid = psDroid->psNext)
+	auto droidIt = std::find_if(apsDroidLists[selectedPlayer].begin(), apsDroidLists[selectedPlayer].end(), [](DROID* d)
 	{
-		if (isTransporter(psDroid) && !transporterFlying(psDroid))
-		{
-			break;
-		}
-	}
+		return isTransporter(d) && !transporterFlying(d);
+	});
+	DROID* psDroid = droidIt != apsDroidLists[selectedPlayer].end() ? *droidIt : nullptr;
+
 	// Didn't find an idle transporter, we can remove the launch button
 	if (psDroid == nullptr)
 	{
@@ -3351,15 +3348,15 @@ bool wzapi::transformPlayerToSpectator(WZAPI_PARAMS(int player))
 // flag all droids as requiring update on next frame
 static void dirtyAllDroids(int player)
 {
-	for (DROID *psDroid = apsDroidLists[player]; psDroid != nullptr; psDroid = psDroid->psNext)
+	for (DROID *psDroid : apsDroidLists[player])
 	{
 		psDroid->flags.set(OBJECT_FLAG_DIRTY);
 	}
-	for (DROID *psDroid = mission.apsDroidLists[player]; psDroid != nullptr; psDroid = psDroid->psNext)
+	for (DROID *psDroid : mission.apsDroidLists[player])
 	{
 		psDroid->flags.set(OBJECT_FLAG_DIRTY);
 	}
-	for (DROID *psDroid = apsLimboDroids[player]; psDroid != nullptr; psDroid = psDroid->psNext)
+	for (DROID *psDroid : apsLimboDroids[player])
 	{
 		psDroid->flags.set(OBJECT_FLAG_DIRTY);
 	}

--- a/src/wzapi.cpp
+++ b/src/wzapi.cpp
@@ -1120,7 +1120,7 @@ std::vector<const FEATURE *> wzapi::enumFeature(WZAPI_PARAMS(int playerFilter, o
 	}
 
 	std::vector<const FEATURE *> matches;
-	for (FEATURE *psFeat = apsFeatureLists[0]; psFeat; psFeat = psFeat->psNext)
+	for (FEATURE *psFeat : apsFeatureLists[0])
 	{
 		if ((playerFilter == ALL_PLAYERS || psFeat->visible[playerFilter])
 		    && !psFeat->died
@@ -1965,7 +1965,7 @@ wzapi::returned_nullable_ptr<const FEATURE> wzapi::addFeature(WZAPI_PARAMS(std::
 {
 	int feature = getFeatureStatFromName(WzString::fromUtf8(featureName));
 	FEATURE_STATS *psStats = &asFeatureStats[feature];
-	for (FEATURE *psFeat = apsFeatureLists[0]; psFeat; psFeat = psFeat->psNext)
+	for (FEATURE *psFeat : apsFeatureLists[0])
 	{
 		SCRIPT_ASSERT(nullptr, context, map_coord(psFeat->pos.x) != x || map_coord(psFeat->pos.y) != y,
 		              "Building feature on tile already occupied");


### PR DESCRIPTION
The main goal of this patchset is to remove `psNext` and `psNextFunc` fields from `BASE_OBJECT` (base class for each object type in the game, e.g. droids, structures, features) and move the list organization and iteration logic out of the `BASE_OBJECT` itself to a separate container.

`BASE_OBJECT:s` were previously organized into various global lists as intrusive lists (e.g. the list structure is embedded directly in the pointed-to structures), which are both

 * hard to understand when some advanced pointer juggling techniques are used.
 * overcomplicates memory management and error-prone, e.g. easy to get dangling pointers.
 * pointer links are a part of the base structure itself, meaning that `psNext` and `psNextFunc` still occupy place even if not used.
 * almost impossible to abstract the way the storage is organized, the same iteration loops are sprinkled across many places throughout the code base.

This changeset replaces the following global C-style arrays of intrusive lists from `objmem.cpp` with their C++
non-intrusive counterparts (`std::array<std::list<OBJECT*>, MAX_PLAYERS>`):

 * `apsDroidLists`
 * `apsStructLists`
 * `apsFeatureLists`
 * `apsFlagPosLists`
 * `apsExtractorLists`
 * `apsSensorList`
 * `apsOilList`

There are still some more structures that need to be converted from intrusive C-style lists, but these are the ones most heavily used.

There are also some minor changes along the way to improve const-correctness of various functions (i.e. `const` modifiers are added wherever possible when dealing with aforementioned object lists).

Some unused functions were removed. Among them, there was `intGotoNextDroidType()` from `hci.cpp`, which wasn't even used before the changes and was troublesome to convert, so it was completely removed.

One immediate benefit after the conversion is that now we can clearly differentiate between mutating and non-mutating loops: the ones which don't mutate the list itself (i.e. don't add new elements or remove existing ones) are implemented via range-based `for` loops, and the ones which modify the list, are implemented via `iterator(current) + iterator(next) + while` combination, which works for `std::list` pretty well, because only affected iterators are invalidated upon modification of the list, as required by a conforming `std::list` implementation.

Tests: Campaign missions, transititions between campaigns (e.g. Alpha -> Beta), loading/saving campaign missions saves, also tested on skirmish and MP games.