### PR TITLE
Fix fully armed VTOLs attached to sensors sitting down near former targets

### DIFF
--- a/src/order.cpp
+++ b/src/order.cpp
@@ -1097,7 +1097,6 @@ void orderUpdateDroid(DROID *psDroid)
 				}
 			}
 			else if (isVtolDroid(psDroid) &&
-			        !vtolFull(psDroid) &&
 			         (psDroid->action != DACTION_NONE) &&
 			         (psDroid->action != DACTION_FIRESUPPORT))
 			{


### PR DESCRIPTION
Now they'll go back to a rearming pad/HQ/LZ like the ones that aren't fully armed.

Noticed this a few times when playing on missions like Beta 9 and 10 where I needed to move my Hover Strike sensor away from danger or to repair. Only, to find VTOLS that just came off a rearm pad to attack would continue flying towards the previous target and sit down near it should the sensor not be watching something by that time.