### PR TITLE
Switch droid groups to using `std::list`

### DIFF
--- a/src/ai.cpp
+++ b/src/ai.cpp
@@ -273,7 +273,7 @@ static SDWORD targetAttackWeight(BASE_OBJECT *psTarget, BASE_OBJECT *psAttacker,
 {
 	SDWORD			targetTypeBonus = 0, damageRatio = 0, attackWeight = 0, noTarget = -1;
 	UDWORD			weaponSlot;
-	DROID			*targetDroid = nullptr, *psAttackerDroid = nullptr, *psGroupDroid, *psDroid;
+	DROID			*targetDroid = nullptr, *psAttackerDroid = nullptr, *psDroid;
 	STRUCTURE		*targetStructure = nullptr;
 	WEAPON_EFFECT	weaponEffect;
 	WEAPON_STATS	*attackerWeapon;
@@ -521,7 +521,7 @@ static SDWORD targetAttackWeight(BASE_OBJECT *psTarget, BASE_OBJECT *psAttacker,
 		}
 
 		//fire support - go through all droids assigned to the commander
-		for (psGroupDroid = psAttackerDroid->psGroup->psList; psGroupDroid; psGroupDroid = psGroupDroid->psGrpNext)
+		for (const DROID* psGroupDroid : psAttackerDroid->psGroup->psList)
 		{
 			for (weaponSlot = 0; weaponSlot < psGroupDroid->numWeaps; weaponSlot++)
 			{

--- a/src/droid.cpp
+++ b/src/droid.cpp
@@ -443,14 +443,16 @@ DROID::~DROID()
 		if (psDroid->psGroup)
 		{
 			//free all droids associated with this Transporter
-			for (DROID* psCurr : psDroid->psGroup->psList)
+			mutating_list_iterate(psDroid->psGroup->psList, [psDroid](DROID* psCurr)
 			{
 				if (psCurr == psDroid)
 				{
-					break;
+					return IterationResult::BREAK_ITERATION;
 				}
+				// This will cause each droid to self-remove from `psGroup->psList`.
 				delete psCurr;
-			}
+				return IterationResult::CONTINUE_ITERATION;
+			});
 		}
 	}
 

--- a/src/droiddef.h
+++ b/src/droiddef.h
@@ -115,7 +115,6 @@ struct DROID : public BASE_OBJECT
 	SWORD           resistance;                     ///< used in Electronic Warfare
 	// The group the droid belongs to
 	DROID_GROUP    *psGroup;
-	DROID          *psGrpNext;
 	STRUCTURE      *psBaseStruct;                   ///< a structure that this droid might be associated with. For VTOLs this is the rearming pad
 	// queued orders
 	SDWORD          listSize;                       ///< Gives the number of synchronised orders. Orders from listSize to the real end of the list may not affect game state.

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -5341,7 +5341,7 @@ static bool loadSaveDroidPointers(const WzString &pFileName, PerPlayerDroidLists
 			}
 			if (isTransporter(psDroid) && psDroid->psGroup != nullptr)  // Check for droids in the transporter.
 			{
-				for (DROID *psTrDroid = psDroid->psGroup->psList; psTrDroid != nullptr; psTrDroid = psTrDroid->psGrpNext)
+				for (DROID *psTrDroid : psDroid->psGroup->psList)
 				{
 					if (psTrDroid->id == id)
 					{
@@ -5485,7 +5485,7 @@ static void writeSaveObject(WzConfig &ini, const BASE_OBJECT *psObj)
 	}
 }
 
-static void writeSaveObjectJSON(nlohmann::json &jsonObj, BASE_OBJECT *psObj)
+static void writeSaveObjectJSON(nlohmann::json &jsonObj, const BASE_OBJECT *psObj)
 {
 	jsonObj["id"] = psObj->id;
 	setPlayerJSON(jsonObj, psObj->player);
@@ -5787,7 +5787,7 @@ static bool loadSaveDroid(const char *pFileName, PerPlayerDroidLists& ppsCurrent
 /*
 Writes the linked list of droids for each player to a file
 */
-static nlohmann::json writeDroid(DROID *psCurr, bool onMission, int &counter)
+static nlohmann::json writeDroid(const DROID *psCurr, bool onMission, int &counter)
 {
 	nlohmann::json droidObj = nlohmann::json::object();
 	droidObj["name"] = psCurr->aName;
@@ -5918,7 +5918,7 @@ static bool writeDroidFile(const char *pFileName, const PerPlayerDroidLists& pps
 			{
 				if (psCurr->psGroup)
 				{
-					for (DROID *psTrans = psCurr->psGroup->psList; psTrans != nullptr; psTrans = psTrans->psGrpNext)
+					for (const DROID *psTrans : psCurr->psGroup->psList)
 					{
 						if (psTrans != psCurr)
 						{

--- a/src/group.h
+++ b/src/group.h
@@ -25,6 +25,7 @@
 #define __INCLUDED_SRC_GROUP_H__
 
 #include "orderdef.h"
+#include "objmem.h"
 
 struct BASE_OBJECT;
 struct DROID;
@@ -51,11 +52,11 @@ public: // TODO: c++ design to members become private.
 
 	void setSecondary(SECONDARY_ORDER sec, SECONDARY_STATE state); // set the secondary state for a group of droids
 
-	GROUP_TYPE	type;         // Type from the enum GROUP_TYPE above
-	SWORD		refCount;     // Number of objects in the group. Group is deleted if refCount<=0. Count number of droids+NULL pointers.
-	DROID		*psList;      // List of droids in the group
-	DROID		*psCommander; // The command droid of a command group
-	int		id;	// unique group id
+	GROUP_TYPE type;         // Type from the enum GROUP_TYPE above
+	SWORD      refCount;     // Number of objects in the group. Group is deleted if refCount<=0. Count number of droids+NULL pointers.
+	DroidList  psList;       // List of droids in the group
+	DROID      *psCommander; // The command droid of a command group
+	int        id;           // unique group id
 };
 
 // initialise the group system

--- a/src/loop.cpp
+++ b/src/loop.cpp
@@ -897,8 +897,6 @@ void adjustDroidCount(DROID *droid, int delta) {
 // Increase counts of droids in a transporter
 void droidCountsInTransporter(DROID *droid, int player)
 {
-	DROID *psDroid = nullptr;
-
 	if (!isTransporter(droid) || droid->psGroup == nullptr)
 	{
 		return;
@@ -907,8 +905,12 @@ void droidCountsInTransporter(DROID *droid, int player)
 	numTransporterDroids[player] += droid->psGroup->refCount - 1;
 
 	// and count the units inside it...
-	for (psDroid = droid->psGroup->psList; psDroid != nullptr && psDroid != droid; psDroid = psDroid->psGrpNext)
+	for (DROID* psDroid : droid->psGroup->psList)
 	{
+		if (psDroid == droid)
+		{
+			break;
+		}
 		if (psDroid->droidType == DROID_CYBORG_CONSTRUCT || psDroid->droidType == DROID_CONSTRUCT)
 		{
 			numConstructorDroids[player] += 1;

--- a/src/multibot.cpp
+++ b/src/multibot.cpp
@@ -243,7 +243,6 @@ bool sendDroidDisembark(DROID const *psTransporter, DROID const *psDroid)
 bool recvDroidDisEmbark(NETQUEUE queue)
 {
 	DROID *psFoundDroid = nullptr, *psTransporterDroid = nullptr;
-	DROID *psCheckDroid = nullptr;
 
 	NETbeginDecode(queue, GAME_DROIDDISEMBARK);
 	{
@@ -270,17 +269,18 @@ bool recvDroidDisEmbark(NETQUEUE queue)
 			return false;
 		}
 		// we need to find the droid *in* the transporter
-		psCheckDroid = (psTransporterDroid->psGroup != nullptr) ? psTransporterDroid->psGroup->psList : nullptr;
-		while (psCheckDroid)
+		if (psTransporterDroid->psGroup)
 		{
-			// is this the one we want?
-			if (psCheckDroid->id == droidID)
+			const auto& groupList = psTransporterDroid->psGroup->psList;
+			auto it = std::find_if(groupList.begin(), groupList.end(),
+				[droidID](DROID* d)
+				{
+					return d->id == droidID;
+				});
+			if (it != groupList.end())
 			{
-				psFoundDroid = psCheckDroid;
-				break;
+				psFoundDroid = *it;
 			}
-			// not found, so check next one in *group*
-			psCheckDroid = psCheckDroid->psGrpNext;
 		}
 		// don't continue if we couldn't find it.
 		if (!psFoundDroid)

--- a/src/objmem.cpp
+++ b/src/objmem.cpp
@@ -708,10 +708,10 @@ static BASE_OBJECT* getBaseObjFromDroidId(const DroidList& list, unsigned id)
 			return psObj;
 		}
 		// if transporter check any droids in the grp
-		if ((psObj->type == OBJ_DROID) && isTransporter((DROID*)psObj))
+		if ((psObj->type == OBJ_DROID) && isTransporter(psObj))
 		{
-			ASSERT_OR_RETURN(nullptr, ((DROID*)psObj)->psGroup != nullptr, "Transporter has null group?");
-			for (DROID* psTrans = ((DROID*)psObj)->psGroup->psList; psTrans != nullptr; psTrans = psTrans->psGrpNext)
+			ASSERT_OR_RETURN(nullptr, psObj->psGroup != nullptr, "Transporter has null group?");
+			for (DROID* psTrans : psObj->psGroup->psList)
 			{
 				if (psTrans->id == id)
 				{
@@ -915,14 +915,9 @@ void objCount(int *droids, int *structures, int *features)
 		for (const DROID *psDroid : apsDroidLists[i])
 		{
 			(*droids)++;
-			if (isTransporter(psDroid) && psDroid->psGroup && psDroid->psGroup->psList)
+			if (isTransporter(psDroid) && psDroid->psGroup && !psDroid->psGroup->psList.empty())
 			{
-				const DROID *psTrans = psDroid->psGroup->psList;
-
-				for (psTrans = psTrans->psGrpNext; psTrans != nullptr; psTrans = psTrans->psGrpNext)
-				{
-					(*droids)++;
-				}
+				*droids += psDroid->psGroup->psList.size();
 			}
 		}
 

--- a/src/research.cpp
+++ b/src/research.cpp
@@ -1596,12 +1596,9 @@ void replaceDroidComponent(DroidList& pList, UDWORD oldType, UDWORD oldCompInc,
 void replaceTransDroidComponents(DROID *psTransporter, UDWORD oldType,
                                  UDWORD oldCompInc, UDWORD newCompInc)
 {
-	DROID       *psCurr;
-
 	ASSERT(isTransporter(psTransporter), "invalid unit type");
 
-	for (psCurr = psTransporter->psGroup->psList; psCurr != nullptr; psCurr =
-	         psCurr->psGrpNext)
+	for (DROID* psCurr : psTransporter->psGroup->psList)
 	{
 		if (psCurr != psTransporter)
 		{

--- a/src/scores.cpp
+++ b/src/scores.cpp
@@ -312,7 +312,7 @@ END_GAME_STATS_DATA	collectEndGameStatsData()
 			{
 				if (isTransporter(psDroid))
 				{
-					for (DROID *psCurr = psDroid->psGroup->psList; psCurr != nullptr; psCurr = psCurr->psGrpNext)
+					for (DROID *psCurr : psDroid->psGroup->psList)
 					{
 						if (psCurr != psDroid)
 						{

--- a/src/wzapi.cpp
+++ b/src/wzapi.cpp
@@ -2281,8 +2281,7 @@ std::vector<const DROID *> wzapi::enumCargo(WZAPI_PARAMS(const DROID *psDroid))
 	std::vector<const DROID *> result;
 	SCRIPT_ASSERT({}, context, psDroid->psGroup, "Droid is not assigned to a group");
 	result.reserve(psDroid->psGroup->getNumMembers());
-	int i = 0;
-	for (DROID *psCurr = psDroid->psGroup->psList; psCurr; psCurr = psCurr->psGrpNext, i++)
+	for (const DROID *psCurr : psDroid->psGroup->psList)
 	{
 		if (psDroid != psCurr)
 		{


### PR DESCRIPTION
Remove `psGrpNext` from `DROID` class, add
`DroidList` field to the `DROID_GROUP` class instead.

Introduce a utility function `mutating_list_iterate` in `objmem.h` which is a for-each-style algorithm
to work with `std::list`, which can cope with
invalidation of the current iterator (this can come handy in cases where we traverse the group list and remove/add from/to the same group list along the way).

"mutating" word here clearly denotes that this loop may modify the list, which will be traversed.