### PR TITLE
Reduce NVTX dependency and add more probes

### DIFF
--- a/3rdparty/CMakeLists.txt
+++ b/3rdparty/CMakeLists.txt
@@ -206,6 +206,14 @@ if (WZ_ENABLE_BASIS_UNIVERSAL)
 endif(WZ_ENABLE_BASIS_UNIVERSAL)
 
 if (WZ_PROFILING_NVTX)
-	find_package(CUDAToolkit REQUIRED VERSION 5.0)
+	include(FetchContent)
+	FetchContent_Declare(
+	  nvtx
+	  GIT_REPOSITORY https://github.com/NVIDIA/NVTX.git
+	  GIT_TAG        a1ceb0677f67371ed29a2b1c022794f077db5fe7
+	)
+
+	FetchContent_MakeAvailable(nvtx)
 	set(PROFILING_NVTX_INCLUDE ${CUDAToolkit_INCLUDE_DIRS} PARENT_SCOPE)
+
 endif ()

--- a/lib/framework/macros.h
+++ b/lib/framework/macros.h
@@ -23,8 +23,13 @@
 #ifndef MACROS_H
 #define MACROS_H
 
+#ifndef MIN
 #define MIN(a, b) (((a) < (b)) ? (a) : (b))
+#endif
+
+#ifndef MAX
 #define MAX(a, b) (((a) > (b)) ? (a) : (b))
+#endif
 
 #define ABSDIF(a,b) ((a)>(b) ? (a)-(b) : (b)-(a))
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -125,7 +125,7 @@ target_link_libraries(warzone2100 SQLite::SQLite3)
 target_link_libraries(warzone2100 SQLiteCpp)
 
 if (WZ_PROFILING_NVTX)
-	target_include_directories(warzone2100 PRIVATE ${PROFILING_NVTX_INCLUDE})
+	target_link_libraries(warzone2100 nvtx3-cpp)
 endif()
 
 set(_curl_gnutls_thread_safe_fix FALSE)

--- a/src/advvis.cpp
+++ b/src/advvis.cpp
@@ -26,6 +26,7 @@
 #include "lib/framework/frame.h"
 
 #include "advvis.h"
+#include "profiling.h"
 #include "map.h"
 
 // ------------------------------------------------------------------------------------
@@ -53,6 +54,7 @@ inline float getTileIllumination(const MAPTILE *psTile)
 // ------------------------------------------------------------------------------------
 void	avUpdateTiles()
 {
+	WZ_PROFILE_SCOPE(avUpdateTiles);
 	const int len = mapHeight * mapWidth;
 	const int playermask = 1 << selectedPlayer;
 	UDWORD i = 0;

--- a/src/atmos.cpp
+++ b/src/atmos.cpp
@@ -33,6 +33,7 @@
 #include "loop.h"
 #include "map.h"
 #include "miscimd.h"
+#include "profiling.h"
 #include "lib/gamelib/gtime.h"
 #include <cmath>
 
@@ -247,6 +248,7 @@ static void atmosAddParticle(const Vector3f &pos, AP_TYPE type)
 /* Move the particles */
 void atmosUpdateSystem()
 {
+	WZ_PROFILE_SCOPE(atmosUpdateSystem);
 	UDWORD	i;
 	UDWORD	numberToAdd;
 	Vector3f pos;
@@ -324,6 +326,7 @@ static inline void renderParticleInternal(ATPART *psPart, const glm::mat4 &viewM
 
 void atmosDrawParticles(const glm::mat4 &viewMatrix, const glm::mat4 &perspectiveViewMatrix)
 {
+	WZ_PROFILE_SCOPE(atmosDrawParticles);
 	UDWORD	i;
 
 	if (weather == WT_NONE)

--- a/src/bucket3d.cpp
+++ b/src/bucket3d.cpp
@@ -34,6 +34,7 @@
 #include "display3d.h"
 #include "effects.h"
 #include "miscimd.h"
+#include "profiling.h"
 
 #include <algorithm>
 
@@ -384,6 +385,7 @@ void bucketAddTypeToList(RENDER_TYPE objectType, void *pObject, const glm::mat4 
 /* render Objects in list */
 void bucketRenderCurrentList(const glm::mat4 &viewMatrix, const glm::mat4 &perspectiveViewMatrix)
 {
+	WZ_PROFILE_SCOPE(bucketRenderCurrentList);
 	std::sort(bucketArray.begin(), bucketArray.end());
 
 	for (auto thisTag = bucketArray.cbegin(); thisTag != bucketArray.cend(); ++thisTag)

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -31,6 +31,7 @@
 #include "lib/ivis_opengl/pietypes.h"
 #include "lib/framework/fixedpoint.h"
 #include "lib/framework/wzapp.h"
+#include "profiling.h"
 
 #include "action.h"
 #include "display.h"

--- a/src/effects.cpp
+++ b/src/effects.cpp
@@ -69,6 +69,7 @@
 
 #include "multiplay.h"
 #include "component.h"
+#include "profiling.h"
 
 #ifndef GLM_ENABLE_EXPERIMENTAL
 	#define GLM_ENABLE_EXPERIMENTAL
@@ -475,6 +476,7 @@ void addEffect(const Vector3i *pos, EFFECT_GROUP group, EFFECT_TYPE type, bool s
 /* Calls all the update functions for each different currently active effect */
 void processEffects(const glm::mat4 &perspectiveViewMatrix)
 {
+	WZ_PROFILE_SCOPE(processEffects);
 	for (auto it = activeList.begin(); it != activeList.end(); )
 	{
 		EFFECT *psEffect = *it;

--- a/src/profiling.cpp
+++ b/src/profiling.cpp
@@ -25,10 +25,14 @@
 #include <string>
 
 #ifdef WZ_PROFILING_NVTX
-#pragma warning( push )
-#pragma warning( disable : 4191 )
+#if defined( _MSC_VER )
+#  pragma warning( push )
+#  pragma warning( disable : 4191 )
+#endif
 #include <nvtx3/nvToolsExt.h>
-#pragma warning( pop )
+#if defined( _MSC_VER )
+#  pragma warning( pop )
+#endif
 #endif
 
 #ifdef WZ_PROFILING_VTUNE

--- a/src/profiling.cpp
+++ b/src/profiling.cpp
@@ -25,7 +25,10 @@
 #include <string>
 
 #ifdef WZ_PROFILING_NVTX
+#pragma warning( push )
+#pragma warning( disable : 4191 )
 #include <nvtx3/nvToolsExt.h>
+#pragma warning( pop )
 #endif
 
 #ifdef WZ_PROFILING_VTUNE

--- a/src/shadowcascades.cpp
+++ b/src/shadowcascades.cpp
@@ -46,6 +46,7 @@
 
 #include "shadowcascades.h"
 #include "display3d.h"
+#include "profiling.h"
 #include "lib/framework/fixedpoint.h"
 #include "lib/ivis_opengl/piematrix.h"
 
@@ -59,6 +60,7 @@ float cascadeSplitLambda = 0.3f;
 
 void calculateShadowCascades(const iView *player, float terrainDistance, const glm::mat4& baseViewMatrix, const glm::vec3& lightInvDir, size_t SHADOW_MAP_CASCADE_COUNT, std::vector<Cascade>& output)
 {
+	WZ_PROFILE_SCOPE(calculateShadowCascades);
 	output.clear();
 	output.resize(SHADOW_MAP_CASCADE_COUNT);
 

--- a/src/terrain.cpp
+++ b/src/terrain.cpp
@@ -59,6 +59,7 @@
 #include "hci.h"
 #include "loop.h"
 #include "wzcrashhandlingproviders.h"
+#include "profiling.h"
 
 #include <cstdint>
 
@@ -1975,6 +1976,7 @@ static void drawTerrainCombined(const glm::mat4 &ModelViewProjection, const glm:
 
 void perFrameTerrainUpdates()
 {
+	WZ_PROFILE_SCOPE(perFrameTerrainUpdates);
 	///////////////////////////////////
 	// set up the lightmap texture
 
@@ -2014,6 +2016,7 @@ void drawTerrainDepthOnly(const glm::mat4 &mvp)
  */
 void drawTerrain(const glm::mat4 &mvp, const glm::mat4& viewMatrix, const Vector3f &cameraPos, const Vector3f &sunPos, const ShadowCascadesInfo& shadowCascades)
 {
+	WZ_PROFILE_SCOPE(drawTerrain);
 	const glm::vec4& paramsXLight = lightmapValues.paramsXLight;
 	const glm::vec4& paramsYLight = lightmapValues.paramsYLight;
 	const glm::mat4& lightMatrix = lightmapValues.lightMatrix;


### PR DESCRIPTION
This PR uses FetchContent() feature in cmake to download nvtx lib only if the corresponding flag is passed to cmake (so there is no change at all in case the option is disabled) ; this way there is no need to download Cuda Toolkit.
This should work on all platform with an nvidia card (eg windows and linux).

Also adds some extra probe to understand where we spend time in the drawTiles part (which is the function where almost everything happen.

## Screenshot
On my machine (intel i7,  9th gen) here is a profiling at the beginning of the first beta mission :
![image](https://github.com/Warzone2100/warzone2100/assets/6413475/9f58430c-2fc0-41f9-9036-c697ac26e805)

Note that the gameloop takes 16ms because I have a 60hz display

