### PR TITLE
Convert more C-style lists to `std::list`

### DIFF
--- a/src/display3d.cpp
+++ b/src/display3d.cpp
@@ -2284,7 +2284,7 @@ static void displayProximityMsgs(const glm::mat4& viewMatrix, const glm::mat4 &p
 	if (selectedPlayer >= MAX_PLAYERS) { return; /* no-op */ }
 
 	/* Go through all the proximity Displays*/
-	for (PROXIMITY_DISPLAY *psProxDisp = apsProxDisp[selectedPlayer]; psProxDisp != nullptr; psProxDisp = psProxDisp->psNext)
+	for (PROXIMITY_DISPLAY* psProxDisp : apsProxDisp[selectedPlayer])
 	{
 		if (!(psProxDisp->psMessage->read))
 		{

--- a/src/feature.cpp
+++ b/src/feature.cpp
@@ -73,7 +73,7 @@ bool loadFeatureStats(WzConfig &ini)
 	{
 		ini.beginGroup(list[i]);
 		asFeatureStats.emplace_back(STAT_FEATURE + i);
-		FEATURE_STATS& p = asFeatureStats.at(i);
+		FEATURE_STATS& p = asFeatureStats[i];
 		p.name = ini.string(WzString::fromUtf8("name"));
 		p.id = list[i];
 		WzString subType = ini.value("type").toWzString();

--- a/src/feature.h
+++ b/src/feature.h
@@ -28,8 +28,7 @@
 #include "lib/framework/wzconfig.h"
 
 /* The statistics for the features */
-extern FEATURE_STATS	*asFeatureStats;
-extern UDWORD			numFeatureStats;
+extern std::vector<FEATURE_STATS> asFeatureStats;
 
 //Value is stored for easy access to this feature in destroyDroid()/destroyStruct()
 extern FEATURE_STATS *oilResFeature;

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -5330,18 +5330,16 @@ static bool loadSaveDroidPointers(const WzString &pFileName, PerPlayerDroidLists
 			continue; // special hack for campaign missions, cannot have targets
 		}
 
-		DroidList::iterator droidIt = (*ppsCurrentDroidLists)[player].begin(), droidItNext;
-		while (droidIt != (*ppsCurrentDroidLists)[player].end())
+		for (DROID* d : (*ppsCurrentDroidLists)[player])
 		{
-			droidItNext = std::next(droidIt);
-			psDroid = *droidIt;
-			if (psDroid->id == id)
+			if (d->id == id)
 			{
+				psDroid = d;
 				break;
 			}
-			if (isTransporter(psDroid) && psDroid->psGroup != nullptr)  // Check for droids in the transporter.
+			if (isTransporter(d) && d->psGroup != nullptr)  // Check for droids in the transporter.
 			{
-				for (DROID *psTrDroid : psDroid->psGroup->psList)
+				for (DROID *psTrDroid : d->psGroup->psList)
 				{
 					if (psTrDroid->id == id)
 					{
@@ -5350,7 +5348,6 @@ static bool loadSaveDroidPointers(const WzString &pFileName, PerPlayerDroidLists
 					}
 				}
 			}
-			droidIt = droidItNext;
 		}
 foundDroid:
 		if (!psDroid)

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2537,7 +2537,7 @@ bool loadGame(const char *pGameToLoad, bool keepObjects, bool freeMem, bool User
 			apsFeatureLists[player].clear();
 			apsFlagPosLists[player].clear();
 			//clear all the messages?
-			apsProxDisp[player] = nullptr;
+			apsProxDisp[player].clear();
 			apsSensorList[0].clear();
 			apsExtractorLists[player].clear();
 		}
@@ -7712,16 +7712,12 @@ static bool writeMessageFile(const char *pFileName)
 			if (psMessage->type == MSG_PROXIMITY)
 			{
 				//get the matching proximity message
-				PROXIMITY_DISPLAY *psProx = nullptr;
-				for (psProx = apsProxDisp[player]; psProx != nullptr; psProx = psProx->psNext)
+				auto psProxIt = std::find_if(apsProxDisp[player].begin(), apsProxDisp[player].end(), [psMessage](PROXIMITY_DISPLAY* psProx)
 				{
-					//compare the pointers
-					if (psProx->psMessage == psMessage)
-					{
-						break;
-					}
-				}
-				ASSERT(psProx != nullptr, "Save message; proximity display not found for message");
+					return psProx->psMessage == psMessage; //compare the pointers
+				});
+				ASSERT(psProxIt != apsProxDisp[player].end(), "Save message; proximity display not found for message");
+				PROXIMITY_DISPLAY* psProx = *psProxIt;
 				if (psProx && psProx->type == POS_PROXDATA)
 				{
 					//message has viewdata so store the name

--- a/src/hci.cpp
+++ b/src/hci.cpp
@@ -1272,7 +1272,7 @@ void intOpenDebugMenu(OBJECT_TYPE id)
 	case OBJ_FEATURE:
 		for (unsigned i = 0, end = std::min<unsigned>(asFeatureStats.size(), MAXFEATURES); i < end; ++i)
 		{
-			apsFeatureList[i] = &asFeatureStats.at(i);
+			apsFeatureList[i] = &asFeatureStats[i];
 		}
 		ppsStatsList = (BASE_STATS **)apsFeatureList;
 		intAddDebugStatsForm(ppsStatsList, std::min<unsigned>(asFeatureStats.size(), MAXFEATURES));

--- a/src/hci.cpp
+++ b/src/hci.cpp
@@ -1270,12 +1270,12 @@ void intOpenDebugMenu(OBJECT_TYPE id)
 		editPosMode = IED_NOPOS;
 		break;
 	case OBJ_FEATURE:
-		for (unsigned i = 0; i < std::min<unsigned>(numFeatureStats, MAXFEATURES); ++i)
+		for (unsigned i = 0, end = std::min<unsigned>(asFeatureStats.size(), MAXFEATURES); i < end; ++i)
 		{
-			apsFeatureList[i] = asFeatureStats + i;
+			apsFeatureList[i] = &asFeatureStats.at(i);
 		}
 		ppsStatsList = (BASE_STATS **)apsFeatureList;
-		intAddDebugStatsForm(ppsStatsList, std::min<unsigned>(numFeatureStats, MAXFEATURES));
+		intAddDebugStatsForm(ppsStatsList, std::min<unsigned>(asFeatureStats.size(), MAXFEATURES));
 		intMode = INT_EDITSTAT;
 		editPosMode = IED_NOPOS;
 		break;

--- a/src/hci.cpp
+++ b/src/hci.cpp
@@ -1300,7 +1300,6 @@ static void intProcessEditStats(UDWORD id)
 			debugMenuDroidDeliveryPoint.factoryInc = 0;
 			debugMenuDroidDeliveryPoint.player = selectedPlayer;
 			debugMenuDroidDeliveryPoint.selected = false;
-			debugMenuDroidDeliveryPoint.psNext = nullptr;
 			startDeliveryPosition(&debugMenuDroidDeliveryPoint);
 		}
 		else

--- a/src/intelmap.cpp
+++ b/src/intelmap.cpp
@@ -539,7 +539,7 @@ void W_INTELLIGENCEOVERLAY_FORM::initialize(bool _playCurrent, bool animate)
 		/* Add the message buttons */
 
 		//add each button
-		for (MESSAGE *psMessage = apsMessages[selectedPlayer]; psMessage != nullptr; psMessage = psMessage->psNext)
+		for (MESSAGE *psMessage : apsMessages[selectedPlayer])
 		{
 			/*if (psMessage->type == MSG_TUTORIAL)
 			{
@@ -901,22 +901,20 @@ static void StartMessageSequences(MESSAGE *psMessage, bool Start)
 
 static void intCleanUpIntelMap()
 {
-	MESSAGE		*psMessage, *psNext;
 	bool removedAMessage = false;
 
 	if (selectedPlayer < MAX_PLAYERS)
 	{
 		//remove any research messages that have been read
-		for (psMessage = apsMessages[selectedPlayer]; psMessage != nullptr; psMessage =
-				 psNext)
+		mutating_list_iterate(apsMessages[selectedPlayer], [&removedAMessage](MESSAGE* psMessage)
 		{
-			psNext = psMessage->psNext;
 			if (psMessage->type == MSG_RESEARCH && psMessage->read)
 			{
 				removeMessage(psMessage, selectedPlayer);
 				removedAMessage = true;
 			}
-		}
+			return IterationResult::CONTINUE_ITERATION;
+		});
 	}
 	if (removedAMessage)
 	{
@@ -1205,20 +1203,16 @@ void addVideoText(SEQ_DISPLAY *psSeqDisplay, UDWORD sequence)
 /*sets psCurrentMsg for the Intelligence screen*/
 void setCurrentMsg()
 {
-	MESSAGE *psMsg, *psLastMsg;
-
 	ASSERT_OR_RETURN(, selectedPlayer < MAX_PLAYERS, "Unsupported selectedPlayer: %" PRIu32 "", selectedPlayer);
 
-	psLastMsg = nullptr;
-	for (psMsg = apsMessages[selectedPlayer]; psMsg != nullptr; psMsg =
-	         psMsg->psNext)
+	for (auto it = apsMessages[selectedPlayer].rbegin(), end = apsMessages[selectedPlayer].rend(); it != end; ++it)
 	{
-		if (psMsg->type != MSG_PROXIMITY)
+		if ((*it)->type != MSG_PROXIMITY)
 		{
-			psLastMsg = psMsg;
+			psCurrentMsg = *it;
+			return;
 		}
 	}
-	psCurrentMsg = psLastMsg;
 }
 
 /*sets which states need to be paused when the intelligence screen is up*/

--- a/src/loop.cpp
+++ b/src/loop.cpp
@@ -542,40 +542,28 @@ static void gameStateUpdate()
 		//update the current power available for a player
 		updatePlayerPower(i);
 
-		DroidList::iterator droidIt = apsDroidLists[i].begin(), droidItNext;
-		while (droidIt != apsDroidLists[i].end())
+		mutating_list_iterate(apsDroidLists[i], [](DROID* d)
 		{
-			// Copy the next pointer - not 100% sure if the droid could get destroyed but this covers us anyway
-			droidItNext = std::next(droidIt);
-			droidUpdate(*droidIt);
-			droidIt = droidItNext;
-		}
+			droidUpdate(d);
+			return IterationResult::CONTINUE_ITERATION;
+		});
+		mutating_list_iterate(mission.apsDroidLists[i], [](DROID* d)
+		{
+			missionDroidUpdate(d);
+			return IterationResult::CONTINUE_ITERATION;
+		});
 
-		droidIt = mission.apsDroidLists[i].begin();
-		while (droidIt != mission.apsDroidLists[i].end())
+		// FIXME: These for-loops are code duplication
+		mutating_list_iterate(apsStructLists[i], [](STRUCTURE* s)
 		{
-			/* Copy the next pointer - not 100% sure if the droid could
-			get destroyed but this covers us anyway */
-			droidItNext = std::next(droidIt);
-			missionDroidUpdate(*droidIt);
-			droidIt = droidItNext;
-		}
-
-		// FIXME: These for-loops are code duplicationo
-		StructureList::iterator structIt = apsStructLists[i].begin(), structItNext;
-		while (structIt != apsStructLists[i].end())
+			structureUpdate(s, false);
+			return IterationResult::CONTINUE_ITERATION;
+		});
+		mutating_list_iterate(mission.apsStructLists[i], [](STRUCTURE* s)
 		{
-			structItNext = std::next(structIt);
-			structureUpdate(*structIt, false);
-			structIt = structItNext;
-		}
-		structIt = mission.apsStructLists[i].begin();
-		while (structIt != mission.apsStructLists[i].end())
-		{
-			structItNext = std::next(structIt);
-			structureUpdate(*structIt, true); // update for mission
-			structIt = structItNext;
-		}
+			structureUpdate(s, true); // update for mission
+			return IterationResult::CONTINUE_ITERATION;
+		});
 	}
 
 	missionTimerUpdate();

--- a/src/message.h
+++ b/src/message.h
@@ -32,7 +32,9 @@
 #define NO_AUDIO_MSG		-1
 
 /** The lists of messages allocated. */
-extern MESSAGE		*apsMessages[MAX_PLAYERS];
+using PerPlayerMessageLists = PerPlayerObjectLists<MESSAGE, MAX_PLAYERS>;
+using MessageList = typename PerPlayerMessageLists::value_type;
+extern PerPlayerMessageLists apsMessages;
 
 /** The IMD to use for the proximity messages. */
 extern iIMDBaseShape	*pProximityMsgIMD;
@@ -79,7 +81,7 @@ VIEWDATA *getViewData(const WzString &name);
 std::vector<WzString> getViewDataKeys();
 
 // Get rid of mission objectives
-void releaseAllFlicMessages(MESSAGE *list[]);
+void releaseAllFlicMessages(PerPlayerMessageLists& list);
 
 /** Release the viewdata memory. */
 void viewDataShutDown(const char *fileName);

--- a/src/message.h
+++ b/src/message.h
@@ -27,6 +27,7 @@
 #include "structure.h"
 #include "messagedef.h"
 #include "lib/framework/wzstring.h"
+#include "objmem.h"
 
 #define NO_AUDIO_MSG		-1
 
@@ -37,7 +38,9 @@ extern MESSAGE		*apsMessages[MAX_PLAYERS];
 extern iIMDBaseShape	*pProximityMsgIMD;
 
 /** The list of proximity displays allocated. */
-extern PROXIMITY_DISPLAY *apsProxDisp[MAX_PLAYERS];
+using PerPlayerProximityDisplayLists = PerPlayerObjectLists<PROXIMITY_DISPLAY, MAX_PLAYERS>;
+using ProximityDisplayList = typename PerPlayerProximityDisplayLists::value_type;
+extern PerPlayerProximityDisplayLists apsProxDisp;
 
 extern bool releaseObjectives;
 

--- a/src/messagedef.h
+++ b/src/messagedef.h
@@ -138,7 +138,6 @@ struct PROXIMITY_DISPLAY : public OBJECT_POSITION
 	UDWORD             timeLastDrawn = 0;     // stores the time the 'button' was last drawn for animation
 	UDWORD             strobe = 0;            // id of image last used
 	UDWORD             buttonID = 0;          // id of the button for the interface
-	PROXIMITY_DISPLAY  *psNext = nullptr;      // pointer to the next in the list
 };
 
 #endif // __INCLUDED_MESSAGEDEF_H__

--- a/src/messagedef.h
+++ b/src/messagedef.h
@@ -127,8 +127,6 @@ struct MESSAGE
 	bool            read = false;                           // flag to indicate whether message has been read
 	UDWORD		player;                                 // which player this message belongs to
 	MSG_DATA_TYPE	dataType;
-
-	MESSAGE         *psNext = nullptr;                       // pointer to the next in the list
 };
 
 //used to display the proximity messages

--- a/src/multigifts.cpp
+++ b/src/multigifts.cpp
@@ -729,8 +729,8 @@ void  technologyGiveAway(const STRUCTURE *pS)
 	}
 
 	int featureIndex;
-	for (featureIndex = 0; featureIndex < numFeatureStats && asFeatureStats[featureIndex].subType != FEAT_GEN_ARTE; ++featureIndex) {}
-	if (featureIndex >= numFeatureStats)
+	for (featureIndex = 0; featureIndex < asFeatureStats.size() && asFeatureStats[featureIndex].subType != FEAT_GEN_ARTE; ++featureIndex) {}
+	if (featureIndex >= asFeatureStats.size())
 	{
 		debug(LOG_WARNING, "No artefact feature!");
 		return;
@@ -774,7 +774,6 @@ void sendMultiPlayerFeature(uint32_t ref, uint32_t x, uint32_t y, uint32_t id)
 void recvMultiPlayerFeature(NETQUEUE queue)
 {
 	uint32_t ref = 0xff, x = 0, y = 0, id = 0;
-	unsigned int i;
 
 	NETbeginDecode(queue, GAME_DEBUG_ADD_FEATURE);
 	{
@@ -793,7 +792,7 @@ void recvMultiPlayerFeature(NETQUEUE queue)
 	}
 
 	// Find the feature stats list that contains the feature type we want to build
-	for (i = 0; i < numFeatureStats; ++i)
+	for (size_t i = 0, end = asFeatureStats.size(); i < end; ++i)
 	{
 		// If we found the correct feature type
 		if (asFeatureStats[i].ref == ref)

--- a/src/multilimit.cpp
+++ b/src/multilimit.cpp
@@ -380,19 +380,15 @@ bool applyLimitSet()
 				{
 					while (asStructureStats[id].curCount[player] > asStructureStats[id].upgrade[player].limit)
 					{
-						StructureList::iterator structIt = apsStructLists[player].begin(), structItNext;
-						while (structIt != apsStructLists[player].end())
+						mutating_list_iterate(apsStructLists[player], [id](STRUCTURE* psStruct)
 						{
-							structItNext = std::next(structIt);
-							STRUCTURE* psStruct = *structIt;
 							if (psStruct->pStructureType->type == asStructureStats[id].type)
 							{
 								removeStruct(psStruct, true);
-								break;
+								return IterationResult::BREAK_ITERATION;
 							}
-							structIt = structItNext;
-						}
-
+							return IterationResult::CONTINUE_ITERATION;
+						});
 					}
 				}
 			}

--- a/src/multiplay.cpp
+++ b/src/multiplay.cpp
@@ -2186,7 +2186,7 @@ MESSAGE *findBeaconMsg(UDWORD player, SDWORD sender)
 {
 	ASSERT_OR_RETURN(nullptr, player < MAX_PLAYERS, "Unsupported player: %" PRIu32 "", player);
 
-	for (MESSAGE *psCurr = apsMessages[player]; psCurr != nullptr; psCurr = psCurr->psNext)
+	for (MESSAGE *psCurr : apsMessages[player])
 	{
 		//look for VIEW_BEACON, should only be 1 per player
 		if (psCurr->dataType == MSG_DATA_BEACON)

--- a/src/multiplay.cpp
+++ b/src/multiplay.cpp
@@ -2431,47 +2431,41 @@ bool makePlayerSpectator(uint32_t playerIndex, bool removeAllStructs, bool quiet
 
 		// Destroy all droids
 		debug(LOG_DEATH, "killing off all droids for player %d", playerIndex);
-		DroidList::iterator droidIt = apsDroidLists[playerIndex].begin(), droidItNext;
-		while (droidIt != apsDroidLists[playerIndex].end())				// delete all droids
+		mutating_list_iterate(apsDroidLists[playerIndex], [quietly](DROID* d)
 		{
-			droidItNext = std::next(droidIt);
 			if (quietly)			// don't show effects
 			{
-				killDroid(*droidIt);
+				killDroid(d);
 			}
 			else				// show effects
 			{
-				destroyDroid(*droidIt, gameTime);
+				destroyDroid(d, gameTime);
 			}
-			droidIt = droidItNext;
-		}
+			return IterationResult::CONTINUE_ITERATION;
+		});
 
 		// Destroy structs
 		debug(LOG_DEATH, "killing off structures for player %d", playerIndex);
-		StructureList::iterator psStructIt = apsStructLists[playerIndex].begin(), psNextIt;
-		while (psStructIt != apsStructLists[playerIndex].end())				// delete structs
+		mutating_list_iterate(apsStructLists[playerIndex], [quietly, removeAllStructs](STRUCTURE* psStruct)
 		{
-			psNextIt = std::next(psStructIt);
-
 			if (removeAllStructs
-				|| (*psStructIt)->pStructureType->type == REF_POWER_GEN
-				|| (*psStructIt)->pStructureType->type == REF_RESEARCH
-				|| (*psStructIt)->pStructureType->type == REF_COMMAND_CONTROL
-				|| StructIsFactory((*psStructIt)))
+				|| psStruct->pStructureType->type == REF_POWER_GEN
+				|| psStruct->pStructureType->type == REF_RESEARCH
+				|| psStruct->pStructureType->type == REF_COMMAND_CONTROL
+				|| StructIsFactory(psStruct))
 			{
 				// FIXME: look why destroyStruct() doesn't put back the feature like removeStruct() does
-				if (quietly || (*psStructIt)->pStructureType->type == REF_RESOURCE_EXTRACTOR)		// don't show effects
+				if (quietly || psStruct->pStructureType->type == REF_RESOURCE_EXTRACTOR)		// don't show effects
 				{
-					removeStruct(*psStructIt, true);
+					removeStruct(psStruct, true);
 				}
 				else			// show effects
 				{
-					destroyStruct(*psStructIt, gameTime);
+					destroyStruct(psStruct, gameTime);
 				}
 			}
-
-			psStructIt = psNextIt;
-		}
+			return IterationResult::CONTINUE_ITERATION;
+		});
 	}
 
 	if (!quietly)

--- a/src/objmem.h
+++ b/src/objmem.h
@@ -29,6 +29,7 @@
 #include <array>
 #include <list>
 #include <functional>
+#include <type_traits>
 
 /* The lists of objects allocated */
 template <typename ObjectType, unsigned PlayerCount>
@@ -166,6 +167,9 @@ enum class IterationResult
 template <typename ObjectType, typename MaybeErasingLoopBodyHandler>
 void mutating_list_iterate(std::list<ObjectType*>& list, MaybeErasingLoopBodyHandler handler)
 {
+	static_assert(std::is_same<std::result_of_t<MaybeErasingLoopBodyHandler(ObjectType*)>, IterationResult>::value,
+		"Loop body handler should return IterationResult");
+
 	typename std::remove_reference_t<decltype(list)>::iterator it = list.begin(), itNext;
 	while (it != list.end())
 	{

--- a/src/structuredef.h
+++ b/src/structuredef.h
@@ -70,7 +70,6 @@ struct FLAG_POSITION : public OBJECT_POSITION
 	Vector3i coords = Vector3i(0, 0, 0); //the world coords of the Position
 	UBYTE    factoryInc;           //indicates whether the first, second etc factory
 	UBYTE    factoryType;          //indicates whether standard, cyborg or vtol factory
-	FLAG_POSITION *psNext;
 };
 
 enum STRUCT_STRENGTH

--- a/src/wzscriptdebug.cpp
+++ b/src/wzscriptdebug.cpp
@@ -178,7 +178,7 @@ static RowDataModel fillMessageModel()
 	RowDataModel result(6);
 	for (int i = 0; i < MAX_PLAYERS; i++)
 	{
-		for (const MESSAGE *psCurr = apsMessages[i]; psCurr != nullptr; psCurr = psCurr->psNext)
+		for (const MESSAGE *psCurr : apsMessages[i])
 		{
 			ASSERT(psCurr->type < msg_type.size(), "Bad message type");
 			ASSERT(psCurr->dataType < msg_data_type.size(), "Bad viewdata type");


### PR DESCRIPTION
This pull request replaces `apsProxDisp` (`PROXIMITY_DISPLAY`) and `apsMessages` (`MESSAGE`) global lists to use `std::list` container instead of intrusive C-style linked lists.

Also, removed redundant `psNext` pointer from `FLAG_POSITION` struct.

`asFeatureStats` global array was converted to use `std::vector`.

Tests: Campaign, Beta -> Gamma transition, load/save campaign games.