### PR TITLE
ci: Don't stop on first build error for pipelines using Ninja and Makefiles

### DIFF
--- a/.github/workflows/CI_alpine.yml
+++ b/.github/workflows/CI_alpine.yml
@@ -71,7 +71,7 @@ jobs:
         else
           echo "::add-matcher::${GITHUB_WORKSPACE}/src/.ci/githubactions/pattern_matchers/gcc.json"
         fi
-        docker run --rm -w "${GITHUB_WORKSPACE}/build" -e WZ_CI_DISABLE_BASIS_COMPRESS_TEXTURES -e CC -e CXX -e "CI=true" -e GITHUB_WORKFLOW -e GITHUB_ACTIONS -e GITHUB_REPOSITORY -e GITHUB_WORKSPACE -e GITHUB_SHA -e GITHUB_REF -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e MAKEFLAGS -v "${GITHUB_WORKSPACE}:${GITHUB_WORKSPACE}" alpine cmake --build .
+        docker run --rm -w "${GITHUB_WORKSPACE}/build" -e WZ_CI_DISABLE_BASIS_COMPRESS_TEXTURES -e CC -e CXX -e "CI=true" -e GITHUB_WORKFLOW -e GITHUB_ACTIONS -e GITHUB_REPOSITORY -e GITHUB_WORKSPACE -e GITHUB_SHA -e GITHUB_REF -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e MAKEFLAGS -v "${GITHUB_WORKSPACE}:${GITHUB_WORKSPACE}" alpine cmake --build . -- -k
         if [ "$WZ_COMPILER" == "clang" ]; then
           echo "::remove-matcher owner=clang::"
         else

--- a/.github/workflows/CI_archlinux.yml
+++ b/.github/workflows/CI_archlinux.yml
@@ -74,7 +74,7 @@ jobs:
         else
           echo "::add-matcher::${GITHUB_WORKSPACE}/src/.ci/githubactions/pattern_matchers/gcc.json"
         fi
-        docker run --rm -w "${GITHUB_WORKSPACE}/build" -e WZ_CI_DISABLE_BASIS_COMPRESS_TEXTURES -e CC -e CXX -e "CI=true" -e GITHUB_WORKFLOW -e GITHUB_ACTIONS -e GITHUB_REPOSITORY -e GITHUB_WORKSPACE -e GITHUB_SHA -e GITHUB_REF -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e MAKEFLAGS -v "${GITHUB_WORKSPACE}:${GITHUB_WORKSPACE}" archlinux cmake --build .
+        docker run --rm -w "${GITHUB_WORKSPACE}/build" -e WZ_CI_DISABLE_BASIS_COMPRESS_TEXTURES -e CC -e CXX -e "CI=true" -e GITHUB_WORKFLOW -e GITHUB_ACTIONS -e GITHUB_REPOSITORY -e GITHUB_WORKSPACE -e GITHUB_SHA -e GITHUB_REF -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e MAKEFLAGS -v "${GITHUB_WORKSPACE}:${GITHUB_WORKSPACE}" archlinux cmake --build . -- -k0
         if [ "$WZ_COMPILER" == "clang" ]; then
           echo "::remove-matcher owner=clang::"
         else

--- a/.github/workflows/CI_fedora.yml
+++ b/.github/workflows/CI_fedora.yml
@@ -92,5 +92,5 @@ jobs:
       working-directory: '${{ github.workspace }}/build'
       run: |
         echo "::add-matcher::${GITHUB_WORKSPACE}/src/.ci/githubactions/pattern_matchers/gcc.json"
-        docker run --rm -w "${GITHUB_WORKSPACE}/build" -e WZ_CI_DISABLE_BASIS_COMPRESS_TEXTURES -e "CI=true" -e GITHUB_WORKFLOW -e GITHUB_ACTIONS -e GITHUB_REPOSITORY -e GITHUB_WORKSPACE -e GITHUB_SHA -e GITHUB_REF -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e MAKEFLAGS -v "${GITHUB_WORKSPACE}:${GITHUB_WORKSPACE}" fedora cmake --build .
+        docker run --rm -w "${GITHUB_WORKSPACE}/build" -e WZ_CI_DISABLE_BASIS_COMPRESS_TEXTURES -e "CI=true" -e GITHUB_WORKFLOW -e GITHUB_ACTIONS -e GITHUB_REPOSITORY -e GITHUB_WORKSPACE -e GITHUB_SHA -e GITHUB_REF -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e MAKEFLAGS -v "${GITHUB_WORKSPACE}:${GITHUB_WORKSPACE}" fedora cmake --build . -- -k0
         echo "::remove-matcher owner=gcc::"

--- a/.github/workflows/CI_ubuntu.yml
+++ b/.github/workflows/CI_ubuntu.yml
@@ -151,7 +151,7 @@ jobs:
       working-directory: '${{ github.workspace }}/build'
       run: |
         echo "::add-matcher::${GITHUB_WORKSPACE}/src/.ci/githubactions/pattern_matchers/${{ matrix.compiler }}.json"
-        docker run --rm -w "${GITHUB_WORKSPACE}/build" -e "CC=${WZ_CC}" -e "CXX=${WZ_CXX}" -e "CI=true" -e GITHUB_WORKFLOW -e GITHUB_ACTIONS -e GITHUB_REPOSITORY -e GITHUB_WORKSPACE -e "GITHUB_SHA=${WZ_GITHUB_SHA}" -e "GITHUB_REF=${WZ_GITHUB_REF}" -e "GITHUB_HEAD_REF=${WZ_GITHUB_HEAD_REF}" -e "GITHUB_BASE_REF=${WZ_GITHUB_BASE_REF}" -e MAKEFLAGS -v "${GITHUB_WORKSPACE}:${GITHUB_WORKSPACE}" ubuntu cmake --build .
+        docker run --rm -w "${GITHUB_WORKSPACE}/build" -e "CC=${WZ_CC}" -e "CXX=${WZ_CXX}" -e "CI=true" -e GITHUB_WORKFLOW -e GITHUB_ACTIONS -e GITHUB_REPOSITORY -e GITHUB_WORKSPACE -e "GITHUB_SHA=${WZ_GITHUB_SHA}" -e "GITHUB_REF=${WZ_GITHUB_REF}" -e "GITHUB_HEAD_REF=${WZ_GITHUB_HEAD_REF}" -e "GITHUB_BASE_REF=${WZ_GITHUB_BASE_REF}" -e MAKEFLAGS -v "${GITHUB_WORKSPACE}:${GITHUB_WORKSPACE}" ubuntu cmake --build . -- -k0
         echo "::remove-matcher owner=${{ matrix.compiler }}::"
     - name: Package .DEB
       working-directory: '${{ github.workspace }}/build'

--- a/.github/workflows/CI_windows.yml
+++ b/.github/workflows/CI_windows.yml
@@ -555,7 +555,7 @@ jobs:
       working-directory: '${{ github.workspace }}\build'
       run: |
         echo "::add-matcher::${{ github.workspace }}\src\.ci\githubactions\pattern_matchers\clang.json"
-        & cmake --build . --config Release --target warzone2100
+        & cmake --build . --config Release --target warzone2100 -- -k0
         echo "::remove-matcher owner=clang::"
     - name: Package Portable Installer
       working-directory: '${{ github.workspace }}\build'


### PR DESCRIPTION
This patch adds `-k` for Makefile-based and `-k0` for Ninja-based CI pipelines, so that the build does not stop on the first build error.

The change allows one to spot as many errors as possible in a single CI run.