### PR TITLE
Find a home for initNoGoAreas()

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1891,11 +1891,14 @@ bool stageThreeInitialise()
 	}
 	else
 	{
+		initNoGoAreas();
+
 		const DebugInputManager& dbgInputManager = gInputManager.debugManager();
 		if (dbgInputManager.debugMappingsAllowed())
 		{
 			triggerEventCheatMode(true);
 		}
+
 		triggerEvent(TRIGGER_GAME_INIT);
 		playerBuiltHQ = structureExists(selectedPlayer, REF_HQ, true, false);
 	}

--- a/src/mission.cpp
+++ b/src/mission.cpp
@@ -263,10 +263,7 @@ void initMission()
 	}
 
 	//init all the landing zones
-	for (auto &inc : sLandingZone)
-	{
-		inc.x1 = inc.y1 = inc.x2 = inc.y2 = 0;
-	}
+	initNoGoAreas();
 
 	bDroidsToSafety = false;
 	setPlayCountDown(true);
@@ -2659,19 +2656,12 @@ LANDING_ZONE *getLandingZone(SDWORD i)
 	return &sLandingZone[i];
 }
 
-/*Initialises all the nogo areas to 0 - DOESN'T INIT THE LIMBO AREA because we
-have to set this up in the mission BEFORE*/
+//Initialises all the nogo areas to 0
 void initNoGoAreas()
 {
-	UBYTE	i;
-
-	for (i = 0; i < MAX_NOGO_AREAS; i++)
+	for (unsigned int i = 0; i < MAX_NOGO_AREAS; ++i)
 	{
-		if (i != LIMBO_LANDING)
-		{
-			sLandingZone[i].x1 = sLandingZone[i].y1 = sLandingZone[i].x2 =
-			                         sLandingZone[i].y2 = 0;
-		}
+		sLandingZone[i].x1 = sLandingZone[i].y1 = sLandingZone[i].x2 = sLandingZone[i].y2 = 0;
 	}
 }
 

--- a/src/wzapi.cpp
+++ b/src/wzapi.cpp
@@ -3209,8 +3209,6 @@ bool wzapi::donatePower(WZAPI_PARAMS(int amount, int player))
 //-- then landing lights are placed. If playerFilter is ```ALL_PLAYERS```, then a limbo landing zone
 //-- is created and limbo droids placed.
 //--
-// FIXME: missing a way to call initNoGoAreas(); check if we can call this in
-// every level start instead of through scripts
 wzapi::no_return_value wzapi::setNoGoArea(WZAPI_PARAMS(int x1, int y1, int x2, int y2, int playerFilter))
 {
 	SCRIPT_ASSERT({}, context, x1 >= 0, "Minimum scroll x value %d is less than zero - ", x1);


### PR DESCRIPTION
LZ areas failed to ever get reinitialized in the source, meaning they'd persist through saveload and could plant themselves anywhere on any given mission all the way until Gamma End. Thus causing a lot of random areas on maps that just can't be built on for magical reasons. Alpha 6, 7, and 10 scripts set a ton of LZ areas per player (as only 1 LZ can exist per player) so these zones follow every map since (as well as any mission with traditional transporter drops changing the usual player number LZ area slot).

The comment about how the Limbo LZ can't be initialized is wrong as all LZ zones are set during eventStartLevel events and the units lost on Gamma 2 will only show up when the appropriate setNoGoArea() function is called. Perhaps true at one point or not, hard to know for sure, as it isn't uncommon to come across wildly outdated or incorrect comments.

---

It is possible to have some nice cleanup of the scripts and remove almost all manually set enemy LZ zones and just blow up any player structures near reinforcement positions instead (if that matters much or not): [branch](https://github.com/Warzone2100/warzone2100/compare/master...KJeff01:warzone2100:nogofix).