### PR TITLE
Very first steps to make `DROID` and `STRUCTURE` look like properly encapsulated C++ classes

### DIFF
--- a/src/action.cpp
+++ b/src/action.cpp
@@ -487,7 +487,7 @@ static void actionUpdateVtolAttack(DROID *psDroid)
 	}
 
 	/* circle around target if hovering and not cyborg */
-	if (psDroid->sMove.Status == MOVEHOVER && !cyborgDroid(psDroid))
+	if (psDroid->sMove.Status == MOVEHOVER && !psDroid->isCyborg())
 	{
 		actionAddVtolAttackRun(psDroid);
 	}

--- a/src/action.cpp
+++ b/src/action.cpp
@@ -350,7 +350,7 @@ bool actionTargetTurret(BASE_OBJECT *psAttacker, BASE_OBJECT *psTarget, WEAPON *
 		int weapon_slot = psWeapon - psDroid->asWeaps;  // Should probably be passed weapon_slot instead of psWeapon.
 		calcDroidMuzzleBaseLocation(psDroid, &attackerTurretPos, weapon_slot);
 
-		if (psDroid->droidType == DROID_WEAPON || isTransporter(psDroid)
+		if (psDroid->droidType == DROID_WEAPON || psDroid->isTransporter()
 		    || psDroid->droidType == DROID_COMMAND || psDroid->droidType == DROID_CYBORG
 		    || psDroid->droidType == DROID_CYBORG_SUPER)
 		{
@@ -2279,7 +2279,7 @@ static void actionDroidBase(DROID *psDroid, DROID_ACTION_DATA *psAction)
 		break;
 
 	case DACTION_ATTACK:
-		if (psDroid->asWeaps[0].nStat == 0 || isTransporter(psDroid) || psAction->psObj == psDroid)
+		if (psDroid->asWeaps[0].nStat == 0 || psDroid->isTransporter() || psAction->psObj == psDroid)
 		{
 			break;
 		}
@@ -2308,7 +2308,7 @@ static void actionDroidBase(DROID *psDroid, DROID_ACTION_DATA *psAction)
 			//in multiPlayer cannot electronically attack a transporter
 			if (bMultiPlayer
 			    && psAction->psObj->type == OBJ_DROID
-			    && isTransporter((DROID *)psAction->psObj))
+			    && ((DROID*)psAction->psObj)->isTransporter())
 			{
 				psDroid->action = DACTION_NONE;
 				break;

--- a/src/action.cpp
+++ b/src/action.cpp
@@ -2289,7 +2289,7 @@ static void actionDroidBase(DROID *psDroid, DROID_ACTION_DATA *psAction)
 			// for ex. AA gun can't attack ground unit
 			break;
 		}
-		if (vtolEmpty(psDroid) && vtolRearming(psDroid))
+		if (vtolEmpty(psDroid) && psDroid->isVtolRearming())
 		{
 			// ignore attack order: we have no ammo and we are rearming right now, or going to rearm, or waiting for it
 			break;
@@ -2636,7 +2636,7 @@ void moveToRearm(DROID *psDroid)
 	}
 
 	//if droid is already returning - ignore
-	if (vtolRearming(psDroid))
+	if (psDroid->isVtolRearming())
 	{
 		return;
 	}

--- a/src/action.cpp
+++ b/src/action.cpp
@@ -1744,7 +1744,7 @@ void actionUpdateDroid(DROID *psDroid)
 				{
 					cantDoRepairLikeAction = true;
 				}
-				else if (order->type != DORDER_DEMOLISH && structureAtPos->body == structureBody(structureAtPos))
+				else if (order->type != DORDER_DEMOLISH && structureAtPos->body == structureAtPos->structureBody())
 				{
 					cantDoRepairLikeAction = true;
 				}

--- a/src/ai.cpp
+++ b/src/ai.cpp
@@ -1176,7 +1176,7 @@ void aiUpdateDroid(DROID *psDroid)
 		updateTarget = false;
 	}
 
-	if (bMultiPlayer && isVtolDroid(psDroid) && isHumanPlayer(psDroid->player))
+	if (bMultiPlayer && psDroid->isVtol() && isHumanPlayer(psDroid->player))
 	{
 		lookForTarget = false;
 		updateTarget = false;

--- a/src/ai.cpp
+++ b/src/ai.cpp
@@ -659,7 +659,7 @@ int aiBestNearestTarget(DROID *psDroid, BASE_OBJECT **ppsObj, int weapon_slot, i
 					// if not electronic then valid target
 					if (!electronic
 					    || (electronic
-					        && !isTransporter((DROID *)targetInQuestion)))
+					        && !((DROID*)targetInQuestion)->isTransporter()))
 					{
 						//only a valid target if NOT a transporter
 						psTarget = targetInQuestion;

--- a/src/ai.cpp
+++ b/src/ai.cpp
@@ -439,7 +439,7 @@ static SDWORD targetAttackWeight(BASE_OBJECT *psTarget, BASE_OBJECT *psAttacker,
 		targetStructure = (STRUCTURE *)psTarget;
 
 		/* Calculate damage this target suffered */
-		damageRatio = 100 - 100 * targetStructure->body / structureBody(targetStructure);
+		damageRatio = 100 - 100 * targetStructure->body / targetStructure->structureBody();
 
 		/* See if this type of a structure should be prioritized */
 		switch (targetStructure->pStructureType->type)

--- a/src/combat.cpp
+++ b/src/combat.cpp
@@ -53,7 +53,7 @@ bool combFire(WEAPON *psWeap, BASE_OBJECT *psAttacker, BASE_OBJECT *psTarget, in
 	ASSERT(psWeap != nullptr, "Invalid weapon pointer");
 
 	/* Don't shoot if the weapon_slot of a vtol is empty */
-	if (psAttacker->type == OBJ_DROID && isVtolDroid(((DROID *)psAttacker))
+	if (psAttacker->type == OBJ_DROID && ((DROID*)psAttacker)->isVtol()
 	    && psWeap->usedAmmo >= getNumAttackRuns(((DROID *)psAttacker), weapon_slot))
 	{
 		objTrace(psAttacker->id, "VTOL slot %d is empty", weapon_slot);
@@ -113,7 +113,7 @@ bool combFire(WEAPON *psWeap, BASE_OBJECT *psAttacker, BASE_OBJECT *psTarget, in
 	}
 
 	/* Check we can hit the target */
-	bool tall = (psAttacker->type == OBJ_DROID && isVtolDroid((DROID *)psAttacker))
+	bool tall = (psAttacker->type == OBJ_DROID && ((DROID*)psAttacker)->isVtol())
 	            || (psAttacker->type == OBJ_STRUCTURE && ((STRUCTURE *)psAttacker)->pStructureType->height > 1);
 	if (proj_Direct(psStats) && !lineOfFire(psAttacker, psTarget, weapon_slot, tall))
 	{
@@ -262,7 +262,7 @@ bool combFire(WEAPON *psWeap, BASE_OBJECT *psAttacker, BASE_OBJECT *psTarget, in
 		}
 
 		predict += Vector3i(iSinCosR(psDroid->sMove.moveDir, psDroid->sMove.speed * flightTime / GAME_TICKS_PER_SEC), 0);
-		if (!isFlying(psDroid))
+		if (!psDroid->isFlying())
 		{
 			predict.z = map_Height(predict.xy());  // Predict that the object will be on the ground.
 		}

--- a/src/component.cpp
+++ b/src/component.cpp
@@ -458,7 +458,7 @@ static bool displayCompObj(DROID *psDroid, bool bButton, const glm::mat4& modelM
 		pieFlag = pie_SHADOW;
 		brightness = pal_SetBrightness(psDroid->illumination);
 		// NOTE: Beware of transporters that are offscreen, on a mission!  We should *not* be checking tiles at this point in time!
-		if (!isTransporter(psDroid) && !missionIsOffworld())
+		if (!psDroid->isTransporter() && !missionIsOffworld())
 		{
 			MAPTILE *psTile = worldTile(psDroid->pos.x, psDroid->pos.y);
 			if (psTile->jammerBits & alliancebits[psDroid->player])
@@ -885,7 +885,7 @@ void displayComponentObject(DROID *psDroid, const glm::mat4 &viewMatrix, const g
 	position.z = -(st.pos.y);
 	position.y = st.pos.z;
 
-	if (isTransporter(psDroid))
+	if (psDroid->isTransporter())
 	{
 		position.y += bobTransporterHeight();
 	}

--- a/src/component.cpp
+++ b/src/component.cpp
@@ -751,7 +751,7 @@ static bool displayCompObj(DROID *psDroid, bool bButton, const glm::mat4& modelM
 				}
 
 				/* translate for construct mount point if cyborg */
-				if (cyborgDroid(psDroid) && psMountShape && !psMountShape->connectors.empty())
+				if (psDroid->isCyborg() && psMountShape && !psMountShape->connectors.empty())
 				{
 					localModelMatrix *= glm::translate(glm::vec3(psMountShape->connectors[0].xzy()));
 					localHeightAboveTerrain += psMountShape->connectors[0].z;
@@ -1028,7 +1028,7 @@ void	compPersonToBits(DROID *psDroid)
 		return;
 	}
 	/* get bits pointers according to whether baba or cyborg*/
-	if (cyborgDroid(psDroid))
+	if (psDroid->isCyborg())
 	{
 		// This is probably unused now, since there's a more appropriate effect for cyborgs.
 		headImd = getImdFromIndex(MI_CYBORG_HEAD);

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -914,7 +914,7 @@ void processMouseClickInput()
 			}
 			// special droid at full health
 			if (arnMPointers[item][selection] == CURSOR_FIX && ObjUnderMouse && ObjUnderMouse->type == OBJ_DROID &&
-			    !droidIsDamaged((DROID *)ObjUnderMouse))
+			    !((DROID *)ObjUnderMouse)->isDamaged())
 			{
 				item = MT_OWNDROID;
 			}
@@ -1755,7 +1755,7 @@ static void dealWithLMBDroid(DROID *psDroid, SELECTION_TYPE selection)
 		FeedbackOrderGiven();
 	}
 	// Clicked on a damaged unit? Will repair it.
-	else if (droidIsDamaged(psDroid) && repairDroidSelected(selectedPlayer))
+	else if (psDroid->isDamaged() && repairDroidSelected(selectedPlayer))
 	{
 		assignDestTarget();
 		orderSelectedObjAdd(selectedPlayer, (BASE_OBJECT *)psDroid, ctrlShiftDown());
@@ -2425,7 +2425,7 @@ static MOUSE_TARGET	itemUnderMouse(BASE_OBJECT **ppObjectUnderMouse)
 						}
 						else
 						{
-							if (droidIsDamaged(psDroid))
+							if (psDroid->isDamaged())
 							{
 								retVal = MT_OWNDROIDDAM;
 							}
@@ -2734,7 +2734,7 @@ bool cyborgDroidSelected(UDWORD player)
 
 	for (const DROID* psCurr : apsDroidLists[player])
 	{
-		if (psCurr->selected && cyborgDroid(psCurr))
+		if (psCurr->selected && psCurr->isCyborg())
 		{
 			return true;
 		}

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -1723,7 +1723,7 @@ static void dealWithLMBDroid(DROID *psDroid, SELECTION_TYPE selection)
 			    (psCurr->selected) &&
 			    (psCurr->asWeaps[0].nStat > 0) &&
 			    ((!proj_Direct(asWeaponStats + psCurr->asWeaps[0].nStat)) ||
-			     isVtolDroid(psCurr)) &&
+			     psCurr->isVtol()) &&
 			    droidSensorDroidWeapon((BASE_OBJECT *)psDroid, psCurr))
 			{
 				bSensorAssigned = true;
@@ -2698,7 +2698,7 @@ bool	vtolDroidSelected(UDWORD player)
 
 	for (DROID* psCurr : apsDroidLists[player])
 	{
-		if (psCurr->selected && isVtolDroid(psCurr))
+		if (psCurr->selected && psCurr->isVtol())
 		{
 			// horrible hack to note one of the selected vtols
 			psSelectedVtol = psCurr;

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -1403,7 +1403,7 @@ void finishDeliveryPosition()
 		psStruct = IdToStruct(flagStructId, selectedPlayer);
 		if (psStruct)
 		{
-			if (StructIsFactory(psStruct) && psStruct->pFunctionality
+			if (psStruct->isFactory() && psStruct->pFunctionality
 				&& psStruct->pFunctionality->factory.psAssemblyPoint)
 			{
 				setAssemblyPoint(psStruct->pFunctionality->factory.psAssemblyPoint,
@@ -1833,7 +1833,7 @@ static void dealWithLMBStructure(STRUCTURE *psStructure, SELECTION_TYPE selectio
 	{
 		if (bRightClickOrders)
 		{
-			if (StructIsFactory(psStructure) && selection != SC_DROID_CONSTRUCT)
+			if (psStructure->isFactory() && selection != SC_DROID_CONSTRUCT)
 			{
 				intAddFactoryOrder(psStructure);
 			}
@@ -2127,7 +2127,7 @@ static void dealWithLMBDClick()
 			psStructure = (STRUCTURE *) psClickedOn;
 			if (psStructure->player == selectedPlayer && !structureIsBlueprint(psStructure))
 			{
-				if (StructIsFactory(psStructure))
+				if (psStructure->isFactory())
 				{
 					setViewPos(map_coord(psStructure->pFunctionality->factory.psAssemblyPoint->coords.x),
 					           map_coord(psStructure->pFunctionality->factory.psAssemblyPoint->coords.y),
@@ -2299,7 +2299,7 @@ static void dealWithRMB()
 							triggerEventSelected();
 						}
 					}
-					else if (StructIsFactory(psStructure))
+					else if (psStructure->isFactory())
 					{
 						//pop up the order interface for the factory
 						intAddFactoryOrder(psStructure);
@@ -2669,7 +2669,7 @@ static SELECTION_TYPE	establishSelection(UDWORD _selectedPlayer)
 /* Just returns true if the building's present body points aren't 100 percent */
 static bool	buildingDamaged(STRUCTURE *psStructure)
 {
-	return psStructure->body < structureBody(psStructure);
+	return psStructure->body < psStructure->structureBody();
 }
 
 /*Looks through the list of selected players droids to see if one is a repair droid*/

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -1667,7 +1667,7 @@ static void dealWithLMBDroid(DROID *psDroid, SELECTION_TYPE selection)
 		orderSelectedObjAdd(selectedPlayer, (BASE_OBJECT *)psDroid, ctrlShiftDown());
 		FeedbackOrderGiven();
 	}
-	else if (isTransporter(psDroid))
+	else if (psDroid->isTransporter())
 	{
 		if (selection == SC_INVALID)
 		{
@@ -2204,7 +2204,7 @@ static void dealWithRMB()
 					dealWithDroidSelect(psDroid, false);
 				}
 				// Not a transporter
-				else if (!isTransporter(psDroid))
+				else if (!psDroid->isTransporter())
 				{
 					if (bRightClickOrders)
 					{
@@ -2394,7 +2394,7 @@ static MOUSE_TARGET	itemUnderMouse(BASE_OBJECT **ppObjectUnderMouse)
 								retVal = MT_SENSOR;
 							}
 						}
-						else if (isTransporter(psDroid) &&
+						else if (psDroid->isTransporter() &&
 						         selectedPlayer == psDroid->player)
 						{
 							//check the transporter is not full

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -2125,7 +2125,7 @@ static void dealWithLMBDClick()
 		{
 			/* We clicked on structure */
 			psStructure = (STRUCTURE *) psClickedOn;
-			if (psStructure->player == selectedPlayer && !structureIsBlueprint(psStructure))
+			if (psStructure->player == selectedPlayer && !psStructure->isBlueprint())
 			{
 				if (psStructure->isFactory())
 				{
@@ -2277,7 +2277,7 @@ static void dealWithRMB()
 					triggerEventSelected();
 					jsDebugSelected(psStructure);
 				}
-				else if (!structureIsBlueprint(psStructure))
+				else if (!psStructure->isBlueprint())
 				{
 					clearSelection();
 

--- a/src/display3d.cpp
+++ b/src/display3d.cpp
@@ -3785,7 +3785,7 @@ void calcScreenCoords(DROID *psDroid, const glm::mat4 &perspectiveViewMatrix)
 		{
 			//don't allow Transporter Droids to be selected here
 			//unless we're in multiPlayer mode!!!!
-			if (!isTransporter(psDroid) || bMultiPlayer)
+			if (!psDroid->isTransporter() || bMultiPlayer)
 			{
 				dealWithDroidSelect(psDroid, true);
 			}

--- a/src/display3d.cpp
+++ b/src/display3d.cpp
@@ -746,7 +746,7 @@ static PIELIGHT structureBrightness(STRUCTURE *psStructure)
 {
 	PIELIGHT buildingBrightness;
 
-	if (structureIsBlueprint(psStructure))
+	if (psStructure->isBlueprint())
 	{
 		buildingBrightness = getBlueprintColour(psStructure->status);
 	}
@@ -2663,7 +2663,7 @@ static void renderStructureTurrets(STRUCTURE *psStructure, iIMDShape *strImd, PI
 	}
 
 	// flags for drawing weapons
-	if (structureIsBlueprint(psStructure))
+	if (psStructure->isBlueprint())
 	{
 		pieFlag = pie_TRANSLUCENT;
 		pieFlagData = BLUEPRINT_OPACITY;
@@ -2874,7 +2874,7 @@ void renderStructure(STRUCTURE *psStructure, const glm::mat4 &viewMatrix, const 
 		/* Draw the building's base first */
 		if (psStructure->pStructureType->pBaseIMD != nullptr)
 		{
-			if (structureIsBlueprint(psStructure))
+			if (psStructure->isBlueprint())
 			{
 				pieFlagData = BLUEPRINT_OPACITY;
 			}
@@ -2920,7 +2920,7 @@ void renderStructure(STRUCTURE *psStructure, const glm::mat4 &viewMatrix, const 
 		return;
 	}
 
-	if (structureIsBlueprint(psStructure))
+	if (psStructure->isBlueprint())
 	{
 		pieFlag = pie_TRANSLUCENT;
 		pieFlagData = BLUEPRINT_OPACITY;
@@ -2941,7 +2941,7 @@ void renderStructure(STRUCTURE *psStructure, const glm::mat4 &viewMatrix, const 
 	while (strImd)
 	{
 		float stretch = 0.f;
-		if (defensive && !structureIsBlueprint(psStructure) && !(strImd->flags & iV_IMD_NOSTRETCH))
+		if (defensive && !psStructure->isBlueprint() && !(strImd->flags & iV_IMD_NOSTRETCH))
 		{
 			stretch = psStructure->pos.z - psStructure->foundationDepth;
 		}
@@ -3049,7 +3049,7 @@ static bool renderWallSection(STRUCTURE *psStructure, const glm::mat4 &viewMatri
 	}
 	else
 	{
-		if (structureIsBlueprint(psStructure))
+		if (psStructure->isBlueprint())
 		{
 			pieFlag = pie_TRANSLUCENT;
 			pieFlagData = BLUEPRINT_OPACITY;

--- a/src/display3d.cpp
+++ b/src/display3d.cpp
@@ -3130,7 +3130,7 @@ static void queueWeaponReloadBarRects(BASE_OBJECT *psObj, WEAPON *psWeap, int we
 		}
 		if (psDroid->resistance)
 		{
-			mulH = (float)PERCENT(psDroid->resistance, droidResistance(psDroid));
+			mulH = (float)PERCENT(psDroid->resistance, psDroid->droidResistance());
 		}
 		else
 		{
@@ -3453,7 +3453,7 @@ static void queueDroidEnemyHealthBarsRects(DROID *psDroid, BatchedMultiRectRende
 	{
 		if (psDroid->resistance)
 		{
-			damage = PERCENT(psDroid->resistance, droidResistance(psDroid));
+			damage = PERCENT(psDroid->resistance, psDroid->droidResistance());
 		}
 		else
 		{
@@ -3486,7 +3486,7 @@ static void queueDroidEnemyHealthBarsRects(DROID *psDroid, BatchedMultiRectRende
 	{
 		if (psDroid->resistance)
 		{
-			mulH = (float)psDroid->resistance / (float)droidResistance(psDroid);
+			mulH = (float)psDroid->resistance / (float)psDroid->droidResistance();
 		}
 		else
 		{

--- a/src/display3d.cpp
+++ b/src/display3d.cpp
@@ -3258,7 +3258,7 @@ static void queueStructureHealth(STRUCTURE *psStruct, BatchedMultiRectRenderer& 
 		health = static_cast<int32_t>((1. - getStructureDamage(psStruct) / 65536.f) * 100);
 
 		// If structure is incomplete, make bar correspondingly thinner.
-		int maxBody = structureBody(psStruct);
+		int maxBody = psStruct->structureBody();
 		int maxBodyBuilt = structureBodyBuilt(psStruct);
 		width = (uint64_t)width * maxBodyBuilt / maxBody;
 	}

--- a/src/droid.cpp
+++ b/src/droid.cpp
@@ -1332,20 +1332,6 @@ static void droidUpdateDroidSelfRepair(DROID *psRepairDroid)
 	droidUpdateDroidRepairBase(psRepairDroid, psRepairDroid);
 }
 
-// return whether a droid is IDF
-bool idfDroid(const DROID *psDroid)
-{
-	//add Cyborgs
-	//if (psDroid->droidType != DROID_WEAPON)
-	if (!(psDroid->droidType == DROID_WEAPON || psDroid->droidType == DROID_CYBORG ||
-		  psDroid->droidType == DROID_CYBORG_SUPER))
-	{
-		return false;
-	}
-
-	return !proj_Direct(psDroid->asWeaps[0].nStat + asWeaponStats);
-}
-
 /* Return the type of a droid */
 DROID_TYPE droidType(const DROID *psDroid)
 {

--- a/src/droid.cpp
+++ b/src/droid.cpp
@@ -570,7 +570,7 @@ bool removeDroidBase(DROID *psDel)
 	}
 
 	// Check to see if constructor droid currently trying to find a location to build
-	if (psDel->player == selectedPlayer && psDel->selected && isConstructionDroid(psDel))
+	if (psDel->player == selectedPlayer && psDel->selected && psDel->isConstructionDroid())
 	{
 		// If currently trying to build, kill off the placement
 		if (tryingToGetLocation())
@@ -578,7 +578,7 @@ bool removeDroidBase(DROID *psDel)
 			int numSelectedConstructors = 0;
 			for (const DROID *psDroid : apsDroidLists[psDel->player])
 			{
-				numSelectedConstructors += psDroid->selected && isConstructionDroid(psDroid);
+				numSelectedConstructors += psDroid->selected && psDroid->isConstructionDroid();
 			}
 			if (numSelectedConstructors <= 1)  // If we were the last selected construction droid.
 			{
@@ -3487,14 +3487,14 @@ bool DROID::isCyborg() const
 			|| droidType == DROID_CYBORG_SUPER);
 }
 
-bool isConstructionDroid(DROID const *psDroid)
+bool DROID::isConstructionDroid() const
 {
-	return psDroid->droidType == DROID_CONSTRUCT || psDroid->droidType == DROID_CYBORG_CONSTRUCT;
+	return droidType == DROID_CONSTRUCT || droidType == DROID_CYBORG_CONSTRUCT;
 }
 
 bool isConstructionDroid(BASE_OBJECT const *psObject)
 {
-	return isDroid(psObject) && isConstructionDroid(castDroid(psObject));
+	return isDroid(psObject) && castDroid(psObject)->isConstructionDroid();
 }
 
 bool droidOnMap(const DROID *psDroid)

--- a/src/droid.cpp
+++ b/src/droid.cpp
@@ -561,7 +561,7 @@ bool removeDroidBase(DROID *psDel)
 		for (auto psStruct : apsStructLists[psDel->player])
 		{
 			// alexl's stab at a right answer.
-			if (psStruct->isFactory()
+			if (psStruct && psStruct->isFactory()
 				&& psStruct->pFunctionality->factory.psCommander == psDel)
 			{
 				assignFactoryCommandDroid(psStruct, nullptr);

--- a/src/droid.cpp
+++ b/src/droid.cpp
@@ -900,7 +900,7 @@ void droidUpdate(DROID *psDroid)
 	if ((psDroid->id + gameTime) / 833 != (psDroid->id + gameTime - deltaGameTime) / 833)
 	{
 		// Zero resistance means not currently been attacked - ignore these
-		if (psDroid->resistance && psDroid->resistance < droidResistance(psDroid))
+		if (psDroid->resistance && psDroid->resistance < psDroid->droidResistance())
 		{
 			// Increase over time if low
 			psDroid->resistance++;
@@ -3368,15 +3368,14 @@ DROID *giftSingleDroid(DROID *psD, UDWORD to, bool electronic, Vector2i pos)
 	return psD;
 }
 
-/*calculates the electronic resistance of a droid based on its experience level*/
-SWORD   droidResistance(const DROID *psDroid)
+int16_t DROID::droidResistance() const
 {
-	CHECK_DROID(psDroid);
-	const BODY_STATS *psStats = asBodyStats + psDroid->asBits[COMP_BODY];
-	int resistance = psDroid->experience / (65536 / MAX(1, psStats->upgrade[psDroid->player].resistance));
+	CHECK_DROID(this);
+	const BODY_STATS *psStats = asBodyStats + asBits[COMP_BODY];
+	int res = experience / (65536 / MAX(1, psStats->upgrade[player].resistance));
 	// ensure resistance is a base minimum
-	resistance = MAX(resistance, psStats->upgrade[psDroid->player].resistance);
-	return MIN(resistance, INT16_MAX);
+	res = MAX(res, psStats->upgrade[player].resistance);
+	return MIN(res, INT16_MAX);
 }
 
 /*this is called to check the weapon is 'allowed'. Check if VTOL, the weapon is

--- a/src/droid.cpp
+++ b/src/droid.cpp
@@ -561,7 +561,7 @@ bool removeDroidBase(DROID *psDel)
 		for (auto psStruct : apsStructLists[psDel->player])
 		{
 			// alexl's stab at a right answer.
-			if (StructIsFactory(psStruct)
+			if (psStruct->isFactory()
 				&& psStruct->pFunctionality->factory.psCommander == psDel)
 			{
 				assignFactoryCommandDroid(psStruct, nullptr);
@@ -1260,7 +1260,7 @@ bool droidUpdateRepair(DROID *psDroid)
 	structureRepair(psStruct, psDroid, iRepairRate);
 
 	/* if not finished repair return true else complete repair and return false */
-	if (psStruct->body < structureBody(psStruct))
+	if (psStruct->body < psStruct->structureBody())
 	{
 		return true;
 	}

--- a/src/droid.cpp
+++ b/src/droid.cpp
@@ -865,7 +865,7 @@ void droidUpdate(DROID *psDroid)
 	}
 	// ------------------------
 	// See if we can and need to self repair.
-	if (!isVtolDroid(psDroid) && droidIsDamaged(psDroid) && psDroid->asBits[COMP_REPAIRUNIT] != 0 && selfRepairEnabled(psDroid->player))
+	if (!isVtolDroid(psDroid) && psDroid->isDamaged() && psDroid->asBits[COMP_REPAIRUNIT] != 0 && selfRepairEnabled(psDroid->player))
 	{
 		droidUpdateDroidSelfRepair(psDroid);
 	}
@@ -2684,10 +2684,10 @@ void setUpBuildModule(DROID *psDroid)
 	cancelBuild(psDroid);
 }
 
-/* Just returns true if the droid's present body points aren't as high as the original*/
-bool	droidIsDamaged(const DROID *psDroid)
+
+bool DROID::isDamaged() const
 {
-	return psDroid->body < psDroid->originalBody;
+	return body < originalBody;
 }
 
 
@@ -2732,7 +2732,7 @@ bool droidUnderRepair(const DROID *psDroid)
 	CHECK_DROID(psDroid);
 
 	//droid must be damaged
-	if (droidIsDamaged(psDroid))
+	if (psDroid->isDamaged())
 	{
 		//look thru the list of players droids to see if any are repairing this droid
 		for (const DROID *psCurr : apsDroidLists[psDroid->player])
@@ -2989,7 +2989,7 @@ bool vtolHappy(const DROID *psDroid)
 
 	ASSERT_OR_RETURN(false, isVtolDroid(psDroid), "not a VTOL droid");
 
-	if (droidIsDamaged(psDroid))
+	if (psDroid->isDamaged())
 	{
 		// VTOLs with less health than their original aren't happy
 		return false;
@@ -3241,7 +3241,7 @@ DROID *giftSingleDroid(DROID *psD, UDWORD to, bool electronic, Vector2i pos)
 		psNewDroid->experience = psD->experience;
 		psNewDroid->kills = psD->kills;
 
-		if (!(psNewDroid->droidType == DROID_PERSON || cyborgDroid(psNewDroid) || isTransporter(psNewDroid)))
+		if (!(psNewDroid->droidType == DROID_PERSON || psNewDroid->isCyborg() || isTransporter(psNewDroid)))
 		{
 			updateDroidOrientation(psNewDroid);
 		}
@@ -3494,13 +3494,12 @@ bool droidAudioTrackStopped(void *psObj)
 	return true;
 }
 
-/*returns true if droid type is one of the Cyborg types*/
-bool cyborgDroid(const DROID *psDroid)
+bool DROID::isCyborg() const
 {
-	return (psDroid->droidType == DROID_CYBORG
-			|| psDroid->droidType == DROID_CYBORG_CONSTRUCT
-			|| psDroid->droidType == DROID_CYBORG_REPAIR
-			|| psDroid->droidType == DROID_CYBORG_SUPER);
+	return (droidType == DROID_CYBORG
+			|| droidType == DROID_CYBORG_CONSTRUCT
+			|| droidType == DROID_CYBORG_REPAIR
+			|| droidType == DROID_CYBORG_SUPER);
 }
 
 bool isConstructionDroid(DROID const *psDroid)

--- a/src/droid.cpp
+++ b/src/droid.cpp
@@ -2878,23 +2878,23 @@ bool vtolReadyToRearm(const DROID *psDroid, const STRUCTURE *psStruct)
 }
 
 // true if a vtol droid currently returning to be rearmed
-bool vtolRearming(const DROID *psDroid)
+bool DROID::isVtolRearming() const
 {
-	CHECK_DROID(psDroid);
+	CHECK_DROID(this);
 
-	if (!psDroid->isVtol())
+	if (!isVtol())
 	{
 		return false;
 	}
-	if (psDroid->droidType != DROID_WEAPON)
+	if (droidType != DROID_WEAPON)
 	{
 		return false;
 	}
 
-	if (psDroid->action == DACTION_MOVETOREARM ||
-		psDroid->action == DACTION_WAITFORREARM ||
-		psDroid->action == DACTION_MOVETOREARMPOINT ||
-		psDroid->action == DACTION_WAITDURINGREARM)
+	if (action == DACTION_MOVETOREARM ||
+		action == DACTION_WAITFORREARM ||
+		action == DACTION_MOVETOREARMPOINT ||
+		action == DACTION_WAITDURINGREARM)
 	{
 		return true;
 	}
@@ -2941,7 +2941,7 @@ bool allVtolsRearmed(const DROID *psDroid)
 	bool stillRearming = false;
 	for (const DROID *psCurr : apsDroidLists[psDroid->player])
 	{
-		if (vtolRearming(psCurr) &&
+		if (psCurr->isVtolRearming() &&
 			psCurr->order.type == psDroid->order.type &&
 			psCurr->order.psObj == psDroid->order.psObj)
 		{

--- a/src/droid.cpp
+++ b/src/droid.cpp
@@ -2903,22 +2903,22 @@ bool vtolRearming(const DROID *psDroid)
 }
 
 // true if a droid is currently attacking
-bool droidAttacking(const DROID *psDroid)
+bool DROID::isAttacking() const
 {
-	CHECK_DROID(psDroid);
+	CHECK_DROID(this);
 
 	//what about cyborgs?
-	if (!(psDroid->droidType == DROID_WEAPON || psDroid->droidType == DROID_CYBORG ||
-		  psDroid->droidType == DROID_CYBORG_SUPER))
+	if (!(droidType == DROID_WEAPON || droidType == DROID_CYBORG ||
+		  droidType == DROID_CYBORG_SUPER))
 	{
 		return false;
 	}
 
-	if (psDroid->action == DACTION_ATTACK ||
-		psDroid->action == DACTION_MOVETOATTACK ||
-		psDroid->action == DACTION_ROTATETOATTACK ||
-		psDroid->action == DACTION_VTOLATTACK ||
-		psDroid->action == DACTION_MOVEFIRE)
+	if (action == DACTION_ATTACK ||
+		action == DACTION_MOVETOATTACK ||
+		action == DACTION_ROTATETOATTACK ||
+		action == DACTION_VTOLATTACK ||
+		action == DACTION_MOVEFIRE)
 	{
 		return true;
 	}

--- a/src/droid.h
+++ b/src/droid.h
@@ -277,9 +277,6 @@ bool standardSensorDroid(const DROID *psDroid);
 // give a droid from one player to another - used in Electronic Warfare and multiplayer
  DROID *giftSingleDroid(DROID *psD, UDWORD to, bool electronic = false, Vector2i pos = {0, 0});
 
-/// Calculates the electronic resistance of a droid based on its experience level
-SWORD droidResistance(const DROID *psDroid);
-
 /// This is called to check the weapon is allowed
 bool checkValidWeaponForProp(const DROID_TEMPLATE *psTemplate);
 

--- a/src/droid.h
+++ b/src/droid.h
@@ -221,9 +221,6 @@ int nextModuleToBuild(STRUCTURE const *psStruct, int lastOrderedModule);
 /// Deals with building a module - checking if any droid is currently doing this if so, helping to build the current one
 void setUpBuildModule(DROID *psDroid);
 
-/// Just returns true if the droid's present body points aren't as high as the original
-bool droidIsDamaged(const DROID *psDroid);
-
 char const *getDroidResourceName(char const *pName);
 
 /// Checks to see if an electronic warfare weapon is attached to the droid
@@ -302,9 +299,6 @@ void DeSelectDroid(DROID *psDroid);
 
 /* audio finished callback */
 bool droidAudioTrackStopped(void *psObj);
-
-/*returns true if droid type is one of the Cyborg types*/
-bool cyborgDroid(const DROID *psDroid);
 
 bool isConstructionDroid(DROID const *psDroid);
 bool isConstructionDroid(BASE_OBJECT const *psObject);

--- a/src/droid.h
+++ b/src/droid.h
@@ -112,9 +112,6 @@ UDWORD calcTemplateBuild(const DROID_TEMPLATE *psTemplate);
 /* Calculate the power points required to build/maintain the droid */
 UDWORD calcTemplatePower(const DROID_TEMPLATE *psTemplate);
 
-// return whether a droid is IDF
-bool idfDroid(const DROID *psDroid);
-
 /* Do damage to a droid */
 int32_t droidDamage(DROID *psDroid, unsigned damage, WEAPON_CLASS weaponClass, WEAPON_SUBCLASS weaponSubClass, unsigned impactTime, bool isDamagePerSecond, int minDamage, bool empRadiusHit);
 

--- a/src/droid.h
+++ b/src/droid.h
@@ -289,7 +289,6 @@ void DeSelectDroid(DROID *psDroid);
 /* audio finished callback */
 bool droidAudioTrackStopped(void *psObj);
 
-bool isConstructionDroid(DROID const *psDroid);
 bool isConstructionDroid(BASE_OBJECT const *psObject);
 
 /** Check if droid is in a legal world position and is not on its way to drive off the map. */

--- a/src/droid.h
+++ b/src/droid.h
@@ -233,7 +233,6 @@ UBYTE checkCommandExist(UBYTE player);
  BASE_OBJECT *checkForRepairRange(DROID *psDroid, DROID *psTarget);
 
 // Returns true if the droid is a transporter.
-bool isTransporter(DROID const *psDroid);
 bool isTransporter(DROID_TEMPLATE const *psTemplate);
 /// Returns true if the droid has VTOL propulsion, and is not a transport.
 bool isVtolDroid(const DROID *psDroid);

--- a/src/droid.h
+++ b/src/droid.h
@@ -251,8 +251,7 @@ void assignVTOLPad(DROID *psNewDroid, STRUCTURE *psReArmPad);
 bool vtolReadyToRearm(const DROID *psDroid, const STRUCTURE *psStruct);
 // true if a vtol droid currently returning to be rearmed
 bool vtolRearming(const DROID *psDroid);
-// true if a droid is currently attacking
-bool droidAttacking(const DROID *psDroid);
+
 // see if there are any other vtols attacking the same target
 // but still rearming
 bool allVtolsRearmed(const DROID *psDroid);

--- a/src/droid.h
+++ b/src/droid.h
@@ -249,8 +249,6 @@ UWORD   getNumAttackRuns(const DROID *psDroid, int weapon_slot);
 void assignVTOLPad(DROID *psNewDroid, STRUCTURE *psReArmPad);
 // true if a vtol is waiting to be rearmed by a particular rearm pad
 bool vtolReadyToRearm(const DROID *psDroid, const STRUCTURE *psStruct);
-// true if a vtol droid currently returning to be rearmed
-bool vtolRearming(const DROID *psDroid);
 
 // see if there are any other vtols attacking the same target
 // but still rearming

--- a/src/droid.h
+++ b/src/droid.h
@@ -234,10 +234,6 @@ UBYTE checkCommandExist(UBYTE player);
 
 // Returns true if the droid is a transporter.
 bool isTransporter(DROID_TEMPLATE const *psTemplate);
-/// Returns true if the droid has VTOL propulsion, and is not a transport.
-bool isVtolDroid(const DROID *psDroid);
-/// Returns true if the droid has VTOL propulsion and is moving.
-bool isFlying(const DROID *psDroid);
 /*returns true if a VTOL weapon droid which has completed all runs*/
 bool vtolEmpty(const DROID *psDroid);
 /*returns true if a VTOL weapon droid which still has full ammo*/

--- a/src/droiddef.h
+++ b/src/droiddef.h
@@ -109,6 +109,8 @@ struct DROID : public BASE_OBJECT
 	int16_t droidResistance() const;
 	// true if a droid is currently attacking
 	bool isAttacking() const;
+	// true if a vtol droid currently returning to be rearmed
+	bool isVtolRearming() const;
 
 	/// UTF-8 name of the droid. This is generated from the droid template
 	///  WARNING: This *can* be changed by the game player after creation & can be translated, do NOT rely on this being the same for everyone!

--- a/src/droiddef.h
+++ b/src/droiddef.h
@@ -98,6 +98,8 @@ struct DROID : public BASE_OBJECT
 	bool isCyborg() const;
 	// Just returns true if the droid's present body points aren't as high as the original
 	bool isDamaged() const;
+	// calculates the electronic resistance of a droid based on its experience level
+	int16_t droidResistance() const;
 
 	/// UTF-8 name of the droid. This is generated from the droid template
 	///  WARNING: This *can* be changed by the game player after creation & can be translated, do NOT rely on this being the same for everyone!

--- a/src/droiddef.h
+++ b/src/droiddef.h
@@ -94,6 +94,11 @@ struct DROID : public BASE_OBJECT
 	DROID(uint32_t id, unsigned player);
 	~DROID();
 
+	// returns true if droid type is one of the Cyborg types
+	bool isCyborg() const;
+	// Just returns true if the droid's present body points aren't as high as the original
+	bool isDamaged() const;
+
 	/// UTF-8 name of the droid. This is generated from the droid template
 	///  WARNING: This *can* be changed by the game player after creation & can be translated, do NOT rely on this being the same for everyone!
 	char            aName[MAX_STR_LENGTH];

--- a/src/droiddef.h
+++ b/src/droiddef.h
@@ -98,6 +98,10 @@ struct DROID : public BASE_OBJECT
 	bool isCyborg() const;
 	// Returns true if the droid is a transporter.
 	bool isTransporter() const;
+	// Returns true if the droid has VTOL propulsion, and is not a transport.
+	bool isVtol() const;
+	// Returns true if the droid has VTOL propulsion and is moving.
+	bool isFlying() const;
 	// Just returns true if the droid's present body points aren't as high as the original
 	bool isDamaged() const;
 	// calculates the electronic resistance of a droid based on its experience level

--- a/src/droiddef.h
+++ b/src/droiddef.h
@@ -94,6 +94,7 @@ struct DROID : public BASE_OBJECT
 	DROID(uint32_t id, unsigned player);
 	~DROID();
 
+	bool isConstructionDroid() const;
 	// returns true if droid type is one of the Cyborg types
 	bool isCyborg() const;
 	// Returns true if the droid is a transporter.

--- a/src/droiddef.h
+++ b/src/droiddef.h
@@ -107,6 +107,8 @@ struct DROID : public BASE_OBJECT
 	bool isDamaged() const;
 	// calculates the electronic resistance of a droid based on its experience level
 	int16_t droidResistance() const;
+	// true if a droid is currently attacking
+	bool isAttacking() const;
 
 	/// UTF-8 name of the droid. This is generated from the droid template
 	///  WARNING: This *can* be changed by the game player after creation & can be translated, do NOT rely on this being the same for everyone!

--- a/src/droiddef.h
+++ b/src/droiddef.h
@@ -96,6 +96,8 @@ struct DROID : public BASE_OBJECT
 
 	// returns true if droid type is one of the Cyborg types
 	bool isCyborg() const;
+	// Returns true if the droid is a transporter.
+	bool isTransporter() const;
 	// Just returns true if the droid's present body points aren't as high as the original
 	bool isDamaged() const;
 	// calculates the electronic resistance of a droid based on its experience level

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2909,7 +2909,7 @@ bool loadGame(const char *pGameToLoad, bool keepObjects, bool freeMem, bool User
 			{
 				if (psCurr->droidType != DROID_PERSON
 				    // && psCurr->droidType != DROID_CYBORG
-				    && !cyborgDroid(psCurr)
+				    && !psCurr->isCyborg()
 				    && (!isTransporter(psCurr))
 				    && psCurr->pos.x != INVALID_XY)
 				{
@@ -3073,7 +3073,7 @@ bool loadGame(const char *pGameToLoad, bool keepObjects, bool freeMem, bool User
 			for (DROID* psCurr : apsDroidLists[player])
 			{
 				if (psCurr->droidType != DROID_PERSON
-				    && !cyborgDroid(psCurr)
+				    && !psCurr->isCyborg()
 				    && (!isTransporter(psCurr))
 				    && psCurr->pos.x != INVALID_XY)
 				{

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2910,7 +2910,7 @@ bool loadGame(const char *pGameToLoad, bool keepObjects, bool freeMem, bool User
 				if (psCurr->droidType != DROID_PERSON
 				    // && psCurr->droidType != DROID_CYBORG
 				    && !psCurr->isCyborg()
-				    && (!isTransporter(psCurr))
+				    && (!psCurr->isTransporter())
 				    && psCurr->pos.x != INVALID_XY)
 				{
 					updateDroidOrientation(psCurr);
@@ -3074,7 +3074,7 @@ bool loadGame(const char *pGameToLoad, bool keepObjects, bool freeMem, bool User
 			{
 				if (psCurr->droidType != DROID_PERSON
 				    && !psCurr->isCyborg()
-				    && (!isTransporter(psCurr))
+				    && !psCurr->isTransporter()
 				    && psCurr->pos.x != INVALID_XY)
 				{
 					updateDroidOrientation(psCurr);
@@ -5339,7 +5339,7 @@ static bool loadSaveDroidPointers(const WzString &pFileName, PerPlayerDroidLists
 				psDroid = d;
 				break;
 			}
-			if (isTransporter(d) && d->psGroup != nullptr)  // Check for droids in the transporter.
+			if (d->isTransporter() && d->psGroup != nullptr)  // Check for droids in the transporter.
 			{
 				for (DROID *psTrDroid : d->psGroup->psList)
 				{
@@ -5711,7 +5711,7 @@ static bool loadSaveDroid(const char *pFileName, PerPlayerDroidLists& ppsCurrent
 		}
 		else
 		{
-			if (isTransporter(psDroid) || psDroid->droidType == DROID_COMMAND)
+			if (psDroid->isTransporter() || psDroid->droidType == DROID_COMMAND)
 			{
 				DROID_GROUP *psGroup = grpCreate(nextFreeGroupID++);
 				psGroup->add(psDroid);
@@ -5782,7 +5782,7 @@ static bool loadSaveDroid(const char *pFileName, PerPlayerDroidLists& ppsCurrent
 			scriptSetStartPos(psDroid->player, psDroid->pos.x, psDroid->pos.y);	// set map start position, FIXME - save properly elsewhere!
 		}
 
-		if (psDroid->psGroup == nullptr || psDroid->psGroup->type != GT_TRANSPORTER || isTransporter(psDroid))  // do not add to list if on a transport, then the group list is used instead
+		if (psDroid->psGroup == nullptr || psDroid->psGroup->type != GT_TRANSPORTER || psDroid->isTransporter())  // do not add to list if on a transport, then the group list is used instead
 		{
 			addDroid(psDroid, ppsCurrentDroidLists);
 		}
@@ -5923,7 +5923,7 @@ static bool writeDroidFile(const char *pFileName, const PerPlayerDroidLists& pps
 		{
 			auto droidKey = "droid_" + (WzString::number(counter++).leftPadToMinimumLength(WzUniCodepoint::fromASCII('0'), 10));  // Zero padded so that alphabetical sort works.
 			mRoot[droidKey.toStdString()] = writeDroid(psCurr, onMission, counter);
-			if (isTransporter(psCurr))	// if transporter save any droids in the grp
+			if (psCurr->isTransporter())	// if transporter save any droids in the grp
 			{
 				if (psCurr->psGroup)
 				{

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -6444,7 +6444,7 @@ static bool loadSaveStructure2(const char *pFileName)
 		default:
 			break;
 		}
-		psStructure->body = healthValue(ini, structureBody(psStructure));
+		psStructure->body = healthValue(ini, psStructure->structureBody());
 		psStructure->currentBuildPts = ini.value("currentBuildPts", structureBuildPointsToCompletion(*psStructure)).toInt();
 		if (psStructure->status == SS_BUILT)
 		{

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -5748,7 +5748,7 @@ static bool loadSaveDroid(const char *pFileName, PerPlayerDroidLists& ppsCurrent
 		Vector2i tmp = ini.vector2i("bumpPosition");
 		psDroid->sMove.bumpPos = Vector3i(tmp.x, tmp.y, 0);
 
-		if (isVtolDroid(psDroid) && psDroid->sMove.Status != MOVEINACTIVE)
+		if (psDroid->isVtol() && psDroid->sMove.Status != MOVEINACTIVE)
 		{
 			psDroid->rot.pitch = 0;
 		}

--- a/src/geometry.cpp
+++ b/src/geometry.cpp
@@ -55,7 +55,7 @@ DROID	*getNearestDroid(UDWORD x, UDWORD y, bool bSelected)
 	/* Go thru' all the droids  - how often have we seen this - a MACRO maybe? */
 	for (DROID *psDroid : apsDroidLists[selectedPlayer])
 	{
-		if (!isVtolDroid(psDroid))
+		if (!psDroid->isVtol())
 		{
 			/* Clever (?) bit that reads whether we're interested in droids being selected or not */
 			if (!bSelected || psDroid->selected)

--- a/src/group.cpp
+++ b/src/group.cpp
@@ -125,7 +125,7 @@ void DROID_GROUP::add(DROID *psDroid)
 		}
 		psDroid->psGroup = this;
 
-		if (isTransporter(psDroid))
+		if (psDroid->isTransporter())
 		{
 			ASSERT_OR_RETURN(, (type == GT_NORMAL), "grpJoin: Cannot have two transporters in a group");
 			ASSERT_OR_RETURN(, psList.empty(), "Adding transporter to non-empty list.");
@@ -189,7 +189,7 @@ void DROID_GROUP::remove(DROID *psDroid)
 			type = GT_NORMAL;
 			psCommander = nullptr;
 		}
-		else if (isTransporter(psDroid) && (type == GT_TRANSPORTER))
+		else if (psDroid->isTransporter() && (type == GT_TRANSPORTER))
 		{
 			type = GT_NORMAL;
 		}

--- a/src/hci.cpp
+++ b/src/hci.cpp
@@ -1861,7 +1861,7 @@ void intObjectSelected(BASE_OBJECT *psObj)
 
 				if (structure->status == SS_BUILT)
 				{
-					if (StructIsFactory(structure))
+					if (structure->isFactory())
 					{
 						intAddManufacture();
 						break;

--- a/src/hci.cpp
+++ b/src/hci.cpp
@@ -1599,7 +1599,7 @@ INT_RETVAL intRunWidgets()
 				// Set the droid order
 				if (intNumSelectedDroids(DROID_CONSTRUCT) == 0
 					&& intNumSelectedDroids(DROID_CYBORG_CONSTRUCT) == 0
-					&& psSelectedBuilder != nullptr && isConstructionDroid(psSelectedBuilder))
+					&& psSelectedBuilder != nullptr && psSelectedBuilder->isConstructionDroid())
 				{
 					orderDroidStatsTwoLocDir(psSelectedBuilder, DORDER_LINEBUILD, (STRUCTURE_STATS *)psPositionStats, pos.x, pos.y, pos2.x, pos2.y, getBuildingDirection(), ModeQueue);
 				}

--- a/src/hci/build.cpp
+++ b/src/hci/build.cpp
@@ -47,7 +47,7 @@ void BuildController::updateBuildersList()
 
 	for (DROID *droid : apsDroidLists[selectedPlayer])
 	{
-		if (isConstructionDroid(droid) && droid->died == 0)
+		if (droid->isConstructionDroid() && droid->died == 0)
 		{
 			builders.push_back(droid);
 		}
@@ -168,7 +168,7 @@ void BuildController::setHighlightedObject(BASE_OBJECT *object)
 
 	auto builder = castDroid(object);
 	ASSERT_NOT_NULLPTR_OR_RETURN(, builder);
-	ASSERT_OR_RETURN(, isConstructionDroid(builder), "Droid is not a construction droid");
+	ASSERT_OR_RETURN(, builder->isConstructionDroid(), "Droid is not a construction droid");
 	highlightedBuilder = builder;
 }
 

--- a/src/hci/manufacture.cpp
+++ b/src/hci/manufacture.cpp
@@ -33,7 +33,7 @@ static const uint8_t commandBrainComponent = 1; // hmm there is only 1 "CommandB
 
 FACTORY *getFactoryOrNullptr(STRUCTURE *factory)
 {
-	ASSERT_OR_RETURN(nullptr, StructIsFactory(factory), "Invalid factory pointer");
+	ASSERT_OR_RETURN(nullptr, factory->isFactory(), "Invalid factory pointer");
 	return (FACTORY *)factory->pFunctionality;
 }
 
@@ -143,7 +143,7 @@ void ManufactureController::updateFactoriesList()
 	{
 		for (auto structure : *intStrList)
 		{
-			if (structure->status == SS_BUILT && structure->died == 0 && StructIsFactory(structure))
+			if (structure->status == SS_BUILT && structure->died == 0 && structure->isFactory())
 			{
 				factories.push_back(structure);
 			}
@@ -197,7 +197,7 @@ void ManufactureController::setHighlightedObject(BASE_OBJECT *object)
 	}
 
 	auto factory = castStructure(object);
-	ASSERT_OR_RETURN(, StructIsFactory(factory), "Invalid factory pointer");
+	ASSERT_OR_RETURN(, factory->isFactory(), "Invalid factory pointer");
 	highlightedFactory = factory;
 }
 

--- a/src/hci/manufacture.cpp
+++ b/src/hci/manufacture.cpp
@@ -33,7 +33,7 @@ static const uint8_t commandBrainComponent = 1; // hmm there is only 1 "CommandB
 
 FACTORY *getFactoryOrNullptr(STRUCTURE *factory)
 {
-	ASSERT_OR_RETURN(nullptr, factory->isFactory(), "Invalid factory pointer");
+	ASSERT_OR_RETURN(nullptr, factory && factory->isFactory(), "Invalid factory pointer");
 	return (FACTORY *)factory->pFunctionality;
 }
 
@@ -197,7 +197,7 @@ void ManufactureController::setHighlightedObject(BASE_OBJECT *object)
 	}
 
 	auto factory = castStructure(object);
-	ASSERT_OR_RETURN(, factory->isFactory(), "Invalid factory pointer");
+	ASSERT_OR_RETURN(, factory && factory->isFactory(), "Invalid factory pointer");
 	highlightedFactory = factory;
 }
 

--- a/src/intdisplay.cpp
+++ b/src/intdisplay.cpp
@@ -1043,7 +1043,7 @@ void IntFancyButton::displayIMD(AtlasImage image, ImdObject imdObject, int xOffs
 
 		if (IMDType == IMDTYPE_DROID)
 		{
-			if (isTransporter((DROID *)Object))
+			if (((DROID*)Object)->isTransporter())
 			{
 				if (((DROID *)Object)->droidType == DROID_TRANSPORTER)
 				{

--- a/src/intorder.cpp
+++ b/src/intorder.cpp
@@ -889,7 +889,7 @@ static bool SetSecondaryState(SECONDARY_ORDER sec, unsigned State)
 		if (SelectedDroid)
 		{
 			//Only set the state if it's not a transporter.
-			if (!isTransporter(SelectedDroid))
+			if (!SelectedDroid->isTransporter())
 			{
 				if (!secondarySetState(SelectedDroid, sec, (SECONDARY_STATE)State))
 				{

--- a/src/intorder.cpp
+++ b/src/intorder.cpp
@@ -450,7 +450,7 @@ static std::vector<AVORDER> buildDroidOrderList()
 // Build a list of orders available for the selected structure.
 static std::vector<AVORDER> buildStructureOrderList(STRUCTURE *psStructure)
 {
-	ASSERT_OR_RETURN(std::vector<AVORDER>(), psStructure->isFactory(), "BuildStructureOrderList: structure is not a factory");
+	ASSERT_OR_RETURN(std::vector<AVORDER>(), psStructure && psStructure->isFactory(), "BuildStructureOrderList: structure is not a factory");
 
 	//this can be hard-coded!
 	std::vector<AVORDER> orders(4);

--- a/src/intorder.cpp
+++ b/src/intorder.cpp
@@ -450,7 +450,7 @@ static std::vector<AVORDER> buildDroidOrderList()
 // Build a list of orders available for the selected structure.
 static std::vector<AVORDER> buildStructureOrderList(STRUCTURE *psStructure)
 {
-	ASSERT_OR_RETURN(std::vector<AVORDER>(), StructIsFactory(psStructure), "BuildStructureOrderList: structure is not a factory");
+	ASSERT_OR_RETURN(std::vector<AVORDER>(), psStructure->isFactory(), "BuildStructureOrderList: structure is not a factory");
 
 	//this can be hard-coded!
 	std::vector<AVORDER> orders(4);
@@ -551,7 +551,7 @@ bool intAddOrder(BASE_OBJECT *psObj)
 			Droid = nullptr;
 			psStructure = (STRUCTURE *)psObj;
 			psSelectedFactory = psStructure;
-			ASSERT_OR_RETURN(false, StructIsFactory(psSelectedFactory), "Trying to select a %s as a factory!",
+			ASSERT_OR_RETURN(false, psSelectedFactory->isFactory(), "Trying to select a %s as a factory!",
 			                 objInfo((BASE_OBJECT *)psSelectedFactory));
 		}
 		else

--- a/src/keybind.cpp
+++ b/src/keybind.cpp
@@ -2111,7 +2111,7 @@ static void kfsf_SetSelectedDroidsState(SECONDARY_ORDER sec, SECONDARY_STATE sta
 	for (DROID* psDroid : apsDroidLists[selectedPlayer])
 	{
 		// Only set the state if it's not a transporter.
-		if (psDroid->selected && !isTransporter(psDroid))
+		if (psDroid->selected && !psDroid->isTransporter())
 		{
 			secondarySetState(psDroid, sec, state);
 		}

--- a/src/keybind.cpp
+++ b/src/keybind.cpp
@@ -231,7 +231,7 @@ void kf_DamageMe()
 	{
 		if (psStruct->selected)
 		{
-			int val = psStruct->body - ((structureBody(psStruct) / 100) * 20);
+			int val = psStruct->body - ((psStruct->structureBody() / 100) * 20);
 			if (val > 0)
 			{
 				psStruct->body = val;

--- a/src/loop.cpp
+++ b/src/loop.cpp
@@ -885,7 +885,7 @@ void adjustDroidCount(DROID *droid, int delta) {
 // Increase counts of droids in a transporter
 void droidCountsInTransporter(DROID *droid, int player)
 {
-	if (!isTransporter(droid) || droid->psGroup == nullptr)
+	if (!droid->isTransporter() || droid->psGroup == nullptr)
 	{
 		return;
 	}

--- a/src/mission.cpp
+++ b/src/mission.cpp
@@ -695,7 +695,7 @@ static void saveMissionData()
 	{
 		for (DROID* psDroid : apsDroidLists[selectedPlayer])
 		{
-			if (droidIsDamaged(psDroid))
+			if (psDroid->isDamaged())
 			{
 				psDroid->body = psDroid->originalBody;
 			}
@@ -1652,7 +1652,7 @@ static void missionResetDroids()
 				}
 
 				// People always stand upright
-				if (psDroid->droidType != DROID_PERSON && !cyborgDroid(psDroid))
+				if (psDroid->droidType != DROID_PERSON && !psDroid->isCyborg())
 				{
 					updateDroidOrientation(psDroid);
 				}

--- a/src/mission.cpp
+++ b/src/mission.cpp
@@ -531,7 +531,7 @@ void addTransporterTimerInterface()
 		//check the player has at least one Transporter back at base
 		for (DROID *psDroid : mission.apsDroidLists[selectedPlayer])
 		{
-			if (isTransporter(psDroid))
+			if (psDroid->isTransporter())
 			{
 				psTransporter = psDroid;
 				break;
@@ -916,7 +916,7 @@ void placeLimboDroids()
 		{
 			addDroid(psDroid, apsDroidLists);
 			//KILL OFF TRANSPORTER - should never be one but....
-			if (isTransporter(psDroid))
+			if (psDroid->isTransporter())
 			{
 				vanishDroid(psDroid);
 				return IterationResult::CONTINUE_ITERATION;
@@ -988,7 +988,7 @@ void saveCampaignData()
 		// Move any Transporters into the mission list
 		mutating_list_iterate(apsDroidLists[selectedPlayer], [](DROID* psDroid)
 		{
-			if (isTransporter(psDroid))
+			if (psDroid->isTransporter())
 			{
 				// Empty the transporter into the mission list
 				ASSERT_OR_RETURN(IterationResult::CONTINUE_ITERATION, psDroid->psGroup != nullptr, "Transporter does not have a group");
@@ -1044,7 +1044,7 @@ void saveCampaignData()
 		//find the *first* transporter
 		mutating_list_iterate(mission.apsDroidLists[selectedPlayer], [](DROID* psDroid)
 		{
-			if (isTransporter(psDroid))
+			if (psDroid->isTransporter())
 			{
 				//fill it with droids from the mission list
 				mutating_list_iterate(mission.apsDroidLists[selectedPlayer], [psDroid](DROID* psSafeDroid)
@@ -1285,7 +1285,7 @@ void processMissionLimbo()
 	mutating_list_iterate(apsDroidLists[selectedPlayer], [&numDroidsAddedToLimboList](DROID* psDroid)
 	{
 		//KILL OFF TRANSPORTER - should never be one but....
-		if (isTransporter(psDroid))
+		if (psDroid->isTransporter())
 		{
 			vanishDroid(psDroid);
 		}
@@ -1507,14 +1507,14 @@ void missionDroidUpdate(DROID *psDroid)
 	/*This is required for Transporters that are moved offWorld so the
 	saveGame doesn't try to set their position in the map - especially important
 	for endCam2 where there isn't a valid map!*/
-	if (isTransporter(psDroid))
+	if (psDroid->isTransporter())
 	{
 		psDroid->pos.x = INVALID_XY;
 		psDroid->pos.y = INVALID_XY;
 	}
 
 	//ignore all droids except Transporters
-	if (!isTransporter(psDroid)
+	if (!psDroid->isTransporter()
 	    || !(orderState(psDroid, DORDER_TRANSPORTOUT)  ||
 	         orderState(psDroid, DORDER_TRANSPORTIN)     ||
 	         orderState(psDroid, DORDER_TRANSPORTRETURN)))
@@ -1558,7 +1558,7 @@ static void missionResetDroids()
 			}
 
 			//KILL OFF TRANSPORTER
-			if (isTransporter(d))
+			if (d->isTransporter())
 			{
 				vanishDroid(d);
 			}
@@ -1689,7 +1689,7 @@ void unloadTransporter(DROID *psTransporter, UDWORD x, UDWORD y, bool goingHome)
 	}
 
 	//unload all the droids from within the current Transporter
-	if (isTransporter(psTransporter))
+	if (psTransporter->isTransporter())
 	{
 		ASSERT(psTransporter->psGroup != nullptr, "psTransporter->psGroup is null??");
 		for (DROID* psDroid : psTransporter->psGroup->psList)
@@ -1818,7 +1818,7 @@ void missionMoveTransporterOffWorld(DROID *psTransporter)
 			ASSERT(selectedPlayer < MAX_PLAYERS, "selectedPlayer %" PRIu32 " exceeds MAX_PLAYERS", selectedPlayer);
 			auto droidIt = std::find_if(mission.apsDroidLists[selectedPlayer].begin(), mission.apsDroidLists[selectedPlayer].end(), [](DROID* d)
 			{
-				return !isTransporter(d);
+				return !d->isTransporter();
 			});
 			if (droidIt == mission.apsDroidLists[selectedPlayer].end())
 			{
@@ -3001,7 +3001,7 @@ bool missionDroidsRemaining(UDWORD player)
 	ASSERT_OR_RETURN(false, player < MAX_PLAYERS, "invalid player: %" PRIu32 "", player);
 	for (const DROID *psDroid : apsDroidLists[player])
 	{
-		if (!isTransporter(psDroid))
+		if (!psDroid->isTransporter())
 		{
 			return true;
 		}
@@ -3014,7 +3014,7 @@ being flown to safety. The droids inside the Transporter are placed into the
 mission list for later use*/
 void moveDroidsToSafety(DROID *psTransporter)
 {
-	ASSERT_OR_RETURN(, isTransporter(psTransporter), "unit not a Transporter");
+	ASSERT_OR_RETURN(, psTransporter->isTransporter(), "unit not a Transporter");
 
 	if (psTransporter->psGroup != nullptr)
 	{
@@ -3070,14 +3070,14 @@ static DROID *find_transporter()
 
 	for (DROID* droid : apsDroidLists[selectedPlayer])
 	{
-		if (isTransporter(droid))
+		if (droid->isTransporter())
 		{
 			return droid;
 		}
 	}
 	for (DROID* droid : mission.apsDroidLists[selectedPlayer])
 	{
-		if (isTransporter(droid))
+		if (droid->isTransporter())
 		{
 			return droid;
 		}
@@ -3177,7 +3177,7 @@ void emptyTransporters(bool bOffWorld)
 	//see if there are any Transporters in the world
 	mutating_list_iterate(apsDroidLists[selectedPlayer], [bOffWorld](DROID* psTransporter)
 	{
-		if (isTransporter(psTransporter))
+		if (psTransporter->isTransporter())
 		{
 			//if flying in, empty the contents
 			if (orderState(psTransporter, DORDER_TRANSPORTIN))
@@ -3233,7 +3233,7 @@ void emptyTransporters(bool bOffWorld)
 	//deal with any transporters that are waiting to come over
 	mutating_list_iterate(mission.apsDroidLists[selectedPlayer], [](DROID* psTransporter)
 	{
-		if (isTransporter(psTransporter))
+		if (psTransporter->isTransporter())
 		{
 			//for each droid within the transporter...
 			mutating_list_iterate(psTransporter->psGroup->psList, [psTransporter](DROID* psDroid)

--- a/src/mission.cpp
+++ b/src/mission.cpp
@@ -888,7 +888,7 @@ void saveMissionLimboData()
 	// any selectedPlayer's factories/research need to be put on holdProduction/holdresearch
 	for (STRUCTURE* psStruct : apsStructLists[selectedPlayer])
 	{
-		if (StructIsFactory(psStruct))
+		if (psStruct->isFactory())
 		{
 			holdProduction(psStruct, ModeImmediate);
 		}
@@ -1576,7 +1576,7 @@ static void missionResetDroids()
 			STRUCTURE* psStruct = psDroid->psBaseStruct;
 			FACTORY* psFactory = nullptr;
 
-			if (psStruct && StructIsFactory(psStruct))
+			if (psStruct && psStruct->isFactory())
 			{
 				psFactory = (FACTORY*)psStruct->pFunctionality;
 			}

--- a/src/mission.cpp
+++ b/src/mission.cpp
@@ -888,6 +888,10 @@ void saveMissionLimboData()
 	// any selectedPlayer's factories/research need to be put on holdProduction/holdresearch
 	for (STRUCTURE* psStruct : apsStructLists[selectedPlayer])
 	{
+		if (!psStruct)
+		{
+			continue;
+		}
 		if (psStruct->isFactory())
 		{
 			holdProduction(psStruct, ModeImmediate);

--- a/src/move.cpp
+++ b/src/move.cpp
@@ -207,7 +207,7 @@ bool moveDroidToNoFormation(DROID *psDroid, UDWORD x, UDWORD y, FPATH_MOVETYPE m
  */
 void moveDroidToDirect(DROID *psDroid, UDWORD x, UDWORD y)
 {
-	ASSERT_OR_RETURN(, psDroid != nullptr && isVtolDroid(psDroid), "Only valid for a VTOL unit");
+	ASSERT_OR_RETURN(, psDroid != nullptr && psDroid->isVtol(), "Only valid for a VTOL unit");
 
 	fpathSetDirectRoute(psDroid, x, y);
 	psDroid->sMove.Status = MOVENAVIGATE;
@@ -324,7 +324,7 @@ static void moveShuffleDroid(DROID *psDroid, Vector2i s)
 
 	// check the location for vtols
 	Vector2i tar = psDroid->pos.xy() + Vector2i(mx, my);
-	if (isVtolDroid(psDroid))
+	if (psDroid->isVtol())
 	{
 		actionVTOLLandingPos(psDroid, &tar);
 	}
@@ -388,7 +388,7 @@ void updateDroidOrientation(DROID *psDroid)
 	int32_t vX, vY;
 
 	if (psDroid->droidType == DROID_PERSON || psDroid->isCyborg() || psDroid->isTransporter()
-	    || isFlying(psDroid))
+	    || psDroid->isFlying())
 	{
 		/* The ground doesn't affect the pitch/roll of these droids*/
 		return;
@@ -744,7 +744,7 @@ static void moveOpenGates(DROID *psDroid, Vector2i tile)
 		return;
 	}
 	MAPTILE *psTile = mapTile(tile);
-	if (!isFlying(psDroid) && psTile && psTile->psObject && psTile->psObject->type == OBJ_STRUCTURE && aiCheckAlliances(psTile->psObject->player, psDroid->player))
+	if (!psDroid->isFlying() && psTile && psTile->psObject && psTile->psObject->type == OBJ_STRUCTURE && aiCheckAlliances(psTile->psObject->player, psDroid->player))
 	{
 		requestOpenGate((STRUCTURE *)psTile->psObject);  // If it's a friendly gate, open it. (It would be impolite to open an enemy gate.)
 	}
@@ -795,7 +795,7 @@ static void moveCalcBlockingSlide(DROID *psDroid, int32_t *pmx, int32_t *pmy, ui
 	}
 
 	// note the bump time and position if necessary
-	if (!isVtolDroid(psDroid) &&
+	if (!psDroid->isVtol() &&
 	    psDroid->sMove.bumpTime == 0)
 	{
 		psDroid->sMove.bumpTime = gameTime;
@@ -1057,8 +1057,8 @@ static void moveCalcDroidSlide(DROID *psDroid, int *pmx, int *pmy)
 				// ignore transporters
 				continue;
 			}
-			if ((!isFlying(psDroid) && isFlying(psObjcast) && psObjcast->pos.z > (psDroid->pos.z + droidR)) || 
-			    (!isFlying(psObjcast) && isFlying(psDroid) && psDroid->pos.z > (psObjcast->pos.z + objR)))
+			if ((!psDroid->isFlying() && psObjcast->isFlying() && psObjcast->pos.z > (psDroid->pos.z + droidR)) ||
+			    (!psObjcast->isFlying() && psDroid->isFlying() && psDroid->pos.z > (psObjcast->pos.z + objR)))
 			{
 				// ground unit can't bump into a flying saucer..
 				continue;
@@ -1180,7 +1180,7 @@ static Vector2i moveGetObstacleVector(DROID *psDroid, Vector2i dest)
 		}
 
 		// vtol droids only avoid each other and don't affect ground droids
-		if (isVtolDroid(psDroid) != isVtolDroid(psObstacle))
+		if (psDroid->isVtol() != psObstacle->isVtol())
 		{
 			continue;
 		}
@@ -1353,7 +1353,7 @@ SDWORD moveCalcDroidSpeed(DROID *psDroid)
 	}
 
 	// slow down shuffling VTOLs
-	if (isVtolDroid(psDroid) &&
+	if (psDroid->isVtol() &&
 	    (psDroid->sMove.Status == MOVESHUFFLE) &&
 	    (speed > MIN_END_SPEED))
 	{
@@ -1496,7 +1496,7 @@ static void moveCheckFinalWaypoint(DROID *psDroid, SDWORD *pSpeed)
 	minEndSpeed = std::min(minEndSpeed, MIN_END_SPEED);
 
 	// don't do this for VTOLs doing attack runs
-	if (isVtolDroid(psDroid) && (psDroid->action == DACTION_VTOLATTACK))
+	if (psDroid->isVtol() && (psDroid->action == DACTION_VTOLATTACK))
 	{
 		return;
 	}
@@ -2018,7 +2018,7 @@ static bool pickupOilDrum(int toPlayer, int fromPlayer)
 static void checkLocalFeatures(DROID *psDroid)
 {
 	// NOTE: Why not do this for AI units also?
-	if ((!isHumanPlayer(psDroid->player) && psDroid->order.type != DORDER_RECOVER) || isVtolDroid(psDroid) || psDroid->isTransporter())  // VTOLs or transporters can't pick up features!
+	if ((!isHumanPlayer(psDroid->player) && psDroid->order.type != DORDER_RECOVER) || psDroid->isVtol() || psDroid->isTransporter())  // VTOLs or transporters can't pick up features!
 	{
 		return;
 	}
@@ -2147,7 +2147,7 @@ void moveUpdateDroid(DROID *psDroid)
 			break;
 		}
 
-		if (isVtolDroid(psDroid))
+		if (psDroid->isVtol())
 		{
 			psDroid->rot.pitch = 0;
 		}

--- a/src/move.cpp
+++ b/src/move.cpp
@@ -387,7 +387,7 @@ void updateDroidOrientation(DROID *psDroid)
 	const int d = 20;
 	int32_t vX, vY;
 
-	if (psDroid->droidType == DROID_PERSON || cyborgDroid(psDroid) || isTransporter(psDroid)
+	if (psDroid->droidType == DROID_PERSON || psDroid->isCyborg() || isTransporter(psDroid)
 	    || isFlying(psDroid))
 	{
 		/* The ground doesn't affect the pitch/roll of these droids*/
@@ -547,7 +547,7 @@ static SDWORD moveObjRadius(const BASE_OBJECT *psObj)
 			{
 				return mvPersRad;
 			}
-			else if (cyborgDroid(psDroid))
+			else if (psDroid->isCyborg())
 			{
 				return mvCybRad;
 			}
@@ -1029,7 +1029,7 @@ static void moveCalcDroidSlide(DROID *psDroid, int *pmx, int *pmy)
 	CHECK_DROID(psDroid);
 
 	bLegs = false;
-	if (psDroid->droidType == DROID_PERSON || cyborgDroid(psDroid))
+	if (psDroid->droidType == DROID_PERSON || psDroid->isCyborg())
 	{
 		bLegs = true;
 	}
@@ -1880,7 +1880,7 @@ static void movePlayDroidMoveAudio(DROID *psDroid)
 		{
 			iAudioID = ID_SOUND_BLIMP_FLIGHT;
 		}
-		else if (iPropType == PROPULSION_TYPE_LEGGED && cyborgDroid(psDroid))
+		else if (iPropType == PROPULSION_TYPE_LEGGED && psDroid->isCyborg())
 		{
 			iAudioID = ID_SOUND_CYBORG_MOVE;
 		}
@@ -2269,7 +2269,7 @@ void moveUpdateDroid(DROID *psDroid)
 	{
 		moveUpdatePersonModel(psDroid, moveSpeed, moveDir);
 	}
-	else if (cyborgDroid(psDroid))
+	else if (psDroid->isCyborg())
 	{
 		moveUpdateCyborgModel(psDroid, moveSpeed, moveDir, oldStatus);
 	}

--- a/src/multibot.cpp
+++ b/src/multibot.cpp
@@ -599,7 +599,7 @@ void sendDroidInfo(DROID *psDroid, DroidOrder const &order, bool add)
 	{
 		info.structRef = order.psStats->ref;
 		info.direction = order.direction;
-		if (!isConstructionDroid(psDroid))
+		if (!psDroid->isConstructionDroid())
 		{
 			return;  // No point ordering things to build if they can't build anything.
 		}

--- a/src/multigifts.cpp
+++ b/src/multigifts.cpp
@@ -325,7 +325,7 @@ static void sendGiftDroids(uint8_t from, uint8_t to)
 
 	for (psD = apsDroidLists[from].begin(); psD != apsDroidLists[from].end() && totalToSend != 0; ++psD)
 	{
-		if (isTransporter(*psD)
+		if ((*psD)->isTransporter()
 		    && !transporterIsEmpty(*psD))
 		{
 			CONPRINTF(_("Tried to give away a non-empty %s - but this is not allowed."), (*psD)->aName);

--- a/src/multijoin.cpp
+++ b/src/multijoin.cpp
@@ -315,7 +315,7 @@ bool splitResourcesAmongTeam(UDWORD player)
 		destroyMatchingStructs(player, [](STRUCTURE *psStruct) { return psStruct->pStructureType->type == REF_RESEARCH; }, false);
 	}
 	distributeMatchingStructs([](STRUCTURE *psStruct) { return psStruct->pStructureType->type == REF_COMMAND_CONTROL; });
-	distributeMatchingStructs([](STRUCTURE *psStruct) { return StructIsFactory(psStruct); });
+	distributeMatchingStructs([](STRUCTURE *psStruct) { return psStruct->isFactory(); });
 
 	return true;
 }

--- a/src/multijoin.cpp
+++ b/src/multijoin.cpp
@@ -293,7 +293,7 @@ bool splitResourcesAmongTeam(UDWORD player)
 
 		mutating_list_iterate(apsStructLists[player], [&cmp, &structsGiftedPerTarget, &incrRecvStruct](STRUCTURE* psStruct)
 		{
-			if (cmp(psStruct))
+			if (psStruct && cmp(psStruct))
 			{
 				giftSingleStructure(psStruct, structsGiftedPerTarget.front().player, false);
 				incrRecvStruct(0);

--- a/src/multiplay.cpp
+++ b/src/multiplay.cpp
@@ -233,7 +233,7 @@ bool multiplayerWinSequence(bool firstCall)
 		// stop all manufacture.
 		for (STRUCTURE* psStruct : apsStructLists[selectedPlayer])
 		{
-			if (StructIsFactory(psStruct))
+			if (psStruct->isFactory())
 			{
 				if (((FACTORY *)psStruct->pFunctionality)->psSubject)//check if active
 				{
@@ -2452,7 +2452,7 @@ bool makePlayerSpectator(uint32_t playerIndex, bool removeAllStructs, bool quiet
 				|| psStruct->pStructureType->type == REF_POWER_GEN
 				|| psStruct->pStructureType->type == REF_RESEARCH
 				|| psStruct->pStructureType->type == REF_COMMAND_CONTROL
-				|| StructIsFactory(psStruct))
+				|| psStruct->isFactory())
 			{
 				// FIXME: look why destroyStruct() doesn't put back the feature like removeStruct() does
 				if (quietly || psStruct->pStructureType->type == REF_RESOURCE_EXTRACTOR)		// don't show effects

--- a/src/multiplay.cpp
+++ b/src/multiplay.cpp
@@ -233,7 +233,7 @@ bool multiplayerWinSequence(bool firstCall)
 		// stop all manufacture.
 		for (STRUCTURE* psStruct : apsStructLists[selectedPlayer])
 		{
-			if (psStruct->isFactory())
+			if (psStruct && psStruct->isFactory())
 			{
 				if (((FACTORY *)psStruct->pFunctionality)->psSubject)//check if active
 				{

--- a/src/multistruct.cpp
+++ b/src/multistruct.cpp
@@ -229,7 +229,7 @@ bool recvLasSat(NETQUEUE queue)
 	{
 		// Lassats have just one weapon
 		unsigned firePause = weaponFirePause(&asWeaponStats[psStruct->asWeaps[0].nStat], player);
-		unsigned damLevel = PERCENT(psStruct->body, structureBody(psStruct));
+		unsigned damLevel = PERCENT(psStruct->body, psStruct->structureBody());
 
 		if (damLevel < HEAVY_DAMAGE_LEVEL)
 		{
@@ -353,7 +353,7 @@ void recvStructureInfo(NETQUEUE queue)
 		return;
 	}
 
-	if (StructIsFactory(psStruct))
+	if (psStruct->isFactory())
 	{
 		popStatusPending(psStruct->pFunctionality->factory);
 	}

--- a/src/objmem.cpp
+++ b/src/objmem.cpp
@@ -462,7 +462,7 @@ void killStruct(STRUCTURE *psBuilding)
 
 	if (psBuilding->pFunctionality != nullptr)
 	{
-		if (StructIsFactory(psBuilding))
+		if (psBuilding->isFactory())
 		{
 			FACTORY *psFactory = &psBuilding->pFunctionality->factory;
 

--- a/src/objmem.cpp
+++ b/src/objmem.cpp
@@ -708,7 +708,7 @@ static BASE_OBJECT* getBaseObjFromDroidId(const DroidList& list, unsigned id)
 			return psObj;
 		}
 		// if transporter check any droids in the grp
-		if ((psObj->type == OBJ_DROID) && isTransporter(psObj))
+		if ((psObj->type == OBJ_DROID) && psObj->isTransporter())
 		{
 			ASSERT_OR_RETURN(nullptr, psObj->psGroup != nullptr, "Transporter has null group?");
 			for (DROID* psTrans : psObj->psGroup->psList)
@@ -915,7 +915,7 @@ void objCount(int *droids, int *structures, int *features)
 		for (const DROID *psDroid : apsDroidLists[i])
 		{
 			(*droids)++;
-			if (isTransporter(psDroid) && psDroid->psGroup && !psDroid->psGroup->psList.empty())
+			if (psDroid->isTransporter() && psDroid->psGroup && !psDroid->psGroup->psList.empty())
 			{
 				*droids += psDroid->psGroup->psList.size();
 			}

--- a/src/order.cpp
+++ b/src/order.cpp
@@ -253,7 +253,7 @@ static DROID* _findSomeoneToRepair(REPAIR_FACILITY *psRepairFac,
 	for (GridIterator gi = gridList.begin(); gi != gridList.end(); ++gi)
 	{
 		DROID *psDroid = (DROID*) *gi;
-		if (droidIsDamaged(psDroid))
+		if (psDroid->isDamaged())
 		{
 			queue.push(psDroid);
 		}
@@ -877,7 +877,7 @@ void orderUpdateDroid(DROID *psDroid)
 			// only place it can be trapped - in multiPlayer can only put cyborgs onto a Cyborg Transporter
 			DROID *temp = (DROID *)psDroid->order.psObj;	// NOTE: It is possible to have a NULL here
 
-			if (temp && temp->droidType == DROID_TRANSPORTER && !cyborgDroid(psDroid))
+			if (temp && temp->droidType == DROID_TRANSPORTER && !psDroid->isCyborg())
 			{
 				psDroid->order = DroidOrder(DORDER_NONE);
 				actionDroid(psDroid, DACTION_NONE);
@@ -958,7 +958,7 @@ void orderUpdateDroid(DROID *psDroid)
 	case DORDER_RTR:
 	case DORDER_RTR_SPECIFIED:
 		// send them back to commander, no need to repair
-		if (!droidIsDamaged(psDroid))
+		if (!psDroid->isDamaged())
 		{
 			objTrace(psDroid->id, "was RTR, but we are full health");
 			droidWasFullyRepaired(psDroid, nullptr);
@@ -2642,7 +2642,7 @@ DroidOrder chooseOrderObj(DROID *psDroid, BASE_OBJECT *psObj, bool altOrder)
 		{
 			return DroidOrder(DORDER_DROIDREPAIR, psObj);
 		}
-		else if ((psDroid->droidType == DROID_WEAPON) || cyborgDroid(psDroid) ||
+		else if ((psDroid->droidType == DROID_WEAPON) || psDroid->isCyborg() ||
 		         (psDroid->droidType == DROID_COMMAND))
 		{
 			return DroidOrder(DORDER_ATTACK, psObj);
@@ -2713,7 +2713,7 @@ DroidOrder chooseOrderObj(DROID *psDroid, BASE_OBJECT *psObj, bool altOrder)
 	         psObj->type == OBJ_DROID &&
 	         (psDroid->droidType == DROID_REPAIR ||
 	          psDroid->droidType == DROID_CYBORG_REPAIR) &&
-	         droidIsDamaged((DROID *)psObj))
+	         ((DROID *)psObj)->isDamaged())
 	{
 		order = DroidOrder(DORDER_DROIDREPAIR, psObj);
 	}
@@ -2983,7 +2983,7 @@ void orderSelectedStatsTwoLocDir(UDWORD player, DROID_ORDER order, STRUCTURE_STA
 /** This function runs though all player's droids to check if any of then is a transporter. Returns the transporter droid if any was found, and NULL else.*/
 DROID *FindATransporter(DROID const *embarkee)
 {
-	bool isCyborg = cyborgDroid(embarkee);
+	const bool isCyborg = embarkee->isCyborg();
 
 	DROID *bestDroid = nullptr;
 	unsigned bestDist = ~0u;

--- a/src/order.cpp
+++ b/src/order.cpp
@@ -455,7 +455,7 @@ void orderUpdateDroid(DROID *psDroid)
 		{
 			orderDroidObj(psDroid, DORDER_GUARD, psDroid->psGroup->psCommander, ModeImmediate);
 		}
-		else if (isTransporter(psDroid) && !bMultiPlayer)
+		else if (psDroid->isTransporter() && !bMultiPlayer)
 		{
 
 		}
@@ -933,7 +933,7 @@ void orderUpdateDroid(DROID *psDroid)
 		if (bMultiPlayer)
 		{
 			//this order can only be given to Transporter droids
-			if (isTransporter(psDroid))
+			if (psDroid->isTransporter())
 			{
 				/*once the Transporter has reached its destination (and landed),
 				get all the units to disembark*/
@@ -1158,7 +1158,7 @@ void orderUpdateDroid(DROID *psDroid)
 			// repairing something, make sure the droid doesn't go too far
 			orderCheckGuardPosition(psDroid, CONSTRUCT_MAXDIST);
 		}
-		else if (isTransporter(psDroid))
+		else if (psDroid->isTransporter())
 		{
 
 		}
@@ -1390,7 +1390,7 @@ void orderDroidBase(DROID *psDroid, DROID_ORDER_DATA *psOrder)
 	}
 
 	// deal with a droid receiving a primary order
-	if (!isTransporter(psDroid) && psOrder->type != DORDER_NONE && psOrder->type != DORDER_STOP && psOrder->type != DORDER_GUARD)
+	if (!psDroid->isTransporter() && psOrder->type != DORDER_NONE && psOrder->type != DORDER_STOP && psOrder->type != DORDER_GUARD)
 	{
 		// reset secondary order
 		const unsigned oldState = psDroid->secondaryOrder;
@@ -1436,7 +1436,7 @@ void orderDroidBase(DROID *psDroid, DROID_ORDER_DATA *psOrder)
 	// A selected campaign transporter shouldn't be given orders by the player.
 	// Campaign transporter selection is required for it to be tracked by the camera, and
 	// should be the only case when it does get selected.
-	if (isTransporter(psDroid) &&
+	if (psDroid->isTransporter() &&
 		!bMultiPlayer &&
 		psDroid->selected &&
 		(psOrder->type != DORDER_TRANSPORTOUT &&
@@ -1471,7 +1471,7 @@ void orderDroidBase(DROID *psDroid, DROID_ORDER_DATA *psOrder)
 		}
 		//in multiPlayer, cannot move Transporter to blocking tile either
 		if (game.type == LEVEL_TYPE::SKIRMISH
-		    && isTransporter(psDroid)
+		    && psDroid->isTransporter()
 		    && fpathBlockingTile(map_coord(psOrder->pos), getPropulsionStats(psDroid)->propulsionType))
 		{
 			break;
@@ -1508,7 +1508,7 @@ void orderDroidBase(DROID *psDroid, DROID_ORDER_DATA *psOrder)
 	case DORDER_ATTACKTARGET:
 		if (psDroid->numWeaps == 0
 		    || psDroid->asWeaps[0].nStat == 0
-		    || isTransporter(psDroid))
+		    || psDroid->isTransporter())
 		{
 			break;
 		}
@@ -1522,7 +1522,7 @@ void orderDroidBase(DROID *psDroid, DROID_ORDER_DATA *psOrder)
 			//cannot attack a Transporter with EW in multiPlayer
 			// FIXME: Why not ?
 			if (game.type == LEVEL_TYPE::SKIRMISH && electronicDroid(psDroid)
-			    && psOrder->psObj->type == OBJ_DROID && isTransporter((DROID *)psOrder->psObj))
+			    && psOrder->psObj->type == OBJ_DROID && ((DROID*)psOrder->psObj)->isTransporter())
 			{
 				break;
 			}
@@ -1619,7 +1619,7 @@ void orderDroidBase(DROID *psDroid, DROID_ORDER_DATA *psOrder)
 		actionDroid(psDroid, DACTION_OBSERVE, psOrder->psObj);
 		break;
 	case DORDER_FIRESUPPORT:
-		if (isTransporter(psDroid))
+		if (psDroid->isTransporter())
 		{
 			debug(LOG_ERROR, "Sorry, transports cannot be assigned to commanders.");
 			psDroid->order = DroidOrder(DORDER_NONE);
@@ -1642,7 +1642,7 @@ void orderDroidBase(DROID *psDroid, DROID_ORDER_DATA *psOrder)
 		}
 		break;
 	case DORDER_COMMANDERSUPPORT:
-		if (isTransporter(psDroid))
+		if (psDroid->isTransporter())
 		{
 			debug(LOG_ERROR, "Sorry, transports cannot be assigned to commanders.");
 			psDroid->order = DroidOrder(DORDER_NONE);
@@ -1667,7 +1667,7 @@ void orderDroidBase(DROID *psDroid, DROID_ORDER_DATA *psOrder)
 
 				psDroid->order = *psOrder;
 				// Find a place to land for vtols. And Transporters in a multiPlay game.
-				if (isVtolDroid(psDroid) || (game.type == LEVEL_TYPE::SKIRMISH && isTransporter(psDroid)))
+				if (isVtolDroid(psDroid) || (game.type == LEVEL_TYPE::SKIRMISH && psDroid->isTransporter()))
 				{
 					actionVTOLLandingPos(psDroid, &pos);
 				}
@@ -1725,7 +1725,7 @@ void orderDroidBase(DROID *psDroid, DROID_ORDER_DATA *psOrder)
 			psDroid->order.pos = psOrder->psObj->pos.xy();
 			/* If in multiPlayer, and the Transporter has been sent to be
 				* repaired, need to find a suitable location to drop down. */
-			if (game.type == LEVEL_TYPE::SKIRMISH && isTransporter(psDroid))
+			if (game.type == LEVEL_TYPE::SKIRMISH && psDroid->isTransporter())
 			{
 				Vector2i pos = psDroid->order.pos;
 				objTrace(psDroid->id, "Repair transport");
@@ -1771,7 +1771,7 @@ void orderDroidBase(DROID *psDroid, DROID_ORDER_DATA *psOrder)
 				psDroid->order.pos = rtrData.psObj->pos.xy();
 				/* If in multiPlayer, and the Transporter has been sent to be
 					* repaired, need to find a suitable location to drop down. */
-				if (game.type == LEVEL_TYPE::SKIRMISH && isTransporter(psDroid))
+				if (game.type == LEVEL_TYPE::SKIRMISH && psDroid->isTransporter())
 				{
 					Vector2i pos = psDroid->order.pos;
 
@@ -1786,7 +1786,7 @@ void orderDroidBase(DROID *psDroid, DROID_ORDER_DATA *psOrder)
 				}
 			}
 			/* give repair order if repair droid found */
-			else if (rtrData.type == RTR_TYPE_DROID && !isTransporter(psDroid))
+			else if (rtrData.type == RTR_TYPE_DROID && !psDroid->isTransporter())
 			{
 				psDroid->order = DroidOrder(psOrder->type, Vector2i(rtrData.psObj->pos.x, rtrData.psObj->pos.y), RTR_TYPE_DROID);
 				psDroid->order.pos = rtrData.psObj->pos.xy();
@@ -1808,8 +1808,8 @@ void orderDroidBase(DROID *psDroid, DROID_ORDER_DATA *psOrder)
 	case DORDER_EMBARK:
 		{
 			DROID *embarkee = castDroid(psOrder->psObj);
-			if (isTransporter(psDroid)  // require a transporter for embarking.
-			    || embarkee == nullptr || !isTransporter(embarkee))  // nor can a transporter load another transporter
+			if (psDroid->isTransporter()  // require a transporter for embarking.
+			    || embarkee == nullptr || !embarkee->isTransporter())  // nor can a transporter load another transporter
 			{
 				debug(LOG_ERROR, "Sorry, can only load things that aren't transporters into things that are.");
 				psDroid->order = DroidOrder(DORDER_NONE);
@@ -1826,7 +1826,7 @@ void orderDroidBase(DROID *psDroid, DROID_ORDER_DATA *psOrder)
 		if (bMultiPlayer)
 		{
 			//this order can only be given to Transporter droids
-			if (isTransporter(psDroid))
+			if (psDroid->isTransporter())
 			{
 				psDroid->order = *psOrder;
 				//move the Transporter to the requested location
@@ -2471,7 +2471,7 @@ DROID_ORDER chooseOrderLoc(DROID *psDroid, UDWORD x, UDWORD y, bool altOrder)
 	DROID_ORDER		order = DORDER_NONE;
 	PROPULSION_TYPE		propulsion = getPropulsionStats(psDroid)->propulsionType;
 
-	if (isTransporter(psDroid) && game.type == LEVEL_TYPE::CAMPAIGN)
+	if (psDroid->isTransporter() && game.type == LEVEL_TYPE::CAMPAIGN)
 	{
 		// transports can't be controlled in campaign
 		return DORDER_NONE;
@@ -2500,7 +2500,7 @@ DROID_ORDER chooseOrderLoc(DROID *psDroid, UDWORD x, UDWORD y, bool altOrder)
 	}
 
 	// and now we want Transporters to fly! - in multiPlayer!!
-	if (isTransporter(psDroid) && game.type == LEVEL_TYPE::SKIRMISH)
+	if (psDroid->isTransporter() && game.type == LEVEL_TYPE::SKIRMISH)
 	{
 		/* in MultiPlayer - if ALT-key is pressed then need to get the Transporter
 		 * to fly to location and all units disembark */
@@ -2611,7 +2611,7 @@ DroidOrder chooseOrderObj(DROID *psDroid, BASE_OBJECT *psObj, bool altOrder)
 {
 	DroidOrder order(DORDER_NONE);
 
-	if (isTransporter(psDroid))
+	if (psDroid->isTransporter())
 	{
 		//in multiPlayer, need to be able to get Transporter repaired
 		if (bMultiPlayer)
@@ -2649,7 +2649,7 @@ DroidOrder chooseOrderObj(DROID *psDroid, BASE_OBJECT *psObj, bool altOrder)
 		}
 	}
 	//check for transporters first
-	if (psObj->type == OBJ_DROID && isTransporter((DROID *)psObj) && psObj->player == psDroid->player)
+	if (psObj->type == OBJ_DROID && ((DROID*)psObj)->isTransporter() && psObj->player == psDroid->player)
 	{
 		order = DroidOrder(DORDER_EMBARK, psObj);
 	}

--- a/src/order.cpp
+++ b/src/order.cpp
@@ -319,7 +319,7 @@ static std::pair<STRUCTURE *, DROID_ACTION> checkForDamagedStruct(DROID *psDroid
 		}
 
 		// Check for structures to repair.
-		if (structure->status == SS_BUILT && structIsDamaged(structure))
+		if (structure->status == SS_BUILT && structure->isDamaged())
 		{
 			bestDistanceSq = distanceSq;
 			best = {structure, DACTION_REPAIR};

--- a/src/order.cpp
+++ b/src/order.cpp
@@ -4028,7 +4028,7 @@ void secondarySetAverageGroupState(UDWORD player, UDWORD group)
  */
 bool setFactoryState(STRUCTURE *psStruct, SECONDARY_ORDER sec, SECONDARY_STATE State)
 {
-	if (!psStruct->isFactory())
+	if (!psStruct || !psStruct->isFactory())
 	{
 		ASSERT(false, "setFactoryState: structure is not a factory");
 		return false;
@@ -4097,7 +4097,7 @@ bool setFactoryState(STRUCTURE *psStruct, SECONDARY_ORDER sec, SECONDARY_STATE S
  */
 bool getFactoryState(const STRUCTURE *psStruct, SECONDARY_ORDER sec, SECONDARY_STATE *pState)
 {
-	ASSERT_OR_RETURN(false, psStruct->isFactory(), "Structure is not a factory");
+	ASSERT_OR_RETURN(false, psStruct && psStruct->isFactory(), "Structure is not a factory");
 	if ((FACTORY *)psStruct->pFunctionality)
 	{
 		UDWORD state = ((FACTORY *)psStruct->pFunctionality)->secondaryOrder;

--- a/src/order.cpp
+++ b/src/order.cpp
@@ -1089,7 +1089,7 @@ void orderUpdateDroid(DROID *psDroid)
 
 				//if not currently attacking or target has changed
 				if (bAttack &&
-				    (!droidAttacking(psDroid) ||
+				    (!psDroid->isAttacking() ||
 				     psFireTarget != psDroid->psActionTarget[0]))
 				{
 					//get the droid to attack
@@ -3645,7 +3645,7 @@ bool secondarySetState(DROID *psDroid, SECONDARY_ORDER sec, SECONDARY_STATE Stat
 					moveToRearm(psDroid);
 				}
 			}
-			else if (droidAttacking(psDroid))
+			else if (psDroid->isAttacking())
 			{
 				// send the unit back to the guard position
 				actionDroid(psDroid, DACTION_NONE);

--- a/src/order.cpp
+++ b/src/order.cpp
@@ -2775,7 +2775,7 @@ DroidOrder chooseOrderObj(DROID *psDroid, BASE_OBJECT *psObj, bool altOrder)
 					}
 				}
 			}
-			else if (psStruct->body < structureBody(psStruct))
+			else if (psStruct->body < psStruct->structureBody())
 			{
 				order = DroidOrder(DORDER_REPAIR, psObj);
 			}
@@ -4028,7 +4028,7 @@ void secondarySetAverageGroupState(UDWORD player, UDWORD group)
  */
 bool setFactoryState(STRUCTURE *psStruct, SECONDARY_ORDER sec, SECONDARY_STATE State)
 {
-	if (!StructIsFactory(psStruct))
+	if (!psStruct->isFactory())
 	{
 		ASSERT(false, "setFactoryState: structure is not a factory");
 		return false;
@@ -4097,7 +4097,7 @@ bool setFactoryState(STRUCTURE *psStruct, SECONDARY_ORDER sec, SECONDARY_STATE S
  */
 bool getFactoryState(const STRUCTURE *psStruct, SECONDARY_ORDER sec, SECONDARY_STATE *pState)
 {
-	ASSERT_OR_RETURN(false, StructIsFactory(psStruct), "Structure is not a factory");
+	ASSERT_OR_RETURN(false, psStruct->isFactory(), "Structure is not a factory");
 	if ((FACTORY *)psStruct->pFunctionality)
 	{
 		UDWORD state = ((FACTORY *)psStruct->pFunctionality)->secondaryOrder;

--- a/src/order.cpp
+++ b/src/order.cpp
@@ -1165,7 +1165,7 @@ void orderUpdateDroid(DROID *psDroid)
 		else
 		{
 			//let vtols return to rearm
-			if (!vtolRearming(psDroid))
+			if (!psDroid->isVtolRearming())
 			{
 				// attacking something, make sure the droid doesn't go too far
 				if (psDroid->order.psObj != nullptr && psDroid->order.psObj->type == OBJ_DROID &&
@@ -1219,7 +1219,7 @@ void orderUpdateDroid(DROID *psDroid)
 	}
 
 	// catch any vtol that is rearming but has finished his order
-	if (psDroid->order.type == DORDER_NONE && vtolRearming(psDroid)
+	if (psDroid->order.type == DORDER_NONE && psDroid->isVtolRearming()
 	    && (psDroid->psActionTarget[0] == nullptr || !psDroid->psActionTarget[0]->died))
 	{
 		psDroid->order = DroidOrder(DORDER_REARM, psDroid->psActionTarget[0]);
@@ -1894,7 +1894,7 @@ void orderDroidBase(DROID *psDroid, DROID_ORDER_DATA *psOrder)
 		break;
 	case DORDER_REARM:
 		// didn't get executed before
-		if (!vtolRearming(psDroid))
+		if (!psDroid->isVtolRearming())
 		{
 			psDroid->order = *psOrder;
 			actionDroid(psDroid, DACTION_MOVETOREARM, psOrder->psObj);
@@ -3299,7 +3299,7 @@ void secondaryCheckDamageLevel(DROID *psDroid)
 		/* set return to repair if not on hold */
 		if (psDroid->order.type != DORDER_RTR &&
 		    psDroid->order.type != DORDER_RTB &&
-		    !vtolRearming(psDroid))
+		    !psDroid->isVtolRearming())
 		{
 			if (psDroid->isVtol())
 			{

--- a/src/order.cpp
+++ b/src/order.cpp
@@ -1544,7 +1544,7 @@ void orderDroidBase(DROID *psDroid, DROID_ORDER_DATA *psOrder)
 	case DORDER_BUILD:
 	case DORDER_LINEBUILD:
 		// build a new structure or line of structures
-		ASSERT_OR_RETURN(, isConstructionDroid(psDroid), "%s cannot construct things!", objInfo(psDroid));
+		ASSERT_OR_RETURN(, psDroid->isConstructionDroid(), "%s cannot construct things!", objInfo(psDroid));
 		ASSERT_OR_RETURN(, psOrder->psStats != nullptr, "invalid structure stats pointer");
 		psDroid->order = *psOrder;
 		ASSERT_OR_RETURN(, !psDroid->order.psStats || psDroid->order.psStats->type != REF_DEMOLISH, "Cannot build demolition");
@@ -1554,7 +1554,7 @@ void orderDroidBase(DROID *psDroid, DROID_ORDER_DATA *psOrder)
 	case DORDER_BUILDMODULE:
 		{
 			//build a module onto the structure
-			if (!isConstructionDroid(psDroid) || psOrder->index < nextModuleToBuild((STRUCTURE *)psOrder->psObj, -1))
+			if (!psDroid->isConstructionDroid() || psOrder->index < nextModuleToBuild((STRUCTURE *)psOrder->psObj, -1))
 			{
 				break;
 			}
@@ -1568,7 +1568,7 @@ void orderDroidBase(DROID *psDroid, DROID_ORDER_DATA *psOrder)
 		break;
 	case DORDER_HELPBUILD:
 		// help to build a structure that is starting to be built
-		ASSERT_OR_RETURN(, isConstructionDroid(psDroid), "Not a constructor droid");
+		ASSERT_OR_RETURN(, psDroid->isConstructionDroid(), "Not a constructor droid");
 		ASSERT_OR_RETURN(, psOrder->psObj != nullptr, "Help to build a NULL pointer?");
 		if (psDroid->action == DACTION_BUILD && psOrder->psObj == psDroid->psActionTarget[0] 
 			// skip DORDER_LINEBUILD -> we still want to drop pending structure blueprints
@@ -2887,7 +2887,7 @@ void orderSelectedObjAdd(UDWORD player, BASE_OBJECT *psObj, bool add)
 		{
 			if (isBlueprint(psObj))
 			{
-				if (isConstructionDroid(psCurr))
+				if (psCurr->isConstructionDroid())
 				{
 					// Help build the planned structure.
 #if defined(WZ_CC_GNU) && !defined(WZ_CC_INTEL) && !defined(WZ_CC_CLANG) && (7 <= __GNUC__)
@@ -2941,7 +2941,7 @@ void orderSelectedStatsLocDir(UDWORD player, DROID_ORDER order, STRUCTURE_STATS 
 
 	for (DROID *psCurr : apsDroidLists[player])
 	{
-		if (psCurr->selected && isConstructionDroid(psCurr))
+		if (psCurr->selected && psCurr->isConstructionDroid())
 		{
 			if (add)
 			{

--- a/src/projectile.cpp
+++ b/src/projectile.cpp
@@ -844,7 +844,7 @@ static void proj_InFlightFunc(PROJECTILE *psProj)
 		else if (!(psStats->surfaceToAir & SHOOT_ON_GROUND) &&
 		         (psTempObj->type == OBJ_STRUCTURE ||
 		          psTempObj->type == OBJ_FEATURE ||
-		          (psTempObj->type == OBJ_DROID && !isFlying((DROID *)psTempObj))
+		          (psTempObj->type == OBJ_DROID && !((DROID*)psTempObj)->isFlying())
 		         ))
 		{
 			// AA weapons should not hit buildings and non-vtol droids
@@ -1429,7 +1429,7 @@ static void proj_checkPeriodicalDamage(PROJECTILE *psProj)
 		}
 
 		if (psCurr->type == OBJ_DROID &&
-		    isVtolDroid((DROID *)psCurr) &&
+		    ((DROID *)psCurr)->isVtol() &&
 		    ((DROID *)psCurr)->sMove.Status != MOVEINACTIVE)
 		{
 			continue;  // Can't set flying vtols on fire.
@@ -1764,7 +1764,7 @@ int establishTargetHeight(BASE_OBJECT const *psTarget)
 			unsigned int utilityHeight = 0, yMax = 0, yMin = 0; // Temporaries for addition of utility's height to total height
 
 			// VTOL's don't have pIMD either it seems...
-			if (isVtolDroid(psDroid))
+			if (psDroid->isVtol())
 			{
 				return (height + VTOL_HITBOX_MODIFICATOR);
 			}

--- a/src/quickjs_backend.cpp
+++ b/src/quickjs_backend.cpp
@@ -1004,7 +1004,7 @@ JSValue convDroid(const DROID *psDroid, JSContext *ctx)
 		break;
 	}
 	QuickJS_DefinePropertyValue(ctx, value, "bodySize", JS_NewInt32(ctx, psBodyStats->size), JS_PROP_ENUMERABLE);
-	if (isTransporter(psDroid))
+	if (psDroid->isTransporter())
 	{
 		QuickJS_DefinePropertyValue(ctx, value, "cargoCapacity", JS_NewInt32(ctx, TRANSPORTER_CAPACITY), JS_PROP_ENUMERABLE);
 		QuickJS_DefinePropertyValue(ctx, value, "cargoLeft", JS_NewInt32(ctx, calcRemainingCapacity(psDroid)), JS_PROP_ENUMERABLE);

--- a/src/quickjs_backend.cpp
+++ b/src/quickjs_backend.cpp
@@ -831,7 +831,7 @@ JSValue convStructure(const STRUCTURE *psStruct, JSContext *ctx)
 	QuickJS_DefinePropertyValue(ctx, value, "isRadarDetector", JS_NewBool(ctx, objRadarDetector(psStruct)), JS_PROP_ENUMERABLE);
 	QuickJS_DefinePropertyValue(ctx, value, "range", JS_NewInt32(ctx, range), JS_PROP_ENUMERABLE);
 	QuickJS_DefinePropertyValue(ctx, value, "status", JS_NewInt32(ctx, (int)psStruct->status), JS_PROP_ENUMERABLE);
-	QuickJS_DefinePropertyValue(ctx, value, "health", JS_NewInt32(ctx, 100 * psStruct->body / MAX(1, structureBody(psStruct))), JS_PROP_ENUMERABLE);
+	QuickJS_DefinePropertyValue(ctx, value, "health", JS_NewInt32(ctx, 100 * psStruct->body / MAX(1, psStruct->structureBody())), JS_PROP_ENUMERABLE);
 	QuickJS_DefinePropertyValue(ctx, value, "cost", JS_NewInt32(ctx, psStruct->pStructureType->powerToBuild), JS_PROP_ENUMERABLE);
 	int stattype = 0;
 	switch (psStruct->pStructureType->type) // don't bleed our source insanities into the scripting world

--- a/src/quickjs_backend.cpp
+++ b/src/quickjs_backend.cpp
@@ -1015,7 +1015,7 @@ JSValue convDroid(const DROID *psDroid, JSContext *ctx)
 	QuickJS_DefinePropertyValue(ctx, value, "isSensor", JS_NewBool(ctx, standardSensorDroid(psDroid)), JS_PROP_ENUMERABLE);
 	QuickJS_DefinePropertyValue(ctx, value, "canHitAir", JS_NewBool(ctx, aa), JS_PROP_ENUMERABLE);
 	QuickJS_DefinePropertyValue(ctx, value, "canHitGround", JS_NewBool(ctx, ga), JS_PROP_ENUMERABLE);
-	QuickJS_DefinePropertyValue(ctx, value, "isVTOL", JS_NewBool(ctx, isVtolDroid(psDroid)), JS_PROP_ENUMERABLE);
+	QuickJS_DefinePropertyValue(ctx, value, "isVTOL", JS_NewBool(ctx, psDroid->isVtol()), JS_PROP_ENUMERABLE);
 	QuickJS_DefinePropertyValue(ctx, value, "droidType", JS_NewInt32(ctx, (int)type), JS_PROP_ENUMERABLE);
 	QuickJS_DefinePropertyValue(ctx, value, "experience", JS_NewFloat64(ctx, (double)psDroid->experience / 65536.0), JS_PROP_ENUMERABLE);
 	QuickJS_DefinePropertyValue(ctx, value, "health", JS_NewFloat64(ctx, 100.0 / (double)psDroid->originalBody * (double)psDroid->body), JS_PROP_ENUMERABLE);

--- a/src/research.cpp
+++ b/src/research.cpp
@@ -1585,7 +1585,7 @@ void replaceDroidComponent(DroidList& pList, UDWORD oldType, UDWORD oldCompInc,
 	{
 		switchComponent(psDroid, oldType, oldCompInc, newCompInc);
 		// Need to replace the units inside the transporter
-		if (isTransporter(psDroid))
+		if (psDroid->isTransporter())
 		{
 			replaceTransDroidComponents(psDroid, oldType, oldCompInc, newCompInc);
 		}
@@ -1596,7 +1596,7 @@ void replaceDroidComponent(DroidList& pList, UDWORD oldType, UDWORD oldCompInc,
 void replaceTransDroidComponents(DROID *psTransporter, UDWORD oldType,
                                  UDWORD oldCompInc, UDWORD newCompInc)
 {
-	ASSERT(isTransporter(psTransporter), "invalid unit type");
+	ASSERT(psTransporter->isTransporter(), "invalid unit type");
 
 	for (DROID* psCurr : psTransporter->psGroup->psList)
 	{

--- a/src/scores.cpp
+++ b/src/scores.cpp
@@ -310,7 +310,7 @@ END_GAME_STATS_DATA	collectEndGameStatsData()
 			}
 			for (const DROID* psDroid : *dList)
 			{
-				if (isTransporter(psDroid))
+				if (psDroid->isTransporter())
 				{
 					for (DROID *psCurr : psDroid->psGroup->psList)
 					{

--- a/src/scores.cpp
+++ b/src/scores.cpp
@@ -627,7 +627,7 @@ void stdOutGameSummary(UDWORD realTimeThrottleSeconds, bool flush_output /* = tr
 				{
 					continue; // ignore structures that aren't completely built, or are "dead"
 				}
-				if (StructIsFactory(psStruct))
+				if (psStruct->isFactory())
 				{
 					numFactories++;
 					if (psStruct->pStructureType->type == REF_FACTORY ||

--- a/src/selection.cpp
+++ b/src/selection.cpp
@@ -86,7 +86,7 @@ static unsigned selSelectUnitsIf(unsigned player, T condition, U value, bool onl
 
 static bool selTransporter(DROID *droid)
 {
-	return isTransporter(droid);
+	return droid->isTransporter();
 }
 static bool selTrue(DROID *droid)
 {

--- a/src/structure.cpp
+++ b/src/structure.cpp
@@ -4704,30 +4704,30 @@ STRUCTURE_STATS *getStructStatsFromName(const WzString &name)
 }
 
 /*check to see if the structure is 'doing' anything  - return true if idle*/
-bool  structureIdle(const STRUCTURE *psBuilding)
+bool  STRUCTURE::isIdle() const
 {
 	BASE_STATS		*pSubject = nullptr;
 
-	CHECK_STRUCTURE(psBuilding);
+	CHECK_STRUCTURE(this);
 
-	if (psBuilding->pFunctionality == nullptr)
+	if (pFunctionality == nullptr)
 	{
 		return true;
 	}
 
 	//determine the Subject
-	switch (psBuilding->pStructureType->type)
+	switch (pStructureType->type)
 	{
 	case REF_RESEARCH:
 		{
-			pSubject = psBuilding->pFunctionality->researchFacility.psSubject;
+			pSubject = pFunctionality->researchFacility.psSubject;
 			break;
 		}
 	case REF_FACTORY:
 	case REF_CYBORG_FACTORY:
 	case REF_VTOL_FACTORY:
 		{
-			pSubject = psBuilding->pFunctionality->factory.psSubject;
+			pSubject = pFunctionality->factory.psSubject;
 			break;
 		}
 	default:

--- a/src/structure.cpp
+++ b/src/structure.cpp
@@ -226,17 +226,17 @@ static int numStructureModules(STRUCTURE const *psStruct)
 	return psStruct->capacity;
 }
 
-bool structureIsBlueprint(const STRUCTURE *psStructure)
+bool STRUCTURE::isBlueprint() const
 {
-	return (psStructure->status == SS_BLUEPRINT_VALID ||
-	        psStructure->status == SS_BLUEPRINT_INVALID ||
-	        psStructure->status == SS_BLUEPRINT_PLANNED ||
-	        psStructure->status == SS_BLUEPRINT_PLANNED_BY_ALLY);
+	return (status == SS_BLUEPRINT_VALID ||
+	        status == SS_BLUEPRINT_INVALID ||
+	        status == SS_BLUEPRINT_PLANNED ||
+	        status == SS_BLUEPRINT_PLANNED_BY_ALLY);
 }
 
 bool isBlueprint(const BASE_OBJECT *psObject)
 {
-	return psObject != nullptr && psObject->type == OBJ_STRUCTURE && structureIsBlueprint((const STRUCTURE *)psObject);
+	return psObject != nullptr && psObject->type == OBJ_STRUCTURE && ((const STRUCTURE*)psObject)->isBlueprint();
 }
 
 void initStructLimits()

--- a/src/structure.cpp
+++ b/src/structure.cpp
@@ -5628,7 +5628,7 @@ bool electronicDamage(BASE_OBJECT *psTarget, UDWORD damage, UBYTE attackPlayer)
 		if (psDroid->resistance == ACTION_START_TIME)
 		{
 			//need to set the current resistance level since not been previously attacked (by EW)
-			psDroid->resistance = droidResistance(psDroid);
+			psDroid->resistance = psDroid->droidResistance();
 		}
 
 		if (psDroid->resistance < 0)

--- a/src/structure.cpp
+++ b/src/structure.cpp
@@ -2540,7 +2540,7 @@ static bool structPlaceDroid(STRUCTURE *psStructure, DROID_TEMPLATE *psTempl, DR
 				orderDroidObj(psNewDroid, DORDER_FIRESUPPORT, psFact->psCommander, ModeQueue);
 				//moveToRearm(psNewDroid);
 			}
-			else if (!isConstructionDroid(psNewDroid))
+			else if (!psNewDroid->isConstructionDroid())
 			{
 				orderDroidObj(psNewDroid, DORDER_COMMANDERSUPPORT, psFact->psCommander, ModeQueue);
 			}

--- a/src/structure.cpp
+++ b/src/structure.cpp
@@ -6735,9 +6735,9 @@ bool vtolOnRearmPad(const STRUCTURE *psStruct, const DROID *psDroid)
 
 
 /* Just returns true if the structure's present body points aren't as high as the original*/
-bool	structIsDamaged(const STRUCTURE *psStruct)
+bool	STRUCTURE::isDamaged() const
 {
-	return psStruct->body < psStruct->structureBody();
+	return body < structureBody();
 }
 
 // give a structure from one player to another - used in Electronic Warfare

--- a/src/structure.cpp
+++ b/src/structure.cpp
@@ -2522,7 +2522,7 @@ static bool structPlaceDroid(STRUCTURE *psStructure, DROID_TEMPLATE *psTempl, DR
 			assignCommander = true;
 		}
 
-		if (isVtolDroid(psNewDroid) && !isTransporter(psNewDroid))
+		if (isVtolDroid(psNewDroid) && !psNewDroid->isTransporter())
 		{
 			moveToRearm(psNewDroid);
 		}
@@ -2530,7 +2530,7 @@ static bool structPlaceDroid(STRUCTURE *psStructure, DROID_TEMPLATE *psTempl, DR
 		{
 			// TODO: Should synchronise .psCommander in all cases.
 			//syncDebug("Has commander.");
-			if (isTransporter(psNewDroid))
+			if (psNewDroid->isTransporter())
 			{
 				// Transporters can't be assigned to commanders, due to abuse of .psGroup. Try to land on the commander instead. Hopefully the transport is heavy enough to crush the commander.
 				orderDroidLoc(psNewDroid, DORDER_MOVE, psFact->psCommander->pos.x, psFact->psCommander->pos.y, ModeQueue);
@@ -5622,7 +5622,7 @@ bool electronicDamage(BASE_OBJECT *psTarget, UDWORD damage, UBYTE attackPlayer)
 		//in multiPlayer cannot attack a Transporter with EW
 		if (bMultiPlayer)
 		{
-			ASSERT_OR_RETURN(true, !isTransporter(psDroid), "Cannot attack a Transporter in multiPlayer");
+			ASSERT_OR_RETURN(true, !psDroid->isTransporter(), "Cannot attack a Transporter in multiPlayer");
 		}
 
 		if (psDroid->resistance == ACTION_START_TIME)

--- a/src/structure.cpp
+++ b/src/structure.cpp
@@ -3465,7 +3465,7 @@ static void aiUpdateStructure(STRUCTURE *psStructure, bool isMission)
 						}
 					}
 				}
-				if (droidIsDamaged(psDroid)) // do repairs
+				if (psDroid->isDamaged()) // do repairs
 				{
 					psDroid->body += gameTimeAdjustedAverage(getBuildingRepairPoints(psStructure));
 					if (psDroid->body >= psDroid->originalBody)

--- a/src/structure.cpp
+++ b/src/structure.cpp
@@ -2522,7 +2522,7 @@ static bool structPlaceDroid(STRUCTURE *psStructure, DROID_TEMPLATE *psTempl, DR
 			assignCommander = true;
 		}
 
-		if (isVtolDroid(psNewDroid) && !psNewDroid->isTransporter())
+		if (psNewDroid->isVtol() && !psNewDroid->isTransporter())
 		{
 			moveToRearm(psNewDroid);
 		}
@@ -2535,7 +2535,7 @@ static bool structPlaceDroid(STRUCTURE *psStructure, DROID_TEMPLATE *psTempl, DR
 				// Transporters can't be assigned to commanders, due to abuse of .psGroup. Try to land on the commander instead. Hopefully the transport is heavy enough to crush the commander.
 				orderDroidLoc(psNewDroid, DORDER_MOVE, psFact->psCommander->pos.x, psFact->psCommander->pos.y, ModeQueue);
 			}
-			else if (isVtolDroid(psNewDroid))
+			else if (psNewDroid->isVtol())
 			{
 				orderDroidObj(psNewDroid, DORDER_FIRESUPPORT, psFact->psCommander, ModeQueue);
 				//moveToRearm(psNewDroid);
@@ -2566,7 +2566,7 @@ static bool structPlaceDroid(STRUCTURE *psStructure, DROID_TEMPLATE *psTempl, DR
 			});
 			ASSERT(psFlag != flagPosList.end(), "No flag found for %s at (%d, %d)", objInfo(psStructure), psStructure->pos.x, psStructure->pos.y);
 			//if vtol droid - send it to ReArm Pad if one exists
-			if (psFlag != flagPosList.end() && isVtolDroid(psNewDroid))
+			if (psFlag != flagPosList.end() && psNewDroid->isVtol())
 			{
 				Vector2i pos = (*psFlag)->coords.xy();
 				//find a suitable location near the delivery point
@@ -3409,7 +3409,7 @@ static void aiUpdateStructure(STRUCTURE *psStructure, bool isMission)
 
 			psDroid = (DROID *)psChosenObj;
 			ASSERT_OR_RETURN(, psDroid != nullptr, "invalid droid pointer");
-			ASSERT_OR_RETURN(, isVtolDroid(psDroid), "invalid droid type");
+			ASSERT_OR_RETURN(, psDroid->isVtol(), "invalid droid type");
 
 			//check hasn't died whilst waiting to be rearmed
 			// also clear out any previously repaired droid
@@ -5349,7 +5349,7 @@ static unsigned int countAssignedDroids(const STRUCTURE *psStructure)
 
 			if (weapontype == MM_INDIRECT
 			    || weapontype == MM_HOMINGINDIRECT
-			    || isVtolDroid(psCurr))
+			    || psCurr->isVtol())
 			{
 				num++;
 			}
@@ -6513,7 +6513,7 @@ bool structSensorDroidWeapon(const STRUCTURE *psStruct, const DROID *psDroid)
 		//else if (structStandardSensor(psStruct) && (psDroid->numWeaps &&
 		if (structStandardSensor(psStruct) && (psDroid->asWeaps[0].nStat > 0 &&
 		                                       !proj_Direct(asWeaponStats + psDroid->asWeaps[0].nStat)) &&
-		    !isVtolDroid(psDroid))
+		    !psDroid->isVtol())
 		{
 			return true;
 		}
@@ -6521,21 +6521,21 @@ bool structSensorDroidWeapon(const STRUCTURE *psStruct, const DROID *psDroid)
 		//if (structCBSensor(psStruct) && (psDroid->numWeaps &&
 		else if (structCBSensor(psStruct) && (psDroid->asWeaps[0].nStat > 0 &&
 		                                      !proj_Direct(asWeaponStats + psDroid->asWeaps[0].nStat)) &&
-		         !isVtolDroid(psDroid))
+		         !psDroid->isVtol())
 		{
 			return true;
 		}
 		//VTOL Intercept Sensor Tower + any weapon VTOL droid
 		//else if (structVTOLSensor(psStruct) && psDroid->numWeaps &&
 		else if (structVTOLSensor(psStruct) && psDroid->asWeaps[0].nStat > 0 &&
-		         isVtolDroid(psDroid))
+		         psDroid->isVtol())
 		{
 			return true;
 		}
 		//VTOL CB Sensor Tower + any weapon VTOL droid
 		//else if (structVTOLCBSensor(psStruct) && psDroid->numWeaps &&
 		else if (structVTOLCBSensor(psStruct) && psDroid->asWeaps[0].nStat > 0 &&
-		         isVtolDroid(psDroid))
+		         psDroid->isVtol())
 		{
 			return true;
 		}
@@ -6703,7 +6703,7 @@ void ensureRearmPadClear(STRUCTURE *psStruct, DROID *psDroid)
 				if (psCurr != psDroid
 				    && map_coord(psCurr->pos.x) == tx
 				    && map_coord(psCurr->pos.y) == ty
-				    && isVtolDroid(psCurr))
+				    && psCurr->isVtol())
 				{
 					actionDroid(psCurr, DACTION_CLEARREARMPAD, psStruct);
 				}

--- a/src/structure.cpp
+++ b/src/structure.cpp
@@ -987,7 +987,7 @@ void structureRepair(STRUCTURE *psStruct, DROID *psDroid, int buildRate)
 
 static void refundFactoryBuildPower(STRUCTURE *psBuilding)
 {
-	ASSERT_OR_RETURN(, psBuilding->isFactory(), "structure not a factory");
+	ASSERT_OR_RETURN(, psBuilding && psBuilding->isFactory(), "structure not a factory");
 	FACTORY *psFactory = &psBuilding->pFunctionality->factory;
 
 	if (psFactory->psSubject)
@@ -1667,6 +1667,10 @@ STRUCTURE *buildStructureDir(STRUCTURE_STATS *pStructureType, UDWORD x, UDWORD y
 		{
 			for (const STRUCTURE *psStruct : apsStructLists[playerNum])
 			{
+				if (!psStruct)
+				{
+					continue;
+				}
 				FLAG_POSITION *fp = nullptr;
 				if (psStruct->isFactory())
 				{
@@ -5990,7 +5994,7 @@ bool FlagIsFactory(const FLAG_POSITION *psCurrFlag)
 //
 FLAG_POSITION *FindFactoryDelivery(const STRUCTURE *Struct)
 {
-	if (Struct->isFactory())
+	if (Struct && Struct->isFactory())
 	{
 		// Find the factories delivery point.
 		for (const auto& psFlag : apsFlagPosLists[Struct->player])
@@ -6016,6 +6020,10 @@ STRUCTURE	*findDeliveryFactory(FLAG_POSITION *psDelPoint)
 
 	for (STRUCTURE* psCurr : apsStructLists[psDelPoint->player])
 	{
+		if (!psCurr)
+		{
+			continue;
+		}
 		if (psCurr->isFactory())
 		{
 			psFactory = &psCurr->pFunctionality->factory;
@@ -6041,7 +6049,7 @@ STRUCTURE	*findDeliveryFactory(FLAG_POSITION *psDelPoint)
 accrued but not used*/
 void cancelProduction(STRUCTURE *psBuilding, QUEUE_MODE mode, bool mayClearProductionRun)
 {
-	ASSERT_OR_RETURN(, psBuilding->isFactory(), "structure not a factory");
+	ASSERT_OR_RETURN(, psBuilding && psBuilding->isFactory(), "structure not a factory");
 
 	FACTORY *psFactory = &psBuilding->pFunctionality->factory;
 
@@ -6075,7 +6083,7 @@ void holdProduction(STRUCTURE *psBuilding, QUEUE_MODE mode)
 {
 	FACTORY *psFactory;
 
-	ASSERT_OR_RETURN(, psBuilding->isFactory(), "structure not a factory");
+	ASSERT_OR_RETURN(, psBuilding && psBuilding->isFactory(), "structure not a factory");
 
 	psFactory = &psBuilding->pFunctionality->factory;
 
@@ -6104,7 +6112,7 @@ void holdProduction(STRUCTURE *psBuilding, QUEUE_MODE mode)
 /*release a factory's production run from hold*/
 void releaseProduction(STRUCTURE *psBuilding, QUEUE_MODE mode)
 {
-	ASSERT_OR_RETURN(, psBuilding->isFactory(), "structure not a factory");
+	ASSERT_OR_RETURN(, psBuilding && psBuilding->isFactory(), "structure not a factory");
 
 	FACTORY *psFactory = &psBuilding->pFunctionality->factory;
 
@@ -6396,6 +6404,10 @@ void checkDeliveryPoints(UDWORD version)
 		{
 			for (STRUCTURE* psStruct : apsStructLists[inc])
 			{
+				if (!psStruct)
+				{
+					continue;
+				}
 				if (psStruct->isFactory())
 				{
 					//check the DP
@@ -6455,7 +6467,7 @@ void factoryLoopAdjust(STRUCTURE *psStruct, bool add)
 {
 	FACTORY		*psFactory;
 
-	ASSERT_OR_RETURN(, psStruct->isFactory(), "structure is not a factory");
+	ASSERT_OR_RETURN(, psStruct && psStruct->isFactory(), "structure is not a factory");
 	ASSERT_OR_RETURN(, psStruct->player == selectedPlayer, "should only be called for selectedPlayer");
 
 	psFactory = &psStruct->pFunctionality->factory;

--- a/src/structure.h
+++ b/src/structure.h
@@ -136,8 +136,6 @@ void alignStructure(STRUCTURE *psBuilding);
 void setCurrentStructQuantity(bool displayError);
 /* get a stat inc based on the name */
 int32_t getStructStatFromName(const WzString &name);
-/*check to see if the structure is 'doing' anything  - return true if idle*/
-bool  structureIdle(const STRUCTURE *psBuilding);
 /*sets the point new droids go to - x/y in world coords for a Factory*/
 void setAssemblyPoint(FLAG_POSITION *psAssemblyPoint, UDWORD x, UDWORD y, UDWORD player, bool bCheck);
 

--- a/src/structure.h
+++ b/src/structure.h
@@ -317,7 +317,6 @@ void changeProductionPlayer(UBYTE player);
 bool IsStatExpansionModule(const STRUCTURE_STATS *psStats);
 
 /// is this a blueprint and not a real structure?
-bool structureIsBlueprint(const STRUCTURE *psStructure);
 bool isBlueprint(const BASE_OBJECT *psObject);
 
 /*returns the power cost to build this structure, or to add its next module */

--- a/src/structure.h
+++ b/src/structure.h
@@ -307,9 +307,6 @@ void ensureRearmPadClear(STRUCTURE *psStruct, DROID *psDroid);
 // return whether a rearm pad has a vtol on it
 bool vtolOnRearmPad(const STRUCTURE *psStruct, const DROID *psDroid);
 
-/* Just returns true if the structure's present body points aren't as high as the original*/
-bool	structIsDamaged(const STRUCTURE *psStruct);
-
 // give a structure from one player to another - used in Electronic Warfare
 STRUCTURE *giftSingleStructure(STRUCTURE *psStructure, UBYTE attackPlayer, bool electronic_warfare = true);
 

--- a/src/structure.h
+++ b/src/structure.h
@@ -224,13 +224,9 @@ bool checkSpecificStructExists(UDWORD structInc, UDWORD player);
 int32_t getStructureDamage(const STRUCTURE *psStructure);
 
 unsigned structureBodyBuilt(const STRUCTURE *psStruct);  ///< Returns the maximum body points of a structure with the current number of build points.
-UDWORD structureBody(const STRUCTURE *psStruct);
 UDWORD structureResistance(const STRUCTURE_STATS *psStats, UBYTE player);
 
 void hqReward(UBYTE losingPlayer, UBYTE rewardPlayer);
-
-// Is a structure a factory of somekind?
-bool StructIsFactory(const STRUCTURE *Struct);
 
 // Is a flag a factory delivery point?
 bool FlagIsFactory(const FLAG_POSITION *psCurrFlag);

--- a/src/structuredef.h
+++ b/src/structuredef.h
@@ -280,6 +280,9 @@ struct STRUCTURE : public BASE_OBJECT
 	STRUCTURE(uint32_t id, unsigned player);
 	~STRUCTURE();
 
+	//check to see if the structure is 'doing' anything  - return true if idle
+	bool isIdle() const;
+
 	STRUCTURE_STATS     *pStructureType;            /* pointer to the structure stats for this type of building */
 	STRUCT_STATES       status;                     /* defines whether the structure is being built, doing nothing or performing a function */
 	uint32_t            currentBuildPts;            /* the build points currently assigned to this structure */

--- a/src/structuredef.h
+++ b/src/structuredef.h
@@ -282,6 +282,9 @@ struct STRUCTURE : public BASE_OBJECT
 
 	//check to see if the structure is 'doing' anything  - return true if idle
 	bool isIdle() const;
+	// Return true if structure is a factory of any type.
+	bool isFactory() const;
+	uint32_t structureBody() const;
 
 	STRUCTURE_STATS     *pStructureType;            /* pointer to the structure stats for this type of building */
 	STRUCT_STATES       status;                     /* defines whether the structure is being built, doing nothing or performing a function */

--- a/src/structuredef.h
+++ b/src/structuredef.h
@@ -285,6 +285,8 @@ struct STRUCTURE : public BASE_OBJECT
 	// Return true if structure is a factory of any type.
 	bool isFactory() const;
 	uint32_t structureBody() const;
+	// Just returns true if the structure's present body points aren't as high as the original
+	bool isDamaged() const;
 
 	STRUCTURE_STATS     *pStructureType;            /* pointer to the structure stats for this type of building */
 	STRUCT_STATES       status;                     /* defines whether the structure is being built, doing nothing or performing a function */

--- a/src/structuredef.h
+++ b/src/structuredef.h
@@ -287,6 +287,8 @@ struct STRUCTURE : public BASE_OBJECT
 	uint32_t structureBody() const;
 	// Just returns true if the structure's present body points aren't as high as the original
 	bool isDamaged() const;
+	// is this a blueprint and not a real structure?
+	bool isBlueprint() const;
 
 	STRUCTURE_STATS     *pStructureType;            /* pointer to the structure stats for this type of building */
 	STRUCT_STATES       status;                     /* defines whether the structure is being built, doing nothing or performing a function */

--- a/src/template.cpp
+++ b/src/template.cpp
@@ -688,7 +688,7 @@ void deleteTemplateFromProduction(DROID_TEMPLATE *psTemplate, unsigned player, Q
 		}
 		for (STRUCTURE* psStruct : *psList)
 		{
-			if (StructIsFactory(psStruct))
+			if (psStruct->isFactory())
 			{
 				if (psStruct->pFunctionality == nullptr)
 				{

--- a/src/template.cpp
+++ b/src/template.cpp
@@ -688,7 +688,7 @@ void deleteTemplateFromProduction(DROID_TEMPLATE *psTemplate, unsigned player, Q
 		}
 		for (STRUCTURE* psStruct : *psList)
 		{
-			if (psStruct->isFactory())
+			if (psStruct && psStruct->isFactory())
 			{
 				if (psStruct->pFunctionality == nullptr)
 				{

--- a/src/transporter.cpp
+++ b/src/transporter.cpp
@@ -430,8 +430,8 @@ bool intAddTransButtonForm()
 		for (DROID* psDroid : *transIntDroidList)
 		{
 			//only interested in Transporter droids
-			if ((isTransporter(psDroid) && (psDroid->action == DACTION_TRANSPORTOUT ||
-				psDroid->action == DACTION_TRANSPORTIN)) || !isTransporter(psDroid))
+			if ((psDroid->isTransporter() && (psDroid->action == DACTION_TRANSPORTOUT ||
+				psDroid->action == DACTION_TRANSPORTIN)) || !psDroid->isTransporter())
 			{
 				continue;
 			}
@@ -610,7 +610,7 @@ bool intAddDroidsAvailForm()
 			break;
 		}
 		//don't add Transporter Droids!
-		if (!isTransporter(psDroid))
+		if (!psDroid->isTransporter())
 		{
 			/* Set the tip and add the button */
 			auto button = std::make_shared<IntTransportButton>();
@@ -688,11 +688,11 @@ int calcRemainingCapacity(const DROID *psTransporter)
 
 bool transporterIsEmpty(const DROID *psTransporter)
 {
-	ASSERT(isTransporter(psTransporter), "Non-transporter droid given");
+	ASSERT(psTransporter->isTransporter(), "Non-transporter droid given");
 
 	// Assume dead droids and non-transporter droids to be empty
 	return (isDead((const BASE_OBJECT *)psTransporter)
-	        || !isTransporter(psTransporter)
+	        || !psTransporter->isTransporter()
 	        || psTransporter->psGroup->psList.empty()
 	        || psTransporter->psGroup->psList.front() == psTransporter);
 }
@@ -881,7 +881,7 @@ void setCurrentTransporter(UDWORD id)
 	{
 		for (DROID* psCurr : *transIntDroidList)
 		{
-			if (isTransporter(psCurr) &&
+			if (psCurr->isTransporter() &&
 				(psCurr->action != DACTION_TRANSPORTOUT &&
 					psCurr->action != DACTION_TRANSPORTIN))
 			{
@@ -1003,7 +1003,7 @@ static void intTransporterAddDroid(UDWORD id)
 	DroidList::iterator droidIt = transIntDroidList->begin();
 	while (droidIt != transIntDroidList->end())
 	{
-		if (!isTransporter(*droidIt))
+		if (!(*droidIt)->isTransporter())
 		{
 			if (currID == id)
 			{
@@ -1088,7 +1088,7 @@ bool checkTransporterSpace(DROID const *psTransporter, DROID const *psAssigned, 
 
 	ASSERT_OR_RETURN(false, psTransporter != nullptr, "Invalid droid pointer");
 	ASSERT_OR_RETURN(false, psAssigned != nullptr, "Invalid droid pointer");
-	ASSERT_OR_RETURN(false, isTransporter(psTransporter), "Droid is not a Transporter");
+	ASSERT_OR_RETURN(false, psTransporter->isTransporter(), "Droid is not a Transporter");
 	ASSERT_OR_RETURN(false, psTransporter->psGroup != nullptr, "transporter doesn't have a group");
 
 	//work out how much space is currently left
@@ -1168,7 +1168,7 @@ bool launchTransporter(DROID *psTransporter)
 	//otherwise just launches the Transporter
 	else
 	{
-		if (!isTransporter(psTransporter))
+		if (!psTransporter->isTransporter())
 		{
 			ASSERT(false, "Invalid Transporter Droid");
 			return false;
@@ -1191,7 +1191,7 @@ have arrived - returns true when there*/
 bool updateTransporter(DROID *psTransporter)
 {
 	ASSERT_OR_RETURN(true, psTransporter != nullptr, "Invalid droid pointer");
-	ASSERT_OR_RETURN(true, isTransporter(psTransporter), "Invalid droid type");
+	ASSERT_OR_RETURN(true, psTransporter->isTransporter(), "Invalid droid type");
 
 	//if not moving to mission site, exit
 	if (psTransporter->action != DACTION_TRANSPORTOUT && psTransporter->action != DACTION_TRANSPORTIN)
@@ -1372,7 +1372,7 @@ void resetTransporter()
 bool transporterFlying(const DROID *psTransporter)
 {
 	ASSERT_OR_RETURN(false, psTransporter != nullptr, "Invalid droid pointer");
-	ASSERT_OR_RETURN(false, isTransporter(psTransporter), "Droid is not a Transporter");
+	ASSERT_OR_RETURN(false, psTransporter->isTransporter(), "Droid is not a Transporter");
 
 	return psTransporter->order.type == DORDER_TRANSPORTOUT ||
 	       psTransporter->order.type == DORDER_TRANSPORTIN ||

--- a/src/visibility.cpp
+++ b/src/visibility.cpp
@@ -525,7 +525,7 @@ int visibleObject(const BASE_OBJECT *psViewer, const BASE_OBJECT *psTarget, bool
 				return 0;
 			}
 
-			if (psTarget->type == OBJ_DROID && isVtolDroid((const DROID *)psTarget)
+			if (psTarget->type == OBJ_DROID && ((const DROID*)psTarget)->isVtol()
 			    && asWeaponStats[psStruct->asWeaps[0].nStat].surfaceToAir == SHOOT_IN_AIR)
 			{
 				range = 3 * range / 2;	// increase vision range of AA vs VTOL
@@ -556,8 +556,8 @@ int visibleObject(const BASE_OBJECT *psViewer, const BASE_OBJECT *psTarget, bool
 	const bool jammed = psTile->jammerBits & ~alliancebits[psViewer->player];
 
 	// Special rule for VTOLs, as they are not affected by ECM
-	if (((psTarget->type == OBJ_DROID && isVtolDroid((const DROID *)psTarget))
-	     || (psViewer->type == OBJ_DROID && isVtolDroid((const DROID *)psViewer)))
+	if (((psTarget->type == OBJ_DROID && ((const DROID*)psTarget)->isVtol())
+	     || (psViewer->type == OBJ_DROID && ((const DROID*)psViewer)->isVtol()))
 	    && dist < range)
 	{
 		return UBYTE_MAX;

--- a/src/wzapi.cpp
+++ b/src/wzapi.cpp
@@ -997,7 +997,7 @@ bool wzapi::clearConsole(WZAPI_NO_PARAMS)
 bool wzapi::structureIdle(WZAPI_PARAMS(const STRUCTURE *psStruct))
 {
 	SCRIPT_ASSERT(false, context, psStruct, "No valid structure provided");
-	return ::structureIdle(psStruct);
+	return psStruct->isIdle();
 }
 
 std::vector<const STRUCTURE *> _enumStruct_fromList(WZAPI_PARAMS(optional<int> _player, optional<wzapi::STRUCTURE_TYPE_or_statsName_string> _structureType, optional<int> _playerFilter), const PerPlayerStructureLists& psStructLists)

--- a/src/wzapi.cpp
+++ b/src/wzapi.cpp
@@ -1944,7 +1944,7 @@ bool wzapi::addDroidToTransporter(WZAPI_PARAMS(game_object_identifier transporte
 	int transporterPlayer = transporter.player;
 	DROID *psTransporter = IdToMissionDroid(transporterId, transporterPlayer);
 	SCRIPT_ASSERT(false, context, psTransporter, "No such transporter id %d belonging to player %d", transporterId, transporterPlayer);
-	SCRIPT_ASSERT(false, context, isTransporter(psTransporter), "Droid id %d belonging to player %d is not a transporter", transporterId, transporterPlayer);
+	SCRIPT_ASSERT(false, context, psTransporter->isTransporter(), "Droid id %d belonging to player %d is not a transporter", transporterId, transporterPlayer);
 	int droidId = droid.id;
 	int droidPlayer = droid.player;
 	DROID *psDroid = IdToMissionDroid(droidId, droidPlayer);
@@ -2277,7 +2277,7 @@ bool wzapi::setExperienceModifier(WZAPI_PARAMS(int player, int percent))
 std::vector<const DROID *> wzapi::enumCargo(WZAPI_PARAMS(const DROID *psDroid))
 {
 	SCRIPT_ASSERT({}, context, psDroid, "No valid droid provided");
-	SCRIPT_ASSERT({}, context, isTransporter(psDroid), "Wrong droid type (expecting: transporter)");
+	SCRIPT_ASSERT({}, context, psDroid->isTransporter(), "Wrong droid type (expecting: transporter)");
 	std::vector<const DROID *> result;
 	SCRIPT_ASSERT({}, context, psDroid->psGroup, "Droid is not assigned to a group");
 	result.reserve(psDroid->psGroup->getNumMembers());
@@ -2535,7 +2535,7 @@ wzapi::no_return_value wzapi::setReinforcementTime(WZAPI_PARAMS(int _time, optio
 		 * since there's no transport to launch */
 		auto droidIt = std::find_if(apsDroidLists[selectedPlayer].begin(), apsDroidLists[selectedPlayer].end(), [](DROID* d)
 		{
-			return isTransporter(d) && !transporterFlying(d);
+			return d->isTransporter() && !transporterFlying(d);
 		});
 		DROID* psDroid = droidIt != apsDroidLists[selectedPlayer].end() ? *droidIt : nullptr;
 

--- a/src/wzapi.cpp
+++ b/src/wzapi.cpp
@@ -1997,7 +1997,7 @@ bool wzapi::componentAvailable(WZAPI_PARAMS(std::string componentType, optional<
 bool wzapi::isVTOL(WZAPI_PARAMS(const DROID *psDroid))
 {
 	SCRIPT_ASSERT(false, context, psDroid, "No valid droid provided");
-	return isVtolDroid(psDroid);
+	return psDroid->isVtol();
 }
 
 //-- ## safeDest(player, x, y)

--- a/src/wzapi.cpp
+++ b/src/wzapi.cpp
@@ -601,7 +601,7 @@ bool wzapi::setHealth(WZAPI_PARAMS(BASE_OBJECT* psObject, int health)) MULTIPLAY
 	{
 		STRUCTURE *psStruct = (STRUCTURE *)psObject;
 		SCRIPT_ASSERT(false, context, psStruct, "No such structure id %d belonging to player %d", id, player);
-		psStruct->body = health * MAX(1, structureBody(psStruct)) / 100;
+		psStruct->body = health * MAX(1, psStruct->structureBody()) / 100;
 	}
 	else
 	{


### PR DESCRIPTION
This patchset attempts to convert at least some of the free functions for `DROID` and `STRUCTURE` manipulation to be member functions of these classes, so that in some point in future we can build on that and eventually completely encapsulate internal details of those classes  and provide a clean API.

Not all functions are covered (actually, only a small fraction right now), and the general approach would be to convert only those functions which don't interact with other objects and are isolated to the implementation details of a single instance, not requiring any communication to other modules of the game.