### PR TITLE
Potentially cleanup enemy LZ areas

### DIFF
--- a/data/base/script/campaign/cam1-5.js
+++ b/data/base/script/campaign/cam1-5.js
@@ -181,11 +181,9 @@ function eventStartLevel()
 
 	useHeavyReinforcement = false; //Start with a light unit reinforcement first
 	const lz = getObject("LandingZone1"); //player lz
-	const lz2 = getObject("LandingZone2"); //new paradigm lz
 	const tEnt = getObject("TransporterEntry");
 	const tExt = getObject("TransporterExit");
 	setNoGoArea(lz.x, lz.y, lz.x2, lz.y2, CAM_HUMAN_PLAYER);
-	setNoGoArea(lz2.x, lz2.y, lz2.x2, lz2.y2, 5);
 	startTransporterEntry(tEnt.x, tEnt.y, CAM_HUMAN_PLAYER);
 	setTransporterExit(tExt.x, tExt.y, CAM_HUMAN_PLAYER);
 

--- a/data/base/script/campaign/cam1a-c.js
+++ b/data/base/script/campaign/cam1a-c.js
@@ -147,13 +147,6 @@ function eventStartLevel()
 
 	setMissionTime(camChangeOnDiff(camHoursToSeconds(1)));
 
-	// make sure player doesn't build on enemy LZs
-	for (let i = 6; i <= 10; ++i)
-	{
-		const ph = getObject("NPLZ" + i);
-		setNoGoArea(ph.x, ph.y, ph.x2, ph.y2, i - 4);
-	}
-
 	camCompleteRequiredResearch(mis_newParadigmRes, CAM_NEW_PARADIGM);
 	camPlayVideos([{video: "MB1A-C_MSG", type: CAMP_MSG}, {video: "MB1A-C_MSG2", type: MISS_MSG}]);
 

--- a/data/base/script/campaign/cam1c.js
+++ b/data/base/script/campaign/cam1c.js
@@ -183,15 +183,6 @@ function eventStartLevel()
 	centreView(startPos.x, startPos.y);
 	setNoGoArea(lz.x, lz.y, lz.x2, lz.y2, CAM_HUMAN_PLAYER);
 
-	// make sure player doesn't build on enemy LZs of the next level
-	for (let i = 1; i <= 5; ++i)
-	{
-		const ph = getObject("PhantomLZ" + i);
-		// HACK: set LZs of bad players, namely 2...6,
-		// note: player 1 is NP, player 7 is scavs
-		setNoGoArea(ph.x, ph.y, ph.x2, ph.y2, i + 1);
-	}
-
 	if (difficulty === HARD)
 	{
 		setMissionTime(camMinutesToSeconds(100));

--- a/data/base/script/campaign/cam1ca.js
+++ b/data/base/script/campaign/cam1ca.js
@@ -156,15 +156,6 @@ function eventStartLevel()
 	setNoGoArea(lz.x, lz.y, lz.x2, lz.y2, CAM_HUMAN_PLAYER);
 	camCompleteRequiredResearch(mis_newParadigmRes, CAM_NEW_PARADIGM);
 
-	// make sure player doesn't build on enemy LZs
-	for (let i = 1; i <= 5; ++i)
-	{
-		const ph = getObject("PhantomLZ" + i);
-		// HACK: set LZs of bad players, namely 2...6,
-		// note: player 1 is NP
-		setNoGoArea(ph.x, ph.y, ph.x2, ph.y2, i + 2);
-	}
-
 	setMissionTime(camChangeOnDiff(camMinutesToSeconds(30)));
 	camPlayVideos({video: "MB1CA_MSG", type: CAMP_MSG});
 

--- a/data/base/script/campaign/cam2-1s.js
+++ b/data/base/script/campaign/cam2-1s.js
@@ -3,7 +3,6 @@ include("script/campaign/libcampaign.js");
 const mis_Labels = {
 	startPos: {x: 88, y: 101},
 	lz: {x: 86, y: 99, x2: 88, y2: 101},
-	lz2: {x: 49, y: 83, x2: 51, y2: 85},
 	trPlace: {x: 87, y: 100},
 	trExit: {x: 70, y: 126}
 };
@@ -14,7 +13,6 @@ function eventStartLevel()
 	camSetupTransporter(mis_Labels.trPlace.x, mis_Labels.trPlace.y, mis_Labels.trExit.x, mis_Labels.trExit.y);
 	centreView(mis_Labels.startPos.x, mis_Labels.startPos.y);
 	setNoGoArea(mis_Labels.lz.x, mis_Labels.lz.y, mis_Labels.lz.x2, mis_Labels.lz.y2, CAM_HUMAN_PLAYER);
-	setNoGoArea(mis_Labels.lz2.x, mis_Labels.lz2.y, mis_Labels.lz2.x2, mis_Labels.lz2.y2, CAM_THE_COLLECTIVE);
 	setMissionTime(camChangeOnDiff(camMinutesToSeconds(30)));
 	camPlayVideos([{video: "MB2_1_MSG", type: CAMP_MSG}, {video: "MB2_1_MSG2", type: MISS_MSG}]);
 }

--- a/data/base/script/campaign/cam2-1x.js
+++ b/data/base/script/campaign/cam2-1x.js
@@ -122,9 +122,6 @@ function eventStartLevel()
 	startTransporterEntry(tEnt.x, tEnt.y, CAM_HUMAN_PLAYER);
 	setTransporterExit(tExt.x, tExt.y, CAM_HUMAN_PLAYER);
 
-	const enemyLz = getObject("COLandingZone");
-	setNoGoArea(enemyLz.x, enemyLz.y, enemyLz.x2, enemyLz.y2, CAM_THE_COLLECTIVE);
-
 	//Add crash site blip and from an alliance with the crashed team.
 	hackAddMessage("C21_OBJECTIVE", PROX_MSG, CAM_HUMAN_PLAYER, false);
 	setAlliance(CAM_HUMAN_PLAYER, MIS_TRANSPORT_TEAM_PLAYER, true);

--- a/data/base/script/campaign/cam2-2.js
+++ b/data/base/script/campaign/cam2-2.js
@@ -194,9 +194,6 @@ function eventStartLevel()
 	startTransporterEntry(tEnt.x, tEnt.y, CAM_HUMAN_PLAYER);
 	setTransporterExit(tExt.x, tExt.y, CAM_HUMAN_PLAYER);
 
-	const enemyLz = getObject("COLandingZone");
-	setNoGoArea(enemyLz.x, enemyLz.y, enemyLz.x2, enemyLz.y2, CAM_THE_COLLECTIVE);
-
 	camSetArtifacts({
 		"COCommander": { tech: "R-Wpn-RocketSlow-Accuracy03" },
 	});

--- a/data/base/script/campaign/cam2-2s.js
+++ b/data/base/script/campaign/cam2-2s.js
@@ -3,7 +3,6 @@ include("script/campaign/libcampaign.js");
 const mis_Labels = {
 	startPos: {x: 88, y: 101},
 	lz: {x: 86, y: 99, x2: 88, y2: 101},
-	lz2: {x: 49, y: 83, x2: 51, y2: 85},
 	trPlace: {x: 87, y: 100},
 	trExit: {x: 70, y: 1}
 };
@@ -13,7 +12,6 @@ function eventStartLevel()
 	camSetupTransporter(mis_Labels.trPlace.x, mis_Labels.trPlace.y, mis_Labels.trExit.x, mis_Labels.trExit.y);
 	centreView(mis_Labels.startPos.x, mis_Labels.startPos.y);
 	setNoGoArea(mis_Labels.lz.x, mis_Labels.lz.y, mis_Labels.lz.x2, mis_Labels.lz.y2, CAM_HUMAN_PLAYER);
-	setNoGoArea(mis_Labels.lz2.x, mis_Labels.lz2.y, mis_Labels.lz2.x2, mis_Labels.lz2.y2, CAM_THE_COLLECTIVE);
 	setMissionTime(camChangeOnDiff(camMinutesToSeconds(70)));
 	camPlayVideos([{video: "MB2_2_MSG", type: CAMP_MSG}, {video:"MB2_2_MSG2", type: CAMP_MSG}, {video: "MB2_2_MSG3", type: MISS_MSG}]);
 	camSetStandardWinLossConditions(CAM_VICTORY_PRE_OFFWORLD, "SUB_2_2");

--- a/data/base/script/campaign/cam2-5.js
+++ b/data/base/script/campaign/cam2-5.js
@@ -105,9 +105,6 @@ function eventStartLevel()
 	startTransporterEntry(tEnt.x, tEnt.y, CAM_HUMAN_PLAYER);
 	setTransporterExit(tExt.x, tExt.y, CAM_HUMAN_PLAYER);
 
-	const enemyLz = getObject("COLandingZone");
-	setNoGoArea(enemyLz.x, enemyLz.y, enemyLz.x2, enemyLz.y2, CAM_THE_COLLECTIVE);
-
 	camSetArtifacts({
 		"NuclearReactor": { tech: "R-Struc-Power-Upgrade01" },
 		"COMediumFactory": { tech: "R-Wpn-Cannon-ROF02" },

--- a/data/base/script/campaign/cam2-5s.js
+++ b/data/base/script/campaign/cam2-5s.js
@@ -3,7 +3,6 @@ include("script/campaign/libcampaign.js");
 const mis_Labels = {
 	startPos: {x: 88, y: 101},
 	lz: {x: 86, y: 99, x2: 88, y2: 101},
-	lz2: {x: 49, y: 83, x2: 51, y2: 85},
 	trPlace: {x: 87, y: 100},
 	trExit: {x: 32, y: 1}
 };
@@ -13,7 +12,6 @@ function eventStartLevel()
 	camSetupTransporter(mis_Labels.trPlace.x, mis_Labels.trPlace.y, mis_Labels.trExit.x, mis_Labels.trExit.y);
 	centreView(mis_Labels.startPos.x, mis_Labels.startPos.y);
 	setNoGoArea(mis_Labels.lz.x, mis_Labels.lz.y, mis_Labels.lz.x2, mis_Labels.lz.y2, CAM_HUMAN_PLAYER);
-	setNoGoArea(mis_Labels.lz2.x, mis_Labels.lz2.y, mis_Labels.lz2.x2, mis_Labels.lz2.y2, CAM_THE_COLLECTIVE);
 	setMissionTime(camChangeOnDiff(camHoursToSeconds(1)));
 	camPlayVideos([{video: "MB2_5_MSG", type: CAMP_MSG}, {video: "MB2_5_MSG2", type: MISS_MSG}]);
 	camSetStandardWinLossConditions(CAM_VICTORY_PRE_OFFWORLD, "SUB_2_5");

--- a/data/base/script/campaign/cam2-6.js
+++ b/data/base/script/campaign/cam2-6.js
@@ -126,9 +126,6 @@ function eventStartLevel()
 	startTransporterEntry(tEnt.x, tEnt.y, CAM_HUMAN_PLAYER);
 	setTransporterExit(tExt.x, tExt.y, CAM_HUMAN_PLAYER);
 
-	const enemyLz = getObject("COLandingZone");
-	setNoGoArea(enemyLz.x, enemyLz.y, enemyLz.x2, enemyLz.y2, CAM_THE_COLLECTIVE);
-
 	camSetArtifacts({
 		"COCyborgFactory-Arti": { tech: "R-Wpn-Rocket07-Tank-Killer" },
 		"COCommandCenter": { tech: "R-Wpn-Mortar3" },

--- a/data/base/script/campaign/cam2-6s.js
+++ b/data/base/script/campaign/cam2-6s.js
@@ -3,7 +3,6 @@ include("script/campaign/libcampaign.js");
 const mis_Labels = {
 	startPos: {x: 88, y: 101},
 	lz: {x: 86, y: 99, x2: 88, y2: 101},
-	lz2: {x: 49, y: 83, x2: 51, y2: 85},
 	trPlace: {x: 87, y: 100},
 	trExit: {x: 16, y: 126}
 };
@@ -13,7 +12,6 @@ function eventStartLevel()
 	camSetupTransporter(mis_Labels.trPlace.x, mis_Labels.trPlace.y, mis_Labels.trExit.x, mis_Labels.trExit.y);
 	centreView(mis_Labels.startPos.x, mis_Labels.startPos.y);
 	setNoGoArea(mis_Labels.lz.x, mis_Labels.lz.y, mis_Labels.lz.x2, mis_Labels.lz.y2, CAM_HUMAN_PLAYER);
-	setNoGoArea(mis_Labels.lz2.x, mis_Labels.lz2.y, mis_Labels.lz2.x2, mis_Labels.lz2.y2, CAM_THE_COLLECTIVE);
 	setMissionTime(camChangeOnDiff(camHoursToSeconds(1)));
 	camPlayVideos([{video: "MB2_6_MSG", type: CAMP_MSG}, {video: "MB2_6_MSG2", type: CAMP_MSG}, {video: "MB2_6_MSG3", type: MISS_MSG}]);
 	camSetStandardWinLossConditions(CAM_VICTORY_PRE_OFFWORLD, "SUB_2_6");

--- a/data/base/script/campaign/cam2-7.js
+++ b/data/base/script/campaign/cam2-7.js
@@ -115,9 +115,6 @@ function eventStartLevel()
 	startTransporterEntry(tEnt.x, tEnt.y, CAM_HUMAN_PLAYER);
 	setTransporterExit(tExt.x, tExt.y, CAM_HUMAN_PLAYER);
 
-	const enemyLz = getObject("COLandingZone");
-	setNoGoArea(enemyLz.x, enemyLz.y, enemyLz.x2, enemyLz.y2, CAM_THE_COLLECTIVE);
-
 	camSetArtifacts({
 		"COHeavyFac-Arti-b2": { tech: ["R-Wpn-Cannon5", "R-Wpn-MG-Damage08"] },
 		"COTankKillerHardpoint": { tech: "R-Wpn-RocketSlow-Damage06" },

--- a/data/base/script/campaign/cam2-7s.js
+++ b/data/base/script/campaign/cam2-7s.js
@@ -3,7 +3,6 @@ include("script/campaign/libcampaign.js");
 const mis_Labels = {
 	startPos: {x: 88, y: 101},
 	lz: {x: 86, y: 99, x2: 88, y2: 101},
-	lz2: {x: 49, y: 83, x2: 51, y2: 85},
 	trPlace: {x: 87, y: 100},
 	trExit: {x: 100, y: 1}
 };
@@ -13,7 +12,6 @@ function eventStartLevel()
 	camSetupTransporter(mis_Labels.trPlace.x, mis_Labels.trPlace.y, mis_Labels.trExit.x, mis_Labels.trExit.y);
 	centreView(mis_Labels.startPos.x, mis_Labels.startPos.y);
 	setNoGoArea(mis_Labels.lz.x, mis_Labels.lz.y, mis_Labels.lz.x2, mis_Labels.lz.y2, CAM_HUMAN_PLAYER);
-	setNoGoArea(mis_Labels.lz2.x, mis_Labels.lz2.y, mis_Labels.lz2.x2, mis_Labels.lz2.y2, CAM_THE_COLLECTIVE);
 	setMissionTime(camChangeOnDiff(camHoursToSeconds(1.5)));
 	camPlayVideos([{video: "MB2_7_MSG", type: CAMP_MSG}, {video: "MB2_7_MSG2", type: MISS_MSG}]);
 	camSetStandardWinLossConditions(CAM_VICTORY_PRE_OFFWORLD, "SUB_2_7");

--- a/data/base/script/campaign/cam2-8.js
+++ b/data/base/script/campaign/cam2-8.js
@@ -104,9 +104,6 @@ function eventStartLevel()
 	startTransporterEntry(tEnt.x, tEnt.y, CAM_HUMAN_PLAYER);
 	setTransporterExit(tExt.x, tExt.y, CAM_HUMAN_PLAYER);
 
-	const enemyLz = getObject("COLandingZone");
-	setNoGoArea(enemyLz.x, enemyLz.y, enemyLz.x2, enemyLz.y2, CAM_THE_COLLECTIVE);
-
 	camSetArtifacts({
 		"COVtolFac-b3": { tech: "R-Vehicle-Body09" }, //Tiger body
 		"COHeavyFacL-b2": { tech: "R-Wpn-HvyHowitzer" },

--- a/data/base/script/campaign/cam2-8s.js
+++ b/data/base/script/campaign/cam2-8s.js
@@ -3,7 +3,6 @@ include("script/campaign/libcampaign.js");
 const mis_Labels = {
 	startPos: {x: 88, y: 101},
 	lz: {x: 86, y: 99, x2: 88, y2: 101},
-	lz2: {x: 49, y: 83, x2: 51, y2: 85},
 	trPlace: {x: 87, y: 100},
 	trExit: {x: 126, y: 60}
 };
@@ -13,7 +12,6 @@ function eventStartLevel()
 	camSetupTransporter(mis_Labels.trPlace.x, mis_Labels.trPlace.y, mis_Labels.trExit.x, mis_Labels.trExit.y);
 	centreView(mis_Labels.startPos.x, mis_Labels.startPos.y);
 	setNoGoArea(mis_Labels.lz.x, mis_Labels.lz.y, mis_Labels.lz.x2, mis_Labels.lz.y2, CAM_HUMAN_PLAYER);
-	setNoGoArea(mis_Labels.lz2.x, mis_Labels.lz2.y, mis_Labels.lz2.x2, mis_Labels.lz2.y2, CAM_THE_COLLECTIVE);
 	setMissionTime(camChangeOnDiff(camHoursToSeconds(1)));
 	camPlayVideos([{video: "MB2_8_MSG", type: CAMP_MSG}, {video: "MB2_8_MSG2", type: MISS_MSG}]);
 	camSetStandardWinLossConditions(CAM_VICTORY_PRE_OFFWORLD, "SUB_2_8");

--- a/data/base/script/campaign/cam2-a.js
+++ b/data/base/script/campaign/cam2-a.js
@@ -346,7 +346,6 @@ function eventStartLevel()
 	const PLAYER_POWER = 5000;
 	const startPos = getObject("startPosition");
 	const lz = getObject("landingZone"); //player lz
-	const enemyLz = getObject("COLandingZone");
 	const tEnt = getObject("transporterEntry");
 	const tExt = getObject("transporterExit");
 
@@ -355,7 +354,6 @@ function eventStartLevel()
 
 	centreView(startPos.x, startPos.y);
 	setNoGoArea(lz.x, lz.y, lz.x2, lz.y2, CAM_HUMAN_PLAYER);
-	setNoGoArea(enemyLz.x, enemyLz.y, enemyLz.x2, enemyLz.y2, 5);
 	startTransporterEntry(tEnt.x, tEnt.y, CAM_HUMAN_PLAYER);
 	setTransporterExit(tExt.x, tExt.y, CAM_HUMAN_PLAYER);
 

--- a/data/base/script/campaign/cam2-b.js
+++ b/data/base/script/campaign/cam2-b.js
@@ -145,9 +145,6 @@ function eventStartLevel()
 	centreView(startPos.x, startPos.y);
 	setNoGoArea(lz.x, lz.y, lz.x2, lz.y2, CAM_HUMAN_PLAYER);
 
-	const enemyLz = getObject("COLandingZone");
-	setNoGoArea(enemyLz.x, enemyLz.y, enemyLz.x2, enemyLz.y2, CAM_THE_COLLECTIVE);
-
 	setMissionTime(camChangeOnDiff(camHoursToSeconds(2)));
 	camPlayVideos([{video: "MB2_B_MSG", type: CAMP_MSG}, {video: "MB2_B_MSG2", type: MISS_MSG}]);
 

--- a/data/base/script/campaign/cam2-c.js
+++ b/data/base/script/campaign/cam2-c.js
@@ -280,9 +280,6 @@ function eventStartLevel()
 	centreView(startPos.x, startPos.y);
 	setNoGoArea(lz.x, lz.y, lz.x2, lz.y2, CAM_HUMAN_PLAYER);
 
-	const enemyLz = getObject("COLandingZone");
-	setNoGoArea(enemyLz.x, enemyLz.y, enemyLz.x2, enemyLz.y2, 5);
-
 	camSetArtifacts({
 		"rippleRocket": { tech: "R-Wpn-Rocket06-IDF" },
 		"quadbof": { tech: "R-Wpn-AAGun02" },

--- a/data/base/script/campaign/cam2-d.js
+++ b/data/base/script/campaign/cam2-d.js
@@ -119,9 +119,6 @@ function eventStartLevel()
 	startTransporterEntry(tEnt.x, tEnt.y, CAM_HUMAN_PLAYER);
 	setTransporterExit(tExt.x, tExt.y, CAM_HUMAN_PLAYER);
 
-	const enemyLz = getObject("COLandingZone");
-	setNoGoArea(enemyLz.x, enemyLz.y, enemyLz.x2, enemyLz.y2, CAM_THE_COLLECTIVE);
-
 	camSetArtifacts({
 		"COCommandCenter": { tech: "R-Struc-VTOLPad-Upgrade01" },
 		"COResearchLab": { tech: "R-Struc-Research-Upgrade04" },

--- a/data/base/script/campaign/cam2-ds.js
+++ b/data/base/script/campaign/cam2-ds.js
@@ -3,7 +3,6 @@ include("script/campaign/libcampaign.js");
 const mis_Labels = {
 	startPos: {x: 88, y: 101},
 	lz: {x: 86, y: 99, x2: 88, y2: 101},
-	lz2: {x: 49, y: 83, x2: 51, y2: 85},
 	trPlace: {x: 87, y: 100},
 	trExit: {x: 1, y: 100}
 };
@@ -13,7 +12,6 @@ function eventStartLevel()
 	camSetupTransporter(mis_Labels.trPlace.x, mis_Labels.trPlace.y, mis_Labels.trExit.x, mis_Labels.trExit.y);
 	centreView(mis_Labels.startPos.x, mis_Labels.startPos.y);
 	setNoGoArea(mis_Labels.lz.x, mis_Labels.lz.y, mis_Labels.lz.x2, mis_Labels.lz.y2, CAM_HUMAN_PLAYER);
-	setNoGoArea(mis_Labels.lz2.x, mis_Labels.lz2.y, mis_Labels.lz2.x2, mis_Labels.lz2.y2, CAM_THE_COLLECTIVE);
 	setMissionTime(camChangeOnDiff(camMinutesToSeconds(75)));
 	camPlayVideos([{video: "MB2_DI_MSG", type: MISS_MSG}, {video: "MB2_DI_MSG2", type: CAMP_MSG}]);
 	camSetStandardWinLossConditions(CAM_VICTORY_PRE_OFFWORLD, "SUB_2D");

--- a/data/base/script/campaign/cam2-end.js
+++ b/data/base/script/campaign/cam2-end.js
@@ -18,7 +18,6 @@ const mis_collectiveRes = [
 const mis_Labels = {
 	startPos: {x: 92, y: 99},
 	lz: {x: 86, y: 99, x2: 88, y2: 101},
-	lz2: {x: 49, y: 83, x2: 51, y2: 85},
 	trPlace: {x: 87, y: 100},
 	trExit: {x: 0, y: 55},
 	northTankAssembly: {x: 95, y: 3},
@@ -233,7 +232,6 @@ function eventStartLevel()
 	camSetupTransporter(mis_Labels.trPlace.x, mis_Labels.trPlace.y, mis_Labels.trExit.x, mis_Labels.trExit.y);
 	centreView(mis_Labels.startPos.x, mis_Labels.startPos.y);
 	setNoGoArea(mis_Labels.lz.x, mis_Labels.lz.y, mis_Labels.lz.x2, mis_Labels.lz.y2, CAM_HUMAN_PLAYER);
-	setNoGoArea(mis_Labels.lz2.x, mis_Labels.lz2.y, mis_Labels.lz2.x2, mis_Labels.lz2.y2, CAM_THE_COLLECTIVE);
 
 	setMissionTime(camMinutesToSeconds(30));
 	camCompleteRequiredResearch(mis_collectiveRes, CAM_THE_COLLECTIVE);

--- a/data/base/script/campaign/cam3-1.js
+++ b/data/base/script/campaign/cam3-1.js
@@ -329,9 +329,6 @@ function eventStartLevel()
 	setTransporterExit(tExt.x, tExt.y, CAM_HUMAN_PLAYER);
 	setScrollLimits(0, 32, 64, 64);
 
-	const enemyLz = getObject("NXlandingZone");
-	setNoGoArea(enemyLz.x, enemyLz.y, enemyLz.x2, enemyLz.y2, CAM_NEXUS);
-
 	camCompleteRequiredResearch(mis_nexusRes, CAM_NEXUS);
 
 	camSetArtifacts({

--- a/data/base/script/campaign/cam3-1s.js
+++ b/data/base/script/campaign/cam3-1s.js
@@ -3,7 +3,6 @@ include("script/campaign/libcampaign.js");
 const mis_Labels = {
 	startPos: {x: 57, y: 119},
 	lz: {x: 55, y: 119, x2: 57, y2: 121},
-	lz2: {x: 7, y: 52, x2: 9, y2: 54},
 	trPlace: {x: 56, y: 120},
 	trExit: {x: 25, y: 87}
 };
@@ -13,7 +12,6 @@ function eventStartLevel()
 	camSetupTransporter(mis_Labels.trPlace.x, mis_Labels.trPlace.y, mis_Labels.trExit.x, mis_Labels.trExit.y);
 	centreView(mis_Labels.startPos.x, mis_Labels.startPos.y);
 	setNoGoArea(mis_Labels.lz.x, mis_Labels.lz.y, mis_Labels.lz.x2, mis_Labels.lz.y2, CAM_HUMAN_PLAYER);
-	setNoGoArea(mis_Labels.lz2.x, mis_Labels.lz2.y, mis_Labels.lz2.x2, mis_Labels.lz2.y2, CAM_NEXUS);
 	setMissionTime(camChangeOnDiff(camMinutesToSeconds(75)));
 	camPlayVideos([{video: "MB3_1A_MSG", type: CAMP_MSG}, {video: "MB3_1A_MSG2", type: MISS_MSG}]);
 	camSetStandardWinLossConditions(CAM_VICTORY_PRE_OFFWORLD, "SUB_3_1");

--- a/data/base/script/campaign/cam3-2.js
+++ b/data/base/script/campaign/cam3-2.js
@@ -306,9 +306,6 @@ function eventStartLevel()
 	startTransporterEntry(tEnt.x, tEnt.y, CAM_HUMAN_PLAYER);
 	setTransporterExit(tExt.x, tExt.y, CAM_HUMAN_PLAYER);
 
-	const enemyLz = getObject("NXlandingZone");
-	setNoGoArea(enemyLz.x, enemyLz.y, enemyLz.x2, enemyLz.y2, CAM_NEXUS);
-
 	camCompleteRequiredResearch(mis_nexusRes, CAM_NEXUS);
 	camCompleteRequiredResearch(mis_gammaAllyRes, MIS_ALPHA_PLAYER);
 	setAlliance(MIS_ALPHA_PLAYER, CAM_NEXUS, true);

--- a/data/base/script/campaign/cam3-2s.js
+++ b/data/base/script/campaign/cam3-2s.js
@@ -3,7 +3,6 @@ include("script/campaign/libcampaign.js");
 const mis_Labels = {
 	startPos: {x: 57, y: 119},
 	lz: {x: 55, y: 119, x2: 57, y2: 121},
-	lz2: {x: 7, y: 52, x2: 9, y2: 54},
 	trPlace: {x: 56, y: 120},
 	trExit: {x: 25, y: 87}
 };
@@ -13,7 +12,6 @@ function eventStartLevel()
 	camSetupTransporter(mis_Labels.trPlace.x, mis_Labels.trPlace.y, mis_Labels.trExit.x, mis_Labels.trExit.y);
 	centreView(mis_Labels.startPos.x, mis_Labels.startPos.y);
 	setNoGoArea(mis_Labels.lz.x, mis_Labels.lz.y, mis_Labels.lz.x2, mis_Labels.lz.y2, CAM_HUMAN_PLAYER);
-	setNoGoArea(mis_Labels.lz2.x, mis_Labels.lz2.y, mis_Labels.lz2.x2, mis_Labels.lz2.y2, CAM_NEXUS);
 	setMissionTime(camChangeOnDiff(camHoursToSeconds(1)));
 	camPlayVideos([{video: "MB3_2_MSG", type: CAMP_MSG}, {video: "MB3_2_MSG2", type: MISS_MSG}]);
 	camSetStandardWinLossConditions(CAM_VICTORY_PRE_OFFWORLD, "SUB_3_2");

--- a/data/base/script/campaign/cam3-4.js
+++ b/data/base/script/campaign/cam3-4.js
@@ -251,9 +251,6 @@ function eventStartLevel()
 	setTransporterExit(tpos.x, tpos.y, CAM_HUMAN_PLAYER);
 	setMissionTime(-1); //Infinite time
 
-	const enemyLz = getObject("NXlandingZone");
-	setNoGoArea(enemyLz.x, enemyLz.y, enemyLz.x2, enemyLz.y2, CAM_NEXUS);
-
 	camCompleteRequiredResearch(mis_nexusRes, CAM_NEXUS);
 	if (difficulty === INSANE)
 	{

--- a/data/base/script/campaign/cam3-4s.js
+++ b/data/base/script/campaign/cam3-4s.js
@@ -3,7 +3,6 @@ include("script/campaign/libcampaign.js");
 const mis_Labels = {
 	startPos: {x: 50, y: 245},
 	lz: {x: 49, y: 244, x2: 51, y2: 246},
-	lz2: {x: 7, y: 52, x2: 9, y2: 54},
 	trPlace: {x: 50, y: 245},
 	trExit: {x: 63, y: 118},
 	limits: {x: 0, y: 137, x2: 64, y2: 256}
@@ -14,7 +13,6 @@ function eventStartLevel()
 	camSetupTransporter(mis_Labels.trPlace.x, mis_Labels.trPlace.y, mis_Labels.trExit.x, mis_Labels.trExit.y);
 	centreView(mis_Labels.startPos.x, mis_Labels.startPos.y);
 	setNoGoArea(mis_Labels.lz.x, mis_Labels.lz.y, mis_Labels.lz.x2, mis_Labels.lz.y2, CAM_HUMAN_PLAYER);
-	setNoGoArea(mis_Labels.lz2.x, mis_Labels.lz2.y, mis_Labels.lz2.x2, mis_Labels.lz2.y2, CAM_NEXUS);
 	setScrollLimits(mis_Labels.limits.x, mis_Labels.limits.y, mis_Labels.limits.x2, mis_Labels.limits.y2);
 	setMissionTime(camMinutesToSeconds(30));
 	setPower(playerPower(CAM_HUMAN_PLAYER) + 50000, CAM_HUMAN_PLAYER);

--- a/data/base/script/campaign/cam3-a.js
+++ b/data/base/script/campaign/cam3-a.js
@@ -310,9 +310,6 @@ function eventStartLevel()
 	startTransporterEntry(tEnt.x, tEnt.y, CAM_HUMAN_PLAYER);
 	setTransporterExit(tExt.x, tExt.y, CAM_HUMAN_PLAYER);
 
-	const enemyLz = getObject("NXlandingZone");
-	setNoGoArea(enemyLz.x, enemyLz.y, enemyLz.x2, enemyLz.y2, CAM_NEXUS);
-
 	camSetArtifacts({
 		"NXPowerGenArti": { tech: "R-Struc-Power-Upgrade02" },
 		"NXResearchLabArti": { tech: "R-Sys-Engineering03" },

--- a/data/base/script/campaign/cam3-ab.js
+++ b/data/base/script/campaign/cam3-ab.js
@@ -269,9 +269,6 @@ function eventStartLevel()
 	setNoGoArea(lz.x, lz.y, lz.x2, lz.y2, CAM_HUMAN_PLAYER);
 	setMissionTime(camChangeOnDiff(camHoursToSeconds(1)));
 
-	const enemyLz = getObject("NXlandingZone");
-	setNoGoArea(enemyLz.x, enemyLz.y, enemyLz.x2, enemyLz.y2, CAM_NEXUS);
-
 	camCompleteRequiredResearch(mis_nexusRes, CAM_NEXUS);
 
 	enableResearch(cam_resistance_circuits.first, CAM_HUMAN_PLAYER);

--- a/data/base/script/campaign/cam3-ad1.js
+++ b/data/base/script/campaign/cam3-ad1.js
@@ -255,7 +255,6 @@ function eventStartLevel()
 {
 	camSetExtraObjectiveMessage(_("Build a forward base at the silos"));
 
-	const siloZone = getObject("missileSilos");
 	const startPos = getObject("startPosition");
 	const lz = getObject("landingZone");
 	const lz2 = getObject("landingZone2"); //LZ for cam3-4s.
@@ -267,9 +266,7 @@ function eventStartLevel()
 
 	centreView(startPos.x, startPos.y);
 	setNoGoArea(lz.x, lz.y, lz.x2, lz.y2, CAM_HUMAN_PLAYER);
-	setNoGoArea(lz2.x, lz2.y, lz2.x2, lz2.y2, 5);
 	setNoGoArea(lz2.x, lz2.y, lz2.x2, lz2.y2, CAM_NEXUS);
-	setNoGoArea(siloZone.x, siloZone.y, siloZone.x2, siloZone.y2, MIS_SILO_PLAYER);
 	setMissionTime(camChangeOnDiff(camHoursToSeconds(2)));
 
 	camCompleteRequiredResearch(mis_nexusRes, CAM_NEXUS);

--- a/data/base/script/campaign/cam3-b.js
+++ b/data/base/script/campaign/cam3-b.js
@@ -303,11 +303,6 @@ function eventStartLevel()
 	centreView(startPos.x, startPos.y);
 	setNoGoArea(lz.x, lz.y, lz.x2, lz.y2, CAM_HUMAN_PLAYER);
 
-	const enemyLz = getObject("NXlandingZone");
-	const enemyLz2 = getObject("NXlandingZone2");
-	setNoGoArea(enemyLz.x, enemyLz.y, enemyLz.x2, enemyLz.y2, CAM_NEXUS);
-	setNoGoArea(enemyLz2.x, enemyLz2.y, enemyLz2.x2, enemyLz2.y2, 5);
-
 	camCompleteRequiredResearch(mis_nexusRes, CAM_NEXUS);
 	camCompleteRequiredResearch(mis_gammaAllyRes, MIS_GAMMA_PLAYER);
 	camCompleteRequiredResearch(mis_nexusRes, MIS_GAMMA_PLAYER); //They get even more research.

--- a/data/base/script/campaign/cam3-c.js
+++ b/data/base/script/campaign/cam3-c.js
@@ -185,9 +185,6 @@ function eventStartLevel()
 	setNoGoArea(limboLZ.x, limboLZ.y, limboLZ.x2, limboLZ.y2, -1);
 	setMissionTime(camChangeOnDiff(camMinutesToSeconds(10)));
 
-	const enemyLz = getObject("NXlandingZone");
-	setNoGoArea(enemyLz.x, enemyLz.y, enemyLz.x2, enemyLz.y2, CAM_NEXUS);
-
 	camCompleteRequiredResearch(mis_nexusRes, CAM_NEXUS);
 	camCompleteRequiredResearch(mis_gammaAllyRes, MIS_GAMMA_PLAYER);
 	hackAddMessage("CM3C_GAMMABASE", PROX_MSG, CAM_HUMAN_PLAYER, false);

--- a/data/base/script/campaign/libcampaign_includes/misc.js
+++ b/data/base/script/campaign/libcampaign_includes/misc.js
@@ -247,6 +247,38 @@ function camCountStructuresInArea(label, playerFilter)
 	return ret;
 }
 
+//;; ## camCleanTileOfObstructions(x, y | pos)
+//;;
+//;; Obliterates player structures and features near the tile around certain coordinates.
+//;; Can be used for spawn locations or transport reinforcement spots. May not
+//;; delete very large objects like factories or skyscrapers.
+//;;
+//;; @param {number|Object} x
+//;; @param {number} [y]
+//;; @returns {void}
+//;;
+function camCleanTileOfObstructions(x, y)
+{
+	if (!camDef(x))
+	{
+		camDebug("invalid parameters?");
+		return;
+	}
+
+	const __TILE_SWEEP_RADIUS = 1;
+	const pos = (camDef(y)) ? {x: x, y: y} : x;
+	const objects = enumRange(pos.x, pos.y, __TILE_SWEEP_RADIUS, CAM_HUMAN_PLAYER, false);
+
+	for (let i = 0, len = objects.length; i < len; ++i)
+	{
+		const obj = objects[i];
+		if (obj.type !== DROID)
+		{
+			camSafeRemoveObject(obj, true);
+		}
+	}
+}
+
 //;; ## camChangeOnDiff(numericValue)
 //;;
 //;; Change a numeric value based on campaign difficulty.

--- a/data/base/script/campaign/libcampaign_includes/reinforcements.js
+++ b/data/base/script/campaign/libcampaign_includes/reinforcements.js
@@ -39,6 +39,10 @@ function camSendReinforcement(playerId, position, templates, kind, data)
 			order_data = data.data;
 		}
 	}
+	if (playerId !== CAM_HUMAN_PLAYER)
+	{
+		camCleanTileOfObstructions(pos);
+	}
 	switch (kind)
 	{
 		case CAM_REINFORCE_GROUND:


### PR DESCRIPTION
While working on resetting LZ areas every mission start in #3602, I noticed we can probably get away with removing almost all manually set LZ areas on Beta/Gamma (aside from the one on Gamma 7 reserved for the future player LZ of Gamma 8/9). This method would involve blowing up any player structures within a tile radius of spawn positions when they come (VTOL spawn points, generic tank/cyborg spawn points, and enemy transporter drop off positions). Doing this will also allow removing a few hacks from Alpha 6. 7, and 10 reserving many build zones across the map under the control of various players, as well as random reserved LZ areas on the Beta/Gamma home base pre-away missions.

At the same time enemy VTOLs will fail to follow DORDER_RTB anymore, falling back to their "LZ", when no pads or HQ are present for them. Not like it's needed anyway.