### PR TITLE
Switch `AUDIO_SAMPLE` and `RES_TYPE/RES_DATA` structures to `std::list`

### DIFF
--- a/lib/framework/frameresource.cpp
+++ b/lib/framework/frameresource.cpp
@@ -231,7 +231,7 @@ static RES_TYPE *resAlloc(const char *pType)
 #endif
 
 	// setup the structure
-	psT = (RES_TYPE *)malloc(sizeof(RES_TYPE));
+	psT = new RES_TYPE();
 	sstrcpy(psT->aType, pType);
 	psT->HashedType = HashString(psT->aType); // store a hased version for super speed !
 	psT->psRes = nullptr;
@@ -775,7 +775,7 @@ void resReleaseAll()
 	for (psT = psResTypes; psT != nullptr; psT = psNT)
 	{
 		psNT = psT->psNext;
-		free(psT);
+		delete psT;
 	}
 
 	psResTypes = nullptr;

--- a/lib/framework/frameresource.cpp
+++ b/lib/framework/frameresource.cpp
@@ -33,6 +33,7 @@
 #include "resly.h"
 
 #include <list>
+#include <algorithm>
 
 // Local prototypes
 static std::list<RES_TYPE *> psResTypes;

--- a/lib/framework/frameresource.h
+++ b/lib/framework/frameresource.h
@@ -72,7 +72,6 @@ struct RES_TYPE
 	UDWORD	HashedType;				// hashed version of the name of the id - // a null hashedtype indicates end of list
 
 	RES_FILELOAD	fileLoad;		// This isn't really used any more ?
-	RES_TYPE       *psNext;
 };
 
 

--- a/lib/framework/frameresource.h
+++ b/lib/framework/frameresource.h
@@ -26,6 +26,8 @@
 
 #include "lib/framework/frame.h"
 
+#include <list>
+
 /** Maximum number of characters in a resource type. */
 #define RESTYPE_MAXCHAR		20
 
@@ -48,7 +50,6 @@ struct RES_DATA
 	SDWORD		blockID;			// which of the blocks is it in (so we can clear some of them...)
 
 	UDWORD	HashedID;				// hashed version of the name of the id
-	RES_DATA       *psNext;                         // next entry - most likely to be following on!
 	UDWORD		usage; // Reference count
 
 	// ID of the resource - filename from the .wrf - e.g. "TRON.PIE"
@@ -67,7 +68,7 @@ struct RES_TYPE
 	RES_FREE release;			// routine to release the data (NULL indicates none)
 
 	// we must have a pointer to the data here so that we can do a resGetData();
-	RES_DATA		*psRes;		// Linked list of data items of this type
+	std::list<RES_DATA*> psRes;		// Linked list of data items of this type
 	UDWORD	HashedType;				// hashed version of the name of the id - // a null hashedtype indicates end of list
 
 	RES_FILELOAD	fileLoad;		// This isn't really used any more ?

--- a/lib/framework/object_list_iteration.h
+++ b/lib/framework/object_list_iteration.h
@@ -100,6 +100,11 @@ void mutating_list_iterate(std::list<ObjectType*>& list, MaybeErasingLoopBodyHan
 		"Unsupported loop body handler signature: "
 		"should return IterationResult and take either an ObjectType* or an iterator");
 
+	if (list.empty())
+	{
+		return;
+	}
+
 	typename std::remove_reference_t<decltype(list)>::iterator it = list.begin(), itNext;
 	while (it != list.end())
 	{

--- a/lib/framework/object_list_iteration.h
+++ b/lib/framework/object_list_iteration.h
@@ -1,0 +1,56 @@
+/*
+	This file is part of Warzone 2100.
+	Copyright (C) 2024  Warzone 2100 Project
+
+	Warzone 2100 is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+
+	Warzone 2100 is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with Warzone 2100; if not, write to the Free Software
+	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+/** @file
+ *  Basic routines for list iteration of various in-game objects (resources, sounds, droids, etc.).
+ */
+#pragma once
+
+#include <list>
+#include <type_traits>
+#include <iterator>
+
+enum class IterationResult
+{
+	BREAK_ITERATION,
+	CONTINUE_ITERATION
+};
+
+// Common iteration helper for lists of game objects
+// with an ability to execute loop body handlers which can
+// possibly invalidate the any iterator in the range `[begin(), currentIterator]`.
+template <typename ObjectType, typename MaybeErasingLoopBodyHandler>
+void mutating_list_iterate(std::list<ObjectType*>& list, MaybeErasingLoopBodyHandler handler)
+{
+	static_assert(std::is_same<std::result_of_t<MaybeErasingLoopBodyHandler(ObjectType*)>, IterationResult>::value,
+		"Loop body handler should return IterationResult");
+
+	typename std::remove_reference_t<decltype(list)>::iterator it = list.begin(), itNext;
+	while (it != list.end())
+	{
+		itNext = std::next(it);
+		// Can possibly invalidate `it` and anything before it.
+		const auto res = handler(*it);
+		if (res == IterationResult::BREAK_ITERATION)
+		{
+			break;
+		}
+		it = itNext;
+	}
+}
+

--- a/lib/framework/object_list_iteration.h
+++ b/lib/framework/object_list_iteration.h
@@ -24,6 +24,7 @@
 #include <list>
 #include <type_traits>
 #include <iterator>
+#include <functional>
 
 enum class IterationResult
 {
@@ -67,7 +68,7 @@ struct LoopBodyHandlerCallStrategy
 	template <typename ObjectType>
 	static constexpr bool handler_accepts_iter = std::is_convertible<
 		Callable,
-		std::function<IterationResult(std::list<ObjectType*>::iterator)>>::value;
+		std::function<IterationResult(typename std::list<ObjectType*>::iterator)>>::value;
 
 	// `Invoke` overload for Callable taking a list iterator as the argument
 	template <typename ObjectType>
@@ -95,8 +96,8 @@ void mutating_list_iterate(std::list<ObjectType*>& list, MaybeErasingLoopBodyHan
 	using HandlerCallStrategy = LoopBodyHandlerCallStrategy<MaybeErasingLoopBodyHandler>;
 
 	static_assert(
-		   HandlerCallStrategy::handler_accepts_ptr<ObjectType>
-		|| HandlerCallStrategy::handler_accepts_iter<ObjectType>,
+		   HandlerCallStrategy::template handler_accepts_ptr<ObjectType>
+		|| HandlerCallStrategy::template handler_accepts_iter<ObjectType>,
 		"Unsupported loop body handler signature: "
 		"should return IterationResult and take either an ObjectType* or an iterator");
 
@@ -110,7 +111,7 @@ void mutating_list_iterate(std::list<ObjectType*>& list, MaybeErasingLoopBodyHan
 	{
 		itNext = std::next(it);
 		// Can possibly invalidate `it` and anything before it.
-		const auto res = HandlerCallStrategy::Invoke<ObjectType>(handler, it);
+		const auto res = HandlerCallStrategy::template Invoke<ObjectType>(handler, it);
 		if (res == IterationResult::BREAK_ITERATION)
 		{
 			break;

--- a/lib/framework/object_list_iteration.h
+++ b/lib/framework/object_list_iteration.h
@@ -31,21 +31,81 @@ enum class IterationResult
 	CONTINUE_ITERATION
 };
 
+/// <summary>
+/// Utility class used to determine how to invoke `Callable`
+/// in the `mutating_list_iterate` function depending on its signature.
+///
+/// Currently two callable signatures are supported:
+/// * `IterationResult(ObjectType*)`
+/// * `IterationResult(std::list<ObjectType*>::iterator)`
+///
+/// The latter overload is convenient when one needs to erase from or
+/// insert into the list being iterated directly inside the handler's body,
+/// avoiding additional lookups to obtain an iterator to the current element.
+/// </summary>
+/// <typeparam name="Callable">
+/// Can either be a function pointer or a lambda expression (or any other callable).
+/// </typeparam>
+template <typename Callable>
+struct LoopBodyHandlerCallStrategy
+{
+	// Since we are constrained by C++14, we'll need to use SFINAE to determine correct
+	// specialization of `Invoke` to call depending on input type of handler function.
+	//
+	// Here we use a bunch of compile-time tests to determine
+	// whether our callable is convertible to `std::function` of a compatible signature.
+	//
+	// This is the most simple way to constrain and choose a correct overload
+	// of `Invoke` function depending on the callable signature.
+	//
+	// Choosing the correct overload is done via `std::enable_if<Cond, T>` helper from <type_traits>,
+	// which basically provides `using type = T` only when `Cond` is `true`.
+	template <typename ObjectType>
+	static constexpr bool handler_accepts_ptr = std::is_convertible<
+		Callable,
+		std::function<IterationResult(ObjectType*)>>::value;
+	template <typename ObjectType>
+	static constexpr bool handler_accepts_iter = std::is_convertible<
+		Callable,
+		std::function<IterationResult(std::list<ObjectType*>::iterator)>>::value;
+
+	// `Invoke` overload for Callable taking a list iterator as the argument
+	template <typename ObjectType>
+	static std::enable_if_t<handler_accepts_iter<ObjectType>, IterationResult>
+		Invoke(Callable handler, typename std::list<ObjectType*>::iterator iter)
+	{
+		return handler(iter);
+	}
+
+	// `Invoke` overload for Callable taking a pointer to `ObjectType` as the argument
+	template <typename ObjectType>
+	static std::enable_if_t<handler_accepts_ptr<ObjectType>, IterationResult>
+		Invoke(Callable handler, typename std::list<ObjectType*>::iterator iter)
+	{
+		return handler(*iter);
+	}
+};
+
 // Common iteration helper for lists of game objects
 // with an ability to execute loop body handlers which can
 // possibly invalidate the any iterator in the range `[begin(), currentIterator]`.
 template <typename ObjectType, typename MaybeErasingLoopBodyHandler>
 void mutating_list_iterate(std::list<ObjectType*>& list, MaybeErasingLoopBodyHandler handler)
 {
-	static_assert(std::is_same<std::result_of_t<MaybeErasingLoopBodyHandler(ObjectType*)>, IterationResult>::value,
-		"Loop body handler should return IterationResult");
+	using HandlerCallStrategy = LoopBodyHandlerCallStrategy<MaybeErasingLoopBodyHandler>;
+
+	static_assert(
+		   HandlerCallStrategy::handler_accepts_ptr<ObjectType>
+		|| HandlerCallStrategy::handler_accepts_iter<ObjectType>,
+		"Unsupported loop body handler signature: "
+		"should return IterationResult and take either an ObjectType* or an iterator");
 
 	typename std::remove_reference_t<decltype(list)>::iterator it = list.begin(), itNext;
 	while (it != list.end())
 	{
 		itNext = std::next(it);
 		// Can possibly invalidate `it` and anything before it.
-		const auto res = handler(*it);
+		const auto res = HandlerCallStrategy::Invoke<ObjectType>(handler, it);
 		if (res == IterationResult::BREAK_ITERATION)
 		{
 			break;

--- a/lib/sound/audio.cpp
+++ b/lib/sound/audio.cpp
@@ -23,6 +23,7 @@
 #include "lib/gamelib/gtime.h"
 #include "lib/ivis_opengl/pietypes.h"
 #include "lib/framework/physfs_ext.h"
+#include "lib/framework/object_list_iteration.h"
 
 #include "oggopus.h"
 #include "oggvorbis.h"
@@ -32,13 +33,16 @@
 #include "audio_id.h"
 #include "openal_error.h"
 #include "mixer.h"
+
+#include <list>
+
 // defines
 #define NO_SAMPLE				- 2
 #define MAX_SAME_SAMPLES		2
 
 // global variables
-static AUDIO_SAMPLE *g_psSampleList = nullptr;
-static AUDIO_SAMPLE *g_psSampleQueue = nullptr;
+static std::list<AUDIO_SAMPLE *> g_psSampleList;
+static std::list<AUDIO_SAMPLE *> g_psSampleQueue;
 static bool			g_bAudioEnabled = false;
 static bool			g_bAudioPaused = false;
 static AUDIO_SAMPLE g_sPreviousSample;
@@ -49,20 +53,7 @@ static int			g_iPreviousSampleTime = 0;
  */
 unsigned int audio_GetSampleQueueCount()
 {
-	//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-	AUDIO_SAMPLE	*psSample = nullptr;
-	unsigned int	count = 0;
-	//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-	// loop through SampleQueue to count how many we have.
-	psSample = g_psSampleQueue;
-	while (psSample != nullptr)
-	{
-		count++;
-		psSample = psSample->psNext;
-	}
-
-	return count;
+	return static_cast<unsigned int>(g_psSampleQueue.size());
 }
 
 /** Counts the number of samples in the SampleList
@@ -70,20 +61,7 @@ unsigned int audio_GetSampleQueueCount()
  */
 unsigned int audio_GetSampleListCount()
 {
-	//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-	AUDIO_SAMPLE *psSample = nullptr;
-	unsigned int count = 0;
-	//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-	// loop through SampleList to count how many we have.
-	psSample = g_psSampleList;
-	while (psSample != nullptr)
-	{
-		++count;
-		psSample = psSample->psNext;
-	}
-
-	return count;
+	return static_cast<unsigned int>(g_psSampleList.size());
 }
 //*
 // =======================================================================================================================
@@ -124,7 +102,6 @@ bool audio_Init(AUDIO_CALLBACK pStopTrackCallback, HRTFMode hrtf, bool really_en
 bool audio_Shutdown(void)
 {
 	//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-	AUDIO_SAMPLE	*psSample = nullptr, *psSampleTemp = nullptr;
 	bool			bOK;
 	//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -138,26 +115,20 @@ bool audio_Shutdown(void)
 	bOK = sound_Shutdown();
 
 	// empty sample list
-	psSample = g_psSampleList;
-	while (psSample != nullptr)
+	for (AUDIO_SAMPLE* psSample : g_psSampleList)
 	{
-		psSampleTemp = psSample->psNext;
 		free(psSample);
-		psSample = psSampleTemp;
 	}
 
 	// empty sample queue
-	psSample = g_psSampleQueue;
-	while (psSample != nullptr)
+	for (AUDIO_SAMPLE* psSample : g_psSampleQueue)
 	{
-		psSampleTemp = psSample->psNext;
 		free(psSample);
-		psSample = psSampleTemp;
 	}
 
 	// free sample heap
-	g_psSampleList = nullptr;
-	g_psSampleQueue = nullptr;
+	g_psSampleList.clear();
+	g_psSampleQueue.clear();
 
 	return bOK;
 }
@@ -211,42 +182,18 @@ bool audio_GetPreviousQueueTrackRadarBlipPos(SDWORD *iX, SDWORD *iY)
 // =======================================================================================================================
 // =======================================================================================================================
 //
-static void audio_AddSampleToHead(AUDIO_SAMPLE **ppsSampleList, AUDIO_SAMPLE *psSample)
+static void audio_AddSampleToHead(std::list<AUDIO_SAMPLE *>& ppsSampleList, AUDIO_SAMPLE *psSample)
 {
-	psSample->psNext = (*ppsSampleList);
-	psSample->psPrev = nullptr;
-	if ((*ppsSampleList) != nullptr)
-	{
-		(*ppsSampleList)->psPrev = psSample;
-	}
-	(*ppsSampleList) = psSample;
+	ppsSampleList.emplace_front(psSample);
 }
 
 //*
 // =======================================================================================================================
 // =======================================================================================================================
 //
-static void audio_AddSampleToTail(AUDIO_SAMPLE **ppsSampleList, AUDIO_SAMPLE *psSample)
+static void audio_AddSampleToTail(std::list<AUDIO_SAMPLE *>& ppsSampleList, AUDIO_SAMPLE *psSample)
 {
-	//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-	AUDIO_SAMPLE	*psSampleTail = nullptr;
-	//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-	if ((*ppsSampleList) == nullptr)
-	{
-		(*ppsSampleList) = psSample;
-		return;
-	}
-
-	psSampleTail = (*ppsSampleList);
-	while (psSampleTail->psNext != nullptr)
-	{
-		psSampleTail = psSampleTail->psNext;
-	}
-
-	psSampleTail->psNext = psSample;
-	psSample->psPrev = psSampleTail;
-	psSample->psNext = nullptr;
+	ppsSampleList.emplace_back(psSample);
 }
 
 //*
@@ -257,32 +204,16 @@ static void audio_AddSampleToTail(AUDIO_SAMPLE **ppsSampleList, AUDIO_SAMPLE *ps
 // =======================================================================================================================
 // =======================================================================================================================
 //
-static void audio_RemoveSample(AUDIO_SAMPLE **ppsSampleList, AUDIO_SAMPLE *psSample)
+static void audio_RemoveSample(std::list<AUDIO_SAMPLE *>& ppsSampleList, AUDIO_SAMPLE *psSample)
 {
 	if (psSample == nullptr)
 	{
 		return;
 	}
 
-	if (psSample == (*ppsSampleList))
-	{
-		// first sample in list
-		(*ppsSampleList) = psSample->psNext;
-	}
-
-	if (psSample->psPrev != nullptr)
-	{
-		psSample->psPrev->psNext = psSample->psNext;
-	}
-
-	if (psSample->psNext != nullptr)
-	{
-		psSample->psNext->psPrev = psSample->psPrev;
-	}
-
-	// set sample pointers NULL for safety
-	psSample->psPrev = nullptr;
-	psSample->psNext = nullptr;
+	auto it = std::find(ppsSampleList.begin(), ppsSampleList.end(), psSample);
+	ASSERT(it != ppsSampleList.end(), "audio_RemoveSample: sample not found in list");
+	ppsSampleList.erase(it);
 }
 
 //*
@@ -293,7 +224,6 @@ static bool audio_CheckSameQueueTracksPlaying(SDWORD iTrack)
 {
 	//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 	SDWORD			iCount;
-	AUDIO_SAMPLE	*psSample = nullptr;
 	bool			bOK = true;
 	//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -306,8 +236,7 @@ static bool audio_CheckSameQueueTracksPlaying(SDWORD iTrack)
 	iCount = 0;
 
 	// loop through queue sounds and check whether too many already in it
-	psSample = g_psSampleQueue;
-	while (psSample != nullptr)
+	for (const AUDIO_SAMPLE* psSample : g_psSampleQueue)
 	{
 		if (psSample->iTrack == iTrack)
 		{
@@ -319,8 +248,6 @@ static bool audio_CheckSameQueueTracksPlaying(SDWORD iTrack)
 			bOK = false;
 			break;
 		}
-
-		psSample = psSample->psNext;
 	}
 
 	return bOK;
@@ -364,7 +291,7 @@ static AUDIO_SAMPLE *audio_QueueSample(SDWORD iTrack)
 	psSample->bFinishedPlaying = false;
 
 	// add to queue
-	audio_AddSampleToTail(&g_psSampleQueue, psSample);
+	audio_AddSampleToTail(g_psSampleQueue, psSample);
 
 	return psSample;
 }
@@ -516,14 +443,14 @@ static void audio_UpdateQueue(void)
 	}
 
 	// check queue for members
-	if (g_psSampleQueue == nullptr)
+	if (g_psSampleQueue.empty())
 	{
 		return;
 	}
 
 	// remove queue head
-	psSample = g_psSampleQueue;
-	audio_RemoveSample(&g_psSampleQueue, psSample);
+	psSample = g_psSampleQueue.front();
+	audio_RemoveSample(g_psSampleQueue, psSample);
 
 	// add sample to list if able to play
 	if (!sound_Play2DTrack(psSample, true))
@@ -533,7 +460,7 @@ static void audio_UpdateQueue(void)
 		return;
 	}
 
-	audio_AddSampleToHead(&g_psSampleList, psSample);
+	audio_AddSampleToHead(g_psSampleList, psSample);
 
 	// update last queue sound coords
 	if (psSample->x != SAMPLE_COORD_INVALID && psSample->y != SAMPLE_COORD_INVALID
@@ -552,7 +479,6 @@ void audio_Update()
 	//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 	Vector3f playerPos;
 	float angle;
-	AUDIO_SAMPLE	*psSample, *psSampleTemp;
 	//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 	// if audio not enabled return true to carry on game without audio
@@ -572,25 +498,20 @@ void audio_Update()
 	sound_SetPlayerOrientation(angle);
 
 	// loop through 3D sounds and remove if finished or update position
-	psSample = g_psSampleList;
-	while (psSample != nullptr)
+	mutating_list_iterate(g_psSampleList, [](AUDIO_SAMPLE* psSample)
 	{
 		// remove finished samples from list
 		if (psSample->bFinishedPlaying == true)
 		{
-			psSampleTemp = psSample->psNext;
-			audio_RemoveSample(&g_psSampleList, psSample);
+			audio_RemoveSample(g_psSampleList, psSample);
 			free(psSample);
-			psSample = psSampleTemp;
 		}
-
-		// check looping sound callbacks for finished condition
-		else
+		else // check looping sound callbacks for finished condition
 		{
 			if (psSample->psObj != nullptr)
 			{
 				if (audio_ObjectDead(psSample->psObj)
-				    || (psSample->pCallback != nullptr && psSample->pCallback(psSample->psObj) == false))
+					|| (psSample->pCallback != nullptr && psSample->pCallback(psSample->psObj) == false))
 				{
 					sound_StopTrack(psSample);
 					psSample->psObj = nullptr;
@@ -601,10 +522,9 @@ void audio_Update()
 					sound_SetObjectPosition(psSample);
 				}
 			}
-			// next sample
-			psSample = psSample->psNext;
 		}
-	}
+		return IterationResult::CONTINUE_ITERATION;
+	});
 
 	sound_Update();
 	return;
@@ -644,7 +564,6 @@ static bool audio_CheckSame3DTracksPlaying(SDWORD iTrack, SDWORD iX, SDWORD iY, 
 {
 	//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 	SDWORD			iCount, iDx, iDy, iDz, iDistSq, iMaxDistSq, iRad;
-	AUDIO_SAMPLE	*psSample = nullptr;
 	bool			bOK = true;
 	//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -657,8 +576,7 @@ static bool audio_CheckSame3DTracksPlaying(SDWORD iTrack, SDWORD iX, SDWORD iY, 
 	iCount = 0;
 
 	// loop through 3D sounds and check whether too many already in earshot
-	psSample = g_psSampleList;
-	while (psSample != nullptr)
+	for (const AUDIO_SAMPLE* psSample : g_psSampleList)
 	{
 		if (psSample->iTrack == iTrack)
 		{
@@ -679,8 +597,6 @@ static bool audio_CheckSame3DTracksPlaying(SDWORD iTrack, SDWORD iX, SDWORD iY, 
 				break;
 			}
 		}
-
-		psSample = psSample->psNext;
 	}
 
 	return bOK;
@@ -764,7 +680,7 @@ static bool audio_Play3DTrack(SDWORD iX, SDWORD iY, SDWORD iZ, int iTrack, SIMPL
 		return false;
 	}
 
-	audio_AddSampleToHead(&g_psSampleList, psSample);
+	audio_AddSampleToHead(g_psSampleList, psSample);
 	return true;
 }
 
@@ -884,10 +800,6 @@ AUDIO_STREAM *audio_PlayStream(const char *fileName, float volume, const std::fu
 //
 void audio_StopObjTrack(SIMPLE_OBJECT *psObj, int iTrack)
 {
-	//~~~~~~~~~~~~~~~~~~~~~~
-	AUDIO_SAMPLE	*psSample;
-	//~~~~~~~~~~~~~~~~~~~~~~
-
 	// return if audio not enabled
 	if (g_bAudioEnabled == false)
 	{
@@ -895,8 +807,7 @@ void audio_StopObjTrack(SIMPLE_OBJECT *psObj, int iTrack)
 	}
 
 	// find sample
-	psSample = g_psSampleList;
-	while (psSample != nullptr)
+	for (AUDIO_SAMPLE* psSample : g_psSampleList)
 	{
 		// If track has been found stop it and return
 		if (psSample->psObj == psObj && psSample->iTrack == iTrack)
@@ -904,9 +815,6 @@ void audio_StopObjTrack(SIMPLE_OBJECT *psObj, int iTrack)
 			sound_StopTrack(psSample);
 			return;
 		}
-
-		// get next sample from linked list
-		psSample = psSample->psNext;
 	}
 }
 static UDWORD lastTimeBuildFailedPlayed = 0;
@@ -970,7 +878,7 @@ void audio_PlayTrack(int iTrack)
 		return;
 	}
 
-	audio_AddSampleToHead(&g_psSampleList, psSample);
+	audio_AddSampleToHead(g_psSampleList, psSample);
 }
 
 //*
@@ -1011,10 +919,6 @@ void audio_ResumeAll(void)
 //
 void audio_StopAll(void)
 {
-	//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-	AUDIO_SAMPLE *psSample;
-	//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
 	// return if audio not enabled
 	if (g_bAudioEnabled == false)
 	{
@@ -1024,7 +928,7 @@ void audio_StopAll(void)
 	//
 	// * empty list - audio_Update will free samples because callbacks have to come in first
 	//
-	for (psSample = g_psSampleList; psSample != nullptr; psSample = psSample->psNext)
+	for (AUDIO_SAMPLE* psSample : g_psSampleList)
 	{
 		// Stop this sound sample
 		sound_StopTrack(psSample);
@@ -1046,19 +950,12 @@ void audio_StopAll(void)
 	}
 
 	// empty sample queue
-	psSample = g_psSampleQueue;
-	while (psSample != nullptr)
+	for (AUDIO_SAMPLE* psSample : g_psSampleQueue)
 	{
-		AUDIO_SAMPLE *psSampleTemp = psSample;
-
-		// Advance the sample iterator (before invalidating it)
-		psSample = psSample->psNext;
-
 		// Destroy the sample
-		free(psSampleTemp);
+		free(psSample);
 	}
-
-	g_psSampleQueue = nullptr;
+	g_psSampleQueue.clear();
 }
 
 //*
@@ -1102,35 +999,30 @@ void audio_RemoveObj(SIMPLE_OBJECT const *psObj)
 	unsigned int count = 0;
 
 	// loop through queued sounds and check if a sample needs to be removed
-	AUDIO_SAMPLE *psSample = g_psSampleQueue;
-	while (psSample != nullptr)
+	mutating_list_iterate(g_psSampleQueue, [psObj, &count](AUDIO_SAMPLE* psSample)
 	{
-		if (psSample->psObj == psObj)
+		if (psSample->psObj != psObj)
 		{
-			// The current audio sample seems to refer to an object
-			// that is about to be destroyed. So destroy this
-			// sample as well.
-			AUDIO_SAMPLE *toRemove = psSample;
-
-			// Make sure to keep our linked list iterator valid
-			psSample = psSample->psNext;
-
-			debug(LOG_MEMORY, "audio_RemoveObj: callback %p sample %d\n", reinterpret_cast<void *>(toRemove->pCallback), toRemove->iTrack);
-			// Remove sound from global active list
-			sound_RemoveActiveSample(toRemove);   //remove from global active list.
-
-			// Perform the actual task of destroying this sample
-			audio_RemoveSample(&g_psSampleQueue, toRemove);
-			free(toRemove);
-
-			// Increment the deletion count
-			++count;
+			return IterationResult::CONTINUE_ITERATION;
 		}
-		else
-		{
-			psSample = psSample->psNext;
-		}
-	}
+		// The current audio sample seems to refer to an object
+		// that is about to be destroyed. So destroy this
+		// sample as well.
+		AUDIO_SAMPLE* toRemove = psSample;
+
+		debug(LOG_MEMORY, "audio_RemoveObj: callback %p sample %d\n", reinterpret_cast<void*>(toRemove->pCallback), toRemove->iTrack);
+		// Remove sound from global active list
+		sound_RemoveActiveSample(toRemove);   //remove from global active list.
+
+		// Perform the actual task of destroying this sample
+		audio_RemoveSample(g_psSampleQueue, toRemove);
+		free(toRemove);
+
+		// Increment the deletion count
+		++count;
+
+		return IterationResult::CONTINUE_ITERATION;
+	});
 
 	if (count)
 	{
@@ -1141,35 +1033,30 @@ void audio_RemoveObj(SIMPLE_OBJECT const *psObj)
 	count = 0;
 
 	// loop through list of currently playing sounds and check if a sample needs to be removed
-	psSample = g_psSampleList;
-	while (psSample != nullptr)
+	mutating_list_iterate(g_psSampleList, [psObj, &count](AUDIO_SAMPLE* psSample)
 	{
-		if (psSample->psObj == psObj)
+		if (psSample->psObj != psObj)
 		{
-			// The current audio sample seems to refer to an object
-			// that is about to be destroyed. So destroy this
-			// sample as well.
-			AUDIO_SAMPLE *toRemove = psSample;
-
-			// Make sure to keep our linked list iterator valid
-			psSample = psSample->psNext;
-
-			debug(LOG_MEMORY, "audio_RemoveObj: callback %p sample %d\n", reinterpret_cast<void *>(toRemove->pCallback), toRemove->iTrack);
-			// Stop this sound sample
-			sound_RemoveActiveSample(toRemove);   //remove from global active list.
-
-			// Perform the actual task of destroying this sample
-			audio_RemoveSample(&g_psSampleList, toRemove);
-			free(toRemove);
-
-			// Increment the deletion count
-			++count;
+			return IterationResult::CONTINUE_ITERATION;
 		}
-		else
-		{
-			psSample = psSample->psNext;
-		}
-	}
+		// The current audio sample seems to refer to an object
+		// that is about to be destroyed. So destroy this
+		// sample as well.
+		AUDIO_SAMPLE* toRemove = psSample;
+
+		debug(LOG_MEMORY, "audio_RemoveObj: callback %p sample %d\n", reinterpret_cast<void*>(toRemove->pCallback), toRemove->iTrack);
+		// Stop this sound sample
+		sound_RemoveActiveSample(toRemove);   //remove from global active list.
+
+		// Perform the actual task of destroying this sample
+		audio_RemoveSample(g_psSampleList, toRemove);
+		free(toRemove);
+
+		// Increment the deletion count
+		++count;
+
+		return IterationResult::CONTINUE_ITERATION;
+	});
 
 	if (count)
 	{

--- a/lib/sound/track.h
+++ b/lib/sound/track.h
@@ -61,8 +61,6 @@ struct AUDIO_SAMPLE
 	bool                    bFinishedPlaying;
 	AUDIO_CALLBACK          pCallback;
 	SIMPLE_OBJECT          *psObj;
-	AUDIO_SAMPLE           *psPrev;
-	AUDIO_SAMPLE           *psNext;
 };
 
 struct TRACK

--- a/src/droid.cpp
+++ b/src/droid.cpp
@@ -27,6 +27,7 @@
 #include "lib/framework/math_ext.h"
 #include "lib/framework/geometry.h"
 #include "lib/framework/strres.h"
+#include "lib/framework/object_list_iteration.h"
 
 #include "lib/gamelib/gtime.h"
 #include "lib/ivis_opengl/piematrix.h"

--- a/src/intdisplay.cpp
+++ b/src/intdisplay.cpp
@@ -25,6 +25,7 @@
  */
 #include "lib/framework/frame.h"
 #include "lib/framework/math_ext.h"
+#include "lib/framework/object_list_iteration.h"
 
 /* Includes direct access to render library */
 #include "lib/ivis_opengl/ivisdef.h"

--- a/src/intelmap.cpp
+++ b/src/intelmap.cpp
@@ -27,6 +27,7 @@
 
 #include "lib/framework/frame.h"
 #include "lib/framework/strres.h"
+#include "lib/framework/object_list_iteration.h"
 #include "lib/widget/widget.h"
 #include "lib/widget/gridlayout.h"
 #include "lib/widget/button.h"

--- a/src/keybind.cpp
+++ b/src/keybind.cpp
@@ -23,6 +23,7 @@
 #include "lib/framework/frame.h"
 #include "lib/framework/wzapp.h"
 #include "lib/framework/rational.h"
+#include "lib/framework/object_list_iteration.h"
 #include "lib/framework/physfs_ext.h"
 #include "objects.h"
 #include "levels.h"

--- a/src/loop.cpp
+++ b/src/loop.cpp
@@ -27,6 +27,7 @@
 #include "lib/framework/input.h"
 #include "lib/framework/strres.h"
 #include "lib/framework/wzapp.h"
+#include "lib/framework/object_list_iteration.h"
 
 #include "lib/ivis_opengl/pieblitfunc.h"
 #include "lib/ivis_opengl/piestate.h" //ivis render code

--- a/src/message.cpp
+++ b/src/message.cpp
@@ -29,6 +29,7 @@
 #include "lib/framework/wzconfig.h"
 #include "lib/framework/frameresource.h"
 #include "lib/framework/strres.h"
+#include "lib/framework/object_list_iteration.h"
 #include "lib/sound/audio.h"
 #include "lib/sound/audio_id.h"
 #include "lib/ivis_opengl/imd.h"

--- a/src/mission.cpp
+++ b/src/mission.cpp
@@ -29,6 +29,7 @@
 #include "lib/framework/frame.h"
 #include "lib/framework/wzapp.h"
 #include "lib/framework/math_ext.h"
+#include "lib/framework/object_list_iteration.h"
 #include "lib/framework/physfs_ext.h"
 #include "lib/ivis_opengl/bitimage.h"
 #include "lib/ivis_opengl/pieblitfunc.h"

--- a/src/multijoin.cpp
+++ b/src/multijoin.cpp
@@ -30,6 +30,7 @@
 #include "lib/framework/frame.h"
 #include "lib/framework/strres.h"
 #include "lib/framework/math_ext.h"
+#include "lib/framework/object_list_iteration.h"
 
 #include "lib/gamelib/gtime.h"
 #include "lib/ivis_opengl/textdraw.h"

--- a/src/multilimit.cpp
+++ b/src/multilimit.cpp
@@ -25,6 +25,7 @@
 #include "lib/framework/frame.h"
 #include "lib/framework/frameresource.h"
 #include "lib/framework/strres.h"
+#include "lib/framework/object_list_iteration.h"
 #include "lib/widget/slider.h"
 #include "lib/widget/widget.h"
 #include "hci.h"

--- a/src/multiplay.cpp
+++ b/src/multiplay.cpp
@@ -32,6 +32,7 @@
 #include "lib/framework/input.h"
 #include "lib/framework/strres.h"
 #include "lib/framework/physfs_ext.h"
+#include "lib/framework/object_list_iteration.h"
 #include "lib/ivis_opengl/piepalette.h" // for pal_Init()
 #include "map.h"
 

--- a/src/objmem.h
+++ b/src/objmem.h
@@ -26,10 +26,11 @@
 
 #include "objectdef.h"
 
+//#include "lib/framework/object_list_iteration.h"
+
 #include <array>
 #include <list>
 #include <functional>
-#include <type_traits>
 
 /* The lists of objects allocated */
 template <typename ObjectType, unsigned PlayerCount>
@@ -154,34 +155,5 @@ void objCount(int *droids, int *structures, int *features);
 #ifdef DEBUG
 void checkFactoryFlags();
 #endif
-
-enum class IterationResult
-{
-	BREAK_ITERATION,
-	CONTINUE_ITERATION
-};
-
-// Common iteration helper for lists of game objects
-// with an ability to execute loop body handlers which can
-// possibly invalidate the any iterator in the range `[begin(), currentIterator]`.
-template <typename ObjectType, typename MaybeErasingLoopBodyHandler>
-void mutating_list_iterate(std::list<ObjectType*>& list, MaybeErasingLoopBodyHandler handler)
-{
-	static_assert(std::is_same<std::result_of_t<MaybeErasingLoopBodyHandler(ObjectType*)>, IterationResult>::value,
-		"Loop body handler should return IterationResult");
-
-	typename std::remove_reference_t<decltype(list)>::iterator it = list.begin(), itNext;
-	while (it != list.end())
-	{
-		itNext = std::next(it);
-		// Can possibly invalidate `it` and anything before it.
-		const auto res = handler(*it);
-		if (res == IterationResult::BREAK_ITERATION)
-		{
-			break;
-		}
-		it = itNext;
-	}
-}
 
 #endif // __INCLUDED_SRC_OBJMEM_H__

--- a/src/objmem.h
+++ b/src/objmem.h
@@ -26,8 +26,6 @@
 
 #include "objectdef.h"
 
-//#include "lib/framework/object_list_iteration.h"
-
 #include <array>
 #include <list>
 #include <functional>

--- a/src/objmem.h
+++ b/src/objmem.h
@@ -28,7 +28,6 @@
 
 #include <array>
 #include <list>
-#include <functional>
 
 /* The lists of objects allocated */
 template <typename ObjectType, unsigned PlayerCount>

--- a/src/order.cpp
+++ b/src/order.cpp
@@ -29,6 +29,7 @@
 #include "lib/framework/frame.h"
 #include "lib/framework/input.h"
 #include "lib/framework/math_ext.h"
+#include "lib/framework/object_list_iteration.h"
 #include "lib/ivis_opengl/ivisdef.h"
 
 #include "objects.h"


### PR DESCRIPTION
The changeset does the following things:

1. Move `mutating_list_iterate` utility function to a separate header `object_list_iteration.h` and move it up the project hierarchy, so that it's accessible in `lib/framework` and `lib/sound`.
2. Enhance `mutating_list_iterate` to be able to accept lambdas which take an iterator, this is used in some places to efficiently erase from list inside of the handler itself.
3. Remove `psNext` and `psPrev` pointers from `AUDIO_SAMPLE`, `RES_TYPE` and `RES_DATA` structures, also convert global lists `g_psSampleList` and `g_psSampleQueue` to `std::list<AUDIO_SAMPLE*>`.

After these changes, there are still some places in WZ code base, which use C-style lists, but it's not much anymore and should be easy to clear it up in a follow up PR a bit later.