### PR TITLE
Reset lightmap during init

### DIFF
--- a/lib/ivis_opengl/pielighting.cpp
+++ b/lib/ivis_opengl/pielighting.cpp
@@ -74,7 +74,7 @@ LightingData& getCurrentLightingData()
 	return scene;
 }
 
-LightMap& getCurrentLighmapData()
+LightMap& getCurrentLightmapData()
 {
 	static LightMap lightmap;
 	return lightmap;

--- a/lib/ivis_opengl/pielighting.h
+++ b/lib/ivis_opengl/pielighting.h
@@ -52,7 +52,7 @@ struct LightingData
 };
 
 LightingData& getCurrentLightingData();
-LightMap& getCurrentLighmapData();
+LightMap& getCurrentLightmapData();
 
 
 

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -2084,7 +2084,7 @@ void	dealWithLMB()
 		        tileIsExplored(psTile) ? "Explored" : "Unexplored",
 		        mouseTileX, mouseTileY, world_coord(mouseTileX), world_coord(mouseTileY),
 		        (int)psTile->limitedContinent, (int)psTile->hoverContinent, psTile->level, (int)psTile->illumination,
-				(int)psTile->ambientOcclusion, getCurrentLighmapData()(mouseTileX, mouseTileY).rgba,
+				(int)psTile->ambientOcclusion, getCurrentLightmapData()(mouseTileX, mouseTileY).rgba,
 		        aux & AUXBITS_DANGER ? "danger" : "", aux & AUXBITS_THREAT ? "threat" : "",
 		        (int)psTile->watchers[selectedPlayer], (int)psTile->sensors[selectedPlayer], (int)psTile->jammers[selectedPlayer],
 				TileNumber_tile(psTile->texture), (TILE_HAS_DECAL(psTile)) ? "y" : "n",

--- a/src/display3d.cpp
+++ b/src/display3d.cpp
@@ -1014,7 +1014,7 @@ void draw3DScene()
 	}
 
 	/* Now, draw the terrain */
-	drawTiles(&playerPos, getCurrentLightingData(), getCurrentLighmapData(), getCurrentLightingManager());
+	drawTiles(&playerPos, getCurrentLightingData(), getCurrentLightmapData(), getCurrentLightingManager());
 
 	wzPerfBegin(PERF_MISC, "3D scene - misc and text");
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1835,6 +1835,7 @@ bool stageThreeInitialise()
 	effectResetUpdates();
 	initLighting(0, 0, mapWidth, mapHeight);
 	pie_InitLighting();
+	getCurrentLightmapData().reset(mapWidth, mapHeight);
 
 	if (fromSave)
 	{

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -1013,7 +1013,7 @@ bool mapLoadFromWzMapData(std::shared_ptr<WzMap::MapData> loadedMap)
 
 	/* Allocate the memory for the map */
 	psMapTiles = std::make_unique<MAPTILE[]>(static_cast<size_t>(width) * height);
-	getCurrentLighmapData().reset(width, height);
+	getCurrentLightmapData().reset(width, height);
 	ASSERT(psMapTiles != nullptr, "Out of memory");
 
 	mapWidth = width;


### PR DESCRIPTION
Fixes some rather large log spam during some combo of saveloading and coming back to home base.

Also fix the name for function getCurrentLightmapData().

---

From my tests this will stop: https://github.com/Warzone2100/warzone2100/pull/3601#issuecomment-1902538706