### PR TITLE
Rendering fixes

### DIFF
--- a/data/base/shaders/tcmask_instanced.frag
+++ b/data/base/shaders/tcmask_instanced.frag
@@ -376,7 +376,9 @@ void main()
 		0., 1., 0.,
 		0., 0., 1.
 	);
-	light += iterateOverAllPointLights(clipSpaceCoord, fragPos, -N, normalize(halfVec - lightDir), diffuse, specularMapValue, identityMat);
+	// Normals are in view space, we need to get back to world space
+	vec3 worldSpaceNormal = -(inverse(ViewMatrix) * vec4(N, 0.f)).xyz;
+	light += iterateOverAllPointLights(clipSpaceCoord, fragPos, worldSpaceNormal, normalize(halfVec - lightDir), diffuse, specularMapValue, identityMat);
 #endif
 
 	light.rgb *= visibility;

--- a/data/base/shaders/vk/tcmask_instanced.frag
+++ b/data/base/shaders/vk/tcmask_instanced.frag
@@ -344,7 +344,9 @@ void main()
 								0., 1., 0.,
 								0., 0., 1.
 								);
-		light += iterateOverAllPointLights(clipSpaceCoord, fragPos, -N, normalize(halfVec - lightDir), diffuse, specularMapValue, identityMat);
+		// Normals are in view space, we need to get back to world space
+		vec3 worldSpaceNormal = -(inverse(ViewMatrix) * vec4(N, 0.f)).xyz;
+		light += iterateOverAllPointLights(clipSpaceCoord, fragPos, worldSpaceNormal, normalize(halfVec - lightDir), diffuse, specularMapValue, identityMat);
 	}
 
 	light.rgb *= visibility;


### PR DESCRIPTION
- Fix: Rendering order of translucent models (i.e. baseplates) vs additive effects
   - Previously, additive effects (such as explosions or power generator lights) could have structure baseplates rendered *over* them, causing a very obvious discrepancy depending on the relative positions & camera position.
- Fix: Tcmask point lighting normals
   - Ported from: https://github.com/Warzone2100/warzone2100/pull/3601