### PR TITLE
pointlights-tcmask-fix: Fix pointlights for tcmask shaders

### DIFF
--- a/data/base/shaders/pointlights.frag
+++ b/data/base/shaders/pointlights.frag
@@ -21,10 +21,20 @@ float pointLightEnergyAtPosition(vec3 position, vec3 pointLightWorldPosition, fl
 	return numerator * numerator / ( 1.f + 2.f * sqNormDist);
 }
 
-vec4 processPointLight(vec3 WorldFragPos, vec3 fragNormal, vec3 viewVector, vec4 albedo, float gloss, vec3 pointLightWorldPosition, float pointLightEnergy, vec3 pointLightColor, mat3 normalWorldSpaceToLocalSpace)
+vec4 processPointLight(
+	vec3 WorldFragPos,
+	vec3 fragNormal, 
+	vec3 viewVector, 
+	vec4 albedo, 
+	float gloss, 
+	vec3 pointLightWorldPosition, 
+	float pointLightEnergy, 
+	vec3 pointLightColor, 
+ 	mat3 worldSpaceToViewSpace,
+	mat3 normalWorldSpaceToLocalSpace)
 {
 	vec3 pointLightVector = WorldFragPos - pointLightWorldPosition;
-	vec3 pointLightDir = -normalize(pointLightVector * normalWorldSpaceToLocalSpace);
+	vec3 pointLightDir = -normalize(worldSpaceToViewSpace * pointLightVector * normalWorldSpaceToLocalSpace);
 
 	float energy = pointLightEnergyAtPosition(WorldFragPos, pointLightWorldPosition, pointLightEnergy);
 	vec4 lightColor = vec4(pointLightColor * energy, 1.f);
@@ -50,6 +60,7 @@ vec4 iterateOverAllPointLights(
 	vec3 viewVector,
 	vec4 albedo,
 	float gloss,
+ 	mat3 worldSpaceToViewSpace,
 	mat3 normalWorldSpaceToLocalSpace
 ) {
 	vec4 light = vec4(0.f);
@@ -62,7 +73,7 @@ vec4 iterateOverAllPointLights(
 		int lightIndex = PointLightsIndex[entryInLightList / 4][entryInLightList % 4];
 		vec4 position = PointLightsPosition[lightIndex];
 		vec4 colorAndEnergy = PointLightsColorAndEnergy[lightIndex];
-		vec3 tmp = position.xyz * vec3(1.f, 1.f, -1.f);
+		vec3 tmp = position.xyz;
 		light += processPointLight(WorldFragPos, fragNormal, viewVector, albedo, gloss, tmp, colorAndEnergy.w, colorAndEnergy.xyz, normalWorldSpaceToLocalSpace);
 	}
 	return light;

--- a/data/base/shaders/tcmask_instanced.frag
+++ b/data/base/shaders/tcmask_instanced.frag
@@ -376,9 +376,7 @@ void main()
 		0., 1., 0.,
 		0., 0., 1.
 	);
-	// Normals are in view space, we need to get back to world space
-	vec3 worldSpaceNormal = -(inverse(ViewMatrix) * vec4(N, 0.f)).xyz;
-	light += iterateOverAllPointLights(clipSpaceCoord, fragPos, worldSpaceNormal, normalize(halfVec - lightDir), diffuse, specularMapValue, identityMat);
+	light += iterateOverAllPointLights(clipSpaceCoord, fragPos, -N, normalize(halfVec - lightDir), diffuse, specularMapValue, ViewMatrix, identityMat);
 #endif
 
 	light.rgb *= visibility;

--- a/data/base/shaders/terrain_combined_high.frag
+++ b/data/base/shaders/terrain_combined_high.frag
@@ -151,7 +151,12 @@ vec4 doBumpMapping(BumpData b, vec3 lightDir, vec3 halfVec) {
 #if WZ_POINT_LIGHT_ENABLED == 1
 	// point lights
 	vec2 clipSpaceCoord = gl_FragCoord.xy / vec2(float(viewportWidth), float(viewportHeight));
-	res += iterateOverAllPointLights(clipSpaceCoord, fragPos, b.N, normalize(halfVec - lightDir), b.color, b.gloss, ModelTangentMatrix);
+	mat3 identityMat = mat3(
+								1., 0., 0.,
+								0., 1., 0.,
+								0., 0., 1.
+								);	
+	res += iterateOverAllPointLights(clipSpaceCoord, fragPos, b.N, normalize(halfVec - lightDir), b.color, b.gloss, identityMat, ModelTangentMatrix);
 #endif
 
 	return vec4(res.rgb, b.color.a);

--- a/data/base/shaders/vk/pointlights.glsl
+++ b/data/base/shaders/vk/pointlights.glsl
@@ -10,10 +10,20 @@ float pointLightEnergyAtPosition(vec3 position, vec3 pointLightWorldPosition, fl
 	return numerator * numerator / ( 1 + 2 * sqNormDist);
 }
 
-vec4 processPointLight(vec3 WorldFragPos, vec3 fragNormal, vec3 viewVector, vec4 albedo, float gloss, vec3 pointLightWorldPosition, float pointLightEnergy, vec3 pointLightColor, mat3 normalWorldSpaceToLocalSpace)
+vec4 processPointLight(vec3 WorldFragPos,
+ vec3 fragNormal, 
+ vec3 viewVector, 
+ vec4 albedo, 
+ float gloss, 
+ vec3 pointLightWorldPosition, 
+ float pointLightEnergy, 
+ vec3 pointLightColor, 
+ mat3 worldSpaceToViewSpace,
+ mat3 normalWorldSpaceToLocalSpace)
 {
 	vec3 pointLightVector = WorldFragPos - pointLightWorldPosition;
 	vec3 pointLightDir = -normalize(pointLightVector * normalWorldSpaceToLocalSpace);
+	pointLightDir = worldSpaceToViewSpace * pointLightDir;
 
 	float energy = pointLightEnergyAtPosition(WorldFragPos, pointLightWorldPosition, pointLightEnergy);
 	vec4 lightColor = vec4(pointLightColor * energy, 1);
@@ -31,6 +41,7 @@ vec4 processPointLight(vec3 WorldFragPos, vec3 fragNormal, vec3 viewVector, vec4
 // - a uniforms named PointLightsPosition of vec4[]
 // - a uniforms named colorAndEnergy of vec4[]
 // fragNormal and view vector are expected to be in the same local space
+// worldSpaceToViewSpace is used to move from world space to view space
 // normalWorldSpaceToLocalSpace is used to move from world space to local space
 vec4 iterateOverAllPointLights(
 	vec2 clipSpaceCoord,
@@ -39,6 +50,7 @@ vec4 iterateOverAllPointLights(
 	vec3 viewVector,
 	vec4 albedo,
 	float gloss,
+ 	mat3 worldSpaceToViewSpace,
 	mat3 normalWorldSpaceToLocalSpace
 ) {
 	vec4 light = vec4(0);
@@ -51,7 +63,7 @@ vec4 iterateOverAllPointLights(
 		int lightIndex = PointLightsIndex[entryInLightList / 4][entryInLightList % 4];
 		vec4 position = PointLightsPosition[lightIndex];
 		vec4 colorAndEnergy = PointLightsColorAndEnergy[lightIndex];
-		vec3 tmp = position.xyz * vec3(1., 1., -1.);
+		vec3 tmp = position.xyz;
 		light += processPointLight(WorldFragPos, fragNormal, viewVector, albedo, gloss, tmp, colorAndEnergy.w, colorAndEnergy.xyz, normalWorldSpaceToLocalSpace);
 	}
 	return light;

--- a/data/base/shaders/vk/tcmask_instanced.frag
+++ b/data/base/shaders/vk/tcmask_instanced.frag
@@ -344,9 +344,8 @@ void main()
 								0., 1., 0.,
 								0., 0., 1.
 								);
-		// Normals are in view space, we need to get back to world space
-		vec3 worldSpaceNormal = -(inverse(ViewMatrix) * vec4(N, 0.f)).xyz;
-		light += iterateOverAllPointLights(clipSpaceCoord, fragPos, worldSpaceNormal, normalize(halfVec - lightDir), diffuse, specularMapValue, identityMat);
+								
+		light += iterateOverAllPointLights(clipSpaceCoord, fragPos, -N, normalize(halfVec - lightDir), diffuse, specularMapValue, ViewMatrix, identityMat);
 	}
 
 	light.rgb *= visibility;

--- a/data/base/shaders/vk/terrain_combined_high.frag
+++ b/data/base/shaders/vk/terrain_combined_high.frag
@@ -90,7 +90,12 @@ vec4 doBumpMapping(BumpData b, vec3 lightDir, vec3 halfVec) {
 	{
 		// point lights
 		vec2 clipSpaceCoord = gl_FragCoord.xy / vec2(viewportWidth, viewportHeight);
-		res += iterateOverAllPointLights(clipSpaceCoord, frag.fragPos, b.N, normalize(halfVec - lightDir), b.color, b.gloss, ModelTangentMatrix);
+		mat3 identityMat = mat3(
+								1., 0., 0.,
+								0., 1., 0.,
+								0., 0., 1.
+								);
+		res += iterateOverAllPointLights(clipSpaceCoord, frag.fragPos, b.N, normalize(halfVec - lightDir), b.color, b.gloss, identityMat, ModelTangentMatrix);
 	}
 
 	return vec4(res.rgb, b.color.a);

--- a/lib/ivis_opengl/pielighting.cpp
+++ b/lib/ivis_opengl/pielighting.cpp
@@ -151,7 +151,8 @@ void renderingNew::LightingManager::ComputeFrameData(const LightingData& data, L
 		const auto& light = culledLights[lightIndex];
 		result.positions[lightIndex].x = light.position.x;
 		result.positions[lightIndex].y = light.position.y;
-		result.positions[lightIndex].z = light.position.z;
+		// WZ coordinate system
+		result.positions[lightIndex].z = -light.position.z;
 		result.colorAndEnergy[lightIndex].x = light.colour.byte.r / 255.f;
 		result.colorAndEnergy[lightIndex].y = light.colour.byte.g / 255.f;
 		result.colorAndEnergy[lightIndex].z = light.colour.byte.b / 255.f;


### PR DESCRIPTION
It turns out normal are computed in view space and not worldspace for tcmask shader.

This PR introduces a new matrix used to fix the coordinate space.

The point lights at the beginning of beta 1 should be fixed