### PR TITLE
(MP)Body cost fix

### DIFF
--- a/data/mp/stats/body.json
+++ b/data/mp/stats/body.json
@@ -598,7 +598,7 @@
 	"Body2SUP": {
 		"armourHeat": 6,
 		"armourKinetic": 14,
-		"buildPoints": 170,
+		"buildPoints": 190,
 		"buildPower": 37,
 		"class": "Droids",
 		"designable": 1,
@@ -641,7 +641,7 @@
 		"armourHeat": 15,
 		"armourKinetic": 20,
 		"buildPoints": 170,
-		"buildPower": 45,
+		"buildPower": 49,
 		"class": "Droids",
 		"designable": 1,
 		"hitpoints": 150,


### PR DESCRIPTION
If you look at the history of changes to bodies, I previously changed prices based primarily on the values of resists and HP, so bodies that recently received buffs also need to adjust their prices

Leopard "buildPoints": 170->190
Retaliation "buildPower": 45-> 49