### PR TITLE
Limit pickup events to half a tile height differences

### DIFF
--- a/src/move.cpp
+++ b/src/move.cpp
@@ -2026,6 +2026,7 @@ static void checkLocalFeatures(DROID *psDroid)
 
 	// scan the neighbours
 #define DROIDDIST ((TILE_UNITS*5)/2)
+	constexpr int MAX_PICKUP_DISTANCE = (TILE_UNITS / 2);
 	static GridList gridList;  // static to avoid allocations.
 	gridList = gridStartIterate(psDroid->pos.x, psDroid->pos.y, DROIDDIST);
 	for (GridIterator gi = gridList.begin(); gi != gridList.end(); ++gi)
@@ -2035,6 +2036,11 @@ static void checkLocalFeatures(DROID *psDroid)
 
 		if (psObj->type == OBJ_FEATURE && !psObj->died)
 		{
+			if (std::abs(psDroid->pos.z - psObj->pos.z) > MAX_PICKUP_DISTANCE)
+			{
+				continue; // Don't pickup if height difference is more than half of a tile.
+			}
+
 			switch (((FEATURE *)psObj)->psStats->subType)
 			{
 			case FEAT_OIL_DRUM:


### PR DESCRIPTION
Most notable case this happens on is Alpha 2's sensor tower artifact. Driving along the rightmost side path far below the artifact would allow you to grab it without actually driving up the hill.

This will limit pickup events to height differences of 64 world coordinates.

![art](https://github.com/Warzone2100/warzone2100/assets/22485442/56e45689-e950-46bc-aa47-fc2bf4bce210)
