### PR TITLE
(MP)HRA cost rollback

### DIFF
--- a/data/mp/stats/weapons.json
+++ b/data/mp/stats/weapons.json
@@ -4083,7 +4083,7 @@
 		"weight": 250
 	},
 	"Rocket-MRL-Hvy": {
-		"buildPoints": 900,
+		"buildPoints": 800,
 		"buildPower": 150,
 		"damage": 40,
 		"designable": 1,


### PR DESCRIPTION
Previously, I nerfed HRA in terms of splash damage and also increased “buildPoints” from 800 to 900 and now, in my opinion, the second action was unnecessary

"buildPoints": 900 -> 800