### PR TITLE
More Sentry crash prevention

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2401,7 +2401,7 @@ static void getIniDroidOrder(WzConfig &ini, WzString const &key, DroidOrder &ord
 
 static void setIniBaseObject(nlohmann::json &json, WzString const &key, BASE_OBJECT const *object)
 {
-	if (object != nullptr && object->died <= 1)
+	if (object != nullptr && object->died <= NOT_CURRENT_LIST)
 	{
 		const auto& keyStr = key.toStdString();
 		json[keyStr + "/id"] = object->id;
@@ -5470,7 +5470,7 @@ static void writeSaveObject(WzConfig &ini, const BASE_OBJECT *psObj)
 		ini.setValue("periodicalDamage", psObj->periodicalDamage);
 	}
 	ini.setValue("born", psObj->born);
-	if (psObj->died > 0)
+	if (psObj->died >= NOT_CURRENT_LIST)
 	{
 		ini.setValue("died", psObj->died);
 	}
@@ -5520,7 +5520,7 @@ static void writeSaveObjectJSON(nlohmann::json &jsonObj, const BASE_OBJECT *psOb
 		jsonObj["periodicalDamage"] = psObj->periodicalDamage;
 	}
 	jsonObj["born"] = psObj->born;
-	if (psObj->died > 0)
+	if (psObj->died >= NOT_CURRENT_LIST)
 	{
 		jsonObj["died"] = psObj->died;
 	}
@@ -5868,7 +5868,7 @@ static nlohmann::json writeDroid(const DROID *psCurr, bool onMission, int &count
 		droidObj["aigroup/type"] = psCurr->psGroup->type;
 	}
 	droidObj["group"] = psCurr->group;	// different kind of group. of course.
-	if (hasCommander(psCurr) && psCurr->psGroup->psCommander->died <= 1)
+	if (hasCommander(psCurr) && psCurr->psGroup->psCommander->died <= NOT_CURRENT_LIST)
 	{
 		droidObj["commander"] = psCurr->psGroup->psCommander->id;
 	}

--- a/src/order.cpp
+++ b/src/order.cpp
@@ -415,7 +415,14 @@ void orderUpdateDroid(DROID *psDroid)
 	SDWORD			xdiff, ydiff;
 	bool			bAttack;
 	SDWORD			xoffset, yoffset;
+
+	if (psDroid == nullptr || isDead(psDroid))
+	{
+		return;
+	}
+
 	const WEAPON_STATS *psWeapStats = psDroid->getWeaponStats(0);
+
 	// clear the target if it has died
 	if (psDroid->order.psObj && psDroid->order.psObj->died)
 	{
@@ -434,11 +441,6 @@ void orderUpdateDroid(DROID *psDroid)
 
 	// check for died objects in the list
 	orderCheckList(psDroid);
-
-	if (isDead(psDroid))
-	{
-		return;
-	}
 
 	switch (psDroid->order.type)
 	{

--- a/src/structure.cpp
+++ b/src/structure.cpp
@@ -1500,7 +1500,7 @@ STRUCTURE *buildStructureDir(STRUCTURE_STATS *pStructureType, UDWORD x, UDWORD y
 				psTile->psObject = psBuilding;
 
 				// if it's a tall structure then flag it in the map.
-				if (psBuilding->sDisplay.imd->max.y > TALLOBJECT_YMAX)
+				if (psBuilding->sDisplay.imd && psBuilding->sDisplay.imd->max.y > TALLOBJECT_YMAX)
 				{
 					auxSetBlocking(tileX, tileY, AIR_BLOCKED);
 				}


### PR DESCRIPTION
A couple more nullptr/dead checks.

A drive-by commit for making a huge hack relating to `died` more obvious (it can mean 3 things) in case someone tries to change that in the future so saves don't get weird.