### PR TITLE
[Flatpak] CI improvements

### DIFF
--- a/.ci/flatpak/net.wz2100.wz2100.yaml.in
+++ b/.ci/flatpak/net.wz2100.wz2100.yaml.in
@@ -95,6 +95,7 @@ modules:
     buildsystem: cmake-ninja
     builddir: true
     build-options:
+      strip: true
       no-debuginfo: true
     # Always build for host - do not include WZ_CROSS_BUILD_OPTIONS
     cleanup:

--- a/.ci/flatpak/net.wz2100.wz2100.yaml.in
+++ b/.ci/flatpak/net.wz2100.wz2100.yaml.in
@@ -163,8 +163,8 @@ modules:
     @WZ_AUTOTOOLS_CROSS_CONFIG_OPTIONS@
     sources:
       - type: archive
-        url: https://github.com/jedisct1/libsodium/releases/download/1.0.18-RELEASE/libsodium-1.0.18.tar.gz
-        sha256: 6f504490b342a4f8a4c4a02fc9b866cbef8622d5df4e5452b46be121e46636c1
+        url: https://github.com/jedisct1/libsodium/releases/download/1.0.19-RELEASE/libsodium-1.0.19.tar.gz
+        sha256: 018d79fe0a045cca07331d37bd0cb57b2e838c51bc48fd837a1472e50068bbea
 
   - name: warzone2100
     buildsystem: cmake-ninja

--- a/.ci/flatpak/net.wz2100.wz2100.yaml.in
+++ b/.ci/flatpak/net.wz2100.wz2100.yaml.in
@@ -139,8 +139,8 @@ modules:
     @WZ_CMAKE_CROSS_CONFIG_OPTIONS@
     sources:
       - type: archive
-        url: https://github.com/icculus/physfs/archive/eb3383b532c5f74bfeb42ec306ba2cf80eed988c.zip # PhysFS 3.2.0
-        sha512: 1068b1e0636b478f0d7910303e94d109923b2e4d809fa7a00232ba3733a4cd39c28d17851ff946859c431d7d7febdd229237cc10176eb5d5d19b49c887919fd8
+        url: https://github.com/icculus/physfs/archive/741c4be358cd87366af1387d1e04e3f7d4f50c1e.zip # PhysFS 3.2.0+
+        sha512: 56bfe808e28d7de6b9f242ca3ce81d08439480499c7d5901f78a3ec8ea75c55b71958515db015f101bb6b884a0a0f1140fab1a7222aff0bbe28555ebf378807f
       
   - name: fribidi
     buildsystem: meson

--- a/.github/workflows/CI_flatpak.yml
+++ b/.github/workflows/CI_flatpak.yml
@@ -48,9 +48,6 @@ jobs:
       WZ_FLATPAK_TARGET_ARCH: ${{ matrix.flatpak-arch }}
       WZ_FLATPAK_BUILD_ARCH: x86_64
       WZ_FREEDESKTOP_RUNTIME_VERSION: 23.08 # should match runtime-version in .ci/flatpak/net.wz2100.wz2100.yaml.in
-    container:
-      image: fedora:latest
-      options: --privileged
     outputs:
       # Needed by the release job - despite this being a matrix job, this should be the same for all, so we can allow whatever is last to persist it
       WZ_GITHUB_REF: ${{ steps.checkout-config.outputs.WZ_GITHUB_REF }}
@@ -59,34 +56,15 @@ jobs:
     steps:
     - name: Install Dependencies
       run: |
-        cat /etc/fedora-release
-        
-        echo "::group::dnf update"
-        dnf update -y
-        echo "::endgroup::"
-        echo "::group::dnf install dependencies"
-        dnf install -y cmake git git-lfs dbus-daemon flatpak flatpak-builder python3-aiohttp python3-tenacity python3-gobject ccache zstd curl appstream
+        echo "::group::apt install dependencies"
+        sudo apt install flatpak python3-aiohttp python3-tenacity dbus-daemon curl
         echo "::endgroup::"
         
         echo "::group::flatpak remote-add"
-        flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
-        flatpak remote-add --if-not-exists flathub-beta https://flathub.org/beta-repo/flathub-beta.flatpakrepo
-        flatpak remote-add --if-not-exists gnome-nightly https://nightly.gnome.org/gnome-nightly.flatpakrepo
+        flatpak --user remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
+        flatpak --user remote-add --if-not-exists flathub-beta https://flathub.org/beta-repo/flathub-beta.flatpakrepo
+        flatpak --user remote-add --if-not-exists gnome-nightly https://nightly.gnome.org/gnome-nightly.flatpakrepo
         echo "::endgroup::"
-        
-        echo "::group::fetch flat-manager-client"
-        curl -Lf https://raw.githubusercontent.com/flatpak/flat-manager/master/flat-manager-client --output /usr/bin/flat-manager-client
-        chmod +x /usr/bin/flat-manager-client
-        echo "::endgroup::"
-    - name: Install QEMU deps
-      if: ${{ matrix.arch != 'x86_64' }}
-      run: |
-        dnf -y install docker
-    - name: Set up QEMU
-      if: ${{ matrix.arch != 'x86_64' }}
-      uses: docker/setup-qemu-action@v2
-      with:
-        platforms: ${{ matrix.arch }}
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
@@ -201,19 +179,19 @@ jobs:
     - name: Install Flatpak manifest deps
       run: |
         # Build SDK
-        flatpak --system install -y --noninteractive flathub org.freedesktop.Sdk//${WZ_FREEDESKTOP_RUNTIME_VERSION}
+        flatpak install --user -y --noninteractive flathub org.freedesktop.Sdk//${WZ_FREEDESKTOP_RUNTIME_VERSION}
         # Target runtime
-        flatpak --system install -y --noninteractive flathub org.freedesktop.Platform/${WZ_FLATPAK_TARGET_ARCH}/${WZ_FREEDESKTOP_RUNTIME_VERSION}
+        flatpak install --user -y --noninteractive flathub org.freedesktop.Platform/${WZ_FLATPAK_TARGET_ARCH}/${WZ_FREEDESKTOP_RUNTIME_VERSION}
         
         if [[ "$WZ_FLATPAK_TARGET_ARCH" != "$WZ_FLATPAK_BUILD_ARCH" ]]; then
           # Cross compiler
-          flatpak --system install -y --noninteractive flathub org.freedesktop.Sdk.Extension.toolchain-${WZ_FLATPAK_TARGET_ARCH}//${WZ_FREEDESKTOP_RUNTIME_VERSION}
+          flatpak install --user -y --noninteractive flathub org.freedesktop.Sdk.Extension.toolchain-${WZ_FLATPAK_TARGET_ARCH}//${WZ_FREEDESKTOP_RUNTIME_VERSION}
           # SDK For target runtime
-          flatpak --system install -y --noninteractive flathub org.freedesktop.Sdk.Compat.${WZ_FLATPAK_TARGET_ARCH}//${WZ_FREEDESKTOP_RUNTIME_VERSION}
+          flatpak install --user -y --noninteractive flathub org.freedesktop.Sdk.Compat.${WZ_FLATPAK_TARGET_ARCH}//${WZ_FREEDESKTOP_RUNTIME_VERSION}
         fi
         
         # Builder (which includes flatpak-builder-lint)
-        flatpak install flathub -y --noninteractive org.flatpak.Builder
+        flatpak install --user flathub -y --noninteractive org.flatpak.Builder
     - name: Build Flatpak
       id: build
       env:
@@ -223,9 +201,7 @@ jobs:
         SENTRY_IO_DSN: '${{ secrets.CRASHREPORTING_SENTRY_IO_DSN }}'
         DISCORD_RPC_APPID: '${{ secrets.DISCORD_RPC_APPID }}'
       run: |
-        . src/.ci/flatpak/build.sh
-        echo "WZ_FLATPAK_LOCAL_REPO_NAME=${WZ_FLATPAK_LOCAL_REPO_NAME}"
-        echo "WZ_FLATPAK_LOCAL_REPO_NAME=${WZ_FLATPAK_LOCAL_REPO_NAME}" >> $GITHUB_OUTPUT
+        dbus-run-session -- bash src/.ci/flatpak/build.sh
     - name: Output generated files listing
       shell: bash
       working-directory: flatpak_app/files
@@ -236,12 +212,14 @@ jobs:
       env:
         WZ_FLATPAK_LOCAL_REPO_NAME: ${{ steps.build.outputs.WZ_FLATPAK_LOCAL_REPO_NAME }}
       run: |
-        # Start a dbus session within the container to allow flatpaks to run
-        # See: https://discussion.fedoraproject.org/t/cannot-run-flatpaks-in-a-fedora-container/73867/2
-        mkdir /run/dbus
-        dbus-send --system /org/freedesktop/DBus org.freedesktop.DBus || dbus-daemon --system --fork
-        
-        flatpak run --command=flatpak-builder-lint org.flatpak.Builder --exceptions repo "${WZ_FLATPAK_LOCAL_REPO_NAME}"
+        WZ_FLATPAK_BUILD_PATH="${WZ_FLATPAK_BUILD_DIR}/files/share"
+        echo "::group::.metainfo.xml file"
+        cat "${WZ_FLATPAK_BUILD_PATH}/metainfo/${WZ_FLATPAK_APPID}.metainfo.xml"
+        echo "::endgroup::"
+        echo "::group::.desktop file"
+        cat "${WZ_FLATPAK_BUILD_PATH}/applications/${WZ_FLATPAK_APPID}.desktop"
+        echo "::endgroup::"
+        dbus-run-session flatpak run --command=flatpak-builder-lint org.flatpak.Builder --exceptions repo "${WZ_FLATPAK_LOCAL_REPO_NAME}"
         echo "flatpak-builder-lint - OK"
     ###############################################################
     # Upload the .flatpak and debugsymbols artifacts
@@ -264,15 +242,19 @@ jobs:
       shell: bash
       run: |
         mkdir output_debug_dependency_snapshot
+        # Get path to runtime files
+        TARGET_FREEDESKTOP_RUNTIME_PATH="$(flatpak info --show-location org.freedesktop.Platform/${WZ_FLATPAK_TARGET_ARCH}/${WZ_FREEDESKTOP_RUNTIME_VERSION})"
+        echo "TARGET_FREEDESKTOP_RUNTIME_PATH=${TARGET_FREEDESKTOP_RUNTIME_PATH}"
+        export TARGET_FREEDESKTOP_RUNTIME_PATH=${TARGET_FREEDESKTOP_RUNTIME_PATH}
         set +e
         # Note: These libraries will be from the runtime that is installed at the time of the build
         ldd flatpak_app/files/bin/warzone2100 | grep -E -v 'linux-vdso|ld-linux-' | awk 'NF == 4 { system("echo " $1) }'
         ret="$?"
         if [ $ret -eq 0 ]; then
-          ldd flatpak_app/files/bin/warzone2100 | grep -E -v 'linux-vdso|ld-linux-' | awk 'NF == 4 { system("cp /var/lib/flatpak/runtime/org.freedesktop.Platform/${WZ_FLATPAK_TARGET_ARCH}/${WZ_FREEDESKTOP_RUNTIME_VERSION}/active/files/lib/${WZ_FLATPAK_TARGET_ARCH}-linux-gnu/" $1 " output_debug_dependency_snapshot") }'
+          ldd flatpak_app/files/bin/warzone2100 | grep -E -v 'linux-vdso|ld-linux-' | awk 'NF == 4 { system("cp ${TARGET_FREEDESKTOP_RUNTIME_PATH}/files/lib/${WZ_FLATPAK_TARGET_ARCH}-linux-gnu/" $1 " output_debug_dependency_snapshot") }'
         else
           # ldd fails for non-native architecture, so use objdump for cross-compiled builds
-          objdump -p flatpak_app/files/bin/warzone2100 | grep NEEDED | grep -E -v 'linux-vdso|ld-linux-' | awk 'NF == 2 { system("echo " $2 " && cp /var/lib/flatpak/runtime/org.freedesktop.Platform/${WZ_FLATPAK_TARGET_ARCH}/${WZ_FREEDESKTOP_RUNTIME_VERSION}/active/files/lib/${WZ_FLATPAK_TARGET_ARCH}-linux-gnu/" $2 " output_debug_dependency_snapshot") }'
+          objdump -p flatpak_app/files/bin/warzone2100 | grep NEEDED | grep -E -v 'linux-vdso|ld-linux-' | awk 'NF == 2 { system("echo " $2 " && cp ${TARGET_FREEDESKTOP_RUNTIME_PATH}/files/lib/${WZ_FLATPAK_TARGET_ARCH}-linux-gnu/" $2 " output_debug_dependency_snapshot") }'
         fi
     - name: Upload additional debug dependency info
       uses: actions/upload-artifact@v4


### PR DESCRIPTION
`.ci/flatpak/build.sh`:
- Use the `org.flatpak.Builder` flatpak's bundled binaries to match Flathub infrastructure (for flatpak-builder, flatpak, ostree, appstreamcli).
- Update the source directory for screenshots to match the latest flatpak-builder changes

The workflow now runs the `build-flatpak` job on ubuntu (instead of a fedora:latest docker image), and uses `dbus-run-session` to run the `build.sh` script.