### PR TITLE
Fix issues in BoneCrusher AI

### DIFF
--- a/data/mp/multiplay/skirmish/bonecrusher/bonecrusher.js
+++ b/data/mp/multiplay/skirmish/bonecrusher/bonecrusher.js
@@ -62,7 +62,7 @@ var debugName = me;
 
 
 //Массив конкретных технологий (tech.js)
-var tech = [];
+var tech = {};
 
 include("multiplay/skirmish/"+vernum+"/names.js");
 
@@ -195,10 +195,10 @@ else rage = HARD;
 var buildersMain = newGroup();
 var buildersHunters = newGroup();
 
-var policy = [];
+var policy = {};
 
 //Фитчи, не совместимые с 3.1.5
-var nf = [];
+var nf = {};
 nf['policy'] = false;
 
 var enemyDist = 0;
@@ -238,7 +238,7 @@ var credit = 0;
 var lassat_charged = false;
 
 
-var eventsRun=[];
+var eventsRun={};
 eventsRun['targetCyborgs'] = 0;
 eventsRun['targetArmy'] = 0;
 eventsRun['targetRegular'] = 0;

--- a/data/mp/multiplay/skirmish/bonecrusher/builders.js
+++ b/data/mp/multiplay/skirmish/bonecrusher/builders.js
@@ -106,9 +106,10 @@ function builderBuild(droid, structure, rotation, position){
 	if (isStructureAvailable(structure, me)) {
 
 		debugMsg('try '+structure, 'builders');
+		var _pos;
 
-		if (position) var _pos = position;
-		else var _pos = base;
+		if (position) _pos = position;
+		else _pos = base;
 
 		if (structure === "A0RepairCentre3" && !position) {
 			if (repfac.length === 0) {

--- a/data/mp/multiplay/skirmish/bonecrusher/chatting.js
+++ b/data/mp/multiplay/skirmish/bonecrusher/chatting.js
@@ -1,32 +1,34 @@
 debugMsg('Module: chatting.js','init');
 
 function chatting(type){
-	var chlen = chatting[type].length;		// Забавно, спустя некотое время я только осознал, что за имя я дал этой переменной xDDD
-	return chatting[type][Math.floor(Math.random()*chlen)];
-	
+	var chlen = _chatting[type].length;		// Забавно, спустя некотое время я только осознал, что за имя я дал этой переменной xDDD
+	return _chatting[type][Math.floor(Math.random()*chlen)];
+
 }
 
-chatting['army'] = [
+var _chatting = {};
+
+_chatting['army'] = [
 	"If u want, i may support you with my army. Just say \"yes\"",
 	"I can share some units, say \"yes\" if u want.",
 	"I can sometimes give you my warriors, just say \"yes\""
 ];
 
-chatting['lassat_fire'] = [
+_chatting['lassat_fire'] = [
 	"Bada-Boom!",
 	"Boom!",
 	"Boo-Boom!",
 	";)"
 ];
 
-chatting['lassat_charged'] = [
+_chatting['lassat_charged'] = [
 	"Scare me",
 	"Laser ready, now get ready",
 	"He-heh",
 	":)"
 ];
 
-chatting['confirm'] = [
+_chatting['confirm'] = [
 	"Ok then! Let's kill them all together!!",
 	"Yeah! That's my boy! >:)",
 	"Allright! Got it!",
@@ -35,14 +37,14 @@ chatting['confirm'] = [
 	"Ok"
 ];
 
-chatting['kick'] = [
+_chatting['kick'] = [
 	"I was kicked out, for what?",
 	"Lol, just kicked..",
 	"Well, bye, i leave.",
 	"Loosers, you're just afraid of me."
 ];
 
-chatting['saved'] = [
+_chatting['saved'] = [
 	"Yeah, better to be saved ;)",
 	"Oh, what, decided to take a break?",
 	"Save, save, save.. How long.",
@@ -52,7 +54,7 @@ chatting['saved'] = [
 	"Oh, don't be scared.. Saved, nice :)"
 ];
 
-chatting['tutorial'] = [
+_chatting['tutorial'] = [
 	"By the way, i can ask me for money, just say \"bc give money\"",
 	"If you die, just say \"bc give truck\", and i resurrect u ;)",
 	"Btw, you can ask me, \"bc give money\" or \"bc give truck\" remember that",
@@ -61,17 +63,17 @@ chatting['tutorial'] = [
 	"Always help the team, or we will all die"
 ];
 
-chatting['ally'] = [
+_chatting['ally'] = [
 	"Hellow my friend! Let's kill them!",
 ];
 
-chatting['threat'] = [
+_chatting['threat'] = [
 	'I kill you!!!',
 	'Nice try! But i will destroy you!',
 	'Do not expect mercy'
 ];
 
-chatting['welcome'] = [
+_chatting['welcome'] = [
 	'Hello everyone',
 	'Hi there',
 	'hi.. gl hf',
@@ -97,7 +99,7 @@ chatting['welcome'] = [
 	"Dosvidaniya... no? %) Hi!"
 ];
 
-chatting['loose'] = [
+_chatting['loose'] = [
 	'ohh.. you win, gg',
 	'nice, gg',
 	'wow.. gg',
@@ -117,7 +119,7 @@ chatting['loose'] = [
 ];
 
 
-chatting['berserk'] = [
+_chatting['berserk'] = [
 'Time to kick someone\'s ..',
 'You made me angry',
 'You\'re clearly pissing me off',
@@ -126,14 +128,14 @@ chatting['berserk'] = [
 'Who needs oil. Oil for suckers'
 ];
 
-chatting['seer'] = [
+_chatting['seer'] = [
 'You\'re a leather bag of brains, and I\'m just a cheater.',
 'Leather bag, aren\'t you afraid?',
 'I can see everything.',
 'Tons of oil - check, see the entire map - check.'
 ];
 
-chatting['no'] = [
+_chatting['no'] = [
 'I\'m sorry, I can\'t do this.',
 'No, I\'m not ready for that',
 'Sorry, but no.',
@@ -146,4 +148,4 @@ chatting['no'] = [
 ];
 
 
-chatting['dev'] = ['This is dev version, dont use it! Данная версия бота не является релизом и может содержать баги! Не используйте её!'];
+_chatting['dev'] = ['This is dev version, dont use it! Данная версия бота не является релизом и может содержать баги! Не используйте её!'];

--- a/data/mp/multiplay/skirmish/bonecrusher/events.js
+++ b/data/mp/multiplay/skirmish/bonecrusher/events.js
@@ -125,9 +125,9 @@ function bc_eventObjectSeen(sensor, gameObject) {
 		if (!allianceExistsBetween(me,gameObject.player)) {
 //			debugMsg("eventObjectSeen: "+ sensor.name+" обнаружил вражескую еденицу: "+gameObject.name, 'events');
 //			getTarget();
-			if (gameObject.droidType === DROID_WEAPON
-				&& isFixVTOL(gameObject)
-				&& distBetweenTwoPoints_p(gameObject.x,gameObject.y,base.x,base.y) < base_range)
+			if (gameObject.droidType === DROID_WEAPON &&
+				isFixVTOL(gameObject) &&
+				distBetweenTwoPoints_p(gameObject.x,gameObject.y,base.x,base.y) < base_range)
 				AA_queue.push({x:gameObject.x,y:gameObject.y});
 		}
 		break;

--- a/data/mp/multiplay/skirmish/bonecrusher/functions.js
+++ b/data/mp/multiplay/skirmish/bonecrusher/functions.js
@@ -26,17 +26,19 @@ function getInfoNear(x,y,command,range,time,obj,cheat,inc){
 
 	debugMsg(x+'x'+y+' '+command, 'gi');
 
-	if (typeof _globalInfoNear[x+'_'+y+'_'+command] !== "undefined"
-	&& gameTime < (_globalInfoNear[x+'_'+y+'_'+command].setTime + _globalInfoNear[x+'_'+y+'_'+command].updateIn)) {
+	if (typeof _globalInfoNear[x+'_'+y+'_'+command] !== "undefined" &&
+		gameTime < (_globalInfoNear[x+'_'+y+'_'+command].setTime + _globalInfoNear[x+'_'+y+'_'+command].updateIn))
+	{
 		if (inc) {
 			_globalInfoNear[x+'_'+y+'_'+command].value++;
 		}
 		return _globalInfoNear[x+'_'+y+'_'+command];
 	} else {
+		var view;
 		if (typeof time === "undefined") time = 30000;
 		if (typeof range === "undefined") range = 7;
-		if (typeof cheat === "undefined") var view = me;
-		else if (cheat) var view = -1;
+		if (typeof cheat === "undefined") view = me;
+		else if (cheat) view = -1;
 //		_globalInfoNear[x+'_'+y+'_'+command] = [];
 		_globalInfoNear[x+'_'+y+'_'+command] = { setTime: gameTime, updateIn: time };
 
@@ -358,8 +360,9 @@ function checkProcess(){
 			}
 
 			if (enumDroid(bc_ally[plally], DROID_CONSTRUCT).length < 3) {
+				var truck;
 				if (groupSize(buildersMain) >= 2) {
-					var truck = enumGroup(buildersMain);
+					truck = enumGroup(buildersMain);
 					if (truck.length > 0) {
 						debugMsg("Send builder["+truck[0].id+"] from "+me+" to "+bc_ally[plally], 'ally');
 						donateObject(truck[0], bc_ally[plally]);
@@ -368,7 +371,7 @@ function checkProcess(){
 				}
 
 				if (groupSize(buildersHunters) > 1) {
-					var truck = enumGroup(buildersHunters);
+					truck = enumGroup(buildersHunters);
 					if (truck.length > 0) {
 						donateObject(truck[0], bc_ally[plally]);
 						debugMsg("Send hunter["+truck[0].id+"] from "+me+" to "+bc_ally[plally], 'ally');
@@ -424,19 +427,19 @@ function gameStop(condition){
 
 function playerLoose(player){
 	var loose = false;
-	if (enumStruct(player,"A0LightFactory").length === 0
-		&& enumDroid(player, DROID_CONSTRUCT).length === 0
-		&& enumStruct(player,"A0CyborgFactory").length === 0
-		&& enumDroid(player, 10).length === 0) loose = true;
+	if (enumStruct(player,"A0LightFactory").length === 0 &&
+		enumDroid(player, DROID_CONSTRUCT).length === 0 &&
+		enumStruct(player,"A0CyborgFactory").length === 0 &&
+		enumDroid(player, 10).length === 0) loose = true;
 	return loose;
 }
 
 function playerSpectator(player){
 	var loose = false;
-	if ((enumStruct(player, "A0Sat-linkCentre").length === 1 || enumStruct(player, "A0CommandCentre").length === 1)
-		&& enumStruct(player,"A0LightFactory").length === 0
-		&& enumStruct(player,"A0CyborgFactory").length === 0
-		&& enumDroid(player, 10).length === 0) loose = true;
+	if ((enumStruct(player, "A0Sat-linkCentre").length === 1 || enumStruct(player, "A0CommandCentre").length === 1) &&
+		enumStruct(player,"A0LightFactory").length === 0 &&
+		enumStruct(player,"A0CyborgFactory").length === 0 &&
+		enumDroid(player, 10).length === 0) loose = true;
 	return loose;
 }
 
@@ -1008,7 +1011,7 @@ var isFixVTOL = function(obj) {
 	} catch(e) {
 //		debugMsg("isFixVTOL(): "+e.message, 'error');
 	}
-}
+};
 
 //from: http://stackoverflow.com/questions/6274339/how-can-i-shuffle-an-array
 function shuffle(a) {
@@ -1266,7 +1269,7 @@ function getFleetPoint(droid){
 	droidsNear = sortByDistance(droidsNear, base);
 //	debugMsg('dl:'+droidsNear.length, 'temp');
 //	debugMsg('dr:'+droidCanReach(droid, base.x, base.y), 'temp');
-	if (droidsNear.length === 0 || droidsNear[0].id === droid.id) return base
+	if (droidsNear.length === 0 || droidsNear[0].id === droid.id) return base;
 	return droidsNear[0];
 
 }

--- a/data/mp/multiplay/skirmish/bonecrusher/names.js
+++ b/data/mp/multiplay/skirmish/bonecrusher/names.js
@@ -561,4 +561,4 @@ const research_name = {
 	"R-Comp-CommandTurret02" : "Command Turret II",
 	"R-Comp-CommandTurret03" : "Command Turret III",
 	"R-Comp-CommandTurret04" : "Command Turret IV"
-}
+};

--- a/data/mp/multiplay/skirmish/bonecrusher/produce.js
+++ b/data/mp/multiplay/skirmish/bonecrusher/produce.js
@@ -223,7 +223,6 @@ function produceCyborgs(){
 
 
 	if (enumStruct(me, FACTORY).length === 0) {
-		var cyborg_factories = enumStruct(me,CYBORG_FACTORY).filter((e) => (e.status === BUILT && structureIdle(e)));
 		if (cyborg_factories.length > 0) {
 			buildDroid(cyborg_factories[0], 'Emergency Builder', 'CyborgLightBody', "CyborgLegs", "", "", 'CyborgSpade');
 		}

--- a/data/mp/multiplay/skirmish/bonecrusher/research.js
+++ b/data/mp/multiplay/skirmish/bonecrusher/research.js
@@ -120,7 +120,7 @@ function doResearch_old(){
 
 	var avail_research = enumResearch().filter((e) => {
 		//		debugMsg(e.name+' - '+e.started+' - '+e.done, 'research_advance');
-		return !e.started
+		return !e.started;
 	});
 
 	if (research_way.length === 0 || avail_research.length === 0) {

--- a/data/mp/multiplay/skirmish/bonecrusher/targeting.js
+++ b/data/mp/multiplay/skirmish/bonecrusher/targeting.js
@@ -85,9 +85,10 @@ function targetJammers(){
 
 
 	var jammers = enumGroup(armyJammers);
+	var partisans;
 
-	if (se_r >= army_rich) var partisans = enumGroup(armyRegular);
-	else var partisans = enumGroup(armyPartisans);
+	if (se_r >= army_rich) partisans = enumGroup(armyRegular);
+	else partisans = enumGroup(armyPartisans);
 
 
 	if (jammers.length === 0 || partisans.length === 0) return;
@@ -467,6 +468,7 @@ function targetRegularRich(target, victim){
 
 	var help = [];
 	var stopPoint;
+	var endPoint;
 	if (ally.length > 0) help = getEnemyNearAlly();
 	if (help.length === 0) {
 		help = getEnemyCloseBase();
@@ -479,10 +481,10 @@ function targetRegularRich(target, victim){
 	}
 
 	if (stopPoint) {
-		var endPoint = {x:stopPoint.x,y:stopPoint.y};
+		endPoint = {x:stopPoint.x,y:stopPoint.y};
 	}
 	else {
-		var endPoint = {x:targRegular.x,y:targRegular.y};
+		endPoint = {x:targRegular.x,y:targRegular.y};
 	}
 
 	if (targRegular.x === 0 && targRegular.y === 0 && !target) {


### PR DESCRIPTION
A few global variables were assigned as arrays but were being used as objects later on. Breaking saves.

Various warnings like missing semicolons and variable redeclarations fixed.

---

Ultimately to ensure BoneCrusher is absolutely saveload safe it would need to just declare `var`s at the root level and initialize what is necessary inside an init function. Much like what is done with libcampaign, Cobra, SemperFi, etc. It does have an init() function called through eventGameLoaded (which fires after saveload) so maybe for now it won't be a big deal. Perhaps when I or anyone feels like doing a `var` to `let/const` conversion process for BoneCrusher it would be a good time to do that.