### PR TITLE
Various interface & user input-handling tweaks

### DIFF
--- a/lib/widget/dropdown.cpp
+++ b/lib/widget/dropdown.cpp
@@ -169,7 +169,7 @@ void DropdownWidget::open()
 			widgRegisterOverlayScreenOnTopOfScreen(dropdownWidget->overlayScreen, dropdownWidget->screenPointer.lock());
 			dropdownWidget->itemsList->setGeometry(dropdownWidget->screenPosX(), dropdownWidget->calculateDropdownListScreenPosY(), dropdownWidget->width(), dropdownWidget->itemsList->height());
 			dropdownWidget->overlayScreen->psForm->attach(dropdownWidget->itemsList);
-			dropdownWidget->overlayScreen->psForm->attach(std::make_shared<DropdownOverlay>([pWeakThis]() { if (auto dropdownWidget = pWeakThis.lock()) { dropdownWidget->close(); } }));
+			dropdownWidget->overlayScreen->psForm->attach(std::make_shared<DropdownOverlay>([pWeakThis]() { if (auto dropdownWidget = pWeakThis.lock()) { dropdownWidget->close(); } }), WIDGET::ChildZPos::Back);
 		}
 	});
 }

--- a/lib/widget/form.cpp
+++ b/lib/widget/form.cpp
@@ -300,7 +300,7 @@ void W_FORM::screenSizeDidChange(int oldWidth, int oldHeight, int newWidth, int 
 	WIDGET::screenSizeDidChange(oldWidth, oldHeight, newWidth, newHeight);
 }
 
-bool W_FORM::hitTest(int x, int y)
+bool W_FORM::hitTest(int x, int y) const
 {
 	if (!minimizable || formState != FormState::MINIMIZED)
 	{

--- a/lib/widget/form.h
+++ b/lib/widget/form.h
@@ -51,7 +51,7 @@ public:
 	void display(int xOffset, int yOffset) override;
 
 	void screenSizeDidChange(int oldWidth, int oldHeight, int newWidth, int newHeight) override;
-	bool hitTest(int x, int y) override;
+	bool hitTest(int x, int y) const override;
 	bool processClickRecursive(W_CONTEXT *psContext, WIDGET_KEY key, bool wasPressed) override;
 	void displayRecursive(WidgetGraphicsContext const &context) override;
 	using WIDGET::displayRecursive;

--- a/lib/widget/table.cpp
+++ b/lib/widget/table.cpp
@@ -156,7 +156,7 @@ void TableRow::displayRecursive(WidgetGraphicsContext const& context)
 	pie_UniTransBoxFill(x0, y0, x0 + width(), y0 + height(), disabledColor);
 }
 
-bool TableRow::hitTest(int x, int y)
+bool TableRow::hitTest(int x, int y) const
 {
 	if (disabledRow) { return false; }
 	return W_BUTTON::hitTest(x, y);

--- a/lib/widget/table.h
+++ b/lib/widget/table.h
@@ -60,7 +60,7 @@ public:
 protected:
 	virtual void display(int, int) override;
 	virtual void displayRecursive(WidgetGraphicsContext const& context) override;
-	virtual bool hitTest(int x, int y) override;
+	virtual bool hitTest(int x, int y) const override;
 public:
 	virtual bool processClickRecursive(W_CONTEXT *psContext, WIDGET_KEY key, bool wasPressed) override;
 protected:

--- a/lib/widget/tip.cpp
+++ b/lib/widget/tip.cpp
@@ -161,11 +161,11 @@ static void refreshTip(std::shared_ptr<WIDGET> mouseOverWidget)
 		height += displayCache.wzTip.back().belowBase();
 	}
 	auto x = clip<SDWORD>(mouseOverWidget->screenPosX() + mouseOverWidget->width() / 2, 0, screenWidth - width - 1);
-	auto y = std::max(mouseOverWidget->screenPosY() + mouseOverWidget->height() + TIP_VGAP, 0);
-	if (y + height >= (int)screenHeight)
+	auto y = std::min(mouseOverWidget->screenPosY() - height - TIP_VGAP, (int)screenHeight);
+	if (y < 0)
 	{
-		/* Position the tip above the button */
-		y = mouseOverWidget->screenPosY() - height - TIP_VGAP;
+		/* Position the tip below the button */
+		y = std::max(mouseOverWidget->screenPosY() + mouseOverWidget->height() + TIP_VGAP, 0);
 	}
 	tipRect = WzRect(x - 1, y - 1, width + 2, height + 2);
 

--- a/lib/widget/widgbase.h
+++ b/lib/widget/widgbase.h
@@ -341,7 +341,12 @@ public:
 	void setGeometry(WzRect const &r);
 	virtual void setGeometryFromScreenRect(WzRect const &r);
 
-	void attach(const std::shared_ptr<WIDGET> &widget);
+	enum class ChildZPos {
+		Front,
+		Back
+	};
+
+	void attach(const std::shared_ptr<WIDGET> &widget, ChildZPos zPos = ChildZPos::Front);
 	/**
 	 * @deprecated use `void WIDGET::attach(const std::shared_ptr<WIDGET> &widget)` instead
 	 **/

--- a/lib/widget/widgbase.h
+++ b/lib/widget/widgbase.h
@@ -70,7 +70,7 @@ typedef std::function<void (WIDGET *psWidget)> WIDGET_CALCLAYOUT_FUNC;
 typedef std::function<void (WIDGET *psWidget)> WIDGET_ONDELETE_FUNC;
 
 /* The optional hit-testing function, used for custom hit-testing within the outer bounding rectangle */
-typedef std::function<bool (WIDGET *psWidget, int x, int y)> WIDGET_HITTEST_FUNC;
+typedef std::function<bool (const WIDGET *psWidget, int x, int y)> WIDGET_HITTEST_FUNC;
 
 
 /* The different base types of widget */
@@ -218,7 +218,7 @@ protected:
 	virtual void display(int, int) {}
 	virtual void geometryChanged() {}
 
-	virtual bool hitTest(int x, int y);
+	virtual bool hitTest(int x, int y) const;
 
 public:
 	virtual unsigned getState();

--- a/lib/widget/widget.cpp
+++ b/lib/widget/widget.cpp
@@ -1157,7 +1157,7 @@ void WIDGET::runRecursive(W_CONTEXT *psContext)
 	}
 }
 
-bool WIDGET::hitTest(int x, int y)
+bool WIDGET::hitTest(int x, int y) const
 {
 	// default hit-testing bounding rect (based on the widget's x, y, width, height)
 	bool hitTestResult = dim.contains(x, y);

--- a/src/display.h
+++ b/src/display.h
@@ -54,8 +54,6 @@ void clearSelection();
 // deal with selecting a droid
 void dealWithDroidSelect(DROID *psDroid, bool bDragBox);
 
-bool isMouseOverRadar();
-
 void	setInvertMouseStatus(bool val);
 bool	getInvertMouseStatus();
 

--- a/src/display3d.cpp
+++ b/src/display3d.cpp
@@ -160,7 +160,6 @@ static gfx_api::buffer* pScreenTriangleVBO = nullptr;
 // To get the real camera position, still need to add Vector3i(player.p.x, 0, player.p.z).
 static Vector3i actualCameraPosition;
 
-bool	bRender3DOnly;
 static bool	bRangeDisplay = false;
 static SDWORD	rangeCenterX, rangeCenterY, rangeRadius;
 static bool	bDrawProximitys = true;
@@ -1030,22 +1029,6 @@ void draw3DScene()
 	}
 
 	drawDroidAndStructureSelections();
-
-	if (!bRender3DOnly)
-	{
-		if (radarVisible())
-		{
-			pie_SetFogStatus(false);
-			gfx_api::context::get().debugStringMarker("Draw 3D scene - radar");
-			drawRadar();
-			pie_SetFogStatus(true);
-		}
-
-		/* Ensure that any text messages are displayed at bottom of screen */
-		pie_SetFogStatus(false);
-		displayConsoleMessages();
-		bRender3DOnly = true;
-	}
 
 	pie_SetFogStatus(false);
 	iV_SetTextColour(WZCOL_TEXT_BRIGHT);

--- a/src/display3d.h
+++ b/src/display3d.h
@@ -118,7 +118,6 @@ void display3dScreenSizeDidChange(unsigned int oldWidth, unsigned int oldHeight,
 extern SDWORD mouseTileX, mouseTileY;
 extern Vector2i mousePos;
 
-extern bool bRender3DOnly;
 extern bool showGateways;
 extern bool showPath;
 extern const Vector2i visibleTiles;

--- a/src/frontend.cpp
+++ b/src/frontend.cpp
@@ -3834,6 +3834,8 @@ std::shared_ptr<W_LABEL> addSideText(WIDGET* psParent, UDWORD id, UDWORD PosX, U
 	};
 
 	auto psLabel = std::make_shared<W_LABEL>(&sLabInit);
+	psLabel->setTransparentToClicks(true);
+	psLabel->setTransparentToMouse(true);
 	psParent->attach(psLabel);
 	return psLabel;
 }

--- a/src/hci.cpp
+++ b/src/hci.cpp
@@ -75,6 +75,7 @@
 #include "keybind.h"
 #include "qtscript.h"
 #include "chat.h"
+#include "radar.h"
 #include "hci/build.h"
 #include "hci/research.h"
 #include "hci/manufacture.h"
@@ -1939,6 +1940,18 @@ void intDisplayWidgets()
 				displayConsoleMessages();
 			}
 		}
+	}
+
+	if (!gameUpdatePaused())
+	{
+		if (radarVisible())
+		{
+			gfx_api::context::get().debugStringMarker("Draw 3D scene - radar");
+			drawRadar();
+		}
+		
+		/* Ensure that any text messages are displayed at bottom of screen */
+		displayConsoleMessages();
 	}
 
 	widgDisplayScreen(psWScreen);

--- a/src/hci.cpp
+++ b/src/hci.cpp
@@ -340,7 +340,7 @@ void setReticuleButtonDimensions(W_BUTTON &button, const WzString &filename)
 		button.setGeometry(button.x(), button.y(), image->Width / 2, image->Height / 2);
 
 		// add a custom hit-testing function that uses a tighter bounding ellipse
-		button.setCustomHitTest([](WIDGET *psWidget, int x, int y) -> bool {
+		button.setCustomHitTest([](const WIDGET *psWidget, int x, int y) -> bool {
 
 			// determine center of ellipse contained within the bounding rect
 			float centerX = ((psWidget->x()) + (psWidget->x() + psWidget->width())) / 2.f;

--- a/src/hci.cpp
+++ b/src/hci.cpp
@@ -1020,6 +1020,13 @@ void intRefreshGroupsUI()
 	IntGroupsRefreshPending = true;
 }
 
+bool intAddRadarWidget()
+{
+	auto radarWidget = getRadarWidget();
+	ASSERT_OR_RETURN(false, radarWidget != nullptr, "Failed to get radar widget?");
+	psWScreen->psForm->attach(radarWidget, WIDGET::ChildZPos::Back);
+	return true;
+}
 
 // see if a delivery point is selected
 static FLAG_POSITION *intFindSelectedDelivPoint()
@@ -1942,16 +1949,19 @@ void intDisplayWidgets()
 		}
 	}
 
+	bool desiredRadarVisibility = false;
 	if (!gameUpdatePaused())
 	{
-		if (radarVisible())
-		{
-			gfx_api::context::get().debugStringMarker("Draw 3D scene - radar");
-			drawRadar();
-		}
-		
+		desiredRadarVisibility = radarVisible();
+
 		/* Ensure that any text messages are displayed at bottom of screen */
 		displayConsoleMessages();
+	}
+
+	auto radarWidget = getRadarWidget();
+	if (radarWidget && (desiredRadarVisibility != radarWidget->visible()))
+	{
+		(desiredRadarVisibility) ? radarWidget->show() : radarWidget->hide();
 	}
 
 	widgDisplayScreen(psWScreen);

--- a/src/hci.h
+++ b/src/hci.h
@@ -268,6 +268,8 @@ extern iIMDShape	*pNewDesignIMD;
 /* Initialise the in game interface */
 bool intInitialise();
 
+bool intAddRadarWidget();
+
 // Check of coordinate is in the build menu
 bool CoordInBuild(int x, int y);
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1879,6 +1879,8 @@ bool stageThreeInitialise()
 		challengeActive = true;
 	}
 
+	// add radar to interface screen, and resize
+	intAddRadarWidget();
 	resizeRadar();
 
 	setAllPauseStates(false);

--- a/src/loadsave.cpp
+++ b/src/loadsave.cpp
@@ -282,6 +282,19 @@ bool addLoadSave(LOADSAVE_MODE savemode, const char *title)
 	sFormInit.UserData = bLoad;
 	widgAddForm(psRequestScreen, &sFormInit);
 
+	// Add Banner Label
+	W_LABINIT sLabInit;
+	sLabInit.formID = LOADSAVE_BANNER;
+	sLabInit.FontID = font_large;
+	sLabInit.id		= LOADSAVE_LABEL;
+	sLabInit.style	= WLAB_ALIGNCENTRE;
+	sLabInit.x		= 0;
+	sLabInit.y		= 0;
+	sLabInit.width	= LOADSAVE_W - (2 * LOADSAVE_HGAP);	//LOADSAVE_W;
+	sLabInit.height = LOADSAVE_BANNER_DEPTH;		//This looks right -Q
+	sLabInit.pText	= WzString::fromUtf8(title);
+	widgAddLabel(psRequestScreen, &sLabInit);
+
 	// add cancel.
 	W_BUTINIT sButInit;
 	sButInit.formID = LOADSAVE_BANNER;
@@ -296,19 +309,6 @@ bool addLoadSave(LOADSAVE_MODE savemode, const char *title)
 	sButInit.pTip = _("Close");
 	sButInit.pDisplay = intDisplayImageHilight;
 	widgAddButton(psRequestScreen, &sButInit);
-
-	// Add Banner Label
-	W_LABINIT sLabInit;
-	sLabInit.formID = LOADSAVE_BANNER;
-	sLabInit.FontID = font_large;
-	sLabInit.id		= LOADSAVE_LABEL;
-	sLabInit.style	= WLAB_ALIGNCENTRE;
-	sLabInit.x		= 0;
-	sLabInit.y		= 0;
-	sLabInit.width	= LOADSAVE_W - (2 * LOADSAVE_HGAP);	//LOADSAVE_W;
-	sLabInit.height = LOADSAVE_BANNER_DEPTH;		//This looks right -Q
-	sLabInit.pText	= WzString::fromUtf8(title);
-	widgAddLabel(psRequestScreen, &sLabInit);
 
 	// add slots
 	sButInit = W_BUTINIT();

--- a/src/loop.cpp
+++ b/src/loop.cpp
@@ -308,12 +308,6 @@ static GAMECODE renderLoop()
 	{
 		if (!gameUpdatePaused())
 		{
-			if (dragBox3D.status != DRAG_DRAGGING
-			    && wallDrag.status != DRAG_DRAGGING
-			    && intRetVal != INT_INTERCEPT)
-			{
-				ProcessRadarInput();
-			}
 			processInput();
 
 			//no key clicks or in Intelligence Screen

--- a/src/loop.cpp
+++ b/src/loop.cpp
@@ -321,7 +321,6 @@ static GAMECODE renderLoop()
 			{
 				processMouseClickInput();
 			}
-			bRender3DOnly = false;
 			displayWorld();
 		}
 		wzPerfBegin(PERF_GUI, "User interface");

--- a/src/multiint.cpp
+++ b/src/multiint.cpp
@@ -4565,7 +4565,7 @@ void WzMultiplayerOptionsTitleUI::openPlayerSlotSwapChooser(uint32_t playerIndex
 
 	// Now create a dummy row for the row being swapped, and display beneath
 	auto playerRow = WzPlayerRow::make(playerIndex, titleUI);
-	playerRow->setCustomHitTest([](WIDGET *psWidget, int x, int y) -> bool { return false; }); // ensure clicks on this display-only row have no effect
+	playerRow->setTransparentToMouse(true); // ensure clicks on this display-only row have no effect
 	swapContextForm->attach(playerRow);
 	playerRow->setCalcLayout([swapContextFormPadding, textHeight](WIDGET *psWidget) {
 		psWidget->setGeometry(PLAYERBOX_X0, swapContextFormPadding + textHeight + 4, MULTIOP_PLAYERWIDTH, MULTIOP_PLAYERHEIGHT);

--- a/src/musicmanager.cpp
+++ b/src/musicmanager.cpp
@@ -489,8 +489,7 @@ static void UpdateTrackDetailsBox(TrackDetailsForm *pTrackDetailsBox)
 	psNowPlaying->setFont(font_regular, WZCOL_TEXT_MEDIUM);
 	psNowPlaying->setString((selectedTrack) ? (WzString::fromUtf8(_("NOW PLAYING")) + ":") : "");
 	psNowPlaying->setTextAlignment(WLAB_ALIGNTOPLEFT);
-	// set a custom hit-testing function that ignores all mouse input / clicks
-	psNowPlaying->setCustomHitTest([](WIDGET *psWidget, int x, int y) -> bool { return false; });
+	psNowPlaying->setTransparentToMouse(true);
 
 	// Add Selected Track name
 	if (!psSelectedTrackName)
@@ -501,8 +500,7 @@ static void UpdateTrackDetailsBox(TrackDetailsForm *pTrackDetailsBox)
 	psSelectedTrackName->setFont(font_regular_bold, WZCOL_TEXT_BRIGHT);
 	psSelectedTrackName->setString((selectedTrack) ? WzString::fromUtf8(selectedTrack->title) : "");
 	psSelectedTrackName->setTextAlignment(WLAB_ALIGNTOPLEFT);
-	// set a custom hit-testing function that ignores all mouse input / clicks
-	psSelectedTrackName->setCustomHitTest([](WIDGET *psWidget, int x, int y) -> bool { return false; });
+	psSelectedTrackName->setTransparentToMouse(true);
 
 	// Add Selected Track author details
 	if (!psSelectedTrackAuthorName)
@@ -513,8 +511,7 @@ static void UpdateTrackDetailsBox(TrackDetailsForm *pTrackDetailsBox)
 	psSelectedTrackAuthorName->setFont(font_regular, WZCOL_TEXT_BRIGHT);
 	psSelectedTrackAuthorName->setString((selectedTrack) ? WzString::fromUtf8(selectedTrack->author) : "");
 	psSelectedTrackAuthorName->setTextAlignment(WLAB_ALIGNTOPLEFT);
-	// set a custom hit-testing function that ignores all mouse input / clicks
-	psSelectedTrackAuthorName->setCustomHitTest([](WIDGET *psWidget, int x, int y) -> bool { return false; });
+	psSelectedTrackAuthorName->setTransparentToMouse(true);
 
 	// album info xPosStart
 	int albumInfoXPosStart = psNowPlaying->x() + psNowPlaying->width() + 10 + WZ_TRACKDETAILS_IMAGE_SIZE + 10;
@@ -529,8 +526,7 @@ static void UpdateTrackDetailsBox(TrackDetailsForm *pTrackDetailsBox)
 	psSelectedTrackAlbumName->setFont(font_small, WZCOL_TEXT_BRIGHT);
 	psSelectedTrackAlbumName->setString((pAlbum) ? (WzString::fromUtf8(_("Album")) + ": " + WzString::fromUtf8(pAlbum->title)) : "");
 	psSelectedTrackAlbumName->setTextAlignment(WLAB_ALIGNTOPLEFT);
-	// set a custom hit-testing function that ignores all mouse input / clicks
-	psSelectedTrackAlbumName->setCustomHitTest([](WIDGET *psWidget, int x, int y) -> bool { return false; });
+	psSelectedTrackAlbumName->setTransparentToMouse(true);
 
 	if (!psSelectedTrackAlbumDate)
 	{
@@ -540,8 +536,7 @@ static void UpdateTrackDetailsBox(TrackDetailsForm *pTrackDetailsBox)
 	psSelectedTrackAlbumDate->setFont(font_small, WZCOL_TEXT_BRIGHT);
 	psSelectedTrackAlbumDate->setString((pAlbum) ? (WzString::fromUtf8(_("Date")) + ": " + WzString::fromUtf8(pAlbum->date)) : "");
 	psSelectedTrackAlbumDate->setTextAlignment(WLAB_ALIGNTOPLEFT);
-	// set a custom hit-testing function that ignores all mouse input / clicks
-	psSelectedTrackAlbumDate->setCustomHitTest([](WIDGET *psWidget, int x, int y) -> bool { return false; });
+	psSelectedTrackAlbumDate->setTransparentToMouse(true);
 
 	if (!psSelectedTrackAlbumDescription)
 	{
@@ -552,8 +547,7 @@ static void UpdateTrackDetailsBox(TrackDetailsForm *pTrackDetailsBox)
 	int heightOfTitleLabel =  psSelectedTrackAlbumDescription->setFormattedString((pAlbum) ? WzString::fromUtf8(pAlbum->description) : "", maxWidthOfAlbumLabel, font_small);
 	psSelectedTrackAlbumDescription->setGeometry(albumInfoXPosStart, 12 + 13 + 15, maxWidthOfAlbumLabel, heightOfTitleLabel);
 	psSelectedTrackAlbumDescription->setTextAlignment(WLAB_ALIGNTOPLEFT);
-	// set a custom hit-testing function that ignores all mouse input / clicks
-	psSelectedTrackAlbumDescription->setCustomHitTest([](WIDGET *psWidget, int x, int y) -> bool { return false; });
+	psSelectedTrackAlbumDescription->setTransparentToMouse(true);
 
 	pTrackDetailsBox->loadImage((pAlbum) ? pAlbum->album_cover_filename : "");
 }
@@ -674,8 +668,7 @@ static void addTrackList(WIDGET *parent, bool ingame)
 	title_header->setFontColour(WZCOL_TEXT_MEDIUM);
 	title_header->setString(_("Title"));
 	title_header->setTextAlignment(WLAB_ALIGNTOPLEFT);
-	// set a custom hit-testing function that ignores all mouse input / clicks
-	title_header->setCustomHitTest([](WIDGET *psWidget, int x, int y) -> bool { return false; });
+	title_header->setTransparentToMouse(true);
 
 	auto album_header = std::make_shared<W_LABEL>();
 	pHeader->attach(album_header);
@@ -683,8 +676,7 @@ static void addTrackList(WIDGET *parent, bool ingame)
 	album_header->setFontColour(WZCOL_TEXT_MEDIUM);
 	album_header->setString(_("Album"));
 	album_header->setTextAlignment(WLAB_ALIGNTOPLEFT);
-	// set a custom hit-testing function that ignores all mouse input / clicks
-	album_header->setCustomHitTest([](WIDGET *psWidget, int x, int y) -> bool { return false; });
+	album_header->setTransparentToMouse(true);
 
 	for (int musicModeIdx = 0; musicModeIdx < NUM_MUSICGAMEMODES; musicModeIdx++)
 	{

--- a/src/notifications.cpp
+++ b/src/notifications.cpp
@@ -671,8 +671,7 @@ std::shared_ptr<W_NOTIFICATION> W_NOTIFICATION::make(WZ_Queued_Notification* req
 	}
 	label_title->setGeometry(titleStartXPos, titleStartYPos, maxTitleWidth, heightOfTitleLabel);
 	label_title->setTextAlignment(WLAB_ALIGNTOPLEFT);
-	// set a custom hit-testing function that ignores all mouse input / clicks
-	label_title->setCustomHitTest([](WIDGET *psWidget, int x, int y) -> bool { return false; });
+	label_title->setTransparentToMouse(true);
 	int titleBottom = label_title->y() + label_title->height();
 	if (isModal)
 	{
@@ -693,8 +692,7 @@ std::shared_ptr<W_NOTIFICATION> W_NOTIFICATION::make(WZ_Queued_Notification* req
 	int heightOfContentsLabel = label_contents->setFormattedString(WzString::fromUtf8(request->notification.contentText), maxContentsWidth, font_regular, WZ_NOTIFICATION_CONTENTS_LINE_SPACING);
 	label_contents->setGeometry(label_contents->x(), label_contents->y(), maxContentsWidth, heightOfContentsLabel);
 	label_contents->setTextAlignment(WLAB_ALIGNTOPLEFT);
-	// set a custom hit-testing function that ignores all mouse input / clicks
-	label_contents->setCustomHitTest([](WIDGET *psWidget, int x, int y) -> bool { return false; });
+	label_contents->setTransparentToMouse(true);
 
 	// Add action buttons
 	std::string dismissLabel = _("Dismiss");

--- a/src/radar.cpp
+++ b/src/radar.cpp
@@ -81,7 +81,7 @@ public:
 protected:
 	void run(W_CONTEXT *) override;
 	void display(int xOffset, int yOffset) override;
-	bool hitTest(int x, int y) override;
+	bool hitTest(int x, int y) const override;
 	void clicked(W_CONTEXT *, WIDGET_KEY = WKEY_PRIMARY) override;
 	void released(W_CONTEXT *, WIDGET_KEY = WKEY_PRIMARY) override;
 	void highlight(W_CONTEXT *) override;
@@ -878,7 +878,7 @@ void RadarWidget::display(int xOffset, int yOffset)
 	drawRadar();
 }
 
-bool RadarWidget::hitTest(int x, int y)
+bool RadarWidget::hitTest(int x, int y) const
 {
 	// NOTE: CoordInRadar expects x, y in *screen* coordinates - this is _currently_ the case as a byproduct of how the radar widget is added to the UI screen
 	return WIDGET::hitTest(x, y) && CoordInRadar(x, y);

--- a/src/radar.h
+++ b/src/radar.h
@@ -28,6 +28,8 @@
 #ifndef __INCLUDED_SRC_RADAR_H__
 #define __INCLUDED_SRC_RADAR_H__
 
+#include "lib/widget/widget.h"
+
 void radarColour(UDWORD tileNumber, uint8_t r, uint8_t g, uint8_t b);	///< Set radar colour for given terrain type.
 
 #define MAX_RADARZOOM		(64)
@@ -42,7 +44,6 @@ void drawRadar();				///< Draw the minimap on the screen.
 void CalcRadarPosition(int mX, int mY, int *PosX, int *PosY);	///< Given a position within the radar, returns a world coordinate.
 void SetRadarZoom(uint8_t ZoomLevel);		///< Set current zoom level. 1.0 is 1:1 resolution.
 uint8_t GetRadarZoom();			///< Get current zoom level.
-bool CoordInRadar(int x, int y);			///< Is screen coordinate inside minimap?
 
 /** Different mini-map draw modes. */
 enum RADAR_DRAW_MODE
@@ -61,6 +62,10 @@ extern bool rotateRadar;
 extern bool radarRotationArrow;
 
 void radarInitVars();			///< Recalculate minimap variables. For initialization code only.
+
+std::shared_ptr<WIDGET> getRadarWidget();
+bool isMouseOverRadar();
+bool isRadarDragging();
 
 extern PIELIGHT clanColours[];
 

--- a/src/spectatorwidgets.cpp
+++ b/src/spectatorwidgets.cpp
@@ -124,7 +124,7 @@ bool specLayerInit(bool showButton /*= true*/)
 					specStatsViewCreate();
 				});
 			});
-			specStatsButton->setCustomHitTest([](WIDGET *psWidget, int x, int y) -> bool {
+			specStatsButton->setCustomHitTest([](const WIDGET *psWidget, int x, int y) -> bool {
 				if (bDisplayMultiJoiningStatus)
 				{
 					// effectively: make this unclickable until the game actually starts


### PR DESCRIPTION
Highlights:
- [widget: Adjust child widget z-order handling](https://github.com/Warzone2100/warzone2100/commit/7e483d043bfd1827b8f130a275cba581085e294e)
   - Processing child widget clicks / input should match visual expectations based on the drawing z-order.
- [Partial refactoring of radar into WIDGET](https://github.com/Warzone2100/warzone2100/commit/4f9f0b1c2dcf2d0c9e01175c59fb1a9dc5f3a95f)
   - So that it gets input events through the normal widget system