### PR TITLE
[GitHub Actions] Windows: Install Gettext tools

### DIFF
--- a/.github/workflows/CI_windows.yml
+++ b/.github/workflows/CI_windows.yml
@@ -168,10 +168,23 @@ jobs:
         $WZ_FULL_CMAKE_PATH = Split-Path -Path ((Get-Command cmake.exe).Path)
         echo "WZ_FULL_CMAKE_PATH=${WZ_FULL_CMAKE_PATH}"
         
+        # ------------------------------
+        # Install Gettext tools
+        
+        $origPath = $env:PATH
+        $env:PATH = "C:\msys64\mingw64\bin;C:\msys64\usr\bin;$origPath"
+        
+        pacman --noconfirm -S --needed gettext
+        if ($LastExitCode -ne 0) {
+            throw "Failed to install gettext with exit code: $LastExitCode"
+        }
+        
         $WZ_FULL_MSGMERGE_PATH = Split-Path -Path ((Get-Command msgmerge.exe).Path)
         echo "WZ_FULL_MSGMERGE_PATH=${WZ_FULL_MSGMERGE_PATH}"
         $WZ_FULL_MSGFMT_PATH = Split-Path -Path ((Get-Command msgfmt.exe).Path)
         echo "WZ_FULL_MSGFMT_PATH=${WZ_FULL_MSGFMT_PATH}"
+        
+        $env:PATH = $origPath
 
         # ------------------------------
         # MSVC version / generator info
@@ -491,6 +504,8 @@ jobs:
         WZ_ENABLE_SENTRY: ${{ steps.settings.outputs.WZ_ENABLE_SENTRY }}
         SENTRY_IO_DSN: '${{ secrets.CRASHREPORTING_SENTRY_IO_DSN }}'
         DISCORD_RPC_APPID: '${{ secrets.DISCORD_RPC_APPID }}'
+        WZ_FULL_MSGMERGE_PATH: ${{ steps.settings.outputs.WZ_FULL_MSGMERGE_PATH }}
+        WZ_FULL_MSGFMT_PATH: ${{ steps.settings.outputs.WZ_FULL_MSGFMT_PATH }}
       run: |
         $ADDITIONAL_CMAKE_PARAMS = ""
         $WZ_BUILD_SENTRY_VALUE = "OFF"
@@ -500,6 +515,7 @@ jobs:
             $ADDITIONAL_CMAKE_PARAMS = "-DSENTRY_IO_DSN:STRING=${env:SENTRY_IO_DSN}"
           }
         }
+        $env:PATH = "${env:PATH};${env:WZ_FULL_MSGMERGE_PATH}";
         # Use CMake to configure with the appropriate Visual Studio (MSBUILD) generator, toolchain, and target platform
         echo "::add-matcher::${{ github.workspace }}\src\.ci\githubactions\pattern_matchers\cmake.json"
         cmake -DCMAKE_TOOLCHAIN_FILE="${{ github.workspace }}\build\vcpkg\scripts\buildsystems\vcpkg.cmake" -DCPACK_PACKAGE_FILE_NAME:STRING="warzone2100_portable" -DWZ_DISTRIBUTOR:STRING="${env:WZ_DISTRIBUTOR}" -DCMAKE_GENERATOR_INSTANCE="${env:WZ_VISUAL_STUDIO_INSTALL_PATH}" -DDISCORD_RPC_APPID:STRING="${env:DISCORD_RPC_APPID}" -DWZ_BUILD_SENTRY:BOOL="${WZ_BUILD_SENTRY_VALUE}" ${ADDITIONAL_CMAKE_PARAMS} -G "${env:WZ_VC_GENERATOR}" -A "${env:WZ_VC_TARGET_PLATFORMNAME}" "${env:WZ_REPO_PATH}"


### PR DESCRIPTION
GitHub Actions Windows images seem to have changed, and gettext tools were no longer being found in PATH.

Explicitly install & grab them from msys2.