### PR TITLE
[Blender] Fix normal flipping between Blender and Warzone2100

### DIFF
--- a/tools/blender/2.9x/pie_addon/pie_export.py
+++ b/tools/blender/2.9x/pie_addon/pie_export.py
@@ -239,15 +239,17 @@ class Exporter():
                                             '{uvx1} {uvy1} {uvx2} {uvy2} '
                                             '{uvx3} {uvy3}').format(
                                     type=200,
+                                    # Normals in Blender and in game are flipped
+                                    # Import and export in opposite order to flip them
                                     v1=face.verts[0].index,
-                                    v2=face.verts[1].index,
-                                    v3=face.verts[2].index,
+                                    v2=face.verts[2].index,
+                                    v3=face.verts[1].index,
                                     uvx1=uvx1,
                                     uvy1=uvy1,
-                                    uvx2=uvx2,
-                                    uvy2=uvy2,
-                                    uvx3=uvx3,
-                                    uvy3=uvy3,
+                                    uvx2=uvx3,
+                                    uvy2=uvy3,
+                                    uvx3=uvx2,
+                                    uvy3=uvy2,
                                 )
 
                         # if child.pie_object_prop.exportNormal is True:

--- a/tools/blender/2.9x/pie_addon/pie_import.py
+++ b/tools/blender/2.9x/pie_addon/pie_import.py
@@ -186,7 +186,9 @@ class Importer():
             pie_polygons = []
 
             for p in level['POLYGONS']:
-                pie_polygons.append((p[2], p[3], p[4]))
+                # Normals in Blender and in game are flipped
+                # Import and export in opposite order to flip them
+                pie_polygons.append((p[2], p[4], p[3]))
             mesh.from_pydata(pie_points, [], pie_polygons)
 
             animatedPolygons = []
@@ -205,12 +207,12 @@ class Importer():
 
                 if pieParse['PIE'] == '3':
                     uvData[L + 0].uv = ((p[5 + m], -p[6 + m] + 1))
-                    uvData[L + 1].uv = ((p[7 + m], -p[8 + m] + 1))
-                    uvData[L + 2].uv = ((p[9 + m], -p[10 + m] + 1))
+                    uvData[L + 1].uv = ((p[9 + m], -p[10 + m] + 1))
+                    uvData[L + 2].uv = ((p[7 + m], -p[8 + m] + 1))
                 elif pieParse['PIE'] == '2':
                     uvData[L + 0].uv = ((p[5 + m] / n, (-p[6 + m] / n) + 1))
-                    uvData[L + 1].uv = ((p[7 + m] / n, (-p[8 + m] / n) + 1))
-                    uvData[L + 2].uv = ((p[9 + m] / n, (-p[10 + m] / n) + 1))
+                    uvData[L + 1].uv = ((p[9 + m] / n, (-p[10 + m] / n) + 1))
+                    uvData[L + 2].uv = ((p[7 + m] / n, (-p[8 + m] / n) + 1))
 
             bpy.ops.object.mode_set(mode='EDIT', toggle=False)
             bm = bmesh.from_edit_mesh(mesh)


### PR DESCRIPTION
Current behaviour: normals are inverted between Blender and the game. You have to export your meshes with all normals inside-out in Blender to look well in game, they are imported inside-out too.

How to reproduce:

- Import a pie object in blender (4.0, but it seems to be bugged with 2.9 too)
- Create a material for the mesh and activate backface culling
- In Shading mode, add an image texture to link to Base Color to the Principled BSDF to check the UV mapping
- Set the Viewport Shading to Material Preview: the normals are inverted in blender
- Export the object to pie: it works in game

This patch changes the order in which the vertices are imported and exported for each polygon so the normals are pointing toward the same direction in Blender and in-game.