### PR TITLE
Fix selNextSpecifiedBuilding()

### DIFF
--- a/src/selection.cpp
+++ b/src/selection.cpp
@@ -474,6 +474,10 @@ void selNextSpecifiedBuilding(STRUCTURE_TYPE structType, bool jump)
 
 	for (STRUCTURE *psCurr : apsStructLists[selectedPlayer])
 	{
+		if (psResult)
+		{
+			break;
+		}
 		if (psCurr->pStructureType->type == structType && psCurr->status == SS_BUILT)
 		{
 			if (!psFirst)


### PR DESCRIPTION
The for loop lost the `psResult` check in the `selNextSpecifiedBuilding()` change in 67a9542f1bab3be05b19f072e82ff009eea3ce39. Fixes not being able to select all the factories types, research labs, and power generators.