### PR TITLE
Adjust skybox fog

### DIFF
--- a/data/base/shaders/skybox.vert
+++ b/data/base/shaders/skybox.vert
@@ -33,9 +33,6 @@ void main()
 
 	if(fog_enabled > 0)
 	{
-		fog =
-		vertex.y < -0.7 ? vec4(0, 0, 0, 1) :
-		vertex.y < 0.5 ? fog_color :
-		vec4(fog_color.xyz, 0);
+		fog = vertex.y < 0.5 ? fog_color : vec4(fog_color.xyz, 0);
 	}
 }

--- a/data/base/shaders/vk/skybox.vert
+++ b/data/base/shaders/vk/skybox.vert
@@ -25,9 +25,6 @@ void main()
 
 	if(fog_enabled > 0)
 	{
-		fog =
-		vertex.y < -0.7 ? vec4(0, 0, 0, 1) :
-		vertex.y < 0.5 ? fog_color :
-		vec4(fog_color.xyz, 0);
+		fog = vertex.y < 0.5 ? fog_color : vec4(fog_color.xyz, 0);
 	}
 }


### PR DESCRIPTION
Now that we no longer need the fade-to-black trick to cover up stencil shadow artifacts at the bottom of the skybox, just use fog color below the skybox image.