### PR TITLE
Switch `PROJECTILE` to use `PagedEntityContainer<PROJECTILE>` as backing storage

### DIFF
--- a/src/projectile.cpp
+++ b/src/projectile.cpp
@@ -1398,7 +1398,15 @@ void proj_UpdateAll()
 	std::for_each(psProjectileListOld.begin(), psProjectileListOld.end(), std::mem_fn(&PROJECTILE::update));
 
 	// Remove and free dead projectiles.
-	psProjectileList.erase(std::remove_if(psProjectileList.begin(), psProjectileList.end(), std::mem_fn(&PROJECTILE::deleteIfDead)), psProjectileList.end());
+	psProjectileList.erase(std::remove_if(psProjectileList.begin(), psProjectileList.end(), [](PROJECTILE* p)
+	{
+		if (p->died == 0 || p->died >= gameTime - deltaGameTime)
+		{
+			return false;
+		}
+		delete p;
+		return true;
+	}), psProjectileList.end());
 }
 
 /***************************************************************************/

--- a/src/projectile.h
+++ b/src/projectile.h
@@ -54,6 +54,8 @@ bool	proj_Shutdown();	///< Shut down projectile subsystem.
 PROJECTILE *proj_GetFirst();	///< Get first projectile in the list.
 PROJECTILE *proj_GetNext();		///< Get next projectile in the list.
 
+void proj_AddActiveProjectile(PROJECTILE* p); ///< Add allocated projectile `p` to the list of active projectiles
+
 void	proj_FreeAllProjectiles();	///< Free all projectiles in the list.
 
 void setExpGain(int player, int gain);
@@ -62,12 +64,16 @@ int getExpGain(int player);
 /// Calculate the initial velocities of an indirect projectile. Returns the flight time.
 int32_t projCalcIndirectVelocities(const int32_t dx, const int32_t dz, int32_t v, int32_t *vx, int32_t *vz, int min_angle);
 
-/** Send a single projectile against the given target. */
-bool proj_SendProjectile(WEAPON *psWeap, SIMPLE_OBJECT *psAttacker, int player, Vector3i target, BASE_OBJECT *psTarget, bool bVisible, int weapon_slot);
+/** Send a single projectile against the given target.
+  * Returns a non-null pointer to the newly-created projectile in the case of penetrating projectiles.
+  * The returned projectile is automatically added `psProjectileList` global list. */
+bool proj_SendProjectile(WEAPON *psWeap, SIMPLE_OBJECT *psAttacker, int player, const Vector3i& target, BASE_OBJECT *psTarget, bool bVisible, int weapon_slot);
 
 /** Send a single projectile against the given target
- * with a minimum shot angle. */
-bool proj_SendProjectileAngled(WEAPON *psWeap, SIMPLE_OBJECT *psAttacker, int player, Vector3i target, BASE_OBJECT *psTarget, bool bVisible, int weapon_slot, int min_angle, unsigned fireTime);
+ * with a minimum shot angle.
+ * Returns a non-null pointer to the newly-created projectile in the case of penetrating projectiles.
+ * The returned projectile is automatically added `psProjectileList` global list. */
+bool proj_SendProjectileAngled(WEAPON *psWeap, SIMPLE_OBJECT *psAttacker, int player, const Vector3i& target, BASE_OBJECT *psTarget, bool bVisible, int weapon_slot, int min_angle, unsigned fireTime);
 
 /** Return whether a weapon is direct or indirect. */
 bool proj_Direct(const WEAPON_STATS *psStats);

--- a/src/projectiledef.h
+++ b/src/projectiledef.h
@@ -43,15 +43,6 @@ struct PROJECTILE : public SIMPLE_OBJECT
 	PROJECTILE(uint32_t id, unsigned player) : SIMPLE_OBJECT(OBJ_PROJECTILE, id, player) {}
 
 	void            update();
-	bool            deleteIfDead()
-	{
-		if (died == 0 || died >= gameTime - deltaGameTime)
-		{
-			return false;
-		}
-		delete this;
-		return true;
-	}
 
 	UBYTE           state;                  ///< current projectile state
 	UBYTE           bVisible;               ///< whether the selected player should see the projectile

--- a/src/projectiledef.h
+++ b/src/projectiledef.h
@@ -42,7 +42,10 @@ struct PROJECTILE : public SIMPLE_OBJECT
 {
 	PROJECTILE(uint32_t id, unsigned player) : SIMPLE_OBJECT(OBJ_PROJECTILE, id, player) {}
 
-	void            update();
+	// Returns non-empty pointer if `update()` has spawned an additional projectile,
+	// which will be true for penetrating projectiles.
+	// The newly-created projectile needs to be manually added to `psProjectileList`.
+	PROJECTILE* update();
 
 	UBYTE           state;                  ///< current projectile state
 	UBYTE           bVisible;               ///< whether the selected player should see the projectile


### PR DESCRIPTION
The game still uses `psProjectileList` to maintain stable and predictable order of iteration for projectiles, but the individual `PROJECTILE` instances are allocated from the global `PagedEntityContainer<PROJECTILE>` instance.

Optimize `proj_UpdateAll()` by removing additional checks inside the tight loop, which enumerates all projectiles currently in play, thus considerably speeding up this frequent and expensive operation.

Brief summary for the performance impact of this PR: on my machine this PR yields ~5-10 FPS improvement in stress-test conditions (e.g. horde of units with Seraph weapons, simultaneously firing lots of projectiles in one direction).

Signed-off-by: Pavel Solodovnikov <pavel.al.solodovnikov@gmail.com>