### PR TITLE
Prevent scouting/patrol allowing CB droids observing something

### DIFF
--- a/src/order.cpp
+++ b/src/order.cpp
@@ -628,7 +628,7 @@ void orderUpdateDroid(DROID *psDroid)
 					}
 					break;
 				case DROID_SENSOR:
-					if (attack)
+					if (!cbSensorDroid(psDroid) && attack)
 					{
 						actionDroid(psDroid, DACTION_OBSERVE, psObj);
 					}


### PR DESCRIPTION
Telling a CB unit to patrol/scout would allow CB droids to observe stuff like a regular sensor for a moment.

---

Could mess with `aiBestNearestTarget()` I guess but at least this is safe from "I touched micro-AI and suddenly a lot of stuff broke" syndrome.