### PR TITLE
Added an algorithm for distributing damaged units between free repair stations

### DIFF
--- a/src/order.cpp
+++ b/src/order.cpp
@@ -94,6 +94,9 @@
 /** The maximum distance allowed to a droid to move out of the path if already attacking a target on a patrol/scout. */
 #define SCOUT_ATTACK_DIST	(TILE_UNITS * 5)
 
+/** The maximum number of units a repair facility can handle before units start crowding and interfering with each other. */
+#define REPAIR_FACILITY_MAX_CAPACITY	8
+
 static void orderClearDroidList(DROID *psDroid);
 
 /** Whether an order effect has been displayed
@@ -3373,6 +3376,23 @@ static inline RtrBestResult decideWhereToRepairAndBalance(DROID *psDroid)
 			if (thisDistToRepair <= 0)
 			{
 				continue;	// cannot reach position
+			}
+			uint32_t droidsAtRepair = 0;
+			for (DROID *psOtherDroid : apsDroidLists[psDroid->player])
+			{
+				if (psDroid == psOtherDroid)
+				{
+					continue;
+				}
+				/* Search for droids within a radius of 2 tiles */
+				if (psOtherDroid->isDamaged() && droidSqDist(psOtherDroid, psStruct) < TILE_WIDTH * TILE_WIDTH * 4)
+				{
+					droidsAtRepair++;
+				}
+			}
+			if (droidsAtRepair > REPAIR_FACILITY_MAX_CAPACITY)
+			{
+				continue;
 			}
 			vFacilityPos.push_back(psStruct->pos);
 			vFacility.push_back(psStruct);


### PR DESCRIPTION
When building repair stations, there is a problem that units are looking for the closest structure, because of this, stations can not be placed, for example, parallel to the flow of damaged units and need to be placed perpendicularly and preferably next to each other. 

The only way to get around it so far is to build the line perpendicular to the flow, or like this, if you want to cover the flow from all angles:

![hexagon!](https://github.com/Warzone2100/warzone2100/assets/3750982/3efbe5bd-9864-4384-8453-26c578cf3421)

This PR adds an additional check so that a lot of damaged units do not crowd near the closest station in large numbers and go directly to a available one.
