### PR TITLE
Switch droids to use `PagedEntityContainer<DROID>` as backing storage

### DIFF
--- a/src/component.h
+++ b/src/component.h
@@ -83,7 +83,7 @@ void drawMuzzleFlash(WEAPON sWeap, iIMDShape *weaponImd, iIMDShape *flashImd, PI
 #define PART_IMD(STATS,DROID,COMPONENT,PLAYER)	(STATS[DROID->asBits[COMPONENT]].pIMD)
 
 /* Get the chassis imd */
-#define BODY_IMD(DROID,PLAYER)	(DROID->getBodyStats()->pIMD)
+#define BODY_IMD(DROID,PLAYER)	((DROID)->getBodyStats()->pIMD)
 /* Get the brain imd - NOTE: Unused!*/
 #define BRAIN_IMD(DROID,PLAYER)	(DROID->getBrainStats()->pIMD)
 /* Get the weapon imd */

--- a/src/droid.h
+++ b/src/droid.h
@@ -24,6 +24,7 @@
 #ifndef __INCLUDED_SRC_DROID_H__
 #define __INCLUDED_SRC_DROID_H__
 
+#include "lib/framework/paged_entity_container.h"
 #include "lib/framework/string_ext.h"
 #include "lib/gamelib/gtime.h"
 
@@ -424,5 +425,11 @@ static inline DROID const *castDroid(SIMPLE_OBJECT const *psObject)
  * repairs were made by a mobile repair turret
  */
 void droidWasFullyRepaired(DROID *psDroid, const REPAIR_FACILITY *psRepairFac);
+
+// Split the droid storage into pages containing 256 droids, disable slot reuse
+// to guard against memory-related issues when some object pointers won't get
+// updated properly, e.g. when transitioning between the base and offworld missions.
+using DroidContainer = PagedEntityContainer<DROID, 256, false>;
+DroidContainer& GlobalDroidContainer();
 
 #endif // __INCLUDED_SRC_DROID_H__

--- a/src/mechanics.cpp
+++ b/src/mechanics.cpp
@@ -39,7 +39,7 @@ bool mechanicsShutdown()
 {
 	for (BASE_OBJECT* psObj : psDestroyedObj)
 	{
-		delete psObj;
+		objmemDestroy(psObj);
 	}
 	psDestroyedObj.clear();
 

--- a/src/objmem.cpp
+++ b/src/objmem.cpp
@@ -86,6 +86,8 @@ bool objmemInitialise()
 /* Release the object heaps */
 void objmemShutdown()
 {
+	auto& droidContainer = GlobalDroidContainer();
+	droidContainer.clear();
 }
 
 // Check that psVictim is not referred to by any other object in the game. We can dump out some extra data in debug builds that help track down sources of dangling pointer errors.

--- a/src/objmem.h
+++ b/src/objmem.h
@@ -74,6 +74,10 @@ void objmemShutdown();
 /* General housekeeping for the object system */
 void objmemUpdate();
 
+/* Remove an object from the destroyed list, finally freeing its memory
+ * Hopefully by this time, no pointers still refer to it! */
+bool objmemDestroy(BASE_OBJECT* psObj);
+
 /// Generates a new, (hopefully) unique object id.
 uint32_t generateNewObjectId();
 /// Generates a new, (hopefully) unique object id, which all clients agree on.

--- a/src/wzapi.cpp
+++ b/src/wzapi.cpp
@@ -2158,6 +2158,7 @@ std::unique_ptr<const DROID> wzapi::getDroidProduction(WZAPI_PARAMS(const STRUCT
 	{
 		return nullptr;
 	}
+	// Since it's not intended to be used anywhere, don't put it in the global droid storage.
 	DROID *psDroid = new DROID(0, player);
 	psDroid->pos = psStruct->pos;
 	psDroid->rot = psStruct->rot;


### PR DESCRIPTION
Aside from changing droids to be allocated via a seprated `PagedEntityContainer<DROID>`, this changeset also implements a couple of other important things:

* The number of elements per page in `PagedEntityContainer` can now be customized
  via `MaxElementsPerPage` template argument. The default value is 1024 elements.
  **NOTE:** The storage for droids uses 256 elements per page.
* `PagedEntityContainer` can now be configured not to reuse slots upon element erasure. In such case, the slot becomes invalid right after first use. The behavior is controlled by `ReuseSlots` template argument. The default value is `true`.
  **NOTE:** The storage for droids disable slot reuse feature, at least until we are sure that other memory-related and dependency-tracking issues between `DROID` instances are eliminated throughout the WZ code base.

This PR should not introduce any notable performance difference. Although, memory utilization patterns should become slightly better (e.g. there should be less memory fragmentation overall).

Signed-off-by: Pavel Solodovnikov <pavel.al.solodovnikov@gmail.com>