### PR TITLE
[MP Balance] Make half-tracks available later

### DIFF
--- a/data/mp/stats/research.json
+++ b/data/mp/stats/research.json
@@ -4609,9 +4609,10 @@
 		"msgName": "RES_HALFT1",
 		"name": "Half-tracked Propulsion",
 		"requiredResearch": [
-			"R-Sys-Engineering01"
+			"R-Sys-Engineering01",
+			"R-Vehicle-Engine02"
 		],
-		"researchPoints": 1200,
+		"researchPoints": 2400,
 		"researchPower": 37,
 		"resultComponents": [
 			"HalfTrack"


### PR DESCRIPTION
This PR aims to increase the viability of wheels, by making half-tracks available later. This PR doubles research time of half-tracks (`1200` -> `2400`) and adds **Fuel Injection Engine Mk2** as a requirement, in addition to Engineering.

(Currently, half-tracks are available around 3:22 minutes.)

Now, by not researching half-tracks at the start of the game, players can gain a research advantage in other techs. They can research half-tracks later.

See previous discussion at this discord thread: [MP Balance: Wheels](https://discord.com/channels/684098359874814041/1212611936747913307)