### PR TITLE
Tweak fire effect pointlight

### DIFF
--- a/lib/ivis_opengl/gfx_api.h
+++ b/lib/ivis_opengl/gfx_api.h
@@ -1022,7 +1022,7 @@ namespace gfx_api
 		float  unused2;
 		std::array<glm::vec4, max_lights> PointLightsPosition;
 		std::array<glm::vec4, max_lights> PointLightsColorAndEnergy;
-		std::array<glm::ivec4, 64> bucketOffsetAndSize;
+		std::array<glm::ivec4, bucket_dimension * bucket_dimension> bucketOffsetAndSize;
 		std::array<glm::ivec4, max_indexed_lights> indexed_lights;
 	};
 

--- a/lib/ivis_opengl/pielighting.cpp
+++ b/lib/ivis_opengl/pielighting.cpp
@@ -130,7 +130,7 @@ void renderingNew::LightingManager::ComputeFrameData(const LightingData& data, L
 		[](const glm::vec3& in) { return in.z <= 1; }
 	};
 
-	std::vector<LIGHT> culledLights;
+	culledLights.clear();
 	for (const auto& light : data.lights)
 	{
 		if (culledLights.size() >= gfx_api::max_lights)

--- a/lib/ivis_opengl/pielighting.cpp
+++ b/lib/ivis_opengl/pielighting.cpp
@@ -152,13 +152,13 @@ void renderingNew::LightingManager::ComputeFrameData(const LightingData& data, L
 		{
 			continue;
 		}
-		culledLights.push_back(light);
+		culledLights.push_back({light, clipSpaceBoundingBox});
 	}
 
 
 	for (size_t lightIndex = 0, end = culledLights.size(); lightIndex < end; lightIndex++)
 	{
-		const auto& light = culledLights[lightIndex];
+		const auto& light = culledLights[lightIndex].light;
 		result.positions[lightIndex].x = light.position.x;
 		result.positions[lightIndex].y = light.position.y;
 		result.positions[lightIndex].z = light.position.z;
@@ -210,8 +210,7 @@ void renderingNew::LightingManager::ComputeFrameData(const LightingData& data, L
 				{
 					continue;
 				}
-				const LIGHT& light = culledLights[lightIndex];
-				BoundingBox clipSpaceBoundingBox = transformBoundingBox(worldViewProjectionMatrix, getLightBoundingBox(light));
+				const BoundingBox& clipSpaceBoundingBox = culledLights[lightIndex].clipSpaceBoundingBox;
 
 				if (isBBoxInClipSpace(frustum, clipSpaceBoundingBox))
 				{

--- a/lib/ivis_opengl/pielighting.h
+++ b/lib/ivis_opengl/pielighting.h
@@ -22,6 +22,7 @@
 
 #include "lib/ivis_opengl/pietypes.h"
 #include "gfx_api.h"
+#include "culling.h"
 #include <glm/glm.hpp>
 #include <memory>
 #include <array>
@@ -98,7 +99,12 @@ namespace renderingNew
 		void ComputeFrameData(const LightingData& data, LightMap& lightmap, const glm::mat4& worldViewProjectionMatrix) override;
 	private:
 		// cached containers to avoid frequent reallocations
-		std::vector<LIGHT> culledLights;
+		struct CulledLightInfo
+		{
+			const LIGHT& light;
+			BoundingBox clipSpaceBoundingBox;
+		};
+		std::vector<CulledLightInfo> culledLights;
 	};
 }
 

--- a/lib/ivis_opengl/pielighting.h
+++ b/lib/ivis_opengl/pielighting.h
@@ -25,6 +25,7 @@
 #include <glm/glm.hpp>
 #include <memory>
 #include <array>
+#include <vector>
 
 struct LIGHT
 {
@@ -95,6 +96,9 @@ namespace renderingNew
 	struct LightingManager final : ILightingManager
 	{
 		void ComputeFrameData(const LightingData& data, LightMap& lightmap, const glm::mat4& worldViewProjectionMatrix) override;
+	private:
+		// cached containers to avoid frequent reallocations
+		std::vector<LIGHT> culledLights;
 	};
 }
 

--- a/src/effects.cpp
+++ b/src/effects.cpp
@@ -1303,8 +1303,11 @@ static bool updateFire(EFFECT *psEffect, LightingData& lightData)
 		percent = 100;
 	}
 
+	constexpr int fireLightHeightAboveGround = 28;
+
 	light.position = psEffect->position;
-	light.range = (percent * psEffect->radius * 3) / 100;
+	light.position.y += fireLightHeightAboveGround;
+	light.range = (percent * psEffect->radius * 6) / 100;
 	light.colour = pal_Colour(255, 0, 0);
 	lightData.lights.push_back(light);
 


### PR DESCRIPTION
Tweak fire effect pointlight:
- Raise it above the input position (i.e. above ground) and increase the range so it better casts light.

# Issues:

This change makes it easy to reproduce an apparent issue with point lights (possibly related to the near plane and the various calculations?) @vlj

Video example:
https://github.com/Warzone2100/warzone2100/assets/30942300/d44ddc4b-f94a-4c31-a813-f96b3c4f3bd8

Here's a save game that should let you reproduce this.
[Sk-Rush-fire-lights.zip](https://github.com/Warzone2100/warzone2100/files/14726243/Sk-Rush-fire-lights.zip)

Steps to reproduce are:
1. Ensure point lights are on in Graphics settings
2. Load the `Sk-Rush-fire-lights` skirmish save game
3. Zoom in on the cluster of walls surrounding the oil derrick (where all the cyborgs are attacking), and potentially rotate to match the video example
4. The closer you zoom, the more readily you'll be able to see the "dividing line" where pointlights aren't having the expected impact (seems to be for things that are closer to the camera - if enabling debug mode, which lets you zoom in even more, you can see how big an impact this can be)