### PR TITLE
Switch structures to use `PagedEntityContainer<STRUCTURE>` as backing storage

### DIFF
--- a/src/display3d.cpp
+++ b/src/display3d.cpp
@@ -363,7 +363,8 @@ struct Blueprint
 			STRUCTURE *psStruct = buildBlueprint();
 			ASSERT_OR_RETURN(, psStruct != nullptr, "buildBlueprint returned nullptr");
 			renderStructure(psStruct, viewMatrix, perspectiveViewMatrix);
-			delete psStruct;
+
+			objmemDestroy(psStruct, false);
 		}
 	}
 
@@ -692,7 +693,11 @@ STRUCTURE *getTileBlueprintStructure(int mapX, int mapY)
 	Blueprint blueprint = getTileBlueprint(mapX, mapY);
 	if (blueprint.state == SS_BLUEPRINT_PLANNED)
 	{
-		delete psStruct;  // Delete previously returned structure, if any.
+		if (psStruct)
+		{
+			// Delete previously returned structure, if any.
+			objmemDestroy(psStruct, false);
+		}
 		psStruct = blueprint.buildBlueprint();
 		return psStruct;  // This blueprint was clicked on.
 	}

--- a/src/mechanics.cpp
+++ b/src/mechanics.cpp
@@ -39,7 +39,7 @@ bool mechanicsShutdown()
 {
 	for (BASE_OBJECT* psObj : psDestroyedObj)
 	{
-		objmemDestroy(psObj);
+		objmemDestroy(psObj, true);
 	}
 	psDestroyedObj.clear();
 

--- a/src/objmem.cpp
+++ b/src/objmem.cpp
@@ -88,6 +88,8 @@ void objmemShutdown()
 {
 	auto& droidContainer = GlobalDroidContainer();
 	droidContainer.clear();
+	auto& structContainer = GlobalStructContainer();
+	structContainer.clear();
 }
 
 // Check that psVictim is not referred to by any other object in the game. We can dump out some extra data in debug builds that help track down sources of dangling pointer errors.

--- a/src/objmem.cpp
+++ b/src/objmem.cpp
@@ -203,7 +203,7 @@ static bool checkReferences(BASE_OBJECT *psVictim)
 
 /* Remove an object from the destroyed list, finally freeing its memory
  * Hopefully by this time, no pointers still refer to it! */
-bool objmemDestroy(BASE_OBJECT *psObj)
+bool objmemDestroy(BASE_OBJECT *psObj, bool checkRefs)
 {
 	switch (psObj->type)
 	{
@@ -222,7 +222,7 @@ bool objmemDestroy(BASE_OBJECT *psObj)
 	default:
 		ASSERT(!"unknown object type", "unknown object type in destroyed list at 0x%p", static_cast<void *>(psObj));
 	}
-	if (!checkReferences(psObj))
+	if (checkRefs && !checkReferences(psObj))
 	{
 		return false;
 	}
@@ -259,7 +259,7 @@ void objmemUpdate()
 	{
 		if ((*it)->died <= gameTime - deltaGameTime)
 		{
-			objmemDestroy(*it);
+			objmemDestroy(*it, true);
 			it = psDestroyedObj.erase(it);
 		}
 		else

--- a/src/objmem.h
+++ b/src/objmem.h
@@ -76,7 +76,7 @@ void objmemUpdate();
 
 /* Remove an object from the destroyed list, finally freeing its memory
  * Hopefully by this time, no pointers still refer to it! */
-bool objmemDestroy(BASE_OBJECT* psObj);
+bool objmemDestroy(BASE_OBJECT* psObj, bool checkRefs);
 
 /// Generates a new, (hopefully) unique object id.
 uint32_t generateNewObjectId();

--- a/src/structure.h
+++ b/src/structure.h
@@ -496,4 +496,10 @@ struct LineBuild
 LineBuild calcLineBuild(Vector2i size, STRUCTURE_TYPE type, Vector2i pos, Vector2i pos2);
 LineBuild calcLineBuild(STRUCTURE_STATS const *stats, uint16_t direction, Vector2i pos, Vector2i pos2);
 
+// Split the struct storage into pages containing 256 structs, disable slot reuse
+// to guard against memory-related issues when some object pointers won't get
+// updated properly, e.g. when transitioning between the base and offworld missions.
+using StructContainer = PagedEntityContainer<STRUCTURE, 256, false>;
+StructContainer& GlobalStructContainer();
+
 #endif // __INCLUDED_SRC_STRUCTURE_H__


### PR DESCRIPTION
Switch structures to use `PagedEntityContainer` as backing storage.

* Structure storage is organized into pages of 256 entities.
* Slot reuse is disabled due to the same underlying reasons as for droids (i.e. as an additional fail-safe against dangling pointers to structs when transitioning between missions).

No performance changes expected, except for slightly better memory utilization patterns, e.g. less memory fragmentation.

Signed-off-by: Pavel Solodovnikov <pavel.al.solodovnikov@gmail.com>