### PR TITLE
Fix some cheats

### DIFF
--- a/src/cheat.cpp
+++ b/src/cheat.cpp
@@ -35,6 +35,7 @@
 #include "multiplay.h"
 #include "qtscript.h"
 #include "template.h"
+#include "difficulty.h"
 #include "activity.h"
 
 struct CHEAT_ENTRY
@@ -68,9 +69,11 @@ static CHEAT_ENTRY cheatCodes[] =
 	{"john kettley", kf_ToggleWeather},	//john kettley
 	{"mouseflip", kf_ToggleMouseInvert},	//mouseflip
 	{"biffer baker", kf_BifferBaker},	// almost invincible units
-	{"easy", kf_SetEasyLevel},	//easy
-	{"normal", kf_SetNormalLevel},	//normal
-	{"hard", kf_SetHardLevel},	//hard
+	{"supereasy", []{ kf_SetDifficultyLevel(DL_SUPER_EASY); }}, //supereasy
+	{"easy", []{ kf_SetDifficultyLevel(DL_EASY); }}, //easy
+	{"normal", []{ kf_SetDifficultyLevel(DL_NORMAL); }}, //normal
+	{"hard", []{ kf_SetDifficultyLevel(DL_HARD); }}, //hard
+	{"insane", []{ kf_SetDifficultyLevel(DL_INSANE); }}, //insane
 	{"double up", kf_DoubleUp},	// your units take half the damage
 	{"whale fin", kf_TogglePower},	// turns on/off infinte power
 	{"get off my land", kf_KillEnemy},	// kills all enemy units and structures

--- a/src/keybind.cpp
+++ b/src/keybind.cpp
@@ -449,7 +449,7 @@ void kf_MakeMeHero()
 
 	for (DROID *psDroid : apsDroidLists[selectedPlayer])
 	{
-		if (psDroid->selected && psDroid->droidType == DROID_COMMAND)
+		if (psDroid->selected && (psDroid->droidType == DROID_COMMAND || psDroid->droidType == DROID_SENSOR))
 		{
 			psDroid->experience = 8 * 65536 * 128;
 		} 

--- a/src/keybind.cpp
+++ b/src/keybind.cpp
@@ -561,19 +561,6 @@ void	kf_BifferBaker()
 	          selectedPlayer, _("Hard as nails!!!"));
 	sendInGameSystemMessage(cmsg.c_str());
 }
-// --------------------------------------------------------------------------
-void	kf_SetEasyLevel()
-{
-	// Bail out if we're running a _true_ multiplayer game (to prevent MP cheating)
-	if (runningMultiplayer())
-	{
-		noMPCheatMsg();
-		return;
-	}
-
-	setDifficultyLevel(DL_EASY);
-	addConsoleMessage(_("Takings thing easy!"), LEFT_JUSTIFY, SYSTEM_MESSAGE);
-}
 
 // --------------------------------------------------------------------------
 void	kf_UpThePower()
@@ -606,7 +593,7 @@ void	kf_MaxPower()
 }
 
 // --------------------------------------------------------------------------
-void	kf_SetNormalLevel()
+void kf_SetDifficultyLevel(const DIFFICULTY_LEVEL level)
 {
 	// Bail out if we're running a _true_ multiplayer game (to prevent MP cheating)
 	if (runningMultiplayer())
@@ -615,21 +602,16 @@ void	kf_SetNormalLevel()
 		return;
 	}
 
-	setDifficultyLevel(DL_NORMAL);
-	addConsoleMessage(_("Back to normality!"), LEFT_JUSTIFY, SYSTEM_MESSAGE);
-}
-// --------------------------------------------------------------------------
-void	kf_SetHardLevel()
-{
-	// Bail out if we're running a _true_ multiplayer game (to prevent MP cheating)
-	if (runningMultiplayer())
+	setDifficultyLevel(level);
+	switch (level)
 	{
-		noMPCheatMsg();
-		return;
+		case DL_SUPER_EASY: addConsoleMessage(_("A power fantasy!"), LEFT_JUSTIFY, SYSTEM_MESSAGE); break;
+		case DL_EASY: addConsoleMessage(_("Taking things easy!"), LEFT_JUSTIFY, SYSTEM_MESSAGE); break;
+		case DL_NORMAL: addConsoleMessage(_("Back to normality!"), LEFT_JUSTIFY, SYSTEM_MESSAGE); break;
+		case DL_HARD: addConsoleMessage(_("Getting tricky!"), LEFT_JUSTIFY, SYSTEM_MESSAGE); break;
+		case DL_INSANE: addConsoleMessage(_("In a nightmare!"), LEFT_JUSTIFY, SYSTEM_MESSAGE);break;
+		default: break;
 	}
-
-	setDifficultyLevel(DL_HARD);
-	addConsoleMessage(_("Getting tricky!"), LEFT_JUSTIFY, SYSTEM_MESSAGE);
 }
 // --------------------------------------------------------------------------
 void	kf_DoubleUp()

--- a/src/keybind.h
+++ b/src/keybind.h
@@ -24,6 +24,7 @@
 #include "console.h"
 #include "selection.h"
 #include "orderdef.h"
+#include "difficulty.h"
 #include "lib/framework/fixedpoint.h"
 
 #define	MAP_ZOOM_RATE_MAX	(1000)
@@ -138,8 +139,7 @@ void kf_ToggleConsoleDrop();
 void kf_ToggleShakeStatus();
 void kf_ToggleMouseInvert();
 void kf_BifferBaker();
-void kf_SetEasyLevel();
-void kf_SetNormalLevel();
+void kf_SetDifficultyLevel(const DIFFICULTY_LEVEL level);
 void kf_DoubleUp();
 void kf_UpThePower();
 void kf_MaxPower();
@@ -147,7 +147,6 @@ void kf_KillEnemy();
 void kf_ToggleMissionTimer();
 void kf_TraceObject();
 
-void kf_SetHardLevel();
 MappableFunction kf_SelectCommander_N(const unsigned int n);
 
 void kf_ToggleShowGateways();


### PR DESCRIPTION
- Cleans up the cheat command difficulty setter functions into one function and adds missing difficulties.
- Make sure "makemehero" works on sensors properly.

Closes #3691.
Closes #3692.