### PR TITLE
Wheel/Half-Track Balance Adjustments

### DIFF
--- a/data/mp/stats/propulsion.json
+++ b/data/mp/stats/propulsion.json
@@ -130,7 +130,7 @@
 		"model": "prlwhl1.pie",
 		"name": "Wheels",
 		"skidDeceleration": 350,
-		"speed": 175,
+		"speed": 188,
 		"type": "Wheeled",
 		"weight": 300
 	}

--- a/data/mp/stats/propulsion.json
+++ b/data/mp/stats/propulsion.json
@@ -35,8 +35,8 @@
 		"weight": 50
 	},
 	"HalfTrack": {
-		"buildPoints": 75,
-		"buildPower": 75,
+		"buildPoints": 100,
+		"buildPower": 100,
 		"designable": 1,
 		"hitpointPctOfBody": 200,
 		"id": "HalfTrack",

--- a/data/mp/stats/weaponmodifier.json
+++ b/data/mp/stats/weaponmodifier.json
@@ -21,7 +21,7 @@
 		"Legged": 30,
 		"Lift": 80,
 		"Tracked": 120,
-		"Wheeled": 130
+		"Wheeled": 100
 	},
 	"ARTILLERY ROUND": {
 		"Half-Tracked": 65,


### PR DESCRIPTION
Half-Track BuildPoints & BuildCost increased from 75 to 100.
Wheel Speed increased from 175 to 188. (1.37 to 1.47)
Wheel Anti-Tank damage decreased from 130 to 100. (130% to 100%)

A small decrease to the number of half-tracks that players can build to increase the favorability of using tracks, Which then increases favorability of wheels due to the stark speed and production differences between the two.  Reduction of AT damage on wheels makes them rough equivalents to hover so wheels are the hard economic counter to hover assuming you can get them into position.