### PR TITLE
Switch features to use `PagedEntityContainer<FEATURE>` as backing storage

### DIFF
--- a/src/feature.cpp
+++ b/src/feature.cpp
@@ -183,14 +183,10 @@ FEATURE *buildFeature(FEATURE_STATS *psStats, UDWORD x, UDWORD y, bool FromSave)
 /* Create a feature on the map */
 FEATURE *buildFeature(FEATURE_STATS *psStats, UDWORD x, UDWORD y, bool FromSave, uint32_t id)
 {
-	//try and create the Feature
-	FEATURE *psFeature = new FEATURE(id, psStats);
+	//try and create the Feature, obtain stable address.
+	FEATURE& feature = GlobalFeatureContainer().emplace(id, psStats);
+	FEATURE* psFeature = &feature;
 
-	if (psFeature == nullptr)
-	{
-		debug(LOG_WARNING, "Feature couldn't be built.");
-		return nullptr;
-	}
 	//add the feature to the list - this enables it to be drawn whilst being built
 	addFeature(psFeature);
 
@@ -555,4 +551,10 @@ StructureBounds getStructureBounds(FEATURE_STATS const *stats, Vector2i pos)
 	const Vector2i size = stats->size();
 	const Vector2i map = map_coord(pos) - size / 2;
 	return StructureBounds(map, size);
+}
+
+FeatureContainer& GlobalFeatureContainer()
+{
+	static FeatureContainer instance;
+	return instance;
 }

--- a/src/feature.h
+++ b/src/feature.h
@@ -26,6 +26,7 @@
 
 #include "objectdef.h"
 #include "lib/framework/wzconfig.h"
+#include "lib/framework/paged_entity_container.h"
 
 /* The statistics for the features */
 extern std::vector<FEATURE_STATS> asFeatureStats;
@@ -81,5 +82,11 @@ static inline FEATURE const *castFeature(SIMPLE_OBJECT const *psObject)
 {
 	return isFeature(psObject) ? (FEATURE const *)psObject : (FEATURE const *)nullptr;
 }
+
+// Split the feature storage into pages containing 128 features, disable slot reuse
+// to guard against memory-related issues when some object pointers won't get
+// updated properly, e.g. when transitioning between the base and offworld missions.
+using FeatureContainer = PagedEntityContainer<FEATURE, 128, false>;
+FeatureContainer& GlobalFeatureContainer();
 
 #endif // __INCLUDED_SRC_FEATURE_H__


### PR DESCRIPTION
1. Split the feature storage into pages containing 128 features
2. Disable slot reuse to guard against memory-related issues when some object pointers won't get updated properly, e.g. when transitioning between the base and offworld missions.