### PR TITLE
Use the translation map for unix system locale

### DIFF
--- a/lib/framework/i18n.cpp
+++ b/lib/framework/i18n.cpp
@@ -312,6 +312,57 @@ const char *getLanguageName()
 	return language;
 }
 
+#if !defined(__EMSCRIPTEN__) && !defined(WZ_OS_WIN)
+const char *unixSystemLANGUAGE = nullptr;
+const char *unixSystemLANG = nullptr;
+static unsigned int getMatchingLanguage(const char *locale)
+{
+	if (locale == nullptr)
+	{
+		return -1;
+	}
+	static char localeName[6] = { '\0' };
+	sstrcpy(localeName, locale);
+	char *delim = NULL;
+	unsigned int i;
+	// cut anything after a '.' to get rid of the encoding part
+	delim = strchr(localeName, '.');
+	if (delim)
+	{
+		*delim = '\0';
+	}
+	for (i = 0; i < ARRAY_SIZE(map); i++)
+	{
+		if (strcmp(localeName, map[i].language) == 0 || strcmp(localeName, map[i].localeFallback) == 0)
+		{
+			return i;
+		}
+	}
+	// if language is xx_XX, cut the _XX part for short language
+	delim = strchr(localeName, '_');
+	if (delim)
+	{
+		*delim = '\0';
+		for (i = 0; i < ARRAY_SIZE(map); i++)
+		{
+			if (strcmp(localeName, map[i].language) == 0 || strcmp(localeName, map[i].localeFallback) == 0)
+			{
+				return i;
+			}
+		}
+	}
+	return -1;
+}
+static unsigned int getUnixSystemLanguage()
+{
+	unsigned int ret = getMatchingLanguage(unixSystemLANGUAGE);
+	if (ret != -1)
+	{
+		return ret;
+	}
+	return getMatchingLanguage(unixSystemLANG);
+}
+#endif
 
 #if defined(ENABLE_NLS)
 #  if defined(WZ_OS_WIN)
@@ -440,6 +491,14 @@ bool setLanguage(const char *language)
 #  elif defined(__EMSCRIPTEN__)
 			return setLocaleEmscripten(map[i].localeFilename);
 #  else
+			if (i == 0)
+			{
+				unsigned int detectedI = getUnixSystemLanguage();
+				if (detectedI != -1)
+				{
+					return setLocaleUnix(map[detectedI].locale) || setLocaleUnix(map[detectedI].localeFallback) || setLocaleUnix_LANGUAGEFallback(map[detectedI].localeFilename);
+				}
+			}
 			return setLocaleUnix(map[i].locale) || setLocaleUnix(map[i].localeFallback) || setLocaleUnix_LANGUAGEFallback(map[i].localeFilename);
 #  endif
 		}
@@ -679,6 +738,11 @@ void initI18n()
 
 	// Should come *after* bindTextDomain
 	canUseLANGUAGEEnvVar = checkSupportsLANGUAGEenvVarOverride();
+
+#if !defined(__EMSCRIPTEN__) && !defined(WZ_OS_WIN)
+	unixSystemLANGUAGE = getenv("LANGUAGE");
+	unixSystemLANG = getenv("LANG");
+#endif
 
 	if (!setLanguage(defaultLanguage.c_str())) // set to system default
 	{


### PR DESCRIPTION
This patchs looks for an acceptable entry when using the System locale (from environment variables) to have the same behaviour as when selecting a locale explicitely.

How to reproduce, before the patch:

- install a locale on your system that is not English and supported by Warzone 2100, set it as your system locale (for example fr_FR, de_DE or ru_RU)
- relog, check your locale with `locale`
- Run the game, it should be translated when you select the language in the settings, but still be in English with System locale

How to test, after the patch:

- With your system still in the non-English locale
- Run the game, it should be translated with System locale
- You can try an alternative locale like de_BE and it should still be in German (unless the locale de_DE is not installed which is an other issue)
