### PR TITLE
PagedEntityContainer: fix `advance_page_index()` for expired pages

### DIFF
--- a/lib/framework/paged_entity_container.h
+++ b/lib/framework/paged_entity_container.h
@@ -577,8 +577,8 @@ public:
 			const auto pagesCount = _c._pages.size();
 			assert(_pageIdx.first < pagesCount);
 			assert(_pageIdx.second <= current_page().max_valid_index());
-			// Move to the next page if already pointing to the last valid index.
-			if (_pageIdx.second == current_page().max_valid_index())
+			// Move to the next page if already pointing to the last valid index or if the current page is expired.
+			if (_pageIdx.second == current_page().max_valid_index() || current_page().is_expired())
 			{
 				// Skip expired pages when transitioning to the next page.
 				do


### PR DESCRIPTION
This prevents accessing invalid indices when an iterator is already pointing within an expired page. This may happen, for example, in the following case:

1. Get an iterator into page `P`, which has one valid element anywhere except the last valid index.
2. Call `erase(it)` for the parent container.
3. Invoke `++it`.

So, previously, the iterator won't notice that the page has expired after `erase(it)` and will try to just increase the infra-index inside page `P`, although this will cause access to already released memory (because, pages release their storage upon expiration).

Fix that by always checking for page expiration first in the `advance_page_index()`.