### PR TITLE
display3d.cpp: don't use heap allocation for `buildBlueprint()`

### DIFF
--- a/src/structure.cpp
+++ b/src/structure.cpp
@@ -1829,11 +1829,11 @@ STRUCTURE *buildStructureDir(STRUCTURE_STATS *pStructureType, UDWORD x, UDWORD y
 	return psBuilding;
 }
 
-STRUCTURE *buildBlueprint(STRUCTURE_STATS const *psStats, Vector3i pos, uint16_t direction, unsigned moduleIndex, STRUCT_STATES state, uint8_t ownerPlayer)
+optional<STRUCTURE> buildBlueprint(STRUCTURE_STATS const *psStats, Vector3i pos, uint16_t direction, unsigned moduleIndex, STRUCT_STATES state, uint8_t ownerPlayer)
 {
-	ASSERT_OR_RETURN(nullptr, psStats != nullptr, "No blueprint stats");
-	ASSERT_OR_RETURN(nullptr, psStats->pIMD[0] != nullptr, "No blueprint model for %s", getStatsName(psStats));
-	ASSERT_OR_RETURN(nullptr, ownerPlayer < MAX_PLAYERS, "invalid ownerPlayer: %" PRIu8 "", ownerPlayer);
+	ASSERT_OR_RETURN(nullopt, psStats != nullptr, "No blueprint stats");
+	ASSERT_OR_RETURN(nullopt, psStats->pIMD[0] != nullptr, "No blueprint model for %s", getStatsName(psStats));
+	ASSERT_OR_RETURN(nullopt, ownerPlayer < MAX_PLAYERS, "invalid ownerPlayer: %" PRIu8 "", ownerPlayer);
 
 	Rotation rot(direction, 0, 0);
 
@@ -1909,9 +1909,7 @@ STRUCTURE *buildBlueprint(STRUCTURE_STATS const *psStats, Vector3i pos, uint16_t
 		}
 	}
 
-	auto& stableBlueprint = GlobalStructContainer().emplace(std::move(blueprint));
-
-	return &stableBlueprint;
+	return blueprint;
 }
 
 static Vector2i defaultAssemblyPointPos(STRUCTURE *psBuilding)

--- a/src/structure.h
+++ b/src/structure.h
@@ -32,6 +32,8 @@
 #include "visibility.h"
 #include "baseobject.h"
 
+#include <nonstd/optional.hpp>
+
 // how long to wait between CALL_STRUCT_ATTACKED's - plus how long to flash on radar for
 #define ATTACK_CB_PAUSE		5000
 
@@ -105,7 +107,9 @@ STRUCTURE *buildStructure(STRUCTURE_STATS *pStructureType, UDWORD x, UDWORD y, U
 STRUCTURE *buildStructureDir(STRUCTURE_STATS *pStructureType, UDWORD x, UDWORD y, uint16_t direction, UDWORD player, bool FromSave, uint32_t id);
 STRUCTURE *buildStructureDir(STRUCTURE_STATS *pStructureType, UDWORD x, UDWORD y, uint16_t direction, UDWORD player, bool FromSave);
 /// Create a blueprint structure, with just enough information to render it
-STRUCTURE *buildBlueprint(STRUCTURE_STATS const *psStats, Vector3i xy, uint16_t direction, unsigned moduleIndex, STRUCT_STATES state, uint8_t ownerPlayer);
+/// IMPORTANT: Do not save the reference to this instance anywhere, since it's
+/// not heap-allocated and thus doesn't have a stable address!
+nonstd::optional<STRUCTURE> buildBlueprint(STRUCTURE_STATS const *psStats, Vector3i xy, uint16_t direction, unsigned moduleIndex, STRUCT_STATES state, uint8_t ownerPlayer);
 /* The main update routine for all Structures */
 void structureUpdate(STRUCTURE *psBuilding, bool bMission);
 


### PR DESCRIPTION
This function is called for every frame, so to avoid constantly inserting/deleting to/from `GlobalStructContainer()`, just construct the pseudo-structure for the blueprint on stack.

This seems to work well enough, meaning that `mouseTarget()`, which, in turn, calls `getTileBlueprintStructure()`, doesn't do anything horribly wrong.