### PR TITLE
netplay, netsocket: pass references to sockets wherever possible

### DIFF
--- a/lib/netplay/netsocket.cpp
+++ b/lib/netplay/netsocket.cpp
@@ -96,9 +96,9 @@ static SocketThreadWriteMap socketThreadWrites;
 static void socketCloseNow(Socket *sock);
 
 
-bool socketReadReady(Socket const *sock)
+bool socketReadReady(const Socket& sock)
 {
-	return sock->ready;
+	return sock.ready;
 }
 
 int getSockErr(void)
@@ -356,7 +356,7 @@ static bool connectionIsOpen(Socket *sock)
 	                 sock && sock->fd[SOCK_CONNECTION] != INVALID_SOCKET, "Invalid socket");
 
 	// Check whether the socket is still connected
-	int ret = checkSockets(&set, 0);
+	int ret = checkSockets(set, 0);
 	if (ret == SOCKET_ERROR)
 	{
 		return false;
@@ -525,32 +525,32 @@ static int socketThreadFunction(void *)
  * Similar to read(2) with the exception that this function won't be
  * interrupted by signals (EINTR).
  */
-ssize_t readNoInt(Socket *sock, void *buf, size_t max_size, size_t *rawByteCount)
+ssize_t readNoInt(Socket& sock, void *buf, size_t max_size, size_t *rawByteCount)
 {
 	size_t ignored;
 	size_t &rawBytes = rawByteCount != nullptr ? *rawByteCount : ignored;
 	rawBytes = 0;
 
-	if (sock->fd[SOCK_CONNECTION] == INVALID_SOCKET)
+	if (sock.fd[SOCK_CONNECTION] == INVALID_SOCKET)
 	{
 		debug(LOG_ERROR, "Invalid socket");
 		setSockErr(EBADF);
 		return SOCKET_ERROR;
 	}
 
-	if (sock->isCompressed)
+	if (sock.isCompressed)
 	{
-		if (sock->zInflateNeedInput)
+		if (sock.zInflateNeedInput)
 		{
 			// No input data, read some.
 
-			sock->zInflateInBuf.resize(max_size + 1000);
+			sock.zInflateInBuf.resize(max_size + 1000);
 
 			ssize_t received;
 			do
 			{
 				//                                                  v----- This weird cast is because recv() takes a char * on windows instead of a void *...
-				received = recv(sock->fd[SOCK_CONNECTION], (char *)&sock->zInflateInBuf[0], sock->zInflateInBuf.size(), 0);
+				received = recv(sock.fd[SOCK_CONNECTION], (char *)&sock.zInflateInBuf[0], sock.zInflateInBuf.size(), 0);
 			}
 			while (received == SOCKET_ERROR && getSockErr() == EINTR);
 			if (received < 0)
@@ -558,23 +558,23 @@ ssize_t readNoInt(Socket *sock, void *buf, size_t max_size, size_t *rawByteCount
 				return received;
 			}
 
-			sock->zInflate.next_in = &sock->zInflateInBuf[0];
-			sock->zInflate.avail_in = received;
+			sock.zInflate.next_in = &sock.zInflateInBuf[0];
+			sock.zInflate.avail_in = received;
 			rawBytes = received;
 
 			if (received == 0)
 			{
-				sock->readDisconnected = true;
+				sock.readDisconnected = true;
 			}
 			else
 			{
-				sock->zInflateNeedInput = false;
+				sock.zInflateNeedInput = false;
 			}
 		}
 
-		sock->zInflate.next_out = (Bytef *)buf;
-		sock->zInflate.avail_out = max_size;
-		int ret = inflate(&sock->zInflate, Z_NO_FLUSH);
+		sock.zInflate.next_out = (Bytef *)buf;
+		sock.zInflate.avail_out = max_size;
+		int ret = inflate(&sock.zInflate, Z_NO_FLUSH);
 		ASSERT(ret != Z_STREAM_ERROR, "zlib inflate not working!");
 		char const *err = nullptr;
 		switch (ret)
@@ -589,35 +589,35 @@ ssize_t readNoInt(Socket *sock, void *buf, size_t max_size, size_t *rawByteCount
 			return -1;  // Bad data!
 		}
 
-		if (sock->zInflate.avail_out != 0)
+		if (sock.zInflate.avail_out != 0)
 		{
-			sock->zInflateNeedInput = true;
-			ASSERT(sock->zInflate.avail_in == 0, "zlib not consuming all input!");
+			sock.zInflateNeedInput = true;
+			ASSERT(sock.zInflate.avail_in == 0, "zlib not consuming all input!");
 		}
 
-		return max_size - sock->zInflate.avail_out;  // Got some data, return how much.
+		return max_size - sock.zInflate.avail_out;  // Got some data, return how much.
 	}
 
 	ssize_t received;
 	do
 	{
-		received = recv(sock->fd[SOCK_CONNECTION], (char *)buf, max_size, 0);
+		received = recv(sock.fd[SOCK_CONNECTION], (char *)buf, max_size, 0);
 		if (received == 0)
 		{
-			sock->readDisconnected = true;
+			sock.readDisconnected = true;
 		}
 	}
 	while (received == SOCKET_ERROR && getSockErr() == EINTR);
 
-	sock->ready = false;
+	sock.ready = false;
 
 	rawBytes = received;
 	return received;
 }
 
-bool socketReadDisconnected(Socket *sock)
+bool socketReadDisconnected(const Socket& sock)
 {
-	return sock->readDisconnected;
+	return sock.readDisconnected;
 }
 
 /**
@@ -626,34 +626,34 @@ bool socketReadDisconnected(Socket *sock)
  *
  * @return @c size when successful or @c SOCKET_ERROR if an error occurred.
  */
-ssize_t writeAll(Socket *sock, const void *buf, size_t size, size_t *rawByteCount)
+ssize_t writeAll(Socket& sock, const void *buf, size_t size, size_t *rawByteCount)
 {
 	size_t ignored;
 	size_t &rawBytes = rawByteCount != nullptr ? *rawByteCount : ignored;
 	rawBytes = 0;
 
-	if (sock->fd[SOCK_CONNECTION] == INVALID_SOCKET)
+	if (sock.fd[SOCK_CONNECTION] == INVALID_SOCKET)
 	{
 		debug(LOG_ERROR, "Invalid socket (EBADF)");
 		setSockErr(EBADF);
 		return SOCKET_ERROR;
 	}
 
-	if (sock->writeError)
+	if (sock.writeError)
 	{
 		return SOCKET_ERROR;
 	}
 
 	if (size > 0)
 	{
-		if (!sock->isCompressed)
+		if (!sock.isCompressed)
 		{
 			wzMutexLock(socketThreadMutex);
 			if (socketThreadWrites.empty())
 			{
 				wzSemaphorePost(socketThreadSemaphore);
 			}
-			std::vector<uint8_t> &writeQueue = socketThreadWrites[sock];
+			std::vector<uint8_t> &writeQueue = socketThreadWrites[&sock];
 			writeQueue.insert(writeQueue.end(), static_cast<char const *>(buf), static_cast<char const *>(buf) + size);
 			wzMutexUnlock(socketThreadMutex);
 			rawBytes = size;
@@ -673,7 +673,7 @@ ssize_t writeAll(Socket *sock, const void *buf, size_t size, size_t *rawByteCoun
 			#endif
 
 			// cast away the const for earlier zlib versions
-			sock->zDeflate.next_in = (Bytef *)buf; // -Wcast-qual
+			sock.zDeflate.next_in = (Bytef *)buf; // -Wcast-qual
 
 			#if defined(__clang__)
 			#  pragma clang diagnostic pop
@@ -682,65 +682,65 @@ ssize_t writeAll(Socket *sock, const void *buf, size_t size, size_t *rawByteCoun
 			#endif
 		#else
 			// zlib >= 1.2.5.2 supports ZLIB_CONST
-			sock->zDeflate.next_in = (const Bytef *)buf;
+			sock.zDeflate.next_in = (const Bytef *)buf;
 		#endif
 
-			sock->zDeflate.avail_in = size;
-			sock->zDeflateInSize += sock->zDeflate.avail_in;
+			sock.zDeflate.avail_in = size;
+			sock.zDeflateInSize += sock.zDeflate.avail_in;
 			do
 			{
-				size_t alreadyHave = sock->zDeflateOutBuf.size();
-				sock->zDeflateOutBuf.resize(alreadyHave + size + 20);  // A bit more than size should be enough to always do everything in one go.
-				sock->zDeflate.next_out = (Bytef *)&sock->zDeflateOutBuf[alreadyHave];
-				sock->zDeflate.avail_out = sock->zDeflateOutBuf.size() - alreadyHave;
+				size_t alreadyHave = sock.zDeflateOutBuf.size();
+				sock.zDeflateOutBuf.resize(alreadyHave + size + 20);  // A bit more than size should be enough to always do everything in one go.
+				sock.zDeflate.next_out = (Bytef *)&sock.zDeflateOutBuf[alreadyHave];
+				sock.zDeflate.avail_out = sock.zDeflateOutBuf.size() - alreadyHave;
 
-				int ret = deflate(&sock->zDeflate, Z_NO_FLUSH);
+				int ret = deflate(&sock.zDeflate, Z_NO_FLUSH);
 				ASSERT(ret != Z_STREAM_ERROR, "zlib compression failed!");
 
 				// Remove unused part of buffer.
-				sock->zDeflateOutBuf.resize(sock->zDeflateOutBuf.size() - sock->zDeflate.avail_out);
+				sock.zDeflateOutBuf.resize(sock.zDeflateOutBuf.size() - sock.zDeflate.avail_out);
 			}
-			while (sock->zDeflate.avail_out == 0);
+			while (sock.zDeflate.avail_out == 0);
 
-			ASSERT(sock->zDeflate.avail_in == 0, "zlib didn't compress everything!");
+			ASSERT(sock.zDeflate.avail_in == 0, "zlib didn't compress everything!");
 		}
 	}
 
 	return size;
 }
 
-void socketFlush(Socket *sock, uint8_t player, size_t *rawByteCount)
+void socketFlush(Socket& sock, uint8_t player, size_t *rawByteCount)
 {
 	size_t ignored;
 	size_t &rawBytes = rawByteCount != nullptr ? *rawByteCount : ignored;
 	rawBytes = 0;
 
-	if (!sock->isCompressed)
+	if (!sock.isCompressed)
 	{
 		return;  // Not compressed, so don't mess with zlib.
 	}
 
-	ASSERT(!sock->writeError, "Socket write error?? (Player: %" PRIu8 "", player);
+	ASSERT(!sock.writeError, "Socket write error?? (Player: %" PRIu8 "", player);
 
 	// Flush data out of zlib compression state.
 	do
 	{
-		sock->zDeflate.next_in = (Bytef *)nullptr;
-		sock->zDeflate.avail_in = 0;
-		size_t alreadyHave = sock->zDeflateOutBuf.size();
-		sock->zDeflateOutBuf.resize(alreadyHave + 1000);  // 100 bytes would probably be enough to flush the rest in one go.
-		sock->zDeflate.next_out = (Bytef *)&sock->zDeflateOutBuf[alreadyHave];
-		sock->zDeflate.avail_out = sock->zDeflateOutBuf.size() - alreadyHave;
+		sock.zDeflate.next_in = (Bytef *)nullptr;
+		sock.zDeflate.avail_in = 0;
+		size_t alreadyHave = sock.zDeflateOutBuf.size();
+		sock.zDeflateOutBuf.resize(alreadyHave + 1000);  // 100 bytes would probably be enough to flush the rest in one go.
+		sock.zDeflate.next_out = (Bytef *)&sock.zDeflateOutBuf[alreadyHave];
+		sock.zDeflate.avail_out = sock.zDeflateOutBuf.size() - alreadyHave;
 
-		int ret = deflate(&sock->zDeflate, Z_PARTIAL_FLUSH);
+		int ret = deflate(&sock.zDeflate, Z_PARTIAL_FLUSH);
 		ASSERT(ret != Z_STREAM_ERROR, "zlib compression failed!");
 
 		// Remove unused part of buffer.
-		sock->zDeflateOutBuf.resize(sock->zDeflateOutBuf.size() - sock->zDeflate.avail_out);
+		sock.zDeflateOutBuf.resize(sock.zDeflateOutBuf.size() - sock.zDeflate.avail_out);
 	}
-	while (sock->zDeflate.avail_out == 0);
+	while (sock.zDeflate.avail_out == 0);
 
-	if (sock->zDeflateOutBuf.empty())
+	if (sock.zDeflateOutBuf.empty())
 	{
 		return;  // No data to flush out.
 	}
@@ -750,8 +750,8 @@ void socketFlush(Socket *sock, uint8_t player, size_t *rawByteCount)
 	{
 		wzSemaphorePost(socketThreadSemaphore);
 	}
-	std::vector<uint8_t> &writeQueue = socketThreadWrites[sock];
-	writeQueue.insert(writeQueue.end(), sock->zDeflateOutBuf.begin(), sock->zDeflateOutBuf.end());
+	std::vector<uint8_t> &writeQueue = socketThreadWrites[&sock];
+	writeQueue.insert(writeQueue.end(), sock.zDeflateOutBuf.begin(), sock.zDeflateOutBuf.end());
 	wzMutexUnlock(socketThreadMutex);
 
 	// Primitive network logging, uncomment to use.
@@ -760,14 +760,14 @@ void socketFlush(Socket *sock, uint8_t player, size_t *rawByteCount)
 	//printf("\n");
 
 	// Data sent, don't send again.
-	rawBytes = sock->zDeflateOutBuf.size();
-	sock->zDeflateInSize = 0;
-	sock->zDeflateOutBuf.clear();
+	rawBytes = sock.zDeflateOutBuf.size();
+	sock.zDeflateInSize = 0;
+	sock.zDeflateOutBuf.clear();
 }
 
-void socketBeginCompression(Socket *sock)
+void socketBeginCompression(Socket& sock)
 {
-	if (sock->isCompressed)
+	if (sock.isCompressed)
 	{
 		return;  // Nothing to do.
 	}
@@ -775,23 +775,23 @@ void socketBeginCompression(Socket *sock)
 	wzMutexLock(socketThreadMutex);
 
 	// Init deflate.
-	sock->zDeflate.zalloc = Z_NULL;
-	sock->zDeflate.zfree = Z_NULL;
-	sock->zDeflate.opaque = Z_NULL;
-	int ret = deflateInit(&sock->zDeflate, 6);
+	sock.zDeflate.zalloc = Z_NULL;
+	sock.zDeflate.zfree = Z_NULL;
+	sock.zDeflate.opaque = Z_NULL;
+	int ret = deflateInit(&sock.zDeflate, 6);
 	ASSERT(ret == Z_OK, "deflateInit failed! Sockets won't work.");
 
-	sock->zInflate.zalloc = Z_NULL;
-	sock->zInflate.zfree = Z_NULL;
-	sock->zInflate.opaque = Z_NULL;
-	sock->zInflate.avail_in = 0;
-	sock->zInflate.next_in = Z_NULL;
-	ret = inflateInit(&sock->zInflate);
+	sock.zInflate.zalloc = Z_NULL;
+	sock.zInflate.zfree = Z_NULL;
+	sock.zInflate.opaque = Z_NULL;
+	sock.zInflate.avail_in = 0;
+	sock.zInflate.next_in = Z_NULL;
+	ret = inflateInit(&sock.zInflate);
 	ASSERT(ret == Z_OK, "deflateInit failed! Sockets won't work.");
 
-	sock->zInflateNeedInput = true;
+	sock.zInflateNeedInput = true;
 
-	sock->isCompressed = true;
+	sock.isCompressed = true;
 	wzMutexUnlock(socketThreadMutex);
 }
 
@@ -819,32 +819,32 @@ void deleteSocketSet(SocketSet *set)
  *
  * @return true if @c socket is successfully added to @set.
  */
-void SocketSet_AddSocket(SocketSet *set, Socket *socket)
+void SocketSet_AddSocket(SocketSet& set, Socket *socket)
 {
 	/* Check whether this socket is already present in this set (i.e. it
 	 * shouldn't be added again).
 	 */
-	size_t i = std::find(set->fds.begin(), set->fds.end(), socket) - set->fds.begin();
-	if (i != set->fds.size())
+	size_t i = std::find(set.fds.begin(), set.fds.end(), socket) - set.fds.begin();
+	if (i != set.fds.size())
 	{
 		debug(LOG_NET, "Already found, socket: (set->fds[%lu]) %p", (unsigned long)i, static_cast<void *>(socket));
 		return;
 	}
 
-	set->fds.push_back(socket);
+	set.fds.push_back(socket);
 	debug(LOG_NET, "Socket added: set->fds[%lu] = %p", (unsigned long)i, static_cast<void *>(socket));
 }
 
 /**
  * Remove the given socket from the given socket set.
  */
-void SocketSet_DelSocket(SocketSet *set, Socket *socket)
+void SocketSet_DelSocket(SocketSet& set, Socket *socket)
 {
-	size_t i = std::find(set->fds.begin(), set->fds.end(), socket) - set->fds.begin();
-	if (i != set->fds.size())
+	size_t i = std::find(set.fds.begin(), set.fds.end(), socket) - set.fds.begin();
+	if (i != set.fds.size())
 	{
 		debug(LOG_NET, "Socket %p erased (set->fds[%lu])", static_cast<void *>(socket), (unsigned long)i);
-		set->fds.erase(set->fds.begin() + i);
+		set.fds.erase(set.fds.begin() + i);
 	}
 }
 
@@ -941,9 +941,9 @@ static void socketBlockSIGPIPE(const SOCKET fd, bool block_sigpipe)
 #endif
 }
 
-int checkSockets(const SocketSet *set, unsigned int timeout)
+int checkSockets(const SocketSet& set, unsigned int timeout)
 {
-	if (set->fds.empty())
+	if (set.fds.empty())
 	{
 		return 0;
 	}
@@ -955,17 +955,17 @@ int checkSockets(const SocketSet *set, unsigned int timeout)
 #endif
 
 	bool compressedReady = false;
-	for (size_t i = 0; i < set->fds.size(); ++i)
+	for (size_t i = 0; i < set.fds.size(); ++i)
 	{
-		ASSERT(set->fds[i]->fd[SOCK_CONNECTION] != INVALID_SOCKET, "Invalid file descriptor!");
+		ASSERT(set.fds[i]->fd[SOCK_CONNECTION] != INVALID_SOCKET, "Invalid file descriptor!");
 
-		if (set->fds[i]->isCompressed && !set->fds[i]->zInflateNeedInput)
+		if (set.fds[i]->isCompressed && !set.fds[i]->zInflateNeedInput)
 		{
 			compressedReady = true;
 			break;
 		}
 
-		maxfd = std::max(maxfd, set->fds[i]->fd[SOCK_CONNECTION]);
+		maxfd = std::max(maxfd, set.fds[i]->fd[SOCK_CONNECTION]);
 	}
 
 	if (compressedReady)
@@ -973,9 +973,9 @@ int checkSockets(const SocketSet *set, unsigned int timeout)
 		// A socket already has some data ready. Don't really poll the sockets.
 
 		int ret = 0;
-		for (size_t i = 0; i < set->fds.size(); ++i)
+		for (size_t i = 0; i < set.fds.size(); ++i)
 		{
-			set->fds[i]->ready = set->fds[i]->isCompressed && !set->fds[i]->zInflateNeedInput;
+			set.fds[i]->ready = set.fds[i]->isCompressed && !set.fds[i]->zInflateNeedInput;
 			++ret;
 		}
 		return ret;
@@ -988,9 +988,9 @@ int checkSockets(const SocketSet *set, unsigned int timeout)
 		struct timeval tv = {(int)(timeout / 1000), (int)(timeout % 1000) * 1000};  // Cast to int to avoid narrowing needed for C++11.
 
 		FD_ZERO(&fds);
-		for (size_t i = 0; i < set->fds.size(); ++i)
+		for (size_t i = 0; i < set.fds.size(); ++i)
 		{
-			const SOCKET fd = set->fds[i]->fd[SOCK_CONNECTION];
+			const SOCKET fd = set.fds[i]->fd[SOCK_CONNECTION];
 
 			FD_SET(fd, &fds);
 		}
@@ -1005,9 +1005,9 @@ int checkSockets(const SocketSet *set, unsigned int timeout)
 		return SOCKET_ERROR;
 	}
 
-	for (size_t i = 0; i < set->fds.size(); ++i)
+	for (size_t i = 0; i < set.fds.size(); ++i)
 	{
-		set->fds[i]->ready = FD_ISSET(set->fds[i]->fd[SOCK_CONNECTION], &fds);
+		set.fds[i]->ready = FD_ISSET(set.fds[i]->fd[SOCK_CONNECTION], &fds);
 	}
 
 	return ret;
@@ -1027,17 +1027,17 @@ int checkSockets(const SocketSet *set, unsigned int timeout)
  * when the other end disconnected or a timeout occurred. Or @c SOCKET_ERROR if
  * an error occurred.
  */
-ssize_t readAll(Socket *sock, void *buf, size_t size, unsigned int timeout)
+ssize_t readAll(Socket& sock, void *buf, size_t size, unsigned int timeout)
 {
-	ASSERT(!sock->isCompressed, "readAll on compressed sockets not implemented.");
+	ASSERT(!sock.isCompressed, "readAll on compressed sockets not implemented.");
 
-	const SocketSet set = {std::vector<Socket *>(1, sock)};
+	const SocketSet set = {std::vector<Socket *>(1, &sock)};
 
 	size_t received = 0;
 
-	if (sock->fd[SOCK_CONNECTION] == INVALID_SOCKET)
+	if (sock.fd[SOCK_CONNECTION] == INVALID_SOCKET)
 	{
-		debug(LOG_ERROR, "Invalid socket (%p), sock->fd[SOCK_CONNECTION]=%" PRIuPTR"x  (error: EBADF)", static_cast<void *>(sock), static_cast<uintptr_t>(sock->fd[SOCK_CONNECTION]));
+		debug(LOG_ERROR, "Invalid socket (%p), sock->fd[SOCK_CONNECTION]=%" PRIuPTR"x  (error: EBADF)", static_cast<void *>(&sock), static_cast<uintptr_t>(sock.fd[SOCK_CONNECTION]));
 		setSockErr(EBADF);
 		return SOCKET_ERROR;
 	}
@@ -1049,26 +1049,26 @@ ssize_t readAll(Socket *sock, void *buf, size_t size, unsigned int timeout)
 		// If a timeout is set, wait for that amount of time for data to arrive (or abort)
 		if (timeout)
 		{
-			ret = checkSockets(&set, timeout);
+			ret = checkSockets(set, timeout);
 			if (ret < (ssize_t)set.fds.size()
-			    || !sock->ready)
+			    || !sock.ready)
 			{
 				if (ret == 0)
 				{
-					debug(LOG_NET, "socket (%p) has timed out.", static_cast<void *>(sock));
+					debug(LOG_NET, "socket (%p) has timed out.", static_cast<void *>(&sock));
 					setSockErr(ETIMEDOUT);
 				}
-				debug(LOG_NET, "socket (%p) error.", static_cast<void *>(sock));
+				debug(LOG_NET, "socket (%p) error.", static_cast<void *>(&sock));
 				return SOCKET_ERROR;
 			}
 		}
 
-		ret = recv(sock->fd[SOCK_CONNECTION], &((char *)buf)[received], size - received, 0);
-		sock->ready = false;
+		ret = recv(sock.fd[SOCK_CONNECTION], &((char *)buf)[received], size - received, 0);
+		sock.ready = false;
 		if (ret == 0)
 		{
-			debug(LOG_NET, "Socket %" PRIuPTR"x disconnected.", static_cast<uintptr_t>(sock->fd[SOCK_CONNECTION]));
-			sock->readDisconnected = true;
+			debug(LOG_NET, "Socket %" PRIuPTR"x disconnected.", static_cast<uintptr_t>(sock.fd[SOCK_CONNECTION]));
+			sock.readDisconnected = true;
 			setSockErr(ECONNRESET);
 			return received;
 		}
@@ -1527,20 +1527,20 @@ Socket *socketOpenAny(const SocketAddress *addr, unsigned timeout)
 	return ret;
 }
 
-WZ_DECL_NONNULL(1) bool socketHasIPv4(const Socket *sock)
+bool socketHasIPv4(const Socket& sock)
 {
-	if (sock->fd[SOCK_IPV4_LISTEN] != INVALID_SOCKET)
+	if (sock.fd[SOCK_IPV4_LISTEN] != INVALID_SOCKET)
 	{
 		return true;
 	}
 	else
 	{
 #if defined(IPV6_V6ONLY)
-		if (sock->fd[SOCK_IPV6_LISTEN] != INVALID_SOCKET)
+		if (sock.fd[SOCK_IPV6_LISTEN] != INVALID_SOCKET)
 		{
 			int ipv6_v6only = 1;
 			socklen_t len = sizeof(ipv6_v6only);
-			if (getsockopt(sock->fd[SOCK_IPV6_LISTEN], IPPROTO_IPV6, IPV6_V6ONLY, (char *)&ipv6_v6only, &len) == 0)
+			if (getsockopt(sock.fd[SOCK_IPV6_LISTEN], IPPROTO_IPV6, IPV6_V6ONLY, (char *)&ipv6_v6only, &len) == 0)
 			{
 				return ipv6_v6only == 0;
 			}
@@ -1550,14 +1550,14 @@ WZ_DECL_NONNULL(1) bool socketHasIPv4(const Socket *sock)
 	}
 }
 
-WZ_DECL_NONNULL(1) bool socketHasIPv6(const Socket *sock)
+bool socketHasIPv6(const Socket& sock)
 {
-	return sock->fd[SOCK_IPV6_LISTEN] != INVALID_SOCKET;
+	return sock.fd[SOCK_IPV6_LISTEN] != INVALID_SOCKET;
 }
 
-char const *getSocketTextAddress(Socket const *sock)
+char const *getSocketTextAddress(const Socket& sock)
 {
-	return sock->textAddress;
+	return sock.textAddress;
 }
 
 std::vector<unsigned char> ipv4_AddressString_To_NetBinary(const std::string& ipv4Address)

--- a/lib/netplay/netsocket.h
+++ b/lib/netplay/netsocket.h
@@ -100,33 +100,33 @@ Socket *socketListen(unsigned int port);                                ///< Cre
 WZ_DECL_NONNULL(1) Socket *socketAccept(Socket *sock);                  ///< Accepts an incoming Socket connection from a listening Socket.
 WZ_DECL_NONNULL(1) void socketClose(Socket *sock);                      ///< Destroys the Socket.
 Socket *socketOpenAny(const SocketAddress *addr, unsigned timeout);     ///< Opens a Socket, using the first address that works in addr.
-WZ_DECL_NONNULL(1) bool socketHasIPv4(const Socket *sock);
-WZ_DECL_NONNULL(1) bool socketHasIPv6(const Socket *sock);
+bool socketHasIPv4(const Socket& sock);
+bool socketHasIPv6(const Socket& sock);
 
-WZ_DECL_NONNULL(1) char const *getSocketTextAddress(Socket const *sock); ///< Gets a string with the socket address.
+char const *getSocketTextAddress(const Socket& sock); ///< Gets a string with the socket address.
 std::vector<unsigned char> ipv4_AddressString_To_NetBinary(const std::string& ipv4Address);
 std::vector<unsigned char> ipv6_AddressString_To_NetBinary(const std::string& ipv6Address);
 std::string ipv4_NetBinary_To_AddressString(const std::vector<unsigned char>& ip4NetBinaryForm);
 std::string ipv6_NetBinary_To_AddressString(const std::vector<unsigned char>& ip6NetBinaryForm);
-WZ_DECL_NONNULL(1) bool socketReadReady(Socket const *sock);            ///< Returns if checkSockets found data to read from this Socket.
-WZ_DECL_NONNULL(1, 2)
-ssize_t readNoInt(Socket *sock, void *buf, size_t max_size, size_t *rawByteCount = nullptr);  ///< Reads up to max_size bytes from the Socket. Raw count of bytes (after compression) returned in rawByteCount.
-WZ_DECL_NONNULL(1, 2)
-ssize_t readAll(Socket *sock, void *buf, size_t size, unsigned timeout);///< Reads exactly size bytes from the Socket, or blocks until the timeout expires.
-WZ_DECL_NONNULL(1, 2)
-ssize_t writeAll(Socket *sock, const void *buf, size_t size, size_t *rawByteCount = nullptr);  ///< Nonblocking write of size bytes to the Socket. All bytes will be written asynchronously, by a separate thread. Raw count of bytes (after compression) returned in rawByteCount, which will often be 0 until the socket is flushed.
+bool socketReadReady(const Socket& sock);            ///< Returns if checkSockets found data to read from this Socket.
+WZ_DECL_NONNULL(2)
+ssize_t readNoInt(Socket& sock, void *buf, size_t max_size, size_t *rawByteCount = nullptr);  ///< Reads up to max_size bytes from the Socket. Raw count of bytes (after compression) returned in rawByteCount.
+WZ_DECL_NONNULL(2)
+ssize_t readAll(Socket& sock, void *buf, size_t size, unsigned timeout);///< Reads exactly size bytes from the Socket, or blocks until the timeout expires.
+WZ_DECL_NONNULL(2)
+ssize_t writeAll(Socket& sock, const void *buf, size_t size, size_t *rawByteCount = nullptr);  ///< Nonblocking write of size bytes to the Socket. All bytes will be written asynchronously, by a separate thread. Raw count of bytes (after compression) returned in rawByteCount, which will often be 0 until the socket is flushed.
 
 // Sockets, compressed.
-WZ_DECL_NONNULL(1) void socketBeginCompression(Socket *sock); ///< Makes future data sent compressed, and future data received expected to be compressed.
-WZ_DECL_NONNULL(1) bool socketReadDisconnected(Socket *sock);  ///< If readNoInt returned 0, returns true if this is the result of a disconnect, or false if the input compressed data just hasn't produced any output bytes.
-WZ_DECL_NONNULL(1) void socketFlush(Socket *sock, uint8_t player, size_t *rawByteCount = nullptr); ///< Actually sends the data written with writeAll. Only useful on compressed sockets. Note that flushing too often makes compression less effective. Raw count of bytes (after compression) returned in rawByteCount.
+void socketBeginCompression(Socket& sock); ///< Makes future data sent compressed, and future data received expected to be compressed.
+bool socketReadDisconnected(const Socket& sock);  ///< If readNoInt returned 0, returns true if this is the result of a disconnect, or false if the input compressed data just hasn't produced any output bytes.
+void socketFlush(Socket& sock, uint8_t player, size_t *rawByteCount = nullptr); ///< Actually sends the data written with writeAll. Only useful on compressed sockets. Note that flushing too often makes compression less effective. Raw count of bytes (after compression) returned in rawByteCount.
 
 // Socket sets.
 WZ_DECL_ALLOCATION SocketSet *allocSocketSet();                         ///< Constructs a SocketSet.
 WZ_DECL_NONNULL(1) void deleteSocketSet(SocketSet *set);                ///< Destroys the SocketSet.
 
-WZ_DECL_NONNULL(1, 2) void SocketSet_AddSocket(SocketSet *set, Socket *socket);  ///< Adds a Socket to a SocketSet.
-WZ_DECL_NONNULL(1, 2) void SocketSet_DelSocket(SocketSet *set, Socket *socket);  ///< Removes a Socket from a SocketSet.
-WZ_DECL_NONNULL(1) int checkSockets(const SocketSet *set, unsigned int timeout); ///< Checks which Sockets are ready for reading. Returns the number of ready Sockets, or returns SOCKET_ERROR on error.
+WZ_DECL_NONNULL(2) void SocketSet_AddSocket(SocketSet& set, Socket *socket);  ///< Adds a Socket to a SocketSet.
+WZ_DECL_NONNULL(2) void SocketSet_DelSocket(SocketSet& set, Socket *socket);  ///< Removes a Socket from a SocketSet.
+int checkSockets(const SocketSet& set, unsigned int timeout); ///< Checks which Sockets are ready for reading. Returns the number of ready Sockets, or returns SOCKET_ERROR on error.
 
 #endif //_net_socket_h


### PR DESCRIPTION
This PR shouldn't change any existing behavior. It's mostly enhancements directed towards having safer APIs, i.e.:

Pass references instead of pointers to sockets wherever possible. This is more self-documenting than having a pointer signature with non-null annotation, and is harder to misuse.

Signed-off-by: Pavel Solodovnikov <pavel.al.solodovnikov@gmail.com>