### PR TITLE
Fix tiles under skyscrapers not changing to rubble

### DIFF
--- a/src/feature.cpp
+++ b/src/feature.cpp
@@ -556,6 +556,7 @@ bool destroyFeature(FEATURE *psDel, unsigned impactTime)
 						if (isUrban)
 						{
 							psTile->texture = TileNumber_texture(psTile->texture) | RUBBLE_TILE;
+							SET_TILE_DECAL(psTile);
 							markTileDirty(b.map.x + width, b.map.y + breadth);
 						}
 						auxClearBlocking(b.map.x + width, b.map.y + breadth, AUXBITS_ALL);
@@ -568,6 +569,7 @@ bool destroyFeature(FEATURE *psDel, unsigned impactTime)
 						if (isUrban)
 						{
 							psTile->texture = TileNumber_texture(psTile->texture) | BLOCKING_RUBBLE_TILE;
+							SET_TILE_DECAL(psTile);
 							markTileDirty(b.map.x + width, b.map.y + breadth);
 						}
 					}

--- a/src/feature.cpp
+++ b/src/feature.cpp
@@ -46,6 +46,7 @@
 #include "combat.h"
 #include "multiplay.h"
 #include "qtscript.h"
+#include "terrain.h"
 
 #include "mapgrid.h"
 #include "display3d.h"
@@ -555,6 +556,7 @@ bool destroyFeature(FEATURE *psDel, unsigned impactTime)
 						if (isUrban)
 						{
 							psTile->texture = TileNumber_texture(psTile->texture) | RUBBLE_TILE;
+							markTileDirty(b.map.x + width, b.map.y + breadth);
 						}
 						auxClearBlocking(b.map.x + width, b.map.y + breadth, AUXBITS_ALL);
 					}
@@ -566,6 +568,7 @@ bool destroyFeature(FEATURE *psDel, unsigned impactTime)
 						if (isUrban)
 						{
 							psTile->texture = TileNumber_texture(psTile->texture) | BLOCKING_RUBBLE_TILE;
+							markTileDirty(b.map.x + width, b.map.y + breadth);
 						}
 					}
 				}

--- a/src/feature.cpp
+++ b/src/feature.cpp
@@ -546,7 +546,9 @@ bool destroyFeature(FEATURE *psDel, unsigned impactTime)
 		{
 			for (int width = 0; width < b.size.x; ++width)
 			{
-				MAPTILE *psTile = mapTile(b.map.x + width, b.map.y + breadth);
+				const unsigned int x = b.map.x + width;
+				const unsigned int y = b.map.y + breadth;
+				MAPTILE *psTile = mapTile(x, y);
 				// stops water texture changing for underwater features
 				if (terrainType(psTile) != TER_WATER)
 				{
@@ -555,22 +557,18 @@ bool destroyFeature(FEATURE *psDel, unsigned impactTime)
 						/* Clear feature bits */
 						if (isUrban)
 						{
-							psTile->texture = TileNumber_texture(psTile->texture) | RUBBLE_TILE;
-							SET_TILE_DECAL(psTile);
-							markTileDirty(b.map.x + width, b.map.y + breadth);
+							makeTileRubbleTexture(psTile, x, y, RUBBLE_TILE);
 						}
-						auxClearBlocking(b.map.x + width, b.map.y + breadth, AUXBITS_ALL);
+						auxClearBlocking(x, y, AUXBITS_ALL);
 					}
 					else
 					{
 						/* This remains a blocking tile */
 						psTile->psObject = nullptr;
-						auxClearBlocking(b.map.x + width, b.map.y + breadth, AIR_BLOCKED);  // Shouldn't remain blocking for air units, however.
+						auxClearBlocking(x, y, AIR_BLOCKED);  // Shouldn't remain blocking for air units, however.
 						if (isUrban)
 						{
-							psTile->texture = TileNumber_texture(psTile->texture) | BLOCKING_RUBBLE_TILE;
-							SET_TILE_DECAL(psTile);
-							markTileDirty(b.map.x + width, b.map.y + breadth);
+							makeTileRubbleTexture(psTile, x, y, BLOCKING_RUBBLE_TILE);
 						}
 					}
 				}

--- a/src/map.h
+++ b/src/map.h
@@ -524,6 +524,13 @@ WZ_DECL_ALWAYS_INLINE static inline bool worldOnMap(Vector2i pos)
 	return worldOnMap(pos.x, pos.y);
 }
 
+static inline void makeTileRubbleTexture(MAPTILE *psTile, const unsigned int x, const unsigned int y, const unsigned int newTexture)
+{
+	psTile->texture = TileNumber_texture(psTile->texture) | newTexture;
+	SET_TILE_DECAL(psTile);
+	markTileDirty(x, y);
+}
+
 
 /* Intersect a line with the map and report tile intersection points */
 bool map_Intersect(int *Cx, int *Cy, int *Vx, int *Vy, int *Sx, int *Sy);

--- a/src/terrain.cpp
+++ b/src/terrain.cpp
@@ -777,6 +777,20 @@ void markTileDirty(int i, int j)
 	}
 }
 
+// Mark all tiles dirty
+// (when switching between classic and other modes, recalculating tile heights is required due to water)
+void dirtyAllSectors()
+{
+	if (sectors)
+	{
+		size_t len = static_cast<size_t>(xSectors) * static_cast<size_t>(ySectors);
+		for (size_t i = 0; i < len; ++i)
+		{
+			sectors[i].dirty = true;
+		}
+	}
+}
+
 void loadWaterTextures(int maxTerrainTextureSize, optional<int> maxTerrainAuxTextureSize = nullopt);
 
 void loadTerrainTextures_Fallback(MAP_TILESET mapTileset)
@@ -2340,15 +2354,7 @@ bool setTerrainShaderQuality(TerrainShaderQuality newValue, bool force, bool for
 		std::string terrainQualityUintStr = std::to_string(debugQualityUint);
 		crashHandlingProviderSetTag("wz.terrain_quality", terrainQualityUintStr);
 
-		if (sectors)
-		{
-			// mark all tiles dirty
-			// (when switching between classic and other modes, recalculating tile heights is required due to water)
-			for (size_t i = 0; i < xSectors * ySectors; ++i)
-			{
-				sectors[i].dirty = true;
-			}
-		}
+		dirtyAllSectors();
 
 		// re-load terrain textures
 		if (!rebuildExistingSearchPathWithGraphicsOptionChange())

--- a/src/terrain.h
+++ b/src/terrain.h
@@ -48,6 +48,7 @@ gfx_api::texture* getTerrainLightmapTexture();
 const glm::mat4& getModelUVLightmapMatrix();
 
 void markTileDirty(int i, int j);
+void dirtyAllSectors();
 
 enum TerrainShaderType
 {


### PR DESCRIPTION
One of the worst bugs this game has ever seen. Oh, how terribly it ruined the aesthetic of Urban tilesets not seeing rubble tiles appear automatically below a destroyed skyscraper. After much torment had this weighed on my mind, I decided to find out how to fix it yet again. By luck or pure genius I eventually found the means to get this working again. And yes, these tiles will persist with the new rubble texture through saveloads.

Fixes #2871.

(Extracted out a way to dirty all tiles which seems like it could be a useful function to have).