### PR TITLE
Let cheat mode persist across missions

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1904,7 +1904,9 @@ bool stageThreeInitialise()
 		const DebugInputManager& dbgInputManager = gInputManager.debugManager();
 		if (dbgInputManager.debugMappingsAllowed())
 		{
+			Cheated = true;
 			triggerEventCheatMode(true);
+			gInputManager.contexts().set(InputContext::DEBUG_MISC, InputContext::State::ACTIVE);
 		}
 
 		triggerEvent(TRIGGER_GAME_INIT);


### PR DESCRIPTION
Like it did a few years ago.

This way once you enter debug mode, you can access the debugger without having to toggle cheat mode every mission.

Fixes #2069.