### PR TITLE
Update quickjs-wz

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -839,8 +839,9 @@ else()
 			COMPONENT Core
 			DESTINATION "${WZ_APP_INSTALL_DEST}/assets")
 		# Also place assets in build dir so it can be run directly
+		file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/assets")
 		foreach(asset IN LISTS static_assets)
-			configure_file("${asset}" "${CMAKE_CURRENT_BINARY_DIR}/" COPYONLY)
+			configure_file("${asset}" "${CMAKE_CURRENT_BINARY_DIR}/assets/" COPYONLY)
 		endforeach()
 	endif()
 


### PR DESCRIPTION
This picks up https://github.com/Warzone2100/quickjs-wz/commit/15efa4b7d404b9fb25800cadadc9f60317640947 which works around a runtime crash that only affects Safari / WebKit on ARM / Apple Silicon.

(The easiest way to trigger this crash in WZ was to try loading either the Cobra or the SemperFi bots, which just so happened to set up the conditions to trigger this as the game started.)

For more discussion of the underlying issue, see: https://github.com/justjake/quickjs-emscripten/issues/166