### PR TITLE
Fix ally construction units deleting structures when helping to build them

### DIFF
--- a/src/droid.cpp
+++ b/src/droid.cpp
@@ -1125,10 +1125,10 @@ bool droidUpdateBuild(DROID *psDroid)
 
 	unsigned constructPoints = constructorPoints(*psDroid->getConstructStats(), psDroid->player);
 
-	unsigned pointsToAdd = constructPoints * (gameTime - psDroid->actionStarted) /
-				  GAME_TICKS_PER_SEC;
+	unsigned pointsToAdd = constructPoints * (gameTime - psDroid->actionStarted) / GAME_TICKS_PER_SEC;
+	int buildPointsToAdd = pointsToAdd - psDroid->actionPoints;
 
-	structureBuild(psStruct, psDroid, pointsToAdd - psDroid->actionPoints, constructPoints);
+	structureBuild(psStruct, psDroid, std::max(1, buildPointsToAdd), constructPoints);
 
 	//store the amount just added
 	psDroid->actionPoints = pointsToAdd;

--- a/src/structure.cpp
+++ b/src/structure.cpp
@@ -861,9 +861,6 @@ void structureBuild(STRUCTURE *psStruct, DROID *psDroid, int buildPoints, int bu
 		addPower(psStruct->player, structureTotalReturn(psStruct));
 	}
 
-	ASSERT(newBuildPoints <= 1 + 3 * (int)structureBuildPointsToCompletion(*psStruct), "unsigned int underflow?");
-	CLIP(newBuildPoints, 0, structureBuildPointsToCompletion(*psStruct));
-
 	int deltaBody = quantiseFraction(9 * psStruct->structureBody(), 10 * structureBuildPointsToCompletion(*psStruct), newBuildPoints, psStruct->currentBuildPts);
 	psStruct->currentBuildPts = newBuildPoints;
 	psStruct->body = std::max<int>(psStruct->body + deltaBody, 1);


### PR DESCRIPTION
What gets passed as "buildPoints" to `buildStructure()` can become negative through various crazy means. If this happens within a 1 tick window of a module being started, with allies helping to build it, the ally truck may delete your building. 

This probably all comes down to allies helping build structures with modules not being accounted for in enough places. In any case, always ensuring we pass at least a positive value will never let this happen again. Since if `buildPoints` is negative then the function assumes a demolish is occuring. I chose 1 instead of 0 as the minimum since the code in `structureBuild()` has some assumption guarded behind `buildPoints > 0`. 

Removed some code duplication in the 2nd commit. Same lines can be found less than 10 lines above the deletion.

Fixes #3699.