### PR TITLE
Fix false-positive warnings from GCC 14 when building with optimizations on Fedora 40

### DIFF
--- a/lib/framework/debug.cpp
+++ b/lib/framework/debug.cpp
@@ -34,7 +34,16 @@
 #include "wzapp.h"
 #include <map>
 #include <string>
-#include <regex>
+// On Fedora 40, GCC 14 produces false-positive warnings for -Walloc-zero
+// when compiling <regex> with optimizations. Silence these warnings.
+#if !defined(__clang__) && !defined(__INTEL_COMPILER) && defined(__GNUC__) && __GNUC__ >= 14 && defined(__OPTIMIZE__)
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Walloc-zero"
+#endif
+# include <regex>
+#if !defined(__clang__) && !defined(__INTEL_COMPILER) && defined(__GNUC__) && __GNUC__ >= 14 && defined(__OPTIMIZE__)
+# pragma GCC diagnostic pop
+#endif
 #include <array>
 
 #if defined(WZ_OS_LINUX) && defined(__GLIBC__)

--- a/lib/ivis_opengl/gfx_api_gl.cpp
+++ b/lib/ivis_opengl/gfx_api_gl.cpp
@@ -31,7 +31,16 @@
 #include <algorithm>
 #include <unordered_set>
 #include <unordered_map>
-#include <regex>
+// On Fedora 40, GCC 14 produces false-positive warnings for -Walloc-zero
+// when compiling <regex> with optimizations. Silence these warnings.
+#if !defined(__clang__) && !defined(__INTEL_COMPILER) && defined(__GNUC__) && __GNUC__ >= 14 && defined(__OPTIMIZE__)
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Walloc-zero"
+#endif
+# include <regex>
+#if !defined(__clang__) && !defined(__INTEL_COMPILER) && defined(__GNUC__) && __GNUC__ >= 14 && defined(__OPTIMIZE__)
+# pragma GCC diagnostic pop
+#endif
 #include <limits>
 #include <typeindex>
 #include <sstream>

--- a/src/qtscript.cpp
+++ b/src/qtscript.cpp
@@ -176,7 +176,16 @@ scripting_engine::timerNode::timerNode(timerNode&& rhs)           // move constr
 
 void scripting_engine::timerNode::swap(timerNode& _rhs)
 {
+// On Fedora 40, GCC 14 produces false-positive warnings for -Wuninitialized
+// when compiling this code with optimizations. Silence these warnings.
+#if !defined(__clang__) && !defined(__INTEL_COMPILER) && defined(__GNUC__) && __GNUC__ >= 14 && defined(__OPTIMIZE__)
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wuninitialized"
+#endif
 	std::swap(timerID, _rhs.timerID);
+#if !defined(__clang__) && !defined(__INTEL_COMPILER) && defined(__GNUC__) && __GNUC__ >= 14 && defined(__OPTIMIZE__)
+# pragma GCC diagnostic pop
+#endif
 	std::swap(function, _rhs.function);
 	std::swap(timerName, _rhs.timerName);
 	std::swap(instance, _rhs.instance);

--- a/src/urlrequest_curl.cpp
+++ b/src/urlrequest_curl.cpp
@@ -57,7 +57,16 @@
 #include <algorithm>
 #include <cstdio>
 #include <vector>
-#include <regex>
+// On Fedora 40, GCC 14 produces false-positive warnings for -Walloc-zero
+// when compiling <regex> with optimizations. Silence these warnings.
+#if !defined(__clang__) && !defined(__INTEL_COMPILER) && defined(__GNUC__) && __GNUC__ >= 14 && defined(__OPTIMIZE__)
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Walloc-zero"
+#endif
+# include <regex>
+#if !defined(__clang__) && !defined(__INTEL_COMPILER) && defined(__GNUC__) && __GNUC__ >= 14 && defined(__OPTIMIZE__)
+# pragma GCC diagnostic pop
+#endif
 #include <stdlib.h>
 #include <chrono>
 #include <sstream>


### PR DESCRIPTION
There were a few places where `-Wzero-alloc` and `-Wuninitialized` were erroneously triggered by optimized GCC14 builds on Fedora CI builder (which has recently transitioned to Fedora 40).

Silence these warnings.