### PR TITLE
Allow building structures on top of structures queued for removal

### DIFF
--- a/src/structure.cpp
+++ b/src/structure.cpp
@@ -1466,7 +1466,7 @@ STRUCTURE *buildStructureDir(STRUCTURE_STATS *pStructureType, UDWORD x, UDWORD y
 				{
 					removeStruct((STRUCTURE *)psTile->psObject, true);
 				}
-				else if (TileHasStructure(psTile))
+				else if (TileHasStructure(psTile) && !wzapi::scriptIsObjectQueuedForRemoval(psTile->psObject))
 				{
 #if defined(WZ_CC_GNU) && !defined(WZ_CC_INTEL) && !defined(WZ_CC_CLANG) && (7 <= __GNUC__)
 # pragma GCC diagnostic push

--- a/src/wzapi.cpp
+++ b/src/wzapi.cpp
@@ -4599,6 +4599,14 @@ wzapi::QueuedObjectRemovalsVector& wzapi::scriptQueuedObjectRemovals()
 	return instance;
 }
 
+bool wzapi::scriptIsObjectQueuedForRemoval(const BASE_OBJECT *psObj)
+{
+	const auto& queuedObjRemovals = scriptQueuedObjectRemovals();
+	return std::any_of(queuedObjRemovals.begin(), queuedObjRemovals.end(), [psObj](const std::pair<BASE_OBJECT*, bool>& p) {
+		return psObj == p.first;
+	});
+}
+
 void wzapi::processScriptQueuedObjectRemovals()
 {
 	auto& queuedObjRemovals = scriptQueuedObjectRemovals();

--- a/src/wzapi.h
+++ b/src/wzapi.h
@@ -1149,6 +1149,7 @@ namespace wzapi
 	using QueuedObjectRemovalsVector = std::vector<std::pair<BASE_OBJECT*, bool>>;
 
 	QueuedObjectRemovalsVector& scriptQueuedObjectRemovals();
+	bool scriptIsObjectQueuedForRemoval(const BASE_OBJECT *psObj);
 	/// <summary>
 	/// Walks `scriptQueuedObjectRemovals()` list, destroys every object in that list
 	/// and clears the container.


### PR DESCRIPTION
To enable the common script pattern of removeObject+addStructure to upgrade on-map structures.

Example: `camUpgradeOnMapStructures` in Fractured Kingdom: https://github.com/DARwins1/fractured-kingdom/blob/1a547e4fe642434a144d2d8ee78953d1955d6bf9/script/campaign/libcampaign_includes/production.js#L373-L385