### PR TITLE
Fix: Call setAssemblyPoint with bCheck=false when loading saved structures

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -6248,7 +6248,7 @@ static bool loadSaveStructure2(const char *pFileName)
 			if (ini.contains("Factory/assemblyPoint/pos"))
 			{
 				Position point = ini.vector3i("Factory/assemblyPoint/pos");
-				setAssemblyPoint(psFactory->psAssemblyPoint, point.x, point.y, player, true);
+				setAssemblyPoint(psFactory->psAssemblyPoint, point.x, point.y, player, false);
 				psFactory->psAssemblyPoint->selected = ini.value("Factory/assemblyPoint/selected", false).toBool();
 			}
 			if (ini.contains("Factory/assemblyPoint/number"))
@@ -6323,7 +6323,7 @@ static bool loadSaveStructure2(const char *pFileName)
 			if (ini.contains("Repair/deliveryPoint/pos"))
 			{
 				Position point = ini.vector3i("Repair/deliveryPoint/pos");
-				setAssemblyPoint(psRepair->psDeliveryPoint, point.x, point.y, player, true);
+				setAssemblyPoint(psRepair->psDeliveryPoint, point.x, point.y, player, false);
 				psRepair->psDeliveryPoint->selected = ini.value("Repair/deliveryPoint/selected", false).toBool();
 			}
 			break;


### PR DESCRIPTION
To ensure that the structure receives the assembly point location that was in the save.

(Issues could arise for saved games where structures existed beyond the scroll limits - for example, in a custom campaign where the map is gradually expanded in response to events. When `bCheck` is `true`, `setAssemblyPoint()` attempts to replace the assembly point within the scroll limits.)