### PR TITLE
Check psTile->psObject before resetting

### DIFF
--- a/src/feature.cpp
+++ b/src/feature.cpp
@@ -549,6 +549,10 @@ bool destroyFeature(FEATURE *psDel, unsigned impactTime)
 				const unsigned int x = b.map.x + width;
 				const unsigned int y = b.map.y + breadth;
 				MAPTILE *psTile = mapTile(x, y);
+				if (psTile->psObject != psDel)
+				{
+					continue;
+				}
 				// stops water texture changing for underwater features
 				if (terrainType(psTile) != TER_WATER)
 				{

--- a/src/structure.cpp
+++ b/src/structure.cpp
@@ -4393,8 +4393,11 @@ static void removeStructFromMap(STRUCTURE *psStruct)
 		for (int i = 0; i < b.size.x; ++i)
 		{
 			MAPTILE *psTile = mapTile(b.map.x + i, b.map.y + j);
-			psTile->psObject = nullptr;
-			auxClearBlocking(b.map.x + i, b.map.y + j, AIR_BLOCKED);
+			if (psTile->psObject == psStruct)
+			{
+				psTile->psObject = nullptr;
+				auxClearBlocking(b.map.x + i, b.map.y + j, AIR_BLOCKED);
+			}
 		}
 	}
 }


### PR DESCRIPTION
With the recent changes that may cause script object removals to be queued (and permit building structures on top of structures queued for removal, see: https://github.com/Warzone2100/warzone2100/pull/3767), ensure that `psTile->psObject` is only reset if it matches the object being deleted.