### PR TITLE
track.cpp: Allow audio JSON files to override existing entries

### DIFF
--- a/lib/sound/track.cpp
+++ b/lib/sound/track.cpp
@@ -127,8 +127,8 @@ unsigned int sound_SetTrackVals(const char *fileName, bool loop, unsigned int vo
 	ASSERT_OR_RETURN(0, trackID < g_apTrack.size(), "Invalid trackID: %u", trackID);
 	if (g_apTrack[trackID] != nullptr)
 	{
-		debug(LOG_ERROR, "sound_SetTrackVals: track %i already set (filename: \"%s\"\n", trackID, g_apTrack[trackID]->fileName);
-		return 0;
+		debug(LOG_SOUND, "sound_SetTrackVals: track %i already set (filename: \"%s\") - overriding", trackID, g_apTrack[trackID]->fileName);
+		ASSERT_OR_RETURN(0, psTrack == g_apTrack[trackID], "Data pointer not equal?");
 	}
 
 	// set track members


### PR DESCRIPTION
This permits, for example, a campaign mod to have a .wrf that loads the base audio.json AUDIOCFG followed by a custom audio-overrides.json AUDIOCFG that overrides the settings for select sound effects.