### PR TITLE
[Modding] Support for new GENERIC Structure types

### DIFF
--- a/data/base/stats/structure.json
+++ b/data/base/stats/structure.json
@@ -2542,7 +2542,7 @@
 			"miupbase.pie"
 		],
 		"thermal": 10,
-		"type": "DEFENSE",
+		"type": "GENERAL",
 		"width": 2
 	},
 	"Wall-RotMg": {

--- a/data/base/stats/structure.json
+++ b/data/base/stats/structure.json
@@ -1035,7 +1035,7 @@
 			"micool.PIE"
 		],
 		"thermal": 20,
-		"type": "DEFENSE",
+		"type": "GENERAL",
 		"width": 1
 	},
 	"Emplacement-HPVcannon": {
@@ -2026,7 +2026,7 @@
 			"minuke.PIE"
 		],
 		"thermal": 20,
-		"type": "DEFENSE",
+		"type": "GENERAL EXPLOSIVE",
 		"width": 2
 	},
 	"P0-AASite-SAM1": {

--- a/data/mp/stats/structure.json
+++ b/data/mp/stats/structure.json
@@ -2901,7 +2901,7 @@
 			"miupbase.pie"
 		],
 		"thermal": 10,
-		"type": "DEFENSE",
+		"type": "GENERAL",
 		"width": 2
 	},
 	"Wall-RotMg": {

--- a/data/mp/stats/structure.json
+++ b/data/mp/stats/structure.json
@@ -1145,7 +1145,7 @@
 			"micool.PIE"
 		],
 		"thermal": 20,
-		"type": "DEFENSE",
+		"type": "GENERAL",
 		"width": 1
 	},
 	"ECM1PylonMk1": {
@@ -2257,7 +2257,7 @@
 			"minuke.PIE"
 		],
 		"thermal": 20,
-		"type": "DEFENSE",
+		"type": "GENERAL EXPLOSIVE",
 		"width": 2
 	},
 	"P0-AASite-Laser": {

--- a/src/structure.cpp
+++ b/src/structure.cpp
@@ -384,6 +384,8 @@ static const StringToEnum<STRUCTURE_TYPE> map_STRUCTURE_TYPE[] =
 	{ "SAT UPLINK",         REF_SAT_UPLINK          },
 	{ "GATE",               REF_GATE                },
 	{ "LASSAT",             REF_LASSAT              },
+	{ "GENERAL",            REF_GENERAL             },
+	{ "GENERAL EXPLOSIVE",  REF_GENERAL_EXPLOSIVE   },
 };
 
 static const StringToEnum<STRUCT_STRENGTH> map_STRUCT_STRENGTH[] =
@@ -4183,6 +4185,8 @@ bool validLocation(BASE_STATS *psStats, Vector2i pos, uint16_t direction, unsign
 		case REF_MISSILE_SILO:
 		case REF_SAT_UPLINK:
 		case REF_LASSAT:
+		case REF_GENERAL:
+		case REF_GENERAL_EXPLOSIVE:
 			{
 				/*need to check each tile the structure will sit on is not water*/
 				for (int j = 0; j < b.size.y; ++j)
@@ -4613,6 +4617,9 @@ bool destroyStruct(STRUCTURE *psDel, unsigned impactTime)
 				break;
 			case REF_RESOURCE_EXTRACTOR:
 				shakeStart(400);
+				break;
+			case REF_GENERAL_EXPLOSIVE:
+				shakeStart(1000);
 				break;
 			default:
 				break;

--- a/src/structuredef.h
+++ b/src/structuredef.h
@@ -62,6 +62,8 @@ enum STRUCTURE_TYPE
 	REF_SAT_UPLINK,         //added for updates - AB 8/6/99
 	REF_GATE,
 	REF_LASSAT,
+	REF_GENERAL,
+	REF_GENERAL_EXPLOSIVE,
 	NUM_DIFF_BUILDINGS,		//need to keep a count of how many types for IMD loading
 };
 


### PR DESCRIPTION
**Description:**
EDIT FOR CLARITY:
`Structure` is the value used in `research.json` for upgrading base structures.
`Wall` is the value used in `research.json` for upgrading defense structures.
`DEFENSE`, `WALL`, `WALL CORNER`, `GATE`, and `GENERIC` are considered `Wall` for upgrade purposes, everything else is `Structure`.

There really needs to be an equivalent of `GENERIC` for structures (`Structure`), maybe `GENERAL` or `MISC`. Right now, if you want to add a new structure with no functionality, so that you can add functionality through a script, you need to use either `DEFENSE` or `GENERIC`, but then your ***structure*** will be considered a `Wall`, which is undesirable.
EDIT FOR CLARITY: For the purposes of applying upgrades through research, this is important.

**Why this is needed:**
There is currently no way to add new structures (`Structure`) with new functionality, while you can add new defenses (`Wall`) with new functionality. There is an exception in the `MISSILE SILO`, but that has potentially unwanted traits, such as being packable and explosive.

**More information:**
May solve this issue: https://github.com/Warzone2100/warzone2100/issues/3773
I am a complete newb to C++ and unfamiliar with the games code, so let me know if i completely (or even a little) screwed this up.
