### PR TITLE
Add "FORTRESS" structure type (with fixes), and fix "GENERIC" structure type

### DIFF
--- a/data/mp/stats/structure.json
+++ b/data/mp/stats/structure.json
@@ -3443,7 +3443,7 @@
 			"STWPFCAN.PIE"
 		],
 		"thermal": 18,
-		"type": "GENERIC",
+		"type": "FORTRESS",
 		"weapons": [
 			"CannonSuper"
 		],
@@ -3466,7 +3466,7 @@
 			"STWPFCAN.PIE"
 		],
 		"thermal": 18,
-		"type": "GENERIC",
+		"type": "FORTRESS",
 		"weapons": [
 			"MassDriver"
 		],
@@ -3489,7 +3489,7 @@
 			"STWPFCAN.PIE"
 		],
 		"thermal": 18,
-		"type": "GENERIC",
+		"type": "FORTRESS",
 		"weapons": [
 			"MissileSuper"
 		],
@@ -3512,7 +3512,7 @@
 			"STWPFCAN.PIE"
 		],
 		"thermal": 18,
-		"type": "GENERIC",
+		"type": "FORTRESS",
 		"weapons": [
 			"RocketSuper"
 		],

--- a/src/ai.cpp
+++ b/src/ai.cpp
@@ -446,6 +446,7 @@ static SDWORD targetAttackWeight(BASE_OBJECT *psTarget, BASE_OBJECT *psAttacker,
 		switch (targetStructure->pStructureType->type)
 		{
 		case REF_DEFENSE:
+		case REF_FORTRESS:
 			targetTypeBonus = WEIGHT_WEAPON_STRUCT;
 			break;
 

--- a/src/droid.cpp
+++ b/src/droid.cpp
@@ -2454,6 +2454,7 @@ static bool ThreatInRange(SDWORD player, SDWORD range, SDWORD rangeX, SDWORD ran
 					case REF_FACTORY:
 					case REF_VTOL_FACTORY:
 					case REF_REARM_PAD:
+					case REF_FORTRESS:
 
 						if (range < 0
 							|| world_coord(static_cast<int32_t>(hypotf(tx - map_coord(psStruct->pos.x), ty - map_coord(psStruct->pos.y)))) < range)	//enemy in range

--- a/src/quickjs_backend.cpp
+++ b/src/quickjs_backend.cpp
@@ -795,7 +795,7 @@ JSValue convResearch(const RESEARCH *psResearch, JSContext *ctx, int player)
 //;; * ```cost``` What it would cost to build this structure. (3.2+ only)
 //;; * ```stattype``` The stattype defines the type of structure. It will be one of ```HQ```, ```FACTORY```, ```POWER_GEN```,
 //;; ```RESOURCE_EXTRACTOR```, ```LASSAT```, ```DEFENSE```, ```WALL```, ```RESEARCH_LAB```, ```REPAIR_FACILITY```,
-//;; ```CYBORG_FACTORY```, ```VTOL_FACTORY```, ```REARM_PAD```, ```SAT_UPLINK```, ```GATE``` and ```COMMAND_CONTROL```.
+//;; ```CYBORG_FACTORY```, ```VTOL_FACTORY```, ```REARM_PAD```, ```SAT_UPLINK```, ```GATE```, ```STRUCT_GENERIC```, and ```COMMAND_CONTROL```.
 //;; * ```modules``` If the stattype is set to one of the factories, ```POWER_GEN``` or ```RESEARCH_LAB```, then this property is set to the
 //;; number of module upgrades it has.
 //;; * ```canHitAir``` True if the structure has anti-air capabilities. (3.2+ only)
@@ -842,7 +842,6 @@ JSValue convStructure(const STRUCTURE *psStruct, JSContext *ctx)
 	case REF_GATE:
 		stattype = (int)REF_WALL;
 		break;
-	case REF_GENERIC:
 	case REF_FORTRESS:
 	case REF_DEFENSE:
 		stattype = (int)REF_DEFENSE;

--- a/src/quickjs_backend.cpp
+++ b/src/quickjs_backend.cpp
@@ -843,6 +843,7 @@ JSValue convStructure(const STRUCTURE *psStruct, JSContext *ctx)
 		stattype = (int)REF_WALL;
 		break;
 	case REF_GENERIC:
+	case REF_FORTRESS:
 	case REF_DEFENSE:
 		stattype = (int)REF_DEFENSE;
 		break;

--- a/src/structure.cpp
+++ b/src/structure.cpp
@@ -384,6 +384,7 @@ static const StringToEnum<STRUCTURE_TYPE> map_STRUCTURE_TYPE[] =
 	{ "SAT UPLINK",         REF_SAT_UPLINK          },
 	{ "GATE",               REF_GATE                },
 	{ "LASSAT",             REF_LASSAT              },
+	{ "FORTRESS",           REF_FORTRESS            },
 };
 
 static const StringToEnum<STRUCT_STRENGTH> map_STRUCT_STRENGTH[] =
@@ -4183,6 +4184,7 @@ bool validLocation(BASE_STATS *psStats, Vector2i pos, uint16_t direction, unsign
 		case REF_MISSILE_SILO:
 		case REF_SAT_UPLINK:
 		case REF_LASSAT:
+		case REF_FORTRESS:
 			{
 				/*need to check each tile the structure will sit on is not water*/
 				for (int j = 0; j < b.size.y; ++j)

--- a/src/structuredef.h
+++ b/src/structuredef.h
@@ -62,6 +62,7 @@ enum STRUCTURE_TYPE
 	REF_SAT_UPLINK,         //added for updates - AB 8/6/99
 	REF_GATE,
 	REF_LASSAT,
+	REF_FORTRESS,			//added in WZ 4.5.0
 	NUM_DIFF_BUILDINGS,		//need to keep a count of how many types for IMD loading
 };
 

--- a/src/wzapi.cpp
+++ b/src/wzapi.cpp
@@ -4391,9 +4391,13 @@ nlohmann::json wzapi::constructStatsObject()
 			nlohmann::json strct = nlohmann::json::object();
 			strct["Id"] = psStats->id;
 			if (psStats->type == REF_DEFENSE || psStats->type == REF_WALL || psStats->type == REF_WALLCORNER
-			    || psStats->type == REF_GENERIC || psStats->type == REF_GATE || psStats->type == REF_FORTRESS)
+			    || psStats->type == REF_GATE || psStats->type == REF_FORTRESS)
 			{
 				strct["Type"] = "Wall";
+			}
+			else if (psStats->type == REF_GENERIC)
+			{
+				strct["Type"] = "Generic";
 			}
 			else if (psStats->type != REF_DEMOLISH)
 			{

--- a/src/wzapi.cpp
+++ b/src/wzapi.cpp
@@ -4502,6 +4502,7 @@ nlohmann::json wzapi::getUsefulConstants()
 	constants["SAT_UPLINK"] = REF_SAT_UPLINK;
 	constants["GATE"] = REF_GATE;
 	constants["LASSAT"] = REF_LASSAT;
+	constants["STRUCT_GENERIC"] = REF_GENERIC;
 	constants["SUPEREASY"] = static_cast<int8_t>(AIDifficulty::SUPEREASY);
 	constants["EASY"] = static_cast<int8_t>(AIDifficulty::EASY);
 	constants["MEDIUM"] = static_cast<int8_t>(AIDifficulty::MEDIUM);

--- a/src/wzapi.cpp
+++ b/src/wzapi.cpp
@@ -4391,7 +4391,7 @@ nlohmann::json wzapi::constructStatsObject()
 			nlohmann::json strct = nlohmann::json::object();
 			strct["Id"] = psStats->id;
 			if (psStats->type == REF_DEFENSE || psStats->type == REF_WALL || psStats->type == REF_WALLCORNER
-			    || psStats->type == REF_GENERIC || psStats->type == REF_GATE)
+			    || psStats->type == REF_GENERIC || psStats->type == REF_GATE || psStats->type == REF_FORTRESS)
 			{
 				strct["Type"] = "Wall";
 			}


### PR DESCRIPTION
Alternate approach to #3775 
Fixes: #3773

The only 4 structures that were previously using "GENERIC" were the fortresses. Presumably this was to opt them out of certain behavior that "DEFENSE" structures get (such as allowing building on any slope, and struct packing, and foundation stretching), but it also had the side effect of not giving them the same `targetAttackWeight` bonus as other defensive structs and not treating them as threats in `ThreatInRange`.

So, instead of adding a new type for "generic" structures, this PR:
- Adds a "FORTRESS" type that gives fortresses the same behavior as previous (plus addressing the two issues mentioned above regarding attack weight and threat level)
- Fixes the "GENERIC" type to no longer be considered as a Wall (for upgrades)
- Adds a `STRUCT_GENERIC` JS constant, and exposes this in the JS structure object `stattype` property for "GENERIC" structures (of which there are now none in the built-in stats files)

Potentially breaking change:
- Any mods editing `structure.json` should probably update `"type": "GENERIC"` -> `"type": "FORTRESS"` for any true fortress structures (unless they want the fixed GENERIC struct behavior).