### PR TITLE
Merge nearby point lights, dynamic quantity of point lighting buckets

### DIFF
--- a/data/base/shaders/pointlights.frag
+++ b/data/base/shaders/pointlights.frag
@@ -6,6 +6,7 @@ uniform vec4 PointLightsPosition[WZ_MAX_POINT_LIGHTS];
 uniform vec4 PointLightsColorAndEnergy[WZ_MAX_POINT_LIGHTS];
 uniform ivec4 bucketOffsetAndSize[WZ_BUCKET_DIMENSION * WZ_BUCKET_DIMENSION];
 uniform ivec4 PointLightsIndex[WZ_MAX_INDEXED_POINT_LIGHTS];
+uniform int bucketDimensionUsed;
 uniform int viewportWidth;
 uniform int viewportHeight;
 
@@ -53,8 +54,8 @@ vec4 iterateOverAllPointLights(
 	mat3 normalWorldSpaceToLocalSpace
 ) {
 	vec4 light = vec4(0.f);
-	ivec2 bucket = ivec2(float(WZ_BUCKET_DIMENSION) * clipSpaceCoord);
-	int bucketId = min(bucket.y + bucket.x * WZ_BUCKET_DIMENSION, WZ_BUCKET_DIMENSION * WZ_BUCKET_DIMENSION - 1);
+	ivec2 bucket = ivec2(float(bucketDimensionUsed) * clipSpaceCoord);
+	int bucketId = min(bucket.y + bucket.x * bucketDimensionUsed, bucketDimensionUsed * bucketDimensionUsed - 1);
 
 	for (int i = 0; i < bucketOffsetAndSize[bucketId].y; i++)
 	{

--- a/data/base/shaders/vk/pointlights.glsl
+++ b/data/base/shaders/vk/pointlights.glsl
@@ -42,8 +42,8 @@ vec4 iterateOverAllPointLights(
 	mat3 normalWorldSpaceToLocalSpace
 ) {
 	vec4 light = vec4(0);
-	ivec2 bucket = ivec2(WZ_BUCKET_DIMENSION * clipSpaceCoord);
-	int bucketId = min(bucket.y + bucket.x * WZ_BUCKET_DIMENSION, WZ_BUCKET_DIMENSION * WZ_BUCKET_DIMENSION - 1);
+	ivec2 bucket = ivec2(bucketDimensionUsed * clipSpaceCoord);
+	int bucketId = min(bucket.y + bucket.x * bucketDimensionUsed, bucketDimensionUsed * bucketDimensionUsed - 1);
 
 	for (int i = 0; i < bucketOffsetAndSize[bucketId].y; i++)
 	{

--- a/data/base/shaders/vk/tcmask_instanced.glsl
+++ b/data/base/shaders/vk/tcmask_instanced.glsl
@@ -31,6 +31,7 @@ layout(std140, set = 0, binding = 0) uniform globaluniforms
 	vec4 PointLightsColorAndEnergy[WZ_MAX_POINT_LIGHTS];
 	ivec4 bucketOffsetAndSize[WZ_BUCKET_DIMENSION * WZ_BUCKET_DIMENSION];
 	ivec4 PointLightsIndex[WZ_MAX_INDEXED_POINT_LIGHTS];
+	int bucketDimensionUsed;
 };
 
 layout(std140, set = 1, binding = 0) uniform meshuniforms

--- a/data/base/shaders/vk/terrain_combined.glsl
+++ b/data/base/shaders/vk/terrain_combined.glsl
@@ -31,6 +31,7 @@ layout(std140, set = 0, binding = 0) uniform cbuffer {
 	vec4 PointLightsColorAndEnergy[WZ_MAX_POINT_LIGHTS];
 	ivec4 bucketOffsetAndSize[WZ_BUCKET_DIMENSION * WZ_BUCKET_DIMENSION];
 	ivec4 PointLightsIndex[WZ_MAX_INDEXED_POINT_LIGHTS];
+	int bucketDimensionUsed;
 };
 
 // interpolated data. location count = 11

--- a/lib/ivis_opengl/gfx_api.h
+++ b/lib/ivis_opengl/gfx_api.h
@@ -1022,7 +1022,7 @@ namespace gfx_api
 		float  unused2;
 		std::array<glm::vec4, max_lights> PointLightsPosition;
 		std::array<glm::vec4, max_lights> PointLightsColorAndEnergy;
-		std::array<glm::ivec4, 64> bucketOffsetAndSize;
+		std::array<glm::ivec4, bucket_dimension * bucket_dimension> bucketOffsetAndSize;
 		std::array<glm::ivec4, max_indexed_lights> indexed_lights;
 	};
 

--- a/lib/ivis_opengl/gfx_api.h
+++ b/lib/ivis_opengl/gfx_api.h
@@ -764,6 +764,7 @@ namespace gfx_api
 		std::array<glm::vec4, max_lights> PointLightsColorAndEnergy;
 		std::array<glm::ivec4, bucket_dimension * bucket_dimension> bucketOffsetAndSize;
 		std::array<glm::ivec4, max_indexed_lights> indexed_lights;
+		int bucketDimensionUsed;
 	};
 
 	// Only change per mesh
@@ -1024,6 +1025,7 @@ namespace gfx_api
 		std::array<glm::vec4, max_lights> PointLightsColorAndEnergy;
 		std::array<glm::ivec4, bucket_dimension * bucket_dimension> bucketOffsetAndSize;
 		std::array<glm::ivec4, max_indexed_lights> indexed_lights;
+		int bucketDimensionUsed;
 	};
 
 	template<REND_MODE render_mode, SHADER_MODE shader>

--- a/lib/ivis_opengl/gfx_api_gl.cpp
+++ b/lib/ivis_opengl/gfx_api_gl.cpp
@@ -828,7 +828,7 @@ static const std::map<SHADER_MODE, program_data> shader_to_file_table =
 	std::make_pair(SHADER_COMPONENT_INSTANCED, program_data{ "Component program", "shaders/tcmask_instanced.vert", "shaders/tcmask_instanced.frag",
 		{
 			// per-frame global uniforms
-			"ProjectionMatrix", "ViewMatrix", "ModelUVLightmapMatrix", "ShadowMapMVPMatrix", "lightPosition", "sceneColor", "ambient", "diffuse", "specular", "fogColor", "ShadowMapCascadeSplits", "ShadowMapSize", "fogEnd", "fogStart", "graphicsCycle", "fogEnabled", "PointLightsPosition", "PointLightsColorAndEnergy", "bucketOffsetAndSize", "PointLightsIndex", "viewportWidth", "viewportHeight",
+			"ProjectionMatrix", "ViewMatrix", "ModelUVLightmapMatrix", "ShadowMapMVPMatrix", "lightPosition", "sceneColor", "ambient", "diffuse", "specular", "fogColor", "ShadowMapCascadeSplits", "ShadowMapSize", "fogEnd", "fogStart", "graphicsCycle", "fogEnabled", "PointLightsPosition", "PointLightsColorAndEnergy", "bucketOffsetAndSize", "PointLightsIndex", "bucketDimensionUsed", "viewportWidth", "viewportHeight",
 			// per-mesh uniforms
 			"tcmask", "normalmap", "specularmap", "hasTangents"
 		},
@@ -853,7 +853,7 @@ static const std::map<SHADER_MODE, program_data> shader_to_file_table =
 	std::make_pair(SHADER_NOLIGHT_INSTANCED, program_data{ "Plain program", "shaders/nolight_instanced.vert", "shaders/nolight_instanced.frag",
 		{
 			// per-frame global uniforms
-			"ProjectionMatrix", "ViewMatrix", "ModelUVLightmapMatrix", "ShadowMapMVPMatrix", "lightPosition", "sceneColor", "ambient", "diffuse", "specular", "fogColor", "ShadowMapCascadeSplits", "ShadowMapSize", "fogEnd", "fogStart", "graphicsCycle", "fogEnabled", "PointLightsPosition", "PointLightsColorAndEnergy", "bucketOffsetAndSize", "PointLightsIndex", "viewportWidth", "viewportHeight",
+			"ProjectionMatrix", "ViewMatrix", "ModelUVLightmapMatrix", "ShadowMapMVPMatrix", "lightPosition", "sceneColor", "ambient", "diffuse", "specular", "fogColor", "ShadowMapCascadeSplits", "ShadowMapSize", "fogEnd", "fogStart", "graphicsCycle", "fogEnabled", "PointLightsPosition", "PointLightsColorAndEnergy", "bucketOffsetAndSize", "PointLightsIndex", "bucketDimensionUsed", "viewportWidth", "viewportHeight",
 			// per-mesh uniforms
 			"tcmask", "normalmap", "specularmap", "hasTangents",
 		},
@@ -873,21 +873,21 @@ static const std::map<SHADER_MODE, program_data> shader_to_file_table =
 	std::make_pair(SHADER_TERRAIN_COMBINED_CLASSIC, program_data{ "terrain decals program", "shaders/terrain_combined.vert", "shaders/terrain_combined_classic.frag",
 			{ "ModelViewProjectionMatrix", "ViewMatrix", "ModelUVLightmapMatrix", "ShadowMapMVPMatrix", "groundScale",
 				"cameraPos", "sunPos", "emissiveLight", "ambientLight", "diffuseLight", "specularLight",
-				"fogColor", "ShadowMapCascadeSplits", "ShadowMapSize", "fogEnabled", "fogEnd", "fogStart", "quality", "PointLightsPosition", "PointLightsColorAndEnergy", "bucketOffsetAndSize", "PointLightsIndex", "viewportWidth", "viewportHeight",
+				"fogColor", "ShadowMapCascadeSplits", "ShadowMapSize", "fogEnabled", "fogEnd", "fogStart", "quality", "PointLightsPosition", "PointLightsColorAndEnergy", "bucketOffsetAndSize", "PointLightsIndex", "bucketDimensionUsed", "viewportWidth", "viewportHeight",
 				"lightmap_tex",
 				"groundTex", "groundNormal", "groundSpecular", "groundHeight",
 				"decalTex",  "decalNormal",  "decalSpecular",  "decalHeight", "shadowMap" } }),
 	std::make_pair(SHADER_TERRAIN_COMBINED_MEDIUM, program_data{ "terrain decals program", "shaders/terrain_combined.vert", "shaders/terrain_combined_medium.frag",
 			{ "ModelViewProjectionMatrix", "ViewMatrix", "ModelUVLightmapMatrix", "ShadowMapMVPMatrix", "groundScale",
 				"cameraPos", "sunPos", "emissiveLight", "ambientLight", "diffuseLight", "specularLight",
-				"fogColor", "ShadowMapCascadeSplits", "ShadowMapSize", "fogEnabled", "fogEnd", "fogStart", "quality", "PointLightsPosition", "PointLightsColorAndEnergy", "bucketOffsetAndSize", "PointLightsIndex", "viewportWidth", "viewportHeight",
+				"fogColor", "ShadowMapCascadeSplits", "ShadowMapSize", "fogEnabled", "fogEnd", "fogStart", "quality", "PointLightsPosition", "PointLightsColorAndEnergy", "bucketOffsetAndSize", "PointLightsIndex", "bucketDimensionUsed", "viewportWidth", "viewportHeight",
 				"lightmap_tex",
 				"groundTex", "groundNormal", "groundSpecular", "groundHeight",
 				"decalTex",  "decalNormal",  "decalSpecular",  "decalHeight", "shadowMap" } }),
 	std::make_pair(SHADER_TERRAIN_COMBINED_HIGH, program_data{ "terrain decals program", "shaders/terrain_combined.vert", "shaders/terrain_combined_high.frag",
 			{ "ModelViewProjectionMatrix", "ViewMatrix", "ModelUVLightmapMatrix", "ShadowMapMVPMatrix", "groundScale",
 				"cameraPos", "sunPos", "emissiveLight", "ambientLight", "diffuseLight", "specularLight",
-				"fogColor", "ShadowMapCascadeSplits", "ShadowMapSize", "fogEnabled", "fogEnd", "fogStart", "quality", "PointLightsPosition", "PointLightsColorAndEnergy", "bucketOffsetAndSize", "PointLightsIndex", "viewportWidth", "viewportHeight",
+				"fogColor", "ShadowMapCascadeSplits", "ShadowMapSize", "fogEnabled", "fogEnd", "fogStart", "quality", "PointLightsPosition", "PointLightsColorAndEnergy", "bucketOffsetAndSize", "PointLightsIndex", "bucketDimensionUsed", "viewportWidth", "viewportHeight",
 				"lightmap_tex",
 				"groundTex", "groundNormal", "groundSpecular", "groundHeight",
 				"decalTex",  "decalNormal",  "decalSpecular",  "decalHeight", "shadowMap" } }),
@@ -2107,16 +2107,17 @@ void gl_pipeline_state_object::set_constants(const gfx_api::Draw3DShapeInstanced
 	setUniforms(17, cbuf.PointLightsColorAndEnergy);
 	setUniforms(18, cbuf.bucketOffsetAndSize);
 	setUniforms(19, cbuf.indexed_lights);
-	setUniforms(20, cbuf.viewportWidth);
-	setUniforms(21, cbuf.viewportheight);
+	setUniforms(20, cbuf.bucketDimensionUsed);
+	setUniforms(21, cbuf.viewportWidth);
+	setUniforms(22, cbuf.viewportheight);
 }
 
 void gl_pipeline_state_object::set_constants(const gfx_api::Draw3DShapeInstancedPerMeshUniforms& cbuf)
 {
-	setUniforms(22, cbuf.tcmask);
-	setUniforms(23, cbuf.normalMap);
-	setUniforms(24, cbuf.specularMap);
-	setUniforms(25, cbuf.hasTangents);
+	setUniforms(23, cbuf.tcmask);
+	setUniforms(24, cbuf.normalMap);
+	setUniforms(25, cbuf.specularMap);
+	setUniforms(26, cbuf.hasTangents);
 }
 
 void gl_pipeline_state_object::set_constants(const gfx_api::Draw3DShapeInstancedDepthOnlyGlobalUniforms& cbuf)
@@ -2207,6 +2208,7 @@ void gl_pipeline_state_object::set_constants(const gfx_api::TerrainCombinedUnifo
 	setUniforms(i++, cbuf.PointLightsColorAndEnergy);
 	setUniforms(i++, cbuf.bucketOffsetAndSize);
 	setUniforms(i++, cbuf.indexed_lights);
+	setUniforms(i++, cbuf.bucketDimensionUsed);
 	setUniforms(i++, cbuf.viewportWidth);
 	setUniforms(i++, cbuf.viewportheight);
 	setUniforms(i++, 0); // lightmap_tex

--- a/lib/ivis_opengl/gfx_api_gl.cpp
+++ b/lib/ivis_opengl/gfx_api_gl.cpp
@@ -3841,7 +3841,8 @@ bool gl_context::initGLContext()
 			// (if there are duplicate uniform names).
 			//
 			// This is now handled with a workaround when processing shaders, so just log it.
-			debug(LOG_3D, "Fragment shaders do not support high precision: (highpFloat: %d; highpInt: %d)", (int)fragmentHighpFloatAvailable, (int)fragmentHighpIntAvailable);
+			debug(LOG_FATAL, "OpenGL ES: Fragment shaders do not support high precision: (highpFloat: %d; highpInt: %d)", (int)fragmentHighpFloatAvailable, (int)fragmentHighpIntAvailable);
+			// FUTURE TODO: return false;
 		}
 	}
 

--- a/lib/ivis_opengl/piedraw.cpp
+++ b/lib/ivis_opengl/piedraw.cpp
@@ -1431,7 +1431,7 @@ bool InstancedMeshRenderer::DrawAll(uint64_t currentGameFrame, const glm::mat4& 
 			projectionMatrix, viewMatrix, modelUVLightmapMatrix, {shadowCascades.shadowMVPMatrix[0], shadowCascades.shadowMVPMatrix[1], shadowCascades.shadowMVPMatrix[2]},
 			glm::vec4(currentSunPosition, 0.f), sceneColor, ambient, diffuse, specular, fogColor,
 			{shadowCascades.shadowCascadeSplit[0], shadowCascades.shadowCascadeSplit[1], shadowCascades.shadowCascadeSplit[2], pie_getPerspectiveZFar()}, shadowCascades.shadowMapSize,
-			renderState.fogBegin, renderState.fogEnd, pie_GetShaderTime(), renderState.fogEnabled, static_cast<int>(dimension.first), static_cast<int>(dimension.second), 0.f, bucketLight.positions, bucketLight.colorAndEnergy, bucketLight.bucketOffsetAndSize, bucketLight.light_index
+			renderState.fogBegin, renderState.fogEnd, pie_GetShaderTime(), renderState.fogEnabled, static_cast<int>(dimension.first), static_cast<int>(dimension.second), 0.f, bucketLight.positions, bucketLight.colorAndEnergy, bucketLight.bucketOffsetAndSize, bucketLight.light_index, static_cast<int>(bucketLight.bucketDimensionUsed)
 		};
 		Draw3DShapes_Instanced(currentGameFrame, perFrameUniformsShaderOnce, globalUniforms, drawParts, depthPass);
 	}

--- a/lib/ivis_opengl/pielighting.cpp
+++ b/lib/ivis_opengl/pielighting.cpp
@@ -171,7 +171,7 @@ void renderingNew::LightingManager::ComputeFrameData(const LightingData& data, L
 	size_t lightsCombined = 0;
 	size_t lightsSkipped = 0;
 	size_t tinyLightsSkipped = 0;
-	
+
 	culledLights.clear();
 	for (const auto& light : data.lights)
 	{
@@ -184,7 +184,7 @@ void renderingNew::LightingManager::ComputeFrameData(const LightingData& data, L
 		{
 			continue;
 		}
-		
+
 		if (light.range >= minLightRange)
 		{
 			std::pair<int32_t, int32_t> lightTileCoords(pielight_maptile_coord(light.position.x), pielight_maptile_coord(light.position.y));

--- a/lib/ivis_opengl/pielighting.cpp
+++ b/lib/ivis_opengl/pielighting.cpp
@@ -130,7 +130,7 @@ void renderingNew::LightingManager::ComputeFrameData(const LightingData& data, L
 		[](const glm::vec3& in) { return in.z <= 1; }
 	};
 
-	std::vector<LIGHT> culledLights;
+	culledLights.clear();
 	for (const auto& light : data.lights)
 	{
 		if (culledLights.size() >= gfx_api::max_lights)

--- a/lib/ivis_opengl/pielighting.cpp
+++ b/lib/ivis_opengl/pielighting.cpp
@@ -152,13 +152,13 @@ void renderingNew::LightingManager::ComputeFrameData(const LightingData& data, L
 		{
 			continue;
 		}
-		culledLights.push_back(light);
+		culledLights.push_back({light, clipSpaceBoundingBox});
 	}
 
 
 	for (size_t lightIndex = 0, end = culledLights.size(); lightIndex < end; lightIndex++)
 	{
-		const auto& light = culledLights[lightIndex];
+		const auto& light = culledLights[lightIndex].light;
 		result.positions[lightIndex].x = light.position.x;
 		result.positions[lightIndex].y = light.position.y;
 		result.positions[lightIndex].z = light.position.z;
@@ -210,8 +210,7 @@ void renderingNew::LightingManager::ComputeFrameData(const LightingData& data, L
 				{
 					continue;
 				}
-				const LIGHT& light = culledLights[lightIndex];
-				BoundingBox clipSpaceBoundingBox = transformBoundingBox(worldViewProjectionMatrix, getLightBoundingBox(light));
+				const BoundingBox& clipSpaceBoundingBox = culledLights[lightIndex].clipSpaceBoundingBox;
 
 				if (isBBoxInClipSpace(frustum, clipSpaceBoundingBox))
 				{

--- a/lib/ivis_opengl/pielighting.cpp
+++ b/lib/ivis_opengl/pielighting.cpp
@@ -24,6 +24,7 @@
 #include <glm/glm.hpp>
 #include <algorithm>
 #include <functional>
+#include <unordered_map>
 #include "culling.h"
 #include "src/profiling.h"
 
@@ -113,6 +114,29 @@ namespace {
 
 }
 
+/* The shift on a world coordinate to get the tile coordinate */
+#define TILE_SHIFT 7
+
+static inline int32_t pielight_maptile_coord(int32_t worldCoord)
+{
+	return worldCoord >> TILE_SHIFT;
+}
+
+struct TileCoordsHasher
+{
+	std::size_t operator()(const std::pair<int32_t, int32_t>& p) const
+	{
+		return std::hash<long long>()(static_cast<long long>(p.first) * (static_cast<long long>(INT_MAX) + 1) + p.second);
+	}
+};
+
+static float pointLightDistanceCalc(const renderingNew::LightingManager::CalculatedPointLight& a, const LIGHT& b)
+{
+	glm::vec3 pointLightVector = a.position - glm::vec3(b.position);
+	auto length = glm::length(pointLightVector);
+	return length;
+}
+
 void renderingNew::LightingManager::ComputeFrameData(const LightingData& data, LightMap&, const glm::mat4& worldViewProjectionMatrix)
 {
 	PointLightBuckets result;
@@ -140,6 +164,14 @@ void renderingNew::LightingManager::ComputeFrameData(const LightingData& data, L
 		[](const glm::vec3& in) { return in.z <= 1; }
 	};
 
+	std::unordered_map<std::pair<int32_t, int32_t>, std::vector<size_t>, TileCoordsHasher> tileRangeLights; // map tile coordinates to vector of culledLight indexes
+	constexpr size_t maxRangedLightsPerTile = 16;
+	constexpr size_t minLightRange = 5;
+	constexpr float distanceCalcCombineThreshold = 32.f;
+	size_t lightsCombined = 0;
+	size_t lightsSkipped = 0;
+	size_t tinyLightsSkipped = 0;
+	
 	culledLights.clear();
 	for (const auto& light : data.lights)
 	{
@@ -152,9 +184,87 @@ void renderingNew::LightingManager::ComputeFrameData(const LightingData& data, L
 		{
 			continue;
 		}
-		culledLights.push_back({light, clipSpaceBoundingBox});
+		
+		if (light.range >= minLightRange)
+		{
+			std::pair<int32_t, int32_t> lightTileCoords(pielight_maptile_coord(light.position.x), pielight_maptile_coord(light.position.y));
+			auto it = tileRangeLights.find(lightTileCoords);
+			if (it != tileRangeLights.end())
+			{
+				// merge point lights (if possible)
+				bool combinedLight = false;
+				for (auto& o : it->second)
+				{
+					auto& existingLight = culledLights[o];
+					auto newLightRange = static_cast<float>(light.range);
+					auto distanceCalc = pointLightDistanceCalc(existingLight.light, light);
+					if ((distanceCalc < distanceCalcCombineThreshold)
+						&& (distanceCalc < (existingLight.light.range + newLightRange)))
+					{
+						// Found two lights close to each other - combine them
+						if (newLightRange > existingLight.light.range)
+						{
+							// If the new light has a greater range, use that as the "base"
+							CalculatedPointLight calcLight;
+							calcLight.position = glm::vec3(light.position.x,  light.position.y, light.position.z);
+							calcLight.colour = glm::vec3(light.colour.byte.r / 255.f, light.colour.byte.g / 255.f, light.colour.byte.b / 255.f);
+							calcLight.range = light.range;
+
+							float weight = existingLight.light.range / calcLight.range;
+							calcLight.colour.x += (existingLight.light.colour.x) * weight;
+							calcLight.colour.y += (existingLight.light.colour.y) * weight;
+							calcLight.colour.z += (existingLight.light.colour.z) * weight;
+
+							existingLight.light = calcLight;
+							existingLight.clipSpaceBoundingBox = clipSpaceBoundingBox;
+						}
+						else
+						{
+							float weight = light.range / existingLight.light.range;
+							existingLight.light.colour.x += (light.colour.byte.r / 255.f) * weight;
+							existingLight.light.colour.y += (light.colour.byte.g / 255.f) * weight;
+							existingLight.light.colour.z += (light.colour.byte.b / 255.f) * weight;
+						}
+						combinedLight = true;
+						break;
+					}
+				}
+				if (combinedLight)
+				{
+					++lightsCombined;
+					continue;
+				}
+				if (it->second.size() >= maxRangedLightsPerTile)
+				{
+					++lightsSkipped;
+					continue;
+				}
+
+				it->second.push_back(culledLights.size());
+			}
+			else
+			{
+				tileRangeLights[lightTileCoords].push_back(culledLights.size());
+			}
+		}
+		else
+		{
+			++tinyLightsSkipped;
+			continue;
+		}
+
+		CalculatedPointLight calcLight;
+		calcLight.position = glm::vec3(light.position.x,  light.position.y, light.position.z);
+		calcLight.colour = glm::vec3(light.colour.byte.r / 255.f, light.colour.byte.g / 255.f, light.colour.byte.b / 255.f);
+		calcLight.range = light.range;
+
+		culledLights.push_back({std::move(calcLight), std::move(clipSpaceBoundingBox)});
 	}
 
+	if (lightsSkipped > 0 || lightsCombined > 0 || tinyLightsSkipped > 0)
+	{
+		// debug(LOG_INFO, "Point lights - merged: %zu, skipped (tile limit): %zu, skipped (tiny): %zu", lightsCombined, lightsSkipped, tinyLightsSkipped);
+	}
 
 	for (size_t lightIndex = 0, end = culledLights.size(); lightIndex < end; lightIndex++)
 	{
@@ -162,9 +272,9 @@ void renderingNew::LightingManager::ComputeFrameData(const LightingData& data, L
 		result.positions[lightIndex].x = light.position.x;
 		result.positions[lightIndex].y = light.position.y;
 		result.positions[lightIndex].z = light.position.z;
-		result.colorAndEnergy[lightIndex].x = light.colour.byte.r / 255.f;
-		result.colorAndEnergy[lightIndex].y = light.colour.byte.g / 255.f;
-		result.colorAndEnergy[lightIndex].z = light.colour.byte.b / 255.f;
+		result.colorAndEnergy[lightIndex].x = light.colour.x;
+		result.colorAndEnergy[lightIndex].y = light.colour.y;
+		result.colorAndEnergy[lightIndex].z = light.colour.z;
 		result.colorAndEnergy[lightIndex].w = light.range;
 	}
 

--- a/lib/ivis_opengl/pielighting.h
+++ b/lib/ivis_opengl/pielighting.h
@@ -97,11 +97,18 @@ namespace renderingNew
 	struct LightingManager final : ILightingManager
 	{
 		void ComputeFrameData(const LightingData& data, LightMap& lightmap, const glm::mat4& worldViewProjectionMatrix) override;
+
+		struct CalculatedPointLight
+		{
+			glm::vec3 position = glm::vec3(0, 0, 0);
+			glm::vec3 colour;
+			float range;
+		};
 	private:
 		// cached containers to avoid frequent reallocations
 		struct CulledLightInfo
 		{
-			const LIGHT& light;
+			CalculatedPointLight light;
 			BoundingBox clipSpaceBoundingBox;
 		};
 		std::vector<CulledLightInfo> culledLights;

--- a/lib/ivis_opengl/pielighting.h
+++ b/lib/ivis_opengl/pielighting.h
@@ -22,6 +22,7 @@
 
 #include "lib/ivis_opengl/pietypes.h"
 #include "gfx_api.h"
+#include "culling.h"
 #include <glm/glm.hpp>
 #include <memory>
 #include <array>
@@ -98,7 +99,12 @@ namespace renderingNew
 		void ComputeFrameData(const LightingData& data, LightMap& lightmap, const glm::mat4& worldViewProjectionMatrix) override;
 	private:
 		// cached containers to avoid frequent reallocations
-		std::vector<LIGHT> culledLights;
+		struct CulledLightInfo
+		{
+			const LIGHT& light;
+			BoundingBox clipSpaceBoundingBox;
+		};
+		std::vector<CulledLightInfo> culledLights;
 	};
 }
 

--- a/lib/ivis_opengl/pielighting.h
+++ b/lib/ivis_opengl/pielighting.h
@@ -25,6 +25,7 @@
 #include <glm/glm.hpp>
 #include <memory>
 #include <array>
+#include <vector>
 
 struct LIGHT
 {
@@ -95,6 +96,9 @@ namespace renderingNew
 	struct LightingManager final : ILightingManager
 	{
 		void ComputeFrameData(const LightingData& data, LightMap& lightmap, const glm::mat4& worldViewProjectionMatrix) override;
+	private:
+		// cached containers to avoid frequent reallocations
+		std::vector<LIGHT> culledLights;
 	};
 }
 

--- a/lib/ivis_opengl/pielighting.h
+++ b/lib/ivis_opengl/pielighting.h
@@ -70,6 +70,8 @@ struct ILightingManager
 		std::array<glm::ivec4, gfx_api::bucket_dimension * gfx_api::bucket_dimension> bucketOffsetAndSize = {};
 		// Unfortunately due to std140 constraint, we pack indexes in glm::ivec4 and unpack them in shader later
 		std::array<glm::ivec4, gfx_api::max_indexed_lights> light_index = {};
+
+		size_t bucketDimensionUsed = gfx_api::bucket_dimension;
 	};
 
 	virtual ~ILightingManager() = default;

--- a/src/effects.cpp
+++ b/src/effects.cpp
@@ -1303,8 +1303,11 @@ static bool updateFire(EFFECT *psEffect, LightingData& lightData)
 		percent = 100;
 	}
 
+	constexpr int fireLightHeightAboveGround = 28;
+
 	light.position = psEffect->position;
-	light.range = (percent * psEffect->radius * 3) / 100;
+	light.position.y += fireLightHeightAboveGround;
+	light.range = (percent * psEffect->radius * 6) / 100;
 	light.colour = pal_Colour(255, 0, 0);
 	lightData.lights.push_back(light);
 

--- a/src/terrain.cpp
+++ b/src/terrain.cpp
@@ -1928,7 +1928,7 @@ static void drawTerrainCombinedmpl(const glm::mat4 &ModelViewProjection, const g
 		glm::vec4(cameraPos, 0), glm::vec4(glm::normalize(sunPos), 0),
 		pie_GetLighting0(LIGHT_EMISSIVE), pie_GetLighting0(LIGHT_AMBIENT), pie_GetLighting0(LIGHT_DIFFUSE), pie_GetLighting0(LIGHT_SPECULAR),
 		getFogColorVec4(), {shadowCascades.shadowCascadeSplit[0], shadowCascades.shadowCascadeSplit[1], shadowCascades.shadowCascadeSplit[2], pie_getPerspectiveZFar()}, shadowCascades.shadowMapSize,
-		renderState.fogEnabled, renderState.fogBegin, renderState.fogEnd, terrainShaderQuality, static_cast<int>(dimension.first), static_cast<int>(dimension.second), 0.f, bucketLight.positions, bucketLight.colorAndEnergy, bucketLight.bucketOffsetAndSize, bucketLight.light_index
+		renderState.fogEnabled, renderState.fogBegin, renderState.fogEnd, terrainShaderQuality, static_cast<int>(dimension.first), static_cast<int>(dimension.second), 0.f, bucketLight.positions, bucketLight.colorAndEnergy, bucketLight.bucketOffsetAndSize, bucketLight.light_index, static_cast<int>(bucketLight.bucketDimensionUsed)
 	};
 	PSO::get().set_uniforms(uniforms);
 


### PR DESCRIPTION
Builds on #3698 

~~(And awaiting a bucket-related fix there, as this doesn't fully solve the issues described in that PR but _does_ make it harder to reproduce them.)~~ Now includes support for a dynamic quantity of buckets for point lighting as well, to help resolve that issue.

Uses a fairly basic algorithm to split point lights by map tile, and "merge" point lights that are close together. The visual output of this merging seems fairly reasonable (although it could certainly be adjusted in the future, as desired).

This can *massively* reduce the number of point lights per tile that are actually sent to the GPU, and yield a huge boost to performance in a number of scenarios (including the extreme-but-not-uncommon scenario described in #3698).