### PR TITLE
Classic campaign fixes

### DIFF
--- a/data/base/script/campaign/libcampaign_includes/nexus.js
+++ b/data/base/script/campaign/libcampaign_includes/nexus.js
@@ -214,7 +214,7 @@ function __camChooseNexusTarget(player)
 			{
 				return true; //Final mission has a static fail chance to hack everything.
 			}
-			else if (getResearch(cam_resistance_circuits.fourth).done)
+			else if (!camClassicMode() && getResearch(cam_resistance_circuits.fourth).done)
 			{
 				return false; //Everything is safe
 			}

--- a/data/base/script/campaign/transitionTech.js
+++ b/data/base/script/campaign/transitionTech.js
@@ -514,7 +514,7 @@ const mis_gammaResearchNewClassic = [
 	"R-Wpn-Missile-Damage02", "R-Wpn-Missile-ROF01", "R-Wpn-Missile-HvSAM", "R-Defense-SamSite2",
 	// 7
 	"R-Wpn-RailGun02", "R-Defense-Rail2", "R-Defense-WallTower-Rail2", "R-Wpn-Rail-Damage02",
-	"R-Wpn-Rail-ROF02", "R-Wpn-Rail-ROF03", "R-Wpn-MdArtMissile", "R-Wpn-Missile-Accuracy02",
+	"R-Wpn-Rail-ROF02", "R-Wpn-Rail-Damage03", "R-Wpn-Rail-ROF03", "R-Wpn-MdArtMissile", "R-Wpn-Missile-Accuracy02",
 	"R-Wpn-Missile-ROF02", "R-Defense-MdArtMissile", "R-Wpn-Laser02", "R-Defense-PulseLas",
 	"R-Wpn-Energy-ROF02", "R-Wpn-Energy-Damage03", "R-Wpn-Energy-ROF03",
 	// 8
@@ -522,7 +522,7 @@ const mis_gammaResearchNewClassic = [
 	// 9
 	"R-Vehicle-Body10", "R-Vehicle-Metals09", "R-Cyborg-Metals09", "R-Vehicle-Armor-Heat06",
 	"R-Cyborg-Armor-Heat06", "R-Vehicle-Engine09",  "R-Wpn-HvArtMissile", "R-Defense-HvyArtMissile",
-	"R-Wpn-Missile-Damage03", "R-Wpn-Missile-ROF03", "R-Wpn-RailGun03", "R-Wpn-Rail-Damage03",
+	"R-Wpn-Missile-Damage03", "R-Wpn-Missile-ROF03", "R-Wpn-RailGun03",
 	"R-Defense-Rail3", "R-Defense-WallTower-Rail3",
 ];
 

--- a/src/group.cpp
+++ b/src/group.cpp
@@ -177,8 +177,14 @@ void DROID_GROUP::remove(DROID *psDroid)
 		if (psDroid->droidType != DROID_COMMAND || type != GT_COMMAND)
 		{
 			auto it = std::find(psList.begin(), psList.end(), psDroid);
-			ASSERT(it != psList.end(), "grpLeave: droid not found");
-			psList.erase(it);
+			if (it != psList.end())
+			{
+				psList.erase(it);
+			}
+			else
+			{
+				ASSERT(false, "grpLeave: droid not found");
+			}
 		}
 
 		psDroid->psGroup = nullptr;


### PR DESCRIPTION
After now completing a run on Classic (with Autosaves-only and the 40 unit limit), I only saw one instance of needing another `camClassicMode()` check to prevent an assert on Gamma 5. Also, move a research topic in the tech-tree notes array to where it actually appears.

This PR also adds pastdue's crash fix for groups as a drive-by commit.