### PR TITLE
research.json: Add support for new "calculationMode" option, "Improved" calculation mode

### DIFF
--- a/data/mods/campaign/wz2100_camclassic/stats/research.json
+++ b/data/mods/campaign/wz2100_camclassic/stats/research.json
@@ -1,4 +1,7 @@
 {
+	"_config_": {
+		"calculationMode": "improved"
+	},
 	"ADVANCEDRESEARCH": {
 		"iconID": "IMAGE_RES_COMPUTERTECH",
 		"id": "ADVANCEDRESEARCH",

--- a/src/research.h
+++ b/src/research.h
@@ -69,6 +69,17 @@ enum
 	RID_MAXRID
 };
 
+enum class ResearchUpgradeCalculationMode
+{
+	// Default / compat cumulative upgrade handling (the only option for many years - from at least 3.x/(3.2+?)-4.4.2?)
+	// This can accumulate noticeable error, especially if repeatedly upgrading small values by small percentages (commonly impacted: armour, thermal)
+	// However, research.json created and tested during this long period may be expecting this outcome / behavior
+	Compat,
+
+	// "Improved" cumulative upgrade handling (significantly reduces accumulated errors)
+	Improved
+};
+
 /* The store for the research stats */
 extern std::vector<RESEARCH> asResearch;
 
@@ -84,6 +95,8 @@ extern SDWORD				CBResFacilityOwner;
 extern UDWORD	aDefaultSensor[MAX_PLAYERS];
 extern UDWORD	aDefaultECM[MAX_PLAYERS];
 extern UDWORD	aDefaultRepair[MAX_PLAYERS];
+
+ResearchUpgradeCalculationMode getResearchUpgradeCalcMode();
 
 bool loadResearch(WzConfig &ini);
 


### PR DESCRIPTION
The default `"calculationMode"` is `"compat"`, and functions as many previous versions for many years have. This mode can accumulate noticeable error - especially if repeatedly upgrading small values by smaller percentages (commonly impacted: armour, thermal).

The new opt-in `"calculationMode"` is `"improved"`. This handles calculating upgrades in a way that significantly reduces accumulated errors from multiple applied research upgrades to a component's value(s).

To opt-in to the new mode, add a new "_config_" dict to the top-level research.json object, specifying the desired "calculationMode".

Example:
```json
{
  "_config_": {
    "calculationMode": "improved"
  },
  ...
}
```