### PR TITLE
fixed property results in convResearch

### DIFF
--- a/src/quickjs_backend.cpp
+++ b/src/quickjs_backend.cpp
@@ -781,7 +781,7 @@ JSValue convResearch(const RESEARCH *psResearch, JSContext *ctx, int player)
 	QuickJS_DefinePropertyValue(ctx, value, "name", JS_NewString(ctx, psResearch->id.toUtf8().c_str()), JS_PROP_ENUMERABLE); // will be changed to contain fullname
 	QuickJS_DefinePropertyValue(ctx, value, "id", JS_NewString(ctx, psResearch->id.toUtf8().c_str()), JS_PROP_ENUMERABLE);
 	QuickJS_DefinePropertyValue(ctx, value, "type", JS_NewInt32(ctx, SCRIPT_RESEARCH), JS_PROP_ENUMERABLE);
-	QuickJS_DefinePropertyValue(ctx, value, "results", mapJsonToQuickJSValue(ctx, psResearch->results, 0), JS_PROP_ENUMERABLE);
+	QuickJS_DefinePropertyValue(ctx, value, "results", mapJsonToQuickJSValue(ctx, psResearch->results, JS_PROP_ENUMERABLE), JS_PROP_ENUMERABLE);
 	return value;
 }
 

--- a/src/quickjs_backend.cpp
+++ b/src/quickjs_backend.cpp
@@ -756,7 +756,7 @@ static int QuickJS_DefinePropertyValue(JSContext *ctx, JSValueConst this_obj, co
 //;; * ```name``` A string containing the full name of the research.
 //;; * ```id``` A string containing the index name of the research.
 //;; * ```type``` The type will always be ```RESEARCH_DATA```.
-//;; * ```results``` An array of coefficients effected by research upgrades (defined in "research.json").
+//;; * ```results``` An array of objects of research upgrades (defined in "research.json").
 //;;
 JSValue convResearch(const RESEARCH *psResearch, JSContext *ctx, int player)
 {

--- a/src/quickjs_backend.cpp
+++ b/src/quickjs_backend.cpp
@@ -756,6 +756,7 @@ static int QuickJS_DefinePropertyValue(JSContext *ctx, JSValueConst this_obj, co
 //;; * ```name``` A string containing the full name of the research.
 //;; * ```id``` A string containing the index name of the research.
 //;; * ```type``` The type will always be ```RESEARCH_DATA```.
+//;; * ```results``` An array of coefficients effected by research upgrades (defined in "research.json").
 //;;
 JSValue convResearch(const RESEARCH *psResearch, JSContext *ctx, int player)
 {


### PR DESCRIPTION
the convResearch have output property "results" undocumented, it is an array of empty objects,
QuickJS_DefinePropertyValue(ctx, value, "results", mapJsonToQuickJSValue(ctx, psResearch->results, 0), JS_PROP_ENUMERABLE);
JSON.stringify(getResearch("R-Wpn-Cannon-ROF06",me).results) -> [{},{}]
new Array(100000).fill(0).forEach(i=>getResearch("R-Wpn-Cannon-ROF06",me)) 2.2s E5-2683 v4 @ 1.20GHz

if add JS_PROP_ENUMERABLE, "results" will be array of normal objects
QuickJS_DefinePropertyValue(ctx, value, "results", mapJsonToQuickJSValue(ctx, psResearch->results, JS_PROP_ENUMERABLE), JS_PROP_ENUMERABLE);
JSON.stringify(getResearch("R-Wpn-Cannon-ROF06",me).results) -> [{"class":"Weapon","filterParameter":"ImpactClass","filterValue":"CANNON","parameter":"FirePause","value":-10},{"class":"Weapon","filterParameter":"ImpactClass","filterValue":"CANNON","parameter":"ReloadTime","value":-10}]
new Array(100000).fill(0).forEach(i=>getResearch("R-Wpn-Cannon-ROF06",me)) 2.3s E5-2683 v4 @ 1.20GHz

It not performance bottleneck, and it make AI that have adaptive research path possible