### PR TITLE
netplay: Enable TCP_NODELAY for game sockets

### DIFF
--- a/lib/netplay/netplay.h
+++ b/lib/netplay/netplay.h
@@ -443,6 +443,8 @@ void NETsetJoinPreferenceIPv6(bool bTryIPv6First);
 bool NETgetJoinPreferenceIPv6();
 void NETsetDefaultMPHostFreeChatPreference(bool enabled);
 bool NETgetDefaultMPHostFreeChatPreference();
+void NETsetEnableTCPNoDelay(bool enabled);
+bool NETgetEnableTCPNoDelay();
 
 void NETsetGamePassword(const char *password);
 void NETBroadcastPlayerInfo(uint32_t index);

--- a/lib/netplay/netsocket.h
+++ b/lib/netplay/netsocket.h
@@ -116,6 +116,8 @@ ssize_t readAll(Socket& sock, void *buf, size_t size, unsigned timeout);///< Rea
 WZ_DECL_NONNULL(2)
 ssize_t writeAll(Socket& sock, const void *buf, size_t size, size_t *rawByteCount = nullptr);  ///< Nonblocking write of size bytes to the Socket. All bytes will be written asynchronously, by a separate thread. Raw count of bytes (after compression) returned in rawByteCount, which will often be 0 until the socket is flushed.
 
+bool socketSetTCPNoDelay(Socket& sock, bool nodelay); ///< nodelay = true disables the Nagle algorithm for TCP socket
+
 // Sockets, compressed.
 void socketBeginCompression(Socket& sock); ///< Makes future data sent compressed, and future data received expected to be compressed.
 bool socketReadDisconnected(const Socket& sock);  ///< If readNoInt returned 0, returns true if this is the result of a disconnect, or false if the input compressed data just hasn't produced any output bytes.

--- a/src/configuration.cpp
+++ b/src/configuration.cpp
@@ -423,6 +423,7 @@ bool loadConfig()
 	}
 	NETsetJoinPreferenceIPv6(iniGetBool("prefer_ipv6", true).value());
 	NETsetDefaultMPHostFreeChatPreference(iniGetBool("hostingChatDefault", NETgetDefaultMPHostFreeChatPreference()).value());
+	NETsetEnableTCPNoDelay(iniGetBool("tcp_nodelay", NETgetEnableTCPNoDelay()).value());
 	setPublicIPv4LookupService(iniGetString("publicIPv4LookupService_Url", WZ_DEFAULT_PUBLIC_IPv4_LOOKUP_SERVICE_URL).value(), iniGetString("publicIPv4LookupService_JSONKey", WZ_DEFAULT_PUBLIC_IPv4_LOOKUP_SERVICE_JSONKEY).value());
 	setPublicIPv6LookupService(iniGetString("publicIPv6LookupService_Url", WZ_DEFAULT_PUBLIC_IPv6_LOOKUP_SERVICE_URL).value(), iniGetString("publicIPv6LookupService_JSONKey", WZ_DEFAULT_PUBLIC_IPv6_LOOKUP_SERVICE_JSONKEY).value());
 	war_SetFMVmode((FMV_MODE)iniGetInteger("FMVmode", war_GetFMVmode()).value());
@@ -722,6 +723,8 @@ bool saveConfig()
 	}
 	iniSetBool("prefer_ipv6", NETgetJoinPreferenceIPv6());
 	iniSetInteger("hostingChatDefault", (NETgetDefaultMPHostFreeChatPreference()) ? 1 : 0);
+	iniSetInteger("tcp_nodelay", (NETgetEnableTCPNoDelay()) ? 1 : 0);
+
 	iniSetString("publicIPv4LookupService_Url", getPublicIPv4LookupServiceUrl());
 	iniSetString("publicIPv4LookupService_JSONKey", getPublicIPv4LookupServiceJSONKey());
 	iniSetString("publicIPv6LookupService_Url", getPublicIPv6LookupServiceUrl());


### PR DESCRIPTION
Among other reasons, we already use an internal buffer.

References:
https://brooker.co.za/blog/2024/05/09/nagle.html