### PR TITLE
[GitHub Actions] Generate artifact attestations to establish build provenance

### DIFF
--- a/.github/workflows/CI_flatpak.yml
+++ b/.github/workflows/CI_flatpak.yml
@@ -41,6 +41,9 @@ jobs:
     name: '${{ matrix.name }} (${{ matrix.arch }})'
     permissions:
       contents: read
+      # needed to generate artifact attestations, see: https://docs.github.com/en/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds
+      id-token: write
+      attestations: write
     runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, '[ci skip]')"
     env:
@@ -264,6 +267,13 @@ jobs:
         path: |
           output_debug_dependency_snapshot
         if-no-files-found: 'error'
+    - name: Generate artifact attestation
+      # Run on push to master branch (development build), or tag release automation build
+      if: success() && ((github.event_name == 'push' && github.ref == 'refs/heads/master') || (github.event_name == 'workflow_run' && github.event.workflow_run.name == 'Draft Tag Release'))
+      uses: actions/attest-build-provenance@v1
+      continue-on-error: true
+      with:
+        subject-path: '${{ steps.settings.outputs.WZ_FLATPAK_BUNDLE }}'
     ###############################################################
     # Package the ostree repo (for use in later publish-release-to-flathub job)
     - name: Tar ostree repo

--- a/.github/workflows/CI_macos.yml
+++ b/.github/workflows/CI_macos.yml
@@ -210,6 +210,9 @@ jobs:
     name: 'Package Universal Binary'
     permissions:
       contents: write # Needed to upload to releases
+      # needed to generate artifact attestations, see: https://docs.github.com/en/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds
+      id-token: write
+      attestations: write
     needs: macos-build
     runs-on: macos-latest
     steps:
@@ -295,6 +298,13 @@ jobs:
           name: "warzone2100_macOS_universal"
           path: ${{ env.WZ_FULL_OUTPUT_ZIP_PATH }}
           if-no-files-found: 'error'
+      - name: 'Generate artifact attestation - (full)'
+        # Run on push to master branch (development build), or tag release automation build
+        if: success() && ((github.event_name == 'push' && github.ref == 'refs/heads/master') || (github.event_name == 'workflow_run' && github.event.workflow_run.name == 'Draft Tag Release'))
+        uses: actions/attest-build-provenance@v1
+        continue-on-error: true
+        with:
+          subject-path: '${{ env.WZ_FULL_OUTPUT_ZIP_PATH }}'
       - name: Upload "universal" to release
         if: success() && (github.event_name == 'workflow_run' && github.event.workflow_run.name == 'Draft Tag Release') && (github.repository == 'Warzone2100/warzone2100')
         run: |
@@ -353,6 +363,13 @@ jobs:
           name: "warzone2100_macOS_universal_novideos"
           path: ${{ env.WZ_FULL_OUTPUT_ZIP_PATH }}
           if-no-files-found: 'error'
+      - name: 'Generate artifact attestation - (novideos)'
+        # Run on push to master branch (development build), or tag release automation build
+        if: success() && ((github.event_name == 'push' && github.ref == 'refs/heads/master') || (github.event_name == 'workflow_run' && github.event.workflow_run.name == 'Draft Tag Release'))
+        uses: actions/attest-build-provenance@v1
+        continue-on-error: true
+        with:
+          subject-path: '${{ env.WZ_FULL_OUTPUT_ZIP_PATH }}'
       - name: Upload "universal_novideos" to release
         if: success() && (github.event_name == 'workflow_run' && github.event.workflow_run.name == 'Draft Tag Release') && (github.repository == 'Warzone2100/warzone2100')
         run: |

--- a/.github/workflows/CI_snapcraft.yml
+++ b/.github/workflows/CI_snapcraft.yml
@@ -32,6 +32,9 @@ jobs:
     name: '${{ matrix.name }}'
     permissions:
       contents: write # Needed to upload to releases
+      # needed to generate artifact attestations, see: https://docs.github.com/en/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds
+      id-token: write
+      attestations: write
     runs-on: ubuntu-20.04 # Use instead of ubuntu-latest until https://github.com/snapcore/action-build/issues/42 is resolved
     if: "!contains(github.event.head_commit.message, '[ci skip]')"
     steps:
@@ -118,6 +121,13 @@ jobs:
         name: 'warzone2100_linux_${{ matrix.arch }}_snap'
         path: '${{ env.WZ_FULL_OUTPUT_SNAP_PATH }}'
         if-no-files-found: 'error'
+    - name: Generate artifact attestation
+      # Run on push to master branch (development build), or tag release automation build
+      if: success() && ((github.event_name == 'push' && github.ref == 'refs/heads/master') || (github.event_name == 'workflow_run' && github.event.workflow_run.name == 'Draft Tag Release'))
+      uses: actions/attest-build-provenance@v1
+      continue-on-error: true
+      with:
+        subject-path: '${{ env.WZ_FULL_OUTPUT_SNAP_PATH }}'
     - name: Upload artifact to release
       if: success() && (github.event_name == 'workflow_run' && github.event.workflow_run.name == 'Draft Tag Release')
       run: |

--- a/.github/workflows/CI_ubuntu.yml
+++ b/.github/workflows/CI_ubuntu.yml
@@ -61,6 +61,9 @@ jobs:
     name: '${{ matrix.name }}'
     permissions:
       contents: write # Needed to upload to releases
+      # needed to generate artifact attestations, see: https://docs.github.com/en/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds
+      id-token: write
+      attestations: write
     runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, '[ci skip]')"
     outputs:
@@ -195,6 +198,13 @@ jobs:
         path: |
           ${{ github.workspace }}/debug
         if-no-files-found: 'error'
+    - name: Generate artifact attestation
+      # Run on push to master branch (development build), or tag release automation build
+      if: success() && (matrix.publish_artifact == true) && ((github.event_name == 'push' && github.ref == 'refs/heads/master') || (github.event_name == 'workflow_run' && github.event.workflow_run.name == 'Draft Tag Release'))
+      uses: actions/attest-build-provenance@v1
+      continue-on-error: true
+      with:
+        subject-path: '${{ env.WZ_FULL_OUTPUT_DEB_PATH }}'
     - name: Upload artifact to release
       if: success() && (github.event_name == 'workflow_run' && github.event.workflow_run.name == 'Draft Tag Release') && (matrix.deploy_release == true)
       run: |
@@ -209,6 +219,9 @@ jobs:
     name: Package Source (Ubuntu 22.04) [GCC]
     permissions:
       contents: write # Needed to upload to releases
+      # needed to generate artifact attestations, see: https://docs.github.com/en/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds
+      id-token: write
+      attestations: write
     runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, '[ci skip]')"
     steps:
@@ -279,6 +292,13 @@ jobs:
         name: warzone2100_src
         path: ${{ env.OUTPUT_DIR }}
         if-no-files-found: 'error'
+    - name: Generate artifact attestation
+      # Run on push to master branch (development build), or tag release automation build
+      if: success() && ((github.event_name == 'push' && github.ref == 'refs/heads/master') || (github.event_name == 'workflow_run' && github.event.workflow_run.name == 'Draft Tag Release'))
+      uses: actions/attest-build-provenance@v1
+      continue-on-error: true
+      with:
+        subject-path: '${{ env.OUTPUT_DIR }}/warzone2100_src.tar.xz'
     - name: Upload source tarball to release
       if: success() && (github.event_name == 'workflow_run' && github.event.workflow_run.name == 'Draft Tag Release')
       run: |

--- a/.github/workflows/CI_windows.yml
+++ b/.github/workflows/CI_windows.yml
@@ -66,6 +66,9 @@ jobs:
     name: '${{ matrix.architecture }} [${{ matrix.compiler }}]'
     permissions:
       contents: write # Needed to upload to releases
+      # needed to generate artifact attestations, see: https://docs.github.com/en/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds
+      id-token: write
+      attestations: write
     runs-on: windows-2022
     if: "!contains(github.event.head_commit.message, '[ci skip]')"
     steps:
@@ -679,6 +682,30 @@ jobs:
         name: warzone2100_${{ steps.settings.outputs.WZ_BUILD_DESC }}_archive
         path: '${{ github.workspace }}\output\archive'
         if-no-files-found: 'error'
+    #####################################################
+    # Generate artifact attestations
+    #####################################################
+    - name: 'Generate artifact attestation - (Portable Build)'
+      # Run on push to master branch (development build), or tag release automation build
+      if: success() && ((github.event_name == 'push' && github.ref == 'refs/heads/master') || (github.event_name == 'workflow_run' && github.event.workflow_run.name == 'Draft Tag Release'))
+      uses: actions/attest-build-provenance@v1
+      continue-on-error: true
+      with:
+        subject-path: '${{ github.workspace }}\output\portable\*'
+    - name: 'Generate artifact attestation - (Regular Installer)'
+      # Run on push to master branch (development build), or tag release automation build
+      if: success() && ((github.event_name == 'push' && github.ref == 'refs/heads/master') || (github.event_name == 'workflow_run' && github.event.workflow_run.name == 'Draft Tag Release'))
+      uses: actions/attest-build-provenance@v1
+      continue-on-error: true
+      with:
+        subject-path: '${{ github.workspace }}\output\installer\*'
+    - name: 'Generate artifact attestation - (Archive)'
+      # Run on push to master branch (development build), or tag release automation build
+      if: success() && ((github.event_name == 'push' && github.ref == 'refs/heads/master') || (github.event_name == 'workflow_run' && github.event.workflow_run.name == 'Draft Tag Release'))
+      uses: actions/attest-build-provenance@v1
+      continue-on-error: true
+      with:
+        subject-path: '${{ github.workspace }}\output\archive\*'
     #####################################################
     # Upload Release assets (if a release tag)
     #####################################################


### PR DESCRIPTION
This can then be verified with different tools, including the GitHub CLI: https://docs.github.com/en/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds#verifying-artifact-attestations-with-the-github-cli

For more information, see:
https://github.blog/2024-05-02-introducing-artifact-attestations-now-in-public-beta/
https://docs.github.com/en/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds

