### PR TITLE
Fixes for campaign mods

### DIFF
--- a/lib/sequence/sequence.cpp
+++ b/lib/sequence/sequence.cpp
@@ -617,7 +617,7 @@ void update_buffers()
 	videoGfx->buffers(NUM_VERTICES, vertices, texcoords);
 }
 
-bool seq_Play(const std::shared_ptr<VideoProvider> &video)
+bool seq_Play(std::shared_ptr<VideoProvider> video)
 {
 	int pp_level_max = 0;
 	int pp_level = 0;

--- a/lib/sequence/sequence.cpp
+++ b/lib/sequence/sequence.cpp
@@ -638,8 +638,7 @@ bool seq_Play(std::shared_ptr<VideoProvider> video)
 		return false;
 	}
 
-	inVideoProvider = video;
-	inVideoProvider->seek_begin();
+	video->seek_begin();
 
 	theora_p = 0;
 	vorbis_p = 0;
@@ -648,7 +647,7 @@ bool seq_Play(std::shared_ptr<VideoProvider> video)
 	/* Only interested in Vorbis/Theora streams */
 	while (!stateflag)
 	{
-		int ret = inVideoProvider->buffer_data(&videodata.oy);
+		int ret = video->buffer_data(&videodata.oy);
 
 		if (ret == 0)
 		{
@@ -743,7 +742,7 @@ bool seq_Play(std::shared_ptr<VideoProvider> video)
 		}
 		else
 		{
-			ret = inVideoProvider->buffer_data(&videodata.oy);   /* someone needs more data */
+			ret = video->buffer_data(&videodata.oy);   /* someone needs more data */
 
 			if (ret == 0)
 			{
@@ -839,6 +838,7 @@ bool seq_Play(std::shared_ptr<VideoProvider> video)
 		example_encoder (and most streams) though. */
 	sampletimeOffset = getTimeNow();
 	videoplaying = true;
+	inVideoProvider = video; // only set this here (after videoplaying is set), so that it's always freed in seq_Shutdown()
 	return true;
 }
 

--- a/lib/sequence/sequence.h
+++ b/lib/sequence/sequence.h
@@ -36,7 +36,7 @@ class VideoProvider;
 std::shared_ptr<VideoProvider> makeVideoProvider(PHYSFS_file *in, const WzString& filename);
 std::shared_ptr<VideoProvider> makeVideoProvider(std::shared_ptr<const std::vector<char>> memoryBuffer, const WzString& filename);
 
-bool seq_Play(const std::shared_ptr<VideoProvider>& video);
+bool seq_Play(std::shared_ptr<VideoProvider> video);
 bool seq_Playing();
 bool seq_Update();
 void seq_Shutdown();

--- a/src/intelmap.cpp
+++ b/src/intelmap.cpp
@@ -137,7 +137,7 @@ static bool				playCurrent;
 
 /* functions declarations ****************/
 static const char* getMessageTitle(const MESSAGE& message);
-static void StartMessageSequences(MESSAGE *psMessage, bool Start);
+static bool StartMessageSequences(MESSAGE *psMessage, bool Start);
 /*Displays the buttons used on the intelligence map */
 class IntMessageButton : public IntFancyButton
 {
@@ -689,11 +689,8 @@ void W_INTELLIGENCEOVERLAY_FORM::intIntelButtonPressed(const std::shared_ptr<Int
 				{
 					intShowMessageView(psMessage);
 				}
-				// only attempt to show videos if they are installed
-				if (seq_hasVideos())
-				{
-					StartMessageSequences(psMessage, true);
-				}
+				// attempt to show video(s)
+				StartMessageSequences(psMessage, true);
 			}
 			else if (psMessage->pViewData->type == VIEW_RES)
 			{
@@ -835,7 +832,7 @@ bool intAddIntelMap()
 }
 
 // Add all the Video Sequences for a message
-static void StartMessageSequences(MESSAGE *psMessage, bool Start)
+static bool StartMessageSequences(MESSAGE *psMessage, bool Start)
 {
 	bool bLoop = false;
 
@@ -844,10 +841,10 @@ static void StartMessageSequences(MESSAGE *psMessage, bool Start)
 	//should never have a proximity message here
 	if (psMessage->type == MSG_PROXIMITY)
 	{
-		return;
+		return false;
 	}
 
-	ASSERT_OR_RETURN(, psMessage->pViewData != nullptr, "Invalid ViewData pointer");
+	ASSERT_OR_RETURN(false, psMessage->pViewData != nullptr, "Invalid ViewData pointer");
 
 	if (psMessage->pViewData->type == VIEW_RPL)
 	{
@@ -878,10 +875,12 @@ static void StartMessageSequences(MESSAGE *psMessage, bool Start)
 		//play first full screen video
 		if (Start == true)
 		{
-			seq_StartNextFullScreenVideo();
+			if (!seq_StartNextFullScreenVideo())
+			{
+				return false;
+			}
 		}
 	}
-
 	else if (psMessage->pViewData->type == VIEW_RES)
 	{
 		VIEW_RESEARCH		*psViewReplay;
@@ -894,10 +893,18 @@ static void StartMessageSequences(MESSAGE *psMessage, bool Start)
 		//play first full screen video
 		if (Start == true)
 		{
-			seq_StartNextFullScreenVideo();
+			if (!seq_StartNextFullScreenVideo())
+			{
+				return false;
+			}
 		}
 	}
+	else
+	{
+		return false;
+	}
 
+	return true;
 }
 
 static void intCleanUpIntelMap()
@@ -1264,11 +1271,11 @@ void displayImmediateMessage(MESSAGE *psMessage)
 		This has to be changed to support a script calling a message in the intelligence screen
 	*/
 
-	// only attempt to show videos if they are installed
-	if (seq_hasVideos())
+	// attempt to show video(s)
+	psCurrentMsg = psMessage;
+	if (!StartMessageSequences(psMessage, true))
 	{
-	    psCurrentMsg = psMessage;
-	    StartMessageSequences(psMessage, true);
+		psCurrentMsg = nullptr;
 	}
 	// remind the player that the message can be seen again from
 	// the intelligence screen

--- a/src/loop.cpp
+++ b/src/loop.cpp
@@ -751,8 +751,9 @@ void videoLoop()
 		seq_StopFullScreenVideo();
 
 		//set the next video off - if any
-		if (videoFinished && seq_AnySeqLeft())
+		if (seq_AnySeqLeft())
 		{
+			skipCounter = 0;
 			seq_StartNextFullScreenVideo();
 		}
 		else

--- a/src/seqdisp.cpp
+++ b/src/seqdisp.cpp
@@ -481,11 +481,13 @@ static bool seqPlayOrQueueFetch(const WzString& videoName, const WzString& audio
 	}
 	else
 	{
-		if (!onDemandVideoProvider.hasBaseURLPath())
+		bool isNoVideo = videoName.startsWith("novideo");
+
+		if (!onDemandVideoProvider.hasBaseURLPath() || isNoVideo)
 		{
 			// no on-demand fallback available - log the failure to open local file
 			code_part log_part = LOG_INFO;
-			if (videoName.compare("novideo.ogg") == 0 || videoName.compare("novideo.ogv") == 0)
+			if (isNoVideo)
 			{
 				// in these special cases, don't clutter the logs with LOG_INFO level events
 				log_part = LOG_VIDEO;

--- a/src/seqdisp.cpp
+++ b/src/seqdisp.cpp
@@ -719,6 +719,7 @@ bool seq_UpdateFullScreenVideo()
 void seqReleaseAll()
 {
 	seq_Shutdown();
+	aVideoProvider.reset();
 	wzCachedSeqText.clear();
 }
 
@@ -733,6 +734,7 @@ bool seq_StopFullScreenVideo()
 
 	seq_Shutdown();
 
+	aVideoProvider.reset();
 	wzCachedSeqText.clear();
 
 	return true;

--- a/src/seqdisp.h
+++ b/src/seqdisp.h
@@ -87,7 +87,7 @@ void seq_SetSubtitles(bool bNewState);
 bool seq_GetSubtitles();
 
 /*returns the next sequence in the list to play*/
-void seq_StartNextFullScreenVideo();
+bool seq_StartNextFullScreenVideo();
 
 void seqReleaseAll();
 

--- a/src/titleui/campaign.cpp
+++ b/src/titleui/campaign.cpp
@@ -1219,6 +1219,7 @@ private:
 	std::shared_ptr<WzFrontendImageButton> resetButton;
 	std::shared_ptr<ScrollableListWidget> tweaksDisplayList;
 	std::vector<std::shared_ptr<WzCampaignTweakOptionToggle>> toggleWidgets;
+	std::unordered_map<size_t, size_t> tweakOptionIdxToToggleWidgetIdxMap;
 	std::shared_ptr<std::vector<WzCampaignTweakOptionSetting>> tweakOptions;
 	int innerPadding = 20;
 	int betweenButtonPadding = 15;
@@ -1292,6 +1293,7 @@ void WzCampaignTweakOptionsEditForm::initialize(const std::shared_ptr<std::vecto
 
 		toggleWidgets.push_back(toggleWidget);
 		tweaksDisplayList->addItem(toggleWidget);
+		tweakOptionIdxToToggleWidgetIdxMap.insert({i, toggleWidgets.size() - 1});
 	}
 
 	int listY0 = formTitle->y() + formTitle->height() + innerPadding;
@@ -1375,7 +1377,12 @@ void WzCampaignTweakOptionsEditForm::resetToDefaults()
 	{
 		auto& o = (*tweakOptions)[i];
 		o.currentValue = o.defaultValue;
-		toggleWidgets[i]->setIsChecked(o.defaultValue);
+		auto it = tweakOptionIdxToToggleWidgetIdxMap.find(i);
+		if (it != tweakOptionIdxToToggleWidgetIdxMap.end())
+		{
+			ASSERT(it->second < toggleWidgets.size(), "Invalid index: %zu", it->second);
+			toggleWidgets[it->second]->setIsChecked(o.defaultValue);
+		}
 	}
 	updateResetButtonStatus();
 }

--- a/src/titleui/campaign.cpp
+++ b/src/titleui/campaign.cpp
@@ -2102,15 +2102,12 @@ void CampaignStartOptionsForm::handleStartGame()
 	sstrcpy(aLevelName, campaignFile.level.toUtf8().c_str());
 	setCampaignName(campaignFile.name.toStdString());
 
-	// show this only when the video sequences are installed
-	if (seq_hasVideos())
+	// show video
+	if (!campaignFile.video.isEmpty())
 	{
-		if (!campaignFile.video.isEmpty())
-		{
-			seq_ClearSeqList();
-			seq_AddSeqToList(campaignFile.video.toUtf8().c_str(), nullptr, campaignFile.captions.toUtf8().c_str(), false);
-			seq_StartNextFullScreenVideo();
-		}
+		seq_ClearSeqList();
+		seq_AddSeqToList(campaignFile.video.toUtf8().c_str(), nullptr, campaignFile.captions.toUtf8().c_str(), false);
+		seq_StartNextFullScreenVideo();
 	}
 
 	// set tweak options

--- a/src/wzapi.cpp
+++ b/src/wzapi.cpp
@@ -2436,11 +2436,8 @@ bool wzapi::gameOverMessage(WZAPI_PARAMS(bool gameWon, optional<bool> _showBackD
 		if (gameWon && showOutro)
 		{
 			showBackDrop = false;
-			if (seq_hasVideos())
-			{
-				seq_AddSeqToList("outro.ogg", nullptr, "outro.txa", false);
-				seq_StartNextFullScreenVideo();
-			}
+			seq_AddSeqToList("outro.ogg", nullptr, "outro.txa", false);
+			seq_StartNextFullScreenVideo();
 		}
 		else
 		{


### PR DESCRIPTION
- campaign.cpp: Fix crash resetting tweak options to defaults
  - If some were excluded from display / skipped
- Fix VideoProvider leaks
  - which could lead to issues unloading a campaign mod (if it provided its own videos)
- videoLoop: Fix skipping videos (when multiple video sequences are queued)
- Improve onDemandVideoProvider failure handling
- seqPlayOrQueueFetch: Remove old "novideo.ogg" hack, silence logs for requests for "novideo.ogg" / "novideo.ogv" (or if falling back to on-demand provider)
- seq_StartFullScreenVideo: Only start loop video playback mode if seqPlayOrQueueFetch succeeds
  - This avoids a blank screen / flicker for a frame if the video can't be loaded (and means we can safely attempt to start a fullscreen video without knowing whether videos are installed or not)

With these changes, `seq_hasVideos()` should generally only be used for notifying the user now.

(`seq_hasVideos()` itself only does detection for built-in campaign videos, but it's possible that a campaign mod might bundle its own videos - so we just want to always attempt to load the video in most cases, now that `seq_StartNextFullScreenVideo()` avoids triggering a blank screen / flicker if the video can't be found)