### PR TITLE
Fix Nexus research for 3.2 balance

### DIFF
--- a/data/base/script/campaign/cam3-a.js
+++ b/data/base/script/campaign/cam3-a.js
@@ -298,7 +298,8 @@ function cam3Setup()
 			camClassicResearch(mis_gammaStartingResearchClassic, CAM_HUMAN_PLAYER);
 			completeResearch("CAM2RESEARCH-UNDO", CAM_HUMAN_PLAYER);
 			completeResearch("CAM3RESEARCH-UNDO", CAM_HUMAN_PLAYER);
-			//Nexus has no research in 3.2
+			//Nexus only has auto-repair and the NavGunSensor for 3.2
+			camClassicResearch(cam_nexusSpecialResearch, CAM_NEXUS);
 		}
 		else
 		{

--- a/data/base/script/campaign/libcampaign.js
+++ b/data/base/script/campaign/libcampaign.js
@@ -281,7 +281,7 @@ var __camPropulsionTypeLimit;
 
 //research
 const __CAM_AI_INSTANT_PRODUCTION_RESEARCH = "R-Struc-Factory-Upgrade-AI";
-const __cam_nexusTech = [
+const cam_nexusSpecialResearch = [
 	"R-Sys-NEXUSrepair", "R-Sys-NEXUSsensor"
 ];
 

--- a/data/base/script/campaign/libcampaign_includes/research.js
+++ b/data/base/script/campaign/libcampaign_includes/research.js
@@ -16,8 +16,9 @@ function camEnableRes(researchIds, playerId)
 	for (let i = 0, l = researchIds.length; i < l; ++i)
 	{
 		const __RESEARCH_ID = researchIds[i];
+		const __FORCE = (cam_nexusSpecialResearch.indexOf(__RESEARCH_ID) !== -1);
 		enableResearch(__RESEARCH_ID, playerId);
-		completeResearch(__RESEARCH_ID, playerId);
+		completeResearch(__RESEARCH_ID, playerId, __FORCE);
 	}
 }
 
@@ -42,7 +43,7 @@ function camCompleteRequiredResearch(researchIds, playerId)
 		if (reqRes.length === 0)
 		{
 			//HACK: autorepair like upgrades don't work after mission transition.
-			if (__cam_nexusTech.indexOf(__RESEARCH_ID) !== -1)
+			if (cam_nexusSpecialResearch.indexOf(__RESEARCH_ID) !== -1)
 			{
 				completeResearch(__RESEARCH_ID, playerId, true);
 			}


### PR DESCRIPTION
- Give auto-repair and the NavGunSensor on Gamma 1.
- Force research auto-repair and NavGunSensor in the camEnableRes() function used for 3.2 balance. As done in camCompleteRequiredResearch().