### PR TITLE
Fix: Actually load saved research state before any droids or structures are loaded

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2822,6 +2822,19 @@ bool loadGame(const char *pGameToLoad, bool keepObjects, bool freeMem, bool User
 		}
 	}
 
+	//if user save game then load up the research BEFORE any droids or structures are loaded
+	if (gameType == GTYPE_SAVE_START || gameType == GTYPE_SAVE_MIDMISSION)
+	{
+		//load in the research list file
+		aFileName[fileExten] = '\0';
+		strcat(aFileName, "resstate.json");
+		if (!loadSaveResearch(aFileName))
+		{
+			debug(LOG_ERROR, "Failed to load research data from %s", aFileName);
+			goto error;
+		}
+	}
+
 	if (saveGameOnMission && UserSaveGame)
 	{
 		//the scroll limits for the mission map have already been written
@@ -3021,19 +3034,6 @@ bool loadGame(const char *pGameToLoad, bool keepObjects, bool freeMem, bool User
 
 	//adjust the scroll range for the new map or the expanded map
 	setMapScroll();
-
-	//if user save game then load up the research BEFORE any droids or structures are loaded
-	if (gameType == GTYPE_SAVE_START || gameType == GTYPE_SAVE_MIDMISSION)
-	{
-		//load in the research list file
-		aFileName[fileExten] = '\0';
-		strcat(aFileName, "resstate.json");
-		if (!loadSaveResearch(aFileName))
-		{
-			debug(LOG_ERROR, "Failed to load research data from %s", aFileName);
-			goto error;
-		}
-	}
 
 	if (IsScenario)
 	{

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -7414,6 +7414,7 @@ bool loadSaveResearch(const char *pFileName)
 			int points = json_getValue(pointsList, plr).toInt();
 
 			psPlRes = &asPlayerResList[plr][statInc];
+			bool resAlreadyCompleted = IsResearchCompleted(psPlRes);
 			// Copy the research status
 			psPlRes->ResearchStatus = (researched & RESBITS_ALL);
 			SetResearchPossible(psPlRes, possible);
@@ -7421,7 +7422,14 @@ bool loadSaveResearch(const char *pFileName)
 			//for any research that has been completed - perform so that upgrade values are set up
 			if (researched == RESEARCHED)
 			{
-				researchResult(statInc, plr, false, nullptr, false);
+				if (!resAlreadyCompleted)
+				{
+					researchResult(statInc, plr, false, nullptr, false);
+				}
+				else
+				{
+					debug(LOG_INFO, "Player %d already completed research: %s - skipping re-apply", plr, name.toUtf8().c_str());
+				}
 			}
 		}
 		ini.endGroup();

--- a/src/keybind.cpp
+++ b/src/keybind.cpp
@@ -1492,7 +1492,6 @@ void	kf_FinishAllResearch()
 			}
 			else
 			{
-				MakeResearchCompleted(&asPlayerResList[selectedPlayer][j]);
 				researchResult(j, selectedPlayer, false, nullptr, false);
 			}
 		}
@@ -1561,18 +1560,27 @@ void	kf_FinishResearch()
 				if (pSubject)
 				{
 					int rindex = ((RESEARCH*)pSubject)->index;
-					if (bMultiMessages)
+					PLAYER_RESEARCH *plrRes = &asPlayerResList[selectedPlayer][rindex];
+					if (!IsResearchCompleted(plrRes))
 					{
-						SendResearch(selectedPlayer, rindex, true);
-						// Wait for our message before doing anything.
+						if (bMultiMessages)
+						{
+							SendResearch(selectedPlayer, rindex, true);
+							// Wait for our message before doing anything.
+						}
+						else
+						{
+							researchResult(rindex, selectedPlayer, true, psCurr, true);
+						}
+						std::string cmsg = astringf(_("(Player %u) is using cheat :%s %s"), selectedPlayer, _("Researched"), getLocalizedStatsName(pSubject));
+						sendInGameSystemMessage(cmsg.c_str());
+						intResearchFinished(psCurr);
 					}
 					else
 					{
-						researchResult(rindex, selectedPlayer, true, psCurr, true);
+						debug(LOG_ERROR, "Research already completed for player %" PRIu32 "?: %s", (int)selectedPlayer, getStatsName(pSubject));
+						continue;
 					}
-					std::string cmsg = astringf(_("(Player %u) is using cheat :%s %s"), selectedPlayer, _("Researched"), getLocalizedStatsName(pSubject));
-					sendInGameSystemMessage(cmsg.c_str());
-					intResearchFinished(psCurr);
 				}
 			}
 		}

--- a/src/multigifts.cpp
+++ b/src/multigifts.cpp
@@ -378,7 +378,6 @@ static void giftResearch(uint8_t from, uint8_t to, bool send)
 			if (IsResearchCompleted(&asPlayerResList[from][i])
 			    && !IsResearchCompleted(&asPlayerResList[to][i]))
 			{
-				MakeResearchCompleted(&asPlayerResList[to][i]);
 				researchResult(i, to, false, nullptr, true);
 			}
 		}

--- a/src/multiplay.cpp
+++ b/src/multiplay.cpp
@@ -1465,7 +1465,6 @@ static bool recvResearch(NETQUEUE queue)
 
 	if (!IsResearchCompleted(pPlayerRes))
 	{
-		MakeResearchCompleted(pPlayerRes);
 		researchResult(index, player, false, nullptr, true);
 	}
 
@@ -1481,7 +1480,6 @@ static bool recvResearch(NETQUEUE queue)
 				if (!IsResearchCompleted(pPlayerRes))
 				{
 					// Do the research for that player
-					MakeResearchCompleted(pPlayerRes);
 					researchResult(index, i, false, nullptr, true);
 				}
 			}


### PR DESCRIPTION
This previously occurred *after* the `mstruct.json` (etc) were loaded, causing issues like re-application of upgrade effects on certain attributes of existing home map structures (when loading an away mission save).

(Although it properly happened before the regular `struct.json` (etc) were loaded, so the bug only impacted home map objects when loading an away mission save.)