### PR TITLE
Fix Build menu tab jumping

### DIFF
--- a/src/hci/build.cpp
+++ b/src/hci/build.cpp
@@ -137,7 +137,7 @@ void BuildController::refresh()
 void BuildController::clearData()
 {
 	builders.clear();
-	setHighlightedObject(nullptr);
+	setHighlightedObject(nullptr, false);
 	stats.clear();
 }
 
@@ -153,12 +153,12 @@ void BuildController::toggleBuilderSelection(DROID *droid)
 		{
 			highlightedObject->selected = true;
 		}
-		selectObject(droid);
+		selectObject(droid, false);
 	}
 	triggerEventSelected();
 }
 
-void BuildController::setHighlightedObject(BASE_OBJECT *object)
+void BuildController::setHighlightedObject(BASE_OBJECT *object, bool jumpToHighlightedStatsObject)
 {
 	if (object == nullptr)
 	{
@@ -169,6 +169,7 @@ void BuildController::setHighlightedObject(BASE_OBJECT *object)
 	auto builder = castDroid(object);
 	ASSERT_NOT_NULLPTR_OR_RETURN(, builder);
 	ASSERT_OR_RETURN(, builder->isConstructionDroid(), "Droid is not a construction droid");
+	queuedJumpToHighlightedStatsObject = queuedJumpToHighlightedStatsObject || jumpToHighlightedStatsObject;
 	highlightedBuilder = builder;
 }
 
@@ -196,7 +197,7 @@ public:
 		}
 
 		controller->clearSelection();
-		controller->selectObject(controller->getObjectAt(objectIndex));
+		controller->selectObject(controller->getObjectAt(objectIndex), false);
 		jump();
 
 		BaseStatsController::scheduleDisplayStatsForm(controller);
@@ -397,7 +398,7 @@ private:
 		else
 		{
 			controller->clearSelection();
-			controller->selectObject(droid);
+			controller->selectObject(droid, true);
 		}
 
 		BaseStatsController::scheduleDisplayStatsForm(controller);
@@ -412,7 +413,7 @@ private:
 		// prevent highlighting a builder when another builder is already selected
 		if (droid == highlighted || !highlighted->selected)
 		{
-			controller->setHighlightedObject(droid);
+			controller->setHighlightedObject(droid, true);
 			BaseStatsController::scheduleDisplayStatsForm(controller);
 		}
 	}

--- a/src/hci/build.h
+++ b/src/hci/build.h
@@ -111,7 +111,7 @@ private:
 	void updateBuildOptionsList();
 	std::vector<STRUCTURE_STATS *> stats;
 	std::vector<DROID *> builders;
-	bool queuedJumpToHighlightedStatsObject = false;
+	bool queuedJumpToHighlightedStatsObject = true;
 
 	static bool showFavorites;
 	static DROID *highlightedBuilder;

--- a/src/hci/build.h
+++ b/src/hci/build.h
@@ -94,13 +94,24 @@ public:
 		return highlightedBuilder;
 	}
 
-	void setHighlightedObject(BASE_OBJECT *object) override;
+	void setHighlightedObject(BASE_OBJECT *object, bool jumpToHighlightedStatsObject) override;
+
+	bool getQueuedJumpToHighlightedStatsObject() const override
+	{
+		return queuedJumpToHighlightedStatsObject;
+	}
+
+	void clearQueuedJumpToHighlightedStatsObject() override
+	{
+		queuedJumpToHighlightedStatsObject = false;
+	}
 
 private:
 	void updateBuildersList();
 	void updateBuildOptionsList();
 	std::vector<STRUCTURE_STATS *> stats;
 	std::vector<DROID *> builders;
+	bool queuedJumpToHighlightedStatsObject = false;
 
 	static bool showFavorites;
 	static DROID *highlightedBuilder;

--- a/src/hci/commander.cpp
+++ b/src/hci/commander.cpp
@@ -82,10 +82,10 @@ void CommanderController::refresh()
 void CommanderController::clearData()
 {
 	commanders.clear();
-	setHighlightedObject(nullptr);
+	setHighlightedObject(nullptr, false);
 }
 
-void CommanderController::setHighlightedObject(BASE_OBJECT *object)
+void CommanderController::setHighlightedObject(BASE_OBJECT *object, bool jumpToHighlightedStatsObject)
 {
 	if (object == nullptr)
 	{
@@ -96,6 +96,7 @@ void CommanderController::setHighlightedObject(BASE_OBJECT *object)
 	auto commander = castDroid(object);
 	ASSERT_NOT_NULLPTR_OR_RETURN(, commander);
 	ASSERT_OR_RETURN(, commander->droidType == DROID_COMMAND, "Droid is not a commander");
+	queuedJumpToHighlightedStatsObject = queuedJumpToHighlightedStatsObject || jumpToHighlightedStatsObject;
 	highlightedCommander = commander;
 }
 
@@ -120,7 +121,7 @@ public:
 	void clickPrimary() override
 	{
 		controller->clearSelection();
-		controller->selectObject(controller->getObjectAt(objectIndex));
+		controller->selectObject(controller->getObjectAt(objectIndex), false);
 		jump();
 		controller->displayOrderForm();
 	}
@@ -293,7 +294,7 @@ private:
 		auto droid = controller->getObjectAt(objectIndex);
 		ASSERT_NOT_NULLPTR_OR_RETURN(, droid);
 		controller->clearSelection();
-		controller->selectObject(droid);
+		controller->selectObject(droid, true);
 		controller->displayOrderForm();
 	}
 
@@ -306,7 +307,7 @@ private:
 		// prevent highlighting a commander when another commander is already selected
 		if (droid == highlighted || (highlighted && !highlighted->selected))
 		{
-			controller->setHighlightedObject(droid);
+			controller->setHighlightedObject(droid, true);
 			controller->displayOrderForm();
 		}
 	}

--- a/src/hci/commander.h
+++ b/src/hci/commander.h
@@ -71,7 +71,7 @@ public:
 private:
 	void updateCommandersList();
 	std::vector<DROID *> commanders;
-	bool queuedJumpToHighlightedStatsObject = false;
+	bool queuedJumpToHighlightedStatsObject = true;
 	static DROID *highlightedCommander;
 };
 

--- a/src/hci/commander.h
+++ b/src/hci/commander.h
@@ -56,11 +56,22 @@ public:
 		return highlightedCommander;
 	}
 
-	void setHighlightedObject(BASE_OBJECT *object) override;
+	void setHighlightedObject(BASE_OBJECT *object, bool jumpToHighlightedStatsObject) override;
+
+	bool getQueuedJumpToHighlightedStatsObject() const override
+	{
+		return queuedJumpToHighlightedStatsObject;
+	}
+
+	void clearQueuedJumpToHighlightedStatsObject() override
+	{
+		queuedJumpToHighlightedStatsObject = false;
+	}
 
 private:
 	void updateCommandersList();
 	std::vector<DROID *> commanders;
+	bool queuedJumpToHighlightedStatsObject = false;
 	static DROID *highlightedCommander;
 };
 

--- a/src/hci/manufacture.cpp
+++ b/src/hci/manufacture.cpp
@@ -184,11 +184,11 @@ void ManufactureController::refresh()
 void ManufactureController::clearData()
 {
 	factories.clear();
-	setHighlightedObject(nullptr);
+	setHighlightedObject(nullptr, false);
 	stats.clear();
 }
 
-void ManufactureController::setHighlightedObject(BASE_OBJECT *object)
+void ManufactureController::setHighlightedObject(BASE_OBJECT *object, bool jumpToHighlightedStatsObject)
 {
 	if (object == nullptr)
 	{
@@ -198,6 +198,7 @@ void ManufactureController::setHighlightedObject(BASE_OBJECT *object)
 
 	auto factory = castStructure(object);
 	ASSERT_OR_RETURN(, factory && factory->isFactory(), "Invalid factory pointer");
+	queuedJumpToHighlightedStatsObject = queuedJumpToHighlightedStatsObject || jumpToHighlightedStatsObject;
 	highlightedFactory = factory;
 }
 
@@ -231,7 +232,7 @@ public:
 	void clickPrimary() override
 	{
 		controller->clearStructureSelection();
-		controller->selectObject(controller->getObjectAt(objectIndex));
+		controller->selectObject(controller->getObjectAt(objectIndex), false);
 		jump();
 		BaseStatsController::scheduleDisplayStatsForm(controller);
 	}
@@ -470,7 +471,7 @@ private:
 		ASSERT_NOT_NULLPTR_OR_RETURN(, factory);
 		controller->releaseFactoryProduction(factory);
 		controller->clearStructureSelection();
-		controller->selectObject(factory);
+		controller->selectObject(factory, true);
 		BaseStatsController::scheduleDisplayStatsForm(controller);
 	}
 
@@ -480,7 +481,7 @@ private:
 		ASSERT_NOT_NULLPTR_OR_RETURN(, factory);
 		controller->clearStructureSelection();
 		controller->cancelFactoryProduction(factory);
-		controller->setHighlightedObject(factory);
+		controller->setHighlightedObject(factory, true);
 		controller->refresh();
 		BaseStatsController::scheduleDisplayStatsForm(controller);
 	}

--- a/src/hci/manufacture.h
+++ b/src/hci/manufacture.h
@@ -80,13 +80,24 @@ public:
 		return highlightedFactory;
 	}
 
-	void setHighlightedObject(BASE_OBJECT *object) override;
+	void setHighlightedObject(BASE_OBJECT *object, bool jumpToHighlightedStatsObject) override;
+
+	bool getQueuedJumpToHighlightedStatsObject() const override
+	{
+		return queuedJumpToHighlightedStatsObject;
+	}
+
+	void clearQueuedJumpToHighlightedStatsObject() override
+	{
+		queuedJumpToHighlightedStatsObject = false;
+	}
 
 private:
 	void updateFactoriesList();
 	void updateManufactureOptionsList();
 	std::vector<DROID_TEMPLATE *> stats;
 	std::vector<STRUCTURE *> factories;
+	bool queuedJumpToHighlightedStatsObject = false;
 	static STRUCTURE *highlightedFactory;
 };
 

--- a/src/hci/manufacture.h
+++ b/src/hci/manufacture.h
@@ -97,7 +97,7 @@ private:
 	void updateManufactureOptionsList();
 	std::vector<DROID_TEMPLATE *> stats;
 	std::vector<STRUCTURE *> factories;
-	bool queuedJumpToHighlightedStatsObject = false;
+	bool queuedJumpToHighlightedStatsObject = true;
 	static STRUCTURE *highlightedFactory;
 };
 

--- a/src/hci/objects_stats.cpp
+++ b/src/hci/objects_stats.cpp
@@ -43,13 +43,13 @@ void BaseObjectsController::clearStructureSelection()
 	}
 }
 
-void BaseObjectsController::selectObject(BASE_OBJECT *object)
+void BaseObjectsController::selectObject(BASE_OBJECT *object, bool jumpToHighlightedStatsObject)
 {
 	ASSERT_NOT_NULLPTR_OR_RETURN(, object);
 	object->selected = true;
 	triggerEventSelected();
 	jsDebugSelected(object);
-	setHighlightedObject(object);
+	setHighlightedObject(object, jumpToHighlightedStatsObject);
 	refresh();
 }
 
@@ -69,14 +69,14 @@ void BaseObjectsController::updateHighlighted()
 {
 	if (objectsSize() == 0)
 	{
-		setHighlightedObject(nullptr);
+		setHighlightedObject(nullptr, false);
 		return;
 	}
 
 	auto findAnySelectedObject = [&] (BASE_OBJECT *object) {
 		if (object->died == 0 && object->selected)
 		{
-			setHighlightedObject(object);
+			setHighlightedObject(object, false);
 			return true;
 		}
 
@@ -93,7 +93,7 @@ void BaseObjectsController::updateHighlighted()
 		auto findHighlightedObject = [&] (BASE_OBJECT *object) {
 			if (object->died == 0 && object == highlighted)
 			{
-				setHighlightedObject(object);
+				setHighlightedObject(object, false);
 				return true;
 			}
 
@@ -106,7 +106,7 @@ void BaseObjectsController::updateHighlighted()
 		}
 	}
 
-	setHighlightedObject(getObjectAt(0));
+	setHighlightedObject(getObjectAt(0), false);
 }
 
 void BaseStatsController::displayStatsForm()
@@ -418,11 +418,13 @@ void BaseObjectsStatsController::updateHighlightedObjectStats()
 void ObjectStatsForm::updateLayout()
 {
 	BaseWidget::updateLayout();
-	getController().updateHighlightedObjectStats();
+	auto& controller = getController();
+	controller.updateHighlightedObjectStats();
 	auto highlighted = getController().getHighlightedObjectStats();
-	if (highlighted != nullptr && previousHighlighted != highlighted)
+	if (highlighted != nullptr && controller.getQueuedJumpToHighlightedStatsObject())
 	{
 		goToHighlightedTab();
+		controller.clearQueuedJumpToHighlightedStatsObject();
 	}
 	previousHighlighted = highlighted;
 }

--- a/src/hci/objects_stats.h
+++ b/src/hci/objects_stats.h
@@ -46,10 +46,12 @@ public:
 	void updateHighlighted();
 	void clearSelection();
 	void clearStructureSelection();
-	void selectObject(BASE_OBJECT *object);
+	void selectObject(BASE_OBJECT *object, bool jumpToHighlightedStatsObject);
 
 	virtual BASE_OBJECT *getHighlightedObject() const = 0;
-	virtual void setHighlightedObject(BASE_OBJECT *object) = 0;
+	virtual void setHighlightedObject(BASE_OBJECT *object, bool jumpToHighlightedStatsObject) = 0;
+	virtual bool getQueuedJumpToHighlightedStatsObject() const = 0;
+	virtual void clearQueuedJumpToHighlightedStatsObject() = 0;
 
 	void closeInterface()
 	{

--- a/src/hci/research.cpp
+++ b/src/hci/research.cpp
@@ -134,7 +134,7 @@ void ResearchController::refresh()
 void ResearchController::clearData()
 {
 	facilities.clear();
-	setHighlightedObject(nullptr);
+	setHighlightedObject(nullptr, false);
 	stats.clear();
 }
 
@@ -186,7 +186,7 @@ void ResearchController::startResearch(RESEARCH &research)
 	stopReticuleButtonFlash(IDRET_RESEARCH);
 }
 
-void ResearchController::setHighlightedObject(BASE_OBJECT *object)
+void ResearchController::setHighlightedObject(BASE_OBJECT *object, bool jumpToHighlightedStatsObject)
 {
 	if (object == nullptr)
 	{
@@ -197,6 +197,7 @@ void ResearchController::setHighlightedObject(BASE_OBJECT *object)
 	auto facility = castStructure(object);
 	ASSERT_NOT_NULLPTR_OR_RETURN(, facility);
 	ASSERT_OR_RETURN(, facility->pStructureType->type == REF_RESEARCH, "Invalid facility pointer");
+	queuedJumpToHighlightedStatsObject = queuedJumpToHighlightedStatsObject || jumpToHighlightedStatsObject;
 	highlightedFacility = facility;
 }
 
@@ -298,7 +299,7 @@ protected:
 	void clickPrimary() override
 	{
 		controller->clearStructureSelection();
-		controller->selectObject(controller->getObjectAt(objectIndex));
+		controller->selectObject(controller->getObjectAt(objectIndex), false);
 		jump();
 		BaseStatsController::scheduleDisplayStatsForm(controller);
 	}
@@ -469,7 +470,7 @@ private:
 		//might need to cancel the hold on research facility
 		releaseResearch(facility, ModeQueue);
 		controller->clearStructureSelection();
-		controller->selectObject(facility);
+		controller->selectObject(facility, true);
 		BaseStatsController::scheduleDisplayStatsForm(controller);
 		controller->refresh();
 	}
@@ -480,7 +481,7 @@ private:
 		ASSERT_NOT_NULLPTR_OR_RETURN(, facility);
 		controller->clearStructureSelection();
 		controller->requestResearchCancellation(facility);
-		controller->setHighlightedObject(facility);
+		controller->setHighlightedObject(facility, true);
 		BaseStatsController::scheduleDisplayStatsForm(controller);
 		controller->refresh();
 	}

--- a/src/hci/research.h
+++ b/src/hci/research.h
@@ -85,7 +85,7 @@ private:
 	void updateResearchOptionsList();
 	std::vector<RESEARCH *> stats;
 	std::vector<STRUCTURE *> facilities;
-	bool queuedJumpToHighlightedStatsObject = false;
+	bool queuedJumpToHighlightedStatsObject = true;
 	static STRUCTURE *highlightedFacility;
 };
 

--- a/src/hci/research.h
+++ b/src/hci/research.h
@@ -68,13 +68,24 @@ public:
 		return highlightedFacility;
 	}
 
-	void setHighlightedObject(BASE_OBJECT *object) override;
+	void setHighlightedObject(BASE_OBJECT *object, bool jumpToHighlightedStatsObject) override;
+
+	bool getQueuedJumpToHighlightedStatsObject() const override
+	{
+		return queuedJumpToHighlightedStatsObject;
+	}
+
+	void clearQueuedJumpToHighlightedStatsObject() override
+	{
+		queuedJumpToHighlightedStatsObject = false;
+	}
 
 private:
 	void updateFacilitiesList();
 	void updateResearchOptionsList();
 	std::vector<RESEARCH *> stats;
 	std::vector<STRUCTURE *> facilities;
+	bool queuedJumpToHighlightedStatsObject = false;
 	static STRUCTURE *highlightedFacility;
 };
 


### PR DESCRIPTION
Fixes: #3807

Previously, ObjectStatsForm called goToHighlightedTab() whenever the highlighted object stats button changed. This could cause the stats window to jump between pages as builders (etc) finished an item and switched to a new item, making it troublesome to queue a new item.

Now, it will only jump to the tab when a user clicks the stats button in the object form (i.e. the button above the builder in the list of builders, or above the factory in the list of factories, etc), or when opening the menu.