### PR TITLE
Fixes for MP rules script

### DIFF
--- a/data/mp/multiplay/script/rules/events/gameinit.js
+++ b/data/mp/multiplay/script/rules/events/gameinit.js
@@ -4,7 +4,7 @@ function eventGameInit()
 	setupGame();
 
 	//From script/rules/printsettings.js
-	printGameSettings();
+	queue("printGameSettings", TICK_TIME);
 
 	//From script/rules/oildrum.js
 	oilDrumInit();

--- a/data/mp/multiplay/script/rules/events/gameinit.js
+++ b/data/mp/multiplay/script/rules/events/gameinit.js
@@ -49,7 +49,7 @@ function eventGameInit()
 
 	//Structures might have been removed so we need to update the reticule button states again
 	//From script/rules/reticule.js
-	setMainReticule();
+	queue("setMainReticule", TICK_TIME);
 
 	if (tilesetType === "URBAN" || tilesetType === "ROCKIES")
 	{

--- a/data/mp/multiplay/script/rules/includes.js
+++ b/data/mp/multiplay/script/rules/includes.js
@@ -7,7 +7,7 @@ include("multiplay/script/rules/variables.js");
 // This file contain functions which contains the logic of technology research equated to time
 include("multiplay/script/functions/camTechEnabler.js");
 
-// Spectial effects of weather.
+// Special effects of weather.
 include("multiplay/script/functions/weather.js");
 
 /* *** SETUP *** */
@@ -35,7 +35,7 @@ include("multiplay/script/rules/reticule.js");
 // Logic and rules of "End conditions" of the match.
 include("multiplay/script/rules/endconditions.js");
 
-// Logic of places oil barrels on the battlefield
+// Logic of placing oil barrels on the battlefield
 include("multiplay/script/rules/oildrum.js");
 
 /* *** EVENTS *** */
@@ -55,5 +55,5 @@ include("multiplay/script/rules/events/chat.js");
 
 /* *** MODS *** */
 //All mods, as well as modpacks, must start in this file.
-//At the moment, it's an empty stub doll.
+//At the moment, it's an empty stub.
 include("multiplay/script/mods/init.js");

--- a/data/mp/multiplay/script/rules/reticule.js
+++ b/data/mp/multiplay/script/rules/reticule.js
@@ -154,7 +154,6 @@ function reticuleUpdate(obj, eventType)
 	if (mainReticule && update_reticule)
 	{
 		//Wait a tick for the counts to update
-		const TICK_TIME = 100;
 		queue("setMainReticule", TICK_TIME);
 	}
 }

--- a/data/mp/multiplay/script/rules/setup/components.js
+++ b/data/mp/multiplay/script/rules/setup/components.js
@@ -1,5 +1,4 @@
 function setupComponents(player)	// inside hackNetOff()
 {
-	// enable cyborgs components that can't be enabled with research
-	makeComponentAvailable("CyborgSpade", player);
+	// Use makeComponentAvailable() here to enable components at the start of a match.
 }

--- a/data/mp/multiplay/script/rules/setupgame.js
+++ b/data/mp/multiplay/script/rules/setupgame.js
@@ -35,6 +35,6 @@ function setupGame()
 	setDesign(true);
 
 	showInterface(); // init buttons. This MUST come before setting the reticule button data
-	setMainReticule();
+	queue("setMainReticule", TICK_TIME);
 	mainReticule = true;
 }

--- a/data/mp/multiplay/script/rules/variables.js
+++ b/data/mp/multiplay/script/rules/variables.js
@@ -7,6 +7,8 @@ var oilDrumData = {
 	maxOilDrums: 0 // maximum amount of random oil drums allowed on the map
 };
 
+const TICK_TIME = 100;
+
 const CREATE_LIKE_EVENT = 0;
 const DESTROY_LIKE_EVENT = 1;
 const TRANSFER_LIKE_EVENT = 2;

--- a/data/mp/stats/research.json
+++ b/data/mp/stats/research.json
@@ -3129,9 +3129,6 @@
 		"name": "Engineering",
 		"researchPoints": 1200,
 		"researchPower": 37,
-		"resultComponents": [
-			"CyborgSpade"
-		],
 		"results": [
 			{
 				"class": "Construct",
@@ -3426,7 +3423,8 @@
 		"name": "Construction Unit",
 		"researchPoints": 10,
 		"resultComponents": [
-			"Spade1Mk1"
+			"Spade1Mk1",
+			"CyborgSpade"
 		],
 		"statID": "Spade1Mk1",
 		"techCode": 1


### PR DESCRIPTION
- Reticule buttons were assuming `removObject()` had immediate effect (as before #3736). Resulting in an incorrect reticule button state where many buttons were available at the start of a No Bases match.
- Delays the match settings message by a tick making it show up. I assume something with how console messages are displayed isn't the same as it was when this was first introduced.
- Fixes some comments.
- Move `CyborgSpade` into the automatically researched truck component research as we can definitely enable cyborg components through research. Thus removing a weird unnecessary hack in the scripts.