### PR TITLE
Added map search functionality

### DIFF
--- a/src/multiint.cpp
+++ b/src/multiint.cpp
@@ -6252,18 +6252,6 @@ void WzMultiplayerOptionsTitleUI::processMultiopWidgets(UDWORD id)
 		case MULTIOP_GNAME_ICON:
 			break;
 
-		case MULTIOP_MAP:
-			widgDelete(psWScreen, MULTIOP_PLAYERS);
-			widgDelete(psWScreen, FRONTEND_SIDETEXT2);  // del text too,
-
-			debug(LOG_WZ, "processMultiopWidgets[MULTIOP_MAP_ICON]: %s.wrf", MultiCustomMapsPath);
-			addMultiRequest(MultiCustomMapsPath, ".wrf", MULTIOP_MAP, 0, widgGetString(psWScreen, MULTIOP_MAP));
-
-			widgSetString(psWScreen, MULTIOP_MAP + 1 , game.map); //What a horrible hack! FIX ME! (See addBlueForm())
-			widgReveal(psWScreen, MULTIOP_MAP_MOD);
-			widgReveal(psWScreen, MULTIOP_MAP_RANDOM);
-			break;
-
 		case MULTIOP_MAP_ICON:
 			widgDelete(psWScreen, MULTIOP_PLAYERS);
 			widgDelete(psWScreen, FRONTEND_SIDETEXT2);					// del text too,

--- a/src/multiint.h
+++ b/src/multiint.h
@@ -171,7 +171,7 @@ void multiClearHostRequestMoveToPlayer(uint32_t playerIdx);
 #define MULTIOP_PLAYERSW		298
 #define MULTIOP_PLAYERS_TABS	10232
 #define MULTIOP_PLAYERS_TABS_H	24
-#define MULTIOP_PLAYERSH		(380 + MULTIOP_PLAYERS_TABS_H + 1)
+#define MULTIOP_PLAYERSH		(384 + MULTIOP_PLAYERS_TABS_H + 1)
 
 #define MULTIOP_ROW_WIDTH		298
 
@@ -208,6 +208,8 @@ void multiClearHostRequestMoveToPlayer(uint32_t playerIdx);
 
 #define MULTIOP_EDITBOXW		196
 #define	MULTIOP_EDITBOXH		30
+
+#define MULTIOP_SEARCHBOXH		15
 
 #define	MULTIOP_BLUEFORMW		226
 

--- a/src/multimenu.cpp
+++ b/src/multimenu.cpp
@@ -35,6 +35,7 @@
 #include "lib/widget/widget.h"
 #include "lib/widget/multibutform.h"
 #include "lib/widget/paneltabbutton.h"
+#include "lib/widget/editbox.h"
 
 #include "display3d.h"
 #include "intdisplay.h"
@@ -416,6 +417,19 @@ void addMultiRequest(const char *searchDir, const char *fileExtension, UDWORD mo
 	requestForm->setCalcLayout(LAMBDA_CALCLAYOUT_SIMPLE({
 		psWidget->setGeometry(M_REQUEST_X, M_REQUEST_Y, M_REQUEST_W, M_REQUEST_H);
 	}));
+
+	// Add the search edit box
+	auto searchBox = std::make_shared<W_EDITBOX>();
+	requestForm->attach(searchBox);
+	searchBox->setGeometry(3, requestForm->height() - MULTIOP_SEARCHBOXH - 3, requestForm->width() - 6, MULTIOP_SEARCHBOXH);
+	searchBox->setBoxColours(WZCOL_MENU_BORDER, WZCOL_MENU_BORDER, WZCOL_MENU_BACKGROUND);
+	searchBox->setPlaceholder(_("Search for map"));
+	searchBox->setString(WzString::fromUtf8(current_searchString));
+
+	searchBox->setOnReturnHandler([searchDir, fileExtension, mode, numPlayers](W_EDITBOX& widg) {
+		closeMultiRequester();
+		addMultiRequest(searchDir, fileExtension, mode, numPlayers, widg.getString().toUtf8());
+	});
 
 	// Add the close button.
 	W_BUTINIT sButInit;

--- a/src/multimenu.cpp
+++ b/src/multimenu.cpp
@@ -418,19 +418,6 @@ void addMultiRequest(const char *searchDir, const char *fileExtension, UDWORD mo
 		psWidget->setGeometry(M_REQUEST_X, M_REQUEST_Y, M_REQUEST_W, M_REQUEST_H);
 	}));
 
-	// Add the search edit box
-	auto searchBox = std::make_shared<W_EDITBOX>();
-	requestForm->attach(searchBox);
-	searchBox->setGeometry(3, requestForm->height() - MULTIOP_SEARCHBOXH - 3, requestForm->width() - 6, MULTIOP_SEARCHBOXH);
-	searchBox->setBoxColours(WZCOL_MENU_BORDER, WZCOL_MENU_BORDER, WZCOL_MENU_BACKGROUND);
-	searchBox->setPlaceholder(_("Search for map"));
-	searchBox->setString(WzString::fromUtf8(current_searchString));
-
-	searchBox->setOnReturnHandler([searchDir, fileExtension, mode, numPlayers](W_EDITBOX& widg) {
-		closeMultiRequester();
-		addMultiRequest(searchDir, fileExtension, mode, numPlayers, widg.getString().toUtf8());
-	});
-
 	// Add the close button.
 	W_BUTINIT sButInit;
 	sButInit.formID = M_REQUEST;
@@ -486,6 +473,19 @@ void addMultiRequest(const char *searchDir, const char *fileExtension, UDWORD mo
 		/* Update the init struct for the next button */
 		++nextButtonId;
 		return true; // continue
+	});
+
+	// Add the search edit box
+	auto searchBox = std::make_shared<W_EDITBOX>();
+	requestForm->attach(searchBox);
+	searchBox->setGeometry(3, requestForm->height() - MULTIOP_SEARCHBOXH - 3, requestForm->width() - 6, MULTIOP_SEARCHBOXH);
+	searchBox->setBoxColours(WZCOL_MENU_BORDER, WZCOL_MENU_BORDER, WZCOL_MENU_BACKGROUND);
+	searchBox->setPlaceholder(_("Search for map"));
+	searchBox->setString(WzString::fromUtf8(current_searchString));
+
+	searchBox->setOnReturnHandler([searchDir, fileExtension, mode, numPlayers](W_EDITBOX& widg) {
+		closeMultiRequester();
+		addMultiRequest(searchDir, fileExtension, mode, numPlayers, widg.getString().toUtf8());
 	});
 
 	multiRequestUp = true;

--- a/src/multimenu.cpp
+++ b/src/multimenu.cpp
@@ -483,9 +483,13 @@ void addMultiRequest(const char *searchDir, const char *fileExtension, UDWORD mo
 	searchBox->setPlaceholder(_("Search for map"));
 	searchBox->setString(WzString::fromUtf8(current_searchString));
 
-	searchBox->setOnReturnHandler([searchDir, fileExtension, mode, numPlayers](W_EDITBOX& widg) {
+	searchBox->setOnEditingStoppedHandler([searchDir, fileExtension, mode, numPlayers](W_EDITBOX& widg) {
+		const std::string &value = widg.getString().toUtf8();
+		if (value == current_searchString) {
+			return;
+		}
 		closeMultiRequester();
-		addMultiRequest(searchDir, fileExtension, mode, numPlayers, widg.getString().toUtf8());
+		addMultiRequest(searchDir, fileExtension, mode, numPlayers, value);
 	});
 
 	multiRequestUp = true;

--- a/src/multimenu.cpp
+++ b/src/multimenu.cpp
@@ -484,7 +484,7 @@ void addMultiRequest(const char *searchDir, const char *fileExtension, UDWORD mo
 	searchBox->setString(WzString::fromUtf8(current_searchString));
 
 	searchBox->setOnEditingStoppedHandler([searchDir, fileExtension, mode, numPlayers](W_EDITBOX& widg) {
-		const std::string &value = widg.getString().toUtf8();
+		std::string value = widg.getString().toUtf8();
 		if (value == current_searchString) {
 			return;
 		}


### PR DESCRIPTION
Added functionality for searching maps. The interesting thing is that it was already halfway added, but there are no widgets to control the sorting of maps (or did I not find it? :D).

![screen1](https://github.com/Warzone2100/warzone2100/assets/3750982/4247b552-71d8-4842-ae29-9182a1dd9597)

![screen2](https://github.com/Warzone2100/warzone2100/assets/3750982/24264f1c-a964-4ea9-8956-f561f220c053)

This will be very useful for those who have a lot of maps.

P.S. Can I set “maps with any number of players” as the default filter?
