### PR TITLE
Add "isFlying" JS field to Droid objects

### DIFF
--- a/doc/js-objects.md
+++ b/doc/js-objects.md
@@ -95,6 +95,7 @@ the action directly, but it may be interesting to look at what it currently is.
 * ```experience``` Amount of experience this droid has, based on damage it has dealt to enemies.
 * ```cost``` What it would cost to build the droid. (3.2+ only)
 * ```isVTOL``` True if the droid is VTOL. (3.2+ only)
+* ```isFlying``` True if the droid is currently flying. (4.6.0+ only)
 * ```canHitAir``` True if the droid has anti-air capabilities. (3.2+ only)
 * ```canHitGround``` True if the droid has anti-ground capabilities. (3.2+ only)
 * ```isSensor``` True if the droid has sensor ability. (3.2+ only)

--- a/src/action.cpp
+++ b/src/action.cpp
@@ -586,7 +586,7 @@ static bool actionRemoveDroidsFromBuildPos(unsigned player, Vector2i pos, uint16
 		}
 
 		Vector2i delta = map_coord(droid->pos.xy()) - b.map;
-		if (delta.x < 0 || delta.x >= b.size.x || delta.y < 0 || delta.y >= b.size.y || droid->isFlying())
+		if (delta.x < 0 || delta.x >= b.size.x || delta.y < 0 || delta.y >= b.size.y || droid->isFlying() || droid->isTransporter())
 		{
 			continue;  // Droid not under new structure (just near it).
 		}

--- a/src/action.cpp
+++ b/src/action.cpp
@@ -586,7 +586,7 @@ static bool actionRemoveDroidsFromBuildPos(unsigned player, Vector2i pos, uint16
 		}
 
 		Vector2i delta = map_coord(droid->pos.xy()) - b.map;
-		if (delta.x < 0 || delta.x >= b.size.x || delta.y < 0 || delta.y >= b.size.y || droid->isFlying() || droid->isTransporter())
+		if (delta.x < 0 || delta.x >= b.size.x || delta.y < 0 || delta.y >= b.size.y || droid->isFlying() || droid->isFlightBasedTransporter())
 		{
 			continue;  // Droid not under new structure (just near it).
 		}

--- a/src/combat.cpp
+++ b/src/combat.cpp
@@ -273,7 +273,7 @@ bool combFire(WEAPON *psWeap, BASE_OBJECT *psAttacker, BASE_OBJECT *psTarget, in
 		}
 
 		predict += Vector3i(iSinCosR(psDroid->sMove.moveDir, psDroid->sMove.speed * flightTime / GAME_TICKS_PER_SEC), 0);
-		if (!psDroid->isFlying())
+		if (!psDroid->isFlying() && !psDroid->isTransporter())
 		{
 			predict.z = map_Height(predict.xy());  // Predict that the object will be on the ground.
 		}

--- a/src/combat.cpp
+++ b/src/combat.cpp
@@ -273,7 +273,7 @@ bool combFire(WEAPON *psWeap, BASE_OBJECT *psAttacker, BASE_OBJECT *psTarget, in
 		}
 
 		predict += Vector3i(iSinCosR(psDroid->sMove.moveDir, psDroid->sMove.speed * flightTime / GAME_TICKS_PER_SEC), 0);
-		if (!psDroid->isFlying() && !psDroid->isTransporter())
+		if (!psDroid->isFlying() && !psDroid->isFlightBasedTransporter())
 		{
 			predict.z = map_Height(predict.xy());  // Predict that the object will be on the ground.
 		}

--- a/src/droid.cpp
+++ b/src/droid.cpp
@@ -3113,6 +3113,11 @@ bool isTransporter(DROID_TEMPLATE const *psTemplate)
 	return isTransporter(psTemplate->droidType);
 }
 
+bool DROID::isFlightBasedTransporter() const
+{
+	return getPropulsionStats()->propulsionType == PROPULSION_TYPE_LIFT && isTransporter();
+}
+
 //access functions for vtols
 bool DROID::isVtol() const
 {

--- a/src/droid.cpp
+++ b/src/droid.cpp
@@ -3123,8 +3123,7 @@ bool DROID::isVtol() const
 /* returns true if the droid has lift propulsion and is moving */
 bool DROID::isFlying() const
 {
-	return getPropulsionStats()->propulsionType == PROPULSION_TYPE_LIFT
-		   && (sMove.Status != MOVEINACTIVE || isTransporter());
+	return getPropulsionStats()->propulsionType == PROPULSION_TYPE_LIFT && sMove.Status != MOVEINACTIVE;
 }
 
 // true if a droid is retreating for repair

--- a/src/droiddef.h
+++ b/src/droiddef.h
@@ -108,6 +108,8 @@ struct DROID : public BASE_OBJECT
 	bool isCyborg() const;
 	// Returns true if the droid is a transporter.
 	bool isTransporter() const;
+	// Returns true if the droid has VTOL Propulsion and is a transporter.
+	bool isFlightBasedTransporter() const;
 	// Returns true if the droid has VTOL propulsion, and is not a transport.
 	bool isVtol() const;
 	// Returns true if the droid has VTOL propulsion and is moving.

--- a/src/move.cpp
+++ b/src/move.cpp
@@ -897,7 +897,7 @@ static void moveOpenGates(DROID *psDroid, Vector2i tile)
 		return;
 	}
 	MAPTILE *psTile = mapTile(tile);
-	if (!psDroid->isFlying() && psTile && psTile->psObject && psTile->psObject->type == OBJ_STRUCTURE && aiCheckAlliances(psTile->psObject->player, psDroid->player))
+	if (!psDroid->isFlying() && !psDroid->isTransporter() && psTile && psTile->psObject && psTile->psObject->type == OBJ_STRUCTURE && aiCheckAlliances(psTile->psObject->player, psDroid->player))
 	{
 		requestOpenGate((STRUCTURE *)psTile->psObject);  // If it's a friendly gate, open it. (It would be impolite to open an enemy gate.)
 	}

--- a/src/move.cpp
+++ b/src/move.cpp
@@ -539,7 +539,7 @@ void updateDroidOrientation(DROID *psDroid)
 	const int d = 20;
 	int32_t vX, vY;
 
-	if (psDroid->droidType == DROID_PERSON || psDroid->isCyborg() || psDroid->isTransporter()
+	if (psDroid->droidType == DROID_PERSON || psDroid->isCyborg() || psDroid->isFlightBasedTransporter()
 	    || psDroid->isFlying())
 	{
 		/* The ground doesn't affect the pitch/roll of these droids*/
@@ -1205,7 +1205,7 @@ static void moveCalcDroidSlide(DROID *psDroid, int *pmx, int *pmy)
 		{
 			DROID * psObjcast = static_cast<DROID*> (psObj);
 			objR = moveObjRadius(psObj);
-			if (psObjcast->isTransporter())
+			if (psObjcast->isFlightBasedTransporter())
 			{
 				// ignore transporters
 				continue;

--- a/src/move.cpp
+++ b/src/move.cpp
@@ -897,7 +897,7 @@ static void moveOpenGates(DROID *psDroid, Vector2i tile)
 		return;
 	}
 	MAPTILE *psTile = mapTile(tile);
-	if (!psDroid->isFlying() && !psDroid->isTransporter() && psTile && psTile->psObject && psTile->psObject->type == OBJ_STRUCTURE && aiCheckAlliances(psTile->psObject->player, psDroid->player))
+	if (!psDroid->isFlying() && !psDroid->isFlightBasedTransporter() && psTile && psTile->psObject && psTile->psObject->type == OBJ_STRUCTURE && aiCheckAlliances(psTile->psObject->player, psDroid->player))
 	{
 		requestOpenGate((STRUCTURE *)psTile->psObject);  // If it's a friendly gate, open it. (It would be impolite to open an enemy gate.)
 	}

--- a/src/projectile.cpp
+++ b/src/projectile.cpp
@@ -893,7 +893,7 @@ static PROJECTILE* proj_InFlightFunc(PROJECTILE *psProj)
 		else if (!(psStats->surfaceToAir & SHOOT_ON_GROUND) &&
 		         (psTempObj->type == OBJ_STRUCTURE ||
 		          psTempObj->type == OBJ_FEATURE ||
-		          (psTempObj->type == OBJ_DROID && !((DROID*)psTempObj)->isFlying())
+		          (psTempObj->type == OBJ_DROID && !((DROID*)psTempObj)->isTransporter() && !((DROID*)psTempObj)->isFlying())
 		         ))
 		{
 			// AA weapons should not hit buildings and non-vtol droids

--- a/src/projectile.cpp
+++ b/src/projectile.cpp
@@ -893,7 +893,7 @@ static PROJECTILE* proj_InFlightFunc(PROJECTILE *psProj)
 		else if (!(psStats->surfaceToAir & SHOOT_ON_GROUND) &&
 		         (psTempObj->type == OBJ_STRUCTURE ||
 		          psTempObj->type == OBJ_FEATURE ||
-		          (psTempObj->type == OBJ_DROID && !((DROID*)psTempObj)->isTransporter() && !((DROID*)psTempObj)->isFlying())
+		          (psTempObj->type == OBJ_DROID && !((DROID*)psTempObj)->isFlightBasedTransporter() && !((DROID*)psTempObj)->isFlying())
 		         ))
 		{
 			// AA weapons should not hit buildings and non-vtol droids

--- a/src/quickjs_backend.cpp
+++ b/src/quickjs_backend.cpp
@@ -979,6 +979,7 @@ JSValue convFeature(const FEATURE *psFeature, JSContext *ctx)
 //;; * ```experience``` Amount of experience this droid has, based on damage it has dealt to enemies.
 //;; * ```cost``` What it would cost to build the droid. (3.2+ only)
 //;; * ```isVTOL``` True if the droid is VTOL. (3.2+ only)
+//;; * ```isFlying``` True if the droid is currently flying. (4.6.0+ only)
 //;; * ```canHitAir``` True if the droid has anti-air capabilities. (3.2+ only)
 //;; * ```canHitGround``` True if the droid has anti-ground capabilities. (3.2+ only)
 //;; * ```isSensor``` True if the droid has sensor ability. (3.2+ only)
@@ -1054,6 +1055,7 @@ JSValue convDroid(const DROID *psDroid, JSContext *ctx)
 	QuickJS_DefinePropertyValue(ctx, value, "canHitAir", JS_NewBool(ctx, aa), JS_PROP_ENUMERABLE);
 	QuickJS_DefinePropertyValue(ctx, value, "canHitGround", JS_NewBool(ctx, ga), JS_PROP_ENUMERABLE);
 	QuickJS_DefinePropertyValue(ctx, value, "isVTOL", JS_NewBool(ctx, psDroid->isVtol()), JS_PROP_ENUMERABLE);
+	QuickJS_DefinePropertyValue(ctx, value, "isFlying", JS_NewBool(ctx, psDroid->isFlying()), JS_PROP_ENUMERABLE);
 	QuickJS_DefinePropertyValue(ctx, value, "droidType", JS_NewInt32(ctx, (int)type), JS_PROP_ENUMERABLE);
 	QuickJS_DefinePropertyValue(ctx, value, "experience", JS_NewFloat64(ctx, (double)psDroid->experience / 65536.0), JS_PROP_ENUMERABLE);
 	QuickJS_DefinePropertyValue(ctx, value, "health", JS_NewFloat64(ctx, 100.0 / (double)psDroid->originalBody * (double)psDroid->body), JS_PROP_ENUMERABLE);


### PR DESCRIPTION
Partner PR to  #3508
Adds an `isFlying` field to JS Droid objects, which is true if the droid (VTOL or Transport) is currently in the air, false otherwise.