### PR TITLE
(MP)CyborgRotMG_fix

### DIFF
--- a/data/mp/stats/weapons.json
+++ b/data/mp/stats/weapons.json
@@ -1828,7 +1828,7 @@
 		"weight": 120
 	},
 	"CyborgRotMG": {
-		"buildPoints": 270,
+		"buildPoints": 200,
 		"buildPower": 90,
 		"damage": 18,
 		"effectSize": 100,


### PR DESCRIPTION
Reduction of production time by 25%
"buildPoints": 270 ->200


At the moment CyborgRotMG is very rarely used by players on maps with high oil and in my opinion this is due to the following reasons:
1. Ineffective in small quantities even against Super Heavy-Gunner
2. Long or expensive production of CyborgRotMG depending on whether you have time to research Robotic Manufacturing and Gas Turbine Generator (most often Robotic Manufacturing is researched after Assault Gun or after Gas Turbine Generator if we are talking about No Shared Res. In any case, speeding up production without an energy boost is stupid)

As a reminder, the current CyborgRotMG production time is 32 sec without Robotic Manufacturing - that's a long time
In comparison 
With Robotic Manufacturing: 
CyborgRotMG - 18sec(with buff - 15sec)
Machinegunner - 13sec
Heavy Gunner - 17sec.
Without Robotic Manufacturing:
CyborgRotMG - 32sec(with buff - 26sec)
Machinegunner - 23sec
Heavy Gunner - 29sec
