### PR TITLE
(MP)Heavy Repair Turret fix

### DIFF
--- a/data/mp/stats/repair.json
+++ b/data/mp/stats/repair.json
@@ -32,7 +32,7 @@
 		"name": "Heavy Repair Turret",
 		"repairPoints": 30,
 		"time": 7,
-		"weight": 3000
+		"weight": 2000
 	},
 	"LightRepair1": {
 		"buildPoints": 125,


### PR DESCRIPTION
Weight reduction - improved mobility
"weight": 3000 -> 2000

I proposed this change over a year ago because I argued that a slow HRT would be out of competition with Repair Facility given their equal research cost because HRTs are more vulnerable to damage and they are very slow and have low HP because all mobile repair turrets produce in combination with only a light body and wheels. 
Also recall that all mobile repair turrets cannot repair units while on the move and since HRTs are currently slow and fragile, why would they be needed if there is a Repair Facility?
As an experiment, choose the map Tiny_Vaut build HRT+Viper+wheels and see how fast the unit moves