### PR TITLE
Update reticules when alt-click unloading transporters

### DIFF
--- a/data/mp/multiplay/script/rules/events/transfer.js
+++ b/data/mp/multiplay/script/rules/events/transfer.js
@@ -21,3 +21,11 @@ function eventTransporterDisembarked(transport)
 		reticuleUpdate(transport, TRANSFER_LIKE_EVENT);
 	}
 }
+
+function eventTransporterLanded(transport)
+{
+	if (transport.player === selectedPlayer)
+	{
+		reticuleUpdate(transport, TRANSFER_LIKE_EVENT);
+	}
+}


### PR DESCRIPTION
Unloading units via this method doesn't trigger the usual disembark event, rather, the transport landed one.

Fixes #3839.