### PR TITLE
Adjust Windows CI, partial fixes for GHA runner image issue

### DIFF
--- a/.ci/vcpkg/overlay-ports/basisu/001-mingw.patch
+++ b/.ci/vcpkg/overlay-ports/basisu/001-mingw.patch
@@ -1,0 +1,39 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 492233a..bdd4dac 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -102,8 +102,10 @@ if (NOT MSVC)
+ 	  	set(CMAKE_C_FLAGS  "${CMAKE_C_FLAGS} -DBASISU_SUPPORT_SSE=0")
+ 		set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -DBASISU_SUPPORT_SSE=0")
+ 	  endif()
+-	  
+-	  set(CMAKE_EXE_LINKER_FLAGS  "${CMAKE_EXE_LINKER_FLAGS} ${GCC_LINK_FLAGS} -Wl,-rpath .")
++
++	  if (NOT MINGW)
++	    set(CMAKE_EXE_LINKER_FLAGS  "${CMAKE_EXE_LINKER_FLAGS} ${GCC_LINK_FLAGS} -Wl,-rpath .")
++	  endif()
+    endif()
+ 
+    set(CMAKE_C_FLAGS  "${CMAKE_C_FLAGS} ${GCC_COMPILE_FLAGS}")
+@@ -123,6 +125,21 @@ else()
+ 	endif()
+ endif()
+ 
++# Set BASISU_HAVE_STD_TRIVIALLY_COPYABLE if the target supports std::is_trivially_copyable
++include(CheckCXXSourceCompiles)
++check_cxx_source_compiles("
++	#include <type_traits>
++	const bool val = std::is_trivially_copyable<bool>::value;
++	int main()
++	{
++		return 0;
++	}"
++	HAVE_STD_IS_TRIVIALLY_COPYABLE
++)
++if (HAVE_STD_IS_TRIVIALLY_COPYABLE)
++	set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -DBASISU_HAVE_STD_TRIVIALLY_COPYABLE")
++endif()
++
+ set(BASISU_SRC_LIST ${COMMON_SRC_LIST} 
+ 	basisu_tool.cpp
+ 	encoder/basisu_backend.cpp

--- a/.ci/vcpkg/overlay-ports/basisu/portfile.cmake
+++ b/.ci/vcpkg/overlay-ports/basisu/portfile.cmake
@@ -4,6 +4,8 @@ vcpkg_from_github(
     REF ad9386a4a1cf2a248f7bbd45f543a7448db15267 # post-1.16.4, including fixes
     SHA512 4922af3a8d42d8c1ab551853d0ab97c0733a869cd99e95ef7a03620da023da48070a1255dcd68f6a384ee7787b5bd5dffe2cd510b2986e2a0e7181929f6ecc64
     HEAD_REF master
+    PATCHES
+        001-mingw.patch
 )
 
 set(_additional_options)

--- a/.ci/vcpkg/overlay-ports/basisu/portfile.cmake
+++ b/.ci/vcpkg/overlay-ports/basisu/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO BinomialLLC/basis_universal
-    REF 1531cfaf9ed5232248a0a45736686a849ca3befc #tag/1.16.3
-    SHA512 fdb0c4360cb8e0c85a592f6fddbf6f880c5ccbfef65c33c752fb2779b96d1edc8d4992d18321a428599a3649ace2e4843f15efe04f170085d951ddca25f87323
+    REF ad9386a4a1cf2a248f7bbd45f543a7448db15267 # post-1.16.4, including fixes
+    SHA512 4922af3a8d42d8c1ab551853d0ab97c0733a869cd99e95ef7a03620da023da48070a1255dcd68f6a384ee7787b5bd5dffe2cd510b2986e2a0e7181929f6ecc64
     HEAD_REF master
 )
 

--- a/.ci/vcpkg/overlay-ports/basisu/vcpkg.json
+++ b/.ci/vcpkg/overlay-ports/basisu/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "basisu",
   "version-string": "1.16.4",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Basis Universal is a supercompressed GPU texture and video compression format that outputs a highly compressed intermediate file format (.basis) that can be quickly transcoded to a wide variety of GPU texture compression formats.",
   "homepage": "https://github.com/BinomialLLC/basis_universal",
   "dependencies": [

--- a/.ci/vcpkg/overlay-ports/basisu/vcpkg.json
+++ b/.ci/vcpkg/overlay-ports/basisu/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "basisu",
-  "version-string": "1.16.3",
+  "version-string": "1.16.4",
+  "port-version": 1,
   "description": "Basis Universal is a supercompressed GPU texture and video compression format that outputs a highly compressed intermediate file format (.basis) that can be quickly transcoded to a wide variety of GPU texture compression formats.",
   "homepage": "https://github.com/BinomialLLC/basis_universal",
   "dependencies": [

--- a/.github/workflows/CI_windows.yml
+++ b/.github/workflows/CI_windows.yml
@@ -149,6 +149,7 @@ jobs:
             # Will need to use a similar workaround as Chromium's build process
             # and use the armasm64.exe tool from MSVC
           }
+          $VCPKG_DEFAULT_HOST_TRIPLET = "x64-mingw-static"
         }
         else {
           $WZ_USING_MINGW = "false"
@@ -162,8 +163,8 @@ jobs:
           elseif ($env:WZ_TARGET_ARCH -eq "arm64") {
             $VCPKG_DEFAULT_TRIPLET = "arm64-windows"
           }
+          $VCPKG_DEFAULT_HOST_TRIPLET = "x64-windows"
         }
-        $VCPKG_DEFAULT_HOST_TRIPLET = "x64-windows"
 
         $WZ_FULL_POWERSHELL_PATH = (Get-Command powershell.exe).Path
         $WZ_FULL_GIT_PATH = Split-Path -Path ((Get-Command git.exe).Path)

--- a/3rdparty/CMakeLists.txt
+++ b/3rdparty/CMakeLists.txt
@@ -146,6 +146,18 @@ if (WZ_ENABLE_BASIS_UNIVERSAL AND NOT WZ_CI_DISABLE_BASIS_COMPRESS_TEXTURES)
 	  message(STATUS "Pre-installed basisu tool found: ${BASIS_UNIVERSAL_CLI}")
 	endif()
 
+	# Test basisu -version
+	execute_process(
+		COMMAND "${BASIS_UNIVERSAL_CLI}" -version
+		OUTPUT_VARIABLE BASISU_VERSION
+		OUTPUT_STRIP_TRAILING_WHITESPACE
+		RESULT_VARIABLE _basisu_result
+	)
+	if(_basisu_result AND NOT _basisu_result EQUAL 0)
+		message(FATAL_ERROR "basisu does not seem to be executable on this host?: ${BASIS_UNIVERSAL_CLI} (exit code: ${_basisu_result})")
+	endif()
+	message(STATUS "Found basisu: ${BASIS_UNIVERSAL_CLI} ${BASISU_VERSION}")
+
 	set(BASIS_UNIVERSAL_CLI "${BASIS_UNIVERSAL_CLI}" PARENT_SCOPE)
 
 endif()


### PR DESCRIPTION
There is currently an issue impacting the `windows-2022`:`20240603.1.0` GitHub Actions runner image. (Many executables built with MSVC won't run on the runner image itself, due to older copies of the vcruntime libraries in the PATH.)

This impacts the `basisu` command-line tool which is built as part of - and used as part of - the build process (via the default `x64-windows` vcpkg triplet, which uses MSVC).

While waiting for an official fix for the GHA runner images, switch our LLVM_MINGW builds over to building host tools with the `x64-mingw-static` vcpkg triplet, bypassing the issue entirely.

(The two MSVC_2022 CI passes will still fail, for now, until a fixed GHA runner image is pushed out.)