### PR TITLE
Improvements to autoLagKick, kick votes, and ability to kick on "Waiting For Players" screen

### DIFF
--- a/src/multiint.cpp
+++ b/src/multiint.cpp
@@ -7285,6 +7285,8 @@ void WzMultiplayerOptionsTitleUI::frontendMultiMessages(bool running)
 
 		NETpop(queue);
 	}
+
+	autoLagKickRoutine();
 }
 
 TITLECODE WzMultiplayerOptionsTitleUI::run()

--- a/src/multiint.cpp
+++ b/src/multiint.cpp
@@ -6675,7 +6675,7 @@ public:
 		addGameOptions(); //refresh to see the proper tech level in the map name
 		return true;
 	}
-	virtual bool kickPlayer(uint32_t player, const char *reason, bool ban) override
+	virtual bool kickPlayer(uint32_t player, const char *reason, bool ban, uint32_t requester) override
 	{
 		ASSERT_HOST_ONLY(return false);
 		ASSERT_OR_RETURN(false, player != NetPlay.hostPlayer, "Unable to kick the host");

--- a/src/multilobbycommands.cpp
+++ b/src/multilobbycommands.cpp
@@ -354,7 +354,7 @@ bool processChatLobbySlashCommands(const NetworkTextMessage& message, HostLobbyO
 			sendRoomSystemMessage("Can't kick the host.");
 			return false;
 		}
-		if (!cmdInterface.kickPlayer(playerIdx, _("Administrator has kicked you from the game."), isBan))
+		if (!cmdInterface.kickPlayer(playerIdx, _("Administrator has kicked you from the game."), isBan, message.sender))
 		{
 			std::string msg = astringf("Failed to kick %s: %u", (playerIdx < MAX_PLAYER_SLOTS) ? "player" : "spectator", playerPos);
 			sendRoomSystemMessage(msg.c_str());

--- a/src/multilobbycommands.h
+++ b/src/multilobbycommands.h
@@ -40,7 +40,7 @@ public:
 	virtual bool changeBase(uint8_t baseValue) = 0;
 	virtual bool changeAlliances(uint8_t allianceValue) = 0;
 	virtual bool changeScavengers(uint8_t scavsValue) = 0;
-	virtual bool kickPlayer(uint32_t player_id, const char *reason, bool ban) = 0;
+	virtual bool kickPlayer(uint32_t player_id, const char *reason, bool ban, uint32_t requester_id) = 0;
 	virtual bool changeHostChatPermissions(uint32_t player_id, bool freeChatEnabled) = 0;
 	virtual bool movePlayerToSpectators(uint32_t player_id) = 0;
 	virtual bool requestMoveSpectatorToPlayers(uint32_t player_id) = 0;

--- a/src/multiplay.cpp
+++ b/src/multiplay.cpp
@@ -127,9 +127,9 @@ static void sendTextMessage(const char* msg)
 	message.send();
 }
 
-static void autoLagKickRoutine()
+void autoLagKickRoutine()
 {
-	if (!NetPlay.isHost)
+	if (!bMultiPlayer || !NetPlay.bComms || !NetPlay.isHost)
 	{
 		return;
 	}
@@ -146,7 +146,8 @@ static void autoLagKickRoutine()
 		return;
 	}
 
-	const bool isInitialLoad = !ingame.TimeEveryoneIsInGame.has_value();
+	const bool isLobby = ingame.localJoiningInProgress;
+	const bool isInitialLoad = !isLobby && !ingame.TimeEveryoneIsInGame.has_value();
 	uint32_t numPlayersLoaded = 0;
 	uint32_t totalNumPlayers = 0;
 

--- a/src/multiplay.cpp
+++ b/src/multiplay.cpp
@@ -210,6 +210,12 @@ void autoLagKickRoutine()
 			continue;
 		}
 
+		if (ingame.PendingDisconnect[i])
+		{
+			// player already technically left, but we're still in the "pre-game" phase so the GAME_PLAYER_LEFT hasn't been processed yet
+			continue;
+		}
+
 		ingame.LagCounter[i]++;
 		if (ingame.LagCounter[i] >= LagAutoKickSeconds) {
 			std::string msg = astringf("Auto-kicking player %" PRIu32 " (\"%s\") because of ping issues. (Timeout: %u seconds)", i, getPlayerName(i), LagAutoKickSeconds);

--- a/src/multiplay.h
+++ b/src/multiplay.h
@@ -252,6 +252,8 @@ void printConsoleNameChange(const char *oldName, const char *newName);  ///< Pri
 
 void turnOffMultiMsg(bool bDoit);
 
+void autoLagKickRoutine();
+
 void sendMap();
 bool multiplayerWinSequence(bool firstCall);
 

--- a/src/multivote.cpp
+++ b/src/multivote.cpp
@@ -62,7 +62,10 @@ public:
 	, requester_player_id(requester_player_id)
 	, target_player_id(target_player_id)
 	{
-		votes[requester_player_id] = true;
+		if (requester_player_id < votes.size())
+		{
+			votes[requester_player_id] = true;
+		}
 		votes[target_player_id] = false;
 		start_time = realTime;
 	}
@@ -659,12 +662,12 @@ void processPendingKickVotes()
 	}
 }
 
-bool startKickVote(uint32_t targetPlayer)
+bool startKickVote(uint32_t targetPlayer, optional<uint32_t> requester_player_id /*= nullopt*/)
 {
 	ASSERT_HOST_ONLY(return false);
 	static uint32_t last_vote_id = 0;
 
-	auto pendingVote = PendingVoteKick(last_vote_id++, selectedPlayer, targetPlayer);
+	auto pendingVote = PendingVoteKick(last_vote_id++, requester_player_id.value_or(selectedPlayer), targetPlayer);
 	auto currentStatus = pendingVote.getKickVoteResult();
 	if (currentStatus.has_value())
 	{

--- a/src/multivote.h
+++ b/src/multivote.h
@@ -21,6 +21,9 @@
 #define __INCLUDED_WZ_MULTI_VOTE_H__
 
 #include <cstdint>
+#include <nonstd/optional.hpp>
+using nonstd::optional;
+using nonstd::nullopt;
 
 void resetLobbyChangeVoteData();
 void resetLobbyChangePlayerVote(uint32_t player);
@@ -29,7 +32,7 @@ uint8_t getLobbyChangeVoteTotal();
 void sendLobbyChangeVoteData(uint8_t currentVote);
 
 void resetKickVoteData();
-bool startKickVote(uint32_t target_player_id);
+bool startKickVote(uint32_t target_player_id, optional<uint32_t> requester_player_id = nullopt);
 void processPendingKickVotes();
 void cancelOrDismissKickVote(uint32_t targetPlayer);
 


### PR DESCRIPTION
- Fixed issue with startKickVote when triggered by a spectator host (could cause a crash) - Fixes #3782
- Improvements to autoLagKick support in several situations including: all players loaded but spectator is blocking game start, lagging / infinite ping in the lobby
- Add UI to allow the host to kick loading players in the "Waiting for Players" screen
  - Simply click any still-loading player / spectator and you'll get a menu with a "Kick Player" / "Kick Spectator" option