### PR TITLE
Partially restore formations (particularly: speed limiting)

### DIFF
--- a/lib/netplay/netplay.cpp
+++ b/lib/netplay/netplay.cpp
@@ -5008,6 +5008,7 @@ const char *messageTypeToString(unsigned messageType_)
 	case GAME_DEBUG_REMOVE_FEATURE:     return "GAME_DEBUG_REMOVE_FEATURE";
 	case GAME_DEBUG_FINISH_RESEARCH:    return "GAME_DEBUG_FINISH_RESEARCH";
 	// End of redundant messages.
+	case GAME_SYNC_OPT_CHANGE:			return "GAME_SYNC_OPT_CHANGE";
 	case GAME_MAX_TYPE:                 return "GAME_MAX_TYPE";
 
 	// The following messages are used for playing back replays.

--- a/lib/netplay/netplay.h
+++ b/lib/netplay/netplay.h
@@ -137,11 +137,17 @@ enum MESSAGE_TYPES
 	GAME_DEBUG_REMOVE_FEATURE,      ///< Remove feature.
 	GAME_DEBUG_FINISH_RESEARCH,     ///< Research has been completed.
 	// End of debug messages.
+	GAME_SYNC_OPT_CHANGE,			///< Change synchronized options for a player (ex formation options)
 	GAME_MAX_TYPE,                  ///< Maximum+1 valid GAME_ type, *MUST* be last.
 
 	// The following messages are used for playing back replays.
 	REPLAY_ENDED					///< A special message for signifying the end of the replay
 	// End of replay messages.
+};
+
+enum SYNC_OPT_TYPES
+{
+	SYNC_OPT_FORMATION_SPEED_LIMITING = 1
 };
 
 #define SYNC_FLAG 0x10000000	//special flag used for logging. (Not sure what this is. Was added in trunk, NUM_GAME_PACKETS not in newnet.)

--- a/lib/netplay/netplay.h
+++ b/lib/netplay/netplay.h
@@ -141,7 +141,7 @@ enum MESSAGE_TYPES
 	GAME_MAX_TYPE,                  ///< Maximum+1 valid GAME_ type, *MUST* be last.
 
 	// The following messages are used for playing back replays.
-	REPLAY_ENDED					///< A special message for signifying the end of the replay
+	REPLAY_ENDED = 255				///< A special message for signifying the end of the replay
 	// End of replay messages.
 };
 

--- a/src/action.cpp
+++ b/src/action.cpp
@@ -33,6 +33,7 @@
 
 #include "action.h"
 #include "combat.h"
+#include "formation.h"
 #include "geometry.h"
 #include "mission.h"
 #include "projectile.h"
@@ -758,6 +759,12 @@ void actionUpdateDroid(DROID *psDroid)
 		}
 		break;
 	case DACTION_WAITDURINGREPAIR:
+		// don't want to be in a formation for this move
+		if (psDroid->sMove.psFormation != nullptr)
+		{
+			formationLeave(psDroid->sMove.psFormation, psDroid);
+			psDroid->sMove.psFormation = nullptr;
+		}
 		// Check that repair facility still exists
 		if (!order->psObj)
 		{
@@ -1017,6 +1024,16 @@ void actionUpdateDroid(DROID *psDroid)
 				break;  // Still turning.
 			}
 			psDroid->action = DACTION_ATTACK;
+		}
+
+		if (psDroid->action == DACTION_ATTACK)
+		{
+			// don't wan't formations for this one
+			if (psDroid->sMove.psFormation)
+			{
+				formationLeave(psDroid->sMove.psFormation, psDroid);
+				psDroid->sMove.psFormation = nullptr;
+			}
 		}
 
 		//check the target hasn't become one the same player ID - Electronic Warfare
@@ -1293,6 +1310,13 @@ void actionUpdateDroid(DROID *psDroid)
 			break;
 		}
 	case DACTION_MOVETOATTACK:
+		// don't wan't formations for this one
+		if (psDroid->sMove.psFormation)
+		{
+			formationLeave(psDroid->sMove.psFormation, psDroid);
+			psDroid->sMove.psFormation = nullptr;
+		}
+
 		// send vtols back to rearm
 		if (psDroid->isVtol() && vtolEmpty(psDroid))
 		{
@@ -1518,6 +1542,13 @@ void actionUpdateDroid(DROID *psDroid)
 			}
 		} // End of check for whether the droid can still succesfully build the ordered structure
 
+		// The droid cannot be in a formation
+		if (psDroid->sMove.psFormation != nullptr)
+		{
+			formationLeave(psDroid->sMove.psFormation, psDroid);
+			psDroid->sMove.psFormation = nullptr;
+		}
+
 		// The droid can still build or help with a build, and is moving to a location to do so - are we there yet, are we there yet, are we there yet?
 		if (actionReachedBuildPos(psDroid, psDroid->actionPos.x, psDroid->actionPos.y, order->direction, order->psStats))
 		{
@@ -1693,6 +1724,12 @@ void actionUpdateDroid(DROID *psDroid)
 			psDroid->action = DACTION_NONE;
 			break;
 		}
+		// The droid cannot be in a formation
+		if (psDroid->sMove.psFormation != nullptr)
+		{
+			formationLeave(psDroid->sMove.psFormation, psDroid);
+			psDroid->sMove.psFormation = nullptr;
+		}
 		if (DROID_STOPPED(psDroid) &&
 		    !actionReachedBuildPos(psDroid, psDroid->actionPos.x, psDroid->actionPos.y, order->direction, order->psStats))
 		{
@@ -1766,6 +1803,14 @@ void actionUpdateDroid(DROID *psDroid)
 				}
 			}
 		}
+
+		// The droid cannot be in a formation
+		if (psDroid->sMove.psFormation != nullptr)
+		{
+			formationLeave(psDroid->sMove.psFormation, psDroid);
+			psDroid->sMove.psFormation = nullptr;
+		}
+
 		// see if the droid is at the edge of what it is moving to
 		if (actionReachedBuildPos(psDroid, psDroid->actionPos.x, psDroid->actionPos.y, ((STRUCTURE *)psDroid->psActionTarget[0])->rot.direction, order->psStats))
 		{
@@ -1861,6 +1906,12 @@ void actionUpdateDroid(DROID *psDroid)
 		}
 		break;
 	case DACTION_MOVETOREPAIRPOINT:
+		// don't want to be in a formation for this move
+		if (psDroid->sMove.psFormation != nullptr)
+		{
+			formationLeave(psDroid->sMove.psFormation, psDroid);
+			psDroid->sMove.psFormation = nullptr;
+		}
 		if (psDroid->order.rtrType == RTR_TYPE_REPAIR_FACILITY)
 		{
 			/* moving from front to rear of repair facility or rearm pad */
@@ -2046,7 +2097,7 @@ void actionUpdateDroid(DROID *psDroid)
 				psDroid->action = DACTION_NONE;
 				break;
 			}
-			
+
 			// If not doing self-repair (psActionTarget[0] is repair target)
 			if (psDroid->psActionTarget[0] != psDroid)
 			{

--- a/src/droid.cpp
+++ b/src/droid.cpp
@@ -54,6 +54,8 @@
 #include "component.h"
 #include "lighting.h"
 #include "multiplay.h"
+#include "formationdef.h"
+#include "formation.h"
 #include "warcam.h"
 #include "display3d.h"
 #include "group.h"
@@ -164,6 +166,8 @@ bool droidInit()
 		recycled_experience[i] = std::priority_queue <int>(); // clear it
 	}
 	psLastDroidHit = nullptr;
+
+	moveInit();
 
 	return true;
 }
@@ -464,6 +468,13 @@ DROID::~DROID()
 
 	fpathRemoveDroidData(psDroid->id);
 
+	// leave the current formation if any
+	if (psDroid->sMove.psFormation)
+	{
+		formationLeave(psDroid->sMove.psFormation, psDroid);
+		psDroid->sMove.psFormation = nullptr;
+	}
+
 	// leave the current group if any
 	if (psDroid->psGroup)
 	{
@@ -532,6 +543,13 @@ bool removeDroidBase(DROID *psDel)
 	}
 
 	syncDebugDroid(psDel, '#');
+
+	// leave the current formation if any
+	if (psDel->sMove.psFormation)
+	{
+		formationLeave(psDel->sMove.psFormation, psDel);
+		psDel->sMove.psFormation = nullptr;
+	}
 
 	//kill all the droids inside the transporter
 	if (psDel->isTransporter())
@@ -695,6 +713,13 @@ bool droidRemove(DROID *psDroid, PerPlayerDroidLists& pList)
 	{
 		// droid has already been killed, quit
 		return false;
+	}
+
+	// leave the current formation if any
+	if (psDroid->sMove.psFormation)
+	{
+		formationLeave(psDroid->sMove.psFormation, psDroid);
+		psDroid->sMove.psFormation = nullptr;
 	}
 
 	// leave the current group if any - not if its a Transporter droid

--- a/src/formation.cpp
+++ b/src/formation.cpp
@@ -1,0 +1,675 @@
+/*
+	This file is part of Warzone 2100.
+	Copyright (C) 1999-2004  Eidos Interactive
+	Copyright (C) 2005-2023  Warzone 2100 Project
+
+	Warzone 2100 is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+
+	Warzone 2100 is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with Warzone 2100; if not, write to the Free Software
+	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+/*
+ * Formation.cpp
+ *
+ * Control units moving in formation.
+ *
+ */
+
+#include <string.h>
+
+#include "lib/framework/frame.h"
+#include "lib/framework/fixedpoint.h"
+#include "lib/ivis_opengl/ivisdef.h"
+#include "objects.h"
+#include "map.h"
+#include "astar.h"
+#include "fpath.h"
+#include "geometry.h"
+
+#include "formationdef.h"
+#include "formation.h"
+
+// radius for the different body sizes
+static SDWORD	fmLtRad = 80, fmMedRad = 100, fmHvyRad = 110;
+
+// default length of a formation line
+#define F_DEFLENGTH		(4*fmLtRad)
+
+// how close to the formation a unit has to be to receive a formation point
+#define F_JOINRANGE		(TILE_UNITS * 3)
+
+// how far apart to keep the ranks in a formation
+#define RANK_DIST		(2*fmLtRad)
+
+// maximum number of ranks for a line
+#define MAX_RANK		15
+
+// the distance for finding formations
+#define FIND_RANGE		(TILE_UNITS/2)
+
+#define FORMATION_SPEED_INIT	100000L
+
+// The list of allocated formations
+static FORMATION	*psFormationList = nullptr;
+
+static SDWORD formationObjRadius(const DROID* psDroid);
+
+/** Initialise the formation system
+ */
+bool formationInitialise()
+{
+	psFormationList = nullptr;
+
+	return true;
+}
+
+/** Shutdown the formation system
+ */
+void formationShutDown()
+{
+	FORMATION	*psNext;
+
+	while (psFormationList)
+	{
+		debug(LOG_NEVER, "formation with %d units still attached", psFormationList->refCount);
+		psNext = psFormationList->psNext;
+		delete psFormationList;
+		psFormationList = psNext;
+	}
+}
+
+/** Create a new formation
+ */
+bool formationNew(FORMATION **ppsFormation, FORMATION_TYPE type,
+					SDWORD x, SDWORD y, uint16_t dir)
+{
+	SDWORD		i;
+	FORMATION	*psNew = new FORMATION();
+
+	// get a heap structure
+	ASSERT_OR_RETURN(false, psNew, "Out of memory");
+
+	// initialise it
+	psNew->refCount = 0;
+	psNew->size = (SWORD)F_DEFLENGTH;
+	psNew->rankDist = (SWORD)RANK_DIST;
+	psNew->direction = dir;
+	psNew->x = x;
+	psNew->y = y;
+	psNew->free = 0;
+	psNew->iSpeed = FORMATION_SPEED_INIT;
+	memset(psNew->asMembers, 0, sizeof(psNew->asMembers));
+	for(i=0; i<F_MAXMEMBERS; i++)
+	{
+		psNew->asMembers[i].next = (SBYTE)(i+1);
+	}
+	psNew->asMembers[F_MAXMEMBERS - 1].next = -1;
+
+	// add the formation lines based on the formation type
+	switch (type)
+	{
+	case FT_LINE:
+		psNew->numLines = 2;
+		// line to the left
+		psNew->asLines[0].xoffset = 0;
+		psNew->asLines[0].yoffset = 0;
+		psNew->asLines[0].direction = dir - DEG(110);
+		psNew->asLines[0].member = -1;
+		// line to the right
+		psNew->asLines[1].xoffset = 0;
+		psNew->asLines[1].yoffset = 0;
+		psNew->asLines[1].direction = dir + DEG(110);
+		psNew->asLines[1].member = -1;
+		break;
+	case FT_COLUMN:
+		psNew->numLines = 1;
+		// line to the left
+		psNew->asLines[0].xoffset = 0;
+		psNew->asLines[0].yoffset = 0;
+		psNew->asLines[0].direction = dir + DEG(180);
+		psNew->asLines[0].member = -1;
+		break;
+	default:
+		ASSERT(false, "Unknown formation type");
+		return false;
+	}
+
+	psNew->psNext = psFormationList;
+	psFormationList = psNew;
+
+	*ppsFormation = psNew;
+
+	return true;
+}
+
+
+/** Try to find a formation near a location
+ */
+FORMATION* formationFind(int x, int y)
+{
+	FORMATION* psFormation;
+
+	for (psFormation = psFormationList; psFormation; psFormation = psFormation->psNext)
+	{
+		// see if the position is close to the formation
+		const int xdiff = psFormation->x - x;
+		const int ydiff = psFormation->y - y;
+		const int distSq = xdiff*xdiff + ydiff*ydiff;
+		if (distSq < FIND_RANGE*FIND_RANGE)
+		{
+			return psFormation;
+		}
+	}
+
+	return NULL;
+}
+
+/** Find formation speed.
+ *  This currently means the speed of the slowest unit.
+ */
+static void formationUpdateSpeed(FORMATION *psFormation, const DROID* psNew)
+{
+	SDWORD		iUnit;
+	F_MEMBER	*asMembers = psFormation->asMembers;
+
+	if (psNew != NULL)
+	{
+		ASSERT(psNew->type == OBJ_DROID, "We've been passed a DROID that really isn't a DROID");
+		if ( psFormation->iSpeed > psNew->baseSpeed)
+		{
+			psFormation->iSpeed = psNew->baseSpeed;
+		}
+	}
+	else
+	{
+		psFormation->iSpeed = FORMATION_SPEED_INIT;
+	}
+
+	for(iUnit=0; iUnit<F_MAXMEMBERS; iUnit++)
+	{
+		if (asMembers[iUnit].psDroid
+		 && psFormation->iSpeed > asMembers[iUnit].psDroid->baseSpeed)
+		{
+			psFormation->iSpeed = asMembers[iUnit].psDroid->baseSpeed;
+		}
+	}
+}
+
+/** Associate a unit with a formation.
+ */
+void formationJoin(FORMATION *psFormation, const DROID* psDroid)
+{
+	SDWORD	rankDist, size;
+
+	ASSERT_OR_RETURN(, psFormation != NULL, "Invalid formation");
+
+	psFormation->refCount += 1;
+
+	rankDist = formationObjRadius(psDroid) * 2;
+	if (psFormation->rankDist < rankDist)
+	{
+		psFormation->rankDist = (SWORD)rankDist;
+	}
+
+	size = formationObjRadius(psDroid) * 4;
+	if (psFormation->size < size)
+	{
+		psFormation->size = (SWORD)size;
+	}
+
+	/* update formation speed */
+	formationUpdateSpeed(psFormation, psDroid);
+}
+
+/** Remove a unit from a formation.
+ */
+void formationLeave(FORMATION *psFormation, const DROID* psDroid)
+{
+	SDWORD		prev, curr, unit, line;
+	F_LINE		*asLines;
+	F_MEMBER	*asMembers;
+	FORMATION	*psCurr, *psPrev;
+
+	ASSERT_OR_RETURN(, psFormation != NULL, "Invalid formation");
+	if (!psDroid)
+	{
+		return;
+	}
+	ASSERT_OR_RETURN(, psFormation->refCount > 0, "Formation refcount is zero");
+
+	asMembers = psFormation->asMembers;
+
+	// see if the unit is a member
+	for(unit=0; unit<F_MAXMEMBERS; unit++)
+	{
+		if (asMembers[unit].psDroid == psDroid)
+		{
+			break;
+		}
+	}
+
+	if (unit<F_MAXMEMBERS)
+	{
+		// remove the member from the members list
+		asLines = psFormation->asLines;
+		prev = -1;
+		line = asMembers[unit].line;
+		curr = asLines[line].member;
+		while (curr != unit)
+		{
+			prev = curr;
+			curr = asMembers[curr].next;
+		}
+
+		if (prev == -1)
+		{
+			asLines[line].member = asMembers[unit].next;
+		}
+		else
+		{
+			asMembers[prev].next = asMembers[unit].next;
+		}
+		asMembers[unit].next = psFormation->free;
+		asMembers[unit].psDroid = NULL;
+		psFormation->free = (SBYTE)unit;
+
+		/* update formation speed */
+		formationUpdateSpeed(psFormation, NULL);
+	}
+
+	psFormation->refCount -= 1;
+	if (psFormation->refCount == 0)
+	{
+		if (psFormation == psFormationList)
+		{
+			psFormationList = psFormationList->psNext;
+		}
+		else
+		{
+			psPrev = NULL;
+			for(psCurr=psFormationList; psCurr && psCurr!= psFormation; psCurr=psCurr->psNext)
+			{
+				psPrev = psCurr;
+			}
+			psPrev->psNext = psFormation->psNext;
+		}
+		delete psFormation;
+	}
+}
+
+
+/** Remove all the members from a formation and release it.
+ */
+void formationReset(FORMATION *psFormation)
+{
+	int i;
+
+	for(i = 0; i < F_MAXMEMBERS; ++i)
+	{
+		if (psFormation->asMembers[i].psDroid)
+		{
+			formationLeave(psFormation, psFormation->asMembers[i].psDroid);
+		}
+	}
+}
+
+/** Calculate the coordinates of a position on a line
+ */
+static void formationCalcPos(DROID *psDroid, FORMATION *psFormation, SDWORD line, SDWORD dist, SDWORD *pX, SDWORD *pY)
+{
+	const int rank = dist / psFormation->size;
+
+	// calculate the offset of the line based on the rank
+	uint16_t dir = psFormation->direction + DEG(180);
+	const int xoffset = iSinR(dir, psFormation->rankDist * rank) + psFormation->asLines[line].xoffset;
+	const int yoffset = iCosR(dir, psFormation->rankDist * rank) + psFormation->asLines[line].yoffset;
+
+	// calculate the position of the gap
+	dir = psFormation->asLines[line].direction;
+	dist -= psFormation->size * rank;
+	*pX = iSinR(dir, dist) + xoffset + psFormation->x;
+	*pY = iCosR(dir, dist) + yoffset + psFormation->y;
+	//objTrace(psDroid->id, "Formation: xoff=%d, yoff=%d, dir=%d, dist=%d; formxoff=%d, formyoff=%d", xoffset, yoffset,
+	//         psFormation->asLines[line].direction, dist, psFormation->asLines[line].xoffset, psFormation->asLines[line].yoffset);
+}
+
+
+// assign a unit to a free spot in the formation
+static void formationFindFree(FORMATION *psFormation, DROID* psDroid,
+					   SDWORD	*pX, SDWORD *pY)
+{
+	SDWORD		line, unit, objRadius, radius;
+	SDWORD		currDist, prev, rank;
+	F_LINE		*asLines = psFormation->asLines;
+	F_MEMBER	*asMembers = psFormation->asMembers;
+	SDWORD		x=0,y=0, xdiff,ydiff, dist, objDist;
+	SDWORD		chosenLine, chosenDist, chosenPrev, chosenRank;
+	bool		found;
+
+	ASSERT(psFormation->free != -1, "No members left to allocate");
+	if (psFormation->free == -1)
+	{
+		*pX = psFormation->x;
+		*pY = psFormation->y;
+		return;
+	}
+
+	objRadius = formationObjRadius(psDroid);
+
+	*pX = psFormation->x;
+	*pY = psFormation->y;
+	chosenLine = 0;
+	chosenDist = 0;
+	chosenPrev = -1;
+	objDist = SDWORD_MAX;
+	chosenRank = SDWORD_MAX;
+	for(line=0; line<psFormation->numLines; line++)
+	{
+		// find the first free position on this line
+		currDist = 0;
+		rank = 1;
+		prev = -1;
+		unit = asLines[line].member;
+		found = false;
+		while (!found && rank <= MAX_RANK)
+		{
+			ASSERT( unit < F_MAXMEMBERS, "formationFindFree: unit out of range" );
+
+			if (unit != -1)
+			{
+				// See if the DROID can fit in the gap between this and the last unit
+				radius = formationObjRadius(asMembers[unit].psDroid);
+				if (objRadius*2 <= asMembers[unit].dist - radius - currDist)
+				{
+					found = true;
+				}
+				else
+				{
+					prev = unit;
+					currDist = asMembers[unit].dist + radius;
+					unit = asMembers[unit].next;
+
+					// if this line is full move onto a rank behind it
+					// reset the distance to the start of a rank
+					if (currDist + objRadius >= psFormation->size * rank)
+					{
+						currDist = psFormation->size * rank;
+						rank += 1;
+					}
+				}
+			}
+			else
+			{
+				found = true;
+			}
+
+			if (found)
+			{
+				// calculate the position on the line
+				formationCalcPos(psDroid, psFormation, line, currDist + objRadius, &x, &y);
+				if (fpathBlockingTile(map_coord(x), map_coord(y), psDroid->getPropulsionStats()->propulsionType))
+				{
+					// blocked, try the next rank
+					found = false;
+					currDist = psFormation->size * rank;
+					rank += 1;
+				}
+			}
+		}
+
+		// see if this gap is closer to the unit than the previous one
+		xdiff = x - psDroid->pos.x;
+		ydiff = y - psDroid->pos.y;
+		dist = xdiff*xdiff + ydiff*ydiff;
+//		dist += psFormation->rankDist*psFormation->rankDist * rank*rank;
+		if ((dist < objDist && rank == chosenRank) || rank < chosenRank)
+		{
+			// this gap is nearer
+			objDist = dist;
+//			objDist += psFormation->rankDist*psFormation->rankDist * rank*rank;
+
+			chosenLine = line;
+			chosenDist = currDist + objRadius;
+			chosenPrev = prev;
+			chosenRank = rank;
+			*pX = x;
+			*pY = y;
+		}
+	}
+
+	// initialise the member
+	unit = psFormation->free;
+	psFormation->free = asMembers[unit].next;
+	asMembers[unit].line = (SBYTE)chosenLine;
+	asMembers[unit].dist = (SWORD)chosenDist;
+	asMembers[unit].psDroid = psDroid;
+
+	// insert the unit into the list
+	if (chosenPrev == -1)
+	{
+		asMembers[unit].next = asLines[chosenLine].member;
+		asLines[chosenLine].member = (SBYTE)unit;
+	}
+	else
+	{
+		asMembers[unit].next =  asMembers[chosenPrev].next;
+		asMembers[chosenPrev].next = (SBYTE)unit;
+	}
+}
+
+
+// re-insert all the units in the formation
+static void formationReorder(FORMATION *psFormation)
+{
+	SDWORD		numObj, i,curr,prev;
+	F_MEMBER	*asMembers, asDroids[F_MAXMEMBERS];
+	SDWORD		xdiff,ydiff, insert;
+	SDWORD		aDist[F_MAXMEMBERS];
+
+	// first find all the units to insert
+	asMembers = psFormation->asMembers;
+	numObj = 0;
+	for(i=0; i<F_MAXMEMBERS; i++)
+	{
+		DROID* psDroid = asMembers[i].psDroid;
+		if (psDroid != NULL)
+		{
+			asDroids[numObj].psDroid = psDroid;
+			xdiff = psDroid->pos.x - psFormation->x;
+			ydiff = psDroid->pos.y - psFormation->y;
+			aDist[numObj] =  xdiff*xdiff + ydiff*ydiff;
+			numObj += 1;
+		}
+	}
+
+	// create a list in distance order
+	insert = -1;
+	for(i=0; i<numObj; i++)
+	{
+		if (insert == -1)
+		{
+			// insert at the start of the list
+			asDroids[i].next = -1;
+			insert = i;
+		}
+		else
+		{
+			prev = -1;
+			for(curr = insert; curr != -1; curr = asDroids[curr].next)
+			{
+				if (aDist[i] < aDist[curr])
+				{
+					break;
+				}
+				prev = curr;
+			}
+			if (prev == -1)
+			{
+				// insert at the start of the list
+				asDroids[i].next = (SBYTE)insert;
+				insert = i;
+			}
+			else
+			{
+				asDroids[i].next = asDroids[prev].next;
+				asDroids[prev].next = (SBYTE)i;
+			}
+		}
+	}
+
+	// reset the free list
+	psFormation->free = 0;
+	memset(psFormation->asMembers, 0, sizeof(psFormation->asMembers));
+	for(i=0; i<F_MAXMEMBERS; i++)
+	{
+		psFormation->asMembers[i].next = (SBYTE)(i+1);
+	}
+	psFormation->asMembers[F_MAXMEMBERS - 1].next = -1;
+	for(i=0; i<psFormation->numLines; i++)
+	{
+		psFormation->asLines[i].member = -1;
+	}
+
+	// insert each member again
+	while (insert != -1)
+	{
+		formationFindFree(psFormation, asDroids[insert].psDroid, &xdiff,&ydiff);
+		insert = asDroids[insert].next;
+	}
+}
+
+// get a target position to move into a formation
+bool formationGetPos( FORMATION *psFormation, DROID* psDroid,
+						SDWORD *pX, SDWORD *pY, bool bCheckLOS )
+{
+	SDWORD		xdiff,ydiff,distSq;
+	SDWORD		member, x,y;
+	F_MEMBER	*asMembers;
+
+	ASSERT_OR_RETURN(false, psFormation != NULL, "Invalid formation pointer");
+
+/*	if (psFormation->refCount == 1)
+	{
+		// nothing else in the formation so don't do anything
+		return false;
+	}*/
+
+	// see if the unit is close enough to join the formation
+	xdiff = (SDWORD)psFormation->x - (SDWORD)psDroid->pos.x;
+	ydiff = (SDWORD)psFormation->y - (SDWORD)psDroid->pos.y;
+	distSq = xdiff*xdiff + ydiff*ydiff;
+//	rangeSq = 3*psFormation->size/2;
+//	rangeSq = rangeSq*rangeSq;
+	if (distSq > F_JOINRANGE*F_JOINRANGE)
+	{
+		return false;
+	}
+
+	// see if the unit is already in the formation
+	asMembers = psFormation->asMembers;
+	for(member=0; member<F_MAXMEMBERS; member++)
+	{
+		if (asMembers[member].psDroid == psDroid)
+		{
+			break;
+		}
+	}
+
+	if (member < F_MAXMEMBERS)
+	{
+		// the unit is already in the formation - return it's current position
+		formationCalcPos(psDroid, psFormation, asMembers[member].line, asMembers[member].dist, &x, &y);
+	}
+	else if (psFormation->free != -1)
+	{
+		// add the new DROID to the members
+		psFormation->asMembers[(int)psFormation->free].psDroid = psDroid;
+		psFormation->free = psFormation->asMembers[(int)psFormation->free].next;
+		formationReorder(psFormation);
+
+		// find the DROID
+		for(member=0; member<F_MAXMEMBERS; member++)
+		{
+			if (asMembers[member].psDroid == psDroid)
+			{
+				break;
+			}
+		}
+
+		// calculate its position
+		formationCalcPos(psDroid, psFormation, asMembers[member].line, asMembers[member].dist, &x, &y);
+	}
+	else
+	{
+		return false;
+	}
+
+// NOTE: fpathTileLOS was removed in: https://github.com/Warzone2100/warzone2100/commit/1cc62d6d9d9d95354e10522c8618423565779b89
+//	// check the unit can get to the formation position
+//	if (bCheckLOS && !fpathTileLOS(psDroid, Vector3i_Init(x, y, 0)))
+//	{
+//		return false;
+//	}
+
+	*pX = x;
+	*pY = y;
+
+	return true;
+}
+
+
+
+// See if a unit is a member of a formation (i.e. it has a position assigned)
+bool formationMember(FORMATION *psFormation, const DROID* psDroid)
+{
+	SDWORD		member;
+	F_MEMBER	*asMembers;
+
+	// see if the unit is already in the formation
+	asMembers = psFormation->asMembers;
+	for(member=0; member<F_MAXMEMBERS; member++)
+	{
+		if (asMembers[member].psDroid == psDroid)
+		{
+			return true;
+		}
+	}
+
+	return false;
+}
+
+SDWORD formationObjRadius(const DROID* psDroid)
+{
+	const BODY_STATS* psBdyStats;
+
+	ASSERT(psDroid->type == OBJ_DROID, "We got passed a DROID that isn't a DROID!");
+
+	psBdyStats = &asBodyStats[psDroid->asBits[COMP_BODY]];
+
+	switch (psBdyStats->size)
+	{
+		case SIZE_LIGHT:
+			return fmLtRad;
+
+		case SIZE_MEDIUM:
+			return fmMedRad;
+
+		case SIZE_HEAVY:
+			return fmHvyRad;
+
+		case SIZE_SUPER_HEAVY:
+			return 500;
+
+		default:
+			return 3 * psDroid->sDisplay.imd->radius / 2;
+	}
+}

--- a/src/formation.h
+++ b/src/formation.h
@@ -38,11 +38,11 @@ bool formationInitialise();
 void formationShutDown();
 
 // Create a new formation
-bool formationNew(FORMATION **ppsFormation, FORMATION_TYPE type,
+bool formationNew(FORMATION **ppsFormation, uint32_t player, FORMATION_TYPE type,
 					SDWORD x, SDWORD y, uint16_t dir);
 
 // Try and find a formation near to a location
-FORMATION* formationFind(int x, int y);
+FORMATION* formationFind(uint32_t player, int x, int y);
 
 // Associate a unit with a formation
 void formationJoin(FORMATION *psFormation, const DROID* psDroid);

--- a/src/formation.h
+++ b/src/formation.h
@@ -1,0 +1,61 @@
+/*
+	This file is part of Warzone 2100.
+	Copyright (C) 1999-2004  Eidos Interactive
+	Copyright (C) 2005-2023  Warzone 2100 Project
+
+	Warzone 2100 is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+
+	Warzone 2100 is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with Warzone 2100; if not, write to the Free Software
+	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+/** @file
+ *  Control units moving in formation.
+ */
+
+#pragma once
+
+#include "formationdef.h"
+
+enum FORMATION_TYPE
+{
+	FT_LINE,
+	FT_COLUMN,
+};
+
+// Initialise the formation system
+bool formationInitialise();
+
+// Shutdown the formation system
+void formationShutDown();
+
+// Create a new formation
+bool formationNew(FORMATION **ppsFormation, FORMATION_TYPE type,
+					SDWORD x, SDWORD y, uint16_t dir);
+
+// Try and find a formation near to a location
+FORMATION* formationFind(int x, int y);
+
+// Associate a unit with a formation
+void formationJoin(FORMATION *psFormation, const DROID* psDroid);
+
+// Remove a unit from a formation
+void formationLeave(FORMATION *psFormation, const DROID* psDroid);
+
+// remove all the members from a formation and release it
+void formationReset(FORMATION *psFormation);
+
+// get a target position to move into a formation
+bool formationGetPos(FORMATION *psFormation, DROID* psDroid,
+					 SDWORD *pX, SDWORD *pY, bool bCheckLOS);
+
+// See if a unit is a member of a formation (i.e. it has a position assigned)
+bool formationMember(FORMATION *psFormation, const DROID* psDroid);

--- a/src/formationdef.h
+++ b/src/formationdef.h
@@ -72,5 +72,5 @@ struct FORMATION
 	// formation speed (currently speed of slowest member) - GJ - sorry.
 	UDWORD		iSpeed;
 
-	FORMATION	*psNext;
+	uint32_t	player;
 };

--- a/src/formationdef.h
+++ b/src/formationdef.h
@@ -1,0 +1,76 @@
+/*
+	This file is part of Warzone 2100.
+	Copyright (C) 1999-2004  Eidos Interactive
+	Copyright (C) 2005-2023  Warzone 2100 Project
+
+	Warzone 2100 is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+
+	Warzone 2100 is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with Warzone 2100; if not, write to the Free Software
+	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+/** \file
+ *  Definitions for formations.
+ */
+
+#pragma once
+
+struct DROID;
+
+// maximum number of lines in a formation
+#define F_MAXLINES		4
+// maximum number of unit members of a formation (cannot be more that 128)
+#define F_MAXMEMBERS	20
+
+// information about a formation line
+// a linked list of the formation members on this line is maintained
+// using their index in the asMembers array.  (-1 == 'NULL')
+// (cuts down the memory use over proper pointers)
+struct F_LINE
+{
+	SWORD		xoffset,yoffset;	// position relative to center
+	uint16_t	direction;		// orientation of line
+	SBYTE		member;				// first member in the 'linked list' of members
+};
+
+// information about a formation member
+struct F_MEMBER
+{
+	SBYTE			line;			// which line this member is on
+	SBYTE			next;			// the next member on this line
+	SWORD			dist;			// distance along the line
+	DROID           *psDroid;       // the member unit
+};
+
+// information about a formation
+struct FORMATION
+{
+	SWORD		refCount;	// number of units using the formation
+
+	SWORD		size;	// maximum length of the lines
+	SWORD		rankDist;	// seperation between the ranks
+	uint16_t	direction;	// direction of the formation
+	SDWORD		x,y;	// position of the front of the formation
+
+	// the lines that make up a formation
+	F_LINE		asLines[F_MAXLINES];
+	SWORD		numLines;
+	UBYTE		maxRank;
+
+	// the units that have a position allocated in the formation
+	SBYTE		free;
+	F_MEMBER	asMembers[F_MAXMEMBERS];
+
+	// formation speed (currently speed of slowest member) - GJ - sorry.
+	UDWORD		iSpeed;
+
+	FORMATION	*psNext;
+};

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -5684,7 +5684,7 @@ static bool loadSaveDroid(const char *pFileName, PerPlayerDroidLists& ppsCurrent
 				auto formationX = json_variant(it_x.value()).toInt();
 				auto formationY = json_variant(it_y.value()).toInt();
 
-				psDroid->sMove.psFormation = formationFind(formationX, formationY);
+				psDroid->sMove.psFormation = formationFind(psDroid->player, formationX, formationY);
 				// join a formation if it exists at the destination
 				if (psDroid->sMove.psFormation)
 				{
@@ -5694,7 +5694,7 @@ static bool loadSaveDroid(const char *pFileName, PerPlayerDroidLists& ppsCurrent
 				{
 					// no formation so create a new one
 					auto formationDirection = json_variant(it_direction.value()).toUInt();
-					if (formationNew(&psDroid->sMove.psFormation, FT_LINE, formationX, formationY,
+					if (formationNew(&psDroid->sMove.psFormation, psDroid->player, FT_LINE, formationX, formationY,
 							static_cast<uint16_t>(formationDirection)))
 					{
 						formationJoin(psDroid->sMove.psFormation, psDroid);

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -59,6 +59,7 @@
 #include "display3d.h"
 #include "edit3d.h"
 #include "effects.h"
+#include "formation.h"
 #include "fpath.h"
 #include "frend.h"
 #include "frontend.h"
@@ -1542,6 +1543,11 @@ bool stageOneInitialise()
 		return false;
 	}
 
+	if (!formationInitialise())		// Initialise the formation system
+	{
+		return false;
+	}
+
 	// initialise the visibility stuff
 	if (!visInitialise())
 	{
@@ -1606,6 +1612,8 @@ bool stageOneShutDown()
 	}
 
 	grpShutDown();
+
+	formationShutDown();
 
 	ResearchRelease();
 

--- a/src/keybind.cpp
+++ b/src/keybind.cpp
@@ -76,6 +76,7 @@
 #include "loadsave.h"
 #include "game.h"
 #include "droid.h"
+#include "move.h"
 #include "spectatorwidgets.h"
 #include "campaigninfo.h"
 
@@ -2185,7 +2186,18 @@ void	kf_CentreOnBase()
 // --------------------------------------------------------------------------
 void kf_ToggleFormationSpeedLimiting()
 {
-	addConsoleMessage(_("Formation speed limiting has been removed from the game due to bugs."), LEFT_JUSTIFY, SYSTEM_MESSAGE);
+	bool resultingValue = false;
+	if (moveToggleFormationSpeedLimiting(selectedPlayer, &resultingValue))
+	{
+		if (resultingValue)
+		{
+			addConsoleMessage(_("Formation speed limiting ON"),LEFT_JUSTIFY, SYSTEM_MESSAGE);
+		}
+		else
+		{
+			addConsoleMessage(_("Formation speed limiting OFF"),LEFT_JUSTIFY, SYSTEM_MESSAGE);
+		}
+	}
 }
 
 // --------------------------------------------------------------------------

--- a/src/move.cpp
+++ b/src/move.cpp
@@ -267,7 +267,7 @@ static bool moveDroidToBase(DROID *psDroid, UDWORD x, UDWORD y, bool bFormation,
 		if (bFormation)
 		{
 			// join a formation if it exists at the destination
-			FORMATION* psFormation = formationFind(x, y);
+			FORMATION* psFormation = formationFind(psDroid->player, x, y);
 			SDWORD	fmx1, fmy1, fmx2, fmy2;
 
 			if (psFormation)
@@ -294,7 +294,7 @@ static bool moveDroidToBase(DROID *psDroid, UDWORD x, UDWORD y, bool bFormation,
 				}
 
 				// no formation so create a new one
-				if (formationNew(&psDroid->sMove.psFormation, FT_LINE, (SDWORD)x,(SDWORD)y,
+				if (formationNew(&psDroid->sMove.psFormation, psDroid->player, FT_LINE, (SDWORD)x,(SDWORD)y,
 						 calcDirection(fmx1,fmy1, fmx2,fmy2)))
 				{
 					formationJoin(psDroid->sMove.psFormation, psDroid);

--- a/src/move.cpp
+++ b/src/move.cpp
@@ -101,14 +101,15 @@
 #define EXTRA_BITS                              8
 #define EXTRA_PRECISION                         (1 << EXTRA_BITS)
 
-static std::vector<bool> playerFormationSpeedLimiting = std::vector<bool>(MAX_PLAYERS, true);
+static std::vector<bool> playerFormationSpeedLimiting = std::vector<bool>(MAX_PLAYERS, false);
 
 void moveInit()
 {
+	// Initialize formation speed limiting to off for all players
 	playerFormationSpeedLimiting.resize(MAX_PLAYERS);
 	for (size_t i = 0; i < playerFormationSpeedLimiting.size(); ++i)
 	{
-		playerFormationSpeedLimiting[i] = true;
+		playerFormationSpeedLimiting[i] = false;
 	}
 }
 

--- a/src/move.h
+++ b/src/move.h
@@ -59,4 +59,11 @@ bool moveCheckDroidMovingAndVisible(void *psObj);
 
 const char *moveDescription(MOVE_STATUS status);
 
+bool moveSetFormationSpeedLimiting(uint32_t player, bool enabled);
+bool moveToggleFormationSpeedLimiting(uint32_t player, bool *pBoolResultingValue);
+bool moveFormationSpeedLimitingOn(uint32_t player);
+bool recvSyncOptChange(NETQUEUE queue);
+
+void moveInit();
+
 #endif // __INCLUDED_SRC_MOVE_H__

--- a/src/movedef.h
+++ b/src/movedef.h
@@ -25,6 +25,7 @@
 #define __INCLUDED_MOVEDEF_H__
 
 #include "lib/framework/vector.h"
+#include "formationdef.h"
 
 #include <vector>
 
@@ -60,6 +61,8 @@ struct MOVE_CONTROL
 	Position bumpPos = Position(0, 0, 0); ///< Position of last bump
 
 	unsigned shuffleStart = 0;            ///< When a shuffle started
+
+	FORMATION *psFormation = nullptr;     ///< formation the droid is currently a member of
 
 	int iVertSpeed = 0;                   ///< VTOL movement
 };

--- a/src/multiplay.cpp
+++ b/src/multiplay.cpp
@@ -65,6 +65,7 @@
 #include "design.h"
 #include "advvis.h"
 #include "lighting.h" // for reInitPaletteAndFog()
+#include "move.h"
 
 #include "template.h"
 #include "lib/netplay/netplay.h"								// the netplay library.
@@ -1260,6 +1261,9 @@ bool recvMessage()
 				break;
 			case GAME_DEBUG_FINISH_RESEARCH:
 				recvResearch(queue);
+				break;
+			case GAME_SYNC_OPT_CHANGE:
+				recvSyncOptChange(queue);
 				break;
 			case REPLAY_ENDED:
 				if (!NETisReplay())

--- a/src/order.cpp
+++ b/src/order.cpp
@@ -36,6 +36,8 @@
 #include "order.h"
 #include "action.h"
 #include "map.h"
+#include "formationdef.h"
+#include "formation.h"
 #include "projectile.h"
 #include "effects.h"	// for waypoint display
 #include "lib/gamelib/gtime.h"
@@ -892,6 +894,13 @@ void orderUpdateDroid(DROID *psDroid)
 			}
 			else
 			{
+				// don't want the droids to go into a formation for this order
+				if (psDroid->sMove.psFormation != nullptr)
+				{
+					formationLeave(psDroid->sMove.psFormation, psDroid);
+					psDroid->sMove.psFormation = nullptr;
+				}
+
 				// Wait for the action to finish then assign to Transporter (if not already flying)
 				if (psDroid->order.psObj == nullptr || transporterFlying((DROID *)psDroid->order.psObj))
 				{
@@ -1113,6 +1122,12 @@ void orderUpdateDroid(DROID *psDroid)
 		}
 		break;
 	case DORDER_RECYCLE:
+		// don't bother with formations for this order
+		if (psDroid->sMove.psFormation)
+		{
+			formationLeave(psDroid->sMove.psFormation, psDroid);
+			psDroid->sMove.psFormation = nullptr;
+		}
 		if (psDroid->order.psObj == nullptr)
 		{
 			psDroid->order = DroidOrder(DORDER_NONE);
@@ -1675,6 +1690,11 @@ void orderDroidBase(DROID *psDroid, DROID_ORDER_DATA *psOrder)
 					actionVTOLLandingPos(psDroid, &pos);
 				}
 				actionDroid(psDroid, DACTION_MOVE, pos.x, pos.y);
+				if (psDroid->sMove.psFormation)
+				{
+					formationLeave(psDroid->sMove.psFormation, psDroid);
+					psDroid->sMove.psFormation = nullptr;
+				}
 				break;
 			}
 		}


### PR DESCRIPTION
- At the moment, this is mainly useful for formation speed limiting. The old functionality that would move a unit into formation on arrival (i.e. actual formation "positions") requires reimplementing.
- Formation speed-limiting is now a per-player setting, which is also synchronized across the network.

Formation speed-limiting is currently disabled by default for all players.