### PR TITLE
Adjust script map max tile height handling

### DIFF
--- a/data/mp/multiplay/maps/6c-Entropy/game.js
+++ b/data/mp/multiplay/maps/6c-Entropy/game.js
@@ -169,7 +169,7 @@ function genRegions(fields) {
 		var regions = [];
 		for (var i = 0; i < fields.count; ++i) {
 			var textureType = textureTypes[gameRand(textureTypes.length)];
-			var height = textureType.isWater? 0 : gameRand(500) + 12;
+			var height = textureType.isWater? 0 : gameRand(499) + 12;
 			regions.push({texture: textureType, height: height, avg: fields.avg[i], reachable: false});
 		}
 
@@ -522,7 +522,7 @@ function placeStuff(regions, startPos) {
 			features.push({name: sample(snow? snowFeatureTypes : featureTypes), position: pos, direction: gameRand(0x10000)});
 		}
 	}
-	
+
 	// Add additional oils
 	for(var i=0;i<60*(richness-3);i++){
 		var oilPos = placeNear(gameRand(mapWidth), gameRand(mapHeight), 1, 1, true, 20);

--- a/lib/wzmaplib/src/map_script.cpp
+++ b/lib/wzmaplib/src/map_script.cpp
@@ -292,7 +292,12 @@ static JSValue runMap_setMapData(JSContext *ctx, JSValueConst this_val, int argc
 		SCRIPT_ASSERT_AND_RETURNERROR(ctx, textureUint32 <= (uint32_t)std::numeric_limits<uint16_t>::max(), "texture value exceeds uint16::max: %" PRIu32 "", textureUint32);
 		mapData->mMapTiles[n].texture = static_cast<uint16_t>(textureUint32);
 		tileHeightUint32 = JSValueToUint32(ctx, heightVal);
-		SCRIPT_ASSERT_AND_RETURNERROR(ctx, tileHeightUint32 <= TILE_MAX_HEIGHT, "tile height (%" PRIu32 ") exceeds TILE_MAX_HEIGHT (%" PRIu32 ")", tileHeightUint32, TILE_MAX_HEIGHT);
+		if (tileHeightUint32 > TILE_MAX_HEIGHT)
+		{
+			// treat as non-fatal error (to support older script maps) - log and cap at TILE_MAX_HEIGHT
+			debug(pCustomLogger, LOG_ERROR, "tile height (%" PRIu32 ") exceeds TILE_MAX_HEIGHT (%" PRIu32 ")", tileHeightUint32, TILE_MAX_HEIGHT);
+			tileHeightUint32 = TILE_MAX_HEIGHT;
+		}
 		mapData->mMapTiles[n].height = static_cast<uint16_t>(tileHeightUint32);
 	}
 	bGotArrayLength = QuickJS_GetArrayLength(ctx, structures, arrayLen);


### PR DESCRIPTION
- wzmaplib: Treat TILE_MAX_HEIGHT check as non-fatal error (log the error, but cap at TILE_MAX_HEIGHT)
- 6c-Entropy: Fix max tile height