### PR TITLE
Prevent underflow in getMissionTime() calculation

### DIFF
--- a/data/mp/multiplay/script/rules/endconditions.js
+++ b/data/mp/multiplay/script/rules/endconditions.js
@@ -398,10 +398,9 @@ function activityAlert()
 		console(
 			_("- unit building - research completion - construction of base structures (factories, power plants, laboratories, modules and oil derricks) - dealing damage")
 		);
-		if (getMissionTime() > idleTime)
+		if (getMissionTime() <= -1)
 		{
-			setMissionTime(
-				(playersTeam[selectedPlayer].lastActivity + idleTime - gameTime) / 1000);
+			setMissionTime((playersTeam[selectedPlayer].lastActivity + idleTime - gameTime) / 1000);
 		}
 	}
 	if (playersTeam[selectedPlayer].lastActivity + idleTime / 2 > gameTime)

--- a/src/wzapi.cpp
+++ b/src/wzapi.cpp
@@ -2565,6 +2565,10 @@ wzapi::no_return_value wzapi::setMissionTime(WZAPI_PARAMS(int _time))
 //--
 int wzapi::getMissionTime(WZAPI_NO_PARAMS)
 {
+	if (mission.time < 0)
+	{
+		return -1;
+	}
 	return (mission.time - (gameTime - mission.startTime)) / GAME_TICKS_PER_SEC;
 }
 


### PR DESCRIPTION
`mission.time` undergoes signed to unsigned int promotion, and when `mission.time` is -1 either from initialization or from a setMissionTime(-1) to disable the timer, it would result in huge values being returned.

This resulted in the scripted power auto-gain bonus giving the player maximum power in this case.