### PR TITLE
Move level loading codes into library

### DIFF
--- a/data/base/script/campaign/cam1-1.js
+++ b/data/base/script/campaign/cam1-1.js
@@ -124,7 +124,7 @@ function blowupNonOriginalStructures()
 //Mission setup stuff
 function eventStartLevel()
 {
-	camSetStandardWinLossConditions(CAM_VICTORY_OFFWORLD, "SUB_1_2S", {
+	camSetStandardWinLossConditions(CAM_VICTORY_OFFWORLD, cam_levels.alpha4.pre, {
 		area: "RTLZ",
 		message: "C1-1_LZ",
 		reinforcements: -1, //No reinforcements

--- a/data/base/script/campaign/cam1-1s.js
+++ b/data/base/script/campaign/cam1-1s.js
@@ -65,7 +65,7 @@ function eventStartLevel()
 	centreView(mis_Labels.startPos.x, mis_Labels.startPos.y);
 	setNoGoArea(mis_Labels.lz.x, mis_Labels.lz.y, mis_Labels.lz.x2, mis_Labels.lz.y2, CAM_HUMAN_PLAYER);
 	setMissionTime((tweakOptions.classicTimers) ? -1 : camChangeOnDiff(camMinutesToSeconds(10))); // 10 min for building module.
-	camSetStandardWinLossConditions(CAM_VICTORY_PRE_OFFWORLD, "SUB_1_1");
+	camSetStandardWinLossConditions(CAM_VICTORY_PRE_OFFWORLD, cam_levels.alpha3.offWorld);
 	cheat = false;
 	powModVideoPlayed = false;
 

--- a/data/base/script/campaign/cam1-2.js
+++ b/data/base/script/campaign/cam1-2.js
@@ -61,7 +61,7 @@ function enableWestFactory()
 
 function eventStartLevel()
 {
-	camSetStandardWinLossConditions(CAM_VICTORY_OFFWORLD, "SUB_1_3S", {
+	camSetStandardWinLossConditions(CAM_VICTORY_OFFWORLD, cam_levels.alpha5.pre, {
 		area: "RTLZ",
 		message: "C1-2_LZ",
 		reinforcements: 60,

--- a/data/base/script/campaign/cam1-2s.js
+++ b/data/base/script/campaign/cam1-2s.js
@@ -14,5 +14,5 @@ function eventStartLevel()
 	setNoGoArea(mis_Labels.lz.x, mis_Labels.lz.y, mis_Labels.lz.x2, mis_Labels.lz.y2, CAM_HUMAN_PLAYER);
 	setMissionTime(camChangeOnDiff(camMinutesToSeconds(30)));
 	camPlayVideos({video: "SB1_2_MSG", type: CAMP_MSG});
-	camSetStandardWinLossConditions(CAM_VICTORY_PRE_OFFWORLD, "SUB_1_2");
+	camSetStandardWinLossConditions(CAM_VICTORY_PRE_OFFWORLD, cam_levels.alpha4.offWorld);
 }

--- a/data/base/script/campaign/cam1-3.js
+++ b/data/base/script/campaign/cam1-3.js
@@ -150,7 +150,7 @@ function eventAttacked(victim, attacker) {
 function enableReinforcements()
 {
 	playSound(cam_sounds.reinforcementsAreAvailable);
-	camSetStandardWinLossConditions(CAM_VICTORY_OFFWORLD, "CAM_1C", {
+	camSetStandardWinLossConditions(CAM_VICTORY_OFFWORLD, cam_levels.alpha6, {
 		area: "RTLZ",
 		message: "C1-3_LZ",
 		reinforcements: camMinutesToSeconds(2), // changes!
@@ -229,7 +229,7 @@ function blowupSouthScavengerBase()
 
 function eventStartLevel()
 {
-	camSetStandardWinLossConditions(CAM_VICTORY_OFFWORLD, "CAM_1C", {
+	camSetStandardWinLossConditions(CAM_VICTORY_OFFWORLD, cam_levels.alpha6, {
 		area: "RTLZ",
 		message: "C1-3_LZ",
 		reinforcements: -1, // will override later

--- a/data/base/script/campaign/cam1-3s.js
+++ b/data/base/script/campaign/cam1-3s.js
@@ -14,5 +14,5 @@ function eventStartLevel()
 	setNoGoArea(mis_Labels.lz.x, mis_Labels.lz.y, mis_Labels.lz.x2, mis_Labels.lz.y2, CAM_HUMAN_PLAYER);
 	setMissionTime(camChangeOnDiff(camHoursToSeconds(1)));
 	camPlayVideos({video: "SB1_3_UPDATE", type: CAMP_MSG});
-	camSetStandardWinLossConditions(CAM_VICTORY_PRE_OFFWORLD, "SUB_1_3");
+	camSetStandardWinLossConditions(CAM_VICTORY_PRE_OFFWORLD, cam_levels.alpha5.offWorld);
 }

--- a/data/base/script/campaign/cam1-4a.js
+++ b/data/base/script/campaign/cam1-4a.js
@@ -65,7 +65,7 @@ camAreaEvent("LandingZoneTrigger", function()
 
 	// Give extra 40 minutes.
 	setMissionTime(camChangeOnDiff(camMinutesToSeconds((tweakOptions.classicTimers) ? 30 : 40)) + getMissionTime());
-	camSetStandardWinLossConditions(CAM_VICTORY_OFFWORLD, "SUB_1_5S", {
+	camSetStandardWinLossConditions(CAM_VICTORY_OFFWORLD, cam_levels.alpha9.pre, {
 		area: "RTLZ",
 		message: "C1-4_LZ",
 		reinforcements: camMinutesToSeconds(1.5), // changes!
@@ -115,7 +115,7 @@ function buildDefenses()
 
 function eventStartLevel()
 {
-	camSetStandardWinLossConditions(CAM_VICTORY_OFFWORLD, "SUB_1_5S", {
+	camSetStandardWinLossConditions(CAM_VICTORY_OFFWORLD, cam_levels.alpha9.pre, {
 		area: "RTLZ",
 		message: "C1-4_LZ",
 		reinforcements: -1, // will override later

--- a/data/base/script/campaign/cam1-4as.js
+++ b/data/base/script/campaign/cam1-4as.js
@@ -14,5 +14,5 @@ function eventStartLevel()
 	setNoGoArea(mis_Labels.lz.x, mis_Labels.lz.y, mis_Labels.lz.x2, mis_Labels.lz.y2, CAM_HUMAN_PLAYER);
 	setMissionTime(camChangeOnDiff(camMinutesToSeconds(30)));
 	camPlayVideos({video: "SB1_4_MSG", type: MISS_MSG});
-	camSetStandardWinLossConditions(CAM_VICTORY_PRE_OFFWORLD, "SUB_1_4A");
+	camSetStandardWinLossConditions(CAM_VICTORY_PRE_OFFWORLD, cam_levels.alpha8.offWorld);
 }

--- a/data/base/script/campaign/cam1-5.js
+++ b/data/base/script/campaign/cam1-5.js
@@ -190,7 +190,7 @@ function camEnemyBaseEliminated_NPBaseGroup()
 
 function eventStartLevel()
 {
-	camSetStandardWinLossConditions(CAM_VICTORY_OFFWORLD, "CAM_1A-C", {
+	camSetStandardWinLossConditions(CAM_VICTORY_OFFWORLD, cam_levels.alpha10, {
 		area: "RTLZ",
 		message: "C1-5_LZ",
 		reinforcements: camMinutesToSeconds(3),

--- a/data/base/script/campaign/cam1-5s.js
+++ b/data/base/script/campaign/cam1-5s.js
@@ -14,5 +14,5 @@ function eventStartLevel()
 	setNoGoArea(mis_Labels.lz.x, mis_Labels.lz.y, mis_Labels.lz.x2, mis_Labels.lz.y2, CAM_HUMAN_PLAYER);
 	setMissionTime(camChangeOnDiff(camHoursToSeconds(1)));
 	camPlayVideos({video: "SB1_5_MSG", type: MISS_MSG});
-	camSetStandardWinLossConditions(CAM_VICTORY_PRE_OFFWORLD, "SUB_1_5");
+	camSetStandardWinLossConditions(CAM_VICTORY_PRE_OFFWORLD, cam_levels.alpha9.offWorld);
 }

--- a/data/base/script/campaign/cam1-7.js
+++ b/data/base/script/campaign/cam1-7.js
@@ -272,7 +272,7 @@ function eventStartLevel()
 	startTransporterEntry(tEnt.x, tEnt.y, CAM_HUMAN_PLAYER);
 	setTransporterExit(tExt.x, tExt.y, CAM_HUMAN_PLAYER);
 
-	camSetStandardWinLossConditions(CAM_VICTORY_OFFWORLD, "SUB_1_DS", {
+	camSetStandardWinLossConditions(CAM_VICTORY_OFFWORLD, cam_levels.alpha12.pre, {
 		area: "RTLZ",
 		message: "C1-7_LZ",
 		reinforcements: camMinutesToSeconds(1),

--- a/data/base/script/campaign/cam1-7s.js
+++ b/data/base/script/campaign/cam1-7s.js
@@ -14,5 +14,5 @@ function eventStartLevel()
 	setNoGoArea(mis_Labels.lz.x, mis_Labels.lz.y, mis_Labels.lz.x2, mis_Labels.lz.y2, CAM_HUMAN_PLAYER);
 	setMissionTime(camChangeOnDiff(camMinutesToSeconds(30)));
 	camPlayVideos([{video: "SB1_7_MSG", type: CAMP_MSG}, {video: "SB1_7_MSG2", type: MISS_MSG}]);
-	camSetStandardWinLossConditions(CAM_VICTORY_PRE_OFFWORLD, "SUB_1_7");
+	camSetStandardWinLossConditions(CAM_VICTORY_PRE_OFFWORLD, cam_levels.alpha11.offWorld);
 }

--- a/data/base/script/campaign/cam1-d.js
+++ b/data/base/script/campaign/cam1-d.js
@@ -157,7 +157,7 @@ function setupPatrols()
 
 function eventStartLevel()
 {
-	camSetStandardWinLossConditions(CAM_VICTORY_OFFWORLD, "CAM_1END", {
+	camSetStandardWinLossConditions(CAM_VICTORY_OFFWORLD, cam_levels.alphaEnd, {
 		area: "RTLZ",
 		message: "C1D_LZ",
 		reinforcements: camMinutesToSeconds(2),

--- a/data/base/script/campaign/cam1-ds.js
+++ b/data/base/script/campaign/cam1-ds.js
@@ -14,5 +14,5 @@ function eventStartLevel()
 	setNoGoArea(mis_Labels.lz.x, mis_Labels.lz.y, mis_Labels.lz.x2, mis_Labels.lz.y2, CAM_HUMAN_PLAYER);
 	setMissionTime(camChangeOnDiff(camHoursToSeconds(2)));
 	camPlayVideos([{video: "MB1D_MSG", type: CAMP_MSG}, {video: "MB1D_MSG2", type: MISS_MSG}]);
-	camSetStandardWinLossConditions(CAM_VICTORY_PRE_OFFWORLD, "SUB_1_D");
+	camSetStandardWinLossConditions(CAM_VICTORY_PRE_OFFWORLD, cam_levels.alpha12.offWorld);
 }

--- a/data/base/script/campaign/cam1a-c.js
+++ b/data/base/script/campaign/cam1a-c.js
@@ -146,7 +146,7 @@ function eventStartLevel()
 {
 	camSetExtraObjectiveMessage(_("Destroy all New Paradigm reinforcements"));
 
-	camSetStandardWinLossConditions(CAM_VICTORY_STANDARD, "SUB_1_7S", {
+	camSetStandardWinLossConditions(CAM_VICTORY_STANDARD, cam_levels.alpha11.pre, {
 		callback: "extraVictoryCondition"
 	});
 

--- a/data/base/script/campaign/cam1a.js
+++ b/data/base/script/campaign/cam1a.js
@@ -217,7 +217,7 @@ function eventStartLevel()
 	const startPos = getObject("startPosition");
 	const lz = getObject("landingZone");
 
-	camSetStandardWinLossConditions(CAM_VICTORY_STANDARD, "CAM_1B");
+	camSetStandardWinLossConditions(CAM_VICTORY_STANDARD, cam_levels.alpha2);
 
 	centreView(startPos.x, startPos.y);
 	setNoGoArea(lz.x, lz.y, lz.x2, lz.y2, CAM_HUMAN_PLAYER);

--- a/data/base/script/campaign/cam1a.js
+++ b/data/base/script/campaign/cam1a.js
@@ -1,6 +1,7 @@
 include("script/campaign/libcampaign.js");
 include("script/campaign/templates.js");
 
+const GUIDE_STRUCT_BUILT_DELAY_TIME = 100;
 const mis_playerRes = [
 	"R-Wpn-MG1Mk1", "R-Vehicle-Body01", "R-Sys-Spade1Mk1", "R-Vehicle-Prop-Wheels",
 ];
@@ -13,13 +14,13 @@ const mis_scavengerRes = [
 
 // Handlers for guide topics
 
-function __cam1A_doAddHQBuiltTopics()
+function cam1A_doAddHQBuiltTopics()
 {
 	addGuideTopic("wz2100::structures::factory");
 	addGuideTopic("wz2100::units::designing", SHOWTOPIC_FIRSTADD);
 }
 
-function __cam1A_doAddFactoryBuiltTopics()
+function cam1A_doAddFactoryBuiltTopics()
 {
 	addGuideTopic("wz2100::units::designing");
 	addGuideTopic("wz2100::structures::rallypoint");
@@ -27,19 +28,17 @@ function __cam1A_doAddFactoryBuiltTopics()
 	addGuideTopic("wz2100::units::building", SHOWTOPIC_FIRSTADD);
 }
 
-function __cam1A_doAddResearchFacilityBuiltTopics()
+function cam1A_doAddResearchFacilityBuiltTopics()
 {
 	addGuideTopic("wz2100::structures::researchfacility", SHOWTOPIC_FIRSTADD);
 }
 
-function __cam1A_doAddOilDerrickBuiltTopics()
+function cam1A_doAddOilDerrickBuiltTopics()
 {
 	addGuideTopic("wz2100::general::power");
 	addGuideTopic("wz2100::structures::oilderrick");
 	addGuideTopic("wz2100::structures::powergenerator", SHOWTOPIC_FIRSTADD);
 }
-
-const GUIDE_STRUCT_BUILT_DELAY_TIME = 100;
 
 // Player zero's droid enters area next to first oil patch.
 camAreaEvent("launchScavAttack", function(droid)
@@ -127,11 +126,11 @@ function eventStructureBuilt(structure, droid)
 	{
 		if (structure.stattype === FACTORY)
 		{
-			queue("__cam1A_doAddFactoryBuiltTopics", GUIDE_STRUCT_BUILT_DELAY_TIME);
+			queue("cam1A_doAddFactoryBuiltTopics", GUIDE_STRUCT_BUILT_DELAY_TIME);
 		}
 		else if (structure.stattype === RESEARCH_LAB)
 		{
-			queue("__cam1A_doAddResearchFacilityBuiltTopics", GUIDE_STRUCT_BUILT_DELAY_TIME);
+			queue("cam1A_doAddResearchFacilityBuiltTopics", GUIDE_STRUCT_BUILT_DELAY_TIME);
 		}
 		else if (structure.stattype === RESOURCE_EXTRACTOR)
 		{
@@ -148,11 +147,11 @@ function eventStructureBuilt(structure, droid)
 			}
 
 			// Add the oil derrick topic
-			queue("__cam1A_doAddOilDerrickBuiltTopics", GUIDE_STRUCT_BUILT_DELAY_TIME);
+			queue("cam1A_doAddOilDerrickBuiltTopics", GUIDE_STRUCT_BUILT_DELAY_TIME);
 		}
 		else if (structure.stattype === HQ)
 		{
-			queue("__cam1A_doAddHQBuiltTopics", GUIDE_STRUCT_BUILT_DELAY_TIME);
+			queue("cam1A_doAddHQBuiltTopics", GUIDE_STRUCT_BUILT_DELAY_TIME);
 		}
 	}
 }
@@ -186,7 +185,7 @@ function enableBaseStructures()
 	}
 }
 
-function __cam1A_doNeedPowerTopics()
+function cam1A_doNeedPowerTopics()
 {
 	// inform the user about power (and the need to build an oil derrick)
 	addGuideTopic("wz2100::structures::oilderrick");
@@ -202,7 +201,7 @@ function eventDroidBuilt(droid, structure)
 	if (droid.player === CAM_HUMAN_PLAYER)
 	{
 		// inform the user about power (and the need to build an oil derrick)
-		camCallOnce("__cam1A_doNeedPowerTopics");
+		camCallOnce("cam1A_doNeedPowerTopics");
 	}
 }
 

--- a/data/base/script/campaign/cam1b.js
+++ b/data/base/script/campaign/cam1b.js
@@ -73,7 +73,7 @@ camAreaEvent("NPSensorRemove", function(droid)
 
 function eventStartLevel()
 {
-	camSetStandardWinLossConditions(CAM_VICTORY_STANDARD, "SUB_1_1S");
+	camSetStandardWinLossConditions(CAM_VICTORY_STANDARD, cam_levels.alpha3.pre);
 	const startPos = getObject("startPosition");
 	const lz = getObject("landingZone");
 	centreView(startPos.x, startPos.y);

--- a/data/base/script/campaign/cam1c.js
+++ b/data/base/script/campaign/cam1c.js
@@ -186,7 +186,7 @@ camAreaEvent("NPLZ2Trigger", function()
 
 function eventStartLevel()
 {
-	camSetStandardWinLossConditions(CAM_VICTORY_STANDARD, "CAM_1CA");
+	camSetStandardWinLossConditions(CAM_VICTORY_STANDARD, cam_levels.alpha7);
 	const startPos = getObject("startPosition");
 	const lz = getObject("landingZone");
 	centreView(startPos.x, startPos.y);

--- a/data/base/script/campaign/cam1ca.js
+++ b/data/base/script/campaign/cam1ca.js
@@ -162,7 +162,7 @@ function eventStartLevel()
 	totalTransportLoads = 0;
 	blipActive = false;
 
-	camSetStandardWinLossConditions(CAM_VICTORY_STANDARD, "SUB_1_4AS", {
+	camSetStandardWinLossConditions(CAM_VICTORY_STANDARD, cam_levels.alpha8.pre, {
 		callback: "extraVictoryCondition"
 	});
 	const startPos = getObject("startPosition");

--- a/data/base/script/campaign/cam1end.js
+++ b/data/base/script/campaign/cam1end.js
@@ -14,5 +14,5 @@ function eventStartLevel()
 	setNoGoArea(mis_Labels.lz.x, mis_Labels.lz.y, mis_Labels.lz.x2, mis_Labels.lz.y2, CAM_HUMAN_PLAYER);
 	setMissionTime(camMinutesToSeconds((tweakOptions.classicTimers) ? 10 : 15));
 	camPlayVideos([{video: "CAM1_OUT", type: CAMP_MSG}, {video: "CAM1_OUT2", type: CAMP_MSG}, {video: "CAM2_BRIEF", type: CAMP_MSG}]);
-	camSetStandardWinLossConditions(CAM_VICTORY_PRE_OFFWORLD, "CAM_2A");
+	camSetStandardWinLossConditions(CAM_VICTORY_PRE_OFFWORLD, cam_levels.beta1);
 }

--- a/data/base/script/campaign/cam2-1s.js
+++ b/data/base/script/campaign/cam2-1s.js
@@ -9,7 +9,7 @@ const mis_Labels = {
 
 function eventStartLevel()
 {
-	camSetStandardWinLossConditions(CAM_VICTORY_PRE_OFFWORLD, "SUB_2_1");
+	camSetStandardWinLossConditions(CAM_VICTORY_PRE_OFFWORLD, cam_levels.beta2.offWorld);
 	camSetupTransporter(mis_Labels.trPlace.x, mis_Labels.trPlace.y, mis_Labels.trExit.x, mis_Labels.trExit.y);
 	centreView(mis_Labels.startPos.x, mis_Labels.startPos.y);
 	setNoGoArea(mis_Labels.lz.x, mis_Labels.lz.y, mis_Labels.lz.x2, mis_Labels.lz.y2, CAM_HUMAN_PLAYER);

--- a/data/base/script/campaign/cam2-1x.js
+++ b/data/base/script/campaign/cam2-1x.js
@@ -115,7 +115,7 @@ function eventStartLevel()
 {
 	camSetExtraObjectiveMessage(_("Locate and rescue your units from the shot down transporter"));
 
-	camSetStandardWinLossConditions(CAM_VICTORY_OFFWORLD, "CAM_2B", {
+	camSetStandardWinLossConditions(CAM_VICTORY_OFFWORLD, cam_levels.beta3, {
 		area: "RTLZ",
 		message: "C21_LZ",
 		reinforcements: -1,

--- a/data/base/script/campaign/cam2-2.js
+++ b/data/base/script/campaign/cam2-2.js
@@ -203,7 +203,7 @@ function eventAttacked(victim, attacker)
 
 function eventStartLevel()
 {
-	camSetStandardWinLossConditions(CAM_VICTORY_OFFWORLD, "CAM_2C",{
+	camSetStandardWinLossConditions(CAM_VICTORY_OFFWORLD, cam_levels.beta5,{
 		area: "RTLZ",
 		message: "C22_LZ",
 		reinforcements: camMinutesToSeconds(3),

--- a/data/base/script/campaign/cam2-2s.js
+++ b/data/base/script/campaign/cam2-2s.js
@@ -14,5 +14,5 @@ function eventStartLevel()
 	setNoGoArea(mis_Labels.lz.x, mis_Labels.lz.y, mis_Labels.lz.x2, mis_Labels.lz.y2, CAM_HUMAN_PLAYER);
 	setMissionTime(camChangeOnDiff(camMinutesToSeconds(70)));
 	camPlayVideos([{video: "MB2_2_MSG", type: CAMP_MSG}, {video:"MB2_2_MSG2", type: CAMP_MSG}, {video: "MB2_2_MSG3", type: MISS_MSG}]);
-	camSetStandardWinLossConditions(CAM_VICTORY_PRE_OFFWORLD, "SUB_2_2");
+	camSetStandardWinLossConditions(CAM_VICTORY_PRE_OFFWORLD, cam_levels.beta4.offWorld);
 }

--- a/data/base/script/campaign/cam2-5.js
+++ b/data/base/script/campaign/cam2-5.js
@@ -102,7 +102,7 @@ function enableFactories()
 
 function eventStartLevel()
 {
-	camSetStandardWinLossConditions(CAM_VICTORY_OFFWORLD, "SUB_2DS",{
+	camSetStandardWinLossConditions(CAM_VICTORY_OFFWORLD, cam_levels.beta7.pre,{
 		area: "RTLZ",
 		message: "C25_LZ",
 		reinforcements: camMinutesToSeconds(3)

--- a/data/base/script/campaign/cam2-5s.js
+++ b/data/base/script/campaign/cam2-5s.js
@@ -14,5 +14,5 @@ function eventStartLevel()
 	setNoGoArea(mis_Labels.lz.x, mis_Labels.lz.y, mis_Labels.lz.x2, mis_Labels.lz.y2, CAM_HUMAN_PLAYER);
 	setMissionTime(camChangeOnDiff(camHoursToSeconds(1)));
 	camPlayVideos([{video: "MB2_5_MSG", type: CAMP_MSG}, {video: "MB2_5_MSG2", type: MISS_MSG}]);
-	camSetStandardWinLossConditions(CAM_VICTORY_PRE_OFFWORLD, "SUB_2_5");
+	camSetStandardWinLossConditions(CAM_VICTORY_PRE_OFFWORLD, cam_levels.beta6.offWorld);
 }

--- a/data/base/script/campaign/cam2-6.js
+++ b/data/base/script/campaign/cam2-6.js
@@ -123,7 +123,7 @@ function enableTimeBasedFactories()
 
 function eventStartLevel()
 {
-	camSetStandardWinLossConditions(CAM_VICTORY_OFFWORLD, "SUB_2_7S", {
+	camSetStandardWinLossConditions(CAM_VICTORY_OFFWORLD, cam_levels.beta9.pre, {
 		area: "RTLZ",
 		message: "C26_LZ",
 		reinforcements: camMinutesToSeconds(3)

--- a/data/base/script/campaign/cam2-6s.js
+++ b/data/base/script/campaign/cam2-6s.js
@@ -14,5 +14,5 @@ function eventStartLevel()
 	setNoGoArea(mis_Labels.lz.x, mis_Labels.lz.y, mis_Labels.lz.x2, mis_Labels.lz.y2, CAM_HUMAN_PLAYER);
 	setMissionTime(camChangeOnDiff(camHoursToSeconds(1)));
 	camPlayVideos([{video: "MB2_6_MSG", type: CAMP_MSG}, {video: "MB2_6_MSG2", type: CAMP_MSG}, {video: "MB2_6_MSG3", type: MISS_MSG}]);
-	camSetStandardWinLossConditions(CAM_VICTORY_PRE_OFFWORLD, "SUB_2_6");
+	camSetStandardWinLossConditions(CAM_VICTORY_PRE_OFFWORLD, cam_levels.beta8.offWorld);
 }

--- a/data/base/script/campaign/cam2-7.js
+++ b/data/base/script/campaign/cam2-7.js
@@ -111,7 +111,7 @@ function truckDefense()
 
 function eventStartLevel()
 {
-	camSetStandardWinLossConditions(CAM_VICTORY_OFFWORLD, "SUB_2_8S", {
+	camSetStandardWinLossConditions(CAM_VICTORY_OFFWORLD, cam_levels.beta10.pre, {
 		eliminateBases: true,
 		area: "RTLZ",
 		message: "C27_LZ",

--- a/data/base/script/campaign/cam2-7s.js
+++ b/data/base/script/campaign/cam2-7s.js
@@ -14,5 +14,5 @@ function eventStartLevel()
 	setNoGoArea(mis_Labels.lz.x, mis_Labels.lz.y, mis_Labels.lz.x2, mis_Labels.lz.y2, CAM_HUMAN_PLAYER);
 	setMissionTime(camChangeOnDiff(camHoursToSeconds(1.5)));
 	camPlayVideos([{video: "MB2_7_MSG", type: CAMP_MSG}, {video: "MB2_7_MSG2", type: MISS_MSG}]);
-	camSetStandardWinLossConditions(CAM_VICTORY_PRE_OFFWORLD, "SUB_2_7");
+	camSetStandardWinLossConditions(CAM_VICTORY_PRE_OFFWORLD, cam_levels.beta9.offWorld);
 }

--- a/data/base/script/campaign/cam2-8.js
+++ b/data/base/script/campaign/cam2-8.js
@@ -101,7 +101,7 @@ function truckDefense()
 
 function eventStartLevel()
 {
-	camSetStandardWinLossConditions(CAM_VICTORY_OFFWORLD, "CAM_2END", {
+	camSetStandardWinLossConditions(CAM_VICTORY_OFFWORLD, cam_levels.betaEnd, {
 		area: "RTLZ",
 		reinforcements: camMinutesToSeconds(3),
 		annihilate: true

--- a/data/base/script/campaign/cam2-8s.js
+++ b/data/base/script/campaign/cam2-8s.js
@@ -14,5 +14,5 @@ function eventStartLevel()
 	setNoGoArea(mis_Labels.lz.x, mis_Labels.lz.y, mis_Labels.lz.x2, mis_Labels.lz.y2, CAM_HUMAN_PLAYER);
 	setMissionTime(camChangeOnDiff(camHoursToSeconds(1)));
 	camPlayVideos([{video: "MB2_8_MSG", type: CAMP_MSG}, {video: "MB2_8_MSG2", type: MISS_MSG}]);
-	camSetStandardWinLossConditions(CAM_VICTORY_PRE_OFFWORLD, "SUB_2_8");
+	camSetStandardWinLossConditions(CAM_VICTORY_PRE_OFFWORLD, cam_levels.beta10.offWorld);
 }

--- a/data/base/script/campaign/cam2-a.js
+++ b/data/base/script/campaign/cam2-a.js
@@ -403,7 +403,7 @@ function eventStartLevel()
 	const tEnt = getObject("transporterEntry");
 	const tExt = getObject("transporterExit");
 
-	camSetStandardWinLossConditions(CAM_VICTORY_STANDARD, "SUB_2_1S");
+	camSetStandardWinLossConditions(CAM_VICTORY_STANDARD, cam_levels.beta2.pre);
 	setReinforcementTime(LZ_COMPROMISED_TIME);
 
 	centreView(startPos.x, startPos.y);

--- a/data/base/script/campaign/cam2-b.js
+++ b/data/base/script/campaign/cam2-b.js
@@ -162,7 +162,7 @@ function transferPower()
 
 function eventStartLevel()
 {
-	camSetStandardWinLossConditions(CAM_VICTORY_STANDARD, "SUB_2_2S");
+	camSetStandardWinLossConditions(CAM_VICTORY_STANDARD, cam_levels.beta4.pre);
 
 	const startPos = getObject("startPosition");
 	const lz = getObject("landingZone"); //player lz

--- a/data/base/script/campaign/cam2-c.js
+++ b/data/base/script/campaign/cam2-c.js
@@ -283,7 +283,7 @@ function extraVictoryCondition()
 
 function eventStartLevel()
 {
-	camSetStandardWinLossConditions(CAM_VICTORY_STANDARD, "SUB_2_5S", {
+	camSetStandardWinLossConditions(CAM_VICTORY_STANDARD, cam_levels.beta6.pre, {
 		callback: "extraVictoryCondition"
 	});
 

--- a/data/base/script/campaign/cam2-d.js
+++ b/data/base/script/campaign/cam2-d.js
@@ -126,7 +126,7 @@ function eventStartLevel()
 {
 	camSetExtraObjectiveMessage(_("Secure the Uplink from The Collective"));
 
-	camSetStandardWinLossConditions(CAM_VICTORY_OFFWORLD, "SUB_2_6S", {
+	camSetStandardWinLossConditions(CAM_VICTORY_OFFWORLD, cam_levels.beta8.pre, {
 		area: "RTLZ",
 		message: "C2D_LZ",
 		reinforcements: camMinutesToSeconds(5),

--- a/data/base/script/campaign/cam2-ds.js
+++ b/data/base/script/campaign/cam2-ds.js
@@ -14,5 +14,5 @@ function eventStartLevel()
 	setNoGoArea(mis_Labels.lz.x, mis_Labels.lz.y, mis_Labels.lz.x2, mis_Labels.lz.y2, CAM_HUMAN_PLAYER);
 	setMissionTime(camChangeOnDiff(camMinutesToSeconds(75)));
 	camPlayVideos([{video: "MB2_DI_MSG", type: MISS_MSG}, {video: "MB2_DI_MSG2", type: CAMP_MSG}]);
-	camSetStandardWinLossConditions(CAM_VICTORY_PRE_OFFWORLD, "SUB_2D");
+	camSetStandardWinLossConditions(CAM_VICTORY_PRE_OFFWORLD, cam_levels.beta7.offWorld);
 }

--- a/data/base/script/campaign/cam2-end.js
+++ b/data/base/script/campaign/cam2-end.js
@@ -260,7 +260,7 @@ function eventStartLevel()
 		camSetExtraObjectiveMessage(_("Send off as many transporters as you can and bring at least one truck"));
 	}
 
-	camSetStandardWinLossConditions(CAM_VICTORY_TIMEOUT, "CAM_3A", {
+	camSetStandardWinLossConditions(CAM_VICTORY_TIMEOUT, cam_levels.gamma1, {
 		reinforcements: camMinutesToSeconds(7), //Duration the transport "leaves" map.
 		callback: "checkIfLaunched"
 	});

--- a/data/base/script/campaign/cam3-1.js
+++ b/data/base/script/campaign/cam3-1.js
@@ -350,7 +350,7 @@ function eventStartLevel()
 		{sound: cam_sounds.missile.countdown, time: 10},
 	];
 
-	camSetStandardWinLossConditions(CAM_VICTORY_OFFWORLD, "CAM_3B", {
+	camSetStandardWinLossConditions(CAM_VICTORY_OFFWORLD, cam_levels.gamma3, {
 		area: "RTLZ",
 		playLzReminder: false,
 		reinforcements: camMinutesToSeconds(3),

--- a/data/base/script/campaign/cam3-1s.js
+++ b/data/base/script/campaign/cam3-1s.js
@@ -14,5 +14,5 @@ function eventStartLevel()
 	setNoGoArea(mis_Labels.lz.x, mis_Labels.lz.y, mis_Labels.lz.x2, mis_Labels.lz.y2, CAM_HUMAN_PLAYER);
 	setMissionTime(camChangeOnDiff(camMinutesToSeconds((tweakOptions.classicTimers) ? 70 : 75)));
 	camPlayVideos([{video: "MB3_1A_MSG", type: CAMP_MSG}, {video: "MB3_1A_MSG2", type: MISS_MSG}]);
-	camSetStandardWinLossConditions(CAM_VICTORY_PRE_OFFWORLD, "SUB_3_1");
+	camSetStandardWinLossConditions(CAM_VICTORY_PRE_OFFWORLD, cam_levels.gamma2.offWorld);
 }

--- a/data/base/script/campaign/cam3-2.js
+++ b/data/base/script/campaign/cam3-2.js
@@ -260,7 +260,7 @@ function vtolAttack()
 function enableReinforcements()
 {
 	playSound(cam_sounds.reinforcementsAreAvailable);
-	camSetStandardWinLossConditions(CAM_VICTORY_OFFWORLD, "CAM3A-B", {
+	camSetStandardWinLossConditions(CAM_VICTORY_OFFWORLD, cam_levels.gamma5, {
 		area: "RTLZ",
 		message: "C32_LZ",
 		reinforcements: camMinutesToSeconds(3),
@@ -312,7 +312,7 @@ function eventStartLevel()
 	const tExt = getObject("transporterExit");
 	startExtraLoss = false;
 
-	camSetStandardWinLossConditions(CAM_VICTORY_OFFWORLD, "CAM3A-B", {
+	camSetStandardWinLossConditions(CAM_VICTORY_OFFWORLD, cam_levels.gamma5, {
 		area: "RTLZ",
 		message: "C32_LZ",
 		reinforcements: -1,

--- a/data/base/script/campaign/cam3-2s.js
+++ b/data/base/script/campaign/cam3-2s.js
@@ -14,5 +14,5 @@ function eventStartLevel()
 	setNoGoArea(mis_Labels.lz.x, mis_Labels.lz.y, mis_Labels.lz.x2, mis_Labels.lz.y2, CAM_HUMAN_PLAYER);
 	setMissionTime(camChangeOnDiff(camHoursToSeconds(1)));
 	camPlayVideos([{video: "MB3_2_MSG", type: CAMP_MSG}, {video: "MB3_2_MSG2", type: MISS_MSG}]);
-	camSetStandardWinLossConditions(CAM_VICTORY_PRE_OFFWORLD, "SUB_3_2");
+	camSetStandardWinLossConditions(CAM_VICTORY_PRE_OFFWORLD, cam_levels.gamma4.offWorld);
 }

--- a/data/base/script/campaign/cam3-4s.js
+++ b/data/base/script/campaign/cam3-4s.js
@@ -17,5 +17,5 @@ function eventStartLevel()
 	setMissionTime(camMinutesToSeconds(30));
 	setPower(playerPower(CAM_HUMAN_PLAYER) + 50000, CAM_HUMAN_PLAYER);
 	camPlayVideos([{video: "MB3_4_MSG", type: CAMP_MSG}, {video: "MB3_4_MSG2", type: MISS_MSG}]);
-	camSetStandardWinLossConditions(CAM_VICTORY_PRE_OFFWORLD, "CAM_3_4");
+	camSetStandardWinLossConditions(CAM_VICTORY_PRE_OFFWORLD, cam_levels.gammaEnd.offWorld);
 }

--- a/data/base/script/campaign/cam3-a.js
+++ b/data/base/script/campaign/cam3-a.js
@@ -357,7 +357,7 @@ function eventStartLevel()
 	const tEnt = getObject("transporterEntry");
 	const tExt = getObject("transporterExit");
 
-	camSetStandardWinLossConditions(CAM_VICTORY_STANDARD, "SUB_3_1S");
+	camSetStandardWinLossConditions(CAM_VICTORY_STANDARD, cam_levels.gamma2.pre);
 	setMissionTime(camChangeOnDiff(camHoursToSeconds(2)));
 
 	centreView(startPos.x, startPos.y);

--- a/data/base/script/campaign/cam3-ab.js
+++ b/data/base/script/campaign/cam3-ab.js
@@ -289,7 +289,7 @@ function eventStartLevel()
 	const startPos = getObject("startPosition");
 	const lz = getObject("landingZone");
 
-	camSetStandardWinLossConditions(CAM_VICTORY_STANDARD, "CAM3C", {
+	camSetStandardWinLossConditions(CAM_VICTORY_STANDARD, cam_levels.gamma6, {
 		callback: "resistanceResearched"
 	});
 

--- a/data/base/script/campaign/cam3-ad1.js
+++ b/data/base/script/campaign/cam3-ad1.js
@@ -271,7 +271,7 @@ function eventStartLevel()
 	const lz2 = getObject("landingZone2"); //LZ for cam3-4s.
 	mapLimit = 1.0;
 
-	camSetStandardWinLossConditions(CAM_VICTORY_STANDARD, "CAM3A-D2", {
+	camSetStandardWinLossConditions(CAM_VICTORY_STANDARD, cam_levels.gamma8, {
 		callback: "checkMissileSilos"
 	});
 

--- a/data/base/script/campaign/cam3-ad2.js
+++ b/data/base/script/campaign/cam3-ad2.js
@@ -364,7 +364,7 @@ function eventStartLevel()
 		{played: false, video: "MB3_AD2_MSG6", type: CAMP_MSG, res: mis_researchTargets.missileCode3},
 	];
 
-	camSetStandardWinLossConditions(CAM_VICTORY_STANDARD, "CAM_3_4S", {
+	camSetStandardWinLossConditions(CAM_VICTORY_STANDARD, cam_levels.gammaEnd.pre, {
 		callback: "checkMissileSilos"
 	});
 

--- a/data/base/script/campaign/cam3-b.js
+++ b/data/base/script/campaign/cam3-b.js
@@ -320,7 +320,7 @@ function eventStartLevel()
 	const startPos = getObject("startPosition");
 	const lz = getObject("landingZone");
 
-	camSetStandardWinLossConditions(CAM_VICTORY_STANDARD, "SUB_3_2S");
+	camSetStandardWinLossConditions(CAM_VICTORY_STANDARD, cam_levels.gamma4.pre);
 	setMissionTime(camChangeOnDiff(camMinutesToSeconds(30))); // For the rescue mission.
 
 	centreView(startPos.x, startPos.y);

--- a/data/base/script/campaign/cam3-c.js
+++ b/data/base/script/campaign/cam3-c.js
@@ -187,7 +187,7 @@ function eventStartLevel()
 
 	findBetaUnitIds();
 
-	camSetStandardWinLossConditions(CAM_VICTORY_STANDARD, "CAM3A-D1", {
+	camSetStandardWinLossConditions(CAM_VICTORY_STANDARD, cam_levels.gamma7, {
 		callback: "betaAlive"
 	});
 

--- a/data/base/script/campaign/libcampaign.js
+++ b/data/base/script/campaign/libcampaign.js
@@ -133,19 +133,61 @@ const __CAM_ALPHA_CAMPAIGN_NUMBER = 1;
 const __CAM_BETA_CAMPAIGN_NUMBER = 2;
 const __CAM_GAMMA_CAMPAIGN_NUMBER = 3;
 const __CAM_UNKNOWN_CAMPAIGN_NUMBER = 1000;
+const cam_levels = {
+	alpha1: "CAM_1A",
+	alpha2: "CAM_1B",
+	alpha3: {pre: "SUB_1_1S", offWorld: "SUB_1_1"},
+	alpha4: {pre: "SUB_1_2S", offWorld: "SUB_1_2"},
+	alpha5: {pre: "SUB_1_3S", offWorld: "SUB_1_3"},
+	alpha6: "CAM_1C",
+	alpha7: "CAM_1CA",
+	alpha8: {pre: "SUB_1_4AS", offWorld: "SUB_1_4A"},
+	alpha9: {pre: "SUB_1_5S", offWorld: "SUB_1_5"},
+	alpha10: "CAM_1A-C",
+	alpha11: {pre: "SUB_1_7S", offWorld: "SUB_1_7"},
+	alpha12: {pre: "SUB_1_DS", offWorld: "SUB_1_D"},
+	alphaEnd: "CAM_1END",
+	beta1: "CAM_2A",
+	beta2: {pre: "SUB_2_1S", offWorld: "SUB_2_1"},
+	beta3: "CAM_2B",
+	beta4: {pre: "SUB_2_2S", offWorld: "SUB_2_2"},
+	beta5: "CAM_2C",
+	beta6: {pre: "SUB_2_5S", offWorld: "SUB_2_5"},
+	beta7: {pre: "SUB_2DS", offWorld: "SUB_2D"},
+	beta8: {pre: "SUB_2_6S", offWorld: "SUB_2_6"},
+	beta9: {pre: "SUB_2_7S", offWorld: "SUB_2_7"},
+	beta10: {pre: "SUB_2_8S", offWorld: "SUB_2_8"},
+	betaEnd: "CAM_2END",
+	gamma1: "CAM_3A",
+	gamma2: {pre: "SUB_3_1S", offWorld: "SUB_3_1"},
+	gamma3: "CAM_3B",
+	gamma4: {pre: "SUB_3_2S", offWorld: "SUB_3_2"},
+	gamma5: "CAM3A-B",
+	gamma6: "CAM3C",
+	gamma7: "CAM3A-D1",
+	gamma8: "CAM3A-D2",
+	gammaEnd: {pre: "CAM_3_4S", offWorld: "CAM_3_4"}
+};
 const __cam_alphaLevels = [
-	"CAM_1A", "CAM_1B", "SUB_1_1S", "SUB_1_1", "SUB_1_2S", "SUB_1_2", "SUB_1_3S",
-	"SUB_1_3", "CAM_1C", "CAM_1CA", "SUB_1_4AS", "SUB_1_4A", "SUB_1_5S", "SUB_1_5",
-	"CAM_1A-C", "SUB_1_7S", "SUB_1_7", "SUB_1_DS", "SUB_1_D", "CAM_1END"
+	cam_levels.alpha1, cam_levels.alpha2, cam_levels.alpha3.pre, cam_levels.alpha3.offWorld,
+	cam_levels.alpha4.pre, cam_levels.alpha4.offWorld, cam_levels.alpha5.pre,
+	cam_levels.alpha5.offWorld, cam_levels.alpha6, cam_levels.alpha7, cam_levels.alpha8.pre,
+	cam_levels.alpha8.offWorld, cam_levels.alpha9.pre, cam_levels.alpha9.offWorld,
+	cam_levels.alpha10, cam_levels.alpha11.pre, cam_levels.alpha11.offWorld,
+	cam_levels.alpha12.pre, cam_levels.alpha12.offWorld, cam_levels.alphaEnd
 ];
 const __cam_betaLevels = [
-	"CAM_2A", "SUB_2_1S", "SUB_2_1", "CAM_2B", "SUB_2_2S", "SUB_2_2", "CAM_2C",
-	"SUB_2_5S", "SUB_2_5", "SUB_2DS", "SUB_2D", "SUB_2_6S", "SUB_2_6", "SUB_2_7S",
-	"SUB_2_7", "SUB_2_8S", "SUB_2_8", "CAM_2END"
+	cam_levels.beta1, cam_levels.beta2.pre, cam_levels.beta2.offWorld, cam_levels.beta3,
+	cam_levels.beta4.pre, cam_levels.beta4.offWorld, cam_levels.beta5, cam_levels.beta6.pre,
+	cam_levels.beta6.offWorld, cam_levels.beta7.pre, cam_levels.beta7.offWorld,
+	cam_levels.beta8.pre, cam_levels.beta8.offWorld, cam_levels.beta9.pre,
+	cam_levels.beta9.offWorld, cam_levels.beta10.pre, cam_levels.beta10.offWorld,
+	cam_levels.betaEnd
 ];
 const __cam_gammaLevels = [
-	"CAM_3A", "SUB_3_1S", "SUB_3_1", "CAM_3B", "SUB_3_2S", "SUB_3_2", "CAM3A-B",
-	"CAM3C", "CAM3A-D1", "CAM3A-D2", "CAM_3_4S", "CAM_3_4"
+	cam_levels.gamma1, cam_levels.gamma2.pre, cam_levels.gamma2.offWorld, cam_levels.gamma3,
+	cam_levels.gamma4.pre, cam_levels.gamma4.offWorld, cam_levels.gamma5, cam_levels.gamma6,
+	cam_levels.gamma7, cam_levels.gamma8, cam_levels.gammaEnd.pre, cam_levels.gammaEnd.offWorld
 ];
 
 // Holds all the sounds the campaign uses. Try to name things as they are said.

--- a/data/base/script/campaign/libcampaign_includes/events.js
+++ b/data/base/script/campaign/libcampaign_includes/events.js
@@ -62,7 +62,7 @@ function cam_eventChat(from, to, message)
 		return;
 	}
 	camTrace(from, to, message);
-	if (message === "let me win" && __camNextLevel !== "SUB_1_1")
+	if (message === "let me win" && __camNextLevel !== cam_levels.alpha3.offWorld)
 	{
 		__camLetMeWin();
 	}
@@ -164,7 +164,7 @@ function cam_eventDroidBuilt(droid, structure)
 	{
 		return;
 	}
-	if (camGetNexusState() && droid.player === CAM_NEXUS && __camNextLevel === "CAM3C" && camRand(100) < 7)
+	if (camGetNexusState() && droid.player === CAM_NEXUS && __camNextLevel === cam_levels.gamma6 && camRand(100) < 7)
 	{
 		// Occasionally hint that NEXUS is producing units on Gamma 5.
 		playSound(cam_sounds.nexus.productionCompleted);
@@ -371,8 +371,10 @@ function cam_eventGameLoaded()
 	receiveAllEvents(true);
 	__camSaveLoading = true;
 	const scavKevlarMissions = [
-		"CAM_1CA", "SUB_1_4AS", "SUB_1_4A", "SUB_1_5S", "SUB_1_5",
-		"CAM_1A-C", "SUB_1_7S", "SUB_1_7", "SUB_1_DS", "CAM_1END", "SUB_2_5S"
+		cam_levels.alpha7, cam_levels.alpha8.pre, cam_levels.alpha8.offWorld,
+		cam_levels.alpha9.pre, cam_levels.alpha9.offWorld, cam_levels.alpha10,
+		cam_levels.alpha11.pre, cam_levels.alpha11.offWorld, cam_levels.alpha12.pre,
+		cam_levels.alphaEnd, cam_levels.beta6.pre
 	];
 
 	//Need to set the scavenger kevlar vests when loading a save from later Alpha

--- a/data/base/script/campaign/libcampaign_includes/guide.js
+++ b/data/base/script/campaign/libcampaign_includes/guide.js
@@ -128,7 +128,7 @@ function __camEnableGuideTopics()
 	addGuideTopic("wz2100::structures::building");
 	addGuideTopic("wz2100::structures::demolishing");
 
-	let isCam1A = (__camNextLevel === 'CAM_1B');
+	let isCam1A = (__camNextLevel === cam_levels.alpha2);
 	if (!isCam1A) // If not very first original campaign level (CAM1A), which displays these in response to events, add them
 	{
 		addGuideTopic("wz2100::general::artifacts");

--- a/data/base/script/campaign/libcampaign_includes/victory.js
+++ b/data/base/script/campaign/libcampaign_includes/victory.js
@@ -220,7 +220,7 @@ function __camPlayerDead()
 		dead = false;
 	}
 
-	if (__camNextLevel === "SUB_3_1S")
+	if (__camNextLevel === cam_levels.gamma2.pre)
 	{
 		//Check for any construction units.
 		//NOTE: countDroid() will return the counts of construction units in
@@ -235,7 +235,7 @@ function __camPlayerDead()
 		//A construction unit is currently on the map.
 		dead = false;
 	}
-	else if (__camNextLevel === "CAM3A-D1")
+	else if (__camNextLevel === cam_levels.gamma7)
 	{
 		const __GAMMA_PLAYER = 1;
 
@@ -284,7 +284,7 @@ function __camPlayerDead()
 		dead = droidCount <= 0 && !__HAVE_FACTORIES;
 
 		//Finish Beta-end early if they have no units and factories on Easy/Normal.
-		if (dead && (difficulty <= MEDIUM) && (__camNextLevel === "CAM_3A"))
+		if (dead && (difficulty <= MEDIUM) && (__camNextLevel === cam_levels.gamma1))
 		{
 			cam_eventMissionTimeout(); //Early victory trigger
 			return false;


### PR DESCRIPTION
- Moves the original campaign level loading strings into the library to reduce magic. Should be no typos...
- Remove __ prefixes from Alpha 1 functions since that is out of place.