### PR TITLE
Add PS1 campaign mode

### DIFF
--- a/data/mods/campaign/wz2100_camclassic/mod-info.json.in
+++ b/data/mods/campaign/wz2100_camclassic/mod-info.json.in
@@ -30,6 +30,11 @@
             "id": "autosavesOnly",
             "default": false,
             "userEditable": true
+        },
+        {
+          "id": "ps1Modifiers",
+          "default": false,
+          "userEditable": true
         }
     ],
     "customTweakOptions": [

--- a/src/campaigninfo.cpp
+++ b/src/campaigninfo.cpp
@@ -181,3 +181,13 @@ bool getCamTweakOption_AutosavesOnly()
 	}
 	return val.get<bool>();
 }
+
+bool getCamTweakOption_PS1Modifiers()
+{
+	auto val = getCamTweakOptionsValue("ps1Modifiers", false);
+	if (!val.is_boolean())
+	{
+		return false;
+	}
+	return val.get<bool>();
+}

--- a/src/campaigninfo.h
+++ b/src/campaigninfo.h
@@ -57,5 +57,6 @@ void clearCamTweakOptions();
 const std::unordered_map<std::string, nlohmann::json>& getCamTweakOptions();
 nlohmann::json getCamTweakOptionsValue(const std::string& identifier, nlohmann::json defaultValue);
 bool getCamTweakOption_AutosavesOnly();
+bool getCamTweakOption_PS1Modifiers();
 
 #endif // __INCLUDED_SRC_CAMPAIGNINFO_H__

--- a/src/difficulty.cpp
+++ b/src/difficulty.cpp
@@ -31,6 +31,7 @@
 #include "lib/framework/frame.h"
 #include "difficulty.h"
 #include "src/multiplay.h"
+#include "campaigninfo.h"
 
 
 // ------------------------------------------------------------------------------------
@@ -43,7 +44,7 @@ static int fDifEnemyModifier;
 void setDamageModifiers(int playerModifier, int enemyModifier)
 {
 	fDifPlayerModifier = playerModifier;
-	fDifEnemyModifier = enemyModifier;
+	fDifEnemyModifier = (!bMultiPlayer && getCamTweakOption_PS1Modifiers()) ? enemyModifier / 3 : enemyModifier;
 }
 
 // ------------------------------------------------------------------------------------

--- a/src/difficulty.cpp
+++ b/src/difficulty.cpp
@@ -43,8 +43,8 @@ static int fDifEnemyModifier;
 
 void setDamageModifiers(int playerModifier, int enemyModifier)
 {
-	fDifPlayerModifier = playerModifier;
-	fDifEnemyModifier = (!bMultiPlayer && getCamTweakOption_PS1Modifiers()) ? enemyModifier / 3 : enemyModifier;
+	fDifPlayerModifier = std::max(1, playerModifier);
+	fDifEnemyModifier = std::max(1, (!bMultiPlayer && getCamTweakOption_PS1Modifiers()) ? enemyModifier / 3 : enemyModifier);
 }
 
 // ------------------------------------------------------------------------------------

--- a/src/titleui/campaign.cpp
+++ b/src/titleui/campaign.cpp
@@ -1945,6 +1945,13 @@ static std::vector<WzCampaignTweakOptionSetting> buildTweakOptionSettings(option
 		false, true
 	);
 
+	results.emplace_back(
+		"ps1Modifiers",
+		_("PS1 Modifiers"),
+		_("Reduces the damage the enemy deals to a third of the current difficulty modifier."),
+		false, true
+	);
+
 	if (modInfo.has_value())
 	{
 		for (auto it = results.begin(); it != results.end(); )


### PR DESCRIPTION
About 10 months ago I found that the difference between the PC and PS1 was really just dividing the damage the player received from the AI by 3. Which makes sense cause the player would lose a lot of APM using a controller over a keyboard and mouse. _If_ there is an increase in the player damage modifier, it must rather small... though that goes beyond this PR.

Playing this mode on Classic with this toggle showed very similar, if not an almost perfect match, of what I saw on YouTube videos of Alpha 1. And, it matches posts in the forums from around 2010 from a PS1 player saying a 2.3.x release was much harder than the PS1 cause in the console version the first 4 tanks could take out the entire Alpha 1 map. My own observations of my PC v1.10 discs showed that the destruction times of tanks is practically the same range as it is in Classic and Remastered, and tanks aren't as invincible as the Pumpkin PS1 release.

---
Available in both Remastered and Classic cause why not, it only adjusts a difficulty modifier.

This worked on all saveloads I tried, toggling on and off when it should, and the special modifier here gets applied during `resetDamageModifiers()` in stage two init if you want to know when it technically goes into effect.

Clipped modifiers cause the Biffer Baker cheat would result in integer truncation of 1/3 = 0.