### PR TITLE
structure.json: Add support for new "baseStructDamageExpLevel" option, revert MP structure update

### DIFF
--- a/data/base/stats/structure.json
+++ b/data/base/stats/structure.json
@@ -1,4 +1,7 @@
 {
+	"_config_": {
+		"baseStructDamageExpLevel": 0
+	},
 	"A0ADemolishStructure": {
 		"armour": 6,
 		"breadth": 1,

--- a/data/mods/campaign/wz2100_camclassic/stats/structure.json
+++ b/data/mods/campaign/wz2100_camclassic/stats/structure.json
@@ -1,4 +1,7 @@
 {
+	"_config_": {
+		"baseStructDamageExpLevel": 0
+	},
 	"A0ADemolishStructure": {
 		"armour": 6,
 		"breadth": 1,

--- a/data/mp/stats/research.json
+++ b/data/mp/stats/research.json
@@ -877,9 +877,6 @@
 		"id": "R-Defense-HeavyLas",
 		"msgName": "RES_EMP_HEAVYLAS",
 		"name": "Heavy Laser Emplacement",
-		"redStructures": [
-			"Emplacement-PrisLas"
-		],
 		"requiredResearch": [
 			"R-Wpn-HvyLaser"
 		],
@@ -957,7 +954,9 @@
 		"msgName": "RES_EMP_HvAM",
 		"name": "Archangel Missile Battery",
 		"redStructures": [
-			"Emplacement-Rocket06-IDF"
+			"Emplacement-Howitzer105",
+			"Emplacement-Rocket06-IDF",
+			"Emplacement-MortarPit02"
 		],
 		"requiredResearch": [
 			"R-Wpn-HvArtMissile"
@@ -992,9 +991,6 @@
 		"id": "R-Defense-HvyHowitzer",
 		"msgName": "RES_EMP_HvHOW",
 		"name": "Ground Shaker Emplacement",
-		"redStructures": [
-			"Emplacement-Howitzer105"
-		],
 		"requiredResearch": [
 			"R-Defense-Howitzer",
 			"R-Wpn-HvyHowitzer"
@@ -1080,9 +1076,6 @@
 		"id": "R-Defense-MassDriver",
 		"msgName": "RES_EMP_MD",
 		"name": "Mass Driver Fortress",
-		"redStructures": [
-			"X-Super-Cannon"
-		],
 		"requiredResearch": [
 			"R-Wpn-RailGun03",
 			"R-Wpn-Rail-ROF03",
@@ -1199,9 +1192,6 @@
 		"id": "R-Defense-Pillbox06",
 		"msgName": "RES_PB_ATR",
 		"name": "Lancer Tower",
-		"redStructures": [
-			"GuardTower6"
-		],
 		"requiredResearch": [
 			"R-Defense-HardcreteWall",
 			"R-Wpn-Rocket01-LtAT"
@@ -1371,9 +1361,6 @@
 		"id": "R-Defense-SamSite1",
 		"msgName": "RES_EMP_SAM1",
 		"name": "Avenger SAM Site",
-		"redStructures": [
-			"P0-AASite-Sunburst"
-		],
 		"requiredResearch": [
 			"R-Wpn-Missile-LtSAM"
 		],
@@ -1438,9 +1425,6 @@
 		"id": "R-Defense-Super-Missile",
 		"msgName": "RES_EMP_MSL",
 		"name": "Missile Fortress",
-		"redStructures": [
-			"X-Super-Rocket"
-		],
 		"requiredResearch": [
 			"R-Defense-WallUpgrade10",
 			"R-Wpn-Missile-ROF03"
@@ -1560,7 +1544,7 @@
 		"msgName": "RES_WT9_ATM",
 		"name": "Scourge Missile Hardpoint",
 		"redStructures": [
-			"WallTower-HvATrocket"
+			"WallTower06"
 		],
 		"requiredResearch": [
 			"R-Wpn-Missile2A-T"
@@ -1628,9 +1612,6 @@
 		"id": "R-Defense-WallTower-HvyA-Trocket",
 		"msgName": "RES_WT12_HAT",
 		"name": "Tank Killer Hardpoint",
-		"redStructures": [
-			"WallTower06"
-		],
 		"requiredResearch": [
 			"R-Wpn-Rocket07-Tank-Killer"
 		],
@@ -1676,11 +1657,6 @@
 		"id": "R-Defense-WallTower-Rail2",
 		"msgName": "RES_WT15_RL2",
 		"name": "Rail Gun Hardpoint",
-		"redStructures": [
-			"WallTower04",
-			"WallTower-HPVcannon",
-			"Wall-VulcanCan"
-		],
 		"requiredResearch": [
 			"R-Wpn-RailGun02"
 		],
@@ -1697,10 +1673,7 @@
 		"msgName": "RES_WT15_RL3",
 		"name": "Gauss Cannon Hardpoint",
 		"redStructures": [
-			"WallTower-Rail2",
-			"WallTower04",
-			"WallTower-HPVcannon",
-			"Wall-VulcanCan"
+			"WallTower-Rail2"
 		],
 		"requiredResearch": [
 			"R-Wpn-RailGun03"
@@ -1953,7 +1926,7 @@
 				"filterParameter": "Type",
 				"filterValue": "Wall",
 				"parameter": "Armour",
-				"value": 45
+				"value": 35
 			},
 			{
 				"class": "Building",
@@ -1981,7 +1954,7 @@
 				"filterParameter": "Type",
 				"filterValue": "Wall",
 				"parameter": "Armour",
-				"value": 45
+				"value": 35
 			},
 			{
 				"class": "Building",
@@ -2010,7 +1983,7 @@
 				"filterParameter": "Type",
 				"filterValue": "Wall",
 				"parameter": "Armour",
-				"value": 45
+				"value": 35
 			},
 			{
 				"class": "Building",
@@ -2041,7 +2014,7 @@
 				"filterParameter": "Type",
 				"filterValue": "Wall",
 				"parameter": "Armour",
-				"value": 55
+				"value": 35
 			},
 			{
 				"class": "Building",
@@ -2069,7 +2042,7 @@
 				"filterParameter": "Type",
 				"filterValue": "Wall",
 				"parameter": "Armour",
-				"value": 55
+				"value": 35
 			},
 			{
 				"class": "Building",
@@ -2098,7 +2071,7 @@
 				"filterParameter": "Type",
 				"filterValue": "Wall",
 				"parameter": "Armour",
-				"value": 55
+				"value": 35
 			},
 			{
 				"class": "Building",
@@ -2127,7 +2100,7 @@
 				"filterParameter": "Type",
 				"filterValue": "Wall",
 				"parameter": "Armour",
-				"value": 65
+				"value": 35
 			},
 			{
 				"class": "Building",
@@ -2156,7 +2129,7 @@
 				"filterParameter": "Type",
 				"filterValue": "Wall",
 				"parameter": "Armour",
-				"value": 65
+				"value": 35
 			},
 			{
 				"class": "Building",
@@ -2185,7 +2158,7 @@
 				"filterParameter": "Type",
 				"filterValue": "Wall",
 				"parameter": "Armour",
-				"value": 65
+				"value": 35
 			},
 			{
 				"class": "Building",

--- a/data/mp/stats/structure.json
+++ b/data/mp/stats/structure.json
@@ -49,7 +49,7 @@
 		"name": "Scavenger MG tower",
 		"resistance": 150,
 		"sensorID": "BaBaSensor",
-		"strength": "SOFT",
+		"strength": "HARD",
 		"structureModel": [
 			"bbaatower.PIE"
 		],
@@ -155,7 +155,7 @@
 		"name": "Scavenger Flame Tower",
 		"resistance": 150,
 		"sensorID": "DefaultSensor1Mk1",
-		"strength": "SOFT",
+		"strength": "MEDIUM",
 		"structureModel": [
 			"Blbrtowf.pie"
 		],
@@ -177,7 +177,7 @@
 		"name": "Scavenger Gun Tower",
 		"resistance": 150,
 		"sensorID": "DefaultSensor1Mk1",
-		"strength": "SOFT",
+		"strength": "MEDIUM",
 		"structureModel": [
 			"BLBRBTW1.PIE"
 		],
@@ -199,7 +199,7 @@
 		"name": "*Scavenger End Tower*",
 		"resistance": 150,
 		"sensorID": "DefaultSensor1Mk1",
-		"strength": "SOFT",
+		"strength": "MEDIUM",
 		"structureModel": [
 			"Blbrbtw2.PIE"
 		],
@@ -239,7 +239,7 @@
 		"name": "*BaBaMortarPit*",
 		"resistance": 150,
 		"sensorID": "DefaultSensor1Mk1",
-		"strength": "SOFT",
+		"strength": "MEDIUM",
 		"structureModel": [
 			"BLBRMRTP.PIE"
 		],
@@ -263,7 +263,7 @@
 		"modulePowerPoints": 40,
 		"resistance": 150,
 		"sensorID": "BaBaSensor",
-		"strength": "MEDIUM",
+		"strength": "SOFT",
 		"structureModel": [
 			"BLBRBGEN.PIE"
 		],
@@ -282,7 +282,7 @@
 		"name": "Scavenger Rocket Pit",
 		"resistance": 150,
 		"sensorID": "DefaultSensor1Mk1",
-		"strength": "SOFT",
+		"strength": "MEDIUM",
 		"structureModel": [
 			"EXROCKET.PIE"
 		],
@@ -304,7 +304,7 @@
 		"name": "Scavenger AT-Rocket Pit",
 		"resistance": 150,
 		"sensorID": "DefaultSensor1Mk1",
-		"strength": "SOFT",
+		"strength": "MEDIUM",
 		"structureModel": [
 			"EXROCKET.PIE"
 		],
@@ -342,8 +342,8 @@
 		"id": "A0CannonTower",
 		"name": "Cannon Tower",
 		"resistance": 150,
-		"sensorID": "DefaultSensor1Mk1",
-		"strength": "SOFT",
+		"sensorID": "TowerSensor",
+		"strength": "MEDIUM",
 		"structureModel": [
 			"BLBRTOWR.PIE"
 		],
@@ -443,8 +443,8 @@
 	"A0HardcreteMk1CWall": {
 		"armour": 15,
 		"breadth": 1,
-		"buildPoints": 100,
-		"buildPower": 15,
+		"buildPoints": 125,
+		"buildPower": 25,
 		"height": 2,
 		"hitpoints": 700,
 		"id": "A0HardcreteMk1CWall",
@@ -460,8 +460,8 @@
 	"A0HardcreteMk1Gate": {
 		"armour": 15,
 		"breadth": 1,
-		"buildPoints": 200,
-		"buildPower": 45,
+		"buildPoints": 250,
+		"buildPower": 75,
 		"height": 2,
 		"hitpoints": 700,
 		"id": "A0HardcreteMk1Gate",
@@ -480,8 +480,8 @@
 	"A0HardcreteMk1Wall": {
 		"armour": 15,
 		"breadth": 1,
-		"buildPoints": 100,
-		"buildPower": 15,
+		"buildPoints": 125,
+		"buildPower": 25,
 		"height": 2,
 		"hitpoints": 700,
 		"id": "A0HardcreteMk1Wall",
@@ -722,12 +722,12 @@
 		"armour": 10,
 		"breadth": 1,
 		"buildPoints": 40,
-		"buildPower": 5,
+		"buildPower": 15,
 		"height": 1,
 		"hitpoints": 200,
 		"id": "A0TankTrap",
 		"name": "Tank Traps",
-		"strength": "MEDIUM",
+		"strength": "HARD",
 		"structureModel": [
 			"MITRAP2.PIE"
 		],
@@ -804,7 +804,7 @@
 		"name": "AA Cyclone Flak Cannon Emplacement",
 		"resistance": 150,
 		"sensorID": "DefaultSensor1Mk1",
-		"strength": "MEDIUM",
+		"strength": "HARD",
 		"structureModel": [
 			"Blaamnt2.PIE"
 		],
@@ -826,7 +826,7 @@
 		"name": "AA Tornado Flak Cannon Emplacement",
 		"resistance": 150,
 		"sensorID": "DefaultSensor1Mk1",
-		"strength": "MEDIUM",
+		"strength": "HARD",
 		"structureModel": [
 			"Blaamnt2.PIE"
 		],
@@ -882,14 +882,14 @@
 		"width": 1
 	},
 	"CO-Tower-HVCan": {
-		"armour": 18,
+		"armour": 12,
 		"breadth": 1,
 		"buildPoints": 500,
-		"buildPower": 275,
+		"buildPower": 100,
 		"combinesWithWall": true,
 		"ecmID": "ZNULLECM",
 		"height": 2,
-		"hitpoints": 1400,
+		"hitpoints": 300,
 		"id": "CO-Tower-HVCan",
 		"name": "*CO-Tower-HVCan*",
 		"resistance": 150,
@@ -898,7 +898,7 @@
 		"structureModel": [
 			"BLGUARD2.pie"
 		],
-		"thermal": 18,
+		"thermal": 12,
 		"type": "DEFENSE",
 		"weapons": [
 			"Cannon4AUTOMk1"
@@ -906,14 +906,14 @@
 		"width": 1
 	},
 	"CO-Tower-HvATRkt": {
-		"armour": 18,
+		"armour": 12,
 		"breadth": 1,
 		"buildPoints": 500,
-		"buildPower": 300,
+		"buildPower": 100,
 		"combinesWithWall": true,
 		"ecmID": "ZNULLECM",
 		"height": 2,
-		"hitpoints": 1400,
+		"hitpoints": 300,
 		"id": "CO-Tower-HvATRkt",
 		"name": "*CO-Tower-HvATRkt*",
 		"resistance": 150,
@@ -922,7 +922,7 @@
 		"structureModel": [
 			"BLGUARD2.pie"
 		],
-		"thermal": 18,
+		"thermal": 12,
 		"type": "DEFENSE",
 		"weapons": [
 			"Rocket-HvyA-T"
@@ -930,13 +930,13 @@
 		"width": 1
 	},
 	"CO-Tower-HvFlame": {
-		"armour": 10,
+		"armour": 12,
 		"breadth": 1,
-		"buildPoints": 200,
-		"buildPower": 110,
+		"buildPoints": 500,
+		"buildPower": 100,
 		"ecmID": "ZNULLECM",
 		"height": 1,
-		"hitpoints": 700,
+		"hitpoints": 300,
 		"id": "CO-Tower-HvFlame",
 		"name": "*CO-Tower-HvFlame*",
 		"resistance": 150,
@@ -945,7 +945,7 @@
 		"structureModel": [
 			"BLHARDPT.pie"
 		],
-		"thermal": 10,
+		"thermal": 12,
 		"type": "DEFENSE",
 		"weapons": [
 			"Flame2"
@@ -953,22 +953,22 @@
 		"width": 1
 	},
 	"CO-Tower-LtATRkt": {
-		"armour": 15,
+		"armour": 12,
 		"breadth": 1,
-		"buildPoints": 350,
-		"buildPower": 200,
+		"buildPoints": 500,
+		"buildPower": 100,
 		"ecmID": "ZNULLECM",
 		"height": 2,
-		"hitpoints": 1000,
+		"hitpoints": 300,
 		"id": "CO-Tower-LtATRkt",
 		"name": "*CO-Tower-LtATRkt*",
 		"resistance": 150,
-		"sensorID": "TowerSensor",
-		"strength": "HARD",
+		"sensorID": "DefaultSensor1Mk1",
+		"strength": "MEDIUM",
 		"structureModel": [
 			"blguardn.pie"
 		],
-		"thermal": 15,
+		"thermal": 12,
 		"type": "DEFENSE",
 		"weapons": [
 			"Rocket-LtA-T"
@@ -976,22 +976,22 @@
 		"width": 1
 	},
 	"CO-Tower-MG3": {
-		"armour": 15,
+		"armour": 12,
 		"breadth": 1,
-		"buildPoints": 400,
-		"buildPower": 150,
+		"buildPoints": 500,
+		"buildPower": 100,
 		"ecmID": "ZNULLECM",
 		"height": 2,
-		"hitpoints": 1000,
+		"hitpoints": 300,
 		"id": "CO-Tower-MG3",
 		"name": "*CO-Tower-MG3*",
 		"resistance": 150,
-		"sensorID": "TowerSensor",
-		"strength": "HARD",
+		"sensorID": "DefaultSensor1Mk1",
+		"strength": "MEDIUM",
 		"structureModel": [
 			"blguardn.PIE"
 		],
-		"thermal": 15,
+		"thermal": 12,
 		"type": "DEFENSE",
 		"weapons": [
 			"MG3Mk1"
@@ -999,14 +999,14 @@
 		"width": 1
 	},
 	"CO-Tower-MdCan": {
-		"armour": 18,
+		"armour": 12,
 		"breadth": 1,
 		"buildPoints": 500,
-		"buildPower": 225,
+		"buildPower": 100,
 		"combinesWithWall": true,
 		"ecmID": "ZNULLECM",
 		"height": 2,
-		"hitpoints": 1400,
+		"hitpoints": 300,
 		"id": "CO-Tower-MdCan",
 		"name": "*CO-Tower-MdCan*",
 		"resistance": 150,
@@ -1015,7 +1015,7 @@
 		"structureModel": [
 			"BLGUARD2.pie"
 		],
-		"thermal": 18,
+		"thermal": 12,
 		"type": "DEFENSE",
 		"weapons": [
 			"Cannon2A-TMk1"
@@ -1023,22 +1023,22 @@
 		"width": 1
 	},
 	"CO-Tower-RotMG": {
-		"armour": 15,
+		"armour": 12,
 		"breadth": 1,
-		"buildPoints": 400,
-		"buildPower": 150,
+		"buildPoints": 500,
+		"buildPower": 100,
 		"ecmID": "ZNULLECM",
 		"height": 2,
-		"hitpoints": 1000,
+		"hitpoints": 300,
 		"id": "CO-Tower-RotMG",
 		"name": "*CO-Tower-RotMG*",
 		"resistance": 150,
-		"sensorID": "TowerSensor",
-		"strength": "HARD",
+		"sensorID": "DefaultSensor1Mk1",
+		"strength": "MEDIUM",
 		"structureModel": [
 			"blguardn.PIE"
 		],
-		"thermal": 15,
+		"thermal": 12,
 		"type": "DEFENSE",
 		"weapons": [
 			"MG4ROTARYMk1"
@@ -1046,14 +1046,14 @@
 		"width": 1
 	},
 	"CO-WallTower-HvCan": {
-		"armour": 18,
+		"armour": 12,
 		"breadth": 1,
 		"buildPoints": 500,
-		"buildPower": 250,
+		"buildPower": 100,
 		"combinesWithWall": true,
 		"ecmID": "ZNULLECM",
 		"height": 2,
-		"hitpoints": 1400,
+		"hitpoints": 400,
 		"id": "CO-WallTower-HvCan",
 		"name": "*CO-WallTower-HvCan*",
 		"resistance": 150,
@@ -1062,7 +1062,7 @@
 		"structureModel": [
 			"BLGUARD2.pie"
 		],
-		"thermal": 18,
+		"thermal": 12,
 		"type": "DEFENSE",
 		"weapons": [
 			"Cannon375mmMk1"
@@ -1070,14 +1070,14 @@
 		"width": 1
 	},
 	"CO-WallTower-RotCan": {
-		"armour": 18,
+		"armour": 12,
 		"breadth": 1,
 		"buildPoints": 500,
-		"buildPower": 275,
+		"buildPower": 100,
 		"combinesWithWall": true,
 		"ecmID": "ZNULLECM",
 		"height": 2,
-		"hitpoints": 1400,
+		"hitpoints": 400,
 		"id": "CO-WallTower-RotCan",
 		"name": "*CO-WallTower-RotCan*",
 		"resistance": 150,
@@ -1086,7 +1086,7 @@
 		"structureModel": [
 			"BLGUARD2.pie"
 		],
-		"thermal": 18,
+		"thermal": 12,
 		"type": "DEFENSE",
 		"weapons": [
 			"Cannon5VulcanMk1"
@@ -1096,8 +1096,8 @@
 	"CollectiveCWall": {
 		"armour": 12,
 		"breadth": 1,
-		"buildPoints": 100,
-		"buildPower": 15,
+		"buildPoints": 125,
+		"buildPower": 25,
 		"ecmID": "ZNULLECM",
 		"height": 2,
 		"hitpoints": 250,
@@ -1115,8 +1115,8 @@
 	"CollectiveWall": {
 		"armour": 12,
 		"breadth": 1,
-		"buildPoints": 100,
-		"buildPower": 15,
+		"buildPoints": 125,
+		"buildPower": 25,
 		"ecmID": "ZNULLECM",
 		"height": 2,
 		"hitpoints": 250,
@@ -1149,37 +1149,37 @@
 		"width": 1
 	},
 	"ECM1PylonMk1": {
-		"armour": 17,
+		"armour": 10,
 		"breadth": 1,
 		"buildPoints": 750,
 		"buildPower": 500,
 		"ecmID": "ECM1TurretMk1",
 		"height": 3,
-		"hitpoints": 1000,
+		"hitpoints": 300,
 		"id": "ECM1PylonMk1",
 		"name": "Jammer Tower",
 		"resistance": 150,
 		"sensorID": "DefaultSensor1Mk1",
-		"strength": "HARD",
+		"strength": "MEDIUM",
 		"structureModel": [
 			"blguardr.pie"
 		],
-		"thermal": 17,
+		"thermal": 10,
 		"type": "DEFENSE",
 		"width": 1
 	},
 	"Emplacement-HPVcannon": {
 		"armour": 10,
 		"breadth": 1,
-		"buildPoints": 225,
-		"buildPower": 130,
+		"buildPoints": 400,
+		"buildPower": 200,
 		"height": 1,
-		"hitpoints": 700,
+		"hitpoints": 400,
 		"id": "Emplacement-HPVcannon",
 		"name": "Hyper Velocity Cannon Emplacement",
 		"resistance": 150,
 		"sensorID": "DefaultSensor1Mk1",
-		"strength": "MEDIUM",
+		"strength": "HARD",
 		"structureModel": [
 			"Blhowmnt.PIE"
 		],
@@ -1193,15 +1193,15 @@
 	"Emplacement-HeavyLaser": {
 		"armour": 10,
 		"breadth": 1,
-		"buildPoints": 250,
-		"buildPower": 170,
+		"buildPoints": 400,
+		"buildPower": 500,
 		"height": 1,
-		"hitpoints": 700,
+		"hitpoints": 400,
 		"id": "Emplacement-HeavyLaser",
 		"name": "Heavy Laser Emplacement",
 		"resistance": 150,
 		"sensorID": "DefaultSensor1Mk1",
-		"strength": "MEDIUM",
+		"strength": "HARD",
 		"structureModel": [
 			"BLHARDPT.PIE"
 		],
@@ -1213,7 +1213,7 @@
 		"width": 1
 	},
 	"Emplacement-Howitzer-Incendiary": {
-		"armour": 12,
+		"armour": 10,
 		"breadth": 1,
 		"buildPoints": 525,
 		"buildPower": 375,
@@ -1223,11 +1223,11 @@
 		"name": "Incendiary Howitzer Emplacement",
 		"resistance": 150,
 		"sensorID": "DefaultSensor1Mk1",
-		"strength": "MEDIUM",
+		"strength": "HARD",
 		"structureModel": [
 			"Blhowmnt.PIE"
 		],
-		"thermal": 12,
+		"thermal": 10,
 		"type": "DEFENSE",
 		"weapons": [
 			"Howitzer-Incendiary"
@@ -1235,7 +1235,7 @@
 		"width": 1
 	},
 	"Emplacement-Howitzer-Incenediary": {
-		"armour": 12,
+		"armour": 10,
 		"breadth": 1,
 		"buildPoints": 550,
 		"buildPower": 400,
@@ -1245,11 +1245,11 @@
 		"name": "Incendiary Howitzer Emplacement 2",
 		"resistance": 150,
 		"sensorID": "DefaultSensor1Mk1",
-		"strength": "MEDIUM",
+		"strength": "HARD",
 		"structureModel": [
 			"Blhowmnt.PIE"
 		],
-		"thermal": 12,
+		"thermal": 10,
 		"type": "DEFENSE",
 		"weapons": [
 			"Howitzer-Incendiary"
@@ -1257,7 +1257,7 @@
 		"width": 1
 	},
 	"Emplacement-Howitzer105": {
-		"armour": 12,
+		"armour": 10,
 		"breadth": 1,
 		"buildPoints": 450,
 		"buildPower": 275,
@@ -1267,11 +1267,11 @@
 		"name": "Howitzer Emplacement",
 		"resistance": 150,
 		"sensorID": "DefaultSensor1Mk1",
-		"strength": "MEDIUM",
+		"strength": "HARD",
 		"structureModel": [
 			"Blhowmnt.PIE"
 		],
-		"thermal": 12,
+		"thermal": 10,
 		"type": "DEFENSE",
 		"weapons": [
 			"Howitzer105Mk1"
@@ -1279,7 +1279,7 @@
 		"width": 1
 	},
 	"Emplacement-Howitzer150": {
-		"armour": 12,
+		"armour": 10,
 		"breadth": 1,
 		"buildPoints": 600,
 		"buildPower": 475,
@@ -1289,11 +1289,11 @@
 		"name": "Ground Shaker Emplacement",
 		"resistance": 150,
 		"sensorID": "DefaultSensor1Mk1",
-		"strength": "MEDIUM",
+		"strength": "HARD",
 		"structureModel": [
 			"Blhowmnt.PIE"
 		],
-		"thermal": 12,
+		"thermal": 10,
 		"type": "DEFENSE",
 		"weapons": [
 			"Howitzer150Mk1"
@@ -1301,7 +1301,7 @@
 		"width": 1
 	},
 	"Emplacement-HvART-pit": {
-		"armour": 12,
+		"armour": 10,
 		"breadth": 1,
 		"buildPoints": 675,
 		"buildPower": 525,
@@ -1311,11 +1311,11 @@
 		"name": "Archangel Missile Emplacement",
 		"resistance": 150,
 		"sensorID": "DefaultSensor1Mk1",
-		"strength": "MEDIUM",
+		"strength": "HARD",
 		"structureModel": [
 			"BLHARDPT.PIE"
 		],
-		"thermal": 12,
+		"thermal": 10,
 		"type": "DEFENSE",
 		"weapons": [
 			"Missile-HvyArt"
@@ -1325,15 +1325,15 @@
 	"Emplacement-HvyATrocket": {
 		"armour": 10,
 		"breadth": 1,
-		"buildPoints": 225,
-		"buildPower": 150,
+		"buildPoints": 500,
+		"buildPower": 275,
 		"height": 1,
-		"hitpoints": 700,
+		"hitpoints": 400,
 		"id": "Emplacement-HvyATrocket",
 		"name": "Tank Killer Emplacement",
 		"resistance": 150,
 		"sensorID": "DefaultSensor1Mk1",
-		"strength": "MEDIUM",
+		"strength": "HARD",
 		"structureModel": [
 			"Blhowmnt.PIE"
 		],
@@ -1345,21 +1345,21 @@
 		"width": 1
 	},
 	"Emplacement-MRL-pit": {
-		"armour": 12,
+		"armour": 10,
 		"breadth": 1,
 		"buildPoints": 400,
 		"buildPower": 125,
 		"height": 1,
-		"hitpoints": 300,
+		"hitpoints": 400,
 		"id": "Emplacement-MRL-pit",
 		"name": "Mini-Rocket Battery",
 		"resistance": 150,
 		"sensorID": "DefaultSensor1Mk1",
-		"strength": "MEDIUM",
+		"strength": "HARD",
 		"structureModel": [
 			"BLHARDPT.PIE"
 		],
-		"thermal": 12,
+		"thermal": 10,
 		"type": "DEFENSE",
 		"weapons": [
 			"Rocket-MRL"
@@ -1367,21 +1367,21 @@
 		"width": 1
 	},
 	"Emplacement-MRLHvy-pit": {
-		"armour": 12,
+		"armour": 10,
 		"breadth": 1,
 		"buildPoints": 450,
-		"buildPower": 200,
+		"buildPower": 150,
 		"height": 1,
-		"hitpoints": 300,
+		"hitpoints": 400,
 		"id": "Emplacement-MRLHvy-pit",
 		"name": "Heavy Rocket Battery",
 		"resistance": 150,
 		"sensorID": "DefaultSensor1Mk1",
-		"strength": "MEDIUM",
+		"strength": "HARD",
 		"structureModel": [
 			"BLHARDPT.PIE"
 		],
-		"thermal": 12,
+		"thermal": 10,
 		"type": "DEFENSE",
 		"weapons": [
 			"Rocket-MRL-Hvy"
@@ -1389,7 +1389,7 @@
 		"width": 1
 	},
 	"Emplacement-MdART-pit": {
-		"armour": 12,
+		"armour": 10,
 		"breadth": 1,
 		"buildPoints": 600,
 		"buildPower": 450,
@@ -1399,11 +1399,11 @@
 		"name": "Seraph Missile Battery",
 		"resistance": 150,
 		"sensorID": "DefaultSensor1Mk1",
-		"strength": "MEDIUM",
+		"strength": "HARD",
 		"structureModel": [
 			"BLHARDPT.PIE"
 		],
-		"thermal": 12,
+		"thermal": 10,
 		"type": "DEFENSE",
 		"weapons": [
 			"Missile-MdArt"
@@ -1411,10 +1411,10 @@
 		"width": 1
 	},
 	"Emplacement-MortarEMP": {
-		"armour": 12,
+		"armour": 10,
 		"breadth": 1,
 		"buildPoints": 450,
-		"buildPower": 200,
+		"buildPower": 150,
 		"height": 1,
 		"hitpoints": 300,
 		"id": "Emplacement-MortarEMP",
@@ -1425,7 +1425,7 @@
 		"structureModel": [
 			"BLMRTPIT.PIE"
 		],
-		"thermal": 12,
+		"thermal": 10,
 		"type": "DEFENSE",
 		"weapons": [
 			"MortarEMP"
@@ -1433,7 +1433,7 @@
 		"width": 1
 	},
 	"Emplacement-MortarPit-Incendiary": {
-		"armour": 12,
+		"armour": 10,
 		"breadth": 1,
 		"buildPoints": 425,
 		"buildPower": 225,
@@ -1447,7 +1447,7 @@
 		"structureModel": [
 			"BLMRTPIT.PIE"
 		],
-		"thermal": 12,
+		"thermal": 10,
 		"type": "DEFENSE",
 		"weapons": [
 			"Mortar-Incendiary"
@@ -1455,10 +1455,10 @@
 		"width": 1
 	},
 	"Emplacement-MortarPit-Incenediary": {
-		"armour": 12,
+		"armour": 10,
 		"breadth": 1,
 		"buildPoints": 425,
-		"buildPower": 225,
+		"buildPower": 170,
 		"height": 1,
 		"hitpoints": 300,
 		"id": "Emplacement-MortarPit-Incenediary",
@@ -1469,7 +1469,7 @@
 		"structureModel": [
 			"BLMRTPIT.PIE"
 		],
-		"thermal": 12,
+		"thermal": 10,
 		"type": "DEFENSE",
 		"weapons": [
 			"Mortar-Incendiary"
@@ -1477,7 +1477,7 @@
 		"width": 1
 	},
 	"Emplacement-MortarPit01": {
-		"armour": 12,
+		"armour": 10,
 		"breadth": 1,
 		"buildPoints": 400,
 		"buildPower": 125,
@@ -1491,7 +1491,7 @@
 		"structureModel": [
 			"BLMRTPIT.PIE"
 		],
-		"thermal": 12,
+		"thermal": 10,
 		"type": "DEFENSE",
 		"weapons": [
 			"Mortar1Mk1"
@@ -1499,7 +1499,7 @@
 		"width": 1
 	},
 	"Emplacement-MortarPit02": {
-		"armour": 12,
+		"armour": 10,
 		"breadth": 1,
 		"buildPoints": 450,
 		"buildPower": 200,
@@ -1513,7 +1513,7 @@
 		"structureModel": [
 			"BLMRTPIT.PIE"
 		],
-		"thermal": 12,
+		"thermal": 10,
 		"type": "DEFENSE",
 		"weapons": [
 			"Mortar2Mk1"
@@ -1523,15 +1523,15 @@
 	"Emplacement-PlasmaCannon": {
 		"armour": 10,
 		"breadth": 1,
-		"buildPoints": 250,
-		"buildPower": 450,
+		"buildPoints": 400,
+		"buildPower": 300,
 		"height": 1,
-		"hitpoints": 700,
+		"hitpoints": 400,
 		"id": "Emplacement-PlasmaCannon",
 		"name": "Plasma Cannon Emplacement",
 		"resistance": 150,
 		"sensorID": "DefaultSensor1Mk1",
-		"strength": "MEDIUM",
+		"strength": "HARD",
 		"structureModel": [
 			"BLHARDPT.PIE"
 		],
@@ -1543,7 +1543,7 @@
 		"width": 1
 	},
 	"Emplacement-HeavyPlasmaLauncher": {
-		"armour": 12,
+		"armour": 10,
 		"breadth": 1,
 		"buildPoints": 675,
 		"buildPower": 525,
@@ -1553,11 +1553,11 @@
 		"name": "Heavy Plasma Launcher Emplacement",
 		"resistance": 150,
 		"sensorID": "DefaultSensor1Mk1",
-		"strength": "MEDIUM",
+		"strength": "HARD",
 		"structureModel": [
 			"Blaamnt2.PIE"
 		],
-		"thermal": 12,
+		"thermal": 10,
 		"type": "DEFENSE",
 		"weapons": [
 			"PlasmaHeavy"
@@ -1567,15 +1567,15 @@
 	"Emplacement-PrisLas": {
 		"armour": 10,
 		"breadth": 1,
-		"buildPoints": 200,
-		"buildPower": 130,
+		"buildPoints": 450,
+		"buildPower": 275,
 		"height": 1,
-		"hitpoints": 700,
+		"hitpoints": 400,
 		"id": "Emplacement-PrisLas",
 		"name": "Flashlight Emplacement",
 		"resistance": 150,
 		"sensorID": "DefaultSensor1Mk1",
-		"strength": "MEDIUM",
+		"strength": "HARD",
 		"structureModel": [
 			"BLHARDPT.PIE"
 		],
@@ -1589,15 +1589,15 @@
 	"Emplacement-PulseLaser": {
 		"armour": 10,
 		"breadth": 1,
-		"buildPoints": 225,
-		"buildPower": 150,
+		"buildPoints": 400,
+		"buildPower": 225,
 		"height": 1,
-		"hitpoints": 700,
+		"hitpoints": 400,
 		"id": "Emplacement-PulseLaser",
 		"name": "Pulse Laser Emplacement",
 		"resistance": 150,
 		"sensorID": "DefaultSensor1Mk1",
-		"strength": "MEDIUM",
+		"strength": "HARD",
 		"structureModel": [
 			"BLHARDPT.PIE"
 		],
@@ -1611,15 +1611,15 @@
 	"Emplacement-Rail2": {
 		"armour": 10,
 		"breadth": 1,
-		"buildPoints": 225,
-		"buildPower": 150,
+		"buildPoints": 500,
+		"buildPower": 350,
 		"height": 1,
-		"hitpoints": 700,
+		"hitpoints": 400,
 		"id": "Emplacement-Rail2",
 		"name": "Railgun Emplacement",
 		"resistance": 150,
 		"sensorID": "DefaultSensor1Mk1",
-		"strength": "MEDIUM",
+		"strength": "HARD",
 		"structureModel": [
 			"BLHARDPT.PIE"
 		],
@@ -1633,15 +1633,15 @@
 	"Emplacement-Rail3": {
 		"armour": 10,
 		"breadth": 1,
-		"buildPoints": 250,
-		"buildPower": 170,
+		"buildPoints": 600,
+		"buildPower": 450,
 		"height": 1,
-		"hitpoints": 700,
+		"hitpoints": 400,
 		"id": "Emplacement-Rail3",
 		"name": "Gauss Cannon Emplacement",
 		"resistance": 150,
 		"sensorID": "DefaultSensor1Mk1",
-		"strength": "MEDIUM",
+		"strength": "HARD",
 		"structureModel": [
 			"BLHARDPT.PIE"
 		],
@@ -1653,7 +1653,7 @@
 		"width": 1
 	},
 	"Emplacement-Rocket06-IDF": {
-		"armour": 12,
+		"armour": 10,
 		"breadth": 1,
 		"buildPoints": 500,
 		"buildPower": 425,
@@ -1663,11 +1663,11 @@
 		"name": "Ripple Rocket Battery",
 		"resistance": 150,
 		"sensorID": "DefaultSensor1Mk1",
-		"strength": "MEDIUM",
+		"strength": "HARD",
 		"structureModel": [
 			"Blhowmnt.PIE"
 		],
-		"thermal": 12,
+		"thermal": 10,
 		"type": "DEFENSE",
 		"weapons": [
 			"Rocket-IDF"
@@ -1675,7 +1675,7 @@
 		"width": 1
 	},
 	"Emplacement-RotHow": {
-		"armour": 12,
+		"armour": 10,
 		"breadth": 1,
 		"buildPoints": 600,
 		"buildPower": 475,
@@ -1685,11 +1685,11 @@
 		"name": "Hellstorm Emplacement",
 		"resistance": 150,
 		"sensorID": "DefaultSensor1Mk1",
-		"strength": "MEDIUM",
+		"strength": "HARD",
 		"structureModel": [
 			"BLHOWMNT.PIE"
 		],
-		"thermal": 12,
+		"thermal": 10,
 		"type": "DEFENSE",
 		"weapons": [
 			"Howitzer03-Rot"
@@ -1697,7 +1697,7 @@
 		"width": 1
 	},
 	"Emplacement-RotMor": {
-		"armour": 12,
+		"armour": 10,
 		"breadth": 1,
 		"buildPoints": 425,
 		"buildPower": 175,
@@ -1711,7 +1711,7 @@
 		"structureModel": [
 			"BLMRTPIT.PIE"
 		],
-		"thermal": 12,
+		"thermal": 10,
 		"type": "DEFENSE",
 		"weapons": [
 			"Mortar3ROTARYMk1"
@@ -1719,21 +1719,21 @@
 		"width": 1
 	},
 	"GuardTower-ATMiss": {
-		"armour": 15,
+		"armour": 10,
 		"breadth": 1,
 		"buildPoints": 450,
-		"buildPower": 250,
+		"buildPower": 325,
 		"height": 2,
-		"hitpoints": 1000,
+		"hitpoints": 600,
 		"id": "GuardTower-ATMiss",
 		"name": "Scourge Missile Tower",
 		"resistance": 150,
 		"sensorID": "TowerSensor",
-		"strength": "HARD",
+		"strength": "MEDIUM",
 		"structureModel": [
 			"BLGUARDR.pie"
 		],
-		"thermal": 15,
+		"thermal": 10,
 		"type": "DEFENSE",
 		"weapons": [
 			"Missile-A-T"
@@ -1741,21 +1741,21 @@
 		"width": 1
 	},
 	"GuardTower-BeamLas": {
-		"armour": 15,
+		"armour": 10,
 		"breadth": 1,
 		"buildPoints": 400,
 		"buildPower": 200,
 		"height": 2,
-		"hitpoints": 1000,
+		"hitpoints": 600,
 		"id": "GuardTower-BeamLas",
 		"name": "Pulse Laser Tower",
 		"resistance": 150,
 		"sensorID": "TowerSensor",
-		"strength": "HARD",
+		"strength": "MEDIUM",
 		"structureModel": [
 			"BLGUARDR.pie"
 		],
-		"thermal": 15,
+		"thermal": 10,
 		"type": "DEFENSE",
 		"weapons": [
 			"Laser2PULSEMk1"
@@ -1763,21 +1763,21 @@
 		"width": 1
 	},
 	"GuardTower-Rail1": {
-		"armour": 15,
+		"armour": 10,
 		"breadth": 1,
 		"buildPoints": 400,
-		"buildPower": 200,
+		"buildPower": 275,
 		"height": 2,
-		"hitpoints": 1000,
+		"hitpoints": 600,
 		"id": "GuardTower-Rail1",
 		"name": "Needle Gun Tower",
 		"resistance": 150,
 		"sensorID": "TowerSensor",
-		"strength": "HARD",
+		"strength": "MEDIUM",
 		"structureModel": [
 			"BLGUARDR.pie"
 		],
-		"thermal": 15,
+		"thermal": 10,
 		"type": "DEFENSE",
 		"weapons": [
 			"RailGun1Mk1"
@@ -1785,21 +1785,21 @@
 		"width": 1
 	},
 	"GuardTower-RotMg": {
-		"armour": 15,
+		"armour": 20,
 		"breadth": 1,
 		"buildPoints": 400,
 		"buildPower": 150,
 		"height": 2,
-		"hitpoints": 1000,
+		"hitpoints": 600,
 		"id": "GuardTower-RotMg",
 		"name": "Assault Gun Tower",
 		"resistance": 150,
 		"sensorID": "TowerSensor",
-		"strength": "HARD",
+		"strength": "MEDIUM",
 		"structureModel": [
 			"blguardr.pie"
 		],
-		"thermal": 15,
+		"thermal": 20,
 		"type": "DEFENSE",
 		"weapons": [
 			"MG4ROTARYMk1"
@@ -1831,8 +1831,8 @@
 	"GuardTower2": {
 		"armour": 10,
 		"breadth": 1,
-		"buildPoints": 300,
-		"buildPower": 80,
+		"buildPoints": 400,
+		"buildPower": 100,
 		"height": 2,
 		"hitpoints": 450,
 		"id": "GuardTower2",
@@ -1854,14 +1854,14 @@
 		"armour": 15,
 		"breadth": 1,
 		"buildPoints": 400,
-		"buildPower": 150,
+		"buildPower": 100,
 		"height": 2,
-		"hitpoints": 1000,
+		"hitpoints": 600,
 		"id": "GuardTower3",
 		"name": "Heavy Machinegun Tower",
 		"resistance": 150,
 		"sensorID": "TowerSensor",
-		"strength": "HARD",
+		"strength": "MEDIUM",
 		"structureModel": [
 			"BLGUARDR.pie"
 		],
@@ -1876,14 +1876,14 @@
 		"armour": 15,
 		"breadth": 1,
 		"buildPoints": 400,
-		"buildPower": 150,
+		"buildPower": 100,
 		"height": 2,
-		"hitpoints": 1000,
+		"hitpoints": 600,
 		"id": "GuardTower4",
 		"name": "Flamer Guard Tower",
 		"resistance": 150,
 		"sensorID": "TowerSensor",
-		"strength": "HARD",
+		"strength": "MEDIUM",
 		"structureModel": [
 			"BLGUARDR.pie"
 		],
@@ -1898,14 +1898,14 @@
 		"armour": 15,
 		"breadth": 1,
 		"buildPoints": 350,
-		"buildPower": 200,
+		"buildPower": 150,
 		"height": 2,
-		"hitpoints": 1000,
+		"hitpoints": 600,
 		"id": "GuardTower5",
 		"name": "Lancer Tower",
 		"resistance": 150,
 		"sensorID": "TowerSensor",
-		"strength": "HARD",
+		"strength": "MEDIUM",
 		"structureModel": [
 			"BLGUARDR.pie"
 		],
@@ -1920,14 +1920,14 @@
 		"armour": 15,
 		"breadth": 1,
 		"buildPoints": 400,
-		"buildPower": 150,
+		"buildPower": 100,
 		"height": 2,
-		"hitpoints": 1000,
+		"hitpoints": 600,
 		"id": "GuardTower6",
 		"name": "Mini-Rocket Tower",
 		"resistance": 150,
 		"sensorID": "TowerSensor",
-		"strength": "HARD",
+		"strength": "MEDIUM",
 		"structureModel": [
 			"BLGUARDR.pie"
 		],
@@ -1959,8 +1959,8 @@
 	"NEXUSCWall": {
 		"armour": 15,
 		"breadth": 1,
-		"buildPoints": 100,
-		"buildPower": 15,
+		"buildPoints": 125,
+		"buildPower": 25,
 		"ecmID": "ZNULLECM",
 		"height": 2,
 		"hitpoints": 250,
@@ -1978,8 +1978,8 @@
 	"NEXUSWall": {
 		"armour": 15,
 		"breadth": 1,
-		"buildPoints": 100,
-		"buildPower": 15,
+		"buildPoints": 125,
+		"buildPower": 25,
 		"ecmID": "ZNULLECM",
 		"height": 2,
 		"hitpoints": 250,
@@ -2014,7 +2014,7 @@
 		"width": 1
 	},
 	"NX-CruiseSite": {
-		"armour": 24,
+		"armour": 20,
 		"breadth": 1,
 		"buildPoints": 500,
 		"buildPower": 100,
@@ -2028,7 +2028,7 @@
 		"structureModel": [
 			"blbunkms.pie"
 		],
-		"thermal": 24,
+		"thermal": 20,
 		"type": "DEFENSE",
 		"width": 1
 	},
@@ -2044,7 +2044,7 @@
 		"name": "*NX-Emp-MedArtMiss-Pit*",
 		"resistance": 150,
 		"sensorID": "NavGunSensor",
-		"strength": "MEDIUM",
+		"strength": "HARD",
 		"structureModel": [
 			"BLHARDPT.PIE"
 		],
@@ -2067,7 +2067,7 @@
 		"name": "*NX-Emp-MultiArtMiss-Pit*",
 		"resistance": 150,
 		"sensorID": "NavGunSensor",
-		"strength": "MEDIUM",
+		"strength": "HARD",
 		"structureModel": [
 			"BLHARDPT.PIE"
 		],
@@ -2090,7 +2090,7 @@
 		"name": "*NX-Emp-Plasma-Pit*",
 		"resistance": 150,
 		"sensorID": "NavGunSensor",
-		"strength": "MEDIUM",
+		"strength": "HARD",
 		"structureModel": [
 			"Blaamnt2.PIE"
 		],
@@ -2104,16 +2104,16 @@
 	"NX-Tower-ATMiss": {
 		"armour": 15,
 		"breadth": 1,
-		"buildPoints": 450,
-		"buildPower": 250,
+		"buildPoints": 400,
+		"buildPower": 40,
 		"ecmID": "ZNULLECM",
 		"height": 2,
-		"hitpoints": 1000,
+		"hitpoints": 300,
 		"id": "NX-Tower-ATMiss",
 		"name": "*NX-Tower-ATMiss*",
 		"resistance": 150,
 		"sensorID": "NavGunSensor",
-		"strength": "HARD",
+		"strength": "MEDIUM",
 		"structureModel": [
 			"Blgrdnex.PIE"
 		],
@@ -2128,15 +2128,15 @@
 		"armour": 15,
 		"breadth": 1,
 		"buildPoints": 400,
-		"buildPower": 200,
+		"buildPower": 40,
 		"ecmID": "ZNULLECM",
 		"height": 2,
-		"hitpoints": 1000,
+		"hitpoints": 300,
 		"id": "NX-Tower-PulseLas",
 		"name": "*NX-Tower-PulseLas*",
 		"resistance": 150,
 		"sensorID": "NavGunSensor",
-		"strength": "HARD",
+		"strength": "MEDIUM",
 		"structureModel": [
 			"Blgrdnex.PIE"
 		],
@@ -2151,15 +2151,15 @@
 		"armour": 15,
 		"breadth": 1,
 		"buildPoints": 400,
-		"buildPower": 200,
+		"buildPower": 40,
 		"ecmID": "ZNULLECM",
 		"height": 2,
-		"hitpoints": 1000,
+		"hitpoints": 300,
 		"id": "NX-Tower-Rail1",
 		"name": "*NX-Tower-Rail1*",
 		"resistance": 150,
 		"sensorID": "NavGunSensor",
-		"strength": "HARD",
+		"strength": "MEDIUM",
 		"structureModel": [
 			"Blgrdnex.PIE"
 		],
@@ -2171,14 +2171,14 @@
 		"width": 1
 	},
 	"NX-WallTower-BeamLas": {
-		"armour": 18,
+		"armour": 15,
 		"breadth": 1,
-		"buildPoints": 500,
-		"buildPower": 250,
+		"buildPoints": 400,
+		"buildPower": 100,
 		"combinesWithWall": true,
 		"ecmID": "ZNULLECM",
 		"height": 2,
-		"hitpoints": 1400,
+		"hitpoints": 400,
 		"id": "NX-WallTower-BeamLas",
 		"name": "*NX-WallTower-BeamLas*",
 		"resistance": 150,
@@ -2187,7 +2187,7 @@
 		"structureModel": [
 			"BLGUARD3.pie"
 		],
-		"thermal": 18,
+		"thermal": 15,
 		"type": "DEFENSE",
 		"weapons": [
 			"Laser3BEAMMk1"
@@ -2195,14 +2195,14 @@
 		"width": 1
 	},
 	"NX-WallTower-Rail2": {
-		"armour": 18,
+		"armour": 15,
 		"breadth": 1,
-		"buildPoints": 500,
-		"buildPower": 350,
+		"buildPoints": 400,
+		"buildPower": 100,
 		"combinesWithWall": true,
 		"ecmID": "ZNULLECM",
 		"height": 2,
-		"hitpoints": 1400,
+		"hitpoints": 400,
 		"id": "NX-WallTower-Rail2",
 		"name": "*NX-WallTower-Rail2*",
 		"resistance": 150,
@@ -2211,7 +2211,7 @@
 		"structureModel": [
 			"BLGUARD3.pie"
 		],
-		"thermal": 18,
+		"thermal": 15,
 		"type": "DEFENSE",
 		"weapons": [
 			"RailGun2Mk1"
@@ -2219,14 +2219,14 @@
 		"width": 1
 	},
 	"NX-WallTower-Rail3": {
-		"armour": 18,
+		"armour": 15,
 		"breadth": 1,
-		"buildPoints": 500,
-		"buildPower": 375,
+		"buildPoints": 400,
+		"buildPower": 100,
 		"combinesWithWall": true,
 		"ecmID": "ZNULLECM",
 		"height": 2,
-		"hitpoints": 1400,
+		"hitpoints": 400,
 		"id": "NX-WallTower-Rail3",
 		"name": "*NX-WallTower-Rail3*",
 		"resistance": 150,
@@ -2235,7 +2235,7 @@
 		"structureModel": [
 			"BLGUARD3.pie"
 		],
-		"thermal": 18,
+		"thermal": 15,
 		"type": "DEFENSE",
 		"weapons": [
 			"RailGun3Mk1"
@@ -2261,7 +2261,7 @@
 		"width": 2
 	},
 	"P0-AASite-Laser": {
-		"armour": 12,
+		"armour": 10,
 		"breadth": 1,
 		"buildPoints": 400,
 		"buildPower": 275,
@@ -2271,11 +2271,11 @@
 		"name": "Stormbringer Emplacement",
 		"resistance": 150,
 		"sensorID": "DefaultSensor1Mk1",
-		"strength": "MEDIUM",
+		"strength": "HARD",
 		"structureModel": [
 			"Blaamnt2.PIE"
 		],
-		"thermal": 12,
+		"thermal": 10,
 		"type": "DEFENSE",
 		"weapons": [
 			"AAGunLaser"
@@ -2283,7 +2283,7 @@
 		"width": 1
 	},
 	"P0-AASite-SAM1": {
-		"armour": 12,
+		"armour": 10,
 		"breadth": 1,
 		"buildPoints": 350,
 		"buildPower": 275,
@@ -2293,11 +2293,11 @@
 		"name": "Avenger SAM Site",
 		"resistance": 150,
 		"sensorID": "DefaultSensor1Mk1",
-		"strength": "MEDIUM",
+		"strength": "HARD",
 		"structureModel": [
 			"Blaamnt1.PIE"
 		],
-		"thermal": 12,
+		"thermal": 10,
 		"type": "DEFENSE",
 		"weapons": [
 			"Missile-LtSAM"
@@ -2305,7 +2305,7 @@
 		"width": 1
 	},
 	"P0-AASite-SAM2": {
-		"armour": 12,
+		"armour": 10,
 		"breadth": 1,
 		"buildPoints": 450,
 		"buildPower": 325,
@@ -2315,11 +2315,11 @@
 		"name": "Vindicator SAM Site",
 		"resistance": 150,
 		"sensorID": "DefaultSensor1Mk1",
-		"strength": "MEDIUM",
+		"strength": "HARD",
 		"structureModel": [
 			"Blaamnt2.PIE"
 		],
-		"thermal": 12,
+		"thermal": 10,
 		"type": "DEFENSE",
 		"weapons": [
 			"Missile-HvySAM"
@@ -2327,10 +2327,10 @@
 		"width": 1
 	},
 	"P0-AASite-Sunburst": {
-		"armour": 12,
+		"armour": 10,
 		"breadth": 1,
 		"buildPoints": 300,
-		"buildPower": 175,
+		"buildPower": 225,
 		"height": 2,
 		"hitpoints": 400,
 		"id": "P0-AASite-Sunburst",
@@ -2341,7 +2341,7 @@
 		"structureModel": [
 			"Blaamnt1.PIE"
 		],
-		"thermal": 12,
+		"thermal": 10,
 		"type": "DEFENSE",
 		"weapons": [
 			"Rocket-Sunburst"
@@ -2349,12 +2349,12 @@
 		"width": 1
 	},
 	"PillBox-Cannon6": {
-		"armour": 24,
+		"armour": 20,
 		"breadth": 1,
-		"buildPoints": 600,
-		"buildPower": 340,
+		"buildPoints": 500,
+		"buildPower": 225,
 		"height": 1,
-		"hitpoints": 1200,
+		"hitpoints": 700,
 		"id": "PillBox-Cannon6",
 		"name": "Twin Assault Cannon Bunker",
 		"resistance": 150,
@@ -2363,7 +2363,7 @@
 		"structureModel": [
 			"Blcanpil.pie"
 		],
-		"thermal": 24,
+		"thermal": 20,
 		"type": "DEFENSE",
 		"weapons": [
 			"Cannon6TwinAslt"
@@ -2371,12 +2371,12 @@
 		"width": 1
 	},
 	"PillBox1": {
-		"armour": 24,
+		"armour": 20,
 		"breadth": 1,
-		"buildPoints": 600,
-		"buildPower": 300,
+		"buildPoints": 400,
+		"buildPower": 100,
 		"height": 1,
-		"hitpoints": 1200,
+		"hitpoints": 700,
 		"id": "PillBox1",
 		"name": "Heavy Machinegun Bunker",
 		"resistance": 150,
@@ -2385,7 +2385,7 @@
 		"structureModel": [
 			"blpilbox.pie"
 		],
-		"thermal": 24,
+		"thermal": 20,
 		"type": "DEFENSE",
 		"weapons": [
 			"MG3-Pillbox"
@@ -2393,12 +2393,12 @@
 		"width": 1
 	},
 	"PillBox2": {
-		"armour": 24,
+		"armour": 20,
 		"breadth": 1,
-		"buildPoints": 600,
-		"buildPower": 300,
+		"buildPoints": 400,
+		"buildPower": 100,
 		"height": 1,
-		"hitpoints": 1200,
+		"hitpoints": 700,
 		"id": "PillBox2",
 		"name": "Twin Machinegun Bunker",
 		"resistance": 150,
@@ -2407,7 +2407,7 @@
 		"structureModel": [
 			"blpilbox.pie"
 		],
-		"thermal": 24,
+		"thermal": 20,
 		"type": "DEFENSE",
 		"weapons": [
 			"MG2-Pillbox"
@@ -2415,12 +2415,12 @@
 		"width": 1
 	},
 	"PillBox3": {
-		"armour": 24,
+		"armour": 20,
 		"breadth": 1,
-		"buildPoints": 600,
-		"buildPower": 300,
+		"buildPoints": 400,
+		"buildPower": 100,
 		"height": 1,
-		"hitpoints": 1200,
+		"hitpoints": 700,
 		"id": "PillBox3",
 		"name": "HMG Bunker",
 		"resistance": 150,
@@ -2429,7 +2429,7 @@
 		"structureModel": [
 			"blpilbox.pie"
 		],
-		"thermal": 24,
+		"thermal": 20,
 		"type": "DEFENSE",
 		"weapons": [
 			"MG3-Pillbox"
@@ -2437,12 +2437,12 @@
 		"width": 1
 	},
 	"PillBox4": {
-		"armour": 24,
+		"armour": 20,
 		"breadth": 1,
-		"buildPoints": 600,
-		"buildPower": 310,
+		"buildPoints": 400,
+		"buildPower": 125,
 		"height": 1,
-		"hitpoints": 1200,
+		"hitpoints": 700,
 		"id": "PillBox4",
 		"name": "Light Cannon Bunker",
 		"resistance": 150,
@@ -2451,7 +2451,7 @@
 		"structureModel": [
 			"Blcanpil.pie"
 		],
-		"thermal": 24,
+		"thermal": 20,
 		"type": "DEFENSE",
 		"weapons": [
 			"Cannon1Mk1"
@@ -2459,12 +2459,12 @@
 		"width": 1
 	},
 	"PillBox5": {
-		"armour": 24,
+		"armour": 20,
 		"breadth": 1,
-		"buildPoints": 600,
-		"buildPower": 300,
+		"buildPoints": 400,
+		"buildPower": 100,
 		"height": 1,
-		"hitpoints": 1200,
+		"hitpoints": 700,
 		"id": "PillBox5",
 		"name": "Flamer Bunker",
 		"resistance": 150,
@@ -2473,7 +2473,7 @@
 		"structureModel": [
 			"Blcanpil.pie"
 		],
-		"thermal": 24,
+		"thermal": 20,
 		"type": "DEFENSE",
 		"weapons": [
 			"Flame1Mk1"
@@ -2481,12 +2481,12 @@
 		"width": 1
 	},
 	"PillBox6": {
-		"armour": 24,
+		"armour": 20,
 		"breadth": 1,
-		"buildPoints": 600,
-		"buildPower": 330,
+		"buildPoints": 400,
+		"buildPower": 150,
 		"height": 1,
-		"hitpoints": 1200,
+		"hitpoints": 700,
 		"id": "PillBox6",
 		"name": "Lancer Bunker",
 		"resistance": 150,
@@ -2495,7 +2495,7 @@
 		"structureModel": [
 			"Blcanpil.pie"
 		],
-		"thermal": 24,
+		"thermal": 20,
 		"type": "DEFENSE",
 		"weapons": [
 			"Rocket-LtA-T"
@@ -2503,12 +2503,12 @@
 		"width": 1
 	},
 	"Pillbox-RotMG": {
-		"armour": 24,
+		"armour": 20,
 		"breadth": 1,
-		"buildPoints": 600,
-		"buildPower": 320,
+		"buildPoints": 400,
+		"buildPower": 150,
 		"height": 1,
-		"hitpoints": 1200,
+		"hitpoints": 700,
 		"id": "Pillbox-RotMG",
 		"name": "Rotary MG Bunker",
 		"resistance": 150,
@@ -2517,7 +2517,7 @@
 		"structureModel": [
 			"blpilbox.pie"
 		],
-		"thermal": 24,
+		"thermal": 20,
 		"type": "DEFENSE",
 		"weapons": [
 			"MG4ROTARY-Pillbox"
@@ -2525,12 +2525,12 @@
 		"width": 1
 	},
 	"Plasmite-flamer-bunker": {
-		"armour": 24,
+		"armour": 20,
 		"breadth": 1,
-		"buildPoints": 600,
-		"buildPower": 330,
+		"buildPoints": 400,
+		"buildPower": 125,
 		"height": 1,
-		"hitpoints": 1200,
+		"hitpoints": 700,
 		"id": "Plasmite-flamer-bunker",
 		"name": "Plasmite Flamer Bunker",
 		"resistance": 150,
@@ -2539,7 +2539,7 @@
 		"structureModel": [
 			"Blcanpil.pie"
 		],
-		"thermal": 24,
+		"thermal": 20,
 		"type": "DEFENSE",
 		"weapons": [
 			"PlasmiteFlamer"
@@ -2547,12 +2547,12 @@
 		"width": 1
 	},
 	"Sys-CB-Tower01": {
-		"armour": 17,
+		"armour": 15,
 		"breadth": 1,
 		"buildPoints": 400,
-		"buildPower": 175,
+		"buildPower": 100,
 		"height": 3,
-		"hitpoints": 1000,
+		"hitpoints": 600,
 		"id": "Sys-CB-Tower01",
 		"name": "CB Tower",
 		"resistance": 150,
@@ -2561,18 +2561,18 @@
 		"structureModel": [
 			"BLGUARDR.pie"
 		],
-		"thermal": 17,
+		"thermal": 15,
 		"type": "DEFENSE",
 		"width": 1
 	},
 	"Sys-NEXUSLinkTOW": {
-		"armour": 17,
+		"armour": 15,
 		"breadth": 1,
-		"buildPoints": 450,
-		"buildPower": 175,
+		"buildPoints": 400,
+		"buildPower": 100,
 		"ecmID": "ZNULLECM",
 		"height": 3,
-		"hitpoints": 1000,
+		"hitpoints": 400,
 		"id": "Sys-NEXUSLinkTOW",
 		"name": "*Sys-NEXUSLinkTOW*",
 		"sensorID": "NavGunSensor",
@@ -2580,7 +2580,7 @@
 		"structureModel": [
 			"Blgrdnex.PIE"
 		],
-		"thermal": 17,
+		"thermal": 15,
 		"type": "DEFENSE",
 		"weapons": [
 			"SpyTurret01"
@@ -2588,13 +2588,13 @@
 		"width": 1
 	},
 	"Sys-NX-CBTower": {
-		"armour": 17,
+		"armour": 15,
 		"breadth": 1,
 		"buildPoints": 400,
-		"buildPower": 175,
+		"buildPower": 100,
 		"ecmID": "ZNULLECM",
 		"height": 3,
-		"hitpoints": 1000,
+		"hitpoints": 400,
 		"id": "Sys-NX-CBTower",
 		"name": "*Sys-NX-CBTower*",
 		"resistance": 150,
@@ -2603,18 +2603,18 @@
 		"structureModel": [
 			"Blgrdnex.PIE"
 		],
-		"thermal": 17,
+		"thermal": 15,
 		"type": "DEFENSE",
 		"width": 1
 	},
 	"Sys-NX-SensorTower": {
-		"armour": 17,
+		"armour": 15,
 		"breadth": 1,
 		"buildPoints": 400,
-		"buildPower": 175,
+		"buildPower": 100,
 		"ecmID": "ZNULLECM",
 		"height": 3,
-		"hitpoints": 1000,
+		"hitpoints": 400,
 		"id": "Sys-NX-SensorTower",
 		"name": "*Sys-NX-SensorTower*",
 		"resistance": 150,
@@ -2623,18 +2623,18 @@
 		"structureModel": [
 			"Blgrdnex.PIE"
 		],
-		"thermal": 17,
+		"thermal": 15,
 		"type": "DEFENSE",
 		"width": 1
 	},
 	"Sys-NX-VTOL-CB-Tow": {
-		"armour": 17,
+		"armour": 15,
 		"breadth": 1,
 		"buildPoints": 400,
-		"buildPower": 175,
+		"buildPower": 100,
 		"ecmID": "ZNULLECM",
 		"height": 3,
-		"hitpoints": 1000,
+		"hitpoints": 400,
 		"id": "Sys-NX-VTOL-CB-Tow",
 		"name": "*Sys-NX-VTOL-CB-Tow*",
 		"resistance": 150,
@@ -2643,18 +2643,18 @@
 		"structureModel": [
 			"Blgrdnex.PIE"
 		],
-		"thermal": 17,
+		"thermal": 15,
 		"type": "DEFENSE",
 		"width": 1
 	},
 	"Sys-NX-VTOL-RadTow": {
-		"armour": 17,
+		"armour": 15,
 		"breadth": 1,
 		"buildPoints": 400,
-		"buildPower": 175,
+		"buildPower": 100,
 		"ecmID": "ZNULLECM",
 		"height": 3,
-		"hitpoints": 1000,
+		"hitpoints": 400,
 		"id": "Sys-NX-VTOL-RadTow",
 		"name": "*Sys-NX-VTOL-RadTow*",
 		"resistance": 150,
@@ -2663,34 +2663,34 @@
 		"structureModel": [
 			"Blgrdnex.PIE"
 		],
-		"thermal": 17,
+		"thermal": 15,
 		"type": "DEFENSE",
 		"width": 1
 	},
 	"Sys-RadarDetector01": {
-		"armour": 17,
+		"armour": 15,
 		"breadth": 1,
 		"buildPoints": 400,
-		"buildPower": 175,
+		"buildPower": 100,
 		"height": 2,
-		"hitpoints": 1000,
+		"hitpoints": 600,
 		"id": "Sys-RadarDetector01",
 		"name": "Radar Detector Tower",
 		"resistance": 150,
 		"sensorID": "RadarDetector",
-		"strength": "HARD",
+		"strength": "MEDIUM",
 		"structureModel": [
 			"BLGUARDR.pie"
 		],
-		"thermal": 17,
+		"thermal": 15,
 		"type": "DEFENSE",
 		"width": 1
 	},
 	"Sys-SensoTower01": {
 		"armour": 10,
 		"breadth": 1,
-		"buildPoints": 200,
-		"buildPower": 50,
+		"buildPoints": 300,
+		"buildPower": 60,
 		"height": 3,
 		"hitpoints": 450,
 		"id": "Sys-SensoTower01",
@@ -2706,12 +2706,12 @@
 		"width": 1
 	},
 	"Sys-SensoTower02": {
-		"armour": 17,
+		"armour": 15,
 		"breadth": 1,
 		"buildPoints": 400,
-		"buildPower": 175,
+		"buildPower": 100,
 		"height": 3,
-		"hitpoints": 1000,
+		"hitpoints": 600,
 		"id": "Sys-SensoTower02",
 		"name": "Hardened Sensor Tower",
 		"resistance": 150,
@@ -2720,17 +2720,17 @@
 		"structureModel": [
 			"BLGUARDR.pie"
 		],
-		"thermal": 17,
+		"thermal": 15,
 		"type": "DEFENSE",
 		"width": 1
 	},
 	"Sys-SensoTowerWS": {
-		"armour": 17,
+		"armour": 15,
 		"breadth": 1,
 		"buildPoints": 800,
 		"buildPower": 350,
 		"height": 3,
-		"hitpoints": 1000,
+		"hitpoints": 600,
 		"id": "Sys-SensoTowerWS",
 		"name": "Wide Spectrum Sensor Tower",
 		"resistance": 150,
@@ -2739,26 +2739,26 @@
 		"structureModel": [
 			"BLGUARDR.pie"
 		],
-		"thermal": 17,
+		"thermal": 15,
 		"type": "DEFENSE",
 		"width": 1
 	},
 	"Sys-SpyTower": {
-		"armour": 17,
+		"armour": 15,
 		"breadth": 1,
-		"buildPoints": 450,
-		"buildPower": 175,
+		"buildPoints": 1600,
+		"buildPower": 800,
 		"height": 3,
-		"hitpoints": 1000,
+		"hitpoints": 600,
 		"id": "Sys-SpyTower",
 		"name": "Nexus Link Tower",
 		"resistance": 150,
-		"sensorID": "TowerSensor",
+		"sensorID": "DefaultSensor1Mk1",
 		"strength": "HARD",
 		"structureModel": [
 			"BLGUARDR.pie"
 		],
-		"thermal": 17,
+		"thermal": 15,
 		"type": "DEFENSE",
 		"weapons": [
 			"SpyTurret01"
@@ -2766,12 +2766,12 @@
 		"width": 1
 	},
 	"Sys-VTOL-CB-Tower01": {
-		"armour": 17,
+		"armour": 15,
 		"breadth": 1,
 		"buildPoints": 400,
-		"buildPower": 175,
+		"buildPower": 100,
 		"height": 3,
-		"hitpoints": 1000,
+		"hitpoints": 600,
 		"id": "Sys-VTOL-CB-Tower01",
 		"name": "VTOL CB Tower",
 		"resistance": 150,
@@ -2780,17 +2780,17 @@
 		"structureModel": [
 			"BLGUARDR.pie"
 		],
-		"thermal": 17,
+		"thermal": 15,
 		"type": "DEFENSE",
 		"width": 1
 	},
 	"Sys-VTOL-RadarTower01": {
-		"armour": 17,
+		"armour": 15,
 		"breadth": 1,
 		"buildPoints": 400,
-		"buildPower": 175,
+		"buildPower": 100,
 		"height": 3,
-		"hitpoints": 1000,
+		"hitpoints": 600,
 		"id": "Sys-VTOL-RadarTower01",
 		"name": "VTOL Strike Tower",
 		"resistance": 150,
@@ -2799,20 +2799,20 @@
 		"structureModel": [
 			"BLGUARDR.pie"
 		],
-		"thermal": 17,
+		"thermal": 15,
 		"type": "DEFENSE",
 		"width": 1
 	},
 	"TankTrapC": {
 		"armour": 10,
 		"breadth": 1,
-		"buildPoints": 40,
-		"buildPower": 5,
+		"buildPoints": 200,
+		"buildPower": 15,
 		"height": 1,
 		"hitpoints": 200,
 		"id": "TankTrapC",
 		"name": "Tank Traps",
-		"strength": "MEDIUM",
+		"strength": "HARD",
 		"structureModel": [
 			"MITRAP2.PIE"
 		],
@@ -2821,12 +2821,12 @@
 		"width": 1
 	},
 	"Tower-Projector": {
-		"armour": 24,
+		"armour": 20,
 		"breadth": 1,
-		"buildPoints": 600,
-		"buildPower": 320,
+		"buildPoints": 400,
+		"buildPower": 125,
 		"height": 1,
-		"hitpoints": 1200,
+		"hitpoints": 700,
 		"id": "Tower-Projector",
 		"name": "Inferno Bunker",
 		"resistance": 150,
@@ -2835,7 +2835,7 @@
 		"structureModel": [
 			"Blcanpil.pie"
 		],
-		"thermal": 24,
+		"thermal": 20,
 		"type": "DEFENSE",
 		"weapons": [
 			"Flame2"
@@ -2843,12 +2843,12 @@
 		"width": 1
 	},
 	"Tower-RotMg": {
-		"armour": 24,
+		"armour": 20,
 		"breadth": 1,
-		"buildPoints": 600,
-		"buildPower": 310,
+		"buildPoints": 100,
+		"buildPower": 125,
 		"height": 1,
-		"hitpoints": 1200,
+		"hitpoints": 700,
 		"id": "Tower-RotMg",
 		"name": "Assault Gun Emplacement",
 		"resistance": 150,
@@ -2857,7 +2857,7 @@
 		"structureModel": [
 			"blcanpil.pie"
 		],
-		"thermal": 24,
+		"thermal": 20,
 		"type": "DEFENSE",
 		"weapons": [
 			"MG4ROTARYMk1"
@@ -2867,15 +2867,15 @@
 	"Tower-VulcanCan": {
 		"armour": 15,
 		"breadth": 1,
-		"buildPoints": 400,
-		"buildPower": 200,
+		"buildPoints": 100,
+		"buildPower": 225,
 		"height": 2,
-		"hitpoints": 1000,
+		"hitpoints": 600,
 		"id": "Tower-VulcanCan",
 		"name": "Assault Cannon Guard Tower",
 		"resistance": 150,
-		"sensorID": "TowerSensor",
-		"strength": "HARD",
+		"sensorID": "DefaultSensor1Mk1",
+		"strength": "MEDIUM",
 		"structureModel": [
 			"BLGUARDR.PIE"
 		],
@@ -2905,13 +2905,13 @@
 		"width": 2
 	},
 	"Wall-RotMg": {
-		"armour": 18,
+		"armour": 15,
 		"breadth": 1,
-		"buildPoints": 500,
-		"buildPower": 225,
+		"buildPoints": 400,
+		"buildPower": 150,
 		"combinesWithWall": true,
 		"height": 2,
-		"hitpoints": 1400,
+		"hitpoints": 800,
 		"id": "Wall-RotMg",
 		"name": "Assault Gun Hardpoint",
 		"resistance": 150,
@@ -2920,7 +2920,7 @@
 		"structureModel": [
 			"BLGUARD1.pie"
 		],
-		"thermal": 18,
+		"thermal": 15,
 		"type": "DEFENSE",
 		"weapons": [
 			"MG4ROTARYMk1"
@@ -2928,13 +2928,13 @@
 		"width": 1
 	},
 	"Wall-VulcanCan": {
-		"armour": 18,
+		"armour": 15,
 		"breadth": 1,
-		"buildPoints": 500,
-		"buildPower": 275,
+		"buildPoints": 400,
+		"buildPower": 250,
 		"combinesWithWall": true,
 		"height": 2,
-		"hitpoints": 1400,
+		"hitpoints": 800,
 		"id": "Wall-VulcanCan",
 		"name": "Assault Cannon Hardpoint",
 		"resistance": 150,
@@ -2943,7 +2943,7 @@
 		"structureModel": [
 			"BLGUARD1.pie"
 		],
-		"thermal": 18,
+		"thermal": 15,
 		"type": "DEFENSE",
 		"weapons": [
 			"Cannon5VulcanMk1"
@@ -2951,13 +2951,13 @@
 		"width": 1
 	},
 	"WallTower-Atmiss": {
-		"armour": 18,
+		"armour": 15,
 		"breadth": 1,
-		"buildPoints": 500,
+		"buildPoints": 400,
 		"buildPower": 350,
 		"combinesWithWall": true,
 		"height": 2,
-		"hitpoints": 1400,
+		"hitpoints": 800,
 		"id": "WallTower-Atmiss",
 		"name": "Scourge Missile Hardpoint",
 		"resistance": 150,
@@ -2966,7 +2966,7 @@
 		"structureModel": [
 			"BLGUARD1.pie"
 		],
-		"thermal": 18,
+		"thermal": 15,
 		"type": "DEFENSE",
 		"weapons": [
 			"Missile-A-T"
@@ -2974,13 +2974,13 @@
 		"width": 1
 	},
 	"WallTower-DoubleAAGun": {
-		"armour": 18,
+		"armour": 15,
 		"breadth": 1,
-		"buildPoints": 500,
-		"buildPower": 225,
+		"buildPoints": 400,
+		"buildPower": 250,
 		"combinesWithWall": true,
 		"height": 2,
-		"hitpoints": 1400,
+		"hitpoints": 800,
 		"id": "WallTower-DoubleAAGun",
 		"name": "AA Cyclone Flak Cannon Hardpoint",
 		"resistance": 150,
@@ -2989,7 +2989,7 @@
 		"structureModel": [
 			"BLGUARD1.pie"
 		],
-		"thermal": 18,
+		"thermal": 15,
 		"type": "DEFENSE",
 		"weapons": [
 			"AAGun2Mk1"
@@ -2997,13 +2997,13 @@
 		"width": 1
 	},
 	"WallTower-DoubleAAGun02": {
-		"armour": 18,
+		"armour": 15,
 		"breadth": 1,
-		"buildPoints": 550,
-		"buildPower": 325,
+		"buildPoints": 450,
+		"buildPower": 300,
 		"combinesWithWall": true,
 		"height": 2,
-		"hitpoints": 1400,
+		"hitpoints": 800,
 		"id": "WallTower-DoubleAAGun02",
 		"name": "AA Tornado Flak Cannon Hardpoint",
 		"resistance": 150,
@@ -3012,7 +3012,7 @@
 		"structureModel": [
 			"BLGUARD1.pie"
 		],
-		"thermal": 18,
+		"thermal": 15,
 		"type": "DEFENSE",
 		"weapons": [
 			"AAGun2Mk1Quad"
@@ -3020,13 +3020,13 @@
 		"width": 1
 	},
 	"WallTower-EMP": {
-		"armour": 18,
+		"armour": 15,
 		"breadth": 1,
-		"buildPoints": 500,
-		"buildPower": 300,
+		"buildPoints": 400,
+		"buildPower": 350,
 		"combinesWithWall": true,
 		"height": 2,
-		"hitpoints": 1400,
+		"hitpoints": 800,
 		"id": "WallTower-EMP",
 		"name": "EMP Cannon Hardpoint",
 		"resistance": 150,
@@ -3035,7 +3035,7 @@
 		"structureModel": [
 			"BLGUARD1.pie"
 		],
-		"thermal": 18,
+		"thermal": 15,
 		"type": "DEFENSE",
 		"weapons": [
 			"EMP-Cannon"
@@ -3043,13 +3043,13 @@
 		"width": 1
 	},
 	"WallTower-HPVcannon": {
-		"armour": 18,
+		"armour": 15,
 		"breadth": 1,
-		"buildPoints": 500,
-		"buildPower": 275,
+		"buildPoints": 400,
+		"buildPower": 225,
 		"combinesWithWall": true,
 		"height": 2,
-		"hitpoints": 1400,
+		"hitpoints": 800,
 		"id": "WallTower-HPVcannon",
 		"name": "Hyper Velocity Cannon Hardpoint",
 		"resistance": 150,
@@ -3058,7 +3058,7 @@
 		"structureModel": [
 			"BLGUARD1.pie"
 		],
-		"thermal": 18,
+		"thermal": 15,
 		"type": "DEFENSE",
 		"weapons": [
 			"Cannon4AUTOMk1"
@@ -3066,13 +3066,13 @@
 		"width": 1
 	},
 	"WallTower-HvATrocket": {
-		"armour": 18,
+		"armour": 15,
 		"breadth": 1,
-		"buildPoints": 500,
-		"buildPower": 300,
+		"buildPoints": 400,
+		"buildPower": 275,
 		"combinesWithWall": true,
 		"height": 2,
-		"hitpoints": 1400,
+		"hitpoints": 800,
 		"id": "WallTower-HvATrocket",
 		"name": "Tank Killer Hardpoint",
 		"resistance": 150,
@@ -3081,7 +3081,7 @@
 		"structureModel": [
 			"BLGUARD1.pie"
 		],
-		"thermal": 18,
+		"thermal": 15,
 		"type": "DEFENSE",
 		"weapons": [
 			"Rocket-HvyA-T"
@@ -3089,21 +3089,21 @@
 		"width": 1
 	},
 	"WallTower-Projector": {
-		"armour": 10,
+		"armour": 15,
 		"breadth": 1,
-		"buildPoints": 200,
-		"buildPower": 110,
+		"buildPoints": 400,
+		"buildPower": 150,
 		"height": 1,
-		"hitpoints": 700,
+		"hitpoints": 800,
 		"id": "WallTower-Projector",
 		"name": "Inferno Hardpoint",
 		"resistance": 150,
 		"sensorID": "DefaultSensor1Mk1",
-		"strength": "MEDIUM",
+		"strength": "HARD",
 		"structureModel": [
 			"BLHARDPT.PIE"
 		],
-		"thermal": 10,
+		"thermal": 15,
 		"type": "DEFENSE",
 		"weapons": [
 			"Flame2"
@@ -3111,13 +3111,13 @@
 		"width": 1
 	},
 	"WallTower-PulseLas": {
-		"armour": 18,
+		"armour": 15,
 		"breadth": 1,
-		"buildPoints": 500,
+		"buildPoints": 400,
 		"buildPower": 275,
 		"combinesWithWall": true,
 		"height": 2,
-		"hitpoints": 1400,
+		"hitpoints": 800,
 		"id": "WallTower-PulseLas",
 		"name": "Pulse Laser Hardpoint",
 		"resistance": 150,
@@ -3126,7 +3126,7 @@
 		"structureModel": [
 			"BLGUARD1.pie"
 		],
-		"thermal": 18,
+		"thermal": 15,
 		"type": "DEFENSE",
 		"weapons": [
 			"Laser2PULSEMk1"
@@ -3134,13 +3134,13 @@
 		"width": 1
 	},
 	"WallTower-QuadRotAAGun": {
-		"armour": 18,
+		"armour": 15,
 		"breadth": 1,
-		"buildPoints": 525,
-		"buildPower": 275,
+		"buildPoints": 375,
+		"buildPower": 250,
 		"combinesWithWall": true,
 		"height": 2,
-		"hitpoints": 1400,
+		"hitpoints": 800,
 		"id": "WallTower-QuadRotAAGun",
 		"name": "Whirlwind Hardpoint",
 		"resistance": 150,
@@ -3149,7 +3149,7 @@
 		"structureModel": [
 			"BLGUARD1.pie"
 		],
-		"thermal": 18,
+		"thermal": 15,
 		"type": "DEFENSE",
 		"weapons": [
 			"QuadRotAAGun"
@@ -3157,13 +3157,13 @@
 		"width": 1
 	},
 	"WallTower-Rail2": {
-		"armour": 18,
+		"armour": 15,
 		"breadth": 1,
-		"buildPoints": 500,
+		"buildPoints": 400,
 		"buildPower": 350,
 		"combinesWithWall": true,
 		"height": 2,
-		"hitpoints": 1400,
+		"hitpoints": 800,
 		"id": "WallTower-Rail2",
 		"name": "Rail Gun Hardpoint",
 		"resistance": 150,
@@ -3172,7 +3172,7 @@
 		"structureModel": [
 			"BLGUARD1.pie"
 		],
-		"thermal": 18,
+		"thermal": 15,
 		"type": "DEFENSE",
 		"weapons": [
 			"RailGun2Mk1"
@@ -3180,13 +3180,13 @@
 		"width": 1
 	},
 	"WallTower-Rail3": {
-		"armour": 18,
+		"armour": 15,
 		"breadth": 1,
-		"buildPoints": 500,
-		"buildPower": 375,
+		"buildPoints": 400,
+		"buildPower": 400,
 		"combinesWithWall": true,
 		"height": 2,
-		"hitpoints": 1400,
+		"hitpoints": 800,
 		"id": "WallTower-Rail3",
 		"name": "Gauss Cannon Hardpoint",
 		"resistance": 150,
@@ -3195,7 +3195,7 @@
 		"structureModel": [
 			"BLGUARD1.pie"
 		],
-		"thermal": 18,
+		"thermal": 15,
 		"type": "DEFENSE",
 		"weapons": [
 			"RailGun3Mk1"
@@ -3203,13 +3203,13 @@
 		"width": 1
 	},
 	"WallTower-SamHvy": {
-		"armour": 18,
+		"armour": 15,
 		"breadth": 1,
 		"buildPoints": 550,
 		"buildPower": 375,
 		"combinesWithWall": true,
 		"height": 2,
-		"hitpoints": 1400,
+		"hitpoints": 800,
 		"id": "WallTower-SamHvy",
 		"name": "Vindicator Hardpoint",
 		"resistance": 150,
@@ -3218,7 +3218,7 @@
 		"structureModel": [
 			"BLGUARD1.pie"
 		],
-		"thermal": 18,
+		"thermal": 15,
 		"type": "DEFENSE",
 		"weapons": [
 			"Missile-HvySAM"
@@ -3226,13 +3226,13 @@
 		"width": 1
 	},
 	"WallTower-SamSite": {
-		"armour": 18,
+		"armour": 15,
 		"breadth": 1,
-		"buildPoints": 550,
-		"buildPower": 325,
+		"buildPoints": 450,
+		"buildPower": 300,
 		"combinesWithWall": true,
 		"height": 2,
-		"hitpoints": 1400,
+		"hitpoints": 800,
 		"id": "WallTower-SamSite",
 		"name": "Avenger Hardpoint",
 		"resistance": 150,
@@ -3241,7 +3241,7 @@
 		"structureModel": [
 			"BLGUARD1.pie"
 		],
-		"thermal": 18,
+		"thermal": 15,
 		"type": "DEFENSE",
 		"weapons": [
 			"Missile-LtSAM"
@@ -3249,13 +3249,13 @@
 		"width": 1
 	},
 	"WallTower-TwinAssaultGun": {
-		"armour": 18,
+		"armour": 15,
 		"breadth": 1,
-		"buildPoints": 500,
+		"buildPoints": 400,
 		"buildPower": 250,
 		"combinesWithWall": true,
 		"height": 2,
-		"hitpoints": 1400,
+		"hitpoints": 800,
 		"id": "WallTower-TwinAssaultGun",
 		"name": "Twin Assault Gun Hardpoint",
 		"resistance": 150,
@@ -3264,7 +3264,7 @@
 		"structureModel": [
 			"BLGUARD1.pie"
 		],
-		"thermal": 18,
+		"thermal": 15,
 		"type": "DEFENSE",
 		"weapons": [
 			"MG5TWINROTARY"
@@ -3272,13 +3272,13 @@
 		"width": 1
 	},
 	"WallTower01": {
-		"armour": 18,
+		"armour": 15,
 		"breadth": 1,
-		"buildPoints": 500,
-		"buildPower": 200,
+		"buildPoints": 400,
+		"buildPower": 100,
 		"combinesWithWall": true,
 		"height": 2,
-		"hitpoints": 1400,
+		"hitpoints": 800,
 		"id": "WallTower01",
 		"name": "Heavy Machinegun Hardpoint",
 		"resistance": 150,
@@ -3287,7 +3287,7 @@
 		"structureModel": [
 			"BLGUARD1.pie"
 		],
-		"thermal": 18,
+		"thermal": 15,
 		"type": "DEFENSE",
 		"weapons": [
 			"MG3Mk1"
@@ -3295,13 +3295,13 @@
 		"width": 1
 	},
 	"WallTower02": {
-		"armour": 18,
+		"armour": 15,
 		"breadth": 1,
-		"buildPoints": 500,
-		"buildPower": 200,
+		"buildPoints": 400,
+		"buildPower": 125,
 		"combinesWithWall": true,
 		"height": 2,
-		"hitpoints": 1400,
+		"hitpoints": 800,
 		"id": "WallTower02",
 		"name": "Light Cannon Hardpoint",
 		"resistance": 150,
@@ -3310,7 +3310,7 @@
 		"structureModel": [
 			"BLGUARD1.pie"
 		],
-		"thermal": 18,
+		"thermal": 15,
 		"type": "DEFENSE",
 		"weapons": [
 			"Cannon1Mk1"
@@ -3318,13 +3318,13 @@
 		"width": 1
 	},
 	"WallTower03": {
-		"armour": 18,
+		"armour": 15,
 		"breadth": 1,
-		"buildPoints": 500,
-		"buildPower": 225,
+		"buildPoints": 400,
+		"buildPower": 200,
 		"combinesWithWall": true,
 		"height": 2,
-		"hitpoints": 1400,
+		"hitpoints": 800,
 		"id": "WallTower03",
 		"name": "Medium Cannon Hardpoint",
 		"resistance": 150,
@@ -3333,7 +3333,7 @@
 		"structureModel": [
 			"BLGUARD1.pie"
 		],
-		"thermal": 18,
+		"thermal": 15,
 		"type": "DEFENSE",
 		"weapons": [
 			"Cannon2A-TMk1"
@@ -3341,13 +3341,13 @@
 		"width": 1
 	},
 	"WallTower04": {
-		"armour": 18,
+		"armour": 15,
 		"breadth": 1,
-		"buildPoints": 500,
+		"buildPoints": 400,
 		"buildPower": 250,
 		"combinesWithWall": true,
 		"height": 2,
-		"hitpoints": 1400,
+		"hitpoints": 800,
 		"id": "WallTower04",
 		"name": "Heavy Cannon Hardpoint",
 		"resistance": 150,
@@ -3356,7 +3356,7 @@
 		"structureModel": [
 			"BLGUARD1.pie"
 		],
-		"thermal": 18,
+		"thermal": 15,
 		"type": "DEFENSE",
 		"weapons": [
 			"Cannon375mmMk1"
@@ -3364,13 +3364,13 @@
 		"width": 1
 	},
 	"WallTower05": {
-		"armour": 18,
+		"armour": 15,
 		"breadth": 1,
-		"buildPoints": 500,
-		"buildPower": 200,
+		"buildPoints": 400,
+		"buildPower": 100,
 		"combinesWithWall": true,
 		"height": 2,
-		"hitpoints": 1400,
+		"hitpoints": 800,
 		"id": "WallTower05",
 		"name": "Flamer Hardpoint",
 		"resistance": 150,
@@ -3379,7 +3379,7 @@
 		"structureModel": [
 			"BLGUARD1.pie"
 		],
-		"thermal": 18,
+		"thermal": 15,
 		"type": "DEFENSE",
 		"weapons": [
 			"Flame1Mk1"
@@ -3387,13 +3387,13 @@
 		"width": 1
 	},
 	"WallTower06": {
-		"armour": 18,
+		"armour": 15,
 		"breadth": 1,
-		"buildPoints": 500,
-		"buildPower": 225,
+		"buildPoints": 400,
+		"buildPower": 175,
 		"combinesWithWall": true,
 		"height": 2,
-		"hitpoints": 1400,
+		"hitpoints": 800,
 		"id": "WallTower06",
 		"name": "Lancer Hardpoint",
 		"resistance": 150,
@@ -3402,7 +3402,7 @@
 		"structureModel": [
 			"BLGUARD1.pie"
 		],
-		"thermal": 18,
+		"thermal": 15,
 		"type": "DEFENSE",
 		"weapons": [
 			"Rocket-LtA-T"
@@ -3427,7 +3427,7 @@
 		"width": 3
 	},
 	"X-Super-Cannon": {
-		"armour": 18,
+		"armour": 15,
 		"breadth": 2,
 		"buildPoints": 2000,
 		"buildPower": 1000,
@@ -3442,7 +3442,7 @@
 		"structureModel": [
 			"STWPFCAN.PIE"
 		],
-		"thermal": 18,
+		"thermal": 15,
 		"type": "FORTRESS",
 		"weapons": [
 			"CannonSuper"
@@ -3450,10 +3450,10 @@
 		"width": 2
 	},
 	"X-Super-MassDriver": {
-		"armour": 18,
+		"armour": 15,
 		"breadth": 2,
 		"buildPoints": 2000,
-		"buildPower": 1600,
+		"buildPower": 1800,
 		"combinesWithWall": true,
 		"height": 3,
 		"hitpoints": 3200,
@@ -3465,7 +3465,7 @@
 		"structureModel": [
 			"STWPFCAN.PIE"
 		],
-		"thermal": 18,
+		"thermal": 15,
 		"type": "FORTRESS",
 		"weapons": [
 			"MassDriver"
@@ -3473,10 +3473,10 @@
 		"width": 2
 	},
 	"X-Super-Missile": {
-		"armour": 18,
+		"armour": 15,
 		"breadth": 2,
 		"buildPoints": 2000,
-		"buildPower": 1800,
+		"buildPower": 1600,
 		"combinesWithWall": true,
 		"height": 3,
 		"hitpoints": 3200,
@@ -3488,7 +3488,7 @@
 		"structureModel": [
 			"STWPFCAN.PIE"
 		],
-		"thermal": 18,
+		"thermal": 15,
 		"type": "FORTRESS",
 		"weapons": [
 			"MissileSuper"
@@ -3496,7 +3496,7 @@
 		"width": 2
 	},
 	"X-Super-Rocket": {
-		"armour": 18,
+		"armour": 15,
 		"breadth": 2,
 		"buildPoints": 2000,
 		"buildPower": 1250,
@@ -3511,7 +3511,7 @@
 		"structureModel": [
 			"STWPFCAN.PIE"
 		],
-		"thermal": 18,
+		"thermal": 15,
 		"type": "FORTRESS",
 		"weapons": [
 			"RocketSuper"

--- a/data/mp/stats/structuremodifier.json
+++ b/data/mp/stats/structuremodifier.json
@@ -1,27 +1,27 @@
 {
 	"ALL ROUNDER": {
-		"BUNKER": 65,
+		"BUNKER": 75,
 		"HARD": 100,
 		"MEDIUM": 100,
-		"SOFT": 110
+		"SOFT": 130
 	},
 	"ANTI PERSONNEL": {
-		"BUNKER": 55,
+		"BUNKER": 50,
 		"HARD": 40,
 		"MEDIUM": 65,
-		"SOFT": 75
+		"SOFT": 160
 	},
 	"ANTI TANK": {
-		"BUNKER": 20,
+		"BUNKER": 60,
 		"HARD": 25,
 		"MEDIUM": 50,
-		"SOFT": 60
+		"SOFT": 75
 	},
 	"ARTILLERY ROUND": {
 		"BUNKER": 20,
 		"HARD": 100,
 		"MEDIUM": 120,
-		"SOFT": 130
+		"SOFT": 200
 	},
 	"BUNKER BUSTER": {
 		"BUNKER": 400,
@@ -33,6 +33,6 @@
 		"BUNKER": 300,
 		"HARD": 10,
 		"MEDIUM": 60,
-		"SOFT": 70
+		"SOFT": 150
 	}
 }

--- a/src/combat.cpp
+++ b/src/combat.cpp
@@ -442,6 +442,10 @@ int32_t objDamage(BASE_OBJECT *psObj, unsigned damage, unsigned originalhp, WEAP
 		// Retrieve highest, applicable, experience level
 		level = getDroidEffectiveLevel(psDroid);
 	}
+	else if (psObj->type == OBJ_STRUCTURE)
+	{
+		level = getStructureDamageBaseExperienceLevel();
+	}
 
 	// Reduce damage taken by EXP_REDUCE_DAMAGE % for each experience level
 	int actualDamage = (damage * (100 - EXP_REDUCE_DAMAGE * level)) / 100;
@@ -518,6 +522,10 @@ unsigned int objGuessFutureDamage(WEAPON_STATS *psStats, unsigned int player, BA
 
 		// Retrieve highest, applicable, experience level
 		level = getDroidEffectiveLevel(psDroid);
+	}
+	else if (psTarget->type == OBJ_STRUCTURE)
+	{
+		level = getStructureDamageBaseExperienceLevel();
 	}
 	//debug(LOG_ATTACK, "objGuessFutureDamage(%d): body %d armour %d damage: %d", psObj->id, psObj->body, armour, damage);
 

--- a/src/structure.h
+++ b/src/structure.h
@@ -84,6 +84,8 @@ bool structureExists(int player, STRUCTURE_TYPE type, bool built, bool isMission
 
 bool IsPlayerDroidLimitReached(int player);
 
+int getStructureDamageBaseExperienceLevel();
+
 bool loadStructureStats(WzConfig &ini);
 /*Load the Structure Strength Modifiers from the file exported from Access*/
 bool loadStructureStrengthModifiers(WzConfig &ini);


### PR DESCRIPTION
Basically, this makes #3361 configurable from the `structure.json` file.

The default `"baseStructDamageExpLevel"` is `1`, and functions as all versions of WZ from 2.0.10-4.4.2 have. With this configuration, structures get the benefit of a hidden experience level damage reduction. (i.e. They get treated as experience level 1, not 0, and the initial calculation before armor is 94% of the base damage value, not 100%.)

To opt-in to explicitly specifying a base experience level for structure damage calculations, add a new `"_config_"` dict to the top-level structure.json object, specifying the desired `"baseStructDamageExpLevel"`.

Example:
```json
{
  "_config_": {
    "baseStructDamageExpLevel": 0
  },
  ...
}
```
Would eliminate this default hidden experience level damage reduction for structures.

As it's now possible to configure this from the `structure.json`, we can now revert the "Structure Update for MP" commit for the 4.5.0 release and just use the prior values *with* the prior behavior. (Until such time as people find a combination of changes they like.)