### PR TITLE
Plasmite Flamer HP, Weight, Range Balance

### DIFF
--- a/data/mp/stats/weapons.json
+++ b/data/mp/stats/weapons.json
@@ -3559,10 +3559,10 @@
 		"flightGfx": "FXLProj.PIE",
 		"flightSpeed": 700,
 		"hitGfx": "FXMETHIT.PIE",
-		"hitpoints": 375,
+		"hitpoints": 205,
 		"id": "PlasmiteFlamer",
 		"lightWorld": 1,
-		"longRange": 512,
+		"longRange": 896,
 		"longHit": 50,
 		"maxElevation": 90,
 		"minElevation": -60,
@@ -3581,13 +3581,13 @@
 		"periodicalDamageTime": 50,
 		"rotate": 180,
 		"shortHit": 75,
-		"shortRange": 384,
+		"shortRange": 768,
 		"waterGfx": "FXMETHIT.PIE",
 		"weaponClass": "HEAT",
 		"weaponEffect": "FLAMER",
 		"weaponSubClass": "FLAME",
 		"weaponWav": "plasflm.ogg",
-		"weight": 1000
+		"weight": 5000
 	},
 	"QuadMg1AAGun": {
 		"buildPoints": 400,


### PR DESCRIPTION
## Hitpoints
Inferno is `4.5x` the HP of Flamer, so I made Plasmite Flamer `4.5x` the HP of Inferno. This is comparable to Light Cannon and HVC, which have `250` HP.
- Flamer HP = `10`
- Inferno HP = `45`
- Plasmite Flamer HP = `125` → `205`

## Weight
I made Plasmite Flamer the same weight as Inferno.
- Flamer weight = `250`
- Inferno weight = `5000`
- Plasmite Flamer weight = `1000` → `5000`

## Range
I gave Plasmite Flamer 2 tiles more range than Inferno. This is comparable to Assault Cannon.
- Flamer range = `256–384` (2–3 tiles)
- Inferno range = `512–640` (4–5 tiles)
- Plasmite Flamer range = `384–512` → `768–896` (6–7 tiles)