### PR TITLE
missionResetDroids: Update visibility

### DIFF
--- a/src/mission.cpp
+++ b/src/mission.cpp
@@ -1567,6 +1567,14 @@ static void missionResetDroids()
 			{
 				vanishDroid(d);
 			}
+			else
+			{
+				if (d->pos.x != INVALID_XY && d->pos.y != INVALID_XY)
+				{
+					// update visibility
+					visTilesUpdate(d);
+				}
+			}
 			return IterationResult::CONTINUE_ITERATION;
 		});
 	}
@@ -1663,6 +1671,9 @@ static void missionResetDroids()
 				}
 				// Reset the selected flag
 				psDroid->selected = false;
+
+				// update visibility
+				visTilesUpdate(psDroid);
 			}
 			else
 			{


### PR DESCRIPTION
Fixes an issue that could occur when:
- Freshly loading an offworld mission save
- Then returning to the base map

In which droid visibility on the base map for pre-existing home base droids might not be updated until they are selected and moved.