### PR TITLE
Use different designs for Sensor/Commander guide units

### DIFF
--- a/data/base/guidetopics/wz2100/units/commanders/_index.json
+++ b/data/base/guidetopics/wz2100/units/commanders/_index.json
@@ -5,9 +5,9 @@
 	"sort": "07",
 	"visual": {
 		"droidTemplate": {
-			"body": "Body11ABT",
+			"body": "Body8MBT",
 			"brain": "CommandBrain01",
-			"name": "Command Turret Python Half-tracks",
+			"name": "Command Turret Scorpion Half-tracks",
 			"propulsion": "HalfTrack",
 			"type": "DROID_COMMAND",
 			"weapons": [

--- a/data/base/guidetopics/wz2100/units/commanders/attaching.json
+++ b/data/base/guidetopics/wz2100/units/commanders/attaching.json
@@ -5,9 +5,9 @@
 	"sort": "01",
 	"visual": {
 		"droidTemplate": {
-			"body": "Body11ABT",
+			"body": "Body8MBT",
 			"brain": "CommandBrain01",
-			"name": "Command Turret Python Half-tracks",
+			"name": "Command Turret Scorpion Half-tracks",
 			"propulsion": "HalfTrack",
 			"type": "DROID_COMMAND",
 			"weapons": [

--- a/data/base/guidetopics/wz2100/units/commanders/detaching.json
+++ b/data/base/guidetopics/wz2100/units/commanders/detaching.json
@@ -5,9 +5,9 @@
 	"sort": "02",
 	"visual": {
 		"droidTemplate": {
-			"body": "Body11ABT",
+			"body": "Body8MBT",
 			"brain": "CommandBrain01",
-			"name": "Command Turret Python Half-tracks",
+			"name": "Command Turret Scorpion Half-tracks",
 			"propulsion": "HalfTrack",
 			"type": "DROID_COMMAND",
 			"weapons": [

--- a/data/base/guidetopics/wz2100/units/commanders/repairs.json
+++ b/data/base/guidetopics/wz2100/units/commanders/repairs.json
@@ -5,9 +5,9 @@
 	"sort": "04",
 	"visual": {
 		"droidTemplate": {
-			"body": "Body11ABT",
+			"body": "Body8MBT",
 			"brain": "CommandBrain01",
-			"name": "Command Turret Python Half-tracks",
+			"name": "Command Turret Scorpion Half-tracks",
 			"propulsion": "HalfTrack",
 			"type": "DROID_COMMAND",
 			"weapons": [

--- a/data/base/guidetopics/wz2100/units/commanders/targeting.json
+++ b/data/base/guidetopics/wz2100/units/commanders/targeting.json
@@ -5,9 +5,9 @@
 	"sort": "03",
 	"visual": {
 		"droidTemplate": {
-			"body": "Body11ABT",
+			"body": "Body8MBT",
 			"brain": "CommandBrain01",
-			"name": "Command Turret Python Half-tracks",
+			"name": "Command Turret Scorpion Half-tracks",
 			"propulsion": "HalfTrack",
 			"type": "DROID_COMMAND",
 			"weapons": [

--- a/data/base/guidetopics/wz2100/units/sensors/_index.json
+++ b/data/base/guidetopics/wz2100/units/sensors/_index.json
@@ -6,9 +6,9 @@
 	"visual": [
 		{
 			"droidTemplate": {
-				"body": "Body11ABT",
-				"name": "Sensor Turret Python Half-tracks",
-				"propulsion": "HalfTrack",
+				"body": "Body1REC",
+				"name": "Sensor Turret Viper Wheels",
+				"propulsion": "wheeled01",
 				"type": "SENSOR",
 				"sensor": "SensorTurret1Mk1"
 			}

--- a/data/base/guidetopics/wz2100/units/sensors/unassigning.json
+++ b/data/base/guidetopics/wz2100/units/sensors/unassigning.json
@@ -6,9 +6,9 @@
 	"visual": [
 		{
 			"droidTemplate": {
-				"body": "Body11ABT",
-				"name": "Sensor Turret Python Half-tracks",
-				"propulsion": "HalfTrack",
+				"body": "Body1REC",
+				"name": "Sensor Turret Viper Wheels",
+				"propulsion": "wheeled01",
 				"type": "SENSOR",
 				"sensor": "SensorTurret1Mk1"
 			}

--- a/data/base/guidetopics/wz2100/units/sensors/using.json
+++ b/data/base/guidetopics/wz2100/units/sensors/using.json
@@ -6,9 +6,9 @@
 	"visual": [
 		{
 			"droidTemplate": {
-				"body": "Body11ABT",
-				"name": "Sensor Turret Python Half-tracks",
-				"propulsion": "HalfTrack",
+				"body": "Body1REC",
+				"name": "Sensor Turret Viper Wheels",
+				"propulsion": "wheeled01",
 				"type": "SENSOR",
 				"sensor": "SensorTurret1Mk1"
 			}


### PR DESCRIPTION
To prevent spoiling the Python body in Alpha campaign.