### PR TITLE
Exclude retreating droids from formation speed limiting

### DIFF
--- a/src/droid.cpp
+++ b/src/droid.cpp
@@ -2900,6 +2900,18 @@ bool DROID::isFlying() const
 		   && (sMove.Status != MOVEINACTIVE || isTransporter());
 }
 
+// true if a droid is retreating for repair
+bool DROID::isRetreatingForRepair() const
+{
+	return order.type == DORDER_RTR || order.type == DORDER_RTR_SPECIFIED;
+}
+
+// true if a droid is returning to base
+bool DROID::isReturningToBase() const
+{
+	return order.type == DORDER_RTB;
+}
+
 /* returns true if it's a VTOL weapon droid which has completed all runs */
 bool vtolEmpty(const DROID *psDroid)
 {

--- a/src/droiddef.h
+++ b/src/droiddef.h
@@ -120,6 +120,10 @@ struct DROID : public BASE_OBJECT
 	bool isAttacking() const;
 	// true if a vtol droid currently returning to be rearmed
 	bool isVtolRearming() const;
+	// true if a droid is retreating for repair
+	bool isRetreatingForRepair() const;
+	// true if a droid is returning to base
+	bool isReturningToBase() const;
 
 	// Helper functions to get various droid stats.
 	BODY_STATS* getBodyStats() const;

--- a/src/move.cpp
+++ b/src/move.cpp
@@ -1505,8 +1505,9 @@ SDWORD moveCalcDroidSpeed(DROID *psDroid)
 	}
 
 	/* adjust speed for formation */
-	if(!psDroid->isVtol() &&
-		moveFormationSpeedLimitingOn(psDroid->player) && psDroid->sMove.psFormation)
+	if(!psDroid->isVtol()
+		&& moveFormationSpeedLimitingOn(psDroid->player) && psDroid->sMove.psFormation
+		&& !psDroid->isRetreatingForRepair() && !psDroid->isReturningToBase())
 	{
 		SDWORD FrmSpeed = (SDWORD)psDroid->sMove.psFormation->iSpeed;
 


### PR DESCRIPTION
A nice little QoL improvement for formation speed limiting, so that retreating droids just go at their max speed to their destination (either a repair structure / droid or base) when formation speed limiting is enabled.