### PR TITLE
(MP)Buff for defensive structures. Step 1

### DIFF
--- a/data/mp/stats/structuremodifier.json
+++ b/data/mp/stats/structuremodifier.json
@@ -1,7 +1,7 @@
 {
 	"ALL ROUNDER": {
-		"BUNKER": 70,
-		"HARD": 75,
+		"BUNKER": 75,
+		"HARD": 80,
 		"MEDIUM": 100,
 		"SOFT": 130
 	},

--- a/data/mp/stats/structuremodifier.json
+++ b/data/mp/stats/structuremodifier.json
@@ -1,7 +1,7 @@
 {
 	"ALL ROUNDER": {
-		"BUNKER": 75,
-		"HARD": 100,
+		"BUNKER": 70,
+		"HARD": 75,
 		"MEDIUM": 100,
 		"SOFT": 130
 	},


### PR DESCRIPTION
Currently, in my opinion, “HARD” type structures (hardpoints and Hardened Towers) are much inferior to bunkers and there are two reasons for this:
1. Units with any non-artillery turrets cannot fire while behind hardpoints or Hardened Towers (while behind bunkers, they can)
2. All weapons with the damage type "ALL ROUNDER" have a value of 100 against structures of the "HARD" type (the same value has the type "ARTILLERY ROUND")
Below, for clarity, I will post a complete list of damage types so that you can understand what I’m getting at.
In fact, units with turrets from the Cannons branch at the T2 stage simply sweep away any defense that they encounter on their way, so I think it is necessary to reduce the damage to “HARD” from 100 to 80. Even with such a small nerf, “ALL ROUNDER” will still be better than "ANTI PERSONNEL" and "ANTI TANK"
```
"ALL ROUNDER": {
		"BUNKER": 75,
		"HARD": 100 -> 80
		"MEDIUM": 100,
		"SOFT": 130
	},
"ANTI PERSONNEL": {
		"BUNKER": 50,
		"HARD": 40,
		"MEDIUM": 65,
		"SOFT": 160
	},
"ANTI TANK": {
		"BUNKER": 60,
		"HARD": 25,
		"MEDIUM": 50,
		"SOFT": 75
	},
"ARTILLERY ROUND": {
		"BUNKER": 20,
		"HARD": 100,
		"MEDIUM": 120,
		"SOFT": 200
	},
"BUNKER BUSTER": {
		"BUNKER": 400,
		"HARD": 300,
		"MEDIUM": 120,
		"SOFT": 100
	},
"FLAMER": {
		"BUNKER": 300,
		"HARD": 10,
		"MEDIUM": 60,
		"SOFT": 150
```
As a result, reducing the "ALL ROUNDER" damage type against "HARD" type structures will be the first step towards buffing defensive structures.