### PR TITLE
Prevent artillery units under firesupport trying to ram targets

### DIFF
--- a/src/action.cpp
+++ b/src/action.cpp
@@ -1143,6 +1143,14 @@ void actionUpdateDroid(DROID *psDroid)
 					else if (!psWeapStats->rotate ||
 					         actionTargetTurret(psDroid, psActionTarget, &psDroid->asWeaps[i]))
 					{
+						// Prevents artillery units attached to a leader sometimes not stopping.
+						if (!psDroid->isVtol() &&
+							!proj_Direct(psWeapStats) &&
+							psDroid->order.type == DORDER_FIRESUPPORT &&
+							!DROID_STOPPED(psDroid))
+						{
+							moveStopDroid(psDroid);
+						}
 						/* In range - fire !!! */
 						combFire(&psDroid->asWeaps[i], psDroid, psActionTarget, i);
 					}


### PR DESCRIPTION
Artillery weapons that can rotate and fire on move, like the campaign MRA, can sometimes not stop moving towards their target. There doesn't seem to be anything in a `DACTION_ATTACK` loop these units, with these specific parameters on artillery, can do to stop this. So I added a check here to stop them if they can fire.

This may or may not seriously break something with artillery units attached to sensors/commanders. So far this micro-AI change seems good without any issue.

Here is an example of this bug this will stop:
https://github.com/Warzone2100/warzone2100/assets/22485442/6e8eae55-f33f-4e36-91b0-15b190de01ad

