### PR TITLE
Fix: Transporter dangling psActionTarget references

### DIFF
--- a/src/clparse.cpp
+++ b/src/clparse.cpp
@@ -501,10 +501,6 @@ bool ParseCommandLineDebugFlags(int argc, const char * const *argv)
 	poptContext poptCon = poptGetContext(nullptr, argc, argv, debugOptionsTable, 0);
 	int iOption;
 
-#if defined(WZ_OS_MAC) && defined(DEBUG)
-	debug_enable_switch("all");
-#endif /* WZ_OS_MAC && DEBUG */
-
 	/* loop through command line */
 	while ((iOption = poptGetNextOpt(poptCon)) > 0 || iOption == POPT_ERROR_BADOPT)
 	{
@@ -597,10 +593,6 @@ ParseCLIEarlyResult ParseCommandLineEarly(int argc, const char * const *argv)
 {
 	poptContext poptCon = poptGetContext(nullptr, argc, argv, getOptionsTable(), 0);
 	int iOption;
-
-#if defined(WZ_OS_MAC) && defined(DEBUG)
-	debug_enable_switch("all");
-#endif /* WZ_OS_MAC && DEBUG */
 
 	/* loop through command line */
 	while ((iOption = poptGetNextOpt(poptCon)) > 0 || iOption == POPT_ERROR_BADOPT)

--- a/src/droid.cpp
+++ b/src/droid.cpp
@@ -842,7 +842,10 @@ void droidUpdate(DROID *psDroid)
 	aiUpdateDroid(psDroid);
 
 	// Update the droids order.
-	orderUpdateDroid(psDroid);
+	if (!orderUpdateDroid(psDroid))
+	{
+		return; // skip further processing - droid was moved to a different list!
+	}
 
 	// update the action of the droid
 	actionUpdateDroid(psDroid);

--- a/src/mission.cpp
+++ b/src/mission.cpp
@@ -1530,7 +1530,10 @@ void missionDroidUpdate(DROID *psDroid)
 	// NO ai update droid
 
 	// update the droids order
-	orderUpdateDroid(psDroid);
+	if (!orderUpdateDroid(psDroid))
+	{
+		ASSERT(false, "orderUpdateDroid returned false?");
+	}
 
 	// update the action of the droid
 	actionUpdateDroid(psDroid);

--- a/src/order.cpp
+++ b/src/order.cpp
@@ -409,8 +409,9 @@ static bool tryDoRepairlikeAction(DROID *psDroid)
 }
 
 /** This function updates all the orders status, according with psdroid's current order and state.
+ * Returns false if all further droid processing should be shortcut for this frame (because, for example, the droid is a transporter that was moved to the off-world list)
  */
-void orderUpdateDroid(DROID *psDroid)
+bool orderUpdateDroid(DROID *psDroid)
 {
 	BASE_OBJECT		*psObj = nullptr;
 	STRUCTURE		*psStruct, *psWall;
@@ -420,7 +421,7 @@ void orderUpdateDroid(DROID *psDroid)
 
 	if (psDroid == nullptr || isDead(psDroid))
 	{
-		return;
+		return true;
 	}
 
 	const WEAPON_STATS *psWeapStats = psDroid->getWeaponStats(0);
@@ -481,6 +482,8 @@ void orderUpdateDroid(DROID *psDroid)
 
 			/* clear order */
 			psDroid->order = DroidOrder(DORDER_NONE);
+
+			return false; // signal to caller to skip further processing this frame - droid was moved to a different list!
 		}
 		break;
 	case DORDER_TRANSPORTOUT:
@@ -1250,6 +1253,8 @@ void orderUpdateDroid(DROID *psDroid)
 		        psDroid->order.type, getDroidOrderName(psDroid->order.type), psDroid->action, getDroidActionName(psDroid->action), psDroid->secondaryOrder,
 		        moveDescription(psDroid->sMove.Status));
 	}
+
+	return true;
 }
 
 

--- a/src/order.h
+++ b/src/order.h
@@ -31,7 +31,7 @@
 
 /** Find some droid to repair, starting at (x, y) within some radius, given a player, or return nullptr.
  * Droids having full HP with order = DORDER_RTR or RTR_SPECIFIED will automatically
- * be sent to delivery point, or back to commander 
+ * be sent to delivery point, or back to commander
  */
 
 DROID *findSomeoneToRepair(const STRUCTURE *obj, int radius);
@@ -44,7 +44,7 @@ void orderDroidBase(DROID *psDroid, DROID_ORDER_DATA *psOrder);
 void orderCheckList(DROID *psDroid);
 
 /** \brief Updates a droids order state. */
-void orderUpdateDroid(DROID *psDroid);
+bool orderUpdateDroid(DROID *psDroid);
 
 /** \brief Sends an order to a droid. */
 void orderDroid(DROID *psDroid, DROID_ORDER order, QUEUE_MODE mode);


### PR DESCRIPTION
When a transporter returns to home base (from an active away mission), it is moved offworld by `orderUpdateDroid()`. (Its properties are reset by `missionMoveTransporterOffWorld()` and it is moved to the mission list, with its action set to `DACTION_NONE`.)

The subsequent call to `actionUpdateDroid()` inside `droidUpdate()` could then set the transporter's `psActionTarget` to a remaining enemy structure / unit on the away mission map - despite the fact that it had already been moved "off world".

To fix this, skip further processing of the droid inside `droidUpdate()` when `orderUpdateDroid()` returns false (as an indicator that the droid has been moved from its current list).