### PR TITLE
PortMappingManager: Provide suggested external port to libplum

### DIFF
--- a/lib/netplay/port_mapping_manager.cpp
+++ b/lib/netplay/port_mapping_manager.cpp
@@ -175,6 +175,7 @@ PortMappingAsyncRequestHandle PortMappingManager::create_port_mapping(uint16_t p
 		memset(&m, 0, sizeof(m));
 		m.protocol = PLUM_IP_PROTOCOL_TCP;
 		m.internal_port = port;
+		m.external_port = port; // suggest an external port the same as the internal port (the router may decide otherwise)
 
 		auto mappingId = plum_create_mapping(&m, PlumMappingCallback);
 		if (mappingId < 0)


### PR DESCRIPTION
The router + libplum may still decide on a different external port, but this at least ensures a first attempt is made with the desired port when falling back to UPnP.