### PR TITLE
doc/hosting/linux_scripts/common.sh: support compound commands like "snap run warzone2100"

### DIFF
--- a/doc/hosting/linux_scripts/common.sh
+++ b/doc/hosting/linux_scripts/common.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/bash
 
 function check {
   if [ ! $(command -v netstat) ] && [ ! $(command -v ss) ]; then

--- a/doc/hosting/linux_scripts/common.sh
+++ b/doc/hosting/linux_scripts/common.sh
@@ -5,7 +5,7 @@ function check {
     echo "[ERROR] netstat or ss is required to check for available ports"
     exit 1
   fi
-  if [ ! $(command -v $wz2100cmd) ]; then
+  if [ ! "$(command -v $wz2100cmd)" ]; then
     echo "[ERROR] Cannot execute \"$wz2100cmd\"."
     exit 1
   fi

--- a/doc/hosting/linux_scripts/common.sh
+++ b/doc/hosting/linux_scripts/common.sh
@@ -76,5 +76,5 @@ function run_host {
     configdir="--configdir=$cfgdir"
   fi
   # Run game
-  $wz2100cmd $configdir --autohost=$hostfile --gameport=$port --startplayers=$players --enablelobbyslashcmd $admcmd --headless --nosound
+  exec $wz2100cmd $configdir --autohost=$hostfile --gameport=$port --startplayers=$players --enablelobbyslashcmd $admcmd --headless --nosound
 }

--- a/doc/hosting/linux_scripts/common.sh
+++ b/doc/hosting/linux_scripts/common.sh
@@ -5,8 +5,8 @@ function check {
     echo "[ERROR] netstat or ss is required to check for available ports"
     exit 1
   fi
-  if [ ! "$(command -v $wz2100cmd)" ]; then
-    echo "[ERROR] Cannot execute \"$wz2100cmd\"."
+  if [ ! -v wz2100cmd ]; then
+    echo "[ERROR] wz2100cmd variable is not set."
     exit 1
   fi
   if [ "$players" == "" ] || [ ! $players -gt 0 ]; then

--- a/doc/hosting/linux_scripts/config_sample.sh
+++ b/doc/hosting/linux_scripts/config_sample.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/bash
 
 ## Common configuration values
 ## This file is shared between all games

--- a/doc/hosting/linux_scripts/game_sample.sh
+++ b/doc/hosting/linux_scripts/game_sample.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/bash
 
 ## Game configuration values
 ## One file for each game type

--- a/doc/hosting/linux_scripts/game_sample.sh
+++ b/doc/hosting/linux_scripts/game_sample.sh
@@ -1,7 +1,5 @@
 #!/bin/bash -e
 
-set -e
-
 ## Game configuration values
 ## One file for each game type
 

--- a/doc/hosting/linux_scripts/game_sample.sh
+++ b/doc/hosting/linux_scripts/game_sample.sh
@@ -1,5 +1,7 @@
 #!/bin/bash -e
 
+set -e
+
 ## Game configuration values
 ## One file for each game type
 


### PR DESCRIPTION
We can't use the command bash built-in to check the existence of the program since it may be something like "snap run warzone2100".
If the command isn't valid, we'll get the error at the end of the script anyway.