### PR TITLE
Make "Reset Pitch" keybind consistent with initial starting pitch

### DIFF
--- a/src/keybind.cpp
+++ b/src/keybind.cpp
@@ -1042,7 +1042,7 @@ void	kf_PitchForward()
 /* Resets pitch to default */
 void	kf_ResetPitch()
 {
-	playerPos.r.x = DEG(360 - 20);
+	playerPos.r.x = DEG(360 + INITIAL_STARTING_PITCH);
 	setViewDistance(STARTDISTANCE);
 }
 


### PR DESCRIPTION
By default, the keybind for "Reset Pitch" is `Keypad 5`. The default angle is `320°`, as specified in `display.h` by `INITIAL_STARTING_PITCH`. However, `keybind.cpp` inconsistently sets the pitch to `340°`. You can see this discrepancy in-game: (1) Start a skirmish game, and (2) press `Keypad 5`. The camera pitch lowers.

I modified `keybind.cpp` to use `INITIAL_STARTING_PITCH` instead of `340°`.