### PR TITLE
Improvements to groups and UI

### DIFF
--- a/src/droid.cpp
+++ b/src/droid.cpp
@@ -833,7 +833,8 @@ void droidUpdate(DROID *psDroid)
 	if (psDroid->repairGroup != UBYTE_MAX &&
 		psDroid->order.type != DORDER_RTR &&
 		psDroid->order.type != DORDER_RTR_SPECIFIED &&
-		psDroid->order.type != DORDER_RTB)
+		psDroid->order.type != DORDER_RTB &&
+		secondaryGetState(psDroid, DSO_REPAIR_LEVEL) == DSS_REPLEV_NEVER)
 	{
 		droidWasFullyRepairedBase(psDroid);
 	}

--- a/src/hci/groups.cpp
+++ b/src/hci/groups.cpp
@@ -210,14 +210,14 @@ protected:
 		{
 			displayIMD(AtlasImage(), ImdObject::DroidTemplate(&(groupInfo->displayDroidTemplate)), xOffset, yOffset);
 			groupCountLabel->setString(WzString::fromUtf8(astringf("%u", groupInfo->numberInGroup)));
-			int32_t xOffset = 0;
+			int32_t xNumberOffset = 0;
 			const uint32_t xFitNumberInTheBox = 16;
 			if (groupCountLabel->getMaxLineWidth() > xFitNumberInTheBox)
 			{
-				xOffset -= groupCountLabel->getMaxLineWidth() - xFitNumberInTheBox;
+				xNumberOffset -= groupCountLabel->getMaxLineWidth() - xFitNumberInTheBox;
 			}
 			groupCountLabel->move(
-				OBJ_TEXTX + 40 + xOffset - groupDamagedCountLabel->getMaxLineWidth(),
+				OBJ_TEXTX + 40 + xNumberOffset - groupDamagedCountLabel->getMaxLineWidth(),
 				groupCountLabel->y()
 			);
 		}

--- a/src/hci/groups.cpp
+++ b/src/hci/groups.cpp
@@ -133,7 +133,7 @@ public:
 		groupNumberLabel->setTransparentToMouse(true);
 
 		attach(groupCountLabel = std::make_shared<W_LABEL>());
-		groupCountLabel->setGeometry(OBJ_TEXTX, OBJ_B1TEXTY + 20, 16, 16);
+		groupCountLabel->setGeometry(OBJ_TEXTX + 40, OBJ_B1TEXTY + 20, 16, 16);
 		groupCountLabel->setString("");
 		groupCountLabel->setTransparentToMouse(true);
 

--- a/src/hci/groups.cpp
+++ b/src/hci/groups.cpp
@@ -40,6 +40,7 @@ public:
 	struct GroupDisplayInfo
 	{
 		size_t numberInGroup = 0;
+		size_t numberDamagedInGroup = 0;
 		size_t numberCommandedByGroup = 0; // the number of droids commanded by commanders in this group
 		uint64_t totalGroupMaxHealth = 0;
 		DROID_TEMPLATE displayDroidTemplate;
@@ -108,6 +109,7 @@ private:
 	std::shared_ptr<GroupsUIController> controller;
 	std::shared_ptr<W_LABEL> groupNumberLabel;
 	std::shared_ptr<W_LABEL> groupCountLabel;
+	std::shared_ptr<W_LABEL> groupDamagedCountLabel;
 	size_t groupNumber;
 	uint32_t lastUpdatedGlowAlphaTime = 0;
 protected:
@@ -131,9 +133,15 @@ public:
 		groupNumberLabel->setTransparentToMouse(true);
 
 		attach(groupCountLabel = std::make_shared<W_LABEL>());
-		groupCountLabel->setGeometry(OBJ_TEXTX + 40, OBJ_B1TEXTY + 20, 16, 16);
+		groupCountLabel->setGeometry(OBJ_TEXTX, OBJ_B1TEXTY + 20, 16, 16);
 		groupCountLabel->setString("");
 		groupCountLabel->setTransparentToMouse(true);
+
+		attach(groupDamagedCountLabel = std::make_shared<W_LABEL>());
+		groupDamagedCountLabel->setGeometry(0, 0, 16, 16);
+		groupDamagedCountLabel->setFontColour(pal_RGBA(255, 0, 0, 255) /* red */);
+		groupDamagedCountLabel->setString("");
+		groupDamagedCountLabel->setTransparentToMouse(true);
 
 		buttonBackgroundEmpty = true;
 
@@ -193,7 +201,7 @@ protected:
 			lastUpdatedGlowAlphaTime = realTime;
 		}
 
-		if (!groupInfo->numberInGroup)
+		if (!groupInfo->numberInGroup && !groupInfo->numberDamagedInGroup)
 		{
 			groupCountLabel->setString("");
 			displayBlank(xOffset, yOffset, false);
@@ -202,6 +210,20 @@ protected:
 		{
 			displayIMD(AtlasImage(), ImdObject::DroidTemplate(&(groupInfo->displayDroidTemplate)), xOffset, yOffset);
 			groupCountLabel->setString(WzString::fromUtf8(astringf("%u", groupInfo->numberInGroup)));
+			groupCountLabel->move(
+				OBJ_TEXTX + 40 - groupDamagedCountLabel->getMaxLineWidth(),
+				groupCountLabel->y()
+			);
+		}
+
+		if (!groupInfo->numberDamagedInGroup)
+		{
+			groupDamagedCountLabel->setString("");
+		}
+		else
+		{
+			groupDamagedCountLabel->setString(WzString::fromUtf8(astringf("+%u", groupInfo->numberDamagedInGroup)));
+			groupDamagedCountLabel->move(groupCountLabel->x() + groupCountLabel->getMaxLineWidth(), groupCountLabel->y());
 		}
 
 		if (groupInfo->currAttackGlowAlpha > 0)
@@ -270,6 +292,7 @@ void GroupsUIController::updateData()
 	struct AccumulatedGroupInfo
 	{
 		size_t numberInGroup = 0;
+		size_t numberDamagedInGroup = 0;
 		size_t numberCommandedByGroup = 0; // the number of droids commanded by commanders in this group
 		uint64_t totalGroupMaxHealth = 0;
 		DROID *displayDroid = nullptr;
@@ -280,6 +303,10 @@ void GroupsUIController::updateData()
 	std::array<AccumulatedGroupInfo, 10> calculatedGroupInfo;
 	for (DROID *psDroid : apsDroidLists[selectedPlayer])
 	{
+		if (psDroid->repairGroup < calculatedGroupInfo.size()) {
+			calculatedGroupInfo[psDroid->repairGroup].numberDamagedInGroup++;
+		}
+
 		auto groupIdx = psDroid->group;
 		if (psDroid->group >= calculatedGroupInfo.size())
 		{
@@ -313,6 +340,7 @@ void GroupsUIController::updateData()
 		const auto& calculatedInfo = calculatedGroupInfo[idx];
 		auto& storedGroupInfo = groupInfo[idx];
 		storedGroupInfo.numberInGroup = calculatedInfo.numberInGroup;
+		storedGroupInfo.numberDamagedInGroup = calculatedInfo.numberDamagedInGroup;
 		storedGroupInfo.numberCommandedByGroup = calculatedInfo.numberCommandedByGroup;
 		storedGroupInfo.totalGroupMaxHealth = calculatedInfo.totalGroupMaxHealth;
 		if (calculatedInfo.numberInGroup > 0)

--- a/src/hci/groups.cpp
+++ b/src/hci/groups.cpp
@@ -210,8 +210,14 @@ protected:
 		{
 			displayIMD(AtlasImage(), ImdObject::DroidTemplate(&(groupInfo->displayDroidTemplate)), xOffset, yOffset);
 			groupCountLabel->setString(WzString::fromUtf8(astringf("%u", groupInfo->numberInGroup)));
+			int32_t xOffset = 0;
+			const uint32_t xFitNumberInTheBox = 16;
+			if (groupCountLabel->getMaxLineWidth() > xFitNumberInTheBox)
+			{
+				xOffset -= groupCountLabel->getMaxLineWidth() - xFitNumberInTheBox;
+			}
 			groupCountLabel->move(
-				OBJ_TEXTX + 40 - groupDamagedCountLabel->getMaxLineWidth(),
+				OBJ_TEXTX + 40 + xOffset - groupDamagedCountLabel->getMaxLineWidth(),
 				groupCountLabel->y()
 			);
 		}

--- a/src/order.cpp
+++ b/src/order.cpp
@@ -3330,6 +3330,7 @@ void secondaryCheckDamageLevel(DROID *psDroid)
 			if (psDroid->group != UBYTE_MAX)
 			{
 				psDroid->repairGroup = psDroid->group;
+				intGroupsChanged(psDroid->group);
 			}
 			psDroid->group = UBYTE_MAX;
 		}


### PR DESCRIPTION
Summary of this PR:

- The droid count is now refreshed immediately when units retreat for repair.
- Added a display of the number of damaged units in the group that will return to it after repair. This is also important information. For example: sometimes you forget about damaged units and they just stay at HQ (forgot to build a repair facility, lost all repairing units, etc.).
- Now a group of damaged units is not recovered until the units are fully repaired, as it was intended in the original PR. Exception: if you set their repair flag to "do or die".
- Improved the display of unit count text inside the widget. The three digit number was exceeding the borders of the widget. Now all variations are displayed correctly. 

![screenshot](https://github.com/user-attachments/assets/b7459073-00a4-44e5-83ee-5b5f5d65b88f)

