### PR TITLE
Fix: loadSaveResearch should not restore "pending" bits

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -7484,7 +7484,7 @@ bool loadSaveResearch(const char *pFileName)
 			psPlRes = &asPlayerResList[plr][statInc];
 			bool resAlreadyCompleted = IsResearchCompleted(psPlRes);
 			// Copy the research status
-			psPlRes->ResearchStatus = (researched & RESBITS_ALL);
+			psPlRes->ResearchStatus = (researched & RESBITS);
 			SetResearchPossible(psPlRes, possible);
 			psPlRes->currentPoints = points;
 			//for any research that has been completed - perform so that upgrade values are set up


### PR DESCRIPTION
EDIT: Nevermind, see comment below.

~~These are only used for the UI in modes that use the netqueues (i.e. skirmish, etc), and only set while waiting for the netqueue to process a research action.~~

However, savegames do not contain the netqueues, so if a save occurs between the time that the user takes a UI action (which sets the state to pending) and when the tick is processed, it could lead to research topics disappearing on saveload (since pending state is restored, but not the changes queued for the unprocessed game tick).

Testing:
- Check https://github.com/Warzone2100/warzone2100/pull/1536#issuecomment-779449266
- See also: https://github.com/Warzone2100/warzone2100/issues/1104#issuecomment-1127691359