### PR TITLE
Fixup pending research states when loading savegames

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2262,6 +2262,8 @@ static bool writeCompListFile(const char *pFileName);
 static bool loadSaveStructTypeList(const char *pFileName);
 static bool writeStructTypeListFile(const char *pFileName);
 
+static void loadFixupResearchPendingStates();
+
 static bool loadSaveResearch(const char *pFileName);
 static bool writeResearchFile(char *pFileName);
 
@@ -3298,6 +3300,11 @@ bool loadGame(const char *pGameToLoad, bool keepObjects, bool freeMem, bool User
 			PerPlayerStructureLists* pList = it->second;
 			loadSaveStructurePointers(key, pList);
 		}
+	}
+
+	if (UserSaveGame)
+	{
+		loadFixupResearchPendingStates();
 	}
 
 	// Load labels
@@ -7432,6 +7439,61 @@ static bool writeStructTypeListFile(const char *pFileName)
 		ini.endGroup();
 	}
 	return true;
+}
+
+void loadFixupResearchPendingStates()
+{
+	const unsigned int players = static_cast<unsigned int>(game.maxPlayers);
+	for (int statInc = 0; statInc < asResearch.size(); statInc++)
+	{
+		for (unsigned int plr = 0; plr < players; plr++)
+		{
+			PLAYER_RESEARCH *pPlayerRes = &asPlayerResList[plr][statInc];
+
+			// Handle "pending" states
+			// - i.e. starting/cancelling research was queued, but the game tick was not processed before the save occurred
+			// - (Ideally the game would prevent this from happening by ensuring the save is queued to happen after the next tick...)
+			if (pPlayerRes->ResearchStatus & CANCELLED_RESEARCH_PENDING)
+			{
+				STRUCTURE *psLab = findResearchingFacilityByResearchIndex(apsStructLists, plr, statInc);
+				if (psLab == nullptr)
+				{
+					// check the mission list
+					psLab = findResearchingFacilityByResearchIndex(mission.apsStructLists, plr, statInc);
+				}
+
+				if (psLab != nullptr)
+				{
+					// Process the pending cancellation with immediate effect
+					debug(LOG_INFO, "Processing CANCELLED_RESEARCH_PENDING for: %s", asResearch[statInc].id.toUtf8().c_str());
+					::cancelResearch(psLab, ModeImmediate);
+				}
+				else
+				{
+					// did not find in *either* list - log and convert the CANCELLED_RESEARCH_PENDING status appropriately
+					if (pPlayerRes->currentPoints == 0)
+					{
+						// Reset this topic as not having been researched
+						debug(LOG_INFO, "Resetting CANCELLED_RESEARCH_PENDING to 0 for: %s", asResearch[statInc].id.toUtf8().c_str());
+						ResetResearchStatus(pPlayerRes);
+					}
+					else
+					{
+						// Set the cancelled flag
+						debug(LOG_INFO, "Resetting CANCELLED_RESEARCH_PENDING to CANCELLED_RESEARCH for: %s", asResearch[statInc].id.toUtf8().c_str());
+						MakeResearchCancelled(pPlayerRes);
+					}
+				}
+			}
+			else if (pPlayerRes->ResearchStatus & STARTED_RESEARCH_PENDING)
+			{
+				// Possible Future TODO: Could try to "recover", and queue this research item in an available research facility (however, the save doesn't contain which facility the user queued it in)
+				// For now: Just clear the STARTED_RESEARCH_PENDING bit, so that the user can re-start the research after loading the save
+				debug(LOG_INFO, "Resetting STARTED_RESEARCH_PENDING to 0 for: %s", asResearch[statInc].id.toUtf8().c_str());
+				pPlayerRes->ResearchStatus &= ~STARTED_RESEARCH_PENDING;
+			}
+		}
+	}
 }
 
 // -----------------------------------------------------------------------------------------

--- a/src/hci/research.cpp
+++ b/src/hci/research.cpp
@@ -159,27 +159,9 @@ void ResearchController::startResearch(RESEARCH &research)
 		cancelResearch(psLab); //Clear it out of this lab as we are now researching it in another.
 	}
 
-	if (bMultiMessages)
-	{
-		// Say that we want to do research [sic].
-		sendResearchStatus(facility, research.ref - STAT_RESEARCH, selectedPlayer, true);
-		setStatusPendingStart(*psResFacilty, &research);  // Tell UI that we are going to research.
-	}
-	else
-	{
-		//set up the player_research
-		auto count = research.ref - STAT_RESEARCH;
-		//meant to still be in the list but greyed out
-		auto pPlayerRes = &asPlayerResList[selectedPlayer][count];
-
-		//set the subject up
-		psResFacilty->psSubject = &research;
-
-		sendResearchStatus(facility, count, selectedPlayer, true);	// inform others, I'm researching this.
-
-		MakeResearchStarted(pPlayerRes);
-		psResFacilty->timeStartHold = 0;
-	}
+	// Say that we want to do research [sic].
+	sendResearchStatus(facility, research.ref - STAT_RESEARCH, selectedPlayer, true);
+	setStatusPendingStart(*psResFacilty, &research);  // Tell UI that we are going to research.
 
 	//stop the button from flashing once a topic has been chosen
 	stopReticuleButtonFlash(IDRET_RESEARCH);

--- a/src/multiplay.cpp
+++ b/src/multiplay.cpp
@@ -1576,19 +1576,24 @@ bool sendResearchStatus(const STRUCTURE *psBuilding, uint32_t index, uint8_t pla
 	return true;
 }
 
-STRUCTURE *findResearchingFacilityByResearchIndex(unsigned player, unsigned index)
+STRUCTURE *findResearchingFacilityByResearchIndex(const PerPlayerStructureLists& pList, unsigned player, unsigned index)
 {
 	// Go through the structs to find the one doing this topic
-	for (STRUCTURE *psBuilding : apsStructLists[player])
+	for (STRUCTURE *psBuilding : pList[player])
 	{
 		if (psBuilding->pStructureType->type == REF_RESEARCH
-		    && ((RESEARCH_FACILITY *)psBuilding->pFunctionality)->psSubject
-		    && ((RESEARCH_FACILITY *)psBuilding->pFunctionality)->psSubject->ref - STAT_RESEARCH == index)
+			&& ((RESEARCH_FACILITY *)psBuilding->pFunctionality)->psSubject
+			&& ((RESEARCH_FACILITY *)psBuilding->pFunctionality)->psSubject->ref - STAT_RESEARCH == index)
 		{
 			return psBuilding;
 		}
 	}
 	return nullptr;  // Not found.
+}
+
+STRUCTURE *findResearchingFacilityByResearchIndex(unsigned player, unsigned index)
+{
+	return findResearchingFacilityByResearchIndex(apsStructLists, player, index);
 }
 
 bool recvResearchStatus(NETQUEUE queue)

--- a/src/multiplay.h
+++ b/src/multiplay.h
@@ -36,6 +36,7 @@
 #include "levels.h"
 #include "console.h"
 #include "multirecv.h"
+#include "objmem.h"
 #include <vector>
 #include <string>
 #include <chrono>
@@ -323,7 +324,8 @@ bool sendBeacon(int32_t locX, int32_t locY, int32_t forPlayer, int32_t sender, c
 void startMultiplayerGame();
 void resetReadyStatus(bool bSendOptions, bool ignoreReadyReset = false);
 
-STRUCTURE *findResearchingFacilityByResearchIndex(unsigned player, unsigned index);
+STRUCTURE *findResearchingFacilityByResearchIndex(const PerPlayerStructureLists& pList, unsigned player, unsigned index);
+STRUCTURE *findResearchingFacilityByResearchIndex(unsigned player, unsigned index); // checks apsStructLists
 
 void sendSyncRequest(int32_t req_id, int32_t x, int32_t y, const BASE_OBJECT *psObj, const BASE_OBJECT *psObj2);
 


### PR DESCRIPTION
Handle "pending" states on saveload
- i.e. when starting/cancelling research was queued, but the game tick was not processed before the save occurred


Ideally the game would prevent this from happening by ensuring the save is queued to happen after the next tick - but adding this handling on saveload also "unbreaks" older (unlucky) saves.