### PR TITLE
Update brain.json

### DIFF
--- a/data/base/script/campaign/cam2-1x.js
+++ b/data/base/script/campaign/cam2-1x.js
@@ -83,7 +83,7 @@ function setupCyborgGroups()
 
 function setCrashedTeamExp()
 {
-	const DROID_EXP = 32;
+	const DROID_EXP = camGetRankThreshold("professional");
 	const droids = enumDroid(MIS_TRANSPORT_TEAM_PLAYER).filter((dr) => (
 		!camIsSystemDroid(dr) && !camIsTransporter(dr)
 	));

--- a/data/base/script/campaign/cam2-a.js
+++ b/data/base/script/campaign/cam2-a.js
@@ -302,7 +302,7 @@ function cam2Setup()
 //Get some higher rank droids.
 function setUnitRank(transport)
 {
-	const droidExp = [128, 64, 32, 16];
+	const ranks = ["elite", "veteran", "professional", "regular"];
 	let droids;
 	let mapRun = false;
 
@@ -322,19 +322,8 @@ function setUnitRank(transport)
 		const droid = droids[i];
 		if (droid.droidType !== DROID_CONSTRUCT && droid.droidType !== DROID_REPAIR)
 		{
-			let mod = 1;
-			if (droid.droidType === DROID_COMMAND || droid.droidType === DROID_SENSOR)
-			{
-				if (camClassicMode())
-				{
-					mod = 4;
-				}
-				else
-				{
-					mod = 8;
-				}
-			}
-			setDroidExperience(droid, mod * droidExp[mapRun ? 0 : (transporterIndex - 1)]);
+			const USE_COMMAND_RANK = (droid.droidType === DROID_COMMAND || droid.droidType === DROID_SENSOR);
+			setDroidExperience(droid, camGetRankThreshold(ranks[mapRun ? 0 : (transporterIndex - 1)], USE_COMMAND_RANK));
 		}
 	}
 }

--- a/data/base/script/campaign/cam3-2.js
+++ b/data/base/script/campaign/cam3-2.js
@@ -76,7 +76,7 @@ camAreaEvent("phantomFacTrigger", function(droid)
 
 function setAlphaExp()
 {
-	const DROID_EXP = 2048; //Hero rank.
+	const DROID_EXP = camGetRankThreshold("hero", true); //Hero Commander rank.
 	const alphaDroids = enumArea("alphaPit", MIS_ALPHA_PLAYER, false).filter((obj) => (
 		obj.type === DROID
 	));

--- a/data/base/script/campaign/cam3-a.js
+++ b/data/base/script/campaign/cam3-a.js
@@ -58,7 +58,12 @@ camAreaEvent ("middleTrigger", function(droid)
 
 function setUnitRank(transport)
 {
-	const droidExp = [2048, 256, 128, 64]; //Can make Hero Commanders if recycled.
+	const droidExp = [
+		camGetRankThreshold("hero", true), //Can make Hero Commanders if recycled.
+		camGetRankThreshold("special"),
+		camGetRankThreshold("elite"),
+		camGetRankThreshold("veteran")
+	];
 	const droids = enumCargo(transport);
 
 	for (let i = 0, len = droids.length; i < len; ++i)

--- a/data/base/script/campaign/libcampaign_includes/misc.js
+++ b/data/base/script/campaign/libcampaign_includes/misc.js
@@ -589,11 +589,57 @@ function camDiscoverCampaign()
 	return __CAM_UNKNOWN_CAMPAIGN_NUMBER;
 }
 
-function camSetExpLevel(number)
+//;; ## camGetRankThreshold(rank [, command [, player]])
+//;;
+//;; Returns the rank threshold for a given rank.
+//;;
+//;; @param {String|Number} rank
+//;; @param {Boolean} command
+//;; @param {Number} player
+//;; @returns {number}
+//;;
+function camGetRankThreshold(rankName, command, player)
 {
-	__camExpLevel = number;
+	if (!camDef(command))
+	{
+		command = false;
+	}
+	if (!camDef(player))
+	{
+		player = CAM_HUMAN_PLAYER;
+	}
+	const __BRAIN_TYPE = (command) ? "Command Turret" : "Z NULL BRAIN";
+	let rank = 0;
+	if (typeof rankName === "string")
+	{
+		rank = __camRankStringToNumber(rankName);
+	}
+	return Upgrades[player]["Brain"][__BRAIN_TYPE]["RankThresholds"][rank];
 }
 
+//;; ## camSetExpLevel(rank)
+//;;
+//;; Sets what rank will be used for the AI when it creates units. Can be a rank threshold
+//;; index or the name of the rank.
+//;;
+//;; @param {Number|String} rank
+//;; @returns {void}
+//;;
+function camSetExpLevel(rank)
+{
+	if (!camDef(rank))
+	{
+		rank = 0;
+	}
+	__camExpLevel = (typeof rank === "string") ? __camRankStringToNumber(rank) : rank;
+}
+
+//;; ## camSetOnMapEnemyUnitExp()
+//;;
+//;; Sets all non-player units to the chosen rank set through camSetExpLevel().
+//;;
+//;; @returns {void}
+//;;
 function camSetOnMapEnemyUnitExp()
 {
 	enumDroid(CAM_NEW_PARADIGM)
@@ -681,35 +727,52 @@ function __camAiPowerReset()
 	}
 }
 
+function __camRankStringToNumber(rankName)
+{
+	if (!camDef(rankName))
+	{
+		camDebug("Undefined parameter");
+		return 0;
+	}
+	if (typeof rankName !== "string")
+	{
+		camDebug("Please specify rank as a string");
+		return 0;
+	}
+	let rank = 0;
+	switch (rankName.toLowerCase())
+	{
+		case "rookie": rank = 0; break;
+		case "green": rank = 1; break;
+		case "trained": rank = 2; break;
+		case "regular": rank = 3; break;
+		case "professional": rank = 4; break;
+		case "veteran": rank = 5; break;
+		case "elite": rank = 6; break;
+		case "special": rank = 7; break;
+		case "hero": rank = 8; break;
+		default: camDebug("Unknown rank encountered");
+	}
+	return rank;
+}
+
 function __camGetExpRangeLevel(useCommanderRanks)
 {
 	if (!camDef(useCommanderRanks))
 	{
 		useCommanderRanks = false;
 	}
-	const unitRanks = {
-		rookie: 0,
-		green: 4,
-		trained: 8,
-		regular: 16,
-		professional: 32,
-		veteran: 64,
-		elite: 128,
-		special: 256,
-		hero: 512,
+	const ranks = {
+		rookie: camGetRankThreshold("rookie", useCommanderRanks),
+		green: camGetRankThreshold("green", useCommanderRanks),
+		trained: camGetRankThreshold("trained", useCommanderRanks),
+		regular: camGetRankThreshold("regular", useCommanderRanks),
+		professional: camGetRankThreshold("professional", useCommanderRanks),
+		veteran: camGetRankThreshold("veteran", useCommanderRanks),
+		elite: camGetRankThreshold("elite", useCommanderRanks),
+		special: camGetRankThreshold("special", useCommanderRanks),
+		hero: camGetRankThreshold("hero", useCommanderRanks)
 	};
-	const commandRanks = {
-		rookie: 0,
-		green: (camClassicMode()) ? 8 : 16,
-		trained: (camClassicMode()) ? 16 : 48,
-		regular: (camClassicMode()) ? 32 : 128,
-		professional: (camClassicMode()) ? 64 : 256,
-		veteran: (camClassicMode()) ? 128 : 512,
-		elite: (camClassicMode()) ? 512 : 1024,
-		special: (camClassicMode()) ? 1024 : 1536,
-		hero: 2048,
-	};
-	const ranks = (useCommanderRanks) ? commandRanks : unitRanks;
 	let exp = [];
 
 	switch (__camExpLevel)

--- a/data/base/stats/brain.json
+++ b/data/base/stats/brain.json
@@ -8,7 +8,7 @@
 		"maxDroidsMult": 2,
 		"name": "Command Turret",
 		"ranks": [ "Rookie", "Green", "Trained", "Regular", "Professional", "Veteran", "Elite", "Special", "Hero" ],
-		"thresholds": [ 0, 16, 48, 128, 256, 512, 1024, 1536, 2048 ],
+		"thresholds": [ 0, 24, 48, 96, 192, 384, 768, 1536, 2048 ],
 		"turret": "CommandTurret1"
 	},
 	"ZNULLBRAIN": {


### PR DESCRIPTION
The original xp system got changed because it was too easy to get a hero commander and therefore the Beta campaign too easy. But the 4.5.1 system is not very logical and the lower ranks are too difficult to achieve. Therefore the commander needs now 6x the xp than a NULLBRAIN unit for every rank except the hero rank because 3072 points are (almost) not to gain except with xp farming.