### PR TITLE
objmem: prevent calling `audio_RemoveObj()` from the destructors of in-game objects

### DIFF
--- a/src/baseobject.cpp
+++ b/src/baseobject.cpp
@@ -85,9 +85,6 @@ SIMPLE_OBJECT::SIMPLE_OBJECT(OBJECT_TYPE type, uint32_t id, unsigned player)
 
 SIMPLE_OBJECT::~SIMPLE_OBJECT()
 {
-	// Make sure to get rid of some final references in the sound code to this object first
-	audio_RemoveObj(this);
-
 	const_cast<OBJECT_TYPE volatile &>(type) = (OBJECT_TYPE)(type + 1000000000);  // Hopefully this will trigger an assert              if someone uses the freed object.
 	const_cast<UBYTE volatile &>(player) += 100;                                  // Hopefully this will trigger an assert and/or crash if someone uses the freed object.
 }

--- a/src/droid.cpp
+++ b/src/droid.cpp
@@ -439,10 +439,6 @@ DROID::DROID(uint32_t id, unsigned player)
  */
 DROID::~DROID()
 {
-	// Make sure to get rid of some final references in the sound code to this object first
-	// In BASE_OBJECT::~BASE_OBJECT() is too late for this, since some callbacks require us to still be a DROID.
-	audio_RemoveObj(this);
-
 	DROID *psDroid = this;
 
 	if (psDroid->isTransporter())

--- a/src/feature.cpp
+++ b/src/feature.cpp
@@ -358,10 +358,7 @@ FEATURE::FEATURE(uint32_t id, FEATURE_STATS const *psStats)
 
 /* Release the resources associated with a feature */
 FEATURE::~FEATURE()
-{
-	// Make sure to get rid of some final references in the sound code to this object first
-	audio_RemoveObj(this);
-}
+{}
 
 void _syncDebugFeature(const char *function, FEATURE const *psFeature, char ch)
 {

--- a/src/projectile.cpp
+++ b/src/projectile.cpp
@@ -233,6 +233,12 @@ void proj_AddActiveProjectile(PROJECTILE* p)
 void
 proj_FreeAllProjectiles()
 {
+	for (const auto* p : psProjectileList)
+	{
+		// Make sure to get rid of some final references in the sound code to this object first
+		audio_RemoveObj(p);
+	}
+
 	psProjectileList.clear();
 	psProjectileNext = psProjectileList.end();
 
@@ -1466,6 +1472,10 @@ void proj_UpdateAll()
 		}
 		auto it = globalProjectileStorage.find(*p);
 		ASSERT(it != globalProjectileStorage.end(), "Invalid projectile, not found in global storage");
+
+		// Make sure to get rid of some final references in the sound code to this object first
+		audio_RemoveObj(p);
+
 		globalProjectileStorage.erase(it);
 		return true;
 	}), psProjectileList.end());

--- a/src/structure.cpp
+++ b/src/structure.cpp
@@ -3992,9 +3992,6 @@ STRUCTURE::STRUCTURE(uint32_t id, unsigned player)
 /* Release all resources associated with a structure */
 STRUCTURE::~STRUCTURE()
 {
-	// Make sure to get rid of some final references in the sound code to this object first
-	audio_RemoveObj(this);
-
 	STRUCTURE *psBuilding = this;
 
 	// free up the space used by the functionality array


### PR DESCRIPTION
The call to `audio_RemoveObj` inside the destructors of `SIMPLE_OBJECT`, `DROID`, `STRUCTURE`, `FEATURE` and `PROJECTILE` classes can possibly invoke undefined behavior if the warzone process is being forcefully shut down (either by us, the user or some other third-party code, like X11 in case of linux).

The reason for this is that by the time a given game object is being destroyed, chances are that the static objects from the audio code, which are being accessed by the `audio_RemoveObj()`, can already be destroyed (due to the inverse of the [Static initialization order fiasco](https://en.cppreference.com/w/cpp/language/siof)).

Signed-off-by: Pavel Solodovnikov <pavel.al.solodovnikov@gmail.com>