### PR TITLE
Use `eventGameLoaded` for Cobra AI group initialization

### DIFF
--- a/data/mp/multiplay/skirmish/cobra_includes/events.js
+++ b/data/mp/multiplay/skirmish/cobra_includes/events.js
@@ -1,7 +1,7 @@
 //This file contains generic events. Chat and research events are split into
 //their own seperate files.
 
-function eventGameInit()
+function eventGameLoaded()
 {
 	initCobraGroups();
 }

--- a/data/mp/multiplay/skirmish/cobra_includes/miscFunctions.js
+++ b/data/mp/multiplay/skirmish/cobra_includes/miscFunctions.js
@@ -395,6 +395,7 @@ function initCobraVars()
 {
 	let isHoverMap = checkIfSeaMap();
 
+	initCobraGroups();
 	lastMsg = "eventStartLevel";
 	lastMsgThrottle = 0;
 	currently_dead = false;


### PR DESCRIPTION
Uses the `eventGameLoaded` event in place of `eventGameInit`.

As for why, API function `newGroup()` has bad behavior (all script assigned "group" numbers get wiped after loading a save, so the results of `newGroup()` resets back to zero--and thus `groupSize()` will probably act weird too).