### PR TITLE
Fix visibility of units restored during limbo missions

### DIFF
--- a/src/mission.cpp
+++ b/src/mission.cpp
@@ -946,6 +946,8 @@ void placeLimboDroids()
 			initDroidMovement(psDroid);
 			//make sure the died flag is not set
 			psDroid->died = false;
+			//update visibility
+			visTilesUpdate(psDroid);
 		}
 		else
 		{
@@ -973,6 +975,10 @@ void restoreMissionLimboData()
 			//reset droid orders
 			orderDroid(psDroid, DORDER_STOP, ModeImmediate);
 			//the location of the droid should be valid!
+			if (psDroid->pos.x != INVALID_XY && psDroid->pos.y != INVALID_XY)
+			{
+				visTilesUpdate(psDroid); //update visibility
+			}
 		}
 		return IterationResult::CONTINUE_ITERATION;
 	});


### PR DESCRIPTION
Units would be sitting in darkness provided they weren't near structures that give visibility.

---

![Screenshot at 2024-08-17 22-22-47](https://github.com/user-attachments/assets/76aa0f6e-ff41-4cf9-bedb-27b9ab861a50)

`placeLimboDroids()`, from setting the "limbo" LZ no less, pulls in droids inside the limbo list onto the map. Not sure if it was necessary to do a vision update but it shouldn't hurt.

`restoreMissionLimboData()` occurs when the rest of the home base gets put back in scroll limits. Here we are restoring the units from the mission list onto the map. The vision update here will make the units in the screenshot not sit in the dark.