### PR TITLE
Give experience when squishing a scavenger

### DIFF
--- a/src/droid.cpp
+++ b/src/droid.cpp
@@ -106,6 +106,7 @@ int getTopExperience(int player)
 	}
 	return recycled_experience[player].top();
 }
+
 void cancelBuild(DROID *psDroid)
 {
 	if (psDroid->order.type == DORDER_NONE || psDroid->order.type == DORDER_PATROL || psDroid->order.type == DORDER_HOLD || psDroid->order.type == DORDER_SCOUT || psDroid->order.type == DORDER_GUARD)
@@ -2410,6 +2411,17 @@ void droidIncreaseExperience(DROID *psDroid, uint32_t experienceInc)
 	{
 		// Trigger new event - unit rank increased
 		triggerEventDroidRankGained(psDroid, finalDroidRank);
+	}
+}
+
+// Possibly increase experience when squishing a scavenger.
+void giveExperienceForSquish(DROID *psDroid)
+{
+	if (psDroid->droidType == DROID_WEAPON || psDroid->droidType == DROID_SENSOR || psDroid->droidType == DROID_COMMAND)
+	{
+		const uint32_t expGain = std::max(65536 / 2, 65536 * getExpGain(psDroid->player) / 100);
+		droidIncreaseExperience(psDroid, expGain);
+		cmdDroidUpdateExperience(psDroid, expGain);
 	}
 }
 

--- a/src/droid.h
+++ b/src/droid.h
@@ -187,6 +187,7 @@ UDWORD getDroidEffectiveLevel(const DROID *psDroid);
 const char *getDroidLevelName(const DROID *psDroid);
 // Increase the experience of a droid (and handle events, if needed).
 void droidIncreaseExperience(DROID *psDroid, uint32_t experienceInc);
+void giveExperienceForSquish(DROID *psDroid);
 
 // Get a droid's name.
 const char *droidGetName(const DROID *psDroid);

--- a/src/move.cpp
+++ b/src/move.cpp
@@ -775,6 +775,7 @@ static void moveCheckSquished(DROID *psDroid, int32_t emx, int32_t emy)
 				// run over a bloke - kill him
 				destroyDroid((DROID *)psObj, gameTime);
 				scoreUpdateVar(WD_BARBARIANS_MOWED_DOWN);
+				giveExperienceForSquish(psDroid);
 			}
 		}
 	}


### PR DESCRIPTION
Adds experience for the critical micro needed to run one over.

A flat 1.0 exp will be gained by default (with a minimum of 0.5 for future proofing purposes). Since nothing changes the experience gain rate it will just be 1.0 until that time.