### PR TITLE
Reset object animation state in a few places

### DIFF
--- a/src/baseobject.cpp
+++ b/src/baseobject.cpp
@@ -225,3 +225,21 @@ StructureBounds getStructureBounds(BASE_STATS const *stats, Vector2i pos, uint16
 
 	return StructureBounds(map_coord(pos), Vector2i(1, 1));  // Default to a 1×1 tile.
 }
+
+// Reset animation state so some units don't walk in place in the menu sometimes.
+void resetObjectAnimationState(BASE_OBJECT *psObj)
+{
+	if (psObj == nullptr)
+	{
+		return;
+	}
+	if (psObj->type == OBJ_DROID || psObj->type == OBJ_STRUCTURE || psObj->type == OBJ_FEATURE)
+	{
+		psObj->timeAnimationStarted = 0;
+		psObj->animationEvent = ANIM_EVENT_NONE;
+	}
+	else
+	{
+		debug(LOG_WARNING, "Tried resetting animation state on unknown object type");
+	}
+}

--- a/src/baseobject.h
+++ b/src/baseobject.h
@@ -68,4 +68,6 @@ Vector2i getStatsSize(BASE_STATS const *pType, uint16_t direction);
 StructureBounds getStructureBounds(BASE_OBJECT const *object);
 StructureBounds getStructureBounds(BASE_STATS const *stats, Vector2i pos, uint16_t direction);
 
+void resetObjectAnimationState(BASE_OBJECT *psObj);
+
 #endif // __INCLUDED_BASEOBJECT_H__

--- a/src/mission.cpp
+++ b/src/mission.cpp
@@ -762,6 +762,7 @@ static void saveMissionData()
 		{
 			orderDroid(psDroid, DORDER_STOP, ModeImmediate);
 		}
+		resetObjectAnimationState(psDroid);
 	}
 
 	resetHomeStructureObjects(); //get rid of soon-to-be illegal references of droids in repair facilities and rearming pads.

--- a/src/move.cpp
+++ b/src/move.cpp
@@ -1796,8 +1796,7 @@ static void moveUpdatePersonModel(DROID *psDroid, SDWORD speed, uint16_t directi
 		}
 		else if (psDroid->animationEvent == ANIM_EVENT_ACTIVE)
 		{
-			psDroid->timeAnimationStarted = 0; // turn off movement animation, since we stopped
-			psDroid->animationEvent = ANIM_EVENT_NONE;
+			resetObjectAnimationState(psDroid);
 		}
 		return;
 	}
@@ -1954,8 +1953,7 @@ static void moveUpdateCyborgModel(DROID *psDroid, SDWORD moveSpeed, uint16_t mov
 	{
 		if (psDroid->animationEvent == ANIM_EVENT_ACTIVE)
 		{
-			psDroid->timeAnimationStarted = 0;
-			psDroid->animationEvent = ANIM_EVENT_NONE;
+			resetObjectAnimationState(psDroid);
 		}
 		return;
 	}
@@ -2271,8 +2269,7 @@ void moveUpdateDroid(DROID *psDroid)
 	case MOVEINACTIVE:
 		if (psDroid->animationEvent == ANIM_EVENT_ACTIVE)
 		{
-			psDroid->timeAnimationStarted = 0;
-			psDroid->animationEvent = ANIM_EVENT_NONE;
+			resetObjectAnimationState(psDroid);
 		}
 		if (bStopped)
 		{

--- a/src/order.cpp
+++ b/src/order.cpp
@@ -924,6 +924,7 @@ bool orderUpdateDroid(DROID *psDroid)
 					setDroidTarget(psDroid, nullptr);
 					psDroid->order.psObj = nullptr;
 					secondarySetState(psDroid, DSO_RETURN_TO_LOC, DSS_NONE);
+					moveReallyStopDroid(psDroid);
 
 					// Fire off embark event
 					transporterSetScriptCurrent(transporter);

--- a/src/structure.cpp
+++ b/src/structure.cpp
@@ -3781,8 +3781,7 @@ void structureUpdate(STRUCTURE *psBuilding, bool bMission)
 		if (!psBuilding->pFunctionality->resourceExtractor.psPowerGen
 		    && psBuilding->animationEvent == ANIM_EVENT_ACTIVE) // no power generator connected
 		{
-			psBuilding->timeAnimationStarted = 0; // so turn off animation, if any
-			psBuilding->animationEvent = ANIM_EVENT_NONE;
+			resetObjectAnimationState(psBuilding);
 		}
 		else if (psBuilding->pFunctionality->resourceExtractor.psPowerGen
 		         && psBuilding->animationEvent == ANIM_EVENT_NONE // we have a power generator, but no animation

--- a/src/transporter.cpp
+++ b/src/transporter.cpp
@@ -1047,6 +1047,9 @@ void transporterAddDroid(DROID *psTransporter, DROID *psDroidToAdd)
 		}
 		return;
 	}
+
+	resetObjectAnimationState(psDroidToAdd);
+
 	if (onMission)
 	{
 		// removing from droid mission list


### PR DESCRIPTION
- When going offworld.
- When moving a droid into a transporter.

This prevents a somewhat uncommon case where cyborgs are walking in-place inside menu buttons, for example.

Edit: In addition to resetting the animation state fixing some of this, I also found out that units retained their speed when embarking. Which caused another animation state event reset to fail causing them to walk after placing them in the transporter before lift off.

And, it fixes movement sounds from playing after disembarking units from a transporter too.