### PR TITLE
lib/sound/openal_track.cpp: fix use-after-free pointed by gcc-15

### DIFF
--- a/lib/sound/openal_track.cpp
+++ b/lib/sound/openal_track.cpp
@@ -1034,9 +1034,9 @@ AUDIO_STREAM *sound_PlayStream(const char* fileName, bool bufferEntireStream,
 		alDeleteBuffers(buffer_count, alBuffersIds);
 
 	_error:
+		alDeleteSources(1, &stream->source);
 		delete stream;
 		delete decoder;
-		alDeleteSources(1, &stream->source);
 		return nullptr;
 }
 


### PR DESCRIPTION
`gcc-15` detects use-after-free as:

    lib/sound/openal_track.cpp: In function 'AUDIO_STREAM* sound_PlayStream(const char*, bool, float, const std::function<void(const AUDIO_STREAM*, const void*)>&, const void*)':
    lib/sound/openal_track.cpp:1039:36: error: pointer used after 'void operator delete(void*, std::size_t)' [-Werror=use-after-free]
     1039 |                 alDeleteSources(1, &stream->source);
          |                                    ^~~~~~~~~~~~~~~
    lib/sound/openal_track.cpp:1037:24: note: call to 'void operator delete(void*, std::size_t)' here
     1037 |                 delete stream;
          |                        ^~~~~~