### PR TITLE
lib/wzmaplib: add missing `<cstdint>` includes

### DIFF
--- a/lib/wzmaplib/include/wzmaplib/map_io.h
+++ b/lib/wzmaplib/include/wzmaplib/map_io.h
@@ -21,6 +21,7 @@
 #pragma once
 
 #include <cstddef>
+#include <cstdint>
 #include <string>
 #include <memory>
 #include <vector>

--- a/lib/wzmaplib/src/map_script.h
+++ b/lib/wzmaplib/src/map_script.h
@@ -19,6 +19,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <vector>
 #include <string>
 #include <memory>


### PR DESCRIPTION
Without the change the build on upcoming `gcc-15` fails as:

    In file included from /build/warzone2100/lib/wzmaplib/src/map_script.cpp:20:
    /build/warzone2100/lib/wzmaplib/src/map_script.h:31:97: error: 'uint32_t' has not been declared
       31 | std::shared_ptr<Map> runMapScript(const std::vector<char>& fileBuffer, const std::string &path, uint32_t seed, bool preview, LoggingProtocol* pCustomLogger = nullptr);
          |                                                                                                 ^~~~~~~~