### PR TITLE
objmem: properly check for missing elements in `freeAllEntitiesImpl`

### DIFF
--- a/src/objmem.cpp
+++ b/src/objmem.cpp
@@ -589,7 +589,10 @@ static void freeAllEntitiesImpl(PerPlayerObjectLists<Entity, PlayerCount>& entit
 		for (auto* ent : list)
 		{
 			auto it = entityContainer.find(*ent);
-			ASSERT(it != entityContainer.end(), "%s not found in the global container!", Traits::entityName());
+			if (it == entityContainer.end()) {
+				ASSERT(false, "%s not found in the global container!", Traits::entityName());
+				continue;
+			}
 			entityContainer.erase(it);
 		}
 		list.clear();


### PR DESCRIPTION
It's forbidden to invoke `.erase()` on the end iterator, so avoid calling the method by guarding this code path by a `continue` + `ASSERT` combination.