### PR TITLE
initial support for admins being allowed to perform host-only actions

### DIFF
--- a/lib/netplay/netplay.cpp
+++ b/lib/netplay/netplay.cpp
@@ -33,6 +33,7 @@
 #include "src/console.h"
 #include "src/component.h"		// FIXME: we need to handle this better
 #include "src/modding.h"		// FIXME: we need to handle this better
+#include "src/multilobbycommands.h"
 
 #include <time.h>			// for stats
 #include <physfs.h>
@@ -4293,9 +4294,12 @@ static void NETallowJoining()
 
 			NEThostPromoteTempSocketToPermanentPlayerConnection(i, index);
 
+			bool isAdminJoining = identityMatchesAdmin(joinRequestInfo.identity);
+
 			NETbeginEncode(NETnetQueue(index), NET_ACCEPTED);
 			NETuint8_t(&index);
 			NETuint32_t(&NetPlay.hostPlayer);
+			NETbool(&isAdminJoining);
 			NETend();
 
 			// First send info about players to newcomer.

--- a/lib/netplay/netplay.h
+++ b/lib/netplay/netplay.h
@@ -316,6 +316,7 @@ struct NETPLAY
 	uint32_t	hostPlayer;		///< Index of host in player array
 	bool		bComms;			///< Actually do the comms?
 	bool		isHost;			///< True if we are hosting the game
+	bool		isAdmin;		///< True if we are promoted to admin by the host
 	bool		isPortMappingEnabled;				// if we want the automatic Port mapping setup routines to run
 	bool		isHostAlive;	/// if the host is still alive
 	char gamePassword[password_string_size];		//

--- a/src/multiint.cpp
+++ b/src/multiint.cpp
@@ -2526,13 +2526,17 @@ bool recvTeamRequest(NETQUEUE queue)
 
 	if (senderHasLobbyCommandAdminPrivs(queue.index) && (queue.index != player || locked.teams))
 	{
-		const char* msg = astringf("Admin %s changed team of player [%d] %s to %d",
+		sendRoomSystemMessage(astringf("Admin %s changed team of player [%d] %s to %d",
 			NetPlay.players[queue.index].name,
 			NetPlay.players[player].position,
 			NetPlay.players[player].name,
-			team).c_str();
-		sendRoomSystemMessage(msg);
-		debug(LOG_INFO, "%s", msg);
+			team).c_str());
+		debug(LOG_INFO, "Admin %s (%s) changed team of player [%d] %s to %d",
+			NetPlay.players[queue.index].name,
+			getMultiStats(queue.index).identity.publicKeyHexString().c_str(),
+			NetPlay.players[player].position,
+			NetPlay.players[player].name,
+			team);
 	}
 
 	if (!alliancesSetTeamsBeforeGame(game.alliance))
@@ -2793,13 +2797,17 @@ bool recvFactionRequest(NETQUEUE queue)
 
 	if (senderHasLobbyCommandAdminPrivs(queue.index) && queue.index != player)
 	{
-		const char* msg = astringf("Admin %s changed faction of player [%d] %s to %d",
+		sendRoomSystemMessage(astringf("Admin %s changed faction of player [%d] %s to %d",
 			NetPlay.players[queue.index].name,
 			NetPlay.players[player].position,
 			NetPlay.players[player].name,
-			faction).c_str();
-		sendRoomSystemMessage(msg);
-		debug(LOG_INFO, "%s", msg);
+			faction).c_str());
+		debug(LOG_INFO, "Admin %s (%s) changed faction of player [%d] %s to %d",
+			NetPlay.players[queue.index].name,
+			getMultiStats(queue.index).identity.publicKeyHexString().c_str(),
+			NetPlay.players[player].position,
+			NetPlay.players[player].name,
+			faction);
 	}
 
 	resetReadyStatus(false, true);
@@ -2835,13 +2843,17 @@ bool recvColourRequest(NETQUEUE queue)
 
 	if (senderHasLobbyCommandAdminPrivs(queue.index) && (queue.index != player))
 	{
-		const char* msg = astringf("Admin %s changed color of player [%d] %s to %d",
+		sendRoomSystemMessage(astringf("Admin %s changed color of player [%d] %s to %d",
 			NetPlay.players[queue.index].name,
 			NetPlay.players[player].position,
 			NetPlay.players[player].name,
-			col).c_str();
-		sendRoomSystemMessage(msg);
-		debug(LOG_INFO, "%s", msg);
+			col).c_str());
+		debug(LOG_INFO, "Admin %s (%s) changed color of player [%d] %s to %d",
+			NetPlay.players[queue.index].name,
+			getMultiStats(queue.index).identity.publicKeyHexString().c_str(),
+			NetPlay.players[player].position,
+			NetPlay.players[player].name,
+			col);
 	}
 
 	resetReadyStatus(false, true);
@@ -2881,13 +2893,17 @@ bool recvPositionRequest(NETQUEUE queue)
 
 	if (senderHasLobbyCommandAdminPrivs(queue.index) && (queue.index != player || (locked.position)))
 	{
-		const char* msg = astringf("Admin %s changed position of player [%d] %s to %d",
+		sendRoomSystemMessage(astringf("Admin %s changed position of player [%d] %s to %d",
 			NetPlay.players[queue.index].name,
 			NetPlay.players[player].position,
 			NetPlay.players[player].name,
-			position).c_str();
-		sendRoomSystemMessage(msg);
-		debug(LOG_INFO, "%s", msg);
+			position).c_str());
+		debug(LOG_INFO, "Admin %s (%s) changed position of player [%d] %s to %d",
+			NetPlay.players[queue.index].name,
+			getMultiStats(queue.index).identity.publicKeyHexString().c_str(),
+			NetPlay.players[player].position,
+			NetPlay.players[player].name,
+			position);
 	}
 
 	resetReadyStatus(false);

--- a/src/multiint.cpp
+++ b/src/multiint.cpp
@@ -2519,18 +2519,20 @@ bool recvTeamRequest(NETQUEUE queue)
 		return false;
 	}
 
-	if (senderHasLobbyCommandAdminPrivs(queue.index))
-	{
-		sendRoomSystemMessage(astringf("Admin %s changed team of player [%d] %s to %d",
-			NetPlay.players[queue.index].name,
-			NetPlay.players[player].position,
-			NetPlay.players[player].name,
-			team).c_str());
-	}
-
 	if (locked.teams && !senderHasLobbyCommandAdminPrivs(queue.index))
 	{
 		return false;
+	}
+
+	if (senderHasLobbyCommandAdminPrivs(queue.index) && (queue.index != player || locked.teams))
+	{
+		const char* msg = astringf("Admin %s changed team of player [%d] %s to %d",
+			NetPlay.players[queue.index].name,
+			NetPlay.players[player].position,
+			NetPlay.players[player].name,
+			team).c_str();
+		sendRoomSystemMessage(msg);
+		debug(LOG_INFO, "%s", msg);
 	}
 
 	if (!alliancesSetTeamsBeforeGame(game.alliance))
@@ -2776,7 +2778,7 @@ bool recvFactionRequest(NETQUEUE queue)
 		return false;
 	}
 
-	if (whosResponsible(player) != queue.index)
+	if (whosResponsible(player) != queue.index && !senderHasLobbyCommandAdminPrivs(queue.index))
 	{
 		HandleBadParam("NET_FACTIONREQUEST given incorrect params.", player, queue.index);
 		return false;
@@ -2787,6 +2789,17 @@ bool recvFactionRequest(NETQUEUE queue)
 	{
 		HandleBadParam("NET_FACTIONREQUEST given incorrect params.", player, queue.index);
 		return false;
+	}
+
+	if (senderHasLobbyCommandAdminPrivs(queue.index) && queue.index != player)
+	{
+		const char* msg = astringf("Admin %s changed faction of player [%d] %s to %d",
+			NetPlay.players[queue.index].name,
+			NetPlay.players[player].position,
+			NetPlay.players[player].name,
+			faction).c_str();
+		sendRoomSystemMessage(msg);
+		debug(LOG_INFO, "%s", msg);
 	}
 
 	resetReadyStatus(false, true);
@@ -2820,13 +2833,15 @@ bool recvColourRequest(NETQUEUE queue)
 		return false;
 	}
 
-	if (senderHasLobbyCommandAdminPrivs(queue.index))
+	if (senderHasLobbyCommandAdminPrivs(queue.index) && (queue.index != player))
 	{
-		sendRoomSystemMessage(astringf("Admin %s changed color of player [%d] %s to %d",
+		const char* msg = astringf("Admin %s changed color of player [%d] %s to %d",
 			NetPlay.players[queue.index].name,
 			NetPlay.players[player].position,
 			NetPlay.players[player].name,
-			col).c_str());
+			col).c_str();
+		sendRoomSystemMessage(msg);
+		debug(LOG_INFO, "%s", msg);
 	}
 
 	resetReadyStatus(false, true);
@@ -2859,18 +2874,20 @@ bool recvPositionRequest(NETQUEUE queue)
 		return false;
 	}
 
-	if (locked.position)
+	if (locked.position && !senderHasLobbyCommandAdminPrivs(queue.index))
 	{
 		return false;
 	}
 
-	if (senderHasLobbyCommandAdminPrivs(queue.index))
+	if (senderHasLobbyCommandAdminPrivs(queue.index) && (queue.index != player || (locked.position)))
 	{
-		sendRoomSystemMessage(astringf("Admin %s changed position of player [%d] %s to %d",
+		const char* msg = astringf("Admin %s changed position of player [%d] %s to %d",
 			NetPlay.players[queue.index].name,
 			NetPlay.players[player].position,
 			NetPlay.players[player].name,
-			position).c_str());
+			position).c_str();
+		sendRoomSystemMessage(msg);
+		debug(LOG_INFO, "%s", msg);
 	}
 
 	resetReadyStatus(false);

--- a/src/multiint.cpp
+++ b/src/multiint.cpp
@@ -2513,13 +2513,22 @@ bool recvTeamRequest(NETQUEUE queue)
 		return false;
 	}
 
-	if (whosResponsible(player) != queue.index)
+	if (whosResponsible(player) != queue.index && !senderHasLobbyCommandAdminPrivs(queue.index))
 	{
 		HandleBadParam("NET_TEAMREQUEST given incorrect params.", player, queue.index);
 		return false;
 	}
 
-	if (locked.teams)
+	if (senderHasLobbyCommandAdminPrivs(queue.index))
+	{
+		sendRoomSystemMessage(astringf("Admin %s changed team of player [%d] %s to %d",
+			NetPlay.players[queue.index].name,
+			NetPlay.players[player].position,
+			NetPlay.players[player].name,
+			team).c_str());
+	}
+
+	if (locked.teams && !senderHasLobbyCommandAdminPrivs(queue.index))
 	{
 		return false;
 	}
@@ -2805,10 +2814,19 @@ bool recvColourRequest(NETQUEUE queue)
 		return false;
 	}
 
-	if (whosResponsible(player) != queue.index)
+	if (whosResponsible(player) != queue.index && !senderHasLobbyCommandAdminPrivs(queue.index))
 	{
 		HandleBadParam("NET_COLOURREQUEST given incorrect params.", player, queue.index);
 		return false;
+	}
+
+	if (senderHasLobbyCommandAdminPrivs(queue.index))
+	{
+		sendRoomSystemMessage(astringf("Admin %s changed color of player [%d] %s to %d",
+			NetPlay.players[queue.index].name,
+			NetPlay.players[player].position,
+			NetPlay.players[player].name,
+			col).c_str());
 	}
 
 	resetReadyStatus(false, true);
@@ -2844,6 +2862,15 @@ bool recvPositionRequest(NETQUEUE queue)
 	if (locked.position)
 	{
 		return false;
+	}
+
+	if (senderHasLobbyCommandAdminPrivs(queue.index))
+	{
+		sendRoomSystemMessage(astringf("Admin %s changed position of player [%d] %s to %d",
+			NetPlay.players[queue.index].name,
+			NetPlay.players[player].position,
+			NetPlay.players[player].name,
+			position).c_str());
 	}
 
 	resetReadyStatus(false);
@@ -3269,7 +3296,7 @@ static SwapPlayerIndexesResult recvSwapPlayerIndexes(NETQUEUE queue, const std::
 
 static bool canChooseTeamFor(int i)
 {
-	return (i == selectedPlayer || NetPlay.isHost);
+	return (i == selectedPlayer || (NetPlay.isHost || NetPlay.isAdmin));
 }
 
 // ////////////////////////////////////////////////////////////////////////////

--- a/src/multiint.cpp
+++ b/src/multiint.cpp
@@ -2858,7 +2858,7 @@ bool recvColourRequest(NETQUEUE queue)
 
 	resetReadyStatus(false, true);
 
-	return changeColour(player, col, false);
+	return changeColour(player, col, senderHasLobbyCommandAdminPrivs(queue.index));
 }
 
 bool recvPositionRequest(NETQUEUE queue)

--- a/src/multiint.cpp
+++ b/src/multiint.cpp
@@ -2114,9 +2114,9 @@ void WzMultiplayerOptionsTitleUI::openTeamChooser(uint32_t player)
 
 	UDWORD i;
 	int disallow = allPlayersOnSameTeam(player);
-	if (bIsTrueMultiplayerGame && NetPlay.isHost)
+	if (bIsTrueMultiplayerGame && (NetPlay.isHost || NetPlay.isAdmin))
 	{
-		// allow configuration of all teams in true multiplayer mode (by host), even if they would block the game starting
+		// allow configuration of all teams in true multiplayer mode (by host/admin), even if they would block the game starting
 		// (i.e. even if all players would be configured to be on the same team)
 		disallow = -1;
 	}

--- a/src/multiint.cpp
+++ b/src/multiint.cpp
@@ -1448,8 +1448,8 @@ static void addGameOptions()
 
 static bool safeToUseColour(unsigned player, unsigned otherPlayer)
 {
-	// Player wants to take the colour from otherPlayer. May not take from a human otherPlayer, unless we're the host.
-	return player == otherPlayer || NetPlay.isHost || !isHumanPlayer(otherPlayer);
+	// Player wants to take the colour from otherPlayer. May not take from a human otherPlayer, unless we're the host/admin.
+	return player == otherPlayer || (NetPlay.isHost || NetPlay.isAdmin) || !isHumanPlayer(otherPlayer);
 }
 
 static int getPlayerTeam(int i)

--- a/src/multilobbycommands.cpp
+++ b/src/multilobbycommands.cpp
@@ -57,6 +57,13 @@ bool removeLobbyAdminPublicKey(const std::string& publicKeyB64Str)
 	return lobbyAdminPublicKeys.erase(publicKeyB64Str) > 0;
 }
 
+// checks for specific identity being an admin
+bool identityMatchesAdmin(const EcKey& identity) {
+	std::string senderIdentityHash = identity.publicHashString();
+	std::string senderPublicKeyB64 = base64Encode(identity.toBytes(EcKey::Public));
+	return lobbyAdminPublicKeys.count(senderPublicKeyB64) != 0 || lobbyAdminPublicHashStrings.count(senderIdentityHash) != 0;
+}
+
 // NOTE: **IMPORTANT** this should *NOT* be used for determining whether a sender has permission to execute admin commands
 // (Use senderHasLobbyCommandAdminPrivs instead)
 static bool senderApparentlyMatchesAdmin(uint32_t playerIdx)
@@ -86,7 +93,7 @@ static bool senderApparentlyMatchesAdmin(uint32_t playerIdx)
 }
 
 // **THIS** is the function that should be used to determine whether a sender currently has permission to execute admin commands
-static bool senderHasLobbyCommandAdminPrivs(uint32_t playerIdx)
+bool senderHasLobbyCommandAdminPrivs(uint32_t playerIdx)
 {
 	if (playerIdx >= MAX_CONNECTED_PLAYERS)
 	{

--- a/src/multilobbycommands.h
+++ b/src/multilobbycommands.h
@@ -52,6 +52,9 @@ void cmdInterfaceLogChatMsg(const NetworkTextMessage& message, const char* log_p
 
 bool processChatLobbySlashCommands(const NetworkTextMessage& message, HostLobbyOperationsInterface& cmdInterface);
 
+bool identityMatchesAdmin(const EcKey& identity);
+bool senderHasLobbyCommandAdminPrivs(uint32_t playerIdx);
+
 bool addLobbyAdminIdentityHash(const std::string& playerIdentityHash);
 bool removeLobbyAdminIdentityHash(const std::string& playerIdentityHash);
 

--- a/src/multiplay.cpp
+++ b/src/multiplay.cpp
@@ -1031,6 +1031,7 @@ HandleMessageAction getMessageHandlingAction(NETQUEUE& queue, uint8_t type)
 	}
 
 	bool senderIsSpectator = NetPlay.players[queue.index].isSpectator;
+	bool senderIsAdmin = senderHasLobbyCommandAdminPrivs(queue.index);
 
 	if (type > NET_MIN_TYPE && type < NET_MAX_TYPE)
 	{
@@ -1053,7 +1054,7 @@ HandleMessageAction getMessageHandlingAction(NETQUEUE& queue, uint8_t type)
 			case NET_BEACONMSG:
 			case NET_TEAMREQUEST: // spectators should not be allowed to request a team / non-spectator slot status
 			case NET_POSITIONREQUEST:
-				if (senderIsSpectator)
+				if (senderIsSpectator && !senderIsAdmin)
 				{
 					return HandleMessageAction::Disallow_And_Kick_Sender;
 				}

--- a/src/screens/joiningscreen.cpp
+++ b/src/screens/joiningscreen.cpp
@@ -1388,6 +1388,7 @@ void WzJoiningGameScreen_HandlerRoot::processJoining()
 			// Retrieve the player ID the game host arranged for us
 			NETuint8_t(&index);
 			NETuint32_t(&hostPlayer); // and the host player idx
+			NETbool(&NetPlay.isAdmin);
 			NETend();
 			NETpop(tmpJoiningQUEUE);
 


### PR DESCRIPTION
probably missing cleanup of NetPlay.isAdmin somewhere

Currently working:
- enables admin gui when you join with identity that is promoted to room admin
- allows swapping people around
- allows changing color of players
- allows changing team of players
- announces all the relevant actions performed by admins

TODO:
- make isAdmin dynamically change in response to admin add/remove on host (as well as identity swaps)
- action announce announcing regular not admin requiring actions like changing color of self or changing own positions to empty ones
- moving in/out of spec (needs to be allowed) (very cursed, needs big rework)
- room settings like alliance/scav/power/base needs to be allowed (needs new netmessages)
- room name change needs to be allowed (needs new netmessages)
- some button to trigger host quit (must be with a double click / with some key pressed or with confirm dialogue)