### PR TITLE
(MP)HVC -> 9 Range

### DIFF
--- a/data/mp/stats/weapons.json
+++ b/data/mp/stats/weapons.json
@@ -969,7 +969,7 @@
 		"hitpoints": 250,
 		"id": "Cannon4AUTOMk1",
 		"lightWorld": 1,
-		"longRange": 1280,
+		"longRange": 1152,
 		"longHit": 65,
 		"maxElevation": 90,
 		"minElevation": -60,


### PR DESCRIPTION
HVC is slightly faster than lancer(tested on the map Black at T2, hvc cobra half tracks vs lancer cobra halftracks), HVC has more HP than lancer (500 more on T2 start), HVC has more range than lancer, HVC has more DPM than lancer (976.5 per min vs 778.05).

HVC needs to be nerfed because the Lancer/MRA combo has no advantage vs it.