### PR TITLE
netsocket: socket operations return error codes via return values

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -74,3 +74,6 @@
 [submodule "lib/netplay/3rdparty/miniupnp"]
 	path = lib/netplay/3rdparty/miniupnp
 	url = https://github.com/miniupnp/miniupnp.git
+[submodule "3rdparty/expected"]
+	path = 3rdparty/expected
+	url = https://github.com/TartanLlama/expected.git

--- a/3rdparty/CMakeLists.txt
+++ b/3rdparty/CMakeLists.txt
@@ -277,3 +277,16 @@ if(NOT MSVC)
 		target_compile_options(plum-static PRIVATE ${_supported_libplum_c_compiler_flags})
 	endif()
 endif()
+
+set(EXPECTED_BUILD_TESTS OFF)
+add_subdirectory(expected EXCLUDE_FROM_ALL)
+# There isn't any release note or established CMake policy about this behavior,
+# but looks like prior to CMake 3.19 only a handful of `INTERFACE_*` properties
+# were allowed for INTERFACE libraries (which is our case). This restriction
+# seems to be lifted in CMake 3.19 and later.
+#
+# See https://discourse.cmake.org/t/how-to-find-current-interface-library-property-whitelist/4784/2
+# for some clarification about this.
+if (CMAKE_VERSION VERSION_GREATER "3.18")
+	set_target_properties(expected PROPERTIES FOLDER "3rdparty")
+endif()

--- a/COPYING.NONGPL
+++ b/COPYING.NONGPL
@@ -13,6 +13,8 @@ data/base/texpages/page-25-sky-urban.png
 	- MIT, Various Authors, See: https://github.com/HowardHinnant/date/blob/master/include/date/date.h
 3rdparty/discord-rpc/*
 	- MIT, Copyright 2017 Discord, Inc.
+3rdparty/expected/*
+	- CC0 1.0 Universal, Written in 2017 by Sy Brand (tartanllama@gmail.com, @TartanLlama)
 3rdparty/json/*
 	- MIT, Copyright (c) 2013-2018 Niels Lohmann <http://nlohmann.me>
 3rdparty/LRUCache11/*

--- a/lib/netplay/CMakeLists.txt
+++ b/lib/netplay/CMakeLists.txt
@@ -57,7 +57,9 @@ add_dependencies(netplay autorevision_netcodeversion)
 set_property(TARGET netplay PROPERTY FOLDER "lib")
 include(WZTargetConfiguration)
 WZ_TARGET_CONFIGURATION(netplay)
-target_link_libraries(netplay PRIVATE framework re2::re2 nlohmann_json plum-static Threads::Threads ZLIB::ZLIB)
+target_link_libraries(netplay
+	PRIVATE framework re2::re2 nlohmann_json plum-static Threads::Threads ZLIB::ZLIB
+	PUBLIC tl::expected)
 
 if(WZ_USE_IMPORTED_MINIUPNPC)
 	target_link_libraries(netplay PRIVATE imported-miniupnpc)

--- a/lib/netplay/error_categories.cpp
+++ b/lib/netplay/error_categories.cpp
@@ -1,0 +1,110 @@
+/*
+	This file is part of Warzone 2100.
+	Copyright (C) 2024  Warzone 2100 Project
+
+	Warzone 2100 is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+
+	Warzone 2100 is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with Warzone 2100; if not, write to the Free Software
+	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+
+#include "error_categories.h"
+
+#include "lib/framework/wzglobal.h"
+
+#ifdef WZ_OS_WIN
+# include <winerror.h>
+# include <ws2tcpip.h>
+#elif defined(WZ_OS_UNIX)
+# include <string.h>
+# include <netdb.h>
+#endif
+
+std::string GenericSystemErrorCategory::message(int ev) const
+{
+#if defined(WZ_OS_WIN)
+	switch (ev)
+	{
+	case 0:                     return "No error";
+	case WSAEINTR:              return "Interrupted system call";
+	case WSAEBADF:              return "Bad file number";
+	case WSAEACCES:             return "Permission denied";
+	case WSAEFAULT:             return "Bad address";
+	case WSAEINVAL:             return "Invalid argument";
+	case WSAEMFILE:             return "Too many open sockets";
+	case WSAEWOULDBLOCK:        return "Operation would block";
+	case WSAEINPROGRESS:        return "Operation now in progress";
+	case WSAEALREADY:           return "Operation already in progress";
+	case WSAENOTSOCK:           return "Socket operation on non-socket";
+	case WSAEDESTADDRREQ:       return "Destination address required";
+	case WSAEMSGSIZE:           return "Message too long";
+	case WSAEPROTOTYPE:         return "Protocol wrong type for socket";
+	case WSAENOPROTOOPT:        return "Bad protocol option";
+	case WSAEPROTONOSUPPORT:    return "Protocol not supported";
+	case WSAESOCKTNOSUPPORT:    return "Socket type not supported";
+	case WSAEOPNOTSUPP:         return "Operation not supported on socket";
+	case WSAEPFNOSUPPORT:       return "Protocol family not supported";
+	case WSAEAFNOSUPPORT:       return "Address family not supported";
+	case WSAEADDRINUSE:         return "Address already in use";
+	case WSAEADDRNOTAVAIL:      return "Can't assign requested address";
+	case WSAENETDOWN:           return "Network is down";
+	case WSAENETUNREACH:        return "Network is unreachable";
+	case WSAENETRESET:          return "Net connection reset";
+	case WSAECONNABORTED:       return "Software caused connection abort";
+	case WSAECONNRESET:         return "Connection reset by peer";
+	case WSAENOBUFS:            return "No buffer space available";
+	case WSAEISCONN:            return "Socket is already connected";
+	case WSAENOTCONN:           return "Socket is not connected";
+	case WSAESHUTDOWN:          return "Can't send after socket shutdown";
+	case WSAETOOMANYREFS:       return "Too many references, can't splice";
+	case WSAETIMEDOUT:          return "Connection timed out";
+	case WSAECONNREFUSED:       return "Connection refused";
+	case WSAELOOP:              return "Too many levels of symbolic links";
+	case WSAENAMETOOLONG:       return "File name too long";
+	case WSAEHOSTDOWN:          return "Host is down";
+	case WSAEHOSTUNREACH:       return "No route to host";
+	case WSAENOTEMPTY:          return "Directory not empty";
+	case WSAEPROCLIM:           return "Too many processes";
+	case WSAEUSERS:             return "Too many users";
+	case WSAEDQUOT:             return "Disc quota exceeded";
+	case WSAESTALE:             return "Stale NFS file handle";
+	case WSAEREMOTE:            return "Too many levels of remote in path";
+	case WSASYSNOTREADY:        return "Network system is unavailable";
+	case WSAVERNOTSUPPORTED:    return "Winsock version out of range";
+	case WSANOTINITIALISED:     return "WSAStartup not yet called";
+	case WSAEDISCON:            return "Graceful shutdown in progress";
+	case WSAHOST_NOT_FOUND:     return "Host not found";
+	case WSANO_DATA:            return "No host data of that type was found";
+	default:                    return "Unknown error";
+	}
+#elif defined(WZ_OS_UNIX)
+	return strerror(ev);
+#endif
+}
+
+std::error_condition GenericSystemErrorCategory::default_error_condition(int ev) const noexcept
+{
+	// Try to map the raw error values either to POSIX or Windows error codes (depending on the OS).
+	// The default system category should capture them all well.
+	return std::system_category().default_error_condition(ev);
+}
+
+const std::error_category& generic_system_error_category()
+{
+	static GenericSystemErrorCategory instance;
+	return instance;
+}
+
+std::error_code make_network_error_code(int ev)
+{
+	return { ev, generic_system_error_category() };
+}

--- a/lib/netplay/error_categories.cpp
+++ b/lib/netplay/error_categories.cpp
@@ -98,13 +98,29 @@ std::error_condition GenericSystemErrorCategory::default_error_condition(int ev)
 	return std::system_category().default_error_condition(ev);
 }
 
+std::string GetaddrinfoErrorCategory::message(int ev) const
+{
+	return gai_strerror(ev);
+}
+
 const std::error_category& generic_system_error_category()
 {
 	static GenericSystemErrorCategory instance;
 	return instance;
 }
 
+const std::error_category& getaddrinfo_error_category()
+{
+	static GetaddrinfoErrorCategory instance;
+	return instance;
+}
+
 std::error_code make_network_error_code(int ev)
 {
 	return { ev, generic_system_error_category() };
+}
+
+std::error_code make_getaddrinfo_error_code(int ev)
+{
+	return { ev, getaddrinfo_error_category() };
 }

--- a/lib/netplay/error_categories.cpp
+++ b/lib/netplay/error_categories.cpp
@@ -29,6 +29,8 @@
 # include <netdb.h>
 #endif
 
+#include <zlib.h>
+
 std::string GenericSystemErrorCategory::message(int ev) const
 {
 #if defined(WZ_OS_WIN)
@@ -103,6 +105,23 @@ std::string GetaddrinfoErrorCategory::message(int ev) const
 	return gai_strerror(ev);
 }
 
+std::string ZlibErrorCategory::message(int ev) const
+{
+	switch (ev)
+	{
+	case Z_STREAM_ERROR:
+		return "Z_STREAM_ERROR";
+	case Z_NEED_DICT:
+		return "Z_NEED_DICT";
+	case Z_DATA_ERROR:
+		return "Z_DATA_ERROR";
+	case Z_MEM_ERROR:
+		return "Z_MEM_ERROR";
+	default:
+		return "Unknown zlib error";
+	}
+}
+
 const std::error_category& generic_system_error_category()
 {
 	static GenericSystemErrorCategory instance;
@@ -115,6 +134,12 @@ const std::error_category& getaddrinfo_error_category()
 	return instance;
 }
 
+const std::error_category& zlib_error_category()
+{
+	static ZlibErrorCategory instance;
+	return instance;
+}
+
 std::error_code make_network_error_code(int ev)
 {
 	return { ev, generic_system_error_category() };
@@ -123,4 +148,9 @@ std::error_code make_network_error_code(int ev)
 std::error_code make_getaddrinfo_error_code(int ev)
 {
 	return { ev, getaddrinfo_error_category() };
+}
+
+std::error_code make_zlib_error_code(int ev)
+{
+	return { ev, zlib_error_category() };
 }

--- a/lib/netplay/error_categories.h
+++ b/lib/netplay/error_categories.h
@@ -65,8 +65,28 @@ public:
 	std::string message(int ev) const override;
 };
 
+/// <summary>
+/// Custom error category which maps some of the error codes from zlib to
+/// the appropriate error messages.
+/// </summary>
+class ZlibErrorCategory : public std::error_category
+{
+public:
+
+	constexpr ZlibErrorCategory() = default;
+
+	const char* name() const noexcept override
+	{
+		return "zlib";
+	}
+
+	std::string message(int ev) const override;
+};
+
 const std::error_category& generic_system_error_category();
 const std::error_category& getaddrinfo_error_category();
+const std::error_category& zlib_error_category();
 
 std::error_code make_network_error_code(int ev);
 std::error_code make_getaddrinfo_error_code(int ev);
+std::error_code make_zlib_error_code(int ev);

--- a/lib/netplay/error_categories.h
+++ b/lib/netplay/error_categories.h
@@ -1,0 +1,52 @@
+/*
+	This file is part of Warzone 2100.
+	Copyright (C) 2024  Warzone 2100 Project
+	Warzone 2100 is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+	Warzone 2100 is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU General Public License for more details.
+	You should have received a copy of the GNU General Public License
+	along with Warzone 2100; if not, write to the Free Software
+	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+
+#pragma once
+
+#include <string>
+#include <system_error>
+
+/// <summary>
+/// Custom error category class, which acts exactly as `std::system_category()` except
+/// that the error messages are always translated to english representation (locale-agnostic behavior).
+///
+/// Please see the bug https://github.com/microsoft/STL/issues/3254 for the explanation
+/// as to why we would need to use a custom error category (at least on Windows).
+/// </summary.
+class GenericSystemErrorCategory : public std::error_category
+{
+public:
+
+	constexpr GenericSystemErrorCategory() = default;
+
+	const char* name() const noexcept override
+	{
+		return "generic system (locale-safe)";
+	}
+
+	/// This method provides locale-agnostic mapping from the underlying POSIX (or Windows)
+	/// error codes to the human-readable error message strings.
+	std::string message(int ev) const override;
+	/// This method overload is needed to support the comparison of `std::error_code:s`
+	/// bound to our custom `GenericSystemErrorCategory` to the values
+	/// of `std::errc` enumeration (which transparently map to `std::error_condition:s`
+	/// bound to the `std::system_category()`).
+	std::error_condition default_error_condition(int ev) const noexcept override;
+};
+
+const std::error_category& generic_system_error_category();
+
+std::error_code make_network_error_code(int ev);

--- a/lib/netplay/error_categories.h
+++ b/lib/netplay/error_categories.h
@@ -47,6 +47,26 @@ public:
 	std::error_condition default_error_condition(int ev) const noexcept override;
 };
 
+/// <summary>
+/// Custom error category which maps error codes from `getaddrinfo()` function to
+/// the appropriate error messages.
+/// </summary>
+class GetaddrinfoErrorCategory : public std::error_category
+{
+public:
+
+	constexpr GetaddrinfoErrorCategory() = default;
+
+	const char* name() const noexcept override
+	{
+		return "getaddrinfo";
+	}
+
+	std::string message(int ev) const override;
+};
+
 const std::error_category& generic_system_error_category();
+const std::error_category& getaddrinfo_error_category();
 
 std::error_code make_network_error_code(int ev);
+std::error_code make_getaddrinfo_error_code(int ev);

--- a/lib/netplay/netplay.cpp
+++ b/lib/netplay/netplay.cpp
@@ -4504,11 +4504,6 @@ bool NEThostGame(const char *SessionName, const char *PlayerName, bool spectator
 	{
 		server_socket_set = allocSocketSet();
 	}
-	if (server_socket_set == nullptr)
-	{
-		debug(LOG_ERROR, "Cannot create socket set: %s", strSockError(getSockErr()));
-		return false;
-	}
 	// allocate socket storage for all possible players
 	for (unsigned i = 0; i < MAX_CONNECTED_PLAYERS; ++i)
 	{
@@ -5102,11 +5097,6 @@ void NETacceptIncomingConnections()
 		// initialize temporary server socket set
 		// FIXME: why is this not done in NETinit()?? - Per
 		tmp_socket_set = allocSocketSet();
-		if (tmp_socket_set == nullptr)
-		{
-			debug(LOG_ERROR, "Cannot create socket set: %s", strSockError(getSockErr()));
-			return;
-		}
 		// FIXME: I guess initialization of allowjoining is here now... - FlexCoral
 		for (auto& tmpState : tmp_connectState)
 		{

--- a/lib/netplay/netsocket.cpp
+++ b/lib/netplay/netsocket.cpp
@@ -1391,12 +1391,6 @@ Socket *socketListen(unsigned int port)
 	unsigned int i;
 
 	Socket *const conn = new Socket;
-	if (conn == nullptr)
-	{
-		debug(LOG_ERROR, "Out of memory!");
-		abort();
-		return nullptr;
-	}
 
 	// Mark all unused socket handles as invalid
 	for (i = 0; i < ARRAY_SIZE(conn->fd); ++i)

--- a/lib/netplay/netsocket.h
+++ b/lib/netplay/netsocket.h
@@ -23,7 +23,16 @@
 
 #include "lib/framework/types.h"
 #include <string>
+#include <system_error>
 #include <vector>
+
+#include <tl/expected.hpp>
+
+namespace net
+{
+	template <typename T>
+	using result = ::tl::expected<T, std::error_code>;
+} // namespace net
 
 #if   defined(WZ_OS_UNIX)
 # include <arpa/inet.h>


### PR DESCRIPTION
Switch to returning socket error codes explicitly via return values instead of using legacy functions `getSockErr()`, `setSockErr`, `strSockError()` to get extended error context.

To facilitate that, use `tl::expected<T, std::error_code>` as the return value type for all main socket operations: read, write, open, listen.

Moving to this new approach has numerous benefits over the old one:

1. Instead of using POSIX constants directly, we wrap them into `std::error_code` instances, which allows to attach custom error categories to them. This can be used to customize error messages and error codes mapping to platform-independent `std::error_conditions`.
2. Calling separate `get/setSockErr()` functions is error-prone: one can easily forget to check the error condition from `getSockErr()` and the value will be overwritten by the next socket function without the ability to recover the former error.

   Conversely, one can forget to call `setSockErr()` to set the proper error code for the caller to check upon.
3. As mentioned above, `std::error_code:s` can be implicitly mapped to platform-independent `std::error_conditions`, allowing for this code to compile successfuly:
   ```c++
       if (errCode == std::errc::connection_reset) { ... }
   ```
   This allows for very convenient and portable error checking code, which completely hides implementation details of how a particular error code is implemented (but, if one really needs to, they still can extract the platform-dependent error code value to get the extended error context).

The `getSockErr()`, `setSockErr` and `strSockError()` functions are still used in the `netsocket.cpp` implementation, but now they are strictly confined to this particular translation unit, meaning they have now become an implementation detail, rather than a part of public API contract of `netplay` library.

Signed-off-by: Pavel Solodovnikov <pavel.al.solodovnikov@gmail.com>