### PR TITLE
Do not remove vision from transporters when loading saves

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -5630,7 +5630,10 @@ static bool loadSaveDroid(const char *pFileName, PerPlayerDroidLists& ppsCurrent
 			if (psGroup->type == GT_TRANSPORTER)
 			{
 				psDroid->selected = false;  // Droid should be visible in the transporter interface.
-				visRemoveVisibility(psDroid); // should not have visibility data when in a transporter
+				if (!psDroid->isTransporter())
+				{
+					visRemoveVisibility(psDroid); // should not have visibility data when in a transporter
+				}
 			}
 		}
 		else


### PR DESCRIPTION
No point in removing vision from the transporter itself, as the intent was to do this for droids inside one. Very easy to see this bug by using debug mode to send a transporter to an unexplored area on a skirmish map. And yes, this happens in campaign too albeit not so noticeable.

There is still another vision issue related to transporters not fixed by this PR: when a transporter is away on an offworld mission, the spot where it left the map will be lit up after saveload for a brief moment. Acting as if it were centered around that spot.