### PR TITLE
netsocket: remove unused `socketReadDisconnected()` function

### DIFF
--- a/lib/netplay/error_categories.h
+++ b/lib/netplay/error_categories.h
@@ -25,6 +25,11 @@
 ///
 /// Please see the bug https://github.com/microsoft/STL/issues/3254 for the explanation
 /// as to why we would need to use a custom error category (at least on Windows).
+///
+/// NOTE: Currently, for OSes other than Windows, error messages are obtained via
+/// `strerror()` function, which is influenced by the `LC_MESSAGES` locale category.
+/// This shouldn't be a problem, though, as opposed to Windows, which suffers from the
+/// aforementioned bug in MSVC STL.
 /// </summary.
 class GenericSystemErrorCategory : public std::error_category
 {

--- a/lib/netplay/netsocket.cpp
+++ b/lib/netplay/netsocket.cpp
@@ -632,11 +632,6 @@ net::result<ssize_t> readNoInt(Socket& sock, void *buf, size_t max_size, size_t 
 	return received;
 }
 
-bool socketReadDisconnected(const Socket& sock)
-{
-	return sock.readDisconnected;
-}
-
 /**
  * Similar to write(2) with the exception that this function will block until
  * <em>all</em> data has been written or an error occurs.

--- a/lib/netplay/netsocket.h
+++ b/lib/netplay/netsocket.h
@@ -124,7 +124,6 @@ bool socketSetTCPNoDelay(Socket& sock, bool nodelay); ///< nodelay = true disabl
 
 // Sockets, compressed.
 void socketBeginCompression(Socket& sock); ///< Makes future data sent compressed, and future data received expected to be compressed.
-bool socketReadDisconnected(const Socket& sock);  ///< If readNoInt returned 0, returns true if this is the result of a disconnect, or false if the input compressed data just hasn't produced any output bytes.
 void socketFlush(Socket& sock, uint8_t player, size_t *rawByteCount = nullptr); ///< Actually sends the data written with writeAll. Only useful on compressed sockets. Note that flushing too often makes compression less effective. Raw count of bytes (after compression) returned in rawByteCount.
 
 // Socket sets.


### PR DESCRIPTION
Signed-off-by: Pavel Solodovnikov <pavel.al.solodovnikov@gmail.com>