### PR TITLE
Add campaign HQs to Multiplayer stats

### DIFF
--- a/data/mp/stats/structure.json
+++ b/data/mp/stats/structure.json
@@ -394,6 +394,69 @@
 		"type": "HQ",
 		"width": 2
 	},
+	"A0CommandCentreCO": {
+		"armour": 10,
+		"baseModel": "blbhq.pie",
+		"breadth": 2,
+		"buildPoints": 500,
+		"buildPower": 100,
+		"ecmID": "ZNULLECM",
+		"height": 3,
+		"hitpoints": 1000,
+		"id": "A0CommandCentreCO",
+		"name": "Collective Command Center",
+		"resistance": 300,
+		"sensorID": "CCSensor",
+		"strength": "HARD",
+		"structureModel": [
+			"blhq3.pie"
+		],
+		"thermal": 10,
+		"type": "HQ",
+		"width": 2
+	},
+	"A0CommandCentreNE": {
+		"armour": 10,
+		"baseModel": "blbhq.pie",
+		"breadth": 2,
+		"buildPoints": 500,
+		"buildPower": 100,
+		"ecmID": "ZNULLECM",
+		"height": 3,
+		"hitpoints": 1000,
+		"id": "A0CommandCentreNE",
+		"name": "*CommandCenterNE*",
+		"resistance": 300,
+		"sensorID": "CCSensor",
+		"strength": "HARD",
+		"structureModel": [
+			"blhq4.pie"
+		],
+		"thermal": 10,
+		"type": "HQ",
+		"width": 2
+	},
+	"A0CommandCentreNP": {
+		"armour": 10,
+		"baseModel": "blbhq.pie",
+		"breadth": 2,
+		"buildPoints": 500,
+		"buildPower": 100,
+		"ecmID": "ZNULLECM",
+		"height": 3,
+		"hitpoints": 1000,
+		"id": "A0CommandCentreNP",
+		"name": "New Paradigm Command Center",
+		"resistance": 300,
+		"sensorID": "CCSensor",
+		"strength": "HARD",
+		"structureModel": [
+			"blhq2.pie"
+		],
+		"thermal": 10,
+		"type": "HQ",
+		"width": 2
+	},
 	"A0CyborgFactory": {
 		"armour": 10,
 		"baseModel": "blbcfact.pie",

--- a/doc/BriefAndProximityFormat.md
+++ b/doc/BriefAndProximityFormat.md
@@ -44,5 +44,5 @@ Within each sequence, there will be two values:
 - name: The unique view data name ID. This will be used as a reference for scripts to invoke to start a video subset.
 - sequences: an array of objects (order matters!) containing variables about each sub-video:
   - loop: An integer between 0-1 to loop the entire video until its audio stops playing. Will always display subtitles every frame if set to 1.
-  - subtitles: Either a string or array of string translation references that will be used in this video.
+  - subtitles: String or array of string translation references for the video. These are added to the Intel menu icon text messages.
   - video: The actual video file to display. Note the directory starts at "data/[base|mp]/sequences/".


### PR DESCRIPTION
Includes the New Paradigm, Collective, and NEXUS HQs into the MP structure stats for maps that may include them.