### PR TITLE
Support for admins performing host-only actions via UI

### DIFF
--- a/lib/netplay/netplay.cpp
+++ b/lib/netplay/netplay.cpp
@@ -33,6 +33,7 @@
 #include "src/console.h"
 #include "src/component.h"		// FIXME: we need to handle this better
 #include "src/modding.h"		// FIXME: we need to handle this better
+#include "src/multilobbycommands.h"
 
 #include <time.h>			// for stats
 #include <physfs.h>
@@ -668,6 +669,7 @@ void NET_InitPlayer(uint32_t i, bool initPosition, bool initTeams, bool initSpec
 	{
 		NetPlay.players[i].isSpectator = false;
 	}
+	NetPlay.players[i].isAdmin = false;
 }
 
 uint8_t NET_numHumanPlayers(void)
@@ -736,6 +738,7 @@ static void NETSendNPlayerInfoTo(uint32_t *index, uint32_t indexLen, unsigned to
 		NETint8_t(reinterpret_cast<int8_t*>(&NetPlay.players[index[n]].difficulty));
 		NETuint8_t(reinterpret_cast<uint8_t *>(&NetPlay.players[index[n]].faction));
 		NETbool(&NetPlay.players[index[n]].isSpectator);
+		NETbool(&NetPlay.players[index[n]].isAdmin);
 	}
 	NETend();
 	ActivityManager::instance().updateMultiplayGameData(game, ingame, NETGameIsLocked());
@@ -2533,6 +2536,7 @@ static bool NETprocessSystemMessage(NETQUEUE playerQueue, uint8_t *type)
 			int8_t difficulty = 0;
 			uint8_t faction = FACTION_NORMAL;
 			bool isSpectator = false;
+			bool isAdmin = false;
 			bool error = false;
 
 			NETbeginDecode(playerQueue, NET_PLAYER_INFO);
@@ -2577,6 +2581,7 @@ static bool NETprocessSystemMessage(NETQUEUE playerQueue, uint8_t *type)
 				NETint8_t(&difficulty);
 				NETuint8_t(&faction);
 				NETbool(&isSpectator);
+				NETbool(&isAdmin);
 
 				auto newFactionId = uintToFactionID(faction);
 				if (!newFactionId.has_value())
@@ -2596,6 +2601,7 @@ static bool NETprocessSystemMessage(NETQUEUE playerQueue, uint8_t *type)
 					NetPlay.players[index].difficulty = static_cast<AIDifficulty>(difficulty);
 					NetPlay.players[index].faction = newFactionId.value();
 					NetPlay.players[index].isSpectator = isSpectator;
+					NetPlay.players[index].isAdmin = isAdmin;
 				}
 
 				debug(LOG_NET, "%s for player %u (%s)", n == 0 ? "Receiving MSG_PLAYER_INFO" : "                      and", (unsigned int)index, NetPlay.players[index].allocated ? "human" : "AI");

--- a/lib/netplay/netplay.cpp
+++ b/lib/netplay/netplay.cpp
@@ -4483,7 +4483,7 @@ bool NEThostGame(const char *SessionName, const char *PlayerName, bool spectator
 		// Now switch player color of the host to what they normally use for MP games
 		if (war_getMPcolour() >= 0)
 		{
-			changeColour(NetPlay.hostPlayer, war_getMPcolour(), true);
+			changeColour(NetPlay.hostPlayer, war_getMPcolour(), realSelectedPlayer);
 		}
 		return true;
 	}
@@ -4541,7 +4541,7 @@ bool NEThostGame(const char *SessionName, const char *PlayerName, bool spectator
 	// Now switch player color of the host to what they normally use for SP games
 	if (NetPlay.hostPlayer < MAX_PLAYERS && war_getMPcolour() >= 0)
 	{
-		changeColour(NetPlay.hostPlayer, war_getMPcolour(), true);
+		changeColour(NetPlay.hostPlayer, war_getMPcolour(), realSelectedPlayer);
 	}
 
 	NETregisterServer(WZ_SERVER_DISCONNECT);

--- a/lib/netplay/netplay.h
+++ b/lib/netplay/netplay.h
@@ -275,6 +275,7 @@ struct PLAYER
 	bool                autoGame;           ///< if we are running a autogame (AI controls us)
 	FactionID			faction;			///< which faction the player has
 	bool				isSpectator;		///< whether this slot is a spectator slot
+	bool				isAdmin;			///< whether this slot has admin privs
 
 	// used on host-ONLY (not transmitted to other clients):
 	std::shared_ptr<std::vector<WZFile>> wzFiles = std::make_shared<std::vector<WZFile>>();            ///< for each player, we keep track of map/mod download progress
@@ -302,6 +303,7 @@ struct PLAYER
 		IPtextAddress[0] = '\0';
 		faction = FACTION_NORMAL;
 		isSpectator = false;
+		isAdmin = false;
 	}
 };
 

--- a/src/hci/quickchat.h
+++ b/src/hci/quickchat.h
@@ -105,11 +105,12 @@
 	/* FROM THIS POINT ON - ONLY INTERNAL MESSAGES! */ \
 	/* WZ-generated internal messages - not for users to deliberately send */ \
 	MSG(INTERNAL_MSG_DELIVERY_FAILURE_TRY_AGAIN) /* This should always be the first internal message! */ \
-	MSG(INTERNAL_LOBBY_NOTICE_MAP_DOWNLOADED)
+	MSG(INTERNAL_LOBBY_NOTICE_MAP_DOWNLOADED) \
+	MSG(INTERNAL_ADMIN_ACTION_NOTICE)
 
 #define GENERATE_ENUM(ENUM) ENUM,
 
-enum class WzQuickChatMessage : uint32_t 
+enum class WzQuickChatMessage : uint32_t
 {
 	FOREACH_QUICKCHATMSG(GENERATE_ENUM)
 	// Always last
@@ -145,14 +146,42 @@ struct WzQuickChatTargeting
 	std::unordered_set<uint32_t> specificPlayers;
 
 public:
+	static WzQuickChatTargeting targetAll();
+
+public:
 	void reset();
 	bool noTargets() const;
 };
+
+struct WzQuickChatMessageData
+{
+	uint32_t dataContext = 0;
+	uint32_t dataA = 0;
+	uint32_t dataB = 0;
+};
+
+// Begin: DataContext Enums for specific messages
+namespace WzQuickChatDataContexts {
+
+// - INTERNAL_ADMIN_ACTION_NOTICE
+namespace INTERNAL_ADMIN_ACTION_NOTICE {
+	enum class Context : uint32_t
+	{
+		Invalid = 0,
+		Team,
+		Position,
+		Color,
+		Faction
+	};
+	WzQuickChatMessageData constructMessageData(Context ctx, uint32_t responsiblePlayerIdx, uint32_t targetPlayerIdx);
+} // namespace INTERNAL_ADMIN_ACTION_NOTICE
+
+} // namespace WzQuickChatDataContexts
 
 std::shared_ptr<W_FORM> createQuickChatForm(WzQuickChatContext context, const std::function<void ()>& onQuickChatSent, optional<WzQuickChatMode> startingPanel = nullopt);
 
 void quickChatInitInGame();
 
 struct NETQUEUE;
-void sendQuickChat(WzQuickChatMessage message, uint32_t fromPlayer, WzQuickChatTargeting targeting);
+void sendQuickChat(WzQuickChatMessage message, uint32_t fromPlayer, WzQuickChatTargeting targeting, optional<WzQuickChatMessageData> messageData = nullopt);
 bool recvQuickChat(NETQUEUE queue);

--- a/src/multiint.h
+++ b/src/multiint.h
@@ -85,7 +85,7 @@ std::shared_ptr<W_BUTTON> addMultiBut(const std::shared_ptr<W_SCREEN> &screen, U
 std::shared_ptr<WzMultiButton> makeMultiBut(UDWORD id, UDWORD width, UDWORD height, const char *tipres, UDWORD norm, UDWORD down, UDWORD hi, unsigned tc, uint8_t alpha = 255);
 
 AtlasImage mpwidgetGetFrontHighlightImage(AtlasImage image);
-bool changeColour(unsigned player, int col, bool isHost);
+bool changeColour(unsigned player, int col, uint32_t responsibleIdx);
 
 extern char sPlayer[128];
 extern bool multiintDisableLobbyRefresh; // gamefind

--- a/src/multilobbycommands.cpp
+++ b/src/multilobbycommands.cpp
@@ -295,7 +295,7 @@ bool processChatLobbySlashCommands(const NetworkTextMessage& message, HostLobbyO
 			sendRoomNotifyMessage("Usage: " LOBBY_COMMAND_PREFIX "team <slot> <team>");
 			return false;
 		}
-		if (!cmdInterface.changeTeam(posToNetPlayer(s1), s2))
+		if (!cmdInterface.changeTeam(posToNetPlayer(s1), s2, message.sender))
 		{
 			std::string msg = astringf("Unable to change player %u team to %u", s1, s2);
 			sendRoomNotifyMessage(msg.c_str());
@@ -387,7 +387,7 @@ bool processChatLobbySlashCommands(const NetworkTextMessage& message, HostLobbyO
 			return false;
 		}
 
-		if (!cmdInterface.changePosition(playerIdxA, s2))
+		if (!cmdInterface.changePosition(playerIdxA, s2, message.sender))
 		{
 			std::string msg = astringf("Unable to swap players %" PRIu8 " and %" PRIu8, s1, s2);
 			sendRoomNotifyMessage(msg.c_str());
@@ -554,7 +554,7 @@ bool processChatLobbySlashCommands(const NetworkTextMessage& message, HostLobbyO
 			sendRoomSystemMessage("Autobalance is available only for even player count.");
 			return false;
 		}
-		if (!cmdInterface.autoBalancePlayers())
+		if (!cmdInterface.autoBalancePlayers(message.sender))
 		{
 			// failure message logged by autoBalancePlayers()
 			return false;

--- a/src/multilobbycommands.cpp
+++ b/src/multilobbycommands.cpp
@@ -57,6 +57,14 @@ bool removeLobbyAdminPublicKey(const std::string& publicKeyB64Str)
 	return lobbyAdminPublicKeys.erase(publicKeyB64Str) > 0;
 }
 
+// checks for specific identity being an admin
+bool identityMatchesAdmin(const EcKey& identity)
+{
+	std::string senderIdentityHash = identity.publicHashString();
+	std::string senderPublicKeyB64 = base64Encode(identity.toBytes(EcKey::Public));
+	return lobbyAdminPublicKeys.count(senderPublicKeyB64) != 0 || lobbyAdminPublicHashStrings.count(senderIdentityHash) != 0;
+}
+
 // NOTE: **IMPORTANT** this should *NOT* be used for determining whether a sender has permission to execute admin commands
 // (Use senderHasLobbyCommandAdminPrivs instead)
 static bool senderApparentlyMatchesAdmin(uint32_t playerIdx)
@@ -75,14 +83,7 @@ static bool senderApparentlyMatchesAdmin(uint32_t playerIdx)
 	{
 		return false;
 	}
-	std::string senderIdentityHash = identity.publicHashString();
-	std::string senderPublicKeyB64 = base64Encode(identity.toBytes(EcKey::Public));
-	if (lobbyAdminPublicKeys.count(senderPublicKeyB64) == 0 && lobbyAdminPublicHashStrings.count(senderIdentityHash) == 0)
-	{
-		return false; // identity hash is not in permitted lists
-	}
-
-	return true;
+	return identityMatchesAdmin(identity);
 }
 
 // **THIS** is the function that should be used to determine whether a sender currently has permission to execute admin commands

--- a/src/multilobbycommands.h
+++ b/src/multilobbycommands.h
@@ -52,6 +52,8 @@ void cmdInterfaceLogChatMsg(const NetworkTextMessage& message, const char* log_p
 
 bool processChatLobbySlashCommands(const NetworkTextMessage& message, HostLobbyOperationsInterface& cmdInterface);
 
+bool identityMatchesAdmin(const EcKey& identity);
+
 bool addLobbyAdminIdentityHash(const std::string& playerIdentityHash);
 bool removeLobbyAdminIdentityHash(const std::string& playerIdentityHash);
 

--- a/src/multilobbycommands.h
+++ b/src/multilobbycommands.h
@@ -35,8 +35,8 @@ public:
 	virtual ~HostLobbyOperationsInterface();
 
 public:
-	virtual bool changeTeam(uint32_t player, uint8_t team) = 0;
-	virtual bool changePosition(uint32_t player, uint8_t position) = 0;
+	virtual bool changeTeam(uint32_t player, uint8_t team, uint32_t responsibleIdx) = 0;
+	virtual bool changePosition(uint32_t player, uint8_t position, uint32_t responsibleIdx) = 0;
 	virtual bool changeBase(uint8_t baseValue) = 0;
 	virtual bool changeAlliances(uint8_t allianceValue) = 0;
 	virtual bool changeScavengers(uint8_t scavsValue) = 0;
@@ -44,7 +44,7 @@ public:
 	virtual bool changeHostChatPermissions(uint32_t player_id, bool freeChatEnabled) = 0;
 	virtual bool movePlayerToSpectators(uint32_t player_id) = 0;
 	virtual bool requestMoveSpectatorToPlayers(uint32_t player_id) = 0;
-	virtual bool autoBalancePlayers() = 0;
+	virtual bool autoBalancePlayers(uint32_t responsibleIdx) = 0;
 	virtual void quitGame(int exitCode) = 0;
 };
 

--- a/src/multiplay.cpp
+++ b/src/multiplay.cpp
@@ -1031,6 +1031,7 @@ HandleMessageAction getMessageHandlingAction(NETQUEUE& queue, uint8_t type)
 	}
 
 	bool senderIsSpectator = NetPlay.players[queue.index].isSpectator;
+	bool senderIsAdmin = NetPlay.players[queue.index].isAdmin;
 
 	if (type > NET_MIN_TYPE && type < NET_MAX_TYPE)
 	{
@@ -1049,10 +1050,16 @@ HandleMessageAction getMessageHandlingAction(NETQUEUE& queue, uint8_t type)
 				}
 				break;
 			case NET_KICK:
+			case NET_TEAMREQUEST: // spectators should not be allowed to request a team / non-spectator slot status
+			case NET_FACTIONREQUEST:
+			case NET_POSITIONREQUEST:
+				if (senderIsSpectator && !senderIsAdmin)
+				{
+					return HandleMessageAction::Disallow_And_Kick_Sender;
+				}
+				break;
 			case NET_AITEXTMSG:
 			case NET_BEACONMSG:
-			case NET_TEAMREQUEST: // spectators should not be allowed to request a team / non-spectator slot status
-			case NET_POSITIONREQUEST:
 				if (senderIsSpectator)
 				{
 					return HandleMessageAction::Disallow_And_Kick_Sender;

--- a/src/multisync.cpp
+++ b/src/multisync.cpp
@@ -38,6 +38,7 @@
 #include "multistat.h"
 #include "multirecv.h"
 #include "stdinreader.h"
+#include "multilobbycommands.h"
 
 #include <array>
 
@@ -329,6 +330,18 @@ bool recvPing(NETQUEUE queue)
 		{
 			// Record that they've verified the identity
 			ingame.VerifiedIdentity[sender] = true;
+
+			if (NetPlay.isHost)
+			{
+				// check if verified identity is an admin, and handle changes to admin status
+				bool oldIsAdminStatus = NetPlay.players[sender].isAdmin;
+				NetPlay.players[sender].isAdmin = identityMatchesAdmin(senderIdentity);
+				if (oldIsAdminStatus != NetPlay.players[sender].isAdmin)
+				{
+					// then send info about admin status changes to all players
+					NETBroadcastPlayerInfo(sender);
+				}
+			}
 
 			// Output to stdinterface, if enabled
 			std::string senderPublicKeyB64 = base64Encode(senderIdentity.toBytes(EcKey::Public));


### PR DESCRIPTION
Supersedes #4084

Rewritten to use a player-level admin status flag, refactored sanity and success checks, and quick-chat based localized admin action messages

Initial support for admin modification of: team, position, color, faction (via UI, just as a host would).