### PR TITLE
Fixed wall gate flickering when in construction state

### DIFF
--- a/src/hci.cpp
+++ b/src/hci.cpp
@@ -1714,7 +1714,6 @@ INT_RETVAL intRunWidgets()
 
 						if (psBuilding->type == REF_DEMOLISH)
 						{
-							STRUCTURE tmp(0, selectedPlayer);
 							MAPTILE *psTile = mapTile(map_coord(pos.x), map_coord(pos.y));
 							FEATURE *psFeature = (FEATURE *)psTile->psObject;
 							STRUCTURE *psStructure = (STRUCTURE *)psTile->psObject;
@@ -1733,6 +1732,7 @@ INT_RETVAL intRunWidgets()
 						{
 							STRUCTURE tmp(generateNewObjectId(), selectedPlayer);
 							STRUCTURE *psStructure = &tmp;
+							tmp.state = SAS_NORMAL;
 							tmp.pStructureType = (STRUCTURE_STATS *)psPositionStats;
 							tmp.pos = {pos.x, pos.y, map_Height(pos.x, pos.y) + world_coord(1) / 10};
 

--- a/src/structure.cpp
+++ b/src/structure.cpp
@@ -1971,6 +1971,7 @@ optional<STRUCTURE> buildBlueprint(STRUCTURE_STATS const *psStats, Vector3i pos,
 	}
 
 	STRUCTURE blueprint(0, ownerPlayer);
+	blueprint.state = SAS_NORMAL;
 	// construct the fake structure
 	blueprint.pStructureType = const_cast<STRUCTURE_STATS *>(psStats);  // Couldn't be bothered to fix const correctness everywhere.
 	if (selectedPlayer < MAX_PLAYERS)


### PR DESCRIPTION
All because the structure.state value is not initialized.

https://youtu.be/2mdIIos__LM?si=ixmcCqQeXmsuOSfF&t=68