### PR TITLE
Ask for confirmation when quickly loading saves by (F8) key

### DIFF
--- a/src/ingameop.cpp
+++ b/src/ingameop.cpp
@@ -885,6 +885,45 @@ static bool startIGMouseOptionsMenu()
 	return true;
 }
 
+class IntFormAnimatedQuickLoad : public IntFormAnimated {};
+
+void showQuickLoadConfirmation()
+{
+	widgDelete(psWScreen, INTINGAMEOP);
+	auto const& parent = psWScreen->psForm;
+
+	auto ingameOp = std::make_shared<IntFormAnimatedQuickLoad>();
+	parent->attach(ingameOp);
+	ingameOp->id = INTINGAMEOP;
+
+	int row = 1;
+
+	auto label = std::make_shared<W_LABEL>();
+	ingameOp->attach(label);
+	label->setGeometry(INTINGAMEOP_2_X, INTINGAMEOPAUTO_Y_LINE(row), INTINGAMEOP4_OP_W, 0);
+	label->setString(_("Warning: Are you sure? Any unsaved progress will be lost."));
+	label->setTextAlignment(WLAB_ALIGNCENTRE);
+	label->setFont(font_medium, WZCOL_YELLOW);
+
+	row++;
+
+	auto label2 = std::make_shared<W_LABEL>();
+	ingameOp->attach(label2);
+	label2->setGeometry(INTINGAMEOP_2_X, INTINGAMEOPAUTO_Y_LINE(row), INTINGAMEOP4_OP_W, 0);
+	label2->setString(_("Press the key again to continue or ESC to cancel."));
+	label2->setTextAlignment(WLAB_ALIGNCENTRE);
+	label2->setFont(font_medium, WZCOL_WHITE);
+
+	ingameOp->setCalcLayout([row](WIDGET* psWidget) {
+		psWidget->setGeometry(INTINGAMEOP4_X, INTINGAMEOPAUTO_Y(row), INTINGAMEOP4_W, INTINGAMEOPAUTO_H(row));
+	});
+}
+
+bool isQuickLoadConfirmationFormOpen()
+{
+	return dynamic_cast<IntFormAnimatedQuickLoad*>(widgGetFromID(psWScreen, INTINGAMEOP)) != nullptr;
+}
+
 static bool runIGMouseOptionsMenu(UDWORD id)
 {
 	switch (id)

--- a/src/ingameop.h
+++ b/src/ingameop.h
@@ -31,6 +31,8 @@ bool intCloseInGameOptions(bool bPutUpLoadSave, bool bResetMissionWidgets);
 void intCloseInGameOptionsNoAnim();
 void intProcessInGameOptions(UDWORD);
 void intAddInGamePopup();
+void showQuickLoadConfirmation();
+bool isQuickLoadConfirmationFormOpen();
 
 extern bool hostQuitConfirmation;
 

--- a/src/keybind.cpp
+++ b/src/keybind.cpp
@@ -2603,7 +2603,13 @@ void kf_QuickLoad()
 
 	const char *filename = bMultiPlayer ? QUICKSAVE_SKI_FILENAME : QUICKSAVE_CAM_FILENAME;
 	// check for .json version, because that's what going to be loaded anyway
-	if (PHYSFS_exists(filename) || PHYSFS_exists(bMultiPlayer ? QUICKSAVE_SKI_JSON_FILENAME : QUICKSAVE_CAM_JSON_FILENAME))
+	if (!(PHYSFS_exists(filename) || PHYSFS_exists(bMultiPlayer ? QUICKSAVE_SKI_JSON_FILENAME : QUICKSAVE_CAM_JSON_FILENAME)))
+	{
+		console(_("QuickSave file does not exist yet"));
+		return;
+	}
+
+	if (isQuickLoadConfirmationFormOpen())
 	{
 		console(_("QuickLoad"));
 		audio_StopAll();
@@ -2618,7 +2624,7 @@ void kf_QuickLoad()
 	}
 	else
 	{
-		console(_("QuickSave file does not exist yet"));
+		showQuickLoadConfirmation();
 	}
 }
 


### PR DESCRIPTION
The quick loading key is very dangerous, because it can be pressed accidentally (or you don't know what it does at all) and the save is loading with no confirmation asked.