### PR TITLE
Cancel previous template when producing a new template in factories

### DIFF
--- a/src/droiddef.h
+++ b/src/droiddef.h
@@ -56,6 +56,8 @@ typedef std::vector<DROID_ORDER_DATA> OrderList;
 struct DROID_TEMPLATE : public BASE_STATS
 {
 	DROID_TEMPLATE();
+	bool operator==(const DROID_TEMPLATE& other) const;
+	bool operator!=(const DROID_TEMPLATE& other) const;
 
 	BODY_STATS* getBodyStats() const;
 	BRAIN_STATS* getBrainStats() const;

--- a/src/structure.cpp
+++ b/src/structure.cpp
@@ -6327,6 +6327,29 @@ void factoryProdAdjust(STRUCTURE *psStructure, DROID_TEMPLATE *psTemplate, bool 
 	ASSERT_OR_RETURN(, psTemplate != nullptr, "NULL template");
 
 	FACTORY *psFactory = &psStructure->pFunctionality->factory;
+
+	// the droid template being produced is different from the one we want to make,
+	// cancel the current production instead of increasing the counter
+	if (psFactory->psSubject && *psFactory->psSubject != *psTemplate)
+	{
+		bool bFound = false;
+		for (auto templ : apsTemplateList)
+		{
+			if (*templ == *psFactory->psSubject)
+			{
+				bFound = true;
+				break;
+			}
+		}
+
+		if (!bFound)
+		{
+			cancelProduction(psStructure, ModeImmediate, false);
+			factoryProdAdjust(psStructure, psTemplate, add);
+			return;
+		}
+	}
+
 	if (psFactory->psAssemblyPoint->factoryInc >= asProductionRun[psFactory->psAssemblyPoint->factoryType].size())
 	{
 		asProductionRun[psFactory->psAssemblyPoint->factoryType].resize(psFactory->psAssemblyPoint->factoryInc + 1);  // Don't have a production list, create it.

--- a/src/template.cpp
+++ b/src/template.cpp
@@ -524,6 +524,22 @@ DROID_TEMPLATE::DROID_TEMPLATE()  // This constructor replaces a memset in scrAs
 	std::fill_n(asWeaps, MAX_WEAPONS, 0);
 }
 
+bool DROID_TEMPLATE::operator==(const DROID_TEMPLATE &other) const
+{
+	return numWeaps == other.numWeaps &&
+		droidType == other.droidType &&
+		multiPlayerID == other.multiPlayerID &&
+		prefab == other.prefab &&
+		enabled == other.enabled &&
+		std::equal(std::begin(asParts), std::end(asParts), std::begin(other.asParts)) &&
+		std::equal(std::begin(asWeaps), std::end(asWeaps), std::begin(other.asWeaps));
+}
+
+bool DROID_TEMPLATE::operator!=(const DROID_TEMPLATE &other) const
+{
+	return !(*this == other);
+}
+
 BODY_STATS* DROID_TEMPLATE::getBodyStats() const
 {
 	return &asBodyStats[asParts[COMP_BODY]];


### PR DESCRIPTION
Less clicks, or else you have to click and cancel the entire production run manually. The behavior when you click on a new droid template, and it updates the counter at the old one is weird to say the least.

https://github.com/user-attachments/assets/ca90d116-833e-420e-a9f1-6e8f554329ba

If there are other templates in the queue, in this case the new template will be added to the end of the queue.

https://github.com/user-attachments/assets/35a81690-2237-45a1-b209-3096ab3ac5ce



