### PR TITLE
Improved factory manufacture

### DIFF
--- a/src/droiddef.h
+++ b/src/droiddef.h
@@ -56,6 +56,8 @@ typedef std::vector<DROID_ORDER_DATA> OrderList;
 struct DROID_TEMPLATE : public BASE_STATS
 {
 	DROID_TEMPLATE();
+	bool operator==(const DROID_TEMPLATE& other) const;
+	bool operator!=(const DROID_TEMPLATE& other) const;
 
 	BODY_STATS* getBodyStats() const;
 	BRAIN_STATS* getBrainStats() const;

--- a/src/hci/manufacture.cpp
+++ b/src/hci/manufacture.cpp
@@ -168,7 +168,8 @@ void ManufactureController::updateManufactureOptionsList()
 DROID_TEMPLATE *ManufactureController::getObjectStatsAt(size_t objectIndex) const
 {
 	auto factory = getFactoryOrNullptr(getObjectAt(objectIndex));
-	return factory == nullptr ? nullptr : factory->psSubject;
+	auto subject = factory->psSubjectObsolete ? factory->psSubjectObsolete.get() : factory->psSubject;
+	return factory == nullptr ? nullptr : subject;
 }
 
 void ManufactureController::refresh()
@@ -419,7 +420,10 @@ private:
 		auto productionRemaining = getProduction(factory, droidTemplate).numRemaining();
 		if (productionRemaining > 0 && factory && StructureIsManufacturingPending(factory))
 		{
-			productionRunSizeLabel->setString(WzString::fromUtf8(astringf("%d", productionRemaining)));
+			auto manufacture = StructureGetFactory(factory);
+			productionRunSizeLabel->setString(manufacture->psSubjectObsolete ?
+				WzString::fromUtf8(astringf("1+%d", productionRemaining)) :
+				WzString::fromUtf8(astringf("%d", productionRemaining)));
 			productionRunSizeLabel->show();
 		}
 		else

--- a/src/structure.cpp
+++ b/src/structure.cpp
@@ -6327,6 +6327,29 @@ void factoryProdAdjust(STRUCTURE *psStructure, DROID_TEMPLATE *psTemplate, bool 
 	ASSERT_OR_RETURN(, psTemplate != nullptr, "NULL template");
 
 	FACTORY *psFactory = &psStructure->pFunctionality->factory;
+
+	// the droid template being produced is different from the one we want to make,
+	// cancel the current production instead of increasing the counter
+	if (psFactory->psSubject && *psFactory->psSubject != *psTemplate)
+	{
+		bool bFound = false;
+		for (auto templ : apsTemplateList)
+		{
+			if (*templ == *psFactory->psSubject)
+			{
+				bFound = true;
+				break;
+			}
+		}
+
+		if (!bFound)
+		{
+			cancelProduction(psStructure, ModeImmediate, false);
+			factoryProdAdjust(psStructure, psTemplate, add);
+			return;
+		}
+	}
+
 	if (psFactory->psAssemblyPoint->factoryInc >= asProductionRun[psFactory->psAssemblyPoint->factoryType].size())
 	{
 		asProductionRun[psFactory->psAssemblyPoint->factoryType].resize(psFactory->psAssemblyPoint->factoryInc + 1);  // Don't have a production list, create it.

--- a/src/structure.cpp
+++ b/src/structure.cpp
@@ -1107,7 +1107,7 @@ static void refundFactoryBuildPower(STRUCTURE *psBuilding)
 			addPower(psBuilding->player, calcTemplatePower(psFactory->psSubjectObsolete.get()));
 		}
 	}
-	if (psFactory->psSubject)
+	else if (psFactory->psSubject)
 	{
 		if (psFactory->buildPointsRemaining < (int)calcTemplateBuild(psFactory->psSubject))
 		{

--- a/src/structuredef.h
+++ b/src/structuredef.h
@@ -205,6 +205,8 @@ struct FACTORY
 	UBYTE loopsPerformed;             /* how many times the loop has been performed*/
 	DROID_TEMPLATE *psSubject;        ///< The subject the structure is working on.
 	DROID_TEMPLATE *psSubjectPending; ///< The subject the structure is going to working on. (Pending = not yet synchronised.)
+	std::unique_ptr<DROID_TEMPLATE>
+				psSubjectObsolete;    ///< Old droid template that will be deleted after production ends.
 	StatusPending statusPending;      ///< Pending = not yet synchronised.
 	unsigned pendingCount;            ///< Number of messages sent but not yet processed.
 	UDWORD timeStarted;               /* The time the building started on the subject*/

--- a/src/structuredef.h
+++ b/src/structuredef.h
@@ -30,6 +30,7 @@
 #include "weapondef.h"
 
 #include <vector>
+#include <memory>
 
 #define NUM_FACTORY_MODULES 2
 #define NUM_POWER_MODULES 4

--- a/src/template.cpp
+++ b/src/template.cpp
@@ -524,6 +524,22 @@ DROID_TEMPLATE::DROID_TEMPLATE()  // This constructor replaces a memset in scrAs
 	std::fill_n(asWeaps, MAX_WEAPONS, 0);
 }
 
+bool DROID_TEMPLATE::operator==(const DROID_TEMPLATE &other) const
+{
+	return numWeaps == other.numWeaps &&
+		droidType == other.droidType &&
+		multiPlayerID == other.multiPlayerID &&
+		prefab == other.prefab &&
+		enabled == other.enabled &&
+		std::equal(std::begin(asParts), std::end(asParts), std::begin(other.asParts)) &&
+		std::equal(std::begin(asWeaps), std::end(asWeaps), std::begin(other.asWeaps));
+}
+
+bool DROID_TEMPLATE::operator!=(const DROID_TEMPLATE &other) const
+{
+	return !(*this == other);
+}
+
 BODY_STATS* DROID_TEMPLATE::getBodyStats() const
 {
 	return &asBodyStats[asParts[COMP_BODY]];


### PR DESCRIPTION
When a droid template is modified and queued, the old template is marked as obsolete to produce a remaining droid in the production run and be removed, and new ones are added to the queue as normal.

https://github.com/user-attachments/assets/f1a548f7-7c85-4be4-8f8e-d3797941032b

