### PR TITLE
wzapi::addBeacon: Center beacon blip

### DIFF
--- a/src/wzapi.cpp
+++ b/src/wzapi.cpp
@@ -2146,8 +2146,8 @@ bool wzapi::addBeacon(WZAPI_PARAMS(int _x, int _y, int playerFilter, optional<st
 	SCRIPT_ASSERT(false, context, _x <= mapWidth, "Beacon x value %d is greater than mapWidth %d", _x, (int)mapWidth);
 	SCRIPT_ASSERT(false, context, _y <= mapHeight, "Beacon y value %d is greater than mapHeight %d", _y, (int)mapHeight);
 
-	int x = world_coord(_x);
-	int y = world_coord(_y);
+	int x = world_coord(_x) + (TILE_UNITS / 2);
+	int y = world_coord(_y) + (TILE_UNITS / 2);
 
 	std::string message;
 	if (_message.has_value())


### PR DESCRIPTION
wzapi function `addBeacon(x, y, playerFilter[, message])` spawns a beacon, but it's not in the middle of a tile. It's placed on the North-West (top left) corner.

# Why it happens
`wzapi.cpp`:
```cpp
bool wzapi::addBeacon(WZAPI_PARAMS(int _x, int _y, int playerFilter, optional<std::string> _message))
{
	SCRIPT_ASSERT(false, context, _x >= 0, "Beacon x value %d is less than zero", _x);
	SCRIPT_ASSERT(false, context, _y >= 0, "Beacon y value %d is less than zero", _y);
	SCRIPT_ASSERT(false, context, _x <= mapWidth, "Beacon x value %d is greater than mapWidth %d", _x, (int)mapWidth);
	SCRIPT_ASSERT(false, context, _y <= mapHeight, "Beacon y value %d is greater than mapHeight %d", _y, (int)mapHeight);

	int x = world_coord(_x);
	int y = world_coord(_y);
        ...
```

Needs to be 

```cpp
	int x = world_coord(_x) + 64;
	int y = world_coord(_y) + 64;
```

Each tile = 128 "world units".

---

I'm not sure this works; I didn't test it. Additionally, I'm not sure if there's an appropriate constant I should be using instead. Review would be appreciated.