### PR TITLE
Initial blind lobby / game support (part 1)

### DIFF
--- a/doc/CmdInterface.md
+++ b/doc/CmdInterface.md
@@ -112,5 +112,8 @@ If state of interface buffer is unknown and/or corrupted, interface can send a f
 * `chat bcast <message [^\n]>`\
 	Send system level message to the room from stdin.
 
+* `set host ready <0|1>`\
+	Sets the host ready state to either not-ready (0) or ready (1).
+
 * `shutdown now`\
 	Trigger graceful shutdown of the game regardless of state.

--- a/doc/hosting/AutohostConfig.md
+++ b/doc/hosting/AutohostConfig.md
@@ -20,6 +20,12 @@ The `challenge` object defines the game parameters for a multiplayer game.
 * `techLevel` sets the starting technology level. `1` for level 1 (wheel), `2` for level 2 (water mill), `3` for level 3 (chip), `4` for level 4 (computer).
 * `spectatorHost` when `true` or `1`, the host will spectate the game. When `false` or `0`, the host will play the game.
 * `openSpectatorSlots` defines how much spectator slots are opened (one more is opened for the host when spectating).
+* `blindMode` configures blind lobby / game mode. Available values are:
+  * `"none"`: blind modes disabled (the default)
+  * `"blind_lobby"`: Players' true identities are hidden from everyone except the host - **until the game _starts_**
+  * `"blind_lobby_simple_lobby"`: Same as `blind_lobby`, but with the addition of "simple lobby" mode (players will be placed in a waiting room where they can't see the list of players until the game starts)
+  * `"blind_game"`: Players' true identities are hidden from everyone except the host - **until the game _ends_**
+  * `"blind_game_simple_lobby"`: Same as `blind_game`, but with the addition of "simple lobby" mode (players will be placed in a waiting room where they can't see the list of players until the game starts)
 * `allowPositionChange` is deprecated, use the `locked` object instead.
 
 ## the `locked` object
@@ -48,7 +54,7 @@ Each player slot can be customized, starting from 0. The first slot will be defi
 
 ## Sample file
 
-```
+```json
 {
 	"locked": {
 		"power": false,
@@ -71,6 +77,7 @@ Each player slot can be customized, starting from 0. The first slot will be defi
 		"techLevel": 1,
 		"spectatorHost": true,
 		"openSpectatorSlots": 2,
+		"blindMode": "none",
 		"allowPositionChange": true
 	},
 	"player_0": {

--- a/doc/hosting/DedicatedHost.md
+++ b/doc/hosting/DedicatedHost.md
@@ -34,6 +34,12 @@ You can provide more arguments to fine-tune your environment.
 * `--autorating=<host>` overrides the autorating url. See `AutoratingServer.md` for details about the autorating server.
 
 
+#### Advanced usage
+
+* `--enablecmdinterface=<stdin|unixsocket:path>` enables the command interface. See [/doc/CmdInterface.md](/doc/CmdInterface.md)
+* `--autohost-not-ready` starts the host (autohost) as not ready, even if it's a spectator host. Should usually be combined with usage of the cmdinterface to trigger host ready via the `set host ready 1` command (or the game will never start!)
+
+
 ### Checking your firewall
 
 If your server starts but nobody can join, check that your firewall is accepting incoming TCP connections on the given port.

--- a/lib/framework/crc.cpp
+++ b/lib/framework/crc.cpp
@@ -345,7 +345,7 @@ EcKey::Key EcKey::toBytes(Privacy privacy) const
 {
 	if (empty())
 	{
-		debug(LOG_INFO, "No key");
+		debug(LOG_WZ, "No key");
 		return Key();
 	}
 	assert(EC_KEY_CAST(vKey) != nullptr);

--- a/lib/netplay/netplay.cpp
+++ b/lib/netplay/netplay.cpp
@@ -3861,7 +3861,7 @@ static void NETallowJoining()
 		{
 			listeningInterfaces.knownExternalAddresses = {{gamestruct.desc.host, gamestruct.hostPort, ActivitySink::ListeningInterfaces::IPType::IPv4}};
 		}
-		ActivityManager::instance().hostGame(gamestruct.name, NetPlay.players[0].name, NETgetMasterserverName(), NETgetMasterserverPort(), listeningInterfaces, gamestruct.gameId);
+		ActivityManager::instance().hostGame(gamestruct.name, NetPlay.players[NetPlay.hostPlayer].name, NETgetMasterserverName(), NETgetMasterserverPort(), listeningInterfaces, gamestruct.gameId);
 	}
 
 	// This is here since we need to get the status, before we can show the info.

--- a/lib/netplay/netplay.cpp
+++ b/lib/netplay/netplay.cpp
@@ -737,9 +737,8 @@ static void NETSendNPlayerInfoTo(uint32_t *index, uint32_t indexLen, unsigned to
 		NETbool(&NetPlay.players[index[n]].allocated);
 		NETbool(&NetPlay.players[index[n]].heartbeat);
 		NETbool(&NetPlay.players[index[n]].kick);
-		if (game.blindMode != BLIND_MODE::NONE // if in blind mode
-			&& index[n] < MAX_PLAYER_SLOTS // and an actual player slot (not a spectator slot)
-			&& !ingame.endTime.has_value()) // and game has not ended
+		if (isBlindPlayerInfoState() // if in blind player info state
+			&& index[n] < MAX_PLAYER_SLOTS) // and an actual player slot (not a spectator slot)
 		{
 			// send a generic player name
 			const char* genericName = getPlayerGenericName(index[n]);
@@ -1018,7 +1017,7 @@ static void NETplayerLeaving(UDWORD index, bool quietSocketClose)
 		NET_DestroyPlayer(index);       // sets index player's array to false
 		if (!wasSpectator)
 		{
-			resetReadyStatus(false, game.blindMode == BLIND_MODE::BLIND_GAME_SIMPLE_LOBBY);		// reset ready status for all players
+			resetReadyStatus(false, isBlindSimpleLobby(game.blindMode));		// reset ready status for all players
 			resetReadyCalled = true;
 		}
 
@@ -1059,7 +1058,7 @@ static void NETplayerDropped(UDWORD index)
 		NET_DestroyPlayer(id);          // just clears array
 		if (!wasSpectator)
 		{
-			resetReadyStatus(false, game.blindMode == BLIND_MODE::BLIND_GAME_SIMPLE_LOBBY);		// reset ready status for all players
+			resetReadyStatus(false, isBlindSimpleLobby(game.blindMode));		// reset ready status for all players
 			resetReadyCalled = true;
 		}
 

--- a/lib/netplay/netplay.cpp
+++ b/lib/netplay/netplay.cpp
@@ -2114,7 +2114,7 @@ bool NETmovePlayerToSpectatorOnlySlot(uint32_t playerIdx, bool hostOverride /*= 
 		std::string playerPublicKeyB64 = base64Encode(getMultiStats(newSpecIdx).identity.toBytes(EcKey::Public));
 		std::string playerIdentityHash = getMultiStats(newSpecIdx).identity.publicHashString();
 		std::string playerVerifiedStatus = (ingame.VerifiedIdentity[newSpecIdx]) ? "V" : "?";
-		std::string playerName = NetPlay.players[newSpecIdx].name;
+		std::string playerName = getPlayerName(newSpecIdx);
 		std::string playerNameB64 = base64Encode(std::vector<unsigned char>(playerName.begin(), playerName.end()));
 		wz_command_interface_output("WZEVENT: movedPlayerToSpec: %" PRIu32 " -> %" PRIu32 " %s %s %s %s %s\n", playerIdx, newSpecIdx, playerPublicKeyB64.c_str(), playerIdentityHash.c_str(), playerVerifiedStatus.c_str(), playerNameB64.c_str(), NetPlay.players[newSpecIdx].IPtextAddress);
 	}
@@ -2174,7 +2174,7 @@ SpectatorToPlayerMoveResult NETmoveSpectatorToPlayerSlot(uint32_t playerIdx, opt
 		std::string playerPublicKeyB64 = base64Encode(getMultiStats(newPlayerIdx.value()).identity.toBytes(EcKey::Public));
 		std::string playerIdentityHash = getMultiStats(newPlayerIdx.value()).identity.publicHashString();
 		std::string playerVerifiedStatus = (ingame.VerifiedIdentity[newPlayerIdx.value()]) ? "V" : "?";
-		std::string playerName = NetPlay.players[newPlayerIdx.value()].name;
+		std::string playerName = getPlayerName(newPlayerIdx.value());
 		std::string playerNameB64 = base64Encode(std::vector<unsigned char>(playerName.begin(), playerName.end()));
 		wz_command_interface_output("WZEVENT: movedSpecToPlayer: %" PRIu32 " -> %" PRIu32 " %s %s %s %s %s\n", playerIdx, newPlayerIdx.value(), playerPublicKeyB64.c_str(), playerIdentityHash.c_str(), playerVerifiedStatus.c_str(), playerNameB64.c_str(), NetPlay.players[newPlayerIdx.value()].IPtextAddress);
 	}
@@ -4328,11 +4328,11 @@ static void NETallowJoining()
 
 			char buf[250] = {'\0'};
 			const char* pPlayerType = (NetPlay.players[index].isSpectator) ? "Spectator" : "Player";
-			snprintf(buf, sizeof(buf), "%s[%" PRIu8 "] %s has joined, IP is: %s", pPlayerType, index, NetPlay.players[index].name, NetPlay.players[index].IPtextAddress);
+			snprintf(buf, sizeof(buf), "%s[%" PRIu8 "] %s has joined, IP is: %s", pPlayerType, index, getPlayerName(index), NetPlay.players[index].IPtextAddress);
 			debug(LOG_INFO, "%s", buf);
 			NETlogEntry(buf, SYNC_FLAG, index);
 
-			debug(LOG_NET, "%s, %s, with index of %u has joined using socket %p", pPlayerType, NetPlay.players[index].name, (unsigned int)index, static_cast<void *>(connected_bsocket[index]));
+			debug(LOG_NET, "%s, %s, with index of %u has joined using socket %p", pPlayerType, getPlayerName(index), (unsigned int)index, static_cast<void *>(connected_bsocket[index]));
 
 			// Increment player count
 			gamestruct.desc.dwCurrentPlayers++;

--- a/lib/netplay/netplay.h
+++ b/lib/netplay/netplay.h
@@ -465,7 +465,8 @@ void NETsetDefaultMPHostFreeChatPreference(bool enabled);
 bool NETgetDefaultMPHostFreeChatPreference();
 void NETsetEnableTCPNoDelay(bool enabled);
 bool NETgetEnableTCPNoDelay();
-uint32_t NETgetJoinConnectionNETPINGChallengeSize();
+uint32_t NETgetJoinConnectionNETPINGChallengeFromHostSize();
+uint32_t NETgetJoinConnectionNETPINGChallengeFromClientSize();
 
 void NETsetGamePassword(const char *password);
 void NETBroadcastPlayerInfo(uint32_t index);

--- a/lib/netplay/netplay.h
+++ b/lib/netplay/netplay.h
@@ -470,6 +470,7 @@ uint32_t NETgetJoinConnectionNETPINGChallengeSize();
 void NETsetGamePassword(const char *password);
 void NETBroadcastPlayerInfo(uint32_t index);
 void NETBroadcastTwoPlayerInfo(uint32_t index1, uint32_t index2);
+void NETSendAllPlayerInfoTo(unsigned to);
 bool NETisCorrectVersion(uint32_t game_version_major, uint32_t game_version_minor);
 uint32_t NETGetMajorVersion();
 uint32_t NETGetMinorVersion();

--- a/lib/netplay/netreplay.h
+++ b/lib/netplay/netreplay.h
@@ -26,7 +26,7 @@
 
 
 bool NETreplaySaveStart(std::string const& subdir, ReplayOptionsHandler const &optionsHandler, int maxReplaysSaved, bool appendPlayerToFilename = false);
-bool NETreplaySaveStop();
+bool NETreplaySaveStop(ReplayOptionsHandler const &optionsHandler);
 void NETreplaySaveNetMessage(NetMessage const *message, uint8_t player);
 
 bool NETreplayLoadStart(std::string const &filename, ReplayOptionsHandler& optionsHandler, uint32_t& output_replayFormatVer);

--- a/lib/netplay/nettypes.cpp
+++ b/lib/netplay/nettypes.cpp
@@ -1035,6 +1035,25 @@ void NETnetMessage(NetMessage const **msg)
 	}
 }
 
+void NETbytesOutputToVector(const std::vector<uint8_t> &data, std::vector<uint8_t>& output)
+{
+	// same logic as using NETbytes() for a write, except written to the `output` vector
+
+	// same as queueAuto(uint32_t) - write the length
+	uint32_t dataSizeU32 = static_cast<uint32_t>(data.size());
+	uint32_t v = dataSizeU32;
+	bool moreBytes = true;
+	for (int n = 0; moreBytes; ++n)
+	{
+		uint8_t b;
+		moreBytes = encode_uint32_t(b, v, n);
+		output.push_back(b);
+	}
+
+	// write all the data bytes
+	output.insert(output.end(), data.begin(), data.end());
+}
+
 ReplayOptionsHandler::~ReplayOptionsHandler() { }
 
 // TODO Call this function somewhere.

--- a/lib/netplay/nettypes.h
+++ b/lib/netplay/nettypes.h
@@ -210,6 +210,8 @@ static inline void NETauto(T (&ar)[N])
 
 void NETnetMessage(NetMessage const **message);  ///< If decoding, must delete the NETMESSAGE.
 
+void NETbytesOutputToVector(const std::vector<uint8_t> &data, std::vector<uint8_t>& output);
+
 #include <nlohmann/json_fwd.hpp>
 
 class ReplayOptionsHandler

--- a/lib/netplay/nettypes.h
+++ b/lib/netplay/nettypes.h
@@ -225,6 +225,7 @@ public:
 public:
 	virtual bool saveOptions(nlohmann::json& object) const = 0;
 	virtual bool saveMap(EmbeddedMapData& mapData) const = 0;
+	virtual bool optionsUpdatePlayerInfo(nlohmann::json& object) const = 0;
 	virtual bool restoreOptions(const nlohmann::json& object, EmbeddedMapData&& embeddedMapData, uint32_t replay_netcodeMajor, uint32_t replay_netcodeMinor) = 0;
 	virtual size_t desiredBufferSize() const = 0;
 	virtual size_t maximumEmbeddedMapBufferSize() const = 0;

--- a/lib/widget/editbox.cpp
+++ b/lib/widget/editbox.cpp
@@ -751,6 +751,10 @@ void W_EDITBOX::display(int xOffset, int yOffset)
 	{
 		displayCache.wzDisplayedText.setText(displayedText, FontID);
 	}
+	if (state & WEDBS_DISABLE)
+	{
+		displayedTextColor = WZCOL_TEXT_DARK;
+	}
 
 	int lineSize = displayCache.wzDisplayedText.lineSize();
 	int aboveBase = displayCache.wzDisplayedText.aboveBase();

--- a/lib/widget/multibutform.cpp
+++ b/lib/widget/multibutform.cpp
@@ -115,6 +115,7 @@ void MultibuttonWidget::setLabel(char const *text)
 	attach(label = std::make_shared<W_LABEL>());
 	label->setString(text);
 	label->setCacheNeverExpires(true);
+	label->setCanTruncate(true);
 
 	geometryChanged();
 }

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -88,8 +88,8 @@ if(ENABLE_NLS)
 	find_package (Intl REQUIRED)
 endif()
 
-file(GLOB HEADERS "*.h" "3rdparty/*.h" "titleui/*.h" "hci/*.h" "input/*.h" "screens/*.h")
-file(GLOB SRC "*.cpp" "3rdparty/*.cpp" "titleui/*.cpp" "hci/*.cpp" "input/*.cpp" "screens/*.cpp")
+file(GLOB HEADERS "*.h" "3rdparty/*.h" "titleui/*.h" "titleui/*/*.h" "hci/*.h" "input/*.h" "screens/*.h")
+file(GLOB SRC "*.cpp" "3rdparty/*.cpp" "titleui/*.cpp" "titleui/*/*.cpp" "hci/*.cpp" "input/*.cpp" "screens/*.cpp")
 
 set(_additionalSourceFiles)
 if(CMAKE_SYSTEM_NAME MATCHES "Windows")

--- a/src/clparse.cpp
+++ b/src/clparse.cpp
@@ -364,6 +364,7 @@ typedef enum
 	CLI_ALLOW_VULKAN_IMPLICIT_LAYERS,
 	CLI_HOST_CHAT_CONFIG,
 	CLI_HOST_ASYNC_JOIN_APPROVAL,
+	CLI_AUTOHOST_START_NOT_READY,
 #if defined(__EMSCRIPTEN__)
 	CLI_VIDEOURL,
 #endif
@@ -457,6 +458,7 @@ static const struct poptOption *getOptionsTable()
 		{ "allow-vulkan-implicit-layers", POPT_ARG_NONE, CLI_ALLOW_VULKAN_IMPLICIT_LAYERS, N_("Allow Vulkan implicit layers (that may be default-disabled due to potential crashes or bugs)"), nullptr },
 		{ "host-chat-config", POPT_ARG_STRING, CLI_HOST_CHAT_CONFIG, N_("Set the default hosting chat configuration / permissions"), "[allow,quickchat]" },
 		{ "async-join-approve", POPT_ARG_NONE, CLI_HOST_ASYNC_JOIN_APPROVAL, N_("Enable async join approval (for connecting clients)"), nullptr },
+		{ "autohost-not-ready", POPT_ARG_NONE, CLI_AUTOHOST_START_NOT_READY, N_("Starts the host (autohost) as not ready, even if it's a spectator host"), nullptr },
 #if defined(__EMSCRIPTEN__)
 		{ "videourl", POPT_ARG_STRING, CLI_VIDEOURL,   N_("Base URL for on-demand video downloads"), N_("Base video URL") },
 #endif
@@ -1343,6 +1345,10 @@ bool ParseCommandLine(int argc, const char * const *argv)
 
 		case CLI_HOST_ASYNC_JOIN_APPROVAL:
 			NETsetAsyncJoinApprovalRequired(true);
+			break;
+
+		case CLI_AUTOHOST_START_NOT_READY:
+			setHostLaunchStartNotReady(true);
 			break;
 
 #if defined(__EMSCRIPTEN__)

--- a/src/configuration.cpp
+++ b/src/configuration.cpp
@@ -912,6 +912,7 @@ bool reloadMPConfig()
 	game.inactivityMinutes = war_getMPInactivityMinutes();
 	game.gameTimeLimitMinutes = war_getMPGameTimeLimitMinutes();
 	game.playerLeaveMode = war_getMPPlayerLeaveMode();
+	game.blindMode = BLIND_MODE::NONE;
 
 	// restore group menus enabled setting (as tutorial may override it)
 	setGroupButtonEnabled(war_getGroupsMenuEnabled());

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -4558,6 +4558,10 @@ static bool loadMainFile(const std::string &fileName)
 	{
 		game.playerLeaveMode = static_cast<PLAYER_LEAVE_MODE>(save.value("playerLeaveMode").toInt());
 	}
+	if (save.contains("blindMode"))
+	{
+		game.blindMode = static_cast<BLIND_MODE>(save.value("blindMode").toInt());
+	}
 	if (save.contains("multiplayer"))
 	{
 		bMultiPlayer = save.value("multiplayer").toBool();
@@ -4800,6 +4804,7 @@ static bool writeMainFile(const std::string &fileName, SDWORD saveType)
 	save.setValue("inactivityMinutes", game.inactivityMinutes);
 	save.setValue("gameTimeLimitMinutes", game.gameTimeLimitMinutes);
 	save.setValue("playerLeaveMode", game.playerLeaveMode);
+	save.setValue("blindMode", game.blindMode);
 	save.setValue("tweakOptions", getCamTweakOptions());
 
 	save.beginArray("scriptSetPlayerDataStrings");

--- a/src/gamehistorylogger.cpp
+++ b/src/gamehistorylogger.cpp
@@ -333,7 +333,7 @@ void GameStoryLogger::logStartGame()
 	for (int i = 0; i < game.maxPlayers; i++)
 	{
 		FixedPlayerAttributes playerAttrib;
-		playerAttrib.name = NetPlay.players[i].name;
+		playerAttrib.name = (strlen(NetPlay.players[i].name) == 0) ? "" : getPlayerName(i);
 		playerAttrib.position = NetPlay.players[i].position;
 		playerAttrib.team = NetPlay.players[i].team;
 		playerAttrib.colour = NetPlay.players[i].colour;

--- a/src/gamehistorylogger.cpp
+++ b/src/gamehistorylogger.cpp
@@ -338,7 +338,7 @@ void GameStoryLogger::logStartGame()
 		playerAttrib.team = NetPlay.players[i].team;
 		playerAttrib.colour = NetPlay.players[i].colour;
 		playerAttrib.faction = NetPlay.players[i].faction;
-		playerAttrib.publicKey = base64Encode(getMultiStats(i).identity.toBytes(EcKey::Public));
+		playerAttrib.publicKey = base64Encode(getOutputPlayerIdentity(i).toBytes(EcKey::Public));
 
 		startingPlayerAttributes.push_back(playerAttrib);
 	}

--- a/src/hci/quickchat.cpp
+++ b/src/hci/quickchat.cpp
@@ -2447,8 +2447,8 @@ namespace INTERNAL_ADMIN_ACTION_NOTICE {
 			return std::string();
 		}
 
-		const char* responsiblePlayerName = NetPlay.players[responsiblePlayerIdx].name;
-		const char* targetPlayerName = NetPlay.players[targetPlayerIdx].name;
+		const char* responsiblePlayerName = getPlayerName(responsiblePlayerIdx);
+		const char* targetPlayerName = getPlayerName(targetPlayerIdx);
 
 		const char* responsiblePlayerType = _("Player");
 		if (responsiblePlayerIdx == NetPlay.hostPlayer)

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -2002,7 +2002,7 @@ bool stageThreeShutDown()
 {
 	debug(LOG_WZ, "== stageThreeShutDown ==");
 
-	setHostLaunch(HostLaunch::Normal);
+	resetHostLaunch();
 
 	removeSpotters();
 

--- a/src/loop.cpp
+++ b/src/loop.cpp
@@ -501,7 +501,7 @@ static void gameStateUpdate()
 	          NetPlay.players[0].allocated, NetPlay.players[1].allocated, NetPlay.players[2].allocated, NetPlay.players[3].allocated, NetPlay.players[4].allocated, NetPlay.players[5].allocated, NetPlay.players[6].allocated, NetPlay.players[7].allocated, NetPlay.players[8].allocated, NetPlay.players[9].allocated,
 	          NetPlay.players[0].position, NetPlay.players[1].position, NetPlay.players[2].position, NetPlay.players[3].position, NetPlay.players[4].position, NetPlay.players[5].position, NetPlay.players[6].position, NetPlay.players[7].position, NetPlay.players[8].position, NetPlay.players[9].position
 	         );
-	bool overrideHandleClientBlindNames = (game.blindMode != BLIND_MODE::NONE) && (NetPlay.isHost || NETisReplay()) && !ingame.endTime.has_value();
+	bool overrideHandleClientBlindNames = (game.blindMode >= BLIND_MODE::BLIND_GAME) && (NetPlay.isHost || NETisReplay()) && !ingame.endTime.has_value();
 	for (unsigned n = 0; n < MAX_PLAYERS; ++n)
 	{
 		syncDebug("Player %d = \"%s\"", n, (!overrideHandleClientBlindNames) ? NetPlay.players[n].name : getPlayerGenericName(n));

--- a/src/loop.cpp
+++ b/src/loop.cpp
@@ -501,9 +501,10 @@ static void gameStateUpdate()
 	          NetPlay.players[0].allocated, NetPlay.players[1].allocated, NetPlay.players[2].allocated, NetPlay.players[3].allocated, NetPlay.players[4].allocated, NetPlay.players[5].allocated, NetPlay.players[6].allocated, NetPlay.players[7].allocated, NetPlay.players[8].allocated, NetPlay.players[9].allocated,
 	          NetPlay.players[0].position, NetPlay.players[1].position, NetPlay.players[2].position, NetPlay.players[3].position, NetPlay.players[4].position, NetPlay.players[5].position, NetPlay.players[6].position, NetPlay.players[7].position, NetPlay.players[8].position, NetPlay.players[9].position
 	         );
+	bool overrideHandleClientBlindNames = (game.blindMode != BLIND_MODE::NONE) && (NetPlay.isHost || NETisReplay()) && !ingame.endTime.has_value();
 	for (unsigned n = 0; n < MAX_PLAYERS; ++n)
 	{
-		syncDebug("Player %d = \"%s\"", n, NetPlay.players[n].name);
+		syncDebug("Player %d = \"%s\"", n, (!overrideHandleClientBlindNames) ? NetPlay.players[n].name : getPlayerGenericName(n));
 	}
 
 	// Add version string to desynch logs. Different version strings will not trigger a desynch dump per se, due to the syncDebug{Get, Set}Crc guard.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1074,7 +1074,8 @@ static void stopGameLoop()
 {
 	clearInfoMessages(); // clear CONPRINTF messages before each new game/mission
 
-	NETreplaySaveStop();
+	WZGameReplayOptionsHandler replayOptions;
+	NETreplaySaveStop(replayOptions);
 	NETshutdownReplay();
 
 	if (gameLoopStatus != GAMECODE_NEWLEVEL)

--- a/src/multiint.cpp
+++ b/src/multiint.cpp
@@ -6245,7 +6245,7 @@ void WzMultiplayerOptionsTitleUI::processMultiopWidgets(UDWORD id)
 
 	case CON_CANCEL:
 
-		setHostLaunch(HostLaunch::Normal); // Dont load the autohost file on subsequent hosts
+		resetHostLaunch(); // Dont load the autohost file on subsequent hosts
 		performedFirstStart = false; // Reset everything
 		if (!challengeActive)
 		{
@@ -7568,7 +7568,7 @@ void WzMultiplayerOptionsTitleUI::start()
 			if (getHostLaunch() == HostLaunch::Autohost)
 			{
 				changeTitleUI(std::make_shared<WzMsgBoxTitleUI>(WzString(_("Failed to process autohost config:")), WzString::fromUtf8(astringf(_("Failed to load the autohost map or config from: %s"), wz_skirmish_test().c_str())), parent));
-				setHostLaunch(HostLaunch::Normal); // Don't load the autohost file on subsequent hosts
+				resetHostLaunch(); // Don't load the autohost file on subsequent hosts
 				return;
 			}
 			// otherwise, treat as non-fatal...
@@ -7642,7 +7642,10 @@ void WzMultiplayerOptionsTitleUI::start()
 		{
 			processMultiopWidgets(MULTIOP_HOST);
 		}
-		sendReadyRequest(selectedPlayer, true);
+		if (!getHostLaunchStartNotReady())
+		{
+			sendReadyRequest(selectedPlayer, true);
+		}
 		if (getHostLaunch() == HostLaunch::Skirmish)
 		{
 			startMultiplayerGame();

--- a/src/multiint.cpp
+++ b/src/multiint.cpp
@@ -3458,8 +3458,8 @@ static SwapPlayerIndexesResult recvSwapPlayerIndexes(NETQUEUE queue, const std::
 		if ((game.blindMode != BLIND_MODE::NONE) && (selectedPlayer < MAX_PLAYERS))
 		{
 			std::string blindLobbyMessage = _("BLIND LOBBY NOTICE:");
-			blindLobbyMessage += "\n";
-			blindLobbyMessage += astringf(_("- You have been assigned the codename: \"%s\""), getPlayerGenericName(selectedPlayer));
+			blindLobbyMessage += "\n- ";
+			blindLobbyMessage += astringf(_("You have been assigned the codename: \"%s\""), getPlayerGenericName(selectedPlayer));
 			displayRoomNotifyMessage(blindLobbyMessage.c_str());
 		}
 	}
@@ -4174,7 +4174,7 @@ void WzMultiplayerOptionsTitleUI::openPlayerSlotSwapChooser(uint32_t playerIndex
 	auto psParentPlayersForm = (W_FORM *)widgGetFromID(psWScreen, MULTIOP_PLAYERS);
 	ASSERT_OR_RETURN(, psParentPlayersForm != nullptr, "Could not find players form?");
 	chooserParent->setCutoutWidget(psParentPlayersForm->shared_from_this()); // should be cleared on close
-	auto titleUI = std::dynamic_pointer_cast<WzMultiplayerOptionsTitleUI>(shared_from_this());
+	auto titleUI = std::static_pointer_cast<WzMultiplayerOptionsTitleUI>(shared_from_this());
 
 	int textHeight = iV_GetTextLineSize(font_regular);
 	int swapContextFormMargin = 1;
@@ -4317,7 +4317,7 @@ void WzMultiplayerOptionsTitleUI::addPlayerBox(bool players)
 		return;
 	}
 
-	auto titleUI = std::dynamic_pointer_cast<WzMultiplayerOptionsTitleUI>(shared_from_this());
+	auto titleUI = std::static_pointer_cast<WzMultiplayerOptionsTitleUI>(shared_from_this());
 
 	if (isBlindSimpleLobby(game.blindMode) && !NetPlay.isHost)
 	{

--- a/src/multiint.cpp
+++ b/src/multiint.cpp
@@ -1407,6 +1407,19 @@ static void addGameOptions()
 	addMultiButton(mapPreviewButton, 0, AtlasImage(FrontImages, IMAGE_FOG_OFF), AtlasImage(FrontImages, IMAGE_FOG_OFF_HI), _("Click to see Map"));
 	optionsList->addWidgetToLayout(mapPreviewButton);
 
+	auto addTechLevelMultibuttonWidget = [&](){
+		auto TechnologyChoice = std::make_shared<MultichoiceWidget>(game.techLevel);
+		optionsList->attach(TechnologyChoice);
+		TechnologyChoice->id = MULTIOP_TECHLEVEL;
+		TechnologyChoice->setLabel(_("Tech"));
+		addMultiButton(TechnologyChoice, TECH_1, AtlasImage(FrontImages, IMAGE_TECHLO), AtlasImage(FrontImages, IMAGE_TECHLO_HI), _("Technology Level 1"));
+		addMultiButton(TechnologyChoice, TECH_2, AtlasImage(FrontImages, IMAGE_TECHMED), AtlasImage(FrontImages, IMAGE_TECHMED_HI), _("Technology Level 2"));
+		addMultiButton(TechnologyChoice, TECH_3, AtlasImage(FrontImages, IMAGE_TECHHI), AtlasImage(FrontImages, IMAGE_TECHHI_HI), _("Technology Level 3"));
+		addMultiButton(TechnologyChoice, TECH_4, AtlasImage(FrontImages, IMAGE_COMPUTER_Y), AtlasImage(FrontImages, IMAGE_COMPUTER_Y_HI), _("Technology Level 4"));
+		optionsList->addWidgetToLayout(TechnologyChoice);
+		return TechnologyChoice;
+	};
+
 	/* Add additional controls if we are (or going to be) hosting the game */
 	if (ingame.side == InGameSide::HOST_OR_SINGLEPLAYER)
 	{
@@ -1433,15 +1446,7 @@ static void addGameOptions()
 			   starting the host is due to the fact that there is not enough room before the "Host Game" button is hidden.		*/
 			if (NetPlay.isHost)
 			{
-				auto TechnologyChoice = std::make_shared<MultichoiceWidget>(game.techLevel);
-				optionsList->attach(TechnologyChoice);
-				TechnologyChoice->id = MULTIOP_TECHLEVEL;
-				TechnologyChoice->setLabel(_("Tech"));
-				addMultiButton(TechnologyChoice, TECH_1, AtlasImage(FrontImages, IMAGE_TECHLO), AtlasImage(FrontImages, IMAGE_TECHLO_HI), _("Technology Level 1"));
-				addMultiButton(TechnologyChoice, TECH_2, AtlasImage(FrontImages, IMAGE_TECHMED), AtlasImage(FrontImages, IMAGE_TECHMED_HI), _("Technology Level 2"));
-				addMultiButton(TechnologyChoice, TECH_3, AtlasImage(FrontImages, IMAGE_TECHHI), AtlasImage(FrontImages, IMAGE_TECHHI_HI), _("Technology Level 3"));
-				addMultiButton(TechnologyChoice, TECH_4, AtlasImage(FrontImages, IMAGE_COMPUTER_Y), AtlasImage(FrontImages, IMAGE_COMPUTER_Y_HI), _("Technology Level 4"));
-				optionsList->addWidgetToLayout(TechnologyChoice);
+				addTechLevelMultibuttonWidget();
 			}
 			/* If not hosting (yet), add the button for starting the host. */
 			else
@@ -1454,6 +1459,11 @@ static void addGameOptions()
 				optionsList->addWidgetToLayout(hostButton);
 			}
 		}
+	}
+	else if (ingame.side == InGameSide::MULTIPLAYER_CLIENT)
+	{
+		// Add tech level widget
+		addTechLevelMultibuttonWidget();
 	}
 
 	// cancel
@@ -5262,6 +5272,11 @@ static void disableMultiButs()
 		((MultichoiceWidget *)widgGetFromID(psWScreen, MULTIOP_BASETYPE))->disable();  // camapign subtype.
 		((MultichoiceWidget *)widgGetFromID(psWScreen, MULTIOP_POWER))->disable();  // pow levels
 		((MultichoiceWidget *)widgGetFromID(psWScreen, MULTIOP_ALLIANCES))->disable();
+		auto psTechLevel = widgGetFromID(psWScreen, MULTIOP_TECHLEVEL);
+		if (psTechLevel)
+		{
+			((MultichoiceWidget *)psTechLevel)->disable();
+		}
 	}
 }
 

--- a/src/multiint.cpp
+++ b/src/multiint.cpp
@@ -952,6 +952,42 @@ void setLobbyError(LOBBY_ERROR_TYPES error_type)
 	}
 }
 
+void to_json(nlohmann::json& j, const JoinConnectionDescription::JoinConnectionType& v)
+{
+	switch (v)
+	{
+	case JoinConnectionDescription::JoinConnectionType::TCP_DIRECT:
+		j = "tcp";
+		break;
+	}
+}
+
+void from_json(const nlohmann::json& j, JoinConnectionDescription::JoinConnectionType& v)
+{
+	auto str = j.get<std::string>();
+	if (str == "tcp")
+	{
+		v = JoinConnectionDescription::JoinConnectionType::TCP_DIRECT;
+		return;
+	}
+	throw nlohmann::json::type_error::create(302, "JoinConnectionType value is unknown: \"" + str + "\"", &j);
+}
+
+void to_json(nlohmann::json& j, const JoinConnectionDescription& v)
+{
+	j = nlohmann::json::object();
+	j["h"] = v.host;
+	j["p"] = v.port;
+	j["t"] = v.type;
+}
+
+void from_json(const nlohmann::json& j, JoinConnectionDescription& v)
+{
+	v.host = j.at("h").get<std::string>();
+	v.port = j.at("p").get<int32_t>();
+	v.type = j.at("t").get<JoinConnectionDescription::JoinConnectionType>();
+}
+
 // NOTE: Must call NETinit(true); before this will actually work
 std::vector<JoinConnectionDescription> findLobbyGame(const std::string& lobbyAddress, unsigned int lobbyPort, uint32_t lobbyGameId)
 {

--- a/src/multiint.cpp
+++ b/src/multiint.cpp
@@ -1309,6 +1309,7 @@ static void addGameOptions()
 	{
 		auto editBox = addMultiEditBox(MULTIOP_OPTIONS, MULTIOP_PASSWORD_EDIT, MCOL0, MROW4, _("Click to set Password"), NetPlay.gamePassword, IMAGE_UNLOCK_BLUE, IMAGE_LOCK_BLUE, MULTIOP_PASSWORD_BUT);
 		editBox->setPlaceholder(_("Enter password here"));
+		editBox->setPlaceholderTextColor(WZCOL_TEXT_DARK);
 		auto *pPasswordButton = dynamic_cast<WzMultiButton*>(widgGetFromID(psWScreen, MULTIOP_PASSWORD_BUT));
 		if (pPasswordButton)
 		{

--- a/src/multiint.cpp
+++ b/src/multiint.cpp
@@ -122,6 +122,7 @@
 #include "multivote.h"
 #include "campaigninfo.h"
 #include "screens/joiningscreen.h"
+#include "titleui/widgets/lobbyplayerrow.h"
 
 #include "activity.h"
 #include <algorithm>
@@ -205,19 +206,12 @@ static std::weak_ptr<WzMultiplayerOptionsTitleUI> currentMultiOptionsTitleUI;
 
 // widget functions
 static W_EDITBOX* addMultiEditBox(UDWORD formid, UDWORD id, UDWORD x, UDWORD y, char const *tip, char const *tipres, UDWORD icon, UDWORD iconhi, UDWORD iconid);
-static std::shared_ptr<W_FORM> createBlueForm(int x, int y, int w, int h, WIDGET_DISPLAY displayFunc = intDisplayFeBox);
 static W_FORM * addBlueForm(UDWORD parent, UDWORD id, UDWORD x, UDWORD y, UDWORD w, UDWORD h, WIDGET_DISPLAY displayFunc = intDisplayFeBox);
 static int numSlotsToBeDisplayed();
 static inline bool spectatorSlotsSupported();
-static inline bool isSpectatorOnlySlot(UDWORD playerIdx);
-//static inline bool isSpectatorOnlyPosition(UDWORD playerPosition);
 
 // Drawing Functions
 static void displayChatEdit(WIDGET *psWidget, UDWORD xOffset, UDWORD yOffset);
-static void displayPlayer(WIDGET *psWidget, UDWORD xOffset, UDWORD yOffset);
-static void displayReadyBoxContainer(WIDGET *psWidget, UDWORD xOffset, UDWORD yOffset);
-static void displayColour(WIDGET *psWidget, UDWORD xOffset, UDWORD yOffset);
-static void displayTeamChooser(WIDGET *psWidget, UDWORD xOffset, UDWORD yOffset);
 static void displaySpectatorAddButton(WIDGET *psWidget, UDWORD xOffset, UDWORD yOffset);
 static void displayAi(WIDGET *psWidget, UDWORD xOffset, UDWORD yOffset);
 static void displayDifficulty(WIDGET *psWidget, UDWORD xOffset, UDWORD yOffset);
@@ -225,19 +219,8 @@ static void displayMultiEditBox(WIDGET *psWidget, UDWORD xOffset, UDWORD yOffset
 static void drawBlueBox_Spectator(UDWORD x, UDWORD y, UDWORD w, UDWORD h);
 static void drawBlueBox_SpectatorOnly(UDWORD x, UDWORD y, UDWORD w, UDWORD h);
 void intDisplayFeBox_SpectatorOnly(WIDGET *psWidget, UDWORD xOffset, UDWORD yOffset);
-static inline void drawBoxForPlayerInfoSegment(UDWORD playerIdx, UDWORD x, UDWORD y, UDWORD w, UDWORD h);
 
 // pUserData structures used by drawing functions
-struct DisplayPlayerCache {
-	std::string	fullMainText;	// the “full” main text (used for storing the full player name when displaying a player)
-	WzText		wzMainText;		// the main text
-
-	std::string fullAltNameText;
-	WzText		wzAltNameText;
-
-	WzText		wzSubText;		// the sub text (used for players)
-	WzText		wzEloText;      // the elo text (used for players)
-};
 struct DisplayPositionCache {
 	WzText wzPositionText;
 };
@@ -261,42 +244,31 @@ static bool		SendPositionRequest(UBYTE player, UBYTE chosenPlayer);
 static bool		SendPlayerSlotTypeRequest(uint32_t player, bool isSpectator);
 bool changeReadyStatus(UBYTE player, bool bReady);
 static void stopJoining(std::shared_ptr<WzTitleUI> parent);
-static int difficultyIcon(int difficulty);
 
 static void sendRoomChatMessage(char const *text, bool skipLocalDisplay = false);
 
-static bool multiplayPlayersReady();
-static bool multiplayIsStartingGame();
 // ////////////////////////////////////////////////////////////////////////////
 // map previews..
 
-static const char *difficultyList[] = { N_("Super Easy"), N_("Easy"), N_("Medium"), N_("Hard"), N_("Insane") };
+static std::array<const char *, 5> difficultyList = { N_("Super Easy"), N_("Easy"), N_("Medium"), N_("Hard"), N_("Insane") };
 static const AIDifficulty difficultyValue[] = { AIDifficulty::SUPEREASY, AIDifficulty::EASY, AIDifficulty::MEDIUM, AIDifficulty::HARD, AIDifficulty::INSANE };
-static struct
-{
-	bool scavengers;
-	bool alliances;
-	bool teams;
-	bool power;
-	bool difficulty;
-	bool ai;
-	bool position;
-	bool bases;
-	bool spectators;
-} locked;
+static MultiplayOptionsLocked locked;
 static bool spectatorHost = false;
 static uint16_t defaultOpenSpectatorSlots = 0;
-
-struct AIDATA
-{
-	AIDATA() : name{0}, js{0}, tip{0}, difficultyTips{0}, assigned(0) {}
-	char name[MAX_LEN_AI_NAME];
-	char js[MAX_LEN_AI_NAME];
-	char tip[255 + 128];            ///< may contain optional AI tournament data
-	char difficultyTips[5][255];    ///< optional difficulty level info
-	int assigned;                   ///< How many AIs have we assigned of this type
-};
 static std::vector<AIDATA> aidata;
+
+const std::vector<AIDATA>& getAIData() { return aidata; }
+const MultiplayOptionsLocked& getLockedOptions() { return locked; }
+
+const char* getDifficultyListStr(size_t idx)
+{
+	ASSERT_OR_RETURN("", idx < difficultyList.size(), "Invalid idx: %zu", idx);
+	return difficultyList[idx];
+}
+size_t getDifficultyListCount()
+{
+	return difficultyList.size();
+}
 
 class ChatBoxButton : public W_BUTTON
 {
@@ -1115,16 +1087,6 @@ static std::shared_ptr<W_FORM> addInlineChooserBlueForm(const std::shared_ptr<W_
 	return std::dynamic_pointer_cast<W_FORM>(psForm->shared_from_this());
 }
 
-static std::shared_ptr<W_FORM> createBlueForm(int x, int y, int w, int h, WIDGET_DISPLAY displayFunc /* = intDisplayFeBox*/)
-{
-	ASSERT(displayFunc != nullptr, "Must have a display func!");
-	auto form = std::make_shared<W_FORM>();
-	form->setGeometry(x, y, w, h);
-	form->style = WFORM_PLAIN;
-	form->displayFunction = displayFunc;
-	return form;
-}
-
 static W_FORM * addBlueForm(UDWORD parent, UDWORD id, UDWORD x, UDWORD y, UDWORD w, UDWORD h, WIDGET_DISPLAY displayFunc /* = intDisplayFeBox*/)
 {
 	ASSERT(displayFunc != nullptr, "Must have a display func!");
@@ -1443,12 +1405,12 @@ static void addGameOptions()
 	updateLimitIcons();
 }
 
-static bool isHostOrAdmin()
+bool isHostOrAdmin()
 {
 	return NetPlay.isHost || NetPlay.players[selectedPlayer].isAdmin;
 }
 
-static bool isPlayerHostOrAdmin(uint32_t playerIdx)
+bool isPlayerHostOrAdmin(uint32_t playerIdx)
 {
 	ASSERT_OR_RETURN(false, playerIdx < MAX_CONNECTED_PLAYERS, "Invalid player idx: %" PRIu32, playerIdx);
 	return (playerIdx == NetPlay.hostPlayer) || NetPlay.players[playerIdx].isAdmin;
@@ -1494,7 +1456,7 @@ static int getPlayerTeam(int i)
  * Checks if all players are on the same team. If so, return that team; if not, return -1;
  * if there are no players, return team MAX_PLAYERS.
  */
-static int allPlayersOnSameTeam(int except)
+int allPlayersOnSameTeam(int except)
 {
 	int minTeam = MAX_PLAYERS, maxTeam = 0;
 	for (unsigned i = 0; i < game.maxPlayers; ++i)
@@ -2009,7 +1971,7 @@ public:
 	}
 };
 
-static std::set<uint32_t> validPlayerIdxTargetsForPlayerPositionMove(uint32_t player)
+std::set<uint32_t> validPlayerIdxTargetsForPlayerPositionMove(uint32_t player)
 {
 	std::set<uint32_t> validTargetPlayerIdx;
 	for (uint32_t i = 0; i < game.maxPlayers; i++)
@@ -2602,7 +2564,7 @@ bool recvTeamRequest(NETQUEUE queue)
 	return changeTeam(player, team, queue.index); // we do this regardless, in case of sync issues
 }
 
-static bool SendReadyRequest(UBYTE player, bool bReady)
+bool sendReadyRequest(UBYTE player, bool bReady)
 {
 	if (NetPlay.isHost)			// do or request the change.
 	{
@@ -3422,10 +3384,7 @@ static SwapPlayerIndexesResult recvSwapPlayerIndexes(NETQUEUE queue, const std::
 	return SwapPlayerIndexesResult::SUCCESS;
 }
 
-static bool canChooseTeamFor(int i)
-{
-	return (i == selectedPlayer || isHostOrAdmin());
-}
+
 
 // ////////////////////////////////////////////////////////////////////////////
 // tabs for player box
@@ -4098,488 +4057,6 @@ void WzPlayerBoxTabs::displayOptionsOverlay(const std::shared_ptr<WIDGET>& psPar
 
 	widgRegisterOverlayScreenOnTopOfScreen(optionsOverlayScreen, lockedScreen);
 }
-
-// ////////////////////////////////////////////////////////////////////////////
-// player row widgets
-
-class WzPlayerRow : public WIDGET
-{
-protected:
-	WzPlayerRow(uint32_t playerIdx, const std::shared_ptr<WzMultiplayerOptionsTitleUI>& parent)
-	: WIDGET()
-	, parentTitleUI(parent)
-	, playerIdx(playerIdx)
-	{ }
-
-public:
-	static std::shared_ptr<WzPlayerRow> make(uint32_t playerIdx, const std::shared_ptr<WzMultiplayerOptionsTitleUI>& parent)
-	{
-		class make_shared_enabler: public WzPlayerRow {
-		public:
-			make_shared_enabler(uint32_t playerIdx, const std::shared_ptr<WzMultiplayerOptionsTitleUI>& parent) : WzPlayerRow(playerIdx, parent) { }
-		};
-		auto widget = std::make_shared<make_shared_enabler>(playerIdx, parent);
-
-		std::weak_ptr<WzMultiplayerOptionsTitleUI> titleUI(parent);
-
-		// add team button (also displays the spectator "eye" for spectators)
-		widget->teamButton = std::make_shared<W_BUTTON>();
-		widget->teamButton->setGeometry(0, 0, MULTIOP_TEAMSWIDTH, MULTIOP_TEAMSHEIGHT);
-		widget->teamButton->UserData = playerIdx;
-		widget->teamButton->displayFunction = displayTeamChooser;
-		widget->attach(widget->teamButton);
-		widget->teamButton->addOnClickHandler([playerIdx, titleUI](W_BUTTON& button){
-			auto strongTitleUI = titleUI.lock();
-			ASSERT_OR_RETURN(, strongTitleUI != nullptr, "Title UI is gone?");
-			if ((!locked.teams || !locked.spectators))  // Clicked on a team chooser
-			{
-				if (canChooseTeamFor(playerIdx))
-				{
-					widgScheduleTask([strongTitleUI, playerIdx] {
-						strongTitleUI->openTeamChooser(playerIdx);
-					});
-				}
-			}
-		});
-
-		// add player colour
-		widget->colorButton = std::make_shared<W_BUTTON>();
-		widget->colorButton->setGeometry(MULTIOP_TEAMSWIDTH, 0, MULTIOP_COLOUR_WIDTH, MULTIOP_PLAYERHEIGHT);
-		widget->colorButton->UserData = playerIdx;
-		widget->colorButton->displayFunction = displayColour;
-		widget->attach(widget->colorButton);
-		widget->colorButton->addOnClickHandler([playerIdx, titleUI](W_BUTTON& button){
-			auto strongTitleUI = titleUI.lock();
-			ASSERT_OR_RETURN(, strongTitleUI != nullptr, "Title UI is gone?");
-			if (playerIdx == selectedPlayer || isHostOrAdmin())
-			{
-				if (!NetPlay.players[playerIdx].isSpectator) // not a spectator
-				{
-					widgScheduleTask([strongTitleUI, playerIdx] {
-						strongTitleUI->openColourChooser(playerIdx);
-					});
-				}
-			}
-		});
-
-		// add ready button
-		widget->updateReadyButton();
-
-		// add player info box (takes up the rest of the space in the middle)
-		widget->playerInfo = std::make_shared<W_BUTTON>();
-		widget->playerInfo->UserData = playerIdx;
-		widget->playerInfo->displayFunction = displayPlayer;
-		widget->playerInfo->pUserData = new DisplayPlayerCache();
-		widget->playerInfo->setOnDelete([](WIDGET *psWidget) {
-			assert(psWidget->pUserData != nullptr);
-			delete static_cast<DisplayPlayerCache *>(psWidget->pUserData);
-			psWidget->pUserData = nullptr;
-		});
-		widget->attach(widget->playerInfo);
-		widget->playerInfo->setCalcLayout([](WIDGET *psWidget) {
-			auto psParent = std::dynamic_pointer_cast<WzPlayerRow>(psWidget->parent());
-			ASSERT_OR_RETURN(, psParent != nullptr, "Null parent");
-			int x0 = MULTIOP_TEAMSWIDTH + MULTIOP_COLOUR_WIDTH;
-			int width = psParent->readyButtonContainer->x() - x0;
-			psWidget->setGeometry(x0, 0, width, psParent->height());
-		});
-		widget->playerInfo->addOnClickHandler([playerIdx, titleUI](W_BUTTON& button){
-			auto strongTitleUI = titleUI.lock();
-			ASSERT_OR_RETURN(, strongTitleUI != nullptr, "Title UI is gone?");
-			if (playerIdx == selectedPlayer || isHostOrAdmin())
-			{
-				uint32_t player = playerIdx;
-				// host/admin can move any player, clients can request to move themselves if there are available slots
-				if (((player == selectedPlayer && validPlayerIdxTargetsForPlayerPositionMove(player).size() > 0) ||
-						(NetPlay.players[player].allocated && isHostOrAdmin()))
-					&& !locked.position
-					&& player < MAX_PLAYERS
-					&& !isSpectatorOnlySlot(player))
-				{
-					widgScheduleTask([strongTitleUI, player] {
-						strongTitleUI->openPositionChooser(player);
-					});
-				}
-				else if (!NetPlay.players[player].allocated && !locked.ai && NetPlay.isHost)
-				{
-					if (button.getOnClickButtonPressed() == WKEY_SECONDARY && player < MAX_PLAYERS)
-					{
-						// Right clicking distributes selected AI's type and difficulty to all other AIs
-						for (int i = 0; i < MAX_PLAYERS; ++i)
-						{
-							// Don't change open/closed slots or humans or spectator-only slots
-							if (NetPlay.players[i].ai >= 0 && i != player && !isHumanPlayer(i) && !isSpectatorOnlySlot(i))
-							{
-								NetPlay.players[i].ai = NetPlay.players[player].ai;
-								NetPlay.players[i].isSpectator = NetPlay.players[player].isSpectator;
-								NetPlay.players[i].difficulty = NetPlay.players[player].difficulty;
-								setPlayerName(i, getAIName(player));
-								NETBroadcastPlayerInfo(i);
-							}
-						}
-						widgScheduleTask([strongTitleUI] {
-							strongTitleUI->updatePlayers();
-							resetReadyStatus(false);
-						});
-					}
-					else
-					{
-						widgScheduleTask([strongTitleUI, player] {
-							strongTitleUI->openAiChooser(player);
-						});
-					}
-				}
-			}
-		});
-
-		// update tooltips and such
-		widget->updateState();
-
-		return widget;
-	}
-
-	void geometryChanged() override
-	{
-		if (readyButtonContainer)
-		{
-			readyButtonContainer->callCalcLayout();
-		}
-		if (playerInfo)
-		{
-			playerInfo->callCalcLayout();
-		}
-	}
-
-	void updateState()
-	{
-		// update team button tooltip
-		if (NetPlay.players[playerIdx].isSpectator)
-		{
-			teamButton->setTip(_("Spectator"));
-		}
-		else if (canChooseTeamFor(playerIdx) && !locked.teams)
-		{
-			teamButton->setTip(_("Choose Team"));
-		}
-		else if (locked.teams)
-		{
-			teamButton->setTip(_("Teams locked"));
-		}
-		else
-		{
-			teamButton->setTip(nullptr);
-		}
-
-		// hide team button if needed
-		bool trueMultiplayerMode = (bMultiPlayer && NetPlay.bComms) || (!NetPlay.isHost && ingame.localJoiningInProgress);
-		if (!alliancesSetTeamsBeforeGame(game.alliance) && !NetPlay.players[playerIdx].isSpectator && !trueMultiplayerMode)
-		{
-			teamButton->hide();
-		}
-		else
-		{
-			teamButton->show();
-		}
-
-		// update color tooltip
-		if ((selectedPlayer == playerIdx || NetPlay.isHost) && (!NetPlay.players[playerIdx].isSpectator))
-		{
-			colorButton->setTip(_("Click to change player colour"));
-		}
-		else
-		{
-			colorButton->setTip(nullptr);
-		}
-
-		// update player info box tooltip
-		std::string playerInfoTooltip;
-		if ((selectedPlayer == playerIdx || NetPlay.isHost) && NetPlay.players[playerIdx].allocated && !locked.position && !isSpectatorOnlySlot(playerIdx))
-		{
-			playerInfoTooltip = _("Click to change player position");
-		}
-		else if (!NetPlay.players[playerIdx].allocated)
-		{
-			if (NetPlay.isHost && !locked.ai)
-			{
-				playerInfo->style |= WBUT_SECONDARY;
-				if (!isSpectatorOnlySlot(playerIdx))
-				{
-					playerInfoTooltip = _("Click to change AI, right click to distribute choice");
-				}
-				else
-				{
-					playerInfoTooltip = _("Click to close spectator slot");
-				}
-			}
-			else if (NetPlay.players[playerIdx].ai >= 0)
-			{
-				// show AI description. Useful for challenges.
-				playerInfoTooltip = aidata[NetPlay.players[playerIdx].ai].tip;
-			}
-		}
-		if (NetPlay.players[playerIdx].allocated)
-		{
-			const PLAYERSTATS& stats = getMultiStats(playerIdx);
-			if (!stats.identity.empty())
-			{
-				if (!playerInfoTooltip.empty())
-				{
-					playerInfoTooltip += "\n";
-				}
-				std::string hash = stats.identity.publicHashString(20);
-				playerInfoTooltip += _("Player ID: ");
-				playerInfoTooltip += hash.empty()? _("(none)") : hash;
-			}
-			std::string autoratingTooltipText;
-			if (stats.autorating.valid)
-			{
-				if (!stats.autorating.altName.empty())
-				{
-					if (!autoratingTooltipText.empty())
-					{
-						autoratingTooltipText += "\n";
-					}
-					std::string altnameStr = stats.autorating.altName;
-					if (altnameStr.size() > 128)
-					{
-						altnameStr = altnameStr.substr(0, 128);
-					}
-					size_t maxLinePos = nthOccurrenceOfChar(altnameStr, '\n', 1);
-					if (maxLinePos != std::string::npos)
-					{
-						altnameStr = altnameStr.substr(0, maxLinePos);
-					}
-					autoratingTooltipText += std::string(_("Alt Name:")) + " " + altnameStr;
-				}
-				if (!stats.autorating.details.empty()
-					&& stats.autoratingFrom == RATING_SOURCE_LOCAL) // do not display host-provided details (for now)
-				{
-					if (!autoratingTooltipText.empty())
-					{
-						autoratingTooltipText += "\n";
-					}
-					std::string detailsstr = stats.autorating.details;
-					if (detailsstr.size() > 512)
-					{
-						detailsstr = detailsstr.substr(0, 512);
-					}
-					size_t maxLinePos = nthOccurrenceOfChar(detailsstr, '\n', 10);
-					if (maxLinePos != std::string::npos)
-					{
-						detailsstr = detailsstr.substr(0, maxLinePos);
-					}
-					autoratingTooltipText += std::string(_("Player rating:")) + "\n" + detailsstr;
-				}
-			}
-			if (!autoratingTooltipText.empty())
-			{
-				if (!playerInfoTooltip.empty())
-				{
-					playerInfoTooltip += "\n\n";
-				}
-				if (stats.autoratingFrom == RATING_SOURCE_HOST)
-				{
-					playerInfoTooltip += std::string("[") + _("Host provided") + "]\n";
-				}
-				else
-				{
-					playerInfoTooltip += std::string("[") + astringf(_("From: %s"), getAutoratingUrl().c_str()) + "]\n";
-				}
-				playerInfoTooltip += autoratingTooltipText;
-			}
-		}
-		playerInfo->setTip(playerInfoTooltip);
-
-		// update ready button
-		updateReadyButton();
-	}
-
-public:
-
-	void updateReadyButton()
-	{
-		int disallow = allPlayersOnSameTeam(-1);
-
-		if (!readyButtonContainer)
-		{
-			// add form to hold 'ready' botton
-			readyButtonContainer = createBlueForm(MULTIOP_PLAYERWIDTH - MULTIOP_READY_WIDTH, 0,
-						MULTIOP_READY_WIDTH, MULTIOP_READY_HEIGHT, displayReadyBoxContainer);
-			readyButtonContainer->UserData = playerIdx;
-			attach(readyButtonContainer);
-			readyButtonContainer->setCalcLayout([](WIDGET *psWidget) {
-				auto psParent = psWidget->parent();
-				ASSERT_OR_RETURN(, psParent != nullptr, "Null parent");
-				psWidget->setGeometry(psParent->width() - MULTIOP_READY_WIDTH, 0, psWidget->width(), psWidget->height());
-			});
-		}
-
-		auto deleteExistingReadyButton = [this]() {
-			if (readyButton)
-			{
-				widgDelete(readyButton.get());
-				readyButton = nullptr;
-			}
-			if (readyTextLabel)
-			{
-				widgDelete(readyTextLabel.get());
-				readyTextLabel = nullptr;
-			}
-		};
-		auto deleteExistingDifficultyButton = [this]() {
-			if (difficultyChooserButton)
-			{
-				widgDelete(difficultyChooserButton.get());
-				difficultyChooserButton = nullptr;
-			}
-		};
-
-		if (!NetPlay.players[playerIdx].allocated && NetPlay.players[playerIdx].ai >= 0)
-		{
-			// Add AI difficulty chooser in place of normal "ready" button
-			deleteExistingReadyButton();
-			int playerDifficulty = static_cast<int8_t>(NetPlay.players[playerIdx].difficulty);
-			int icon = difficultyIcon(playerDifficulty);
-			char tooltip[128 + 255];
-			if (playerDifficulty >= static_cast<int>(AIDifficulty::EASY) && playerDifficulty < static_cast<int>(AIDifficulty::INSANE) + 1)
-			{
-				sstrcpy(tooltip, _(difficultyList[playerDifficulty]));
-				if (NetPlay.players[playerIdx].ai < aidata.size())
-				{
-					const char *difficultyTip = aidata[NetPlay.players[playerIdx].ai].difficultyTips[playerDifficulty];
-					if (strcmp(difficultyTip, "") != 0)
-					{
-						sstrcat(tooltip, "\n");
-						sstrcat(tooltip, difficultyTip);
-					}
-				}
-			}
-			bool freshDifficultyButton = (difficultyChooserButton == nullptr);
-			difficultyChooserButton = addMultiBut(*readyButtonContainer, MULTIOP_DIFFICULTY_INIT_START + playerIdx, 6, 4, MULTIOP_READY_WIDTH, MULTIOP_READY_HEIGHT,
-						(NetPlay.isHost && !locked.difficulty) ? _("Click to change difficulty") : tooltip, icon, icon, icon, MAX_PLAYERS, (NetPlay.isHost && !locked.difficulty) ? 255 : 125);
-			auto player = playerIdx;
-			auto weakTitleUi = parentTitleUI;
-			if (freshDifficultyButton)
-			{
-				difficultyChooserButton->addOnClickHandler([player, weakTitleUi](W_BUTTON&){
-					auto strongTitleUI = weakTitleUi.lock();
-					ASSERT_OR_RETURN(, strongTitleUI != nullptr, "Title UI is gone?");
-					if (!locked.difficulty && NetPlay.isHost)
-					{
-						widgScheduleTask([strongTitleUI, player] {
-							strongTitleUI->openDifficultyChooser(player);
-						});
-					}
-				});
-			}
-			return;
-		}
-		else if (!NetPlay.players[playerIdx].allocated)
-		{
-			// closed or open - remove ready / difficulty button
-			deleteExistingReadyButton();
-			deleteExistingDifficultyButton();
-			return;
-		}
-
-		if (disallow != -1)
-		{
-			// remove ready / difficulty button
-			deleteExistingReadyButton();
-			deleteExistingDifficultyButton();
-			return;
-		}
-
-		deleteExistingDifficultyButton();
-
-		bool isMe = playerIdx == selectedPlayer;
-		int isReady = NETgetDownloadProgress(playerIdx) != 100 ? 2 : NetPlay.players[playerIdx].ready ? 1 : 0;
-		char const *const toolTips[2][3] = {{_("Waiting for player"), _("Player is ready"), _("Player is downloading")}, {_("Click when ready"), _("Waiting for other players"), _("Waiting for download")}};
-		unsigned images[2][3] = {{IMAGE_CHECK_OFF, IMAGE_CHECK_ON, IMAGE_CHECK_DOWNLOAD}, {IMAGE_CHECK_OFF_HI, IMAGE_CHECK_ON_HI, IMAGE_CHECK_DOWNLOAD_HI}};
-
-		// draw 'ready' button
-		bool greyedOutReady = (NetPlay.players[playerIdx].isSpectator && NetPlay.players[playerIdx].ready) || (playerIdx != selectedPlayer);
-		bool freshReadyButton = (readyButton == nullptr);
-		readyButton = addMultiBut(*readyButtonContainer, MULTIOP_READY_START + playerIdx, 3, 10, MULTIOP_READY_WIDTH, MULTIOP_READY_HEIGHT,
-					toolTips[isMe][isReady], images[0][isReady], images[0][isReady], images[isMe][isReady], MAX_PLAYERS, (!greyedOutReady) ? 255 : 125);
-		ASSERT_OR_RETURN(, readyButton != nullptr, "Failed to create ready button");
-		readyButton->minClickInterval = GAME_TICKS_PER_SEC;
-		readyButton->unlock();
-		if (greyedOutReady && !NetPlay.isHost)
-		{
-			std::shared_ptr<WzMultiButton> pReadyBut_MultiButton = std::dynamic_pointer_cast<WzMultiButton>(readyButton);
-			if (pReadyBut_MultiButton)
-			{
-				pReadyBut_MultiButton->downStateMask = WBUT_DOWN | WBUT_CLICKLOCK;
-			}
-			auto currentState = readyButton->getState();
-			readyButton->setState(currentState | WBUT_LOCK);
-		}
-		if (freshReadyButton)
-		{
-			// must add onclick handler
-			auto player = playerIdx;
-			auto weakTitleUi = parentTitleUI;
-			readyButton->addOnClickHandler([player, weakTitleUi](W_BUTTON& button){
-				auto pButton = button.shared_from_this();
-				widgScheduleTask([weakTitleUi, player, pButton] {
-					auto strongTitleUI = weakTitleUi.lock();
-					ASSERT_OR_RETURN(, strongTitleUI != nullptr, "Title UI is gone?");
-
-					if (player == selectedPlayer
-						&& (!NetPlay.players[player].isSpectator || !NetPlay.players[player].ready || NetPlay.isHost)) // spectators can never toggle off "ready"
-					{
-						// Lock the "ready" button (until the request is processed)
-						pButton->setState(WBUT_LOCK);
-
-						SendReadyRequest(selectedPlayer, !NetPlay.players[player].ready);
-
-						// if hosting try to start the game if everyone is ready
-						if (NetPlay.isHost && multiplayPlayersReady())
-						{
-							startMultiplayerGame();
-							// reset flag in case people dropped/quit on join screen
-							NETsetPlayerConnectionStatus(CONNECTIONSTATUS_NORMAL, NET_ALL_PLAYERS);
-						}
-					}
-
-					if (NetPlay.isHost && !alliancesSetTeamsBeforeGame(game.alliance))
-					{
-						if (mouseDown(MOUSE_RMB) && player != NetPlay.hostPlayer) // both buttons....
-						{
-							std::string msg = astringf(_("The host has kicked %s from the game!"), getPlayerName(player));
-							sendRoomSystemMessage(msg.c_str());
-							kickPlayer(player, _("The host has kicked you from the game."), ERROR_KICKED, false);
-							resetReadyStatus(true);		//reset and send notification to all clients
-						}
-					}
-				});
-			});
-		}
-
-		if (!readyTextLabel)
-		{
-			readyTextLabel = std::make_shared<W_LABEL>();
-			readyButtonContainer->attach(readyTextLabel);
-			readyTextLabel->id = MULTIOP_READY_START + MAX_CONNECTED_PLAYERS + playerIdx;
-		}
-		readyTextLabel->setGeometry(0, 0, MULTIOP_READY_WIDTH, 17);
-		readyTextLabel->setTextAlignment(WLAB_ALIGNBOTTOM);
-		readyTextLabel->setFont(font_small, WZCOL_TEXT_BRIGHT);
-		readyTextLabel->setString(_("READY?"));
-	}
-
-private:
-	std::weak_ptr<WzMultiplayerOptionsTitleUI> parentTitleUI;
-	unsigned playerIdx = 0;
-	std::shared_ptr<W_BUTTON> teamButton;
-	std::shared_ptr<W_BUTTON> colorButton;
-	std::shared_ptr<W_BUTTON> playerInfo;
-	std::shared_ptr<WIDGET> readyButtonContainer;
-	std::shared_ptr<W_BUTTON> difficultyChooserButton;
-	std::shared_ptr<W_BUTTON> readyButton;
-	std::shared_ptr<W_LABEL> readyTextLabel;
-};
 
 // ////////////////////////////////////////////////////////////////////////////
 
@@ -5980,7 +5457,7 @@ static void loadMapPlayerSettings(WzConfig& ini)
 			}
 
 			WzString value = ini.value("difficulty", "Medium").toWzString();
-			for (unsigned j = 0; j < ARRAY_SIZE(difficultyList); ++j)
+			for (unsigned j = 0; j < difficultyList.size(); ++j)
 			{
 				if (strcasecmp(difficultyList[j], value.toUtf8().c_str()) == 0)
 				{
@@ -6754,7 +6231,7 @@ void handleAutoReadyRequest()
 	if (desiredReadyState != NetPlay.players[selectedPlayer].ready)
 	{
 		// Automatically set ready status
-		SendReadyRequest(selectedPlayer, desiredReadyState);
+		sendReadyRequest(selectedPlayer, desiredReadyState);
 	}
 }
 
@@ -7993,7 +7470,7 @@ void WzMultiplayerOptionsTitleUI::start()
 		{
 			processMultiopWidgets(MULTIOP_HOST);
 		}
-		SendReadyRequest(selectedPlayer, true);
+		sendReadyRequest(selectedPlayer, true);
 		if (getHostLaunch() == HostLaunch::Skirmish)
 		{
 			startMultiplayerGame();
@@ -8033,34 +7510,6 @@ void displayChatEdit(WIDGET *psWidget, UDWORD xOffset, UDWORD yOffset)
 
 // ////////////////////////////////////////////////////////////////////////////
 
-void displayTeamChooser(WIDGET *psWidget, UDWORD xOffset, UDWORD yOffset)
-{
-	int x = xOffset + psWidget->x();
-	int y = yOffset + psWidget->y();
-	UDWORD		i = psWidget->UserData;
-
-	ASSERT_OR_RETURN(, i < MAX_CONNECTED_PLAYERS, "Index (%" PRIu32 ") out of bounds", i);
-
-	drawBoxForPlayerInfoSegment(i, x, y, psWidget->width(), psWidget->height());
-
-	if (!NetPlay.players[i].isSpectator)
-	{
-		if (alliancesSetTeamsBeforeGame(game.alliance))
-		{
-			ASSERT_OR_RETURN(, NetPlay.players[i].team >= 0 && NetPlay.players[i].team < MAX_PLAYERS, "Team index out of bounds");
-			iV_DrawImage(FrontImages, IMAGE_TEAM0 + NetPlay.players[i].team, x + 1, y + 8);
-		}
-		else
-		{
-			// TODO: Maybe display something else here to signify "no team, FFA"
-		}
-	}
-	else
-	{
-		iV_DrawImage(FrontImages, IMAGE_SPECTATOR, x + 1, y + 8);
-	}
-}
-
 void displaySpectatorAddButton(WIDGET *psWidget, UDWORD xOffset, UDWORD yOffset)
 {
 	int x = xOffset + psWidget->x();
@@ -8070,7 +7519,7 @@ void displaySpectatorAddButton(WIDGET *psWidget, UDWORD xOffset, UDWORD yOffset)
 	iV_DrawImage(FrontImages, IMAGE_SPECTATOR, x + 2, y + 1);
 }
 
-static void displayAi(WIDGET *psWidget, UDWORD xOffset, UDWORD yOffset)
+void displayAi(WIDGET *psWidget, UDWORD xOffset, UDWORD yOffset)
 {
 	// Any widget using displayAi must have its pUserData initialized to a (DisplayAICache*)
 	assert(psWidget->pUserData != nullptr);
@@ -8083,6 +7532,7 @@ static void displayAi(WIDGET *psWidget, UDWORD xOffset, UDWORD yOffset)
 	drawBlueBox(x, y, psWidget->width(), psWidget->height());
 	WzString displayText;
 	PIELIGHT textColor = WZCOL_FORM_TEXT;
+
 	if (j >= 0)
 	{
 		if (j < aidata.size())
@@ -8117,7 +7567,7 @@ static void displayAi(WIDGET *psWidget, UDWORD xOffset, UDWORD yOffset)
 	cache.wzText.render(x + 10, y + 22, textColor);
 }
 
-static int difficultyIcon(int difficulty)
+int difficultyIcon(int difficulty)
 {
 	switch (difficulty)
 	{
@@ -8139,304 +7589,13 @@ static void displayDifficulty(WIDGET *psWidget, UDWORD xOffset, UDWORD yOffset)
 	const int y = yOffset + psWidget->y();
 	const int j = psWidget->UserData;
 
-	ASSERT_OR_RETURN(, j < ARRAY_SIZE(difficultyList), "Bad difficulty found: %d", j);
+	ASSERT_OR_RETURN(, j < difficultyList.size(), "Bad difficulty found: %d", j);
 	drawBlueBox(x, y, psWidget->width(), psWidget->height());
 	iV_DrawImage(FrontImages, difficultyIcon(j), x + 5, y + 5);
 	cache.wzDifficultyText.setText(gettext(difficultyList[j]), font_regular);
 	cache.wzDifficultyText.render(x + 42, y + 22, WZCOL_FORM_TEXT);
 }
 
-static bool isKnownPlayer(std::map<std::string, EcKey::Key> const &knownPlayers, std::string const &name, EcKey const &key)
-{
-	if (key.empty())
-	{
-		return false;
-	}
-	std::map<std::string, EcKey::Key>::const_iterator i = knownPlayers.find(name);
-	return i != knownPlayers.end() && key.toBytes(EcKey::Public) == i->second;
-}
-
-static void displayAltNameBox(int x, int y, WIDGET *psWidget, DisplayPlayerCache& cache, const PLAYERSTATS::Autorating& ar, bool isHighlight)
-{
-	int altNameBoxWidth = cache.wzAltNameText.width() + 4;
-	int altNameBoxHeight = cache.wzAltNameText.lineSize() + 2;
-	int altNameBoxX0 = (x + psWidget->width()) - altNameBoxWidth;
-	PIELIGHT altNameBoxColor = WZCOL_MENU_BORDER;
-	altNameBoxColor.byte.a = static_cast<uint8_t>(static_cast<float>(altNameBoxColor.byte.a) * (isHighlight ? 0.3f : 0.75f));
-	pie_UniTransBoxFill(altNameBoxX0, y, altNameBoxX0 + altNameBoxWidth, y + altNameBoxHeight, altNameBoxColor);
-
-	int altNameTextY0 = y + (altNameBoxHeight - cache.wzAltNameText.lineSize()) / 2 - cache.wzAltNameText.aboveBase();
-	PIELIGHT altNameTextColor = WZCOL_TEXT_MEDIUM;
-	if (ar.altNameTextColorOverride[0] != 255 || ar.altNameTextColorOverride[1] != 255 || ar.altNameTextColorOverride[2] != 255)
-	{
-		altNameTextColor = pal_Colour(ar.altNameTextColorOverride[0], ar.altNameTextColorOverride[1], ar.altNameTextColorOverride[2]);
-	}
-	if (isHighlight)
-	{
-		altNameTextColor.byte.a = static_cast<uint8_t>(static_cast<float>(altNameTextColor.byte.a) * 0.3f);
-	}
-	cache.wzAltNameText.render(altNameBoxX0 + 2, altNameTextY0, altNameTextColor);
-}
-
-// ////////////////////////////////////////////////////////////////////////////
-void displayPlayer(WIDGET *psWidget, UDWORD xOffset, UDWORD yOffset)
-{
-	// Any widget using displayPlayer must have its pUserData initialized to a (DisplayPlayerCache*)
-	assert(psWidget->pUserData != nullptr);
-	DisplayPlayerCache& cache = *static_cast<DisplayPlayerCache *>(psWidget->pUserData);
-
-	int const x = xOffset + psWidget->x();
-	int const y = yOffset + psWidget->y();
-	unsigned const j = psWidget->UserData;
-	bool isHighlight = (psWidget->getState() & WBUT_HIGHLIGHT) != 0;
-
-	const int nameX = 32;
-
-	unsigned downloadProgress = NETgetDownloadProgress(j);
-
-	drawBoxForPlayerInfoSegment(j, x, y, psWidget->width(), psWidget->height());
-	if (downloadProgress != 100)
-	{
-		char progressString[MAX_STR_LENGTH];
-		ssprintf(progressString, j != selectedPlayer ? _("Sending Map: %u%% ") : _("Map: %u%% downloaded"), downloadProgress);
-		cache.wzMainText.setText(progressString, font_regular);
-		cache.wzMainText.render(x + 5, y + 22, WZCOL_FORM_TEXT);
-		cache.fullMainText = progressString;
-		return;
-	}
-	else if (ingame.localOptionsReceived && NetPlay.players[j].allocated)					// only draw if real player!
-	{
-		const PLAYERSTATS& stat = getMultiStats(j);
-		auto ar = stat.autorating;
-
-		std::string name = getPlayerName(j);
-
-		std::map<std::string, EcKey::Key> serverPlayers;  // TODO Fill this with players known to the server (needs implementing on the server, too). Currently useless.
-
-		PIELIGHT colour;
-		if (ingame.PingTimes[j] >= PING_LIMIT)
-		{
-			colour = WZCOL_FORM_PLAYER_NOPING;
-		}
-		else if (isKnownPlayer(serverPlayers, name, getMultiStats(j).identity))
-		{
-			colour = WZCOL_FORM_PLAYER_KNOWN_BY_SERVER;
-		}
-		else if (isLocallyKnownPlayer(name, getMultiStats(j).identity))
-		{
-			colour = WZCOL_FORM_PLAYER_KNOWN;
-		}
-		else
-		{
-			colour = WZCOL_FORM_PLAYER_UNKNOWN;
-		}
-
-		// name
-		if (cache.fullMainText != name)
-		{
-			if ((int)iV_GetTextWidth(name.c_str(), font_regular) > psWidget->width() - nameX)
-			{
-				while (!name.empty() && (int)iV_GetTextWidth((name + "...").c_str(), font_regular) > psWidget->width() - nameX)
-				{
-					name.resize(name.size() - 1);  // Clip name.
-				}
-				name += "...";
-			}
-			cache.wzMainText.setText(WzString::fromUtf8(name), font_regular);
-			cache.fullMainText = name;
-		}
-		WzString subText;
-		if (j == NetPlay.hostPlayer && NetPlay.bComms)
-		{
-			subText += _("HOST");
-		}
-		if (NetPlay.bComms && j != selectedPlayer)
-		{
-			char buf[250] = {'\0'};
-
-			// show "actual" ping time
-			ssprintf(buf, "%s%s: ", subText.isEmpty() ? "" : ", ", _("Ping"));
-			subText += buf;
-			if (ingame.PingTimes[j] < PING_LIMIT)
-			{
-				ssprintf(buf, "%03d", ingame.PingTimes[j]);
-			}
-			else
-			{
-				ssprintf(buf, "%s", "∞");  // Player has ping of somewhat questionable quality.
-			}
-			subText += buf;
-		}
-
-		if (!ar.valid)
-		{
-			ar.dummy = stat.played < 5;
-			// star 1 total droid kills
-			ar.star[0] = stat.totalKills > 600? 1 : stat.totalKills > 300? 2 : stat.totalKills > 150? 3 : 0;
-
-			// star 2 games played
-			ar.star[1] = stat.played > 200? 1 : stat.played > 100? 2 : stat.played > 50? 3 : 0;
-
-			// star 3 games won.
-			ar.star[2] = stat.wins > 80? 1 : stat.wins > 40? 2 : stat.wins > 10? 3 : 0;
-
-			// medals.
-			ar.medal = stat.wins >= 24 && stat.wins > 8 * stat.losses? 1 : stat.wins >= 12 && stat.wins > 4 * stat.losses? 2 : stat.wins >= 6 && stat.wins > 2 * stat.losses? 3 : 0;
-
-			ar.level = 0;
-			ar.autohoster = false;
-			ar.elo.clear();
-		}
-
-		if (cache.fullAltNameText != ar.altName)
-		{
-			std::string altName = ar.altName;
-			int maxAltNameWidth = static_cast<int>(static_cast<float>(psWidget->width() - nameX) * 0.65f);
-			iV_fonts fontID = font_small;
-			cache.wzAltNameText.setText(WzString::fromUtf8(altName), fontID);
-			cache.fullAltNameText = altName;
-			if (cache.wzAltNameText.width() > maxAltNameWidth)
-			{
-				while (!altName.empty() && ((int)iV_GetTextWidth(altName.c_str(), cache.wzAltNameText.getFontID()) + iV_GetEllipsisWidth(cache.wzAltNameText.getFontID())) > maxAltNameWidth)
-				{
-					altName.resize(altName.size() - 1);  // Clip alt name.
-				}
-				altName += "\u2026";
-				cache.wzAltNameText.setText(WzString::fromUtf8(altName), fontID);
-			}
-		}
-
-		if (!ar.altName.empty() && isHighlight)
-		{
-			// display first, behind everything
-			displayAltNameBox(x, y, psWidget, cache, ar, isHighlight);
-		}
-
-		int H = 5;
-		cache.wzMainText.render(x + nameX, y + 22 - H*!subText.isEmpty() - H*(ar.valid && !ar.elo.empty()), colour);
-		if (!subText.isEmpty())
-		{
-			cache.wzSubText.setText(subText, font_small);
-			cache.wzSubText.render(x + nameX, y + 28 - H*!ar.elo.empty(), WZCOL_TEXT_MEDIUM);
-		}
-
-		if (ar.autohoster)
-		{
-			iV_DrawImage(FrontImages, IMAGE_PLAYER_PC, x, y + 11);
-		}
-		else if (ar.dummy)
-		{
-			iV_DrawImage(FrontImages, IMAGE_MEDAL_DUMMY, x + 4, y + 13);
-		}
-		else
-		{
-			constexpr int starImgs[4] = {0, IMAGE_MULTIRANK1, IMAGE_MULTIRANK2, IMAGE_MULTIRANK3};
-			if (1 <= ar.star[0] && ar.star[0] < ARRAY_SIZE(starImgs))
-			{
-				iV_DrawImage(FrontImages, starImgs[ar.star[0]], x + 4, y + 3);
-			}
-			if (1 <= ar.star[1] && ar.star[1] < ARRAY_SIZE(starImgs))
-			{
-				iV_DrawImage(FrontImages, starImgs[ar.star[1]], x + 4, y + 13);
-			}
-			if (1 <= ar.star[2] && ar.star[2] < ARRAY_SIZE(starImgs))
-			{
-				iV_DrawImage(FrontImages, starImgs[ar.star[2]], x + 4, y + 23);
-			}
-			constexpr int medalImgs[4] = {0, IMAGE_MEDAL_GOLD, IMAGE_MEDAL_SILVER, IMAGE_MEDAL_BRONZE};
-			if (1 <= ar.medal && ar.medal < ARRAY_SIZE(medalImgs))
-			{
-				iV_DrawImage(FrontImages, medalImgs[ar.medal], x + 16 - 2*(ar.level != 0), y + 11);
-			}
-		}
-		constexpr int levelImgs[9] = {0, IMAGE_LEV_0, IMAGE_LEV_1, IMAGE_LEV_2, IMAGE_LEV_3, IMAGE_LEV_4, IMAGE_LEV_5, IMAGE_LEV_6, IMAGE_LEV_7};
-		if (ar.level > 0 && ar.level < ARRAY_SIZE(levelImgs))
-		{
-			iV_DrawImage(IntImages, levelImgs[ar.level], x + 24, y + 15);
-		}
-
-		if (!ar.elo.empty())
-		{
-			PIELIGHT eloColour = WZCOL_TEXT_BRIGHT;
-			if (ar.eloTextColorOverride[0] != 255 || ar.eloTextColorOverride[1] != 255 || ar.eloTextColorOverride[2] != 255)
-			{
-				eloColour = pal_Colour(ar.eloTextColorOverride[0], ar.eloTextColorOverride[1], ar.eloTextColorOverride[2]);
-			}
-			cache.wzEloText.setText(WzString::fromUtf8(ar.elo), font_small);
-			cache.wzEloText.render(x + nameX, y + 28 + H*!subText.isEmpty(), eloColour);
-		}
-
-		if (!ar.altName.empty() && !isHighlight)
-		{
-			// display last, over top of everything
-			displayAltNameBox(x, y, psWidget, cache, ar, isHighlight);
-		}
-	}
-	else	// AI
-	{
-		char aitext[100];
-
-		if (NetPlay.players[j].ai >= 0)
-		{
-			iV_DrawImage(FrontImages, IMAGE_PLAYER_PC, x, y + 11);
-		}
-
-		// challenges may use custom AIs that are not in aidata and set to 127
-		if (!challengeActive)
-		{
-		    ASSERT_OR_RETURN(, NetPlay.players[j].ai < (int)aidata.size(), "Uh-oh, AI index out of bounds");
-		}
-
-		PIELIGHT textColor = WZCOL_FORM_TEXT;
-		switch (NetPlay.players[j].ai)
-		{
-		case AI_OPEN:
-			if (!NetPlay.players[j].isSpectator)
-			{
-				sstrcpy(aitext, _("Open"));
-			}
-			else
-			{
-				sstrcpy(aitext, _("Spectator"));
-				textColor.byte.a = 220;
-			}
-			break;
-		case AI_CLOSED: sstrcpy(aitext, _("Closed")); break;
-		default: sstrcpy(aitext, getPlayerName(j)); break;
-		}
-		cache.wzMainText.setText(aitext, font_regular);
-		cache.wzMainText.render(x + nameX, y + 22, textColor);
-		cache.fullMainText = aitext;
-	}
-}
-
-static int factionIcon(FactionID faction)
-{
-	switch (faction)
-	{
-	case 0: return IMAGE_FACTION_NORMAL;
-	case 1: return IMAGE_FACTION_NEXUS;
-	case 2: return IMAGE_FACTION_COLLECTIVE;
-	default: return IMAGE_NO;	/// what??
-	}
-}
-
-void displayColour(WIDGET *psWidget, UDWORD xOffset, UDWORD yOffset)
-{
-	const int x = xOffset + psWidget->x();
-	const int y = yOffset + psWidget->y();
-	const int j = psWidget->UserData;
-
-	drawBoxForPlayerInfoSegment(j, x, y, psWidget->width(), psWidget->height());
-	if (!NetPlay.players[j].fileSendInProgress() && (isHumanPlayer(j) || NetPlay.players[j].difficulty != AIDifficulty::DISABLED) && !NetPlay.players[j].isSpectator)
-	{
-		int player = getPlayerColour(j);
-		STATIC_ASSERT(MAX_PLAYERS <= 16);
-		iV_DrawImageTc(FrontImages, IMAGE_PLAYERN, IMAGE_PLAYERN_TC, x + 3, y + 9, pal_GetTeamColour(player));
-		FactionID faction = NetPlay.players[j].faction;
-		iV_DrawImageFileAnisotropic(FrontImages, factionIcon(faction), x, y, Vector2f(11, 9));
-	}
-}
 
 // ////////////////////////////////////////////////////////////////////////////
 // Display blue box
@@ -8497,35 +7656,6 @@ void intDisplayFeBox_SpectatorOnly(WIDGET *psWidget, UDWORD xOffset, UDWORD yOff
 	int h = psWidget->height();
 
 	drawBlueBox_SpectatorOnly(x, y, w, h);
-}
-
-static inline void drawBoxForPlayerInfoSegment(UDWORD playerIdx, UDWORD x, UDWORD y, UDWORD w, UDWORD h)
-{
-	ASSERT(playerIdx < NetPlay.players.size(), "Invalid playerIdx: %zu", static_cast<size_t>(playerIdx));
-	if (playerIdx >= NetPlay.players.size() || !NetPlay.players[playerIdx].isSpectator)
-	{
-		drawBlueBox(x, y, w, h);
-	}
-	else
-	{
-		if (!isSpectatorOnlySlot(playerIdx))
-		{
-			drawBlueBox_Spectator(x, y, w, h);
-		}
-		else
-		{
-			drawBlueBox_SpectatorOnly(x, y, w, h);
-		}
-	}
-}
-
-static void displayReadyBoxContainer(WIDGET *psWidget, UDWORD xOffset, UDWORD yOffset)
-{
-	const int x = xOffset + psWidget->x();
-	const int y = yOffset + psWidget->y();
-	const int j = psWidget->UserData;
-
-	drawBoxForPlayerInfoSegment(j, x, y, psWidget->width(), psWidget->height());
 }
 
 // ////////////////////////////////////////////////////////////////////////////
@@ -8717,7 +7847,7 @@ std::shared_ptr<W_BUTTON> addMultiBut(const std::shared_ptr<W_SCREEN> &screen, U
 }
 
 /* Returns true if the multiplayer game can start (i.e. all players are ready) */
-static bool multiplayPlayersReady()
+bool multiplayPlayersReady()
 {
 	bool bReady = true;
 	size_t numReadyPlayers = 0;
@@ -8745,7 +7875,7 @@ static bool multiplayPlayersReady()
 	return bReady && (numReadyPlayers > 1) && (allPlayersOnSameTeam(-1) == -1);
 }
 
-static bool multiplayIsStartingGame()
+bool multiplayIsStartingGame()
 {
 	return bInActualHostedLobby && multiplayPlayersReady();
 }
@@ -8827,7 +7957,7 @@ static inline bool spectatorSlotsSupported()
 }
 
 // NOTE: Pass in the index in the NetPlay.players array
-static inline bool isSpectatorOnlySlot(UDWORD playerIdx)
+bool isSpectatorOnlySlot(UDWORD playerIdx)
 {
 	ASSERT_OR_RETURN(false, playerIdx < NetPlay.players.size(), "Invalid playerIdx: %" PRIu32 "", playerIdx);
 	return playerIdx >= MAX_PLAYERS || NetPlay.players[playerIdx].position >= game.maxPlayers;

--- a/src/multiint.cpp
+++ b/src/multiint.cpp
@@ -2510,7 +2510,7 @@ static void informIfAdminChangedOtherTeam(uint32_t targetPlayerIdx, uint32_t res
 	sendQuickChat(WzQuickChatMessage::INTERNAL_ADMIN_ACTION_NOTICE, realSelectedPlayer, WzQuickChatTargeting::targetAll(), WzQuickChatDataContexts::INTERNAL_ADMIN_ACTION_NOTICE::constructMessageData(WzQuickChatDataContexts::INTERNAL_ADMIN_ACTION_NOTICE::Context::Team, responsibleIdx, targetPlayerIdx));
 
 	std::string senderPublicKeyB64 = base64Encode(getMultiStats(responsibleIdx).identity.toBytes(EcKey::Public));
-	debug(LOG_INFO, "Admin %s (%s) changed team of player ([%u] %s) to: %d", NetPlay.players[responsibleIdx].name, senderPublicKeyB64.c_str(), NetPlay.players[targetPlayerIdx].position, NetPlay.players[targetPlayerIdx].name, NetPlay.players[targetPlayerIdx].team);
+	debug(LOG_INFO, "Admin %s (%s) changed team of player ([%u] %s) to: %d", getPlayerName(responsibleIdx), senderPublicKeyB64.c_str(), NetPlay.players[targetPlayerIdx].position, getPlayerName(targetPlayerIdx), NetPlay.players[targetPlayerIdx].team);
 }
 
 static bool changeTeam(UBYTE player, UBYTE team, uint32_t responsibleIdx)
@@ -2598,7 +2598,7 @@ bool recvTeamRequest(NETQUEUE queue)
 	{
 		resetReadyStatus(false);
 	}
-	debug(LOG_NET, "%s is now part of team: %d", NetPlay.players[player].name, (int) team);
+	debug(LOG_NET, "%s is now part of team: %d", getPlayerName(player), (int) team);
 	return changeTeam(player, team, queue.index); // we do this regardless, in case of sync issues
 }
 
@@ -2612,7 +2612,7 @@ static bool SendReadyRequest(UBYTE player, bool bReady)
 			std::string playerPublicKeyB64 = base64Encode(getMultiStats(player).identity.toBytes(EcKey::Public));
 			std::string playerIdentityHash = getMultiStats(player).identity.publicHashString();
 			std::string playerVerifiedStatus = (ingame.VerifiedIdentity[player]) ? "V" : "?";
-			std::string playerName = NetPlay.players[player].name;
+			std::string playerName = getPlayerName(player);
 			std::string playerNameB64 = base64Encode(std::vector<unsigned char>(playerName.begin(), playerName.end()));
 			wz_command_interface_output("WZEVENT: readyStatus=%d: %" PRIu32 " %s %s %s %s %s\n", bReady ? 1 : 0, player, playerPublicKeyB64.c_str(), playerIdentityHash.c_str(), playerVerifiedStatus.c_str(), playerNameB64.c_str(), NetPlay.players[player].IPtextAddress);
 
@@ -2667,7 +2667,7 @@ bool recvReadyRequest(NETQUEUE queue)
 	if (stats.identity.empty() && bReady && !NetPlay.players[player].isSpectator)
 	{
 		// log this!
-		debug(LOG_INFO, "Player has empty identity: (player: %u, name: \"%s\", IP: %s)", (unsigned)player, NetPlay.players[player].name, NetPlay.players[player].IPtextAddress);
+		debug(LOG_INFO, "Player has empty identity: (player: %u, name: \"%s\", IP: %s)", (unsigned)player, getPlayerName(player), NetPlay.players[player].IPtextAddress);
 
 		// kick the player
 		HandleBadParam("NET_READY_REQUEST failed due to player empty identity.", player, queue.index);
@@ -2680,7 +2680,7 @@ bool recvReadyRequest(NETQUEUE queue)
 		std::string playerPublicKeyB64 = base64Encode(stats.identity.toBytes(EcKey::Public));
 		std::string playerIdentityHash = stats.identity.publicHashString();
 		std::string playerVerifiedStatus = (ingame.VerifiedIdentity[player]) ? "V" : "?";
-		std::string playerName = NetPlay.players[player].name;
+		std::string playerName = getPlayerName(player);
 		std::string playerNameB64 = base64Encode(std::vector<unsigned char>(playerName.begin(), playerName.end()));
 		wz_command_interface_output("WZEVENT: readyStatus=%d: %" PRIu32 " %s %s %s %s %s\n", bReady ? 1 : 0, player, playerPublicKeyB64.c_str(), playerIdentityHash.c_str(), playerVerifiedStatus.c_str(), playerNameB64.c_str(), NetPlay.players[player].IPtextAddress);
 
@@ -2712,7 +2712,7 @@ static void informIfAdminChangedOtherPosition(uint32_t targetPlayerIdx, uint32_t
 	sendQuickChat(WzQuickChatMessage::INTERNAL_ADMIN_ACTION_NOTICE, realSelectedPlayer, WzQuickChatTargeting::targetAll(), WzQuickChatDataContexts::INTERNAL_ADMIN_ACTION_NOTICE::constructMessageData(WzQuickChatDataContexts::INTERNAL_ADMIN_ACTION_NOTICE::Context::Position, responsibleIdx, targetPlayerIdx));
 
 	std::string senderPublicKeyB64 = base64Encode(getMultiStats(responsibleIdx).identity.toBytes(EcKey::Public));
-	debug(LOG_INFO, "Admin %s (%s) changed position of player (%s) to: %d", NetPlay.players[responsibleIdx].name, senderPublicKeyB64.c_str(), NetPlay.players[targetPlayerIdx].name, NetPlay.players[targetPlayerIdx].position);
+	debug(LOG_INFO, "Admin %s (%s) changed position of player (%s) to: %d", getPlayerName(responsibleIdx), senderPublicKeyB64.c_str(), getPlayerName(targetPlayerIdx), NetPlay.players[targetPlayerIdx].position);
 }
 
 static bool changePosition(UBYTE player, UBYTE position, uint32_t responsibleIdx)
@@ -2765,7 +2765,7 @@ static void informIfAdminChangedOtherColor(uint32_t targetPlayerIdx, uint32_t re
 	sendQuickChat(WzQuickChatMessage::INTERNAL_ADMIN_ACTION_NOTICE, realSelectedPlayer, WzQuickChatTargeting::targetAll(), WzQuickChatDataContexts::INTERNAL_ADMIN_ACTION_NOTICE::constructMessageData(WzQuickChatDataContexts::INTERNAL_ADMIN_ACTION_NOTICE::Context::Color, responsibleIdx, targetPlayerIdx));
 
 	std::string senderPublicKeyB64 = base64Encode(getMultiStats(responsibleIdx).identity.toBytes(EcKey::Public));
-	debug(LOG_INFO, "Admin %s (%s) changed color of player ([%u] %s) to: [%d] %s", NetPlay.players[responsibleIdx].name, senderPublicKeyB64.c_str(), NetPlay.players[targetPlayerIdx].position, NetPlay.players[targetPlayerIdx].name, NetPlay.players[targetPlayerIdx].colour, getPlayerColourName(targetPlayerIdx));
+	debug(LOG_INFO, "Admin %s (%s) changed color of player ([%u] %s) to: [%d] %s", getPlayerName(responsibleIdx), senderPublicKeyB64.c_str(), NetPlay.players[targetPlayerIdx].position, getPlayerName(targetPlayerIdx), NetPlay.players[targetPlayerIdx].colour, getPlayerColourName(targetPlayerIdx));
 }
 
 bool changeColour(unsigned player, int col, uint32_t responsibleIdx)
@@ -2845,7 +2845,7 @@ static void informIfAdminChangedOtherFaction(uint32_t targetPlayerIdx, uint32_t 
 	sendQuickChat(WzQuickChatMessage::INTERNAL_ADMIN_ACTION_NOTICE, realSelectedPlayer, WzQuickChatTargeting::targetAll(), WzQuickChatDataContexts::INTERNAL_ADMIN_ACTION_NOTICE::constructMessageData(WzQuickChatDataContexts::INTERNAL_ADMIN_ACTION_NOTICE::Context::Faction, responsibleIdx, targetPlayerIdx));
 
 	std::string senderPublicKeyB64 = base64Encode(getMultiStats(responsibleIdx).identity.toBytes(EcKey::Public));
-	debug(LOG_INFO, "Admin %s (%s) changed faction of player ([%u] %s) to: %s", NetPlay.players[responsibleIdx].name, senderPublicKeyB64.c_str(), NetPlay.players[targetPlayerIdx].position, NetPlay.players[targetPlayerIdx].name, to_localized_string(static_cast<FactionID>(NetPlay.players[targetPlayerIdx].faction)));
+	debug(LOG_INFO, "Admin %s (%s) changed faction of player ([%u] %s) to: %s", getPlayerName(responsibleIdx), senderPublicKeyB64.c_str(), NetPlay.players[targetPlayerIdx].position, getPlayerName(targetPlayerIdx), to_localized_string(static_cast<FactionID>(NetPlay.players[targetPlayerIdx].faction)));
 }
 
 bool changeFaction(unsigned player, FactionID faction, uint32_t responsibleIdx)
@@ -6912,7 +6912,7 @@ public:
 			std::string playerPublicKeyB64 = base64Encode(getMultiStats(player).identity.toBytes(EcKey::Public));
 			std::string playerIdentityHash = getMultiStats(player).identity.publicHashString();
 			std::string playerVerifiedStatus = (ingame.VerifiedIdentity[player]) ? "V" : "?";
-			std::string playerName = NetPlay.players[player].name;
+			std::string playerName = getPlayerName(player);
 			std::string playerNameB64 = base64Encode(std::vector<unsigned char>(playerName.begin(), playerName.end()));
 			wz_command_interface_output("WZEVENT: hostChatPermissions=%s: %" PRIu32 " %" PRIu32 " %s %s %s %s %s\n", (freeChatEnabled) ? "Y" : "N", player, gameTime, playerPublicKeyB64.c_str(), playerIdentityHash.c_str(), playerVerifiedStatus.c_str(), playerNameB64.c_str(), NetPlay.players[player].IPtextAddress);
 		}
@@ -8209,7 +8209,7 @@ void displayPlayer(WIDGET *psWidget, UDWORD xOffset, UDWORD yOffset)
 		const PLAYERSTATS& stat = getMultiStats(j);
 		auto ar = stat.autorating;
 
-		std::string name = NetPlay.players[j].name;
+		std::string name = getPlayerName(j);
 
 		std::map<std::string, EcKey::Key> serverPlayers;  // TODO Fill this with players known to the server (needs implementing on the server, too). Currently useless.
 

--- a/src/multiint.cpp
+++ b/src/multiint.cpp
@@ -8249,6 +8249,11 @@ bool WZGameReplayOptionsHandler::saveOptions(nlohmann::json& object) const
 	return true;
 }
 
+bool WZGameReplayOptionsHandler::optionsUpdatePlayerInfo(nlohmann::json& object) const
+{
+	return true;
+}
+
 constexpr PHYSFS_sint64 MAX_REPLAY_EMBEDDED_MAP_SIZE_LIMIT = 150 * 1024;
 
 size_t WZGameReplayOptionsHandler::maximumEmbeddedMapBufferSize() const

--- a/src/multiint.h
+++ b/src/multiint.h
@@ -102,6 +102,8 @@ bool isHostOrAdmin();
 bool isPlayerHostOrAdmin(uint32_t playerIdx);
 bool isSpectatorOnlySlot(UDWORD playerIdx);
 
+void printBlindModeHelpMessagesToConsole();
+
 /**
  * Checks if all players are on the same team. If so, return that team; if not, return -1;
  * if there are no players, return team MAX_PLAYERS.
@@ -221,6 +223,7 @@ bool autoBalancePlayersCmd();
 #define MULTIOP_PLAYERS_TABS	10232
 #define MULTIOP_PLAYERS_TABS_H	24
 #define MULTIOP_PLAYERSH		(384 + MULTIOP_PLAYERS_TABS_H + 1)
+#define MULTIOP_BLIND_WAITING_ROOM	10233
 
 #define MULTIOP_ROW_WIDTH		298
 

--- a/src/multiint.h
+++ b/src/multiint.h
@@ -31,6 +31,7 @@
 #include "lib/widget/button.h"
 #include <functional>
 #include <vector>
+#include <set>
 #include "lib/framework/wzstring.h"
 #include "titleui/multiplayer.h"
 #include "faction.h"
@@ -65,6 +66,52 @@ void loadMultiScripts();	///< step 2, load the actual AI scripts
 const char *getAIName(int player);	///< only run this -after- readAIs() is called
 const std::vector<WzString> getAINames();
 int matchAIbyName(const char* name);	///< only run this -after- readAIs() is called
+
+struct AIDATA
+{
+	AIDATA() : name{0}, js{0}, tip{0}, difficultyTips{0}, assigned(0) {}
+	char name[MAX_LEN_AI_NAME];
+	char js[MAX_LEN_AI_NAME];
+	char tip[255 + 128];            ///< may contain optional AI tournament data
+	char difficultyTips[5][255];    ///< optional difficulty level info
+	int assigned;                   ///< How many AIs have we assigned of this type
+};
+const std::vector<AIDATA>& getAIData();
+
+struct MultiplayOptionsLocked
+{
+	bool scavengers;
+	bool alliances;
+	bool teams;
+	bool power;
+	bool difficulty;
+	bool ai;
+	bool position;
+	bool bases;
+	bool spectators;
+};
+const MultiplayOptionsLocked& getLockedOptions();
+
+const char* getDifficultyListStr(size_t idx);
+size_t getDifficultyListCount();
+int difficultyIcon(int difficulty);
+
+std::set<uint32_t> validPlayerIdxTargetsForPlayerPositionMove(uint32_t player);
+
+bool isHostOrAdmin();
+bool isPlayerHostOrAdmin(uint32_t playerIdx);
+bool isSpectatorOnlySlot(UDWORD playerIdx);
+
+/**
+ * Checks if all players are on the same team. If so, return that team; if not, return -1;
+ * if there are no players, return team MAX_PLAYERS.
+ */
+int allPlayersOnSameTeam(int except);
+
+bool multiplayPlayersReady();
+bool multiplayIsStartingGame();
+
+bool sendReadyRequest(UBYTE player, bool bReady);
 
 LOBBY_ERROR_TYPES getLobbyError();
 void setLobbyError(LOBBY_ERROR_TYPES error_type);

--- a/src/multijoin.cpp
+++ b/src/multijoin.cpp
@@ -479,7 +479,7 @@ bool MultiPlayerLeave(UDWORD playerIndex)
 		std::string playerPublicKeyB64 = base64Encode(getMultiStats(playerIndex).identity.toBytes(EcKey::Public));
 		std::string playerIdentityHash = getMultiStats(playerIndex).identity.publicHashString();
 		std::string playerVerifiedStatus = (ingame.VerifiedIdentity[playerIndex]) ? "V" : "?";
-		std::string playerName = NetPlay.players[playerIndex].name;
+		std::string playerName = getPlayerName(playerIndex);
 		std::string playerNameB64 = base64Encode(std::vector<unsigned char>(playerName.begin(), playerName.end()));
 		wz_command_interface_output("WZEVENT: playerLeft: %" PRIu32 " %" PRIu32 " %s %s %s %s %s\n", playerIndex, gameTime, playerPublicKeyB64.c_str(), playerIdentityHash.c_str(), playerVerifiedStatus.c_str(), playerNameB64.c_str(), NetPlay.players[playerIndex].IPtextAddress);
 	}

--- a/src/multilobbycommands.cpp
+++ b/src/multilobbycommands.cpp
@@ -65,29 +65,8 @@ bool identityMatchesAdmin(const EcKey& identity)
 	return lobbyAdminPublicKeys.count(senderPublicKeyB64) != 0 || lobbyAdminPublicHashStrings.count(senderIdentityHash) != 0;
 }
 
-// NOTE: **IMPORTANT** this should *NOT* be used for determining whether a sender has permission to execute admin commands
-// (Use senderHasLobbyCommandAdminPrivs instead)
-static bool senderApparentlyMatchesAdmin(uint32_t playerIdx)
-{
-	if (playerIdx >= MAX_CONNECTED_PLAYERS)
-	{
-		return false;
-	}
-	if (playerIdx == NetPlay.hostPlayer && NetPlay.isHost)
-	{
-		// the host is always an admin
-		return true;
-	}
-	auto& identity = getMultiStats(playerIdx).identity;
-	if (identity.empty())
-	{
-		return false;
-	}
-	return identityMatchesAdmin(identity);
-}
-
 // **THIS** is the function that should be used to determine whether a sender currently has permission to execute admin commands
-static bool senderHasLobbyCommandAdminPrivs(uint32_t playerIdx)
+static bool senderHasLobbyCommandAdminPrivs(uint32_t playerIdx, bool quiet = false)
 {
 	if (playerIdx >= MAX_CONNECTED_PLAYERS)
 	{
@@ -98,27 +77,37 @@ static bool senderHasLobbyCommandAdminPrivs(uint32_t playerIdx)
 		// the host always has permissions
 		return true;
 	}
-	if (!senderApparentlyMatchesAdmin(playerIdx))
+
+	auto trueIdentity = getTruePlayerIdentity(playerIdx);
+	if (trueIdentity.identity.empty())
 	{
-		// identity hash is not in permitted list
 		return false;
 	}
+	if (!identityMatchesAdmin(trueIdentity.identity))
+	{
+		// identity is not in permitted list
+		return false;
+	}
+
 	// Verify the player's identity has been verified
-	if (!ingame.VerifiedIdentity[playerIdx])
+	if (!trueIdentity.verified)
 	{
 		// While this player claims to have an identity that matches an admin,
 		// they have not yet verified it by responding to a NET_PING with a valid signature
-		auto& identity = getMultiStats(playerIdx).identity;
-		std::string senderIdentityHash = identity.publicHashString();
-		std::string senderPublicKeyB64 = base64Encode(identity.toBytes(EcKey::Public));
-		sendRoomSystemMessageToSingleReceiver("Waiting for sync (admin privileges not yet enabled)", playerIdx, true);
-		if (lobbyAdminPublicKeys.count(senderPublicKeyB64) > 0)
+		if (!quiet)
 		{
-			debug(LOG_INFO, "Received an admin check for player %" PRIu32 " that passed (public key: %s), but they have not yet verified their identity", playerIdx, senderPublicKeyB64.c_str());
-		}
-		else
-		{
-			debug(LOG_INFO, "Received an admin check for player %" PRIu32 " that passed (public identity: %s), but they have not yet verified their identity", playerIdx, senderIdentityHash.c_str());
+			auto& identity = getOutputPlayerIdentity(playerIdx);
+			std::string senderIdentityHash = identity.publicHashString();
+			std::string senderPublicKeyB64 = base64Encode(identity.toBytes(EcKey::Public));
+			sendRoomSystemMessageToSingleReceiver("Waiting for sync (admin privileges not yet enabled)", playerIdx, true);
+			if (lobbyAdminPublicKeys.count(senderPublicKeyB64) > 0)
+			{
+				debug(LOG_INFO, "Received an admin check for player %" PRIu32 " that passed (public key: %s), but they have not yet verified their identity", playerIdx, senderPublicKeyB64.c_str());
+			}
+			else
+			{
+				debug(LOG_INFO, "Received an admin check for player %" PRIu32 " that passed (public identity: %s), but they have not yet verified their identity", playerIdx, senderIdentityHash.c_str());
+			}
 		}
 		return false;
 	}
@@ -131,7 +120,7 @@ static void lobbyCommand_PrintHelp(uint32_t receiver)
 	sendRoomSystemMessageToSingleReceiver(LOBBY_COMMAND_PREFIX "help - Get this message", receiver, true);
 	sendRoomSystemMessageToSingleReceiver(LOBBY_COMMAND_PREFIX "admin - Display currently-connected admin players", receiver, true);
 	sendRoomSystemMessageToSingleReceiver(LOBBY_COMMAND_PREFIX "me - Display your information", receiver, true);
-	if (!senderApparentlyMatchesAdmin(receiver))
+	if (!senderHasLobbyCommandAdminPrivs(receiver, true))
 	{
 		sendRoomSystemMessageToSingleReceiver("(Additional commands are available for admins)", receiver, true);
 		return;
@@ -153,7 +142,7 @@ static std::unordered_set<size_t> getConnectedAdminPlayerIndexes()
 	std::unordered_set<size_t> adminPlayerIndexes;
 	for (size_t playerIdx = 0; playerIdx < std::min<size_t>(MAX_CONNECTED_PLAYERS, NetPlay.players.size()); ++playerIdx)
 	{
-		if (senderApparentlyMatchesAdmin(playerIdx))
+		if (senderHasLobbyCommandAdminPrivs(playerIdx, true))
 		{
 			adminPlayerIndexes.insert(playerIdx);
 		}
@@ -185,7 +174,7 @@ static void lobbyCommand_Admin()
 		}
 		msg += " [";
 		msg += std::to_string(adminPlayerIdx) + "] ";
-		msg += NetPlay.players[adminPlayerIdx].name;
+		msg += getPlayerName(adminPlayerIdx, true);
 		++currNum;
 	}
 	sendRoomSystemMessage(msg.c_str());
@@ -215,11 +204,11 @@ void cmdInterfaceLogChatMsg(const NetworkTextMessage& message, const char* log_p
 
 	ASSERT_OR_RETURN(, message.sender < MAX_CONNECTED_PLAYERS, "Invalid message.sender (%d)", message.sender);
 
-	const auto& identity = getMultiStats(message.sender).identity;
+	const auto& identity = getOutputPlayerIdentity(message.sender);
 	std::string senderhash = _senderhash.value_or(identity.publicHashString(64));
 	std::string senderPublicKeyB64 = _senderPublicKeyB64.value_or(base64Encode(identity.toBytes(EcKey::Public)));
 	std::string senderVerifiedStatus = (ingame.VerifiedIdentity[message.sender]) ? "V" : "?";
-	std::string sendername = NetPlay.players[message.sender].name;
+	std::string sendername = getPlayerName(message.sender);
 	std::string sendername64 = base64Encode(std::vector<unsigned char>(sendername.begin(), sendername.end()));
 	std::string messagetext = message.text;
 	std::string messagetext64 = base64Encode(std::vector<unsigned char>(messagetext.begin(), messagetext.end()));
@@ -262,7 +251,7 @@ bool processChatLobbySlashCommands(const NetworkTextMessage& message, HostLobbyO
 		}
 		return a;
 	};
-	const auto& identity = getMultiStats(message.sender).identity;
+	const auto& identity = getOutputPlayerIdentity(message.sender);
 	std::string senderhash = identity.publicHashString(64);
 	std::string senderPublicKeyB64 = base64Encode(identity.toBytes(EcKey::Public));
 	debug(LOG_INFO, "message [%s] [%s]", senderhash.c_str(), message.text);
@@ -282,7 +271,7 @@ bool processChatLobbySlashCommands(const NetworkTextMessage& message, HostLobbyO
 								senderhash.c_str(),
 								message.sender,
 								NetPlay.players[message.sender].position,
-								NetPlay.players[message.sender].name);
+								getPlayerName(message.sender, true));
 		sendRoomSystemMessageToSingleReceiver(msg.c_str(), message.sender, true);
 	}
 	else if (strncmp(&message.text[startingCommandPosition], "team ", 5) == 0)

--- a/src/multiopt.cpp
+++ b/src/multiopt.cpp
@@ -534,6 +534,8 @@ bool hostCampaign(const char *SessionName, char *hostPlayerName, bool spectatorH
 	setMultiStats(selectedPlayer, playerStats, true);
 	lookupRatingAsync(selectedPlayer);
 
+	multiStatsSetVerifiedHostIdentityFromJoin(playerStats.identity.toBytes(EcKey::Public));
+
 	ActivityManager::instance().updateMultiplayGameData(game, ingame, NETGameIsLocked());
 	return true;
 }

--- a/src/multiplay.cpp
+++ b/src/multiplay.cpp
@@ -1458,7 +1458,7 @@ bool recvMessage()
 						std::string playerPublicKeyB64 = base64Encode(getMultiStats(player_id).identity.toBytes(EcKey::Public));
 						std::string playerIdentityHash = getMultiStats(player_id).identity.publicHashString();
 						std::string playerVerifiedStatus = (ingame.VerifiedIdentity[player_id]) ? "V" : "?";
-						std::string playerName = NetPlay.players[player_id].name;
+						std::string playerName = getPlayerName(player_id);
 						std::string playerNameB64 = base64Encode(std::vector<unsigned char>(playerName.begin(), playerName.end()));
 						wz_command_interface_output("WZEVENT: playerResponding: %" PRIu32 " %s %s %s %s %s\n", player_id, playerPublicKeyB64.c_str(), playerIdentityHash.c_str(), playerVerifiedStatus.c_str(), playerNameB64.c_str(), NetPlay.players[player_id].IPtextAddress);
 
@@ -2466,7 +2466,7 @@ static bool recvBeacon(NETQUEUE queue)
 
 	debug(LOG_WZ, "Received beacon for player: %d, from: %d", receiver, sender);
 
-	sstrcat(msg, NetPlay.players[sender].name);    // name
+	sstrcat(msg, getPlayerName(sender));    // name
 	sstrcpy(beaconReceiveMsg[sender], msg);
 
 	return addBeaconBlip(locX, locY, receiver, sender, beaconReceiveMsg[sender]);

--- a/src/multiplay.h
+++ b/src/multiplay.h
@@ -238,6 +238,7 @@ Vector3i cameraToHome(UDWORD player, bool scroll, bool fromSave);
 
 bool multiPlayerLoop();							// for loop.c
 
+bool isBlindPlayerInfoState();
 // return a "generic" player name that is fixed based on the player idx (useful for blind mode games)
 const char *getPlayerGenericName(int player);
 

--- a/src/multiplay.h
+++ b/src/multiplay.h
@@ -345,6 +345,7 @@ bool makePlayerSpectator(uint32_t player_id, bool removeAllStructs = false, bool
 class WZGameReplayOptionsHandler : public ReplayOptionsHandler
 {
 	virtual bool saveOptions(nlohmann::json& object) const override;
+	virtual bool optionsUpdatePlayerInfo(nlohmann::json& object) const override;
 	virtual bool saveMap(EmbeddedMapData& mapData) const override;
 	virtual bool restoreOptions(const nlohmann::json& object, EmbeddedMapData&& embeddedMapData, uint32_t replay_netcodeMajor, uint32_t replay_netcodeMinor) override;
 	virtual size_t desiredBufferSize() const override;

--- a/src/multiplay.h
+++ b/src/multiplay.h
@@ -78,6 +78,7 @@ struct MULTIPLAYERGAME
 	uint32_t	inactivityMinutes;			// The number of minutes without active play before a player should be considered "inactive". (0 = disable activity alerts)
 	uint32_t	gameTimeLimitMinutes;		// The number of minutes before the game automatically ends (0 = disable time limit)
 	PLAYER_LEAVE_MODE	playerLeaveMode;	// The behavior used for when players leave a game
+	BLIND_MODE	blindMode = BLIND_MODE::NONE;
 
 	// NOTE: If adding to this struct, a lot of things probably require changing
 	// (send/recvOptions? loadMainFile/writeMainFile? to/from_json in multiint.h.cpp?)
@@ -222,7 +223,7 @@ WZ_DECL_WARN_UNUSED_RESULT DROID			*IdToMissionDroid(UDWORD id, UDWORD player);
 WZ_DECL_WARN_UNUSED_RESULT FEATURE		*IdToFeature(UDWORD id, UDWORD player);
 WZ_DECL_WARN_UNUSED_RESULT DROID_TEMPLATE	*IdToTemplate(UDWORD tempId, UDWORD player);
 
-const char *getPlayerName(int player);
+const char *getPlayerName(uint32_t player, bool treatAsNonHost = false);
 bool setPlayerName(int player, const char *sName);
 void clearPlayerName(unsigned int player);
 const char *getPlayerColourName(int player);
@@ -237,6 +238,8 @@ Vector3i cameraToHome(UDWORD player, bool scroll, bool fromSave);
 
 bool multiPlayerLoop();							// for loop.c
 
+// return a "generic" player name that is fixed based on the player idx (useful for blind mode games)
+const char *getPlayerGenericName(int player);
 
 enum class HandleMessageAction
 {

--- a/src/multiplay.h
+++ b/src/multiplay.h
@@ -305,6 +305,11 @@ public:
 	uint32_t port = 0;
 	JoinConnectionType type = JoinConnectionType::TCP_DIRECT;
 };
+void to_json(nlohmann::json& j, const JoinConnectionDescription::JoinConnectionType& v);
+void from_json(const nlohmann::json& j, JoinConnectionDescription::JoinConnectionType& v);
+void to_json(nlohmann::json& j, const JoinConnectionDescription& v);
+void from_json(const nlohmann::json& j, JoinConnectionDescription& v);
+
 std::vector<JoinConnectionDescription> findLobbyGame(const std::string& lobbyAddress, unsigned int lobbyPort, uint32_t lobbyGameId);
 void joinGame(const char *connectionString, bool asSpectator = false);
 void joinGame(const char *host, uint32_t port, bool asSpectator = false);

--- a/src/multiplaydefs.h
+++ b/src/multiplaydefs.h
@@ -37,10 +37,14 @@ constexpr PLAYER_LEAVE_MODE PLAYER_LEAVE_MODE_DEFAULT = PLAYER_LEAVE_MODE::SPLIT
 enum class BLIND_MODE : uint8_t
 {
 	NONE,
+	BLIND_LOBBY,	// standard blind mode lobby (players' true identities are hidden from everyone except a spectator host until the game starts)
+	BLIND_LOBBY_SIMPLE_LOBBY,	// BLIND_LOBBY, but not showing any other players in lobby (players will just be informed that they are waiting for other players)
 	BLIND_GAME,		// standard blind mode game (players' true identities are hidden from everyone except a spectator host until the game is over)
 	BLIND_GAME_SIMPLE_LOBBY		// BLIND_GAME, but not showing any other players in lobby (players will just be informed that they are waiting for other players)
 };
 
 constexpr BLIND_MODE BLIND_MODE_MAX = BLIND_MODE::BLIND_GAME_SIMPLE_LOBBY;
+
+static inline bool isBlindSimpleLobby(BLIND_MODE mode) { return mode == BLIND_MODE::BLIND_LOBBY_SIMPLE_LOBBY || mode == BLIND_MODE::BLIND_GAME_SIMPLE_LOBBY; }
 
 #endif // __INCLUDED_SRC_MULTIPLAYDEFS_H__

--- a/src/multiplaydefs.h
+++ b/src/multiplaydefs.h
@@ -34,4 +34,13 @@ constexpr PLAYER_LEAVE_MODE PLAYER_LEAVE_MODE_MAX = PLAYER_LEAVE_MODE::SPLIT_WIT
 
 constexpr PLAYER_LEAVE_MODE PLAYER_LEAVE_MODE_DEFAULT = PLAYER_LEAVE_MODE::SPLIT_WITH_TEAM;
 
+enum class BLIND_MODE : uint8_t
+{
+	NONE,
+	BLIND_GAME,		// standard blind mode game (players' true identities are hidden from everyone except a spectator host until the game is over)
+	BLIND_GAME_SIMPLE_LOBBY		// BLIND_GAME, but not showing any other players in lobby (players will just be informed that they are waiting for other players)
+};
+
+constexpr BLIND_MODE BLIND_MODE_MAX = BLIND_MODE::BLIND_GAME_SIMPLE_LOBBY;
+
 #endif // __INCLUDED_SRC_MULTIPLAYDEFS_H__

--- a/src/multistat.cpp
+++ b/src/multistat.cpp
@@ -713,6 +713,12 @@ void multiStatsSetVerifiedIdentityFromJoin(uint32_t playerIndex, const EcKey::Ke
 	}
 }
 
+void multiStatsSetVerifiedHostIdentityFromJoin(const EcKey::Key &identity)
+{
+	ASSERT_OR_RETURN(, NetPlay.isHost || NetPlay.isHostAlive, "Unexpected state when called");
+	hostVerifiedJoinIdentities[NetPlay.hostPlayer].fromBytes(identity, EcKey::Public);
+}
+
 // ////////////////////////////////////////////////////////////////////////////
 // Load Player Stats
 

--- a/src/multistat.cpp
+++ b/src/multistat.cpp
@@ -143,7 +143,7 @@ void lookupRatingAsync(uint32_t playerIndex)
 	req.setRequestHeader("WZ-Player-Hash", hash);
 	req.setRequestHeader("WZ-Player-Key", key);
 	req.setRequestHeader("WZ-Locale", getLanguage());
-	debug(LOG_INFO, "Requesting \"%s\" for player %d (%.32s) (%s)", req.url.c_str(), playerIndex, NetPlay.players[playerIndex].name, hash.c_str());
+	debug(LOG_INFO, "Requesting \"%s\" for player %d (%.32s) (%s)", req.url.c_str(), playerIndex, getPlayerName(playerIndex), hash.c_str());
 	req.onSuccess = [playerIndex, hash](std::string const &url, HTTPResponseDetails const &response, std::shared_ptr<MemoryStruct> const &data) {
 		long httpStatusCode = response.httpStatusCode();
 		std::string urlCopy = url;
@@ -225,7 +225,7 @@ bool swapPlayerMultiStatsLocal(uint32_t playerIndexA, uint32_t playerIndexB)
 			generateSessionKeysWithPlayer(playerIndexA);
 		}
 		catch (const std::invalid_argument& e) {
-			debug(LOG_INFO, "Cannot create session keys: (self: %u), (other: %u, name: \"%s\"), with error: %s", realSelectedPlayer, playerIndexA, NetPlay.players[playerIndexA].name, e.what());
+			debug(LOG_INFO, "Cannot create session keys: (self: %u), (other: %u, name: \"%s\"), with error: %s", realSelectedPlayer, playerIndexA, getPlayerName(playerIndexA), e.what());
 		}
 	}
 	if (playerIndexB != realSelectedPlayer && (playerIndexB < MAX_PLAYERS || playerIndexB == NetPlay.hostPlayer))
@@ -234,7 +234,7 @@ bool swapPlayerMultiStatsLocal(uint32_t playerIndexA, uint32_t playerIndexB)
 			generateSessionKeysWithPlayer(playerIndexB);
 		}
 		catch (const std::invalid_argument& e) {
-			debug(LOG_INFO, "Cannot create session keys: (self: %u), (other: %u, name: \"%s\"), with error: %s", realSelectedPlayer, playerIndexB, NetPlay.players[playerIndexB].name, e.what());
+			debug(LOG_INFO, "Cannot create session keys: (self: %u), (other: %u, name: \"%s\"), with error: %s", realSelectedPlayer, playerIndexB, getPlayerName(playerIndexB), e.what());
 		}
 	}
 	return true;
@@ -358,18 +358,18 @@ bool multiStatsSetIdentity(uint32_t playerIndex, const EcKey::Key &identity, boo
 		{
 			if (!playerStats[playerIndex].identity.fromBytes(identity, EcKey::Public))
 			{
-				debug(LOG_INFO, "Player sent invalid identity: (player: %u, name: \"%s\", IP: %s)", playerIndex, NetPlay.players[playerIndex].name, NetPlay.players[playerIndex].IPtextAddress);
+				debug(LOG_INFO, "Player sent invalid identity: (player: %u, name: \"%s\", IP: %s)", playerIndex, getPlayerName(playerIndex), NetPlay.players[playerIndex].IPtextAddress);
 			}
 		}
 		else
 		{
-			debug(LOG_INFO, "Player sent empty identity: (player: %u, name: \"%s\", IP: %s)", playerIndex, NetPlay.players[playerIndex].name, NetPlay.players[playerIndex].IPtextAddress);
+			debug(LOG_INFO, "Player sent empty identity: (player: %u, name: \"%s\", IP: %s)", playerIndex, getPlayerName(playerIndex), NetPlay.players[playerIndex].IPtextAddress);
 		}
 		if ((identity != prevIdentity) || identity.empty())
 		{
 			if (GetGameMode() == GS_NORMAL)
 			{
-				debug(LOG_INFO, "Unexpected identity change after NET_FIREUP for: (player: %u, name: \"%s\", IP: %s)", playerIndex, NetPlay.players[playerIndex].name, NetPlay.players[playerIndex].IPtextAddress);
+				debug(LOG_INFO, "Unexpected identity change after NET_FIREUP for: (player: %u, name: \"%s\", IP: %s)", playerIndex, getPlayerName(playerIndex), NetPlay.players[playerIndex].IPtextAddress);
 			}
 
 			ingame.PingTimes[playerIndex] = PING_LIMIT;
@@ -404,7 +404,7 @@ bool multiStatsSetIdentity(uint32_t playerIndex, const EcKey::Key &identity, boo
 				{
 					std::string senderPublicKeyB64 = base64Encode(playerStats[playerIndex].identity.toBytes(EcKey::Public));
 					std::string senderIdentityHash = playerStats[playerIndex].identity.publicHashString();
-					std::string sendername = NetPlay.players[playerIndex].name;
+					std::string sendername = getPlayerName(playerIndex);
 					std::string senderNameB64 = base64Encode(std::vector<unsigned char>(sendername.begin(), sendername.end()));
 					wz_command_interface_output("WZEVENT: player identity UNVERIFIED: %" PRIu32 " %s %s %s %s\n", playerIndex, senderPublicKeyB64.c_str(), senderIdentityHash.c_str(), senderNameB64.c_str(), NetPlay.players[playerIndex].IPtextAddress);
 				}
@@ -433,7 +433,7 @@ bool multiStatsSetIdentity(uint32_t playerIndex, const EcKey::Key &identity, boo
 						generateSessionKeysWithPlayer(playerIndex);
 					}
 					catch (const std::invalid_argument& e) {
-						debug(LOG_INFO, "Cannot create session keys: (self: %u), (other: %u, name: \"%s\", IP: %s), with error: %s", realSelectedPlayer, playerIndex, NetPlay.players[playerIndex].name, NetPlay.players[playerIndex].IPtextAddress, e.what());
+						debug(LOG_INFO, "Cannot create session keys: (self: %u), (other: %u, name: \"%s\", IP: %s), with error: %s", realSelectedPlayer, playerIndex, getPlayerName(playerIndex), NetPlay.players[playerIndex].IPtextAddress, e.what());
 					}
 				}
 				else

--- a/src/multistat.cpp
+++ b/src/multistat.cpp
@@ -329,7 +329,7 @@ bool swapPlayerMultiStatsLocal(uint32_t playerIndexA, uint32_t playerIndexB)
 
 static bool sendMultiStatsInternal(uint32_t playerIndex, optional<uint32_t> recipientPlayerIndex = nullopt, bool sendHostVerifiedJoinIdentity = false)
 {
-	ASSERT(NetPlay.isHost || playerIndex == realSelectedPlayer, "Hah");
+	ASSERT(NetPlay.isHost || playerIndex == realSelectedPlayer, "Huh?");
 
 	NETQUEUE queue;
 	if (!recipientPlayerIndex.has_value())

--- a/src/multistat.h
+++ b/src/multistat.h
@@ -92,8 +92,11 @@ struct RESEARCH;
 bool saveMultiStats(const char *sFName, const char *sPlayerName, const PLAYERSTATS *playerStats);	// to disk
 bool loadMultiStats(char *sPlayerName, PLAYERSTATS *playerStats);					// form disk
 PLAYERSTATS const &getMultiStats(UDWORD player);									// get from net
+const EcKey& getLocalSharedIdentity();
 bool setMultiStats(uint32_t player, PLAYERSTATS plStats, bool bLocal);  // set + send to net.
+bool clearPlayerMultiStats(uint32_t playerIndex);
 bool sendMultiStats(uint32_t playerIndex, optional<uint32_t> recipientPlayerIndex = nullopt); // send to net
+bool sendMultiStatsHostVerifiedIdentities(uint32_t playerIndex);
 bool sendMultiStatsScoreUpdates(uint32_t player);
 void updateMultiStatsDamage(UDWORD attacker, UDWORD defender, UDWORD inflicted);
 void updateMultiStatsGames();
@@ -101,6 +104,7 @@ void updateMultiStatsWins();
 void updateMultiStatsLoses();
 void incrementMultiStatsResearchPerformance(UDWORD player);
 void incrementMultiStatsResearchPotential(UDWORD player);
+struct BASE_OBJECT;
 void updateMultiStatsKills(BASE_OBJECT *psKilled, UDWORD player);
 void updateMultiStatsBuilt(BASE_OBJECT *psBuilt);
 void updateMultiStatsResearchComplete(RESEARCH *psResearch, UDWORD player);
@@ -147,5 +151,29 @@ void resetRecentScoreData();
 
 bool saveMultiStatsToJSON(nlohmann::json& json);
 bool loadMultiStatsFromJSON(const nlohmann::json& json);
+bool updateMultiStatsIdentitiesInJSON(nlohmann::json& json, bool useVerifiedJoinIdentity = false);
+
+bool generateBlindIdentity();
+
+// When host, this will return:
+// - The identity verified on initial player join
+// When a client, this will return:
+// - In "regular" lobbies, the current player identity (if it has been verified with this client)
+// - In "blind" lobbies...
+//   - Before game ends, an empty identity
+//   - After game ends, the host-verified join identity
+const EcKey& getVerifiedJoinIdentity(UDWORD player);
+
+// In blind games, it returns the verified join identity (if executed on the host, or on all clients after the game has ended)
+// In regular games, it returns the current player identity
+struct TrueIdentity
+{
+	const EcKey& identity;
+	bool verified;
+};
+TrueIdentity getTruePlayerIdentity(UDWORD player);
+
+// Should be used when a player identity is to be output (in logs, or otherwise accessible to the user)
+const EcKey& getOutputPlayerIdentity(UDWORD player);
 
 #endif // __INCLUDED_SRC_MULTISTATS_H__

--- a/src/multistat.h
+++ b/src/multistat.h
@@ -112,6 +112,7 @@ bool recvMultiStats(NETQUEUE queue);
 void lookupRatingAsync(uint32_t playerIndex);
 
 void multiStatsSetVerifiedIdentityFromJoin(uint32_t playerIndex, const EcKey::Key &identity);
+void multiStatsSetVerifiedHostIdentityFromJoin(const EcKey::Key &identity);
 
 bool swapPlayerMultiStatsLocal(uint32_t playerIndexA, uint32_t playerIndexB);
 

--- a/src/multivote.cpp
+++ b/src/multivote.cpp
@@ -158,6 +158,8 @@ uint8_t getLobbyChangeVoteTotal()
 
 static void recvLobbyChangeVote(uint32_t player, uint8_t newVote)
 {
+	ASSERT_OR_RETURN(, player < MAX_PLAYERS, "Invalid sender: %" PRIu32, player);
+
 	playerVotes[player] = (newVote == 1) ? 1 : 0;
 
 	debug(LOG_NET, "total votes: %d/%d", static_cast<int>(getLobbyChangeVoteTotal()), static_cast<int>(NET_numHumanPlayers()));
@@ -165,7 +167,7 @@ static void recvLobbyChangeVote(uint32_t player, uint8_t newVote)
 	// there is no "votes" that disallows map change so assume they are all allowing
 	if(newVote == 1) {
 		char msg[128] = {0};
-		ssprintf(msg, _("%s (%d) allowed map change. Total: %d/%d"), NetPlay.players[player].name, player, static_cast<int>(getLobbyChangeVoteTotal()), static_cast<int>(NET_numHumanPlayers()));
+		ssprintf(msg, _("%s (%d) allowed map change. Total: %d/%d"), getPlayerName(player), player, static_cast<int>(getLobbyChangeVoteTotal()), static_cast<int>(NET_numHumanPlayers()));
 		sendRoomSystemMessage(msg);
 	}
 }

--- a/src/scores.cpp
+++ b/src/scores.cpp
@@ -653,7 +653,7 @@ void stdOutGameSummary(UDWORD realTimeThrottleSeconds, bool flush_output /* = tr
 			// NOTE: This duplicates the logic in rules.js - checkEndConditions()
 			const bool playerCantDoAnything = (numFactoriesThatCanProduceConstructionUnits == 0) && (numUnits == 0);
 			const char * deadStatus = playerCantDoAnything ? "x" : "";
-			fprintf(stdout, "%2u | %11.11s | %10" PRIi64 " | %12" PRIi32 " | %13.13s | %11" PRIi32 " | %7" PRIi32 " | %s\n", n, NetPlay.players[n].name, getExtractedPower(n), unitsKilled, structInfoString.c_str(), numUnits, getPower(n), deadStatus);
+			fprintf(stdout, "%2u | %11.11s | %10" PRIi64 " | %12" PRIi32 " | %13.13s | %11" PRIi32 " | %7" PRIi32 " | %s\n", n, getPlayerName(n), getExtractedPower(n), unitsKilled, structInfoString.c_str(), numUnits, getPower(n), deadStatus);
 		}
 	}
 	fprintf(stdout, "--------------------------------------------------------------------------------------\n");

--- a/src/screens/joiningscreen.cpp
+++ b/src/screens/joiningscreen.cpp
@@ -1545,6 +1545,11 @@ void WzJoiningGameScreen_HandlerRoot::processJoining()
 			// tmpJoiningQueuePair is now "owned" by NetPlay.hostPlayer's netQueue - do not delete it here!
 			tmpJoiningQueuePair = nullptr;
 
+			if ((game.blindMode == BLIND_MODE::NONE) || (NetPlay.hostPlayer >= MAX_PLAYER_SLOTS))
+			{
+				multiStatsSetVerifiedHostIdentityFromJoin(hostIdentity.toBytes(EcKey::Public));
+			}
+
 			handleSuccess();
 			return;
 		}

--- a/src/stdinreader.cpp
+++ b/src/stdinreader.cpp
@@ -1036,6 +1036,43 @@ int cmdInputThreadFunc(void *)
 				wz_command_interface_output_room_status_json();
 			});
 		}
+		else if(!strncmpl(line, "set host ready "))
+		{
+			unsigned hostReadyVal = 0;
+			int r = sscanf(line, "set host ready %u", &hostReadyVal);
+			if (r != 1)
+			{
+				wz_command_interface_output_onmainthread("WZCMD error: Failed to get host ready value!\n");
+			}
+			else
+			{
+				bool hostReady = false;
+				if (hostReadyVal == 1 || hostReadyVal == 0)
+				{
+					hostReady = static_cast<bool>(hostReadyVal);
+				}
+				else
+				{
+					wz_command_interface_output_onmainthread("WZCMD error: Unsupported set host ready value!\n");
+					continue;
+				}
+
+				wzAsyncExecOnMainThread([hostReady] {
+					if (!NetPlay.isHostAlive)
+					{
+						wz_command_interface_output("WZCMD error: Unable to change host ready status because host isn't yet hosting!\n");
+						return;
+					}
+					if (!NetPlay.isHost)
+					{
+						wz_command_interface_output("WZCMD error: Unable to change host ready status when not the host!\n");
+						return;
+					}
+
+					sendReadyRequest(selectedPlayer, hostReady);
+				});
+			}
+		}
 		else if(!strncmpl(line, "shutdown now"))
 		{
 			inexit = true;

--- a/src/titleui/campaign.cpp
+++ b/src/titleui/campaign.cpp
@@ -44,6 +44,7 @@
 #include "lib/ivis_opengl/pieblitfunc.h"
 #include "../modding.h"
 #include "../version.h"
+#include "widgets/infobutton.h"
 
 #define WZ2100_CORE_CLASSIC_BALANCE_MOD_FILENAME "wz2100_camclassic.wz"
 
@@ -789,54 +790,6 @@ public:
 	bool currentValue = false;
 	bool editable = true;
 };
-
-class WzInfoButton : public W_BUTTON
-{
-protected:
-	WzInfoButton() {}
-public:
-	static std::shared_ptr<WzInfoButton> make()
-	{
-		class make_shared_enabler: public WzInfoButton {};
-		auto widget = std::make_shared<make_shared_enabler>();
-		return widget;
-	}
-	void setImageDimensions(int imageSize);
-protected:
-	void display(int xOffset, int yOffset) override;
-private:
-	int imageDimensions = 16;
-};
-
-void WzInfoButton::setImageDimensions(int imageSize)
-{
-	imageDimensions = imageSize;
-}
-
-void WzInfoButton::display(int xOffset, int yOffset)
-{
-	int x0 = x() + xOffset;
-	int y0 = y() + yOffset;
-
-	bool isDown = (getState() & (WBUT_DOWN | WBUT_LOCK | WBUT_CLICKLOCK)) != 0;
-	bool isDisabled = (getState() & WBUT_DISABLE) != 0;
-	bool isHighlight = !isDisabled && ((getState() & WBUT_HIGHLIGHT) != 0);
-
-	if (isHighlight)
-	{
-		// Display highlight rect
-		int highlightRectDimensions = std::max(std::min<int>(width(), height()), imageDimensions + 2);
-		int boxX0 = x0 + (width() - highlightRectDimensions) / 2;
-		int boxY0 = y0 + (height() - highlightRectDimensions) / 2;
-		iV_Box(boxX0, boxY0, boxX0 + highlightRectDimensions + 1, boxY0 + highlightRectDimensions + 1, (isDown) ? pal_RGBA(255,255,255,255) : WZCOL_TEXT_MEDIUM);
-	}
-
-	// Display the info icon, centered
-	int imgPosX0 = x0 + (width() - imageDimensions) / 2;
-	int imgPosY0 = y0 + (height() - imageDimensions) / 2;
-	PIELIGHT imgColor = (isHighlight) ? pal_RGBA(255,255,255,255) : WZCOL_TEXT_MEDIUM;
-	iV_DrawImageFileAnisotropicTint(FrontImages, IMAGE_INFO_CIRCLE, imgPosX0, imgPosY0, Vector2f(imageDimensions, imageDimensions), imgColor);
-}
 
 class WzFrontendImageButton : public W_BUTTON
 {

--- a/src/titleui/widgets/blindwaitingroom.cpp
+++ b/src/titleui/widgets/blindwaitingroom.cpp
@@ -1,0 +1,796 @@
+/*
+	This file is part of Warzone 2100.
+	Copyright (C) 2024-2025  Warzone 2100 Project
+
+	Warzone 2100 is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+
+	Warzone 2100 is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with Warzone 2100; if not, write to the Free Software
+	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+/** \file
+ *  Blind lobby waiting room widgets
+ */
+
+#include "blindwaitingroom.h"
+#include "lib/widget/widget.h"
+#include "lib/widget/label.h"
+#include "lib/widget/button.h"
+#include "infobutton.h"
+#include "lobbyplayerrow.h"
+
+#include "lib/netplay/netplay.h"
+
+#include "src/titleui/multiplayer.h"
+#include "src/multistat.h"
+#include "src/multiint.h"
+#include "src/multiplay.h"
+
+#include "lib/ivis_opengl/pieblitfunc.h"
+
+#include "src/screens/joiningscreen.h"
+
+#include <chrono>
+
+// ////////////////////////////////////////////////////////////////////////////
+// Blind Waiting Room
+
+class WzRoomTitleBanner : public WIDGET
+{
+public:
+	typedef std::function<void ()> InfoClickHandler;
+
+protected:
+	WzRoomTitleBanner()
+	: WIDGET()
+	{}
+
+	void initialize(const std::string& title, const InfoClickHandler& infoClickHandler);
+
+public:
+	static std::shared_ptr<WzRoomTitleBanner> make(const std::string& title, const InfoClickHandler& infoClickHandler)
+	{
+		class make_shared_enabler: public WzRoomTitleBanner {};
+		auto widget = std::make_shared<make_shared_enabler>();
+
+		widget->initialize(title, infoClickHandler);
+		return widget;
+	}
+
+	void display(int xOffset, int yOffset) override;
+	int32_t idealHeight() override;
+	void geometryChanged() override;
+
+private:
+	InfoClickHandler infoClickHandler;
+	int topPadding = 10;
+	int bottomPadding = 10;
+	int internalHorizontalPadding = 10;
+	std::shared_ptr<W_LABEL> titleLabel;
+	std::shared_ptr<WzInfoButton> infoButton;
+};
+
+int32_t WzRoomTitleBanner::idealHeight()
+{
+	// the height for one row of text
+	int32_t titleHeight = std::max<int32_t>(titleLabel->idealHeight(), (infoButton) ? infoButton->idealHeight() : 0);
+	return topPadding + bottomPadding + titleHeight;
+}
+
+void WzRoomTitleBanner::initialize(const std::string& title, const InfoClickHandler& _onInfoButtonClick)
+{
+	infoClickHandler = _onInfoButtonClick;
+
+	// add the titleLabel
+	titleLabel = std::make_shared<W_LABEL>();
+	titleLabel->setFont(font_regular, WZCOL_TEXT_BRIGHT);
+	titleLabel->setString(WzString::fromUtf8(title));
+	titleLabel->setGeometry(0, 0, titleLabel->getMaxLineWidth(), titleLabel->idealHeight());
+	titleLabel->setCanTruncate(true);
+	titleLabel->setTransparentToMouse(true);
+	attach(titleLabel);
+	titleLabel->setCalcLayout(LAMBDA_CALCLAYOUT_SIMPLE({
+		auto psParent = std::dynamic_pointer_cast<WzRoomTitleBanner>(psWidget->parent());
+		ASSERT_OR_RETURN(, psParent != nullptr, "No parent?");
+		int x0 = psParent->internalHorizontalPadding;
+		int w = psParent->width() - (psParent->internalHorizontalPadding * 3) - 16;
+		int h = psParent->height() - (psParent->topPadding + psParent->bottomPadding);
+		psWidget->setGeometry(x0, psParent->topPadding, w, h);
+	}));
+
+	if (infoClickHandler)
+	{
+		infoButton = WzInfoButton::make();
+		infoButton->setImageDimensions(16);
+		attach(infoButton);
+		infoButton->setCalcLayout(LAMBDA_CALCLAYOUT_SIMPLE({
+			auto psParent = std::dynamic_pointer_cast<WzRoomTitleBanner>(psWidget->parent());
+			ASSERT_OR_RETURN(, psParent != nullptr, "No parent?");
+			int w = 16 + psParent->internalHorizontalPadding;
+			int x0 = psParent->width() - w;
+			int h = psParent->height() - (psParent->topPadding + psParent->bottomPadding);
+			psWidget->setGeometry(x0, psParent->topPadding, w, h);
+		}));
+		auto weakSelf = std::weak_ptr<WzRoomTitleBanner>(std::dynamic_pointer_cast<WzRoomTitleBanner>(shared_from_this()));
+		infoButton->addOnClickHandler([weakSelf](W_BUTTON&) {
+			auto strongSelf = weakSelf.lock();
+			ASSERT_OR_RETURN(, strongSelf != nullptr, "No parent?");
+			if (strongSelf->infoClickHandler)
+			{
+				strongSelf->infoClickHandler();
+			}
+		});
+	}
+}
+
+void WzRoomTitleBanner::display(int xOffset, int yOffset)
+{
+	int x0 = xOffset + x();
+	int y0 = yOffset + y();
+	int w = width();
+	int h = height();
+	bool highlight = false;
+
+	// draw box
+	PIELIGHT boxBorder = WZCOL_MENU_BORDER;
+	if (highlight)
+	{
+		boxBorder = pal_RGBA(255, 255, 255, 255);
+	}
+	PIELIGHT boxBackground = WZCOL_MENU_BORDER;
+	pie_BoxFill(x0, y0, x0 + w, y0 + h, boxBorder);
+	pie_BoxFill(x0 + 1, y0 + 1, x0 + w - 1, y0 + h - 1, boxBackground);
+}
+
+void WzRoomTitleBanner::geometryChanged()
+{
+	titleLabel->callCalcLayout();
+	if (infoButton)
+	{
+		infoButton->callCalcLayout();
+	}
+}
+
+// MARK: - WzBlindRoomHostInfo
+
+class WzBlindRoomHostInfo : public WIDGET
+{
+protected:
+	WzBlindRoomHostInfo()
+	: WIDGET()
+	{}
+
+	void initialize();
+
+public:
+	static std::shared_ptr<WzBlindRoomHostInfo> make()
+	{
+		class make_shared_enabler: public WzBlindRoomHostInfo {};
+		auto widget = std::make_shared<make_shared_enabler>();
+		widget->initialize();
+		return widget;
+	}
+
+	void run(W_CONTEXT *) override;
+	int32_t idealHeight() override;
+	void geometryChanged() override;
+
+private:
+	int topPadding = 4;
+	int bottomPadding = 4;
+	int internalHorizontalPadding = 10;
+	std::shared_ptr<W_LABEL> hostLabel;
+	std::shared_ptr<W_LABEL> hostName;
+};
+
+int32_t WzBlindRoomHostInfo::idealHeight()
+{
+	// the height for one row of text
+	int32_t titleHeight = std::max<int32_t>(hostLabel->idealHeight(), hostName->idealHeight());
+	return topPadding + bottomPadding + titleHeight;
+}
+
+void WzBlindRoomHostInfo::initialize()
+{
+	hostLabel = std::make_shared<W_LABEL>();
+	hostLabel->setFont(font_regular, WZCOL_TEXT_DARK);
+	hostLabel->setString(_("Host:"));
+	hostLabel->setGeometry(0, 0, hostLabel->getMaxLineWidth(), hostLabel->idealHeight());
+	hostLabel->setCanTruncate(false);
+	hostLabel->setTransparentToMouse(true);
+	attach(hostLabel);
+
+	hostName = std::make_shared<W_LABEL>();
+	hostName->setFont(font_regular, WZCOL_TEXT_MEDIUM);
+	hostName->setString(NetPlay.players[NetPlay.hostPlayer].name);
+	hostName->setGeometry(0, 0, hostName->getMaxLineWidth(), hostName->idealHeight());
+	hostName->setCanTruncate(true);
+	attach(hostName);
+
+	std::string hostTipStr;
+	if (NetPlay.hostPlayer < MAX_PLAYER_SLOTS)
+	{
+		hostTipStr = _("NOTE: Host is also a player.");
+	}
+	else
+	{
+		const auto& identity = getOutputPlayerIdentity(NetPlay.hostPlayer);
+		if (!identity.empty())
+		{
+			if (!hostTipStr.empty())
+			{
+				hostTipStr += "\n";
+			}
+			std::string hash = identity.publicHashString(20);
+			hostTipStr += _("Player ID: ");
+			hostTipStr += hash.empty()? _("(none)") : hash;
+		}
+	}
+	hostName->setTip(hostTipStr);
+}
+
+void WzBlindRoomHostInfo::geometryChanged()
+{
+	int w = width();
+	int h = height();
+	hostLabel->setGeometry(0, 0, hostLabel->width(), h);
+
+	int hostNameX0 = hostLabel->width() + internalHorizontalPadding;
+	int hostNameWidth = w - hostNameX0;
+	hostName->setGeometry(hostNameX0, 0, hostNameWidth, h);
+}
+
+void WzBlindRoomHostInfo::run(W_CONTEXT *)
+{
+	hostName->setString(NetPlay.players[NetPlay.hostPlayer].name);
+}
+
+// MARK: - WzBlindRoomPlayerInfo
+
+class WzBlindRoomPlayerInfo : public WIDGET
+{
+protected:
+	WzBlindRoomPlayerInfo()
+	: WIDGET()
+	{}
+
+	void initialize(const std::shared_ptr<WzMultiplayerOptionsTitleUI> &parent);
+
+public:
+	static std::shared_ptr<WzBlindRoomPlayerInfo> make(const std::shared_ptr<WzMultiplayerOptionsTitleUI> &parent)
+	{
+		class make_shared_enabler: public WzBlindRoomPlayerInfo {};
+		auto widget = std::make_shared<make_shared_enabler>();
+		widget->initialize(parent);
+		return widget;
+	}
+
+	void run(W_CONTEXT *) override;
+	int32_t idealHeight() override;
+	void geometryChanged() override;
+
+private:
+	int topPadding = 4;
+	int bottomPadding = 4;
+	int internalVerticalPadding = 10;
+	std::shared_ptr<W_LABEL> playerLabel;
+	std::shared_ptr<WzPlayerRow> playerRow;
+};
+
+int32_t WzBlindRoomPlayerInfo::idealHeight()
+{
+	int32_t result = topPadding + bottomPadding;
+	result += playerLabel->idealHeight();
+	result += internalVerticalPadding + MULTIOP_PLAYERHEIGHT;
+	return result;
+}
+
+void WzBlindRoomPlayerInfo::initialize(const std::shared_ptr<WzMultiplayerOptionsTitleUI> &parent)
+{
+	playerLabel = std::make_shared<W_LABEL>();
+	playerLabel->setFont(font_regular, WZCOL_TEXT_DARK);
+	playerLabel->setString(_("You:"));
+	playerLabel->setGeometry(0, 0, playerLabel->getMaxLineWidth(), playerLabel->idealHeight());
+	playerLabel->setCanTruncate(false);
+	playerLabel->setTransparentToMouse(true);
+	attach(playerLabel);
+	int textBottom = playerLabel->y() + playerLabel->height();
+
+	playerRow = WzPlayerRow::make(selectedPlayer, parent);
+	attach(playerRow);
+	playerRow->setGeometry(0, textBottom + internalVerticalPadding, MULTIOP_PLAYERWIDTH, MULTIOP_PLAYERHEIGHT);
+
+	geometryChanged();
+}
+
+void WzBlindRoomPlayerInfo::geometryChanged()
+{
+	int w = width();
+
+	playerLabel->setGeometry(0, 0, playerLabel->width(), playerLabel->idealHeight());
+	int textBottom = playerLabel->y() + playerLabel->height();
+
+	int playerWidgetWidth = std::min<int>(MULTIOP_PLAYERWIDTH, w);
+	if (playerWidgetWidth > 0)
+	{
+		playerRow->setGeometry(0, textBottom + internalVerticalPadding, playerWidgetWidth, MULTIOP_PLAYERHEIGHT);
+	}
+}
+
+void WzBlindRoomPlayerInfo::run(W_CONTEXT *psContext)
+{
+	// currently, no-op
+}
+
+// MARK: - WzBlindRoomStatusInfo
+
+class WzBlindRoomStatusInfo : public WIDGET
+{
+protected:
+	WzBlindRoomStatusInfo()
+	: WIDGET()
+	{}
+
+	void initialize();
+
+public:
+	static std::shared_ptr<WzBlindRoomStatusInfo> make()
+	{
+		class make_shared_enabler: public WzBlindRoomStatusInfo {};
+		auto widget = std::make_shared<make_shared_enabler>();
+		widget->initialize();
+		return widget;
+	}
+
+	void run(W_CONTEXT *) override;
+	int32_t idealHeight() override;
+	void geometryChanged() override;
+
+private:
+	int topPadding = 4;
+	int bottomPadding = 4;
+	int internalVerticalPadding = 5;
+	std::shared_ptr<W_LABEL> statusLabel;
+	std::shared_ptr<W_LABEL> statusDetails;
+	std::shared_ptr<WIDGET> indeterminateIndicator;
+	WzString statusStr;
+	std::chrono::steady_clock::time_point lastStatusUpdate;
+	std::chrono::milliseconds minUpdateFreq = std::chrono::milliseconds(500);
+};
+
+int32_t WzBlindRoomStatusInfo::idealHeight()
+{
+	// the height for one row of text
+	int result = topPadding + bottomPadding;
+	result += statusLabel->idealHeight();
+	result += internalVerticalPadding;
+	result += statusDetails->idealHeight();
+	return result;
+}
+
+void WzBlindRoomStatusInfo::initialize()
+{
+	statusLabel = std::make_shared<W_LABEL>();
+	statusLabel->setFont(font_regular, WZCOL_TEXT_DARK);
+	statusLabel->setString(_("Status:"));
+	statusLabel->setGeometry(0, 0, statusLabel->getMaxLineWidth(), statusLabel->idealHeight());
+	statusLabel->setCanTruncate(false);
+	statusLabel->setTransparentToMouse(true);
+	attach(statusLabel);
+
+	statusDetails = std::make_shared<W_LABEL>();
+	statusDetails->setFont(font_regular, WZCOL_TEXT_MEDIUM);
+	statusDetails->setString(NetPlay.players[NetPlay.hostPlayer].name);
+	statusDetails->setGeometry(0, 0, statusDetails->getMaxLineWidth(), statusDetails->idealHeight());
+	statusDetails->setCanTruncate(true);
+	attach(statusDetails);
+
+	indeterminateIndicator = createJoiningIndeterminateProgressWidget(font_regular_bold);
+	attach(indeterminateIndicator);
+}
+
+void WzBlindRoomStatusInfo::geometryChanged()
+{
+	int w = width();
+	statusLabel->setGeometry(0, 0, statusLabel->width(), statusLabel->idealHeight());
+	int textBottom = statusLabel->y() + statusLabel->height();
+
+	int statusDetailsWidth = w - indeterminateIndicator->idealWidth() - 5;
+	statusDetails->setGeometry(0, textBottom + internalVerticalPadding, statusDetailsWidth, statusDetails->idealHeight());
+
+	indeterminateIndicator->setGeometry(statusDetailsWidth + 5, textBottom + internalVerticalPadding, indeterminateIndicator->idealWidth(), indeterminateIndicator->idealHeight());
+}
+
+void WzBlindRoomStatusInfo::run(W_CONTEXT *)
+{
+	const std::chrono::steady_clock::time_point now = std::chrono::steady_clock::now();
+	if (std::chrono::duration_cast<std::chrono::milliseconds>(now - lastStatusUpdate) < minUpdateFreq)
+	{
+		return;
+	}
+
+	size_t numNotReadyPlayers = 0;
+	size_t numReadyPlayers = 0;
+	size_t numNotReadySpectators = 0;
+	bool hostIsReady = false;
+	bool selfIsReady = NetPlay.players[realSelectedPlayer].ready;
+	bool playersAllOnSameTeam = (allPlayersOnSameTeam(-1) != -1);
+
+	for (size_t player = 0; player < NetPlay.players.size(); player++)
+	{
+		// check if this human player is ready, ignore AIs
+		if (NetPlay.players[player].allocated)
+		{
+			if (NetPlay.players[player].ready)
+			{
+				if (player < game.maxPlayers)
+				{
+					numReadyPlayers++;
+				}
+				if (player == NetPlay.hostPlayer)
+				{
+					hostIsReady = true;
+				}
+			}
+			else
+			{
+				if (player < game.maxPlayers)
+				{
+					numNotReadyPlayers++;
+				}
+				else
+				{
+					numNotReadySpectators++;
+				}
+			}
+		}
+		else if (NetPlay.players[player].ai >= 0 && player < game.maxPlayers)
+		{
+			numReadyPlayers++;
+		}
+	}
+
+	// Determine status string
+	if (playersAllOnSameTeam)
+	{
+		if (numNotReadyPlayers + numReadyPlayers > 1)
+		{
+			statusStr = _("Waiting for host to configure teams");
+		}
+		else
+		{
+			statusStr = _("Waiting for players");
+		}
+	}
+	else if (!selfIsReady)
+	{
+		if (NETgetDownloadProgress(realSelectedPlayer) != 100)
+		{
+			statusStr = _("Downloading map / mods");
+		}
+		else
+		{
+			statusStr = _("Waiting for you to check ready");
+		}
+	}
+	else if (numReadyPlayers > 0 && numNotReadyPlayers > 0)
+	{
+		statusStr = _("Waiting for players");
+	}
+	else if (!hostIsReady && NetPlay.players[NetPlay.hostPlayer].isSpectator)
+	{
+		statusStr = _("Waiting for host to start game");
+	}
+	else if (numNotReadySpectators > 0)
+	{
+		statusStr = _("Waiting for spectators");
+	}
+	else
+	{
+		statusStr = _("Waiting for players");
+	}
+
+	statusDetails->setString(statusStr);
+
+	lastStatusUpdate = now;
+}
+
+// MARK: - WzBlindPlayersReadyInfo
+
+class WzBlindPlayersReadyInfo : public WIDGET
+{
+protected:
+	WzBlindPlayersReadyInfo()
+	: WIDGET()
+	{}
+
+	void initialize();
+
+public:
+	static std::shared_ptr<WzBlindPlayersReadyInfo> make()
+	{
+		class make_shared_enabler: public WzBlindPlayersReadyInfo {};
+		auto widget = std::make_shared<make_shared_enabler>();
+		widget->initialize();
+		return widget;
+	}
+
+	void run(W_CONTEXT *) override;
+	int32_t idealHeight() override;
+	void geometryChanged() override;
+	std::string getTip() override;
+
+private:
+	int topPadding = 4;
+	int bottomPadding = 4;
+	int internalHorizontalPadding = 10;
+	std::shared_ptr<W_LABEL> readyCountLabel;
+	std::shared_ptr<W_LABEL> readyCountValue;
+	std::chrono::steady_clock::time_point lastStatusUpdate;
+	std::chrono::milliseconds minUpdateFreq = std::chrono::milliseconds(500);
+	std::string tooltip;
+};
+
+int32_t WzBlindPlayersReadyInfo::idealHeight()
+{
+	// the height for one row of text
+	int32_t titleHeight = std::max<int32_t>(readyCountLabel->idealHeight(), readyCountValue->idealHeight());
+	return topPadding + bottomPadding + titleHeight;
+}
+
+void WzBlindPlayersReadyInfo::initialize()
+{
+	readyCountLabel = std::make_shared<W_LABEL>();
+	readyCountLabel->setFont(font_regular, WZCOL_TEXT_DARK);
+	readyCountLabel->setString(_("Players ready & waiting for match:"));
+	readyCountLabel->setGeometry(0, 0, readyCountLabel->getMaxLineWidth(), readyCountLabel->idealHeight());
+	readyCountLabel->setCanTruncate(false);
+	readyCountLabel->setTransparentToMouse(true);
+	attach(readyCountLabel);
+
+	readyCountValue = std::make_shared<W_LABEL>();
+	readyCountValue->setFont(font_regular, WZCOL_TEXT_DARK);
+	readyCountValue->setString("0");
+	readyCountValue->setGeometry(0, 0, readyCountValue->getMaxLineWidth(), readyCountValue->idealHeight());
+	readyCountValue->setCanTruncate(true);
+	readyCountValue->setTransparentToMouse(true);
+	attach(readyCountValue);
+}
+
+void WzBlindPlayersReadyInfo::geometryChanged()
+{
+	int w = width();
+	int h = height();
+
+	// ensure the value is fully visible
+	int readyCountValueWidth = readyCountValue->getMaxLineWidth();
+	int readyCountValueX0 = w - readyCountValueWidth;
+	readyCountValue->setGeometry(readyCountValueX0, 0, readyCountValueWidth, h);
+
+	// then use the rest of the space for the label
+	int labelWidth = std::max<int>(w - readyCountValueWidth - internalHorizontalPadding, 0);
+	readyCountLabel->setGeometry(0, 0, labelWidth, h);
+}
+
+void WzBlindPlayersReadyInfo::run(W_CONTEXT *)
+{
+	const std::chrono::steady_clock::time_point now = std::chrono::steady_clock::now();
+	if (std::chrono::duration_cast<std::chrono::milliseconds>(now - lastStatusUpdate) < minUpdateFreq)
+	{
+		return;
+	}
+
+	size_t numNotReadyPlayers = 0;
+	size_t numReadyPlayers = 0;
+	size_t numReadyAIBots = 0;
+	size_t numNotReadySpectators = 0;
+	size_t numReadySpectators = 0;
+	bool hostIsReady = false;
+
+	for (size_t player = 0; player < NetPlay.players.size(); player++)
+	{
+		// check if this human player is ready, ignore AIs
+		if (NetPlay.players[player].allocated)
+		{
+			if (NetPlay.players[player].ready)
+			{
+				if (player < game.maxPlayers)
+				{
+					numReadyPlayers++;
+				}
+				else
+				{
+					numReadySpectators++;
+				}
+				if (player == NetPlay.hostPlayer)
+				{
+					hostIsReady = true;
+				}
+			}
+			else
+			{
+				if (player < game.maxPlayers)
+				{
+					numNotReadyPlayers++;
+				}
+				else
+				{
+					numNotReadySpectators++;
+				}
+			}
+		}
+		else if (NetPlay.players[player].ai >= 0 && player < game.maxPlayers)
+		{
+			numReadyAIBots++;
+		}
+	}
+
+	readyCountValue->setString(WzString::number(numReadyPlayers));
+
+	tooltip = astringf(_("Players: (%zu ready, %zu not ready)"), numReadyPlayers, numNotReadyPlayers);
+	if (numReadyAIBots > 0)
+	{
+		tooltip += "\n";
+		tooltip += astringf(_("AI Bots: %zu"), numReadyAIBots);
+	}
+	if (numReadySpectators > 0 || numNotReadySpectators > 0)
+	{
+		tooltip += "\n";
+		tooltip += astringf(_("Spectators: (%zu ready, %zu not ready)"), numReadySpectators, numNotReadySpectators);
+	}
+	tooltip += "\n";
+	tooltip += astringf(_("Host: %s"), (hostIsReady) ? _("ready") : _("not ready"));
+}
+
+std::string WzBlindPlayersReadyInfo::getTip()
+{
+	return tooltip;
+}
+
+// MARK: - WzPlayerBlindWaitingRoom
+
+class WzPlayerBlindWaitingRoom : public WIDGET
+{
+protected:
+	WzPlayerBlindWaitingRoom(const std::shared_ptr<WzMultiplayerOptionsTitleUI>& titleUI)
+	: WIDGET()
+	, weakTitleUI(titleUI)
+	{ }
+
+	~WzPlayerBlindWaitingRoom()
+	{
+	}
+
+public:
+	static std::shared_ptr<WzPlayerBlindWaitingRoom> make(const std::shared_ptr<WzMultiplayerOptionsTitleUI>& titleUI)
+	{
+		class make_shared_enabler: public WzPlayerBlindWaitingRoom {
+		public:
+			make_shared_enabler(const std::shared_ptr<WzMultiplayerOptionsTitleUI>& titleUI) : WzPlayerBlindWaitingRoom(titleUI) { }
+		};
+		auto widget = std::make_shared<make_shared_enabler>(titleUI);
+		widget->initialize(titleUI);
+		return widget;
+	}
+
+	void initialize(const std::shared_ptr<WzMultiplayerOptionsTitleUI>& titleUI)
+	{
+		// Add the "BLIND ROOM" info bar at top
+		titleBanner = WzRoomTitleBanner::make(_("Blind Waiting Room"), []() {
+			widgScheduleTask([]() {
+				printBlindModeHelpMessagesToConsole();
+			});
+		});
+		attach(titleBanner);
+
+		// Add host details
+		hostInfo = WzBlindRoomHostInfo::make();
+		attach(hostInfo);
+
+		// Add the current player details
+		playerInfo = WzBlindRoomPlayerInfo::make(titleUI);
+		attach(playerInfo);
+
+		// Add Status field)
+		statusInfo = WzBlindRoomStatusInfo::make();
+		attach(statusInfo);
+
+		// Add "People ready & waiting for match: <number>"
+		playersReadyInfo = WzBlindPlayersReadyInfo::make();
+		attach(playersReadyInfo);
+
+		setCalcLayout(LAMBDA_CALCLAYOUT_SIMPLE({
+			auto psPlayerBlindWaitingRoom = std::dynamic_pointer_cast<WzPlayerBlindWaitingRoom>(psWidget->shared_from_this());
+			ASSERT_OR_RETURN(, psPlayerBlindWaitingRoom.get() != nullptr, "Wrong type of psWidget??");
+			psPlayerBlindWaitingRoom->recalculateInternalLayout();
+		}));
+	}
+
+	void geometryChanged() override
+	{
+		recalculateInternalLayout();
+	}
+
+	int getPlayerRowY0()
+	{
+		ASSERT_OR_RETURN(0, playerInfo != nullptr, "Invalid widget?");
+		return playerInfo->y();
+	}
+
+protected:
+	void display(int xOffset, int yOffset) override;
+
+private:
+
+	void recalculateInternalLayout()
+	{
+		int w = width();
+		int h = height();
+
+		titleBanner->setGeometry(0, 0, w, titleBanner->idealHeight());
+		int nextWidgetY0 = titleBanner->y() + titleBanner->height() + titleBannerBottomPadding;
+
+		int widgetX0 = outerWidgetPaddingX;
+		int usableWidgetWidth = w - (outerWidgetPaddingX * 2);
+		hostInfo->setGeometry(widgetX0, nextWidgetY0, usableWidgetWidth, hostInfo->idealHeight());
+		nextWidgetY0 = hostInfo->y() + hostInfo->height() + betweenWidgetPaddingY;
+
+		playerInfo->setGeometry(widgetX0, nextWidgetY0, usableWidgetWidth, playerInfo->idealHeight());
+		nextWidgetY0 = playerInfo->y() + playerInfo->height() + betweenWidgetPaddingY;
+
+		statusInfo->setGeometry(widgetX0, nextWidgetY0, usableWidgetWidth, statusInfo->idealHeight());
+		nextWidgetY0 = statusInfo->y() + statusInfo->height() + betweenWidgetPaddingY;
+
+		// aligned bottom-up
+		int bottomWidgetY0 = h - playersReadyInfo->idealHeight() - bottomPaddingY;
+		playersReadyInfo->setGeometry(widgetX0, bottomWidgetY0, usableWidgetWidth, playersReadyInfo->idealHeight());
+	}
+
+private:
+	std::weak_ptr<WzMultiplayerOptionsTitleUI> weakTitleUI;
+
+	int titleBannerBottomPadding = 10;
+	int outerWidgetPaddingX = 15;
+	int betweenWidgetPaddingY = 10;
+	int bottomPaddingY = 15;
+
+	std::shared_ptr<WzRoomTitleBanner> titleBanner;
+	std::shared_ptr<WzBlindRoomHostInfo> hostInfo;
+	std::shared_ptr<WzBlindRoomPlayerInfo> playerInfo;
+	std::shared_ptr<WzBlindRoomStatusInfo> statusInfo;
+	std::shared_ptr<WzBlindPlayersReadyInfo> playersReadyInfo;
+};
+
+void WzPlayerBlindWaitingRoom::display(int xOffset, int yOffset)
+{
+	int x0 = xOffset + x();
+	int y0 = yOffset + y();
+	int w = width();
+	int h = height();
+
+	pie_BoxFill(x0, y0, x0 + w, y0 + h, WZCOL_MENU_BACKGROUND);
+	iV_Box(x0, y0, x0 + w, y0 + h, WZCOL_MENU_BORDER);
+}
+
+
+// MARK: - Public methods
+
+std::shared_ptr<WIDGET> makeWzPlayerBlindWaitingRoom(const std::shared_ptr<WzMultiplayerOptionsTitleUI>& titleUI)
+{
+	return WzPlayerBlindWaitingRoom::make(titleUI);
+}
+
+int getWzPlayerBlindWaitingRoomPlayerRowY0(const std::shared_ptr<WIDGET>& blindWaitingRoomWidget)
+{
+	auto pBlindWaitingRoomWidget = std::dynamic_pointer_cast<WzPlayerBlindWaitingRoom>(blindWaitingRoomWidget);
+	ASSERT_OR_RETURN(0, pBlindWaitingRoomWidget != nullptr, "Invalid widget");
+	return pBlindWaitingRoomWidget->getPlayerRowY0();
+}

--- a/src/titleui/widgets/blindwaitingroom.h
+++ b/src/titleui/widgets/blindwaitingroom.h
@@ -1,6 +1,6 @@
 /*
 	This file is part of Warzone 2100.
-	Copyright (C) 2024  Warzone 2100 Project
+	Copyright (C) 2024-2025  Warzone 2100 Project
 
 	Warzone 2100 is free software; you can redistribute it and/or modify
 	it under the terms of the GNU General Public License as published by
@@ -16,17 +16,15 @@
 	along with Warzone 2100; if not, write to the Free Software
 	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
 */
+/** \file
+ *  Blind lobby waiting room widgets
+ */
 
 #pragma once
 
 #include "lib/widget/widget.h"
-#include "lib/widget/form.h"
 
-#include <functional>
+class WzMultiplayerOptionsTitleUI;
 
-#include "../multiplay.h"	// for JoinConnectionDescription
-
-bool startJoiningAttempt(char* playerName, std::vector<JoinConnectionDescription> connection_list, bool asSpectator = false);
-void shutdownJoiningAttempt();
-
-std::shared_ptr<WIDGET> createJoiningIndeterminateProgressWidget(iV_fonts fontID);
+std::shared_ptr<WIDGET> makeWzPlayerBlindWaitingRoom(const std::shared_ptr<WzMultiplayerOptionsTitleUI>& titleUI);
+int getWzPlayerBlindWaitingRoomPlayerRowY0(const std::shared_ptr<WIDGET>& blindWaitingRoomWidget);

--- a/src/titleui/widgets/infobutton.cpp
+++ b/src/titleui/widgets/infobutton.cpp
@@ -1,0 +1,70 @@
+/*
+	This file is part of Warzone 2100.
+	Copyright (C) 2024  Warzone 2100 Project
+
+	Warzone 2100 is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+
+	Warzone 2100 is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with Warzone 2100; if not, write to the Free Software
+	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+/** \file
+ *  Info Button
+ */
+
+#include "infobutton.h"
+#include "src/frontend.h"
+#include "src/frend.h"
+#include "lib/widget/widget.h"
+#include "lib/widget/label.h"
+#include "lib/ivis_opengl/pieblitfunc.h"
+
+std::shared_ptr<WzInfoButton> WzInfoButton::make()
+{
+	class make_shared_enabler: public WzInfoButton {};
+	auto widget = std::make_shared<make_shared_enabler>();
+	return widget;
+}
+
+void WzInfoButton::setImageDimensions(int imageSize)
+{
+	imageDimensions = imageSize;
+}
+
+int32_t WzInfoButton::idealHeight()
+{
+	return imageDimensions;
+}
+
+void WzInfoButton::display(int xOffset, int yOffset)
+{
+	int x0 = x() + xOffset;
+	int y0 = y() + yOffset;
+
+	bool isDown = (getState() & (WBUT_DOWN | WBUT_LOCK | WBUT_CLICKLOCK)) != 0;
+	bool isDisabled = (getState() & WBUT_DISABLE) != 0;
+	bool isHighlight = !isDisabled && ((getState() & WBUT_HIGHLIGHT) != 0);
+
+	if (isHighlight)
+	{
+		// Display highlight rect
+		int highlightRectDimensions = std::max(std::min<int>(width(), height()), imageDimensions + 2);
+		int boxX0 = x0 + (width() - highlightRectDimensions) / 2;
+		int boxY0 = y0 + (height() - highlightRectDimensions) / 2;
+		iV_Box(boxX0, boxY0, boxX0 + highlightRectDimensions + 1, boxY0 + highlightRectDimensions + 1, (isDown) ? imageColorHighlighted : imageColor);
+	}
+
+	// Display the info icon, centered
+	int imgPosX0 = x0 + (width() - imageDimensions) / 2;
+	int imgPosY0 = y0 + (height() - imageDimensions) / 2;
+	PIELIGHT imgColor = (isHighlight) ? imageColorHighlighted : imageColor;
+	iV_DrawImageFileAnisotropicTint(FrontImages, IMAGE_INFO_CIRCLE, imgPosX0, imgPosY0, Vector2f(imageDimensions, imageDimensions), imgColor);
+}

--- a/src/titleui/widgets/infobutton.h
+++ b/src/titleui/widgets/infobutton.h
@@ -1,0 +1,42 @@
+/*
+	This file is part of Warzone 2100.
+	Copyright (C) 2024  Warzone 2100 Project
+
+	Warzone 2100 is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+
+	Warzone 2100 is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with Warzone 2100; if not, write to the Free Software
+	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+/** \file
+ *  Info Button
+ */
+
+#pragma once
+
+#include "lib/widget/widget.h"
+#include "lib/widget/button.h"
+
+class WzInfoButton : public W_BUTTON
+{
+protected:
+	WzInfoButton() {}
+public:
+	static std::shared_ptr<WzInfoButton> make();
+	void setImageDimensions(int imageSize);
+	int32_t idealHeight() override;
+protected:
+	void display(int xOffset, int yOffset) override;
+private:
+	int imageDimensions = 16;
+	PIELIGHT imageColor = WZCOL_TEXT_MEDIUM;
+	PIELIGHT imageColorHighlighted = pal_RGBA(255,255,255,255);
+};

--- a/src/titleui/widgets/lobbyplayerrow.cpp
+++ b/src/titleui/widgets/lobbyplayerrow.cpp
@@ -1,0 +1,943 @@
+/*
+	This file is part of Warzone 2100.
+	Copyright (C) 2024  Warzone 2100 Project
+
+	Warzone 2100 is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+
+	Warzone 2100 is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with Warzone 2100; if not, write to the Free Software
+	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+/** \file
+ *  Lobby Player Row Widget (and associated display functions)
+ */
+
+#include "lobbyplayerrow.h"
+#include "src/frontend.h"
+#include "src/frend.h"
+#include "src/intimage.h"
+#include "src/multiint.h"
+#include "src/loadsave.h"
+#include "src/multiplay.h"
+#include "src/ai.h"
+#include "src/component.h"
+#include "src/clparse.h"
+#include "src/challenge.h"
+//#include "lib/widget/widget.h"
+//#include "lib/widget/label.h"
+//#include "lib/widget/button.h"
+//#include "infobutton.h"
+
+#include "lib/framework/input.h"
+
+#include "lib/netplay/netplay.h"
+
+#include "src/titleui/multiplayer.h"
+#include "src/multistat.h"
+
+#include "lib/ivis_opengl/pieblitfunc.h"
+
+struct DisplayPlayerCache {
+	std::string	fullMainText;	// the “full” main text (used for storing the full player name when displaying a player)
+	WzText		wzMainText;		// the main text
+
+	std::string fullAltNameText;
+	WzText		wzAltNameText;
+
+	WzText		wzSubText;		// the sub text (used for players)
+	WzText		wzEloText;      // the elo text (used for players)
+};
+
+static void drawBlueBox_Spectator(UDWORD x, UDWORD y, UDWORD w, UDWORD h)
+{
+	// Match drawBlueBox behavior
+	x -= 1;
+	y -= 1;
+	w += 2;
+	h += 2;
+	PIELIGHT backgroundClr = WZCOL_FORM_DARK;
+	backgroundClr.byte.a = 200;
+	pie_BoxFill(x, y, x + w, y + h, WZCOL_MENU_BORDER);
+	pie_UniTransBoxFill(x + 1, y + 1, x + w - 1, y + h - 1, backgroundClr);
+}
+
+static void drawBlueBox_SpectatorOnly(UDWORD x, UDWORD y, UDWORD w, UDWORD h)
+{
+	// Match drawBlueBox behavior
+	x -= 1;
+	y -= 1;
+	w += 2;
+	h += 2;
+	PIELIGHT backgroundClr = WZCOL_FORM_DARK;
+	backgroundClr.byte.a = 175;
+//	PIELIGHT borderClr = pal_RGBA(30, 30, 30, 120);
+//	pie_UniTransBoxFill(x, y, x + w, y + h, borderClr);
+//	pie_UniTransBoxFill(x + 1, y + 1, x + w - 1, y + h - 1, backgroundClr);
+	pie_UniTransBoxFill(x, y, x + w, y + h, backgroundClr);
+}
+
+static inline void drawBoxForPlayerInfoSegment(UDWORD playerIdx, UDWORD x, UDWORD y, UDWORD w, UDWORD h)
+{
+	ASSERT(playerIdx < NetPlay.players.size(), "Invalid playerIdx: %zu", static_cast<size_t>(playerIdx));
+	if (playerIdx >= NetPlay.players.size() || !NetPlay.players[playerIdx].isSpectator)
+	{
+		drawBlueBox(x, y, w, h);
+	}
+	else
+	{
+		if (!isSpectatorOnlySlot(playerIdx))
+		{
+			drawBlueBox_Spectator(x, y, w, h);
+		}
+		else
+		{
+			drawBlueBox_SpectatorOnly(x, y, w, h);
+		}
+	}
+}
+
+static void displayReadyBoxContainer(WIDGET *psWidget, UDWORD xOffset, UDWORD yOffset)
+{
+	const int x = xOffset + psWidget->x();
+	const int y = yOffset + psWidget->y();
+	const int j = psWidget->UserData;
+
+	drawBoxForPlayerInfoSegment(j, x, y, psWidget->width(), psWidget->height());
+}
+
+static int factionIcon(FactionID faction)
+{
+	switch (faction)
+	{
+	case 0: return IMAGE_FACTION_NORMAL;
+	case 1: return IMAGE_FACTION_NEXUS;
+	case 2: return IMAGE_FACTION_COLLECTIVE;
+	default: return IMAGE_NO;	/// what??
+	}
+}
+
+static void displayColour(WIDGET *psWidget, UDWORD xOffset, UDWORD yOffset)
+{
+	const int x = xOffset + psWidget->x();
+	const int y = yOffset + psWidget->y();
+	const int j = psWidget->UserData;
+
+	drawBoxForPlayerInfoSegment(j, x, y, psWidget->width(), psWidget->height());
+	if (!NetPlay.players[j].fileSendInProgress() && (isHumanPlayer(j) || NetPlay.players[j].difficulty != AIDifficulty::DISABLED) && !NetPlay.players[j].isSpectator)
+	{
+		int player = getPlayerColour(j);
+		STATIC_ASSERT(MAX_PLAYERS <= 16);
+		iV_DrawImageTc(FrontImages, IMAGE_PLAYERN, IMAGE_PLAYERN_TC, x + 3, y + 9, pal_GetTeamColour(player));
+		FactionID faction = NetPlay.players[j].faction;
+		iV_DrawImageFileAnisotropic(FrontImages, factionIcon(faction), x, y, Vector2f(11, 9));
+	}
+}
+
+void displayTeamChooser(WIDGET *psWidget, UDWORD xOffset, UDWORD yOffset)
+{
+	int x = xOffset + psWidget->x();
+	int y = yOffset + psWidget->y();
+	UDWORD		i = psWidget->UserData;
+
+	ASSERT_OR_RETURN(, i < MAX_CONNECTED_PLAYERS, "Index (%" PRIu32 ") out of bounds", i);
+
+	drawBoxForPlayerInfoSegment(i, x, y, psWidget->width(), psWidget->height());
+
+	if (!NetPlay.players[i].isSpectator)
+	{
+		if (alliancesSetTeamsBeforeGame(game.alliance))
+		{
+			ASSERT_OR_RETURN(, NetPlay.players[i].team >= 0 && NetPlay.players[i].team < MAX_PLAYERS, "Team index out of bounds");
+			iV_DrawImage(FrontImages, IMAGE_TEAM0 + NetPlay.players[i].team, x + 1, y + 8);
+		}
+		else
+		{
+			// TODO: Maybe display something else here to signify "no team, FFA"
+		}
+	}
+	else
+	{
+		iV_DrawImage(FrontImages, IMAGE_SPECTATOR, x + 1, y + 8);
+	}
+}
+
+void displaySpectatorAddButton(WIDGET *psWidget, UDWORD xOffset, UDWORD yOffset)
+{
+	int x = xOffset + psWidget->x();
+	int y = yOffset + psWidget->y();
+
+	drawBlueBox_SpectatorOnly(x, y, psWidget->width(), psWidget->height());
+	iV_DrawImage(FrontImages, IMAGE_SPECTATOR, x + 2, y + 1);
+}
+
+static bool isKnownPlayer(std::map<std::string, EcKey::Key> const &knownPlayers, std::string const &name, EcKey const &key)
+{
+	if (key.empty())
+	{
+		return false;
+	}
+	std::map<std::string, EcKey::Key>::const_iterator i = knownPlayers.find(name);
+	return i != knownPlayers.end() && key.toBytes(EcKey::Public) == i->second;
+}
+
+static void displayAltNameBox(int x, int y, WIDGET *psWidget, DisplayPlayerCache& cache, const PLAYERSTATS::Autorating& ar, bool isHighlight)
+{
+	int altNameBoxWidth = cache.wzAltNameText.width() + 4;
+	int altNameBoxHeight = cache.wzAltNameText.lineSize() + 2;
+	int altNameBoxX0 = (x + psWidget->width()) - altNameBoxWidth;
+	PIELIGHT altNameBoxColor = WZCOL_MENU_BORDER;
+	altNameBoxColor.byte.a = static_cast<uint8_t>(static_cast<float>(altNameBoxColor.byte.a) * (isHighlight ? 0.3f : 0.75f));
+	pie_UniTransBoxFill(altNameBoxX0, y, altNameBoxX0 + altNameBoxWidth, y + altNameBoxHeight, altNameBoxColor);
+
+	int altNameTextY0 = y + (altNameBoxHeight - cache.wzAltNameText.lineSize()) / 2 - cache.wzAltNameText.aboveBase();
+	PIELIGHT altNameTextColor = WZCOL_TEXT_MEDIUM;
+	if (ar.altNameTextColorOverride[0] != 255 || ar.altNameTextColorOverride[1] != 255 || ar.altNameTextColorOverride[2] != 255)
+	{
+		altNameTextColor = pal_Colour(ar.altNameTextColorOverride[0], ar.altNameTextColorOverride[1], ar.altNameTextColorOverride[2]);
+	}
+	if (isHighlight)
+	{
+		altNameTextColor.byte.a = static_cast<uint8_t>(static_cast<float>(altNameTextColor.byte.a) * 0.3f);
+	}
+	cache.wzAltNameText.render(altNameBoxX0 + 2, altNameTextY0, altNameTextColor);
+}
+
+void displayPlayer(WIDGET *psWidget, UDWORD xOffset, UDWORD yOffset)
+{
+	// Any widget using displayPlayer must have its pUserData initialized to a (DisplayPlayerCache*)
+	assert(psWidget->pUserData != nullptr);
+	DisplayPlayerCache& cache = *static_cast<DisplayPlayerCache *>(psWidget->pUserData);
+
+	const auto& aidata = getAIData();
+
+	int const x = xOffset + psWidget->x();
+	int const y = yOffset + psWidget->y();
+	unsigned const j = psWidget->UserData;
+	bool isHighlight = (psWidget->getState() & WBUT_HIGHLIGHT) != 0;
+
+	const int nameX = 32;
+
+	unsigned downloadProgress = NETgetDownloadProgress(j);
+
+	drawBoxForPlayerInfoSegment(j, x, y, psWidget->width(), psWidget->height());
+	if (downloadProgress != 100)
+	{
+		char progressString[MAX_STR_LENGTH];
+		ssprintf(progressString, j != selectedPlayer ? _("Sending Map: %u%% ") : _("Map: %u%% downloaded"), downloadProgress);
+		cache.wzMainText.setText(progressString, font_regular);
+		cache.wzMainText.render(x + 5, y + 22, WZCOL_FORM_TEXT);
+		cache.fullMainText = progressString;
+		return;
+	}
+	else if (ingame.localOptionsReceived && NetPlay.players[j].allocated)					// only draw if real player!
+	{
+		const PLAYERSTATS& stat = getMultiStats(j);
+		auto ar = stat.autorating;
+
+		std::string name = getPlayerName(j);
+
+		std::map<std::string, EcKey::Key> serverPlayers;  // TODO Fill this with players known to the server (needs implementing on the server, too). Currently useless.
+
+		PIELIGHT colour;
+		iV_fonts nameFont = font_regular;
+		if (j == selectedPlayer)
+		{
+			colour = WZCOL_TEXT_BRIGHT;
+//			nameFont = font_regular_bold;
+		}
+		else if (ingame.PingTimes[j] >= PING_LIMIT)
+		{
+			colour = WZCOL_FORM_PLAYER_NOPING;
+		}
+		else if (isKnownPlayer(serverPlayers, name, getMultiStats(j).identity))
+		{
+			colour = WZCOL_FORM_PLAYER_KNOWN_BY_SERVER;
+		}
+		else if (isLocallyKnownPlayer(name, getMultiStats(j).identity))
+		{
+			colour = WZCOL_FORM_PLAYER_KNOWN;
+		}
+		else
+		{
+			colour = WZCOL_FORM_PLAYER_UNKNOWN;
+		}
+
+		// name
+		if (cache.fullMainText != name)
+		{
+			if ((int)iV_GetTextWidth(name.c_str(), font_regular) > psWidget->width() - nameX)
+			{
+				while (!name.empty() && (int)iV_GetTextWidth((name + "...").c_str(), font_regular) > psWidget->width() - nameX)
+				{
+					name.resize(name.size() - 1);  // Clip name.
+				}
+				name += "...";
+			}
+			cache.wzMainText.setText(WzString::fromUtf8(name), nameFont);
+			cache.fullMainText = name;
+		}
+
+		WzString subText;
+
+		if (j == NetPlay.hostPlayer && NetPlay.bComms)
+		{
+			subText += _("HOST");
+		}
+
+		if (NetPlay.bComms && j != selectedPlayer)
+		{
+			char buf[250] = {'\0'};
+
+			// show ping time
+			ssprintf(buf, "%s%s: ", subText.isEmpty() ? "" : ", ", _("Ping"));
+			subText += buf;
+			if (ingame.PingTimes[j] < PING_LIMIT)
+			{
+					// show actual ping time
+					ssprintf(buf, "%03d", ingame.PingTimes[j]);
+			}
+			else
+			{
+				ssprintf(buf, "%s", "∞");  // Player has ping of somewhat questionable quality.
+			}
+			subText += buf;
+		}
+
+		if (!ar.valid)
+		{
+			ar.dummy = stat.played < 5;
+			// star 1 total droid kills
+			ar.star[0] = stat.totalKills > 600? 1 : stat.totalKills > 300? 2 : stat.totalKills > 150? 3 : 0;
+
+			// star 2 games played
+			ar.star[1] = stat.played > 200? 1 : stat.played > 100? 2 : stat.played > 50? 3 : 0;
+
+			// star 3 games won.
+			ar.star[2] = stat.wins > 80? 1 : stat.wins > 40? 2 : stat.wins > 10? 3 : 0;
+
+			// medals.
+			ar.medal = stat.wins >= 24 && stat.wins > 8 * stat.losses? 1 : stat.wins >= 12 && stat.wins > 4 * stat.losses? 2 : stat.wins >= 6 && stat.wins > 2 * stat.losses? 3 : 0;
+
+			ar.level = 0;
+			ar.autohoster = false;
+			ar.elo.clear();
+		}
+
+		if (cache.fullAltNameText != ar.altName)
+		{
+			std::string altName = ar.altName;
+			int maxAltNameWidth = static_cast<int>(static_cast<float>(psWidget->width() - nameX) * 0.65f);
+			iV_fonts fontID = font_small;
+			cache.wzAltNameText.setText(WzString::fromUtf8(altName), fontID);
+			cache.fullAltNameText = altName;
+			if (cache.wzAltNameText.width() > maxAltNameWidth)
+			{
+				while (!altName.empty() && ((int)iV_GetTextWidth(altName.c_str(), cache.wzAltNameText.getFontID()) + iV_GetEllipsisWidth(cache.wzAltNameText.getFontID())) > maxAltNameWidth)
+				{
+					altName.resize(altName.size() - 1);  // Clip alt name.
+				}
+				altName += "\u2026";
+				cache.wzAltNameText.setText(WzString::fromUtf8(altName), fontID);
+			}
+		}
+
+		if (!ar.altName.empty() && isHighlight)
+		{
+			// display first, behind everything
+			displayAltNameBox(x, y, psWidget, cache, ar, isHighlight);
+		}
+
+		int H = 5;
+		cache.wzMainText.render(x + nameX, y + 22 - H*!subText.isEmpty() - H*(ar.valid && !ar.elo.empty()), colour);
+		if (!subText.isEmpty())
+		{
+			cache.wzSubText.setText(subText, font_small);
+			cache.wzSubText.render(x + nameX, y + 28 - H*!ar.elo.empty(), WZCOL_TEXT_MEDIUM);
+		}
+
+		if (ar.autohoster)
+		{
+			iV_DrawImage(FrontImages, IMAGE_PLAYER_PC, x, y + 11);
+		}
+		else if (ar.dummy)
+		{
+			iV_DrawImage(FrontImages, IMAGE_MEDAL_DUMMY, x + 4, y + 13);
+		}
+		else
+		{
+			constexpr int starImgs[4] = {0, IMAGE_MULTIRANK1, IMAGE_MULTIRANK2, IMAGE_MULTIRANK3};
+			if (1 <= ar.star[0] && ar.star[0] < ARRAY_SIZE(starImgs))
+			{
+				iV_DrawImage(FrontImages, starImgs[ar.star[0]], x + 4, y + 3);
+			}
+			if (1 <= ar.star[1] && ar.star[1] < ARRAY_SIZE(starImgs))
+			{
+				iV_DrawImage(FrontImages, starImgs[ar.star[1]], x + 4, y + 13);
+			}
+			if (1 <= ar.star[2] && ar.star[2] < ARRAY_SIZE(starImgs))
+			{
+				iV_DrawImage(FrontImages, starImgs[ar.star[2]], x + 4, y + 23);
+			}
+			constexpr int medalImgs[4] = {0, IMAGE_MEDAL_GOLD, IMAGE_MEDAL_SILVER, IMAGE_MEDAL_BRONZE};
+			if (1 <= ar.medal && ar.medal < ARRAY_SIZE(medalImgs))
+			{
+				iV_DrawImage(FrontImages, medalImgs[ar.medal], x + 16 - 2*(ar.level != 0), y + 11);
+			}
+		}
+		constexpr int levelImgs[9] = {0, IMAGE_LEV_0, IMAGE_LEV_1, IMAGE_LEV_2, IMAGE_LEV_3, IMAGE_LEV_4, IMAGE_LEV_5, IMAGE_LEV_6, IMAGE_LEV_7};
+		if (ar.level > 0 && ar.level < ARRAY_SIZE(levelImgs))
+		{
+			iV_DrawImage(IntImages, levelImgs[ar.level], x + 24, y + 15);
+		}
+
+		if (!ar.elo.empty())
+		{
+			PIELIGHT eloColour = WZCOL_TEXT_BRIGHT;
+			if (ar.eloTextColorOverride[0] != 255 || ar.eloTextColorOverride[1] != 255 || ar.eloTextColorOverride[2] != 255)
+			{
+				eloColour = pal_Colour(ar.eloTextColorOverride[0], ar.eloTextColorOverride[1], ar.eloTextColorOverride[2]);
+			}
+			cache.wzEloText.setText(WzString::fromUtf8(ar.elo), font_small);
+			cache.wzEloText.render(x + nameX, y + 28 + H*!subText.isEmpty(), eloColour);
+		}
+
+		if (!ar.altName.empty() && !isHighlight)
+		{
+			// display last, over top of everything
+			displayAltNameBox(x, y, psWidget, cache, ar, isHighlight);
+		}
+	}
+	else	// AI
+	{
+		char aitext[100];
+
+		if (NetPlay.players[j].ai >= 0)
+		{
+			iV_DrawImage(FrontImages, IMAGE_PLAYER_PC, x, y + 11);
+		}
+
+		// challenges may use custom AIs that are not in aidata and set to 127
+		if (!challengeActive)
+		{
+			ASSERT_OR_RETURN(, NetPlay.players[j].ai < (int)aidata.size(), "Uh-oh, AI index out of bounds");
+		}
+
+		PIELIGHT textColor = WZCOL_FORM_TEXT;
+		switch (NetPlay.players[j].ai)
+		{
+		case AI_OPEN:
+			if (!NetPlay.players[j].isSpectator)
+			{
+				sstrcpy(aitext, _("Open"));
+			}
+			else
+			{
+				sstrcpy(aitext, _("Spectator"));
+				textColor.byte.a = 220;
+			}
+			break;
+		case AI_CLOSED: sstrcpy(aitext, _("Closed")); break;
+		default: sstrcpy(aitext, getPlayerName(j)); break;
+		}
+		cache.wzMainText.setText(aitext, font_regular);
+		cache.wzMainText.render(x + nameX, y + 22, textColor);
+		cache.fullMainText = aitext;
+	}
+}
+
+static bool canChooseTeamFor(int i)
+{
+	return (i == selectedPlayer || isHostOrAdmin());
+}
+
+static std::shared_ptr<W_FORM> createBlueForm(int x, int y, int w, int h, WIDGET_DISPLAY displayFunc /* = intDisplayFeBox*/)
+{
+	ASSERT(displayFunc != nullptr, "Must have a display func!");
+	auto form = std::make_shared<W_FORM>();
+	form->setGeometry(x, y, w, h);
+	form->style = WFORM_PLAIN;
+	form->displayFunction = displayFunc;
+	return form;
+}
+
+// ////////////////////////////////////////////////////////////////////////////
+// Lobby player row
+
+WzPlayerRow::WzPlayerRow(uint32_t playerIdx, const std::shared_ptr<WzMultiplayerOptionsTitleUI>& parent)
+: WIDGET()
+, parentTitleUI(parent)
+, playerIdx(playerIdx)
+{ }
+
+std::shared_ptr<WzPlayerRow> WzPlayerRow::make(uint32_t playerIdx, const std::shared_ptr<WzMultiplayerOptionsTitleUI>& parent)
+{
+	class make_shared_enabler: public WzPlayerRow {
+	public:
+		make_shared_enabler(uint32_t playerIdx, const std::shared_ptr<WzMultiplayerOptionsTitleUI>& parent) : WzPlayerRow(playerIdx, parent) { }
+	};
+	auto widget = std::make_shared<make_shared_enabler>(playerIdx, parent);
+
+	std::weak_ptr<WzMultiplayerOptionsTitleUI> titleUI(parent);
+
+	// add team button (also displays the spectator "eye" for spectators)
+	widget->teamButton = std::make_shared<W_BUTTON>();
+	widget->teamButton->setGeometry(0, 0, MULTIOP_TEAMSWIDTH, MULTIOP_TEAMSHEIGHT);
+	widget->teamButton->UserData = playerIdx;
+	widget->teamButton->displayFunction = displayTeamChooser;
+	widget->attach(widget->teamButton);
+	widget->teamButton->addOnClickHandler([playerIdx, titleUI](W_BUTTON& button){
+		auto strongTitleUI = titleUI.lock();
+		ASSERT_OR_RETURN(, strongTitleUI != nullptr, "Title UI is gone?");
+		const auto& locked = getLockedOptions();
+		if ((!locked.teams || !locked.spectators))  // Clicked on a team chooser
+		{
+			if (canChooseTeamFor(playerIdx))
+			{
+				widgScheduleTask([strongTitleUI, playerIdx] {
+					strongTitleUI->openTeamChooser(playerIdx);
+				});
+			}
+		}
+	});
+
+	// add player colour
+	widget->colorButton = std::make_shared<W_BUTTON>();
+	widget->colorButton->setGeometry(MULTIOP_TEAMSWIDTH, 0, MULTIOP_COLOUR_WIDTH, MULTIOP_PLAYERHEIGHT);
+	widget->colorButton->UserData = playerIdx;
+	widget->colorButton->displayFunction = displayColour;
+	widget->attach(widget->colorButton);
+	widget->colorButton->addOnClickHandler([playerIdx, titleUI](W_BUTTON& button){
+		auto strongTitleUI = titleUI.lock();
+		ASSERT_OR_RETURN(, strongTitleUI != nullptr, "Title UI is gone?");
+		if (playerIdx == selectedPlayer || isHostOrAdmin())
+		{
+			if (!NetPlay.players[playerIdx].isSpectator) // not a spectator
+			{
+				widgScheduleTask([strongTitleUI, playerIdx] {
+					strongTitleUI->openColourChooser(playerIdx);
+				});
+			}
+		}
+	});
+
+	// add ready button
+	widget->updateReadyButton();
+
+	// add player info box (takes up the rest of the space in the middle)
+	widget->playerInfo = std::make_shared<W_BUTTON>();
+	widget->playerInfo->UserData = playerIdx;
+	widget->playerInfo->displayFunction = displayPlayer;
+	widget->playerInfo->pUserData = new DisplayPlayerCache();
+	widget->playerInfo->setOnDelete([](WIDGET *psWidget) {
+		assert(psWidget->pUserData != nullptr);
+		delete static_cast<DisplayPlayerCache *>(psWidget->pUserData);
+		psWidget->pUserData = nullptr;
+	});
+	widget->attach(widget->playerInfo);
+	widget->playerInfo->setCalcLayout([](WIDGET *psWidget) {
+		auto psParent = std::dynamic_pointer_cast<WzPlayerRow>(psWidget->parent());
+		ASSERT_OR_RETURN(, psParent != nullptr, "Null parent");
+		int x0 = MULTIOP_TEAMSWIDTH + MULTIOP_COLOUR_WIDTH;
+		int width = psParent->readyButtonContainer->x() - x0;
+		psWidget->setGeometry(x0, 0, width, psParent->height());
+	});
+	widget->playerInfo->addOnClickHandler([playerIdx, titleUI](W_BUTTON& button){
+		auto strongTitleUI = titleUI.lock();
+		ASSERT_OR_RETURN(, strongTitleUI != nullptr, "Title UI is gone?");
+		const auto& locked = getLockedOptions();
+		if (playerIdx == selectedPlayer || isHostOrAdmin())
+		{
+			uint32_t player = playerIdx;
+			// host/admin can move any player, clients can request to move themselves if there are available slots
+			if (((player == selectedPlayer && validPlayerIdxTargetsForPlayerPositionMove(player).size() > 0) ||
+					(NetPlay.players[player].allocated && isHostOrAdmin()))
+				&& !locked.position
+				&& player < MAX_PLAYERS
+				&& !isSpectatorOnlySlot(player))
+			{
+				widgScheduleTask([strongTitleUI, player] {
+					strongTitleUI->openPositionChooser(player);
+				});
+			}
+			else if (!NetPlay.players[player].allocated && !locked.ai && NetPlay.isHost)
+			{
+				if (button.getOnClickButtonPressed() == WKEY_SECONDARY && player < MAX_PLAYERS)
+				{
+					// Right clicking distributes selected AI's type and difficulty to all other AIs
+					for (int i = 0; i < MAX_PLAYERS; ++i)
+					{
+						// Don't change open/closed slots or humans or spectator-only slots
+						if (NetPlay.players[i].ai >= 0 && i != player && !isHumanPlayer(i) && !isSpectatorOnlySlot(i))
+						{
+							NetPlay.players[i].ai = NetPlay.players[player].ai;
+							NetPlay.players[i].isSpectator = NetPlay.players[player].isSpectator;
+							NetPlay.players[i].difficulty = NetPlay.players[player].difficulty;
+							setPlayerName(i, getAIName(player));
+							NETBroadcastPlayerInfo(i);
+						}
+					}
+					widgScheduleTask([strongTitleUI] {
+						strongTitleUI->updatePlayers();
+						resetReadyStatus(false);
+					});
+				}
+				else
+				{
+					widgScheduleTask([strongTitleUI, player] {
+						strongTitleUI->openAiChooser(player);
+					});
+				}
+			}
+		}
+	});
+
+	// update tooltips and such
+	widget->updateState();
+
+	return widget;
+}
+
+void WzPlayerRow::geometryChanged()
+{
+	if (readyButtonContainer)
+	{
+		readyButtonContainer->callCalcLayout();
+	}
+	if (playerInfo)
+	{
+		playerInfo->callCalcLayout();
+	}
+}
+
+void WzPlayerRow::updateState()
+{
+	const auto& aidata = getAIData();
+	const auto& locked = getLockedOptions();
+
+	// update team button tooltip
+	if (NetPlay.players[playerIdx].isSpectator)
+	{
+		teamButton->setTip(_("Spectator"));
+	}
+	else if (canChooseTeamFor(playerIdx) && !locked.teams)
+	{
+		teamButton->setTip(_("Choose Team"));
+	}
+	else if (locked.teams)
+	{
+		teamButton->setTip(_("Teams locked"));
+	}
+	else
+	{
+		teamButton->setTip(nullptr);
+	}
+
+	// hide team button if needed
+	bool trueMultiplayerMode = (bMultiPlayer && NetPlay.bComms) || (!NetPlay.isHost && ingame.localJoiningInProgress);
+	if (!alliancesSetTeamsBeforeGame(game.alliance) && !NetPlay.players[playerIdx].isSpectator && !trueMultiplayerMode)
+	{
+		teamButton->hide();
+	}
+	else
+	{
+		teamButton->show();
+	}
+
+	// update color tooltip
+	if ((selectedPlayer == playerIdx || NetPlay.isHost) && (!NetPlay.players[playerIdx].isSpectator))
+	{
+		colorButton->setTip(_("Click to change player colour"));
+	}
+	else
+	{
+		colorButton->setTip(nullptr);
+	}
+
+	// update player info box tooltip
+	std::string playerInfoTooltip;
+	if ((selectedPlayer == playerIdx || NetPlay.isHost) && NetPlay.players[playerIdx].allocated && !locked.position && !isSpectatorOnlySlot(playerIdx))
+	{
+		playerInfoTooltip = _("Click to change player position");
+	}
+	else if (!NetPlay.players[playerIdx].allocated)
+	{
+		if (NetPlay.isHost && !locked.ai)
+		{
+			playerInfo->style |= WBUT_SECONDARY;
+			if (!isSpectatorOnlySlot(playerIdx))
+			{
+				playerInfoTooltip = _("Click to change AI, right click to distribute choice");
+			}
+			else
+			{
+				playerInfoTooltip = _("Click to close spectator slot");
+			}
+		}
+		else if (NetPlay.players[playerIdx].ai >= 0)
+		{
+			// show AI description. Useful for challenges.
+			playerInfoTooltip = aidata[NetPlay.players[playerIdx].ai].tip;
+		}
+	}
+	if (NetPlay.players[playerIdx].allocated)
+	{
+		const PLAYERSTATS& stats = getMultiStats(playerIdx);
+		const auto& identity = stats.identity;
+		if (!identity.empty())
+		{
+			if (!playerInfoTooltip.empty())
+			{
+				playerInfoTooltip += "\n";
+			}
+			std::string hash = identity.publicHashString(20);
+			playerInfoTooltip += _("Player ID: ");
+			playerInfoTooltip += hash.empty()? _("(none)") : hash;
+		}
+		std::string autoratingTooltipText;
+		if (stats.autorating.valid)
+		{
+			if (!stats.autorating.altName.empty())
+			{
+				if (!autoratingTooltipText.empty())
+				{
+					autoratingTooltipText += "\n";
+				}
+				std::string altnameStr = stats.autorating.altName;
+				if (altnameStr.size() > 128)
+				{
+					altnameStr = altnameStr.substr(0, 128);
+				}
+				size_t maxLinePos = nthOccurrenceOfChar(altnameStr, '\n', 1);
+				if (maxLinePos != std::string::npos)
+				{
+					altnameStr = altnameStr.substr(0, maxLinePos);
+				}
+				autoratingTooltipText += std::string(_("Alt Name:")) + " " + altnameStr;
+			}
+			if (!stats.autorating.details.empty()
+				&& stats.autoratingFrom == RATING_SOURCE_LOCAL) // do not display host-provided details (for now)
+			{
+				if (!autoratingTooltipText.empty())
+				{
+					autoratingTooltipText += "\n";
+				}
+				std::string detailsstr = stats.autorating.details;
+				if (detailsstr.size() > 512)
+				{
+					detailsstr = detailsstr.substr(0, 512);
+				}
+				size_t maxLinePos = nthOccurrenceOfChar(detailsstr, '\n', 10);
+				if (maxLinePos != std::string::npos)
+				{
+					detailsstr = detailsstr.substr(0, maxLinePos);
+				}
+				autoratingTooltipText += std::string(_("Player rating:")) + "\n" + detailsstr;
+			}
+		}
+		if (!autoratingTooltipText.empty())
+		{
+			if (!playerInfoTooltip.empty())
+			{
+				playerInfoTooltip += "\n\n";
+			}
+			if (stats.autoratingFrom == RATING_SOURCE_HOST)
+			{
+				playerInfoTooltip += std::string("[") + _("Host provided") + "]\n";
+			}
+			else
+			{
+				playerInfoTooltip += std::string("[") + astringf(_("From: %s"), getAutoratingUrl().c_str()) + "]\n";
+			}
+			playerInfoTooltip += autoratingTooltipText;
+		}
+	}
+	playerInfo->setTip(playerInfoTooltip);
+
+	// update ready button
+	updateReadyButton();
+}
+
+void WzPlayerRow::updateReadyButton()
+{
+	int disallow = allPlayersOnSameTeam(-1);
+
+	const auto& aidata = getAIData();
+	const auto& locked = getLockedOptions();
+
+	if (!readyButtonContainer)
+	{
+		// add form to hold 'ready' botton
+		readyButtonContainer = createBlueForm(MULTIOP_PLAYERWIDTH - MULTIOP_READY_WIDTH, 0,
+					MULTIOP_READY_WIDTH, MULTIOP_READY_HEIGHT, displayReadyBoxContainer);
+		readyButtonContainer->UserData = playerIdx;
+		attach(readyButtonContainer);
+		readyButtonContainer->setCalcLayout([](WIDGET *psWidget) {
+			auto psParent = psWidget->parent();
+			ASSERT_OR_RETURN(, psParent != nullptr, "Null parent");
+			psWidget->setGeometry(psParent->width() - MULTIOP_READY_WIDTH, 0, psWidget->width(), psWidget->height());
+		});
+	}
+
+	auto deleteExistingReadyButton = [this]() {
+		if (readyButton)
+		{
+			widgDelete(readyButton.get());
+			readyButton = nullptr;
+		}
+		if (readyTextLabel)
+		{
+			widgDelete(readyTextLabel.get());
+			readyTextLabel = nullptr;
+		}
+	};
+	auto deleteExistingDifficultyButton = [this]() {
+		if (difficultyChooserButton)
+		{
+			widgDelete(difficultyChooserButton.get());
+			difficultyChooserButton = nullptr;
+		}
+	};
+
+	if (!NetPlay.players[playerIdx].allocated && NetPlay.players[playerIdx].ai >= 0)
+	{
+		// Add AI difficulty chooser in place of normal "ready" button
+		deleteExistingReadyButton();
+		int playerDifficulty = static_cast<int8_t>(NetPlay.players[playerIdx].difficulty);
+		int icon = difficultyIcon(playerDifficulty);
+		char tooltip[128 + 255];
+		if (playerDifficulty >= static_cast<int>(AIDifficulty::EASY) && playerDifficulty < static_cast<int>(AIDifficulty::INSANE) + 1)
+		{
+			sstrcpy(tooltip, gettext(getDifficultyListStr(playerDifficulty)));
+			if (NetPlay.players[playerIdx].ai < aidata.size())
+			{
+				const char *difficultyTip = aidata[NetPlay.players[playerIdx].ai].difficultyTips[playerDifficulty];
+				if (strcmp(difficultyTip, "") != 0)
+				{
+					sstrcat(tooltip, "\n");
+					sstrcat(tooltip, difficultyTip);
+				}
+			}
+		}
+		bool freshDifficultyButton = (difficultyChooserButton == nullptr);
+		difficultyChooserButton = addMultiBut(*readyButtonContainer, MULTIOP_DIFFICULTY_INIT_START + playerIdx, 6, 4, MULTIOP_READY_WIDTH, MULTIOP_READY_HEIGHT,
+					(NetPlay.isHost && !locked.difficulty) ? _("Click to change difficulty") : tooltip, icon, icon, icon, MAX_PLAYERS, (NetPlay.isHost && !locked.difficulty) ? 255 : 125);
+		auto player = playerIdx;
+		auto weakTitleUi = parentTitleUI;
+		if (freshDifficultyButton)
+		{
+			difficultyChooserButton->addOnClickHandler([player, weakTitleUi](W_BUTTON&){
+				auto strongTitleUI = weakTitleUi.lock();
+				ASSERT_OR_RETURN(, strongTitleUI != nullptr, "Title UI is gone?");
+				const auto& locked = getLockedOptions();
+				if (!locked.difficulty && NetPlay.isHost)
+				{
+					widgScheduleTask([strongTitleUI, player] {
+						strongTitleUI->openDifficultyChooser(player);
+					});
+				}
+			});
+		}
+		return;
+	}
+	else if (!NetPlay.players[playerIdx].allocated)
+	{
+		// closed or open - remove ready / difficulty button
+		deleteExistingReadyButton();
+		deleteExistingDifficultyButton();
+		return;
+	}
+
+	if (disallow != -1)
+	{
+		// remove ready / difficulty button
+		deleteExistingReadyButton();
+		deleteExistingDifficultyButton();
+		return;
+	}
+
+	deleteExistingDifficultyButton();
+
+	bool isMe = playerIdx == selectedPlayer;
+	int isReady = NETgetDownloadProgress(playerIdx) != 100 ? 2 : NetPlay.players[playerIdx].ready ? 1 : 0;
+	char const *const toolTips[2][3] = {{_("Waiting for player"), _("Player is ready"), _("Player is downloading")}, {_("Click when ready"), _("Waiting for other players"), _("Waiting for download")}};
+	unsigned images[2][3] = {{IMAGE_CHECK_OFF, IMAGE_CHECK_ON, IMAGE_CHECK_DOWNLOAD}, {IMAGE_CHECK_OFF_HI, IMAGE_CHECK_ON_HI, IMAGE_CHECK_DOWNLOAD_HI}};
+
+	// draw 'ready' button
+	bool greyedOutReady = (NetPlay.players[playerIdx].isSpectator && NetPlay.players[playerIdx].ready) || (playerIdx != selectedPlayer);
+	bool freshReadyButton = (readyButton == nullptr);
+	readyButton = addMultiBut(*readyButtonContainer, MULTIOP_READY_START + playerIdx, 3, 10, MULTIOP_READY_WIDTH, MULTIOP_READY_HEIGHT,
+				toolTips[isMe][isReady], images[0][isReady], images[0][isReady], images[isMe][isReady], MAX_PLAYERS, (!greyedOutReady) ? 255 : 125);
+	ASSERT_OR_RETURN(, readyButton != nullptr, "Failed to create ready button");
+	readyButton->minClickInterval = GAME_TICKS_PER_SEC;
+	readyButton->unlock();
+	if (greyedOutReady && !NetPlay.isHost)
+	{
+		std::shared_ptr<WzMultiButton> pReadyBut_MultiButton = std::dynamic_pointer_cast<WzMultiButton>(readyButton);
+		if (pReadyBut_MultiButton)
+		{
+			pReadyBut_MultiButton->downStateMask = WBUT_DOWN | WBUT_CLICKLOCK;
+		}
+		auto currentState = readyButton->getState();
+		readyButton->setState(currentState | WBUT_LOCK);
+	}
+	if (freshReadyButton)
+	{
+		// must add onclick handler
+		auto player = playerIdx;
+		auto weakTitleUi = parentTitleUI;
+		readyButton->addOnClickHandler([player, weakTitleUi](W_BUTTON& button){
+			auto pButton = button.shared_from_this();
+			widgScheduleTask([weakTitleUi, player, pButton] {
+				auto strongTitleUI = weakTitleUi.lock();
+				ASSERT_OR_RETURN(, strongTitleUI != nullptr, "Title UI is gone?");
+
+				if (player == selectedPlayer
+					&& (!NetPlay.players[player].isSpectator || !NetPlay.players[player].ready || NetPlay.isHost)) // spectators can never toggle off "ready"
+				{
+					// Lock the "ready" button (until the request is processed)
+					pButton->setState(WBUT_LOCK);
+
+					sendReadyRequest(selectedPlayer, !NetPlay.players[player].ready);
+
+					// if hosting try to start the game if everyone is ready
+					if (NetPlay.isHost && multiplayPlayersReady())
+					{
+						startMultiplayerGame();
+						// reset flag in case people dropped/quit on join screen
+						NETsetPlayerConnectionStatus(CONNECTIONSTATUS_NORMAL, NET_ALL_PLAYERS);
+					}
+				}
+
+				if (NetPlay.isHost && !alliancesSetTeamsBeforeGame(game.alliance))
+				{
+					if (mouseDown(MOUSE_RMB) && player != NetPlay.hostPlayer) // both buttons....
+					{
+						std::string msg = astringf(_("The host has kicked %s from the game!"), getPlayerName(player));
+						sendRoomSystemMessage(msg.c_str());
+						kickPlayer(player, _("The host has kicked you from the game."), ERROR_KICKED, false);
+						resetReadyStatus(true);		//reset and send notification to all clients
+					}
+				}
+			});
+		});
+	}
+
+	if (!readyTextLabel)
+	{
+		readyTextLabel = std::make_shared<W_LABEL>();
+		readyButtonContainer->attach(readyTextLabel);
+		readyTextLabel->id = MULTIOP_READY_START + MAX_CONNECTED_PLAYERS + playerIdx;
+	}
+	readyTextLabel->setGeometry(0, 0, MULTIOP_READY_WIDTH, 17);
+	readyTextLabel->setTextAlignment(WLAB_ALIGNBOTTOM);
+	readyTextLabel->setFont(font_small, WZCOL_TEXT_BRIGHT);
+	readyTextLabel->setString(_("READY?"));
+}

--- a/src/titleui/widgets/lobbyplayerrow.cpp
+++ b/src/titleui/widgets/lobbyplayerrow.cpp
@@ -492,7 +492,7 @@ void displayPlayer(WIDGET *psWidget, UDWORD xOffset, UDWORD yOffset)
 
 static bool canChooseTeamFor(int i)
 {
-	if (game.blindMode == BLIND_MODE::BLIND_GAME_SIMPLE_LOBBY && !NetPlay.isHost)
+	if (isBlindSimpleLobby(game.blindMode) && !NetPlay.isHost)
 	{
 		return false;
 	}
@@ -603,7 +603,7 @@ std::shared_ptr<WzPlayerRow> WzPlayerRow::make(uint32_t playerIdx, const std::sh
 				&& !locked.position
 				&& player < MAX_PLAYERS
 				&& !isSpectatorOnlySlot(player)
-				&& ((game.blindMode != BLIND_MODE::BLIND_GAME_SIMPLE_LOBBY) || NetPlay.isHost))
+				&& (!isBlindSimpleLobby(game.blindMode) || NetPlay.isHost))
 			{
 				widgScheduleTask([strongTitleUI, player] {
 					strongTitleUI->openPositionChooser(player);
@@ -628,7 +628,7 @@ std::shared_ptr<WzPlayerRow> WzPlayerRow::make(uint32_t playerIdx, const std::sh
 					}
 					widgScheduleTask([strongTitleUI] {
 						strongTitleUI->updatePlayers();
-						resetReadyStatus(false, game.blindMode == BLIND_MODE::BLIND_GAME_SIMPLE_LOBBY);
+						resetReadyStatus(false, isBlindSimpleLobby(game.blindMode));
 					});
 				}
 				else
@@ -709,7 +709,7 @@ void WzPlayerRow::updateState()
 		&& NetPlay.players[playerIdx].allocated
 		&& !locked.position
 		&& !isSpectatorOnlySlot(playerIdx)
-		&& ((game.blindMode != BLIND_MODE::BLIND_GAME_SIMPLE_LOBBY) || NetPlay.isHost))
+		&& (!isBlindSimpleLobby(game.blindMode) || NetPlay.isHost))
 	{
 		playerInfoTooltip = _("Click to change player position");
 	}
@@ -813,7 +813,7 @@ void WzPlayerRow::updateState()
 
 void WzPlayerRow::updateReadyButton()
 {
-	bool disallow = (allPlayersOnSameTeam(-1) != -1) && (game.blindMode != BLIND_MODE::BLIND_GAME_SIMPLE_LOBBY);
+	bool disallow = (allPlayersOnSameTeam(-1) != -1) && !isBlindSimpleLobby(game.blindMode);
 
 	const auto& aidata = getAIData();
 	const auto& locked = getLockedOptions();
@@ -969,7 +969,7 @@ void WzPlayerRow::updateReadyButton()
 						std::string msg = astringf(_("The host has kicked %s from the game!"), getPlayerName(player, true));
 						sendRoomSystemMessage(msg.c_str());
 						kickPlayer(player, _("The host has kicked you from the game."), ERROR_KICKED, false);
-						resetReadyStatus(true, game.blindMode == BLIND_MODE::BLIND_GAME_SIMPLE_LOBBY);		//reset and send notification to all clients
+						resetReadyStatus(true, isBlindSimpleLobby(game.blindMode));		//reset and send notification to all clients
 					}
 				}
 			});

--- a/src/titleui/widgets/lobbyplayerrow.h
+++ b/src/titleui/widgets/lobbyplayerrow.h
@@ -1,0 +1,56 @@
+/*
+	This file is part of Warzone 2100.
+	Copyright (C) 2024  Warzone 2100 Project
+
+	Warzone 2100 is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+
+	Warzone 2100 is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with Warzone 2100; if not, write to the Free Software
+	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+/** \file
+ *  Lobby Player Row Widget (and associated display functions)
+ */
+
+#pragma once
+
+#include "lib/widget/widget.h"
+#include "lib/widget/label.h"
+#include "lib/widget/button.h"
+
+class WzMultiplayerOptionsTitleUI;
+
+class WzPlayerRow : public WIDGET
+{
+protected:
+	WzPlayerRow(uint32_t playerIdx, const std::shared_ptr<WzMultiplayerOptionsTitleUI>& parent);
+
+public:
+	static std::shared_ptr<WzPlayerRow> make(uint32_t playerIdx, const std::shared_ptr<WzMultiplayerOptionsTitleUI>& parent);
+
+	void geometryChanged() override;
+
+	void updateState();
+
+private:
+	void updateReadyButton();
+
+private:
+	std::weak_ptr<WzMultiplayerOptionsTitleUI> parentTitleUI;
+	unsigned playerIdx = 0;
+	std::shared_ptr<W_BUTTON> teamButton;
+	std::shared_ptr<W_BUTTON> colorButton;
+	std::shared_ptr<W_BUTTON> playerInfo;
+	std::shared_ptr<WIDGET> readyButtonContainer;
+	std::shared_ptr<W_BUTTON> difficultyChooserButton;
+	std::shared_ptr<W_BUTTON> readyButton;
+	std::shared_ptr<W_LABEL> readyTextLabel;
+};

--- a/src/wrappers.cpp
+++ b/src/wrappers.cpp
@@ -356,6 +356,24 @@ bool displayGameOver(bool bDidit, bool showBackDrop)
 		{
 			ingame.endTime = std::chrono::steady_clock::now();
 			debug(LOG_INFO, "Game ended (duration: %lld)", (long long)std::chrono::duration_cast<std::chrono::seconds>(ingame.endTime.value() - ingame.startTime).count());
+
+			// If in blind mode, send data on who the players were
+			if (game.blindMode != BLIND_MODE::NONE)
+			{
+				if (NetPlay.isHost)
+				{
+					// Send updated player info (which will include real names, now that game has ended) to all players
+					NETSendAllPlayerInfoTo(NET_ALL_PLAYERS);
+
+					// Send the verified player identity from initial join for each player (now that game has ended)
+					for (uint32_t idx = 0; idx < MAX_CONNECTED_PLAYERS; ++idx)
+					{
+						sendMultiStatsHostVerifiedIdentities(idx);
+					}
+				}
+
+				// Note: Replay player info updating occurs as part of NETreplaySaveStop
+			}
 		}
 	}
 	if (bDidit)

--- a/src/wrappers.cpp
+++ b/src/wrappers.cpp
@@ -44,6 +44,7 @@
 #include "warzoneconfig.h"
 #include "wrappers.h"
 #include "titleui/titleui.h"
+#include "stdinreader.h"
 
 #if defined(__EMSCRIPTEN__)
 #include <emscripten.h>
@@ -64,6 +65,7 @@ static UBYTE    scriptWinLoseVideo = PLAY_NONE;
 static HostLaunch hostlaunch = HostLaunch::Normal;  // used to detect if we are hosting a game via command line option.
 static bool bHeadlessAutoGameModeCLIOption = false;
 static bool bActualHeadlessAutoGameMode = false;
+static bool bHostLaunchStartNotReady = false;
 
 static uint32_t lastTick = 0;
 static int barLeftX, barLeftY, barRightX, barRightY, boxWidth, boxHeight, starsNum, starHeight;
@@ -125,6 +127,12 @@ void setHostLaunch(HostLaunch value)
 	bActualHeadlessAutoGameMode = recalculateEffectiveHeadlessValue();
 }
 
+void resetHostLaunch()
+{
+	setHostLaunch(HostLaunch::Normal);
+	setHostLaunchStartNotReady(false);
+}
+
 HostLaunch getHostLaunch()
 {
 	return hostlaunch;
@@ -139,6 +147,21 @@ void setHeadlessGameMode(bool enabled)
 bool headlessGameMode()
 {
 	return bActualHeadlessAutoGameMode;
+}
+
+void setHostLaunchStartNotReady(bool value)
+{
+	bHostLaunchStartNotReady = value;
+}
+
+bool getHostLaunchStartNotReady()
+{
+	if (bHostLaunchStartNotReady && headlessGameMode() && !wz_command_interface_enabled())
+	{
+		debug(LOG_ERROR, "--autohost-not-ready specified while in headless mode without --enablecmdinterface specified. No way to start the host. Ignoring.");
+		bHostLaunchStartNotReady = false;
+	}
+	return bHostLaunchStartNotReady;
 }
 
 

--- a/src/wrappers.h
+++ b/src/wrappers.h
@@ -46,9 +46,13 @@ enum class HostLaunch
 
 void setHostLaunch(HostLaunch value);
 HostLaunch getHostLaunch();
+void resetHostLaunch();
 
 void setHeadlessGameMode(bool enabled);
 bool headlessGameMode();
+
+void setHostLaunchStartNotReady(bool value);
+bool getHostLaunchStartNotReady();
 
 bool frontendInitVars();
 TITLECODE titleLoop();

--- a/src/wzapi.cpp
+++ b/src/wzapi.cpp
@@ -4685,7 +4685,15 @@ nlohmann::json wzapi::constructStaticPlayerData()
 	for (int i = 0; i < game.maxPlayers; i++)
 	{
 		nlohmann::json vector = nlohmann::json::object();
-		vector["name"] = NetPlay.players[i].name;
+		if (game.blindMode >= BLIND_MODE::BLIND_GAME)
+		{
+			// to ensure the "name" field exposed to api is consistent across blind games _and_ replays of those games, always set it to the generic name if in blind mode
+			vector["name"] = getPlayerGenericName(i);
+		}
+		else
+		{
+			vector["name"] = NetPlay.players[i].name;
+		}
 		vector["difficulty"] = static_cast<int8_t>(NetPlay.players[i].difficulty);
 		vector["faction"] = NetPlay.players[i].faction;
 		vector["colour"] = NetPlay.players[i].colour;

--- a/src/wzscriptdebug.cpp
+++ b/src/wzscriptdebug.cpp
@@ -302,7 +302,7 @@ static nlohmann::ordered_json fillPlayerModel(int i)
 	nlohmann::ordered_json result = nlohmann::ordered_json::object();
 	result["playerStats score"] = getMultiPlayRecentScore(i);
 	result["playerStats kills"] = getMultiPlayUnitsKilled(i);
-	result["NetPlay.players.name"] = NetPlay.players[i].name;
+	result["NetPlay.players.name"] = getPlayerName(i, true);;
 	result["NetPlay.players.position"] = NetPlay.players[i].position;
 	result["NetPlay.players.colour"] = NetPlay.players[i].colour;
 	result["NetPlay.players.allocated"] = NetPlay.players[i].allocated;


### PR DESCRIPTION
This PRs enables "blind" lobbies / games.

### What is a "blind" lobby / game?

In a blind lobby: Players' true identities are hidden from everyone (except the host) - **until the game _starts_**
In a blind game: Players' true identities are hidden from everyone (except the host) - **until the game _ends_**

The host (currently, a spectator host) has the ability to see players' chosen player names / identities, and configure all of the game settings as expected (position, teams, etc).

You might want to also consider other configuration options, like blocking free chat, if you want to prevent players in the lobby from purposefully revealing their identities to each other.

### What is the new "simple lobby" waiting room for blind lobbies / games?

A blind lobby / game can optionally be configured with an even simpler waiting room, which does not reveal the list of players, but simply:

- Basic information on the host
- The ability to check ready
- Basic status information on the lobby (number of ready players, whether waiting on the host to start the game, etc)

<img width="665" alt="blind_waiting_room" src="https://github.com/user-attachments/assets/0b8d183d-20ae-4756-90ed-8ac075ad09b5" />

### Implementation Details

When connecting to a game configured in any of the blind modes, each client will generate a unique new "blind identity" which is exchanged and used for communication with other clients. The host will receive the "true" player name / identity on join, which it can verify as appropriate, but will only share the "blind identity" and generic player names / details with all other clients.

Once the game begins (in "blind lobby" mode) or the game ends (in "blind game") mode, the host shares the host-verified "true" player names / identities with all other connected players. These are then "fixed-up" in the replay files so that replays play back with the true player names / identities revealed.