### PR TITLE
Fix: Crash on exit if TCP_DIRECT connection provider is not registered

### DIFF
--- a/lib/netplay/connection_provider_registry.cpp
+++ b/lib/netplay/connection_provider_registry.cpp
@@ -53,5 +53,14 @@ void ConnectionProviderRegistry::Register(ConnectionProviderType pt)
 
 void ConnectionProviderRegistry::Deregister(ConnectionProviderType pt)
 {
-	registeredProviders_.erase(pt);
+	const auto it = registeredProviders_.find(pt);
+	if (it == registeredProviders_.end())
+	{
+		return;
+	}
+	if (it->second)
+	{
+		it->second->shutdown();
+	}
+	registeredProviders_.erase(it);
 }

--- a/lib/netplay/netplay.cpp
+++ b/lib/netplay/netplay.cpp
@@ -1606,7 +1606,6 @@ int NETshutdown()
 	}
 	NetPlay.MOTD = nullptr;
 	NETdeleteQueue();
-	ConnectionProviderRegistry::Instance().Get(ConnectionProviderType::TCP_DIRECT).shutdown();
 	ConnectionProviderRegistry::Instance().Deregister(ConnectionProviderType::TCP_DIRECT);
 
 	// Reset net usage statistics.


### PR DESCRIPTION
Make ConnectionProviderRegistry::Deregister handle calling WzConnectionProvider::shutdown()

Fixes issue introduced by #4105