### PR TITLE
netplay: introduce `ICompressionAdapter` facility for dealing with compression

### DIFF
--- a/lib/netplay/compression_adapter.h
+++ b/lib/netplay/compression_adapter.h
@@ -1,0 +1,140 @@
+/*
+	This file is part of Warzone 2100.
+	Copyright (C) 2025  Warzone 2100 Project
+
+	Warzone 2100 is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+
+	Warzone 2100 is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with Warzone 2100; if not, write to the Free Software
+	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+
+#pragma once
+
+#include "net_result.h"
+
+#include <stddef.h>
+#include <stdint.h>
+#include <vector>
+
+/// <summary>
+/// Generic facade for integration of various compression algorithms into WZ's
+/// networking code.
+///
+/// Provides very basic facilities to initialize compression/decompression streams
+/// and perform compression/decompression tasks.
+/// </summary>
+class ICompressionAdapter
+{
+public:
+
+	virtual ~ICompressionAdapter() = default;
+
+	/// <summary>
+	/// The first thing that should be called on an `ICompressionAdapter` instance
+	/// before doing anything else with it.
+	///
+	/// Initializes states of internal buffers, streams, etc.
+	/// </summary>
+	/// <returns>
+	/// In case of failure, returns an error code describing the error.
+	/// </returns>
+	virtual net::result<void> initialize() = 0;
+
+	/// <summary>
+	/// Executes the compression routine against `src` buffer of a given size.
+	/// The result (compressed buffer) can be later accessed via `compressionOutBuffer()` function.
+	///
+	/// This function should be used to incrementally compress incoming data.
+	///
+	/// Note, that it won't necessarily flush all the data to the output buffer,
+	/// so one would then need to call `flushCompressionStream()` to flush all
+	/// internal streams to the output buffer.
+	/// </summary>
+	/// <param name="src">Source buffer containing uncompressed data</param>
+	/// <param name="size">Size of the source buffer in bytes</param>
+	/// <returns>
+	/// In case of failure, returns an error code describing the error.
+	/// </returns>
+	virtual net::result<void> compress(const void* src, size_t size) = 0;
+	/// <summary>
+	/// Flushes the internal compression stream to the output buffer.
+	/// The resulting data can be accessed via `compressionOutBuffer()`
+	/// accessor function.
+	/// </summary>
+	/// <returns>
+	/// In case of failure, returns an error code describing the error.
+	/// </returns>
+	virtual net::result<void> flushCompressionStream() = 0;
+	/// <summary>
+	/// Accessor function (non-const) for compression output buffer (this will be the
+	/// implicit destination to `compress()` and `flushCompressionStream()` functions.
+	/// </summary>
+	virtual std::vector<uint8_t>& compressionOutBuffer() = 0;
+	/// <summary>
+	/// Accessor function (const) for compression output buffer (this will be the
+	/// implicit destination to `compress()` and `flushCompressionStream()` functions.
+	/// </summary>
+	virtual const std::vector<uint8_t>& compressionOutBuffer() const = 0;
+
+	/// <summary>
+	/// Decompress the data from the compressed buffer into `dst` output buffer
+	/// of a given size.
+	///
+	/// The caller is responsible for ensuring that `dst` is long enough to
+	/// hold the decompression result of `size` length in bytes.
+	///
+	/// One would also need to call `resetDecompressionStreamInput()` function
+	/// first to specify the input buffer (containing compressed data) before
+	/// calling this function.
+	///
+	/// </summary>
+	/// <param name="dst">Destination buffer, where the decompressed data will go</param>
+	/// <param name="size">Size of the destination buffer</param>
+	/// <returns>
+	/// In case of failure, returns an error code describing the error.
+	/// </returns>
+	virtual net::result<void> decompress(void* dst, size_t size) = 0;
+	/// <summary>
+	/// Accessor function (non-const) for decompression input buffer (this will be
+	/// the implicit source for `decompress()` function).
+	/// </summary>
+	virtual std::vector<uint8_t>& decompressionInBuffer() = 0;
+	/// <summary>
+	/// Accessor function (const) for decompression input buffer (this will be
+	/// the implicit source for `decompress()` function).
+	/// </summary>
+	virtual const std::vector<uint8_t>& decompressionInBuffer() const = 0;
+	/// <summary>
+	/// Remaining free space (in bytes) at the decompression output buffer.
+	/// </summary>
+	virtual size_t availableSpaceToDecompress() const = 0;
+	/// <summary>
+	/// Returns `true` if the internal decompression stream doesn't have any more
+	/// available bytes in the input buffer (all input was consumed by a prior
+	/// `decompress()` function call).
+	/// </summary>
+	virtual bool decompressionStreamConsumedAllInput() const = 0;
+	/// <summary>
+	/// Returns `true` if the decompression algorithm needs to process more input (i.e.
+	/// there's more data available to process).
+	/// </summary>
+	virtual bool decompressionNeedInput() const = 0;
+	/// <summary>
+	/// Update the decompression algorithm on whether it needs more input or not.
+	/// </summary>
+	virtual void setDecompressionNeedInput(bool needInput) = 0;
+	/// <summary>
+	/// Updates the available input bytes count at the decompression input stream.
+	/// </summary>
+	/// <param name="size">New size for the decompression input stream</param>
+	virtual void resetDecompressionStreamInputSize(size_t size) = 0;
+};

--- a/lib/netplay/zlib_compression_adapter.cpp
+++ b/lib/netplay/zlib_compression_adapter.cpp
@@ -1,0 +1,192 @@
+/*
+	This file is part of Warzone 2100.
+	Copyright (C) 2025  Warzone 2100 Project
+
+	Warzone 2100 is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+
+	Warzone 2100 is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with Warzone 2100; if not, write to the Free Software
+	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+
+#include "zlib_compression_adapter.h"
+#include "error_categories.h"
+
+#include "lib/framework/frame.h" // for `ASSERT`
+
+#include <cstring>
+
+ZlibCompressionAdapter::ZlibCompressionAdapter()
+{
+	std::memset(&deflateStream_, 0, sizeof(deflateStream_));
+	std::memset(&inflateStream_, 0, sizeof(inflateStream_));
+}
+
+ZlibCompressionAdapter::~ZlibCompressionAdapter()
+{
+	deflateEnd(&deflateStream_);
+	deflateEnd(&inflateStream_);
+}
+
+net::result<void> ZlibCompressionAdapter::initialize()
+{
+	// Init deflate stream
+	deflateStream_.zalloc = Z_NULL;
+	deflateStream_.zfree = Z_NULL;
+	deflateStream_.opaque = Z_NULL;
+	int ret = deflateInit(&deflateStream_, 6);
+	ASSERT(ret == Z_OK, "deflateInit failed! Sockets won't work.");
+	if (ret != Z_OK)
+	{
+		return tl::make_unexpected(make_zlib_error_code(ret));
+	}
+
+	// Init inflate stream
+	inflateStream_.zalloc = Z_NULL;
+	inflateStream_.zfree = Z_NULL;
+	inflateStream_.opaque = Z_NULL;
+	inflateStream_.avail_in = 0;
+	inflateStream_.next_in = Z_NULL;
+	ret = inflateInit(&inflateStream_);
+	ASSERT(ret == Z_OK, "deflateInit failed! Sockets won't work.");
+	if (ret != Z_OK)
+	{
+		return tl::make_unexpected(make_zlib_error_code(ret));
+	}
+
+	inflateNeedInput_ = true;
+
+	return {};
+}
+
+void ZlibCompressionAdapter::resetCompressionStreamInput(const void* src, size_t size)
+{
+#if ZLIB_VERNUM < 0x1252
+	// zlib < 1.2.5.2 does not support `#define ZLIB_CONST`
+	// Unfortunately, some OSes (ex. OpenBSD) ship with zlib < 1.2.5.2
+	// Workaround: cast away the const of the input, and disable the resulting -Wcast-qual warning
+#if defined(__clang__)
+#  pragma clang diagnostic push
+#  pragma clang diagnostic ignored "-Wcast-qual"
+#elif defined(__GNUC__)
+#  pragma GCC diagnostic push
+#  pragma GCC diagnostic ignored "-Wcast-qual"
+#endif
+
+	// cast away the const for earlier zlib versions
+	deflateStream_.next_in = (Bytef*)src; // -Wcast-qual
+
+#if defined(__clang__)
+#  pragma clang diagnostic pop
+#elif defined(__GNUC__)
+#  pragma GCC diagnostic pop
+#endif
+#else
+	// zlib >= 1.2.5.2 supports ZLIB_CONST
+	deflateStream_.next_in = (const Bytef*)src;
+#endif
+
+	deflateStream_.avail_in = size;
+}
+
+net::result<void> ZlibCompressionAdapter::compress(const void* src, size_t size)
+{
+	resetCompressionStreamInput(src, size);
+	do
+	{
+		const size_t alreadyHave = deflateOutBuf_.size();
+		deflateOutBuf_.resize(alreadyHave + size + 20);  // A bit more than size should be enough to always do everything in one go.
+		deflateStream_.next_out = (Bytef*)&deflateOutBuf_[alreadyHave];
+		deflateStream_.avail_out = deflateOutBuf_.size() - alreadyHave;
+
+		int ret = deflate(&deflateStream_, Z_NO_FLUSH);
+		ASSERT(ret != Z_STREAM_ERROR, "zlib compression failed!");
+
+		// Remove unused part of buffer.
+		deflateOutBuf_.resize(deflateOutBuf_.size() - deflateStream_.avail_out);
+	} while (deflateStream_.avail_out == 0);
+
+	ASSERT(deflateStream_.avail_in == 0, "zlib didn't compress everything!");
+
+	return {};
+}
+
+net::result<void> ZlibCompressionAdapter::flushCompressionStream()
+{
+	// Flush data out of zlib compression state.
+	do
+	{
+		deflateStream_.next_in = (Bytef*)nullptr;
+		deflateStream_.avail_in = 0;
+		const size_t alreadyHave = deflateOutBuf_.size();
+		deflateOutBuf_.resize(alreadyHave + 1000);  // 100 bytes would probably be enough to flush the rest in one go.
+		deflateStream_.next_out = (Bytef*)&deflateOutBuf_[alreadyHave];
+		deflateStream_.avail_out = deflateOutBuf_.size() - alreadyHave;
+
+		int ret = deflate(&deflateStream_, Z_PARTIAL_FLUSH);
+		ASSERT(ret != Z_STREAM_ERROR, "zlib compression failed!");
+
+		// Remove unused part of buffer.
+		deflateOutBuf_.resize(deflateOutBuf_.size() - deflateStream_.avail_out);
+	} while (deflateStream_.avail_out == 0);
+
+	return {};
+}
+
+net::result<void> ZlibCompressionAdapter::decompress(void* dst, size_t size)
+{
+	resetDecompressionStreamOutput(dst, size);
+
+	int ret = inflate(&inflateStream_, Z_NO_FLUSH);
+	ASSERT(ret != Z_STREAM_ERROR, "zlib inflate not working!");
+	char const* err = nullptr;
+	switch (ret)
+	{
+	case Z_NEED_DICT:  err = "Z_NEED_DICT";  break;
+	case Z_DATA_ERROR: err = "Z_DATA_ERROR"; break;
+	case Z_MEM_ERROR:  err = "Z_MEM_ERROR";  break;
+	}
+	if (ret == Z_STREAM_ERROR)
+	{
+		if (err)
+		{
+			debug(LOG_ERROR, "Couldn't decompress data from socket. zlib error %s", err);
+		}
+		else
+		{
+			debug(LOG_ERROR, "Couldn't decompress data from socket. Unknown zlib error");
+		}
+		return tl::make_unexpected(make_zlib_error_code(ret));
+	}
+	return {};
+}
+
+size_t ZlibCompressionAdapter::availableSpaceToDecompress() const
+{
+	return inflateStream_.avail_out;
+}
+
+bool ZlibCompressionAdapter::decompressionStreamConsumedAllInput() const
+{
+	return inflateStream_.avail_in == 0;
+}
+
+void ZlibCompressionAdapter::resetDecompressionStreamInputSize(size_t size)
+{
+	inflateStream_.next_in = inflateInBuf_.data();
+	inflateStream_.avail_in = size;
+}
+
+void ZlibCompressionAdapter::resetDecompressionStreamOutput(void* buf, size_t size)
+{
+	inflateStream_.next_out = (Bytef*)buf;
+	inflateStream_.avail_out = size;
+}

--- a/lib/netplay/zlib_compression_adapter.h
+++ b/lib/netplay/zlib_compression_adapter.h
@@ -1,0 +1,90 @@
+/*
+	This file is part of Warzone 2100.
+	Copyright (C) 2025  Warzone 2100 Project
+
+	Warzone 2100 is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+
+	Warzone 2100 is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with Warzone 2100; if not, write to the Free Software
+	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+
+#pragma once
+
+#include "compression_adapter.h"
+
+#if !defined(ZLIB_CONST)
+#  define ZLIB_CONST
+#endif
+#include <zlib.h>
+
+/// <summary>
+/// Implementation of `ICompressionAdapter` interface, which uses the
+/// Zlib library to compress/decompress the data.
+/// </summary>
+class ZlibCompressionAdapter : public ICompressionAdapter
+{
+public:
+
+	explicit ZlibCompressionAdapter();
+	virtual ~ZlibCompressionAdapter() override;
+
+	virtual net::result<void> initialize() override;
+
+	virtual net::result<void> compress(const void* src, size_t size) override;
+	virtual net::result<void> flushCompressionStream() override;
+
+	virtual std::vector<uint8_t>& compressionOutBuffer() override
+	{
+		return deflateOutBuf_;
+	}
+
+	virtual const std::vector<uint8_t>& compressionOutBuffer() const override
+	{
+		return deflateOutBuf_;
+	}
+
+	virtual net::result<void> decompress(void* dst, size_t size) override;
+
+	virtual std::vector<uint8_t>& decompressionInBuffer() override
+	{
+		return inflateInBuf_;
+	}
+
+	virtual const std::vector<uint8_t>& decompressionInBuffer() const override
+	{
+		return inflateInBuf_;
+	}
+
+	virtual size_t availableSpaceToDecompress() const override;
+	virtual bool decompressionStreamConsumedAllInput() const override;
+	virtual bool decompressionNeedInput() const override
+	{
+		return inflateNeedInput_;
+	}
+	virtual void setDecompressionNeedInput(bool needInput) override
+	{
+		inflateNeedInput_ = needInput;
+	}
+
+	virtual void resetDecompressionStreamInputSize(size_t size) override;
+
+private:
+
+	void resetCompressionStreamInput(const void* src, size_t size);
+	void resetDecompressionStreamOutput(void* dst, size_t size);
+
+	std::vector<uint8_t> deflateOutBuf_;
+	std::vector<uint8_t> inflateInBuf_;
+	z_stream deflateStream_;
+	z_stream inflateStream_;
+	bool inflateNeedInput_ = false;
+};


### PR DESCRIPTION
The patch provides:
* Base `ICompressionAdapter` interface for compression utilities to be used in the networking code
* `ZlibCompressionAdapter` implementation, which handles the existing zlib compression logic.

`tcp::Socket` now uses `ZlibCompressionAdapter` directly, which would later be helpful in isolating and extracting more low-level stuff (`readNoInt`, `writeAll`, `flush`) into a higher level of abstraction (`IClientConnection` and pending writes manager).