### PR TITLE
netplay/tcp: generalize `checkSockets()` function to be usable with various polling APIs

### DIFF
--- a/lib/netplay/connection_poll_group.h
+++ b/lib/netplay/connection_poll_group.h
@@ -38,7 +38,7 @@ public:
 	/// <returns>On success, returns the number of connection descriptors in the poll group.
 	/// On failure, `0` can returned if the timeout expired before any connection descriptors
 	/// became ready, or `-1` if there was an error during the internal poll operation.</returns>
-	virtual int checkSockets(unsigned timeout) = 0;
+	virtual int checkSocketsReadable(unsigned timeout) = 0;
 
 	virtual void add(IClientConnection* conn) = 0;
 	virtual void remove(IClientConnection* conn) = 0;

--- a/lib/netplay/netplay.cpp
+++ b/lib/netplay/netplay.cpp
@@ -2881,7 +2881,7 @@ bool NETrecvNet(NETQUEUE *queue, uint8_t *type)
 	}
 
 	IConnectionPollGroup* pollGroup = NetPlay.isHost ? server_socket_set : client_socket_set;
-	if (pollGroup == nullptr || pollGroup->checkSockets(NET_READ_TIMEOUT) <= 0)
+	if (pollGroup == nullptr || pollGroup->checkSocketsReadable(NET_READ_TIMEOUT) <= 0)
 	{
 		goto checkMessages;
 	}
@@ -3656,7 +3656,7 @@ void LobbyServerConnectionHandler::run()
 			bool exceededTimeout = (realTime - lastConnectionTime >= 10000);
 			// We use readLobbyResponse to display error messages and handle state changes if there's no response
 			// So if exceededTimeout, just call it with a low timeout
-			int checkSocketRet = waitingForConnectionFinalize->checkSockets(NET_READ_TIMEOUT);
+			int checkSocketRet = waitingForConnectionFinalize->checkSocketsReadable(NET_READ_TIMEOUT);
 			if (checkSocketRet == SOCKET_ERROR)
 			{
 				debug(LOG_ERROR, "Lost connection to lobby server");
@@ -3923,7 +3923,7 @@ static void NETallowJoining()
 	}
 
 	ASSERT(tmp_socket_set != nullptr, "Null tmp_socket_set");
-	if (tmp_socket_set->checkSockets(NET_READ_TIMEOUT) > 0)
+	if (tmp_socket_set->checkSocketsReadable(NET_READ_TIMEOUT) > 0)
 	{
 		for (i = 0; i < MAX_TMP_SOCKETS; ++i)
 		{

--- a/lib/netplay/tcp/descriptor_set.h
+++ b/lib/netplay/tcp/descriptor_set.h
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+/*
+	This file is part of Warzone 2100.
+	Copyright (C) 2025  Warzone 2100 Project
+
+	Warzone 2100 is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+
+	Warzone 2100 is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with Warzone 2100; if not, write to the Free Software
+	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+
+#pragma once
+
+#include "lib/framework/wzglobal.h"
+#include "lib/netplay/net_result.h"
+
+#ifdef WZ_OS_WIN
+# include <winsock2.h>
+#elif defined(WZ_OS_UNIX)
+using SOCKET = int;
+#endif
+
+#include <chrono>
+
+namespace tcp
+{
+
+enum class PollEventType
+{
+	READABLE,
+	WRITABLE
+};
+
+/// <summary>
+/// Abstract class for describing polling descriptor sets used by various polling APIs (e.g. `select()` and `poll()`).
+/// </summary>
+class IDescriptorSet
+{
+public:
+
+	virtual ~IDescriptorSet() = default;
+
+	virtual bool add(SOCKET fd) = 0;
+	virtual void clear() = 0;
+
+	/// <summary>
+	/// Polling algorithm implementation for this descriptor set kind.
+	/// Should represent the same semantics as `select()` or `poll()` APIs, i.e. after calling `pollImpl()` one
+	/// should check individual descriptors via `isSet()` to see, which of them were marked as ready.
+	/// </summary>
+	/// <param name="timeout">Timeout value in milliseconds</param>
+	/// <returns>
+	/// * Non-negative integer indicating the number of descriptors that have a return event set
+	/// by an internal polling function.
+	/// * Zero if none of the descriptors have been set (polling function timed out).
+	/// * `std::error_code` containing error condition otherwise.
+	/// </returns>
+	virtual net::result<int> poll(std::chrono::milliseconds timeout) = 0;
+
+	virtual bool isSet(SOCKET fd) const = 0;
+};
+
+} // namespace tcp

--- a/lib/netplay/tcp/netsocket.cpp
+++ b/lib/netplay/tcp/netsocket.cpp
@@ -348,7 +348,7 @@ static net::result<void> connectionStatus(Socket *sock)
 	                 sock && sock->fd[SOCK_CONNECTION] != INVALID_SOCKET, "Invalid socket");
 
 	// Check whether the socket is still connected
-	int ret = checkSockets(set, 0);
+	int ret = checkSocketsReadable(set, 0);
 	if (ret == SOCKET_ERROR)
 	{
 		return tl::make_unexpected(make_network_error_code(getSockErr()));
@@ -854,7 +854,7 @@ static void socketBlockSIGPIPE(const SOCKET fd, bool block_sigpipe)
 #endif
 }
 
-int checkSockets(const SocketSet& set, unsigned int timeout)
+int checkSocketsReadable(const SocketSet& set, unsigned int timeout)
 {
 	if (set.fds.empty())
 	{
@@ -961,7 +961,7 @@ net::result<ssize_t> readAll(Socket& sock, void *buf, size_t size, unsigned int 
 		// If a timeout is set, wait for that amount of time for data to arrive (or abort)
 		if (timeout)
 		{
-			ret = checkSockets(set, timeout);
+			ret = checkSocketsReadable(set, timeout);
 			if (ret < (ssize_t)set.fds.size()
 			    || !sock.ready)
 			{

--- a/lib/netplay/tcp/netsocket.h
+++ b/lib/netplay/tcp/netsocket.h
@@ -136,7 +136,7 @@ WZ_DECL_NONNULL(1) void deleteSocketSet(SocketSet *set);                ///< Des
 
 WZ_DECL_NONNULL(2) void SocketSet_AddSocket(SocketSet& set, Socket *socket);  ///< Adds a Socket to a SocketSet.
 WZ_DECL_NONNULL(2) void SocketSet_DelSocket(SocketSet& set, Socket *socket);  ///< Removes a Socket from a SocketSet.
-int checkSockets(const SocketSet& set, unsigned int timeout); ///< Checks which Sockets are ready for reading. Returns the number of ready Sockets, or returns SOCKET_ERROR on error.
+int checkSocketsReadable(const SocketSet& set, unsigned int timeout); ///< Checks which Sockets are ready for reading. Returns the number of ready Sockets, or returns SOCKET_ERROR on error.
 
 } // namespace tcp
 

--- a/lib/netplay/tcp/netsocket.h
+++ b/lib/netplay/tcp/netsocket.h
@@ -48,22 +48,6 @@ static const SOCKET INVALID_SOCKET = -1;
 #ifdef WZ_OS_WIN
 # include <winsock2.h>
 # include <ws2tcpip.h>
-# undef EAGAIN
-# undef EBADF
-# undef ECONNRESET
-# undef EINPROGRESS
-# undef EINTR
-# undef EISCONN
-# undef ETIMEDOUT
-# undef EWOULDBLOCK
-# define EAGAIN      WSAEWOULDBLOCK
-# define EBADF       WSAEBADF
-# define ECONNRESET  WSAECONNRESET
-# define EINPROGRESS WSAEINPROGRESS
-# define EINTR       WSAEINTR
-# define EISCONN     WSAEISCONN
-# define ETIMEDOUT   WSAETIMEDOUT
-# define EWOULDBLOCK WSAEWOULDBLOCK
 # ifndef AI_V4MAPPED
 #  define AI_V4MAPPED	0x0008	/* IPv4 mapped addresses are acceptable.  */
 # endif
@@ -71,6 +55,8 @@ static const SOCKET INVALID_SOCKET = -1;
 #  define AI_ADDRCONFIG	0x0020	/* Use configuration of this host to choose returned address type..  */
 # endif
 #endif
+
+#include "lib/netplay/tcp/sock_error.h"
 
 // Fallback for systems that don't #define this flag
 #ifndef MSG_NOSIGNAL

--- a/lib/netplay/tcp/poll_descriptor_set.h
+++ b/lib/netplay/tcp/poll_descriptor_set.h
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+/*
+	This file is part of Warzone 2100.
+	Copyright (C) 2025  Warzone 2100 Project
+
+	Warzone 2100 is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+
+	Warzone 2100 is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with Warzone 2100; if not, write to the Free Software
+	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+
+#pragma once
+
+#include "descriptor_set.h"
+
+#include "lib/netplay/nettypes.h" // for MAX_CONNECTED_PLAYERS, MAX_TMP_SOCKETS
+
+#ifdef WZ_OS_WIN
+# include <winsock2.h>
+#elif defined(WZ_OS_UNIX)
+# include <poll.h> // for pollfd, poll
+#endif
+
+#include "lib/netplay/error_categories.h"
+#include "lib/netplay/tcp/sock_error.h"
+
+#include <array>
+#include <stdexcept>
+#include <algorithm>
+
+namespace tcp
+{
+
+/// <summary>
+/// Descriptor set interface specialization using the `poll()` API for actual polling.
+/// </summary>
+/// <typeparam name="EventType">Type of updates (readable/writable sockets) to poll for.</typeparam>
+template <PollEventType EventType>
+class PollDescriptorSet : public IDescriptorSet
+{
+public:
+
+	explicit PollDescriptorSet() = default;
+
+	virtual bool add(SOCKET fd) override
+	{
+		constexpr short evt = EventType == PollEventType::READABLE ? POLLIN : POLLOUT;
+
+		assert(size_ < MAX_FDS_COUNT);
+		if (size_ >= MAX_FDS_COUNT)
+		{
+			return false;
+		}
+		fds_[size_++] = { fd, evt, 0 };
+		return true;
+	}
+
+	virtual void clear() override
+	{
+		fds_.fill({});
+		size_ = 0;
+	}
+
+	virtual net::result<int> poll(std::chrono::milliseconds timeout) override
+	{
+		int ret;
+		do
+		{
+			ret = pollImpl(timeout);
+		} while (ret == SOCKET_ERROR && (getSockErr() == EINTR || getSockErr() == EAGAIN));
+
+		if (ret == SOCKET_ERROR)
+		{
+			return tl::make_unexpected(make_network_error_code(getSockErr()));
+		}
+
+		return ret;
+	}
+
+	virtual bool isSet(SOCKET fd) const override
+	{
+		constexpr short evt = EventType == PollEventType::READABLE ? POLLIN : POLLOUT;
+
+		const auto it = std::find_if(fds_.begin(), fds_.end(), [fd](const pollfd& pfd) { return pfd.fd == fd; });
+		return it != fds_.end() && (it->revents & evt);
+	}
+
+private:
+
+	int pollImpl(std::chrono::milliseconds timeout)
+	{
+#ifdef WZ_OS_WIN
+		return WSAPoll(fds_.data(), size_, timeout.count());
+#else
+		return ::poll(fds_.data(), size_, timeout.count());
+#endif
+	}
+
+	// The size limit directly corresponds to the theoretical limit on
+	// the number of connections (from the host side) opened at the same time, which is:
+	// `MAX_CONNECTED_PLAYERS` for `connected_bsocket` (in netplay.cpp)
+	// `MAX_TMP_SOCKETS` for `tmp_socket_set` (netplay.cpp)
+	// another 1 for the `rs_socket` (also in netplay.cpp)
+	static constexpr size_t MAX_FDS_COUNT = MAX_CONNECTED_PLAYERS + MAX_TMP_SOCKETS + 1;
+
+	std::array<pollfd, MAX_FDS_COUNT> fds_;
+	size_t size_ = 0;
+};
+
+} // namespace tcp

--- a/lib/netplay/tcp/select_descriptor_set.h
+++ b/lib/netplay/tcp/select_descriptor_set.h
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+/*
+	This file is part of Warzone 2100.
+	Copyright (C) 2025  Warzone 2100 Project
+
+	Warzone 2100 is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+
+	Warzone 2100 is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with Warzone 2100; if not, write to the Free Software
+	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+
+#pragma once
+
+#include "descriptor_set.h"
+
+#ifdef WZ_OS_WIN
+# include <winsock2.h>
+#elif defined(WZ_OS_UNIX)
+# include <sys/select.h> // for fd_set
+#endif
+
+#include "lib/netplay/error_categories.h"
+#include "lib/netplay/tcp/sock_error.h"
+
+#include <algorithm>
+
+namespace tcp
+{
+
+/// <summary>
+/// Descriptor set interface specialization using the `select()` API for actual polling.
+/// </summary>
+/// <typeparam name="EventType">Type of updates (readable/writable sockets) to poll for.</typeparam>
+template <PollEventType EventType>
+class SelectDescriptorSet : public IDescriptorSet
+{
+public:
+
+	explicit SelectDescriptorSet()
+	{
+		FD_ZERO(&fds_);
+	}
+
+	virtual bool add(SOCKET fd) override
+	{
+		FD_SET(fd, &fds_);
+		maxfd_ = std::max(maxfd_, fd);
+		return true;
+	}
+
+	virtual void clear() override
+	{
+		FD_ZERO(&fds_);
+		maxfd_ = 0;
+	}
+
+	virtual net::result<int> poll(std::chrono::milliseconds timeout) override
+	{
+		int ret;
+		do
+		{
+			ret = pollImpl(timeout);
+		} while (ret == SOCKET_ERROR && (getSockErr() == EINTR || getSockErr() == EAGAIN));
+
+		if (ret == SOCKET_ERROR)
+		{
+			return tl::make_unexpected(make_network_error_code(getSockErr()));
+		}
+
+		return ret;
+	}
+
+	virtual bool isSet(SOCKET fd) const override
+	{
+		// Force conversion to `fd_set*` since `FD_ISSET` expects a pointer to non-const `fd_set`.
+		return FD_ISSET(fd, const_cast<fd_set*>(&fds_));
+	}
+
+private:
+
+	int pollImpl(std::chrono::milliseconds timeout)
+	{
+		const int msCount = timeout.count();
+		struct timeval tv = { msCount / 1000, (msCount % 1000) * 1000 };
+
+		switch (EventType)
+		{
+		case PollEventType::READABLE:
+			return select(maxfd_ + 1, &fds_, nullptr, nullptr, &tv);
+		case PollEventType::WRITABLE:
+			return select(maxfd_ + 1, nullptr, &fds_, nullptr, &tv);
+		default:
+			return -1;
+		}
+	}
+
+	fd_set fds_;
+	SOCKET maxfd_ = 0;
+};
+
+} // namespace tcp

--- a/lib/netplay/tcp/sock_error.cpp
+++ b/lib/netplay/tcp/sock_error.cpp
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+/*
+	This file is part of Warzone 2100.
+	Copyright (C) 2025  Warzone 2100 Project
+
+	Warzone 2100 is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+
+	Warzone 2100 is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with Warzone 2100; if not, write to the Free Software
+	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+
+#include "sock_error.h"
+
+#ifdef WZ_OS_UNIX
+# include <errno.h>
+#elif defined(WZ_OS_WIN)
+# include <winsock.h> // WSAGetLastError
+#endif
+
+namespace tcp
+{
+
+int getSockErr()
+{
+#ifdef WZ_OS_UNIX
+	return errno;
+#elif defined(WZ_OS_WIN)
+	return WSAGetLastError();
+#endif
+}
+
+} // namespace tcp

--- a/lib/netplay/tcp/sock_error.h
+++ b/lib/netplay/tcp/sock_error.h
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+/*
+	This file is part of Warzone 2100.
+	Copyright (C) 2025  Warzone 2100 Project
+
+	Warzone 2100 is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+
+	Warzone 2100 is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with Warzone 2100; if not, write to the Free Software
+	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+
+#pragma once
+
+#include "lib/framework/wzglobal.h"
+
+#ifdef WZ_OS_WIN
+# include <winerror.h> // WSA* error codes
+# undef EAGAIN
+# undef EBADF
+# undef ECONNRESET
+# undef EINPROGRESS
+# undef EINTR
+# undef EISCONN
+# undef ETIMEDOUT
+# undef EWOULDBLOCK
+# define EAGAIN      WSAEWOULDBLOCK
+# define EBADF       WSAEBADF
+# define ECONNRESET  WSAECONNRESET
+# define EINPROGRESS WSAEINPROGRESS
+# define EINTR       WSAEINTR
+# define EISCONN     WSAEISCONN
+# define ETIMEDOUT   WSAETIMEDOUT
+# define EWOULDBLOCK WSAEWOULDBLOCK
+#endif
+
+namespace tcp
+{
+
+/// <summary>
+/// Cross-platform wrapper around `errno` (for Linux/macOS/*BSD) and `WSAGetLastError()` (for Windows).
+/// </summary>
+/// <returns>Returns the last error for the calling thread.</returns>
+int getSockErr();
+
+} // namespace tcp

--- a/lib/netplay/tcp/tcp_connection_poll_group.cpp
+++ b/lib/netplay/tcp/tcp_connection_poll_group.cpp
@@ -38,9 +38,9 @@ TCPConnectionPollGroup::~TCPConnectionPollGroup()
 	}
 }
 
-int TCPConnectionPollGroup::checkSockets(unsigned timeout)
+int TCPConnectionPollGroup::checkSocketsReadable(unsigned timeout)
 {
-	return tcp::checkSockets(*sset_, timeout);
+	return tcp::checkSocketsReadable(*sset_, timeout);
 }
 
 void TCPConnectionPollGroup::add(IClientConnection* conn)

--- a/lib/netplay/tcp/tcp_connection_poll_group.h
+++ b/lib/netplay/tcp/tcp_connection_poll_group.h
@@ -33,7 +33,7 @@ public:
 	explicit TCPConnectionPollGroup(SocketSet* sset);
 	virtual ~TCPConnectionPollGroup() override;
 
-	virtual int checkSockets(unsigned timeout) override;
+	virtual int checkSocketsReadable(unsigned timeout) override;
 	virtual void add(IClientConnection* conn) override;
 	virtual void remove(IClientConnection* conn) override;
 

--- a/src/screens/joiningscreen.cpp
+++ b/src/screens/joiningscreen.cpp
@@ -1367,7 +1367,7 @@ void WzJoiningGameScreen_HandlerRoot::processJoining()
 	if (currentJoiningState == JoiningState::AwaitingInitialNetcodeHandshakeAck)
 	{
 		// read in data, if we have it
-		if (tmp_joining_socket_set->checkSockets(NET_READ_TIMEOUT) > 0)
+		if (tmp_joining_socket_set->checkSocketsReadable(NET_READ_TIMEOUT) > 0)
 		{
 			if (!client_transient_socket->readReady())
 			{
@@ -1420,7 +1420,7 @@ void WzJoiningGameScreen_HandlerRoot::processJoining()
 	if (currentJoiningState == JoiningState::ProcessingJoinMessages)
 	{
 		// read in data, if we have it
-		if (tmp_joining_socket_set->checkSockets(NET_READ_TIMEOUT) > 0)
+		if (tmp_joining_socket_set->checkSocketsReadable(NET_READ_TIMEOUT) > 0)
 		{
 			if (!client_transient_socket->readReady())
 			{


### PR DESCRIPTION
The patchset introduces the following abstractions to make it easier to switch between various polling APIs in the TCP_DIRECT netcode:

1. `IDescriptorSet` interface to abstract away the details of a particular polling API (`select()` and `poll()` are supported).
2. `PollEventType` enumeration to be used in concrete subclasses of `IDescriptorSet` to describe the type of events we are interested in, when polling a given descriptor set (generally speaking, both `select` and `poll` can listen for multiple types of events simultaneously, but in our particular case we listen for only one of them at a time).
3. `SelectDescriptorSet<PollEventType>` and `PollDescriptorSet<PollEventType>` descriptor set types which actually implement the support for `select` and `poll` APIs.
4. `checkSocketsReadable()` function now makes direct use of `SelectDescriptorSet`(Windows, note on support below) and `PollDescriptorSet`(Linux/macOS/*BSD).

NOTE: We don't use `poll()`(`WSAPoll()`, to be accurate) on Windows for the time being, since it's affected by a bug in Windows versions prior to Windows 10 version 2004 (and there wasn't any prior analysis on how many potential players will be affected):

`WSAPoll()` function can time out on socket connection errors instead of returning an error early.

For more information on the bug, see: https://stackoverflow.com/questions/21653003/is-this-wsapoll-bug-for-non-blocking-sockets-fixed
and also https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-wsapoll#remarks

Signed-off-by: Pavel Solodovnikov <pavel.al.solodovnikov@gmail.com>