### PR TITLE
(MP)Make plasma cannon emplacement cost not less than plasma cannon itself

### DIFF
--- a/data/mp/stats/structure.json
+++ b/data/mp/stats/structure.json
@@ -1587,7 +1587,7 @@
 		"armour": 10,
 		"breadth": 1,
 		"buildPoints": 400,
-		"buildPower": 200,
+		"buildPower": 450,
 		"height": 1,
 		"hitpoints": 400,
 		"id": "Emplacement-PlasmaCannon",


### PR DESCRIPTION
Currently (and imho unfortunately) plasma cannon emplacement is being abused as early "glass fortress" since at the time of opening it can be quiet difficult to outrange and break down, especially if it is buried under layer of something more sturdy.

Cost of plasma cannon (turret) is 400
Cost of plasma cannon emplacement (structure) is 200 (*WHY?*)

Requested change:
Plasma cannon emplacement build cost: 200 -> 450

Some context:
| Name | Open time | Build time | Cost | Range | DPS |
| --- | --- | --- | --- | --- | --- |
| Cannon fortress | 20:11 | 2t: 01:23 4t: 00:41 | 1000 | 11 | `1045*14.29=14933.05` |
| **Plasma cannon emplacement** | 20:12 | 2t: 00:16 4t: 00:08 | **200** | 10 | `1375*5.71=7851.25` |
| Rocket fortress | 25:11 | 2t: 01:06 4t: 00:33 | 1250 | 16 | `910*32=29120` |

*Note that effective DPS of plasma cannon emplacement is `7851.25*2=15702.5` or greater because splash of 2.5 tiles of same thermal type damage*

*Note that in time you build 1 cannon fortress you can build at least 5 plasma cannon emplacements*

At the time of research (20:12) availability of outranging per weapon looks like this:
- **CANT** Assault gun (MG) (need 10 have 9)
- **CANT** HPV (10/10 so you shoot - you die, does not count)
- **CANT** Lancer (10/9)
- **CANT** Tank-killer (10/10)
- **CANT** Bunker buster (10/10)
- **CANT** HRA (10/10)

Further down the tech tree there are weapons that are capable of dealing with the "plasma cheese" but they require additional research time, production time and rally time: (**about whole 3-5 minutes later**)
- **BARELY** at 23:21 Needle (need 10 have 11)
- **OK** at 23:44 Scourge (10/14)
- **OK** at 23:11 Flashlight (10/13)

Before #3952 the cost was still quiet low but not *that* low, 300 to be exact. Also what surprises nobody, since all changes were not clearly conveyed in pull request description literally nobody noticed such 300->200 buff to already very strong defensive structure.

For people with not monotonic and limited mindset, yes, it can be countered by VTOL and/or arty but you would not be able to pull it off in 1x1 scenario normally against same-level opponent. Team play is currently the only solution on noshared and overwhelming majority lacks such talent making plasma cannon emplacement a godsend for building up defences that will hold for a bit until you yourself get needle for example.