### PR TITLE
netplay: extract tcp's `socketThreadFunction` to a higher level entity as `PendingWritesManager`

### DIFF
--- a/lib/netplay/client_connection.cpp
+++ b/lib/netplay/client_connection.cpp
@@ -1,0 +1,195 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+/*
+	This file is part of Warzone 2100.
+	Copyright (C) 2025  Warzone 2100 Project
+
+	Warzone 2100 is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+
+	Warzone 2100 is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with Warzone 2100; if not, write to the Free Software
+	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+
+#include "client_connection.h"
+
+#include "lib/netplay/error_categories.h"
+#include "lib/netplay/pending_writes_manager.h"
+#include "lib/netplay/zlib_compression_adapter.h"
+
+net::result<ssize_t> IClientConnection::readNoInt(void* buf, size_t max_size, size_t* rawByteCount)
+{
+	if (rawByteCount)
+	{
+		*rawByteCount = 0;
+	}
+
+	if (!isValid())
+	{
+		debug(LOG_ERROR, "Invalid socket");
+		return tl::make_unexpected(make_network_error_code(EBADF));
+	}
+
+	if (isCompressed())
+	{
+		if (compressionAdapter_->decompressionNeedInput())
+		{
+			// No input data, read some.
+			auto& decompressInBuf = compressionAdapter_->decompressionInBuffer();
+			decompressInBuf.resize(max_size + 1000);
+
+			const auto recvRes = recvImpl(reinterpret_cast<char*>(decompressInBuf.data()), decompressInBuf.size());
+			if (!recvRes.has_value())
+			{
+				return recvRes;
+			}
+			const auto received = recvRes.value();
+			compressionAdapter_->resetDecompressionStreamInputSize(received);
+			if (rawByteCount)
+			{
+				*rawByteCount = received;
+			}
+			compressionAdapter_->setDecompressionNeedInput(false);
+		}
+
+		const auto decompressRes = compressionAdapter_->decompress(buf, max_size);
+		if (!decompressRes.has_value())
+		{
+			return tl::make_unexpected(decompressRes.error());
+		}
+
+		if (compressionAdapter_->availableSpaceToDecompress() != 0)
+		{
+			compressionAdapter_->setDecompressionNeedInput(true);
+			ASSERT(compressionAdapter_->decompressionStreamConsumedAllInput(), "Compression algorithm impl not consuming all input!");
+		}
+
+		return max_size - compressionAdapter_->availableSpaceToDecompress();  // Got some data, return how much.
+	}
+
+	const auto recvRes = recvImpl(reinterpret_cast<char*>(buf), max_size);
+	if (!recvRes.has_value())
+	{
+		return recvRes;
+	}
+
+	setReadReady(false);
+	const auto received = recvRes.value();
+	if (rawByteCount)
+	{
+		*rawByteCount = received;
+	}
+
+	return received;
+}
+
+net::result<ssize_t> IClientConnection::writeAll(const void* buf, size_t size, size_t* rawByteCount)
+{
+	if (!isValid())
+	{
+		debug(LOG_ERROR, "Invalid socket (EBADF)");
+		return tl::make_unexpected(make_network_error_code(EBADF));
+	}
+
+	if (writeErrorCode().has_value())
+	{
+		return tl::make_unexpected(writeErrorCode().value());
+	}
+
+	if (rawByteCount)
+	{
+		*rawByteCount = 0;
+	}
+
+	if (size == 0)
+	{
+		return 0;
+	}
+
+	if (!isCompressed())
+	{
+		PendingWritesManager::instance().append(this, [buf, size](std::vector<uint8_t>& writeQueue)
+		{
+			writeQueue.insert(writeQueue.end(), static_cast<char const*>(buf), static_cast<char const*>(buf) + size);
+		});
+		if (rawByteCount)
+		{
+			*rawByteCount = size;
+		}
+	}
+	else
+	{
+		compressionAdapter_->compress(buf, size);
+	}
+
+	return size;
+}
+
+void IClientConnection::flush(size_t* rawByteCount)
+{
+	if (rawByteCount)
+	{
+		*rawByteCount = 0;
+	}
+	if (!isCompressed())
+	{
+		return;  // Not compressed, so don't mess with compression.
+	}
+
+	ASSERT(!writeErrorCode().has_value(), "Socket write error encountered in flush");
+
+	compressionAdapter_->flushCompressionStream();
+
+	auto& compressionBuf = compressionAdapter_->compressionOutBuffer();
+	if (compressionBuf.empty())
+	{
+		return;  // No data to flush out.
+	}
+
+	auto& pwm = PendingWritesManager::instance();
+	pwm.append(this, [&compressionBuf] (PendingWritesManager::ConnectionWriteQueue& writeQueue)
+	{
+		writeQueue.reserve(writeQueue.size() + compressionBuf.size());
+		writeQueue.insert(writeQueue.end(), compressionBuf.begin(), compressionBuf.end());
+	});
+	// Data sent, don't send again.
+	if (rawByteCount)
+	{
+		*rawByteCount = compressionBuf.size();
+	}
+	compressionBuf.clear();
+}
+
+void IClientConnection::enableCompression()
+{
+	if (isCompressed_)
+	{
+		return;  // Nothing to do.
+	}
+
+	PendingWritesManager::instance().executeUnderLock([this]
+	{
+		compressionAdapter_ = std::make_unique<ZlibCompressionAdapter>();
+		const auto initRes = compressionAdapter_->initialize();
+		if (!initRes.has_value())
+		{
+			const auto errMsg = initRes.error().message();
+			debug(LOG_NET, "Failed to initialize compression algorithms. Sockets won't work properly! Detailed error message: %s", errMsg.c_str());
+			return;
+		}
+		isCompressed_ = true;
+	});
+}
+
+void IClientConnection::close()
+{
+	PendingWritesManager::instance().safeDispose(this);
+}

--- a/lib/netplay/connection_provider_registry.h
+++ b/lib/netplay/connection_provider_registry.h
@@ -49,6 +49,8 @@ public:
 private:
 
 	ConnectionProviderRegistry() = default;
+	ConnectionProviderRegistry(const ConnectionProviderRegistry&) = delete;
+	ConnectionProviderRegistry(ConnectionProviderRegistry&&) = delete;
 
 	std::unordered_map<ConnectionProviderType, std::unique_ptr<WzConnectionProvider>> registeredProviders_;
 };

--- a/lib/netplay/descriptor_set.cpp
+++ b/lib/netplay/descriptor_set.cpp
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+/*
+	This file is part of Warzone 2100.
+	Copyright (C) 2025  Warzone 2100 Project
+
+	Warzone 2100 is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+
+	Warzone 2100 is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with Warzone 2100; if not, write to the Free Software
+	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+
+#include "lib/framework/wzglobal.h"
+
+#include "descriptor_set.h"
+
+#ifdef WZ_OS_WIN
+# include "lib/netplay/tcp/select_descriptor_set.h"
+#else
+# include "lib/netplay/tcp/poll_descriptor_set.h"
+#endif
+
+std::unique_ptr<IDescriptorSet> IDescriptorSet::create(PollEventType eventType)
+{
+	// For now, use `select()` on Windows instead of `poll()` because of a bug in
+	// Windows versions prior to "Windows 10 2004", which can lead to `poll()`
+	// function timing out on socket connection errors instead of returning an error early.
+	//
+	// For more information on the bug, see: https://stackoverflow.com/questions/21653003/is-this-wsapoll-bug-for-non-blocking-sockets-fixed
+	// and also https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-wsapoll#remarks
+	switch (eventType)
+	{
+	case PollEventType::READABLE:
+	{
+#ifdef WZ_OS_WIN
+		IDescriptorSet* rawPtr = new tcp::SelectDescriptorSet<PollEventType::READABLE>();
+		return std::unique_ptr<IDescriptorSet>(rawPtr);
+#else
+		IDescriptorSet* rawPtr = new tcp::PollDescriptorSet<PollEventType::READABLE>();
+		return std::unique_ptr<IDescriptorSet>(rawPtr);
+#endif
+	}
+	case PollEventType::WRITABLE:
+	{
+#ifdef WZ_OS_WIN
+		IDescriptorSet* rawPtr = new tcp::SelectDescriptorSet<PollEventType::WRITABLE>();
+		return std::unique_ptr<IDescriptorSet>(rawPtr);
+#else
+		IDescriptorSet* rawPtr = new tcp::PollDescriptorSet<PollEventType::WRITABLE>();
+		return std::unique_ptr<IDescriptorSet>(rawPtr);
+#endif
+	}
+	default:
+		ASSERT(false, "Unexpected PollEventType value: %d", static_cast<int>(eventType));
+		return nullptr;
+	}
+}

--- a/lib/netplay/pending_writes_manager.cpp
+++ b/lib/netplay/pending_writes_manager.cpp
@@ -1,0 +1,225 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+/*
+	This file is part of Warzone 2100.
+	Copyright (C) 2025  Warzone 2100 Project
+
+	Warzone 2100 is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+
+	Warzone 2100 is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with Warzone 2100; if not, write to the Free Software
+	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+
+#include "pending_writes_manager.h"
+
+#include "lib/framework/frame.h" // for ASSERT
+#include "lib/netplay/descriptor_set.h"
+#include "lib/netplay/client_connection.h"
+
+#include <system_error>
+
+PendingWritesManager& PendingWritesManager::instance()
+{
+	static PendingWritesManager instance;
+	return instance;
+}
+
+PendingWritesManager::~PendingWritesManager()
+{
+	deinitialize();
+}
+
+void PendingWritesManager::deinitialize()
+{
+	if (thread_ == nullptr)
+	{
+		// No-op in case of a repeated `deinitialize()` call
+		return;
+	}
+	wzMutexLock(mtx_);
+	stopRequested_ = true;
+	pendingWrites_.clear();
+	wzMutexUnlock(mtx_);
+	wzSemaphorePost(sema_);  // Wake up the thread, so it can quit.
+	wzThreadJoin(thread_);
+	wzMutexDestroy(mtx_);
+	wzSemaphoreDestroy(sema_);
+	thread_ = nullptr;
+}
+
+void PendingWritesManager::initialize()
+{
+	if (thread_ != nullptr)
+	{
+		// No-op in case of a repeated `initialize()` call
+		return;
+	}
+	stopRequested_ = false;
+	mtx_ = wzMutexCreate();
+	sema_ = wzSemaphoreCreate(0);
+	thread_ = wzThreadCreate(pendingWritesThreadFunction, reinterpret_cast<void*>(this), "WzPendingWrites");
+	wzThreadStart(thread_);
+}
+
+net::result<int> PendingWritesManager::checkConnectionsWritable(IDescriptorSet& writableSet, std::chrono::milliseconds timeout)
+{
+	if (writableSet.empty())
+	{
+		return 0;
+	}
+
+	wzMutexUnlock(mtx_);
+	const auto pollRes = writableSet.poll(timeout);
+	wzMutexLock(mtx_);
+
+	if (!pollRes.has_value())
+	{
+		const auto msg = pollRes.error().message();
+		debug(LOG_ERROR, "poll failed: %s", msg.c_str());
+		return pollRes;
+	}
+
+	if (pollRes.value() == 0)
+	{
+		debug(LOG_WARNING, "poll timed out after waiting for %u milliseconds", static_cast<unsigned int>(timeout.count()));
+		return 0;
+	}
+
+	return pollRes.value();
+}
+
+void PendingWritesManager::populateWritableSet(IDescriptorSet& writableSet)
+{
+	for (auto it = pendingWrites_.begin(); it != pendingWrites_.end();)
+	{
+		const auto& pendingConnWrite = *it;
+		if (!pendingConnWrite.second.empty())
+		{
+			writableSet.add(pendingConnWrite.first);
+			++it;
+		}
+		else
+		{
+			ASSERT(false, "Empty buffer for pending socket writes"); // This shouldn't happen!
+			IClientConnection* conn = pendingConnWrite.first;
+			it = pendingWrites_.erase(it);
+			if (conn->deleteLaterRequested())
+			{
+				delete conn;
+			}
+		}
+	}
+}
+
+void PendingWritesManager::threadImplFunction()
+{
+	wzMutexLock(mtx_);
+	while (!stopRequested_)
+	{
+		static constexpr std::chrono::milliseconds WRITABLE_CHECK_TIMEOUT{ 50 };
+		static std::unique_ptr<IDescriptorSet> writableSet = IDescriptorSet::create(PollEventType::WRITABLE);
+
+		// Check if we can write to some connections.
+		writableSet->clear();
+		populateWritableSet(*writableSet);
+
+		const auto checkWritableRes = checkConnectionsWritable(*writableSet, WRITABLE_CHECK_TIMEOUT);
+
+		if (checkWritableRes.has_value() && checkWritableRes.value() != 0)
+		{
+			for (auto connIt = pendingWrites_.begin(); connIt != pendingWrites_.end();)
+			{
+				auto currentIt = connIt;
+				++connIt;
+
+				IClientConnection* conn = currentIt->first;
+				ConnectionWriteQueue& writeQueue = currentIt->second;
+				ASSERT(!writeQueue.empty(), "writeQueue[sock] must not be empty.");
+
+				if (!writableSet->isSet(conn) || writeQueue.empty())
+				{
+					continue;  // This connection is not ready for writing, or we don't have anything to write.
+				}
+
+				// Write data.
+				const auto retSent = conn->sendImpl(writeQueue);
+				if (retSent.has_value())
+				{
+					// Erase as much data as written.
+					writeQueue.erase(writeQueue.begin(), writeQueue.begin() + retSent.value());
+					if (writeQueue.empty())
+					{
+						pendingWrites_.erase(currentIt);  // Nothing left to write, delete from pending list.
+						if (conn->deleteLaterRequested())
+						{
+							delete conn;
+						}
+					}
+				}
+				else
+				{
+					if (retSent.error() == std::errc::interrupted)
+					{
+						// Not an actual error, just try to send again later
+						continue;
+					}
+					const auto connStatus = conn->connectionStatus();
+					if (!conn->isValid() || !connStatus.has_value()) // Check if the connection is still open
+					{
+						const auto errMsg = connStatus.error().message();
+						debug(LOG_NET, "Socket error: %s", errMsg.c_str());
+						conn->setWriteErrorCode(connStatus.error());
+						pendingWrites_.erase(currentIt);  // Connection broken, don't try writing to it again.
+						if (conn->deleteLaterRequested())
+						{
+							delete conn;
+						}
+					}
+				}
+			}
+		}
+		if (pendingWrites_.empty())
+		{
+			// Nothing to do, expect to wait.
+			wzMutexUnlock(mtx_);
+			wzSemaphoreWait(sema_);
+			wzMutexLock(mtx_);
+		}
+	}
+	wzMutexUnlock(mtx_);
+}
+
+void PendingWritesManager::safeDispose(IClientConnection* conn)
+{
+	executeUnderLock([this, conn]
+	{
+		// Need a `const_cast` to make the `unordered_map` work with `const` key type.
+		if (pendingWrites_.count(const_cast<IClientConnection*>(conn)) != 0)
+		{
+			// Wait until the data is written, then delete the socket.
+			conn->requestDeleteLater();
+		}
+		else
+		{
+			// Delete the socket and destroy the connection right away.
+			delete conn;
+		}
+	});
+}
+
+int pendingWritesThreadFunction(void* data)
+{
+	PendingWritesManager* inst = reinterpret_cast<PendingWritesManager*>(data);
+	inst->threadImplFunction();
+	// Return value ignored
+	return 0;
+}

--- a/lib/netplay/pending_writes_manager.cpp
+++ b/lib/netplay/pending_writes_manager.cpp
@@ -131,6 +131,7 @@ void PendingWritesManager::threadImplFunction()
 		// Check if we can write to some connections.
 		writableSet->clear();
 		populateWritableSet(*writableSet);
+		ASSERT(!writableSet->empty() || pendingWrites_.empty(), "writableSet must not be empty if there are pending writes.");
 
 		const auto checkWritableRes = checkConnectionsWritable(*writableSet, WRITABLE_CHECK_TIMEOUT);
 

--- a/lib/netplay/pending_writes_manager.h
+++ b/lib/netplay/pending_writes_manager.h
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+/*
+	This file is part of Warzone 2100.
+	Copyright (C) 2025  Warzone 2100 Project
+
+	Warzone 2100 is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+
+	Warzone 2100 is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with Warzone 2100; if not, write to the Free Software
+	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+
+#pragma once
+
+#include <chrono>
+#include <unordered_map>
+#include <vector>
+#include <stdint.h>
+
+#include "lib/framework/wzapp.h"
+#include "lib/netplay/net_result.h"
+
+struct WZ_THREAD;
+struct WZ_MUTEX;
+struct WZ_SEMAPHORE;
+
+class IClientConnection;
+class IDescriptorSet;
+
+/// This is a wrapper function that acts as a proxy to `PendingWritesManager::threadImplFunction`.
+/// Argument is `PendingWritesManager*` cast to `void*`.
+int pendingWritesThreadFunction(void*);
+
+/// <summary>
+/// Singleton manager class, that handles all network write operations.
+///
+/// The main reason for its existence is the fact that we would like
+/// to keep all socket write operations asynchronous, which provide the
+/// following advantages over blocking approach:
+///
+/// 1. Improves responsiveness of the application.
+/// 2. Provides means to batch several outstanding write requests
+///    into a single larger one to save on network bandwidth.
+/// 3. Provides the ability to efficiently compress the write
+///    requests, absolutely transparently for the caller.
+///
+/// This class implements the submission queue running on
+/// a separate thread, which intercepts and batches all write
+/// requests, automatically handles data compression and provides
+/// safe disposal of closed connections (i.e. we want to wait
+/// for the data to be sent before actually terminating a client
+/// connection).
+/// </summary>
+class PendingWritesManager
+{
+public:
+
+	using ConnectionWriteQueue = std::vector<uint8_t>;
+
+	~PendingWritesManager();
+
+	static PendingWritesManager& instance();
+
+	void initialize();
+	void deinitialize();
+
+	template <typename Fn>
+	void executeUnderLock(Fn&& fn)
+	{
+		wzMutexLock(mtx_);
+		fn();
+		wzMutexUnlock(mtx_);
+	}
+
+	template <typename Fn>
+	void executeUnderLock(Fn&& fn) const
+	{
+		wzMutexLock(mtx_);
+		fn();
+		wzMutexUnlock(mtx_);
+	}
+
+	/// <summary>
+	/// Get the submission queue for a given connection and execute a function, which
+	/// may modify the write queue, in a thread-safe manner (while holding the pending writes lock).
+	/// </summary>
+	/// <typeparam name="AppendToWriteQueueFn">Should accept `ConnectionWriteQueue` by reference.</typeparam>
+	/// <param name="conn">Client connection object to search for in the pending writes map.</param>
+	/// <param name="appendFn">The function to execute against the connection's write queue.</param>
+	template <typename AppendToWriteQueueFn>
+	void append(IClientConnection* conn, AppendToWriteQueueFn&& appendFn)
+	{
+		executeUnderLock([this, conn, &appendFn]
+		{
+			if (pendingWrites_.empty())
+			{
+				wzSemaphorePost(sema_);
+			}
+			ConnectionWriteQueue& writeQueue = pendingWrites_[conn];
+			appendFn(writeQueue);
+		});
+	}
+
+	/// <summary>
+	/// Safely (in a thread-safe manner) dispose of a connection, which may have a registered pending write attached:
+	///
+	/// If the connection has a pending write, this method marks it as "needs to be disposed of",
+	/// and it will be cleaned up at the next available opportunity.
+	/// Otherwise, the connection object will be destroyed right away.
+	///
+	/// WARNING: don't use `conn` object after calling this function. It will eventually be destroyed!
+	/// </summary>
+	/// <param name="conn"></param>
+	void safeDispose(IClientConnection* conn);
+
+private:
+
+	using ConnectionThreadWriteMap = std::unordered_map<IClientConnection*, ConnectionWriteQueue>;
+
+	friend int pendingWritesThreadFunction(void*);
+
+	PendingWritesManager() = default;
+	PendingWritesManager(const PendingWritesManager&) = delete;
+	PendingWritesManager(PendingWritesManager&&) = delete;
+
+	void threadImplFunction();
+	net::result<int> checkConnectionsWritable(IDescriptorSet& writableSet, std::chrono::milliseconds timeout);
+	void populateWritableSet(IDescriptorSet& writableSet);
+
+	ConnectionThreadWriteMap pendingWrites_;
+	mutable WZ_MUTEX* mtx_ = nullptr;
+	WZ_SEMAPHORE* sema_ = nullptr;
+	WZ_THREAD* thread_ = nullptr;
+	bool stopRequested_ = false;
+};

--- a/lib/netplay/tcp/netsocket.cpp
+++ b/lib/netplay/tcp/netsocket.cpp
@@ -66,11 +66,6 @@ struct Socket
 	char textAddress[40] = {};
 };
 
-struct SocketSet
-{
-	std::vector<Socket *> fds;
-};
-
 SOCKET getRawSocketFd(const Socket& sock)
 {
 	return sock.fd[SOCK_CONNECTION];
@@ -331,50 +326,6 @@ bool socketSetTCPNoDelay(Socket& sock, bool nodelay)
 	debug(LOG_NET, "Unable to set TCP_NODELAY on socket - unsupported");
 	return false;
 #endif
-}
-
-SocketSet *allocSocketSet()
-{
-	return new SocketSet;
-}
-
-void deleteSocketSet(SocketSet *set)
-{
-	delete set;
-}
-
-/**
- * Add the given socket to the given socket set.
- *
- * @return true if @c socket is successfully added to @set.
- */
-void SocketSet_AddSocket(SocketSet& set, Socket *socket)
-{
-	/* Check whether this socket is already present in this set (i.e. it
-	 * shouldn't be added again).
-	 */
-	size_t i = std::find(set.fds.begin(), set.fds.end(), socket) - set.fds.begin();
-	if (i != set.fds.size())
-	{
-		debug(LOG_NET, "Already found, socket: (set->fds[%lu]) %p", (unsigned long)i, static_cast<void *>(socket));
-		return;
-	}
-
-	set.fds.push_back(socket);
-	debug(LOG_NET, "Socket added: set->fds[%lu] = %p", (unsigned long)i, static_cast<void *>(socket));
-}
-
-/**
- * Remove the given socket from the given socket set.
- */
-void SocketSet_DelSocket(SocketSet& set, Socket *socket)
-{
-	size_t i = std::find(set.fds.begin(), set.fds.end(), socket) - set.fds.begin();
-	if (i != set.fds.size())
-	{
-		debug(LOG_NET, "Socket %p erased (set->fds[%lu])", static_cast<void *>(socket), (unsigned long)i);
-		set.fds.erase(set.fds.begin() + i);
-	}
 }
 
 #if !defined(SOCK_CLOEXEC)

--- a/lib/netplay/tcp/netsocket.h
+++ b/lib/netplay/tcp/netsocket.h
@@ -70,7 +70,6 @@ namespace tcp
 {
 
 struct Socket;
-struct SocketSet;
 
 } // namespace tcp
 
@@ -114,11 +113,6 @@ void socketSetReadReady(Socket& sock, bool ready);
 bool socketSetTCPNoDelay(Socket& sock, bool nodelay); ///< nodelay = true disables the Nagle algorithm for TCP socket
 
 // Socket sets.
-WZ_DECL_ALLOCATION SocketSet *allocSocketSet();                         ///< Constructs a SocketSet.
-WZ_DECL_NONNULL(1) void deleteSocketSet(SocketSet *set);                ///< Destroys the SocketSet.
-
-WZ_DECL_NONNULL(2) void SocketSet_AddSocket(SocketSet& set, Socket *socket);  ///< Adds a Socket to a SocketSet.
-WZ_DECL_NONNULL(2) void SocketSet_DelSocket(SocketSet& set, Socket *socket);  ///< Removes a Socket from a SocketSet.
 int checkSocketsReadable(const std::vector<IClientConnection*>& conns, IDescriptorSet& readableSet, unsigned int timeout); ///< Checks which Sockets are ready for reading. Returns the number of ready Sockets, or returns SOCKET_ERROR on error.
 
 } // namespace tcp

--- a/lib/netplay/tcp/poll_descriptor_set.h
+++ b/lib/netplay/tcp/poll_descriptor_set.h
@@ -74,14 +74,19 @@ public:
 	virtual net::result<int> poll(std::chrono::milliseconds timeout) override
 	{
 		int ret;
+		int sockErr = 0;
 		do
 		{
 			ret = pollImpl(timeout);
-		} while (ret == SOCKET_ERROR && (getSockErr() == EINTR || getSockErr() == EAGAIN));
+			if (ret == SOCKET_ERROR)
+			{
+				sockErr = getSockErr();
+			}
+		} while (ret == SOCKET_ERROR && (sockErr == EINTR || sockErr == EAGAIN));
 
 		if (ret == SOCKET_ERROR)
 		{
-			return tl::make_unexpected(make_network_error_code(getSockErr()));
+			return tl::make_unexpected(make_network_error_code(sockErr));
 		}
 
 		return ret;

--- a/lib/netplay/tcp/tcp_client_connection.cpp
+++ b/lib/netplay/tcp/tcp_client_connection.cpp
@@ -17,67 +17,210 @@
 	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
 */
 
-#include "lib/netplay/tcp/tcp_client_connection.h"
-#include "lib/netplay/tcp/netsocket.h"
 #include "lib/framework/wzapp.h"
 #include "lib/framework/debug.h"
 #include "lib/framework/string_ext.h"
+#include "lib/netplay/error_categories.h"
+#include "lib/netplay/tcp/tcp_client_connection.h"
+#include "lib/netplay/tcp/netsocket.h"
+#include "lib/netplay/tcp/sock_error.h"
 
 namespace tcp
 {
 
+namespace
+{
+
+void resetAuxDescriptorSet(IDescriptorSet& dset, IClientConnection* conn)
+{
+	dset.clear();
+	ASSERT(dset.add(conn), "Failed to add connection to internal descriptor set");
+}
+
+} // anonymous namespace
+
 TCPClientConnection::TCPClientConnection(Socket* rawSocket)
-	: socket_(rawSocket)
+	: socket_(rawSocket),
+	selfConnList_({ this }),
+	readAllDescriptorSet_(IDescriptorSet::create(PollEventType::READABLE)),
+	connStatusDescriptorSet_(IDescriptorSet::create(PollEventType::READABLE))
 {
 	ASSERT(socket_ != nullptr, "Null socket passed to TCPClientConnection ctor");
 }
 
 TCPClientConnection::~TCPClientConnection()
 {
-	if (socket_)
+	if (!socket_)
 	{
-		socketClose(socket_);
+		return;
 	}
+	tcp::socketCloseNow(socket_);
+	socket_ = nullptr;
 }
 
 net::result<ssize_t> TCPClientConnection::readAll(void* buf, size_t size, unsigned timeout)
 {
-	return tcp::readAll(*socket_, buf, size, timeout);
+	ASSERT(!isCompressed(), "readAll on compressed sockets not implemented.");
+
+	Socket& sock = *socket_;
+	SOCKET sockfd = getRawSocketFd();
+	size_t received = 0;
+
+	if (sockfd == INVALID_SOCKET)
+	{
+		debug(LOG_ERROR, "Invalid socket (%p), sock->fd[SOCK_CONNECTION]=%" PRIuPTR"x  (error: EBADF)", static_cast<void*>(&sock), static_cast<uintptr_t>(sockfd));
+		return tl::make_unexpected(make_network_error_code(EBADF));
+	}
+
+	while (received < size)
+	{
+		ssize_t ret = 0;
+		// If a timeout is set, wait for that amount of time for data to arrive (or abort)
+		if (timeout)
+		{
+			resetAuxDescriptorSet(*readAllDescriptorSet_, this);
+			ret = tcp::checkSocketsReadable(selfConnList_, *readAllDescriptorSet_, timeout);
+			if (ret < (ssize_t)selfConnList_.size() || !readReady())
+			{
+				if (ret == 0)
+				{
+					debug(LOG_NET, "socket (%p) has timed out.", static_cast<void*>(&sock));
+					return tl::make_unexpected(make_network_error_code(ETIMEDOUT));
+				}
+				debug(LOG_NET, "socket (%p) error.", static_cast<void*>(&sock));
+				return tl::make_unexpected(make_network_error_code(getSockErr()));
+			}
+		}
+		const auto recvRes = recvImpl(&((char*)buf)[received], size - received);
+		setReadReady(false);
+		if (!recvRes.has_value())
+		{
+			const auto ec = recvRes.error();
+			if (ec == std::errc::resource_unavailable_try_again || // EWOULDBLOCK
+				ec == std::errc::operation_would_block || // EAGAIN
+				ec == std::errc::interrupted) // EINTR
+			{
+				continue;
+			}
+			return recvRes;
+		}
+		received += recvRes.value();
+	}
+
+	return received;
 }
 
-net::result<ssize_t> TCPClientConnection::readNoInt(void* buf, size_t maxSize, size_t* rawByteCount)
+net::result<ssize_t> TCPClientConnection::sendImpl(const std::vector<uint8_t>& data)
 {
-	return tcp::readNoInt(*socket_, buf, maxSize, rawByteCount);
+	if (!isValid())
+	{
+		debug(LOG_ERROR, "Invalid socket (EBADF)");
+		return tl::make_unexpected(make_network_error_code(EBADF));
+	}
+
+	ssize_t retSent = ::send(getRawSocketFd(), reinterpret_cast<const char*>(data.data()), data.size(), MSG_NOSIGNAL);
+	if (retSent != SOCKET_ERROR)
+	{
+		return retSent;
+	}
+	return tl::make_unexpected(make_network_error_code(tcp::getSockErr()));
 }
 
-net::result<ssize_t> TCPClientConnection::writeAll(const void* buf, size_t size, size_t* rawByteCount)
+net::result<ssize_t> TCPClientConnection::recvImpl(char* dst, size_t maxSize)
 {
-	return tcp::writeAll(*socket_, buf, size, rawByteCount);
+	const auto fd = getRawSocketFd();
+	int lastSockErr = 0;
+	ssize_t received;
+	do
+	{
+		received = ::recv(fd, dst, maxSize, 0);
+		if (received == SOCKET_ERROR)
+		{
+			lastSockErr = tcp::getSockErr();
+		} else if (received == 0)
+		{
+			// Socket got disconnected. No reason to do anything else here.
+			return tl::make_unexpected(make_network_error_code(ECONNRESET));
+		}
+	} while (received == SOCKET_ERROR && lastSockErr == EINTR);
+
+	if (received == SOCKET_ERROR)
+	{
+		return tl::make_unexpected(make_network_error_code(lastSockErr));
+	}
+	return received;
 }
 
 bool TCPClientConnection::readReady() const
 {
-	return socketReadReady(*socket_);
+	return tcp::socketReadReady(*socket_);
 }
 
-void TCPClientConnection::flush(size_t* rawByteCount)
+void TCPClientConnection::setReadReady(bool ready)
 {
-	socketFlush(*socket_, std::numeric_limits<uint8_t>::max()/*unused*/, rawByteCount);
-}
-
-void TCPClientConnection::enableCompression()
-{
-	socketBeginCompression(*socket_);
+	tcp::socketSetReadReady(*socket_, ready);
 }
 
 void TCPClientConnection::useNagleAlgorithm(bool enable)
 {
-	socketSetTCPNoDelay(*socket_, !enable);
+	tcp::socketSetTCPNoDelay(*socket_, !enable);
 }
 
 std::string TCPClientConnection::textAddress() const
 {
 	return getSocketTextAddress(*socket_);
+}
+
+bool TCPClientConnection::isValid() const
+{
+	return socket_ != nullptr && tcp::isValidSocket(*socket_);
+}
+
+net::result<void> TCPClientConnection::connectionStatus() const
+{
+	ASSERT_OR_RETURN(tl::make_unexpected(make_network_error_code(EBADF)),
+		isValid(), "Invalid connection object");
+
+	// Check whether the socket is still connected
+	resetAuxDescriptorSet(*connStatusDescriptorSet_,
+		static_cast<IClientConnection*>(const_cast<TCPClientConnection*>(this)));
+	ssize_t ret = tcp::checkSocketsReadable(selfConnList_, *connStatusDescriptorSet_, 0);
+	if (ret == SOCKET_ERROR)
+	{
+		return tl::make_unexpected(make_network_error_code(tcp::getSockErr()));
+	}
+	else if (ret == (int)selfConnList_.size() && readReady())
+	{
+		/* The next recv(2) call won't block, but we're writing. So
+		 * check the read queue to see if the connection is closed.
+		 * If there's no data in the queue that means the connection
+		 * is closed.
+		 */
+#if defined(WZ_OS_WIN)
+		unsigned long readQueue;
+		ret = ioctlsocket(getRawSocketFd(), FIONREAD, &readQueue);
+#else
+		int readQueue;
+		ret = ioctl(getRawSocketFd(), FIONREAD, &readQueue);
+#endif
+		if (ret == SOCKET_ERROR)
+		{
+			debug(LOG_NET, "socket error");
+			return tl::make_unexpected(make_network_error_code(tcp::getSockErr()));
+		}
+		else if (readQueue == 0)
+		{
+			// Disconnected
+			debug(LOG_NET, "Read queue empty - failing (ECONNRESET)");
+			return tl::make_unexpected(make_network_error_code(ECONNRESET));
+		}
+	}
+	return {};
+}
+
+SOCKET TCPClientConnection::getRawSocketFd() const
+{
+	return tcp::getRawSocketFd(*socket_);
 }
 
 } // namespace tcp

--- a/lib/netplay/tcp/tcp_connection_poll_group.h
+++ b/lib/netplay/tcp/tcp_connection_poll_group.h
@@ -21,17 +21,21 @@
 
 #include "lib/netplay/connection_poll_group.h"
 
+#include <vector>
+#include <memory>
+
+class IClientConnection;
+class IDescriptorSet;
+
 namespace tcp
 {
-
-struct SocketSet;
 
 class TCPConnectionPollGroup : public IConnectionPollGroup
 {
 public:
 
-	explicit TCPConnectionPollGroup(SocketSet* sset);
-	virtual ~TCPConnectionPollGroup() override;
+	explicit TCPConnectionPollGroup();
+	virtual ~TCPConnectionPollGroup() override = default;
 
 	virtual int checkSocketsReadable(unsigned timeout) override;
 	virtual void add(IClientConnection* conn) override;
@@ -39,7 +43,10 @@ public:
 
 private:
 
-	SocketSet* sset_;
+	std::vector<IClientConnection*> conns_;
+	// Pre-allocated descriptor set for `checkSocketsReadable` operation
+	// to avoid extra memory allocations.
+	std::unique_ptr<IDescriptorSet> readableSet_;
 };
 
 } // namespace tcp

--- a/lib/netplay/tcp/tcp_connection_provider.cpp
+++ b/lib/netplay/tcp/tcp_connection_provider.cpp
@@ -80,12 +80,7 @@ net::result<IClientConnection*> TCPConnectionProvider::openClientConnectionAny(c
 
 IConnectionPollGroup* TCPConnectionProvider::newConnectionPollGroup()
 {
-	auto* sset = allocSocketSet();
-	if (!sset)
-	{
-		return nullptr;
-	}
-	return new TCPConnectionPollGroup(sset);
+	return new TCPConnectionPollGroup();
 }
 
 } // namespace tcp

--- a/lib/netplay/tcp/tcp_listen_socket.cpp
+++ b/lib/netplay/tcp/tcp_listen_socket.cpp
@@ -34,7 +34,7 @@ TCPListenSocket::~TCPListenSocket()
 {
 	if (listenSocket_)
 	{
-		socketClose(listenSocket_);
+		socketCloseNow(listenSocket_);
 	}
 }
 

--- a/src/screens/joiningscreen.cpp
+++ b/src/screens/joiningscreen.cpp
@@ -1295,7 +1295,7 @@ void WzJoiningGameScreen_HandlerRoot::closeConnectionAttempt()
 		{
 			tmp_joining_socket_set->remove(client_transient_socket);
 		}
-		delete client_transient_socket;
+		client_transient_socket->close();
 		client_transient_socket = nullptr;
 	}
 	if (tmp_joining_socket_set)


### PR DESCRIPTION
Provide the singleton manager class `PendingWritesManager`, that handles all network write operations in a generic manner (not specific to `TCP_DIRECT` backend).

The main reason for its existence is the fact that we would like to keep all socket write operations asynchronous, which provide the following advantages over blocking approach:

1. Improves responsiveness of the application.
2. Provides means to batch several outstanding write requests into a single larger one to save on network bandwidth.
3. Provides the ability to efficiently compress the write requests, absolutely transparently for the caller.

This class implements the submission queue running on a separate thread, which intercepts and batches all write requests, automatically handles data compression and provides safe disposal of closed connections (i.e. we want to wait for the data to be sent before actually terminating a client connection).

This changeset also involves other API changes to make it work:

1. The generic logic from `readNoInt`, `writeAll` and `flush()` operations is extracted to the `IClientConnection` level, while backend-specific part is abstracted away as `recvImpl()` and `sendImpl()` virtual functions.
2. `IDescriptorSet` classes now work in terms of `IClientConnection:s` instead of TCP_DIRECT-specific `SOCKET:s`.
3. `IClientConnection` now interoperates with `PendingWritesManager` to ensure correct and thread-safe behavior when async write requests are involved.

CPU time and heap memory profiling has been conducted to verify that nothing new shows up in performance analysis sessions.

Signed-off-by: Pavel Solodovnikov <pavel.al.solodovnikov@gmail.com>