### PR TITLE
Adjust Emplacement-PlasmaCannon cost 200 -> 350, buildPoints 400 -> 500

### DIFF
--- a/data/mp/stats/structure.json
+++ b/data/mp/stats/structure.json
@@ -1586,8 +1586,8 @@
 	"Emplacement-PlasmaCannon": {
 		"armour": 10,
 		"breadth": 1,
-		"buildPoints": 400,
-		"buildPower": 200,
+		"buildPoints": 500,
+		"buildPower": 350,
 		"height": 1,
 		"hitpoints": 400,
 		"id": "Emplacement-PlasmaCannon",


### PR DESCRIPTION
An alternative attempt to #4200 to nerf the plasma cannon emplacement