### PR TITLE
netplay: move `checkSocketsReadable` to a higher level of abstraction

### DIFF
--- a/lib/netplay/client_connection.h
+++ b/lib/netplay/client_connection.h
@@ -119,7 +119,7 @@ public:
 	/// <summary>
 	/// Set the "read ready" state on the underlying socket, which is used to indicate whether
 	/// the socket has some data to be ready without blocking. Usually used in conjunction
-	/// with polling, e.g.: `checkSocketsReadable` will set this flag for all affected connections
+	/// with polling, e.g.: `checkConnectionsReadable` will set this flag for all affected connections
 	/// if they are ready to read anything right away.
 	/// </summary>
 	/// <param name="ready"></param>

--- a/lib/netplay/connection_poll_group.h
+++ b/lib/netplay/connection_poll_group.h
@@ -19,6 +19,10 @@
 
 #pragma once
 
+#include <chrono>
+
+#include "lib/netplay/net_result.h"
+
 class IClientConnection;
 
 /// <summary>
@@ -31,14 +35,14 @@ public:
 	virtual ~IConnectionPollGroup() = default;
 
 	/// <summary>
-	/// Polls the sockets in the poll group for updates.
+	/// Polls the sockets in the poll group for read updates.
 	/// </summary>
 	/// <param name="timeout">Timeout value after which the internal implementation should abandon
 	/// polling the client connections and return.</param>
 	/// <returns>On success, returns the number of connection descriptors in the poll group.
 	/// On failure, `0` can returned if the timeout expired before any connection descriptors
 	/// became ready, or `-1` if there was an error during the internal poll operation.</returns>
-	virtual int checkSocketsReadable(unsigned timeout) = 0;
+	virtual net::result<int> checkConnectionsReadable(std::chrono::milliseconds timeout) = 0;
 
 	virtual void add(IClientConnection* conn) = 0;
 	virtual void remove(IClientConnection* conn) = 0;

--- a/lib/netplay/polling_util.cpp
+++ b/lib/netplay/polling_util.cpp
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+/*
+	This file is part of Warzone 2100.
+	Copyright (C) 2025  Warzone 2100 Project
+
+	Warzone 2100 is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+
+	Warzone 2100 is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with Warzone 2100; if not, write to the Free Software
+	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+
+#include "polling_util.h"
+
+#include "lib/framework/frame.h" // for ASSERT, debug
+#include "lib/netplay/client_connection.h"
+#include "lib/netplay/descriptor_set.h"
+
+namespace
+{
+
+void resetDescriptorSet(const std::vector<IClientConnection*>& conns, IDescriptorSet& dset)
+{
+	dset.clear();
+	for (const auto& conn : conns)
+	{
+		ASSERT(dset.add(conn), "Failed to add connection to descriptor set");
+	}
+}
+
+} // anonymous namespace
+
+net::result<int> checkConnectionsReadable(const std::vector<IClientConnection*>& conns,
+	IDescriptorSet& readableSet, std::chrono::milliseconds timeout)
+{
+	if (conns.empty())
+	{
+		return 0;
+	}
+
+	bool compressedReady = false;
+	for (const auto& conn : conns)
+	{
+		ASSERT(conn->isValid(), "Invalid connection!");
+
+		if (conn->isCompressed() && !conn->compressionAdapter().decompressionNeedInput())
+		{
+			compressedReady = true;
+			break;
+		}
+	}
+
+	if (compressedReady)
+	{
+		// A socket already has some data ready. Don't really poll the sockets.
+		for (auto& conn : conns)
+		{
+			conn->setReadReady(conn->isCompressed() && !conn->compressionAdapter().decompressionNeedInput());
+		}
+		return conns.size();
+	}
+
+	resetDescriptorSet(conns, readableSet);
+	const auto pollRes = readableSet.poll(timeout);
+	if (!pollRes.has_value())
+	{
+		const auto msg = pollRes.error().message();
+		debug(LOG_ERROR, "poll failed: %s", msg.c_str());
+		return pollRes;
+	}
+
+	if (pollRes.value() == 0)
+	{
+		debug(LOG_WARNING, "poll timed out after waiting for %u milliseconds", static_cast<unsigned int>(timeout.count()));
+		return 0;
+	}
+
+	for (auto& conn : conns)
+	{
+		conn->setReadReady(readableSet.isSet(conn));
+	}
+	return pollRes.value();
+}

--- a/lib/netplay/polling_util.h
+++ b/lib/netplay/polling_util.h
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+/*
+	This file is part of Warzone 2100.
+	Copyright (C) 2025  Warzone 2100 Project
+
+	Warzone 2100 is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+
+	Warzone 2100 is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with Warzone 2100; if not, write to the Free Software
+	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+
+#include <vector>
+#include <chrono>
+
+#include "lib/netplay/net_result.h"
+
+class IClientConnection;
+class IDescriptorSet;
+
+/// <summary>
+/// Checks which client connections are ready for reading within the specified
+/// `timeout` by performing poll operation on `readableSet`.
+///
+/// User of the function should check the `readableSet` after calling this function
+/// to see which descriptors were set by the internal poll operation (by calling `IDescriptorSet::isSet()`).
+/// </summary>
+/// <param name="conns">List of client connections to poll.</param>
+/// <param name="readableSet">`IDescriptorSet` instance, which may have some of
+/// the descriptors being "set" for read-readiness after internal polling call completes.</param>
+/// <param name="timeout">Timeout in milliseconds.</param>
+/// <returns>On success, returns the number of connections being "set" to "ready to read" state.
+/// On failure, an `std::error_code` describing the error will be returned.</returns>
+net::result<int> checkConnectionsReadable(const std::vector<IClientConnection*>& conns,
+	IDescriptorSet& readableSet, std::chrono::milliseconds timeout);

--- a/lib/netplay/tcp/netsocket.h
+++ b/lib/netplay/tcp/netsocket.h
@@ -112,9 +112,6 @@ void socketSetReadReady(Socket& sock, bool ready);
 
 bool socketSetTCPNoDelay(Socket& sock, bool nodelay); ///< nodelay = true disables the Nagle algorithm for TCP socket
 
-// Socket sets.
-int checkSocketsReadable(const std::vector<IClientConnection*>& conns, IDescriptorSet& readableSet, unsigned int timeout); ///< Checks which Sockets are ready for reading. Returns the number of ready Sockets, or returns SOCKET_ERROR on error.
-
 } // namespace tcp
 
 #endif //_net_socket_h

--- a/lib/netplay/tcp/tcp_connection_poll_group.cpp
+++ b/lib/netplay/tcp/tcp_connection_poll_group.cpp
@@ -20,6 +20,7 @@
 #include "lib/netplay/tcp/tcp_connection_poll_group.h"
 #include "lib/netplay/tcp/tcp_client_connection.h"
 #include "lib/netplay/tcp/netsocket.h"
+#include "lib/netplay/polling_util.h"
 #include "lib/framework/wzapp.h"
 #include "lib/framework/debug.h"
 
@@ -32,9 +33,9 @@ TCPConnectionPollGroup::TCPConnectionPollGroup()
 	: readableSet_(IDescriptorSet::create(PollEventType::READABLE))
 {}
 
-int TCPConnectionPollGroup::checkSocketsReadable(unsigned timeout)
+net::result<int> TCPConnectionPollGroup::checkConnectionsReadable(std::chrono::milliseconds timeout)
 {
-	return tcp::checkSocketsReadable(conns_, *readableSet_, timeout);
+	return ::checkConnectionsReadable(conns_, *readableSet_, timeout);
 }
 
 void TCPConnectionPollGroup::add(IClientConnection* conn)

--- a/lib/netplay/tcp/tcp_connection_poll_group.h
+++ b/lib/netplay/tcp/tcp_connection_poll_group.h
@@ -37,14 +37,14 @@ public:
 	explicit TCPConnectionPollGroup();
 	virtual ~TCPConnectionPollGroup() override = default;
 
-	virtual int checkSocketsReadable(unsigned timeout) override;
+	virtual net::result<int> checkConnectionsReadable(std::chrono::milliseconds timeout) override;
 	virtual void add(IClientConnection* conn) override;
 	virtual void remove(IClientConnection* conn) override;
 
 private:
 
 	std::vector<IClientConnection*> conns_;
-	// Pre-allocated descriptor set for `checkSocketsReadable` operation
+	// Pre-allocated descriptor set for `checkConnectionsReadable` operation
 	// to avoid extra memory allocations.
 	std::unique_ptr<IDescriptorSet> readableSet_;
 };

--- a/src/screens/joiningscreen.cpp
+++ b/src/screens/joiningscreen.cpp
@@ -56,7 +56,7 @@ static std::weak_ptr<WzJoiningGameScreen> psCurrentJoiningAttemptScreen;
 
 void shutdownJoiningAttemptInternal(std::shared_ptr<W_SCREEN> expectedScreen);
 
-constexpr int NET_READ_TIMEOUT = 0;
+constexpr std::chrono::milliseconds NET_READ_TIMEOUT{ 0 };
 constexpr size_t NET_BUFFER_SIZE = MaxMsgSize;
 constexpr uint32_t HOST_RESPONSE_TIMEOUT = 10000;
 
@@ -1367,7 +1367,7 @@ void WzJoiningGameScreen_HandlerRoot::processJoining()
 	if (currentJoiningState == JoiningState::AwaitingInitialNetcodeHandshakeAck)
 	{
 		// read in data, if we have it
-		if (tmp_joining_socket_set->checkSocketsReadable(NET_READ_TIMEOUT) > 0)
+		if (tmp_joining_socket_set->checkConnectionsReadable(NET_READ_TIMEOUT).value_or(0) > 0)
 		{
 			if (!client_transient_socket->readReady())
 			{
@@ -1420,7 +1420,7 @@ void WzJoiningGameScreen_HandlerRoot::processJoining()
 	if (currentJoiningState == JoiningState::ProcessingJoinMessages)
 	{
 		// read in data, if we have it
-		if (tmp_joining_socket_set->checkSocketsReadable(NET_READ_TIMEOUT) > 0)
+		if (tmp_joining_socket_set->checkConnectionsReadable(NET_READ_TIMEOUT).value_or(0) > 0)
 		{
 			if (!client_transient_socket->readReady())
 			{


### PR DESCRIPTION
And rename the function to `checkConnectionsReadable` to match current abstraction level (client connections vs sockets).

Change return value to be `net::result<int>`, so that clients don't have to check for `SOCKET_ERROR` and extract error condition via `tcp::getSockErr()`.

Also, `TCPClientConnection` used to manually reset its descriptor sets in `readAll()` and `connectionStatus()`, while this isn't necessary, since `checkConnectionsReadable()` already does it internally. So, remove this unneded reset code from `TCPClientConnection`.