### PR TITLE
netplay: some more `IClientConnection` improvements (safety and completeness)

### DIFF
--- a/lib/netplay/client_connection.h
+++ b/lib/netplay/client_connection.h
@@ -55,8 +55,6 @@ class IClientConnection
 {
 public:
 
-	virtual ~IClientConnection() = default;
-
 	/// <summary>
 	/// Read exactly `size` bytes into `buf` buffer.
 	/// Supports setting a timeout value in milliseconds.
@@ -219,7 +217,16 @@ public:
 
 protected:
 
+	// Allow `PendingWritesManager` to access hidden destructor
+	// since this class ultimately does the final cleanup of
+	// disposed connections.
+	friend class PendingWritesManager;
+
 	IClientConnection(WzConnectionProvider& connProvider);
+	// Hide the destructor so that external code cannot accidentally
+	// `delete` the connection directly and has to use `close()` method
+	// to dispose of the connection object.
+	virtual ~IClientConnection() = default;
 
 	// Pre-allocated (in ctor) connection list and descriptor sets, which
 	// only contain `this`.

--- a/lib/netplay/open_connection_result.h
+++ b/lib/netplay/open_connection_result.h
@@ -43,16 +43,25 @@ public:
 		: open_socket(open_socket)
 	{ }
 
-public:
 	bool hasError() const { return errorCode.has_value(); }
-public:
+
 	OpenConnectionResult(const OpenConnectionResult& other) = delete; // non construction-copyable
 	OpenConnectionResult& operator=(const OpenConnectionResult&) = delete; // non copyable
 	OpenConnectionResult(OpenConnectionResult&&) = default;
 	OpenConnectionResult& operator=(OpenConnectionResult&&) = default;
-public:
 
-	std::unique_ptr<IClientConnection> open_socket;
+	struct ConnectionCloser
+	{
+		void operator() (IClientConnection* conn)
+		{
+			if (conn)
+			{
+				conn->close();
+			}
+		}
+	};
+
+	std::unique_ptr<IClientConnection, ConnectionCloser> open_socket;
 	optional<std::error_code> errorCode = nullopt;
 	std::string errorString;
 };

--- a/lib/netplay/tcp/tcp_client_connection.h
+++ b/lib/netplay/tcp/tcp_client_connection.h
@@ -37,7 +37,6 @@ public:
 	explicit TCPClientConnection(WzConnectionProvider& connProvider, Socket* rawSocket);
 	virtual ~TCPClientConnection() override;
 
-	virtual net::result<ssize_t> readAll(void* buf, size_t size, unsigned timeout) override;
 	virtual net::result<ssize_t> sendImpl(const std::vector<uint8_t>& data) override;
 	virtual net::result<ssize_t> recvImpl(char* dst, size_t maxSize) override;
 
@@ -58,15 +57,6 @@ private:
 
 	Socket* socket_;
 
-	// Pre-allocated (in ctor) connection list and descriptor sets, which
-	// only contain `this`.
-	//
-	// Used for some operations which may use polling internally
-	// (like `readAll()` and `connectionStatus()`) to avoid extra
-	// memory allocations.
-	const std::vector<IClientConnection*> selfConnList_;
-	WzConnectionProvider* connProvider_;
-	std::unique_ptr<IDescriptorSet> readAllDescriptorSet_;
 	std::unique_ptr<IDescriptorSet> connStatusDescriptorSet_;
 };
 


### PR DESCRIPTION
The changeset contains the following two fixes:
1. Make `IClientConnection` as generic as possible by moving `readAll()` implementation from `TCPClientConnection` to `IClientConnection` level
2. Enforce safe disposal pattern for client connections, so that one doesn't have the ability to accidentally call `delete` on a connection instance directly and has to use `IClientConnection::close()`, which will ensure that connection disposal is performed in a safe way (i.e. doesn't interfere with `PendingWritesManager`). 