### PR TITLE
aiUpdateStructure: Avoid (expensive) duplicate call to aiChooseTarget for weapon_slot 0

### DIFF
--- a/src/structure.cpp
+++ b/src/structure.cpp
@@ -3116,7 +3116,7 @@ static void aiUpdateStructure(STRUCTURE *psStructure, bool isMission)
 				}
 				else
 				{
-					if (aiChooseTarget(psStructure, &psChosenObjs[0], 0, true, &tmpOrigin))
+					if (i > 0)
 					{
 						if (psChosenObjs[0])
 						{


### PR DESCRIPTION
(The loop body already calls `aiChooseTarget` for weapon_slot `0`, which sets `psChosenObjs[0]` on success)