### PR TITLE
netplay: introduce per-WzConnectionProvider pending writes manager mapping

### DIFF
--- a/lib/netplay/client_connection.h
+++ b/lib/netplay/client_connection.h
@@ -34,6 +34,7 @@
 using nonstd::optional;
 
 class IDescriptorSet;
+class PendingWritesManager;
 class WzCompressionProvider;
 class WzConnectionProvider;
 
@@ -223,7 +224,7 @@ protected:
 	// disposed connections.
 	friend class PendingWritesManager;
 
-	IClientConnection(WzConnectionProvider& connProvider, WzCompressionProvider& compressionProvider);
+	IClientConnection(WzConnectionProvider& connProvider, WzCompressionProvider& compressionProvider, PendingWritesManager& pwm);
 	// Hide the destructor so that external code cannot accidentally
 	// `delete` the connection directly and has to use `close()` method
 	// to dispose of the connection object.
@@ -240,6 +241,9 @@ protected:
 	WzConnectionProvider* connProvider_ = nullptr;
 	// Compression provider which is used to initialize compression algorithm in `enableCompression()`.
 	WzCompressionProvider* compressionProvider_ = nullptr;
+	// Pending writes manager instance, specific to a particular connection provider,
+	// which is used to schedule all write operations for this connection.
+	PendingWritesManager* pwm_ = nullptr;
 
 private:
 

--- a/lib/netplay/connection_provider_registry.cpp
+++ b/lib/netplay/connection_provider_registry.cpp
@@ -38,6 +38,11 @@ WzConnectionProvider& ConnectionProviderRegistry::Get(ConnectionProviderType pt)
 	return *it->second;
 }
 
+bool ConnectionProviderRegistry::IsRegistered(ConnectionProviderType pt) const
+{
+	return registeredProviders_.count(pt) != 0;
+}
+
 void ConnectionProviderRegistry::Register(ConnectionProviderType pt)
 {
 	// No-op in case this provider has been already registered.

--- a/lib/netplay/connection_provider_registry.h
+++ b/lib/netplay/connection_provider_registry.h
@@ -19,6 +19,7 @@
 
 #pragma once
 
+#include <stdint.h>
 #include <memory>
 #include <unordered_map>
 
@@ -27,7 +28,7 @@
 /// <summary>
 /// Available types of connection providers (i.e. network backend implementations).
 /// </summary>
-enum class ConnectionProviderType
+enum class ConnectionProviderType : uint8_t
 {
 	TCP_DIRECT
 };
@@ -42,6 +43,7 @@ public:
 	static ConnectionProviderRegistry& Instance();
 
 	WzConnectionProvider& Get(ConnectionProviderType pt);
+	bool IsRegistered(ConnectionProviderType) const;
 
 	void Register(ConnectionProviderType pt);
 	void Deregister(ConnectionProviderType pt);

--- a/lib/netplay/listen_socket.cpp
+++ b/lib/netplay/listen_socket.cpp
@@ -21,6 +21,8 @@
 
 #include "listen_socket.h"
 
-IListenSocket::IListenSocket(WzCompressionProvider& compressionProvider)
-	: compressionProvider_(&compressionProvider)
+IListenSocket::IListenSocket(WzConnectionProvider& connProvider, WzCompressionProvider& compressionProvider, PendingWritesManager& pwm)
+	: connProvider_(&connProvider),
+	compressionProvider_(&compressionProvider),
+	pwm_(&pwm)
 {}

--- a/lib/netplay/listen_socket.h
+++ b/lib/netplay/listen_socket.h
@@ -23,6 +23,8 @@
 #include <type_traits>
 
 class IClientConnection;
+class PendingWritesManager;
+class WzConnectionProvider;
 class WzCompressionProvider;
 
 /// <summary>
@@ -49,7 +51,9 @@ public:
 
 protected:
 
-	IListenSocket(WzCompressionProvider& compressionProvider);
+	IListenSocket(WzConnectionProvider& connProvider, WzCompressionProvider& compressionProvider, PendingWritesManager& pwm);
 
+	WzConnectionProvider* connProvider_ = nullptr;
 	WzCompressionProvider* compressionProvider_ = nullptr;
+	PendingWritesManager* pwm_ = nullptr;
 };

--- a/lib/netplay/pending_writes_manager_map.cpp
+++ b/lib/netplay/pending_writes_manager_map.cpp
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+/*
+	This file is part of Warzone 2100.
+	Copyright (C) 2025  Warzone 2100 Project
+
+	Warzone 2100 is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+
+	Warzone 2100 is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with Warzone 2100; if not, write to the Free Software
+	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+
+#include "pending_writes_manager_map.h"
+#include "pending_writes_manager.h"
+
+#include "lib/framework/frame.h" // for ASSERT
+
+PendingWritesManagerMap& PendingWritesManagerMap::instance()
+{
+	static PendingWritesManagerMap instance;
+	return instance;
+}
+
+PendingWritesManager& PendingWritesManagerMap::get(ConnectionProviderType pt)
+{
+	auto& cpr = ConnectionProviderRegistry::Instance();
+	ASSERT(cpr.IsRegistered(pt), "Connection provider %d is not registered", static_cast<int>(pt));
+	auto it = pendingWritesManagers_.find(pt);
+	if (it != pendingWritesManagers_.end())
+	{
+		return *it->second;
+	}
+	auto& connProvider = cpr.Get(pt);
+	auto pwm = std::make_unique<PendingWritesManager>();
+	pwm->initialize(connProvider);
+	it = pendingWritesManagers_.emplace(pt, std::move(pwm)).first;
+	return *it->second;
+}
+
+PendingWritesManager& PendingWritesManagerMap::get(const WzConnectionProvider& connProvider)
+{
+	return get(connProvider.type());
+}

--- a/lib/netplay/pending_writes_manager_map.h
+++ b/lib/netplay/pending_writes_manager_map.h
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+/*
+	This file is part of Warzone 2100.
+	Copyright (C) 2025  Warzone 2100 Project
+
+	Warzone 2100 is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+
+	Warzone 2100 is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with Warzone 2100; if not, write to the Free Software
+	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+
+#pragma once
+
+#include <memory>
+
+#include "lib/netplay/connection_provider_registry.h"
+
+class PendingWritesManager;
+
+/// <summary>
+/// Global singleton mapping from connection provider types to `PendingWritesManager` instances.
+///
+/// Each `PendingWritesManager` instance obtained via `get(ConnectionProviderType)`,
+/// should be `initialize()`-d with a corresponding `WzConnectionProvider` instance.
+/// </summary>
+class PendingWritesManagerMap
+{
+public:
+
+	static PendingWritesManagerMap& instance();
+
+	/// <summary>
+	/// Get or create a `PendingWritesManager` instance for a given connection provider type.
+	///
+	/// If a new instance is created, it's automatically initialized with a reference to the
+	/// corresponding `WzConnectionProvider` instance.
+	/// </summary>
+	/// <param name="pt"></param>
+	/// <returns>Reference to the `PendingWritesManager` instance bound to the connection
+	/// provider corresponding to `pt`.</returns>
+	PendingWritesManager& get(ConnectionProviderType pt);
+	PendingWritesManager& get(const WzConnectionProvider& connProvider);
+
+private:
+
+	explicit PendingWritesManagerMap() = default;
+	PendingWritesManagerMap(const PendingWritesManagerMap&) = delete;
+	PendingWritesManagerMap(PendingWritesManagerMap&&) = delete;
+
+	// `PendingWritesManager` is stored as `unique_ptr` to avoid undesired theoretical
+	// side effects in case `pendingWritesManagers_` map is rehashed upon insertion.
+	// We don't want `PendingWritesManager` to ever be destroyed and reallocated (possibly midway
+	// during some work).
+	std::unordered_map<ConnectionProviderType, std::unique_ptr<PendingWritesManager>> pendingWritesManagers_;
+};

--- a/lib/netplay/tcp/tcp_client_connection.cpp
+++ b/lib/netplay/tcp/tcp_client_connection.cpp
@@ -30,8 +30,8 @@
 namespace tcp
 {
 
-TCPClientConnection::TCPClientConnection(WzConnectionProvider& connProvider, WzCompressionProvider& compressionProvider, Socket* rawSocket)
-	: IClientConnection(connProvider, compressionProvider),
+TCPClientConnection::TCPClientConnection(WzConnectionProvider& connProvider, WzCompressionProvider& compressionProvider, PendingWritesManager& pwm, Socket* rawSocket)
+	: IClientConnection(connProvider, compressionProvider, pwm),
 	socket_(rawSocket),
 	connStatusDescriptorSet_(connProvider_->newDescriptorSet(PollEventType::READABLE))
 {

--- a/lib/netplay/tcp/tcp_client_connection.h
+++ b/lib/netplay/tcp/tcp_client_connection.h
@@ -23,6 +23,7 @@
 #include "lib/netplay/descriptor_set.h"
 #include "lib/netplay/tcp/netsocket.h" // for SOCKET
 
+class PendingWritesManager;
 class WzCompressionProvider;
 class WzConnectionProvider;
 
@@ -35,7 +36,7 @@ class TCPClientConnection : public IClientConnection
 {
 public:
 
-	explicit TCPClientConnection(WzConnectionProvider& connProvider, WzCompressionProvider& compressionProvider, Socket* rawSocket);
+	explicit TCPClientConnection(WzConnectionProvider& connProvider, WzCompressionProvider& compressionProvider, PendingWritesManager& pwm, Socket* rawSocket);
 	virtual ~TCPClientConnection() override;
 
 	virtual net::result<ssize_t> sendImpl(const std::vector<uint8_t>& data) override;

--- a/lib/netplay/tcp/tcp_connection_provider.h
+++ b/lib/netplay/tcp/tcp_connection_provider.h
@@ -35,6 +35,8 @@ public:
 	virtual void initialize() override;
 	virtual void shutdown() override;
 
+	virtual ConnectionProviderType type() const noexcept override;
+
 	virtual net::result<std::unique_ptr<IConnectionAddress>> resolveHost(const char* host, uint16_t port) override;
 
 	virtual net::result<IListenSocket*> openListenSocket(uint16_t port) override;

--- a/lib/netplay/tcp/tcp_listen_socket.cpp
+++ b/lib/netplay/tcp/tcp_listen_socket.cpp
@@ -26,10 +26,9 @@
 namespace tcp
 {
 
-TCPListenSocket::TCPListenSocket(WzConnectionProvider& connProvider, WzCompressionProvider& compressionProvider, Socket* rawSocket)
-	: IListenSocket(compressionProvider),
-	listenSocket_(rawSocket),
-	connProvider_(&connProvider)
+TCPListenSocket::TCPListenSocket(WzConnectionProvider& connProvider, WzCompressionProvider& compressionProvider, PendingWritesManager& pwm, Socket* rawSocket)
+	: IListenSocket(connProvider, compressionProvider, pwm),
+	listenSocket_(rawSocket)
 {}
 
 TCPListenSocket::~TCPListenSocket()
@@ -52,7 +51,7 @@ IClientConnection* TCPListenSocket::accept()
 	{
 		return nullptr;
 	}
-	return new TCPClientConnection(*connProvider_, *compressionProvider_, s);
+	return new TCPClientConnection(*connProvider_, *compressionProvider_, *pwm_, s);
 }
 
 IListenSocket::IPVersionsMask TCPListenSocket::supportedIpVersions() const

--- a/lib/netplay/tcp/tcp_listen_socket.h
+++ b/lib/netplay/tcp/tcp_listen_socket.h
@@ -23,6 +23,7 @@
 
 #include "lib/netplay/listen_socket.h"
 
+class PendingWritesManager;
 class WzCompressionProvider;
 class WzConnectionProvider;
 
@@ -35,7 +36,7 @@ class TCPListenSocket : public IListenSocket
 {
 public:
 
-	explicit TCPListenSocket(WzConnectionProvider& connProvider, WzCompressionProvider& compressionProvider, tcp::Socket* rawSocket);
+	explicit TCPListenSocket(WzConnectionProvider& connProvider, WzCompressionProvider& compressionProvider, PendingWritesManager& pwm, tcp::Socket* rawSocket);
 	virtual ~TCPListenSocket() override;
 
 	virtual IClientConnection* accept() override;
@@ -44,7 +45,6 @@ public:
 private:
 
 	tcp::Socket* listenSocket_ = nullptr;
-	WzConnectionProvider* connProvider_ = nullptr;
 };
 
 } // namespace tcp

--- a/lib/netplay/wz_connection_provider.h
+++ b/lib/netplay/wz_connection_provider.h
@@ -34,6 +34,8 @@ class IClientConnection;
 class IConnectionPollGroup;
 struct IConnectionAddress;
 
+enum class ConnectionProviderType : uint8_t;
+
 /// <summary>
 /// Abstraction layer to facilitate creating client/server connections and
 /// provide host resolution routines for a given network backend.
@@ -57,6 +59,8 @@ public:
 
 	virtual void initialize() = 0;
 	virtual void shutdown() = 0;
+
+	virtual ConnectionProviderType type() const noexcept = 0;
 
 	/// <summary>
 	/// Resolve host + port combination and return an opaque `ConnectionAddress` handle


### PR DESCRIPTION
Introduce the ability to run multiple `PendingWritesManager:s`, specific to each registered connection provider.

Upon adding new network backend, the code, which talks to lobby server, will still be using legacy TCP backend, so in this case we'll have to run two network backends at the same time.