### PR TITLE
Check for infinitely circling units 

### DIFF
--- a/src/movedef.h
+++ b/src/movedef.h
@@ -59,7 +59,7 @@ struct MOVE_CONTROL
 	uint16_t lastBump = 0;                ///< Time of last bump with a droid - relative to bumpTime
 	uint16_t pauseTime = 0;               ///< When MOVEPAUSE started - relative to bumpTime
 	Position bumpPos = Position(0, 0, 0); ///< Position of last bump
-
+	unsigned tolerance = 0;               ///< Increases until unit gives up and goes to the next waypoint, if close enough
 	unsigned shuffleStart = 0;            ///< When a shuffle started
 
 	FORMATION *psFormation = nullptr;     ///< formation the droid is currently a member of


### PR DESCRIPTION
This is my attempt to alleviate the infinite spinning behavior you may see when two units are constantly moving around each other. This all happens because the final waypoint is very precise, down to 1/4 of a tile, and thus the units will never stop circling. They are simply to big and far away enough while trying to avoid each other so that they never realize they reached the waypoint.

Intermediate waypoints are precise to 1/2 a tile but just using that will prevent fine-tuning unit location in a noticeable way, so I opted to create a little tolerance threshold that when exceeded makes them stop.

This tolerance threshold starts being active once the unit is within 3/4 of a tile distance from any waypoint and takes about 10 seconds before they give up and go to the next one. The distance works for Dragon body, and the time is enough even the slowest unit will reach the 1/4 tile distance check.

This works for the base game models at least. Bodies bigger than Dragon would need a larger distance check + increased time threshold before moving to another waypoint. Of course, there may be another better way.

In lieu of actual pathfinding changes that may help this situation, I think this is good enough to try out in the next beta release some months from now.

---

You may see something called `bumpTime` in the nearby diff here. It only gets set when units actually crash into or touch each other, so it's not sufficient.