### PR TITLE
Fix `targetAttackWeight()` selecting targets that can't be hit

### DIFF
--- a/src/ai.cpp
+++ b/src/ai.cpp
@@ -36,6 +36,7 @@
 #include "projectile.h"
 #include "objmem.h"
 #include "order.h"
+#include "visibility.h"
 
 /* Weights used for target selection code,
  * target distance is used as 'common currency'
@@ -48,6 +49,7 @@
 #define	WEIGHT_HEALTH_STRUCT		(WEIGHT_DIST_TILE * 7)
 
 #define	WEIGHT_NOT_VISIBLE_F		10						//We really don't like objects we can't see
+#define WEIGHT_NOT_LOS_VISIBLE_F	4
 
 #define	WEIGHT_SERVICE_DROIDS		(WEIGHT_DIST_TILE_DROID * 5)		//We don't want them to be repairing droids or structures while we are after them
 #define	WEIGHT_WEAPON_DROIDS		(WEIGHT_DIST_TILE_DROID * 4)		//We prefer to go after anything that has a gun and can hurt us
@@ -485,6 +487,11 @@ static SDWORD targetAttackWeight(BASE_OBJECT *psTarget, BASE_OBJECT *psAttacker,
 	else	//a feature
 	{
 		return 1;
+	}
+
+	if (bDirect && !lineOfFire(psAttacker, psTarget, weapon_slot, false))
+	{
+		attackWeight /= WEIGHT_NOT_LOS_VISIBLE_F; // Prefer objects not obstructed by terrain
 	}
 
 	/* We prefer objects we can see and can attack immediately */


### PR DESCRIPTION
Deduct target weight of objects if line of fire is obstructed by terrain.

This is probably one of the most important bug fixes of all time. WZ makes a terrible mistake of not having the **target auto-selection** account for terrain obstruction (hills) in-between the attacker and potential target. This means the micro-AI can easily get tunnel vision on something it can't hit (within long range) but is visible at the same time. As such, objects that have the ability to shoot downwards have a **colossal** advantage over those that shoot upwards.

In effect the battles of campaign and low oil will feel a lot more fair and smooth with this fix. Hard to pass chokepoints with hills, like the one in Beta 6, should no longer draw out battles longer than usual if you don't click on something directly within a straight firing line. Or by rushing into them to reach the poorly selected unit.

Not sure if the two ifs should be side by side or turned into an if-elseif. I left it as it is in case guard behavior may wish to track a nearby damaged unit over a hill under vision. This PR should probably have a performance impact check done on it since this gets called a lot. Would like additional testing on this--I've already played up to Beta 3 with it so far.

Fixes #4163

---

In this video I recorded to show pastdue some weeks ago, you can see my units freely choosing enemy units that it can fire at, instead of the ones behind the hill as in Arc's video. This bug affects mobile units too, not just holding ones, so if I showed my tanks moving in this recording, they would still fire at the debug units I was putting to the right side of them (unlike any past release).

https://github.com/user-attachments/assets/f90d2abb-d546-472c-9326-0340171ad574

