### PR TITLE
netplay: un-hardcode connection provider setup

### DIFF
--- a/lib/netplay/connection_provider_registry.cpp
+++ b/lib/netplay/connection_provider_registry.cpp
@@ -45,7 +45,11 @@ bool ConnectionProviderRegistry::IsRegistered(ConnectionProviderType pt) const
 
 void ConnectionProviderRegistry::Register(ConnectionProviderType pt)
 {
-	// No-op in case this provider has been already registered.
+	if (IsRegistered(pt))
+	{
+		return;
+	}
+
 	switch (pt)
 	{
 	case ConnectionProviderType::TCP_DIRECT:

--- a/lib/netplay/netplay.cpp
+++ b/lib/netplay/netplay.cpp
@@ -1554,7 +1554,7 @@ void NETinitPortMapping()
 
 // ////////////////////////////////////////////////////////////////////////
 // setup stuff
-int NETinit(bool bFirstCall)
+int NETinit()
 {
 	debug(LOG_NET, "NETinit");
 	NETlogEntry("NETinit!", SYNC_FLAG, selectedPlayer);
@@ -1565,20 +1565,17 @@ int NETinit(bool bFirstCall)
 	connProvider.initialize();
 	PendingWritesManagerMap::instance().get(connProvider).initialize(connProvider);
 
-	if (bFirstCall)
-	{
-		debug(LOG_NET, "NETPLAY: Init called, MORNIN'");
+	debug(LOG_NET, "NETPLAY: Init called, MORNIN'");
 
-		// NOTE NetPlay.isPortMappingEnabled is already set in configuration.c!
-		NetPlay.bComms = true;
-		NetPlay.GamePassworded = false;
-		NetPlay.ShowedMOTD = false;
-		NetPlay.isHostAlive = false;
-		NetPlay.HaveUpgrade = false;
-		NetPlay.gamePassword[0] = '\0';
-		NetPlay.MOTD = nullptr;
-		NETstartLogging();
-	}
+	// NOTE NetPlay.isPortMappingEnabled is already set in configuration.c!
+	NetPlay.bComms = true;
+	NetPlay.GamePassworded = false;
+	NetPlay.ShowedMOTD = false;
+	NetPlay.isHostAlive = false;
+	NetPlay.HaveUpgrade = false;
+	NetPlay.gamePassword[0] = '\0';
+	NetPlay.MOTD = nullptr;
+	NETstartLogging();
 
 	if (NetPlay.MOTD)
 	{
@@ -4739,7 +4736,7 @@ bool NETenumerateGames(const std::function<bool (const GAMESTRUCT& game)>& handl
 
 	if (!NetPlay.bComms)
 	{
-		debug(LOG_ERROR, "Likely missing NETinit(true) - this won't return any results");
+		debug(LOG_ERROR, "Likely missing NETinit() - this won't return any results");
 		return false;
 	}
 	auto& connProvider = ConnectionProviderRegistry::Instance().Get(ConnectionProviderType::TCP_DIRECT);

--- a/lib/netplay/netplay.h
+++ b/lib/netplay/netplay.h
@@ -353,10 +353,11 @@ extern PortMappingAsyncRequestHandle ipv4MappingRequest;
 		failAction; \
 	}
 
+enum class ConnectionProviderType : uint8_t;
 
 // ////////////////////////////////////////////////////////////////////////
 // functions available to you.
-int NETinit();
+int NETinit(ConnectionProviderType pt);
 WZ_DECL_NONNULL(2) bool NETsend(NETQUEUE queue, NetMessage const *message);   ///< send to player, or broadcast if player == NET_ALL_PLAYERS.
 void NETsendProcessDelayedActions();
 WZ_DECL_NONNULL(1, 2) bool NETrecvNet(NETQUEUE *queue, uint8_t *type);        ///< recv a message from the net queues if possible.

--- a/lib/netplay/netplay.h
+++ b/lib/netplay/netplay.h
@@ -356,7 +356,7 @@ extern PortMappingAsyncRequestHandle ipv4MappingRequest;
 
 // ////////////////////////////////////////////////////////////////////////
 // functions available to you.
-int NETinit(bool bFirstCall);
+int NETinit();
 WZ_DECL_NONNULL(2) bool NETsend(NETQUEUE queue, NetMessage const *message);   ///< send to player, or broadcast if player == NET_ALL_PLAYERS.
 void NETsendProcessDelayedActions();
 WZ_DECL_NONNULL(1, 2) bool NETrecvNet(NETQUEUE *queue, uint8_t *type);        ///< recv a message from the net queues if possible.

--- a/lib/netplay/pending_writes_manager.cpp
+++ b/lib/netplay/pending_writes_manager.cpp
@@ -50,6 +50,8 @@ void PendingWritesManager::deinitialize()
 	wzMutexDestroy(mtx_);
 	wzSemaphoreDestroy(sema_);
 	thread_ = nullptr;
+	mtx_ = nullptr;
+	sema_ = nullptr;
 }
 
 void PendingWritesManager::initialize(WzConnectionProvider& connProvider)

--- a/lib/netplay/tcp/netsocket.cpp
+++ b/lib/netplay/tcp/netsocket.cpp
@@ -975,25 +975,24 @@ void deleteSocketAddress(SocketAddress *addr)
 void SOCKETinit()
 {
 #if defined(WZ_OS_WIN)
-	static bool firstCall = true;
-	if (firstCall)
+	if (winsock2_dll)
 	{
-		firstCall = false;
+		return;
+	}
 
-		static WSADATA stuff;
-		WORD ver_required = (2 << 8) + 2;
-		if (WSAStartup(ver_required, &stuff) != 0)
-		{
-			debug(LOG_ERROR, "Failed to initialize Winsock: %s", strSockError(getSockErr()));
-			return;
-		}
+	static WSADATA stuff;
+	WORD ver_required = (2 << 8) + 2;
+	if (WSAStartup(ver_required, &stuff) != 0)
+	{
+		debug(LOG_ERROR, "Failed to initialize Winsock: %s", strSockError(getSockErr()));
+		return;
+	}
 
-		winsock2_dll = LoadLibraryA("ws2_32.dll");
-		if (winsock2_dll)
-		{
-			getaddrinfo_dll_func = reinterpret_cast<GETADDRINFO_DLL_FUNC>(reinterpret_cast<void*>(GetProcAddress(winsock2_dll, "getaddrinfo")));
-			freeaddrinfo_dll_func = reinterpret_cast<FREEADDRINFO_DLL_FUNC>(reinterpret_cast<void*>(GetProcAddress(winsock2_dll, "freeaddrinfo")));
-		}
+	winsock2_dll = LoadLibraryA("ws2_32.dll");
+	if (winsock2_dll)
+	{
+		getaddrinfo_dll_func = reinterpret_cast<GETADDRINFO_DLL_FUNC>(reinterpret_cast<void*>(GetProcAddress(winsock2_dll, "getaddrinfo")));
+		freeaddrinfo_dll_func = reinterpret_cast<FREEADDRINFO_DLL_FUNC>(reinterpret_cast<void*>(GetProcAddress(winsock2_dll, "freeaddrinfo")));
 	}
 #endif
 }

--- a/src/frontend.cpp
+++ b/src/frontend.cpp
@@ -32,6 +32,8 @@
 #include "lib/ivis_opengl/bitimage.h"
 #include "lib/ivis_opengl/pieblitfunc.h"
 #include "lib/ivis_opengl/piestate.h"
+#include "lib/netplay/connection_provider_registry.h"
+#include "lib/netplay/netplay.h"
 #include "lib/sound/mixer.h"
 #include "lib/sound/tracklib.h"
 #include "lib/widget/button.h"
@@ -573,13 +575,14 @@ bool runMultiPlayerMenu()
 			ingame.side = InGameSide::HOST_OR_SINGLEPLAYER;
 			bMultiPlayer = true;
 			bMultiMessages = true;
-			NETinit();
+			NETinit(ConnectionProviderType::TCP_DIRECT);
 			NETinitPortMapping();
 			game.type = LEVEL_TYPE::SKIRMISH;		// needed?
 			changeTitleUI(std::make_shared<WzMultiplayerOptionsTitleUI>(wzTitleUICurrent));
 			break;
 		case FRONTEND_JOIN:
-			NETinit();
+			// Don't call `NETinit()` just yet.
+			// It will be called automatically during join attempts.
 			ingame.side = InGameSide::MULTIPLAYER_CLIENT;
 			if (getLobbyError() != ERROR_INVALID)
 			{

--- a/src/frontend.cpp
+++ b/src/frontend.cpp
@@ -573,13 +573,13 @@ bool runMultiPlayerMenu()
 			ingame.side = InGameSide::HOST_OR_SINGLEPLAYER;
 			bMultiPlayer = true;
 			bMultiMessages = true;
-			NETinit(true);
+			NETinit();
 			NETinitPortMapping();
 			game.type = LEVEL_TYPE::SKIRMISH;		// needed?
 			changeTitleUI(std::make_shared<WzMultiplayerOptionsTitleUI>(wzTitleUICurrent));
 			break;
 		case FRONTEND_JOIN:
-			NETinit(true);
+			NETinit();
 			ingame.side = InGameSide::MULTIPLAYER_CLIENT;
 			if (getLobbyError() != ERROR_INVALID)
 			{

--- a/src/integrations/wzdiscordrpc.cpp
+++ b/src/integrations/wzdiscordrpc.cpp
@@ -206,7 +206,6 @@ static void joinGameImpl(const std::vector<JoinConnectionDescription>& joinConne
 	}
 	// join the game!
 	NetPlay.bComms = true; // use network = true
-	NETinit();
 	// Ensure the joinGame has a place to return to
 	changeTitleMode(TITLE);
 	joinGame(joinConnectionDetails);
@@ -235,10 +234,9 @@ static void findAndJoinLobbyGameImpl(const std::string& lobbyAddress, unsigned i
 				return;
 			}
 
-			// For now, it is necessary to call `NETinit()` before calling findLobbyGame
+			// `findLobbyGame()` will automatically call `NETinit()`, if needed.
 			// Obviously this wouldn't be a good idea to do *during* a game, hence the check above to
 			// ensure we're still in the menus...
-			NETinit();
 			ingame.side = InGameSide::MULTIPLAYER_CLIENT;
 			auto joinConnectionDetails = findLobbyGame(lobbyAddressCopy, lobbyPort, lobbyGameId);
 

--- a/src/integrations/wzdiscordrpc.cpp
+++ b/src/integrations/wzdiscordrpc.cpp
@@ -206,7 +206,7 @@ static void joinGameImpl(const std::vector<JoinConnectionDescription>& joinConne
 	}
 	// join the game!
 	NetPlay.bComms = true; // use network = true
-	NETinit(true);
+	NETinit();
 	// Ensure the joinGame has a place to return to
 	changeTitleMode(TITLE);
 	joinGame(joinConnectionDetails);
@@ -235,10 +235,10 @@ static void findAndJoinLobbyGameImpl(const std::string& lobbyAddress, unsigned i
 				return;
 			}
 
-			// For now, it is necessary to call `NETinit(true)` before calling findLobbyGame
+			// For now, it is necessary to call `NETinit()` before calling findLobbyGame
 			// Obviously this wouldn't be a good idea to do *during* a game, hence the check above to
 			// ensure we're still in the menus...
-			NETinit(true);
+			NETinit();
 			ingame.side = InGameSide::MULTIPLAYER_CLIENT;
 			auto joinConnectionDetails = findLobbyGame(lobbyAddressCopy, lobbyPort, lobbyGameId);
 

--- a/src/multiint.cpp
+++ b/src/multiint.cpp
@@ -988,7 +988,7 @@ void from_json(const nlohmann::json& j, JoinConnectionDescription& v)
 	v.type = j.at("t").get<JoinConnectionDescription::JoinConnectionType>();
 }
 
-// NOTE: Must call NETinit(true); before this will actually work
+// NOTE: Must call NETinit(); before this will actually work
 std::vector<JoinConnectionDescription> findLobbyGame(const std::string& lobbyAddress, unsigned int lobbyPort, uint32_t lobbyGameId)
 {
 	WzString originalLobbyServerName = WzString::fromUtf8(NETgetMasterserverName());

--- a/src/screens/joiningscreen.cpp
+++ b/src/screens/joiningscreen.cpp
@@ -46,7 +46,6 @@
 
 #include <chrono>
 #include <algorithm>
-#include <fmt/format.h>
 
 class WzJoiningGameScreen_HandlerRoot;
 struct WzJoiningGameScreen;
@@ -1147,9 +1146,8 @@ static ConnectionProviderType toConnectionProviderType(JoinConnectionDescription
 	{
 	case JoinConnectionDescription::JoinConnectionType::TCP_DIRECT:
 		return ConnectionProviderType::TCP_DIRECT;
-	default:
-		throw std::runtime_error(fmt::format("Invalid join connection type: %d", static_cast<int>(ct)));
 	}
+	throw std::runtime_error(astringf("Invalid join connection type: %d", static_cast<int>(ct))); // prevent GCC warning
 }
 
 void WzJoiningGameScreen_HandlerRoot::processOpenConnectionResult(size_t connectionIdx, OpenConnectionResult&& result)

--- a/src/screens/joiningscreen.cpp
+++ b/src/screens/joiningscreen.cpp
@@ -1797,7 +1797,7 @@ bool startJoiningAttempt(char* playerName, std::vector<JoinConnectionDescription
 
 	// network communication preparation
 	NetPlay.bComms = true; // use network = true
-	NETinit(true);
+	NETinit();
 
 	PLAYERSTATS	playerStats;
 	loadMultiStats(playerName, &playerStats);

--- a/src/wrappers.cpp
+++ b/src/wrappers.cpp
@@ -206,7 +206,7 @@ TITLECODE titleLoop()
 			{
 				NetPlay.bComms = true; // use network = true
 				bMultiMessages = true;
-				NETinit(true);
+				NETinit();
 				NETinitPortMapping();
 			}
 			bMultiPlayer = true;
@@ -219,7 +219,7 @@ TITLECODE titleLoop()
 		else if (strlen(iptoconnect))
 		{
 			NetPlay.bComms = true; // use network = true
-			NETinit(true);
+			NETinit();
 			// Ensure the joinGame has a place to return to
 			changeTitleMode(TITLE);
 			joinGame(iptoconnect, cliConnectToIpAsSpectator);

--- a/src/wrappers.cpp
+++ b/src/wrappers.cpp
@@ -30,6 +30,7 @@
 #include "lib/ivis_opengl/piemode.h"
 #include "lib/ivis_opengl/piestate.h"
 #include "lib/ivis_opengl/screen.h"
+#include "lib/netplay/connection_provider_registry.h"
 #include "lib/netplay/netplay.h"	// multiplayer
 #include "lib/sound/audio.h"
 #include "lib/framework/wzapp.h"
@@ -206,7 +207,7 @@ TITLECODE titleLoop()
 			{
 				NetPlay.bComms = true; // use network = true
 				bMultiMessages = true;
-				NETinit();
+				NETinit(ConnectionProviderType::TCP_DIRECT);
 				NETinitPortMapping();
 			}
 			bMultiPlayer = true;
@@ -219,9 +220,11 @@ TITLECODE titleLoop()
 		else if (strlen(iptoconnect))
 		{
 			NetPlay.bComms = true; // use network = true
-			NETinit();
 			// Ensure the joinGame has a place to return to
 			changeTitleMode(TITLE);
+			// Don't call `NETinit()` just yet.
+			// It will be automatically called by `joinGame()` upon connection attempt
+			// with the correct connection provider type corresponding to the connection string.
 			joinGame(iptoconnect, cliConnectToIpAsSpectator);
 		}
 		else


### PR DESCRIPTION
While joining, the `ConnectionProviderType` is inferred from the current join connection description. After an unsuccessful join attempt, an `NETshutdown()` will be called before moving on to the next entry in the connection list.

For host, it's currently hard-coded to `TCP_DIRECT`, but it's completely transparent for `NETinit()` now, as it's passed as an argument to `NETinit()`. Previously, the function had a `bool bFirstCall` argument, but the function was always called with the `true` value, so this argument was also removed.

Lobby connection handler uses its own reference to connection provider, which isn't generally the same as `activeConnProvider`, so it does its own optional initialization step for `TCP_DIRECT` (which it currently has to use either way) by calling `ensureInitialized()`.

Also, tcp-related init (`SOCKETinit()`) can now be called several times, matched by the corresponding `SOCKETshutdown()`.

Signed-off-by: Pavel Solodovnikov <pavel.al.solodovnikov@gmail.com>