### PR TITLE
netplay: host network backend configuration

### DIFF
--- a/.github/workflows/CI_windows.yml
+++ b/.github/workflows/CI_windows.yml
@@ -507,7 +507,6 @@ jobs:
       if: success() && (steps.settings.outputs.WZ_USING_MINGW != 'true')
       working-directory: '${{ github.workspace }}\build'
       env:
-        CXXFLAGS: '/MP'
         BUILD_SENTRY_SUPPORT: ${{ matrix.support_sentry }}
         WZ_ENABLE_SENTRY: ${{ steps.settings.outputs.WZ_ENABLE_SENTRY }}
         SENTRY_IO_DSN: '${{ secrets.CRASHREPORTING_SENTRY_IO_DSN }}'
@@ -515,12 +514,12 @@ jobs:
         WZ_FULL_MSGMERGE_PATH: ${{ steps.settings.outputs.WZ_FULL_MSGMERGE_PATH }}
         WZ_FULL_MSGFMT_PATH: ${{ steps.settings.outputs.WZ_FULL_MSGFMT_PATH }}
       run: |
-        $ADDITIONAL_CMAKE_PARAMS = ""
+        $ADDITIONAL_CMAKE_PARAMS = "-DWZ_MSVC_MULTITHREADED_COMPILATION:BOOL=ON"
         $WZ_BUILD_SENTRY_VALUE = "OFF"
         if ("${env:BUILD_SENTRY_SUPPORT}" -eq "true") {
           $WZ_BUILD_SENTRY_VALUE = "ON"
           if (("${env:WZ_ENABLE_SENTRY}" -eq "true") -and (-not ([string]::IsNullOrEmpty("${env:SENTRY_IO_DSN}")))) {
-            $ADDITIONAL_CMAKE_PARAMS = "-DSENTRY_IO_DSN:STRING=${env:SENTRY_IO_DSN}"
+            $ADDITIONAL_CMAKE_PARAMS = "$ADDITIONAL_CMAKE_PARAMS -DSENTRY_IO_DSN:STRING=${env:SENTRY_IO_DSN}"
           }
         }
         $env:PATH = "${env:PATH};${env:WZ_FULL_MSGMERGE_PATH}";
@@ -575,8 +574,6 @@ jobs:
     - name: CMake Build (MSVC)
       if: success() && (steps.settings.outputs.WZ_USING_MINGW != 'true')
       working-directory: '${{ github.workspace }}\build'
-      env:
-        CXXFLAGS: '/MP'
       run: |
         # Workaround: https://github.com/actions/runner-images/issues/10004
         $env:CXXFLAGS = "${env:CXXFLAGS} /D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -233,6 +233,12 @@ if("${CMAKE_CXX_COMPILER_ID}" MATCHES "MSVC")
 
 	# Default stack size is 1MB - increase to better match other platforms
 	set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /STACK:8000000")
+
+	# Enable multithreaded compilation by default
+	option(WZ_MSVC_MULTITHREADED_COMPILATION "Controls multithreaded compilation for MSVC builds" ON)
+	if(WZ_MSVC_MULTITHREADED_COMPILATION)
+		add_compile_options("/MP")
+	endif()
 elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU|Clang" AND NOT APPLE AND NOT CMAKE_SYSTEM_NAME MATCHES "Emscripten")
 	# Ensure all builds always have debug info built (Xcode is handled separately below, Emscripten handled above)
 	set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -g")

--- a/lib/netplay/netplay.cpp
+++ b/lib/netplay/netplay.cpp
@@ -1578,6 +1578,12 @@ int NETinit(ConnectionProviderType pt)
 
 	debug(LOG_NET, "NETPLAY: Init called, MORNIN'");
 
+	wzAsyncExecOnMainThread([pt]() {
+		const auto strPt = to_string(pt);
+		std::string msg = astringf(_("Using %s network backend."), strPt.c_str());
+		addConsoleMessage(msg.c_str(), DEFAULT_JUSTIFY, NOTIFY_MESSAGE);
+	});
+
 	// NOTE NetPlay.isPortMappingEnabled is already set in configuration.c!
 	NetPlay.bComms = true;
 	NetPlay.GamePassworded = false;

--- a/src/clparse.cpp
+++ b/src/clparse.cpp
@@ -368,6 +368,7 @@ typedef enum
 #if defined(__EMSCRIPTEN__)
 	CLI_VIDEOURL,
 #endif
+	CLI_HOST_CONNECTION_PROVIDER,
 } CLI_OPTIONS;
 
 // Separate table that avoids *any* translated strings, to avoid any risk of gettext / libintl function calls
@@ -462,6 +463,7 @@ static const struct poptOption *getOptionsTable()
 #if defined(__EMSCRIPTEN__)
 		{ "videourl", POPT_ARG_STRING, CLI_VIDEOURL,   N_("Base URL for on-demand video downloads"), N_("Base video URL") },
 #endif
+		{ "host-connection-provider", POPT_ARG_STRING, CLI_HOST_CONNECTION_PROVIDER, N_("Specify connection provider type to use when hosting game sessions"), "[tcp]" },
 
 		// Terminating entry
 		{ nullptr, 0, 0,              nullptr,                                    nullptr },
@@ -1362,6 +1364,20 @@ bool ParseCommandLine(int argc, const char * const *argv)
 			debug(LOG_INFO, "Using \"%s\" as base video URL.", token);
 			break;
 #endif
+
+		case CLI_HOST_CONNECTION_PROVIDER:
+			token = poptGetOptArg(poptCon);
+			if (token == nullptr || strlen(token) == 0)
+			{
+				qFatal("Missing value for the host connection provider argument");
+			}
+			ConnectionProviderType pt;
+			if (!net_backend_from_str(token, pt))
+			{
+				qFatal("Unsupported / invalid network backend");
+			}
+			war_setHostConnectionProvider(pt);
+			break;
 
 		} // switch (option)
 	} // while

--- a/src/frontend.cpp
+++ b/src/frontend.cpp
@@ -575,7 +575,7 @@ bool runMultiPlayerMenu()
 			ingame.side = InGameSide::HOST_OR_SINGLEPLAYER;
 			bMultiPlayer = true;
 			bMultiMessages = true;
-			NETinit(ConnectionProviderType::TCP_DIRECT);
+			NETinit(war_getHostConnectionProvider());
 			NETinitPortMapping();
 			game.type = LEVEL_TYPE::SKIRMISH;		// needed?
 			changeTitleUI(std::make_shared<WzMultiplayerOptionsTitleUI>(wzTitleUICurrent));

--- a/src/warzoneconfig.cpp
+++ b/src/warzoneconfig.cpp
@@ -28,6 +28,7 @@
 #include "lib/ivis_opengl/piestate.h"
 #include "lib/ivis_opengl/piepalette.h"
 #include "lib/sound/sounddefs.h"
+#include "lib/netplay/connection_provider_registry.h"
 #include "advvis.h"
 #include "component.h"
 #include "display.h"
@@ -103,6 +104,9 @@ struct WARZONE_GLOBALS
 
 	// run-time only settings (not persisted to config!)
 	bool allowVulkanImplicitLayers = false;
+
+	// Connection provider used for hosting games
+	ConnectionProviderType hostProviderType = ConnectionProviderType::TCP_DIRECT;
 };
 
 static WARZONE_GLOBALS warGlobs;
@@ -717,4 +721,35 @@ void war_setOptionsButtonVisibility(uint8_t val)
 bool war_getAllowVulkanImplicitLayers()
 {
 	return warGlobs.allowVulkanImplicitLayers;
+}
+
+void war_setHostConnectionProvider(ConnectionProviderType pt)
+{
+	warGlobs.hostProviderType = pt;
+}
+
+ConnectionProviderType war_getHostConnectionProvider()
+{
+	return warGlobs.hostProviderType;
+}
+
+bool net_backend_from_str(const char* str, ConnectionProviderType& pt)
+{
+	if (strcasecmp(str, "tcp") == 0)
+	{
+		pt = ConnectionProviderType::TCP_DIRECT;
+		return true;
+	}
+	return false;
+}
+
+std::string to_string(ConnectionProviderType pt)
+{
+	switch (pt)
+	{
+	case ConnectionProviderType::TCP_DIRECT:
+		return "tcp";
+	}
+	ASSERT(false, "Invalid connection provider type enumeration value: %d", static_cast<int>(pt)); // silence GCC warning
+	return {};
 }

--- a/src/warzoneconfig.h
+++ b/src/warzoneconfig.h
@@ -29,6 +29,7 @@
 #include "lib/sound/sounddefs.h"
 #include "multiplaydefs.h"
 #include <string>
+#include <stdint.h>
 
 #define	CAMERASPEED_MAX		(5000)
 #define	CAMERASPEED_MIN		(100)
@@ -174,6 +175,14 @@ void war_setOptionsButtonVisibility(uint8_t val);
 
 void war_runtimeOnlySetAllowVulkanImplicitLayers(bool allowed); // not persisted to config
 bool war_getAllowVulkanImplicitLayers();
+
+enum class ConnectionProviderType : uint8_t;
+
+void war_setHostConnectionProvider(ConnectionProviderType pt);
+ConnectionProviderType war_getHostConnectionProvider();
+
+bool net_backend_from_str(const char* str, ConnectionProviderType& pt);
+std::string to_string(ConnectionProviderType pt);
 
 /**
  * Enable or disable sound initialization

--- a/src/wrappers.cpp
+++ b/src/wrappers.cpp
@@ -207,7 +207,7 @@ TITLECODE titleLoop()
 			{
 				NetPlay.bComms = true; // use network = true
 				bMultiMessages = true;
-				NETinit(ConnectionProviderType::TCP_DIRECT);
+				NETinit(war_getHostConnectionProvider());
 				NETinitPortMapping();
 			}
 			bMultiPlayer = true;


### PR DESCRIPTION
This changeset contains the machinery to allow easily switching between various network backends (connection providers), when we have more than a single one:

1. Introduce global INI configuration section (`hostConnectionProvider`) for host connection provider. Currently, only `tcp` is supported (which is mapped to `ConnectionProviderType::TCP_DIRECT`)
2. Introduce `--host-connection-provider` command-line switch for overriding configuration defaults