### PR TITLE
Heavy Laser Buff

### DIFF
--- a/data/mp/stats/weapons.json
+++ b/data/mp/stats/weapons.json
@@ -1989,7 +1989,7 @@
 	"HeavyLaser": {
 		"buildPoints": 600,
 		"buildPower": 400,
-		"damage": 380,
+		"damage": 290,
 		"designable": 1,
 		"effectSize": 100,
 		"explosionWav": "lsrexpl.ogg",
@@ -2019,7 +2019,7 @@
 		"shortRange": 2048,
 		"waterGfx": "FXMExp.PIE",
 		"weaponClass": "HEAT",
-		"weaponEffect": "ANTI PERSONNEL",
+		"weaponEffect": "ALL ROUNDER",
 		"weaponSubClass": "ENERGY",
 		"weaponWav": "hevlsr.ogg",
 		"weight": 5000
@@ -2027,7 +2027,7 @@
 	"HeavyLaser-VTOL": {
 		"buildPoints": 1000,
 		"buildPower": 400,
-		"damage": 720,
+		"damage": 550,
 		"designable": 1,
 		"effectSize": 100,
 		"explosionWav": "lsrexpl.ogg",
@@ -2060,7 +2060,7 @@
 		"shortRange": 2304,
 		"waterGfx": "FXMExp.PIE",
 		"weaponClass": "HEAT",
-		"weaponEffect": "ANTI PERSONNEL",
+		"weaponEffect": "ALL ROUNDER",
 		"weaponSubClass": "ENERGY",
 		"weaponWav": "hevlsr.ogg",
 		"weight": 5000


### PR DESCRIPTION
- Damage type changed from `ANTI PERSONNEL` → `ALL ROUNDER`
- Damage reduced by about `25%`
  - Damage: `380` → `290`
  - VTOL Damage: `720` → `550`

https://youtu.be/2Ya1q_r_IU8

[HeavyLaserBuff2.zip](https://github.com/user-attachments/files/19266245/HeavyLaserBuff2.zip)