### PR TITLE
Update DROID_CONSTRUCT description to not include cyborgs

### DIFF
--- a/doc/js-objects.md
+++ b/doc/js-objects.md
@@ -80,7 +80,7 @@ In addition, the following properties are defined:
 C++ code may change the action frequently as it tries to carry out its order. You never want to set
 the action directly, but it may be interesting to look at what it currently is.
 * ```droidType``` The droid's type. The following types are defined:
-  * ```DROID_CONSTRUCT``` Trucks and cyborg constructors.
+  * ```DROID_CONSTRUCT``` Truck constructors.
   * ```DROID_WEAPON``` Droids with weapon turrets, except cyborgs.
   * ```DROID_PERSON``` Non-cyborg two-legged units, like scavengers.
   * ```DROID_REPAIR``` Units with repair turret, including repair cyborgs.


### PR DESCRIPTION
`doc/js-objects.md` incorrectly states that `DROID_CONSTRUCT` includes cyborg constructors. I fixed this, and was also planning on adding the updated droid types `DROID_CYBORG_CONSTRUCT` `DROID_CYBORG_REPAIR` and `DROID_CYBORG_SUPER`:

https://github.com/Warzone2100/warzone2100/blob/79232da5e9c2070e4b17895b00ecfdbbd0c9d9af/src/statsdef.h#L37-L54

But I came across https://github.com/Warzone2100/warzone2100/pull/614 which seems to suggest that these newer droid types are intentionally excluded? So I didn't add them.