### PR TITLE
wzapi::hackTextMarker - Place colored text marker on map

### DIFF
--- a/src/display3d.cpp
+++ b/src/display3d.cpp
@@ -385,6 +385,13 @@ struct TextMarker
 		, color(color)
 	{}
 
+	TextMarker(BASE_OBJECT *object, std::string message, uint8_t color)
+		: object(object)
+		, message(message)
+		, color(color)
+	{}
+
+	BASE_OBJECT *object = {};
 	uint8_t x;
 	uint8_t y;
 	std::string message;
@@ -760,6 +767,10 @@ void clearBlueprints()
 void addTextMarker(uint8_t mapX, uint8_t mapY, std::string message, uint8_t color)
 {
 	textMarkers.emplace_back(TextMarker{mapX, mapY, message, color});
+}
+void addTextMarker(BASE_OBJECT *object, std::string message, uint8_t color)
+{
+	textMarkers.emplace_back(TextMarker{object, message, color});
 }
 
 void clearTextMarkers()
@@ -1157,18 +1168,34 @@ void draw3DScene()
 	}
 	if (1)
 	{
-		for (auto textMarker: textMarkers) {
-			if (textMarker.x < map_coord(playerPos.p.x) - visibleTiles.x / 2) continue;
-			if (textMarker.y < map_coord(playerPos.p.z) - visibleTiles.y / 2) continue;
-			if (textMarker.x > map_coord(playerPos.p.x) + visibleTiles.x / 2) continue;
-			if (textMarker.y > map_coord(playerPos.p.z) + visibleTiles.y / 2) continue;
-			auto idx=visibleTiles.y / 2 + textMarker.y - map_coord(playerPos.p.z);
-			auto jdx=visibleTiles.x / 2 + textMarker.x - map_coord(playerPos.p.x);
-
+		for (auto textMarker: textMarkers)
+		{
 			iV_SetTextColour(clanColours[textMarker.color]);
-			iV_DrawText(textMarker.message.c_str(), tileScreenInfo[idx][jdx].x, tileScreenInfo[idx][jdx].y, font_regular);
-		}
 
+			/** Convert to tile marker if object is destroyed */
+			if (textMarker.object != nullptr && textMarker.object->died)
+			{
+				textMarker.x = map_coord(textMarker.object->pos.x);
+				textMarker.y = map_coord(textMarker.object->pos.y);
+				textMarker.object = nullptr;
+			}
+
+			if (textMarker.object == nullptr)
+			{
+				if (textMarker.x < map_coord(playerPos.p.x) - visibleTiles.x / 2) continue;
+				if (textMarker.y < map_coord(playerPos.p.z) - visibleTiles.y / 2) continue;
+				if (textMarker.x > map_coord(playerPos.p.x) + visibleTiles.x / 2) continue;
+				if (textMarker.y > map_coord(playerPos.p.z) + visibleTiles.y / 2) continue;
+				auto idx=visibleTiles.y / 2 + textMarker.y - map_coord(playerPos.p.z);
+				auto jdx=visibleTiles.x / 2 + textMarker.x - map_coord(playerPos.p.x);
+				iV_DrawText(textMarker.message.c_str(), tileScreenInfo[idx][jdx].x, tileScreenInfo[idx][jdx].y, font_regular);
+			}
+			else
+			{
+				if (textMarker.object->sDisplay.frameNumber < frameGetFrameNumber()) continue;
+				iV_DrawText(textMarker.message.c_str(), textMarker.object->sDisplay.screenX, textMarker.object->sDisplay.screenY, font_regular);
+			}
+		}
 	}
 
 	setupConnectionStatusForm();

--- a/src/display3d.cpp
+++ b/src/display3d.cpp
@@ -376,6 +376,23 @@ struct Blueprint
 
 static std::vector<Blueprint> blueprints;
 
+struct TextMarker
+{
+	TextMarker(uint8_t x, uint8_t y, std::string message, uint8_t color)
+		: x(x)
+		, y(y)
+		, message(message)
+		, color(color)
+	{}
+
+	uint8_t x;
+	uint8_t y;
+	std::string message;
+	uint8_t color;
+};
+
+static std::vector<TextMarker> textMarkers;
+
 #define	TARGET_TO_SENSOR_TIME	((4*(GAME_TICKS_PER_SEC))/5)
 #define	DEST_TARGET_TIME	(GAME_TICKS_PER_SEC/4)
 
@@ -738,6 +755,16 @@ bool anyBlueprintTooClose(STRUCTURE_STATS const *stats, Vector2i pos, uint16_t d
 void clearBlueprints()
 {
 	blueprints.clear();
+}
+
+void addTextMarker(uint8_t mapX, uint8_t mapY, std::string message, uint8_t color)
+{
+	textMarkers.emplace_back(TextMarker{mapX, mapY, message, color});
+}
+
+void clearTextMarkers()
+{
+	textMarkers.clear();
 }
 
 static PIELIGHT selectionBrightness()
@@ -1128,6 +1155,21 @@ void draw3DScene()
 		droidText.setText(droidCounts, font_regular);
 		droidText.render(pie_GetVideoBufferWidth() - droidText.width() - 10, droidText.height() + 2, WZCOL_TEXT_BRIGHT);
 	}
+	if (1) 
+	{
+		for (auto textMarker: textMarkers) {
+			if (textMarker.x < map_coord(playerPos.p.x) - visibleTiles.x / 2) continue;
+			if (textMarker.y < map_coord(playerPos.p.z) - visibleTiles.y / 2) continue;
+			if (textMarker.x > map_coord(playerPos.p.x) + visibleTiles.x / 2) continue;
+			if (textMarker.y > map_coord(playerPos.p.z) + visibleTiles.y / 2) continue;
+			auto idx=visibleTiles.y / 2 + textMarker.y - map_coord(playerPos.p.z);
+			auto jdx=visibleTiles.x / 2 + textMarker.x - map_coord(playerPos.p.x);	
+
+			iV_SetTextColour(clanColours[textMarker.color]);
+			iV_DrawText(textMarker.message.c_str(), tileScreenInfo[idx][jdx].x, tileScreenInfo[idx][jdx].y, font_regular);
+		}
+
+	}
 
 	setupConnectionStatusForm();
 
@@ -1388,8 +1430,8 @@ static void drawTiles(iView *player, LightingData& lightData, LightMap& lightmap
 				Vector2i screen(0, 0);
 				Position pos;
 
-				pos.x = world_coord(j);
-				pos.z = -world_coord(i);
+				pos.x = world_coord(j) - playerPos.p.x % TILE_WIDTH;
+				pos.z = -world_coord(i) + playerPos.p.z % TILE_HEIGHT;
 				pos.y = 0;
 
 				if (tileOnMap(playerXTile + j, playerZTile + i))

--- a/src/display3d.cpp
+++ b/src/display3d.cpp
@@ -1155,7 +1155,7 @@ void draw3DScene()
 		droidText.setText(droidCounts, font_regular);
 		droidText.render(pie_GetVideoBufferWidth() - droidText.width() - 10, droidText.height() + 2, WZCOL_TEXT_BRIGHT);
 	}
-	if (1) 
+	if (1)
 	{
 		for (auto textMarker: textMarkers) {
 			if (textMarker.x < map_coord(playerPos.p.x) - visibleTiles.x / 2) continue;
@@ -1163,7 +1163,7 @@ void draw3DScene()
 			if (textMarker.x > map_coord(playerPos.p.x) + visibleTiles.x / 2) continue;
 			if (textMarker.y > map_coord(playerPos.p.z) + visibleTiles.y / 2) continue;
 			auto idx=visibleTiles.y / 2 + textMarker.y - map_coord(playerPos.p.z);
-			auto jdx=visibleTiles.x / 2 + textMarker.x - map_coord(playerPos.p.x);	
+			auto jdx=visibleTiles.x / 2 + textMarker.x - map_coord(playerPos.p.x);
 
 			iV_SetTextColour(clanColours[textMarker.color]);
 			iV_DrawText(textMarker.message.c_str(), tileScreenInfo[idx][jdx].x, tileScreenInfo[idx][jdx].y, font_regular);

--- a/src/display3d.h
+++ b/src/display3d.h
@@ -113,6 +113,9 @@ STRUCTURE_STATS const *getTileBlueprintStats(int mapX, int mapY);  ///< Gets the
 bool anyBlueprintTooClose(STRUCTURE_STATS const *stats, Vector2i pos, uint16_t dir);  ///< Checks if any blueprint is too close to the given structure.
 void clearBlueprints();
 
+void addTextMarker(uint8_t mapX, uint8_t mapY, std::string message, uint8_t color);
+void clearTextMarkers();
+
 void display3dScreenSizeDidChange(unsigned int oldWidth, unsigned int oldHeight, unsigned int newWidth, unsigned int newHeight);
 
 extern SDWORD mouseTileX, mouseTileY;

--- a/src/display3d.h
+++ b/src/display3d.h
@@ -114,6 +114,7 @@ bool anyBlueprintTooClose(STRUCTURE_STATS const *stats, Vector2i pos, uint16_t d
 void clearBlueprints();
 
 void addTextMarker(uint8_t mapX, uint8_t mapY, std::string message, uint8_t color);
+void addTextMarker(BASE_OBJECT *object, std::string message, uint8_t color);
 void clearTextMarkers();
 
 void display3dScreenSizeDidChange(unsigned int oldWidth, unsigned int oldHeight, unsigned int newWidth, unsigned int newHeight);

--- a/src/quickjs_backend.cpp
+++ b/src/quickjs_backend.cpp
@@ -3446,7 +3446,7 @@ bool quickjs_scripting_instance::registerFunctions(const std::string& scriptName
 	JS_REGISTER_FUNC(hackGetObj, 3); // WZAPI
 	JS_REGISTER_FUNC2(hackAssert, 2, 2 + MAX_JS_VARARGS); // WZAPI
 	JS_REGISTER_FUNC2(hackMarkTiles, 1, 4); // WZAPI
-	JS_REGISTER_FUNC(hackTextMarker, 4); // WZAPI
+	JS_REGISTER_FUNC2(hackTextMarker, 3, 5); // WZAPI
 	JS_REGISTER_FUNC2(receiveAllEvents, 0, 1); // WZAPI
 	JS_REGISTER_FUNC(hackDoNotSave, 1); // WZAPI
 	JS_REGISTER_FUNC(hackPlayIngameAudio, 0); // WZAPI

--- a/src/quickjs_backend.cpp
+++ b/src/quickjs_backend.cpp
@@ -3239,6 +3239,7 @@ IMPL_JS_FUNC(setWeather, wzapi::setWeather)
 IMPL_JS_FUNC(setSky, wzapi::setSky)
 IMPL_JS_FUNC(hackDoNotSave, wzapi::hackDoNotSave)
 IMPL_JS_FUNC(hackMarkTiles, wzapi::hackMarkTiles)
+IMPL_JS_FUNC(hackTextMarker, wzapi::hackTextMarker)
 IMPL_JS_FUNC(cameraSlide, wzapi::cameraSlide)
 IMPL_JS_FUNC(cameraZoom, wzapi::cameraZoom)
 IMPL_JS_FUNC(cameraTrack, wzapi::cameraTrack)
@@ -3438,6 +3439,7 @@ bool quickjs_scripting_instance::registerFunctions(const std::string& scriptName
 	JS_REGISTER_FUNC(hackGetObj, 3); // WZAPI
 	JS_REGISTER_FUNC2(hackAssert, 2, 2 + MAX_JS_VARARGS); // WZAPI
 	JS_REGISTER_FUNC2(hackMarkTiles, 1, 4); // WZAPI
+	JS_REGISTER_FUNC(hackTextMarker, 4); // WZAPI
 	JS_REGISTER_FUNC2(receiveAllEvents, 0, 1); // WZAPI
 	JS_REGISTER_FUNC(hackDoNotSave, 1); // WZAPI
 	JS_REGISTER_FUNC(hackPlayIngameAudio, 0); // WZAPI

--- a/src/wzapi.cpp
+++ b/src/wzapi.cpp
@@ -929,28 +929,48 @@ wzapi::no_return_value wzapi::hackMarkTiles(WZAPI_PARAMS(optional<wzapi::label_o
 	return {};
 }
 
-//-- ## hackTextMarker(x, y, message, colour)
+//-- ## hackTextMarker(message, colour, label | x, y | type, player, id)
 //--
-//-- Place a text marker given tile on the map.
-//-- See ```changePlayerColour``` for all available colour.
-//-- If both x and y equal to -1, all text marker are cleared. (4.6+ only)
+//-- Place a text marker given tile / object on the map.
+//-- See ```changePlayerColour``` for all available colours.
+//-- If message is empty, all text marker are cleared. (4.6+ only)
 //--
-wzapi::no_return_value wzapi::hackTextMarker(WZAPI_PARAMS(int _x, int _y, std::string _message, int _colour))
+wzapi::no_return_value wzapi::hackTextMarker(WZAPI_PARAMS(std::string _message, int _colour, wzapi::object_request request))
 {
-	if ((_x == -1) && (_y == -1))
-	{
+	SCRIPT_ASSERT({}, context, _colour >= 0, "Colour value %d is less than zero", _colour);
+	SCRIPT_ASSERT({}, context, _colour <= 15, "Colour value %d is greater than 15", _colour);
+
+	if (_message.length()==0) {
 		clearTextMarkers();
 		return {};
 	}
 
-	SCRIPT_ASSERT({}, context, _x >= 0, "Text x value %d is less than zero", _x);
-	SCRIPT_ASSERT({}, context, _y >= 0, "Text y value %d is less than zero", _y);
-	SCRIPT_ASSERT({}, context, _x <= mapWidth, "Text x value %d is greater than mapWidth %d", _x, (int)mapWidth);
-	SCRIPT_ASSERT({}, context, _y <= mapHeight, "Text y value %d is greater than mapHeight %d", _y, (int)mapHeight);
-	SCRIPT_ASSERT({}, context, _colour >= 0, "Colour value %d is less than zero", _colour);
-	SCRIPT_ASSERT({}, context, _colour <= 15, "Colour value %d is greater than 15", _colour);
-
-	addTextMarker(_x, _y, _message, _colour);
+	if (request.requestType == wzapi::object_request::RequestType::MAPPOS_REQUEST)
+	{
+		auto pos = request.getMapPosition();
+		int x = pos.x;
+		int y = pos.y;
+		SCRIPT_ASSERT({}, context, tileOnMap(x, y), "Map position (%d, %d) not on the map!", x, y);
+		addTextMarker(x, y, _message, _colour);
+		return {};
+	}
+	else if (request.requestType == wzapi::object_request::RequestType::OBJECTID_REQUEST)
+	{
+		auto type_player_id = request.getObjectIDRequest();
+		OBJECT_TYPE type = std::get<0>(type_player_id);
+		int player = std::get<1>(type_player_id);
+		int id = std::get<2>(type_player_id);
+		SCRIPT_ASSERT_PLAYER({}, context, player);
+		auto object=IdToObject(type, id, player);
+		addTextMarker(object, _message, _colour);
+		return {};
+	}
+	else if (request.requestType == wzapi::object_request::RequestType::LABEL_REQUEST)
+	{
+		auto object=scripting_engine::instance().getObjectFromLabel(context, request.getLabel()).getObject();
+		addTextMarker(object, _message, _colour);
+		return {};
+	}
 	return {};
 }
 

--- a/src/wzapi.cpp
+++ b/src/wzapi.cpp
@@ -929,6 +929,31 @@ wzapi::no_return_value wzapi::hackMarkTiles(WZAPI_PARAMS(optional<wzapi::label_o
 	return {};
 }
 
+//-- ## hackTextMarker(x, y, message, colour)
+//--
+//-- Place a text marker given tile on the map.
+//-- See ```changePlayerColour``` for all available colour.
+//-- If both x and y equal to -1, all text marker are cleared. (4.6+ only)
+//--
+wzapi::no_return_value wzapi::hackTextMarker(WZAPI_PARAMS(int _x, int _y, std::string _message, int _colour))
+{
+	if ((_x == -1) && (_y == -1))
+	{
+		clearTextMarkers();
+		return {};
+	}
+
+	SCRIPT_ASSERT({}, context, _x >= 0, "Text x value %d is less than zero", _x);
+	SCRIPT_ASSERT({}, context, _y >= 0, "Text y value %d is less than zero", _y);
+	SCRIPT_ASSERT({}, context, _x <= mapWidth, "Text x value %d is greater than mapWidth %d", _x, (int)mapWidth);
+	SCRIPT_ASSERT({}, context, _y <= mapHeight, "Text y value %d is greater than mapHeight %d", _y, (int)mapHeight);
+	SCRIPT_ASSERT({}, context, _colour >= 0, "Colour value %d is less than zero", _colour);
+	SCRIPT_ASSERT({}, context, _colour <= 15, "Colour value %d is greater than 15", _colour);
+
+	addTextMarker(_x, _y, _message, _colour);
+	return {};
+}
+
 // MARK: - General functions -- geared for use in AI scripts
 
 //-- ## dump(string...)

--- a/src/wzapi.h
+++ b/src/wzapi.h
@@ -1016,7 +1016,7 @@ namespace wzapi
 	no_return_value hackPlayIngameAudio(WZAPI_NO_PARAMS);
 	no_return_value hackStopIngameAudio(WZAPI_NO_PARAMS);
 	no_return_value hackMarkTiles(WZAPI_PARAMS(optional<label_or_position_values> _tilePosOrArea));
-	no_return_value hackTextMarker(WZAPI_PARAMS(int _x, int _y, std::string _message, int _colour));
+	no_return_value hackTextMarker(WZAPI_PARAMS(std::string _message, int _colour, wzapi::object_request request));
 
 	// General functions -- geared for use in AI scripts
 	no_return_value dump(WZAPI_PARAMS(va_list_treat_as_strings strings));

--- a/src/wzapi.h
+++ b/src/wzapi.h
@@ -1016,6 +1016,7 @@ namespace wzapi
 	no_return_value hackPlayIngameAudio(WZAPI_NO_PARAMS);
 	no_return_value hackStopIngameAudio(WZAPI_NO_PARAMS);
 	no_return_value hackMarkTiles(WZAPI_PARAMS(optional<label_or_position_values> _tilePosOrArea));
+	no_return_value hackTextMarker(WZAPI_PARAMS(int _x, int _y, std::string _message, int _color));
 
 	// General functions -- geared for use in AI scripts
 	no_return_value dump(WZAPI_PARAMS(va_list_treat_as_strings strings));

--- a/src/wzapi.h
+++ b/src/wzapi.h
@@ -1016,7 +1016,7 @@ namespace wzapi
 	no_return_value hackPlayIngameAudio(WZAPI_NO_PARAMS);
 	no_return_value hackStopIngameAudio(WZAPI_NO_PARAMS);
 	no_return_value hackMarkTiles(WZAPI_PARAMS(optional<label_or_position_values> _tilePosOrArea));
-	no_return_value hackTextMarker(WZAPI_PARAMS(int _x, int _y, std::string _message, int _color));
+	no_return_value hackTextMarker(WZAPI_PARAMS(int _x, int _y, std::string _message, int _colour));
 
 	// General functions -- geared for use in AI scripts
 	no_return_value dump(WZAPI_PARAMS(va_list_treat_as_strings strings));


### PR DESCRIPTION
Place text on map is useful for AI debugging or tutorial.
It use same palette of player colour.
It use iV_DrawText, which is relative slow (1500 characters for 60 fps).

effect:
![1](https://github.com/user-attachments/assets/84343829-00c4-492e-bc36-45a2548f7384)

subtract playerPos.p.x % TILE_WIDTH ... for better sub-tile precision (mp4 video):
before:
https://github.com/user-attachments/assets/416ee2b4-7020-4e98-8d71-7096888f9439
after:
https://github.com/user-attachments/assets/a8c63624-4795-4bf0-b34a-1e623f17c513

