### PR TITLE
Changes to test using SuperTransport - body size and ascend/descend speeds

### DIFF
--- a/src/move.cpp
+++ b/src/move.cpp
@@ -1854,8 +1854,8 @@ static void moveAdjustVtolHeight(DROID *psDroid, int32_t iMapHeight)
 
     if (psDroid->droidType == DROID_SUPERTRANSPORTER && bMultiPlayer) // Set ascend and descend speeds based on droid type, only in multiplayer (MP)
     {
-         ascendSpeed = SUPERTRANSPORTER_ASCEND_SPEED;
-        descendSpeed = SUPERTRANSPORTER_DESCEND_SPEED;
+         ascendSpeed = SUPERTRANSPORTER_VERTICAL_SPEED_ASCEND_MP;
+        descendSpeed = SUPERTRANSPORTER_VERTICAL_SPEED_DESCEND_MP;
     }
     else if (psDroid->droidType == DROID_SUPERTRANSPORTER || psDroid->droidType == DROID_TRANSPORTER) // Cam unaffected
     {

--- a/src/move.cpp
+++ b/src/move.cpp
@@ -1969,10 +1969,8 @@ static void moveUpdateCyborgModel(DROID *psDroid, SDWORD moveSpeed, uint16_t mov
 		psDroid->timeAnimationStarted = gameTime;
 		psDroid->animationEvent = ANIM_EVENT_ACTIVE;
 	}
-
 	/* use baba person movement */
 	moveUpdatePersonModel(psDroid, moveSpeed, moveDir);
-
 	psDroid->rot.pitch = 0;
 	psDroid->rot.roll  = 0;
 }
@@ -1980,28 +1978,26 @@ static void moveUpdateCyborgModel(DROID *psDroid, SDWORD moveSpeed, uint16_t mov
 static void moveDescending(DROID *psDroid)
 {
 	int32_t iMapHeight = map_Height(psDroid->pos.x, psDroid->pos.y);
-
 	psDroid->sMove.speed = 0;
-
 	if (psDroid->pos.z > iMapHeight)
 	{
-		/* descending */
+	    if (psDroid->droidType == DROID_SUPERTRANSPORTER && bMultiPlayer)
+    	    {
+        	psDroid->sMove.iVertSpeed = (SWORD) -SUPERTRANSPORTER_VERTICAL_SPEED_DESCEND_MP;
+    	    }
+	    else
+	    {
 		psDroid->sMove.iVertSpeed = (SWORD) - VTOL_VERTICAL_SPEED_OLD;
+	    }
 	}
 	else
 	{
-		/* on floor - stop */
-		psDroid->pos.z = iMapHeight;
-		psDroid->sMove.iVertSpeed = 0;
-
-		/* reset move state */
+		psDroid->pos.z = iMapHeight;     /* on floor - stop */
+		psDroid->sMove.iVertSpeed = 0;   /* reset move state */
 		psDroid->sMove.Status = MOVEINACTIVE;
-
-		/* conform to terrain */
-		updateDroidOrientation(psDroid);
+		updateDroidOrientation(psDroid); /* conform to terrain */
 	}
 }
-
 
 bool moveCheckDroidMovingAndVisible(void *psObj)
 {

--- a/src/transporter.cpp
+++ b/src/transporter.cpp
@@ -1120,12 +1120,11 @@ bool checkTransporterSpace(DROID const *psTransporter, DROID const *psAssigned, 
 	}
 }
 
-/*returns the space the droid occupies on a transporter based on the body size*/
-int transporterSpaceRequired(const DROID *psDroid)
+int transporterSpaceRequired(const DROID *psDroid) /*returns the space the droid occupies on a transporter based on the body size*/
 {
-	// all droids are the same weight for campaign games.
+	// All droid body sizes are the same weight.
 	// TODO - move this into a droid flag
-	return bMultiPlayer ? psDroid->getBodyStats()->size + 1 : 1;
+	return bMultiPlayer ? psDroid->getBodyStats()->size 1 : 1;
 }
 
 /*sets which list of droids to use for the transporter interface*/

--- a/src/transporter.cpp
+++ b/src/transporter.cpp
@@ -1121,12 +1121,9 @@ bool checkTransporterSpace(DROID const *psTransporter, DROID const *psAssigned, 
 }
 
 int transporterSpaceRequired(const DROID *psDroid) /*returns the space the droid occupies on a transporter based on the body size*/
-{
-	// All droid body sizes are the same weight.
-	// TODO - move this into a droid flag
-	return bMultiPlayer ? psDroid->getBodyStats()->size 1 : 1;
+{	// TODO - move this into a droid flag
+	return bMultiPlayer ? std::max<int>(psDroid->getBodyStats()->size, 1) : 1; // All droid body sizes are the same weight.
 }
-
 /*sets which list of droids to use for the transporter interface*/
 DroidList* transInterfaceDroidList()
 {


### PR DESCRIPTION
* Sets SuperTransport capacity at 10 tanks, irrespective of body size. - As per https://discord.com/channels/684098359874814041/1344814554844237925
* Separates a new added ascend and descend speed for SuperTransports  - only in MP. As per -  https://discord.com/channels/684098359874814041/1345044324517416981

Just need to test this with a few players. A few have been eager previously. ( A Win x64 build is needed )
I expect the values for both ascend and descend speed will need adjusting prior to requesting any sort of MP vote.

