### PR TITLE
Music Manager - Enable or disable all music tracks at once or per Select Album

### DIFF
--- a/src/musicmanager.cpp
+++ b/src/musicmanager.cpp
@@ -45,17 +45,17 @@
 #define W_TRACK_COL_PADDING 10
 #define W_TRACK_CHECKBOX_SIZE 12
 
-#define W_TRACK_COL_TITLE_X 	W_TRACK_COL_PADDING
+#define W_TRACK_COL_TITLE_X 		W_TRACK_COL_PADDING
 #define W_TRACK_COL_TITLE_W		180
 #define W_TRACK_COL_ALBUM_X		(W_TRACK_COL_TITLE_X + W_TRACK_COL_TITLE_W + W_TRACK_COL_PADDING)
 #define W_TRACK_COL_ALBUM_W		130
-#define W_TRACK_CHECKBOX_STARTINGPOS (W_TRACK_COL_ALBUM_X + W_TRACK_COL_ALBUM_W + W_TRACK_COL_PADDING + W_TRACK_COL_PADDING)
+#define W_TRACK_CHECKBOX_STARTINGPOS	(W_TRACK_COL_ALBUM_X + W_TRACK_COL_ALBUM_W + W_TRACK_COL_PADDING + W_TRACK_COL_PADDING)
 
 #define W_TRACK_HEADER_Y		 20
 #define W_TRACK_HEADER_HEIGHT		(20 + (W_TRACK_ROW_PADDING * 2))
 #define W_TRACK_HEADER_COL_IMAGE_SIZE	 16
 
-//#define TL_W_WITH_CHECKBOX		(TL_W + 100) // Width to accommodate checkboxes for; (Campaign, Challenges, Skirmish, Multiplayer) to block toggle all tracks independently.
+#define TL_W_WITH_CHECKBOX		(TL_W + 100) // Width to accommodate checkboxes for; (Campaign, Challenges, Skirmish, Multiplayer) to block toggle all tracks independently.
 #define TL_W				FRONTEND_BOTFORMW
 #define TL_H				400
 #define TL_X				FRONTEND_BOTFORMX
@@ -64,7 +64,6 @@
 
 #define TL_ENTRYW			(FRONTEND_BOTFORMW - 80)
 #define TL_ENTRYH			(25)
-
 #define TL_PREVIEWBOX_Y_SPACING 45
 #define TL_PREVIEWBOX_H		80
 
@@ -101,16 +100,15 @@ static int GetTrackListStartXPos(int ingame)
 	}
 	return TL_X - 10;
 }
-
 // MARK: - MusicManager_CDAudioEventSink declaration
 class MusicManager_CDAudioEventSink : public CDAudioEventSink
 {
 public:
 	virtual ~MusicManager_CDAudioEventSink() override {};
 	virtual void startedPlayingTrack(const std::shared_ptr<const WZ_TRACK>& track) override;
-	virtual void trackEnded(const std::shared_ptr<const WZ_TRACK>& track) override;
+	virtual void trackEnded  (const std::shared_ptr<const WZ_TRACK>& track) override;
 	virtual void musicStopped() override;
-	virtual void musicPaused(const std::shared_ptr<const WZ_TRACK>& track) override;
+	virtual void musicPaused (const std::shared_ptr<const WZ_TRACK>& track) override;
 	virtual void musicResumed(const std::shared_ptr<const WZ_TRACK>& track) override;
 	virtual bool unregisterEventSink() const override { return shouldUnregisterEventSink; }
 public:
@@ -151,11 +149,9 @@ public:
 		});
 	}
 	void display(int xOffset, int yOffset) override;
-	void highlight(W_CONTEXT *psContext) override;
+	void highlight(W_CONTEXT *psContext)   override;
 	void highlightLost() override;
-
 	bool getIsChecked() const { return isChecked; }
-
 	void setCheckboxSize(int size)
 	{
 		cbSize = size;
@@ -177,9 +173,8 @@ void W_MusicModeCheckboxButton::display(int xOffset, int yOffset)
 	int y0 = yOffset + y();
 	bool down = (getState() & (WBUT_DOWN | WBUT_LOCK | WBUT_CLICKLOCK)) != 0;
 	bool isDisabled = (getState() & WBUT_DISABLE) != 0;
-
 	// Calculate checkbox dimensions
-	Vector2i checkboxOffset{0, (height() - cbSize) / 2}; // left-align, center vertically
+	Vector2i checkboxOffset{0, (height() - cbSize) / 2}; // Left-align, center vertically
 	Vector2i checkboxPos{x0 + checkboxOffset.x, y0 + checkboxOffset.y};
 	// Draw checkbox border
 	PIELIGHT notifyBoxAddColor = WZCOL_NOTIFICATION_BOX;
@@ -194,8 +189,7 @@ void W_MusicModeCheckboxButton::display(int xOffset, int yOffset)
 
 	if (down || isChecked)
 	{
-		// Draw checkbox "checked" inside
-		#define CB_INNER_INSET 2
+		#define CB_INNER_INSET 2 // Draw checkbox "checked" inside
 		PIELIGHT checkBoxInsideColor = WZCOL_TEXT_MEDIUM;
 		checkBoxInsideColor.byte.a = (!isDisabled) ? 200 : 60;
 		pie_UniTransBoxFill(checkboxPos.x + CB_INNER_INSET, checkboxPos.y + CB_INNER_INSET, checkboxPos.x + cbSize - (CB_INNER_INSET), checkboxPos.y + cbSize - (CB_INNER_INSET), checkBoxInsideColor);
@@ -213,7 +207,6 @@ void W_MusicModeCheckboxButton::highlightLost()
 	if (!isEnabled()) return;
 	W_BUTTON::highlightLost();
 }
-
 // MARK: - W_TrackRow
 struct TrackRowCache {
 	WzText wzText_Title;
@@ -241,14 +234,12 @@ public:
 	}
 
 	void display(int xOffset, int yOffset) override;
-
 	std::shared_ptr<const WZ_TRACK> getTrack() const {
 		return std::shared_ptr<const WZ_TRACK>(track);
 	};
 
 protected:
 	void geometryChanged() override;
-
 private:
 	std::shared_ptr<const WZ_TRACK> track;
 	std::string album_name;
@@ -260,9 +251,7 @@ void W_TrackRow::initialize(bool ingame)
 {
 	auto album = track->album.lock();
 	album_name = album->title;
-
-	// add music mode checkboxes
-	musicMode = MusicGameMode::MENUS;
+	musicMode = MusicGameMode::MENUS; // Add music mode checkboxes
 	if (ingame)
 	{
 		musicMode = PlayList_GetCurrentMusicMode();
@@ -286,7 +275,6 @@ void W_TrackRow::initialize(bool ingame)
 				pCheckBox->setState(WBUT_DISABLE);
 			}
 		}
-
 		musicModeCheckboxes.push_back(pCheckBox);
 	}
 }
@@ -320,8 +308,7 @@ static WzString truncateTextToMaxWidth(WzString str, iV_fonts fontID, int maxWid
 void W_TrackRow::display(int xOffset, int yOffset)
 {
 	bool isSelectedTrack = (track == selectedTrack);
-	// get track cache
-	std::shared_ptr<TrackRowCache> pCache = nullptr;
+	std::shared_ptr<TrackRowCache> pCache = nullptr; // Get track cache
 	auto it = trackRowsCache.find(this);
 	if (it != trackRowsCache.end())
 	{
@@ -331,7 +318,6 @@ void W_TrackRow::display(int xOffset, int yOffset)
 	{
 		pCache = std::make_shared<TrackRowCache>();
 		trackRowsCache[this] = pCache;
-
 		// Calculate max displayable length for title and album
 		WzString title_truncated = truncateTextToMaxWidth(WzString::fromUtf8(track->title), font_regular, W_TRACK_COL_TITLE_W);
 		WzString album_truncated = truncateTextToMaxWidth(WzString::fromUtf8(album_name), font_regular, W_TRACK_COL_ALBUM_W);
@@ -347,28 +333,20 @@ void W_TrackRow::display(int xOffset, int yOffset)
 
 	if (isSelectedTrack)
 	{
-		// draw selected background
-		pie_UniTransBoxFill(x0, y0, x1, y1, WZCOL_KEYMAP_ACTIVE);
+		pie_UniTransBoxFill(x0, y0, x1, y1, WZCOL_KEYMAP_ACTIVE); // Draw selected background
 	}
-
 	PIELIGHT textColor = WZCOL_TEXT_BRIGHT;
 	if ((musicMode != MusicGameMode::MENUS) && !PlayList_IsTrackEnabledForMusicMode(track, musicMode))
 	{
 		textColor.byte.a = uint8_t(float(textColor.byte.a) * 0.6f);
 	}
-
-	// draw track title
-	Vector2i textBoundingBoxOffset(0, 0);
+	Vector2i textBoundingBoxOffset(0, 0); // Draw track title
 	textBoundingBoxOffset.y = yOffset + y() + (height() - pCache->wzText_Title.lineSize()) / 2;
 	float fy = float(textBoundingBoxOffset.y) /*+ float(W_TRACK_ROW_PADDING)*/ - float(pCache->wzText_Title.aboveBase());
 	pCache->wzText_Title.render(W_TRACK_COL_TITLE_X + x0, static_cast<int>(fy), textColor);
-
-	// draw album name
-	pCache->wzText_Album.render(W_TRACK_COL_ALBUM_X + x0, static_cast<int>(fy), textColor);
-
+	pCache->wzText_Album.render(W_TRACK_COL_ALBUM_X + x0, static_cast<int>(fy), textColor); // Draw album name
 	// Music mode checkboxes are child widgets
 }
-
 // MARK: - "Now Playing" Details Block
 static gfx_api::texture* loadImageToTexture(const std::string& imagePath)
 {
@@ -376,10 +354,8 @@ static gfx_api::texture* loadImageToTexture(const std::string& imagePath)
 	{
 		return nullptr;
 	}
-
 	const std::string& filename = imagePath;
-	const char *extension = strrchr(filename.c_str(), '.'); // determine the filetype
-
+	const char *extension = strrchr(filename.c_str(), '.'); // Determine the filetype
 	if (!extension || strcmp(extension, ".png") != 0)
 	{
 		debug(LOG_ERROR, "Bad image filename: %s", filename.c_str());
@@ -443,11 +419,9 @@ private:
 	gfx_api::texture* pAlbumCoverTexture = nullptr;
 	std::string album_cover_path;
 };
-
 #define WZ_TRACKDETAILS_IMAGE_X	(20 + 210 + 10)
 #define WZ_TRACKDETAILS_IMAGE_Y 10
 #define WZ_TRACKDETAILS_IMAGE_SIZE 60
-
 void TrackDetailsForm::display(int xOffset, int yOffset)
 {
 	IntFormAnimated::display(xOffset, yOffset);
@@ -464,8 +438,7 @@ void TrackDetailsForm::display(int xOffset, int yOffset)
 static void UpdateTrackDetailsBox(TrackDetailsForm *pTrackDetailsBox)
 {
 	ASSERT_OR_RETURN(, pTrackDetailsBox, "pTrackDetailsBox is null");
-	// Add "Now Playing" label
-	if (!psNowPlaying)
+	if (!psNowPlaying) // Add "Now Playing" label
 	{
 		pTrackDetailsBox->attach(psNowPlaying = std::make_shared<W_LABEL>());
 	}
@@ -474,8 +447,7 @@ static void UpdateTrackDetailsBox(TrackDetailsForm *pTrackDetailsBox)
 	psNowPlaying->setString((selectedTrack) ? (WzString::fromUtf8(_("NOW PLAYING")) + ":") : "");
 	psNowPlaying->setTextAlignment(WLAB_ALIGNTOPLEFT);
 	psNowPlaying->setTransparentToMouse(true);
-	// Add Selected Track name
-	if (!psSelectedTrackName)
+	if (!psSelectedTrackName) // Add Selected Track name
 	{
 		pTrackDetailsBox->attach(psSelectedTrackName = std::make_shared<W_LABEL>());
 	}
@@ -484,9 +456,7 @@ static void UpdateTrackDetailsBox(TrackDetailsForm *pTrackDetailsBox)
 	psSelectedTrackName->setString((selectedTrack) ? WzString::fromUtf8(selectedTrack->title) : "");
 	psSelectedTrackName->setTextAlignment(WLAB_ALIGNTOPLEFT);
 	psSelectedTrackName->setTransparentToMouse(true);
-
-	// Add Selected Track author details
-	if (!psSelectedTrackAuthorName)
+	if (!psSelectedTrackAuthorName) // Add Selected Track author details
 	{
 		pTrackDetailsBox->attach(psSelectedTrackAuthorName = std::make_shared<W_LABEL>());
 	}
@@ -638,7 +608,6 @@ static void addTrackList(WIDGET *parent, bool ingame)
 	auto pHeader = std::make_shared<MusicListHeader>();
 	parent->attach(pHeader);
 	pHeader->setGeometry(GetTrackListStartXPos(ingame), W_TRACK_HEADER_Y, TL_ENTRYW, W_TRACK_HEADER_HEIGHT);
-
 	const int headerColY = W_TRACK_ROW_PADDING + (W_TRACK_ROW_PADDING / 2);
 
 	auto title_header = std::make_shared<W_LABEL>();
@@ -689,9 +658,7 @@ static void addTrackList(WIDGET *parent, bool ingame)
 		pTracksScrollableList->addItem(pTrackRow);
 	}
 }
-
 // MARK: - "Now Playing" Details Block
-
 static void closeMusicManager(bool ingame)
 {
 	trackList.clear();
@@ -738,10 +705,8 @@ protected:
 			botForm->setCalcLayout(LAMBDA_CALCLAYOUT_SIMPLE({
 				psWidget->setGeometry(TL_X, 20, TL_W, GetTrackListHeight());
 			}));
-
-			// cancel
-			addMultiBut(*botForm, MM_RETURN, 10, 5, MULTIOP_OKW, MULTIOP_OKH, _("Return To Previous Screen"),
-					IMAGE_RETURN, IMAGE_RETURN_HI, IMAGE_RETURN_HI);
+			addMultiBut(*botForm, MM_RETURN, 10, 5, MULTIOP_OKW, MULTIOP_OKH, _("Return To Previous Screen"), // Cancel
+			IMAGE_RETURN, IMAGE_RETURN_HI, IMAGE_RETURN_HI);
 		}
 		else
 		{
@@ -753,15 +718,12 @@ protected:
 			addButton(botForm, _("Go Back"), MM_GO_BACK, GetTrackListHeight() - 20);
 			addButton(botForm, _("Resume Game"), MM_RETURN, GetTrackListHeight());
 		}
-
 		// get track list
 		trackList = PlayList_GetFullTrackList();
 		selectedTrack = cdAudio_GetCurrentTrack();
-
 		// register for cd audio events
 		musicManagerAudioEventSink = std::make_shared<MusicManager_CDAudioEventSink>();
 		cdAudio_RegisterForEvents(std::static_pointer_cast<CDAudioEventSink>(musicManagerAudioEventSink));
-
 		addTrackList(botForm.get(), ingame);
 		addTrackDetailsBox(this, ingame);
 	}
@@ -769,7 +731,6 @@ protected:
 	static void addButton(const std::shared_ptr<IntFormAnimated> &botForm, const char *text, int id, int y)
 	{
 		W_BUTINIT sButInit;
-
 		sButInit.formID		= botForm->id;
 		sButInit.style		= WBUT_PLAIN | WBUT_TXTCENTRE;
 		sButInit.width		= TL_W;
@@ -790,7 +751,6 @@ protected:
 		sButInit.calcLayout = [y] (WIDGET *psWidget) {
 			psWidget->move(0, y);
 		};
-
 		botForm->attach(std::make_shared<W_BUTTON>(&sButInit));
 	}
 
@@ -830,7 +790,7 @@ bool startInGameMusicManager(InputManager& inputManager)
 
 bool startMusicManager()
 {
-	addBackdrop();	//background image
+	addBackdrop();	//Background image
 	addSideText(FRONTEND_SIDETEXT, TL_SX, 20, _("MUSIC MANAGER"));
 	WIDGET *parent = widgGetFromID(psWScreen, FRONTEND_BACKDROP);
 	return musicManager(parent, false);
@@ -854,7 +814,7 @@ static void perFrameCleanup()
 
 bool runInGameMusicManager(unsigned id, InputManager& inputManager)
 {
-	if (id == MM_RETURN)			// return
+	if (id == MM_RETURN)			// Return
 	{
 		inputManager.contexts().popState();
 		widgDelete(psWScreen, MM_FORM);

--- a/src/musicmanager.cpp
+++ b/src/musicmanager.cpp
@@ -18,7 +18,6 @@
 */
 /*
  * musicmanager.cpp
- *
  * This is the Music Manager screen.
  */
 
@@ -42,7 +41,6 @@
 #include <chrono>
 #include <memory>
 
-
 #define W_TRACK_ROW_PADDING 5
 #define W_TRACK_COL_PADDING 10
 #define W_TRACK_CHECKBOX_SIZE 12
@@ -53,10 +51,11 @@
 #define W_TRACK_COL_ALBUM_W		130
 #define W_TRACK_CHECKBOX_STARTINGPOS (W_TRACK_COL_ALBUM_X + W_TRACK_COL_ALBUM_W + W_TRACK_COL_PADDING + W_TRACK_COL_PADDING)
 
-#define W_TRACK_HEADER_Y		20
-#define W_TRACK_HEADER_HEIGHT	(20 + (W_TRACK_ROW_PADDING * 2))
-#define W_TRACK_HEADER_COL_IMAGE_SIZE	16
+#define W_TRACK_HEADER_Y		 20
+#define W_TRACK_HEADER_HEIGHT		(20 + (W_TRACK_ROW_PADDING * 2))
+#define W_TRACK_HEADER_COL_IMAGE_SIZE	 16
 
+//#define TL_W_WITH_CHECKBOX		(TL_W + 100) // Width to accommodate checkboxes for; (Campaign, Challenges, Skirmish, Multiplayer) to block toggle all tracks independently.
 #define TL_W				FRONTEND_BOTFORMW
 #define TL_H				400
 #define TL_X				FRONTEND_BOTFORMX
@@ -122,26 +121,21 @@ public:
 private:
 	bool shouldUnregisterEventSink = false;
 };
-
 // MARK: - Globals
-
-struct TrackRowCache; // forward-declare
-class W_TrackRow; // foward-declare
+struct TrackRowCache; // Forward-declare
+class W_TrackRow;     // Forward-declare
 static std::unordered_map<W_TrackRow*, std::shared_ptr<TrackRowCache>> trackRowsCache;
 static std::vector<std::shared_ptr<const WZ_TRACK>> trackList;
 static std::shared_ptr<const WZ_TRACK> selectedTrack;
 static std::shared_ptr<MusicManager_CDAudioEventSink> musicManagerAudioEventSink;
-
-// now-playing widgets
+// Now-playing widgets
 static std::shared_ptr<W_LABEL> psNowPlaying = nullptr;
 static std::shared_ptr<W_LABEL> psSelectedTrackName = nullptr;
 static std::shared_ptr<W_LABEL> psSelectedTrackAuthorName = nullptr;
 static std::shared_ptr<W_LABEL> psSelectedTrackAlbumName = nullptr;
 static std::shared_ptr<W_LABEL> psSelectedTrackAlbumDate = nullptr;
 static std::shared_ptr<W_LABEL> psSelectedTrackAlbumDescription = nullptr;
-
 // MARK: - W_MusicModeCheckboxButton
-
 struct W_MusicModeCheckboxButton : public W_BUTTON
 {
 public:
@@ -181,15 +175,13 @@ void W_MusicModeCheckboxButton::display(int xOffset, int yOffset)
 {
 	int x0 = xOffset + x();
 	int y0 = yOffset + y();
-
 	bool down = (getState() & (WBUT_DOWN | WBUT_LOCK | WBUT_CLICKLOCK)) != 0;
 	bool isDisabled = (getState() & WBUT_DISABLE) != 0;
 
-	// calculate checkbox dimensions
+	// Calculate checkbox dimensions
 	Vector2i checkboxOffset{0, (height() - cbSize) / 2}; // left-align, center vertically
 	Vector2i checkboxPos{x0 + checkboxOffset.x, y0 + checkboxOffset.y};
-
-	// draw checkbox border
+	// Draw checkbox border
 	PIELIGHT notifyBoxAddColor = WZCOL_NOTIFICATION_BOX;
 	notifyBoxAddColor.byte.a = uint8_t(float(notifyBoxAddColor.byte.a) * ((!isDisabled) ? 0.7f : 0.2f));
 	pie_UniTransBoxFill(checkboxPos.x, checkboxPos.y, checkboxPos.x + cbSize, checkboxPos.y + cbSize, notifyBoxAddColor);
@@ -202,7 +194,7 @@ void W_MusicModeCheckboxButton::display(int xOffset, int yOffset)
 
 	if (down || isChecked)
 	{
-		// draw checkbox "checked" inside
+		// Draw checkbox "checked" inside
 		#define CB_INNER_INSET 2
 		PIELIGHT checkBoxInsideColor = WZCOL_TEXT_MEDIUM;
 		checkBoxInsideColor.byte.a = (!isDisabled) ? 200 : 60;
@@ -223,7 +215,6 @@ void W_MusicModeCheckboxButton::highlightLost()
 }
 
 // MARK: - W_TrackRow
-
 struct TrackRowCache {
 	WzText wzText_Title;
 	WzText wzText_Album;
@@ -329,7 +320,6 @@ static WzString truncateTextToMaxWidth(WzString str, iV_fonts fontID, int maxWid
 void W_TrackRow::display(int xOffset, int yOffset)
 {
 	bool isSelectedTrack = (track == selectedTrack);
-
 	// get track cache
 	std::shared_ptr<TrackRowCache> pCache = nullptr;
 	auto it = trackRowsCache.find(this);
@@ -342,7 +332,7 @@ void W_TrackRow::display(int xOffset, int yOffset)
 		pCache = std::make_shared<TrackRowCache>();
 		trackRowsCache[this] = pCache;
 
-		// calculate max displayable length for title and album
+		// Calculate max displayable length for title and album
 		WzString title_truncated = truncateTextToMaxWidth(WzString::fromUtf8(track->title), font_regular, W_TRACK_COL_TITLE_W);
 		WzString album_truncated = truncateTextToMaxWidth(WzString::fromUtf8(album_name), font_regular, W_TRACK_COL_ALBUM_W);
 		pCache->wzText_Title.setText(title_truncated, font_regular);
@@ -380,7 +370,6 @@ void W_TrackRow::display(int xOffset, int yOffset)
 }
 
 // MARK: - "Now Playing" Details Block
-
 static gfx_api::texture* loadImageToTexture(const std::string& imagePath)
 {
 	if (imagePath.empty())
@@ -432,8 +421,7 @@ public:
 
 		if (imagePath == album_cover_path)
 		{
-			// already loaded
-			return true;
+			return true; // Already loaded
 		}
 
 		if (pAlbumCoverTexture)
@@ -463,13 +451,10 @@ private:
 void TrackDetailsForm::display(int xOffset, int yOffset)
 {
 	IntFormAnimated::display(xOffset, yOffset);
-
 	if (disableChildren) { return; }
-
-	// now draw the album cover, if present
+	// Now draw the album cover, if present
 	int imageLeft = x() + xOffset + WZ_TRACKDETAILS_IMAGE_X;
-	int imageTop = y() + yOffset + WZ_TRACKDETAILS_IMAGE_Y;
-
+	int imageTop  = y() + yOffset + WZ_TRACKDETAILS_IMAGE_Y;
 	if (pAlbumCoverTexture)
 	{
 		iV_DrawImageAnisotropic(*pAlbumCoverTexture, Vector2i(imageLeft, imageTop), Vector2f(0,0), Vector2f(WZ_TRACKDETAILS_IMAGE_SIZE, WZ_TRACKDETAILS_IMAGE_SIZE), 0.f, WZCOL_WHITE);
@@ -479,7 +464,6 @@ void TrackDetailsForm::display(int xOffset, int yOffset)
 static void UpdateTrackDetailsBox(TrackDetailsForm *pTrackDetailsBox)
 {
 	ASSERT_OR_RETURN(, pTrackDetailsBox, "pTrackDetailsBox is null");
-
 	// Add "Now Playing" label
 	if (!psNowPlaying)
 	{
@@ -490,7 +474,6 @@ static void UpdateTrackDetailsBox(TrackDetailsForm *pTrackDetailsBox)
 	psNowPlaying->setString((selectedTrack) ? (WzString::fromUtf8(_("NOW PLAYING")) + ":") : "");
 	psNowPlaying->setTextAlignment(WLAB_ALIGNTOPLEFT);
 	psNowPlaying->setTransparentToMouse(true);
-
 	// Add Selected Track name
 	if (!psSelectedTrackName)
 	{
@@ -512,8 +495,7 @@ static void UpdateTrackDetailsBox(TrackDetailsForm *pTrackDetailsBox)
 	psSelectedTrackAuthorName->setString((selectedTrack) ? WzString::fromUtf8(selectedTrack->author) : "");
 	psSelectedTrackAuthorName->setTextAlignment(WLAB_ALIGNTOPLEFT);
 	psSelectedTrackAuthorName->setTransparentToMouse(true);
-
-	// album info xPosStart
+	// Album info xPosStart
 	int albumInfoXPosStart = psNowPlaying->x() + psNowPlaying->width() + 10 + WZ_TRACKDETAILS_IMAGE_SIZE + 10;
 	int maxWidthOfAlbumLabel = TL_W - albumInfoXPosStart - 20;
 	std::shared_ptr<const WZ_ALBUM> pAlbum = (selectedTrack) ? selectedTrack->album.lock() : nullptr;
@@ -577,9 +559,7 @@ static void addTrackDetailsBox(WIDGET *parent, bool ingame)
 
 	UpdateTrackDetailsBox(pTrackDetailsBox.get());
 }
-
 // MARK: - Track List
-
 class MusicListHeader : public W_FORM
 {
 public:
@@ -599,8 +579,7 @@ void MusicListHeader::display(int xOffset, int yOffset)
 	int y1 = y0 + height() - 1;
 	iV_TransBoxFill(x0, y0, x1, y1);
 	iV_Line(x0, y1, x1, y1, WZCOL_MENU_SEPARATOR);
-
-	// column lines
+	// Column lines
 	iV_Line(x0 + W_TRACK_COL_TITLE_X + W_TRACK_COL_TITLE_W, y0 + 5, x0 + W_TRACK_COL_TITLE_X + W_TRACK_COL_TITLE_W, y1 - 5, WZCOL_MENU_SEPARATOR);
 	iV_Line(x0 + W_TRACK_COL_ALBUM_X + W_TRACK_COL_ALBUM_W, y0 + 5, x0 + W_TRACK_COL_ALBUM_X + W_TRACK_COL_ALBUM_W, y1 - 5, WZCOL_MENU_SEPARATOR);
 }
@@ -749,8 +728,7 @@ protected:
 		this->setCalcLayout(LAMBDA_CALCLAYOUT_SIMPLE({
 			psWidget->setGeometry(0, 0, pie_GetVideoBufferWidth(), pie_GetVideoBufferHeight());
 		}));
-
-		// draws the background of the form
+		// Draws the background of the form
 		auto botForm = std::make_shared<IntFormAnimated>();
 		this->attach(botForm);
 		botForm->id = MM_FORM + 1;
@@ -916,9 +894,7 @@ bool runMusicManager()
 
 	return true;
 }
-
 // MARK: - CD Audio Event Sink Implementation
-
 static void CDAudioEvent_UpdateCurrentTrack(const std::shared_ptr<const WZ_TRACK>& track)
 {
 	if (selectedTrack == track)
@@ -940,7 +916,7 @@ void MusicManager_CDAudioEventSink::startedPlayingTrack(const std::shared_ptr<co
 }
 void MusicManager_CDAudioEventSink::trackEnded(const std::shared_ptr<const WZ_TRACK>& track)
 {
-	// currently a no-op
+	// Currently a no-op
 }
 
 void MusicManager_CDAudioEventSink::musicStopped()


### PR DESCRIPTION
(enables or disables all music tracks at once)

Select Album added under Album, so can do same on Album level.

Worked out against the smallest res of 640x480 so it will fit with spare pixels on both sides.
Took me a few attempts to get the maths right. Concept is to keep close as possible to current setup.

Idea is to look like this conceptually, adding a selection box to toggle all or no tracks with single button per mode:
```
+--------------------------- Music Manager ---------------------------+
| Title                | Album             | C | Ch | S | M |          |
|                      | Select Album  [ ] |[X]|[ ]|[ ]|[ ]|          |
|----------------------|-------------------|---|---|---|---|----------|
| Track Title        | Album name...         | [X] [ ] [ ] [ ]          |
```

Next I'll need to test to see how it will actually look... as I hope.
Both for menu and in-game.
Would make it easier to instead of manually click one by one on each track, more so if and when more albums are added.