### PR TITLE
Fix premature game loss with mp end conditions

### DIFF
--- a/data/mp/multiplay/script/rules/endconditions.js
+++ b/data/mp/multiplay/script/rules/endconditions.js
@@ -53,7 +53,9 @@ class Player
 
 	hasOnlyConstructor()
 	{
-		if (countDroid(DROID_ANY, this.playNum) - countDroid(DROID_CONSTRUCT, this.playNum) === 0)
+		const truckCnt = countDroid(DROID_CONSTRUCT, this.playNum);
+		const unitCnt = countDroid(DROID_ANY, this.playNum);
+		if (truckCnt > 0 && unitCnt - truckCnt === 0)
 		{
 			return true;
 		}


### PR DESCRIPTION
Should be just enough to stop premature losses when in teamed games. Would be good if someone wants to play a few games with the this change.

To reproduce, start a Rush teamed skirmish match and destroy all of your team's derricks, combat units (aside from yours), trucks, and factories + cyb factories. You will then be the last remaining player alive in your team and die regardless of if you have 100 units or whatever. `hasOnlyConstructors()` erroneously returned true if a player has zero units remaining since `0(totalUnits) - 0(trucks) === 0`.

What's going on in Arc's video is summed up as completing the final if statement in `canPlay()`.
1. I have no factories. True.
2. I have only trucks cause I have no units. True.
3. I can't reach any oil derricks cause I have no trucks. True.
4. Can I play? No, returns false.

Closes #4251
Closes #2530 