### PR TITLE
Added velocity gain to droid particles upon destruction

### DIFF
--- a/src/component.cpp
+++ b/src/component.cpp
@@ -949,7 +949,7 @@ void displayComponentObject(DROID *psDroid, const glm::mat4 &viewMatrix, const g
 }
 
 
-void destroyFXDroid(DROID *psDroid, unsigned impactTime)
+void destroyFXDroid(DROID *psDroid, unsigned impactTime, Vector3f &velocity)
 {
 	for (int i = 0; i < 5; ++i)
 	{
@@ -1011,12 +1011,12 @@ void destroyFXDroid(DROID *psDroid, unsigned impactTime)
 		}
 		// Tell the effect system that it needs to use this player's color for the next effect
 		SetEffectForPlayer(psDroid->player);
-		addEffect(&pos, EFFECT_GRAVITON, GRAVITON_TYPE_EMITTING_DR, true, psImd->displayModel(), getPlayerColour(psDroid->player), impactTime);
+		addEffect(&pos, EFFECT_GRAVITON, GRAVITON_TYPE_EMITTING_DR, true, psImd->displayModel(), getPlayerColour(psDroid->player), impactTime, nullptr, &velocity);
 	}
 }
 
 
-void	compPersonToBits(DROID *psDroid)
+void	compPersonToBits(DROID *psDroid, Vector3f &velocity)
 {
 	Vector3i position;	//,rotation,velocity;
 	iIMDBaseShape	*headImd, *legsImd, *armImd, *bodyImd;
@@ -1052,10 +1052,10 @@ void	compPersonToBits(DROID *psDroid)
 	/* Tell about player colour */
 	col = getPlayerColour(psDroid->player);
 
-	addEffect(&position, EFFECT_GRAVITON, GRAVITON_TYPE_GIBLET, true, headImd->displayModel(), col, gameTime - deltaGameTime + 1);
-	addEffect(&position, EFFECT_GRAVITON, GRAVITON_TYPE_GIBLET, true, legsImd->displayModel(), col, gameTime - deltaGameTime + 1);
-	addEffect(&position, EFFECT_GRAVITON, GRAVITON_TYPE_GIBLET, true, armImd->displayModel(), col, gameTime - deltaGameTime + 1);
-	addEffect(&position, EFFECT_GRAVITON, GRAVITON_TYPE_GIBLET, true, bodyImd->displayModel(), col, gameTime - deltaGameTime + 1);
+	addEffect(&position, EFFECT_GRAVITON, GRAVITON_TYPE_GIBLET, true, headImd->displayModel(), col, gameTime - deltaGameTime + 1, nullptr, &velocity);
+	addEffect(&position, EFFECT_GRAVITON, GRAVITON_TYPE_GIBLET, true, legsImd->displayModel(), col, gameTime - deltaGameTime + 1, nullptr, &velocity);
+	addEffect(&position, EFFECT_GRAVITON, GRAVITON_TYPE_GIBLET, true, armImd->displayModel(), col, gameTime - deltaGameTime + 1, nullptr, &velocity);
+	addEffect(&position, EFFECT_GRAVITON, GRAVITON_TYPE_GIBLET, true, bodyImd->displayModel(), col, gameTime - deltaGameTime + 1, nullptr, &velocity);
 }
 
 

--- a/src/component.h
+++ b/src/component.h
@@ -72,10 +72,10 @@ void displayComponentButtonTemplate(const DROID_TEMPLATE *psTemplate, const Vect
 void displayComponentButtonObject(const DROID *psDroid, const Vector3i *Rotation, const Vector3i *Position, int scale);
 void displayComponentObject(DROID *psDroid, const glm::mat4 &viewMatrix, const glm::mat4 &perspectiveViewMatrix);
 
-void compPersonToBits(DROID *psDroid);
+void compPersonToBits(DROID *psDroid, Vector3f &velocity);
 
 SDWORD rescaleButtonObject(SDWORD radius, SDWORD baseScale, SDWORD baseRadius);
-void destroyFXDroid(DROID *psDroid, unsigned impactTime);
+void destroyFXDroid(DROID *psDroid, unsigned impactTime, Vector3f &velocity);
 
 void drawMuzzleFlash(WEAPON sWeap, const iIMDShape *weaponImd, const iIMDShape *flashImd, PIELIGHT buildingBrightness, int pieFlag, int pieFlagData, glm::mat4 modelMatrix, const glm::mat4 &viewMatrix, float heightAboveTerrain, UBYTE colour = 0);
 

--- a/src/droid.cpp
+++ b/src/droid.cpp
@@ -640,9 +640,13 @@ static void removeDroidFX(DROID *psDel, unsigned impactTime)
 		return;
 	}
 
+	auto adiff = psDel->rot.direction - psDel->sMove.moveDir;
+	auto move = iCosR(adiff, psDel->sMove.speed);
+	Vector3f velocity(iSinR(psDel->rot.direction, move), 0.f, iCosR(psDel->rot.direction, move));
+
 	if (psDel->animationEvent != ANIM_EVENT_DYING)
 	{
-		compPersonToBits(psDel);
+		compPersonToBits(psDel, velocity);
 	}
 
 	/* if baba then squish */
@@ -653,7 +657,7 @@ static void removeDroidFX(DROID *psDel, unsigned impactTime)
 	}
 	else
 	{
-		destroyFXDroid(psDel, impactTime);
+		destroyFXDroid(psDel, impactTime, velocity);
 		pos.x = psDel->pos.x;
 		pos.z = psDel->pos.y;
 		pos.y = psDel->pos.z;

--- a/src/droid.cpp
+++ b/src/droid.cpp
@@ -78,6 +78,7 @@
 #define DEFAULT_RECOIL_TIME	(GAME_TICKS_PER_SEC/4)
 #define	DROID_DAMAGE_SPREAD	(16 - rand()%32)
 #define	DROID_REPAIR_SPREAD	(20 - rand()%40)
+#define DROID_EXPLOSION_VELOCITY_FACTOR 0.9f
 
 // store the experience of recently recycled droids
 static std::priority_queue<int> recycled_experience[MAX_PLAYERS];
@@ -643,6 +644,7 @@ static void removeDroidFX(DROID *psDel, unsigned impactTime)
 	auto adiff = psDel->rot.direction - psDel->sMove.moveDir;
 	auto move = iCosR(adiff, psDel->sMove.speed);
 	Vector3f velocity(iSinR(psDel->rot.direction, move), 0.f, iCosR(psDel->rot.direction, move));
+	velocity *= DROID_EXPLOSION_VELOCITY_FACTOR;
 
 	if (psDel->animationEvent != ANIM_EVENT_DYING)
 	{

--- a/src/effects.cpp
+++ b/src/effects.cpp
@@ -1047,6 +1047,10 @@ static bool updateGraviton(EFFECT *psEffect, LightingData& lightData)
 				/* Half it's velocity */
 				psEffect->velocity.y /= (float)(-2); // only y gets flipped
 
+				/* Also decrease other velocities */
+				psEffect->velocity.x *= 0.5f;
+				psEffect->velocity.z *= 0.5f;
+
 				/* Set it at ground level - may have gone through */
 				psEffect->position.y = (float)groundHeight;
 			}
@@ -1878,8 +1882,8 @@ void	effectSetupGraviton(EFFECT& effect)
 	switch (effect.type)
 	{
 	case GRAVITON_TYPE_GIBLET:
-		effect.velocity.x = GIBLET_INIT_VEL_X;
-		effect.velocity.z = GIBLET_INIT_VEL_Z;
+		effect.velocity.x += GIBLET_INIT_VEL_X;
+		effect.velocity.z += GIBLET_INIT_VEL_Z;
 		effect.velocity.y = GIBLET_INIT_VEL_Y;
 		break;
 	case GRAVITON_TYPE_EMITTING_ST:
@@ -1889,8 +1893,8 @@ void	effectSetupGraviton(EFFECT& effect)
 		effect.size = (UWORD)(120 + rand() % 30);
 		break;
 	case GRAVITON_TYPE_EMITTING_DR:
-		effect.velocity.x = GRAVITON_INIT_VEL_X / 2;
-		effect.velocity.z = GRAVITON_INIT_VEL_Z / 2;
+		effect.velocity.x += GRAVITON_INIT_VEL_X / 2;
+		effect.velocity.z += GRAVITON_INIT_VEL_Z / 2;
 		effect.velocity.y = GRAVITON_INIT_VEL_Y;
 		break;
 	default:


### PR DESCRIPTION
It has always confused me that when flying units are destroyed while moving their particles never inherit their current velocity. This PR fixes that.

https://youtu.be/ZQmodpo6_xk