### PR TITLE
[GitHub Actions] Tweak Fedora m32 Dockerfile

### DIFF
--- a/docker/fedora-latest-m32/Dockerfile
+++ b/docker/fedora-latest-m32/Dockerfile
@@ -1,4 +1,5 @@
-FROM fedora:latest
+#FROM fedora:latest
+FROM fedora:41
 
 RUN cat /etc/fedora-release
 


### PR DESCRIPTION
Pin to fedora:41 due to lack of SDL2-devel.i686 on 42