### PR TITLE
Fix naval damage, production and camera

### DIFF
--- a/data/mp/stats/propulsion.json
+++ b/data/mp/stats/propulsion.json
@@ -66,6 +66,7 @@
 	"Naval": {
 		"buildPoints": 150,
 		"buildPower": 150,
+		"designable": 1,
 		"hitpointPctOfBody": 300,
 		"id": "Naval",
 		"model": "prhnaval1.pie",

--- a/data/mp/stats/weaponmodifier.json
+++ b/data/mp/stats/weaponmodifier.json
@@ -4,6 +4,7 @@
 		"Hover": 120,
 		"Legged": 65,
 		"Lift": 40,
+		"Propellor": 105,
 		"Tracked": 105,
 		"Wheeled": 125
 	},
@@ -12,6 +13,7 @@
 		"Hover": 110,
 		"Legged": 150,
 		"Lift": 60,
+		"Propellor": 50,
 		"Tracked": 40,
 		"Wheeled": 100
 	},
@@ -20,6 +22,7 @@
 		"Hover": 90,
 		"Legged": 30,
 		"Lift": 80,
+		"Propellor": 120,
 		"Tracked": 120,
 		"Wheeled": 130
 	},
@@ -28,6 +31,7 @@
 		"Hover": 110,
 		"Legged": 130,
 		"Lift": 25,
+		"Propellor": 65,
 		"Tracked": 30,
 		"Wheeled": 90
 	},
@@ -36,6 +40,7 @@
 		"Hover": 20,
 		"Legged": 30,
 		"Lift": 30,
+		"Propellor": 50,
 		"Tracked": 50,
 		"Wheeled": 30
 	},
@@ -44,6 +49,7 @@
 		"Hover": 130,
 		"Legged": 130,
 		"Lift": 25,
+		"Propellor": 90,
 		"Tracked": 90,
 		"Wheeled": 110
 	}

--- a/src/display3d.cpp
+++ b/src/display3d.cpp
@@ -1240,7 +1240,7 @@ static int calcAverageTerrainHeight(int tileX, int tileZ)
 				/* Get a pointer to the tile at this location */
 				MAPTILE *psTile = mapTile(tileX + j, tileZ + i);
 
-				result += psTile->height;
+				result += std::max(psTile->height, psTile->waterLevel);
 				numTilesAveraged++;
 			}
 		}

--- a/src/structure.cpp
+++ b/src/structure.cpp
@@ -2396,12 +2396,12 @@ void clearCommandDroidFactory(DROID *psDroid)
 }
 
 /* Check that a tile is vacant for a droid to be placed */
-static bool structClearTile(UWORD x, UWORD y)
+static bool structClearTile(UWORD x, UWORD y, PROPULSION_TYPE propulsion)
 {
 	UDWORD	player;
 
 	/* Check for a structure */
-	if (fpathBlockingTile(x, y, PROPULSION_TYPE_WHEELED))
+	if (fpathBlockingTile(x, y, propulsion))
 	{
 		debug(LOG_NEVER, "failed - blocked");
 		return false;
@@ -2432,7 +2432,7 @@ static bool comparePlacementPoints(Vector2i a, Vector2i b)
 }
 
 /* Find a location near to a structure to start the droid of */
-bool placeDroid(STRUCTURE *psStructure, UDWORD *droidX, UDWORD *droidY)
+bool placeDroid(STRUCTURE *psStructure, const DROID_TEMPLATE * psTempl, UDWORD *droidX, UDWORD *droidY)
 {
 	CHECK_STRUCTURE(psStructure);
 
@@ -2479,7 +2479,7 @@ bool placeDroid(STRUCTURE *psStructure, UDWORD *droidX, UDWORD *droidY)
 	{
 		for (int x = xmin; x <= xmax; ++x)
 		{
-			if (structClearTile(x, y))
+			if (structClearTile(x, y, psTempl->getPropulsionStats()->propulsionType))
 			{
 				tiles.push_back(Vector2i(12 * x - sx, 12 * y - sy));
 			}
@@ -2572,7 +2572,7 @@ static bool structPlaceDroid(STRUCTURE *psStructure, DROID_TEMPLATE *psTempl, DR
 
 	CHECK_STRUCTURE(psStructure);
 
-	placed = placeDroid(psStructure, &x, &y);
+	placed = placeDroid(psStructure, psTempl, &x, &y);
 
 	if (placed)
 	{

--- a/src/structure.h
+++ b/src/structure.h
@@ -155,7 +155,7 @@ void resetFactoryNumFlag();
 STRUCTURE_STATS *structGetDemolishStat();
 
 /*find a location near to the factory to start the droid of*/
-bool placeDroid(STRUCTURE *psStructure, UDWORD *droidX, UDWORD *droidY);
+bool placeDroid(STRUCTURE *psStructure, const DROID_TEMPLATE * psTempl, UDWORD *droidX, UDWORD *droidY);
 
 //Set the factory secondary orders to a droid
 void setFactorySecondaryState(DROID *psDroid, STRUCTURE *psStructure);


### PR DESCRIPTION
Changes:
- Add weapon modifiers to naval propulsion
- Make factory place naval droid on nearby water
- Use max of land height and sealevel to calculate camera height

(For balance, naval component still can't be researched)