### PR TITLE
add underRepair cache for droid object

### DIFF
--- a/src/droid.cpp
+++ b/src/droid.cpp
@@ -2880,13 +2880,26 @@ bool droidUnderRepair(const DROID *psDroid)
 		//look thru the list of players droids to mark repairing ones
 		for (const DROID *psCurr : apsDroidLists[psDroid->player])
 		{
-			if ((psCurr->droidType == DROID_REPAIR || psCurr->droidType ==
-				 DROID_CYBORG_REPAIR) && psCurr->action ==
-				DACTION_DROIDREPAIR && psCurr->order.psObj != nullptr &&
-				psCurr->order.psObj->type == OBJ_DROID)
+			if ((psCurr->droidType == DROID_REPAIR ||
+				psCurr->droidType == DROID_CYBORG_REPAIR) &&
+				psCurr->action == DACTION_DROIDREPAIR)
 			{
-				//droid must be damaged
-				DROID *psDroid2 = (DROID *)(psCurr->order.psObj);
+				for (int i = 0; i < MAX_WEAPONS; i++)
+				{
+					if (psCurr->psActionTarget[i] == nullptr ||
+						psCurr->psActionTarget[i]->type != OBJ_DROID) continue;
+					DROID *psDroid2 = (DROID *)(psCurr->psActionTarget[i]);
+					psDroid2->underRepair = psDroid2->isDamaged();
+				}
+			}
+		}
+		for (const STRUCTURE *psCurr : apsStructLists[psDroid->player])
+		{
+			if (psCurr->pStructureType->type == REF_REPAIR_FACILITY)
+			{
+				if (psCurr->pFunctionality->repairFacility.psObj == nullptr ||
+					psCurr->pFunctionality->repairFacility.psObj->type != OBJ_DROID) continue;
+				DROID *psDroid2 = (DROID *)(psCurr->pFunctionality->repairFacility.psObj);
 				psDroid2->underRepair = psDroid2->isDamaged();
 			}
 		}

--- a/src/droid.cpp
+++ b/src/droid.cpp
@@ -2867,32 +2867,31 @@ bool electronicDroid(const DROID *psDroid)
 /*checks to see if the droid is currently being repaired by another*/
 bool droidUnderRepair(const DROID *psDroid)
 {
+	static UDWORD lastCall = 0;
 	CHECK_DROID(psDroid);
 
-	//droid must be damaged
-	if (psDroid->isDamaged())
+	if (lastCall != gameTime)
 	{
-		//look thru the list of players droids to see if any are repairing this droid
+		lastCall = gameTime;
+		for (DROID *psCurr : apsDroidLists[psDroid->player])
+		{
+			psCurr->underRepair = 0;
+		}
+		//look thru the list of players droids to mark repairing ones
 		for (const DROID *psCurr : apsDroidLists[psDroid->player])
 		{
 			if ((psCurr->droidType == DROID_REPAIR || psCurr->droidType ==
 				 DROID_CYBORG_REPAIR) && psCurr->action ==
-				DACTION_DROIDREPAIR && psCurr->order.psObj == psDroid)
+				DACTION_DROIDREPAIR && psCurr->order.psObj != nullptr &&
+				psCurr->order.psObj->type == OBJ_DROID)
 			{
-				BASE_OBJECT *psLeader = nullptr;
-				if (hasCommander(psCurr))
-				{
-					psLeader = (BASE_OBJECT *)psCurr->psGroup->psCommander;
-				}
-				if (psLeader && psLeader->id == psDroid->id)
-				{
-					continue;
-				}
-				return true;
+				//droid must be damaged
+				DROID *psDroid2 = (DROID *)(psCurr->order.psObj);
+				psDroid2->underRepair = psDroid2->isDamaged();
 			}
 		}
 	}
-	return false;
+	return psDroid->underRepair;
 }
 
 //count how many Command Droids exist in the world at any one moment

--- a/src/droiddef.h
+++ b/src/droiddef.h
@@ -196,6 +196,7 @@ struct DROID : public BASE_OBJECT
 	/* anim data */
 	SDWORD          iAudioID;
 	int32_t			heightAboveMap;					///< Current calculated height above the terrain (set for VTOL-propulsion units)
+	uint8_t         underRepair;
 };
 
 #endif // __INCLUDED_DROIDDEF_H__


### PR DESCRIPTION
#4290

It improves performance for Energy Bars Display

Test: 2000 Machinegunner Cyborg on Sk-UrbanChasm
To test worst case, all droid are damaged and no repair
Reveal All by debug, no movement to avoid pathfind
Average density: 5 droids / tile

System: Ubuntu 24.04
CPU: 2.5GHz (E5-2670v2, produced in 2013)
Memory: 800MHz (DDR3)

```
Before cache:
Energy Bars Display     FPS         FPS(moving,selected)    FPS(moving,unselected)
Off                     12Hz        25Hz                    6Hz                    
Droid only              75Hz        25Hz                    25Hz
All                     75Hz        25Hz                    25Hz

After:
Energy Bars Display     FPS         FPS(moving,selected)    FPS(moving,unselected)
Off                     75Hz        25Hz                    25Hz
Droid only              75Hz        25Hz                    25Hz
All                     75Hz        25Hz                    25Hz
```