### PR TITLE
Add underRepair state / counter to DROID object

### DIFF
--- a/src/droid.h
+++ b/src/droid.h
@@ -428,6 +428,9 @@ static inline DROID const *castDroid(SIMPLE_OBJECT const *psObject)
 	return isDroid(psObject) ? (DROID const *)psObject : (DROID const *)nullptr;
 }
 
+void droidRepairStarted(DROID *psDroid, BASE_OBJECT const *psRepairer);
+void droidRepairStopped(DROID *psDroid, BASE_OBJECT const *psFormerRepairer);
+
 /** \brief sends droid to delivery point, or back to commander. psRepairFac maybe nullptr when
  * repairs were made by a mobile repair turret
  */

--- a/src/droiddef.h
+++ b/src/droiddef.h
@@ -196,6 +196,8 @@ struct DROID : public BASE_OBJECT
 	/* anim data */
 	SDWORD          iAudioID;
 	int32_t			heightAboveMap;					///< Current calculated height above the terrain (set for VTOL-propulsion units)
+	/* repair data */
+	uint16_t		underRepair;					///< Number of other droids / structures currently repairing this unit (does not include self-repair tech)
 };
 
 #endif // __INCLUDED_DROIDDEF_H__

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -5685,6 +5685,14 @@ static bool loadSaveDroid(const char *pFileName, PerPlayerDroidLists& ppsCurrent
 			psDroid->rot.pitch = 0;
 		}
 
+		auto tmpUnderRepair = ini.value("underRepair").toUInt();
+		if (tmpUnderRepair > std::numeric_limits<decltype(psDroid->underRepair)>::max())
+		{
+			debug(LOG_INFO, "Out of bounds underRepair value: %u", tmpUnderRepair);
+			tmpUnderRepair = std::numeric_limits<decltype(psDroid->underRepair)>::max();
+		}
+		psDroid->underRepair = static_cast<uint16_t>(tmpUnderRepair);
+
 		// recreate formation if present
 		auto formationInfo = ini.value("formation").jsonValue();
 		if (formationInfo.is_object())
@@ -5887,6 +5895,8 @@ static nlohmann::json writeDroid(const DROID *psCurr, bool onMission, int &count
 		formationObj["y"] = psCurr->sMove.psFormation->y;
 		droidObj["formation"] = std::move(formationObj);
 	}
+
+	droidObj["underRepair"] = psCurr->underRepair;
 
 	droidObj["onMission"] = onMission;
 	return droidObj;

--- a/src/structure.cpp
+++ b/src/structure.cpp
@@ -3656,7 +3656,7 @@ void _syncDebugStructure(const char *function, STRUCTURE const *psStruct, char c
 	int ref = 0;
 	int refChr = ' ';
 
-	// Print what the structure is producing, too.
+	// Print what the structure is producing (or repairing), too.
 	switch (psStruct->pStructureType->type)
 	{
 	case REF_RESEARCH:
@@ -3673,6 +3673,13 @@ void _syncDebugStructure(const char *function, STRUCTURE const *psStruct, char c
 		{
 			ref = psStruct->pFunctionality->factory.psSubject->multiPlayerID;
 			refChr = 'p';
+		}
+		break;
+	case REF_REPAIR_FACILITY:
+		if (psStruct->pFunctionality->repairFacility.psObj != nullptr)
+		{
+			ref = (int)psStruct->pFunctionality->repairFacility.psObj->id;
+			refChr = '+';
 		}
 		break;
 	default:

--- a/src/structure.cpp
+++ b/src/structure.cpp
@@ -3660,7 +3660,7 @@ void _syncDebugStructure(const char *function, STRUCTURE const *psStruct, char c
 	switch (psStruct->pStructureType->type)
 	{
 	case REF_RESEARCH:
-		if (psStruct->pFunctionality->researchFacility.psSubject != nullptr)
+		if (psStruct->pFunctionality && psStruct->pFunctionality->researchFacility.psSubject != nullptr)
 		{
 			ref = psStruct->pFunctionality->researchFacility.psSubject->ref;
 			refChr = 'r';
@@ -3669,14 +3669,14 @@ void _syncDebugStructure(const char *function, STRUCTURE const *psStruct, char c
 	case REF_FACTORY:
 	case REF_CYBORG_FACTORY:
 	case REF_VTOL_FACTORY:
-		if (psStruct->pFunctionality->factory.psSubject != nullptr)
+		if (psStruct->pFunctionality && psStruct->pFunctionality->factory.psSubject != nullptr)
 		{
 			ref = psStruct->pFunctionality->factory.psSubject->multiPlayerID;
 			refChr = 'p';
 		}
 		break;
 	case REF_REPAIR_FACILITY:
-		if (psStruct->pFunctionality->repairFacility.psObj != nullptr)
+		if (psStruct->pFunctionality && psStruct->pFunctionality->repairFacility.psObj != nullptr)
 		{
 			ref = (int)psStruct->pFunctionality->repairFacility.psObj->id;
 			refChr = '+';


### PR DESCRIPTION
Fixes `droidUnderRepair()` performance, and can now be used in game-state-related calculations

Fixes: #4290 