### PR TITLE
netplay/gns: Fix `recvImpl` behavior for large messages

### DIFF
--- a/lib/netplay/gns/gns_client_connection.h
+++ b/lib/netplay/gns/gns_client_connection.h
@@ -87,6 +87,7 @@ private:
 	ISteamNetworkingSockets* networkInterface_ = nullptr;
 	HSteamNetConnection conn_ = k_HSteamNetConnection_Invalid;
 	std::queue<SteamNetworkingMessage_t*> pendingMessagesToRead_;
+	size_t currentMsgReadPos_ = 0;
 	bool useNagle_ = true;
 	GNSConnectionPollGroup* pollGroup_ = nullptr;
 };


### PR DESCRIPTION
Keep track of the current read position offset into the current message (top of the `pendingMessagesToRead_` queue) and read as much, as possible so to not exceed `maxSize` byte count.

If there are still some bytes left to read from the current message, then the next `recvImpl` operation will:
1. Read them, consuming the message completely
2. Reset the read position offset to 0 for the next message
3. Dispose of the message and move on to the next one