### PR TITLE
Transporter not to stack move.cpp (Wanjia_1 's code)

### DIFF
--- a/src/move.cpp
+++ b/src/move.cpp
@@ -1333,12 +1333,14 @@ static Vector2i moveGetObstacleVector(DROID *psDroid, Vector2i dest)
 		}
 
 		// vtol droids only avoid each other and don't affect ground droids
-		if (psDroid->isVtol() != psObstacle->isVtol())
+		if ((psDroid->isVtol() != psObstacle->isVtol()) ||
+			(bMultiPlayer && psDroid->isTransporter() && psDroid->sMove.speed < TILE_UNITS))
 		{
 			continue;
 		}
 
-		if (psObstacle->isTransporter() ||
+		if ((psObstacle->isTransporter() &&
+			(!bMultiPlayer || !psDroid->isTransporter())) ||
 		    (psObstacle->droidType == DROID_PERSON &&
 		     psObstacle->player != psDroid->player))
 		{
@@ -1427,7 +1429,7 @@ static uint16_t moveGetDirection(DROID *psDroid)
 	Vector2i dest = target - src;
 
 	// Transporters don't need to avoid obstacles, but everyone else should
-	if (!psDroid->isTransporter())
+	if (!psDroid->isTransporter() || (bMultiPlayer && psDroid->order.type != DORDER_DISEMBARK))
 	{
 		dest = moveGetObstacleVector(psDroid, dest);
 	}


### PR DESCRIPTION
Edits of the move.ccp made by Wanjia_1 that prevents transporters from stacking.
edit : that's my first pull request I may have made an error while attempting at comparing branches or something, please forgive me for that.