### PR TITLE
Fix: Inform interface when a droid is removed

### DIFF
--- a/src/droid.cpp
+++ b/src/droid.cpp
@@ -622,6 +622,7 @@ bool removeDroidBase(DROID *psDel)
 
 	if (psDel->player == selectedPlayer)
 	{
+		intInformInterfaceObjectRemoved(psDel);
 		intRefreshScreen();
 	}
 
@@ -819,6 +820,7 @@ bool droidRemove(DROID *psDroid, PerPlayerDroidLists& pList)
 
 	if (psDroid->player == selectedPlayer)
 	{
+		intInformInterfaceObjectRemoved(psDroid);
 		intRefreshScreen();
 	}
 

--- a/src/hci.cpp
+++ b/src/hci.cpp
@@ -1056,6 +1056,16 @@ void intRefreshGroupsUI()
 	IntGroupsRefreshPending = true;
 }
 
+void intInformInterfaceObjectRemoved(const BASE_OBJECT *psObj)
+{
+	if (psSelectedBuilder == psObj)
+	{
+		debug(LOG_INFO, "Selected builder removed");
+		psSelectedBuilder = nullptr;
+	}
+	// intDoScreenRefresh handles refreshing the backing stores for any open interfaceController
+}
+
 bool intAddRadarWidget()
 {
 	auto radarWidget = getRadarWidget();

--- a/src/hci.h
+++ b/src/hci.h
@@ -268,6 +268,8 @@ extern iIMDShape	*pNewDesignIMD;
 /* Initialise the in game interface */
 bool intInitialise();
 
+void intInformInterfaceObjectRemoved(const BASE_OBJECT *psObj);
+
 bool intAddRadarWidget();
 
 // Check of coordinate is in the build menu


### PR DESCRIPTION
So it can clear `psSelectedBuilder`