### PR TITLE
display3d: Better sub-tile precision for tile screen coordinates

### DIFF
--- a/src/display3d.cpp
+++ b/src/display3d.cpp
@@ -1389,8 +1389,8 @@ static void drawTiles(iView *player, LightingData& lightData, LightMap& lightmap
 				Vector2i screen(0, 0);
 				Position pos;
 
-				pos.x = world_coord(j);
-				pos.z = -world_coord(i);
+				pos.x = world_coord(j) - (playerPos.p.x % TILE_WIDTH);
+				pos.z = -world_coord(i) + (playerPos.p.z % TILE_HEIGHT);
 				pos.y = 0;
 
 				if (tileOnMap(playerXTile + j, playerZTile + i))
@@ -3970,8 +3970,8 @@ void screenCoordToWorld(Vector2i screenCoord, Vector2i &worldCoord, SDWORD &tile
 				/* We've got a match for our mouse coords */
 				if (inQuad(&screenCoord, &quad))
 				{
-					outMousePos.x = playerPos.p.x + world_coord(j);
-					outMousePos.y = playerPos.p.z + world_coord(i);
+					outMousePos.x = playerPos.p.x + (world_coord(j) - (playerPos.p.x % TILE_WIDTH));
+					outMousePos.y = playerPos.p.z + (world_coord(i) - (playerPos.p.z % TILE_HEIGHT));
 					outMousePos += positionInQuad(screenCoord, quad);
 					if (outMousePos.x < 0)
 					{


### PR DESCRIPTION
Pulls out a specific change from #4243 for more testing.

Note: Includes a draft fix to `screenCoordToWorld`, to resolve `locateMouse` issues introduced by the original change.