### PR TITLE
netplay: Get rid of static message reader/writer instances

### DIFF
--- a/lib/gamelib/gtime.cpp
+++ b/lib/gamelib/gtime.cpp
@@ -418,12 +418,12 @@ void sendPlayerGameTime()
 			continue;
 		}
 
-		NETbeginEncode(NETgameQueue(player), GAME_GAME_TIME);
-		NETuint32_t(&latencyTicks);
-		NETuint32_t(&checkTime);
-		NETuint16_t(&checkCrc);
-		NETuint16_t(&wantedLatency);
-		NETend();
+		auto w = NETbeginEncode(NETgameQueue(player), GAME_GAME_TIME);
+		NETuint32_t(w, latencyTicks);
+		NETuint32_t(w, checkTime);
+		NETuint16_t(w, checkCrc);
+		NETuint16_t(w, wantedLatency);
+		NETend(w);
 	}
 
 	debugVerboseLogSyncIfNeeded();
@@ -456,12 +456,12 @@ void recvPlayerGameTime(NETQUEUE queue)
 	uint32_t checkTime = 0;
 	GameCrcType checkCrc = 0;
 
-	NETbeginDecode(queue, GAME_GAME_TIME);
-	NETuint32_t(&latencyTicks);
-	NETuint32_t(&checkTime);
-	NETuint16_t(&checkCrc);
-	NETuint16_t(&wantedLatencies[queue.index]);
-	NETend();
+	auto r = NETbeginDecode(queue, GAME_GAME_TIME);
+	NETuint32_t(r, latencyTicks);
+	NETuint32_t(r, checkTime);
+	NETuint16_t(r, checkCrc);
+	NETuint16_t(r, wantedLatencies[queue.index]);
+	NETend(r);
 
 	gameQueueTime[queue.index] = checkTime + latencyTicks * GAME_TICKS_PER_UPDATE;  // gameTime when future messages shall be processed.
 

--- a/lib/netplay/nettypes.cpp
+++ b/lib/netplay/nettypes.cpp
@@ -61,276 +61,9 @@ static NetQueuePair *tmpQueues[MAX_TMP_SOCKETS] = {nullptr};
 /// Sending a message to the broadcast queue is equivalent to sending the message to the net queues of all other players.
 static NetQueue *broadcastQueue = nullptr;
 
-// Only used between NETbegin{Encode,Decode} and NETend calls.
-static MessageWriter writer;  ///< Used when serialising a message.
-static MessageReader reader;  ///< Used when deserialising a message.
-static NetMessage message;    ///< A message which is being serialised or deserialised.
-static NETQUEUE queueInfo;    ///< Indicates which queue is currently being (de)serialised.
-static PACKETDIR NetDir;      ///< Indicates whether a message is being serialised (PACKET_ENCODE) or deserialised (PACKET_DECODE), or not doing anything (PACKET_INVALID).
-static bool bSecretMessageWrap = false;
-
 static std::array<std::unique_ptr<SessionKeys>, MAX_CONNECTED_PLAYERS> netSessionKeys;
 
 static bool bIsReplay = false;
-
-static void NETsetPacketDir(PACKETDIR dir)
-{
-	NetDir = dir;
-}
-
-PACKETDIR NETgetPacketDir()
-{
-	return NetDir;
-}
-
-// The queue(q, v) functions (de)serialise the object v to/from q, depending on whether q is a MessageWriter or MessageReader.
-
-template<class Q>
-static void queue(const Q &q, uint8_t &v)
-{
-	q.byte(v);
-}
-
-template<class Q>
-static void queue(const Q &q, uint16_t &v)
-{
-	uint8_t b[2] = {uint8_t(v >> 8), uint8_t(v)};
-	queue(q, b[0]);
-	queue(q, b[1]);
-	if (Q::Direction == Q::Read)
-	{
-		v = b[0] << 8 | b[1];
-	}
-}
-
-template<class Q>
-static void queue(const Q &q, uint32_t &vOrig)
-{
-	if (Q::Direction == Q::Write)
-	{
-		uint32_t v = vOrig;
-		bool moreBytes = true;
-		for (int n = 0; moreBytes; ++n)
-		{
-			uint8_t b;
-			moreBytes = encode_uint32_t(b, v, n);
-			queue(q, b);
-		}
-	}
-	else if (Q::Direction == Q::Read)
-	{
-		uint32_t v = 0;
-		bool moreBytes = true;
-		for (int n = 0; moreBytes; ++n)
-		{
-			uint8_t b = 0;
-			queue(q, b);
-			moreBytes = decode_uint32_t(b, v, n);
-		}
-
-		vOrig = v;
-	}
-}
-
-template<class Q>
-static void queue(const Q &q, uint64_t &v)
-{
-	uint32_t b[2] = {uint32_t(v >> 32), uint32_t(v)};
-	queue(q, b[0]);
-	queue(q, b[1]);
-	if (Q::Direction == Q::Read)
-	{
-		v = uint64_t(b[0]) << 32 | b[1];
-	}
-}
-
-template<class Q>
-static void queue(const Q &q, char &v)
-{
-	uint8_t b = v;
-	queue(q, b);
-	if (Q::Direction == Q::Read)
-	{
-		v = b;
-	}
-
-	STATIC_ASSERT(sizeof(b) == sizeof(v));
-}
-
-template<class Q>
-static void queue(const Q &q, int8_t &v)
-{
-	uint8_t b = v;
-	queue(q, b);
-	if (Q::Direction == Q::Read)
-	{
-		v = b;
-	}
-
-	STATIC_ASSERT(sizeof(b) == sizeof(v));
-}
-
-template<class Q>
-static void queue(const Q &q, int16_t &v)
-{
-	uint16_t b = v;
-	queue(q, b);
-	if (Q::Direction == Q::Read)
-	{
-		v = b;
-	}
-
-	STATIC_ASSERT(sizeof(b) == sizeof(v));
-}
-
-template<class Q>
-static void queue(const Q &q, int32_t &v)
-{
-	// Non-negative values: value*2
-	// Negative values:     -value*2 - 1
-	// Example: int32_t -5 -4 -3 -2 -1  0  1  2  3  4  5
-	// becomes uint32_t  9  7  5  3  1  0  2  4  6  8 10
-
-#if defined( _MSC_VER )
-	#pragma warning( push )
-	#pragma warning( disable : 4146 ) // warning C4146: unary minus operator applied to unsigned type, result still unsigned
-#endif
-
-	uint32_t b = (uint32_t)v << 1 ^ (-((uint32_t)v >> 31));
-	queue(q, b);
-	if (Q::Direction == Q::Read)
-	{
-		v = b >> 1 ^ -(b & 1);
-	}
-
-#if defined( _MSC_VER )
-	#pragma warning( pop )
-#endif
-
-	STATIC_ASSERT(sizeof(b) == sizeof(v));
-}
-
-template<class Q>
-static void queue(const Q &q, int64_t &v)
-{
-	uint64_t b = v;
-	queue(q, b);
-	if (Q::Direction == Q::Read)
-	{
-		v = b;
-	}
-
-	STATIC_ASSERT(sizeof(b) == sizeof(v));
-}
-
-template<class Q>
-static void queue(const Q &q, Position &v)
-{
-	queue(q, v.x);
-	queue(q, v.y);
-	queue(q, v.z);
-}
-
-template<class Q>
-static void queue(const Q &q, Rotation &v)
-{
-	queue(q, v.direction);
-	queue(q, v.pitch);
-	queue(q, v.roll);
-}
-
-template<class Q>
-static void queue(const Q &q, Vector2i &v)
-{
-	queue(q, v.x);
-	queue(q, v.y);
-}
-
-template<class Q, class T>
-static void queue(const Q &q, std::vector<T> &v)
-{
-	ASSERT(v.size() <= static_cast<size_t>(std::numeric_limits<uint32_t>::max()), "v.size() exceeds uint32_t max");
-	uint32_t len = static_cast<uint32_t>(std::min(v.size(), static_cast<size_t>(std::numeric_limits<uint32_t>::max())));
-	queue(q, len);
-	switch (Q::Direction)
-	{
-	case Q::Write:
-		for (uint32_t i = 0; i != len; ++i)
-		{
-			queue(q, v[i]);
-		}
-		break;
-	case Q::Read:
-		v.clear();
-		for (uint32_t i = 0; i != len && q.valid(); ++i)
-		{
-			T tmp;
-			queue(q, tmp);
-			v.push_back(tmp);
-		}
-		break;
-	}
-}
-
-template<class Q>
-static void queue(const Q &q, std::vector<uint8_t> &v)
-{
-	ASSERT(v.size() <= static_cast<size_t>(std::numeric_limits<uint32_t>::max()), "v.size() exceeds uint32_t max");
-	uint32_t len = static_cast<uint32_t>(std::min(v.size(), static_cast<size_t>(std::numeric_limits<uint32_t>::max())));
-	queue(q, len);
-	switch (Q::Direction)
-	{
-	case Q::Write:
-		q.bytes(v.data(), v.size());
-		break;
-	case Q::Read:
-		v.clear();
-		if (q.valid())
-		{
-			q.bytesVector(v, len);
-		}
-		break;
-	}
-}
-
-struct NetBytes {
-	uint8_t *buf = nullptr;
-	uint32_t len = 0;
-};
-
-template<class Q>
-static void queue(const Q &q, NetBytes &v)
-{
-	switch (Q::Direction)
-	{
-	case Q::Write:
-		q.bytes(v.buf, v.len);
-		break;
-	case Q::Read:
-		q.bytes(v.buf, v.len);
-		break;
-	}
-}
-
-template<class Q>
-static void queue(const Q &q, NetMessage &v)
-{
-	queue(q, v.type);
-	queue(q, v.data);
-}
-
-template<class T>
-static void queueAuto(T &v)
-{
-	if (NETgetPacketDir() == PACKET_ENCODE)
-	{
-		queue(writer, v);
-	}
-	else if (NETgetPacketDir() == PACKET_DECODE)
-	{
-		queue(reader, v);
-	}
-}
 
 // Queue selection functions
 
@@ -547,24 +280,16 @@ void NETswapQueues(NETQUEUE src, NETQUEUE dst)
 	std::swap(pairQueue(src), pairQueue(dst));
 }
 
-void NETbeginEncode(NETQUEUE queue, uint8_t type)
+MessageWriter NETbeginEncode(NETQUEUE queue, uint8_t type)
 {
-	NETsetPacketDir(PACKET_ENCODE);
-
-	queueInfo = queue;
-	message = type;
-	writer = MessageWriter(message);
+	return MessageWriter(queue, type);
 }
 
-void NETbeginDecode(NETQUEUE queue, uint8_t type)
+MessageReader NETbeginDecode(NETQUEUE queue, uint8_t type)
 {
-	NETsetPacketDir(PACKET_DECODE);
-
-	queueInfo = queue;
-	message = receiveQueue(queueInfo)->getMessage();
-	reader = MessageReader(message);
-
-	assert(type == message.type);
+	auto res = MessageReader(queue, receiveQueue(queue)->getMessage());
+	assert(type == res.message->type);
+	return res;
 }
 
 void NETsetSessionKeys(uint8_t player, SessionKeys&& keys)
@@ -603,20 +328,19 @@ bool NETisExpectedSecuredMessageType(uint8_t type)
 // For encoding a secured net message, for a *specific player*
 // Returns `false` on failure
 // Notes:
-//	- *DO NOT CALL NETend() if this returns false!!*
 //	- Only for NET_* messages
-bool NETbeginEncodeSecured(NETQUEUE queue, uint8_t type)
+optional<MessageWriter> NETbeginEncodeSecured(NETQUEUE queue, uint8_t type)
 {
-	ASSERT_OR_RETURN(false, type < NET_MAX_TYPE, "Message type %u is >= NET_MAX_TYPE", static_cast<unsigned>(type));
-	ASSERT_OR_RETURN(false, queue.index != realSelectedPlayer, "Secured messages are for other players, not ourselves.");
-	ASSERT_OR_RETURN(false, queue.index < MAX_PLAYERS || queue.index == NetPlay.hostPlayer, "Invalid recipient (queue.index == %u)", static_cast<unsigned>(queue.index));
-	ASSERT_OR_RETURN(false, netSessionKeys[queue.index] != nullptr, "Lacking session key for recipient: %u", static_cast<unsigned>(queue.index));
+	ASSERT_OR_RETURN(nullopt, type < NET_MAX_TYPE, "Message type %u is >= NET_MAX_TYPE", static_cast<unsigned>(type));
+	ASSERT_OR_RETURN(nullopt, queue.index != realSelectedPlayer, "Secured messages are for other players, not ourselves.");
+	ASSERT_OR_RETURN(nullopt, queue.index < MAX_PLAYERS || queue.index == NetPlay.hostPlayer, "Invalid recipient (queue.index == %u)", static_cast<unsigned>(queue.index));
+	ASSERT_OR_RETURN(nullopt, netSessionKeys[queue.index] != nullptr, "Lacking session key for recipient: %u", static_cast<unsigned>(queue.index));
 	ASSERT(NETisExpectedSecuredMessageType(type), "Message type is not expected to be secured, and will be ignored on receipt");
 
-	NETbeginEncode(queue, type);
-	bSecretMessageWrap = true;
+	auto w = NETbeginEncode(queue, type);
+	w.bSecretMessageWrap = true;
 
-	return true;
+	return w;
 }
 
 // For decoding what is expected to have been a secured message
@@ -624,15 +348,14 @@ bool NETbeginEncodeSecured(NETQUEUE queue, uint8_t type)
 // Notes:
 //	- *DO NOT CALL NETend() if this returns false!!*
 //	- Only for NET_* messages
-bool NETbeginDecodeSecured(NETQUEUE queue, uint8_t type)
+optional<MessageReader> NETbeginDecodeSecured(NETQUEUE queue, uint8_t type)
 {
-	ASSERT_OR_RETURN(false, type < NET_MAX_TYPE, "Message type %u is >= NET_MAX_TYPE", static_cast<unsigned>(type));
-	ASSERT_OR_RETURN(false, queue.index != realSelectedPlayer, "Secured messages are for other players, not ourselves.");
-	ASSERT_OR_RETURN(false, queue.index < MAX_PLAYERS || queue.index == NetPlay.hostPlayer, "Invalid sender (queue.index == %u)", static_cast<unsigned>(queue.index));
-	ASSERT_OR_RETURN(false, receiveQueue(queue)->currentMessageWasDecrypted(), "Message was not sent secured (type: %s)", messageTypeToString(type));
+	ASSERT_OR_RETURN(nullopt, type < NET_MAX_TYPE, "Message type %u is >= NET_MAX_TYPE", static_cast<unsigned>(type));
+	ASSERT_OR_RETURN(nullopt, queue.index != realSelectedPlayer, "Secured messages are for other players, not ourselves.");
+	ASSERT_OR_RETURN(nullopt, queue.index < MAX_PLAYERS || queue.index == NetPlay.hostPlayer, "Invalid sender (queue.index == %u)", static_cast<unsigned>(queue.index));
+	ASSERT_OR_RETURN(nullopt, receiveQueue(queue)->currentMessageWasDecrypted(), "Message was not sent secured (type: %s)", messageTypeToString(type));
 
-	NETbeginDecode(queue, type);
-	return true;
+	return NETbeginDecode(queue, type);
 }
 
 // Decrypts a secured net message in a queue *and replaces it with the decrypted message*
@@ -683,120 +406,98 @@ bool NETdecryptSecuredNetMessage(NETQUEUE queue, uint8_t& type)
 	return true;
 }
 
+bool NETend(MessageReader& r)
+{
+	return r.valid();
+}
+
 static std::vector<uint8_t> tmpMessageRawDataBuffer;
 
-bool NETend()
+bool NETend(MessageWriter& w)
 {
-	bool shouldWrapSecretMessage = bSecretMessageWrap;
-	bSecretMessageWrap = false; // reset global, always
+	bool shouldWrapSecretMessage = w.bSecretMessageWrap;
+	w.bSecretMessageWrap = false; // reset, always
 
-	// If we are encoding just return true
-	if (NETgetPacketDir() == PACKET_ENCODE)
+	if (bIsReplay && w.queueInfo.index != realSelectedPlayer)
 	{
-		if (bIsReplay && queueInfo.index != realSelectedPlayer)
-		{
-			// don't bother adding to the send queue if we're playing a replay
-			NETsetPacketDir(PACKET_INVALID);
-			return true;
-		}
-
-		// Push the message onto the list.
-		NetQueue *queue = sendQueue(queueInfo);
-		if (queue == nullptr) {
-			debug(LOG_WARNING, "Sending %s to null queue, type %d.", messageTypeToString(message.type), queueInfo.queueType);
-			return true;
-		}
-
-		if (shouldWrapSecretMessage)
-		{
-			// Need to actually encrypt and wrap the current net message in a NET_SECURED_NET_MESSAGE message
-			ASSERT(message.type < NET_MAX_TYPE, "Message type %u is >= NET_MAX_TYPE", static_cast<unsigned>(message.type));
-			ASSERT(queueInfo.index < MAX_PLAYERS || queueInfo.index == NetPlay.hostPlayer, "Invalid recipient (queue.index == %u)", static_cast<unsigned>(queueInfo.index));
-			ASSERT(netSessionKeys[queueInfo.index] != nullptr, "Lacking session key for recipient: %u", static_cast<unsigned>(queueInfo.index));
-
-			// Decoded in NETprocessSystemMessage in netplay.cpp.
-			// Encrypt the serialized message (including type and size)
-			NetMessage encryptedNetMessage(NET_SECURED_NET_MESSAGE);
-			tmpMessageRawDataBuffer.clear();
-			message.rawDataAppendToVector(tmpMessageRawDataBuffer);
-			encryptedNetMessage.data = netSessionKeys[queueInfo.index]->encryptMessageForOther(&tmpMessageRawDataBuffer[0], tmpMessageRawDataBuffer.size());
-
-			message = encryptedNetMessage;
-		}
-
-		queue->pushMessage(message);
-		NETlogPacket(message.type, static_cast<uint32_t>(message.data.size()), false);
-
-		if (queueInfo.queueType == QUEUE_GAME || queueInfo.queueType == QUEUE_GAME_FORCED)
-		{
-			ASSERT(message.type > GAME_MIN_TYPE && message.type < GAME_MAX_TYPE, "Inserting %s into game queue.", messageTypeToString(message.type));
-		}
-		else
-		{
-			ASSERT(message.type > NET_MIN_TYPE && message.type < NET_MAX_TYPE, "Inserting %s into net queue.", messageTypeToString(message.type));
-		}
-
-		if (queueInfo.queueType == QUEUE_NET || queueInfo.queueType == QUEUE_BROADCAST || queueInfo.queueType == QUEUE_TMP)
-		{
-			NETsend(queueInfo, &queue->getMessageForNet());
-			queue->popMessageForNet();
-			ASSERT(queue->numMessagesForNet() == 0, "Queue not empty (%u messages remaining). (message = type: %" PRIu8 ", size: %zu), (queue = index: %" PRIu8 "; queueType: %" PRIu8 "; exclude: %" PRIu8 "; isPair: %d)", queue->numMessagesForNet(), message.type, message.data.size(), queueInfo.index, queueInfo.queueType, queueInfo.exclude, (int)queueInfo.isPair);
-		}
-
-		// We have ended the serialisation, so mark the direction invalid
-		NETsetPacketDir(PACKET_INVALID);
-
-		// Process any delayed actions from the NETsend call
-		NETsendProcessDelayedActions();
-
-		if (queueInfo.queueType == QUEUE_GAME_FORCED)  // If true, we must be the host, inserting a GAME_PLAYER_LEFT into the other player's game queue. Since they left, they're not around to complain about us messing with their queue, which would normally cause a desynch.
-		{
-			// Almost duplicate code from NETflushGameQueues() in here.
-			// Message must be sent as message in a NET_SHARE_GAME_QUEUE in a NET_SEND_TO_PLAYER.
-			// If not sent inside a NET_SEND_TO_PLAYER, and the message arrives at the same time as a real message from that player, then the messages may be processed in an unexpected order.
-			// See NETrecvNet, in the for (current = 0; current < MAX_CONNECTED_PLAYERS; ++current) loop.
-			// Assume dropped client sends a NET_SENT_TO_PLAYERS(broadcast, NET_SHARE_GAME_QUEUE(GAME_REALMESSAGE)), and then drops.
-			// The host then sends the NET_SEND_TO_PLAYER(broadcast, NET_SHARE_GAME_QUEUE(GAME_REALMESSAGE)) to everyone. If the host then spoofs a NET_SHARE_GAME_QUEUE(GAME_PLAYER_LEFT) without
-			// wrapping it in a NET_SEND_TO_PLAYER from that player, then the client may sometimes unwrap the real NET_SEND_TO_PLAYER message, then process the host's spoofed NET_SHARE_GAME_QUEUE
-			// message, and then after that process the previously unwrapped NET_SHARE_GAME_QUEUE(GAME_REALMESSAGE) message, such that the GAME_PLAYER_LEFT appears on the queue before the
-			// GAME_REALMESSAGE.
-
-			// Decoded in NETprocessSystemMessage in netplay.cpp.
-			uint8_t player = queueInfo.index;
-			uint32_t num = 1;
-			NetMessage backupMessage = message;  // 'message' will be overwritten, so we need a copy (to avoid trying to insert a message into itself).
-			NETbeginEncode(NETbroadcastQueue(), NET_SHARE_GAME_QUEUE);
-			NETuint8_t(&player);
-			NETuint32_t(&num);
-			for (uint32_t n = 0; n < num; ++n)
-			{
-				queueAuto(backupMessage);
-			}
-			NETsetPacketDir(PACKET_INVALID);  // Instead of NETend();
-			backupMessage = message;  // 'message' will be overwritten again, so we need a copy of this NET_SHARE_GAME_QUEUE message.
-			uint8_t allPlayers = NET_ALL_PLAYERS;
-			NETbeginEncode(NETbroadcastQueue(), NET_SEND_TO_PLAYER);
-			NETuint8_t(&player);
-			NETuint8_t(&allPlayers);
-			queueAuto(backupMessage);
-			NETend();  // This time we actually send it.
-		}
-
-		return true;  // Serialising never fails.
+		// don't bother adding to the send queue if we're playing a replay
+		return true;
 	}
 
-	if (NETgetPacketDir() == PACKET_DECODE)
-	{
-		bool ret = reader.valid();
-
-		// We have ended the deserialisation, so mark the direction invalid
-		NETsetPacketDir(PACKET_INVALID);
-
-		return ret;
+	// Push the message onto the list.
+	NetQueue* queue = sendQueue(w.queueInfo);
+	if (queue == nullptr) {
+		debug(LOG_WARNING, "Sending %s to null queue, type %d.", messageTypeToString(w.message.type), w.queueInfo.queueType);
+		return true;
 	}
 
-	assert(false && false && false);
-	return false;
+	if (shouldWrapSecretMessage)
+	{
+		// Need to actually encrypt and wrap the current net message in a NET_SECURED_NET_MESSAGE message
+		ASSERT(w.message.type < NET_MAX_TYPE, "Message type %u is >= NET_MAX_TYPE", static_cast<unsigned>(w.message.type));
+		ASSERT(w.queueInfo.index < MAX_PLAYERS || w.queueInfo.index == NetPlay.hostPlayer, "Invalid recipient (queue.index == %u)", static_cast<unsigned>(w.queueInfo.index));
+		ASSERT(netSessionKeys[w.queueInfo.index] != nullptr, "Lacking session key for recipient: %u", static_cast<unsigned>(w.queueInfo.index));
+
+		// Decoded in NETprocessSystemMessage in netplay.cpp.
+		// Encrypt the serialized message (including type and size)
+		NetMessage encryptedNetMessage(NET_SECURED_NET_MESSAGE);
+		tmpMessageRawDataBuffer.clear();
+		w.message.rawDataAppendToVector(tmpMessageRawDataBuffer);
+		encryptedNetMessage.data = netSessionKeys[w.queueInfo.index]->encryptMessageForOther(&tmpMessageRawDataBuffer[0], tmpMessageRawDataBuffer.size());
+
+		w.message = std::move(encryptedNetMessage);
+	}
+
+	queue->pushMessage(w.message);
+	NETlogPacket(w.message.type, static_cast<uint32_t>(w.message.data.size()), false);
+
+	if (w.queueInfo.queueType == QUEUE_GAME || w.queueInfo.queueType == QUEUE_GAME_FORCED)
+	{
+		ASSERT(w.message.type > GAME_MIN_TYPE && w.message.type < GAME_MAX_TYPE, "Inserting %s into game queue.", messageTypeToString(w.message.type));
+	}
+	else
+	{
+		ASSERT(w.message.type > NET_MIN_TYPE && w.message.type < NET_MAX_TYPE, "Inserting %s into net queue.", messageTypeToString(w.message.type));
+	}
+
+	if (w.queueInfo.queueType == QUEUE_NET || w.queueInfo.queueType == QUEUE_BROADCAST || w.queueInfo.queueType == QUEUE_TMP)
+	{
+		NETsend(w.queueInfo, &queue->getMessageForNet());
+		queue->popMessageForNet();
+		ASSERT(queue->numMessagesForNet() == 0, "Queue not empty (%u messages remaining). (message = type: %" PRIu8 ", size: %zu), (queue = index: %" PRIu8 "; queueType: %" PRIu8 "; exclude: %" PRIu8 "; isPair: %d)", queue->numMessagesForNet(), w.message.type, w.message.data.size(), w.queueInfo.index, w.queueInfo.queueType, w.queueInfo.exclude, (int)w.queueInfo.isPair);
+	}
+
+	// Process any delayed actions from the NETsend call
+	NETsendProcessDelayedActions();
+
+	if (w.queueInfo.queueType == QUEUE_GAME_FORCED)  // If true, we must be the host, inserting a GAME_PLAYER_LEFT into the other player's game queue. Since they left, they're not around to complain about us messing with their queue, which would normally cause a desynch.
+	{
+		// Almost duplicate code from NETflushGameQueues() in here.
+		// Message must be sent as message in a NET_SHARE_GAME_QUEUE in a NET_SEND_TO_PLAYER.
+		// If not sent inside a NET_SEND_TO_PLAYER, and the message arrives at the same time as a real message from that player, then the messages may be processed in an unexpected order.
+		// See NETrecvNet, in the for (current = 0; current < MAX_CONNECTED_PLAYERS; ++current) loop.
+		// Assume dropped client sends a NET_SENT_TO_PLAYERS(broadcast, NET_SHARE_GAME_QUEUE(GAME_REALMESSAGE)), and then drops.
+		// The host then sends the NET_SEND_TO_PLAYER(broadcast, NET_SHARE_GAME_QUEUE(GAME_REALMESSAGE)) to everyone. If the host then spoofs a NET_SHARE_GAME_QUEUE(GAME_PLAYER_LEFT) without
+		// wrapping it in a NET_SEND_TO_PLAYER from that player, then the client may sometimes unwrap the real NET_SEND_TO_PLAYER message, then process the host's spoofed NET_SHARE_GAME_QUEUE
+		// message, and then after that process the previously unwrapped NET_SHARE_GAME_QUEUE(GAME_REALMESSAGE) message, such that the GAME_PLAYER_LEFT appears on the queue before the
+		// GAME_REALMESSAGE.
+
+		// Decoded in NETprocessSystemMessage in netplay.cpp.
+		uint8_t player = w.queueInfo.index;
+		auto shareQueueWriter = NETbeginEncode(NETbroadcastQueue(), NET_SHARE_GAME_QUEUE);
+		NETuint8_t(shareQueueWriter, player);
+		NETuint32_t(shareQueueWriter, 1);
+		NETnetMessage(shareQueueWriter, w.message);
+
+		uint8_t allPlayers = NET_ALL_PLAYERS;
+		auto sendToPlayerWriter = NETbeginEncode(NETbroadcastQueue(), NET_SEND_TO_PLAYER);
+		NETuint8_t(sendToPlayerWriter, player);
+		NETuint8_t(sendToPlayerWriter, allPlayers);
+		NETnetMessage(sendToPlayerWriter, shareQueueWriter.message);
+		NETend(sendToPlayerWriter);  // This time we actually send it.
+	}
+
+	return true;  // Serialising never fails.
 }
 
 void NETflushGameQueues()
@@ -820,236 +521,21 @@ void NETflushGameQueues()
 		ASSERT(!bIsReplay, "Where are we sending this if it's a replay?");
 
 		// Decoded in NETprocessSystemMessage in netplay.cpp.
-		NETbeginEncode(NETbroadcastQueue(), NET_SHARE_GAME_QUEUE);
-		NETuint8_t(&player);
-		NETuint32_t(&num);
+		auto w = NETbeginEncode(NETbroadcastQueue(), NET_SHARE_GAME_QUEUE);
+		NETuint8_t(w, player);
+		NETuint32_t(w, num);
 		for (uint32_t n = 0; n < num; ++n)
 		{
-			queueAuto(const_cast<NetMessage &>(queue->getMessageForNet()));  // const_cast is safe since we are encoding, not decoding.
+			NETnetMessage(w, queue->getMessageForNet());
 			queue->popMessageForNet();
 		}
-		NETend();
+		NETend(w);
 	}
 }
 
 void NETpop(NETQUEUE queue)
 {
 	receiveQueue(queue)->popMessage();
-}
-
-void NETint8_t(int8_t *ip)
-{
-	queueAuto(*ip);
-}
-
-void NETuint8_t(uint8_t *ip)
-{
-	queueAuto(*ip);
-}
-
-void NETint16_t(int16_t *ip)
-{
-	queueAuto(*ip);
-}
-
-void NETuint16_t(uint16_t *ip)
-{
-	queueAuto(*ip);
-}
-
-void NETint32_t(int32_t *ip)
-{
-	queueAuto(*ip);
-}
-
-void NETuint32_t(uint32_t *ip)
-{
-	queueAuto(*ip);
-}
-
-void NETuint32_t(const uint32_t *ip)
-{
-	uint32_t ip_ = *ip;
-	queueAuto(ip_);
-}
-
-void NETint64_t(int64_t *ip)
-{
-	queueAuto(*ip);
-}
-
-void NETuint64_t(uint64_t *ip)
-{
-	queueAuto(*ip);
-}
-
-void NETbool(bool *bp)
-{
-	uint8_t i = !!*bp;
-	queueAuto(i);
-	*bp = !!i;
-}
-
-/** Sends or receives a string to or from the current network package.
- *  \param str    When encoding a packet this is the (NUL-terminated string to
- *                be sent in the current network package. When decoding this
- *                is the buffer to decode the string from the network package
- *                into. When decoding this string is guaranteed to be
- *                NUL-terminated provided that this buffer is at least 1 byte
- *                large.
- *  \param maxlen The buffer size of \c str. For static buffers this means
- *                sizeof(\c str), for dynamically allocated buffers this is
- *                whatever number you passed to malloc().
- *  \note If while decoding \c maxlen is smaller than the actual length of the
- *        string being decoded, the resulting string (in \c str) will be
- *        truncated.
- */
-void NETstring(char *str, uint16_t maxlen)
-{
-	/*
-	 * Strings sent over the network are prefixed with their length, sent as an
-	 * unsigned 16-bit integer, not including \0 termination.
-	 */
-
-	uint16_t len = 0;
-	if (NETgetPacketDir() == PACKET_ENCODE)
-	{
-		size_t cappedStrLen = strnlen1(str, maxlen);
-		len = static_cast<uint16_t>((cappedStrLen > 0) ? (cappedStrLen - 1) : 0);
-	}
-	queueAuto(len);
-
-	// Truncate length if necessary
-	uint16_t maxReadLen = (maxlen > 0) ? static_cast<uint16_t>(maxlen - 1) : 0;
-	if (len > maxReadLen)
-	{
-		debug(LOG_ERROR, "NETstring: %s packet, length %u truncated at %u", NETgetPacketDir() == PACKET_ENCODE ? "Encoding" : "Decoding", len, maxlen);
-		len = maxReadLen;
-	}
-
-	for (unsigned i = 0; i < len; ++i)
-	{
-		queueAuto(str[i]);
-	}
-
-	if (NETgetPacketDir() == PACKET_DECODE && maxlen > 0)
-	{
-		// NUL-terminate
-		str[len] = '\0';
-	}
-}
-
-void NETwzstring(WzString &str)
-{
-	// NOTE: To be backwards-compatible with the old NETqstring (QString-based) function,
-	// this uses UTF-16 encoding.
-
-	std::vector<uint16_t> u16_characters;
-	uint32_t len = 0;
-	if (NETgetPacketDir() == PACKET_ENCODE)
-	{
-		u16_characters = str.toUtf16();
-		ASSERT(u16_characters.size() <= static_cast<size_t>(std::numeric_limits<uint32_t>::max()), "u16_characters.size() exceeds uint32_t max");
-		len = static_cast<uint32_t>(std::min(u16_characters.size(), static_cast<size_t>(std::numeric_limits<uint32_t>::max())));
-	}
-
-	queueAuto(len);
-
-	if (NETgetPacketDir() == PACKET_DECODE)
-	{
-		u16_characters.resize(len);
-	}
-	for (unsigned i = 0; i < len; ++i)
-	{
-		uint16_t c = 0;
-		if (NETgetPacketDir() == PACKET_ENCODE)
-		{
-			c = u16_characters[i];
-		}
-		queueAuto(c);
-		if (NETgetPacketDir() == PACKET_DECODE)
-		{
-			u16_characters[i] = c;
-		}
-	}
-
-	if (NETgetPacketDir() == PACKET_DECODE)
-	{
-		str = WzString::fromUtf16(u16_characters);
-	}
-}
-
-void NETstring(char const *str, uint16_t maxlen)
-{
-	ASSERT(NETgetPacketDir() == PACKET_ENCODE, "Writing to const!");
-	NETstring(const_cast<char *>(str), maxlen);
-}
-
-void NETbytes(std::vector<uint8_t> *vec, unsigned maxLen)
-{
-	/*
-	 * Strings sent over the network are prefixed with their length, sent as an
-	 * unsigned 16-bit integer, not including \0 termination.
-	 */
-
-	ASSERT((NETgetPacketDir() != PACKET_ENCODE) || vec->size() <= static_cast<size_t>(std::numeric_limits<uint32_t>::max()), "vec->size() exceeds uint32_t max");
-	uint32_t vecSize = static_cast<uint32_t>(std::min(vec->size(), static_cast<size_t>(std::numeric_limits<uint32_t>::max())));
-	uint32_t len = NETgetPacketDir() == PACKET_ENCODE ? vecSize : 0;
-	queueAuto(len);
-
-	if (len > maxLen)
-	{
-		debug(LOG_ERROR, "NETbytes: %s packet, length %u truncated at %u", NETgetPacketDir() == PACKET_ENCODE ? "Encoding" : "Decoding", len, maxLen);
-	}
-
-	len = std::min<unsigned>(len, maxLen);  // Truncate length if necessary.
-	if (NETgetPacketDir() == PACKET_DECODE)
-	{
-		vec->clear();
-		vec->resize(len);  // vec->assign(len, 0) would call the wrong version of assign, here.
-	}
-
-	for (unsigned i = 0; i < len; ++i)
-	{
-		queueAuto((*vec)[i]);
-	}
-}
-
-void NETbin(uint8_t *str, uint32_t len)
-{
-	NetBytes nb{str, len};
-	queueAuto(nb);
-}
-
-void NETPosition(Position *vp)
-{
-	queueAuto(*vp);
-}
-
-void NETRotation(Rotation *vp)
-{
-	queueAuto(*vp);
-}
-
-void NETVector2i(Vector2i *vp)
-{
-	queueAuto(*vp);
-}
-
-void NETnetMessage(NetMessage const **msg)
-{
-	if (NETgetPacketDir() == PACKET_ENCODE)
-	{
-		queueAuto(*const_cast<NetMessage *>(*msg));  // Const cast safe when encoding.
-	}
-
-	if (NETgetPacketDir() == PACKET_DECODE)
-	{
-		NetMessage *m = new NetMessage;
-		queueAuto(*m);
-		*msg = m;
-		return;
-	}
 }
 
 void NETbytesOutputToVector(const std::vector<uint8_t> &data, std::vector<uint8_t>& output)
@@ -1128,4 +614,354 @@ void NETshutdownReplay()
 	}
 
 	bIsReplay = false;
+}
+
+// New overloads implementation
+void NETuint8_t(MessageReader& r, uint8_t& val)
+{
+	r.byte(val);
+}
+
+void NETint8_t(MessageReader &r, int8_t& val)
+{
+	NETuint8_t(r, reinterpret_cast<uint8_t&>(val));
+}
+
+void NETuint16_t(MessageReader& r, uint16_t& val)
+{
+	uint8_t b[2];
+	r.byte(b[0]);
+	r.byte(b[1]);
+	val = (b[0] << 8) | b[1];
+}
+
+void NETint16_t(MessageReader &r, int16_t& val)
+{
+	NETuint16_t(r, reinterpret_cast<uint16_t&>(val));
+}
+
+void NETuint32_t(MessageReader& r, uint32_t& val)
+{
+	uint32_t v = 0;
+	bool moreBytes = true;
+	for (size_t n = 0; moreBytes; ++n)
+	{
+		uint8_t b = 0;
+		r.byte(b);
+		moreBytes = decode_uint32_t(b, v, n);
+	}
+	val = v;
+}
+
+void NETint32_t(MessageReader &r, int32_t& val)
+{
+	// Non-negative values: value*2
+	// Negative values:     -value*2 - 1
+	// Example: int32_t -5 -4 -3 -2 -1  0  1  2  3  4  5
+	// becomes uint32_t  9  7  5  3  1  0  2  4  6  8 10
+
+#if defined( _MSC_VER )
+	#pragma warning( push )
+	#pragma warning( disable : 4146 ) // warning C4146: unary minus operator applied to unsigned type, result still unsigned
+#endif
+
+	uint32_t b = 0;
+	NETuint32_t(r, b);
+	val = b >> 1 ^ -(b & 1);
+
+#if defined( _MSC_VER )
+	#pragma warning( pop )
+#endif
+}
+
+void NETuint64_t(MessageReader& r, uint64_t& val)
+{
+	uint32_t b[2];
+	NETuint32_t(r, b[0]);
+	NETuint32_t(r, b[1]);
+	val = (uint64_t)b[0] << 32 | b[1];
+}
+
+void NETint64_t(MessageReader &r, int64_t& val)
+{
+	NETuint64_t(r, reinterpret_cast<uint64_t&>(val));
+}
+
+void NETbool(MessageReader &r, bool& val)
+{
+    uint8_t b;
+	NETuint8_t(r, b);
+    val = b != 0;
+}
+
+void NETwzstring(MessageReader &r, WzString &str)
+{
+    std::vector<uint16_t> u16_characters;
+    uint32_t len;
+    NETuint32_t(r, len);
+
+    u16_characters.resize(len);
+    for (uint32_t i = 0; i < len; i++)
+    {
+        uint16_t c;
+        NETuint16_t(r, c);
+        u16_characters[i] = c;
+    }
+    str = WzString::fromUtf16(u16_characters);
+}
+
+/** Receives a string from the current network package.
+ *  \param str    The buffer to decode the string from the network package
+ *                into. This string is guaranteed to be NUL-terminated
+ *                provided that this buffer is at least 1 byte large.
+ *  \param maxlen The buffer size of \c str. For static buffers this means
+ *                sizeof(\c str), for dynamically allocated buffers this is
+ *                whatever number you passed to malloc().
+ *  \note If while decoding \c maxlen is smaller than the actual length of the
+ *        string being decoded, the resulting string (in \c str) will be
+ *        truncated.
+ */
+void NETstring(MessageReader &r, char *str, uint16_t maxlen)
+{
+    uint16_t len;
+    NETuint16_t(r, len);
+    len = std::min(len, maxlen);
+
+    r.bytes((uint8_t *)str, len);
+    str[len] = '\0';
+}
+
+void NETstring(MessageReader& r, std::string& s, uint32_t maxLen /* = 65536 */)
+{
+	uint32_t len = 0;
+	NETuint32_t(r, len);
+	len = std::min(len, maxLen);
+	s.resize(len);
+	if (r.valid())
+	{
+		NETbin(r, reinterpret_cast<uint8_t*>(&s[0]), len);
+	}
+}
+
+void NETbin(MessageReader &r, uint8_t *str, uint32_t len)
+{
+    r.bytes(str, len);
+}
+
+void NETbytes(MessageReader &r, std::vector<uint8_t>& vec, unsigned maxLen /* = 10000 */)
+{
+	/*
+	 * Strings sent over the network are prefixed with their length, sent as an
+	 * unsigned 16-bit integer, not including \0 termination.
+	 */
+
+	uint32_t len = 0;
+	NETuint32_t(r, len);
+	if (len > maxLen)
+	{
+		debug(LOG_ERROR, "NETbytes: Decoding packet, length %u truncated at %u", len, maxLen);
+	}
+	len = std::min<unsigned>(len, maxLen);  // Truncate length if necessary.
+	vec.clear();
+	if (r.valid())
+	{
+		r.bytesVector(vec, len);
+	}
+}
+
+void NETPosition(MessageReader& r, Position& pos)
+{
+	NETint32_t(r, pos.x);
+	NETint32_t(r, pos.y);
+	NETint32_t(r, pos.z);
+}
+
+void NETRotation(MessageReader& r, Rotation& rot)
+{
+	NETuint16_t(r, rot.direction);
+	NETuint16_t(r, rot.pitch);
+	NETuint16_t(r, rot.roll);
+}
+
+void NETVector2i(MessageReader& r, Vector2i& vec)
+{
+	NETint32_t(r, vec.x);
+	NETint32_t(r, vec.y);
+}
+
+void NETnetMessage(MessageReader& r, NetMessage const** msg)
+{
+	NetMessage* m = new NetMessage();
+
+	NETuint8_t(r, m->type);
+	NETbytes(r, m->data, std::numeric_limits<uint32_t>::max());
+
+	*msg = m;
+}
+
+// MessageWriter overloads for encoding
+void NETuint8_t(MessageWriter& w, uint8_t val)
+{
+	w.byte(val);
+}
+
+void NETint8_t(MessageWriter& w, int8_t val)
+{
+	NETuint8_t(w, static_cast<uint8_t>(val));
+}
+
+void NETuint16_t(MessageWriter& w, uint16_t val)
+{
+	uint8_t b[2] = { uint8_t(val >> 8), uint8_t(val) };
+	NETuint8_t(w, b[0]);
+	NETuint8_t(w, b[1]);
+}
+
+void NETint16_t(MessageWriter& w, int16_t val)
+{
+	NETuint16_t(w, static_cast<uint16_t>(val));
+}
+
+void NETuint32_t(MessageWriter& w, uint32_t val)
+{
+	uint32_t v = val;
+	bool moreBytes = true;
+	for (int n = 0; moreBytes; ++n)
+	{
+		uint8_t b = 0;
+		moreBytes = encode_uint32_t(b, v, n);
+		NETuint8_t(w, b);
+	}
+}
+
+void NETint32_t(MessageWriter& w, int32_t val)
+{
+	// Non-negative values: value*2
+	// Negative values:     -value*2 - 1
+	// Example: int32_t -5 -4 -3 -2 -1  0  1  2  3  4  5
+	// becomes uint32_t  9  7  5  3  1  0  2  4  6  8 10
+
+#if defined( _MSC_VER )
+	#pragma warning( push )
+	#pragma warning( disable : 4146 ) // warning C4146: unary minus operator applied to unsigned type, result still unsigned
+#endif
+
+	uint32_t b = (uint32_t)val << 1 ^ (-((uint32_t)val >> 31));
+	NETuint32_t(w, b);
+
+#if defined( _MSC_VER )
+	#pragma warning( pop )
+#endif
+}
+
+void NETuint64_t(MessageWriter& w, uint64_t val)
+{
+	uint32_t b[2] = { uint32_t(val >> 32), uint32_t(val) };
+	NETuint32_t(w, b[0]);
+	NETuint32_t(w, b[1]);
+}
+
+void NETint64_t(MessageWriter& w, int64_t val)
+{
+	NETuint64_t(w, static_cast<uint64_t>(val));
+}
+
+void NETbool(MessageWriter& w, bool val)
+{
+	uint8_t i = !!val;
+	NETuint8_t(w, i);
+}
+
+void NETwzstring(MessageWriter& w, const WzString& str)
+{
+	// NOTE: To be backwards-compatible with the old NETqstring (QString-based) function,
+	// this uses UTF-16 encoding.
+
+	const std::vector<uint16_t> u16_characters = str.toUtf16();
+	ASSERT(u16_characters.size() <= static_cast<size_t>(std::numeric_limits<uint32_t>::max()), "u16_characters.size() exceeds uint32_t max");
+
+	uint32_t len = static_cast<uint32_t>(std::min(u16_characters.size(), static_cast<size_t>(std::numeric_limits<uint32_t>::max())));
+	NETuint32_t(w, len);
+	for (uint32_t i = 0; i < len; ++i)
+	{
+		NETuint16_t(w, u16_characters[i]);
+	}
+}
+
+void NETstring(MessageWriter& w, const char* str, uint16_t maxlen)
+{
+	/*
+	 * Strings sent over the network are prefixed with their length, sent as an
+	 * unsigned 16-bit integer, not including \0 termination.
+	 */
+
+	uint16_t len = 0;
+	size_t cappedStrLen = strnlen1(str, maxlen);
+	len = static_cast<uint16_t>((cappedStrLen > 0) ? (cappedStrLen - 1) : 0);
+	NETuint16_t(w, len);
+
+	// Truncate length if necessary
+	uint16_t maxReadLen = (maxlen > 0) ? static_cast<uint16_t>(maxlen - 1) : 0;
+	if (len > maxReadLen)
+	{
+		debug(LOG_ERROR, "NETstring: Encoding packet, length %u truncated at %u", len, maxlen);
+		len = maxReadLen;
+	}
+	w.bytes(reinterpret_cast<const uint8_t*>(str), len);
+}
+
+void NETstring(MessageWriter& w, const std::string& s, uint32_t maxLen /* = 65536 */)
+{
+	uint32_t len = static_cast<uint32_t>(std::min<size_t>(s.size(), maxLen));
+	NETuint32_t(w, len);
+	NETbin(w, reinterpret_cast<const uint8_t*>(s.c_str()), len);
+}
+
+void NETbin(MessageWriter& w, const uint8_t* str, uint32_t len)
+{
+	w.bytes(str, len);
+}
+
+void NETbytes(MessageWriter& w, const std::vector<uint8_t>& vec, unsigned maxLen)
+{
+	/*
+	 * Strings sent over the network are prefixed with their length, sent as an
+	 * unsigned 16-bit integer, not including \0 termination.
+	 */
+
+	ASSERT(vec.size() <= static_cast<size_t>(std::numeric_limits<uint32_t>::max()), "vec.size() exceeds uint32_t max");
+	uint32_t len = static_cast<uint32_t>(std::min(vec.size(), static_cast<size_t>(std::numeric_limits<uint32_t>::max())));
+	if (len > maxLen)
+	{
+		debug(LOG_ERROR, "NETbytes: Encoding packet, length %u truncated at %u", len, maxLen);
+	}
+	len = std::min<unsigned>(len, maxLen);  // Truncate length if necessary.
+	NETuint32_t(w, len);
+	w.bytes(vec.data(), len);
+}
+
+void NETPosition(MessageWriter& w, const Position& pos)
+{
+	NETint32_t(w, pos.x);
+	NETint32_t(w, pos.y);
+	NETint32_t(w, pos.z);
+}
+
+void NETRotation(MessageWriter& w, const Rotation& rot)
+{
+	NETuint16_t(w, rot.direction);
+	NETuint16_t(w, rot.pitch);
+	NETuint16_t(w, rot.roll);
+}
+
+void NETVector2i(MessageWriter& w, const Vector2i& vec)
+{
+	NETint32_t(w, vec.x);
+	NETint32_t(w, vec.y);
+}
+
+void NETnetMessage(MessageWriter& w, const NetMessage& msg)
+{
+	NETuint8_t(w, msg.type);
+	NETbytes(w, msg.data, std::numeric_limits<uint32_t>::max());
 }

--- a/src/chat.cpp
+++ b/src/chat.cpp
@@ -137,11 +137,11 @@ void InGameChatMessage::sendToAiPlayer(uint32_t receiver)
 		return;
 	}
 
-	NETbeginEncode(NETnetQueue(responsiblePlayer), NET_AITEXTMSG);
-	NETuint32_t(&sender);
-	NETuint32_t(&receiver);
-	NETstring(text, MAX_CONSOLE_STRING_LENGTH);
-	NETend();
+	auto w = NETbeginEncode(NETnetQueue(responsiblePlayer), NET_AITEXTMSG);
+	NETuint32_t(w, sender);
+	NETuint32_t(w, receiver);
+	NETstring(w, text, MAX_CONSOLE_STRING_LENGTH);
+	NETend(w);
 }
 
 void InGameChatMessage::sendToAiPlayers()
@@ -189,10 +189,10 @@ void InGameChatMessage::sendToSpectators()
 
 void InGameChatMessage::enqueueSpectatorMessage(NETQUEUE queue, char const* formattedMsg)
 {
-	NETbeginEncode(queue, NET_SPECTEXTMSG);
-	NETuint32_t(&sender);
-	NETstring(formattedMsg, MAX_CONSOLE_STRING_LENGTH);
-	NETend();
+	auto w = NETbeginEncode(queue, NET_SPECTEXTMSG);
+	NETuint32_t(w, sender);
+	NETstring(w, formattedMsg, MAX_CONSOLE_STRING_LENGTH);
+	NETend(w);
 }
 
 void InGameChatMessage::addReceiverByPosition(uint32_t playerPosition)

--- a/src/cheat.cpp
+++ b/src/cheat.cpp
@@ -186,9 +186,9 @@ void sendProcessDebugMappings(bool val)
 	{
 		return;
 	}
-	NETbeginEncode(NETgameQueue(selectedPlayer), GAME_DEBUG_MODE);
-	NETbool(&val);
-	NETend();
+	auto w = NETbeginEncode(NETgameQueue(selectedPlayer), GAME_DEBUG_MODE);
+	NETbool(w, val);
+	NETend(w);
 }
 
 #if !defined(__clang__) && defined(__GNUC__) && (12 <= __GNUC__)
@@ -219,9 +219,9 @@ static std::string getWantedDebugMappingStatuses(const DebugInputManager& dbgInp
 void recvProcessDebugMappings(NETQUEUE queue)
 {
 	bool val = false;
-	NETbeginDecode(queue, GAME_DEBUG_MODE);
-	NETbool(&val);
-	NETend();
+	auto r = NETbeginDecode(queue, GAME_DEBUG_MODE);
+	NETbool(r, val);
+	NETend(r);
 
 	DebugInputManager& dbgInputManager = gInputManager.debugManager();
 	bool oldDebugMode = dbgInputManager.debugMappingsAllowed();

--- a/src/hci/teamstrategy.cpp
+++ b/src/hci/teamstrategy.cpp
@@ -165,13 +165,15 @@ void sendStrategyPlanUpdate(uint32_t forPlayer)
 		// Only send to active (connected) human players - *NOT* AIs (which would effectively just have to send this to the host)
 		if (isHumanPlayer(player))
 		{
-			if (NETbeginEncodeSecured(NETnetQueue(player), NET_TEAM_STRATEGY))
+			auto w = NETbeginEncodeSecured(NETnetQueue(player), NET_TEAM_STRATEGY);
+			if (w)
 			{
+				auto& wref = *w;
 				uint32_t sender = forPlayer;
-				NETuint32_t(&sender);
-				NETbytes(&weaponStates);
-				NETbytes(&unitStates);
-				NETend();
+				NETuint32_t(wref, sender);
+				NETbytes(wref, weaponStates);
+				NETbytes(wref, unitStates);
+				NETend(wref);
 			}
 		}
 	}
@@ -183,14 +185,16 @@ bool recvStrategyPlanUpdate(NETQUEUE queue)
 	std::vector<uint8_t> weaponStates;
 	std::vector<uint8_t> unitStates;
 
-	if (!NETbeginDecodeSecured(queue, NET_TEAM_STRATEGY))
+	auto r = NETbeginDecodeSecured(queue, NET_TEAM_STRATEGY);
+	if (!r)
 	{
 		return false;
 	}
-	NETuint32_t(&sender);
-	NETbytes(&weaponStates);
-	NETbytes(&unitStates);
-	NETend();
+	auto& rref = *r;
+	NETuint32_t(rref, sender);
+	NETbytes(rref, weaponStates);
+	NETbytes(rref, unitStates);
+	NETend(rref);
 
 	if (whosResponsible(sender) != queue.index)
 	{

--- a/src/move.cpp
+++ b/src/move.cpp
@@ -123,11 +123,11 @@ bool moveSetFormationSpeedLimiting(uint32_t player, bool enabled)
 		auto currentPlayer = static_cast<uint8_t>(player);
 		uint8_t optType = SYNC_OPT_FORMATION_SPEED_LIMITING;
 		uint8_t value = (enabled) ? 1 : 0;
-		NETbeginEncode(NETgameQueue(currentPlayer), GAME_SYNC_OPT_CHANGE);
-		NETuint8_t(&currentPlayer);		// player
-		NETuint8_t(&optType);
-		NETuint8_t(&value);				// formation speed limiting value
-		return NETend();
+		auto w = NETbeginEncode(NETgameQueue(currentPlayer), GAME_SYNC_OPT_CHANGE);
+		NETuint8_t(w, currentPlayer);		// player
+		NETuint8_t(w, optType);
+		NETuint8_t(w, value);				// formation speed limiting value
+		return NETend(w);
 	}
 	else
 	{
@@ -162,11 +162,11 @@ bool recvSyncOptChange(NETQUEUE queue)
 	uint8_t optType;
 	uint8_t	value;
 
-	NETbeginDecode(queue, GAME_SYNC_OPT_CHANGE);
-	NETuint8_t(&player); // the player
-	NETuint8_t(&optType);
-	NETuint8_t(&value);
-	NETend();
+	auto r = NETbeginDecode(queue, GAME_SYNC_OPT_CHANGE);
+	NETuint8_t(r, player); // the player
+	NETuint8_t(r, optType);
+	NETuint8_t(r, value);
+	NETend(r);
 
 	if (!canGiveOrdersFor(queue.index, player))
 	{

--- a/src/multigifts.cpp
+++ b/src/multigifts.cpp
@@ -70,12 +70,12 @@ bool recvGift(NETQUEUE queue)
 	int		audioTrack;
 	uint32_t droidID;
 
-	NETbeginDecode(queue, GAME_GIFT);
-	NETuint8_t(&type);
-	NETuint8_t(&from);
-	NETuint8_t(&to);
-	NETuint32_t(&droidID);
-	NETend();
+	auto r = NETbeginDecode(queue, GAME_GIFT);
+	NETuint8_t(r, type);
+	NETuint8_t(r, from);
+	NETuint8_t(r, to);
+	NETuint32_t(r, droidID);
+	NETend(r);
 
 	if (!canGiveOrdersFor(queue.index, from))
 	{
@@ -192,12 +192,12 @@ static void giftAutoGame(uint8_t from, uint8_t to, bool send)
 	{
 		uint8_t subType = AUTOGAME_GIFT;
 
-		NETbeginEncode(NETgameQueue(selectedPlayer), GAME_GIFT);
-		NETuint8_t(&subType);
-		NETuint8_t(&from);
-		NETuint8_t(&to);
-		NETuint32_t(&dummy);
-		NETend();
+		auto w = NETbeginEncode(NETgameQueue(selectedPlayer), GAME_GIFT);
+		NETuint8_t(w, subType);
+		NETuint8_t(w, from);
+		NETuint8_t(w, to);
+		NETuint32_t(w, dummy);
+		NETend(w);
 		debug(LOG_SYNC, "We (%d) are telling %d we want to enable/disable a autogame", from, to);
 	}
 	// If we are receiving the "gift"
@@ -223,12 +223,12 @@ void giftRadar(uint8_t from, uint8_t to, bool send)
 	{
 		uint8_t subType = RADAR_GIFT;
 
-		NETbeginEncode(NETgameQueue(selectedPlayer), GAME_GIFT);
-		NETuint8_t(&subType);
-		NETuint8_t(&from);
-		NETuint8_t(&to);
-		NETuint32_t(&dummy);
-		NETend();
+		auto w = NETbeginEncode(NETgameQueue(selectedPlayer), GAME_GIFT);
+		NETuint8_t(w, subType);
+		NETuint8_t(w, from);
+		NETuint8_t(w, to);
+		NETuint32_t(w, dummy);
+		NETend(w);
 	}
 	// If we are receiving the gift
 	else
@@ -337,13 +337,13 @@ static void sendGiftDroids(uint8_t from, uint8_t to)
 				continue;
 			}
 
-			NETbeginEncode(NETgameQueue(selectedPlayer), GAME_GIFT);
-			NETuint8_t(&giftType);
-			NETuint8_t(&from);
-			NETuint8_t(&to);
+			auto w = NETbeginEncode(NETgameQueue(selectedPlayer), GAME_GIFT);
+			NETuint8_t(w, giftType);
+			NETuint8_t(w, from);
+			NETuint8_t(w, to);
 			// Add the droid to the packet
-			NETuint32_t(&(*psD)->id);
-			NETend();
+			NETuint32_t(w, (*psD)->id);
+			NETend(w);
 
 			// Decrement the number of droids left to send
 			--totalToSend;
@@ -362,12 +362,12 @@ static void giftResearch(uint8_t from, uint8_t to, bool send)
 	{
 		uint8_t giftType = RESEARCH_GIFT;
 
-		NETbeginEncode(NETgameQueue(selectedPlayer), GAME_GIFT);
-		NETuint8_t(&giftType);
-		NETuint8_t(&from);
-		NETuint8_t(&to);
-		NETuint32_t(&dummy);
-		NETend();
+		auto w = NETbeginEncode(NETgameQueue(selectedPlayer), GAME_GIFT);
+		NETuint8_t(w, giftType);
+		NETuint8_t(w, from);
+		NETuint8_t(w, to);
+		NETuint32_t(w, dummy);
+		NETend(w);
 	}
 	else if (alliancesCanGiveResearchAndRadar(game.alliance))
 	{
@@ -397,12 +397,12 @@ void giftPower(uint8_t from, uint8_t to, uint32_t amount, bool send)
 	{
 		uint8_t giftType = POWER_GIFT;
 
-		NETbeginEncode(NETgameQueue(selectedPlayer), GAME_GIFT);
-		NETuint8_t(&giftType);
-		NETuint8_t(&from);
-		NETuint8_t(&to);
-		NETuint32_t(&amount);
-		NETend();
+		auto w = NETbeginEncode(NETgameQueue(selectedPlayer), GAME_GIFT);
+		NETuint8_t(w, giftType);
+		NETuint8_t(w, from);
+		NETuint8_t(w, to);
+		NETuint32_t(w, amount);
+		NETend(w);
 	}
 	else
 	{
@@ -641,12 +641,12 @@ void formAlliance(uint8_t p1, uint8_t p2, bool prop, bool allowAudio, bool allow
 
 void sendAlliance(uint8_t from, uint8_t to, uint8_t state, int32_t value)
 {
-	NETbeginEncode(NETgameQueue(selectedPlayer), GAME_ALLIANCE);
-	NETuint8_t(&from);
-	NETuint8_t(&to);
-	NETuint8_t(&state);
-	NETint32_t(&value);
-	NETend();
+	auto w = NETbeginEncode(NETgameQueue(selectedPlayer), GAME_ALLIANCE);
+	NETuint8_t(w, from);
+	NETuint8_t(w, to);
+	NETuint8_t(w, state);
+	NETint32_t(w, value);
+	NETend(w);
 }
 
 bool recvAlliance(NETQUEUE queue, bool allowAudio)
@@ -654,12 +654,12 @@ bool recvAlliance(NETQUEUE queue, bool allowAudio)
 	uint8_t to, from, state;
 	int32_t value;
 
-	NETbeginDecode(queue, GAME_ALLIANCE);
-	NETuint8_t(&from);
-	NETuint8_t(&to);
-	NETuint8_t(&state);
-	NETint32_t(&value);
-	NETend();
+	auto r = NETbeginDecode(queue, GAME_ALLIANCE);
+	NETuint8_t(r, from);
+	NETuint8_t(r, to);
+	NETuint8_t(r, state);
+	NETint32_t(r, value);
+	NETend(r);
 
 	if (!canGiveOrdersFor(queue.index, from))
 	{
@@ -764,28 +764,28 @@ void  technologyGiveAway(const STRUCTURE *pS)
  */
 void sendMultiPlayerFeature(uint32_t ref, uint32_t x, uint32_t y, uint32_t id)
 {
-	NETbeginEncode(NETgameQueue(selectedPlayer), GAME_DEBUG_ADD_FEATURE);
+	auto w = NETbeginEncode(NETgameQueue(selectedPlayer), GAME_DEBUG_ADD_FEATURE);
 	{
-		NETuint32_t(&ref);
-		NETuint32_t(&x);
-		NETuint32_t(&y);
-		NETuint32_t(&id);
+		NETuint32_t(w, ref);
+		NETuint32_t(w, x);
+		NETuint32_t(w, y);
+		NETuint32_t(w, id);
 	}
-	NETend();
+	NETend(w);
 }
 
 void recvMultiPlayerFeature(NETQUEUE queue)
 {
 	uint32_t ref = 0xff, x = 0, y = 0, id = 0;
 
-	NETbeginDecode(queue, GAME_DEBUG_ADD_FEATURE);
+	auto r = NETbeginDecode(queue, GAME_DEBUG_ADD_FEATURE);
 	{
-		NETuint32_t(&ref);
-		NETuint32_t(&x);
-		NETuint32_t(&y);
-		NETuint32_t(&id);
+		NETuint32_t(r, ref);
+		NETuint32_t(r, x);
+		NETuint32_t(r, y);
+		NETuint32_t(r, id);
 	}
-	NETend();
+	NETend(r);
 
 	const DebugInputManager& dbgInputManager = gInputManager.debugManager();
 	if (!dbgInputManager.debugMappingsAllowed() && bMultiPlayer)

--- a/src/multiint.cpp
+++ b/src/multiint.cpp
@@ -2524,12 +2524,10 @@ static bool SendTeamRequest(UBYTE player, UBYTE chosenTeam)
 	}
 	else
 	{
-		NETbeginEncode(NETnetQueue(NetPlay.hostPlayer), NET_TEAMREQUEST);
-
-		NETuint8_t(&player);
-		NETuint8_t(&chosenTeam);
-
-		NETend();
+		auto w = NETbeginEncode(NETnetQueue(NetPlay.hostPlayer), NET_TEAMREQUEST);
+		NETuint8_t(w, player);
+		NETuint8_t(w, chosenTeam);
+		NETend(w);
 
 	}
 	return true;
@@ -2539,12 +2537,12 @@ bool recvTeamRequest(NETQUEUE queue)
 {
 	ASSERT_HOST_ONLY(return true);
 
-	NETbeginDecode(queue, NET_TEAMREQUEST);
+	auto r = NETbeginDecode(queue, NET_TEAMREQUEST);
 
 	UBYTE player, team;
-	NETuint8_t(&player);
-	NETuint8_t(&team);
-	NETend();
+	NETuint8_t(r, player);
+	NETuint8_t(r, team);
+	NETend(r);
 
 	if (player >= MAX_PLAYERS || team >= MAX_PLAYERS)
 	{
@@ -2599,10 +2597,10 @@ bool sendReadyRequest(UBYTE player, bool bReady)
 	}
 	else
 	{
-		NETbeginEncode(NETnetQueue(NetPlay.hostPlayer), NET_READY_REQUEST);
-		NETuint8_t(&player);
-		NETbool(&bReady);
-		NETend();
+		auto w = NETbeginEncode(NETnetQueue(NetPlay.hostPlayer), NET_READY_REQUEST);
+		NETuint8_t(w, player);
+		NETbool(w, bReady);
+		NETend(w);
 	}
 	return true;
 }
@@ -2611,13 +2609,13 @@ bool recvReadyRequest(NETQUEUE queue)
 {
 	ASSERT_HOST_ONLY(return true);
 
-	NETbeginDecode(queue, NET_READY_REQUEST);
+	auto r = NETbeginDecode(queue, NET_READY_REQUEST);
 
 	UBYTE player;
 	bool bReady = false;
-	NETuint8_t(&player);
-	NETbool(&bReady);
-	NETend();
+	NETuint8_t(r, player);
+	NETbool(r, bReady);
+	NETend(r);
 
 	if (player >= MAX_CONNECTED_PLAYERS)
 	{
@@ -2805,10 +2803,10 @@ bool SendColourRequest(UBYTE player, UBYTE col)
 	else
 	{
 		// clients tell the host which color they want
-		NETbeginEncode(NETnetQueue(NetPlay.hostPlayer), NET_COLOURREQUEST);
-		NETuint8_t(&player);
-		NETuint8_t(&col);
-		NETend();
+		auto w = NETbeginEncode(NETnetQueue(NetPlay.hostPlayer), NET_COLOURREQUEST);
+		NETuint8_t(w, player);
+		NETuint8_t(w, col);
+		NETend(w);
 	}
 	return true;
 }
@@ -2858,10 +2856,10 @@ static bool SendFactionRequest(UBYTE player, UBYTE faction)
 	else
 	{
 		// clients tell the host which color they want
-		NETbeginEncode(NETnetQueue(NetPlay.hostPlayer), NET_FACTIONREQUEST);
-		NETuint8_t(&player);
-		NETuint8_t(&faction);
-		NETend();
+		auto w = NETbeginEncode(NETnetQueue(NetPlay.hostPlayer), NET_FACTIONREQUEST);
+		NETuint8_t(w, player);
+		NETuint8_t(w, faction);
+		NETend(w);
 	}
 	return true;
 }
@@ -2876,10 +2874,10 @@ static bool SendPositionRequest(UBYTE player, UBYTE position)
 	{
 		debug(LOG_NET, "Requesting the host to change our position. From %d to %d", player, position);
 		// clients tell the host which position they want
-		NETbeginEncode(NETnetQueue(NetPlay.hostPlayer), NET_POSITIONREQUEST);
-		NETuint8_t(&player);
-		NETuint8_t(&position);
-		NETend();
+		auto w = NETbeginEncode(NETnetQueue(NetPlay.hostPlayer), NET_POSITIONREQUEST);
+		NETuint8_t(w, player);
+		NETuint8_t(w, position);
+		NETend(w);
 	}
 	return true;
 }
@@ -2888,12 +2886,12 @@ bool recvFactionRequest(NETQUEUE queue)
 {
 	ASSERT_HOST_ONLY(return true);
 
-	NETbeginDecode(queue, NET_FACTIONREQUEST);
+	auto r = NETbeginDecode(queue, NET_FACTIONREQUEST);
 
 	UBYTE player, faction;
-	NETuint8_t(&player);
-	NETuint8_t(&faction);
-	NETend();
+	NETuint8_t(r, player);
+	NETuint8_t(r, faction);
+	NETend(r);
 
 	if (player >= MAX_PLAYERS)
 	{
@@ -2924,12 +2922,12 @@ bool recvColourRequest(NETQUEUE queue)
 {
 	ASSERT_HOST_ONLY(return true);
 
-	NETbeginDecode(queue, NET_COLOURREQUEST);
+	auto r = NETbeginDecode(queue, NET_COLOURREQUEST);
 
 	UBYTE player, col;
-	NETuint8_t(&player);
-	NETuint8_t(&col);
-	NETend();
+	NETuint8_t(r, player);
+	NETuint8_t(r, col);
+	NETend(r);
 
 	if (player >= MAX_PLAYERS)
 	{
@@ -2953,12 +2951,12 @@ bool recvPositionRequest(NETQUEUE queue)
 {
 	ASSERT_HOST_ONLY(return true);
 
-	NETbeginDecode(queue, NET_POSITIONREQUEST);
+	auto r = NETbeginDecode(queue, NET_POSITIONREQUEST);
 
 	UBYTE	player, position;
-	NETuint8_t(&player);
-	NETuint8_t(&position);
-	NETend();
+	NETuint8_t(r, player);
+	NETuint8_t(r, position);
+	NETend(r);
 	debug(LOG_NET, "Host received position request from player %d to %d", player, position);
 
 	if (player >= MAX_PLAYERS || position >= MAX_PLAYERS)
@@ -3002,10 +3000,10 @@ static bool SendPlayerSlotTypeRequest(uint32_t player, bool isSpectator)
 
 	debug(LOG_NET, "Requesting the host to change our slot type. From %s to %s", originalPlayerSlotType, desiredPlayerSlotType);
 	// clients tell the host which player slot type they want (but the host may not allow)
-	NETbeginEncode(NETnetQueue((!NetPlay.isHost) ? NetPlay.hostPlayer : player), NET_PLAYER_SLOTTYPE_REQUEST);
-	NETuint32_t(&player);
-	NETbool(&isSpectator);
-	NETend();
+	auto w = NETbeginEncode(NETnetQueue((!NetPlay.isHost) ? NetPlay.hostPlayer : player), NET_PLAYER_SLOTTYPE_REQUEST);
+	NETuint32_t(w, player);
+	NETbool(w, isSpectator);
+	NETend(w);
 	return true;
 }
 
@@ -3016,10 +3014,10 @@ static bool recvPlayerSlotTypeRequestAndPop(WzMultiplayerOptionsTitleUI& titleUI
 
 	uint32_t playerIndex;
 	bool desiredIsSpectator = false;
-	NETbeginDecode(queue, NET_PLAYER_SLOTTYPE_REQUEST);
-	NETuint32_t(&playerIndex);
-	NETbool(&desiredIsSpectator);
-	NETend();
+	auto r = NETbeginDecode(queue, NET_PLAYER_SLOTTYPE_REQUEST);
+	NETuint32_t(r, playerIndex);
+	NETbool(r, desiredIsSpectator);
+	NETend(r);
 
 	NETpop(queue); // this function *must* handle popping the message itself since, if a player index switch occurs, the queue may be invalidated
 
@@ -3264,10 +3262,10 @@ static SwapPlayerIndexesResult recvSwapPlayerIndexes(NETQUEUE queue, const std::
 	uint32_t playerIndexA;
 	uint32_t playerIndexB;
 
-	NETbeginDecode(queue, NET_PLAYER_SWAP_INDEX);
-	NETuint32_t(&playerIndexA);
-	NETuint32_t(&playerIndexB);
-	NETend();
+	auto r = NETbeginDecode(queue, NET_PLAYER_SWAP_INDEX);
+	NETuint32_t(r, playerIndexA);
+	NETuint32_t(r, playerIndexB);
+	NETend(r);
 
 	if (!ingame.localJoiningInProgress)  // Only if game hasn't actually started yet.
 	{
@@ -3333,10 +3331,10 @@ static SwapPlayerIndexesResult recvSwapPlayerIndexes(NETQUEUE queue, const std::
 		bool selectedPlayerWasSpectator = wasSpectator[(playerIndexA == selectedPlayer) ? 0 : 1];
 
 		// Send an acknowledgement that we received and are processing the player index swap for us
-		NETbeginEncode(NETnetQueue(NetPlay.hostPlayer), NET_PLAYER_SWAP_INDEX_ACK);
-		NETuint32_t(&oldPlayerIndex);
-		NETuint32_t(&newPlayerIndex);
-		NETend();
+		auto w = NETbeginEncode(NETnetQueue(NetPlay.hostPlayer), NET_PLAYER_SWAP_INDEX_ACK);
+		NETuint32_t(w, oldPlayerIndex);
+		NETuint32_t(w, newPlayerIndex);
+		NETend(w);
 
 		// 1.) Basically what happens in NETjoinGame after receiving NET_ACCEPTED
 
@@ -4377,9 +4375,9 @@ static void SendFireUp()
 
 	debug(LOG_INFO, "Sending NET_FIREUP");
 
-	NETbeginEncode(NETbroadcastQueue(), NET_FIREUP);
-	NETuint32_t(&randomSeed);
-	NETend();
+	auto w = NETbeginEncode(NETbroadcastQueue(), NET_FIREUP);
+	NETuint32_t(w, randomSeed);
+	NETend(w);
 	printSearchPath();
 	gameSRand(randomSeed);  // Set the seed for the synchronised random number generator. The clients will use the same seed.
 }
@@ -4392,11 +4390,11 @@ void kickPlayer(uint32_t player_id, const char *reason, LOBBY_ERROR_TYPES type, 
 	debug(LOG_INFO, "Kicking player %u (%s). Reason: %s", (unsigned int)player_id, getPlayerName(player_id), reason);
 
 	// send a kick msg
-	NETbeginEncode(NETbroadcastQueue(), NET_KICK);
-	NETuint32_t(&player_id);
-	NETstring(reason, MAX_KICK_REASON);
-	NETenum(&type);
-	NETend();
+	auto w = NETbeginEncode(NETbroadcastQueue(), NET_KICK);
+	NETuint32_t(w, player_id);
+	NETstring(w, reason, MAX_KICK_REASON);
+	NETenum(w, type);
+	NETend(w);
 	NETflush();
 	wzDelay(300);
 
@@ -5179,8 +5177,8 @@ static void stopJoining(std::shared_ptr<WzTitleUI> parent)
 	{
 		// annouce we are leaving...
 		debug(LOG_NET, "Host is quitting game...");
-		NETbeginEncode(NETbroadcastQueue(), NET_HOST_DROPPED);
-		NETend();
+		auto w = NETbeginEncode(NETbroadcastQueue(), NET_HOST_DROPPED);
+		NETend(w);
 		sendLeavingMsg();								// say goodbye
 		NETclose();										// quit running game.
 		ActivityManager::instance().hostLobbyQuit();
@@ -6427,9 +6425,9 @@ void WzMultiplayerOptionsTitleUI::frontendMultiMessages(bool running)
 				Sha256 hash;
 				hash.setZero();
 
-				NETbeginDecode(queue, NET_FILE_CANCELLED);
-				NETbin(hash.bytes, hash.Bytes);
-				NETend();
+				auto r = NETbeginDecode(queue, NET_FILE_CANCELLED);
+				NETbin(r, hash.bytes, hash.Bytes);
+				NETend(r);
 
 				debug(LOG_WARNING, "Received file cancel request from player %u, they weren't expecting the file.", queue.index);
 				auto &pWzFiles = NetPlay.players[queue.index].wzFiles;
@@ -6584,11 +6582,11 @@ void WzMultiplayerOptionsTitleUI::frontendMultiMessages(bool running)
 
 				resetReadyStatus(false, isBlindSimpleLobby(game.blindMode));
 
-				NETbeginDecode(queue, NET_PLAYER_DROPPED);
+				auto r = NETbeginDecode(queue, NET_PLAYER_DROPPED);
 				{
-					NETuint32_t(&player_id);
+					NETuint32_t(r, player_id);
 				}
-				NETend();
+				NETend(r);
 
 				if (player_id >= MAX_CONNECTED_PLAYERS)
 				{
@@ -6626,10 +6624,10 @@ void WzMultiplayerOptionsTitleUI::frontendMultiMessages(bool running)
 
 				resetReadyStatus(false);
 
-				NETbeginDecode(queue, NET_PLAYERRESPONDING);
+				auto r = NETbeginDecode(queue, NET_PLAYERRESPONDING);
 				// the player that has just responded
-				NETuint32_t(&player_id);
-				NETend();
+				NETuint32_t(r, player_id);
+				NETend(r);
 
 				if (player_id >= MAX_CONNECTED_PLAYERS)
 				{
@@ -6662,9 +6660,9 @@ void WzMultiplayerOptionsTitleUI::frontendMultiMessages(bool running)
 			if (ingame.localOptionsReceived)
 			{
 				uint32_t randomSeed = 0;
-				NETbeginDecode(queue, NET_FIREUP);
-				NETuint32_t(&randomSeed);
-				NETend();
+				auto r = NETbeginDecode(queue, NET_FIREUP);
+				NETuint32_t(r, randomSeed);
+				NETend(r);
 
 				saveMultiOptionPrefValues(sPlayer, selectedPlayer); // persist any changes to multioption preferences
 
@@ -6693,11 +6691,11 @@ void WzMultiplayerOptionsTitleUI::frontendMultiMessages(bool running)
 				char reason[MAX_KICK_REASON];
 				LOBBY_ERROR_TYPES KICK_TYPE = ERROR_NOERROR;
 
-				NETbeginDecode(queue, NET_KICK);
-				NETuint32_t(&player_id);
-				NETstring(reason, MAX_KICK_REASON);
-				NETenum(&KICK_TYPE);
-				NETend();
+				auto r = NETbeginDecode(queue, NET_KICK);
+				NETuint32_t(r, player_id);
+				NETstring(r, reason, MAX_KICK_REASON);
+				NETenum(r, KICK_TYPE);
+				NETend(r);
 
 				if (player_id >= MAX_CONNECTED_PLAYERS)
 				{
@@ -6744,13 +6742,14 @@ void WzMultiplayerOptionsTitleUI::frontendMultiMessages(bool running)
 				break;
 			}
 		case NET_HOST_DROPPED:
-			NETbeginDecode(queue, NET_HOST_DROPPED);
-			NETend();
+		{
+			auto r = NETbeginDecode(queue, NET_HOST_DROPPED);
+			NETend(r);
 			stopJoining(std::make_shared<WzMsgBoxTitleUI>(WzString(_("Connection lost:")), WzString(_("No connection to host.")), parent));
 			debug(LOG_NET, "The host has quit!");
 			setLobbyError(ERROR_HOSTDROPPED);
 			break;
-
+		}
 		case NET_TEXTMSG:					// Chat message
 			if (ingame.localOptionsReceived)
 			{

--- a/src/multijoin.cpp
+++ b/src/multijoin.cpp
@@ -398,9 +398,9 @@ static void sendPlayerLeft(uint32_t playerIndex)
 
 	uint32_t forcedPlayerIndex = whosResponsible(playerIndex);
 	NETQUEUE(*netQueueType)(unsigned) = forcedPlayerIndex != selectedPlayer ? NETgameQueueForced : NETgameQueue;
-	NETbeginEncode(netQueueType(forcedPlayerIndex), GAME_PLAYER_LEFT);
-	NETuint32_t(&playerIndex);
-	NETend();
+	auto w = NETbeginEncode(netQueueType(forcedPlayerIndex), GAME_PLAYER_LEFT);
+	NETuint32_t(w, playerIndex);
+	NETend(w);
 }
 
 static void addConsolePlayerLeftMessage(unsigned playerIndex)
@@ -429,9 +429,9 @@ static void addConsolePlayerJoinMessage(unsigned playerIndex)
 void recvPlayerLeft(NETQUEUE queue)
 {
 	uint32_t playerIndex = 0;
-	NETbeginDecode(queue, GAME_PLAYER_LEFT);
-	NETuint32_t(&playerIndex);
-	NETend();
+	auto r = NETbeginDecode(queue, GAME_PLAYER_LEFT);
+	NETuint32_t(r, playerIndex);
+	NETend(r);
 
 	addConsolePlayerLeftMessage(playerIndex);
 
@@ -504,9 +504,9 @@ bool MultiPlayerLeave(UDWORD playerIndex)
 
 		if (bDisplayMultiJoiningStatus) // if still waiting for players to load *or* waiting for game to start...
 		{
-			NETbeginEncode(NETbroadcastQueue(), NET_PLAYER_DROPPED);
-			NETuint32_t(&playerIndex);
-			NETend();
+			auto w = NETbeginEncode(NETbroadcastQueue(), NET_PLAYER_DROPPED);
+			NETuint32_t(w, playerIndex);
+			NETend(w);
 			// only set ingame.JoiningInProgress[player_id] to false
 			// when the game starts, it will handle the GAME_PLAYER_LEFT message in their queue properly
 			ingame.JoiningInProgress[playerIndex] = false;
@@ -607,12 +607,12 @@ bool sendDataCheck()
 {
 	int i = 0;
 
-	NETbeginEncode(NETnetQueue(NetPlay.hostPlayer), NET_DATA_CHECK);		// only need to send to HOST
+	auto w = NETbeginEncode(NETnetQueue(NetPlay.hostPlayer), NET_DATA_CHECK);		// only need to send to HOST
 	for (i = 0; i < DATA_MAXDATA; i++)
 	{
-		NETuint32_t(&DataHash[i]);
+		NETuint32_t(w, DataHash[i]);
 	}
-	NETend();
+	NETend(w);
 	debug(LOG_NET, "sent hash to host");
 	return true;
 }
@@ -629,12 +629,12 @@ bool recvDataCheck(NETQUEUE queue)
 		return false;
 	}
 
-	NETbeginDecode(queue, NET_DATA_CHECK);
+	auto r = NETbeginDecode(queue, NET_DATA_CHECK);
 	for (i = 0; i < DATA_MAXDATA; i++)
 	{
-		NETuint32_t(&tempBuffer[i]);
+		NETuint32_t(r, tempBuffer[i]);
 	}
-	NETend();
+	NETend(r);
 
 	if (player >= MAX_CONNECTED_PLAYERS) // invalid player number.
 	{

--- a/src/multiopt.cpp
+++ b/src/multiopt.cpp
@@ -78,49 +78,48 @@ void sendOptions()
 
 	game.modHashes = getModHashList();
 
-	NETbeginEncode(NETbroadcastQueue(), NET_OPTIONS);
-
+	auto w = NETbeginEncode(NETbroadcastQueue(), NET_OPTIONS);
 	// First send information about the game
-	NETuint8_t(reinterpret_cast<uint8_t*>(&game.type));
-	NETstring(game.map, 128);
-	NETbin(game.hash.bytes, game.hash.Bytes);
+	NETuint8_t(w, static_cast<uint8_t>(game.type));
+	NETstring(w, game.map, 128);
+	NETbin(w, game.hash.bytes, game.hash.Bytes);
 	uint32_t modHashesSize = game.modHashes.size();
-	NETuint32_t(&modHashesSize);
+	NETuint32_t(w, modHashesSize);
 	for (auto &hash : game.modHashes)
 	{
-		NETbin(hash.bytes, hash.Bytes);
+		NETbin(w, hash.bytes, hash.Bytes);
 	}
-	NETuint8_t(&game.maxPlayers);
-	NETstring(game.name, 128);
-	NETuint32_t(&game.power);
-	NETuint8_t(&game.base);
-	NETuint8_t(&game.alliance);
-	NETuint8_t(&game.scavengers);
-	NETbool(&game.isMapMod);
-	NETuint32_t(&game.techLevel);
+	NETuint8_t(w, game.maxPlayers);
+	NETstring(w, game.name, 128);
+	NETuint32_t(w, game.power);
+	NETuint8_t(w, game.base);
+	NETuint8_t(w, game.alliance);
+	NETuint8_t(w, game.scavengers);
+	NETbool(w, game.isMapMod);
+	NETuint32_t(w, game.techLevel);
 	if (game.inactivityMinutes > 0 && game.inactivityMinutes < MIN_MPINACTIVITY_MINUTES)
 	{
 		debug(LOG_ERROR, "Invalid inactivityMinutes value specified: %" PRIu32 "; resetting to: %" PRIu32, game.inactivityMinutes, static_cast<uint32_t>(MIN_MPINACTIVITY_MINUTES));
 		game.inactivityMinutes = MIN_MPINACTIVITY_MINUTES;
 	}
-	NETuint32_t(&game.inactivityMinutes);
+	NETuint32_t(w, game.inactivityMinutes);
 	if (game.gameTimeLimitMinutes > 0 && game.gameTimeLimitMinutes < MIN_MPGAMETIMELIMIT_MINUTES)
 	{
 		debug(LOG_ERROR, "Invalid gameTimeLimitMinutes value specified: %" PRIu32 "; resetting to: %" PRIu32, game.gameTimeLimitMinutes, static_cast<uint32_t>(MIN_MPGAMETIMELIMIT_MINUTES));
 		game.gameTimeLimitMinutes = MIN_MPGAMETIMELIMIT_MINUTES;
 	}
-	NETuint32_t(&game.gameTimeLimitMinutes);
-	NETuint8_t(reinterpret_cast<uint8_t*>(&game.playerLeaveMode));
+	NETuint32_t(w, game.gameTimeLimitMinutes);
+	NETuint8_t(w, static_cast<uint8_t>(game.playerLeaveMode));
 
 	for (unsigned i = 0; i < MAX_PLAYERS; i++)
 	{
-		NETint8_t(reinterpret_cast<int8_t*>(&NetPlay.players[i].difficulty));
+		NETint8_t(w, static_cast<int8_t>(NetPlay.players[i].difficulty));
 	}
 
 	// Send the list of who is still joining
 	for (unsigned i = 0; i < MAX_CONNECTED_PLAYERS; i++)
 	{
-		NETbool(&ingame.JoiningInProgress[i]);
+		NETbool(w, ingame.JoiningInProgress[i]);
 	}
 
 	// Same goes for the alliances
@@ -128,7 +127,7 @@ void sendOptions()
 	{
 		for (unsigned j = 0; j < MAX_PLAYERS; j++)
 		{
-			NETuint8_t(&alliances[i][j]);
+			NETuint8_t(w, alliances[i][j]);
 		}
 	}
 
@@ -139,18 +138,18 @@ void sendOptions()
 		debug(LOG_ERROR, "Number of structure limits (%" PRIu32") exceeds maximum supported - truncating", numStructureLimits);
 		numStructureLimits = MAX_STRUCTURE_LIMITS;
 	}
-	NETuint32_t(&numStructureLimits);
+	NETuint32_t(w, numStructureLimits);
 	debug(LOG_NET, "(Host) Structure limits to process on client is %zu", ingame.structureLimits.size());
 	// Send the structures changed
 	for (auto structLimit : ingame.structureLimits)
 	{
-		NETuint32_t(&structLimit.id);
-		NETuint32_t(&structLimit.limit);
+		NETuint32_t(w, structLimit.id);
+		NETuint32_t(w, structLimit.limit);
 	}
 	updateStructureDisabledFlags();
-	NETuint8_t(&ingame.flags);
+	NETuint8_t(w, ingame.flags);
 
-	NETend();
+	NETend(w);
 
 	// also send a NET_HOST_CONFIG msg here
 	sendHostConfig();
@@ -174,42 +173,42 @@ bool recvOptions(NETQUEUE queue)
 	MULTIPLAYERGAME priorGameInfo = game;
 
 	debug(LOG_NET, "Receiving options from host");
-	NETbeginDecode(queue, NET_OPTIONS);
+	auto r = NETbeginDecode(queue, NET_OPTIONS);
 
 	// Get general information about the game
-	NETuint8_t(reinterpret_cast<uint8_t*>(&game.type));
-	NETstring(game.map, 128);
-	NETbin(game.hash.bytes, game.hash.Bytes);
+	NETuint8_t(r, reinterpret_cast<uint8_t&>(game.type));
+	NETstring(r, game.map, 128);
+	NETbin(r, game.hash.bytes, game.hash.Bytes);
 	uint32_t modHashesSize;
-	NETuint32_t(&modHashesSize);
+	NETuint32_t(r, modHashesSize);
 	ASSERT_OR_RETURN(false, modHashesSize < 1000000, "Way too many mods %u", modHashesSize);
 	game.modHashes.resize(modHashesSize);
 	for (auto &hash : game.modHashes)
 	{
-		NETbin(hash.bytes, hash.Bytes);
+		NETbin(r, hash.bytes, hash.Bytes);
 	}
-	NETuint8_t(&game.maxPlayers);
-	NETstring(game.name, 128);
-	NETuint32_t(&game.power);
-	NETuint8_t(&game.base);
-	NETuint8_t(&game.alliance);
-	NETuint8_t(&game.scavengers);
-	NETbool(&game.isMapMod);
-	NETuint32_t(&game.techLevel);
-	NETuint32_t(&game.inactivityMinutes);
+	NETuint8_t(r, game.maxPlayers);
+	NETstring(r, game.name, 128);
+	NETuint32_t(r, game.power);
+	NETuint8_t(r, game.base);
+	NETuint8_t(r, game.alliance);
+	NETuint8_t(r, game.scavengers);
+	NETbool(r, game.isMapMod);
+	NETuint32_t(r, game.techLevel);
+	NETuint32_t(r, game.inactivityMinutes);
 	if (game.inactivityMinutes > 0 && game.inactivityMinutes < MIN_MPINACTIVITY_MINUTES)
 	{
 		debug(LOG_ERROR, "Invalid inactivityMinutes value specified: %" PRIu32, game.inactivityMinutes);
 		return false;
 	}
-	NETuint32_t(&game.gameTimeLimitMinutes);
+	NETuint32_t(r, game.gameTimeLimitMinutes);
 	if (game.gameTimeLimitMinutes > 0 && game.gameTimeLimitMinutes < MIN_MPGAMETIMELIMIT_MINUTES)
 	{
 		debug(LOG_ERROR, "Invalid gameTimeLimitMinutes value specified: %" PRIu32, game.gameTimeLimitMinutes);
 		return false;
 	}
 	uint8_t tempPlayerLeaveModeValue = 0;
-	NETuint8_t(&tempPlayerLeaveModeValue);
+	NETuint8_t(r, tempPlayerLeaveModeValue);
 	if (tempPlayerLeaveModeValue > static_cast<uint8_t>(PLAYER_LEAVE_MODE_MAX))
 	{
 		debug(LOG_ERROR, "Invalid playerLeaveMode value specified: %" PRIu8, tempPlayerLeaveModeValue);
@@ -219,13 +218,13 @@ bool recvOptions(NETQUEUE queue)
 
 	for (i = 0; i < MAX_PLAYERS; i++)
 	{
-		NETint8_t(reinterpret_cast<int8_t*>(&NetPlay.players[i].difficulty));
+		NETint8_t(r, reinterpret_cast<int8_t&>(NetPlay.players[i].difficulty));
 	}
 
 	// Send the list of who is still joining
 	for (i = 0; i < MAX_CONNECTED_PLAYERS; i++)
 	{
-		NETbool(&ingame.JoiningInProgress[i]);
+		NETbool(r, ingame.JoiningInProgress[i]);
 	}
 
 	// Alliances
@@ -235,7 +234,7 @@ bool recvOptions(NETQUEUE queue)
 
 		for (j = 0; j < MAX_PLAYERS; j++)
 		{
-			NETuint8_t(&alliances[i][j]);
+			NETuint8_t(r, alliances[i][j]);
 		}
 	}
 
@@ -249,12 +248,12 @@ bool recvOptions(NETQUEUE queue)
 
 	// Get the number of structure limits to expect
 	uint32_t numStructureLimits = 0;
-	NETuint32_t(&numStructureLimits);
+	NETuint32_t(r, numStructureLimits);
 	debug(LOG_NET, "Host is sending us %u structure limits", numStructureLimits);
 	if (numStructureLimits > MAX_STRUCTURE_LIMITS)
 	{
 		debug(LOG_POPUP, "Number of structure limits (%" PRIu32") exceeds maximum supported. Incompatible host.", numStructureLimits);
-		NETend();
+		NETend(r);
 		return false;
 	}
 	// If there were any changes allocate memory for them
@@ -280,12 +279,12 @@ bool recvOptions(NETQUEUE queue)
 
 	for (i = 0; i < numStructureLimits; i++)
 	{
-		NETuint32_t(&ingame.structureLimits[i].id);
-		NETuint32_t(&ingame.structureLimits[i].limit);
+		NETuint32_t(r, ingame.structureLimits[i].id);
+		NETuint32_t(r, ingame.structureLimits[i].limit);
 	}
-	NETuint8_t(&ingame.flags);
+	NETuint8_t(r, ingame.flags);
 
-	NETend();
+	NETend(r);
 
 	// Do not print limits information if we don't have them loaded
 	if (bLimiterLoaded)
@@ -359,9 +358,9 @@ bool recvOptions(NETQUEUE queue)
 		NET_addDownloadingWZFile(WZFile(pFileHandle, filename, hash));
 
 		// Request the map/mod from the host
-		NETbeginEncode(NETnetQueue(NetPlay.hostPlayer), NET_FILE_REQUESTED);
-		NETbin(hash.bytes, hash.Bytes);
-		NETend();
+		auto w = NETbeginEncode(NETnetQueue(NetPlay.hostPlayer), NET_FILE_REQUESTED);
+		NETbin(w, hash.bytes, hash.Bytes);
+		NETend(w);
 
 		return FileRequestResult::StartingDownload;  // Starting download now.
 	};
@@ -505,15 +504,15 @@ bool hostCampaign(const char *SessionName, char *hostPlayerName, bool spectatorH
 bool sendLeavingMsg()
 {
 	debug(LOG_NET, "We are leaving 'nicely'");
-	NETbeginEncode(NETnetQueue(NetPlay.hostPlayer), NET_PLAYER_LEAVING);
+	auto w = NETbeginEncode(NETnetQueue(NetPlay.hostPlayer), NET_PLAYER_LEAVING);
 	{
 		bool host = NetPlay.isHost;
 		uint32_t id = selectedPlayer;
 
-		NETuint32_t(&id);
-		NETbool(&host);
+		NETuint32_t(w, id);
+		NETbool(w, host);
 	}
-	NETend();
+	NETend(w);
 	NETflush();
 
 	return true;
@@ -610,9 +609,9 @@ void playerResponding()
 	}
 
 	// Tell the world we're here
-	NETbeginEncode(NETbroadcastQueue(), NET_PLAYERRESPONDING);
-	NETuint32_t(&selectedPlayer);
-	NETend();
+	auto w = NETbeginEncode(NETbroadcastQueue(), NET_PLAYERRESPONDING);
+	NETuint32_t(w, selectedPlayer);
+	NETend(w);
 }
 
 // ////////////////////////////////////////////////////////////////////////////
@@ -793,15 +792,15 @@ void sendHostConfig()
 {
 	ASSERT_HOST_ONLY(return);
 
-	NETbeginEncode(NETbroadcastQueue(), NET_HOST_CONFIG);
+	auto w = NETbeginEncode(NETbroadcastQueue(), NET_HOST_CONFIG);
 
 	// Send the list of host-set player chat permissions
 	for (unsigned i = 0; i < MAX_CONNECTED_PLAYERS; i++)
 	{
-		NETbool(&ingame.hostChatPermissions[i]);
+		NETbool(w, ingame.hostChatPermissions[i]);
 	}
 
-	NETend();
+	NETend(w);
 }
 
 // ////////////////////////////////////////////////////////////////////////////
@@ -814,15 +813,15 @@ bool recvHostConfig(NETQUEUE queue)
 	std::array<bool, MAX_CONNECTED_PLAYERS> priorHostChatPermissions = ingame.hostChatPermissions;
 
 	debug(LOG_NET, "Receiving host_config from host");
-	NETbeginDecode(queue, NET_HOST_CONFIG);
+	auto r = NETbeginDecode(queue, NET_HOST_CONFIG);
 
 	// Host-set player chat permissions
 	for (unsigned int i = 0; i < MAX_CONNECTED_PLAYERS; i++)
 	{
-		NETbool(&ingame.hostChatPermissions[i]);
+		NETbool(r, ingame.hostChatPermissions[i]);
 	}
 
-	NETend();
+	NETend(r);
 
 	informOnHostChatPermissionChanges(priorHostChatPermissions);
 

--- a/src/multiplay.cpp
+++ b/src/multiplay.cpp
@@ -923,15 +923,15 @@ static void recvSyncRequest(NETQUEUE queue)
 	int32_t req_id, x, y, obj_id, obj_id2, player_id, player_id2;
 	BASE_OBJECT *psObj = nullptr, *psObj2 = nullptr;
 
-	NETbeginDecode(queue, GAME_SYNC_REQUEST);
-	NETint32_t(&req_id);
-	NETint32_t(&x);
-	NETint32_t(&y);
-	NETint32_t(&obj_id);
-	NETint32_t(&player_id);
-	NETint32_t(&obj_id2);
-	NETint32_t(&player_id2);
-	NETend();
+	auto r = NETbeginDecode(queue, GAME_SYNC_REQUEST);
+	NETint32_t(r, req_id);
+	NETint32_t(r, x);
+	NETint32_t(r, y);
+	NETint32_t(r, obj_id);
+	NETint32_t(r, player_id);
+	NETint32_t(r, obj_id2);
+	NETint32_t(r, player_id2);
+	NETend(r);
 
 	syncDebug("sync request received from%d req_id%d x%u y%u %obj1 %obj2", queue.index, req_id, x, y, obj_id, obj_id2);
 	if (obj_id)
@@ -945,32 +945,32 @@ static void recvSyncRequest(NETQUEUE queue)
 	triggerEventSyncRequest(queue.index, req_id, x, y, psObj, psObj2);
 }
 
-static void sendObj(const BASE_OBJECT *psObj)
+static void sendObj(MessageWriter& w, const BASE_OBJECT *psObj)
 {
 	if (psObj)
 	{
 		int32_t obj_id = psObj->id;
 		int32_t player = psObj->player;
-		NETint32_t(&obj_id);
-		NETint32_t(&player);
+		NETint32_t(w, obj_id);
+		NETint32_t(w, player);
 	}
 	else
 	{
 		int32_t dummy = 0;
-		NETint32_t(&dummy);
-		NETint32_t(&dummy);
+		NETint32_t(w, dummy);
+		NETint32_t(w, dummy);
 	}
 }
 
 void sendSyncRequest(int32_t req_id, int32_t x, int32_t y, const BASE_OBJECT *psObj, const BASE_OBJECT *psObj2)
 {
-	NETbeginEncode(NETgameQueue(selectedPlayer), GAME_SYNC_REQUEST);
-	NETint32_t(&req_id);
-	NETint32_t(&x);
-	NETint32_t(&y);
-	sendObj(psObj);
-	sendObj(psObj2);
-	NETend();
+	auto w = NETbeginEncode(NETgameQueue(selectedPlayer), GAME_SYNC_REQUEST);
+	NETint32_t(w, req_id);
+	NETint32_t(w, x);
+	NETint32_t(w, y);
+	sendObj(w, psObj);
+	sendObj(w, psObj2);
+	NETend(w);
 }
 
 static inline std::chrono::seconds maxDataCheck2WaitSeconds()
@@ -1014,9 +1014,9 @@ static bool sendDataCheck2()
 				continue;
 			}
 
-			NETbeginEncode(NETnetQueue(player), NET_DATA_CHECK2);
-			NETuint32_t(&NetPlay.hostPlayer);
-			NETend();
+			auto w = NETbeginEncode(NETnetQueue(player), NET_DATA_CHECK2);
+			NETuint32_t(w, NetPlay.hostPlayer);
+			NETend(w);
 			if (!ingame.lastSentPlayerDataCheck2[player].has_value())
 			{
 				ingame.lastSentPlayerDataCheck2[player] = now;
@@ -1027,31 +1027,31 @@ static bool sendDataCheck2()
 	}
 
 	// For a player, respond to the host
-	NETbeginEncode(NETnetQueue(NetPlay.hostPlayer), NET_DATA_CHECK2);		// only need to send to HOST
-	NETuint32_t(&selectedPlayer);
-	NETuint32_t(&realSelectedPlayer);
+	auto w = NETbeginEncode(NETnetQueue(NetPlay.hostPlayer), NET_DATA_CHECK2);		// only need to send to HOST
+	NETuint32_t(w, selectedPlayer);
+	NETuint32_t(w, realSelectedPlayer);
 	std::unordered_map<uint16_t, uint32_t> layers;
 	widgForEachOverlayScreen([&layers](const std::shared_ptr<W_SCREEN> &pScreen, uint16_t zOrder) -> bool {
 		layers[zOrder]++;
 		return true;
 	});
 	uint32_t layersSize = static_cast<uint32_t>(layers.size());
-	NETuint32_t(&layersSize);
+	NETuint32_t(w, layersSize);
 	for (auto& layer : layers)
 	{
 		uint16_t zOrder = layer.first;
-		NETuint16_t(&zOrder);
-		NETuint32_t(&layer.second);
+		NETuint16_t(w, zOrder);
+		NETuint32_t(w, layer.second);
 	}
 	for (size_t i = 0; i < DATA_MAXDATA; i++)
 	{
-		NETuint32_t(&DataHash[i]);
+		NETuint32_t(w, DataHash[i]);
 	}
 	int8_t aiIndex = NetPlay.players[realSelectedPlayer].ai;
-	NETint8_t(&aiIndex);
+	NETint8_t(w, aiIndex);
 	bool bValue = godMode;
-	NETbool(&bValue);
-	NETend();
+	NETbool(w, bValue);
+	NETend(w);
 	return true;
 }
 
@@ -1068,34 +1068,34 @@ static bool recvDataCheck2(NETQUEUE queue)
 	if (!NetPlay.isHost) // the host can send NET_DATA_CHECK2 messages to clients to request a check
 	{
 		ASSERT_OR_RETURN(false, NetPlay.hostPlayer == queue.index, "Non-host player (%u) is sending NET_DATA_CHECK2 to us??", queue.index);
-		NETbeginDecode(queue, NET_DATA_CHECK2);
-		NETuint32_t(&recvSelectedPlayer);
-		NETend();
+		auto r = NETbeginDecode(queue, NET_DATA_CHECK2);
+		NETuint32_t(r, recvSelectedPlayer);
+		NETend(r);
 		ASSERT_OR_RETURN(false, NetPlay.hostPlayer == recvSelectedPlayer, "Non-host player (selectedPlayer: %u) is sending NET_DATA_CHECK2 to us??", recvSelectedPlayer);
 		sendDataCheck2();
 		return true;
 	}
 
-	NETbeginDecode(queue, NET_DATA_CHECK2);
-	NETuint32_t(&recvSelectedPlayer);
-	NETuint32_t(&recvRealSelectedPlayer);
+	auto r = NETbeginDecode(queue, NET_DATA_CHECK2);
+	NETuint32_t(r, recvSelectedPlayer);
+	NETuint32_t(r, recvRealSelectedPlayer);
 	uint32_t layersSize = 0;
 	uint16_t zOrder = 0;
 	uint32_t layerCount = 0;
-	NETuint32_t(&layersSize);
+	NETuint32_t(r, layersSize);
 	for (uint32_t i = 0; i < layersSize; ++i)
 	{
-		NETuint16_t(&zOrder);
-		NETuint32_t(&layerCount);
+		NETuint16_t(r, zOrder);
+		NETuint32_t(r, layerCount);
 		layers[zOrder] = layerCount;
 	}
 	for (size_t i = 0; i < DATA_MAXDATA; ++i)
 	{
-		NETuint32_t(&tempBuffer[i]);
+		NETuint32_t(r, tempBuffer[i]);
 	}
-	NETint8_t(&aiIndex);
-	NETbool(&recvGM);
-	NETend();
+	NETint8_t(r, aiIndex);
+	NETbool(r, recvGM);
+	NETend(r);
 
 	if (player >= MAX_CONNECTED_PLAYERS) // invalid player number.
 	{
@@ -1474,11 +1474,11 @@ bool recvMessage()
 			{
 				uint32_t player_id;
 
-				NETbeginDecode(queue, NET_PLAYER_DROPPED);
+				auto r = NETbeginDecode(queue, NET_PLAYER_DROPPED);
 				{
-					NETuint32_t(&player_id);
+					NETuint32_t(r, player_id);
 				}
-				NETend();
+				NETend(r);
 
 				if (player_id >= MAX_CONNECTED_PLAYERS)
 				{
@@ -1510,10 +1510,10 @@ bool recvMessage()
 
 				resetReadyStatus(false);
 
-				NETbeginDecode(queue, NET_PLAYERRESPONDING);
+				auto r = NETbeginDecode(queue, NET_PLAYERRESPONDING);
 				// the player that has just responded
-				NETuint32_t(&player_id);
-				NETend();
+				NETuint32_t(r, player_id);
+				NETend(r);
 				if (player_id >= MAX_CONNECTED_PLAYERS)
 				{
 					debug(LOG_ERROR, "Bad NET_PLAYERRESPONDING received, ID is %d", (int)player_id);
@@ -1571,11 +1571,11 @@ bool recvMessage()
 				char reason[MAX_KICK_REASON];
 				LOBBY_ERROR_TYPES KICK_TYPE = ERROR_NOERROR;
 
-				NETbeginDecode(queue, NET_KICK);
-				NETuint32_t(&player_id);
-				NETstring(reason, MAX_KICK_REASON);
-				NETenum(&KICK_TYPE);
-				NETend();
+				auto r = NETbeginDecode(queue, NET_KICK);
+				NETuint32_t(r, player_id);
+				NETstring(r, reason, MAX_KICK_REASON);
+				NETenum(r, KICK_TYPE);
+				NETend(r);
 
 				if (player_id == NetPlay.hostPlayer)
 				{
@@ -1669,10 +1669,10 @@ void HandleBadParam(const char *msg, const int from, const int actual)
 bool SendResearch(uint8_t player, uint32_t index, bool trigger)
 {
 	// Send the player that is researching the topic and the topic itself
-	NETbeginEncode(NETgameQueue(selectedPlayer), GAME_DEBUG_FINISH_RESEARCH);
-	NETuint8_t(&player);
-	NETuint32_t(&index);
-	NETend();
+	auto w = NETbeginEncode(NETgameQueue(selectedPlayer), GAME_DEBUG_FINISH_RESEARCH);
+	NETuint8_t(w, player);
+	NETuint32_t(w, index);
+	NETend(w);
 
 	return true;
 }
@@ -1685,10 +1685,10 @@ static bool recvResearch(NETQUEUE queue)
 	int				i;
 	PLAYER_RESEARCH	*pPlayerRes;
 
-	NETbeginDecode(queue, GAME_DEBUG_FINISH_RESEARCH);
-	NETuint8_t(&player);
-	NETuint32_t(&index);
-	NETend();
+	auto r = NETbeginDecode(queue, GAME_DEBUG_FINISH_RESEARCH);
+	NETuint8_t(r, player);
+	NETuint32_t(r, index);
+	NETend(r);
 
 	const DebugInputManager& dbgInputManager = gInputManager.debugManager();
 	if (!dbgInputManager.debugMappingsAllowed() && bMultiPlayer)
@@ -1745,25 +1745,25 @@ bool sendResearchStatus(const STRUCTURE *psBuilding, uint32_t index, uint8_t pla
 		return true;
 	}
 
-	NETbeginEncode(NETgameQueue(selectedPlayer), GAME_RESEARCHSTATUS);
-	NETuint8_t(&player);
-	NETbool(&bStart);
+	auto w = NETbeginEncode(NETgameQueue(selectedPlayer), GAME_RESEARCHSTATUS);
+	NETuint8_t(w, player);
+	NETbool(w, bStart);
 
 	// If we know the building researching it then send its ID
 	if (psBuilding)
 	{
 		uint32_t buildingID = psBuilding->id;
-		NETuint32_t(&buildingID);
+		NETuint32_t(w, buildingID);
 	}
 	else
 	{
 		uint32_t zero = 0;
-		NETuint32_t(&zero);
+		NETuint32_t(w, zero);
 	}
 
 	// Finally the topic in question
-	NETuint32_t(&index);
-	NETend();
+	NETuint32_t(w, index);
+	NETend(w);
 
 	// Tell UI to remove from the list of available research.
 	MakeResearchStartedPending(&asPlayerResList[player][index]);
@@ -1801,12 +1801,12 @@ bool recvResearchStatus(NETQUEUE queue)
 	bool bStart = false;
 	uint32_t			index, structRef;
 
-	NETbeginDecode(queue, GAME_RESEARCHSTATUS);
-	NETuint8_t(&player);
-	NETbool(&bStart);
-	NETuint32_t(&structRef);
-	NETuint32_t(&index);
-	NETend();
+	auto r = NETbeginDecode(queue, GAME_RESEARCHSTATUS);
+	NETuint8_t(r, player);
+	NETbool(r, bStart);
+	NETuint32_t(r, structRef);
+	NETuint32_t(r, index);
+	NETend(r);
 
 	syncDebug("player%d, bStart%d, structRef%u, index%u", player, bStart, structRef, index);
 
@@ -1956,22 +1956,22 @@ NetworkTextMessage::NetworkTextMessage(int32_t messageSender, char const *messag
 
 void NetworkTextMessage::enqueue(NETQUEUE queue)
 {
-	NETbeginEncode(queue, NET_TEXTMSG);
-	NETint32_t(&sender);
-	NETbool(&teamSpecific);
-	NETstring(text, MAX_CONSOLE_STRING_LENGTH);
-	NETend();
+	auto w = NETbeginEncode(queue, NET_TEXTMSG);
+	NETint32_t(w, sender);
+	NETbool(w, teamSpecific);
+	NETstring(w, text, MAX_CONSOLE_STRING_LENGTH);
+	NETend(w);
 }
 
 bool NetworkTextMessage::receive(NETQUEUE queue)
 {
 	memset(text, 0x0, sizeof(text));
 
-	NETbeginDecode(queue, NET_TEXTMSG);
-	NETint32_t(&sender);
-	NETbool(&teamSpecific);
-	NETstring(text, MAX_CONSOLE_STRING_LENGTH);
-	NETend();
+	auto r = NETbeginDecode(queue, NET_TEXTMSG);
+	NETint32_t(r, sender);
+	NETbool(r, teamSpecific);
+	NETstring(r, text, MAX_CONSOLE_STRING_LENGTH);
+	NETend(r);
 
 	if (whosResponsible(sender) != queue.index)
 	{
@@ -2045,16 +2045,16 @@ bool sendBeacon(int32_t locX, int32_t locY, int32_t forPlayer, int32_t sender, c
 
 	// I assume this is correct, looks like it sends it to ONLY that person, and the routine
 	// kf_AddHelpBlip() iterates for each player it needs.
-	NETbeginEncode(NETnetQueue(sendPlayer), NET_BEACONMSG);    // send to the player who is hosting 'to' player (might be himself if human and not AI)
-	NETint32_t(&sender);                                // save the actual sender
+	auto w = NETbeginEncode(NETnetQueue(sendPlayer), NET_BEACONMSG);    // send to the player who is hosting 'to' player (might be himself if human and not AI)
+	NETint32_t(w, sender);                                // save the actual sender
 
 	// save the actual player that is to get this msg on the source machine (source can host many AIs)
-	NETint32_t(&forPlayer);                             // save the actual receiver (might not be the same as the one we are actually sending to, in case of AIs)
-	NETint32_t(&locX);                                  // save location
-	NETint32_t(&locY);
+	NETint32_t(w, forPlayer);                             // save the actual receiver (might not be the same as the one we are actually sending to, in case of AIs)
+	NETint32_t(w, locX);                                  // save location
+	NETint32_t(w, locY);
 
-	NETstring(pStr, MAX_CONSOLE_STRING_LENGTH); // copy message in.
-	NETend();
+	NETstring(w, pStr, MAX_CONSOLE_STRING_LENGTH); // copy message in.
+	NETend(w);
 
 	return true;
 }
@@ -2101,11 +2101,11 @@ bool recvTextMessageAI(NETQUEUE queue)
 	char	msg[MAX_CONSOLE_STRING_LENGTH];
 	char	newmsg[MAX_CONSOLE_STRING_LENGTH];
 
-	NETbeginDecode(queue, NET_AITEXTMSG);
-	NETuint32_t(&sender);			//in-game player index ('normal' one)
-	NETuint32_t(&receiver);			//in-game player index
-	NETstring(newmsg, MAX_CONSOLE_STRING_LENGTH);
-	NETend();
+	auto r = NETbeginDecode(queue, NET_AITEXTMSG);
+	NETuint32_t(r, sender);			//in-game player index ('normal' one)
+	NETuint32_t(r, receiver);			//in-game player index
+	NETstring(r, newmsg, MAX_CONSOLE_STRING_LENGTH);
+	NETend(r);
 
 	if (whosResponsible(sender) != queue.index)
 	{
@@ -2128,10 +2128,10 @@ bool recvSpecInGameTextMessage(NETQUEUE queue)
 	UDWORD	sender;
 	char	newmsg[MAX_CONSOLE_STRING_LENGTH] = {};
 
-	NETbeginDecode(queue, NET_SPECTEXTMSG);
-	NETuint32_t(&sender);			//in-game player index ('normal' one)
-	NETstring(newmsg, MAX_CONSOLE_STRING_LENGTH);
-	NETend();
+	auto r = NETbeginDecode(queue, NET_SPECTEXTMSG);
+	NETuint32_t(r, sender);			//in-game player index ('normal' one)
+	NETstring(r, newmsg, MAX_CONSOLE_STRING_LENGTH);
+	NETend(r);
 
 	if (whosResponsible(sender) != queue.index)
 	{
@@ -2181,9 +2181,9 @@ bool recvDestroyFeature(NETQUEUE queue)
 	FEATURE *pF;
 	uint32_t	id;
 
-	NETbeginDecode(queue, GAME_DEBUG_REMOVE_FEATURE);
-	NETuint32_t(&id);
-	NETend();
+	auto r = NETbeginDecode(queue, GAME_DEBUG_REMOVE_FEATURE);
+	NETuint32_t(r, id);
+	NETend(r);
 
 	const DebugInputManager& dbgInputManager = gInputManager.debugManager();
 	if (!dbgInputManager.debugMappingsAllowed() && bMultiPlayer)
@@ -2218,9 +2218,9 @@ bool recvMapFileRequested(NETQUEUE queue)
 
 	Sha256 hash;
 	hash.setZero();
-	NETbeginDecode(queue, NET_FILE_REQUESTED);
-	NETbin(hash.bytes, hash.Bytes);
-	NETend();
+	auto r = NETbeginDecode(queue, NET_FILE_REQUESTED);
+	NETbin(r, hash.bytes, hash.Bytes);
+	NETend(r);
 
 	auto files = NetPlay.players[player].wzFiles;
 	ASSERT_OR_RETURN(false, files != nullptr, "wzFiles is uninitialized?? (Player: %" PRIu32 ")", player);
@@ -2268,8 +2268,8 @@ bool recvMapFileRequested(NETQUEUE queue)
 		// NOTE: if we get here, then the game is basically over, The host can't send the file for whatever reason...
 		// Which also means, that we can't continue.
 		debug(LOG_NET, "***Host has a file issue, and is being forced to quit!***");
-		NETbeginEncode(NETbroadcastQueue(), NET_HOST_DROPPED);
-		NETend();
+		auto w = NETbeginEncode(NETbroadcastQueue(), NET_HOST_DROPPED);
+		NETend(w);
 		abort();
 	}
 
@@ -2539,13 +2539,13 @@ static bool recvBeacon(NETQUEUE queue)
 	int32_t sender, receiver, locX, locY;
 	char    msg[MAX_CONSOLE_STRING_LENGTH];
 
-	NETbeginDecode(queue, NET_BEACONMSG);
-	NETint32_t(&sender);            // the actual sender
-	NETint32_t(&receiver);          // the actual receiver (might not be the same as the one we are actually sending to, in case of AIs)
-	NETint32_t(&locX);
-	NETint32_t(&locY);
-	NETstring(msg, sizeof(msg));    // Receive the actual message
-	NETend();
+	auto r = NETbeginDecode(queue, NET_BEACONMSG);
+	NETint32_t(r, sender);            // the actual sender
+	NETint32_t(r, receiver);          // the actual receiver (might not be the same as the one we are actually sending to, in case of AIs)
+	NETint32_t(r, locX);
+	NETint32_t(r, locY);
+	NETstring(r, msg, sizeof(msg));    // Receive the actual message
+	NETend(r);
 
 	if (!canGiveOrdersFor(queue.index, sender))
 	{

--- a/src/multistruct.cpp
+++ b/src/multistruct.cpp
@@ -63,14 +63,14 @@ bool SendBuildFinished(STRUCTURE *psStruct)
 	uint8_t player = psStruct->player;
 	ASSERT_OR_RETURN(false, player < MAX_PLAYERS, "invalid player %u", player);
 
-	NETbeginEncode(NETgameQueue(selectedPlayer), GAME_DEBUG_ADD_STRUCTURE);
-	NETuint32_t(&psStruct->id);		// ID of building
+	auto w = NETbeginEncode(NETgameQueue(selectedPlayer), GAME_DEBUG_ADD_STRUCTURE);
+	NETuint32_t(w, psStruct->id);		// ID of building
 
 	// Along with enough info to build it (if needed)
-	NETuint32_t(&psStruct->pStructureType->ref);
-	NETPosition(&psStruct->pos);
-	NETuint8_t(&player);
-	return NETend();
+	NETuint32_t(w, psStruct->pStructureType->ref);
+	NETPosition(w, psStruct->pos);
+	NETuint8_t(w, player);
+	return NETend(w);
 }
 
 // ////////////////////////////////////////////////////////////////////////////
@@ -82,12 +82,12 @@ bool recvBuildFinished(NETQUEUE queue)
 	uint32_t	type, typeindex;
 	uint8_t		player;
 
-	NETbeginDecode(queue, GAME_DEBUG_ADD_STRUCTURE);
-	NETuint32_t(&structId);	// get the struct id.
-	NETuint32_t(&type); 	// Kind of building.
-	NETPosition(&pos);      // pos
-	NETuint8_t(&player);
-	NETend();
+	auto r = NETbeginDecode(queue, GAME_DEBUG_ADD_STRUCTURE);
+	NETuint32_t(r, structId);	// get the struct id.
+	NETuint32_t(r, type); 	// Kind of building.
+	NETPosition(r, pos);      // pos
+	NETuint8_t(r, player);
+	NETend(r);
 
 	ASSERT_OR_RETURN(false, player < MAX_PLAYERS, "invalid player %u", player);
 
@@ -147,12 +147,11 @@ bool recvBuildFinished(NETQUEUE queue)
 // Inform others that a structure has been destroyed
 bool SendDestroyStructure(STRUCTURE *s)
 {
-	NETbeginEncode(NETgameQueue(selectedPlayer), GAME_DEBUG_REMOVE_STRUCTURE);
-
+	auto w = NETbeginEncode(NETgameQueue(selectedPlayer), GAME_DEBUG_REMOVE_STRUCTURE);
 	// Struct to destroy
-	NETuint32_t(&s->id);
+	NETuint32_t(w, s->id);
 
-	return NETend();
+	return NETend(w);
 }
 
 // ////////////////////////////////////////////////////////////////////////////
@@ -162,9 +161,9 @@ bool recvDestroyStructure(NETQUEUE queue)
 	uint32_t structID;
 	STRUCTURE *psStruct;
 
-	NETbeginDecode(queue, GAME_DEBUG_REMOVE_STRUCTURE);
-	NETuint32_t(&structID);
-	NETend();
+	auto r = NETbeginDecode(queue, GAME_DEBUG_REMOVE_STRUCTURE);
+	NETuint32_t(r, structID);
+	NETend(r);
 
 	const DebugInputManager& dbgInputManager = gInputManager.debugManager();
 	if (!dbgInputManager.debugMappingsAllowed() && bMultiPlayer)
@@ -192,14 +191,13 @@ bool recvDestroyStructure(NETQUEUE queue)
 
 bool sendLasSat(UBYTE player, STRUCTURE *psStruct, BASE_OBJECT *psObj)
 {
-	NETbeginEncode(NETgameQueue(selectedPlayer), GAME_LASSAT);
+	auto w = NETbeginEncode(NETgameQueue(selectedPlayer), GAME_LASSAT);
+	NETuint8_t(w, player);
+	NETuint32_t(w, psStruct->id);
+	NETuint32_t(w, psObj->id);	// Target
+	NETuint8_t(w, psObj->player);	// Target player
 
-	NETuint8_t(&player);
-	NETuint32_t(&psStruct->id);
-	NETuint32_t(&psObj->id);	// Target
-	NETuint8_t(&psObj->player);	// Target player
-
-	return NETend();
+	return NETend(w);
 }
 
 // recv lassat info on the receiving end.
@@ -210,12 +208,12 @@ bool recvLasSat(NETQUEUE queue)
 	STRUCTURE	*psStruct;
 	uint32_t	id, targetid;
 
-	NETbeginDecode(queue, GAME_LASSAT);
-	NETuint8_t(&player);
-	NETuint32_t(&id);
-	NETuint32_t(&targetid);
-	NETuint8_t(&targetplayer);
-	NETend();
+	auto r = NETbeginDecode(queue, GAME_LASSAT);
+	NETuint8_t(r, player);
+	NETuint32_t(r, id);
+	NETuint32_t(r, targetid);
+	NETuint8_t(r, targetplayer);
+	NETend(r);
 
 	psStruct = IdToStruct(id, player);
 	psObj	 = IdToPointer(targetid, targetplayer);
@@ -260,31 +258,31 @@ void sendStructureInfo(STRUCTURE *psStruct, STRUCTURE_INFO structureInfo_, DROID
 	uint32_t structId = psStruct->id;
 	uint8_t  structureInfo = structureInfo_;
 
-	NETbeginEncode(NETgameQueue(selectedPlayer), GAME_STRUCTUREINFO);
-	NETuint8_t(&player);
-	NETuint32_t(&structId);
-	NETuint8_t(&structureInfo);
+	auto w = NETbeginEncode(NETgameQueue(selectedPlayer), GAME_STRUCTUREINFO);
+	NETuint8_t(w, player);
+	NETuint32_t(w, structId);
+	NETuint8_t(w, structureInfo);
 	if (structureInfo_ == STRUCTUREINFO_MANUFACTURE)
 	{
 		int32_t droidType = pT->droidType;
 		WzString name = pT->name;
-		NETwzstring(name);
-		NETuint32_t(&pT->multiPlayerID);
-		NETint32_t(&droidType);
-		NETuint8_t(&pT->asParts[COMP_BODY]);
-		NETuint8_t(&pT->asParts[COMP_BRAIN]);
-		NETuint8_t(&pT->asParts[COMP_PROPULSION]);
-		NETuint8_t(&pT->asParts[COMP_REPAIRUNIT]);
-		NETuint8_t(&pT->asParts[COMP_ECM]);
-		NETuint8_t(&pT->asParts[COMP_SENSOR]);
-		NETuint8_t(&pT->asParts[COMP_CONSTRUCT]);
-		NETint8_t(&pT->numWeaps);
+		NETwzstring(w, name);
+		NETuint32_t(w, pT->multiPlayerID);
+		NETint32_t(w, droidType);
+		NETuint8_t(w, pT->asParts[COMP_BODY]);
+		NETuint8_t(w, pT->asParts[COMP_BRAIN]);
+		NETuint8_t(w, pT->asParts[COMP_PROPULSION]);
+		NETuint8_t(w, pT->asParts[COMP_REPAIRUNIT]);
+		NETuint8_t(w, pT->asParts[COMP_ECM]);
+		NETuint8_t(w, pT->asParts[COMP_SENSOR]);
+		NETuint8_t(w, pT->asParts[COMP_CONSTRUCT]);
+		NETint8_t(w, pT->numWeaps);
 		for (int i = 0; i < pT->numWeaps; i++)
 		{
-			NETuint32_t(&pT->asWeaps[i]);
+			NETuint32_t(w, pT->asWeaps[i]);
 		}
 	}
-	NETend();
+	NETend(w);
 }
 
 void recvStructureInfo(NETQUEUE queue)
@@ -296,34 +294,34 @@ void recvStructureInfo(NETQUEUE queue)
 	DROID_TEMPLATE t, *pT = &t;
 	int32_t droidType;
 
-	NETbeginDecode(queue, GAME_STRUCTUREINFO);
-	NETuint8_t(&player);
-	NETuint32_t(&structId);
-	NETuint8_t(&structureInfo);
+	auto r = NETbeginDecode(queue, GAME_STRUCTUREINFO);
+	NETuint8_t(r, player);
+	NETuint32_t(r, structId);
+	NETuint8_t(r, structureInfo);
 	if (structureInfo == STRUCTUREINFO_MANUFACTURE)
 	{
 		WzString name;
-		NETwzstring(name);
+		NETwzstring(r, name);
 		pT->name = name;
-		NETuint32_t(&pT->multiPlayerID);
-		NETint32_t(&droidType);
-		NETuint8_t(&pT->asParts[COMP_BODY]);
-		NETuint8_t(&pT->asParts[COMP_BRAIN]);
-		NETuint8_t(&pT->asParts[COMP_PROPULSION]);
-		NETuint8_t(&pT->asParts[COMP_REPAIRUNIT]);
-		NETuint8_t(&pT->asParts[COMP_ECM]);
-		NETuint8_t(&pT->asParts[COMP_SENSOR]);
-		NETuint8_t(&pT->asParts[COMP_CONSTRUCT]);
-		NETint8_t(&pT->numWeaps);
+		NETuint32_t(r, pT->multiPlayerID);
+		NETint32_t(r, droidType);
+		NETuint8_t(r, pT->asParts[COMP_BODY]);
+		NETuint8_t(r, pT->asParts[COMP_BRAIN]);
+		NETuint8_t(r, pT->asParts[COMP_PROPULSION]);
+		NETuint8_t(r, pT->asParts[COMP_REPAIRUNIT]);
+		NETuint8_t(r, pT->asParts[COMP_ECM]);
+		NETuint8_t(r, pT->asParts[COMP_SENSOR]);
+		NETuint8_t(r, pT->asParts[COMP_CONSTRUCT]);
+		NETint8_t(r, pT->numWeaps);
 		ASSERT_OR_RETURN(, pT->numWeaps >= 0 && pT->numWeaps <= ARRAY_SIZE(pT->asWeaps), "Bad numWeaps %d", pT->numWeaps);
 		for (int i = 0; i < pT->numWeaps; i++)
 		{
-			NETuint32_t(&pT->asWeaps[i]);
+			NETuint32_t(r, pT->asWeaps[i]);
 		}
 		pT->droidType = (DROID_TYPE)droidType;
 		pT = copyTemplate(player, pT);
 	}
-	NETend();
+	NETend(r);
 
 	psStruct = IdToStruct(structId, player);
 

--- a/src/multisync.cpp
+++ b/src/multisync.cpp
@@ -221,11 +221,11 @@ bool sendPing()
 			{
 				pingChallenges[i] = generatePingChallenge(i);
 
-				NETbeginEncode(NETnetQueue(i), NET_PING);
-				NETuint8_t(&player);
-				NETbool(&isNew);
-				NETbin(pingChallenges[i].value().data(), PING_CHALLENGE_BYTES);
-				NETend();
+				auto w = NETbeginEncode(NETnetQueue(i), NET_PING);
+				NETuint8_t(w, player);
+				NETbool(w, isNew);
+				NETbin(w, pingChallenges[i].value().data(), PING_CHALLENGE_BYTES);
+				NETend(w);
 
 				// Note when we sent the ping
 				PingSend[i] = realTime;
@@ -237,11 +237,11 @@ bool sendPing()
 		// Just generate and broadcast the same ping challenge to all other players
 		pingChallenges[0] = generatePingChallenge(0);
 
-		NETbeginEncode(NETbroadcastQueue(), NET_PING);
-		NETuint8_t(&player);
-		NETbool(&isNew);
-		NETbin(pingChallenges[0].value().data(), PING_CHALLENGE_BYTES);
-		NETend();
+		auto w = NETbeginEncode(NETbroadcastQueue(), NET_PING);
+		NETuint8_t(w, player);
+		NETbool(w, isNew);
+		NETbin(w, pingChallenges[0].value().data(), PING_CHALLENGE_BYTES);
+		NETend(w);
 
 		// Note when we sent the ping
 		for (int i = 0; i < MAX_CONNECTED_PLAYERS; ++i)
@@ -266,18 +266,18 @@ bool recvPing(NETQUEUE queue)
 	uint8_t challenge[PING_CHALLENGE_BYTES];
 	EcKey::Sig challengeResponse;
 
-	NETbeginDecode(queue, NET_PING);
-	NETuint8_t(&sender);
-	NETbool(&isNew);
+	auto r = NETbeginDecode(queue, NET_PING);
+	NETuint8_t(r, sender);
+	NETbool(r, isNew);
 	if (isNew)
 	{
-		NETbin(challenge, PING_CHALLENGE_BYTES);
+		NETbin(r, challenge, PING_CHALLENGE_BYTES);
 	}
 	else
 	{
-		NETbytes(&challengeResponse);
+		NETbytes(r, challengeResponse);
 	}
-	NETend();
+	NETend(r);
 
 	if (sender >= MAX_CONNECTED_PLAYERS)
 	{
@@ -296,14 +296,14 @@ bool recvPing(NETQUEUE queue)
 	{
 		challengeResponse = getLocalSharedIdentity().sign(&challenge, PING_CHALLENGE_BYTES);
 
-		NETbeginEncode(NETnetQueue(sender), NET_PING);
+		auto w = NETbeginEncode(NETnetQueue(sender), NET_PING);
 		// We are responding to a new ping
 		isNew = false;
 
-		NETuint8_t(&us);
-		NETbool(&isNew);
-		NETbytes(&challengeResponse);
-		NETend();
+		NETuint8_t(w, us);
+		NETbool(w, isNew);
+		NETbytes(w, challengeResponse);
+		NETend(w);
 	}
 	// They are responding to one of our pings
 	else

--- a/src/wzapi.cpp
+++ b/src/wzapi.cpp
@@ -3265,12 +3265,12 @@ bool wzapi::donateObject(WZAPI_PARAMS(BASE_OBJECT *psObject, int player))
 	{
 		return false;
 	}
-	NETbeginEncode(NETgameQueue(selectedPlayer), GAME_GIFT);
-	NETuint8_t(&giftType);
-	NETuint8_t(&from);
-	NETuint8_t(&to);
-	NETuint32_t(&object_id);
-	NETend();
+	auto w = NETbeginEncode(NETgameQueue(selectedPlayer), GAME_GIFT);
+	NETuint8_t(w, giftType);
+	NETuint8_t(w, from);
+	NETuint8_t(w, to);
+	NETuint32_t(w, object_id);
+	NETend(w);
 	return true;
 }
 


### PR DESCRIPTION
High-level summary of changes introduced by this commit:

1.  `NETbeginEncode`, `NETbeginDecode` now return an instance of `MessageWriter` and `MessageReader` correspondingly.
2.  `NETbeginXXXSecured` variants now return an `optional` holding either message reader or message writer.
3.  All serde utility functions (`NETint*`, `NETbool` and alike) now accept either `MessageReader&` or `MessageWriter&`.
4.  Encode functions now accept arguments either by value or by const-qualified references to enforce const safety.
5.  Decode functions now accept arugments via non-const references instead of pointers.
6.  `NETend()` also accepts either message reader or message writer instance.
7.  Internal code doesn't use static reader or writer anymore.
8.  All call sites in the higher level code have been patched to use the new function overloads.
9.  Removed `queue()`, `queueAuto()` and `NETauto()` functions since they are not used anymore (and even before the change, there were just a few uses across the code base, so it's just not worth the effort to support these; plus, `NETauto()` can now be emulated by using a function template accepting either `MessageReader` or `MessageWriter` as the first argument).
10. Last, but not the least: fixed performance bottleneck in `NETbytes()`, which happened to iterate through the in/out vector in an element-wise fashion instead of calling to the `Message{Reader,Writer}::{bytes,bytesVector}()`.

Closes: https://github.com/Warzone2100/warzone2100/issues/4300