### PR TITLE
Fix: Use gameRandU32() for the mapSeed only when loading the game, not when loading a preview

### DIFF
--- a/lib/netplay/sync_debug.cpp
+++ b/lib/netplay/sync_debug.cpp
@@ -350,7 +350,7 @@ private:
 		typedef std::unordered_map<uint32_t, LogOutputter> DesyncOutputs;
 		DesyncOutputs outputs;
 	};
-	std::array<PlayerDesyncLogOutput, MAX_CONNECTED_PLAYERS> players;
+	std::array<PlayerDesyncLogOutput, MAX_GAMEQUEUE_SLOTS> players;
 };
 
 static DesyncLogOutputter playerDesyncLogOutput;
@@ -389,16 +389,19 @@ void DesyncLogOutputter::willLogLocalDesyncLog(uint32_t time)
 
 bool DesyncLogOutputter::canWriteLogFor(uint32_t time, unsigned player)
 {
+	ASSERT_OR_RETURN(false, player < players.size(), "Invalid player idx: %u", player);
 	return players[player].canWriteLogFor(time);
 }
 
 bool DesyncLogOutputter::alreadyWroteLogFor(uint32_t time, unsigned player)
 {
+	ASSERT_OR_RETURN(false, player < players.size(), "Invalid player idx: %u", player);
 	return players[player].alreadyWroteLogFor(time);
 }
 
 bool DesyncLogOutputter::write(uint32_t time, unsigned player, const uint8_t* buf, size_t bufLen)
 {
+	ASSERT_OR_RETURN(false, player < players.size(), "Invalid player idx: %u", player);
 	return players[player].write(time, player, buf, bufLen);
 }
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2571,34 +2571,26 @@ std::string GameLoadDetails::getMapFolderPath() const
 	return result;
 }
 
-std::shared_ptr<WzMap::Map> GameLoadDetails::getMap() const
+std::shared_ptr<WzMap::Map> GameLoadDetails::getMap(uint32_t mapSeed) const
 {
-	if (m_loadedMap)
-	{
-		return m_loadedMap;
-	}
-
-	uint32_t mapSeed = gameRandU32();
 	switch (loadType)
 	{
 		case GameLoadType::UserSaveGame:
-			m_loadedMap = WzMap::Map::loadFromPath(getMapFolderPath(), getWzMapType(true), game.maxPlayers, mapSeed, m_logger, std::make_shared<WzMapPhysFSIO>());
-			break;
+			return WzMap::Map::loadFromPath(getMapFolderPath(), getWzMapType(true), game.maxPlayers, mapSeed, m_logger, std::make_shared<WzMapPhysFSIO>());
 		case GameLoadType::MapPackage:
 		{
 			auto package = getMapPackage();
-			if (package)
+			if (!package)
 			{
-				m_loadedMap = m_loadedPackage->loadMap(mapSeed);
+				return nullptr;
 			}
-			break;
+			return m_loadedPackage->loadMap(mapSeed);
 		}
 		case GameLoadType::Level:
-			m_loadedMap = WzMap::Map::loadFromPath(getMapFolderPath(), getWzMapType(false), game.maxPlayers, mapSeed, m_logger, std::make_shared<WzMapPhysFSIO>());
-			break;
+			return WzMap::Map::loadFromPath(getMapFolderPath(), getWzMapType(false), game.maxPlayers, mapSeed, m_logger, std::make_shared<WzMapPhysFSIO>());
 	}
 
-	return m_loadedMap;
+	return nullptr; // silence compiler warning
 }
 
 std::shared_ptr<WzMap::MapPackage> GameLoadDetails::getMapPackage() const
@@ -2897,7 +2889,7 @@ bool loadGame(const GameLoadDetails& gameToLoad, bool keepObjects, bool freeMem)
 
 	// construct the WzMap object for loading map data
 	aFileName[fileExten] = '\0';
-	data = gameToLoad.getMap();
+	data = gameToLoad.getMap(gameRandU32());
 
 	if (data && data->wasScriptGenerated())
 	{

--- a/src/game.h
+++ b/src/game.h
@@ -67,7 +67,7 @@ public:
 	GameLoadDetails& setLogger(const std::shared_ptr<WzMap::LoggingProtocol>& logger);
 public:
 	std::string getMapFolderPath() const;
-	std::shared_ptr<WzMap::Map> getMap() const;
+	std::shared_ptr<WzMap::Map> getMap(uint32_t mapSeed) const;
 	const WzMap::GamInfo* getGamInfoFromPackage() const;
 private:
 	std::shared_ptr<WzMap::MapPackage> getMapPackage() const;
@@ -77,7 +77,6 @@ public:
 private:
 	std::shared_ptr<WzMap::LoggingProtocol> m_logger;
 	mutable std::shared_ptr<WzMap::MapPackage> m_loadedPackage;
-	mutable std::shared_ptr<WzMap::Map> m_loadedMap;
 };
 
 bool loadGame(const GameLoadDetails& gameToLoad, bool keepObjects, bool freeMem);

--- a/src/multiint.cpp
+++ b/src/multiint.cpp
@@ -764,7 +764,7 @@ void loadMapPreview(bool hideInterface)
 	auto gameLoadDetails = (psLevel->realFileName) ? GameLoadDetails::makeMapPackageLoad(psLevel->realFileName) : GameLoadDetails::makeLevelFileLoad(aFileName);
 
 	// load the map data
-	auto data = gameLoadDetails.getMap();
+	auto data = gameLoadDetails.getMap(rand());
 	if (!data)
 	{
 		debug(LOG_ERROR, "Failed to load map from path: %s", aFileName.c_str());


### PR DESCRIPTION
Fixes issue introduced by commit cfd634a15a40df18df2455809582c0b772ebfe89

Also, a drive-by fix for a crash on desync while playing a replay (introduced in #4303).