### PR TITLE
gns: Tweak default limits for client connections

### DIFF
--- a/lib/netplay/gns/gns_connection_provider.cpp
+++ b/lib/netplay/gns/gns_connection_provider.cpp
@@ -48,6 +48,39 @@
 namespace gns
 {
 
+namespace
+{
+
+void setupCommonConnOptions(std::vector<SteamNetworkingConfigValue_t>& opts)
+{
+	constexpr int32_t SEND_BUFFER_SIZE = 1024 * 1024; // 1 MB
+	constexpr int32_t RECV_BUFFER_SIZE = 2 * 1024 * 1024; // 2 MB
+	constexpr int32_t SEND_RATE_LIMIT = 10 * 1024 * 1024; // 10 MB/s
+
+	// Adjust the default Send/Receive buffer sizes for the client connections.
+	// Send buffer size defaults to 512 KB and receive buffer size defaults to 1024 KB, which may not
+	// be enough for some edge cases, so increase them to 1 MB and 2 MB, respectively.
+	SteamNetworkingConfigValue_t sendBufferSize;
+	sendBufferSize.SetInt32(k_ESteamNetworkingConfig_SendBufferSize, SEND_BUFFER_SIZE);
+	opts.emplace_back(std::move(sendBufferSize));
+
+	SteamNetworkingConfigValue_t recvBufferSize;
+	recvBufferSize.SetInt32(k_ESteamNetworkingConfig_RecvBufferSize, RECV_BUFFER_SIZE);
+	opts.emplace_back(std::move(recvBufferSize));
+
+	// Increase the send rate limit for the created connections from the default 256 KB/s to 10 MB/s
+	// to ensure that we're not artificially rate-limited in any realistic scenario.
+	SteamNetworkingConfigValue_t sendRateMin;
+	sendRateMin.SetInt32(k_ESteamNetworkingConfig_SendRateMin, SEND_RATE_LIMIT);
+	opts.emplace_back(std::move(sendRateMin));
+
+	SteamNetworkingConfigValue_t sendRateMax;
+	sendRateMax.SetInt32(k_ESteamNetworkingConfig_SendRateMax, SEND_RATE_LIMIT);
+	opts.emplace_back(std::move(sendRateMax));
+}
+
+} // anonymous namespace
+
 static std::once_flag gnsInitFlag;
 static GNSConnectionProvider* activeServer = nullptr;
 
@@ -98,12 +131,16 @@ void GNSConnectionProvider::initialize()
 		constexpr int32_t CONNECTED_TIMEOUT_MS = 10000;
 		connectedTimeoutMs.SetInt32(k_ESteamNetworkingConfig_TimeoutConnected, CONNECTED_TIMEOUT_MS);
 		listenSocketOpts_.emplace_back(std::move(connectedTimeoutMs));
+
+		setupCommonConnOptions(listenSocketOpts_);
 	}
 	{
 		// Initialize base client-side options for client connections
 		SteamNetworkingConfigValue_t connStatusCb;
 		connStatusCb.SetPtr(k_ESteamNetworkingConfig_Callback_ConnectionStatusChanged, reinterpret_cast<void*>(GNSConnectionProvider::ClientConnectionStateChanged));
 		clientConnOpts_.emplace_back(std::move(connStatusCb));
+
+		setupCommonConnOptions(clientConnOpts_);
 	}
 
 	activeServer = this;


### PR DESCRIPTION
Adjust the default Send/Receive buffer sizes for the client connections. Send buffer size defaults to 512 KB and receive buffer size defaults to 1024 KB, which may not be enough for some edge cases, so increase them to 1 MB and 2 MB, respectively.

Increase the send rate limits for the created connections from the default 256 KB/s to 10 MB/s to ensure that we're not artificially rate-limited in any realistic scenario.