### PR TITLE
Updated shield glsl shaders

### DIFF
--- a/data/base/shaders/tcmask_instanced.frag
+++ b/data/base/shaders/tcmask_instanced.frag
@@ -308,10 +308,11 @@ vec3 blendAddEffectLighting(vec3 a, vec3 b) {
 
 vec4 applyShieldFuzzEffect(vec4 color) {
 	float cycle = 0.66 + 0.66 * graphicsCycle;
-	float r = random(vec2(fragPos.x * cycle, fragPos.y * cycle));
-	vec3 col = vec3(color.r, color.g, 0.5 + (0.5 * r));
+	vec3 col = vec3(random(vec2(fragPos.x * cycle, fragPos.y * cycle)));
+	col.r *= 0.5;
+	col.g *= 0.5;
 	col.b *= 2.0;
-	return vec4(col, (color.a * r) / 3.0);
+	return vec4(col, color.a / 6.0);
 }
 
 void main()

--- a/data/base/shaders/vk/tcmask_instanced.frag
+++ b/data/base/shaders/vk/tcmask_instanced.frag
@@ -275,10 +275,11 @@ vec3 blendAddEffectLighting(vec3 a, vec3 b) {
 
 vec4 applyShieldFuzzEffect(vec4 color) {
 	float cycle = 0.66 + 0.66 * graphicsCycle;
-	float r = random(vec2(fragPos.x * cycle, fragPos.y * cycle));
-	vec3 col = vec3(color.r, color.g, 0.5 + (0.5 * r));
+	vec3 col = vec3(random(vec2(fragPos.x * cycle, fragPos.y * cycle)));
+	col.r *= 0.5;
+	col.g *= 0.5;
 	col.b *= 2.0;
-	return vec4(col, (color.a * r) / 3.0);
+	return vec4(col, color.a / 6.0);
 }
 
 void main()


### PR DESCRIPTION
![pic](https://github.com/user-attachments/assets/51bd4d10-52e3-413a-82e4-668baf598db2)

Brought back the old algorithm for displaying the effect that doesn't use the original model texture (if you zoom in, you can see the original transparent texture of the tank).