### PR TITLE
Support multi-threaded fpath job processing

### DIFF
--- a/lib/framework/wzapp.h
+++ b/lib/framework/wzapp.h
@@ -153,6 +153,7 @@ bool wzBackendAttemptOpenURL(const char *url);
 
 // System information related
 uint64_t wzGetCurrentSystemRAM(); // gets the system RAM in MiB
+uint32_t wzGetLogicalCPUCount();
 
 // Thread related
 WZ_THREAD *wzThreadCreate(int (*threadFunc)(void *), void *data, const char* name = nullptr);

--- a/lib/sdl/main_sdl.cpp
+++ b/lib/sdl/main_sdl.cpp
@@ -3980,6 +3980,17 @@ uint64_t wzGetCurrentSystemRAM()
 	return (value > 0) ? static_cast<uint64_t>(value) : 0;
 }
 
+uint32_t wzGetLogicalCPUCount()
+{
+	auto result = SDL_GetCPUCount();
+	if (result <= 0)
+	{
+		debug(LOG_ERROR, "Failed to get logical CPU count - defaulting to 1");
+		result = 1;
+	}
+	return static_cast<uint32_t>(result);
+}
+
 // MARK: - Emscripten-specific functions
 
 #if defined(__EMSCRIPTEN__)

--- a/src/astar.cpp
+++ b/src/astar.cpp
@@ -441,6 +441,8 @@ class FPathExecuteContextImpl : public FPathExecuteContext
 {
 public:
 	virtual ~FPathExecuteContextImpl();
+
+	void resetForNewGameTimeIfNeeded(const PATHJOB& job);
 public:
 	/// Last recently used list of contexts.
 	std::list<PathfindContext> fpathContexts;
@@ -454,6 +456,14 @@ FPathExecuteContext::~FPathExecuteContext()
 FPathExecuteContextImpl::~FPathExecuteContextImpl()
 { }
 
+void FPathExecuteContextImpl::resetForNewGameTimeIfNeeded(const PATHJOB& job)
+{
+	if (!fpathContexts.empty() && job.blockingMap->type.gameTime != fpathContexts.front().myGameTime)
+	{
+		fpathContexts.clear();
+	}
+}
+
 std::shared_ptr<FPathExecuteContext> makeFPathExecuteContext()
 {
 	return std::make_shared<FPathExecuteContextImpl>();
@@ -466,6 +476,7 @@ ASR_RETVAL fpathAStarRoute(const std::shared_ptr<FPathExecuteContext>& ctx, MOVE
 	bool            mustReverse = true;
 
 	auto ctxImpl = std::static_pointer_cast<FPathExecuteContextImpl>(ctx);
+	ctxImpl->resetForNewGameTimeIfNeeded(*psJob);
 
 	std::list<PathfindContext>& fpathContexts = ctxImpl->fpathContexts;
 	const PathCoord tileOrig(map_coord(psJob->origX), map_coord(psJob->origY));

--- a/src/astar.cpp
+++ b/src/astar.cpp
@@ -171,12 +171,12 @@ struct PathfindContext
 	{
 		return !blockingMap->dangerMap.empty() && blockingMap->dangerMap[x + y * mapWidth];
 	}
-	bool matches(std::shared_ptr<PathBlockingMap> &blockingMap_, PathCoord tileS_, PathNonblockingArea dstIgnore_) const
+	bool matches(const std::shared_ptr<const PathBlockingMap> &blockingMap_, PathCoord tileS_, PathNonblockingArea dstIgnore_) const
 	{
 		// Must check myGameTime == blockingMap_->type.gameTime, otherwise blockingMap could be a deleted pointer which coincidentally compares equal to the valid pointer blockingMap_.
 		return myGameTime == blockingMap_->type.gameTime && blockingMap == blockingMap_ && tileS == tileS_ && dstIgnore == dstIgnore_;
 	}
-	void assign(std::shared_ptr<PathBlockingMap> &blockingMap_, PathCoord tileS_, PathNonblockingArea dstIgnore_)
+	void assign(const std::shared_ptr<const PathBlockingMap> &blockingMap_, PathCoord tileS_, PathNonblockingArea dstIgnore_)
 	{
 		blockingMap = blockingMap_;
 		tileS = tileS_;
@@ -206,7 +206,7 @@ struct PathfindContext
 
 	std::vector<PathNode> nodes;        ///< Edge of explored region of the map.
 	std::vector<PathExploredTile> map;  ///< Map, with paths leading back to tileS.
-	std::shared_ptr<PathBlockingMap> blockingMap; ///< Map of blocking tiles for the type of object which needs a path.
+	std::shared_ptr<const PathBlockingMap> blockingMap; ///< Map of blocking tiles for the type of object which needs a path.
 	PathNonblockingArea dstIgnore;      ///< Area of structure at destination which should be considered nonblocking.
 };
 
@@ -432,7 +432,7 @@ static PathCoord fpathAStarExplore(PathfindContext &context, PathCoord tileF)
 	return nearestCoord;
 }
 
-static void fpathInitContext(PathfindContext &context, std::shared_ptr<PathBlockingMap> &blockingMap, PathCoord tileS, PathCoord tileRealS, PathCoord tileF, PathNonblockingArea dstIgnore)
+static void fpathInitContext(PathfindContext &context, const std::shared_ptr<const PathBlockingMap> &blockingMap, PathCoord tileS, PathCoord tileRealS, PathCoord tileF, PathNonblockingArea dstIgnore)
 {
 	context.assign(blockingMap, tileS, dstIgnore);
 

--- a/src/astar.cpp
+++ b/src/astar.cpp
@@ -621,8 +621,8 @@ void fpathSetBlockingMap(PATHJOB *psJob)
 	if (i == fpathBlockingMaps.end())
 	{
 		// Didn't find the map, so i does not point to a map.
-		PathBlockingMap *blockMap = new PathBlockingMap();
-		fpathBlockingMaps.emplace_back(blockMap);
+		auto blockMap = std::make_shared<PathBlockingMap>();
+		fpathBlockingMaps.push_back(blockMap);
 
 		// blockMap now points to an empty map with no data. Fill the map.
 		blockMap->type = type;
@@ -648,7 +648,7 @@ void fpathSetBlockingMap(PATHJOB *psJob)
 		}
 		syncDebug("blockingMap(%d,%d,%d,%d) = %08X %08X", gameTime, psJob->propulsion, psJob->owner, psJob->moveType, checksumMap, checksumDangerMap);
 
-		psJob->blockingMap = fpathBlockingMaps.back();
+		psJob->blockingMap = blockMap;
 	}
 	else
 	{

--- a/src/astar.cpp
+++ b/src/astar.cpp
@@ -51,6 +51,8 @@
 #include <vector>
 #include <algorithm>
 #include <memory>
+#include <iterator>
+#include <cstddef>
 
 #include "lib/netplay/sync_debug.h"
 
@@ -437,6 +439,111 @@ static void fpathInitContext(PathfindContext &context, const std::shared_ptr<con
 	ASSERT(!context.nodes.empty(), "fpathNewNode failed to add node.");
 }
 
+class PathfindContextList
+{
+public:
+	struct Iterator
+	{
+		using iterator_category = std::random_access_iterator_tag;
+		using difference_type = std::ptrdiff_t;
+		using value_type = PathfindContext;
+		using pointer = value_type*;
+		using reference = value_type&;
+
+		Iterator(PathfindContextList& list, size_t idx) : m_list(list), m_idx(idx)
+		{}
+
+		Iterator(const Iterator& other)
+		: m_list(other.m_list)
+		, m_idx(other.m_idx)
+		{}
+
+		Iterator& operator=(const Iterator& other)
+		{
+			m_list = other.m_list;
+			m_idx = other.m_idx;
+			return *this;
+		}
+
+		reference operator*() const { return m_list.contexts[m_list.orderedIndexes[m_idx]]; }
+		pointer operator->() const { return &m_list.contexts[m_list.orderedIndexes[m_idx]]; }
+
+		Iterator& operator++() { ++m_idx; return *this; }
+		Iterator operator++(int) { Iterator tmp = *this; ++(*this); return tmp; }
+
+		Iterator& operator--() { --m_idx; return *this; }
+		Iterator operator--(int) { Iterator tmp = *this; --(*this); return tmp; }
+
+		Iterator operator+(difference_type n) const { return Iterator(m_list, m_idx + n); }
+		Iterator operator-(difference_type n) const { return Iterator(m_list, m_idx - n); }
+		difference_type operator-(const Iterator& other) const { return m_idx - other.m_idx; }
+		Iterator& operator+=(difference_type n) { m_idx += n; return *this; }
+		Iterator& operator-=(difference_type n) { m_idx -= n; return *this; }
+
+		reference operator[](difference_type n) const { return m_list.contexts[m_list.orderedIndexes[n]]; }
+
+		bool operator== (const Iterator& other) { return m_idx == other.m_idx; }
+		bool operator!= (const Iterator& other) { return m_idx != other.m_idx; }
+		bool operator< (const Iterator& other) const { return m_idx < other.m_idx; }
+		bool operator> (const Iterator& other) const { return m_idx > other.m_idx; }
+		bool operator<= (const Iterator& other) const { return m_idx <= other.m_idx; }
+		bool operator>= (const Iterator& other) const { return m_idx >= other.m_idx; }
+
+	private:
+		friend class PathfindContextList;
+
+		PathfindContextList& m_list;
+		size_t m_idx;
+	};
+
+public:
+
+	Iterator push_back(PathfindContext& ctx);
+	Iterator push_back(PathfindContext&& ctx);
+
+	void moveToFront(Iterator it); // invalidates any iterators
+
+	Iterator begin() { return Iterator(*this, 0); }
+	Iterator end() { return Iterator(*this, orderedIndexes.size()); }
+
+	void clear();
+
+	bool empty() const { return contexts.empty(); }
+	PathfindContext& front() { return contexts[orderedIndexes.front()]; }
+
+	size_t size() const { return contexts.size(); }
+
+private:
+	std::vector<PathfindContext> contexts;
+	std::vector<size_t> orderedIndexes;
+};
+
+PathfindContextList::Iterator PathfindContextList::push_back(PathfindContext& ctx)
+{
+	contexts.push_back(ctx);
+	orderedIndexes.push_back(contexts.size() - 1);
+	return Iterator(*this, orderedIndexes.size() - 1);
+}
+
+PathfindContextList::Iterator PathfindContextList::push_back(PathfindContext&& ctx)
+{
+	contexts.push_back(std::move(ctx));
+	orderedIndexes.push_back(contexts.size() - 1);
+	return Iterator(*this, orderedIndexes.size() - 1);
+}
+
+void PathfindContextList::moveToFront(Iterator it)
+{
+	auto oIt = orderedIndexes.begin() + it.m_idx;
+	std::rotate(orderedIndexes.begin(), oIt, oIt + 1);
+}
+
+void PathfindContextList::clear()
+{
+	contexts.clear();
+	orderedIndexes.clear();
+}
+
 class FPathExecuteContextImpl : public FPathExecuteContext
 {
 public:
@@ -445,7 +552,7 @@ public:
 	void resetForNewGameTimeIfNeeded(const PATHJOB& job);
 public:
 	/// Last recently used list of contexts.
-	std::list<PathfindContext> fpathContexts;
+	PathfindContextList fpathContexts;
 	/// Used to avoid extra allocations in fpathAStarRoute
 	std::vector<Vector2i> pathBuffer;
 };
@@ -478,15 +585,15 @@ ASR_RETVAL fpathAStarRoute(const std::shared_ptr<FPathExecuteContext>& ctx, MOVE
 	auto ctxImpl = std::static_pointer_cast<FPathExecuteContextImpl>(ctx);
 	ctxImpl->resetForNewGameTimeIfNeeded(*psJob);
 
-	std::list<PathfindContext>& fpathContexts = ctxImpl->fpathContexts;
+	auto& fpathContexts = ctxImpl->fpathContexts;
 	const PathCoord tileOrig(map_coord(psJob->origX), map_coord(psJob->origY));
 	const PathCoord tileDest(map_coord(psJob->destX), map_coord(psJob->destY));
 	const PathNonblockingArea dstIgnore(psJob->dstStructure);
 
 	PathCoord endCoord;  // Either nearest coord (mustReverse = true) or orig (mustReverse = false).
 
-	std::list<PathfindContext>::iterator contextIterator = fpathContexts.begin();
-	for (contextIterator = fpathContexts.begin(); contextIterator != fpathContexts.end(); ++contextIterator)
+	auto contextIterator = fpathContexts.begin();
+	for (; contextIterator != fpathContexts.end(); ++contextIterator)
 	{
 		if (!contextIterator->matches(psJob->blockingMap, tileDest, dstIgnore))
 		{
@@ -522,12 +629,7 @@ ASR_RETVAL fpathAStarRoute(const std::shared_ptr<FPathExecuteContext>& ctx, MOVE
 	if (contextIterator == fpathContexts.end())
 	{
 		// We did not find an appropriate context. Make one.
-
-		if (fpathContexts.size() < 30)
-		{
-			fpathContexts.push_back(PathfindContext());
-		}
-		--contextIterator;
+		contextIterator = fpathContexts.push_back(PathfindContext());
 
 		// Init a new context, overwriting the oldest one if we are caching too many.
 		// We will be searching from orig to dest, since we don't know where the nearest reachable tile to dest is.
@@ -622,7 +724,7 @@ ASR_RETVAL fpathAStarRoute(const std::shared_ptr<FPathExecuteContext>& ctx, MOVE
 	// Move context to beginning of last recently used list.
 	if (contextIterator != fpathContexts.begin())  // Not sure whether or not the splice is a safe noop, if equal.
 	{
-		fpathContexts.splice(fpathContexts.begin(), fpathContexts, contextIterator);
+		fpathContexts.moveToFront(contextIterator);
 	}
 
 	psMove->destination = psMove->asPath[path.size() - 1];

--- a/src/astar.h
+++ b/src/astar.h
@@ -22,6 +22,7 @@
 #define __INCLUDED_SRC_ASTART_H__
 
 #include "fpath.h"
+#include <memory>
 
 /** return codes for astar
  *
@@ -34,11 +35,20 @@ enum ASR_RETVAL
 	ASR_NEAREST,    ///< found a partial route to a nearby position
 };
 
+class FPathExecuteContext
+{
+protected:
+	FPathExecuteContext() { }
+public:
+	virtual ~FPathExecuteContext();
+};
+std::shared_ptr<FPathExecuteContext> makeFPathExecuteContext();
+
 /** Use the A* algorithm to find a path
  *
  *  @ingroup pathfinding
  */
-ASR_RETVAL fpathAStarRoute(MOVE_CONTROL *psMove, PATHJOB *psJob);
+ASR_RETVAL fpathAStarRoute(const std::shared_ptr<FPathExecuteContext>& ctx, MOVE_CONTROL *psMove, PATHJOB *psJob);
 
 /// Call from main thread.
 /// Sets psJob->blockingMap for later use by pathfinding thread, generating the required map if not already generated.

--- a/src/fpath.cpp
+++ b/src/fpath.cpp
@@ -57,19 +57,57 @@ struct PATHRESULT
 
 
 // threading stuff
-static WZ_THREAD        *fpathThread = nullptr;
-static WZ_MUTEX         *fpathMutex = nullptr;
-static WZ_SEMAPHORE     *fpathSemaphore = nullptr;
 using packagedPathJob = wz::packaged_task<PATHRESULT(const std::shared_ptr<FPathExecuteContext>& ctx)>;
-static std::list<packagedPathJob>    pathJobs;
+
+struct FpathThreadInfo
+{
+public:
+	FpathThreadInfo()
+	{
+		mutex = wzMutexCreate();
+		semaphore = wzSemaphoreCreate(0);
+	}
+
+	~FpathThreadInfo()
+	{
+		wzMutexDestroy(mutex);
+		mutex = nullptr;
+		wzSemaphoreDestroy(semaphore);
+		semaphore = nullptr;
+	}
+
+	FpathThreadInfo(FpathThreadInfo&&) = delete;
+	FpathThreadInfo& operator=(FpathThreadInfo&&) = delete;
+	FpathThreadInfo(const FpathThreadInfo&) = delete;
+	FpathThreadInfo& operator=(const FpathThreadInfo&) = delete;
+public:
+	WZ_SEMAPHORE *semaphore;
+	WZ_MUTEX *mutex;
+	std::list<packagedPathJob> pathJobs;
+};
+
+static std::vector<WZ_THREAD *> fpathThreads;
+static std::vector<std::unique_ptr<FpathThreadInfo>> fpathThreadsInfo;
 static std::unordered_map<uint32_t, wz::future<PATHRESULT>> pathResults;
+
+#ifdef DEBUG
+static std::vector<size_t> numJobsPerThreadThisTick;
+static uint32_t currentFpathTick = 0;
+#endif
+
+constexpr size_t MAX_FPATH_THREADS = 2;
 
 static PATHRESULT fpathExecute(const std::shared_ptr<FPathExecuteContext>& ctx, PATHJOB psJob);
 
 
 /** This runs in a separate thread */
-static int fpathThreadFunc(void *)
+static int fpathThreadFunc(void *data)
 {
+	FpathThreadInfo* threadInfo = static_cast<FpathThreadInfo*>(data);
+	WZ_SEMAPHORE *fpathSemaphore = threadInfo->semaphore;
+	WZ_MUTEX *fpathMutex = threadInfo->mutex;
+	std::list<packagedPathJob>& pathJobs = threadInfo->pathJobs;
+
 	// create an fpath astar job context
 	auto ctx = makeFPathExecuteContext();
 
@@ -105,6 +143,16 @@ static int fpathThreadFunc(void *)
 	return 0;
 }
 
+static size_t fpathDetermineNumberOfThreads()
+{
+	auto logicalCPUCount = wzGetLogicalCPUCount();
+	if (logicalCPUCount <= 1)
+	{
+		return 1;
+	}
+	// subtract one for the main thread
+	return std::min<size_t>(logicalCPUCount - 1, MAX_FPATH_THREADS);
+}
 
 // initialise the findpath module
 bool fpathInitialise()
@@ -112,12 +160,21 @@ bool fpathInitialise()
 	// The path system is up
 	fpathQuit = false;
 
-	if (!fpathThread)
+	if (fpathThreads.empty())
 	{
-		fpathMutex = wzMutexCreate();
-		fpathSemaphore = wzSemaphoreCreate(0);
-		fpathThread = wzThreadCreate(fpathThreadFunc, nullptr, "wzPath");
-		wzThreadStart(fpathThread);
+		auto numThreads = fpathDetermineNumberOfThreads();
+		debug(LOG_INFO, "Using threads: %zu", numThreads);
+		fpathThreads.resize(numThreads, nullptr);
+		fpathThreadsInfo.resize(numThreads);
+#ifdef DEBUG
+		numJobsPerThreadThisTick.resize(numThreads);
+#endif
+		for (size_t i = 0; i < fpathThreads.size(); ++i)
+		{
+			fpathThreadsInfo[i] = std::make_unique<FpathThreadInfo>();
+			fpathThreads[i] = wzThreadCreate(fpathThreadFunc, fpathThreadsInfo[i].get(), "wzPath");
+			wzThreadStart(fpathThreads[i]);
+		}
 	}
 
 	return true;
@@ -126,18 +183,25 @@ bool fpathInitialise()
 
 void fpathShutdown()
 {
-	if (fpathThread)
+	if (!fpathThreads.empty())
 	{
-		// Signal the path finding thread to quit
+		// Signal the path finding thread(s) to quit
 		fpathQuit = true;
-		wzSemaphorePost(fpathSemaphore);  // Wake up thread.
+		for (size_t i = 0; i < fpathThreadsInfo.size(); ++i)
+		{
+			wzSemaphorePost(fpathThreadsInfo[i]->semaphore);  // Wake up a thread
+		}
+		for (size_t i = 0; i < fpathThreads.size(); ++i)
+		{
+			wzThreadJoin(fpathThreads[i]);
+		}
+		fpathThreads.clear();
+		fpathThreadsInfo.clear();
 
-		wzThreadJoin(fpathThread);
-		fpathThread = nullptr;
-		wzMutexDestroy(fpathMutex);
-		fpathMutex = nullptr;
-		wzSemaphoreDestroy(fpathSemaphore);
-		fpathSemaphore = nullptr;
+#ifdef DEBUG
+		numJobsPerThreadThisTick.clear();
+		currentFpathTick = 0;
+#endif
 	}
 	fpathHardTableReset();
 }
@@ -162,6 +226,49 @@ static constexpr size_t fpathPropulsionDomain(PROPULSION_TYPE propulsion)
 	case PROPULSION_TYPE_HOVER:     return 3;  // Land and water
 	}
 	return 0; // silence compiler warning
+}
+
+inline void hash_combine(std::size_t& seed) { }
+
+template <typename T, typename... Rest>
+inline void hash_combine(std::size_t& seed, const T& v, Rest... rest) {
+	std::hash<T> hasher;
+#if SIZE_MAX >= UINT64_MAX
+	seed ^= hasher(v) + 0x9e3779b97f4a7c15L + (seed<<6) + (seed>>2);
+#else
+	seed ^= hasher(v) + 0x9e3779b9 + (seed<<6) + (seed>>2);
+#endif
+	hash_combine(seed, rest...);
+}
+
+static inline size_t fpathJobDispatchThreadId(const PATHJOB& job, size_t numThreads)
+{
+	if (numThreads == 1) { return 0; }
+
+	// Every job that matches a PathfindContext must be processed by the same thread, as the result of fpathAStarRoute is dependent upon jobs
+	// within each matching "cohort" having access to the same PathfindContext (and PathfindContexts are not shared between threads).
+	//
+	// (In other words, the results may slightly differ depending on whether an existing PathfindContext is reused versus starting from scratch.)
+
+	std::size_t h = 0;
+	auto domain = fpathPropulsionDomain(job.propulsion);
+	const Vector2i tileDest(map_coord(job.destX), map_coord(job.destY));
+
+	// Note: We use part of the behavior of PathfindContext::matches() (which is called by fpathAStarRoute)
+	// Specifically, we match using the same logic as fpathIsEquivalentBlocking, plus tileDest
+	if (domain == fpathPropulsionDomain(PROPULSION_TYPE_LIFT))
+	{
+		// Air units ignore move type and player (see: fpathIsEquivalentBlocking)
+		// So just use the domain + tileDest
+		hash_combine(h, domain, tileDest.x, tileDest.y);
+	}
+	else
+	{
+		// All other unit types care about domain + player + moveType (see: fpathIsEquivalentBlocking)
+		// So use those + tileDest
+		hash_combine(h, domain, job.owner, job.moveType, tileDest.x, tileDest.y);
+	}
+	return h % numThreads;
 }
 
 bool fpathIsEquivalentBlocking(PROPULSION_TYPE propulsion1, int player1, FPATH_MOVETYPE moveType1,
@@ -314,6 +421,27 @@ static FPATH_RETVAL fpathRoute(MOVE_CONTROL *psMove, unsigned id, int startX, in
 {
 	objTrace(id, "called(*,id=%d,sx=%d,sy=%d,ex=%d,ey=%d,prop=%d,type=%d,move=%d,owner=%d)", id, startX, startY, tX, tY, (int)propulsionType, (int)droidType, (int)moveType, owner);
 
+#ifdef DEBUG
+	if (gameTime != currentFpathTick)
+	{
+		if (enabled_debug[currentFpathTick])
+		{
+			static std::string tmpDgbStr;
+			tmpDgbStr = "Last tick fpath jobs per thread:";
+			for (const auto& c : numJobsPerThreadThisTick)
+			{
+				tmpDgbStr += " " + std::to_string(c) + ",";
+			}
+			debug(LOG_MOVEMENT, "%s", tmpDgbStr.c_str());
+		}
+		currentFpathTick = gameTime;
+		for (auto& c : numJobsPerThreadThisTick)
+		{
+			c = 0;
+		}
+	}
+#endif
+
 	if (!worldOnMap(startX, startY) || !worldOnMap(tX, tY))
 	{
 		debug(LOG_ERROR, "Droid trying to find path to/from invalid location (%d %d) -> (%d %d).", startX, startY, tX, tY);
@@ -389,13 +517,21 @@ queuePathfinding:
 	packagedPathJob task([job](const std::shared_ptr<FPathExecuteContext>& ctx) { return fpathExecute(ctx, job); });
 	pathResults[id] = task.get_future();
 
-	// Add to end of list
-	wzMutexLock(fpathMutex);
-	bool isFirstJob = pathJobs.empty();
-	pathJobs.push_back(std::move(task));
-	wzMutexUnlock(fpathMutex);
+	// Get target thread for job
+	auto targetThreadId = fpathJobDispatchThreadId(job, fpathThreads.size());
+	auto& threadInfo = *fpathThreadsInfo[targetThreadId];
 
-	wzSemaphorePost(fpathSemaphore);  // Increment semaphore
+	// Add to end of appropriate list
+	wzMutexLock(threadInfo.mutex);
+	bool isFirstJob = threadInfo.pathJobs.empty();
+	threadInfo.pathJobs.push_back(std::move(task));
+	wzMutexUnlock(threadInfo.mutex);
+
+	wzSemaphorePost(threadInfo.semaphore);  // Increment semaphore
+
+#ifdef DEBUG
+	numJobsPerThreadThisTick[targetThreadId]++;
+#endif
 
 	objTrace(id, "Queued up a path-finding request to (%d, %d), at least %d items earlier in queue", tX, tY, isFirstJob);
 	syncDebug("fpathRoute(..., %d, %d, %d, %d, %d, %d, %d, %d, %d) = FPR_WAIT", id, startX, startY, tX, tY, propulsionType, droidType, moveType, owner);
@@ -500,21 +636,22 @@ static size_t fpathJobQueueLength()
 {
 	size_t count = 0;
 
-	wzMutexLock(fpathMutex);
-	count = pathJobs.size();  // O(N) function call for std::list. .empty() is faster, but this function isn't used except in tests.
-	wzMutexUnlock(fpathMutex);
+	for (const auto& threadInfo : fpathThreadsInfo)
+	{
+		wzMutexLock(threadInfo->mutex);
+		count += threadInfo->pathJobs.size(); // O(N) function call for std::list. .empty() is faster, but this function isn't used except in tests.
+		wzMutexUnlock(threadInfo->mutex);
+	}
 	return count;
 }
 
 
-/** Find the length of the result queue, excepting future results. Function is thread-safe. */
+/** Find the length of the result queue, excepting future results. Function must be called from the main thread.. */
 static size_t fpathResultQueueLength()
 {
 	size_t count = 0;
 
-	wzMutexLock(fpathMutex);
 	count = pathResults.size();  // O(N) function call for std::list. .empty() is faster, but this function isn't used except in tests.
-	wzMutexUnlock(fpathMutex);
 	return count;
 }
 
@@ -535,10 +672,13 @@ void fpathTest(int x, int y, int x2, int y2)
 	(void)fpathJobQueueLength();
 
 	/* Check initial state */
-	assert(fpathThread != nullptr);
-	assert(fpathMutex != nullptr);
-	assert(fpathSemaphore != nullptr);
-	assert(pathJobs.empty());
+	assert(!fpathThreads.empty());
+	for (const auto& threadInfo : fpathThreadsInfo)
+	{
+		ASSERT(threadInfo->mutex != nullptr, "Failed to initialize mutex?");
+		ASSERT(threadInfo->semaphore != nullptr, "Failed to initialize semaphore?");
+	}
+	assert(fpathJobQueueLength() == 0);
 	assert(pathResults.empty());
 	fpathRemoveDroidData(0);	// should not crash
 

--- a/src/fpath.cpp
+++ b/src/fpath.cpp
@@ -152,32 +152,30 @@ void fpathUpdate()
 	// Nothing now
 }
 
+static constexpr size_t fpathPropulsionDomain(PROPULSION_TYPE propulsion)
+{
+	switch (propulsion)
+	{
+	default:                        return 0;  // Land
+	case PROPULSION_TYPE_LIFT:      return 1;  // Air
+	case PROPULSION_TYPE_PROPELLOR: return 2;  // Water
+	case PROPULSION_TYPE_HOVER:     return 3;  // Land and water
+	}
+	return 0; // silence compiler warning
+}
 
 bool fpathIsEquivalentBlocking(PROPULSION_TYPE propulsion1, int player1, FPATH_MOVETYPE moveType1,
                                PROPULSION_TYPE propulsion2, int player2, FPATH_MOVETYPE moveType2)
 {
-	int domain1, domain2;
-	switch (propulsion1)
-	{
-	default:                        domain1 = 0; break;  // Land
-	case PROPULSION_TYPE_LIFT:      domain1 = 1; break;  // Air
-	case PROPULSION_TYPE_PROPELLOR: domain1 = 2; break;  // Water
-	case PROPULSION_TYPE_HOVER:     domain1 = 3; break;  // Land and water
-	}
-	switch (propulsion2)
-	{
-	default:                        domain2 = 0; break;  // Land
-	case PROPULSION_TYPE_LIFT:      domain2 = 1; break;  // Air
-	case PROPULSION_TYPE_PROPELLOR: domain2 = 2; break;  // Water
-	case PROPULSION_TYPE_HOVER:     domain2 = 3; break;  // Land and water
-	}
+	auto domain1 = fpathPropulsionDomain(propulsion1);
+	auto domain2 = fpathPropulsionDomain(propulsion2);
 
 	if (domain1 != domain2)
 	{
 		return false;
 	}
 
-	if (domain1 == 1)
+	if (domain1 == fpathPropulsionDomain(PROPULSION_TYPE_LIFT))
 	{
 		return true;  // Air units ignore move type and player.
 	}

--- a/src/fpath.h
+++ b/src/fpath.h
@@ -54,7 +54,7 @@ struct PATHJOB
 	UDWORD		droidID;
 	FPATH_MOVETYPE	moveType;
 	int		owner;		///< Player owner
-	std::shared_ptr<PathBlockingMap> blockingMap;   ///< Map of blocking tiles.
+	std::shared_ptr<const PathBlockingMap> blockingMap;   ///< Map of blocking tiles.
 	bool		acceptNearest;
 	bool            deleted;        ///< Droid was deleted, so throw away result when complete. Must still process this PATHJOB, since processing order can affect resulting paths (but can't affect the path length).
 };


### PR DESCRIPTION
Various refactoring to support splitting fpath jobs into multiple background threads.

Jobs are split based on "cohorts". Cohorts are based on a combination of the blocking map and the destination tile. Or in other words, we have to ensure a job is executed on the same thread as any other jobs that create or use contexts where `PathfindContext::matches` might return `true`, and thus reuse of an existing `PathfindContext` could occur.

Why? Because the results may slightly differ depending on whether an existing `PathfindContext` is reused versus starting from scratch, and we have to ensure the same output results regardless of the number of background threads.

For now, the number of background fpath threads is capped at 2 (as long as there are at least 3 logical cores present on the system).