### PR TITLE
Don't send game time updates for bot slots or closed slots

### DIFF
--- a/lib/gamelib/gtime.cpp
+++ b/lib/gamelib/gtime.cpp
@@ -413,7 +413,7 @@ void sendPlayerGameTime()
 
 	for (player = 0; player < MAX_CONNECTED_PLAYERS; ++player)
 	{
-		if (!myResponsibility(player))
+		if (!myResponsibility(player) || !isHumanPlayer(player))
 		{
 			continue;
 		}

--- a/src/multiplay.cpp
+++ b/src/multiplay.cpp
@@ -803,7 +803,15 @@ bool isHumanPlayer(int player)
 	{
 		return false;	// obvious, really
 	}
-	return NetPlay.players[player].allocated;
+	const auto& p = NetPlay.players[player];
+	return p.allocated && p.difficulty == AIDifficulty::HUMAN;
+}
+
+// Returns true if this player slot is not occupied by either player or a bot
+bool isClosedPlayerSlot(int player)
+{
+	const auto& p = NetPlay.players[player];
+	return p.allocated == false && p.difficulty == AIDifficulty::DISABLED;
 }
 
 // Clear player name data after game quit.
@@ -833,7 +841,7 @@ int whosResponsible(int player)
 //returns true if selected player is responsible for 'player'
 bool myResponsibility(int player)
 {
-	return (whosResponsible(player) == selectedPlayer || whosResponsible(player) == realSelectedPlayer);
+	return !isClosedPlayerSlot(player) && (whosResponsible(player) == selectedPlayer || whosResponsible(player) == realSelectedPlayer);
 }
 
 //returns true if 'player' is responsible for 'playerinquestion'

--- a/src/multiplay.h
+++ b/src/multiplay.h
@@ -246,6 +246,7 @@ bool setPlayerName(int player, const char *sName);
 void clearPlayerName(unsigned int player);
 const char *getPlayerColourName(int player);
 bool isHumanPlayer(int player);				//to tell if the player is a computer or not.
+bool isClosedPlayerSlot(int player); // Returns true if this player slot is not occupied by either player or a bot
 bool myResponsibility(int player);
 bool responsibleFor(int player, int playerinquestion);
 int whosResponsible(int player);


### PR DESCRIPTION
Avoid sending game time messages for closed slots as this doesn't make any sense.

Also, don't send these messages to currently occupied bot slots, since messages from the bot game queues aren't actually processed anywhere (instead, everything is routed through the host's game queue).