### PR TITLE
gametime: Send game time updates only to human player slots

### DIFF
--- a/lib/gamelib/gtime.cpp
+++ b/lib/gamelib/gtime.cpp
@@ -413,7 +413,7 @@ void sendPlayerGameTime()
 
 	for (player = 0; player < MAX_CONNECTED_PLAYERS; ++player)
 	{
-		if (!myResponsibility(player))
+		if (!myResponsibility(player) || !isHumanPlayer(player))
 		{
 			continue;
 		}


### PR DESCRIPTION
Don't send these messages to currently occupied bot slots (or closed slots), since messages from the bot game queues aren't actually processed anywhere (instead, everything is routed through the host's game queue).