### PR TITLE
ingameop.cpp: Fix crash on host game quit due to invalid C-style cast

### DIFF
--- a/src/ingameop.cpp
+++ b/src/ingameop.cpp
@@ -420,26 +420,26 @@ bool intCloseInGameOptions(bool bPutUpLoadSave, bool bResetMissionWidgets)
 	{
 		// close the form.
 		// Start the window close animation.
-		IntFormAnimated *form = (IntFormAnimated *)widgGetFromID(psWScreen, INTINGAMEPOPUP);
+		IntFormAnimated *form = dynamic_cast<IntFormAnimated *>(widgGetFromID(psWScreen, INTINGAMEPOPUP));
 		if (form)	// FIXME: we hijack this routine for the popup close.
 		{
 			form->closeAnimateDelete();
 			isInGamePopupUp = false;
 		}
-		form = (IntFormAnimated *)widgGetFromID(psWScreen, INTINGAMEOP_POPUP_QUIT);
+		form = dynamic_cast<IntFormAnimated *>(widgGetFromID(psWScreen, INTINGAMEOP_POPUP_QUIT));
 		if (form)
 		{
 			form->closeAnimateDelete();
 			isInGamePopupUp = false;
 		}
 
-		form = (IntFormAnimated *)widgGetFromID(psWScreen, INTINGAMEOP);
+		form = dynamic_cast<IntFormAnimated *>(widgGetFromID(psWScreen, INTINGAMEOP));
 		if (form)
 		{
 			form->closeAnimateDelete();
 			InGameOpUp = false;
 		}
-		form = (IntFormAnimated *)widgGetFromID(psWScreen, INTINGAMEOP_QUIT);
+		form = dynamic_cast<IntFormAnimated *>(widgGetFromID(psWScreen, INTINGAMEOP_QUIT));
 		if (form)
 		{
 			form->closeAnimateDelete();


### PR DESCRIPTION
`widgGetFromID(psWScreen, INTINGAMEOP_QUIT)` returns `W_BUTTON`, which inherits `WIDGET`, so the C-style cast to `IntFormAnimated*` is UB. This leads to a crash, easily reproducible by starting an MP game as a host and quitting it via the `Quit Game` button.