### PR TITLE
netqueue: Implement pooling for `NetMessage`:s

### DIFF
--- a/lib/framework/memory_pool.cpp
+++ b/lib/framework/memory_pool.cpp
@@ -1,0 +1,252 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+/*
+	This file is part of Warzone 2100.
+	Copyright (C) 2025  Warzone 2100 Project
+
+	Warzone 2100 is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+
+	Warzone 2100 is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with Warzone 2100; if not, write to the Free Software
+	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+#include "lib/framework/memory_pool.h"
+#include "lib/framework/frame.h" // FOR ASSERT, ASSERT_OR_RETURN
+
+namespace
+{
+
+size_t num_size_classes(const MemoryPoolOptions& opts)
+{
+	size_t n = 1;
+	size_t sz = opts.minimal_supported_block_size;
+	while (sz < opts.largest_required_block_size)
+	{
+		sz <<= 1;
+		++n;
+	}
+	return n;
+}
+
+size_t initial_chunk_capacity(const MemoryPoolOptions& opts, size_t blockSize)
+{
+	// Sub-pools corresponding to smaller blocks will get more capacity by default.
+	// Always allocate at least `opts.minimal_required_capacity` blocks for any given `blockSize`.
+	return std::max(
+		(opts.required_capacity_for_smallest_sub_pool * opts.minimal_supported_block_size) / blockSize,
+		opts.minimal_required_capacity);
+}
+
+bool is_pow_2(size_t x)
+{
+	return (x & (x - 1)) == 0;
+}
+
+// Round up `x` to the nearest power-of-2
+size_t bit_ceil(size_t x)
+{
+	if (x <= 1)
+	{
+		return 1;
+	}
+	size_t i = 1;
+	while ((size_t(1) << i) < x)
+	{
+		++i;
+	}
+	return size_t(1) << i;
+}
+
+// Provide some validation of initial memory pool options + fixup the values, if needed, to match implementation expectations.
+MemoryPoolOptions fixup_options(const MemoryPoolOptions& opts)
+{
+	ASSERT(is_pow_2(opts.minimal_supported_block_size) && is_pow_2(opts.largest_required_block_size), "Block size should be a power of 2");
+	ASSERT(opts.minimal_required_capacity > 0, "Invalid minimal required size class capacity");
+	ASSERT(opts.required_capacity_for_smallest_sub_pool >= opts.minimal_required_capacity, "Invalid required capacity for smallest sub-pool");
+
+	MemoryPoolOptions res;
+
+	// Default to 8 if minimal_required_capacity is set to 0 by user.
+	res.minimal_required_capacity = opts.minimal_required_capacity > 0 ? opts.minimal_required_capacity : 8;
+	// Use x2 multiplier (relative to the minimal required capacity) heuristic for the worst case.
+	res.required_capacity_for_smallest_sub_pool =
+		opts.required_capacity_for_smallest_sub_pool >= opts.minimal_required_capacity ?
+		opts.required_capacity_for_smallest_sub_pool :
+		opts.minimal_required_capacity * 2;
+	// Round up block size limits to the nearest powers-of-2
+	res.minimal_supported_block_size = bit_ceil(opts.minimal_supported_block_size);
+	res.largest_required_block_size = bit_ceil(opts.largest_required_block_size);
+
+	return res;
+}
+
+} // anonymous namespace
+
+MemoryPool::MemoryPool(const MemoryPoolOptions& opts)
+	: opts_(fixup_options(opts))
+{
+	allocate_sub_pools(num_size_classes(opts_));
+}
+
+void* MemoryPool::allocate(size_t size, size_t alignment)
+{
+	if (size == 0 || size > largest_supported_block_size())
+	{
+		ASSERT(false, "Invalid allocation size (doesn't fit into any available size class): %zu", size);
+		return nullptr;
+	}
+	SubPool* pool = find_pool(size, alignment);
+	ASSERT_OR_RETURN(nullptr, pool != nullptr, "No available blocks in any pool for size %zu and alignment %zu", size, alignment);
+
+	// If there are free blocks, serve from freelist or from chunk's nextFreeIndex
+	if (pool->totalFreeBlocks != 0)
+	{
+		for (auto& chunk : pool->chunks)
+		{
+			// Serve from the chunk's freelist if it's not empty
+			if (!chunk.freeBlocks.empty())
+			{
+				return pool->allocate_from_freelist(chunk, alignment);
+			}
+			// Otherwise, find the first chunk with nextFreeIndex < capacity
+			if (chunk.nextFreeIndex < chunk.capacity)
+			{
+				return pool->allocate_new_block(chunk, alignment);
+			}
+		}
+		// Should not reach here if totalFreeBlocks is correct
+		ASSERT(false, "totalFreeBlocks > 0 but no available block found");
+		return nullptr;
+	}
+
+	// If no free blocks, allocate a new chunk (capacities increasing in a geometric progression)
+	// and serve the allocation from it
+	size_t newChunkCapacity = pool->chunks.back().capacity * 2;
+	auto& newChunk = pool->chunks.emplace_back(pool->blockSize, newChunkCapacity);
+	pool->totalFreeBlocks += newChunkCapacity;
+	return pool->allocate_new_block(newChunk, alignment);
+}
+
+void MemoryPool::deallocate(void* ptr, size_t bytes, size_t alignment)
+{
+	if (!ptr)
+	{
+		return;
+	}
+	SubPool* pool = find_pool(bytes, alignment);
+	ASSERT_OR_RETURN(, pool != nullptr, "No sub-pool found for deallocation (bytes=%zu, alignment=%zu)", bytes, alignment);
+
+	// Find the chunk that owns this pointer
+	auto chunkIt = pool->get_owning_chunk(ptr);
+	ASSERT_OR_RETURN(, chunkIt != pool->chunks.end(), "Pointer %p not from this pool", ptr);
+
+	++chunkIt->freeBlocksCount;
+	++pool->totalFreeBlocks;
+
+	// Each subsequent chunk in the list is larger than the previous one
+	// Always prefer larger chunks over smaller ones (with the smaller one being automatically reclaimed)
+	if (chunkIt->freeBlocksCount == chunkIt->capacity && std::next(chunkIt) != pool->chunks.end())
+	{
+		// Reclaim the now-empty chunk
+		const auto reclaimedCapacity = chunkIt->capacity;
+		pool->chunks.erase(chunkIt);
+		// Fixup the total sub-pool capacity to account for the just reclaimed chunk
+		pool->totalFreeBlocks -= reclaimedCapacity;
+	}
+	else
+	{
+		// Either this is _the_ largest chunk available in the sub-pool, or it's not empty yet
+		// Push the block to the chunk's freelist
+		chunkIt->freeBlocks.push(ptr);
+	}
+}
+
+size_t MemoryPool::largest_supported_block_size() const
+{
+	return opts_.largest_required_block_size;
+}
+
+void MemoryPool::allocate_sub_pools(size_t numSizeClasses)
+{
+	subPools_.reserve(numSizeClasses);
+
+	size_t block_size = opts_.minimal_supported_block_size;
+	for (size_t i = 0; i < numSizeClasses; ++i)
+	{
+		SubPool sp;
+		sp.blockSize = block_size;
+		// Create initial chunk
+		size_t initial_capacity = initial_chunk_capacity(opts_, block_size);
+
+		sp.chunks.emplace_back(block_size, initial_capacity);
+		sp.totalFreeBlocks = initial_capacity;
+
+		subPools_.emplace_back(std::move(sp));
+
+		block_size <<= 1;
+	}
+}
+
+MemoryPool::SubPool* MemoryPool::find_pool(size_t bytes, size_t alignment)
+{
+	for (auto& p : subPools_)
+	{
+		if (p.blockSize >= bytes && p.blockSize >= alignment && p.blockSize % alignment == 0)
+		{
+			return &p;
+		}
+	}
+	return nullptr;
+}
+
+MemoryPool::SubPool::ChunkStorage::iterator MemoryPool::SubPool::get_owning_chunk(void* ptr)
+{
+	uint8_t* p = static_cast<uint8_t*>(ptr);
+	for (auto it = chunks.begin(), end = chunks.end(); it != end; ++it)
+	{
+		Chunk& chunk = *it;
+		uint8_t* buf = chunk.buffer.get();
+		size_t total_size = chunk.blockSize * chunk.capacity;
+		if (p >= buf && p < buf + total_size)
+		{
+			size_t offset = static_cast<size_t>(p - buf);
+			ASSERT_OR_RETURN(chunks.end(), offset % chunk.blockSize == 0, "Pointer is not aligned to block size");
+			return it;
+		}
+	}
+	return chunks.end();
+}
+
+void* MemoryPool::SubPool::allocate_new_block(Chunk& chunk, size_t alignment)
+{
+	void* block = chunk.buffer.get() + chunk.nextFreeIndex * chunk.blockSize;
+	++chunk.nextFreeIndex;
+	--chunk.freeBlocksCount;
+	--totalFreeBlocks;
+	ASSERT_OR_RETURN(nullptr, reinterpret_cast<uintptr_t>(block) % alignment == 0, "Block returned is not properly aligned");
+	return block;
+}
+
+void* MemoryPool::SubPool::allocate_from_freelist(Chunk& chunk, size_t alignment)
+{
+	void* block = chunk.freeBlocks.front();
+	chunk.freeBlocks.pop();
+	--chunk.freeBlocksCount;
+	--totalFreeBlocks;
+	ASSERT_OR_RETURN(nullptr, reinterpret_cast<uintptr_t>(block) % alignment == 0, "Block returned from free list is not properly aligned");
+	return block;
+}
+
+MemoryPool& defaultMemoryPool()
+{
+	static MemoryPool instance({});
+	return instance;
+}

--- a/lib/framework/memory_pool.h
+++ b/lib/framework/memory_pool.h
@@ -1,0 +1,176 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+/*
+	This file is part of Warzone 2100.
+	Copyright (C) 2025  Warzone 2100 Project
+
+	Warzone 2100 is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+
+	Warzone 2100 is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with Warzone 2100; if not, write to the Free Software
+	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+/**
+ * @file memory_pool.h
+ * MemoryPool provides efficient allocation and deallocation of fixed-size memory blocks using
+ * multiple power-of-2 size classes.
+ * Works best for relatively small block sizes (<=256 KiB).
+ */
+#pragma once
+
+#include "lib/framework/frame.h" // for ASSERT
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <cassert>
+#include <queue>
+#include <list>
+#include <utility>
+#include <vector>
+
+/// <summary>
+/// Options for MemoryPool controlling how many size classes there are,
+/// how block sizes are distributed and how much elements each individual
+/// size class has.
+/// </summary>
+struct MemoryPoolOptions
+{
+	// Minimal supported block size (in bytes). This needs to be a power-of-2.
+	// The very first (smallest one in terms of block size) size class will have this block size.
+	size_t minimal_supported_block_size = 8;
+	// The largest block size required to be supported by the MemoryPool (in bytes).
+	// MemoryPool may allocate size classes that have block size at least this much bytes.
+	size_t largest_required_block_size = 65536;
+	// The very first (the smallest one in terms of block size) size class will have this much
+	// elements initially allocated in the first memory chunk.
+	size_t required_capacity_for_smallest_sub_pool = 512;
+	// Each size class is required to have at least this much elements in a single memory chunk.
+	size_t minimal_required_capacity = 8;
+};
+
+/// <summary>
+/// MemoryPool provides efficient allocation and deallocation of fixed-size memory blocks using
+/// multiple power-of-2 size classes.
+/// Works best for relatively small block sizes (<=256 KiB).
+///
+/// MemoryPool consists of a set of sub-pools.
+///
+/// Each sub-pool is responsible for serving fixed-sized allocations (equal to its block size)
+/// from a single contiguous chunk of memory. If the capacity of a sub-pool is exceeded,
+/// it will automatically replenish it by allocating a new chunk of memory having its capacity
+/// to be twice the capacity of the previous chunk.
+/// Every memory chunk manages its own free list for fast block reuse.
+///
+/// On deallocation, the sub-pool will automatically reclaim and deallocate smaller chunks
+/// (if the current chunk has become empty) in favor of larger chunks (if there's any).
+/// This helps to keep memory consumption better overall.
+///
+/// Each subsequent sub-pool will have block size twice as large than the previous one.
+/// </summary>
+class MemoryPool
+{
+public:
+
+	explicit MemoryPool(const MemoryPoolOptions& opts);
+
+	~MemoryPool() = default;
+	MemoryPool(const MemoryPool&) = delete;
+	MemoryPool& operator=(const MemoryPool&) = delete;
+
+	/// <summary>
+	/// Allocate a block of at least the requested size and alignment.
+	/// </summary>
+	void* allocate(size_t size, size_t alignment);
+
+	/// <summary>
+	/// Deallocate a previously allocated block. Finds the sub-pool by size and alignment.
+	///
+	/// Will try to automatically deallocate the "now-empty" chunk if there's a larger one
+	/// available in the current sub-pool.
+	/// </summary>
+	void deallocate(void* ptr, size_t bytes, size_t alignment);
+
+	size_t largest_supported_block_size() const;
+
+private:
+
+	struct Chunk
+	{
+		size_t blockSize;
+		size_t capacity;
+		size_t freeBlocksCount;
+		size_t nextFreeIndex = 0;  // Next index for a block that has never been allocated before
+		std::unique_ptr<uint8_t[]> buffer;
+		std::queue<void*> freeBlocks;
+
+		Chunk(size_t bSize, size_t cap)
+			: blockSize(bSize)
+			, capacity(cap)
+			, freeBlocksCount(cap)
+			, nextFreeIndex(0)
+			, buffer(std::make_unique<uint8_t[]>(bSize * cap))
+		{}
+	};
+
+	struct SubPool
+	{
+		explicit SubPool() = default;
+		SubPool(SubPool&& other) = default;
+
+		using ChunkStorage = std::list<Chunk>;
+
+		size_t blockSize = 0;
+		size_t totalFreeBlocks = 0;
+		ChunkStorage chunks;
+
+		// Returns the owning chunk for a pointer
+		ChunkStorage::iterator get_owning_chunk(void* ptr);
+
+		/// <summary>
+		/// Helper to allocate a block from a chunk, update counters, and check alignment.
+		/// </summary>
+		/// <param name="chunk">Reference to the chunk to allocate from.</param>
+		/// <param name="alignment">Alignment requirement for the memory block.</param>
+		/// <returns>Pointer to the allocated memory block.</returns>
+		void* allocate_new_block(Chunk& chunk, size_t alignment);
+
+		/// <summary>
+		/// Helper to allocate a block from the freelist of a given chunk.
+		/// </summary>
+		/// <param name="pool">Pointer to the chunk containing the freelist.</param>
+		/// <param name="alignment">Alignment requirement for the memory block.</param>
+		/// <returns>Pointer to the allocated memory block.</returns>
+		void* allocate_from_freelist(Chunk& chunk, size_t alignment);
+	};
+
+	/// <summary>
+	/// Allocates sub-pools for supported size classes.
+	/// </summary>
+	void allocate_sub_pools(size_t numSizeClasses);
+
+	/// <summary>
+	/// Finds a suitable sub-pool for the specified size and alignment.
+	/// </summary>
+	/// <param name="bytes">Size of the memory block to find a pool for.</param>
+	/// <param name="alignment">Alignment requirement for the memory block.</param>
+	/// <returns>Pointer to the appropriate SubPool, or nullptr if no suitable pool is found.</returns>
+	SubPool* find_pool(size_t bytes, size_t alignment);
+
+	MemoryPoolOptions opts_;
+	std::vector<SubPool> subPools_;
+};
+
+/// <summary>
+/// Provides a default singleton memory pool instance for use throughout the application.
+/// </summary>
+/// <returns>Reference to the default memory pool instance.</returns>
+MemoryPool& defaultMemoryPool();

--- a/lib/framework/pool_allocator.h
+++ b/lib/framework/pool_allocator.h
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+/*
+	This file is part of Warzone 2100.
+	Copyright (C) 2025  Warzone 2100 Project
+
+	Warzone 2100 is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+
+	Warzone 2100 is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with Warzone 2100; if not, write to the Free Software
+	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+/**
+ * @file pool_allocator.h
+ * STL-compatible allocator that uses MemoryPool for memory management.
+ */
+#pragma once
+
+#include "lib/framework/memory_pool.h"
+#include <algorithm>
+#include <cstddef>
+#include <memory>
+#include <type_traits>
+#include <unordered_set>
+
+/// <summary>
+/// STL-compatible allocator that uses MemoryPool for memory management.
+/// </summary>
+template <typename T, typename PoolT = MemoryPool>
+class PoolAllocator
+{
+public:
+	using value_type = T;
+	using pointer = T*;
+	using const_pointer = const T*;
+	using reference = T&;
+	using const_reference = const T&;
+	using size_type = std::size_t;
+	using difference_type = std::ptrdiff_t;
+
+	template <typename U>
+	struct rebind { using other = PoolAllocator<U, PoolT>; };
+
+	PoolAllocator() noexcept : pool_(defaultMemoryPool()) {}
+
+	explicit PoolAllocator(PoolT& pool) noexcept : pool_(pool) {}
+
+	PoolAllocator(const PoolAllocator& other) noexcept
+		: pool_(other.pool_),
+		defaultAlloc_(other.defaultAlloc_),
+		oversizedAllocs_(other.oversizedAllocs_)
+	{}
+
+	template <typename U>
+	PoolAllocator(const PoolAllocator<U, PoolT>& other) noexcept
+		: pool_(other.pool_),
+		defaultAlloc_(other.defaultAlloc_),
+		oversizedAllocs_(other.oversizedAllocs_)
+	{}
+
+	pointer allocate(size_type n)
+	{
+		if (pool_.largest_supported_block_size() < std::max(n * sizeof(T), alignof(T)))
+		{
+			// Allocate via default new-delete allocator if there's no suitable block size available in the memory pool.
+			T* ret = defaultAlloc_.allocate(n);
+			oversizedAllocs_.emplace(ret);
+			return ret;
+		}
+		T* ret = static_cast<pointer>(pool_.allocate(n * sizeof(T), alignof(T)));
+		if (!ret)
+		{
+			// This could only happen if the underlying memory pool failed to replenish its capacity (failed to allocate a new chunk).
+			// Not much we can do in this particular situation.
+			throw std::bad_alloc();
+		}
+		return ret;
+	}
+
+	void deallocate(pointer p, size_type n)
+	{
+		if (pool_.largest_supported_block_size() < std::max(n * sizeof(T), alignof(T)))
+		{
+			auto oversizedIt = oversizedAllocs_.find(p);
+			ASSERT(oversizedIt != oversizedAllocs_.end(), "Block %p not allocated by the current allocator.", static_cast<void*>(p));
+			if (oversizedIt != oversizedAllocs_.end())
+			{
+				oversizedAllocs_.erase(oversizedIt);
+				defaultAlloc_.deallocate(p, n);
+			}
+			return;
+		}
+		pool_.deallocate(static_cast<void*>(p), n * sizeof(T), alignof(T));
+	}
+
+	template <typename U, typename... Args>
+	void construct(U* p, Args&&... args)
+	{
+		::new ((void*)p) U(std::forward<Args>(args)...);
+	}
+
+	template <typename U>
+	void destroy(U* p)
+	{
+		p->~U();
+	}
+
+	// Comparison operators
+	bool operator==(const PoolAllocator& other) const noexcept { return &pool_ == &other.pool_ && defaultAlloc_ == other.defaultAlloc_; }
+	bool operator!=(const PoolAllocator& other) const noexcept { return !(*this == other); }
+
+	PoolT& pool_;
+	std::allocator<T> defaultAlloc_;
+	std::unordered_set<void*> oversizedAllocs_;
+};

--- a/lib/netplay/netqueue.cpp
+++ b/lib/netplay/netqueue.cpp
@@ -107,7 +107,7 @@ bool decode_uint32_t(uint8_t b, uint32_t &v, unsigned n)
 	return !isLastByte;
 }
 
-NetMessage::NetMessage(std::vector<uint8_t>&& data)
+NetMessage::NetMessage(NetMsgDataVector&& data)
 	: data_(std::move(data))
 {}
 
@@ -117,7 +117,7 @@ uint8_t NetMessage::type() const
 	return data_[0];
 }
 
-const std::vector<uint8_t>& NetMessage::rawData() const
+const NetMsgDataVector& NetMessage::rawData() const
 {
 	return data_;
 }
@@ -161,19 +161,21 @@ void NetMessage::rawDataAppendToVector(std::vector<uint8_t>& output) const
 }
 
 NetMessageBuilder::NetMessageBuilder(uint8_t type, size_t reservedCapacity /* = 16 */)
+	: data_(MsgDataAllocator(defaultMemoryPool()))
 {
 	data_.reserve(reservedCapacity + NetMessage::HEADER_LENGTH);
 	data_.resize(NetMessage::HEADER_LENGTH);
 	data_[0] = type;
 }
 
-NetMessageBuilder::NetMessageBuilder(std::vector<uint8_t>&& rawData)
+NetMessageBuilder::NetMessageBuilder(NetMsgDataVector&& rawData)
 	: data_(std::move(rawData))
 {}
 
 NetQueue::NetQueue()
 	: canGetMessagesForNet(true)
 	, canGetMessages(true)
+	, messages(MsgAllocator(defaultMemoryPool()))
 	, pendingGameTimeUpdateMessages(0)
 	, bCurrentMessageWasDecrypted(false)
 {

--- a/lib/netplay/nettypes.cpp
+++ b/lib/netplay/nettypes.cpp
@@ -773,27 +773,6 @@ void NETbin(MessageReader &r, uint8_t *str, uint32_t len)
     r.bytes(str, len);
 }
 
-void NETbytes(MessageReader &r, std::vector<uint8_t>& vec, unsigned maxLen /* = 10000 */)
-{
-	/*
-	 * Strings sent over the network are prefixed with their length, sent as an
-	 * unsigned 16-bit integer, not including \0 termination.
-	 */
-
-	uint32_t len = 0;
-	NETuint32_t(r, len);
-	if (len > maxLen)
-	{
-		debug(LOG_ERROR, "NETbytes: Decoding packet, length %u truncated at %u", len, maxLen);
-	}
-	len = std::min<unsigned>(len, maxLen);  // Truncate length if necessary.
-	vec.clear();
-	if (r.valid())
-	{
-		r.bytesVector(vec, len);
-	}
-}
-
 void NETPosition(MessageReader& r, Position& pos)
 {
 	NETint32_t(r, pos.x);
@@ -816,7 +795,7 @@ void NETVector2i(MessageReader& r, Vector2i& vec)
 
 void NETnetMessage(MessageReader& r, NetMessage** msg)
 {
-	std::vector<uint8_t> rawData;
+	NetMsgDataVector rawData{MsgDataAllocator(defaultMemoryPool())};
 	NETbytes(r, rawData, std::numeric_limits<uint32_t>::max());
 	*msg = new NetMessage(NetMessageBuilder(std::move(rawData)).build());
 }
@@ -944,24 +923,6 @@ void NETstring(MessageWriter& w, const std::string& s, uint32_t maxLen /* = 6553
 void NETbin(MessageWriter& w, const uint8_t* str, uint32_t len)
 {
 	w.bytes(str, len);
-}
-
-void NETbytes(MessageWriter& w, const std::vector<uint8_t>& vec, unsigned maxLen)
-{
-	/*
-	 * Strings sent over the network are prefixed with their length, sent as an
-	 * unsigned 16-bit integer, not including \0 termination.
-	 */
-
-	ASSERT(vec.size() <= static_cast<size_t>(std::numeric_limits<uint32_t>::max()), "vec.size() exceeds uint32_t max");
-	uint32_t len = static_cast<uint32_t>(std::min(vec.size(), static_cast<size_t>(std::numeric_limits<uint32_t>::max())));
-	if (len > maxLen)
-	{
-		debug(LOG_ERROR, "NETbytes: Encoding packet, length %u truncated at %u", len, maxLen);
-	}
-	len = std::min<unsigned>(len, maxLen);  // Truncate length if necessary.
-	NETuint32_t(w, len);
-	w.bytes(vec.data(), len);
 }
 
 void NETPosition(MessageWriter& w, const Position& pos)


### PR DESCRIPTION
The changeset implements the following things to address memory fragmentation issues in WZ:

* `MemoryPool` for efficient allocation and deallocation of small fixed-size memory blocks using multiple power-of-2 size classes.
* `MemoryPoolOptions` configuration struct to facilitate creating memory pools for various needs.
* `PoolAllocator<T>` which uses `MemoryPool` under the hood.
* `defaultMemoryPool()` function, which returns the application-wide singleton pool for generic purposes.
* Switches `NetQueue::messages` to use pooled allocations via `PoolAllocator`.

Fixes: https://github.com/Warzone2100/warzone2100/issues/4364