### PR TITLE
netplay: Call `WzConnectionProvider::disposeConnection()` before actually deleting connection object

### DIFF
--- a/lib/netplay/gns/gns_connection_provider.cpp
+++ b/lib/netplay/gns/gns_connection_provider.cpp
@@ -264,11 +264,11 @@ void GNSConnectionProvider::ServerConnectionStateChanged(SteamNetConnectionStatu
 		break;
 	case k_ESteamNetworkingConnectionState_ClosedByPeer:
 		debug(LOG_ERROR, "Connection closed by peer: %u", pInfo->m_hConn);
-		connProvider->disposeConnection(pInfo->m_hConn);
+		connProvider->disposeConnectionImpl(pInfo->m_hConn);
 		break;
 	case k_ESteamNetworkingConnectionState_ProblemDetectedLocally:
 		debug(LOG_ERROR, "Connection closed, problem detected locally: %u", pInfo->m_hConn);
-		connProvider->disposeConnection(pInfo->m_hConn);
+		connProvider->disposeConnectionImpl(pInfo->m_hConn);
 		break;
 	default:
 		break;
@@ -293,11 +293,11 @@ void GNSConnectionProvider::ClientConnectionStateChanged(SteamNetConnectionStatu
 		break;
 	case k_ESteamNetworkingConnectionState_ClosedByPeer:
 		debug(LOG_WARNING, "Connection closed by peer: %u", pInfo->m_hConn);
-		connProvider->disposeConnection(pInfo->m_hConn);
+		connProvider->disposeConnectionImpl(pInfo->m_hConn);
 		break;
 	case k_ESteamNetworkingConnectionState_ProblemDetectedLocally:
 		debug(LOG_ERROR, "Connection closed, problem detected locally: %u", pInfo->m_hConn);
-		connProvider->disposeConnection(pInfo->m_hConn);
+		connProvider->disposeConnectionImpl(pInfo->m_hConn);
 		break;
 	default:
 		break;
@@ -328,7 +328,14 @@ void GNSConnectionProvider::registerAcceptedConnection(GNSClientConnection* conn
 	activeClients_[conn->connectionHandle()] = conn;
 }
 
-void GNSConnectionProvider::disposeConnection(HSteamNetConnection hConn)
+void GNSConnectionProvider::disposeConnection(IClientConnection* conn)
+{
+	auto* gnsConn = dynamic_cast<GNSClientConnection*>(conn);
+	ASSERT_OR_RETURN(, gnsConn != nullptr, "Expected GNSClientConnection instance");
+	disposeConnectionImpl(gnsConn->connectionHandle());
+}
+
+void GNSConnectionProvider::disposeConnectionImpl(HSteamNetConnection hConn)
 {
 	if (hConn == k_HSteamNetConnection_Invalid)
 	{

--- a/lib/netplay/gns/gns_connection_provider.h
+++ b/lib/netplay/gns/gns_connection_provider.h
@@ -81,6 +81,8 @@ public:
 
 	virtual PortMappingInternetProtocolMask portMappingProtocolTypes() const override;
 
+	virtual void disposeConnection(IClientConnection* conn) override;
+
 	void registerAcceptedConnection(GNSClientConnection* conn);
 
 private:
@@ -102,7 +104,7 @@ private:
 	// The connection object is automatically removed from its owning poll group (if there's any)
 	// and the internal GNS connection handle is closed, so that the connection object
 	// will be left in an invalid state (that is, `isValid()` will become `false`).
-	void disposeConnection(HSteamNetConnection hConn);
+	void disposeConnectionImpl(HSteamNetConnection hConn);
 
 	ISteamNetworkingSockets* networkInterface_ = nullptr;
 	std::unordered_map<HSteamNetConnection, GNSClientConnection*> activeClients_;

--- a/lib/netplay/pending_writes_manager.cpp
+++ b/lib/netplay/pending_writes_manager.cpp
@@ -217,6 +217,8 @@ void PendingWritesManager::safeDispose(IClientConnection* conn)
 		}
 		else
 		{
+			// Notify the owning connection provider to properly dispose of the connection object.
+			conn->connProvider_->disposeConnection(conn);
 			// Delete the socket and destroy the connection right away.
 			delete conn;
 		}

--- a/lib/netplay/tcp/tcp_connection_provider.h
+++ b/lib/netplay/tcp/tcp_connection_provider.h
@@ -62,6 +62,12 @@ public:
 
 	virtual PortMappingInternetProtocolMask portMappingProtocolTypes() const override;
 
+	virtual void disposeConnection(IClientConnection* conn) override
+	{
+		// TODO: Remove the connection from the owning poll group (if there's any).
+		// For this, we'll need to have a reference to the poll group in the `IClientConnection` interface.
+	}
+
 private:
 
 	std::unique_ptr<IAddressResolver> addressResolver_;

--- a/lib/netplay/wz_connection_provider.h
+++ b/lib/netplay/wz_connection_provider.h
@@ -111,4 +111,12 @@ public:
 	virtual void processConnectionStateChanges() = 0;
 
 	virtual PortMappingInternetProtocolMask portMappingProtocolTypes() const = 0;
+
+	/// <summary>
+	/// Perform generic cleanup actions for a given connection, i.e.: update the bookkeeping
+	/// information for the connection provider, flush any pending writes, remove the connection
+	/// from owning poll group (if there's any), etc.
+	/// </summary>
+	/// <param name="conn">Connection object to dispose of.</param>
+	virtual void disposeConnection(IClientConnection* conn) = 0;
 };


### PR DESCRIPTION
Allow the owning `WzConnectionProvider` instance to perform any necessary cleanup steps for the connection object (e.g., remove it from any internal connection state mappings, flush pending messages, unsubscribe from poll groups etc.) before destroying the connection object.