### PR TITLE
add wzapi::structureCanFit

### DIFF
--- a/src/quickjs_backend.cpp
+++ b/src/quickjs_backend.cpp
@@ -3122,6 +3122,7 @@ IMPL_JS_FUNC(enumDroid, wzapi::enumDroid)
 IMPL_JS_FUNC(dump, wzapi::dump)
 IMPL_JS_FUNC(debug, wzapi::debugOutputStrings)
 IMPL_JS_FUNC(pickStructLocation, wzapi::pickStructLocation)
+IMPL_JS_FUNC(structureCanFit, wzapi::structureCanFit)
 IMPL_JS_FUNC(structureIdle, wzapi::structureIdle)
 IMPL_JS_FUNC(removeStruct, wzapi::removeStruct)
 IMPL_JS_FUNC(removeObject, wzapi::removeObject)
@@ -3479,6 +3480,7 @@ bool quickjs_scripting_instance::registerFunctions(const std::string& scriptName
 	JS_REGISTER_FUNC(queuedPower, 1); // WZAPI
 	JS_REGISTER_FUNC2(isStructureAvailable, 1, 2); // WZAPI
 	JS_REGISTER_FUNC2(pickStructLocation, 4, 5); // WZAPI
+	JS_REGISTER_FUNC2(structureCanFit, 3, 4); // WZAPI
 	JS_REGISTER_FUNC(droidCanReach, 3); // WZAPI
 	JS_REGISTER_FUNC(propulsionCanReach, 5); // WZAPI
 	JS_REGISTER_FUNC(terrainType, 2); // WZAPI

--- a/src/wzapi.cpp
+++ b/src/wzapi.cpp
@@ -1676,8 +1676,11 @@ endstructloc:
 bool wzapi::structureCanFit(WZAPI_PARAMS(std::string structureName, int x, int y, optional<float> _direction))
 {
 	const int player = context.player();
+	SCRIPT_ASSERT_PLAYER(false, context, player);
 	int structureIndex = getStructStatFromName(WzString::fromUtf8(structureName));
+	SCRIPT_ASSERT(false, context, structureIndex >= 0 && structureIndex < numStructureStats, "Structure %s not found", structureName.c_str());
 	STRUCTURE_STATS	*psStat = &asStructureStats[structureIndex];
+	SCRIPT_ASSERT(false, context, psStat, "No such stat found: %s", structureName.c_str());
 
 	if (_direction.has_value() && std::isnan(_direction.value()))
 	{

--- a/src/wzapi.cpp
+++ b/src/wzapi.cpp
@@ -1669,6 +1669,26 @@ endstructloc:
 	return {};
 }
 
+//-- ## structureCanFit(structureName, x, y[, direction])
+//--
+//-- Return true if given building can be built at the position. (4.6+ only)
+//--
+bool wzapi::structureCanFit(WZAPI_PARAMS(std::string structureName, int x, int y, optional<float> _direction))
+{
+	const int player = context.player();
+	int structureIndex = getStructStatFromName(WzString::fromUtf8(structureName));
+	STRUCTURE_STATS	*psStat = &asStructureStats[structureIndex];
+
+	if (_direction.has_value() && std::isnan(_direction.value()))
+	{
+		_direction = 0.f; // avoid undefined behavior (nan is outside the range of representable values of type 'unsigned short')
+	}
+	uint16_t direction = static_cast<uint16_t>(DEG(_direction.value_or(0)));
+
+	return (tileOnMap(x, y)
+			&& validLocation(psStat, world_coord(Vector2i(x, y)), direction, player, false));
+}
+
 //-- ## droidCanReach(droid, x, y)
 //--
 //-- Return whether or not the given droid could possibly drive to the given position. Does

--- a/src/wzapi.h
+++ b/src/wzapi.h
@@ -1041,6 +1041,7 @@ namespace wzapi
 	int queuedPower(WZAPI_PARAMS(int player));
 	bool isStructureAvailable(WZAPI_PARAMS(std::string structureName, optional<int> _player));
 	optional<scr_position> pickStructLocation(WZAPI_PARAMS(const DROID *psDroid, std::string structureName, int startX, int startY, optional<int> _maxBlockingTiles));
+	bool structureCanFit(WZAPI_PARAMS(std::string structureName, int x, int y, optional<float> _direction));
 	bool droidCanReach(WZAPI_PARAMS(const DROID *psDroid, int x, int y));
 	bool propulsionCanReach(WZAPI_PARAMS(std::string propulsionName, int x1, int y1, int x2, int y2));
 	int terrainType(WZAPI_PARAMS(int x, int y));


### PR DESCRIPTION
Currently, there is only 1 function to check if a position fits for a structure, but it have unwanted side-effect:

pickStructLocation(droid, structureName, x, y[, maxBlockingTiles]):
- need a truck
- forced continent check
- always preserve spaces
- always snap to right down corner even if origin is free
- reveal unseen enemy structures
- slow (30K calls/s on flat map)

also, pickStructLocation don't consider travel distance, sometimes return a far location in hover map
the new function avoid side-effects above, as fast as quickjs bytecodes, which suited for implementing custom search function in script:

structureCanFit(structureName, x, y[, direction]):
- don't need a truck
- no continent check, suited for prediction
- don't reveal unseen enemy structures
- have direction option
- results consistent with structure location check of GUI
- fast (3M calls/s on flat map)

![structureCanFit](https://github.com/user-attachments/assets/7a07c286-5fb2-4ead-af0c-4aa47ec0286f)
