### PR TITLE
recvDroidInfo: Do not remove droid from the commander group on return-to-repair

### DIFF
--- a/src/multibot.cpp
+++ b/src/multibot.cpp
@@ -703,7 +703,9 @@ bool recvDroidInfo(NETQUEUE queue)
 				* If the current order not is a command order and we are not a
 				* commander yet are in the commander group remove us from it.
 				*/
-				if (hasCommander(psDroid))
+				if (hasCommander(psDroid)
+					&& info.order != DORDER_RTR
+					&& info.order != DORDER_RTR_SPECIFIED)
 				{
 					psDroid->psGroup->remove(psDroid);
 				}


### PR DESCRIPTION
#4367 moved various RTR orders from ModeImmediate to ModeQueue, leading to this code in `recvDroidInfo` being triggered, which removes the droid from the commander's group.

For droids ordered to RTR, this breaks the ability to return the droid to the commander once it has been repaired by a repair facility.

Exclude RTR orders from this behavior to fix it.