### PR TITLE
make wzapi::fireWeaponAtLoc hit immediately

### DIFF
--- a/src/projectile.cpp
+++ b/src/projectile.cpp
@@ -528,7 +528,14 @@ static PROJECTILE* proj_SendProjectileAngledInternal(WEAPON* psWeap, SIMPLE_OBJE
 	}
 	else
 	{
-		proj.dst.z = target.z + LINE_OF_FIRE_MINIMUM;
+		if (psAttacker == nullptr)
+		{
+			proj.dst.z = target.z - LINE_OF_FIRE_MINIMUM;
+		}
+		else
+		{
+			proj.dst.z = target.z + LINE_OF_FIRE_MINIMUM;
+		}
 		scoreUpdateVar(WD_SHOTS_OFF_TARGET);
 	}
 

--- a/src/wzapi.cpp
+++ b/src/wzapi.cpp
@@ -3394,7 +3394,7 @@ wzapi::no_return_value wzapi::fireWeaponAtLoc(WZAPI_PARAMS(std::string weaponNam
 	Vector3i target;
 	target.x = world_coord(x);
 	target.y = world_coord(y);
-	target.z = map_Height(x, y);
+	target.z = mapTile(x, y)->height;
 
 	WEAPON sWeapon;
 	sWeapon.nStat = weaponIndex;


### PR DESCRIPTION
I want to make a mod that droid explode when destroyed, but there is no available API:
fireWeaponAtObj don't works for object that about to be destroyed,
fireWeaponAtLoc have long delay, and don't works for some weapons
so I tweaked the projectile function a bit, but don't break previous usages:

previous fireWeaponAtLoc:
- Spawn on max height (512)
- Have upward initial velocity
- Hit time vary by initial velocity, 4 seconds for ground shaker, 25 seconds for lassat
- Don't works for light cannon

tweaked fireWeaponAtLoc:
- Spawn on surface
- Have downward initial velocity
- Hit immediately for all weapons except lassat (25 seconds)
- Works for light cannon