### PR TITLE
paged_entity_container: Fix UB in `PagedEntityContainer::find()`

### DIFF
--- a/lib/framework/paged_entity_container.h
+++ b/lib/framework/paged_entity_container.h
@@ -680,7 +680,12 @@ public:
 		for (size_t i = 0, end = _pages.size(); i != end; ++i)
 		{
 			Page& p = _pages[i];
+			if (p.is_expired())
+			{
+				continue;
+			}
 			auto* storage = p.storage();
+			assert(storage != nullptr);
 			// If the address is inside the current page, calculate the index from raw offset.
 			if (addr >= storage && addr <= &storage[p.max_valid_index()])
 			{


### PR DESCRIPTION
The `find()` method doesn't properly skip expired pages with deallocated storage, leading to UB while evaluating storage pointer offsets.

Prevent that by explicitly skipping expired pages, plus add an assert to make sure we don't access invalid storage pointers.