### PR TITLE
fix: loading challenge clears challenge name in next save

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -3982,6 +3982,7 @@ static bool gameLoad(const char *fileName)
 		{
 			debug(LOG_ERROR, "Failed to unload old data. Attempting to load anyway");
 		}
+		challengeFileName = "";
 
 		//remove the file extension
 		CurrentFileName[strlen(CurrentFileName) - 4] = '\0';
@@ -3992,7 +3993,6 @@ static bool gameLoad(const char *fileName)
 
 		loadMainFileFinal(std::string(CurrentFileName) + "/main.json");
 
-		challengeFileName = "";
 		return retVal;
 	}
 	else


### PR DESCRIPTION
I noticed scripts were not always loaded when loading a challenge game file (which contained some extra scripts). Then I noticed the `challengeFileName` was overwritten after it was loaded from the save file. I moved it closer to other code that seems to clear the current game state and I'm now able to save/load challenges with extra scripts multiple times without problem.