### PR TITLE
Vulkan: Set DISABLE_LAYER_AMD_SWITCHABLE_GRAPHICS_1

### DIFF
--- a/lib/ivis_opengl/gfx_api_vk.cpp
+++ b/lib/ivis_opengl/gfx_api_vk.cpp
@@ -164,6 +164,8 @@ const std::vector<std::tuple<_vkl_env_text_type, _vkl_env_text_type, bool>> vulk
 	, {_vkl_env_text("DISABLE_VK_LAYER_reshade_1"), _vkl_env_text("1"), true}
 	, {_vkl_env_text("DISABLE_VK_LAYER_GPUOpen_GRS"), _vkl_env_text("1"), true}
 	, {_vkl_env_text("DISABLE_VKBASALT"), _vkl_env_text("1"), true}
+	// Disable this layer to avoid various issues enumerating all devices on systems with AMD iGPU + dedicated graphics card
+	, {_vkl_env_text("DISABLE_LAYER_AMD_SWITCHABLE_GRAPHICS_1"), _vkl_env_text("1"), true}
 };
 
 #if defined(VK_EXT_layer_settings)

--- a/lib/ivis_opengl/gfx_api_vk.cpp
+++ b/lib/ivis_opengl/gfx_api_vk.cpp
@@ -3485,6 +3485,7 @@ std::vector<vk::LayerSettingEXT> VkRoot::initLayerSettings()
 bool VkRoot::createVulkanInstance(uint32_t apiVersion, const std::vector<const char*>& extensions, const std::vector<const char*>& _layers, PFN_vkGetInstanceProcAddr _vkGetInstanceProcAddr)
 {
 	appInfo = vk::ApplicationInfo()
+	.setPNext(nullptr)
 	.setPApplicationName("Warzone2100")
 	.setApplicationVersion(1)
 	.setPEngineName("Warzone2100")
@@ -3493,6 +3494,8 @@ bool VkRoot::createVulkanInstance(uint32_t apiVersion, const std::vector<const c
 
 	// Now we can make the Vulkan instance
 	instanceCreateInfo = vk::InstanceCreateInfo()
+	  .setPNext(nullptr)
+	  .setFlags({})
 	  .setPpEnabledLayerNames(_layers.data())
 	  .setEnabledLayerCount(static_cast<uint32_t>(_layers.size()))
 	  .setPApplicationInfo(&appInfo)


### PR DESCRIPTION
This layer is reported to cause various issues (example: on systems with AMD iGPU + dedicated graphics card, a failure in vkEnumeratePhysicalDevices), and disabling it allows enumerating all devices (as is desired).
  - Reference: https://github.com/godotengine/godot/issues/57708