### PR TITLE
Bonecrusher AI - Typo corrections in messages

### DIFF
--- a/data/mp/multiplay/skirmish/bonecrusher/bonecrusher.js
+++ b/data/mp/multiplay/skirmish/bonecrusher/bonecrusher.js
@@ -600,16 +600,8 @@ function init(){
 	//Просто дебаг информация
 	var oilDrums = enumFeature(ALL_PLAYERS, "OilDrum");
 	debugMsg("На карте "+oilDrums.length+" бочек с нефтью", 'init');
-
-	queue("welcome", 3000+me*(Math.floor(Math.random()*2000)+1500) );
 	queue("checkAlly", 2000);
 	letsRockThisFxxxingWorld(true); // <-- Жжём плазмитом сцуко!
-}
-
-function welcome(){
-	playerData.forEach((data, player) => {
-		if (!asPlayer)chat(player, ' from '+debugName+': '+chatting('welcome'));
-	});
 }
 
 //Старт

--- a/data/mp/multiplay/skirmish/bonecrusher/chatting.js
+++ b/data/mp/multiplay/skirmish/bonecrusher/chatting.js
@@ -3,29 +3,26 @@ debugMsg('Module: chatting.js','init');
 function chatting(type){
 	var chlen = _chatting[type].length;		// Забавно, спустя некотое время я только осознал, что за имя я дал этой переменной xDDD
 	return _chatting[type][Math.floor(Math.random()*chlen)];
-
 }
 
 var _chatting = {};
 
 _chatting['army'] = [
-	"If u want, i may support you with my army. Just say \"yes\"",
-	"I can share some units, say \"yes\" if u want.",
-	"I can sometimes give you my warriors, just say \"yes\""
+	"If you want, I may support you with my army. Just say \"yes\"",
+	"I can share some units, say \"yes\" if you want.",
+	"I can give you some of my warriors, just say \"yes\""
 ];
 
 _chatting['lassat_fire'] = [
 	"Bada-Boom!",
 	"Boom!",
-	"Boo-Boom!",
-	";)"
+	"Boo-Boom!"
 ];
 
 _chatting['lassat_charged'] = [
 	"Scare me",
 	"Laser ready, now get ready",
-	"He-heh",
-	":)"
+	"He-heh"
 ];
 
 _chatting['confirm'] = [
@@ -40,8 +37,8 @@ _chatting['confirm'] = [
 _chatting['kick'] = [
 	"I was kicked out, for what?",
 	"Lol, just kicked..",
-	"Well, bye, i leave.",
-	"Loosers, you're just afraid of me."
+	"Well, bye, I'll leave.",
+	"Losers, you're just afraid of me."
 ];
 
 _chatting['saved'] = [
@@ -49,17 +46,17 @@ _chatting['saved'] = [
 	"Oh, what, decided to take a break?",
 	"Save, save, save.. How long.",
 	"Now you just put my brains in a box.",
-	"Save me, save me againg!",
+	"Save me, save me again!",
 	"Save your self, save your life!",
 	"Oh, don't be scared.. Saved, nice :)"
 ];
 
 _chatting['tutorial'] = [
-	"By the way, i can ask me for money, just say \"bc give money\"",
-	"If you die, just say \"bc give truck\", and i resurrect u ;)",
+	"By the way, you can ask me for money, just say \"bc give money\"",
+	"If you die, just say \"bc give truck\", and I'll resurrect you ;)",
 	"Btw, you can ask me, \"bc give money\" or \"bc give truck\" remember that",
-	"If u don't known, team chat binding on Ctrl+Enter keys %)",
-	"btw, u can fast rotate camera by pressing Ctrl+arrows ;)",
+	"If you don't know, team chat binding on Ctrl+Enter keys %)",
+	"btw, you can fast rotate camera by pressing Ctrl+arrows ;)",
 	"Always help the team, or we will all die"
 ];
 
@@ -69,53 +66,26 @@ _chatting['ally'] = [
 
 _chatting['threat'] = [
 	'I kill you!!!',
-	'Nice try! But i will destroy you!',
+	'Nice try! But I will destroy you!',
 	'Do not expect mercy'
 ];
 
-_chatting['welcome'] = [
-	'Hello everyone',
-	'Hi there',
-	'hi.. gl hf',
-	'gl',
-	'glhf',
-	'gl hf',
-	'Hi!! ))',
-	'gl ;)',
-	'gl hf )',
-	'Hello, good luck!',
-	"i'm noob.. :|",
-	'Hi all',
-	'GLHF!',
-	'have fun..',
-	'yo',
-	'hello',
-	'=)',
-	'yoyo, hi',
-	'hi, how are you?',
-	"приветы",
-	"Здравствуйте",
-	"Всем привет",
-	"Dosvidaniya... no? %) Hi!"
-];
-
-_chatting['loose'] = [
+_chatting['lose'] = [
 	'ohh.. you win, gg',
 	'nice, gg',
 	'wow.. gg',
-	"gg i'm loose",
+	"gg I've lost",
 	'ggwp',
 	'gg wp',
 	'sorry im noob',
 	'aaarrgghghh!! You are cheater!',
-	'cheater? .. i loose..',
+	'cheater? .. I lose..',
 	'=( gg',
 	'bye',
 	'oh no! =( bye..',
 	'How dare you!',
 	'wtf?.. lol, gg',
 	'nice cheat man.. bye'
-
 ];
 
 

--- a/data/mp/multiplay/skirmish/bonecrusher/functions.js
+++ b/data/mp/multiplay/skirmish/bonecrusher/functions.js
@@ -122,7 +122,7 @@ function checkAlly(){
 			+", ally=spectator, dist="+dist, "ally");
 			return;
 		}
-		if (playerLoose(player)) {
+		if (playerLose(player)) {
 			debugMsg("#"+player+" name=\"Empty Slot\""
 			+", ally=empty, dist="+dist, "ally");
 			return;
@@ -344,8 +344,8 @@ function checkProcess(){
 	if (!running)return;
 	if (Math.floor(gameTime / 1000) < 300) return;
 
-	if (playerLoose(me)) {
-		gameStop("loose");
+	if (playerLose(me)) {
+		gameStop("lose");
 	}
 
 	for (const plally in bc_ally) {
@@ -386,11 +386,11 @@ function checkProcess(){
 function gameStop(condition){
 
 
-	if (condition === 'loose') {
-		debugMsg("I guess, i'm loose.. Give up", 'end');
+	if (condition === 'lose') {
+		debugMsg("I guess, i'm lose.. Give up", 'end');
 		if (running) {
 			playerData.forEach((data, player) => {
-				if (!asPlayer)chat(player, ' from '+debugName+': '+chatting('loose'));
+				if (!asPlayer)chat(player, ' from '+debugName+': '+chatting('lose'));
 			});
 		}
 
@@ -399,7 +399,7 @@ function gameStop(condition){
 		var _ally=false;
 		playerData.forEach((data, player) => {
 			if (player === me) return;
-			if (playerLoose(player)) return;
+			if (playerLose(player)) return;
 			if (playerSpectator(player)) return;
 			if (!allianceExistsBetween(me,player)) return;
 			if (allianceExistsBetween(me,player)) {
@@ -425,22 +425,22 @@ function gameStop(condition){
 		running = false;
 }
 
-function playerLoose(player){
-	var loose = false;
+function playerLose(player){
+	var lose = false;
 	if (enumStruct(player,"A0LightFactory").length === 0 &&
 		enumDroid(player, DROID_CONSTRUCT).length === 0 &&
 		enumStruct(player,"A0CyborgFactory").length === 0 &&
-		enumDroid(player, 10).length === 0) loose = true;
-	return loose;
+		enumDroid(player, 10).length === 0) lose = true;
+	return lose;
 }
 
 function playerSpectator(player){
-	var loose = false;
+	var lose = false;
 	if ((enumStruct(player, "A0Sat-linkCentre").length === 1 || enumStruct(player, "A0CommandCentre").length === 1) &&
 		enumStruct(player,"A0LightFactory").length === 0 &&
 		enumStruct(player,"A0CyborgFactory").length === 0 &&
-		enumDroid(player, 10).length === 0) loose = true;
-	return loose;
+		enumDroid(player, 10).length === 0) lose = true;
+	return lose;
 }
 
 //функция отфильтровывает объекты, которые находяться близко
@@ -449,7 +449,7 @@ function filterNearAlly(obj){
 	for (let p = 0; p < maxPlayers; ++p) {
 		if (p === me) continue; //Выкидываем себя
 		if (!allianceExistsBetween(me,p)) continue; //Выкидываем вражеские
-//		if (playerLoose(p)) continue; //Пропускаем проигравших
+//		if (playerLose(p)) continue; //Пропускаем проигравших
 		if (playerSpectator(p)) continue;
 
 		//Если союзнику доступно 40 вышек, не уступаем ему свободную.
@@ -499,7 +499,7 @@ function getEnemyNearAlly(){
 	for (let p = 0; p < maxPlayers; ++p) {
 		if (p === me) continue;
 		if (!allianceExistsBetween(me,p)) continue;
-//		if (playerLoose(p)) continue; //Пропускаем проигравших
+//		if (playerLose(p)) continue; //Пропускаем проигравших
 		if (playerSpectator(p)) continue;
 //		enemy = enemy.concat(targ.filter((e) => {if (distBetweenTwoPoints_p(e.x,e.y,startPositions[p].x,startPositions[p].y) < (base_range/2)) {
 		enemy = enemy.concat(targ.filter((e) => {if (distBetweenTwoPoints_p(e.x,e.y,startPositions[p].x,startPositions[p].y) < base_range) {
@@ -680,7 +680,7 @@ function getNumEnemies(){
 	for (let e = 0; e < maxPlayers; ++e) {
 		if (allianceExistsBetween(me,e)) continue;
 		if (playerSpectator(e)) continue;
-		if (playerLoose(e)) continue;
+		if (playerLose(e)) continue;
 		if (e === me) continue;
 		enemies++;
 	}
@@ -754,7 +754,7 @@ function getEnemyStartPos(){
 	for (let e = 0; e < maxPlayers; ++e) {
 		if (allianceExistsBetween(me,e)) continue;
 		if (playerSpectator(e)) continue;
-		if (playerLoose(e)) continue;
+		if (playerLose(e)) continue;
 		targ = targ.concat(startPositions[e]);
 	}
 	return targ;
@@ -1103,7 +1103,7 @@ function longCycle(){
 		playerData.forEach((data, player) => {
 			if (!access) return;
 			if (player === me) return;
-			if (playerLoose(player)) return;
+			if (playerLose(player)) return;
 			if (playerSpectator(player)) return;
 			if (allianceExistsBetween(me,player)) return;
 			if (propulsionCanReach('wheeled01', base.x, base.y, startPositions[player].x, startPositions[player].y)) { access = false; debugMsg("LongCycle: "+player+', land - exit', 'debug'); return; }
@@ -1154,7 +1154,7 @@ function longCycle(){
 	if (playerPower(me) > 10000) {
 		playerData.forEach((data, player) => {
 			if (player === me) return;
-			if (playerLoose(player)) return;
+			if (playerLose(player)) return;
 			if (playerSpectator(player)) return;
 			if (!allianceExistsBetween(me,player)) return;
 			if (allianceExistsBetween(me,player)) {


### PR DESCRIPTION
For the Bonecrusher AI a series of mostly minor typos are seen in messages delivered to the player.

Makes minor grammatical/typo corrections.

This also drops the welcome messages, which if is of no real value to the player and is a distraction on game start.
With more bots in a larger lobby, this floods the console screen.

Ideally rather than pure English and Russian, having native translations by some means would be ideal to any given player.