### PR TITLE
Fix: Debug change selectedPlayer

### DIFF
--- a/src/cheat.cpp
+++ b/src/cheat.cpp
@@ -186,7 +186,7 @@ void sendProcessDebugMappings(bool val)
 	{
 		return;
 	}
-	auto w = NETbeginEncode(NETgameQueue(selectedPlayer), GAME_DEBUG_MODE);
+	auto w = NETbeginEncode(NETgameQueue(realSelectedPlayer), GAME_DEBUG_MODE);
 	NETbool(w, val);
 	NETend(w);
 }

--- a/src/multibot.cpp
+++ b/src/multibot.cpp
@@ -225,7 +225,7 @@ bool sendDroidDisembark(DROID const *psTransporter, DROID const *psDroid)
 		return true;
 	}
 
-	auto w = NETbeginEncode(NETgameQueue(selectedPlayer), GAME_DROIDDISEMBARK);
+	auto w = NETbeginEncode(NETgameQueue(realSelectedPlayer), GAME_DROIDDISEMBARK);
 	uint32_t player = psTransporter->player;
 	uint32_t droidId = psDroid->id;
 	uint32_t transportId = psTransporter->id;
@@ -325,7 +325,7 @@ bool SendDroid(DROID_TEMPLATE *pTemplate, uint32_t x, uint32_t y, uint8_t player
 	}
 
 	debug(LOG_SYNC, "Droid sent with id of %u", id);
-	auto w = NETbeginEncode(NETgameQueue(selectedPlayer), GAME_DEBUG_ADD_DROID);
+	auto w = NETbeginEncode(NETgameQueue(realSelectedPlayer), GAME_DEBUG_ADD_DROID);
 	{
 		Position pos(x, y, 0);
 		bool haveInitialOrders = initialOrdersP != nullptr;
@@ -536,7 +536,7 @@ void sendQueuedDroidInfo()
 			for (eqEnd = eqBegin + 1; eqEnd != qOrders.end() && eqEnd->orderCompare(*eqBegin) == 0; ++eqEnd)
 			{}
 
-			auto w = NETbeginEncode(NETgameQueue(selectedPlayer), GAME_DROIDINFO);
+			auto w = NETbeginEncode(NETgameQueue(realSelectedPlayer), GAME_DROIDINFO);
 			NETQueuedDroidInfo(w, *eqBegin);
 
 			uint32_t num = eqEnd - eqBegin;
@@ -792,7 +792,7 @@ static BASE_OBJECT *processDroidTarget(OBJECT_TYPE desttype, uint32_t destid)
 // Inform other players that a droid has been destroyed
 bool SendDestroyDroid(const DROID *psDroid)
 {
-	auto w = NETbeginEncode(NETgameQueue(selectedPlayer), GAME_DEBUG_REMOVE_DROID);
+	auto w = NETbeginEncode(NETgameQueue(realSelectedPlayer), GAME_DEBUG_REMOVE_DROID);
 	{
 		uint32_t id = psDroid->id;
 

--- a/src/multigifts.cpp
+++ b/src/multigifts.cpp
@@ -192,7 +192,7 @@ static void giftAutoGame(uint8_t from, uint8_t to, bool send)
 	{
 		uint8_t subType = AUTOGAME_GIFT;
 
-		auto w = NETbeginEncode(NETgameQueue(selectedPlayer), GAME_GIFT);
+		auto w = NETbeginEncode(NETgameQueue(realSelectedPlayer), GAME_GIFT);
 		NETuint8_t(w, subType);
 		NETuint8_t(w, from);
 		NETuint8_t(w, to);
@@ -223,7 +223,7 @@ void giftRadar(uint8_t from, uint8_t to, bool send)
 	{
 		uint8_t subType = RADAR_GIFT;
 
-		auto w = NETbeginEncode(NETgameQueue(selectedPlayer), GAME_GIFT);
+		auto w = NETbeginEncode(NETgameQueue(realSelectedPlayer), GAME_GIFT);
 		NETuint8_t(w, subType);
 		NETuint8_t(w, from);
 		NETuint8_t(w, to);
@@ -337,7 +337,7 @@ static void sendGiftDroids(uint8_t from, uint8_t to)
 				continue;
 			}
 
-			auto w = NETbeginEncode(NETgameQueue(selectedPlayer), GAME_GIFT);
+			auto w = NETbeginEncode(NETgameQueue(realSelectedPlayer), GAME_GIFT);
 			NETuint8_t(w, giftType);
 			NETuint8_t(w, from);
 			NETuint8_t(w, to);
@@ -362,7 +362,7 @@ static void giftResearch(uint8_t from, uint8_t to, bool send)
 	{
 		uint8_t giftType = RESEARCH_GIFT;
 
-		auto w = NETbeginEncode(NETgameQueue(selectedPlayer), GAME_GIFT);
+		auto w = NETbeginEncode(NETgameQueue(realSelectedPlayer), GAME_GIFT);
 		NETuint8_t(w, giftType);
 		NETuint8_t(w, from);
 		NETuint8_t(w, to);
@@ -397,7 +397,7 @@ void giftPower(uint8_t from, uint8_t to, uint32_t amount, bool send)
 	{
 		uint8_t giftType = POWER_GIFT;
 
-		auto w = NETbeginEncode(NETgameQueue(selectedPlayer), GAME_GIFT);
+		auto w = NETbeginEncode(NETgameQueue(realSelectedPlayer), GAME_GIFT);
 		NETuint8_t(w, giftType);
 		NETuint8_t(w, from);
 		NETuint8_t(w, to);
@@ -641,7 +641,7 @@ void formAlliance(uint8_t p1, uint8_t p2, bool prop, bool allowAudio, bool allow
 
 void sendAlliance(uint8_t from, uint8_t to, uint8_t state, int32_t value)
 {
-	auto w = NETbeginEncode(NETgameQueue(selectedPlayer), GAME_ALLIANCE);
+	auto w = NETbeginEncode(NETgameQueue(realSelectedPlayer), GAME_ALLIANCE);
 	NETuint8_t(w, from);
 	NETuint8_t(w, to);
 	NETuint8_t(w, state);
@@ -764,7 +764,7 @@ void  technologyGiveAway(const STRUCTURE *pS)
  */
 void sendMultiPlayerFeature(uint32_t ref, uint32_t x, uint32_t y, uint32_t id)
 {
-	auto w = NETbeginEncode(NETgameQueue(selectedPlayer), GAME_DEBUG_ADD_FEATURE);
+	auto w = NETbeginEncode(NETgameQueue(realSelectedPlayer), GAME_DEBUG_ADD_FEATURE);
 	{
 		NETuint32_t(w, ref);
 		NETuint32_t(w, x);

--- a/src/multiplay.cpp
+++ b/src/multiplay.cpp
@@ -906,7 +906,7 @@ int whosResponsible(int player)
 	{
 		return player;			// Responsible for him or her self
 	}
-	else if (player == selectedPlayer)
+	else if (player == realSelectedPlayer)
 	{
 		return player;			// We are responsibly for ourselves
 	}
@@ -1050,7 +1050,7 @@ static void sendObj(MessageWriter& w, const BASE_OBJECT *psObj)
 
 void sendSyncRequest(int32_t req_id, int32_t x, int32_t y, const BASE_OBJECT *psObj, const BASE_OBJECT *psObj2)
 {
-	auto w = NETbeginEncode(NETgameQueue(selectedPlayer), GAME_SYNC_REQUEST);
+	auto w = NETbeginEncode(NETgameQueue(realSelectedPlayer), GAME_SYNC_REQUEST);
 	NETint32_t(w, req_id);
 	NETint32_t(w, x);
 	NETint32_t(w, y);
@@ -1753,7 +1753,7 @@ void HandleBadParam(const char *msg, const int from, const int actual)
 bool SendResearch(uint8_t player, uint32_t index, bool trigger)
 {
 	// Send the player that is researching the topic and the topic itself
-	auto w = NETbeginEncode(NETgameQueue(selectedPlayer), GAME_DEBUG_FINISH_RESEARCH);
+	auto w = NETbeginEncode(NETgameQueue(realSelectedPlayer), GAME_DEBUG_FINISH_RESEARCH);
 	NETuint8_t(w, player);
 	NETuint32_t(w, index);
 	NETend(w);
@@ -1829,7 +1829,7 @@ bool sendResearchStatus(const STRUCTURE *psBuilding, uint32_t index, uint8_t pla
 		return true;
 	}
 
-	auto w = NETbeginEncode(NETgameQueue(selectedPlayer), GAME_RESEARCHSTATUS);
+	auto w = NETbeginEncode(NETgameQueue(realSelectedPlayer), GAME_RESEARCHSTATUS);
 	NETuint8_t(w, player);
 	NETbool(w, bStart);
 

--- a/src/multistruct.cpp
+++ b/src/multistruct.cpp
@@ -63,7 +63,7 @@ bool SendBuildFinished(STRUCTURE *psStruct)
 	uint8_t player = psStruct->player;
 	ASSERT_OR_RETURN(false, player < MAX_PLAYERS, "invalid player %u", player);
 
-	auto w = NETbeginEncode(NETgameQueue(selectedPlayer), GAME_DEBUG_ADD_STRUCTURE);
+	auto w = NETbeginEncode(NETgameQueue(realSelectedPlayer), GAME_DEBUG_ADD_STRUCTURE);
 	NETuint32_t(w, psStruct->id);		// ID of building
 
 	// Along with enough info to build it (if needed)
@@ -147,7 +147,7 @@ bool recvBuildFinished(NETQUEUE queue)
 // Inform others that a structure has been destroyed
 bool SendDestroyStructure(STRUCTURE *s)
 {
-	auto w = NETbeginEncode(NETgameQueue(selectedPlayer), GAME_DEBUG_REMOVE_STRUCTURE);
+	auto w = NETbeginEncode(NETgameQueue(realSelectedPlayer), GAME_DEBUG_REMOVE_STRUCTURE);
 	// Struct to destroy
 	NETuint32_t(w, s->id);
 
@@ -191,7 +191,7 @@ bool recvDestroyStructure(NETQUEUE queue)
 
 bool sendLasSat(UBYTE player, STRUCTURE *psStruct, BASE_OBJECT *psObj)
 {
-	auto w = NETbeginEncode(NETgameQueue(selectedPlayer), GAME_LASSAT);
+	auto w = NETbeginEncode(NETgameQueue(realSelectedPlayer), GAME_LASSAT);
 	NETuint8_t(w, player);
 	NETuint32_t(w, psStruct->id);
 	NETuint32_t(w, psObj->id);	// Target
@@ -258,7 +258,7 @@ void sendStructureInfo(STRUCTURE *psStruct, STRUCTURE_INFO structureInfo_, DROID
 	uint32_t structId = psStruct->id;
 	uint8_t  structureInfo = structureInfo_;
 
-	auto w = NETbeginEncode(NETgameQueue(selectedPlayer), GAME_STRUCTUREINFO);
+	auto w = NETbeginEncode(NETgameQueue(realSelectedPlayer), GAME_STRUCTUREINFO);
 	NETuint8_t(w, player);
 	NETuint32_t(w, structId);
 	NETuint8_t(w, structureInfo);

--- a/src/qtscript.cpp
+++ b/src/qtscript.cpp
@@ -933,7 +933,7 @@ void jsShowDebug()
 {
 	globalDialog = true;
 	class make_shared_enabler : public scripting_engine::DebugInterface { };
-	bool isSpectator = NetPlay.players[selectedPlayer].isSpectator;
+	bool isSpectator = NetPlay.players[realSelectedPlayer].isSpectator;
 	jsDebugCreate(std::make_shared<make_shared_enabler>(), jsHandleDebugClosed, isSpectator);
 }
 

--- a/src/wzapi.cpp
+++ b/src/wzapi.cpp
@@ -3288,7 +3288,7 @@ bool wzapi::donateObject(WZAPI_PARAMS(BASE_OBJECT *psObject, int player))
 	{
 		return false;
 	}
-	auto w = NETbeginEncode(NETgameQueue(selectedPlayer), GAME_GIFT);
+	auto w = NETbeginEncode(NETgameQueue(realSelectedPlayer), GAME_GIFT);
 	NETuint8_t(w, giftType);
 	NETuint8_t(w, from);
 	NETuint8_t(w, to);

--- a/src/wzscriptdebug.cpp
+++ b/src/wzscriptdebug.cpp
@@ -885,10 +885,7 @@ private:
 		}
 		ASSERT_OR_RETURN(, selectedPlayer < MAX_PLAYERS, "Invalid selectedPlayer: %" PRIu32 "", selectedPlayer);
 		// Do not change realSelectedPlayer here, so game doesn't pause.
-		const int oldSelectedPlayer = selectedPlayer;
 		selectedPlayer = value;
-		NetPlay.players[selectedPlayer].allocated = !NetPlay.players[selectedPlayer].allocated;
-		NetPlay.players[oldSelectedPlayer].allocated = !NetPlay.players[oldSelectedPlayer].allocated;
 	}
 public:
 	std::shared_ptr<DropdownWidget> playersDropdown;


### PR DESCRIPTION
The script debugger's ability to change selectedPlayer was broken at some point. It was made more obvious by #4376 (which causes the game to actually pause when switching, due to the same underlying causes).

- Always send via the `realSelectedPlayer` `NETgameQueue`
- `whosResponsible` should check `realSelectedPlayer`
- Don't mess with player `allocated` status in script debugger