### PR TITLE
Various net/string tweaks

### DIFF
--- a/lib/framework/wzstring.cpp
+++ b/lib/framework/wzstring.cpp
@@ -126,7 +126,7 @@ WzString WzString::fromUtf16(const std::vector<uint16_t>& utf16)
 		ASSERT(false, "Conversion from UTF16 failed with error: %s", e.what());
 		utf8str.clear();
 	}
-	return WzString(utf8str);
+	return WzString::fromUtf8(utf8str);
 }
 
 WzString WzString::fromUtf32(const std::vector<uint32_t>& utf32)
@@ -139,7 +139,7 @@ WzString WzString::fromUtf32(const std::vector<uint32_t>& utf32)
 		ASSERT(false, "Conversion from UTF32 failed with error: %s", e.what());
 		utf8str.clear();
 	}
-	return WzString(utf8str);
+	return WzString::fromUtf8(utf8str);
 }
 
 bool WzString::isValidUtf8(const char * str, size_t len)

--- a/lib/netplay/netreplay.cpp
+++ b/lib/netplay/netreplay.cpp
@@ -52,6 +52,7 @@ static PHYSFS_file *replayLoadHandle = nullptr;
 
 static const uint32_t magicReplayNumber = 0x575A7270;  // "WZrp"
 static const uint32_t currentReplayFormatVer = 3;
+static const uint32_t minReplayFormatVerSupported = 3;
 static const size_t DefaultReplayBufferSize = 32768;
 static const size_t MaxReplayBufferSize = 2 * 1024 * 1024;
 
@@ -353,6 +354,17 @@ bool NETreplayLoadStart(std::string const &filename, ReplayOptionsHandler& optio
 			wzDisplayDialog(Dialog_Error, _("Replay File Format Unsupported"), mismatchVersionDescription.c_str());
 
 			std::string failLogStr = "Replay file format is newer than this version of Warzone 2100 can support: " + std::to_string(replayFormatVer);
+			return onFail(failLogStr.c_str());
+		}
+
+		if (replayFormatVer < minReplayFormatVerSupported)
+		{
+			std::string mismatchVersionDescription = _("The replay file format is older than this version of Warzone 2100 can support.");
+			mismatchVersionDescription += "\n\n";
+			mismatchVersionDescription += astringf(_("Replay Format Version: %u"), static_cast<unsigned>(replayFormatVer));
+			wzDisplayDialog(Dialog_Error, _("Replay File Format Unsupported"), mismatchVersionDescription.c_str());
+
+			std::string failLogStr = "Replay file format is older than this version of Warzone 2100 can support: " + std::to_string(replayFormatVer);
 			return onFail(failLogStr.c_str());
 		}
 

--- a/lib/netplay/nettypes.cpp
+++ b/lib/netplay/nettypes.cpp
@@ -721,18 +721,9 @@ void NETbool(MessageReader &r, bool& val)
 
 void NETwzstring(MessageReader &r, WzString &str)
 {
-    std::vector<uint16_t> u16_characters;
-    uint32_t len;
-    NETuint32_t(r, len);
-
-    u16_characters.resize(len);
-    for (uint32_t i = 0; i < len; i++)
-    {
-        uint16_t c;
-        NETuint16_t(r, c);
-        u16_characters[i] = c;
-    }
-    str = WzString::fromUtf16(u16_characters);
+    std::string s;
+    NETstring(r, s);
+    str = WzString::fromUtf8(s);
 }
 
 /** Receives a string from the current network package.
@@ -877,18 +868,9 @@ void NETbool(MessageWriter& w, bool val)
 
 void NETwzstring(MessageWriter& w, const WzString& str)
 {
-	// NOTE: To be backwards-compatible with the old NETqstring (QString-based) function,
-	// this uses UTF-16 encoding.
-
-	const std::vector<uint16_t> u16_characters = str.toUtf16();
-	ASSERT(u16_characters.size() <= static_cast<size_t>(std::numeric_limits<uint32_t>::max()), "u16_characters.size() exceeds uint32_t max");
-
-	uint32_t len = static_cast<uint32_t>(std::min(u16_characters.size(), static_cast<size_t>(std::numeric_limits<uint32_t>::max())));
-	NETuint32_t(w, len);
-	for (uint32_t i = 0; i < len; ++i)
-	{
-		NETuint16_t(w, u16_characters[i]);
-	}
+	const std::string& utf8_string = str.toUtf8();
+	ASSERT(utf8_string.size() <= static_cast<size_t>(std::numeric_limits<uint16_t>::max()), "utf8_string.size() exceeds uint16_t max");
+	NETstring(w, utf8_string);
 }
 
 void NETstring(MessageWriter& w, const char* str, uint16_t maxlen)

--- a/src/multibot.cpp
+++ b/src/multibot.cpp
@@ -334,8 +334,7 @@ bool SendDroid(DROID_TEMPLATE *pTemplate, uint32_t x, uint32_t y, uint8_t player
 		NETuint8_t(w, player);
 		NETuint32_t(w, id);
 		NETPosition(w, pos);
-		WzString name = pTemplate->name;
-		NETwzstring(w, name);
+		NETwzstring(w, pTemplate->name);
 		NETint32_t(w, droidType);
 		NETuint8_t(w, pTemplate->asParts[COMP_BODY]);
 		NETuint8_t(w, pTemplate->asParts[COMP_BRAIN]);

--- a/src/multibot.cpp
+++ b/src/multibot.cpp
@@ -218,7 +218,7 @@ bool sendDroidSecondary(const DROID *psDroid, SECONDARY_ORDER sec, SECONDARY_STA
  *
  *  \sa recvDroidDisEmbark()
  */
-bool sendDroidDisembark(DROID const *psTransporter, DROID const *psDroid)
+bool sendDroidDisembark(const DROID *psTransporter, DROID const *psDroid)
 {
 	if (!bMultiMessages)
 	{
@@ -301,7 +301,7 @@ bool recvDroidDisEmbark(NETQUEUE queue)
 
 // ////////////////////////////////////////////////////////////////////////////
 // Send a new Droid to the other players
-bool SendDroid(DROID_TEMPLATE *pTemplate, uint32_t x, uint32_t y, uint8_t player, uint32_t id, const INITIAL_DROID_ORDERS *initialOrdersP)
+bool SendDroid(const DROID_TEMPLATE *pTemplate, uint32_t x, uint32_t y, uint8_t player, uint32_t id, const INITIAL_DROID_ORDERS *initialOrdersP)
 {
 	if (!bMultiMessages)
 	{

--- a/src/multiplay.h
+++ b/src/multiplay.h
@@ -298,19 +298,19 @@ bool multiplayerWinSequence(bool firstCall);
 // definitions of functions in multiplay's other c files.
 
 // Buildings . multistruct
-bool SendDestroyStructure(STRUCTURE *s);
-bool SendBuildFinished(STRUCTURE *psStruct);
-bool sendLasSat(UBYTE player, STRUCTURE *psStruct, BASE_OBJECT *psObj);
-void sendStructureInfo(STRUCTURE *psStruct, STRUCTURE_INFO structureInfo, DROID_TEMPLATE *psTempl);
+bool SendDestroyStructure(const STRUCTURE *s);
+bool SendBuildFinished(const STRUCTURE *psStruct);
+bool sendLasSat(UBYTE player, const STRUCTURE *psStruct, const BASE_OBJECT *psObj);
+void sendStructureInfo(const STRUCTURE *psStruct, STRUCTURE_INFO structureInfo, const DROID_TEMPLATE *psTempl);
 
 // droids . multibot
-bool SendDroid(DROID_TEMPLATE *pTemplate, uint32_t x, uint32_t y, uint8_t player, uint32_t id, const INITIAL_DROID_ORDERS *initialOrders);
+bool SendDroid(const DROID_TEMPLATE *pTemplate, uint32_t x, uint32_t y, uint8_t player, uint32_t id, const INITIAL_DROID_ORDERS *initialOrders);
 bool SendDestroyDroid(const DROID *psDroid);
 void sendQueuedDroidInfo();  ///< Actually sends the droid orders which were queued by SendDroidInfo.
 void sendDroidInfo(DROID *psDroid, DroidOrder const &order, bool add);
 
 bool sendDroidSecondary(const DROID *psDroid, SECONDARY_ORDER sec, SECONDARY_STATE state);
-bool sendDroidDisembark(DROID const *psTransporter, DROID const *psDroid);
+bool sendDroidDisembark(const DROID *psTransporter, DROID const *psDroid);
 
 // Startup. mulitopt
 bool multiShutdown();

--- a/src/multistruct.cpp
+++ b/src/multistruct.cpp
@@ -58,7 +58,7 @@
 
 // ////////////////////////////////////////////////////////////////////////////
 // INFORM others that a building has been completed.
-bool SendBuildFinished(STRUCTURE *psStruct)
+bool SendBuildFinished(const STRUCTURE *psStruct)
 {
 	uint8_t player = psStruct->player;
 	ASSERT_OR_RETURN(false, player < MAX_PLAYERS, "invalid player %u", player);
@@ -145,7 +145,7 @@ bool recvBuildFinished(NETQUEUE queue)
 
 // ////////////////////////////////////////////////////////////////////////////
 // Inform others that a structure has been destroyed
-bool SendDestroyStructure(STRUCTURE *s)
+bool SendDestroyStructure(const STRUCTURE *s)
 {
 	auto w = NETbeginEncode(NETgameQueue(realSelectedPlayer), GAME_DEBUG_REMOVE_STRUCTURE);
 	// Struct to destroy
@@ -189,7 +189,7 @@ bool recvDestroyStructure(NETQUEUE queue)
 // ////////////////////////////////////////////////////////////////////////////
 //lassat is firing
 
-bool sendLasSat(UBYTE player, STRUCTURE *psStruct, BASE_OBJECT *psObj)
+bool sendLasSat(UBYTE player, const STRUCTURE *psStruct, const BASE_OBJECT *psObj)
 {
 	auto w = NETbeginEncode(NETgameQueue(realSelectedPlayer), GAME_LASSAT);
 	NETuint8_t(w, player);
@@ -252,7 +252,7 @@ bool recvLasSat(NETQUEUE queue)
 	return true;
 }
 
-void sendStructureInfo(STRUCTURE *psStruct, STRUCTURE_INFO structureInfo_, DROID_TEMPLATE *pT)
+void sendStructureInfo(const STRUCTURE *psStruct, STRUCTURE_INFO structureInfo_, const DROID_TEMPLATE *pT)
 {
 	uint8_t  player = psStruct->player;
 	uint32_t structId = psStruct->id;

--- a/src/multistruct.cpp
+++ b/src/multistruct.cpp
@@ -265,8 +265,7 @@ void sendStructureInfo(STRUCTURE *psStruct, STRUCTURE_INFO structureInfo_, DROID
 	if (structureInfo_ == STRUCTUREINFO_MANUFACTURE)
 	{
 		int32_t droidType = pT->droidType;
-		WzString name = pT->name;
-		NETwzstring(w, name);
+		NETwzstring(w, pT->name);
 		NETuint32_t(w, pT->multiPlayerID);
 		NETint32_t(w, droidType);
 		NETuint8_t(w, pT->asParts[COMP_BODY]);


### PR DESCRIPTION
Breaking change: Use UTF-8 in `NETwzstring()`
- Different versions can't crossplay anyway, so we don't have to worry about netcode breakage with earlier versions
- The replay file format already changed (and the version was incremented) with other post-4.5.5 changes
- 4.6.0+ already can't load and play back <= 4.5.5 replays anyway (without desyncs or other issues), due to other netcode & stats & game simulation changes