### PR TITLE
Use surface height to calculate tile screen position

### DIFF
--- a/src/display3d.cpp
+++ b/src/display3d.cpp
@@ -1397,7 +1397,7 @@ static void drawTiles(iView *player, LightingData& lightData, LightMap& lightmap
 				{
 					MAPTILE* psTile = mapTile(playerXTile + j, playerZTile + i);
 
-					pos.y = map_TileHeight(playerXTile + j, playerZTile + i);
+					pos.y = map_TileHeightSurface(playerXTile + j, playerZTile + i);
 					auto color = pal_SetBrightness((currTerrainShaderType == TerrainShaderType::SINGLE_PASS) ? 0 : static_cast<UBYTE>(psTile->level));
 					lightmap(playerXTile + j, playerZTile + i) = color;
 				}


### PR DESCRIPTION
Cherry-pick from #4421

> "use surface height to calculate tile screen position" make hover or naval combat easier, because droids will go to correct surface position, it also useful when adding structures on water (floating structures) to the game