### PR TITLE
projectile: Fix isFriendlyFire psDest usage

### DIFF
--- a/src/projectile.cpp
+++ b/src/projectile.cpp
@@ -1705,7 +1705,7 @@ static int32_t objectDamageDispatch(DAMAGE *psDamage)
 
 static bool isFriendlyFire(DAMAGE* psDamage)
 {
-	return psDamage->psProjectile->psDest && psDamage->psProjectile->psSource->player == psDamage->psProjectile->psDest->player;
+	return psDamage->psDest && psDamage->psProjectile->psSource->player == psDamage->psDest->player;
 }
 
 static bool shouldIncreaseExperience(DAMAGE *psDamage)


### PR DESCRIPTION
Should use `psDamage->psDest` instead of `psDamage->psProjectile->psDest` (which differ in the case of splash damage).