### PR TITLE
vcpkg overlay port for abseil, fixes MONOLITHIC_SHARED_LIBS on mingw

### DIFF
--- a/.ci/vcpkg/overlay-ports/abseil/001-mingw-dll.patch
+++ b/.ci/vcpkg/overlay-ports/abseil/001-mingw-dll.patch
@@ -1,0 +1,13 @@
+diff --git a/CMake/AbseilDll.cmake b/CMake/AbseilDll.cmake
+--- a/CMake/AbseilDll.cmake
++++ b/CMake/AbseilDll.cmake
+@@ -839,6 +839,9 @@ function(absl_make_dll)
+       ${_dll_libs}
+       ${ABSL_DEFAULT_LINKOPTS}
+       $<$<BOOL:${ANDROID}>:-llog>
++      $<$<BOOL:${MINGW}>:-ladvapi32>
++      $<$<BOOL:${MINGW}>:-ldbghelp>
++      $<$<BOOL:${MINGW}>:-lbcrypt>
+   )
+   set_target_properties(${_dll} PROPERTIES
+     LINKER_LANGUAGE "CXX"

--- a/.ci/vcpkg/overlay-ports/abseil/portfile.cmake
+++ b/.ci/vcpkg/overlay-ports/abseil/portfile.cmake
@@ -1,0 +1,83 @@
+if(NOT VCPKG_TARGET_IS_WINDOWS)
+    vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+endif()
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO abseil/abseil-cpp
+    REF "${VERSION}"
+    SHA512 8312acf0ed74fa28c6397f3e41ada656dbd5ca2bf8db484319d74b144ad19c0ebdc77f7f03436be6c6ca1cde706b9055079233cf0d6b5ada4ca48406f8a55dd8
+    HEAD_REF master
+    PATCHES 
+        "001-mingw-dll.patch"
+)
+
+# With ABSL_PROPAGATE_CXX_STD=ON abseil automatically detect if it is being
+# compiled with C++14 or C++17, and modifies the installed `absl/base/options.h`
+# header accordingly. This works even if CMAKE_CXX_STANDARD is not set. Abseil
+# uses the compiler default behavior to update `absl/base/options.h` as needed.
+set(ABSL_USE_CXX17_OPTION "")
+if("cxx17" IN_LIST FEATURES)
+    set(ABSL_USE_CXX17_OPTION "-DCMAKE_CXX_STANDARD=17")
+endif()
+
+set(ABSL_TEST_HELPERS_OPTIONS "")
+if("test-helpers" IN_LIST FEATURES)
+    set(ABSL_TEST_HELPERS_OPTIONS "-DABSL_BUILD_TEST_HELPERS=ON" "-DABSL_USE_EXTERNAL_GOOGLETEST=ON" "-DABSL_FIND_GOOGLETEST=ON")
+endif()
+
+set(ABSL_STATIC_RUNTIME_OPTION "")
+if(VCPKG_TARGET_IS_WINDOWS AND VCPKG_CRT_LINKAGE STREQUAL "static")
+    set(ABSL_STATIC_RUNTIME_OPTION "-DABSL_MSVC_STATIC_RUNTIME=ON")
+endif()
+
+set(ABSL_MINGW_OPTIONS "")
+if(VCPKG_TARGET_IS_MINGW)
+    # LIBRT-NOTFOUND is needed since the system librt may be found by cmake in
+    # a cross-compile setup.
+    # See https://github.com/pywinrt/pywinrt/pull/83 for the FIReference
+    # definition issue.
+    set(ABSL_MINGW_OPTIONS "-DLIBRT=LIBRT-NOTFOUND"
+        "-DCMAKE_CXX_FLAGS=-D____FIReference_1_boolean_INTERFACE_DEFINED__")
+    # Specify ABSL_BUILD_MONOLITHIC_SHARED_LIBS=ON to match Abseil's Windows (MSVC) defaults
+    if(VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
+        vcpkg_list(APPEND ABSL_MINGW_OPTIONS "-DABSL_BUILD_MONOLITHIC_SHARED_LIBS=ON")
+    endif()
+endif()
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    DISABLE_PARALLEL_CONFIGURE
+    OPTIONS
+        -DABSL_PROPAGATE_CXX_STD=ON
+        ${ABSL_USE_CXX17_OPTION}
+        ${ABSL_TEST_HELPERS_OPTIONS}
+        ${ABSL_STATIC_RUNTIME_OPTION}
+        ${ABSL_MINGW_OPTIONS}
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(PACKAGE_NAME absl CONFIG_PATH lib/cmake/absl)
+
+if(VCPKG_TARGET_IS_IOS OR VCPKG_TARGET_IS_OSX)
+    file(APPEND "${CURRENT_PACKAGES_DIR}/lib/pkgconfig/absl_time.pc" "Libs.private: -framework CoreFoundation\n")
+    if(NOT VCPKG_BUILD_TYPE)
+        file(APPEND "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/absl_time.pc" "Libs.private: -framework CoreFoundation\n")
+    endif()
+endif()
+vcpkg_fixup_pkgconfig()
+
+vcpkg_copy_pdbs()
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share"
+                    "${CURRENT_PACKAGES_DIR}/debug/include"
+                    "${CURRENT_PACKAGES_DIR}/include/absl/copts"
+                    "${CURRENT_PACKAGES_DIR}/include/absl/strings/testdata"
+                    "${CURRENT_PACKAGES_DIR}/include/absl/time/internal/cctz/testdata"
+)
+
+if(VCPKG_TARGET_IS_WINDOWS AND VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/absl/base/config.h" "defined(ABSL_CONSUME_DLL)" "1")
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/absl/base/internal/thread_identity.h" "defined(ABSL_CONSUME_DLL)" "1")
+endif()
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/.ci/vcpkg/overlay-ports/abseil/vcpkg.json
+++ b/.ci/vcpkg/overlay-ports/abseil/vcpkg.json
@@ -1,0 +1,44 @@
+{
+  "name": "abseil",
+  "version": "20250127.1",
+  "port-version": 4,
+  "description": [
+    "Abseil is an open-source collection of C++ library code designed to augment the C++ standard library. The Abseil library code is collected from Google's own C++ code base, has been extensively tested and used in production, and is the same code we depend on in our daily coding lives.",
+    "In some cases, Abseil provides pieces missing from the C++ standard; in others, Abseil provides alternatives to the standard for special needs we've found through usage in the Google code base. We denote those cases clearly within the library code we provide you.",
+    "Abseil is not meant to be a competitor to the standard library; we've just found that many of these utilities serve a purpose within our code base, and we now want to provide those resources to the C++ community as a whole."
+  ],
+  "homepage": "https://github.com/abseil/abseil-cpp",
+  "license": "Apache-2.0",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "features": {
+    "cxx17": {
+      "description": "Enable compiler C++17."
+    },
+    "test-helpers": {
+      "description": "Build Abseil's test helpers",
+      "dependencies": [
+        {
+          "name": "abseil",
+          "features": [
+            "cxx17"
+          ]
+        },
+        {
+          "name": "gtest",
+          "features": [
+            "cxx17"
+          ]
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
With this, abseil builds as a single .dll file (instead of _43_ dlls...)