### PR TITLE
Handle mouse pan speed edge case

### DIFF
--- a/src/display.cpp
+++ b/src/display.cpp
@@ -1227,7 +1227,7 @@ void displayWorld()
 			int mouseDeltaX = mouseX() - panMouseX;
 			int mouseDeltaY = mouseY() - panMouseY;
 
-			int panningSpeed = war_GetCameraSpeed() / 200;
+			int panningSpeed = std::max(1, war_GetCameraSpeed() / 200);
 
 			float horizontalMovement = panXTracker->setTargetDelta(mouseDeltaX * panningSpeed)->update()->getCurrentDelta();
 			float verticalMovement = -1 * panZTracker->setTargetDelta(mouseDeltaY * panningSpeed)->update()->getCurrentDelta();


### PR DESCRIPTION
When camera speed is set to `100` (lowest setting), mouse pan speed becomes 0, and the camera does not move.

This pull request sets a minimum panningSpeed of 1, fixing this issue.