### PR TITLE
Do not add GNS to joinLobbyGame connection list

### DIFF
--- a/src/multiint.cpp
+++ b/src/multiint.cpp
@@ -1155,9 +1155,6 @@ std::vector<JoinConnectionDescription> findLobbyGame(const std::string& lobbyAdd
 	}
 	std::string host = lobbyGame.desc.host;
 	std::vector<JoinConnectionDescription> connList;
-#ifdef WZ_GNS_NETWORK_BACKEND_ENABLED
-	connList.emplace_back(JoinConnectionDescription::JoinConnectionType::GNS_DIRECT, host, lobbyGame.hostPort);
-#endif
 	connList.emplace_back(JoinConnectionDescription::JoinConnectionType::TCP_DIRECT, host, lobbyGame.hostPort);
 	return connList;
 }

--- a/src/titleui/gamefind.cpp
+++ b/src/titleui/gamefind.cpp
@@ -303,9 +303,6 @@ static void joinLobbyGame(uint32_t gameNumber, bool asSpectator)
 	ASSERT_OR_RETURN(, gameNumber < gamesList.size(), "Invalid gameNumber: %" PRIu32, gameNumber);
 
 	std::vector<JoinConnectionDescription> connectionDesc;
-#ifdef WZ_GNS_NETWORK_BACKEND_ENABLED
-	connectionDesc.emplace_back(JoinConnectionDescription::JoinConnectionType::GNS_DIRECT, gamesList[gameNumber].desc.host, gamesList[gameNumber].hostPort);
-#endif
 	connectionDesc.emplace_back(JoinConnectionDescription::JoinConnectionType::TCP_DIRECT, gamesList[gameNumber].desc.host, gamesList[gameNumber].hostPort);
 	ActivityManager::instance().willAttemptToJoinLobbyGame(NETgetMasterserverName(), NETgetMasterserverPort(), gamesList[gameNumber].gameId, connectionDesc);
 


### PR DESCRIPTION
As the lobby does not currently support, nor can it currently advertise, GNS_DIRECT games.

Prevents a 10+ second delay connecting to lobby-listed games