### PR TITLE
Fix: autoLobbyNotReadyKickRoutine using the wrong value

### DIFF
--- a/src/multiplay.cpp
+++ b/src/multiplay.cpp
@@ -362,7 +362,7 @@ void autoLobbyNotReadyKickRoutine(std::chrono::steady_clock::time_point now)
 		return;
 	}
 
-	int NotReadyAutoKickSeconds = war_getAutoLagKickSeconds();
+	int NotReadyAutoKickSeconds = war_getAutoNotReadyKickSeconds();
 	if (NotReadyAutoKickSeconds <= 0)
 	{
 		return;


### PR DESCRIPTION
Fixes #4484