### PR TITLE
Fix: Move NETshutdown() later in systemShutdown()

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1164,6 +1164,7 @@ void systemShutdown()
 	pal_ShutDown();		// currently unused stub
 	frameShutDown();	// close screen / SDL / resources / cursors / trig
 	screenShutDown();
+	NETshutdown();		// MUST come after widgShutDown (as widget screens might have connections, etc)
 	gfx_api::context::get().shutdown();
 	cleanSearchPath();	// clean PHYSFS search paths
 	debug_exit();		// cleanup debug routines

--- a/src/multiopt.cpp
+++ b/src/multiopt.cpp
@@ -526,10 +526,6 @@ bool sendLeavingMsg()
 // called in Init.c to shutdown the whole netgame gubbins.
 bool multiShutdown()
 {
-	// shut down netplay lib.
-	debug(LOG_MAIN, "shutting down networking");
-	NETshutdown();
-
 	debug(LOG_MAIN, "free game data (structure limits)");
 	ingame.structureLimits.clear();
 


### PR DESCRIPTION
To ensure it comes after widgShutDown (as widget screens - like the joiningGameScreen - might be managing a connection)

Fixes a possible crash on exit