### PR TITLE
full revert brain.json

### DIFF
--- a/data/mp/stats/brain.json
+++ b/data/mp/stats/brain.json
@@ -4,32 +4,18 @@
 		"droidType": "DROID_COMMAND",
 		"hitpoints": 500,
 		"id": "CommandBrain01",
-		"maxDroids": 12,
-		"maxDroidsMult": 6,
+		"maxDroids": 6,
+		"maxDroidsMult": 2,
 		"name": "Command Turret",
 		"ranks": [ "Rookie", "Green", "Trained", "Regular", "Professional", "Veteran", "Elite", "Special", "Hero" ],
 		"thresholds": [ 0, 12, 24, 36, 48, 60, 72, 84, 96 ],
-		"turret": "CommandTurret1",
-		"initialShieldPointsPercent": 25,
-		"additiveShieldPointsPercent": 10,
-		"initialShieldRegenTime": 32,
-		"shieldRegenTimeDec": 2,
-		"initialShieldInterruptRegenTime": 2000,
-		"shieldInterruptRegenTimeDec": 100,
-		"shieldPointsPerStep": 4
+		"turret": "CommandTurret1"
 	},
 	"ZNULLBRAIN": {
 		"id": "ZNULLBRAIN",
 		"name": "Z NULL BRAIN",
 		"ranks": [ "Rookie", "Green", "Trained", "Regular", "Professional", "Veteran", "Elite", "Special", "Hero" ],
 		"thresholds": [ 0, 2, 4, 6, 8, 10, 12, 14, 16 ],
-		"turret": "ZNULLWEAPON",
-		"initialShieldPointsPercent": 25,
-		"additiveShieldPointsPercent": 10,
-		"initialShieldRegenTime": 32,
-		"shieldRegenTimeDec": 2,
-		"initialShieldInterruptRegenTime": 2000,
-		"shieldInterruptRegenTimeDec": 100,
-		"shieldPointsPerStep": 4
+		"turret": "ZNULLWEAPON"
 	}
 }


### PR DESCRIPTION
We have done a playtest of shields.
At the moment, shields and strengthened commanders do not add variety to the gameplay. All the discussion of balance between how to make commanders not OP. When they are weakened enough, they will become unnecessary again...

That is why I propose to roll back the changes to commanders. Shields remain available for modders. I will also remind you that these MP balance changes were made without proper discussion and voting.