### PR TITLE
Vulkan backend tweaks

### DIFF
--- a/lib/ivis_opengl/CMakeLists.txt
+++ b/lib/ivis_opengl/CMakeLists.txt
@@ -124,7 +124,7 @@ else()
 endif()
 
 if(WZ_ENABLE_BACKEND_VULKAN)
-	find_package(VulkanHeaders 154) # minimum supported version of the Vulkan headers is 154
+	find_package(VulkanHeaders 290) # minimum supported version of the Vulkan headers is 290
 	set(_vulkanheaders_dl_gittag "vulkan-sdk-1.3.296.0")
 	if(NOT VulkanHeaders_FOUND AND (NOT WZ_DISABLE_FETCHCONTENT_GIT_CLONE))
 		# Fetch newer Vulkan headers (using FetchContent, which requires CMake 3.11+)

--- a/lib/ivis_opengl/gfx_api_vk.cpp
+++ b/lib/ivis_opengl/gfx_api_vk.cpp
@@ -70,8 +70,8 @@ const uint32_t minSupportedVulkanVersion = VK_API_VERSION_1_0;
 // For debug builds, limit to the minimum that should be supported by this backend (which is Vulkan 1.0, see above)
 const uint32_t maxRequestableInstanceVulkanVersion = VK_API_VERSION_1_0;
 #else
-// For regular builds, currently limit to: Vulkan 1.1
-const uint32_t maxRequestableInstanceVulkanVersion = (uint32_t)VK_MAKE_VERSION(1, 1, 0);
+// For regular builds, currently limit to: Vulkan 1.3
+const uint32_t maxRequestableInstanceVulkanVersion = (uint32_t)VK_MAKE_VERSION(1, 3, 0);
 #endif
 
 const size_t MAX_FRAMES_IN_FLIGHT = 2;


### PR DESCRIPTION
- Add support for device / driver blocklist
  - Block old Intel Vulkan drivers that advertise < Vulkan 1.1.0 support (due to crashes on at least Windows)
- Bump max requested Vulkan version to 1.3
  - If a system supports Vulkan 1.3+, and WZ requests Vulkan 1.3+, the VulkanMemoryAllocator gets to potentially use more optimal APIs / paths
- Update minimum VK_HEADER_VERSION to 290