### PR TITLE
Cleanup Commander template limit code

### DIFF
--- a/src/cmddroiddef.h
+++ b/src/cmddroiddef.h
@@ -31,7 +31,4 @@
 
 struct DROID;
 
-/** This defines the maximum number of command droids allowed per player.*/
-#define MAX_CMDDROIDS	5
-
 #endif // __INCLUDED_CMDDROIDDEF_H__

--- a/src/droid.cpp
+++ b/src/droid.cpp
@@ -3058,21 +3058,6 @@ bool droidUnderRepair(const DROID *psDroid)
 	return false;
 }
 
-//count how many Command Droids exist in the world at any one moment
-UBYTE checkCommandExist(UBYTE player)
-{
-	UBYTE	quantity = 0;
-
-	for (const DROID *psDroid : apsDroidLists[player])
-	{
-		if (psDroid->droidType == DROID_COMMAND)
-		{
-			quantity++;
-		}
-	}
-	return quantity;
-}
-
 static inline bool isTransporter(DROID_TYPE type)
 {
 	return type == DROID_TRANSPORTER || type == DROID_SUPERTRANSPORTER;

--- a/src/droid.h
+++ b/src/droid.h
@@ -241,9 +241,6 @@ bool electronicDroid(const DROID *psDroid);
 /// checks to see if the droid is currently being repaired by another
 bool droidUnderRepair(const DROID *psDroid);
 
-/// Count how many Command Droids exist in the world at any one moment
-UBYTE checkCommandExist(UBYTE player);
-
 /// For a given repair droid, check if there are any damaged droids within a defined range
  BASE_OBJECT *checkForRepairRange(DROID *psDroid, DROID *psTarget);
 

--- a/src/structure.cpp
+++ b/src/structure.cpp
@@ -6451,38 +6451,6 @@ ProductionRunEntry getProduction(STRUCTURE *psStructure, DROID_TEMPLATE *psTempl
 	return ProductionRunEntry();
 }
 
-
-/*looks through a players production list to see how many command droids
-are being built*/
-UBYTE checkProductionForCommand(UBYTE player)
-{
-	unsigned quantity = 0;
-
-	if (player == productionPlayer)
-	{
-		//assumes Cyborg or VTOL droids are not Command types!
-		unsigned factoryType = FACTORY_FLAG;
-
-		for (unsigned factoryInc = 0; factoryInc < factoryNumFlag[player][factoryType].size(); ++factoryInc)
-		{
-			//check to see if there is a factory with a production run
-			if (factoryNumFlag[player][factoryType][factoryInc] && factoryInc < asProductionRun[factoryType].size())
-			{
-				ProductionRun &productionRun = asProductionRun[factoryType][factoryInc];
-				for (unsigned inc = 0; inc < productionRun.size(); ++inc)
-				{
-					if (productionRun[inc].psTemplate->droidType == DROID_COMMAND)
-					{
-						quantity += productionRun[inc].numRemaining();
-					}
-				}
-			}
-		}
-	}
-	return quantity;
-}
-
-
 // Count number of factories assignable to a command droid.
 //
 UWORD countAssignableFactories(UBYTE player, UWORD factoryType)

--- a/src/structure.h
+++ b/src/structure.h
@@ -253,9 +253,6 @@ void factoryProdAdjust(STRUCTURE *psStructure, DROID_TEMPLATE *psTemplate, bool 
 //returns the quantity of a specific template in the production list
 ProductionRunEntry getProduction(STRUCTURE *psStructure, DROID_TEMPLATE *psTemplate);
 
-//looks through a players production list to see if a command droid is being built
-UBYTE checkProductionForCommand(UBYTE player);
-
 //check that delivery points haven't been put down in invalid location
 void checkDeliveryPoints(UDWORD version);
 

--- a/src/template.cpp
+++ b/src/template.cpp
@@ -852,15 +852,6 @@ std::vector<DROID_TEMPLATE *> fillTemplateList(STRUCTURE *psFactory)
 		// Must add droids if currently in production.
 		if (!getProduction(psFactory, psCurr).quantity)
 		{
-			//can only have (MAX_CMDDROIDS) in the world at any one time
-			if (psCurr->droidType == DROID_COMMAND)
-			{
-				if (checkProductionForCommand(player) + checkCommandExist(player) >= (MAX_CMDDROIDS))
-				{
-					continue;
-				}
-			}
-
 			if (!psCurr->enabled
 				|| (bMultiPlayer && !playerBuiltHQ && (psCurr->droidType != DROID_CONSTRUCT && psCurr->droidType != DROID_CYBORG_CONSTRUCT))
 				|| !validTemplateForFactory(psCurr, psFactory, false)


### PR DESCRIPTION
Totally unnecessary to hide the template as it will still appear in the factory producing it even if the now gone hardcoded limit is exceeded.

The game will alert the player to being over the limits through the usual pathways AND will now allow multiple factory queues for them to exist.

---

I don't see any problems with this so far in my testing.