### PR TITLE
increment structure count on donation

### DIFF
--- a/src/structure.cpp
+++ b/src/structure.cpp
@@ -6913,6 +6913,10 @@ STRUCTURE *giftSingleStructure(STRUCTURE *psStructure, UBYTE attackPlayer, bool 
 			// add to other list.
 			addStructure(psStructure);
 
+			// increment structure count for new owner
+			UDWORD max = psStructure->pStructureType - asStructureStats;
+			asStructureStats[max].curCount[attackPlayer]++;
+
 			//check through the 'attackPlayer' players list of droids to see if any are targetting it
 			for (DROID* psCurr : apsDroidLists[attackPlayer])
 			{


### PR DESCRIPTION
Fixes #4516

Do not need to fix decrement since structure count is decremented inside `removeStruct()` ✅

Follow-up question: Why is the structure count not incremented in `addStructure()`?