### PR TITLE
Additional calls to droidRepairStopped()

### DIFF
--- a/src/mission.cpp
+++ b/src/mission.cpp
@@ -205,6 +205,10 @@ static void resetHomeStructureObjects()
 				REPAIR_FACILITY *psRepairFac = &psStruct->pFunctionality->repairFacility;
 				if (psRepairFac->psObj)
 				{
+					if (psRepairFac->state == RepairState::Repairing)
+					{
+						droidRepairStopped(castDroid(psRepairFac->psObj), psStruct);
+					}
 					psRepairFac->psObj = nullptr;
 					psRepairFac->state = RepairState::Idle;
 				}

--- a/src/structure.cpp
+++ b/src/structure.cpp
@@ -1047,6 +1047,10 @@ void structureBuild(STRUCTURE *psStruct, DROID *psDroid, int buildPoints, int bu
 					REPAIR_FACILITY	*psRepairFac = &psStruct->pFunctionality->repairFacility;
 					if (psRepairFac->psObj)
 					{
+						if (psRepairFac->state == RepairState::Repairing)
+						{
+							droidRepairStopped(castDroid(psRepairFac->psObj), psStruct);
+						}
 						psRepairFac->psObj = nullptr;
 						psRepairFac->state = RepairState::Idle;
 					}


### PR DESCRIPTION
Fixes the droid incorrectly hanging onto its "under repair" state if the repair facility that is actively repairing it is demolished.