### PR TITLE
Remove experimental commander-based shield implementation, leave stubs for future shield experiments

### DIFF
--- a/data/mp/stats/brain.json
+++ b/data/mp/stats/brain.json
@@ -10,15 +10,7 @@
 		"ranks": [ "Rookie", "Green", "Trained", "Regular", "Professional", "Veteran", "Elite", "Special", "Hero" ],
 		"thresholds": [ 0, 12, 24, 36, 48, 60, 72, 84, 96 ],
 		"cmdExpRange": [],
-		"turret": "CommandTurret1",
-		"initialShieldPointsPercent": 15,
-		"additiveShieldPointsPercent": 5,
-		"initialShieldRegenTime": 32,
-		"shieldRegenTimeDec": 2,
-		"initialShieldInterruptRegenTime": 2000,
-		"shieldInterruptRegenTimeDec": 100,
-		"shieldPointsPerStep": 4,
-		"shieldRange": []
+		"turret": "CommandTurret1"
 	},
 	"ZNULLBRAIN": {
 		"id": "ZNULLBRAIN",
@@ -26,14 +18,6 @@
 		"ranks": [ "Rookie", "Green", "Trained", "Regular", "Professional", "Veteran", "Elite", "Special", "Hero" ],
 		"thresholds": [ 0, 2, 4, 6, 8, 10, 12, 14, 16 ],
 		"cmdExpRange": [ 512, 768, 1024, 1280, 1536, 1792, 2048, 2304, 2560 ],
-		"turret": "ZNULLWEAPON",
-		"initialShieldPointsPercent": 15,
-		"additiveShieldPointsPercent": 5,
-		"initialShieldRegenTime": 32,
-		"shieldRegenTimeDec": 2,
-		"initialShieldInterruptRegenTime": 2000,
-		"shieldInterruptRegenTimeDec": 100,
-		"shieldPointsPerStep": 4,
-		"shieldRange": [ 512, 768, 1024, 1280, 1536, 1792, 2048, 2304, 2560 ]
+		"turret": "ZNULLWEAPON"
 	}
 }

--- a/src/cmddroid.cpp
+++ b/src/cmddroid.cpp
@@ -199,7 +199,7 @@ void cmdDroidUpdateExperience(DROID *psShooter, uint32_t experienceInc)
 {
 	ASSERT_OR_RETURN(, psShooter != nullptr, "invalid Unit pointer");
 
-	if (hasCommander(psShooter) && droidWithinCommanderRange(psShooter, false))
+	if (hasCommander(psShooter) && droidWithinCommanderRange(psShooter))
 	{
 		DROID *psCommander = psShooter->psGroup->psCommander;
 		droidIncreaseExperience(psCommander, MIN(experienceInc, UINT32_MAX - psCommander->experience));

--- a/src/droid.cpp
+++ b/src/droid.cpp
@@ -1048,7 +1048,7 @@ void droidUpdate(DROID *psDroid)
 }
 
 /* Check if droid is within commander's range */
-bool droidWithinCommanderRange(const DROID *psDroid, bool shield)
+bool droidWithinCommanderRange(const DROID *psDroid)
 {
 	if (psDroid->droidType == DROID_COMMAND)
 	{
@@ -1057,7 +1057,7 @@ bool droidWithinCommanderRange(const DROID *psDroid, bool shield)
 
 	ASSERT_OR_RETURN(false, psDroid->psGroup && psDroid->psGroup->psCommander, "Droid group or commander is NULL");
 
-	const auto &rangeArray = shield ? psDroid->getBrainStats()->shield.shieldRange : psDroid->getBrainStats()->cmdExpRange;
+	const auto &rangeArray = psDroid->getBrainStats()->cmdExpRange;
 
 	auto level = getDroidLevel(psDroid->psGroup->psCommander);
 	auto rangeArraySize = rangeArray.size();
@@ -1078,66 +1078,13 @@ bool droidWithinCommanderRange(const DROID *psDroid, bool shield)
 
 void droidUpdateShields(DROID *psDroid)
 {
-	if (hasCommander(psDroid) || psDroid->droidType == DROID_COMMAND)
-	{
-		if (psDroid->shieldPoints < 0)
-		{
-			psDroid->shieldPoints = 0;
-			psDroid->shieldRegenTime = gameTime;
-			psDroid->shieldInterruptRegenTime = gameTime;
-		}
-		else
-		{
-			if (!((psDroid->lastHitWeapon == WSC_EMP) && ((gameTime - psDroid->timeLastHit) < EMP_DISABLE_TIME)) &&
-				gameTime - psDroid->shieldInterruptRegenTime > droidCalculateShieldInterruptRegenTime(psDroid) &&
-				gameTime - psDroid->shieldRegenTime > droidCalculateShieldRegenTime(psDroid) &&
-				droidWithinCommanderRange(psDroid, true))
-			{
-				auto availableShieldPoints = droidGetMaxShieldPoints(psDroid) - psDroid->shieldPoints;
-
-				if (availableShieldPoints > 0)
-				{
-					auto pointsToAdd = std::min<UDWORD>(psDroid->getBrainStats()->shield.shieldPointsPerStep, availableShieldPoints);
-					psDroid->shieldPoints += pointsToAdd;
-				}
-				psDroid->shieldRegenTime = gameTime;
-			}
-		}
-	}
-	else
-	{
-		// unit has lost commander, shields are down!
-		psDroid->shieldPoints = -1;
-	}
-}
-
-UDWORD droidCalculateShieldRegenTime(const DROID *psDroid)
-{
-	const auto &psStats = psDroid->getBrainStats()->shield;
-	auto levelBasedReduction = (psStats.shieldRegenTimeDec * getDroidLevel(psDroid));
-	if (levelBasedReduction >= psStats.initialShieldRegenTime)
-	{
-		return 0;
-	}
-	return psStats.initialShieldRegenTime - levelBasedReduction;
-}
-
-UDWORD droidCalculateShieldInterruptRegenTime(const DROID *psDroid)
-{
-	const auto &psStats = psDroid->getBrainStats()->shield;
-	auto levelBasedReduction = (psStats.shieldInterruptRegenTimeDec * getDroidLevel(psDroid));
-	if (levelBasedReduction >= psStats.initialShieldInterruptRegenTime)
-	{
-		return 0;
-	}
-	return psStats.initialShieldInterruptRegenTime - levelBasedReduction;
+	// shields are down (left for experimentation with different implementations)
+	psDroid->shieldPoints = -1;
 }
 
 UDWORD droidGetMaxShieldPoints(const DROID *psDroid)
 {
-	const auto &psStats = psDroid->getBrainStats()->shield;
-	UDWORD percent = psDroid->originalBody / 100;
-	return percent * (psStats.initialShieldPointsPercent + psStats.additiveShieldPointsPercent * getDroidLevel(psDroid));
+	return 0; // currently disabled, but left for experimentation with different implementations
 }
 
 /* See if a droid is next to a structure */

--- a/src/droid.h
+++ b/src/droid.h
@@ -119,16 +119,10 @@ int32_t droidDamage(DROID *psDroid, PROJECTILE *psProjectile, unsigned damage, W
 void droidUpdate(DROID *psDroid);
 
 /* Check if droid is within commander's range */
-bool droidWithinCommanderRange(const DROID *psDroid, bool shield);
+bool droidWithinCommanderRange(const DROID *psDroid);
 
 /* Update droid shields. */
 void droidUpdateShields(DROID *psDroid);
-
-/* Calculate the droid's shield regeneration step time */
-UDWORD droidCalculateShieldRegenTime(const DROID *psDroid);
-
-/* Calculate the droid's shield interruption time */
-UDWORD droidCalculateShieldInterruptRegenTime(const DROID *psDroid);
 
 /* Get droid maximum shield points */
 UDWORD droidGetMaxShieldPoints(const DROID *psDroid);

--- a/src/stats.cpp
+++ b/src/stats.cpp
@@ -720,23 +720,6 @@ bool loadBrainStats(WzConfig &ini)
 		psStats->weight = ini.value("weight", 0).toInt();
 		psStats->base.maxDroids = ini.value("maxDroids").toInt();
 		psStats->base.maxDroidsMult = ini.value("maxDroidsMult").toInt();
-		psStats->shield.initialShieldPointsPercent = ini.value("initialShieldPointsPercent").toInt();
-		psStats->shield.additiveShieldPointsPercent = ini.value("additiveShieldPointsPercent").toInt();
-		psStats->shield.initialShieldRegenTime = ini.value("initialShieldRegenTime").toInt();
-		psStats->shield.shieldRegenTimeDec = ini.value("shieldRegenTimeDec").toInt();
-		psStats->shield.initialShieldInterruptRegenTime = ini.value("initialShieldInterruptRegenTime").toInt();
-		psStats->shield.shieldInterruptRegenTimeDec = ini.value("shieldInterruptRegenTimeDec").toInt();
-		psStats->shield.shieldPointsPerStep = ini.value("shieldPointsPerStep").toInt();
-
-		auto shieldRange = ini.json("shieldRange");
-		if (!shieldRange.is_null())
-		{
-			ASSERT(shieldRange.is_array(), "shieldRange is not an array");
-			for (const auto& v : shieldRange)
-			{
-				psStats->shield.shieldRange.push_back(v.get<int>());
-			}
-		}
 
 		auto cmdExpRange = ini.json("cmdExpRange");
 		if (!cmdExpRange.is_null())

--- a/src/statsdef.h
+++ b/src/statsdef.h
@@ -487,17 +487,6 @@ struct BRAIN_STATS : public COMPONENT_STATS
 	} upgrade[MAX_PLAYERS], base;
 	std::vector<std::string> rankNames;
 	std::vector<int> cmdExpRange;
-	struct
-	{
-		int initialShieldPointsPercent = 0;
-		int additiveShieldPointsPercent = 0;
-		int initialShieldRegenTime = 0;
-		int shieldRegenTimeDec = 0;
-		int initialShieldInterruptRegenTime = 0;
-		int shieldInterruptRegenTimeDec = 0;
-		int shieldPointsPerStep = 0;
-		std::vector<int> shieldRange;
-	} shield;
 };
 
 /*


### PR DESCRIPTION
MP balance change voting on the current (experimental) command-shield implementation yielded the following results:
- 88% against inclusion in the stable release

A huge thank you to everyone involved in working on and testing this experiment, and testing the beta builds!

This PR removes the commander-based shield implementation.

However, we are keeping stub functions, as well as the other implementation pieces (including per-DROID shield values, visual display of shields, UI display of shield strength) so that future experiments on implementing shields (perhaps via a research-based mechanism) can be more easily undertaken.