### PR TITLE
Bump repair spread area

### DIFF
--- a/src/order.cpp
+++ b/src/order.cpp
@@ -3467,13 +3467,13 @@ static inline RtrBestResult decideWhereToRepairAndBalance(DROID *psDroid)
 	// debug(LOG_INFO, "found a total of %lu RT, and %lu RF", vDroid.size(), vFacility.size());
 
 	// the center of this area starts at the closest repair droid/facility!
-	#define MAGIC_SUITABLE_REPAIR_AREA ((REPAIR_RANGE*3) * (REPAIR_RANGE*3))
+	#define MAGIC_SUITABLE_REPAIR_AREA ((REPAIR_RANGE*5) * (REPAIR_RANGE*5))
 	Position bestRepairPoint = bestDistToRepairFac < bestDistToRepairDroid ? bestFacPos: bestDroidPos;
 	// find all close enough repairing candidates
 	for (int i=0; i < vFacilityPos.size(); i++)
 	{
 		Vector2i diff = (bestRepairPoint - vFacilityPos[i]).xy();
-		if (dot(diff, diff) < MAGIC_SUITABLE_REPAIR_AREA)
+		if (dot(diff, diff) <= MAGIC_SUITABLE_REPAIR_AREA)
 		{
 			vFacilityCloseEnough.push_back(i);
 		}
@@ -3481,7 +3481,7 @@ static inline RtrBestResult decideWhereToRepairAndBalance(DROID *psDroid)
 	for (int i=0; i < vDroidPos.size(); i++)
 	{
 		Vector2i diff = (bestRepairPoint - vDroidPos[i]).xy();
-		if (dot(diff, diff) < MAGIC_SUITABLE_REPAIR_AREA)
+		if (dot(diff, diff) <= MAGIC_SUITABLE_REPAIR_AREA)
 		{
 			vDroidCloseEnough.push_back(i);
 		}


### PR DESCRIPTION
From 6 to 10 tiles. This means all 5 repair facilities in a standard MP game will get distributed to if built in a straight line.

Also, because the distance check used < instead of <=, it meant the 4th facility (in a line) would get skipped since 4 repair facilities are 6 tiles apart.

---

Thus it means units were only going to 3 of the 5 facilities if they were built in a line, AND if the closest one was on the end of the line.

Should be a nice QoL update in place of better load balancing. Pastdue and I were thinking either 8 or 10 tiles. I chose 10 as it allows a single misplaced repair facility gap without preventing units from reaching the farthest one. Just in case battles are too hectic and you make a little mistake trying to build one again.

Notice how current behavior causes units to go to the first 3 repairs, and this PR makes them choose all 5. This is an extreme example coming from a side angle. If coming from north or south the effect would be greater.

CURRENT

https://github.com/user-attachments/assets/f5b12a32-50a4-43d0-9288-bbe9f02b3d0e


THIS PR

https://github.com/user-attachments/assets/f2dd26d5-388f-4efb-8885-705fe4b8160e

