### PR TITLE
gns: Guard read/write accesses to `activeClients_` with a mutex

### DIFF
--- a/lib/netplay/gns/gns_connection_provider.cpp
+++ b/lib/netplay/gns/gns_connection_provider.cpp
@@ -219,6 +219,7 @@ net::result<IClientConnection*> GNSConnectionProvider::openClientConnectionAny(c
 		return tl::make_unexpected(make_network_error_code(EBADF)); // bad file descriptor
 	}
 	auto conn = new GNSClientConnection(*this, WzCompressionProvider::Instance(), PendingWritesManagerMap::instance().get(type()), networkInterface_, h);
+	std::unique_lock lock(activeClientsMtx_);
 	activeClients_.emplace(h, conn);
 	return conn;
 }
@@ -244,7 +245,7 @@ void GNSConnectionProvider::ServerConnectionStateChanged(SteamNetConnectionStatu
 	case k_ESteamNetworkingConnectionState_None:
 		break;
 	case k_ESteamNetworkingConnectionState_Connecting:
-		ASSERT(connProvider->activeClients_.count(pInfo->m_hConn) == 0, "Expected to have a new connection");
+	{
 		ASSERT(pInfo->m_info.m_hListenSocket == connProvider->activeListenSocket_.first, "Unexpected listen socket handle");
 		if (connProvider->networkInterface_->AcceptConnection(pInfo->m_hConn) != k_EResultOK)
 		{
@@ -252,16 +253,24 @@ void GNSConnectionProvider::ServerConnectionStateChanged(SteamNetConnectionStatu
 			connProvider->networkInterface_->CloseConnection(pInfo->m_hConn, 0, nullptr, false);
 			break;
 		}
+		std::unique_lock lock(connProvider->activeClientsMtx_);
+
+		ASSERT(connProvider->activeClients_.count(pInfo->m_hConn) == 0, "Expected to have a new connection");
 		// We don't yet have a live `IClientConnection` instance for this connection
 		connProvider->activeClients_.emplace(pInfo->m_hConn, nullptr);
 		break;
+	}
 	case k_ESteamNetworkingConnectionState_FindingRoute:
 		break;
 	case k_ESteamNetworkingConnectionState_Connected:
+	{
+		std::unique_lock lock(connProvider->activeClientsMtx_);
+
 		ASSERT(connProvider->activeClients_.count(pInfo->m_hConn) != 0, "Expected to be a connection that we are aware of");
 		ASSERT(pInfo->m_info.m_hListenSocket == connProvider->activeListenSocket_.first, "Unexpected listen socket handle");
 		connProvider->activeListenSocket_.second->addPendingAcceptedConnection(pInfo->m_hConn);
 		break;
+	}
 	case k_ESteamNetworkingConnectionState_ClosedByPeer:
 		debug(LOG_ERROR, "Connection closed by peer: %u", pInfo->m_hConn);
 		connProvider->disposeConnectionImpl(pInfo->m_hConn);
@@ -325,6 +334,7 @@ PortMappingInternetProtocolMask GNSConnectionProvider::portMappingProtocolTypes(
 void GNSConnectionProvider::registerAcceptedConnection(GNSClientConnection* conn)
 {
 	ASSERT_OR_RETURN(, conn->isValid(), "Invalid GNS client connection handle");
+	std::unique_lock lock(activeClientsMtx_);
 	activeClients_[conn->connectionHandle()] = conn;
 }
 
@@ -341,10 +351,16 @@ void GNSConnectionProvider::disposeConnectionImpl(HSteamNetConnection hConn)
 	{
 		return;
 	}
+	std::unique_lock lock(activeClientsMtx_);
 	const auto connIt = activeClients_.find(hConn);
 	if (connIt != activeClients_.end())
 	{
 		GNSClientConnection* conn = connIt->second;
+		// Remove this connection handle from active clients list
+		activeClients_.erase(connIt);
+		// No more need to hold the lock since the connection is not visible anymore
+		lock.unlock();
+
 		if (conn)
 		{
 			// Remove any pending writes for this connection
@@ -361,8 +377,6 @@ void GNSConnectionProvider::disposeConnectionImpl(HSteamNetConnection hConn)
 			// This call renders the current connection object invalid!
 			conn->expireConnectionHandle();
 		}
-		// Remove this connection handle from active clients list
-		activeClients_.erase(connIt);
 	}
 	// Close the internal GNS connection handle
 	networkInterface_->CloseConnection(hConn, 0, nullptr, true);

--- a/lib/netplay/gns/gns_connection_provider.h
+++ b/lib/netplay/gns/gns_connection_provider.h
@@ -25,6 +25,7 @@
 
 #include <stdint.h>
 #include <memory>
+#include <mutex>
 #include <string>
 #include <unordered_map>
 #include <utility>
@@ -112,6 +113,7 @@ private:
 	std::vector<SteamNetworkingConfigValue_t> listenSocketOpts_;
 	std::vector<SteamNetworkingConfigValue_t> clientConnOpts_;
 	std::unique_ptr<IAddressResolver> addressResolver_;
+	std::mutex activeClientsMtx_;
 };
 
-} // namespace tcp
+} // namespace gns


### PR DESCRIPTION
`activeClients_` map may be updated from several threads, so make sure we don't do unprotected accesses to it.

No performance problems are expected, since this map is only used when initiating/terminating connections, hence these code paths shouldn't be exercised while a game session is in progress.