### PR TITLE
Add hostAutoLagKickAggressiveness config value

### DIFF
--- a/src/configuration.cpp
+++ b/src/configuration.cpp
@@ -626,6 +626,7 @@ bool loadConfig()
 		pie_EnableFog(false);
 	}
 	war_setAutoLagKickSeconds(iniGetInteger("hostAutoLagKickSeconds", war_getAutoLagKickSeconds()).value());
+	war_setAutoLagKickAggressiveness(iniGetInteger("hostAutoLagKickAggressiveness", war_getAutoLagKickAggressiveness()).value());
 	war_setAutoDesyncKickSeconds(iniGetInteger("hostAutoDesyncKickSeconds", war_getAutoDesyncKickSeconds()).value());
 	war_setAutoNotReadyKickSeconds(iniGetInteger("hostAutoNotReadyKickSeconds", war_getAutoNotReadyKickSeconds()).value());
 	war_setDisableReplayRecording(iniGetBool("disableReplayRecord", war_getDisableReplayRecording()).value());

--- a/src/multiplay.cpp
+++ b/src/multiplay.cpp
@@ -135,6 +135,7 @@ void autoLagKickRoutine(std::chrono::steady_clock::time_point now)
 	{
 		return;
 	}
+	int LagKickAggressiveness = std::max<int>(war_getAutoLagKickAggressiveness(), 1);
 
 	if (std::chrono::duration_cast<std::chrono::milliseconds>(now - ingame.lastLagCheck) < LagCheckInterval)
 	{
@@ -215,8 +216,10 @@ void autoLagKickRoutine(std::chrono::steady_clock::time_point now)
 			continue;
 		}
 
-		ingame.LagCounter[i]++;
-		if (ingame.LagCounter[i] >= LagAutoKickSeconds) {
+		ingame.LagCounter[i] += LagKickAggressiveness;
+		int LagSecondsCount = ingame.LagCounter[i] / LagKickAggressiveness;
+
+		if (LagSecondsCount >= LagAutoKickSeconds) {
 			std::string msg = astringf("Auto-kicking player %" PRIu32 " (\"%s\") because of ping issues. (Timeout: %u seconds)", i, getPlayerName(i, true), LagAutoKickSeconds);
 			debug(LOG_INFO, "%s", msg.c_str());
 			sendInGameSystemMessage(msg.c_str());
@@ -228,13 +231,13 @@ void autoLagKickRoutine(std::chrono::steady_clock::time_point now)
 			kickPlayer(i, "Your connection was too laggy.", ERROR_CONNECTION, false);
 			ingame.LagCounter[i] = 0;
 		}
-		else if (ingame.LagCounter[i] >= (LagAutoKickSeconds - 3)) {
-			std::string msg = astringf("Auto-kicking player %" PRIu32 " (\"%s\") in %u seconds. (lag)", i, getPlayerName(i, true), (LagAutoKickSeconds - ingame.LagCounter[i]));
+		else if (LagSecondsCount >= (LagAutoKickSeconds - 3)) {
+			std::string msg = astringf("Auto-kicking player %" PRIu32 " (\"%s\") in %u seconds. (lag)", i, getPlayerName(i, true), (LagAutoKickSeconds - LagSecondsCount));
 			debug(LOG_INFO, "%s", msg.c_str());
 			sendInGameSystemMessage(msg.c_str());
 		}
-		else if (ingame.LagCounter[i] % 15 == 0) { // every 15 seconds
-			std::string msg = astringf("Auto-kicking player %" PRIu32 " (\"%s\") in %u seconds. (lag)", i, getPlayerName(i, true), (LagAutoKickSeconds - ingame.LagCounter[i]));
+		else if (LagSecondsCount % 15 == 0) { // every 15 seconds
+			std::string msg = astringf("Auto-kicking player %" PRIu32 " (\"%s\") in %u seconds. (lag)", i, getPlayerName(i, true), (LagAutoKickSeconds - LagSecondsCount));
 			debug(LOG_INFO, "%s", msg.c_str());
 			sendInGameSystemMessage(msg.c_str());
 		}

--- a/src/warzoneconfig.cpp
+++ b/src/warzoneconfig.cpp
@@ -75,6 +75,7 @@ struct WARZONE_GLOBALS
 	JS_BACKEND jsBackend = (JS_BACKEND)0;
 	bool autoAdjustDisplayScale = true;
 	int autoLagKickSeconds = 60;
+	int autoLagKickAggressiveness = 3;
 	int autoDesyncKickSeconds = 10;
 	int autoNotReadyKickSeconds = 0;
 	bool disableReplayRecording = false;
@@ -494,6 +495,18 @@ void war_setAutoLagKickSeconds(int seconds)
 		seconds = std::max(seconds, 60);
 	}
 	warGlobs.autoLagKickSeconds = seconds;
+}
+
+int war_getAutoLagKickAggressiveness()
+{
+	return warGlobs.autoLagKickAggressiveness;
+}
+
+void war_setAutoLagKickAggressiveness(int aggressiveness)
+{
+	aggressiveness = std::max(aggressiveness, 1);
+	aggressiveness = std::min(aggressiveness, 10);
+	warGlobs.autoLagKickAggressiveness = aggressiveness;
 }
 
 int war_getAutoDesyncKickSeconds()

--- a/src/warzoneconfig.h
+++ b/src/warzoneconfig.h
@@ -140,6 +140,8 @@ bool war_getAutoAdjustDisplayScale();
 void war_setAutoAdjustDisplayScale(bool autoAdjustDisplayScale);
 int war_getAutoLagKickSeconds();
 void war_setAutoLagKickSeconds(int seconds);
+int war_getAutoLagKickAggressiveness();
+void war_setAutoLagKickAggressiveness(int aggressiveness);
 int war_getAutoDesyncKickSeconds();
 void war_setAutoDesyncKickSeconds(int seconds);
 int war_getAutoNotReadyKickSeconds();


### PR DESCRIPTION
To control how seconds spent lagging are valued versus seconds spent not lagging.

Allows calibrating the auto lag kick for players who are experiencing frequent lag spikes.

(For example, setting `hostAutoLagKickAggressiveness=3` - the default - means that 1 second spent lagging will count 3x as much as 1 second spent not-lagging. Or, in other words, a player will have to _not_ lag for 3 seconds for every 1 second spent lagging to avoid accumulating "lagging" time that eventually leads to an auto-lag kick.)