### PR TITLE
Buffed repair speed for wheels, hover and cyborgs

### DIFF
--- a/data/mp/stats/propulsion.json
+++ b/data/mp/stats/propulsion.json
@@ -33,7 +33,8 @@
 		"turnSpeed": 225,
 		"type": "Legged",
 		"usageClass": "Cyborg",
-		"weight": 50
+		"weight": 50,
+		"repairFactor": 125
 	},
 	"HalfTrack": {
 		"buildPoints": 75,
@@ -108,7 +109,8 @@
 		"skidDeceleration": 120,
 		"speed": 300,
 		"type": "Hover",
-		"weight": 200
+		"weight": 200,
+		"repairFactor": 150
 	},
 	"tracked01": {
 		"buildPoints": 125,
@@ -134,6 +136,7 @@
 		"skidDeceleration": 350,
 		"speed": 175,
 		"type": "Wheeled",
-		"weight": 300
+		"weight": 300,
+		"repairFactor": 200
 	}
 }

--- a/lib/framework/math_ext.h
+++ b/lib/framework/math_ext.h
@@ -111,6 +111,13 @@ static inline WZ_DECL_CONST T clip(T x, T min, T max)
 	return x < min ? min : x > max ? max : x;
 }
 
+template <typename T>
+static inline WZ_DECL_CONST T idiv_round(T numerator, T denominator)
+{
+	return ((numerator < 0) == (denominator < 0))
+		? ((numerator + denominator / 2) / denominator)
+		: ((numerator - denominator / 2) / denominator);
+}
 
 /*!
  * Clips x to boundaries

--- a/src/droid.cpp
+++ b/src/droid.cpp
@@ -1527,6 +1527,8 @@ static bool droidUpdateDroidRepairBase(DROID *psRepairDroid, DROID *psDroidToRep
 
 	int iPointsToAdd = gameTimeAdjustedAverage(iRepairRateNumerator, iRepairRateDenominator);
 
+	iPointsToAdd = idiv_round<int>(iPointsToAdd * psDroidToRepair->getPropulsionStats()->repairFactor, 100);
+
 	psDroidToRepair->body = clip<UDWORD>(psDroidToRepair->body + iPointsToAdd, 0, psDroidToRepair->originalBody);
 
 	/* add plasma repair effect whilst being repaired */

--- a/src/stats.cpp
+++ b/src/stats.cpp
@@ -844,6 +844,7 @@ bool loadPropulsionStats(WzConfig &ini)
 		psStats->acceleration = ini.value("acceleration", 250).toInt();
 		ASSERT(psStats->acceleration != 0, "\"%s\".\"acceleration\" is 0", psStats->id.toUtf8().c_str());
 		psStats->deceleration = ini.value("deceleration", 800).toInt();
+		psStats->repairFactor = ini.value("repairFactor", 100).toInt();
 		psStats->skidDeceleration = ini.value("skidDeceleration", 600).toInt();
 		psStats->pIMD = nullptr;
 		psStats->pIMD = statsGetIMD(ini, psStats, "model");

--- a/src/statsdef.h
+++ b/src/statsdef.h
@@ -338,6 +338,7 @@ struct PROPULSION_STATS : public COMPONENT_STATS
 	unsigned skidDeceleration = 0;
 	unsigned deceleration = 0;
 	unsigned acceleration = 0;
+	unsigned repairFactor = 0;
 
 	struct UPGRADE : COMPONENT_STATS::UPGRADE
 	{


### PR DESCRIPTION
Rebased version of: https://github.com/Warzone2100/warzone2100/pull/3705

Added the repairFactor field to propulsion. The idea is to increase the usefulness of wheels and hover in the game, at least in terms of repair speed.

If hover has some situational application, then wheels are hardly ever used.