### PR TITLE
Share more host options with clients (so clients can display the state)

### DIFF
--- a/lib/netplay/netplay.cpp
+++ b/lib/netplay/netplay.cpp
@@ -2798,9 +2798,9 @@ static bool NETprocessSystemMessage(NETQUEUE playerQueue, uint8_t *type)
 				break;
 			}
 
-			if (NetPlay.isHost && !ingame.hostChatPermissions[player])
+			if (NetPlay.isHost && (!ingame.hostChatPermissions[player] || getLockedOptions().name))
 			{
-				// Name changes are denied when the host has muted a player
+				// Name changes are denied when the host has muted a player (or name changes are locked)
 				// Inform the player that their name is still what it was (resets their local display)
 				if (NetPlay.players[player].allocated)
 				{

--- a/src/multiint.cpp
+++ b/src/multiint.cpp
@@ -1285,7 +1285,7 @@ static bool updatePlayerNameBox()
 	ASSERT_OR_RETURN(false, pNameMultiBut != nullptr, "No player name edit button?");
 
 	const bool isInBlindMode = (game.blindMode != BLIND_MODE::NONE);
-	const bool changesAllowed = ingame.hostChatPermissions[selectedPlayer] && !isInBlindMode;
+	const bool changesAllowed = ingame.hostChatPermissions[selectedPlayer] && !isInBlindMode && !locked.name;
 
 	WzString playerNameTip;
 	if (!isInBlindMode)
@@ -1297,6 +1297,10 @@ static bool updatePlayerNameBox()
 		else if (!ingame.hostChatPermissions[selectedPlayer])
 		{
 			playerNameTip = _("Player Name changes are not allowed when you are muted");
+		}
+		else
+		{
+			playerNameTip = _("Player Name changes are not allowed by the host");
 		}
 	}
 	else
@@ -5530,6 +5534,7 @@ static bool loadMapChallengeSettings(WzConfig& ini)
 		locked.position = ini.value("position", challengeActive).toBool();
 		locked.bases = ini.value("bases", challengeActive).toBool();
 		locked.spectators = ini.value("spectators", challengeActive).toBool();
+		locked.name = ini.value("name", false).toBool();
 	}
 	ini.endGroup();
 

--- a/src/multiint.h
+++ b/src/multiint.h
@@ -90,6 +90,7 @@ struct MultiplayOptionsLocked
 	bool position;
 	bool bases;
 	bool spectators;
+	bool name;
 
 	bool operator==(const MultiplayOptionsLocked& other) const
 	{
@@ -101,7 +102,8 @@ struct MultiplayOptionsLocked
 			&& ai == other.ai
 			&& position == other.position
 			&& bases == other.bases
-			&& spectators == other.spectators;
+			&& spectators == other.spectators
+			&& name == other.name;
 	}
 };
 const MultiplayOptionsLocked& getLockedOptions();

--- a/src/multiopt.cpp
+++ b/src/multiopt.cpp
@@ -827,6 +827,7 @@ static void NETlockedOptions(MessageWriter& w, const MultiplayOptionsLocked& loc
 	NETbool(w, lockedOpts.position);
 	NETbool(w, lockedOpts.bases);
 	NETbool(w, lockedOpts.spectators);
+	NETbool(w, lockedOpts.name);
 }
 
 static void NETlockedOptions(MessageReader &r, MultiplayOptionsLocked& lockedOpts)
@@ -840,6 +841,7 @@ static void NETlockedOptions(MessageReader &r, MultiplayOptionsLocked& lockedOpt
 	NETbool(r, lockedOpts.position);
 	NETbool(r, lockedOpts.bases);
 	NETbool(r, lockedOpts.spectators);
+	NETbool(r, lockedOpts.name);
 }
 
 void sendHostConfig()


### PR DESCRIPTION
For example, a host can configure locked teams or locked positions, but (currently) the clients do not know this - and can request a change via the UI (which the host will then deny).

This PR shares additional host configurations with the clients so they can utilize it when displaying the UI and options