### PR TITLE
netplay: Use shared/weak_ptr for WzConnectionProvider, refactor shutdown handling

### DIFF
--- a/lib/netplay/client_connection.cpp
+++ b/lib/netplay/client_connection.cpp
@@ -29,10 +29,10 @@
 
 IClientConnection::IClientConnection(WzConnectionProvider& connProvider, WzCompressionProvider& compressionProvider, PendingWritesManager& pwm)
 	: selfConnList_({ this }),
-	connProvider_(&connProvider),
+	connProvider_(connProvider.shared_from_this()),
 	compressionProvider_(&compressionProvider),
 	pwm_(&pwm),
-	readAllDescriptorSet_(connProvider_->newDescriptorSet(PollEventType::READABLE))
+	readAllDescriptorSet_(connProvider.newDescriptorSet(PollEventType::READABLE))
 {}
 
 net::result<ssize_t> IClientConnection::readAll(void* buf, size_t size, unsigned timeout)

--- a/lib/netplay/client_connection.h
+++ b/lib/netplay/client_connection.h
@@ -241,7 +241,7 @@ protected:
 	// memory allocations.
 	const std::vector<IClientConnection*> selfConnList_;
 	// Connection provider used to create internal descriptor sets.
-	WzConnectionProvider* connProvider_ = nullptr;
+	std::weak_ptr<WzConnectionProvider> connProvider_;
 	// Compression provider which is used to initialize compression algorithm in `enableCompression()`.
 	WzCompressionProvider* compressionProvider_ = nullptr;
 	// Pending writes manager instance, specific to a particular connection provider,

--- a/lib/netplay/connection_provider_registry.cpp
+++ b/lib/netplay/connection_provider_registry.cpp
@@ -31,14 +31,14 @@ ConnectionProviderRegistry& ConnectionProviderRegistry::Instance()
 	return instance;
 }
 
-WzConnectionProvider& ConnectionProviderRegistry::Get(ConnectionProviderType pt)
+std::shared_ptr<WzConnectionProvider> ConnectionProviderRegistry::Get(ConnectionProviderType pt)
 {
 	const auto it = registeredProviders_.find(pt);
 	if (it == registeredProviders_.end())
 	{
 		throw std::runtime_error("Attempt to get nonexistent connection provider");
 	}
-	return *it->second;
+	return it->second;
 }
 
 bool ConnectionProviderRegistry::IsRegistered(ConnectionProviderType pt) const
@@ -56,11 +56,11 @@ void ConnectionProviderRegistry::Register(ConnectionProviderType pt)
 	switch (pt)
 	{
 	case ConnectionProviderType::TCP_DIRECT:
-		registeredProviders_.emplace(pt, std::make_unique<tcp::TCPConnectionProvider>());
+		registeredProviders_.emplace(pt, std::make_shared<tcp::TCPConnectionProvider>());
 		break;
 #ifdef WZ_GNS_NETWORK_BACKEND_ENABLED
 	case ConnectionProviderType::GNS_DIRECT:
-		registeredProviders_.emplace(pt, std::make_unique<gns::GNSConnectionProvider>());
+		registeredProviders_.emplace(pt, std::make_shared<gns::GNSConnectionProvider>());
 		break;
 #endif
 	default:

--- a/lib/netplay/connection_provider_registry.cpp
+++ b/lib/netplay/connection_provider_registry.cpp
@@ -68,16 +68,11 @@ void ConnectionProviderRegistry::Register(ConnectionProviderType pt)
 	}
 }
 
-void ConnectionProviderRegistry::Deregister(ConnectionProviderType pt)
+void ConnectionProviderRegistry::Shutdown()
 {
-	const auto it = registeredProviders_.find(pt);
-	if (it == registeredProviders_.end())
+	for (auto it : registeredProviders_)
 	{
-		return;
+		it.second->shutdown();
 	}
-	if (it->second)
-	{
-		it->second->shutdown();
-	}
-	registeredProviders_.erase(it);
+	registeredProviders_.clear();
 }

--- a/lib/netplay/connection_provider_registry.h
+++ b/lib/netplay/connection_provider_registry.h
@@ -51,7 +51,8 @@ public:
 	bool IsRegistered(ConnectionProviderType) const;
 
 	void Register(ConnectionProviderType pt);
-	void Deregister(ConnectionProviderType pt);
+
+	void Shutdown();
 
 private:
 

--- a/lib/netplay/connection_provider_registry.h
+++ b/lib/netplay/connection_provider_registry.h
@@ -47,7 +47,7 @@ public:
 
 	static ConnectionProviderRegistry& Instance();
 
-	WzConnectionProvider& Get(ConnectionProviderType pt);
+	std::shared_ptr<WzConnectionProvider> Get(ConnectionProviderType pt);
 	bool IsRegistered(ConnectionProviderType) const;
 
 	void Register(ConnectionProviderType pt);
@@ -59,5 +59,5 @@ private:
 	ConnectionProviderRegistry(const ConnectionProviderRegistry&) = delete;
 	ConnectionProviderRegistry(ConnectionProviderRegistry&&) = delete;
 
-	std::unordered_map<ConnectionProviderType, std::unique_ptr<WzConnectionProvider>> registeredProviders_;
+	std::unordered_map<ConnectionProviderType, std::shared_ptr<WzConnectionProvider>> registeredProviders_;
 };

--- a/lib/netplay/gns/gns_connection_provider.cpp
+++ b/lib/netplay/gns/gns_connection_provider.cpp
@@ -86,6 +86,8 @@ static GNSConnectionProvider* activeServer = nullptr;
 
 void GNSConnectionProvider::initialize()
 {
+	if (initialized_) { return; }
+
 	std::call_once(gnsInitFlag, []()
 	{
 		SteamDatagramErrMsg errMsg;
@@ -99,6 +101,8 @@ void GNSConnectionProvider::initialize()
 	{
 		throw std::runtime_error("Failed to initialize GNS network interface");
 	}
+
+	initialized_ = true;
 
 	addressResolver_ = std::make_unique<tcp::TCPAddressResolver>();
 
@@ -148,6 +152,8 @@ void GNSConnectionProvider::initialize()
 
 void GNSConnectionProvider::shutdown()
 {
+	if (!initialized_) { return; }
+	initialized_ = false;
 	addressResolver_.reset();
 	activeServer = nullptr;
 }

--- a/lib/netplay/gns/gns_connection_provider.h
+++ b/lib/netplay/gns/gns_connection_provider.h
@@ -107,6 +107,7 @@ private:
 	// will be left in an invalid state (that is, `isValid()` will become `false`).
 	void disposeConnectionImpl(HSteamNetConnection hConn);
 
+	bool initialized_ = false;
 	ISteamNetworkingSockets* networkInterface_ = nullptr;
 	std::unordered_map<HSteamNetConnection, GNSClientConnection*> activeClients_;
 	std::pair<HSteamListenSocket, GNSListenSocket*> activeListenSocket_ = { k_HSteamListenSocket_Invalid, nullptr };

--- a/lib/netplay/netplay.cpp
+++ b/lib/netplay/netplay.cpp
@@ -1687,7 +1687,7 @@ int NETinit(ConnectionProviderType pt)
 }
 
 // ////////////////////////////////////////////////////////////////////////
-// SHUTDOWN THE CONNECTION.
+// shutdown state related to the active connection
 int NETshutdown()
 {
 	debug(LOG_NET, "NETshutdown");
@@ -1702,14 +1702,7 @@ int NETshutdown()
 	NetPlay.MOTD.clear();
 	NETdeleteQueue();
 
-	auto& cpr = ConnectionProviderRegistry::Instance();
-	if (activeConnProvider && cpr.IsRegistered(activeConnProvider->type()))
-	{
-		const auto cpType = activeConnProvider->type();
-		PendingWritesManagerMap::instance().get(cpType).deinitialize();
-		cpr.Deregister(cpType);
-		activeConnProvider = nullptr;
-	}
+	activeConnProvider = nullptr;
 
 	// Reset net usage statistics.
 	nStats = nZeroStats;
@@ -1717,6 +1710,17 @@ int NETshutdown()
 	nStatsSecondLastSec = nZeroStats;
 
 	return 0;
+}
+
+// ////////////////////////////////////////////////////////////////////////
+// shutdown netplay (to be called at app shutdown only)
+bool netplayShutDown()
+{
+	NETshutdown();
+
+	PendingWritesManagerMap::instance().Shutdown();
+	ConnectionProviderRegistry::Instance().Shutdown();
+	return true;
 }
 
 // ////////////////////////////////////////////////////////////////////////

--- a/lib/netplay/netplay.h
+++ b/lib/netplay/netplay.h
@@ -450,8 +450,8 @@ bool NETsetGameFlags(UDWORD flag, SDWORD value);	// set game flag(1-4) to value.
 bool NEThaltJoining();				// stop new players joining this game
 
 class WzConnectionProvider;
-WzConnectionProvider* NET_getLobbyConnectionProvider();
-bool NETenumerateGames(WzConnectionProvider* connProvider, const std::function<bool (const GAMESTRUCT& game)>& handleEnumerateGameFunc, const std::function<void(std::string&& lobbyMOTD)>& lobbyMotdFunc = nullptr);
+std::shared_ptr<WzConnectionProvider> NET_getLobbyConnectionProvider();
+bool NETenumerateGames(const std::shared_ptr<WzConnectionProvider>& connProvider, const std::function<bool (const GAMESTRUCT& game)>& handleEnumerateGameFunc, const std::function<void(std::string&& lobbyMOTD)>& lobbyMotdFunc = nullptr);
 bool NETfindGames(std::vector<GAMESTRUCT>& results, std::string& lobbyMOTD, size_t startingIndex, size_t resultsLimit, bool onlyMatchingLocalVersion = false);
 bool NETfindGame(uint32_t gameId, GAMESTRUCT& output);
 

--- a/lib/netplay/netplay.h
+++ b/lib/netplay/netplay.h
@@ -376,6 +376,8 @@ unsigned NETgetDownloadProgress(unsigned player);     ///< Returns 100 when done
 int NETclose();					// close current game
 int NETshutdown();					// leave the game in play.
 
+bool netplayShutDown();
+
 void NETaddRedirects();
 void NETremRedirects();
 /// Initializes the port mapping infrastructure and spawns a background thread,

--- a/lib/netplay/pending_writes_manager.cpp
+++ b/lib/netplay/pending_writes_manager.cpp
@@ -218,7 +218,14 @@ void PendingWritesManager::safeDispose(IClientConnection* conn)
 		else
 		{
 			// Notify the owning connection provider to properly dispose of the connection object.
-			conn->connProvider_->disposeConnection(conn);
+			if (auto connProvider = conn->connProvider_.lock())
+			{
+				connProvider->disposeConnection(conn);
+			}
+			else
+			{
+				ASSERT(false, "IClientConnection::connProvider_ has gone away before safeDispose!");
+			}
 			// Delete the socket and destroy the connection right away.
 			delete conn;
 		}

--- a/lib/netplay/pending_writes_manager_map.cpp
+++ b/lib/netplay/pending_writes_manager_map.cpp
@@ -51,3 +51,12 @@ PendingWritesManager& PendingWritesManagerMap::get(const WzConnectionProvider& c
 {
 	return get(connProvider.type());
 }
+
+void PendingWritesManagerMap::Shutdown()
+{
+	for (auto& it : pendingWritesManagers_)
+	{
+		it.second->deinitialize();
+	}
+	pendingWritesManagers_.clear();
+}

--- a/lib/netplay/pending_writes_manager_map.cpp
+++ b/lib/netplay/pending_writes_manager_map.cpp
@@ -39,9 +39,10 @@ PendingWritesManager& PendingWritesManagerMap::get(ConnectionProviderType pt)
 	{
 		return *it->second;
 	}
-	auto& connProvider = cpr.Get(pt);
+	auto connProvider = cpr.Get(pt);
+	ASSERT(connProvider != nullptr, "Null connection provider");
 	auto pwm = std::make_unique<PendingWritesManager>();
-	pwm->initialize(connProvider);
+	pwm->initialize(*connProvider);
 	it = pendingWritesManagers_.emplace(pt, std::move(pwm)).first;
 	return *it->second;
 }

--- a/lib/netplay/pending_writes_manager_map.h
+++ b/lib/netplay/pending_writes_manager_map.h
@@ -51,6 +51,8 @@ public:
 	PendingWritesManager& get(ConnectionProviderType pt);
 	PendingWritesManager& get(const WzConnectionProvider& connProvider);
 
+	void Shutdown();
+
 private:
 
 	explicit PendingWritesManagerMap() = default;

--- a/lib/netplay/tcp/tcp_client_connection.cpp
+++ b/lib/netplay/tcp/tcp_client_connection.cpp
@@ -33,7 +33,7 @@ namespace tcp
 TCPClientConnection::TCPClientConnection(WzConnectionProvider& connProvider, WzCompressionProvider& compressionProvider, PendingWritesManager& pwm, Socket* rawSocket)
 	: IClientConnection(connProvider, compressionProvider, pwm),
 	socket_(rawSocket),
-	connStatusDescriptorSet_(connProvider_->newDescriptorSet(PollEventType::READABLE))
+	connStatusDescriptorSet_(connProvider.newDescriptorSet(PollEventType::READABLE))
 {
 	ASSERT(socket_ != nullptr, "Null socket passed to TCPClientConnection ctor");
 }

--- a/lib/netplay/wz_connection_provider.h
+++ b/lib/netplay/wz_connection_provider.h
@@ -54,7 +54,7 @@ using PortMappingInternetProtocolMask = std::underlying_type_t<PortMappingIntern
 /// 4. Opening client-side connections (sync and async).
 /// 5. Creating connection poll groups.
 /// </summary>
-class WzConnectionProvider
+class WzConnectionProvider : public std::enable_shared_from_this<WzConnectionProvider>
 {
 public:
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1166,7 +1166,7 @@ void systemShutdown()
 	frameShutDown();	// close screen / SDL / resources / cursors / trig
 	screenShutDown();
 	shutdownLobbyBrowserFetches();
-	NETshutdown();		// MUST come after widgShutDown (as widget screens might have connections, etc)
+	netplayShutDown();	// MUST come after widgShutDown (as widget screens might have connections, etc)
 	gfx_api::context::get().shutdown();
 	cleanSearchPath();	// clean PHYSFS search paths
 	debug_exit();		// cleanup debug routines

--- a/src/multiopt.cpp
+++ b/src/multiopt.cpp
@@ -526,6 +526,9 @@ bool sendLeavingMsg()
 // called in Init.c to shutdown the whole netgame gubbins.
 bool multiShutdown()
 {
+	debug(LOG_MAIN, "shutting down networking");
+	NETshutdown();
+
 	debug(LOG_MAIN, "free game data (structure limits)");
 	ingame.structureLimits.clear();
 

--- a/src/screens/joiningscreen.cpp
+++ b/src/screens/joiningscreen.cpp
@@ -1237,8 +1237,8 @@ void WzJoiningGameScreen_HandlerRoot::processOpenConnectionResult(size_t connect
 		return;
 	}
 
-	auto& connProvider = ConnectionProviderRegistry::Instance().Get(toConnectionProviderType(connectionList[connectionIdx].type));
-	tmp_joining_socket_set = connProvider.newConnectionPollGroup();
+	auto connProvider = ConnectionProviderRegistry::Instance().Get(toConnectionProviderType(connectionList[connectionIdx].type));
+	tmp_joining_socket_set = connProvider->newConnectionPollGroup();
 	if (tmp_joining_socket_set == nullptr)
 	{
 		debug(LOG_ERROR, "Cannot create socket set - out of memory?");
@@ -1290,8 +1290,8 @@ void WzJoiningGameScreen_HandlerRoot::attemptToOpenConnection(size_t connectionI
 
 	const auto ct = toConnectionProviderType(description.type);
 	NETinit(ct);
-	auto& connProvider = ConnectionProviderRegistry::Instance().Get(ct);
-	connProvider.openClientConnectionAsync(description.host, description.port, CLIENT_OPEN_ASYNC_TIMEOUT,
+	auto connProvider = ConnectionProviderRegistry::Instance().Get(ct);
+	connProvider->openClientConnectionAsync(description.host, description.port, CLIENT_OPEN_ASYNC_TIMEOUT,
 		[weakSelf, connectionIdx](OpenConnectionResult&& result) {
 		auto strongSelf = weakSelf.lock();
 		if (!strongSelf)

--- a/src/titleui/widgets/gamebrowserform.cpp
+++ b/src/titleui/widgets/gamebrowserform.cpp
@@ -793,7 +793,7 @@ public:
 	size_t startingIndex = 0;
 	size_t resultsLimit = 100;
 	bool onlyMatchingLocalVersion = false;
-	WzConnectionProvider* connProvider = nullptr;
+	std::shared_ptr<WzConnectionProvider> connProvider = nullptr;
 	CompletionHandlerFunc completionHandler;
 };
 


### PR DESCRIPTION
Resolves some edge cases where the `WzConnectionProvider` could potentially be used after it had been deinitialized / became invalid (example: in background asynchronous attempts to open a connection, which might be blocked pending a network call result).

This PR includes two main approaches to fixing the problem + defense-in-depth changes:

1. Use `shared_ptr`/`weak_ptr` for some important cases where we want to ensure the `WzConnectionProvider` stays around (or we want to be able to tell if it's still around).
2. Refactor `NETshutdown()`, and only shutdown the `PendingWritesManagerMap`/`ConnectionProviderRegistry` at `systemShutdown()`. This ensures that, once created, `WzConnectionProvider`s (etc) stick around until shutdown (instead of potentially creating and destroying them for each connection attempt - ex. when joining a game).