### PR TITLE
Call countUpdate() at init, not unsynchronized at top of gameLoop()

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1807,6 +1807,9 @@ bool stageThreeInitialise()
 		}
 	}
 
+	// Call once again to update counts (if modified by earlier wzapi events)
+	countUpdate(false);
+
 	return true;
 }
 

--- a/src/loop.cpp
+++ b/src/loop.cpp
@@ -643,9 +643,6 @@ GAMECODE gameLoop()
 	static size_t numForcedUpdatesLastCall = 0;
 	static bool previousUpdateWasRender = false;
 
-	// Shouldn't this be when initialising the game, rather than randomly called between ticks?
-	countUpdate(false); // kick off with correct counts
-
 	size_t numRegularUpdatesTicks = 0;
 	size_t numFastForwardTicks = 0;
 	gameTimeUpdateBegin();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -853,6 +853,9 @@ static bool startGameLoop()
 	executeFnAndProcessScriptQueuedRemovals([]() { triggerEvent(TRIGGER_START_LEVEL); });
 	screen_disableMapPreview();
 
+	// Call once again to update starting counts (if modified by TRIGGER_START_LEVEL event)
+	countUpdate(false);
+
 	if (!bMultiPlayer && getCamTweakOption_AutosavesOnly())
 	{
 		forcedAutosaveTime = gameTime + 1000; //Really just to prevent Intel videos messages from not getting saved if run immediately.


### PR DESCRIPTION
Hopefully fixes a rare single-tick desync where the symptoms are:
- The only differences in the sync logs are: `[adjustDroidCount] numDroids[%d]:%d=%d→%d` lines, where (clearly) the starting count number for the player differs
- Yet the `[countUpdate] counts[%d]` log-lines at the end of the tick match exactly among all clients
- (i.e. all clients agree on the counts at the end of the problem tick, _and_ agreed on the counts at the end of the *prior* tick - which didn't cause a desync - so they got updated in-between only on some clients)

Synchronized `countUpdate` calls still occur at the end of `gameStateUpdate`