### PR TITLE
buildMapList: Adjust log levels

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1022,14 +1022,14 @@ bool buildMapList(bool campaignOnly)
 		auto mapZipIO = WzMapZipIO::openZipArchiveReadIOProvider(zipReadSource, debugLoggerInstance.get());
 		if (!mapZipIO)
 		{
-			debug(LOG_POPUP, "Failed to open archive: %s.\nPlease delete or move the file specified.", realFilePathAndName.c_str());
+			debug(LOG_INFO, "Failed to open archive: %s.\nPlease delete or move the file specified.", realFilePathAndName.c_str());
 			continue;
 		}
 		debugLoggerInstance->setLogErrors(false);
 		auto mapPackage = WzMap::MapPackage::loadPackage("", debugLoggerInstance, mapZipIO);
 		if (!mapPackage)
 		{
-			debug(LOG_POPUP, "Failed to load %s.\nPlease delete or move the file specified.", realFilePathAndName.c_str());
+			debug(LOG_INFO, "Failed to load %s.\nPlease delete or move the file specified.", realFilePathAndName.c_str());
 			continue;
 		}
 


### PR DESCRIPTION
Avoid `LOG_POPUP`, as this can occur frequently (during first load and otherwise) and we don't want to spam the user with popups