### PR TITLE
Improve campaign coordinate generators

### DIFF
--- a/data/base/script/campaign/cam2-1x.js
+++ b/data/base/script/campaign/cam2-1x.js
@@ -53,10 +53,11 @@ camAreaEvent("crashSite", function(droid)
 
 function insaneReinforcementSpawn()
 {
+	const SCAN_DISTANCE = 2; // Skyscrapers are close to some edges.
 	const DISTANCE_FROM_POS = 25;
 	const units = [cTempl.commc, cTempl.commrl, cTempl.commrp, cTempl.npcybc];
 	const limits = {minimum: 2, maxRandom: 2};
-	const location = camGenerateRandomMapEdgeCoordinate(getObject("startingPosition"), CAM_GENERIC_LAND_STAT, DISTANCE_FROM_POS);
+	const location = camGenerateRandomMapEdgeCoordinate(getObject("startingPosition"), CAM_GENERIC_LAND_STAT, DISTANCE_FROM_POS, SCAN_DISTANCE);
 	camSendGenericSpawn(CAM_REINFORCE_GROUND, CAM_THE_COLLECTIVE, CAM_REINFORCE_CONDITION_BASES, location, units, limits.minimum, limits.maxRandom);
 }
 

--- a/data/base/script/campaign/cam2-2.js
+++ b/data/base/script/campaign/cam2-2.js
@@ -142,11 +142,12 @@ function vtolAttack()
 
 function insaneReinforcementSpawn()
 {
+	const SCAN_DISTANCE = 2;
 	const DISTANCE_FROM_POS = 30;
 	const USE_WEST_SPAWN = (camRand(100) < 20);
 	const units = (USE_WEST_SPAWN) ? [cTempl.cohct, cTempl.comtathh, cTempl.comorb, cTempl.cohhch, cTempl.comtath] : [cTempl.cohhch, cTempl.comtath];
 	const limits = {minimum: 6, maxRandom: 5};
-	const location = (USE_WEST_SPAWN) ? camMakePos(getObject("westSpawnPos")) : camGenerateRandomMapEdgeCoordinate(getObject("startPosition"), CAM_GENERIC_WATER_STAT, DISTANCE_FROM_POS);
+	const location = (USE_WEST_SPAWN) ? camMakePos(getObject("westSpawnPos")) : camGenerateRandomMapEdgeCoordinate(getObject("startPosition"), CAM_GENERIC_WATER_STAT, DISTANCE_FROM_POS, SCAN_DISTANCE);
 	camSendGenericSpawn(CAM_REINFORCE_GROUND, CAM_THE_COLLECTIVE, CAM_REINFORCE_CONDITION_BASES, location, units, limits.minimum, limits.maxRandom);
 }
 

--- a/data/base/script/campaign/cam2-5.js
+++ b/data/base/script/campaign/cam2-5.js
@@ -150,10 +150,11 @@ function insaneVtolAttack()
 
 function insaneReinforcementSpawn()
 {
+	const SCAN_DISTANCE = 2;
 	const DISTANCE_FROM_POS = 30;
 	const units = [cTempl.comltath, cTempl.cohhvch, cTempl.comagh];
 	const limits = {minimum: 4, maxRandom: 2};
-	const location = camGenerateRandomMapEdgeCoordinate(getObject("startPosition"), CAM_GENERIC_WATER_STAT, DISTANCE_FROM_POS);
+	const location = camGenerateRandomMapEdgeCoordinate(getObject("startPosition"), CAM_GENERIC_WATER_STAT, DISTANCE_FROM_POS, SCAN_DISTANCE);
 	camSendGenericSpawn(CAM_REINFORCE_GROUND, CAM_THE_COLLECTIVE, CAM_REINFORCE_CONDITION_ARTIFACTS, location, units, limits.minimum, limits.maxRandom);
 }
 

--- a/data/base/script/campaign/cam2-8.js
+++ b/data/base/script/campaign/cam2-8.js
@@ -142,10 +142,11 @@ function insaneVtolAttack()
 
 function insaneReinforcementSpawn()
 {
+	const SCAN_DISTANCE = 1;
 	const DISTANCE_FROM_POS = 25;
 	const units = [cTempl.cohhvch, cTempl.comagh, cTempl.cohach, cTempl.comltath];
 	const limits = {minimum: 5, maxRandom: 3};
-	const location = camGenerateRandomMapEdgeCoordinate(getObject("startPosition"), CAM_GENERIC_WATER_STAT, DISTANCE_FROM_POS);
+	const location = camGenerateRandomMapEdgeCoordinate(getObject("startPosition"), CAM_GENERIC_WATER_STAT, DISTANCE_FROM_POS, SCAN_DISTANCE);
 	camSendGenericSpawn(CAM_REINFORCE_GROUND, CAM_THE_COLLECTIVE, CAM_REINFORCE_CONDITION_ARTIFACTS, location, units, limits.minimum, limits.maxRandom);
 }
 

--- a/doc/js-campaign.md
+++ b/doc/js-campaign.md
@@ -328,14 +328,38 @@ Break alliances between all players.
 
 @returns {void}
 
-## camGenerateRandomMapEdgeCoordinate(reachPosition [, propulsion [, distFromReach]])
+## camIsWaterPropulsion(propulsion)
+
+Check if a propulsion can traverse water tiles. Until the Stats object can tell us this
+information, it simply uses a very basic name check against the default hover propulsions.
+
+@param {String} propulsion
+@returns {Boolean}
+
+## camNearInaccessibleAreas(start, destination [, propulsion [, distance]])
+
+Determine if a start position can reach a destination position within the limits of
+the chosen propulsion, and if there are nearby cliffs/water tiles nearby within a certain distance.
+if `destination` is undefined it will cause this function to just scan around the start position.
+
+@param {Object} start
+@param {Object} destination
+@param {String} propulsion
+@param {Number} distance
+@returns {Boolean}
+
+## camGenerateRandomMapEdgeCoordinate(reachPosition [, propulsion [, distFromReach [, scanObjectRadius]]])
 
 Returns a random coordinate anywhere on the edge of the map that reaches a position.
-`reachPosition` may be undefined if you just want a random edge coordinate.
+`reachPosition` may be undefined if you just want a random edge coordinate, without object scans.
+Which can be useful for spawning transporter entry/exit points or VTOL spawn positions.
+`scanObjectRadius` may be defined to scan possible spawn points for nearby objects,
+and should be above one tile if there are large skyscrapers at the edges of some maps.
 
 @param {Object} reachPosition
 @param {String} propulsion
 @param {Number} distFromReach
+@param {Number} scanObjectRadius
 @returns {Object}
 
 ## camGenerateRandomMapCoordinate(reachPosition [, propulsion [, distFromReach [, scanObjectRadius, [, avoidNearbyCliffs]]]])


### PR DESCRIPTION
As Alfred was playing his Insane+ run, he ran into an instance of randomized map edge position tank spawns being trapped in a southern pit in both Beta 2 and Beta 7. This prevents this from happening by adding tile type checks for cliffs and water tiles (for non-hover) as `propulsionCanReach()` is seemingly not very good at truly determining if something can move from point A to B in the presence of some partial cliff/water tiles. Additionally, threw in a check to scan map edges for objects (mostly for skyscrapers) on some maps that have them very close to potential spawn points (and potentially trapping them) as I saw on Beta 2 while simulating many spawns.