### PR TITLE
Added Build Support for Debian / Raspberry Pi OS

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ the “Warzone 2100 Project”.
 
 After the liberation of the Warzone 2100 source-code on December 6th, 2004, all
 proprietary technologies have been replaced with open-source counterparts, and
-extensive improvements and additions have been made throughout while preserving 
+extensive improvements and additions have been made throughout while preserving
 what made the original release so great.
 
 Development continues on GitHub, and bug reports & contributions are welcome!
@@ -259,7 +259,7 @@ Do **not** use GitHub's "Download Zip" option, as it **does not contain submodul
    * To build with Vulkan support: the full [Vulkan SDK](https://vulkan.lunarg.com/sdk/home) _(strongly recommended: ≥ 1.2.148.1)_
 * **Installing prerequisites:**
    * Using `get-dependencies_linux.sh`:
-      1. Specify one of the linux distros supported by the script: (`ubuntu`, `fedora`, `alpine`, `archlinux`, `opensuse-tumbleweed`) _REQUIRED_
+      1. Specify one of the linux distros supported by the script: (`ubuntu`, `fedora`, `alpine`, `archlinux`, `opensuse-tumbleweed`, `gentoo`, `debian`, `raspberrypios`) _REQUIRED_
       2. Specify a mode: (`build-all` (default), `build-dependencies`) _OPTIONAL_
 
       Example:


### PR DESCRIPTION
Adds support for building on Debian / Raspberry Pi OS.

Confirmed working on a Raspberry Pi 500+, this is the 16GB model of the Pi 500. During compiling, the system never got above 60C and never used more than 6GB of RAM. The whole compile process took around 25 minutes. This does not include Vulkan support as of yet, but it's a good base. Running with the Classic video settings the system gets 80FPS. In the modern settings, we get around 18FPS. I think Vulkan would massively help here.