### PR TITLE
Remove hardcoded cyborg movement sound

### DIFF
--- a/data/base/stats/propulsionsounds.json
+++ b/data/base/stats/propulsionsounds.json
@@ -15,6 +15,14 @@
 		"szShutDown": "hovstop.ogg",
 		"szStart": "hovstart.ogg"
 	},
+	"Legged": {
+		"szHiss": -1,
+		"szIdle": -1,
+		"szMove": "cyber-move.ogg",
+		"szMoveOff": -1,
+		"szShutDown": -1,
+		"szStart": -1
+	},
 	"Lift": {
 		"szHiss": -1,
 		"szIdle": -1,

--- a/data/mp/stats/propulsionsounds.json
+++ b/data/mp/stats/propulsionsounds.json
@@ -15,6 +15,14 @@
 		"szShutDown": "hovstop.ogg",
 		"szStart": "hovstart.ogg"
 	},
+	"Legged": {
+		"szHiss": -1,
+		"szIdle": -1,
+		"szMove": "cyber-move.ogg",
+		"szMoveOff": -1,
+		"szShutDown": -1,
+		"szStart": -1
+	},
 	"Lift": {
 		"szHiss": -1,
 		"szIdle": -1,

--- a/src/move.cpp
+++ b/src/move.cpp
@@ -2068,7 +2068,7 @@ static void movePlayDroidMoveAudio(DROID *psDroid)
 		{
 			iAudioID = ID_SOUND_BLIMP_FLIGHT;
 		}
-		else if (iPropType == PROPULSION_TYPE_LEGGED && psDroid->isCyborg())
+		else if (iPropType == PROPULSION_TYPE_LEGGED && psDroid->isCyborg() && psPropType->moveID == NO_SOUND)
 		{
 			iAudioID = ID_SOUND_CYBORG_MOVE;
 		}


### PR DESCRIPTION
Raptor wanted to change the cyborg movement sound, though when I took a look at the source... I saw it always used "cyber-move.ogg". Probably overlooked at some point as propulsionsounds.json can easily override it to whatever else someone wants.

As a bonus this makes it easier to introduce Super Cyborg movement sounds later, if we make a specific propulsion type for it. We can just as easily hardcode that in the mean time until then of course.

---

The movement sound will default to cyber-move.ogg if not initialized by propulsionsounds.json.

On another note, Hiss, Idle, and MoveOff seemingly have no triggers in the codebase from what I saw.