### PR TITLE
Fix Turtle AI defense building

### DIFF
--- a/data/mp/multiplay/skirmish/nb_includes/build.js
+++ b/data/mp/multiplay/skirmish/nb_includes/build.js
@@ -301,7 +301,7 @@ function buildModules() {
 }
 
 _global.buildVtols = function() {
-	if (buildMinimum(structures.vtolPads, enumDroid(me, DROID_WEAPON).filter(isVTOL).length), IMPORTANCE.MANDATORY)
+	if (buildMinimum(structures.vtolPads, enumDroid(me, DROID_WEAPON).filter(isVTOL).length, IMPORTANCE.PEACETIME))
 		return true;
 	return false;
 }


### PR DESCRIPTION
Restores the defense building behaviour of Turtle AI (and other Nullbot variants).

Commit 97660b3 inadvertently broke this due to some preexisting misplaced brackets.

I have changed the importance of building VTOL rearming pads to PEACETIME rather than MANDATORY, so that Nullbots won't try to build rearming pads in dangerous areas. This does not affect the number of VTOL rearming pads built.

Here's what a Turtle AI base can look like with the fix.

<img width="1661" height="918" alt="image" src="https://github.com/user-attachments/assets/f9c6736f-f13a-404d-9c42-9d354395d57e" />
