### PR TITLE
Multiplayer balance: Increase Avenger SAM Site hitpoints

### DIFF
--- a/data/mp/stats/structure.json
+++ b/data/mp/stats/structure.json
@@ -2373,14 +2373,14 @@
 		"buildPoints": 350,
 		"buildPower": 275,
 		"height": 2,
-		"hitpoints": 400,
+		"hitpoints": 600,
 		"id": "P0-AASite-SAM1",
 		"name": "Avenger SAM Site",
 		"resistance": 150,
 		"sensorID": "DefaultSensor1Mk1",
 		"strength": "HARD",
 		"structureModel": [
-			"Blaamnt1.PIE"
+			"Blaamnt2.PIE"
 		],
 		"thermal": 10,
 		"type": "DEFENSE",


### PR DESCRIPTION
hitpoints 400 -> 600

(also changes the structure base model to be same as Stormbringer/Vindicator)

---

The `HARD` structure classification is typically meant for heavy concrete structures such as towers, hardpoints, fortresses, etc. The Avenger SAM Site is the only `HARD` AA with a sandbag model. There are 2 ways to resolve this inconsistency/confusion:
1. Make Avenger SAM Site same as Sunburst/Hurricane/Whirlwind
   - 400 hitpoints (no change)
   - `HARD` -> `MEDIUM`

2. Make Avenger SAM Site same as Stormbringer/Vindicator
   - 400 -> 600 hitpoints
   - `HARD` (no change)

This pull request picks option 2