### PR TITLE
Remove validation layers in device create info

### DIFF
--- a/lib/ivis_opengl/gfx_api_vk.cpp
+++ b/lib/ivis_opengl/gfx_api_vk.cpp
@@ -5283,8 +5283,6 @@ bool VkRoot::createLogicalDevice()
 	debug(LOG_3D, "Using device extensions: %s", deviceExtensionsAsString.c_str());
 
 	const auto deviceCreateInfo = vk::DeviceCreateInfo()
-		.setEnabledLayerCount(static_cast<uint32_t>(layers.size()))
-		.setPpEnabledLayerNames(layers.data())
 		.setEnabledExtensionCount(static_cast<uint32_t>(enabledDeviceExtensions.size()))
 		.setPpEnabledExtensionNames(enabledDeviceExtensions.data())
 		.setPEnabledFeatures(&enabledFeatures)


### PR DESCRIPTION
Device layers are deprecated in the newest Vulkan headers[^1]. Trying to set them results in the following error:

    /build/warzone2100/lib/ivis_opengl/gfx_api_vk.cpp: In member function 'bool VkRoot::createLogicalDevice()':
    /build/warzone2100/lib/ivis_opengl/gfx_api_vk.cpp:5286:38: error: 'constexpr vk::DeviceCreateInfo& vk::DeviceCreateInfo::setEnabledLayerCount(uint32_t)' is deprecated: ignored [-Werror=deprecated-declarations]
     5285 |         const auto deviceCreateInfo = vk::DeviceCreateInfo()
          |                                       ~~~~~~~~~~~~~~~~~~~~~~
     5286 |                 .setEnabledLayerCount(static_cast<uint32_t>(layers.size()))
          |                 ~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

[^1]: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-devicelayers