### PR TITLE
Snap: Add workaround for amdgpu.ids issue

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -232,6 +232,8 @@ parts:
     override-prime: |
       craftctl default
       ${CRAFT_PART_SRC}/bin/gpu-2404-cleanup mesa-2404
+      # Workaround for https://bugs.launchpad.net/snapd/+bug/2055273
+      mkdir -p "${CRAFT_PRIME}/gpu-2404"
     # Note: No "prime" part here, as we only use this for cleanup, and rely on the gnome extension to properly stage and setup the gpu-2404-wrapper and the command-chain
 
   # This part removes all the files in this snap which already exist in


### PR DESCRIPTION
As is now recommended by the documentation: https://canonical.com/mir/docs/the-gpu-2404-snap-interface