### PR TITLE
Update js-globals.md - scriptName in playerData objects

### DIFF
--- a/doc/js-globals.md
+++ b/doc/js-globals.md
@@ -76,6 +76,7 @@ containing the following variables:
   * ```isHuman``` whether the player is human (3.2+ only)
   * ```name``` the name of the player (3.2+ only)
   * ```team``` the number of the team the player is part of
+  * ```scriptName``` File name of the AI's JS file. (4.6.2+ only)
 * ```MapTiles``` A two-dimensional array of static information about the map tiles in a game. Each item in MapTiles[y][x] is an object
 containing the following variables:
   * ```terrainType``` (see ```terrainType(x, y)``` function)

--- a/src/wzapi.cpp
+++ b/src/wzapi.cpp
@@ -4707,7 +4707,7 @@ nlohmann::json wzapi::constructStaticPlayerData()
 	//==   * ```isHuman``` whether the player is human (3.2+ only)
 	//==   * ```name``` the name of the player (3.2+ only)
 	//==   * ```team``` the number of the team the player is part of
-	//==   * ```scriptName``` File name of the AI's JS file. (4.6+ only)
+	//==   * ```scriptName``` File name of the AI's JS file. (4.6.2+ only)
 	nlohmann::json playerData = nlohmann::json::array(); //engine->newArray(game.maxPlayers);
 	const auto& aidata = getAIData();
 	for (int i = 0; i < game.maxPlayers; i++)


### PR DESCRIPTION
API was updated in #4647 but not mentioned in docs

> API
>
> * Add scriptName to playerData array, allowing us to see what script this player is using. Helpful if we need to see what exact AI the player is without name translation interference.
