### PR TITLE
wzapi: Add optional `center` param to `fireWeaponAtLoc`

### DIFF
--- a/doc/js-functions.md
+++ b/doc/js-functions.md
@@ -874,11 +874,15 @@ Set or unset an object flag on a given game object. Does not take care of networ
 needs wrapping in a syncRequest. (3.3+ only.)
 Recognized object flags: ```OBJECT_FLAG_UNSELECTABLE``` - makes object unavailable for selection from player UI.
 
-## fireWeaponAtLoc(weaponName, x, y[, player])
+## fireWeaponAtLoc(weaponName, x, y[, player[, center]])
 
 Fires a weapon at the given coordinates (3.3+ only). The player is who owns the projectile.
+
 Please use fireWeaponAtObj() to damage objects as multiplayer and campaign
 may have different friendly fire logic for a few weapons (like the lassat).
+
+The optional ```center``` parameter (4.6.2+ only) can be set to ```true```
+to target the center of the tile. (The default is ```false```.)
 
 ## fireWeaponAtObj(weaponName, gameObject[, player])
 

--- a/src/quickjs_backend.cpp
+++ b/src/quickjs_backend.cpp
@@ -3625,7 +3625,7 @@ bool quickjs_scripting_instance::registerFunctions(const std::string& scriptName
 	JS_REGISTER_FUNC(startTransporterEntry, 3); // WZAPI
 	JS_REGISTER_FUNC(setTransporterExit, 3); // WZAPI
 	JS_REGISTER_FUNC(setObjectFlag, 3); // WZAPI
-	JS_REGISTER_FUNC2(fireWeaponAtLoc, 3, 4); // WZAPI
+	JS_REGISTER_FUNC2(fireWeaponAtLoc, 3, 5); // WZAPI
 	JS_REGISTER_FUNC2(fireWeaponAtObj, 2, 3); // WZAPI
 	JS_REGISTER_FUNC(transformPlayerToSpectator, 1); // WZAPI
 	JS_REGISTER_FUNC(isSpectator, 1); // WZAPI

--- a/src/wzapi.cpp
+++ b/src/wzapi.cpp
@@ -3379,13 +3379,17 @@ wzapi::no_return_value wzapi::setObjectFlag(WZAPI_PARAMS(BASE_OBJECT *psObj, int
 	return {};
 }
 
-//-- ## fireWeaponAtLoc(weaponName, x, y[, player])
+//-- ## fireWeaponAtLoc(weaponName, x, y[, player[, center]])
 //--
 //-- Fires a weapon at the given coordinates (3.3+ only). The player is who owns the projectile.
+//--
 //-- Please use fireWeaponAtObj() to damage objects as multiplayer and campaign
 //-- may have different friendly fire logic for a few weapons (like the lassat).
 //--
-wzapi::no_return_value wzapi::fireWeaponAtLoc(WZAPI_PARAMS(std::string weaponName, int x, int y, optional<int> _player))
+//-- The optional ```center``` parameter (4.6.2+ only) can be set to ```true```
+//-- to target the center of the tile. (The default is ```false```.)
+//--
+wzapi::no_return_value wzapi::fireWeaponAtLoc(WZAPI_PARAMS(std::string weaponName, int x, int y, optional<int> _player, optional<bool> center))
 {
 	int weaponIndex = getCompFromName(COMP_WEAPON, WzString::fromUtf8(weaponName));
 	SCRIPT_ASSERT({}, context, weaponIndex > 0, "No such weapon: %s", weaponName.c_str());
@@ -3396,6 +3400,11 @@ wzapi::no_return_value wzapi::fireWeaponAtLoc(WZAPI_PARAMS(std::string weaponNam
 	Vector3i target;
 	target.x = world_coord(x);
 	target.y = world_coord(y);
+	if (center.value_or(false))
+	{
+		target.x += (TILE_UNITS / 2);
+		target.y += (TILE_UNITS / 2);
+	}
 	target.z = mapTile(x, y)->height;
 
 	WEAPON sWeapon;

--- a/src/wzapi.h
+++ b/src/wzapi.h
@@ -1130,7 +1130,7 @@ namespace wzapi
 	no_return_value startTransporterEntry(WZAPI_PARAMS(int x, int y, int player));
 	no_return_value setTransporterExit(WZAPI_PARAMS(int x, int y, int player));
 	no_return_value setObjectFlag(WZAPI_PARAMS(BASE_OBJECT *psObj, int _flag, bool flagValue)) MULTIPLAY_SYNCREQUEST_REQUIRED;
-	no_return_value fireWeaponAtLoc(WZAPI_PARAMS(std::string weaponName, int x, int y, optional<int> _player));
+	no_return_value fireWeaponAtLoc(WZAPI_PARAMS(std::string weaponName, int x, int y, optional<int> _player, optional<bool> center));
 	no_return_value fireWeaponAtObj(WZAPI_PARAMS(std::string weaponName, BASE_OBJECT *psObj, optional<int> _player));
 	bool setUpgradeStats(WZAPI_BASE_PARAMS(int player, const std::string& name, int type, unsigned index, const nlohmann::json& newValue));
 	nlohmann::json getUpgradeStats(WZAPI_BASE_PARAMS(int player, const std::string& name, int type, unsigned index));


### PR DESCRIPTION
To enable spawning explosions in the center of the tile

Supersedes #4616