### PR TITLE
Fix `[T]hermal` typo under `bbaatow` in `structure.json`

### DIFF
--- a/data/mp/stats/structure.json
+++ b/data/mp/stats/structure.json
@@ -53,7 +53,7 @@
 		"structureModel": [
 			"bbaatower.PIE"
 		],
-		"Thermal": 11,
+		"thermal": 11,
 		"type": "DEFENSE",
 		"weapons": [
 			"bbaawep"


### PR DESCRIPTION
Property names are case sensitive.

Changed `T` to `t` in keeping with all other properties of same name.