### PR TITLE
netplay: Schedule port mapping request callbacks under the mutex

### DIFF
--- a/lib/netplay/port_mapping_manager.cpp
+++ b/lib/netplay/port_mapping_manager.cpp
@@ -361,6 +361,11 @@ void PortMappingManager::scheduleCallbacksOnMainThread(CallbacksPerRequest cbReq
 				}
 			});
 		}
+		else if (cb.first->status() == PortMappingDiscoveryStatus::NOT_STARTED)
+		{
+			// That would probably mean that the request in question has already been cancelled.
+			// Just ignore it and don't schedule any callbacks.
+		}
 		else
 		{
 			ASSERT(false, "Should be unreachable");
@@ -426,10 +431,10 @@ void PortMappingManager::thread_monitor_function()
 					++it;
 				}
 			}
+			// Schedule execution of registered callbacks for all requests, which have already
+			// transitioned to some terminal (either success or failure) state.
+			scheduleCallbacksOnMainThread(std::move(callbacksPerRequest));
 		}
-		// Schedule execution of registered callbacks for all requests, which have already
-		// transitioned to some terminal (either success or failure) state.
-		scheduleCallbacksOnMainThread(std::move(callbacksPerRequest));
 		callbacksPerRequest.clear();
 		// Move any requestsSwitchingImpl to the appropriate mapping entry in the activeDiscoveriesMap_
 		for (const auto& req : requestsSwitchingImpl)


### PR DESCRIPTION
There's a possibility for a data race to happen between `PortMappingManager::scheduleCallbacksOnMainThread()` and port mapping request destruction:

If the timing is just right so that the request gets deleted (cancelled) after leaving the lock guard scope in `PortMappingManager::thread_monitor_function()` and right before calling `scheduleCallbacksOnMainThread()`, then the latter function call will see invalid request state, that's neither succeeded, nor failed.

Since the callbacks are scheduled asynchronously, it isn't a big deal to move `scheduleCallbacksOnMainThread()` inside the mutex lock guard scope, which this patch does.

Also, just as an additional failsafe, add a case in the `scheduleCallbacksOnMainThread()` to check if a request is in a bad state, which most likely means that it has already been cancelled.