### PR TITLE
Partial revert: SuperTransport base HP tweak

### DIFF
--- a/data/mp/stats/body.json
+++ b/data/mp/stats/body.json
@@ -1002,7 +1002,7 @@
 		"buildPower": 500,
 		"class": "Transports",
 		"droidType": "SUPERTRANSPORTER",
-		"hitpoints": 3000,
+		"hitpoints": 2200,
 		"id": "SuperTransportBody",
 		"model": "drtrans.pie",
 		"name": "Super Transport Body",


### PR DESCRIPTION
Reduced partially from the increase in #3215, due to interactions with transporter armor and HP upgrades in #3252

Takes into account comments and analysis in #4654