### PR TITLE
Update quickjs_backend.cpp - documentation tweaks

### DIFF
--- a/src/quickjs_backend.cpp
+++ b/src/quickjs_backend.cpp
@@ -843,6 +843,7 @@ JSValue convResearch(const RESEARCH *psResearch, JSContext *ctx, int player)
 //;; * ```isRadarDetector``` True if the structure has radar detector ability. (3.2+ only)
 //;; * ```range``` Maximum range of its weapons. (3.2+ only)
 //;; * ```hasIndirect``` One or more of the structure's weapons are indirect. (3.2+ only)
+//;; * ```health``` Percentage that this structure is damaged (where 100 means not damaged at all).
 //;;
 JSValue convStructure(const STRUCTURE *psStruct, JSContext *ctx)
 {
@@ -923,6 +924,7 @@ JSValue convStructure(const STRUCTURE *psStruct, JSContext *ctx)
 //;; * ```type``` It will always be ```FEATURE```.
 //;; * ```stattype``` The type of feature. Defined types are ```OIL_RESOURCE```, ```OIL_DRUM``` and ```ARTIFACT```.
 //;; * ```damageable``` Can this feature be damaged?
+//;; * ```health``` Percentage that this feature is damaged (where 100 means not damaged at all).
 //;;
 JSValue convFeature(const FEATURE *psFeature, JSContext *ctx)
 {
@@ -976,7 +978,6 @@ JSValue convFeature(const FEATURE *psFeature, JSContext *ctx)
 //;;   * ```DROID_TRANSPORTER``` Cyborg transporter.
 //;;   * ```DROID_SUPERTRANSPORTER``` Droid transporter.
 //;;   * ```DROID_COMMAND``` Commanders.
-//;; * ```group``` The group this droid is member of. This is a numerical ID. If not a member of any group, will be set to \emph{null}.
 //;; * ```armed``` The percentage of weapon capability that is fully armed. Will be \emph{null} for droids other than VTOLs.
 //;; * ```experience``` Amount of experience this droid has, based on damage it has dealt to enemies.
 //;; * ```cost``` What it would cost to build the droid. (3.2+ only)
@@ -996,6 +997,7 @@ JSValue convFeature(const FEATURE *psFeature, JSContext *ctx)
 //;; * ```cargoSpace``` Defined for transporters only: Cargo capacity left. (3.2+ only)
 //;; * ```cargoCount``` Defined for transporters only: Number of individual \emph{items} in the cargo hold. (3.2+ only)
 //;; * ```cargoSize``` The amount of cargo space the droid will take inside a transport. (3.2+ only)
+//;; * ```health``` Percentage that this droid is damaged (where 100 means not damaged at all).
 //;;
 JSValue convDroid(const DROID *psDroid, JSContext *ctx)
 {
@@ -1099,10 +1101,10 @@ JSValue convDroid(const DROID *psDroid, JSContext *ctx)
 //;; * ```player``` The player owning this object.
 //;; * ```selected``` A boolean saying whether 'selectedPlayer' has selected this object.
 //;; * ```name``` A user-friendly name for this object.
-//;; * ```health``` Percentage that this object is damaged (where 100 means not damaged at all).
 //;; * ```armour``` Amount of armour points that protect against kinetic weapons.
 //;; * ```thermal``` Amount of thermal protection that protect against heat based weapons.
 //;; * ```born``` The game time at which this object was produced or came into the world. (3.2+ only)
+//;; * ```group``` The group this object is member of. This is a numerical ID. If not a member of any group, will be set to \emph{null}.
 //;;
 JSValue convObj(const BASE_OBJECT *psObj, JSContext *ctx)
 {


### PR DESCRIPTION
The `.group` property is part of the base object, not Droid.

The `.health` properties are part of Droid / Structure / Feature objects, not base object.