### PR TITLE
Nexus AI: Send help chat messages to allies only

### DIFF
--- a/data/mp/multiplay/skirmish/nexus_includes/chat.js
+++ b/data/mp/multiplay/skirmish/nexus_includes/chat.js
@@ -37,7 +37,7 @@ function processCommand(message, sender, blipMessage)
 				helpInfo.location[sender].x,
 				helpInfo.location[sender].y))
 			{
-				chat(ALL_PLAYERS, CHAT_RESPONSE.confirm);
+				chat(ALLIES, CHAT_RESPONSE.confirm);
 			}
 		}
 		else
@@ -63,7 +63,7 @@ function processCommand(message, sender, blipMessage)
 		if (helpingAlly() && helpInfo.lastHelpPlayer === sender)
 		{
 			stopHelpingAlly();
-			chat(ALL_PLAYERS, CHAT_RESPONSE.affirmative);
+			chat(ALLIES, CHAT_RESPONSE.affirmative);
 		}
 		else if (numEnemiesInBase() > 0)
 		{

--- a/data/mp/multiplay/skirmish/nexus_includes/help.js
+++ b/data/mp/multiplay/skirmish/nexus_includes/help.js
@@ -111,14 +111,14 @@ function attemptToHelp(player, x, y)
 	{
 		if (!HELPING_SELF && !haveHelpers())
 		{
-			chat(ALL_PLAYERS, CHAT_RESPONSE.noHelp);
+			chat(ALLIES, CHAT_RESPONSE.noHelp);
 		}
 
 		helpPlayer(player, x, y);
 	}
 	else if (defined(helpInfo.lastHelpPlayer))
 	{
-		chat(ALL_PLAYERS, "Helping " + getPlayerName(helpInfo.lastHelpPlayer) + " already");
+		chat(ALLIES, "Helping " + getPlayerName(helpInfo.lastHelpPlayer) + " already");
 	}
 
 	return false;


### PR DESCRIPTION
Nexus AI currently sends some help-related chat messages to `ALL_PLAYERS` instead of `ALLIES`. This commit sends those messages to allies only, so Nexus won't randomly message "ok" to its opponents.

This is noticeable if you play the "Hide behind me" challenge, for example:

<img width="470" height="177" alt="image" src="https://github.com/user-attachments/assets/d271f52d-64f2-488e-ae19-fdd6726c288a" />
