### PR TITLE
Semperfi AI: Fully rearm VTOLs

### DIFF
--- a/data/mp/multiplay/skirmish/semperfi.js
+++ b/data/mp/multiplay/skirmish/semperfi.js
@@ -13,6 +13,7 @@ const REPAIR_FACILITY_STAT = "A0RepairCentre3";
 const SENSOR_TOWERS = ["Sys-SensoTower02", "Sys-SensoTowerWS"];
 const UPLINK_STAT = "A0Sat-linkCentre";
 const ELECTRONIC_DEFENSES = ["Sys-SpyTower", "WallTower-EMP", "Emplacement-MortarEMP"];
+const DACTION_WAITDURINGREARM = 35;
 
 // -- globals
 const MIN_BASE_TRUCKS = 3;

--- a/data/mp/multiplay/skirmish/semperfi_includes/tactics.js
+++ b/data/mp/multiplay/skirmish/semperfi_includes/tactics.js
@@ -22,6 +22,11 @@ function vtolReady(vtolID)
 		return false;
 	}
 
+	if (vtol.action === DACTION_WAITDURINGREARM)
+	{
+		return false;
+	}
+
 	return true;
 }
 


### PR DESCRIPTION
Semperfi will send rearming VTOLs to attack as soon as they have any ammunition. For example, tank killer VTOLs will take off with only one missile instead of two. This occurs because ordering a VTOL to rearm with DORDER_REARM does not change its order if the droid's current order is DORDER_SCOUT, which is what semperfi uses to get its VTOLs to attack. The fix is to inspect the action of the VTOL, waiting until it is no longer actively rearming before sending it to attack again.

<img width="702" height="522" alt="image" src="https://github.com/user-attachments/assets/231fe3de-30a3-4c88-b2d4-39da840bfe09" />
