### PR TITLE
Fix 'disabled' state of mouse key code

### DIFF
--- a/src/configuration.cpp
+++ b/src/configuration.cpp
@@ -341,6 +341,10 @@ bool loadConfig()
 		{
 			return defaultValue;
 		}
+		if (intVal.value() == 0)
+		{
+			return nullopt; // 0 represents "disabled"
+		}
 		if (intVal.value() >= MOUSE_LMB && intVal.value() <= MOUSE_X2) // deliberately exclude mouse MOUSE_WUP + MOUSE_WDN
 		{
 			return static_cast<MOUSE_KEY_CODE>(intVal.value());


### PR DESCRIPTION
The disabled state is represented by `nullopt`, which is saved as `0` (see `iniSetMouseKeyOpt`). However, on loading, `0` was not being converted back to `nullopt`, resulting in `defaultValue`. So add explicit check for `0` and return `nullopt`.

Fixes #4812