### PR TITLE
Partial revert tcmask shader improvements

### DIFF
--- a/data/base/shaders/tcmask_instanced.frag
+++ b/data/base/shaders/tcmask_instanced.frag
@@ -174,7 +174,6 @@ void main()
 	light += iterateOverAllPointLights(clipSpaceCoord, posModelSpace, N, normalize(halfVec - lightDir), diffuseMap, specularMapValue, mat3(1.f));
 #endif
 
-	light.rgb *= lightmap_vec4.a; // apply lightmap.a here to hide objects in fog of war
 	light.a = 1.0f;
 
 	vec4 fragColour;

--- a/data/base/shaders/vk/tcmask_instanced.frag
+++ b/data/base/shaders/vk/tcmask_instanced.frag
@@ -130,7 +130,6 @@ void main()
 		light += iterateOverAllPointLights(clipSpaceCoord, posModelSpace, N, normalize(halfVec - lightDir), diffuseMap, specularMapValue, mat3(1.f));
 	}
 
-	light.rgb *= lightmap_vec4.a; // apply lightmap.a here to hide objects in fog of war
 	light.a = 1.0f;
 
 	vec4 fragColour;


### PR DESCRIPTION
Specifically, revert the additional multiply by `lightmap.a`.

This was an attempt to tweak the brightness of features (example: trees) on unexplored terrain in skirmish / MP, but the proper place to adjust how brightness is calculated in this case is in the core engine, which will be addressed later.

(There were problematic side-effects of this multiply by `lightmap.a`, which included: terrain darkness due to satellite strike contributing heavily to unit brightness - even VTOLs.)