### PR TITLE
[Help Wanted] Allow non-hard-coded sound IDs for ingame sounds and unrestrict sound map blips

### DIFF
--- a/data/base/script/campaign/cam3-1.js
+++ b/data/base/script/campaign/cam3-1.js
@@ -268,7 +268,7 @@ function getCountdown()
 			}
 			if (!skip)
 			{
-				playSound(countdownObject[0].sound, CAM_HUMAN_PLAYER);
+				playSound(countdownObject[0].sound);
 			}
 
 			if (SILOS_DESTROYED)

--- a/data/base/script/campaign/libcampaign_includes/artifact.js
+++ b/data/base/script/campaign/libcampaign_includes/artifact.js
@@ -228,7 +228,7 @@ function __camPickupArtifact(artifact)
 	}
 	ai.pickedUp = true;
 	camTrace("Picked up", ai.tech);
-	playSound(cam_sounds.artifactRecovered, artifact.x, artifact.y, artifact.z);
+	playSound(cam_sounds.artifactRecovered);
 	// artifacts are not self-removing...
 	camSafeRemoveObject(artifact);
 	if (ai.tech instanceof Array)

--- a/data/base/script/campaign/libcampaign_includes/base.js
+++ b/data/base/script/campaign/libcampaign_includes/base.js
@@ -179,7 +179,7 @@ function camDetectEnemyBase(baseLabel)
 		}
 		if (camDef(pos))
 		{
-			playSound(bi.detectSnd, pos.x, pos.y, 0);
+			playSound(bi.detectSnd);
 		}
 	}
 	if (camDef(bi.detectMsg))
@@ -304,7 +304,7 @@ function __camCheckBaseEliminated(group)
 			{
 				// play sound
 				const pos = camMakePos(bi.cleanup);
-				playSound(bi.eliminateSnd, pos.x, pos.y, 0);
+				playSound(bi.eliminateSnd);
 			}
 		}
 		else

--- a/data/base/script/campaign/libcampaign_includes/victory.js
+++ b/data/base/script/campaign/libcampaign_includes/victory.js
@@ -434,7 +434,7 @@ function __camVictoryOffworld()
 					if (!__USED_REMIND || (__USED_REMIND && __camVictoryData.playLzReminder))
 					{
 						const pos = camMakePos(lz);
-						playSound(cam_sounds.lz.returnToLZ, pos.x, pos.y, 0);
+						playSound(cam_sounds.lz.returnToLZ);
 						console(_("Return to LZ"));
 					}
 				}
@@ -469,7 +469,7 @@ function __camVictoryOffworld()
 	{
 		camTrace("LZ clear");
 		const pos = camMakePos(lz);
-		playSound(cam_sounds.lz.LZClear, pos.x, pos.y, 0);
+		playSound(cam_sounds.lz.LZClear);
 		setReinforcementTime(__camVictoryData.reinforcements, false);
 		__camLZCompromisedTicker = 0;
 		if (__camRTLZTicker === 0)

--- a/data/base/script/tutorial.js
+++ b/data/base/script/tutorial.js
@@ -398,7 +398,7 @@ function addToConsole()
 
 			if (camDef(tutPhase.audio))
 			{
-				playSound(tutPhase.audio, CAM_HUMAN_PLAYER);
+				playSound(tutPhase.audio);
 			}
 
 			if (camDef(tutPhase.clear) && tutPhase.clear)

--- a/lib/sound/audio.cpp
+++ b/lib/sound/audio.cpp
@@ -208,12 +208,6 @@ bool audio_GetPreviousQueueTrackRadarBlipPos(SDWORD *iX, SDWORD *iY)
 		return false;
 	}
 
-	if (g_sPreviousSample.iTrack != ID_SOUND_STRUCTURE_UNDER_ATTACK && g_sPreviousSample.iTrack != ID_SOUND_UNIT_UNDER_ATTACK &&
-	    g_sPreviousSample.iTrack != ID_SOUND_LASER_SATELLITE_FIRING && g_sPreviousSample.iTrack != ID_SOUND_INCOMING_LASER_SAT_STRIKE)
-	{
-		return false;
-	}
-
 	if (realTime > g_iPreviousSampleTime + 5 * GAME_TICKS_PER_SEC)
 	{
 		return false;

--- a/src/stats.cpp
+++ b/src/stats.cpp
@@ -37,6 +37,7 @@
 #include "map.h"
 #include "main.h"
 #include "lib/sound/audio_id.h"
+#include "lib/sound/audio.h"
 #include "projectile.h"
 #include "text.h"
 #include "notifications.h"
@@ -1180,12 +1181,12 @@ static bool statsGetAudioIDFromString(const WzString &szStatName, const WzString
 	{
 		*piWavID = NO_SOUND;
 	}
-	else if ((*piWavID = audio_GetIDFromStr(szWavName.toUtf8().c_str())) == NO_SOUND)
+	else if ((*piWavID = audio_GetTrackID(szWavName.toUtf8().c_str())) == NO_SOUND)
 	{
 		debug(LOG_FATAL, "Could not get ID %d for sound %s", *piWavID, szWavName.toUtf8().c_str());
 		return false;
 	}
-	if ((*piWavID < 0 || *piWavID > ID_MAX_SOUND) && *piWavID != NO_SOUND)
+	if (*piWavID < 0 && *piWavID != NO_SOUND)
 	{
 		debug(LOG_FATAL, "Invalid ID - %d for sound %s", *piWavID, szStatName.toUtf8().c_str());
 		return false;


### PR DESCRIPTION
Previously, if a mod wanted to add a new sound effect for a weapon (or any other component), the mod would have to overwrite another sound effect listed [here](https://github.com/Warzone2100/warzone2100/blob/bfa315073b2c773d3b90e899552658c20595a8d5/lib/sound/audio_id.cpp#L41), since only sounds with these hard-coded IDs could be loaded as component sounds. This PR changes `statsGetAudioIDFromString()` to use `audio_GetTrackID()` instead of `audio_GetIDFromStr()`, which allows for additional non-hard-coded sound IDs to be used for things like weapon or propulsion SFX. This allows mods to add new usable sound effects without needing to cannibalize hard-coded IDs.

To demonstrate this, I made a simple test mod that replaces the Light Cannon's explosion sound with a new one I found floating around in the `base.wz` audio folder (and is completely unreferenced and unused). To test it, download [newsound.zip](https://github.com/user-attachments/files/25428268/newsound.zip), change the extension to `.wz`, and start a skirmish game. Using this mod without the PR, the game will complain that it can't find "mpodexpl.ogg" and abort loading. But with the PR, the game will load and the sound effect plays as expected, without the need to override any other existing sound effects.

This PR also removes the restrictions on which sound effects create a red minimap blip when played through scripts with `playSound()`. Previously, only sound effects such as the "Unit Under Attack" were allowed to place minimap blips. Now, any sound supplied with coordinates will also place a minimap blip. This should allow modders (or developers) to easily add new alert-type notifications (in case anyone was eyeing that unused "derrick under attack" voiceline).

To adjust for this change, I took the liberty of tweaking some libcampaign `playSound()` calls to avoid placing red blips in cases where it might look off (such as when picking up artifacts).

So, what's with the [Help Wanted] in the title?
When testing the PR, I noticed that the game would consistently throw out warnings that looked like this when launching a skirmish game:
```
info    |23:38:36: [resGetDataFromHash:602] resGetDataFromHash: Unknown ID: 7664507 Type: WAV
info    |23:38:41: [resGetData:618] resGetData: Unable to find data for lrgcan.ogg type WAV
fatal   |23:38:42: [statsGetAudioIDFromString:1191] Invalid ID - -3 for sound AAGun2Mk1Quad
info    |23:38:48: [loadWeaponStats:587] Weapon sound lrgcan.ogg not found for AA Tornado Flak Cannon
info    |23:38:50: [resLoadFile:549] The load function for resource type "SWEAPON" failed for file "weapons.json"
fatal   |23:38:51: [resLoad:213] Failed to parse wrf/limiter_data.wrf
info    |23:38:53: [startMultiplayerGame:6363] Unable to load limiter_data.
```
The strange part is:
- This doesn't seem to happen when starting a campaign.
- This always triggers on the AA Tornado Flak Cannon, (or any weapon listed second in `weapons.json`).
- Despite the warnings, all sounds seem to work fine when the game actually starts. Even the Tornado's sound effects seem to be working properly.

I'm currently at a bit of a loss as to what is causing these asserts. My hunch is that `resGetDataFromHash()` is trying to access resource data before it's properly stored, but hopefully someone more knowledgeable on WZ's hashing methods might understand what's happening here.