### PR TITLE
poll_descriptor_set: Handle `POLLNVAL` in `PollDescriptorSet::isSet()`

### DIFF
--- a/lib/netplay/tcp/poll_descriptor_set.h
+++ b/lib/netplay/tcp/poll_descriptor_set.h
@@ -136,6 +136,11 @@ public:
 			return tl::make_unexpected(ErroredState::HangUp);
 		}
 
+		if (it->revents & POLLNVAL)
+		{
+			return tl::make_unexpected(ErroredState::InvalidConn);
+		}
+
 		return false;
 	}
 


### PR DESCRIPTION
The code previously didn't handle `POLLNVAL`, so we might fail to indentify some kinds of problems with client connections, where the underlying fd has been closed for some reason.