### PR TITLE
js api: `cancelProduction(factory)` function

### DIFF
--- a/src/quickjs_backend.cpp
+++ b/src/quickjs_backend.cpp
@@ -3188,6 +3188,7 @@ IMPL_JS_FUNC(addFeature, wzapi::addFeature)
 IMPL_JS_FUNC(addDroid, wzapi::addDroid)
 IMPL_JS_FUNC(addDroidToTransporter, wzapi::addDroidToTransporter)
 IMPL_JS_FUNC(makeTemplate, wzapi::makeTemplate)
+IMPL_JS_FUNC(cancelProduction, wzapi::cancelProduction)
 IMPL_JS_FUNC(buildDroid, wzapi::buildDroid)
 IMPL_JS_FUNC(enumStruct, wzapi::enumStruct)
 IMPL_JS_FUNC(enumStructOffWorld, wzapi::enumStructOffWorld)
@@ -3603,6 +3604,7 @@ bool quickjs_scripting_instance::registerFunctions(const std::string& scriptName
 	JS_REGISTER_FUNC2(orderDroidBuild, 5, 6); // WZAPI
 	JS_REGISTER_FUNC(orderDroidObj, 3); // WZAPI
 	JS_REGISTER_FUNC(orderDroid, 2); // WZAPI
+	JS_REGISTER_FUNC(cancelProduction, 1); // WZAPI
 	JS_REGISTER_FUNC2(buildDroid, 7, 7 + MAX_JS_VARARGS); // WZAPI
 	JS_REGISTER_FUNC2(addDroid, 9, 9 + MAX_JS_VARARGS); // WZAPI
 	JS_REGISTER_FUNC(addDroidToTransporter, 2); // WZAPI

--- a/src/wzapi.cpp
+++ b/src/wzapi.cpp
@@ -1869,6 +1869,28 @@ static std::unique_ptr<DROID_TEMPLATE> makeTemplate(int player, const std::strin
 	}
 }
 
+//-- ## cancelProduction(factory)
+//--
+//-- Cancel current droid production at the given factory. Returns true if
+//-- production was successfully cancelled, false if nothing was being produced. (4.6.4+ only)
+//--
+bool wzapi::cancelProduction(WZAPI_PARAMS(STRUCTURE *psFactory))
+{
+    STRUCTURE *psStruct = psFactory;
+    SCRIPT_ASSERT(false, context, psStruct, "No valid structure provided");
+    SCRIPT_ASSERT(false, context, psStruct->pStructureType->type == REF_FACTORY
+                  || psStruct->pStructureType->type == REF_CYBORG_FACTORY
+                  || psStruct->pStructureType->type == REF_VTOL_FACTORY,
+                  "Structure %s is not a factory", objInfo(psStruct));
+    const FACTORY *psFactory_ = &psStruct->pFunctionality->factory;
+    if (psFactory_->psSubject == nullptr)
+    {
+        return false; // nothing being produced
+    }
+    ::cancelProduction(psStruct, ModeQueue);
+    return true;
+}
+
 //-- ## buildDroid(factory, templateName, body, propulsion, reserved, reserved, turrets...)
 //--
 //-- Start factory production of new droid with the given name, body, propulsion and turrets.

--- a/src/wzapi.h
+++ b/src/wzapi.h
@@ -1047,6 +1047,7 @@ namespace wzapi
 	int terrainType(WZAPI_PARAMS(int x, int y));
 	bool tileIsBurning(WZAPI_PARAMS(int x, int y));
 	bool orderDroidObj(WZAPI_PARAMS(DROID *psDroid, int _order, BASE_OBJECT *psObj));
+	bool cancelProduction(WZAPI_PARAMS(STRUCTURE *psFactory));
 	bool buildDroid(WZAPI_PARAMS(STRUCTURE *psFactory, std::string templateName, string_or_string_list body, string_or_string_list propulsion, reservedParam reserved1, reservedParam reserved2, va_list<string_or_string_list> turrets));
 	returned_nullable_ptr<const DROID> addDroid(WZAPI_PARAMS(int player, int x, int y, std::string templateName, string_or_string_list body, string_or_string_list propulsion, reservedParam reserved1, reservedParam reserved2, va_list<string_or_string_list> turrets)); MUTLIPLAY_UNSAFE
 	std::unique_ptr<const DROID_TEMPLATE> makeTemplate(WZAPI_PARAMS(int player, std::string templateName, string_or_string_list body, string_or_string_list propulsion, reservedParam reserved1, va_list<string_or_string_list> turrets));


### PR DESCRIPTION
Cancels production at a factory, allowing AIs to claw back a little power in emergencies.

Fixes #4841