### PR TITLE
gitignore .vs folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,6 +106,9 @@ cscope.out
 # VS Code
 .vscode
 
+# Visual Studio
+.vs
+
 # Eclipse CDT
 .project
 .cproject


### PR DESCRIPTION
Visual Studio 2022 was adding all sorts of stuff to a .vs folder which was showing up in git desktop; added .vs to gitignore