### PR TITLE
Rework Droid Resistance Scaling

### DIFF
--- a/src/droid.cpp
+++ b/src/droid.cpp
@@ -3687,10 +3687,7 @@ int16_t DROID::droidResistance() const
 {
 	CHECK_DROID(this);
 	const BODY_STATS *psStats = getBodyStats();
-	int res = experience / (65536 / MAX(1, psStats->upgrade[player].resistance));
-	// ensure resistance is a base minimum
-	res = MAX(res, psStats->upgrade[player].resistance);
-	return MIN(res, INT16_MAX);
+	return psStats->upgrade[player].resistance;
 }
 
 /*this is called to check the weapon is 'allowed'. Check if VTOL, the weapon is


### PR DESCRIPTION
Currently, units scale their total resistance (electronic HP) based on their current experience, with a formula that boils down to:
```
Actual Resistance = max(E*R, R)
Where:
E = Experience
R = Body resistance (after upgrades)
```
It's important to note here that "experience" is not "rank". Units gain experience by dealing damage, and gain 1 experience for each full enemy health bar they deplete. Rank only increases when the unit's experience exceeds a certain threshold (8, 16, 32... etc.).
Since unit resistance scales with *experience*, experienced units will have *massively* more resistance compared to fresh ones. For example, a unit with 4 kills will have 4 EXP, and 4x resistance compared to a unit with 0 EXP. A unit with 10 EXP will have 10x resistance. A unit with 20 EXP will have 20x resistance, etc. It's also worth noting that this scaling doesn't seem to have any practical limit, a hero-ranked unit can keep gathering EXP to increase its resistance.
What this means is that units with even a moderate amount of EXP will be effectively immune to the NEXUS Link Turret, since they simply have too much electronic HP to chew through.

This PR removes this resistance scaling entirely. Unit resistance is now only influenced by body stats and upgrades (i.e. NEXUS Resistance Circuits). However, electronic damage is now affected by rank damage resistance (just like normal damage).
This means NEXUS Link Turrets are now usable against high-EXP units. This PR shouldn't change anything against structures, but some damage/resistance values may need to be tweaked for balancing reasons now that unit resistance doesn't scale off the charts.