### PR TITLE
Cooperative resource loading controller driven through the main loop

### DIFF
--- a/lib/framework/frameresource.cpp
+++ b/lib/framework/frameresource.cpp
@@ -50,6 +50,84 @@ static void ResetResourceFile();
 
 // callback to resload screen.
 static RESLOAD_CALLBACK resLoadCallback = nullptr;
+static ResLoadPlan *activeResLoadPlan = nullptr;
+static size_t resLoadPlanEntriesPerStepSetting = 2;
+
+bool resParserBeginLoadPlanBuild(ResLoadPlan *plan)
+{
+	ASSERT(plan != nullptr, "resParserBeginLoadPlanBuild called with null plan");
+	ASSERT(activeResLoadPlan == nullptr, "res parser plan build already active");
+	if (plan == nullptr || activeResLoadPlan != nullptr)
+	{
+		return false;
+	}
+
+	activeResLoadPlan = plan;
+	activeResLoadPlan->entries.clear();
+	activeResLoadPlan->nextEntry = 0;
+	sstrcpy(aCurrResDir, aResDir);
+	return true;
+}
+
+void resParserEndLoadPlanBuild()
+{
+	activeResLoadPlan = nullptr;
+}
+
+bool resParserSetDirectory(const char *directory)
+{
+	size_t len;
+
+	ASSERT(activeResLoadPlan != nullptr, "resParserSetDirectory called without an active plan");
+	ASSERT(directory != nullptr, "resParserSetDirectory called with null directory");
+	if (activeResLoadPlan == nullptr || directory == nullptr)
+	{
+		return false;
+	}
+
+	debug(LOG_NEVER, "directory: %s", directory);
+	if (strncmp(directory, "/:", strlen("/:")) == 0)
+	{
+		sstrcpy(aCurrResDir, directory);
+	}
+	else
+	{
+		sstrcpy(aCurrResDir, aResDir);
+		sstrcat(aCurrResDir, directory);
+	}
+
+	if (strlen(directory) > 0)
+	{
+		ASSERT(WZ_PHYSFS_isDirectory(aCurrResDir), "%s is not a directory!", aCurrResDir);
+		if (!WZ_PHYSFS_isDirectory(aCurrResDir))
+		{
+			debug(LOG_ERROR, "Resource directory does not exist: %s", aCurrResDir);
+			return false;
+		}
+
+		len = strlen(aCurrResDir);
+		aCurrResDir[len] = '/';
+		aCurrResDir[len + 1] = 0;
+		debug(LOG_NEVER, "Current resource directory: %s", aCurrResDir);
+	}
+
+	return true;
+}
+
+bool resParserAddFile(const char *type, const char *file)
+{
+	ASSERT(activeResLoadPlan != nullptr, "resParserAddFile called without an active plan");
+	ASSERT(type != nullptr, "resParserAddFile called with null type");
+	ASSERT(file != nullptr, "resParserAddFile called with null file");
+	if (activeResLoadPlan == nullptr || type == nullptr || file == nullptr)
+	{
+		return false;
+	}
+
+	debug(LOG_NEVER, "file: %s %s", type, file);
+	activeResLoadPlan->entries.push_back({aCurrResDir, type, file});
+	return true;
+}
 
 
 /* next four used in HashPJW */
@@ -154,6 +232,8 @@ bool resInitialise()
 	psResTypes.clear();
 	resBlockID = 0;
 	resLoadCallback = nullptr;
+	activeResLoadPlan = nullptr;
+	resLoadPlanEntriesPerStepSetting = 2;
 
 	ResetResourceFile();
 
@@ -187,6 +267,25 @@ void resSetBaseDir(const char *pResDir)
 /* Parse the res file */
 bool resLoad(const char *pResFile, SDWORD blockID)
 {
+	ResLoadPlan plan;
+	if (!resPrepareLoadPlan(pResFile, blockID, plan))
+	{
+		return false;
+	}
+
+	while (!resLoadPlanComplete(plan))
+	{
+		if (!resLoadPlanStep(plan, resGetLoadPlanEntriesPerStep()))
+		{
+			return false;
+		}
+	}
+
+	return true;
+}
+
+bool resPrepareLoadPlan(const char *pResFile, SDWORD blockID, ResLoadPlan &plan)
+{
 	bool retval = true;
 	lexerinput_t input;
 
@@ -206,18 +305,60 @@ bool resLoad(const char *pResFile, SDWORD blockID)
 		return false;
 	}
 
-	// and parse it
+	plan = {};
+	plan.resourceFile = pResFile;
+	plan.blockID = blockID;
+	if (!resParserBeginLoadPlanBuild(&plan))
+	{
+		PHYSFS_close(input.input.physfsfile);
+		return false;
+	}
+
 	res_set_extra(&input);
+
+	// Parse the RES file
 	if (res_parse() != 0)
 	{
 		debug(LOG_FATAL, "Failed to parse %s", pResFile);
 		retval = false;
 	}
 
+	resParserEndLoadPlanBuild();
 	res_lex_destroy();
 	PHYSFS_close(input.input.physfsfile);
 
 	return retval;
+}
+
+bool resLoadPlanStep(ResLoadPlan &plan, size_t maxEntriesPerStep)
+{
+	resBlockID = plan.blockID;
+	for (size_t processed = 0; processed < maxEntriesPerStep && plan.nextEntry < plan.entries.size(); ++processed, ++plan.nextEntry)
+	{
+		const ResLoadPlanEntry &entry = plan.entries[plan.nextEntry];
+		sstrcpy(aCurrResDir, entry.resourceDirectory.c_str());
+		if (!resLoadFile(entry.type.c_str(), entry.file.c_str()))
+		{
+			return false;
+		}
+	}
+
+	return true;
+}
+
+bool resLoadPlanComplete(const ResLoadPlan &plan)
+{
+	return plan.nextEntry >= plan.entries.size();
+}
+
+size_t resGetLoadPlanEntriesPerStep()
+{
+	return resLoadPlanEntriesPerStepSetting;
+}
+
+void resSetLoadPlanEntriesPerStep(size_t entriesPerStep)
+{
+	resLoadPlanEntriesPerStepSetting = entriesPerStep > 0 ? entriesPerStep : 1;
 }
 
 

--- a/lib/framework/frameresource.h
+++ b/lib/framework/frameresource.h
@@ -27,6 +27,8 @@
 #include "lib/framework/frame.h"
 
 #include <list>
+#include <string>
+#include <vector>
 
 /** Maximum number of characters in a resource type. */
 #define RESTYPE_MAXCHAR		20
@@ -43,6 +45,21 @@ typedef void (*RES_FREE)(void *pData);
 
 /** callback type for resload display callback. */
 typedef void (*RESLOAD_CALLBACK)();
+
+struct ResLoadPlanEntry
+{
+	std::string resourceDirectory;
+	std::string type;
+	std::string file;
+};
+
+struct ResLoadPlan
+{
+	std::string resourceFile;
+	SDWORD blockID = 0;
+	std::vector<ResLoadPlanEntry> entries;
+	size_t nextEntry = 0;
+};
 
 struct RES_DATA
 {
@@ -93,6 +110,13 @@ WZ_DECL_NONNULL(1) void resForceBaseDir(const char *pResDir);
 
 /** Parse the res file. */
 WZ_DECL_NONNULL(1) bool resLoad(const char *pResFile, SDWORD blockID);
+WZ_DECL_NONNULL(1) bool resPrepareLoadPlan(const char *pResFile, SDWORD blockID, ResLoadPlan &plan);
+bool resLoadPlanStep(ResLoadPlan &plan, size_t maxEntriesPerStep = 1);
+bool resLoadPlanComplete(const ResLoadPlan &plan);
+
+/** Default max resource entries processed per resLoadPlanStep for cooperative loading. Min 1. */
+size_t resGetLoadPlanEntriesPerStep();
+void resSetLoadPlanEntriesPerStep(size_t entriesPerStep);
 
 /** Release all the resources currently loaded and the resource load functions. */
 void resReleaseAll();

--- a/lib/framework/resource_parser.cpp
+++ b/lib/framework/resource_parser.cpp
@@ -89,6 +89,9 @@ extern char* res_get_text(void);
 #include "lib/framework/resly.h"
 #include "lib/framework/physfs_ext.h"
 
+extern bool resParserSetDirectory(const char *directory);
+extern bool resParserAddFile(const char *type, const char *file);
+
 extern void yyerror(const char* msg);
 void yyerror(const char* msg)
 {
@@ -1412,44 +1415,24 @@ yyreduce:
         case 6:
 
 /* Line 1806 of yacc.c  */
-#line 85 "resource_parser.ypp"
+#line 88 "resource_parser.ypp"
     {
-					UDWORD len;
-
-					// set a new input directory
-					debug(LOG_NEVER, "directory: %s", (yyvsp[(2) - (2)].sval));
-					if (strncmp((yyvsp[(2) - (2)].sval), "/:", strlen("/:")) == 0)
-					{
-						// the new dir is rooted
-						sstrcpy(aCurrResDir, (yyvsp[(2) - (2)].sval));
-					}
-					else
-					{
-						sstrcpy(aCurrResDir, aResDir);
-						sstrcat(aCurrResDir, (yyvsp[(2) - (2)].sval));
-					}
-					if (strlen((yyvsp[(2) - (2)].sval)) > 0)
-					{
-						ASSERT(WZ_PHYSFS_isDirectory(aCurrResDir), "%s is not a directory!", aCurrResDir);
-						// Add a trailing '/'
-						len = strlen(aCurrResDir);
-						aCurrResDir[len] = '/';
-						aCurrResDir[len+1] = 0;
-						debug(LOG_NEVER, "Current resource directory: %s", aCurrResDir);
-					}
+					bool success = resParserSetDirectory((yyvsp[(2) - (2)].sval));
 					free((yyvsp[(2) - (2)].sval));
+
+					if (!success)
+					{
+						YYABORT;
+					}
 				}
     break;
 
   case 7:
 
 /* Line 1806 of yacc.c  */
-#line 115 "resource_parser.ypp"
+#line 101 "resource_parser.ypp"
     {
-					bool success;
-					/* load a data file */
-					debug(LOG_NEVER, "file: %s %s", (yyvsp[(2) - (3)].sval), (yyvsp[(3) - (3)].sval));
-					success = resLoadFile((yyvsp[(2) - (3)].sval), (yyvsp[(3) - (3)].sval));
+					bool success = resParserAddFile((yyvsp[(2) - (3)].sval), (yyvsp[(3) - (3)].sval));
 					free((yyvsp[(2) - (3)].sval));
 					free((yyvsp[(3) - (3)].sval));
 

--- a/lib/framework/resource_parser.ypp
+++ b/lib/framework/resource_parser.ypp
@@ -40,6 +40,9 @@ extern char* res_get_text(void);
 #include "lib/framework/resly.h"
 #include "lib/framework/physfs_ext.h"
 
+extern bool resParserSetDirectory(const char *directory);
+extern bool resParserAddFile(const char *type, const char *file);
+
 extern void yyerror(const char* msg);
 void yyerror(const char* msg)
 {
@@ -84,40 +87,20 @@ res_line:			dir_line
 
 dir_line:			DIRECTORY QTEXT_T
 				{
-					UDWORD len;
-
-					// set a new input directory
-					debug(LOG_NEVER, "directory: %s", $2);
-					if (strncmp($2, "/:", strlen("/:")) == 0)
-					{
-						// the new dir is rooted
-						sstrcpy(aCurrResDir, $2);
-					}
-					else
-					{
-						sstrcpy(aCurrResDir, aResDir);
-						sstrcat(aCurrResDir, $2);
-					}
-					if (strlen($2) > 0)
-					{
-						ASSERT(WZ_PHYSFS_isDirectory(aCurrResDir), "%s is not a directory!", aCurrResDir);
-						// Add a trailing '/'
-						len = strlen(aCurrResDir);
-						aCurrResDir[len] = '/';
-						aCurrResDir[len+1] = 0;
-						debug(LOG_NEVER, "Current resource directory: %s", aCurrResDir);
-					}
+					bool success = resParserSetDirectory($2);
 					free($2);
+
+					if (!success)
+					{
+						YYABORT;
+					}
 				}
 				;
 
 
 file_line:			FILETOKEN TEXT_T QTEXT_T
 				{
-					bool success;
-					/* load a data file */
-					debug(LOG_NEVER, "file: %s %s", $2, $3);
-					success = resLoadFile($2, $3);
+					bool success = resParserAddFile($2, $3);
 					free($2);
 					free($3);
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1187,6 +1187,23 @@ bool frontendInitialise(const char *ResourceFile)
 
 	debug(LOG_WZ, "== Initializing frontend == : %s", ResourceFile);
 
+	if (!frontendInitialiseSetup())
+	{
+		return false;
+	}
+
+	debug(LOG_MAIN, "frontEndInitialise: loading resource file .....");
+	if (!resLoad(ResourceFile, 0))
+	{
+		//need the object heaps to have been set up before loading in the save game
+		return false;
+	}
+
+	return frontendInitialiseFinalize();
+}
+
+bool frontendInitialiseSetup()
+{
 	if (!InitialiseGlobals())				// Initialise all globals and statics everywhere.
 	{
 		return false;
@@ -1207,13 +1224,11 @@ bool frontendInitialise(const char *ResourceFile)
 		return false;
 	}
 
-	debug(LOG_MAIN, "frontEndInitialise: loading resource file .....");
-	if (!resLoad(ResourceFile, 0))
-	{
-		//need the object heaps to have been set up before loading in the save game
-		return false;
-	}
+	return true;
+}
 
+bool frontendInitialiseFinalize()
+{
 	if (!dispInitialise())					// Initialise the display system
 	{
 		return false;

--- a/src/init.h
+++ b/src/init.h
@@ -38,6 +38,8 @@ extern char fileLoadBuffer[];
 bool systemInitialise(unsigned int horizScalePercentage, unsigned int vertScalePercentage);
 void systemShutdown();
 bool frontendInitialise(const char *ResourceFile);
+bool frontendInitialiseSetup();
+bool frontendInitialiseFinalize();
 bool frontendShutdown();
 bool stageOneInitialise();
 bool stageOneShutDown();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -82,6 +82,8 @@
 #include "frontend.h"
 #include "game.h"
 #include "init.h"
+#include "resource_loading_controller.h"
+#include "main_resource_loading.h"
 #include "levels.h"
 #include "lighting.h"
 #include "loadsave.h"
@@ -198,6 +200,7 @@ static bool ignoredSIGPIPE = false;
 #endif
 
 static void stopGameLoop();
+static void startTitleLoop(bool onInitialStartup = false);
 
 #if defined(WZ_OS_WIN)
 
@@ -730,7 +733,7 @@ static void make_dir(char *dest, const char *dirname, const char *subdir)
  * Preparations before entering the title (mainmenu) loop
  * Would start the timer in an event based mainloop
  */
-static void startTitleLoop(bool onInitialStartup = false)
+static void startTitleLoop(bool onInitialStartup)
 {
 	SetGameMode(GS_TITLE_SCREEN);
 
@@ -784,11 +787,10 @@ static void setCDAudioForCurrentGameMode()
 	}
 }
 
-/*!
- * Preparations before entering the game loop
- * Would start the timer in an event based mainloop
- */
-static bool startGameLoop()
+namespace main_resource_loading
+{
+
+void startGameBeforeLevelLoad()
 {
 	if (runningMultiplayer())
 	{
@@ -804,25 +806,32 @@ static bool startGameLoop()
 
 	// set up CD audio for game mode
 	setCDAudioForCurrentGameMode();
+}
 
+bool startGameRunLevelLoad()
+{
 	// Not sure what aLevelName is, in relation to game.map. But need to use aLevelName here, to be able to start the right map for campaign, and need game.hash, to start the right non-campaign map, if there are multiple identically named maps.
-	if (!levLoadData(aLevelName, &game.hash, nullptr, GTYPE_SCENARIO_START))
-	{
-		debug(LOG_ERROR, "Failed to load level data / map: %s %s", aLevelName, (!game.hash.isZero()) ? game.hash.toString().c_str() : "");
-		if (bMultiPlayer)
-		{
-			multiGameShutdown();
-		}
-		levReleaseAll();
-		closeLoadingScreen();
-		cdAudio_SetGameMode(MusicGameMode::MENUS);
-		stopGameLoop();
-		pie_LoadBackDrop(SCREEN_RANDOMBDROP);
-		startTitleLoop(); // Restart into titleloop
-		gameLoopStatus = GAMECODE_CONTINUE;
-		return false;
-	}
+	return levLoadData(aLevelName, &game.hash, nullptr, GTYPE_SCENARIO_START);
+}
 
+void startGameAbortLevelLoadFailure()
+{
+	debug(LOG_ERROR, "Failed to load level data / map: %s %s", aLevelName, (!game.hash.isZero()) ? game.hash.toString().c_str() : "");
+	if (bMultiPlayer)
+	{
+		multiGameShutdown();
+	}
+	levReleaseAll();
+	closeLoadingScreen();
+	cdAudio_SetGameMode(MusicGameMode::MENUS);
+	stopGameLoop();
+	pie_LoadBackDrop(SCREEN_RANDOMBDROP);
+	startTitleLoop(); // Restart into titleloop
+	gameLoopStatus = GAMECODE_CONTINUE;
+}
+
+bool startGameAfterLevelLoad()
+{
 	screen_StopBackDrop();
 	closeLoadingScreen();
 
@@ -907,6 +916,77 @@ static bool startGameLoop()
 	return true;
 }
 
+void saveGameLoadBefore()
+{
+	SetGameMode(GS_NORMAL);
+}
+
+bool saveGameLoadRun()
+{
+	return loadGameInit(GameLoadDetails::makeUserSaveGameLoad(saveGameName));
+}
+
+void saveGameLoadAbortOnFailure()
+{
+	// FIXME: we really should throw up a error window, but we can't (easily) so I won't.
+	debug(LOG_ERROR, "Trying to load Game %s failed!", saveGameName);
+	debug(LOG_POPUP, _("Failed to load a save game! It is either corrupted or a unsupported format.\n\nRestarting main menu."));
+	// FIXME: If we bomb out on a in game load, then we would crash if we don't do the next two calls
+	// Doesn't seem to be a way to tell where we are in game loop to determine if/when we should do the two calls.
+	gameLoopStatus = GAMECODE_FASTEXIT;
+	// we had a error loading savegame (corrupt?), so go back to title screen?
+	stopGameLoop();
+	startTitleLoop(); // Restart into titleloop
+	changeTitleMode(TITLE);
+	SetGameMode(GS_TITLE_SCREEN);
+}
+
+bool saveGameLoadAfter()
+{
+	ActivityManager::instance().startingSavedGame();
+	// set up CD audio for game mode
+	// (must come after savegame is loaded so that proper game mode can be determined)
+	setCDAudioForCurrentGameMode();
+
+	screen_StopBackDrop();
+	closeLoadingScreen();
+
+	// Trap the cursor if cursor snapping is enabled
+	if (shouldTrapCursor())
+	{
+		wzGrabMouse();
+	}
+	if (challengeActive)
+	{
+		addMissionTimerInterface();
+	}
+
+	// set a flag for the trigger/event system to indicate initialisation is complete
+	gameInitialised = true;
+
+	return true;
+}
+
+} // namespace main_resource_loading
+
+/*!
+ * Preparations before entering the game loop
+ * Would start the timer in an event based mainloop
+ */
+static bool startGameLoop()
+{
+	using namespace main_resource_loading;
+
+	initLoadingScreen(true);
+	startGameBeforeLevelLoad();
+	if (!startGameRunLevelLoad())
+	{
+		startGameAbortLevelLoadFailure();
+		return false;
+	}
+	return startGameAfterLevelLoad();
+}
+
 
 /*!
  * Shutdown/cleanup after the game loop
@@ -966,57 +1046,6 @@ static void stopGameLoop()
 
 
 /*!
- * Load a savegame and start into the game loop
- * Game data should be initialised afterwards, so that startGameLoop is not necessary anymore.
- */
-static bool initSaveGameLoad()
-{
-	// NOTE: always setGameMode correctly before *any* loading routines!
-	SetGameMode(GS_NORMAL);
-	initLoadingScreen(true);
-
-	// load up a save game
-	if (!loadGameInit(GameLoadDetails::makeUserSaveGameLoad(saveGameName)))
-	{
-		// FIXME: we really should throw up a error window, but we can't (easily) so I won't.
-		debug(LOG_ERROR, "Trying to load Game %s failed!", saveGameName);
-		debug(LOG_POPUP, "Failed to load a save game! It is either corrupted or a unsupported format.\n\nRestarting main menu.");
-		// FIXME: If we bomb out on a in game load, then we would crash if we don't do the next two calls
-		// Doesn't seem to be a way to tell where we are in game loop to determine if/when we should do the two calls.
-		gameLoopStatus = GAMECODE_FASTEXIT;	// clear out all old data
-		stopGameLoop();
-		startTitleLoop(); // Restart into titleloop
-		SetGameMode(GS_TITLE_SCREEN);
-		return false;
-	}
-
-	ActivityManager::instance().startingSavedGame();
-
-	// set up CD audio for game mode
-	// (must come after savegame is loaded so that proper game mode can be determined)
-	setCDAudioForCurrentGameMode();
-
-	screen_StopBackDrop();
-	closeLoadingScreen();
-
-	// Trap the cursor if cursor snapping is enabled
-	if (shouldTrapCursor())
-	{
-		wzGrabMouse();
-	}
-	if (challengeActive)
-	{
-		addMissionTimerInterface();
-	}
-
-	// set a flag for the trigger/event system to indicate initialisation is complete
-	gameInitialised = true;
-
-	return true;
-}
-
-
-/*!
  * Run the code inside the gameloop
  */
 static void runGameLoop()
@@ -1036,20 +1065,16 @@ static void runGameLoop()
 	case GAMECODE_LOADGAME:
 		debug(LOG_MAIN, "GAMECODE_LOADGAME");
 		stopGameLoop();
-		initSaveGameLoad(); // Restart and load a savegame
+		// Restart and load a savegame
+		ResourceLoadingController::instance().request(ResourceLoadingRequest::loadSaveGame());
 		gameLoopStatus = GAMECODE_CONTINUE;
 		return;
 	case GAMECODE_NEWLEVEL:
 		debug(LOG_MAIN, "GAMECODE_NEWLEVEL");
 		stopGameLoop();
-		if (startGameLoop()) // Restart gameloop
-		{
-			gameLoopStatus = GAMECODE_CONTINUE;
-		}
-		else
-		{
-			debug(LOG_POPUP, _("Failed to load level data or map. Exiting to main menu."));
-		}
+		// Restart gameloop
+		ResourceLoadingController::instance().request(ResourceLoadingRequest::startGame());
+		gameLoopStatus = GAMECODE_CONTINUE;
 		return;
 	default:
 		// ignore other values, and proceed with gameLoop
@@ -1105,27 +1130,14 @@ static void runTitleLoop()
 				debug(LOG_MAIN, "TITLECODE_SAVEGAMELOAD");
 				// Restart into gameloop and load a savegame, ONLY on a good savegame load!
 				stopTitleLoop();
-				if (!initSaveGameLoad())
-				{
-					// we had a error loading savegame (corrupt?), so go back to title screen?
-					stopGameLoop();
-					startTitleLoop();
-					changeTitleMode(TITLE);
-				}
-				closeLoadingScreen();
+				ResourceLoadingController::instance().request(ResourceLoadingRequest::loadSaveGame());
 				return;
 			}
 		case TITLECODE_STARTGAME:
 			debug(LOG_MAIN, "TITLECODE_STARTGAME");
 			stopTitleLoop();
-			if (startGameLoop()) // Restart into gameloop
-			{
-				closeLoadingScreen();
-			}
-			else
-			{
-				debug(LOG_POPUP, _("Failed to load level data or map. Exiting to main menu."));
-			}
+			// Restart into gameloop
+			ResourceLoadingController::instance().request(ResourceLoadingRequest::startGame());
 			return;
 		default:
 			// ignore unexpected value
@@ -1188,12 +1200,25 @@ void mainLoop()
 
 	if (NetPlay.bComms || focusState == FOCUS_IN || !war_GetPauseOnFocusLoss())
 	{
-		if (loop_GetVideoStatus())
+		bool frameEnded = false;
+		ResourceLoadingController &loadingController = ResourceLoadingController::instance();
+		if (loadingController.active())
+		{
+			ResourceLoadingController::FrameProcessingMode loadingFrameMode = loadingController.currentFrameProcessingMode();
+			loadingController.step();
+			loadingController.presentLoadingScreenIfNeeded();
+			if (loadingFrameMode == ResourceLoadingController::FrameProcessingMode::ConsumeFrame)
+			{
+				pie_ScreenFrameRenderEnd();
+				frameEnded = true;
+			}
+		}
+		if (!frameEnded && loop_GetVideoStatus())
 		{
 			videoLoop(); // Display the video if necessary
 			pie_ScreenFrameRenderEnd();
 		}
-		else switch (GetGameMode())
+		else if (!frameEnded) switch (GetGameMode())
 			{
 			case GS_NORMAL: // Run the gameloop code
 				runGameLoop();
@@ -1221,6 +1246,16 @@ void mainLoop()
 #if defined(ENABLE_DISCORD)
 	discordRPCPerFrame();
 #endif
+}
+
+void requestMapPreviewLoad(bool hideInterface)
+{
+	ResourceLoadingController::instance().request(ResourceLoadingRequest::mapPreview(hideInterface));
+}
+
+void requestMapPreviewLoad(bool hideInterface, const char *mapName, const Sha256& mapHash)
+{
+	ResourceLoadingController::instance().request(ResourceLoadingRequest::mapPreview(hideInterface, mapName, mapHash));
 }
 
 bool getUTF8CmdLine(int *const _utfargc WZ_DECL_UNUSED, char *** const _utfargv WZ_DECL_UNUSED) // explicitely pass by reference
@@ -2089,14 +2124,14 @@ int realmain(int argc, char *argv[])
 	{
 	case GS_TITLE_SCREEN:
 		// The usual case (unless command-line flags specify otherwise): Load into the title menu
-		startTitleLoop(true);
+		ResourceLoadingController::instance().request(ResourceLoadingRequest::frontendInit(true));
 		break;
 	case GS_SAVEGAMELOAD:
 		if (headlessGameMode())
 		{
 			fprintf(stdout, "Loading savegame ...\n");
 		}
-		initSaveGameLoad();
+		ResourceLoadingController::instance().request(ResourceLoadingRequest::loadSaveGame());
 		break;
 	case GS_NORMAL:
 		if (!startGameLoop())

--- a/src/main.h
+++ b/src/main.h
@@ -21,6 +21,8 @@
 #ifndef __INCLUDED_SRC_MAIN_H__
 #define __INCLUDED_SRC_MAIN_H__
 
+struct Sha256;
+
 enum GS_GAMEMODE
 {
 	GS_TITLE_SCREEN,
@@ -64,6 +66,9 @@ struct SaveGamePath_t
 GS_GAMEMODE GetGameMode() WZ_DECL_PURE;
 void SetGameMode(GS_GAMEMODE status);
 void mainLoop();
+
+void requestMapPreviewLoad(bool hideInterface);
+void requestMapPreviewLoad(bool hideInterface, const char *mapName, const Sha256& mapHash);
 
 extern char SaveGamePath[PATH_MAX];
 extern char ReplayPath[PATH_MAX];

--- a/src/main_resource_loading.h
+++ b/src/main_resource_loading.h
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+/*
+	This file is part of Warzone 2100.
+	Copyright (C) 2026  Warzone 2100 Project
+
+	Warzone 2100 is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+
+	Warzone 2100 is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with Warzone 2100; if not, write to the Free Software
+	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+/** \file main_resource_loading.h
+ * \brief Phases hooks for starting a new game and loading a save: split so
+ * StartGameResourceJob / LoadSaveGameResourceJob can run before / blocking load / after (and failure cleanup)
+ * across cooperative loading steps; implementations are in main.cpp in this namespace.
+ * The same functions are also used by the synchronous `startGameLoop()` path in `main.cpp`.
+ *
+ * NOTE: This is a temporary solution to allow the cooperative loading controller to
+ * handle the loading of a new game and a save game. It is not a long-term solution
+ * and should be replaced with something more architecturally sound later.
+ */
+
+#pragma once
+
+namespace main_resource_loading
+{
+
+// Per-phase hooks used by `StartGameResourceJob` and `startGameLoop()`.
+
+// Prepares entering a new match (multiplayer timeouts, `setGameMode(GS_NORMAL)`,
+// loading screen, activity / CD-audio) before `levLoadData()`.
+void startGameBeforeLevelLoad();
+
+// Runs blocking levLoadData for the current `aLevelName` / `game.hash`; returns success.
+bool startGameRunLevelLoad();
+
+// Tears down after a failed start-game load and returns to the title loop.
+void startGameAbortLevelLoadFailure();
+
+// Post-success setup after `levLoadData()` (UI, gameInitialised, triggers, replay-related, etc.).
+bool startGameAfterLevelLoad();
+
+// Per-phase hooks used by `LoadSaveGameResourceJob` and `saveGameLoop()`.
+
+// Switches to `GS_NORMAL` immediately before `loadGameInit()` for a user save.
+void saveGameLoadBefore();
+
+// Loads the user save via `loadGameInit(makeUserSaveGameLoad(saveGameName))`; returns success.
+bool saveGameLoadRun();
+
+// On save load failure: log/popup, fast-exit game loop, return to title.
+void saveGameLoadAbortOnFailure();
+
+// Post-success after save load (activity, CD-audio, backdrop/loading, cursor, gameInitialised).
+bool saveGameLoadAfter();
+
+} // namespace main_resource_loading

--- a/src/multiint.cpp
+++ b/src/multiint.cpp
@@ -735,7 +735,7 @@ private:
 };
 
 /// Loads the entire map just to show a picture of it
-void loadMapPreview(bool hideInterface)
+void loadMapPreview(bool hideInterface, const char *mapName, const Sha256& mapHash)
 {
 	std::string		aFileName;
 	Vector2i playerpos[MAX_PLAYERS];	// Will hold player positions
@@ -752,16 +752,16 @@ void loadMapPreview(bool hideInterface)
 	}
 
 	// load the terrain types
-	LEVEL_DATASET *psLevel = levFindDataSet(game.map, &game.hash);
+	LEVEL_DATASET *psLevel = levFindDataSet(mapName, &mapHash);
 	if (psLevel == nullptr)
 	{
-		debug(LOG_INFO, "Could not find level dataset \"%s\" %s. We %s waiting for a download.", game.map, game.hash.toString().c_str(), !NET_getDownloadingWzFiles().empty() ? "are" : "aren't");
+		debug(LOG_INFO, "Could not find level dataset \"%s\" %s. We %s waiting for a download.", mapName, mapHash.toString().c_str(), !NET_getDownloadingWzFiles().empty() ? "are" : "aren't");
 		loadEmptyMapPreview();
 		return;
 	}
 	if (psLevel->game < 0 || psLevel->game >= LEVEL_MAXFILES)
 	{
-		debug(LOG_ERROR, "apDataFiles index (%" PRIi16 ") is out of bounds for: \"%s\" %s.", psLevel->game, game.map, game.hash.toString().c_str());
+		debug(LOG_ERROR, "apDataFiles index (%" PRIi16 ") is out of bounds for: \"%s\" %s.", psLevel->game, mapName, mapHash.toString().c_str());
 		loadEmptyMapPreview();
 		return;
 	}
@@ -881,6 +881,11 @@ void loadMapPreview(bool hideInterface)
 	{
 		hideTime = gameTime;
 	}
+}
+
+void loadMapPreview(bool hideInterface)
+{
+	loadMapPreview(hideInterface, game.map, game.hash);
 }
 
 // ////////////////////////////////////////////////////////////////////////////
@@ -7274,7 +7279,7 @@ TITLECODE WzMultiplayerOptionsTitleUI::run()
 			}
 
 			addPlayerBox(true);				// update the player box.
-			loadMapPreview(false);
+			requestMapPreviewLoad(false);
 			updateGameOptions();
 		}
 	}
@@ -7370,7 +7375,7 @@ TITLECODE WzMultiplayerOptionsTitleUI::run()
 						game.maxPlayers = mapData->players;
 						game.isMapMod = CheckForMod(mapData->realFileName);
 						game.isRandom = CheckForRandom(mapData->realFileName, mapData->apDataFiles[0].c_str());
-						loadMapPreview(false);
+						requestMapPreviewLoad(false, mapData->pName.c_str(), game.hash);
 
 						/* Change game info to match the previous selection if hover preview was displayed */
 						sstrcpy(game.map, oldGameMap);
@@ -7403,7 +7408,7 @@ TITLECODE WzMultiplayerOptionsTitleUI::run()
 					uint8_t oldMaxPlayers = game.maxPlayers;
 					updateMapSettings(mapData);
 
-					loadMapPreview(false);
+					requestMapPreviewLoad(false);
 					loadMapChallengeAndPlayerSettings();
 					debug(LOG_INFO, "Switching map: %s (builtin: %d)", (!mapData->pName.empty()) ? mapData->pName.c_str() : "n/a", (int)builtInMap);
 
@@ -7436,7 +7441,7 @@ TITLECODE WzMultiplayerOptionsTitleUI::run()
 				}
 				break;
 			default:
-				loadMapPreview(false);  // Restore the preview of the old map.
+				requestMapPreviewLoad(false);  // Restore the preview of the old map.
 				break;
 			}
 			if (!isHoverPreview)
@@ -7703,7 +7708,7 @@ void WzMultiplayerOptionsTitleUI::start()
 		}
 	}
 
-	loadMapPreview(false);
+	requestMapPreviewLoad(false);
 
 	const bool hostOrSingle = ingame.side == InGameSide::HOST_OR_SINGLEPLAYER;
 	/* Re-entering or entering without a challenge */

--- a/src/multiint.h
+++ b/src/multiint.h
@@ -168,7 +168,11 @@ std::string getDefaultSkirmishAI(const bool& displayNameOnly=false);
 
 void kickPlayer(uint32_t player_id, const char *reason, LOBBY_ERROR_TYPES type, bool banPlayer = false);
 void displayKickReasonPopup(const std::string &reason);
+
+struct Sha256;
+
 void loadMapPreview(bool hideInterface);
+void loadMapPreview(bool hideInterface, const char *mapName, const Sha256& mapHash);
 
 bool changeReadyStatus(UBYTE player, bool bReady);
 WzString formatGameName(WzString name);

--- a/src/multiopt.cpp
+++ b/src/multiopt.cpp
@@ -443,7 +443,7 @@ bool recvOptions(NETQUEUE queue)
 
 	if (mapData)
 	{
-		loadMapPreview(false);
+		requestMapPreviewLoad(false);
 	}
 
 	ActivityManager::instance().updateMultiplayGameData(game, ingame, NETGameIsLocked());

--- a/src/multiplay.cpp
+++ b/src/multiplay.cpp
@@ -2521,7 +2521,7 @@ bool recvMapFileData(NETQUEUE queue)
 			game.isRandom = true;
 		}
 
-		loadMapPreview(false);
+		requestMapPreviewLoad(false);
 		return true;
 	}
 

--- a/src/resource_loading_controller.cpp
+++ b/src/resource_loading_controller.cpp
@@ -1,0 +1,419 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+/*
+	This file is part of Warzone 2100.
+	Copyright (C) 2026  Warzone 2100 Project
+
+	Warzone 2100 is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+
+	Warzone 2100 is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with Warzone 2100; if not, write to the Free Software
+	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+/** \file resource_loading_controller.cpp
+ * \brief Implementation of the cooperative loading controller.
+ */
+
+#include "resource_loading_controller.h"
+
+#include "lib/framework/frameresource.h"
+#include "lib/framework/wzapp.h"
+
+#include "frontend.h"
+#include "init.h"
+#include "main.h"
+#include "main_resource_loading.h"
+#include "multiint.h"
+#include "wrappers.h"
+
+#include <utility>
+
+using namespace main_resource_loading;
+
+/// <summary>
+/// Cooperative loading job: a small per-frame state machine.
+/// `ResourceLoadingController::step()` calls `step()` at most once per main-loop
+/// iteration while the job is active.
+///
+/// Each `step()` performs part of the work, advances an internal phase (or leaves
+/// it unchanged), and returns:
+/// * `InProgress`  — keep the job; controller will call `step()` again on a later frame.
+/// * `Completed`   — controller calls `finalizeSuccess()` once, then destroys the job.
+/// * `Failed`      — controller calls `finalizeFailure()` once, then destroys the job.
+///
+/// Do not assume multiple `step()` calls in the same frame. Heavy work should be
+/// split across phases (or use a nested cooperative API like `resLoadPlanStep`)
+/// so the UI can update between frames.
+///
+/// `frameProcessingMode()` tells `mainLoop` whether this frame ends after loading UI
+/// only (`ConsumeFrame`) or may continue into the normal title/game loop (`ContinueMainLoop`).
+/// </summary>
+class IResourceLoadingJob
+{
+public:
+	enum class StepResult
+	{
+		InProgress,
+		Completed,
+		Failed,
+	};
+
+	virtual ~IResourceLoadingJob() = default;
+	virtual StepResult step() = 0;
+	virtual void finalizeSuccess() = 0;
+	virtual void finalizeFailure() = 0;
+	virtual ResourceLoadingController::FrameProcessingMode frameProcessingMode() const
+	{
+		return ResourceLoadingController::FrameProcessingMode::ConsumeFrame;
+	}
+};
+
+namespace
+{
+
+/// <summary>
+/// Frontend boot job:
+/// 1. Setup
+/// 2. cooperative WRF load (`ResLoadPlan` + `resLoadPlanStep`)
+///    * prepare load plan
+///    * load resources
+///    * complete load
+/// 3. finalize initialization
+/// </summary>
+class FrontendInitJob final : public IResourceLoadingJob
+{
+public:
+	explicit FrontendInitJob(ResourceLoadingRequest requestIn)
+		: request(std::move(requestIn))
+	{
+	}
+
+	StepResult step() override
+	{
+		switch (phase)
+		{
+		case Phase::Setup:
+			SetGameMode(GS_TITLE_SCREEN);
+			frontendIsShuttingDown();
+			debug(LOG_WZ, "== Initializing frontend == : %s", request.resourceFile.c_str());
+			if (!frontendInitialiseSetup())
+			{
+				return StepResult::Failed;
+			}
+			phase = Phase::PrepareResLoadPlan;
+			return StepResult::InProgress;
+		case Phase::PrepareResLoadPlan:
+			debug(LOG_MAIN, "frontEndInitialise: loading resource file .....");
+			if (!resPrepareLoadPlan(request.resourceFile.c_str(), 0, plan))
+			{
+				return StepResult::Failed;
+			}
+			phase = Phase::LoadResources;
+			return StepResult::InProgress;
+		case Phase::LoadResources:
+			if (!resLoadPlanStep(plan, resGetLoadPlanEntriesPerStep()))
+			{
+				return StepResult::Failed;
+			}
+			if (!resLoadPlanComplete(plan))
+			{
+				return StepResult::InProgress;
+			}
+			phase = Phase::Finalize;
+			return StepResult::InProgress;
+		case Phase::Finalize:
+			return frontendInitialiseFinalize() ? StepResult::Completed : StepResult::Failed;
+		}
+
+		return StepResult::Failed;
+	}
+
+	void finalizeSuccess() override
+	{
+		closeLoadingScreen();
+	}
+
+	void finalizeFailure() override
+	{
+		closeLoadingScreen();
+		debug(LOG_FATAL, "Shutting down after failure");
+		exit(EXIT_FAILURE);
+	}
+
+	ResourceLoadingController::FrameProcessingMode frameProcessingMode() const override
+	{
+		return ResourceLoadingController::FrameProcessingMode::ConsumeFrame;
+	}
+
+private:
+	enum class Phase
+	{
+		Setup,
+		PrepareResLoadPlan,
+		LoadResources,
+		Finalize,
+	};
+
+	ResourceLoadingRequest request;
+	Phase phase = Phase::Setup;
+	ResLoadPlan plan;
+};
+
+/// <summary>
+/// Start game from lobby/menu job:
+/// Currently uses hooks before/after a single blocking `levLoadData` path.
+/// </summary>
+class StartGameResourceJob final : public IResourceLoadingJob
+{
+public:
+	StepResult step() override
+	{
+		switch (phase)
+		{
+		case Phase::PresentInitialFrame:
+			phase = Phase::BeforeLevelLoad;
+			return StepResult::InProgress;
+		case Phase::BeforeLevelLoad:
+			startGameBeforeLevelLoad();
+			phase = Phase::LevelLoad;
+			return StepResult::InProgress;
+		case Phase::LevelLoad:
+			if (!startGameRunLevelLoad())
+			{
+				return StepResult::Failed;
+			}
+			phase = Phase::AfterLevelLoad;
+			return StepResult::InProgress;
+		case Phase::AfterLevelLoad:
+			return startGameAfterLevelLoad()
+			           ? StepResult::Completed
+			           : StepResult::Failed;
+		}
+		return StepResult::Failed;
+	}
+
+	void finalizeSuccess() override
+	{
+		closeLoadingScreen();
+	}
+
+	void finalizeFailure() override
+	{
+		startGameAbortLevelLoadFailure();
+		closeLoadingScreen();
+		debug(LOG_POPUP, _("Failed to load level data or map. Exiting to main menu."));
+	}
+
+private:
+	enum class Phase
+	{
+		PresentInitialFrame,
+		BeforeLevelLoad,
+		LevelLoad,
+		AfterLevelLoad,
+	};
+
+	Phase phase = Phase::PresentInitialFrame;
+};
+
+/// <summary>
+/// Load a save game job:
+/// Currently uses hooks before/after a single blocking save-load path (macro-phases only).
+/// </summary>
+class LoadSaveGameResourceJob final : public IResourceLoadingJob
+{
+public:
+	StepResult step() override
+	{
+		switch (phase)
+		{
+		case Phase::PresentInitialFrame:
+			phase = Phase::BeforeSaveLoad;
+			return StepResult::InProgress;
+		case Phase::BeforeSaveLoad:
+			saveGameLoadBefore();
+			phase = Phase::RunSaveLoad;
+			return StepResult::InProgress;
+		case Phase::RunSaveLoad:
+			if (!saveGameLoadRun())
+			{
+				return StepResult::Failed;
+			}
+			phase = Phase::AfterSaveLoad;
+			return StepResult::InProgress;
+		case Phase::AfterSaveLoad:
+			return saveGameLoadAfter()
+			           ? StepResult::Completed
+			           : StepResult::Failed;
+		}
+		return StepResult::Failed;
+	}
+
+	void finalizeSuccess() override
+	{
+		closeLoadingScreen();
+	}
+
+	void finalizeFailure() override
+	{
+		saveGameLoadAbortOnFailure();
+		closeLoadingScreen();
+	}
+
+private:
+	enum class Phase
+	{
+		PresentInitialFrame,
+		BeforeSaveLoad,
+		RunSaveLoad,
+		AfterSaveLoad,
+	};
+
+	Phase phase = Phase::PresentInitialFrame;
+};
+
+/// <summary>
+/// Lobby map backdrop preview job:
+/// One-shot CPU load + raster upload; defers work to controller but finishes same frame.
+/// </summary>
+class MapPreviewJob final : public IResourceLoadingJob
+{
+public:
+	explicit MapPreviewJob(ResourceLoadingRequest requestIn)
+		: request(std::move(requestIn))
+	{
+	}
+
+	StepResult step() override
+	{
+		if (request.previewMapName.empty())
+		{
+			loadMapPreview(request.hideInterface);
+		}
+		else
+		{
+			loadMapPreview(request.hideInterface, request.previewMapName.c_str(), request.previewMapHash);
+		}
+		return StepResult::Completed;
+	}
+
+	void finalizeSuccess() override { }
+
+	void finalizeFailure() override { }
+
+	ResourceLoadingController::FrameProcessingMode frameProcessingMode() const override
+	{
+		return ResourceLoadingController::FrameProcessingMode::ContinueMainLoop;
+	}
+
+private:
+	ResourceLoadingRequest request;
+};
+
+} // anonymous namespace
+
+ResourceLoadingController& ResourceLoadingController::instance()
+{
+	static ResourceLoadingController instance;
+	return instance;
+}
+
+void ResourceLoadingController::request(ResourceLoadingRequest requestIn)
+{
+	if (activeJob)
+	{
+		queuedRequest = std::move(requestIn);
+		return;
+	}
+
+	begin(std::move(requestIn));
+}
+
+void ResourceLoadingController::begin(ResourceLoadingRequest requestIn)
+{
+	ASSERT(!activeJob, "LoadingController.begin called while another loading job is active");
+	activeRequest = std::move(requestIn);
+	activeJob = makeJob(activeRequest.value());
+	ASSERT(activeJob, "Failed to create loading job");
+
+	const bool hadLoadingScreen = isLoadingScreenActive();
+	if (activeRequest->showLoadingScreen && !hadLoadingScreen)
+	{
+		initLoadingScreen(activeRequest->drawBackdrop);
+	}
+}
+
+bool ResourceLoadingController::active() const
+{
+	return activeJob != nullptr;
+}
+
+void ResourceLoadingController::step()
+{
+	ASSERT(activeJob, "LoadingController.step called without an active job");
+	IResourceLoadingJob::StepResult result = activeJob->step();
+	switch (result)
+	{
+	case IResourceLoadingJob::StepResult::InProgress:
+		return;
+	case IResourceLoadingJob::StepResult::Completed:
+		activeJob->finalizeSuccess();
+		break;
+	case IResourceLoadingJob::StepResult::Failed:
+		activeJob->finalizeFailure();
+		break;
+	}
+
+	activeJob.reset();
+	activeRequest.reset();
+
+	if (queuedRequest.has_value())
+	{
+		ResourceLoadingRequest nextRequest = std::move(queuedRequest.value());
+		queuedRequest.reset();
+		begin(std::move(nextRequest));
+	}
+}
+
+void ResourceLoadingController::presentLoadingScreenIfNeeded()
+{
+	if (activeRequest && activeRequest->showLoadingScreen)
+	{
+		presentLoadingScreenForCurrentFrame();
+	}
+}
+
+ResourceLoadingController::FrameProcessingMode ResourceLoadingController::currentFrameProcessingMode() const
+{
+	ASSERT(activeJob, "LoadingController.currentFrameProcessingMode called without an active job");
+	return activeJob->frameProcessingMode();
+}
+
+bool ResourceLoadingController::loadingScreenHandledByController() const
+{
+	return activeJob != nullptr && activeRequest.has_value() && activeRequest->showLoadingScreen;
+}
+
+std::unique_ptr<IResourceLoadingJob> ResourceLoadingController::makeJob(const ResourceLoadingRequest &request)
+{
+	switch (request.kind)
+	{
+	case ResourceLoadingRequest::Kind::FrontendInit:
+		return std::make_unique<FrontendInitJob>(request);
+	case ResourceLoadingRequest::Kind::StartGame:
+		return std::make_unique<StartGameResourceJob>();
+	case ResourceLoadingRequest::Kind::LoadSaveGame:
+		return std::make_unique<LoadSaveGameResourceJob>();
+	case ResourceLoadingRequest::Kind::MapPreview:
+		return std::make_unique<MapPreviewJob>(request);
+	}
+	return nullptr;
+}

--- a/src/resource_loading_controller.h
+++ b/src/resource_loading_controller.h
@@ -1,0 +1,176 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+/*
+	This file is part of Warzone 2100.
+	Copyright (C) 2026  Warzone 2100 Project
+
+	Warzone 2100 is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+
+	Warzone 2100 is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with Warzone 2100; if not, write to the Free Software
+	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+/** \file resource_loading_controller.h
+ * \brief Cooperative loading: schedule heavy load work from the main loop
+ * instead of freezing the game in one long call (or be dependent on
+ * `RESLOAD_CALLBACK` deep within the call chains to update the loading screen
+ * frames).
+ *
+ * Describes what to load (`frontendInit`, `startGame`, `loadSaveGame`, `mapPreview`)
+ * and exposes the controller API used to submit work and drive progress each frame,
+ * including when to show the normal loading screen.
+ */
+
+#pragma once
+
+#include "lib/framework/crc.h"
+
+#include <memory>
+#include <optional>
+#include <string>
+
+class IResourceLoadingJob;
+
+/// <summary>
+/// Describes one unit of loading work submitted to the resource loading controller.
+///
+/// NOTE: uses only a subset of the fields specific to each kind of loading request.
+/// </summary>
+struct ResourceLoadingRequest
+{
+	enum class Kind
+	{
+		FrontendInit,
+		StartGame,
+		LoadSaveGame,
+		MapPreview,
+	};
+
+	Kind kind;
+	bool drawBackdrop = true;
+	bool showLoadingScreen = true;
+	std::string resourceFile;
+	bool onInitialStartup = false;
+	bool hideInterface = false;
+	std::string previewMapName;
+	Sha256 previewMapHash;
+
+	static ResourceLoadingRequest frontendInit(bool onInitialStartup = false)
+	{
+		ResourceLoadingRequest request;
+		request.kind = Kind::FrontendInit;
+		request.drawBackdrop = !onInitialStartup;
+		request.showLoadingScreen = !onInitialStartup;
+		request.resourceFile = "wrf/frontend.wrf";
+		request.onInitialStartup = onInitialStartup;
+		return request;
+	}
+
+	static ResourceLoadingRequest startGame()
+	{
+		ResourceLoadingRequest request;
+		request.kind = Kind::StartGame;
+		return request;
+	}
+
+	static ResourceLoadingRequest loadSaveGame()
+	{
+		ResourceLoadingRequest request;
+		request.kind = Kind::LoadSaveGame;
+		return request;
+	}
+
+	static ResourceLoadingRequest mapPreview(bool hideInterface)
+	{
+		ResourceLoadingRequest request;
+		request.kind = Kind::MapPreview;
+		request.drawBackdrop = false;
+		request.showLoadingScreen = false;
+		request.hideInterface = hideInterface;
+		return request;
+	}
+
+	static ResourceLoadingRequest mapPreview(bool hideInterface, std::string mapName, Sha256 mapHash)
+	{
+		ResourceLoadingRequest request = mapPreview(hideInterface);
+		request.previewMapName = std::move(mapName);
+		request.previewMapHash = mapHash;
+		return request;
+	}
+};
+
+/// <summary>
+/// Global cooperative loading scheduler used from `mainLoop`: at most one active job,
+/// optional single queued follow-up `request`. `step` runs once per frame while active.
+/// Jobs may consume the whole frame or allow the normal title/game loop to run afterward
+/// (`FrameProcessingMode`).
+///
+/// Loading screen UI is driven here when `showLoadingScreen` is set.
+/// </summary>
+class ResourceLoadingController
+{
+public:
+
+	// How `mainLoop` should finish the current iteration after `step()` for the active job.
+	enum class FrameProcessingMode
+	{
+		// End frame after loading step + optional loading UI; skip title/game loop this tick.
+		ConsumeFrame,
+		// Same frame continues into normal mode (e.g. map preview job).
+		ContinueMainLoop,
+	};
+
+	static ResourceLoadingController &instance();
+
+	explicit ResourceLoadingController() = default;
+	~ResourceLoadingController() = default;
+
+	ResourceLoadingController(const ResourceLoadingController&) = delete;
+	ResourceLoadingController &operator=(const ResourceLoadingController&) = delete;
+
+	ResourceLoadingController(ResourceLoadingController&&) = delete;
+	ResourceLoadingController &operator=(ResourceLoadingController&&) = delete;
+
+	// Submit a new loading request. If there is an active job, queue the request;
+	// otherwise begin a new job with the request.
+	void request(ResourceLoadingRequest request);
+
+	// Returns true if there is an active job.
+	bool active() const;
+
+	// Advance the active job's state machine.
+	void step();
+
+	// Present the loading screen if needed.
+	void presentLoadingScreenIfNeeded();
+
+	// Valid only while `active()`; reflects the active job's policy for this frame.
+	FrameProcessingMode currentFrameProcessingMode() const;
+
+	// When true, mainLoop presents the loading screen; callback must not flip frames.
+	bool loadingScreenHandledByController() const;
+
+private:
+
+	void begin(ResourceLoadingRequest request);
+	static std::unique_ptr<IResourceLoadingJob> makeJob(const ResourceLoadingRequest &request);
+
+	std::optional<ResourceLoadingRequest> activeRequest;
+	// NOTE: It makes sense to support queueing only a single request at a time,
+	// since resource loading jobs represent coarse-grained loading steps (additional
+	// work that'll be made on behalf of the currently active job is represented
+	// by a new sub-job belonging to the active job).
+	//
+	// So it's absolutely sufficient to only store the next loading step in the
+	// controller's state machine.
+	std::optional<ResourceLoadingRequest> queuedRequest;
+	std::unique_ptr<IResourceLoadingJob> activeJob;
+};

--- a/src/titleui/widgets/multilobbyoptions.cpp
+++ b/src/titleui/widgets/multilobbyoptions.cpp
@@ -44,6 +44,7 @@
 #include "src/multiplay.h"
 #include "src/multivote.h"
 #include "src/multilimit.h"
+#include "src/main.h"
 #include "src/frend.h"
 #include "src/loadsave.h"
 #include "src/intimage.h"
@@ -946,7 +947,7 @@ void WzMultiLobbyOptionsImpl::initialize(bool _isChallenge, const std::shared_pt
 		mapViewButton->setTip(_("Click to see Map"));
 		mapViewButton->addOnClickHandler([](W_BUTTON&) {
 			widgScheduleTask([]{
-				loadMapPreview(true);
+				requestMapPreviewLoad(true);
 			});
 		});
 		auto mapChangeButton = addSectionImageButton(mapWidget, IMAGE_GLOBE, 2);

--- a/src/wrappers.cpp
+++ b/src/wrappers.cpp
@@ -43,6 +43,7 @@
 #include "multistat.h"
 #include "warzoneconfig.h"
 #include "wrappers.h"
+#include "resource_loading_controller.h"
 #include "titleui/titleui.h"
 #include "stdinreader.h"
 
@@ -66,6 +67,7 @@ static HostLaunch hostlaunch = HostLaunch::Normal;  // used to detect if we are 
 static bool bHeadlessAutoGameModeCLIOption = false;
 static bool bActualHeadlessAutoGameMode = false;
 static bool bHostLaunchStartNotReady = false;
+static bool loadingScreenSessionActive = false;
 
 static uint32_t lastTick = 0;
 static int barLeftX, barLeftY, barRightX, barRightY, boxWidth, boxHeight, starsNum, starHeight;
@@ -78,6 +80,31 @@ static STAR newStar()
 	s.speed = static_cast<int>((rand() % 30 + 6) * pie_GetVideoBufferWidth() / 640.0);
 	s.colour = pal_SetBrightness(150 + rand() % 100);
 	return s;
+}
+
+static void renderLoadingScreenPass()
+{
+	const PIELIGHT loadingbar_background = WZCOL_LOADING_BAR_BACKGROUND;
+
+	pie_UniTransBoxFill(barLeftX - 2, barLeftY - 2, barRightX + 2, barRightY + 2, loadingbar_background);
+
+	for (unsigned int i = 1; i < static_cast<unsigned int>(starsNum); ++i)
+	{
+		stars[i].xPos = stars[i].xPos + stars[i].speed;
+		if (barLeftX + stars[i].xPos >= barRightX)
+		{
+			stars[i] = newStar();
+			stars[i].xPos = 1;
+		}
+		{
+			const int topX = barLeftX + stars[i].xPos;
+			const int topY = barLeftY + i * (boxHeight - starHeight) / starsNum;
+			const int botX = MIN(topX + stars[i].speed, barRightX);
+			const int botY = topY + starHeight;
+
+			pie_UniTransBoxFill(topX, topY, botX, botY, stars[i].colour);
+		}
+	}
 }
 
 static void setupLoadingScreen()
@@ -267,12 +294,30 @@ TITLECODE titleLoop()
 ////////////////////////////////////////////////////////////////////////////////
 // Loading Screen.
 
-//loadbar update
+bool isLoadingScreenActive()
+{
+	return loadingScreenSessionActive;
+}
+
+void presentLoadingScreenForCurrentFrame()
+{
+	if (!loadingScreenSessionActive || headlessGameMode())
+	{
+		return;
+	}
+
+	if (screen_GetBackDrop())
+	{
+		screen_Display();
+	}
+
+	renderLoadingScreenPass();
+}
+
+//loadbar update — audio/event pump only; drawing is done from mainLoop via presentLoadingScreenForCurrentFrame.
 void loadingScreenCallback()
 {
-	const PIELIGHT loadingbar_background = WZCOL_LOADING_BAR_BACKGROUND;
 	const uint32_t currTick = wzGetTicks();
-	unsigned int i;
 
 	if (currTick - lastTick < 50)
 	{
@@ -281,33 +326,18 @@ void loadingScreenCallback()
 
 	lastTick = currTick;
 
-	/* Draw the black rectangle at the bottom, with a two pixel border */
-	pie_UniTransBoxFill(barLeftX - 2, barLeftY - 2, barRightX + 2, barRightY + 2, loadingbar_background);
-
-	for (i = 1; i < starsNum; ++i)
-	{
-		stars[i].xPos = stars[i].xPos + stars[i].speed;
-		if (barLeftX + stars[i].xPos >= barRightX)
-		{
-			stars[i] = newStar();
-			stars[i].xPos = 1;
-		}
-		{
-			const int topX = barLeftX + stars[i].xPos;
-			const int topY = barLeftY + i * (boxHeight - starHeight) / starsNum;
-			const int botX = MIN(topX + stars[i].speed, barRightX);
-			const int botY = topY + starHeight;
-
-			pie_UniTransBoxFill(topX, topY, botX, botY, stars[i].colour);
-		}
-	}
-
-	pie_ScreenFrameRenderEnd();
-	pie_ScreenFrameRenderBegin();
-
 	audio_Update();
 
 	wzPumpEventsWhileLoading();
+
+	// Blocking loads (e.g. startTitleLoop → frontendInitialise) still use this callback from deep
+	// inside resLoad; cooperative jobs present from mainLoop instead.
+	if (!ResourceLoadingController::instance().loadingScreenHandledByController() && loadingScreenSessionActive && !headlessGameMode())
+	{
+		presentLoadingScreenForCurrentFrame();
+		pie_ScreenFrameRenderEnd();
+		pie_ScreenFrameRenderBegin();
+	}
 }
 
 #if defined(__EMSCRIPTEN__)
@@ -327,10 +357,11 @@ void wzemscripten_display_web_loading_indicator(int x)
 // fill buffers with the static screen
 void initLoadingScreen(bool drawbdrop)
 {
-	pie_ScreenFrameRenderBegin(); // start a frame *if one isn't yet started*
 	setupLoadingScreen();
 	wzShowMouse(false);
 	pie_SetFogStatus(false);
+	loadingScreenSessionActive = true;
+	lastTick = 0;
 
 #if !defined(__EMSCRIPTEN__)
 	// setup the callback....
@@ -356,6 +387,8 @@ void initLoadingScreen(bool drawbdrop)
 // shut down the loading screen
 void closeLoadingScreen()
 {
+	loadingScreenSessionActive = false;
+
 	if (stars)
 	{
 		free(stars);

--- a/src/wrappers.h
+++ b/src/wrappers.h
@@ -60,6 +60,8 @@ TITLECODE titleLoop();
 void initLoadingScreen(bool drawbdrop);
 void closeLoadingScreen();
 void loadingScreenCallback();
+bool isLoadingScreenActive();
+void presentLoadingScreenForCurrentFrame();
 
 bool displayGameOver(bool success, bool showBackDrop);
 void setPlayerHasLost(bool val);


### PR DESCRIPTION
Route major load paths (frontend boot, starting a game, loading a save, map preview) through a single loading controller advanced once per main loop iteration, instead of doing all work in one blocking call deep in the call stack (and be dependent on calling `RESLOAD_CALLBACK` across multiple scattered places to ensure the loading screen UI gets updated in a timely manner).

Refactor WRF handling so parsing builds a load plan and resources are applied in steps; split frontend init into phases that fit that model. Draw the loading screen from the main loop so presentation stays under the same frame owner as the rest of the game.

Share start-game and save-load steps via small hooks used by both the controller-driven path and existing synchronous entry points where they still apply. Lobby map preview is requested through the controller so it aligns with the same scheduling model.

NOTE: In the current state, there may be a slight regression in how frequent loading screen UI gets updated, because level loading code used to call `RESLOAD_CALLBACK` in a few pre-defined steps. Now that we don't use it, further refactoring of `levLoadData()` will be needed to address this (well, we still use it, although its responsibility to drive rendering of loading screen is greatly reduced and eventually after some more rounds of refactoring it will be gone).

Partially addresses #4858 (`GS_LOADING` not implemented here + additional refactoring for `levLoadData()` and mission transitions will be needed).