### PR TITLE
Reduce `apsFeatureLists` to a single list and rename to `apsFeatureList`

### DIFF
--- a/src/display3d.cpp
+++ b/src/display3d.cpp
@@ -2328,7 +2328,7 @@ static void displayFeatures(const glm::mat4 &viewMatrix, const glm::mat4 &perspe
 	// player can only be 0 for the features.
 
 	/* Go through all the features */
-	for (BASE_OBJECT* obj : apsFeatureLists[0])
+	for (BASE_OBJECT* obj : apsFeatureList[0])
 	{
 		if (obj->type == OBJ_FEATURE
 			&& (obj->died == 0 || obj->died > graphicsTime)
@@ -3711,7 +3711,7 @@ static void	drawDroidSelections()
 		}
 	}
 
-	for (const FEATURE *psFeature : apsFeatureLists[0])
+	for (const FEATURE *psFeature : apsFeatureList[0])
 	{
 		if (!psFeature->died && psFeature->sDisplay.frameNumber == currentGameFrame)
 		{

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2703,14 +2703,14 @@ bool loadGame(const GameLoadDetails& gameToLoad, bool keepObjects, bool freeMem)
 		{
 			apsDroidLists[player].clear();
 			apsStructLists[player].clear();
-			apsFeatureLists[player].clear();
 			apsFlagPosLists[player].clear();
 			//clear all the messages?
 			apsProxDisp[player].clear();
-			apsSensorList[0].clear();
 			apsExtractorLists[player].clear();
 		}
+		apsFeatureList[0].clear();
 		apsOilList[0].clear();
+		apsSensorList[0].clear();
 		initFactoryNumFlag();
 	}
 
@@ -2722,10 +2722,10 @@ bool loadGame(const GameLoadDetails& gameToLoad, bool keepObjects, bool freeMem)
 			apsLimboDroids[player].clear();
 			mission.apsDroidLists[player].clear();
 			mission.apsStructLists[player].clear();
-			mission.apsFeatureLists[player].clear();
 			mission.apsFlagPosLists[player].clear();
 			mission.apsExtractorLists[player].clear();
 		}
+		mission.apsFeatureList[0].clear();
 		mission.apsOilList[0].clear();
 		mission.apsSensorList[0].clear();
 
@@ -3034,7 +3034,7 @@ bool loadGame(const GameLoadDetails& gameToLoad, bool keepObjects, bool freeMem)
 		aFileName[fileExten] = '\0';
 		strcat(aFileName, "mfeature.json");
 
-		//load the data into apsFeatureLists
+		//load the data into apsFeatureList
 		if (!loadSaveFeature2(aFileName))
 		{
 			aFileName[fileExten] = '\0';
@@ -7218,7 +7218,7 @@ bool writeFeatureFile(const char *pFileName)
 	WzConfig ini(WzString::fromUtf8(pFileName), WzConfig::ReadAndWrite);
 	int counter = 0;
 
-	for (const FEATURE *psCurr : apsFeatureLists[0])
+	for (const FEATURE *psCurr : apsFeatureList[0])
 	{
 		ini.beginGroup("feature_" + (WzString::number(counter++).leftPadToMinimumLength(WzUniCodepoint::fromASCII('0'), 10)));  // Zero padded so that alphabetical sort works.
 		ini.setValue("name", psCurr->psStats->id);

--- a/src/keybind.cpp
+++ b/src/keybind.cpp
@@ -1318,7 +1318,7 @@ void	kf_ToggleGodMode()
 		godMode = false;
 		setRevealStatus(pastReveal);
 		// now hide the features
-		for (BASE_OBJECT* psFeat : apsFeatureLists[0])
+		for (BASE_OBJECT* psFeat : apsFeatureList[0])
 		{
 			psFeat->visible[selectedPlayer] = 0;
 		}

--- a/src/loop.cpp
+++ b/src/loop.cpp
@@ -598,7 +598,7 @@ static void gameStateUpdate()
 
 	executeFnAndProcessScriptQueuedRemovals([]() { proj_UpdateAll(); });
 
-	for (FEATURE *psCFeat : apsFeatureLists[0])
+	for (FEATURE *psCFeat : apsFeatureList[0])
 	{
 		featureUpdate(psCFeat);
 	}

--- a/src/mapgrid.cpp
+++ b/src/mapgrid.cpp
@@ -79,15 +79,15 @@ void gridReset()
 				}
 			}
 		}
-		for (BASE_OBJECT* psObj : apsFeatureLists[player])
+	}
+	for (BASE_OBJECT* psObj : apsFeatureList[0])
+	{
+		if (!psObj->died)
 		{
-			if (!psObj->died)
+			gridPointTree->insert(psObj, psObj->pos.x, psObj->pos.y);
+			for (unsigned char& viewer : psObj->seenThisTick)
 			{
-				gridPointTree->insert(psObj, psObj->pos.x, psObj->pos.y);
-				for (unsigned char& viewer : psObj->seenThisTick)
-				{
-					viewer = 0;
-				}
+				viewer = 0;
 			}
 		}
 	}
@@ -150,7 +150,7 @@ static GridList const &gridStartIterateFiltered(int32_t x, int32_t y, uint32_t r
 
 	// In case you are curious.
 	//debug(LOG_WARNING, "gridStartIterateFiltered(%d, %d, %u) found %u objects", x, y, radius, (unsigned)gridPointTree->lastQueryResults.size());
-	
+
 	static GridList gridList;
 	gridList.resize(gridPointTree->lastQueryResults.size());
 	for (unsigned n = 0; n < gridList.size(); ++n)

--- a/src/mission.cpp
+++ b/src/mission.cpp
@@ -275,11 +275,11 @@ void initMission()
 	{
 		mission.apsStructLists[inc].clear();
 		mission.apsDroidLists[inc].clear();
-		mission.apsFeatureLists[inc].clear();
 		mission.apsFlagPosLists[inc].clear();
 		mission.apsExtractorLists[inc].clear();
 		apsLimboDroids[inc].clear();
 	}
+	mission.apsFeatureList[0].clear();
 	mission.apsSensorList[0].clear();
 	mission.apsOilList[0].clear();
 	offWorldKeepLists = false;
@@ -342,15 +342,15 @@ bool missionShutDown()
 			mission.apsDroidLists[inc].clear();
 			apsStructLists[inc] = std::move(mission.apsStructLists[inc]);
 			mission.apsStructLists[inc].clear();
-			apsFeatureLists[inc] = std::move(mission.apsFeatureLists[inc]);
-			mission.apsFeatureLists[inc].clear();
 			apsFlagPosLists[inc] = std::move(mission.apsFlagPosLists[inc]);
 			mission.apsFlagPosLists[inc].clear();
 			apsExtractorLists[inc] = std::move(mission.apsExtractorLists[inc]);
 			mission.apsExtractorLists[inc].clear();
 		}
+		apsFeatureList[0] = std::move(mission.apsFeatureList[0]);
 		apsSensorList[0] = std::move(mission.apsSensorList[0]);
 		apsOilList[0] = std::move(mission.apsOilList[0]);
+		mission.apsFeatureList[0].clear();
 		mission.apsSensorList[0].clear();
 		mission.apsOilList[0].clear();
 
@@ -796,10 +796,10 @@ static void saveMissionData()
 	{
 		mission.apsStructLists[inc] = apsStructLists[inc];
 		mission.apsDroidLists[inc] = apsDroidLists[inc];
-		mission.apsFeatureLists[inc] = apsFeatureLists[inc];
 		mission.apsFlagPosLists[inc] = apsFlagPosLists[inc];
 		mission.apsExtractorLists[inc] = apsExtractorLists[inc];
 	}
+	mission.apsFeatureList[0] = apsFeatureList[0];
 	mission.apsSensorList[0] = apsSensorList[0];
 	mission.apsOilList[0] = apsOilList[0];
 
@@ -859,17 +859,16 @@ void restoreMissionData()
 		apsStructLists[inc] = std::move(mission.apsStructLists[inc]);
 		mission.apsStructLists[inc].clear();
 
-		apsFeatureLists[inc] = std::move(mission.apsFeatureLists[inc]);
-		mission.apsFeatureLists[inc].clear();
-
 		apsFlagPosLists[inc] = std::move(mission.apsFlagPosLists[inc]);
 		mission.apsFlagPosLists[inc].clear();
 
 		apsExtractorLists[inc] = std::move(mission.apsExtractorLists[inc]);
 		mission.apsExtractorLists[inc].clear();
 	}
+	apsFeatureList[0] = std::move(mission.apsFeatureList[0]);
 	apsSensorList[0] = std::move(mission.apsSensorList[0]);
 	apsOilList[0] = std::move(mission.apsOilList[0]);
+	mission.apsFeatureList[0].clear();
 	mission.apsSensorList[0].clear();
 	apsOilList[0].clear();
 	//swap mission data over
@@ -1406,10 +1405,10 @@ void swapMissionPointers()
 	{
 		std::swap(apsDroidLists[inc],     mission.apsDroidLists[inc]);
 		std::swap(apsStructLists[inc],    mission.apsStructLists[inc]);
-		std::swap(apsFeatureLists[inc],   mission.apsFeatureLists[inc]);
 		std::swap(apsFlagPosLists[inc],   mission.apsFlagPosLists[inc]);
 		std::swap(apsExtractorLists[inc], mission.apsExtractorLists[inc]);
 	}
+	std::swap(apsFeatureList[0],   mission.apsFeatureList[0]);
 	std::swap(apsSensorList[0], mission.apsSensorList[0]);
 	std::swap(apsOilList[0],    mission.apsOilList[0]);
 }

--- a/src/missiondef.h
+++ b/src/missiondef.h
@@ -68,7 +68,7 @@ struct MISSION
 	PerPlayerExtractorLists apsExtractorLists;
 
 	PerPlayerDroidLists              apsDroidLists;
-	PerPlayerFeatureLists           apsFeatureLists;
+	GlobalFeatureList               apsFeatureList;
 	GlobalSensorList                apsSensorList;
 	GlobalOilList                   apsOilList;
 	PerPlayerFlagPositionLists      apsFlagPosLists;

--- a/src/multiplay.cpp
+++ b/src/multiplay.cpp
@@ -732,7 +732,7 @@ STRUCTURE *IdToStruct(UDWORD id, UDWORD player)
 FEATURE *IdToFeature(UDWORD id, UDWORD player)
 {
 	(void)player;	// unused, all features go into player 0
-	return (FEATURE*)getBaseObjFromId(apsFeatureLists[0], id);
+	return (FEATURE*)getBaseObjFromId(apsFeatureList[0], id);
 }
 
 // ////////////////////////////////////////////////////////////////////////////

--- a/src/objmem.cpp
+++ b/src/objmem.cpp
@@ -59,7 +59,7 @@ uint32_t                synchObjID;
 /* The lists of objects allocated */
 PerPlayerDroidLists apsDroidLists;
 PerPlayerStructureLists apsStructLists;
-PerPlayerFeatureLists apsFeatureLists;		///< Only player zero is valid for features. TODO: Reduce to single list.
+GlobalFeatureList apsFeatureList;
 PerPlayerExtractorLists apsExtractorLists;
 GlobalOilList apsOilList;
 GlobalSensorList apsSensorList; ///< List of sensors in the game.
@@ -363,10 +363,11 @@ uint32_t generateSynchronisedObjectId()
 /* Add the object to its list
  * \param list is a pointer to the object list
  */
-template <typename OBJECT>
-static inline void addObjectToList(PerPlayerObjectLists<OBJECT, MAX_PLAYERS>& list, OBJECT* object, int player)
+template <typename OBJECT, size_t PlayerCount = MAX_PLAYERS>
+static inline void addObjectToList(PerPlayerObjectLists<OBJECT, PlayerCount>& list, OBJECT* object, int player)
 {
 	ASSERT_OR_RETURN(, object != nullptr, "Invalid pointer");
+	ASSERT_OR_RETURN(, player < PlayerCount, "Invalid player index: %d", player);
 
 	// Prepend the object to the top of the list
 	list[player].emplace_front(object);
@@ -390,10 +391,11 @@ static inline void addObjectToFuncList(FunctionList& list, OBJECT *object, int p
  * \param list is a pointer to the object list
  * \param del is a pointer to the object to remove
  */
-template <typename OBJECT>
-static inline void destroyObject(PerPlayerObjectLists<OBJECT, MAX_PLAYERS>& list, OBJECT* object)
+template <typename OBJECT, size_t PlayerCount = MAX_PLAYERS>
+static inline void destroyObject(PerPlayerObjectLists<OBJECT, PlayerCount>& list, OBJECT* object)
 {
 	ASSERT_OR_RETURN(, object != nullptr, "Invalid pointer");
+	ASSERT_OR_RETURN(, object->player < PlayerCount, "Invalid player index: %d", object->player);
 	ASSERT(gameTime - deltaGameTime <= gameTime || gameTime == 2, "Expected %u <= %u, bad time", gameTime - deltaGameTime, gameTime);
 
 	auto it = std::find(list[object->player].begin(), list[object->player].end(), object);
@@ -751,7 +753,7 @@ void removeStructureFromList(STRUCTURE *psStructToRemove, PerPlayerStructureList
 /* add the feature to the Feature Lists */
 void addFeature(FEATURE *psFeatureToAdd)
 {
-	addObjectToList(apsFeatureLists, psFeatureToAdd, 0);
+	addObjectToList(apsFeatureList, psFeatureToAdd, 0);
 	if (psFeatureToAdd->psStats->subType == FEAT_OIL_RESOURCE)
 	{
 		addObjectToFuncList(apsOilList, psFeatureToAdd, 0);
@@ -766,7 +768,7 @@ void killFeature(FEATURE *psDel)
 	ASSERT(psDel->type == OBJ_FEATURE,
 	       "killFeature: pointer is not a feature");
 	psDel->player = 0;
-	destroyObject(apsFeatureLists, psDel);
+	destroyObject(apsFeatureList, psDel);
 
 	if (psDel->psStats->subType == FEAT_OIL_RESOURCE)
 	{
@@ -777,7 +779,7 @@ void killFeature(FEATURE *psDel)
 /* Remove all features */
 void freeAllFeatures()
 {
-	freeAllEntitiesImpl<FEATURE, MAX_PLAYERS>(apsFeatureLists);
+	freeAllEntitiesImpl<FEATURE, 1>(apsFeatureList);
 }
 
 /**************************  FLAG_POSITION ********************************/
@@ -994,12 +996,12 @@ BASE_OBJECT *getBaseObjFromData(unsigned id, unsigned player, OBJECT_TYPE type)
 		}
 	case OBJ_FEATURE:
 		{
-			auto pFeat = getBaseObjFromId(apsFeatureLists[0], id);
+			auto pFeat = getBaseObjFromId(apsFeatureList[0], id);
 			if (pFeat)
 			{
 				return pFeat;
 			}
-			pFeat = getBaseObjFromId(mission.apsFeatureLists[0], id);
+			pFeat = getBaseObjFromId(mission.apsFeatureList[0], id);
 			if (pFeat)
 			{
 				return pFeat;
@@ -1118,7 +1120,7 @@ static void objListIntegCheck()
 			       objInfo(psStruct), (void*)psStruct, player, (int)psStruct->player);
 		}
 	}
-	for (const BASE_OBJECT* obj : apsFeatureLists[0])
+	for (const BASE_OBJECT* obj : apsFeatureList[0])
 	{
 		ASSERT(obj->type == OBJ_FEATURE,
 		       "objListIntegCheck: misplaced object in the feature list");
@@ -1150,5 +1152,5 @@ void objCount(int *droids, int *structures, int *features)
 		*structures += apsStructLists[i].size();
 	}
 
-	*features += apsFeatureLists[0].size();
+	*features += apsFeatureList[0].size();
 }

--- a/src/objmem.h
+++ b/src/objmem.h
@@ -41,9 +41,9 @@ using PerPlayerStructureLists = PerPlayerObjectLists<STRUCTURE, MAX_PLAYERS>;
 using StructureList = typename PerPlayerStructureLists::value_type;
 extern PerPlayerStructureLists apsStructLists;
 
-using PerPlayerFeatureLists = PerPlayerObjectLists<FEATURE, MAX_PLAYERS>;
-using FeatureList = typename PerPlayerFeatureLists::value_type;
-extern PerPlayerFeatureLists apsFeatureLists;
+using GlobalFeatureList = PerPlayerObjectLists<FEATURE, 1>;
+using FeatureList = typename GlobalFeatureList::value_type;
+extern GlobalFeatureList apsFeatureList;
 
 using PerPlayerFlagPositionLists = PerPlayerObjectLists<FLAG_POSITION, MAX_PLAYERS>;
 using FlagPositionList = typename PerPlayerFlagPositionLists::value_type;

--- a/src/structure.cpp
+++ b/src/structure.cpp
@@ -6092,15 +6092,6 @@ void hqReward(UBYTE losingPlayer, UBYTE rewardPlayer)
 			}
 		}
 
-		//feature
-		for (FEATURE *psFeat : apsFeatureLists[i])
-		{
-			if (psFeat->visible[losingPlayer])
-			{
-				psFeat->visible[rewardPlayer] = psFeat->visible[losingPlayer];
-			}
-		}
-
 		//droids.
 		for (DROID *psDroid : apsDroidLists[i])
 		{
@@ -6108,6 +6099,15 @@ void hqReward(UBYTE losingPlayer, UBYTE rewardPlayer)
 			{
 				psDroid->visible[rewardPlayer] = UBYTE_MAX;
 			}
+		}
+	}
+
+	//feature
+	for (FEATURE *psFeat : apsFeatureList[0])
+	{
+		if (psFeat->visible[losingPlayer])
+		{
+			psFeat->visible[rewardPlayer] = psFeat->visible[losingPlayer];
 		}
 	}
 }

--- a/src/visibility.cpp
+++ b/src/visibility.cpp
@@ -846,10 +846,10 @@ void processVisibility()
 		{
 			processVisibilitySelf(psObj);
 		}
-		for (BASE_OBJECT* psObj : apsFeatureLists[player])
-		{
-			processVisibilitySelf(psObj);
-		}
+	}
+	for (BASE_OBJECT* psObj : apsFeatureList[0])
+	{
+		processVisibilitySelf(psObj);
 	}
 	for (int player = 0; player < MAX_PLAYERS; ++player)
 	{
@@ -888,10 +888,10 @@ void processVisibility()
 		{
 			processVisibilityLevel(psObj, addedMessage);
 		}
-		for (BASE_OBJECT* psObj : apsFeatureLists[player])
-		{
-			processVisibilityLevel(psObj, addedMessage);
-		}
+	}
+	for (BASE_OBJECT* psObj : apsFeatureList[0])
+	{
+		processVisibilityLevel(psObj, addedMessage);
 	}
 	if (addedMessage)
 	{

--- a/src/wzapi.cpp
+++ b/src/wzapi.cpp
@@ -1143,7 +1143,7 @@ std::vector<const FEATURE *> wzapi::enumFeature(WZAPI_PARAMS(int playerFilter, o
 	}
 
 	std::vector<const FEATURE *> matches;
-	for (const FEATURE *psFeat : apsFeatureLists[0])
+	for (const FEATURE *psFeat : apsFeatureList[0])
 	{
 		if ((playerFilter == ALL_PLAYERS || psFeat->visible[playerFilter])
 		    && !psFeat->died
@@ -2017,7 +2017,7 @@ wzapi::returned_nullable_ptr<const FEATURE> wzapi::addFeature(WZAPI_PARAMS(std::
 	int feature = getFeatureStatFromName(WzString::fromUtf8(featureName));
 	SCRIPT_ASSERT(nullptr, context, feature >= 0 && feature < asFeatureStats.size(), "Unknown feature name: %s", featureName.c_str());
 	FEATURE_STATS *psStats = &asFeatureStats[feature];
-	for (const FEATURE *psFeat : apsFeatureLists[0])
+	for (const FEATURE *psFeat : apsFeatureList[0])
 	{
 		SCRIPT_ASSERT(nullptr, context, map_coord(psFeat->pos.x) != x || map_coord(psFeat->pos.y) != y,
 		              "Building feature on tile already occupied");


### PR DESCRIPTION
This is perfectly safe since all features are assigned to player slot 0.