### PR TITLE
framework: Simplify some SFINAE checks for `PagedEntityContainer` and `LoopBodyHandlerCallStrategy`

### DIFF
--- a/lib/framework/object_list_iteration.h
+++ b/lib/framework/object_list_iteration.h
@@ -22,7 +22,6 @@
 #pragma once
 
 #include <list>
-#include <type_traits>
 #include <iterator>
 #include <functional>
 
@@ -50,17 +49,11 @@ enum class IterationResult
 template <typename Callable>
 struct LoopBodyHandlerCallStrategy
 {
-	// Since we are constrained by C++14, we'll need to use SFINAE to determine correct
-	// specialization of `Invoke` to call depending on input type of handler function.
-	//
-	// Here we use a bunch of compile-time tests to determine
-	// whether our callable is convertible to `std::function` of a compatible signature.
+	// Use a bunch of compile-time tests to determine whether our callable is
+	// convertible to `std::function` of a compatible signature.
 	//
 	// This is the most simple way to constrain and choose a correct overload
-	// of `Invoke` function depending on the callable signature.
-	//
-	// Choosing the correct overload is done via `std::enable_if<Cond, T>` helper from <type_traits>,
-	// which basically provides `using type = T` only when `Cond` is `true`.
+	// of `Invoke` function depending on the callable signature given C++17 capabilities.
 	template <typename ObjectType>
 	static constexpr bool handler_accepts_ptr = std::is_convertible<
 		Callable,
@@ -70,20 +63,24 @@ struct LoopBodyHandlerCallStrategy
 		Callable,
 		std::function<IterationResult(typename std::list<ObjectType*>::iterator)>>::value;
 
-	// `Invoke` overload for Callable taking a list iterator as the argument
-	template <typename ObjectType>
-	static std::enable_if_t<handler_accepts_iter<ObjectType>, IterationResult>
-		Invoke(Callable handler, typename std::list<ObjectType*>::iterator iter)
-	{
-		return handler(iter);
-	}
 
-	// `Invoke` overload for Callable taking a pointer to `ObjectType` as the argument
 	template <typename ObjectType>
-	static std::enable_if_t<handler_accepts_ptr<ObjectType>, IterationResult>
-		Invoke(Callable handler, typename std::list<ObjectType*>::iterator iter)
+	static IterationResult Invoke(Callable handler, typename std::list<ObjectType*>::iterator iter)
 	{
-		return handler(*iter);
+		if constexpr (handler_accepts_iter<ObjectType>)
+		{
+			// `Invoke` overload for Callable taking a list iterator as the argument
+			return handler(iter);
+		}
+		else if constexpr (handler_accepts_ptr<ObjectType>)
+		{
+			// `Invoke` overload for Callable taking a pointer to `ObjectType` as the argument
+			return handler(*iter);
+		}
+		else
+		{
+			static_assert(sizeof(ObjectType) != sizeof(ObjectType), "Unsupported loop body handler signature");
+		}
 	}
 };
 

--- a/lib/framework/paged_entity_container.h
+++ b/lib/framework/paged_entity_container.h
@@ -424,7 +424,7 @@ public:
 
 		// Either advance slot generation number or invalidate the slot right away,
 		// the behavior depends on whether we reuse the slots or not.
-		advance_slot_generation<ReuseSlots>(slotMetadata);
+		advance_slot_generation(slotMetadata);
 
 		// Ensure that the element pointed-to by this slot is dead.
 		slotMetadata.set_dead();
@@ -444,10 +444,7 @@ public:
 			// Increase counters for expired slots tracking.
 			_pages[pageIdx.first].increase_expired_slots_count();
 			++_expiredSlotsCount;
-			// Looks like at least GCC is smart enough to optimize the following
-			// instructions away, even when this is not a `constexpr if`, but a regular `if`,
-			// See https://godbolt.org/z/bY8oEYsdz.
-			if (!ReuseSlots)
+			if constexpr (!ReuseSlots)
 			{
 				if (_pages[pageIdx.first].is_expired())
 				{
@@ -729,7 +726,7 @@ public:
 		_capacity = MaxElementsPerPage;
 		// No valid items in the container now.
 		_maxIndex = INVALID_SLOT_IDX;
-		if (!ReuseSlots)
+		if constexpr (!ReuseSlots)
 		{
 			// If the first page is in the expired state, then
 			// its storage is deallocated, too. So, reallocate it.
@@ -772,16 +769,12 @@ private:
 		return new (address) T(std::forward<Args>(args)...);
 	}
 
-	// Use some hacks for SFINAE to make it compliant to C++ standard,
-	// see https://stackoverflow.com/a/11056319 for details.
-	template <typename U = T, std::enable_if_t<std::is_trivially_destructible<U>::value, bool> = true>
-	void deallocate_element_impl(T* /*element*/)
-	{}
-
-	template <typename U = T, std::enable_if_t<!std::is_trivially_destructible<U>::value, bool> = true>
 	void deallocate_element_impl(T* element)
 	{
-		element->~T();
+		if constexpr (!std::is_trivially_destructible<T>::value)
+		{
+			element->~T();
+		}
 	}
 
 	SlotMetadata& get_slot_metadata(const PageIndex& idx)
@@ -806,18 +799,16 @@ private:
 		return idx.first * MaxElementsPerPage + idx.second;
 	}
 
-	// No need to call destructors manually for trivially destructible types.
-	template <typename U = T, std::enable_if_t<std::is_trivially_destructible<U>::value, bool> = true>
-	void destroy_live_elements()
-	{}
-
-	template <typename U = T, std::enable_if_t<!std::is_trivially_destructible<U>::value, bool> = true>
 	void destroy_live_elements()
 	{
-		for (auto it = begin(), endIt = end(); it != endIt; ++it)
+		if constexpr (!std::is_trivially_destructible<T>::value)
 		{
-			deallocate_element_impl(&*it);
+			for (auto it = begin(), endIt = end(); it != endIt; ++it)
+			{
+				deallocate_element_impl(&*it);
+			}
 		}
+		// No need to call destructors manually for trivially destructible types.
 	}
 
 	size_t find_first_page_with_recycled_ids() const
@@ -842,19 +833,18 @@ private:
 		return (reinterpret_cast<uintptr_t>(addr) % alignof(T)) == 0;
 	}
 
-	template <bool ReuseSlotsAux = ReuseSlots, std::enable_if_t<ReuseSlotsAux, bool> = true>
 	void advance_slot_generation(SlotMetadata& meta)
 	{
-		// Advance slot generation number, when `ReuseSlots=true`.
-		meta.advance_generation();
-	}
-
-	// Specialization for the case when `ReuseSlots=false`.
-	template <bool ReuseSlotsAux = ReuseSlots, std::enable_if_t<!ReuseSlotsAux, bool> = true>
-	void advance_slot_generation(SlotMetadata& meta)
-	{
-		// Invalidate slot right away so that it cannot be reused anymore.
-		meta.invalidate();
+		if constexpr (ReuseSlots)
+		{
+			// Advance slot generation number, when `ReuseSlots=true`.
+			meta.advance_generation();
+		}
+		else
+		{
+			// Invalidate slot right away so that it cannot be reused anymore.
+			meta.invalidate();
+		}
 	}
 
 	std::vector<Page> _pages;


### PR DESCRIPTION
Since minimal supported C++ standard now is C++17, `if constexpr` can be used to get rid of SFINAE checks, which previously required the use of `std::enable_if` utilities.