### PR TITLE
mission: Fix `restoreMissionData()` incorrectly clearing wrong `apsOilList`

### DIFF
--- a/src/mission.cpp
+++ b/src/mission.cpp
@@ -870,7 +870,7 @@ void restoreMissionData()
 	apsOilList[0] = std::move(mission.apsOilList[0]);
 	mission.apsFeatureList[0].clear();
 	mission.apsSensorList[0].clear();
-	apsOilList[0].clear();
+	mission.apsOilList[0].clear();
 	//swap mission data over
 
 	psMapTiles = std::move(mission.psMapTiles);


### PR DESCRIPTION
The bug was accidentally introduced by https://github.com/Warzone2100/warzone2100/commit/2bffaa0909207ce637411ad92a5a08dabfbfb43f