### PR TITLE
Introduce `GameWorld` abstraction to hold all map and object state

### DIFF
--- a/src/action.cpp
+++ b/src/action.cpp
@@ -46,7 +46,7 @@
 #include "objmem.h"
 #include "move.h"
 #include "cmddroid.h"
-#include "world_object_state.h"
+#include "game_world.h"
 
 /* attack run distance */
 #define	VTOL_ATTACK_LENGTH		1000
@@ -464,7 +464,7 @@ static void actionAddVtolAttackRun(DROID *psDroid)
 	/* add waypoint behind target attack length away*/
 	Vector2i dest = psTarget->pos.xy() + delta * VTOL_ATTACK_LENGTH / dist;
 
-	if (!worldOnMap(worldMapState, dest))
+	if (!worldOnMap(gameWorld.map, dest))
 	{
 		debug(LOG_NEVER, "*** actionAddVtolAttackRun: run off map! ***");
 	}
@@ -536,7 +536,7 @@ static void actionCalcPullBackPoint(BASE_OBJECT *psObj, BASE_OBJECT *psTarget, i
 	*py = psObj->pos.y + ydiff * PULL_BACK_DIST;
 
 	// make sure coordinates stay inside of the map
-	clip_world_offmap(worldMapState, px, py);
+	clip_world_offmap(gameWorld.map, px, py);
 }
 
 // check whether a droid is in the neighboring tile of another droid
@@ -805,11 +805,11 @@ void actionUpdateDroid(DROID *psDroid)
 			{
 				UDWORD droidX, droidY;
 
-				if (!droidRemove(psDroid, mission.worldObjectState.droids))
+				if (!droidRemove(psDroid, mission.gameWorld.objects.droids))
 				{
 					ASSERT_OR_RETURN(, false, "Unable to remove transporter from mission list");
 				}
-				addDroid(psDroid, worldObjectState.droids);
+				addDroid(psDroid, gameWorld.objects.droids);
 				//set the x/y up since they were set to INVALID_XY when moved offWorld
 				missionGetTransporterExit(selectedPlayer, &droidX, &droidY);
 				psDroid->pos.x = droidX;
@@ -1589,7 +1589,7 @@ void actionUpdateDroid(DROID *psDroid)
 					debug(LOG_NEVER, "DACTION_MOVETOBUILD: setUpBuildModule");
 					setUpBuildModule(psDroid);
 				}
-				else if (TileHasStructure(worldTile(worldMapState, pos)))
+				else if (TileHasStructure(worldTile(gameWorld.map, pos)))
 				{
 					// structure on the build location - see if it is the same type
 					STRUCTURE *const psStruct = getTileStructure(map_coord(pos.x), map_coord(pos.y));
@@ -1637,7 +1637,7 @@ void actionUpdateDroid(DROID *psDroid)
 			else if (order->type == DORDER_LINEBUILD || order->type == DORDER_BUILD)
 			{
 				// building a wall.
-				MAPTILE *const psTile = worldTile(worldMapState, psDroid->actionPos);
+				MAPTILE *const psTile = worldTile(gameWorld.map, psDroid->actionPos);
 				syncDebug("Reached build target: wall");
 				if (order->psObj == nullptr
 				    && (TileHasStructure(psTile)
@@ -2761,12 +2761,12 @@ void moveToRearm(DROID *psDroid)
 // whether a tile is suitable for a vtol to land on
 static bool vtolLandingTile(SDWORD x, SDWORD y)
 {
-	if (x < 0 || x >= (SDWORD)worldMapState.width || y < 0 || y >= (SDWORD)worldMapState.height)
+	if (x < 0 || x >= (SDWORD)gameWorld.map.width || y < 0 || y >= (SDWORD)gameWorld.map.height)
 	{
 		return false;
 	}
 
-	const MAPTILE *psTile = mapTile(worldMapState, x, y);
+	const MAPTILE *psTile = mapTile(gameWorld.map, x, y);
 	if (psTile->tileInfoBits & BITS_FPATHBLOCK ||
 	    TileIsOccupied(psTile) ||
 	    terrainType(psTile) == TER_CLIFFFACE ||
@@ -2875,7 +2875,7 @@ bool actionVTOLLandingPos(DROID const *psDroid, Vector2i *p)
 	int startY = map_coord(p->y);
 
 	// set blocking flags for all the other droids
-	for (const DROID *psCurr : worldObjectState.droids[psDroid->player])
+	for (const DROID *psCurr : gameWorld.objects.droids[psDroid->player])
 	{
 		Vector2i t(0, 0);
 		if (DROID_STOPPED(psCurr))
@@ -2888,9 +2888,9 @@ bool actionVTOLLandingPos(DROID const *psDroid, Vector2i *p)
 		}
 		if (psCurr != psDroid)
 		{
-			if (tileOnMap(worldMapState, t))
+			if (tileOnMap(gameWorld.map, t))
 			{
-				mapTile(worldMapState, t)->tileInfoBits |= BITS_FPATHBLOCK;
+				mapTile(gameWorld.map, t)->tileInfoBits |= BITS_FPATHBLOCK;
 			}
 		}
 	}
@@ -2907,7 +2907,7 @@ bool actionVTOLLandingPos(DROID const *psDroid, Vector2i *p)
 	}
 
 	// clear blocking flags for all the other droids
-	for (const DROID *psCurr : worldObjectState.droids[psDroid->player])
+	for (const DROID *psCurr : gameWorld.objects.droids[psDroid->player])
 	{
 		Vector2i t(0, 0);
 		if (DROID_STOPPED(psCurr))
@@ -2918,9 +2918,9 @@ bool actionVTOLLandingPos(DROID const *psDroid, Vector2i *p)
 		{
 			t = map_coord(psCurr->sMove.destination);
 		}
-		if (tileOnMap(worldMapState, t))
+		if (tileOnMap(gameWorld.map, t))
 		{
-			mapTile(worldMapState, t)->tileInfoBits &= ~BITS_FPATHBLOCK;
+			mapTile(gameWorld.map, t)->tileInfoBits &= ~BITS_FPATHBLOCK;
 		}
 	}
 

--- a/src/action.cpp
+++ b/src/action.cpp
@@ -46,6 +46,7 @@
 #include "objmem.h"
 #include "move.h"
 #include "cmddroid.h"
+#include "world_object_state.h"
 
 /* attack run distance */
 #define	VTOL_ATTACK_LENGTH		1000
@@ -804,11 +805,11 @@ void actionUpdateDroid(DROID *psDroid)
 			{
 				UDWORD droidX, droidY;
 
-				if (!droidRemove(psDroid, mission.apsDroidLists))
+				if (!droidRemove(psDroid, mission.worldObjectState.droids))
 				{
 					ASSERT_OR_RETURN(, false, "Unable to remove transporter from mission list");
 				}
-				addDroid(psDroid, apsDroidLists);
+				addDroid(psDroid, worldObjectState.droids);
 				//set the x/y up since they were set to INVALID_XY when moved offWorld
 				missionGetTransporterExit(selectedPlayer, &droidX, &droidY);
 				psDroid->pos.x = droidX;
@@ -2874,7 +2875,7 @@ bool actionVTOLLandingPos(DROID const *psDroid, Vector2i *p)
 	int startY = map_coord(p->y);
 
 	// set blocking flags for all the other droids
-	for (const DROID *psCurr : apsDroidLists[psDroid->player])
+	for (const DROID *psCurr : worldObjectState.droids[psDroid->player])
 	{
 		Vector2i t(0, 0);
 		if (DROID_STOPPED(psCurr))
@@ -2906,7 +2907,7 @@ bool actionVTOLLandingPos(DROID const *psDroid, Vector2i *p)
 	}
 
 	// clear blocking flags for all the other droids
-	for (const DROID *psCurr : apsDroidLists[psDroid->player])
+	for (const DROID *psCurr : worldObjectState.droids[psDroid->player])
 	{
 		Vector2i t(0, 0);
 		if (DROID_STOPPED(psCurr))

--- a/src/action.cpp
+++ b/src/action.cpp
@@ -464,7 +464,7 @@ static void actionAddVtolAttackRun(DROID *psDroid)
 	/* add waypoint behind target attack length away*/
 	Vector2i dest = psTarget->pos.xy() + delta * VTOL_ATTACK_LENGTH / dist;
 
-	if (!worldOnMap(dest))
+	if (!worldOnMap(worldMapState, dest))
 	{
 		debug(LOG_NEVER, "*** actionAddVtolAttackRun: run off map! ***");
 	}
@@ -536,7 +536,7 @@ static void actionCalcPullBackPoint(BASE_OBJECT *psObj, BASE_OBJECT *psTarget, i
 	*py = psObj->pos.y + ydiff * PULL_BACK_DIST;
 
 	// make sure coordinates stay inside of the map
-	clip_world_offmap(px, py);
+	clip_world_offmap(worldMapState, px, py);
 }
 
 // check whether a droid is in the neighboring tile of another droid
@@ -1589,7 +1589,7 @@ void actionUpdateDroid(DROID *psDroid)
 					debug(LOG_NEVER, "DACTION_MOVETOBUILD: setUpBuildModule");
 					setUpBuildModule(psDroid);
 				}
-				else if (TileHasStructure(worldTile(pos)))
+				else if (TileHasStructure(worldTile(worldMapState, pos)))
 				{
 					// structure on the build location - see if it is the same type
 					STRUCTURE *const psStruct = getTileStructure(map_coord(pos.x), map_coord(pos.y));
@@ -1637,7 +1637,7 @@ void actionUpdateDroid(DROID *psDroid)
 			else if (order->type == DORDER_LINEBUILD || order->type == DORDER_BUILD)
 			{
 				// building a wall.
-				MAPTILE *const psTile = worldTile(psDroid->actionPos);
+				MAPTILE *const psTile = worldTile(worldMapState, psDroid->actionPos);
 				syncDebug("Reached build target: wall");
 				if (order->psObj == nullptr
 				    && (TileHasStructure(psTile)
@@ -2766,7 +2766,7 @@ static bool vtolLandingTile(SDWORD x, SDWORD y)
 		return false;
 	}
 
-	const MAPTILE *psTile = mapTile(x, y);
+	const MAPTILE *psTile = mapTile(worldMapState, x, y);
 	if (psTile->tileInfoBits & BITS_FPATHBLOCK ||
 	    TileIsOccupied(psTile) ||
 	    terrainType(psTile) == TER_CLIFFFACE ||
@@ -2888,9 +2888,9 @@ bool actionVTOLLandingPos(DROID const *psDroid, Vector2i *p)
 		}
 		if (psCurr != psDroid)
 		{
-			if (tileOnMap(t))
+			if (tileOnMap(worldMapState, t))
 			{
-				mapTile(t)->tileInfoBits |= BITS_FPATHBLOCK;
+				mapTile(worldMapState, t)->tileInfoBits |= BITS_FPATHBLOCK;
 			}
 		}
 	}
@@ -2918,9 +2918,9 @@ bool actionVTOLLandingPos(DROID const *psDroid, Vector2i *p)
 		{
 			t = map_coord(psCurr->sMove.destination);
 		}
-		if (tileOnMap(t))
+		if (tileOnMap(worldMapState, t))
 		{
-			mapTile(t)->tileInfoBits &= ~BITS_FPATHBLOCK;
+			mapTile(worldMapState, t)->tileInfoBits &= ~BITS_FPATHBLOCK;
 		}
 	}
 

--- a/src/action.cpp
+++ b/src/action.cpp
@@ -2760,7 +2760,7 @@ void moveToRearm(DROID *psDroid)
 // whether a tile is suitable for a vtol to land on
 static bool vtolLandingTile(SDWORD x, SDWORD y)
 {
-	if (x < 0 || x >= (SDWORD)mapWidth || y < 0 || y >= (SDWORD)mapHeight)
+	if (x < 0 || x >= (SDWORD)worldMapState.width || y < 0 || y >= (SDWORD)worldMapState.height)
 	{
 		return false;
 	}

--- a/src/advvis.cpp
+++ b/src/advvis.cpp
@@ -48,7 +48,7 @@ inline float getTileIllumination(const MAPTILE *psTile)
 void	avUpdateTiles()
 {
 	WZ_PROFILE_SCOPE(avUpdateTiles);
-	const int len = mapHeight * mapWidth;
+	const int len = worldMapState.height * worldMapState.width;
 	const int playermask = 1 << selectedPlayer;
 	UDWORD i = 0;
 	float maxLevel, increment = graphicsTimeAdjustedIncrement(FADE_IN_TIME);	// call once per frame
@@ -59,7 +59,7 @@ void	avUpdateTiles()
 	/* Go through the tiles */
 	for (; i < len; i++)
 	{
-		psTile = &psMapTiles[i];
+		psTile = &worldMapState.tiles[i];
 		maxLevel = getTileIllumination(psTile);
 
 		if (psTile->level > MIN_ILLUM || psTile->tileExploredBits & playermask)	// seen
@@ -112,9 +112,9 @@ void	setRevealStatus(bool val)
 // ------------------------------------------------------------------------------------
 void	preProcessVisibility()
 {
-	for (int i = 0; i < mapWidth; i++)
+	for (int i = 0; i < worldMapState.width; i++)
 	{
-		for (int j = 0; j < mapHeight; j++)
+		for (int j = 0; j < worldMapState.height; j++)
 		{
 			MAPTILE *psTile = mapTile(i, j);
 			psTile->level = bRevealActive ? MIN(MIN_ILLUM, getTileIllumination(psTile) / 4.0f) : 0;

--- a/src/advvis.cpp
+++ b/src/advvis.cpp
@@ -116,7 +116,7 @@ void	preProcessVisibility()
 	{
 		for (int j = 0; j < worldMapState.height; j++)
 		{
-			MAPTILE *psTile = mapTile(i, j);
+			MAPTILE *psTile = mapTile(worldMapState, i, j);
 			psTile->level = bRevealActive ? MIN(MIN_ILLUM, getTileIllumination(psTile) / 4.0f) : 0;
 
 			if (TEST_TILE_VISIBLE_TO_SELECTEDPLAYER(psTile))

--- a/src/advvis.cpp
+++ b/src/advvis.cpp
@@ -28,6 +28,7 @@
 #include "advvis.h"
 #include "profiling.h"
 #include "map.h"
+#include "game_world.h"
 
 // ------------------------------------------------------------------------------------
 #define FADE_IN_TIME	(GAME_TICKS_PER_SEC/10)
@@ -48,7 +49,7 @@ inline float getTileIllumination(const MAPTILE *psTile)
 void	avUpdateTiles()
 {
 	WZ_PROFILE_SCOPE(avUpdateTiles);
-	const int len = worldMapState.height * worldMapState.width;
+	const int len = gameWorld.map.height * gameWorld.map.width;
 	const int playermask = 1 << selectedPlayer;
 	UDWORD i = 0;
 	float maxLevel, increment = graphicsTimeAdjustedIncrement(FADE_IN_TIME);	// call once per frame
@@ -59,7 +60,7 @@ void	avUpdateTiles()
 	/* Go through the tiles */
 	for (; i < len; i++)
 	{
-		psTile = &worldMapState.tiles[i];
+		psTile = &gameWorld.map.tiles[i];
 		maxLevel = getTileIllumination(psTile);
 
 		if (psTile->level > MIN_ILLUM || psTile->tileExploredBits & playermask)	// seen
@@ -112,11 +113,11 @@ void	setRevealStatus(bool val)
 // ------------------------------------------------------------------------------------
 void	preProcessVisibility()
 {
-	for (int i = 0; i < worldMapState.width; i++)
+	for (int i = 0; i < gameWorld.map.width; i++)
 	{
-		for (int j = 0; j < worldMapState.height; j++)
+		for (int j = 0; j < gameWorld.map.height; j++)
 		{
-			MAPTILE *psTile = mapTile(worldMapState, i, j);
+			MAPTILE *psTile = mapTile(gameWorld.map, i, j);
 			psTile->level = bRevealActive ? MIN(MIN_ILLUM, getTileIllumination(psTile) / 4.0f) : 0;
 
 			if (TEST_TILE_VISIBLE_TO_SELECTEDPLAYER(psTile))

--- a/src/ai.cpp
+++ b/src/ai.cpp
@@ -37,6 +37,7 @@
 #include "objmem.h"
 #include "order.h"
 #include "visibility.h"
+#include "game_world.h"
 
 /* Weights used for target selection code,
  * target distance is used as 'common currency'
@@ -179,7 +180,7 @@ static BASE_OBJECT *aiSearchSensorTargets(BASE_OBJECT *psObj, int weapon_slot, W
 		*targetOrigin = ORIGIN_UNKNOWN;
 	}
 
-	for (BASE_OBJECT* psSensor : worldObjectState.sensors[0])
+	for (BASE_OBJECT* psSensor : gameWorld.objects.sensors[0])
 	{
 		BASE_OBJECT	*psTemp = nullptr;
 		bool		isCB = false;

--- a/src/ai.cpp
+++ b/src/ai.cpp
@@ -179,7 +179,7 @@ static BASE_OBJECT *aiSearchSensorTargets(BASE_OBJECT *psObj, int weapon_slot, W
 		*targetOrigin = ORIGIN_UNKNOWN;
 	}
 
-	for (BASE_OBJECT* psSensor : apsSensorList[0])
+	for (BASE_OBJECT* psSensor : worldObjectState.sensors[0])
 	{
 		BASE_OBJECT	*psTemp = nullptr;
 		bool		isCB = false;

--- a/src/astar.cpp
+++ b/src/astar.cpp
@@ -653,7 +653,7 @@ ASR_RETVAL fpathAStarRoute(const std::shared_ptr<FPathExecuteContext>& ctx, MOVE
 	Vector2i newP(0, 0);
 	for (Vector2i p(world_coord(endCoord.x) + TILE_UNITS / 2, world_coord(endCoord.y) + TILE_UNITS / 2); true; p = newP)
 	{
-		ASSERT_OR_RETURN(ASR_FAILED, worldOnMap(p.x, p.y), "Assigned XY coordinates (%d, %d) not on map!", (int)p.x, (int)p.y);
+		ASSERT_OR_RETURN(ASR_FAILED, worldOnMap(worldMapState, p.x, p.y), "Assigned XY coordinates (%d, %d) not on map!", (int)p.x, (int)p.y);
 		ASSERT_OR_RETURN(ASR_FAILED, path.size() < (static_cast<size_t>(worldMapState.width) * static_cast<size_t>(worldMapState.height)), "Pathfinding got in a loop.");
 
 		path.push_back(p);
@@ -776,7 +776,7 @@ void fpathSetBlockingMap(PATHJOB *psJob)
 			for (int y = 0; y < worldMapState.height; ++y)
 				for (int x = 0; x < worldMapState.width; ++x)
 				{
-					dangerMap[x + y * worldMapState.width] = auxTile(x, y, type.owner) & AUXBITS_THREAT;
+					dangerMap[x + y * worldMapState.width] = auxTile(worldMapState, x, y, type.owner) & AUXBITS_THREAT;
 					checksumDangerMap ^= dangerMap[x + y * worldMapState.width] * (factor = 3 * factor + 1);
 				}
 		}

--- a/src/astar.cpp
+++ b/src/astar.cpp
@@ -55,6 +55,7 @@
 #include <cstddef>
 
 #include "lib/netplay/sync_debug.h"
+#include "game_world.h"
 
 /// A coordinate.
 struct PathCoord
@@ -167,11 +168,11 @@ struct PathfindContext
 			return false;  // The path is actually blocked here by a structure, but ignore it since it's where we want to go (or where we came from).
 		}
 		// Not sure whether the out-of-bounds check is needed, can only happen if pathfinding is started on a blocking tile (or off the map).
-		return x < 0 || y < 0 || x >= worldMapState.width || y >= worldMapState.height || blockingMap->map[x + y * worldMapState.width];
+		return x < 0 || y < 0 || x >= gameWorld.map.width || y >= gameWorld.map.height || blockingMap->map[x + y * gameWorld.map.width];
 	}
 	bool isDangerous(int x, int y) const
 	{
-		return !blockingMap->dangerMap.empty() && blockingMap->dangerMap[x + y * worldMapState.width];
+		return !blockingMap->dangerMap.empty() && blockingMap->dangerMap[x + y * gameWorld.map.width];
 	}
 	bool matches(const std::shared_ptr<const PathBlockingMap> &blockingMap_, PathCoord tileS_, PathNonblockingArea dstIgnore_) const
 	{
@@ -192,7 +193,7 @@ struct PathfindContext
 			map.clear();  // There are no values of iteration guaranteed not to exist in map, so clear the map.
 			iteration = 0;
 		}
-		map.resize(static_cast<size_t>(worldMapState.width) * static_cast<size_t>(worldMapState.height));  // Allocate space for map, if needed.
+		map.resize(static_cast<size_t>(gameWorld.map.width) * static_cast<size_t>(gameWorld.map.height));  // Allocate space for map, if needed.
 	}
 
 	PathCoord       tileS;                // Start tile for pathfinding. (May be either source or target tile.)
@@ -270,7 +271,7 @@ static inline unsigned WZ_DECL_PURE fpathGoodEstimate(PathCoord s, PathCoord f)
  */
 static inline void fpathNewNode(PathfindContext &context, PathCoord dest, PathCoord pos, unsigned prevDist, PathCoord prevPos)
 {
-	ASSERT_OR_RETURN(, (unsigned)pos.x < (unsigned)worldMapState.width && (unsigned)pos.y < (unsigned)worldMapState.height, "X (%d) or Y (%d) coordinate for path finding node is out of range!", pos.x, pos.y);
+	ASSERT_OR_RETURN(, (unsigned)pos.x < (unsigned)gameWorld.map.width && (unsigned)pos.y < (unsigned)gameWorld.map.height, "X (%d) or Y (%d) coordinate for path finding node is out of range!", pos.x, pos.y);
 
 	// Create the node.
 	PathNode node;
@@ -282,7 +283,7 @@ static inline void fpathNewNode(PathfindContext &context, PathCoord dest, PathCo
 	Vector2i delta = Vector2i(pos.x - prevPos.x, pos.y - prevPos.y) * 64;
 	bool isDiagonal = delta.x && delta.y;
 
-	PathExploredTile &expl = context.map[pos.x + pos.y * worldMapState.width];
+	PathExploredTile &expl = context.map[pos.x + pos.y * gameWorld.map.width];
 	if (expl.iteration == context.iteration)
 	{
 		if (expl.visited)
@@ -361,11 +362,11 @@ static PathCoord fpathAStarExplore(PathfindContext &context, PathCoord tileF)
 	while (!context.nodes.empty() && !foundIt)
 	{
 		PathNode node = fpathTakeNode(context.nodes);
-		if (context.map[node.p.x + node.p.y * worldMapState.width].visited)
+		if (context.map[node.p.x + node.p.y * gameWorld.map.width].visited)
 		{
 			continue;  // Already been here.
 		}
-		context.map[node.p.x + node.p.y * worldMapState.width].visited = true;
+		context.map[node.p.x + node.p.y * gameWorld.map.width].visited = true;
 
 		// note the nearest node to the target so far
 		if (node.est - node.dist < nearestDist)
@@ -603,8 +604,8 @@ ASR_RETVAL fpathAStarRoute(const std::shared_ptr<FPathExecuteContext>& ctx, MOVE
 
 		// We have tried going to tileDest before.
 
-		if (contextIterator->map[tileOrig.x + tileOrig.y * worldMapState.width].iteration == contextIterator->iteration
-		    && contextIterator->map[tileOrig.x + tileOrig.y * worldMapState.width].visited)
+		if (contextIterator->map[tileOrig.x + tileOrig.y * gameWorld.map.width].iteration == contextIterator->iteration
+		    && contextIterator->map[tileOrig.x + tileOrig.y * gameWorld.map.width].visited)
 		{
 			// Already know the path from orig to dest.
 			endCoord = tileOrig;
@@ -653,12 +654,12 @@ ASR_RETVAL fpathAStarRoute(const std::shared_ptr<FPathExecuteContext>& ctx, MOVE
 	Vector2i newP(0, 0);
 	for (Vector2i p(world_coord(endCoord.x) + TILE_UNITS / 2, world_coord(endCoord.y) + TILE_UNITS / 2); true; p = newP)
 	{
-		ASSERT_OR_RETURN(ASR_FAILED, worldOnMap(worldMapState, p.x, p.y), "Assigned XY coordinates (%d, %d) not on map!", (int)p.x, (int)p.y);
-		ASSERT_OR_RETURN(ASR_FAILED, path.size() < (static_cast<size_t>(worldMapState.width) * static_cast<size_t>(worldMapState.height)), "Pathfinding got in a loop.");
+		ASSERT_OR_RETURN(ASR_FAILED, worldOnMap(gameWorld.map, p.x, p.y), "Assigned XY coordinates (%d, %d) not on map!", (int)p.x, (int)p.y);
+		ASSERT_OR_RETURN(ASR_FAILED, path.size() < (static_cast<size_t>(gameWorld.map.width) * static_cast<size_t>(gameWorld.map.height)), "Pathfinding got in a loop.");
 
 		path.push_back(p);
 
-		PathExploredTile &tile = context.map[map_coord(p.x) + map_coord(p.y) * worldMapState.width];
+		PathExploredTile &tile = context.map[map_coord(p.x) + map_coord(p.y) * gameWorld.map.width];
 		newP = p - Vector2i(tile.dx, tile.dy) * (TILE_UNITS / 64);
 		Vector2i mapP = map_coord(newP);
 		int xSide = newP.x - world_coord(mapP.x) > TILE_UNITS / 2 ? 1 : -1; // 1 if newP is on right-hand side of the tile, or -1 if newP is on the left-hand side of the tile.
@@ -761,23 +762,23 @@ void fpathSetBlockingMap(PATHJOB *psJob)
 		// blockMap now points to an empty map with no data. Fill the map.
 		blockMap->type = type;
 		std::vector<bool> &map = blockMap->map;
-		map.resize(static_cast<size_t>(worldMapState.width) * static_cast<size_t>(worldMapState.height));
+		map.resize(static_cast<size_t>(gameWorld.map.width) * static_cast<size_t>(gameWorld.map.height));
 		uint32_t checksumMap = 0, checksumDangerMap = 0, factor = 0;
-		for (int y = 0; y < worldMapState.height; ++y)
-			for (int x = 0; x < worldMapState.width; ++x)
+		for (int y = 0; y < gameWorld.map.height; ++y)
+			for (int x = 0; x < gameWorld.map.width; ++x)
 			{
-				map[x + y * worldMapState.width] = fpathBaseBlockingTile(x, y, type.propulsion, type.owner, type.moveType);
-				checksumMap ^= map[x + y * worldMapState.width] * (factor = 3 * factor + 1);
+				map[x + y * gameWorld.map.width] = fpathBaseBlockingTile(x, y, type.propulsion, type.owner, type.moveType);
+				checksumMap ^= map[x + y * gameWorld.map.width] * (factor = 3 * factor + 1);
 			}
 		if (!isHumanPlayer(type.owner) && type.moveType == FMT_MOVE)
 		{
 			std::vector<bool> &dangerMap = blockMap->dangerMap;
-			dangerMap.resize(static_cast<size_t>(worldMapState.width) * static_cast<size_t>(worldMapState.height));
-			for (int y = 0; y < worldMapState.height; ++y)
-				for (int x = 0; x < worldMapState.width; ++x)
+			dangerMap.resize(static_cast<size_t>(gameWorld.map.width) * static_cast<size_t>(gameWorld.map.height));
+			for (int y = 0; y < gameWorld.map.height; ++y)
+				for (int x = 0; x < gameWorld.map.width; ++x)
 				{
-					dangerMap[x + y * worldMapState.width] = auxTile(worldMapState, x, y, type.owner) & AUXBITS_THREAT;
-					checksumDangerMap ^= dangerMap[x + y * worldMapState.width] * (factor = 3 * factor + 1);
+					dangerMap[x + y * gameWorld.map.width] = auxTile(gameWorld.map, x, y, type.owner) & AUXBITS_THREAT;
+					checksumDangerMap ^= dangerMap[x + y * gameWorld.map.width] * (factor = 3 * factor + 1);
 				}
 		}
 		syncDebug("blockingMap(%d,%d,%d,%d) = %08X %08X", gameTime, psJob->propulsion, psJob->owner, psJob->moveType, checksumMap, checksumDangerMap);

--- a/src/astar.cpp
+++ b/src/astar.cpp
@@ -167,11 +167,11 @@ struct PathfindContext
 			return false;  // The path is actually blocked here by a structure, but ignore it since it's where we want to go (or where we came from).
 		}
 		// Not sure whether the out-of-bounds check is needed, can only happen if pathfinding is started on a blocking tile (or off the map).
-		return x < 0 || y < 0 || x >= mapWidth || y >= mapHeight || blockingMap->map[x + y * mapWidth];
+		return x < 0 || y < 0 || x >= worldMapState.width || y >= worldMapState.height || blockingMap->map[x + y * worldMapState.width];
 	}
 	bool isDangerous(int x, int y) const
 	{
-		return !blockingMap->dangerMap.empty() && blockingMap->dangerMap[x + y * mapWidth];
+		return !blockingMap->dangerMap.empty() && blockingMap->dangerMap[x + y * worldMapState.width];
 	}
 	bool matches(const std::shared_ptr<const PathBlockingMap> &blockingMap_, PathCoord tileS_, PathNonblockingArea dstIgnore_) const
 	{
@@ -192,7 +192,7 @@ struct PathfindContext
 			map.clear();  // There are no values of iteration guaranteed not to exist in map, so clear the map.
 			iteration = 0;
 		}
-		map.resize(static_cast<size_t>(mapWidth) * static_cast<size_t>(mapHeight));  // Allocate space for map, if needed.
+		map.resize(static_cast<size_t>(worldMapState.width) * static_cast<size_t>(worldMapState.height));  // Allocate space for map, if needed.
 	}
 
 	PathCoord       tileS;                // Start tile for pathfinding. (May be either source or target tile.)
@@ -270,7 +270,7 @@ static inline unsigned WZ_DECL_PURE fpathGoodEstimate(PathCoord s, PathCoord f)
  */
 static inline void fpathNewNode(PathfindContext &context, PathCoord dest, PathCoord pos, unsigned prevDist, PathCoord prevPos)
 {
-	ASSERT_OR_RETURN(, (unsigned)pos.x < (unsigned)mapWidth && (unsigned)pos.y < (unsigned)mapHeight, "X (%d) or Y (%d) coordinate for path finding node is out of range!", pos.x, pos.y);
+	ASSERT_OR_RETURN(, (unsigned)pos.x < (unsigned)worldMapState.width && (unsigned)pos.y < (unsigned)worldMapState.height, "X (%d) or Y (%d) coordinate for path finding node is out of range!", pos.x, pos.y);
 
 	// Create the node.
 	PathNode node;
@@ -282,7 +282,7 @@ static inline void fpathNewNode(PathfindContext &context, PathCoord dest, PathCo
 	Vector2i delta = Vector2i(pos.x - prevPos.x, pos.y - prevPos.y) * 64;
 	bool isDiagonal = delta.x && delta.y;
 
-	PathExploredTile &expl = context.map[pos.x + pos.y * mapWidth];
+	PathExploredTile &expl = context.map[pos.x + pos.y * worldMapState.width];
 	if (expl.iteration == context.iteration)
 	{
 		if (expl.visited)
@@ -361,11 +361,11 @@ static PathCoord fpathAStarExplore(PathfindContext &context, PathCoord tileF)
 	while (!context.nodes.empty() && !foundIt)
 	{
 		PathNode node = fpathTakeNode(context.nodes);
-		if (context.map[node.p.x + node.p.y * mapWidth].visited)
+		if (context.map[node.p.x + node.p.y * worldMapState.width].visited)
 		{
 			continue;  // Already been here.
 		}
-		context.map[node.p.x + node.p.y * mapWidth].visited = true;
+		context.map[node.p.x + node.p.y * worldMapState.width].visited = true;
 
 		// note the nearest node to the target so far
 		if (node.est - node.dist < nearestDist)
@@ -603,8 +603,8 @@ ASR_RETVAL fpathAStarRoute(const std::shared_ptr<FPathExecuteContext>& ctx, MOVE
 
 		// We have tried going to tileDest before.
 
-		if (contextIterator->map[tileOrig.x + tileOrig.y * mapWidth].iteration == contextIterator->iteration
-		    && contextIterator->map[tileOrig.x + tileOrig.y * mapWidth].visited)
+		if (contextIterator->map[tileOrig.x + tileOrig.y * worldMapState.width].iteration == contextIterator->iteration
+		    && contextIterator->map[tileOrig.x + tileOrig.y * worldMapState.width].visited)
 		{
 			// Already know the path from orig to dest.
 			endCoord = tileOrig;
@@ -654,11 +654,11 @@ ASR_RETVAL fpathAStarRoute(const std::shared_ptr<FPathExecuteContext>& ctx, MOVE
 	for (Vector2i p(world_coord(endCoord.x) + TILE_UNITS / 2, world_coord(endCoord.y) + TILE_UNITS / 2); true; p = newP)
 	{
 		ASSERT_OR_RETURN(ASR_FAILED, worldOnMap(p.x, p.y), "Assigned XY coordinates (%d, %d) not on map!", (int)p.x, (int)p.y);
-		ASSERT_OR_RETURN(ASR_FAILED, path.size() < (static_cast<size_t>(mapWidth) * static_cast<size_t>(mapHeight)), "Pathfinding got in a loop.");
+		ASSERT_OR_RETURN(ASR_FAILED, path.size() < (static_cast<size_t>(worldMapState.width) * static_cast<size_t>(worldMapState.height)), "Pathfinding got in a loop.");
 
 		path.push_back(p);
 
-		PathExploredTile &tile = context.map[map_coord(p.x) + map_coord(p.y) * mapWidth];
+		PathExploredTile &tile = context.map[map_coord(p.x) + map_coord(p.y) * worldMapState.width];
 		newP = p - Vector2i(tile.dx, tile.dy) * (TILE_UNITS / 64);
 		Vector2i mapP = map_coord(newP);
 		int xSide = newP.x - world_coord(mapP.x) > TILE_UNITS / 2 ? 1 : -1; // 1 if newP is on right-hand side of the tile, or -1 if newP is on the left-hand side of the tile.
@@ -761,23 +761,23 @@ void fpathSetBlockingMap(PATHJOB *psJob)
 		// blockMap now points to an empty map with no data. Fill the map.
 		blockMap->type = type;
 		std::vector<bool> &map = blockMap->map;
-		map.resize(static_cast<size_t>(mapWidth) * static_cast<size_t>(mapHeight));
+		map.resize(static_cast<size_t>(worldMapState.width) * static_cast<size_t>(worldMapState.height));
 		uint32_t checksumMap = 0, checksumDangerMap = 0, factor = 0;
-		for (int y = 0; y < mapHeight; ++y)
-			for (int x = 0; x < mapWidth; ++x)
+		for (int y = 0; y < worldMapState.height; ++y)
+			for (int x = 0; x < worldMapState.width; ++x)
 			{
-				map[x + y * mapWidth] = fpathBaseBlockingTile(x, y, type.propulsion, type.owner, type.moveType);
-				checksumMap ^= map[x + y * mapWidth] * (factor = 3 * factor + 1);
+				map[x + y * worldMapState.width] = fpathBaseBlockingTile(x, y, type.propulsion, type.owner, type.moveType);
+				checksumMap ^= map[x + y * worldMapState.width] * (factor = 3 * factor + 1);
 			}
 		if (!isHumanPlayer(type.owner) && type.moveType == FMT_MOVE)
 		{
 			std::vector<bool> &dangerMap = blockMap->dangerMap;
-			dangerMap.resize(static_cast<size_t>(mapWidth) * static_cast<size_t>(mapHeight));
-			for (int y = 0; y < mapHeight; ++y)
-				for (int x = 0; x < mapWidth; ++x)
+			dangerMap.resize(static_cast<size_t>(worldMapState.width) * static_cast<size_t>(worldMapState.height));
+			for (int y = 0; y < worldMapState.height; ++y)
+				for (int x = 0; x < worldMapState.width; ++x)
 				{
-					dangerMap[x + y * mapWidth] = auxTile(x, y, type.owner) & AUXBITS_THREAT;
-					checksumDangerMap ^= dangerMap[x + y * mapWidth] * (factor = 3 * factor + 1);
+					dangerMap[x + y * worldMapState.width] = auxTile(x, y, type.owner) & AUXBITS_THREAT;
+					checksumDangerMap ^= dangerMap[x + y * worldMapState.width] * (factor = 3 * factor + 1);
 				}
 		}
 		syncDebug("blockingMap(%d,%d,%d,%d) = %08X %08X", gameTime, psJob->propulsion, psJob->owner, psJob->moveType, checksumMap, checksumDangerMap);

--- a/src/atmos.cpp
+++ b/src/atmos.cpp
@@ -135,8 +135,8 @@ static void processParticle(ATPART *psPart)
 
 		/* If it's gone off the WORLD... */
 		if (psPart->position.x < 0 || psPart->position.z < 0 ||
-		    psPart->position.x > ((mapWidth - 1)*TILE_UNITS) ||
-		    psPart->position.z > ((mapHeight - 1)*TILE_UNITS))
+		    psPart->position.x > ((worldMapState.width - 1)*TILE_UNITS) ||
+		    psPart->position.z > ((worldMapState.height - 1)*TILE_UNITS))
 		{
 			/* The kill it */
 			psPart->status = APS_INACTIVE;
@@ -298,8 +298,8 @@ void atmosUpdateSystem()
 
 			/* If we've got one on the grid */
 			if (pos.x > 0 && pos.z > 0 &&
-			    pos.x < (SDWORD)world_coord(mapWidth - 1) &&
-			    pos.z < (SDWORD)world_coord(mapHeight - 1))
+			    pos.x < (SDWORD)world_coord(worldMapState.width - 1) &&
+			    pos.z < (SDWORD)world_coord(worldMapState.height - 1))
 			{
 				/* On grid, so which particle shall we add? */
 				switch (weather)

--- a/src/atmos.cpp
+++ b/src/atmos.cpp
@@ -35,6 +35,7 @@
 #include "miscimd.h"
 #include "profiling.h"
 #include "lib/gamelib/gtime.h"
+#include "game_world.h"
 #include <cmath>
 
 #ifndef GLM_ENABLE_EXPERIMENTAL
@@ -135,8 +136,8 @@ static void processParticle(ATPART *psPart)
 
 		/* If it's gone off the WORLD... */
 		if (psPart->position.x < 0 || psPart->position.z < 0 ||
-		    psPart->position.x > ((worldMapState.width - 1)*TILE_UNITS) ||
-		    psPart->position.z > ((worldMapState.height - 1)*TILE_UNITS))
+		    psPart->position.x > ((gameWorld.map.width - 1)*TILE_UNITS) ||
+		    psPart->position.z > ((gameWorld.map.height - 1)*TILE_UNITS))
 		{
 			/* The kill it */
 			psPart->status = APS_INACTIVE;
@@ -147,7 +148,7 @@ static void processParticle(ATPART *psPart)
 		if (psPart->position.y < TILE_MAX_HEIGHT)
 		{
 			/* Get ground height */
-			groundHeight = map_Height(worldMapState, static_cast<int>(psPart->position.x), static_cast<int>(psPart->position.z));
+			groundHeight = map_Height(gameWorld.map, static_cast<int>(psPart->position.x), static_cast<int>(psPart->position.z));
 
 			/* Are we below ground? */
 			if ((int)psPart->position.y < groundHeight
@@ -159,7 +160,7 @@ static void processParticle(ATPART *psPart)
 				{
 					x = map_coord(static_cast<int32_t>(psPart->position.x));
 					y = map_coord(static_cast<int32_t>(psPart->position.z));
-					psTile = mapTile(worldMapState, x, y);
+					psTile = mapTile(gameWorld.map, x, y);
 					if (terrainType(psTile) == TER_WATER && TEST_TILE_VISIBLE_TO_SELECTEDPLAYER(psTile)) // display-only check for adding effect
 					{
 						pos.x = static_cast<int>(psPart->position.x);
@@ -298,8 +299,8 @@ void atmosUpdateSystem()
 
 			/* If we've got one on the grid */
 			if (pos.x > 0 && pos.z > 0 &&
-			    pos.x < (SDWORD)world_coord(worldMapState.width - 1) &&
-			    pos.z < (SDWORD)world_coord(worldMapState.height - 1))
+			    pos.x < (SDWORD)world_coord(gameWorld.map.width - 1) &&
+			    pos.z < (SDWORD)world_coord(gameWorld.map.height - 1))
 			{
 				/* On grid, so which particle shall we add? */
 				switch (weather)

--- a/src/atmos.cpp
+++ b/src/atmos.cpp
@@ -147,7 +147,7 @@ static void processParticle(ATPART *psPart)
 		if (psPart->position.y < TILE_MAX_HEIGHT)
 		{
 			/* Get ground height */
-			groundHeight = map_Height(static_cast<int>(psPart->position.x), static_cast<int>(psPart->position.z));
+			groundHeight = map_Height(worldMapState, static_cast<int>(psPart->position.x), static_cast<int>(psPart->position.z));
 
 			/* Are we below ground? */
 			if ((int)psPart->position.y < groundHeight
@@ -159,7 +159,7 @@ static void processParticle(ATPART *psPart)
 				{
 					x = map_coord(static_cast<int32_t>(psPart->position.x));
 					y = map_coord(static_cast<int32_t>(psPart->position.z));
-					psTile = mapTile(x, y);
+					psTile = mapTile(worldMapState, x, y);
 					if (terrainType(psTile) == TER_WATER && TEST_TILE_VISIBLE_TO_SELECTEDPLAYER(psTile)) // display-only check for adding effect
 					{
 						pos.x = static_cast<int>(psPart->position.x);

--- a/src/aud.cpp
+++ b/src/aud.cpp
@@ -83,7 +83,7 @@ void audio_Get3DPlayerRotAboutVerticalAxis(float *angle)
 void audio_GetStaticPos(SDWORD iWorldX, SDWORD iWorldY, SDWORD *piX, SDWORD *piY, SDWORD *piZ)
 {
 	*piX = iWorldX;
-	*piZ = map_TileHeight(map_coord(iWorldX), map_coord(iWorldY));
+	*piZ = map_TileHeight(worldMapState, map_coord(iWorldX), map_coord(iWorldY));
 	/* invert y to match QSOUND axes */
 	*piY = world_coord(worldMapState.height) - iWorldY;
 }
@@ -95,7 +95,7 @@ void audio_GetObjectPos(const SIMPLE_OBJECT *psBaseObj, SDWORD *piX, SDWORD *piY
 	ASSERT_OR_RETURN(, psBaseObj != nullptr, "Game object pointer invalid");
 
 	*piX = psBaseObj->pos.x;
-	*piZ = map_TileHeight(map_coord(psBaseObj->pos.x), map_coord(psBaseObj->pos.y));
+	*piZ = map_TileHeight(worldMapState, map_coord(psBaseObj->pos.x), map_coord(psBaseObj->pos.y));
 
 	/* invert y to match QSOUND axes */
 	*piY = world_coord(worldMapState.height) - psBaseObj->pos.y;

--- a/src/aud.cpp
+++ b/src/aud.cpp
@@ -30,6 +30,7 @@
 
 #include "display3d.h"
 #include "map.h"
+#include "game_world.h"
 
 bool audio_ObjectDead(const SIMPLE_OBJECT *psSimpleObj)
 {
@@ -63,7 +64,7 @@ Vector3f audio_GetPlayerPos()
 
 	// Invert Y to match QSOUND axes
 	// @NOTE What is QSOUND? Why invert the Y axis?
-	pos.y = world_coord(worldMapState.height) - pos.y;
+	pos.y = world_coord(gameWorld.map.height) - pos.y;
 
 	return pos;
 }
@@ -83,9 +84,9 @@ void audio_Get3DPlayerRotAboutVerticalAxis(float *angle)
 void audio_GetStaticPos(SDWORD iWorldX, SDWORD iWorldY, SDWORD *piX, SDWORD *piY, SDWORD *piZ)
 {
 	*piX = iWorldX;
-	*piZ = map_TileHeight(worldMapState, map_coord(iWorldX), map_coord(iWorldY));
+	*piZ = map_TileHeight(gameWorld.map, map_coord(iWorldX), map_coord(iWorldY));
 	/* invert y to match QSOUND axes */
-	*piY = world_coord(worldMapState.height) - iWorldY;
+	*piY = world_coord(gameWorld.map.height) - iWorldY;
 }
 
 // @FIXME we don't need to do this, since we are not using qsound.
@@ -95,10 +96,10 @@ void audio_GetObjectPos(const SIMPLE_OBJECT *psBaseObj, SDWORD *piX, SDWORD *piY
 	ASSERT_OR_RETURN(, psBaseObj != nullptr, "Game object pointer invalid");
 
 	*piX = psBaseObj->pos.x;
-	*piZ = map_TileHeight(worldMapState, map_coord(psBaseObj->pos.x), map_coord(psBaseObj->pos.y));
+	*piZ = map_TileHeight(gameWorld.map, map_coord(psBaseObj->pos.x), map_coord(psBaseObj->pos.y));
 
 	/* invert y to match QSOUND axes */
-	*piY = world_coord(worldMapState.height) - psBaseObj->pos.y;
+	*piY = world_coord(gameWorld.map.height) - psBaseObj->pos.y;
 }
 
 UDWORD sound_GetGameTime()

--- a/src/aud.cpp
+++ b/src/aud.cpp
@@ -63,7 +63,7 @@ Vector3f audio_GetPlayerPos()
 
 	// Invert Y to match QSOUND axes
 	// @NOTE What is QSOUND? Why invert the Y axis?
-	pos.y = world_coord(mapHeight) - pos.y;
+	pos.y = world_coord(worldMapState.height) - pos.y;
 
 	return pos;
 }
@@ -85,7 +85,7 @@ void audio_GetStaticPos(SDWORD iWorldX, SDWORD iWorldY, SDWORD *piX, SDWORD *piY
 	*piX = iWorldX;
 	*piZ = map_TileHeight(map_coord(iWorldX), map_coord(iWorldY));
 	/* invert y to match QSOUND axes */
-	*piY = world_coord(mapHeight) - iWorldY;
+	*piY = world_coord(worldMapState.height) - iWorldY;
 }
 
 // @FIXME we don't need to do this, since we are not using qsound.
@@ -98,7 +98,7 @@ void audio_GetObjectPos(const SIMPLE_OBJECT *psBaseObj, SDWORD *piX, SDWORD *piY
 	*piZ = map_TileHeight(map_coord(psBaseObj->pos.x), map_coord(psBaseObj->pos.y));
 
 	/* invert y to match QSOUND axes */
-	*piY = world_coord(mapHeight) - psBaseObj->pos.y;
+	*piY = world_coord(worldMapState.height) - psBaseObj->pos.y;
 }
 
 UDWORD sound_GetGameTime()

--- a/src/cmddroid.cpp
+++ b/src/cmddroid.cpp
@@ -37,6 +37,7 @@
 #include "objmem.h"
 #include "droid.h"
 #include "hci.h"
+#include "game_world.h"
 
 /**This represents the current selected player, which is the client's player.*/
 extern UDWORD selectedPlayer;
@@ -175,7 +176,7 @@ SDWORD cmdDroidGetIndex(const DROID *psCommander)
 		return 0;
 	}
 
-	for (const DROID* psCurr : worldObjectState.droids[psCommander->player])
+	for (const DROID* psCurr : gameWorld.objects.droids[psCommander->player])
 	{
 		if (psCurr->droidType == DROID_COMMAND &&
 		    psCurr->id < psCommander->id)

--- a/src/cmddroid.cpp
+++ b/src/cmddroid.cpp
@@ -175,7 +175,7 @@ SDWORD cmdDroidGetIndex(const DROID *psCommander)
 		return 0;
 	}
 
-	for (const DROID* psCurr : apsDroidLists[psCommander->player])
+	for (const DROID* psCurr : worldObjectState.droids[psCommander->player])
 	{
 		if (psCurr->droidType == DROID_COMMAND &&
 		    psCurr->id < psCommander->id)

--- a/src/combat.cpp
+++ b/src/combat.cpp
@@ -275,7 +275,7 @@ bool combFire(WEAPON *psWeap, BASE_OBJECT *psAttacker, BASE_OBJECT *psTarget, in
 		predict += Vector3i(iSinCosR(psDroid->sMove.moveDir, psDroid->sMove.speed * flightTime / GAME_TICKS_PER_SEC), 0);
 		if (!psDroid->isFlying() && !psDroid->isFlightBasedTransporter())
 		{
-			predict.z = map_Height(predict.xy());  // Predict that the object will be on the ground.
+			predict.z = map_Height(worldMapState, predict.xy());  // Predict that the object will be on the ground.
 		}
 	}
 

--- a/src/combat.cpp
+++ b/src/combat.cpp
@@ -275,7 +275,7 @@ bool combFire(WEAPON *psWeap, BASE_OBJECT *psAttacker, BASE_OBJECT *psTarget, in
 		predict += Vector3i(iSinCosR(psDroid->sMove.moveDir, psDroid->sMove.speed * flightTime / GAME_TICKS_PER_SEC), 0);
 		if (!psDroid->isFlying() && !psDroid->isFlightBasedTransporter())
 		{
-			predict.z = map_Height(worldMapState, predict.xy());  // Predict that the object will be on the ground.
+			predict.z = map_Height(gameWorld.map, predict.xy());  // Predict that the object will be on the ground.
 		}
 	}
 
@@ -327,8 +327,8 @@ bool combFire(WEAPON *psWeap, BASE_OBJECT *psAttacker, BASE_OBJECT *psTarget, in
 	}
 
 	// Make sure we don't pass any negative or out of bounds numbers to proj_SendProjectile
-	CLIP(predict.x, 0, world_coord(worldMapState.width - 1));
-	CLIP(predict.y, 0, world_coord(worldMapState.height - 1));
+	CLIP(predict.x, 0, world_coord(gameWorld.map.width - 1));
+	CLIP(predict.y, 0, world_coord(gameWorld.map.height - 1));
 
 	proj_SendProjectileAngled(psWeap, psAttacker, psAttacker->player, predict, psTarget, bVisibleAnyway, weapon_slot, min_angle, fireTime);
 	return true;
@@ -351,7 +351,7 @@ void counterBatteryFire(BASE_OBJECT *psAttacker, BASE_OBJECT *psTarget)
 
 	CHECK_OBJECT(psTarget);
 
-	for (BASE_OBJECT* psViewer : worldObjectState.sensors[0])
+	for (BASE_OBJECT* psViewer : gameWorld.objects.sensors[0])
 	{
 		if (aiCheckAlliances(psTarget->player, psViewer->player))
 		{

--- a/src/combat.cpp
+++ b/src/combat.cpp
@@ -351,7 +351,7 @@ void counterBatteryFire(BASE_OBJECT *psAttacker, BASE_OBJECT *psTarget)
 
 	CHECK_OBJECT(psTarget);
 
-	for (BASE_OBJECT* psViewer : apsSensorList[0])
+	for (BASE_OBJECT* psViewer : worldObjectState.sensors[0])
 	{
 		if (aiCheckAlliances(psTarget->player, psViewer->player))
 		{

--- a/src/combat.cpp
+++ b/src/combat.cpp
@@ -327,8 +327,8 @@ bool combFire(WEAPON *psWeap, BASE_OBJECT *psAttacker, BASE_OBJECT *psTarget, in
 	}
 
 	// Make sure we don't pass any negative or out of bounds numbers to proj_SendProjectile
-	CLIP(predict.x, 0, world_coord(mapWidth - 1));
-	CLIP(predict.y, 0, world_coord(mapHeight - 1));
+	CLIP(predict.x, 0, world_coord(worldMapState.width - 1));
+	CLIP(predict.y, 0, world_coord(worldMapState.height - 1));
 
 	proj_SendProjectileAngled(psWeap, psAttacker, psAttacker->player, predict, psTarget, bVisibleAnyway, weapon_slot, min_angle, fireTime);
 	return true;

--- a/src/component.cpp
+++ b/src/component.cpp
@@ -467,7 +467,7 @@ static bool displayCompObj(const DROID *psDroid, bool bButton, const glm::mat4& 
 		// NOTE: Beware of transporters that are offscreen, on a mission!  We should *not* be checking tiles at this point in time!
 		if (!psDroid->isTransporter() && !missionIsOffworld())
 		{
-			MAPTILE *psTile = worldTile(psDroid->pos.x, psDroid->pos.y);
+			MAPTILE *psTile = worldTile(worldMapState, psDroid->pos.x, psDroid->pos.y);
 			if (psTile->jammerBits & alliancebits[psDroid->player])
 			{
 				pieFlag |= pie_ECM;

--- a/src/component.cpp
+++ b/src/component.cpp
@@ -467,7 +467,7 @@ static bool displayCompObj(const DROID *psDroid, bool bButton, const glm::mat4& 
 		// NOTE: Beware of transporters that are offscreen, on a mission!  We should *not* be checking tiles at this point in time!
 		if (!psDroid->isTransporter() && !missionIsOffworld())
 		{
-			MAPTILE *psTile = worldTile(worldMapState, psDroid->pos.x, psDroid->pos.y);
+			MAPTILE *psTile = worldTile(gameWorld.map, psDroid->pos.x, psDroid->pos.y);
 			if (psTile->jammerBits & alliancebits[psDroid->player])
 			{
 				pieFlag |= pie_ECM;

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -81,6 +81,7 @@
 #include "input/keyconfig.h"
 #include "mapgrid.h"
 #include "main.h"
+#include "game_world.h"
 
 InputManager gInputManager;
 KeyFunctionConfiguration gKeyFuncConfig;
@@ -414,7 +415,7 @@ static bool localPlayerHasSelection()
 		return false;
 	}
 
-	for (const DROID* psDroid : worldObjectState.droids[selectedPlayer])
+	for (const DROID* psDroid : gameWorld.objects.droids[selectedPlayer])
 	{
 		if (psDroid->selected)
 		{
@@ -422,7 +423,7 @@ static bool localPlayerHasSelection()
 		}
 	}
 
-	for (const STRUCTURE* psStruct : worldObjectState.structures[selectedPlayer])
+	for (const STRUCTURE* psStruct : gameWorld.objects.structures[selectedPlayer])
 	{
 		if (psStruct->selected)
 		{
@@ -796,7 +797,7 @@ void processMouseClickInput()
 			else if (selection == SC_DROID_REPAIR)
 			{
 				// We can't repair ourselves, so change it to a blocking cursor
-				for (const DROID *psCurr : worldObjectState.droids[selectedPlayer])
+				for (const DROID *psCurr : gameWorld.objects.droids[selectedPlayer])
 				{
 					if (psCurr->selected)
 					{
@@ -897,7 +898,7 @@ void processMouseClickInput()
 			}
 
 			if (item == MT_TERRAIN
-			    && terrainType(mapTile(worldMapState, mouseTileX, mouseTileY)) == TER_CLIFFFACE)
+			    && terrainType(mapTile(gameWorld.map, mouseTileX, mouseTileY)) == TER_CLIFFFACE)
 			{
 				item = MT_BLOCKING;
 			}
@@ -1140,10 +1141,10 @@ void resetScroll()
 // Checks if coordinate is inside scroll limits, returns false if not.
 bool CheckInScrollLimits(const int &xPos, const int &yPos)
 {
-	int minX = world_coord(worldMapState.scroll.minX);
-	int maxX = world_coord(worldMapState.scroll.maxX - 1);
-	int minY = world_coord(worldMapState.scroll.minY);
-	int maxY = world_coord(worldMapState.scroll.maxY - 1);
+	int minX = world_coord(gameWorld.map.scroll.minX);
+	int maxX = world_coord(gameWorld.map.scroll.maxX - 1);
+	int minY = world_coord(gameWorld.map.scroll.minY);
+	int maxY = world_coord(gameWorld.map.scroll.maxY - 1);
 
 	if ((xPos < minX) || (xPos >= maxX) || (yPos < minY) || (yPos >= maxY))
 	{
@@ -1161,10 +1162,10 @@ bool CheckInScrollLimitsCamera(SDWORD *xPos, SDWORD *zPos)
 	bool EdgeHit = false;
 	SDWORD	minX, minY, maxX, maxY;
 
-	minX = world_coord(worldMapState.scroll.minX);
-	maxX = world_coord(worldMapState.scroll.maxX - 1);
-	minY = world_coord(worldMapState.scroll.minY);
-	maxY = world_coord(worldMapState.scroll.maxY - 1);
+	minX = world_coord(gameWorld.map.scroll.minX);
+	maxX = world_coord(gameWorld.map.scroll.maxX - 1);
+	minY = world_coord(gameWorld.map.scroll.minY);
+	maxY = world_coord(gameWorld.map.scroll.maxY - 1);
 
 	//scroll is limited to what can be seen for current campaign
 	if (*xPos < minX)
@@ -1321,7 +1322,7 @@ BASE_OBJECT *mouseTarget()
 	BASE_OBJECT *psReturn = nullptr;
 	int dispX, dispY, dispR;
 
-	if (mouseTileX < 0 || mouseTileY < 0 || mouseTileX > worldMapState.width - 1 || mouseTileY > worldMapState.height - 1)
+	if (mouseTileX < 0 || mouseTileY < 0 || mouseTileX > gameWorld.map.width - 1 || mouseTileY > gameWorld.map.height - 1)
 	{
 		return (nullptr);
 	}
@@ -1329,7 +1330,7 @@ BASE_OBJECT *mouseTarget()
 	/* First have a look through the droid lists */
 	for (int i = 0; i < MAX_PLAYERS; i++)
 	{
-		for (DROID *psDroid : worldObjectState.droids[i])
+		for (DROID *psDroid : gameWorld.objects.droids[i])
 		{
 			dispX = psDroid->sDisplay.screenX;
 			dispY = psDroid->sDisplay.screenY;
@@ -1379,7 +1380,7 @@ void startDeliveryPosition(FLAG_POSITION *psFlag)
 	ASSERT_OR_RETURN(, selectedPlayer < MAX_PLAYERS, "Invalid player (selectedPlayer: %" PRIu32 ")", selectedPlayer);
 
 	//clear the selected delivery point
-	for (auto& psFlagPos : worldObjectState.flags[selectedPlayer])
+	for (auto& psFlagPos : gameWorld.objects.flags[selectedPlayer])
 	{
 		psFlagPos->selected = false;
 	}
@@ -1430,7 +1431,7 @@ void finishDeliveryPosition()
 			}
 		}
 		//deselect once moved
-		for (auto& psFlag : worldObjectState.flags[selectedPlayer])
+		for (auto& psFlag : gameWorld.objects.flags[selectedPlayer])
 		{
 			psFlag->selected = false;
 		}
@@ -1452,14 +1453,14 @@ bool deliveryReposValid()
 	Vector2i map = map_coord(flagPos.coords.xy());
 
 	//make sure we are not too near map edge
-	if (map.x < worldMapState.scroll.minX + TOO_NEAR_EDGE || map.x + 1 > worldMapState.scroll.maxX - TOO_NEAR_EDGE ||
-	    map.y < worldMapState.scroll.minY + TOO_NEAR_EDGE || map.y + 1 > worldMapState.scroll.maxY - TOO_NEAR_EDGE)
+	if (map.x < gameWorld.map.scroll.minX + TOO_NEAR_EDGE || map.x + 1 > gameWorld.map.scroll.maxX - TOO_NEAR_EDGE ||
+	    map.y < gameWorld.map.scroll.minY + TOO_NEAR_EDGE || map.y + 1 > gameWorld.map.scroll.maxY - TOO_NEAR_EDGE)
 	{
 		return false;
 	}
 
 	// cant place on top of a delivery point...
-	for (const auto& psFlag : worldObjectState.flags[selectedPlayer])
+	for (const auto& psFlag : gameWorld.objects.flags[selectedPlayer])
 	{
 		Vector2i flagTile = map_coord(psFlag->coords.xy());
 		if (flagTile == map)
@@ -1497,10 +1498,10 @@ void processDeliveryRepos()
 		return;
 	}
 
-	int bX = clip<int>(mouseTileX, 2, worldMapState.width - 3);
-	int bY = clip<int>(mouseTileY, 2, worldMapState.height - 3);
+	int bX = clip<int>(mouseTileX, 2, gameWorld.map.width - 3);
+	int bY = clip<int>(mouseTileY, 2, gameWorld.map.height - 3);
 
-	flagPos.coords = Vector3i(world_coord(Vector2i(bX, bY)) + Vector2i(TILE_UNITS / 2, TILE_UNITS / 2), map_TileHeight(worldMapState, bX, bY) + 2 * ASSEMBLY_POINT_Z_PADDING);
+	flagPos.coords = Vector3i(world_coord(Vector2i(bX, bY)) + Vector2i(TILE_UNITS / 2, TILE_UNITS / 2), map_TileHeight(gameWorld.map, bX, bY) + 2 * ASSEMBLY_POINT_Z_PADDING);
 }
 
 // Cancel repositioning of the delivery point without moving it.
@@ -1730,7 +1731,7 @@ static void dealWithLMBDroid(DROID *psDroid, SELECTION_TYPE selection)
 	else if (psDroid->droidType == DROID_SENSOR)
 	{
 		bSensorAssigned = false;
-		for (DROID* psCurr : worldObjectState.droids[selectedPlayer])
+		for (DROID* psCurr : gameWorld.objects.droids[selectedPlayer])
 		{
 			//must be indirect weapon droid or VTOL weapon droid
 			if ((psCurr->droidType == DROID_WEAPON) &&
@@ -1858,7 +1859,7 @@ static void dealWithLMBStructure(STRUCTURE *psStructure, SELECTION_TYPE selectio
 			if (selection == SC_INVALID)
 			{
 				/* Clear old building selection(s) - should only be one */
-				for (STRUCTURE* psCurr : worldObjectState.structures[selectedPlayer])
+				for (STRUCTURE* psCurr : gameWorld.objects.structures[selectedPlayer])
 				{
 					psCurr->selected = false;
 				}
@@ -1883,7 +1884,7 @@ static void dealWithLMBStructure(STRUCTURE *psStructure, SELECTION_TYPE selectio
 	         selection == SC_INVALID && ownStruct)
 	{
 		/* Clear old building selection(s) - should only be one */
-		for (STRUCTURE* psCurr : worldObjectState.structures[selectedPlayer])
+		for (STRUCTURE* psCurr : gameWorld.objects.structures[selectedPlayer])
 		{
 			psCurr->selected = false;
 		}
@@ -1946,12 +1947,12 @@ static void dealWithLMBFeature(FEATURE *psFeature)
 		    (apStructTypeLists[selectedPlayer][i] == AVAILABLE))	// don't go any further if no derrick stat found.
 		{
 			// for each droid
-			for (DROID* psCurr : worldObjectState.droids[selectedPlayer])
+			for (DROID* psCurr : gameWorld.objects.droids[selectedPlayer])
 			{
 				if ((droidType(psCurr) == DROID_CONSTRUCT ||
 				     droidType(psCurr) == DROID_CYBORG_CONSTRUCT) && (psCurr->selected))
 				{
-					if (fireOnLocation(worldMapState, psFeature->pos.x, psFeature->pos.y))
+					if (fireOnLocation(gameWorld.map, psFeature->pos.x, psFeature->pos.y))
 					{
 						// Can't build because it's burning
 						AddDerrickBurningMessage();
@@ -2079,10 +2080,10 @@ void	dealWithLMB()
 	}
 
 	const DebugInputManager& dbgInputManager = gInputManager.debugManager();
-	if (dbgInputManager.debugMappingsAllowed() && tileOnMap(worldMapState, mouseTileX, mouseTileY))
+	if (dbgInputManager.debugMappingsAllowed() && tileOnMap(gameWorld.map, mouseTileX, mouseTileY))
 	{
-		MAPTILE *psTile = mapTile(worldMapState, mouseTileX, mouseTileY);
-		uint8_t aux = auxTile(worldMapState, mouseTileX, mouseTileY, selectedPlayer);
+		MAPTILE *psTile = mapTile(gameWorld.map, mouseTileX, mouseTileY);
+		uint8_t aux = auxTile(gameWorld.map, mouseTileX, mouseTileY, selectedPlayer);
 
 		int flipVal = 0;
 		if (TileNumber_texture(psTile->texture) & TILE_XFLIP)
@@ -2168,7 +2169,7 @@ static FLAG_POSITION *findMouseDeliveryPoint()
 		return nullptr;
 	}
 
-	for (const auto& psPoint : worldObjectState.flags[selectedPlayer])
+	for (const auto& psPoint : gameWorld.objects.flags[selectedPlayer])
 	{
 		if (psPoint->type != POS_DELIVERY) {
 			continue;
@@ -2370,7 +2371,7 @@ static MOUSE_TARGET	itemUnderMouse(BASE_OBJECT **ppObjectUnderMouse)
 
 	*ppObjectUnderMouse = nullptr;
 
-	if (mouseTileX < 0 || mouseTileY < 0 || mouseTileX > (int)(worldMapState.width - 1) || mouseTileY > (int)(worldMapState.height - 1))
+	if (mouseTileX < 0 || mouseTileY < 0 || mouseTileX > (int)(gameWorld.map.width - 1) || mouseTileY > (int)(gameWorld.map.height - 1))
 	{
 		retVal = MT_BLOCKING;
 		return retVal;
@@ -2382,7 +2383,7 @@ static MOUSE_TARGET	itemUnderMouse(BASE_OBJECT **ppObjectUnderMouse)
 	/* First have a look through the droid lists */
 	for (i = 0; i < MAX_PLAYERS; i++)
 	{
-		for (DROID* psDroid : worldObjectState.droids[i])
+		for (DROID* psDroid : gameWorld.objects.droids[i])
 		{
 			dispX = psDroid->sDisplay.screenX;
 			dispY = psDroid->sDisplay.screenY;
@@ -2601,7 +2602,7 @@ static SELECTION_TYPE	establishSelection(UDWORD _selectedPlayer)
 		return SC_INVALID;
 	}
 
-	for (DROID *psDroid : worldObjectState.droids[_selectedPlayer])
+	for (DROID *psDroid : gameWorld.objects.droids[_selectedPlayer])
 	{
 		// This works, uses the DroidSelectionWeights[] table to priorities the different
 		// droid types and find the dominant selection.
@@ -2691,7 +2692,7 @@ bool	repairDroidSelected(UDWORD player)
 {
 	ASSERT_OR_RETURN(false, player < MAX_PLAYERS, "Invalid player (%" PRIu32 ")", player);
 
-	for (const DROID* psCurr : worldObjectState.droids[player])
+	for (const DROID* psCurr : gameWorld.objects.droids[player])
 	{
 		if (psCurr->selected && (
 		        psCurr->droidType == DROID_REPAIR ||
@@ -2710,7 +2711,7 @@ bool	vtolDroidSelected(UDWORD player)
 {
 	ASSERT_OR_RETURN(false, player < MAX_PLAYERS, "player: %" PRIu32 "", player);
 
-	for (DROID* psCurr : worldObjectState.droids[player])
+	for (DROID* psCurr : gameWorld.objects.droids[player])
 	{
 		if (psCurr->selected && psCurr->isVtol())
 		{
@@ -2729,7 +2730,7 @@ bool	anyDroidSelected(UDWORD player)
 {
 	ASSERT_OR_RETURN(false, player < MAX_PLAYERS, "Invalid player (%" PRIu32 ")", player);
 
-	for (const DROID* psCurr : worldObjectState.droids[player])
+	for (const DROID* psCurr : gameWorld.objects.droids[player])
 	{
 		if (psCurr->selected)
 		{
@@ -2746,7 +2747,7 @@ bool cyborgDroidSelected(UDWORD player)
 {
 	ASSERT_OR_RETURN(false, player < MAX_PLAYERS, "Invalid player (%" PRIu32 ")", player);
 
-	for (const DROID* psCurr : worldObjectState.droids[player])
+	for (const DROID* psCurr : gameWorld.objects.droids[player])
 	{
 		if (psCurr->selected && psCurr->isCyborg())
 		{
@@ -2768,17 +2769,17 @@ void clearSelection()
 		return;
 	}
 
-	for (DROID* psCurrDroid : worldObjectState.droids[selectedPlayer])
+	for (DROID* psCurrDroid : gameWorld.objects.droids[selectedPlayer])
 	{
 		psCurrDroid->selected = false;
 	}
-	for (STRUCTURE* psStruct : worldObjectState.structures[selectedPlayer])
+	for (STRUCTURE* psStruct : gameWorld.objects.structures[selectedPlayer])
 	{
 		psStruct->selected = false;
 	}
 	bLasSatStruct = false;
 	//clear the Deliv Point if one
-	for (auto& psFlag : worldObjectState.flags[selectedPlayer])
+	for (auto& psFlag : gameWorld.objects.flags[selectedPlayer])
 	{
 		psFlag->selected = false;
 	}

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -414,7 +414,7 @@ static bool localPlayerHasSelection()
 		return false;
 	}
 
-	for (const DROID* psDroid : apsDroidLists[selectedPlayer])
+	for (const DROID* psDroid : worldObjectState.droids[selectedPlayer])
 	{
 		if (psDroid->selected)
 		{
@@ -422,7 +422,7 @@ static bool localPlayerHasSelection()
 		}
 	}
 
-	for (const STRUCTURE* psStruct : apsStructLists[selectedPlayer])
+	for (const STRUCTURE* psStruct : worldObjectState.structures[selectedPlayer])
 	{
 		if (psStruct->selected)
 		{
@@ -796,7 +796,7 @@ void processMouseClickInput()
 			else if (selection == SC_DROID_REPAIR)
 			{
 				// We can't repair ourselves, so change it to a blocking cursor
-				for (const DROID *psCurr : apsDroidLists[selectedPlayer])
+				for (const DROID *psCurr : worldObjectState.droids[selectedPlayer])
 				{
 					if (psCurr->selected)
 					{
@@ -1329,7 +1329,7 @@ BASE_OBJECT *mouseTarget()
 	/* First have a look through the droid lists */
 	for (int i = 0; i < MAX_PLAYERS; i++)
 	{
-		for (DROID *psDroid : apsDroidLists[i])
+		for (DROID *psDroid : worldObjectState.droids[i])
 		{
 			dispX = psDroid->sDisplay.screenX;
 			dispY = psDroid->sDisplay.screenY;
@@ -1379,7 +1379,7 @@ void startDeliveryPosition(FLAG_POSITION *psFlag)
 	ASSERT_OR_RETURN(, selectedPlayer < MAX_PLAYERS, "Invalid player (selectedPlayer: %" PRIu32 ")", selectedPlayer);
 
 	//clear the selected delivery point
-	for (auto& psFlagPos : apsFlagPosLists[selectedPlayer])
+	for (auto& psFlagPos : worldObjectState.flags[selectedPlayer])
 	{
 		psFlagPos->selected = false;
 	}
@@ -1430,7 +1430,7 @@ void finishDeliveryPosition()
 			}
 		}
 		//deselect once moved
-		for (auto& psFlag : apsFlagPosLists[selectedPlayer])
+		for (auto& psFlag : worldObjectState.flags[selectedPlayer])
 		{
 			psFlag->selected = false;
 		}
@@ -1459,7 +1459,7 @@ bool deliveryReposValid()
 	}
 
 	// cant place on top of a delivery point...
-	for (const auto& psFlag : apsFlagPosLists[selectedPlayer])
+	for (const auto& psFlag : worldObjectState.flags[selectedPlayer])
 	{
 		Vector2i flagTile = map_coord(psFlag->coords.xy());
 		if (flagTile == map)
@@ -1730,7 +1730,7 @@ static void dealWithLMBDroid(DROID *psDroid, SELECTION_TYPE selection)
 	else if (psDroid->droidType == DROID_SENSOR)
 	{
 		bSensorAssigned = false;
-		for (DROID* psCurr : apsDroidLists[selectedPlayer])
+		for (DROID* psCurr : worldObjectState.droids[selectedPlayer])
 		{
 			//must be indirect weapon droid or VTOL weapon droid
 			if ((psCurr->droidType == DROID_WEAPON) &&
@@ -1858,7 +1858,7 @@ static void dealWithLMBStructure(STRUCTURE *psStructure, SELECTION_TYPE selectio
 			if (selection == SC_INVALID)
 			{
 				/* Clear old building selection(s) - should only be one */
-				for (STRUCTURE* psCurr : apsStructLists[selectedPlayer])
+				for (STRUCTURE* psCurr : worldObjectState.structures[selectedPlayer])
 				{
 					psCurr->selected = false;
 				}
@@ -1883,7 +1883,7 @@ static void dealWithLMBStructure(STRUCTURE *psStructure, SELECTION_TYPE selectio
 	         selection == SC_INVALID && ownStruct)
 	{
 		/* Clear old building selection(s) - should only be one */
-		for (STRUCTURE* psCurr : apsStructLists[selectedPlayer])
+		for (STRUCTURE* psCurr : worldObjectState.structures[selectedPlayer])
 		{
 			psCurr->selected = false;
 		}
@@ -1946,7 +1946,7 @@ static void dealWithLMBFeature(FEATURE *psFeature)
 		    (apStructTypeLists[selectedPlayer][i] == AVAILABLE))	// don't go any further if no derrick stat found.
 		{
 			// for each droid
-			for (DROID* psCurr : apsDroidLists[selectedPlayer])
+			for (DROID* psCurr : worldObjectState.droids[selectedPlayer])
 			{
 				if ((droidType(psCurr) == DROID_CONSTRUCT ||
 				     droidType(psCurr) == DROID_CYBORG_CONSTRUCT) && (psCurr->selected))
@@ -2168,7 +2168,7 @@ static FLAG_POSITION *findMouseDeliveryPoint()
 		return nullptr;
 	}
 
-	for (const auto& psPoint : apsFlagPosLists[selectedPlayer])
+	for (const auto& psPoint : worldObjectState.flags[selectedPlayer])
 	{
 		if (psPoint->type != POS_DELIVERY) {
 			continue;
@@ -2382,7 +2382,7 @@ static MOUSE_TARGET	itemUnderMouse(BASE_OBJECT **ppObjectUnderMouse)
 	/* First have a look through the droid lists */
 	for (i = 0; i < MAX_PLAYERS; i++)
 	{
-		for (DROID* psDroid : apsDroidLists[i])
+		for (DROID* psDroid : worldObjectState.droids[i])
 		{
 			dispX = psDroid->sDisplay.screenX;
 			dispY = psDroid->sDisplay.screenY;
@@ -2601,7 +2601,7 @@ static SELECTION_TYPE	establishSelection(UDWORD _selectedPlayer)
 		return SC_INVALID;
 	}
 
-	for (DROID *psDroid : apsDroidLists[_selectedPlayer])
+	for (DROID *psDroid : worldObjectState.droids[_selectedPlayer])
 	{
 		// This works, uses the DroidSelectionWeights[] table to priorities the different
 		// droid types and find the dominant selection.
@@ -2691,7 +2691,7 @@ bool	repairDroidSelected(UDWORD player)
 {
 	ASSERT_OR_RETURN(false, player < MAX_PLAYERS, "Invalid player (%" PRIu32 ")", player);
 
-	for (const DROID* psCurr : apsDroidLists[player])
+	for (const DROID* psCurr : worldObjectState.droids[player])
 	{
 		if (psCurr->selected && (
 		        psCurr->droidType == DROID_REPAIR ||
@@ -2710,7 +2710,7 @@ bool	vtolDroidSelected(UDWORD player)
 {
 	ASSERT_OR_RETURN(false, player < MAX_PLAYERS, "player: %" PRIu32 "", player);
 
-	for (DROID* psCurr : apsDroidLists[player])
+	for (DROID* psCurr : worldObjectState.droids[player])
 	{
 		if (psCurr->selected && psCurr->isVtol())
 		{
@@ -2729,7 +2729,7 @@ bool	anyDroidSelected(UDWORD player)
 {
 	ASSERT_OR_RETURN(false, player < MAX_PLAYERS, "Invalid player (%" PRIu32 ")", player);
 
-	for (const DROID* psCurr : apsDroidLists[player])
+	for (const DROID* psCurr : worldObjectState.droids[player])
 	{
 		if (psCurr->selected)
 		{
@@ -2746,7 +2746,7 @@ bool cyborgDroidSelected(UDWORD player)
 {
 	ASSERT_OR_RETURN(false, player < MAX_PLAYERS, "Invalid player (%" PRIu32 ")", player);
 
-	for (const DROID* psCurr : apsDroidLists[player])
+	for (const DROID* psCurr : worldObjectState.droids[player])
 	{
 		if (psCurr->selected && psCurr->isCyborg())
 		{
@@ -2768,17 +2768,17 @@ void clearSelection()
 		return;
 	}
 
-	for (DROID* psCurrDroid : apsDroidLists[selectedPlayer])
+	for (DROID* psCurrDroid : worldObjectState.droids[selectedPlayer])
 	{
 		psCurrDroid->selected = false;
 	}
-	for (STRUCTURE* psStruct : apsStructLists[selectedPlayer])
+	for (STRUCTURE* psStruct : worldObjectState.structures[selectedPlayer])
 	{
 		psStruct->selected = false;
 	}
 	bLasSatStruct = false;
 	//clear the Deliv Point if one
-	for (auto& psFlag : apsFlagPosLists[selectedPlayer])
+	for (auto& psFlag : worldObjectState.flags[selectedPlayer])
 	{
 		psFlag->selected = false;
 	}

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -1140,10 +1140,10 @@ void resetScroll()
 // Checks if coordinate is inside scroll limits, returns false if not.
 bool CheckInScrollLimits(const int &xPos, const int &yPos)
 {
-	int minX = world_coord(scrollMinX);
-	int maxX = world_coord(scrollMaxX - 1);
-	int minY = world_coord(scrollMinY);
-	int maxY = world_coord(scrollMaxY - 1);
+	int minX = world_coord(worldMapState.scroll.minX);
+	int maxX = world_coord(worldMapState.scroll.maxX - 1);
+	int minY = world_coord(worldMapState.scroll.minY);
+	int maxY = world_coord(worldMapState.scroll.maxY - 1);
 
 	if ((xPos < minX) || (xPos >= maxX) || (yPos < minY) || (yPos >= maxY))
 	{
@@ -1161,10 +1161,10 @@ bool CheckInScrollLimitsCamera(SDWORD *xPos, SDWORD *zPos)
 	bool EdgeHit = false;
 	SDWORD	minX, minY, maxX, maxY;
 
-	minX = world_coord(scrollMinX);
-	maxX = world_coord(scrollMaxX - 1);
-	minY = world_coord(scrollMinY);
-	maxY = world_coord(scrollMaxY - 1);
+	minX = world_coord(worldMapState.scroll.minX);
+	maxX = world_coord(worldMapState.scroll.maxX - 1);
+	minY = world_coord(worldMapState.scroll.minY);
+	maxY = world_coord(worldMapState.scroll.maxY - 1);
 
 	//scroll is limited to what can be seen for current campaign
 	if (*xPos < minX)
@@ -1321,7 +1321,7 @@ BASE_OBJECT *mouseTarget()
 	BASE_OBJECT *psReturn = nullptr;
 	int dispX, dispY, dispR;
 
-	if (mouseTileX < 0 || mouseTileY < 0 || mouseTileX > mapWidth - 1 || mouseTileY > mapHeight - 1)
+	if (mouseTileX < 0 || mouseTileY < 0 || mouseTileX > worldMapState.width - 1 || mouseTileY > worldMapState.height - 1)
 	{
 		return (nullptr);
 	}
@@ -1452,8 +1452,8 @@ bool deliveryReposValid()
 	Vector2i map = map_coord(flagPos.coords.xy());
 
 	//make sure we are not too near map edge
-	if (map.x < scrollMinX + TOO_NEAR_EDGE || map.x + 1 > scrollMaxX - TOO_NEAR_EDGE ||
-	    map.y < scrollMinY + TOO_NEAR_EDGE || map.y + 1 > scrollMaxY - TOO_NEAR_EDGE)
+	if (map.x < worldMapState.scroll.minX + TOO_NEAR_EDGE || map.x + 1 > worldMapState.scroll.maxX - TOO_NEAR_EDGE ||
+	    map.y < worldMapState.scroll.minY + TOO_NEAR_EDGE || map.y + 1 > worldMapState.scroll.maxY - TOO_NEAR_EDGE)
 	{
 		return false;
 	}
@@ -1497,8 +1497,8 @@ void processDeliveryRepos()
 		return;
 	}
 
-	int bX = clip<int>(mouseTileX, 2, mapWidth - 3);
-	int bY = clip<int>(mouseTileY, 2, mapHeight - 3);
+	int bX = clip<int>(mouseTileX, 2, worldMapState.width - 3);
+	int bY = clip<int>(mouseTileY, 2, worldMapState.height - 3);
 
 	flagPos.coords = Vector3i(world_coord(Vector2i(bX, bY)) + Vector2i(TILE_UNITS / 2, TILE_UNITS / 2), map_TileHeight(bX, bY) + 2 * ASSEMBLY_POINT_Z_PADDING);
 }
@@ -2370,7 +2370,7 @@ static MOUSE_TARGET	itemUnderMouse(BASE_OBJECT **ppObjectUnderMouse)
 
 	*ppObjectUnderMouse = nullptr;
 
-	if (mouseTileX < 0 || mouseTileY < 0 || mouseTileX > (int)(mapWidth - 1) || mouseTileY > (int)(mapHeight - 1))
+	if (mouseTileX < 0 || mouseTileY < 0 || mouseTileX > (int)(worldMapState.width - 1) || mouseTileY > (int)(worldMapState.height - 1))
 	{
 		retVal = MT_BLOCKING;
 		return retVal;

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -897,7 +897,7 @@ void processMouseClickInput()
 			}
 
 			if (item == MT_TERRAIN
-			    && terrainType(mapTile(mouseTileX, mouseTileY)) == TER_CLIFFFACE)
+			    && terrainType(mapTile(worldMapState, mouseTileX, mouseTileY)) == TER_CLIFFFACE)
 			{
 				item = MT_BLOCKING;
 			}
@@ -1500,7 +1500,7 @@ void processDeliveryRepos()
 	int bX = clip<int>(mouseTileX, 2, worldMapState.width - 3);
 	int bY = clip<int>(mouseTileY, 2, worldMapState.height - 3);
 
-	flagPos.coords = Vector3i(world_coord(Vector2i(bX, bY)) + Vector2i(TILE_UNITS / 2, TILE_UNITS / 2), map_TileHeight(bX, bY) + 2 * ASSEMBLY_POINT_Z_PADDING);
+	flagPos.coords = Vector3i(world_coord(Vector2i(bX, bY)) + Vector2i(TILE_UNITS / 2, TILE_UNITS / 2), map_TileHeight(worldMapState, bX, bY) + 2 * ASSEMBLY_POINT_Z_PADDING);
 }
 
 // Cancel repositioning of the delivery point without moving it.
@@ -1951,7 +1951,7 @@ static void dealWithLMBFeature(FEATURE *psFeature)
 				if ((droidType(psCurr) == DROID_CONSTRUCT ||
 				     droidType(psCurr) == DROID_CYBORG_CONSTRUCT) && (psCurr->selected))
 				{
-					if (fireOnLocation(psFeature->pos.x, psFeature->pos.y))
+					if (fireOnLocation(worldMapState, psFeature->pos.x, psFeature->pos.y))
 					{
 						// Can't build because it's burning
 						AddDerrickBurningMessage();
@@ -2079,10 +2079,10 @@ void	dealWithLMB()
 	}
 
 	const DebugInputManager& dbgInputManager = gInputManager.debugManager();
-	if (dbgInputManager.debugMappingsAllowed() && tileOnMap(mouseTileX, mouseTileY))
+	if (dbgInputManager.debugMappingsAllowed() && tileOnMap(worldMapState, mouseTileX, mouseTileY))
 	{
-		MAPTILE *psTile = mapTile(mouseTileX, mouseTileY);
-		uint8_t aux = auxTile(mouseTileX, mouseTileY, selectedPlayer);
+		MAPTILE *psTile = mapTile(worldMapState, mouseTileX, mouseTileY);
+		uint8_t aux = auxTile(worldMapState, mouseTileX, mouseTileY, selectedPlayer);
 
 		int flipVal = 0;
 		if (TileNumber_texture(psTile->texture) & TILE_XFLIP)

--- a/src/display3d.cpp
+++ b/src/display3d.cpp
@@ -90,6 +90,7 @@
 #include "wzcrashhandlingproviders.h"
 #include "shadowcascades.h"
 #include "profiling.h"
+#include "game_world.h"
 
 
 /********************  Prototypes  ********************/
@@ -412,7 +413,7 @@ public:
 		bool bDrawAll = barMode == BAR_DROIDS || barMode == BAR_DROIDS_AND_STRUCTURES;
 
 		// first, for all droids, queue the various rects
-		for (DROID *psDroid : worldObjectState.droids[player])
+		for (DROID *psDroid : gameWorld.objects.droids[player])
 		{
 			if (psDroid->sDisplay.frameNumber == currentGameFrame)
 			{
@@ -453,7 +454,7 @@ public:
 	void addStructureSelectionsToRender(uint32_t player, BASE_OBJECT *psClickedOn, bool bMouseOverOwnStructure)
 	{
 		/* Go thru' all the buildings */
-		for (STRUCTURE *psStruct : worldObjectState.structures[player])
+		for (STRUCTURE *psStruct : gameWorld.objects.structures[player])
 		{
 			if (psStruct->sDisplay.frameNumber == currentGameFrame)
 			{
@@ -534,7 +535,7 @@ public:
 			SDWORD scrX, scrY;
 			for (uint32_t i = 0; i < MAX_PLAYERS; i++)
 			{
-				for (const STRUCTURE* psStruct : worldObjectState.structures[i])
+				for (const STRUCTURE* psStruct : gameWorld.objects.structures[i])
 				{
 					/* If it's targetted and on-screen */
 					if (psStruct->flags.test(OBJECT_FLAG_TARGETED)
@@ -783,7 +784,7 @@ static PIELIGHT structureBrightness(STRUCTURE *psStructure)
 		{
 			buildingBrightness = pal_SetBrightness(avGetObjLightLevel((BASE_OBJECT *)psStructure, buildingBrightness.byte.r));
 		}
-		if (!hasSensorOnTile(mapTile(worldMapState, map_coord(psStructure->pos.x), map_coord(psStructure->pos.y)), selectedPlayer))
+		if (!hasSensorOnTile(mapTile(gameWorld.map, map_coord(psStructure->pos.x), map_coord(psStructure->pos.y)), selectedPlayer))
 		{
 			buildingBrightness.byte.r /= 2;
 			buildingBrightness.byte.g /= 2;
@@ -807,7 +808,7 @@ static void showDroidPaths()
 		return; // no-op for now
 	}
 
-	for (const DROID *psDroid : worldObjectState.droids[selectedPlayer])
+	for (const DROID *psDroid : gameWorld.objects.droids[selectedPlayer])
 	{
 		if (psDroid->selected && psDroid->sMove.Status != MOVEINACTIVE)
 		{
@@ -816,10 +817,10 @@ static void showDroidPaths()
 			{
 				Vector3i pos;
 
-				ASSERT(worldOnMap(worldMapState, psDroid->sMove.asPath[i].x, psDroid->sMove.asPath[i].y), "Path off map!");
+				ASSERT(worldOnMap(gameWorld.map, psDroid->sMove.asPath[i].x, psDroid->sMove.asPath[i].y), "Path off map!");
 				pos.x = psDroid->sMove.asPath[i].x;
 				pos.z = psDroid->sMove.asPath[i].y;
-				pos.y = map_Height(worldMapState, pos.x, pos.z) + 16;
+				pos.y = map_Height(gameWorld.map, pos.x, pos.z) + 16;
 
 				effectGiveAuxVar(80);
 				addEffect(&pos, EFFECT_EXPLOSION, EXPLOSION_TYPE_LASER, false, nullptr, 0);
@@ -1118,7 +1119,7 @@ void draw3DScene()
 	{
 		int visibleDroids = 0;
 		int undrawnDroids = 0;
-		for (const DROID *psDroid : worldObjectState.droids[selectedPlayer])
+		for (const DROID *psDroid : gameWorld.objects.droids[selectedPlayer])
 		{
 			if (psDroid->sDisplay.frameNumber != currentGameFrame)
 			{
@@ -1239,10 +1240,10 @@ static int calcAverageTerrainHeight(int tileX, int tileZ)
 	{
 		for (int j = -4; j <= 4; j++)
 		{
-			if (tileOnMap(worldMapState, tileX + j, tileZ + i))
+			if (tileOnMap(gameWorld.map, tileX + j, tileZ + i))
 			{
 				/* Get a pointer to the tile at this location */
-				MAPTILE *psTile = mapTile(worldMapState, tileX + j, tileZ + i);
+				MAPTILE *psTile = mapTile(gameWorld.map, tileX + j, tileZ + i);
 
 				result += std::max(psTile->height, psTile->waterLevel);
 				numTilesAveraged++;
@@ -1258,7 +1259,7 @@ static int calcAverageTerrainHeight(int tileX, int tileZ)
 	 * Work out the average height.
 	 * We use this information to keep the player camera above the terrain.
 	 */
-	MAPTILE *psTile = mapTile(worldMapState, tileX, tileZ);
+	MAPTILE *psTile = mapTile(gameWorld.map, tileX, tileZ);
 
 	result /= numTilesAveraged;
 	if (result < psTile->height)
@@ -1395,9 +1396,9 @@ static void drawTiles(iView *player, LightingData& lightData, LightMap& lightmap
 				pos.z = -world_coord(i) + (playerPos.p.z % TILE_HEIGHT);
 				pos.y = 0;
 
-				if (tileOnMap(worldMapState, playerXTile + j, playerZTile + i))
+				if (tileOnMap(gameWorld.map, playerXTile + j, playerZTile + i))
 				{
-					pos.y = map_TileHeightSurface(worldMapState, playerXTile + j, playerZTile + i);
+					pos.y = map_TileHeightSurface(gameWorld.map, playerXTile + j, playerZTile + i);
 					auto color = pal_SetBrightness(0);
 					lightmap(playerXTile + j, playerZTile + i) = color;
 				}
@@ -2022,7 +2023,7 @@ static void displayStaticObjects(const glm::mat4 &viewMatrix, const glm::mat4 &p
 	for (unsigned aPlayer = 0; aPlayer < MAX_PLAYERS; ++aPlayer)
 	{
 		/* Now go all buildings for that player */
-		for (BASE_OBJECT* obj : worldObjectState.structures[aPlayer])
+		for (BASE_OBJECT* obj : gameWorld.objects.structures[aPlayer])
 		{
 			/* Worth rendering the structure? */
 			if (obj->type != OBJ_STRUCTURE || (obj->died != 0 && obj->died < graphicsTime)
@@ -2094,7 +2095,7 @@ static void drawLineBuild(uint8_t player, STRUCTURE_STATS const *psStats, Vector
 	for (int i = 0; i < lb.count; ++i)
 	{
 		Vector2i cur = lb[i];
-		if (tileHasIncompatibleStructure(worldTile(worldMapState, cur), psStats, 0))
+		if (tileHasIncompatibleStructure(worldTile(gameWorld.map, cur), psStats, 0))
 		{
 			continue;  // construction has started
 		}
@@ -2104,7 +2105,7 @@ static void drawLineBuild(uint8_t player, STRUCTURE_STATS const *psStats, Vector
 		for (int j = 0; j <= b.size.y; ++j)
 			for (int k = 0; k <= b.size.x; ++k)
 			{
-				z = std::max(z, map_TileHeight(worldMapState, b.map.x + k, b.map.y + j));
+				z = std::max(z, map_TileHeight(gameWorld.map, b.map.x + k, b.map.y + j));
 			}
 		Blueprint blueprint(psStats, Vector3i(cur, z), snapDirection(direction), 0, state, player); // snapDirection may be unnecessary here
 		blueprints.push_back(blueprint);
@@ -2140,14 +2141,14 @@ static void renderBuildOrder(uint8_t droidPlayer, DroidOrder const &order, STRUC
 	{
 		drawLineBuild(droidPlayer, stats, pos, order.pos2, order.direction, state);
 	}
-	if ((order.type == DORDER_BUILD || order.type == DORDER_BUILDMODULE) && !tileHasIncompatibleStructure(mapTile(worldMapState, map_coord(pos)), stats, order.index))
+	if ((order.type == DORDER_BUILD || order.type == DORDER_BUILDMODULE) && !tileHasIncompatibleStructure(mapTile(gameWorld.map, map_coord(pos)), stats, order.index))
 	{
 		StructureBounds b = getStructureBounds(stats, pos, order.direction);
 		int z = 0;
 		for (int j = 0; j <= b.size.y; ++j)
 			for (int i = 0; i <= b.size.x; ++i)
 			{
-				z = std::max(z, map_TileHeight(worldMapState, b.map.x + i, b.map.y + j));
+				z = std::max(z, map_TileHeight(gameWorld.map, b.map.x + i, b.map.y + j));
 			}
 		Blueprint blueprint(stats, Vector3i(pos, z), snapDirection(order.direction), order.index, state, droidPlayer);
 		blueprints.push_back(blueprint);
@@ -2165,8 +2166,8 @@ void displayBlueprints(const glm::mat4 &viewMatrix, const glm::mat4 &perspective
 	blueprints.clear();  // Delete old blueprints and draw new ones.
 
 	if ((buildState == BUILD3D_VALID || buildState == BUILD3D_POS) &&
-	    sBuildDetails.x > 0 && sBuildDetails.x < (int)worldMapState.width &&
-	    sBuildDetails.y > 0 && sBuildDetails.y < (int)worldMapState.height)
+	    sBuildDetails.x > 0 && sBuildDetails.x < (int)gameWorld.map.width &&
+	    sBuildDetails.y > 0 && sBuildDetails.y < (int)gameWorld.map.height)
 	{
 		STRUCT_STATES state;
 		if (buildState == BUILD3D_VALID)
@@ -2208,7 +2209,7 @@ void displayBlueprints(const glm::mat4 &viewMatrix, const glm::mat4 &perspective
 				for (int j = 0; j <= b.size.y; ++j)
 					for (int i = 0; i <= b.size.x; ++i)
 					{
-						z = std::max(z, map_TileHeight(worldMapState, b.map.x + i, b.map.y + j));
+						z = std::max(z, map_TileHeight(gameWorld.map, b.map.x + i, b.map.y + j));
 					}
 
 				if(!playerBlueprintX->isTracking()){
@@ -2254,7 +2255,7 @@ void displayBlueprints(const glm::mat4 &viewMatrix, const glm::mat4 &perspective
 			continue;
 		}
 		STRUCT_STATES state = player == selectedPlayer ? SS_BLUEPRINT_PLANNED : SS_BLUEPRINT_PLANNED_BY_ALLY;
-		for (const DROID *psDroid : worldObjectState.droids[player])
+		for (const DROID *psDroid : gameWorld.objects.droids[player])
 		{
 			if (psDroid->droidType == DROID_CONSTRUCT || psDroid->droidType == DROID_CYBORG_CONSTRUCT)
 			{
@@ -2286,7 +2287,7 @@ static void displayDelivPoints(const glm::mat4& viewMatrix, const glm::mat4 &per
 {
 	WZ_PROFILE_SCOPE(displayDelivPoints);
 	if (selectedPlayer >= MAX_PLAYERS) { return; /* no-op */ }
-	for (const auto& psDelivPoint : worldObjectState.flags[selectedPlayer])
+	for (const auto& psDelivPoint : gameWorld.objects.flags[selectedPlayer])
 	{
 		if (clipXY(psDelivPoint->coords.x, psDelivPoint->coords.y))
 		{
@@ -2328,7 +2329,7 @@ static void displayFeatures(const glm::mat4 &viewMatrix, const glm::mat4 &perspe
 	// player can only be 0 for the features.
 
 	/* Go through all the features */
-	for (BASE_OBJECT* obj : worldObjectState.features[0])
+	for (BASE_OBJECT* obj : gameWorld.objects.features[0])
 	{
 		if (obj->type == OBJ_FEATURE
 			&& (obj->died == 0 || obj->died > graphicsTime)
@@ -2407,7 +2408,7 @@ static void displayDynamicObjects(const glm::mat4 &viewMatrix, const glm::mat4 &
 	/* Need to go through all the droid lists */
 	for (unsigned player = 0; player < MAX_PLAYERS; ++player)
 	{
-		for (DROID* psDroid : worldObjectState.droids[player])
+		for (DROID* psDroid : gameWorld.objects.droids[player])
 		{
 			if (!psDroid || (psDroid->died != 0 && psDroid->died < graphicsTime)
 			    || !quickClipXYToMaximumTilesFromCurrentPosition(psDroid->pos.x, psDroid->pos.y))
@@ -2470,7 +2471,7 @@ Vector2i getPlayerPos()
 /// Set the player position
 void setPlayerPos(SDWORD x, SDWORD y)
 {
-	ASSERT(x >= 0 && x < world_coord(worldMapState.width) && y >= 0 && y < world_coord(worldMapState.height), "Position off map");
+	ASSERT(x >= 0 && x < world_coord(gameWorld.map.width) && y >= 0 && y < world_coord(gameWorld.map.height), "Position off map");
 	playerPos.p.x = x;
 	playerPos.p.z = y;
 	playerPos.r.z = 0;
@@ -2511,7 +2512,7 @@ void	renderFeature(FEATURE *psFeature, const glm::mat4 &viewMatrix, const glm::m
 	psFeature->sDisplay.frameNumber = currentGameFrame;
 
 	/* Daft hack to get around the oil derrick issue */
-	if (!TileHasFeature(mapTile(worldMapState, map_coord(psFeature->pos.xy()))))
+	if (!TileHasFeature(mapTile(gameWorld.map, map_coord(psFeature->pos.xy()))))
 	{
 		return;
 	}
@@ -2542,7 +2543,7 @@ void	renderFeature(FEATURE *psFeature, const glm::mat4 &viewMatrix, const glm::m
 	{
 		brightness = pal_SetBrightness(avGetObjLightLevel((BASE_OBJECT *)psFeature, brightness.byte.r));
 	}
-	if (!hasSensorOnTile(mapTile(worldMapState, map_coord(psFeature->pos.x), map_coord(psFeature->pos.y)), selectedPlayer))
+	if (!hasSensorOnTile(mapTile(gameWorld.map, map_coord(psFeature->pos.x), map_coord(psFeature->pos.y)), selectedPlayer))
 	{
 		brightness.byte.r /= 2;
 		brightness.byte.g /= 2;
@@ -2612,7 +2613,7 @@ void renderProximityMsg(PROXIMITY_DISPLAY *psProxDisp, const glm::mat4& viewMatr
 			/* in case of a beacon message put above objects */
 			if (psProxDisp->psMessage->pViewData->type == VIEW_BEACON)
 			{
-				if (TileIsOccupied(mapTile(worldMapState, msgX / TILE_UNITS, msgY / TILE_UNITS)))
+				if (TileIsOccupied(mapTile(gameWorld.map, msgX / TILE_UNITS, msgY / TILE_UNITS)))
 				{
 					dv.y = pViewProximity->z + 150;
 				}
@@ -2914,7 +2915,7 @@ void renderStructure(STRUCTURE *psStructure, const glm::mat4 &viewMatrix, const 
 	bool defensive = false;
 	const FACTION *faction = getPlayerFaction(psStructure->player);
 	const iIMDShape *strImd = getFactionDisplayIMD(faction, psStructure->sDisplay.imd->displayModel());
-	MAPTILE *psTile = worldTile(worldMapState, psStructure->pos.x, psStructure->pos.y);
+	MAPTILE *psTile = worldTile(gameWorld.map, psStructure->pos.x, psStructure->pos.y);
 
 	glm::mat4 modelMatrix = glm::translate(glm::vec3(dv)) * glm::rotate(UNDEG(-psStructure->rot.direction), glm::vec3(0.f, 1.f, 0.f));
 
@@ -3105,7 +3106,7 @@ static bool renderWallSection(STRUCTURE *psStructure, const glm::mat4 &viewMatri
 	PIELIGHT		brightness;
 	Vector3i			dv;
 	int				pieFlag, pieFlagData;
-	MAPTILE			*psTile = worldTile(worldMapState, psStructure->pos.x, psStructure->pos.y);
+	MAPTILE			*psTile = worldTile(gameWorld.map, psStructure->pos.x, psStructure->pos.y);
 	const FACTION *faction = getPlayerFaction(psStructure->player);
 
 	if (!psStructure->visibleForLocalDisplay())
@@ -3693,7 +3694,7 @@ static void	drawDroidSelections()
 	for (int i = 0; i < MAX_PLAYERS; i++)
 	{
 		/* Go thru' all the droids */
-		for (const DROID *psDroid : worldObjectState.droids[i])
+		for (const DROID *psDroid : gameWorld.objects.droids[i])
 		{
 			if (showORDERS)
 			{
@@ -3711,7 +3712,7 @@ static void	drawDroidSelections()
 		}
 	}
 
-	for (const FEATURE *psFeature : worldObjectState.features[0])
+	for (const FEATURE *psFeature : gameWorld.objects.features[0])
 	{
 		if (!psFeature->died && psFeature->sDisplay.frameNumber == currentGameFrame)
 		{
@@ -4009,17 +4010,17 @@ void screenCoordToWorld(Vector2i screenCoord, Vector2i &worldCoord, SDWORD &tile
 					{
 						outMousePos.x = 0;
 					}
-					else if (outMousePos.x > world_coord(worldMapState.width - 1))
+					else if (outMousePos.x > world_coord(gameWorld.map.width - 1))
 					{
-						outMousePos.x = world_coord(worldMapState.width - 1);
+						outMousePos.x = world_coord(gameWorld.map.width - 1);
 					}
 					if (outMousePos.y < 0)
 					{
 						outMousePos.y = 0;
 					}
-					else if (outMousePos.y > world_coord(worldMapState.height - 1))
+					else if (outMousePos.y > world_coord(gameWorld.map.height - 1))
 					{
-						outMousePos.y = world_coord(worldMapState.height - 1);
+						outMousePos.y = world_coord(gameWorld.map.height - 1);
 					}
 					tileX = map_coord(outMousePos.x);
 					tileY = map_coord(outMousePos.y);
@@ -4234,7 +4235,7 @@ static void structureEffectsPlayer(UDWORD player)
 		return;  // Don't add effects this frame.
 	}
 
-	for (const STRUCTURE *psStructure : worldObjectState.structures[player])
+	for (const STRUCTURE *psStructure : gameWorld.objects.structures[player])
 	{
 		if (psStructure->status != SS_BUILT)
 		{
@@ -4279,7 +4280,7 @@ static void structureEffectsPlayer(UDWORD player)
 
 				pos.x = psStructure->pos.x + xDif;
 				pos.z = psStructure->pos.y + yDif;
-				pos.y = map_Height(worldMapState, pos.x, pos.z) + 64 + (i * 20);	// 64 up to get to base of spire
+				pos.y = map_Height(gameWorld.map, pos.x, pos.z) + 64 + (i * 20);	// 64 up to get to base of spire
 				effectGiveAuxVar(50);	// half normal plasma size...
 				addEffect(&pos, EFFECT_EXPLOSION, EXPLOSION_TYPE_LASER, false, nullptr, 0);
 
@@ -4311,7 +4312,7 @@ static void structureEffectsPlayer(UDWORD player)
 				yDif = iCosSR(effectTime, 720, radius);
 				pos.x = psStructure->pos.x + xDif;
 				pos.z = psStructure->pos.y + yDif;
-				pos.y = map_Height(worldMapState, pos.x, pos.z) + pDisplayModel->max.y;
+				pos.y = map_Height(gameWorld.map, pos.x, pos.z) + pDisplayModel->max.y;
 				effectGiveAuxVar(30 + bFXSize);	// half normal plasma size...
 				addEffect(&pos, EFFECT_EXPLOSION, EXPLOSION_TYPE_LASER, false, nullptr, 0);
 				pos.x = psStructure->pos.x - xDif;
@@ -4328,7 +4329,7 @@ static void structureEffects()
 {
 	for (unsigned i = 0; i < MAX_PLAYERS; i++)
 	{
-		if (!worldObjectState.structures[i].empty())
+		if (!gameWorld.objects.structures[i].empty())
 		{
 			structureEffectsPlayer(i);
 		}
@@ -4345,7 +4346,7 @@ static void	showDroidSensorRanges()
 	if (rangeOnScreen
 		&& (graphicsTime - lastRangeUpdateTime) >= 50)		// note, we still have to decide what to do with multiple units selected, since it will draw it for all of them! -Q 5-10-05
 	{
-		for (DROID* psDroid : worldObjectState.droids[selectedPlayer])
+		for (DROID* psDroid : gameWorld.objects.droids[selectedPlayer])
 		{
 			if (psDroid->selected)
 			{
@@ -4353,7 +4354,7 @@ static void	showDroidSensorRanges()
 			}
 		}
 
-		for (STRUCTURE* psStruct : worldObjectState.structures[selectedPlayer])
+		for (STRUCTURE* psStruct : gameWorld.objects.structures[selectedPlayer])
 		{
 			if (psStruct->selected)
 			{
@@ -4375,9 +4376,9 @@ static void showEffectCircle(Position centre, int32_t radius, uint32_t auxVar, E
 		pos.z = centre.y - iCosSR(i, circumference, radius);  // [sic] y -> z
 
 		// Check if it's actually on map
-		if (worldOnMap(worldMapState, pos.x, pos.z))
+		if (worldOnMap(gameWorld.map, pos.x, pos.z))
 		{
-			pos.y = map_Height(worldMapState, pos.x, pos.z) + 16;
+			pos.y = map_Height(gameWorld.map, pos.x, pos.z) + 16;
 			effectGiveAuxVar(auxVar);
 			addEffect(&pos, group, type, false, nullptr, 0);
 		}
@@ -4525,7 +4526,7 @@ static void doConstructionLines(const glm::mat4 &viewMatrix)
 	WZ_PROFILE_SCOPE(doConstructionLines);
 	for (unsigned i = 0; i < MAX_PLAYERS; i++)
 	{
-		for (DROID *psDroid : worldObjectState.droids[i])
+		for (DROID *psDroid : gameWorld.objects.droids[i])
 		{
 			if (clipXY(psDroid->pos.x, psDroid->pos.y)
 			    && psDroid->visibleForLocalDisplay() == UBYTE_MAX

--- a/src/display3d.cpp
+++ b/src/display3d.cpp
@@ -783,7 +783,7 @@ static PIELIGHT structureBrightness(STRUCTURE *psStructure)
 		{
 			buildingBrightness = pal_SetBrightness(avGetObjLightLevel((BASE_OBJECT *)psStructure, buildingBrightness.byte.r));
 		}
-		if (!hasSensorOnTile(mapTile(map_coord(psStructure->pos.x), map_coord(psStructure->pos.y)), selectedPlayer))
+		if (!hasSensorOnTile(mapTile(worldMapState, map_coord(psStructure->pos.x), map_coord(psStructure->pos.y)), selectedPlayer))
 		{
 			buildingBrightness.byte.r /= 2;
 			buildingBrightness.byte.g /= 2;
@@ -816,10 +816,10 @@ static void showDroidPaths()
 			{
 				Vector3i pos;
 
-				ASSERT(worldOnMap(psDroid->sMove.asPath[i].x, psDroid->sMove.asPath[i].y), "Path off map!");
+				ASSERT(worldOnMap(worldMapState, psDroid->sMove.asPath[i].x, psDroid->sMove.asPath[i].y), "Path off map!");
 				pos.x = psDroid->sMove.asPath[i].x;
 				pos.z = psDroid->sMove.asPath[i].y;
-				pos.y = map_Height(pos.x, pos.z) + 16;
+				pos.y = map_Height(worldMapState, pos.x, pos.z) + 16;
 
 				effectGiveAuxVar(80);
 				addEffect(&pos, EFFECT_EXPLOSION, EXPLOSION_TYPE_LASER, false, nullptr, 0);
@@ -1239,10 +1239,10 @@ static int calcAverageTerrainHeight(int tileX, int tileZ)
 	{
 		for (int j = -4; j <= 4; j++)
 		{
-			if (tileOnMap(tileX + j, tileZ + i))
+			if (tileOnMap(worldMapState, tileX + j, tileZ + i))
 			{
 				/* Get a pointer to the tile at this location */
-				MAPTILE *psTile = mapTile(tileX + j, tileZ + i);
+				MAPTILE *psTile = mapTile(worldMapState, tileX + j, tileZ + i);
 
 				result += std::max(psTile->height, psTile->waterLevel);
 				numTilesAveraged++;
@@ -1258,7 +1258,7 @@ static int calcAverageTerrainHeight(int tileX, int tileZ)
 	 * Work out the average height.
 	 * We use this information to keep the player camera above the terrain.
 	 */
-	MAPTILE *psTile = mapTile(tileX, tileZ);
+	MAPTILE *psTile = mapTile(worldMapState, tileX, tileZ);
 
 	result /= numTilesAveraged;
 	if (result < psTile->height)
@@ -1395,9 +1395,9 @@ static void drawTiles(iView *player, LightingData& lightData, LightMap& lightmap
 				pos.z = -world_coord(i) + (playerPos.p.z % TILE_HEIGHT);
 				pos.y = 0;
 
-				if (tileOnMap(playerXTile + j, playerZTile + i))
+				if (tileOnMap(worldMapState, playerXTile + j, playerZTile + i))
 				{
-					pos.y = map_TileHeightSurface(playerXTile + j, playerZTile + i);
+					pos.y = map_TileHeightSurface(worldMapState, playerXTile + j, playerZTile + i);
 					auto color = pal_SetBrightness(0);
 					lightmap(playerXTile + j, playerZTile + i) = color;
 				}
@@ -2094,7 +2094,7 @@ static void drawLineBuild(uint8_t player, STRUCTURE_STATS const *psStats, Vector
 	for (int i = 0; i < lb.count; ++i)
 	{
 		Vector2i cur = lb[i];
-		if (tileHasIncompatibleStructure(worldTile(cur), psStats, 0))
+		if (tileHasIncompatibleStructure(worldTile(worldMapState, cur), psStats, 0))
 		{
 			continue;  // construction has started
 		}
@@ -2104,7 +2104,7 @@ static void drawLineBuild(uint8_t player, STRUCTURE_STATS const *psStats, Vector
 		for (int j = 0; j <= b.size.y; ++j)
 			for (int k = 0; k <= b.size.x; ++k)
 			{
-				z = std::max(z, map_TileHeight(b.map.x + k, b.map.y + j));
+				z = std::max(z, map_TileHeight(worldMapState, b.map.x + k, b.map.y + j));
 			}
 		Blueprint blueprint(psStats, Vector3i(cur, z), snapDirection(direction), 0, state, player); // snapDirection may be unnecessary here
 		blueprints.push_back(blueprint);
@@ -2140,14 +2140,14 @@ static void renderBuildOrder(uint8_t droidPlayer, DroidOrder const &order, STRUC
 	{
 		drawLineBuild(droidPlayer, stats, pos, order.pos2, order.direction, state);
 	}
-	if ((order.type == DORDER_BUILD || order.type == DORDER_BUILDMODULE) && !tileHasIncompatibleStructure(mapTile(map_coord(pos)), stats, order.index))
+	if ((order.type == DORDER_BUILD || order.type == DORDER_BUILDMODULE) && !tileHasIncompatibleStructure(mapTile(worldMapState, map_coord(pos)), stats, order.index))
 	{
 		StructureBounds b = getStructureBounds(stats, pos, order.direction);
 		int z = 0;
 		for (int j = 0; j <= b.size.y; ++j)
 			for (int i = 0; i <= b.size.x; ++i)
 			{
-				z = std::max(z, map_TileHeight(b.map.x + i, b.map.y + j));
+				z = std::max(z, map_TileHeight(worldMapState, b.map.x + i, b.map.y + j));
 			}
 		Blueprint blueprint(stats, Vector3i(pos, z), snapDirection(order.direction), order.index, state, droidPlayer);
 		blueprints.push_back(blueprint);
@@ -2208,7 +2208,7 @@ void displayBlueprints(const glm::mat4 &viewMatrix, const glm::mat4 &perspective
 				for (int j = 0; j <= b.size.y; ++j)
 					for (int i = 0; i <= b.size.x; ++i)
 					{
-						z = std::max(z, map_TileHeight(b.map.x + i, b.map.y + j));
+						z = std::max(z, map_TileHeight(worldMapState, b.map.x + i, b.map.y + j));
 					}
 
 				if(!playerBlueprintX->isTracking()){
@@ -2511,7 +2511,7 @@ void	renderFeature(FEATURE *psFeature, const glm::mat4 &viewMatrix, const glm::m
 	psFeature->sDisplay.frameNumber = currentGameFrame;
 
 	/* Daft hack to get around the oil derrick issue */
-	if (!TileHasFeature(mapTile(map_coord(psFeature->pos.xy()))))
+	if (!TileHasFeature(mapTile(worldMapState, map_coord(psFeature->pos.xy()))))
 	{
 		return;
 	}
@@ -2542,7 +2542,7 @@ void	renderFeature(FEATURE *psFeature, const glm::mat4 &viewMatrix, const glm::m
 	{
 		brightness = pal_SetBrightness(avGetObjLightLevel((BASE_OBJECT *)psFeature, brightness.byte.r));
 	}
-	if (!hasSensorOnTile(mapTile(map_coord(psFeature->pos.x), map_coord(psFeature->pos.y)), selectedPlayer))
+	if (!hasSensorOnTile(mapTile(worldMapState, map_coord(psFeature->pos.x), map_coord(psFeature->pos.y)), selectedPlayer))
 	{
 		brightness.byte.r /= 2;
 		brightness.byte.g /= 2;
@@ -2612,7 +2612,7 @@ void renderProximityMsg(PROXIMITY_DISPLAY *psProxDisp, const glm::mat4& viewMatr
 			/* in case of a beacon message put above objects */
 			if (psProxDisp->psMessage->pViewData->type == VIEW_BEACON)
 			{
-				if (TileIsOccupied(mapTile(msgX / TILE_UNITS, msgY / TILE_UNITS)))
+				if (TileIsOccupied(mapTile(worldMapState, msgX / TILE_UNITS, msgY / TILE_UNITS)))
 				{
 					dv.y = pViewProximity->z + 150;
 				}
@@ -2914,7 +2914,7 @@ void renderStructure(STRUCTURE *psStructure, const glm::mat4 &viewMatrix, const 
 	bool defensive = false;
 	const FACTION *faction = getPlayerFaction(psStructure->player);
 	const iIMDShape *strImd = getFactionDisplayIMD(faction, psStructure->sDisplay.imd->displayModel());
-	MAPTILE *psTile = worldTile(psStructure->pos.x, psStructure->pos.y);
+	MAPTILE *psTile = worldTile(worldMapState, psStructure->pos.x, psStructure->pos.y);
 
 	glm::mat4 modelMatrix = glm::translate(glm::vec3(dv)) * glm::rotate(UNDEG(-psStructure->rot.direction), glm::vec3(0.f, 1.f, 0.f));
 
@@ -3105,7 +3105,7 @@ static bool renderWallSection(STRUCTURE *psStructure, const glm::mat4 &viewMatri
 	PIELIGHT		brightness;
 	Vector3i			dv;
 	int				pieFlag, pieFlagData;
-	MAPTILE			*psTile = worldTile(psStructure->pos.x, psStructure->pos.y);
+	MAPTILE			*psTile = worldTile(worldMapState, psStructure->pos.x, psStructure->pos.y);
 	const FACTION *faction = getPlayerFaction(psStructure->player);
 
 	if (!psStructure->visibleForLocalDisplay())
@@ -4279,7 +4279,7 @@ static void structureEffectsPlayer(UDWORD player)
 
 				pos.x = psStructure->pos.x + xDif;
 				pos.z = psStructure->pos.y + yDif;
-				pos.y = map_Height(pos.x, pos.z) + 64 + (i * 20);	// 64 up to get to base of spire
+				pos.y = map_Height(worldMapState, pos.x, pos.z) + 64 + (i * 20);	// 64 up to get to base of spire
 				effectGiveAuxVar(50);	// half normal plasma size...
 				addEffect(&pos, EFFECT_EXPLOSION, EXPLOSION_TYPE_LASER, false, nullptr, 0);
 
@@ -4311,7 +4311,7 @@ static void structureEffectsPlayer(UDWORD player)
 				yDif = iCosSR(effectTime, 720, radius);
 				pos.x = psStructure->pos.x + xDif;
 				pos.z = psStructure->pos.y + yDif;
-				pos.y = map_Height(pos.x, pos.z) + pDisplayModel->max.y;
+				pos.y = map_Height(worldMapState, pos.x, pos.z) + pDisplayModel->max.y;
 				effectGiveAuxVar(30 + bFXSize);	// half normal plasma size...
 				addEffect(&pos, EFFECT_EXPLOSION, EXPLOSION_TYPE_LASER, false, nullptr, 0);
 				pos.x = psStructure->pos.x - xDif;
@@ -4375,9 +4375,9 @@ static void showEffectCircle(Position centre, int32_t radius, uint32_t auxVar, E
 		pos.z = centre.y - iCosSR(i, circumference, radius);  // [sic] y -> z
 
 		// Check if it's actually on map
-		if (worldOnMap(pos.x, pos.z))
+		if (worldOnMap(worldMapState, pos.x, pos.z))
 		{
-			pos.y = map_Height(pos.x, pos.z) + 16;
+			pos.y = map_Height(worldMapState, pos.x, pos.z) + 16;
 			effectGiveAuxVar(auxVar);
 			addEffect(&pos, group, type, false, nullptr, 0);
 		}

--- a/src/display3d.cpp
+++ b/src/display3d.cpp
@@ -2165,8 +2165,8 @@ void displayBlueprints(const glm::mat4 &viewMatrix, const glm::mat4 &perspective
 	blueprints.clear();  // Delete old blueprints and draw new ones.
 
 	if ((buildState == BUILD3D_VALID || buildState == BUILD3D_POS) &&
-	    sBuildDetails.x > 0 && sBuildDetails.x < (int)mapWidth &&
-	    sBuildDetails.y > 0 && sBuildDetails.y < (int)mapHeight)
+	    sBuildDetails.x > 0 && sBuildDetails.x < (int)worldMapState.width &&
+	    sBuildDetails.y > 0 && sBuildDetails.y < (int)worldMapState.height)
 	{
 		STRUCT_STATES state;
 		if (buildState == BUILD3D_VALID)
@@ -2470,7 +2470,7 @@ Vector2i getPlayerPos()
 /// Set the player position
 void setPlayerPos(SDWORD x, SDWORD y)
 {
-	ASSERT(x >= 0 && x < world_coord(mapWidth) && y >= 0 && y < world_coord(mapHeight), "Position off map");
+	ASSERT(x >= 0 && x < world_coord(worldMapState.width) && y >= 0 && y < world_coord(worldMapState.height), "Position off map");
 	playerPos.p.x = x;
 	playerPos.p.z = y;
 	playerPos.r.z = 0;
@@ -4009,17 +4009,17 @@ void screenCoordToWorld(Vector2i screenCoord, Vector2i &worldCoord, SDWORD &tile
 					{
 						outMousePos.x = 0;
 					}
-					else if (outMousePos.x > world_coord(mapWidth - 1))
+					else if (outMousePos.x > world_coord(worldMapState.width - 1))
 					{
-						outMousePos.x = world_coord(mapWidth - 1);
+						outMousePos.x = world_coord(worldMapState.width - 1);
 					}
 					if (outMousePos.y < 0)
 					{
 						outMousePos.y = 0;
 					}
-					else if (outMousePos.y > world_coord(mapHeight - 1))
+					else if (outMousePos.y > world_coord(worldMapState.height - 1))
 					{
-						outMousePos.y = world_coord(mapHeight - 1);
+						outMousePos.y = world_coord(worldMapState.height - 1);
 					}
 					tileX = map_coord(outMousePos.x);
 					tileY = map_coord(outMousePos.y);

--- a/src/display3d.cpp
+++ b/src/display3d.cpp
@@ -412,7 +412,7 @@ public:
 		bool bDrawAll = barMode == BAR_DROIDS || barMode == BAR_DROIDS_AND_STRUCTURES;
 
 		// first, for all droids, queue the various rects
-		for (DROID *psDroid : apsDroidLists[player])
+		for (DROID *psDroid : worldObjectState.droids[player])
 		{
 			if (psDroid->sDisplay.frameNumber == currentGameFrame)
 			{
@@ -453,7 +453,7 @@ public:
 	void addStructureSelectionsToRender(uint32_t player, BASE_OBJECT *psClickedOn, bool bMouseOverOwnStructure)
 	{
 		/* Go thru' all the buildings */
-		for (STRUCTURE *psStruct : apsStructLists[player])
+		for (STRUCTURE *psStruct : worldObjectState.structures[player])
 		{
 			if (psStruct->sDisplay.frameNumber == currentGameFrame)
 			{
@@ -534,7 +534,7 @@ public:
 			SDWORD scrX, scrY;
 			for (uint32_t i = 0; i < MAX_PLAYERS; i++)
 			{
-				for (const STRUCTURE* psStruct : apsStructLists[i])
+				for (const STRUCTURE* psStruct : worldObjectState.structures[i])
 				{
 					/* If it's targetted and on-screen */
 					if (psStruct->flags.test(OBJECT_FLAG_TARGETED)
@@ -807,7 +807,7 @@ static void showDroidPaths()
 		return; // no-op for now
 	}
 
-	for (const DROID *psDroid : apsDroidLists[selectedPlayer])
+	for (const DROID *psDroid : worldObjectState.droids[selectedPlayer])
 	{
 		if (psDroid->selected && psDroid->sMove.Status != MOVEINACTIVE)
 		{
@@ -1118,7 +1118,7 @@ void draw3DScene()
 	{
 		int visibleDroids = 0;
 		int undrawnDroids = 0;
-		for (const DROID *psDroid : apsDroidLists[selectedPlayer])
+		for (const DROID *psDroid : worldObjectState.droids[selectedPlayer])
 		{
 			if (psDroid->sDisplay.frameNumber != currentGameFrame)
 			{
@@ -2022,7 +2022,7 @@ static void displayStaticObjects(const glm::mat4 &viewMatrix, const glm::mat4 &p
 	for (unsigned aPlayer = 0; aPlayer < MAX_PLAYERS; ++aPlayer)
 	{
 		/* Now go all buildings for that player */
-		for (BASE_OBJECT* obj : apsStructLists[aPlayer])
+		for (BASE_OBJECT* obj : worldObjectState.structures[aPlayer])
 		{
 			/* Worth rendering the structure? */
 			if (obj->type != OBJ_STRUCTURE || (obj->died != 0 && obj->died < graphicsTime)
@@ -2254,7 +2254,7 @@ void displayBlueprints(const glm::mat4 &viewMatrix, const glm::mat4 &perspective
 			continue;
 		}
 		STRUCT_STATES state = player == selectedPlayer ? SS_BLUEPRINT_PLANNED : SS_BLUEPRINT_PLANNED_BY_ALLY;
-		for (const DROID *psDroid : apsDroidLists[player])
+		for (const DROID *psDroid : worldObjectState.droids[player])
 		{
 			if (psDroid->droidType == DROID_CONSTRUCT || psDroid->droidType == DROID_CYBORG_CONSTRUCT)
 			{
@@ -2286,7 +2286,7 @@ static void displayDelivPoints(const glm::mat4& viewMatrix, const glm::mat4 &per
 {
 	WZ_PROFILE_SCOPE(displayDelivPoints);
 	if (selectedPlayer >= MAX_PLAYERS) { return; /* no-op */ }
-	for (const auto& psDelivPoint : apsFlagPosLists[selectedPlayer])
+	for (const auto& psDelivPoint : worldObjectState.flags[selectedPlayer])
 	{
 		if (clipXY(psDelivPoint->coords.x, psDelivPoint->coords.y))
 		{
@@ -2328,7 +2328,7 @@ static void displayFeatures(const glm::mat4 &viewMatrix, const glm::mat4 &perspe
 	// player can only be 0 for the features.
 
 	/* Go through all the features */
-	for (BASE_OBJECT* obj : apsFeatureList[0])
+	for (BASE_OBJECT* obj : worldObjectState.features[0])
 	{
 		if (obj->type == OBJ_FEATURE
 			&& (obj->died == 0 || obj->died > graphicsTime)
@@ -2407,7 +2407,7 @@ static void displayDynamicObjects(const glm::mat4 &viewMatrix, const glm::mat4 &
 	/* Need to go through all the droid lists */
 	for (unsigned player = 0; player < MAX_PLAYERS; ++player)
 	{
-		for (DROID* psDroid : apsDroidLists[player])
+		for (DROID* psDroid : worldObjectState.droids[player])
 		{
 			if (!psDroid || (psDroid->died != 0 && psDroid->died < graphicsTime)
 			    || !quickClipXYToMaximumTilesFromCurrentPosition(psDroid->pos.x, psDroid->pos.y))
@@ -3693,7 +3693,7 @@ static void	drawDroidSelections()
 	for (int i = 0; i < MAX_PLAYERS; i++)
 	{
 		/* Go thru' all the droids */
-		for (const DROID *psDroid : apsDroidLists[i])
+		for (const DROID *psDroid : worldObjectState.droids[i])
 		{
 			if (showORDERS)
 			{
@@ -3711,7 +3711,7 @@ static void	drawDroidSelections()
 		}
 	}
 
-	for (const FEATURE *psFeature : apsFeatureList[0])
+	for (const FEATURE *psFeature : worldObjectState.features[0])
 	{
 		if (!psFeature->died && psFeature->sDisplay.frameNumber == currentGameFrame)
 		{
@@ -4234,7 +4234,7 @@ static void structureEffectsPlayer(UDWORD player)
 		return;  // Don't add effects this frame.
 	}
 
-	for (const STRUCTURE *psStructure : apsStructLists[player])
+	for (const STRUCTURE *psStructure : worldObjectState.structures[player])
 	{
 		if (psStructure->status != SS_BUILT)
 		{
@@ -4328,7 +4328,7 @@ static void structureEffects()
 {
 	for (unsigned i = 0; i < MAX_PLAYERS; i++)
 	{
-		if (!apsStructLists[i].empty())
+		if (!worldObjectState.structures[i].empty())
 		{
 			structureEffectsPlayer(i);
 		}
@@ -4345,7 +4345,7 @@ static void	showDroidSensorRanges()
 	if (rangeOnScreen
 		&& (graphicsTime - lastRangeUpdateTime) >= 50)		// note, we still have to decide what to do with multiple units selected, since it will draw it for all of them! -Q 5-10-05
 	{
-		for (DROID* psDroid : apsDroidLists[selectedPlayer])
+		for (DROID* psDroid : worldObjectState.droids[selectedPlayer])
 		{
 			if (psDroid->selected)
 			{
@@ -4353,7 +4353,7 @@ static void	showDroidSensorRanges()
 			}
 		}
 
-		for (STRUCTURE* psStruct : apsStructLists[selectedPlayer])
+		for (STRUCTURE* psStruct : worldObjectState.structures[selectedPlayer])
 		{
 			if (psStruct->selected)
 			{
@@ -4525,7 +4525,7 @@ static void doConstructionLines(const glm::mat4 &viewMatrix)
 	WZ_PROFILE_SCOPE(doConstructionLines);
 	for (unsigned i = 0; i < MAX_PLAYERS; i++)
 	{
-		for (DROID *psDroid : apsDroidLists[i])
+		for (DROID *psDroid : worldObjectState.droids[i])
 		{
 			if (clipXY(psDroid->pos.x, psDroid->pos.y)
 			    && psDroid->visibleForLocalDisplay() == UBYTE_MAX

--- a/src/droid.cpp
+++ b/src/droid.cpp
@@ -1095,8 +1095,8 @@ static bool droidNextToStruct(DROID *psDroid, STRUCTURE *psStruct)
 	auto pos = map_coord(psDroid->pos);
 	int minX = std::max(pos.x - 1, 0);
 	int minY = std::max(pos.y - 1, 0);
-	int maxX = std::min(pos.x + 1, mapWidth);
-	int maxY = std::min(pos.y + 1, mapHeight);
+	int maxX = std::min(pos.x + 1, worldMapState.width);
+	int maxY = std::min(pos.y + 1, worldMapState.height);
 	for (int y = minY; y <= maxY; ++y)
 	{
 		for (int x = minX; x <= maxX; ++x)
@@ -2687,11 +2687,11 @@ static bool oneDroidMax(UDWORD x, UDWORD y)
 static bool sensiblePlace(SDWORD x, SDWORD y, PROPULSION_TYPE propulsion)
 {
 	// not too near the edges.
-	if ((x < TOO_NEAR_EDGE) || (x > (SDWORD)(mapWidth - TOO_NEAR_EDGE)))
+	if ((x < TOO_NEAR_EDGE) || (x > (SDWORD)(worldMapState.width - TOO_NEAR_EDGE)))
 	{
 		return false;
 	}
-	if ((y < TOO_NEAR_EDGE) || (y > (SDWORD)(mapHeight - TOO_NEAR_EDGE)))
+	if ((y < TOO_NEAR_EDGE) || (y > (SDWORD)(worldMapState.height - TOO_NEAR_EDGE)))
 	{
 		return false;
 	}
@@ -2812,8 +2812,8 @@ bool	pickATileGenThreat(UDWORD *x, UDWORD *y, UBYTE numIterations, SDWORD threat
 	UDWORD		passes;
 	Vector3i	origin(world_coord(*x), world_coord(*y), 0);
 
-	ASSERT_OR_RETURN(false, *x < mapWidth, "x coordinate is off-map for pickATileGen");
-	ASSERT_OR_RETURN(false, *y < mapHeight, "y coordinate is off-map for pickATileGen");
+	ASSERT_OR_RETURN(false, *x < worldMapState.width, "x coordinate is off-map for pickATileGen");
+	ASSERT_OR_RETURN(false, *y < worldMapState.height, "y coordinate is off-map for pickATileGen");
 
 	if (function(*x, *y) && ((threatRange <= 0) || (!ThreatInRange(player, threatRange, *x, *y, false))))	//TODO: vtol check really not needed?
 	{
@@ -3870,7 +3870,7 @@ bool droidOnMap(const DROID *psDroid)
 {
 	if (psDroid->died == NOT_CURRENT_LIST || psDroid->isTransporter()
 		|| psDroid->pos.x == INVALID_XY || psDroid->pos.y == INVALID_XY || missionIsOffworld()
-		|| mapHeight == 0)
+		|| worldMapState.height == 0)
 	{
 		// Off world or on a transport or is a transport or in mission list, or on a mission, or no map - ignore
 		return true;

--- a/src/droid.cpp
+++ b/src/droid.cpp
@@ -570,7 +570,7 @@ bool removeDroidBase(DROID *psDel)
 					return IterationResult::BREAK_ITERATION;
 				}
 				/* add droid to droid list then vanish it - hope this works! - GJ */
-				addDroid(psCurr, apsDroidLists);
+				addDroid(psCurr, worldObjectState.droids);
 				vanishDroid(psCurr);
 
 				return IterationResult::CONTINUE_ITERATION;
@@ -588,7 +588,7 @@ bool removeDroidBase(DROID *psDel)
 	/* Put Deliv. Pts back into world when a command droid dies */
 	if (psDel->droidType == DROID_COMMAND)
 	{
-		for (auto psStruct : apsStructLists[psDel->player])
+		for (auto psStruct : worldObjectState.structures[psDel->player])
 		{
 			// alexl's stab at a right answer.
 			if (psStruct && psStruct->isFactory()
@@ -606,7 +606,7 @@ bool removeDroidBase(DROID *psDel)
 		if (tryingToGetLocation())
 		{
 			int numSelectedConstructors = 0;
-			for (const DROID *psDroid : apsDroidLists[psDel->player])
+			for (const DROID *psDroid : worldObjectState.droids[psDel->player])
 			{
 				numSelectedConstructors += psDroid->selected && psDroid->isConstructionDroid();
 			}
@@ -758,7 +758,7 @@ static size_t droidCancelRepairers(DROID *psDroid, PerPlayerDroidLists& pList)
 		}
 
 		// search the main (current) list of active structures to see if any point to this
-		StructureList* pStructList = &apsStructLists[player];
+		StructureList* pStructList = &worldObjectState.structures[player];
 		for (STRUCTURE *psCurr : *pStructList)
 		{
 			if (psCurr->pStructureType->type == REF_REPAIR_FACILITY && psCurr->pFunctionality)
@@ -872,8 +872,8 @@ void droidUpdate(DROID *psDroid)
 	// Check that we are (still) in the sensor list
 	if (psDroid->droidType == DROID_SENSOR)
 	{
-		const auto sensor = std::find(apsSensorList[0].begin(), apsSensorList[0].end(), (BASE_OBJECT*)psDroid);
-		ASSERT(sensor != apsSensorList[0].end(), "%s(%p) not in sensor list!",
+		const auto sensor = std::find(worldObjectState.sensors[0].begin(), worldObjectState.sensors[0].end(), (BASE_OBJECT*)psDroid);
+		ASSERT(sensor != worldObjectState.sensors[0].end(), "%s(%p) not in sensor list!",
 			   droidGetName(psDroid), static_cast<void *>(psDroid));
 	}
 #endif
@@ -2081,7 +2081,7 @@ void assignObjectToGroup(UDWORD	playerNumber, UDWORD groupNumber, bool clearGrou
 	if (groupNumber < UBYTE_MAX)
 	{
 		/* Run through all the droids */
-		for (DROID* psDroid : apsDroidLists[playerNumber])
+		for (DROID* psDroid : worldObjectState.droids[playerNumber])
 		{
 			/* Clear out the old ones */
 			if (clearGroup && psDroid->group == groupNumber)
@@ -2104,7 +2104,7 @@ void assignObjectToGroup(UDWORD	playerNumber, UDWORD groupNumber, bool clearGrou
 	{
 		//clear the Deliv Point if one
 		ASSERT_OR_RETURN(, selectedPlayer < MAX_PLAYERS, "Unsupported selectedPlayer: %" PRIu32 "", selectedPlayer);
-		for (auto& psFlag : apsFlagPosLists[selectedPlayer])
+		for (auto& psFlag : worldObjectState.flags[selectedPlayer])
 		{
 			psFlag->selected = false;
 		}
@@ -2124,7 +2124,7 @@ void assignObjectToGroup(UDWORD	playerNumber, UDWORD groupNumber, bool clearGrou
 	{
 		/* If no droids were selected to be added to the group, check if a factory is selected */
 		/* Run through all the structures */
-		for (STRUCTURE *psStruct : apsStructLists[playerNumber])
+		for (STRUCTURE *psStruct : worldObjectState.structures[playerNumber])
 		{
 			if (psStruct->selected && psStruct->isFactory())
 			{
@@ -2150,7 +2150,7 @@ void removeObjectFromGroup(UDWORD playerNumber)
 
 	ASSERT_OR_RETURN(, playerNumber < MAX_PLAYERS, "Invalid player: %" PRIu32 "", playerNumber);
 
-	for (STRUCTURE *psStruct : apsStructLists[playerNumber])
+	for (STRUCTURE *psStruct : worldObjectState.structures[playerNumber])
 	{
 		if (psStruct->selected && psStruct->isFactory())
 		{
@@ -2159,7 +2159,7 @@ void removeObjectFromGroup(UDWORD playerNumber)
 		}
 	}
 
-	for (DROID* psDroid : apsDroidLists[playerNumber])
+	for (DROID* psDroid : worldObjectState.droids[playerNumber])
 	{
 		if (psDroid->selected)
 		{
@@ -2185,7 +2185,7 @@ bool activateGroupAndMove(UDWORD playerNumber, UDWORD groupNumber)
 
 	if (groupNumber < UBYTE_MAX)
 	{
-		for (DROID* psDroid : apsDroidLists[playerNumber])
+		for (DROID* psDroid : worldObjectState.droids[playerNumber])
 		{
 			/* Wipe out the ones in the wrong group */
 			if (psDroid->selected && psDroid->group != groupNumber)
@@ -2208,7 +2208,7 @@ bool activateGroupAndMove(UDWORD playerNumber, UDWORD groupNumber)
 			ASSERT(selectedPlayer < MAX_PLAYERS, "Unsupported selectedPlayer: %" PRIu32 "", selectedPlayer);
 			if (selectedPlayer < MAX_PLAYERS)
 			{
-				for (auto& psFlag : apsFlagPosLists[selectedPlayer])
+				for (auto& psFlag : worldObjectState.flags[selectedPlayer])
 				{
 					psFlag->selected = false;
 				}
@@ -2252,7 +2252,7 @@ bool activateNoGroup(UDWORD playerNumber, const SELECTIONTYPE selectionType, con
 	ASSERT_OR_RETURN(false, playerNumber < MAX_PLAYERS, "Invalid player: %" PRIu32 "", playerNumber);
 
 	selectionCount = selDroidSelection(selectedPlayer, dselectionClass, dselectionType, dbOnScreen);
-	for (DROID* psDroid : apsDroidLists[playerNumber])
+	for (DROID* psDroid : worldObjectState.droids[playerNumber])
 	{
 		/* Wipe out the ones in the wrong group */
 		if (psDroid->selected && psDroid->group != UBYTE_MAX)
@@ -2265,7 +2265,7 @@ bool activateNoGroup(UDWORD playerNumber, const SELECTIONTYPE selectionType, con
 	{
 		//clear the Deliv Point if one
 		ASSERT_OR_RETURN(false, selectedPlayer < MAX_PLAYERS, "Unsupported selectedPlayer: %" PRIu32 "", selectedPlayer);
-		for (auto& psFlag : apsFlagPosLists[selectedPlayer])
+		for (auto& psFlag : worldObjectState.flags[selectedPlayer])
 		{
 			psFlag->selected = false;
 		}
@@ -2284,7 +2284,7 @@ bool activateGroup(UDWORD playerNumber, UDWORD groupNumber)
 
 	if (groupNumber < UBYTE_MAX)
 	{
-		for (DROID* psDroid : apsDroidLists[playerNumber])
+		for (DROID* psDroid : worldObjectState.droids[playerNumber])
 		{
 			/* Wipe out the ones in the wrong group */
 			if (psDroid->selected && psDroid->group != groupNumber)
@@ -2305,7 +2305,7 @@ bool activateGroup(UDWORD playerNumber, UDWORD groupNumber)
 	{
 		//clear the Deliv Point if one
 		ASSERT_OR_RETURN(false, selectedPlayer < MAX_PLAYERS, "Unsupported selectedPlayer: %" PRIu32 "", selectedPlayer);
-		for (auto& psFlag : apsFlagPosLists[selectedPlayer])
+		for (auto& psFlag : worldObjectState.flags[selectedPlayer])
 		{
 			psFlag->selected = false;
 		}
@@ -2546,7 +2546,7 @@ UDWORD	getNumDroidsForLevel(uint32_t player, UDWORD level)
 		DroidList* dList = nullptr;
 		switch (idx)
 		{
-			case 0: dList = &apsDroidLists[selectedPlayer]; break;
+			case 0: dList = &worldObjectState.droids[selectedPlayer]; break;
 			case 1: if (prevMissionType == LEVEL_TYPE::LDS_MKEEP_LIMBO) { dList = &apsLimboDroids[selectedPlayer]; } break;
 			default: dList = nullptr;
 		}
@@ -2644,7 +2644,7 @@ bool noDroid(UDWORD x, UDWORD y)
 	// check each droid list
 	for (i = 0; i < MAX_PLAYERS; ++i)
 	{
-		for (const DROID* psDroid : apsDroidLists[i])
+		for (const DROID* psDroid : worldObjectState.droids[i])
 		{
 			if (map_coord(psDroid->pos.x) == x
 				&& map_coord(psDroid->pos.y) == y)
@@ -2665,7 +2665,7 @@ static bool oneDroidMax(UDWORD x, UDWORD y)
 	// check each droid list
 	for (i = 0; i < MAX_PLAYERS; i++)
 	{
-		for (const DROID* pD : apsDroidLists[i])
+		for (const DROID* pD : worldObjectState.droids[i])
 		{
 			if (map_coord(pD->pos.x) == x
 				&& map_coord(pD->pos.y) == y)
@@ -2746,7 +2746,7 @@ static bool ThreatInRange(SDWORD player, SDWORD range, SDWORD rangeX, SDWORD ran
 		}
 
 		//check structures
-		for (const STRUCTURE* psStruct : apsStructLists[i])
+		for (const STRUCTURE* psStruct : worldObjectState.structures[i])
 		{
 			if (psStruct->visible[player] || psStruct->born == 2)	// if can see it or started there
 			{
@@ -2776,7 +2776,7 @@ static bool ThreatInRange(SDWORD player, SDWORD range, SDWORD rangeX, SDWORD ran
 		}
 
 		//check droids
-		for (const DROID* psDroid : apsDroidLists[i])
+		for (const DROID* psDroid : worldObjectState.droids[i])
 		{
 			if (psDroid->visible[player])		//can see this droid?
 			{
@@ -2866,7 +2866,7 @@ PICKTILE pickHalfATile(UDWORD *x, UDWORD *y, UBYTE numIterations)
 building the specified structure - returns true if finds one*/
 bool checkDroidsBuilding(const STRUCTURE *psStructure)
 {
-	for (const DROID* psDroid : apsDroidLists[psStructure->player])
+	for (const DROID* psDroid : worldObjectState.droids[psStructure->player])
 	{
 		//check DORDER_BUILD, HELP_BUILD is handled the same
 		BASE_OBJECT *const psStruct = orderStateObj(psDroid, DORDER_BUILD);
@@ -2882,7 +2882,7 @@ bool checkDroidsBuilding(const STRUCTURE *psStructure)
 demolishing the specified structure - returns true if finds one*/
 bool checkDroidsDemolishing(const STRUCTURE *psStructure)
 {
-	for (const DROID* psDroid : apsDroidLists[psStructure->player])
+	for (const DROID* psDroid : worldObjectState.droids[psStructure->player])
 	{
 		//check DORDER_DEMOLISH
 		BASE_OBJECT *const psStruct = orderStateObj(psDroid, DORDER_DEMOLISH);
@@ -3259,7 +3259,7 @@ bool allVtolsRearmed(const DROID *psDroid)
 	}
 
 	bool stillRearming = false;
-	for (const DROID *psCurr : apsDroidLists[psDroid->player])
+	for (const DROID *psCurr : worldObjectState.droids[psDroid->player])
 	{
 		if (psCurr->isVtolRearming() &&
 			psCurr->order.type == psDroid->order.type &&
@@ -3543,7 +3543,7 @@ DROID *giftSingleDroid(DROID *psD, UDWORD to, bool electronic, Vector2i pos)
 		psNewDroid = reallyBuildDroid(&sTemplate, newPos, to, false, psD->rot);
 		ASSERT_OR_RETURN(nullptr, psNewDroid, "Unable to build unit");
 
-		addDroid(psNewDroid, apsDroidLists);
+		addDroid(psNewDroid, worldObjectState.droids);
 		adjustDroidCount(psNewDroid, 1);
 
 		psNewDroid->body = clip((psD->body*psNewDroid->originalBody + psD->originalBody/2)/std::max(psD->originalBody, 1u), 1u, psNewDroid->originalBody);
@@ -3568,7 +3568,7 @@ DROID *giftSingleDroid(DROID *psD, UDWORD to, bool electronic, Vector2i pos)
 	int oldPlayer = psD->player;
 
 	// reset the assigned state of units attached to a leader
-	for (DROID *psCurr : apsDroidLists[oldPlayer])
+	for (DROID *psCurr : worldObjectState.droids[oldPlayer])
 	{
 		BASE_OBJECT	*psLeader;
 
@@ -3595,11 +3595,11 @@ DROID *giftSingleDroid(DROID *psD, UDWORD to, bool electronic, Vector2i pos)
 	adjustDroidCount(psD, -1);
 	scriptRemoveObject(psD); //Remove droid from any script groups
 
-	if (droidRemove(psD, apsDroidLists))
+	if (droidRemove(psD, worldObjectState.droids))
 	{
 		psD->player	= to;
 
-		addDroid(psD, apsDroidLists);
+		addDroid(psD, worldObjectState.droids);
 		adjustDroidCount(psD, 1);
 
 		// the new player may have different default sensor/ecm/repair components
@@ -3642,7 +3642,7 @@ DROID *giftSingleDroid(DROID *psD, UDWORD to, bool electronic, Vector2i pos)
 			continue;
 		}
 
-		for (DROID *psCurr : apsDroidLists[i])
+		for (DROID *psCurr : worldObjectState.droids[i])
 		{
 			if (psCurr->order.psObj == psD || psCurr->psActionTarget[0] == psD)
 			{
@@ -3670,7 +3670,7 @@ DROID *giftSingleDroid(DROID *psD, UDWORD to, bool electronic, Vector2i pos)
 		}
 
 		// check through the players list, and our allies, of structures to see if any are targetting it
-		for (STRUCTURE *psStruct : apsStructLists[i])
+		for (STRUCTURE *psStruct : worldObjectState.structures[i])
 		{
 			if (psStruct->psTarget[0] == psD)
 			{
@@ -3783,7 +3783,7 @@ void SelectDroid(DROID *psDroid, bool programmaticSelection)
 void SelectGroupDroid(DROID *psGroupDroid)
 {
 	std::vector<DROID*> groupDroids;
-	for (DROID *psDroid : apsDroidLists[psGroupDroid->player])
+	for (DROID *psDroid : worldObjectState.droids[psGroupDroid->player])
 	{
 		// skip itself because psGroupDroid may already exist in apsDroidLists
 		if (psDroid == psGroupDroid)

--- a/src/droid.cpp
+++ b/src/droid.cpp
@@ -522,7 +522,7 @@ void recycleDroid(DROID *psDroid)
 
 	Vector3i position = psDroid->pos.xzy();
 	const auto mapCoord = map_coord({psDroid->pos.x, psDroid->pos.y});
-	const auto psTile = mapTile(mapCoord);
+	const auto psTile = mapTile(worldMapState, mapCoord);
 	if (tileIsClearlyVisible(psTile))
 	{
 		addEffect(&position, EFFECT_EXPLOSION, EXPLOSION_TYPE_DISCOVERY, false, nullptr, false, gameTime - deltaGameTime + 1);
@@ -693,7 +693,7 @@ bool destroyDroid(DROID *psDel, unsigned impactTime)
 		{
 			for (breadth = mapY - 1; breadth <= mapY + 1; breadth++)
 			{
-				psTile = mapTile(width, breadth);
+				psTile = mapTile(worldMapState, width, breadth);
 				if (TEST_TILE_VISIBLE_TO_SELECTEDPLAYER(psTile))
 				{
 					psTile->illumination /= 2;
@@ -1101,7 +1101,7 @@ static bool droidNextToStruct(DROID *psDroid, STRUCTURE *psStruct)
 	{
 		for (int x = minX; x <= maxX; ++x)
 		{
-			if (TileHasStructure(mapTile(x, y)) &&
+			if (TileHasStructure(mapTile(worldMapState, x, y)) &&
 				getTileStructure(x, y) == psStruct)
 			{
 				return true;
@@ -1169,7 +1169,7 @@ DroidStartBuild droidStartBuild(DROID *psDroid)
 			return DroidStartBuildFailed;
 		}
 		// Can't build on burning oil derricks.
-		if (psStructStat->type == REF_RESOURCE_EXTRACTOR && fireOnLocation(psDroid->order.pos.x, psDroid->order.pos.y))
+		if (psStructStat->type == REF_RESOURCE_EXTRACTOR && fireOnLocation(worldMapState, psDroid->order.pos.x, psDroid->order.pos.y))
 		{
 			// Don't cancel build, since we can wait for it to stop burning.
 			objTrace(psDroid->id, "DroidStartBuildPending: burning");
@@ -1192,7 +1192,7 @@ DroidStartBuild droidStartBuild(DROID *psDroid)
 		psStruct = castStructure(psDroid->order.psObj);
 		if (psStruct == nullptr)
 		{
-			psStruct = castStructure(worldTile(psDroid->actionPos)->psObject);
+			psStruct = castStructure(worldTile(worldMapState, psDroid->actionPos)->psObject);
 		}
 		if (psStruct && !droidNextToStruct(psDroid, psStruct))
 		{
@@ -1241,7 +1241,7 @@ static void addConstructorEffect(STRUCTURE *psStruct)
 		ASSERT_OR_RETURN(, size.x > 0 && size.y > 0, "Zero-size building?: %s", (psStruct && psStruct->pStructureType) ? psStruct->pStructureType->id.toUtf8().c_str() : "<null>");
 		Vector3i temp;
 		temp.x = psStruct->pos.x + ((rand() % (2 * size.x)) - size.x);
-		temp.y = map_TileHeight(map_coord(psStruct->pos.x), map_coord(psStruct->pos.y)) + (psStruct->sDisplay.imd->max.y / 6);
+		temp.y = map_TileHeight(worldMapState, map_coord(psStruct->pos.x), map_coord(psStruct->pos.y)) + (psStruct->sDisplay.imd->max.y / 6);
 		temp.z = psStruct->pos.y + ((rand() % (2 * size.y)) - size.y);
 		if (rand() % 2)
 		{
@@ -1863,7 +1863,7 @@ UDWORD calcDroidPower(const DROID *psDroid)
 DROID *reallyBuildDroid(const DROID_TEMPLATE *pTemplate, Position pos, UDWORD player, bool onMission, Rotation rot, uint32_t id)
 {
 	// Don't use this assertion in single player, since droids can finish building while on an away mission
-	ASSERT(!bMultiPlayer || worldOnMap(pos.x, pos.y), "the build locations are not on the map");
+	ASSERT(!bMultiPlayer || worldOnMap(worldMapState, pos.x, pos.y), "the build locations are not on the map");
 
 	ASSERT_OR_RETURN(nullptr, player < MAX_PLAYERS, "Invalid player: %" PRIu32 "", player);
 
@@ -1879,7 +1879,7 @@ DROID *reallyBuildDroid(const DROID_TEMPLATE *pTemplate, Position pos, UDWORD pl
 	if (!onMission)
 	{
 		//set droid height
-		droid.pos.z = map_Height(droid.pos.x, droid.pos.y);
+		droid.pos.z = map_Height(worldMapState, droid.pos.x, droid.pos.y);
 	}
 
 	if (droid.isTransporter() || droid.droidType == DROID_COMMAND)
@@ -3875,7 +3875,7 @@ bool droidOnMap(const DROID *psDroid)
 		// Off world or on a transport or is a transport or in mission list, or on a mission, or no map - ignore
 		return true;
 	}
-	return worldOnMap(psDroid->pos.x, psDroid->pos.y);
+	return worldOnMap(worldMapState, psDroid->pos.x, psDroid->pos.y);
 }
 
 /** Teleport a droid to a new position on the map */
@@ -3883,7 +3883,7 @@ void droidSetPosition(DROID *psDroid, int x, int y)
 {
 	psDroid->pos.x = x;
 	psDroid->pos.y = y;
-	psDroid->pos.z = map_Height(psDroid->pos.x, psDroid->pos.y);
+	psDroid->pos.z = map_Height(worldMapState, psDroid->pos.x, psDroid->pos.y);
 	initDroidMovement(psDroid);
 	visTilesUpdate((BASE_OBJECT *)psDroid);
 }

--- a/src/droid.cpp
+++ b/src/droid.cpp
@@ -522,7 +522,7 @@ void recycleDroid(DROID *psDroid)
 
 	Vector3i position = psDroid->pos.xzy();
 	const auto mapCoord = map_coord({psDroid->pos.x, psDroid->pos.y});
-	const auto psTile = mapTile(worldMapState, mapCoord);
+	const auto psTile = mapTile(gameWorld.map, mapCoord);
 	if (tileIsClearlyVisible(psTile))
 	{
 		addEffect(&position, EFFECT_EXPLOSION, EXPLOSION_TYPE_DISCOVERY, false, nullptr, false, gameTime - deltaGameTime + 1);
@@ -570,7 +570,7 @@ bool removeDroidBase(DROID *psDel)
 					return IterationResult::BREAK_ITERATION;
 				}
 				/* add droid to droid list then vanish it - hope this works! - GJ */
-				addDroid(psCurr, worldObjectState.droids);
+				addDroid(psCurr, gameWorld.objects.droids);
 				vanishDroid(psCurr);
 
 				return IterationResult::CONTINUE_ITERATION;
@@ -588,7 +588,7 @@ bool removeDroidBase(DROID *psDel)
 	/* Put Deliv. Pts back into world when a command droid dies */
 	if (psDel->droidType == DROID_COMMAND)
 	{
-		for (auto psStruct : worldObjectState.structures[psDel->player])
+		for (auto psStruct : gameWorld.objects.structures[psDel->player])
 		{
 			// alexl's stab at a right answer.
 			if (psStruct && psStruct->isFactory()
@@ -606,7 +606,7 @@ bool removeDroidBase(DROID *psDel)
 		if (tryingToGetLocation())
 		{
 			int numSelectedConstructors = 0;
-			for (const DROID *psDroid : worldObjectState.droids[psDel->player])
+			for (const DROID *psDroid : gameWorld.objects.droids[psDel->player])
 			{
 				numSelectedConstructors += psDroid->selected && psDroid->isConstructionDroid();
 			}
@@ -693,7 +693,7 @@ bool destroyDroid(DROID *psDel, unsigned impactTime)
 		{
 			for (breadth = mapY - 1; breadth <= mapY + 1; breadth++)
 			{
-				psTile = mapTile(worldMapState, width, breadth);
+				psTile = mapTile(gameWorld.map, width, breadth);
 				if (TEST_TILE_VISIBLE_TO_SELECTEDPLAYER(psTile))
 				{
 					psTile->illumination /= 2;
@@ -758,7 +758,7 @@ static size_t droidCancelRepairers(DROID *psDroid, PerPlayerDroidLists& pList)
 		}
 
 		// search the main (current) list of active structures to see if any point to this
-		StructureList* pStructList = &worldObjectState.structures[player];
+		StructureList* pStructList = &gameWorld.objects.structures[player];
 		for (STRUCTURE *psCurr : *pStructList)
 		{
 			if (psCurr->pStructureType->type == REF_REPAIR_FACILITY && psCurr->pFunctionality)
@@ -872,8 +872,8 @@ void droidUpdate(DROID *psDroid)
 	// Check that we are (still) in the sensor list
 	if (psDroid->droidType == DROID_SENSOR)
 	{
-		const auto sensor = std::find(worldObjectState.sensors[0].begin(), worldObjectState.sensors[0].end(), (BASE_OBJECT*)psDroid);
-		ASSERT(sensor != worldObjectState.sensors[0].end(), "%s(%p) not in sensor list!",
+		const auto sensor = std::find(gameWorld.objects.sensors[0].begin(), gameWorld.objects.sensors[0].end(), (BASE_OBJECT*)psDroid);
+		ASSERT(sensor != gameWorld.objects.sensors[0].end(), "%s(%p) not in sensor list!",
 			   droidGetName(psDroid), static_cast<void *>(psDroid));
 	}
 #endif
@@ -1095,13 +1095,13 @@ static bool droidNextToStruct(DROID *psDroid, STRUCTURE *psStruct)
 	auto pos = map_coord(psDroid->pos);
 	int minX = std::max(pos.x - 1, 0);
 	int minY = std::max(pos.y - 1, 0);
-	int maxX = std::min(pos.x + 1, worldMapState.width);
-	int maxY = std::min(pos.y + 1, worldMapState.height);
+	int maxX = std::min(pos.x + 1, gameWorld.map.width);
+	int maxY = std::min(pos.y + 1, gameWorld.map.height);
 	for (int y = minY; y <= maxY; ++y)
 	{
 		for (int x = minX; x <= maxX; ++x)
 		{
-			if (TileHasStructure(mapTile(worldMapState, x, y)) &&
+			if (TileHasStructure(mapTile(gameWorld.map, x, y)) &&
 				getTileStructure(x, y) == psStruct)
 			{
 				return true;
@@ -1169,7 +1169,7 @@ DroidStartBuild droidStartBuild(DROID *psDroid)
 			return DroidStartBuildFailed;
 		}
 		// Can't build on burning oil derricks.
-		if (psStructStat->type == REF_RESOURCE_EXTRACTOR && fireOnLocation(worldMapState, psDroid->order.pos.x, psDroid->order.pos.y))
+		if (psStructStat->type == REF_RESOURCE_EXTRACTOR && fireOnLocation(gameWorld.map, psDroid->order.pos.x, psDroid->order.pos.y))
 		{
 			// Don't cancel build, since we can wait for it to stop burning.
 			objTrace(psDroid->id, "DroidStartBuildPending: burning");
@@ -1192,7 +1192,7 @@ DroidStartBuild droidStartBuild(DROID *psDroid)
 		psStruct = castStructure(psDroid->order.psObj);
 		if (psStruct == nullptr)
 		{
-			psStruct = castStructure(worldTile(worldMapState, psDroid->actionPos)->psObject);
+			psStruct = castStructure(worldTile(gameWorld.map, psDroid->actionPos)->psObject);
 		}
 		if (psStruct && !droidNextToStruct(psDroid, psStruct))
 		{
@@ -1241,7 +1241,7 @@ static void addConstructorEffect(STRUCTURE *psStruct)
 		ASSERT_OR_RETURN(, size.x > 0 && size.y > 0, "Zero-size building?: %s", (psStruct && psStruct->pStructureType) ? psStruct->pStructureType->id.toUtf8().c_str() : "<null>");
 		Vector3i temp;
 		temp.x = psStruct->pos.x + ((rand() % (2 * size.x)) - size.x);
-		temp.y = map_TileHeight(worldMapState, map_coord(psStruct->pos.x), map_coord(psStruct->pos.y)) + (psStruct->sDisplay.imd->max.y / 6);
+		temp.y = map_TileHeight(gameWorld.map, map_coord(psStruct->pos.x), map_coord(psStruct->pos.y)) + (psStruct->sDisplay.imd->max.y / 6);
 		temp.z = psStruct->pos.y + ((rand() % (2 * size.y)) - size.y);
 		if (rand() % 2)
 		{
@@ -1863,7 +1863,7 @@ UDWORD calcDroidPower(const DROID *psDroid)
 DROID *reallyBuildDroid(const DROID_TEMPLATE *pTemplate, Position pos, UDWORD player, bool onMission, Rotation rot, uint32_t id)
 {
 	// Don't use this assertion in single player, since droids can finish building while on an away mission
-	ASSERT(!bMultiPlayer || worldOnMap(worldMapState, pos.x, pos.y), "the build locations are not on the map");
+	ASSERT(!bMultiPlayer || worldOnMap(gameWorld.map, pos.x, pos.y), "the build locations are not on the map");
 
 	ASSERT_OR_RETURN(nullptr, player < MAX_PLAYERS, "Invalid player: %" PRIu32 "", player);
 
@@ -1879,7 +1879,7 @@ DROID *reallyBuildDroid(const DROID_TEMPLATE *pTemplate, Position pos, UDWORD pl
 	if (!onMission)
 	{
 		//set droid height
-		droid.pos.z = map_Height(worldMapState, droid.pos.x, droid.pos.y);
+		droid.pos.z = map_Height(gameWorld.map, droid.pos.x, droid.pos.y);
 	}
 
 	if (droid.isTransporter() || droid.droidType == DROID_COMMAND)
@@ -2081,7 +2081,7 @@ void assignObjectToGroup(UDWORD	playerNumber, UDWORD groupNumber, bool clearGrou
 	if (groupNumber < UBYTE_MAX)
 	{
 		/* Run through all the droids */
-		for (DROID* psDroid : worldObjectState.droids[playerNumber])
+		for (DROID* psDroid : gameWorld.objects.droids[playerNumber])
 		{
 			/* Clear out the old ones */
 			if (clearGroup && psDroid->group == groupNumber)
@@ -2104,7 +2104,7 @@ void assignObjectToGroup(UDWORD	playerNumber, UDWORD groupNumber, bool clearGrou
 	{
 		//clear the Deliv Point if one
 		ASSERT_OR_RETURN(, selectedPlayer < MAX_PLAYERS, "Unsupported selectedPlayer: %" PRIu32 "", selectedPlayer);
-		for (auto& psFlag : worldObjectState.flags[selectedPlayer])
+		for (auto& psFlag : gameWorld.objects.flags[selectedPlayer])
 		{
 			psFlag->selected = false;
 		}
@@ -2124,7 +2124,7 @@ void assignObjectToGroup(UDWORD	playerNumber, UDWORD groupNumber, bool clearGrou
 	{
 		/* If no droids were selected to be added to the group, check if a factory is selected */
 		/* Run through all the structures */
-		for (STRUCTURE *psStruct : worldObjectState.structures[playerNumber])
+		for (STRUCTURE *psStruct : gameWorld.objects.structures[playerNumber])
 		{
 			if (psStruct->selected && psStruct->isFactory())
 			{
@@ -2150,7 +2150,7 @@ void removeObjectFromGroup(UDWORD playerNumber)
 
 	ASSERT_OR_RETURN(, playerNumber < MAX_PLAYERS, "Invalid player: %" PRIu32 "", playerNumber);
 
-	for (STRUCTURE *psStruct : worldObjectState.structures[playerNumber])
+	for (STRUCTURE *psStruct : gameWorld.objects.structures[playerNumber])
 	{
 		if (psStruct->selected && psStruct->isFactory())
 		{
@@ -2159,7 +2159,7 @@ void removeObjectFromGroup(UDWORD playerNumber)
 		}
 	}
 
-	for (DROID* psDroid : worldObjectState.droids[playerNumber])
+	for (DROID* psDroid : gameWorld.objects.droids[playerNumber])
 	{
 		if (psDroid->selected)
 		{
@@ -2185,7 +2185,7 @@ bool activateGroupAndMove(UDWORD playerNumber, UDWORD groupNumber)
 
 	if (groupNumber < UBYTE_MAX)
 	{
-		for (DROID* psDroid : worldObjectState.droids[playerNumber])
+		for (DROID* psDroid : gameWorld.objects.droids[playerNumber])
 		{
 			/* Wipe out the ones in the wrong group */
 			if (psDroid->selected && psDroid->group != groupNumber)
@@ -2208,7 +2208,7 @@ bool activateGroupAndMove(UDWORD playerNumber, UDWORD groupNumber)
 			ASSERT(selectedPlayer < MAX_PLAYERS, "Unsupported selectedPlayer: %" PRIu32 "", selectedPlayer);
 			if (selectedPlayer < MAX_PLAYERS)
 			{
-				for (auto& psFlag : worldObjectState.flags[selectedPlayer])
+				for (auto& psFlag : gameWorld.objects.flags[selectedPlayer])
 				{
 					psFlag->selected = false;
 				}
@@ -2252,7 +2252,7 @@ bool activateNoGroup(UDWORD playerNumber, const SELECTIONTYPE selectionType, con
 	ASSERT_OR_RETURN(false, playerNumber < MAX_PLAYERS, "Invalid player: %" PRIu32 "", playerNumber);
 
 	selectionCount = selDroidSelection(selectedPlayer, dselectionClass, dselectionType, dbOnScreen);
-	for (DROID* psDroid : worldObjectState.droids[playerNumber])
+	for (DROID* psDroid : gameWorld.objects.droids[playerNumber])
 	{
 		/* Wipe out the ones in the wrong group */
 		if (psDroid->selected && psDroid->group != UBYTE_MAX)
@@ -2265,7 +2265,7 @@ bool activateNoGroup(UDWORD playerNumber, const SELECTIONTYPE selectionType, con
 	{
 		//clear the Deliv Point if one
 		ASSERT_OR_RETURN(false, selectedPlayer < MAX_PLAYERS, "Unsupported selectedPlayer: %" PRIu32 "", selectedPlayer);
-		for (auto& psFlag : worldObjectState.flags[selectedPlayer])
+		for (auto& psFlag : gameWorld.objects.flags[selectedPlayer])
 		{
 			psFlag->selected = false;
 		}
@@ -2284,7 +2284,7 @@ bool activateGroup(UDWORD playerNumber, UDWORD groupNumber)
 
 	if (groupNumber < UBYTE_MAX)
 	{
-		for (DROID* psDroid : worldObjectState.droids[playerNumber])
+		for (DROID* psDroid : gameWorld.objects.droids[playerNumber])
 		{
 			/* Wipe out the ones in the wrong group */
 			if (psDroid->selected && psDroid->group != groupNumber)
@@ -2305,7 +2305,7 @@ bool activateGroup(UDWORD playerNumber, UDWORD groupNumber)
 	{
 		//clear the Deliv Point if one
 		ASSERT_OR_RETURN(false, selectedPlayer < MAX_PLAYERS, "Unsupported selectedPlayer: %" PRIu32 "", selectedPlayer);
-		for (auto& psFlag : worldObjectState.flags[selectedPlayer])
+		for (auto& psFlag : gameWorld.objects.flags[selectedPlayer])
 		{
 			psFlag->selected = false;
 		}
@@ -2546,7 +2546,7 @@ UDWORD	getNumDroidsForLevel(uint32_t player, UDWORD level)
 		DroidList* dList = nullptr;
 		switch (idx)
 		{
-			case 0: dList = &worldObjectState.droids[selectedPlayer]; break;
+			case 0: dList = &gameWorld.objects.droids[selectedPlayer]; break;
 			case 1: if (prevMissionType == LEVEL_TYPE::LDS_MKEEP_LIMBO) { dList = &apsLimboDroids[selectedPlayer]; } break;
 			default: dList = nullptr;
 		}
@@ -2644,7 +2644,7 @@ bool noDroid(UDWORD x, UDWORD y)
 	// check each droid list
 	for (i = 0; i < MAX_PLAYERS; ++i)
 	{
-		for (const DROID* psDroid : worldObjectState.droids[i])
+		for (const DROID* psDroid : gameWorld.objects.droids[i])
 		{
 			if (map_coord(psDroid->pos.x) == x
 				&& map_coord(psDroid->pos.y) == y)
@@ -2665,7 +2665,7 @@ static bool oneDroidMax(UDWORD x, UDWORD y)
 	// check each droid list
 	for (i = 0; i < MAX_PLAYERS; i++)
 	{
-		for (const DROID* pD : worldObjectState.droids[i])
+		for (const DROID* pD : gameWorld.objects.droids[i])
 		{
 			if (map_coord(pD->pos.x) == x
 				&& map_coord(pD->pos.y) == y)
@@ -2687,11 +2687,11 @@ static bool oneDroidMax(UDWORD x, UDWORD y)
 static bool sensiblePlace(SDWORD x, SDWORD y, PROPULSION_TYPE propulsion)
 {
 	// not too near the edges.
-	if ((x < TOO_NEAR_EDGE) || (x > (SDWORD)(worldMapState.width - TOO_NEAR_EDGE)))
+	if ((x < TOO_NEAR_EDGE) || (x > (SDWORD)(gameWorld.map.width - TOO_NEAR_EDGE)))
 	{
 		return false;
 	}
-	if ((y < TOO_NEAR_EDGE) || (y > (SDWORD)(worldMapState.height - TOO_NEAR_EDGE)))
+	if ((y < TOO_NEAR_EDGE) || (y > (SDWORD)(gameWorld.map.height - TOO_NEAR_EDGE)))
 	{
 		return false;
 	}
@@ -2746,7 +2746,7 @@ static bool ThreatInRange(SDWORD player, SDWORD range, SDWORD rangeX, SDWORD ran
 		}
 
 		//check structures
-		for (const STRUCTURE* psStruct : worldObjectState.structures[i])
+		for (const STRUCTURE* psStruct : gameWorld.objects.structures[i])
 		{
 			if (psStruct->visible[player] || psStruct->born == 2)	// if can see it or started there
 			{
@@ -2776,7 +2776,7 @@ static bool ThreatInRange(SDWORD player, SDWORD range, SDWORD rangeX, SDWORD ran
 		}
 
 		//check droids
-		for (const DROID* psDroid : worldObjectState.droids[i])
+		for (const DROID* psDroid : gameWorld.objects.droids[i])
 		{
 			if (psDroid->visible[player])		//can see this droid?
 			{
@@ -2812,8 +2812,8 @@ bool	pickATileGenThreat(UDWORD *x, UDWORD *y, UBYTE numIterations, SDWORD threat
 	UDWORD		passes;
 	Vector3i	origin(world_coord(*x), world_coord(*y), 0);
 
-	ASSERT_OR_RETURN(false, *x < worldMapState.width, "x coordinate is off-map for pickATileGen");
-	ASSERT_OR_RETURN(false, *y < worldMapState.height, "y coordinate is off-map for pickATileGen");
+	ASSERT_OR_RETURN(false, *x < gameWorld.map.width, "x coordinate is off-map for pickATileGen");
+	ASSERT_OR_RETURN(false, *y < gameWorld.map.height, "y coordinate is off-map for pickATileGen");
 
 	if (function(*x, *y) && ((threatRange <= 0) || (!ThreatInRange(player, threatRange, *x, *y, false))))	//TODO: vtol check really not needed?
 	{
@@ -2866,7 +2866,7 @@ PICKTILE pickHalfATile(UDWORD *x, UDWORD *y, UBYTE numIterations)
 building the specified structure - returns true if finds one*/
 bool checkDroidsBuilding(const STRUCTURE *psStructure)
 {
-	for (const DROID* psDroid : worldObjectState.droids[psStructure->player])
+	for (const DROID* psDroid : gameWorld.objects.droids[psStructure->player])
 	{
 		//check DORDER_BUILD, HELP_BUILD is handled the same
 		BASE_OBJECT *const psStruct = orderStateObj(psDroid, DORDER_BUILD);
@@ -2882,7 +2882,7 @@ bool checkDroidsBuilding(const STRUCTURE *psStructure)
 demolishing the specified structure - returns true if finds one*/
 bool checkDroidsDemolishing(const STRUCTURE *psStructure)
 {
-	for (const DROID* psDroid : worldObjectState.droids[psStructure->player])
+	for (const DROID* psDroid : gameWorld.objects.droids[psStructure->player])
 	{
 		//check DORDER_DEMOLISH
 		BASE_OBJECT *const psStruct = orderStateObj(psDroid, DORDER_DEMOLISH);
@@ -3259,7 +3259,7 @@ bool allVtolsRearmed(const DROID *psDroid)
 	}
 
 	bool stillRearming = false;
-	for (const DROID *psCurr : worldObjectState.droids[psDroid->player])
+	for (const DROID *psCurr : gameWorld.objects.droids[psDroid->player])
 	{
 		if (psCurr->isVtolRearming() &&
 			psCurr->order.type == psDroid->order.type &&
@@ -3543,7 +3543,7 @@ DROID *giftSingleDroid(DROID *psD, UDWORD to, bool electronic, Vector2i pos)
 		psNewDroid = reallyBuildDroid(&sTemplate, newPos, to, false, psD->rot);
 		ASSERT_OR_RETURN(nullptr, psNewDroid, "Unable to build unit");
 
-		addDroid(psNewDroid, worldObjectState.droids);
+		addDroid(psNewDroid, gameWorld.objects.droids);
 		adjustDroidCount(psNewDroid, 1);
 
 		psNewDroid->body = clip((psD->body*psNewDroid->originalBody + psD->originalBody/2)/std::max(psD->originalBody, 1u), 1u, psNewDroid->originalBody);
@@ -3568,7 +3568,7 @@ DROID *giftSingleDroid(DROID *psD, UDWORD to, bool electronic, Vector2i pos)
 	int oldPlayer = psD->player;
 
 	// reset the assigned state of units attached to a leader
-	for (DROID *psCurr : worldObjectState.droids[oldPlayer])
+	for (DROID *psCurr : gameWorld.objects.droids[oldPlayer])
 	{
 		BASE_OBJECT	*psLeader;
 
@@ -3595,11 +3595,11 @@ DROID *giftSingleDroid(DROID *psD, UDWORD to, bool electronic, Vector2i pos)
 	adjustDroidCount(psD, -1);
 	scriptRemoveObject(psD); //Remove droid from any script groups
 
-	if (droidRemove(psD, worldObjectState.droids))
+	if (droidRemove(psD, gameWorld.objects.droids))
 	{
 		psD->player	= to;
 
-		addDroid(psD, worldObjectState.droids);
+		addDroid(psD, gameWorld.objects.droids);
 		adjustDroidCount(psD, 1);
 
 		// the new player may have different default sensor/ecm/repair components
@@ -3642,7 +3642,7 @@ DROID *giftSingleDroid(DROID *psD, UDWORD to, bool electronic, Vector2i pos)
 			continue;
 		}
 
-		for (DROID *psCurr : worldObjectState.droids[i])
+		for (DROID *psCurr : gameWorld.objects.droids[i])
 		{
 			if (psCurr->order.psObj == psD || psCurr->psActionTarget[0] == psD)
 			{
@@ -3670,7 +3670,7 @@ DROID *giftSingleDroid(DROID *psD, UDWORD to, bool electronic, Vector2i pos)
 		}
 
 		// check through the players list, and our allies, of structures to see if any are targetting it
-		for (STRUCTURE *psStruct : worldObjectState.structures[i])
+		for (STRUCTURE *psStruct : gameWorld.objects.structures[i])
 		{
 			if (psStruct->psTarget[0] == psD)
 			{
@@ -3783,7 +3783,7 @@ void SelectDroid(DROID *psDroid, bool programmaticSelection)
 void SelectGroupDroid(DROID *psGroupDroid)
 {
 	std::vector<DROID*> groupDroids;
-	for (DROID *psDroid : worldObjectState.droids[psGroupDroid->player])
+	for (DROID *psDroid : gameWorld.objects.droids[psGroupDroid->player])
 	{
 		// skip itself because psGroupDroid may already exist in apsDroidLists
 		if (psDroid == psGroupDroid)
@@ -3870,12 +3870,12 @@ bool droidOnMap(const DROID *psDroid)
 {
 	if (psDroid->died == NOT_CURRENT_LIST || psDroid->isTransporter()
 		|| psDroid->pos.x == INVALID_XY || psDroid->pos.y == INVALID_XY || missionIsOffworld()
-		|| worldMapState.height == 0)
+		|| gameWorld.map.height == 0)
 	{
 		// Off world or on a transport or is a transport or in mission list, or on a mission, or no map - ignore
 		return true;
 	}
-	return worldOnMap(worldMapState, psDroid->pos.x, psDroid->pos.y);
+	return worldOnMap(gameWorld.map, psDroid->pos.x, psDroid->pos.y);
 }
 
 /** Teleport a droid to a new position on the map */
@@ -3883,7 +3883,7 @@ void droidSetPosition(DROID *psDroid, int x, int y)
 {
 	psDroid->pos.x = x;
 	psDroid->pos.y = y;
-	psDroid->pos.z = map_Height(worldMapState, psDroid->pos.x, psDroid->pos.y);
+	psDroid->pos.z = map_Height(gameWorld.map, psDroid->pos.x, psDroid->pos.y);
 	initDroidMovement(psDroid);
 	visTilesUpdate((BASE_OBJECT *)psDroid);
 }

--- a/src/edit3d.cpp
+++ b/src/edit3d.cpp
@@ -31,6 +31,7 @@ Alex McLean, Pumpkin Studios, EIDOS Interactive, 1997
 #include "objects.h"
 #include "display.h"
 #include "hci.h"
+#include "game_world.h"
 
 /*
 Definition of a tile to highlight - presently more than is required
@@ -58,15 +59,15 @@ void raiseTile(int tile3dX, int tile3dY)
 {
 	int i, j;
 
-	if (tile3dX < 0 || tile3dX > worldMapState.width - 1 || tile3dY < 0 || tile3dY > worldMapState.height - 1)
+	if (tile3dX < 0 || tile3dX > gameWorld.map.width - 1 || tile3dY < 0 || tile3dY > gameWorld.map.height - 1)
 	{
 		return;
 	}
-	for (i = tile3dX; i <= MIN(worldMapState.width - 1, tile3dX + brushSize); i++)
+	for (i = tile3dX; i <= MIN(gameWorld.map.width - 1, tile3dX + brushSize); i++)
 	{
-		for (j = tile3dY; j <= MIN(worldMapState.height - 1, tile3dY + brushSize); j++)
+		for (j = tile3dY; j <= MIN(gameWorld.map.height - 1, tile3dY + brushSize); j++)
 		{
-			adjustTileHeight(mapTile(worldMapState, i, j), TILE_RAISE);
+			adjustTileHeight(mapTile(gameWorld.map, i, j), TILE_RAISE);
 			markTileDirty(i, j);
 		}
 	}
@@ -77,15 +78,15 @@ void lowerTile(int tile3dX, int tile3dY)
 {
 	int i, j;
 
-	if (tile3dX < 0 || tile3dX > worldMapState.width - 1 || tile3dY < 0 || tile3dY > worldMapState.height - 1)
+	if (tile3dX < 0 || tile3dX > gameWorld.map.width - 1 || tile3dY < 0 || tile3dY > gameWorld.map.height - 1)
 	{
 		return;
 	}
-	for (i = tile3dX; i <= MIN(worldMapState.width - 1, tile3dX + brushSize); i++)
+	for (i = tile3dX; i <= MIN(gameWorld.map.width - 1, tile3dX + brushSize); i++)
 	{
-		for (j = tile3dY; j <= MIN(worldMapState.height - 1, tile3dY + brushSize); j++)
+		for (j = tile3dY; j <= MIN(gameWorld.map.height - 1, tile3dY + brushSize); j++)
 		{
-			adjustTileHeight(mapTile(worldMapState, i, j), TILE_LOWER);
+			adjustTileHeight(mapTile(gameWorld.map, i, j), TILE_LOWER);
 			markTileDirty(i, j);
 		}
 	}
@@ -160,7 +161,7 @@ bool process3DBuilding()
 
 	/* Need to update the building locations if we're building */
 	int border = 5*TILE_UNITS/2;
-	Vector2i bv = {clip(mousePos.x, border, worldMapState.width*TILE_UNITS - border), clip(mousePos.y, border, worldMapState.height*TILE_UNITS - border)};
+	Vector2i bv = {clip(mousePos.x, border, gameWorld.map.width*TILE_UNITS - border), clip(mousePos.y, border, gameWorld.map.height*TILE_UNITS - border)};
 	Vector2i size = getStatsSize(sBuildDetails.psStats, getBuildingDirection());
 	Vector2i worldSize = world_coord(size);
 	bv = round_to_nearest_tile(bv - worldSize/2) + worldSize/2;

--- a/src/edit3d.cpp
+++ b/src/edit3d.cpp
@@ -66,7 +66,7 @@ void raiseTile(int tile3dX, int tile3dY)
 	{
 		for (j = tile3dY; j <= MIN(worldMapState.height - 1, tile3dY + brushSize); j++)
 		{
-			adjustTileHeight(mapTile(i, j), TILE_RAISE);
+			adjustTileHeight(mapTile(worldMapState, i, j), TILE_RAISE);
 			markTileDirty(i, j);
 		}
 	}
@@ -85,7 +85,7 @@ void lowerTile(int tile3dX, int tile3dY)
 	{
 		for (j = tile3dY; j <= MIN(worldMapState.height - 1, tile3dY + brushSize); j++)
 		{
-			adjustTileHeight(mapTile(i, j), TILE_LOWER);
+			adjustTileHeight(mapTile(worldMapState, i, j), TILE_LOWER);
 			markTileDirty(i, j);
 		}
 	}

--- a/src/edit3d.cpp
+++ b/src/edit3d.cpp
@@ -58,13 +58,13 @@ void raiseTile(int tile3dX, int tile3dY)
 {
 	int i, j;
 
-	if (tile3dX < 0 || tile3dX > mapWidth - 1 || tile3dY < 0 || tile3dY > mapHeight - 1)
+	if (tile3dX < 0 || tile3dX > worldMapState.width - 1 || tile3dY < 0 || tile3dY > worldMapState.height - 1)
 	{
 		return;
 	}
-	for (i = tile3dX; i <= MIN(mapWidth - 1, tile3dX + brushSize); i++)
+	for (i = tile3dX; i <= MIN(worldMapState.width - 1, tile3dX + brushSize); i++)
 	{
-		for (j = tile3dY; j <= MIN(mapHeight - 1, tile3dY + brushSize); j++)
+		for (j = tile3dY; j <= MIN(worldMapState.height - 1, tile3dY + brushSize); j++)
 		{
 			adjustTileHeight(mapTile(i, j), TILE_RAISE);
 			markTileDirty(i, j);
@@ -77,13 +77,13 @@ void lowerTile(int tile3dX, int tile3dY)
 {
 	int i, j;
 
-	if (tile3dX < 0 || tile3dX > mapWidth - 1 || tile3dY < 0 || tile3dY > mapHeight - 1)
+	if (tile3dX < 0 || tile3dX > worldMapState.width - 1 || tile3dY < 0 || tile3dY > worldMapState.height - 1)
 	{
 		return;
 	}
-	for (i = tile3dX; i <= MIN(mapWidth - 1, tile3dX + brushSize); i++)
+	for (i = tile3dX; i <= MIN(worldMapState.width - 1, tile3dX + brushSize); i++)
 	{
-		for (j = tile3dY; j <= MIN(mapHeight - 1, tile3dY + brushSize); j++)
+		for (j = tile3dY; j <= MIN(worldMapState.height - 1, tile3dY + brushSize); j++)
 		{
 			adjustTileHeight(mapTile(i, j), TILE_LOWER);
 			markTileDirty(i, j);
@@ -160,7 +160,7 @@ bool process3DBuilding()
 
 	/* Need to update the building locations if we're building */
 	int border = 5*TILE_UNITS/2;
-	Vector2i bv = {clip(mousePos.x, border, mapWidth*TILE_UNITS - border), clip(mousePos.y, border, mapHeight*TILE_UNITS - border)};
+	Vector2i bv = {clip(mousePos.x, border, worldMapState.width*TILE_UNITS - border), clip(mousePos.y, border, worldMapState.height*TILE_UNITS - border)};
 	Vector2i size = getStatsSize(sBuildDetails.psStats, getBuildingDirection());
 	Vector2i worldSize = world_coord(size);
 	bv = round_to_nearest_tile(bv - worldSize/2) + worldSize/2;

--- a/src/effects.cpp
+++ b/src/effects.cpp
@@ -2243,7 +2243,7 @@ static void effectStructureUpdates()
 	/* Go thru' all players */
 	for (unsigned player = 0; player < MAX_PLAYERS; ++player)
 	{
-		for (STRUCTURE *psStructure : apsStructLists[player])
+		for (STRUCTURE *psStructure : worldObjectState.structures[player])
 		{
 			// Find its group.
 			unsigned int partition = psStructure->id % EFFECT_STRUCTURE_DIVISION;

--- a/src/effects.cpp
+++ b/src/effects.cpp
@@ -965,7 +965,7 @@ static bool updateGraviton(EFFECT *psEffect, LightingData& lightData)
 	psEffect->position.z += graphicsTimeAdjustedIncrement(psEffect->velocity.z);
 
 	/* If it's bounced/drifted off the map then kill it */
-	if (map_coord(static_cast<int32_t>(psEffect->position.x)) >= mapWidth || map_coord(static_cast<int32_t>(psEffect->position.z)) >= mapHeight)
+	if (map_coord(static_cast<int32_t>(psEffect->position.x)) >= worldMapState.width || map_coord(static_cast<int32_t>(psEffect->position.z)) >= worldMapState.height)
 	{
 		return false;
 	}

--- a/src/effects.cpp
+++ b/src/effects.cpp
@@ -71,6 +71,7 @@
 #include "multiplay.h"
 #include "component.h"
 #include "profiling.h"
+#include "game_world.h"
 
 #ifndef GLM_ENABLE_EXPERIMENTAL
 	#define GLM_ENABLE_EXPERIMENTAL
@@ -965,12 +966,12 @@ static bool updateGraviton(EFFECT *psEffect, LightingData& lightData)
 	psEffect->position.z += graphicsTimeAdjustedIncrement(psEffect->velocity.z);
 
 	/* If it's bounced/drifted off the map then kill it */
-	if (map_coord(static_cast<int32_t>(psEffect->position.x)) >= worldMapState.width || map_coord(static_cast<int32_t>(psEffect->position.z)) >= worldMapState.height)
+	if (map_coord(static_cast<int32_t>(psEffect->position.x)) >= gameWorld.map.width || map_coord(static_cast<int32_t>(psEffect->position.z)) >= gameWorld.map.height)
 	{
 		return false;
 	}
 
-	int groundHeight = map_Height(worldMapState, static_cast<int>(psEffect->position.x), static_cast<int>(psEffect->position.z));
+	int groundHeight = map_Height(gameWorld.map, static_cast<int>(psEffect->position.x), static_cast<int>(psEffect->position.z));
 
 	/* If it's going up and it's still under the landscape, then remove it... */
 	if (psEffect->position.y < groundHeight && psEffect->velocity.y > 0)
@@ -1032,7 +1033,7 @@ static bool updateGraviton(EFFECT *psEffect, LightingData& lightData)
 	/* Are we below it? - Hit the ground? */
 	if ((int)psEffect->position.y < (int)groundHeight)
 	{
-		psTile = mapTile(worldMapState, map_coord(static_cast<int32_t>(psEffect->position.x)), map_coord(static_cast<int32_t>(psEffect->position.z)));
+		psTile = mapTile(gameWorld.map, map_coord(static_cast<int32_t>(psEffect->position.x)), map_coord(static_cast<int32_t>(psEffect->position.z)));
 		if (terrainType(psTile) == TER_WATER)
 		{
 			return false;
@@ -1281,7 +1282,7 @@ static bool updateConstruction(EFFECT *psEffect)
 	if (TEST_CYCLIC(psEffect))
 	{
 		/* Has it hit the ground */
-		if (static_cast<int>(psEffect->position.y) <= map_Height(worldMapState, static_cast<int>(psEffect->position.x), static_cast<int>(psEffect->position.z)))
+		if (static_cast<int>(psEffect->position.y) <= map_Height(gameWorld.map, static_cast<int>(psEffect->position.x), static_cast<int>(psEffect->position.z)))
 		{
 			return false;
 		}
@@ -1323,12 +1324,12 @@ static bool updateFire(EFFECT *psEffect, LightingData& lightData)
 		pos.z = static_cast<int>(psEffect->position.z + ((rand() % psEffect->radius) - (rand() % (2 * psEffect->radius))));
 
 		// Effect is off map, no need to update it anymore
-		if (!worldOnMap(worldMapState, pos.x, pos.z))
+		if (!worldOnMap(gameWorld.map, pos.x, pos.z))
 		{
 			return false;
 		}
 
-		pos.y = map_Height(worldMapState, pos.x, pos.z);
+		pos.y = map_Height(gameWorld.map, pos.x, pos.z);
 
 		if (psEffect->type == FIRE_TYPE_SMOKY_BLUE)
 		{
@@ -1343,7 +1344,7 @@ static bool updateFire(EFFECT *psEffect, LightingData& lightData)
 		{
 			pos.x = static_cast<int>(psEffect->position.x + ((rand() % psEffect->radius / 2) - (rand() % (2 * psEffect->radius / 2))));
 			pos.z = static_cast<int>(psEffect->position.z + ((rand() % psEffect->radius / 2) - (rand() % (2 * psEffect->radius / 2))));
-			pos.y = map_Height(worldMapState, pos.x, pos.z);
+			pos.y = map_Height(gameWorld.map, pos.x, pos.z);
 			addEffect(&pos, EFFECT_SMOKE, SMOKE_TYPE_DRIFTING_HIGH, false, nullptr, 0);
 		}
 		else
@@ -1352,12 +1353,12 @@ static bool updateFire(EFFECT *psEffect, LightingData& lightData)
 			pos.z = static_cast<int>(psEffect->position.z + ((rand() % psEffect->radius) - (rand() % (2 * psEffect->radius))));
 
 			// Effect is off map, no need to update it anymore
-			if (!worldOnMap(worldMapState, pos.x, pos.z))
+			if (!worldOnMap(gameWorld.map, pos.x, pos.z))
 			{
 				return false;
 			}
 
-			pos.y = map_Height(worldMapState, pos.x, pos.z);
+			pos.y = map_Height(gameWorld.map, pos.x, pos.z);
 			addEffect(&pos, EFFECT_EXPLOSION, EXPLOSION_TYPE_SMALL, false, nullptr, 0);
 		}
 
@@ -2243,7 +2244,7 @@ static void effectStructureUpdates()
 	/* Go thru' all players */
 	for (unsigned player = 0; player < MAX_PLAYERS; ++player)
 	{
-		for (STRUCTURE *psStructure : worldObjectState.structures[player])
+		for (STRUCTURE *psStructure : gameWorld.objects.structures[player])
 		{
 			// Find its group.
 			unsigned int partition = psStructure->id % EFFECT_STRUCTURE_DIVISION;
@@ -2438,7 +2439,7 @@ bool readFXData(const char *fileName)
 			// Sanity check - don't allow a negative time to wrap to a huge positive unsigned value.
 			if (timeLeftToRun > 0)
 			{
-				tileSetFire(worldMapState, static_cast<int32_t>(curEffect.position.x), static_cast<int32_t>(curEffect.position.z), static_cast<uint32_t>(timeLeftToRun));
+				tileSetFire(gameWorld.map, static_cast<int32_t>(curEffect.position.x), static_cast<int32_t>(curEffect.position.z), static_cast<uint32_t>(timeLeftToRun));
 			}
 		}
 

--- a/src/effects.cpp
+++ b/src/effects.cpp
@@ -970,7 +970,7 @@ static bool updateGraviton(EFFECT *psEffect, LightingData& lightData)
 		return false;
 	}
 
-	int groundHeight = map_Height(static_cast<int>(psEffect->position.x), static_cast<int>(psEffect->position.z));
+	int groundHeight = map_Height(worldMapState, static_cast<int>(psEffect->position.x), static_cast<int>(psEffect->position.z));
 
 	/* If it's going up and it's still under the landscape, then remove it... */
 	if (psEffect->position.y < groundHeight && psEffect->velocity.y > 0)
@@ -1032,7 +1032,7 @@ static bool updateGraviton(EFFECT *psEffect, LightingData& lightData)
 	/* Are we below it? - Hit the ground? */
 	if ((int)psEffect->position.y < (int)groundHeight)
 	{
-		psTile = mapTile(map_coord(static_cast<int32_t>(psEffect->position.x)), map_coord(static_cast<int32_t>(psEffect->position.z)));
+		psTile = mapTile(worldMapState, map_coord(static_cast<int32_t>(psEffect->position.x)), map_coord(static_cast<int32_t>(psEffect->position.z)));
 		if (terrainType(psTile) == TER_WATER)
 		{
 			return false;
@@ -1281,7 +1281,7 @@ static bool updateConstruction(EFFECT *psEffect)
 	if (TEST_CYCLIC(psEffect))
 	{
 		/* Has it hit the ground */
-		if (static_cast<int>(psEffect->position.y) <= map_Height(static_cast<int>(psEffect->position.x), static_cast<int>(psEffect->position.z)))
+		if (static_cast<int>(psEffect->position.y) <= map_Height(worldMapState, static_cast<int>(psEffect->position.x), static_cast<int>(psEffect->position.z)))
 		{
 			return false;
 		}
@@ -1323,12 +1323,12 @@ static bool updateFire(EFFECT *psEffect, LightingData& lightData)
 		pos.z = static_cast<int>(psEffect->position.z + ((rand() % psEffect->radius) - (rand() % (2 * psEffect->radius))));
 
 		// Effect is off map, no need to update it anymore
-		if (!worldOnMap(pos.x, pos.z))
+		if (!worldOnMap(worldMapState, pos.x, pos.z))
 		{
 			return false;
 		}
 
-		pos.y = map_Height(pos.x, pos.z);
+		pos.y = map_Height(worldMapState, pos.x, pos.z);
 
 		if (psEffect->type == FIRE_TYPE_SMOKY_BLUE)
 		{
@@ -1343,7 +1343,7 @@ static bool updateFire(EFFECT *psEffect, LightingData& lightData)
 		{
 			pos.x = static_cast<int>(psEffect->position.x + ((rand() % psEffect->radius / 2) - (rand() % (2 * psEffect->radius / 2))));
 			pos.z = static_cast<int>(psEffect->position.z + ((rand() % psEffect->radius / 2) - (rand() % (2 * psEffect->radius / 2))));
-			pos.y = map_Height(pos.x, pos.z);
+			pos.y = map_Height(worldMapState, pos.x, pos.z);
 			addEffect(&pos, EFFECT_SMOKE, SMOKE_TYPE_DRIFTING_HIGH, false, nullptr, 0);
 		}
 		else
@@ -1352,12 +1352,12 @@ static bool updateFire(EFFECT *psEffect, LightingData& lightData)
 			pos.z = static_cast<int>(psEffect->position.z + ((rand() % psEffect->radius) - (rand() % (2 * psEffect->radius))));
 
 			// Effect is off map, no need to update it anymore
-			if (!worldOnMap(pos.x, pos.z))
+			if (!worldOnMap(worldMapState, pos.x, pos.z))
 			{
 				return false;
 			}
 
-			pos.y = map_Height(pos.x, pos.z);
+			pos.y = map_Height(worldMapState, pos.x, pos.z);
 			addEffect(&pos, EFFECT_EXPLOSION, EXPLOSION_TYPE_SMALL, false, nullptr, 0);
 		}
 
@@ -2438,7 +2438,7 @@ bool readFXData(const char *fileName)
 			// Sanity check - don't allow a negative time to wrap to a huge positive unsigned value.
 			if (timeLeftToRun > 0)
 			{
-				tileSetFire(static_cast<int32_t>(curEffect.position.x), static_cast<int32_t>(curEffect.position.z), static_cast<uint32_t>(timeLeftToRun));
+				tileSetFire(worldMapState, static_cast<int32_t>(curEffect.position.x), static_cast<int32_t>(curEffect.position.z), static_cast<uint32_t>(timeLeftToRun));
 			}
 		}
 

--- a/src/feature.cpp
+++ b/src/feature.cpp
@@ -307,8 +307,8 @@ FEATURE *buildFeature(FEATURE_STATS *psStats, UDWORD x, UDWORD y, bool FromSave,
 			MAPTILE *psTile = mapTile(b.map.x + width, b.map.y + breadth);
 
 			//check not outside of map - for load save game
-			ASSERT_OR_RETURN(nullptr, b.map.x + width < mapWidth, "x coord bigger than map width - %s, id = %d", getStatsName(psFeature->psStats), psFeature->id);
-			ASSERT_OR_RETURN(nullptr, b.map.y + breadth < mapHeight, "y coord bigger than map height - %s, id = %d", getStatsName(psFeature->psStats), psFeature->id);
+			ASSERT_OR_RETURN(nullptr, b.map.x + width < worldMapState.width, "x coord bigger than map width - %s, id = %d", getStatsName(psFeature->psStats), psFeature->id);
+			ASSERT_OR_RETURN(nullptr, b.map.y + breadth < worldMapState.height, "y coord bigger than map height - %s, id = %d", getStatsName(psFeature->psStats), psFeature->id);
 
 			if (width != psStats->baseWidth && breadth != psStats->baseBreadth)
 			{

--- a/src/feature.cpp
+++ b/src/feature.cpp
@@ -51,6 +51,7 @@
 #include "mapgrid.h"
 #include "display3d.h"
 #include "random.h"
+#include "game_world.h"
 
 /* The statistics for the features */
 std::vector<FEATURE_STATS> asFeatureStats;
@@ -194,10 +195,10 @@ static void updateFeatureOrientation(FEATURE *psFeature)
 	//    hy0
 	// hx0 * hx1      (* = feature)
 	//    hy1
-	hx1 = map_Height(worldMapState, psFeature->pos.x + d, psFeature->pos.y);
-	hx0 = map_Height(worldMapState, MAX(0, psFeature->pos.x - d), psFeature->pos.y);
-	hy1 = map_Height(worldMapState, psFeature->pos.x, psFeature->pos.y + d);
-	hy0 = map_Height(worldMapState, psFeature->pos.x, MAX(0, psFeature->pos.y - d));
+	hx1 = map_Height(gameWorld.map, psFeature->pos.x + d, psFeature->pos.y);
+	hx0 = map_Height(gameWorld.map, MAX(0, psFeature->pos.x - d), psFeature->pos.y);
+	hy1 = map_Height(gameWorld.map, psFeature->pos.x, psFeature->pos.y + d);
+	hy0 = map_Height(gameWorld.map, psFeature->pos.x, MAX(0, psFeature->pos.y - d));
 
 	//update height in case in the bottom of a trough
 	psFeature->pos.z = MAX(psFeature->pos.z, (hx0 + hx1) / 2);
@@ -268,7 +269,7 @@ FEATURE *buildFeature(FEATURE_STATS *psStats, UDWORD x, UDWORD y, bool FromSave,
 	{
 		for (int width = 0; width <= b.size.x; ++width)
 		{
-			int h = map_TileHeight(worldMapState, b.map.x + width, b.map.y + breadth);
+			int h = map_TileHeight(gameWorld.map, b.map.x + width, b.map.y + breadth);
 			foundationMin = std::min(foundationMin, h);
 			foundationMax = std::max(foundationMax, h);
 		}
@@ -304,11 +305,11 @@ FEATURE *buildFeature(FEATURE_STATS *psStats, UDWORD x, UDWORD y, bool FromSave,
 	{
 		for (int width = 0; width < b.size.x; ++width)
 		{
-			MAPTILE *psTile = mapTile(worldMapState, b.map.x + width, b.map.y + breadth);
+			MAPTILE *psTile = mapTile(gameWorld.map, b.map.x + width, b.map.y + breadth);
 
 			//check not outside of map - for load save game
-			ASSERT_OR_RETURN(nullptr, b.map.x + width < worldMapState.width, "x coord bigger than map width - %s, id = %d", getStatsName(psFeature->psStats), psFeature->id);
-			ASSERT_OR_RETURN(nullptr, b.map.y + breadth < worldMapState.height, "y coord bigger than map height - %s, id = %d", getStatsName(psFeature->psStats), psFeature->id);
+			ASSERT_OR_RETURN(nullptr, b.map.x + width < gameWorld.map.width, "x coord bigger than map width - %s, id = %d", getStatsName(psFeature->psStats), psFeature->id);
+			ASSERT_OR_RETURN(nullptr, b.map.y + breadth < gameWorld.map.height, "y coord bigger than map height - %s, id = %d", getStatsName(psFeature->psStats), psFeature->id);
 
 			if (width != psStats->baseWidth && breadth != psStats->baseBreadth)
 			{
@@ -328,12 +329,12 @@ FEATURE *buildFeature(FEATURE_STATS *psStats, UDWORD x, UDWORD y, bool FromSave,
 				// if it's a tall feature then flag it in the map.
 				if (psFeature->sDisplay.imd->max.y > TALLOBJECT_YMAX)
 				{
-					auxSetBlocking(worldMapState, b.map.x + width, b.map.y + breadth, AIR_BLOCKED);
+					auxSetBlocking(gameWorld.map, b.map.x + width, b.map.y + breadth, AIR_BLOCKED);
 				}
 
 				if (psStats->subType != FEAT_GEN_ARTE && psStats->subType != FEAT_OIL_DRUM)
 				{
-					auxSetBlocking(worldMapState, b.map.x + width, b.map.y + breadth, FEATURE_BLOCKED);
+					auxSetBlocking(gameWorld.map, b.map.x + width, b.map.y + breadth, FEATURE_BLOCKED);
 				}
 			}
 
@@ -343,7 +344,7 @@ FEATURE *buildFeature(FEATURE_STATS *psStats, UDWORD x, UDWORD y, bool FromSave,
 			}
 		}
 	}
-	psFeature->pos.z = map_TileHeight(worldMapState, psFeature->pos.x, psFeature->pos.y);//jps 18july97
+	psFeature->pos.z = map_TileHeight(gameWorld.map, psFeature->pos.x, psFeature->pos.y);//jps 18july97
 	updateFeatureOrientation(psFeature);
 
 	return psFeature;
@@ -414,14 +415,14 @@ bool removeFeature(FEATURE *psDel)
 	{
 		for (int width = 0; width < b.size.x; ++width)
 		{
-			if (tileOnMap(worldMapState, b.map.x + width, b.map.y + breadth))
+			if (tileOnMap(gameWorld.map, b.map.x + width, b.map.y + breadth))
 			{
-				MAPTILE *psTile = mapTile(worldMapState, b.map.x + width, b.map.y + breadth);
+				MAPTILE *psTile = mapTile(gameWorld.map, b.map.x + width, b.map.y + breadth);
 
 				if (psTile->psObject == psDel)
 				{
 					psTile->psObject = nullptr;
-					auxClearBlocking(worldMapState, b.map.x + width, b.map.y + breadth, FEATURE_BLOCKED | AIR_BLOCKED);
+					auxClearBlocking(gameWorld.map, b.map.x + width, b.map.y + breadth, FEATURE_BLOCKED | AIR_BLOCKED);
 				}
 			}
 		}
@@ -431,7 +432,7 @@ bool removeFeature(FEATURE *psDel)
 	{
 		pos.x = psDel->pos.x;
 		pos.z = psDel->pos.y;
-		pos.y = map_Height(worldMapState, pos.x, pos.z) + 30;
+		pos.y = map_Height(gameWorld.map, pos.x, pos.z) + 30;
 		addEffect(&pos, EFFECT_EXPLOSION, EXPLOSION_TYPE_DISCOVERY, false, nullptr, 0, gameTime - deltaGameTime + 1);
 		if (psDel->psStats->subType == FEAT_GEN_ARTE)
 		{
@@ -518,7 +519,7 @@ bool destroyFeature(FEATURE *psDel, unsigned impactTime)
 		/* Then a sequence of effects */
 		pos.x = psDel->pos.x;
 		pos.z = psDel->pos.y;
-		pos.y = map_Height(worldMapState, pos.x, pos.z);
+		pos.y = map_Height(gameWorld.map, pos.x, pos.z);
 		addEffect(&pos, EFFECT_DESTRUCTION, DESTRUCTION_TYPE_FEATURE, false, nullptr, 0, impactTime);
 
 		//play sound
@@ -545,7 +546,7 @@ bool destroyFeature(FEATURE *psDel, unsigned impactTime)
 			{
 				const unsigned int x = b.map.x + width;
 				const unsigned int y = b.map.y + breadth;
-				MAPTILE *psTile = mapTile(worldMapState, x, y);
+				MAPTILE *psTile = mapTile(gameWorld.map, x, y);
 				if (psTile->psObject != psDel)
 				{
 					continue;
@@ -560,13 +561,13 @@ bool destroyFeature(FEATURE *psDel, unsigned impactTime)
 						{
 							makeTileRubbleTexture(psTile, x, y, RUBBLE_TILE);
 						}
-						auxClearBlocking(worldMapState, x, y, AUXBITS_ALL);
+						auxClearBlocking(gameWorld.map, x, y, AUXBITS_ALL);
 					}
 					else
 					{
 						/* This remains a blocking tile */
 						psTile->psObject = nullptr;
-						auxClearBlocking(worldMapState, x, y, AIR_BLOCKED);  // Shouldn't remain blocking for air units, however.
+						auxClearBlocking(gameWorld.map, x, y, AIR_BLOCKED);  // Shouldn't remain blocking for air units, however.
 						if (isUrban)
 						{
 							makeTileRubbleTexture(psTile, x, y, BLOCKING_RUBBLE_TILE);

--- a/src/feature.cpp
+++ b/src/feature.cpp
@@ -194,10 +194,10 @@ static void updateFeatureOrientation(FEATURE *psFeature)
 	//    hy0
 	// hx0 * hx1      (* = feature)
 	//    hy1
-	hx1 = map_Height(psFeature->pos.x + d, psFeature->pos.y);
-	hx0 = map_Height(MAX(0, psFeature->pos.x - d), psFeature->pos.y);
-	hy1 = map_Height(psFeature->pos.x, psFeature->pos.y + d);
-	hy0 = map_Height(psFeature->pos.x, MAX(0, psFeature->pos.y - d));
+	hx1 = map_Height(worldMapState, psFeature->pos.x + d, psFeature->pos.y);
+	hx0 = map_Height(worldMapState, MAX(0, psFeature->pos.x - d), psFeature->pos.y);
+	hy1 = map_Height(worldMapState, psFeature->pos.x, psFeature->pos.y + d);
+	hy0 = map_Height(worldMapState, psFeature->pos.x, MAX(0, psFeature->pos.y - d));
 
 	//update height in case in the bottom of a trough
 	psFeature->pos.z = MAX(psFeature->pos.z, (hx0 + hx1) / 2);
@@ -268,7 +268,7 @@ FEATURE *buildFeature(FEATURE_STATS *psStats, UDWORD x, UDWORD y, bool FromSave,
 	{
 		for (int width = 0; width <= b.size.x; ++width)
 		{
-			int h = map_TileHeight(b.map.x + width, b.map.y + breadth);
+			int h = map_TileHeight(worldMapState, b.map.x + width, b.map.y + breadth);
 			foundationMin = std::min(foundationMin, h);
 			foundationMax = std::max(foundationMax, h);
 		}
@@ -304,7 +304,7 @@ FEATURE *buildFeature(FEATURE_STATS *psStats, UDWORD x, UDWORD y, bool FromSave,
 	{
 		for (int width = 0; width < b.size.x; ++width)
 		{
-			MAPTILE *psTile = mapTile(b.map.x + width, b.map.y + breadth);
+			MAPTILE *psTile = mapTile(worldMapState, b.map.x + width, b.map.y + breadth);
 
 			//check not outside of map - for load save game
 			ASSERT_OR_RETURN(nullptr, b.map.x + width < worldMapState.width, "x coord bigger than map width - %s, id = %d", getStatsName(psFeature->psStats), psFeature->id);
@@ -328,12 +328,12 @@ FEATURE *buildFeature(FEATURE_STATS *psStats, UDWORD x, UDWORD y, bool FromSave,
 				// if it's a tall feature then flag it in the map.
 				if (psFeature->sDisplay.imd->max.y > TALLOBJECT_YMAX)
 				{
-					auxSetBlocking(b.map.x + width, b.map.y + breadth, AIR_BLOCKED);
+					auxSetBlocking(worldMapState, b.map.x + width, b.map.y + breadth, AIR_BLOCKED);
 				}
 
 				if (psStats->subType != FEAT_GEN_ARTE && psStats->subType != FEAT_OIL_DRUM)
 				{
-					auxSetBlocking(b.map.x + width, b.map.y + breadth, FEATURE_BLOCKED);
+					auxSetBlocking(worldMapState, b.map.x + width, b.map.y + breadth, FEATURE_BLOCKED);
 				}
 			}
 
@@ -343,7 +343,7 @@ FEATURE *buildFeature(FEATURE_STATS *psStats, UDWORD x, UDWORD y, bool FromSave,
 			}
 		}
 	}
-	psFeature->pos.z = map_TileHeight(psFeature->pos.x, psFeature->pos.y);//jps 18july97
+	psFeature->pos.z = map_TileHeight(worldMapState, psFeature->pos.x, psFeature->pos.y);//jps 18july97
 	updateFeatureOrientation(psFeature);
 
 	return psFeature;
@@ -414,14 +414,14 @@ bool removeFeature(FEATURE *psDel)
 	{
 		for (int width = 0; width < b.size.x; ++width)
 		{
-			if (tileOnMap(b.map.x + width, b.map.y + breadth))
+			if (tileOnMap(worldMapState, b.map.x + width, b.map.y + breadth))
 			{
-				MAPTILE *psTile = mapTile(b.map.x + width, b.map.y + breadth);
+				MAPTILE *psTile = mapTile(worldMapState, b.map.x + width, b.map.y + breadth);
 
 				if (psTile->psObject == psDel)
 				{
 					psTile->psObject = nullptr;
-					auxClearBlocking(b.map.x + width, b.map.y + breadth, FEATURE_BLOCKED | AIR_BLOCKED);
+					auxClearBlocking(worldMapState, b.map.x + width, b.map.y + breadth, FEATURE_BLOCKED | AIR_BLOCKED);
 				}
 			}
 		}
@@ -431,7 +431,7 @@ bool removeFeature(FEATURE *psDel)
 	{
 		pos.x = psDel->pos.x;
 		pos.z = psDel->pos.y;
-		pos.y = map_Height(pos.x, pos.z) + 30;
+		pos.y = map_Height(worldMapState, pos.x, pos.z) + 30;
 		addEffect(&pos, EFFECT_EXPLOSION, EXPLOSION_TYPE_DISCOVERY, false, nullptr, 0, gameTime - deltaGameTime + 1);
 		if (psDel->psStats->subType == FEAT_GEN_ARTE)
 		{
@@ -518,7 +518,7 @@ bool destroyFeature(FEATURE *psDel, unsigned impactTime)
 		/* Then a sequence of effects */
 		pos.x = psDel->pos.x;
 		pos.z = psDel->pos.y;
-		pos.y = map_Height(pos.x, pos.z);
+		pos.y = map_Height(worldMapState, pos.x, pos.z);
 		addEffect(&pos, EFFECT_DESTRUCTION, DESTRUCTION_TYPE_FEATURE, false, nullptr, 0, impactTime);
 
 		//play sound
@@ -545,7 +545,7 @@ bool destroyFeature(FEATURE *psDel, unsigned impactTime)
 			{
 				const unsigned int x = b.map.x + width;
 				const unsigned int y = b.map.y + breadth;
-				MAPTILE *psTile = mapTile(x, y);
+				MAPTILE *psTile = mapTile(worldMapState, x, y);
 				if (psTile->psObject != psDel)
 				{
 					continue;
@@ -560,13 +560,13 @@ bool destroyFeature(FEATURE *psDel, unsigned impactTime)
 						{
 							makeTileRubbleTexture(psTile, x, y, RUBBLE_TILE);
 						}
-						auxClearBlocking(x, y, AUXBITS_ALL);
+						auxClearBlocking(worldMapState, x, y, AUXBITS_ALL);
 					}
 					else
 					{
 						/* This remains a blocking tile */
 						psTile->psObject = nullptr;
-						auxClearBlocking(x, y, AIR_BLOCKED);  // Shouldn't remain blocking for air units, however.
+						auxClearBlocking(worldMapState, x, y, AIR_BLOCKED);  // Shouldn't remain blocking for air units, however.
 						if (isUrban)
 						{
 							makeTileRubbleTexture(psTile, x, y, BLOCKING_RUBBLE_TILE);

--- a/src/fpath.cpp
+++ b/src/fpath.cpp
@@ -332,7 +332,7 @@ bool fpathBaseBlockingTile(SDWORD x, SDWORD y, PROPULSION_TYPE propulsion, int m
 		// coords off map - auto blocking tile
 		return true;
 	}
-	unsigned aux = auxTile(x, y, mapIndex);
+	unsigned aux = auxTile(worldMapState, x, y, mapIndex);
 
 	int auxMask = 0;
 	switch (moveType)
@@ -349,7 +349,7 @@ bool fpathBaseBlockingTile(SDWORD x, SDWORD y, PROPULSION_TYPE propulsion, int m
 	}
 
 	// the MAX hack below is because blockTile() range does not include player-specific versions...
-	return (blockTile(x, y, MAX(0, mapIndex - MAX_PLAYERS)) & unitbits) != 0;  // finally check if move is blocked by propulsion related factors
+	return (blockTile(worldMapState, x, y, MAX(0, mapIndex - MAX_PLAYERS)) & unitbits) != 0;  // finally check if move is blocked by propulsion related factors
 }
 
 bool fpathDroidBlockingTile(DROID *psDroid, int x, int y, FPATH_MOVETYPE moveType)
@@ -442,7 +442,7 @@ static FPATH_RETVAL fpathRoute(MOVE_CONTROL *psMove, unsigned id, int startX, in
 	}
 #endif
 
-	if (!worldOnMap(startX, startY) || !worldOnMap(tX, tY))
+	if (!worldOnMap(worldMapState, startX, startY) || !worldOnMap(worldMapState, tX, tY))
 	{
 		debug(LOG_ERROR, "Droid trying to find path to/from invalid location (%d %d) -> (%d %d).", startX, startY, tX, tY);
 		objTrace(id, "Invalid start/end.");
@@ -557,7 +557,7 @@ FPATH_RETVAL fpathDroidRoute(DROID *psDroid, SDWORD tX, SDWORD tY, FPATH_MOVETYP
 	// Check whether the start and end points of the route are blocking tiles and find an alternative if they are.
 	Position startPos = psDroid->pos;
 	Position endPos = Position(tX, tY, 0);
-	StructureBounds dstStructure = getStructureBounds(worldTile(endPos.xy())->psObject);
+	StructureBounds dstStructure = getStructureBounds(worldTile(worldMapState, endPos.xy())->psObject);
 	const auto droidPropulsionType = psDroid->getPropulsionStats()->propulsionType;
 	startPos = findNonblockingPosition(startPos, droidPropulsionType, psDroid->player, moveType);
 	if (!dstStructure.valid())  // If there's a structure over the destination, ignore it, otherwise pathfind from somewhere around the obstruction.
@@ -754,13 +754,13 @@ bool fpathCheck(Position orig, Position dest, PROPULSION_TYPE propulsion)
 	// We have to be careful with this check because it is called on
 	// load when playing campaign on droids that are on the other
 	// map during missions, and those maps are usually larger.
-	if (!worldOnMap(orig.xy()) || !worldOnMap(dest.xy()))
+	if (!worldOnMap(worldMapState, orig.xy()) || !worldOnMap(worldMapState, dest.xy()))
 	{
 		return false;
 	}
 
-	MAPTILE *origTile = worldTile(findNonblockingPosition(orig, propulsion).xy());
-	MAPTILE *destTile = worldTile(findNonblockingPosition(dest, propulsion).xy());
+	MAPTILE *origTile = worldTile(worldMapState, findNonblockingPosition(orig, propulsion).xy());
+	MAPTILE *destTile = worldTile(worldMapState, findNonblockingPosition(dest, propulsion).xy());
 
 	ASSERT_OR_RETURN(false, propulsion != PROPULSION_TYPE_NUM, "Bad propulsion type");
 	ASSERT_OR_RETURN(false, origTile != nullptr && destTile != nullptr, "Bad tile parameter");

--- a/src/fpath.cpp
+++ b/src/fpath.cpp
@@ -321,13 +321,13 @@ static uint8_t prop2bits(PROPULSION_TYPE propulsion)
 bool fpathBaseBlockingTile(SDWORD x, SDWORD y, PROPULSION_TYPE propulsion, int mapIndex, FPATH_MOVETYPE moveType)
 {
 	/* All tiles outside of the map and on map border are blocking. */
-	if (x < 1 || y < 1 || x > mapWidth - 1 || y > mapHeight - 1)
+	if (x < 1 || y < 1 || x > worldMapState.width - 1 || y > worldMapState.height - 1)
 	{
 		return true;
 	}
 
 	/* Check scroll limits (used in campaign to partition the map. */
-	if (propulsion != PROPULSION_TYPE_LIFT && (x < scrollMinX + 1 || y < scrollMinY + 1 || x >= scrollMaxX - 1 || y >= scrollMaxY - 1))
+	if (propulsion != PROPULSION_TYPE_LIFT && (x < worldMapState.scroll.minX + 1 || y < worldMapState.scroll.minY + 1 || x >= worldMapState.scroll.maxX - 1 || y >= worldMapState.scroll.maxY - 1))
 	{
 		// coords off map - auto blocking tile
 		return true;

--- a/src/fpath.cpp
+++ b/src/fpath.cpp
@@ -40,6 +40,7 @@
 
 #include "fpath.h"
 #include "profiling.h"
+#include "game_world.h"
 
 // If the path finding system is shutdown or not
 static volatile bool fpathQuit = false;
@@ -321,18 +322,18 @@ static uint8_t prop2bits(PROPULSION_TYPE propulsion)
 bool fpathBaseBlockingTile(SDWORD x, SDWORD y, PROPULSION_TYPE propulsion, int mapIndex, FPATH_MOVETYPE moveType)
 {
 	/* All tiles outside of the map and on map border are blocking. */
-	if (x < 1 || y < 1 || x > worldMapState.width - 1 || y > worldMapState.height - 1)
+	if (x < 1 || y < 1 || x > gameWorld.map.width - 1 || y > gameWorld.map.height - 1)
 	{
 		return true;
 	}
 
 	/* Check scroll limits (used in campaign to partition the map. */
-	if (propulsion != PROPULSION_TYPE_LIFT && (x < worldMapState.scroll.minX + 1 || y < worldMapState.scroll.minY + 1 || x >= worldMapState.scroll.maxX - 1 || y >= worldMapState.scroll.maxY - 1))
+	if (propulsion != PROPULSION_TYPE_LIFT && (x < gameWorld.map.scroll.minX + 1 || y < gameWorld.map.scroll.minY + 1 || x >= gameWorld.map.scroll.maxX - 1 || y >= gameWorld.map.scroll.maxY - 1))
 	{
 		// coords off map - auto blocking tile
 		return true;
 	}
-	unsigned aux = auxTile(worldMapState, x, y, mapIndex);
+	unsigned aux = auxTile(gameWorld.map, x, y, mapIndex);
 
 	int auxMask = 0;
 	switch (moveType)
@@ -349,7 +350,7 @@ bool fpathBaseBlockingTile(SDWORD x, SDWORD y, PROPULSION_TYPE propulsion, int m
 	}
 
 	// the MAX hack below is because blockTile() range does not include player-specific versions...
-	return (blockTile(worldMapState, x, y, MAX(0, mapIndex - MAX_PLAYERS)) & unitbits) != 0;  // finally check if move is blocked by propulsion related factors
+	return (blockTile(gameWorld.map, x, y, MAX(0, mapIndex - MAX_PLAYERS)) & unitbits) != 0;  // finally check if move is blocked by propulsion related factors
 }
 
 bool fpathDroidBlockingTile(DROID *psDroid, int x, int y, FPATH_MOVETYPE moveType)
@@ -442,7 +443,7 @@ static FPATH_RETVAL fpathRoute(MOVE_CONTROL *psMove, unsigned id, int startX, in
 	}
 #endif
 
-	if (!worldOnMap(worldMapState, startX, startY) || !worldOnMap(worldMapState, tX, tY))
+	if (!worldOnMap(gameWorld.map, startX, startY) || !worldOnMap(gameWorld.map, tX, tY))
 	{
 		debug(LOG_ERROR, "Droid trying to find path to/from invalid location (%d %d) -> (%d %d).", startX, startY, tX, tY);
 		objTrace(id, "Invalid start/end.");
@@ -557,7 +558,7 @@ FPATH_RETVAL fpathDroidRoute(DROID *psDroid, SDWORD tX, SDWORD tY, FPATH_MOVETYP
 	// Check whether the start and end points of the route are blocking tiles and find an alternative if they are.
 	Position startPos = psDroid->pos;
 	Position endPos = Position(tX, tY, 0);
-	StructureBounds dstStructure = getStructureBounds(worldTile(worldMapState, endPos.xy())->psObject);
+	StructureBounds dstStructure = getStructureBounds(worldTile(gameWorld.map, endPos.xy())->psObject);
 	const auto droidPropulsionType = psDroid->getPropulsionStats()->propulsionType;
 	startPos = findNonblockingPosition(startPos, droidPropulsionType, psDroid->player, moveType);
 	if (!dstStructure.valid())  // If there's a structure over the destination, ignore it, otherwise pathfind from somewhere around the obstruction.
@@ -754,13 +755,13 @@ bool fpathCheck(Position orig, Position dest, PROPULSION_TYPE propulsion)
 	// We have to be careful with this check because it is called on
 	// load when playing campaign on droids that are on the other
 	// map during missions, and those maps are usually larger.
-	if (!worldOnMap(worldMapState, orig.xy()) || !worldOnMap(worldMapState, dest.xy()))
+	if (!worldOnMap(gameWorld.map, orig.xy()) || !worldOnMap(gameWorld.map, dest.xy()))
 	{
 		return false;
 	}
 
-	MAPTILE *origTile = worldTile(worldMapState, findNonblockingPosition(orig, propulsion).xy());
-	MAPTILE *destTile = worldTile(worldMapState, findNonblockingPosition(dest, propulsion).xy());
+	MAPTILE *origTile = worldTile(gameWorld.map, findNonblockingPosition(orig, propulsion).xy());
+	MAPTILE *destTile = worldTile(gameWorld.map, findNonblockingPosition(dest, propulsion).xy());
 
 	ASSERT_OR_RETURN(false, propulsion != PROPULSION_TYPE_NUM, "Bad propulsion type");
 	ASSERT_OR_RETURN(false, origTile != nullptr && destTile != nullptr, "Bad tile parameter");

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -3001,10 +3001,10 @@ bool loadGame(const GameLoadDetails& gameToLoad, bool keepObjects, bool freeMem)
 		//the scroll limits for the mission map have already been written
 		if (saveGameVersion >= VERSION_29)
 		{
-			missionScrollMinX = (UWORD)mission.scrollMinX;
-			missionScrollMinY = (UWORD)mission.scrollMinY;
-			missionScrollMaxX = (UWORD)mission.scrollMaxX;
-			missionScrollMaxY = (UWORD)mission.scrollMaxY;
+			missionScrollMinX = (UWORD)mission.worldMapState.scroll.minX;
+			missionScrollMinY = (UWORD)mission.worldMapState.scroll.minY;
+			missionScrollMaxX = (UWORD)mission.worldMapState.scroll.maxX;
+			missionScrollMaxY = (UWORD)mission.worldMapState.scroll.maxY;
 		}
 
 		//load the map and the droids then swap pointers
@@ -3113,17 +3113,17 @@ bool loadGame(const GameLoadDetails& gameToLoad, bool keepObjects, bool freeMem)
 		//once the mission map has been loaded reset the mission scroll limits
 		if (saveGameVersion >= VERSION_29)
 		{
-			mission.scrollMinX = missionScrollMinX;
-			mission.scrollMinY = missionScrollMinY;
-			mission.scrollMaxX = missionScrollMaxX;
-			mission.scrollMaxY = missionScrollMaxY;
+			mission.worldMapState.scroll.minX = missionScrollMinX;
+			mission.worldMapState.scroll.minY = missionScrollMinY;
+			mission.worldMapState.scroll.maxX = missionScrollMaxX;
+			mission.worldMapState.scroll.maxY = missionScrollMaxY;
 		}
 	}
 
 	//if Campaign Expand then don't load in another map
 	if (gameType != GTYPE_SCENARIO_EXPAND)
 	{
-		psMapTiles = nullptr;
+		worldMapState.tiles = nullptr;
 		// load in the map file
 		if (!data)
 		{
@@ -3530,7 +3530,7 @@ error:
 	freeAllStructs();
 	freeAllFeatures();
 	droidTemplateShutDown();
-	psMapTiles = nullptr;
+	worldMapState.tiles = nullptr;
 
 	/* Start the game clock */
 	gameTimeStart();
@@ -4557,10 +4557,10 @@ bool gameLoadV(PHYSFS_file *fileHandle, unsigned int version, nonstd::optional<n
 
 	if (saveGameVersion >= VERSION_29)
 	{
-		mission.scrollMinX = saveGameData.missionScrollMinX;
-		mission.scrollMinY = saveGameData.missionScrollMinY;
-		mission.scrollMaxX = saveGameData.missionScrollMaxX;
-		mission.scrollMaxY = saveGameData.missionScrollMaxY;
+		mission.worldMapState.scroll.minX = saveGameData.missionScrollMinX;
+		mission.worldMapState.scroll.minY = saveGameData.missionScrollMinY;
+		mission.worldMapState.scroll.maxX = saveGameData.missionScrollMaxX;
+		mission.worldMapState.scroll.maxY = saveGameData.missionScrollMaxY;
 	}
 
 	if (saveGameVersion >= VERSION_31)
@@ -4835,8 +4835,8 @@ static bool writeMainFile(const std::string &fileName, SDWORD saveType)
 	save.setValue("campaignName", getCampaignName());
 	save.setValue("gameTime", gameTime);
 	save.setValue("missionTime", mission.startTime);
-	save.setVector2i("scrollMin", Vector2i(scrollMinX, scrollMinY));
-	save.setVector2i("scrollMax", Vector2i(scrollMaxX, scrollMaxY));
+	save.setVector2i("scrollMin", Vector2i(worldMapState.scroll.minX, worldMapState.scroll.minY));
+	save.setVector2i("scrollMax", Vector2i(worldMapState.scroll.maxX, worldMapState.scroll.maxY));
 	save.setValue("saveType", saveType);
 	ASSERT_OR_RETURN(false, strlen(aLevelName) < MAX_LEVEL_SIZE, "Unable to save level name - too long (max %d) - %s", (int)MAX_LEVEL_SIZE, aLevelName);
 	save.setValue("levelName", aLevelName);
@@ -4847,8 +4847,8 @@ static bool writeMainFile(const std::string &fileName, SDWORD saveType)
 	save.setValue("missionCheatTime", mission.cheatTime);
 	save.setVector2i("missionHomeLZ", Vector2i(mission.homeLZ_X, mission.homeLZ_Y));
 	save.setVector2i("missionPlayerPos", Vector2i(mission.playerX, mission.playerY));
-	save.setVector2i("missionScrollMin", Vector2i(mission.scrollMinX, mission.scrollMinY));
-	save.setVector2i("missionScrollMax", Vector2i(mission.scrollMaxX, mission.scrollMaxY));
+	save.setVector2i("missionScrollMin", Vector2i(mission.worldMapState.scroll.minX, mission.worldMapState.scroll.minY));
+	save.setVector2i("missionScrollMax", Vector2i(mission.worldMapState.scroll.maxX, mission.worldMapState.scroll.maxY));
 	save.setValue("offWorldKeepLists", offWorldKeepLists);
 	save.setValue("rubbleTile", getRubbleTileNum());
 	save.setValue("waterTile", getWaterTileNum());
@@ -5011,10 +5011,10 @@ static bool writeGameFile(const char *fileName, SDWORD saveType)
 	saveGame.missionTime = mission.startTime;
 
 	//put in the scroll data
-	saveGame.ScrollMinX = scrollMinX;
-	saveGame.ScrollMinY = scrollMinY;
-	saveGame.ScrollMaxX = scrollMaxX;
-	saveGame.ScrollMaxY = scrollMaxY;
+	saveGame.ScrollMinX = worldMapState.scroll.minX;
+	saveGame.ScrollMinY = worldMapState.scroll.minY;
+	saveGame.ScrollMaxX = worldMapState.scroll.maxX;
+	saveGame.ScrollMaxY = worldMapState.scroll.maxY;
 
 	saveGame.GameType = saveType;
 
@@ -5042,10 +5042,10 @@ static bool writeGameFile(const char *fileName, SDWORD saveType)
 	saveGame.missionHomeLZ_Y =		mission.homeLZ_Y;
 	saveGame.missionPlayerX =		mission.playerX;
 	saveGame.missionPlayerY =		mission.playerY;
-	saveGame.missionScrollMinX = (UWORD)mission.scrollMinX;
-	saveGame.missionScrollMinY = (UWORD)mission.scrollMinY;
-	saveGame.missionScrollMaxX = (UWORD)mission.scrollMaxX;
-	saveGame.missionScrollMaxY = (UWORD)mission.scrollMaxY;
+	saveGame.missionScrollMinX = (UWORD)mission.worldMapState.scroll.minX;
+	saveGame.missionScrollMinY = (UWORD)mission.worldMapState.scroll.minY;
+	saveGame.missionScrollMaxX = (UWORD)mission.worldMapState.scroll.maxX;
+	saveGame.missionScrollMaxY = (UWORD)mission.worldMapState.scroll.maxY;
 
 	saveGame.offWorldKeepLists = offWorldKeepLists;
 	saveGame.RubbleTile	= getRubbleTileNum();
@@ -5725,8 +5725,8 @@ static bool loadSaveDroid(const char *pFileName, PerPlayerDroidLists& ppsCurrent
 		// If droid is on a mission, calling with the saved position might cause an assertion. Or something like that.
 		if (!onMission)
 		{
-			pos.x = clip(pos.x, world_coord(1), world_coord(mapWidth - 1));
-			pos.y = clip(pos.y, world_coord(1), world_coord(mapHeight - 1));
+			pos.x = clip(pos.x, world_coord(1), world_coord(worldMapState.width - 1));
+			pos.y = clip(pos.y, world_coord(1), world_coord(worldMapState.height - 1));
 		}
 
 		/* Create the Droid */
@@ -6250,13 +6250,13 @@ bool loadSaveStructure(char *pFileData, UDWORD filesize)
 		}
 
 		//check not trying to build too near the edge
-		if (map_coord(psSaveStructure->x) < TOO_NEAR_EDGE || map_coord(psSaveStructure->x) > mapWidth - TOO_NEAR_EDGE)
+		if (map_coord(psSaveStructure->x) < TOO_NEAR_EDGE || map_coord(psSaveStructure->x) > worldMapState.width - TOO_NEAR_EDGE)
 		{
 			debug(LOG_ERROR, "Structure %s, x coord too near the edge of the map. id - %d", getSaveStructNameV19((SAVE_STRUCTURE_V17 *)psSaveStructure), psSaveStructure->id);
 			//ignore this
 			continue;
 		}
-		if (map_coord(psSaveStructure->y) < TOO_NEAR_EDGE || map_coord(psSaveStructure->y) > mapHeight - TOO_NEAR_EDGE)
+		if (map_coord(psSaveStructure->y) < TOO_NEAR_EDGE || map_coord(psSaveStructure->y) > worldMapState.height - TOO_NEAR_EDGE)
 		{
 			debug(LOG_ERROR, "Structure %s, y coord too near the edge of the map. id - %d", getSaveStructNameV19((SAVE_STRUCTURE_V17 *)psSaveStructure), psSaveStructure->id);
 			//ignore this
@@ -6339,8 +6339,8 @@ static bool loadWzMapStructure(WzMap::Map& wzMap, std::unordered_map<UDWORD, UDW
 			}
 		}
 		//check not trying to build too near the edge
-		if (map_coord(structure.position.x) < TOO_NEAR_EDGE || map_coord(structure.position.x) > mapWidth - TOO_NEAR_EDGE
-		 || map_coord(structure.position.y) < TOO_NEAR_EDGE || map_coord(structure.position.y) > mapHeight - TOO_NEAR_EDGE)
+		if (map_coord(structure.position.x) < TOO_NEAR_EDGE || map_coord(structure.position.x) > worldMapState.width - TOO_NEAR_EDGE
+		 || map_coord(structure.position.y) < TOO_NEAR_EDGE || map_coord(structure.position.y) > worldMapState.height - TOO_NEAR_EDGE)
 		{
 			debug(LOG_ERROR, "Structure %s, coord too near the edge of the map", structure.name.c_str());
 			continue; // skip it
@@ -6476,8 +6476,8 @@ static bool loadSaveStructure2(const char *pFileName)
 			}
 		}
 		//check not trying to build too near the edge
-		if (map_coord(pos.x) < TOO_NEAR_EDGE || map_coord(pos.x) > mapWidth - TOO_NEAR_EDGE
-		    || map_coord(pos.y) < TOO_NEAR_EDGE || map_coord(pos.y) > mapHeight - TOO_NEAR_EDGE)
+		if (map_coord(pos.x) < TOO_NEAR_EDGE || map_coord(pos.x) > worldMapState.width - TOO_NEAR_EDGE
+		    || map_coord(pos.y) < TOO_NEAR_EDGE || map_coord(pos.y) > worldMapState.height - TOO_NEAR_EDGE)
 		{
 			debug(LOG_ERROR, "Structure %s (%s), coord too near the edge of the map", name.toUtf8().c_str(), list[i].toUtf8().c_str());
 			ini.endGroup();
@@ -8211,39 +8211,39 @@ static void setMapScroll()
 	//if loading in a pre version5 then scroll values will not have been set up so set to max poss
 	if (width == 0 && height == 0)
 	{
-		scrollMinX = 0;
-		scrollMaxX = mapWidth;
-		scrollMinY = 0;
-		scrollMaxY = mapHeight;
+		worldMapState.scroll.minX = 0;
+		worldMapState.scroll.maxX = worldMapState.width;
+		worldMapState.scroll.minY = 0;
+		worldMapState.scroll.maxY = worldMapState.height;
 		return;
 	}
-	scrollMinX = startX;
-	scrollMinY = startY;
-	scrollMaxX = startX + width;
-	scrollMaxY = startY + height;
+	worldMapState.scroll.minX = startX;
+	worldMapState.scroll.minY = startY;
+	worldMapState.scroll.maxX = startX + width;
+	worldMapState.scroll.maxY = startY + height;
 	//check not going beyond width/height of map
-	if (scrollMaxX > (SDWORD)mapWidth)
+	if (worldMapState.scroll.maxX > (SDWORD)worldMapState.width)
 	{
-		scrollMaxX = mapWidth;
+		worldMapState.scroll.maxX = worldMapState.width;
 		debug(LOG_NEVER, "scrollMaxX was too big - It has been set to map width");
 	}
-	if (scrollMaxY > (SDWORD)mapHeight)
+	if (worldMapState.scroll.maxY > (SDWORD)worldMapState.height)
 	{
-		scrollMaxY = mapHeight;
+		worldMapState.scroll.maxY = worldMapState.height;
 		debug(LOG_NEVER, "scrollMaxY was too big - It has been set to map height");
 	}
 	// check for invalid minimum values (fixes some broken maps)
-	if (scrollMinX >= scrollMaxX)
+	if (worldMapState.scroll.minX >= worldMapState.scroll.maxX)
 	{
 		ASSERT(false, "scrollMinX was >= scrollMaxX - min has been set to 0, max has been set to mapWidth");
-		scrollMinX = 0;
-		scrollMaxX = mapWidth;
+		worldMapState.scroll.minX = 0;
+		worldMapState.scroll.maxX = worldMapState.width;
 	}
-	if (scrollMinY >= scrollMaxY)
+	if (worldMapState.scroll.minY >= worldMapState.scroll.maxY)
 	{
 		ASSERT(false, "scrollMinY was >= scrollMaxY - min has been set to 0, max has been set to mapHeight");
-		scrollMinY = 0;
-		scrollMaxY = mapHeight;
+		worldMapState.scroll.minY = 0;
+		worldMapState.scroll.maxY = worldMapState.height;
 	}
 }
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -101,7 +101,7 @@
 #include "keybind.h"
 #include "loop.h"
 #include "screens/guidescreen.h"
-#include "world_object_state.h"
+#include "game_world.h"
 #include <array>
 
 #include "wzphysfszipioprovider.h"
@@ -2414,7 +2414,7 @@ static void sanityUpdate()
 {
 	for (int player = 0; player < game.maxPlayers; player++)
 	{
-		for (DROID *psDroid : worldObjectState.droids[player])
+		for (DROID *psDroid : gameWorld.objects.droids[player])
 		{
 			orderCheckList(psDroid);
 			actionSanity(psDroid);
@@ -2702,16 +2702,16 @@ bool loadGame(const GameLoadDetails& gameToLoad, bool keepObjects, bool freeMem)
 		//initialise the lists
 		for (player = 0; player < MAX_PLAYERS; player++)
 		{
-			worldObjectState.droids[player].clear();
-			worldObjectState.structures[player].clear();
-			worldObjectState.flags[player].clear();
+			gameWorld.objects.droids[player].clear();
+			gameWorld.objects.structures[player].clear();
+			gameWorld.objects.flags[player].clear();
 			//clear all the messages?
 			apsProxDisp[player].clear();
-			worldObjectState.extractors[player].clear();
+			gameWorld.objects.extractors[player].clear();
 		}
-		worldObjectState.features[0].clear();
-		worldObjectState.oils[0].clear();
-		worldObjectState.sensors[0].clear();
+		gameWorld.objects.features[0].clear();
+		gameWorld.objects.oils[0].clear();
+		gameWorld.objects.sensors[0].clear();
 		initFactoryNumFlag();
 	}
 
@@ -2721,14 +2721,14 @@ bool loadGame(const GameLoadDetails& gameToLoad, bool keepObjects, bool freeMem)
 		for (player = 0; player < MAX_PLAYERS; player++)
 		{
 			apsLimboDroids[player].clear();
-			mission.worldObjectState.droids[player].clear();
-			mission.worldObjectState.structures[player].clear();
-			mission.worldObjectState.flags[player].clear();
-			mission.worldObjectState.extractors[player].clear();
+			mission.gameWorld.objects.droids[player].clear();
+			mission.gameWorld.objects.structures[player].clear();
+			mission.gameWorld.objects.flags[player].clear();
+			mission.gameWorld.objects.extractors[player].clear();
 		}
-		mission.worldObjectState.features[0].clear();
-		mission.worldObjectState.oils[0].clear();
-		mission.worldObjectState.sensors[0].clear();
+		mission.gameWorld.objects.features[0].clear();
+		mission.gameWorld.objects.oils[0].clear();
+		mission.gameWorld.objects.sensors[0].clear();
 
 		// Stuff added after level load to avoid being reset or initialised during load
 		// always !keepObjects
@@ -2929,7 +2929,7 @@ bool loadGame(const GameLoadDetails& gameToLoad, bool keepObjects, bool freeMem)
 			if (pl != selectedPlayer)
 			{
 				/* Structures */
-				for (STRUCTURE *psStr : worldObjectState.structures[pl])
+				for (STRUCTURE *psStr : gameWorld.objects.structures[pl])
 				{
 					if (selectedPlayer < MAX_PLAYERS && aiCheckAlliances(psStr->player, selectedPlayer))
 					{
@@ -2938,7 +2938,7 @@ bool loadGame(const GameLoadDetails& gameToLoad, bool keepObjects, bool freeMem)
 				}
 
 				/* Droids */
-				for (DROID *psDroid : worldObjectState.droids[pl])
+				for (DROID *psDroid : gameWorld.objects.droids[pl])
 				{
 					if (selectedPlayer < MAX_PLAYERS && aiCheckAlliances(psDroid->player, selectedPlayer))
 					{
@@ -3002,10 +3002,10 @@ bool loadGame(const GameLoadDetails& gameToLoad, bool keepObjects, bool freeMem)
 		//the scroll limits for the mission map have already been written
 		if (saveGameVersion >= VERSION_29)
 		{
-			missionScrollMinX = (UWORD)mission.worldMapState.scroll.minX;
-			missionScrollMinY = (UWORD)mission.worldMapState.scroll.minY;
-			missionScrollMaxX = (UWORD)mission.worldMapState.scroll.maxX;
-			missionScrollMaxY = (UWORD)mission.worldMapState.scroll.maxY;
+			missionScrollMinX = (UWORD)mission.gameWorld.map.scroll.minX;
+			missionScrollMinY = (UWORD)mission.gameWorld.map.scroll.minY;
+			missionScrollMaxX = (UWORD)mission.gameWorld.map.scroll.maxX;
+			missionScrollMaxY = (UWORD)mission.gameWorld.map.scroll.maxY;
 		}
 
 		//load the map and the droids then swap pointers
@@ -3079,15 +3079,15 @@ bool loadGame(const GameLoadDetails& gameToLoad, bool keepObjects, bool freeMem)
 		}
 		else
 		{
-			structMap[aFileName] = &mission.worldObjectState.structures;	// we swap pointers below
+			structMap[aFileName] = &mission.gameWorld.objects.structures;	// we swap pointers below
 		}
 
 		// load in the mission droids, if any
 		aFileName[fileExten] = '\0';
 		strcat(aFileName, "mdroid.json");
-		if (loadSaveDroid(aFileName, worldObjectState.droids))
+		if (loadSaveDroid(aFileName, gameWorld.objects.droids))
 		{
-			droidMap[aFileName] = &mission.worldObjectState.droids; // need to swap here to read correct list later
+			droidMap[aFileName] = &mission.gameWorld.objects.droids; // need to swap here to read correct list later
 		}
 
 		/* after we've loaded in the units we need to redo the orientation because
@@ -3096,7 +3096,7 @@ bool loadGame(const GameLoadDetails& gameToLoad, bool keepObjects, bool freeMem)
 		 */
 		for (player = 0; player < MAX_PLAYERS; ++player)
 		{
-			for (DROID* psCurr : worldObjectState.droids[player])
+			for (DROID* psCurr : gameWorld.objects.droids[player])
 			{
 				if (psCurr->droidType != DROID_PERSON
 				    // && psCurr->droidType != DROID_CYBORG
@@ -3114,17 +3114,17 @@ bool loadGame(const GameLoadDetails& gameToLoad, bool keepObjects, bool freeMem)
 		//once the mission map has been loaded reset the mission scroll limits
 		if (saveGameVersion >= VERSION_29)
 		{
-			mission.worldMapState.scroll.minX = missionScrollMinX;
-			mission.worldMapState.scroll.minY = missionScrollMinY;
-			mission.worldMapState.scroll.maxX = missionScrollMaxX;
-			mission.worldMapState.scroll.maxY = missionScrollMaxY;
+			mission.gameWorld.map.scroll.minX = missionScrollMinX;
+			mission.gameWorld.map.scroll.minY = missionScrollMinY;
+			mission.gameWorld.map.scroll.maxX = missionScrollMaxX;
+			mission.gameWorld.map.scroll.maxY = missionScrollMaxY;
 		}
 	}
 
 	//if Campaign Expand then don't load in another map
 	if (gameType != GTYPE_SCENARIO_EXPAND)
 	{
-		worldMapState.tiles = nullptr;
+		gameWorld.map.tiles = nullptr;
 		// load in the map file
 		if (!data)
 		{
@@ -3210,10 +3210,10 @@ bool loadGame(const GameLoadDetails& gameToLoad, bool keepObjects, bool freeMem)
 		}
 		else
 		{
-			if (loadSaveDroid(aFileName, worldObjectState.droids))
+			if (loadSaveDroid(aFileName, gameWorld.objects.droids))
 			{
 				debug(LOG_SAVE, "Loaded new style droids");
-				droidMap[aFileName] = &worldObjectState.droids;	// load pointers later
+				droidMap[aFileName] = &gameWorld.objects.droids;	// load pointers later
 			}
 		}
 	}
@@ -3224,12 +3224,12 @@ bool loadGame(const GameLoadDetails& gameToLoad, bool keepObjects, bool freeMem)
 		strcat(aFileName, "droid.json");
 
 		//load the data into apsDroidLists
-		if (!loadSaveDroid(aFileName, worldObjectState.droids))
+		if (!loadSaveDroid(aFileName, gameWorld.objects.droids))
 		{
 			debug(LOG_ERROR, "failed to load %s", aFileName);
 			goto error;
 		}
-		droidMap[aFileName] = &worldObjectState.droids;	// load pointers later
+		droidMap[aFileName] = &gameWorld.objects.droids;	// load pointers later
 
 		/* after we've loaded in the units we need to redo the orientation because
 		 * the direction may have been saved - we need to do it outside of the loop
@@ -3237,7 +3237,7 @@ bool loadGame(const GameLoadDetails& gameToLoad, bool keepObjects, bool freeMem)
 		 */
 		for (player = 0; player < MAX_PLAYERS; ++player)
 		{
-			for (DROID* psCurr : worldObjectState.droids[player])
+			for (DROID* psCurr : gameWorld.objects.droids[player])
 			{
 				if (psCurr->droidType != DROID_PERSON
 				    && !psCurr->isCyborg()
@@ -3255,9 +3255,9 @@ bool loadGame(const GameLoadDetails& gameToLoad, bool keepObjects, bool freeMem)
 			strcat(aFileName, "mdroid.json");
 
 			// load the data into mission.apsDroidLists, if any
-			if (loadSaveDroid(aFileName, mission.worldObjectState.droids))
+			if (loadSaveDroid(aFileName, mission.gameWorld.objects.droids))
 			{
-				droidMap[aFileName] = &mission.worldObjectState.droids;
+				droidMap[aFileName] = &mission.gameWorld.objects.droids;
 			}
 		}
 	}
@@ -3324,7 +3324,7 @@ bool loadGame(const GameLoadDetails& gameToLoad, bool keepObjects, bool freeMem)
 			debug(LOG_ERROR, "Failed with: %s", aFileName);
 			goto error;
 		}
-		structMap[aFileName] = &worldObjectState.structures;
+		structMap[aFileName] = &gameWorld.objects.structures;
 	}
 
 	//if user save game then load up the current level for structs and components
@@ -3475,7 +3475,7 @@ bool loadGame(const GameLoadDetails& gameToLoad, bool keepObjects, bool freeMem)
 			//Which later causes issues in saveCampaignData() which tries to extract
 			//the first transporter group sent off at Beta-end by reversing this very list.
 			ASSERT(selectedPlayer < MAX_PLAYERS, "selectedPlayer is out of bounds: %" PRIu32 "", selectedPlayer);
-			mission.worldObjectState.droids[selectedPlayer].reverse();
+			mission.gameWorld.objects.droids[selectedPlayer].reverse();
 		}
 	}
 
@@ -3500,7 +3500,7 @@ bool loadGame(const GameLoadDetails& gameToLoad, bool keepObjects, bool freeMem)
 		 * the day excuses...excuses...excuses
 		 */
 		ASSERT(selectedPlayer < MAX_PLAYERS, "selectedPlayer is out of bounds: %" PRIu32 "", selectedPlayer);
-		if (mission.worldObjectState.droids[selectedPlayer].empty())
+		if (mission.gameWorld.objects.droids[selectedPlayer].empty())
 		{
 			//set the mission type
 			startMissionSave(LEVEL_TYPE::LDS_EXPAND);
@@ -3531,7 +3531,7 @@ error:
 	freeAllStructs();
 	freeAllFeatures();
 	droidTemplateShutDown();
-	worldMapState.tiles = nullptr;
+	gameWorld.map.tiles = nullptr;
 
 	/* Start the game clock */
 	gameTimeStart();
@@ -3593,7 +3593,7 @@ bool saveGame(const char *aFileName, GAME_TYPE saveType, bool isAutoSave)
 	CurrentFileName[fileExtension] = '\0';
 	strcat(CurrentFileName, "droid.json");
 	/*Write the current droid lists to the file*/
-	if (!writeDroidFile(CurrentFileName, worldObjectState.droids))
+	if (!writeDroidFile(CurrentFileName, gameWorld.objects.droids))
 	{
 		debug(LOG_ERROR, "writeDroidFile(\"%s\") failed", CurrentFileName);
 		goto error;
@@ -3747,7 +3747,7 @@ bool saveGame(const char *aFileName, GAME_TYPE saveType, bool isAutoSave)
 	CurrentFileName[fileExtension] = '\0';
 	strcat(CurrentFileName, "mdroid.json");
 	/*Write the swapped droid lists to the file*/
-	if (!writeDroidFile(CurrentFileName, mission.worldObjectState.droids))
+	if (!writeDroidFile(CurrentFileName, mission.gameWorld.objects.droids))
 	{
 		debug(LOG_ERROR, "writeDroidFile(\"%s\") failed", CurrentFileName);
 		goto error;
@@ -4558,10 +4558,10 @@ bool gameLoadV(PHYSFS_file *fileHandle, unsigned int version, nonstd::optional<n
 
 	if (saveGameVersion >= VERSION_29)
 	{
-		mission.worldMapState.scroll.minX = saveGameData.missionScrollMinX;
-		mission.worldMapState.scroll.minY = saveGameData.missionScrollMinY;
-		mission.worldMapState.scroll.maxX = saveGameData.missionScrollMaxX;
-		mission.worldMapState.scroll.maxY = saveGameData.missionScrollMaxY;
+		mission.gameWorld.map.scroll.minX = saveGameData.missionScrollMinX;
+		mission.gameWorld.map.scroll.minY = saveGameData.missionScrollMinY;
+		mission.gameWorld.map.scroll.maxX = saveGameData.missionScrollMaxX;
+		mission.gameWorld.map.scroll.maxY = saveGameData.missionScrollMaxY;
 	}
 
 	if (saveGameVersion >= VERSION_31)
@@ -4836,8 +4836,8 @@ static bool writeMainFile(const std::string &fileName, SDWORD saveType)
 	save.setValue("campaignName", getCampaignName());
 	save.setValue("gameTime", gameTime);
 	save.setValue("missionTime", mission.startTime);
-	save.setVector2i("scrollMin", Vector2i(worldMapState.scroll.minX, worldMapState.scroll.minY));
-	save.setVector2i("scrollMax", Vector2i(worldMapState.scroll.maxX, worldMapState.scroll.maxY));
+	save.setVector2i("scrollMin", Vector2i(gameWorld.map.scroll.minX, gameWorld.map.scroll.minY));
+	save.setVector2i("scrollMax", Vector2i(gameWorld.map.scroll.maxX, gameWorld.map.scroll.maxY));
 	save.setValue("saveType", saveType);
 	ASSERT_OR_RETURN(false, strlen(aLevelName) < MAX_LEVEL_SIZE, "Unable to save level name - too long (max %d) - %s", (int)MAX_LEVEL_SIZE, aLevelName);
 	save.setValue("levelName", aLevelName);
@@ -4848,8 +4848,8 @@ static bool writeMainFile(const std::string &fileName, SDWORD saveType)
 	save.setValue("missionCheatTime", mission.cheatTime);
 	save.setVector2i("missionHomeLZ", Vector2i(mission.homeLZ_X, mission.homeLZ_Y));
 	save.setVector2i("missionPlayerPos", Vector2i(mission.playerX, mission.playerY));
-	save.setVector2i("missionScrollMin", Vector2i(mission.worldMapState.scroll.minX, mission.worldMapState.scroll.minY));
-	save.setVector2i("missionScrollMax", Vector2i(mission.worldMapState.scroll.maxX, mission.worldMapState.scroll.maxY));
+	save.setVector2i("missionScrollMin", Vector2i(mission.gameWorld.map.scroll.minX, mission.gameWorld.map.scroll.minY));
+	save.setVector2i("missionScrollMax", Vector2i(mission.gameWorld.map.scroll.maxX, mission.gameWorld.map.scroll.maxY));
 	save.setValue("offWorldKeepLists", offWorldKeepLists);
 	save.setValue("rubbleTile", getRubbleTileNum());
 	save.setValue("waterTile", getWaterTileNum());
@@ -5012,10 +5012,10 @@ static bool writeGameFile(const char *fileName, SDWORD saveType)
 	saveGame.missionTime = mission.startTime;
 
 	//put in the scroll data
-	saveGame.ScrollMinX = worldMapState.scroll.minX;
-	saveGame.ScrollMinY = worldMapState.scroll.minY;
-	saveGame.ScrollMaxX = worldMapState.scroll.maxX;
-	saveGame.ScrollMaxY = worldMapState.scroll.maxY;
+	saveGame.ScrollMinX = gameWorld.map.scroll.minX;
+	saveGame.ScrollMinY = gameWorld.map.scroll.minY;
+	saveGame.ScrollMaxX = gameWorld.map.scroll.maxX;
+	saveGame.ScrollMaxY = gameWorld.map.scroll.maxY;
 
 	saveGame.GameType = saveType;
 
@@ -5043,10 +5043,10 @@ static bool writeGameFile(const char *fileName, SDWORD saveType)
 	saveGame.missionHomeLZ_Y =		mission.homeLZ_Y;
 	saveGame.missionPlayerX =		mission.playerX;
 	saveGame.missionPlayerY =		mission.playerY;
-	saveGame.missionScrollMinX = (UWORD)mission.worldMapState.scroll.minX;
-	saveGame.missionScrollMinY = (UWORD)mission.worldMapState.scroll.minY;
-	saveGame.missionScrollMaxX = (UWORD)mission.worldMapState.scroll.maxX;
-	saveGame.missionScrollMaxY = (UWORD)mission.worldMapState.scroll.maxY;
+	saveGame.missionScrollMinX = (UWORD)mission.gameWorld.map.scroll.minX;
+	saveGame.missionScrollMinY = (UWORD)mission.gameWorld.map.scroll.minY;
+	saveGame.missionScrollMaxX = (UWORD)mission.gameWorld.map.scroll.maxX;
+	saveGame.missionScrollMaxY = (UWORD)mission.gameWorld.map.scroll.maxY;
 
 	saveGame.offWorldKeepLists = offWorldKeepLists;
 	saveGame.RubbleTile	= getRubbleTileNum();
@@ -5317,7 +5317,7 @@ static bool loadWzMapDroidInit(WzMap::Map &wzMap, std::unordered_map<UDWORD, UDW
 			scriptSetStartPos(psDroid->player, psDroid->pos.x, psDroid->pos.y);	// set map start position, FIXME - save properly elsewhere!
 		}
 
-		addDroid(psDroid, worldObjectState.droids);
+		addDroid(psDroid, gameWorld.objects.droids);
 	}
 	if (NumberOfSkippedDroids)
 	{
@@ -5442,7 +5442,7 @@ static bool loadSaveDroidPointers(const WzString &pFileName, PerPlayerDroidLists
 foundDroid:
 		if (!psDroid)
 		{
-			DROID* d = (DROID*)getBaseObjFromId(mission.worldObjectState.droids[player], id);
+			DROID* d = (DROID*)getBaseObjFromId(mission.gameWorld.objects.droids[player], id);
 			// FIXME
 			if (d)
 			{
@@ -5726,8 +5726,8 @@ static bool loadSaveDroid(const char *pFileName, PerPlayerDroidLists& ppsCurrent
 		// If droid is on a mission, calling with the saved position might cause an assertion. Or something like that.
 		if (!onMission)
 		{
-			pos.x = clip(pos.x, world_coord(1), world_coord(worldMapState.width - 1));
-			pos.y = clip(pos.y, world_coord(1), world_coord(worldMapState.height - 1));
+			pos.x = clip(pos.x, world_coord(1), world_coord(gameWorld.map.width - 1));
+			pos.y = clip(pos.y, world_coord(1), world_coord(gameWorld.map.height - 1));
 		}
 
 		/* Create the Droid */
@@ -6102,7 +6102,7 @@ static bool writeDroidFile(const char *pFileName, const PerPlayerDroidLists& pps
 {
 	nlohmann::json mRoot = nlohmann::json::object();
 	int counter = 0;
-	bool onMission = (&ppsCurrentDroidLists == &mission.worldObjectState.droids);
+	bool onMission = (&ppsCurrentDroidLists == &mission.gameWorld.objects.droids);
 
 	for (int player = 0; player < MAX_PLAYERS; player++)
 	{
@@ -6124,7 +6124,7 @@ static bool writeDroidFile(const char *pFileName, const PerPlayerDroidLists& pps
 					}
 				}
 				//always save transporter droids that are in the mission list with an invalid value
-				if (&ppsCurrentDroidLists[player] == &mission.worldObjectState.droids[player])
+				if (&ppsCurrentDroidLists[player] == &mission.gameWorld.objects.droids[player])
 				{
 					mRoot[droidKey.toStdString()]["position"] = Vector3i(INVALID_XY, INVALID_XY, -1); // Must be INVALID_XY or else unit placement could get messed up in missionResetDroids().
 				}
@@ -6251,13 +6251,13 @@ bool loadSaveStructure(char *pFileData, UDWORD filesize)
 		}
 
 		//check not trying to build too near the edge
-		if (map_coord(psSaveStructure->x) < TOO_NEAR_EDGE || map_coord(psSaveStructure->x) > worldMapState.width - TOO_NEAR_EDGE)
+		if (map_coord(psSaveStructure->x) < TOO_NEAR_EDGE || map_coord(psSaveStructure->x) > gameWorld.map.width - TOO_NEAR_EDGE)
 		{
 			debug(LOG_ERROR, "Structure %s, x coord too near the edge of the map. id - %d", getSaveStructNameV19((SAVE_STRUCTURE_V17 *)psSaveStructure), psSaveStructure->id);
 			//ignore this
 			continue;
 		}
-		if (map_coord(psSaveStructure->y) < TOO_NEAR_EDGE || map_coord(psSaveStructure->y) > worldMapState.height - TOO_NEAR_EDGE)
+		if (map_coord(psSaveStructure->y) < TOO_NEAR_EDGE || map_coord(psSaveStructure->y) > gameWorld.map.height - TOO_NEAR_EDGE)
 		{
 			debug(LOG_ERROR, "Structure %s, y coord too near the edge of the map. id - %d", getSaveStructNameV19((SAVE_STRUCTURE_V17 *)psSaveStructure), psSaveStructure->id);
 			//ignore this
@@ -6340,8 +6340,8 @@ static bool loadWzMapStructure(WzMap::Map& wzMap, std::unordered_map<UDWORD, UDW
 			}
 		}
 		//check not trying to build too near the edge
-		if (map_coord(structure.position.x) < TOO_NEAR_EDGE || map_coord(structure.position.x) > worldMapState.width - TOO_NEAR_EDGE
-		 || map_coord(structure.position.y) < TOO_NEAR_EDGE || map_coord(structure.position.y) > worldMapState.height - TOO_NEAR_EDGE)
+		if (map_coord(structure.position.x) < TOO_NEAR_EDGE || map_coord(structure.position.x) > gameWorld.map.width - TOO_NEAR_EDGE
+		 || map_coord(structure.position.y) < TOO_NEAR_EDGE || map_coord(structure.position.y) > gameWorld.map.height - TOO_NEAR_EDGE)
 		{
 			debug(LOG_ERROR, "Structure %s, coord too near the edge of the map", structure.name.c_str());
 			continue; // skip it
@@ -6477,8 +6477,8 @@ static bool loadSaveStructure2(const char *pFileName)
 			}
 		}
 		//check not trying to build too near the edge
-		if (map_coord(pos.x) < TOO_NEAR_EDGE || map_coord(pos.x) > worldMapState.width - TOO_NEAR_EDGE
-		    || map_coord(pos.y) < TOO_NEAR_EDGE || map_coord(pos.y) > worldMapState.height - TOO_NEAR_EDGE)
+		if (map_coord(pos.x) < TOO_NEAR_EDGE || map_coord(pos.x) > gameWorld.map.width - TOO_NEAR_EDGE
+		    || map_coord(pos.y) < TOO_NEAR_EDGE || map_coord(pos.y) > gameWorld.map.height - TOO_NEAR_EDGE)
 		{
 			debug(LOG_ERROR, "Structure %s (%s), coord too near the edge of the map", name.toUtf8().c_str(), list[i].toUtf8().c_str());
 			ini.endGroup();
@@ -6718,7 +6718,7 @@ bool writeStructFile(const char *pFileName)
 
 	for (int player = 0; player < MAX_PLAYERS; player++)
 	{
-		for (const STRUCTURE *psCurr : worldObjectState.structures[player])
+		for (const STRUCTURE *psCurr : gameWorld.objects.structures[player])
 		{
 			if (!psCurr->pStructureType)
 			{
@@ -6923,7 +6923,7 @@ bool loadSaveStructurePointers(const WzString& filename, PerPlayerStructureLists
 				{
 					DROID *psCommander = (DROID *)getBaseObjFromData(tid, tplayer, ttype);
 					ASSERT(psCommander, "Commander %d not found for building %d", tid, id);
-					if (ppList == &mission.worldObjectState.structures)
+					if (ppList == &mission.gameWorld.objects.structures)
 					{
 						psFactory->psCommander = psCommander;
 					}
@@ -7219,7 +7219,7 @@ bool writeFeatureFile(const char *pFileName)
 	WzConfig ini(WzString::fromUtf8(pFileName), WzConfig::ReadAndWrite);
 	int counter = 0;
 
-	for (const FEATURE *psCurr : worldObjectState.features[0])
+	for (const FEATURE *psCurr : gameWorld.objects.features[0])
 	{
 		ini.beginGroup("feature_" + (WzString::number(counter++).leftPadToMinimumLength(WzUniCodepoint::fromASCII('0'), 10)));  // Zero padded so that alphabetical sort works.
 		ini.setValue("name", psCurr->psStats->id);
@@ -7307,7 +7307,7 @@ bool writeTemplateFile(const char *pFileName)
 	mRoot["version"] = 1;
 	for (int player = 0; player < MAX_PLAYERS; player++)
 	{
-		if (worldObjectState.droids[player].empty() && worldObjectState.structures[player].empty())	// only write out templates of players that are still 'alive'
+		if (gameWorld.objects.droids[player].empty() && gameWorld.objects.structures[player].empty())	// only write out templates of players that are still 'alive'
 		{
 			continue;
 		}
@@ -7631,11 +7631,11 @@ void loadFixupResearchPendingStates()
 			// - (Ideally the game would prevent this from happening by ensuring the save is queued to happen after the next tick...)
 			if (pPlayerRes->ResearchStatus & CANCELLED_RESEARCH_PENDING)
 			{
-				STRUCTURE *psLab = findResearchingFacilityByResearchIndex(worldObjectState.structures, plr, statInc);
+				STRUCTURE *psLab = findResearchingFacilityByResearchIndex(gameWorld.objects.structures, plr, statInc);
 				if (psLab == nullptr)
 				{
 					// check the mission list
-					psLab = findResearchingFacilityByResearchIndex(mission.worldObjectState.structures, plr, statInc);
+					psLab = findResearchingFacilityByResearchIndex(mission.gameWorld.objects.structures, plr, statInc);
 				}
 
 				if (psLab != nullptr)
@@ -7871,7 +7871,7 @@ bool loadSaveMessage(const char* pFileName, LEVEL_TYPE levelType)
 						{
 							psMessage->pViewData = psViewData;
 							// Check the z value is at least the height of the terrain
-							const int terrainHeight = map_Height(worldMapState, ((VIEW_PROXIMITY*)psViewData->pData)->x, ((VIEW_PROXIMITY*)psViewData->pData)->y);
+							const int terrainHeight = map_Height(gameWorld.map, ((VIEW_PROXIMITY*)psViewData->pData)->x, ((VIEW_PROXIMITY*)psViewData->pData)->y);
 							if (((VIEW_PROXIMITY*)psViewData->pData)->z < terrainHeight)
 							{
 								((VIEW_PROXIMITY*)psViewData->pData)->z = terrainHeight;
@@ -8212,39 +8212,39 @@ static void setMapScroll()
 	//if loading in a pre version5 then scroll values will not have been set up so set to max poss
 	if (width == 0 && height == 0)
 	{
-		worldMapState.scroll.minX = 0;
-		worldMapState.scroll.maxX = worldMapState.width;
-		worldMapState.scroll.minY = 0;
-		worldMapState.scroll.maxY = worldMapState.height;
+		gameWorld.map.scroll.minX = 0;
+		gameWorld.map.scroll.maxX = gameWorld.map.width;
+		gameWorld.map.scroll.minY = 0;
+		gameWorld.map.scroll.maxY = gameWorld.map.height;
 		return;
 	}
-	worldMapState.scroll.minX = startX;
-	worldMapState.scroll.minY = startY;
-	worldMapState.scroll.maxX = startX + width;
-	worldMapState.scroll.maxY = startY + height;
+	gameWorld.map.scroll.minX = startX;
+	gameWorld.map.scroll.minY = startY;
+	gameWorld.map.scroll.maxX = startX + width;
+	gameWorld.map.scroll.maxY = startY + height;
 	//check not going beyond width/height of map
-	if (worldMapState.scroll.maxX > (SDWORD)worldMapState.width)
+	if (gameWorld.map.scroll.maxX > (SDWORD)gameWorld.map.width)
 	{
-		worldMapState.scroll.maxX = worldMapState.width;
+		gameWorld.map.scroll.maxX = gameWorld.map.width;
 		debug(LOG_NEVER, "scrollMaxX was too big - It has been set to map width");
 	}
-	if (worldMapState.scroll.maxY > (SDWORD)worldMapState.height)
+	if (gameWorld.map.scroll.maxY > (SDWORD)gameWorld.map.height)
 	{
-		worldMapState.scroll.maxY = worldMapState.height;
+		gameWorld.map.scroll.maxY = gameWorld.map.height;
 		debug(LOG_NEVER, "scrollMaxY was too big - It has been set to map height");
 	}
 	// check for invalid minimum values (fixes some broken maps)
-	if (worldMapState.scroll.minX >= worldMapState.scroll.maxX)
+	if (gameWorld.map.scroll.minX >= gameWorld.map.scroll.maxX)
 	{
 		ASSERT(false, "scrollMinX was >= scrollMaxX - min has been set to 0, max has been set to mapWidth");
-		worldMapState.scroll.minX = 0;
-		worldMapState.scroll.maxX = worldMapState.width;
+		gameWorld.map.scroll.minX = 0;
+		gameWorld.map.scroll.maxX = gameWorld.map.width;
 	}
-	if (worldMapState.scroll.minY >= worldMapState.scroll.maxY)
+	if (gameWorld.map.scroll.minY >= gameWorld.map.scroll.maxY)
 	{
 		ASSERT(false, "scrollMinY was >= scrollMaxY - min has been set to 0, max has been set to mapHeight");
-		worldMapState.scroll.minY = 0;
-		worldMapState.scroll.maxY = worldMapState.height;
+		gameWorld.map.scroll.minY = 0;
+		gameWorld.map.scroll.maxY = gameWorld.map.height;
 	}
 }
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -7871,7 +7871,7 @@ bool loadSaveMessage(const char* pFileName, LEVEL_TYPE levelType)
 						{
 							psMessage->pViewData = psViewData;
 							// Check the z value is at least the height of the terrain
-							const int terrainHeight = map_Height(((VIEW_PROXIMITY*)psViewData->pData)->x, ((VIEW_PROXIMITY*)psViewData->pData)->y);
+							const int terrainHeight = map_Height(worldMapState, ((VIEW_PROXIMITY*)psViewData->pData)->x, ((VIEW_PROXIMITY*)psViewData->pData)->y);
 							if (((VIEW_PROXIMITY*)psViewData->pData)->z < terrainHeight)
 							{
 								((VIEW_PROXIMITY*)psViewData->pData)->z = terrainHeight;

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -101,6 +101,7 @@
 #include "keybind.h"
 #include "loop.h"
 #include "screens/guidescreen.h"
+#include "world_object_state.h"
 #include <array>
 
 #include "wzphysfszipioprovider.h"
@@ -2413,7 +2414,7 @@ static void sanityUpdate()
 {
 	for (int player = 0; player < game.maxPlayers; player++)
 	{
-		for (DROID *psDroid : apsDroidLists[player])
+		for (DROID *psDroid : worldObjectState.droids[player])
 		{
 			orderCheckList(psDroid);
 			actionSanity(psDroid);
@@ -2701,16 +2702,16 @@ bool loadGame(const GameLoadDetails& gameToLoad, bool keepObjects, bool freeMem)
 		//initialise the lists
 		for (player = 0; player < MAX_PLAYERS; player++)
 		{
-			apsDroidLists[player].clear();
-			apsStructLists[player].clear();
-			apsFlagPosLists[player].clear();
+			worldObjectState.droids[player].clear();
+			worldObjectState.structures[player].clear();
+			worldObjectState.flags[player].clear();
 			//clear all the messages?
 			apsProxDisp[player].clear();
-			apsExtractorLists[player].clear();
+			worldObjectState.extractors[player].clear();
 		}
-		apsFeatureList[0].clear();
-		apsOilList[0].clear();
-		apsSensorList[0].clear();
+		worldObjectState.features[0].clear();
+		worldObjectState.oils[0].clear();
+		worldObjectState.sensors[0].clear();
 		initFactoryNumFlag();
 	}
 
@@ -2720,14 +2721,14 @@ bool loadGame(const GameLoadDetails& gameToLoad, bool keepObjects, bool freeMem)
 		for (player = 0; player < MAX_PLAYERS; player++)
 		{
 			apsLimboDroids[player].clear();
-			mission.apsDroidLists[player].clear();
-			mission.apsStructLists[player].clear();
-			mission.apsFlagPosLists[player].clear();
-			mission.apsExtractorLists[player].clear();
+			mission.worldObjectState.droids[player].clear();
+			mission.worldObjectState.structures[player].clear();
+			mission.worldObjectState.flags[player].clear();
+			mission.worldObjectState.extractors[player].clear();
 		}
-		mission.apsFeatureList[0].clear();
-		mission.apsOilList[0].clear();
-		mission.apsSensorList[0].clear();
+		mission.worldObjectState.features[0].clear();
+		mission.worldObjectState.oils[0].clear();
+		mission.worldObjectState.sensors[0].clear();
 
 		// Stuff added after level load to avoid being reset or initialised during load
 		// always !keepObjects
@@ -2928,7 +2929,7 @@ bool loadGame(const GameLoadDetails& gameToLoad, bool keepObjects, bool freeMem)
 			if (pl != selectedPlayer)
 			{
 				/* Structures */
-				for (STRUCTURE *psStr : apsStructLists[pl])
+				for (STRUCTURE *psStr : worldObjectState.structures[pl])
 				{
 					if (selectedPlayer < MAX_PLAYERS && aiCheckAlliances(psStr->player, selectedPlayer))
 					{
@@ -2937,7 +2938,7 @@ bool loadGame(const GameLoadDetails& gameToLoad, bool keepObjects, bool freeMem)
 				}
 
 				/* Droids */
-				for (DROID *psDroid : apsDroidLists[pl])
+				for (DROID *psDroid : worldObjectState.droids[pl])
 				{
 					if (selectedPlayer < MAX_PLAYERS && aiCheckAlliances(psDroid->player, selectedPlayer))
 					{
@@ -3078,15 +3079,15 @@ bool loadGame(const GameLoadDetails& gameToLoad, bool keepObjects, bool freeMem)
 		}
 		else
 		{
-			structMap[aFileName] = &mission.apsStructLists;	// we swap pointers below
+			structMap[aFileName] = &mission.worldObjectState.structures;	// we swap pointers below
 		}
 
 		// load in the mission droids, if any
 		aFileName[fileExten] = '\0';
 		strcat(aFileName, "mdroid.json");
-		if (loadSaveDroid(aFileName, apsDroidLists))
+		if (loadSaveDroid(aFileName, worldObjectState.droids))
 		{
-			droidMap[aFileName] = &mission.apsDroidLists; // need to swap here to read correct list later
+			droidMap[aFileName] = &mission.worldObjectState.droids; // need to swap here to read correct list later
 		}
 
 		/* after we've loaded in the units we need to redo the orientation because
@@ -3095,7 +3096,7 @@ bool loadGame(const GameLoadDetails& gameToLoad, bool keepObjects, bool freeMem)
 		 */
 		for (player = 0; player < MAX_PLAYERS; ++player)
 		{
-			for (DROID* psCurr : apsDroidLists[player])
+			for (DROID* psCurr : worldObjectState.droids[player])
 			{
 				if (psCurr->droidType != DROID_PERSON
 				    // && psCurr->droidType != DROID_CYBORG
@@ -3209,10 +3210,10 @@ bool loadGame(const GameLoadDetails& gameToLoad, bool keepObjects, bool freeMem)
 		}
 		else
 		{
-			if (loadSaveDroid(aFileName, apsDroidLists))
+			if (loadSaveDroid(aFileName, worldObjectState.droids))
 			{
 				debug(LOG_SAVE, "Loaded new style droids");
-				droidMap[aFileName] = &apsDroidLists;	// load pointers later
+				droidMap[aFileName] = &worldObjectState.droids;	// load pointers later
 			}
 		}
 	}
@@ -3223,12 +3224,12 @@ bool loadGame(const GameLoadDetails& gameToLoad, bool keepObjects, bool freeMem)
 		strcat(aFileName, "droid.json");
 
 		//load the data into apsDroidLists
-		if (!loadSaveDroid(aFileName, apsDroidLists))
+		if (!loadSaveDroid(aFileName, worldObjectState.droids))
 		{
 			debug(LOG_ERROR, "failed to load %s", aFileName);
 			goto error;
 		}
-		droidMap[aFileName] = &apsDroidLists;	// load pointers later
+		droidMap[aFileName] = &worldObjectState.droids;	// load pointers later
 
 		/* after we've loaded in the units we need to redo the orientation because
 		 * the direction may have been saved - we need to do it outside of the loop
@@ -3236,7 +3237,7 @@ bool loadGame(const GameLoadDetails& gameToLoad, bool keepObjects, bool freeMem)
 		 */
 		for (player = 0; player < MAX_PLAYERS; ++player)
 		{
-			for (DROID* psCurr : apsDroidLists[player])
+			for (DROID* psCurr : worldObjectState.droids[player])
 			{
 				if (psCurr->droidType != DROID_PERSON
 				    && !psCurr->isCyborg()
@@ -3254,9 +3255,9 @@ bool loadGame(const GameLoadDetails& gameToLoad, bool keepObjects, bool freeMem)
 			strcat(aFileName, "mdroid.json");
 
 			// load the data into mission.apsDroidLists, if any
-			if (loadSaveDroid(aFileName, mission.apsDroidLists))
+			if (loadSaveDroid(aFileName, mission.worldObjectState.droids))
 			{
-				droidMap[aFileName] = &mission.apsDroidLists;
+				droidMap[aFileName] = &mission.worldObjectState.droids;
 			}
 		}
 	}
@@ -3323,7 +3324,7 @@ bool loadGame(const GameLoadDetails& gameToLoad, bool keepObjects, bool freeMem)
 			debug(LOG_ERROR, "Failed with: %s", aFileName);
 			goto error;
 		}
-		structMap[aFileName] = &apsStructLists;
+		structMap[aFileName] = &worldObjectState.structures;
 	}
 
 	//if user save game then load up the current level for structs and components
@@ -3474,7 +3475,7 @@ bool loadGame(const GameLoadDetails& gameToLoad, bool keepObjects, bool freeMem)
 			//Which later causes issues in saveCampaignData() which tries to extract
 			//the first transporter group sent off at Beta-end by reversing this very list.
 			ASSERT(selectedPlayer < MAX_PLAYERS, "selectedPlayer is out of bounds: %" PRIu32 "", selectedPlayer);
-			mission.apsDroidLists[selectedPlayer].reverse();
+			mission.worldObjectState.droids[selectedPlayer].reverse();
 		}
 	}
 
@@ -3499,7 +3500,7 @@ bool loadGame(const GameLoadDetails& gameToLoad, bool keepObjects, bool freeMem)
 		 * the day excuses...excuses...excuses
 		 */
 		ASSERT(selectedPlayer < MAX_PLAYERS, "selectedPlayer is out of bounds: %" PRIu32 "", selectedPlayer);
-		if (mission.apsDroidLists[selectedPlayer].empty())
+		if (mission.worldObjectState.droids[selectedPlayer].empty())
 		{
 			//set the mission type
 			startMissionSave(LEVEL_TYPE::LDS_EXPAND);
@@ -3592,7 +3593,7 @@ bool saveGame(const char *aFileName, GAME_TYPE saveType, bool isAutoSave)
 	CurrentFileName[fileExtension] = '\0';
 	strcat(CurrentFileName, "droid.json");
 	/*Write the current droid lists to the file*/
-	if (!writeDroidFile(CurrentFileName, apsDroidLists))
+	if (!writeDroidFile(CurrentFileName, worldObjectState.droids))
 	{
 		debug(LOG_ERROR, "writeDroidFile(\"%s\") failed", CurrentFileName);
 		goto error;
@@ -3746,7 +3747,7 @@ bool saveGame(const char *aFileName, GAME_TYPE saveType, bool isAutoSave)
 	CurrentFileName[fileExtension] = '\0';
 	strcat(CurrentFileName, "mdroid.json");
 	/*Write the swapped droid lists to the file*/
-	if (!writeDroidFile(CurrentFileName, mission.apsDroidLists))
+	if (!writeDroidFile(CurrentFileName, mission.worldObjectState.droids))
 	{
 		debug(LOG_ERROR, "writeDroidFile(\"%s\") failed", CurrentFileName);
 		goto error;
@@ -5316,7 +5317,7 @@ static bool loadWzMapDroidInit(WzMap::Map &wzMap, std::unordered_map<UDWORD, UDW
 			scriptSetStartPos(psDroid->player, psDroid->pos.x, psDroid->pos.y);	// set map start position, FIXME - save properly elsewhere!
 		}
 
-		addDroid(psDroid, apsDroidLists);
+		addDroid(psDroid, worldObjectState.droids);
 	}
 	if (NumberOfSkippedDroids)
 	{
@@ -5441,7 +5442,7 @@ static bool loadSaveDroidPointers(const WzString &pFileName, PerPlayerDroidLists
 foundDroid:
 		if (!psDroid)
 		{
-			DROID* d = (DROID*)getBaseObjFromId(mission.apsDroidLists[player], id);
+			DROID* d = (DROID*)getBaseObjFromId(mission.worldObjectState.droids[player], id);
 			// FIXME
 			if (d)
 			{
@@ -6101,7 +6102,7 @@ static bool writeDroidFile(const char *pFileName, const PerPlayerDroidLists& pps
 {
 	nlohmann::json mRoot = nlohmann::json::object();
 	int counter = 0;
-	bool onMission = (&ppsCurrentDroidLists == &mission.apsDroidLists);
+	bool onMission = (&ppsCurrentDroidLists == &mission.worldObjectState.droids);
 
 	for (int player = 0; player < MAX_PLAYERS; player++)
 	{
@@ -6123,7 +6124,7 @@ static bool writeDroidFile(const char *pFileName, const PerPlayerDroidLists& pps
 					}
 				}
 				//always save transporter droids that are in the mission list with an invalid value
-				if (&ppsCurrentDroidLists[player] == &mission.apsDroidLists[player])
+				if (&ppsCurrentDroidLists[player] == &mission.worldObjectState.droids[player])
 				{
 					mRoot[droidKey.toStdString()]["position"] = Vector3i(INVALID_XY, INVALID_XY, -1); // Must be INVALID_XY or else unit placement could get messed up in missionResetDroids().
 				}
@@ -6717,7 +6718,7 @@ bool writeStructFile(const char *pFileName)
 
 	for (int player = 0; player < MAX_PLAYERS; player++)
 	{
-		for (const STRUCTURE *psCurr : apsStructLists[player])
+		for (const STRUCTURE *psCurr : worldObjectState.structures[player])
 		{
 			if (!psCurr->pStructureType)
 			{
@@ -6922,7 +6923,7 @@ bool loadSaveStructurePointers(const WzString& filename, PerPlayerStructureLists
 				{
 					DROID *psCommander = (DROID *)getBaseObjFromData(tid, tplayer, ttype);
 					ASSERT(psCommander, "Commander %d not found for building %d", tid, id);
-					if (ppList == &mission.apsStructLists)
+					if (ppList == &mission.worldObjectState.structures)
 					{
 						psFactory->psCommander = psCommander;
 					}
@@ -7218,7 +7219,7 @@ bool writeFeatureFile(const char *pFileName)
 	WzConfig ini(WzString::fromUtf8(pFileName), WzConfig::ReadAndWrite);
 	int counter = 0;
 
-	for (const FEATURE *psCurr : apsFeatureList[0])
+	for (const FEATURE *psCurr : worldObjectState.features[0])
 	{
 		ini.beginGroup("feature_" + (WzString::number(counter++).leftPadToMinimumLength(WzUniCodepoint::fromASCII('0'), 10)));  // Zero padded so that alphabetical sort works.
 		ini.setValue("name", psCurr->psStats->id);
@@ -7306,7 +7307,7 @@ bool writeTemplateFile(const char *pFileName)
 	mRoot["version"] = 1;
 	for (int player = 0; player < MAX_PLAYERS; player++)
 	{
-		if (apsDroidLists[player].empty() && apsStructLists[player].empty())	// only write out templates of players that are still 'alive'
+		if (worldObjectState.droids[player].empty() && worldObjectState.structures[player].empty())	// only write out templates of players that are still 'alive'
 		{
 			continue;
 		}
@@ -7630,11 +7631,11 @@ void loadFixupResearchPendingStates()
 			// - (Ideally the game would prevent this from happening by ensuring the save is queued to happen after the next tick...)
 			if (pPlayerRes->ResearchStatus & CANCELLED_RESEARCH_PENDING)
 			{
-				STRUCTURE *psLab = findResearchingFacilityByResearchIndex(apsStructLists, plr, statInc);
+				STRUCTURE *psLab = findResearchingFacilityByResearchIndex(worldObjectState.structures, plr, statInc);
 				if (psLab == nullptr)
 				{
 					// check the mission list
-					psLab = findResearchingFacilityByResearchIndex(mission.apsStructLists, plr, statInc);
+					psLab = findResearchingFacilityByResearchIndex(mission.worldObjectState.structures, plr, statInc);
 				}
 
 				if (psLab != nullptr)

--- a/src/game_world.cpp
+++ b/src/game_world.cpp
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+/*
+	This file is part of Warzone 2100.
+	Copyright (C) 2026  Warzone 2100 Project (https://github.com/Warzone2100)
+
+	Warzone 2100 is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+
+	Warzone 2100 is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with Warzone 2100; if not, write to the Free Software
+	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+/** \file
+ *  Game world state implementation.
+ */
+#include "game_world.h"
+
+GameWorld gameWorld;

--- a/src/game_world.h
+++ b/src/game_world.h
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+/*
+	This file is part of Warzone 2100.
+	Copyright (C) 2026  Warzone 2100 Project (https://github.com/Warzone2100)
+
+	Warzone 2100 is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+
+	Warzone 2100 is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with Warzone 2100; if not, write to the Free Software
+	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+/** \file
+ *  Game world state (map + objects).
+ */
+#pragma once
+
+#include "world_map_state.h"
+#include "world_object_state.h"
+
+#include <string>
+
+/// <summary>
+/// A simple wrapper around the map and object state for the current active level.
+/// </summary>
+struct GameWorld
+{
+	WorldMapState map;
+	WorldObjectState objects;
+	std::string name;
+};
+
+/// The global game world, which holds both map and object state for the current active level.
+extern GameWorld gameWorld;

--- a/src/gamehistorylogger.cpp
+++ b/src/gamehistorylogger.cpp
@@ -91,7 +91,7 @@ static std::tuple<uint32_t, uint32_t> getDroidHPPercentageAndExperience(uint32_t
 	uint64_t totalHP = 0;
 	uint64_t totalExp = 0;
 	uint64_t numDroids = 0;
-	for (const DROID *psDroid : worldObjectState.droids[player])
+	for (const DROID *psDroid : gameWorld.objects.droids[player])
 	{
 		if (psDroid->died)
 		{
@@ -115,7 +115,7 @@ static uint32_t getNumOilRigs(uint32_t player)
 	}
 
 	uint32_t result = 0;
-	for (const STRUCTURE *psStruct : worldObjectState.structures[player])
+	for (const STRUCTURE *psStruct : gameWorld.objects.structures[player])
 	{
 		if (!psStruct->died
 			&& (REF_RESOURCE_EXTRACTOR == psStruct->pStructureType->type))

--- a/src/gamehistorylogger.cpp
+++ b/src/gamehistorylogger.cpp
@@ -91,7 +91,7 @@ static std::tuple<uint32_t, uint32_t> getDroidHPPercentageAndExperience(uint32_t
 	uint64_t totalHP = 0;
 	uint64_t totalExp = 0;
 	uint64_t numDroids = 0;
-	for (const DROID *psDroid : apsDroidLists[player])
+	for (const DROID *psDroid : worldObjectState.droids[player])
 	{
 		if (psDroid->died)
 		{
@@ -115,7 +115,7 @@ static uint32_t getNumOilRigs(uint32_t player)
 	}
 
 	uint32_t result = 0;
-	for (const STRUCTURE *psStruct : apsStructLists[player])
+	for (const STRUCTURE *psStruct : worldObjectState.structures[player])
 	{
 		if (!psStruct->died
 			&& (REF_RESOURCE_EXTRACTOR == psStruct->pStructureType->type))

--- a/src/gateway.cpp
+++ b/src/gateway.cpp
@@ -30,6 +30,7 @@
 #include "wrappers.h"
 
 #include "gateway.h"
+#include "game_world.h"
 
 /// the list of gateways on the current map
 static GATEWAY_LIST psGateways;
@@ -43,24 +44,24 @@ static void gwFreeGateway(GATEWAY *psDel);
 // get the size of the map
 static SDWORD gwMapWidth()
 {
-	return (SDWORD)worldMapState.width;
+	return (SDWORD)gameWorld.map.width;
 }
 
 static SDWORD gwMapHeight()
 {
-	return (SDWORD)worldMapState.height;
+	return (SDWORD)gameWorld.map.height;
 }
 
 // set the gateway flag on a tile
 static void gwSetGatewayFlag(SDWORD x, SDWORD y)
 {
-	mapTile(worldMapState, (UDWORD)x, (UDWORD)y)->tileInfoBits |= BITS_GATEWAY;
+	mapTile(gameWorld.map, (UDWORD)x, (UDWORD)y)->tileInfoBits |= BITS_GATEWAY;
 }
 
 // clear the gateway flag on a tile
 static void gwClearGatewayFlag(SDWORD x, SDWORD y)
 {
-	mapTile(worldMapState, (UDWORD)x, (UDWORD)y)->tileInfoBits &= ~BITS_GATEWAY;
+	mapTile(gameWorld.map, (UDWORD)x, (UDWORD)y)->tileInfoBits &= ~BITS_GATEWAY;
 }
 
 
@@ -115,8 +116,8 @@ bool gwNewGateway(SDWORD x1, SDWORD y1, SDWORD x2, SDWORD y2)
 	// Initialise the gateway, correct out-of-map gateways
 	psNew->x1 = MAX(3, x1);
 	psNew->y1 = MAX(3, y1);
-	psNew->x2 = MIN(x2, worldMapState.width - 4);
-	psNew->y2 = MIN(y2, worldMapState.height - 4);
+	psNew->x2 = MIN(x2, gameWorld.map.width - 4);
+	psNew->y2 = MIN(y2, gameWorld.map.height - 4);
 
 	// add the gateway to the list
 	psGateways.push_back(psNew);
@@ -158,7 +159,7 @@ static void gwFreeGateway(GATEWAY *psDel)
 {
 	int pos;
 
-	if (worldMapState.tiles) // this lines fixes the bug where we were closing the gateways after freeing the map
+	if (gameWorld.map.tiles) // this lines fixes the bug where we were closing the gateways after freeing the map
 	{
 		// clear the map flags
 		if (psDel->x1 == psDel->x2)

--- a/src/gateway.cpp
+++ b/src/gateway.cpp
@@ -54,13 +54,13 @@ static SDWORD gwMapHeight()
 // set the gateway flag on a tile
 static void gwSetGatewayFlag(SDWORD x, SDWORD y)
 {
-	mapTile((UDWORD)x, (UDWORD)y)->tileInfoBits |= BITS_GATEWAY;
+	mapTile(worldMapState, (UDWORD)x, (UDWORD)y)->tileInfoBits |= BITS_GATEWAY;
 }
 
 // clear the gateway flag on a tile
 static void gwClearGatewayFlag(SDWORD x, SDWORD y)
 {
-	mapTile((UDWORD)x, (UDWORD)y)->tileInfoBits &= ~BITS_GATEWAY;
+	mapTile(worldMapState, (UDWORD)x, (UDWORD)y)->tileInfoBits &= ~BITS_GATEWAY;
 }
 
 

--- a/src/gateway.cpp
+++ b/src/gateway.cpp
@@ -43,12 +43,12 @@ static void gwFreeGateway(GATEWAY *psDel);
 // get the size of the map
 static SDWORD gwMapWidth()
 {
-	return (SDWORD)mapWidth;
+	return (SDWORD)worldMapState.width;
 }
 
 static SDWORD gwMapHeight()
 {
-	return (SDWORD)mapHeight;
+	return (SDWORD)worldMapState.height;
 }
 
 // set the gateway flag on a tile
@@ -115,8 +115,8 @@ bool gwNewGateway(SDWORD x1, SDWORD y1, SDWORD x2, SDWORD y2)
 	// Initialise the gateway, correct out-of-map gateways
 	psNew->x1 = MAX(3, x1);
 	psNew->y1 = MAX(3, y1);
-	psNew->x2 = MIN(x2, mapWidth - 4);
-	psNew->y2 = MIN(y2, mapHeight - 4);
+	psNew->x2 = MIN(x2, worldMapState.width - 4);
+	psNew->y2 = MIN(y2, worldMapState.height - 4);
 
 	// add the gateway to the list
 	psGateways.push_back(psNew);
@@ -158,7 +158,7 @@ static void gwFreeGateway(GATEWAY *psDel)
 {
 	int pos;
 
-	if (psMapTiles) // this lines fixes the bug where we were closing the gateways after freeing the map
+	if (worldMapState.tiles) // this lines fixes the bug where we were closing the gateways after freeing the map
 	{
 		// clear the map flags
 		if (psDel->x1 == psDel->x2)

--- a/src/gateway.h
+++ b/src/gateway.h
@@ -24,9 +24,13 @@
 #ifndef __INCLUDED_SRC_GATEWAY_H__
 #define __INCLUDED_SRC_GATEWAY_H__
 
+#include <list>
+
+#include <stdint.h>
+
 struct GATEWAY
 {
-	UBYTE x1, y1, x2, y2;
+	uint8_t x1, y1, x2, y2;
 };
 
 typedef std::list<GATEWAY *> GATEWAY_LIST;

--- a/src/geometry.cpp
+++ b/src/geometry.cpp
@@ -53,7 +53,7 @@ DROID	*getNearestDroid(UDWORD x, UDWORD y, bool bSelected)
 	ASSERT_OR_RETURN(nullptr, selectedPlayer < MAX_PLAYERS, "Not supported selectedPlayer: %" PRIu32 "", selectedPlayer);
 
 	/* Go thru' all the droids  - how often have we seen this - a MACRO maybe? */
-	for (DROID *psDroid : worldObjectState.droids[selectedPlayer])
+	for (DROID *psDroid : gameWorld.objects.droids[selectedPlayer])
 	{
 		if (!psDroid->isVtol())
 		{

--- a/src/geometry.cpp
+++ b/src/geometry.cpp
@@ -53,7 +53,7 @@ DROID	*getNearestDroid(UDWORD x, UDWORD y, bool bSelected)
 	ASSERT_OR_RETURN(nullptr, selectedPlayer < MAX_PLAYERS, "Not supported selectedPlayer: %" PRIu32 "", selectedPlayer);
 
 	/* Go thru' all the droids  - how often have we seen this - a MACRO maybe? */
-	for (DROID *psDroid : apsDroidLists[selectedPlayer])
+	for (DROID *psDroid : worldObjectState.droids[selectedPlayer])
 	{
 		if (!psDroid->isVtol())
 		{

--- a/src/geometry.h
+++ b/src/geometry.h
@@ -36,7 +36,7 @@ bool objectOnScreen(const BASE_OBJECT *object, SDWORD tolerance);
 
 static inline STRUCTURE *getTileStructure(UDWORD x, UDWORD y)
 {
-	BASE_OBJECT *psObj = mapTile(x, y)->psObject;
+	BASE_OBJECT *psObj = mapTile(worldMapState, x, y)->psObject;
 	if (psObj && psObj->type == OBJ_STRUCTURE)
 	{
 		return (STRUCTURE *)psObj;
@@ -46,7 +46,7 @@ static inline STRUCTURE *getTileStructure(UDWORD x, UDWORD y)
 
 static inline FEATURE *getTileFeature(UDWORD x, UDWORD y)
 {
-	BASE_OBJECT *psObj = mapTile(x, y)->psObject;
+	BASE_OBJECT *psObj = mapTile(worldMapState, x, y)->psObject;
 	if (psObj && psObj->type == OBJ_FEATURE)
 	{
 		return (FEATURE *)psObj;
@@ -58,11 +58,11 @@ static inline FEATURE *getTileFeature(UDWORD x, UDWORD y)
 /// Must *NOT* be used for anything game-state/simulation-calculation related
 static inline BASE_OBJECT *getTileOccupier(UDWORD x, UDWORD y)
 {
-	MAPTILE *psTile = mapTile(x, y);
+	MAPTILE *psTile = mapTile(worldMapState, x, y);
 
 	if (TEST_TILE_VISIBLE_TO_SELECTEDPLAYER(psTile))
 	{
-		return mapTile(x, y)->psObject;
+		return mapTile(worldMapState, x, y)->psObject;
 	}
 	else
 	{

--- a/src/geometry.h
+++ b/src/geometry.h
@@ -22,6 +22,7 @@
 #define __INCLUDED_SRC_GEOMETRY_H__
 
 #include "map.h"
+#include "game_world.h"
 
 struct QUAD
 {
@@ -36,7 +37,7 @@ bool objectOnScreen(const BASE_OBJECT *object, SDWORD tolerance);
 
 static inline STRUCTURE *getTileStructure(UDWORD x, UDWORD y)
 {
-	BASE_OBJECT *psObj = mapTile(worldMapState, x, y)->psObject;
+	BASE_OBJECT *psObj = mapTile(gameWorld.map, x, y)->psObject;
 	if (psObj && psObj->type == OBJ_STRUCTURE)
 	{
 		return (STRUCTURE *)psObj;
@@ -46,7 +47,7 @@ static inline STRUCTURE *getTileStructure(UDWORD x, UDWORD y)
 
 static inline FEATURE *getTileFeature(UDWORD x, UDWORD y)
 {
-	BASE_OBJECT *psObj = mapTile(worldMapState, x, y)->psObject;
+	BASE_OBJECT *psObj = mapTile(gameWorld.map, x, y)->psObject;
 	if (psObj && psObj->type == OBJ_FEATURE)
 	{
 		return (FEATURE *)psObj;
@@ -58,11 +59,11 @@ static inline FEATURE *getTileFeature(UDWORD x, UDWORD y)
 /// Must *NOT* be used for anything game-state/simulation-calculation related
 static inline BASE_OBJECT *getTileOccupier(UDWORD x, UDWORD y)
 {
-	MAPTILE *psTile = mapTile(worldMapState, x, y);
+	MAPTILE *psTile = mapTile(gameWorld.map, x, y);
 
 	if (TEST_TILE_VISIBLE_TO_SELECTEDPLAYER(psTile))
 	{
-		return mapTile(worldMapState, x, y)->psObject;
+		return mapTile(gameWorld.map, x, y)->psObject;
 	}
 	else
 	{

--- a/src/hci.cpp
+++ b/src/hci.cpp
@@ -1677,7 +1677,7 @@ INT_RETVAL intRunWidgets()
 					// Don't allow derrick to be built on burning ground.
 					if (((STRUCTURE_STATS *)psPositionStats)->type == REF_RESOURCE_EXTRACTOR)
 					{
-						if (fireOnLocation(pos.x, pos.y))
+						if (fireOnLocation(worldMapState, pos.x, pos.y))
 						{
 							AddDerrickBurningMessage();
 						}
@@ -1743,7 +1743,7 @@ INT_RETVAL intRunWidgets()
 
 						if (psBuilding->type == REF_DEMOLISH)
 						{
-							MAPTILE *psTile = mapTile(map_coord(pos.x), map_coord(pos.y));
+							MAPTILE *psTile = mapTile(worldMapState, map_coord(pos.x), map_coord(pos.y));
 							FEATURE *psFeature = (FEATURE *)psTile->psObject;
 							STRUCTURE *psStructure = (STRUCTURE *)psTile->psObject;
 
@@ -1763,7 +1763,7 @@ INT_RETVAL intRunWidgets()
 							STRUCTURE *psStructure = &tmp;
 							tmp.state = SAS_NORMAL;
 							tmp.pStructureType = (STRUCTURE_STATS *)psPositionStats;
-							tmp.pos = {pos.x, pos.y, map_Height(pos.x, pos.y) + world_coord(1) / 10};
+							tmp.pos = {pos.x, pos.y, map_Height(worldMapState, pos.x, pos.y) + world_coord(1) / 10};
 
 							// In multiplayer games be sure to send a message to the
 							// other players, telling them a new structure has been

--- a/src/hci.cpp
+++ b/src/hci.cpp
@@ -1079,7 +1079,7 @@ static FLAG_POSITION *intFindSelectedDelivPoint()
 {
 	ASSERT_OR_RETURN(nullptr, selectedPlayer < MAX_PLAYERS, "Not supported selectedPlayer: %" PRIu32 "", selectedPlayer);
 
-	for (const auto& psFlag : apsFlagPosLists[selectedPlayer])
+	for (const auto& psFlag : worldObjectState.flags[selectedPlayer])
 	{
 		if (psFlag->selected && psFlag->type == POS_DELIVERY)
 		{
@@ -1796,7 +1796,7 @@ INT_RETVAL intRunWidgets()
 						cancelDeliveryRepos();
 						if (psDroid)
 						{
-							addDroid(psDroid, apsDroidLists);
+							addDroid(psDroid, worldObjectState.droids);
 
 							// Send a text message to all players, notifying them of
 							// the fact that we're cheating ourselves a new droid.
@@ -2724,11 +2724,11 @@ StructureList *interfaceStructList()
 
 	if (offWorldKeepLists)
 	{
-		return &mission.apsStructLists[selectedPlayer];
+		return &mission.worldObjectState.structures[selectedPlayer];
 	}
 	else
 	{
-		return &apsStructLists[selectedPlayer];
+		return &worldObjectState.structures[selectedPlayer];
 	}
 }
 
@@ -2958,7 +2958,7 @@ static SDWORD intNumSelectedDroids(UDWORD droidType)
 	}
 
 	num = 0;
-	for (const DROID* psDroid : apsDroidLists[selectedPlayer])
+	for (const DROID* psDroid : worldObjectState.droids[selectedPlayer])
 	{
 		if (psDroid->selected && psDroid->droidType == droidType)
 		{

--- a/src/hci.cpp
+++ b/src/hci.cpp
@@ -1079,7 +1079,7 @@ static FLAG_POSITION *intFindSelectedDelivPoint()
 {
 	ASSERT_OR_RETURN(nullptr, selectedPlayer < MAX_PLAYERS, "Not supported selectedPlayer: %" PRIu32 "", selectedPlayer);
 
-	for (const auto& psFlag : worldObjectState.flags[selectedPlayer])
+	for (const auto& psFlag : gameWorld.objects.flags[selectedPlayer])
 	{
 		if (psFlag->selected && psFlag->type == POS_DELIVERY)
 		{
@@ -1677,7 +1677,7 @@ INT_RETVAL intRunWidgets()
 					// Don't allow derrick to be built on burning ground.
 					if (((STRUCTURE_STATS *)psPositionStats)->type == REF_RESOURCE_EXTRACTOR)
 					{
-						if (fireOnLocation(worldMapState, pos.x, pos.y))
+						if (fireOnLocation(gameWorld.map, pos.x, pos.y))
 						{
 							AddDerrickBurningMessage();
 						}
@@ -1743,7 +1743,7 @@ INT_RETVAL intRunWidgets()
 
 						if (psBuilding->type == REF_DEMOLISH)
 						{
-							MAPTILE *psTile = mapTile(worldMapState, map_coord(pos.x), map_coord(pos.y));
+							MAPTILE *psTile = mapTile(gameWorld.map, map_coord(pos.x), map_coord(pos.y));
 							FEATURE *psFeature = (FEATURE *)psTile->psObject;
 							STRUCTURE *psStructure = (STRUCTURE *)psTile->psObject;
 
@@ -1763,7 +1763,7 @@ INT_RETVAL intRunWidgets()
 							STRUCTURE *psStructure = &tmp;
 							tmp.state = SAS_NORMAL;
 							tmp.pStructureType = (STRUCTURE_STATS *)psPositionStats;
-							tmp.pos = {pos.x, pos.y, map_Height(worldMapState, pos.x, pos.y) + world_coord(1) / 10};
+							tmp.pos = {pos.x, pos.y, map_Height(gameWorld.map, pos.x, pos.y) + world_coord(1) / 10};
 
 							// In multiplayer games be sure to send a message to the
 							// other players, telling them a new structure has been
@@ -1796,7 +1796,7 @@ INT_RETVAL intRunWidgets()
 						cancelDeliveryRepos();
 						if (psDroid)
 						{
-							addDroid(psDroid, worldObjectState.droids);
+							addDroid(psDroid, gameWorld.objects.droids);
 
 							// Send a text message to all players, notifying them of
 							// the fact that we're cheating ourselves a new droid.
@@ -2724,11 +2724,11 @@ StructureList *interfaceStructList()
 
 	if (offWorldKeepLists)
 	{
-		return &mission.worldObjectState.structures[selectedPlayer];
+		return &mission.gameWorld.objects.structures[selectedPlayer];
 	}
 	else
 	{
-		return &worldObjectState.structures[selectedPlayer];
+		return &gameWorld.objects.structures[selectedPlayer];
 	}
 }
 
@@ -2958,7 +2958,7 @@ static SDWORD intNumSelectedDroids(UDWORD droidType)
 	}
 
 	num = 0;
-	for (const DROID* psDroid : worldObjectState.droids[selectedPlayer])
+	for (const DROID* psDroid : gameWorld.objects.droids[selectedPlayer])
 	{
 		if (psDroid->selected && psDroid->droidType == droidType)
 		{

--- a/src/hci/build.cpp
+++ b/src/hci/build.cpp
@@ -28,7 +28,7 @@
 #include "../qtscript.h"
 #include "../power.h"
 #include "../map.h"
-#include "../world_object_state.h"
+#include "../game_world.h"
 
 DROID *BuildController::highlightedBuilder = nullptr;
 bool BuildController::showFavorites = false;
@@ -46,7 +46,7 @@ void BuildController::updateBuildersList()
 
 	ASSERT_OR_RETURN(, selectedPlayer < MAX_PLAYERS, "selectedPlayer = %" PRIu32 "", selectedPlayer);
 
-	for (DROID *droid : worldObjectState.droids[selectedPlayer])
+	for (DROID *droid : gameWorld.objects.droids[selectedPlayer])
 	{
 		if (droid->isConstructionDroid() && droid->died == 0)
 		{

--- a/src/hci/build.cpp
+++ b/src/hci/build.cpp
@@ -28,6 +28,7 @@
 #include "../qtscript.h"
 #include "../power.h"
 #include "../map.h"
+#include "../world_object_state.h"
 
 DROID *BuildController::highlightedBuilder = nullptr;
 bool BuildController::showFavorites = false;
@@ -45,7 +46,7 @@ void BuildController::updateBuildersList()
 
 	ASSERT_OR_RETURN(, selectedPlayer < MAX_PLAYERS, "selectedPlayer = %" PRIu32 "", selectedPlayer);
 
-	for (DROID *droid : apsDroidLists[selectedPlayer])
+	for (DROID *droid : worldObjectState.droids[selectedPlayer])
 	{
 		if (droid->isConstructionDroid() && droid->died == 0)
 		{

--- a/src/hci/commander.cpp
+++ b/src/hci/commander.cpp
@@ -23,6 +23,7 @@
 #include "../cmddroid.h"
 #include "../group.h"
 #include "../intorder.h"
+#include "../game_world.h"
 
 DROID *CommanderController::highlightedCommander = nullptr;
 
@@ -38,7 +39,7 @@ void CommanderController::updateCommandersList()
 
 	ASSERT_OR_RETURN(, selectedPlayer < MAX_PLAYERS, "selectedPlayer = %" PRIu32 "", selectedPlayer);
 
-	for (DROID *droid : worldObjectState.droids[selectedPlayer])
+	for (DROID *droid : gameWorld.objects.droids[selectedPlayer])
 	{
 		if (droid->droidType == DROID_COMMAND && droid->died == 0)
 		{

--- a/src/hci/commander.cpp
+++ b/src/hci/commander.cpp
@@ -38,7 +38,7 @@ void CommanderController::updateCommandersList()
 
 	ASSERT_OR_RETURN(, selectedPlayer < MAX_PLAYERS, "selectedPlayer = %" PRIu32 "", selectedPlayer);
 
-	for (DROID *droid : apsDroidLists[selectedPlayer])
+	for (DROID *droid : worldObjectState.droids[selectedPlayer])
 	{
 		if (droid->droidType == DROID_COMMAND && droid->died == 0)
 		{

--- a/src/hci/groups.cpp
+++ b/src/hci/groups.cpp
@@ -21,6 +21,7 @@
 #include "groups.h"
 #include "objects_stats.h"
 #include "../group.h"
+#include "../game_world.h"
 
 static bool groupButtonEnabled = true;
 
@@ -307,7 +308,7 @@ void GroupsUIController::updateData()
 	};
 
 	std::array<AccumulatedGroupInfo, 10> calculatedGroupInfo;
-	for (DROID *psDroid : worldObjectState.droids[selectedPlayer])
+	for (DROID *psDroid : gameWorld.objects.droids[selectedPlayer])
 	{
 		if (psDroid->repairGroup < calculatedGroupInfo.size()) {
 			calculatedGroupInfo[psDroid->repairGroup].numberDamagedInGroup++;

--- a/src/hci/groups.cpp
+++ b/src/hci/groups.cpp
@@ -307,7 +307,7 @@ void GroupsUIController::updateData()
 	};
 
 	std::array<AccumulatedGroupInfo, 10> calculatedGroupInfo;
-	for (DROID *psDroid : apsDroidLists[selectedPlayer])
+	for (DROID *psDroid : worldObjectState.droids[selectedPlayer])
 	{
 		if (psDroid->repairGroup < calculatedGroupInfo.size()) {
 			calculatedGroupInfo[psDroid->repairGroup].numberDamagedInGroup++;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1719,9 +1719,9 @@ bool stageThreeInitialise()
 	}
 
 	effectResetUpdates();
-	initLighting(0, 0, worldMapState.width, worldMapState.height);
+	initLighting(0, 0, gameWorld.map.width, gameWorld.map.height);
 	pie_InitLighting();
-	getCurrentLightmapData().reset(worldMapState.width, worldMapState.height);
+	getCurrentLightmapData().reset(gameWorld.map.width, gameWorld.map.height);
 
 	if (fromSave)
 	{

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1719,9 +1719,9 @@ bool stageThreeInitialise()
 	}
 
 	effectResetUpdates();
-	initLighting(0, 0, mapWidth, mapHeight);
+	initLighting(0, 0, worldMapState.width, worldMapState.height);
 	pie_InitLighting();
-	getCurrentLightmapData().reset(mapWidth, mapHeight);
+	getCurrentLightmapData().reset(worldMapState.width, worldMapState.height);
 
 	if (fromSave)
 	{

--- a/src/intdisplay.cpp
+++ b/src/intdisplay.cpp
@@ -1379,7 +1379,7 @@ STRUCTURE *droidGetCommandFactory(DROID *psDroid)
 		if (psDroid->secondaryOrder & (1 << (inc + DSS_ASSPROD_SHIFT)))
 		{
 			// found an assigned factory - look for it in the lists
-			for (STRUCTURE* psCurr : apsStructLists[psDroid->player])
+			for (STRUCTURE* psCurr : worldObjectState.structures[psDroid->player])
 			{
 				if ((psCurr->pStructureType->type == REF_FACTORY) &&
 				    (((FACTORY *)psCurr->pFunctionality)->
@@ -1392,7 +1392,7 @@ STRUCTURE *droidGetCommandFactory(DROID *psDroid)
 		if (psDroid->secondaryOrder & (1 << (inc + DSS_ASSPROD_CYBORG_SHIFT)))
 		{
 			// found an assigned factory - look for it in the lists
-			for (STRUCTURE* psCurr : apsStructLists[psDroid->player])
+			for (STRUCTURE* psCurr : worldObjectState.structures[psDroid->player])
 			{
 				if ((psCurr->pStructureType->type == REF_CYBORG_FACTORY) &&
 				    (((FACTORY *)psCurr->pFunctionality)->
@@ -1405,7 +1405,7 @@ STRUCTURE *droidGetCommandFactory(DROID *psDroid)
 		if (psDroid->secondaryOrder & (1 << (inc + DSS_ASSPROD_VTOL_SHIFT)))
 		{
 			// found an assigned factory - look for it in the lists
-			for (STRUCTURE* psCurr : apsStructLists[psDroid->player])
+			for (STRUCTURE* psCurr : worldObjectState.structures[psDroid->player])
 			{
 				if ((psCurr->pStructureType->type == REF_VTOL_FACTORY) &&
 				    (((FACTORY *)psCurr->pFunctionality)->

--- a/src/intdisplay.cpp
+++ b/src/intdisplay.cpp
@@ -1703,8 +1703,8 @@ void drawRadarBlips(int radarX, int radarY, float pixSizeH, float pixSizeV, cons
 	static const uint16_t *const imagesProxTypes[] = {imagesEnemy, imagesResource, imagesArtifact};
 
 	// store the width & height of the radar/mini-map
-	width = scrollMaxX - scrollMinX;
-	height = scrollMaxY - scrollMinY;
+	width = worldMapState.scroll.maxX - worldMapState.scroll.minX;
+	height = worldMapState.scroll.maxY - worldMapState.scroll.minY;
 
 	/* Go through all the proximity Displays */
 	if (selectedPlayer < MAX_PLAYERS)
@@ -1769,13 +1769,13 @@ void drawRadarBlips(int radarX, int radarY, float pixSizeH, float pixSizeV, cons
 			{
 				const VIEW_PROXIMITY* psViewProx = (VIEW_PROXIMITY*)psProxDisp->psMessage->pViewData->pData;
 
-				x = static_cast<int>((psViewProx->x / TILE_UNITS - scrollMinX) * pixSizeH);
-				y = static_cast<int>((psViewProx->y / TILE_UNITS - scrollMinY) * pixSizeV);
+				x = static_cast<int>((psViewProx->x / TILE_UNITS - worldMapState.scroll.minX) * pixSizeH);
+				y = static_cast<int>((psViewProx->y / TILE_UNITS - worldMapState.scroll.minY) * pixSizeV);
 			}
 			else if (psProxDisp->type == POS_PROXOBJ)
 			{
-				x = static_cast<int>((psProxDisp->psMessage->psObj->pos.x / TILE_UNITS - scrollMinX) * pixSizeH);
-				y = static_cast<int>((psProxDisp->psMessage->psObj->pos.y / TILE_UNITS - scrollMinY) * pixSizeV);
+				x = static_cast<int>((psProxDisp->psMessage->psObj->pos.x / TILE_UNITS - worldMapState.scroll.minX) * pixSizeH);
+				y = static_cast<int>((psProxDisp->psMessage->psObj->pos.y / TILE_UNITS - worldMapState.scroll.minY) * pixSizeV);
 			}
 			else
 			{
@@ -1798,8 +1798,8 @@ void drawRadarBlips(int radarX, int radarY, float pixSizeH, float pixSizeV, cons
 	{
 		unsigned        animationLength = ARRAY_SIZE(imagesEnemy) - 1;
 		int             strobe = (realTime / delay) % animationLength;
-		x = static_cast<int>((x / TILE_UNITS - scrollMinX) * pixSizeH);
-		y = static_cast<int>((y / TILE_UNITS - scrollMinY) * pixSizeV);
+		x = static_cast<int>((x / TILE_UNITS - worldMapState.scroll.minX) * pixSizeH);
+		y = static_cast<int>((y / TILE_UNITS - worldMapState.scroll.minY) * pixSizeV);
 		imageID = imagesEnemy[strobe];
 
 		// NOTE:  On certain missions (limbo & expand), there is still valid data that is stored outside the

--- a/src/intdisplay.cpp
+++ b/src/intdisplay.cpp
@@ -1379,7 +1379,7 @@ STRUCTURE *droidGetCommandFactory(DROID *psDroid)
 		if (psDroid->secondaryOrder & (1 << (inc + DSS_ASSPROD_SHIFT)))
 		{
 			// found an assigned factory - look for it in the lists
-			for (STRUCTURE* psCurr : worldObjectState.structures[psDroid->player])
+			for (STRUCTURE* psCurr : gameWorld.objects.structures[psDroid->player])
 			{
 				if ((psCurr->pStructureType->type == REF_FACTORY) &&
 				    (((FACTORY *)psCurr->pFunctionality)->
@@ -1392,7 +1392,7 @@ STRUCTURE *droidGetCommandFactory(DROID *psDroid)
 		if (psDroid->secondaryOrder & (1 << (inc + DSS_ASSPROD_CYBORG_SHIFT)))
 		{
 			// found an assigned factory - look for it in the lists
-			for (STRUCTURE* psCurr : worldObjectState.structures[psDroid->player])
+			for (STRUCTURE* psCurr : gameWorld.objects.structures[psDroid->player])
 			{
 				if ((psCurr->pStructureType->type == REF_CYBORG_FACTORY) &&
 				    (((FACTORY *)psCurr->pFunctionality)->
@@ -1405,7 +1405,7 @@ STRUCTURE *droidGetCommandFactory(DROID *psDroid)
 		if (psDroid->secondaryOrder & (1 << (inc + DSS_ASSPROD_VTOL_SHIFT)))
 		{
 			// found an assigned factory - look for it in the lists
-			for (STRUCTURE* psCurr : worldObjectState.structures[psDroid->player])
+			for (STRUCTURE* psCurr : gameWorld.objects.structures[psDroid->player])
 			{
 				if ((psCurr->pStructureType->type == REF_VTOL_FACTORY) &&
 				    (((FACTORY *)psCurr->pFunctionality)->
@@ -1703,8 +1703,8 @@ void drawRadarBlips(int radarX, int radarY, float pixSizeH, float pixSizeV, cons
 	static const uint16_t *const imagesProxTypes[] = {imagesEnemy, imagesResource, imagesArtifact};
 
 	// store the width & height of the radar/mini-map
-	width = worldMapState.scroll.maxX - worldMapState.scroll.minX;
-	height = worldMapState.scroll.maxY - worldMapState.scroll.minY;
+	width = gameWorld.map.scroll.maxX - gameWorld.map.scroll.minX;
+	height = gameWorld.map.scroll.maxY - gameWorld.map.scroll.minY;
 
 	/* Go through all the proximity Displays */
 	if (selectedPlayer < MAX_PLAYERS)
@@ -1736,7 +1736,7 @@ void drawRadarBlips(int radarX, int radarY, float pixSizeH, float pixSizeV, cons
 				if (psFeature && psFeature->psStats && psFeature->psStats->subType == FEAT_OIL_RESOURCE)
 				{
 					images = imagesResource;
-					if (fireOnLocation(worldMapState, psFeature->pos.x, psFeature->pos.y))
+					if (fireOnLocation(gameWorld.map, psFeature->pos.x, psFeature->pos.y))
 					{
 						images = imagesBurningResource;
 						animationLength = ARRAY_SIZE(imagesBurningResource) - 1;  // Longer animation for burning oil wells.
@@ -1769,13 +1769,13 @@ void drawRadarBlips(int radarX, int radarY, float pixSizeH, float pixSizeV, cons
 			{
 				const VIEW_PROXIMITY* psViewProx = (VIEW_PROXIMITY*)psProxDisp->psMessage->pViewData->pData;
 
-				x = static_cast<int>((psViewProx->x / TILE_UNITS - worldMapState.scroll.minX) * pixSizeH);
-				y = static_cast<int>((psViewProx->y / TILE_UNITS - worldMapState.scroll.minY) * pixSizeV);
+				x = static_cast<int>((psViewProx->x / TILE_UNITS - gameWorld.map.scroll.minX) * pixSizeH);
+				y = static_cast<int>((psViewProx->y / TILE_UNITS - gameWorld.map.scroll.minY) * pixSizeV);
 			}
 			else if (psProxDisp->type == POS_PROXOBJ)
 			{
-				x = static_cast<int>((psProxDisp->psMessage->psObj->pos.x / TILE_UNITS - worldMapState.scroll.minX) * pixSizeH);
-				y = static_cast<int>((psProxDisp->psMessage->psObj->pos.y / TILE_UNITS - worldMapState.scroll.minY) * pixSizeV);
+				x = static_cast<int>((psProxDisp->psMessage->psObj->pos.x / TILE_UNITS - gameWorld.map.scroll.minX) * pixSizeH);
+				y = static_cast<int>((psProxDisp->psMessage->psObj->pos.y / TILE_UNITS - gameWorld.map.scroll.minY) * pixSizeV);
 			}
 			else
 			{
@@ -1798,8 +1798,8 @@ void drawRadarBlips(int radarX, int radarY, float pixSizeH, float pixSizeV, cons
 	{
 		unsigned        animationLength = ARRAY_SIZE(imagesEnemy) - 1;
 		int             strobe = (realTime / delay) % animationLength;
-		x = static_cast<int>((x / TILE_UNITS - worldMapState.scroll.minX) * pixSizeH);
-		y = static_cast<int>((y / TILE_UNITS - worldMapState.scroll.minY) * pixSizeV);
+		x = static_cast<int>((x / TILE_UNITS - gameWorld.map.scroll.minX) * pixSizeH);
+		y = static_cast<int>((y / TILE_UNITS - gameWorld.map.scroll.minY) * pixSizeV);
 		imageID = imagesEnemy[strobe];
 
 		// NOTE:  On certain missions (limbo & expand), there is still valid data that is stored outside the

--- a/src/intdisplay.cpp
+++ b/src/intdisplay.cpp
@@ -1736,7 +1736,7 @@ void drawRadarBlips(int radarX, int radarY, float pixSizeH, float pixSizeV, cons
 				if (psFeature && psFeature->psStats && psFeature->psStats->subType == FEAT_OIL_RESOURCE)
 				{
 					images = imagesResource;
-					if (fireOnLocation(psFeature->pos.x, psFeature->pos.y))
+					if (fireOnLocation(worldMapState, psFeature->pos.x, psFeature->pos.y))
 					{
 						images = imagesBurningResource;
 						animationLength = ARRAY_SIZE(imagesBurningResource) - 1;  // Longer animation for burning oil wells.

--- a/src/intorder.cpp
+++ b/src/intorder.cpp
@@ -410,7 +410,7 @@ static bool BuildSelectedDroidList()
 		return false;
 	}
 
-	for (DROID *psDroid : apsDroidLists[selectedPlayer])
+	for (DROID *psDroid : worldObjectState.droids[selectedPlayer])
 	{
 		if (psDroid->selected)
 		{

--- a/src/intorder.cpp
+++ b/src/intorder.cpp
@@ -26,6 +26,7 @@
 #include "intorder.h"
 #include "objects.h"
 #include "order.h"
+#include "game_world.h"
 
 #include <set>
 #include <algorithm>
@@ -410,7 +411,7 @@ static bool BuildSelectedDroidList()
 		return false;
 	}
 
-	for (DROID *psDroid : worldObjectState.droids[selectedPlayer])
+	for (DROID *psDroid : gameWorld.objects.droids[selectedPlayer])
 	{
 		if (psDroid->selected)
 		{

--- a/src/keybind.cpp
+++ b/src/keybind.cpp
@@ -233,7 +233,7 @@ void kf_DamageMe()
 	{
 		return; // no-op
 	}
-	for (DROID *psDroid : worldObjectState.droids[selectedPlayer])
+	for (DROID *psDroid : gameWorld.objects.droids[selectedPlayer])
 	{
 		if (psDroid->selected)
 		{
@@ -249,7 +249,7 @@ void kf_DamageMe()
 			}
 		}
 	}
-	for (STRUCTURE *psStruct : worldObjectState.structures[selectedPlayer])
+	for (STRUCTURE *psStruct : gameWorld.objects.structures[selectedPlayer])
 	{
 		if (psStruct->selected)
 		{
@@ -274,7 +274,7 @@ void	kf_TraceObject()
 		return; // no-op
 	}
 
-	for (const DROID* psCDroid : worldObjectState.droids[selectedPlayer])
+	for (const DROID* psCDroid : gameWorld.objects.droids[selectedPlayer])
 	{
 		if (psCDroid->selected)
 		{
@@ -283,7 +283,7 @@ void	kf_TraceObject()
 			return;
 		}
 	}
-	for (const STRUCTURE* psCStruct : worldObjectState.structures[selectedPlayer])
+	for (const STRUCTURE* psCStruct : gameWorld.objects.structures[selectedPlayer])
 	{
 		if (psCStruct->selected)
 		{
@@ -326,11 +326,11 @@ void	kf_HalveHeights()
 {
 	MAPTILE	*psTile;
 
-	for (int j = 0; j < worldMapState.height; ++j)
+	for (int j = 0; j < gameWorld.map.height; ++j)
 	{
-		for (int i = 0; i < worldMapState.width; ++i)
+		for (int i = 0; i < gameWorld.map.width; ++i)
 		{
-			psTile = mapTile(worldMapState, i, j);
+			psTile = mapTile(gameWorld.map, i, j);
 			psTile->height /= 2;
 		}
 	}
@@ -381,7 +381,7 @@ void	kf_DebugDroidInfo()
 		return; // no-op
 	}
 
-	for (const DROID* psDroid : worldObjectState.droids[selectedPlayer])
+	for (const DROID* psDroid : gameWorld.objects.droids[selectedPlayer])
 	{
 		if (psDroid->selected)
 		{
@@ -409,7 +409,7 @@ void kf_CloneSelected(int limit)
 
 	bool selectedAnything = false;
 	const DROID* droidToClone = nullptr;
-	for (const DROID* d : worldObjectState.droids[selectedPlayer])
+	for (const DROID* d : gameWorld.objects.droids[selectedPlayer])
 	{
 		if (!d->selected)
 		{
@@ -450,7 +450,7 @@ void kf_CloneSelected(int limit)
 		DROID* psNewDroid = buildDroid(sTemplate, pos.x, pos.y, droidToClone->player, false, nullptr);
 		if (psNewDroid)
 		{
-			addDroid(psNewDroid, worldObjectState.droids);
+			addDroid(psNewDroid, gameWorld.objects.droids);
 			triggerEventDroidBuilt(psNewDroid, nullptr);
 		}
 		else if (!bMultiMessages)
@@ -479,7 +479,7 @@ void kf_MakeMeHero()
 		return; // no-op
 	}
 
-	for (DROID *psDroid : worldObjectState.droids[selectedPlayer])
+	for (DROID *psDroid : gameWorld.objects.droids[selectedPlayer])
 	{
 		if (psDroid->selected && (psDroid->droidType == DROID_COMMAND || psDroid->droidType == DROID_SENSOR))
 		{
@@ -508,7 +508,7 @@ void kf_TeachSelected()
 		return; // no-op
 	}
 
-	for (DROID *psDroid : worldObjectState.droids[selectedPlayer])
+	for (DROID *psDroid : gameWorld.objects.droids[selectedPlayer])
 	{
 		if (psDroid->selected)
 		{
@@ -533,7 +533,7 @@ void kf_Unselectable()
 		return; // no-op
 	}
 
-	for (DROID *psDroid : worldObjectState.droids[selectedPlayer])
+	for (DROID *psDroid : gameWorld.objects.droids[selectedPlayer])
 	{
 		if (psDroid->selected)
 		{
@@ -541,7 +541,7 @@ void kf_Unselectable()
 			psDroid->selected = false;
 		}
 	}
-	for (STRUCTURE *psStruct : worldObjectState.structures[selectedPlayer])
+	for (STRUCTURE *psStruct : gameWorld.objects.structures[selectedPlayer])
 	{
 		if (psStruct->selected)
 		{
@@ -754,7 +754,7 @@ void kf_ListDroids()
 	}
 	for (int i = 0; i < MAX_PLAYERS; i++)
 	{
-		for (const DROID *psDroid : worldObjectState.droids[i])
+		for (const DROID *psDroid : gameWorld.objects.droids[i])
 		{
 			const auto x = map_coord(psDroid->pos.x);
 			const auto y = map_coord(psDroid->pos.y);
@@ -805,7 +805,7 @@ void	kf_TogglePower()
 /* Recalculates the lighting values for a tile */
 void	kf_RecalcLighting()
 {
-	initLighting(0, 0, worldMapState.width, worldMapState.height);
+	initLighting(0, 0, gameWorld.map.width, gameWorld.map.height);
 	addConsoleMessage(_("Lighting values for all tiles recalculated"), DEFAULT_JUSTIFY, SYSTEM_MESSAGE);
 }
 
@@ -846,7 +846,7 @@ void	kf_AllAvailable()
 void	kf_TriFlip()
 {
 	MAPTILE	*psTile;
-	psTile = mapTile(worldMapState, mouseTileX, mouseTileY);
+	psTile = mapTile(gameWorld.map, mouseTileX, mouseTileY);
 	TOGGLE_TRIFLIP(psTile);
 //	addConsoleMessage(_("Triangle flip status toggled"),DEFAULT_JUSTIFY,SYSTEM_MESSAGE);
 }
@@ -856,7 +856,7 @@ void	kf_TriFlip()
 /* Debug info about a map tile */
 void	kf_TileInfo()
 {
-	MAPTILE	*psTile = mapTile(worldMapState, mouseTileX, mouseTileY);
+	MAPTILE	*psTile = mapTile(gameWorld.map, mouseTileX, mouseTileY);
 
 	debug(LOG_ERROR, "Tile position=(%d, %d) Terrain=%d Texture=%u Height=%d Illumination=%u",
 	      mouseTileX, mouseTileY, (int)terrainType(psTile), TileNumber_tile(psTile->texture), psTile->height,
@@ -918,19 +918,19 @@ void kf_MapCheck()
 
 	if (selectedPlayer >= MAX_PLAYERS) { return; }
 
-	for (DROID* psDroid : worldObjectState.droids[selectedPlayer])
+	for (DROID* psDroid : gameWorld.objects.droids[selectedPlayer])
 	{
-		psDroid->pos.z = map_Height(worldMapState, psDroid->pos.x, psDroid->pos.y);
+		psDroid->pos.z = map_Height(gameWorld.map, psDroid->pos.x, psDroid->pos.y);
 	}
 
-	for (STRUCTURE* psStruct : worldObjectState.structures[selectedPlayer])
+	for (STRUCTURE* psStruct : gameWorld.objects.structures[selectedPlayer])
 	{
 		alignStructure(psStruct);
 	}
 
-	for (auto& psFlag : worldObjectState.flags[selectedPlayer])
+	for (auto& psFlag : gameWorld.objects.flags[selectedPlayer])
 	{
-		psFlag->coords.z = map_Height(worldMapState, psFlag->coords.x, psFlag->coords.y) + ASSEMBLY_POINT_Z_PADDING;
+		psFlag->coords.z = map_Height(gameWorld.map, psFlag->coords.x, psFlag->coords.y) + ASSEMBLY_POINT_Z_PADDING;
 	}
 }
 
@@ -989,9 +989,9 @@ MappableFunction kf_RadarZoom(const int multiplier)
 // --------------------------------------------------------------------------
 void kf_MaxScrollLimits()
 {
-	worldMapState.scroll.minX = worldMapState.scroll.minY = 0;
-	worldMapState.scroll.maxX = worldMapState.width;
-	worldMapState.scroll.maxY = worldMapState.height;
+	gameWorld.map.scroll.minX = gameWorld.map.scroll.minY = 0;
+	gameWorld.map.scroll.maxX = gameWorld.map.width;
+	gameWorld.map.scroll.maxY = gameWorld.map.height;
 }
 
 // --------------------------------------------------------------------------
@@ -1097,7 +1097,7 @@ void kf_SelectGrouping(UDWORD groupNumber)
 	bool	Selected;
 
 	bAlreadySelected = false;
-	for (DROID* psDroid : worldObjectState.droids[selectedPlayer])
+	for (DROID* psDroid : gameWorld.objects.droids[selectedPlayer])
 	{
 		/* Wipe out the ones in the wrong group */
 		if (psDroid->selected && psDroid->group != groupNumber)
@@ -1318,7 +1318,7 @@ void	kf_ToggleGodMode()
 		godMode = false;
 		setRevealStatus(pastReveal);
 		// now hide the features
-		for (BASE_OBJECT* psFeat : worldObjectState.features[0])
+		for (BASE_OBJECT* psFeat : gameWorld.objects.features[0])
 		{
 			psFeat->visible[selectedPlayer] = 0;
 		}
@@ -1328,7 +1328,7 @@ void	kf_ToggleGodMode()
 		{
 			if (playerId != selectedPlayer)
 			{
-				for (STRUCTURE* psStruct : worldObjectState.structures[playerId])
+				for (STRUCTURE* psStruct : gameWorld.objects.structures[playerId])
 				{
 					psStruct->visible[selectedPlayer] = 0;
 				}
@@ -1677,16 +1677,16 @@ void	kf_JumpToResourceExtractor()
 	/* not supported if a spectator */
 	SPECTATOR_NO_OP();
 
-	if (worldObjectState.extractors[selectedPlayer].empty())
+	if (gameWorld.objects.extractors[selectedPlayer].empty())
 	{
 		addConsoleMessage(_("Unable to locate any oil derricks!"), LEFT_JUSTIFY, SYSTEM_MESSAGE);
 		return;
 	}
 
-	if (!psOldRE.has_value() || std::next(*psOldRE) == worldObjectState.extractors[selectedPlayer].end())
+	if (!psOldRE.has_value() || std::next(*psOldRE) == gameWorld.objects.extractors[selectedPlayer].end())
 	{
 		// Reset the pointer if `psOldRE` is either not initialized yet or points to the last element.
-		psOldRE.emplace(worldObjectState.extractors[selectedPlayer].begin());
+		psOldRE.emplace(gameWorld.objects.extractors[selectedPlayer].begin());
 	}
 	else
 	{
@@ -1706,7 +1706,7 @@ void	kf_JumpToResourceExtractor()
 
 void keybindInformResourceExtractorRemoved(const STRUCTURE* psResourceExtractor)
 {
-	if (psOldRE.has_value() && *psOldRE != worldObjectState.extractors[selectedPlayer].end() && **psOldRE == psResourceExtractor)
+	if (psOldRE.has_value() && *psOldRE != gameWorld.objects.extractors[selectedPlayer].end() && **psOldRE == psResourceExtractor)
 	{
 		psOldRE.reset();
 	}
@@ -1905,7 +1905,7 @@ MappableFunction kf_SelectNextFactory(const STRUCTURE_TYPE factoryType, const bo
 		selNextSpecifiedBuilding(factoryType, bJumpToSelected);
 
 		//deselect factories of other types
-		for (STRUCTURE* psCurrent : worldObjectState.structures[selectedPlayer])
+		for (STRUCTURE* psCurrent : gameWorld.objects.structures[selectedPlayer])
 		{
 			const STRUCTURE_TYPE currentType = psCurrent->pStructureType->type;
 			const bool bIsAnotherTypeOfFactory = currentType != factoryType && std::any_of(FACTORY_TYPES.begin(), FACTORY_TYPES.end(), [currentType](const STRUCTURE_TYPE type) {
@@ -1979,12 +1979,12 @@ void	kf_KillEnemy()
 		if (playerId != selectedPlayer && !aiCheckAlliances(selectedPlayer, playerId))
 		{
 			// wipe out all the droids
-			for (const DROID* psCDroid : worldObjectState.droids[playerId])
+			for (const DROID* psCDroid : gameWorld.objects.droids[playerId])
 			{
 				SendDestroyDroid(psCDroid);
 			}
 			// wipe out all their structures
-			for (STRUCTURE* psCStruct : worldObjectState.structures[playerId])
+			for (STRUCTURE* psCStruct : gameWorld.objects.structures[playerId])
 			{
 				SendDestroyStructure(psCStruct);
 			}
@@ -2015,14 +2015,14 @@ void kf_KillSelected()
 	audio_PlayTrack(ID_SOUND_COLL_DIE);
 	Cheated = true;
 
-	for (const DROID* psCDroid : worldObjectState.droids[selectedPlayer])
+	for (const DROID* psCDroid : gameWorld.objects.droids[selectedPlayer])
 	{
 		if (psCDroid->selected)
 		{
 			SendDestroyDroid(psCDroid);
 		}
 	}
-	for (STRUCTURE* psCStruct : worldObjectState.structures[selectedPlayer])
+	for (STRUCTURE* psCStruct : gameWorld.objects.structures[selectedPlayer])
 	{
 		if (psCStruct->selected)
 		{
@@ -2125,7 +2125,7 @@ MappableFunction kf_OrderDroid(const DroidOrderType order)
 		/* not supported if a spectator */
 		SPECTATOR_NO_OP();
 
-		for (DROID* psDroid : worldObjectState.droids[selectedPlayer])
+		for (DROID* psDroid : gameWorld.objects.droids[selectedPlayer])
 		{
 			if (psDroid->selected)
 			{
@@ -2162,7 +2162,7 @@ static void kfsf_SetSelectedDroidsState(SECONDARY_ORDER sec, SECONDARY_STATE sta
 	// _not_ be disallowed in multiplayer games.
 
 	// This code is similar to SetSecondaryState() in intorder.cpp. Unfortunately, it seems hard to un-duplicate the code.
-	for (DROID* psDroid : worldObjectState.droids[selectedPlayer])
+	for (DROID* psDroid : gameWorld.objects.droids[selectedPlayer])
 	{
 		// Only set the state if it's not a transporter.
 		if (psDroid->selected && !psDroid->isTransporter())
@@ -2179,12 +2179,12 @@ void	kf_TriggerRayCast()
 	/* not supported if a spectator */
 	SPECTATOR_NO_OP();
 
-	auto selectedDroidIt = std::find_if(worldObjectState.droids[selectedPlayer].begin(), worldObjectState.droids[selectedPlayer].end(), [](DROID* d)
+	auto selectedDroidIt = std::find_if(gameWorld.objects.droids[selectedPlayer].begin(), gameWorld.objects.droids[selectedPlayer].end(), [](DROID* d)
 	{
 		return d->selected;
 	});
 
-	if (selectedDroidIt != worldObjectState.droids[selectedPlayer].end())
+	if (selectedDroidIt != gameWorld.objects.droids[selectedPlayer].end())
 	{
 //		getBlockHeightDirToEdgeOfGrid(UDWORD x, UDWORD y, UBYTE direction, UDWORD *height, UDWORD *dist)
 //		getBlockHeightDirToEdgeOfGrid(psOther->pos.x,psOther->pos.y,psOther->direction,&height,&dist);
@@ -2202,7 +2202,7 @@ void	kf_CentreOnBase()
 	SPECTATOR_NO_OP();
 
 	/* Got through our buildings */
-	for (const STRUCTURE* pStruct : worldObjectState.structures[selectedPlayer])
+	for (const STRUCTURE* pStruct : gameWorld.objects.structures[selectedPlayer])
 	{
 		/* Have we got a HQ? */
 		if (pStruct->pStructureType->type == REF_HQ)
@@ -2266,7 +2266,7 @@ void	kf_RightOrderMenu()
 	/* not supported if a spectator */
 	SPECTATOR_NO_OP();
 
-	for (DROID* psDroid : worldObjectState.droids[selectedPlayer])
+	for (DROID* psDroid : gameWorld.objects.droids[selectedPlayer])
 	{
 		if (psDroid->selected) // && droidOnScreen(psDroid,0))
 		{

--- a/src/keybind.cpp
+++ b/src/keybind.cpp
@@ -326,9 +326,9 @@ void	kf_HalveHeights()
 {
 	MAPTILE	*psTile;
 
-	for (int j = 0; j < mapHeight; ++j)
+	for (int j = 0; j < worldMapState.height; ++j)
 	{
-		for (int i = 0; i < mapWidth; ++i)
+		for (int i = 0; i < worldMapState.width; ++i)
 		{
 			psTile = mapTile(i, j);
 			psTile->height /= 2;
@@ -805,7 +805,7 @@ void	kf_TogglePower()
 /* Recalculates the lighting values for a tile */
 void	kf_RecalcLighting()
 {
-	initLighting(0, 0, mapWidth, mapHeight);
+	initLighting(0, 0, worldMapState.width, worldMapState.height);
 	addConsoleMessage(_("Lighting values for all tiles recalculated"), DEFAULT_JUSTIFY, SYSTEM_MESSAGE);
 }
 
@@ -989,9 +989,9 @@ MappableFunction kf_RadarZoom(const int multiplier)
 // --------------------------------------------------------------------------
 void kf_MaxScrollLimits()
 {
-	scrollMinX = scrollMinY = 0;
-	scrollMaxX = mapWidth;
-	scrollMaxY = mapHeight;
+	worldMapState.scroll.minX = worldMapState.scroll.minY = 0;
+	worldMapState.scroll.maxX = worldMapState.width;
+	worldMapState.scroll.maxY = worldMapState.height;
 }
 
 // --------------------------------------------------------------------------

--- a/src/keybind.cpp
+++ b/src/keybind.cpp
@@ -233,7 +233,7 @@ void kf_DamageMe()
 	{
 		return; // no-op
 	}
-	for (DROID *psDroid : apsDroidLists[selectedPlayer])
+	for (DROID *psDroid : worldObjectState.droids[selectedPlayer])
 	{
 		if (psDroid->selected)
 		{
@@ -249,7 +249,7 @@ void kf_DamageMe()
 			}
 		}
 	}
-	for (STRUCTURE *psStruct : apsStructLists[selectedPlayer])
+	for (STRUCTURE *psStruct : worldObjectState.structures[selectedPlayer])
 	{
 		if (psStruct->selected)
 		{
@@ -274,7 +274,7 @@ void	kf_TraceObject()
 		return; // no-op
 	}
 
-	for (const DROID* psCDroid : apsDroidLists[selectedPlayer])
+	for (const DROID* psCDroid : worldObjectState.droids[selectedPlayer])
 	{
 		if (psCDroid->selected)
 		{
@@ -283,7 +283,7 @@ void	kf_TraceObject()
 			return;
 		}
 	}
-	for (const STRUCTURE* psCStruct : apsStructLists[selectedPlayer])
+	for (const STRUCTURE* psCStruct : worldObjectState.structures[selectedPlayer])
 	{
 		if (psCStruct->selected)
 		{
@@ -381,7 +381,7 @@ void	kf_DebugDroidInfo()
 		return; // no-op
 	}
 
-	for (const DROID* psDroid : apsDroidLists[selectedPlayer])
+	for (const DROID* psDroid : worldObjectState.droids[selectedPlayer])
 	{
 		if (psDroid->selected)
 		{
@@ -409,7 +409,7 @@ void kf_CloneSelected(int limit)
 
 	bool selectedAnything = false;
 	const DROID* droidToClone = nullptr;
-	for (const DROID* d : apsDroidLists[selectedPlayer])
+	for (const DROID* d : worldObjectState.droids[selectedPlayer])
 	{
 		if (!d->selected)
 		{
@@ -450,7 +450,7 @@ void kf_CloneSelected(int limit)
 		DROID* psNewDroid = buildDroid(sTemplate, pos.x, pos.y, droidToClone->player, false, nullptr);
 		if (psNewDroid)
 		{
-			addDroid(psNewDroid, apsDroidLists);
+			addDroid(psNewDroid, worldObjectState.droids);
 			triggerEventDroidBuilt(psNewDroid, nullptr);
 		}
 		else if (!bMultiMessages)
@@ -479,7 +479,7 @@ void kf_MakeMeHero()
 		return; // no-op
 	}
 
-	for (DROID *psDroid : apsDroidLists[selectedPlayer])
+	for (DROID *psDroid : worldObjectState.droids[selectedPlayer])
 	{
 		if (psDroid->selected && (psDroid->droidType == DROID_COMMAND || psDroid->droidType == DROID_SENSOR))
 		{
@@ -508,7 +508,7 @@ void kf_TeachSelected()
 		return; // no-op
 	}
 
-	for (DROID *psDroid : apsDroidLists[selectedPlayer])
+	for (DROID *psDroid : worldObjectState.droids[selectedPlayer])
 	{
 		if (psDroid->selected)
 		{
@@ -533,7 +533,7 @@ void kf_Unselectable()
 		return; // no-op
 	}
 
-	for (DROID *psDroid : apsDroidLists[selectedPlayer])
+	for (DROID *psDroid : worldObjectState.droids[selectedPlayer])
 	{
 		if (psDroid->selected)
 		{
@@ -541,7 +541,7 @@ void kf_Unselectable()
 			psDroid->selected = false;
 		}
 	}
-	for (STRUCTURE *psStruct : apsStructLists[selectedPlayer])
+	for (STRUCTURE *psStruct : worldObjectState.structures[selectedPlayer])
 	{
 		if (psStruct->selected)
 		{
@@ -754,7 +754,7 @@ void kf_ListDroids()
 	}
 	for (int i = 0; i < MAX_PLAYERS; i++)
 	{
-		for (const DROID *psDroid : apsDroidLists[i])
+		for (const DROID *psDroid : worldObjectState.droids[i])
 		{
 			const auto x = map_coord(psDroid->pos.x);
 			const auto y = map_coord(psDroid->pos.y);
@@ -918,17 +918,17 @@ void kf_MapCheck()
 
 	if (selectedPlayer >= MAX_PLAYERS) { return; }
 
-	for (DROID* psDroid : apsDroidLists[selectedPlayer])
+	for (DROID* psDroid : worldObjectState.droids[selectedPlayer])
 	{
 		psDroid->pos.z = map_Height(psDroid->pos.x, psDroid->pos.y);
 	}
 
-	for (STRUCTURE* psStruct : apsStructLists[selectedPlayer])
+	for (STRUCTURE* psStruct : worldObjectState.structures[selectedPlayer])
 	{
 		alignStructure(psStruct);
 	}
 
-	for (auto& psFlag : apsFlagPosLists[selectedPlayer])
+	for (auto& psFlag : worldObjectState.flags[selectedPlayer])
 	{
 		psFlag->coords.z = map_Height(psFlag->coords.x, psFlag->coords.y) + ASSEMBLY_POINT_Z_PADDING;
 	}
@@ -1097,7 +1097,7 @@ void kf_SelectGrouping(UDWORD groupNumber)
 	bool	Selected;
 
 	bAlreadySelected = false;
-	for (DROID* psDroid : apsDroidLists[selectedPlayer])
+	for (DROID* psDroid : worldObjectState.droids[selectedPlayer])
 	{
 		/* Wipe out the ones in the wrong group */
 		if (psDroid->selected && psDroid->group != groupNumber)
@@ -1318,7 +1318,7 @@ void	kf_ToggleGodMode()
 		godMode = false;
 		setRevealStatus(pastReveal);
 		// now hide the features
-		for (BASE_OBJECT* psFeat : apsFeatureList[0])
+		for (BASE_OBJECT* psFeat : worldObjectState.features[0])
 		{
 			psFeat->visible[selectedPlayer] = 0;
 		}
@@ -1328,7 +1328,7 @@ void	kf_ToggleGodMode()
 		{
 			if (playerId != selectedPlayer)
 			{
-				for (STRUCTURE* psStruct : apsStructLists[playerId])
+				for (STRUCTURE* psStruct : worldObjectState.structures[playerId])
 				{
 					psStruct->visible[selectedPlayer] = 0;
 				}
@@ -1677,16 +1677,16 @@ void	kf_JumpToResourceExtractor()
 	/* not supported if a spectator */
 	SPECTATOR_NO_OP();
 
-	if (apsExtractorLists[selectedPlayer].empty())
+	if (worldObjectState.extractors[selectedPlayer].empty())
 	{
 		addConsoleMessage(_("Unable to locate any oil derricks!"), LEFT_JUSTIFY, SYSTEM_MESSAGE);
 		return;
 	}
 
-	if (!psOldRE.has_value() || std::next(*psOldRE) == apsExtractorLists[selectedPlayer].end())
+	if (!psOldRE.has_value() || std::next(*psOldRE) == worldObjectState.extractors[selectedPlayer].end())
 	{
 		// Reset the pointer if `psOldRE` is either not initialized yet or points to the last element.
-		psOldRE.emplace(apsExtractorLists[selectedPlayer].begin());
+		psOldRE.emplace(worldObjectState.extractors[selectedPlayer].begin());
 	}
 	else
 	{
@@ -1706,7 +1706,7 @@ void	kf_JumpToResourceExtractor()
 
 void keybindInformResourceExtractorRemoved(const STRUCTURE* psResourceExtractor)
 {
-	if (psOldRE.has_value() && *psOldRE != apsExtractorLists[selectedPlayer].end() && **psOldRE == psResourceExtractor)
+	if (psOldRE.has_value() && *psOldRE != worldObjectState.extractors[selectedPlayer].end() && **psOldRE == psResourceExtractor)
 	{
 		psOldRE.reset();
 	}
@@ -1905,7 +1905,7 @@ MappableFunction kf_SelectNextFactory(const STRUCTURE_TYPE factoryType, const bo
 		selNextSpecifiedBuilding(factoryType, bJumpToSelected);
 
 		//deselect factories of other types
-		for (STRUCTURE* psCurrent : apsStructLists[selectedPlayer])
+		for (STRUCTURE* psCurrent : worldObjectState.structures[selectedPlayer])
 		{
 			const STRUCTURE_TYPE currentType = psCurrent->pStructureType->type;
 			const bool bIsAnotherTypeOfFactory = currentType != factoryType && std::any_of(FACTORY_TYPES.begin(), FACTORY_TYPES.end(), [currentType](const STRUCTURE_TYPE type) {
@@ -1979,12 +1979,12 @@ void	kf_KillEnemy()
 		if (playerId != selectedPlayer && !aiCheckAlliances(selectedPlayer, playerId))
 		{
 			// wipe out all the droids
-			for (const DROID* psCDroid : apsDroidLists[playerId])
+			for (const DROID* psCDroid : worldObjectState.droids[playerId])
 			{
 				SendDestroyDroid(psCDroid);
 			}
 			// wipe out all their structures
-			for (STRUCTURE* psCStruct : apsStructLists[playerId])
+			for (STRUCTURE* psCStruct : worldObjectState.structures[playerId])
 			{
 				SendDestroyStructure(psCStruct);
 			}
@@ -2015,14 +2015,14 @@ void kf_KillSelected()
 	audio_PlayTrack(ID_SOUND_COLL_DIE);
 	Cheated = true;
 
-	for (const DROID* psCDroid : apsDroidLists[selectedPlayer])
+	for (const DROID* psCDroid : worldObjectState.droids[selectedPlayer])
 	{
 		if (psCDroid->selected)
 		{
 			SendDestroyDroid(psCDroid);
 		}
 	}
-	for (STRUCTURE* psCStruct : apsStructLists[selectedPlayer])
+	for (STRUCTURE* psCStruct : worldObjectState.structures[selectedPlayer])
 	{
 		if (psCStruct->selected)
 		{
@@ -2125,7 +2125,7 @@ MappableFunction kf_OrderDroid(const DroidOrderType order)
 		/* not supported if a spectator */
 		SPECTATOR_NO_OP();
 
-		for (DROID* psDroid : apsDroidLists[selectedPlayer])
+		for (DROID* psDroid : worldObjectState.droids[selectedPlayer])
 		{
 			if (psDroid->selected)
 			{
@@ -2162,7 +2162,7 @@ static void kfsf_SetSelectedDroidsState(SECONDARY_ORDER sec, SECONDARY_STATE sta
 	// _not_ be disallowed in multiplayer games.
 
 	// This code is similar to SetSecondaryState() in intorder.cpp. Unfortunately, it seems hard to un-duplicate the code.
-	for (DROID* psDroid : apsDroidLists[selectedPlayer])
+	for (DROID* psDroid : worldObjectState.droids[selectedPlayer])
 	{
 		// Only set the state if it's not a transporter.
 		if (psDroid->selected && !psDroid->isTransporter())
@@ -2179,12 +2179,12 @@ void	kf_TriggerRayCast()
 	/* not supported if a spectator */
 	SPECTATOR_NO_OP();
 
-	auto selectedDroidIt = std::find_if(apsDroidLists[selectedPlayer].begin(), apsDroidLists[selectedPlayer].end(), [](DROID* d)
+	auto selectedDroidIt = std::find_if(worldObjectState.droids[selectedPlayer].begin(), worldObjectState.droids[selectedPlayer].end(), [](DROID* d)
 	{
 		return d->selected;
 	});
 
-	if (selectedDroidIt != apsDroidLists[selectedPlayer].end())
+	if (selectedDroidIt != worldObjectState.droids[selectedPlayer].end())
 	{
 //		getBlockHeightDirToEdgeOfGrid(UDWORD x, UDWORD y, UBYTE direction, UDWORD *height, UDWORD *dist)
 //		getBlockHeightDirToEdgeOfGrid(psOther->pos.x,psOther->pos.y,psOther->direction,&height,&dist);
@@ -2202,7 +2202,7 @@ void	kf_CentreOnBase()
 	SPECTATOR_NO_OP();
 
 	/* Got through our buildings */
-	for (const STRUCTURE* pStruct : apsStructLists[selectedPlayer])
+	for (const STRUCTURE* pStruct : worldObjectState.structures[selectedPlayer])
 	{
 		/* Have we got a HQ? */
 		if (pStruct->pStructureType->type == REF_HQ)
@@ -2266,7 +2266,7 @@ void	kf_RightOrderMenu()
 	/* not supported if a spectator */
 	SPECTATOR_NO_OP();
 
-	for (DROID* psDroid : apsDroidLists[selectedPlayer])
+	for (DROID* psDroid : worldObjectState.droids[selectedPlayer])
 	{
 		if (psDroid->selected) // && droidOnScreen(psDroid,0))
 		{

--- a/src/keybind.cpp
+++ b/src/keybind.cpp
@@ -330,7 +330,7 @@ void	kf_HalveHeights()
 	{
 		for (int i = 0; i < worldMapState.width; ++i)
 		{
-			psTile = mapTile(i, j);
+			psTile = mapTile(worldMapState, i, j);
 			psTile->height /= 2;
 		}
 	}
@@ -846,7 +846,7 @@ void	kf_AllAvailable()
 void	kf_TriFlip()
 {
 	MAPTILE	*psTile;
-	psTile = mapTile(mouseTileX, mouseTileY);
+	psTile = mapTile(worldMapState, mouseTileX, mouseTileY);
 	TOGGLE_TRIFLIP(psTile);
 //	addConsoleMessage(_("Triangle flip status toggled"),DEFAULT_JUSTIFY,SYSTEM_MESSAGE);
 }
@@ -856,7 +856,7 @@ void	kf_TriFlip()
 /* Debug info about a map tile */
 void	kf_TileInfo()
 {
-	MAPTILE	*psTile = mapTile(mouseTileX, mouseTileY);
+	MAPTILE	*psTile = mapTile(worldMapState, mouseTileX, mouseTileY);
 
 	debug(LOG_ERROR, "Tile position=(%d, %d) Terrain=%d Texture=%u Height=%d Illumination=%u",
 	      mouseTileX, mouseTileY, (int)terrainType(psTile), TileNumber_tile(psTile->texture), psTile->height,
@@ -920,7 +920,7 @@ void kf_MapCheck()
 
 	for (DROID* psDroid : worldObjectState.droids[selectedPlayer])
 	{
-		psDroid->pos.z = map_Height(psDroid->pos.x, psDroid->pos.y);
+		psDroid->pos.z = map_Height(worldMapState, psDroid->pos.x, psDroid->pos.y);
 	}
 
 	for (STRUCTURE* psStruct : worldObjectState.structures[selectedPlayer])
@@ -930,7 +930,7 @@ void kf_MapCheck()
 
 	for (auto& psFlag : worldObjectState.flags[selectedPlayer])
 	{
-		psFlag->coords.z = map_Height(psFlag->coords.x, psFlag->coords.y) + ASSEMBLY_POINT_Z_PADDING;
+		psFlag->coords.z = map_Height(worldMapState, psFlag->coords.x, psFlag->coords.y) + ASSEMBLY_POINT_Z_PADDING;
 	}
 }
 

--- a/src/lighting.cpp
+++ b/src/lighting.cpp
@@ -41,6 +41,7 @@
 #include "display3d.h"
 #include "terrain.h"
 #include "warzoneconfig.h"
+#include "game_world.h"
 
 // These magic values determine the fog
 #define FOG_ALTITUDE_COEFFICIENT 1.3f
@@ -63,7 +64,7 @@ void setTheSun(Vector3f newSun)
 	if(oldSun != theSun)
 	{
 		// The sun has changed - must relcalulate lighting
-		initLighting(0, 0, worldMapState.width, worldMapState.height);
+		initLighting(0, 0, gameWorld.map.width, gameWorld.map.height);
 	}
 }
 
@@ -83,7 +84,7 @@ Vector3f getTheSun()
 void initLighting(UDWORD x1, UDWORD y1, UDWORD x2, UDWORD y2)
 {
 	// quick check not trying to go off the map - don't need to check for < 0 since UWORD's!!
-	if (x1 > worldMapState.width || x2 > worldMapState.width || y1 > worldMapState.height || y2 > worldMapState.height)
+	if (x1 > gameWorld.map.width || x2 > gameWorld.map.width || y1 > gameWorld.map.height || y2 > gameWorld.map.height)
 	{
 		ASSERT(false, "initLighting: coords off edge of map");
 		return;
@@ -93,10 +94,10 @@ void initLighting(UDWORD x1, UDWORD y1, UDWORD x2, UDWORD y2)
 	{
 		for (unsigned i = x1; i < x2; i++)
 		{
-			MAPTILE	*psTile = mapTile(worldMapState, i, j);
+			MAPTILE	*psTile = mapTile(gameWorld.map, i, j);
 
 			// always make the edge tiles dark
-			if (i == 0 || j == 0 || i >= worldMapState.width - 1 || j >= worldMapState.height - 1)
+			if (i == 0 || j == 0 || i >= gameWorld.map.width - 1 || j >= gameWorld.map.height - 1)
 			{
 				psTile->illumination = 16;
 				psTile->ambientOcclusion = 16.0;
@@ -107,8 +108,8 @@ void initLighting(UDWORD x1, UDWORD y1, UDWORD x2, UDWORD y2)
 			}
 			// Basically darkens down the tiles that are outside the scroll
 			// limits - thereby emphasising the cannot-go-there-ness of them
-			if ((SDWORD)i < worldMapState.scroll.minX + 4 || (SDWORD)i > worldMapState.scroll.maxX - 4
-			    || (SDWORD)j < worldMapState.scroll.minY + 4 || (SDWORD)j > worldMapState.scroll.maxY - 4)
+			if ((SDWORD)i < gameWorld.map.scroll.minX + 4 || (SDWORD)i > gameWorld.map.scroll.maxX - 4
+			    || (SDWORD)j < gameWorld.map.scroll.minY + 4 || (SDWORD)j > gameWorld.map.scroll.maxY - 4)
 			{
 				psTile->illumination /= 3;
 				psTile->ambientOcclusion /= 3;
@@ -130,7 +131,7 @@ static void normalsOnTile(unsigned int tileX, unsigned int tileY, unsigned int q
 			tiles[i][j] = Vector2i(tileX + i, tileY + j);
 			/* Get a pointer to our tile */
 			/* And to the ones to the east, south and southeast of it */
-			psTiles[i][j] = mapTile(worldMapState, tiles[i][j]);
+			psTiles[i][j] = mapTile(gameWorld.map, tiles[i][j]);
 			corners[i][j] = Vector3f(world_coord(tiles[i][j]), psTiles[i][j]->height);
 		}
 
@@ -214,8 +215,8 @@ static void calcTileIllum(UDWORD tileX, UDWORD tileY)
 
 	// Primitive ambient occlusion calculation.
 	float ao = 0;
-	const int cx = world_coord(tileX), cy = world_coord(tileY), maxX = world_coord(worldMapState.width), maxY = world_coord(worldMapState.height);
-	float height = map_Height(worldMapState, clip<int>(cx, 0, maxX), clip<int>(cy, 0, maxY));
+	const int cx = world_coord(tileX), cy = world_coord(tileY), maxX = world_coord(gameWorld.map.width), maxY = world_coord(gameWorld.map.height);
+	float height = map_Height(gameWorld.map, clip<int>(cx, 0, maxX), clip<int>(cy, 0, maxY));
 	constexpr float I = 100;
 	constexpr float H = I*0.70710678118654752440f;  // √½
 	constexpr int Dirs = 8;
@@ -225,7 +226,7 @@ static void calcTileIllum(UDWORD tileX, UDWORD tileY)
 	for (int dir = 0; dir < Dirs; ++dir) {
 		float maxTangent = 0;
 		for (int dist = 1; dist < 9; ++dist) {
-			float tangent = (map_Height(worldMapState, clip<int>(static_cast<int>(cx + dx[dir]*dist), 0, maxX), clip<int>(static_cast<int>(cy + dy[dir]*dist), 0, maxY)) - height)/(I*dist);
+			float tangent = (map_Height(gameWorld.map, clip<int>(static_cast<int>(cx + dx[dir]*dist), 0, maxX), clip<int>(static_cast<int>(cy + dy[dir]*dist), 0, maxY)) - height)/(I*dist);
 			maxTangent = std::max(maxTangent, tangent);
 		}
 		// Ambient light in this direction is proportional to the integral from tan(φ) = tangent to tan(φ) = ∞ of dφ cos(φ).
@@ -235,7 +236,7 @@ static void calcTileIllum(UDWORD tileX, UDWORD tileY)
 	ao *= 1.f/Dirs;
 	ao = clip<float>(ao, 0.25f, 1.f);
 
-	MAPTILE *tile = mapTile(worldMapState, tileX, tileY);
+	MAPTILE *tile = mapTile(gameWorld.map, tileX, tileY);
 	tile->illumination = static_cast<uint8_t>(clip<int>(static_cast<int>(abs(dotProduct*ao)), 24, 254));
 	tile->ambientOcclusion = static_cast<uint8_t>(clip<float>(254.f*ao, 60.f, 254.f));
 }
@@ -273,11 +274,11 @@ void rendering1999::LightingManager::ComputeFrameData(const LightingData& data, 
 		/* Clip to grid limits */
 		startX = MAX(startX, 0);
 		endX = MAX(endX, 0);
-		endX = MIN(endX, worldMapState.width - 1);
+		endX = MIN(endX, gameWorld.map.width - 1);
 		startX = MIN(startX, endX);
 		startY = MAX(startY, 0);
 		endY = MAX(endY, 0);
-		endY = MIN(endY, worldMapState.height - 1);
+		endY = MIN(endY, gameWorld.map.height - 1);
 		startY = MIN(startY, endY);
 
 		for (int i = startX; i <= endX; i++)
@@ -306,7 +307,7 @@ static UDWORD calcDistToTile(UDWORD tileX, UDWORD tileY, Vector3i *pos)
 
 	/* The coordinates of the tile corner */
 	x1 = tileX * TILE_UNITS;
-	y1 = map_TileHeight(worldMapState, tileX, tileY);
+	y1 = map_TileHeight(gameWorld.map, tileX, tileY);
 	z1 = tileY * TILE_UNITS;
 
 	return iHypot3(x1 - pos->x, y1 - pos->y, z1 - pos->z);
@@ -351,23 +352,23 @@ void calcDroidIllumination(DROID *psDroid)
 	const int tileY = map_coord(psDroid->pos.y);
 
 	/* Are we at the edge, or even on the map */
-	if (!tileOnMap(worldMapState, tileX, tileY))
+	if (!tileOnMap(gameWorld.map, tileX, tileY))
 	{
 		psDroid->illumination = UBYTE_MAX;
 		return;
 	}
-	else if (tileX <= 1 || tileX >= worldMapState.width - 2 || tileY <= 1 || tileY >= worldMapState.height - 2)
+	else if (tileX <= 1 || tileX >= gameWorld.map.width - 2 || tileY <= 1 || tileY >= gameWorld.map.height - 2)
 	{
-		lightVal = mapTile(worldMapState, tileX, tileY)->illumination;
+		lightVal = mapTile(gameWorld.map, tileX, tileY)->illumination;
 		lightVal += MIN_DROID_LIGHT_LEVEL;
 	}
 	else
 	{
-		lightVal = mapTile(worldMapState, tileX, tileY)->illumination +		 //
-		           mapTile(worldMapState, tileX - 1, tileY)->illumination +	 //		 *
-		           mapTile(worldMapState, tileX, tileY - 1)->illumination +	 //		***		pattern
-		           mapTile(worldMapState, tileX + 1, tileY)->illumination +	 //		 *
-		           mapTile(worldMapState, tileX + 1, tileY + 1)->illumination;	 //
+		lightVal = mapTile(gameWorld.map, tileX, tileY)->illumination +		 //
+		           mapTile(gameWorld.map, tileX - 1, tileY)->illumination +	 //		 *
+		           mapTile(gameWorld.map, tileX, tileY - 1)->illumination +	 //		***		pattern
+		           mapTile(gameWorld.map, tileX + 1, tileY)->illumination +	 //		 *
+		           mapTile(gameWorld.map, tileX + 1, tileY + 1)->illumination;	 //
 		lightVal /= 5;
 		lightVal += MIN_DROID_LIGHT_LEVEL;
 	}

--- a/src/lighting.cpp
+++ b/src/lighting.cpp
@@ -93,7 +93,7 @@ void initLighting(UDWORD x1, UDWORD y1, UDWORD x2, UDWORD y2)
 	{
 		for (unsigned i = x1; i < x2; i++)
 		{
-			MAPTILE	*psTile = mapTile(i, j);
+			MAPTILE	*psTile = mapTile(worldMapState, i, j);
 
 			// always make the edge tiles dark
 			if (i == 0 || j == 0 || i >= worldMapState.width - 1 || j >= worldMapState.height - 1)
@@ -130,7 +130,7 @@ static void normalsOnTile(unsigned int tileX, unsigned int tileY, unsigned int q
 			tiles[i][j] = Vector2i(tileX + i, tileY + j);
 			/* Get a pointer to our tile */
 			/* And to the ones to the east, south and southeast of it */
-			psTiles[i][j] = mapTile(tiles[i][j]);
+			psTiles[i][j] = mapTile(worldMapState, tiles[i][j]);
 			corners[i][j] = Vector3f(world_coord(tiles[i][j]), psTiles[i][j]->height);
 		}
 
@@ -215,7 +215,7 @@ static void calcTileIllum(UDWORD tileX, UDWORD tileY)
 	// Primitive ambient occlusion calculation.
 	float ao = 0;
 	const int cx = world_coord(tileX), cy = world_coord(tileY), maxX = world_coord(worldMapState.width), maxY = world_coord(worldMapState.height);
-	float height = map_Height(clip<int>(cx, 0, maxX), clip<int>(cy, 0, maxY));
+	float height = map_Height(worldMapState, clip<int>(cx, 0, maxX), clip<int>(cy, 0, maxY));
 	constexpr float I = 100;
 	constexpr float H = I*0.70710678118654752440f;  // √½
 	constexpr int Dirs = 8;
@@ -225,7 +225,7 @@ static void calcTileIllum(UDWORD tileX, UDWORD tileY)
 	for (int dir = 0; dir < Dirs; ++dir) {
 		float maxTangent = 0;
 		for (int dist = 1; dist < 9; ++dist) {
-			float tangent = (map_Height(clip<int>(static_cast<int>(cx + dx[dir]*dist), 0, maxX), clip<int>(static_cast<int>(cy + dy[dir]*dist), 0, maxY)) - height)/(I*dist);
+			float tangent = (map_Height(worldMapState, clip<int>(static_cast<int>(cx + dx[dir]*dist), 0, maxX), clip<int>(static_cast<int>(cy + dy[dir]*dist), 0, maxY)) - height)/(I*dist);
 			maxTangent = std::max(maxTangent, tangent);
 		}
 		// Ambient light in this direction is proportional to the integral from tan(φ) = tangent to tan(φ) = ∞ of dφ cos(φ).
@@ -235,7 +235,7 @@ static void calcTileIllum(UDWORD tileX, UDWORD tileY)
 	ao *= 1.f/Dirs;
 	ao = clip<float>(ao, 0.25f, 1.f);
 
-	MAPTILE *tile = mapTile(tileX, tileY);
+	MAPTILE *tile = mapTile(worldMapState, tileX, tileY);
 	tile->illumination = static_cast<uint8_t>(clip<int>(static_cast<int>(abs(dotProduct*ao)), 24, 254));
 	tile->ambientOcclusion = static_cast<uint8_t>(clip<float>(254.f*ao, 60.f, 254.f));
 }
@@ -306,7 +306,7 @@ static UDWORD calcDistToTile(UDWORD tileX, UDWORD tileY, Vector3i *pos)
 
 	/* The coordinates of the tile corner */
 	x1 = tileX * TILE_UNITS;
-	y1 = map_TileHeight(tileX, tileY);
+	y1 = map_TileHeight(worldMapState, tileX, tileY);
 	z1 = tileY * TILE_UNITS;
 
 	return iHypot3(x1 - pos->x, y1 - pos->y, z1 - pos->z);
@@ -351,23 +351,23 @@ void calcDroidIllumination(DROID *psDroid)
 	const int tileY = map_coord(psDroid->pos.y);
 
 	/* Are we at the edge, or even on the map */
-	if (!tileOnMap(tileX, tileY))
+	if (!tileOnMap(worldMapState, tileX, tileY))
 	{
 		psDroid->illumination = UBYTE_MAX;
 		return;
 	}
 	else if (tileX <= 1 || tileX >= worldMapState.width - 2 || tileY <= 1 || tileY >= worldMapState.height - 2)
 	{
-		lightVal = mapTile(tileX, tileY)->illumination;
+		lightVal = mapTile(worldMapState, tileX, tileY)->illumination;
 		lightVal += MIN_DROID_LIGHT_LEVEL;
 	}
 	else
 	{
-		lightVal = mapTile(tileX, tileY)->illumination +		 //
-		           mapTile(tileX - 1, tileY)->illumination +	 //		 *
-		           mapTile(tileX, tileY - 1)->illumination +	 //		***		pattern
-		           mapTile(tileX + 1, tileY)->illumination +	 //		 *
-		           mapTile(tileX + 1, tileY + 1)->illumination;	 //
+		lightVal = mapTile(worldMapState, tileX, tileY)->illumination +		 //
+		           mapTile(worldMapState, tileX - 1, tileY)->illumination +	 //		 *
+		           mapTile(worldMapState, tileX, tileY - 1)->illumination +	 //		***		pattern
+		           mapTile(worldMapState, tileX + 1, tileY)->illumination +	 //		 *
+		           mapTile(worldMapState, tileX + 1, tileY + 1)->illumination;	 //
 		lightVal /= 5;
 		lightVal += MIN_DROID_LIGHT_LEVEL;
 	}

--- a/src/lighting.cpp
+++ b/src/lighting.cpp
@@ -63,7 +63,7 @@ void setTheSun(Vector3f newSun)
 	if(oldSun != theSun)
 	{
 		// The sun has changed - must relcalulate lighting
-		initLighting(0, 0, mapWidth, mapHeight);
+		initLighting(0, 0, worldMapState.width, worldMapState.height);
 	}
 }
 
@@ -83,7 +83,7 @@ Vector3f getTheSun()
 void initLighting(UDWORD x1, UDWORD y1, UDWORD x2, UDWORD y2)
 {
 	// quick check not trying to go off the map - don't need to check for < 0 since UWORD's!!
-	if (x1 > mapWidth || x2 > mapWidth || y1 > mapHeight || y2 > mapHeight)
+	if (x1 > worldMapState.width || x2 > worldMapState.width || y1 > worldMapState.height || y2 > worldMapState.height)
 	{
 		ASSERT(false, "initLighting: coords off edge of map");
 		return;
@@ -96,7 +96,7 @@ void initLighting(UDWORD x1, UDWORD y1, UDWORD x2, UDWORD y2)
 			MAPTILE	*psTile = mapTile(i, j);
 
 			// always make the edge tiles dark
-			if (i == 0 || j == 0 || i >= mapWidth - 1 || j >= mapHeight - 1)
+			if (i == 0 || j == 0 || i >= worldMapState.width - 1 || j >= worldMapState.height - 1)
 			{
 				psTile->illumination = 16;
 				psTile->ambientOcclusion = 16.0;
@@ -107,8 +107,8 @@ void initLighting(UDWORD x1, UDWORD y1, UDWORD x2, UDWORD y2)
 			}
 			// Basically darkens down the tiles that are outside the scroll
 			// limits - thereby emphasising the cannot-go-there-ness of them
-			if ((SDWORD)i < scrollMinX + 4 || (SDWORD)i > scrollMaxX - 4
-			    || (SDWORD)j < scrollMinY + 4 || (SDWORD)j > scrollMaxY - 4)
+			if ((SDWORD)i < worldMapState.scroll.minX + 4 || (SDWORD)i > worldMapState.scroll.maxX - 4
+			    || (SDWORD)j < worldMapState.scroll.minY + 4 || (SDWORD)j > worldMapState.scroll.maxY - 4)
 			{
 				psTile->illumination /= 3;
 				psTile->ambientOcclusion /= 3;
@@ -214,7 +214,7 @@ static void calcTileIllum(UDWORD tileX, UDWORD tileY)
 
 	// Primitive ambient occlusion calculation.
 	float ao = 0;
-	const int cx = world_coord(tileX), cy = world_coord(tileY), maxX = world_coord(mapWidth), maxY = world_coord(mapHeight);
+	const int cx = world_coord(tileX), cy = world_coord(tileY), maxX = world_coord(worldMapState.width), maxY = world_coord(worldMapState.height);
 	float height = map_Height(clip<int>(cx, 0, maxX), clip<int>(cy, 0, maxY));
 	constexpr float I = 100;
 	constexpr float H = I*0.70710678118654752440f;  // √½
@@ -273,11 +273,11 @@ void rendering1999::LightingManager::ComputeFrameData(const LightingData& data, 
 		/* Clip to grid limits */
 		startX = MAX(startX, 0);
 		endX = MAX(endX, 0);
-		endX = MIN(endX, mapWidth - 1);
+		endX = MIN(endX, worldMapState.width - 1);
 		startX = MIN(startX, endX);
 		startY = MAX(startY, 0);
 		endY = MAX(endY, 0);
-		endY = MIN(endY, mapHeight - 1);
+		endY = MIN(endY, worldMapState.height - 1);
 		startY = MIN(startY, endY);
 
 		for (int i = startX; i <= endX; i++)
@@ -356,7 +356,7 @@ void calcDroidIllumination(DROID *psDroid)
 		psDroid->illumination = UBYTE_MAX;
 		return;
 	}
-	else if (tileX <= 1 || tileX >= mapWidth - 2 || tileY <= 1 || tileY >= mapHeight - 2)
+	else if (tileX <= 1 || tileX >= worldMapState.width - 2 || tileY <= 1 || tileY >= worldMapState.height - 2)
 	{
 		lightVal = mapTile(tileX, tileY)->illumination;
 		lightVal += MIN_DROID_LIGHT_LEVEL;

--- a/src/loop.cpp
+++ b/src/loop.cpp
@@ -210,7 +210,7 @@ static GAMECODE renderLoop()
 
 			for (unsigned i = 0; i < MAX_PLAYERS; i++)
 			{
-				for (DROID *psCurr : worldObjectState.droids[i])
+				for (DROID *psCurr : gameWorld.objects.droids[i])
 				{
 					// Don't copy the next pointer - if droids somehow get destroyed in the graphics rendering loop, who cares if we crash.
 					calcDroidIllumination(psCurr);
@@ -411,7 +411,7 @@ void countUpdate(bool synch)
 		numMissionDroids[i] = 0;
 		numTransporterDroids[i] = 0;
 
-		for (DROID *psCurr : worldObjectState.droids[i])
+		for (DROID *psCurr : gameWorld.objects.droids[i])
 		{
 			numDroids[i]++;
 			switch (psCurr->droidType)
@@ -431,7 +431,7 @@ void countUpdate(bool synch)
 				break;
 			}
 		}
-		for (DROID *psCurr : mission.worldObjectState.droids[i])
+		for (DROID *psCurr : mission.gameWorld.objects.droids[i])
 		{
 			numMissionDroids[i]++;
 			switch (psCurr->droidType)
@@ -469,7 +469,7 @@ void countUpdate(bool synch)
 		}
 		// FIXME: These for-loops are code duplicationo
 		setLasSatExists(false, i);
-		for (const STRUCTURE *psCBuilding : worldObjectState.structures[i])
+		for (const STRUCTURE *psCBuilding : gameWorld.objects.structures[i])
 		{
 			if (psCBuilding == nullptr || isDead(psCBuilding))
 			{
@@ -485,7 +485,7 @@ void countUpdate(bool synch)
 				setLasSatExists(true, i);
 			}
 		}
-		for (const STRUCTURE *psCBuilding : mission.worldObjectState.structures[i])
+		for (const STRUCTURE *psCBuilding : mission.gameWorld.objects.structures[i])
 		{
 			if (psCBuilding == nullptr || isDead(psCBuilding))
 			{
@@ -564,14 +564,14 @@ static void gameStateUpdate()
 		updatePlayerPower(i);
 
 		executeFnAndProcessScriptQueuedRemovals([i]() {
-			mutating_list_iterate(worldObjectState.droids[i], [](DROID* d)
+			mutating_list_iterate(gameWorld.objects.droids[i], [](DROID* d)
 			{
 				droidUpdate(d);
 				return IterationResult::CONTINUE_ITERATION;
 			});
 		});
 		executeFnAndProcessScriptQueuedRemovals([i]() {
-			mutating_list_iterate(mission.worldObjectState.droids[i], [](DROID* d)
+			mutating_list_iterate(mission.gameWorld.objects.droids[i], [](DROID* d)
 			{
 				missionDroidUpdate(d);
 				return IterationResult::CONTINUE_ITERATION;
@@ -579,14 +579,14 @@ static void gameStateUpdate()
 		});
 		// FIXME: These for-loops are code duplication
 		executeFnAndProcessScriptQueuedRemovals([i]() {
-			mutating_list_iterate(worldObjectState.structures[i], [](STRUCTURE* s)
+			mutating_list_iterate(gameWorld.objects.structures[i], [](STRUCTURE* s)
 			{
 				structureUpdate(s, false);
 				return IterationResult::CONTINUE_ITERATION;
 			});
 		});
 		executeFnAndProcessScriptQueuedRemovals([i]() {
-			mutating_list_iterate(mission.worldObjectState.structures[i], [](STRUCTURE* s)
+			mutating_list_iterate(mission.gameWorld.objects.structures[i], [](STRUCTURE* s)
 			{
 				structureUpdate(s, true); // update for mission
 				return IterationResult::CONTINUE_ITERATION;
@@ -598,7 +598,7 @@ static void gameStateUpdate()
 
 	executeFnAndProcessScriptQueuedRemovals([]() { proj_UpdateAll(); });
 
-	for (FEATURE *psCFeat : worldObjectState.features[0])
+	for (FEATURE *psCFeat : gameWorld.objects.features[0])
 	{
 		featureUpdate(psCFeat);
 	}

--- a/src/loop.cpp
+++ b/src/loop.cpp
@@ -210,7 +210,7 @@ static GAMECODE renderLoop()
 
 			for (unsigned i = 0; i < MAX_PLAYERS; i++)
 			{
-				for (DROID *psCurr : apsDroidLists[i])
+				for (DROID *psCurr : worldObjectState.droids[i])
 				{
 					// Don't copy the next pointer - if droids somehow get destroyed in the graphics rendering loop, who cares if we crash.
 					calcDroidIllumination(psCurr);
@@ -411,7 +411,7 @@ void countUpdate(bool synch)
 		numMissionDroids[i] = 0;
 		numTransporterDroids[i] = 0;
 
-		for (DROID *psCurr : apsDroidLists[i])
+		for (DROID *psCurr : worldObjectState.droids[i])
 		{
 			numDroids[i]++;
 			switch (psCurr->droidType)
@@ -431,7 +431,7 @@ void countUpdate(bool synch)
 				break;
 			}
 		}
-		for (DROID *psCurr : mission.apsDroidLists[i])
+		for (DROID *psCurr : mission.worldObjectState.droids[i])
 		{
 			numMissionDroids[i]++;
 			switch (psCurr->droidType)
@@ -469,7 +469,7 @@ void countUpdate(bool synch)
 		}
 		// FIXME: These for-loops are code duplicationo
 		setLasSatExists(false, i);
-		for (const STRUCTURE *psCBuilding : apsStructLists[i])
+		for (const STRUCTURE *psCBuilding : worldObjectState.structures[i])
 		{
 			if (psCBuilding == nullptr || isDead(psCBuilding))
 			{
@@ -485,7 +485,7 @@ void countUpdate(bool synch)
 				setLasSatExists(true, i);
 			}
 		}
-		for (const STRUCTURE *psCBuilding : mission.apsStructLists[i])
+		for (const STRUCTURE *psCBuilding : mission.worldObjectState.structures[i])
 		{
 			if (psCBuilding == nullptr || isDead(psCBuilding))
 			{
@@ -564,14 +564,14 @@ static void gameStateUpdate()
 		updatePlayerPower(i);
 
 		executeFnAndProcessScriptQueuedRemovals([i]() {
-			mutating_list_iterate(apsDroidLists[i], [](DROID* d)
+			mutating_list_iterate(worldObjectState.droids[i], [](DROID* d)
 			{
 				droidUpdate(d);
 				return IterationResult::CONTINUE_ITERATION;
 			});
 		});
 		executeFnAndProcessScriptQueuedRemovals([i]() {
-			mutating_list_iterate(mission.apsDroidLists[i], [](DROID* d)
+			mutating_list_iterate(mission.worldObjectState.droids[i], [](DROID* d)
 			{
 				missionDroidUpdate(d);
 				return IterationResult::CONTINUE_ITERATION;
@@ -579,14 +579,14 @@ static void gameStateUpdate()
 		});
 		// FIXME: These for-loops are code duplication
 		executeFnAndProcessScriptQueuedRemovals([i]() {
-			mutating_list_iterate(apsStructLists[i], [](STRUCTURE* s)
+			mutating_list_iterate(worldObjectState.structures[i], [](STRUCTURE* s)
 			{
 				structureUpdate(s, false);
 				return IterationResult::CONTINUE_ITERATION;
 			});
 		});
 		executeFnAndProcessScriptQueuedRemovals([i]() {
-			mutating_list_iterate(mission.apsStructLists[i], [](STRUCTURE* s)
+			mutating_list_iterate(mission.worldObjectState.structures[i], [](STRUCTURE* s)
 			{
 				structureUpdate(s, true); // update for mission
 				return IterationResult::CONTINUE_ITERATION;
@@ -598,7 +598,7 @@ static void gameStateUpdate()
 
 	executeFnAndProcessScriptQueuedRemovals([]() { proj_UpdateAll(); });
 
-	for (FEATURE *psCFeat : apsFeatureList[0])
+	for (FEATURE *psCFeat : worldObjectState.features[0])
 	{
 		featureUpdate(psCFeat);
 	}

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -145,7 +145,7 @@ void syncLogDumpAuxMaps()
 			std::string rowDetails;
 			for (int x = 0; x < worldMapState.width; ++x)
 			{
-				auto val = auxTile(x, y, auxIdx);
+				auto val = auxTile(worldMapState, x, y, auxIdx);
 				rowDetails += std::to_string(val) + ",";
 			}
 			syncDebug("psAuxMap[%d] row[%d]: %s", auxIdx, y, rowDetails.c_str());
@@ -160,7 +160,7 @@ void syncLogDumpAuxMaps()
 			std::string rowDetails;
 			for (int x = 0; x < worldMapState.width; ++x)
 			{
-				auto val = blockTile(x, y, idx);
+				auto val = blockTile(worldMapState, x, y, idx);
 				rowDetails += std::to_string(val) + ",";
 			}
 			syncDebug("psBlockMap[%d] row[%d]: %s", idx, y, rowDetails.c_str());
@@ -574,7 +574,7 @@ static int determineGroundType(int x, int y, const char *tileset)
 			}
 			else
 			{
-				psTile = mapTile(x + i - 1, y + j - 1);
+				psTile = mapTile(worldMapState, x + i - 1, y + j - 1);
 				tile = psTile->texture;
 			}
 			a = i;
@@ -690,7 +690,7 @@ static void SetDecals(const char *filename, const char *decal_type)
 static bool hasDecals(int i, int j)
 {
 	int index = 0;
-	index = TileNumber_tile(mapTile(i, j)->texture);
+	index = TileNumber_tile(mapTile(worldMapState, i, j)->texture);
 	if (index > MAX_TERRAIN_TILES)
 	{
 		debug(LOG_FATAL, "Tile index is out of range!  Was %d, our max is %d", index, MAX_TERRAIN_TILES);
@@ -706,7 +706,7 @@ static bool mapSetGroundTypes()
 	{
 		for (int i = 0; i < worldMapState.width; i++)
 		{
-			MAPTILE *psTile = mapTile(i, j);
+			MAPTILE *psTile = mapTile(worldMapState, i, j);
 
 			psTile->ground = determineGroundType(i, j, tilesetDir);
 
@@ -743,8 +743,8 @@ static bool isWaterVertex(int x, int y)
 	{
 		return false;
 	}
-	return terrainType(mapTile(x, y)) == TER_WATER && terrainType(mapTile(x - 1, y)) == TER_WATER
-	       && terrainType(mapTile(x, y - 1)) == TER_WATER && terrainType(mapTile(x - 1, y - 1)) == TER_WATER;
+	return terrainType(mapTile(worldMapState, x, y)) == TER_WATER && terrainType(mapTile(worldMapState, x - 1, y)) == TER_WATER
+	       && terrainType(mapTile(worldMapState, x, y - 1)) == TER_WATER && terrainType(mapTile(worldMapState, x - 1, y - 1)) == TER_WATER;
 }
 
 static void generateRiverbed()
@@ -814,7 +814,7 @@ static void generateRiverbed()
 			if (isWaterVertex(x, y))
 			{
 				l = (WATER_MAX_DEPTH + 1 - WATER_MIN_DEPTH) * (maxIdx - idxVal - mt.u32() % (maxIdx / 6 + 1));
-				mapTile(x, y)->height -= WATER_MIN_DEPTH - (l / maxIdx);
+				mapTile(worldMapState, x, y)->height -= WATER_MIN_DEPTH - (l / maxIdx);
 			}
 		}
 	}
@@ -1142,7 +1142,7 @@ static bool afterMapLoad()
 		for (int x = 0; x < worldMapState.width; ++x)
 		{
 			// FIXME: magic number
-			mapTile(x, y)->waterLevel = mapTile(x, y)->height - world_coord(1) / 3;
+			mapTile(worldMapState, x, y)->waterLevel = mapTile(worldMapState, x, y)->height - world_coord(1) / 3;
 		}
 	}
 	generateRiverbed();
@@ -1168,27 +1168,27 @@ static bool afterMapLoad()
 	{
 		for (int x = 0; x < worldMapState.width; ++x)
 		{
-			MAPTILE *psTile = mapTile(x, y);
+			MAPTILE *psTile = mapTile(worldMapState, x, y);
 
-			auxClearBlocking(x, y, AUXBITS_ALL);
-			auxClearAll(x, y, AUXBITS_ALL);
+			auxClearBlocking(worldMapState, x, y, AUXBITS_ALL);
+			auxClearAll(worldMapState, x, y, AUXBITS_ALL);
 
 			/* All tiles outside of the map and on map border are blocking. */
 			if (x < 1 || y < 1 || x > worldMapState.width - 1 || y > worldMapState.height - 1)
 			{
-				auxSetBlocking(x, y, AUXBITS_ALL);	// block everything
+				auxSetBlocking(worldMapState, x, y, AUXBITS_ALL);	// block everything
 			}
 			if (terrainType(psTile) == TER_WATER)
 			{
-				auxSetBlocking(x, y, WATER_BLOCKED);
+				auxSetBlocking(worldMapState, x, y, WATER_BLOCKED);
 			}
 			else
 			{
-				auxSetBlocking(x, y, LAND_BLOCKED);
+				auxSetBlocking(worldMapState, x, y, LAND_BLOCKED);
 			}
 			if (terrainType(psTile) == TER_CLIFFFACE)
 			{
-				auxSetBlocking(x, y, FEATURE_BLOCKED);
+				auxSetBlocking(worldMapState, x, y, FEATURE_BLOCKED);
 			}
 		}
 	}
@@ -1526,7 +1526,7 @@ unsigned map_LineIntersect(Vector3i src, Vector3i dst, unsigned tMax)
 		for (int q = 0; q < 4; ++q)
 		{
 			Vector2i corner = tile + quadrantCorner(quadrant + q);
-			height[q] = map_TileHeightSurface(corner.x, corner.y);
+			height[q] = map_TileHeightSurface(worldMapState, corner.x, corner.y);
 		}
 		Vector3i dif = dst - src;
 		//     We are considering the volume of a quadrant (the volume above a quarter of a map tile, which is
@@ -1599,7 +1599,7 @@ unsigned map_LineIntersect(Vector3i src, Vector3i dst, unsigned tMax)
 }
 
 /// The max height of the terrain and water at the specified world coordinates
-extern int32_t map_Height(int x, int y)
+extern int32_t map_Height(const WorldMapState& mapState, int x, int y)
 {
 	int tileX, tileY;
 	int i, j;
@@ -1611,14 +1611,14 @@ extern int32_t map_Height(int x, int y)
 
 	// Clamp x and y values to actual ones
 	// Give one tile worth of leeway before asserting, for units/transporters coming in from off-map.
-	ASSERT(x >= -TILE_UNITS, "map_Height: x value is too small (%d,%d) in %dx%d", map_coord(x), map_coord(y), worldMapState.width, worldMapState.height);
-	ASSERT(y >= -TILE_UNITS, "map_Height: y value is too small (%d,%d) in %dx%d", map_coord(x), map_coord(y), worldMapState.width, worldMapState.height);
+	ASSERT(x >= -TILE_UNITS, "map_Height: x value is too small (%d,%d) in %dx%d", map_coord(x), map_coord(y), mapState.width, mapState.height);
+	ASSERT(y >= -TILE_UNITS, "map_Height: y value is too small (%d,%d) in %dx%d", map_coord(x), map_coord(y), mapState.width, mapState.height);
 	x = MAX(x, 0);
 	y = MAX(y, 0);
-	ASSERT(x < world_coord(worldMapState.width) + TILE_UNITS, "map_Height: x value is too big (%d,%d) in %dx%d", map_coord(x), map_coord(y), worldMapState.width, worldMapState.height);
-	ASSERT(y < world_coord(worldMapState.height) + TILE_UNITS, "map_Height: y value is too big (%d,%d) in %dx%d", map_coord(x), map_coord(y), worldMapState.width, worldMapState.height);
-	x = MIN(x, world_coord(worldMapState.width) - 1);
-	y = MIN(y, world_coord(worldMapState.height) - 1);
+	ASSERT(x < world_coord(mapState.width) + TILE_UNITS, "map_Height: x value is too big (%d,%d) in %dx%d", map_coord(x), map_coord(y), mapState.width, mapState.height);
+	ASSERT(y < world_coord(mapState.height) + TILE_UNITS, "map_Height: y value is too big (%d,%d) in %dx%d", map_coord(x), map_coord(y), mapState.width, mapState.height);
+	x = MIN(x, world_coord(mapState.width) - 1);
+	y = MIN(y, world_coord(mapState.height) - 1);
 
 	// on which tile are these coords?
 	tileX = map_coord(x);
@@ -1634,7 +1634,7 @@ extern int32_t map_Height(int x, int y)
 	{
 		for (j = 0; j < 2; j++)
 		{
-			height[i][j] = map_TileHeightSurface(tileX + i, tileY + j);
+			height[i][j] = map_TileHeightSurface(mapState, tileX + i, tileY + j);
 			center += height[i][j];
 		}
 	}
@@ -1728,7 +1728,7 @@ bool mapObjIsAboveGround(const SIMPLE_OBJECT *psObj)
 	}
 
 	/* exhaustive test */
-	return psObj->pos.z > map_Height(psObj->pos.x, psObj->pos.y);
+	return psObj->pos.z > map_Height(worldMapState, psObj->pos.x, psObj->pos.y);
 }
 
 /* returns the max and min height of a tile by looking at the four corners
@@ -1741,7 +1741,7 @@ void getTileMaxMin(int x, int y, int *pMax, int *pMin)
 	for (int j = 0; j < 2; ++j)
 		for (int i = 0; i < 2; ++i)
 		{
-			int height = map_TileHeight(x + i, y + j);
+			int height = map_TileHeight(worldMapState, x + i, y + j);
 			*pMin = std::min(*pMin, height);
 			*pMax = std::max(*pMax, height);
 		}
@@ -1901,7 +1901,7 @@ static void mapFloodFill(int x, int y, int continent, uint8_t blockedBits, uint1
 {
 	std::vector<Vector2i> open;
 	open.push_back(Vector2i(x, y));
-	mapTile(x, y)->*varContinent = continent;  // Set continent value
+	mapTile(worldMapState, x, y)->*varContinent = continent;  // Set continent value
 
 	while (!open.empty())
 	{
@@ -1919,9 +1919,9 @@ static void mapFloodFill(int x, int y, int continent, uint8_t blockedBits, uint1
 			{
 				continue;
 			}
-			MAPTILE *psTile = mapTile(npos);
+			MAPTILE *psTile = mapTile(worldMapState, npos);
 
-			if (!(blockTile(npos.x, npos.y, AUX_MAP) & blockedBits) && psTile->*varContinent == 0)
+			if (!(blockTile(worldMapState, npos.x, npos.y, AUX_MAP) & blockedBits) && psTile->*varContinent == 0)
 			{
 				open.push_back(npos);               // add to open list
 				psTile->*varContinent = continent;  // Set continent value
@@ -1939,7 +1939,7 @@ void mapFloodFillContinents()
 	{
 		for (x = 0; x < worldMapState.width; x++)
 		{
-			MAPTILE *psTile = mapTile(x, y);
+			MAPTILE *psTile = mapTile(worldMapState, x, y);
 
 			psTile->limitedContinent = 0;
 			psTile->hoverContinent = 0;
@@ -1951,7 +1951,7 @@ void mapFloodFillContinents()
 	{
 		for (x = 1; x < worldMapState.width - 2; x++)
 		{
-			MAPTILE *psTile = mapTile(x, y);
+			MAPTILE *psTile = mapTile(worldMapState, x, y);
 
 			if (psTile->limitedContinent == 0 && !fpathBlockingTile(x, y, PROPULSION_TYPE_WHEELED))
 			{
@@ -1971,11 +1971,11 @@ void mapFloodFillContinents()
 	debug(LOG_MAP, "Found %d limited and %d hover continents", limitedContinents, hoverContinents);
 }
 
-void tileSetFire(int32_t x, int32_t y, uint32_t duration)
+void tileSetFire(WorldMapState& mapState, int32_t x, int32_t y, uint32_t duration)
 {
 	const int posX = map_coord(x);
 	const int posY = map_coord(y);
-	MAPTILE *const tile = mapTile(posX, posY);
+	MAPTILE *const tile = mapTile(mapState, posX, posY);
 
 	uint16_t currentTime =  gameTime             / GAME_TICKS_PER_UPDATE;
 	uint16_t fireEndTime = (gameTime + duration) / GAME_TICKS_PER_UPDATE;
@@ -1996,11 +1996,11 @@ void tileSetFire(int32_t x, int32_t y, uint32_t duration)
 }
 
 /** Check if tile contained within the given world coordinates is burning. */
-bool fireOnLocation(unsigned int x, unsigned int y)
+bool fireOnLocation(WorldMapState& mapState, unsigned int x, unsigned int y)
 {
 	const int posX = map_coord(x);
 	const int posY = map_coord(y);
-	const MAPTILE *psTile = mapTile(posX, posY);
+	const MAPTILE *psTile = mapTile(mapState, posX, posY);
 
 	ASSERT(psTile, "Checking fire on tile outside the map (%d, %d)", posX, posY);
 	return psTile != nullptr && TileIsBurning(psTile);
@@ -2021,8 +2021,8 @@ static int dangerFloodFill(int player)
 	{
 		for (x = 0; x < worldMapState.width; x++)
 		{
-			auxSet(x, y, MAX_PLAYERS + AUX_DANGERMAP, AUXBITS_DANGER);
-			auxClear(x, y, MAX_PLAYERS + AUX_DANGERMAP, AUXBITS_TEMPORARY);
+			auxSet(worldMapState, x, y, MAX_PLAYERS + AUX_DANGERMAP, AUXBITS_DANGER);
+			auxClear(worldMapState, x, y, MAX_PLAYERS + AUX_DANGERMAP, AUXBITS_TEMPORARY);
 		}
 	}
 
@@ -2037,12 +2037,12 @@ static int dangerFloodFill(int player)
 		{
 			npos.x = pos.x + aDirOffset[i].x;
 			npos.y = pos.y + aDirOffset[i].y;
-			if (!tileOnMap(npos.x, npos.y))
+			if (!tileOnMap(worldMapState, npos.x, npos.y))
 			{
 				continue;
 			}
-			aux = auxTile(npos.x, npos.y, MAX_PLAYERS + AUX_DANGERMAP);
-			block = blockTile(pos.x, pos.y, AUX_DANGERMAP);
+			aux = auxTile(worldMapState, npos.x, npos.y, MAX_PLAYERS + AUX_DANGERMAP);
+			block = blockTile(worldMapState, pos.x, pos.y, AUX_DANGERMAP);
 			if (!(aux & AUXBITS_TEMPORARY) && !(aux & AUXBITS_THREAT) && (aux & AUXBITS_DANGER))
 			{
 				// Note that we do not consider water to be a blocker here. This may or may not be a feature...
@@ -2058,14 +2058,14 @@ static int dangerFloodFill(int player)
 				}
 				else
 				{
-					auxClear(npos.x, npos.y, MAX_PLAYERS + AUX_DANGERMAP, AUXBITS_DANGER);
+					auxClear(worldMapState, npos.x, npos.y, MAX_PLAYERS + AUX_DANGERMAP, AUXBITS_DANGER);
 				}
-				auxSet(npos.x, npos.y, MAX_PLAYERS + AUX_DANGERMAP, AUXBITS_TEMPORARY); // make sure we do not process it more than once
+				auxSet(worldMapState, npos.x, npos.y, MAX_PLAYERS + AUX_DANGERMAP, AUXBITS_TEMPORARY); // make sure we do not process it more than once
 			}
 		}
 
 		// Clear danger
-		auxClear(pos.x, pos.y, MAX_PLAYERS + AUX_DANGERMAP, AUXBITS_DANGER);
+		auxClear(worldMapState, pos.x, pos.y, MAX_PLAYERS + AUX_DANGERMAP, AUXBITS_DANGER);
 
 		// Pop the last open node off the bucket list for the next iteration
 		if (bucketcounter)
@@ -2099,11 +2099,11 @@ static inline void threatUpdateTarget(int player, BASE_OBJECT *psObj, bool groun
 		{
 			if (ground)
 			{
-				auxSet(pos.x, pos.y, MAX_PLAYERS + AUX_DANGERMAP, AUXBITS_THREAT);	// set ground threat for this tile
+				auxSet(worldMapState, pos.x, pos.y, MAX_PLAYERS + AUX_DANGERMAP, AUXBITS_THREAT);	// set ground threat for this tile
 			}
 			if (air)
 			{
-				auxSet(pos.x, pos.y, MAX_PLAYERS + AUX_DANGERMAP, AUXBITS_AATHREAT);	// set air threat for this tile
+				auxSet(worldMapState, pos.x, pos.y, MAX_PLAYERS + AUX_DANGERMAP, AUXBITS_AATHREAT);	// set air threat for this tile
 			}
 		}
 	}
@@ -2118,7 +2118,7 @@ static void threatUpdate(int player)
 	{
 		for (x = 0; x < worldMapState.width; x++)
 		{
-			auxClear(x, y, MAX_PLAYERS + AUX_DANGERMAP, AUXBITS_THREAT | AUXBITS_AATHREAT);
+			auxClear(worldMapState, x, y, MAX_PLAYERS + AUX_DANGERMAP, AUXBITS_THREAT | AUXBITS_AATHREAT);
 		}
 	}
 
@@ -2190,10 +2190,10 @@ void mapInit()
 	{
 		for (player = 0; player < MAX_PLAYERS; player++)
 		{
-			auxMapStore(player, AUX_DANGERMAP);
+			auxMapStore(worldMapState, player, AUX_DANGERMAP);
 			threatUpdate(player);
 			dangerFloodFill(player);
-			auxMapRestore(player, AUX_DANGERMAP, AUXBITS_DANGER | AUXBITS_THREAT | AUXBITS_AATHREAT);
+			auxMapRestore(worldMapState, player, AUX_DANGERMAP, AUXBITS_DANGER | AUXBITS_THREAT | AUXBITS_AATHREAT);
 		}
 		lastDangerPlayer = 0;
 		dangerSemaphore = wzSemaphoreCreate(0);
@@ -2211,7 +2211,7 @@ void mapUpdate()
 	for (posY = 0; posY < worldMapState.height; ++posY)
 		for (posX = 0; posX < worldMapState.width; ++posX)
 		{
-			MAPTILE *const tile = mapTile(posX, posY);
+			MAPTILE *const tile = mapTile(worldMapState, posX, posY);
 
 			if ((tile->tileInfoBits & BITS_ON_FIRE) != 0 && tile->fireEndTime == currentTime)
 			{
@@ -2230,9 +2230,9 @@ void mapUpdate()
 		// Lock if previous job not done yet
 		wzSemaphoreWait(dangerDoneSemaphore);
 
-		auxMapRestore(lastDangerPlayer, AUX_DANGERMAP, AUXBITS_THREAT | AUXBITS_AATHREAT | AUXBITS_DANGER);
+		auxMapRestore(worldMapState, lastDangerPlayer, AUX_DANGERMAP, AUXBITS_THREAT | AUXBITS_AATHREAT | AUXBITS_DANGER);
 		lastDangerPlayer = (lastDangerPlayer + 1) % game.maxPlayers;
-		auxMapStore(lastDangerPlayer, AUX_DANGERMAP);
+		auxMapStore(worldMapState, lastDangerPlayer, AUX_DANGERMAP);
 		threatUpdate(lastDangerPlayer);
 		wzSemaphorePost(dangerSemaphore);
 	}

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -39,6 +39,7 @@
 #include "projectile.h"
 #include "display3d.h"
 #include "game.h"
+#include "world_map_state.h"
 #include "texture.h"
 #include "advvis.h"
 #include "random.h"
@@ -69,8 +70,7 @@ static int bucketcounter;
 static UDWORD lastDangerUpdate = 0;
 static int lastDangerPlayer = -1;
 
-//scroll min and max values
-SDWORD		scrollMinX, scrollMaxX, scrollMinY, scrollMaxY;
+WorldMapState worldMapState;
 
 //For saves to determine if loading the terrain type override should occur
 bool builtInMap;
@@ -109,12 +109,6 @@ struct GATEWAY_SAVE
 // Maximum expected return value from get height
 #define	MAX_HEIGHT			(256 * ELEVATION_SCALE)
 
-/* The size and contents of the map */
-SDWORD	mapWidth = 0, mapHeight = 0;
-std::unique_ptr<MAPTILE[]> psMapTiles;
-std::unique_ptr<uint8_t[]> psBlockMap[AUX_MAX];
-std::unique_ptr<uint8_t[]> psAuxMap[MAX_PLAYERS + AUX_MAX];        // yes, we waste one element... eyes wide open... makes API nicer
-
 #define WATER_MIN_DEPTH 500
 #define WATER_MAX_DEPTH (WATER_MIN_DEPTH + 400)
 
@@ -146,10 +140,10 @@ void syncLogDumpAuxMaps()
 	for (int auxIdx = 0; auxIdx < MAX_PLAYERS + AUX_MAX; auxIdx++)
 	{
 		syncDebug("psAuxMap[%d]:", auxIdx);
-		for (int y = 0; y < mapHeight; ++y)
+		for (int y = 0; y < worldMapState.height; ++y)
 		{
 			std::string rowDetails;
-			for (int x = 0; x < mapWidth; ++x)
+			for (int x = 0; x < worldMapState.width; ++x)
 			{
 				auto val = auxTile(x, y, auxIdx);
 				rowDetails += std::to_string(val) + ",";
@@ -161,10 +155,10 @@ void syncLogDumpAuxMaps()
 	for (int idx = 0; idx < AUX_MAX; idx++)
 	{
 		syncDebug("psBlockMap[%d]:", idx);
-		for (int y = 0; y < mapHeight; ++y)
+		for (int y = 0; y < worldMapState.height; ++y)
 		{
 			std::string rowDetails;
-			for (int x = 0; x < mapWidth; ++x)
+			for (int x = 0; x < worldMapState.width; ++x)
 			{
 				auto val = blockTile(x, y, idx);
 				rowDetails += std::to_string(val) + ",";
@@ -563,7 +557,7 @@ static int determineGroundType(int x, int y, const char *tileset)
 	int a, b, best;
 	MAPTILE *psTile;
 
-	if (x < 0 || y < 0 || x >= mapWidth || y >= mapHeight)
+	if (x < 0 || y < 0 || x >= worldMapState.width || y >= worldMapState.height)
 	{
 		return 0; // just return the first ground type
 	}
@@ -573,7 +567,7 @@ static int determineGroundType(int x, int y, const char *tileset)
 	{
 		for (j = 0; j < 2; j++)
 		{
-			if (x + i - 1 < 0 || y + j - 1 < 0 || x + i - 1 >= mapWidth || y + j - 1 >= mapHeight)
+			if (x + i - 1 < 0 || y + j - 1 < 0 || x + i - 1 >= worldMapState.width || y + j - 1 >= worldMapState.height)
 			{
 				psTile = nullptr;
 				tile = 0;
@@ -708,9 +702,9 @@ static bool hasDecals(int i, int j)
 // Sets the ground type to be a decal or not
 static bool mapSetGroundTypes()
 {
-	for (int j = 0; j < mapHeight; j++)
+	for (int j = 0; j < worldMapState.height; j++)
 	{
-		for (int i = 0; i < mapWidth; i++)
+		for (int i = 0; i < worldMapState.width; i++)
 		{
 			MAPTILE *psTile = mapTile(i, j);
 
@@ -745,7 +739,7 @@ bool mapReloadGroundTypes()
 
 static bool isWaterVertex(int x, int y)
 {
-	if (x < 1 || y < 1 || x > mapWidth - 1 || y > mapHeight - 1)
+	if (x < 1 || y < 1 || x > worldMapState.width - 1 || y > worldMapState.height - 1)
 	{
 		return false;
 	}
@@ -757,17 +751,17 @@ static void generateRiverbed()
 {
 	MersenneTwister mt(12345);  // 12345 = random seed.
 	int maxIdx = 1;
-	ASSERT_OR_RETURN(, mapWidth > 0 && mapHeight > 0, "Invalid map width or height (%d x %d)", mapWidth, mapHeight);
-	std::vector<int> idx(static_cast<size_t>(mapWidth) * static_cast<size_t>(mapHeight), 0);
+	ASSERT_OR_RETURN(, worldMapState.width > 0 && worldMapState.height > 0, "Invalid map width or height (%d x %d)", worldMapState.width, worldMapState.height);
+	std::vector<int> idx(static_cast<size_t>(worldMapState.width) * static_cast<size_t>(worldMapState.height), 0);
 	int x, y, l = 0;
 
-	for (y = 0; y < mapHeight; y++)
+	for (y = 0; y < worldMapState.height; y++)
 	{
-		for (x = 0; x < mapWidth; x++)
+		for (x = 0; x < worldMapState.width; x++)
 		{
 			// initially set the seabed index to 0 for ground and 100 for water
 			int val = 100 * isWaterVertex(x, y);
-			idx[x + (y * mapWidth)] = val;
+			idx[x + (y * worldMapState.width)] = val;
 			if (val > 0)
 			{
 				l++;
@@ -783,15 +777,15 @@ static void generateRiverbed()
 	do
 	{
 		maxIdx = 1;
-		for (y = 1; y < mapHeight - 2; y++)
+		for (y = 1; y < worldMapState.height - 2; y++)
 		{
-			for (x = 1; x < mapWidth - 2; x++)
+			for (x = 1; x < worldMapState.width - 2; x++)
 			{
-				int rowOffset = (y * mapWidth);
+				int rowOffset = (y * worldMapState.width);
 				auto& idxVal = idx[x + rowOffset];
 				if (idxVal > 0)
 				{
-					idxVal = (idx[(x - 1) + rowOffset] + idx[x + ((y - 1) * mapWidth)] + idx[x + ((y + 1) * mapWidth)] + idx[(x + 1) + rowOffset]) / 4;
+					idxVal = (idx[(x - 1) + rowOffset] + idx[x + ((y - 1) * worldMapState.width)] + idx[x + ((y + 1) * worldMapState.width)] + idx[(x + 1) + rowOffset]) / 4;
 					if (idxVal > maxIdx)
 					{
 						maxIdx = idxVal;
@@ -804,11 +798,11 @@ static void generateRiverbed()
 	}
 	while (maxIdx > 90 && l < 20);
 
-	for (y = 0; y < mapHeight; y++)
+	for (y = 0; y < worldMapState.height; y++)
 	{
-		for (x = 0; x < mapWidth; x++)
+		for (x = 0; x < worldMapState.width; x++)
 		{
-			auto& idxVal = idx[x + (y * mapWidth)];
+			auto& idxVal = idx[x + (y * worldMapState.width)];
 			if (idxVal > maxIdx)
 			{
 				idxVal = maxIdx;
@@ -1064,15 +1058,15 @@ bool mapLoadFromWzMapData(std::shared_ptr<WzMap::MapData> loadedMap)
 	height = loadedMap->height;
 
 	/* See if this is the first time a map has been loaded */
-	ASSERT(psMapTiles == nullptr, "Map has not been cleared before calling mapLoad()!");
+	ASSERT(worldMapState.tiles == nullptr, "Map has not been cleared before calling mapLoad()!");
 
 	/* Allocate the memory for the map */
-	psMapTiles = std::make_unique<MAPTILE[]>(static_cast<size_t>(width) * height);
+	worldMapState.tiles = std::make_unique<MAPTILE[]>(static_cast<size_t>(width) * height);
 	getCurrentLightmapData().reset(width, height);
-	ASSERT(psMapTiles != nullptr, "Out of memory");
+	ASSERT(worldMapState.tiles != nullptr, "Out of memory");
 
-	mapWidth = width;
-	mapHeight = height;
+	worldMapState.width = width;
+	worldMapState.height = height;
 
 	// FIXME: the map preview code loads the map without setting the tileset
 	if (!tilesetDir)
@@ -1097,19 +1091,19 @@ bool mapLoadFromWzMapData(std::shared_ptr<WzMap::MapData> loadedMap)
 	//load in the map data itself
 
 	/* Load in the map data */
-	for (int i = 0; i < mapWidth * mapHeight; ++i)
+	for (int i = 0; i < worldMapState.width * worldMapState.height; ++i)
 	{
 		ASSERT(loadedMap->mMapTiles[i].height <= TILE_MAX_HEIGHT, "Tile height (%" PRIu16 ") exceeds TILE_MAX_HEIGHT (%zu)", loadedMap->mMapTiles[i].height, static_cast<size_t>(TILE_MAX_HEIGHT));
-		psMapTiles[i].texture = loadedMap->mMapTiles[i].texture;
-		psMapTiles[i].height = loadedMap->mMapTiles[i].height;
+		worldMapState.tiles[i].texture = loadedMap->mMapTiles[i].texture;
+		worldMapState.tiles[i].height = loadedMap->mMapTiles[i].height;
 
 		// Visibility stuff
-		memset(psMapTiles[i].watchers, 0, sizeof(psMapTiles[i].watchers));
-		memset(psMapTiles[i].sensors, 0, sizeof(psMapTiles[i].sensors));
-		memset(psMapTiles[i].jammers, 0, sizeof(psMapTiles[i].jammers));
-		psMapTiles[i].sensorBits = 0;
-		psMapTiles[i].jammerBits = 0;
-		psMapTiles[i].tileExploredBits = 0;
+		memset(worldMapState.tiles[i].watchers, 0, sizeof(worldMapState.tiles[i].watchers));
+		memset(worldMapState.tiles[i].sensors, 0, sizeof(worldMapState.tiles[i].sensors));
+		memset(worldMapState.tiles[i].jammers, 0, sizeof(worldMapState.tiles[i].jammers));
+		worldMapState.tiles[i].sensorBits = 0;
+		worldMapState.tiles[i].jammerBits = 0;
+		worldMapState.tiles[i].tileExploredBits = 0;
 	}
 
 	if (preview)
@@ -1143,9 +1137,9 @@ static bool afterMapLoad()
 		return false;
 	}
 
-	for (int y = 0; y < mapHeight; ++y)
+	for (int y = 0; y < worldMapState.height; ++y)
 	{
-		for (int x = 0; x < mapWidth; ++x)
+		for (int x = 0; x < worldMapState.width; ++x)
 		{
 			// FIXME: magic number
 			mapTile(x, y)->waterLevel = mapTile(x, y)->height - world_coord(1) / 3;
@@ -1154,25 +1148,25 @@ static bool afterMapLoad()
 	generateRiverbed();
 
 	/* set up the scroll mins and maxs - set values to valid ones for any new map */
-	scrollMinX = scrollMinY = 0;
-	scrollMaxX = mapWidth;
-	scrollMaxY = mapHeight;
+	worldMapState.scroll.minX = worldMapState.scroll.minY = 0;
+	worldMapState.scroll.maxX = worldMapState.width;
+	worldMapState.scroll.maxY = worldMapState.height;
 
 	/* Allocate aux maps */
-	ASSERT(mapWidth >= 0 && mapHeight >= 0, "Invalid mapWidth or mapHeight (%d x %d)", mapWidth, mapHeight);
-	const size_t mapSize = static_cast<size_t>(mapWidth) * static_cast<size_t>(mapHeight);
-	psBlockMap[AUX_MAP] = std::make_unique<uint8_t[]>(mapSize);
-	psBlockMap[AUX_ASTARMAP] =  std::make_unique<uint8_t[]>(mapSize);
-	psBlockMap[AUX_DANGERMAP] = std::make_unique<uint8_t[]>(mapSize);
+	ASSERT(worldMapState.width >= 0 && worldMapState.height >= 0, "Invalid mapWidth or mapHeight (%d x %d)", worldMapState.width, worldMapState.height);
+	const size_t mapSize = static_cast<size_t>(worldMapState.width) * static_cast<size_t>(worldMapState.height);
+	worldMapState.blockMap[AUX_MAP] = std::make_unique<uint8_t[]>(mapSize);
+	worldMapState.blockMap[AUX_ASTARMAP] =  std::make_unique<uint8_t[]>(mapSize);
+	worldMapState.blockMap[AUX_DANGERMAP] = std::make_unique<uint8_t[]>(mapSize);
 	for (int x = 0; x < MAX_PLAYERS + AUX_MAX; ++x)
 	{
-		psAuxMap[x] = std::make_unique<uint8_t[]> (mapSize);
+		worldMapState.auxMap[x] = std::make_unique<uint8_t[]> (mapSize);
 	}
 
 	// Set our blocking bits
-	for (int y = 0; y < mapHeight; ++y)
+	for (int y = 0; y < worldMapState.height; ++y)
 	{
-		for (int x = 0; x < mapWidth; ++x)
+		for (int x = 0; x < worldMapState.width; ++x)
 		{
 			MAPTILE *psTile = mapTile(x, y);
 
@@ -1180,7 +1174,7 @@ static bool afterMapLoad()
 			auxClearAll(x, y, AUXBITS_ALL);
 
 			/* All tiles outside of the map and on map border are blocking. */
-			if (x < 1 || y < 1 || x > mapWidth - 1 || y > mapHeight - 1)
+			if (x < 1 || y < 1 || x > worldMapState.width - 1 || y > worldMapState.height - 1)
 			{
 				auxSetBlocking(x, y, AUXBITS_ALL);	// block everything
 			}
@@ -1208,8 +1202,8 @@ static bool afterMapLoad()
 /* Save the map data */
 bool mapSaveToWzMapData(WzMap::MapData& output)
 {
-	output.width = mapWidth;
-	output.height = mapHeight;
+	output.width = worldMapState.width;
+	output.height = worldMapState.height;
 
 	// Write out the map tile data
 	uint32_t numMapTiles = output.width * output.height;
@@ -1218,14 +1212,14 @@ bool mapSaveToWzMapData(WzMap::MapData& output)
 	for (uint32_t i = 0; i < numMapTiles; i++)
 	{
 		WzMap::MapData::MapTile mapDataTile = {};
-		mapDataTile.texture = psMapTiles[i].texture;
-		if (terrainType(&psMapTiles[i]) == TER_WATER)
+		mapDataTile.texture = worldMapState.tiles[i].texture;
+		if (terrainType(&worldMapState.tiles[i]) == TER_WATER)
 		{
-			mapDataTile.height = (psMapTiles[i].waterLevel + world_coord(1) / 3); // this magic number stuff should match afterMapLoad()'s handling of water tiles (??)
+			mapDataTile.height = (worldMapState.tiles[i].waterLevel + world_coord(1) / 3); // this magic number stuff should match afterMapLoad()'s handling of water tiles (??)
 		}
 		else
 		{
-			mapDataTile.height = psMapTiles[i].height;
+			mapDataTile.height = worldMapState.tiles[i].height;
 		}
 		output.mMapTiles.push_back(std::move(mapDataTile));
 	}
@@ -1242,7 +1236,7 @@ bool mapSaveToWzMapData(WzMap::MapData& output)
 		gw.y2 = psCurrGate->y2;
 		ASSERT(gw.x1 == gw.x2 || gw.y1 == gw.y2, "Invalid gateway coordinates (%d, %d, %d, %d)",
 			   gw.x1, gw.y1, gw.x2, gw.y2);
-		ASSERT(gw.x1 < mapWidth && gw.y1 < mapHeight && gw.x2 < mapWidth && gw.y2 < mapHeight,
+		ASSERT(gw.x1 < worldMapState.width && gw.y1 < worldMapState.height && gw.x2 < worldMapState.width && gw.y2 < worldMapState.height,
 			   "Bad gateway dimensions for savegame");
 		output.mGateways.push_back(std::move(gw));
 	}
@@ -1269,21 +1263,21 @@ bool mapShutdown()
 	}
 
 	mapDecals = nullptr;
-	psBlockMap[AUX_MAP] = nullptr;
-	psBlockMap[AUX_ASTARMAP] = nullptr;
+	worldMapState.blockMap[AUX_MAP] = nullptr;
+	worldMapState.blockMap[AUX_ASTARMAP] = nullptr;
 	free(floodbucket);
-	psBlockMap[AUX_DANGERMAP] = nullptr;
+	worldMapState.blockMap[AUX_DANGERMAP] = nullptr;
 	for (x = 0; x < MAX_PLAYERS + AUX_MAX; x++)
 	{
-		psAuxMap[x].reset();
+		worldMapState.auxMap[x].reset();
 	}
 
 	map = nullptr;
 	floodbucket = nullptr;
 	groundTypes.clear();
 	mapDecals = nullptr;
-	psMapTiles = nullptr;
-	mapWidth = mapHeight = 0;
+	worldMapState.tiles = nullptr;
+	worldMapState.width = worldMapState.height = 0;
 	numTile_names = 0;
 	Tile_names = nullptr;
 	if (tilesetDir)
@@ -1413,7 +1407,7 @@ bool map_Intersect(int *Cx, int *Cy, int *Vx, int *Vy, int *Sx, int *Sy)
 	ASSERT(*Cy >= world_coord(tileY) && *Cy <= world_coord(tileY + 1), "map_Intersect(): tile Bounds %i %i, %i %i -> %i,%i,%i,%i", x, y, Dx, Dy, *Cx, *Cy, *Vx, *Vy);
 	ASSERT(*Vx >= world_coord(tileX) && *Vx <= world_coord(tileX + 1), "map_Intersect(): tile Bounds %i %i, %i %i -> %i,%i,%i,%i", x, y, Dx, Dy, *Cx, *Cy, *Vx, *Vy);
 	ASSERT(*Vy >= world_coord(tileY) && *Vy <= world_coord(tileY + 1), "map_Intersect(): tile Bounds %i %i, %i %i -> %i,%i,%i,%i", x, y, Dx, Dy, *Cx, *Cy, *Vx, *Vy);
-	ASSERT(tileX >= 0 && tileY >= 0 && tileX < mapWidth && tileY < mapHeight, "map_Intersect(): map Bounds %i %i, %i %i -> %i,%i,%i,%i", x, y, Dx, Dy, *Cx, *Cy, *Vx, *Vy);
+	ASSERT(tileX >= 0 && tileY >= 0 && tileX < worldMapState.width && tileY < worldMapState.height, "map_Intersect(): map Bounds %i %i, %i %i -> %i,%i,%i,%i", x, y, Dx, Dy, *Cx, *Cy, *Vx, *Vy);
 
 	//calculate midway line intersection points
 	if (((map_coord(itx) == tileX) == (map_coord(ily) == tileY)) && ((map_coord(ibx) == tileX) == (map_coord(iry) == tileY)))
@@ -1578,7 +1572,7 @@ unsigned map_LineIntersect(Vector3i src, Vector3i dst, unsigned tMax)
 			src = rotateWorldQuadrant(src, -2) + Vector3i(0, -TILE_UNITS, 0);
 			dst = rotateWorldQuadrant(dst, -2) + Vector3i(0, -TILE_UNITS, 0);
 
-			if (tile.x < 0 || tile.x >= mapWidth || tile.y < 0 || tile.y >= mapHeight)
+			if (tile.x < 0 || tile.x >= worldMapState.width || tile.y < 0 || tile.y >= worldMapState.height)
 			{
 				// Intersect edge of map.
 				return (int64_t)tMax * numer[firstIntersection] / denom[firstIntersection];
@@ -1617,14 +1611,14 @@ extern int32_t map_Height(int x, int y)
 
 	// Clamp x and y values to actual ones
 	// Give one tile worth of leeway before asserting, for units/transporters coming in from off-map.
-	ASSERT(x >= -TILE_UNITS, "map_Height: x value is too small (%d,%d) in %dx%d", map_coord(x), map_coord(y), mapWidth, mapHeight);
-	ASSERT(y >= -TILE_UNITS, "map_Height: y value is too small (%d,%d) in %dx%d", map_coord(x), map_coord(y), mapWidth, mapHeight);
+	ASSERT(x >= -TILE_UNITS, "map_Height: x value is too small (%d,%d) in %dx%d", map_coord(x), map_coord(y), worldMapState.width, worldMapState.height);
+	ASSERT(y >= -TILE_UNITS, "map_Height: y value is too small (%d,%d) in %dx%d", map_coord(x), map_coord(y), worldMapState.width, worldMapState.height);
 	x = MAX(x, 0);
 	y = MAX(y, 0);
-	ASSERT(x < world_coord(mapWidth) + TILE_UNITS, "map_Height: x value is too big (%d,%d) in %dx%d", map_coord(x), map_coord(y), mapWidth, mapHeight);
-	ASSERT(y < world_coord(mapHeight) + TILE_UNITS, "map_Height: y value is too big (%d,%d) in %dx%d", map_coord(x), map_coord(y), mapWidth, mapHeight);
-	x = MIN(x, world_coord(mapWidth) - 1);
-	y = MIN(y, world_coord(mapHeight) - 1);
+	ASSERT(x < world_coord(worldMapState.width) + TILE_UNITS, "map_Height: x value is too big (%d,%d) in %dx%d", map_coord(x), map_coord(y), worldMapState.width, worldMapState.height);
+	ASSERT(y < world_coord(worldMapState.height) + TILE_UNITS, "map_Height: y value is too big (%d,%d) in %dx%d", map_coord(x), map_coord(y), worldMapState.width, worldMapState.height);
+	x = MIN(x, world_coord(worldMapState.width) - 1);
+	y = MIN(y, world_coord(worldMapState.height) - 1);
 
 	// on which tile are these coords?
 	tileX = map_coord(x);
@@ -1711,15 +1705,15 @@ bool mapObjIsAboveGround(const SIMPLE_OBJECT *psObj)
 {
 	// min is used to make sure we don't go over array bounds!
 	// TODO Using the corner of the map instead doesn't make sense. Fix this...
-	const int mapsize = mapWidth * mapHeight - 1;
+	const int mapsize = worldMapState.width * worldMapState.height - 1;
 	const int tileX = map_coord(psObj->pos.x);
 	const int tileY = map_coord(psObj->pos.y);
-	const int tileYOffset1 = (tileY * mapWidth);
-	const int tileYOffset2 = ((tileY + 1) * mapWidth);
-	const int h1 = psMapTiles[MIN(mapsize, tileYOffset1 + tileX)    ].height;
-	const int h2 = psMapTiles[MIN(mapsize, tileYOffset1 + tileX + 1)].height;
-	const int h3 = psMapTiles[MIN(mapsize, tileYOffset2 + tileX)    ].height;
-	const int h4 = psMapTiles[MIN(mapsize, tileYOffset2 + tileX + 1)].height;
+	const int tileYOffset1 = (tileY * worldMapState.width);
+	const int tileYOffset2 = ((tileY + 1) * worldMapState.width);
+	const int h1 = worldMapState.tiles[MIN(mapsize, tileYOffset1 + tileX)    ].height;
+	const int h2 = worldMapState.tiles[MIN(mapsize, tileYOffset1 + tileX + 1)].height;
+	const int h3 = worldMapState.tiles[MIN(mapsize, tileYOffset2 + tileX)    ].height;
+	const int h4 = worldMapState.tiles[MIN(mapsize, tileYOffset2 + tileX + 1)].height;
 
 	/* trivial test above */
 	if (psObj->pos.z > h1 && psObj->pos.z > h2 && psObj->pos.z > h3 && psObj->pos.z > h4)
@@ -1789,9 +1783,9 @@ bool writeVisibilityData(const char *fileName)
 
 	for (unsigned plane = 0; plane < planes; ++plane)
 	{
-		for (i = 0; i < mapWidth * mapHeight; ++i)
+		for (i = 0; i < worldMapState.width * worldMapState.height; ++i)
 		{
-			if (!PHYSFS_writeUBE8(fileHandle, psMapTiles[i].tileExploredBits >> (plane * 8)))
+			if (!PHYSFS_writeUBE8(fileHandle, worldMapState.tiles[i].tileExploredBits >> (plane * 8)))
 			{
 				debug(LOG_ERROR, "writeVisibilityData: could not write to %s; PHYSFS error: %s", fileName, WZ_PHYSFS_getLastError());
 				PHYSFS_close(fileHandle);
@@ -1848,7 +1842,7 @@ bool readVisibilityData(const char *fileName)
 	int planes = (game.maxPlayers + 7) / 8;
 
 	// Validate the filesize
-	expectedFileSize = sizeof(fileHeader.aFileType) + sizeof(fileHeader.version) + mapWidth * mapHeight * planes;
+	expectedFileSize = sizeof(fileHeader.aFileType) + sizeof(fileHeader.version) + worldMapState.width * worldMapState.height * planes;
 	fileSize = PHYSFS_fileLength(fileHandle);
 	if (fileSize != expectedFileSize)
 	{
@@ -1859,13 +1853,13 @@ bool readVisibilityData(const char *fileName)
 	}
 
 	// For every tile...
-	for (i = 0; i < mapWidth * mapHeight; i++)
+	for (i = 0; i < worldMapState.width * worldMapState.height; i++)
 	{
-		psMapTiles[i].tileExploredBits = 0;
+		worldMapState.tiles[i].tileExploredBits = 0;
 	}
 	for (unsigned plane = 0; plane < planes; ++plane)
 	{
-		for (i = 0; i < mapWidth * mapHeight; i++)
+		for (i = 0; i < worldMapState.width * worldMapState.height; i++)
 		{
 			/* Get the visibility data */
 			uint8_t val = 0;
@@ -1875,7 +1869,7 @@ bool readVisibilityData(const char *fileName)
 				PHYSFS_close(fileHandle);
 				return false;
 			}
-			psMapTiles[i].tileExploredBits |= val << (plane * 8);
+			worldMapState.tiles[i].tileExploredBits |= val << (plane * 8);
 		}
 	}
 
@@ -1921,7 +1915,7 @@ static void mapFloodFill(int x, int y, int continent, uint8_t blockedBits, uint1
 			// rely on the fact that all border tiles are inaccessible to avoid checking explicitly
 			Vector2i npos = pos + aDirOffset[i];
 
-			if (npos.x < 1 || npos.y < 1 || npos.x > mapWidth - 2 || npos.y > mapHeight - 2)
+			if (npos.x < 1 || npos.y < 1 || npos.x > worldMapState.width - 2 || npos.y > worldMapState.height - 2)
 			{
 				continue;
 			}
@@ -1941,9 +1935,9 @@ void mapFloodFillContinents()
 	int x, y, limitedContinents = 0, hoverContinents = 0;
 
 	/* Clear continents */
-	for (y = 0; y < mapHeight; y++)
+	for (y = 0; y < worldMapState.height; y++)
 	{
-		for (x = 0; x < mapWidth; x++)
+		for (x = 0; x < worldMapState.width; x++)
 		{
 			MAPTILE *psTile = mapTile(x, y);
 
@@ -1953,9 +1947,9 @@ void mapFloodFillContinents()
 	}
 
 	/* Iterate over the whole map, looking for unset continents */
-	for (y = 1; y < mapHeight - 2; y++)
+	for (y = 1; y < worldMapState.height - 2; y++)
 	{
-		for (x = 1; x < mapWidth - 2; x++)
+		for (x = 1; x < worldMapState.width - 2; x++)
 		{
 			MAPTILE *psTile = mapTile(x, y);
 
@@ -2023,9 +2017,9 @@ static int dangerFloodFill(int player)
 	bool start = true;	// hack to disregard the blocking status of any building exactly on the starting position
 
 	// Set our danger bits
-	for (y = 0; y < mapHeight; y++)
+	for (y = 0; y < worldMapState.height; y++)
 	{
-		for (x = 0; x < mapWidth; x++)
+		for (x = 0; x < worldMapState.width; x++)
 		{
 			auxSet(x, y, MAX_PLAYERS + AUX_DANGERMAP, AUXBITS_DANGER);
 			auxClear(x, y, MAX_PLAYERS + AUX_DANGERMAP, AUXBITS_TEMPORARY);
@@ -2120,9 +2114,9 @@ static void threatUpdate(int player)
 	int i, weapon, x, y;
 
 	// Step 1: Clear our threat bits
-	for (y = 0; y < mapHeight; y++)
+	for (y = 0; y < worldMapState.height; y++)
 	{
-		for (x = 0; x < mapWidth; x++)
+		for (x = 0; x < worldMapState.width; x++)
 		{
 			auxClear(x, y, MAX_PLAYERS + AUX_DANGERMAP, AUXBITS_THREAT | AUXBITS_AATHREAT);
 		}
@@ -2185,7 +2179,7 @@ void mapInit()
 	int player;
 
 	free(floodbucket);
-	floodbucket = (struct floodtile *)malloc(mapWidth * mapHeight * sizeof(*floodbucket));
+	floodbucket = (struct floodtile *)malloc(worldMapState.width * worldMapState.height * sizeof(*floodbucket));
 
 	lastDangerUpdate = 0;
 	lastDangerPlayer = -1;
@@ -2214,8 +2208,8 @@ void mapUpdate()
 	const uint16_t currentTime = gameTime / GAME_TICKS_PER_UPDATE;
 	int posX, posY;
 
-	for (posY = 0; posY < mapHeight; ++posY)
-		for (posX = 0; posX < mapWidth; ++posX)
+	for (posY = 0; posY < worldMapState.height; ++posY)
+		for (posX = 0; posX < worldMapState.width; ++posX)
 		{
 			MAPTILE *const tile = mapTile(posX, posY);
 

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -2131,7 +2131,7 @@ static void threatUpdate(int player)
 			continue;
 		}
 
-		for (DROID* psDroid : apsDroidLists[i])
+		for (DROID* psDroid : worldObjectState.droids[i])
 		{
 			UBYTE mode = 0;
 
@@ -2154,7 +2154,7 @@ static void threatUpdate(int player)
 			}
 		}
 
-		for (STRUCTURE* psStruct : apsStructLists[i])
+		for (STRUCTURE* psStruct : worldObjectState.structures[i])
 		{
 			UBYTE mode = 0;
 

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -70,8 +70,6 @@ static int bucketcounter;
 static UDWORD lastDangerUpdate = 0;
 static int lastDangerPlayer = -1;
 
-WorldMapState worldMapState;
-
 //For saves to determine if loading the terrain type override should occur
 bool builtInMap;
 bool useTerrainOverrides;
@@ -140,12 +138,12 @@ void syncLogDumpAuxMaps()
 	for (int auxIdx = 0; auxIdx < MAX_PLAYERS + AUX_MAX; auxIdx++)
 	{
 		syncDebug("psAuxMap[%d]:", auxIdx);
-		for (int y = 0; y < worldMapState.height; ++y)
+		for (int y = 0; y < gameWorld.map.height; ++y)
 		{
 			std::string rowDetails;
-			for (int x = 0; x < worldMapState.width; ++x)
+			for (int x = 0; x < gameWorld.map.width; ++x)
 			{
-				auto val = auxTile(worldMapState, x, y, auxIdx);
+				auto val = auxTile(gameWorld.map, x, y, auxIdx);
 				rowDetails += std::to_string(val) + ",";
 			}
 			syncDebug("psAuxMap[%d] row[%d]: %s", auxIdx, y, rowDetails.c_str());
@@ -155,12 +153,12 @@ void syncLogDumpAuxMaps()
 	for (int idx = 0; idx < AUX_MAX; idx++)
 	{
 		syncDebug("psBlockMap[%d]:", idx);
-		for (int y = 0; y < worldMapState.height; ++y)
+		for (int y = 0; y < gameWorld.map.height; ++y)
 		{
 			std::string rowDetails;
-			for (int x = 0; x < worldMapState.width; ++x)
+			for (int x = 0; x < gameWorld.map.width; ++x)
 			{
-				auto val = blockTile(worldMapState, x, y, idx);
+				auto val = blockTile(gameWorld.map, x, y, idx);
 				rowDetails += std::to_string(val) + ",";
 			}
 			syncDebug("psBlockMap[%d] row[%d]: %s", idx, y, rowDetails.c_str());
@@ -557,7 +555,7 @@ static int determineGroundType(int x, int y, const char *tileset)
 	int a, b, best;
 	MAPTILE *psTile;
 
-	if (x < 0 || y < 0 || x >= worldMapState.width || y >= worldMapState.height)
+	if (x < 0 || y < 0 || x >= gameWorld.map.width || y >= gameWorld.map.height)
 	{
 		return 0; // just return the first ground type
 	}
@@ -567,14 +565,14 @@ static int determineGroundType(int x, int y, const char *tileset)
 	{
 		for (j = 0; j < 2; j++)
 		{
-			if (x + i - 1 < 0 || y + j - 1 < 0 || x + i - 1 >= worldMapState.width || y + j - 1 >= worldMapState.height)
+			if (x + i - 1 < 0 || y + j - 1 < 0 || x + i - 1 >= gameWorld.map.width || y + j - 1 >= gameWorld.map.height)
 			{
 				psTile = nullptr;
 				tile = 0;
 			}
 			else
 			{
-				psTile = mapTile(worldMapState, x + i - 1, y + j - 1);
+				psTile = mapTile(gameWorld.map, x + i - 1, y + j - 1);
 				tile = psTile->texture;
 			}
 			a = i;
@@ -690,7 +688,7 @@ static void SetDecals(const char *filename, const char *decal_type)
 static bool hasDecals(int i, int j)
 {
 	int index = 0;
-	index = TileNumber_tile(mapTile(worldMapState, i, j)->texture);
+	index = TileNumber_tile(mapTile(gameWorld.map, i, j)->texture);
 	if (index > MAX_TERRAIN_TILES)
 	{
 		debug(LOG_FATAL, "Tile index is out of range!  Was %d, our max is %d", index, MAX_TERRAIN_TILES);
@@ -702,11 +700,11 @@ static bool hasDecals(int i, int j)
 // Sets the ground type to be a decal or not
 static bool mapSetGroundTypes()
 {
-	for (int j = 0; j < worldMapState.height; j++)
+	for (int j = 0; j < gameWorld.map.height; j++)
 	{
-		for (int i = 0; i < worldMapState.width; i++)
+		for (int i = 0; i < gameWorld.map.width; i++)
 		{
-			MAPTILE *psTile = mapTile(worldMapState, i, j);
+			MAPTILE *psTile = mapTile(gameWorld.map, i, j);
 
 			psTile->ground = determineGroundType(i, j, tilesetDir);
 
@@ -739,29 +737,29 @@ bool mapReloadGroundTypes()
 
 static bool isWaterVertex(int x, int y)
 {
-	if (x < 1 || y < 1 || x > worldMapState.width - 1 || y > worldMapState.height - 1)
+	if (x < 1 || y < 1 || x > gameWorld.map.width - 1 || y > gameWorld.map.height - 1)
 	{
 		return false;
 	}
-	return terrainType(mapTile(worldMapState, x, y)) == TER_WATER && terrainType(mapTile(worldMapState, x - 1, y)) == TER_WATER
-	       && terrainType(mapTile(worldMapState, x, y - 1)) == TER_WATER && terrainType(mapTile(worldMapState, x - 1, y - 1)) == TER_WATER;
+	return terrainType(mapTile(gameWorld.map, x, y)) == TER_WATER && terrainType(mapTile(gameWorld.map, x - 1, y)) == TER_WATER
+	       && terrainType(mapTile(gameWorld.map, x, y - 1)) == TER_WATER && terrainType(mapTile(gameWorld.map, x - 1, y - 1)) == TER_WATER;
 }
 
 static void generateRiverbed()
 {
 	MersenneTwister mt(12345);  // 12345 = random seed.
 	int maxIdx = 1;
-	ASSERT_OR_RETURN(, worldMapState.width > 0 && worldMapState.height > 0, "Invalid map width or height (%d x %d)", worldMapState.width, worldMapState.height);
-	std::vector<int> idx(static_cast<size_t>(worldMapState.width) * static_cast<size_t>(worldMapState.height), 0);
+	ASSERT_OR_RETURN(, gameWorld.map.width > 0 && gameWorld.map.height > 0, "Invalid map width or height (%d x %d)", gameWorld.map.width, gameWorld.map.height);
+	std::vector<int> idx(static_cast<size_t>(gameWorld.map.width) * static_cast<size_t>(gameWorld.map.height), 0);
 	int x, y, l = 0;
 
-	for (y = 0; y < worldMapState.height; y++)
+	for (y = 0; y < gameWorld.map.height; y++)
 	{
-		for (x = 0; x < worldMapState.width; x++)
+		for (x = 0; x < gameWorld.map.width; x++)
 		{
 			// initially set the seabed index to 0 for ground and 100 for water
 			int val = 100 * isWaterVertex(x, y);
-			idx[x + (y * worldMapState.width)] = val;
+			idx[x + (y * gameWorld.map.width)] = val;
 			if (val > 0)
 			{
 				l++;
@@ -777,15 +775,15 @@ static void generateRiverbed()
 	do
 	{
 		maxIdx = 1;
-		for (y = 1; y < worldMapState.height - 2; y++)
+		for (y = 1; y < gameWorld.map.height - 2; y++)
 		{
-			for (x = 1; x < worldMapState.width - 2; x++)
+			for (x = 1; x < gameWorld.map.width - 2; x++)
 			{
-				int rowOffset = (y * worldMapState.width);
+				int rowOffset = (y * gameWorld.map.width);
 				auto& idxVal = idx[x + rowOffset];
 				if (idxVal > 0)
 				{
-					idxVal = (idx[(x - 1) + rowOffset] + idx[x + ((y - 1) * worldMapState.width)] + idx[x + ((y + 1) * worldMapState.width)] + idx[(x + 1) + rowOffset]) / 4;
+					idxVal = (idx[(x - 1) + rowOffset] + idx[x + ((y - 1) * gameWorld.map.width)] + idx[x + ((y + 1) * gameWorld.map.width)] + idx[(x + 1) + rowOffset]) / 4;
 					if (idxVal > maxIdx)
 					{
 						maxIdx = idxVal;
@@ -798,11 +796,11 @@ static void generateRiverbed()
 	}
 	while (maxIdx > 90 && l < 20);
 
-	for (y = 0; y < worldMapState.height; y++)
+	for (y = 0; y < gameWorld.map.height; y++)
 	{
-		for (x = 0; x < worldMapState.width; x++)
+		for (x = 0; x < gameWorld.map.width; x++)
 		{
-			auto& idxVal = idx[x + (y * worldMapState.width)];
+			auto& idxVal = idx[x + (y * gameWorld.map.width)];
 			if (idxVal > maxIdx)
 			{
 				idxVal = maxIdx;
@@ -814,7 +812,7 @@ static void generateRiverbed()
 			if (isWaterVertex(x, y))
 			{
 				l = (WATER_MAX_DEPTH + 1 - WATER_MIN_DEPTH) * (maxIdx - idxVal - mt.u32() % (maxIdx / 6 + 1));
-				mapTile(worldMapState, x, y)->height -= WATER_MIN_DEPTH - (l / maxIdx);
+				mapTile(gameWorld.map, x, y)->height -= WATER_MIN_DEPTH - (l / maxIdx);
 			}
 		}
 	}
@@ -1058,15 +1056,15 @@ bool mapLoadFromWzMapData(std::shared_ptr<WzMap::MapData> loadedMap)
 	height = loadedMap->height;
 
 	/* See if this is the first time a map has been loaded */
-	ASSERT(worldMapState.tiles == nullptr, "Map has not been cleared before calling mapLoad()!");
+	ASSERT(gameWorld.map.tiles == nullptr, "Map has not been cleared before calling mapLoad()!");
 
 	/* Allocate the memory for the map */
-	worldMapState.tiles = std::make_unique<MAPTILE[]>(static_cast<size_t>(width) * height);
+	gameWorld.map.tiles = std::make_unique<MAPTILE[]>(static_cast<size_t>(width) * height);
 	getCurrentLightmapData().reset(width, height);
-	ASSERT(worldMapState.tiles != nullptr, "Out of memory");
+	ASSERT(gameWorld.map.tiles != nullptr, "Out of memory");
 
-	worldMapState.width = width;
-	worldMapState.height = height;
+	gameWorld.map.width = width;
+	gameWorld.map.height = height;
 
 	// FIXME: the map preview code loads the map without setting the tileset
 	if (!tilesetDir)
@@ -1091,19 +1089,19 @@ bool mapLoadFromWzMapData(std::shared_ptr<WzMap::MapData> loadedMap)
 	//load in the map data itself
 
 	/* Load in the map data */
-	for (int i = 0; i < worldMapState.width * worldMapState.height; ++i)
+	for (int i = 0; i < gameWorld.map.width * gameWorld.map.height; ++i)
 	{
 		ASSERT(loadedMap->mMapTiles[i].height <= TILE_MAX_HEIGHT, "Tile height (%" PRIu16 ") exceeds TILE_MAX_HEIGHT (%zu)", loadedMap->mMapTiles[i].height, static_cast<size_t>(TILE_MAX_HEIGHT));
-		worldMapState.tiles[i].texture = loadedMap->mMapTiles[i].texture;
-		worldMapState.tiles[i].height = loadedMap->mMapTiles[i].height;
+		gameWorld.map.tiles[i].texture = loadedMap->mMapTiles[i].texture;
+		gameWorld.map.tiles[i].height = loadedMap->mMapTiles[i].height;
 
 		// Visibility stuff
-		memset(worldMapState.tiles[i].watchers, 0, sizeof(worldMapState.tiles[i].watchers));
-		memset(worldMapState.tiles[i].sensors, 0, sizeof(worldMapState.tiles[i].sensors));
-		memset(worldMapState.tiles[i].jammers, 0, sizeof(worldMapState.tiles[i].jammers));
-		worldMapState.tiles[i].sensorBits = 0;
-		worldMapState.tiles[i].jammerBits = 0;
-		worldMapState.tiles[i].tileExploredBits = 0;
+		memset(gameWorld.map.tiles[i].watchers, 0, sizeof(gameWorld.map.tiles[i].watchers));
+		memset(gameWorld.map.tiles[i].sensors, 0, sizeof(gameWorld.map.tiles[i].sensors));
+		memset(gameWorld.map.tiles[i].jammers, 0, sizeof(gameWorld.map.tiles[i].jammers));
+		gameWorld.map.tiles[i].sensorBits = 0;
+		gameWorld.map.tiles[i].jammerBits = 0;
+		gameWorld.map.tiles[i].tileExploredBits = 0;
 	}
 
 	if (preview)
@@ -1137,58 +1135,58 @@ static bool afterMapLoad()
 		return false;
 	}
 
-	for (int y = 0; y < worldMapState.height; ++y)
+	for (int y = 0; y < gameWorld.map.height; ++y)
 	{
-		for (int x = 0; x < worldMapState.width; ++x)
+		for (int x = 0; x < gameWorld.map.width; ++x)
 		{
 			// FIXME: magic number
-			mapTile(worldMapState, x, y)->waterLevel = mapTile(worldMapState, x, y)->height - world_coord(1) / 3;
+			mapTile(gameWorld.map, x, y)->waterLevel = mapTile(gameWorld.map, x, y)->height - world_coord(1) / 3;
 		}
 	}
 	generateRiverbed();
 
 	/* set up the scroll mins and maxs - set values to valid ones for any new map */
-	worldMapState.scroll.minX = worldMapState.scroll.minY = 0;
-	worldMapState.scroll.maxX = worldMapState.width;
-	worldMapState.scroll.maxY = worldMapState.height;
+	gameWorld.map.scroll.minX = gameWorld.map.scroll.minY = 0;
+	gameWorld.map.scroll.maxX = gameWorld.map.width;
+	gameWorld.map.scroll.maxY = gameWorld.map.height;
 
 	/* Allocate aux maps */
-	ASSERT(worldMapState.width >= 0 && worldMapState.height >= 0, "Invalid mapWidth or mapHeight (%d x %d)", worldMapState.width, worldMapState.height);
-	const size_t mapSize = static_cast<size_t>(worldMapState.width) * static_cast<size_t>(worldMapState.height);
-	worldMapState.blockMap[AUX_MAP] = std::make_unique<uint8_t[]>(mapSize);
-	worldMapState.blockMap[AUX_ASTARMAP] =  std::make_unique<uint8_t[]>(mapSize);
-	worldMapState.blockMap[AUX_DANGERMAP] = std::make_unique<uint8_t[]>(mapSize);
+	ASSERT(gameWorld.map.width >= 0 && gameWorld.map.height >= 0, "Invalid mapWidth or mapHeight (%d x %d)", gameWorld.map.width, gameWorld.map.height);
+	const size_t mapSize = static_cast<size_t>(gameWorld.map.width) * static_cast<size_t>(gameWorld.map.height);
+	gameWorld.map.blockMap[AUX_MAP] = std::make_unique<uint8_t[]>(mapSize);
+	gameWorld.map.blockMap[AUX_ASTARMAP] =  std::make_unique<uint8_t[]>(mapSize);
+	gameWorld.map.blockMap[AUX_DANGERMAP] = std::make_unique<uint8_t[]>(mapSize);
 	for (int x = 0; x < MAX_PLAYERS + AUX_MAX; ++x)
 	{
-		worldMapState.auxMap[x] = std::make_unique<uint8_t[]> (mapSize);
+		gameWorld.map.auxMap[x] = std::make_unique<uint8_t[]> (mapSize);
 	}
 
 	// Set our blocking bits
-	for (int y = 0; y < worldMapState.height; ++y)
+	for (int y = 0; y < gameWorld.map.height; ++y)
 	{
-		for (int x = 0; x < worldMapState.width; ++x)
+		for (int x = 0; x < gameWorld.map.width; ++x)
 		{
-			MAPTILE *psTile = mapTile(worldMapState, x, y);
+			MAPTILE *psTile = mapTile(gameWorld.map, x, y);
 
-			auxClearBlocking(worldMapState, x, y, AUXBITS_ALL);
-			auxClearAll(worldMapState, x, y, AUXBITS_ALL);
+			auxClearBlocking(gameWorld.map, x, y, AUXBITS_ALL);
+			auxClearAll(gameWorld.map, x, y, AUXBITS_ALL);
 
 			/* All tiles outside of the map and on map border are blocking. */
-			if (x < 1 || y < 1 || x > worldMapState.width - 1 || y > worldMapState.height - 1)
+			if (x < 1 || y < 1 || x > gameWorld.map.width - 1 || y > gameWorld.map.height - 1)
 			{
-				auxSetBlocking(worldMapState, x, y, AUXBITS_ALL);	// block everything
+				auxSetBlocking(gameWorld.map, x, y, AUXBITS_ALL);	// block everything
 			}
 			if (terrainType(psTile) == TER_WATER)
 			{
-				auxSetBlocking(worldMapState, x, y, WATER_BLOCKED);
+				auxSetBlocking(gameWorld.map, x, y, WATER_BLOCKED);
 			}
 			else
 			{
-				auxSetBlocking(worldMapState, x, y, LAND_BLOCKED);
+				auxSetBlocking(gameWorld.map, x, y, LAND_BLOCKED);
 			}
 			if (terrainType(psTile) == TER_CLIFFFACE)
 			{
-				auxSetBlocking(worldMapState, x, y, FEATURE_BLOCKED);
+				auxSetBlocking(gameWorld.map, x, y, FEATURE_BLOCKED);
 			}
 		}
 	}
@@ -1202,8 +1200,8 @@ static bool afterMapLoad()
 /* Save the map data */
 bool mapSaveToWzMapData(WzMap::MapData& output)
 {
-	output.width = worldMapState.width;
-	output.height = worldMapState.height;
+	output.width = gameWorld.map.width;
+	output.height = gameWorld.map.height;
 
 	// Write out the map tile data
 	uint32_t numMapTiles = output.width * output.height;
@@ -1212,14 +1210,14 @@ bool mapSaveToWzMapData(WzMap::MapData& output)
 	for (uint32_t i = 0; i < numMapTiles; i++)
 	{
 		WzMap::MapData::MapTile mapDataTile = {};
-		mapDataTile.texture = worldMapState.tiles[i].texture;
-		if (terrainType(&worldMapState.tiles[i]) == TER_WATER)
+		mapDataTile.texture = gameWorld.map.tiles[i].texture;
+		if (terrainType(&gameWorld.map.tiles[i]) == TER_WATER)
 		{
-			mapDataTile.height = (worldMapState.tiles[i].waterLevel + world_coord(1) / 3); // this magic number stuff should match afterMapLoad()'s handling of water tiles (??)
+			mapDataTile.height = (gameWorld.map.tiles[i].waterLevel + world_coord(1) / 3); // this magic number stuff should match afterMapLoad()'s handling of water tiles (??)
 		}
 		else
 		{
-			mapDataTile.height = worldMapState.tiles[i].height;
+			mapDataTile.height = gameWorld.map.tiles[i].height;
 		}
 		output.mMapTiles.push_back(std::move(mapDataTile));
 	}
@@ -1236,7 +1234,7 @@ bool mapSaveToWzMapData(WzMap::MapData& output)
 		gw.y2 = psCurrGate->y2;
 		ASSERT(gw.x1 == gw.x2 || gw.y1 == gw.y2, "Invalid gateway coordinates (%d, %d, %d, %d)",
 			   gw.x1, gw.y1, gw.x2, gw.y2);
-		ASSERT(gw.x1 < worldMapState.width && gw.y1 < worldMapState.height && gw.x2 < worldMapState.width && gw.y2 < worldMapState.height,
+		ASSERT(gw.x1 < gameWorld.map.width && gw.y1 < gameWorld.map.height && gw.x2 < gameWorld.map.width && gw.y2 < gameWorld.map.height,
 			   "Bad gateway dimensions for savegame");
 		output.mGateways.push_back(std::move(gw));
 	}
@@ -1263,21 +1261,21 @@ bool mapShutdown()
 	}
 
 	mapDecals = nullptr;
-	worldMapState.blockMap[AUX_MAP] = nullptr;
-	worldMapState.blockMap[AUX_ASTARMAP] = nullptr;
+	gameWorld.map.blockMap[AUX_MAP] = nullptr;
+	gameWorld.map.blockMap[AUX_ASTARMAP] = nullptr;
 	free(floodbucket);
-	worldMapState.blockMap[AUX_DANGERMAP] = nullptr;
+	gameWorld.map.blockMap[AUX_DANGERMAP] = nullptr;
 	for (x = 0; x < MAX_PLAYERS + AUX_MAX; x++)
 	{
-		worldMapState.auxMap[x].reset();
+		gameWorld.map.auxMap[x].reset();
 	}
 
 	map = nullptr;
 	floodbucket = nullptr;
 	groundTypes.clear();
 	mapDecals = nullptr;
-	worldMapState.tiles = nullptr;
-	worldMapState.width = worldMapState.height = 0;
+	gameWorld.map.tiles = nullptr;
+	gameWorld.map.width = gameWorld.map.height = 0;
 	numTile_names = 0;
 	Tile_names = nullptr;
 	if (tilesetDir)
@@ -1407,7 +1405,7 @@ bool map_Intersect(int *Cx, int *Cy, int *Vx, int *Vy, int *Sx, int *Sy)
 	ASSERT(*Cy >= world_coord(tileY) && *Cy <= world_coord(tileY + 1), "map_Intersect(): tile Bounds %i %i, %i %i -> %i,%i,%i,%i", x, y, Dx, Dy, *Cx, *Cy, *Vx, *Vy);
 	ASSERT(*Vx >= world_coord(tileX) && *Vx <= world_coord(tileX + 1), "map_Intersect(): tile Bounds %i %i, %i %i -> %i,%i,%i,%i", x, y, Dx, Dy, *Cx, *Cy, *Vx, *Vy);
 	ASSERT(*Vy >= world_coord(tileY) && *Vy <= world_coord(tileY + 1), "map_Intersect(): tile Bounds %i %i, %i %i -> %i,%i,%i,%i", x, y, Dx, Dy, *Cx, *Cy, *Vx, *Vy);
-	ASSERT(tileX >= 0 && tileY >= 0 && tileX < worldMapState.width && tileY < worldMapState.height, "map_Intersect(): map Bounds %i %i, %i %i -> %i,%i,%i,%i", x, y, Dx, Dy, *Cx, *Cy, *Vx, *Vy);
+	ASSERT(tileX >= 0 && tileY >= 0 && tileX < gameWorld.map.width && tileY < gameWorld.map.height, "map_Intersect(): map Bounds %i %i, %i %i -> %i,%i,%i,%i", x, y, Dx, Dy, *Cx, *Cy, *Vx, *Vy);
 
 	//calculate midway line intersection points
 	if (((map_coord(itx) == tileX) == (map_coord(ily) == tileY)) && ((map_coord(ibx) == tileX) == (map_coord(iry) == tileY)))
@@ -1526,7 +1524,7 @@ unsigned map_LineIntersect(Vector3i src, Vector3i dst, unsigned tMax)
 		for (int q = 0; q < 4; ++q)
 		{
 			Vector2i corner = tile + quadrantCorner(quadrant + q);
-			height[q] = map_TileHeightSurface(worldMapState, corner.x, corner.y);
+			height[q] = map_TileHeightSurface(gameWorld.map, corner.x, corner.y);
 		}
 		Vector3i dif = dst - src;
 		//     We are considering the volume of a quadrant (the volume above a quarter of a map tile, which is
@@ -1572,7 +1570,7 @@ unsigned map_LineIntersect(Vector3i src, Vector3i dst, unsigned tMax)
 			src = rotateWorldQuadrant(src, -2) + Vector3i(0, -TILE_UNITS, 0);
 			dst = rotateWorldQuadrant(dst, -2) + Vector3i(0, -TILE_UNITS, 0);
 
-			if (tile.x < 0 || tile.x >= worldMapState.width || tile.y < 0 || tile.y >= worldMapState.height)
+			if (tile.x < 0 || tile.x >= gameWorld.map.width || tile.y < 0 || tile.y >= gameWorld.map.height)
 			{
 				// Intersect edge of map.
 				return (int64_t)tMax * numer[firstIntersection] / denom[firstIntersection];
@@ -1705,15 +1703,15 @@ bool mapObjIsAboveGround(const SIMPLE_OBJECT *psObj)
 {
 	// min is used to make sure we don't go over array bounds!
 	// TODO Using the corner of the map instead doesn't make sense. Fix this...
-	const int mapsize = worldMapState.width * worldMapState.height - 1;
+	const int mapsize = gameWorld.map.width * gameWorld.map.height - 1;
 	const int tileX = map_coord(psObj->pos.x);
 	const int tileY = map_coord(psObj->pos.y);
-	const int tileYOffset1 = (tileY * worldMapState.width);
-	const int tileYOffset2 = ((tileY + 1) * worldMapState.width);
-	const int h1 = worldMapState.tiles[MIN(mapsize, tileYOffset1 + tileX)    ].height;
-	const int h2 = worldMapState.tiles[MIN(mapsize, tileYOffset1 + tileX + 1)].height;
-	const int h3 = worldMapState.tiles[MIN(mapsize, tileYOffset2 + tileX)    ].height;
-	const int h4 = worldMapState.tiles[MIN(mapsize, tileYOffset2 + tileX + 1)].height;
+	const int tileYOffset1 = (tileY * gameWorld.map.width);
+	const int tileYOffset2 = ((tileY + 1) * gameWorld.map.width);
+	const int h1 = gameWorld.map.tiles[MIN(mapsize, tileYOffset1 + tileX)    ].height;
+	const int h2 = gameWorld.map.tiles[MIN(mapsize, tileYOffset1 + tileX + 1)].height;
+	const int h3 = gameWorld.map.tiles[MIN(mapsize, tileYOffset2 + tileX)    ].height;
+	const int h4 = gameWorld.map.tiles[MIN(mapsize, tileYOffset2 + tileX + 1)].height;
 
 	/* trivial test above */
 	if (psObj->pos.z > h1 && psObj->pos.z > h2 && psObj->pos.z > h3 && psObj->pos.z > h4)
@@ -1728,7 +1726,7 @@ bool mapObjIsAboveGround(const SIMPLE_OBJECT *psObj)
 	}
 
 	/* exhaustive test */
-	return psObj->pos.z > map_Height(worldMapState, psObj->pos.x, psObj->pos.y);
+	return psObj->pos.z > map_Height(gameWorld.map, psObj->pos.x, psObj->pos.y);
 }
 
 /* returns the max and min height of a tile by looking at the four corners
@@ -1741,7 +1739,7 @@ void getTileMaxMin(int x, int y, int *pMax, int *pMin)
 	for (int j = 0; j < 2; ++j)
 		for (int i = 0; i < 2; ++i)
 		{
-			int height = map_TileHeight(worldMapState, x + i, y + j);
+			int height = map_TileHeight(gameWorld.map, x + i, y + j);
 			*pMin = std::min(*pMin, height);
 			*pMax = std::max(*pMax, height);
 		}
@@ -1783,9 +1781,9 @@ bool writeVisibilityData(const char *fileName)
 
 	for (unsigned plane = 0; plane < planes; ++plane)
 	{
-		for (i = 0; i < worldMapState.width * worldMapState.height; ++i)
+		for (i = 0; i < gameWorld.map.width * gameWorld.map.height; ++i)
 		{
-			if (!PHYSFS_writeUBE8(fileHandle, worldMapState.tiles[i].tileExploredBits >> (plane * 8)))
+			if (!PHYSFS_writeUBE8(fileHandle, gameWorld.map.tiles[i].tileExploredBits >> (plane * 8)))
 			{
 				debug(LOG_ERROR, "writeVisibilityData: could not write to %s; PHYSFS error: %s", fileName, WZ_PHYSFS_getLastError());
 				PHYSFS_close(fileHandle);
@@ -1842,7 +1840,7 @@ bool readVisibilityData(const char *fileName)
 	int planes = (game.maxPlayers + 7) / 8;
 
 	// Validate the filesize
-	expectedFileSize = sizeof(fileHeader.aFileType) + sizeof(fileHeader.version) + worldMapState.width * worldMapState.height * planes;
+	expectedFileSize = sizeof(fileHeader.aFileType) + sizeof(fileHeader.version) + gameWorld.map.width * gameWorld.map.height * planes;
 	fileSize = PHYSFS_fileLength(fileHandle);
 	if (fileSize != expectedFileSize)
 	{
@@ -1853,13 +1851,13 @@ bool readVisibilityData(const char *fileName)
 	}
 
 	// For every tile...
-	for (i = 0; i < worldMapState.width * worldMapState.height; i++)
+	for (i = 0; i < gameWorld.map.width * gameWorld.map.height; i++)
 	{
-		worldMapState.tiles[i].tileExploredBits = 0;
+		gameWorld.map.tiles[i].tileExploredBits = 0;
 	}
 	for (unsigned plane = 0; plane < planes; ++plane)
 	{
-		for (i = 0; i < worldMapState.width * worldMapState.height; i++)
+		for (i = 0; i < gameWorld.map.width * gameWorld.map.height; i++)
 		{
 			/* Get the visibility data */
 			uint8_t val = 0;
@@ -1869,7 +1867,7 @@ bool readVisibilityData(const char *fileName)
 				PHYSFS_close(fileHandle);
 				return false;
 			}
-			worldMapState.tiles[i].tileExploredBits |= val << (plane * 8);
+			gameWorld.map.tiles[i].tileExploredBits |= val << (plane * 8);
 		}
 	}
 
@@ -1901,7 +1899,7 @@ static void mapFloodFill(int x, int y, int continent, uint8_t blockedBits, uint1
 {
 	std::vector<Vector2i> open;
 	open.push_back(Vector2i(x, y));
-	mapTile(worldMapState, x, y)->*varContinent = continent;  // Set continent value
+	mapTile(gameWorld.map, x, y)->*varContinent = continent;  // Set continent value
 
 	while (!open.empty())
 	{
@@ -1915,13 +1913,13 @@ static void mapFloodFill(int x, int y, int continent, uint8_t blockedBits, uint1
 			// rely on the fact that all border tiles are inaccessible to avoid checking explicitly
 			Vector2i npos = pos + aDirOffset[i];
 
-			if (npos.x < 1 || npos.y < 1 || npos.x > worldMapState.width - 2 || npos.y > worldMapState.height - 2)
+			if (npos.x < 1 || npos.y < 1 || npos.x > gameWorld.map.width - 2 || npos.y > gameWorld.map.height - 2)
 			{
 				continue;
 			}
-			MAPTILE *psTile = mapTile(worldMapState, npos);
+			MAPTILE *psTile = mapTile(gameWorld.map, npos);
 
-			if (!(blockTile(worldMapState, npos.x, npos.y, AUX_MAP) & blockedBits) && psTile->*varContinent == 0)
+			if (!(blockTile(gameWorld.map, npos.x, npos.y, AUX_MAP) & blockedBits) && psTile->*varContinent == 0)
 			{
 				open.push_back(npos);               // add to open list
 				psTile->*varContinent = continent;  // Set continent value
@@ -1935,11 +1933,11 @@ void mapFloodFillContinents()
 	int x, y, limitedContinents = 0, hoverContinents = 0;
 
 	/* Clear continents */
-	for (y = 0; y < worldMapState.height; y++)
+	for (y = 0; y < gameWorld.map.height; y++)
 	{
-		for (x = 0; x < worldMapState.width; x++)
+		for (x = 0; x < gameWorld.map.width; x++)
 		{
-			MAPTILE *psTile = mapTile(worldMapState, x, y);
+			MAPTILE *psTile = mapTile(gameWorld.map, x, y);
 
 			psTile->limitedContinent = 0;
 			psTile->hoverContinent = 0;
@@ -1947,11 +1945,11 @@ void mapFloodFillContinents()
 	}
 
 	/* Iterate over the whole map, looking for unset continents */
-	for (y = 1; y < worldMapState.height - 2; y++)
+	for (y = 1; y < gameWorld.map.height - 2; y++)
 	{
-		for (x = 1; x < worldMapState.width - 2; x++)
+		for (x = 1; x < gameWorld.map.width - 2; x++)
 		{
-			MAPTILE *psTile = mapTile(worldMapState, x, y);
+			MAPTILE *psTile = mapTile(gameWorld.map, x, y);
 
 			if (psTile->limitedContinent == 0 && !fpathBlockingTile(x, y, PROPULSION_TYPE_WHEELED))
 			{
@@ -2017,12 +2015,12 @@ static int dangerFloodFill(int player)
 	bool start = true;	// hack to disregard the blocking status of any building exactly on the starting position
 
 	// Set our danger bits
-	for (y = 0; y < worldMapState.height; y++)
+	for (y = 0; y < gameWorld.map.height; y++)
 	{
-		for (x = 0; x < worldMapState.width; x++)
+		for (x = 0; x < gameWorld.map.width; x++)
 		{
-			auxSet(worldMapState, x, y, MAX_PLAYERS + AUX_DANGERMAP, AUXBITS_DANGER);
-			auxClear(worldMapState, x, y, MAX_PLAYERS + AUX_DANGERMAP, AUXBITS_TEMPORARY);
+			auxSet(gameWorld.map, x, y, MAX_PLAYERS + AUX_DANGERMAP, AUXBITS_DANGER);
+			auxClear(gameWorld.map, x, y, MAX_PLAYERS + AUX_DANGERMAP, AUXBITS_TEMPORARY);
 		}
 	}
 
@@ -2037,12 +2035,12 @@ static int dangerFloodFill(int player)
 		{
 			npos.x = pos.x + aDirOffset[i].x;
 			npos.y = pos.y + aDirOffset[i].y;
-			if (!tileOnMap(worldMapState, npos.x, npos.y))
+			if (!tileOnMap(gameWorld.map, npos.x, npos.y))
 			{
 				continue;
 			}
-			aux = auxTile(worldMapState, npos.x, npos.y, MAX_PLAYERS + AUX_DANGERMAP);
-			block = blockTile(worldMapState, pos.x, pos.y, AUX_DANGERMAP);
+			aux = auxTile(gameWorld.map, npos.x, npos.y, MAX_PLAYERS + AUX_DANGERMAP);
+			block = blockTile(gameWorld.map, pos.x, pos.y, AUX_DANGERMAP);
 			if (!(aux & AUXBITS_TEMPORARY) && !(aux & AUXBITS_THREAT) && (aux & AUXBITS_DANGER))
 			{
 				// Note that we do not consider water to be a blocker here. This may or may not be a feature...
@@ -2058,14 +2056,14 @@ static int dangerFloodFill(int player)
 				}
 				else
 				{
-					auxClear(worldMapState, npos.x, npos.y, MAX_PLAYERS + AUX_DANGERMAP, AUXBITS_DANGER);
+					auxClear(gameWorld.map, npos.x, npos.y, MAX_PLAYERS + AUX_DANGERMAP, AUXBITS_DANGER);
 				}
-				auxSet(worldMapState, npos.x, npos.y, MAX_PLAYERS + AUX_DANGERMAP, AUXBITS_TEMPORARY); // make sure we do not process it more than once
+				auxSet(gameWorld.map, npos.x, npos.y, MAX_PLAYERS + AUX_DANGERMAP, AUXBITS_TEMPORARY); // make sure we do not process it more than once
 			}
 		}
 
 		// Clear danger
-		auxClear(worldMapState, pos.x, pos.y, MAX_PLAYERS + AUX_DANGERMAP, AUXBITS_DANGER);
+		auxClear(gameWorld.map, pos.x, pos.y, MAX_PLAYERS + AUX_DANGERMAP, AUXBITS_DANGER);
 
 		// Pop the last open node off the bucket list for the next iteration
 		if (bucketcounter)
@@ -2099,11 +2097,11 @@ static inline void threatUpdateTarget(int player, BASE_OBJECT *psObj, bool groun
 		{
 			if (ground)
 			{
-				auxSet(worldMapState, pos.x, pos.y, MAX_PLAYERS + AUX_DANGERMAP, AUXBITS_THREAT);	// set ground threat for this tile
+				auxSet(gameWorld.map, pos.x, pos.y, MAX_PLAYERS + AUX_DANGERMAP, AUXBITS_THREAT);	// set ground threat for this tile
 			}
 			if (air)
 			{
-				auxSet(worldMapState, pos.x, pos.y, MAX_PLAYERS + AUX_DANGERMAP, AUXBITS_AATHREAT);	// set air threat for this tile
+				auxSet(gameWorld.map, pos.x, pos.y, MAX_PLAYERS + AUX_DANGERMAP, AUXBITS_AATHREAT);	// set air threat for this tile
 			}
 		}
 	}
@@ -2114,11 +2112,11 @@ static void threatUpdate(int player)
 	int i, weapon, x, y;
 
 	// Step 1: Clear our threat bits
-	for (y = 0; y < worldMapState.height; y++)
+	for (y = 0; y < gameWorld.map.height; y++)
 	{
-		for (x = 0; x < worldMapState.width; x++)
+		for (x = 0; x < gameWorld.map.width; x++)
 		{
-			auxClear(worldMapState, x, y, MAX_PLAYERS + AUX_DANGERMAP, AUXBITS_THREAT | AUXBITS_AATHREAT);
+			auxClear(gameWorld.map, x, y, MAX_PLAYERS + AUX_DANGERMAP, AUXBITS_THREAT | AUXBITS_AATHREAT);
 		}
 	}
 
@@ -2131,7 +2129,7 @@ static void threatUpdate(int player)
 			continue;
 		}
 
-		for (DROID* psDroid : worldObjectState.droids[i])
+		for (DROID* psDroid : gameWorld.objects.droids[i])
 		{
 			UBYTE mode = 0;
 
@@ -2154,7 +2152,7 @@ static void threatUpdate(int player)
 			}
 		}
 
-		for (STRUCTURE* psStruct : worldObjectState.structures[i])
+		for (STRUCTURE* psStruct : gameWorld.objects.structures[i])
 		{
 			UBYTE mode = 0;
 
@@ -2179,7 +2177,7 @@ void mapInit()
 	int player;
 
 	free(floodbucket);
-	floodbucket = (struct floodtile *)malloc(worldMapState.width * worldMapState.height * sizeof(*floodbucket));
+	floodbucket = (struct floodtile *)malloc(gameWorld.map.width * gameWorld.map.height * sizeof(*floodbucket));
 
 	lastDangerUpdate = 0;
 	lastDangerPlayer = -1;
@@ -2190,10 +2188,10 @@ void mapInit()
 	{
 		for (player = 0; player < MAX_PLAYERS; player++)
 		{
-			auxMapStore(worldMapState, player, AUX_DANGERMAP);
+			auxMapStore(gameWorld.map, player, AUX_DANGERMAP);
 			threatUpdate(player);
 			dangerFloodFill(player);
-			auxMapRestore(worldMapState, player, AUX_DANGERMAP, AUXBITS_DANGER | AUXBITS_THREAT | AUXBITS_AATHREAT);
+			auxMapRestore(gameWorld.map, player, AUX_DANGERMAP, AUXBITS_DANGER | AUXBITS_THREAT | AUXBITS_AATHREAT);
 		}
 		lastDangerPlayer = 0;
 		dangerSemaphore = wzSemaphoreCreate(0);
@@ -2208,10 +2206,10 @@ void mapUpdate()
 	const uint16_t currentTime = gameTime / GAME_TICKS_PER_UPDATE;
 	int posX, posY;
 
-	for (posY = 0; posY < worldMapState.height; ++posY)
-		for (posX = 0; posX < worldMapState.width; ++posX)
+	for (posY = 0; posY < gameWorld.map.height; ++posY)
+		for (posX = 0; posX < gameWorld.map.width; ++posX)
 		{
-			MAPTILE *const tile = mapTile(worldMapState, posX, posY);
+			MAPTILE *const tile = mapTile(gameWorld.map, posX, posY);
 
 			if ((tile->tileInfoBits & BITS_ON_FIRE) != 0 && tile->fireEndTime == currentTime)
 			{
@@ -2230,9 +2228,9 @@ void mapUpdate()
 		// Lock if previous job not done yet
 		wzSemaphoreWait(dangerDoneSemaphore);
 
-		auxMapRestore(worldMapState, lastDangerPlayer, AUX_DANGERMAP, AUXBITS_THREAT | AUXBITS_AATHREAT | AUXBITS_DANGER);
+		auxMapRestore(gameWorld.map, lastDangerPlayer, AUX_DANGERMAP, AUXBITS_THREAT | AUXBITS_AATHREAT | AUXBITS_DANGER);
 		lastDangerPlayer = (lastDangerPlayer + 1) % game.maxPlayers;
-		auxMapStore(worldMapState, lastDangerPlayer, AUX_DANGERMAP);
+		auxMapStore(gameWorld.map, lastDangerPlayer, AUX_DANGERMAP);
 		threatUpdate(lastDangerPlayer);
 		wzSemaphorePost(dangerSemaphore);
 	}

--- a/src/map.h
+++ b/src/map.h
@@ -33,6 +33,7 @@
 #include "multiplay.h"
 #include "display.h"
 #include "ai.h"
+#include "world_map_state.h"
 
 #define TALLOBJECT_YMAX		(200)
 #define TALLOBJECT_ADJUST	(300)
@@ -53,37 +54,8 @@ struct GROUND_TYPE
 	bool highQualityTextures = false; // whether this ground_type has normal / specular / height maps
 };
 
-/* Information stored with each tile */
-struct MAPTILE
-{
-	uint8_t         tileInfoBits;
-	PlayerMask      tileExploredBits;
-	PlayerMask      sensorBits;             ///< bit per player, who can see tile with sensor
-	uint16_t        watchers[MAX_PLAYERS];  // player sees through fog of war here with this many objects
-	uint16_t        texture;                // Which graphics texture is on this tile
-	int32_t         height;                 ///< The height at the top left of the tile
-	BASE_OBJECT *   psObject;               // Any object sitting on the location (e.g. building)
-	uint16_t        limitedContinent;       ///< For land or sea limited propulsion types
-	uint16_t        hoverContinent;         ///< For hover type propulsions
-	uint16_t        fireEndTime;            ///< The (uint16_t)(gameTime / GAME_TICKS_PER_UPDATE) that BITS_ON_FIRE should be cleared.
-	int32_t         waterLevel;             ///< At what height is the water for this tile
-	PlayerMask      jammerBits;             ///< bit per player, who is jamming tile
-	uint16_t        sensors[MAX_PLAYERS];   ///< player sees this tile with this many radar sensors
-	uint16_t        jammers[MAX_PLAYERS];   ///< player jams the tile with this many objects
+extern WorldMapState worldMapState;
 
-	// DISPLAY ONLY (NOT for use in game calculations)
-	uint8_t         ground;                 ///< The ground type used for the terrain renderer
-	uint8_t         illumination;           // How bright is this tile? = diffuseSunLight * ambientOcclusion
-	uint8_t			ambientOcclusion;		// ambient occlusion. from 1 (max occlusion) to 254 (no occlusion), similar to illumination.
-	float           level;                  ///< The visibility level of the top left of the tile, for this client. for terrain lightmap
-};
-
-/* The size and contents of the map */
-extern SDWORD	mapWidth, mapHeight;
-
-
-
-extern std::unique_ptr<MAPTILE[]> psMapTiles;
 extern float waterLevel;
 extern char *tilesetDir;
 extern MAP_TILESET currentMapTileset;
@@ -112,27 +84,24 @@ size_t getNumGroundTypes();
 #define AUX_DANGERMAP	2
 #define AUX_MAX		3
 
-extern std::unique_ptr<uint8_t[]> psBlockMap[AUX_MAX];
-extern std::unique_ptr<uint8_t[]> psAuxMap[MAX_PLAYERS + AUX_MAX];	// yes, we waste one element... eyes wide open... makes API nicer
-
 /// Find aux bitfield for a given tile
 WZ_DECL_ALWAYS_INLINE static inline uint8_t auxTile(int x, int y, int player)
 {
 	ASSERT_OR_RETURN(AUXBITS_ALL, player >= 0 && player < MAX_PLAYERS + AUX_MAX, "invalid player: %d", player);
-	return psAuxMap[player][x + y * mapWidth];
+	return worldMapState.auxMap[player][x + y * worldMapState.width];
 }
 
 /// Find blocking bitfield for a given tile
 WZ_DECL_ALWAYS_INLINE static inline uint8_t blockTile(int x, int y, int slot)
 {
-	return psBlockMap[slot][x + y * mapWidth];
+	return worldMapState.blockMap[slot][x + y * worldMapState.width];
 }
 
 /// Store a shadow copy of a player's aux map for use in threaded calculations
 static inline void auxMapStore(int player, int slot)
 {
-	memcpy(psBlockMap[slot].get(), psBlockMap[0].get(), sizeof(uint8_t) * mapWidth * mapHeight);
-	memcpy(psAuxMap[MAX_PLAYERS + slot].get(), psAuxMap[player].get(), sizeof(uint8_t) * mapWidth * mapHeight);
+	memcpy(worldMapState.blockMap[slot].get(), worldMapState.blockMap[0].get(), sizeof(uint8_t) * worldMapState.width * worldMapState.height);
+	memcpy(worldMapState.auxMap[MAX_PLAYERS + slot].get(), worldMapState.auxMap[player].get(), sizeof(uint8_t) * worldMapState.width * worldMapState.height);
 }
 
 /// Restore selected fields from the shadow copy of a player's aux map (ignoring the block map)
@@ -141,18 +110,18 @@ static inline void auxMapRestore(int player, int slot, int mask)
 	int i;
 	uint8_t original, cached;
 
-	for (i = 0; i < mapHeight * mapWidth; i++)
+	for (i = 0; i < worldMapState.height * worldMapState.width; i++)
 	{
-		original = psAuxMap[player][i];
-		cached = psAuxMap[MAX_PLAYERS + slot][i];
-		psAuxMap[player][i] = original ^ ((original ^ cached) & mask);
+		original = worldMapState.auxMap[player][i];
+		cached = worldMapState.auxMap[MAX_PLAYERS + slot][i];
+		worldMapState.auxMap[player][i] = original ^ ((original ^ cached) & mask);
 	}
 }
 
 /// Set aux bits. Always set identically for all players. States not set are retained.
 WZ_DECL_ALWAYS_INLINE static inline void auxSet(int x, int y, int player, int state)
 {
-	psAuxMap[player][x + y * mapWidth] |= state;
+	worldMapState.auxMap[player][x + y * worldMapState.width] |= state;
 }
 
 /// Set aux bits. Always set identically for all players. States not set are retained.
@@ -162,7 +131,7 @@ WZ_DECL_ALWAYS_INLINE static inline void auxSetAll(int x, int y, int state)
 
 	for (i = 0; i < MAX_PLAYERS; i++)
 	{
-		psAuxMap[i][x + y * mapWidth] |= state;
+		worldMapState.auxMap[i][x + y * worldMapState.width] |= state;
 	}
 }
 
@@ -175,7 +144,7 @@ WZ_DECL_ALWAYS_INLINE static inline void auxSetAllied(int x, int y, int player, 
 	{
 		if (aiCheckAlliances(player, i))
 		{
-			psAuxMap[i][x + y * mapWidth] |= state;
+			worldMapState.auxMap[i][x + y * worldMapState.width] |= state;
 		}
 	}
 }
@@ -189,7 +158,7 @@ WZ_DECL_ALWAYS_INLINE static inline void auxSetEnemy(int x, int y, int player, i
 	{
 		if (!aiCheckAlliances(player, i))
 		{
-			psAuxMap[i][x + y * mapWidth] |= state;
+			worldMapState.auxMap[i][x + y * worldMapState.width] |= state;
 		}
 	}
 }
@@ -197,7 +166,7 @@ WZ_DECL_ALWAYS_INLINE static inline void auxSetEnemy(int x, int y, int player, i
 /// Clear aux bits. Always set identically for all players. States not cleared are retained.
 WZ_DECL_ALWAYS_INLINE static inline void auxClear(int x, int y, int player, int state)
 {
-	psAuxMap[player][x + y * mapWidth] &= ~state;
+	worldMapState.auxMap[player][x + y * worldMapState.width] &= ~state;
 }
 
 /// Clear all aux bits. Always set identically for all players. States not cleared are retained.
@@ -207,20 +176,20 @@ WZ_DECL_ALWAYS_INLINE static inline void auxClearAll(int x, int y, int state)
 
 	for (i = 0; i < MAX_PLAYERS; i++)
 	{
-		psAuxMap[i][x + y * mapWidth] &= ~state;
+		worldMapState.auxMap[i][x + y * worldMapState.width] &= ~state;
 	}
 }
 
 /// Set blocking bits. Always set identically for all players. States not set are retained.
 WZ_DECL_ALWAYS_INLINE static inline void auxSetBlocking(int x, int y, int state)
 {
-	psBlockMap[0][x + y * mapWidth] |= state;
+	worldMapState.blockMap[0][x + y * worldMapState.width] |= state;
 }
 
 /// Clear blocking bits. Always set identically for all players. States not cleared are retained.
 WZ_DECL_ALWAYS_INLINE static inline void auxClearBlocking(int x, int y, int state)
 {
-	psBlockMap[0][x + y * mapWidth] &= ~state;
+	worldMapState.blockMap[0][x + y * worldMapState.width] &= ~state;
 }
 
 /**
@@ -381,8 +350,8 @@ static inline void clip_world_offmap(int *worldX, int *worldY)
 	// x,y must be > 0
 	*worldX = MAX(1, *worldX);
 	*worldY = MAX(1, *worldY);
-	*worldX = MIN(world_coord(mapWidth) - 1, *worldX);
-	*worldY = MIN(world_coord(mapHeight) - 1, *worldY);
+	*worldX = MIN(world_coord(worldMapState.width) - 1, *worldX);
+	*worldY = MIN(world_coord(worldMapState.height) - 1, *worldY);
 }
 
 /* Shutdown the map module */
@@ -435,16 +404,16 @@ static inline WZ_DECL_PURE MAPTILE *mapTile(int32_t x, int32_t y)
 {
 	// Clamp x and y values to actual ones
 	// Give one tile worth of leeway before asserting, for units/transporters coming in from off-map.
-	ASSERT(x >= -1, "mapTile: x value is too small (%d,%d) in %dx%d", x, y, mapWidth, mapHeight);
-	ASSERT(y >= -1, "mapTile: y value is too small (%d,%d) in %dx%d", x, y, mapWidth, mapHeight);
+	ASSERT(x >= -1, "mapTile: x value is too small (%d,%d) in %dx%d", x, y, worldMapState.width, worldMapState.height);
+	ASSERT(y >= -1, "mapTile: y value is too small (%d,%d) in %dx%d", x, y, worldMapState.width, worldMapState.height);
 	x = MAX(x, 0);
 	y = MAX(y, 0);
-	ASSERT(x < mapWidth + 1, "mapTile: x value is too big (%d,%d) in %dx%d", x, y, mapWidth, mapHeight);
-	ASSERT(y < mapHeight + 1, "mapTile: y value is too big (%d,%d) in %dx%d", x, y, mapWidth, mapHeight);
-	x = MIN(x, mapWidth - 1);
-	y = MIN(y, mapHeight - 1);
+	ASSERT(x < worldMapState.width + 1, "mapTile: x value is too big (%d,%d) in %dx%d", x, y, worldMapState.width, worldMapState.height);
+	ASSERT(y < worldMapState.height + 1, "mapTile: y value is too big (%d,%d) in %dx%d", x, y, worldMapState.width, worldMapState.height);
+	x = MIN(x, worldMapState.width - 1);
+	y = MIN(y, worldMapState.height - 1);
 
-	return &psMapTiles[x + (y * mapWidth)];
+	return &worldMapState.tiles[x + (y * worldMapState.width)];
 }
 
 static inline WZ_DECL_PURE MAPTILE *mapTile(Vector2i const &v)
@@ -465,48 +434,48 @@ static inline WZ_DECL_PURE MAPTILE *worldTile(Vector2i const &v)
 /// Return ground height of top-left corner of tile at x,y
 static inline WZ_DECL_PURE int32_t map_TileHeight(int32_t x, int32_t y)
 {
-	if (x >= mapWidth || y >= mapHeight || x < 0 || y < 0)
+	if (x >= worldMapState.width || y >= worldMapState.height || x < 0 || y < 0)
 	{
 		return 0;
 	}
-	return psMapTiles[x + (y * mapWidth)].height;
+	return worldMapState.tiles[x + (y * worldMapState.width)].height;
 }
 
 /// Return water height of top-left corner of tile at x,y
 static inline WZ_DECL_PURE int32_t map_WaterHeight(int32_t x, int32_t y)
 {
-	if (x >= mapWidth || y >= mapHeight || x < 0 || y < 0)
+	if (x >= worldMapState.width || y >= worldMapState.height || x < 0 || y < 0)
 	{
 		return 0;
 	}
-	return psMapTiles[x + (y * mapWidth)].waterLevel;
+	return worldMapState.tiles[x + (y * worldMapState.width)].waterLevel;
 }
 
 /// Return max(ground, water) height of top-left corner of tile at x,y
 static inline WZ_DECL_PURE int32_t map_TileHeightSurface(int32_t x, int32_t y)
 {
-	if (x >= mapWidth || y >= mapHeight || x < 0 || y < 0)
+	if (x >= worldMapState.width || y >= worldMapState.height || x < 0 || y < 0)
 	{
 		return 0;
 	}
-	return MAX(psMapTiles[x + (y * mapWidth)].height, psMapTiles[x + (y * mapWidth)].waterLevel);
+	return MAX(worldMapState.tiles[x + (y * worldMapState.width)].height, worldMapState.tiles[x + (y * worldMapState.width)].waterLevel);
 }
 
 
 /*sets the tile height */
 static inline void setTileHeight(int32_t x, int32_t y, int32_t height)
 {
-	ASSERT_OR_RETURN(, x < mapWidth && x >= 0, "x coordinate %d bigger than map width %u", x, mapWidth);
-	ASSERT_OR_RETURN(, y < mapHeight && x >= 0, "y coordinate %d bigger than map height %u", y, mapHeight);
+	ASSERT_OR_RETURN(, x < worldMapState.width && x >= 0, "x coordinate %d bigger than map width %u", x, worldMapState.width);
+	ASSERT_OR_RETURN(, y < worldMapState.height && x >= 0, "y coordinate %d bigger than map height %u", y, worldMapState.height);
 
-	psMapTiles[x + (y * mapWidth)].height = height;
+	worldMapState.tiles[x + (y * worldMapState.width)].height = height;
 	markTileDirty(x, y);
 }
 
 /* Return whether a tile coordinate is on the map */
 WZ_DECL_ALWAYS_INLINE static inline bool tileOnMap(SDWORD x, SDWORD y)
 {
-	return (x >= 0) && (x < (SDWORD)mapWidth) && (y >= 0) && (y < (SDWORD)mapHeight);
+	return (x >= 0) && (x < (SDWORD)worldMapState.width) && (y >= 0) && (y < (SDWORD)worldMapState.height);
 }
 
 WZ_DECL_ALWAYS_INLINE static inline bool tileOnMap(Vector2i pos)
@@ -517,8 +486,8 @@ WZ_DECL_ALWAYS_INLINE static inline bool tileOnMap(Vector2i pos)
 /* Return whether a world coordinate is on the map */
 WZ_DECL_ALWAYS_INLINE static inline bool worldOnMap(int x, int y)
 {
-	return (x >= 0) && (x < ((SDWORD)mapWidth << TILE_SHIFT)) &&
-	       (y >= 0) && (y < ((SDWORD)mapHeight << TILE_SHIFT));
+	return (x >= 0) && (x < ((SDWORD)worldMapState.width << TILE_SHIFT)) &&
+	       (y >= 0) && (y < ((SDWORD)worldMapState.height << TILE_SHIFT));
 }
 
 
@@ -564,9 +533,6 @@ void getTileMaxMin(int x, int y, int *pMax, int *pMin);
 
 bool readVisibilityData(const char *fileName);
 bool writeVisibilityData(const char *fileName);
-
-//scroll min and max values
-extern SDWORD scrollMinX, scrollMaxX, scrollMinY, scrollMaxY;
 
 void mapFloodFillContinents();
 

--- a/src/map.h
+++ b/src/map.h
@@ -54,8 +54,6 @@ struct GROUND_TYPE
 	bool highQualityTextures = false; // whether this ground_type has normal / specular / height maps
 };
 
-extern WorldMapState worldMapState;
-
 extern float waterLevel;
 extern char *tilesetDir;
 extern MAP_TILESET currentMapTileset;

--- a/src/map.h
+++ b/src/map.h
@@ -85,58 +85,58 @@ size_t getNumGroundTypes();
 #define AUX_MAX		3
 
 /// Find aux bitfield for a given tile
-WZ_DECL_ALWAYS_INLINE static inline uint8_t auxTile(int x, int y, int player)
+WZ_DECL_ALWAYS_INLINE static inline uint8_t auxTile(const WorldMapState& mapState, int x, int y, int player)
 {
 	ASSERT_OR_RETURN(AUXBITS_ALL, player >= 0 && player < MAX_PLAYERS + AUX_MAX, "invalid player: %d", player);
-	return worldMapState.auxMap[player][x + y * worldMapState.width];
+	return mapState.auxMap[player][x + y * mapState.width];
 }
 
 /// Find blocking bitfield for a given tile
-WZ_DECL_ALWAYS_INLINE static inline uint8_t blockTile(int x, int y, int slot)
+WZ_DECL_ALWAYS_INLINE static inline uint8_t blockTile(const WorldMapState& mapState, int x, int y, int slot)
 {
-	return worldMapState.blockMap[slot][x + y * worldMapState.width];
+	return mapState.blockMap[slot][x + y * mapState.width];
 }
 
 /// Store a shadow copy of a player's aux map for use in threaded calculations
-static inline void auxMapStore(int player, int slot)
+static inline void auxMapStore(WorldMapState& mapState, int player, int slot)
 {
-	memcpy(worldMapState.blockMap[slot].get(), worldMapState.blockMap[0].get(), sizeof(uint8_t) * worldMapState.width * worldMapState.height);
-	memcpy(worldMapState.auxMap[MAX_PLAYERS + slot].get(), worldMapState.auxMap[player].get(), sizeof(uint8_t) * worldMapState.width * worldMapState.height);
+	memcpy(mapState.blockMap[slot].get(), mapState.blockMap[0].get(), sizeof(uint8_t) * mapState.width * mapState.height);
+	memcpy(mapState.auxMap[MAX_PLAYERS + slot].get(), mapState.auxMap[player].get(), sizeof(uint8_t) * mapState.width * mapState.height);
 }
 
 /// Restore selected fields from the shadow copy of a player's aux map (ignoring the block map)
-static inline void auxMapRestore(int player, int slot, int mask)
+static inline void auxMapRestore(WorldMapState& mapState, int player, int slot, int mask)
 {
 	int i;
 	uint8_t original, cached;
 
-	for (i = 0; i < worldMapState.height * worldMapState.width; i++)
+	for (i = 0; i < mapState.height * mapState.width; i++)
 	{
-		original = worldMapState.auxMap[player][i];
-		cached = worldMapState.auxMap[MAX_PLAYERS + slot][i];
-		worldMapState.auxMap[player][i] = original ^ ((original ^ cached) & mask);
+		original = mapState.auxMap[player][i];
+		cached = mapState.auxMap[MAX_PLAYERS + slot][i];
+		mapState.auxMap[player][i] = original ^ ((original ^ cached) & mask);
 	}
 }
 
 /// Set aux bits. Always set identically for all players. States not set are retained.
-WZ_DECL_ALWAYS_INLINE static inline void auxSet(int x, int y, int player, int state)
+WZ_DECL_ALWAYS_INLINE static inline void auxSet(WorldMapState& mapState, int x, int y, int player, int state)
 {
-	worldMapState.auxMap[player][x + y * worldMapState.width] |= state;
+	mapState.auxMap[player][x + y * mapState.width] |= state;
 }
 
 /// Set aux bits. Always set identically for all players. States not set are retained.
-WZ_DECL_ALWAYS_INLINE static inline void auxSetAll(int x, int y, int state)
+WZ_DECL_ALWAYS_INLINE static inline void auxSetAll(WorldMapState& mapState, int x, int y, int state)
 {
 	int i;
 
 	for (i = 0; i < MAX_PLAYERS; i++)
 	{
-		worldMapState.auxMap[i][x + y * worldMapState.width] |= state;
+		mapState.auxMap[i][x + y * mapState.width] |= state;
 	}
 }
 
 /// Set aux bits. Always set identically for all players. States not set are retained.
-WZ_DECL_ALWAYS_INLINE static inline void auxSetAllied(int x, int y, int player, int state)
+WZ_DECL_ALWAYS_INLINE static inline void auxSetAllied(WorldMapState& mapState, int x, int y, int player, int state)
 {
 	int i;
 
@@ -144,13 +144,13 @@ WZ_DECL_ALWAYS_INLINE static inline void auxSetAllied(int x, int y, int player, 
 	{
 		if (aiCheckAlliances(player, i))
 		{
-			worldMapState.auxMap[i][x + y * worldMapState.width] |= state;
+			mapState.auxMap[i][x + y * mapState.width] |= state;
 		}
 	}
 }
 
 /// Set aux bits. Always set identically for all players. States not set are retained.
-WZ_DECL_ALWAYS_INLINE static inline void auxSetEnemy(int x, int y, int player, int state)
+WZ_DECL_ALWAYS_INLINE static inline void auxSetEnemy(WorldMapState& mapState, int x, int y, int player, int state)
 {
 	int i;
 
@@ -158,38 +158,38 @@ WZ_DECL_ALWAYS_INLINE static inline void auxSetEnemy(int x, int y, int player, i
 	{
 		if (!aiCheckAlliances(player, i))
 		{
-			worldMapState.auxMap[i][x + y * worldMapState.width] |= state;
+			mapState.auxMap[i][x + y * mapState.width] |= state;
 		}
 	}
 }
 
 /// Clear aux bits. Always set identically for all players. States not cleared are retained.
-WZ_DECL_ALWAYS_INLINE static inline void auxClear(int x, int y, int player, int state)
+WZ_DECL_ALWAYS_INLINE static inline void auxClear(WorldMapState& mapState, int x, int y, int player, int state)
 {
-	worldMapState.auxMap[player][x + y * worldMapState.width] &= ~state;
+	mapState.auxMap[player][x + y * mapState.width] &= ~state;
 }
 
 /// Clear all aux bits. Always set identically for all players. States not cleared are retained.
-WZ_DECL_ALWAYS_INLINE static inline void auxClearAll(int x, int y, int state)
+WZ_DECL_ALWAYS_INLINE static inline void auxClearAll(WorldMapState& mapState, int x, int y, int state)
 {
 	int i;
 
 	for (i = 0; i < MAX_PLAYERS; i++)
 	{
-		worldMapState.auxMap[i][x + y * worldMapState.width] &= ~state;
+		mapState.auxMap[i][x + y * mapState.width] &= ~state;
 	}
 }
 
 /// Set blocking bits. Always set identically for all players. States not set are retained.
-WZ_DECL_ALWAYS_INLINE static inline void auxSetBlocking(int x, int y, int state)
+WZ_DECL_ALWAYS_INLINE static inline void auxSetBlocking(WorldMapState& mapState, int x, int y, int state)
 {
-	worldMapState.blockMap[0][x + y * worldMapState.width] |= state;
+	mapState.blockMap[0][x + y * mapState.width] |= state;
 }
 
 /// Clear blocking bits. Always set identically for all players. States not cleared are retained.
-WZ_DECL_ALWAYS_INLINE static inline void auxClearBlocking(int x, int y, int state)
+WZ_DECL_ALWAYS_INLINE static inline void auxClearBlocking(WorldMapState& mapState, int x, int y, int state)
 {
-	worldMapState.blockMap[0][x + y * worldMapState.width] &= ~state;
+	mapState.blockMap[0][x + y * mapState.width] &= ~state;
 }
 
 /**
@@ -345,13 +345,13 @@ static inline Vector2i round_to_nearest_tile(Vector2i const &worldCoord)
  *  \post 1 <= *worldX <= world_coord(mapWidth)-1 and
  *        1 <= *worldy <= world_coord(mapHeight)-1
  */
-static inline void clip_world_offmap(int *worldX, int *worldY)
+static inline void clip_world_offmap(const WorldMapState& mapState, int *worldX, int *worldY)
 {
 	// x,y must be > 0
 	*worldX = MAX(1, *worldX);
 	*worldY = MAX(1, *worldY);
-	*worldX = MIN(world_coord(worldMapState.width) - 1, *worldX);
-	*worldY = MIN(world_coord(worldMapState.height) - 1, *worldY);
+	*worldX = MIN(world_coord(mapState.width) - 1, *worldX);
+	*worldY = MIN(world_coord(mapState.height) - 1, *worldY);
 }
 
 /* Shutdown the map module */
@@ -400,101 +400,101 @@ public:
 bool mapSaveToWzMapData(WzMap::MapData& output);
 
 /** Return a pointer to the tile structure at x,y in map coordinates */
-static inline WZ_DECL_PURE MAPTILE *mapTile(int32_t x, int32_t y)
+static inline WZ_DECL_PURE MAPTILE *mapTile(WorldMapState& mapState, int32_t x, int32_t y)
 {
 	// Clamp x and y values to actual ones
 	// Give one tile worth of leeway before asserting, for units/transporters coming in from off-map.
-	ASSERT(x >= -1, "mapTile: x value is too small (%d,%d) in %dx%d", x, y, worldMapState.width, worldMapState.height);
-	ASSERT(y >= -1, "mapTile: y value is too small (%d,%d) in %dx%d", x, y, worldMapState.width, worldMapState.height);
+	ASSERT(x >= -1, "mapTile: x value is too small (%d,%d) in %dx%d", x, y, mapState.width, mapState.height);
+	ASSERT(y >= -1, "mapTile: y value is too small (%d,%d) in %dx%d", x, y, mapState.width, mapState.height);
 	x = MAX(x, 0);
 	y = MAX(y, 0);
-	ASSERT(x < worldMapState.width + 1, "mapTile: x value is too big (%d,%d) in %dx%d", x, y, worldMapState.width, worldMapState.height);
-	ASSERT(y < worldMapState.height + 1, "mapTile: y value is too big (%d,%d) in %dx%d", x, y, worldMapState.width, worldMapState.height);
-	x = MIN(x, worldMapState.width - 1);
-	y = MIN(y, worldMapState.height - 1);
+	ASSERT(x < mapState.width + 1, "mapTile: x value is too big (%d,%d) in %dx%d", x, y, mapState.width, mapState.height);
+	ASSERT(y < mapState.height + 1, "mapTile: y value is too big (%d,%d) in %dx%d", x, y, mapState.width, mapState.height);
+	x = MIN(x, mapState.width - 1);
+	y = MIN(y, mapState.height - 1);
 
-	return &worldMapState.tiles[x + (y * worldMapState.width)];
+	return &mapState.tiles[x + (y * mapState.width)];
 }
 
-static inline WZ_DECL_PURE MAPTILE *mapTile(Vector2i const &v)
+static inline WZ_DECL_PURE MAPTILE *mapTile(WorldMapState& mapState, Vector2i const &v)
 {
-	return mapTile(v.x, v.y);
+	return mapTile(mapState, v.x, v.y);
 }
 
 /** Return a pointer to the tile structure at x,y in world coordinates */
-static inline WZ_DECL_PURE MAPTILE *worldTile(int32_t x, int32_t y)
+static inline WZ_DECL_PURE MAPTILE *worldTile(WorldMapState& mapState, int32_t x, int32_t y)
 {
-	return mapTile(map_coord(x), map_coord(y));
+	return mapTile(mapState, map_coord(x), map_coord(y));
 }
-static inline WZ_DECL_PURE MAPTILE *worldTile(Vector2i const &v)
+static inline WZ_DECL_PURE MAPTILE *worldTile(WorldMapState& mapState, Vector2i const &v)
 {
-	return mapTile(map_coord(v));
+	return mapTile(mapState, map_coord(v));
 }
 
 /// Return ground height of top-left corner of tile at x,y
-static inline WZ_DECL_PURE int32_t map_TileHeight(int32_t x, int32_t y)
+static inline WZ_DECL_PURE int32_t map_TileHeight(const WorldMapState& mapState, int32_t x, int32_t y)
 {
-	if (x >= worldMapState.width || y >= worldMapState.height || x < 0 || y < 0)
+	if (x >= mapState.width || y >= mapState.height || x < 0 || y < 0)
 	{
 		return 0;
 	}
-	return worldMapState.tiles[x + (y * worldMapState.width)].height;
+	return mapState.tiles[x + (y * mapState.width)].height;
 }
 
 /// Return water height of top-left corner of tile at x,y
-static inline WZ_DECL_PURE int32_t map_WaterHeight(int32_t x, int32_t y)
+static inline WZ_DECL_PURE int32_t map_WaterHeight(const WorldMapState& mapState, int32_t x, int32_t y)
 {
-	if (x >= worldMapState.width || y >= worldMapState.height || x < 0 || y < 0)
+	if (x >= mapState.width || y >= mapState.height || x < 0 || y < 0)
 	{
 		return 0;
 	}
-	return worldMapState.tiles[x + (y * worldMapState.width)].waterLevel;
+	return mapState.tiles[x + (y * mapState.width)].waterLevel;
 }
 
 /// Return max(ground, water) height of top-left corner of tile at x,y
-static inline WZ_DECL_PURE int32_t map_TileHeightSurface(int32_t x, int32_t y)
+static inline WZ_DECL_PURE int32_t map_TileHeightSurface(const WorldMapState& mapState, int32_t x, int32_t y)
 {
-	if (x >= worldMapState.width || y >= worldMapState.height || x < 0 || y < 0)
+	if (x >= mapState.width || y >= mapState.height || x < 0 || y < 0)
 	{
 		return 0;
 	}
-	return MAX(worldMapState.tiles[x + (y * worldMapState.width)].height, worldMapState.tiles[x + (y * worldMapState.width)].waterLevel);
+	return MAX(mapState.tiles[x + (y * mapState.width)].height, mapState.tiles[x + (y * mapState.width)].waterLevel);
 }
 
 
 /*sets the tile height */
-static inline void setTileHeight(int32_t x, int32_t y, int32_t height)
+static inline void setTileHeight(WorldMapState& mapState, int32_t x, int32_t y, int32_t height)
 {
-	ASSERT_OR_RETURN(, x < worldMapState.width && x >= 0, "x coordinate %d bigger than map width %u", x, worldMapState.width);
-	ASSERT_OR_RETURN(, y < worldMapState.height && x >= 0, "y coordinate %d bigger than map height %u", y, worldMapState.height);
+	ASSERT_OR_RETURN(, x < mapState.width && x >= 0, "x coordinate %d bigger than map width %u", x, mapState.width);
+	ASSERT_OR_RETURN(, y < mapState.height && x >= 0, "y coordinate %d bigger than map height %u", y, mapState.height);
 
-	worldMapState.tiles[x + (y * worldMapState.width)].height = height;
+	mapState.tiles[x + (y * mapState.width)].height = height;
 	markTileDirty(x, y);
 }
 
 /* Return whether a tile coordinate is on the map */
-WZ_DECL_ALWAYS_INLINE static inline bool tileOnMap(SDWORD x, SDWORD y)
+WZ_DECL_ALWAYS_INLINE static inline bool tileOnMap(const WorldMapState& mapState, SDWORD x, SDWORD y)
 {
-	return (x >= 0) && (x < (SDWORD)worldMapState.width) && (y >= 0) && (y < (SDWORD)worldMapState.height);
+	return (x >= 0) && (x < (SDWORD)mapState.width) && (y >= 0) && (y < (SDWORD)mapState.height);
 }
 
-WZ_DECL_ALWAYS_INLINE static inline bool tileOnMap(Vector2i pos)
+WZ_DECL_ALWAYS_INLINE static inline bool tileOnMap(const WorldMapState& mapState, Vector2i pos)
 {
-	return tileOnMap(pos.x, pos.y);
+	return tileOnMap(mapState, pos.x, pos.y);
 }
 
 /* Return whether a world coordinate is on the map */
-WZ_DECL_ALWAYS_INLINE static inline bool worldOnMap(int x, int y)
+WZ_DECL_ALWAYS_INLINE static inline bool worldOnMap(const WorldMapState& mapState, int x, int y)
 {
-	return (x >= 0) && (x < ((SDWORD)worldMapState.width << TILE_SHIFT)) &&
-	       (y >= 0) && (y < ((SDWORD)worldMapState.height << TILE_SHIFT));
+	return (x >= 0) && (x < ((SDWORD)mapState.width << TILE_SHIFT)) &&
+	       (y >= 0) && (y < ((SDWORD)mapState.height << TILE_SHIFT));
 }
 
 
 /* Return whether a world coordinate is on the map */
-WZ_DECL_ALWAYS_INLINE static inline bool worldOnMap(Vector2i pos)
+WZ_DECL_ALWAYS_INLINE static inline bool worldOnMap(const WorldMapState& mapState, Vector2i pos)
 {
-	return worldOnMap(pos.x, pos.y);
+	return worldOnMap(mapState, pos.x, pos.y);
 }
 
 static inline void makeTileRubbleTexture(MAPTILE *psTile, const unsigned int x, const unsigned int y, const unsigned int newTexture)
@@ -517,11 +517,11 @@ bool map_Intersect(int *Cx, int *Cy, int *Vx, int *Vy, int *Sx, int *Sy);
 unsigned map_LineIntersect(Vector3i src, Vector3i dst, unsigned tMax);
 
 /// The max height of the terrain and water at the specified world coordinates
-int32_t map_Height(int x, int y);
+int32_t map_Height(const WorldMapState& mapState, int x, int y);
 
-static inline int32_t map_Height(Vector2i const &v)
+static inline int32_t map_Height(const WorldMapState& mapState, Vector2i const &v)
 {
-	return map_Height(v.x, v.y);
+	return map_Height(mapState, v.x, v.y);
 }
 
 /* returns true if object is above ground */
@@ -536,8 +536,8 @@ bool writeVisibilityData(const char *fileName);
 
 void mapFloodFillContinents();
 
-void tileSetFire(int32_t x, int32_t y, uint32_t duration);
-bool fireOnLocation(unsigned int x, unsigned int y);
+void tileSetFire(WorldMapState& mapState, int32_t x, int32_t y, uint32_t duration);
+bool fireOnLocation(WorldMapState& mapState, unsigned int x, unsigned int y); // FIXME: add const overload
 
 /**
  * Transitive sensor check for tile. Has to be here rather than

--- a/src/mapgrid.cpp
+++ b/src/mapgrid.cpp
@@ -57,7 +57,7 @@ void gridReset()
 	// Put all existing objects into the point tree.
 	for (unsigned player = 0; player < MAX_PLAYERS; player++)
 	{
-		for (BASE_OBJECT* psObj : apsDroidLists[player])
+		for (BASE_OBJECT* psObj : worldObjectState.droids[player])
 		{
 			if (!psObj->died)
 			{
@@ -68,7 +68,7 @@ void gridReset()
 				}
 			}
 		}
-		for (BASE_OBJECT* psObj : apsStructLists[player])
+		for (BASE_OBJECT* psObj : worldObjectState.structures[player])
 		{
 			if (!psObj->died)
 			{
@@ -80,7 +80,7 @@ void gridReset()
 			}
 		}
 	}
-	for (BASE_OBJECT* psObj : apsFeatureList[0])
+	for (BASE_OBJECT* psObj : worldObjectState.features[0])
 	{
 		if (!psObj->died)
 		{

--- a/src/mapgrid.cpp
+++ b/src/mapgrid.cpp
@@ -30,6 +30,7 @@
 
 #include "mapgrid.h"
 #include "pointtree.h"
+#include "game_world.h"
 
 
 static PointTree *gridPointTree = nullptr;  // A quad-tree-like object.
@@ -57,7 +58,7 @@ void gridReset()
 	// Put all existing objects into the point tree.
 	for (unsigned player = 0; player < MAX_PLAYERS; player++)
 	{
-		for (BASE_OBJECT* psObj : worldObjectState.droids[player])
+		for (BASE_OBJECT* psObj : gameWorld.objects.droids[player])
 		{
 			if (!psObj->died)
 			{
@@ -68,7 +69,7 @@ void gridReset()
 				}
 			}
 		}
-		for (BASE_OBJECT* psObj : worldObjectState.structures[player])
+		for (BASE_OBJECT* psObj : gameWorld.objects.structures[player])
 		{
 			if (!psObj->died)
 			{
@@ -80,7 +81,7 @@ void gridReset()
 			}
 		}
 	}
-	for (BASE_OBJECT* psObj : worldObjectState.features[0])
+	for (BASE_OBJECT* psObj : gameWorld.objects.features[0])
 	{
 		if (!psObj->died)
 		{

--- a/src/mission.cpp
+++ b/src/mission.cpp
@@ -82,7 +82,7 @@
 #include "lib/framework/wztime.h"
 #include "keybind.h"
 #include "campaigninfo.h"
-#include "world_object_state.h"
+#include "game_world.h"
 #include "wzapi.h"
 #include "screens/guidescreen.h"
 
@@ -195,7 +195,7 @@ static void resetHomeStructureObjects()
 {
 	for (unsigned int i = 0; i < MAX_PLAYERS; ++i)
 	{
-		for (STRUCTURE *psStruct : worldObjectState.structures[i])
+		for (STRUCTURE *psStruct : gameWorld.objects.structures[i])
 		{
 			if (!psStruct->pFunctionality || !psStruct->pStructureType)
 			{
@@ -274,29 +274,29 @@ void initMission()
 	mission.type = LEVEL_TYPE::LDS_NONE;
 	for (int inc = 0; inc < MAX_PLAYERS; inc++)
 	{
-		mission.worldObjectState.structures[inc].clear();
-		mission.worldObjectState.droids[inc].clear();
-		mission.worldObjectState.flags[inc].clear();
-		mission.worldObjectState.extractors[inc].clear();
+		mission.gameWorld.objects.structures[inc].clear();
+		mission.gameWorld.objects.droids[inc].clear();
+		mission.gameWorld.objects.flags[inc].clear();
+		mission.gameWorld.objects.extractors[inc].clear();
 		apsLimboDroids[inc].clear();
 	}
-	mission.worldObjectState.features[0].clear();
-	mission.worldObjectState.sensors[0].clear();
-	mission.worldObjectState.oils[0].clear();
+	mission.gameWorld.objects.features[0].clear();
+	mission.gameWorld.objects.sensors[0].clear();
+	mission.gameWorld.objects.oils[0].clear();
 	offWorldKeepLists = false;
 	mission.time = -1;
 	setMissionCountDown();
 
 	mission.ETA = -1;
 	mission.startTime = 0;
-	mission.worldMapState.gateways.clear(); // just in case
-	mission.worldMapState.height = 0;
-	mission.worldMapState.width = 0;
-	for (auto &i : mission.worldMapState.blockMap)
+	mission.gameWorld.map.gateways.clear(); // just in case
+	mission.gameWorld.map.height = 0;
+	mission.gameWorld.map.width = 0;
+	for (auto &i : mission.gameWorld.map.blockMap)
 	{
 		i.reset();
 	}
-	for (auto &i : mission.worldMapState.auxMap)
+	for (auto &i : mission.gameWorld.map.auxMap)
 	{
 		i.reset();
 	}
@@ -339,34 +339,34 @@ bool missionShutDown()
 
 		for (int inc = 0; inc < MAX_PLAYERS; inc++)
 		{
-			worldObjectState.droids[inc] = std::move(mission.worldObjectState.droids[inc]);
-			mission.worldObjectState.droids[inc].clear();
-			worldObjectState.structures[inc] = std::move(mission.worldObjectState.structures[inc]);
-			mission.worldObjectState.structures[inc].clear();
-			worldObjectState.flags[inc] = std::move(mission.worldObjectState.flags[inc]);
-			mission.worldObjectState.flags[inc].clear();
-			worldObjectState.extractors[inc] = std::move(mission.worldObjectState.extractors[inc]);
-			mission.worldObjectState.extractors[inc].clear();
+			gameWorld.objects.droids[inc] = std::move(mission.gameWorld.objects.droids[inc]);
+			mission.gameWorld.objects.droids[inc].clear();
+			gameWorld.objects.structures[inc] = std::move(mission.gameWorld.objects.structures[inc]);
+			mission.gameWorld.objects.structures[inc].clear();
+			gameWorld.objects.flags[inc] = std::move(mission.gameWorld.objects.flags[inc]);
+			mission.gameWorld.objects.flags[inc].clear();
+			gameWorld.objects.extractors[inc] = std::move(mission.gameWorld.objects.extractors[inc]);
+			mission.gameWorld.objects.extractors[inc].clear();
 		}
-		worldObjectState.features[0] = std::move(mission.worldObjectState.features[0]);
-		worldObjectState.sensors[0] = std::move(mission.worldObjectState.sensors[0]);
-		worldObjectState.oils[0] = std::move(mission.worldObjectState.oils[0]);
-		mission.worldObjectState.features[0].clear();
-		mission.worldObjectState.sensors[0].clear();
-		mission.worldObjectState.oils[0].clear();
+		gameWorld.objects.features[0] = std::move(mission.gameWorld.objects.features[0]);
+		gameWorld.objects.sensors[0] = std::move(mission.gameWorld.objects.sensors[0]);
+		gameWorld.objects.oils[0] = std::move(mission.gameWorld.objects.oils[0]);
+		mission.gameWorld.objects.features[0].clear();
+		mission.gameWorld.objects.sensors[0].clear();
+		mission.gameWorld.objects.oils[0].clear();
 
-		worldMapState.tiles = std::move(mission.worldMapState.tiles);
-		worldMapState.width = mission.worldMapState.width;
-		worldMapState.height = mission.worldMapState.height;
-		for (int i = 0; i < ARRAY_SIZE(mission.worldMapState.blockMap); ++i)
+		gameWorld.map.tiles = std::move(mission.gameWorld.map.tiles);
+		gameWorld.map.width = mission.gameWorld.map.width;
+		gameWorld.map.height = mission.gameWorld.map.height;
+		for (int i = 0; i < ARRAY_SIZE(mission.gameWorld.map.blockMap); ++i)
 		{
-			worldMapState.blockMap[i] = std::move(mission.worldMapState.blockMap[i]);
+			gameWorld.map.blockMap[i] = std::move(mission.gameWorld.map.blockMap[i]);
 		}
-		for (int i = 0; i < ARRAY_SIZE(mission.worldMapState.auxMap); ++i)
+		for (int i = 0; i < ARRAY_SIZE(mission.gameWorld.map.auxMap); ++i)
 		{
-			worldMapState.auxMap[i] = std::move(mission.worldMapState.auxMap[i]);
+			gameWorld.map.auxMap[i] = std::move(mission.gameWorld.map.auxMap[i]);
 		}
-		std::swap(mission.worldMapState.gateways, gwGetGateways());
+		std::swap(mission.gameWorld.map.gateways, gwGetGateways());
 	}
 	keybindShutdown();
 	// sorry if this breaks something - but it looks like it's what should happen - John
@@ -568,7 +568,7 @@ void addTransporterTimerInterface()
 	if (mission.ETA >= 0 && selectedPlayer < MAX_PLAYERS)
 	{
 		//check the player has at least one Transporter back at base
-		for (DROID *psDroid : mission.worldObjectState.droids[selectedPlayer])
+		for (DROID *psDroid : mission.gameWorld.objects.droids[selectedPlayer])
 		{
 			if (psDroid->isTransporter())
 			{
@@ -623,10 +623,10 @@ void missionFlyTransportersIn(SDWORD iPlayer, bool bTrackTransporter)
 	iLandX = getLandingX(iPlayer);
 	iLandY = getLandingY(iPlayer);
 	missionGetTransporterEntry(iPlayer, &iX, &iY);
-	iZ = (UWORD)(map_Height(worldMapState, iX, iY) + OFFSCREEN_HEIGHT);
+	iZ = (UWORD)(map_Height(gameWorld.map, iX, iY) + OFFSCREEN_HEIGHT);
 
 	//get the droids for the mission
-	mutating_list_iterate(mission.worldObjectState.droids[iPlayer], [iPlayer, bTrackTransporter, iX, iY, iZ, iLandX, iLandY](DROID* psTransporter)
+	mutating_list_iterate(mission.gameWorld.objects.droids[iPlayer], [iPlayer, bTrackTransporter, iX, iY, iZ, iLandX, iLandY](DROID* psTransporter)
 	{
 		SDWORD iDx, iDy;
 
@@ -639,10 +639,10 @@ void missionFlyTransportersIn(SDWORD iPlayer, bool bTrackTransporter)
 				psTransporter->watchedTiles.clear();
 
 				// Remove out of stored list and add to current Droid list
-				if (droidRemove(psTransporter, mission.worldObjectState.droids))
+				if (droidRemove(psTransporter, mission.gameWorld.objects.droids))
 				{
 					// Do not want to add it unless managed to remove it from the previous list
-					addDroid(psTransporter, worldObjectState.droids);
+					addDroid(psTransporter, gameWorld.objects.droids);
 				}
 
 				/* set start position */
@@ -702,13 +702,13 @@ static void saveMissionData()
 	audio_StopAll();
 
 	//set any structures currently being built to completed for the selected player
-	mutating_list_iterate(worldObjectState.structures[selectedPlayer], [&bRepairExists, &bRearmPadExists](STRUCTURE* psStruct)
+	mutating_list_iterate(gameWorld.objects.structures[selectedPlayer], [&bRepairExists, &bRearmPadExists](STRUCTURE* psStruct)
 	{
 		STRUCTURE* psStructBeingBuilt;
 		if (psStruct->status == SS_BEING_BUILT)
 		{
 			//find a droid working on it
-			for (const DROID* psDroid : worldObjectState.droids[selectedPlayer])
+			for (const DROID* psDroid : gameWorld.objects.droids[selectedPlayer])
 			{
 				if ((psStructBeingBuilt = (STRUCTURE*)orderStateObj(psDroid, DORDER_BUILD))
 					&& psStructBeingBuilt == psStruct)
@@ -738,7 +738,7 @@ static void saveMissionData()
 	//repair and rearm all droids back at home base if have a repair facility or rearming pad
 	if (bRepairExists || bRearmPadExists)
 	{
-		for (DROID* psDroid : worldObjectState.droids[selectedPlayer])
+		for (DROID* psDroid : gameWorld.objects.droids[selectedPlayer])
 		{
 			bool vtolAndPadsExist = (psDroid->isVtol() && bRearmPadExists);
 			if ((bRepairExists || vtolAndPadsExist) && psDroid->isDamaged())
@@ -753,7 +753,7 @@ static void saveMissionData()
 	}
 
 	//clear droid orders for all droids except constructors still building
-	for (DROID* psDroid : worldObjectState.droids[selectedPlayer])
+	for (DROID* psDroid : gameWorld.objects.droids[selectedPlayer])
 	{
 		STRUCTURE* psStructBeingBuilt;
 		if ((psStructBeingBuilt = (STRUCTURE *)orderStateObj(psDroid, DORDER_BUILD)))
@@ -773,36 +773,36 @@ static void saveMissionData()
 	resetHomeStructureObjects(); //get rid of soon-to-be illegal references of droids in repair facilities and rearming pads.
 
 	//save the mission data
-	mission.worldMapState.tiles = std::move(worldMapState.tiles);
-	mission.worldMapState.width = worldMapState.width;
-	mission.worldMapState.height = worldMapState.height;
-	for (int i = 0; i < ARRAY_SIZE(mission.worldMapState.blockMap); ++i)
+	mission.gameWorld.map.tiles = std::move(gameWorld.map.tiles);
+	mission.gameWorld.map.width = gameWorld.map.width;
+	mission.gameWorld.map.height = gameWorld.map.height;
+	for (int i = 0; i < ARRAY_SIZE(mission.gameWorld.map.blockMap); ++i)
 	{
-		mission.worldMapState.blockMap[i] = std::move(worldMapState.blockMap[i]);
+		mission.gameWorld.map.blockMap[i] = std::move(gameWorld.map.blockMap[i]);
 	}
-	for (int i = 0; i < ARRAY_SIZE(mission.worldMapState.auxMap); ++i)
+	for (int i = 0; i < ARRAY_SIZE(mission.gameWorld.map.auxMap); ++i)
 	{
-		mission.worldMapState.auxMap[i] = std::move(worldMapState.auxMap[i]);
+		mission.gameWorld.map.auxMap[i] = std::move(gameWorld.map.auxMap[i]);
 	}
-	mission.worldMapState.scroll.minX = worldMapState.scroll.minX;
-	mission.worldMapState.scroll.minY = worldMapState.scroll.minY;
-	mission.worldMapState.scroll.maxX = worldMapState.scroll.maxX;
-	mission.worldMapState.scroll.maxY = worldMapState.scroll.maxY;
-	std::swap(mission.worldMapState.gateways, gwGetGateways());
+	mission.gameWorld.map.scroll.minX = gameWorld.map.scroll.minX;
+	mission.gameWorld.map.scroll.minY = gameWorld.map.scroll.minY;
+	mission.gameWorld.map.scroll.maxX = gameWorld.map.scroll.maxX;
+	mission.gameWorld.map.scroll.maxY = gameWorld.map.scroll.maxY;
+	std::swap(mission.gameWorld.map.gateways, gwGetGateways());
 	// save the selectedPlayer's LZ
 	mission.homeLZ_X = getLandingX(selectedPlayer);
 	mission.homeLZ_Y = getLandingY(selectedPlayer);
 
 	for (unsigned int inc = 0; inc < MAX_PLAYERS; ++inc)
 	{
-		mission.worldObjectState.structures[inc] = worldObjectState.structures[inc];
-		mission.worldObjectState.droids[inc] = worldObjectState.droids[inc];
-		mission.worldObjectState.flags[inc] = worldObjectState.flags[inc];
-		mission.worldObjectState.extractors[inc] = worldObjectState.extractors[inc];
+		mission.gameWorld.objects.structures[inc] = gameWorld.objects.structures[inc];
+		mission.gameWorld.objects.droids[inc] = gameWorld.objects.droids[inc];
+		mission.gameWorld.objects.flags[inc] = gameWorld.objects.flags[inc];
+		mission.gameWorld.objects.extractors[inc] = gameWorld.objects.extractors[inc];
 	}
-	mission.worldObjectState.features[0] = worldObjectState.features[0];
-	mission.worldObjectState.sensors[0] = worldObjectState.sensors[0];
-	mission.worldObjectState.oils[0] = worldObjectState.oils[0];
+	mission.gameWorld.objects.features[0] = gameWorld.objects.features[0];
+	mission.gameWorld.objects.sensors[0] = gameWorld.objects.sensors[0];
+	mission.gameWorld.objects.oils[0] = gameWorld.objects.oils[0];
 
 	mission.playerX = playerPos.p.x;
 	mission.playerY = playerPos.p.z;
@@ -850,56 +850,56 @@ void restoreMissionData()
 	//restore the game pointers
 	for (inc = 0; inc < MAX_PLAYERS; inc++)
 	{
-		worldObjectState.droids[inc] = std::move(mission.worldObjectState.droids[inc]);
-		mission.worldObjectState.droids[inc].clear();
-		for (DROID* psObj : worldObjectState.droids[inc])
+		gameWorld.objects.droids[inc] = std::move(mission.gameWorld.objects.droids[inc]);
+		mission.gameWorld.objects.droids[inc].clear();
+		for (DROID* psObj : gameWorld.objects.droids[inc])
 		{
 			psObj->died = false;	//make sure the died flag is not set
 		}
 
-		worldObjectState.structures[inc] = std::move(mission.worldObjectState.structures[inc]);
-		mission.worldObjectState.structures[inc].clear();
+		gameWorld.objects.structures[inc] = std::move(mission.gameWorld.objects.structures[inc]);
+		mission.gameWorld.objects.structures[inc].clear();
 
-		worldObjectState.flags[inc] = std::move(mission.worldObjectState.flags[inc]);
-		mission.worldObjectState.flags[inc].clear();
+		gameWorld.objects.flags[inc] = std::move(mission.gameWorld.objects.flags[inc]);
+		mission.gameWorld.objects.flags[inc].clear();
 
-		worldObjectState.extractors[inc] = std::move(mission.worldObjectState.extractors[inc]);
-		mission.worldObjectState.extractors[inc].clear();
+		gameWorld.objects.extractors[inc] = std::move(mission.gameWorld.objects.extractors[inc]);
+		mission.gameWorld.objects.extractors[inc].clear();
 	}
-	worldObjectState.features[0] = std::move(mission.worldObjectState.features[0]);
-	worldObjectState.sensors[0] = std::move(mission.worldObjectState.sensors[0]);
-	worldObjectState.oils[0] = std::move(mission.worldObjectState.oils[0]);
-	mission.worldObjectState.features[0].clear();
-	mission.worldObjectState.sensors[0].clear();
-	mission.worldObjectState.oils[0].clear();
+	gameWorld.objects.features[0] = std::move(mission.gameWorld.objects.features[0]);
+	gameWorld.objects.sensors[0] = std::move(mission.gameWorld.objects.sensors[0]);
+	gameWorld.objects.oils[0] = std::move(mission.gameWorld.objects.oils[0]);
+	mission.gameWorld.objects.features[0].clear();
+	mission.gameWorld.objects.sensors[0].clear();
+	mission.gameWorld.objects.oils[0].clear();
 	//swap mission data over
 
-	worldMapState.tiles = std::move(mission.worldMapState.tiles);
+	gameWorld.map.tiles = std::move(mission.gameWorld.map.tiles);
 
-	worldMapState.width = mission.worldMapState.width;
-	worldMapState.height = mission.worldMapState.height;
-	for (int i = 0; i < ARRAY_SIZE(mission.worldMapState.blockMap); ++i)
+	gameWorld.map.width = mission.gameWorld.map.width;
+	gameWorld.map.height = mission.gameWorld.map.height;
+	for (int i = 0; i < ARRAY_SIZE(mission.gameWorld.map.blockMap); ++i)
 	{
-		worldMapState.blockMap[i] = std::move(mission.worldMapState.blockMap[i]);
+		gameWorld.map.blockMap[i] = std::move(mission.gameWorld.map.blockMap[i]);
 	}
-	for (int i = 0; i < ARRAY_SIZE(mission.worldMapState.auxMap); ++i)
+	for (int i = 0; i < ARRAY_SIZE(mission.gameWorld.map.auxMap); ++i)
 	{
-		worldMapState.auxMap[i] = std::move(mission.worldMapState.auxMap[i]);
+		gameWorld.map.auxMap[i] = std::move(mission.gameWorld.map.auxMap[i]);
 	}
-	worldMapState.scroll.minX = mission.worldMapState.scroll.minX;
-	worldMapState.scroll.minY = mission.worldMapState.scroll.minY;
-	worldMapState.scroll.maxX = mission.worldMapState.scroll.maxX;
-	worldMapState.scroll.maxY = mission.worldMapState.scroll.maxY;
-	std::swap(mission.worldMapState.gateways, gwGetGateways());
+	gameWorld.map.scroll.minX = mission.gameWorld.map.scroll.minX;
+	gameWorld.map.scroll.minY = mission.gameWorld.map.scroll.minY;
+	gameWorld.map.scroll.maxX = mission.gameWorld.map.scroll.maxX;
+	gameWorld.map.scroll.maxY = mission.gameWorld.map.scroll.maxY;
+	std::swap(mission.gameWorld.map.gateways, gwGetGateways());
 	//and clear the mission pointers
-	mission.worldMapState.tiles	= nullptr;
-	mission.worldMapState.width	= 0;
-	mission.worldMapState.height	= 0;
-	mission.worldMapState.scroll.minX	= 0;
-	mission.worldMapState.scroll.minY	= 0;
-	mission.worldMapState.scroll.maxX	= 0;
-	mission.worldMapState.scroll.maxY	= 0;
-	mission.worldMapState.gateways.clear();
+	mission.gameWorld.map.tiles	= nullptr;
+	mission.gameWorld.map.width	= 0;
+	mission.gameWorld.map.height	= 0;
+	mission.gameWorld.map.scroll.minX	= 0;
+	mission.gameWorld.map.scroll.minY	= 0;
+	mission.gameWorld.map.scroll.maxX	= 0;
+	mission.gameWorld.map.scroll.maxY	= 0;
+	mission.gameWorld.map.gateways.clear();
 
 	//reset the current structure lists
 	setCurrentStructQuantity(false);
@@ -927,18 +927,18 @@ void saveMissionLimboData()
 	processPreviousCampDroids();
 
 	// move droids properly - does all the clean up code
-	mutating_list_iterate(worldObjectState.droids[selectedPlayer], [](DROID* psDroid)
+	mutating_list_iterate(gameWorld.objects.droids[selectedPlayer], [](DROID* psDroid)
 	{
-		if (droidRemove(psDroid, worldObjectState.droids))
+		if (droidRemove(psDroid, gameWorld.objects.droids))
 		{
-			addDroid(psDroid, mission.worldObjectState.droids);
+			addDroid(psDroid, mission.gameWorld.objects.droids);
 		}
 		return IterationResult::CONTINUE_ITERATION;
 	});
-	worldObjectState.droids[selectedPlayer].clear();
+	gameWorld.objects.droids[selectedPlayer].clear();
 
 	// any selectedPlayer's factories/research need to be put on holdProduction/holdresearch
-	for (STRUCTURE* psStruct : worldObjectState.structures[selectedPlayer])
+	for (STRUCTURE* psStruct : gameWorld.objects.structures[selectedPlayer])
 	{
 		if (!psStruct)
 		{
@@ -970,7 +970,7 @@ void placeLimboDroids()
 
 		if (droidRemove(psDroid, apsLimboDroids))
 		{
-			addDroid(psDroid, worldObjectState.droids);
+			addDroid(psDroid, gameWorld.objects.droids);
 			//KILL OFF TRANSPORTER - should never be one but....
 			if (psDroid->isTransporter())
 			{
@@ -987,8 +987,8 @@ void placeLimboDroids()
 			}
 			psDroid->pos.x = (UWORD)world_coord(droidX);
 			psDroid->pos.y = (UWORD)world_coord(droidY);
-			ASSERT(worldOnMap(worldMapState, psDroid->pos.x, psDroid->pos.y), "limbo droid is not on the map");
-			psDroid->pos.z = map_Height(worldMapState, psDroid->pos.x, psDroid->pos.y);
+			ASSERT(worldOnMap(gameWorld.map, psDroid->pos.x, psDroid->pos.y), "limbo droid is not on the map");
+			psDroid->pos.z = map_Height(gameWorld.map, psDroid->pos.x, psDroid->pos.y);
 			updateDroidOrientation(psDroid);
 			psDroid->selected = false;
 			//this is mainly for VTOLs
@@ -1017,12 +1017,12 @@ void restoreMissionLimboData()
 
 	/*the droids stored in the mission droid list need to be added back
 	into the current droid list*/
-	mutating_list_iterate(mission.worldObjectState.droids[selectedPlayer], [](DROID* psDroid)
+	mutating_list_iterate(mission.gameWorld.objects.droids[selectedPlayer], [](DROID* psDroid)
 	{
 		//remove out of stored list and add to current Droid list
-		if (droidRemove(psDroid, mission.worldObjectState.droids))
+		if (droidRemove(psDroid, mission.gameWorld.objects.droids))
 		{
-			addDroid(psDroid, worldObjectState.droids);
+			addDroid(psDroid, gameWorld.objects.droids);
 			//reset droid orders
 			orderDroid(psDroid, DORDER_STOP, ModeImmediate);
 			//the location of the droid should be valid!
@@ -1033,7 +1033,7 @@ void restoreMissionLimboData()
 		}
 		return IterationResult::CONTINUE_ITERATION;
 	});
-	ASSERT(mission.worldObjectState.droids[selectedPlayer].empty(), "list should be empty");
+	ASSERT(mission.gameWorld.objects.droids[selectedPlayer].empty(), "list should be empty");
 }
 
 /*Saves the necessary data when moving from one campaign to the start of the
@@ -1048,7 +1048,7 @@ void saveCampaignData()
 	if (getDroidsToSafetyFlag())
 	{
 		// Move any Transporters into the mission list
-		mutating_list_iterate(worldObjectState.droids[selectedPlayer], [](DROID* psDroid)
+		mutating_list_iterate(gameWorld.objects.droids[selectedPlayer], [](DROID* psDroid)
 		{
 			if (psDroid->isTransporter())
 			{
@@ -1067,17 +1067,17 @@ void saveCampaignData()
 					psCurr->pos.x = INVALID_XY;
 					psCurr->pos.y = INVALID_XY;
 					// Add it back into current droid lists
-					addDroid(psCurr, mission.worldObjectState.droids);
+					addDroid(psCurr, mission.gameWorld.objects.droids);
 
 					return IterationResult::CONTINUE_ITERATION;
 				});
 				// Remove the transporter from the current list
-				if (droidRemove(psDroid, worldObjectState.droids))
+				if (droidRemove(psDroid, gameWorld.objects.droids))
 				{
 					//cam change add droid
 					psDroid->pos.x = INVALID_XY;
 					psDroid->pos.y = INVALID_XY;
-					addDroid(psDroid, mission.worldObjectState.droids);
+					addDroid(psDroid, mission.gameWorld.objects.droids);
 				}
 			}
 			return IterationResult::CONTINUE_ITERATION;
@@ -1086,9 +1086,9 @@ void saveCampaignData()
 	else
 	{
 		// Reserve the droids for selected player for start of next campaign
-		mission.worldObjectState.droids[selectedPlayer] = std::move(worldObjectState.droids[selectedPlayer]);
-		worldObjectState.droids[selectedPlayer].clear();
-		for (DROID* psDroid : mission.worldObjectState.droids[selectedPlayer])
+		mission.gameWorld.objects.droids[selectedPlayer] = std::move(gameWorld.objects.droids[selectedPlayer]);
+		gameWorld.objects.droids[selectedPlayer].clear();
+		for (DROID* psDroid : mission.gameWorld.objects.droids[selectedPlayer])
 		{
 			//cam change add droid
 			psDroid->pos.x = INVALID_XY;
@@ -1101,22 +1101,22 @@ void saveCampaignData()
 	{
 		/*now that every unit for the selected player has been moved into the
 		mission list - reverse it and fill the transporter with the first ten units*/
-		mission.worldObjectState.droids[selectedPlayer].reverse();
+		mission.gameWorld.objects.droids[selectedPlayer].reverse();
 
 		//find the *first* transporter
-		mutating_list_iterate(mission.worldObjectState.droids[selectedPlayer], [](DROID* psDroid)
+		mutating_list_iterate(mission.gameWorld.objects.droids[selectedPlayer], [](DROID* psDroid)
 		{
 			if (psDroid->isTransporter())
 			{
 				//fill it with droids from the mission list
-				mutating_list_iterate(mission.worldObjectState.droids[selectedPlayer], [psDroid](DROID* psSafeDroid)
+				mutating_list_iterate(mission.gameWorld.objects.droids[selectedPlayer], [psDroid](DROID* psSafeDroid)
 				{
 					if (psSafeDroid != psDroid)
 					{
 						//add to the Transporter, checking for when full
 						if (checkTransporterSpace(psDroid, psSafeDroid))
 						{
-							if (droidRemove(psSafeDroid, mission.worldObjectState.droids))
+							if (droidRemove(psSafeDroid, mission.gameWorld.objects.droids))
 							{
 								psDroid->psGroup->add(psSafeDroid);
 							}
@@ -1138,7 +1138,7 @@ void saveCampaignData()
 	//clear all other droids
 	for (int inc = 0; inc < MAX_PLAYERS; inc++)
 	{
-		mutating_list_iterate(worldObjectState.droids[inc], [](DROID* d)
+		mutating_list_iterate(gameWorld.objects.droids[inc], [](DROID* d)
 		{
 			vanishDroid(d);
 			return IterationResult::CONTINUE_ITERATION;
@@ -1282,7 +1282,7 @@ static void clearCampaignUnits()
 {
 	if (selectedPlayer >= MAX_PLAYERS) { return; }
 
-	for (DROID *psDroid : worldObjectState.droids[selectedPlayer])
+	for (DROID *psDroid : gameWorld.objects.droids[selectedPlayer])
 	{
 		orderDroid(psDroid, DORDER_STOP, ModeImmediate);
 		setDroidBase(psDroid, nullptr);
@@ -1297,7 +1297,7 @@ static void processMission()
 	ASSERT(selectedPlayer < MAX_PLAYERS, "selectedPlayer %" PRIu32 " exceeds MAX_PLAYERS", selectedPlayer);
 
 	//and the rest on the mission map  - for now?
-	mutating_list_iterate(worldObjectState.droids[selectedPlayer], [](DROID* psDroid)
+	mutating_list_iterate(gameWorld.objects.droids[selectedPlayer], [](DROID* psDroid)
 	{
 		UDWORD			droidX, droidY;
 		PICKTILE		pickRes;
@@ -1306,11 +1306,11 @@ static void processMission()
 		// clean up visibility
 		visRemoveVisibility((BASE_OBJECT*)psDroid);
 		//remove out of stored list and add to current Droid list
-		if (droidRemove(psDroid, worldObjectState.droids))
+		if (droidRemove(psDroid, gameWorld.objects.droids))
 		{
 			int	x, y;
 
-			addDroid(psDroid, mission.worldObjectState.droids);
+			addDroid(psDroid, mission.gameWorld.objects.droids);
 			droidX = getHomeLandingX();
 			droidY = getHomeLandingY();
 			// Swap the droid and map pointers
@@ -1321,7 +1321,7 @@ static void processMission()
 			x = (UWORD)world_coord(droidX);
 			y = (UWORD)world_coord(droidY);
 			droidSetPosition(psDroid, x, y);
-			ASSERT(worldOnMap(worldMapState, psDroid->pos.x, psDroid->pos.y), "the droid is not on the map");
+			ASSERT(worldOnMap(gameWorld.map, psDroid->pos.x, psDroid->pos.y), "the droid is not on the map");
 			updateDroidOrientation(psDroid);
 			// Swap the droid and map pointers back again
 			swapMissionPointers();
@@ -1344,7 +1344,7 @@ void processMissionLimbo()
 	ASSERT(selectedPlayer < MAX_PLAYERS, "selectedPlayer %" PRIu32 " exceeds MAX_PLAYERS", selectedPlayer);
 
 	//all droids (for selectedPlayer only) are placed into the limbo list
-	mutating_list_iterate(worldObjectState.droids[selectedPlayer], [&numDroidsAddedToLimboList](DROID* psDroid)
+	mutating_list_iterate(gameWorld.objects.droids[selectedPlayer], [&numDroidsAddedToLimboList](DROID* psDroid)
 	{
 		//KILL OFF TRANSPORTER - should never be one but....
 		if (psDroid->isTransporter())
@@ -1360,7 +1360,7 @@ void processMissionLimbo()
 			else
 			{
 				// Remove out of stored list and add to current Droid list
-				if (droidRemove(psDroid, worldObjectState.droids))
+				if (droidRemove(psDroid, gameWorld.objects.droids))
 				{
 					// Limbo list invalidate XY
 					psDroid->pos.x = INVALID_XY;
@@ -1385,33 +1385,33 @@ void swapMissionPointers()
 {
 	debug(LOG_SAVE, "called");
 
-	std::swap(worldMapState.tiles, mission.worldMapState.tiles);
-	std::swap(worldMapState.width,   mission.worldMapState.width);
-	std::swap(worldMapState.height,  mission.worldMapState.height);
-	for (int i = 0; i < ARRAY_SIZE(mission.worldMapState.blockMap); ++i)
+	std::swap(gameWorld.map.tiles, mission.gameWorld.map.tiles);
+	std::swap(gameWorld.map.width,   mission.gameWorld.map.width);
+	std::swap(gameWorld.map.height,  mission.gameWorld.map.height);
+	for (int i = 0; i < ARRAY_SIZE(mission.gameWorld.map.blockMap); ++i)
 	{
-		std::swap(worldMapState.blockMap[i], mission.worldMapState.blockMap[i]);
+		std::swap(gameWorld.map.blockMap[i], mission.gameWorld.map.blockMap[i]);
 	}
-	for (int i = 0; i < ARRAY_SIZE(mission.worldMapState.auxMap); ++i)
+	for (int i = 0; i < ARRAY_SIZE(mission.gameWorld.map.auxMap); ++i)
 	{
-		std::swap(worldMapState.auxMap[i],   mission.worldMapState.auxMap[i]);
+		std::swap(gameWorld.map.auxMap[i],   mission.gameWorld.map.auxMap[i]);
 	}
 	//swap gateway zones
-	std::swap(mission.worldMapState.gateways, gwGetGateways());
-	std::swap(worldMapState.scroll.minX, mission.worldMapState.scroll.minX);
-	std::swap(worldMapState.scroll.minY, mission.worldMapState.scroll.minY);
-	std::swap(worldMapState.scroll.maxX, mission.worldMapState.scroll.maxX);
-	std::swap(worldMapState.scroll.maxY, mission.worldMapState.scroll.maxY);
+	std::swap(mission.gameWorld.map.gateways, gwGetGateways());
+	std::swap(gameWorld.map.scroll.minX, mission.gameWorld.map.scroll.minX);
+	std::swap(gameWorld.map.scroll.minY, mission.gameWorld.map.scroll.minY);
+	std::swap(gameWorld.map.scroll.maxX, mission.gameWorld.map.scroll.maxX);
+	std::swap(gameWorld.map.scroll.maxY, mission.gameWorld.map.scroll.maxY);
 	for (unsigned inc = 0; inc < MAX_PLAYERS; inc++)
 	{
-		std::swap(worldObjectState.droids[inc],     mission.worldObjectState.droids[inc]);
-		std::swap(worldObjectState.structures[inc],    mission.worldObjectState.structures[inc]);
-		std::swap(worldObjectState.flags[inc],   mission.worldObjectState.flags[inc]);
-		std::swap(worldObjectState.extractors[inc], mission.worldObjectState.extractors[inc]);
+		std::swap(gameWorld.objects.droids[inc],     mission.gameWorld.objects.droids[inc]);
+		std::swap(gameWorld.objects.structures[inc],    mission.gameWorld.objects.structures[inc]);
+		std::swap(gameWorld.objects.flags[inc],   mission.gameWorld.objects.flags[inc]);
+		std::swap(gameWorld.objects.extractors[inc], mission.gameWorld.objects.extractors[inc]);
 	}
-	std::swap(worldObjectState.features[0],   mission.worldObjectState.features[0]);
-	std::swap(worldObjectState.sensors[0], mission.worldObjectState.sensors[0]);
-	std::swap(worldObjectState.oils[0],    mission.worldObjectState.oils[0]);
+	std::swap(gameWorld.objects.features[0],   mission.gameWorld.objects.features[0]);
+	std::swap(gameWorld.objects.sensors[0], mission.gameWorld.objects.sensors[0]);
+	std::swap(gameWorld.objects.oils[0],    mission.gameWorld.objects.oils[0]);
 }
 
 void endMission()
@@ -1607,7 +1607,7 @@ static void missionResetDroids()
 
 	for (unsigned int player = 0; player < MAX_PLAYERS; player++)
 	{
-		mutating_list_iterate(worldObjectState.droids[player], [](DROID* d)
+		mutating_list_iterate(gameWorld.objects.droids[player], [](DROID* d)
 		{
 			// Reset order - unless constructor droid that is mid-build
 			if ((d->droidType == DROID_CONSTRUCT
@@ -1639,7 +1639,7 @@ static void missionResetDroids()
 		});
 	}
 
-	mutating_list_iterate(worldObjectState.droids[selectedPlayer], [](DROID* psDroid)
+	mutating_list_iterate(gameWorld.objects.droids[selectedPlayer], [](DROID* psDroid)
 	{
 		bool	placed = false;
 
@@ -1686,7 +1686,7 @@ static void missionResetDroids()
 			}
 			else // if couldn't find the factory - try to place near HQ instead
 			{
-				for (const STRUCTURE* psStructure : worldObjectState.structures[psDroid->player])
+				for (const STRUCTURE* psStructure : gameWorld.objects.structures[psDroid->player])
 				{
 					if (psStructure->pStructureType->type == REF_HQ)
 					{
@@ -1716,8 +1716,8 @@ static void missionResetDroids()
 				// check the droid is a reasonable distance from the edge of the map
 				if (psDroid->pos.x <= world_coord(EDGE_SIZE) ||
 					psDroid->pos.y <= world_coord(EDGE_SIZE) ||
-					psDroid->pos.x >= world_coord(worldMapState.width - EDGE_SIZE) ||
-					psDroid->pos.y >= world_coord(worldMapState.height - EDGE_SIZE))
+					psDroid->pos.x >= world_coord(gameWorld.map.width - EDGE_SIZE) ||
+					psDroid->pos.y >= world_coord(gameWorld.map.height - EDGE_SIZE))
 				{
 					debug(LOG_ERROR, "missionResetUnits: unit too close to edge of map - removing");
 					vanishDroid(psDroid);
@@ -1756,7 +1756,7 @@ void unloadTransporter(DROID *psTransporter, UDWORD x, UDWORD y)
 	DROID_GROUP	*psGroup;
 
 	ASSERT_OR_RETURN(, psTransporter != nullptr, "Invalid transporter");
-	ppCurrentList = &worldObjectState.droids;
+	ppCurrentList = &gameWorld.objects.droids;
 
 	disembarkedDroids.clear();
 
@@ -1883,9 +1883,9 @@ void missionMoveTransporterOffWorld(DROID *psTransporter)
 		/* trigger script callback */
 		triggerEvent(TRIGGER_TRANSPORTER_EXIT, psTransporter);
 
-		if (droidRemove(psTransporter, worldObjectState.droids))
+		if (droidRemove(psTransporter, gameWorld.objects.droids))
 		{
-			addDroid(psTransporter, mission.worldObjectState.droids);
+			addDroid(psTransporter, mission.gameWorld.objects.droids);
 		}
 
 		//stop the droid moving - the moveUpdate happens AFTER the orderUpdate and can cause problems if the droid moves from one tile to another
@@ -1917,11 +1917,11 @@ void missionMoveTransporterOffWorld(DROID *psTransporter)
 		if (psTransporter->player == selectedPlayer)
 		{
 			ASSERT(selectedPlayer < MAX_PLAYERS, "selectedPlayer %" PRIu32 " exceeds MAX_PLAYERS", selectedPlayer);
-			auto droidIt = std::find_if(mission.worldObjectState.droids[selectedPlayer].begin(), mission.worldObjectState.droids[selectedPlayer].end(), [](DROID* d)
+			auto droidIt = std::find_if(mission.gameWorld.objects.droids[selectedPlayer].begin(), mission.gameWorld.objects.droids[selectedPlayer].end(), [](DROID* d)
 			{
 				return !d->isTransporter();
 			});
-			if (droidIt == mission.worldObjectState.droids[selectedPlayer].end())
+			if (droidIt == mission.gameWorld.objects.droids[selectedPlayer].end())
 			{
 				triggerEvent(TRIGGER_TRANSPORTER_DONE, psTransporter);
 			}
@@ -2623,7 +2623,7 @@ DROID *buildMissionDroid(DROID_TEMPLATE *psTempl, UDWORD x, UDWORD y, UDWORD pla
 	{
 		return nullptr;
 	}
-	addDroid(psNewDroid, mission.worldObjectState.droids);
+	addDroid(psNewDroid, mission.gameWorld.objects.droids);
 	//set its x/y to impossible values so can detect when return from mission
 	psNewDroid->pos.x = INVALID_XY;
 	psNewDroid->pos.y = INVALID_XY;
@@ -2813,7 +2813,7 @@ static inline void addLandingLight(int x, int y, LAND_LIGHT_SPEC spec, bool lit)
 
 	pos.x = x;
 	pos.z = y;
-	pos.y = map_Height(worldMapState, x, y) + AboveGround;
+	pos.y = map_Height(gameWorld.map, x, y) + AboveGround;
 
 	effectSetLandLightSpec(spec);
 
@@ -2841,8 +2841,8 @@ bool withinLandingZone(UDWORD x, UDWORD y)
 {
 	UDWORD		inc;
 
-	ASSERT(x < worldMapState.width, "withinLandingZone: x coord bigger than mapWidth");
-	ASSERT(y < worldMapState.height, "withinLandingZone: y coord bigger than mapHeight");
+	ASSERT(x < gameWorld.map.width, "withinLandingZone: x coord bigger than mapWidth");
+	ASSERT(y < gameWorld.map.height, "withinLandingZone: y coord bigger than mapHeight");
 
 
 	for (inc = 0; inc < MAX_NOGO_AREAS; inc++)
@@ -2888,24 +2888,24 @@ void missionSetTransporterEntry(SDWORD iPlayer, SDWORD iEntryTileX, SDWORD iEntr
 {
 	ASSERT_OR_RETURN(, iPlayer < MAX_PLAYERS, "missionSetTransporterEntry: player %i too high", iPlayer);
 
-	if ((iEntryTileX > worldMapState.scroll.minX) && (iEntryTileX < worldMapState.scroll.maxX))
+	if ((iEntryTileX > gameWorld.map.scroll.minX) && (iEntryTileX < gameWorld.map.scroll.maxX))
 	{
 		mission.iTranspEntryTileX[iPlayer] = (UWORD) iEntryTileX;
 	}
 	else
 	{
-		debug(LOG_SAVE, "entry point x %i outside scroll limits %i->%i", iEntryTileX, worldMapState.scroll.minX, worldMapState.scroll.maxX);
-		mission.iTranspEntryTileX[iPlayer] = (UWORD)(worldMapState.scroll.minX + EDGE_SIZE);
+		debug(LOG_SAVE, "entry point x %i outside scroll limits %i->%i", iEntryTileX, gameWorld.map.scroll.minX, gameWorld.map.scroll.maxX);
+		mission.iTranspEntryTileX[iPlayer] = (UWORD)(gameWorld.map.scroll.minX + EDGE_SIZE);
 	}
 
-	if ((iEntryTileY > worldMapState.scroll.minY) && (iEntryTileY < worldMapState.scroll.maxY))
+	if ((iEntryTileY > gameWorld.map.scroll.minY) && (iEntryTileY < gameWorld.map.scroll.maxY))
 	{
 		mission.iTranspEntryTileY[iPlayer] = (UWORD) iEntryTileY;
 	}
 	else
 	{
-		debug(LOG_SAVE, "entry point y %i outside scroll limits %i->%i", iEntryTileY, worldMapState.scroll.minY, worldMapState.scroll.maxY);
-		mission.iTranspEntryTileY[iPlayer] = (UWORD)(worldMapState.scroll.minY + EDGE_SIZE);
+		debug(LOG_SAVE, "entry point y %i outside scroll limits %i->%i", iEntryTileY, gameWorld.map.scroll.minY, gameWorld.map.scroll.maxY);
+		mission.iTranspEntryTileY[iPlayer] = (UWORD)(gameWorld.map.scroll.minY + EDGE_SIZE);
 	}
 }
 
@@ -2913,24 +2913,24 @@ void missionSetTransporterExit(SDWORD iPlayer, SDWORD iExitTileX, SDWORD iExitTi
 {
 	ASSERT_OR_RETURN(, iPlayer < MAX_PLAYERS, "missionSetTransporterExit: player %i too high", iPlayer);
 
-	if ((iExitTileX > worldMapState.scroll.minX) && (iExitTileX < worldMapState.scroll.maxX))
+	if ((iExitTileX > gameWorld.map.scroll.minX) && (iExitTileX < gameWorld.map.scroll.maxX))
 	{
 		mission.iTranspExitTileX[iPlayer] = (UWORD) iExitTileX;
 	}
 	else
 	{
-		debug(LOG_SAVE, "entry point x %i outside scroll limits %i->%i", iExitTileX, worldMapState.scroll.minX, worldMapState.scroll.maxX);
-		mission.iTranspExitTileX[iPlayer] = (UWORD)(worldMapState.scroll.minX + EDGE_SIZE);
+		debug(LOG_SAVE, "entry point x %i outside scroll limits %i->%i", iExitTileX, gameWorld.map.scroll.minX, gameWorld.map.scroll.maxX);
+		mission.iTranspExitTileX[iPlayer] = (UWORD)(gameWorld.map.scroll.minX + EDGE_SIZE);
 	}
 
-	if ((iExitTileY > worldMapState.scroll.minY) && (iExitTileY < worldMapState.scroll.maxY))
+	if ((iExitTileY > gameWorld.map.scroll.minY) && (iExitTileY < gameWorld.map.scroll.maxY))
 	{
 		mission.iTranspExitTileY[iPlayer] = (UWORD) iExitTileY;
 	}
 	else
 	{
-		debug(LOG_SAVE, "entry point y %i outside scroll limits %i->%i", iExitTileY, worldMapState.scroll.minY, worldMapState.scroll.maxY);
-		mission.iTranspExitTileY[iPlayer] = (UWORD)(worldMapState.scroll.minY + EDGE_SIZE);
+		debug(LOG_SAVE, "entry point y %i outside scroll limits %i->%i", iExitTileY, gameWorld.map.scroll.minY, gameWorld.map.scroll.maxY);
+		mission.iTranspExitTileY[iPlayer] = (UWORD)(gameWorld.map.scroll.minY + EDGE_SIZE);
 	}
 }
 
@@ -2987,25 +2987,25 @@ void missionDestroyObjects()
 		{
 			// AI player, clear out old data
 
-			mutating_list_iterate(worldObjectState.droids[Player], [](DROID* d)
+			mutating_list_iterate(gameWorld.objects.droids[Player], [](DROID* d)
 			{
 				removeDroidBase(d);
 				return IterationResult::CONTINUE_ITERATION;
 			});
 
 			//clear out the mission lists as well to make sure no Transporters exist
-			worldObjectState.droids[Player] = std::move(mission.worldObjectState.droids[Player]);
+			gameWorld.objects.droids[Player] = std::move(mission.gameWorld.objects.droids[Player]);
 
-			mutating_list_iterate(worldObjectState.droids[Player], [](DROID* psDroid)
+			mutating_list_iterate(gameWorld.objects.droids[Player], [](DROID* psDroid)
 			{
 				//make sure its died flag is not set since we've swapped the apsDroidList pointers over
 				psDroid->died = false;
 				removeDroidBase(psDroid);
 				return IterationResult::CONTINUE_ITERATION;
 			});
-			mission.worldObjectState.droids[Player].clear();
+			mission.gameWorld.objects.droids[Player].clear();
 
-			mutating_list_iterate(worldObjectState.structures[Player], [](STRUCTURE* s)
+			mutating_list_iterate(gameWorld.objects.structures[Player], [](STRUCTURE* s)
 			{
 				removeStruct(s, true);
 				return IterationResult::CONTINUE_ITERATION;
@@ -3017,7 +3017,7 @@ void missionDestroyObjects()
 	ASSERT(selectedPlayer < MAX_PLAYERS, "selectedPlayer %" PRIu32 " exceeds MAX_PLAYERS", selectedPlayer);
 	Player = selectedPlayer;
 
-	for (DROID* psDroid : worldObjectState.droids[Player])
+	for (DROID* psDroid : gameWorld.objects.droids[Player])
 	{
 		if (psDroid->psBaseStruct && psDroid->psBaseStruct->died)
 		{
@@ -3044,7 +3044,7 @@ void missionDestroyObjects()
 		}
 	}
 
-	for (STRUCTURE* psStruct : worldObjectState.structures[Player])
+	for (STRUCTURE* psStruct : gameWorld.objects.structures[Player])
 	{
 		for (i = 0; i < MAX_WEAPONS; i++)
 		{
@@ -3070,15 +3070,15 @@ void processPreviousCampDroids()
 	ASSERT(selectedPlayer < MAX_PLAYERS, "selectedPlayer %" PRIu32 " exceeds MAX_PLAYERS", selectedPlayer);
 
 	// See if any are left
-	if (!mission.worldObjectState.droids[selectedPlayer].empty())
+	if (!mission.gameWorld.objects.droids[selectedPlayer].empty())
 	{
-		mutating_list_iterate(mission.worldObjectState.droids[selectedPlayer], [](DROID* psDroid)
+		mutating_list_iterate(mission.gameWorld.objects.droids[selectedPlayer], [](DROID* psDroid)
 		{
 			// We want to kill off all droids now! - AB 27/01/99
 			// KILL OFF TRANSPORTER
-			if (droidRemove(psDroid, mission.worldObjectState.droids))
+			if (droidRemove(psDroid, mission.gameWorld.objects.droids))
 			{
-				addDroid(psDroid, worldObjectState.droids);
+				addDroid(psDroid, gameWorld.objects.droids);
 				vanishDroid(psDroid);
 			}
 			return IterationResult::CONTINUE_ITERATION;
@@ -3114,7 +3114,7 @@ bool getPlayCountDown()
 bool missionDroidsRemaining(UDWORD player)
 {
 	ASSERT_OR_RETURN(false, player < MAX_PLAYERS, "invalid player: %" PRIu32 "", player);
-	for (const DROID *psDroid : worldObjectState.droids[player])
+	for (const DROID *psDroid : gameWorld.objects.droids[player])
 	{
 		if (!psDroid->isTransporter())
 		{
@@ -3144,16 +3144,16 @@ void moveDroidsToSafety(DROID *psTransporter)
 			//cam change add droid
 			psDroid->pos.x = INVALID_XY;
 			psDroid->pos.y = INVALID_XY;
-			addDroid(psDroid, mission.worldObjectState.droids);
+			addDroid(psDroid, mission.gameWorld.objects.droids);
 
 			return IterationResult::CONTINUE_ITERATION;
 		});
 	}
 
 	//move the transporter into the mission list also
-	if (droidRemove(psTransporter, worldObjectState.droids))
+	if (droidRemove(psTransporter, gameWorld.objects.droids))
 	{
-		addDroid(psTransporter, mission.worldObjectState.droids);
+		addDroid(psTransporter, mission.gameWorld.objects.droids);
 	}
 }
 
@@ -3183,14 +3183,14 @@ static DROID *find_transporter()
 		return nullptr;
 	}
 
-	for (DROID* droid : worldObjectState.droids[selectedPlayer])
+	for (DROID* droid : gameWorld.objects.droids[selectedPlayer])
 	{
 		if (droid->isTransporter())
 		{
 			return droid;
 		}
 	}
-	for (DROID* droid : mission.worldObjectState.droids[selectedPlayer])
+	for (DROID* droid : mission.gameWorld.objects.droids[selectedPlayer])
 	{
 		if (droid->isTransporter())
 		{
@@ -3238,7 +3238,7 @@ void emptyTransporters(bool bOffWorld)
 	ASSERT_OR_RETURN(, selectedPlayer < MAX_PLAYERS, "selectedPlayer %" PRIu32 " >= MAX_PLAYERS", selectedPlayer);
 
 	//see if there are any Transporters in the world
-	mutating_list_iterate(worldObjectState.droids[selectedPlayer], [bOffWorld](DROID* psTransporter)
+	mutating_list_iterate(gameWorld.objects.droids[selectedPlayer], [bOffWorld](DROID* psTransporter)
 	{
 		if (psTransporter->isTransporter())
 		{
@@ -3258,7 +3258,7 @@ void emptyTransporters(bool bOffWorld)
 						//take it out of the Transporter group
 						psTransporter->psGroup->remove(psDroid);
 						//add it back into current droid lists
-						addDroid(psDroid, worldObjectState.droids);
+						addDroid(psDroid, gameWorld.objects.droids);
 
 						return IterationResult::CONTINUE_ITERATION;
 					});
@@ -3276,7 +3276,7 @@ void emptyTransporters(bool bOffWorld)
 						//take it out of the Transporter group
 						psTransporter->psGroup->remove(psDroid);
 						//add it back into current droid lists
-						addDroid(psDroid, mission.worldObjectState.droids);
+						addDroid(psDroid, mission.gameWorld.objects.droids);
 
 						return IterationResult::CONTINUE_ITERATION;
 					});
@@ -3294,7 +3294,7 @@ void emptyTransporters(bool bOffWorld)
 	});
 
 	//deal with any transporters that are waiting to come over
-	mutating_list_iterate(mission.worldObjectState.droids[selectedPlayer], [](DROID* psTransporter)
+	mutating_list_iterate(mission.gameWorld.objects.droids[selectedPlayer], [](DROID* psTransporter)
 	{
 		if (psTransporter->isTransporter())
 		{
@@ -3308,7 +3308,7 @@ void emptyTransporters(bool bOffWorld)
 				//take it out of the Transporter group
 				psTransporter->psGroup->remove(psDroid);
 				//add it back into mission droid lists
-				addDroid(psDroid, mission.worldObjectState.droids);
+				addDroid(psDroid, mission.gameWorld.objects.droids);
 
 				return IterationResult::CONTINUE_ITERATION;
 			});

--- a/src/mission.cpp
+++ b/src/mission.cpp
@@ -288,14 +288,14 @@ void initMission()
 
 	mission.ETA = -1;
 	mission.startTime = 0;
-	mission.psGateways.clear(); // just in case
-	mission.mapHeight = 0;
-	mission.mapWidth = 0;
-	for (auto &i : mission.psBlockMap)
+	mission.worldMapState.gateways.clear(); // just in case
+	mission.worldMapState.height = 0;
+	mission.worldMapState.width = 0;
+	for (auto &i : mission.worldMapState.blockMap)
 	{
 		i.reset();
 	}
-	for (auto &i : mission.psAuxMap)
+	for (auto &i : mission.worldMapState.auxMap)
 	{
 		i.reset();
 	}
@@ -354,18 +354,18 @@ bool missionShutDown()
 		mission.apsSensorList[0].clear();
 		mission.apsOilList[0].clear();
 
-		psMapTiles = std::move(mission.psMapTiles);
-		mapWidth = mission.mapWidth;
-		mapHeight = mission.mapHeight;
-		for (int i = 0; i < ARRAY_SIZE(mission.psBlockMap); ++i)
+		worldMapState.tiles = std::move(mission.worldMapState.tiles);
+		worldMapState.width = mission.worldMapState.width;
+		worldMapState.height = mission.worldMapState.height;
+		for (int i = 0; i < ARRAY_SIZE(mission.worldMapState.blockMap); ++i)
 		{
-			psBlockMap[i] = std::move(mission.psBlockMap[i]);
+			worldMapState.blockMap[i] = std::move(mission.worldMapState.blockMap[i]);
 		}
-		for (int i = 0; i < ARRAY_SIZE(mission.psAuxMap); ++i)
+		for (int i = 0; i < ARRAY_SIZE(mission.worldMapState.auxMap); ++i)
 		{
-			psAuxMap[i] = std::move(mission.psAuxMap[i]);
+			worldMapState.auxMap[i] = std::move(mission.worldMapState.auxMap[i]);
 		}
-		std::swap(mission.psGateways, gwGetGateways());
+		std::swap(mission.worldMapState.gateways, gwGetGateways());
 	}
 	keybindShutdown();
 	// sorry if this breaks something - but it looks like it's what should happen - John
@@ -772,22 +772,22 @@ static void saveMissionData()
 	resetHomeStructureObjects(); //get rid of soon-to-be illegal references of droids in repair facilities and rearming pads.
 
 	//save the mission data
-	mission.psMapTiles = std::move(psMapTiles);
-	mission.mapWidth = mapWidth;
-	mission.mapHeight = mapHeight;
-	for (int i = 0; i < ARRAY_SIZE(mission.psBlockMap); ++i)
+	mission.worldMapState.tiles = std::move(worldMapState.tiles);
+	mission.worldMapState.width = worldMapState.width;
+	mission.worldMapState.height = worldMapState.height;
+	for (int i = 0; i < ARRAY_SIZE(mission.worldMapState.blockMap); ++i)
 	{
-		mission.psBlockMap[i] = std::move(psBlockMap[i]);
+		mission.worldMapState.blockMap[i] = std::move(worldMapState.blockMap[i]);
 	}
-	for (int i = 0; i < ARRAY_SIZE(mission.psAuxMap); ++i)
+	for (int i = 0; i < ARRAY_SIZE(mission.worldMapState.auxMap); ++i)
 	{
-		mission.psAuxMap[i] = std::move(psAuxMap[i]);
+		mission.worldMapState.auxMap[i] = std::move(worldMapState.auxMap[i]);
 	}
-	mission.scrollMinX = scrollMinX;
-	mission.scrollMinY = scrollMinY;
-	mission.scrollMaxX = scrollMaxX;
-	mission.scrollMaxY = scrollMaxY;
-	std::swap(mission.psGateways, gwGetGateways());
+	mission.worldMapState.scroll.minX = worldMapState.scroll.minX;
+	mission.worldMapState.scroll.minY = worldMapState.scroll.minY;
+	mission.worldMapState.scroll.maxX = worldMapState.scroll.maxX;
+	mission.worldMapState.scroll.maxY = worldMapState.scroll.maxY;
+	std::swap(mission.worldMapState.gateways, gwGetGateways());
 	// save the selectedPlayer's LZ
 	mission.homeLZ_X = getLandingX(selectedPlayer);
 	mission.homeLZ_Y = getLandingY(selectedPlayer);
@@ -873,32 +873,32 @@ void restoreMissionData()
 	mission.apsOilList[0].clear();
 	//swap mission data over
 
-	psMapTiles = std::move(mission.psMapTiles);
+	worldMapState.tiles = std::move(mission.worldMapState.tiles);
 
-	mapWidth = mission.mapWidth;
-	mapHeight = mission.mapHeight;
-	for (int i = 0; i < ARRAY_SIZE(mission.psBlockMap); ++i)
+	worldMapState.width = mission.worldMapState.width;
+	worldMapState.height = mission.worldMapState.height;
+	for (int i = 0; i < ARRAY_SIZE(mission.worldMapState.blockMap); ++i)
 	{
-		psBlockMap[i] = std::move(mission.psBlockMap[i]);
+		worldMapState.blockMap[i] = std::move(mission.worldMapState.blockMap[i]);
 	}
-	for (int i = 0; i < ARRAY_SIZE(mission.psAuxMap); ++i)
+	for (int i = 0; i < ARRAY_SIZE(mission.worldMapState.auxMap); ++i)
 	{
-		psAuxMap[i] = std::move(mission.psAuxMap[i]);
+		worldMapState.auxMap[i] = std::move(mission.worldMapState.auxMap[i]);
 	}
-	scrollMinX = mission.scrollMinX;
-	scrollMinY = mission.scrollMinY;
-	scrollMaxX = mission.scrollMaxX;
-	scrollMaxY = mission.scrollMaxY;
-	std::swap(mission.psGateways, gwGetGateways());
+	worldMapState.scroll.minX = mission.worldMapState.scroll.minX;
+	worldMapState.scroll.minY = mission.worldMapState.scroll.minY;
+	worldMapState.scroll.maxX = mission.worldMapState.scroll.maxX;
+	worldMapState.scroll.maxY = mission.worldMapState.scroll.maxY;
+	std::swap(mission.worldMapState.gateways, gwGetGateways());
 	//and clear the mission pointers
-	mission.psMapTiles	= nullptr;
-	mission.mapWidth	= 0;
-	mission.mapHeight	= 0;
-	mission.scrollMinX	= 0;
-	mission.scrollMinY	= 0;
-	mission.scrollMaxX	= 0;
-	mission.scrollMaxY	= 0;
-	mission.psGateways.clear();
+	mission.worldMapState.tiles	= nullptr;
+	mission.worldMapState.width	= 0;
+	mission.worldMapState.height	= 0;
+	mission.worldMapState.scroll.minX	= 0;
+	mission.worldMapState.scroll.minY	= 0;
+	mission.worldMapState.scroll.maxX	= 0;
+	mission.worldMapState.scroll.maxY	= 0;
+	mission.worldMapState.gateways.clear();
 
 	//reset the current structure lists
 	setCurrentStructQuantity(false);
@@ -1384,23 +1384,23 @@ void swapMissionPointers()
 {
 	debug(LOG_SAVE, "called");
 
-	std::swap(psMapTiles, mission.psMapTiles);
-	std::swap(mapWidth,   mission.mapWidth);
-	std::swap(mapHeight,  mission.mapHeight);
-	for (int i = 0; i < ARRAY_SIZE(mission.psBlockMap); ++i)
+	std::swap(worldMapState.tiles, mission.worldMapState.tiles);
+	std::swap(worldMapState.width,   mission.worldMapState.width);
+	std::swap(worldMapState.height,  mission.worldMapState.height);
+	for (int i = 0; i < ARRAY_SIZE(mission.worldMapState.blockMap); ++i)
 	{
-		std::swap(psBlockMap[i], mission.psBlockMap[i]);
+		std::swap(worldMapState.blockMap[i], mission.worldMapState.blockMap[i]);
 	}
-	for (int i = 0; i < ARRAY_SIZE(mission.psAuxMap); ++i)
+	for (int i = 0; i < ARRAY_SIZE(mission.worldMapState.auxMap); ++i)
 	{
-		std::swap(psAuxMap[i],   mission.psAuxMap[i]);
+		std::swap(worldMapState.auxMap[i],   mission.worldMapState.auxMap[i]);
 	}
 	//swap gateway zones
-	std::swap(mission.psGateways, gwGetGateways());
-	std::swap(scrollMinX, mission.scrollMinX);
-	std::swap(scrollMinY, mission.scrollMinY);
-	std::swap(scrollMaxX, mission.scrollMaxX);
-	std::swap(scrollMaxY, mission.scrollMaxY);
+	std::swap(mission.worldMapState.gateways, gwGetGateways());
+	std::swap(worldMapState.scroll.minX, mission.worldMapState.scroll.minX);
+	std::swap(worldMapState.scroll.minY, mission.worldMapState.scroll.minY);
+	std::swap(worldMapState.scroll.maxX, mission.worldMapState.scroll.maxX);
+	std::swap(worldMapState.scroll.maxY, mission.worldMapState.scroll.maxY);
 	for (unsigned inc = 0; inc < MAX_PLAYERS; inc++)
 	{
 		std::swap(apsDroidLists[inc],     mission.apsDroidLists[inc]);
@@ -1715,8 +1715,8 @@ static void missionResetDroids()
 				// check the droid is a reasonable distance from the edge of the map
 				if (psDroid->pos.x <= world_coord(EDGE_SIZE) ||
 					psDroid->pos.y <= world_coord(EDGE_SIZE) ||
-					psDroid->pos.x >= world_coord(mapWidth - EDGE_SIZE) ||
-					psDroid->pos.y >= world_coord(mapHeight - EDGE_SIZE))
+					psDroid->pos.x >= world_coord(worldMapState.width - EDGE_SIZE) ||
+					psDroid->pos.y >= world_coord(worldMapState.height - EDGE_SIZE))
 				{
 					debug(LOG_ERROR, "missionResetUnits: unit too close to edge of map - removing");
 					vanishDroid(psDroid);
@@ -2840,8 +2840,8 @@ bool withinLandingZone(UDWORD x, UDWORD y)
 {
 	UDWORD		inc;
 
-	ASSERT(x < mapWidth, "withinLandingZone: x coord bigger than mapWidth");
-	ASSERT(y < mapHeight, "withinLandingZone: y coord bigger than mapHeight");
+	ASSERT(x < worldMapState.width, "withinLandingZone: x coord bigger than mapWidth");
+	ASSERT(y < worldMapState.height, "withinLandingZone: y coord bigger than mapHeight");
 
 
 	for (inc = 0; inc < MAX_NOGO_AREAS; inc++)
@@ -2887,24 +2887,24 @@ void missionSetTransporterEntry(SDWORD iPlayer, SDWORD iEntryTileX, SDWORD iEntr
 {
 	ASSERT_OR_RETURN(, iPlayer < MAX_PLAYERS, "missionSetTransporterEntry: player %i too high", iPlayer);
 
-	if ((iEntryTileX > scrollMinX) && (iEntryTileX < scrollMaxX))
+	if ((iEntryTileX > worldMapState.scroll.minX) && (iEntryTileX < worldMapState.scroll.maxX))
 	{
 		mission.iTranspEntryTileX[iPlayer] = (UWORD) iEntryTileX;
 	}
 	else
 	{
-		debug(LOG_SAVE, "entry point x %i outside scroll limits %i->%i", iEntryTileX, scrollMinX, scrollMaxX);
-		mission.iTranspEntryTileX[iPlayer] = (UWORD)(scrollMinX + EDGE_SIZE);
+		debug(LOG_SAVE, "entry point x %i outside scroll limits %i->%i", iEntryTileX, worldMapState.scroll.minX, worldMapState.scroll.maxX);
+		mission.iTranspEntryTileX[iPlayer] = (UWORD)(worldMapState.scroll.minX + EDGE_SIZE);
 	}
 
-	if ((iEntryTileY > scrollMinY) && (iEntryTileY < scrollMaxY))
+	if ((iEntryTileY > worldMapState.scroll.minY) && (iEntryTileY < worldMapState.scroll.maxY))
 	{
 		mission.iTranspEntryTileY[iPlayer] = (UWORD) iEntryTileY;
 	}
 	else
 	{
-		debug(LOG_SAVE, "entry point y %i outside scroll limits %i->%i", iEntryTileY, scrollMinY, scrollMaxY);
-		mission.iTranspEntryTileY[iPlayer] = (UWORD)(scrollMinY + EDGE_SIZE);
+		debug(LOG_SAVE, "entry point y %i outside scroll limits %i->%i", iEntryTileY, worldMapState.scroll.minY, worldMapState.scroll.maxY);
+		mission.iTranspEntryTileY[iPlayer] = (UWORD)(worldMapState.scroll.minY + EDGE_SIZE);
 	}
 }
 
@@ -2912,24 +2912,24 @@ void missionSetTransporterExit(SDWORD iPlayer, SDWORD iExitTileX, SDWORD iExitTi
 {
 	ASSERT_OR_RETURN(, iPlayer < MAX_PLAYERS, "missionSetTransporterExit: player %i too high", iPlayer);
 
-	if ((iExitTileX > scrollMinX) && (iExitTileX < scrollMaxX))
+	if ((iExitTileX > worldMapState.scroll.minX) && (iExitTileX < worldMapState.scroll.maxX))
 	{
 		mission.iTranspExitTileX[iPlayer] = (UWORD) iExitTileX;
 	}
 	else
 	{
-		debug(LOG_SAVE, "entry point x %i outside scroll limits %i->%i", iExitTileX, scrollMinX, scrollMaxX);
-		mission.iTranspExitTileX[iPlayer] = (UWORD)(scrollMinX + EDGE_SIZE);
+		debug(LOG_SAVE, "entry point x %i outside scroll limits %i->%i", iExitTileX, worldMapState.scroll.minX, worldMapState.scroll.maxX);
+		mission.iTranspExitTileX[iPlayer] = (UWORD)(worldMapState.scroll.minX + EDGE_SIZE);
 	}
 
-	if ((iExitTileY > scrollMinY) && (iExitTileY < scrollMaxY))
+	if ((iExitTileY > worldMapState.scroll.minY) && (iExitTileY < worldMapState.scroll.maxY))
 	{
 		mission.iTranspExitTileY[iPlayer] = (UWORD) iExitTileY;
 	}
 	else
 	{
-		debug(LOG_SAVE, "entry point y %i outside scroll limits %i->%i", iExitTileY, scrollMinY, scrollMaxY);
-		mission.iTranspExitTileY[iPlayer] = (UWORD)(scrollMinY + EDGE_SIZE);
+		debug(LOG_SAVE, "entry point y %i outside scroll limits %i->%i", iExitTileY, worldMapState.scroll.minY, worldMapState.scroll.maxY);
+		mission.iTranspExitTileY[iPlayer] = (UWORD)(worldMapState.scroll.minY + EDGE_SIZE);
 	}
 }
 

--- a/src/mission.cpp
+++ b/src/mission.cpp
@@ -623,7 +623,7 @@ void missionFlyTransportersIn(SDWORD iPlayer, bool bTrackTransporter)
 	iLandX = getLandingX(iPlayer);
 	iLandY = getLandingY(iPlayer);
 	missionGetTransporterEntry(iPlayer, &iX, &iY);
-	iZ = (UWORD)(map_Height(iX, iY) + OFFSCREEN_HEIGHT);
+	iZ = (UWORD)(map_Height(worldMapState, iX, iY) + OFFSCREEN_HEIGHT);
 
 	//get the droids for the mission
 	mutating_list_iterate(mission.worldObjectState.droids[iPlayer], [iPlayer, bTrackTransporter, iX, iY, iZ, iLandX, iLandY](DROID* psTransporter)
@@ -987,8 +987,8 @@ void placeLimboDroids()
 			}
 			psDroid->pos.x = (UWORD)world_coord(droidX);
 			psDroid->pos.y = (UWORD)world_coord(droidY);
-			ASSERT(worldOnMap(psDroid->pos.x, psDroid->pos.y), "limbo droid is not on the map");
-			psDroid->pos.z = map_Height(psDroid->pos.x, psDroid->pos.y);
+			ASSERT(worldOnMap(worldMapState, psDroid->pos.x, psDroid->pos.y), "limbo droid is not on the map");
+			psDroid->pos.z = map_Height(worldMapState, psDroid->pos.x, psDroid->pos.y);
 			updateDroidOrientation(psDroid);
 			psDroid->selected = false;
 			//this is mainly for VTOLs
@@ -1321,7 +1321,7 @@ static void processMission()
 			x = (UWORD)world_coord(droidX);
 			y = (UWORD)world_coord(droidY);
 			droidSetPosition(psDroid, x, y);
-			ASSERT(worldOnMap(psDroid->pos.x, psDroid->pos.y), "the droid is not on the map");
+			ASSERT(worldOnMap(worldMapState, psDroid->pos.x, psDroid->pos.y), "the droid is not on the map");
 			updateDroidOrientation(psDroid);
 			// Swap the droid and map pointers back again
 			swapMissionPointers();
@@ -2813,7 +2813,7 @@ static inline void addLandingLight(int x, int y, LAND_LIGHT_SPEC spec, bool lit)
 
 	pos.x = x;
 	pos.z = y;
-	pos.y = map_Height(x, y) + AboveGround;
+	pos.y = map_Height(worldMapState, x, y) + AboveGround;
 
 	effectSetLandLightSpec(spec);
 

--- a/src/mission.cpp
+++ b/src/mission.cpp
@@ -82,6 +82,7 @@
 #include "lib/framework/wztime.h"
 #include "keybind.h"
 #include "campaigninfo.h"
+#include "world_object_state.h"
 #include "wzapi.h"
 #include "screens/guidescreen.h"
 
@@ -194,7 +195,7 @@ static void resetHomeStructureObjects()
 {
 	for (unsigned int i = 0; i < MAX_PLAYERS; ++i)
 	{
-		for (STRUCTURE *psStruct : apsStructLists[i])
+		for (STRUCTURE *psStruct : worldObjectState.structures[i])
 		{
 			if (!psStruct->pFunctionality || !psStruct->pStructureType)
 			{
@@ -273,15 +274,15 @@ void initMission()
 	mission.type = LEVEL_TYPE::LDS_NONE;
 	for (int inc = 0; inc < MAX_PLAYERS; inc++)
 	{
-		mission.apsStructLists[inc].clear();
-		mission.apsDroidLists[inc].clear();
-		mission.apsFlagPosLists[inc].clear();
-		mission.apsExtractorLists[inc].clear();
+		mission.worldObjectState.structures[inc].clear();
+		mission.worldObjectState.droids[inc].clear();
+		mission.worldObjectState.flags[inc].clear();
+		mission.worldObjectState.extractors[inc].clear();
 		apsLimboDroids[inc].clear();
 	}
-	mission.apsFeatureList[0].clear();
-	mission.apsSensorList[0].clear();
-	mission.apsOilList[0].clear();
+	mission.worldObjectState.features[0].clear();
+	mission.worldObjectState.sensors[0].clear();
+	mission.worldObjectState.oils[0].clear();
 	offWorldKeepLists = false;
 	mission.time = -1;
 	setMissionCountDown();
@@ -338,21 +339,21 @@ bool missionShutDown()
 
 		for (int inc = 0; inc < MAX_PLAYERS; inc++)
 		{
-			apsDroidLists[inc] = std::move(mission.apsDroidLists[inc]);
-			mission.apsDroidLists[inc].clear();
-			apsStructLists[inc] = std::move(mission.apsStructLists[inc]);
-			mission.apsStructLists[inc].clear();
-			apsFlagPosLists[inc] = std::move(mission.apsFlagPosLists[inc]);
-			mission.apsFlagPosLists[inc].clear();
-			apsExtractorLists[inc] = std::move(mission.apsExtractorLists[inc]);
-			mission.apsExtractorLists[inc].clear();
+			worldObjectState.droids[inc] = std::move(mission.worldObjectState.droids[inc]);
+			mission.worldObjectState.droids[inc].clear();
+			worldObjectState.structures[inc] = std::move(mission.worldObjectState.structures[inc]);
+			mission.worldObjectState.structures[inc].clear();
+			worldObjectState.flags[inc] = std::move(mission.worldObjectState.flags[inc]);
+			mission.worldObjectState.flags[inc].clear();
+			worldObjectState.extractors[inc] = std::move(mission.worldObjectState.extractors[inc]);
+			mission.worldObjectState.extractors[inc].clear();
 		}
-		apsFeatureList[0] = std::move(mission.apsFeatureList[0]);
-		apsSensorList[0] = std::move(mission.apsSensorList[0]);
-		apsOilList[0] = std::move(mission.apsOilList[0]);
-		mission.apsFeatureList[0].clear();
-		mission.apsSensorList[0].clear();
-		mission.apsOilList[0].clear();
+		worldObjectState.features[0] = std::move(mission.worldObjectState.features[0]);
+		worldObjectState.sensors[0] = std::move(mission.worldObjectState.sensors[0]);
+		worldObjectState.oils[0] = std::move(mission.worldObjectState.oils[0]);
+		mission.worldObjectState.features[0].clear();
+		mission.worldObjectState.sensors[0].clear();
+		mission.worldObjectState.oils[0].clear();
 
 		worldMapState.tiles = std::move(mission.worldMapState.tiles);
 		worldMapState.width = mission.worldMapState.width;
@@ -567,7 +568,7 @@ void addTransporterTimerInterface()
 	if (mission.ETA >= 0 && selectedPlayer < MAX_PLAYERS)
 	{
 		//check the player has at least one Transporter back at base
-		for (DROID *psDroid : mission.apsDroidLists[selectedPlayer])
+		for (DROID *psDroid : mission.worldObjectState.droids[selectedPlayer])
 		{
 			if (psDroid->isTransporter())
 			{
@@ -625,7 +626,7 @@ void missionFlyTransportersIn(SDWORD iPlayer, bool bTrackTransporter)
 	iZ = (UWORD)(map_Height(iX, iY) + OFFSCREEN_HEIGHT);
 
 	//get the droids for the mission
-	mutating_list_iterate(mission.apsDroidLists[iPlayer], [iPlayer, bTrackTransporter, iX, iY, iZ, iLandX, iLandY](DROID* psTransporter)
+	mutating_list_iterate(mission.worldObjectState.droids[iPlayer], [iPlayer, bTrackTransporter, iX, iY, iZ, iLandX, iLandY](DROID* psTransporter)
 	{
 		SDWORD iDx, iDy;
 
@@ -638,10 +639,10 @@ void missionFlyTransportersIn(SDWORD iPlayer, bool bTrackTransporter)
 				psTransporter->watchedTiles.clear();
 
 				// Remove out of stored list and add to current Droid list
-				if (droidRemove(psTransporter, mission.apsDroidLists))
+				if (droidRemove(psTransporter, mission.worldObjectState.droids))
 				{
 					// Do not want to add it unless managed to remove it from the previous list
-					addDroid(psTransporter, apsDroidLists);
+					addDroid(psTransporter, worldObjectState.droids);
 				}
 
 				/* set start position */
@@ -701,13 +702,13 @@ static void saveMissionData()
 	audio_StopAll();
 
 	//set any structures currently being built to completed for the selected player
-	mutating_list_iterate(apsStructLists[selectedPlayer], [&bRepairExists, &bRearmPadExists](STRUCTURE* psStruct)
+	mutating_list_iterate(worldObjectState.structures[selectedPlayer], [&bRepairExists, &bRearmPadExists](STRUCTURE* psStruct)
 	{
 		STRUCTURE* psStructBeingBuilt;
 		if (psStruct->status == SS_BEING_BUILT)
 		{
 			//find a droid working on it
-			for (const DROID* psDroid : apsDroidLists[selectedPlayer])
+			for (const DROID* psDroid : worldObjectState.droids[selectedPlayer])
 			{
 				if ((psStructBeingBuilt = (STRUCTURE*)orderStateObj(psDroid, DORDER_BUILD))
 					&& psStructBeingBuilt == psStruct)
@@ -737,7 +738,7 @@ static void saveMissionData()
 	//repair and rearm all droids back at home base if have a repair facility or rearming pad
 	if (bRepairExists || bRearmPadExists)
 	{
-		for (DROID* psDroid : apsDroidLists[selectedPlayer])
+		for (DROID* psDroid : worldObjectState.droids[selectedPlayer])
 		{
 			bool vtolAndPadsExist = (psDroid->isVtol() && bRearmPadExists);
 			if ((bRepairExists || vtolAndPadsExist) && psDroid->isDamaged())
@@ -752,7 +753,7 @@ static void saveMissionData()
 	}
 
 	//clear droid orders for all droids except constructors still building
-	for (DROID* psDroid : apsDroidLists[selectedPlayer])
+	for (DROID* psDroid : worldObjectState.droids[selectedPlayer])
 	{
 		STRUCTURE* psStructBeingBuilt;
 		if ((psStructBeingBuilt = (STRUCTURE *)orderStateObj(psDroid, DORDER_BUILD)))
@@ -794,14 +795,14 @@ static void saveMissionData()
 
 	for (unsigned int inc = 0; inc < MAX_PLAYERS; ++inc)
 	{
-		mission.apsStructLists[inc] = apsStructLists[inc];
-		mission.apsDroidLists[inc] = apsDroidLists[inc];
-		mission.apsFlagPosLists[inc] = apsFlagPosLists[inc];
-		mission.apsExtractorLists[inc] = apsExtractorLists[inc];
+		mission.worldObjectState.structures[inc] = worldObjectState.structures[inc];
+		mission.worldObjectState.droids[inc] = worldObjectState.droids[inc];
+		mission.worldObjectState.flags[inc] = worldObjectState.flags[inc];
+		mission.worldObjectState.extractors[inc] = worldObjectState.extractors[inc];
 	}
-	mission.apsFeatureList[0] = apsFeatureList[0];
-	mission.apsSensorList[0] = apsSensorList[0];
-	mission.apsOilList[0] = apsOilList[0];
+	mission.worldObjectState.features[0] = worldObjectState.features[0];
+	mission.worldObjectState.sensors[0] = worldObjectState.sensors[0];
+	mission.worldObjectState.oils[0] = worldObjectState.oils[0];
 
 	mission.playerX = playerPos.p.x;
 	mission.playerY = playerPos.p.z;
@@ -849,28 +850,28 @@ void restoreMissionData()
 	//restore the game pointers
 	for (inc = 0; inc < MAX_PLAYERS; inc++)
 	{
-		apsDroidLists[inc] = std::move(mission.apsDroidLists[inc]);
-		mission.apsDroidLists[inc].clear();
-		for (DROID* psObj : apsDroidLists[inc])
+		worldObjectState.droids[inc] = std::move(mission.worldObjectState.droids[inc]);
+		mission.worldObjectState.droids[inc].clear();
+		for (DROID* psObj : worldObjectState.droids[inc])
 		{
 			psObj->died = false;	//make sure the died flag is not set
 		}
 
-		apsStructLists[inc] = std::move(mission.apsStructLists[inc]);
-		mission.apsStructLists[inc].clear();
+		worldObjectState.structures[inc] = std::move(mission.worldObjectState.structures[inc]);
+		mission.worldObjectState.structures[inc].clear();
 
-		apsFlagPosLists[inc] = std::move(mission.apsFlagPosLists[inc]);
-		mission.apsFlagPosLists[inc].clear();
+		worldObjectState.flags[inc] = std::move(mission.worldObjectState.flags[inc]);
+		mission.worldObjectState.flags[inc].clear();
 
-		apsExtractorLists[inc] = std::move(mission.apsExtractorLists[inc]);
-		mission.apsExtractorLists[inc].clear();
+		worldObjectState.extractors[inc] = std::move(mission.worldObjectState.extractors[inc]);
+		mission.worldObjectState.extractors[inc].clear();
 	}
-	apsFeatureList[0] = std::move(mission.apsFeatureList[0]);
-	apsSensorList[0] = std::move(mission.apsSensorList[0]);
-	apsOilList[0] = std::move(mission.apsOilList[0]);
-	mission.apsFeatureList[0].clear();
-	mission.apsSensorList[0].clear();
-	mission.apsOilList[0].clear();
+	worldObjectState.features[0] = std::move(mission.worldObjectState.features[0]);
+	worldObjectState.sensors[0] = std::move(mission.worldObjectState.sensors[0]);
+	worldObjectState.oils[0] = std::move(mission.worldObjectState.oils[0]);
+	mission.worldObjectState.features[0].clear();
+	mission.worldObjectState.sensors[0].clear();
+	mission.worldObjectState.oils[0].clear();
 	//swap mission data over
 
 	worldMapState.tiles = std::move(mission.worldMapState.tiles);
@@ -926,18 +927,18 @@ void saveMissionLimboData()
 	processPreviousCampDroids();
 
 	// move droids properly - does all the clean up code
-	mutating_list_iterate(apsDroidLists[selectedPlayer], [](DROID* psDroid)
+	mutating_list_iterate(worldObjectState.droids[selectedPlayer], [](DROID* psDroid)
 	{
-		if (droidRemove(psDroid, apsDroidLists))
+		if (droidRemove(psDroid, worldObjectState.droids))
 		{
-			addDroid(psDroid, mission.apsDroidLists);
+			addDroid(psDroid, mission.worldObjectState.droids);
 		}
 		return IterationResult::CONTINUE_ITERATION;
 	});
-	apsDroidLists[selectedPlayer].clear();
+	worldObjectState.droids[selectedPlayer].clear();
 
 	// any selectedPlayer's factories/research need to be put on holdProduction/holdresearch
-	for (STRUCTURE* psStruct : apsStructLists[selectedPlayer])
+	for (STRUCTURE* psStruct : worldObjectState.structures[selectedPlayer])
 	{
 		if (!psStruct)
 		{
@@ -969,7 +970,7 @@ void placeLimboDroids()
 
 		if (droidRemove(psDroid, apsLimboDroids))
 		{
-			addDroid(psDroid, apsDroidLists);
+			addDroid(psDroid, worldObjectState.droids);
 			//KILL OFF TRANSPORTER - should never be one but....
 			if (psDroid->isTransporter())
 			{
@@ -1016,12 +1017,12 @@ void restoreMissionLimboData()
 
 	/*the droids stored in the mission droid list need to be added back
 	into the current droid list*/
-	mutating_list_iterate(mission.apsDroidLists[selectedPlayer], [](DROID* psDroid)
+	mutating_list_iterate(mission.worldObjectState.droids[selectedPlayer], [](DROID* psDroid)
 	{
 		//remove out of stored list and add to current Droid list
-		if (droidRemove(psDroid, mission.apsDroidLists))
+		if (droidRemove(psDroid, mission.worldObjectState.droids))
 		{
-			addDroid(psDroid, apsDroidLists);
+			addDroid(psDroid, worldObjectState.droids);
 			//reset droid orders
 			orderDroid(psDroid, DORDER_STOP, ModeImmediate);
 			//the location of the droid should be valid!
@@ -1032,7 +1033,7 @@ void restoreMissionLimboData()
 		}
 		return IterationResult::CONTINUE_ITERATION;
 	});
-	ASSERT(mission.apsDroidLists[selectedPlayer].empty(), "list should be empty");
+	ASSERT(mission.worldObjectState.droids[selectedPlayer].empty(), "list should be empty");
 }
 
 /*Saves the necessary data when moving from one campaign to the start of the
@@ -1047,7 +1048,7 @@ void saveCampaignData()
 	if (getDroidsToSafetyFlag())
 	{
 		// Move any Transporters into the mission list
-		mutating_list_iterate(apsDroidLists[selectedPlayer], [](DROID* psDroid)
+		mutating_list_iterate(worldObjectState.droids[selectedPlayer], [](DROID* psDroid)
 		{
 			if (psDroid->isTransporter())
 			{
@@ -1066,17 +1067,17 @@ void saveCampaignData()
 					psCurr->pos.x = INVALID_XY;
 					psCurr->pos.y = INVALID_XY;
 					// Add it back into current droid lists
-					addDroid(psCurr, mission.apsDroidLists);
+					addDroid(psCurr, mission.worldObjectState.droids);
 
 					return IterationResult::CONTINUE_ITERATION;
 				});
 				// Remove the transporter from the current list
-				if (droidRemove(psDroid, apsDroidLists))
+				if (droidRemove(psDroid, worldObjectState.droids))
 				{
 					//cam change add droid
 					psDroid->pos.x = INVALID_XY;
 					psDroid->pos.y = INVALID_XY;
-					addDroid(psDroid, mission.apsDroidLists);
+					addDroid(psDroid, mission.worldObjectState.droids);
 				}
 			}
 			return IterationResult::CONTINUE_ITERATION;
@@ -1085,9 +1086,9 @@ void saveCampaignData()
 	else
 	{
 		// Reserve the droids for selected player for start of next campaign
-		mission.apsDroidLists[selectedPlayer] = std::move(apsDroidLists[selectedPlayer]);
-		apsDroidLists[selectedPlayer].clear();
-		for (DROID* psDroid : mission.apsDroidLists[selectedPlayer])
+		mission.worldObjectState.droids[selectedPlayer] = std::move(worldObjectState.droids[selectedPlayer]);
+		worldObjectState.droids[selectedPlayer].clear();
+		for (DROID* psDroid : mission.worldObjectState.droids[selectedPlayer])
 		{
 			//cam change add droid
 			psDroid->pos.x = INVALID_XY;
@@ -1100,22 +1101,22 @@ void saveCampaignData()
 	{
 		/*now that every unit for the selected player has been moved into the
 		mission list - reverse it and fill the transporter with the first ten units*/
-		mission.apsDroidLists[selectedPlayer].reverse();
+		mission.worldObjectState.droids[selectedPlayer].reverse();
 
 		//find the *first* transporter
-		mutating_list_iterate(mission.apsDroidLists[selectedPlayer], [](DROID* psDroid)
+		mutating_list_iterate(mission.worldObjectState.droids[selectedPlayer], [](DROID* psDroid)
 		{
 			if (psDroid->isTransporter())
 			{
 				//fill it with droids from the mission list
-				mutating_list_iterate(mission.apsDroidLists[selectedPlayer], [psDroid](DROID* psSafeDroid)
+				mutating_list_iterate(mission.worldObjectState.droids[selectedPlayer], [psDroid](DROID* psSafeDroid)
 				{
 					if (psSafeDroid != psDroid)
 					{
 						//add to the Transporter, checking for when full
 						if (checkTransporterSpace(psDroid, psSafeDroid))
 						{
-							if (droidRemove(psSafeDroid, mission.apsDroidLists))
+							if (droidRemove(psSafeDroid, mission.worldObjectState.droids))
 							{
 								psDroid->psGroup->add(psSafeDroid);
 							}
@@ -1137,7 +1138,7 @@ void saveCampaignData()
 	//clear all other droids
 	for (int inc = 0; inc < MAX_PLAYERS; inc++)
 	{
-		mutating_list_iterate(apsDroidLists[inc], [](DROID* d)
+		mutating_list_iterate(worldObjectState.droids[inc], [](DROID* d)
 		{
 			vanishDroid(d);
 			return IterationResult::CONTINUE_ITERATION;
@@ -1281,7 +1282,7 @@ static void clearCampaignUnits()
 {
 	if (selectedPlayer >= MAX_PLAYERS) { return; }
 
-	for (DROID *psDroid : apsDroidLists[selectedPlayer])
+	for (DROID *psDroid : worldObjectState.droids[selectedPlayer])
 	{
 		orderDroid(psDroid, DORDER_STOP, ModeImmediate);
 		setDroidBase(psDroid, nullptr);
@@ -1296,7 +1297,7 @@ static void processMission()
 	ASSERT(selectedPlayer < MAX_PLAYERS, "selectedPlayer %" PRIu32 " exceeds MAX_PLAYERS", selectedPlayer);
 
 	//and the rest on the mission map  - for now?
-	mutating_list_iterate(apsDroidLists[selectedPlayer], [](DROID* psDroid)
+	mutating_list_iterate(worldObjectState.droids[selectedPlayer], [](DROID* psDroid)
 	{
 		UDWORD			droidX, droidY;
 		PICKTILE		pickRes;
@@ -1305,11 +1306,11 @@ static void processMission()
 		// clean up visibility
 		visRemoveVisibility((BASE_OBJECT*)psDroid);
 		//remove out of stored list and add to current Droid list
-		if (droidRemove(psDroid, apsDroidLists))
+		if (droidRemove(psDroid, worldObjectState.droids))
 		{
 			int	x, y;
 
-			addDroid(psDroid, mission.apsDroidLists);
+			addDroid(psDroid, mission.worldObjectState.droids);
 			droidX = getHomeLandingX();
 			droidY = getHomeLandingY();
 			// Swap the droid and map pointers
@@ -1343,7 +1344,7 @@ void processMissionLimbo()
 	ASSERT(selectedPlayer < MAX_PLAYERS, "selectedPlayer %" PRIu32 " exceeds MAX_PLAYERS", selectedPlayer);
 
 	//all droids (for selectedPlayer only) are placed into the limbo list
-	mutating_list_iterate(apsDroidLists[selectedPlayer], [&numDroidsAddedToLimboList](DROID* psDroid)
+	mutating_list_iterate(worldObjectState.droids[selectedPlayer], [&numDroidsAddedToLimboList](DROID* psDroid)
 	{
 		//KILL OFF TRANSPORTER - should never be one but....
 		if (psDroid->isTransporter())
@@ -1359,7 +1360,7 @@ void processMissionLimbo()
 			else
 			{
 				// Remove out of stored list and add to current Droid list
-				if (droidRemove(psDroid, apsDroidLists))
+				if (droidRemove(psDroid, worldObjectState.droids))
 				{
 					// Limbo list invalidate XY
 					psDroid->pos.x = INVALID_XY;
@@ -1403,14 +1404,14 @@ void swapMissionPointers()
 	std::swap(worldMapState.scroll.maxY, mission.worldMapState.scroll.maxY);
 	for (unsigned inc = 0; inc < MAX_PLAYERS; inc++)
 	{
-		std::swap(apsDroidLists[inc],     mission.apsDroidLists[inc]);
-		std::swap(apsStructLists[inc],    mission.apsStructLists[inc]);
-		std::swap(apsFlagPosLists[inc],   mission.apsFlagPosLists[inc]);
-		std::swap(apsExtractorLists[inc], mission.apsExtractorLists[inc]);
+		std::swap(worldObjectState.droids[inc],     mission.worldObjectState.droids[inc]);
+		std::swap(worldObjectState.structures[inc],    mission.worldObjectState.structures[inc]);
+		std::swap(worldObjectState.flags[inc],   mission.worldObjectState.flags[inc]);
+		std::swap(worldObjectState.extractors[inc], mission.worldObjectState.extractors[inc]);
 	}
-	std::swap(apsFeatureList[0],   mission.apsFeatureList[0]);
-	std::swap(apsSensorList[0], mission.apsSensorList[0]);
-	std::swap(apsOilList[0],    mission.apsOilList[0]);
+	std::swap(worldObjectState.features[0],   mission.worldObjectState.features[0]);
+	std::swap(worldObjectState.sensors[0], mission.worldObjectState.sensors[0]);
+	std::swap(worldObjectState.oils[0],    mission.worldObjectState.oils[0]);
 }
 
 void endMission()
@@ -1606,7 +1607,7 @@ static void missionResetDroids()
 
 	for (unsigned int player = 0; player < MAX_PLAYERS; player++)
 	{
-		mutating_list_iterate(apsDroidLists[player], [](DROID* d)
+		mutating_list_iterate(worldObjectState.droids[player], [](DROID* d)
 		{
 			// Reset order - unless constructor droid that is mid-build
 			if ((d->droidType == DROID_CONSTRUCT
@@ -1638,7 +1639,7 @@ static void missionResetDroids()
 		});
 	}
 
-	mutating_list_iterate(apsDroidLists[selectedPlayer], [](DROID* psDroid)
+	mutating_list_iterate(worldObjectState.droids[selectedPlayer], [](DROID* psDroid)
 	{
 		bool	placed = false;
 
@@ -1685,7 +1686,7 @@ static void missionResetDroids()
 			}
 			else // if couldn't find the factory - try to place near HQ instead
 			{
-				for (const STRUCTURE* psStructure : apsStructLists[psDroid->player])
+				for (const STRUCTURE* psStructure : worldObjectState.structures[psDroid->player])
 				{
 					if (psStructure->pStructureType->type == REF_HQ)
 					{
@@ -1755,7 +1756,7 @@ void unloadTransporter(DROID *psTransporter, UDWORD x, UDWORD y)
 	DROID_GROUP	*psGroup;
 
 	ASSERT_OR_RETURN(, psTransporter != nullptr, "Invalid transporter");
-	ppCurrentList = &apsDroidLists;
+	ppCurrentList = &worldObjectState.droids;
 
 	disembarkedDroids.clear();
 
@@ -1882,9 +1883,9 @@ void missionMoveTransporterOffWorld(DROID *psTransporter)
 		/* trigger script callback */
 		triggerEvent(TRIGGER_TRANSPORTER_EXIT, psTransporter);
 
-		if (droidRemove(psTransporter, apsDroidLists))
+		if (droidRemove(psTransporter, worldObjectState.droids))
 		{
-			addDroid(psTransporter, mission.apsDroidLists);
+			addDroid(psTransporter, mission.worldObjectState.droids);
 		}
 
 		//stop the droid moving - the moveUpdate happens AFTER the orderUpdate and can cause problems if the droid moves from one tile to another
@@ -1916,11 +1917,11 @@ void missionMoveTransporterOffWorld(DROID *psTransporter)
 		if (psTransporter->player == selectedPlayer)
 		{
 			ASSERT(selectedPlayer < MAX_PLAYERS, "selectedPlayer %" PRIu32 " exceeds MAX_PLAYERS", selectedPlayer);
-			auto droidIt = std::find_if(mission.apsDroidLists[selectedPlayer].begin(), mission.apsDroidLists[selectedPlayer].end(), [](DROID* d)
+			auto droidIt = std::find_if(mission.worldObjectState.droids[selectedPlayer].begin(), mission.worldObjectState.droids[selectedPlayer].end(), [](DROID* d)
 			{
 				return !d->isTransporter();
 			});
-			if (droidIt == mission.apsDroidLists[selectedPlayer].end())
+			if (droidIt == mission.worldObjectState.droids[selectedPlayer].end())
 			{
 				triggerEvent(TRIGGER_TRANSPORTER_DONE, psTransporter);
 			}
@@ -2622,7 +2623,7 @@ DROID *buildMissionDroid(DROID_TEMPLATE *psTempl, UDWORD x, UDWORD y, UDWORD pla
 	{
 		return nullptr;
 	}
-	addDroid(psNewDroid, mission.apsDroidLists);
+	addDroid(psNewDroid, mission.worldObjectState.droids);
 	//set its x/y to impossible values so can detect when return from mission
 	psNewDroid->pos.x = INVALID_XY;
 	psNewDroid->pos.y = INVALID_XY;
@@ -2986,25 +2987,25 @@ void missionDestroyObjects()
 		{
 			// AI player, clear out old data
 
-			mutating_list_iterate(apsDroidLists[Player], [](DROID* d)
+			mutating_list_iterate(worldObjectState.droids[Player], [](DROID* d)
 			{
 				removeDroidBase(d);
 				return IterationResult::CONTINUE_ITERATION;
 			});
 
 			//clear out the mission lists as well to make sure no Transporters exist
-			apsDroidLists[Player] = std::move(mission.apsDroidLists[Player]);
+			worldObjectState.droids[Player] = std::move(mission.worldObjectState.droids[Player]);
 
-			mutating_list_iterate(apsDroidLists[Player], [](DROID* psDroid)
+			mutating_list_iterate(worldObjectState.droids[Player], [](DROID* psDroid)
 			{
 				//make sure its died flag is not set since we've swapped the apsDroidList pointers over
 				psDroid->died = false;
 				removeDroidBase(psDroid);
 				return IterationResult::CONTINUE_ITERATION;
 			});
-			mission.apsDroidLists[Player].clear();
+			mission.worldObjectState.droids[Player].clear();
 
-			mutating_list_iterate(apsStructLists[Player], [](STRUCTURE* s)
+			mutating_list_iterate(worldObjectState.structures[Player], [](STRUCTURE* s)
 			{
 				removeStruct(s, true);
 				return IterationResult::CONTINUE_ITERATION;
@@ -3016,7 +3017,7 @@ void missionDestroyObjects()
 	ASSERT(selectedPlayer < MAX_PLAYERS, "selectedPlayer %" PRIu32 " exceeds MAX_PLAYERS", selectedPlayer);
 	Player = selectedPlayer;
 
-	for (DROID* psDroid : apsDroidLists[Player])
+	for (DROID* psDroid : worldObjectState.droids[Player])
 	{
 		if (psDroid->psBaseStruct && psDroid->psBaseStruct->died)
 		{
@@ -3043,7 +3044,7 @@ void missionDestroyObjects()
 		}
 	}
 
-	for (STRUCTURE* psStruct : apsStructLists[Player])
+	for (STRUCTURE* psStruct : worldObjectState.structures[Player])
 	{
 		for (i = 0; i < MAX_WEAPONS; i++)
 		{
@@ -3069,15 +3070,15 @@ void processPreviousCampDroids()
 	ASSERT(selectedPlayer < MAX_PLAYERS, "selectedPlayer %" PRIu32 " exceeds MAX_PLAYERS", selectedPlayer);
 
 	// See if any are left
-	if (!mission.apsDroidLists[selectedPlayer].empty())
+	if (!mission.worldObjectState.droids[selectedPlayer].empty())
 	{
-		mutating_list_iterate(mission.apsDroidLists[selectedPlayer], [](DROID* psDroid)
+		mutating_list_iterate(mission.worldObjectState.droids[selectedPlayer], [](DROID* psDroid)
 		{
 			// We want to kill off all droids now! - AB 27/01/99
 			// KILL OFF TRANSPORTER
-			if (droidRemove(psDroid, mission.apsDroidLists))
+			if (droidRemove(psDroid, mission.worldObjectState.droids))
 			{
-				addDroid(psDroid, apsDroidLists);
+				addDroid(psDroid, worldObjectState.droids);
 				vanishDroid(psDroid);
 			}
 			return IterationResult::CONTINUE_ITERATION;
@@ -3113,7 +3114,7 @@ bool getPlayCountDown()
 bool missionDroidsRemaining(UDWORD player)
 {
 	ASSERT_OR_RETURN(false, player < MAX_PLAYERS, "invalid player: %" PRIu32 "", player);
-	for (const DROID *psDroid : apsDroidLists[player])
+	for (const DROID *psDroid : worldObjectState.droids[player])
 	{
 		if (!psDroid->isTransporter())
 		{
@@ -3143,16 +3144,16 @@ void moveDroidsToSafety(DROID *psTransporter)
 			//cam change add droid
 			psDroid->pos.x = INVALID_XY;
 			psDroid->pos.y = INVALID_XY;
-			addDroid(psDroid, mission.apsDroidLists);
+			addDroid(psDroid, mission.worldObjectState.droids);
 
 			return IterationResult::CONTINUE_ITERATION;
 		});
 	}
 
 	//move the transporter into the mission list also
-	if (droidRemove(psTransporter, apsDroidLists))
+	if (droidRemove(psTransporter, worldObjectState.droids))
 	{
-		addDroid(psTransporter, mission.apsDroidLists);
+		addDroid(psTransporter, mission.worldObjectState.droids);
 	}
 }
 
@@ -3182,14 +3183,14 @@ static DROID *find_transporter()
 		return nullptr;
 	}
 
-	for (DROID* droid : apsDroidLists[selectedPlayer])
+	for (DROID* droid : worldObjectState.droids[selectedPlayer])
 	{
 		if (droid->isTransporter())
 		{
 			return droid;
 		}
 	}
-	for (DROID* droid : mission.apsDroidLists[selectedPlayer])
+	for (DROID* droid : mission.worldObjectState.droids[selectedPlayer])
 	{
 		if (droid->isTransporter())
 		{
@@ -3237,7 +3238,7 @@ void emptyTransporters(bool bOffWorld)
 	ASSERT_OR_RETURN(, selectedPlayer < MAX_PLAYERS, "selectedPlayer %" PRIu32 " >= MAX_PLAYERS", selectedPlayer);
 
 	//see if there are any Transporters in the world
-	mutating_list_iterate(apsDroidLists[selectedPlayer], [bOffWorld](DROID* psTransporter)
+	mutating_list_iterate(worldObjectState.droids[selectedPlayer], [bOffWorld](DROID* psTransporter)
 	{
 		if (psTransporter->isTransporter())
 		{
@@ -3257,7 +3258,7 @@ void emptyTransporters(bool bOffWorld)
 						//take it out of the Transporter group
 						psTransporter->psGroup->remove(psDroid);
 						//add it back into current droid lists
-						addDroid(psDroid, apsDroidLists);
+						addDroid(psDroid, worldObjectState.droids);
 
 						return IterationResult::CONTINUE_ITERATION;
 					});
@@ -3275,7 +3276,7 @@ void emptyTransporters(bool bOffWorld)
 						//take it out of the Transporter group
 						psTransporter->psGroup->remove(psDroid);
 						//add it back into current droid lists
-						addDroid(psDroid, mission.apsDroidLists);
+						addDroid(psDroid, mission.worldObjectState.droids);
 
 						return IterationResult::CONTINUE_ITERATION;
 					});
@@ -3293,7 +3294,7 @@ void emptyTransporters(bool bOffWorld)
 	});
 
 	//deal with any transporters that are waiting to come over
-	mutating_list_iterate(mission.apsDroidLists[selectedPlayer], [](DROID* psTransporter)
+	mutating_list_iterate(mission.worldObjectState.droids[selectedPlayer], [](DROID* psTransporter)
 	{
 		if (psTransporter->isTransporter())
 		{
@@ -3307,7 +3308,7 @@ void emptyTransporters(bool bOffWorld)
 				//take it out of the Transporter group
 				psTransporter->psGroup->remove(psDroid);
 				//add it back into mission droid lists
-				addDroid(psDroid, mission.apsDroidLists);
+				addDroid(psDroid, mission.worldObjectState.droids);
 
 				return IterationResult::CONTINUE_ITERATION;
 			});

--- a/src/missiondef.h
+++ b/src/missiondef.h
@@ -30,6 +30,7 @@
 #include "featuredef.h"
 #include "power.h"
 #include "gateway.h"
+#include "world_map_state.h"
 
 //mission types
 
@@ -53,16 +54,8 @@ struct LANDING_ZONE
 struct MISSION
 {
 	LEVEL_TYPE			type;							//defines which start and end functions to use - see levels_type in levels.h
-	std::unique_ptr<MAPTILE[]>		psMapTiles;					//the original mapTiles
-	int32_t                         mapWidth;                       //the original mapWidth
-	int32_t                         mapHeight;                      //the original mapHeight
-	std::unique_ptr<uint8_t[]>      psBlockMap[AUX_MAX];
-	std::unique_ptr<uint8_t[]>		psAuxMap[MAX_PLAYERS + AUX_MAX];
-	GATEWAY_LIST                    psGateways;                     //the gateway list
-	int32_t                         scrollMinX;                     //scroll coords for original map
-	int32_t                         scrollMinY;
-	int32_t                         scrollMaxX;
-	int32_t                         scrollMaxY;
+	WorldMapState worldMapState;
+
 	//original object lists
 	PerPlayerStructureLists apsStructLists;
 	PerPlayerExtractorLists apsExtractorLists;

--- a/src/missiondef.h
+++ b/src/missiondef.h
@@ -30,8 +30,7 @@
 #include "featuredef.h"
 #include "power.h"
 #include "gateway.h"
-#include "world_map_state.h"
-#include "world_object_state.h"
+#include "game_world.h"
 
 //mission types
 
@@ -55,10 +54,7 @@ struct LANDING_ZONE
 struct MISSION
 {
 	LEVEL_TYPE			type;							//defines which start and end functions to use - see levels_type in levels.h
-	WorldMapState worldMapState;
-
-	//original object lists
-	WorldObjectState worldObjectState;
+	GameWorld gameWorld;
 
 	int32_t                         asCurrentPower[MAX_PLAYERS];
 

--- a/src/missiondef.h
+++ b/src/missiondef.h
@@ -31,6 +31,7 @@
 #include "power.h"
 #include "gateway.h"
 #include "world_map_state.h"
+#include "world_object_state.h"
 
 //mission types
 
@@ -57,14 +58,8 @@ struct MISSION
 	WorldMapState worldMapState;
 
 	//original object lists
-	PerPlayerStructureLists apsStructLists;
-	PerPlayerExtractorLists apsExtractorLists;
+	WorldObjectState worldObjectState;
 
-	PerPlayerDroidLists              apsDroidLists;
-	GlobalFeatureList               apsFeatureList;
-	GlobalSensorList                apsSensorList;
-	GlobalOilList                   apsOilList;
-	PerPlayerFlagPositionLists      apsFlagPosLists;
 	int32_t                         asCurrentPower[MAX_PLAYERS];
 
 	UDWORD				startTime;			//time the mission started

--- a/src/move.cpp
+++ b/src/move.cpp
@@ -563,10 +563,10 @@ void updateDroidOrientation(DROID *psDroid)
 	//    hy0
 	// hx0 * hx1      (* = droid)
 	//    hy1
-	hx1 = map_Height(worldMapState, psDroid->pos.x + d, psDroid->pos.y);
-	hx0 = map_Height(worldMapState, MAX(0, psDroid->pos.x - d), psDroid->pos.y);
-	hy1 = map_Height(worldMapState, psDroid->pos.x, psDroid->pos.y + d);
-	hy0 = map_Height(worldMapState, psDroid->pos.x, MAX(0, psDroid->pos.y - d));
+	hx1 = map_Height(gameWorld.map, psDroid->pos.x + d, psDroid->pos.y);
+	hx0 = map_Height(gameWorld.map, MAX(0, psDroid->pos.x - d), psDroid->pos.y);
+	hy1 = map_Height(gameWorld.map, psDroid->pos.x, psDroid->pos.y + d);
+	hy0 = map_Height(gameWorld.map, psDroid->pos.x, MAX(0, psDroid->pos.y - d));
 
 	//update height in case were in the bottom of a trough
 	psDroid->pos.z = MAX(psDroid->pos.z, (hx0 + hx1) / 2);
@@ -905,11 +905,11 @@ static void moveCalcSlideVector(DROID *psDroid, int32_t objX, int32_t objY, int3
 static void moveOpenGates(DROID *psDroid, Vector2i tile)
 {
 	// is the new tile a gate?
-	if (!worldOnMap(worldMapState, tile.x, tile.y))
+	if (!worldOnMap(gameWorld.map, tile.x, tile.y))
 	{
 		return;
 	}
-	MAPTILE *psTile = mapTile(worldMapState, tile);
+	MAPTILE *psTile = mapTile(gameWorld.map, tile);
 	if (!psDroid->isFlying() && !psDroid->isFlightBasedTransporter() && psTile && psTile->psObject && psTile->psObject->type == OBJ_STRUCTURE && aiCheckAlliances(psTile->psObject->player, psDroid->player))
 	{
 		requestOpenGate((STRUCTURE *)psTile->psObject);  // If it's a friendly gate, open it. (It would be impolite to open an enemy gate.)
@@ -1401,7 +1401,7 @@ SDWORD moveCalcDroidSpeed(DROID *psDroid)
 	{
 		mapX = map_coord(psDroid->pos.x);
 		mapY = map_coord(psDroid->pos.y);
-		speed = calcDroidSpeed(psDroid->baseSpeed, terrainType(mapTile(worldMapState, mapX, mapY)), psDroid->asBits[COMP_PROPULSION], getDroidEffectiveLevel(psDroid, false));
+		speed = calcDroidSpeed(psDroid->baseSpeed, terrainType(mapTile(gameWorld.map, mapX, mapY)), psDroid->asBits[COMP_PROPULSION], getDroidEffectiveLevel(psDroid, false));
 	}
 
 
@@ -1617,7 +1617,7 @@ static void moveUpdateDroidPos(DROID *psDroid, int32_t dx, int32_t dy)
 	psDroid->pos.y += gameTimeAdjustedAverage(dy, EXTRA_PRECISION);
 
 	/* impact if about to go off map else update coordinates */
-	if (worldOnMap(worldMapState, psDroid->pos.x, psDroid->pos.y) == false)
+	if (worldOnMap(gameWorld.map, psDroid->pos.x, psDroid->pos.y) == false)
 	{
 		/* transporter going off-world will trigger next map, and is ok */
 		ASSERT(psDroid->isTransporter(), "droid trying to move off the map!");
@@ -1691,7 +1691,7 @@ static void moveUpdateGroundModel(DROID *psDroid, SDWORD speed, uint16_t directi
 	moveUpdateDroidPos(psDroid, bx, by);
 
 	//set the droid height here so other routines can use it
-	psDroid->pos.z = map_Height(worldMapState, psDroid->pos.x, psDroid->pos.y);//jps 21july96
+	psDroid->pos.z = map_Height(gameWorld.map, psDroid->pos.x, psDroid->pos.y);//jps 21july96
 	updateDroidOrientation(psDroid);
 }
 
@@ -1744,7 +1744,7 @@ static void moveUpdatePersonModel(DROID *psDroid, SDWORD speed, uint16_t directi
 	moveUpdateDroidPos(psDroid, dx, dy);
 
 	//set the droid height here so other routines can use it
-	psDroid->pos.z = map_Height(worldMapState, psDroid->pos.x, psDroid->pos.y);//jps 21july96
+	psDroid->pos.z = map_Height(gameWorld.map, psDroid->pos.x, psDroid->pos.y);//jps 21july96
 
 	/* update anim if moving */
 	if (psDroid->droidType == DROID_PERSON && speed != 0 && (psDroid->animationEvent != ANIM_EVENT_ACTIVE && psDroid->animationEvent != ANIM_EVENT_DYING))
@@ -1859,9 +1859,9 @@ static void moveUpdateVtolModel(DROID *psDroid, SDWORD speed, uint16_t direction
 	psDroid->rot.roll = psDroid->rot.roll + (uint16_t)gameTimeAdjustedIncrement(3 * angleDelta(targetRoll - psDroid->rot.roll));
 
 	/* do vertical movement - only if on the map */
-	if (worldOnMap(worldMapState, psDroid->pos.x, psDroid->pos.y))
+	if (worldOnMap(gameWorld.map, psDroid->pos.x, psDroid->pos.y))
 	{
-		iMapZ = map_Height(worldMapState, psDroid->pos.x, psDroid->pos.y);
+		iMapZ = map_Height(gameWorld.map, psDroid->pos.x, psDroid->pos.y);
 		psDroid->pos.z = MAX(iMapZ, psDroid->pos.z + gameTimeAdjustedIncrement(psDroid->sMove.iVertSpeed));
 		moveAdjustVtolHeight(psDroid, iMapZ);
 		psDroid->heightAboveMap = psDroid->pos.z - iMapZ;
@@ -1897,7 +1897,7 @@ static void moveUpdateCyborgModel(DROID *psDroid, SDWORD moveSpeed, uint16_t mov
 
 static void moveDescending(DROID *psDroid)
 {
-	int32_t iMapHeight = map_Height(worldMapState, psDroid->pos.x, psDroid->pos.y);
+	int32_t iMapHeight = map_Height(gameWorld.map, psDroid->pos.x, psDroid->pos.y);
 
 	psDroid->sMove.speed = 0;
 
@@ -2439,7 +2439,7 @@ void moveUpdateDroid(DROID *psDroid)
 //	}
 
 	/* If it's sitting in water then it's got to go with the flow! */
-	if (worldOnMap(worldMapState, psDroid->pos.x, psDroid->pos.y) && terrainType(mapTile(worldMapState, map_coord(psDroid->pos.x), map_coord(psDroid->pos.y))) == TER_WATER)
+	if (worldOnMap(gameWorld.map, psDroid->pos.x, psDroid->pos.y) && terrainType(mapTile(gameWorld.map, map_coord(psDroid->pos.x), map_coord(psDroid->pos.y))) == TER_WATER)
 	{
 		updateDroidOrientation(psDroid);
 	}

--- a/src/move.cpp
+++ b/src/move.cpp
@@ -563,10 +563,10 @@ void updateDroidOrientation(DROID *psDroid)
 	//    hy0
 	// hx0 * hx1      (* = droid)
 	//    hy1
-	hx1 = map_Height(psDroid->pos.x + d, psDroid->pos.y);
-	hx0 = map_Height(MAX(0, psDroid->pos.x - d), psDroid->pos.y);
-	hy1 = map_Height(psDroid->pos.x, psDroid->pos.y + d);
-	hy0 = map_Height(psDroid->pos.x, MAX(0, psDroid->pos.y - d));
+	hx1 = map_Height(worldMapState, psDroid->pos.x + d, psDroid->pos.y);
+	hx0 = map_Height(worldMapState, MAX(0, psDroid->pos.x - d), psDroid->pos.y);
+	hy1 = map_Height(worldMapState, psDroid->pos.x, psDroid->pos.y + d);
+	hy0 = map_Height(worldMapState, psDroid->pos.x, MAX(0, psDroid->pos.y - d));
 
 	//update height in case were in the bottom of a trough
 	psDroid->pos.z = MAX(psDroid->pos.z, (hx0 + hx1) / 2);
@@ -905,11 +905,11 @@ static void moveCalcSlideVector(DROID *psDroid, int32_t objX, int32_t objY, int3
 static void moveOpenGates(DROID *psDroid, Vector2i tile)
 {
 	// is the new tile a gate?
-	if (!worldOnMap(tile.x, tile.y))
+	if (!worldOnMap(worldMapState, tile.x, tile.y))
 	{
 		return;
 	}
-	MAPTILE *psTile = mapTile(tile);
+	MAPTILE *psTile = mapTile(worldMapState, tile);
 	if (!psDroid->isFlying() && !psDroid->isFlightBasedTransporter() && psTile && psTile->psObject && psTile->psObject->type == OBJ_STRUCTURE && aiCheckAlliances(psTile->psObject->player, psDroid->player))
 	{
 		requestOpenGate((STRUCTURE *)psTile->psObject);  // If it's a friendly gate, open it. (It would be impolite to open an enemy gate.)
@@ -1401,7 +1401,7 @@ SDWORD moveCalcDroidSpeed(DROID *psDroid)
 	{
 		mapX = map_coord(psDroid->pos.x);
 		mapY = map_coord(psDroid->pos.y);
-		speed = calcDroidSpeed(psDroid->baseSpeed, terrainType(mapTile(mapX, mapY)), psDroid->asBits[COMP_PROPULSION], getDroidEffectiveLevel(psDroid, false));
+		speed = calcDroidSpeed(psDroid->baseSpeed, terrainType(mapTile(worldMapState, mapX, mapY)), psDroid->asBits[COMP_PROPULSION], getDroidEffectiveLevel(psDroid, false));
 	}
 
 
@@ -1617,7 +1617,7 @@ static void moveUpdateDroidPos(DROID *psDroid, int32_t dx, int32_t dy)
 	psDroid->pos.y += gameTimeAdjustedAverage(dy, EXTRA_PRECISION);
 
 	/* impact if about to go off map else update coordinates */
-	if (worldOnMap(psDroid->pos.x, psDroid->pos.y) == false)
+	if (worldOnMap(worldMapState, psDroid->pos.x, psDroid->pos.y) == false)
 	{
 		/* transporter going off-world will trigger next map, and is ok */
 		ASSERT(psDroid->isTransporter(), "droid trying to move off the map!");
@@ -1691,7 +1691,7 @@ static void moveUpdateGroundModel(DROID *psDroid, SDWORD speed, uint16_t directi
 	moveUpdateDroidPos(psDroid, bx, by);
 
 	//set the droid height here so other routines can use it
-	psDroid->pos.z = map_Height(psDroid->pos.x, psDroid->pos.y);//jps 21july96
+	psDroid->pos.z = map_Height(worldMapState, psDroid->pos.x, psDroid->pos.y);//jps 21july96
 	updateDroidOrientation(psDroid);
 }
 
@@ -1744,7 +1744,7 @@ static void moveUpdatePersonModel(DROID *psDroid, SDWORD speed, uint16_t directi
 	moveUpdateDroidPos(psDroid, dx, dy);
 
 	//set the droid height here so other routines can use it
-	psDroid->pos.z = map_Height(psDroid->pos.x, psDroid->pos.y);//jps 21july96
+	psDroid->pos.z = map_Height(worldMapState, psDroid->pos.x, psDroid->pos.y);//jps 21july96
 
 	/* update anim if moving */
 	if (psDroid->droidType == DROID_PERSON && speed != 0 && (psDroid->animationEvent != ANIM_EVENT_ACTIVE && psDroid->animationEvent != ANIM_EVENT_DYING))
@@ -1859,9 +1859,9 @@ static void moveUpdateVtolModel(DROID *psDroid, SDWORD speed, uint16_t direction
 	psDroid->rot.roll = psDroid->rot.roll + (uint16_t)gameTimeAdjustedIncrement(3 * angleDelta(targetRoll - psDroid->rot.roll));
 
 	/* do vertical movement - only if on the map */
-	if (worldOnMap(psDroid->pos.x, psDroid->pos.y))
+	if (worldOnMap(worldMapState, psDroid->pos.x, psDroid->pos.y))
 	{
-		iMapZ = map_Height(psDroid->pos.x, psDroid->pos.y);
+		iMapZ = map_Height(worldMapState, psDroid->pos.x, psDroid->pos.y);
 		psDroid->pos.z = MAX(iMapZ, psDroid->pos.z + gameTimeAdjustedIncrement(psDroid->sMove.iVertSpeed));
 		moveAdjustVtolHeight(psDroid, iMapZ);
 		psDroid->heightAboveMap = psDroid->pos.z - iMapZ;
@@ -1897,7 +1897,7 @@ static void moveUpdateCyborgModel(DROID *psDroid, SDWORD moveSpeed, uint16_t mov
 
 static void moveDescending(DROID *psDroid)
 {
-	int32_t iMapHeight = map_Height(psDroid->pos.x, psDroid->pos.y);
+	int32_t iMapHeight = map_Height(worldMapState, psDroid->pos.x, psDroid->pos.y);
 
 	psDroid->sMove.speed = 0;
 
@@ -2439,7 +2439,7 @@ void moveUpdateDroid(DROID *psDroid)
 //	}
 
 	/* If it's sitting in water then it's got to go with the flow! */
-	if (worldOnMap(psDroid->pos.x, psDroid->pos.y) && terrainType(mapTile(map_coord(psDroid->pos.x), map_coord(psDroid->pos.y))) == TER_WATER)
+	if (worldOnMap(worldMapState, psDroid->pos.x, psDroid->pos.y) && terrainType(mapTile(worldMapState, map_coord(psDroid->pos.x), map_coord(psDroid->pos.y))) == TER_WATER)
 	{
 		updateDroidOrientation(psDroid);
 	}

--- a/src/multibot.cpp
+++ b/src/multibot.cpp
@@ -435,7 +435,7 @@ bool recvDroid(NETQUEUE queue)
 	// If we were able to build the droid set it up
 	if (psDroid)
 	{
-		addDroid(psDroid, apsDroidLists);
+		addDroid(psDroid, worldObjectState.droids);
 
 		if (haveInitialOrders)
 		{

--- a/src/multibot.cpp
+++ b/src/multibot.cpp
@@ -43,6 +43,7 @@
 #include "mapgrid.h"
 #include "multirecv.h"
 #include "transporter.h"
+#include "game_world.h"
 
 #include <vector>
 #include <algorithm>
@@ -421,7 +422,7 @@ bool recvDroid(NETQUEUE queue)
 	ASSERT_OR_RETURN(false, player < MAX_PLAYERS, "invalid player %u", player);
 
 	debug(LOG_LIFE, "<=== getting Droid from %u id of %u ", player, id);
-	if ((pos.x == 0 && pos.y == 0) || pos.x > world_coord(worldMapState.width) || pos.y > world_coord(worldMapState.height))
+	if ((pos.x == 0 && pos.y == 0) || pos.x > world_coord(gameWorld.map.width) || pos.y > world_coord(gameWorld.map.height))
 	{
 		debug(LOG_ERROR, "Received bad droid position (%d, %d) from %d about p%d (%s)", (int)pos.x, (int)pos.y,
 		      queue.index, player, isHumanPlayer(player) ? "Human" : "AI");
@@ -435,7 +436,7 @@ bool recvDroid(NETQUEUE queue)
 	// If we were able to build the droid set it up
 	if (psDroid)
 	{
-		addDroid(psDroid, worldObjectState.droids);
+		addDroid(psDroid, gameWorld.objects.droids);
 
 		if (haveInitialOrders)
 		{

--- a/src/multibot.cpp
+++ b/src/multibot.cpp
@@ -421,7 +421,7 @@ bool recvDroid(NETQUEUE queue)
 	ASSERT_OR_RETURN(false, player < MAX_PLAYERS, "invalid player %u", player);
 
 	debug(LOG_LIFE, "<=== getting Droid from %u id of %u ", player, id);
-	if ((pos.x == 0 && pos.y == 0) || pos.x > world_coord(mapWidth) || pos.y > world_coord(mapHeight))
+	if ((pos.x == 0 && pos.y == 0) || pos.x > world_coord(worldMapState.width) || pos.y > world_coord(worldMapState.height))
 	{
 		debug(LOG_ERROR, "Received bad droid position (%d, %d) from %d about p%d (%s)", (int)pos.x, (int)pos.y,
 		      queue.index, player, isHumanPlayer(player) ? "Human" : "AI");

--- a/src/multigifts.cpp
+++ b/src/multigifts.cpp
@@ -512,8 +512,8 @@ void breakAlliance(uint8_t p1, uint8_t p2, bool prop, bool allowAudio)
 		{
 			for (int j = 0; j < b.size.y; j++)
 			{
-				auxClearAll(b.map.x + i, b.map.y + j, AUXBITS_OUR_BUILDING);
-				auxSetAllied(b.map.x + i, b.map.y + j, psStructure->player, AUXBITS_OUR_BUILDING);
+				auxClearAll(worldMapState, b.map.x + i, b.map.y + j, AUXBITS_OUR_BUILDING);
+				auxSetAllied(worldMapState, b.map.x + i, b.map.y + j, psStructure->player, AUXBITS_OUR_BUILDING);
 			}
 		}
 	}
@@ -526,8 +526,8 @@ void breakAlliance(uint8_t p1, uint8_t p2, bool prop, bool allowAudio)
 		{
 			for (int j = 0; j < b.size.y; j++)
 			{
-				auxClearAll(b.map.x + i, b.map.y + j, AUXBITS_OUR_BUILDING);
-				auxSetAllied(b.map.x + i, b.map.y + j, psStructure->player, AUXBITS_OUR_BUILDING);
+				auxClearAll(worldMapState, b.map.x + i, b.map.y + j, AUXBITS_OUR_BUILDING);
+				auxSetAllied(worldMapState, b.map.x + i, b.map.y + j, psStructure->player, AUXBITS_OUR_BUILDING);
 			}
 		}
 	}
@@ -603,13 +603,13 @@ void formAlliance(uint8_t p1, uint8_t p2, bool prop, bool allowAudio, bool allow
 			{
 				if (!(psStructure->pStructureType->type == REF_GATE))
 				{
-					auxSetAllied(b.map.x + i, b.map.y + j, psStructure->player, AUXBITS_OUR_BUILDING);
+					auxSetAllied(worldMapState, b.map.x + i, b.map.y + j, psStructure->player, AUXBITS_OUR_BUILDING);
 				}
 				else
 				{
 					// Make sure gates aren't set as impassible to our new allies
-					auxClearAll(b.map.x + i, b.map.y + j, AUXBITS_NONPASSABLE);
-					auxSetEnemy(b.map.x + i, b.map.y + j, psStructure->player, AUXBITS_NONPASSABLE);
+					auxClearAll(worldMapState, b.map.x + i, b.map.y + j, AUXBITS_NONPASSABLE);
+					auxSetEnemy(worldMapState, b.map.x + i, b.map.y + j, psStructure->player, AUXBITS_NONPASSABLE);
 				}
 			}
 		}
@@ -625,12 +625,12 @@ void formAlliance(uint8_t p1, uint8_t p2, bool prop, bool allowAudio, bool allow
 			{
 				if (!(psStructure->pStructureType->type == REF_GATE))
 				{
-					auxSetAllied(b.map.x + i, b.map.y + j, psStructure->player, AUXBITS_OUR_BUILDING);
+					auxSetAllied(worldMapState, b.map.x + i, b.map.y + j, psStructure->player, AUXBITS_OUR_BUILDING);
 				}
 				else
 				{
-					auxClearAll(b.map.x + i, b.map.y + j, AUXBITS_NONPASSABLE);
-					auxSetEnemy(b.map.x + i, b.map.y + j, psStructure->player, AUXBITS_NONPASSABLE);
+					auxClearAll(worldMapState, b.map.x + i, b.map.y + j, AUXBITS_NONPASSABLE);
+					auxSetEnemy(worldMapState, b.map.x + i, b.map.y + j, psStructure->player, AUXBITS_NONPASSABLE);
 				}
 			}
 		}

--- a/src/multigifts.cpp
+++ b/src/multigifts.cpp
@@ -298,7 +298,7 @@ static void sendGiftDroids(uint8_t from, uint8_t to)
 	uint8_t      giftType = DROID_GIFT;
 	uint8_t      totalToSend = 0;
 
-	if (apsDroidLists[from].empty())
+	if (worldObjectState.droids[from].empty())
 	{
 		return;
 	}
@@ -309,8 +309,8 @@ static void sendGiftDroids(uint8_t from, uint8_t to)
 	 * over their droid limit.
 	 */
 
-	for (psD = apsDroidLists[from].begin();
-	     psD != apsDroidLists[from].end() && (getNumDroids(to) + totalToSend < getMaxDroids(to)) && totalToSend != UINT8_MAX;
+	for (psD = worldObjectState.droids[from].begin();
+	     psD != worldObjectState.droids[from].end() && (getNumDroids(to) + totalToSend < getMaxDroids(to)) && totalToSend != UINT8_MAX;
 	     ++psD)
 	{
 		if ((*psD)->selected)
@@ -328,7 +328,7 @@ static void sendGiftDroids(uint8_t from, uint8_t to)
 	 * does its own net calls.
 	 */
 
-	for (psD = apsDroidLists[from].begin(); psD != apsDroidLists[from].end() && totalToSend != 0; ++psD)
+	for (psD = worldObjectState.droids[from].begin(); psD != worldObjectState.droids[from].end() && totalToSend != 0; ++psD)
 	{
 		if ((*psD)->selected)
 		{
@@ -504,7 +504,7 @@ void breakAlliance(uint8_t p1, uint8_t p2, bool prop, bool allowAudio)
 
 	// Make sure p1's structures are no longer considered "our buildings" to their former allies
 	// For unit pathing
-	for (const STRUCTURE* psStructure : apsStructLists[p1])
+	for (const STRUCTURE* psStructure : worldObjectState.structures[p1])
 	{
 		StructureBounds b = getStructureBounds(psStructure);
 
@@ -518,7 +518,7 @@ void breakAlliance(uint8_t p1, uint8_t p2, bool prop, bool allowAudio)
 		}
 	}
 	// Do the same for p2's stuff
-	for (const STRUCTURE* psStructure : apsStructLists[p2])
+	for (const STRUCTURE* psStructure : worldObjectState.structures[p2])
 	{
 		StructureBounds b = getStructureBounds(psStructure);
 
@@ -573,7 +573,7 @@ void formAlliance(uint8_t p1, uint8_t p2, bool prop, bool allowAudio, bool allow
 	}
 
 	// Clear out any attacking orders
-	for (DROID* psDroid : apsDroidLists[p1])	// from -> to
+	for (DROID* psDroid : worldObjectState.droids[p1])	// from -> to
 	{
 		if (psDroid->order.type == DORDER_ATTACK
 		    && psDroid->order.psObj
@@ -582,7 +582,7 @@ void formAlliance(uint8_t p1, uint8_t p2, bool prop, bool allowAudio, bool allow
 			orderDroid(psDroid, DORDER_STOP, ModeImmediate);
 		}
 	}
-	for (DROID* psDroid : apsDroidLists[p2])	// to -> from
+	for (DROID* psDroid : worldObjectState.droids[p2])	// to -> from
 	{
 		if (psDroid->order.type == DORDER_ATTACK
 		    && psDroid->order.psObj
@@ -593,7 +593,7 @@ void formAlliance(uint8_t p1, uint8_t p2, bool prop, bool allowAudio, bool allow
 	}
 
 	// Properly mark all of p1's structures as allied buildings for unit pathing
-	for (const STRUCTURE* psStructure : apsStructLists[p1])
+	for (const STRUCTURE* psStructure : worldObjectState.structures[p1])
 	{
 		StructureBounds b = getStructureBounds(psStructure);
 
@@ -615,7 +615,7 @@ void formAlliance(uint8_t p1, uint8_t p2, bool prop, bool allowAudio, bool allow
 		}
 	}
 	// Do the same for p2's stuff
-	for (const STRUCTURE* psStructure : apsStructLists[p2])
+	for (const STRUCTURE* psStructure : worldObjectState.structures[p2])
 	{
 		StructureBounds b = getStructureBounds(psStructure);
 

--- a/src/multigifts.cpp
+++ b/src/multigifts.cpp
@@ -298,7 +298,7 @@ static void sendGiftDroids(uint8_t from, uint8_t to)
 	uint8_t      giftType = DROID_GIFT;
 	uint8_t      totalToSend = 0;
 
-	if (worldObjectState.droids[from].empty())
+	if (gameWorld.objects.droids[from].empty())
 	{
 		return;
 	}
@@ -309,8 +309,8 @@ static void sendGiftDroids(uint8_t from, uint8_t to)
 	 * over their droid limit.
 	 */
 
-	for (psD = worldObjectState.droids[from].begin();
-	     psD != worldObjectState.droids[from].end() && (getNumDroids(to) + totalToSend < getMaxDroids(to)) && totalToSend != UINT8_MAX;
+	for (psD = gameWorld.objects.droids[from].begin();
+	     psD != gameWorld.objects.droids[from].end() && (getNumDroids(to) + totalToSend < getMaxDroids(to)) && totalToSend != UINT8_MAX;
 	     ++psD)
 	{
 		if ((*psD)->selected)
@@ -328,7 +328,7 @@ static void sendGiftDroids(uint8_t from, uint8_t to)
 	 * does its own net calls.
 	 */
 
-	for (psD = worldObjectState.droids[from].begin(); psD != worldObjectState.droids[from].end() && totalToSend != 0; ++psD)
+	for (psD = gameWorld.objects.droids[from].begin(); psD != gameWorld.objects.droids[from].end() && totalToSend != 0; ++psD)
 	{
 		if ((*psD)->selected)
 		{
@@ -504,7 +504,7 @@ void breakAlliance(uint8_t p1, uint8_t p2, bool prop, bool allowAudio)
 
 	// Make sure p1's structures are no longer considered "our buildings" to their former allies
 	// For unit pathing
-	for (const STRUCTURE* psStructure : worldObjectState.structures[p1])
+	for (const STRUCTURE* psStructure : gameWorld.objects.structures[p1])
 	{
 		StructureBounds b = getStructureBounds(psStructure);
 
@@ -512,13 +512,13 @@ void breakAlliance(uint8_t p1, uint8_t p2, bool prop, bool allowAudio)
 		{
 			for (int j = 0; j < b.size.y; j++)
 			{
-				auxClearAll(worldMapState, b.map.x + i, b.map.y + j, AUXBITS_OUR_BUILDING);
-				auxSetAllied(worldMapState, b.map.x + i, b.map.y + j, psStructure->player, AUXBITS_OUR_BUILDING);
+				auxClearAll(gameWorld.map, b.map.x + i, b.map.y + j, AUXBITS_OUR_BUILDING);
+				auxSetAllied(gameWorld.map, b.map.x + i, b.map.y + j, psStructure->player, AUXBITS_OUR_BUILDING);
 			}
 		}
 	}
 	// Do the same for p2's stuff
-	for (const STRUCTURE* psStructure : worldObjectState.structures[p2])
+	for (const STRUCTURE* psStructure : gameWorld.objects.structures[p2])
 	{
 		StructureBounds b = getStructureBounds(psStructure);
 
@@ -526,8 +526,8 @@ void breakAlliance(uint8_t p1, uint8_t p2, bool prop, bool allowAudio)
 		{
 			for (int j = 0; j < b.size.y; j++)
 			{
-				auxClearAll(worldMapState, b.map.x + i, b.map.y + j, AUXBITS_OUR_BUILDING);
-				auxSetAllied(worldMapState, b.map.x + i, b.map.y + j, psStructure->player, AUXBITS_OUR_BUILDING);
+				auxClearAll(gameWorld.map, b.map.x + i, b.map.y + j, AUXBITS_OUR_BUILDING);
+				auxSetAllied(gameWorld.map, b.map.x + i, b.map.y + j, psStructure->player, AUXBITS_OUR_BUILDING);
 			}
 		}
 	}
@@ -573,7 +573,7 @@ void formAlliance(uint8_t p1, uint8_t p2, bool prop, bool allowAudio, bool allow
 	}
 
 	// Clear out any attacking orders
-	for (DROID* psDroid : worldObjectState.droids[p1])	// from -> to
+	for (DROID* psDroid : gameWorld.objects.droids[p1])	// from -> to
 	{
 		if (psDroid->order.type == DORDER_ATTACK
 		    && psDroid->order.psObj
@@ -582,7 +582,7 @@ void formAlliance(uint8_t p1, uint8_t p2, bool prop, bool allowAudio, bool allow
 			orderDroid(psDroid, DORDER_STOP, ModeImmediate);
 		}
 	}
-	for (DROID* psDroid : worldObjectState.droids[p2])	// to -> from
+	for (DROID* psDroid : gameWorld.objects.droids[p2])	// to -> from
 	{
 		if (psDroid->order.type == DORDER_ATTACK
 		    && psDroid->order.psObj
@@ -593,7 +593,7 @@ void formAlliance(uint8_t p1, uint8_t p2, bool prop, bool allowAudio, bool allow
 	}
 
 	// Properly mark all of p1's structures as allied buildings for unit pathing
-	for (const STRUCTURE* psStructure : worldObjectState.structures[p1])
+	for (const STRUCTURE* psStructure : gameWorld.objects.structures[p1])
 	{
 		StructureBounds b = getStructureBounds(psStructure);
 
@@ -603,19 +603,19 @@ void formAlliance(uint8_t p1, uint8_t p2, bool prop, bool allowAudio, bool allow
 			{
 				if (!(psStructure->pStructureType->type == REF_GATE))
 				{
-					auxSetAllied(worldMapState, b.map.x + i, b.map.y + j, psStructure->player, AUXBITS_OUR_BUILDING);
+					auxSetAllied(gameWorld.map, b.map.x + i, b.map.y + j, psStructure->player, AUXBITS_OUR_BUILDING);
 				}
 				else
 				{
 					// Make sure gates aren't set as impassible to our new allies
-					auxClearAll(worldMapState, b.map.x + i, b.map.y + j, AUXBITS_NONPASSABLE);
-					auxSetEnemy(worldMapState, b.map.x + i, b.map.y + j, psStructure->player, AUXBITS_NONPASSABLE);
+					auxClearAll(gameWorld.map, b.map.x + i, b.map.y + j, AUXBITS_NONPASSABLE);
+					auxSetEnemy(gameWorld.map, b.map.x + i, b.map.y + j, psStructure->player, AUXBITS_NONPASSABLE);
 				}
 			}
 		}
 	}
 	// Do the same for p2's stuff
-	for (const STRUCTURE* psStructure : worldObjectState.structures[p2])
+	for (const STRUCTURE* psStructure : gameWorld.objects.structures[p2])
 	{
 		StructureBounds b = getStructureBounds(psStructure);
 
@@ -625,12 +625,12 @@ void formAlliance(uint8_t p1, uint8_t p2, bool prop, bool allowAudio, bool allow
 			{
 				if (!(psStructure->pStructureType->type == REF_GATE))
 				{
-					auxSetAllied(worldMapState, b.map.x + i, b.map.y + j, psStructure->player, AUXBITS_OUR_BUILDING);
+					auxSetAllied(gameWorld.map, b.map.x + i, b.map.y + j, psStructure->player, AUXBITS_OUR_BUILDING);
 				}
 				else
 				{
-					auxClearAll(worldMapState, b.map.x + i, b.map.y + j, AUXBITS_NONPASSABLE);
-					auxSetEnemy(worldMapState, b.map.x + i, b.map.y + j, psStructure->player, AUXBITS_NONPASSABLE);
+					auxClearAll(gameWorld.map, b.map.x + i, b.map.y + j, AUXBITS_NONPASSABLE);
+					auxSetEnemy(gameWorld.map, b.map.x + i, b.map.y + j, psStructure->player, AUXBITS_NONPASSABLE);
 				}
 			}
 		}

--- a/src/multijoin.cpp
+++ b/src/multijoin.cpp
@@ -75,6 +75,7 @@
 #include "multilobbycommands.h"
 #include "stdinreader.h"
 #include "hci/quickchat.h"
+#include "game_world.h"
 
 // ////////////////////////////////////////////////////////////////////////////
 // Local Functions
@@ -138,7 +139,7 @@ void destroyPlayerResources(UDWORD player, bool quietly)
 
 	debug(LOG_DEATH, "killing off all droids for player %d", player);
 	// delete all droids
-	mutating_list_iterate(worldObjectState.droids[player], [quietly](DROID* d)
+	mutating_list_iterate(gameWorld.objects.droids[player], [quietly](DROID* d)
 	{
 		if (quietly)			// don't show effects
 		{
@@ -153,7 +154,7 @@ void destroyPlayerResources(UDWORD player, bool quietly)
 
 	debug(LOG_DEATH, "killing off all structures for player %d", player);
 	// delete all structs
-	mutating_list_iterate(worldObjectState.structures[player], [quietly](STRUCTURE* psStruct)
+	mutating_list_iterate(gameWorld.objects.structures[player], [quietly](STRUCTURE* psStruct)
 	{
 		// FIXME: look why destroyStruct() doesn't put back the feature like removeStruct() does
 		if (quietly || psStruct->pStructureType->type == REF_RESOURCE_EXTRACTOR)		// don't show effects
@@ -173,7 +174,7 @@ void destroyPlayerResources(UDWORD player, bool quietly)
 static bool destroyMatchingStructs(UDWORD player, std::function<bool (STRUCTURE *)> cmp, bool quietly)
 {
 	bool destroyedAnyStructs = false;
-	mutating_list_iterate(worldObjectState.structures[player], [quietly, &cmp, &destroyedAnyStructs](STRUCTURE* psStruct)
+	mutating_list_iterate(gameWorld.objects.structures[player], [quietly, &cmp, &destroyedAnyStructs](STRUCTURE* psStruct)
 	{
 		if (cmp(psStruct))
 		{
@@ -256,7 +257,7 @@ bool splitResourcesAmongTeam(UDWORD player)
 			return a.itemsRecv < b.itemsRecv;
 		});
 	};
-	mutating_list_iterate(worldObjectState.droids[player], [&droidsGiftedPerTarget, &incrRecvItem](DROID* d)
+	mutating_list_iterate(gameWorld.objects.droids[player], [&droidsGiftedPerTarget, &incrRecvItem](DROID* d)
 	{
 		bool transferredDroid = false;
 		if (!isDead(d))
@@ -294,7 +295,7 @@ bool splitResourcesAmongTeam(UDWORD player)
 			});
 		};
 
-		mutating_list_iterate(worldObjectState.structures[player], [&cmp, &structsGiftedPerTarget, &incrRecvStruct](STRUCTURE* psStruct)
+		mutating_list_iterate(gameWorld.objects.structures[player], [&cmp, &structsGiftedPerTarget, &incrRecvStruct](STRUCTURE* psStruct)
 		{
 			if (psStruct && cmp(psStruct))
 			{
@@ -384,13 +385,13 @@ static void resetMultiVisibility(UDWORD player)
 		if (owned != player)								// done reset own stuff..
 		{
 			//droids
-			for (DROID* pDroid : worldObjectState.droids[owned])
+			for (DROID* pDroid : gameWorld.objects.droids[owned])
 			{
 				pDroid->visible[player] = false;
 			}
 
 			//structures
-			for (STRUCTURE* pStruct : worldObjectState.structures[owned])
+			for (STRUCTURE* pStruct : gameWorld.objects.structures[owned])
 			{
 				pStruct->visible[player] = false;
 			}

--- a/src/multijoin.cpp
+++ b/src/multijoin.cpp
@@ -138,7 +138,7 @@ void destroyPlayerResources(UDWORD player, bool quietly)
 
 	debug(LOG_DEATH, "killing off all droids for player %d", player);
 	// delete all droids
-	mutating_list_iterate(apsDroidLists[player], [quietly](DROID* d)
+	mutating_list_iterate(worldObjectState.droids[player], [quietly](DROID* d)
 	{
 		if (quietly)			// don't show effects
 		{
@@ -153,7 +153,7 @@ void destroyPlayerResources(UDWORD player, bool quietly)
 
 	debug(LOG_DEATH, "killing off all structures for player %d", player);
 	// delete all structs
-	mutating_list_iterate(apsStructLists[player], [quietly](STRUCTURE* psStruct)
+	mutating_list_iterate(worldObjectState.structures[player], [quietly](STRUCTURE* psStruct)
 	{
 		// FIXME: look why destroyStruct() doesn't put back the feature like removeStruct() does
 		if (quietly || psStruct->pStructureType->type == REF_RESOURCE_EXTRACTOR)		// don't show effects
@@ -173,7 +173,7 @@ void destroyPlayerResources(UDWORD player, bool quietly)
 static bool destroyMatchingStructs(UDWORD player, std::function<bool (STRUCTURE *)> cmp, bool quietly)
 {
 	bool destroyedAnyStructs = false;
-	mutating_list_iterate(apsStructLists[player], [quietly, &cmp, &destroyedAnyStructs](STRUCTURE* psStruct)
+	mutating_list_iterate(worldObjectState.structures[player], [quietly, &cmp, &destroyedAnyStructs](STRUCTURE* psStruct)
 	{
 		if (cmp(psStruct))
 		{
@@ -256,7 +256,7 @@ bool splitResourcesAmongTeam(UDWORD player)
 			return a.itemsRecv < b.itemsRecv;
 		});
 	};
-	mutating_list_iterate(apsDroidLists[player], [&droidsGiftedPerTarget, &incrRecvItem](DROID* d)
+	mutating_list_iterate(worldObjectState.droids[player], [&droidsGiftedPerTarget, &incrRecvItem](DROID* d)
 	{
 		bool transferredDroid = false;
 		if (!isDead(d))
@@ -294,7 +294,7 @@ bool splitResourcesAmongTeam(UDWORD player)
 			});
 		};
 
-		mutating_list_iterate(apsStructLists[player], [&cmp, &structsGiftedPerTarget, &incrRecvStruct](STRUCTURE* psStruct)
+		mutating_list_iterate(worldObjectState.structures[player], [&cmp, &structsGiftedPerTarget, &incrRecvStruct](STRUCTURE* psStruct)
 		{
 			if (psStruct && cmp(psStruct))
 			{
@@ -384,13 +384,13 @@ static void resetMultiVisibility(UDWORD player)
 		if (owned != player)								// done reset own stuff..
 		{
 			//droids
-			for (DROID* pDroid : apsDroidLists[owned])
+			for (DROID* pDroid : worldObjectState.droids[owned])
 			{
 				pDroid->visible[player] = false;
 			}
 
 			//structures
-			for (STRUCTURE* pStruct : apsStructLists[owned])
+			for (STRUCTURE* pStruct : worldObjectState.structures[owned])
 			{
 				pStruct->visible[player] = false;
 			}

--- a/src/multilimit.cpp
+++ b/src/multilimit.cpp
@@ -54,6 +54,7 @@
 #include "challenge.h"
 #include "objmem.h"
 #include "titleui/titleui.h"
+#include "game_world.h"
 
 // ////////////////////////////////////////////////////////////////////////////
 // defines
@@ -398,7 +399,7 @@ bool applyLimitSet()
 				{
 					while (asStructureStats[id].curCount[player] > asStructureStats[id].upgrade[player].limit)
 					{
-						mutating_list_iterate(worldObjectState.structures[player], [id](STRUCTURE* psStruct)
+						mutating_list_iterate(gameWorld.objects.structures[player], [id](STRUCTURE* psStruct)
 						{
 							if (psStruct->pStructureType->type == asStructureStats[id].type)
 							{

--- a/src/multilimit.cpp
+++ b/src/multilimit.cpp
@@ -398,7 +398,7 @@ bool applyLimitSet()
 				{
 					while (asStructureStats[id].curCount[player] > asStructureStats[id].upgrade[player].limit)
 					{
-						mutating_list_iterate(apsStructLists[player], [id](STRUCTURE* psStruct)
+						mutating_list_iterate(worldObjectState.structures[player], [id](STRUCTURE* psStruct)
 						{
 							if (psStruct->pStructureType->type == asStructureStats[id].type)
 							{

--- a/src/multimenu.cpp
+++ b/src/multimenu.cpp
@@ -146,7 +146,7 @@ static bool		giftsUp[MAX_PLAYERS] = {true};		//gift buttons for player are up.
 static PIELIGHT GetPlayerTextColor(int mode, UDWORD player)
 {
 	// override color if they are dead...
-	if (player >= MAX_PLAYERS || (apsDroidLists[player].empty() && apsStructLists[player].empty()))
+	if (player >= MAX_PLAYERS || (worldObjectState.droids[player].empty() && worldObjectState.structures[player].empty()))
 	{
 		return WZCOL_GREY;			// dead text color
 	}
@@ -750,7 +750,7 @@ public:
 	void display(int xOffset, int yOffset) override
 	{
 		// a droid of theirs.
-		DroidList* displayDroidList = (player < MAX_PLAYERS) ? &apsDroidLists[player] : nullptr;
+		DroidList* displayDroidList = (player < MAX_PLAYERS) ? &worldObjectState.droids[player] : nullptr;
 		if (!displayDroidList)
 		{
 			return;
@@ -779,7 +779,7 @@ public:
 
 			displayComponentButtonObject(displayDroid, &rotation, &position, 100);
 		}
-		else if ((player < MAX_PLAYERS) && !apsDroidLists[player].empty())
+		else if ((player < MAX_PLAYERS) && !worldObjectState.droids[player].empty())
 		{
 			// Show that they have droids, but not which droids, since we can't see them.
 			iV_DrawImageTc(
@@ -1123,7 +1123,7 @@ private:
 				if (isAlly || gInputManager.debugManager().debugMappingsAllowed())
 				{
 					// NOTE, This tallys up *all* the structures you have. Test out via 'start with no base'.
-					int num = apsStructLists[playerWidget.player].size();
+					int num = worldObjectState.structures[playerWidget.player].size();
 					ssprintf(lastString, "%d", num);
 				}
 			}

--- a/src/multimenu.cpp
+++ b/src/multimenu.cpp
@@ -146,7 +146,7 @@ static bool		giftsUp[MAX_PLAYERS] = {true};		//gift buttons for player are up.
 static PIELIGHT GetPlayerTextColor(int mode, UDWORD player)
 {
 	// override color if they are dead...
-	if (player >= MAX_PLAYERS || (worldObjectState.droids[player].empty() && worldObjectState.structures[player].empty()))
+	if (player >= MAX_PLAYERS || (gameWorld.objects.droids[player].empty() && gameWorld.objects.structures[player].empty()))
 	{
 		return WZCOL_GREY;			// dead text color
 	}
@@ -750,7 +750,7 @@ public:
 	void display(int xOffset, int yOffset) override
 	{
 		// a droid of theirs.
-		DroidList* displayDroidList = (player < MAX_PLAYERS) ? &worldObjectState.droids[player] : nullptr;
+		DroidList* displayDroidList = (player < MAX_PLAYERS) ? &gameWorld.objects.droids[player] : nullptr;
 		if (!displayDroidList)
 		{
 			return;
@@ -779,7 +779,7 @@ public:
 
 			displayComponentButtonObject(displayDroid, &rotation, &position, 100);
 		}
-		else if ((player < MAX_PLAYERS) && !worldObjectState.droids[player].empty())
+		else if ((player < MAX_PLAYERS) && !gameWorld.objects.droids[player].empty())
 		{
 			// Show that they have droids, but not which droids, since we can't see them.
 			iV_DrawImageTc(
@@ -1123,7 +1123,7 @@ private:
 				if (isAlly || gInputManager.debugManager().debugMappingsAllowed())
 				{
 					// NOTE, This tallys up *all* the structures you have. Test out via 'start with no base'.
-					int num = worldObjectState.structures[playerWidget.player].size();
+					int num = gameWorld.objects.structures[playerWidget.player].size();
 					ssprintf(lastString, "%d", num);
 				}
 			}

--- a/src/multiplay.cpp
+++ b/src/multiplay.cpp
@@ -41,6 +41,7 @@
 #include "hci.h"
 
 #include <time.h>									// for recording ping times.
+#include "objmem.h"
 #include "research.h"
 #include "display3d.h"								// for changing the viewpoint
 #include "console.h"								// for screen messages
@@ -463,7 +464,7 @@ bool multiplayerWinSequence(bool firstCall)
 		CancelAllResearch(selectedPlayer);
 
 		// stop all manufacture.
-		for (STRUCTURE* psStruct : apsStructLists[selectedPlayer])
+		for (STRUCTURE* psStruct : worldObjectState.structures[selectedPlayer])
 		{
 			if (psStruct && psStruct->isFactory())
 			{
@@ -648,7 +649,7 @@ DROID *IdToDroid(UDWORD id, UDWORD player)
 	{
 		for (int i = 0; i < MAX_PLAYERS; i++)
 		{
-			DROID* d = (DROID*)getBaseObjFromId(apsDroidLists[i], id);
+			DROID* d = (DROID*)getBaseObjFromId(worldObjectState.droids[i], id);
 			if (d)
 			{
 				return d;
@@ -657,7 +658,7 @@ DROID *IdToDroid(UDWORD id, UDWORD player)
 	}
 	else if (player < MAX_PLAYERS)
 	{
-		DROID* d = (DROID*)getBaseObjFromId(apsDroidLists[player], id);
+		DROID* d = (DROID*)getBaseObjFromId(worldObjectState.droids[player], id);
 		if (d)
 		{
 			return d;
@@ -673,7 +674,7 @@ DROID *IdToMissionDroid(UDWORD id, UDWORD player)
 	{
 		for (int i = 0; i < MAX_PLAYERS; i++)
 		{
-			DROID* d = (DROID*)getBaseObjFromId(mission.apsDroidLists[i], id);
+			DROID* d = (DROID*)getBaseObjFromId(mission.worldObjectState.droids[i], id);
 			if (d)
 			{
 				return d;
@@ -682,7 +683,7 @@ DROID *IdToMissionDroid(UDWORD id, UDWORD player)
 	}
 	else if (player < MAX_PLAYERS)
 	{
-		DROID* d = (DROID*)getBaseObjFromId(mission.apsDroidLists[player], id);
+		DROID* d = (DROID*)getBaseObjFromId(mission.worldObjectState.droids[player], id);
 		if (d)
 		{
 			return d;
@@ -695,12 +696,12 @@ static STRUCTURE* _IdToStruct(UDWORD id, UDWORD beginPlayer, UDWORD endPlayer)
 {
 	for (int i = beginPlayer; i < endPlayer; ++i)
 	{
-		STRUCTURE* s = (STRUCTURE*)getBaseObjFromId(apsStructLists[i], id);
+		STRUCTURE* s = (STRUCTURE*)getBaseObjFromId(worldObjectState.structures[i], id);
 		if (s)
 		{
 			return s;
 		}
-		s = (STRUCTURE*)getBaseObjFromId(mission.apsStructLists[i], id);
+		s = (STRUCTURE*)getBaseObjFromId(mission.worldObjectState.structures[i], id);
 		if (s)
 		{
 			return s;
@@ -732,7 +733,7 @@ STRUCTURE *IdToStruct(UDWORD id, UDWORD player)
 FEATURE *IdToFeature(UDWORD id, UDWORD player)
 {
 	(void)player;	// unused, all features go into player 0
-	return (FEATURE*)getBaseObjFromId(apsFeatureList[0], id);
+	return (FEATURE*)getBaseObjFromId(worldObjectState.features[0], id);
 }
 
 // ////////////////////////////////////////////////////////////////////////////
@@ -969,11 +970,11 @@ Vector3i cameraToHome(UDWORD player, bool scroll, bool fromSave)
 
 	if (player < MAX_PLAYERS)
 	{
-		auto buildingIt = std::find_if(apsStructLists[player].begin(), apsStructLists[player].end(), [](STRUCTURE* building)
+		auto buildingIt = std::find_if(worldObjectState.structures[player].begin(), worldObjectState.structures[player].end(), [](STRUCTURE* building)
 		{
 			return building->pStructureType->type == REF_HQ;
 		});
-		if (buildingIt != apsStructLists[player].end())
+		if (buildingIt != worldObjectState.structures[player].end())
 		{
 			psBuilding = *buildingIt;
 		}
@@ -984,15 +985,15 @@ Vector3i cameraToHome(UDWORD player, bool scroll, bool fromSave)
 		x = map_coord(psBuilding->pos.x);
 		y = map_coord(psBuilding->pos.y);
 	}
-	else if ((player < MAX_PLAYERS) && !apsDroidLists[player].empty())				// or first droid
+	else if ((player < MAX_PLAYERS) && !worldObjectState.droids[player].empty())				// or first droid
 	{
-		x = map_coord(apsDroidLists[player].front()->pos.x);
-		y =	map_coord(apsDroidLists[player].front()->pos.y);
+		x = map_coord(worldObjectState.droids[player].front()->pos.x);
+		y =	map_coord(worldObjectState.droids[player].front()->pos.y);
 	}
-	else if ((player < MAX_PLAYERS) && !apsStructLists[player].empty())				// center on first struct
+	else if ((player < MAX_PLAYERS) && !worldObjectState.structures[player].empty())				// center on first struct
 	{
-		x = map_coord(apsStructLists[player].front()->pos.x);
-		y = map_coord(apsStructLists[player].front()->pos.y);
+		x = map_coord(worldObjectState.structures[player].front()->pos.x);
+		y = map_coord(worldObjectState.structures[player].front()->pos.y);
 	}
 	else														//or map center.
 	{
@@ -1885,7 +1886,7 @@ STRUCTURE *findResearchingFacilityByResearchIndex(const PerPlayerStructureLists&
 
 STRUCTURE *findResearchingFacilityByResearchIndex(unsigned player, unsigned index)
 {
-	return findResearchingFacilityByResearchIndex(apsStructLists, player, index);
+	return findResearchingFacilityByResearchIndex(worldObjectState.structures, player, index);
 }
 
 bool recvResearchStatus(NETQUEUE queue)
@@ -2820,7 +2821,7 @@ bool makePlayerSpectator(uint32_t playerIndex, bool removeAllStructs, bool quiet
 
 		// Destroy HQ
 		std::vector<STRUCTURE *> hqStructs;
-		for (STRUCTURE *psStruct : apsStructLists[playerIndex])
+		for (STRUCTURE *psStruct : worldObjectState.structures[playerIndex])
 		{
 			if (REF_HQ == psStruct->pStructureType->type)
 			{
@@ -2841,7 +2842,7 @@ bool makePlayerSpectator(uint32_t playerIndex, bool removeAllStructs, bool quiet
 
 		// Destroy all droids
 		debug(LOG_DEATH, "killing off all droids for player %d", playerIndex);
-		mutating_list_iterate(apsDroidLists[playerIndex], [quietly](DROID* d)
+		mutating_list_iterate(worldObjectState.droids[playerIndex], [quietly](DROID* d)
 		{
 			if (quietly)			// don't show effects
 			{
@@ -2856,7 +2857,7 @@ bool makePlayerSpectator(uint32_t playerIndex, bool removeAllStructs, bool quiet
 
 		// Destroy structs
 		debug(LOG_DEATH, "killing off structures for player %d", playerIndex);
-		mutating_list_iterate(apsStructLists[playerIndex], [quietly, removeAllStructs](STRUCTURE* psStruct)
+		mutating_list_iterate(worldObjectState.structures[playerIndex], [quietly, removeAllStructs](STRUCTURE* psStruct)
 		{
 			if (removeAllStructs
 				|| psStruct->pStructureType->type == REF_POWER_GEN

--- a/src/multiplay.cpp
+++ b/src/multiplay.cpp
@@ -1013,7 +1013,7 @@ Vector3i cameraToHome(UDWORD player, bool scroll, bool fromSave)
 
 	Vector3i res;
 	res.x = world_coord(x);
-	res.y = map_TileHeight(x, y);
+	res.y = map_TileHeight(worldMapState, x, y);
 	res.z = world_coord(y);
 	return res;
 }
@@ -2563,7 +2563,7 @@ VIEWDATA *CreateBeaconViewData(SDWORD sender, UDWORD LocX, UDWORD LocY)
 	((VIEW_PROXIMITY *)psViewData->pData)->y = (UDWORD)LocY;
 
 	//check the z value is at least the height of the terrain
-	height = map_Height(LocX, LocY);
+	height = map_Height(worldMapState, LocX, LocY);
 
 	((VIEW_PROXIMITY *)psViewData->pData)->z = height;
 

--- a/src/multiplay.cpp
+++ b/src/multiplay.cpp
@@ -464,7 +464,7 @@ bool multiplayerWinSequence(bool firstCall)
 		CancelAllResearch(selectedPlayer);
 
 		// stop all manufacture.
-		for (STRUCTURE* psStruct : worldObjectState.structures[selectedPlayer])
+		for (STRUCTURE* psStruct : gameWorld.objects.structures[selectedPlayer])
 		{
 			if (psStruct && psStruct->isFactory())
 			{
@@ -504,9 +504,9 @@ bool multiplayerWinSequence(bool firstCall)
 			pos2.x = 128;
 		}
 
-		if ((unsigned)pos2.x > world_coord(worldMapState.width))
+		if ((unsigned)pos2.x > world_coord(gameWorld.map.width))
 		{
-			pos2.x = world_coord(worldMapState.width);
+			pos2.x = world_coord(gameWorld.map.width);
 		}
 
 		if (pos2.z < 0)
@@ -514,9 +514,9 @@ bool multiplayerWinSequence(bool firstCall)
 			pos2.z = 128;
 		}
 
-		if ((unsigned)pos2.z > world_coord(worldMapState.height))
+		if ((unsigned)pos2.z > world_coord(gameWorld.map.height))
 		{
-			pos2.z = world_coord(worldMapState.height);
+			pos2.z = world_coord(gameWorld.map.height);
 		}
 
 		addEffect(&pos2, EFFECT_FIREWORK, FIREWORK_TYPE_LAUNCHER, false, nullptr, 0);	// throw up some fire works.
@@ -649,7 +649,7 @@ DROID *IdToDroid(UDWORD id, UDWORD player)
 	{
 		for (int i = 0; i < MAX_PLAYERS; i++)
 		{
-			DROID* d = (DROID*)getBaseObjFromId(worldObjectState.droids[i], id);
+			DROID* d = (DROID*)getBaseObjFromId(gameWorld.objects.droids[i], id);
 			if (d)
 			{
 				return d;
@@ -658,7 +658,7 @@ DROID *IdToDroid(UDWORD id, UDWORD player)
 	}
 	else if (player < MAX_PLAYERS)
 	{
-		DROID* d = (DROID*)getBaseObjFromId(worldObjectState.droids[player], id);
+		DROID* d = (DROID*)getBaseObjFromId(gameWorld.objects.droids[player], id);
 		if (d)
 		{
 			return d;
@@ -674,7 +674,7 @@ DROID *IdToMissionDroid(UDWORD id, UDWORD player)
 	{
 		for (int i = 0; i < MAX_PLAYERS; i++)
 		{
-			DROID* d = (DROID*)getBaseObjFromId(mission.worldObjectState.droids[i], id);
+			DROID* d = (DROID*)getBaseObjFromId(mission.gameWorld.objects.droids[i], id);
 			if (d)
 			{
 				return d;
@@ -683,7 +683,7 @@ DROID *IdToMissionDroid(UDWORD id, UDWORD player)
 	}
 	else if (player < MAX_PLAYERS)
 	{
-		DROID* d = (DROID*)getBaseObjFromId(mission.worldObjectState.droids[player], id);
+		DROID* d = (DROID*)getBaseObjFromId(mission.gameWorld.objects.droids[player], id);
 		if (d)
 		{
 			return d;
@@ -696,12 +696,12 @@ static STRUCTURE* _IdToStruct(UDWORD id, UDWORD beginPlayer, UDWORD endPlayer)
 {
 	for (int i = beginPlayer; i < endPlayer; ++i)
 	{
-		STRUCTURE* s = (STRUCTURE*)getBaseObjFromId(worldObjectState.structures[i], id);
+		STRUCTURE* s = (STRUCTURE*)getBaseObjFromId(gameWorld.objects.structures[i], id);
 		if (s)
 		{
 			return s;
 		}
-		s = (STRUCTURE*)getBaseObjFromId(mission.worldObjectState.structures[i], id);
+		s = (STRUCTURE*)getBaseObjFromId(mission.gameWorld.objects.structures[i], id);
 		if (s)
 		{
 			return s;
@@ -733,7 +733,7 @@ STRUCTURE *IdToStruct(UDWORD id, UDWORD player)
 FEATURE *IdToFeature(UDWORD id, UDWORD player)
 {
 	(void)player;	// unused, all features go into player 0
-	return (FEATURE*)getBaseObjFromId(worldObjectState.features[0], id);
+	return (FEATURE*)getBaseObjFromId(gameWorld.objects.features[0], id);
 }
 
 // ////////////////////////////////////////////////////////////////////////////
@@ -970,11 +970,11 @@ Vector3i cameraToHome(UDWORD player, bool scroll, bool fromSave)
 
 	if (player < MAX_PLAYERS)
 	{
-		auto buildingIt = std::find_if(worldObjectState.structures[player].begin(), worldObjectState.structures[player].end(), [](STRUCTURE* building)
+		auto buildingIt = std::find_if(gameWorld.objects.structures[player].begin(), gameWorld.objects.structures[player].end(), [](STRUCTURE* building)
 		{
 			return building->pStructureType->type == REF_HQ;
 		});
-		if (buildingIt != worldObjectState.structures[player].end())
+		if (buildingIt != gameWorld.objects.structures[player].end())
 		{
 			psBuilding = *buildingIt;
 		}
@@ -985,20 +985,20 @@ Vector3i cameraToHome(UDWORD player, bool scroll, bool fromSave)
 		x = map_coord(psBuilding->pos.x);
 		y = map_coord(psBuilding->pos.y);
 	}
-	else if ((player < MAX_PLAYERS) && !worldObjectState.droids[player].empty())				// or first droid
+	else if ((player < MAX_PLAYERS) && !gameWorld.objects.droids[player].empty())				// or first droid
 	{
-		x = map_coord(worldObjectState.droids[player].front()->pos.x);
-		y =	map_coord(worldObjectState.droids[player].front()->pos.y);
+		x = map_coord(gameWorld.objects.droids[player].front()->pos.x);
+		y =	map_coord(gameWorld.objects.droids[player].front()->pos.y);
 	}
-	else if ((player < MAX_PLAYERS) && !worldObjectState.structures[player].empty())				// center on first struct
+	else if ((player < MAX_PLAYERS) && !gameWorld.objects.structures[player].empty())				// center on first struct
 	{
-		x = map_coord(worldObjectState.structures[player].front()->pos.x);
-		y = map_coord(worldObjectState.structures[player].front()->pos.y);
+		x = map_coord(gameWorld.objects.structures[player].front()->pos.x);
+		y = map_coord(gameWorld.objects.structures[player].front()->pos.y);
 	}
 	else														//or map center.
 	{
-		x = worldMapState.width / 2;
-		y = worldMapState.height / 2;
+		x = gameWorld.map.width / 2;
+		y = gameWorld.map.height / 2;
 	}
 
 
@@ -1013,7 +1013,7 @@ Vector3i cameraToHome(UDWORD player, bool scroll, bool fromSave)
 
 	Vector3i res;
 	res.x = world_coord(x);
-	res.y = map_TileHeight(worldMapState, x, y);
+	res.y = map_TileHeight(gameWorld.map, x, y);
 	res.z = world_coord(y);
 	return res;
 }
@@ -1886,7 +1886,7 @@ STRUCTURE *findResearchingFacilityByResearchIndex(const PerPlayerStructureLists&
 
 STRUCTURE *findResearchingFacilityByResearchIndex(unsigned player, unsigned index)
 {
-	return findResearchingFacilityByResearchIndex(worldObjectState.structures, player, index);
+	return findResearchingFacilityByResearchIndex(gameWorld.objects.structures, player, index);
 }
 
 bool recvResearchStatus(NETQUEUE queue)
@@ -2563,7 +2563,7 @@ VIEWDATA *CreateBeaconViewData(SDWORD sender, UDWORD LocX, UDWORD LocY)
 	((VIEW_PROXIMITY *)psViewData->pData)->y = (UDWORD)LocY;
 
 	//check the z value is at least the height of the terrain
-	height = map_Height(worldMapState, LocX, LocY);
+	height = map_Height(gameWorld.map, LocX, LocY);
 
 	((VIEW_PROXIMITY *)psViewData->pData)->z = height;
 
@@ -2821,7 +2821,7 @@ bool makePlayerSpectator(uint32_t playerIndex, bool removeAllStructs, bool quiet
 
 		// Destroy HQ
 		std::vector<STRUCTURE *> hqStructs;
-		for (STRUCTURE *psStruct : worldObjectState.structures[playerIndex])
+		for (STRUCTURE *psStruct : gameWorld.objects.structures[playerIndex])
 		{
 			if (REF_HQ == psStruct->pStructureType->type)
 			{
@@ -2842,7 +2842,7 @@ bool makePlayerSpectator(uint32_t playerIndex, bool removeAllStructs, bool quiet
 
 		// Destroy all droids
 		debug(LOG_DEATH, "killing off all droids for player %d", playerIndex);
-		mutating_list_iterate(worldObjectState.droids[playerIndex], [quietly](DROID* d)
+		mutating_list_iterate(gameWorld.objects.droids[playerIndex], [quietly](DROID* d)
 		{
 			if (quietly)			// don't show effects
 			{
@@ -2857,7 +2857,7 @@ bool makePlayerSpectator(uint32_t playerIndex, bool removeAllStructs, bool quiet
 
 		// Destroy structs
 		debug(LOG_DEATH, "killing off structures for player %d", playerIndex);
-		mutating_list_iterate(worldObjectState.structures[playerIndex], [quietly, removeAllStructs](STRUCTURE* psStruct)
+		mutating_list_iterate(gameWorld.objects.structures[playerIndex], [quietly, removeAllStructs](STRUCTURE* psStruct)
 		{
 			if (removeAllStructs
 				|| psStruct->pStructureType->type == REF_POWER_GEN

--- a/src/multiplay.cpp
+++ b/src/multiplay.cpp
@@ -503,9 +503,9 @@ bool multiplayerWinSequence(bool firstCall)
 			pos2.x = 128;
 		}
 
-		if ((unsigned)pos2.x > world_coord(mapWidth))
+		if ((unsigned)pos2.x > world_coord(worldMapState.width))
 		{
-			pos2.x = world_coord(mapWidth);
+			pos2.x = world_coord(worldMapState.width);
 		}
 
 		if (pos2.z < 0)
@@ -513,9 +513,9 @@ bool multiplayerWinSequence(bool firstCall)
 			pos2.z = 128;
 		}
 
-		if ((unsigned)pos2.z > world_coord(mapHeight))
+		if ((unsigned)pos2.z > world_coord(worldMapState.height))
 		{
-			pos2.z = world_coord(mapHeight);
+			pos2.z = world_coord(worldMapState.height);
 		}
 
 		addEffect(&pos2, EFFECT_FIREWORK, FIREWORK_TYPE_LAUNCHER, false, nullptr, 0);	// throw up some fire works.
@@ -996,8 +996,8 @@ Vector3i cameraToHome(UDWORD player, bool scroll, bool fromSave)
 	}
 	else														//or map center.
 	{
-		x = mapWidth / 2;
-		y = mapHeight / 2;
+		x = worldMapState.width / 2;
+		y = worldMapState.height / 2;
 	}
 
 

--- a/src/object_lists_types.h
+++ b/src/object_lists_types.h
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+/*
+	This file is part of Warzone 2100.
+	Copyright (C) 2026  Warzone 2100 Project (https://github.com/Warzone2100)
+
+	Warzone 2100 is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+
+	Warzone 2100 is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with Warzone 2100; if not, write to the Free Software
+	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+/** \file
+ *  Type aliases for per-player object list storage.
+ */
+
+#pragma once
+
+#include <array>
+#include <list>
+
+#include "lib/framework/frame.h" // MAX_PLAYERS
+
+struct BASE_OBJECT;
+struct DROID;
+struct STRUCTURE;
+struct FEATURE;
+struct FLAG_POSITION;
+
+template <typename ObjectType, unsigned PlayerCount>
+using PerPlayerObjectLists = std::array<std::list<ObjectType*>, PlayerCount>;
+
+using PerPlayerDroidLists = PerPlayerObjectLists<DROID, MAX_PLAYERS>;
+using DroidList = typename PerPlayerDroidLists::value_type;
+
+using PerPlayerStructureLists = PerPlayerObjectLists<STRUCTURE, MAX_PLAYERS>;
+using StructureList = typename PerPlayerStructureLists::value_type;
+
+using PerPlayerFeatureLists = PerPlayerObjectLists<FEATURE, 1>;
+using FeatureList = typename PerPlayerFeatureLists::value_type;
+
+using PerPlayerFlagPositionLists = PerPlayerObjectLists<FLAG_POSITION, MAX_PLAYERS>;
+using FlagPositionList = typename PerPlayerFlagPositionLists::value_type;
+
+using PerPlayerExtractorLists = PerPlayerStructureLists;
+using ExtractorList = typename PerPlayerExtractorLists::value_type;
+
+using GlobalSensorList = PerPlayerObjectLists<BASE_OBJECT, 1>;
+using SensorList = typename GlobalSensorList::value_type;
+
+using GlobalOilList = PerPlayerObjectLists<FEATURE, 1>;
+using OilList = typename GlobalOilList::value_type;
+
+using DestroyedObjectsList = std::list<BASE_OBJECT*>;

--- a/src/objmem.cpp
+++ b/src/objmem.cpp
@@ -57,15 +57,7 @@ uint32_t                unsynchObjID;
 uint32_t                synchObjID;
 
 /* The lists of objects allocated */
-PerPlayerDroidLists apsDroidLists;
-PerPlayerStructureLists apsStructLists;
-GlobalFeatureList apsFeatureList;
-PerPlayerExtractorLists apsExtractorLists;
-GlobalOilList apsOilList;
-GlobalSensorList apsSensorList; ///< List of sensors in the game.
-
-/*The list of Flag Positions allocated */
-PerPlayerFlagPositionLists apsFlagPosLists;
+WorldObjectState worldObjectState;
 
 /* The list of destroyed objects */
 DestroyedObjectsList psDestroyedObj;
@@ -247,11 +239,11 @@ static bool checkReferences(BASE_OBJECT *psVictim)
 {
 	for (unsigned plr = 0; plr < MAX_PLAYERS; ++plr)
 	{
-		if (!checkPlrStructReferences(psVictim, apsStructLists)) { return false; }
-		if (!checkPlrStructReferences(psVictim, mission.apsStructLists)) { return false; }
+		if (!checkPlrStructReferences(psVictim, worldObjectState.structures)) { return false; }
+		if (!checkPlrStructReferences(psVictim, mission.worldObjectState.structures)) { return false; }
 
-		if (!checkPlrDroidReferences(psVictim, apsDroidLists)) { return false; }
-		if (!checkPlrDroidReferences(psVictim, mission.apsDroidLists)) { return false; }
+		if (!checkPlrDroidReferences(psVictim, worldObjectState.droids)) { return false; }
+		if (!checkPlrDroidReferences(psVictim, mission.worldObjectState.droids)) { return false; }
 		if (!checkPlrDroidReferences(psVictim, apsLimboDroids)) { return false; }
 	}
 	return true;
@@ -482,12 +474,12 @@ void addDroid(DROID *psDroidToAdd, PerPlayerDroidLists& pList)
 	/* Whenever a droid gets added to a list other than the current list
 	 * its died flag is set to NOT_CURRENT_LIST so that anything targetting
 	 * it will cancel itself - HACK?! */
-	if (&pList[psDroidToAdd->player] == &apsDroidLists[psDroidToAdd->player])
+	if (&pList[psDroidToAdd->player] == &worldObjectState.droids[psDroidToAdd->player])
 	{
 		psDroidToAdd->died = false;
 		if (psDroidToAdd->droidType == DROID_SENSOR)
 		{
-			addObjectToFuncList(apsSensorList, (BASE_OBJECT *)psDroidToAdd, 0);
+			addObjectToFuncList(worldObjectState.sensors, (BASE_OBJECT *)psDroidToAdd, 0);
 		}
 
 		// commanders have to get their group back if not already loaded
@@ -497,11 +489,11 @@ void addDroid(DROID *psDroidToAdd, PerPlayerDroidLists& pList)
 			psGroup->add(psDroidToAdd);
 		}
 	}
-	else if (&pList[psDroidToAdd->player] == &mission.apsDroidLists[psDroidToAdd->player])
+	else if (&pList[psDroidToAdd->player] == &mission.worldObjectState.droids[psDroidToAdd->player])
 	{
 		if (psDroidToAdd->droidType == DROID_SENSOR)
 		{
-			addObjectToFuncList(mission.apsSensorList, (BASE_OBJECT *)psDroidToAdd, 0);
+			addObjectToFuncList(mission.worldObjectState.sensors, (BASE_OBJECT *)psDroidToAdd, 0);
 		}
 	}
 }
@@ -524,10 +516,10 @@ void killDroid(DROID *psDel)
 	setDroidBase(psDel, nullptr);
 	if (psDel->droidType == DROID_SENSOR)
 	{
-		removeObjectFromFuncList(apsSensorList, (BASE_OBJECT *)psDel, 0);
+		removeObjectFromFuncList(worldObjectState.sensors, (BASE_OBJECT *)psDel, 0);
 	}
 
-	destroyObject(apsDroidLists, psDel);
+	destroyObject(worldObjectState.droids, psDel);
 }
 
 template <typename EntityType>
@@ -604,7 +596,7 @@ static void freeAllEntitiesImpl(PerPlayerObjectLists<Entity, PlayerCount>& entit
 /* Remove all droids */
 void freeAllDroids()
 {
-	freeAllEntitiesImpl<DROID, MAX_PLAYERS>(apsDroidLists);
+	freeAllEntitiesImpl<DROID, MAX_PLAYERS>(worldObjectState.droids);
 }
 
 /*Remove a single Droid from a list*/
@@ -617,19 +609,19 @@ void removeDroid(DROID* psDroidToRemove, PerPlayerDroidLists& pList)
 	/* Whenever a droid is removed from the current list its died
 	 * flag is set to NOT_CURRENT_LIST so that anything targetting
 	 * it will cancel itself, and we know it is not really on the map. */
-	if (&pList[psDroidToRemove->player] == &apsDroidLists[psDroidToRemove->player])
+	if (&pList[psDroidToRemove->player] == &worldObjectState.droids[psDroidToRemove->player])
 	{
 		if (psDroidToRemove->droidType == DROID_SENSOR)
 		{
-			removeObjectFromFuncList(apsSensorList, (BASE_OBJECT*)psDroidToRemove, 0);
+			removeObjectFromFuncList(worldObjectState.sensors, (BASE_OBJECT*)psDroidToRemove, 0);
 		}
 		psDroidToRemove->died = NOT_CURRENT_LIST;
 	}
-	else if (&pList[psDroidToRemove->player] == &mission.apsDroidLists[psDroidToRemove->player])
+	else if (&pList[psDroidToRemove->player] == &mission.worldObjectState.droids[psDroidToRemove->player])
 	{
 		if (psDroidToRemove->droidType == DROID_SENSOR)
 		{
-			removeObjectFromFuncList(mission.apsSensorList, (BASE_OBJECT*)psDroidToRemove, 0);
+			removeObjectFromFuncList(mission.worldObjectState.sensors, (BASE_OBJECT*)psDroidToRemove, 0);
 		}
 	}
 }
@@ -637,7 +629,7 @@ void removeDroid(DROID* psDroidToRemove, PerPlayerDroidLists& pList)
 /*Removes all droids that may be stored in the mission lists*/
 void freeAllMissionDroids()
 {
-	freeAllEntitiesImpl<DROID, MAX_PLAYERS>(mission.apsDroidLists);
+	freeAllEntitiesImpl<DROID, MAX_PLAYERS>(mission.worldObjectState.droids);
 }
 
 /*Removes all droids that may be stored in the limbo lists*/
@@ -651,15 +643,15 @@ void freeAllLimboDroids()
 /* add the structure to the Structure Lists */
 void addStructure(STRUCTURE *psStructToAdd)
 {
-	addObjectToList(apsStructLists, psStructToAdd, psStructToAdd->player);
+	addObjectToList(worldObjectState.structures, psStructToAdd, psStructToAdd->player);
 	if (psStructToAdd->pStructureType->pSensor
 	    && psStructToAdd->pStructureType->pSensor->location == LOC_TURRET)
 	{
-		addObjectToFuncList(apsSensorList, (BASE_OBJECT *)psStructToAdd, 0);
+		addObjectToFuncList(worldObjectState.sensors, (BASE_OBJECT *)psStructToAdd, 0);
 	}
 	else if (psStructToAdd->pStructureType->type == REF_RESOURCE_EXTRACTOR)
 	{
-		addObjectToFuncList(apsExtractorLists, psStructToAdd, psStructToAdd->player);
+		addObjectToFuncList(worldObjectState.extractors, psStructToAdd, psStructToAdd->player);
 	}
 }
 
@@ -676,11 +668,11 @@ void killStruct(STRUCTURE *psBuilding)
 	if (psBuilding->pStructureType->pSensor
 	    && psBuilding->pStructureType->pSensor->location == LOC_TURRET)
 	{
-		removeObjectFromFuncList(apsSensorList, (BASE_OBJECT *)psBuilding, 0);
+		removeObjectFromFuncList(worldObjectState.sensors, (BASE_OBJECT *)psBuilding, 0);
 	}
 	else if (psBuilding->pStructureType->type == REF_RESOURCE_EXTRACTOR)
 	{
-		removeObjectFromFuncList(apsExtractorLists, psBuilding, psBuilding->player);
+		removeObjectFromFuncList(worldObjectState.extractors, psBuilding, psBuilding->player);
 	}
 
 	for (i = 0; i < MAX_WEAPONS; i++)
@@ -720,13 +712,13 @@ void killStruct(STRUCTURE *psBuilding)
 		}
 	}
 
-	destroyObject(apsStructLists, psBuilding);
+	destroyObject(worldObjectState.structures, psBuilding);
 }
 
 /* Remove heapall structures */
 void freeAllStructs()
 {
-	freeAllEntitiesImpl<STRUCTURE, MAX_PLAYERS>(apsStructLists);
+	freeAllEntitiesImpl<STRUCTURE, MAX_PLAYERS>(worldObjectState.structures);
 }
 
 /*Remove a single Structure from a list*/
@@ -740,11 +732,11 @@ void removeStructureFromList(STRUCTURE *psStructToRemove, PerPlayerStructureList
 	if (psStructToRemove->pStructureType->pSensor
 	    && psStructToRemove->pStructureType->pSensor->location == LOC_TURRET)
 	{
-		removeObjectFromFuncList(apsSensorList, (BASE_OBJECT *)psStructToRemove, 0);
+		removeObjectFromFuncList(worldObjectState.sensors, (BASE_OBJECT *)psStructToRemove, 0);
 	}
 	else if (psStructToRemove->pStructureType->type == REF_RESOURCE_EXTRACTOR)
 	{
-		removeObjectFromFuncList(apsExtractorLists, psStructToRemove, psStructToRemove->player);
+		removeObjectFromFuncList(worldObjectState.extractors, psStructToRemove, psStructToRemove->player);
 	}
 }
 
@@ -753,10 +745,10 @@ void removeStructureFromList(STRUCTURE *psStructToRemove, PerPlayerStructureList
 /* add the feature to the Feature Lists */
 void addFeature(FEATURE *psFeatureToAdd)
 {
-	addObjectToList(apsFeatureList, psFeatureToAdd, 0);
+	addObjectToList(worldObjectState.features, psFeatureToAdd, 0);
 	if (psFeatureToAdd->psStats->subType == FEAT_OIL_RESOURCE)
 	{
-		addObjectToFuncList(apsOilList, psFeatureToAdd, 0);
+		addObjectToFuncList(worldObjectState.oils, psFeatureToAdd, 0);
 	}
 }
 
@@ -768,18 +760,18 @@ void killFeature(FEATURE *psDel)
 	ASSERT(psDel->type == OBJ_FEATURE,
 	       "killFeature: pointer is not a feature");
 	psDel->player = 0;
-	destroyObject(apsFeatureList, psDel);
+	destroyObject(worldObjectState.features, psDel);
 
 	if (psDel->psStats->subType == FEAT_OIL_RESOURCE)
 	{
-		removeObjectFromFuncList(apsOilList, psDel, 0);
+		removeObjectFromFuncList(worldObjectState.oils, psDel, 0);
 	}
 }
 
 /* Remove all features */
 void freeAllFeatures()
 {
-	freeAllEntitiesImpl<FEATURE, 1>(apsFeatureList);
+	freeAllEntitiesImpl<FEATURE, 1>(worldObjectState.features);
 }
 
 /**************************  FLAG_POSITION ********************************/
@@ -830,7 +822,7 @@ void addFlagPositionToList(FLAG_POSITION *psFlagPosToAdd, PerPlayerFlagPositionL
 /* add the Flag Position to the Flag Position Lists */
 void addFlagPosition(FLAG_POSITION *psFlagPosToAdd)
 {
-	addFlagPositionToList(psFlagPosToAdd, apsFlagPosLists);
+	addFlagPositionToList(psFlagPosToAdd, worldObjectState.flags);
 }
 
 // Remove it from the list, but don't delete it!
@@ -839,7 +831,7 @@ static bool removeFlagPositionFromList(FLAG_POSITION *psRemove)
 	ASSERT_OR_RETURN(false, psRemove != nullptr, "Invalid Flag Position pointer");
 	ASSERT_OR_RETURN(false, psRemove->player < MAX_PLAYERS, "Invalid Flag Position player: %" PRIu32, psRemove->player);
 
-	auto& flagPosList = apsFlagPosLists[psRemove->player];
+	auto& flagPosList = worldObjectState.flags[psRemove->player];
 	auto it = std::find(flagPosList.begin(), flagPosList.end(), psRemove);
 	if (it != flagPosList.end())
 	{
@@ -880,12 +872,12 @@ void freeAllFlagPositions()
 {
 	for (uint32_t player = 0; player < MAX_PLAYERS; player++)
 	{
-		for (const auto& flagPos : apsFlagPosLists[player])
+		for (const auto& flagPos : worldObjectState.flags[player])
 		{
 			ASSERT(player == flagPos->player, "Player mismatch? (flagPos->player == %" PRIu32 ", expecting: %d", flagPos->player, player);
 			free(flagPos);
 		}
-		apsFlagPosLists[player].clear();
+		worldObjectState.flags[player].clear();
 	}
 }
 
@@ -905,7 +897,7 @@ void checkFactoryFlags()
 			factoryDeliveryPointCheck[type].clear();
 		}
 
-		for (const auto& flagPos : apsFlagPosLists[player])
+		for (const auto& flagPos : worldObjectState.flags[player])
 		{
 			if ((flagPos->type == POS_DELIVERY) &&//check this is attached to a unique factory
 				(flagPos->factoryType != REPAIR_FLAG))
@@ -960,12 +952,12 @@ BASE_OBJECT *getBaseObjFromData(unsigned id, unsigned player, OBJECT_TYPE type)
 	{
 	case OBJ_DROID:
 		{
-			auto pDroid = getBaseObjFromDroidId(apsDroidLists[player], id);
+			auto pDroid = getBaseObjFromDroidId(worldObjectState.droids[player], id);
 			if (pDroid)
 			{
 				return pDroid;
 			}
-			pDroid = getBaseObjFromDroidId(mission.apsDroidLists[player], id);
+			pDroid = getBaseObjFromDroidId(mission.worldObjectState.droids[player], id);
 			if (pDroid)
 			{
 				return pDroid;
@@ -982,12 +974,12 @@ BASE_OBJECT *getBaseObjFromData(unsigned id, unsigned player, OBJECT_TYPE type)
 		}
 	case OBJ_STRUCTURE:
 		{
-			auto pStruct = getBaseObjFromId(apsStructLists[player], id);
+			auto pStruct = getBaseObjFromId(worldObjectState.structures[player], id);
 			if (pStruct)
 			{
 				return pStruct;
 			}
-			pStruct = getBaseObjFromId(mission.apsStructLists[player], id);
+			pStruct = getBaseObjFromId(mission.worldObjectState.structures[player], id);
 			if (pStruct)
 			{
 				return pStruct;
@@ -996,12 +988,12 @@ BASE_OBJECT *getBaseObjFromData(unsigned id, unsigned player, OBJECT_TYPE type)
 		}
 	case OBJ_FEATURE:
 		{
-			auto pFeat = getBaseObjFromId(apsFeatureList[0], id);
+			auto pFeat = getBaseObjFromId(worldObjectState.features[0], id);
 			if (pFeat)
 			{
 				return pFeat;
 			}
-			pFeat = getBaseObjFromId(mission.apsFeatureList[0], id);
+			pFeat = getBaseObjFromId(mission.worldObjectState.features[0], id);
 			if (pFeat)
 			{
 				return pFeat;
@@ -1069,7 +1061,7 @@ UDWORD getRepairIdFromFlag(const FLAG_POSITION *psFlag)
 		{
 		case 0:
 		{
-			auto id = getRepairIdFromFlagSingleList(psFlag, player, apsStructLists[player]);
+			auto id = getRepairIdFromFlagSingleList(psFlag, player, worldObjectState.structures[player]);
 			if (id != UDWORD_MAX)
 			{
 				return id;
@@ -1078,7 +1070,7 @@ UDWORD getRepairIdFromFlag(const FLAG_POSITION *psFlag)
 		}
 		case 1:
 		{
-			auto id = getRepairIdFromFlagSingleList(psFlag, player, mission.apsStructLists[player]);
+			auto id = getRepairIdFromFlagSingleList(psFlag, player, mission.worldObjectState.structures[player]);
 			if (id != UDWORD_MAX)
 			{
 				return id;
@@ -1102,7 +1094,7 @@ static void objListIntegCheck()
 
 	for (player = 0; player < MAX_PLAYERS; player += 1)
 	{
-		for (const DROID* psCurr : apsDroidLists[player])
+		for (const DROID* psCurr : worldObjectState.droids[player])
 		{
 			ASSERT(psCurr->type == OBJ_DROID &&
 			       (SDWORD)psCurr->player == player,
@@ -1112,7 +1104,7 @@ static void objListIntegCheck()
 	}
 	for (player = 0; player < MAX_PLAYERS; player += 1)
 	{
-		for (const STRUCTURE* psStruct : apsStructLists[player])
+		for (const STRUCTURE* psStruct : worldObjectState.structures[player])
 		{
 			ASSERT(psStruct->type == OBJ_STRUCTURE &&
 			       (SDWORD)psStruct->player == player,
@@ -1120,7 +1112,7 @@ static void objListIntegCheck()
 			       objInfo(psStruct), (void*)psStruct, player, (int)psStruct->player);
 		}
 	}
-	for (const BASE_OBJECT* obj : apsFeatureList[0])
+	for (const BASE_OBJECT* obj : worldObjectState.features[0])
 	{
 		ASSERT(obj->type == OBJ_FEATURE,
 		       "objListIntegCheck: misplaced object in the feature list");
@@ -1140,7 +1132,7 @@ void objCount(int *droids, int *structures, int *features)
 
 	for (int i = 0; i < MAX_PLAYERS; i++)
 	{
-		for (const DROID *psDroid : apsDroidLists[i])
+		for (const DROID *psDroid : worldObjectState.droids[i])
 		{
 			(*droids)++;
 			if (psDroid->isTransporter() && psDroid->psGroup && !psDroid->psGroup->psList.empty())
@@ -1149,8 +1141,8 @@ void objCount(int *droids, int *structures, int *features)
 			}
 		}
 
-		*structures += apsStructLists[i].size();
+		*structures += worldObjectState.structures[i].size();
 	}
 
-	*features += apsFeatureList[0].size();
+	*features += worldObjectState.features[0].size();
 }

--- a/src/objmem.cpp
+++ b/src/objmem.cpp
@@ -56,9 +56,6 @@
 uint32_t                unsynchObjID;
 uint32_t                synchObjID;
 
-/* The lists of objects allocated */
-WorldObjectState worldObjectState;
-
 /* The list of destroyed objects */
 DestroyedObjectsList psDestroyedObj;
 
@@ -239,11 +236,11 @@ static bool checkReferences(BASE_OBJECT *psVictim)
 {
 	for (unsigned plr = 0; plr < MAX_PLAYERS; ++plr)
 	{
-		if (!checkPlrStructReferences(psVictim, worldObjectState.structures)) { return false; }
-		if (!checkPlrStructReferences(psVictim, mission.worldObjectState.structures)) { return false; }
+		if (!checkPlrStructReferences(psVictim, gameWorld.objects.structures)) { return false; }
+		if (!checkPlrStructReferences(psVictim, mission.gameWorld.objects.structures)) { return false; }
 
-		if (!checkPlrDroidReferences(psVictim, worldObjectState.droids)) { return false; }
-		if (!checkPlrDroidReferences(psVictim, mission.worldObjectState.droids)) { return false; }
+		if (!checkPlrDroidReferences(psVictim, gameWorld.objects.droids)) { return false; }
+		if (!checkPlrDroidReferences(psVictim, mission.gameWorld.objects.droids)) { return false; }
 		if (!checkPlrDroidReferences(psVictim, apsLimboDroids)) { return false; }
 	}
 	return true;
@@ -474,12 +471,12 @@ void addDroid(DROID *psDroidToAdd, PerPlayerDroidLists& pList)
 	/* Whenever a droid gets added to a list other than the current list
 	 * its died flag is set to NOT_CURRENT_LIST so that anything targetting
 	 * it will cancel itself - HACK?! */
-	if (&pList[psDroidToAdd->player] == &worldObjectState.droids[psDroidToAdd->player])
+	if (&pList[psDroidToAdd->player] == &gameWorld.objects.droids[psDroidToAdd->player])
 	{
 		psDroidToAdd->died = false;
 		if (psDroidToAdd->droidType == DROID_SENSOR)
 		{
-			addObjectToFuncList(worldObjectState.sensors, (BASE_OBJECT *)psDroidToAdd, 0);
+			addObjectToFuncList(gameWorld.objects.sensors, (BASE_OBJECT *)psDroidToAdd, 0);
 		}
 
 		// commanders have to get their group back if not already loaded
@@ -489,11 +486,11 @@ void addDroid(DROID *psDroidToAdd, PerPlayerDroidLists& pList)
 			psGroup->add(psDroidToAdd);
 		}
 	}
-	else if (&pList[psDroidToAdd->player] == &mission.worldObjectState.droids[psDroidToAdd->player])
+	else if (&pList[psDroidToAdd->player] == &mission.gameWorld.objects.droids[psDroidToAdd->player])
 	{
 		if (psDroidToAdd->droidType == DROID_SENSOR)
 		{
-			addObjectToFuncList(mission.worldObjectState.sensors, (BASE_OBJECT *)psDroidToAdd, 0);
+			addObjectToFuncList(mission.gameWorld.objects.sensors, (BASE_OBJECT *)psDroidToAdd, 0);
 		}
 	}
 }
@@ -516,10 +513,10 @@ void killDroid(DROID *psDel)
 	setDroidBase(psDel, nullptr);
 	if (psDel->droidType == DROID_SENSOR)
 	{
-		removeObjectFromFuncList(worldObjectState.sensors, (BASE_OBJECT *)psDel, 0);
+		removeObjectFromFuncList(gameWorld.objects.sensors, (BASE_OBJECT *)psDel, 0);
 	}
 
-	destroyObject(worldObjectState.droids, psDel);
+	destroyObject(gameWorld.objects.droids, psDel);
 }
 
 template <typename EntityType>
@@ -596,7 +593,7 @@ static void freeAllEntitiesImpl(PerPlayerObjectLists<Entity, PlayerCount>& entit
 /* Remove all droids */
 void freeAllDroids()
 {
-	freeAllEntitiesImpl<DROID, MAX_PLAYERS>(worldObjectState.droids);
+	freeAllEntitiesImpl<DROID, MAX_PLAYERS>(gameWorld.objects.droids);
 }
 
 /*Remove a single Droid from a list*/
@@ -609,19 +606,19 @@ void removeDroid(DROID* psDroidToRemove, PerPlayerDroidLists& pList)
 	/* Whenever a droid is removed from the current list its died
 	 * flag is set to NOT_CURRENT_LIST so that anything targetting
 	 * it will cancel itself, and we know it is not really on the map. */
-	if (&pList[psDroidToRemove->player] == &worldObjectState.droids[psDroidToRemove->player])
+	if (&pList[psDroidToRemove->player] == &gameWorld.objects.droids[psDroidToRemove->player])
 	{
 		if (psDroidToRemove->droidType == DROID_SENSOR)
 		{
-			removeObjectFromFuncList(worldObjectState.sensors, (BASE_OBJECT*)psDroidToRemove, 0);
+			removeObjectFromFuncList(gameWorld.objects.sensors, (BASE_OBJECT*)psDroidToRemove, 0);
 		}
 		psDroidToRemove->died = NOT_CURRENT_LIST;
 	}
-	else if (&pList[psDroidToRemove->player] == &mission.worldObjectState.droids[psDroidToRemove->player])
+	else if (&pList[psDroidToRemove->player] == &mission.gameWorld.objects.droids[psDroidToRemove->player])
 	{
 		if (psDroidToRemove->droidType == DROID_SENSOR)
 		{
-			removeObjectFromFuncList(mission.worldObjectState.sensors, (BASE_OBJECT*)psDroidToRemove, 0);
+			removeObjectFromFuncList(mission.gameWorld.objects.sensors, (BASE_OBJECT*)psDroidToRemove, 0);
 		}
 	}
 }
@@ -629,7 +626,7 @@ void removeDroid(DROID* psDroidToRemove, PerPlayerDroidLists& pList)
 /*Removes all droids that may be stored in the mission lists*/
 void freeAllMissionDroids()
 {
-	freeAllEntitiesImpl<DROID, MAX_PLAYERS>(mission.worldObjectState.droids);
+	freeAllEntitiesImpl<DROID, MAX_PLAYERS>(mission.gameWorld.objects.droids);
 }
 
 /*Removes all droids that may be stored in the limbo lists*/
@@ -643,15 +640,15 @@ void freeAllLimboDroids()
 /* add the structure to the Structure Lists */
 void addStructure(STRUCTURE *psStructToAdd)
 {
-	addObjectToList(worldObjectState.structures, psStructToAdd, psStructToAdd->player);
+	addObjectToList(gameWorld.objects.structures, psStructToAdd, psStructToAdd->player);
 	if (psStructToAdd->pStructureType->pSensor
 	    && psStructToAdd->pStructureType->pSensor->location == LOC_TURRET)
 	{
-		addObjectToFuncList(worldObjectState.sensors, (BASE_OBJECT *)psStructToAdd, 0);
+		addObjectToFuncList(gameWorld.objects.sensors, (BASE_OBJECT *)psStructToAdd, 0);
 	}
 	else if (psStructToAdd->pStructureType->type == REF_RESOURCE_EXTRACTOR)
 	{
-		addObjectToFuncList(worldObjectState.extractors, psStructToAdd, psStructToAdd->player);
+		addObjectToFuncList(gameWorld.objects.extractors, psStructToAdd, psStructToAdd->player);
 	}
 }
 
@@ -668,11 +665,11 @@ void killStruct(STRUCTURE *psBuilding)
 	if (psBuilding->pStructureType->pSensor
 	    && psBuilding->pStructureType->pSensor->location == LOC_TURRET)
 	{
-		removeObjectFromFuncList(worldObjectState.sensors, (BASE_OBJECT *)psBuilding, 0);
+		removeObjectFromFuncList(gameWorld.objects.sensors, (BASE_OBJECT *)psBuilding, 0);
 	}
 	else if (psBuilding->pStructureType->type == REF_RESOURCE_EXTRACTOR)
 	{
-		removeObjectFromFuncList(worldObjectState.extractors, psBuilding, psBuilding->player);
+		removeObjectFromFuncList(gameWorld.objects.extractors, psBuilding, psBuilding->player);
 	}
 
 	for (i = 0; i < MAX_WEAPONS; i++)
@@ -712,13 +709,13 @@ void killStruct(STRUCTURE *psBuilding)
 		}
 	}
 
-	destroyObject(worldObjectState.structures, psBuilding);
+	destroyObject(gameWorld.objects.structures, psBuilding);
 }
 
 /* Remove heapall structures */
 void freeAllStructs()
 {
-	freeAllEntitiesImpl<STRUCTURE, MAX_PLAYERS>(worldObjectState.structures);
+	freeAllEntitiesImpl<STRUCTURE, MAX_PLAYERS>(gameWorld.objects.structures);
 }
 
 /*Remove a single Structure from a list*/
@@ -732,11 +729,11 @@ void removeStructureFromList(STRUCTURE *psStructToRemove, PerPlayerStructureList
 	if (psStructToRemove->pStructureType->pSensor
 	    && psStructToRemove->pStructureType->pSensor->location == LOC_TURRET)
 	{
-		removeObjectFromFuncList(worldObjectState.sensors, (BASE_OBJECT *)psStructToRemove, 0);
+		removeObjectFromFuncList(gameWorld.objects.sensors, (BASE_OBJECT *)psStructToRemove, 0);
 	}
 	else if (psStructToRemove->pStructureType->type == REF_RESOURCE_EXTRACTOR)
 	{
-		removeObjectFromFuncList(worldObjectState.extractors, psStructToRemove, psStructToRemove->player);
+		removeObjectFromFuncList(gameWorld.objects.extractors, psStructToRemove, psStructToRemove->player);
 	}
 }
 
@@ -745,10 +742,10 @@ void removeStructureFromList(STRUCTURE *psStructToRemove, PerPlayerStructureList
 /* add the feature to the Feature Lists */
 void addFeature(FEATURE *psFeatureToAdd)
 {
-	addObjectToList(worldObjectState.features, psFeatureToAdd, 0);
+	addObjectToList(gameWorld.objects.features, psFeatureToAdd, 0);
 	if (psFeatureToAdd->psStats->subType == FEAT_OIL_RESOURCE)
 	{
-		addObjectToFuncList(worldObjectState.oils, psFeatureToAdd, 0);
+		addObjectToFuncList(gameWorld.objects.oils, psFeatureToAdd, 0);
 	}
 }
 
@@ -760,18 +757,18 @@ void killFeature(FEATURE *psDel)
 	ASSERT(psDel->type == OBJ_FEATURE,
 	       "killFeature: pointer is not a feature");
 	psDel->player = 0;
-	destroyObject(worldObjectState.features, psDel);
+	destroyObject(gameWorld.objects.features, psDel);
 
 	if (psDel->psStats->subType == FEAT_OIL_RESOURCE)
 	{
-		removeObjectFromFuncList(worldObjectState.oils, psDel, 0);
+		removeObjectFromFuncList(gameWorld.objects.oils, psDel, 0);
 	}
 }
 
 /* Remove all features */
 void freeAllFeatures()
 {
-	freeAllEntitiesImpl<FEATURE, 1>(worldObjectState.features);
+	freeAllEntitiesImpl<FEATURE, 1>(gameWorld.objects.features);
 }
 
 /**************************  FLAG_POSITION ********************************/
@@ -822,7 +819,7 @@ void addFlagPositionToList(FLAG_POSITION *psFlagPosToAdd, PerPlayerFlagPositionL
 /* add the Flag Position to the Flag Position Lists */
 void addFlagPosition(FLAG_POSITION *psFlagPosToAdd)
 {
-	addFlagPositionToList(psFlagPosToAdd, worldObjectState.flags);
+	addFlagPositionToList(psFlagPosToAdd, gameWorld.objects.flags);
 }
 
 // Remove it from the list, but don't delete it!
@@ -831,7 +828,7 @@ static bool removeFlagPositionFromList(FLAG_POSITION *psRemove)
 	ASSERT_OR_RETURN(false, psRemove != nullptr, "Invalid Flag Position pointer");
 	ASSERT_OR_RETURN(false, psRemove->player < MAX_PLAYERS, "Invalid Flag Position player: %" PRIu32, psRemove->player);
 
-	auto& flagPosList = worldObjectState.flags[psRemove->player];
+	auto& flagPosList = gameWorld.objects.flags[psRemove->player];
 	auto it = std::find(flagPosList.begin(), flagPosList.end(), psRemove);
 	if (it != flagPosList.end())
 	{
@@ -872,12 +869,12 @@ void freeAllFlagPositions()
 {
 	for (uint32_t player = 0; player < MAX_PLAYERS; player++)
 	{
-		for (const auto& flagPos : worldObjectState.flags[player])
+		for (const auto& flagPos : gameWorld.objects.flags[player])
 		{
 			ASSERT(player == flagPos->player, "Player mismatch? (flagPos->player == %" PRIu32 ", expecting: %d", flagPos->player, player);
 			free(flagPos);
 		}
-		worldObjectState.flags[player].clear();
+		gameWorld.objects.flags[player].clear();
 	}
 }
 
@@ -897,7 +894,7 @@ void checkFactoryFlags()
 			factoryDeliveryPointCheck[type].clear();
 		}
 
-		for (const auto& flagPos : worldObjectState.flags[player])
+		for (const auto& flagPos : gameWorld.objects.flags[player])
 		{
 			if ((flagPos->type == POS_DELIVERY) &&//check this is attached to a unique factory
 				(flagPos->factoryType != REPAIR_FLAG))
@@ -952,12 +949,12 @@ BASE_OBJECT *getBaseObjFromData(unsigned id, unsigned player, OBJECT_TYPE type)
 	{
 	case OBJ_DROID:
 		{
-			auto pDroid = getBaseObjFromDroidId(worldObjectState.droids[player], id);
+			auto pDroid = getBaseObjFromDroidId(gameWorld.objects.droids[player], id);
 			if (pDroid)
 			{
 				return pDroid;
 			}
-			pDroid = getBaseObjFromDroidId(mission.worldObjectState.droids[player], id);
+			pDroid = getBaseObjFromDroidId(mission.gameWorld.objects.droids[player], id);
 			if (pDroid)
 			{
 				return pDroid;
@@ -974,12 +971,12 @@ BASE_OBJECT *getBaseObjFromData(unsigned id, unsigned player, OBJECT_TYPE type)
 		}
 	case OBJ_STRUCTURE:
 		{
-			auto pStruct = getBaseObjFromId(worldObjectState.structures[player], id);
+			auto pStruct = getBaseObjFromId(gameWorld.objects.structures[player], id);
 			if (pStruct)
 			{
 				return pStruct;
 			}
-			pStruct = getBaseObjFromId(mission.worldObjectState.structures[player], id);
+			pStruct = getBaseObjFromId(mission.gameWorld.objects.structures[player], id);
 			if (pStruct)
 			{
 				return pStruct;
@@ -988,12 +985,12 @@ BASE_OBJECT *getBaseObjFromData(unsigned id, unsigned player, OBJECT_TYPE type)
 		}
 	case OBJ_FEATURE:
 		{
-			auto pFeat = getBaseObjFromId(worldObjectState.features[0], id);
+			auto pFeat = getBaseObjFromId(gameWorld.objects.features[0], id);
 			if (pFeat)
 			{
 				return pFeat;
 			}
-			pFeat = getBaseObjFromId(mission.worldObjectState.features[0], id);
+			pFeat = getBaseObjFromId(mission.gameWorld.objects.features[0], id);
 			if (pFeat)
 			{
 				return pFeat;
@@ -1061,7 +1058,7 @@ UDWORD getRepairIdFromFlag(const FLAG_POSITION *psFlag)
 		{
 		case 0:
 		{
-			auto id = getRepairIdFromFlagSingleList(psFlag, player, worldObjectState.structures[player]);
+			auto id = getRepairIdFromFlagSingleList(psFlag, player, gameWorld.objects.structures[player]);
 			if (id != UDWORD_MAX)
 			{
 				return id;
@@ -1070,7 +1067,7 @@ UDWORD getRepairIdFromFlag(const FLAG_POSITION *psFlag)
 		}
 		case 1:
 		{
-			auto id = getRepairIdFromFlagSingleList(psFlag, player, mission.worldObjectState.structures[player]);
+			auto id = getRepairIdFromFlagSingleList(psFlag, player, mission.gameWorld.objects.structures[player]);
 			if (id != UDWORD_MAX)
 			{
 				return id;
@@ -1094,7 +1091,7 @@ static void objListIntegCheck()
 
 	for (player = 0; player < MAX_PLAYERS; player += 1)
 	{
-		for (const DROID* psCurr : worldObjectState.droids[player])
+		for (const DROID* psCurr : gameWorld.objects.droids[player])
 		{
 			ASSERT(psCurr->type == OBJ_DROID &&
 			       (SDWORD)psCurr->player == player,
@@ -1104,7 +1101,7 @@ static void objListIntegCheck()
 	}
 	for (player = 0; player < MAX_PLAYERS; player += 1)
 	{
-		for (const STRUCTURE* psStruct : worldObjectState.structures[player])
+		for (const STRUCTURE* psStruct : gameWorld.objects.structures[player])
 		{
 			ASSERT(psStruct->type == OBJ_STRUCTURE &&
 			       (SDWORD)psStruct->player == player,
@@ -1112,7 +1109,7 @@ static void objListIntegCheck()
 			       objInfo(psStruct), (void*)psStruct, player, (int)psStruct->player);
 		}
 	}
-	for (const BASE_OBJECT* obj : worldObjectState.features[0])
+	for (const BASE_OBJECT* obj : gameWorld.objects.features[0])
 	{
 		ASSERT(obj->type == OBJ_FEATURE,
 		       "objListIntegCheck: misplaced object in the feature list");
@@ -1132,7 +1129,7 @@ void objCount(int *droids, int *structures, int *features)
 
 	for (int i = 0; i < MAX_PLAYERS; i++)
 	{
-		for (const DROID *psDroid : worldObjectState.droids[i])
+		for (const DROID *psDroid : gameWorld.objects.droids[i])
 		{
 			(*droids)++;
 			if (psDroid->isTransporter() && psDroid->psGroup && !psDroid->psGroup->psList.empty())
@@ -1141,8 +1138,8 @@ void objCount(int *droids, int *structures, int *features)
 			}
 		}
 
-		*structures += worldObjectState.structures[i].size();
+		*structures += gameWorld.objects.structures[i].size();
 	}
 
-	*features += worldObjectState.features[0].size();
+	*features += gameWorld.objects.features[0].size();
 }

--- a/src/objmem.h
+++ b/src/objmem.h
@@ -25,13 +25,9 @@
 #define __INCLUDED_SRC_OBJMEM_H__
 
 #include "objectdef.h"
-
-#include "world_object_state.h"
+#include "object_lists_types.h"
 
 #include <list>
-
-/* The lists of objects allocated */
-extern WorldObjectState worldObjectState;
 
 /* The list of destroyed objects */
 using DestroyedObjectsList = std::list<BASE_OBJECT*>;

--- a/src/objmem.h
+++ b/src/objmem.h
@@ -26,40 +26,12 @@
 
 #include "objectdef.h"
 
-#include <array>
+#include "world_object_state.h"
+
 #include <list>
 
 /* The lists of objects allocated */
-template <typename ObjectType, unsigned PlayerCount>
-using PerPlayerObjectLists = std::array<std::list<ObjectType*>, PlayerCount>;
-
-using PerPlayerDroidLists = PerPlayerObjectLists<DROID, MAX_PLAYERS>;
-using DroidList = typename PerPlayerDroidLists::value_type;
-extern PerPlayerDroidLists apsDroidLists;
-
-using PerPlayerStructureLists = PerPlayerObjectLists<STRUCTURE, MAX_PLAYERS>;
-using StructureList = typename PerPlayerStructureLists::value_type;
-extern PerPlayerStructureLists apsStructLists;
-
-using GlobalFeatureList = PerPlayerObjectLists<FEATURE, 1>;
-using FeatureList = typename GlobalFeatureList::value_type;
-extern GlobalFeatureList apsFeatureList;
-
-using PerPlayerFlagPositionLists = PerPlayerObjectLists<FLAG_POSITION, MAX_PLAYERS>;
-using FlagPositionList = typename PerPlayerFlagPositionLists::value_type;
-extern PerPlayerFlagPositionLists apsFlagPosLists;
-
-using PerPlayerExtractorLists = PerPlayerStructureLists;
-using ExtractorList = typename PerPlayerExtractorLists::value_type;
-extern PerPlayerExtractorLists apsExtractorLists;
-
-using GlobalSensorList = PerPlayerObjectLists<BASE_OBJECT, 1>;
-using SensorList = typename GlobalSensorList::value_type;
-extern GlobalSensorList apsSensorList;
-
-using GlobalOilList = PerPlayerObjectLists<FEATURE, 1>;
-using OilList = typename GlobalOilList::value_type;
-extern GlobalOilList apsOilList;
+extern WorldObjectState worldObjectState;
 
 /* The list of destroyed objects */
 using DestroyedObjectsList = std::list<BASE_OBJECT*>;

--- a/src/order.cpp
+++ b/src/order.cpp
@@ -38,6 +38,7 @@
 #include "map.h"
 #include "formationdef.h"
 #include "formation.h"
+#include "objmem.h"
 #include "projectile.h"
 #include "effects.h"	// for waypoint display
 #include "lib/gamelib/gtime.h"
@@ -1681,7 +1682,7 @@ void orderDroidBase(DROID *psDroid, DROID_ORDER_DATA *psOrder)
 		}
 		break;
 	case DORDER_RTB:
-		for (const STRUCTURE* psStruct : apsStructLists[psDroid->player])
+		for (const STRUCTURE* psStruct : worldObjectState.structures[psDroid->player])
 		{
 			if (psStruct->pStructureType->type == REF_HQ)
 			{
@@ -1867,7 +1868,7 @@ void orderDroidBase(DROID *psDroid, DROID_ORDER_DATA *psOrder)
 	case DORDER_RECYCLE:
 		psFactory = nullptr;
 		iFactoryDistSq = 0;
-		for (STRUCTURE* psStruct : apsStructLists[psDroid->player])
+		for (STRUCTURE* psStruct : worldObjectState.structures[psDroid->player])
 		{
 			// Look for nearest factory or repair facility
 			if (psStruct->pStructureType->type == REF_FACTORY || psStruct->pStructureType->type == REF_CYBORG_FACTORY
@@ -2569,7 +2570,7 @@ void orderSelectedLoc(uint32_t player, uint32_t x, uint32_t y, bool add)
 	// note that an order list graphic needs to be displayed
 	bOrderEffectDisplayed = false;
 
-	for (DROID* psCurr : apsDroidLists[player])
+	for (DROID* psCurr : worldObjectState.droids[player])
 	{
 		if (psCurr->selected)
 		{
@@ -2873,7 +2874,7 @@ static void orderPlayOrderObjAudio(UDWORD player, BASE_OBJECT *psObj)
 	ASSERT_PLAYER_OR_RETURN(, player);
 
 	/* loop over selected droids */
-	for (const DROID *psDroid : apsDroidLists[player])
+	for (const DROID *psDroid : worldObjectState.droids[player])
 	{
 		if (psDroid->selected)
 		{
@@ -2908,7 +2909,7 @@ void orderSelectedObjAdd(UDWORD player, BASE_OBJECT *psObj, bool add)
 	// note that an order list graphic needs to be displayed
 	bOrderEffectDisplayed = false;
 
-	for (DROID *psCurr : apsDroidLists[player])
+	for (DROID *psCurr : worldObjectState.droids[player])
 	{
 		if (psCurr->selected)
 		{
@@ -2966,7 +2967,7 @@ void orderSelectedStatsLocDir(UDWORD player, DROID_ORDER order, STRUCTURE_STATS 
 {
 	ASSERT_PLAYER_OR_RETURN(, player);
 
-	for (DROID *psCurr : apsDroidLists[player])
+	for (DROID *psCurr : worldObjectState.droids[player])
 	{
 		if (psCurr->selected && psCurr->isConstructionDroid())
 		{
@@ -2990,7 +2991,7 @@ void orderSelectedStatsTwoLocDir(UDWORD player, DROID_ORDER order, STRUCTURE_STA
 {
 	ASSERT_PLAYER_OR_RETURN(, player);
 
-	for (DROID *psCurr : apsDroidLists[player])
+	for (DROID *psCurr : worldObjectState.droids[player])
 	{
 		if (psCurr->selected)
 		{
@@ -3015,7 +3016,7 @@ DROID *FindATransporter(DROID const *embarkee)
 	DROID *bestDroid = nullptr;
 	unsigned bestDist = ~0u;
 
-	for (DROID *psDroid : apsDroidLists[embarkee->player])
+	for (DROID *psDroid : worldObjectState.droids[embarkee->player])
 	{
 		if ((isCyborg && psDroid->droidType == DROID_TRANSPORTER) || psDroid->droidType == DROID_SUPERTRANSPORTER)
 		{
@@ -3041,7 +3042,7 @@ static STRUCTURE *FindAFactory(UDWORD player, UDWORD factoryType)
 {
 	ASSERT_PLAYER_OR_RETURN(nullptr, player);
 
-	for (STRUCTURE *psStruct : apsStructLists[player])
+	for (STRUCTURE *psStruct : worldObjectState.structures[player])
 	{
 		if (psStruct->pStructureType->type == factoryType)
 		{
@@ -3058,7 +3059,7 @@ static STRUCTURE *FindARepairFacility(unsigned player)
 {
 	ASSERT_PLAYER_OR_RETURN(nullptr, player);
 
-	for (STRUCTURE *psStruct : apsStructLists[player])
+	for (STRUCTURE *psStruct : worldObjectState.structures[player])
 	{
 		if (psStruct->pStructureType->type == REF_REPAIR_FACILITY)
 		{
@@ -3298,7 +3299,7 @@ static bool secondaryCheckDamageLevelDeselect(DROID *psDroid, SECONDARY_STATE re
 		// Only deselect the droid if there is another droid selected.
 		if (psDroid->selected && selectedPlayer < MAX_PLAYERS)
 		{
-			for (DROID* psTempDroid : apsDroidLists[selectedPlayer])
+			for (DROID* psTempDroid : worldObjectState.droids[selectedPlayer])
 			{
 				if (psTempDroid != psDroid && psTempDroid->selected)
 				{
@@ -3391,7 +3392,7 @@ static inline RtrBestResult decideWhereToRepairAndBalance(DROID *psDroid)
 	vDroidPos.clear();
 	vDroid.clear();
 
-	for (STRUCTURE *psStruct : apsStructLists[psDroid->player])
+	for (STRUCTURE *psStruct : worldObjectState.structures[psDroid->player])
 	{
 		if (psStruct->pStructureType->type == REF_HQ)
 		{
@@ -3430,7 +3431,7 @@ static inline RtrBestResult decideWhereToRepairAndBalance(DROID *psDroid)
 		&& secondaryGetState(psDroid, DSO_ACCEPT_RETREP)))
 	{
 		// one of these lists is empty when on mission
-		DroidList* psdroidList = !apsDroidLists[psDroid->player].empty() ? &apsDroidLists[psDroid->player] : &mission.apsDroidLists[psDroid->player];
+		DroidList* psdroidList = !worldObjectState.droids[psDroid->player].empty() ? &worldObjectState.droids[psDroid->player] : &mission.worldObjectState.droids[psDroid->player];
 		if (!psdroidList->empty())
 		{
 			for (DROID* psCurr : *psdroidList)
@@ -3725,7 +3726,7 @@ bool secondarySetState(DROID *psDroid, SECONDARY_ORDER sec, SECONDARY_STATE Stat
 		if (psDroid->droidType == DROID_COMMAND)
 		{
 			// look for the factories
-			for (STRUCTURE* psStruct : apsStructLists[psDroid->player])
+			for (STRUCTURE* psStruct : worldObjectState.structures[psDroid->player])
 			{
 				factType = psStruct->pStructureType->type;
 				if (factType == REF_FACTORY ||
@@ -3974,7 +3975,7 @@ static void secondarySetGroupState(UDWORD player, UDWORD group, SECONDARY_ORDER 
 {
 	ASSERT_PLAYER_OR_RETURN(, player);
 
-	for (DROID *psCurr : apsDroidLists[player])
+	for (DROID *psCurr : worldObjectState.droids[player])
 	{
 		if (psCurr->group == group &&
 		    secondaryGetState(psCurr, sec) != state)
@@ -4003,7 +4004,7 @@ static SECONDARY_STATE secondaryGetAverageGroupState(UDWORD player, UDWORD group
 	// count the number of units for each state
 	numStates = 0;
 	memset(aStateCount, 0, sizeof(aStateCount));
-	for (const DROID* psCurr : apsDroidLists[player])
+	for (const DROID* psCurr : worldObjectState.droids[player])
 	{
 		if (psCurr->group == group)
 		{
@@ -4184,7 +4185,7 @@ void orderStructureObj(UDWORD player, BASE_OBJECT *psObj)
 {
 	ASSERT_PLAYER_OR_RETURN(, player);
 
-	for (STRUCTURE* psStruct : apsStructLists[player])
+	for (STRUCTURE* psStruct : worldObjectState.structures[player])
 	{
 		if (lasSatStructSelected(psStruct))
 		{

--- a/src/order.cpp
+++ b/src/order.cpp
@@ -745,7 +745,7 @@ bool orderUpdateDroid(DROID *psDroid)
 					yoffset = iCosR(angle, 1500);
 					angle -= DEG(10);
 				}
-				while (!worldOnMap(psDroid->order.pos.x + xoffset, psDroid->order.pos.y + yoffset));    // Don't try to fly off map.
+				while (!worldOnMap(worldMapState, psDroid->order.pos.x + xoffset, psDroid->order.pos.y + yoffset));    // Don't try to fly off map.
 				actionDroid(psDroid, DACTION_MOVE, psDroid->order.pos.x + xoffset, psDroid->order.pos.y + yoffset);
 			}
 
@@ -2297,7 +2297,7 @@ void orderDroidAddPending(DROID *psDroid, DROID_ORDER_DATA *psOrder)
 		{
 			position = psOrder->psObj->pos.xzy();
 		}
-		position.y = map_Height(position.x, position.z) + 32;
+		position.y = map_Height(worldMapState, position.x, position.z) + 32;
 		if (psOrder->psObj != nullptr && psOrder->psObj->sDisplay.imd != nullptr)
 		{
 			position.y += psOrder->psObj->sDisplay.imd->max.y;
@@ -2612,7 +2612,7 @@ static int highestQueuedModule(DroidOrder const &order, STRUCTURE const *structu
 		{
 			// Current order is weird, the DORDER_BUILDMODULE mutates into a DORDER_BUILD, and we use the order.pos instead of order.psObj.
 			// Also, might be DORDER_BUILD if selecting the module from the menu before clicking on the structure.
-			STRUCTURE *orderStructure = castStructure(worldTile(order.pos)->psObject);
+			STRUCTURE *orderStructure = castStructure(worldTile(worldMapState, order.pos)->psObject);
 			if (orderStructure == structure && (order.psStats == orderStructure->pStructureType || order.psStats == getModuleStat(orderStructure)))  // Order must be for this structure.
 			{
 				thisQueuedModule = nextModuleToBuild(structure, prevHighestQueuedModule);

--- a/src/order.cpp
+++ b/src/order.cpp
@@ -745,7 +745,7 @@ bool orderUpdateDroid(DROID *psDroid)
 					yoffset = iCosR(angle, 1500);
 					angle -= DEG(10);
 				}
-				while (!worldOnMap(worldMapState, psDroid->order.pos.x + xoffset, psDroid->order.pos.y + yoffset));    // Don't try to fly off map.
+				while (!worldOnMap(gameWorld.map, psDroid->order.pos.x + xoffset, psDroid->order.pos.y + yoffset));    // Don't try to fly off map.
 				actionDroid(psDroid, DACTION_MOVE, psDroid->order.pos.x + xoffset, psDroid->order.pos.y + yoffset);
 			}
 
@@ -1682,7 +1682,7 @@ void orderDroidBase(DROID *psDroid, DROID_ORDER_DATA *psOrder)
 		}
 		break;
 	case DORDER_RTB:
-		for (const STRUCTURE* psStruct : worldObjectState.structures[psDroid->player])
+		for (const STRUCTURE* psStruct : gameWorld.objects.structures[psDroid->player])
 		{
 			if (psStruct->pStructureType->type == REF_HQ)
 			{
@@ -1868,7 +1868,7 @@ void orderDroidBase(DROID *psDroid, DROID_ORDER_DATA *psOrder)
 	case DORDER_RECYCLE:
 		psFactory = nullptr;
 		iFactoryDistSq = 0;
-		for (STRUCTURE* psStruct : worldObjectState.structures[psDroid->player])
+		for (STRUCTURE* psStruct : gameWorld.objects.structures[psDroid->player])
 		{
 			// Look for nearest factory or repair facility
 			if (psStruct->pStructureType->type == REF_FACTORY || psStruct->pStructureType->type == REF_CYBORG_FACTORY
@@ -2297,7 +2297,7 @@ void orderDroidAddPending(DROID *psDroid, DROID_ORDER_DATA *psOrder)
 		{
 			position = psOrder->psObj->pos.xzy();
 		}
-		position.y = map_Height(worldMapState, position.x, position.z) + 32;
+		position.y = map_Height(gameWorld.map, position.x, position.z) + 32;
 		if (psOrder->psObj != nullptr && psOrder->psObj->sDisplay.imd != nullptr)
 		{
 			position.y += psOrder->psObj->sDisplay.imd->max.y;
@@ -2570,7 +2570,7 @@ void orderSelectedLoc(uint32_t player, uint32_t x, uint32_t y, bool add)
 	// note that an order list graphic needs to be displayed
 	bOrderEffectDisplayed = false;
 
-	for (DROID* psCurr : worldObjectState.droids[player])
+	for (DROID* psCurr : gameWorld.objects.droids[player])
 	{
 		if (psCurr->selected)
 		{
@@ -2612,7 +2612,7 @@ static int highestQueuedModule(DroidOrder const &order, STRUCTURE const *structu
 		{
 			// Current order is weird, the DORDER_BUILDMODULE mutates into a DORDER_BUILD, and we use the order.pos instead of order.psObj.
 			// Also, might be DORDER_BUILD if selecting the module from the menu before clicking on the structure.
-			STRUCTURE *orderStructure = castStructure(worldTile(worldMapState, order.pos)->psObject);
+			STRUCTURE *orderStructure = castStructure(worldTile(gameWorld.map, order.pos)->psObject);
 			if (orderStructure == structure && (order.psStats == orderStructure->pStructureType || order.psStats == getModuleStat(orderStructure)))  // Order must be for this structure.
 			{
 				thisQueuedModule = nextModuleToBuild(structure, prevHighestQueuedModule);
@@ -2874,7 +2874,7 @@ static void orderPlayOrderObjAudio(UDWORD player, BASE_OBJECT *psObj)
 	ASSERT_PLAYER_OR_RETURN(, player);
 
 	/* loop over selected droids */
-	for (const DROID *psDroid : worldObjectState.droids[player])
+	for (const DROID *psDroid : gameWorld.objects.droids[player])
 	{
 		if (psDroid->selected)
 		{
@@ -2909,7 +2909,7 @@ void orderSelectedObjAdd(UDWORD player, BASE_OBJECT *psObj, bool add)
 	// note that an order list graphic needs to be displayed
 	bOrderEffectDisplayed = false;
 
-	for (DROID *psCurr : worldObjectState.droids[player])
+	for (DROID *psCurr : gameWorld.objects.droids[player])
 	{
 		if (psCurr->selected)
 		{
@@ -2967,7 +2967,7 @@ void orderSelectedStatsLocDir(UDWORD player, DROID_ORDER order, STRUCTURE_STATS 
 {
 	ASSERT_PLAYER_OR_RETURN(, player);
 
-	for (DROID *psCurr : worldObjectState.droids[player])
+	for (DROID *psCurr : gameWorld.objects.droids[player])
 	{
 		if (psCurr->selected && psCurr->isConstructionDroid())
 		{
@@ -2991,7 +2991,7 @@ void orderSelectedStatsTwoLocDir(UDWORD player, DROID_ORDER order, STRUCTURE_STA
 {
 	ASSERT_PLAYER_OR_RETURN(, player);
 
-	for (DROID *psCurr : worldObjectState.droids[player])
+	for (DROID *psCurr : gameWorld.objects.droids[player])
 	{
 		if (psCurr->selected)
 		{
@@ -3016,7 +3016,7 @@ DROID *FindATransporter(DROID const *embarkee)
 	DROID *bestDroid = nullptr;
 	unsigned bestDist = ~0u;
 
-	for (DROID *psDroid : worldObjectState.droids[embarkee->player])
+	for (DROID *psDroid : gameWorld.objects.droids[embarkee->player])
 	{
 		if ((isCyborg && psDroid->droidType == DROID_TRANSPORTER) || psDroid->droidType == DROID_SUPERTRANSPORTER)
 		{
@@ -3042,7 +3042,7 @@ static STRUCTURE *FindAFactory(UDWORD player, UDWORD factoryType)
 {
 	ASSERT_PLAYER_OR_RETURN(nullptr, player);
 
-	for (STRUCTURE *psStruct : worldObjectState.structures[player])
+	for (STRUCTURE *psStruct : gameWorld.objects.structures[player])
 	{
 		if (psStruct->pStructureType->type == factoryType)
 		{
@@ -3059,7 +3059,7 @@ static STRUCTURE *FindARepairFacility(unsigned player)
 {
 	ASSERT_PLAYER_OR_RETURN(nullptr, player);
 
-	for (STRUCTURE *psStruct : worldObjectState.structures[player])
+	for (STRUCTURE *psStruct : gameWorld.objects.structures[player])
 	{
 		if (psStruct->pStructureType->type == REF_REPAIR_FACILITY)
 		{
@@ -3299,7 +3299,7 @@ static bool secondaryCheckDamageLevelDeselect(DROID *psDroid, SECONDARY_STATE re
 		// Only deselect the droid if there is another droid selected.
 		if (psDroid->selected && selectedPlayer < MAX_PLAYERS)
 		{
-			for (DROID* psTempDroid : worldObjectState.droids[selectedPlayer])
+			for (DROID* psTempDroid : gameWorld.objects.droids[selectedPlayer])
 			{
 				if (psTempDroid != psDroid && psTempDroid->selected)
 				{
@@ -3392,7 +3392,7 @@ static inline RtrBestResult decideWhereToRepairAndBalance(DROID *psDroid)
 	vDroidPos.clear();
 	vDroid.clear();
 
-	for (STRUCTURE *psStruct : worldObjectState.structures[psDroid->player])
+	for (STRUCTURE *psStruct : gameWorld.objects.structures[psDroid->player])
 	{
 		if (psStruct->pStructureType->type == REF_HQ)
 		{
@@ -3431,7 +3431,7 @@ static inline RtrBestResult decideWhereToRepairAndBalance(DROID *psDroid)
 		&& secondaryGetState(psDroid, DSO_ACCEPT_RETREP)))
 	{
 		// one of these lists is empty when on mission
-		DroidList* psdroidList = !worldObjectState.droids[psDroid->player].empty() ? &worldObjectState.droids[psDroid->player] : &mission.worldObjectState.droids[psDroid->player];
+		DroidList* psdroidList = !gameWorld.objects.droids[psDroid->player].empty() ? &gameWorld.objects.droids[psDroid->player] : &mission.gameWorld.objects.droids[psDroid->player];
 		if (!psdroidList->empty())
 		{
 			for (DROID* psCurr : *psdroidList)
@@ -3726,7 +3726,7 @@ bool secondarySetState(DROID *psDroid, SECONDARY_ORDER sec, SECONDARY_STATE Stat
 		if (psDroid->droidType == DROID_COMMAND)
 		{
 			// look for the factories
-			for (STRUCTURE* psStruct : worldObjectState.structures[psDroid->player])
+			for (STRUCTURE* psStruct : gameWorld.objects.structures[psDroid->player])
 			{
 				factType = psStruct->pStructureType->type;
 				if (factType == REF_FACTORY ||
@@ -3975,7 +3975,7 @@ static void secondarySetGroupState(UDWORD player, UDWORD group, SECONDARY_ORDER 
 {
 	ASSERT_PLAYER_OR_RETURN(, player);
 
-	for (DROID *psCurr : worldObjectState.droids[player])
+	for (DROID *psCurr : gameWorld.objects.droids[player])
 	{
 		if (psCurr->group == group &&
 		    secondaryGetState(psCurr, sec) != state)
@@ -4004,7 +4004,7 @@ static SECONDARY_STATE secondaryGetAverageGroupState(UDWORD player, UDWORD group
 	// count the number of units for each state
 	numStates = 0;
 	memset(aStateCount, 0, sizeof(aStateCount));
-	for (const DROID* psCurr : worldObjectState.droids[player])
+	for (const DROID* psCurr : gameWorld.objects.droids[player])
 	{
 		if (psCurr->group == group)
 		{
@@ -4185,7 +4185,7 @@ void orderStructureObj(UDWORD player, BASE_OBJECT *psObj)
 {
 	ASSERT_PLAYER_OR_RETURN(, player);
 
-	for (STRUCTURE* psStruct : worldObjectState.structures[player])
+	for (STRUCTURE* psStruct : gameWorld.objects.structures[player])
 	{
 		if (lasSatStructSelected(psStruct))
 		{

--- a/src/power.cpp
+++ b/src/power.cpp
@@ -255,11 +255,11 @@ StructureList* powerStructList(int player)
 	ASSERT_OR_RETURN(nullptr, player < MAX_PLAYERS, "Invalid player %d", player);
 	if (offWorldKeepLists)
 	{
-		return &mission.apsStructLists[player];
+		return &mission.worldObjectState.structures[player];
 	}
 	else
 	{
-		return &apsStructLists[player];
+		return &worldObjectState.structures[player];
 	}
 }
 

--- a/src/power.cpp
+++ b/src/power.cpp
@@ -255,11 +255,11 @@ StructureList* powerStructList(int player)
 	ASSERT_OR_RETURN(nullptr, player < MAX_PLAYERS, "Invalid player %d", player);
 	if (offWorldKeepLists)
 	{
-		return &mission.worldObjectState.structures[player];
+		return &mission.gameWorld.objects.structures[player];
 	}
 	else
 	{
-		return &worldObjectState.structures[player];
+		return &gameWorld.objects.structures[player];
 	}
 }
 

--- a/src/projectile.cpp
+++ b/src/projectile.cpp
@@ -59,6 +59,7 @@
 #include "random.h"
 #include "display3d.h"
 #include "profiling.h"
+#include "game_world.h"
 
 #include <algorithm>
 #include <functional>
@@ -817,17 +818,17 @@ static PROJECTILE* proj_InFlightFunc(PROJECTILE *psProj)
 					int flightTime = iHypot(delta.xy()) * GAME_TICKS_PER_SEC / psStats->flightSpeed;
 					psProj->dst += Vector3i(iSinCosR(targetDroid->sMove.moveDir, std::min<int>(targetDroid->sMove.speed, psStats->flightSpeed * 3 / 4) * flightTime / GAME_TICKS_PER_SEC), 0);
 				}
-				psProj->dst.x = clip(psProj->dst.x, 0, world_coord(worldMapState.width) - 1);
-				psProj->dst.y = clip(psProj->dst.y, 0, world_coord(worldMapState.height) - 1);
+				psProj->dst.x = clip(psProj->dst.x, 0, world_coord(gameWorld.map.width) - 1);
+				psProj->dst.y = clip(psProj->dst.y, 0, world_coord(gameWorld.map.height) - 1);
 			}
 			if (psStats->movementModel == MM_HOMINGINDIRECT)
 			{
 				if (psProj->psDest == nullptr)
 				{
-					psProj->dst.z = map_Height(worldMapState, psProj->pos.xy()) - 1;  // Target missing, so just home in on the ground under where the target was.
+					psProj->dst.z = map_Height(gameWorld.map, psProj->pos.xy()) - 1;  // Target missing, so just home in on the ground under where the target was.
 				}
 				int horizontalTargetDistance = iHypot((psProj->dst - psProj->pos).xy());
-				int terrainHeight = std::max(map_Height(worldMapState, psProj->pos.xy()), map_Height(worldMapState, psProj->pos.xy() + iSinCosR(iAtan2((psProj->dst - psProj->pos).xy()), psStats->flightSpeed * 2 * deltaProjectileTime / GAME_TICKS_PER_SEC)));
+				int terrainHeight = std::max(map_Height(gameWorld.map, psProj->pos.xy()), map_Height(gameWorld.map, psProj->pos.xy() + iSinCosR(iAtan2((psProj->dst - psProj->pos).xy()), psStats->flightSpeed * 2 * deltaProjectileTime / GAME_TICKS_PER_SEC)));
 				int desiredMinHeight = terrainHeight + std::min(horizontalTargetDistance / 4, HOMINGINDIRECT_HEIGHT_MIN);
 				int desiredMaxHeight = std::max(psProj->dst.z, terrainHeight + HOMINGINDIRECT_HEIGHT_MAX);
 				int heightError = psProj->pos.z - clip(psProj->pos.z, desiredMinHeight, desiredMaxHeight);
@@ -1133,7 +1134,7 @@ static void proj_ImpactFunc(PROJECTILE *psObj)
 		{
 			position.x = psObj->pos.x;
 			position.z = psObj->pos.y; // z = y [sic] intentional
-			position.y = map_Height(worldMapState, position.x, position.z);
+			position.y = map_Height(gameWorld.map, position.x, position.z);
 			effectGiveAuxVar(psStats->upgrade[psObj->player].periodicalDamageRadius);
 			effectGiveAuxVarSec(psStats->upgrade[psObj->player].periodicalDamageTime);
 			addEffect(&position, EFFECT_FIRE, FIRE_TYPE_LOCALISED, false, nullptr, 0, psObj->time);
@@ -1144,7 +1145,7 @@ static void proj_ImpactFunc(PROJECTILE *psObj)
 		{
 			position.x = psObj->pos.x;
 			position.z = psObj->pos.y;  // z = y [sic] intentional
-			position.y = map_Height(worldMapState, position.x, position.z);
+			position.y = map_Height(gameWorld.map, position.x, position.z);
 			addEffect(&position, EFFECT_SAT_LASER, SAT_LASER_STANDARD, false, nullptr, 0, psObj->time);
 
 			if (clipXY(psObj->pos.x, psObj->pos.y))
@@ -1156,7 +1157,7 @@ static void proj_ImpactFunc(PROJECTILE *psObj)
 
 	if (psStats->upgrade[psObj->player].periodicalDamageRadius && psStats->upgrade[psObj->player].periodicalDamageTime)
 	{
-		tileSetFire(worldMapState, psObj->pos.x, psObj->pos.y, psStats->upgrade[psObj->player].periodicalDamageTime);
+		tileSetFire(gameWorld.map, psObj->pos.x, psObj->pos.y, psStats->upgrade[psObj->player].periodicalDamageTime);
 	}
 
 	// Set the effects position and radius
@@ -1176,7 +1177,7 @@ static void proj_ImpactFunc(PROJECTILE *psObj)
 			EFFECT_TYPE facing = (psStats->facePlayer ? EXPLOSION_TYPE_SPECIFIED : EXPLOSION_TYPE_NOT_FACING);
 
 			// The graphic to show depends on if we hit water or not
-			if (terrainType(mapTile(worldMapState, map_coord(psObj->pos.x), map_coord(psObj->pos.y))) == TER_WATER)
+			if (terrainType(mapTile(gameWorld.map, map_coord(psObj->pos.x), map_coord(psObj->pos.y))) == TER_WATER)
 			{
 				imd = psStats->pWaterHitGraphic;
 			}
@@ -1399,7 +1400,7 @@ PROJECTILE* PROJECTILE::update()
 	psDamaged.erase(std::remove_if(psDamaged.begin(), psDamaged.end(), [](const BASE_OBJECT *psObj) { return ::isDead(psObj); }), psDamaged.end());
 
 	// This extra check fixes a crash in cam2, mission1
-	if (worldOnMap(worldMapState, psObj->pos.x, psObj->pos.y) == false)
+	if (worldOnMap(gameWorld.map, psObj->pos.x, psObj->pos.y) == false)
 	{
 		psObj->died = true;
 		return nullptr;

--- a/src/projectile.cpp
+++ b/src/projectile.cpp
@@ -824,10 +824,10 @@ static PROJECTILE* proj_InFlightFunc(PROJECTILE *psProj)
 			{
 				if (psProj->psDest == nullptr)
 				{
-					psProj->dst.z = map_Height(psProj->pos.xy()) - 1;  // Target missing, so just home in on the ground under where the target was.
+					psProj->dst.z = map_Height(worldMapState, psProj->pos.xy()) - 1;  // Target missing, so just home in on the ground under where the target was.
 				}
 				int horizontalTargetDistance = iHypot((psProj->dst - psProj->pos).xy());
-				int terrainHeight = std::max(map_Height(psProj->pos.xy()), map_Height(psProj->pos.xy() + iSinCosR(iAtan2((psProj->dst - psProj->pos).xy()), psStats->flightSpeed * 2 * deltaProjectileTime / GAME_TICKS_PER_SEC)));
+				int terrainHeight = std::max(map_Height(worldMapState, psProj->pos.xy()), map_Height(worldMapState, psProj->pos.xy() + iSinCosR(iAtan2((psProj->dst - psProj->pos).xy()), psStats->flightSpeed * 2 * deltaProjectileTime / GAME_TICKS_PER_SEC)));
 				int desiredMinHeight = terrainHeight + std::min(horizontalTargetDistance / 4, HOMINGINDIRECT_HEIGHT_MIN);
 				int desiredMaxHeight = std::max(psProj->dst.z, terrainHeight + HOMINGINDIRECT_HEIGHT_MAX);
 				int heightError = psProj->pos.z - clip(psProj->pos.z, desiredMinHeight, desiredMaxHeight);
@@ -1133,7 +1133,7 @@ static void proj_ImpactFunc(PROJECTILE *psObj)
 		{
 			position.x = psObj->pos.x;
 			position.z = psObj->pos.y; // z = y [sic] intentional
-			position.y = map_Height(position.x, position.z);
+			position.y = map_Height(worldMapState, position.x, position.z);
 			effectGiveAuxVar(psStats->upgrade[psObj->player].periodicalDamageRadius);
 			effectGiveAuxVarSec(psStats->upgrade[psObj->player].periodicalDamageTime);
 			addEffect(&position, EFFECT_FIRE, FIRE_TYPE_LOCALISED, false, nullptr, 0, psObj->time);
@@ -1144,7 +1144,7 @@ static void proj_ImpactFunc(PROJECTILE *psObj)
 		{
 			position.x = psObj->pos.x;
 			position.z = psObj->pos.y;  // z = y [sic] intentional
-			position.y = map_Height(position.x, position.z);
+			position.y = map_Height(worldMapState, position.x, position.z);
 			addEffect(&position, EFFECT_SAT_LASER, SAT_LASER_STANDARD, false, nullptr, 0, psObj->time);
 
 			if (clipXY(psObj->pos.x, psObj->pos.y))
@@ -1156,7 +1156,7 @@ static void proj_ImpactFunc(PROJECTILE *psObj)
 
 	if (psStats->upgrade[psObj->player].periodicalDamageRadius && psStats->upgrade[psObj->player].periodicalDamageTime)
 	{
-		tileSetFire(psObj->pos.x, psObj->pos.y, psStats->upgrade[psObj->player].periodicalDamageTime);
+		tileSetFire(worldMapState, psObj->pos.x, psObj->pos.y, psStats->upgrade[psObj->player].periodicalDamageTime);
 	}
 
 	// Set the effects position and radius
@@ -1176,7 +1176,7 @@ static void proj_ImpactFunc(PROJECTILE *psObj)
 			EFFECT_TYPE facing = (psStats->facePlayer ? EXPLOSION_TYPE_SPECIFIED : EXPLOSION_TYPE_NOT_FACING);
 
 			// The graphic to show depends on if we hit water or not
-			if (terrainType(mapTile(map_coord(psObj->pos.x), map_coord(psObj->pos.y))) == TER_WATER)
+			if (terrainType(mapTile(worldMapState, map_coord(psObj->pos.x), map_coord(psObj->pos.y))) == TER_WATER)
 			{
 				imd = psStats->pWaterHitGraphic;
 			}
@@ -1399,7 +1399,7 @@ PROJECTILE* PROJECTILE::update()
 	psDamaged.erase(std::remove_if(psDamaged.begin(), psDamaged.end(), [](const BASE_OBJECT *psObj) { return ::isDead(psObj); }), psDamaged.end());
 
 	// This extra check fixes a crash in cam2, mission1
-	if (worldOnMap(psObj->pos.x, psObj->pos.y) == false)
+	if (worldOnMap(worldMapState, psObj->pos.x, psObj->pos.y) == false)
 	{
 		psObj->died = true;
 		return nullptr;

--- a/src/projectile.cpp
+++ b/src/projectile.cpp
@@ -817,8 +817,8 @@ static PROJECTILE* proj_InFlightFunc(PROJECTILE *psProj)
 					int flightTime = iHypot(delta.xy()) * GAME_TICKS_PER_SEC / psStats->flightSpeed;
 					psProj->dst += Vector3i(iSinCosR(targetDroid->sMove.moveDir, std::min<int>(targetDroid->sMove.speed, psStats->flightSpeed * 3 / 4) * flightTime / GAME_TICKS_PER_SEC), 0);
 				}
-				psProj->dst.x = clip(psProj->dst.x, 0, world_coord(mapWidth) - 1);
-				psProj->dst.y = clip(psProj->dst.y, 0, world_coord(mapHeight) - 1);
+				psProj->dst.x = clip(psProj->dst.x, 0, world_coord(worldMapState.width) - 1);
+				psProj->dst.y = clip(psProj->dst.y, 0, world_coord(worldMapState.height) - 1);
 			}
 			if (psStats->movementModel == MM_HOMINGINDIRECT)
 			{

--- a/src/qtscript.cpp
+++ b/src/qtscript.cpp
@@ -607,9 +607,9 @@ wzapi::scripting_instance* scripting_engine::loadPlayerScript(const WzString& pa
 	//== * ```scavengers``` Whether or not scavengers are activated in this game, and, if so, which type.
 	globalVars["scavengers"] = game.scavengers;
 	//== * ```mapWidth``` Width of map in tiles.
-	globalVars["mapWidth"] = mapWidth;
+	globalVars["mapWidth"] = worldMapState.width;
 	//== * ```mapHeight``` Height of map in tiles.
-	globalVars["mapHeight"] = mapHeight;
+	globalVars["mapHeight"] = worldMapState.height;
 	//== * ```scavengerPlayer``` Index of scavenger player. (3.2+ only)
 	globalVars["scavengerPlayer"] = scavengerSlot();
 	//== * ```isMultiplayer``` If the current game is a online multiplayer game or not. (3.2+ only)
@@ -1792,9 +1792,9 @@ std::vector<scripting_engine::LabelInfo> scripting_engine::debug_GetLabelInfo() 
 
 void clearMarks()
 {
-	for (int y = 0; y < mapHeight; y++)
+	for (int y = 0; y < worldMapState.height; y++)
 	{
-		for (int x = 0; x < mapWidth; x++) // clear old marks
+		for (int x = 0; x < worldMapState.width; x++) // clear old marks
 		{
 			MAPTILE *psTile = mapTile(x, y);
 			psTile->tileInfoBits &= ~BITS_MARKED;
@@ -1839,8 +1839,8 @@ void scripting_engine::showLabel(const std::string &key, bool clear_old, bool ju
 		int maxy = map_coord(l.p2.y);
 		if (l.type == SCRIPT_POSITION)
 		{
-			maxx = MIN(mapWidth, maxx + 1);
-			maxy = MIN(mapHeight, maxy + 1);
+			maxx = MIN(worldMapState.width, maxx + 1);
+			maxy = MIN(worldMapState.height, maxy + 1);
 		}
 		for (int x = map_coord(l.p1.x); x < maxx; x++) // make new ones
 		{
@@ -1857,9 +1857,9 @@ void scripting_engine::showLabel(const std::string &key, bool clear_old, bool ju
 		{
 			setViewPos(map_coord(l.p1.x), map_coord(l.p1.y), false); // move camera position
 		}
-		for (int x = MAX(map_coord(l.p1.x - l.p2.x), 0); x < MIN(map_coord(l.p1.x + l.p2.x), mapWidth); x++)
+		for (int x = MAX(map_coord(l.p1.x - l.p2.x), 0); x < MIN(map_coord(l.p1.x + l.p2.x), worldMapState.width); x++)
 		{
-			for (int y = MAX(map_coord(l.p1.y - l.p2.x), 0); y < MIN(map_coord(l.p1.y + l.p2.x), mapHeight); y++) // l.p2.x is radius, not a bug
+			for (int y = MAX(map_coord(l.p1.y - l.p2.x), 0); y < MIN(map_coord(l.p1.y + l.p2.x), worldMapState.height); y++) // l.p2.x is radius, not a bug
 			{
 				if (iHypot(map_coord(l.p1) - Vector2i(x, y)) < map_coord(l.p2.x))
 				{
@@ -2837,7 +2837,7 @@ wzapi::no_return_value scripting_engine::hackMarkTiles_ByLabel(WZAPI_PARAMS(cons
 		{
 			for (int y = map_coord(l.p1.y - l.p2.x); y < map_coord(l.p1.y + l.p2.x); y++)
 			{
-				if (x >= -1 && x < mapWidth + 1 && y >= -1 && y < mapWidth + 1 && iHypot(map_coord(l.p1) - Vector2i(x, y)) < map_coord(l.p2.x))
+				if (x >= -1 && x < worldMapState.width + 1 && y >= -1 && y < worldMapState.width + 1 && iHypot(map_coord(l.p1) - Vector2i(x, y)) < map_coord(l.p2.x))
 				{
 					MAPTILE *psTile = mapTile(x, y);
 					psTile->tileInfoBits |= BITS_MARKED;

--- a/src/qtscript.cpp
+++ b/src/qtscript.cpp
@@ -2724,7 +2724,7 @@ wzapi::no_return_value scripting_engine::groupAddArea(WZAPI_PARAMS(int groupId, 
 	int x2 = world_coord(_x2);
 	int y2 = world_coord(_y2);
 
-	for (DROID *psDroid : apsDroidLists[player])
+	for (DROID *psDroid : worldObjectState.droids[player])
 	{
 		if (psDroid->pos.x >= x1 && psDroid->pos.x <= x2 && psDroid->pos.y >= y1 && psDroid->pos.y <= y2)
 		{

--- a/src/qtscript.cpp
+++ b/src/qtscript.cpp
@@ -1796,7 +1796,7 @@ void clearMarks()
 	{
 		for (int x = 0; x < worldMapState.width; x++) // clear old marks
 		{
-			MAPTILE *psTile = mapTile(x, y);
+			MAPTILE *psTile = mapTile(worldMapState, x, y);
 			psTile->tileInfoBits &= ~BITS_MARKED;
 		}
 	}
@@ -1846,7 +1846,7 @@ void scripting_engine::showLabel(const std::string &key, bool clear_old, bool ju
 		{
 			for (int y = map_coord(l.p1.y); y < maxy; y++)
 			{
-				MAPTILE *psTile = mapTile(x, y);
+				MAPTILE *psTile = mapTile(worldMapState, x, y);
 				psTile->tileInfoBits |= BITS_MARKED;
 			}
 		}
@@ -1863,7 +1863,7 @@ void scripting_engine::showLabel(const std::string &key, bool clear_old, bool ju
 			{
 				if (iHypot(map_coord(l.p1) - Vector2i(x, y)) < map_coord(l.p2.x))
 				{
-					MAPTILE *psTile = mapTile(x, y);
+					MAPTILE *psTile = mapTile(worldMapState, x, y);
 					psTile->tileInfoBits |= BITS_MARKED;
 				}
 			}
@@ -1878,7 +1878,7 @@ void scripting_engine::showLabel(const std::string &key, bool clear_old, bool ju
 			{
 				setViewPos(map_coord(psObj->pos.x), map_coord(psObj->pos.y), false); // move camera position
 			}
-			MAPTILE *psTile = mapTile(map_coord(psObj->pos.x), map_coord(psObj->pos.y));
+			MAPTILE *psTile = mapTile(worldMapState, map_coord(psObj->pos.x), map_coord(psObj->pos.y));
 			psTile->tileInfoBits |= BITS_MARKED;
 		}
 	}
@@ -1898,7 +1898,7 @@ void scripting_engine::showLabel(const std::string &key, bool clear_old, bool ju
 						setViewPos(map_coord(psObj->pos.x), map_coord(psObj->pos.y), false); // move camera position
 						cameraMoved = true;
 					}
-					MAPTILE *psTile = mapTile(map_coord(psObj->pos.x), map_coord(psObj->pos.y));
+					MAPTILE *psTile = mapTile(worldMapState, map_coord(psObj->pos.x), map_coord(psObj->pos.y));
 					psTile->tileInfoBits |= BITS_MARKED;
 				}
 			}
@@ -2550,8 +2550,8 @@ generic_script_object scripting_engine::getObject(WZAPI_PARAMS(wzapi::object_req
 		auto pos = request.getMapPosition();
 		int x = pos.x;
 		int y = pos.y;
-		SCRIPT_ASSERT({}, context, tileOnMap(x, y), "Map position (%d, %d) not on the map!", x, y);
-		const MAPTILE *psTile = mapTile(x, y);
+		SCRIPT_ASSERT({}, context, tileOnMap(worldMapState, x, y), "Map position (%d, %d) not on the map!", x, y);
+		const MAPTILE *psTile = mapTile(worldMapState, x, y);
 		return generic_script_object::fromObject(psTile->psObject);
 	}
 	else if (request.requestType == wzapi::object_request::RequestType::OBJECTID_REQUEST)
@@ -2826,7 +2826,7 @@ wzapi::no_return_value scripting_engine::hackMarkTiles_ByLabel(WZAPI_PARAMS(cons
 		{
 			for (int y = map_coord(l.p1.y); y < map_coord(l.p2.y); y++)
 			{
-				MAPTILE *psTile = mapTile(x, y);
+				MAPTILE *psTile = mapTile(worldMapState, x, y);
 				psTile->tileInfoBits |= BITS_MARKED;
 			}
 		}
@@ -2839,7 +2839,7 @@ wzapi::no_return_value scripting_engine::hackMarkTiles_ByLabel(WZAPI_PARAMS(cons
 			{
 				if (x >= -1 && x < worldMapState.width + 1 && y >= -1 && y < worldMapState.width + 1 && iHypot(map_coord(l.p1) - Vector2i(x, y)) < map_coord(l.p2.x))
 				{
-					MAPTILE *psTile = mapTile(x, y);
+					MAPTILE *psTile = mapTile(worldMapState, x, y);
 					psTile->tileInfoBits |= BITS_MARKED;
 				}
 			}

--- a/src/qtscript.cpp
+++ b/src/qtscript.cpp
@@ -607,9 +607,9 @@ wzapi::scripting_instance* scripting_engine::loadPlayerScript(const WzString& pa
 	//== * ```scavengers``` Whether or not scavengers are activated in this game, and, if so, which type.
 	globalVars["scavengers"] = game.scavengers;
 	//== * ```mapWidth``` Width of map in tiles.
-	globalVars["mapWidth"] = worldMapState.width;
+	globalVars["mapWidth"] = gameWorld.map.width;
 	//== * ```mapHeight``` Height of map in tiles.
-	globalVars["mapHeight"] = worldMapState.height;
+	globalVars["mapHeight"] = gameWorld.map.height;
 	//== * ```scavengerPlayer``` Index of scavenger player. (3.2+ only)
 	globalVars["scavengerPlayer"] = scavengerSlot();
 	//== * ```isMultiplayer``` If the current game is a online multiplayer game or not. (3.2+ only)
@@ -1792,11 +1792,11 @@ std::vector<scripting_engine::LabelInfo> scripting_engine::debug_GetLabelInfo() 
 
 void clearMarks()
 {
-	for (int y = 0; y < worldMapState.height; y++)
+	for (int y = 0; y < gameWorld.map.height; y++)
 	{
-		for (int x = 0; x < worldMapState.width; x++) // clear old marks
+		for (int x = 0; x < gameWorld.map.width; x++) // clear old marks
 		{
-			MAPTILE *psTile = mapTile(worldMapState, x, y);
+			MAPTILE *psTile = mapTile(gameWorld.map, x, y);
 			psTile->tileInfoBits &= ~BITS_MARKED;
 		}
 	}
@@ -1839,14 +1839,14 @@ void scripting_engine::showLabel(const std::string &key, bool clear_old, bool ju
 		int maxy = map_coord(l.p2.y);
 		if (l.type == SCRIPT_POSITION)
 		{
-			maxx = MIN(worldMapState.width, maxx + 1);
-			maxy = MIN(worldMapState.height, maxy + 1);
+			maxx = MIN(gameWorld.map.width, maxx + 1);
+			maxy = MIN(gameWorld.map.height, maxy + 1);
 		}
 		for (int x = map_coord(l.p1.x); x < maxx; x++) // make new ones
 		{
 			for (int y = map_coord(l.p1.y); y < maxy; y++)
 			{
-				MAPTILE *psTile = mapTile(worldMapState, x, y);
+				MAPTILE *psTile = mapTile(gameWorld.map, x, y);
 				psTile->tileInfoBits |= BITS_MARKED;
 			}
 		}
@@ -1857,13 +1857,13 @@ void scripting_engine::showLabel(const std::string &key, bool clear_old, bool ju
 		{
 			setViewPos(map_coord(l.p1.x), map_coord(l.p1.y), false); // move camera position
 		}
-		for (int x = MAX(map_coord(l.p1.x - l.p2.x), 0); x < MIN(map_coord(l.p1.x + l.p2.x), worldMapState.width); x++)
+		for (int x = MAX(map_coord(l.p1.x - l.p2.x), 0); x < MIN(map_coord(l.p1.x + l.p2.x), gameWorld.map.width); x++)
 		{
-			for (int y = MAX(map_coord(l.p1.y - l.p2.x), 0); y < MIN(map_coord(l.p1.y + l.p2.x), worldMapState.height); y++) // l.p2.x is radius, not a bug
+			for (int y = MAX(map_coord(l.p1.y - l.p2.x), 0); y < MIN(map_coord(l.p1.y + l.p2.x), gameWorld.map.height); y++) // l.p2.x is radius, not a bug
 			{
 				if (iHypot(map_coord(l.p1) - Vector2i(x, y)) < map_coord(l.p2.x))
 				{
-					MAPTILE *psTile = mapTile(worldMapState, x, y);
+					MAPTILE *psTile = mapTile(gameWorld.map, x, y);
 					psTile->tileInfoBits |= BITS_MARKED;
 				}
 			}
@@ -1878,7 +1878,7 @@ void scripting_engine::showLabel(const std::string &key, bool clear_old, bool ju
 			{
 				setViewPos(map_coord(psObj->pos.x), map_coord(psObj->pos.y), false); // move camera position
 			}
-			MAPTILE *psTile = mapTile(worldMapState, map_coord(psObj->pos.x), map_coord(psObj->pos.y));
+			MAPTILE *psTile = mapTile(gameWorld.map, map_coord(psObj->pos.x), map_coord(psObj->pos.y));
 			psTile->tileInfoBits |= BITS_MARKED;
 		}
 	}
@@ -1898,7 +1898,7 @@ void scripting_engine::showLabel(const std::string &key, bool clear_old, bool ju
 						setViewPos(map_coord(psObj->pos.x), map_coord(psObj->pos.y), false); // move camera position
 						cameraMoved = true;
 					}
-					MAPTILE *psTile = mapTile(worldMapState, map_coord(psObj->pos.x), map_coord(psObj->pos.y));
+					MAPTILE *psTile = mapTile(gameWorld.map, map_coord(psObj->pos.x), map_coord(psObj->pos.y));
 					psTile->tileInfoBits |= BITS_MARKED;
 				}
 			}
@@ -2550,8 +2550,8 @@ generic_script_object scripting_engine::getObject(WZAPI_PARAMS(wzapi::object_req
 		auto pos = request.getMapPosition();
 		int x = pos.x;
 		int y = pos.y;
-		SCRIPT_ASSERT({}, context, tileOnMap(worldMapState, x, y), "Map position (%d, %d) not on the map!", x, y);
-		const MAPTILE *psTile = mapTile(worldMapState, x, y);
+		SCRIPT_ASSERT({}, context, tileOnMap(gameWorld.map, x, y), "Map position (%d, %d) not on the map!", x, y);
+		const MAPTILE *psTile = mapTile(gameWorld.map, x, y);
 		return generic_script_object::fromObject(psTile->psObject);
 	}
 	else if (request.requestType == wzapi::object_request::RequestType::OBJECTID_REQUEST)
@@ -2724,7 +2724,7 @@ wzapi::no_return_value scripting_engine::groupAddArea(WZAPI_PARAMS(int groupId, 
 	int x2 = world_coord(_x2);
 	int y2 = world_coord(_y2);
 
-	for (DROID *psDroid : worldObjectState.droids[player])
+	for (DROID *psDroid : gameWorld.objects.droids[player])
 	{
 		if (psDroid->pos.x >= x1 && psDroid->pos.x <= x2 && psDroid->pos.y >= y1 && psDroid->pos.y <= y2)
 		{
@@ -2826,7 +2826,7 @@ wzapi::no_return_value scripting_engine::hackMarkTiles_ByLabel(WZAPI_PARAMS(cons
 		{
 			for (int y = map_coord(l.p1.y); y < map_coord(l.p2.y); y++)
 			{
-				MAPTILE *psTile = mapTile(worldMapState, x, y);
+				MAPTILE *psTile = mapTile(gameWorld.map, x, y);
 				psTile->tileInfoBits |= BITS_MARKED;
 			}
 		}
@@ -2837,9 +2837,9 @@ wzapi::no_return_value scripting_engine::hackMarkTiles_ByLabel(WZAPI_PARAMS(cons
 		{
 			for (int y = map_coord(l.p1.y - l.p2.x); y < map_coord(l.p1.y + l.p2.x); y++)
 			{
-				if (x >= -1 && x < worldMapState.width + 1 && y >= -1 && y < worldMapState.width + 1 && iHypot(map_coord(l.p1) - Vector2i(x, y)) < map_coord(l.p2.x))
+				if (x >= -1 && x < gameWorld.map.width + 1 && y >= -1 && y < gameWorld.map.width + 1 && iHypot(map_coord(l.p1) - Vector2i(x, y)) < map_coord(l.p2.x))
 				{
-					MAPTILE *psTile = mapTile(worldMapState, x, y);
+					MAPTILE *psTile = mapTile(gameWorld.map, x, y);
 					psTile->tileInfoBits |= BITS_MARKED;
 				}
 			}

--- a/src/radar.cpp
+++ b/src/radar.cpp
@@ -561,7 +561,7 @@ static void DrawRadarObjects()
 		flashCol = flashColours[getPlayerColour(clan)];
 
 		/* Go through all droids */
-		for (const DROID* psDroid : apsDroidLists[clan])
+		for (const DROID* psDroid : worldObjectState.droids[clan])
 		{
 			if (psDroid->pos.x < world_coord(worldMapState.scroll.minX) || psDroid->pos.y < world_coord(worldMapState.scroll.minY)
 			    || psDroid->pos.x >= world_coord(worldMapState.scroll.maxX) || psDroid->pos.y >= world_coord(worldMapState.scroll.maxY))

--- a/src/radar.cpp
+++ b/src/radar.cpp
@@ -262,8 +262,8 @@ bool resizeRadar()
 	{
 		free(radarOverlayBuffer);
 	}
-	radarTexWidth = static_cast<size_t>(std::abs(scrollMaxX - scrollMinX));
-	radarTexHeight = static_cast<size_t>(std::abs(scrollMaxY - scrollMinY));
+	radarTexWidth = static_cast<size_t>(std::abs(worldMapState.scroll.maxX - worldMapState.scroll.minX));
+	radarTexHeight = static_cast<size_t>(std::abs(worldMapState.scroll.maxY - worldMapState.scroll.minY));
 	radarBufferSize = radarTexWidth * radarTexHeight * sizeof(UDWORD);
 	radarBitmap.allocate(radarTexWidth, radarTexHeight, 4, true);
 	radarOverlayBuffer = (uint32_t*)malloc(radarBufferSize);
@@ -346,17 +346,17 @@ void CalcRadarPosition(int mX, int mY, int *PosX, int *PosY)
 	CalcRadarPixelSize(&pixSizeH, &pixSizeV);
 	sPosX = static_cast<int>(pos.x / pixSizeH);	// adjust for pixel size
 	sPosY = static_cast<int>(pos.y / pixSizeV);
-	sPosX += scrollMinX;		// adjust for scroll limits
-	sPosY += scrollMinY;
+	sPosX += worldMapState.scroll.minX;		// adjust for scroll limits
+	sPosY += worldMapState.scroll.minY;
 
 #if REALLY_DEBUG_RADAR
 	debug(LOG_ERROR, "m=(%d,%d) radar=(%d,%d) pos(%d,%d), scroll=(%u-%u,%u-%u) sPos=(%d,%d), pixSize=(%f,%f)",
-	      mX, mY, radarX, radarY, posX, posY, scrollMinX, scrollMaxX, scrollMinY, scrollMaxY, sPosX, sPosY, pixSizeH, pixSizeV);
+	      mX, mY, radarX, radarY, posX, posY, worldMapState.scroll.minX, worldMapState.scroll.maxX, worldMapState.scroll.minY, worldMapState.scroll.maxY, sPosX, sPosY, pixSizeH, pixSizeV);
 #endif
 
 	// old safety code -- still necessary?
-	sPosX = clip<int>(sPosX, scrollMinX, scrollMaxX -1);
-	sPosY = clip<int>(sPosY, scrollMinY, scrollMaxY -1);
+	sPosX = clip<int>(sPosX, worldMapState.scroll.minX, worldMapState.scroll.maxX -1);
+	sPosY = clip<int>(sPosY, worldMapState.scroll.minY, worldMapState.scroll.maxY -1);
 
 	*PosX = sPosX;
 	*PosY = sPosY;
@@ -501,15 +501,15 @@ static void DrawRadarTiles()
 	size_t radarBufferSize2 = radarBitmap.size_in_bytes();
 	unsigned char* pRaderBuffer = radarBitmap.bmp_w();
 
-	for (x = scrollMinX; x < scrollMaxX; x++)
+	for (x = worldMapState.scroll.minX; x < worldMapState.scroll.maxX; x++)
 	{
-		for (y = scrollMinY; y < scrollMaxY; y++)
+		for (y = worldMapState.scroll.minY; y < worldMapState.scroll.maxY; y++)
 		{
 			MAPTILE	*psTile = mapTile(x, y);
-			size_t pixelStartPos = (radarTexWidth * (y - scrollMinY) + (x - scrollMinX)) * 4;
+			size_t pixelStartPos = (radarTexWidth * (y - worldMapState.scroll.minY) + (x - worldMapState.scroll.minX)) * 4;
 
 			ASSERT(pixelStartPos < radarBufferSize2, "Buffer overrun");
-			if (y == scrollMinY || x == scrollMinX || y == scrollMaxY - 1 || x == scrollMaxX - 1)
+			if (y == worldMapState.scroll.minY || x == worldMapState.scroll.minX || y == worldMapState.scroll.maxY - 1 || x == worldMapState.scroll.maxX - 1)
 			{
 				pRaderBuffer[pixelStartPos] = WZCOL_BLACK.byte.r;
 				pRaderBuffer[pixelStartPos + 1] = WZCOL_BLACK.byte.g;
@@ -563,8 +563,8 @@ static void DrawRadarObjects()
 		/* Go through all droids */
 		for (const DROID* psDroid : apsDroidLists[clan])
 		{
-			if (psDroid->pos.x < world_coord(scrollMinX) || psDroid->pos.y < world_coord(scrollMinY)
-			    || psDroid->pos.x >= world_coord(scrollMaxX) || psDroid->pos.y >= world_coord(scrollMaxY))
+			if (psDroid->pos.x < world_coord(worldMapState.scroll.minX) || psDroid->pos.y < world_coord(worldMapState.scroll.minY)
+			    || psDroid->pos.x >= world_coord(worldMapState.scroll.maxX) || psDroid->pos.y >= world_coord(worldMapState.scroll.maxY))
 			{
 				continue;
 			}
@@ -574,7 +574,7 @@ static void DrawRadarObjects()
 			{
 				int	x = psDroid->pos.x / TILE_UNITS;
 				int	y = psDroid->pos.y / TILE_UNITS;
-				size_t	pos = (x - scrollMinX) + (y - scrollMinY) * radarTexWidth;
+				size_t	pos = (x - worldMapState.scroll.minX) + (y - worldMapState.scroll.minY) * radarTexWidth;
 
 				ASSERT(pos * sizeof(*radarOverlayBuffer) < radarBufferSize, "Buffer overrun");
 				if (clan == selectedPlayer && gameTime > HIT_NOTIFICATION && gameTime - psDroid->timeLastHit < HIT_NOTIFICATION)
@@ -596,13 +596,13 @@ static void DrawRadarObjects()
 	}
 
 	/* Do the same for structures */
-	for (SDWORD x = scrollMinX; x < scrollMaxX; x++)
+	for (SDWORD x = worldMapState.scroll.minX; x < worldMapState.scroll.maxX; x++)
 	{
-		for (SDWORD y = scrollMinY; y < scrollMaxY; y++)
+		for (SDWORD y = worldMapState.scroll.minY; y < worldMapState.scroll.maxY; y++)
 		{
 			MAPTILE		*psTile = mapTile(x, y);
 			STRUCTURE	*psStruct;
-			size_t		pos = (x - scrollMinX) + (y - scrollMinY) * radarTexWidth;
+			size_t		pos = (x - worldMapState.scroll.minX) + (y - worldMapState.scroll.minY) * radarTexWidth;
 
 			ASSERT(pos * sizeof(*radarOverlayBuffer) < radarBufferSize, "Buffer overrun");
 			if (!TileHasStructure(psTile))
@@ -758,8 +758,8 @@ static void setViewingWindow()
 	v[3].x = -shortX;
 	v[3].y = yDrop;
 
-	centre.x = static_cast<int>(x - scrollMinX * pixSizeH);
-	centre.y = static_cast<int>(y - scrollMinY * pixSizeV);
+	centre.x = static_cast<int>(x - worldMapState.scroll.minX * pixSizeH);
+	centre.y = static_cast<int>(y - worldMapState.scroll.minY * pixSizeV);
 
 	RotateVector2D(v, tv, &centre, playerPos.r.y, 4);
 

--- a/src/radar.cpp
+++ b/src/radar.cpp
@@ -505,7 +505,7 @@ static void DrawRadarTiles()
 	{
 		for (y = worldMapState.scroll.minY; y < worldMapState.scroll.maxY; y++)
 		{
-			MAPTILE	*psTile = mapTile(x, y);
+			MAPTILE	*psTile = mapTile(worldMapState, x, y);
 			size_t pixelStartPos = (radarTexWidth * (y - worldMapState.scroll.minY) + (x - worldMapState.scroll.minX)) * 4;
 
 			ASSERT(pixelStartPos < radarBufferSize2, "Buffer overrun");
@@ -600,7 +600,7 @@ static void DrawRadarObjects()
 	{
 		for (SDWORD y = worldMapState.scroll.minY; y < worldMapState.scroll.maxY; y++)
 		{
-			MAPTILE		*psTile = mapTile(x, y);
+			MAPTILE		*psTile = mapTile(worldMapState, x, y);
 			STRUCTURE	*psStruct;
 			size_t		pos = (x - worldMapState.scroll.minX) + (y - worldMapState.scroll.minY) * radarTexWidth;
 

--- a/src/radar.cpp
+++ b/src/radar.cpp
@@ -262,8 +262,8 @@ bool resizeRadar()
 	{
 		free(radarOverlayBuffer);
 	}
-	radarTexWidth = static_cast<size_t>(std::abs(worldMapState.scroll.maxX - worldMapState.scroll.minX));
-	radarTexHeight = static_cast<size_t>(std::abs(worldMapState.scroll.maxY - worldMapState.scroll.minY));
+	radarTexWidth = static_cast<size_t>(std::abs(gameWorld.map.scroll.maxX - gameWorld.map.scroll.minX));
+	radarTexHeight = static_cast<size_t>(std::abs(gameWorld.map.scroll.maxY - gameWorld.map.scroll.minY));
 	radarBufferSize = radarTexWidth * radarTexHeight * sizeof(UDWORD);
 	radarBitmap.allocate(radarTexWidth, radarTexHeight, 4, true);
 	radarOverlayBuffer = (uint32_t*)malloc(radarBufferSize);
@@ -346,17 +346,17 @@ void CalcRadarPosition(int mX, int mY, int *PosX, int *PosY)
 	CalcRadarPixelSize(&pixSizeH, &pixSizeV);
 	sPosX = static_cast<int>(pos.x / pixSizeH);	// adjust for pixel size
 	sPosY = static_cast<int>(pos.y / pixSizeV);
-	sPosX += worldMapState.scroll.minX;		// adjust for scroll limits
-	sPosY += worldMapState.scroll.minY;
+	sPosX += gameWorld.map.scroll.minX;		// adjust for scroll limits
+	sPosY += gameWorld.map.scroll.minY;
 
 #if REALLY_DEBUG_RADAR
 	debug(LOG_ERROR, "m=(%d,%d) radar=(%d,%d) pos(%d,%d), scroll=(%u-%u,%u-%u) sPos=(%d,%d), pixSize=(%f,%f)",
-	      mX, mY, radarX, radarY, posX, posY, worldMapState.scroll.minX, worldMapState.scroll.maxX, worldMapState.scroll.minY, worldMapState.scroll.maxY, sPosX, sPosY, pixSizeH, pixSizeV);
+	      mX, mY, radarX, radarY, posX, posY, gameWorld.map.scroll.minX, gameWorld.map.scroll.maxX, gameWorld.map.scroll.minY, gameWorld.map.scroll.maxY, sPosX, sPosY, pixSizeH, pixSizeV);
 #endif
 
 	// old safety code -- still necessary?
-	sPosX = clip<int>(sPosX, worldMapState.scroll.minX, worldMapState.scroll.maxX -1);
-	sPosY = clip<int>(sPosY, worldMapState.scroll.minY, worldMapState.scroll.maxY -1);
+	sPosX = clip<int>(sPosX, gameWorld.map.scroll.minX, gameWorld.map.scroll.maxX -1);
+	sPosY = clip<int>(sPosY, gameWorld.map.scroll.minY, gameWorld.map.scroll.maxY -1);
 
 	*PosX = sPosX;
 	*PosY = sPosY;
@@ -501,15 +501,15 @@ static void DrawRadarTiles()
 	size_t radarBufferSize2 = radarBitmap.size_in_bytes();
 	unsigned char* pRaderBuffer = radarBitmap.bmp_w();
 
-	for (x = worldMapState.scroll.minX; x < worldMapState.scroll.maxX; x++)
+	for (x = gameWorld.map.scroll.minX; x < gameWorld.map.scroll.maxX; x++)
 	{
-		for (y = worldMapState.scroll.minY; y < worldMapState.scroll.maxY; y++)
+		for (y = gameWorld.map.scroll.minY; y < gameWorld.map.scroll.maxY; y++)
 		{
-			MAPTILE	*psTile = mapTile(worldMapState, x, y);
-			size_t pixelStartPos = (radarTexWidth * (y - worldMapState.scroll.minY) + (x - worldMapState.scroll.minX)) * 4;
+			MAPTILE	*psTile = mapTile(gameWorld.map, x, y);
+			size_t pixelStartPos = (radarTexWidth * (y - gameWorld.map.scroll.minY) + (x - gameWorld.map.scroll.minX)) * 4;
 
 			ASSERT(pixelStartPos < radarBufferSize2, "Buffer overrun");
-			if (y == worldMapState.scroll.minY || x == worldMapState.scroll.minX || y == worldMapState.scroll.maxY - 1 || x == worldMapState.scroll.maxX - 1)
+			if (y == gameWorld.map.scroll.minY || x == gameWorld.map.scroll.minX || y == gameWorld.map.scroll.maxY - 1 || x == gameWorld.map.scroll.maxX - 1)
 			{
 				pRaderBuffer[pixelStartPos] = WZCOL_BLACK.byte.r;
 				pRaderBuffer[pixelStartPos + 1] = WZCOL_BLACK.byte.g;
@@ -561,10 +561,10 @@ static void DrawRadarObjects()
 		flashCol = flashColours[getPlayerColour(clan)];
 
 		/* Go through all droids */
-		for (const DROID* psDroid : worldObjectState.droids[clan])
+		for (const DROID* psDroid : gameWorld.objects.droids[clan])
 		{
-			if (psDroid->pos.x < world_coord(worldMapState.scroll.minX) || psDroid->pos.y < world_coord(worldMapState.scroll.minY)
-			    || psDroid->pos.x >= world_coord(worldMapState.scroll.maxX) || psDroid->pos.y >= world_coord(worldMapState.scroll.maxY))
+			if (psDroid->pos.x < world_coord(gameWorld.map.scroll.minX) || psDroid->pos.y < world_coord(gameWorld.map.scroll.minY)
+			    || psDroid->pos.x >= world_coord(gameWorld.map.scroll.maxX) || psDroid->pos.y >= world_coord(gameWorld.map.scroll.maxY))
 			{
 				continue;
 			}
@@ -574,7 +574,7 @@ static void DrawRadarObjects()
 			{
 				int	x = psDroid->pos.x / TILE_UNITS;
 				int	y = psDroid->pos.y / TILE_UNITS;
-				size_t	pos = (x - worldMapState.scroll.minX) + (y - worldMapState.scroll.minY) * radarTexWidth;
+				size_t	pos = (x - gameWorld.map.scroll.minX) + (y - gameWorld.map.scroll.minY) * radarTexWidth;
 
 				ASSERT(pos * sizeof(*radarOverlayBuffer) < radarBufferSize, "Buffer overrun");
 				if (clan == selectedPlayer && gameTime > HIT_NOTIFICATION && gameTime - psDroid->timeLastHit < HIT_NOTIFICATION)
@@ -596,13 +596,13 @@ static void DrawRadarObjects()
 	}
 
 	/* Do the same for structures */
-	for (SDWORD x = worldMapState.scroll.minX; x < worldMapState.scroll.maxX; x++)
+	for (SDWORD x = gameWorld.map.scroll.minX; x < gameWorld.map.scroll.maxX; x++)
 	{
-		for (SDWORD y = worldMapState.scroll.minY; y < worldMapState.scroll.maxY; y++)
+		for (SDWORD y = gameWorld.map.scroll.minY; y < gameWorld.map.scroll.maxY; y++)
 		{
-			MAPTILE		*psTile = mapTile(worldMapState, x, y);
+			MAPTILE		*psTile = mapTile(gameWorld.map, x, y);
 			STRUCTURE	*psStruct;
-			size_t		pos = (x - worldMapState.scroll.minX) + (y - worldMapState.scroll.minY) * radarTexWidth;
+			size_t		pos = (x - gameWorld.map.scroll.minX) + (y - gameWorld.map.scroll.minY) * radarTexWidth;
 
 			ASSERT(pos * sizeof(*radarOverlayBuffer) < radarBufferSize, "Buffer overrun");
 			if (!TileHasStructure(psTile))
@@ -758,8 +758,8 @@ static void setViewingWindow()
 	v[3].x = -shortX;
 	v[3].y = yDrop;
 
-	centre.x = static_cast<int>(x - worldMapState.scroll.minX * pixSizeH);
-	centre.y = static_cast<int>(y - worldMapState.scroll.minY * pixSizeV);
+	centre.x = static_cast<int>(x - gameWorld.map.scroll.minX * pixSizeH);
+	centre.y = static_cast<int>(y - gameWorld.map.scroll.minY * pixSizeV);
 
 	RotateVector2D(v, tv, &centre, playerPos.r.y, 4);
 

--- a/src/raycast.cpp
+++ b/src/raycast.cpp
@@ -29,6 +29,7 @@
 #include "raycast.h"
 #include "map.h" // TILE_UNITS
 #include "display3d.h" // clipXY()
+#include "game_world.h"
 
 struct HeightCallbackHelp_t
 {
@@ -108,7 +109,7 @@ void rayCast(Vector2i src, Vector2i dst, RAY_CALLBACK callback, void *data)
 			// But make sure it's on the right tile, since it could be off-by-one if the line passes exactly through a grid intersection.
 			avg.x = std::min(std::max(avg.x, world_coord(selTile.x)), world_coord(selTile.x + 1) - 1);
 			avg.y = std::min(std::max(avg.y, world_coord(selTile.y)), world_coord(selTile.y + 1) - 1);
-			if (!worldOnMap(worldMapState, avg) || !callback(avg, iHypot(avg), data))
+			if (!worldOnMap(gameWorld.map, avg) || !callback(avg, iHypot(avg), data))
 			{
 				return;  // Callback doesn't want any more points, or we reached the edge of the map, so return.
 			}
@@ -118,7 +119,7 @@ void rayCast(Vector2i src, Vector2i dst, RAY_CALLBACK callback, void *data)
 	}
 
 	// Include the endpoint.
-	if (!worldOnMap(worldMapState, dst))
+	if (!worldOnMap(gameWorld.map, dst))
 	{
 		return;  // Stop, since reached the edge of the map.
 	}
@@ -137,14 +138,14 @@ static bool getTileHeightCallback(Vector2i pos, int32_t dist, void *data)
 	/* Are we still on the grid? */
 	if (clipXY(pos.x, pos.y))
 	{
-		bool HasTallStructure = blockTile(worldMapState, map_coord(pos.x), map_coord(pos.y), AUX_MAP) & AIR_BLOCKED;
+		bool HasTallStructure = blockTile(gameWorld.map, map_coord(pos.x), map_coord(pos.y), AUX_MAP) & AIR_BLOCKED;
 
 		if (dist > TILE_UNITS || HasTallStructure)
 		{
 			// Only do it the current tile is > TILE_UNITS away from the starting tile. Or..
 			// there is a tall structure  on the current tile and the current tile is not the starting tile.
 			/* Get height at this intersection point */
-			int height = map_Height(worldMapState, pos.x, pos.y), heightDiff;
+			int height = map_Height(gameWorld.map, pos.x, pos.y), heightDiff;
 			uint16_t newPitch;
 
 			if (HasTallStructure)
@@ -190,7 +191,7 @@ static bool getTileHeightCallback(Vector2i pos, int32_t dist, void *data)
 
 void getBestPitchToEdgeOfGrid(UDWORD x, UDWORD y, uint16_t direction, uint16_t *pitch)
 {
-	HeightCallbackHelp_t help = {map_Height(worldMapState, x, y), 0};
+	HeightCallbackHelp_t help = {map_Height(gameWorld.map, x, y), 0};
 
 	Vector3i src(x, y, 0);
 	Vector3i delta(iSinCosR(direction, 5430), 0);

--- a/src/raycast.cpp
+++ b/src/raycast.cpp
@@ -108,7 +108,7 @@ void rayCast(Vector2i src, Vector2i dst, RAY_CALLBACK callback, void *data)
 			// But make sure it's on the right tile, since it could be off-by-one if the line passes exactly through a grid intersection.
 			avg.x = std::min(std::max(avg.x, world_coord(selTile.x)), world_coord(selTile.x + 1) - 1);
 			avg.y = std::min(std::max(avg.y, world_coord(selTile.y)), world_coord(selTile.y + 1) - 1);
-			if (!worldOnMap(avg) || !callback(avg, iHypot(avg), data))
+			if (!worldOnMap(worldMapState, avg) || !callback(avg, iHypot(avg), data))
 			{
 				return;  // Callback doesn't want any more points, or we reached the edge of the map, so return.
 			}
@@ -118,7 +118,7 @@ void rayCast(Vector2i src, Vector2i dst, RAY_CALLBACK callback, void *data)
 	}
 
 	// Include the endpoint.
-	if (!worldOnMap(dst))
+	if (!worldOnMap(worldMapState, dst))
 	{
 		return;  // Stop, since reached the edge of the map.
 	}
@@ -137,14 +137,14 @@ static bool getTileHeightCallback(Vector2i pos, int32_t dist, void *data)
 	/* Are we still on the grid? */
 	if (clipXY(pos.x, pos.y))
 	{
-		bool HasTallStructure = blockTile(map_coord(pos.x), map_coord(pos.y), AUX_MAP) & AIR_BLOCKED;
+		bool HasTallStructure = blockTile(worldMapState, map_coord(pos.x), map_coord(pos.y), AUX_MAP) & AIR_BLOCKED;
 
 		if (dist > TILE_UNITS || HasTallStructure)
 		{
 			// Only do it the current tile is > TILE_UNITS away from the starting tile. Or..
 			// there is a tall structure  on the current tile and the current tile is not the starting tile.
 			/* Get height at this intersection point */
-			int height = map_Height(pos.x, pos.y), heightDiff;
+			int height = map_Height(worldMapState, pos.x, pos.y), heightDiff;
 			uint16_t newPitch;
 
 			if (HasTallStructure)
@@ -190,7 +190,7 @@ static bool getTileHeightCallback(Vector2i pos, int32_t dist, void *data)
 
 void getBestPitchToEdgeOfGrid(UDWORD x, UDWORD y, uint16_t direction, uint16_t *pitch)
 {
-	HeightCallbackHelp_t help = {map_Height(x, y), 0};
+	HeightCallbackHelp_t help = {map_Height(worldMapState, x, y), 0};
 
 	Vector3i src(x, y, 0);
 	Vector3i delta(iSinCosR(direction, 5430), 0);

--- a/src/research.cpp
+++ b/src/research.cpp
@@ -1370,7 +1370,7 @@ void CancelAllResearch(UDWORD pl)
 {
 	if (pl >= MAX_PLAYERS) { return; }
 
-	for (STRUCTURE* psCurr : apsStructLists[pl])
+	for (STRUCTURE* psCurr : worldObjectState.structures[pl])
 	{
 		if (psCurr->pStructureType->type == REF_RESEARCH)
 		{
@@ -1655,8 +1655,8 @@ static void replaceComponent(COMPONENT_STATS *pNewComponent, COMPONENT_STATS *pO
 		return;
 	}
 
-	replaceDroidComponent(apsDroidLists[player], oldType, oldCompInc, newCompInc);
-	replaceDroidComponent(mission.apsDroidLists[player], oldType, oldCompInc, newCompInc);
+	replaceDroidComponent(worldObjectState.droids[player], oldType, oldCompInc, newCompInc);
+	replaceDroidComponent(mission.worldObjectState.droids[player], oldType, oldCompInc, newCompInc);
 	replaceDroidComponent(apsLimboDroids[player], oldType, oldCompInc, newCompInc);
 	const auto replaceComponentInTemplate = [oldType, oldCompInc, newCompInc](DROID_TEMPLATE* psTemplates) {
 		switch (oldType)
@@ -1692,7 +1692,7 @@ static void replaceComponent(COMPONENT_STATS *pNewComponent, COMPONENT_STATS *pO
 	//check thru the templates
 	enumerateTemplates(player, replaceComponentInTemplate);
 	// also check build queues
-	for (STRUCTURE *psCBuilding : apsStructLists[player])
+	for (STRUCTURE *psCBuilding : worldObjectState.structures[player])
 	{
 		if ((psCBuilding->pStructureType->type == STRUCTURE_TYPE::REF_FACTORY ||
 			psCBuilding->pStructureType->type == STRUCTURE_TYPE::REF_CYBORG_FACTORY ||
@@ -1702,8 +1702,8 @@ static void replaceComponent(COMPONENT_STATS *pNewComponent, COMPONENT_STATS *pO
 			replaceComponentInTemplate(psCBuilding->pFunctionality->factory.psSubject);
 		}
 	}
-	replaceStructureComponent(apsStructLists[player], oldType, oldCompInc, newCompInc, player);
-	replaceStructureComponent(mission.apsStructLists[player], oldType, oldCompInc, newCompInc, player);
+	replaceStructureComponent(worldObjectState.structures[player], oldType, oldCompInc, newCompInc, player);
+	replaceStructureComponent(mission.worldObjectState.structures[player], oldType, oldCompInc, newCompInc, player);
 }
 
 /*Looks through all the currently allocated stats to check the name is not
@@ -1756,7 +1756,7 @@ void researchReward(UBYTE losingPlayer, UBYTE rewardPlayer)
 	UDWORD topicIndex = 0, researchPoints = 0, rewardID = 0;
 
 	//look through the losing players structures to find a research facility
-	for (const STRUCTURE *psStruct : apsStructLists[losingPlayer])
+	for (const STRUCTURE *psStruct : worldObjectState.structures[losingPlayer])
 	{
 		if (psStruct->pStructureType->type == REF_RESEARCH)
 		{
@@ -1962,7 +1962,7 @@ std::vector<AllyResearch> const &listAllyResearch(unsigned ref)
 			}
 
 			// Check each research facility to see if they are doing this topic. (As opposed to having started the topic, but stopped researching it.)
-			for (const STRUCTURE *psStruct : apsStructLists[player])
+			for (const STRUCTURE *psStruct : worldObjectState.structures[player])
 			{
 				RESEARCH_FACILITY *res = (RESEARCH_FACILITY *)psStruct->pFunctionality;
 				if (psStruct->pStructureType->type != REF_RESEARCH || res->psSubject == nullptr)

--- a/src/research.cpp
+++ b/src/research.cpp
@@ -1370,7 +1370,7 @@ void CancelAllResearch(UDWORD pl)
 {
 	if (pl >= MAX_PLAYERS) { return; }
 
-	for (STRUCTURE* psCurr : worldObjectState.structures[pl])
+	for (STRUCTURE* psCurr : gameWorld.objects.structures[pl])
 	{
 		if (psCurr->pStructureType->type == REF_RESEARCH)
 		{
@@ -1655,8 +1655,8 @@ static void replaceComponent(COMPONENT_STATS *pNewComponent, COMPONENT_STATS *pO
 		return;
 	}
 
-	replaceDroidComponent(worldObjectState.droids[player], oldType, oldCompInc, newCompInc);
-	replaceDroidComponent(mission.worldObjectState.droids[player], oldType, oldCompInc, newCompInc);
+	replaceDroidComponent(gameWorld.objects.droids[player], oldType, oldCompInc, newCompInc);
+	replaceDroidComponent(mission.gameWorld.objects.droids[player], oldType, oldCompInc, newCompInc);
 	replaceDroidComponent(apsLimboDroids[player], oldType, oldCompInc, newCompInc);
 	const auto replaceComponentInTemplate = [oldType, oldCompInc, newCompInc](DROID_TEMPLATE* psTemplates) {
 		switch (oldType)
@@ -1692,7 +1692,7 @@ static void replaceComponent(COMPONENT_STATS *pNewComponent, COMPONENT_STATS *pO
 	//check thru the templates
 	enumerateTemplates(player, replaceComponentInTemplate);
 	// also check build queues
-	for (STRUCTURE *psCBuilding : worldObjectState.structures[player])
+	for (STRUCTURE *psCBuilding : gameWorld.objects.structures[player])
 	{
 		if ((psCBuilding->pStructureType->type == STRUCTURE_TYPE::REF_FACTORY ||
 			psCBuilding->pStructureType->type == STRUCTURE_TYPE::REF_CYBORG_FACTORY ||
@@ -1702,8 +1702,8 @@ static void replaceComponent(COMPONENT_STATS *pNewComponent, COMPONENT_STATS *pO
 			replaceComponentInTemplate(psCBuilding->pFunctionality->factory.psSubject);
 		}
 	}
-	replaceStructureComponent(worldObjectState.structures[player], oldType, oldCompInc, newCompInc, player);
-	replaceStructureComponent(mission.worldObjectState.structures[player], oldType, oldCompInc, newCompInc, player);
+	replaceStructureComponent(gameWorld.objects.structures[player], oldType, oldCompInc, newCompInc, player);
+	replaceStructureComponent(mission.gameWorld.objects.structures[player], oldType, oldCompInc, newCompInc, player);
 }
 
 /*Looks through all the currently allocated stats to check the name is not
@@ -1756,7 +1756,7 @@ void researchReward(UBYTE losingPlayer, UBYTE rewardPlayer)
 	UDWORD topicIndex = 0, researchPoints = 0, rewardID = 0;
 
 	//look through the losing players structures to find a research facility
-	for (const STRUCTURE *psStruct : worldObjectState.structures[losingPlayer])
+	for (const STRUCTURE *psStruct : gameWorld.objects.structures[losingPlayer])
 	{
 		if (psStruct->pStructureType->type == REF_RESEARCH)
 		{
@@ -1962,7 +1962,7 @@ std::vector<AllyResearch> const &listAllyResearch(unsigned ref)
 			}
 
 			// Check each research facility to see if they are doing this topic. (As opposed to having started the topic, but stopped researching it.)
-			for (const STRUCTURE *psStruct : worldObjectState.structures[player])
+			for (const STRUCTURE *psStruct : gameWorld.objects.structures[player])
 			{
 				RESEARCH_FACILITY *res = (RESEARCH_FACILITY *)psStruct->pFunctionality;
 				if (psStruct->pStructureType->type != REF_RESEARCH || res->psSubject == nullptr)

--- a/src/scores.cpp
+++ b/src/scores.cpp
@@ -299,8 +299,8 @@ END_GAME_STATS_DATA	collectEndGameStatsData()
 			DroidList* dList = nullptr;
 			switch (idx)
 			{
-				case 0: dList = &apsDroidLists[selectedPlayer]; break;
-				case 1: dList = &mission.apsDroidLists[selectedPlayer]; break;
+				case 0: dList = &worldObjectState.droids[selectedPlayer]; break;
+				case 1: dList = &mission.worldObjectState.droids[selectedPlayer]; break;
 				case 2: if (prevMissionType == LEVEL_TYPE::LDS_MKEEP_LIMBO) { dList = &apsLimboDroids[selectedPlayer]; } break;
 				default: dList = nullptr;
 			}
@@ -624,12 +624,12 @@ void stdOutGameSummary(UDWORD realTimeThrottleSeconds, bool flush_output /* = tr
 				continue;
 			}
 			uint32_t unitsKilled = getMultiPlayUnitsKilled(n);
-			uint32_t numUnits = apsDroidLists[n].size();
-			uint32_t numStructs = apsStructLists[n].size();
+			uint32_t numUnits = worldObjectState.droids[n].size();
+			uint32_t numStructs = worldObjectState.structures[n].size();
 			uint32_t numFactories = 0;
 			uint32_t numResearch = 0;
 			uint32_t numFactoriesThatCanProduceConstructionUnits = 0;
-			for (const STRUCTURE *psStruct : apsStructLists[n])
+			for (const STRUCTURE *psStruct : worldObjectState.structures[n])
 			{
 				if (psStruct->status != SS_BUILT || psStruct->died != 0)
 				{

--- a/src/scores.cpp
+++ b/src/scores.cpp
@@ -299,8 +299,8 @@ END_GAME_STATS_DATA	collectEndGameStatsData()
 			DroidList* dList = nullptr;
 			switch (idx)
 			{
-				case 0: dList = &worldObjectState.droids[selectedPlayer]; break;
-				case 1: dList = &mission.worldObjectState.droids[selectedPlayer]; break;
+				case 0: dList = &gameWorld.objects.droids[selectedPlayer]; break;
+				case 1: dList = &mission.gameWorld.objects.droids[selectedPlayer]; break;
 				case 2: if (prevMissionType == LEVEL_TYPE::LDS_MKEEP_LIMBO) { dList = &apsLimboDroids[selectedPlayer]; } break;
 				default: dList = nullptr;
 			}
@@ -624,12 +624,12 @@ void stdOutGameSummary(UDWORD realTimeThrottleSeconds, bool flush_output /* = tr
 				continue;
 			}
 			uint32_t unitsKilled = getMultiPlayUnitsKilled(n);
-			uint32_t numUnits = worldObjectState.droids[n].size();
-			uint32_t numStructs = worldObjectState.structures[n].size();
+			uint32_t numUnits = gameWorld.objects.droids[n].size();
+			uint32_t numStructs = gameWorld.objects.structures[n].size();
 			uint32_t numFactories = 0;
 			uint32_t numResearch = 0;
 			uint32_t numFactoriesThatCanProduceConstructionUnits = 0;
-			for (const STRUCTURE *psStruct : worldObjectState.structures[n])
+			for (const STRUCTURE *psStruct : gameWorld.objects.structures[n])
 			{
 				if (psStruct->status != SS_BUILT || psStruct->died != 0)
 				{

--- a/src/selection.cpp
+++ b/src/selection.cpp
@@ -60,7 +60,7 @@ static unsigned selSelectUnitsIf(unsigned player, T condition, bool onlyOnScreen
 	selDroidDeselect(player);
 
 	// Go through all.
-	for (DROID *psDroid : worldObjectState.droids[player])
+	for (DROID *psDroid : gameWorld.objects.droids[player])
 	{
 		bool shouldSelect = (!onlyOnScreen || objectOnScreen(psDroid, 0)) &&
 		                    condition(psDroid);
@@ -142,7 +142,7 @@ unsigned int selDroidDeselect(unsigned int player)
 	unsigned int count = 0;
 	if (player >= MAX_PLAYERS) { return 0; }
 
-	for (DROID* psDroid : worldObjectState.droids[player])
+	for (DROID* psDroid : gameWorld.objects.droids[player])
 	{
 		if (psDroid->selected)
 		{
@@ -161,7 +161,7 @@ unsigned int selNumSelected(unsigned int player)
 	unsigned int count = 0;
 	if (player >= MAX_PLAYERS) { return 0; }
 
-	for (const DROID *psDroid : worldObjectState.droids[player])
+	for (const DROID *psDroid : gameWorld.objects.droids[player])
 	{
 		if (psDroid->selected)
 		{
@@ -239,7 +239,7 @@ static unsigned int selSelectAllSame(unsigned int player, bool bOnScreen)
 	if (player >= MAX_PLAYERS) { return 0; }
 
 	// find out which units will need to be compared to which component combinations
-	for (DROID *psDroid : worldObjectState.droids[player])
+	for (DROID *psDroid : gameWorld.objects.droids[player])
 	{
 		if (bOnScreen && !objectOnScreen(psDroid, 0))
 		{
@@ -260,7 +260,7 @@ static unsigned int selSelectAllSame(unsigned int player, bool bOnScreen)
 	{
 		// reset unit counter
 		i = 0;
-		for (DROID *psDroid : worldObjectState.droids[player])
+		for (DROID *psDroid : gameWorld.objects.droids[player])
 		{
 			if (excluded.empty() || *excluded.begin() != i)
 			{
@@ -290,7 +290,7 @@ void selNextSpecifiedUnit(DROID_TYPE unitType)
 
 	ASSERT_OR_RETURN(, selectedPlayer < MAX_PLAYERS, "invalid selectedPlayer: %" PRIu32 "", selectedPlayer);
 
-	for (DROID *psCurr : worldObjectState.droids[selectedPlayer])
+	for (DROID *psCurr : gameWorld.objects.droids[selectedPlayer])
 	{
 		//exceptions - as always...
 		bool bMatch = false;
@@ -398,7 +398,7 @@ void selNextUnassignedUnit()
 
 	ASSERT_OR_RETURN(, selectedPlayer < MAX_PLAYERS, "invalid selectedPlayer: %" PRIu32 "", selectedPlayer);
 
-	for (DROID *psCurr : worldObjectState.droids[selectedPlayer])
+	for (DROID *psCurr : gameWorld.objects.droids[selectedPlayer])
 	{
 		/* Only look at unselected ones */
 		if (psCurr->group == UBYTE_MAX)
@@ -472,7 +472,7 @@ void selNextSpecifiedBuilding(STRUCTURE_TYPE structType, bool jump)
 	/* Firstly, start coughing if the type is invalid */
 	ASSERT(structType <= NUM_DIFF_BUILDINGS, "Invalid structure type %u", structType);
 
-	for (STRUCTURE *psCurr : worldObjectState.structures[selectedPlayer])
+	for (STRUCTURE *psCurr : gameWorld.objects.structures[selectedPlayer])
 	{
 		if (psResult)
 		{
@@ -536,7 +536,7 @@ static bool droidIsCommanderNum(DROID *psDroid, SDWORD n)
 	}
 
 	int numLess = 0;
-	for (const DROID *psCurr : worldObjectState.droids[psDroid->player])
+	for (const DROID *psCurr : gameWorld.objects.droids[psDroid->player])
 	{
 		if ((psCurr->droidType == DROID_COMMAND) && (psCurr->id < psDroid->id))
 		{
@@ -552,7 +552,7 @@ void selCommander(int n)
 {
 	ASSERT_OR_RETURN(, selectedPlayer < MAX_PLAYERS, "invalid selectedPlayer: %" PRIu32 "", selectedPlayer);
 
-	for (DROID *psCurr : worldObjectState.droids[selectedPlayer])
+	for (DROID *psCurr : gameWorld.objects.droids[selectedPlayer])
 	{
 		if (droidIsCommanderNum(psCurr, n))
 		{

--- a/src/selection.cpp
+++ b/src/selection.cpp
@@ -60,7 +60,7 @@ static unsigned selSelectUnitsIf(unsigned player, T condition, bool onlyOnScreen
 	selDroidDeselect(player);
 
 	// Go through all.
-	for (DROID *psDroid : apsDroidLists[player])
+	for (DROID *psDroid : worldObjectState.droids[player])
 	{
 		bool shouldSelect = (!onlyOnScreen || objectOnScreen(psDroid, 0)) &&
 		                    condition(psDroid);
@@ -142,7 +142,7 @@ unsigned int selDroidDeselect(unsigned int player)
 	unsigned int count = 0;
 	if (player >= MAX_PLAYERS) { return 0; }
 
-	for (DROID* psDroid : apsDroidLists[player])
+	for (DROID* psDroid : worldObjectState.droids[player])
 	{
 		if (psDroid->selected)
 		{
@@ -161,7 +161,7 @@ unsigned int selNumSelected(unsigned int player)
 	unsigned int count = 0;
 	if (player >= MAX_PLAYERS) { return 0; }
 
-	for (const DROID *psDroid : apsDroidLists[player])
+	for (const DROID *psDroid : worldObjectState.droids[player])
 	{
 		if (psDroid->selected)
 		{
@@ -239,7 +239,7 @@ static unsigned int selSelectAllSame(unsigned int player, bool bOnScreen)
 	if (player >= MAX_PLAYERS) { return 0; }
 
 	// find out which units will need to be compared to which component combinations
-	for (DROID *psDroid : apsDroidLists[player])
+	for (DROID *psDroid : worldObjectState.droids[player])
 	{
 		if (bOnScreen && !objectOnScreen(psDroid, 0))
 		{
@@ -260,7 +260,7 @@ static unsigned int selSelectAllSame(unsigned int player, bool bOnScreen)
 	{
 		// reset unit counter
 		i = 0;
-		for (DROID *psDroid : apsDroidLists[player])
+		for (DROID *psDroid : worldObjectState.droids[player])
 		{
 			if (excluded.empty() || *excluded.begin() != i)
 			{
@@ -290,7 +290,7 @@ void selNextSpecifiedUnit(DROID_TYPE unitType)
 
 	ASSERT_OR_RETURN(, selectedPlayer < MAX_PLAYERS, "invalid selectedPlayer: %" PRIu32 "", selectedPlayer);
 
-	for (DROID *psCurr : apsDroidLists[selectedPlayer])
+	for (DROID *psCurr : worldObjectState.droids[selectedPlayer])
 	{
 		//exceptions - as always...
 		bool bMatch = false;
@@ -398,7 +398,7 @@ void selNextUnassignedUnit()
 
 	ASSERT_OR_RETURN(, selectedPlayer < MAX_PLAYERS, "invalid selectedPlayer: %" PRIu32 "", selectedPlayer);
 
-	for (DROID *psCurr : apsDroidLists[selectedPlayer])
+	for (DROID *psCurr : worldObjectState.droids[selectedPlayer])
 	{
 		/* Only look at unselected ones */
 		if (psCurr->group == UBYTE_MAX)
@@ -472,7 +472,7 @@ void selNextSpecifiedBuilding(STRUCTURE_TYPE structType, bool jump)
 	/* Firstly, start coughing if the type is invalid */
 	ASSERT(structType <= NUM_DIFF_BUILDINGS, "Invalid structure type %u", structType);
 
-	for (STRUCTURE *psCurr : apsStructLists[selectedPlayer])
+	for (STRUCTURE *psCurr : worldObjectState.structures[selectedPlayer])
 	{
 		if (psResult)
 		{
@@ -536,7 +536,7 @@ static bool droidIsCommanderNum(DROID *psDroid, SDWORD n)
 	}
 
 	int numLess = 0;
-	for (const DROID *psCurr : apsDroidLists[psDroid->player])
+	for (const DROID *psCurr : worldObjectState.droids[psDroid->player])
 	{
 		if ((psCurr->droidType == DROID_COMMAND) && (psCurr->id < psDroid->id))
 		{
@@ -552,7 +552,7 @@ void selCommander(int n)
 {
 	ASSERT_OR_RETURN(, selectedPlayer < MAX_PLAYERS, "invalid selectedPlayer: %" PRIu32 "", selectedPlayer);
 
-	for (DROID *psCurr : apsDroidLists[selectedPlayer])
+	for (DROID *psCurr : worldObjectState.droids[selectedPlayer])
 	{
 		if (droidIsCommanderNum(psCurr, n))
 		{

--- a/src/structure.cpp
+++ b/src/structure.cpp
@@ -1531,13 +1531,13 @@ STRUCTURE *buildStructureDir(STRUCTURE_STATS *pStructureType, UDWORD x, UDWORD y
 		y = (y & ~TILE_MASK) + size.y % 2 * TILE_UNITS / 2;
 
 		//check not trying to build too near the edge
-		if (map_coord(x) < TOO_NEAR_EDGE || map_coord(x) > (mapWidth - TOO_NEAR_EDGE))
+		if (map_coord(x) < TOO_NEAR_EDGE || map_coord(x) > (worldMapState.width - TOO_NEAR_EDGE))
 		{
 			debug(LOG_WARNING, "attempting to build too closely to map-edge, "
 			      "x coord (%u) too near edge (req. distance is %u)", x, TOO_NEAR_EDGE);
 			return nullptr;
 		}
-		if (map_coord(y) < TOO_NEAR_EDGE || map_coord(y) > (mapHeight - TOO_NEAR_EDGE))
+		if (map_coord(y) < TOO_NEAR_EDGE || map_coord(y) > (worldMapState.height - TOO_NEAR_EDGE))
 		{
 			debug(LOG_WARNING, "attempting to build too closely to map-edge, "
 			      "y coord (%u) too near edge (req. distance is %u)", y, TOO_NEAR_EDGE);
@@ -1735,15 +1735,15 @@ STRUCTURE *buildStructureDir(STRUCTURE_STATS *pStructureType, UDWORD x, UDWORD y
 		if (FromSave && player == selectedPlayer && missionLimboExpand())
 		{
 			//save the current values
-			preScrollMinX = scrollMinX;
-			preScrollMinY = scrollMinY;
-			preScrollMaxX = scrollMaxX;
-			preScrollMaxY = scrollMaxY;
+			preScrollMinX = worldMapState.scroll.minX;
+			preScrollMinY = worldMapState.scroll.minY;
+			preScrollMaxX = worldMapState.scroll.maxX;
+			preScrollMaxY = worldMapState.scroll.maxY;
 			//set the current values to mapWidth/mapHeight
-			scrollMinX = 0;
-			scrollMinY = 0;
-			scrollMaxX = mapWidth;
-			scrollMaxY = mapHeight;
+			worldMapState.scroll.minX = 0;
+			worldMapState.scroll.minY = 0;
+			worldMapState.scroll.maxX = worldMapState.width;
+			worldMapState.scroll.maxY = worldMapState.height;
 			// NOTE: resizeRadar() may be required here, since we change scroll limits?
 		}
 		//set the functionality dependent on the type of structure
@@ -1755,10 +1755,10 @@ STRUCTURE *buildStructureDir(STRUCTURE_STATS *pStructureType, UDWORD x, UDWORD y
 			if (FromSave && player == selectedPlayer && missionLimboExpand())
 			{
 				//reset the current values
-				scrollMinX = preScrollMinX;
-				scrollMinY = preScrollMinY;
-				scrollMaxX = preScrollMaxX;
-				scrollMaxY = preScrollMaxY;
+				worldMapState.scroll.minX = preScrollMinX;
+				worldMapState.scroll.minY = preScrollMinY;
+				worldMapState.scroll.maxX = preScrollMaxX;
+				worldMapState.scroll.maxY = preScrollMaxY;
 				// NOTE: resizeRadar() may be required here, since we change scroll limits?
 			}
 			return nullptr;
@@ -1768,10 +1768,10 @@ STRUCTURE *buildStructureDir(STRUCTURE_STATS *pStructureType, UDWORD x, UDWORD y
 		if (FromSave && player == selectedPlayer && missionLimboExpand())
 		{
 			//reset the current values
-			scrollMinX = preScrollMinX;
-			scrollMinY = preScrollMinY;
-			scrollMaxX = preScrollMaxX;
-			scrollMaxY = preScrollMaxY;
+			worldMapState.scroll.minX = preScrollMinX;
+			worldMapState.scroll.minY = preScrollMinY;
+			worldMapState.scroll.maxX = preScrollMaxX;
+			worldMapState.scroll.maxY = preScrollMaxY;
 			// NOTE: resizeRadar() may be required here, since we change scroll limits?
 		}
 
@@ -2488,9 +2488,9 @@ bool placeDroid(STRUCTURE *psStructure, const DROID_TEMPLATE * psTempl, UDWORD *
 	// Find the four corners of the square
 	StructureBounds bounds = getStructureBounds(psStructure);
 	int xmin = std::max(bounds.map.x - 1, 0);
-	int xmax = std::min(bounds.map.x + bounds.size.x, mapWidth);
+	int xmax = std::min(bounds.map.x + bounds.size.x, worldMapState.width);
 	int ymin = std::max(bounds.map.y - 1, 0);
-	int ymax = std::min(bounds.map.y + bounds.size.y, mapHeight);
+	int ymax = std::min(bounds.map.y + bounds.size.y, worldMapState.height);
 
 	// Round direction to nearest 90°.
 	uint16_t direction = snapDirection(psStructure->rot.direction);
@@ -4278,8 +4278,8 @@ bool validLocation(BASE_STATS *psStats, Vector2i pos, uint16_t direction, unsign
 	StructureBounds b = getStructureBounds(psStats, pos, direction);
 
 	//make sure we are not too near map edge and not going to go over it
-	if (b.map.x < scrollMinX + TOO_NEAR_EDGE || b.map.x + b.size.x > scrollMaxX - TOO_NEAR_EDGE ||
-	    b.map.y < scrollMinY + TOO_NEAR_EDGE || b.map.y + b.size.y > scrollMaxY - TOO_NEAR_EDGE)
+	if (b.map.x < worldMapState.scroll.minX + TOO_NEAR_EDGE || b.map.x + b.size.x > worldMapState.scroll.maxX - TOO_NEAR_EDGE ||
+	    b.map.y < worldMapState.scroll.minY + TOO_NEAR_EDGE || b.map.y + b.size.y > worldMapState.scroll.maxY - TOO_NEAR_EDGE)
 	{
 		return false;
 	}
@@ -6069,9 +6069,9 @@ void hqReward(UBYTE losingPlayer, UBYTE rewardPlayer)
 	ASSERT_OR_RETURN(, losingPlayer < MAX_PLAYERS && rewardPlayer < MAX_PLAYERS, "losingPlayer (%" PRIu8 "), rewardPlayer (%" PRIu8 ") must both be < MAXPLAYERS", losingPlayer, rewardPlayer);
 
 	// share exploration info - pretty useless but perhaps a nice touch?
-	for (int y = 0; y < mapHeight; ++y)
+	for (int y = 0; y < worldMapState.height; ++y)
 	{
-		for (int x = 0; x < mapWidth; ++x)
+		for (int x = 0; x < worldMapState.width; ++x)
 		{
 			MAPTILE *psTile = mapTile(x, y);
 			if (TEST_TILE_VISIBLE(losingPlayer, psTile))

--- a/src/structure.cpp
+++ b/src/structure.cpp
@@ -171,10 +171,10 @@ static void auxStructureNonblocking(STRUCTURE *psStructure)
 		{
 			int x = b.map.x + i;
 			int y = b.map.y + j;
-			MAPTILE *psTile = mapTile(x, y);
+			MAPTILE *psTile = mapTile(worldMapState, x, y);
 			if (psTile->psObject == psStructure)
 			{
-				auxClearAll(x, y, AUXBITS_BLOCKING | AUXBITS_OUR_BUILDING | AUXBITS_NONPASSABLE);
+				auxClearAll(worldMapState, x, y, AUXBITS_BLOCKING | AUXBITS_OUR_BUILDING | AUXBITS_NONPASSABLE);
 			}
 			else
 			{
@@ -193,8 +193,8 @@ static void auxStructureBlocking(STRUCTURE *psStructure)
 	{
 		for (int j = 0; j < b.size.y; j++)
 		{
-			auxSetAllied(b.map.x + i, b.map.y + j, psStructure->player, AUXBITS_OUR_BUILDING);
-			auxSetAll(b.map.x + i, b.map.y + j, AUXBITS_BLOCKING | AUXBITS_NONPASSABLE);
+			auxSetAllied(worldMapState, b.map.x + i, b.map.y + j, psStructure->player, AUXBITS_OUR_BUILDING);
+			auxSetAll(worldMapState, b.map.x + i, b.map.y + j, AUXBITS_BLOCKING | AUXBITS_NONPASSABLE);
 		}
 	}
 }
@@ -207,7 +207,7 @@ static void auxStructureOpenGate(STRUCTURE *psStructure)
 	{
 		for (int j = 0; j < b.size.y; j++)
 		{
-			auxClearAll(b.map.x + i, b.map.y + j, AUXBITS_BLOCKING);
+			auxClearAll(worldMapState, b.map.x + i, b.map.y + j, AUXBITS_BLOCKING);
 		}
 	}
 }
@@ -220,8 +220,8 @@ static void auxStructureClosedGate(STRUCTURE *psStructure)
 	{
 		for (int j = 0; j < b.size.y; j++)
 		{
-			auxSetEnemy(b.map.x + i, b.map.y + j, psStructure->player, AUXBITS_NONPASSABLE);
-			auxSetAll(b.map.x + i, b.map.y + j, AUXBITS_BLOCKING);
+			auxSetEnemy(worldMapState, b.map.x + i, b.map.y + j, psStructure->player, AUXBITS_NONPASSABLE);
+			auxSetAll(worldMapState, b.map.x + i, b.map.y + j, AUXBITS_BLOCKING);
 		}
 	}
 }
@@ -257,7 +257,7 @@ bool isBlueprint(const BASE_OBJECT *psObject)
 static void displayConstructionCloud(const Vector3i &pos)
 {
 	const Vector2i coordinates = {pos.x, pos.y};
-	const MAPTILE *psTile = mapTile(map_coord(coordinates));
+	const MAPTILE *psTile = mapTile(worldMapState, map_coord(coordinates));
 	if (!tileIsClearlyVisible(psTile))
 	{
 		return;
@@ -266,7 +266,7 @@ static void displayConstructionCloud(const Vector3i &pos)
 	Vector3i iVecEffect;
 
 	iVecEffect.x = pos.x;
-	iVecEffect.y = map_Height(pos.x, pos.y) + DROID_CONSTRUCTION_SMOKE_HEIGHT;
+	iVecEffect.y = map_Height(worldMapState, pos.x, pos.y) + DROID_CONSTRUCTION_SMOKE_HEIGHT;
 	iVecEffect.z = pos.y;
 	addEffect(&iVecEffect, EFFECT_CONSTRUCTION, CONSTRUCTION_TYPE_DRIFTING, false, nullptr, 0, gameTime - deltaGameTime + 1);
 	iVecEffect.x = pos.x - DROID_CONSTRUCTION_SMOKE_OFFSET;
@@ -1272,7 +1272,7 @@ static void structFindWalls(unsigned player, Vector2i map, bool aWallPresent[5][
 	for (int y = -2; y <= 2; ++y)
 		for (int x = -2; x <= 2; ++x)
 		{
-			STRUCTURE *psStruct = castStructure(mapTile(map.x + x, map.y + y)->psObject);
+			STRUCTURE *psStruct = castStructure(mapTile(worldMapState, map.x + x, map.y + y)->psObject);
 			if (psStruct != nullptr && isWallCombiningStructureType(psStruct->pStructureType) && player < MAX_PLAYERS && aiCheckAlliances(player, psStruct->player))
 			{
 				aWallPresent[x + 2][y + 2] = true;
@@ -1298,7 +1298,7 @@ static void structFindWallBlueprints(Vector2i map, bool aWallPresent[5][5])
 
 static bool wallBlockingTerrainJoin(Vector2i map)
 {
-	MAPTILE *psTile = mapTile(map);
+	MAPTILE *psTile = mapTile(worldMapState, map);
 	return terrainType(psTile) == TER_WATER || terrainType(psTile) == TER_CLIFFFACE || psTile->psObject != nullptr;
 }
 
@@ -1405,7 +1405,7 @@ static int foundationHeight(const STRUCTURE *psStruct)
 	{
 		for (int width = 0; width <= b.size.x; width++)
 		{
-			int height = map_TileHeight(b.map.x + width, b.map.y + breadth);
+			int height = map_TileHeight(worldMapState, b.map.x + width, b.map.y + breadth);
 			foundationMin = std::min(foundationMin, height);
 			foundationMax = std::max(foundationMax, height);
 		}
@@ -1423,9 +1423,9 @@ static void buildFlatten(STRUCTURE *pStructure, int h)
 	{
 		for (int width = 0; width <= b.size.x; ++width)
 		{
-			setTileHeight(b.map.x + width, b.map.y + breadth, h);
+			setTileHeight(worldMapState, b.map.x + width, b.map.y + breadth, h);
 			// We need to raise features on raised tiles to the new height
-			if (TileHasFeature(mapTile(b.map.x + width, b.map.y + breadth)))
+			if (TileHasFeature(mapTile(worldMapState, b.map.x + width, b.map.y + breadth)))
 			{
 				getTileFeature(b.map.x + width, b.map.y + breadth)->pos.z = h;
 			}
@@ -1457,7 +1457,7 @@ void alignStructure(STRUCTURE *psBuilding)
 		{
 			for (int width = -1; width <= b.size.x; ++width)
 			{
-				STRUCTURE *neighbourStructure = castStructure(mapTile(b.map.x + width, b.map.y + breadth)->psObject);
+				STRUCTURE *neighbourStructure = castStructure(mapTile(worldMapState, b.map.x + width, b.map.y + breadth)->psObject);
 				if (neighbourStructure != nullptr && isPulledToTerrain(neighbourStructure))
 				{
 					alignStructure(neighbourStructure);  // Recursive call, but will go to the else case, so will not re-recurse.
@@ -1479,10 +1479,10 @@ void alignStructure(STRUCTURE *psBuilding)
 		Vector2i p1{s->max.x * dir.y - s->max.z * dir.x, s->max.x * dir.x + s->max.z * dir.y};
 		Vector2i p2{s->min.x * dir.y - s->min.z * dir.x, s->min.x * dir.x + s->min.z * dir.y};
 
-		int h1 = map_Height(psBuilding->pos.x + p1.x, psBuilding->pos.y + p2.y);
-		int h2 = map_Height(psBuilding->pos.x + p1.x, psBuilding->pos.y + p1.y);
-		int h3 = map_Height(psBuilding->pos.x + p2.x, psBuilding->pos.y + p1.y);
-		int h4 = map_Height(psBuilding->pos.x + p2.x, psBuilding->pos.y + p2.y);
+		int h1 = map_Height(worldMapState, psBuilding->pos.x + p1.x, psBuilding->pos.y + p2.y);
+		int h2 = map_Height(worldMapState, psBuilding->pos.x + p1.x, psBuilding->pos.y + p1.y);
+		int h3 = map_Height(worldMapState, psBuilding->pos.x + p2.x, psBuilding->pos.y + p1.y);
+		int h4 = map_Height(worldMapState, psBuilding->pos.x + p2.x, psBuilding->pos.y + p2.y);
 		int minH = std::min({h1, h2, h3, h4});
 		int maxH = std::max({h1, h2, h3, h4});
 		psBuilding->pos.z = std::max(psBuilding->pos.z, maxH);
@@ -1587,7 +1587,7 @@ STRUCTURE *buildStructureDir(STRUCTURE_STATS *pStructureType, UDWORD x, UDWORD y
 
 			if (psFeature && psFeature->psStats->subType == FEAT_OIL_RESOURCE)
 			{
-				if (fireOnLocation(psFeature->pos.x, psFeature->pos.y))
+				if (fireOnLocation(worldMapState, psFeature->pos.x, psFeature->pos.y))
 				{
 					// Can't build on burning oil resource
 					return nullptr;
@@ -1603,7 +1603,7 @@ STRUCTURE *buildStructureDir(STRUCTURE_STATS *pStructureType, UDWORD x, UDWORD y
 		{
 			for (int tileX = map.x; tileX < map.x + size.x; ++tileX)
 			{
-				MAPTILE *psTile = mapTile(tileX, tileY);
+				MAPTILE *psTile = mapTile(worldMapState, tileX, tileY);
 
 				/* Remove any walls underneath the building. You can build defense buildings on top
 				 * of walls, you see. This is not the place to test whether we own it! */
@@ -1635,13 +1635,13 @@ STRUCTURE *buildStructureDir(STRUCTURE_STATS *pStructureType, UDWORD x, UDWORD y
 			for (int tileX = map.x; tileX < map.x + size.x; ++tileX)
 			{
 				// We now know the previous loop didn't return early, so it is safe to save references to `stableBuilding` now.
-				MAPTILE *psTile = mapTile(tileX, tileY);
+				MAPTILE *psTile = mapTile(worldMapState, tileX, tileY);
 				psTile->psObject = psBuilding;
 
 				// if it's a tall structure then flag it in the map.
 				if (psBuilding->sDisplay.imd && psBuilding->sDisplay.imd->max.y > TALLOBJECT_YMAX)
 				{
-					auxSetBlocking(tileX, tileY, AIR_BLOCKED);
+					auxSetBlocking(worldMapState, tileX, tileY, AIR_BLOCKED);
 				}
 			}
 		}
@@ -1988,7 +1988,7 @@ optional<STRUCTURE> buildBlueprint(STRUCTURE_STATS const *psStats, Vector3i pos,
 	std::vector<iIMDBaseShape *> const *pIMD = &psStats->pIMD;
 	if (IsStatExpansionModule(psStats))
 	{
-		STRUCTURE *baseStruct = castStructure(worldTile(pos.xy())->psObject);
+		STRUCTURE *baseStruct = castStructure(worldTile(worldMapState, pos.xy())->psObject);
 		if (baseStruct != nullptr)
 		{
 			if (moduleIndex == 0)
@@ -3989,7 +3989,7 @@ void structureUpdate(STRUCTURE *psBuilding, bool bMission)
 				realY = static_cast<SDWORD>(structHeightScale(psBuilding) * point->y);
 				position.y = psBuilding->pos.z + realY;
 				position.z = static_cast<int>(psBuilding->pos.y - point->z);
-				const auto psTile = mapTile(map_coord({position.x, position.y}));
+				const auto psTile = mapTile(worldMapState, map_coord({position.x, position.y}));
 				if (tileIsClearlyVisible(psTile))
 				{
 					effectSetSize(30);
@@ -4308,7 +4308,7 @@ bool validLocation(BASE_STATS *psStats, Vector2i pos, uint16_t direction, unsign
 			{
 				// Don't allow building structures (allow delivery points, though) outside visible area in single-player with debug mode off. (Why..?)
 				const DebugInputManager& dbgInputManager = gInputManager.debugManager();
-				if (!bMultiPlayer && !dbgInputManager.debugMappingsAllowed() && !TEST_TILE_VISIBLE(player, mapTile(b.map.x + i, b.map.y + j)))
+				if (!bMultiPlayer && !dbgInputManager.debugMappingsAllowed() && !TEST_TILE_VISIBLE(player, mapTile(worldMapState, b.map.x + i, b.map.y + j)))
 				{
 					return false;
 				}
@@ -4346,7 +4346,7 @@ bool validLocation(BASE_STATS *psStats, Vector2i pos, uint16_t direction, unsign
 				for (int j = 0; j < b.size.y; ++j)
 					for (int i = 0; i < b.size.x; ++i)
 					{
-						MAPTILE const *psTile = mapTile(b.map.x + i, b.map.y + j);
+						MAPTILE const *psTile = mapTile(worldMapState, b.map.x + i, b.map.y + j);
 						if ((terrainType(psTile) == TER_WATER) ||
 						    (terrainType(psTile) == TER_CLIFFFACE))
 						{
@@ -4397,7 +4397,7 @@ bool validLocation(BASE_STATS *psStats, Vector2i pos, uint16_t direction, unsign
 						//skip the actual area the structure will cover
 						if (i < 0 || i >= b.size.x || j < 0 || j >= b.size.y)
 						{
-							BASE_OBJECT *object = mapTile(b.map.x + i, b.map.y + j)->psObject;
+							BASE_OBJECT *object = mapTile(worldMapState, b.map.x + i, b.map.y + j)->psObject;
 							STRUCTURE *structure = castStructure(object);
 							if (structure != nullptr && !structure->visible[player] && !aiCheckAlliances(player, structure->player))
 							{
@@ -4441,7 +4441,7 @@ bool validLocation(BASE_STATS *psStats, Vector2i pos, uint16_t direction, unsign
 				for (int j = 0; j < b.size.y; ++j)
 					for (int i = 0; i < b.size.x; ++i)
 					{
-						MAPTILE const *psTile = mapTile(b.map.x + i, b.map.y + j);
+						MAPTILE const *psTile = mapTile(worldMapState, b.map.x + i, b.map.y + j);
 						if (TileIsKnownOccupied(psTile, player))
 						{
 							if (TileHasWall(psTile) && (psBuilding->type == REF_DEFENSE || psBuilding->type == REF_GATE || psBuilding->type == REF_WALL))
@@ -4461,7 +4461,7 @@ bool validLocation(BASE_STATS *psStats, Vector2i pos, uint16_t direction, unsign
 				break;
 			}
 		case REF_FACTORY_MODULE:
-			if (TileHasStructure(worldTile(pos)))
+			if (TileHasStructure(worldTile(worldMapState, pos)))
 			{
 				STRUCTURE const *psStruct = getTileStructure(map_coord(pos.x), map_coord(pos.y));
 				if (psStruct && (psStruct->pStructureType->type == REF_FACTORY ||
@@ -4474,7 +4474,7 @@ bool validLocation(BASE_STATS *psStats, Vector2i pos, uint16_t direction, unsign
 			}
 			return false;
 		case REF_RESEARCH_MODULE:
-			if (TileHasStructure(worldTile(pos)))
+			if (TileHasStructure(worldTile(worldMapState, pos)))
 			{
 				STRUCTURE const *psStruct = getTileStructure(map_coord(pos.x), map_coord(pos.y));
 				if (psStruct && psStruct->pStructureType->type == REF_RESEARCH
@@ -4487,7 +4487,7 @@ bool validLocation(BASE_STATS *psStats, Vector2i pos, uint16_t direction, unsign
 			}
 			return false;
 		case REF_POWER_MODULE:
-			if (TileHasStructure(worldTile(pos)))
+			if (TileHasStructure(worldTile(worldMapState, pos)))
 			{
 				STRUCTURE const *psStruct = getTileStructure(map_coord(pos.x), map_coord(pos.y));
 				if (psStruct && psStruct->pStructureType->type == REF_POWER_GEN
@@ -4500,7 +4500,7 @@ bool validLocation(BASE_STATS *psStats, Vector2i pos, uint16_t direction, unsign
 			}
 			return false;
 		case REF_RESOURCE_EXTRACTOR:
-			if (TileHasFeature(worldTile(pos)))
+			if (TileHasFeature(worldTile(worldMapState, pos)))
 			{
 				FEATURE const *psFeat = getTileFeature(map_coord(pos.x), map_coord(pos.y));
 				if (psFeat && psFeat->psStats->subType == FEAT_OIL_RESOURCE)
@@ -4550,11 +4550,11 @@ static void removeStructFromMap(STRUCTURE *psStruct)
 	{
 		for (int i = 0; i < b.size.x; ++i)
 		{
-			MAPTILE *psTile = mapTile(b.map.x + i, b.map.y + j);
+			MAPTILE *psTile = mapTile(worldMapState, b.map.x + i, b.map.y + j);
 			if (psTile->psObject == psStruct)
 			{
 				psTile->psObject = nullptr;
-				auxClearBlocking(b.map.x + i, b.map.y + j, AIR_BLOCKED);
+				auxClearBlocking(worldMapState, b.map.x + i, b.map.y + j, AIR_BLOCKED);
 			}
 		}
 	}
@@ -4723,7 +4723,7 @@ bool destroyStruct(STRUCTURE *psDel, unsigned impactTime)
 		/* Get coordinates for everybody! */
 		pos.x = psDel->pos.x;
 		pos.z = psDel->pos.y;  // z = y [sic] intentional
-		pos.y = map_Height(pos.x, pos.z);
+		pos.y = map_Height(worldMapState, pos.x, pos.z);
 
 		// Set off a fire, provide dimensions for the fire
 		if (bMinor)
@@ -4793,7 +4793,7 @@ bool destroyStruct(STRUCTURE *psDel, unsigned impactTime)
 	}
 
 	// Actually set the tiles on fire - even if the effect is not visible.
-	tileSetFire(psDel->pos.x, psDel->pos.y, burnDuration);
+	tileSetFire(worldMapState, psDel->pos.x, psDel->pos.y, burnDuration);
 
 	const bool resourceFound = removeStruct(psDel, true);
 	psDel->died = impactTime;
@@ -4806,7 +4806,7 @@ bool destroyStruct(STRUCTURE *psDel, unsigned impactTime)
 		{
 			for (int width = 0; width < b.size.x; ++width)
 			{
-				MAPTILE *psTile = mapTile(b.map.x + width, b.map.y + breadth);
+				MAPTILE *psTile = mapTile(worldMapState, b.map.x + width, b.map.y + breadth);
 				if (TEST_TILE_VISIBLE_TO_SELECTEDPLAYER(psTile))
 				{
 					psTile->illumination /= 2;
@@ -5000,7 +5000,7 @@ void setAssemblyPoint(FLAG_POSITION *psAssemblyPoint, UDWORD x, UDWORD y,
 	psAssemblyPoint->coords.y = y;
 
 	// Deliv Point sits at the height of the tile it's centre is on + arbitrary amount!
-	psAssemblyPoint->coords.z = map_Height(x, y) + ASSEMBLY_POINT_Z_PADDING;
+	psAssemblyPoint->coords.z = map_Height(worldMapState, x, y) + ASSEMBLY_POINT_Z_PADDING;
 }
 
 
@@ -5583,7 +5583,7 @@ void printStructureInfo(STRUCTURE *psStructure)
 		console(_("%s - Hitpoints %d/%d"), getLocalizedStatsName(psStructure->pStructureType), psStructure->body, psStructure->structureBody());
 		if (dbgInputManager.debugMappingsAllowed() && selectedPlayer < MAX_PLAYERS)
 		{
-			console(_("ID %d - %s"), psStructure->id, (auxTile(map_coord(psStructure->pos.x), map_coord(psStructure->pos.y), selectedPlayer) & AUXBITS_DANGER) ? "danger" : "safe");
+			console(_("ID %d - %s"), psStructure->id, (auxTile(worldMapState, map_coord(psStructure->pos.x), map_coord(psStructure->pos.y), selectedPlayer) & AUXBITS_DANGER) ? "danger" : "safe");
 		}
 		break;
 	case REF_POWER_GEN:
@@ -6074,7 +6074,7 @@ void hqReward(UBYTE losingPlayer, UBYTE rewardPlayer)
 	{
 		for (int x = 0; x < worldMapState.width; ++x)
 		{
-			MAPTILE *psTile = mapTile(x, y);
+			MAPTILE *psTile = mapTile(worldMapState, x, y);
 			if (TEST_TILE_VISIBLE(losingPlayer, psTile))
 			{
 				psTile->tileExploredBits |= alliancebits[rewardPlayer];

--- a/src/structure.cpp
+++ b/src/structure.cpp
@@ -171,10 +171,10 @@ static void auxStructureNonblocking(STRUCTURE *psStructure)
 		{
 			int x = b.map.x + i;
 			int y = b.map.y + j;
-			MAPTILE *psTile = mapTile(worldMapState, x, y);
+			MAPTILE *psTile = mapTile(gameWorld.map, x, y);
 			if (psTile->psObject == psStructure)
 			{
-				auxClearAll(worldMapState, x, y, AUXBITS_BLOCKING | AUXBITS_OUR_BUILDING | AUXBITS_NONPASSABLE);
+				auxClearAll(gameWorld.map, x, y, AUXBITS_BLOCKING | AUXBITS_OUR_BUILDING | AUXBITS_NONPASSABLE);
 			}
 			else
 			{
@@ -193,8 +193,8 @@ static void auxStructureBlocking(STRUCTURE *psStructure)
 	{
 		for (int j = 0; j < b.size.y; j++)
 		{
-			auxSetAllied(worldMapState, b.map.x + i, b.map.y + j, psStructure->player, AUXBITS_OUR_BUILDING);
-			auxSetAll(worldMapState, b.map.x + i, b.map.y + j, AUXBITS_BLOCKING | AUXBITS_NONPASSABLE);
+			auxSetAllied(gameWorld.map, b.map.x + i, b.map.y + j, psStructure->player, AUXBITS_OUR_BUILDING);
+			auxSetAll(gameWorld.map, b.map.x + i, b.map.y + j, AUXBITS_BLOCKING | AUXBITS_NONPASSABLE);
 		}
 	}
 }
@@ -207,7 +207,7 @@ static void auxStructureOpenGate(STRUCTURE *psStructure)
 	{
 		for (int j = 0; j < b.size.y; j++)
 		{
-			auxClearAll(worldMapState, b.map.x + i, b.map.y + j, AUXBITS_BLOCKING);
+			auxClearAll(gameWorld.map, b.map.x + i, b.map.y + j, AUXBITS_BLOCKING);
 		}
 	}
 }
@@ -220,8 +220,8 @@ static void auxStructureClosedGate(STRUCTURE *psStructure)
 	{
 		for (int j = 0; j < b.size.y; j++)
 		{
-			auxSetEnemy(worldMapState, b.map.x + i, b.map.y + j, psStructure->player, AUXBITS_NONPASSABLE);
-			auxSetAll(worldMapState, b.map.x + i, b.map.y + j, AUXBITS_BLOCKING);
+			auxSetEnemy(gameWorld.map, b.map.x + i, b.map.y + j, psStructure->player, AUXBITS_NONPASSABLE);
+			auxSetAll(gameWorld.map, b.map.x + i, b.map.y + j, AUXBITS_BLOCKING);
 		}
 	}
 }
@@ -257,7 +257,7 @@ bool isBlueprint(const BASE_OBJECT *psObject)
 static void displayConstructionCloud(const Vector3i &pos)
 {
 	const Vector2i coordinates = {pos.x, pos.y};
-	const MAPTILE *psTile = mapTile(worldMapState, map_coord(coordinates));
+	const MAPTILE *psTile = mapTile(gameWorld.map, map_coord(coordinates));
 	if (!tileIsClearlyVisible(psTile))
 	{
 		return;
@@ -266,7 +266,7 @@ static void displayConstructionCloud(const Vector3i &pos)
 	Vector3i iVecEffect;
 
 	iVecEffect.x = pos.x;
-	iVecEffect.y = map_Height(worldMapState, pos.x, pos.y) + DROID_CONSTRUCTION_SMOKE_HEIGHT;
+	iVecEffect.y = map_Height(gameWorld.map, pos.x, pos.y) + DROID_CONSTRUCTION_SMOKE_HEIGHT;
 	iVecEffect.z = pos.y;
 	addEffect(&iVecEffect, EFFECT_CONSTRUCTION, CONSTRUCTION_TYPE_DRIFTING, false, nullptr, 0, gameTime - deltaGameTime + 1);
 	iVecEffect.x = pos.x - DROID_CONSTRUCTION_SMOKE_OFFSET;
@@ -363,7 +363,7 @@ void resetFactoryNumFlag()
 			factoryNumFlag[i][type].clear();
 		}
 		//look through the list of structures to see which have been used
-		for (const STRUCTURE *psStruct : worldObjectState.structures[i])
+		for (const STRUCTURE *psStruct : gameWorld.objects.structures[i])
 		{
 			FLAG_TYPE type;
 			switch (psStruct->pStructureType->type)
@@ -753,7 +753,7 @@ void setCurrentStructQuantity(bool displayError)
 		{
 			asStructureStats[inc].curCount[player] = 0;
 		}
-		for (const STRUCTURE *psCurr : worldObjectState.structures[player])
+		for (const STRUCTURE *psCurr : gameWorld.objects.structures[player])
 		{
 			unsigned inc = psCurr->pStructureType - asStructureStats;
 			asStructureStats[inc].curCount[player]++;
@@ -928,7 +928,7 @@ void structureBuild(STRUCTURE *psStruct, DROID *psDroid, int buildPoints, int bu
 	{
 		for (unsigned player = 0; player < MAX_PLAYERS; player++)
 		{
-			for (const DROID *psCurr : worldObjectState.droids[player])
+			for (const DROID *psCurr : gameWorld.objects.droids[player])
 			{
 				// An enemy droid is blocking it
 				if ((STRUCTURE *) orderStateObj(psCurr, DORDER_BUILD) == psStruct
@@ -985,7 +985,7 @@ void structureBuild(STRUCTURE *psStruct, DROID *psDroid, int buildPoints, int bu
 		if (psDroid)
 		{
 			// Clear all orders for helping hands. Needed for AI script which runs next frame.
-			for (DROID* psIter : worldObjectState.droids[psDroid->player])
+			for (DROID* psIter : gameWorld.objects.droids[psDroid->player])
 			{
 				if ((psIter->order.type == DORDER_BUILD || psIter->order.type == DORDER_HELPBUILD || psIter->order.type == DORDER_LINEBUILD)
 				    && psIter->order.psObj == psStruct
@@ -1272,7 +1272,7 @@ static void structFindWalls(unsigned player, Vector2i map, bool aWallPresent[5][
 	for (int y = -2; y <= 2; ++y)
 		for (int x = -2; x <= 2; ++x)
 		{
-			STRUCTURE *psStruct = castStructure(mapTile(worldMapState, map.x + x, map.y + y)->psObject);
+			STRUCTURE *psStruct = castStructure(mapTile(gameWorld.map, map.x + x, map.y + y)->psObject);
 			if (psStruct != nullptr && isWallCombiningStructureType(psStruct->pStructureType) && player < MAX_PLAYERS && aiCheckAlliances(player, psStruct->player))
 			{
 				aWallPresent[x + 2][y + 2] = true;
@@ -1298,7 +1298,7 @@ static void structFindWallBlueprints(Vector2i map, bool aWallPresent[5][5])
 
 static bool wallBlockingTerrainJoin(Vector2i map)
 {
-	MAPTILE *psTile = mapTile(worldMapState, map);
+	MAPTILE *psTile = mapTile(gameWorld.map, map);
 	return terrainType(psTile) == TER_WATER || terrainType(psTile) == TER_CLIFFFACE || psTile->psObject != nullptr;
 }
 
@@ -1405,7 +1405,7 @@ static int foundationHeight(const STRUCTURE *psStruct)
 	{
 		for (int width = 0; width <= b.size.x; width++)
 		{
-			int height = map_TileHeight(worldMapState, b.map.x + width, b.map.y + breadth);
+			int height = map_TileHeight(gameWorld.map, b.map.x + width, b.map.y + breadth);
 			foundationMin = std::min(foundationMin, height);
 			foundationMax = std::max(foundationMax, height);
 		}
@@ -1423,9 +1423,9 @@ static void buildFlatten(STRUCTURE *pStructure, int h)
 	{
 		for (int width = 0; width <= b.size.x; ++width)
 		{
-			setTileHeight(worldMapState, b.map.x + width, b.map.y + breadth, h);
+			setTileHeight(gameWorld.map, b.map.x + width, b.map.y + breadth, h);
 			// We need to raise features on raised tiles to the new height
-			if (TileHasFeature(mapTile(worldMapState, b.map.x + width, b.map.y + breadth)))
+			if (TileHasFeature(mapTile(gameWorld.map, b.map.x + width, b.map.y + breadth)))
 			{
 				getTileFeature(b.map.x + width, b.map.y + breadth)->pos.z = h;
 			}
@@ -1457,7 +1457,7 @@ void alignStructure(STRUCTURE *psBuilding)
 		{
 			for (int width = -1; width <= b.size.x; ++width)
 			{
-				STRUCTURE *neighbourStructure = castStructure(mapTile(worldMapState, b.map.x + width, b.map.y + breadth)->psObject);
+				STRUCTURE *neighbourStructure = castStructure(mapTile(gameWorld.map, b.map.x + width, b.map.y + breadth)->psObject);
 				if (neighbourStructure != nullptr && isPulledToTerrain(neighbourStructure))
 				{
 					alignStructure(neighbourStructure);  // Recursive call, but will go to the else case, so will not re-recurse.
@@ -1479,10 +1479,10 @@ void alignStructure(STRUCTURE *psBuilding)
 		Vector2i p1{s->max.x * dir.y - s->max.z * dir.x, s->max.x * dir.x + s->max.z * dir.y};
 		Vector2i p2{s->min.x * dir.y - s->min.z * dir.x, s->min.x * dir.x + s->min.z * dir.y};
 
-		int h1 = map_Height(worldMapState, psBuilding->pos.x + p1.x, psBuilding->pos.y + p2.y);
-		int h2 = map_Height(worldMapState, psBuilding->pos.x + p1.x, psBuilding->pos.y + p1.y);
-		int h3 = map_Height(worldMapState, psBuilding->pos.x + p2.x, psBuilding->pos.y + p1.y);
-		int h4 = map_Height(worldMapState, psBuilding->pos.x + p2.x, psBuilding->pos.y + p2.y);
+		int h1 = map_Height(gameWorld.map, psBuilding->pos.x + p1.x, psBuilding->pos.y + p2.y);
+		int h2 = map_Height(gameWorld.map, psBuilding->pos.x + p1.x, psBuilding->pos.y + p1.y);
+		int h3 = map_Height(gameWorld.map, psBuilding->pos.x + p2.x, psBuilding->pos.y + p1.y);
+		int h4 = map_Height(gameWorld.map, psBuilding->pos.x + p2.x, psBuilding->pos.y + p2.y);
 		int minH = std::min({h1, h2, h3, h4});
 		int maxH = std::max({h1, h2, h3, h4});
 		psBuilding->pos.z = std::max(psBuilding->pos.z, maxH);
@@ -1532,13 +1532,13 @@ STRUCTURE *buildStructureDir(STRUCTURE_STATS *pStructureType, UDWORD x, UDWORD y
 		y = (y & ~TILE_MASK) + size.y % 2 * TILE_UNITS / 2;
 
 		//check not trying to build too near the edge
-		if (map_coord(x) < TOO_NEAR_EDGE || map_coord(x) > (worldMapState.width - TOO_NEAR_EDGE))
+		if (map_coord(x) < TOO_NEAR_EDGE || map_coord(x) > (gameWorld.map.width - TOO_NEAR_EDGE))
 		{
 			debug(LOG_WARNING, "attempting to build too closely to map-edge, "
 			      "x coord (%u) too near edge (req. distance is %u)", x, TOO_NEAR_EDGE);
 			return nullptr;
 		}
-		if (map_coord(y) < TOO_NEAR_EDGE || map_coord(y) > (worldMapState.height - TOO_NEAR_EDGE))
+		if (map_coord(y) < TOO_NEAR_EDGE || map_coord(y) > (gameWorld.map.height - TOO_NEAR_EDGE))
 		{
 			debug(LOG_WARNING, "attempting to build too closely to map-edge, "
 			      "y coord (%u) too near edge (req. distance is %u)", y, TOO_NEAR_EDGE);
@@ -1587,7 +1587,7 @@ STRUCTURE *buildStructureDir(STRUCTURE_STATS *pStructureType, UDWORD x, UDWORD y
 
 			if (psFeature && psFeature->psStats->subType == FEAT_OIL_RESOURCE)
 			{
-				if (fireOnLocation(worldMapState, psFeature->pos.x, psFeature->pos.y))
+				if (fireOnLocation(gameWorld.map, psFeature->pos.x, psFeature->pos.y))
 				{
 					// Can't build on burning oil resource
 					return nullptr;
@@ -1603,7 +1603,7 @@ STRUCTURE *buildStructureDir(STRUCTURE_STATS *pStructureType, UDWORD x, UDWORD y
 		{
 			for (int tileX = map.x; tileX < map.x + size.x; ++tileX)
 			{
-				MAPTILE *psTile = mapTile(worldMapState, tileX, tileY);
+				MAPTILE *psTile = mapTile(gameWorld.map, tileX, tileY);
 
 				/* Remove any walls underneath the building. You can build defense buildings on top
 				 * of walls, you see. This is not the place to test whether we own it! */
@@ -1635,13 +1635,13 @@ STRUCTURE *buildStructureDir(STRUCTURE_STATS *pStructureType, UDWORD x, UDWORD y
 			for (int tileX = map.x; tileX < map.x + size.x; ++tileX)
 			{
 				// We now know the previous loop didn't return early, so it is safe to save references to `stableBuilding` now.
-				MAPTILE *psTile = mapTile(worldMapState, tileX, tileY);
+				MAPTILE *psTile = mapTile(gameWorld.map, tileX, tileY);
 				psTile->psObject = psBuilding;
 
 				// if it's a tall structure then flag it in the map.
 				if (psBuilding->sDisplay.imd && psBuilding->sDisplay.imd->max.y > TALLOBJECT_YMAX)
 				{
-					auxSetBlocking(worldMapState, tileX, tileY, AIR_BLOCKED);
+					auxSetBlocking(gameWorld.map, tileX, tileY, AIR_BLOCKED);
 				}
 			}
 		}
@@ -1736,15 +1736,15 @@ STRUCTURE *buildStructureDir(STRUCTURE_STATS *pStructureType, UDWORD x, UDWORD y
 		if (FromSave && player == selectedPlayer && missionLimboExpand())
 		{
 			//save the current values
-			preScrollMinX = worldMapState.scroll.minX;
-			preScrollMinY = worldMapState.scroll.minY;
-			preScrollMaxX = worldMapState.scroll.maxX;
-			preScrollMaxY = worldMapState.scroll.maxY;
+			preScrollMinX = gameWorld.map.scroll.minX;
+			preScrollMinY = gameWorld.map.scroll.minY;
+			preScrollMaxX = gameWorld.map.scroll.maxX;
+			preScrollMaxY = gameWorld.map.scroll.maxY;
 			//set the current values to mapWidth/mapHeight
-			worldMapState.scroll.minX = 0;
-			worldMapState.scroll.minY = 0;
-			worldMapState.scroll.maxX = worldMapState.width;
-			worldMapState.scroll.maxY = worldMapState.height;
+			gameWorld.map.scroll.minX = 0;
+			gameWorld.map.scroll.minY = 0;
+			gameWorld.map.scroll.maxX = gameWorld.map.width;
+			gameWorld.map.scroll.maxY = gameWorld.map.height;
 			// NOTE: resizeRadar() may be required here, since we change scroll limits?
 		}
 		//set the functionality dependent on the type of structure
@@ -1756,10 +1756,10 @@ STRUCTURE *buildStructureDir(STRUCTURE_STATS *pStructureType, UDWORD x, UDWORD y
 			if (FromSave && player == selectedPlayer && missionLimboExpand())
 			{
 				//reset the current values
-				worldMapState.scroll.minX = preScrollMinX;
-				worldMapState.scroll.minY = preScrollMinY;
-				worldMapState.scroll.maxX = preScrollMaxX;
-				worldMapState.scroll.maxY = preScrollMaxY;
+				gameWorld.map.scroll.minX = preScrollMinX;
+				gameWorld.map.scroll.minY = preScrollMinY;
+				gameWorld.map.scroll.maxX = preScrollMaxX;
+				gameWorld.map.scroll.maxY = preScrollMaxY;
 				// NOTE: resizeRadar() may be required here, since we change scroll limits?
 			}
 			return nullptr;
@@ -1769,10 +1769,10 @@ STRUCTURE *buildStructureDir(STRUCTURE_STATS *pStructureType, UDWORD x, UDWORD y
 		if (FromSave && player == selectedPlayer && missionLimboExpand())
 		{
 			//reset the current values
-			worldMapState.scroll.minX = preScrollMinX;
-			worldMapState.scroll.minY = preScrollMinY;
-			worldMapState.scroll.maxX = preScrollMaxX;
-			worldMapState.scroll.maxY = preScrollMaxY;
+			gameWorld.map.scroll.minX = preScrollMinX;
+			gameWorld.map.scroll.minY = preScrollMinY;
+			gameWorld.map.scroll.maxX = preScrollMaxX;
+			gameWorld.map.scroll.maxY = preScrollMaxY;
 			// NOTE: resizeRadar() may be required here, since we change scroll limits?
 		}
 
@@ -1804,7 +1804,7 @@ STRUCTURE *buildStructureDir(STRUCTURE_STATS *pStructureType, UDWORD x, UDWORD y
 		StructureBounds bounds = getStructureBounds(psBuilding);
 		for (unsigned playerNum = 0; playerNum < MAX_PLAYERS; ++playerNum)
 		{
-			for (const STRUCTURE *psStruct : worldObjectState.structures[playerNum])
+			for (const STRUCTURE *psStruct : gameWorld.objects.structures[playerNum])
 			{
 				if (!psStruct)
 				{
@@ -1988,7 +1988,7 @@ optional<STRUCTURE> buildBlueprint(STRUCTURE_STATS const *psStats, Vector3i pos,
 	std::vector<iIMDBaseShape *> const *pIMD = &psStats->pIMD;
 	if (IsStatExpansionModule(psStats))
 	{
-		STRUCTURE *baseStruct = castStructure(worldTile(worldMapState, pos.xy())->psObject);
+		STRUCTURE *baseStruct = castStructure(worldTile(gameWorld.map, pos.xy())->psObject);
 		if (baseStruct != nullptr)
 		{
 			if (moduleIndex == 0)
@@ -2360,7 +2360,7 @@ void assignFactoryCommandDroid(STRUCTURE *psStruct, DROID *psCommander)
 		}
 		else
 		{
-			addFlagPositionToList(psFact->psAssemblyPoint, mission.worldObjectState.flags);
+			addFlagPositionToList(psFact->psAssemblyPoint, mission.gameWorld.objects.flags);
 		}
 	}
 
@@ -2370,7 +2370,7 @@ void assignFactoryCommandDroid(STRUCTURE *psStruct, DROID *psCommander)
 
 		factoryInc = psFact->psAssemblyPoint->factoryInc;
 
-		auto& flagPosList = worldObjectState.flags[psStruct->player];
+		auto& flagPosList = gameWorld.objects.flags[psStruct->player];
 		FlagPositionList::iterator flagPosIt = flagPosList.begin(), flagPosItNext;
 		while (flagPosIt != flagPosList.end())
 		{
@@ -2403,7 +2403,7 @@ void clearCommandDroidFactory(DROID *psDroid)
 {
 	ASSERT_OR_RETURN(, selectedPlayer < MAX_PLAYERS, "invalid selectedPlayer: %" PRIu32 "", selectedPlayer);
 
-	for (STRUCTURE* psCurr : worldObjectState.structures[selectedPlayer])
+	for (STRUCTURE* psCurr : gameWorld.objects.structures[selectedPlayer])
 	{
 		if ((psCurr->pStructureType->type == REF_FACTORY) ||
 		    (psCurr->pStructureType->type == REF_CYBORG_FACTORY) ||
@@ -2415,7 +2415,7 @@ void clearCommandDroidFactory(DROID *psDroid)
 			}
 		}
 	}
-	for (STRUCTURE* psCurr : mission.worldObjectState.structures[selectedPlayer])
+	for (STRUCTURE* psCurr : mission.gameWorld.objects.structures[selectedPlayer])
 	{
 		if ((psCurr->pStructureType->type == REF_FACTORY) ||
 		    (psCurr->pStructureType->type == REF_CYBORG_FACTORY) ||
@@ -2445,7 +2445,7 @@ static bool structClearTile(UWORD x, UWORD y, PROPULSION_TYPE propulsion)
 	/* Check for a droid */
 	for (player = 0; player < MAX_PLAYERS; player++)
 	{
-		for (const DROID* psCurr : worldObjectState.droids[player])
+		for (const DROID* psCurr : gameWorld.objects.droids[player])
 		{
 			if (map_coord(psCurr->pos.x) == x
 			    && map_coord(psCurr->pos.y) == y)
@@ -2489,9 +2489,9 @@ bool placeDroid(STRUCTURE *psStructure, const DROID_TEMPLATE * psTempl, UDWORD *
 	// Find the four corners of the square
 	StructureBounds bounds = getStructureBounds(psStructure);
 	int xmin = std::max(bounds.map.x - 1, 0);
-	int xmax = std::min(bounds.map.x + bounds.size.x, worldMapState.width);
+	int xmax = std::min(bounds.map.x + bounds.size.x, gameWorld.map.width);
 	int ymin = std::max(bounds.map.y - 1, 0);
-	int ymax = std::min(bounds.map.y + bounds.size.y, worldMapState.height);
+	int ymax = std::min(bounds.map.y + bounds.size.y, gameWorld.map.height);
 
 	// Round direction to nearest 90°.
 	uint16_t direction = snapDirection(psStructure->rot.direction);
@@ -2651,7 +2651,7 @@ static bool structPlaceDroid(STRUCTURE *psStructure, DROID_TEMPLATE *psTempl, DR
 		setFactorySecondaryState(psNewDroid, psStructure);
 		displayConstructionCloud(psNewDroid->pos);
 		/* add the droid to the list */
-		addDroid(psNewDroid, worldObjectState.droids);
+		addDroid(psNewDroid, gameWorld.objects.droids);
 		*ppsDroid = psNewDroid;
 		if (psNewDroid->player == selectedPlayer)
 		{
@@ -2707,7 +2707,7 @@ static bool structPlaceDroid(STRUCTURE *psStructure, DROID_TEMPLATE *psTempl, DR
 				factoryType = VTOL_FLAG;
 			}
 			//find flag in question.
-			const auto& flagPosList = worldObjectState.flags[psFact->psAssemblyPoint->player];
+			const auto& flagPosList = gameWorld.objects.flags[psFact->psAssemblyPoint->player];
 			auto psFlag = std::find_if(flagPosList.begin(), flagPosList.end(), [psFact, factoryType](FLAG_POSITION* psFlag)
 			{
 				return psFlag->factoryInc == psFact->psAssemblyPoint->factoryInc // correct fact.
@@ -2789,7 +2789,7 @@ bool structureExists(int player, STRUCTURE_TYPE type, bool built, bool isMission
 		return false;
 	}
 
-	StructureList* pList = isMission ? &mission.worldObjectState.structures[player] : &worldObjectState.structures[player];
+	StructureList* pList = isMission ? &mission.gameWorld.objects.structures[player] : &gameWorld.objects.structures[player];
 	for (const STRUCTURE *psCurr : *pList)
 	{
 		if (psCurr->pStructureType->type == type && (!built || (built && psCurr->status == SS_BUILT)))
@@ -3075,11 +3075,11 @@ static void aiUpdateStructure(STRUCTURE *psStructure, bool isMission)
 	{
 		// This isn't supposed to happen, and really shouldn't be possible - if this happens, maybe a structure is being updated twice?
 		int count1 = 0, count2 = 0;
-		for (const STRUCTURE* s : worldObjectState.structures[psStructure->player])
+		for (const STRUCTURE* s : gameWorld.objects.structures[psStructure->player])
 		{
 			count1 += s == psStructure;
 		}
-		for (const STRUCTURE* s : mission.worldObjectState.structures[psStructure->player])
+		for (const STRUCTURE* s : mission.gameWorld.objects.structures[psStructure->player])
 		{
 			count2 += s == psStructure;
 		}
@@ -3285,7 +3285,7 @@ static void aiUpdateStructure(STRUCTURE *psStructure, bool isMission)
 			if (psChosenObj == nullptr)
 			{
 				objTrace(psStructure->id, "Rearm pad idle - look for victim");
-				for (DROID* psCurr : worldObjectState.droids[psStructure->player])
+				for (DROID* psCurr : gameWorld.objects.droids[psStructure->player])
 				{
 					// move next droid waiting on ground to rearm pad
 					if (vtolReadyToRearm(psCurr, psStructure) &&
@@ -3301,7 +3301,7 @@ static void aiUpdateStructure(STRUCTURE *psStructure, bool isMission)
 				{
 					if (aiCheckAlliances(i, psStructure->player) && i != psStructure->player)
 					{
-						for (DROID* psCurr : worldObjectState.droids[i])
+						for (DROID* psCurr : gameWorld.objects.droids[i])
 						{
 							// move next droid waiting on ground to rearm pad
 							if (vtolReadyToRearm(psCurr, psStructure))
@@ -3989,7 +3989,7 @@ void structureUpdate(STRUCTURE *psBuilding, bool bMission)
 				realY = static_cast<SDWORD>(structHeightScale(psBuilding) * point->y);
 				position.y = psBuilding->pos.z + realY;
 				position.z = static_cast<int>(psBuilding->pos.y - point->z);
-				const auto psTile = mapTile(worldMapState, map_coord({position.x, position.y}));
+				const auto psTile = mapTile(gameWorld.map, map_coord({position.x, position.y}));
 				if (tileIsClearlyVisible(psTile))
 				{
 					effectSetSize(30);
@@ -4064,7 +4064,7 @@ std::vector<STRUCTURE_STATS *> fillStructureList(UDWORD _selectedPlayer, UDWORD 
 	//if currently on a mission can't build factory/research/power/derricks
 	if (!missionIsOffworld())
 	{
-		for (const STRUCTURE* psCurr : worldObjectState.structures[_selectedPlayer])
+		for (const STRUCTURE* psCurr : gameWorld.objects.structures[_selectedPlayer])
 		{
 			if (psCurr->pStructureType->type == REF_RESEARCH && psCurr->status == SS_BUILT)
 			{
@@ -4279,8 +4279,8 @@ bool validLocation(BASE_STATS *psStats, Vector2i pos, uint16_t direction, unsign
 	StructureBounds b = getStructureBounds(psStats, pos, direction);
 
 	//make sure we are not too near map edge and not going to go over it
-	if (b.map.x < worldMapState.scroll.minX + TOO_NEAR_EDGE || b.map.x + b.size.x > worldMapState.scroll.maxX - TOO_NEAR_EDGE ||
-	    b.map.y < worldMapState.scroll.minY + TOO_NEAR_EDGE || b.map.y + b.size.y > worldMapState.scroll.maxY - TOO_NEAR_EDGE)
+	if (b.map.x < gameWorld.map.scroll.minX + TOO_NEAR_EDGE || b.map.x + b.size.x > gameWorld.map.scroll.maxX - TOO_NEAR_EDGE ||
+	    b.map.y < gameWorld.map.scroll.minY + TOO_NEAR_EDGE || b.map.y + b.size.y > gameWorld.map.scroll.maxY - TOO_NEAR_EDGE)
 	{
 		return false;
 	}
@@ -4288,7 +4288,7 @@ bool validLocation(BASE_STATS *psStats, Vector2i pos, uint16_t direction, unsign
 	if (bCheckBuildQueue)
 	{
 		// cant place on top of a delivery point...
-		for (const auto& psFlag : worldObjectState.flags[selectedPlayer])
+		for (const auto& psFlag : gameWorld.objects.flags[selectedPlayer])
 		{
 			ASSERT_OR_RETURN(false, psFlag->coords.x != ~0, "flag has invalid position");
 			Vector2i flagTile = map_coord(psFlag->coords.xy());
@@ -4308,7 +4308,7 @@ bool validLocation(BASE_STATS *psStats, Vector2i pos, uint16_t direction, unsign
 			{
 				// Don't allow building structures (allow delivery points, though) outside visible area in single-player with debug mode off. (Why..?)
 				const DebugInputManager& dbgInputManager = gInputManager.debugManager();
-				if (!bMultiPlayer && !dbgInputManager.debugMappingsAllowed() && !TEST_TILE_VISIBLE(player, mapTile(worldMapState, b.map.x + i, b.map.y + j)))
+				if (!bMultiPlayer && !dbgInputManager.debugMappingsAllowed() && !TEST_TILE_VISIBLE(player, mapTile(gameWorld.map, b.map.x + i, b.map.y + j)))
 				{
 					return false;
 				}
@@ -4346,7 +4346,7 @@ bool validLocation(BASE_STATS *psStats, Vector2i pos, uint16_t direction, unsign
 				for (int j = 0; j < b.size.y; ++j)
 					for (int i = 0; i < b.size.x; ++i)
 					{
-						MAPTILE const *psTile = mapTile(worldMapState, b.map.x + i, b.map.y + j);
+						MAPTILE const *psTile = mapTile(gameWorld.map, b.map.x + i, b.map.y + j);
 						if ((terrainType(psTile) == TER_WATER) ||
 						    (terrainType(psTile) == TER_CLIFFFACE))
 						{
@@ -4397,7 +4397,7 @@ bool validLocation(BASE_STATS *psStats, Vector2i pos, uint16_t direction, unsign
 						//skip the actual area the structure will cover
 						if (i < 0 || i >= b.size.x || j < 0 || j >= b.size.y)
 						{
-							BASE_OBJECT *object = mapTile(worldMapState, b.map.x + i, b.map.y + j)->psObject;
+							BASE_OBJECT *object = mapTile(gameWorld.map, b.map.x + i, b.map.y + j)->psObject;
 							STRUCTURE *structure = castStructure(object);
 							if (structure != nullptr && !structure->visible[player] && !aiCheckAlliances(player, structure->player))
 							{
@@ -4441,7 +4441,7 @@ bool validLocation(BASE_STATS *psStats, Vector2i pos, uint16_t direction, unsign
 				for (int j = 0; j < b.size.y; ++j)
 					for (int i = 0; i < b.size.x; ++i)
 					{
-						MAPTILE const *psTile = mapTile(worldMapState, b.map.x + i, b.map.y + j);
+						MAPTILE const *psTile = mapTile(gameWorld.map, b.map.x + i, b.map.y + j);
 						if (TileIsKnownOccupied(psTile, player))
 						{
 							if (TileHasWall(psTile) && (psBuilding->type == REF_DEFENSE || psBuilding->type == REF_GATE || psBuilding->type == REF_WALL))
@@ -4461,7 +4461,7 @@ bool validLocation(BASE_STATS *psStats, Vector2i pos, uint16_t direction, unsign
 				break;
 			}
 		case REF_FACTORY_MODULE:
-			if (TileHasStructure(worldTile(worldMapState, pos)))
+			if (TileHasStructure(worldTile(gameWorld.map, pos)))
 			{
 				STRUCTURE const *psStruct = getTileStructure(map_coord(pos.x), map_coord(pos.y));
 				if (psStruct && (psStruct->pStructureType->type == REF_FACTORY ||
@@ -4474,7 +4474,7 @@ bool validLocation(BASE_STATS *psStats, Vector2i pos, uint16_t direction, unsign
 			}
 			return false;
 		case REF_RESEARCH_MODULE:
-			if (TileHasStructure(worldTile(worldMapState, pos)))
+			if (TileHasStructure(worldTile(gameWorld.map, pos)))
 			{
 				STRUCTURE const *psStruct = getTileStructure(map_coord(pos.x), map_coord(pos.y));
 				if (psStruct && psStruct->pStructureType->type == REF_RESEARCH
@@ -4487,7 +4487,7 @@ bool validLocation(BASE_STATS *psStats, Vector2i pos, uint16_t direction, unsign
 			}
 			return false;
 		case REF_POWER_MODULE:
-			if (TileHasStructure(worldTile(worldMapState, pos)))
+			if (TileHasStructure(worldTile(gameWorld.map, pos)))
 			{
 				STRUCTURE const *psStruct = getTileStructure(map_coord(pos.x), map_coord(pos.y));
 				if (psStruct && psStruct->pStructureType->type == REF_POWER_GEN
@@ -4500,7 +4500,7 @@ bool validLocation(BASE_STATS *psStats, Vector2i pos, uint16_t direction, unsign
 			}
 			return false;
 		case REF_RESOURCE_EXTRACTOR:
-			if (TileHasFeature(worldTile(worldMapState, pos)))
+			if (TileHasFeature(worldTile(gameWorld.map, pos)))
 			{
 				FEATURE const *psFeat = getTileFeature(map_coord(pos.x), map_coord(pos.y));
 				if (psFeat && psFeat->psStats->subType == FEAT_OIL_RESOURCE)
@@ -4550,11 +4550,11 @@ static void removeStructFromMap(STRUCTURE *psStruct)
 	{
 		for (int i = 0; i < b.size.x; ++i)
 		{
-			MAPTILE *psTile = mapTile(worldMapState, b.map.x + i, b.map.y + j);
+			MAPTILE *psTile = mapTile(gameWorld.map, b.map.x + i, b.map.y + j);
 			if (psTile->psObject == psStruct)
 			{
 				psTile->psObject = nullptr;
-				auxClearBlocking(worldMapState, b.map.x + i, b.map.y + j, AIR_BLOCKED);
+				auxClearBlocking(gameWorld.map, b.map.x + i, b.map.y + j, AIR_BLOCKED);
 			}
 		}
 	}
@@ -4723,7 +4723,7 @@ bool destroyStruct(STRUCTURE *psDel, unsigned impactTime)
 		/* Get coordinates for everybody! */
 		pos.x = psDel->pos.x;
 		pos.z = psDel->pos.y;  // z = y [sic] intentional
-		pos.y = map_Height(worldMapState, pos.x, pos.z);
+		pos.y = map_Height(gameWorld.map, pos.x, pos.z);
 
 		// Set off a fire, provide dimensions for the fire
 		if (bMinor)
@@ -4793,7 +4793,7 @@ bool destroyStruct(STRUCTURE *psDel, unsigned impactTime)
 	}
 
 	// Actually set the tiles on fire - even if the effect is not visible.
-	tileSetFire(worldMapState, psDel->pos.x, psDel->pos.y, burnDuration);
+	tileSetFire(gameWorld.map, psDel->pos.x, psDel->pos.y, burnDuration);
 
 	const bool resourceFound = removeStruct(psDel, true);
 	psDel->died = impactTime;
@@ -4806,7 +4806,7 @@ bool destroyStruct(STRUCTURE *psDel, unsigned impactTime)
 		{
 			for (int width = 0; width < b.size.x; ++width)
 			{
-				MAPTILE *psTile = mapTile(worldMapState, b.map.x + width, b.map.y + breadth);
+				MAPTILE *psTile = mapTile(gameWorld.map, b.map.x + width, b.map.y + breadth);
 				if (TEST_TILE_VISIBLE_TO_SELECTEDPLAYER(psTile))
 				{
 					psTile->illumination /= 2;
@@ -4908,7 +4908,7 @@ bool checkSpecificStructExists(UDWORD structInc, UDWORD player)
 {
 	ASSERT_OR_RETURN(false, structInc < numStructureStats, "Invalid structure inc");
 
-	for (const STRUCTURE *psStructure : worldObjectState.structures[player])
+	for (const STRUCTURE *psStructure : gameWorld.objects.structures[player])
 	{
 		if (psStructure->status == SS_BUILT)
 		{
@@ -5000,7 +5000,7 @@ void setAssemblyPoint(FLAG_POSITION *psAssemblyPoint, UDWORD x, UDWORD y,
 	psAssemblyPoint->coords.y = y;
 
 	// Deliv Point sits at the height of the tile it's centre is on + arbitrary amount!
-	psAssemblyPoint->coords.z = map_Height(worldMapState, x, y) + ASSEMBLY_POINT_Z_PADDING;
+	psAssemblyPoint->coords.z = map_Height(gameWorld.map, x, y) + ASSEMBLY_POINT_Z_PADDING;
 }
 
 
@@ -5184,7 +5184,7 @@ void checkForResExtractors(STRUCTURE *psBuilding)
 	typedef std::vector<Derrick> Derricks;
 	Derricks derricks;
 	derricks.reserve(NUM_POWER_MODULES + 1);
-	for (STRUCTURE *currExtractor : worldObjectState.extractors[psBuilding->player])
+	for (STRUCTURE *currExtractor : gameWorld.objects.extractors[psBuilding->player])
 	{
 		RES_EXTRACTOR *resExtractor = &currExtractor->pFunctionality->resourceExtractor;
 
@@ -5239,7 +5239,7 @@ uint16_t countPlayerUnusedDerricks()
 
 	if (selectedPlayer >= MAX_PLAYERS) { return 0; }
 
-	for (const STRUCTURE *psStruct : worldObjectState.extractors[selectedPlayer])
+	for (const STRUCTURE *psStruct : gameWorld.objects.extractors[selectedPlayer])
 	{
 		if (psStruct->status == SS_BUILT && psStruct->pStructureType->type == REF_RESOURCE_EXTRACTOR)
 		{
@@ -5267,7 +5267,7 @@ void checkForPowerGen(STRUCTURE *psBuilding)
 	// Find a power generator, if possible with a power module.
 	STRUCTURE *bestPowerGen = nullptr;
 	int bestSlot = 0;
-	for (STRUCTURE *psCurr : worldObjectState.structures[psBuilding->player])
+	for (STRUCTURE *psCurr : gameWorld.objects.structures[psBuilding->player])
 	{
 		if (psCurr->pStructureType->type == REF_POWER_GEN && psCurr->status == SS_BUILT)
 		{
@@ -5348,7 +5348,7 @@ void releaseResExtractor(STRUCTURE *psRelease)
 	psRelease->pFunctionality->resourceExtractor.psPowerGen = nullptr;
 
 	//there may be spare resource extractors
-	for (STRUCTURE* psCurr : worldObjectState.extractors[psRelease->player])
+	for (STRUCTURE* psCurr : gameWorld.objects.extractors[psRelease->player])
 	{
 		//check not connected and power left and built!
 		if (psCurr != psRelease && psCurr->pFunctionality->resourceExtractor.psPowerGen == nullptr && psCurr->status == SS_BUILT)
@@ -5384,7 +5384,7 @@ void releasePowerGen(STRUCTURE *psRelease)
 		}
 	}
 	//may have a power gen with spare capacity
-	for (STRUCTURE* psCurr : worldObjectState.structures[psRelease->player])
+	for (STRUCTURE* psCurr : gameWorld.objects.structures[psRelease->player])
 	{
 		if (psCurr->pStructureType->type == REF_POWER_GEN &&
 		    psCurr != psRelease && psCurr->status == SS_BUILT)
@@ -5494,7 +5494,7 @@ static unsigned int countAssignedDroids(const STRUCTURE *psStructure)
 	}
 
 	num = 0;
-	for (const DROID* psCurr : worldObjectState.droids[selectedPlayer])
+	for (const DROID* psCurr : gameWorld.objects.droids[selectedPlayer])
 	{
 		if (psCurr->order.psObj
 		    && psCurr->order.psObj->id == psStructure->id
@@ -5583,7 +5583,7 @@ void printStructureInfo(STRUCTURE *psStructure)
 		console(_("%s - Hitpoints %d/%d"), getLocalizedStatsName(psStructure->pStructureType), psStructure->body, psStructure->structureBody());
 		if (dbgInputManager.debugMappingsAllowed() && selectedPlayer < MAX_PLAYERS)
 		{
-			console(_("ID %d - %s"), psStructure->id, (auxTile(worldMapState, map_coord(psStructure->pos.x), map_coord(psStructure->pos.y), selectedPlayer) & AUXBITS_DANGER) ? "danger" : "safe");
+			console(_("ID %d - %s"), psStructure->id, (auxTile(gameWorld.map, map_coord(psStructure->pos.x), map_coord(psStructure->pos.y), selectedPlayer) & AUXBITS_DANGER) ? "danger" : "safe");
 		}
 		break;
 	case REF_POWER_GEN:
@@ -6070,11 +6070,11 @@ void hqReward(UBYTE losingPlayer, UBYTE rewardPlayer)
 	ASSERT_OR_RETURN(, losingPlayer < MAX_PLAYERS && rewardPlayer < MAX_PLAYERS, "losingPlayer (%" PRIu8 "), rewardPlayer (%" PRIu8 ") must both be < MAXPLAYERS", losingPlayer, rewardPlayer);
 
 	// share exploration info - pretty useless but perhaps a nice touch?
-	for (int y = 0; y < worldMapState.height; ++y)
+	for (int y = 0; y < gameWorld.map.height; ++y)
 	{
-		for (int x = 0; x < worldMapState.width; ++x)
+		for (int x = 0; x < gameWorld.map.width; ++x)
 		{
-			MAPTILE *psTile = mapTile(worldMapState, x, y);
+			MAPTILE *psTile = mapTile(gameWorld.map, x, y);
 			if (TEST_TILE_VISIBLE(losingPlayer, psTile))
 			{
 				psTile->tileExploredBits |= alliancebits[rewardPlayer];
@@ -6085,7 +6085,7 @@ void hqReward(UBYTE losingPlayer, UBYTE rewardPlayer)
 	//struct
 	for (int i = 0; i < MAX_PLAYERS; ++i)
 	{
-		for (STRUCTURE *psStruct : worldObjectState.structures[i])
+		for (STRUCTURE *psStruct : gameWorld.objects.structures[i])
 		{
 			if (psStruct->visible[losingPlayer] && !psStruct->died)
 			{
@@ -6094,7 +6094,7 @@ void hqReward(UBYTE losingPlayer, UBYTE rewardPlayer)
 		}
 
 		//droids.
-		for (DROID *psDroid : worldObjectState.droids[i])
+		for (DROID *psDroid : gameWorld.objects.droids[i])
 		{
 			if (psDroid->visible[losingPlayer] || psDroid->player == losingPlayer)
 			{
@@ -6104,7 +6104,7 @@ void hqReward(UBYTE losingPlayer, UBYTE rewardPlayer)
 	}
 
 	//feature
-	for (FEATURE *psFeat : worldObjectState.features[0])
+	for (FEATURE *psFeat : gameWorld.objects.features[0])
 	{
 		if (psFeat->visible[losingPlayer])
 		{
@@ -6149,7 +6149,7 @@ FLAG_POSITION *FindFactoryDelivery(const STRUCTURE *Struct)
 	if (Struct && Struct->isFactory())
 	{
 		// Find the factories delivery point.
-		for (const auto& psFlag : worldObjectState.flags[Struct->player])
+		for (const auto& psFlag : gameWorld.objects.flags[Struct->player])
 		{
 			if (FlagIsFactory(psFlag)
 				&& Struct->pFunctionality->factory.psAssemblyPoint->factoryInc == psFlag->factoryInc
@@ -6170,7 +6170,7 @@ STRUCTURE	*findDeliveryFactory(FLAG_POSITION *psDelPoint)
 	FACTORY		*psFactory;
 	REPAIR_FACILITY *psRepair;
 
-	for (STRUCTURE* psCurr : worldObjectState.structures[psDelPoint->player])
+	for (STRUCTURE* psCurr : gameWorld.objects.structures[psDelPoint->player])
 	{
 		if (!psCurr)
 		{
@@ -6522,7 +6522,7 @@ void checkDeliveryPoints(UDWORD version)
 		//will have been called to put in down in the first place
 		if (inc != selectedPlayer)
 		{
-			for (STRUCTURE* psStruct : worldObjectState.structures[inc])
+			for (STRUCTURE* psStruct : gameWorld.objects.structures[inc])
 			{
 				if (!psStruct)
 				{
@@ -6783,7 +6783,7 @@ STRUCTURE *findNearestReArmPad(DROID *psDroid, STRUCTURE *psTarget, bool bClear)
 	totallyDist = SDWORD_MAX;
 	psNearest = nullptr;
 	psTotallyClear = nullptr;
-	for (STRUCTURE *psStruct : worldObjectState.structures[psDroid->player])
+	for (STRUCTURE *psStruct : gameWorld.objects.structures[psDroid->player])
 	{
 		if (psStruct->pStructureType->type == REF_REARM_PAD && (!bClear || clearRearmPad(psStruct)))
 		{
@@ -6830,7 +6830,7 @@ void ensureRearmPadClear(STRUCTURE *psStruct, DROID *psDroid)
 	{
 		if (aiCheckAlliances(psStruct->player, i))
 		{
-			for (DROID *psCurr : worldObjectState.droids[i])
+			for (DROID *psCurr : gameWorld.objects.droids[i])
 			{
 				if (psCurr != psDroid
 				    && map_coord(psCurr->pos.x) == tx
@@ -6853,7 +6853,7 @@ bool vtolOnRearmPad(const STRUCTURE *psStruct, const DROID *psDroid)
 	tx = map_coord(psStruct->pos.x);
 	ty = map_coord(psStruct->pos.y);
 
-	for (const DROID* psCurr : worldObjectState.droids[psStruct->player])
+	for (const DROID* psCurr : gameWorld.objects.droids[psStruct->player])
 	{
 		if (psCurr != psDroid
 		    && map_coord(psCurr->pos.x) == tx
@@ -6902,7 +6902,7 @@ STRUCTURE *giftSingleStructure(STRUCTURE *psStructure, UBYTE attackPlayer, bool 
 			(void)removeStruct(psStructure, false);
 
 			// remove structure from one list
-			removeStructureFromList(psStructure, worldObjectState.structures);
+			removeStructureFromList(psStructure, gameWorld.objects.structures);
 
 			psStructure->selected = false;
 
@@ -6920,7 +6920,7 @@ STRUCTURE *giftSingleStructure(STRUCTURE *psStructure, UBYTE attackPlayer, bool 
 			asStructureStats[max].curCount[attackPlayer]++;
 
 			//check through the 'attackPlayer' players list of droids to see if any are targetting it
-			for (DROID* psCurr : worldObjectState.droids[attackPlayer])
+			for (DROID* psCurr : gameWorld.objects.droids[attackPlayer])
 			{
 				if (psCurr->order.psObj == psStructure)
 				{
@@ -6940,7 +6940,7 @@ STRUCTURE *giftSingleStructure(STRUCTURE *psStructure, UBYTE attackPlayer, bool 
 			}
 
 			//check through the 'attackPlayer' players list of structures to see if any are targetting it
-			for (STRUCTURE* psStruct : worldObjectState.structures[attackPlayer])
+			for (STRUCTURE* psStruct : gameWorld.objects.structures[attackPlayer])
 			{
 				if (psStruct->psTarget[0] == psStructure)
 				{

--- a/src/structure.cpp
+++ b/src/structure.cpp
@@ -36,6 +36,7 @@
 #include "ai.h"
 #include "map.h"
 #include "lib/gamelib/gtime.h"
+#include "objmem.h"
 #include "visibility.h"
 #include "structure.h"
 #include "research.h"
@@ -362,7 +363,7 @@ void resetFactoryNumFlag()
 			factoryNumFlag[i][type].clear();
 		}
 		//look through the list of structures to see which have been used
-		for (const STRUCTURE *psStruct : apsStructLists[i])
+		for (const STRUCTURE *psStruct : worldObjectState.structures[i])
 		{
 			FLAG_TYPE type;
 			switch (psStruct->pStructureType->type)
@@ -752,7 +753,7 @@ void setCurrentStructQuantity(bool displayError)
 		{
 			asStructureStats[inc].curCount[player] = 0;
 		}
-		for (const STRUCTURE *psCurr : apsStructLists[player])
+		for (const STRUCTURE *psCurr : worldObjectState.structures[player])
 		{
 			unsigned inc = psCurr->pStructureType - asStructureStats;
 			asStructureStats[inc].curCount[player]++;
@@ -927,7 +928,7 @@ void structureBuild(STRUCTURE *psStruct, DROID *psDroid, int buildPoints, int bu
 	{
 		for (unsigned player = 0; player < MAX_PLAYERS; player++)
 		{
-			for (const DROID *psCurr : apsDroidLists[player])
+			for (const DROID *psCurr : worldObjectState.droids[player])
 			{
 				// An enemy droid is blocking it
 				if ((STRUCTURE *) orderStateObj(psCurr, DORDER_BUILD) == psStruct
@@ -984,7 +985,7 @@ void structureBuild(STRUCTURE *psStruct, DROID *psDroid, int buildPoints, int bu
 		if (psDroid)
 		{
 			// Clear all orders for helping hands. Needed for AI script which runs next frame.
-			for (DROID* psIter : apsDroidLists[psDroid->player])
+			for (DROID* psIter : worldObjectState.droids[psDroid->player])
 			{
 				if ((psIter->order.type == DORDER_BUILD || psIter->order.type == DORDER_HELPBUILD || psIter->order.type == DORDER_LINEBUILD)
 				    && psIter->order.psObj == psStruct
@@ -1803,7 +1804,7 @@ STRUCTURE *buildStructureDir(STRUCTURE_STATS *pStructureType, UDWORD x, UDWORD y
 		StructureBounds bounds = getStructureBounds(psBuilding);
 		for (unsigned playerNum = 0; playerNum < MAX_PLAYERS; ++playerNum)
 		{
-			for (const STRUCTURE *psStruct : apsStructLists[playerNum])
+			for (const STRUCTURE *psStruct : worldObjectState.structures[playerNum])
 			{
 				if (!psStruct)
 				{
@@ -2359,7 +2360,7 @@ void assignFactoryCommandDroid(STRUCTURE *psStruct, DROID *psCommander)
 		}
 		else
 		{
-			addFlagPositionToList(psFact->psAssemblyPoint, mission.apsFlagPosLists);
+			addFlagPositionToList(psFact->psAssemblyPoint, mission.worldObjectState.flags);
 		}
 	}
 
@@ -2369,7 +2370,7 @@ void assignFactoryCommandDroid(STRUCTURE *psStruct, DROID *psCommander)
 
 		factoryInc = psFact->psAssemblyPoint->factoryInc;
 
-		auto& flagPosList = apsFlagPosLists[psStruct->player];
+		auto& flagPosList = worldObjectState.flags[psStruct->player];
 		FlagPositionList::iterator flagPosIt = flagPosList.begin(), flagPosItNext;
 		while (flagPosIt != flagPosList.end())
 		{
@@ -2402,7 +2403,7 @@ void clearCommandDroidFactory(DROID *psDroid)
 {
 	ASSERT_OR_RETURN(, selectedPlayer < MAX_PLAYERS, "invalid selectedPlayer: %" PRIu32 "", selectedPlayer);
 
-	for (STRUCTURE* psCurr : apsStructLists[selectedPlayer])
+	for (STRUCTURE* psCurr : worldObjectState.structures[selectedPlayer])
 	{
 		if ((psCurr->pStructureType->type == REF_FACTORY) ||
 		    (psCurr->pStructureType->type == REF_CYBORG_FACTORY) ||
@@ -2414,7 +2415,7 @@ void clearCommandDroidFactory(DROID *psDroid)
 			}
 		}
 	}
-	for (STRUCTURE* psCurr : mission.apsStructLists[selectedPlayer])
+	for (STRUCTURE* psCurr : mission.worldObjectState.structures[selectedPlayer])
 	{
 		if ((psCurr->pStructureType->type == REF_FACTORY) ||
 		    (psCurr->pStructureType->type == REF_CYBORG_FACTORY) ||
@@ -2444,7 +2445,7 @@ static bool structClearTile(UWORD x, UWORD y, PROPULSION_TYPE propulsion)
 	/* Check for a droid */
 	for (player = 0; player < MAX_PLAYERS; player++)
 	{
-		for (const DROID* psCurr : apsDroidLists[player])
+		for (const DROID* psCurr : worldObjectState.droids[player])
 		{
 			if (map_coord(psCurr->pos.x) == x
 			    && map_coord(psCurr->pos.y) == y)
@@ -2650,7 +2651,7 @@ static bool structPlaceDroid(STRUCTURE *psStructure, DROID_TEMPLATE *psTempl, DR
 		setFactorySecondaryState(psNewDroid, psStructure);
 		displayConstructionCloud(psNewDroid->pos);
 		/* add the droid to the list */
-		addDroid(psNewDroid, apsDroidLists);
+		addDroid(psNewDroid, worldObjectState.droids);
 		*ppsDroid = psNewDroid;
 		if (psNewDroid->player == selectedPlayer)
 		{
@@ -2706,7 +2707,7 @@ static bool structPlaceDroid(STRUCTURE *psStructure, DROID_TEMPLATE *psTempl, DR
 				factoryType = VTOL_FLAG;
 			}
 			//find flag in question.
-			const auto& flagPosList = apsFlagPosLists[psFact->psAssemblyPoint->player];
+			const auto& flagPosList = worldObjectState.flags[psFact->psAssemblyPoint->player];
 			auto psFlag = std::find_if(flagPosList.begin(), flagPosList.end(), [psFact, factoryType](FLAG_POSITION* psFlag)
 			{
 				return psFlag->factoryInc == psFact->psAssemblyPoint->factoryInc // correct fact.
@@ -2788,7 +2789,7 @@ bool structureExists(int player, STRUCTURE_TYPE type, bool built, bool isMission
 		return false;
 	}
 
-	StructureList* pList = isMission ? &mission.apsStructLists[player] : &apsStructLists[player];
+	StructureList* pList = isMission ? &mission.worldObjectState.structures[player] : &worldObjectState.structures[player];
 	for (const STRUCTURE *psCurr : *pList)
 	{
 		if (psCurr->pStructureType->type == type && (!built || (built && psCurr->status == SS_BUILT)))
@@ -3074,11 +3075,11 @@ static void aiUpdateStructure(STRUCTURE *psStructure, bool isMission)
 	{
 		// This isn't supposed to happen, and really shouldn't be possible - if this happens, maybe a structure is being updated twice?
 		int count1 = 0, count2 = 0;
-		for (const STRUCTURE* s : apsStructLists[psStructure->player])
+		for (const STRUCTURE* s : worldObjectState.structures[psStructure->player])
 		{
 			count1 += s == psStructure;
 		}
-		for (const STRUCTURE* s : mission.apsStructLists[psStructure->player])
+		for (const STRUCTURE* s : mission.worldObjectState.structures[psStructure->player])
 		{
 			count2 += s == psStructure;
 		}
@@ -3284,7 +3285,7 @@ static void aiUpdateStructure(STRUCTURE *psStructure, bool isMission)
 			if (psChosenObj == nullptr)
 			{
 				objTrace(psStructure->id, "Rearm pad idle - look for victim");
-				for (DROID* psCurr : apsDroidLists[psStructure->player])
+				for (DROID* psCurr : worldObjectState.droids[psStructure->player])
 				{
 					// move next droid waiting on ground to rearm pad
 					if (vtolReadyToRearm(psCurr, psStructure) &&
@@ -3300,7 +3301,7 @@ static void aiUpdateStructure(STRUCTURE *psStructure, bool isMission)
 				{
 					if (aiCheckAlliances(i, psStructure->player) && i != psStructure->player)
 					{
-						for (DROID* psCurr : apsDroidLists[i])
+						for (DROID* psCurr : worldObjectState.droids[i])
 						{
 							// move next droid waiting on ground to rearm pad
 							if (vtolReadyToRearm(psCurr, psStructure))
@@ -4063,7 +4064,7 @@ std::vector<STRUCTURE_STATS *> fillStructureList(UDWORD _selectedPlayer, UDWORD 
 	//if currently on a mission can't build factory/research/power/derricks
 	if (!missionIsOffworld())
 	{
-		for (const STRUCTURE* psCurr : apsStructLists[_selectedPlayer])
+		for (const STRUCTURE* psCurr : worldObjectState.structures[_selectedPlayer])
 		{
 			if (psCurr->pStructureType->type == REF_RESEARCH && psCurr->status == SS_BUILT)
 			{
@@ -4287,7 +4288,7 @@ bool validLocation(BASE_STATS *psStats, Vector2i pos, uint16_t direction, unsign
 	if (bCheckBuildQueue)
 	{
 		// cant place on top of a delivery point...
-		for (const auto& psFlag : apsFlagPosLists[selectedPlayer])
+		for (const auto& psFlag : worldObjectState.flags[selectedPlayer])
 		{
 			ASSERT_OR_RETURN(false, psFlag->coords.x != ~0, "flag has invalid position");
 			Vector2i flagTile = map_coord(psFlag->coords.xy());
@@ -4907,7 +4908,7 @@ bool checkSpecificStructExists(UDWORD structInc, UDWORD player)
 {
 	ASSERT_OR_RETURN(false, structInc < numStructureStats, "Invalid structure inc");
 
-	for (const STRUCTURE *psStructure : apsStructLists[player])
+	for (const STRUCTURE *psStructure : worldObjectState.structures[player])
 	{
 		if (psStructure->status == SS_BUILT)
 		{
@@ -5183,7 +5184,7 @@ void checkForResExtractors(STRUCTURE *psBuilding)
 	typedef std::vector<Derrick> Derricks;
 	Derricks derricks;
 	derricks.reserve(NUM_POWER_MODULES + 1);
-	for (STRUCTURE *currExtractor : apsExtractorLists[psBuilding->player])
+	for (STRUCTURE *currExtractor : worldObjectState.extractors[psBuilding->player])
 	{
 		RES_EXTRACTOR *resExtractor = &currExtractor->pFunctionality->resourceExtractor;
 
@@ -5238,7 +5239,7 @@ uint16_t countPlayerUnusedDerricks()
 
 	if (selectedPlayer >= MAX_PLAYERS) { return 0; }
 
-	for (const STRUCTURE *psStruct : apsExtractorLists[selectedPlayer])
+	for (const STRUCTURE *psStruct : worldObjectState.extractors[selectedPlayer])
 	{
 		if (psStruct->status == SS_BUILT && psStruct->pStructureType->type == REF_RESOURCE_EXTRACTOR)
 		{
@@ -5266,7 +5267,7 @@ void checkForPowerGen(STRUCTURE *psBuilding)
 	// Find a power generator, if possible with a power module.
 	STRUCTURE *bestPowerGen = nullptr;
 	int bestSlot = 0;
-	for (STRUCTURE *psCurr : apsStructLists[psBuilding->player])
+	for (STRUCTURE *psCurr : worldObjectState.structures[psBuilding->player])
 	{
 		if (psCurr->pStructureType->type == REF_POWER_GEN && psCurr->status == SS_BUILT)
 		{
@@ -5347,7 +5348,7 @@ void releaseResExtractor(STRUCTURE *psRelease)
 	psRelease->pFunctionality->resourceExtractor.psPowerGen = nullptr;
 
 	//there may be spare resource extractors
-	for (STRUCTURE* psCurr : apsExtractorLists[psRelease->player])
+	for (STRUCTURE* psCurr : worldObjectState.extractors[psRelease->player])
 	{
 		//check not connected and power left and built!
 		if (psCurr != psRelease && psCurr->pFunctionality->resourceExtractor.psPowerGen == nullptr && psCurr->status == SS_BUILT)
@@ -5383,7 +5384,7 @@ void releasePowerGen(STRUCTURE *psRelease)
 		}
 	}
 	//may have a power gen with spare capacity
-	for (STRUCTURE* psCurr : apsStructLists[psRelease->player])
+	for (STRUCTURE* psCurr : worldObjectState.structures[psRelease->player])
 	{
 		if (psCurr->pStructureType->type == REF_POWER_GEN &&
 		    psCurr != psRelease && psCurr->status == SS_BUILT)
@@ -5493,7 +5494,7 @@ static unsigned int countAssignedDroids(const STRUCTURE *psStructure)
 	}
 
 	num = 0;
-	for (const DROID* psCurr : apsDroidLists[selectedPlayer])
+	for (const DROID* psCurr : worldObjectState.droids[selectedPlayer])
 	{
 		if (psCurr->order.psObj
 		    && psCurr->order.psObj->id == psStructure->id
@@ -6084,7 +6085,7 @@ void hqReward(UBYTE losingPlayer, UBYTE rewardPlayer)
 	//struct
 	for (int i = 0; i < MAX_PLAYERS; ++i)
 	{
-		for (STRUCTURE *psStruct : apsStructLists[i])
+		for (STRUCTURE *psStruct : worldObjectState.structures[i])
 		{
 			if (psStruct->visible[losingPlayer] && !psStruct->died)
 			{
@@ -6093,7 +6094,7 @@ void hqReward(UBYTE losingPlayer, UBYTE rewardPlayer)
 		}
 
 		//droids.
-		for (DROID *psDroid : apsDroidLists[i])
+		for (DROID *psDroid : worldObjectState.droids[i])
 		{
 			if (psDroid->visible[losingPlayer] || psDroid->player == losingPlayer)
 			{
@@ -6103,7 +6104,7 @@ void hqReward(UBYTE losingPlayer, UBYTE rewardPlayer)
 	}
 
 	//feature
-	for (FEATURE *psFeat : apsFeatureList[0])
+	for (FEATURE *psFeat : worldObjectState.features[0])
 	{
 		if (psFeat->visible[losingPlayer])
 		{
@@ -6148,7 +6149,7 @@ FLAG_POSITION *FindFactoryDelivery(const STRUCTURE *Struct)
 	if (Struct && Struct->isFactory())
 	{
 		// Find the factories delivery point.
-		for (const auto& psFlag : apsFlagPosLists[Struct->player])
+		for (const auto& psFlag : worldObjectState.flags[Struct->player])
 		{
 			if (FlagIsFactory(psFlag)
 				&& Struct->pFunctionality->factory.psAssemblyPoint->factoryInc == psFlag->factoryInc
@@ -6169,7 +6170,7 @@ STRUCTURE	*findDeliveryFactory(FLAG_POSITION *psDelPoint)
 	FACTORY		*psFactory;
 	REPAIR_FACILITY *psRepair;
 
-	for (STRUCTURE* psCurr : apsStructLists[psDelPoint->player])
+	for (STRUCTURE* psCurr : worldObjectState.structures[psDelPoint->player])
 	{
 		if (!psCurr)
 		{
@@ -6521,7 +6522,7 @@ void checkDeliveryPoints(UDWORD version)
 		//will have been called to put in down in the first place
 		if (inc != selectedPlayer)
 		{
-			for (STRUCTURE* psStruct : apsStructLists[inc])
+			for (STRUCTURE* psStruct : worldObjectState.structures[inc])
 			{
 				if (!psStruct)
 				{
@@ -6782,7 +6783,7 @@ STRUCTURE *findNearestReArmPad(DROID *psDroid, STRUCTURE *psTarget, bool bClear)
 	totallyDist = SDWORD_MAX;
 	psNearest = nullptr;
 	psTotallyClear = nullptr;
-	for (STRUCTURE *psStruct : apsStructLists[psDroid->player])
+	for (STRUCTURE *psStruct : worldObjectState.structures[psDroid->player])
 	{
 		if (psStruct->pStructureType->type == REF_REARM_PAD && (!bClear || clearRearmPad(psStruct)))
 		{
@@ -6829,7 +6830,7 @@ void ensureRearmPadClear(STRUCTURE *psStruct, DROID *psDroid)
 	{
 		if (aiCheckAlliances(psStruct->player, i))
 		{
-			for (DROID *psCurr : apsDroidLists[i])
+			for (DROID *psCurr : worldObjectState.droids[i])
 			{
 				if (psCurr != psDroid
 				    && map_coord(psCurr->pos.x) == tx
@@ -6852,7 +6853,7 @@ bool vtolOnRearmPad(const STRUCTURE *psStruct, const DROID *psDroid)
 	tx = map_coord(psStruct->pos.x);
 	ty = map_coord(psStruct->pos.y);
 
-	for (const DROID* psCurr : apsDroidLists[psStruct->player])
+	for (const DROID* psCurr : worldObjectState.droids[psStruct->player])
 	{
 		if (psCurr != psDroid
 		    && map_coord(psCurr->pos.x) == tx
@@ -6901,7 +6902,7 @@ STRUCTURE *giftSingleStructure(STRUCTURE *psStructure, UBYTE attackPlayer, bool 
 			(void)removeStruct(psStructure, false);
 
 			// remove structure from one list
-			removeStructureFromList(psStructure, apsStructLists);
+			removeStructureFromList(psStructure, worldObjectState.structures);
 
 			psStructure->selected = false;
 
@@ -6919,7 +6920,7 @@ STRUCTURE *giftSingleStructure(STRUCTURE *psStructure, UBYTE attackPlayer, bool 
 			asStructureStats[max].curCount[attackPlayer]++;
 
 			//check through the 'attackPlayer' players list of droids to see if any are targetting it
-			for (DROID* psCurr : apsDroidLists[attackPlayer])
+			for (DROID* psCurr : worldObjectState.droids[attackPlayer])
 			{
 				if (psCurr->order.psObj == psStructure)
 				{
@@ -6939,7 +6940,7 @@ STRUCTURE *giftSingleStructure(STRUCTURE *psStructure, UBYTE attackPlayer, bool 
 			}
 
 			//check through the 'attackPlayer' players list of structures to see if any are targetting it
-			for (STRUCTURE* psStruct : apsStructLists[attackPlayer])
+			for (STRUCTURE* psStruct : worldObjectState.structures[attackPlayer])
 			{
 				if (psStruct->psTarget[0] == psStructure)
 				{

--- a/src/template.cpp
+++ b/src/template.cpp
@@ -748,10 +748,10 @@ void deleteTemplateFromProduction(DROID_TEMPLATE *psTemplate, unsigned player, Q
 		switch (i)
 		{
 		case 0:
-			psList = &apsStructLists[player];
+			psList = &worldObjectState.structures[player];
 			break;
 		case 1:
-			psList = &mission.apsStructLists[player];
+			psList = &mission.worldObjectState.structures[player];
 			break;
 		}
 		if (!psList)

--- a/src/template.cpp
+++ b/src/template.cpp
@@ -748,10 +748,10 @@ void deleteTemplateFromProduction(DROID_TEMPLATE *psTemplate, unsigned player, Q
 		switch (i)
 		{
 		case 0:
-			psList = &worldObjectState.structures[player];
+			psList = &gameWorld.objects.structures[player];
 			break;
 		case 1:
-			psList = &mission.worldObjectState.structures[player];
+			psList = &mission.gameWorld.objects.structures[player];
 			break;
 		}
 		if (!psList)

--- a/src/terrain.cpp
+++ b/src/terrain.cpp
@@ -65,6 +65,8 @@
 
 #include "profiling.h"
 
+#include "game_world.h"
+
 #include <cstdint>
 
 // TODO: Fix and remove after merging terrain rendering changes
@@ -313,10 +315,10 @@ static void averagePos(Vector3i *center, Vector3i *a, Vector3i *b, Vector3i *c, 
 static bool isWater(int x, int y)
 {
 	bool result = false;
-	result = result || (tileOnMap(worldMapState, x  , y) && terrainType(mapTile(worldMapState, x  , y)) == TER_WATER);
-	result = result || (tileOnMap(worldMapState, x - 1, y) && terrainType(mapTile(worldMapState, x - 1, y)) == TER_WATER);
-	result = result || (tileOnMap(worldMapState, x  , y - 1) && terrainType(mapTile(worldMapState, x  , y - 1)) == TER_WATER);
-	result = result || (tileOnMap(worldMapState, x - 1, y - 1) && terrainType(mapTile(worldMapState, x - 1, y - 1)) == TER_WATER);
+	result = result || (tileOnMap(gameWorld.map, x  , y) && terrainType(mapTile(gameWorld.map, x  , y)) == TER_WATER);
+	result = result || (tileOnMap(gameWorld.map, x - 1, y) && terrainType(mapTile(gameWorld.map, x - 1, y)) == TER_WATER);
+	result = result || (tileOnMap(gameWorld.map, x  , y - 1) && terrainType(mapTile(gameWorld.map, x  , y - 1)) == TER_WATER);
+	result = result || (tileOnMap(gameWorld.map, x - 1, y - 1) && terrainType(mapTile(gameWorld.map, x - 1, y - 1)) == TER_WATER);
 	return result;
 }
 
@@ -324,10 +326,10 @@ static bool isWater(int x, int y)
 static bool isOnlyWater(int x, int y)
 {
 	bool result = true;
-	result = result && (tileOnMap(worldMapState, x  , y) && terrainType(mapTile(worldMapState, x  , y)) == TER_WATER);
-	result = result && (tileOnMap(worldMapState, x - 1, y) && terrainType(mapTile(worldMapState, x - 1, y)) == TER_WATER);
-	result = result && (tileOnMap(worldMapState, x  , y - 1) && terrainType(mapTile(worldMapState, x  , y - 1)) == TER_WATER);
-	result = result && (tileOnMap(worldMapState, x - 1, y - 1) && terrainType(mapTile(worldMapState, x - 1, y - 1)) == TER_WATER);
+	result = result && (tileOnMap(gameWorld.map, x  , y) && terrainType(mapTile(gameWorld.map, x  , y)) == TER_WATER);
+	result = result && (tileOnMap(gameWorld.map, x - 1, y) && terrainType(mapTile(gameWorld.map, x - 1, y)) == TER_WATER);
+	result = result && (tileOnMap(gameWorld.map, x  , y - 1) && terrainType(mapTile(gameWorld.map, x  , y - 1)) == TER_WATER);
+	result = result && (tileOnMap(gameWorld.map, x - 1, y - 1) && terrainType(mapTile(gameWorld.map, x - 1, y - 1)) == TER_WATER);
 	return result;
 }
 
@@ -347,7 +349,7 @@ static void getGridPos(Vector3i *result, int x, int y, bool center, bool water)
 	result->x = world_coord(x);
 	result->z = world_coord(-y);
 
-	if (x <= 0 || y <= 0 || x >= worldMapState.width || y >= worldMapState.height)
+	if (x <= 0 || y <= 0 || x >= gameWorld.map.width || y >= gameWorld.map.height)
 	{
 		result->y = 0;
 	}
@@ -355,15 +357,15 @@ static void getGridPos(Vector3i *result, int x, int y, bool center, bool water)
 	{
 		if (terrainShaderQuality != TerrainShaderQuality::CLASSIC)
 		{
-			result->y = map_TileHeight(worldMapState, x, y);
+			result->y = map_TileHeight(gameWorld.map, x, y);
 			if (water)
 			{
-				result->y = map_WaterHeight(worldMapState, x, y);
+				result->y = map_WaterHeight(gameWorld.map, x, y);
 			}
 		}
 		else
 		{
-			result->y = map_TileHeightSurface(worldMapState, x, y);
+			result->y = map_TileHeightSurface(gameWorld.map, x, y);
 		}
 	}
 }
@@ -414,7 +416,7 @@ static void setSectorGeometry(int sx, int sy,
 			geometry[*geometrySize].pos = pos;
 			(*geometrySize)++;
 
-			float waterHeight = map_WaterHeight(worldMapState, x, y);
+			float waterHeight = map_WaterHeight(gameWorld.map, x, y);
 			water[*waterSize] = glm::vec4(pos.x, (terrainShaderQuality != TerrainShaderQuality::CLASSIC) ? waterHeight : pos.y, pos.z, waterHeight - pos.y);
 			(*waterSize)++;
 
@@ -438,12 +440,12 @@ static void setSectorDecalVertex_SinglePass(int x, int y, gfx_api::TerrainDecalV
 	{
 		for (j = y * sectorSize; j < y * sectorSize + sectorSize; j++)
 		{
-			if (i < 0 || j < 0 || i >= worldMapState.width || j >= worldMapState.height)
+			if (i < 0 || j < 0 || i >= gameWorld.map.width || j >= gameWorld.map.height)
 			{
 				continue;
 			}
 
-			MAPTILE *tile = mapTile(worldMapState, i, j);
+			MAPTILE *tile = mapTile(gameWorld.map, i, j);
 			center = getTileTexArrCoords(*uv, tile->texture);
 			int decalNo = static_cast<int>(TileNumber_tile(tile->texture));
 			bool skipDecalDraw = !TILE_HAS_DECAL(tile);
@@ -467,7 +469,7 @@ static void setSectorDecalVertex_SinglePass(int x, int y, gfx_api::TerrainDecalV
 				vs[k].decalUv = uv[dx][dy];
 				vs[k].normal = getGridNormal(i + dx, j + dy);
 				vs[k].decalNo = decalNo;
-				groundsBytes[k] = mapTile(worldMapState, i + dx, j + dy)->ground;
+				groundsBytes[k] = mapTile(gameWorld.map, i + dx, j + dy)->ground;
 				vs[k].groundWeights.clear();
 				vs[k].groundWeights.setByte(k, 255);
 			}
@@ -977,8 +979,8 @@ bool initTerrain()
 
 	/////////////////////
 	// Create the sectors
-	xSectors = (worldMapState.width + sectorSize - 1) / sectorSize;
-	ySectors = (worldMapState.height + sectorSize - 1) / sectorSize;
+	xSectors = (gameWorld.map.width + sectorSize - 1) / sectorSize;
+	ySectors = (gameWorld.map.height + sectorSize - 1) / sectorSize;
 	sectors = std::unique_ptr<Sector[]> (new Sector[xSectors * ySectors]());
 
 	////////////////////
@@ -1017,7 +1019,7 @@ bool initTerrain()
 			{
 				for (j = 0; j < sectorSize; j++)
 				{
-					if (x * sectorSize + i >= worldMapState.width || y * sectorSize + j >= worldMapState.height)
+					if (x * sectorSize + i >= gameWorld.map.width || y * sectorSize + j >= gameWorld.map.height)
 					{
 						continue; // off map, so skip
 					}
@@ -1109,7 +1111,7 @@ bool initTerrain()
 
 
 	// and finally the decals
-	gfx_api::TerrainDecalVertex *terrainDecalData = (gfx_api::TerrainDecalVertex *)malloc(sizeof(gfx_api::TerrainDecalVertex) * worldMapState.width * worldMapState.height * 12);
+	gfx_api::TerrainDecalVertex *terrainDecalData = (gfx_api::TerrainDecalVertex *)malloc(sizeof(gfx_api::TerrainDecalVertex) * gameWorld.map.width * gameWorld.map.height * 12);
 	int terrainDecalSize = 0;
 
 	for (x = 0; x < xSectors; x++)
@@ -1145,13 +1147,13 @@ bool initTerrain()
 	lightmapWidth = 1;
 	lightmapHeight = 1;
 	// determine the smallest power-of-two size we can use for the lightmap
-	while (worldMapState.width > (lightmapWidth <<= 1)) {}
-	while (worldMapState.height > (lightmapHeight <<= 1)) {}
-	debug(LOG_TERRAIN, "the size of the map is %ix%i", worldMapState.width, worldMapState.height);
+	while (gameWorld.map.width > (lightmapWidth <<= 1)) {}
+	while (gameWorld.map.height > (lightmapHeight <<= 1)) {}
+	debug(LOG_TERRAIN, "the size of the map is %ix%i", gameWorld.map.width, gameWorld.map.height);
 	debug(LOG_TERRAIN, "lightmap texture size is %zu x %zu", lightmapWidth, lightmapHeight);
 
-	lightmapValues.paramsXLight = glm::vec4(1.0f / world_coord(worldMapState.width) *((float)worldMapState.width / (float)lightmapWidth), 0, 0, 0);
-	lightmapValues.paramsYLight = glm::vec4(0, 0, -1.0f / world_coord(worldMapState.height) *((float)worldMapState.height / (float)lightmapHeight), 0);
+	lightmapValues.paramsXLight = glm::vec4(1.0f / world_coord(gameWorld.map.width) *((float)gameWorld.map.width / (float)lightmapWidth), 0, 0, 0);
+	lightmapValues.paramsYLight = glm::vec4(0, 0, -1.0f / world_coord(gameWorld.map.height) *((float)gameWorld.map.height / (float)lightmapHeight), 0);
 
 	// shift the lightmap half a tile as lights are supposed to be placed at the center of a tile
 	lightmapValues.lightMatrix = glm::translate(glm::vec3(1.f / (float)lightmapWidth / 2, 1.f / (float)lightmapHeight / 2, 0.f));
@@ -1218,11 +1220,11 @@ static void updateLightMap(const LightMap& lightmap)
 {
 	size_t lightmapChannels = lightmapPixmap->channels(); // should always be 4 now...
 	unsigned char* lightMapWritePtr = lightmapPixmap->bmp_w();
-	for (int j = 0; j < worldMapState.height; ++j)
+	for (int j = 0; j < gameWorld.map.height; ++j)
 	{
-		for (int i = 0; i < worldMapState.width; ++i)
+		for (int i = 0; i < gameWorld.map.width; ++i)
 		{
-			MAPTILE *psTile = mapTile(worldMapState, i, j);
+			MAPTILE *psTile = mapTile(gameWorld.map, i, j);
 			PIELIGHT colour = lightmap(i, j);
 			UBYTE level = static_cast<UBYTE>(psTile->level);
 

--- a/src/terrain.cpp
+++ b/src/terrain.cpp
@@ -347,7 +347,7 @@ static void getGridPos(Vector3i *result, int x, int y, bool center, bool water)
 	result->x = world_coord(x);
 	result->z = world_coord(-y);
 
-	if (x <= 0 || y <= 0 || x >= mapWidth || y >= mapHeight)
+	if (x <= 0 || y <= 0 || x >= worldMapState.width || y >= worldMapState.height)
 	{
 		result->y = 0;
 	}
@@ -438,7 +438,7 @@ static void setSectorDecalVertex_SinglePass(int x, int y, gfx_api::TerrainDecalV
 	{
 		for (j = y * sectorSize; j < y * sectorSize + sectorSize; j++)
 		{
-			if (i < 0 || j < 0 || i >= mapWidth || j >= mapHeight)
+			if (i < 0 || j < 0 || i >= worldMapState.width || j >= worldMapState.height)
 			{
 				continue;
 			}
@@ -977,8 +977,8 @@ bool initTerrain()
 
 	/////////////////////
 	// Create the sectors
-	xSectors = (mapWidth + sectorSize - 1) / sectorSize;
-	ySectors = (mapHeight + sectorSize - 1) / sectorSize;
+	xSectors = (worldMapState.width + sectorSize - 1) / sectorSize;
+	ySectors = (worldMapState.height + sectorSize - 1) / sectorSize;
 	sectors = std::unique_ptr<Sector[]> (new Sector[xSectors * ySectors]());
 
 	////////////////////
@@ -1017,7 +1017,7 @@ bool initTerrain()
 			{
 				for (j = 0; j < sectorSize; j++)
 				{
-					if (x * sectorSize + i >= mapWidth || y * sectorSize + j >= mapHeight)
+					if (x * sectorSize + i >= worldMapState.width || y * sectorSize + j >= worldMapState.height)
 					{
 						continue; // off map, so skip
 					}
@@ -1109,7 +1109,7 @@ bool initTerrain()
 
 
 	// and finally the decals
-	gfx_api::TerrainDecalVertex *terrainDecalData = (gfx_api::TerrainDecalVertex *)malloc(sizeof(gfx_api::TerrainDecalVertex) * mapWidth * mapHeight * 12);
+	gfx_api::TerrainDecalVertex *terrainDecalData = (gfx_api::TerrainDecalVertex *)malloc(sizeof(gfx_api::TerrainDecalVertex) * worldMapState.width * worldMapState.height * 12);
 	int terrainDecalSize = 0;
 
 	for (x = 0; x < xSectors; x++)
@@ -1145,13 +1145,13 @@ bool initTerrain()
 	lightmapWidth = 1;
 	lightmapHeight = 1;
 	// determine the smallest power-of-two size we can use for the lightmap
-	while (mapWidth > (lightmapWidth <<= 1)) {}
-	while (mapHeight > (lightmapHeight <<= 1)) {}
-	debug(LOG_TERRAIN, "the size of the map is %ix%i", mapWidth, mapHeight);
+	while (worldMapState.width > (lightmapWidth <<= 1)) {}
+	while (worldMapState.height > (lightmapHeight <<= 1)) {}
+	debug(LOG_TERRAIN, "the size of the map is %ix%i", worldMapState.width, worldMapState.height);
 	debug(LOG_TERRAIN, "lightmap texture size is %zu x %zu", lightmapWidth, lightmapHeight);
 
-	lightmapValues.paramsXLight = glm::vec4(1.0f / world_coord(mapWidth) *((float)mapWidth / (float)lightmapWidth), 0, 0, 0);
-	lightmapValues.paramsYLight = glm::vec4(0, 0, -1.0f / world_coord(mapHeight) *((float)mapHeight / (float)lightmapHeight), 0);
+	lightmapValues.paramsXLight = glm::vec4(1.0f / world_coord(worldMapState.width) *((float)worldMapState.width / (float)lightmapWidth), 0, 0, 0);
+	lightmapValues.paramsYLight = glm::vec4(0, 0, -1.0f / world_coord(worldMapState.height) *((float)worldMapState.height / (float)lightmapHeight), 0);
 
 	// shift the lightmap half a tile as lights are supposed to be placed at the center of a tile
 	lightmapValues.lightMatrix = glm::translate(glm::vec3(1.f / (float)lightmapWidth / 2, 1.f / (float)lightmapHeight / 2, 0.f));
@@ -1218,9 +1218,9 @@ static void updateLightMap(const LightMap& lightmap)
 {
 	size_t lightmapChannels = lightmapPixmap->channels(); // should always be 4 now...
 	unsigned char* lightMapWritePtr = lightmapPixmap->bmp_w();
-	for (int j = 0; j < mapHeight; ++j)
+	for (int j = 0; j < worldMapState.height; ++j)
 	{
-		for (int i = 0; i < mapWidth; ++i)
+		for (int i = 0; i < worldMapState.width; ++i)
 		{
 			MAPTILE *psTile = mapTile(i, j);
 			PIELIGHT colour = lightmap(i, j);

--- a/src/terrain.cpp
+++ b/src/terrain.cpp
@@ -313,10 +313,10 @@ static void averagePos(Vector3i *center, Vector3i *a, Vector3i *b, Vector3i *c, 
 static bool isWater(int x, int y)
 {
 	bool result = false;
-	result = result || (tileOnMap(x  , y) && terrainType(mapTile(x  , y)) == TER_WATER);
-	result = result || (tileOnMap(x - 1, y) && terrainType(mapTile(x - 1, y)) == TER_WATER);
-	result = result || (tileOnMap(x  , y - 1) && terrainType(mapTile(x  , y - 1)) == TER_WATER);
-	result = result || (tileOnMap(x - 1, y - 1) && terrainType(mapTile(x - 1, y - 1)) == TER_WATER);
+	result = result || (tileOnMap(worldMapState, x  , y) && terrainType(mapTile(worldMapState, x  , y)) == TER_WATER);
+	result = result || (tileOnMap(worldMapState, x - 1, y) && terrainType(mapTile(worldMapState, x - 1, y)) == TER_WATER);
+	result = result || (tileOnMap(worldMapState, x  , y - 1) && terrainType(mapTile(worldMapState, x  , y - 1)) == TER_WATER);
+	result = result || (tileOnMap(worldMapState, x - 1, y - 1) && terrainType(mapTile(worldMapState, x - 1, y - 1)) == TER_WATER);
 	return result;
 }
 
@@ -324,10 +324,10 @@ static bool isWater(int x, int y)
 static bool isOnlyWater(int x, int y)
 {
 	bool result = true;
-	result = result && (tileOnMap(x  , y) && terrainType(mapTile(x  , y)) == TER_WATER);
-	result = result && (tileOnMap(x - 1, y) && terrainType(mapTile(x - 1, y)) == TER_WATER);
-	result = result && (tileOnMap(x  , y - 1) && terrainType(mapTile(x  , y - 1)) == TER_WATER);
-	result = result && (tileOnMap(x - 1, y - 1) && terrainType(mapTile(x - 1, y - 1)) == TER_WATER);
+	result = result && (tileOnMap(worldMapState, x  , y) && terrainType(mapTile(worldMapState, x  , y)) == TER_WATER);
+	result = result && (tileOnMap(worldMapState, x - 1, y) && terrainType(mapTile(worldMapState, x - 1, y)) == TER_WATER);
+	result = result && (tileOnMap(worldMapState, x  , y - 1) && terrainType(mapTile(worldMapState, x  , y - 1)) == TER_WATER);
+	result = result && (tileOnMap(worldMapState, x - 1, y - 1) && terrainType(mapTile(worldMapState, x - 1, y - 1)) == TER_WATER);
 	return result;
 }
 
@@ -355,15 +355,15 @@ static void getGridPos(Vector3i *result, int x, int y, bool center, bool water)
 	{
 		if (terrainShaderQuality != TerrainShaderQuality::CLASSIC)
 		{
-			result->y = map_TileHeight(x, y);
+			result->y = map_TileHeight(worldMapState, x, y);
 			if (water)
 			{
-				result->y = map_WaterHeight(x, y);
+				result->y = map_WaterHeight(worldMapState, x, y);
 			}
 		}
 		else
 		{
-			result->y = map_TileHeightSurface(x, y);
+			result->y = map_TileHeightSurface(worldMapState, x, y);
 		}
 	}
 }
@@ -414,7 +414,7 @@ static void setSectorGeometry(int sx, int sy,
 			geometry[*geometrySize].pos = pos;
 			(*geometrySize)++;
 
-			float waterHeight = map_WaterHeight(x, y);
+			float waterHeight = map_WaterHeight(worldMapState, x, y);
 			water[*waterSize] = glm::vec4(pos.x, (terrainShaderQuality != TerrainShaderQuality::CLASSIC) ? waterHeight : pos.y, pos.z, waterHeight - pos.y);
 			(*waterSize)++;
 
@@ -443,7 +443,7 @@ static void setSectorDecalVertex_SinglePass(int x, int y, gfx_api::TerrainDecalV
 				continue;
 			}
 
-			MAPTILE *tile = mapTile(i, j);
+			MAPTILE *tile = mapTile(worldMapState, i, j);
 			center = getTileTexArrCoords(*uv, tile->texture);
 			int decalNo = static_cast<int>(TileNumber_tile(tile->texture));
 			bool skipDecalDraw = !TILE_HAS_DECAL(tile);
@@ -467,7 +467,7 @@ static void setSectorDecalVertex_SinglePass(int x, int y, gfx_api::TerrainDecalV
 				vs[k].decalUv = uv[dx][dy];
 				vs[k].normal = getGridNormal(i + dx, j + dy);
 				vs[k].decalNo = decalNo;
-				groundsBytes[k] = mapTile(i + dx, j + dy)->ground;
+				groundsBytes[k] = mapTile(worldMapState, i + dx, j + dy)->ground;
 				vs[k].groundWeights.clear();
 				vs[k].groundWeights.setByte(k, 255);
 			}
@@ -1222,7 +1222,7 @@ static void updateLightMap(const LightMap& lightmap)
 	{
 		for (int i = 0; i < worldMapState.width; ++i)
 		{
-			MAPTILE *psTile = mapTile(i, j);
+			MAPTILE *psTile = mapTile(worldMapState, i, j);
 			PIELIGHT colour = lightmap(i, j);
 			UBYTE level = static_cast<UBYTE>(psTile->level);
 

--- a/src/transporter.cpp
+++ b/src/transporter.cpp
@@ -605,7 +605,7 @@ bool intAddDroidsAvailForm()
 	sBarInit.sMinorCol = WZCOL_ACTION_PROGRESS_BAR_MINOR;
 
 	//add droids built before the mission
-	for (DROID *psDroid : mission.worldObjectState.droids[selectedPlayer])
+	for (DROID *psDroid : mission.gameWorld.objects.droids[selectedPlayer])
 	{
 		//stop adding the buttons once IDTRANS_DROIDEND has been reached
 		if (nextButtonId == IDTRANS_DROIDEND)
@@ -952,12 +952,12 @@ void transporterRemoveDroid(DROID *psTransport, DROID *psDroid, QUEUE_MODE mode)
 	//add it back into apsDroidLists
 	if (onMission)
 	{
-		addDroid(psDroid, mission.worldObjectState.droids);
+		addDroid(psDroid, mission.gameWorld.objects.droids);
 	}
 	else
 	{
 		// add the droid back onto the droid list
-		addDroid(psDroid, worldObjectState.droids);
+		addDroid(psDroid, gameWorld.objects.droids);
 	}
 
 	if (psDroid->pos.x != INVALID_XY)
@@ -1039,7 +1039,7 @@ void transporterAddDroid(DROID *psTransporter, DROID *psDroidToAdd)
 		if (bMultiPlayer)
 		{
 			// search for the nearest transporter if the current one is already full
-			for (auto psOtherDroid : worldObjectState.droids[psTransporter->player])
+			for (auto psOtherDroid : gameWorld.objects.droids[psTransporter->player])
 			{
 				if (psOtherDroid->isTransporter() &&
 					checkTransporterSpace(psOtherDroid, psDroidToAdd) &&
@@ -1075,12 +1075,12 @@ void transporterAddDroid(DROID *psTransporter, DROID *psDroidToAdd)
 	if (onMission)
 	{
 		// removing from droid mission list
-		bDroidRemoved = droidRemove(psDroidToAdd, mission.worldObjectState.droids);
+		bDroidRemoved = droidRemove(psDroidToAdd, mission.gameWorld.objects.droids);
 	}
 	else
 	{
 		// removing from droid list
-		bDroidRemoved = droidRemove(psDroidToAdd, worldObjectState.droids);
+		bDroidRemoved = droidRemove(psDroidToAdd, gameWorld.objects.droids);
 	}
 
 	if (bDroidRemoved)
@@ -1156,11 +1156,11 @@ DroidList* transInterfaceDroidList()
 	ASSERT_OR_RETURN(nullptr, selectedPlayer < MAX_PLAYERS, "Cannot be called for selectedPlayer: %" PRIu32 "", selectedPlayer);
 	if (onMission)
 	{
-		return &mission.worldObjectState.droids[selectedPlayer];
+		return &mission.gameWorld.objects.droids[selectedPlayer];
 	}
 	else
 	{
-		return &worldObjectState.droids[selectedPlayer];
+		return &gameWorld.objects.droids[selectedPlayer];
 	}
 }
 

--- a/src/transporter.cpp
+++ b/src/transporter.cpp
@@ -605,7 +605,7 @@ bool intAddDroidsAvailForm()
 	sBarInit.sMinorCol = WZCOL_ACTION_PROGRESS_BAR_MINOR;
 
 	//add droids built before the mission
-	for (DROID *psDroid : mission.apsDroidLists[selectedPlayer])
+	for (DROID *psDroid : mission.worldObjectState.droids[selectedPlayer])
 	{
 		//stop adding the buttons once IDTRANS_DROIDEND has been reached
 		if (nextButtonId == IDTRANS_DROIDEND)
@@ -952,12 +952,12 @@ void transporterRemoveDroid(DROID *psTransport, DROID *psDroid, QUEUE_MODE mode)
 	//add it back into apsDroidLists
 	if (onMission)
 	{
-		addDroid(psDroid, mission.apsDroidLists);
+		addDroid(psDroid, mission.worldObjectState.droids);
 	}
 	else
 	{
 		// add the droid back onto the droid list
-		addDroid(psDroid, apsDroidLists);
+		addDroid(psDroid, worldObjectState.droids);
 	}
 
 	if (psDroid->pos.x != INVALID_XY)
@@ -1039,7 +1039,7 @@ void transporterAddDroid(DROID *psTransporter, DROID *psDroidToAdd)
 		if (bMultiPlayer)
 		{
 			// search for the nearest transporter if the current one is already full
-			for (auto psOtherDroid : apsDroidLists[psTransporter->player])
+			for (auto psOtherDroid : worldObjectState.droids[psTransporter->player])
 			{
 				if (psOtherDroid->isTransporter() &&
 					checkTransporterSpace(psOtherDroid, psDroidToAdd) &&
@@ -1075,12 +1075,12 @@ void transporterAddDroid(DROID *psTransporter, DROID *psDroidToAdd)
 	if (onMission)
 	{
 		// removing from droid mission list
-		bDroidRemoved = droidRemove(psDroidToAdd, mission.apsDroidLists);
+		bDroidRemoved = droidRemove(psDroidToAdd, mission.worldObjectState.droids);
 	}
 	else
 	{
 		// removing from droid list
-		bDroidRemoved = droidRemove(psDroidToAdd, apsDroidLists);
+		bDroidRemoved = droidRemove(psDroidToAdd, worldObjectState.droids);
 	}
 
 	if (bDroidRemoved)
@@ -1156,11 +1156,11 @@ DroidList* transInterfaceDroidList()
 	ASSERT_OR_RETURN(nullptr, selectedPlayer < MAX_PLAYERS, "Cannot be called for selectedPlayer: %" PRIu32 "", selectedPlayer);
 	if (onMission)
 	{
-		return &mission.apsDroidLists[selectedPlayer];
+		return &mission.worldObjectState.droids[selectedPlayer];
 	}
 	else
 	{
-		return &apsDroidLists[selectedPlayer];
+		return &worldObjectState.droids[selectedPlayer];
 	}
 }
 

--- a/src/visibility.cpp
+++ b/src/visibility.cpp
@@ -141,7 +141,7 @@ uint32_t addSpotter(int x, int y, int player, int radius, bool radar, uint32_t e
 	{
 		const int mapX = x + tiles[i].dx;
 		const int mapY = y + tiles[i].dy;
-		if (mapX < 0 || mapX >= mapWidth || mapY < 0 || mapY >= mapHeight)
+		if (mapX < 0 || mapX >= worldMapState.width || mapY < 0 || mapY >= worldMapState.height)
 		{
 			continue;
 		}
@@ -283,7 +283,7 @@ static void doWaveTerrain(BASE_OBJECT *psObj)
 	{
 		const int mapX = map_coord(sx) + tiles[i].dx;
 		const int mapY = map_coord(sy) + tiles[i].dy;
-		if (mapX < 0 || mapX >= mapWidth || mapY < 0 || mapY >= mapHeight)
+		if (mapX < 0 || mapX >= worldMapState.width || mapY < 0 || mapY >= worldMapState.height)
 		{
 			continue;
 		}
@@ -344,7 +344,7 @@ static bool rayLOSCallback(Vector2i pos, int32_t dist, void *data)
 {
 	VisibleObjectHelp_t *help = (VisibleObjectHelp_t *)data;
 
-	ASSERT(pos.x >= 0 && pos.x < world_coord(mapWidth) && pos.y >= 0 && pos.y < world_coord(mapHeight), "rayLOSCallback: coords off map");
+	ASSERT(pos.x >= 0 && pos.x < world_coord(worldMapState.width) && pos.y >= 0 && pos.y < world_coord(worldMapState.height), "rayLOSCallback: coords off map");
 
 	if (help->rayStart)
 	{
@@ -391,7 +391,7 @@ static bool rayLOSCallback(Vector2i pos, int32_t dist, void *data)
 /* Remove tile visibility from object */
 void visRemoveVisibility(BASE_OBJECT *psObj)
 {
-	if (mapWidth && mapHeight)
+	if (worldMapState.width && worldMapState.height)
 	{
 		for (TILEPOS pos : psObj->watchedTiles)
 		{
@@ -464,9 +464,9 @@ void revealAll(UBYTE player)
 	}
 
 	//reveal all tiles
-	for (j = 0; j < mapHeight; j++)
+	for (j = 0; j < worldMapState.height; j++)
 	{
-		for (i = 0; i < mapWidth; i++)
+		for (i = 0; i < worldMapState.width; i++)
 		{
 			psTile = mapTile(i, j);
 			psTile->tileExploredBits |= alliancebits[player];

--- a/src/visibility.cpp
+++ b/src/visibility.cpp
@@ -635,7 +635,7 @@ STRUCTURE *visGetBlockingWall(const BASE_OBJECT *psViewer, const BASE_OBJECT *ps
 
 		for (player = 0; player < MAX_PLAYERS; player++)
 		{
-			for (STRUCTURE* psWall : apsStructLists[player])
+			for (STRUCTURE* psWall : worldObjectState.structures[player])
 			{
 				if (map_coord(psWall->pos) == tile)
 				{
@@ -838,35 +838,35 @@ void processVisibility()
 	updateSpotters();
 	for (int player = 0; player < MAX_PLAYERS; ++player)
 	{
-		for (BASE_OBJECT* psObj : apsDroidLists[player])
+		for (BASE_OBJECT* psObj : worldObjectState.droids[player])
 		{
 			processVisibilitySelf(psObj);
 		}
-		for (BASE_OBJECT* psObj : apsStructLists[player])
+		for (BASE_OBJECT* psObj : worldObjectState.structures[player])
 		{
 			processVisibilitySelf(psObj);
 		}
 	}
-	for (BASE_OBJECT* psObj : apsFeatureList[0])
+	for (BASE_OBJECT* psObj : worldObjectState.features[0])
 	{
 		processVisibilitySelf(psObj);
 	}
 	for (int player = 0; player < MAX_PLAYERS; ++player)
 	{
-		for (BASE_OBJECT* psObj : apsDroidLists[player])
+		for (BASE_OBJECT* psObj : worldObjectState.droids[player])
 		{
 			processVisibilityVision(psObj);
 		}
-		for (BASE_OBJECT* psObj : apsStructLists[player])
+		for (BASE_OBJECT* psObj : worldObjectState.structures[player])
 		{
 			processVisibilityVision(psObj);
 		}
 	}
-	for (const BASE_OBJECT *psObj : apsSensorList[0])
+	for (const BASE_OBJECT *psObj : worldObjectState.sensors[0])
 	{
 		if (objRadarDetector(psObj))
 		{
-			for (BASE_OBJECT *psTarget : apsSensorList[0])
+			for (BASE_OBJECT *psTarget : worldObjectState.sensors[0])
 			{
 				if (psObj != psTarget && psTarget->visible[psObj->player] < UBYTE_MAX / 2
 				    && objActiveRadar(psTarget)
@@ -880,16 +880,16 @@ void processVisibility()
 	bool addedMessage = false;
 	for (int player = 0; player < MAX_PLAYERS; ++player)
 	{
-		for (BASE_OBJECT* psObj : apsDroidLists[player])
+		for (BASE_OBJECT* psObj : worldObjectState.droids[player])
 		{
 			processVisibilityLevel(psObj, addedMessage);
 		}
-		for (BASE_OBJECT* psObj : apsStructLists[player])
+		for (BASE_OBJECT* psObj : worldObjectState.structures[player])
 		{
 			processVisibilityLevel(psObj, addedMessage);
 		}
 	}
-	for (BASE_OBJECT* psObj : apsFeatureList[0])
+	for (BASE_OBJECT* psObj : worldObjectState.features[0])
 	{
 		processVisibilityLevel(psObj, addedMessage);
 	}

--- a/src/visibility.cpp
+++ b/src/visibility.cpp
@@ -145,7 +145,7 @@ uint32_t addSpotter(int x, int y, int player, int radius, bool radar, uint32_t e
 		{
 			continue;
 		}
-		MAPTILE *psTile = mapTile(mapX, mapY);
+		MAPTILE *psTile = mapTile(worldMapState, mapX, mapY);
 		psTile->tileExploredBits |= alliancebits[player];
 		uint16_t *visionType = (!radar) ? psTile->watchers : psTile->sensors;
 		if (visionType[player] < UINT16_MAX)
@@ -214,7 +214,7 @@ SPOTTER::~SPOTTER()
 	for (int i = 0; i < numWatchedTiles; i++)
 	{
 		const TILEPOS tilePos = watchedTiles[i];
-		MAPTILE *psTile = mapTile(tilePos.x, tilePos.y);
+		MAPTILE *psTile = mapTile(worldMapState, tilePos.x, tilePos.y);
 		uint16_t *visionType = (tilePos.type == 0) ? psTile->watchers : psTile->sensors;
 		ASSERT(visionType[player] > 0, "Not watching watched tile (%d, %d)", (int)tilePos.x, (int)tilePos.y);
 		visionType[player]--;
@@ -288,7 +288,7 @@ static void doWaveTerrain(BASE_OBJECT *psObj)
 			continue;
 		}
 
-		MAPTILE *psTile = mapTile(mapX, mapY);
+		MAPTILE *psTile = mapTile(worldMapState, mapX, mapY);
 		int tileHeight = std::max(psTile->height, psTile->waterLevel);  // If we can see the water surface, then let us see water-covered tiles too.
 		int perspectiveHeight = (tileHeight - sz) * tiles[i].invRadius;
 		int perspectiveHeightLeeway = (tileHeight - sz + MIN_VIS_HEIGHT) * tiles[i].invRadius;
@@ -361,7 +361,7 @@ static bool rayLOSCallback(Vector2i pos, int32_t dist, void *data)
 	}
 
 	help->lastDist = dist;
-	help->lastHeight = map_Height(pos.x, pos.y);
+	help->lastHeight = map_Height(worldMapState, pos.x, pos.y);
 
 	if (help->wallsBlock)
 	{
@@ -370,7 +370,7 @@ static bool rayLOSCallback(Vector2i pos, int32_t dist, void *data)
 
 		if (tile != help->final)
 		{
-			MAPTILE *psTile = mapTile(tile);
+			MAPTILE *psTile = mapTile(worldMapState, tile);
 			if (TileHasWall_raycast(psTile) && !TileHasSmallStructure(psTile))
 			{
 				STRUCTURE *psStruct = (STRUCTURE *)psTile->psObject;
@@ -396,7 +396,7 @@ void visRemoveVisibility(BASE_OBJECT *psObj)
 		for (TILEPOS pos : psObj->watchedTiles)
 		{
 			// FIXME: the mapTile might have been swapped out, see swapMissionPointers()
-			MAPTILE *psTile = mapTile(pos.x, pos.y);
+			MAPTILE *psTile = mapTile(worldMapState, pos.x, pos.y);
 
 			ASSERT(pos.type < 2, "Invalid visibility type %d", (int)pos.type);
 			uint16_t *visionType = (pos.type == 0) ? psTile->sensors : psTile->watchers;
@@ -468,7 +468,7 @@ void revealAll(UBYTE player)
 	{
 		for (i = 0; i < worldMapState.width; i++)
 		{
-			psTile = mapTile(i, j);
+			psTile = mapTile(worldMapState, i, j);
 			psTile->tileExploredBits |= alliancebits[player];
 		}
 	}
@@ -489,7 +489,7 @@ int visibleObject(const BASE_OBJECT *psViewer, const BASE_OBJECT *psTarget, bool
 
 	int range = objSensorRange(psViewer);
 
-	if (!worldOnMap(psViewer->pos.x, psViewer->pos.y) || !worldOnMap(psTarget->pos.x, psTarget->pos.y))
+	if (!worldOnMap(worldMapState, psViewer->pos.x, psViewer->pos.y) || !worldOnMap(worldMapState, psTarget->pos.x, psTarget->pos.y))
 	{
 		//Most likely a VTOL or transporter
 		debug(LOG_WARNING, "Trying to view something off map!");
@@ -554,7 +554,7 @@ int visibleObject(const BASE_OBJECT *psViewer, const BASE_OBJECT *psTarget, bool
 		return UBYTE_MAX;	// Should never be on top of each other, but ...
 	}
 
-	const MAPTILE *psTile = mapTile(map_coord(psTarget->pos.x), map_coord(psTarget->pos.y));
+	const MAPTILE *psTile = mapTile(worldMapState, map_coord(psTarget->pos.x), map_coord(psTarget->pos.y));
 	const bool jammed = psTile->jammerBits & ~alliancebits[psViewer->player];
 
 	// Special rule for VTOLs, as they are not affected by ECM
@@ -569,7 +569,7 @@ int visibleObject(const BASE_OBJECT *psViewer, const BASE_OBJECT *psTarget, bool
 	VisibleObjectHelp_t help = {
 		true,
 		wallsBlock,
-		psViewer->pos.z + map_Height(psViewer->pos.x, psViewer->pos.y),
+		psViewer->pos.z + map_Height(worldMapState, psViewer->pos.x, psViewer->pos.y),
 		map_coord(psTarget->pos.xy()),
 		0,
 		0,
@@ -803,7 +803,7 @@ static void processVisibilityLevel(BASE_OBJECT *psObj, bool& addedMessage)
 
 				/* If this is an oil resource we want to add a proximity message for
 				 * the selected Player - if there isn't an Resource Extractor on it. */
-				if (((FEATURE *)psObj)->psStats->subType == FEAT_OIL_RESOURCE && !TileHasStructure(mapTile(map_coord(psObj->pos.x), map_coord(psObj->pos.y))))
+				if (((FEATURE *)psObj)->psStats->subType == FEAT_OIL_RESOURCE && !TileHasStructure(mapTile(worldMapState, map_coord(psObj->pos.x), map_coord(psObj->pos.y))))
 				{
 					type = ID_SOUND_RESOURCE_HERE;
 				}
@@ -936,7 +936,7 @@ void	setUnderTilesVis(BASE_OBJECT *psObj, UDWORD player)
 	{
 		for (j = 0; j < breadth + 1; j++)  // + 1 because visibility is for top left of tile.
 		{
-			psTile = mapTile(mapX + i, mapY + j);
+			psTile = mapTile(worldMapState, mapX + i, mapY + j);
 			if (psTile)
 			{
 				psTile->tileExploredBits |= alliancebits[player];
@@ -1101,7 +1101,7 @@ static int checkFireLine(const SIMPLE_OBJECT *psViewer, const BASE_OBJECT *psTar
 
 		if (partSq > 0)
 		{
-			angle_check(&angletan, partSq, map_Height(current) - pos.z, distSq, dest.z - pos.z, direct);
+			angle_check(&angletan, partSq, map_Height(worldMapState, current) - pos.z, distSq, dest.z - pos.z, direct);
 		}
 
 		// intersect current tile with line of fire
@@ -1121,7 +1121,7 @@ static int checkFireLine(const SIMPLE_OBJECT *psViewer, const BASE_OBJECT *psTar
 
 			if (partSq > 0)
 			{
-				angle_check(&angletan, partSq, map_Height(halfway) - pos.z, distSq, dest.z - pos.z, direct);
+				angle_check(&angletan, partSq, map_Height(worldMapState, halfway) - pos.z, distSq, dest.z - pos.z, direct);
 			}
 		}
 
@@ -1131,7 +1131,7 @@ static int checkFireLine(const SIMPLE_OBJECT *psViewer, const BASE_OBJECT *psTar
 		{
 			const MAPTILE *psTile;
 			halfway = current + (next - current) / 2;
-			psTile = mapTile(map_coord(halfway.x), map_coord(halfway.y));
+			psTile = mapTile(worldMapState, map_coord(halfway.x), map_coord(halfway.y));
 			if (TileHasStructure(psTile) && psTile->psObject != psTarget)
 			{
 				// check whether target was reached before tile's "half way" line

--- a/src/visibility.cpp
+++ b/src/visibility.cpp
@@ -141,11 +141,11 @@ uint32_t addSpotter(int x, int y, int player, int radius, bool radar, uint32_t e
 	{
 		const int mapX = x + tiles[i].dx;
 		const int mapY = y + tiles[i].dy;
-		if (mapX < 0 || mapX >= worldMapState.width || mapY < 0 || mapY >= worldMapState.height)
+		if (mapX < 0 || mapX >= gameWorld.map.width || mapY < 0 || mapY >= gameWorld.map.height)
 		{
 			continue;
 		}
-		MAPTILE *psTile = mapTile(worldMapState, mapX, mapY);
+		MAPTILE *psTile = mapTile(gameWorld.map, mapX, mapY);
 		psTile->tileExploredBits |= alliancebits[player];
 		uint16_t *visionType = (!radar) ? psTile->watchers : psTile->sensors;
 		if (visionType[player] < UINT16_MAX)
@@ -214,7 +214,7 @@ SPOTTER::~SPOTTER()
 	for (int i = 0; i < numWatchedTiles; i++)
 	{
 		const TILEPOS tilePos = watchedTiles[i];
-		MAPTILE *psTile = mapTile(worldMapState, tilePos.x, tilePos.y);
+		MAPTILE *psTile = mapTile(gameWorld.map, tilePos.x, tilePos.y);
 		uint16_t *visionType = (tilePos.type == 0) ? psTile->watchers : psTile->sensors;
 		ASSERT(visionType[player] > 0, "Not watching watched tile (%d, %d)", (int)tilePos.x, (int)tilePos.y);
 		visionType[player]--;
@@ -283,12 +283,12 @@ static void doWaveTerrain(BASE_OBJECT *psObj)
 	{
 		const int mapX = map_coord(sx) + tiles[i].dx;
 		const int mapY = map_coord(sy) + tiles[i].dy;
-		if (mapX < 0 || mapX >= worldMapState.width || mapY < 0 || mapY >= worldMapState.height)
+		if (mapX < 0 || mapX >= gameWorld.map.width || mapY < 0 || mapY >= gameWorld.map.height)
 		{
 			continue;
 		}
 
-		MAPTILE *psTile = mapTile(worldMapState, mapX, mapY);
+		MAPTILE *psTile = mapTile(gameWorld.map, mapX, mapY);
 		int tileHeight = std::max(psTile->height, psTile->waterLevel);  // If we can see the water surface, then let us see water-covered tiles too.
 		int perspectiveHeight = (tileHeight - sz) * tiles[i].invRadius;
 		int perspectiveHeightLeeway = (tileHeight - sz + MIN_VIS_HEIGHT) * tiles[i].invRadius;
@@ -344,7 +344,7 @@ static bool rayLOSCallback(Vector2i pos, int32_t dist, void *data)
 {
 	VisibleObjectHelp_t *help = (VisibleObjectHelp_t *)data;
 
-	ASSERT(pos.x >= 0 && pos.x < world_coord(worldMapState.width) && pos.y >= 0 && pos.y < world_coord(worldMapState.height), "rayLOSCallback: coords off map");
+	ASSERT(pos.x >= 0 && pos.x < world_coord(gameWorld.map.width) && pos.y >= 0 && pos.y < world_coord(gameWorld.map.height), "rayLOSCallback: coords off map");
 
 	if (help->rayStart)
 	{
@@ -361,7 +361,7 @@ static bool rayLOSCallback(Vector2i pos, int32_t dist, void *data)
 	}
 
 	help->lastDist = dist;
-	help->lastHeight = map_Height(worldMapState, pos.x, pos.y);
+	help->lastHeight = map_Height(gameWorld.map, pos.x, pos.y);
 
 	if (help->wallsBlock)
 	{
@@ -370,7 +370,7 @@ static bool rayLOSCallback(Vector2i pos, int32_t dist, void *data)
 
 		if (tile != help->final)
 		{
-			MAPTILE *psTile = mapTile(worldMapState, tile);
+			MAPTILE *psTile = mapTile(gameWorld.map, tile);
 			if (TileHasWall_raycast(psTile) && !TileHasSmallStructure(psTile))
 			{
 				STRUCTURE *psStruct = (STRUCTURE *)psTile->psObject;
@@ -391,12 +391,12 @@ static bool rayLOSCallback(Vector2i pos, int32_t dist, void *data)
 /* Remove tile visibility from object */
 void visRemoveVisibility(BASE_OBJECT *psObj)
 {
-	if (worldMapState.width && worldMapState.height)
+	if (gameWorld.map.width && gameWorld.map.height)
 	{
 		for (TILEPOS pos : psObj->watchedTiles)
 		{
 			// FIXME: the mapTile might have been swapped out, see swapMissionPointers()
-			MAPTILE *psTile = mapTile(worldMapState, pos.x, pos.y);
+			MAPTILE *psTile = mapTile(gameWorld.map, pos.x, pos.y);
 
 			ASSERT(pos.type < 2, "Invalid visibility type %d", (int)pos.type);
 			uint16_t *visionType = (pos.type == 0) ? psTile->sensors : psTile->watchers;
@@ -464,11 +464,11 @@ void revealAll(UBYTE player)
 	}
 
 	//reveal all tiles
-	for (j = 0; j < worldMapState.height; j++)
+	for (j = 0; j < gameWorld.map.height; j++)
 	{
-		for (i = 0; i < worldMapState.width; i++)
+		for (i = 0; i < gameWorld.map.width; i++)
 		{
-			psTile = mapTile(worldMapState, i, j);
+			psTile = mapTile(gameWorld.map, i, j);
 			psTile->tileExploredBits |= alliancebits[player];
 		}
 	}
@@ -489,7 +489,7 @@ int visibleObject(const BASE_OBJECT *psViewer, const BASE_OBJECT *psTarget, bool
 
 	int range = objSensorRange(psViewer);
 
-	if (!worldOnMap(worldMapState, psViewer->pos.x, psViewer->pos.y) || !worldOnMap(worldMapState, psTarget->pos.x, psTarget->pos.y))
+	if (!worldOnMap(gameWorld.map, psViewer->pos.x, psViewer->pos.y) || !worldOnMap(gameWorld.map, psTarget->pos.x, psTarget->pos.y))
 	{
 		//Most likely a VTOL or transporter
 		debug(LOG_WARNING, "Trying to view something off map!");
@@ -554,7 +554,7 @@ int visibleObject(const BASE_OBJECT *psViewer, const BASE_OBJECT *psTarget, bool
 		return UBYTE_MAX;	// Should never be on top of each other, but ...
 	}
 
-	const MAPTILE *psTile = mapTile(worldMapState, map_coord(psTarget->pos.x), map_coord(psTarget->pos.y));
+	const MAPTILE *psTile = mapTile(gameWorld.map, map_coord(psTarget->pos.x), map_coord(psTarget->pos.y));
 	const bool jammed = psTile->jammerBits & ~alliancebits[psViewer->player];
 
 	// Special rule for VTOLs, as they are not affected by ECM
@@ -569,7 +569,7 @@ int visibleObject(const BASE_OBJECT *psViewer, const BASE_OBJECT *psTarget, bool
 	VisibleObjectHelp_t help = {
 		true,
 		wallsBlock,
-		psViewer->pos.z + map_Height(worldMapState, psViewer->pos.x, psViewer->pos.y),
+		psViewer->pos.z + map_Height(gameWorld.map, psViewer->pos.x, psViewer->pos.y),
 		map_coord(psTarget->pos.xy()),
 		0,
 		0,
@@ -635,7 +635,7 @@ STRUCTURE *visGetBlockingWall(const BASE_OBJECT *psViewer, const BASE_OBJECT *ps
 
 		for (player = 0; player < MAX_PLAYERS; player++)
 		{
-			for (STRUCTURE* psWall : worldObjectState.structures[player])
+			for (STRUCTURE* psWall : gameWorld.objects.structures[player])
 			{
 				if (map_coord(psWall->pos) == tile)
 				{
@@ -803,7 +803,7 @@ static void processVisibilityLevel(BASE_OBJECT *psObj, bool& addedMessage)
 
 				/* If this is an oil resource we want to add a proximity message for
 				 * the selected Player - if there isn't an Resource Extractor on it. */
-				if (((FEATURE *)psObj)->psStats->subType == FEAT_OIL_RESOURCE && !TileHasStructure(mapTile(worldMapState, map_coord(psObj->pos.x), map_coord(psObj->pos.y))))
+				if (((FEATURE *)psObj)->psStats->subType == FEAT_OIL_RESOURCE && !TileHasStructure(mapTile(gameWorld.map, map_coord(psObj->pos.x), map_coord(psObj->pos.y))))
 				{
 					type = ID_SOUND_RESOURCE_HERE;
 				}
@@ -838,35 +838,35 @@ void processVisibility()
 	updateSpotters();
 	for (int player = 0; player < MAX_PLAYERS; ++player)
 	{
-		for (BASE_OBJECT* psObj : worldObjectState.droids[player])
+		for (BASE_OBJECT* psObj : gameWorld.objects.droids[player])
 		{
 			processVisibilitySelf(psObj);
 		}
-		for (BASE_OBJECT* psObj : worldObjectState.structures[player])
+		for (BASE_OBJECT* psObj : gameWorld.objects.structures[player])
 		{
 			processVisibilitySelf(psObj);
 		}
 	}
-	for (BASE_OBJECT* psObj : worldObjectState.features[0])
+	for (BASE_OBJECT* psObj : gameWorld.objects.features[0])
 	{
 		processVisibilitySelf(psObj);
 	}
 	for (int player = 0; player < MAX_PLAYERS; ++player)
 	{
-		for (BASE_OBJECT* psObj : worldObjectState.droids[player])
+		for (BASE_OBJECT* psObj : gameWorld.objects.droids[player])
 		{
 			processVisibilityVision(psObj);
 		}
-		for (BASE_OBJECT* psObj : worldObjectState.structures[player])
+		for (BASE_OBJECT* psObj : gameWorld.objects.structures[player])
 		{
 			processVisibilityVision(psObj);
 		}
 	}
-	for (const BASE_OBJECT *psObj : worldObjectState.sensors[0])
+	for (const BASE_OBJECT *psObj : gameWorld.objects.sensors[0])
 	{
 		if (objRadarDetector(psObj))
 		{
-			for (BASE_OBJECT *psTarget : worldObjectState.sensors[0])
+			for (BASE_OBJECT *psTarget : gameWorld.objects.sensors[0])
 			{
 				if (psObj != psTarget && psTarget->visible[psObj->player] < UBYTE_MAX / 2
 				    && objActiveRadar(psTarget)
@@ -880,16 +880,16 @@ void processVisibility()
 	bool addedMessage = false;
 	for (int player = 0; player < MAX_PLAYERS; ++player)
 	{
-		for (BASE_OBJECT* psObj : worldObjectState.droids[player])
+		for (BASE_OBJECT* psObj : gameWorld.objects.droids[player])
 		{
 			processVisibilityLevel(psObj, addedMessage);
 		}
-		for (BASE_OBJECT* psObj : worldObjectState.structures[player])
+		for (BASE_OBJECT* psObj : gameWorld.objects.structures[player])
 		{
 			processVisibilityLevel(psObj, addedMessage);
 		}
 	}
-	for (BASE_OBJECT* psObj : worldObjectState.features[0])
+	for (BASE_OBJECT* psObj : gameWorld.objects.features[0])
 	{
 		processVisibilityLevel(psObj, addedMessage);
 	}
@@ -936,7 +936,7 @@ void	setUnderTilesVis(BASE_OBJECT *psObj, UDWORD player)
 	{
 		for (j = 0; j < breadth + 1; j++)  // + 1 because visibility is for top left of tile.
 		{
-			psTile = mapTile(worldMapState, mapX + i, mapY + j);
+			psTile = mapTile(gameWorld.map, mapX + i, mapY + j);
 			if (psTile)
 			{
 				psTile->tileExploredBits |= alliancebits[player];
@@ -1101,7 +1101,7 @@ static int checkFireLine(const SIMPLE_OBJECT *psViewer, const BASE_OBJECT *psTar
 
 		if (partSq > 0)
 		{
-			angle_check(&angletan, partSq, map_Height(worldMapState, current) - pos.z, distSq, dest.z - pos.z, direct);
+			angle_check(&angletan, partSq, map_Height(gameWorld.map, current) - pos.z, distSq, dest.z - pos.z, direct);
 		}
 
 		// intersect current tile with line of fire
@@ -1121,7 +1121,7 @@ static int checkFireLine(const SIMPLE_OBJECT *psViewer, const BASE_OBJECT *psTar
 
 			if (partSq > 0)
 			{
-				angle_check(&angletan, partSq, map_Height(worldMapState, halfway) - pos.z, distSq, dest.z - pos.z, direct);
+				angle_check(&angletan, partSq, map_Height(gameWorld.map, halfway) - pos.z, distSq, dest.z - pos.z, direct);
 			}
 		}
 
@@ -1131,7 +1131,7 @@ static int checkFireLine(const SIMPLE_OBJECT *psViewer, const BASE_OBJECT *psTar
 		{
 			const MAPTILE *psTile;
 			halfway = current + (next - current) / 2;
-			psTile = mapTile(worldMapState, map_coord(halfway.x), map_coord(halfway.y));
+			psTile = mapTile(gameWorld.map, map_coord(halfway.x), map_coord(halfway.y));
 			if (TileHasStructure(psTile) && psTile->psObject != psTarget)
 			{
 				// check whether target was reached before tile's "half way" line

--- a/src/warcam.cpp
+++ b/src/warcam.cpp
@@ -183,7 +183,7 @@ static void processLeaderSelection()
 	switch (leaderClass)
 	{
 	case	LEADER_LEFT:
-		for (DROID* psDroid : worldObjectState.droids[selectedPlayer])
+		for (DROID* psDroid : gameWorld.objects.droids[selectedPlayer])
 		{
 			/* Is it even on the sscreen? */
 			if (DrawnInLastFrame(psDroid->sDisplay.frameNumber) && psDroid->selected && psDroid != trackingCamera.target)
@@ -202,7 +202,7 @@ static void processLeaderSelection()
 		}
 		break;
 	case	LEADER_RIGHT:
-		for (DROID* psDroid : worldObjectState.droids[selectedPlayer])
+		for (DROID* psDroid : gameWorld.objects.droids[selectedPlayer])
 		{
 			/* Is it even on the sscreen? */
 			if (DrawnInLastFrame(psDroid->sDisplay.frameNumber) && psDroid->selected && psDroid != trackingCamera.target)
@@ -221,7 +221,7 @@ static void processLeaderSelection()
 		}
 		break;
 	case	LEADER_UP:
-		for (DROID* psDroid : worldObjectState.droids[selectedPlayer])
+		for (DROID* psDroid : gameWorld.objects.droids[selectedPlayer])
 		{
 			/* Is it even on the sscreen? */
 			if (DrawnInLastFrame(psDroid->sDisplay.frameNumber) && psDroid->selected && psDroid != trackingCamera.target)
@@ -240,7 +240,7 @@ static void processLeaderSelection()
 		}
 		break;
 	case	LEADER_DOWN:
-		for (DROID* psDroid : worldObjectState.droids[selectedPlayer])
+		for (DROID* psDroid : gameWorld.objects.droids[selectedPlayer])
 		{
 			/* Is it even on the sscreen? */
 			if (DrawnInLastFrame(psDroid->sDisplay.frameNumber) && psDroid->selected && psDroid != trackingCamera.target)
@@ -384,7 +384,7 @@ DROID *camFindDroidTarget()
 		return nullptr;
 	}
 
-	for (DROID* psDroid : worldObjectState.droids[selectedPlayer])
+	for (DROID* psDroid : gameWorld.objects.droids[selectedPlayer])
 	{
 		if (psDroid->selected)
 		{
@@ -453,7 +453,7 @@ static uint16_t getAverageTrackAngle(unsigned groupNumber, bool bCheckOnScreen)
 	}
 
 	/* Got thru' all droids */
-	for (const DROID* psDroid : worldObjectState.droids[selectedPlayer])
+	for (const DROID* psDroid : gameWorld.objects.droids[selectedPlayer])
 	{
 		/* Is he worth selecting? */
 		if (groupNumber == GROUP_SELECTED ? psDroid->selected : psDroid->group == groupNumber)
@@ -482,7 +482,7 @@ static void getTrackingConcerns(SDWORD *x, SDWORD *y, SDWORD *z, UDWORD groupNum
 		return;
 	}
 
-	for (const DROID* psDroid : worldObjectState.droids[selectedPlayer])
+	for (const DROID* psDroid : gameWorld.objects.droids[selectedPlayer])
 	{
 		if (groupNumber == GROUP_SELECTED ? psDroid->selected : psDroid->group == groupNumber)
 		{
@@ -682,7 +682,7 @@ static void updateCameraRotationAcceleration(UBYTE update)
 
 		bGotFlying = true;
 		droidHeight = trackingCamera.target->pos.z;
-		droidMapHeight = map_Height(worldMapState, trackingCamera.target->pos.x, trackingCamera.target->pos.y);
+		droidMapHeight = map_Height(gameWorld.map, trackingCamera.target->pos.x, trackingCamera.target->pos.y);
 		difHeight = abs(droidHeight - droidMapHeight);
 		if (difHeight < MIN_TRACK_HEIGHT)
 		{

--- a/src/warcam.cpp
+++ b/src/warcam.cpp
@@ -682,7 +682,7 @@ static void updateCameraRotationAcceleration(UBYTE update)
 
 		bGotFlying = true;
 		droidHeight = trackingCamera.target->pos.z;
-		droidMapHeight = map_Height(trackingCamera.target->pos.x, trackingCamera.target->pos.y);
+		droidMapHeight = map_Height(worldMapState, trackingCamera.target->pos.x, trackingCamera.target->pos.y);
 		difHeight = abs(droidHeight - droidMapHeight);
 		if (difHeight < MIN_TRACK_HEIGHT)
 		{

--- a/src/warcam.cpp
+++ b/src/warcam.cpp
@@ -183,7 +183,7 @@ static void processLeaderSelection()
 	switch (leaderClass)
 	{
 	case	LEADER_LEFT:
-		for (DROID* psDroid : apsDroidLists[selectedPlayer])
+		for (DROID* psDroid : worldObjectState.droids[selectedPlayer])
 		{
 			/* Is it even on the sscreen? */
 			if (DrawnInLastFrame(psDroid->sDisplay.frameNumber) && psDroid->selected && psDroid != trackingCamera.target)
@@ -202,7 +202,7 @@ static void processLeaderSelection()
 		}
 		break;
 	case	LEADER_RIGHT:
-		for (DROID* psDroid : apsDroidLists[selectedPlayer])
+		for (DROID* psDroid : worldObjectState.droids[selectedPlayer])
 		{
 			/* Is it even on the sscreen? */
 			if (DrawnInLastFrame(psDroid->sDisplay.frameNumber) && psDroid->selected && psDroid != trackingCamera.target)
@@ -221,7 +221,7 @@ static void processLeaderSelection()
 		}
 		break;
 	case	LEADER_UP:
-		for (DROID* psDroid : apsDroidLists[selectedPlayer])
+		for (DROID* psDroid : worldObjectState.droids[selectedPlayer])
 		{
 			/* Is it even on the sscreen? */
 			if (DrawnInLastFrame(psDroid->sDisplay.frameNumber) && psDroid->selected && psDroid != trackingCamera.target)
@@ -240,7 +240,7 @@ static void processLeaderSelection()
 		}
 		break;
 	case	LEADER_DOWN:
-		for (DROID* psDroid : apsDroidLists[selectedPlayer])
+		for (DROID* psDroid : worldObjectState.droids[selectedPlayer])
 		{
 			/* Is it even on the sscreen? */
 			if (DrawnInLastFrame(psDroid->sDisplay.frameNumber) && psDroid->selected && psDroid != trackingCamera.target)
@@ -384,7 +384,7 @@ DROID *camFindDroidTarget()
 		return nullptr;
 	}
 
-	for (DROID* psDroid : apsDroidLists[selectedPlayer])
+	for (DROID* psDroid : worldObjectState.droids[selectedPlayer])
 	{
 		if (psDroid->selected)
 		{
@@ -453,7 +453,7 @@ static uint16_t getAverageTrackAngle(unsigned groupNumber, bool bCheckOnScreen)
 	}
 
 	/* Got thru' all droids */
-	for (const DROID* psDroid : apsDroidLists[selectedPlayer])
+	for (const DROID* psDroid : worldObjectState.droids[selectedPlayer])
 	{
 		/* Is he worth selecting? */
 		if (groupNumber == GROUP_SELECTED ? psDroid->selected : psDroid->group == groupNumber)
@@ -482,7 +482,7 @@ static void getTrackingConcerns(SDWORD *x, SDWORD *y, SDWORD *z, UDWORD groupNum
 		return;
 	}
 
-	for (const DROID* psDroid : apsDroidLists[selectedPlayer])
+	for (const DROID* psDroid : worldObjectState.droids[selectedPlayer])
 	{
 		if (groupNumber == GROUP_SELECTED ? psDroid->selected : psDroid->group == groupNumber)
 		{

--- a/src/world_map_state.h
+++ b/src/world_map_state.h
@@ -21,7 +21,6 @@
 /** \file
  * Per-world map state storage.
  */
-
 #pragma once
 
 #include "lib/framework/frame.h"

--- a/src/world_map_state.h
+++ b/src/world_map_state.h
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+/*
+	This file is part of Warzone 2100.
+	Copyright (C) 2026  Warzone 2100 Project (https://github.com/Warzone2100)
+
+	Warzone 2100 is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+
+	Warzone 2100 is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with Warzone 2100; if not, write to the Free Software
+	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+/** \file
+ * Per-world map state storage.
+ */
+
+#pragma once
+
+#include "lib/framework/frame.h"
+#include "gateway.h"
+
+#include <memory>
+
+#include <stdint.h>
+
+#define AUX_MAP		0
+#define AUX_ASTARMAP	1
+#define AUX_DANGERMAP	2
+#define AUX_MAX		3
+
+struct BASE_OBJECT;
+
+/// <summary>
+/// Information stored with each tile on a given map.
+/// </summary>
+struct MAPTILE
+{
+	uint8_t         tileInfoBits;
+	PlayerMask      tileExploredBits;
+	PlayerMask      sensorBits;             ///< bit per player, who can see tile with sensor
+	uint16_t        watchers[MAX_PLAYERS];  // player sees through fog of war here with this many objects
+	uint16_t        texture;                // Which graphics texture is on this tile
+	int32_t         height;                 ///< The height at the top left of the tile
+	BASE_OBJECT *   psObject;               // Any object sitting on the location (e.g. building)
+	uint16_t        limitedContinent;       ///< For land or sea limited propulsion types
+	uint16_t        hoverContinent;         ///< For hover type propulsions
+	uint16_t        fireEndTime;            ///< The (uint16_t)(gameTime / GAME_TICKS_PER_UPDATE) that BITS_ON_FIRE should be cleared.
+	int32_t         waterLevel;             ///< At what height is the water for this tile
+	PlayerMask      jammerBits;             ///< bit per player, who is jamming tile
+	uint16_t        sensors[MAX_PLAYERS];   ///< player sees this tile with this many radar sensors
+	uint16_t        jammers[MAX_PLAYERS];   ///< player jams the tile with this many objects
+
+	// DISPLAY ONLY (NOT for use in game calculations)
+	uint8_t         ground;                 ///< The ground type used for the terrain renderer
+	uint8_t         illumination;           // How bright is this tile? = diffuseSunLight * ambientOcclusion
+	uint8_t         ambientOcclusion;       // ambient occlusion. from 1 (max occlusion) to 254 (no occlusion), similar to illumination.
+	float           level;                  ///< The visibility level of the top left of the tile, for this client. for terrain lightmap
+};
+
+/// <summary>
+/// Scroll min and max values (per-world).
+/// </summary>
+struct WorldScrollLimits
+{
+	int32_t minX = 0;
+	int32_t minY = 0;
+	int32_t maxX = 0;
+	int32_t maxY = 0;
+};
+
+/// <summary>
+/// A simple wrapper around the map state (per-world).
+/// </summary>
+struct WorldMapState
+{
+	std::unique_ptr<MAPTILE[]> tiles;
+	int32_t width = 0;
+	int32_t height = 0;
+	std::unique_ptr<uint8_t[]> blockMap[AUX_MAX];
+	std::unique_ptr<uint8_t[]> auxMap[MAX_PLAYERS + AUX_MAX]; ///< yes, we waste one element... eyes wide open... makes API nicer
+	WorldScrollLimits scroll;
+	GATEWAY_LIST gateways;
+};

--- a/src/world_object_state.h
+++ b/src/world_object_state.h
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+/*
+	This file is part of Warzone 2100.
+	Copyright (C) 2026  Warzone 2100 Project (https://github.com/Warzone2100)
+
+	Warzone 2100 is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+
+	Warzone 2100 is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with Warzone 2100; if not, write to the Free Software
+	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+/** \file
+ *  Per-world simulation object list storage.
+ */
+
+#pragma once
+
+#include "object_lists_types.h"
+
+/// <summary>
+/// A simple wrapper around various object lists (per-world).
+/// </summary>
+struct WorldObjectState
+{
+	PerPlayerDroidLists droids;
+	PerPlayerStructureLists structures;
+	PerPlayerFeatureLists features;
+	PerPlayerFlagPositionLists flags; ///< The list of Flag Positions allocated
+	PerPlayerExtractorLists extractors;
+	GlobalSensorList sensors; ///< List of sensors in the game.
+	GlobalOilList oils;
+};

--- a/src/wzapi.cpp
+++ b/src/wzapi.cpp
@@ -1260,8 +1260,8 @@ std::vector<const BASE_OBJECT *> wzapi::enumRange(WZAPI_PARAMS(int _x, int _y, i
 {
 	_x = std::max<int>(_x, 0);
 	_y = std::max<int>(_y, 0);
-	_x = std::min<int>(_x, mapWidth);
-	_y = std::min<int>(_y, mapHeight);
+	_x = std::min<int>(_x, worldMapState.width);
+	_y = std::min<int>(_y, worldMapState.height);
 
 	int player = context.player();
 	int x = world_coord(_x);
@@ -1598,7 +1598,7 @@ optional<scr_position> wzapi::pickStructLocation(WZAPI_PARAMS(const DROID *psDro
 	int incX, incY, x, y;
 	int maxBlockingTiles = _maxBlockingTiles.value_or(0);
 
-	SCRIPT_ASSERT({}, context, startX >= 0 && startX < mapWidth && startY >= 0 && startY < mapHeight, "Bad position (%d, %d)", startX, startY);
+	SCRIPT_ASSERT({}, context, startX >= 0 && startX < worldMapState.width && startY >= 0 && startY < worldMapState.height, "Bad position (%d, %d)", startX, startY);
 
 	x = startX;
 	y = startY;
@@ -2168,8 +2168,8 @@ bool wzapi::addBeacon(WZAPI_PARAMS(int _x, int _y, int playerFilter, optional<st
 {
 	SCRIPT_ASSERT(false, context, _x >= 0, "Beacon x value %d is less than zero", _x);
 	SCRIPT_ASSERT(false, context, _y >= 0, "Beacon y value %d is less than zero", _y);
-	SCRIPT_ASSERT(false, context, _x <= mapWidth, "Beacon x value %d is greater than mapWidth %d", _x, (int)mapWidth);
-	SCRIPT_ASSERT(false, context, _y <= mapHeight, "Beacon y value %d is greater than mapHeight %d", _y, (int)mapHeight);
+	SCRIPT_ASSERT(false, context, _x <= worldMapState.width, "Beacon x value %d is greater than mapWidth %d", _x, (int)worldMapState.width);
+	SCRIPT_ASSERT(false, context, _y <= worldMapState.height, "Beacon y value %d is greater than mapHeight %d", _y, (int)worldMapState.height);
 
 	int x = world_coord(_x) + (TILE_UNITS / 2);
 	int y = world_coord(_y) + (TILE_UNITS / 2);
@@ -2421,8 +2421,8 @@ bool wzapi::centreView(WZAPI_PARAMS(int x, int y))
 {
 	SCRIPT_ASSERT(false, context, x >= 0, "x value %d is less than zero", x);
 	SCRIPT_ASSERT(false, context, y >= 0, "y value %d is less than zero", y);
-	SCRIPT_ASSERT(false, context, x <= mapWidth, "x value %d is greater than mapWidth %d", x, (int)mapWidth);
-	SCRIPT_ASSERT(false, context, y <= mapHeight, "y value %d is greater than mapHeight %d", y, (int)mapHeight);
+	SCRIPT_ASSERT(false, context, x <= worldMapState.width, "x value %d is greater than mapWidth %d", x, (int)worldMapState.width);
+	SCRIPT_ASSERT(false, context, y <= worldMapState.height, "y value %d is greater than mapHeight %d", y, (int)worldMapState.height);
 	setViewPos(x, y, false);
 	return true;
 }
@@ -2465,8 +2465,8 @@ bool wzapi::emitSound(WZAPI_PARAMS(std::string sound, int x, int y))
 {
 	SCRIPT_ASSERT(false, context, x >= 0, "x value %d is less than zero", x);
 	SCRIPT_ASSERT(false, context, y >= 0, "y value %d is less than zero", y);
-	SCRIPT_ASSERT(false, context, x <= mapWidth, "x value %d is greater than mapWidth %d", x, (int)mapWidth);
-	SCRIPT_ASSERT(false, context, y <= mapHeight, "y value %d is greater than mapHeight %d", y, (int)mapHeight);
+	SCRIPT_ASSERT(false, context, x <= worldMapState.width, "x value %d is greater than mapWidth %d", x, (int)worldMapState.width);
+	SCRIPT_ASSERT(false, context, y <= worldMapState.height, "y value %d is greater than mapHeight %d", y, (int)worldMapState.height);
 
 	int soundID = audio_GetTrackID(sound.c_str());
 	if (soundID == SAMPLE_NOT_FOUND)
@@ -3099,24 +3099,24 @@ wzapi::no_return_value wzapi::setScrollLimits(WZAPI_PARAMS(int x1, int y1, int x
 
 	SCRIPT_ASSERT({}, context, minX >= 0, "Minimum scroll x value %d is less than zero - ", minX);
 	SCRIPT_ASSERT({}, context, minY >= 0, "Minimum scroll y value %d is less than zero - ", minY);
-	SCRIPT_ASSERT({}, context, maxX <= mapWidth, "Maximum scroll x value %d is greater than mapWidth %d", maxX, (int)mapWidth);
-	SCRIPT_ASSERT({}, context, maxY <= mapHeight, "Maximum scroll y value %d is greater than mapHeight %d", maxY, (int)mapHeight);
+	SCRIPT_ASSERT({}, context, maxX <= worldMapState.width, "Maximum scroll x value %d is greater than mapWidth %d", maxX, (int)worldMapState.width);
+	SCRIPT_ASSERT({}, context, maxY <= worldMapState.height, "Maximum scroll y value %d is greater than mapHeight %d", maxY, (int)worldMapState.height);
 
-	const int prevMinX = scrollMinX;
-	const int prevMinY = scrollMinY;
-	const int prevMaxX = scrollMaxX;
-	const int prevMaxY = scrollMaxY;
+	const int prevMinX = worldMapState.scroll.minX;
+	const int prevMinY = worldMapState.scroll.minY;
+	const int prevMaxX = worldMapState.scroll.maxX;
+	const int prevMaxY = worldMapState.scroll.maxY;
 
-	scrollMinX = minX;
-	scrollMaxX = maxX;
-	scrollMinY = minY;
-	scrollMaxY = maxY;
+	worldMapState.scroll.minX = minX;
+	worldMapState.scroll.maxX = maxX;
+	worldMapState.scroll.minY = minY;
+	worldMapState.scroll.maxY = maxY;
 
 	// When the scroll limits change midgame - need to redo the lighting
-	initLighting(prevMinX < scrollMinX ? prevMinX : scrollMinX,
-	             prevMinY < scrollMinY ? prevMinY : scrollMinY,
-	             prevMaxX < scrollMaxX ? prevMaxX : scrollMaxX,
-	             prevMaxY < scrollMaxY ? prevMaxY : scrollMaxY);
+	initLighting(prevMinX < worldMapState.scroll.minX ? prevMinX : worldMapState.scroll.minX,
+	             prevMinY < worldMapState.scroll.minY ? prevMinY : worldMapState.scroll.minY,
+	             prevMaxX < worldMapState.scroll.maxX ? prevMaxX : worldMapState.scroll.maxX,
+	             prevMaxY < worldMapState.scroll.maxY ? prevMaxY : worldMapState.scroll.maxY);
 
 	// need to reset radar to take into account of new size
 	resizeRadar();
@@ -3130,10 +3130,10 @@ wzapi::no_return_value wzapi::setScrollLimits(WZAPI_PARAMS(int x1, int y1, int x
 scr_area wzapi::getScrollLimits(WZAPI_NO_PARAMS)
 {
 	scr_area limits;
-	limits.x1 = scrollMinX;
-	limits.y1 = scrollMinY;
-	limits.x2 = scrollMaxX;
-	limits.y2 = scrollMaxY;
+	limits.x1 = worldMapState.scroll.minX;
+	limits.y1 = worldMapState.scroll.minY;
+	limits.x2 = worldMapState.scroll.maxX;
+	limits.y2 = worldMapState.scroll.maxY;
 	return limits;
 }
 
@@ -3341,8 +3341,8 @@ wzapi::no_return_value wzapi::setNoGoArea(WZAPI_PARAMS(int x1, int y1, int x2, i
 {
 	SCRIPT_ASSERT({}, context, x1 >= 0, "Minimum scroll x value %d is less than zero - ", x1);
 	SCRIPT_ASSERT({}, context, y1 >= 0, "Minimum scroll y value %d is less than zero - ", y1);
-	SCRIPT_ASSERT({}, context, x2 <= mapWidth, "Maximum scroll x value %d is greater than mapWidth %d", x2, (int)mapWidth);
-	SCRIPT_ASSERT({}, context, y2 <= mapHeight, "Maximum scroll y value %d is greater than mapHeight %d", y2, (int)mapHeight);
+	SCRIPT_ASSERT({}, context, x2 <= worldMapState.width, "Maximum scroll x value %d is greater than mapWidth %d", x2, (int)worldMapState.width);
+	SCRIPT_ASSERT({}, context, y2 <= worldMapState.height, "Maximum scroll y value %d is greater than mapHeight %d", y2, (int)worldMapState.height);
 	SCRIPT_ASSERT({}, context, (playerFilter >= 0 && playerFilter < MAX_PLAYERS) || playerFilter == ALL_PLAYERS, "Bad player filter value %d", playerFilter);
 
 	if (playerFilter == ALL_PLAYERS)
@@ -4782,10 +4782,10 @@ nlohmann::json wzapi::constructMapTilesArray()
 	//==   * ```hoverContinent``` (For hover type propulsions)
 	//==   * ```limitedContinent``` (For land or sea limited propulsion types)
 	nlohmann::json mapTileArray = nlohmann::json::array();
-	for (SDWORD y = 0; y < mapHeight; y++)
+	for (SDWORD y = 0; y < worldMapState.height; y++)
 	{
 		nlohmann::json mapRow = nlohmann::json::array();
-		for (SDWORD x = 0; x < mapWidth; x++)
+		for (SDWORD x = 0; x < worldMapState.width; x++)
 		{
 			MAPTILE *psTile = mapTile(x, y);
 			nlohmann::json mapTile = nlohmann::json::object();

--- a/src/wzapi.cpp
+++ b/src/wzapi.cpp
@@ -30,6 +30,7 @@
 #include "lib/sound/audio.h"
 #include "lib/sound/cdaudio.h"
 #include "lib/netplay/netplay.h"
+#include "objmem.h"
 #include "qtscript.h"
 #include "lib/ivis_opengl/tex.h"
 #include "lib/ivis_opengl/piestate.h"
@@ -521,7 +522,7 @@ bool wzapi::cameraTrack(WZAPI_PARAMS(optional<DROID *> _droid))
 		DROID *droid = _droid.value();
 		SCRIPT_ASSERT(false, context, droid, "No valid droid provided");
 		SCRIPT_ASSERT(false, context, selectedPlayer < MAX_PLAYERS, "Invalid selectedPlayer for current client: %" PRIu32 "", selectedPlayer);
-		for (DROID *psDroid : apsDroidLists[selectedPlayer])
+		for (DROID *psDroid : worldObjectState.droids[selectedPlayer])
 		{
 			psDroid->selected = psDroid == droid; // select only the target droid
 		}
@@ -1065,7 +1066,7 @@ std::vector<const STRUCTURE *> _enumStruct_fromList(WZAPI_PARAMS(optional<int> _
 //--
 std::vector<const STRUCTURE *> wzapi::enumStruct(WZAPI_PARAMS(optional<int> _player, optional<STRUCTURE_TYPE_or_statsName_string> _structureType, optional<int> _playerFilter))
 {
-	return _enumStruct_fromList(context, _player, _structureType, _playerFilter, apsStructLists);
+	return _enumStruct_fromList(context, _player, _structureType, _playerFilter, worldObjectState.structures);
 }
 
 //-- ## enumStructOffWorld([player[, structureType[, playerFilter]]])
@@ -1079,7 +1080,7 @@ std::vector<const STRUCTURE *> wzapi::enumStruct(WZAPI_PARAMS(optional<int> _pla
 //--
 std::vector<const STRUCTURE *> wzapi::enumStructOffWorld(WZAPI_PARAMS(optional<int> _player, optional<STRUCTURE_TYPE_or_statsName_string> _structureType, optional<int> _playerFilter))
 {
-	return _enumStruct_fromList(context, _player, _structureType, _playerFilter, (mission.apsStructLists));
+	return _enumStruct_fromList(context, _player, _structureType, _playerFilter, (mission.worldObjectState.structures));
 }
 
 //-- ## enumDroid([player[, droidType[, playerFilter]]])
@@ -1115,7 +1116,7 @@ std::vector<const DROID *> wzapi::enumDroid(WZAPI_PARAMS(optional<int> _player, 
 	}
 	SCRIPT_ASSERT_PLAYER({}, context, player);
 	SCRIPT_ASSERT({}, context, (playerFilter >= 0 && playerFilter < MAX_PLAYERS) || playerFilter == ALL_PLAYERS, "Player filter index out of range: %d", playerFilter);
-	for (DROID *psDroid : apsDroidLists[player])
+	for (DROID *psDroid : worldObjectState.droids[player])
 	{
 		if ((playerFilter == ALL_PLAYERS || psDroid->visible[playerFilter])
 		    && !psDroid->died
@@ -1143,7 +1144,7 @@ std::vector<const FEATURE *> wzapi::enumFeature(WZAPI_PARAMS(int playerFilter, o
 	}
 
 	std::vector<const FEATURE *> matches;
-	for (const FEATURE *psFeat : apsFeatureList[0])
+	for (const FEATURE *psFeat : worldObjectState.features[0])
 	{
 		if ((playerFilter == ALL_PLAYERS || psFeat->visible[playerFilter])
 		    && !psFeat->died
@@ -1165,7 +1166,7 @@ std::vector<scr_position> wzapi::enumBlips(WZAPI_PARAMS(int player))
 {
 	SCRIPT_ASSERT_PLAYER({}, context, player);
 	std::vector<scr_position> matches;
-	for (const BASE_OBJECT *psSensor : apsSensorList[0])
+	for (const BASE_OBJECT *psSensor : worldObjectState.sensors[0])
 	{
 		if (psSensor->visible[player] > 0 && psSensor->visible[player] < UBYTE_MAX)
 		{
@@ -1186,14 +1187,14 @@ std::vector<const BASE_OBJECT *> wzapi::enumSelected(WZAPI_NO_PARAMS_NO_CONTEXT)
 	{
 		return matches;
 	}
-	for (DROID *psDroid : apsDroidLists[selectedPlayer])
+	for (DROID *psDroid : worldObjectState.droids[selectedPlayer])
 	{
 		if (psDroid->selected)
 		{
 			matches.push_back(psDroid);
 		}
 	}
-	for (STRUCTURE *psStruct : apsStructLists[selectedPlayer])
+	for (STRUCTURE *psStruct : worldObjectState.structures[selectedPlayer])
 	{
 		if (psStruct->selected)
 		{
@@ -1955,7 +1956,7 @@ wzapi::returned_nullable_ptr<const DROID> wzapi::addDroid(WZAPI_PARAMS(int playe
 			psDroid = ::buildDroid(psTemplate.get(), world_coord(x) + TILE_UNITS / 2, world_coord(y) + TILE_UNITS / 2, player, onMission, nullptr);
 			if (psDroid)
 			{
-				addDroid(psDroid, apsDroidLists);
+				addDroid(psDroid, worldObjectState.droids);
 				debug(LOG_LIFE, "Created droid %s by script for player %d: %u", objInfo(psDroid), player, psDroid->id);
 			}
 			else
@@ -2001,7 +2002,7 @@ bool wzapi::addDroidToTransporter(WZAPI_PARAMS(game_object_identifier transporte
 	DROID *psDroid = IdToMissionDroid(droidId, droidPlayer);
 	SCRIPT_ASSERT(false, context, psDroid, "No such droid id %d belonging to player %d", droidId, droidPlayer);
 	SCRIPT_ASSERT(false, context, checkTransporterSpace(psTransporter, psDroid), "Not enough room in transporter %d for droid %d", transporterId, droidId);
-	bool removeSuccessful = droidRemove(psDroid, mission.apsDroidLists);
+	bool removeSuccessful = droidRemove(psDroid, mission.worldObjectState.droids);
 	SCRIPT_ASSERT(false, context, removeSuccessful, "Could not remove droid id %d from mission list", droidId);
 	psTransporter->psGroup->add(psDroid);
 	return true;
@@ -2017,7 +2018,7 @@ wzapi::returned_nullable_ptr<const FEATURE> wzapi::addFeature(WZAPI_PARAMS(std::
 	int feature = getFeatureStatFromName(WzString::fromUtf8(featureName));
 	SCRIPT_ASSERT(nullptr, context, feature >= 0 && feature < asFeatureStats.size(), "Unknown feature name: %s", featureName.c_str());
 	FEATURE_STATS *psStats = &asFeatureStats[feature];
-	for (const FEATURE *psFeat : apsFeatureList[0])
+	for (const FEATURE *psFeat : worldObjectState.features[0])
 	{
 		SCRIPT_ASSERT(nullptr, context, map_coord(psFeat->pos.x) != x || map_coord(psFeat->pos.y) != y,
 		              "Building feature on tile already occupied");
@@ -2673,11 +2674,11 @@ wzapi::no_return_value wzapi::setReinforcementTime(WZAPI_PARAMS(int _time, optio
 	{
 		/* Search for a transport that is idle; if we can't find any, remove the launch button
 		 * since there's no transport to launch */
-		auto droidIt = std::find_if(apsDroidLists[selectedPlayer].begin(), apsDroidLists[selectedPlayer].end(), [](DROID* d)
+		auto droidIt = std::find_if(worldObjectState.droids[selectedPlayer].begin(), worldObjectState.droids[selectedPlayer].end(), [](DROID* d)
 		{
 			return d->isTransporter() && !transporterFlying(d);
 		});
-		DROID* psDroid = droidIt != apsDroidLists[selectedPlayer].end() ? *droidIt : nullptr;
+		DROID* psDroid = droidIt != worldObjectState.droids[selectedPlayer].end() ? *droidIt : nullptr;
 
 		// Didn't find an idle transporter, we can remove the launch button
 		if (psDroid == nullptr)
@@ -3482,11 +3483,11 @@ bool wzapi::transformPlayerToSpectator(WZAPI_PARAMS(int player))
 // flag all droids as requiring update on next frame
 static void dirtyAllDroids(int player)
 {
-	for (DROID *psDroid : apsDroidLists[player])
+	for (DROID *psDroid : worldObjectState.droids[player])
 	{
 		psDroid->flags.set(OBJECT_FLAG_DIRTY);
 	}
-	for (DROID *psDroid : mission.apsDroidLists[player])
+	for (DROID *psDroid : mission.worldObjectState.droids[player])
 	{
 		psDroid->flags.set(OBJECT_FLAG_DIRTY);
 	}
@@ -3498,11 +3499,11 @@ static void dirtyAllDroids(int player)
 
 static void dirtyAllStructures(int player)
 {
-	for (STRUCTURE *psCurr : apsStructLists[player])
+	for (STRUCTURE *psCurr : worldObjectState.structures[player])
 	{
 		psCurr->flags.set(OBJECT_FLAG_DIRTY);
 	}
-	for (STRUCTURE *psCurr : mission.apsStructLists[player])
+	for (STRUCTURE *psCurr : mission.worldObjectState.structures[player])
 	{
 		psCurr->flags.set(OBJECT_FLAG_DIRTY);
 	}
@@ -3827,14 +3828,14 @@ bool wzapi::setUpgradeStats(WZAPI_BASE_PARAMS(int player, const std::string& nam
 		case SCRCB_ELW:
 			// Update resistance points for all structures, to avoid making them damaged
 			// FIXME - this is _really_ slow! we could be doing this for dozens of buildings one at a time!
-			for (STRUCTURE *psCurr : apsStructLists[player])
+			for (STRUCTURE *psCurr : worldObjectState.structures[player])
 			{
 				if (psStats == psCurr->pStructureType && psStats->upgrade[player].resistance < value)
 				{
 					psCurr->resistance = value;
 				}
 			}
-			for (STRUCTURE *psCurr : mission.apsStructLists[player])
+			for (STRUCTURE *psCurr : mission.worldObjectState.structures[player])
 			{
 				if (psStats == psCurr->pStructureType && psStats->upgrade[player].resistance < value)
 				{
@@ -3847,14 +3848,14 @@ bool wzapi::setUpgradeStats(WZAPI_BASE_PARAMS(int player, const std::string& nam
 			// Update body points for all structures, to avoid making them damaged
 			// FIXME - this is _really_ slow! we could be doing this for
 			// dozens of buildings one at a time!
-			for (STRUCTURE *psCurr : apsStructLists[player])
+			for (STRUCTURE *psCurr : worldObjectState.structures[player])
 			{
 				if (psStats == psCurr->pStructureType && (!bMultiPlayer || (bMultiPlayer && psStats->upgrade[player].hitpoints < value)))
 				{
 					psCurr->body = (psCurr->body * value) / psStats->upgrade[player].hitpoints;
 				}
 			}
-			for (STRUCTURE *psCurr : mission.apsStructLists[player])
+			for (STRUCTURE *psCurr : mission.worldObjectState.structures[player])
 			{
 				if (psStats == psCurr->pStructureType && (!bMultiPlayer || (bMultiPlayer && psStats->upgrade[player].hitpoints < value)))
 				{

--- a/src/wzapi.cpp
+++ b/src/wzapi.cpp
@@ -522,7 +522,7 @@ bool wzapi::cameraTrack(WZAPI_PARAMS(optional<DROID *> _droid))
 		DROID *droid = _droid.value();
 		SCRIPT_ASSERT(false, context, droid, "No valid droid provided");
 		SCRIPT_ASSERT(false, context, selectedPlayer < MAX_PLAYERS, "Invalid selectedPlayer for current client: %" PRIu32 "", selectedPlayer);
-		for (DROID *psDroid : worldObjectState.droids[selectedPlayer])
+		for (DROID *psDroid : gameWorld.objects.droids[selectedPlayer])
 		{
 			psDroid->selected = psDroid == droid; // select only the target droid
 		}
@@ -759,7 +759,7 @@ wzapi::no_return_value wzapi::hackAddMessage(WZAPI_PARAMS(std::string message, i
 		{
 			VIEW_PROXIMITY *psProx = (VIEW_PROXIMITY *)psViewData->pData;
 			// check the z value is at least the height of the terrain
-			int height = map_Height(worldMapState, psProx->x, psProx->y);
+			int height = map_Height(gameWorld.map, psProx->x, psProx->y);
 			if (psProx->z < height)
 			{
 				psProx->z = height;
@@ -911,7 +911,7 @@ wzapi::no_return_value wzapi::hackMarkTiles(WZAPI_PARAMS(optional<wzapi::label_o
 				{
 					for (int y = y1; y < y2; y++)
 					{
-						MAPTILE *psTile = mapTile(worldMapState, x, y);
+						MAPTILE *psTile = mapTile(gameWorld.map, x, y);
 						psTile->tileInfoBits |= BITS_MARKED;
 					}
 				}
@@ -920,7 +920,7 @@ wzapi::no_return_value wzapi::hackMarkTiles(WZAPI_PARAMS(optional<wzapi::label_o
 			{
 				int x = tilePosOrArea.x1;
 				int y = tilePosOrArea.y1;
-				MAPTILE *psTile = mapTile(worldMapState, x, y);
+				MAPTILE *psTile = mapTile(gameWorld.map, x, y);
 				psTile->tileInfoBits |= BITS_MARKED;
 			}
 		}
@@ -1066,7 +1066,7 @@ std::vector<const STRUCTURE *> _enumStruct_fromList(WZAPI_PARAMS(optional<int> _
 //--
 std::vector<const STRUCTURE *> wzapi::enumStruct(WZAPI_PARAMS(optional<int> _player, optional<STRUCTURE_TYPE_or_statsName_string> _structureType, optional<int> _playerFilter))
 {
-	return _enumStruct_fromList(context, _player, _structureType, _playerFilter, worldObjectState.structures);
+	return _enumStruct_fromList(context, _player, _structureType, _playerFilter, gameWorld.objects.structures);
 }
 
 //-- ## enumStructOffWorld([player[, structureType[, playerFilter]]])
@@ -1080,7 +1080,7 @@ std::vector<const STRUCTURE *> wzapi::enumStruct(WZAPI_PARAMS(optional<int> _pla
 //--
 std::vector<const STRUCTURE *> wzapi::enumStructOffWorld(WZAPI_PARAMS(optional<int> _player, optional<STRUCTURE_TYPE_or_statsName_string> _structureType, optional<int> _playerFilter))
 {
-	return _enumStruct_fromList(context, _player, _structureType, _playerFilter, (mission.worldObjectState.structures));
+	return _enumStruct_fromList(context, _player, _structureType, _playerFilter, (mission.gameWorld.objects.structures));
 }
 
 //-- ## enumDroid([player[, droidType[, playerFilter]]])
@@ -1116,7 +1116,7 @@ std::vector<const DROID *> wzapi::enumDroid(WZAPI_PARAMS(optional<int> _player, 
 	}
 	SCRIPT_ASSERT_PLAYER({}, context, player);
 	SCRIPT_ASSERT({}, context, (playerFilter >= 0 && playerFilter < MAX_PLAYERS) || playerFilter == ALL_PLAYERS, "Player filter index out of range: %d", playerFilter);
-	for (DROID *psDroid : worldObjectState.droids[player])
+	for (DROID *psDroid : gameWorld.objects.droids[player])
 	{
 		if ((playerFilter == ALL_PLAYERS || psDroid->visible[playerFilter])
 		    && !psDroid->died
@@ -1144,7 +1144,7 @@ std::vector<const FEATURE *> wzapi::enumFeature(WZAPI_PARAMS(int playerFilter, o
 	}
 
 	std::vector<const FEATURE *> matches;
-	for (const FEATURE *psFeat : worldObjectState.features[0])
+	for (const FEATURE *psFeat : gameWorld.objects.features[0])
 	{
 		if ((playerFilter == ALL_PLAYERS || psFeat->visible[playerFilter])
 		    && !psFeat->died
@@ -1166,7 +1166,7 @@ std::vector<scr_position> wzapi::enumBlips(WZAPI_PARAMS(int player))
 {
 	SCRIPT_ASSERT_PLAYER({}, context, player);
 	std::vector<scr_position> matches;
-	for (const BASE_OBJECT *psSensor : worldObjectState.sensors[0])
+	for (const BASE_OBJECT *psSensor : gameWorld.objects.sensors[0])
 	{
 		if (psSensor->visible[player] > 0 && psSensor->visible[player] < UBYTE_MAX)
 		{
@@ -1187,14 +1187,14 @@ std::vector<const BASE_OBJECT *> wzapi::enumSelected(WZAPI_NO_PARAMS_NO_CONTEXT)
 	{
 		return matches;
 	}
-	for (DROID *psDroid : worldObjectState.droids[selectedPlayer])
+	for (DROID *psDroid : gameWorld.objects.droids[selectedPlayer])
 	{
 		if (psDroid->selected)
 		{
 			matches.push_back(psDroid);
 		}
 	}
-	for (STRUCTURE *psStruct : worldObjectState.structures[selectedPlayer])
+	for (STRUCTURE *psStruct : gameWorld.objects.structures[selectedPlayer])
 	{
 		if (psStruct->selected)
 		{
@@ -1261,8 +1261,8 @@ std::vector<const BASE_OBJECT *> wzapi::enumRange(WZAPI_PARAMS(int _x, int _y, i
 {
 	_x = std::max<int>(_x, 0);
 	_y = std::max<int>(_y, 0);
-	_x = std::min<int>(_x, worldMapState.width);
-	_y = std::min<int>(_y, worldMapState.height);
+	_x = std::min<int>(_x, gameWorld.map.width);
+	_y = std::min<int>(_y, gameWorld.map.height);
 
 	int player = context.player();
 	int x = world_coord(_x);
@@ -1458,7 +1458,7 @@ bool wzapi::orderDroidLoc(WZAPI_PARAMS(DROID *psDroid, int order_, int x, int y)
 	SCRIPT_ASSERT(false, context, psDroid, "No valid droid provided");
 	DROID_ORDER order = (DROID_ORDER)order_;
 	SCRIPT_ASSERT(false, context, validOrderForLoc(order), "Invalid location based order: %s", getDroidOrderName(order));
-	SCRIPT_ASSERT(false, context, tileOnMap(worldMapState, x, y), "Outside map bounds (%d, %d)", x, y);
+	SCRIPT_ASSERT(false, context, tileOnMap(gameWorld.map, x, y), "Outside map bounds (%d, %d)", x, y);
 	DROID_ORDER_DATA *droidOrder = &psDroid->order;
 	if (droidOrder->type == order && psDroid->actionPos.x == world_coord(x) && psDroid->actionPos.y == world_coord(y))
 	{
@@ -1599,7 +1599,7 @@ optional<scr_position> wzapi::pickStructLocation(WZAPI_PARAMS(const DROID *psDro
 	int incX, incY, x, y;
 	int maxBlockingTiles = _maxBlockingTiles.value_or(0);
 
-	SCRIPT_ASSERT({}, context, startX >= 0 && startX < worldMapState.width && startY >= 0 && startY < worldMapState.height, "Bad position (%d, %d)", startX, startY);
+	SCRIPT_ASSERT({}, context, startX >= 0 && startX < gameWorld.map.width && startY >= 0 && startY < gameWorld.map.height, "Bad position (%d, %d)", startX, startY);
 
 	x = startX;
 	y = startY;
@@ -1609,7 +1609,7 @@ optional<scr_position> wzapi::pickStructLocation(WZAPI_PARAMS(const DROID *psDro
 	PROPULSION_TYPE propType = (psDroid) ? psDroid->getPropulsionStats()->propulsionType : PROPULSION_TYPE_WHEELED;
 
 	// save a lot of typing... checks whether a position is valid
-#define LOC_OK(_x, _y) (tileOnMap(worldMapState, _x, _y) && \
+#define LOC_OK(_x, _y) (tileOnMap(gameWorld.map, _x, _y) && \
                         (!psDroid || fpathCheck(psDroid->pos, Vector3i(world_coord(_x), world_coord(_y), 0), propType)) \
                         && validLocation(psStat, world_coord(Vector2i(_x, _y)) + offset, 0, player, false) && structDoubleCheck(psStat, _x, _y, maxBlockingTiles, propType))
 
@@ -1691,7 +1691,7 @@ bool wzapi::structureCanFit(WZAPI_PARAMS(std::string structureName, int x, int y
 	}
 	uint16_t direction = static_cast<uint16_t>(DEG(_direction.value_or(0)));
 
-	return (tileOnMap(worldMapState, x, y)
+	return (tileOnMap(gameWorld.map, x, y)
 			&& validLocation(psStat, world_coord(Vector2i(x, y)), direction, player, false));
 }
 
@@ -1727,7 +1727,7 @@ bool wzapi::propulsionCanReach(WZAPI_PARAMS(std::string propulsionName, int x1, 
 //--
 int wzapi::terrainType(WZAPI_PARAMS(int x, int y))
 {
-	return ::terrainType(mapTile(worldMapState, x, y));
+	return ::terrainType(mapTile(gameWorld.map, x, y));
 }
 
 //-- ## tileIsBurning(x, y)
@@ -1736,7 +1736,7 @@ int wzapi::terrainType(WZAPI_PARAMS(int x, int y))
 //--
 bool wzapi::tileIsBurning(WZAPI_PARAMS(int x, int y))
 {
-	const MAPTILE *psTile = mapTile(worldMapState, x, y);
+	const MAPTILE *psTile = mapTile(gameWorld.map, x, y);
 	SCRIPT_ASSERT(false, context, psTile, "Checking fire on tile outside the map (%d, %d)", x, y);
 	return ::TileIsBurning(psTile);
 }
@@ -1956,7 +1956,7 @@ wzapi::returned_nullable_ptr<const DROID> wzapi::addDroid(WZAPI_PARAMS(int playe
 			psDroid = ::buildDroid(psTemplate.get(), world_coord(x) + TILE_UNITS / 2, world_coord(y) + TILE_UNITS / 2, player, onMission, nullptr);
 			if (psDroid)
 			{
-				addDroid(psDroid, worldObjectState.droids);
+				addDroid(psDroid, gameWorld.objects.droids);
 				debug(LOG_LIFE, "Created droid %s by script for player %d: %u", objInfo(psDroid), player, psDroid->id);
 			}
 			else
@@ -2002,7 +2002,7 @@ bool wzapi::addDroidToTransporter(WZAPI_PARAMS(game_object_identifier transporte
 	DROID *psDroid = IdToMissionDroid(droidId, droidPlayer);
 	SCRIPT_ASSERT(false, context, psDroid, "No such droid id %d belonging to player %d", droidId, droidPlayer);
 	SCRIPT_ASSERT(false, context, checkTransporterSpace(psTransporter, psDroid), "Not enough room in transporter %d for droid %d", transporterId, droidId);
-	bool removeSuccessful = droidRemove(psDroid, mission.worldObjectState.droids);
+	bool removeSuccessful = droidRemove(psDroid, mission.gameWorld.objects.droids);
 	SCRIPT_ASSERT(false, context, removeSuccessful, "Could not remove droid id %d from mission list", droidId);
 	psTransporter->psGroup->add(psDroid);
 	return true;
@@ -2018,7 +2018,7 @@ wzapi::returned_nullable_ptr<const FEATURE> wzapi::addFeature(WZAPI_PARAMS(std::
 	int feature = getFeatureStatFromName(WzString::fromUtf8(featureName));
 	SCRIPT_ASSERT(nullptr, context, feature >= 0 && feature < asFeatureStats.size(), "Unknown feature name: %s", featureName.c_str());
 	FEATURE_STATS *psStats = &asFeatureStats[feature];
-	for (const FEATURE *psFeat : worldObjectState.features[0])
+	for (const FEATURE *psFeat : gameWorld.objects.features[0])
 	{
 		SCRIPT_ASSERT(nullptr, context, map_coord(psFeat->pos.x) != x || map_coord(psFeat->pos.y) != y,
 		              "Building feature on tile already occupied");
@@ -2061,8 +2061,8 @@ bool wzapi::isVTOL(WZAPI_PARAMS(const DROID *psDroid))
 bool wzapi::safeDest(WZAPI_PARAMS(int player, int x, int y))
 {
 	SCRIPT_ASSERT_PLAYER(false, context, player);
-	SCRIPT_ASSERT(false, context, tileOnMap(worldMapState, x, y), "Out of bounds coordinates(%d, %d)", x, y);
-	return !(auxTile(worldMapState, x, y, player) & AUXBITS_DANGER);
+	SCRIPT_ASSERT(false, context, tileOnMap(gameWorld.map, x, y), "Out of bounds coordinates(%d, %d)", x, y);
+	return !(auxTile(gameWorld.map, x, y, player) & AUXBITS_DANGER);
 }
 
 //-- ## activateStructure(structure[, target])
@@ -2153,7 +2153,7 @@ std::vector<scr_position> wzapi::getDroidPath(WZAPI_PARAMS(const DROID *psDroid)
 	for (size_t i = startPos; i < len; i++)
 	{
 		const auto& pathCoords = psDroid->sMove.asPath[i];
-		ASSERT(worldOnMap(worldMapState, pathCoords.x, pathCoords.y), "Path off map!");
+		ASSERT(worldOnMap(gameWorld.map, pathCoords.x, pathCoords.y), "Path off map!");
 		result.emplace_back(scr_position {map_coord(pathCoords.x), map_coord(pathCoords.y)});
 	}
 
@@ -2169,8 +2169,8 @@ bool wzapi::addBeacon(WZAPI_PARAMS(int _x, int _y, int playerFilter, optional<st
 {
 	SCRIPT_ASSERT(false, context, _x >= 0, "Beacon x value %d is less than zero", _x);
 	SCRIPT_ASSERT(false, context, _y >= 0, "Beacon y value %d is less than zero", _y);
-	SCRIPT_ASSERT(false, context, _x <= worldMapState.width, "Beacon x value %d is greater than mapWidth %d", _x, (int)worldMapState.width);
-	SCRIPT_ASSERT(false, context, _y <= worldMapState.height, "Beacon y value %d is greater than mapHeight %d", _y, (int)worldMapState.height);
+	SCRIPT_ASSERT(false, context, _x <= gameWorld.map.width, "Beacon x value %d is greater than mapWidth %d", _x, (int)gameWorld.map.width);
+	SCRIPT_ASSERT(false, context, _y <= gameWorld.map.height, "Beacon y value %d is greater than mapHeight %d", _y, (int)gameWorld.map.height);
 
 	int x = world_coord(_x) + (TILE_UNITS / 2);
 	int y = world_coord(_y) + (TILE_UNITS / 2);
@@ -2422,8 +2422,8 @@ bool wzapi::centreView(WZAPI_PARAMS(int x, int y))
 {
 	SCRIPT_ASSERT(false, context, x >= 0, "x value %d is less than zero", x);
 	SCRIPT_ASSERT(false, context, y >= 0, "y value %d is less than zero", y);
-	SCRIPT_ASSERT(false, context, x <= worldMapState.width, "x value %d is greater than mapWidth %d", x, (int)worldMapState.width);
-	SCRIPT_ASSERT(false, context, y <= worldMapState.height, "y value %d is greater than mapHeight %d", y, (int)worldMapState.height);
+	SCRIPT_ASSERT(false, context, x <= gameWorld.map.width, "x value %d is greater than mapWidth %d", x, (int)gameWorld.map.width);
+	SCRIPT_ASSERT(false, context, y <= gameWorld.map.height, "y value %d is greater than mapHeight %d", y, (int)gameWorld.map.height);
 	setViewPos(x, y, false);
 	return true;
 }
@@ -2466,8 +2466,8 @@ bool wzapi::emitSound(WZAPI_PARAMS(std::string sound, int x, int y))
 {
 	SCRIPT_ASSERT(false, context, x >= 0, "x value %d is less than zero", x);
 	SCRIPT_ASSERT(false, context, y >= 0, "y value %d is less than zero", y);
-	SCRIPT_ASSERT(false, context, x <= worldMapState.width, "x value %d is greater than mapWidth %d", x, (int)worldMapState.width);
-	SCRIPT_ASSERT(false, context, y <= worldMapState.height, "y value %d is greater than mapHeight %d", y, (int)worldMapState.height);
+	SCRIPT_ASSERT(false, context, x <= gameWorld.map.width, "x value %d is greater than mapWidth %d", x, (int)gameWorld.map.width);
+	SCRIPT_ASSERT(false, context, y <= gameWorld.map.height, "y value %d is greater than mapHeight %d", y, (int)gameWorld.map.height);
 
 	int soundID = audio_GetTrackID(sound.c_str());
 	if (soundID == SAMPLE_NOT_FOUND)
@@ -2674,11 +2674,11 @@ wzapi::no_return_value wzapi::setReinforcementTime(WZAPI_PARAMS(int _time, optio
 	{
 		/* Search for a transport that is idle; if we can't find any, remove the launch button
 		 * since there's no transport to launch */
-		auto droidIt = std::find_if(worldObjectState.droids[selectedPlayer].begin(), worldObjectState.droids[selectedPlayer].end(), [](DROID* d)
+		auto droidIt = std::find_if(gameWorld.objects.droids[selectedPlayer].begin(), gameWorld.objects.droids[selectedPlayer].end(), [](DROID* d)
 		{
 			return d->isTransporter() && !transporterFlying(d);
 		});
-		DROID* psDroid = droidIt != worldObjectState.droids[selectedPlayer].end() ? *droidIt : nullptr;
+		DROID* psDroid = droidIt != gameWorld.objects.droids[selectedPlayer].end() ? *droidIt : nullptr;
 
 		// Didn't find an idle transporter, we can remove the launch button
 		if (psDroid == nullptr)
@@ -3100,24 +3100,24 @@ wzapi::no_return_value wzapi::setScrollLimits(WZAPI_PARAMS(int x1, int y1, int x
 
 	SCRIPT_ASSERT({}, context, minX >= 0, "Minimum scroll x value %d is less than zero - ", minX);
 	SCRIPT_ASSERT({}, context, minY >= 0, "Minimum scroll y value %d is less than zero - ", minY);
-	SCRIPT_ASSERT({}, context, maxX <= worldMapState.width, "Maximum scroll x value %d is greater than mapWidth %d", maxX, (int)worldMapState.width);
-	SCRIPT_ASSERT({}, context, maxY <= worldMapState.height, "Maximum scroll y value %d is greater than mapHeight %d", maxY, (int)worldMapState.height);
+	SCRIPT_ASSERT({}, context, maxX <= gameWorld.map.width, "Maximum scroll x value %d is greater than mapWidth %d", maxX, (int)gameWorld.map.width);
+	SCRIPT_ASSERT({}, context, maxY <= gameWorld.map.height, "Maximum scroll y value %d is greater than mapHeight %d", maxY, (int)gameWorld.map.height);
 
-	const int prevMinX = worldMapState.scroll.minX;
-	const int prevMinY = worldMapState.scroll.minY;
-	const int prevMaxX = worldMapState.scroll.maxX;
-	const int prevMaxY = worldMapState.scroll.maxY;
+	const int prevMinX = gameWorld.map.scroll.minX;
+	const int prevMinY = gameWorld.map.scroll.minY;
+	const int prevMaxX = gameWorld.map.scroll.maxX;
+	const int prevMaxY = gameWorld.map.scroll.maxY;
 
-	worldMapState.scroll.minX = minX;
-	worldMapState.scroll.maxX = maxX;
-	worldMapState.scroll.minY = minY;
-	worldMapState.scroll.maxY = maxY;
+	gameWorld.map.scroll.minX = minX;
+	gameWorld.map.scroll.maxX = maxX;
+	gameWorld.map.scroll.minY = minY;
+	gameWorld.map.scroll.maxY = maxY;
 
 	// When the scroll limits change midgame - need to redo the lighting
-	initLighting(prevMinX < worldMapState.scroll.minX ? prevMinX : worldMapState.scroll.minX,
-	             prevMinY < worldMapState.scroll.minY ? prevMinY : worldMapState.scroll.minY,
-	             prevMaxX < worldMapState.scroll.maxX ? prevMaxX : worldMapState.scroll.maxX,
-	             prevMaxY < worldMapState.scroll.maxY ? prevMaxY : worldMapState.scroll.maxY);
+	initLighting(prevMinX < gameWorld.map.scroll.minX ? prevMinX : gameWorld.map.scroll.minX,
+	             prevMinY < gameWorld.map.scroll.minY ? prevMinY : gameWorld.map.scroll.minY,
+	             prevMaxX < gameWorld.map.scroll.maxX ? prevMaxX : gameWorld.map.scroll.maxX,
+	             prevMaxY < gameWorld.map.scroll.maxY ? prevMaxY : gameWorld.map.scroll.maxY);
 
 	// need to reset radar to take into account of new size
 	resizeRadar();
@@ -3131,10 +3131,10 @@ wzapi::no_return_value wzapi::setScrollLimits(WZAPI_PARAMS(int x1, int y1, int x
 scr_area wzapi::getScrollLimits(WZAPI_NO_PARAMS)
 {
 	scr_area limits;
-	limits.x1 = worldMapState.scroll.minX;
-	limits.y1 = worldMapState.scroll.minY;
-	limits.x2 = worldMapState.scroll.maxX;
-	limits.y2 = worldMapState.scroll.maxY;
+	limits.x1 = gameWorld.map.scroll.minX;
+	limits.y1 = gameWorld.map.scroll.minY;
+	limits.x2 = gameWorld.map.scroll.maxX;
+	limits.y2 = gameWorld.map.scroll.maxY;
 	return limits;
 }
 
@@ -3342,8 +3342,8 @@ wzapi::no_return_value wzapi::setNoGoArea(WZAPI_PARAMS(int x1, int y1, int x2, i
 {
 	SCRIPT_ASSERT({}, context, x1 >= 0, "Minimum scroll x value %d is less than zero - ", x1);
 	SCRIPT_ASSERT({}, context, y1 >= 0, "Minimum scroll y value %d is less than zero - ", y1);
-	SCRIPT_ASSERT({}, context, x2 <= worldMapState.width, "Maximum scroll x value %d is greater than mapWidth %d", x2, (int)worldMapState.width);
-	SCRIPT_ASSERT({}, context, y2 <= worldMapState.height, "Maximum scroll y value %d is greater than mapHeight %d", y2, (int)worldMapState.height);
+	SCRIPT_ASSERT({}, context, x2 <= gameWorld.map.width, "Maximum scroll x value %d is greater than mapWidth %d", x2, (int)gameWorld.map.width);
+	SCRIPT_ASSERT({}, context, y2 <= gameWorld.map.height, "Maximum scroll y value %d is greater than mapHeight %d", y2, (int)gameWorld.map.height);
 	SCRIPT_ASSERT({}, context, (playerFilter >= 0 && playerFilter < MAX_PLAYERS) || playerFilter == ALL_PLAYERS, "Bad player filter value %d", playerFilter);
 
 	if (playerFilter == ALL_PLAYERS)
@@ -3426,7 +3426,7 @@ wzapi::no_return_value wzapi::fireWeaponAtLoc(WZAPI_PARAMS(std::string weaponNam
 		target.x += (TILE_UNITS / 2);
 		target.y += (TILE_UNITS / 2);
 	}
-	target.z = mapTile(worldMapState, x, y)->height;
+	target.z = mapTile(gameWorld.map, x, y)->height;
 
 	WEAPON sWeapon;
 	sWeapon.nStat = weaponIndex;
@@ -3483,11 +3483,11 @@ bool wzapi::transformPlayerToSpectator(WZAPI_PARAMS(int player))
 // flag all droids as requiring update on next frame
 static void dirtyAllDroids(int player)
 {
-	for (DROID *psDroid : worldObjectState.droids[player])
+	for (DROID *psDroid : gameWorld.objects.droids[player])
 	{
 		psDroid->flags.set(OBJECT_FLAG_DIRTY);
 	}
-	for (DROID *psDroid : mission.worldObjectState.droids[player])
+	for (DROID *psDroid : mission.gameWorld.objects.droids[player])
 	{
 		psDroid->flags.set(OBJECT_FLAG_DIRTY);
 	}
@@ -3499,11 +3499,11 @@ static void dirtyAllDroids(int player)
 
 static void dirtyAllStructures(int player)
 {
-	for (STRUCTURE *psCurr : worldObjectState.structures[player])
+	for (STRUCTURE *psCurr : gameWorld.objects.structures[player])
 	{
 		psCurr->flags.set(OBJECT_FLAG_DIRTY);
 	}
-	for (STRUCTURE *psCurr : mission.worldObjectState.structures[player])
+	for (STRUCTURE *psCurr : mission.gameWorld.objects.structures[player])
 	{
 		psCurr->flags.set(OBJECT_FLAG_DIRTY);
 	}
@@ -3828,14 +3828,14 @@ bool wzapi::setUpgradeStats(WZAPI_BASE_PARAMS(int player, const std::string& nam
 		case SCRCB_ELW:
 			// Update resistance points for all structures, to avoid making them damaged
 			// FIXME - this is _really_ slow! we could be doing this for dozens of buildings one at a time!
-			for (STRUCTURE *psCurr : worldObjectState.structures[player])
+			for (STRUCTURE *psCurr : gameWorld.objects.structures[player])
 			{
 				if (psStats == psCurr->pStructureType && psStats->upgrade[player].resistance < value)
 				{
 					psCurr->resistance = value;
 				}
 			}
-			for (STRUCTURE *psCurr : mission.worldObjectState.structures[player])
+			for (STRUCTURE *psCurr : mission.gameWorld.objects.structures[player])
 			{
 				if (psStats == psCurr->pStructureType && psStats->upgrade[player].resistance < value)
 				{
@@ -3848,14 +3848,14 @@ bool wzapi::setUpgradeStats(WZAPI_BASE_PARAMS(int player, const std::string& nam
 			// Update body points for all structures, to avoid making them damaged
 			// FIXME - this is _really_ slow! we could be doing this for
 			// dozens of buildings one at a time!
-			for (STRUCTURE *psCurr : worldObjectState.structures[player])
+			for (STRUCTURE *psCurr : gameWorld.objects.structures[player])
 			{
 				if (psStats == psCurr->pStructureType && (!bMultiPlayer || (bMultiPlayer && psStats->upgrade[player].hitpoints < value)))
 				{
 					psCurr->body = (psCurr->body * value) / psStats->upgrade[player].hitpoints;
 				}
 			}
-			for (STRUCTURE *psCurr : mission.worldObjectState.structures[player])
+			for (STRUCTURE *psCurr : mission.gameWorld.objects.structures[player])
 			{
 				if (psStats == psCurr->pStructureType && (!bMultiPlayer || (bMultiPlayer && psStats->upgrade[player].hitpoints < value)))
 				{
@@ -4783,12 +4783,12 @@ nlohmann::json wzapi::constructMapTilesArray()
 	//==   * ```hoverContinent``` (For hover type propulsions)
 	//==   * ```limitedContinent``` (For land or sea limited propulsion types)
 	nlohmann::json mapTileArray = nlohmann::json::array();
-	for (SDWORD y = 0; y < worldMapState.height; y++)
+	for (SDWORD y = 0; y < gameWorld.map.height; y++)
 	{
 		nlohmann::json mapRow = nlohmann::json::array();
-		for (SDWORD x = 0; x < worldMapState.width; x++)
+		for (SDWORD x = 0; x < gameWorld.map.width; x++)
 		{
-			MAPTILE *psTile = mapTile(worldMapState, x, y);
+			MAPTILE *psTile = mapTile(gameWorld.map, x, y);
 			nlohmann::json mapTile = nlohmann::json::object();
 			mapTile["terrainType"] = ::terrainType(psTile);
 			mapTile["height"] = psTile->height;

--- a/src/wzapi.cpp
+++ b/src/wzapi.cpp
@@ -759,7 +759,7 @@ wzapi::no_return_value wzapi::hackAddMessage(WZAPI_PARAMS(std::string message, i
 		{
 			VIEW_PROXIMITY *psProx = (VIEW_PROXIMITY *)psViewData->pData;
 			// check the z value is at least the height of the terrain
-			int height = map_Height(psProx->x, psProx->y);
+			int height = map_Height(worldMapState, psProx->x, psProx->y);
 			if (psProx->z < height)
 			{
 				psProx->z = height;
@@ -911,7 +911,7 @@ wzapi::no_return_value wzapi::hackMarkTiles(WZAPI_PARAMS(optional<wzapi::label_o
 				{
 					for (int y = y1; y < y2; y++)
 					{
-						MAPTILE *psTile = mapTile(x, y);
+						MAPTILE *psTile = mapTile(worldMapState, x, y);
 						psTile->tileInfoBits |= BITS_MARKED;
 					}
 				}
@@ -920,7 +920,7 @@ wzapi::no_return_value wzapi::hackMarkTiles(WZAPI_PARAMS(optional<wzapi::label_o
 			{
 				int x = tilePosOrArea.x1;
 				int y = tilePosOrArea.y1;
-				MAPTILE *psTile = mapTile(x, y);
+				MAPTILE *psTile = mapTile(worldMapState, x, y);
 				psTile->tileInfoBits |= BITS_MARKED;
 			}
 		}
@@ -1458,7 +1458,7 @@ bool wzapi::orderDroidLoc(WZAPI_PARAMS(DROID *psDroid, int order_, int x, int y)
 	SCRIPT_ASSERT(false, context, psDroid, "No valid droid provided");
 	DROID_ORDER order = (DROID_ORDER)order_;
 	SCRIPT_ASSERT(false, context, validOrderForLoc(order), "Invalid location based order: %s", getDroidOrderName(order));
-	SCRIPT_ASSERT(false, context, tileOnMap(x, y), "Outside map bounds (%d, %d)", x, y);
+	SCRIPT_ASSERT(false, context, tileOnMap(worldMapState, x, y), "Outside map bounds (%d, %d)", x, y);
 	DROID_ORDER_DATA *droidOrder = &psDroid->order;
 	if (droidOrder->type == order && psDroid->actionPos.x == world_coord(x) && psDroid->actionPos.y == world_coord(y))
 	{
@@ -1609,7 +1609,7 @@ optional<scr_position> wzapi::pickStructLocation(WZAPI_PARAMS(const DROID *psDro
 	PROPULSION_TYPE propType = (psDroid) ? psDroid->getPropulsionStats()->propulsionType : PROPULSION_TYPE_WHEELED;
 
 	// save a lot of typing... checks whether a position is valid
-#define LOC_OK(_x, _y) (tileOnMap(_x, _y) && \
+#define LOC_OK(_x, _y) (tileOnMap(worldMapState, _x, _y) && \
                         (!psDroid || fpathCheck(psDroid->pos, Vector3i(world_coord(_x), world_coord(_y), 0), propType)) \
                         && validLocation(psStat, world_coord(Vector2i(_x, _y)) + offset, 0, player, false) && structDoubleCheck(psStat, _x, _y, maxBlockingTiles, propType))
 
@@ -1691,7 +1691,7 @@ bool wzapi::structureCanFit(WZAPI_PARAMS(std::string structureName, int x, int y
 	}
 	uint16_t direction = static_cast<uint16_t>(DEG(_direction.value_or(0)));
 
-	return (tileOnMap(x, y)
+	return (tileOnMap(worldMapState, x, y)
 			&& validLocation(psStat, world_coord(Vector2i(x, y)), direction, player, false));
 }
 
@@ -1727,7 +1727,7 @@ bool wzapi::propulsionCanReach(WZAPI_PARAMS(std::string propulsionName, int x1, 
 //--
 int wzapi::terrainType(WZAPI_PARAMS(int x, int y))
 {
-	return ::terrainType(mapTile(x, y));
+	return ::terrainType(mapTile(worldMapState, x, y));
 }
 
 //-- ## tileIsBurning(x, y)
@@ -1736,7 +1736,7 @@ int wzapi::terrainType(WZAPI_PARAMS(int x, int y))
 //--
 bool wzapi::tileIsBurning(WZAPI_PARAMS(int x, int y))
 {
-	const MAPTILE *psTile = mapTile(x, y);
+	const MAPTILE *psTile = mapTile(worldMapState, x, y);
 	SCRIPT_ASSERT(false, context, psTile, "Checking fire on tile outside the map (%d, %d)", x, y);
 	return ::TileIsBurning(psTile);
 }
@@ -2061,8 +2061,8 @@ bool wzapi::isVTOL(WZAPI_PARAMS(const DROID *psDroid))
 bool wzapi::safeDest(WZAPI_PARAMS(int player, int x, int y))
 {
 	SCRIPT_ASSERT_PLAYER(false, context, player);
-	SCRIPT_ASSERT(false, context, tileOnMap(x, y), "Out of bounds coordinates(%d, %d)", x, y);
-	return !(auxTile(x, y, player) & AUXBITS_DANGER);
+	SCRIPT_ASSERT(false, context, tileOnMap(worldMapState, x, y), "Out of bounds coordinates(%d, %d)", x, y);
+	return !(auxTile(worldMapState, x, y, player) & AUXBITS_DANGER);
 }
 
 //-- ## activateStructure(structure[, target])
@@ -2153,7 +2153,7 @@ std::vector<scr_position> wzapi::getDroidPath(WZAPI_PARAMS(const DROID *psDroid)
 	for (size_t i = startPos; i < len; i++)
 	{
 		const auto& pathCoords = psDroid->sMove.asPath[i];
-		ASSERT(worldOnMap(pathCoords.x, pathCoords.y), "Path off map!");
+		ASSERT(worldOnMap(worldMapState, pathCoords.x, pathCoords.y), "Path off map!");
 		result.emplace_back(scr_position {map_coord(pathCoords.x), map_coord(pathCoords.y)});
 	}
 
@@ -3426,7 +3426,7 @@ wzapi::no_return_value wzapi::fireWeaponAtLoc(WZAPI_PARAMS(std::string weaponNam
 		target.x += (TILE_UNITS / 2);
 		target.y += (TILE_UNITS / 2);
 	}
-	target.z = mapTile(x, y)->height;
+	target.z = mapTile(worldMapState, x, y)->height;
 
 	WEAPON sWeapon;
 	sWeapon.nStat = weaponIndex;
@@ -4788,7 +4788,7 @@ nlohmann::json wzapi::constructMapTilesArray()
 		nlohmann::json mapRow = nlohmann::json::array();
 		for (SDWORD x = 0; x < worldMapState.width; x++)
 		{
-			MAPTILE *psTile = mapTile(x, y);
+			MAPTILE *psTile = mapTile(worldMapState, x, y);
 			nlohmann::json mapTile = nlohmann::json::object();
 			mapTile["terrainType"] = ::terrainType(psTile);
 			mapTile["height"] = psTile->height;

--- a/src/wzscriptdebug.cpp
+++ b/src/wzscriptdebug.cpp
@@ -913,7 +913,7 @@ static bool debugReloadSelectedObjectDisplayModels()
 		return false;
 	}
 
-	for (const DROID* psDroid : apsDroidLists[selectedPlayer])
+	for (const DROID* psDroid : worldObjectState.droids[selectedPlayer])
 	{
 		if (psDroid->selected)
 		{
@@ -1027,7 +1027,7 @@ static bool debugReloadSelectedObjectDisplayModels()
 		}
 	};
 
-	for (const STRUCTURE* psStructure : apsStructLists[selectedPlayer])
+	for (const STRUCTURE* psStructure : worldObjectState.structures[selectedPlayer])
 	{
 		if (psStructure->selected)
 		{

--- a/src/wzscriptdebug.cpp
+++ b/src/wzscriptdebug.cpp
@@ -913,7 +913,7 @@ static bool debugReloadSelectedObjectDisplayModels()
 		return false;
 	}
 
-	for (const DROID* psDroid : worldObjectState.droids[selectedPlayer])
+	for (const DROID* psDroid : gameWorld.objects.droids[selectedPlayer])
 	{
 		if (psDroid->selected)
 		{
@@ -1027,7 +1027,7 @@ static bool debugReloadSelectedObjectDisplayModels()
 		}
 	};
 
-	for (const STRUCTURE* psStructure : worldObjectState.structures[selectedPlayer])
+	for (const STRUCTURE* psStructure : gameWorld.objects.structures[selectedPlayer])
 	{
 		if (psStructure->selected)
 		{


### PR DESCRIPTION
This changeset consists of mostly simple mechanical work to replace all uses of global variables for map state (like `psMapTiles`) and object state (`aps*Lists` variables) with aggregated `GameWorld` structs.

Despite this being a huge PR, 99% of changes is purely mechanical grep+replace work, so no observable changes in game logic are expected.

For best reviewing experience, it's easier to go through the patches one-by-one in order. 

This PR is a prerequisite for more advanced refactorings across the code base, which should ultimately lead to a nicer separation between main and offworld game world states, which, in turn, would enable further round of improvements involving global state management.

Signed-off-by: Pavel Solodovnikov <pavel.al.solodovnikov@gmail.com>