### PR TITLE
treewide: Introduce more world-aware functions (part 1)

### DIFF
--- a/src/action.cpp
+++ b/src/action.cpp
@@ -94,6 +94,8 @@ static_assert(MAX_SULK_TIME > MIN_SULK_TIME, "MAX_SULK_TIME must be > MIN_SULK_T
  *
  * @brief pointer to a 'tile search function', used by spiralSearch()
  *
+ * @param mapState the WorldMapState to use for the search
+ *
  * @param x,y  are the coordinates that should be inspected.
  *
  * @param data a pointer to state data, allows the search function to retain
@@ -103,7 +105,7 @@ static_assert(MAX_SULK_TIME > MIN_SULK_TIME, "MAX_SULK_TIME must be > MIN_SULK_T
  * @return true when the search has finished, false when the search should
  *         continue.
  */
-typedef bool (*tileMatchFunction)(int x, int y, void *matchState);
+typedef bool (*tileMatchFunction)(WorldMapState& mapState, int x, int y, void *matchState);
 
 const char *getDroidActionName(DROID_ACTION action)
 {
@@ -610,7 +612,7 @@ static bool actionRemoveDroidsFromBuildPos(unsigned player, Vector2i pos, uint16
 			{
 				Vector2i dest = world_coord(b.map + Vector2i(x, y)) + Vector2i(TILE_UNITS, TILE_UNITS) / 2;
 				unsigned dist = iHypot(droid->pos.xy() - dest);
-				if (dist < bestDist && !fpathBlockingTile(map_coord(dest.x), map_coord(dest.y), droid->getPropulsionStats()->propulsionType))
+				if (dist < bestDist && !fpathBlockingTile(gameWorld.map, map_coord(dest.x), map_coord(dest.y), droid->getPropulsionStats()->propulsionType))
 				{
 					bestDest = dest;
 					bestDist = dist;
@@ -1498,7 +1500,7 @@ void actionUpdateDroid(DROID *psDroid)
 		{
 			// Determine if the droid can still build or help to build the ordered structure at the specified location
 			const STRUCTURE_STATS* const desiredStructure = order->psStats;
-			const STRUCTURE* const structureAtBuildPosition = getTileStructure(map_coord(psDroid->actionPos.x), map_coord(psDroid->actionPos.y));
+			const STRUCTURE* const structureAtBuildPosition = getTileStructure(gameWorld.map, map_coord(psDroid->actionPos.x), map_coord(psDroid->actionPos.y));
 
 			if (nullptr != structureAtBuildPosition)
 			{
@@ -1592,7 +1594,7 @@ void actionUpdateDroid(DROID *psDroid)
 				else if (TileHasStructure(worldTile(gameWorld.map, pos)))
 				{
 					// structure on the build location - see if it is the same type
-					STRUCTURE *const psStruct = getTileStructure(map_coord(pos.x), map_coord(pos.y));
+					STRUCTURE *const psStruct = getTileStructure(gameWorld.map, map_coord(pos.x), map_coord(pos.y));
 					if (psStruct->pStructureType == order->psStats ||
 					    (order->psStats->type == REF_WALL && psStruct->pStructureType->type == REF_WALLCORNER))
 					{
@@ -1620,7 +1622,7 @@ void actionUpdateDroid(DROID *psDroid)
 						cancelBuild(psDroid);
 					}
 				}
-				else if (!validLocation(order->psStats, pos, dir, psDroid->player, false))
+				else if (!validLocation(gameWorld, order->psStats, pos, dir, psDroid->player, false))
 				{
 					syncDebug("Reached build target: invalid");
 					objTrace(psDroid->id, "DACTION_MOVETOBUILD: !validLocation");
@@ -1646,7 +1648,7 @@ void actionUpdateDroid(DROID *psDroid)
 					if (TileHasStructure(psTile))
 					{
 						// structure on the build location - see if it is the same type
-						STRUCTURE *const psStruct = getTileStructure(map_coord(psDroid->actionPos.x), map_coord(psDroid->actionPos.y));
+						STRUCTURE *const psStruct = getTileStructure(gameWorld.map, map_coord(psDroid->actionPos.x), map_coord(psDroid->actionPos.y));
 						ASSERT(psStruct, "TileHasStructure, but getTileStructure returned nullptr");
 #if defined(WZ_CC_GNU) && !defined(WZ_CC_INTEL) && !defined(WZ_CC_CLANG) && (7 <= __GNUC__)
 # pragma GCC diagnostic push
@@ -1683,7 +1685,7 @@ void actionUpdateDroid(DROID *psDroid)
 					}
 					else if (TileHasFeature(psTile))
 					{
-						FEATURE *feature = getTileFeature(map_coord(psDroid->actionPos.x), map_coord(psDroid->actionPos.y));
+						FEATURE *feature = getTileFeature(gameWorld.map, map_coord(psDroid->actionPos.x), map_coord(psDroid->actionPos.y));
 						objTrace(psDroid->id, "DACTION_MOVETOBUILD: tile has feature %d", feature->psStats->subType);
 						if (feature->psStats->subType == FEAT_OIL_RESOURCE && order->psStats->type == REF_RESOURCE_EXTRACTOR)
 						{
@@ -1776,7 +1778,7 @@ void actionUpdateDroid(DROID *psDroid)
 		}
 		else
 		{
-			const STRUCTURE* structureAtPos = getTileStructure(map_coord(psDroid->actionPos.x), map_coord(psDroid->actionPos.y));
+			const STRUCTURE* structureAtPos = getTileStructure(gameWorld.map, map_coord(psDroid->actionPos.x), map_coord(psDroid->actionPos.y));
 
 			if (structureAtPos == nullptr || psDroid->psActionTarget[0] == nullptr)
 			{
@@ -1948,7 +1950,7 @@ void actionUpdateDroid(DROID *psDroid)
 					/* set droid points to max */
 					psDroid->body = psDroid->originalBody;
 					// if completely repaired then reset order
-					secondarySetState(psDroid, DSO_RETURN_TO_LOC, DSS_NONE);
+					secondarySetState(psDroid, gameWorld.objects, DSO_RETURN_TO_LOC, DSS_NONE);
 					orderDroidObj(psDroid, DORDER_GUARD, psDroid->order.psObj, ModeImmediate);
 				}
 				else
@@ -2759,14 +2761,14 @@ void moveToRearm(DROID *psDroid)
 
 
 // whether a tile is suitable for a vtol to land on
-static bool vtolLandingTile(SDWORD x, SDWORD y)
+static bool vtolLandingTile(WorldMapState& mapState, SDWORD x, SDWORD y)
 {
-	if (x < 0 || x >= (SDWORD)gameWorld.map.width || y < 0 || y >= (SDWORD)gameWorld.map.height)
+	if (x < 0 || x >= (SDWORD)mapState.width || y < 0 || y >= (SDWORD)mapState.height)
 	{
 		return false;
 	}
 
-	const MAPTILE *psTile = mapTile(gameWorld.map, x, y);
+	const MAPTILE *psTile = mapTile(mapState, x, y);
 	if (psTile->tileInfoBits & BITS_FPATHBLOCK ||
 	    TileIsOccupied(psTile) ||
 	    terrainType(psTile) == TER_CLIFFFACE ||
@@ -2782,6 +2784,8 @@ static bool vtolLandingTile(SDWORD x, SDWORD y)
  * including) radius. For each tile, the search function is called; if it
  * returns 'true', the search will finish immediately.
  *
+ * @param mapState the WorldMapState to use for the search
+ *
  * @param startX,startY starting x and y coordinates
  *
  * @param max_radius radius to examine. Search will finish when @c max_radius is exceeded.
@@ -2791,10 +2795,10 @@ static bool vtolLandingTile(SDWORD x, SDWORD y)
  * \return true if finished because the searchFunction requested termination,
  *         false if the radius limit was reached
  */
-static bool spiralSearch(int startX, int startY, int max_radius, tileMatchFunction match, void *matchState)
+static bool spiralSearch(WorldMapState& mapState, int startX, int startY, int max_radius, tileMatchFunction match, void *matchState)
 {
 	// test center tile
-	if (match(startX, startY, matchState))
+	if (match(mapState, startX, startY, matchState))
 	{
 		return true;
 	}
@@ -2828,10 +2832,10 @@ static bool spiralSearch(int startX, int startY, int max_radius, tileMatchFuncti
 				}
 
 				// call search function for each of the 4 quadrants of the circle
-				if (match(startX + dx, startY + dy, matchState)
-				    || match(startX - dx, startY - dy, matchState)
-				    || match(startX + dy, startY - dx, matchState)
-				    || match(startX - dy, startY + dx, matchState))
+				if (match(mapState, startX + dx, startY + dy, matchState)
+				    || match(mapState, startX - dx, startY - dy, matchState)
+				    || match(mapState, startX + dy, startY - dx, matchState)
+				    || match(mapState, startX - dy, startY + dx, matchState))
 				{
 					return true;
 				}
@@ -2850,11 +2854,11 @@ static bool spiralSearch(int startX, int startY, int max_radius, tileMatchFuncti
  *
  * @return true if coordinates are a valid landing tile, false if not.
  */
-static bool vtolLandingTileSearchFunction(int x, int y, void *matchState)
+static bool vtolLandingTileSearchFunction(WorldMapState& mapState, int x, int y, void *matchState)
 {
 	Vector2i *const xyCoords = (Vector2i *)matchState;
 
-	if (vtolLandingTile(x, y))
+	if (vtolLandingTile(mapState, x, y))
 	{
 		xyCoords->x = x;
 		xyCoords->y = y;
@@ -2897,7 +2901,7 @@ bool actionVTOLLandingPos(DROID const *psDroid, Vector2i *p)
 
 	// search for landing tile; will stop when found or radius exceeded
 	Vector2i xyCoords(0, 0);
-	const bool foundTile = spiralSearch(startX, startY, vtolLandingRadius,
+	const bool foundTile = spiralSearch(gameWorld.map, startX, startY, vtolLandingRadius,
 	                                    vtolLandingTileSearchFunction, &xyCoords);
 	if (foundTile)
 	{

--- a/src/advvis.cpp
+++ b/src/advvis.cpp
@@ -46,10 +46,10 @@ inline float getTileIllumination(const MAPTILE *psTile)
 }
 
 // ------------------------------------------------------------------------------------
-void	avUpdateTiles()
+void	avUpdateTiles(WorldMapState& mapState)
 {
 	WZ_PROFILE_SCOPE(avUpdateTiles);
-	const int len = gameWorld.map.height * gameWorld.map.width;
+	const int len = mapState.height * mapState.width;
 	const int playermask = 1 << selectedPlayer;
 	UDWORD i = 0;
 	float maxLevel, increment = graphicsTimeAdjustedIncrement(FADE_IN_TIME);	// call once per frame
@@ -60,7 +60,7 @@ void	avUpdateTiles()
 	/* Go through the tiles */
 	for (; i < len; i++)
 	{
-		psTile = &gameWorld.map.tiles[i];
+		psTile = &mapState.tiles[i];
 		maxLevel = getTileIllumination(psTile);
 
 		if (psTile->level > MIN_ILLUM || psTile->tileExploredBits & playermask)	// seen
@@ -111,13 +111,13 @@ void	setRevealStatus(bool val)
 }
 
 // ------------------------------------------------------------------------------------
-void	preProcessVisibility()
+void	preProcessVisibility(WorldMapState& mapState)
 {
-	for (int i = 0; i < gameWorld.map.width; i++)
+	for (int i = 0; i < mapState.width; i++)
 	{
-		for (int j = 0; j < gameWorld.map.height; j++)
+		for (int j = 0; j < mapState.height; j++)
 		{
-			MAPTILE *psTile = mapTile(gameWorld.map, i, j);
+			MAPTILE *psTile = mapTile(mapState, i, j);
 			psTile->level = bRevealActive ? MIN(MIN_ILLUM, getTileIllumination(psTile) / 4.0f) : 0;
 
 			if (TEST_TILE_VISIBLE_TO_SELECTEDPLAYER(psTile))

--- a/src/advvis.h
+++ b/src/advvis.h
@@ -23,10 +23,12 @@
 
 #include "basedef.h"
 
-void avUpdateTiles();
+struct WorldMapState;
+
+void avUpdateTiles(WorldMapState& mapState);
 UDWORD avGetObjLightLevel(BASE_OBJECT const *psObj, UDWORD origLevel);
 void setRevealStatus(bool val);
 bool getRevealStatus();
-void preProcessVisibility();
+void preProcessVisibility(WorldMapState& mapState);
 
 #endif // __INCLUDED_SRC_ADVVIS_H__

--- a/src/astar.cpp
+++ b/src/astar.cpp
@@ -767,7 +767,7 @@ void fpathSetBlockingMap(PATHJOB *psJob)
 		for (int y = 0; y < gameWorld.map.height; ++y)
 			for (int x = 0; x < gameWorld.map.width; ++x)
 			{
-				map[x + y * gameWorld.map.width] = fpathBaseBlockingTile(x, y, type.propulsion, type.owner, type.moveType);
+				map[x + y * gameWorld.map.width] = fpathBaseBlockingTile(gameWorld.map, x, y, type.propulsion, type.owner, type.moveType);
 				checksumMap ^= map[x + y * gameWorld.map.width] * (factor = 3 * factor + 1);
 			}
 		if (!isHumanPlayer(type.owner) && type.moveType == FMT_MOVE)

--- a/src/atmos.cpp
+++ b/src/atmos.cpp
@@ -116,7 +116,7 @@ static void testParticleWrap(ATPART *psPart)
 }
 
 /* Moves one of the particles */
-static void processParticle(ATPART *psPart)
+static void processParticle(WorldMapState& mapState, ATPART *psPart)
 {
 	SDWORD	groundHeight;
 	Vector3i pos;
@@ -136,8 +136,8 @@ static void processParticle(ATPART *psPart)
 
 		/* If it's gone off the WORLD... */
 		if (psPart->position.x < 0 || psPart->position.z < 0 ||
-		    psPart->position.x > ((gameWorld.map.width - 1)*TILE_UNITS) ||
-		    psPart->position.z > ((gameWorld.map.height - 1)*TILE_UNITS))
+		    psPart->position.x > ((mapState.width - 1)*TILE_UNITS) ||
+		    psPart->position.z > ((mapState.height - 1)*TILE_UNITS))
 		{
 			/* The kill it */
 			psPart->status = APS_INACTIVE;
@@ -148,7 +148,7 @@ static void processParticle(ATPART *psPart)
 		if (psPart->position.y < TILE_MAX_HEIGHT)
 		{
 			/* Get ground height */
-			groundHeight = map_Height(gameWorld.map, static_cast<int>(psPart->position.x), static_cast<int>(psPart->position.z));
+			groundHeight = map_Height(mapState, static_cast<int>(psPart->position.x), static_cast<int>(psPart->position.z));
 
 			/* Are we below ground? */
 			if ((int)psPart->position.y < groundHeight
@@ -160,7 +160,7 @@ static void processParticle(ATPART *psPart)
 				{
 					x = map_coord(static_cast<int32_t>(psPart->position.x));
 					y = map_coord(static_cast<int32_t>(psPart->position.z));
-					psTile = mapTile(gameWorld.map, x, y);
+					psTile = mapTile(mapState, x, y);
 					if (terrainType(psTile) == TER_WATER && TEST_TILE_VISIBLE_TO_SELECTEDPLAYER(psTile)) // display-only check for adding effect
 					{
 						pos.x = static_cast<int>(psPart->position.x);
@@ -251,7 +251,7 @@ static void atmosAddParticle(const Vector3f &pos, AP_TYPE type)
 }
 
 /* Move the particles */
-void atmosUpdateSystem()
+void atmosUpdateSystem(WorldMapState& mapState)
 {
 	WZ_PROFILE_SCOPE(atmosUpdateSystem);
 	UDWORD	i;
@@ -271,7 +271,7 @@ void atmosUpdateSystem()
 			/* See if it's active */
 			if (asAtmosParts[i].status == APS_ACTIVE)
 			{
-				processParticle(&asAtmosParts[i]);
+				processParticle(mapState, &asAtmosParts[i]);
 			}
 		}
 
@@ -299,8 +299,8 @@ void atmosUpdateSystem()
 
 			/* If we've got one on the grid */
 			if (pos.x > 0 && pos.z > 0 &&
-			    pos.x < (SDWORD)world_coord(gameWorld.map.width - 1) &&
-			    pos.z < (SDWORD)world_coord(gameWorld.map.height - 1))
+			    pos.x < (SDWORD)world_coord(mapState.width - 1) &&
+			    pos.z < (SDWORD)world_coord(mapState.height - 1))
 			{
 				/* On grid, so which particle shall we add? */
 				switch (weather)

--- a/src/atmos.h
+++ b/src/atmos.h
@@ -41,8 +41,10 @@ enum WT_CLASS
 	WT_NONE
 };
 
+struct WorldMapState;
+
 void atmosInitSystem();
-void atmosUpdateSystem();
+void atmosUpdateSystem(WorldMapState& mapState);
 void renderParticle(ATPART *psPart, const glm::mat4 &perspectiveViewMatrix);
 void atmosDrawParticles(const glm::mat4 &viewMatrix, const glm::mat4 &perspectiveViewMatrix);
 void atmosSetWeatherType(WT_CLASS type);

--- a/src/baseobject.cpp
+++ b/src/baseobject.cpp
@@ -29,6 +29,7 @@
 #include "feature.h"
 #include "intdisplay.h"
 #include "map.h"
+#include "game_world.h"
 
 
 static inline uint16_t interpolateAngle(uint16_t v1, uint16_t v2, uint32_t t1, uint32_t t2, uint32_t t)
@@ -120,7 +121,7 @@ BASE_OBJECT::BASE_OBJECT(OBJECT_TYPE type, uint32_t id, unsigned player)
 
 BASE_OBJECT::~BASE_OBJECT()
 {
-	visRemoveVisibility(this);
+	visRemoveVisibility(this, gameWorld.map);
 }
 
 

--- a/src/cmddroid.cpp
+++ b/src/cmddroid.cpp
@@ -111,9 +111,9 @@ bool cmdDroidAddDroid(DROID *psCommander, DROID *psDroid)
 
 		// set the secondary states for the unit
 		// dont reset DSO_ATTACK_RANGE, because there is no way to modify it under commander
-		secondarySetState(psDroid, DSO_REPAIR_LEVEL, (SECONDARY_STATE)(psCommander->secondaryOrder & DSS_REPLEV_MASK), ModeImmediate);
-		secondarySetState(psDroid, DSO_ATTACK_LEVEL, (SECONDARY_STATE)(psCommander->secondaryOrder & DSS_ALEV_MASK), ModeImmediate);
-		secondarySetState(psDroid, DSO_HALTTYPE, (SECONDARY_STATE)(psCommander->secondaryOrder & DSS_HALT_MASK), ModeImmediate);
+		secondarySetState(psDroid, gameWorld.objects, DSO_REPAIR_LEVEL, (SECONDARY_STATE)(psCommander->secondaryOrder & DSS_REPLEV_MASK), ModeImmediate);
+		secondarySetState(psDroid, gameWorld.objects, DSO_ATTACK_LEVEL, (SECONDARY_STATE)(psCommander->secondaryOrder & DSS_ALEV_MASK), ModeImmediate);
+		secondarySetState(psDroid, gameWorld.objects, DSO_HALTTYPE, (SECONDARY_STATE)(psCommander->secondaryOrder & DSS_HALT_MASK), ModeImmediate);
 
 		orderDroidObj(psDroid, DORDER_GUARD, (BASE_OBJECT *)psCommander, ModeImmediate);
 	}

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -110,10 +110,10 @@ int scrollDirUpDown = 0;
 #endif
 
 static bool	buildingDamaged(STRUCTURE *psStructure);
-static bool	repairDroidSelected(UDWORD player);
-static bool vtolDroidSelected(UDWORD player);
-static bool	anyDroidSelected(UDWORD player);
-static bool cyborgDroidSelected(UDWORD player);
+static bool	repairDroidSelected(const WorldObjectState& objState, UDWORD player);
+static bool vtolDroidSelected(const WorldObjectState& objState, UDWORD player);
+static bool	anyDroidSelected(const WorldObjectState& objState, UDWORD player);
+static bool cyborgDroidSelected(const WorldObjectState& objState, UDWORD player);
 static bool bInvertMouse = true;
 static bool bRightClickOrders = false;
 optional<MOUSE_KEY_CODE> rotateMouseKey = MOUSE_RMB;
@@ -408,14 +408,14 @@ void resetInput()
 	gInputManager.contexts().resetStates();
 }
 
-static bool localPlayerHasSelection()
+static bool localPlayerHasSelection(const WorldObjectState& objState)
 {
 	if (selectedPlayer >= MAX_PLAYERS)
 	{
 		return false;
 	}
 
-	for (const DROID* psDroid : gameWorld.objects.droids[selectedPlayer])
+	for (const DROID* psDroid : objState.droids[selectedPlayer])
 	{
 		if (psDroid->selected)
 		{
@@ -423,7 +423,7 @@ static bool localPlayerHasSelection()
 		}
 	}
 
-	for (const STRUCTURE* psStruct : gameWorld.objects.structures[selectedPlayer])
+	for (const STRUCTURE* psStruct : objState.structures[selectedPlayer])
 	{
 		if (psStruct->selected)
 		{
@@ -472,7 +472,7 @@ void processInput()
 
 	gInputManager.contexts().set(
 		InputContext::DEBUG_HAS_SELECTION,
-		localPlayerHasSelection() ? InputContext::State::ACTIVE : InputContext::State::INACTIVE
+		localPlayerHasSelection(gameWorld.objects) ? InputContext::State::ACTIVE : InputContext::State::INACTIVE
 	);
 	gInputManager.contexts().updatePriorityStatus();
 
@@ -875,7 +875,7 @@ void processMouseClickInput()
 			//check for VTOL droids being assigned to a sensor droid/structure
 			else if ((item == MT_SENSOR || item == MT_SENSORSTRUCT || item == MT_SENSORSTRUCTDAM)
 			         && selection == SC_DROID_DIRECT
-			         && vtolDroidSelected((UBYTE)selectedPlayer))
+			         && vtolDroidSelected(gameWorld.objects, (UBYTE)selectedPlayer))
 			{
 				// NB. psSelectedVtol was set by vtolDroidSelected - yes I know its horrible, but it
 				// only smells as much as the rest of display.c so I don't feel so bad
@@ -892,7 +892,7 @@ void processMouseClickInput()
 			//vtols cannot pick up artifacts
 			else if (item == MT_ARTIFACT
 			         && selection == SC_DROID_DIRECT
-			         && vtolDroidSelected((UBYTE)selectedPlayer))
+			         && vtolDroidSelected(gameWorld.objects, (UBYTE)selectedPlayer))
 			{
 				item = MT_BLOCKING;
 			}
@@ -1112,7 +1112,7 @@ static void handleCameraScrolling()
 		playerPos.p.x += xDif;
 		playerPos.p.z += yDif;
 
-		CheckScrollLimits();
+		CheckScrollLimits(gameWorld.map);
 	}
 
 	// Reset scroll directions
@@ -1139,12 +1139,12 @@ void resetScroll()
 }
 
 // Checks if coordinate is inside scroll limits, returns false if not.
-bool CheckInScrollLimits(const int &xPos, const int &yPos)
+bool CheckInScrollLimits(const WorldMapState& mapState, const int &xPos, const int &yPos)
 {
-	int minX = world_coord(gameWorld.map.scroll.minX);
-	int maxX = world_coord(gameWorld.map.scroll.maxX - 1);
-	int minY = world_coord(gameWorld.map.scroll.minY);
-	int maxY = world_coord(gameWorld.map.scroll.maxY - 1);
+	int minX = world_coord(mapState.scroll.minX);
+	int maxX = world_coord(mapState.scroll.maxX - 1);
+	int minY = world_coord(mapState.scroll.minY);
+	int maxY = world_coord(mapState.scroll.maxY - 1);
 
 	if ((xPos < minX) || (xPos >= maxX) || (yPos < minY) || (yPos >= maxY))
 	{
@@ -1157,15 +1157,15 @@ bool CheckInScrollLimits(const int &xPos, const int &yPos)
 // Check a coordinate is within the scroll limits, SDWORD version.
 // Returns true if edge hit.
 //
-bool CheckInScrollLimitsCamera(SDWORD *xPos, SDWORD *zPos)
+bool CheckInScrollLimitsCamera(const WorldMapState& mapState, SDWORD *xPos, SDWORD *zPos)
 {
 	bool EdgeHit = false;
 	SDWORD	minX, minY, maxX, maxY;
 
-	minX = world_coord(gameWorld.map.scroll.minX);
-	maxX = world_coord(gameWorld.map.scroll.maxX - 1);
-	minY = world_coord(gameWorld.map.scroll.minY);
-	maxY = world_coord(gameWorld.map.scroll.maxY - 1);
+	minX = world_coord(mapState.scroll.minX);
+	maxX = world_coord(mapState.scroll.maxX - 1);
+	minY = world_coord(mapState.scroll.minY);
+	maxY = world_coord(mapState.scroll.maxY - 1);
 
 	//scroll is limited to what can be seen for current campaign
 	if (*xPos < minX)
@@ -1196,11 +1196,11 @@ bool CheckInScrollLimitsCamera(SDWORD *xPos, SDWORD *zPos)
 // Check the view is within the scroll limits,
 // Returns true if edge hit.
 //
-bool CheckScrollLimits()
+bool CheckScrollLimits(const WorldMapState& mapState)
 {
 	SDWORD xp = playerPos.p.x;
 	SDWORD zp = playerPos.p.z;
-	bool ret = CheckInScrollLimitsCamera(&xp, &zp);
+	bool ret = CheckInScrollLimitsCamera(mapState, &xp, &zp);
 
 	playerPos.p.x = xp;
 	playerPos.p.z = zp;
@@ -1239,7 +1239,7 @@ void displayWorld()
 			playerPos.p.z = static_cast<int>(panZTracker->getInitial()
 				+ sin(-playerPos.r.y * (M_PI / 32768)) * horizontalMovement
 				- cos(-playerPos.r.y * (M_PI / 32768)) * verticalMovement);
-			CheckScrollLimits();
+			CheckScrollLimits(gameWorld.map);
 		}
 	}
 
@@ -1352,7 +1352,7 @@ BASE_OBJECT *mouseTarget()
 
 	/*	Not a droid, so maybe a structure or feature?
 		If still NULL after this then nothing */
-	psReturn = getTileOccupier(mouseTileX, mouseTileY);
+	psReturn = getTileOccupier(gameWorld.map, mouseTileX, mouseTileY);
 
 	if (psReturn == nullptr)
 	{
@@ -1421,12 +1421,12 @@ void finishDeliveryPosition()
 			if (psStruct->isFactory() && psStruct->pFunctionality
 				&& psStruct->pFunctionality->factory.psAssemblyPoint)
 			{
-				setAssemblyPoint(psStruct->pFunctionality->factory.psAssemblyPoint,
+				setAssemblyPoint(gameWorld, psStruct->pFunctionality->factory.psAssemblyPoint,
 								 flagPos.coords.x, flagPos.coords.y, selectedPlayer, true);
 			}
 			else if (psStruct->pStructureType && psStruct->pStructureType->type == REF_REPAIR_FACILITY && psStruct->pFunctionality != nullptr)
 			{
-				setAssemblyPoint(psStruct->pFunctionality->repairFacility.psDeliveryPoint,
+				setAssemblyPoint(gameWorld, psStruct->pFunctionality->repairFacility.psDeliveryPoint,
 								 flagPos.coords.x, flagPos.coords.y, selectedPlayer, true);
 			}
 		}
@@ -1469,7 +1469,7 @@ bool deliveryReposValid()
 		}
 	}
 
-	if (fpathBlockingTile(map.x, map.y, PROPULSION_TYPE_WHEELED))
+	if (fpathBlockingTile(gameWorld.map, map.x, map.y, PROPULSION_TYPE_WHEELED))
 	{
 		return false;
 	}
@@ -1705,7 +1705,7 @@ static void dealWithLMBDroid(DROID *psDroid, SELECTION_TYPE selection)
 		else
 		{
 			// We can order all units to use the transport now
-			if (cyborgDroidSelected(selectedPlayer))
+			if (cyborgDroidSelected(gameWorld.objects, selectedPlayer))
 			{
 				// TODO add special processing for cyborgDroids
 			}
@@ -1770,7 +1770,7 @@ static void dealWithLMBDroid(DROID *psDroid, SELECTION_TYPE selection)
 		FeedbackOrderGiven();
 	}
 	// Clicked on a damaged unit? Will repair it.
-	else if (psDroid->isDamaged() && repairDroidSelected(selectedPlayer))
+	else if (psDroid->isDamaged() && repairDroidSelected(gameWorld.objects, selectedPlayer))
 	{
 		assignDestTarget();
 		orderSelectedObjAdd(selectedPlayer, (BASE_OBJECT *)psDroid, ctrlShiftDown());
@@ -1855,7 +1855,7 @@ static void dealWithLMBStructure(STRUCTURE *psStructure, SELECTION_TYPE selectio
 		}
 		else
 		{
-			auto shouldDisplayInterface = !anyDroidSelected(selectedPlayer);
+			auto shouldDisplayInterface = !anyDroidSelected(gameWorld.objects, selectedPlayer);
 			if (selection == SC_INVALID)
 			{
 				/* Clear old building selection(s) - should only be one */
@@ -1971,7 +1971,7 @@ static void dealWithLMBFeature(FEATURE *psFeature)
 		case FEAT_GEN_ARTE:
 		case FEAT_OIL_DRUM:
 			{
-				DROID *psNearestUnit = getNearestDroid(mouseTileX * TILE_UNITS + TILE_UNITS / 2,
+				DROID *psNearestUnit = getNearestDroid(gameWorld.objects, mouseTileX * TILE_UNITS + TILE_UNITS / 2,
 				                                       mouseTileY * TILE_UNITS + TILE_UNITS / 2, true);
 				/* If so then find the nearest unit! */
 				if (psNearestUnit)	// bloody well should be!!!
@@ -2051,7 +2051,7 @@ void	dealWithLMB()
 
 	if (auto deliveryPoint = findMouseDeliveryPoint())
 	{
-		if (selNumSelected(selectedPlayer) == 0) {
+		if (selNumSelected(gameWorld.objects, selectedPlayer) == 0) {
 			if (bRightClickOrders)
 			{
 				//centre the view on the owning Factory
@@ -2133,7 +2133,7 @@ static void dealWithLMBDClick()
 			if (psDroid->player == selectedPlayer)
 			{
 				// Now selects all of same type on screen
-				selDroidSelection(selectedPlayer, DS_BY_TYPE, DST_ALL_SAME, true);
+				selDroidSelection(gameWorld.objects, selectedPlayer, DS_BY_TYPE, DST_ALL_SAME, true);
 			}
 		}
 		else if (psClickedOn->type == OBJ_STRUCTURE)
@@ -2464,7 +2464,7 @@ static MOUSE_TARGET	itemUnderMouse(BASE_OBJECT **ppObjectUnderMouse)
 
 	/*	Not a droid, so maybe a structure or feature?
 		If still NULL after this then nothing */
-	psNotDroid = getTileOccupier(mouseTileX, mouseTileY);
+	psNotDroid = getTileOccupier(gameWorld.map, mouseTileX, mouseTileY);
 	if (psNotDroid == nullptr)
 	{
 		psNotDroid = getTileBlueprintStructure(mouseTileX, mouseTileY);
@@ -2688,11 +2688,11 @@ static bool	buildingDamaged(STRUCTURE *psStructure)
 }
 
 /*Looks through the list of selected players droids to see if one is a repair droid*/
-bool	repairDroidSelected(UDWORD player)
+bool	repairDroidSelected(const WorldObjectState& objState, UDWORD player)
 {
 	ASSERT_OR_RETURN(false, player < MAX_PLAYERS, "Invalid player (%" PRIu32 ")", player);
 
-	for (const DROID* psCurr : gameWorld.objects.droids[player])
+	for (const DROID* psCurr : objState.droids[player])
 	{
 		if (psCurr->selected && (
 		        psCurr->droidType == DROID_REPAIR ||
@@ -2707,11 +2707,11 @@ bool	repairDroidSelected(UDWORD player)
 }
 
 /*Looks through the list of selected players droids to see if one is a VTOL droid*/
-bool	vtolDroidSelected(UDWORD player)
+bool	vtolDroidSelected(const WorldObjectState& objState, UDWORD player)
 {
 	ASSERT_OR_RETURN(false, player < MAX_PLAYERS, "player: %" PRIu32 "", player);
 
-	for (DROID* psCurr : gameWorld.objects.droids[player])
+	for (DROID* psCurr : objState.droids[player])
 	{
 		if (psCurr->selected && psCurr->isVtol())
 		{
@@ -2726,11 +2726,11 @@ bool	vtolDroidSelected(UDWORD player)
 }
 
 /*Looks through the list of selected players droids to see if any is selected*/
-bool	anyDroidSelected(UDWORD player)
+bool	anyDroidSelected(const WorldObjectState& objState, UDWORD player)
 {
 	ASSERT_OR_RETURN(false, player < MAX_PLAYERS, "Invalid player (%" PRIu32 ")", player);
 
-	for (const DROID* psCurr : gameWorld.objects.droids[player])
+	for (const DROID* psCurr : objState.droids[player])
 	{
 		if (psCurr->selected)
 		{
@@ -2743,11 +2743,11 @@ bool	anyDroidSelected(UDWORD player)
 }
 
 /*Looks through the list of selected players droids to see if one is a cyborg droid*/
-bool cyborgDroidSelected(UDWORD player)
+bool cyborgDroidSelected(const WorldObjectState& objState, UDWORD player)
 {
 	ASSERT_OR_RETURN(false, player < MAX_PLAYERS, "Invalid player (%" PRIu32 ")", player);
 
-	for (const DROID* psCurr : gameWorld.objects.droids[player])
+	for (const DROID* psCurr : objState.droids[player])
 	{
 		if (psCurr->selected && psCurr->isCyborg())
 		{

--- a/src/display.h
+++ b/src/display.h
@@ -195,9 +195,11 @@ extern void shakeStop();
 // reset the input state
 void resetInput();
 
-bool CheckInScrollLimits(const int &xPos, const int &yPos);
-bool CheckInScrollLimitsCamera(SDWORD *xPos, SDWORD *zPos);
-bool CheckScrollLimits();
+struct WorldMapState;
+
+bool CheckInScrollLimits(const WorldMapState& mapState, const int &xPos, const int &yPos);
+bool CheckInScrollLimitsCamera(const WorldMapState& mapState, SDWORD *xPos, SDWORD *zPos);
+bool CheckScrollLimits(const WorldMapState& mapState);
 
 BASE_OBJECT	*mouseTarget();
 

--- a/src/display3d.cpp
+++ b/src/display3d.cpp
@@ -127,7 +127,7 @@ static void	drawDroidCmndNo(DROID *psDroid);
 static void	drawDroidOrder(const DROID *psDroid);
 static void	drawDroidRank(DROID *psDroid);
 static void	drawDroidSensorLock(DROID *psDroid);
-static	int	calcAverageTerrainHeight(int tileX, int tileZ);
+static	int	calcAverageTerrainHeight(WorldMapState& mapState, int tileX, int tileZ);
 static	int	calculateCameraHeight(int height);
 static void	updatePlayerAverageCentreTerrainHeight();
 bool	doWeDrawProximitys();
@@ -359,7 +359,7 @@ struct Blueprint
 	}
 	optional<STRUCTURE> buildBlueprint() const
 	{
-		return ::buildBlueprint(stats, pos, dir, index, state, player);
+		return ::buildBlueprint(gameWorld.map, stats, pos, dir, index, state, player);
 	}
 	void renderBlueprint(const glm::mat4 &viewMatrix, const glm::mat4 &perspectiveViewMatrix) const
 	{
@@ -395,7 +395,7 @@ static const int BLUEPRINT_OPACITY = 120;
 void display3dScreenSizeDidChange(unsigned int oldWidth, unsigned int oldHeight, unsigned int newWidth, unsigned int newHeight)
 {
 	if (psWScreen == nullptr) return;
-	resizeRadar(); // recalculate radar position
+	resizeRadar(gameWorld.map); // recalculate radar position
 }
 
 static void queueDroidPowerBarsRects(DROID *psDroid, bool drawBox, BatchedMultiRectRenderer& batchedMultiRectRenderer, size_t rectGroup);
@@ -796,7 +796,7 @@ static PIELIGHT structureBrightness(STRUCTURE *psStructure)
 
 
 /// Show all droid movement parts by displaying an explosion at every step
-static void showDroidPaths()
+static void showDroidPaths(const GameWorld& world)
 {
 	if ((graphicsTime / 250 % 2) != 0)
 	{
@@ -808,7 +808,7 @@ static void showDroidPaths()
 		return; // no-op for now
 	}
 
-	for (const DROID *psDroid : gameWorld.objects.droids[selectedPlayer])
+	for (const DROID *psDroid : world.objects.droids[selectedPlayer])
 	{
 		if (psDroid->selected && psDroid->sMove.Status != MOVEINACTIVE)
 		{
@@ -817,10 +817,10 @@ static void showDroidPaths()
 			{
 				Vector3i pos;
 
-				ASSERT(worldOnMap(gameWorld.map, psDroid->sMove.asPath[i].x, psDroid->sMove.asPath[i].y), "Path off map!");
+				ASSERT(worldOnMap(world.map, psDroid->sMove.asPath[i].x, psDroid->sMove.asPath[i].y), "Path off map!");
 				pos.x = psDroid->sMove.asPath[i].x;
 				pos.z = psDroid->sMove.asPath[i].y;
-				pos.y = map_Height(gameWorld.map, pos.x, pos.z) + 16;
+				pos.y = map_Height(world.map, pos.x, pos.z) + 16;
 
 				effectGiveAuxVar(80);
 				addEffect(&pos, EFFECT_EXPLOSION, EXPLOSION_TYPE_LASER, false, nullptr, 0);
@@ -1208,7 +1208,7 @@ void draw3DScene()
 
 	if (showPath)
 	{
-		showDroidPaths();
+		showDroidPaths(gameWorld);
 	}
 
 	wzPerfEnd(PERF_MISC);
@@ -1227,7 +1227,7 @@ void	setProximityDraw(bool val)
 }
 /***************************************************************************/
 /// Calculate the average terrain height for the area directly below the tile
-static int calcAverageTerrainHeight(int tileX, int tileZ)
+static int calcAverageTerrainHeight(WorldMapState& mapState, int tileX, int tileZ)
 {
 	int numTilesAveraged = 0;
 
@@ -1240,10 +1240,10 @@ static int calcAverageTerrainHeight(int tileX, int tileZ)
 	{
 		for (int j = -4; j <= 4; j++)
 		{
-			if (tileOnMap(gameWorld.map, tileX + j, tileZ + i))
+			if (tileOnMap(mapState, tileX + j, tileZ + i))
 			{
 				/* Get a pointer to the tile at this location */
-				MAPTILE *psTile = mapTile(gameWorld.map, tileX + j, tileZ + i);
+				MAPTILE *psTile = mapTile(mapState, tileX + j, tileZ + i);
 
 				result += std::max(psTile->height, psTile->waterLevel);
 				numTilesAveraged++;
@@ -1259,7 +1259,7 @@ static int calcAverageTerrainHeight(int tileX, int tileZ)
 	 * Work out the average height.
 	 * We use this information to keep the player camera above the terrain.
 	 */
-	MAPTILE *psTile = mapTile(gameWorld.map, tileX, tileZ);
+	MAPTILE *psTile = mapTile(mapState, tileX, tileZ);
 
 	result /= numTilesAveraged;
 	if (result < psTile->height)
@@ -1272,7 +1272,7 @@ static int calcAverageTerrainHeight(int tileX, int tileZ)
 
 static void updatePlayerAverageCentreTerrainHeight()
 {
-	averageCentreTerrainHeight = calcAverageTerrainHeight(playerXTile, playerZTile);
+	averageCentreTerrainHeight = calcAverageTerrainHeight(gameWorld.map, playerXTile, playerZTile);
 }
 
 inline bool quadIntersectsWithScreen(const QUAD & quad)
@@ -1443,8 +1443,8 @@ static void drawTiles(iView *player, LightingData& lightData, LightMap& lightmap
 	/* This is done here as effects can light the terrain - pause mode problems though */
 	wzPerfBegin(PERF_EFFECTS, "3D scene - effects");
 	processEffects(perspectiveViewMatrix, lightData);
-	atmosUpdateSystem();
-	avUpdateTiles();
+	atmosUpdateSystem(gameWorld.map);
+	avUpdateTiles(gameWorld.map);
 	wzPerfEnd(PERF_EFFECTS);
 
 	// The lightmap need to be ready at this point
@@ -1454,7 +1454,7 @@ static void drawTiles(iView *player, LightingData& lightData, LightMap& lightmap
 	}
 
 	// prepare terrain for drawing
-	perFrameTerrainUpdates(lightmap);
+	perFrameTerrainUpdates(gameWorld.map, lightmap);
 
 	// and prepare for rendering the models
 	wzPerfBegin(PERF_MODEL_INIT, "Draw 3D scene - model init");
@@ -1602,7 +1602,7 @@ bool init3DView()
 	playerPos.r.y = 0; // rotation
 	playerPos.r.x = DEG(360 + INITIAL_STARTING_PITCH); // angle
 
-	if (!initTerrain())
+	if (!initTerrain(gameWorld.map))
 	{
 		return false;
 	}
@@ -2469,9 +2469,9 @@ Vector2i getPlayerPos()
 }
 
 /// Set the player position
-void setPlayerPos(SDWORD x, SDWORD y)
+void setPlayerPos(const WorldMapState& mapState, SDWORD x, SDWORD y)
 {
-	ASSERT(x >= 0 && x < world_coord(gameWorld.map.width) && y >= 0 && y < world_coord(gameWorld.map.height), "Position off map");
+	ASSERT(x >= 0 && x < world_coord(mapState.width) && y >= 0 && y < world_coord(mapState.height), "Position off map");
 	playerPos.p.x = x;
 	playerPos.p.z = y;
 	playerPos.r.z = 0;
@@ -4065,9 +4065,9 @@ static int calculateCameraHeight(int _mapHeight)
 	return static_cast<int>(std::ceil(static_cast<float>(_mapHeight) / static_cast<float>(HEIGHT_TRACK_INCREMENTS))) * HEIGHT_TRACK_INCREMENTS + CAMERA_PIVOT_HEIGHT;
 }
 
-int calculateCameraHeightAt(int tileX, int tileY)
+int calculateCameraHeightAt(WorldMapState& mapState, int tileX, int tileY)
 {
-	return calculateCameraHeight(calcAverageTerrainHeight(tileX, tileY));
+	return calculateCameraHeight(calcAverageTerrainHeight(mapState, tileX, tileY));
 }
 
 /// Smoothly adjust player height to match the desired height

--- a/src/display3d.h
+++ b/src/display3d.h
@@ -30,6 +30,8 @@
 
 #define HEIGHT_TRACK_INCREMENTS (50)
 
+struct WorldMapState;
+
 /*!
  * Special tile types
  */
@@ -72,7 +74,7 @@ bool radarVisible();
 extern bool rangeOnScreen; // Added to get sensor/gun range on screen.  -Q 5-10-05
 void setViewPos(UDWORD x, UDWORD y, bool Pan);
 Vector2i    getPlayerPos();
-void setPlayerPos(SDWORD x, SDWORD y);
+void setPlayerPos(const WorldMapState& mapState, SDWORD x, SDWORD y);
 void disp3d_setView(iView *newView);
 void disp3d_oldView(); // for save games <= 10
 void disp3d_getView(iView *newView);
@@ -141,6 +143,6 @@ extern bool tuiTargetOrigin;
 /// Draws using the animation systems. Usually want to use in a while loop to get all model levels.
 bool drawShape(const iIMDShape *strImd, UDWORD timeAnimationStarted, int colour, PIELIGHT buildingBrightness, int pieFlag, int pieFlagData, const glm::mat4& modelMatrix, const glm::mat4& viewMatrix, float stretchDepth = 0.f);
 
-int calculateCameraHeightAt(int tileX, int tileY);
+int calculateCameraHeightAt(WorldMapState& mapState, int tileX, int tileY);
 
 #endif // __INCLUDED_SRC_DISPLAY3D_H__

--- a/src/droid.cpp
+++ b/src/droid.cpp
@@ -321,7 +321,7 @@ int32_t droidDamage(DROID *psDroid, PROJECTILE *psProjectile, unsigned damage, W
 		// reset the attack level
 		if (secondaryGetState(psDroid, DSO_ATTACK_LEVEL) == DSS_ALEV_ATTACKED)
 		{
-			secondarySetState(psDroid, DSO_ATTACK_LEVEL, DSS_ALEV_ALWAYS);
+			secondarySetState(psDroid, gameWorld.objects, DSO_ATTACK_LEVEL, DSS_ALEV_ALWAYS);
 		}
 		// Now check for auto return on droid's secondary orders (i.e. return on medium/heavy damage)
 		secondaryCheckDamageLevel(psDroid);
@@ -882,7 +882,7 @@ void droidUpdate(DROID *psDroid)
 
 	if (psDroid->flags.test(OBJECT_FLAG_DIRTY))
 	{
-		visTilesUpdate(psDroid);
+		visTilesUpdate(psDroid, gameWorld.map);
 		droidBodyUpgrade(psDroid);
 		psDroid->flags.set(OBJECT_FLAG_DIRTY, false);
 	}
@@ -1102,7 +1102,7 @@ static bool droidNextToStruct(DROID *psDroid, STRUCTURE *psStruct)
 		for (int x = minX; x <= maxX; ++x)
 		{
 			if (TileHasStructure(mapTile(gameWorld.map, x, y)) &&
-				getTileStructure(x, y) == psStruct)
+				getTileStructure(gameWorld.map, x, y) == psStruct)
 			{
 				return true;
 			}
@@ -1177,7 +1177,7 @@ DroidStartBuild droidStartBuild(DROID *psDroid)
 		}
 		//ok to build
 		const auto id = generateSynchronisedObjectId();
-		psStruct = buildStructureDir(psStructStat, psDroid->order.pos.x, psDroid->order.pos.y, psDroid->order.direction, psDroid->player, false, id);
+		psStruct = buildStructureDir(gameWorld, psStructStat, psDroid->order.pos.x, psDroid->order.pos.y, psDroid->order.direction, psDroid->player, false, id);
 		if (!psStruct)
 		{
 			cancelBuild(psDroid);
@@ -1565,7 +1565,7 @@ bool droidUpdateDroidRepair(DROID *psRepairDroid)
 		// if psDroidToRepair has a commander, commander will call him back anyway
 		// if no commanders, just DORDER_GUARD the repair turret
 		orderDroidObj(psDroidToRepair, DORDER_GUARD, psRepairDroid, ModeImmediate);
-		secondarySetState(psDroidToRepair, DSO_RETURN_TO_LOC, DSS_NONE);
+		secondarySetState(psDroidToRepair, gameWorld.objects, DSO_RETURN_TO_LOC, DSS_NONE);
 		psDroidToRepair->order.psObj = nullptr;
 	}
 	return needMoreRepair;
@@ -1860,10 +1860,10 @@ UDWORD calcDroidPower(const DROID *psDroid)
 }
 
 //Builds an instance of a Droid - the x/y passed in are in world coords.
-DROID *reallyBuildDroid(const DROID_TEMPLATE *pTemplate, Position pos, UDWORD player, bool onMission, Rotation rot, uint32_t id)
+DROID *reallyBuildDroid(GameWorld& world, const DROID_TEMPLATE *pTemplate, Position pos, UDWORD player, bool onMission, Rotation rot, uint32_t id)
 {
 	// Don't use this assertion in single player, since droids can finish building while on an away mission
-	ASSERT(!bMultiPlayer || worldOnMap(gameWorld.map, pos.x, pos.y), "the build locations are not on the map");
+	ASSERT(!bMultiPlayer || worldOnMap(world.map, pos.x, pos.y), "the build locations are not on the map");
 
 	ASSERT_OR_RETURN(nullptr, player < MAX_PLAYERS, "Invalid player: %" PRIu32 "", player);
 
@@ -1879,7 +1879,7 @@ DROID *reallyBuildDroid(const DROID_TEMPLATE *pTemplate, Position pos, UDWORD pl
 	if (!onMission)
 	{
 		//set droid height
-		droid.pos.z = map_Height(gameWorld.map, droid.pos.x, droid.pos.y);
+		droid.pos.z = map_Height(world.map, droid.pos.x, droid.pos.y);
 	}
 
 	if (droid.isTransporter() || droid.droidType == DROID_COMMAND)
@@ -1933,9 +1933,9 @@ DROID *reallyBuildDroid(const DROID_TEMPLATE *pTemplate, Position pos, UDWORD pl
 		/* People always stand upright */
 		if (droid.droidType != DROID_PERSON)
 		{
-			updateDroidOrientation(&droid);
+			updateDroidOrientation(&droid, world.map);
 		}
-		visTilesUpdate(&droid);
+		visTilesUpdate(&droid, world.map);
 	}
 
 	/* transporter-specific stuff */
@@ -1951,7 +1951,7 @@ DROID *reallyBuildDroid(const DROID_TEMPLATE *pTemplate, Position pos, UDWORD pl
 		droid.pos.z += TRANSPORTER_HOVER_HEIGHT;
 
 		/* reset halt secondary order from guard to hold */
-		secondarySetState(&droid, DSO_HALTTYPE, DSS_HALT_HOLD);
+		secondarySetState(&droid, world.objects, DSO_HALTTYPE, DSS_HALT_HOLD);
 	}
 
 	if (player == selectedPlayer)
@@ -1968,13 +1968,13 @@ DROID *reallyBuildDroid(const DROID_TEMPLATE *pTemplate, Position pos, UDWORD pl
 	return &droid;
 }
 
-DROID *reallyBuildDroid(const DROID_TEMPLATE *pTemplate, Position pos, UDWORD player, bool onMission, Rotation rot)
+DROID *reallyBuildDroid(GameWorld& world, const DROID_TEMPLATE *pTemplate, Position pos, UDWORD player, bool onMission, Rotation rot)
 {
 	const auto id = generateSynchronisedObjectId();
-	return reallyBuildDroid(pTemplate, pos, player, onMission, rot, id);
+	return reallyBuildDroid(world, pTemplate, pos, player, onMission, rot, id);
 }
 
-DROID *buildDroid(DROID_TEMPLATE *pTemplate, UDWORD x, UDWORD y, UDWORD player, bool onMission, const INITIAL_DROID_ORDERS *initialOrders, Rotation rot)
+DROID *buildDroid(GameWorld& world, DROID_TEMPLATE *pTemplate, UDWORD x, UDWORD y, UDWORD player, bool onMission, const INITIAL_DROID_ORDERS *initialOrders, Rotation rot)
 {
 	ASSERT_OR_RETURN(nullptr, player < MAX_PLAYERS, "invalid player?: %" PRIu32 "", player);
 	// ajl. droid will be created, so inform others
@@ -1986,7 +1986,7 @@ DROID *buildDroid(DROID_TEMPLATE *pTemplate, UDWORD x, UDWORD y, UDWORD player, 
 	}
 	else
 	{
-		return reallyBuildDroid(pTemplate, Position(x, y, 0), player, onMission, rot);
+		return reallyBuildDroid(world, pTemplate, Position(x, y, 0), player, onMission, rot);
 	}
 }
 
@@ -2144,13 +2144,13 @@ void assignObjectToGroup(UDWORD	playerNumber, UDWORD groupNumber, bool clearGrou
 }
 
 
-void removeObjectFromGroup(UDWORD playerNumber)
+void removeObjectFromGroup(WorldObjectState& objState, UDWORD playerNumber)
 {
 	unsigned removedCount = 0;
 
 	ASSERT_OR_RETURN(, playerNumber < MAX_PLAYERS, "Invalid player: %" PRIu32 "", playerNumber);
 
-	for (STRUCTURE *psStruct : gameWorld.objects.structures[playerNumber])
+	for (STRUCTURE *psStruct : objState.structures[playerNumber])
 	{
 		if (psStruct->selected && psStruct->isFactory())
 		{
@@ -2159,7 +2159,7 @@ void removeObjectFromGroup(UDWORD playerNumber)
 		}
 	}
 
-	for (DROID* psDroid : gameWorld.objects.droids[playerNumber])
+	for (DROID* psDroid : objState.droids[playerNumber])
 	{
 		if (psDroid->selected)
 		{
@@ -2251,7 +2251,7 @@ bool activateNoGroup(UDWORD playerNumber, const SELECTIONTYPE selectionType, con
 
 	ASSERT_OR_RETURN(false, playerNumber < MAX_PLAYERS, "Invalid player: %" PRIu32 "", playerNumber);
 
-	selectionCount = selDroidSelection(selectedPlayer, dselectionClass, dselectionType, dbOnScreen);
+	selectionCount = selDroidSelection(gameWorld.objects, selectedPlayer, dselectionClass, dselectionType, dbOnScreen);
 	for (DROID* psDroid : gameWorld.objects.droids[playerNumber])
 	{
 		/* Wipe out the ones in the wrong group */
@@ -2320,7 +2320,7 @@ bool activateGroup(UDWORD playerNumber, UDWORD groupNumber)
 
 void	groupConsoleInformOfSelection(UDWORD groupNumber)
 {
-	unsigned int num_selected = selNumSelected(selectedPlayer);
+	unsigned int num_selected = selNumSelected(gameWorld.objects, selectedPlayer);
 
 	CONPRINTF(ngettext("Group %u selected - %u Unit", "Group %u selected - %u Units", num_selected), groupNumber, num_selected);
 }
@@ -2329,7 +2329,7 @@ void	groupConsoleInformOfCreation(UDWORD groupNumber)
 {
 	if (!getWarCamStatus())
 	{
-		unsigned int num_selected = selNumSelected(selectedPlayer);
+		unsigned int num_selected = selNumSelected(gameWorld.objects, selectedPlayer);
 
 		CONPRINTF(ngettext("%u unit assigned to Group %u", "%u units assigned to Group %u", num_selected), num_selected, groupNumber);
 	}
@@ -2340,7 +2340,7 @@ void 	groupConsoleInformOfRemoval()
 {
 	if (!getWarCamStatus())
 	{
-		unsigned int num_selected = selNumSelected(selectedPlayer);
+		unsigned int num_selected = selNumSelected(gameWorld.objects, selectedPlayer);
 
 		CONPRINTF(ngettext("%u units removed from their Group", "%u units removed from their Group", num_selected), num_selected);
 	}
@@ -2348,7 +2348,7 @@ void 	groupConsoleInformOfRemoval()
 
 void	groupConsoleInformOfCentering(UDWORD groupNumber)
 {
-	unsigned int num_selected = selNumSelected(selectedPlayer);
+	unsigned int num_selected = selNumSelected(gameWorld.objects, selectedPlayer);
 
 	if (!getWarCamStatus())
 	{
@@ -2637,14 +2637,14 @@ void droidSetName(DROID *psDroid, const char *pName)
 
 // ////////////////////////////////////////////////////////////////////////////
 // returns true when no droid on x,y square.
-bool noDroid(UDWORD x, UDWORD y)
+bool noDroid(const GameWorld& world, UDWORD x, UDWORD y)
 {
 	unsigned int i;
 
 	// check each droid list
 	for (i = 0; i < MAX_PLAYERS; ++i)
 	{
-		for (const DROID* psDroid : gameWorld.objects.droids[i])
+		for (const DROID* psDroid : world.objects.droids[i])
 		{
 			if (map_coord(psDroid->pos.x) == x
 				&& map_coord(psDroid->pos.y) == y)
@@ -2658,14 +2658,14 @@ bool noDroid(UDWORD x, UDWORD y)
 
 // ////////////////////////////////////////////////////////////////////////////
 // returns true when at most one droid on x,y square.
-static bool oneDroidMax(UDWORD x, UDWORD y)
+static bool oneDroidMax(const GameWorld& world, UDWORD x, UDWORD y)
 {
 	UDWORD i;
 	bool bFound = false;
 	// check each droid list
 	for (i = 0; i < MAX_PLAYERS; i++)
 	{
-		for (const DROID* pD : gameWorld.objects.droids[i])
+		for (const DROID* pD : world.objects.droids[i])
 		{
 			if (map_coord(pD->pos.x) == x
 				&& map_coord(pD->pos.y) == y)
@@ -2684,20 +2684,20 @@ static bool oneDroidMax(UDWORD x, UDWORD y)
 
 // ////////////////////////////////////////////////////////////////////////////
 // returns true if it's a sensible place to put that droid.
-static bool sensiblePlace(SDWORD x, SDWORD y, PROPULSION_TYPE propulsion)
+static bool sensiblePlace(const WorldMapState& mapState, SDWORD x, SDWORD y, PROPULSION_TYPE propulsion)
 {
 	// not too near the edges.
-	if ((x < TOO_NEAR_EDGE) || (x > (SDWORD)(gameWorld.map.width - TOO_NEAR_EDGE)))
+	if ((x < TOO_NEAR_EDGE) || (x > (SDWORD)(mapState.width - TOO_NEAR_EDGE)))
 	{
 		return false;
 	}
-	if ((y < TOO_NEAR_EDGE) || (y > (SDWORD)(gameWorld.map.height - TOO_NEAR_EDGE)))
+	if ((y < TOO_NEAR_EDGE) || (y > (SDWORD)(mapState.height - TOO_NEAR_EDGE)))
 	{
 		return false;
 	}
 
 	// not on a blocking tile.
-	if (fpathBlockingTile(x, y, propulsion))
+	if (fpathBlockingTile(mapState, x, y, propulsion))
 	{
 		return false;
 	}
@@ -2707,31 +2707,31 @@ static bool sensiblePlace(SDWORD x, SDWORD y, PROPULSION_TYPE propulsion)
 
 // ------------------------------------------------------------------------------------
 // Should stop things being placed in inaccessible areas? Assume wheeled propulsion.
-bool	zonedPAT(UDWORD x, UDWORD y)
+bool	zonedPAT(const GameWorld& world, UDWORD x, UDWORD y)
 {
-	return sensiblePlace(x, y, PROPULSION_TYPE_WHEELED) && noDroid(x, y);
+	return sensiblePlace(world.map, x, y, PROPULSION_TYPE_WHEELED) && noDroid(world, x, y);
 }
 
-static bool canFitDroid(UDWORD x, UDWORD y)
+static bool canFitDroid(const GameWorld& world, UDWORD x, UDWORD y)
 {
-	return sensiblePlace(x, y, PROPULSION_TYPE_WHEELED) && oneDroidMax(x, y);
+	return sensiblePlace(world.map, x, y, PROPULSION_TYPE_WHEELED) && oneDroidMax(world, x, y);
 }
 
 /// find a tile for which the function will return true
-bool	pickATileGen(UDWORD *x, UDWORD *y, UBYTE numIterations, bool (*function)(UDWORD x, UDWORD y))
+bool	pickATileGen(GameWorld& world, UDWORD *x, UDWORD *y, UBYTE numIterations, pickATileFn function)
 {
-	return pickATileGenThreat(x, y, numIterations, -1, -1, function);
+	return pickATileGenThreat(world, x, y, numIterations, -1, -1, function);
 }
 
-bool pickATileGen(Vector2i *pos, unsigned numIterations, bool (*function)(UDWORD x, UDWORD y))
+bool pickATileGen(GameWorld& world, Vector2i *pos, unsigned numIterations, pickATileFn function)
 {
 	UDWORD x = pos->x, y = pos->y;
-	bool ret = pickATileGenThreat(&x, &y, numIterations, -1, -1, function);
+	bool ret = pickATileGenThreat(world, &x, &y, numIterations, -1, -1, function);
 	*pos = Vector2i(x, y);
 	return ret;
 }
 
-static bool ThreatInRange(SDWORD player, SDWORD range, SDWORD rangeX, SDWORD rangeY, bool bVTOLs)
+static bool ThreatInRange(const WorldObjectState& objState, SDWORD player, SDWORD range, SDWORD rangeX, SDWORD rangeY, bool bVTOLs)
 {
 	UDWORD				i, structType;
 
@@ -2746,7 +2746,7 @@ static bool ThreatInRange(SDWORD player, SDWORD range, SDWORD rangeX, SDWORD ran
 		}
 
 		//check structures
-		for (const STRUCTURE* psStruct : gameWorld.objects.structures[i])
+		for (const STRUCTURE* psStruct : objState.structures[i])
 		{
 			if (psStruct->visible[player] || psStruct->born == 2)	// if can see it or started there
 			{
@@ -2776,7 +2776,7 @@ static bool ThreatInRange(SDWORD player, SDWORD range, SDWORD rangeX, SDWORD ran
 		}
 
 		//check droids
-		for (const DROID* psDroid : gameWorld.objects.droids[i])
+		for (const DROID* psDroid : objState.droids[i])
 		{
 			if (psDroid->visible[player])		//can see this droid?
 			{
@@ -2804,18 +2804,18 @@ static bool ThreatInRange(SDWORD player, SDWORD range, SDWORD rangeX, SDWORD ran
 }
 
 /// find a tile for which the passed function will return true without any threat in the specified range
-bool	pickATileGenThreat(UDWORD *x, UDWORD *y, UBYTE numIterations, SDWORD threatRange,
-						   SDWORD player, bool (*function)(UDWORD x, UDWORD y))
+bool	pickATileGenThreat(GameWorld& world, UDWORD *x, UDWORD *y, UBYTE numIterations, SDWORD threatRange,
+						   SDWORD player, pickATileFn function)
 {
 	SDWORD		i, j;
 	SDWORD		startX, endX, startY, endY;
 	UDWORD		passes;
 	Vector3i	origin(world_coord(*x), world_coord(*y), 0);
 
-	ASSERT_OR_RETURN(false, *x < gameWorld.map.width, "x coordinate is off-map for pickATileGen");
-	ASSERT_OR_RETURN(false, *y < gameWorld.map.height, "y coordinate is off-map for pickATileGen");
+	ASSERT_OR_RETURN(false, *x < world.map.width, "x coordinate is off-map for pickATileGen");
+	ASSERT_OR_RETURN(false, *y < world.map.height, "y coordinate is off-map for pickATileGen");
 
-	if (function(*x, *y) && ((threatRange <= 0) || (!ThreatInRange(player, threatRange, *x, *y, false))))	//TODO: vtol check really not needed?
+	if (function(world, *x, *y) && ((threatRange <= 0) || (!ThreatInRange(world.objects, player, threatRange, *x, *y, false))))	//TODO: vtol check really not needed?
 	{
 		return (true);
 	}
@@ -2837,9 +2837,9 @@ bool	pickATileGenThreat(UDWORD *x, UDWORD *y, UBYTE numIterations, SDWORD threat
 					Vector3i newPos(world_coord(i), world_coord(j), 0);
 
 					/* Good enough? */
-					if (function(i, j)
-						&& fpathCheck(origin, newPos, PROPULSION_TYPE_WHEELED)
-						&& ((threatRange <= 0) || (!ThreatInRange(player, threatRange, world_coord(i), world_coord(j), false))))
+					if (function(world, i, j)
+						&& fpathCheck(world.map, origin, newPos, PROPULSION_TYPE_WHEELED)
+						&& ((threatRange <= 0) || (!ThreatInRange(world.objects, player, threatRange, world_coord(i), world_coord(j), false))))
 					{
 						/* Set exit conditions and get out NOW */
 						*x = i;	*y = j;
@@ -2857,9 +2857,9 @@ bool	pickATileGenThreat(UDWORD *x, UDWORD *y, UBYTE numIterations, SDWORD threat
 }
 
 /// find a tile for a wheeled droid with only one other droid present
-PICKTILE pickHalfATile(UDWORD *x, UDWORD *y, UBYTE numIterations)
+PICKTILE pickHalfATile(GameWorld& world, UDWORD *x, UDWORD *y, UBYTE numIterations)
 {
-	return pickATileGen(x, y, numIterations, canFitDroid) ? FREE_TILE : NO_FREE_TILE;
+	return pickATileGen(world, x, y, numIterations, canFitDroid) ? FREE_TILE : NO_FREE_TILE;
 }
 
 /* Looks through the players list of droids to see if any of them are
@@ -2959,7 +2959,7 @@ void setUpBuildModule(DROID *psDroid)
 	Vector2i tile = map_coord(psDroid->order.pos);
 
 	//check not another Truck started
-	STRUCTURE *psStruct = getTileStructure(tile.x, tile.y);
+	STRUCTURE *psStruct = getTileStructure(gameWorld.map, tile.x, tile.y);
 	if (psStruct)
 	{
 		// if a droid is currently building, or building is in progress of being built/upgraded the droid's order should be DORDER_HELPBUILD
@@ -3530,7 +3530,7 @@ DROID *giftSingleDroid(DROID *psD, UDWORD to, bool electronic, Vector2i pos)
 		{
 			unsigned int pickX = map_coord(pos.x);
 			unsigned int pickY = map_coord(pos.y);
-			if (pickATileGen(&pickX, &pickY, LOOK_FOR_EMPTY_TILE, zonedPAT) != NO_FREE_TILE)
+			if (pickATileGen(gameWorld, &pickX, &pickY, LOOK_FOR_EMPTY_TILE, zonedPAT) != NO_FREE_TILE)
 			{
 				newPos = Position(world_coord(pickX), world_coord(pickY), 0);
 			}
@@ -3540,7 +3540,7 @@ DROID *giftSingleDroid(DROID *psD, UDWORD to, bool electronic, Vector2i pos)
 			}
 		}
 		// create a new droid
-		psNewDroid = reallyBuildDroid(&sTemplate, newPos, to, false, psD->rot);
+		psNewDroid = reallyBuildDroid(gameWorld, &sTemplate, newPos, to, false, psD->rot);
 		ASSERT_OR_RETURN(nullptr, psNewDroid, "Unable to build unit");
 
 		addDroid(psNewDroid, gameWorld.objects.droids);
@@ -3552,7 +3552,7 @@ DROID *giftSingleDroid(DROID *psD, UDWORD to, bool electronic, Vector2i pos)
 
 		if (!(psNewDroid->droidType == DROID_PERSON || psNewDroid->isCyborg() || psNewDroid->isTransporter()))
 		{
-			updateDroidOrientation(psNewDroid);
+			updateDroidOrientation(psNewDroid, gameWorld.map);
 		}
 
 		triggerEventObjectTransfer(psNewDroid, psD->player);
@@ -3589,7 +3589,7 @@ DROID *giftSingleDroid(DROID *psD, UDWORD to, bool electronic, Vector2i pos)
 		}
 	}
 
-	visRemoveVisibility((BASE_OBJECT *)psD);
+	visRemoveVisibility((BASE_OBJECT *)psD, gameWorld.map);
 	psD->selected = false;
 
 	adjustDroidCount(psD, -1);
@@ -3632,7 +3632,7 @@ DROID *giftSingleDroid(DROID *psD, UDWORD to, bool electronic, Vector2i pos)
 	}
 
 	// Update visibility
-	visTilesUpdate((BASE_OBJECT*)psD);
+	visTilesUpdate((BASE_OBJECT*)psD, gameWorld.map);
 
 	// check through the players, and our allies, list of droids to see if any are targetting it
 	for (unsigned int i = 0; i < MAX_PLAYERS; ++i)
@@ -3885,7 +3885,7 @@ void droidSetPosition(DROID *psDroid, int x, int y)
 	psDroid->pos.y = y;
 	psDroid->pos.z = map_Height(gameWorld.map, psDroid->pos.x, psDroid->pos.y);
 	initDroidMovement(psDroid);
-	visTilesUpdate((BASE_OBJECT *)psDroid);
+	visTilesUpdate((BASE_OBJECT *)psDroid, gameWorld.map);
 }
 
 /** Check validity of a droid. Crash hard if it fails. */
@@ -3914,7 +3914,7 @@ int droidSqDist(const DROID *psDroid, const BASE_OBJECT *psObj)
 {
 	PROPULSION_STATS *psPropStats = psDroid->getPropulsionStats();
 
-	if (!fpathCheck(psDroid->pos, psObj->pos, psPropStats->propulsionType))
+	if (!fpathCheck(gameWorld.map, psDroid->pos, psObj->pos, psPropStats->propulsionType))
 	{
 		return -1;
 	}

--- a/src/droid.h
+++ b/src/droid.h
@@ -78,12 +78,16 @@ struct INITIAL_DROID_ORDERS
 	int32_t moveToY;
 	uint32_t factoryId;
 };
+
+struct GameWorld;
+struct WorldObjectState;
+
 /*Builds an instance of a Structure - the x/y passed in are in world coords.*/
 /// Sends a GAME_DROID message if bMultiMessages is true, or actually creates it if false. Only uses initialOrders if sending a GAME_DROID message.
-DROID *buildDroid(DROID_TEMPLATE *pTemplate, UDWORD x, UDWORD y, UDWORD player, bool onMission, const INITIAL_DROID_ORDERS *initialOrders, Rotation rot = Rotation());
+DROID *buildDroid(GameWorld& world, DROID_TEMPLATE *pTemplate, UDWORD x, UDWORD y, UDWORD player, bool onMission, const INITIAL_DROID_ORDERS *initialOrders, Rotation rot = Rotation());
 /// Creates a droid locally, instead of sending a message, even if the bMultiMessages HACK is set to true.
-DROID *reallyBuildDroid(const DROID_TEMPLATE *pTemplate, Position pos, UDWORD player, bool onMission, Rotation rot = Rotation());
-DROID *reallyBuildDroid(const DROID_TEMPLATE *pTemplate, Position pos, UDWORD player, bool onMission, Rotation rot, uint32_t id);
+DROID *reallyBuildDroid(GameWorld& world, const DROID_TEMPLATE *pTemplate, Position pos, UDWORD player, bool onMission, Rotation rot = Rotation());
+DROID *reallyBuildDroid(GameWorld& world, const DROID_TEMPLATE *pTemplate, Position pos, UDWORD player, bool onMission, Rotation rot, uint32_t id);
 
 /* Set the asBits in a DROID structure given it's template. */
 void droidSetBits(const DROID_TEMPLATE *pTemplate, DROID *psDroid);
@@ -175,7 +179,7 @@ DROID_TYPE droidType(const DROID *psDroid);
 DROID_TYPE droidTemplateType(const DROID_TEMPLATE *psTemplate);
 
 void assignObjectToGroup(UDWORD	playerNumber, UDWORD groupNumber, bool clearGroup);
-void removeObjectFromGroup(UDWORD playerNumber);
+void removeObjectFromGroup(WorldObjectState& objState, UDWORD playerNumber);
 
 bool activateNoGroup(UDWORD playerNumber, const SELECTIONTYPE selectionType, const SELECTION_CLASS selectionClass, const bool bOnScreen);
 
@@ -204,15 +208,20 @@ const char *droidGetName(const DROID *psDroid);
 // Set a droid's name.
 void droidSetName(DROID *psDroid, const char *pName);
 
+struct GameWorld;
+
 // returns true when no droid on x,y square.
-bool noDroid(UDWORD x, UDWORD y);				// true if no droid at x,y
+bool noDroid(const GameWorld& world, UDWORD x, UDWORD y);				// true if no droid at x,y
+
+using pickATileFn = bool (*)(const GameWorld& world, UDWORD x, UDWORD y);
+
 // returns an x/y coord to place a droid
-PICKTILE pickHalfATile(UDWORD *x, UDWORD *y, UBYTE numIterations);
-bool zonedPAT(UDWORD x, UDWORD y);
-bool pickATileGen(UDWORD *x, UDWORD *y, UBYTE numIterations, bool (*function)(UDWORD x, UDWORD y));
-bool pickATileGen(Vector2i *pos, unsigned numIterations, bool (*function)(UDWORD x, UDWORD y));
-bool pickATileGenThreat(UDWORD *x, UDWORD *y, UBYTE numIterations, SDWORD threatRange,
-                                   SDWORD player, bool (*function)(UDWORD x, UDWORD y));
+PICKTILE pickHalfATile(GameWorld& world, UDWORD *x, UDWORD *y, UBYTE numIterations);
+bool zonedPAT(const GameWorld& world, UDWORD x, UDWORD y);
+bool pickATileGen(GameWorld& world, UDWORD *x, UDWORD *y, UBYTE numIterations, pickATileFn function);
+bool pickATileGen(GameWorld& world, Vector2i *pos, unsigned numIterations, pickATileFn function);
+bool pickATileGenThreat(GameWorld& world, UDWORD *x, UDWORD *y, UBYTE numIterations, SDWORD threatRange,
+                        SDWORD player, pickATileFn function);
 
 
 //initialises the droid movement model

--- a/src/edit3d.cpp
+++ b/src/edit3d.cpp
@@ -55,38 +55,38 @@ void Edit3DInitVars()
 }
 
 /* Raises a tile by a #defined height */
-void raiseTile(int tile3dX, int tile3dY)
+void raiseTile(WorldMapState& mapState, int tile3dX, int tile3dY)
 {
 	int i, j;
 
-	if (tile3dX < 0 || tile3dX > gameWorld.map.width - 1 || tile3dY < 0 || tile3dY > gameWorld.map.height - 1)
+	if (tile3dX < 0 || tile3dX > mapState.width - 1 || tile3dY < 0 || tile3dY > mapState.height - 1)
 	{
 		return;
 	}
-	for (i = tile3dX; i <= MIN(gameWorld.map.width - 1, tile3dX + brushSize); i++)
+	for (i = tile3dX; i <= MIN(mapState.width - 1, tile3dX + brushSize); i++)
 	{
-		for (j = tile3dY; j <= MIN(gameWorld.map.height - 1, tile3dY + brushSize); j++)
+		for (j = tile3dY; j <= MIN(mapState.height - 1, tile3dY + brushSize); j++)
 		{
-			adjustTileHeight(mapTile(gameWorld.map, i, j), TILE_RAISE);
+			adjustTileHeight(mapTile(mapState, i, j), TILE_RAISE);
 			markTileDirty(i, j);
 		}
 	}
 }
 
 /* Lowers a tile by a #defined height */
-void lowerTile(int tile3dX, int tile3dY)
+void lowerTile(WorldMapState& mapState, int tile3dX, int tile3dY)
 {
 	int i, j;
 
-	if (tile3dX < 0 || tile3dX > gameWorld.map.width - 1 || tile3dY < 0 || tile3dY > gameWorld.map.height - 1)
+	if (tile3dX < 0 || tile3dX > mapState.width - 1 || tile3dY < 0 || tile3dY > mapState.height - 1)
 	{
 		return;
 	}
-	for (i = tile3dX; i <= MIN(gameWorld.map.width - 1, tile3dX + brushSize); i++)
+	for (i = tile3dX; i <= MIN(mapState.width - 1, tile3dX + brushSize); i++)
 	{
-		for (j = tile3dY; j <= MIN(gameWorld.map.height - 1, tile3dY + brushSize); j++)
+		for (j = tile3dY; j <= MIN(mapState.height - 1, tile3dY + brushSize); j++)
 		{
-			adjustTileHeight(mapTile(gameWorld.map, i, j), TILE_LOWER);
+			adjustTileHeight(mapTile(mapState, i, j), TILE_LOWER);
 			markTileDirty(i, j);
 		}
 	}
@@ -176,12 +176,12 @@ bool process3DBuilding()
 			auto lb = calcLineBuild(static_cast<STRUCTURE_STATS *>(sBuildDetails.psStats), getBuildingDirection(), wallDrag.pos, wallDrag.pos2);
 			for (int i = 0; i < lb.count && isValid; ++i)
 			{
-				isValid &= validLocation(sBuildDetails.psStats, lb[i], getBuildingDirection(), selectedPlayer, true);
+				isValid &= validLocation(gameWorld, sBuildDetails.psStats, lb[i], getBuildingDirection(), selectedPlayer, true);
 			}
 		}
 		else
 		{
-			isValid = validLocation(sBuildDetails.psStats, bv, getBuildingDirection(), selectedPlayer, true);
+			isValid = validLocation(gameWorld, sBuildDetails.psStats, bv, getBuildingDirection(), selectedPlayer, true);
 		}
 
 		buildState = isValid? BUILD3D_VALID : BUILD3D_POS;

--- a/src/edit3d.h
+++ b/src/edit3d.h
@@ -26,6 +26,8 @@
 #define TILE_RAISE	1
 #define TILE_LOWER	-1
 
+struct WorldMapState;
+
 typedef void (*BUILDCALLBACK)(UDWORD xPos, UDWORD yPos, void *UserData);
 
 void Edit3DInitVars();
@@ -38,8 +40,8 @@ void incrementBuildingDirection(uint16_t amount);
 uint16_t getBuildingDirection();
 
 void adjustTileHeight(MAPTILE *psTile, SDWORD adjust);
-void raiseTile(int tile3dX, int tile3dY);
-void lowerTile(int tile3dX, int tile3dY);
+void raiseTile(WorldMapState& mapState, int tile3dX, int tile3dY);
+void lowerTile(WorldMapState& mapState, int tile3dX, int tile3dY);
 
 enum BuildState
 {

--- a/src/effects.cpp
+++ b/src/effects.cpp
@@ -2386,7 +2386,7 @@ bool writeFXData(const char *fileName)
 }
 
 /** This will read in the effects data */
-bool readFXData(const char *fileName)
+bool readFXData(const char *fileName, WorldMapState& mapState)
 {
 	// Clear out anything that's there already!
 	initEffectsSystem();
@@ -2439,7 +2439,7 @@ bool readFXData(const char *fileName)
 			// Sanity check - don't allow a negative time to wrap to a huge positive unsigned value.
 			if (timeLeftToRun > 0)
 			{
-				tileSetFire(gameWorld.map, static_cast<int32_t>(curEffect.position.x), static_cast<int32_t>(curEffect.position.z), static_cast<uint32_t>(timeLeftToRun));
+				tileSetFire(mapState, static_cast<int32_t>(curEffect.position.x), static_cast<int32_t>(curEffect.position.z), static_cast<uint32_t>(timeLeftToRun));
 			}
 		}
 

--- a/src/effects.h
+++ b/src/effects.h
@@ -162,7 +162,9 @@ void	effectResetUpdates();
 
 void	initPerimeterSmoke(const iIMDShape *pImd, Vector3i base);
 
-bool	readFXData(const char *fileName);
+struct WorldMapState;
+
+bool	readFXData(const char *fileName, WorldMapState& mapState);
 bool	writeFXData(const char *fileName);
 void	effectSetSize(UDWORD size);
 void	effectSetLandLightSpec(LAND_LIGHT_SPEC spec);

--- a/src/feature.cpp
+++ b/src/feature.cpp
@@ -176,10 +176,10 @@ int32_t featureDamage(FEATURE *psFeature, unsigned damage, WEAPON_CLASS weaponCl
 	}
 }
 
-FEATURE *buildFeature(FEATURE_STATS *psStats, UDWORD x, UDWORD y, bool FromSave)
+FEATURE *buildFeature(WorldMapState& mapState, FEATURE_STATS *psStats, UDWORD x, UDWORD y, bool FromSave)
 {
 	const auto id = generateSynchronisedObjectId();
-	return buildFeature(psStats, x, y, FromSave, id);
+	return buildFeature(mapState, psStats, x, y, FromSave, id);
 }
 
 /* Get pitch and roll from direction and tile data */
@@ -233,7 +233,7 @@ static void updateFeatureOrientation(FEATURE *psFeature)
 }
 
 /* Create a feature on the map */
-FEATURE *buildFeature(FEATURE_STATS *psStats, UDWORD x, UDWORD y, bool FromSave, uint32_t id)
+FEATURE *buildFeature(WorldMapState& mapState, FEATURE_STATS *psStats, UDWORD x, UDWORD y, bool FromSave, uint32_t id)
 {
 	//try and create the Feature, obtain stable address.
 	FEATURE& feature = GlobalFeatureContainer().emplace(id, psStats);
@@ -269,7 +269,7 @@ FEATURE *buildFeature(FEATURE_STATS *psStats, UDWORD x, UDWORD y, bool FromSave,
 	{
 		for (int width = 0; width <= b.size.x; ++width)
 		{
-			int h = map_TileHeight(gameWorld.map, b.map.x + width, b.map.y + breadth);
+			int h = map_TileHeight(mapState, b.map.x + width, b.map.y + breadth);
 			foundationMin = std::min(foundationMin, h);
 			foundationMax = std::max(foundationMax, h);
 		}
@@ -305,11 +305,11 @@ FEATURE *buildFeature(FEATURE_STATS *psStats, UDWORD x, UDWORD y, bool FromSave,
 	{
 		for (int width = 0; width < b.size.x; ++width)
 		{
-			MAPTILE *psTile = mapTile(gameWorld.map, b.map.x + width, b.map.y + breadth);
+			MAPTILE *psTile = mapTile(mapState, b.map.x + width, b.map.y + breadth);
 
 			//check not outside of map - for load save game
-			ASSERT_OR_RETURN(nullptr, b.map.x + width < gameWorld.map.width, "x coord bigger than map width - %s, id = %d", getStatsName(psFeature->psStats), psFeature->id);
-			ASSERT_OR_RETURN(nullptr, b.map.y + breadth < gameWorld.map.height, "y coord bigger than map height - %s, id = %d", getStatsName(psFeature->psStats), psFeature->id);
+			ASSERT_OR_RETURN(nullptr, b.map.x + width < mapState.width, "x coord bigger than map width - %s, id = %d", getStatsName(psFeature->psStats), psFeature->id);
+			ASSERT_OR_RETURN(nullptr, b.map.y + breadth < mapState.height, "y coord bigger than map height - %s, id = %d", getStatsName(psFeature->psStats), psFeature->id);
 
 			if (width != psStats->baseWidth && breadth != psStats->baseBreadth)
 			{
@@ -329,12 +329,12 @@ FEATURE *buildFeature(FEATURE_STATS *psStats, UDWORD x, UDWORD y, bool FromSave,
 				// if it's a tall feature then flag it in the map.
 				if (psFeature->sDisplay.imd->max.y > TALLOBJECT_YMAX)
 				{
-					auxSetBlocking(gameWorld.map, b.map.x + width, b.map.y + breadth, AIR_BLOCKED);
+					auxSetBlocking(mapState, b.map.x + width, b.map.y + breadth, AIR_BLOCKED);
 				}
 
 				if (psStats->subType != FEAT_GEN_ARTE && psStats->subType != FEAT_OIL_DRUM)
 				{
-					auxSetBlocking(gameWorld.map, b.map.x + width, b.map.y + breadth, FEATURE_BLOCKED);
+					auxSetBlocking(mapState, b.map.x + width, b.map.y + breadth, FEATURE_BLOCKED);
 				}
 			}
 
@@ -344,7 +344,7 @@ FEATURE *buildFeature(FEATURE_STATS *psStats, UDWORD x, UDWORD y, bool FromSave,
 			}
 		}
 	}
-	psFeature->pos.z = map_TileHeight(gameWorld.map, psFeature->pos.x, psFeature->pos.y);//jps 18july97
+	psFeature->pos.z = map_TileHeight(mapState, psFeature->pos.x, psFeature->pos.y);//jps 18july97
 	updateFeatureOrientation(psFeature);
 
 	return psFeature;

--- a/src/feature.h
+++ b/src/feature.h
@@ -28,6 +28,8 @@
 #include "lib/framework/wzconfig.h"
 #include "lib/framework/paged_entity_container.h"
 
+struct WorldMapState;
+
 /* The statistics for the features */
 extern std::vector<FEATURE_STATS> asFeatureStats;
 
@@ -41,8 +43,8 @@ bool loadFeatureStats(WzConfig &ini);
 void featureStatsShutDown();
 
 /* Create a feature on the map */
-FEATURE *buildFeature(FEATURE_STATS *psStats, UDWORD x, UDWORD y, bool FromSave);
-FEATURE *buildFeature(FEATURE_STATS *psStats, UDWORD x, UDWORD y, bool FromSave, uint32_t id);
+FEATURE *buildFeature(WorldMapState& mapState, FEATURE_STATS *psStats, UDWORD x, UDWORD y, bool FromSave);
+FEATURE *buildFeature(WorldMapState& mapState, FEATURE_STATS *psStats, UDWORD x, UDWORD y, bool FromSave, uint32_t id);
 
 /* Update routine for features */
 void featureUpdate(FEATURE *psFeat);

--- a/src/formation.cpp
+++ b/src/formation.cpp
@@ -417,7 +417,7 @@ static void formationFindFree(FORMATION *psFormation, DROID* psDroid,
 			{
 				// calculate the position on the line
 				formationCalcPos(psDroid, psFormation, line, currDist + objRadius, &x, &y);
-				if (fpathBlockingTile(map_coord(x), map_coord(y), psDroid->getPropulsionStats()->propulsionType))
+				if (fpathBlockingTile(gameWorld.map, map_coord(x), map_coord(y), psDroid->getPropulsionStats()->propulsionType))
 				{
 					// blocked, try the next rank
 					found = false;

--- a/src/fpath.cpp
+++ b/src/fpath.cpp
@@ -319,21 +319,21 @@ static uint8_t prop2bits(PROPULSION_TYPE propulsion)
 }
 
 // Check if the map tile at a location blocks a droid
-bool fpathBaseBlockingTile(SDWORD x, SDWORD y, PROPULSION_TYPE propulsion, int mapIndex, FPATH_MOVETYPE moveType)
+bool fpathBaseBlockingTile(const WorldMapState& mapState, SDWORD x, SDWORD y, PROPULSION_TYPE propulsion, int mapIndex, FPATH_MOVETYPE moveType)
 {
 	/* All tiles outside of the map and on map border are blocking. */
-	if (x < 1 || y < 1 || x > gameWorld.map.width - 1 || y > gameWorld.map.height - 1)
+	if (x < 1 || y < 1 || x > mapState.width - 1 || y > mapState.height - 1)
 	{
 		return true;
 	}
 
 	/* Check scroll limits (used in campaign to partition the map. */
-	if (propulsion != PROPULSION_TYPE_LIFT && (x < gameWorld.map.scroll.minX + 1 || y < gameWorld.map.scroll.minY + 1 || x >= gameWorld.map.scroll.maxX - 1 || y >= gameWorld.map.scroll.maxY - 1))
+	if (propulsion != PROPULSION_TYPE_LIFT && (x < mapState.scroll.minX + 1 || y < mapState.scroll.minY + 1 || x >= mapState.scroll.maxX - 1 || y >= mapState.scroll.maxY - 1))
 	{
 		// coords off map - auto blocking tile
 		return true;
 	}
-	unsigned aux = auxTile(gameWorld.map, x, y, mapIndex);
+	unsigned aux = auxTile(mapState, x, y, mapIndex);
 
 	int auxMask = 0;
 	switch (moveType)
@@ -350,26 +350,26 @@ bool fpathBaseBlockingTile(SDWORD x, SDWORD y, PROPULSION_TYPE propulsion, int m
 	}
 
 	// the MAX hack below is because blockTile() range does not include player-specific versions...
-	return (blockTile(gameWorld.map, x, y, MAX(0, mapIndex - MAX_PLAYERS)) & unitbits) != 0;  // finally check if move is blocked by propulsion related factors
+	return (blockTile(mapState, x, y, MAX(0, mapIndex - MAX_PLAYERS)) & unitbits) != 0;  // finally check if move is blocked by propulsion related factors
 }
 
 bool fpathDroidBlockingTile(DROID *psDroid, int x, int y, FPATH_MOVETYPE moveType)
 {
-	return fpathBaseBlockingTile(x, y, psDroid->getPropulsionStats()->propulsionType, psDroid->player, moveType);
+	return fpathBaseBlockingTile(gameWorld.map, x, y, psDroid->getPropulsionStats()->propulsionType, psDroid->player, moveType);
 }
 
 // Check if the map tile at a location blocks a droid
-bool fpathBlockingTile(SDWORD x, SDWORD y, PROPULSION_TYPE propulsion)
+bool fpathBlockingTile(const WorldMapState& mapState, SDWORD x, SDWORD y, PROPULSION_TYPE propulsion)
 {
-	return fpathBaseBlockingTile(x, y, propulsion, 0, FMT_BLOCK);  // with FMT_BLOCK, it is irrelevant which player is passed in
+	return fpathBaseBlockingTile(mapState, x, y, propulsion, 0, FMT_BLOCK);  // with FMT_BLOCK, it is irrelevant which player is passed in
 }
 
 
 // Returns the closest non-blocking tile to pos, or returns pos if no non-blocking tiles are present within a 2 tile distance.
-static Position findNonblockingPosition(Position pos, PROPULSION_TYPE propulsion, int player = 0, FPATH_MOVETYPE moveType = FMT_BLOCK)
+static Position findNonblockingPosition(const WorldMapState& mapState, Position pos, PROPULSION_TYPE propulsion, int player = 0, FPATH_MOVETYPE moveType = FMT_BLOCK)
 {
 	Vector2i centreTile = map_coord(pos.xy());
-	if (!fpathBaseBlockingTile(centreTile.x, centreTile.y, propulsion, player, moveType))
+	if (!fpathBaseBlockingTile(mapState, centreTile.x, centreTile.y, propulsion, player, moveType))
 	{
 		return pos;  // Fast case, pos is not on a blocking tile.
 	}
@@ -382,7 +382,7 @@ static Position findNonblockingPosition(Position pos, PROPULSION_TYPE propulsion
 			Vector2i tile = centreTile + Vector2i(x, y);
 			Vector2i diff = world_coord(tile) + Vector2i(TILE_UNITS / 2, TILE_UNITS / 2) - pos.xy();
 			int distSq = dot(diff, diff);
-			if (distSq < bestDistSq && !fpathBaseBlockingTile(tile.x, tile.y, propulsion, player, moveType))
+			if (distSq < bestDistSq && !fpathBaseBlockingTile(mapState, tile.x, tile.y, propulsion, player, moveType))
 			{
 				bestTile = tile;
 				bestDistSq = distSq;
@@ -560,10 +560,10 @@ FPATH_RETVAL fpathDroidRoute(DROID *psDroid, SDWORD tX, SDWORD tY, FPATH_MOVETYP
 	Position endPos = Position(tX, tY, 0);
 	StructureBounds dstStructure = getStructureBounds(worldTile(gameWorld.map, endPos.xy())->psObject);
 	const auto droidPropulsionType = psDroid->getPropulsionStats()->propulsionType;
-	startPos = findNonblockingPosition(startPos, droidPropulsionType, psDroid->player, moveType);
+	startPos = findNonblockingPosition(gameWorld.map, startPos, droidPropulsionType, psDroid->player, moveType);
 	if (!dstStructure.valid())  // If there's a structure over the destination, ignore it, otherwise pathfind from somewhere around the obstruction.
 	{
-		endPos   = findNonblockingPosition(endPos, droidPropulsionType, psDroid->player, moveType);
+		endPos   = findNonblockingPosition(gameWorld.map, endPos, droidPropulsionType, psDroid->player, moveType);
 	}
 	objTrace(psDroid->id, "Want to go to (%d, %d) -> (%d, %d), going (%d, %d) -> (%d, %d)", map_coord(psDroid->pos.x), map_coord(psDroid->pos.y), map_coord(tX), map_coord(tY), map_coord(startPos.x), map_coord(startPos.y), map_coord(endPos.x), map_coord(endPos.y));
 	switch (psDroid->order.type)
@@ -750,18 +750,18 @@ void fpathTest(int x, int y, int x2, int y2)
 	(void)r;  // Squelch unused-but-set warning.
 }
 
-bool fpathCheck(Position orig, Position dest, PROPULSION_TYPE propulsion)
+bool fpathCheck(WorldMapState& mapState, Position orig, Position dest, PROPULSION_TYPE propulsion)
 {
 	// We have to be careful with this check because it is called on
 	// load when playing campaign on droids that are on the other
 	// map during missions, and those maps are usually larger.
-	if (!worldOnMap(gameWorld.map, orig.xy()) || !worldOnMap(gameWorld.map, dest.xy()))
+	if (!worldOnMap(mapState, orig.xy()) || !worldOnMap(mapState, dest.xy()))
 	{
 		return false;
 	}
 
-	MAPTILE *origTile = worldTile(gameWorld.map, findNonblockingPosition(orig, propulsion).xy());
-	MAPTILE *destTile = worldTile(gameWorld.map, findNonblockingPosition(dest, propulsion).xy());
+	MAPTILE *origTile = worldTile(mapState, findNonblockingPosition(mapState, orig, propulsion).xy());
+	MAPTILE *destTile = worldTile(mapState, findNonblockingPosition(mapState, dest, propulsion).xy());
 
 	ASSERT_OR_RETURN(false, propulsion != PROPULSION_TYPE_NUM, "Bad propulsion type");
 	ASSERT_OR_RETURN(false, origTile != nullptr && destTile != nullptr, "Bad tile parameter");

--- a/src/fpath.h
+++ b/src/fpath.h
@@ -28,6 +28,7 @@
 
 #include <memory>
 
+struct WorldMapState;
 
 /** Return values for routing
  *
@@ -96,13 +97,13 @@ bool fpathIsEquivalentBlocking(PROPULSION_TYPE propulsion1, int player1, FPATH_M
  *
  *  @return true if the given tile is blocking for this droid
  */
-bool fpathBlockingTile(SDWORD x, SDWORD y, PROPULSION_TYPE propulsion);
+bool fpathBlockingTile(const WorldMapState& mapState, SDWORD x, SDWORD y, PROPULSION_TYPE propulsion);
 bool fpathDroidBlockingTile(DROID *psDroid, int x, int y, FPATH_MOVETYPE moveType);
-bool fpathBaseBlockingTile(SDWORD x, SDWORD y, PROPULSION_TYPE propulsion, int player, FPATH_MOVETYPE moveType);
+bool fpathBaseBlockingTile(const WorldMapState& mapState, SDWORD x, SDWORD y, PROPULSION_TYPE propulsion, int player, FPATH_MOVETYPE moveType);
 
-static inline bool fpathBlockingTile(Vector2i tile, PROPULSION_TYPE propulsion)
+static inline bool fpathBlockingTile(const WorldMapState& mapState, Vector2i tile, PROPULSION_TYPE propulsion)
 {
-	return fpathBlockingTile(tile.x, tile.y, propulsion);
+	return fpathBlockingTile(mapState, tile.x, tile.y, propulsion);
 }
 
 /** Set a direct path to position.
@@ -119,7 +120,7 @@ void fpathRemoveDroidData(int id);
 
 /** Quick O(1) test of whether it is theoretically possible to go from origin to destination
  *  using the given propulsion type. orig and dest are in world coordinates. */
-bool fpathCheck(Position orig, Position dest, PROPULSION_TYPE propulsion);
+bool fpathCheck(WorldMapState& mapState, Position orig, Position dest, PROPULSION_TYPE propulsion);
 
 /** Unit testing. */
 void fpathTest(int x, int y, int x2, int y2);

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2245,7 +2245,7 @@ static bool loadMainFile(const std::string &fileName);
 static bool loadMainFileFinal(const std::string &fileName);
 static bool writeMainFile(const std::string &fileName, SDWORD saveType);
 static bool writeGameFile(const char *fileName, SDWORD saveType);
-static bool writeMapFile(const char *fileName);
+static bool writeMapFile(const char *fileName, const WorldMapState& mapState);
 
 static bool loadWzMapDroidInit(WzMap::Map &wzMap, std::unordered_map<UDWORD, UDWORD>& fixedMapIdToGeneratedId);
 
@@ -2254,17 +2254,17 @@ static bool loadSaveDroidPointers(const WzString &pFileName, PerPlayerDroidLists
 static bool writeDroidFile(const char *pFileName, const PerPlayerDroidLists& ppsCurrentDroidLists);
 
 static bool loadSaveStructure(char *pFileData, UDWORD filesize);
-static bool loadSaveStructure2(const char *pFileName);
+static bool loadSaveStructure2(const char *pFileName, GameWorld& world);
 static bool loadWzMapStructure(WzMap::Map& wzMap, std::unordered_map<UDWORD, UDWORD>& fixedMapIdToGeneratedId, std::array<std::unordered_map<UDWORD, UDWORD>, MAX_PLAYER_SLOTS>& moduleToBuilding);
 static bool loadSaveStructurePointers(const WzString& filename, PerPlayerStructureLists *ppList);
-static bool writeStructFile(const char *pFileName);
+static bool writeStructFile(const char *pFileName, const WorldObjectState& objState);
 
 static bool loadSaveTemplate(const char *pFileName);
 static bool writeTemplateFile(const char *pFileName);
 
 static bool loadSaveFeature(char *pFileData, UDWORD filesize);
-static bool writeFeatureFile(const char *pFileName);
-static bool loadSaveFeature2(const char *pFileName);
+static bool writeFeatureFile(const char *pFileName, const WorldObjectState& objState);
+static bool loadSaveFeature2(const char *pFileName, GameWorld& world);
 static bool loadWzMapFeature(WzMap::Map &wzMap, std::unordered_map<UDWORD, UDWORD>& fixedMapIdToGeneratedId);
 
 static bool writeTerrainTypeMapFile(char *pFileName);
@@ -2299,7 +2299,7 @@ static bool loadRulesetJson();
 static bool gameLoad(const char *fileName);
 
 /* set the global scroll values to use for the save game */
-static void setMapScroll();
+static void setMapScroll(WorldMapState& mapState);
 
 static char *getSaveStructNameV19(SAVE_STRUCTURE_V17 *psSaveStructure)
 {
@@ -2410,11 +2410,11 @@ bool loadMissionExtras(const char* pGameToLoad, LEVEL_TYPE levelType)
 	return true;
 }
 
-static void sanityUpdate()
+static void sanityUpdate(WorldObjectState& objState)
 {
 	for (int player = 0; player < game.maxPlayers; player++)
 	{
-		for (DROID *psDroid : gameWorld.objects.droids[player])
+		for (DROID *psDroid : objState.droids[player])
 		{
 			orderCheckList(psDroid);
 			actionSanity(psDroid);
@@ -2689,9 +2689,9 @@ bool loadGame(const GameLoadDetails& gameToLoad, bool keepObjects, bool freeMem)
 		//clear out the audio
 		audio_StopAll();
 
-		freeAllDroids();
-		freeAllStructs();
-		freeAllFeatures();
+		freeAllDroids(gameWorld);
+		freeAllStructs(gameWorld);
+		freeAllFeatures(gameWorld);
 
 		//clear all the messages?
 		releaseAllProxDisp();
@@ -2819,7 +2819,7 @@ bool loadGame(const GameLoadDetails& gameToLoad, bool keepObjects, bool freeMem)
 			{
 				setPlayerColour(i, saveGameData.playerColour[i]);
 			}
-			SetRadarZoom(saveGameData.radarZoom);
+			SetRadarZoom(gameWorld.map, saveGameData.radarZoom);
 		}
 
 		if (saveGameVersion >= VERSION_20)//V21
@@ -2933,7 +2933,7 @@ bool loadGame(const GameLoadDetails& gameToLoad, bool keepObjects, bool freeMem)
 				{
 					if (selectedPlayer < MAX_PLAYERS && aiCheckAlliances(psStr->player, selectedPlayer))
 					{
-						visTilesUpdate((BASE_OBJECT *)psStr);
+						visTilesUpdate((BASE_OBJECT *)psStr, gameWorld.map);
 					}
 				}
 
@@ -2942,7 +2942,7 @@ bool loadGame(const GameLoadDetails& gameToLoad, bool keepObjects, bool freeMem)
 				{
 					if (selectedPlayer < MAX_PLAYERS && aiCheckAlliances(psDroid->player, selectedPlayer))
 					{
-						visTilesUpdate((BASE_OBJECT *)psDroid);
+						visTilesUpdate((BASE_OBJECT *)psDroid, gameWorld.map);
 					}
 				}
 			}
@@ -3013,7 +3013,7 @@ bool loadGame(const GameLoadDetails& gameToLoad, bool keepObjects, bool freeMem)
 		//load in the map file
 		aFileName[fileExten] = '\0';
 		strcat(aFileName, "mission.map");
-		if (!mapLoad(aFileName))
+		if (!mapLoad(aFileName, gameWorld.map))
 		{
 			debug(LOG_ERROR, "Failed with: %s", aFileName);
 			return false;
@@ -3024,7 +3024,7 @@ bool loadGame(const GameLoadDetails& gameToLoad, bool keepObjects, bool freeMem)
 		strcat(aFileName, "misvis.bjo");
 
 		// Load in the visibility data from the chosen file
-		if (!readVisibilityData(aFileName))
+		if (!readVisibilityData(aFileName, gameWorld.map))
 		{
 			debug(LOG_ERROR, "Failed with: %s", aFileName);
 			goto error;
@@ -3036,7 +3036,7 @@ bool loadGame(const GameLoadDetails& gameToLoad, bool keepObjects, bool freeMem)
 		strcat(aFileName, "mfeature.json");
 
 		//load the data into apsFeatureList
-		if (!loadSaveFeature2(aFileName))
+		if (!loadSaveFeature2(aFileName, gameWorld))
 		{
 			aFileName[fileExten] = '\0';
 			strcat(aFileName, "mfeat.bjo");
@@ -3059,7 +3059,7 @@ bool loadGame(const GameLoadDetails& gameToLoad, bool keepObjects, bool freeMem)
 		strcat(aFileName, "mstruct.json");
 
 		//load in the mission structures
-		if (!loadSaveStructure2(aFileName))
+		if (!loadSaveStructure2(aFileName, gameWorld))
 		{
 			aFileName[fileExten] = '\0';
 			strcat(aFileName, "mstruct.bjo");
@@ -3104,7 +3104,7 @@ bool loadGame(const GameLoadDetails& gameToLoad, bool keepObjects, bool freeMem)
 				    && (!psCurr->isTransporter())
 				    && psCurr->pos.x != INVALID_XY)
 				{
-					updateDroidOrientation(psCurr);
+					updateDroidOrientation(psCurr, gameWorld.map);
 				}
 			}
 		}
@@ -3145,7 +3145,7 @@ bool loadGame(const GameLoadDetails& gameToLoad, bool keepObjects, bool freeMem)
 			syncDebug("crc(droids) = 0x%08x", data->crcSumDroids(0));
 			syncDebug("crc(features) = 0x%08x", data->crcSumFeatures(0));
 		}
-		if (!mapLoadFromWzMapData(mapData))
+		if (!mapLoadFromWzMapData(mapData, gameWorld.map))
 		{
 			debug(LOG_ERROR, "Failed to process map data from path: %s", aFileName);
 			return false;
@@ -3164,7 +3164,7 @@ bool loadGame(const GameLoadDetails& gameToLoad, bool keepObjects, bool freeMem)
 			strcat(aFileName, "fxstate.json");
 
 			// load the fx data from the file
-			if (!readFXData(aFileName))
+			if (!readFXData(aFileName, gameWorld.map))
 			{
 				debug(LOG_ERROR, "Failed with: %s", aFileName);
 				goto error;
@@ -3184,7 +3184,7 @@ bool loadGame(const GameLoadDetails& gameToLoad, bool keepObjects, bool freeMem)
 	}
 
 	//adjust the scroll range for the new map or the expanded map
-	setMapScroll();
+	setMapScroll(gameWorld.map);
 
 	if (IsScenario)
 	{
@@ -3244,7 +3244,7 @@ bool loadGame(const GameLoadDetails& gameToLoad, bool keepObjects, bool freeMem)
 				    && !psCurr->isTransporter()
 				    && psCurr->pos.x != INVALID_XY)
 				{
-					updateDroidOrientation(psCurr);
+					updateDroidOrientation(psCurr, gameWorld.map);
 				}
 			}
 		}
@@ -3288,7 +3288,7 @@ bool loadGame(const GameLoadDetails& gameToLoad, bool keepObjects, bool freeMem)
 	{
 		aFileName[fileExten] = '\0';
 		strcat(aFileName, "feature.json");
-		if (!loadSaveFeature2(aFileName))
+		if (!loadSaveFeature2(aFileName, gameWorld))
 		{
 			debug(LOG_ERROR, "Failed with: %s", aFileName);
 			goto error;
@@ -3304,7 +3304,7 @@ bool loadGame(const GameLoadDetails& gameToLoad, bool keepObjects, bool freeMem)
 		ASSERT(data != nullptr, "Expecting WzMap::Map instance");
 		if (game.type != LEVEL_TYPE::CAMPAIGN)
 		{
-			freeAllFlagPositions();		//clear any flags put in during level loads
+			freeAllFlagPositions(gameWorld.objects);		//clear any flags put in during level loads
 		}
 		if (!loadWzMapStructure(*(data.get()), fixedMapIdToGeneratedId, moduleToBuilding))
 		{
@@ -3314,12 +3314,12 @@ bool loadGame(const GameLoadDetails& gameToLoad, bool keepObjects, bool freeMem)
 		}
 		if (game.type != LEVEL_TYPE::CAMPAIGN)
 		{
-			resetFactoryNumFlag();	//reset flags into the masks
+			resetFactoryNumFlag(gameWorld.objects);	//reset flags into the masks
 		}
 	}
 	else
 	{
-		if (!loadSaveStructure2(aFileName))
+		if (!loadSaveStructure2(aFileName, gameWorld))
 		{
 			debug(LOG_ERROR, "Failed with: %s", aFileName);
 			goto error;
@@ -3368,7 +3368,7 @@ bool loadGame(const GameLoadDetails& gameToLoad, bool keepObjects, bool freeMem)
 			strcat(aFileName, "visstate.bjo");
 
 			// Load in the visibility data from the chosen file
-			if (!readVisibilityData(aFileName))
+			if (!readVisibilityData(aFileName, gameWorld.map))
 			{
 				debug(LOG_ERROR, "Failed with: %s", aFileName);
 				goto error;
@@ -3414,15 +3414,15 @@ bool loadGame(const GameLoadDetails& gameToLoad, bool keepObjects, bool freeMem)
 
 	if ((saveGameVersion >= VERSION_15) && UserSaveGame)
 	{
-		setCurrentStructQuantity(false);
+		setCurrentStructQuantity(gameWorld.objects, false);
 	}
 	else
 	{
-		setCurrentStructQuantity(true);
+		setCurrentStructQuantity(gameWorld.objects, true);
 	}
 
 	//check that delivery points haven't been put down in invalid location
-	checkDeliveryPoints(saveGameVersion);
+	checkDeliveryPoints(gameWorld, saveGameVersion);
 
 	//turn power on for rest of game
 	powerCalculated = true;
@@ -3527,9 +3527,9 @@ error:
 	      keepObjects ? "true" : "false", freeMem ? "true" : "false", UserSaveGame ? "true" : "false");
 
 	/* Clear all the objects off the map and free up the map memory */
-	freeAllDroids();
-	freeAllStructs();
-	freeAllFeatures();
+	freeAllDroids(gameWorld);
+	freeAllStructs(gameWorld);
+	freeAllFeatures(gameWorld);
 	droidTemplateShutDown();
 	gameWorld.map.tiles = nullptr;
 
@@ -3553,7 +3553,7 @@ bool saveGame(const char *aFileName, GAME_TYPE saveType, bool isAutoSave)
 
 	fileExtension = strlen(CurrentFileName) - 3;
 	gameTimeStop();
-	sanityUpdate();
+	sanityUpdate(gameWorld.objects);
 
 	/* Write the data to the file */
 	if (!writeGameFile(CurrentFileName, saveType))
@@ -3573,7 +3573,7 @@ bool saveGame(const char *aFileName, GAME_TYPE saveType, bool isAutoSave)
 	//save the map file
 	strcat(CurrentFileName, "/game.map");
 	/* Write the data to the file */
-	if (!writeMapFile(CurrentFileName))
+	if (!writeMapFile(CurrentFileName, gameWorld.map))
 	{
 		debug(LOG_ERROR, "saveGame: writeMapFile(\"%s\") failed", CurrentFileName);
 		goto error;
@@ -3603,7 +3603,7 @@ bool saveGame(const char *aFileName, GAME_TYPE saveType, bool isAutoSave)
 	CurrentFileName[fileExtension] = '\0';
 	strcat(CurrentFileName, "struct.json");
 	/*Write the data to the file*/
-	if (!writeStructFile(CurrentFileName))
+	if (!writeStructFile(CurrentFileName, gameWorld.objects))
 	{
 		debug(LOG_ERROR, "saveGame: writeStructFile(\"%s\") failed", CurrentFileName);
 		goto error;
@@ -3623,7 +3623,7 @@ bool saveGame(const char *aFileName, GAME_TYPE saveType, bool isAutoSave)
 	CurrentFileName[fileExtension] = '\0';
 	strcat(CurrentFileName, "feature.json");
 	/*Write the data to the file*/
-	if (!writeFeatureFile(CurrentFileName))
+	if (!writeFeatureFile(CurrentFileName, gameWorld.objects))
 	{
 		debug(LOG_ERROR, "saveGame: writeFeatureFile(\"%s\") failed", CurrentFileName);
 		goto error;
@@ -3691,7 +3691,7 @@ bool saveGame(const char *aFileName, GAME_TYPE saveType, bool isAutoSave)
 	CurrentFileName[fileExtension] = '\0';
 	strcat(CurrentFileName, "visstate.bjo");
 	/*Write the data to the file*/
-	if (!writeVisibilityData(CurrentFileName))
+	if (!writeVisibilityData(CurrentFileName, gameWorld.map))
 	{
 		debug(LOG_ERROR, "saveGame: writeVisibilityData(\"%s\") failed", CurrentFileName);
 		goto error;
@@ -3791,7 +3791,7 @@ bool saveGame(const char *aFileName, GAME_TYPE saveType, bool isAutoSave)
 		CurrentFileName[fileExtension] = '\0';
 		strcat(CurrentFileName, "mission.map");
 		/* Write the data to the file */
-		if (!writeMapFile(CurrentFileName))
+		if (!writeMapFile(CurrentFileName, gameWorld.map))
 		{
 			debug(LOG_ERROR, "saveGame: writeMapFile(\"%s\") failed", CurrentFileName);
 			goto error;
@@ -3801,7 +3801,7 @@ bool saveGame(const char *aFileName, GAME_TYPE saveType, bool isAutoSave)
 		CurrentFileName[fileExtension] = '\0';
 		strcat(CurrentFileName, "misvis.bjo");
 		/* Write the data to the file */
-		if (!writeVisibilityData(CurrentFileName))
+		if (!writeVisibilityData(CurrentFileName, gameWorld.map))
 		{
 			debug(LOG_ERROR, "saveGame: writeVisibilityData(\"%s\") failed", CurrentFileName);
 			goto error;
@@ -3811,7 +3811,7 @@ bool saveGame(const char *aFileName, GAME_TYPE saveType, bool isAutoSave)
 		CurrentFileName[fileExtension] = '\0';
 		strcat(CurrentFileName, "mstruct.json");
 		/*Write the data to the file*/
-		if (!writeStructFile(CurrentFileName))
+		if (!writeStructFile(CurrentFileName, gameWorld.objects))
 		{
 			debug(LOG_ERROR, "saveGame: writeStructFile(\"%s\") failed", CurrentFileName);
 			goto error;
@@ -3821,7 +3821,7 @@ bool saveGame(const char *aFileName, GAME_TYPE saveType, bool isAutoSave)
 		CurrentFileName[fileExtension] = '\0';
 		strcat(CurrentFileName, "mfeature.json");
 		/*Write the data to the file*/
-		if (!writeFeatureFile(CurrentFileName))
+		if (!writeFeatureFile(CurrentFileName, gameWorld.objects))
 		{
 			debug(LOG_ERROR, "saveGame: writeFeatureFile(\"%s\") failed", CurrentFileName);
 			goto error;
@@ -3851,13 +3851,13 @@ error:
 }
 
 // -----------------------------------------------------------------------------------------
-static bool writeMapFile(const char *fileName)
+static bool writeMapFile(const char *fileName, const WorldMapState& mapState)
 {
 	ASSERT_OR_RETURN(false, fileName != nullptr, "filename is null");
 
 	/* Get the save data */
 	WzMap::MapData mapData;
-	bool status = mapSaveToWzMapData(mapData);
+	bool status = mapSaveToWzMapData(mapData, mapState);
 	if (!status)
 	{
 		return false;
@@ -5301,7 +5301,7 @@ static bool loadWzMapDroidInit(WzMap::Map &wzMap, std::unordered_map<UDWORD, UDW
 				debug(LOG_ERROR, "Found duplicate hard-coded object ID in map data: %" PRIu32 "", droid.id.value());
 			}
 		}
-		psDroid = reallyBuildDroid(psTemplate, Position(droid.position.x, droid.position.y, 0), player, false, {droid.direction, 0, 0}, newID);
+		psDroid = reallyBuildDroid(gameWorld, psTemplate, Position(droid.position.x, droid.position.y, 0), player, false, {droid.direction, 0, 0}, newID);
 		turnOffMultiMsg(false);
 		if (psDroid == nullptr)
 		{
@@ -5734,11 +5734,11 @@ static bool loadSaveDroid(const char *pFileName, PerPlayerDroidLists& ppsCurrent
 		turnOffMultiMsg(true);
 		if (id > 0)
 		{
-			psDroid = reallyBuildDroid(psTemplate, pos, player, onMission, rot, id);
+			psDroid = reallyBuildDroid(gameWorld, psTemplate, pos, player, onMission, rot, id);
 		} else
 		{
 			// will generate a new id
-			psDroid = reallyBuildDroid(psTemplate, pos, player, onMission, rot);
+			psDroid = reallyBuildDroid(gameWorld, psTemplate, pos, player, onMission, rot);
 		}
 		ASSERT_OR_RETURN(false, psDroid != nullptr, "Failed to build unit %s", sortedList[i].second.toUtf8().c_str());
 		turnOffMultiMsg(false);
@@ -5817,7 +5817,7 @@ static bool loadSaveDroid(const char *pFileName, PerPlayerDroidLists& ppsCurrent
 				psDroid->selected = false;  // Droid should be visible in the transporter interface.
 				if (!psDroid->isTransporter())
 				{
-					visRemoveVisibility(psDroid); // should not have visibility data when in a transporter
+					visRemoveVisibility(psDroid, gameWorld.map); // should not have visibility data when in a transporter
 				}
 			}
 		}
@@ -6241,7 +6241,7 @@ bool loadSaveStructure(char *pFileData, UDWORD filesize)
 		//for modules - need to check the base structure exists
 		if (IsStatExpansionModule(psStats))
 		{
-			psStructure = getTileStructure(map_coord(psSaveStructure->x), map_coord(psSaveStructure->y));
+			psStructure = getTileStructure(gameWorld.map, map_coord(psSaveStructure->x), map_coord(psSaveStructure->y));
 			if (psStructure == nullptr)
 			{
 				debug(LOG_ERROR, "No owning structure for module - %s for player - %d", getSaveStructNameV19((SAVE_STRUCTURE_V17 *)psSaveStructure), psSaveStructure->player);
@@ -6264,7 +6264,7 @@ bool loadSaveStructure(char *pFileData, UDWORD filesize)
 			continue;
 		}
 
-		psStructure = buildStructureDir(psStats, psSaveStructure->x, psSaveStructure->y, DEG(psSaveStructure->direction), psSaveStructure->player, true);
+		psStructure = buildStructureDir(gameWorld, psStats, psSaveStructure->x, psSaveStructure->y, DEG(psSaveStructure->direction), psSaveStructure->player, true);
 		ASSERT(psStructure, "Unable to create structure");
 		if (!psStructure)
 		{
@@ -6332,7 +6332,7 @@ static bool loadWzMapStructure(WzMap::Map& wzMap, std::unordered_map<UDWORD, UDW
 		//for modules - need to check the base structure exists
 		if (IsStatExpansionModule(psStats))
 		{
-			STRUCTURE *psStructure = getTileStructure(map_coord(structure.position.x), map_coord(structure.position.y));
+			STRUCTURE *psStructure = getTileStructure(gameWorld.map, map_coord(structure.position.x), map_coord(structure.position.y));
 			if (psStructure == nullptr)
 			{
 				debug(LOG_ERROR, "No owning structure for module - %s for player - %d", structure.name.c_str(), structure.player);
@@ -6369,7 +6369,7 @@ static bool loadWzMapStructure(WzMap::Map& wzMap, std::unordered_map<UDWORD, UDW
 				debug(LOG_ERROR, "Found duplicate hard-coded object ID in map data: %" PRIu32 "", structure.id.value());
 			}
 		}
-		psStructure = buildStructureDir(psStats, structure.position.x, structure.position.y, structure.direction, player, true, newID, true);
+		psStructure = buildStructureDir(gameWorld, psStats, structure.position.x, structure.position.y, structure.direction, player, true, newID, true);
 		if (psStructure == nullptr)
 		{
 			debug(LOG_ERROR, "Structure %s couldn't be built (probably on top of another structure).", structure.name.c_str());
@@ -6401,7 +6401,7 @@ static bool loadWzMapStructure(WzMap::Map& wzMap, std::unordered_map<UDWORD, UDW
 			}
 			for (int i = 0; i < structure.modules; ++i)
 			{
-				buildStructure(moduleStat, structure.position.x, structure.position.y, player, true);
+				buildStructure(gameWorld, moduleStat, structure.position.x, structure.position.y, player, true);
 			}
 		}
 		buildingComplete(psStructure);
@@ -6426,7 +6426,7 @@ static bool loadWzMapStructure(WzMap::Map& wzMap, std::unordered_map<UDWORD, UDW
 
 // -----------------------------------------------------------------------------------------
 /* code for versions after version 20 of a save structure */
-static bool loadSaveStructure2(const char *pFileName)
+static bool loadSaveStructure2(const char *pFileName, GameWorld& world)
 {
 	if (!PHYSFS_exists(pFileName))
 	{
@@ -6435,7 +6435,7 @@ static bool loadSaveStructure2(const char *pFileName)
 	}
 	WzConfig ini(WzString::fromUtf8(pFileName), WzConfig::ReadOnly);
 
-	freeAllFlagPositions();		//clear any flags put in during level loads
+	freeAllFlagPositions(world.objects);		//clear any flags put in during level loads
 
 	std::vector<WzString> list = ini.childGroups();
 	for (size_t i = 0; i < list.size(); ++i)
@@ -6468,7 +6468,7 @@ static bool loadSaveStructure2(const char *pFileName)
 		//for modules - need to check the base structure exists
 		if (IsStatExpansionModule(psStats))
 		{
-			STRUCTURE *psTileStructure = getTileStructure(map_coord(pos.x), map_coord(pos.y));
+			STRUCTURE *psTileStructure = getTileStructure(world.map, map_coord(pos.x), map_coord(pos.y));
 			if (psTileStructure == nullptr)
 			{
 				debug(LOG_ERROR, "No owning structure for module - %s for player - %d", name.toUtf8().c_str(), player);
@@ -6477,8 +6477,8 @@ static bool loadSaveStructure2(const char *pFileName)
 			}
 		}
 		//check not trying to build too near the edge
-		if (map_coord(pos.x) < TOO_NEAR_EDGE || map_coord(pos.x) > gameWorld.map.width - TOO_NEAR_EDGE
-		    || map_coord(pos.y) < TOO_NEAR_EDGE || map_coord(pos.y) > gameWorld.map.height - TOO_NEAR_EDGE)
+		if (map_coord(pos.x) < TOO_NEAR_EDGE || map_coord(pos.x) > world.map.width - TOO_NEAR_EDGE
+		    || map_coord(pos.y) < TOO_NEAR_EDGE || map_coord(pos.y) > world.map.height - TOO_NEAR_EDGE)
 		{
 			debug(LOG_ERROR, "Structure %s (%s), coord too near the edge of the map", name.toUtf8().c_str(), list[i].toUtf8().c_str());
 			ini.endGroup();
@@ -6489,7 +6489,7 @@ static bool loadSaveStructure2(const char *pFileName)
 			id = generateSynchronisedObjectId();
 		}
 		debug(LOG_NEVER, "trying to build structure %i;%i;%s;%i;%i", id, player, psStats->name.toUtf8().c_str(), map_coord(pos.y), map_coord(pos.y));
-		psStructure = buildStructureDir(psStats, pos.x, pos.y, rot.direction, player, true, id);
+		psStructure = buildStructureDir(world, psStats, pos.x, pos.y, rot.direction, player, true, id);
 		ASSERT(psStructure, "Unable to create structure");
 		if (!psStructure)
 		{
@@ -6527,7 +6527,7 @@ static bool loadSaveStructure2(const char *pFileName)
 				//build the appropriate number of modules
 				for (int moduleIdx = 0; moduleIdx < capacity; moduleIdx++)
 				{
-					buildStructure(psModule, psStructure->pos.x, psStructure->pos.y, psStructure->player, true);
+					buildStructure(world, psModule, psStructure->pos.x, psStructure->pos.y, psStructure->player, true);
 
 				}
 			}
@@ -6539,7 +6539,7 @@ static bool loadSaveStructure2(const char *pFileName)
 			if (ini.contains("Factory/assemblyPoint/pos"))
 			{
 				Position point = ini.vector3i("Factory/assemblyPoint/pos");
-				setAssemblyPoint(psFactory->psAssemblyPoint, point.x, point.y, player, false);
+				setAssemblyPoint(world, psFactory->psAssemblyPoint, point.x, point.y, player, false);
 				psFactory->psAssemblyPoint->selected = ini.value("Factory/assemblyPoint/selected", false).toBool();
 			}
 			if (ini.contains("Factory/assemblyPoint/number"))
@@ -6580,7 +6580,7 @@ static bool loadSaveStructure2(const char *pFileName)
 			if (capacity)
 			{
 				psModule = getModuleStat(psStructure);
-				buildStructure(psModule, psStructure->pos.x, psStructure->pos.y, psStructure->player, true);
+				buildStructure(world, psModule, psStructure->pos.x, psStructure->pos.y, psStructure->player, true);
 			}
 			//clear subject
 			psResearch->psSubject = nullptr;
@@ -6605,7 +6605,7 @@ static bool loadSaveStructure2(const char *pFileName)
 			if (capacity)
 			{
 				psModule = getModuleStat(psStructure);
-				buildStructure(psModule, psStructure->pos.x, psStructure->pos.y, psStructure->player, true);
+				buildStructure(world, psModule, psStructure->pos.x, psStructure->pos.y, psStructure->player, true);
 			}
 			break;
 		case REF_RESOURCE_EXTRACTOR:
@@ -6615,7 +6615,7 @@ static bool loadSaveStructure2(const char *pFileName)
 			if (ini.contains("Repair/deliveryPoint/pos"))
 			{
 				Position point = ini.vector3i("Repair/deliveryPoint/pos");
-				setAssemblyPoint(psRepair->psDeliveryPoint, point.x, point.y, player, false);
+				setAssemblyPoint(world, psRepair->psDeliveryPoint, point.x, point.y, player, false);
 				psRepair->psDeliveryPoint->selected = ini.value("Repair/deliveryPoint/selected", false).toBool();
 			}
 			break;
@@ -6667,7 +6667,7 @@ static bool loadSaveStructure2(const char *pFileName)
 		}
 		ini.endGroup();
 	}
-	resetFactoryNumFlag();	//reset flags into the masks
+	resetFactoryNumFlag(world.objects);	//reset flags into the masks
 
 	return true;
 }
@@ -6711,14 +6711,14 @@ bool writeGameInfo(const char *pFileName)
 /*
 Writes the linked list of structure for each player to a file
 */
-bool writeStructFile(const char *pFileName)
+bool writeStructFile(const char *pFileName, const WorldObjectState& objState)
 {
 	WzConfig ini(WzString::fromUtf8(pFileName), WzConfig::ReadAndWrite);
 	int counter = 0;
 
 	for (int player = 0; player < MAX_PLAYERS; player++)
 	{
-		for (const STRUCTURE *psCurr : gameWorld.objects.structures[player])
+		for (const STRUCTURE *psCurr : objState.structures[player])
 		{
 			if (!psCurr->pStructureType)
 			{
@@ -7064,7 +7064,7 @@ bool loadSaveFeature(char *pFileData, UDWORD filesize)
 			continue;
 		}
 		//create the Feature
-		pFeature = buildFeature(psStats, psSaveFeature->x, psSaveFeature->y, true, psSaveFeature->id);
+		pFeature = buildFeature(gameWorld.map, psStats, psSaveFeature->x, psSaveFeature->y, true, psSaveFeature->id);
 		if (!pFeature)
 		{
 			debug(LOG_ERROR, "Unable to create feature %s", psSaveFeature->name);
@@ -7121,7 +7121,7 @@ static bool loadWzMapFeature(WzMap::Map &wzMap, std::unordered_map<UDWORD, UDWOR
 				debug(LOG_ERROR, "Found duplicate hard-coded object ID in map data: %" PRIu32 "", feature.id.value());
 			}
 		}
-		pFeature = buildFeature(&*psStats, feature.position.x, feature.position.y, true, newID);
+		pFeature = buildFeature(gameWorld.map, &*psStats, feature.position.x, feature.position.y, true, newID);
 		if (!pFeature)
 		{
 			debug(LOG_ERROR, "Unable to create feature %s", feature.name.c_str());
@@ -7139,7 +7139,7 @@ static bool loadWzMapFeature(WzMap::Map &wzMap, std::unordered_map<UDWORD, UDWOR
 	return true;
 }
 
-bool loadSaveFeature2(const char *pFileName)
+bool loadSaveFeature2(const char *pFileName, GameWorld& world)
 {
 	if (!PHYSFS_exists(pFileName))
 	{
@@ -7181,11 +7181,11 @@ bool loadSaveFeature2(const char *pFileName)
 		int id = ini.value("id", -1).toInt();
 		if (id > 0)
 		{
-			pFeature = buildFeature(psStats, pos.x, pos.y, true, id);
+			pFeature = buildFeature(world.map, psStats, pos.x, pos.y, true, id);
 		}
 		else
 		{
-			pFeature = buildFeature(psStats, pos.x, pos.y, true);
+			pFeature = buildFeature(world.map, psStats, pos.x, pos.y, true);
 		}
 		if (!pFeature)
 		{
@@ -7214,12 +7214,12 @@ bool loadSaveFeature2(const char *pFileName)
 /*
 Writes the linked list of features to a file
 */
-bool writeFeatureFile(const char *pFileName)
+bool writeFeatureFile(const char *pFileName, const WorldObjectState& objState)
 {
 	WzConfig ini(WzString::fromUtf8(pFileName), WzConfig::ReadAndWrite);
 	int counter = 0;
 
-	for (const FEATURE *psCurr : gameWorld.objects.features[0])
+	for (const FEATURE *psCurr : objState.features[0])
 	{
 		ini.beginGroup("feature_" + (WzString::number(counter++).leftPadToMinimumLength(WzUniCodepoint::fromASCII('0'), 10)));  // Zero padded so that alphabetical sort works.
 		ini.setValue("name", psCurr->psStats->id);
@@ -8207,44 +8207,44 @@ static bool loadSaveGuideTopics(const char *pFileName)
 
 // -----------------------------------------------------------------------------------------
 /* set the global scroll values to use for the save game */
-static void setMapScroll()
+static void setMapScroll(WorldMapState& mapState)
 {
 	//if loading in a pre version5 then scroll values will not have been set up so set to max poss
 	if (width == 0 && height == 0)
 	{
-		gameWorld.map.scroll.minX = 0;
-		gameWorld.map.scroll.maxX = gameWorld.map.width;
-		gameWorld.map.scroll.minY = 0;
-		gameWorld.map.scroll.maxY = gameWorld.map.height;
+		mapState.scroll.minX = 0;
+		mapState.scroll.maxX = mapState.width;
+		mapState.scroll.minY = 0;
+		mapState.scroll.maxY = mapState.height;
 		return;
 	}
-	gameWorld.map.scroll.minX = startX;
-	gameWorld.map.scroll.minY = startY;
-	gameWorld.map.scroll.maxX = startX + width;
-	gameWorld.map.scroll.maxY = startY + height;
+	mapState.scroll.minX = startX;
+	mapState.scroll.minY = startY;
+	mapState.scroll.maxX = startX + width;
+	mapState.scroll.maxY = startY + height;
 	//check not going beyond width/height of map
-	if (gameWorld.map.scroll.maxX > (SDWORD)gameWorld.map.width)
+	if (mapState.scroll.maxX > (SDWORD)mapState.width)
 	{
-		gameWorld.map.scroll.maxX = gameWorld.map.width;
+		mapState.scroll.maxX = mapState.width;
 		debug(LOG_NEVER, "scrollMaxX was too big - It has been set to map width");
 	}
-	if (gameWorld.map.scroll.maxY > (SDWORD)gameWorld.map.height)
+	if (mapState.scroll.maxY > (SDWORD)mapState.height)
 	{
-		gameWorld.map.scroll.maxY = gameWorld.map.height;
+		mapState.scroll.maxY = mapState.height;
 		debug(LOG_NEVER, "scrollMaxY was too big - It has been set to map height");
 	}
 	// check for invalid minimum values (fixes some broken maps)
-	if (gameWorld.map.scroll.minX >= gameWorld.map.scroll.maxX)
+	if (mapState.scroll.minX >= mapState.scroll.maxX)
 	{
 		ASSERT(false, "scrollMinX was >= scrollMaxX - min has been set to 0, max has been set to mapWidth");
-		gameWorld.map.scroll.minX = 0;
-		gameWorld.map.scroll.maxX = gameWorld.map.width;
+		mapState.scroll.minX = 0;
+		mapState.scroll.maxX = mapState.width;
 	}
-	if (gameWorld.map.scroll.minY >= gameWorld.map.scroll.maxY)
+	if (mapState.scroll.minY >= mapState.scroll.maxY)
 	{
 		ASSERT(false, "scrollMinY was >= scrollMaxY - min has been set to 0, max has been set to mapHeight");
-		gameWorld.map.scroll.minY = 0;
-		gameWorld.map.scroll.maxY = gameWorld.map.height;
+		mapState.scroll.minY = 0;
+		mapState.scroll.maxY = mapState.height;
 	}
 }
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2245,7 +2245,7 @@ static bool loadMainFile(const std::string &fileName);
 static bool loadMainFileFinal(const std::string &fileName);
 static bool writeMainFile(const std::string &fileName, SDWORD saveType);
 static bool writeGameFile(const char *fileName, SDWORD saveType);
-static bool writeMapFile(const char *fileName);
+static bool writeMapFile(const char *fileName, const WorldMapState& mapState);
 
 static bool loadWzMapDroidInit(WzMap::Map &wzMap, std::unordered_map<UDWORD, UDWORD>& fixedMapIdToGeneratedId);
 
@@ -2254,17 +2254,17 @@ static bool loadSaveDroidPointers(const WzString &pFileName, PerPlayerDroidLists
 static bool writeDroidFile(const char *pFileName, const PerPlayerDroidLists& ppsCurrentDroidLists);
 
 static bool loadSaveStructure(char *pFileData, UDWORD filesize);
-static bool loadSaveStructure2(const char *pFileName);
+static bool loadSaveStructure2(const char *pFileName, GameWorld& world);
 static bool loadWzMapStructure(WzMap::Map& wzMap, std::unordered_map<UDWORD, UDWORD>& fixedMapIdToGeneratedId, std::array<std::unordered_map<UDWORD, UDWORD>, MAX_PLAYER_SLOTS>& moduleToBuilding);
 static bool loadSaveStructurePointers(const WzString& filename, PerPlayerStructureLists *ppList);
-static bool writeStructFile(const char *pFileName);
+static bool writeStructFile(const char *pFileName, const WorldObjectState& objState);
 
 static bool loadSaveTemplate(const char *pFileName);
 static bool writeTemplateFile(const char *pFileName);
 
 static bool loadSaveFeature(char *pFileData, UDWORD filesize);
-static bool writeFeatureFile(const char *pFileName);
-static bool loadSaveFeature2(const char *pFileName);
+static bool writeFeatureFile(const char *pFileName, const WorldObjectState& objState);
+static bool loadSaveFeature2(const char *pFileName, GameWorld& world);
 static bool loadWzMapFeature(WzMap::Map &wzMap, std::unordered_map<UDWORD, UDWORD>& fixedMapIdToGeneratedId);
 
 static bool writeTerrainTypeMapFile(char *pFileName);
@@ -2299,7 +2299,7 @@ static bool loadRulesetJson();
 static bool gameLoad(const char *fileName);
 
 /* set the global scroll values to use for the save game */
-static void setMapScroll();
+static void setMapScroll(WorldMapState& mapState);
 
 static char *getSaveStructNameV19(SAVE_STRUCTURE_V17 *psSaveStructure)
 {
@@ -2410,11 +2410,11 @@ bool loadMissionExtras(const char* pGameToLoad, LEVEL_TYPE levelType)
 	return true;
 }
 
-static void sanityUpdate()
+static void sanityUpdate(WorldObjectState& objState)
 {
 	for (int player = 0; player < game.maxPlayers; player++)
 	{
-		for (DROID *psDroid : gameWorld.objects.droids[player])
+		for (DROID *psDroid : objState.droids[player])
 		{
 			orderCheckList(psDroid);
 			actionSanity(psDroid);
@@ -2689,9 +2689,9 @@ bool loadGame(const GameLoadDetails& gameToLoad, bool keepObjects, bool freeMem)
 		//clear out the audio
 		audio_StopAll();
 
-		freeAllDroids();
-		freeAllStructs();
-		freeAllFeatures();
+		freeAllDroids(gameWorld);
+		freeAllStructs(gameWorld);
+		freeAllFeatures(gameWorld);
 
 		//clear all the messages?
 		releaseAllProxDisp();
@@ -2819,7 +2819,7 @@ bool loadGame(const GameLoadDetails& gameToLoad, bool keepObjects, bool freeMem)
 			{
 				setPlayerColour(i, saveGameData.playerColour[i]);
 			}
-			SetRadarZoom(saveGameData.radarZoom);
+			SetRadarZoom(gameWorld.map, saveGameData.radarZoom);
 		}
 
 		if (saveGameVersion >= VERSION_20)//V21
@@ -2933,7 +2933,7 @@ bool loadGame(const GameLoadDetails& gameToLoad, bool keepObjects, bool freeMem)
 				{
 					if (selectedPlayer < MAX_PLAYERS && aiCheckAlliances(psStr->player, selectedPlayer))
 					{
-						visTilesUpdate((BASE_OBJECT *)psStr);
+						visTilesUpdate((BASE_OBJECT *)psStr, gameWorld.map);
 					}
 				}
 
@@ -2942,7 +2942,7 @@ bool loadGame(const GameLoadDetails& gameToLoad, bool keepObjects, bool freeMem)
 				{
 					if (selectedPlayer < MAX_PLAYERS && aiCheckAlliances(psDroid->player, selectedPlayer))
 					{
-						visTilesUpdate((BASE_OBJECT *)psDroid);
+						visTilesUpdate((BASE_OBJECT *)psDroid, gameWorld.map);
 					}
 				}
 			}
@@ -3013,7 +3013,7 @@ bool loadGame(const GameLoadDetails& gameToLoad, bool keepObjects, bool freeMem)
 		//load in the map file
 		aFileName[fileExten] = '\0';
 		strcat(aFileName, "mission.map");
-		if (!mapLoad(aFileName))
+		if (!mapLoad(aFileName, gameWorld.map))
 		{
 			debug(LOG_ERROR, "Failed with: %s", aFileName);
 			return false;
@@ -3024,7 +3024,7 @@ bool loadGame(const GameLoadDetails& gameToLoad, bool keepObjects, bool freeMem)
 		strcat(aFileName, "misvis.bjo");
 
 		// Load in the visibility data from the chosen file
-		if (!readVisibilityData(aFileName))
+		if (!readVisibilityData(aFileName, gameWorld.map))
 		{
 			debug(LOG_ERROR, "Failed with: %s", aFileName);
 			goto error;
@@ -3036,7 +3036,7 @@ bool loadGame(const GameLoadDetails& gameToLoad, bool keepObjects, bool freeMem)
 		strcat(aFileName, "mfeature.json");
 
 		//load the data into apsFeatureList
-		if (!loadSaveFeature2(aFileName))
+		if (!loadSaveFeature2(aFileName, gameWorld))
 		{
 			aFileName[fileExten] = '\0';
 			strcat(aFileName, "mfeat.bjo");
@@ -3059,7 +3059,7 @@ bool loadGame(const GameLoadDetails& gameToLoad, bool keepObjects, bool freeMem)
 		strcat(aFileName, "mstruct.json");
 
 		//load in the mission structures
-		if (!loadSaveStructure2(aFileName))
+		if (!loadSaveStructure2(aFileName, gameWorld))
 		{
 			aFileName[fileExten] = '\0';
 			strcat(aFileName, "mstruct.bjo");
@@ -3104,7 +3104,7 @@ bool loadGame(const GameLoadDetails& gameToLoad, bool keepObjects, bool freeMem)
 				    && (!psCurr->isTransporter())
 				    && psCurr->pos.x != INVALID_XY)
 				{
-					updateDroidOrientation(psCurr);
+					updateDroidOrientation(psCurr, gameWorld.map);
 				}
 			}
 		}
@@ -3145,7 +3145,7 @@ bool loadGame(const GameLoadDetails& gameToLoad, bool keepObjects, bool freeMem)
 			syncDebug("crc(droids) = 0x%08x", data->crcSumDroids(0));
 			syncDebug("crc(features) = 0x%08x", data->crcSumFeatures(0));
 		}
-		if (!mapLoadFromWzMapData(mapData))
+		if (!mapLoadFromWzMapData(mapData, gameWorld.map))
 		{
 			debug(LOG_ERROR, "Failed to process map data from path: %s", aFileName);
 			return false;
@@ -3164,7 +3164,7 @@ bool loadGame(const GameLoadDetails& gameToLoad, bool keepObjects, bool freeMem)
 			strcat(aFileName, "fxstate.json");
 
 			// load the fx data from the file
-			if (!readFXData(aFileName))
+			if (!readFXData(aFileName, gameWorld.map))
 			{
 				debug(LOG_ERROR, "Failed with: %s", aFileName);
 				goto error;
@@ -3184,7 +3184,7 @@ bool loadGame(const GameLoadDetails& gameToLoad, bool keepObjects, bool freeMem)
 	}
 
 	//adjust the scroll range for the new map or the expanded map
-	setMapScroll();
+	setMapScroll(gameWorld.map);
 
 	if (IsScenario)
 	{
@@ -3244,7 +3244,7 @@ bool loadGame(const GameLoadDetails& gameToLoad, bool keepObjects, bool freeMem)
 				    && !psCurr->isTransporter()
 				    && psCurr->pos.x != INVALID_XY)
 				{
-					updateDroidOrientation(psCurr);
+					updateDroidOrientation(psCurr, gameWorld.map);
 				}
 			}
 		}
@@ -3288,7 +3288,7 @@ bool loadGame(const GameLoadDetails& gameToLoad, bool keepObjects, bool freeMem)
 	{
 		aFileName[fileExten] = '\0';
 		strcat(aFileName, "feature.json");
-		if (!loadSaveFeature2(aFileName))
+		if (!loadSaveFeature2(aFileName, gameWorld))
 		{
 			debug(LOG_ERROR, "Failed with: %s", aFileName);
 			goto error;
@@ -3304,7 +3304,7 @@ bool loadGame(const GameLoadDetails& gameToLoad, bool keepObjects, bool freeMem)
 		ASSERT(data != nullptr, "Expecting WzMap::Map instance");
 		if (game.type != LEVEL_TYPE::CAMPAIGN)
 		{
-			freeAllFlagPositions();		//clear any flags put in during level loads
+			freeAllFlagPositions(gameWorld.objects);		//clear any flags put in during level loads
 		}
 		if (!loadWzMapStructure(*(data.get()), fixedMapIdToGeneratedId, moduleToBuilding))
 		{
@@ -3314,12 +3314,12 @@ bool loadGame(const GameLoadDetails& gameToLoad, bool keepObjects, bool freeMem)
 		}
 		if (game.type != LEVEL_TYPE::CAMPAIGN)
 		{
-			resetFactoryNumFlag();	//reset flags into the masks
+			resetFactoryNumFlag(gameWorld.objects);	//reset flags into the masks
 		}
 	}
 	else
 	{
-		if (!loadSaveStructure2(aFileName))
+		if (!loadSaveStructure2(aFileName, gameWorld))
 		{
 			debug(LOG_ERROR, "Failed with: %s", aFileName);
 			goto error;
@@ -3368,7 +3368,7 @@ bool loadGame(const GameLoadDetails& gameToLoad, bool keepObjects, bool freeMem)
 			strcat(aFileName, "visstate.bjo");
 
 			// Load in the visibility data from the chosen file
-			if (!readVisibilityData(aFileName))
+			if (!readVisibilityData(aFileName, gameWorld.map))
 			{
 				debug(LOG_ERROR, "Failed with: %s", aFileName);
 				goto error;
@@ -3414,15 +3414,15 @@ bool loadGame(const GameLoadDetails& gameToLoad, bool keepObjects, bool freeMem)
 
 	if ((saveGameVersion >= VERSION_15) && UserSaveGame)
 	{
-		setCurrentStructQuantity(false);
+		setCurrentStructQuantity(gameWorld.objects, false);
 	}
 	else
 	{
-		setCurrentStructQuantity(true);
+		setCurrentStructQuantity(gameWorld.objects, true);
 	}
 
 	//check that delivery points haven't been put down in invalid location
-	checkDeliveryPoints(saveGameVersion);
+	checkDeliveryPoints(gameWorld, saveGameVersion);
 
 	//turn power on for rest of game
 	powerCalculated = true;
@@ -3527,9 +3527,9 @@ error:
 	      keepObjects ? "true" : "false", freeMem ? "true" : "false", UserSaveGame ? "true" : "false");
 
 	/* Clear all the objects off the map and free up the map memory */
-	freeAllDroids();
-	freeAllStructs();
-	freeAllFeatures();
+	freeAllDroids(gameWorld);
+	freeAllStructs(gameWorld);
+	freeAllFeatures(gameWorld);
 	droidTemplateShutDown();
 	gameWorld.map.tiles = nullptr;
 
@@ -3553,7 +3553,7 @@ bool saveGame(const char *aFileName, GAME_TYPE saveType, bool isAutoSave)
 
 	fileExtension = strlen(CurrentFileName) - 3;
 	gameTimeStop();
-	sanityUpdate();
+	sanityUpdate(gameWorld.objects);
 
 	/* Write the data to the file */
 	if (!writeGameFile(CurrentFileName, saveType))
@@ -3573,7 +3573,7 @@ bool saveGame(const char *aFileName, GAME_TYPE saveType, bool isAutoSave)
 	//save the map file
 	strcat(CurrentFileName, "/game.map");
 	/* Write the data to the file */
-	if (!writeMapFile(CurrentFileName))
+	if (!writeMapFile(CurrentFileName, gameWorld.map))
 	{
 		debug(LOG_ERROR, "saveGame: writeMapFile(\"%s\") failed", CurrentFileName);
 		goto error;
@@ -3603,7 +3603,7 @@ bool saveGame(const char *aFileName, GAME_TYPE saveType, bool isAutoSave)
 	CurrentFileName[fileExtension] = '\0';
 	strcat(CurrentFileName, "struct.json");
 	/*Write the data to the file*/
-	if (!writeStructFile(CurrentFileName))
+	if (!writeStructFile(CurrentFileName, gameWorld.objects))
 	{
 		debug(LOG_ERROR, "saveGame: writeStructFile(\"%s\") failed", CurrentFileName);
 		goto error;
@@ -3623,7 +3623,7 @@ bool saveGame(const char *aFileName, GAME_TYPE saveType, bool isAutoSave)
 	CurrentFileName[fileExtension] = '\0';
 	strcat(CurrentFileName, "feature.json");
 	/*Write the data to the file*/
-	if (!writeFeatureFile(CurrentFileName))
+	if (!writeFeatureFile(CurrentFileName, gameWorld.objects))
 	{
 		debug(LOG_ERROR, "saveGame: writeFeatureFile(\"%s\") failed", CurrentFileName);
 		goto error;
@@ -3691,7 +3691,7 @@ bool saveGame(const char *aFileName, GAME_TYPE saveType, bool isAutoSave)
 	CurrentFileName[fileExtension] = '\0';
 	strcat(CurrentFileName, "visstate.bjo");
 	/*Write the data to the file*/
-	if (!writeVisibilityData(CurrentFileName))
+	if (!writeVisibilityData(CurrentFileName, gameWorld.map))
 	{
 		debug(LOG_ERROR, "saveGame: writeVisibilityData(\"%s\") failed", CurrentFileName);
 		goto error;
@@ -3791,7 +3791,7 @@ bool saveGame(const char *aFileName, GAME_TYPE saveType, bool isAutoSave)
 		CurrentFileName[fileExtension] = '\0';
 		strcat(CurrentFileName, "mission.map");
 		/* Write the data to the file */
-		if (!writeMapFile(CurrentFileName))
+		if (!writeMapFile(CurrentFileName, gameWorld.map))
 		{
 			debug(LOG_ERROR, "saveGame: writeMapFile(\"%s\") failed", CurrentFileName);
 			goto error;
@@ -3801,7 +3801,7 @@ bool saveGame(const char *aFileName, GAME_TYPE saveType, bool isAutoSave)
 		CurrentFileName[fileExtension] = '\0';
 		strcat(CurrentFileName, "misvis.bjo");
 		/* Write the data to the file */
-		if (!writeVisibilityData(CurrentFileName))
+		if (!writeVisibilityData(CurrentFileName, gameWorld.map))
 		{
 			debug(LOG_ERROR, "saveGame: writeVisibilityData(\"%s\") failed", CurrentFileName);
 			goto error;
@@ -3811,7 +3811,7 @@ bool saveGame(const char *aFileName, GAME_TYPE saveType, bool isAutoSave)
 		CurrentFileName[fileExtension] = '\0';
 		strcat(CurrentFileName, "mstruct.json");
 		/*Write the data to the file*/
-		if (!writeStructFile(CurrentFileName))
+		if (!writeStructFile(CurrentFileName, gameWorld.objects))
 		{
 			debug(LOG_ERROR, "saveGame: writeStructFile(\"%s\") failed", CurrentFileName);
 			goto error;
@@ -3821,7 +3821,7 @@ bool saveGame(const char *aFileName, GAME_TYPE saveType, bool isAutoSave)
 		CurrentFileName[fileExtension] = '\0';
 		strcat(CurrentFileName, "mfeature.json");
 		/*Write the data to the file*/
-		if (!writeFeatureFile(CurrentFileName))
+		if (!writeFeatureFile(CurrentFileName, gameWorld.objects))
 		{
 			debug(LOG_ERROR, "saveGame: writeFeatureFile(\"%s\") failed", CurrentFileName);
 			goto error;
@@ -3851,13 +3851,13 @@ error:
 }
 
 // -----------------------------------------------------------------------------------------
-static bool writeMapFile(const char *fileName)
+static bool writeMapFile(const char *fileName, const WorldMapState& mapState)
 {
 	ASSERT_OR_RETURN(false, fileName != nullptr, "filename is null");
 
 	/* Get the save data */
 	WzMap::MapData mapData;
-	bool status = mapSaveToWzMapData(mapData);
+	bool status = mapSaveToWzMapData(mapData, mapState);
 	if (!status)
 	{
 		return false;
@@ -5301,7 +5301,7 @@ static bool loadWzMapDroidInit(WzMap::Map &wzMap, std::unordered_map<UDWORD, UDW
 				debug(LOG_ERROR, "Found duplicate hard-coded object ID in map data: %" PRIu32 "", droid.id.value());
 			}
 		}
-		psDroid = reallyBuildDroid(psTemplate, Position(droid.position.x, droid.position.y, 0), player, false, {droid.direction, 0, 0}, newID);
+		psDroid = reallyBuildDroid(gameWorld, psTemplate, Position(droid.position.x, droid.position.y, 0), player, false, {droid.direction, 0, 0}, newID);
 		turnOffMultiMsg(false);
 		if (psDroid == nullptr)
 		{
@@ -5734,11 +5734,11 @@ static bool loadSaveDroid(const char *pFileName, PerPlayerDroidLists& ppsCurrent
 		turnOffMultiMsg(true);
 		if (id > 0)
 		{
-			psDroid = reallyBuildDroid(psTemplate, pos, player, onMission, rot, id);
+			psDroid = reallyBuildDroid(gameWorld, psTemplate, pos, player, onMission, rot, id);
 		} else
 		{
 			// will generate a new id
-			psDroid = reallyBuildDroid(psTemplate, pos, player, onMission, rot);
+			psDroid = reallyBuildDroid(gameWorld, psTemplate, pos, player, onMission, rot);
 		}
 		ASSERT_OR_RETURN(false, psDroid != nullptr, "Failed to build unit %s", sortedList[i].second.toUtf8().c_str());
 		turnOffMultiMsg(false);
@@ -5817,7 +5817,7 @@ static bool loadSaveDroid(const char *pFileName, PerPlayerDroidLists& ppsCurrent
 				psDroid->selected = false;  // Droid should be visible in the transporter interface.
 				if (!psDroid->isTransporter())
 				{
-					visRemoveVisibility(psDroid); // should not have visibility data when in a transporter
+					visRemoveVisibility(psDroid, gameWorld.map); // should not have visibility data when in a transporter
 				}
 			}
 		}
@@ -6241,7 +6241,7 @@ bool loadSaveStructure(char *pFileData, UDWORD filesize)
 		//for modules - need to check the base structure exists
 		if (IsStatExpansionModule(psStats))
 		{
-			psStructure = getTileStructure(map_coord(psSaveStructure->x), map_coord(psSaveStructure->y));
+			psStructure = getTileStructure(gameWorld.map, map_coord(psSaveStructure->x), map_coord(psSaveStructure->y));
 			if (psStructure == nullptr)
 			{
 				debug(LOG_ERROR, "No owning structure for module - %s for player - %d", getSaveStructNameV19((SAVE_STRUCTURE_V17 *)psSaveStructure), psSaveStructure->player);
@@ -6264,7 +6264,7 @@ bool loadSaveStructure(char *pFileData, UDWORD filesize)
 			continue;
 		}
 
-		psStructure = buildStructureDir(psStats, psSaveStructure->x, psSaveStructure->y, DEG(psSaveStructure->direction), psSaveStructure->player, true);
+		psStructure = buildStructureDir(gameWorld, psStats, psSaveStructure->x, psSaveStructure->y, DEG(psSaveStructure->direction), psSaveStructure->player, true);
 		ASSERT(psStructure, "Unable to create structure");
 		if (!psStructure)
 		{
@@ -6332,7 +6332,7 @@ static bool loadWzMapStructure(WzMap::Map& wzMap, std::unordered_map<UDWORD, UDW
 		//for modules - need to check the base structure exists
 		if (IsStatExpansionModule(psStats))
 		{
-			STRUCTURE *psStructure = getTileStructure(map_coord(structure.position.x), map_coord(structure.position.y));
+			STRUCTURE *psStructure = getTileStructure(gameWorld.map, map_coord(structure.position.x), map_coord(structure.position.y));
 			if (psStructure == nullptr)
 			{
 				debug(LOG_ERROR, "No owning structure for module - %s for player - %d", structure.name.c_str(), structure.player);
@@ -6369,7 +6369,7 @@ static bool loadWzMapStructure(WzMap::Map& wzMap, std::unordered_map<UDWORD, UDW
 				debug(LOG_ERROR, "Found duplicate hard-coded object ID in map data: %" PRIu32 "", structure.id.value());
 			}
 		}
-		psStructure = buildStructureDir(psStats, structure.position.x, structure.position.y, structure.direction, player, true, newID);
+		psStructure = buildStructureDir(gameWorld, psStats, structure.position.x, structure.position.y, structure.direction, player, true, newID);
 		if (psStructure == nullptr)
 		{
 			debug(LOG_ERROR, "Structure %s couldn't be built (probably on top of another structure).", structure.name.c_str());
@@ -6401,7 +6401,7 @@ static bool loadWzMapStructure(WzMap::Map& wzMap, std::unordered_map<UDWORD, UDW
 			}
 			for (int i = 0; i < structure.modules; ++i)
 			{
-				buildStructure(moduleStat, structure.position.x, structure.position.y, player, true);
+				buildStructure(gameWorld, moduleStat, structure.position.x, structure.position.y, player, true);
 			}
 		}
 		buildingComplete(psStructure);
@@ -6426,7 +6426,7 @@ static bool loadWzMapStructure(WzMap::Map& wzMap, std::unordered_map<UDWORD, UDW
 
 // -----------------------------------------------------------------------------------------
 /* code for versions after version 20 of a save structure */
-static bool loadSaveStructure2(const char *pFileName)
+static bool loadSaveStructure2(const char *pFileName, GameWorld& world)
 {
 	if (!PHYSFS_exists(pFileName))
 	{
@@ -6435,7 +6435,7 @@ static bool loadSaveStructure2(const char *pFileName)
 	}
 	WzConfig ini(WzString::fromUtf8(pFileName), WzConfig::ReadOnly);
 
-	freeAllFlagPositions();		//clear any flags put in during level loads
+	freeAllFlagPositions(world.objects);		//clear any flags put in during level loads
 
 	std::vector<WzString> list = ini.childGroups();
 	for (size_t i = 0; i < list.size(); ++i)
@@ -6468,7 +6468,7 @@ static bool loadSaveStructure2(const char *pFileName)
 		//for modules - need to check the base structure exists
 		if (IsStatExpansionModule(psStats))
 		{
-			STRUCTURE *psTileStructure = getTileStructure(map_coord(pos.x), map_coord(pos.y));
+			STRUCTURE *psTileStructure = getTileStructure(world.map, map_coord(pos.x), map_coord(pos.y));
 			if (psTileStructure == nullptr)
 			{
 				debug(LOG_ERROR, "No owning structure for module - %s for player - %d", name.toUtf8().c_str(), player);
@@ -6477,8 +6477,8 @@ static bool loadSaveStructure2(const char *pFileName)
 			}
 		}
 		//check not trying to build too near the edge
-		if (map_coord(pos.x) < TOO_NEAR_EDGE || map_coord(pos.x) > gameWorld.map.width - TOO_NEAR_EDGE
-		    || map_coord(pos.y) < TOO_NEAR_EDGE || map_coord(pos.y) > gameWorld.map.height - TOO_NEAR_EDGE)
+		if (map_coord(pos.x) < TOO_NEAR_EDGE || map_coord(pos.x) > world.map.width - TOO_NEAR_EDGE
+		    || map_coord(pos.y) < TOO_NEAR_EDGE || map_coord(pos.y) > world.map.height - TOO_NEAR_EDGE)
 		{
 			debug(LOG_ERROR, "Structure %s (%s), coord too near the edge of the map", name.toUtf8().c_str(), list[i].toUtf8().c_str());
 			ini.endGroup();
@@ -6489,7 +6489,7 @@ static bool loadSaveStructure2(const char *pFileName)
 			id = generateSynchronisedObjectId();
 		}
 		debug(LOG_NEVER, "trying to build structure %i;%i;%s;%i;%i", id, player, psStats->name.toUtf8().c_str(), map_coord(pos.y), map_coord(pos.y));
-		psStructure = buildStructureDir(psStats, pos.x, pos.y, rot.direction, player, true, id);
+		psStructure = buildStructureDir(world, psStats, pos.x, pos.y, rot.direction, player, true, id);
 		ASSERT(psStructure, "Unable to create structure");
 		if (!psStructure)
 		{
@@ -6527,7 +6527,7 @@ static bool loadSaveStructure2(const char *pFileName)
 				//build the appropriate number of modules
 				for (int moduleIdx = 0; moduleIdx < capacity; moduleIdx++)
 				{
-					buildStructure(psModule, psStructure->pos.x, psStructure->pos.y, psStructure->player, true);
+					buildStructure(world, psModule, psStructure->pos.x, psStructure->pos.y, psStructure->player, true);
 
 				}
 			}
@@ -6539,7 +6539,7 @@ static bool loadSaveStructure2(const char *pFileName)
 			if (ini.contains("Factory/assemblyPoint/pos"))
 			{
 				Position point = ini.vector3i("Factory/assemblyPoint/pos");
-				setAssemblyPoint(psFactory->psAssemblyPoint, point.x, point.y, player, false);
+				setAssemblyPoint(world, psFactory->psAssemblyPoint, point.x, point.y, player, false);
 				psFactory->psAssemblyPoint->selected = ini.value("Factory/assemblyPoint/selected", false).toBool();
 			}
 			if (ini.contains("Factory/assemblyPoint/number"))
@@ -6580,7 +6580,7 @@ static bool loadSaveStructure2(const char *pFileName)
 			if (capacity)
 			{
 				psModule = getModuleStat(psStructure);
-				buildStructure(psModule, psStructure->pos.x, psStructure->pos.y, psStructure->player, true);
+				buildStructure(world, psModule, psStructure->pos.x, psStructure->pos.y, psStructure->player, true);
 			}
 			//clear subject
 			psResearch->psSubject = nullptr;
@@ -6605,7 +6605,7 @@ static bool loadSaveStructure2(const char *pFileName)
 			if (capacity)
 			{
 				psModule = getModuleStat(psStructure);
-				buildStructure(psModule, psStructure->pos.x, psStructure->pos.y, psStructure->player, true);
+				buildStructure(world, psModule, psStructure->pos.x, psStructure->pos.y, psStructure->player, true);
 			}
 			break;
 		case REF_RESOURCE_EXTRACTOR:
@@ -6615,7 +6615,7 @@ static bool loadSaveStructure2(const char *pFileName)
 			if (ini.contains("Repair/deliveryPoint/pos"))
 			{
 				Position point = ini.vector3i("Repair/deliveryPoint/pos");
-				setAssemblyPoint(psRepair->psDeliveryPoint, point.x, point.y, player, false);
+				setAssemblyPoint(world, psRepair->psDeliveryPoint, point.x, point.y, player, false);
 				psRepair->psDeliveryPoint->selected = ini.value("Repair/deliveryPoint/selected", false).toBool();
 			}
 			break;
@@ -6667,7 +6667,7 @@ static bool loadSaveStructure2(const char *pFileName)
 		}
 		ini.endGroup();
 	}
-	resetFactoryNumFlag();	//reset flags into the masks
+	resetFactoryNumFlag(world.objects);	//reset flags into the masks
 
 	return true;
 }
@@ -6711,14 +6711,14 @@ bool writeGameInfo(const char *pFileName)
 /*
 Writes the linked list of structure for each player to a file
 */
-bool writeStructFile(const char *pFileName)
+bool writeStructFile(const char *pFileName, const WorldObjectState& objState)
 {
 	WzConfig ini(WzString::fromUtf8(pFileName), WzConfig::ReadAndWrite);
 	int counter = 0;
 
 	for (int player = 0; player < MAX_PLAYERS; player++)
 	{
-		for (const STRUCTURE *psCurr : gameWorld.objects.structures[player])
+		for (const STRUCTURE *psCurr : objState.structures[player])
 		{
 			if (!psCurr->pStructureType)
 			{
@@ -7064,7 +7064,7 @@ bool loadSaveFeature(char *pFileData, UDWORD filesize)
 			continue;
 		}
 		//create the Feature
-		pFeature = buildFeature(psStats, psSaveFeature->x, psSaveFeature->y, true, psSaveFeature->id);
+		pFeature = buildFeature(gameWorld.map, psStats, psSaveFeature->x, psSaveFeature->y, true, psSaveFeature->id);
 		if (!pFeature)
 		{
 			debug(LOG_ERROR, "Unable to create feature %s", psSaveFeature->name);
@@ -7121,7 +7121,7 @@ static bool loadWzMapFeature(WzMap::Map &wzMap, std::unordered_map<UDWORD, UDWOR
 				debug(LOG_ERROR, "Found duplicate hard-coded object ID in map data: %" PRIu32 "", feature.id.value());
 			}
 		}
-		pFeature = buildFeature(&*psStats, feature.position.x, feature.position.y, true, newID);
+		pFeature = buildFeature(gameWorld.map, &*psStats, feature.position.x, feature.position.y, true, newID);
 		if (!pFeature)
 		{
 			debug(LOG_ERROR, "Unable to create feature %s", feature.name.c_str());
@@ -7139,7 +7139,7 @@ static bool loadWzMapFeature(WzMap::Map &wzMap, std::unordered_map<UDWORD, UDWOR
 	return true;
 }
 
-bool loadSaveFeature2(const char *pFileName)
+bool loadSaveFeature2(const char *pFileName, GameWorld& world)
 {
 	if (!PHYSFS_exists(pFileName))
 	{
@@ -7181,11 +7181,11 @@ bool loadSaveFeature2(const char *pFileName)
 		int id = ini.value("id", -1).toInt();
 		if (id > 0)
 		{
-			pFeature = buildFeature(psStats, pos.x, pos.y, true, id);
+			pFeature = buildFeature(world.map, psStats, pos.x, pos.y, true, id);
 		}
 		else
 		{
-			pFeature = buildFeature(psStats, pos.x, pos.y, true);
+			pFeature = buildFeature(world.map, psStats, pos.x, pos.y, true);
 		}
 		if (!pFeature)
 		{
@@ -7214,12 +7214,12 @@ bool loadSaveFeature2(const char *pFileName)
 /*
 Writes the linked list of features to a file
 */
-bool writeFeatureFile(const char *pFileName)
+bool writeFeatureFile(const char *pFileName, const WorldObjectState& objState)
 {
 	WzConfig ini(WzString::fromUtf8(pFileName), WzConfig::ReadAndWrite);
 	int counter = 0;
 
-	for (const FEATURE *psCurr : gameWorld.objects.features[0])
+	for (const FEATURE *psCurr : objState.features[0])
 	{
 		ini.beginGroup("feature_" + (WzString::number(counter++).leftPadToMinimumLength(WzUniCodepoint::fromASCII('0'), 10)));  // Zero padded so that alphabetical sort works.
 		ini.setValue("name", psCurr->psStats->id);
@@ -8207,44 +8207,44 @@ static bool loadSaveGuideTopics(const char *pFileName)
 
 // -----------------------------------------------------------------------------------------
 /* set the global scroll values to use for the save game */
-static void setMapScroll()
+static void setMapScroll(WorldMapState& mapState)
 {
 	//if loading in a pre version5 then scroll values will not have been set up so set to max poss
 	if (width == 0 && height == 0)
 	{
-		gameWorld.map.scroll.minX = 0;
-		gameWorld.map.scroll.maxX = gameWorld.map.width;
-		gameWorld.map.scroll.minY = 0;
-		gameWorld.map.scroll.maxY = gameWorld.map.height;
+		mapState.scroll.minX = 0;
+		mapState.scroll.maxX = mapState.width;
+		mapState.scroll.minY = 0;
+		mapState.scroll.maxY = mapState.height;
 		return;
 	}
-	gameWorld.map.scroll.minX = startX;
-	gameWorld.map.scroll.minY = startY;
-	gameWorld.map.scroll.maxX = startX + width;
-	gameWorld.map.scroll.maxY = startY + height;
+	mapState.scroll.minX = startX;
+	mapState.scroll.minY = startY;
+	mapState.scroll.maxX = startX + width;
+	mapState.scroll.maxY = startY + height;
 	//check not going beyond width/height of map
-	if (gameWorld.map.scroll.maxX > (SDWORD)gameWorld.map.width)
+	if (mapState.scroll.maxX > (SDWORD)mapState.width)
 	{
-		gameWorld.map.scroll.maxX = gameWorld.map.width;
+		mapState.scroll.maxX = mapState.width;
 		debug(LOG_NEVER, "scrollMaxX was too big - It has been set to map width");
 	}
-	if (gameWorld.map.scroll.maxY > (SDWORD)gameWorld.map.height)
+	if (mapState.scroll.maxY > (SDWORD)mapState.height)
 	{
-		gameWorld.map.scroll.maxY = gameWorld.map.height;
+		mapState.scroll.maxY = mapState.height;
 		debug(LOG_NEVER, "scrollMaxY was too big - It has been set to map height");
 	}
 	// check for invalid minimum values (fixes some broken maps)
-	if (gameWorld.map.scroll.minX >= gameWorld.map.scroll.maxX)
+	if (mapState.scroll.minX >= mapState.scroll.maxX)
 	{
 		ASSERT(false, "scrollMinX was >= scrollMaxX - min has been set to 0, max has been set to mapWidth");
-		gameWorld.map.scroll.minX = 0;
-		gameWorld.map.scroll.maxX = gameWorld.map.width;
+		mapState.scroll.minX = 0;
+		mapState.scroll.maxX = mapState.width;
 	}
-	if (gameWorld.map.scroll.minY >= gameWorld.map.scroll.maxY)
+	if (mapState.scroll.minY >= mapState.scroll.maxY)
 	{
 		ASSERT(false, "scrollMinY was >= scrollMaxY - min has been set to 0, max has been set to mapHeight");
-		gameWorld.map.scroll.minY = 0;
-		gameWorld.map.scroll.maxY = gameWorld.map.height;
+		mapState.scroll.minY = 0;
+		mapState.scroll.maxY = mapState.height;
 	}
 }
 

--- a/src/gateway.cpp
+++ b/src/gateway.cpp
@@ -32,36 +32,33 @@
 #include "gateway.h"
 #include "game_world.h"
 
-/// the list of gateways on the current map
-static GATEWAY_LIST psGateways;
-
 // Prototypes
-static void gwFreeGateway(GATEWAY *psDel);
+static void gwFreeGateway(WorldMapState& mapState, GATEWAY *psDel);
 
 /******************************************************************************************************/
 /*                   Gateway data access functions                                                    */
 
 // get the size of the map
-static SDWORD gwMapWidth()
+static SDWORD gwMapWidth(const WorldMapState& mapState)
 {
-	return (SDWORD)gameWorld.map.width;
+	return (SDWORD)mapState.width;
 }
 
-static SDWORD gwMapHeight()
+static SDWORD gwMapHeight(const WorldMapState& mapState)
 {
-	return (SDWORD)gameWorld.map.height;
+	return (SDWORD)mapState.height;
 }
 
 // set the gateway flag on a tile
-static void gwSetGatewayFlag(SDWORD x, SDWORD y)
+static void gwSetGatewayFlag(WorldMapState& mapState, SDWORD x, SDWORD y)
 {
-	mapTile(gameWorld.map, (UDWORD)x, (UDWORD)y)->tileInfoBits |= BITS_GATEWAY;
+	mapTile(mapState, (UDWORD)x, (UDWORD)y)->tileInfoBits |= BITS_GATEWAY;
 }
 
 // clear the gateway flag on a tile
-static void gwClearGatewayFlag(SDWORD x, SDWORD y)
+static void gwClearGatewayFlag(WorldMapState& mapState, SDWORD x, SDWORD y)
 {
-	mapTile(gameWorld.map, (UDWORD)x, (UDWORD)y)->tileInfoBits &= ~BITS_GATEWAY;
+	mapTile(mapState, (UDWORD)x, (UDWORD)y)->tileInfoBits &= ~BITS_GATEWAY;
 }
 
 
@@ -69,30 +66,30 @@ static void gwClearGatewayFlag(SDWORD x, SDWORD y)
 /*                   Gateway functions                                                                */
 
 // Initialise the gateway system
-bool gwInitialise()
+bool gwInitialise(WorldMapState& mapState)
 {
-	psGateways.clear();
+	mapState.gateways.clear();
 	return true;
 }
 
 // Shutdown the gateway system
-void gwShutDown()
+void gwShutDown(WorldMapState& mapState)
 {
-	for (auto psGateway : psGateways)
+	for (auto psGateway : mapState.gateways)
 	{
-		gwFreeGateway(psGateway);
+		gwFreeGateway(mapState, psGateway);
 	}
-	psGateways.clear();
+	mapState.gateways.clear();
 }
 
 // Add a gateway to the system
-bool gwNewGateway(SDWORD x1, SDWORD y1, SDWORD x2, SDWORD y2)
+bool gwNewGateway(WorldMapState& mapState, SDWORD x1, SDWORD y1, SDWORD x2, SDWORD y2)
 {
 	GATEWAY		*psNew;
 	SDWORD		pos, temp;
 
-	ASSERT_OR_RETURN(false, x1 >= 0 && x1 < gwMapWidth() && y1 >= 0 && y1 < gwMapHeight()
-	                 && x2 >= 0 && x2 < gwMapWidth() && y2 >= 0 && y2 < gwMapHeight()
+	ASSERT_OR_RETURN(false, x1 >= 0 && x1 < gwMapWidth(mapState) && y1 >= 0 && y1 < gwMapHeight(mapState)
+	                 && x2 >= 0 && x2 < gwMapWidth(mapState) && y2 >= 0 && y2 < gwMapHeight(mapState)
 	                 && (x1 == x2 || y1 == y2), "Invalid gateway coordinates (%d, %d, %d, %d)",
 	                 x1, y1, x2, y2);
 	psNew = (GATEWAY *)malloc(sizeof(GATEWAY));
@@ -116,11 +113,11 @@ bool gwNewGateway(SDWORD x1, SDWORD y1, SDWORD x2, SDWORD y2)
 	// Initialise the gateway, correct out-of-map gateways
 	psNew->x1 = MAX(3, x1);
 	psNew->y1 = MAX(3, y1);
-	psNew->x2 = MIN(x2, gameWorld.map.width - 4);
-	psNew->y2 = MIN(y2, gameWorld.map.height - 4);
+	psNew->x2 = MIN(x2, mapState.width - 4);
+	psNew->y2 = MIN(y2, mapState.height - 4);
 
 	// add the gateway to the list
-	psGateways.push_back(psNew);
+	mapState.gateways.push_back(psNew);
 
 	// set the map flags
 	if (psNew->x1 == psNew->x2)
@@ -128,7 +125,7 @@ bool gwNewGateway(SDWORD x1, SDWORD y1, SDWORD x2, SDWORD y2)
 		// vertical gateway
 		for (pos = psNew->y1; pos <= psNew->y2; pos++)
 		{
-			gwSetGatewayFlag(psNew->x1, pos);
+			gwSetGatewayFlag(mapState, psNew->x1, pos);
 		}
 	}
 	else
@@ -136,7 +133,7 @@ bool gwNewGateway(SDWORD x1, SDWORD y1, SDWORD x2, SDWORD y2)
 		// horizontal gateway
 		for (pos = psNew->x1; pos <= psNew->x2; pos++)
 		{
-			gwSetGatewayFlag(pos, psNew->y1);
+			gwSetGatewayFlag(mapState, pos, psNew->y1);
 		}
 	}
 
@@ -144,22 +141,22 @@ bool gwNewGateway(SDWORD x1, SDWORD y1, SDWORD x2, SDWORD y2)
 }
 
 // Return the number of gateways.
-size_t gwNumGateways()
+size_t gwNumGateways(const WorldMapState& mapState)
 {
-	return psGateways.size();
+	return mapState.gateways.size();
 }
 
-GATEWAY_LIST &gwGetGateways()
+GATEWAY_LIST &gwGetGateways(WorldMapState& mapState)
 {
-	return psGateways;
+	return mapState.gateways;
 }
 
 // Release a gateway
-static void gwFreeGateway(GATEWAY *psDel)
+static void gwFreeGateway(WorldMapState& mapState, GATEWAY *psDel)
 {
 	int pos;
 
-	if (gameWorld.map.tiles) // this lines fixes the bug where we were closing the gateways after freeing the map
+	if (mapState.tiles) // this lines fixes the bug where we were closing the gateways after freeing the map
 	{
 		// clear the map flags
 		if (psDel->x1 == psDel->x2)
@@ -167,7 +164,7 @@ static void gwFreeGateway(GATEWAY *psDel)
 			// vertical gateway
 			for (pos = psDel->y1; pos <= psDel->y2; pos++)
 			{
-				gwClearGatewayFlag(psDel->x1, pos);
+				gwClearGatewayFlag(mapState, psDel->x1, pos);
 			}
 		}
 		else
@@ -175,7 +172,7 @@ static void gwFreeGateway(GATEWAY *psDel)
 			// horizontal gateway
 			for (pos = psDel->x1; pos <= psDel->x2; pos++)
 			{
-				gwClearGatewayFlag(pos, psDel->y1);
+				gwClearGatewayFlag(mapState, pos, psDel->y1);
 			}
 		}
 

--- a/src/gateway.h
+++ b/src/gateway.h
@@ -28,6 +28,8 @@
 
 #include <stdint.h>
 
+struct WorldMapState;
+
 struct GATEWAY
 {
 	uint8_t x1, y1, x2, y2;
@@ -36,18 +38,18 @@ struct GATEWAY
 typedef std::list<GATEWAY *> GATEWAY_LIST;
 
 /// Initialise the gateway system
-bool gwInitialise();
+bool gwInitialise(WorldMapState& mapState);
 
 /// Shutdown the gateway system
-void gwShutDown();
+void gwShutDown(WorldMapState& mapState);
 
 /// Add a gateway to the system
-bool gwNewGateway(int x1, int y1, int x2, int y2);
+bool gwNewGateway(WorldMapState& mapState, int x1, int y1, int x2, int y2);
 
 /// Get number of gateways.
-size_t gwNumGateways();
+size_t gwNumGateways(const WorldMapState& mapState);
 
 /// Get the gateway list.
-GATEWAY_LIST &gwGetGateways();
+GATEWAY_LIST &gwGetGateways(WorldMapState& mapState);
 
 #endif // __INCLUDED_SRC_GATEWAY_H__

--- a/src/geometry.cpp
+++ b/src/geometry.cpp
@@ -45,7 +45,7 @@ uint16_t calcDirection(int32_t x0, int32_t y0, int32_t x1, int32_t y1)
   NB*****THIS WON'T PICK A VTOL DROID*****
 */
 
-DROID	*getNearestDroid(UDWORD x, UDWORD y, bool bSelected)
+DROID	*getNearestDroid(WorldObjectState& objState, UDWORD x, UDWORD y, bool bSelected)
 {
 	DROID *psBestUnit = nullptr;
 	unsigned bestSoFar = UDWORD_MAX;
@@ -53,7 +53,7 @@ DROID	*getNearestDroid(UDWORD x, UDWORD y, bool bSelected)
 	ASSERT_OR_RETURN(nullptr, selectedPlayer < MAX_PLAYERS, "Not supported selectedPlayer: %" PRIu32 "", selectedPlayer);
 
 	/* Go thru' all the droids  - how often have we seen this - a MACRO maybe? */
-	for (DROID *psDroid : gameWorld.objects.droids[selectedPlayer])
+	for (DROID *psDroid : objState.droids[selectedPlayer])
 	{
 		if (!psDroid->isVtol())
 		{

--- a/src/geometry.h
+++ b/src/geometry.h
@@ -23,6 +23,9 @@
 
 #include "map.h"
 #include "game_world.h"
+#include "world_map_state.h"
+
+struct WorldObjectState;
 
 struct QUAD
 {
@@ -32,12 +35,12 @@ struct QUAD
 uint16_t calcDirection(int32_t x0, int32_t y0, int32_t x1, int32_t y1);
 bool inQuad(const Vector2i *pt, const QUAD *quad);
 Vector2i positionInQuad(Vector2i const &pt, QUAD const &quad);
-DROID *getNearestDroid(UDWORD x, UDWORD y, bool bSelected);
+DROID *getNearestDroid(WorldObjectState& objState, UDWORD x, UDWORD y, bool bSelected);
 bool objectOnScreen(const BASE_OBJECT *object, SDWORD tolerance);
 
-static inline STRUCTURE *getTileStructure(UDWORD x, UDWORD y)
+static inline STRUCTURE *getTileStructure(WorldMapState& mapState, UDWORD x, UDWORD y)
 {
-	BASE_OBJECT *psObj = mapTile(gameWorld.map, x, y)->psObject;
+	BASE_OBJECT *psObj = mapTile(mapState, x, y)->psObject;
 	if (psObj && psObj->type == OBJ_STRUCTURE)
 	{
 		return (STRUCTURE *)psObj;
@@ -45,9 +48,9 @@ static inline STRUCTURE *getTileStructure(UDWORD x, UDWORD y)
 	return nullptr;
 }
 
-static inline FEATURE *getTileFeature(UDWORD x, UDWORD y)
+static inline FEATURE *getTileFeature(WorldMapState& mapState, UDWORD x, UDWORD y)
 {
-	BASE_OBJECT *psObj = mapTile(gameWorld.map, x, y)->psObject;
+	BASE_OBJECT *psObj = mapTile(mapState, x, y)->psObject;
 	if (psObj && psObj->type == OBJ_FEATURE)
 	{
 		return (FEATURE *)psObj;
@@ -57,13 +60,13 @@ static inline FEATURE *getTileFeature(UDWORD x, UDWORD y)
 
 /// WARNING: Returns NULL if tile not visible to selectedPlayer.
 /// Must *NOT* be used for anything game-state/simulation-calculation related
-static inline BASE_OBJECT *getTileOccupier(UDWORD x, UDWORD y)
+static inline BASE_OBJECT *getTileOccupier(WorldMapState& mapState, UDWORD x, UDWORD y)
 {
-	MAPTILE *psTile = mapTile(gameWorld.map, x, y);
+	MAPTILE *psTile = mapTile(mapState, x, y);
 
 	if (TEST_TILE_VISIBLE_TO_SELECTEDPLAYER(psTile))
 	{
-		return mapTile(gameWorld.map, x, y)->psObject;
+		return mapTile(mapState, x, y)->psObject;
 	}
 	else
 	{

--- a/src/group.cpp
+++ b/src/group.cpp
@@ -32,6 +32,7 @@
 #include "droid.h"
 #include "order.h"
 #include "hci.h"
+#include "game_world.h"
 #include <map>
 
 // Group system variables: grpGlobalManager enables to remove all the groups to Shutdown the system
@@ -232,6 +233,6 @@ void DROID_GROUP::setSecondary(SECONDARY_ORDER sec, SECONDARY_STATE state)
 
 	for (DROID* psCurr : psList)
 	{
-		secondarySetState(psCurr, sec, state);
+		secondarySetState(psCurr, gameWorld.objects, sec, state);
 	}
 }

--- a/src/hci.cpp
+++ b/src/hci.cpp
@@ -1792,7 +1792,7 @@ INT_RETVAL intRunWidgets()
 					else if (psPositionStats->hasType(STAT_TEMPLATE))
 					{
 						std::string msg;
-						DROID *psDroid = buildDroid((DROID_TEMPLATE *)psPositionStats, pos.x, pos.y, selectedPlayer, false, nullptr);
+						DROID *psDroid = buildDroid(gameWorld, (DROID_TEMPLATE *)psPositionStats, pos.x, pos.y, selectedPlayer, false, nullptr);
 						cancelDeliveryRepos();
 						if (psDroid)
 						{

--- a/src/hci/build.cpp
+++ b/src/hci/build.cpp
@@ -59,7 +59,7 @@ void BuildController::updateBuildersList()
 
 void BuildController::updateBuildOptionsList()
 {
-	auto newBuildOptions = fillStructureList(selectedPlayer, MAXSTRUCTURES - 1, shouldShowFavorites());
+	auto newBuildOptions = fillStructureList(gameWorld.objects, selectedPlayer, MAXSTRUCTURES - 1, shouldShowFavorites());
 
 	stats = std::vector<STRUCTURE_STATS *>(newBuildOptions.begin(), newBuildOptions.end());
 }

--- a/src/hci/objects_stats.cpp
+++ b/src/hci/objects_stats.cpp
@@ -61,7 +61,7 @@ void BaseObjectsController::prepareToClose()
 void BaseObjectsController::jumpToObject(BASE_OBJECT *object)
 {
 	ASSERT_NOT_NULLPTR_OR_RETURN(, object);
-	setPlayerPos(object->pos.x, object->pos.y);
+	setPlayerPos(gameWorld.map, object->pos.x, object->pos.y);
 	setWarCamActive(false);
 }
 
@@ -202,7 +202,7 @@ void ObjectButton::jump()
 	}
 	else
 	{
-		setPlayerPos(jumpPosition.x, jumpPosition.y);
+		setPlayerPos(gameWorld.map, jumpPosition.x, jumpPosition.y);
 		setWarCamActive(false);
 		jumpPosition = {0, 0};
 	}

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1434,7 +1434,7 @@ bool stageOneShutDown()
 	ResearchRelease();
 
 	//free up the gateway stuff?
-	gwShutDown();
+	gwShutDown(gameWorld.map);
 
 	shutdownTerrain();
 
@@ -1531,7 +1531,7 @@ bool stageTwoInitialise()
 		return false;
 	}
 
-	if (!gwInitialise())
+	if (!gwInitialise(gameWorld.map))
 	{
 		return false;
 	}
@@ -1601,10 +1601,10 @@ bool stageTwoShutDown()
 
 	cdAudio_Stop();
 
-	freeAllStructs();
-	freeAllDroids();
-	freeAllFeatures();
-	freeAllFlagPositions();
+	freeAllStructs(gameWorld);
+	freeAllDroids(gameWorld);
+	freeAllFeatures(gameWorld);
+	freeAllFlagPositions(gameWorld.objects);
 
 	if (!messageShutdown())
 	{
@@ -1621,7 +1621,7 @@ bool stageTwoShutDown()
 	cmdDroidShutDown();
 
 	//free up the gateway stuff?
-	gwShutDown();
+	gwShutDown(gameWorld.map);
 
 	if (!mapShutdown())
 	{
@@ -1719,7 +1719,7 @@ bool stageThreeInitialise()
 	}
 
 	effectResetUpdates();
-	initLighting(0, 0, gameWorld.map.width, gameWorld.map.height);
+	initLighting(gameWorld.map, 0, 0, gameWorld.map.width, gameWorld.map.height);
 	pie_InitLighting();
 	getCurrentLightmapData().reset(gameWorld.map.width, gameWorld.map.height);
 
@@ -1738,7 +1738,7 @@ bool stageThreeInitialise()
 		initTemplates();
 	}
 
-	preProcessVisibility();
+	preProcessVisibility(gameWorld.map);
 
 	prepareScripts(getLevelLoadType() == GTYPE_SAVE_MIDMISSION || getLevelLoadType() == GTYPE_SAVE_START);
 
@@ -1747,8 +1747,8 @@ bool stageThreeInitialise()
 		return false;
 	}
 
-	mapInit();
-	gridReset();
+	mapInit(gameWorld);
+	gridReset(gameWorld);
 
 	//if mission screen is up, close it.
 	if (MissionResUp)
@@ -1768,7 +1768,7 @@ bool stageThreeInitialise()
 
 	// add radar to interface screen, and resize
 	intAddRadarWidget();
-	resizeRadar();
+	resizeRadar(gameWorld.map);
 
 	setAllPauseStates(false);
 
@@ -1791,7 +1791,7 @@ bool stageThreeInitialise()
 		}
 
 		executeFnAndProcessScriptQueuedRemovals([]() { triggerEvent(TRIGGER_GAME_INIT); });
-		playerBuiltHQ = structureExists(selectedPlayer, REF_HQ, true, false);
+		playerBuiltHQ = structureExists(gameWorld.objects, selectedPlayer, REF_HQ, true);
 	}
 
 	// Start / randomize in-game music
@@ -1879,7 +1879,7 @@ bool stageThreeShutDown()
 bool campaignReset()
 {
 	debug(LOG_MAIN, "campaignReset");
-	gwShutDown();
+	gwShutDown(gameWorld.map);
 	mapShutdown();
 	shutdownTerrain();
 	// when the terrain textures are reloaded we need to reset the radar
@@ -1896,15 +1896,15 @@ bool saveGameReset()
 
 	cdAudio_Stop();
 
-	freeAllStructs();
-	freeAllDroids();
-	freeAllFeatures();
-	freeAllFlagPositions();
+	freeAllStructs(gameWorld);
+	freeAllDroids(gameWorld);
+	freeAllFeatures(gameWorld);
+	freeAllFlagPositions(gameWorld.objects);
 	initMission();
 	initTransporters();
 
 	//free up the gateway stuff?
-	gwShutDown();
+	gwShutDown(gameWorld.map);
 	intResetScreen(true);
 
 	if (!mapShutdown())

--- a/src/intdisplay.cpp
+++ b/src/intdisplay.cpp
@@ -278,7 +278,7 @@ void PowerBar::display(int xOffset, int yOffset)
 
 	imageDrawBatch.draw(true);
 
-	auto unusedDerricks = countPlayerUnusedDerricks();
+	auto unusedDerricks = countPlayerUnusedDerricks(gameWorld.objects);
 
 	auto showNeedMessage = true;
 	if (unusedDerricks > 0)

--- a/src/intorder.cpp
+++ b/src/intorder.cpp
@@ -916,7 +916,7 @@ static bool SetSecondaryState(SECONDARY_ORDER sec, unsigned State)
 			//Only set the state if it's not a transporter.
 			if (!SelectedDroid->isTransporter())
 			{
-				if (!secondarySetState(SelectedDroid, sec, (SECONDARY_STATE)State))
+				if (!secondarySetState(SelectedDroid, gameWorld.objects, sec, (SECONDARY_STATE)State))
 				{
 					return false;
 				}

--- a/src/keybind.cpp
+++ b/src/keybind.cpp
@@ -447,7 +447,7 @@ void kf_CloneSelected(int limit)
 	for (int i = 0; i < limit; i++)
 	{
 		Vector2i pos = droidToClone->pos.xy() + iSinCosR(40503 * i, iSqrt(50 * 50 * (i + 1)));  // 40503 = 65536/φ (A bit more than a right angle)
-		DROID* psNewDroid = buildDroid(sTemplate, pos.x, pos.y, droidToClone->player, false, nullptr);
+		DROID* psNewDroid = buildDroid(gameWorld, sTemplate, pos.x, pos.y, droidToClone->player, false, nullptr);
 		if (psNewDroid)
 		{
 			addDroid(psNewDroid, gameWorld.objects.droids);
@@ -805,7 +805,7 @@ void	kf_TogglePower()
 /* Recalculates the lighting values for a tile */
 void	kf_RecalcLighting()
 {
-	initLighting(0, 0, gameWorld.map.width, gameWorld.map.height);
+	initLighting(gameWorld.map, 0, 0, gameWorld.map.width, gameWorld.map.height);
 	addConsoleMessage(_("Lighting values for all tiles recalculated"), DEFAULT_JUSTIFY, SYSTEM_MESSAGE);
 }
 
@@ -900,7 +900,7 @@ void kf_RevealMapAtPos()
 
 	if (selectedPlayer >= MAX_PLAYERS) { return; }
 
-	addSpotter(mouseTileX, mouseTileY, selectedPlayer, 1024, false, gameTime + 2000);
+	addSpotter(gameWorld.map, mouseTileX, mouseTileY, selectedPlayer, 1024, false, gameTime + 2000);
 }
 
 // --------------------------------------------------------------------------
@@ -942,7 +942,7 @@ void	kf_RaiseTile()
 		return;  // Don't desynch if pressing 'W'...
 	}
 
-	raiseTile(mouseTileX, mouseTileY);
+	raiseTile(gameWorld.map, mouseTileX, mouseTileY);
 }
 
 // --------------------------------------------------------------------------
@@ -955,7 +955,7 @@ void	kf_LowerTile()
 		return;  // Don't desynch if pressing 'A'...
 	}
 
-	lowerTile(mouseTileX, mouseTileY);
+	lowerTile(gameWorld.map, mouseTileX, mouseTileY);
 }
 
 // --------------------------------------------------------------------------
@@ -979,7 +979,7 @@ MappableFunction kf_RadarZoom(const int multiplier)
 		if (newZoomLevel != oldZoomLevel)
 		{
 			CONPRINTF(_("Setting radar zoom to %u"), static_cast<unsigned>(newZoomLevel));
-			SetRadarZoom(newZoomLevel);
+			SetRadarZoom(gameWorld.map, newZoomLevel);
 			war_SetRadarZoom(GetRadarZoom()); // persist changed setting to config
 			audio_PlayTrack(ID_SOUND_BUTTON_CLICK_5);
 		}
@@ -1171,7 +1171,7 @@ MappableFunction kf_RemoveFromGrouping()
 		/* not supported if a spectator */
 		SPECTATOR_NO_OP();
 
-		removeObjectFromGroup(selectedPlayer);
+		removeObjectFromGroup(gameWorld.objects, selectedPlayer);
 	};
 }
 
@@ -1288,11 +1288,11 @@ void enableGodMode()
 	}
 
 	godMode = true; // view all structures and droids
-	revealAll(selectedPlayer);
+	revealAll(gameWorld.map, selectedPlayer);
 	setRevealStatus(true); // view the entire map
 	radarPermitted = true; //add minimap without CC building
 
-	preProcessVisibility();
+	preProcessVisibility(gameWorld.map);
 }
 
 void	kf_ToggleGodMode()
@@ -1336,7 +1336,7 @@ void	kf_ToggleGodMode()
 		}
 		// remove all proximity messages
 		releaseAllProxDisp();
-		radarPermitted = structureExists(selectedPlayer, REF_HQ, true, false) || structureExists(selectedPlayer, REF_HQ, true, true);
+		radarPermitted = structureExists(gameWorld.objects, selectedPlayer, REF_HQ, true) || structureExists(mission.gameWorld.objects, selectedPlayer, REF_HQ, true);
 	}
 	else
 	{
@@ -1719,7 +1719,7 @@ MappableFunction kf_JumpToUnits(const DROID_TYPE droidType)
 		/* not supported if a spectator */
 		SPECTATOR_NO_OP();
 
-		selNextSpecifiedUnit(droidType);
+		selNextSpecifiedUnit(gameWorld.objects, droidType);
 	};
 }
 
@@ -1729,7 +1729,7 @@ void	kf_JumpToUnassignedUnits()
 	/* not supported if a spectator */
 	SPECTATOR_NO_OP();
 
-	selNextUnassignedUnit();
+	selNextUnassignedUnit(gameWorld.objects);
 }
 // --------------------------------------------------------------------------
 
@@ -1902,7 +1902,7 @@ MappableFunction kf_SelectNextFactory(const STRUCTURE_TYPE factoryType, const bo
 		/* not supported if a spectator */
 		SPECTATOR_NO_OP();
 
-		selNextSpecifiedBuilding(factoryType, bJumpToSelected);
+		selNextSpecifiedBuilding(gameWorld.objects, factoryType, bJumpToSelected);
 
 		//deselect factories of other types
 		for (STRUCTURE* psCurrent : gameWorld.objects.structures[selectedPlayer])
@@ -1932,7 +1932,7 @@ MappableFunction kf_SelectNextResearch(const bool bJumpToSelected)
 		/* not supported if a spectator */
 		SPECTATOR_NO_OP();
 
-		selNextSpecifiedBuilding(REF_RESEARCH, bJumpToSelected);
+		selNextSpecifiedBuilding(gameWorld.objects, REF_RESEARCH, bJumpToSelected);
 		if (intCheckReticuleButEnabled(IDRET_RESEARCH))
 		{
 			setKeyButtonMapping(IDRET_RESEARCH);
@@ -1948,7 +1948,7 @@ MappableFunction kf_SelectNextPowerStation(const bool bJumpToSelected)
 		/* not supported if a spectator */
 		SPECTATOR_NO_OP();
 
-		selNextSpecifiedBuilding(REF_POWER_GEN, bJumpToSelected);
+		selNextSpecifiedBuilding(gameWorld.objects, REF_POWER_GEN, bJumpToSelected);
 		triggerEventSelected();
 	};
 }
@@ -2095,7 +2095,7 @@ void	kf_ToggleConsole()
 MappableFunction kf_SelectUnits(const SELECTIONTYPE selectionType, const SELECTION_CLASS selectionClass, const bool bOnScreen)
 {
 	return [selectionClass, selectionType, bOnScreen]() {
-		selDroidSelection(selectedPlayer, selectionClass, selectionType, bOnScreen);
+		selDroidSelection(gameWorld.objects, selectedPlayer, selectionClass, selectionType, bOnScreen);
 	};
 }
 
@@ -2167,7 +2167,7 @@ static void kfsf_SetSelectedDroidsState(SECONDARY_ORDER sec, SECONDARY_STATE sta
 		// Only set the state if it's not a transporter.
 		if (psDroid->selected && !psDroid->isTransporter())
 		{
-			secondarySetState(psDroid, sec, state);
+			secondarySetState(psDroid, gameWorld.objects, sec, state);
 		}
 	}
 	intRefreshOrder();
@@ -2468,7 +2468,7 @@ void kf_ToggleRadarAllyEnemy()
 	{
 		CONPRINTF("%s", _("Radar showing player colors"));
 	}
-	resizeRadar();
+	resizeRadar(gameWorld.map);
 }
 
 void kf_ToggleRadarTerrain()
@@ -2521,7 +2521,7 @@ void	kf_AddHelpBlip()
 	y = mouseY();
 	if (isMouseOverRadar())
 	{
-		CalcRadarPosition(x, y, &worldX, &worldY);
+		CalcRadarPosition(gameWorld.map, x, y, &worldX, &worldY);
 		worldX = worldX * TILE_UNITS + TILE_UNITS / 2;
 		worldY = worldY * TILE_UNITS + TILE_UNITS / 2;
 	}

--- a/src/lighting.cpp
+++ b/src/lighting.cpp
@@ -64,7 +64,7 @@ void setTheSun(Vector3f newSun)
 	if(oldSun != theSun)
 	{
 		// The sun has changed - must relcalulate lighting
-		initLighting(0, 0, gameWorld.map.width, gameWorld.map.height);
+		initLighting(gameWorld.map, 0, 0, gameWorld.map.width, gameWorld.map.height);
 	}
 }
 
@@ -81,10 +81,10 @@ Vector3f getTheSun()
 
 //By passing in params - it means that if the scroll limits are changed mid-mission
 //we can re-do over the area that hasn't been seen
-void initLighting(UDWORD x1, UDWORD y1, UDWORD x2, UDWORD y2)
+void initLighting(WorldMapState& mapState, UDWORD x1, UDWORD y1, UDWORD x2, UDWORD y2)
 {
 	// quick check not trying to go off the map - don't need to check for < 0 since UWORD's!!
-	if (x1 > gameWorld.map.width || x2 > gameWorld.map.width || y1 > gameWorld.map.height || y2 > gameWorld.map.height)
+	if (x1 > mapState.width || x2 > mapState.width || y1 > mapState.height || y2 > mapState.height)
 	{
 		ASSERT(false, "initLighting: coords off edge of map");
 		return;
@@ -94,10 +94,10 @@ void initLighting(UDWORD x1, UDWORD y1, UDWORD x2, UDWORD y2)
 	{
 		for (unsigned i = x1; i < x2; i++)
 		{
-			MAPTILE	*psTile = mapTile(gameWorld.map, i, j);
+			MAPTILE	*psTile = mapTile(mapState, i, j);
 
 			// always make the edge tiles dark
-			if (i == 0 || j == 0 || i >= gameWorld.map.width - 1 || j >= gameWorld.map.height - 1)
+			if (i == 0 || j == 0 || i >= mapState.width - 1 || j >= mapState.height - 1)
 			{
 				psTile->illumination = 16;
 				psTile->ambientOcclusion = 16.0;
@@ -108,8 +108,8 @@ void initLighting(UDWORD x1, UDWORD y1, UDWORD x2, UDWORD y2)
 			}
 			// Basically darkens down the tiles that are outside the scroll
 			// limits - thereby emphasising the cannot-go-there-ness of them
-			if ((SDWORD)i < gameWorld.map.scroll.minX + 4 || (SDWORD)i > gameWorld.map.scroll.maxX - 4
-			    || (SDWORD)j < gameWorld.map.scroll.minY + 4 || (SDWORD)j > gameWorld.map.scroll.maxY - 4)
+			if ((SDWORD)i < mapState.scroll.minX + 4 || (SDWORD)i > mapState.scroll.maxX - 4
+			    || (SDWORD)j < mapState.scroll.minY + 4 || (SDWORD)j > mapState.scroll.maxY - 4)
 			{
 				psTile->illumination /= 3;
 				psTile->ambientOcclusion /= 3;

--- a/src/lighting.h
+++ b/src/lighting.h
@@ -24,6 +24,7 @@
 #include "lib/ivis_opengl/pietypes.h"
 #include "lib/ivis_opengl/pielighting.h"
 
+struct WorldMapState;
 
 namespace rendering1999
 {
@@ -37,7 +38,7 @@ namespace rendering1999
 void setTheSun(Vector3f newSun);
 Vector3f getTheSun();
 
-void initLighting(UDWORD x1, UDWORD y1, UDWORD x2, UDWORD y2);
+void initLighting(WorldMapState& mapState, UDWORD x1, UDWORD y1, UDWORD x2, UDWORD y2);
 void updateFogDistance(float distance);
 void setDefaultFogColour();
 void calcDroidIllumination(DROID *psDroid);

--- a/src/loop.cpp
+++ b/src/loop.cpp
@@ -544,13 +544,13 @@ static void gameStateUpdate()
 	visUpdateLevel();
 
 	// Put all droids/structures/features into the grid.
-	gridReset();
+	gridReset(gameWorld);
 
 	// Check which objects are visible.
 	processVisibility();
 
 	// Update the map.
-	mapUpdate();
+	mapUpdate(gameWorld);
 
 	//update the findpath system
 	fpathUpdate();

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -39,7 +39,7 @@
 #include "projectile.h"
 #include "display3d.h"
 #include "game.h"
-#include "world_map_state.h"
+#include "game_world.h"
 #include "texture.h"
 #include "advvis.h"
 #include "random.h"
@@ -112,7 +112,7 @@ struct GATEWAY_SAVE
 
 static void SetGroundForTile(const char *filename, const char *nametype);
 static int getTextureType(const char *textureType);
-static bool hasDecals(int i, int j);
+static bool hasDecals(WorldMapState& mapState, int i, int j);
 static void SetDecals(const char *filename, const char *decal_type);
 static void init_tileNames(MAP_TILESET type);
 
@@ -133,17 +133,17 @@ static std::unique_ptr<bool[]> mapDecals;           // array that tells us what 
 UBYTE terrainTypes[MAX_TILE_TEXTURES];
 
 #if 0
-void syncLogDumpAuxMaps()
+void syncLogDumpAuxMaps(const WorldMapState& mapState)
 {
 	for (int auxIdx = 0; auxIdx < MAX_PLAYERS + AUX_MAX; auxIdx++)
 	{
 		syncDebug("psAuxMap[%d]:", auxIdx);
-		for (int y = 0; y < gameWorld.map.height; ++y)
+		for (int y = 0; y < mapState.height; ++y)
 		{
 			std::string rowDetails;
-			for (int x = 0; x < gameWorld.map.width; ++x)
+			for (int x = 0; x < mapState.width; ++x)
 			{
-				auto val = auxTile(gameWorld.map, x, y, auxIdx);
+				auto val = auxTile(mapState, x, y, auxIdx);
 				rowDetails += std::to_string(val) + ",";
 			}
 			syncDebug("psAuxMap[%d] row[%d]: %s", auxIdx, y, rowDetails.c_str());
@@ -153,12 +153,12 @@ void syncLogDumpAuxMaps()
 	for (int idx = 0; idx < AUX_MAX; idx++)
 	{
 		syncDebug("psBlockMap[%d]:", idx);
-		for (int y = 0; y < gameWorld.map.height; ++y)
+		for (int y = 0; y < mapState.height; ++y)
 		{
 			std::string rowDetails;
-			for (int x = 0; x < gameWorld.map.width; ++x)
+			for (int x = 0; x < mapState.width; ++x)
 			{
-				auto val = blockTile(gameWorld.map, x, y, idx);
+				auto val = blockTile(mapState, x, y, idx);
 				rowDetails += std::to_string(val) + ",";
 			}
 			syncDebug("psBlockMap[%d] row[%d]: %s", idx, y, rowDetails.c_str());
@@ -546,7 +546,7 @@ static void rotFlip(int tile, int *i, int *j)
 }
 
 /// Tries to figure out what ground type a grid point is from the surrounding tiles
-static int determineGroundType(int x, int y, const char *tileset)
+static int determineGroundType(WorldMapState& mapState, int x, int y, const char *tileset)
 {
 	int ground[2][2];
 	int votes[2][2];
@@ -555,7 +555,7 @@ static int determineGroundType(int x, int y, const char *tileset)
 	int a, b, best;
 	MAPTILE *psTile;
 
-	if (x < 0 || y < 0 || x >= gameWorld.map.width || y >= gameWorld.map.height)
+	if (x < 0 || y < 0 || x >= mapState.width || y >= mapState.height)
 	{
 		return 0; // just return the first ground type
 	}
@@ -565,14 +565,14 @@ static int determineGroundType(int x, int y, const char *tileset)
 	{
 		for (j = 0; j < 2; j++)
 		{
-			if (x + i - 1 < 0 || y + j - 1 < 0 || x + i - 1 >= gameWorld.map.width || y + j - 1 >= gameWorld.map.height)
+			if (x + i - 1 < 0 || y + j - 1 < 0 || x + i - 1 >= mapState.width || y + j - 1 >= mapState.height)
 			{
 				psTile = nullptr;
 				tile = 0;
 			}
 			else
 			{
-				psTile = mapTile(gameWorld.map, x + i - 1, y + j - 1);
+				psTile = mapTile(mapState, x + i - 1, y + j - 1);
 				tile = psTile->texture;
 			}
 			a = i;
@@ -685,10 +685,10 @@ static void SetDecals(const char *filename, const char *decal_type)
 }
 // hasDecals()
 // Checks to see if the requested tile has a decal on it or not.
-static bool hasDecals(int i, int j)
+static bool hasDecals(WorldMapState& mapState, int i, int j)
 {
 	int index = 0;
-	index = TileNumber_tile(mapTile(gameWorld.map, i, j)->texture);
+	index = TileNumber_tile(mapTile(mapState, i, j)->texture);
 	if (index > MAX_TERRAIN_TILES)
 	{
 		debug(LOG_FATAL, "Tile index is out of range!  Was %d, our max is %d", index, MAX_TERRAIN_TILES);
@@ -698,17 +698,17 @@ static bool hasDecals(int i, int j)
 }
 // mapSetGroundTypes()
 // Sets the ground type to be a decal or not
-static bool mapSetGroundTypes()
+static bool mapSetGroundTypes(WorldMapState& mapState)
 {
-	for (int j = 0; j < gameWorld.map.height; j++)
+	for (int j = 0; j < mapState.height; j++)
 	{
-		for (int i = 0; i < gameWorld.map.width; i++)
+		for (int i = 0; i < mapState.width; i++)
 		{
-			MAPTILE *psTile = mapTile(gameWorld.map, i, j);
+			MAPTILE *psTile = mapTile(mapState, i, j);
 
-			psTile->ground = determineGroundType(i, j, tilesetDir);
+			psTile->ground = determineGroundType(mapState, i, j, tilesetDir);
 
-			if (hasDecals(i, j))
+			if (hasDecals(mapState, i, j))
 			{
 				SET_TILE_DECAL(psTile);
 			}
@@ -728,38 +728,38 @@ bool mapReloadGroundTypes()
 		return false;
 	}
 	mapLoadGroundTypes(false);
-	if (!mapSetGroundTypes())
+	if (!mapSetGroundTypes(gameWorld.map))
 	{
 		return false;
 	}
 	return true;
 }
 
-static bool isWaterVertex(int x, int y)
+static bool isWaterVertex(WorldMapState& mapState, int x, int y)
 {
-	if (x < 1 || y < 1 || x > gameWorld.map.width - 1 || y > gameWorld.map.height - 1)
+	if (x < 1 || y < 1 || x > mapState.width - 1 || y > mapState.height - 1)
 	{
 		return false;
 	}
-	return terrainType(mapTile(gameWorld.map, x, y)) == TER_WATER && terrainType(mapTile(gameWorld.map, x - 1, y)) == TER_WATER
-	       && terrainType(mapTile(gameWorld.map, x, y - 1)) == TER_WATER && terrainType(mapTile(gameWorld.map, x - 1, y - 1)) == TER_WATER;
+	return terrainType(mapTile(mapState, x, y)) == TER_WATER && terrainType(mapTile(mapState, x - 1, y)) == TER_WATER
+	       && terrainType(mapTile(mapState, x, y - 1)) == TER_WATER && terrainType(mapTile(mapState, x - 1, y - 1)) == TER_WATER;
 }
 
-static void generateRiverbed()
+static void generateRiverbed(WorldMapState& mapState)
 {
 	MersenneTwister mt(12345);  // 12345 = random seed.
 	int maxIdx = 1;
-	ASSERT_OR_RETURN(, gameWorld.map.width > 0 && gameWorld.map.height > 0, "Invalid map width or height (%d x %d)", gameWorld.map.width, gameWorld.map.height);
-	std::vector<int> idx(static_cast<size_t>(gameWorld.map.width) * static_cast<size_t>(gameWorld.map.height), 0);
+	ASSERT_OR_RETURN(, mapState.width > 0 && mapState.height > 0, "Invalid map width or height (%d x %d)", mapState.width, mapState.height);
+	std::vector<int> idx(static_cast<size_t>(mapState.width) * static_cast<size_t>(mapState.height), 0);
 	int x, y, l = 0;
 
-	for (y = 0; y < gameWorld.map.height; y++)
+	for (y = 0; y < mapState.height; y++)
 	{
-		for (x = 0; x < gameWorld.map.width; x++)
+		for (x = 0; x < mapState.width; x++)
 		{
 			// initially set the seabed index to 0 for ground and 100 for water
-			int val = 100 * isWaterVertex(x, y);
-			idx[x + (y * gameWorld.map.width)] = val;
+			int val = 100 * isWaterVertex(mapState, x, y);
+			idx[x + (y * mapState.width)] = val;
 			if (val > 0)
 			{
 				l++;
@@ -775,15 +775,15 @@ static void generateRiverbed()
 	do
 	{
 		maxIdx = 1;
-		for (y = 1; y < gameWorld.map.height - 2; y++)
+		for (y = 1; y < mapState.height - 2; y++)
 		{
-			for (x = 1; x < gameWorld.map.width - 2; x++)
+			for (x = 1; x < mapState.width - 2; x++)
 			{
-				int rowOffset = (y * gameWorld.map.width);
+				int rowOffset = (y * mapState.width);
 				auto& idxVal = idx[x + rowOffset];
 				if (idxVal > 0)
 				{
-					idxVal = (idx[(x - 1) + rowOffset] + idx[x + ((y - 1) * gameWorld.map.width)] + idx[x + ((y + 1) * gameWorld.map.width)] + idx[(x + 1) + rowOffset]) / 4;
+					idxVal = (idx[(x - 1) + rowOffset] + idx[x + ((y - 1) * mapState.width)] + idx[x + ((y + 1) * mapState.width)] + idx[(x + 1) + rowOffset]) / 4;
 					if (idxVal > maxIdx)
 					{
 						maxIdx = idxVal;
@@ -796,11 +796,11 @@ static void generateRiverbed()
 	}
 	while (maxIdx > 90 && l < 20);
 
-	for (y = 0; y < gameWorld.map.height; y++)
+	for (y = 0; y < mapState.height; y++)
 	{
-		for (x = 0; x < gameWorld.map.width; x++)
+		for (x = 0; x < mapState.width; x++)
 		{
-			auto& idxVal = idx[x + (y * gameWorld.map.width)];
+			auto& idxVal = idx[x + (y * mapState.width)];
 			if (idxVal > maxIdx)
 			{
 				idxVal = maxIdx;
@@ -809,17 +809,17 @@ static void generateRiverbed()
 			{
 				idxVal = 1;
 			}
-			if (isWaterVertex(x, y))
+			if (isWaterVertex(mapState, x, y))
 			{
 				l = (WATER_MAX_DEPTH + 1 - WATER_MIN_DEPTH) * (maxIdx - idxVal - mt.u32() % (maxIdx / 6 + 1));
-				mapTile(gameWorld.map, x, y)->height -= WATER_MIN_DEPTH - (l / maxIdx);
+				mapTile(mapState, x, y)->height -= WATER_MIN_DEPTH - (l / maxIdx);
 			}
 		}
 	}
 
 }
 
-static bool afterMapLoad();
+static bool afterMapLoad(WorldMapState& mapState);
 
 class WzMapBinaryPhysFSStream : public WzMap::BinaryIOStream
 {
@@ -1001,7 +1001,7 @@ void WzMapDebugLogger::printLog(WzMap::LoggingProtocol::LogLevel level, const ch
 }
 
 /* Initialise the map structure */
-bool mapLoad(char const *filename)
+bool mapLoad(char const *filename, WorldMapState& mapState)
 {
 	WzMapPhysFSIO mapIO;
 	WzMapDebugLogger debugLoggerInstance;
@@ -1012,7 +1012,7 @@ bool mapLoad(char const *filename)
 		// loadMapData call handles logging errors
 		return false;
 	}
-	return mapLoadFromWzMapData(loadedMap);
+	return mapLoadFromWzMapData(loadedMap, mapState);
 
 }
 
@@ -1047,7 +1047,7 @@ bool loadTerrainTypeMap(const std::shared_ptr<WzMap::TerrainTypeData>& ttypeData
 }
 
 ///* Initialise the map structure */
-bool mapLoadFromWzMapData(std::shared_ptr<WzMap::MapData> loadedMap)
+bool mapLoadFromWzMapData(std::shared_ptr<WzMap::MapData> loadedMap, WorldMapState& mapState)
 {
 	uint32_t		width, height;
 	const bool		preview = false;
@@ -1056,15 +1056,15 @@ bool mapLoadFromWzMapData(std::shared_ptr<WzMap::MapData> loadedMap)
 	height = loadedMap->height;
 
 	/* See if this is the first time a map has been loaded */
-	ASSERT(gameWorld.map.tiles == nullptr, "Map has not been cleared before calling mapLoad()!");
+	ASSERT(mapState.tiles == nullptr, "Map has not been cleared before calling mapLoad()!");
 
 	/* Allocate the memory for the map */
-	gameWorld.map.tiles = std::make_unique<MAPTILE[]>(static_cast<size_t>(width) * height);
+	mapState.tiles = std::make_unique<MAPTILE[]>(static_cast<size_t>(width) * height);
 	getCurrentLightmapData().reset(width, height);
-	ASSERT(gameWorld.map.tiles != nullptr, "Out of memory");
+	ASSERT(mapState.tiles != nullptr, "Out of memory");
 
-	gameWorld.map.width = width;
-	gameWorld.map.height = height;
+	mapState.width = width;
+	mapState.height = height;
 
 	// FIXME: the map preview code loads the map without setting the tileset
 	if (!tilesetDir)
@@ -1089,19 +1089,19 @@ bool mapLoadFromWzMapData(std::shared_ptr<WzMap::MapData> loadedMap)
 	//load in the map data itself
 
 	/* Load in the map data */
-	for (int i = 0; i < gameWorld.map.width * gameWorld.map.height; ++i)
+	for (int i = 0; i < mapState.width * mapState.height; ++i)
 	{
 		ASSERT(loadedMap->mMapTiles[i].height <= TILE_MAX_HEIGHT, "Tile height (%" PRIu16 ") exceeds TILE_MAX_HEIGHT (%zu)", loadedMap->mMapTiles[i].height, static_cast<size_t>(TILE_MAX_HEIGHT));
-		gameWorld.map.tiles[i].texture = loadedMap->mMapTiles[i].texture;
-		gameWorld.map.tiles[i].height = loadedMap->mMapTiles[i].height;
+		mapState.tiles[i].texture = loadedMap->mMapTiles[i].texture;
+		mapState.tiles[i].height = loadedMap->mMapTiles[i].height;
 
 		// Visibility stuff
-		memset(gameWorld.map.tiles[i].watchers, 0, sizeof(gameWorld.map.tiles[i].watchers));
-		memset(gameWorld.map.tiles[i].sensors, 0, sizeof(gameWorld.map.tiles[i].sensors));
-		memset(gameWorld.map.tiles[i].jammers, 0, sizeof(gameWorld.map.tiles[i].jammers));
-		gameWorld.map.tiles[i].sensorBits = 0;
-		gameWorld.map.tiles[i].jammerBits = 0;
-		gameWorld.map.tiles[i].tileExploredBits = 0;
+		memset(mapState.tiles[i].watchers, 0, sizeof(mapState.tiles[i].watchers));
+		memset(mapState.tiles[i].sensors, 0, sizeof(mapState.tiles[i].sensors));
+		memset(mapState.tiles[i].jammers, 0, sizeof(mapState.tiles[i].jammers));
+		mapState.tiles[i].sensorBits = 0;
+		mapState.tiles[i].jammerBits = 0;
+		mapState.tiles[i].tileExploredBits = 0;
 	}
 
 	if (preview)
@@ -1113,14 +1113,14 @@ bool mapLoadFromWzMapData(std::shared_ptr<WzMap::MapData> loadedMap)
 	size_t gwIdx = 0;
 	for (const auto gateway : loadedMap->mGateways)
 	{
-		if (!gwNewGateway(gateway.x1, gateway.y1, gateway.x2, gateway.y2))
+		if (!gwNewGateway(mapState, gateway.x1, gateway.y1, gateway.x2, gateway.y2))
 		{
 			debug(LOG_ERROR, "Unable to add gateway %zu - dropping it", gwIdx);
 		}
 		gwIdx++;
 	}
 
-	if (!afterMapLoad())
+	if (!afterMapLoad(mapState))
 	{
 		return false;
 	}
@@ -1128,80 +1128,80 @@ bool mapLoadFromWzMapData(std::shared_ptr<WzMap::MapData> loadedMap)
 	return true;
 }
 
-static bool afterMapLoad()
+static bool afterMapLoad(WorldMapState& mapState)
 {
-	if (!mapSetGroundTypes())
+	if (!mapSetGroundTypes(mapState))
 	{
 		return false;
 	}
 
-	for (int y = 0; y < gameWorld.map.height; ++y)
+	for (int y = 0; y < mapState.height; ++y)
 	{
-		for (int x = 0; x < gameWorld.map.width; ++x)
+		for (int x = 0; x < mapState.width; ++x)
 		{
 			// FIXME: magic number
-			mapTile(gameWorld.map, x, y)->waterLevel = mapTile(gameWorld.map, x, y)->height - world_coord(1) / 3;
+			mapTile(mapState, x, y)->waterLevel = mapTile(mapState, x, y)->height - world_coord(1) / 3;
 		}
 	}
-	generateRiverbed();
+	generateRiverbed(mapState);
 
 	/* set up the scroll mins and maxs - set values to valid ones for any new map */
-	gameWorld.map.scroll.minX = gameWorld.map.scroll.minY = 0;
-	gameWorld.map.scroll.maxX = gameWorld.map.width;
-	gameWorld.map.scroll.maxY = gameWorld.map.height;
+	mapState.scroll.minX = mapState.scroll.minY = 0;
+	mapState.scroll.maxX = mapState.width;
+	mapState.scroll.maxY = mapState.height;
 
 	/* Allocate aux maps */
-	ASSERT(gameWorld.map.width >= 0 && gameWorld.map.height >= 0, "Invalid mapWidth or mapHeight (%d x %d)", gameWorld.map.width, gameWorld.map.height);
-	const size_t mapSize = static_cast<size_t>(gameWorld.map.width) * static_cast<size_t>(gameWorld.map.height);
-	gameWorld.map.blockMap[AUX_MAP] = std::make_unique<uint8_t[]>(mapSize);
-	gameWorld.map.blockMap[AUX_ASTARMAP] =  std::make_unique<uint8_t[]>(mapSize);
-	gameWorld.map.blockMap[AUX_DANGERMAP] = std::make_unique<uint8_t[]>(mapSize);
+	ASSERT(mapState.width >= 0 && mapState.height >= 0, "Invalid mapWidth or mapHeight (%d x %d)", mapState.width, mapState.height);
+	const size_t mapSize = static_cast<size_t>(mapState.width) * static_cast<size_t>(mapState.height);
+	mapState.blockMap[AUX_MAP] = std::make_unique<uint8_t[]>(mapSize);
+	mapState.blockMap[AUX_ASTARMAP] =  std::make_unique<uint8_t[]>(mapSize);
+	mapState.blockMap[AUX_DANGERMAP] = std::make_unique<uint8_t[]>(mapSize);
 	for (int x = 0; x < MAX_PLAYERS + AUX_MAX; ++x)
 	{
-		gameWorld.map.auxMap[x] = std::make_unique<uint8_t[]> (mapSize);
+		mapState.auxMap[x] = std::make_unique<uint8_t[]> (mapSize);
 	}
 
 	// Set our blocking bits
-	for (int y = 0; y < gameWorld.map.height; ++y)
+	for (int y = 0; y < mapState.height; ++y)
 	{
-		for (int x = 0; x < gameWorld.map.width; ++x)
+		for (int x = 0; x < mapState.width; ++x)
 		{
-			MAPTILE *psTile = mapTile(gameWorld.map, x, y);
+			MAPTILE *psTile = mapTile(mapState, x, y);
 
-			auxClearBlocking(gameWorld.map, x, y, AUXBITS_ALL);
-			auxClearAll(gameWorld.map, x, y, AUXBITS_ALL);
+			auxClearBlocking(mapState, x, y, AUXBITS_ALL);
+			auxClearAll(mapState, x, y, AUXBITS_ALL);
 
 			/* All tiles outside of the map and on map border are blocking. */
-			if (x < 1 || y < 1 || x > gameWorld.map.width - 1 || y > gameWorld.map.height - 1)
+			if (x < 1 || y < 1 || x > mapState.width - 1 || y > mapState.height - 1)
 			{
-				auxSetBlocking(gameWorld.map, x, y, AUXBITS_ALL);	// block everything
+				auxSetBlocking(mapState, x, y, AUXBITS_ALL);	// block everything
 			}
 			if (terrainType(psTile) == TER_WATER)
 			{
-				auxSetBlocking(gameWorld.map, x, y, WATER_BLOCKED);
+				auxSetBlocking(mapState, x, y, WATER_BLOCKED);
 			}
 			else
 			{
-				auxSetBlocking(gameWorld.map, x, y, LAND_BLOCKED);
+				auxSetBlocking(mapState, x, y, LAND_BLOCKED);
 			}
 			if (terrainType(psTile) == TER_CLIFFFACE)
 			{
-				auxSetBlocking(gameWorld.map, x, y, FEATURE_BLOCKED);
+				auxSetBlocking(mapState, x, y, FEATURE_BLOCKED);
 			}
 		}
 	}
 
 	/* Set continents. This should ideally be done in advance by the map editor. */
-	mapFloodFillContinents();
+	mapFloodFillContinents(mapState);
 
 	return true;
 }
 
 /* Save the map data */
-bool mapSaveToWzMapData(WzMap::MapData& output)
+bool mapSaveToWzMapData(WzMap::MapData& output, const WorldMapState& mapState)
 {
-	output.width = gameWorld.map.width;
-	output.height = gameWorld.map.height;
+	output.width = mapState.width;
+	output.height = mapState.height;
 
 	// Write out the map tile data
 	uint32_t numMapTiles = output.width * output.height;
@@ -1210,22 +1210,22 @@ bool mapSaveToWzMapData(WzMap::MapData& output)
 	for (uint32_t i = 0; i < numMapTiles; i++)
 	{
 		WzMap::MapData::MapTile mapDataTile = {};
-		mapDataTile.texture = gameWorld.map.tiles[i].texture;
-		if (terrainType(&gameWorld.map.tiles[i]) == TER_WATER)
+		mapDataTile.texture = mapState.tiles[i].texture;
+		if (terrainType(&mapState.tiles[i]) == TER_WATER)
 		{
-			mapDataTile.height = (gameWorld.map.tiles[i].waterLevel + world_coord(1) / 3); // this magic number stuff should match afterMapLoad()'s handling of water tiles (??)
+			mapDataTile.height = (mapState.tiles[i].waterLevel + world_coord(1) / 3); // this magic number stuff should match afterMapLoad()'s handling of water tiles (??)
 		}
 		else
 		{
-			mapDataTile.height = gameWorld.map.tiles[i].height;
+			mapDataTile.height = mapState.tiles[i].height;
 		}
 		output.mMapTiles.push_back(std::move(mapDataTile));
 	}
 
 	// Write out the gateway data
 	output.mGateways.clear();
-	output.mGateways.reserve(gwNumGateways());
-	for (auto psCurrGate : gwGetGateways())
+	output.mGateways.reserve(mapState.gateways.size());
+	for (auto psCurrGate : mapState.gateways)
 	{
 		WzMap::MapData::Gateway gw = {};
 		gw.x1 = psCurrGate->x1;
@@ -1234,7 +1234,7 @@ bool mapSaveToWzMapData(WzMap::MapData& output)
 		gw.y2 = psCurrGate->y2;
 		ASSERT(gw.x1 == gw.x2 || gw.y1 == gw.y2, "Invalid gateway coordinates (%d, %d, %d, %d)",
 			   gw.x1, gw.y1, gw.x2, gw.y2);
-		ASSERT(gw.x1 < gameWorld.map.width && gw.y1 < gameWorld.map.height && gw.x2 < gameWorld.map.width && gw.y2 < gameWorld.map.height,
+		ASSERT(gw.x1 < mapState.width && gw.y1 < mapState.height && gw.x2 < mapState.width && gw.y2 < mapState.height,
 			   "Bad gateway dimensions for savegame");
 		output.mGateways.push_back(std::move(gw));
 	}
@@ -1731,7 +1731,7 @@ bool mapObjIsAboveGround(const SIMPLE_OBJECT *psObj)
 
 /* returns the max and min height of a tile by looking at the four corners
    in tile coords */
-void getTileMaxMin(int x, int y, int *pMax, int *pMin)
+void getTileMaxMin(const WorldMapState& mapState, int x, int y, int *pMax, int *pMin)
 {
 	*pMin = INT32_MAX;
 	*pMax = INT32_MIN;
@@ -1739,7 +1739,7 @@ void getTileMaxMin(int x, int y, int *pMax, int *pMin)
 	for (int j = 0; j < 2; ++j)
 		for (int i = 0; i < 2; ++i)
 		{
-			int height = map_TileHeight(gameWorld.map, x + i, y + j);
+			int height = map_TileHeight(mapState, x + i, y + j);
 			*pMin = std::min(*pMin, height);
 			*pMax = std::max(*pMax, height);
 		}
@@ -1748,7 +1748,7 @@ void getTileMaxMin(int x, int y, int *pMax, int *pMin)
 
 // -----------------------------------------------------------------------------------
 /* This will save out the visibility data */
-bool writeVisibilityData(const char *fileName)
+bool writeVisibilityData(const char *fileName, const WorldMapState& mapState)
 {
 	unsigned int i;
 	VIS_SAVEHEADER fileHeader;
@@ -1781,9 +1781,9 @@ bool writeVisibilityData(const char *fileName)
 
 	for (unsigned plane = 0; plane < planes; ++plane)
 	{
-		for (i = 0; i < gameWorld.map.width * gameWorld.map.height; ++i)
+		for (i = 0; i < mapState.width * mapState.height; ++i)
 		{
-			if (!PHYSFS_writeUBE8(fileHandle, gameWorld.map.tiles[i].tileExploredBits >> (plane * 8)))
+			if (!PHYSFS_writeUBE8(fileHandle, mapState.tiles[i].tileExploredBits >> (plane * 8)))
 			{
 				debug(LOG_ERROR, "writeVisibilityData: could not write to %s; PHYSFS error: %s", fileName, WZ_PHYSFS_getLastError());
 				PHYSFS_close(fileHandle);
@@ -1799,7 +1799,7 @@ bool writeVisibilityData(const char *fileName)
 
 // -----------------------------------------------------------------------------------
 /* This will read in the visibility data */
-bool readVisibilityData(const char *fileName)
+bool readVisibilityData(const char *fileName, WorldMapState& mapState)
 {
 	VIS_SAVEHEADER fileHeader;
 	unsigned int expectedFileSize, fileSize;
@@ -1840,7 +1840,7 @@ bool readVisibilityData(const char *fileName)
 	int planes = (game.maxPlayers + 7) / 8;
 
 	// Validate the filesize
-	expectedFileSize = sizeof(fileHeader.aFileType) + sizeof(fileHeader.version) + gameWorld.map.width * gameWorld.map.height * planes;
+	expectedFileSize = sizeof(fileHeader.aFileType) + sizeof(fileHeader.version) + mapState.width * mapState.height * planes;
 	fileSize = PHYSFS_fileLength(fileHandle);
 	if (fileSize != expectedFileSize)
 	{
@@ -1851,13 +1851,13 @@ bool readVisibilityData(const char *fileName)
 	}
 
 	// For every tile...
-	for (i = 0; i < gameWorld.map.width * gameWorld.map.height; i++)
+	for (i = 0; i < mapState.width * mapState.height; i++)
 	{
-		gameWorld.map.tiles[i].tileExploredBits = 0;
+		mapState.tiles[i].tileExploredBits = 0;
 	}
 	for (unsigned plane = 0; plane < planes; ++plane)
 	{
-		for (i = 0; i < gameWorld.map.width * gameWorld.map.height; i++)
+		for (i = 0; i < mapState.width * mapState.height; i++)
 		{
 			/* Get the visibility data */
 			uint8_t val = 0;
@@ -1867,7 +1867,7 @@ bool readVisibilityData(const char *fileName)
 				PHYSFS_close(fileHandle);
 				return false;
 			}
-			gameWorld.map.tiles[i].tileExploredBits |= val << (plane * 8);
+			mapState.tiles[i].tileExploredBits |= val << (plane * 8);
 		}
 	}
 
@@ -1895,11 +1895,11 @@ static const Vector2i aDirOffset[] =
 
 // Flood fill a "continent".
 // TODO take into account scroll limits and update continents on scroll limit changes
-static void mapFloodFill(int x, int y, int continent, uint8_t blockedBits, uint16_t MAPTILE::*varContinent)
+static void mapFloodFill(WorldMapState& mapState, int x, int y, int continent, uint8_t blockedBits, uint16_t MAPTILE::*varContinent)
 {
 	std::vector<Vector2i> open;
 	open.push_back(Vector2i(x, y));
-	mapTile(gameWorld.map, x, y)->*varContinent = continent;  // Set continent value
+	mapTile(mapState, x, y)->*varContinent = continent;  // Set continent value
 
 	while (!open.empty())
 	{
@@ -1913,13 +1913,13 @@ static void mapFloodFill(int x, int y, int continent, uint8_t blockedBits, uint1
 			// rely on the fact that all border tiles are inaccessible to avoid checking explicitly
 			Vector2i npos = pos + aDirOffset[i];
 
-			if (npos.x < 1 || npos.y < 1 || npos.x > gameWorld.map.width - 2 || npos.y > gameWorld.map.height - 2)
+			if (npos.x < 1 || npos.y < 1 || npos.x > mapState.width - 2 || npos.y > mapState.height - 2)
 			{
 				continue;
 			}
-			MAPTILE *psTile = mapTile(gameWorld.map, npos);
+			MAPTILE *psTile = mapTile(mapState, npos);
 
-			if (!(blockTile(gameWorld.map, npos.x, npos.y, AUX_MAP) & blockedBits) && psTile->*varContinent == 0)
+			if (!(blockTile(mapState, npos.x, npos.y, AUX_MAP) & blockedBits) && psTile->*varContinent == 0)
 			{
 				open.push_back(npos);               // add to open list
 				psTile->*varContinent = continent;  // Set continent value
@@ -1928,16 +1928,16 @@ static void mapFloodFill(int x, int y, int continent, uint8_t blockedBits, uint1
 	}
 }
 
-void mapFloodFillContinents()
+void mapFloodFillContinents(WorldMapState& mapState)
 {
 	int x, y, limitedContinents = 0, hoverContinents = 0;
 
 	/* Clear continents */
-	for (y = 0; y < gameWorld.map.height; y++)
+	for (y = 0; y < mapState.height; y++)
 	{
-		for (x = 0; x < gameWorld.map.width; x++)
+		for (x = 0; x < mapState.width; x++)
 		{
-			MAPTILE *psTile = mapTile(gameWorld.map, x, y);
+			MAPTILE *psTile = mapTile(mapState, x, y);
 
 			psTile->limitedContinent = 0;
 			psTile->hoverContinent = 0;
@@ -1945,24 +1945,24 @@ void mapFloodFillContinents()
 	}
 
 	/* Iterate over the whole map, looking for unset continents */
-	for (y = 1; y < gameWorld.map.height - 2; y++)
+	for (y = 1; y < mapState.height - 2; y++)
 	{
-		for (x = 1; x < gameWorld.map.width - 2; x++)
+		for (x = 1; x < mapState.width - 2; x++)
 		{
-			MAPTILE *psTile = mapTile(gameWorld.map, x, y);
+			MAPTILE *psTile = mapTile(mapState, x, y);
 
-			if (psTile->limitedContinent == 0 && !fpathBlockingTile(x, y, PROPULSION_TYPE_WHEELED))
+			if (psTile->limitedContinent == 0 && !fpathBlockingTile(mapState, x, y, PROPULSION_TYPE_WHEELED))
 			{
-				mapFloodFill(x, y, 1 + limitedContinents++, WATER_BLOCKED | FEATURE_BLOCKED, &MAPTILE::limitedContinent);
+				mapFloodFill(mapState, x, y, 1 + limitedContinents++, WATER_BLOCKED | FEATURE_BLOCKED, &MAPTILE::limitedContinent);
 			}
-			else if (psTile->limitedContinent == 0 && !fpathBlockingTile(x, y, PROPULSION_TYPE_PROPELLOR))
+			else if (psTile->limitedContinent == 0 && !fpathBlockingTile(mapState, x, y, PROPULSION_TYPE_PROPELLOR))
 			{
-				mapFloodFill(x, y, 1 + limitedContinents++, LAND_BLOCKED | FEATURE_BLOCKED, &MAPTILE::limitedContinent);
+				mapFloodFill(mapState, x, y, 1 + limitedContinents++, LAND_BLOCKED | FEATURE_BLOCKED, &MAPTILE::limitedContinent);
 			}
 
-			if (psTile->hoverContinent == 0 && !fpathBlockingTile(x, y, PROPULSION_TYPE_HOVER))
+			if (psTile->hoverContinent == 0 && !fpathBlockingTile(mapState, x, y, PROPULSION_TYPE_HOVER))
 			{
-				mapFloodFill(x, y, 1 + hoverContinents++, FEATURE_BLOCKED, &MAPTILE::hoverContinent);
+				mapFloodFill(mapState, x, y, 1 + hoverContinents++, FEATURE_BLOCKED, &MAPTILE::hoverContinent);
 			}
 		}
 	}
@@ -2005,7 +2005,7 @@ bool fireOnLocation(WorldMapState& mapState, unsigned int x, unsigned int y)
 }
 
 // This function runs in a separate thread!
-static int dangerFloodFill(int player)
+static int dangerFloodFill(WorldMapState& mapState, int player)
 {
 	int i;
 	Vector2i pos = getPlayerStartPosition(player);
@@ -2015,12 +2015,12 @@ static int dangerFloodFill(int player)
 	bool start = true;	// hack to disregard the blocking status of any building exactly on the starting position
 
 	// Set our danger bits
-	for (y = 0; y < gameWorld.map.height; y++)
+	for (y = 0; y < mapState.height; y++)
 	{
-		for (x = 0; x < gameWorld.map.width; x++)
+		for (x = 0; x < mapState.width; x++)
 		{
-			auxSet(gameWorld.map, x, y, MAX_PLAYERS + AUX_DANGERMAP, AUXBITS_DANGER);
-			auxClear(gameWorld.map, x, y, MAX_PLAYERS + AUX_DANGERMAP, AUXBITS_TEMPORARY);
+			auxSet(mapState, x, y, MAX_PLAYERS + AUX_DANGERMAP, AUXBITS_DANGER);
+			auxClear(mapState, x, y, MAX_PLAYERS + AUX_DANGERMAP, AUXBITS_TEMPORARY);
 		}
 	}
 
@@ -2035,12 +2035,12 @@ static int dangerFloodFill(int player)
 		{
 			npos.x = pos.x + aDirOffset[i].x;
 			npos.y = pos.y + aDirOffset[i].y;
-			if (!tileOnMap(gameWorld.map, npos.x, npos.y))
+			if (!tileOnMap(mapState, npos.x, npos.y))
 			{
 				continue;
 			}
-			aux = auxTile(gameWorld.map, npos.x, npos.y, MAX_PLAYERS + AUX_DANGERMAP);
-			block = blockTile(gameWorld.map, pos.x, pos.y, AUX_DANGERMAP);
+			aux = auxTile(mapState, npos.x, npos.y, MAX_PLAYERS + AUX_DANGERMAP);
+			block = blockTile(mapState, pos.x, pos.y, AUX_DANGERMAP);
 			if (!(aux & AUXBITS_TEMPORARY) && !(aux & AUXBITS_THREAT) && (aux & AUXBITS_DANGER))
 			{
 				// Note that we do not consider water to be a blocker here. This may or may not be a feature...
@@ -2056,14 +2056,14 @@ static int dangerFloodFill(int player)
 				}
 				else
 				{
-					auxClear(gameWorld.map, npos.x, npos.y, MAX_PLAYERS + AUX_DANGERMAP, AUXBITS_DANGER);
+					auxClear(mapState, npos.x, npos.y, MAX_PLAYERS + AUX_DANGERMAP, AUXBITS_DANGER);
 				}
-				auxSet(gameWorld.map, npos.x, npos.y, MAX_PLAYERS + AUX_DANGERMAP, AUXBITS_TEMPORARY); // make sure we do not process it more than once
+				auxSet(mapState, npos.x, npos.y, MAX_PLAYERS + AUX_DANGERMAP, AUXBITS_TEMPORARY); // make sure we do not process it more than once
 			}
 		}
 
 		// Clear danger
-		auxClear(gameWorld.map, pos.x, pos.y, MAX_PLAYERS + AUX_DANGERMAP, AUXBITS_DANGER);
+		auxClear(mapState, pos.x, pos.y, MAX_PLAYERS + AUX_DANGERMAP, AUXBITS_DANGER);
 
 		// Pop the last open node off the bucket list for the next iteration
 		if (bucketcounter)
@@ -2082,7 +2082,7 @@ static int dangerThreadFunc(WZ_DECL_UNUSED void *data)
 {
 	while (lastDangerPlayer != -1)
 	{
-		dangerFloodFill(lastDangerPlayer);	// Do the actual work
+		dangerFloodFill(gameWorld.map, lastDangerPlayer);	// Do the actual work
 		wzSemaphorePost(dangerDoneSemaphore);   // Signal that we are done
 		wzSemaphoreWait(dangerSemaphore);	// Go to sleep until needed.
 	}
@@ -2107,16 +2107,16 @@ static inline void threatUpdateTarget(int player, BASE_OBJECT *psObj, bool groun
 	}
 }
 
-static void threatUpdate(int player)
+static void threatUpdate(GameWorld& world, int player)
 {
 	int i, weapon, x, y;
 
 	// Step 1: Clear our threat bits
-	for (y = 0; y < gameWorld.map.height; y++)
+	for (y = 0; y < world.map.height; y++)
 	{
-		for (x = 0; x < gameWorld.map.width; x++)
+		for (x = 0; x < world.map.width; x++)
 		{
-			auxClear(gameWorld.map, x, y, MAX_PLAYERS + AUX_DANGERMAP, AUXBITS_THREAT | AUXBITS_AATHREAT);
+			auxClear(world.map, x, y, MAX_PLAYERS + AUX_DANGERMAP, AUXBITS_THREAT | AUXBITS_AATHREAT);
 		}
 	}
 
@@ -2129,7 +2129,7 @@ static void threatUpdate(int player)
 			continue;
 		}
 
-		for (DROID* psDroid : gameWorld.objects.droids[i])
+		for (DROID* psDroid : world.objects.droids[i])
 		{
 			UBYTE mode = 0;
 
@@ -2152,7 +2152,7 @@ static void threatUpdate(int player)
 			}
 		}
 
-		for (STRUCTURE* psStruct : gameWorld.objects.structures[i])
+		for (STRUCTURE* psStruct : world.objects.structures[i])
 		{
 			UBYTE mode = 0;
 
@@ -2172,12 +2172,12 @@ static void threatUpdate(int player)
 	}
 }
 
-void mapInit()
+void mapInit(GameWorld& world)
 {
 	int player;
 
 	free(floodbucket);
-	floodbucket = (struct floodtile *)malloc(gameWorld.map.width * gameWorld.map.height * sizeof(*floodbucket));
+	floodbucket = (struct floodtile *)malloc(world.map.width * world.map.height * sizeof(*floodbucket));
 
 	lastDangerUpdate = 0;
 	lastDangerPlayer = -1;
@@ -2188,10 +2188,10 @@ void mapInit()
 	{
 		for (player = 0; player < MAX_PLAYERS; player++)
 		{
-			auxMapStore(gameWorld.map, player, AUX_DANGERMAP);
-			threatUpdate(player);
-			dangerFloodFill(player);
-			auxMapRestore(gameWorld.map, player, AUX_DANGERMAP, AUXBITS_DANGER | AUXBITS_THREAT | AUXBITS_AATHREAT);
+			auxMapStore(world.map, player, AUX_DANGERMAP);
+			threatUpdate(world, player);
+			dangerFloodFill(world.map, player);
+			auxMapRestore(world.map, player, AUX_DANGERMAP, AUXBITS_DANGER | AUXBITS_THREAT | AUXBITS_AATHREAT);
 		}
 		lastDangerPlayer = 0;
 		dangerSemaphore = wzSemaphoreCreate(0);
@@ -2201,15 +2201,15 @@ void mapInit()
 	}
 }
 
-void mapUpdate()
+void mapUpdate(GameWorld& world)
 {
 	const uint16_t currentTime = gameTime / GAME_TICKS_PER_UPDATE;
 	int posX, posY;
 
-	for (posY = 0; posY < gameWorld.map.height; ++posY)
-		for (posX = 0; posX < gameWorld.map.width; ++posX)
+	for (posY = 0; posY < world.map.height; ++posY)
+		for (posX = 0; posX < world.map.width; ++posX)
 		{
-			MAPTILE *const tile = mapTile(gameWorld.map, posX, posY);
+			MAPTILE *const tile = mapTile(world.map, posX, posY);
 
 			if ((tile->tileInfoBits & BITS_ON_FIRE) != 0 && tile->fireEndTime == currentTime)
 			{
@@ -2228,10 +2228,10 @@ void mapUpdate()
 		// Lock if previous job not done yet
 		wzSemaphoreWait(dangerDoneSemaphore);
 
-		auxMapRestore(gameWorld.map, lastDangerPlayer, AUX_DANGERMAP, AUXBITS_THREAT | AUXBITS_AATHREAT | AUXBITS_DANGER);
+		auxMapRestore(world.map, lastDangerPlayer, AUX_DANGERMAP, AUXBITS_THREAT | AUXBITS_AATHREAT | AUXBITS_DANGER);
 		lastDangerPlayer = (lastDangerPlayer + 1) % game.maxPlayers;
-		auxMapStore(gameWorld.map, lastDangerPlayer, AUX_DANGERMAP);
-		threatUpdate(lastDangerPlayer);
+		auxMapStore(world.map, lastDangerPlayer, AUX_DANGERMAP);
+		threatUpdate(world, lastDangerPlayer);
 		wzSemaphorePost(dangerSemaphore);
 	}
 }

--- a/src/map.h
+++ b/src/map.h
@@ -356,10 +356,10 @@ static inline void clip_world_offmap(const WorldMapState& mapState, int *worldX,
 bool mapShutdown();
 
 /* Load the map data */
-bool mapLoad(char const *filename);
+bool mapLoad(char const *filename, WorldMapState& mapState);
 struct ScriptMapData;
 bool loadTerrainTypeMap(const std::shared_ptr<WzMap::TerrainTypeData>& ttypeData);
-bool mapLoadFromWzMapData(std::shared_ptr<WzMap::MapData> mapData);
+bool mapLoadFromWzMapData(std::shared_ptr<WzMap::MapData> mapData, WorldMapState& mapState);
 
 // used to reload decal + ground types types when switching terrain overrides
 bool mapReloadGroundTypes();
@@ -395,7 +395,7 @@ public:
 };
 
 /* Save the map data */
-bool mapSaveToWzMapData(WzMap::MapData& output);
+bool mapSaveToWzMapData(WzMap::MapData& output, const WorldMapState& mapState);
 
 /** Return a pointer to the tile structure at x,y in map coordinates */
 static inline WZ_DECL_PURE MAPTILE *mapTile(WorldMapState& mapState, int32_t x, int32_t y)
@@ -414,9 +414,19 @@ static inline WZ_DECL_PURE MAPTILE *mapTile(WorldMapState& mapState, int32_t x, 
 	return &mapState.tiles[x + (y * mapState.width)];
 }
 
+static inline WZ_DECL_PURE const MAPTILE* mapTile(const WorldMapState& mapState, int32_t x, int32_t y)
+{
+	return const_cast<const MAPTILE*>(mapTile(const_cast<WorldMapState&>(mapState), x, y));
+}
+
 static inline WZ_DECL_PURE MAPTILE *mapTile(WorldMapState& mapState, Vector2i const &v)
 {
 	return mapTile(mapState, v.x, v.y);
+}
+
+static inline WZ_DECL_PURE const MAPTILE* mapTile(const WorldMapState& mapState, Vector2i const &v)
+{
+	return const_cast<const MAPTILE*>(mapTile(const_cast<WorldMapState&>(mapState), v.x, v.y));
 }
 
 /** Return a pointer to the tile structure at x,y in world coordinates */
@@ -424,9 +434,20 @@ static inline WZ_DECL_PURE MAPTILE *worldTile(WorldMapState& mapState, int32_t x
 {
 	return mapTile(mapState, map_coord(x), map_coord(y));
 }
+
+static inline WZ_DECL_PURE const MAPTILE* worldTile(const WorldMapState& mapState, int32_t x, int32_t y)
+{
+	return const_cast<const MAPTILE*>(worldTile(const_cast<WorldMapState&>(mapState), x, y));
+}
+
 static inline WZ_DECL_PURE MAPTILE *worldTile(WorldMapState& mapState, Vector2i const &v)
 {
 	return mapTile(mapState, map_coord(v));
+}
+
+static inline WZ_DECL_PURE const MAPTILE* worldTile(const WorldMapState& mapState, Vector2i const &v)
+{
+	return const_cast<const MAPTILE*>(worldTile(const_cast<WorldMapState&>(mapState), v));
 }
 
 /// Return ground height of top-left corner of tile at x,y
@@ -527,12 +548,12 @@ bool mapObjIsAboveGround(const SIMPLE_OBJECT *psObj);
 
 /* returns the max and min height of a tile by looking at the four corners
    in tile coords */
-void getTileMaxMin(int x, int y, int *pMax, int *pMin);
+void getTileMaxMin(const WorldMapState& mapState, int x, int y, int *pMax, int *pMin);
 
-bool readVisibilityData(const char *fileName);
-bool writeVisibilityData(const char *fileName);
+bool readVisibilityData(const char *fileName, WorldMapState& mapState);
+bool writeVisibilityData(const char *fileName, const WorldMapState& mapState);
 
-void mapFloodFillContinents();
+void mapFloodFillContinents(WorldMapState& mapState);
 
 void tileSetFire(WorldMapState& mapState, int32_t x, int32_t y, uint32_t duration);
 bool fireOnLocation(WorldMapState& mapState, unsigned int x, unsigned int y); // FIXME: add const overload
@@ -548,8 +569,10 @@ WZ_DECL_ALWAYS_INLINE static inline bool hasSensorOnTile(MAPTILE *psTile, unsign
 			);
 }
 
-void mapInit();
-void mapUpdate();
+struct GameWorld;
+
+void mapInit(GameWorld& world);
+void mapUpdate(GameWorld& world);
 
 bool shouldLoadTerrainTypeOverrides(const std::string& name);
 bool loadTerrainTypeMapOverride(MAP_TILESET tileSet);

--- a/src/mapgrid.cpp
+++ b/src/mapgrid.cpp
@@ -51,14 +51,14 @@ bool gridInitialise()
 }
 
 // reset the grid system
-void gridReset()
+void gridReset(GameWorld& world)
 {
 	gridPointTree->clear();
 
 	// Put all existing objects into the point tree.
 	for (unsigned player = 0; player < MAX_PLAYERS; player++)
 	{
-		for (BASE_OBJECT* psObj : gameWorld.objects.droids[player])
+		for (BASE_OBJECT* psObj : world.objects.droids[player])
 		{
 			if (!psObj->died)
 			{
@@ -69,7 +69,7 @@ void gridReset()
 				}
 			}
 		}
-		for (BASE_OBJECT* psObj : gameWorld.objects.structures[player])
+		for (BASE_OBJECT* psObj : world.objects.structures[player])
 		{
 			if (!psObj->died)
 			{
@@ -81,7 +81,7 @@ void gridReset()
 			}
 		}
 	}
-	for (BASE_OBJECT* psObj : gameWorld.objects.features[0])
+	for (BASE_OBJECT* psObj : world.objects.features[0])
 	{
 		if (!psObj->died)
 		{

--- a/src/mapgrid.h
+++ b/src/mapgrid.h
@@ -27,6 +27,8 @@
 typedef std::vector<BASE_OBJECT *> GridList;
 typedef GridList::const_iterator GridIterator;
 
+struct GameWorld;
+
 // initialise the grid system
 bool gridInitialise();
 
@@ -35,7 +37,7 @@ void gridShutDown();
 
 // Reset the grid system. Called once per update.
 // Resets seenThisTick[] to false.
-void gridReset();
+void gridReset(GameWorld& world);
 
 /// Find all objects within radius.
 GridList const &gridStartIterate(int32_t x, int32_t y, uint32_t radius);

--- a/src/mission.cpp
+++ b/src/mission.cpp
@@ -315,7 +315,7 @@ void initMission()
 void releaseMission()
 {
 	/* mission.apsDroidLists may contain some droids that have been transferred from one campaign to the next */
-	freeAllMissionDroids();
+	freeAllDroids(mission.gameWorld);
 
 	/* apsLimboDroids may contain some droids that have been saved at the end of one mission and not yet used */
 	freeAllLimboDroids();
@@ -330,12 +330,12 @@ bool missionShutDown()
 		//clear out the audio
 		audio_StopAll();
 
-		freeAllDroids();
-		freeAllStructs();
-		freeAllFeatures();
-		freeAllFlagPositions();
+		freeAllDroids(gameWorld);
+		freeAllStructs(gameWorld);
+		freeAllFeatures(gameWorld);
+		freeAllFlagPositions(gameWorld.objects);
 		releaseAllProxDisp();
-		gwShutDown();
+		gwShutDown(gameWorld.map);
 
 		for (int inc = 0; inc < MAX_PLAYERS; inc++)
 		{
@@ -366,7 +366,7 @@ bool missionShutDown()
 		{
 			gameWorld.map.auxMap[i] = std::move(mission.gameWorld.map.auxMap[i]);
 		}
-		std::swap(mission.gameWorld.map.gateways, gwGetGateways());
+		std::swap(mission.gameWorld.map.gateways, gwGetGateways(gameWorld.map));
 	}
 	keybindShutdown();
 	// sorry if this breaks something - but it looks like it's what should happen - John
@@ -660,7 +660,7 @@ void missionFlyTransportersIn(SDWORD iPlayer, bool bTrackTransporter)
 				if ((bTrackTransporter == true) && (iPlayer == (SDWORD)selectedPlayer))
 				{
 					/* deselect all droids */
-					selDroidDeselect(selectedPlayer);
+					selDroidDeselect(gameWorld.objects, selectedPlayer);
 
 					if (getWarCamStatus())
 					{
@@ -788,7 +788,7 @@ static void saveMissionData()
 	mission.gameWorld.map.scroll.minY = gameWorld.map.scroll.minY;
 	mission.gameWorld.map.scroll.maxX = gameWorld.map.scroll.maxX;
 	mission.gameWorld.map.scroll.maxY = gameWorld.map.scroll.maxY;
-	std::swap(mission.gameWorld.map.gateways, gwGetGateways());
+	std::swap(mission.gameWorld.map.gateways, gwGetGateways(gameWorld.map));
 	// save the selectedPlayer's LZ
 	mission.homeLZ_X = getLandingX(selectedPlayer);
 	mission.homeLZ_Y = getLandingY(selectedPlayer);
@@ -816,7 +816,7 @@ static void saveMissionData()
 	//clear all the effects from the map
 	initEffectsSystem();
 
-	resizeRadar();
+	resizeRadar(gameWorld.map);
 }
 
 /*
@@ -837,11 +837,11 @@ void restoreMissionData()
 
 	//clear all the lists
 	proj_FreeAllProjectiles();
-	freeAllDroids();
-	freeAllStructs();
-	freeAllFeatures();
-	freeAllFlagPositions();
-	gwShutDown();
+	freeAllDroids(gameWorld);
+	freeAllStructs(gameWorld);
+	freeAllFeatures(gameWorld);
+	freeAllFlagPositions(gameWorld.objects);
+	gwShutDown(gameWorld.map);
 	if (game.type != LEVEL_TYPE::CAMPAIGN)
 	{
 		ASSERT(false, "game type isn't campaign, but we are in a campaign game!");
@@ -890,7 +890,7 @@ void restoreMissionData()
 	gameWorld.map.scroll.minY = mission.gameWorld.map.scroll.minY;
 	gameWorld.map.scroll.maxX = mission.gameWorld.map.scroll.maxX;
 	gameWorld.map.scroll.maxY = mission.gameWorld.map.scroll.maxY;
-	std::swap(mission.gameWorld.map.gateways, gwGetGateways());
+	std::swap(mission.gameWorld.map.gateways, gwGetGateways(gameWorld.map));
 	//and clear the mission pointers
 	mission.gameWorld.map.tiles	= nullptr;
 	mission.gameWorld.map.width	= 0;
@@ -902,14 +902,14 @@ void restoreMissionData()
 	mission.gameWorld.map.gateways.clear();
 
 	//reset the current structure lists
-	setCurrentStructQuantity(false);
+	setCurrentStructQuantity(gameWorld.objects, false);
 
 	initFactoryNumFlag();
-	resetFactoryNumFlag();
+	resetFactoryNumFlag(gameWorld.objects);
 
 	offWorldKeepLists = false;
 
-	resizeRadar();
+	resizeRadar(gameWorld.map);
 }
 
 /*Saves the necessary data when moving from one mission to a limbo expand Mission*/
@@ -980,7 +980,7 @@ void placeLimboDroids()
 			//set up location for each of the droids
 			droidX = map_coord(getLandingX(LIMBO_LANDING));
 			droidY = map_coord(getLandingY(LIMBO_LANDING));
-			pickRes = pickHalfATile(&droidX, &droidY, LOOK_FOR_EMPTY_TILE);
+			pickRes = pickHalfATile(gameWorld, &droidX, &droidY, LOOK_FOR_EMPTY_TILE);
 			if (pickRes == NO_FREE_TILE)
 			{
 				ASSERT(false, "placeLimboUnits: Unable to find a free location");
@@ -989,7 +989,7 @@ void placeLimboDroids()
 			psDroid->pos.y = (UWORD)world_coord(droidY);
 			ASSERT(worldOnMap(gameWorld.map, psDroid->pos.x, psDroid->pos.y), "limbo droid is not on the map");
 			psDroid->pos.z = map_Height(gameWorld.map, psDroid->pos.x, psDroid->pos.y);
-			updateDroidOrientation(psDroid);
+			updateDroidOrientation(psDroid, gameWorld.map);
 			psDroid->selected = false;
 			//this is mainly for VTOLs
 			setDroidBase(psDroid, nullptr);
@@ -998,7 +998,7 @@ void placeLimboDroids()
 			//make sure the died flag is not set
 			psDroid->died = false;
 			//update visibility
-			visTilesUpdate(psDroid);
+			visTilesUpdate(psDroid, gameWorld.map);
 		}
 		else
 		{
@@ -1028,7 +1028,7 @@ void restoreMissionLimboData()
 			//the location of the droid should be valid!
 			if (psDroid->pos.x != INVALID_XY && psDroid->pos.y != INVALID_XY)
 			{
-				visTilesUpdate(psDroid); //update visibility
+				visTilesUpdate(psDroid, gameWorld.map); //update visibility
 			}
 		}
 		return IterationResult::CONTINUE_ITERATION;
@@ -1149,8 +1149,8 @@ void saveCampaignData()
 	audio_StopAll();
 
 	//clear all other memory
-	freeAllStructs();
-	freeAllFeatures();
+	freeAllStructs(gameWorld);
+	freeAllFeatures(gameWorld);
 }
 
 
@@ -1304,7 +1304,7 @@ static void processMission()
 		//reset order - do this to all the droids that are returning from offWorld
 		orderDroid(psDroid, DORDER_STOP, ModeImmediate);
 		// clean up visibility
-		visRemoveVisibility((BASE_OBJECT*)psDroid);
+		visRemoveVisibility((BASE_OBJECT*)psDroid, gameWorld.map);
 		//remove out of stored list and add to current Droid list
 		if (droidRemove(psDroid, gameWorld.objects.droids))
 		{
@@ -1316,13 +1316,13 @@ static void processMission()
 			// Swap the droid and map pointers
 			swapMissionPointers();
 
-			pickRes = pickHalfATile(&droidX, &droidY, LOOK_FOR_EMPTY_TILE);
+			pickRes = pickHalfATile(gameWorld, &droidX, &droidY, LOOK_FOR_EMPTY_TILE);
 			ASSERT(pickRes != NO_FREE_TILE, "processMission: Unable to find a free location");
 			x = (UWORD)world_coord(droidX);
 			y = (UWORD)world_coord(droidY);
 			droidSetPosition(psDroid, x, y);
 			ASSERT(worldOnMap(gameWorld.map, psDroid->pos.x, psDroid->pos.y), "the droid is not on the map");
-			updateDroidOrientation(psDroid);
+			updateDroidOrientation(psDroid, gameWorld.map);
 			// Swap the droid and map pointers back again
 			swapMissionPointers();
 			psDroid->selected = false;
@@ -1397,7 +1397,7 @@ void swapMissionPointers()
 		std::swap(gameWorld.map.auxMap[i],   mission.gameWorld.map.auxMap[i]);
 	}
 	//swap gateway zones
-	std::swap(mission.gameWorld.map.gateways, gwGetGateways());
+	std::swap(mission.gameWorld.map.gateways, gwGetGateways(gameWorld.map));
 	std::swap(gameWorld.map.scroll.minX, mission.gameWorld.map.scroll.minX);
 	std::swap(gameWorld.map.scroll.minY, mission.gameWorld.map.scroll.minY);
 	std::swap(gameWorld.map.scroll.maxX, mission.gameWorld.map.scroll.maxX);
@@ -1632,7 +1632,7 @@ static void missionResetDroids()
 				if (d->pos.x != INVALID_XY && d->pos.y != INVALID_XY)
 				{
 					// update visibility
-					visTilesUpdate(d);
+					visTilesUpdate(d, gameWorld.map);
 				}
 			}
 			return IterationResult::CONTINUE_ITERATION;
@@ -1670,7 +1670,7 @@ static void missionResetDroids()
 					x = map_coord(psStruct->pos.x);
 					y = map_coord(psStruct->pos.y);
 				}
-				pickRes = pickHalfATile(&x, &y, LOOK_FOR_EMPTY_TILE);
+				pickRes = pickHalfATile(gameWorld, &x, &y, LOOK_FOR_EMPTY_TILE);
 				if (pickRes == NO_FREE_TILE)
 				{
 					ASSERT(false, "missionResetUnits: Unable to find a free location");
@@ -1692,7 +1692,7 @@ static void missionResetDroids()
 					{
 						UDWORD		x = map_coord(psStructure->pos.x);
 						UDWORD		y = map_coord(psStructure->pos.y);
-						PICKTILE	pickRes = pickHalfATile(&x, &y, LOOK_FOR_EMPTY_TILE);
+						PICKTILE	pickRes = pickHalfATile(gameWorld, &x, &y, LOOK_FOR_EMPTY_TILE);
 
 						if (pickRes == NO_FREE_TILE)
 						{
@@ -1727,13 +1727,13 @@ static void missionResetDroids()
 				// People always stand upright
 				if (psDroid->droidType != DROID_PERSON && !psDroid->isCyborg())
 				{
-					updateDroidOrientation(psDroid);
+					updateDroidOrientation(psDroid, gameWorld.map);
 				}
 				// Reset the selected flag
 				psDroid->selected = false;
 
 				// update visibility
-				visTilesUpdate(psDroid);
+				visTilesUpdate(psDroid, gameWorld.map);
 			}
 			else
 			{
@@ -1774,7 +1774,7 @@ void unloadTransporter(DROID *psTransporter, UDWORD x, UDWORD y)
 			//starting point...based around the value passed in
 			droidX = map_coord(x);
 			droidY = map_coord(y);
-			if (!pickATileGen(&droidX, &droidY, LOOK_FOR_EMPTY_TILE, zonedPAT))
+			if (!pickATileGen(gameWorld, &droidX, &droidY, LOOK_FOR_EMPTY_TILE, zonedPAT))
 			{
 				if (!bMultiPlayer)
 				{
@@ -1805,7 +1805,7 @@ void unloadTransporter(DROID *psTransporter, UDWORD x, UDWORD y)
 			addDroid(psDroid, *ppCurrentList);
 
 			droidSetPosition(psDroid, world_coord(droidX), world_coord(droidY));
-			updateDroidOrientation(psDroid);
+			updateDroidOrientation(psDroid, gameWorld.map);
 
 			//reset droid orders
 			orderDroid(psDroid, DORDER_STOP, ModeImmediate);
@@ -2618,7 +2618,8 @@ DROID *buildMissionDroid(DROID_TEMPLATE *psTempl, UDWORD x, UDWORD y, UDWORD pla
 {
 	DROID		*psNewDroid;
 
-	psNewDroid = buildDroid(psTempl, world_coord(x), world_coord(y), player, true, nullptr);
+	// XXX: gameWorld.map - should be mission.gameWorld.map really (but keeping it for now to ensure it works exactly as before)
+	psNewDroid = buildDroid(gameWorld, psTempl, world_coord(x), world_coord(y), player, true, nullptr);
 	if (!psNewDroid)
 	{
 		return nullptr;
@@ -2837,12 +2838,12 @@ static void addLandingLights(UDWORD x, UDWORD y)
 
 /*	checks the x,y passed in are not within the boundary of any Landing Zone
 	x and y in tile coords*/
-bool withinLandingZone(UDWORD x, UDWORD y)
+bool withinLandingZone(const WorldMapState& mapState, UDWORD x, UDWORD y)
 {
 	UDWORD		inc;
 
-	ASSERT(x < gameWorld.map.width, "withinLandingZone: x coord bigger than mapWidth");
-	ASSERT(y < gameWorld.map.height, "withinLandingZone: y coord bigger than mapHeight");
+	ASSERT(x < mapState.width, "withinLandingZone: x coord bigger than mapWidth");
+	ASSERT(y < mapState.height, "withinLandingZone: y coord bigger than mapHeight");
 
 
 	for (inc = 0; inc < MAX_NOGO_AREAS; inc++)

--- a/src/mission.h
+++ b/src/mission.h
@@ -37,6 +37,8 @@
 #define         MAX_NOGO_AREAS          (MAX_PLAYERS + 1)
 #define         LIMBO_LANDING           MAX_PLAYERS
 
+struct WorldMapState;
+
 extern MISSION		mission;
 extern bool			offWorldKeepLists;
 extern PerPlayerDroidLists apsLimboDroids;
@@ -134,7 +136,7 @@ void setPlayCountDown(UBYTE set);
 bool getPlayCountDown();
 
 /** Checks the x,y passed in are not within the boundary of the Landing Zone x and y in tile coords. */
-bool withinLandingZone(UDWORD x, UDWORD y);
+bool withinLandingZone(const WorldMapState& mapState, UDWORD x, UDWORD y);
 
 //sets the coords for the Transporter to land
 LANDING_ZONE *getLandingZone(SDWORD i);

--- a/src/move.cpp
+++ b/src/move.cpp
@@ -420,17 +420,17 @@ static void moveShuffleDroid(DROID *psDroid, Vector2i s)
 
 	const auto droidPropType = psDroid->getPropulsionStats()->propulsionType;
 	// check for blocking tiles
-	if (fpathBlockingTile(map_coord((SDWORD)psDroid->pos.x + lvx),
+	if (fpathBlockingTile(gameWorld.map, map_coord((SDWORD)psDroid->pos.x + lvx),
 	                      map_coord((SDWORD)psDroid->pos.y + lvy), droidPropType))
 	{
 		leftClear = false;
 	}
-	else if (fpathBlockingTile(map_coord((SDWORD)psDroid->pos.x + rvx),
+	else if (fpathBlockingTile(gameWorld.map, map_coord((SDWORD)psDroid->pos.x + rvx),
 	                           map_coord((SDWORD)psDroid->pos.y + rvy), droidPropType))
 	{
 		rightClear = false;
 	}
-	else if (fpathBlockingTile(map_coord((SDWORD)psDroid->pos.x + svx),
+	else if (fpathBlockingTile(gameWorld.map, map_coord((SDWORD)psDroid->pos.x + svx),
 	                           map_coord((SDWORD)psDroid->pos.y + svy), droidPropType))
 	{
 		frontClear = false;
@@ -544,7 +544,7 @@ void moveReallyStopDroid(DROID *psDroid)
 #define PITCH_LIMIT 150
 
 /* Get pitch and roll from direction and tile data */
-void updateDroidOrientation(DROID *psDroid)
+void updateDroidOrientation(DROID *psDroid, const WorldMapState& mapState)
 {
 	int32_t hx0, hx1, hy0, hy1;
 	int newPitch, deltaPitch, pitchLimit;
@@ -563,10 +563,10 @@ void updateDroidOrientation(DROID *psDroid)
 	//    hy0
 	// hx0 * hx1      (* = droid)
 	//    hy1
-	hx1 = map_Height(gameWorld.map, psDroid->pos.x + d, psDroid->pos.y);
-	hx0 = map_Height(gameWorld.map, MAX(0, psDroid->pos.x - d), psDroid->pos.y);
-	hy1 = map_Height(gameWorld.map, psDroid->pos.x, psDroid->pos.y + d);
-	hy0 = map_Height(gameWorld.map, psDroid->pos.x, MAX(0, psDroid->pos.y - d));
+	hx1 = map_Height(mapState, psDroid->pos.x + d, psDroid->pos.y);
+	hx0 = map_Height(mapState, MAX(0, psDroid->pos.x - d), psDroid->pos.y);
+	hy1 = map_Height(mapState, psDroid->pos.x, psDroid->pos.y + d);
+	hy0 = map_Height(mapState, psDroid->pos.x, MAX(0, psDroid->pos.y - d));
 
 	//update height in case were in the bottom of a trough
 	psDroid->pos.z = MAX(psDroid->pos.z, (hx0 + hx1) / 2);
@@ -605,10 +605,10 @@ struct BLOCKING_CALLBACK_DATA
 	Vector2i dst;
 };
 
-static bool moveBlockingTileCallback(Vector2i pos, int32_t dist, void *data_)
+static bool moveBlockingTileCallback(WorldMapState& mapState, Vector2i pos, int32_t dist, void *data_)
 {
 	BLOCKING_CALLBACK_DATA *data = (BLOCKING_CALLBACK_DATA *)data_;
-	data->blocking |= pos != data->src && pos != data->dst && fpathBlockingTile(map_coord(pos.x), map_coord(pos.y), data->propulsionType);
+	data->blocking |= pos != data->src && pos != data->dst && fpathBlockingTile(mapState, map_coord(pos.x), map_coord(pos.y), data->propulsionType);
 	return !data->blocking;
 }
 
@@ -624,7 +624,7 @@ static int32_t moveDirectPathToWaypoint(DROID *psDroid, unsigned positionIndex)
 	data.blocking = false;
 	data.src = src;
 	data.dst = dst;
-	rayCast(src, dst, &moveBlockingTileCallback, &data);
+	rayCast(gameWorld.map, src, dst, &moveBlockingTileCallback, &data);
 	return data.blocking ? -1 - dist : dist;
 }
 
@@ -947,7 +947,7 @@ static void moveCalcBlockingSlide(DROID *psDroid, int32_t *pmx, int32_t *pmy, ui
 	moveOpenGates(psDroid, Vector2i(ntx, nty));
 
 	// is the new tile blocking?
-	if (!fpathBlockingTile(ntx, nty, propulsion))
+	if (!fpathBlockingTile(gameWorld.map, ntx, nty, propulsion))
 	{
 		// not blocking, don't change the move vector
 		return;
@@ -982,7 +982,7 @@ static void moveCalcBlockingSlide(DROID *psDroid, int32_t *pmx, int32_t *pmy, ui
 		vertX = ntx;
 		vertY = my < 0 ? nty + 1 : nty - 1;
 
-		if (fpathBlockingTile(horizX, horizY, propulsion) && fpathBlockingTile(vertX, vertY, propulsion))
+		if (fpathBlockingTile(gameWorld.map, horizX, horizY, propulsion) && fpathBlockingTile(gameWorld.map, vertX, vertY, propulsion))
 		{
 			// in a corner - choose an arbitrary slide
 			if (gameRand(2) == 0)
@@ -996,11 +996,11 @@ static void moveCalcBlockingSlide(DROID *psDroid, int32_t *pmx, int32_t *pmy, ui
 				*pmy = 0;
 			}
 		}
-		else if (fpathBlockingTile(horizX, horizY, propulsion))
+		else if (fpathBlockingTile(gameWorld.map, horizX, horizY, propulsion))
 		{
 			*pmy = 0;
 		}
-		else if (fpathBlockingTile(vertX, vertY, propulsion))
+		else if (fpathBlockingTile(gameWorld.map, vertX, vertY, propulsion))
 		{
 			*pmx = 0;
 		}
@@ -1015,7 +1015,7 @@ static void moveCalcBlockingSlide(DROID *psDroid, int32_t *pmx, int32_t *pmy, ui
 		if ((psDroid->pos.y & TILE_MASK) > TILE_UNITS / 2)
 		{
 			// top half
-			if (fpathBlockingTile(ntx, nty + 1, propulsion))
+			if (fpathBlockingTile(gameWorld.map, ntx, nty + 1, propulsion))
 			{
 				*pmx = 0;
 			}
@@ -1027,7 +1027,7 @@ static void moveCalcBlockingSlide(DROID *psDroid, int32_t *pmx, int32_t *pmy, ui
 		else
 		{
 			// bottom half
-			if (fpathBlockingTile(ntx, nty - 1, propulsion))
+			if (fpathBlockingTile(gameWorld.map, ntx, nty - 1, propulsion))
 			{
 				*pmx = 0;
 			}
@@ -1043,7 +1043,7 @@ static void moveCalcBlockingSlide(DROID *psDroid, int32_t *pmx, int32_t *pmy, ui
 		if ((psDroid->pos.x & TILE_MASK) > TILE_UNITS / 2)
 		{
 			// top half
-			if (fpathBlockingTile(ntx + 1, nty, propulsion))
+			if (fpathBlockingTile(gameWorld.map, ntx + 1, nty, propulsion))
 			{
 				*pmy = 0;
 			}
@@ -1055,7 +1055,7 @@ static void moveCalcBlockingSlide(DROID *psDroid, int32_t *pmx, int32_t *pmy, ui
 		else
 		{
 			// bottom half
-			if (fpathBlockingTile(ntx - 1, nty, propulsion))
+			if (fpathBlockingTile(gameWorld.map, ntx - 1, nty, propulsion))
 			{
 				*pmy = 0;
 			}
@@ -1079,12 +1079,12 @@ static void moveCalcBlockingSlide(DROID *psDroid, int32_t *pmx, int32_t *pmy, ui
 			if (inty < TILE_UNITS / 2)
 			{
 				// top left
-				if ((mx < 0) && fpathBlockingTile(tx - 1, ty, propulsion))
+				if ((mx < 0) && fpathBlockingTile(gameWorld.map, tx - 1, ty, propulsion))
 				{
 					bJumped = true;
 					jumpy = (jumpy & ~TILE_MASK) - 1;
 				}
-				if ((my < 0) && fpathBlockingTile(tx, ty - 1, propulsion))
+				if ((my < 0) && fpathBlockingTile(gameWorld.map, tx, ty - 1, propulsion))
 				{
 					bJumped = true;
 					jumpx = (jumpx & ~TILE_MASK) - 1;
@@ -1093,12 +1093,12 @@ static void moveCalcBlockingSlide(DROID *psDroid, int32_t *pmx, int32_t *pmy, ui
 			else
 			{
 				// bottom left
-				if ((mx < 0) && fpathBlockingTile(tx - 1, ty, propulsion))
+				if ((mx < 0) && fpathBlockingTile(gameWorld.map, tx - 1, ty, propulsion))
 				{
 					bJumped = true;
 					jumpy = (jumpy & ~TILE_MASK) + TILE_UNITS;
 				}
-				if ((my >= 0) && fpathBlockingTile(tx, ty + 1, propulsion))
+				if ((my >= 0) && fpathBlockingTile(gameWorld.map, tx, ty + 1, propulsion))
 				{
 					bJumped = true;
 					jumpx = (jumpx & ~TILE_MASK) - 1;
@@ -1110,12 +1110,12 @@ static void moveCalcBlockingSlide(DROID *psDroid, int32_t *pmx, int32_t *pmy, ui
 			if (inty < TILE_UNITS / 2)
 			{
 				// top right
-				if ((mx >= 0) && fpathBlockingTile(tx + 1, ty, propulsion))
+				if ((mx >= 0) && fpathBlockingTile(gameWorld.map, tx + 1, ty, propulsion))
 				{
 					bJumped = true;
 					jumpy = (jumpy & ~TILE_MASK) - 1;
 				}
-				if ((my < 0) && fpathBlockingTile(tx, ty - 1, propulsion))
+				if ((my < 0) && fpathBlockingTile(gameWorld.map, tx, ty - 1, propulsion))
 				{
 					bJumped = true;
 					jumpx = (jumpx & ~TILE_MASK) + TILE_UNITS;
@@ -1124,12 +1124,12 @@ static void moveCalcBlockingSlide(DROID *psDroid, int32_t *pmx, int32_t *pmy, ui
 			else
 			{
 				// bottom right
-				if ((mx >= 0) && fpathBlockingTile(tx + 1, ty, propulsion))
+				if ((mx >= 0) && fpathBlockingTile(gameWorld.map, tx + 1, ty, propulsion))
 				{
 					bJumped = true;
 					jumpy = (jumpy & ~TILE_MASK) + TILE_UNITS;
 				}
-				if ((my >= 0) && fpathBlockingTile(tx, ty + 1, propulsion))
+				if ((my >= 0) && fpathBlockingTile(gameWorld.map, tx, ty + 1, propulsion))
 				{
 					bJumped = true;
 					jumpx = (jumpx & ~TILE_MASK) + TILE_UNITS;
@@ -1692,7 +1692,7 @@ static void moveUpdateGroundModel(DROID *psDroid, SDWORD speed, uint16_t directi
 
 	//set the droid height here so other routines can use it
 	psDroid->pos.z = map_Height(gameWorld.map, psDroid->pos.x, psDroid->pos.y);//jps 21july96
-	updateDroidOrientation(psDroid);
+	updateDroidOrientation(psDroid, gameWorld.map);
 }
 
 /* Update a persons position and speed given target values */
@@ -1916,7 +1916,7 @@ static void moveDescending(DROID *psDroid)
 		psDroid->sMove.Status = MOVEINACTIVE;
 
 		/* conform to terrain */
-		updateDroidOrientation(psDroid);
+		updateDroidOrientation(psDroid, gameWorld.map);
 	}
 }
 
@@ -2410,7 +2410,7 @@ void moveUpdateDroid(DROID *psDroid)
 	if (map_coord(oldx) != map_coord(psDroid->pos.x)
 	    || map_coord(oldy) != map_coord(psDroid->pos.y))
 	{
-		visTilesUpdate((BASE_OBJECT *)psDroid);
+		visTilesUpdate((BASE_OBJECT *)psDroid, gameWorld.map);
 
 		// object moved from one tile to next, check to see if droid is near stuff.(oil)
 		checkLocalFeatures(psDroid);
@@ -2441,7 +2441,7 @@ void moveUpdateDroid(DROID *psDroid)
 	/* If it's sitting in water then it's got to go with the flow! */
 	if (worldOnMap(gameWorld.map, psDroid->pos.x, psDroid->pos.y) && terrainType(mapTile(gameWorld.map, map_coord(psDroid->pos.x), map_coord(psDroid->pos.y))) == TER_WATER)
 	{
-		updateDroidOrientation(psDroid);
+		updateDroidOrientation(psDroid, gameWorld.map);
 	}
 
 	if (psDroid->sMove.Status == MOVETURNTOTARGET && psDroid->rot.direction == moveDir)

--- a/src/move.h
+++ b/src/move.h
@@ -27,6 +27,8 @@
 #include "objectdef.h"
 #include "fpath.h"
 
+struct WorldMapState;
+
 /* Set a target location for a droid to move to  - returns a bool based on if there is a path to the destination (true if there is a path)*/
 bool moveDroidTo(DROID *psDroid, UDWORD x, UDWORD y, FPATH_MOVETYPE moveType = FMT_MOVE);
 
@@ -52,7 +54,7 @@ void moveUpdateDroid(DROID *psDroid);
 SDWORD moveCalcDroidSpeed(DROID *psDroid);
 
 /* update body and turret to local slope */
-void updateDroidOrientation(DROID *psDroid);
+void updateDroidOrientation(DROID *psDroid, const WorldMapState& mapState);
 
 /* audio callback used to kill movement sounds */
 bool moveCheckDroidMovingAndVisible(void *psObj);

--- a/src/multibot.cpp
+++ b/src/multibot.cpp
@@ -257,7 +257,7 @@ bool recvDroidDisEmbark(NETQUEUE queue)
 		NETend(r);
 
 		// find the transporter first
-		psTransporterDroid = IdToDroid(transporterID, player);
+		psTransporterDroid = IdToDroid(gameWorld.objects, transporterID, player);
 		if (!psTransporterDroid)
 		{
 			// Possible it already died? (sync error?)
@@ -431,7 +431,7 @@ bool recvDroid(NETQUEUE queue)
 
 	// Create that droid on this machine.
 	const auto rot = Rotation();
-	psDroid = reallyBuildDroid(pT, pos, player, false, rot, id);
+	psDroid = reallyBuildDroid(gameWorld, pT, pos, player, false, rot, id);
 
 	// If we were able to build the droid set it up
 	if (psDroid)
@@ -676,7 +676,7 @@ bool recvDroidInfo(NETQUEUE queue)
 			NETuint32_t(r, deltaDroidId);
 			info.droidId += deltaDroidId;
 
-			DROID *psDroid = IdToDroid(info.droidId, info.player);
+			DROID *psDroid = IdToDroid(gameWorld.objects, info.droidId, info.player);
 			if (!psDroid)
 			{
 				debug(LOG_NEVER, "Packet from %d refers to non-existent droid %u, [%s : p%d]",
@@ -726,7 +726,7 @@ bool recvDroidInfo(NETQUEUE queue)
 			case SecondaryOrder:
 				// Set the droids secondary order
 				turnOffMultiMsg(true);
-				secondarySetState(psDroid, info.secOrder, info.secState);
+				secondarySetState(psDroid, gameWorld.objects, info.secOrder, info.secState);
 				turnOffMultiMsg(false);
 				break;
 			}
@@ -758,13 +758,13 @@ static BASE_OBJECT *processDroidTarget(OBJECT_TYPE desttype, uint32_t destid)
 		switch (desttype)
 		{
 		case OBJ_DROID:
-			psObj = IdToDroid(destid, ANYPLAYER);
+			psObj = IdToDroid(gameWorld.objects, destid, ANYPLAYER);
 			break;
 		case OBJ_STRUCTURE:
 			psObj = IdToStruct(destid, ANYPLAYER);
 			break;
 		case OBJ_FEATURE:
-			psObj = IdToFeature(destid, ANYPLAYER);
+			psObj = IdToFeature(gameWorld.objects, destid, ANYPLAYER);
 			break;
 
 		// We should not get this!
@@ -815,7 +815,7 @@ bool recvDestroyDroid(NETQUEUE queue)
 
 		// Retrieve the droid
 		NETuint32_t(r, id);
-		psDroid = IdToDroid(id, ANYPLAYER);
+		psDroid = IdToDroid(gameWorld.objects, id, ANYPLAYER);
 		if (!psDroid)
 		{
 			debug(LOG_DEATH, "droid %d on request from player %d can't be found? Must be dead already?",

--- a/src/multigifts.cpp
+++ b/src/multigifts.cpp
@@ -57,7 +57,7 @@
 
 static void recvGiftStruct(uint8_t from, uint8_t to, uint32_t structID);
 static void recvGiftDroids(uint8_t from, uint8_t to, uint32_t droidID);
-static void sendGiftDroids(uint8_t from, uint8_t to);
+static void sendGiftDroids(const WorldObjectState& objState, uint8_t from, uint8_t to);
 static void giftResearch(uint8_t from, uint8_t to, bool send);
 static void giftAutoGame(uint8_t from, uint8_t to, bool send);
 
@@ -156,7 +156,7 @@ bool sendGift(uint8_t type, uint8_t to)
 		break;
 	case DROID_GIFT:
 		audioTrack = ID_UNITS_TRANSFER;
-		sendGiftDroids(selectedPlayer, to);
+		sendGiftDroids(gameWorld.objects, selectedPlayer, to);
 		break;
 	case RESEARCH_GIFT:
 		audioTrack = ID_TECHNOLOGY_TRANSFER;
@@ -233,7 +233,7 @@ void giftRadar(uint8_t from, uint8_t to, bool send)
 	// If we are receiving the gift
 	else
 	{
-		hqReward(from, to);
+		hqReward(gameWorld, from, to);
 		if (to == selectedPlayer && loopMissionState == LMS_NORMAL)
 		{
 			CONPRINTF(_("%s Gives You A Visibility Report"), getPlayerName(from));
@@ -269,7 +269,7 @@ static void recvGiftStruct(uint8_t from, uint8_t to, uint32_t structID)
 // \param to    :player that should be getting the droid
 static void recvGiftDroids(uint8_t from, uint8_t to, uint32_t droidID)
 {
-	DROID *psDroid = IdToDroid(droidID, from);
+	DROID *psDroid = IdToDroid(gameWorld.objects, droidID, from);
 
 	if (psDroid)
 	{
@@ -290,15 +290,16 @@ static void recvGiftDroids(uint8_t from, uint8_t to, uint32_t droidID)
 // sendGiftDroids()
 // We give selected droid(s) as a gift to another player.
 //
+// \param objState : the object state to send the droids between `from` and `to`
 // \param from  :player that sent us the droid
 // \param to    :player that should be getting the droid
-static void sendGiftDroids(uint8_t from, uint8_t to)
+static void sendGiftDroids(const WorldObjectState& objState, uint8_t from, uint8_t to)
 {
 	DroidList::const_iterator psD;
 	uint8_t      giftType = DROID_GIFT;
 	uint8_t      totalToSend = 0;
 
-	if (gameWorld.objects.droids[from].empty())
+	if (objState.droids[from].empty())
 	{
 		return;
 	}
@@ -309,8 +310,8 @@ static void sendGiftDroids(uint8_t from, uint8_t to)
 	 * over their droid limit.
 	 */
 
-	for (psD = gameWorld.objects.droids[from].begin();
-	     psD != gameWorld.objects.droids[from].end() && (getNumDroids(to) + totalToSend < getMaxDroids(to)) && totalToSend != UINT8_MAX;
+	for (psD = objState.droids[from].begin();
+	     psD != objState.droids[from].end() && (getNumDroids(to) + totalToSend < getMaxDroids(to)) && totalToSend != UINT8_MAX;
 	     ++psD)
 	{
 		if ((*psD)->selected)
@@ -328,7 +329,7 @@ static void sendGiftDroids(uint8_t from, uint8_t to)
 	 * does its own net calls.
 	 */
 
-	for (psD = gameWorld.objects.droids[from].begin(); psD != gameWorld.objects.droids[from].end() && totalToSend != 0; ++psD)
+	for (psD = objState.droids[from].begin(); psD != objState.droids[from].end() && totalToSend != 0; ++psD)
 	{
 		if ((*psD)->selected)
 		{
@@ -740,13 +741,13 @@ void  technologyGiveAway(const STRUCTURE *pS)
 	}
 
 	uint32_t x = map_coord(pS->pos.x), y = map_coord(pS->pos.y);
-	if (!pickATileGen(&x, &y, LOOK_FOR_EMPTY_TILE, zonedPAT))
+	if (!pickATileGen(gameWorld, &x, &y, LOOK_FOR_EMPTY_TILE, zonedPAT))
 	{
 		syncDebug("Did not find location for oil drum.");
 		debug(LOG_FEATURE, "Unable to find a free location.");
 		return;
 	}
-	FEATURE *pF = buildFeature(&asFeatureStats[featureIndex], world_coord(x), world_coord(y), false);
+	FEATURE *pF = buildFeature(gameWorld.map, &asFeatureStats[featureIndex], world_coord(x), world_coord(y), false);
 	if (pF)
 	{
 		pF->player = pS->player;
@@ -801,7 +802,7 @@ void recvMultiPlayerFeature(NETQUEUE queue)
 		if (asFeatureStats[i].ref == ref)
 		{
 			// Create a feature of the specified type at the given location
-			buildFeature(&asFeatureStats[i], x, y, false, id);
+			buildFeature(gameWorld.map, &asFeatureStats[i], x, y, false, id);
 			break;
 		}
 	}

--- a/src/multijoin.cpp
+++ b/src/multijoin.cpp
@@ -81,16 +81,17 @@
 // Local Functions
 
 static void resetMultiVisibility(UDWORD player);
-void destroyPlayerResources(UDWORD player, bool quietly);
+void destroyPlayerResources(WorldObjectState& objState, UDWORD player, bool quietly);
 
 //////////////////////////////////////////////////////////////////////////////
 /*
 ** when a remote player leaves an arena game do this!
 **
+** @param objState : the object state to destroy the resources for `player` from
 ** @param player -- the one we need to clear
 ** @param quietly -- true means without any visible effects
 */
-void clearPlayer(UDWORD player, bool quietly)
+void clearPlayer(WorldObjectState& objState, UDWORD player, bool quietly)
 {
 	ASSERT_OR_RETURN(, player < MAX_CONNECTED_PLAYERS, "Invalid player: %" PRIu32 "", player);
 
@@ -112,10 +113,10 @@ void clearPlayer(UDWORD player, bool quietly)
 		return; // no more to do
 	}
 
-	destroyPlayerResources(player, quietly);
+	destroyPlayerResources(objState, player, quietly);
 }
 
-void destroyPlayerResources(UDWORD player, bool quietly)
+void destroyPlayerResources(WorldObjectState& objState, UDWORD player, bool quietly)
 {
 	UDWORD			i;
 
@@ -139,7 +140,7 @@ void destroyPlayerResources(UDWORD player, bool quietly)
 
 	debug(LOG_DEATH, "killing off all droids for player %d", player);
 	// delete all droids
-	mutating_list_iterate(gameWorld.objects.droids[player], [quietly](DROID* d)
+	mutating_list_iterate(objState.droids[player], [quietly](DROID* d)
 	{
 		if (quietly)			// don't show effects
 		{
@@ -154,7 +155,7 @@ void destroyPlayerResources(UDWORD player, bool quietly)
 
 	debug(LOG_DEATH, "killing off all structures for player %d", player);
 	// delete all structs
-	mutating_list_iterate(gameWorld.objects.structures[player], [quietly](STRUCTURE* psStruct)
+	mutating_list_iterate(objState.structures[player], [quietly](STRUCTURE* psStruct)
 	{
 		// FIXME: look why destroyStruct() doesn't put back the feature like removeStruct() does
 		if (quietly || psStruct->pStructureType->type == REF_RESOURCE_EXTRACTOR)		// don't show effects
@@ -357,14 +358,14 @@ void handlePlayerLeftInGame(UDWORD player)
 	switch (mode)
 	{
 		case PLAYER_LEAVE_MODE::DESTROY_RESOURCES:
-			destroyPlayerResources(player, false);
+			destroyPlayerResources(gameWorld.objects, player, false);
 			break;
 		case PLAYER_LEAVE_MODE::SPLIT_WITH_TEAM:
 			if (!splitResourcesAmongTeam(player))
 			{
 				// no valid targets to split resources among
 				// instead, destroy the player
-				destroyPlayerResources(player, false);
+				destroyPlayerResources(gameWorld.objects, player, false);
 			}
 			break;
 	}
@@ -519,7 +520,7 @@ bool MultiPlayerLeave(UDWORD playerIndex)
 	if (ingame.localJoiningInProgress)
 	{
 		addConsolePlayerLeftMessage(playerIndex);
-		clearPlayer(playerIndex, false);
+		clearPlayer(gameWorld.objects, playerIndex, false);
 		clearPlayerMultiStats(playerIndex); // local only
 		NetPlay.players[playerIndex].difficulty = AIDifficulty::DISABLED;
 	}

--- a/src/multijoin.h
+++ b/src/multijoin.h
@@ -32,11 +32,13 @@
 using nonstd::optional;
 using nonstd::nullopt;
 
+struct WorldObjectState;
+
 void recvPlayerLeft(NETQUEUE queue);
 bool MultiPlayerLeave(UDWORD playerIndex);						// A player has left the game.
 bool MultiPlayerJoin(UDWORD playerIndex, optional<EcKey::Key> verifiedJoinIdentity = nullopt);	// A Player has joined the game.
 void setupNewPlayer(UDWORD player);		// stuff to do when player joins.
-void clearPlayer(UDWORD player, bool quietly);     // wipe a player off the face of the earth.
+void clearPlayer(WorldObjectState& objState, UDWORD player, bool quietly);     // wipe a player off the face of the earth.
 void handlePlayerLeftInGame(UDWORD player);		   // handle a player leaving in-game
 
 void ShowLobbyStatusMessage(const std::vector<std::string>& msgs);

--- a/src/multiopt.cpp
+++ b/src/multiopt.cpp
@@ -67,6 +67,7 @@
 #include "activity.h"
 #include "warzoneconfig.h"
 #include "screens/netpregamescreen.h"
+#include "game_world.h"
 
 #define MAX_STRUCTURE_LIMITS 4096 // Set a high (but explicit) maximum for the number of structure limits supported
 
@@ -573,7 +574,7 @@ static bool gameInit()
 			&& !(NetPlay.players[player].isSpectator && NetPlay.players[player].allocated)
 			&& !(player < game.maxPlayers && NetPlay.players[player].allocated))
 		{
-			clearPlayer(player, true);			// do this quietly
+			clearPlayer(gameWorld.objects, player, true);			// do this quietly
 			debug(LOG_NET, "removing disabled AI (%d) from map.", player);
 		}
 	}

--- a/src/multiplay.cpp
+++ b/src/multiplay.cpp
@@ -547,7 +547,7 @@ bool multiPlayerLoop()
 	if (joinCount)
 	{
 		// deselect anything selected.
-		selDroidDeselect(selectedPlayer);
+		selDroidDeselect(gameWorld.objects, selectedPlayer);
 	}
 	else		//everyone is in the game now!
 	{
@@ -643,13 +643,13 @@ bool multiPlayerLoop()
 // quikie functions.
 
 // to get droids ...
-DROID *IdToDroid(UDWORD id, UDWORD player)
+DROID *IdToDroid(const WorldObjectState& objState, UDWORD id, UDWORD player)
 {
 	if (player == ANYPLAYER)
 	{
 		for (int i = 0; i < MAX_PLAYERS; i++)
 		{
-			DROID* d = (DROID*)getBaseObjFromId(gameWorld.objects.droids[i], id);
+			DROID* d = (DROID*)getBaseObjFromId(objState.droids[i], id);
 			if (d)
 			{
 				return d;
@@ -658,32 +658,7 @@ DROID *IdToDroid(UDWORD id, UDWORD player)
 	}
 	else if (player < MAX_PLAYERS)
 	{
-		DROID* d = (DROID*)getBaseObjFromId(gameWorld.objects.droids[player], id);
-		if (d)
-		{
-			return d;
-		}
-	}
-	return nullptr;
-}
-
-// find off-world droids
-DROID *IdToMissionDroid(UDWORD id, UDWORD player)
-{
-	if (player == ANYPLAYER)
-	{
-		for (int i = 0; i < MAX_PLAYERS; i++)
-		{
-			DROID* d = (DROID*)getBaseObjFromId(mission.gameWorld.objects.droids[i], id);
-			if (d)
-			{
-				return d;
-			}
-		}
-	}
-	else if (player < MAX_PLAYERS)
-	{
-		DROID* d = (DROID*)getBaseObjFromId(mission.gameWorld.objects.droids[player], id);
+		DROID* d = (DROID*)getBaseObjFromId(objState.droids[player], id);
 		if (d)
 		{
 			return d;
@@ -730,10 +705,10 @@ STRUCTURE *IdToStruct(UDWORD id, UDWORD player)
 
 // ////////////////////////////////////////////////////////////////////////////
 // find a feature
-FEATURE *IdToFeature(UDWORD id, UDWORD player)
+FEATURE *IdToFeature(const WorldObjectState& objState, UDWORD id, UDWORD player)
 {
 	(void)player;	// unused, all features go into player 0
-	return (FEATURE*)getBaseObjFromId(gameWorld.objects.features[0], id);
+	return (FEATURE*)getBaseObjFromId(objState.features[0], id);
 }
 
 // ////////////////////////////////////////////////////////////////////////////
@@ -770,7 +745,7 @@ BASE_OBJECT *IdToPointer(UDWORD id, UDWORD player)
 	FEATURE		*pF;
 	// droids.
 
-	pD = IdToDroid(id, player);
+	pD = IdToDroid(gameWorld.objects, id, player);
 	if (pD)
 	{
 		return (BASE_OBJECT *)pD;
@@ -784,7 +759,7 @@ BASE_OBJECT *IdToPointer(UDWORD id, UDWORD player)
 	}
 
 	// features
-	pF = IdToFeature(id, player);
+	pF = IdToFeature(gameWorld.objects, id, player);
 	if (pF)
 	{
 		return (BASE_OBJECT *)pF;
@@ -2335,7 +2310,7 @@ bool recvDestroyFeature(NETQUEUE queue)
 		return false;
 	}
 
-	pF = IdToFeature(id, ANYPLAYER);
+	pF = IdToFeature(gameWorld.objects, id, ANYPLAYER);
 	if (pF == nullptr)
 	{
 		debug(LOG_FEATURE, "feature id %d not found (probably already destroyed)", id);

--- a/src/multiplay.cpp
+++ b/src/multiplay.cpp
@@ -547,7 +547,7 @@ bool multiPlayerLoop()
 	if (joinCount)
 	{
 		// deselect anything selected.
-		selDroidDeselect(selectedPlayer);
+		selDroidDeselect(gameWorld.objects, selectedPlayer);
 	}
 	else		//everyone is in the game now!
 	{
@@ -643,7 +643,7 @@ bool multiPlayerLoop()
 // quikie functions.
 
 // to get droids ...
-DROID *IdToDroid(UDWORD id, UDWORD player)
+DROID *IdToDroid(const WorldObjectState& objState, UDWORD id, UDWORD player)
 {
 	if (player == ANYPLAYER)
 	{
@@ -659,31 +659,6 @@ DROID *IdToDroid(UDWORD id, UDWORD player)
 	else if (player < MAX_PLAYERS)
 	{
 		DROID* d = (DROID*)getBaseObjFromId(gameWorld.objects.droids[player], id);
-		if (d)
-		{
-			return d;
-		}
-	}
-	return nullptr;
-}
-
-// find off-world droids
-DROID *IdToMissionDroid(UDWORD id, UDWORD player)
-{
-	if (player == ANYPLAYER)
-	{
-		for (int i = 0; i < MAX_PLAYERS; i++)
-		{
-			DROID* d = (DROID*)getBaseObjFromId(mission.gameWorld.objects.droids[i], id);
-			if (d)
-			{
-				return d;
-			}
-		}
-	}
-	else if (player < MAX_PLAYERS)
-	{
-		DROID* d = (DROID*)getBaseObjFromId(mission.gameWorld.objects.droids[player], id);
 		if (d)
 		{
 			return d;
@@ -730,10 +705,10 @@ STRUCTURE *IdToStruct(UDWORD id, UDWORD player)
 
 // ////////////////////////////////////////////////////////////////////////////
 // find a feature
-FEATURE *IdToFeature(UDWORD id, UDWORD player)
+FEATURE *IdToFeature(const WorldObjectState& objState, UDWORD id, UDWORD player)
 {
 	(void)player;	// unused, all features go into player 0
-	return (FEATURE*)getBaseObjFromId(gameWorld.objects.features[0], id);
+	return (FEATURE*)getBaseObjFromId(objState.features[0], id);
 }
 
 // ////////////////////////////////////////////////////////////////////////////
@@ -770,7 +745,7 @@ BASE_OBJECT *IdToPointer(UDWORD id, UDWORD player)
 	FEATURE		*pF;
 	// droids.
 
-	pD = IdToDroid(id, player);
+	pD = IdToDroid(gameWorld.objects, id, player);
 	if (pD)
 	{
 		return (BASE_OBJECT *)pD;
@@ -784,7 +759,7 @@ BASE_OBJECT *IdToPointer(UDWORD id, UDWORD player)
 	}
 
 	// features
-	pF = IdToFeature(id, player);
+	pF = IdToFeature(gameWorld.objects, id, player);
 	if (pF)
 	{
 		return (BASE_OBJECT *)pF;
@@ -2335,7 +2310,7 @@ bool recvDestroyFeature(NETQUEUE queue)
 		return false;
 	}
 
-	pF = IdToFeature(id, ANYPLAYER);
+	pF = IdToFeature(gameWorld.objects, id, ANYPLAYER);
 	if (pF == nullptr)
 	{
 		debug(LOG_FEATURE, "feature id %d not found (probably already destroyed)", id);

--- a/src/multiplay.h
+++ b/src/multiplay.h
@@ -56,6 +56,7 @@ struct DROID_TEMPLATE;
 struct FEATURE;
 struct INITIAL_DROID_ORDERS;
 struct STRUCTURE;
+struct WorldObjectState;
 
 // /////////////////////////////////////////////////////////////////////////////////////////////////
 // Game Options Structure. Enough info to completely describe the static stuff in a multiplayer game.
@@ -246,9 +247,8 @@ constexpr TechLevel TECH_LEVEL_MAX = TechLevel::TECH_4;
 
 WZ_DECL_WARN_UNUSED_RESULT BASE_OBJECT		*IdToPointer(UDWORD id, UDWORD player);
 WZ_DECL_WARN_UNUSED_RESULT STRUCTURE		*IdToStruct(UDWORD id, UDWORD player);
-WZ_DECL_WARN_UNUSED_RESULT DROID			*IdToDroid(UDWORD id, UDWORD player);
-WZ_DECL_WARN_UNUSED_RESULT DROID			*IdToMissionDroid(UDWORD id, UDWORD player);
-WZ_DECL_WARN_UNUSED_RESULT FEATURE		*IdToFeature(UDWORD id, UDWORD player);
+WZ_DECL_WARN_UNUSED_RESULT DROID			*IdToDroid(const WorldObjectState& objState, UDWORD id, UDWORD player);
+WZ_DECL_WARN_UNUSED_RESULT FEATURE		*IdToFeature(const WorldObjectState& objState, UDWORD id, UDWORD player);
 WZ_DECL_WARN_UNUSED_RESULT DROID_TEMPLATE	*IdToTemplate(UDWORD tempId, UDWORD player);
 
 const char *getPlayerName(uint32_t player, bool treatAsNonHost = false);

--- a/src/multistruct.cpp
+++ b/src/multistruct.cpp
@@ -121,7 +121,7 @@ bool recvBuildFinished(NETQUEUE queue)
 	for (typeindex = 0; typeindex < numStructureStats && asStructureStats[typeindex].ref != type; typeindex++) {}	// Find structure target
 
 	// Build the structure
-	psStruct = buildStructureDir(&(asStructureStats[typeindex]), pos.x, pos.y, 0, player, true, structId, true);
+	psStruct = buildStructureDir(gameWorld, &(asStructureStats[typeindex]), pos.x, pos.y, 0, player, true, structId, true);
 	if (psStruct)
 	{
 		psStruct->status	= SS_BUILT;

--- a/src/multistruct.cpp
+++ b/src/multistruct.cpp
@@ -121,7 +121,7 @@ bool recvBuildFinished(NETQUEUE queue)
 	for (typeindex = 0; typeindex < numStructureStats && asStructureStats[typeindex].ref != type; typeindex++) {}	// Find structure target
 
 	// Build the structure
-	psStruct = buildStructureDir(&(asStructureStats[typeindex]), pos.x, pos.y, 0, player, true, structId);
+	psStruct = buildStructureDir(gameWorld, &(asStructureStats[typeindex]), pos.x, pos.y, 0, player, true, structId);
 	if (psStruct)
 	{
 		psStruct->status	= SS_BUILT;

--- a/src/objmem.cpp
+++ b/src/objmem.cpp
@@ -44,6 +44,7 @@
 #include "qtscript.h"
 #include "order.h"
 #include "wzcrashhandlingproviders.h"
+#include "world_object_state.h"
 
 #include <algorithm>
 
@@ -591,9 +592,9 @@ static void freeAllEntitiesImpl(PerPlayerObjectLists<Entity, PlayerCount>& entit
 }
 
 /* Remove all droids */
-void freeAllDroids()
+void freeAllDroids(GameWorld& world)
 {
-	freeAllEntitiesImpl<DROID, MAX_PLAYERS>(gameWorld.objects.droids);
+	freeAllEntitiesImpl<DROID, MAX_PLAYERS>(world.objects.droids);
 }
 
 /*Remove a single Droid from a list*/
@@ -621,12 +622,6 @@ void removeDroid(DROID* psDroidToRemove, PerPlayerDroidLists& pList)
 			removeObjectFromFuncList(mission.gameWorld.objects.sensors, (BASE_OBJECT*)psDroidToRemove, 0);
 		}
 	}
-}
-
-/*Removes all droids that may be stored in the mission lists*/
-void freeAllMissionDroids()
-{
-	freeAllEntitiesImpl<DROID, MAX_PLAYERS>(mission.gameWorld.objects.droids);
 }
 
 /*Removes all droids that may be stored in the limbo lists*/
@@ -713,9 +708,9 @@ void killStruct(STRUCTURE *psBuilding)
 }
 
 /* Remove heapall structures */
-void freeAllStructs()
+void freeAllStructs(GameWorld& world)
 {
-	freeAllEntitiesImpl<STRUCTURE, MAX_PLAYERS>(gameWorld.objects.structures);
+	freeAllEntitiesImpl<STRUCTURE, MAX_PLAYERS>(world.objects.structures);
 }
 
 /*Remove a single Structure from a list*/
@@ -766,9 +761,9 @@ void killFeature(FEATURE *psDel)
 }
 
 /* Remove all features */
-void freeAllFeatures()
+void freeAllFeatures(GameWorld& world)
 {
-	freeAllEntitiesImpl<FEATURE, 1>(gameWorld.objects.features);
+	freeAllEntitiesImpl<FEATURE, 1>(world.objects.features);
 }
 
 /**************************  FLAG_POSITION ********************************/
@@ -865,16 +860,16 @@ void transferFlagPositionToPlayer(FLAG_POSITION *psFlagPos, UDWORD originalPlaye
 }
 
 // free all flag positions
-void freeAllFlagPositions()
+void freeAllFlagPositions(WorldObjectState& objState)
 {
 	for (uint32_t player = 0; player < MAX_PLAYERS; player++)
 	{
-		for (const auto& flagPos : gameWorld.objects.flags[player])
+		for (const auto& flagPos : objState.flags[player])
 		{
 			ASSERT(player == flagPos->player, "Player mismatch? (flagPos->player == %" PRIu32 ", expecting: %d", flagPos->player, player);
 			free(flagPos);
 		}
-		gameWorld.objects.flags[player].clear();
+		objState.flags[player].clear();
 	}
 }
 

--- a/src/objmem.h
+++ b/src/objmem.h
@@ -29,6 +29,9 @@
 
 #include <list>
 
+struct GameWorld;
+struct WorldObjectState;
+
 /* The list of destroyed objects */
 using DestroyedObjectsList = std::list<BASE_OBJECT*>;
 extern DestroyedObjectsList psDestroyedObj;
@@ -58,13 +61,10 @@ void addDroid(DROID *psDroidToAdd, PerPlayerDroidLists& pList);
 void killDroid(DROID *psDel);
 
 /* Remove all droids */
-void freeAllDroids();
+void freeAllDroids(GameWorld& world);
 
 /*Remove a single Droid from its list*/
 void removeDroid(DROID *psDroidToRemove, PerPlayerDroidLists& pList);
-
-/*Removes all droids that may be stored in the mission lists*/
-void freeAllMissionDroids();
 
 /*Removes all droids that may be stored in the limbo lists*/
 void freeAllLimboDroids();
@@ -76,7 +76,7 @@ void addStructure(STRUCTURE *psStructToAdd);
 void killStruct(STRUCTURE *psDel);
 
 /* Remove all structures */
-void freeAllStructs();
+void freeAllStructs(GameWorld& world);
 
 /*Remove a single Structure from a list*/
 void removeStructureFromList(STRUCTURE *psStructToRemove, PerPlayerStructureLists& pList);
@@ -88,7 +88,7 @@ void addFeature(FEATURE *psFeatureToAdd);
 void killFeature(FEATURE *psDel);
 
 /* Remove all features */
-void freeAllFeatures();
+void freeAllFeatures(GameWorld& world);
 
 /* Create a new Flag Position */
 bool createFlagPosition(FLAG_POSITION **ppsNew, UDWORD player);
@@ -99,7 +99,7 @@ void removeFlagPosition(FLAG_POSITION *psDel);
 /* Transfer a Flag Position to a new player */
 void transferFlagPositionToPlayer(FLAG_POSITION *psFlagPos, UDWORD originalPlayer, UDWORD newPlayer);
 // free all flag positions
-void freeAllFlagPositions();
+void freeAllFlagPositions(WorldObjectState& objState);
 // used to add flag position to a specific list (ex. from assignFactoryCommandDroid)
 void addFlagPositionToList(FLAG_POSITION* psFlagPosToAdd, PerPlayerFlagPositionLists& list);
 

--- a/src/order.cpp
+++ b/src/order.cpp
@@ -924,7 +924,7 @@ bool orderUpdateDroid(DROID *psDroid)
 					orderDroid(psDroid, DORDER_STOP, ModeImmediate);
 					setDroidTarget(psDroid, nullptr);
 					psDroid->order.psObj = nullptr;
-					secondarySetState(psDroid, DSO_RETURN_TO_LOC, DSS_NONE);
+					secondarySetState(psDroid, gameWorld.objects, DSO_RETURN_TO_LOC, DSS_NONE);
 					moveReallyStopDroid(psDroid);
 
 					// Fire off embark event
@@ -967,7 +967,7 @@ bool orderUpdateDroid(DROID *psDroid)
 		if (psDroid->action == DACTION_NONE)
 		{
 			psDroid->order = DroidOrder(DORDER_NONE);
-			secondarySetState(psDroid, DSO_RETURN_TO_LOC, DSS_NONE);
+			secondarySetState(psDroid, gameWorld.objects, DSO_RETURN_TO_LOC, DSS_NONE);
 		}
 		break;
 	case DORDER_RTR:
@@ -1400,7 +1400,7 @@ void orderDroidBase(DROID *psDroid, DROID_ORDER_DATA *psOrder)
 	if (psOrder->type != DORDER_TRANSPORTIN         // transporters special
 	    && psOrder->psObj == nullptr			// location-type order
 	    && (validOrderForLoc(psOrder->type) || psOrder->type == DORDER_BUILD)
-	    && !fpathCheck(psDroid->pos, rPos, psPropStats->propulsionType))
+	    && !fpathCheck(gameWorld.map, psDroid->pos, rPos, psPropStats->propulsionType))
 	{
 		if (!isHumanPlayer(psDroid->player))
 		{
@@ -1488,14 +1488,14 @@ void orderDroidBase(DROID *psDroid, DROID_ORDER_DATA *psOrder)
 	case DORDER_SCOUT:
 		// can't move vtols to blocking tiles
 		if (psDroid->isVtol()
-		    && fpathBlockingTile(map_coord(psOrder->pos), psDroid->getPropulsionStats()->propulsionType))
+		    && fpathBlockingTile(gameWorld.map, map_coord(psOrder->pos), psDroid->getPropulsionStats()->propulsionType))
 		{
 			break;
 		}
 		//in multiPlayer, cannot move Transporter to blocking tile either
 		if (game.type == LEVEL_TYPE::SKIRMISH
 		    && psDroid->isTransporter()
-		    && fpathBlockingTile(map_coord(psOrder->pos), psDroid->getPropulsionStats()->propulsionType))
+		    && fpathBlockingTile(gameWorld.map, map_coord(psOrder->pos), psDroid->getPropulsionStats()->propulsionType))
 		{
 			break;
 		}
@@ -1687,7 +1687,7 @@ void orderDroidBase(DROID *psDroid, DROID_ORDER_DATA *psOrder)
 			if (psStruct->pStructureType->type == REF_HQ)
 			{
 				Vector2i pos = psStruct->pos.xy();
-				if (!CheckInScrollLimits(pos.x, pos.y))
+				if (!CheckInScrollLimits(gameWorld.map, pos.x, pos.y))
 				{
 					continue;
 				}
@@ -1715,12 +1715,12 @@ void orderDroidBase(DROID *psDroid, DROID_ORDER_DATA *psOrder)
 			int iDY = getLandingY(psDroid->player);
 			Vector2i startPos = getPlayerStartPosition(psDroid->player);
 
-			if (iDX && iDY && CheckInScrollLimits(iDX, iDY))
+			if (iDX && iDY && CheckInScrollLimits(gameWorld.map, iDX, iDY))
 			{
 				psDroid->order = *psOrder;
 				actionDroid(psDroid, DACTION_MOVE, iDX, iDY);
 			}
-			else if (bMultiPlayer && (startPos.x != 0 && startPos.y != 0) && CheckInScrollLimits(startPos.x, startPos.y))
+			else if (bMultiPlayer && (startPos.x != 0 && startPos.y != 0) && CheckInScrollLimits(gameWorld.map, startPos.x, startPos.y))
 			{
 				psDroid->order = *psOrder;
 				actionDroid(psDroid, DACTION_MOVE, startPos.x, startPos.y);
@@ -2510,7 +2510,7 @@ DROID_ORDER chooseOrderLoc(DROID *psDroid, UDWORD x, UDWORD y, bool altOrder)
 	{
 		propulsion = PROPULSION_TYPE_WHEELED;
 	}
-	if (!fpathBlockingTile(map_coord(x), map_coord(y), propulsion))
+	if (!fpathBlockingTile(gameWorld.map, map_coord(x), map_coord(y), propulsion))
 	{
 		order = DORDER_MOVE;
 	}
@@ -2539,12 +2539,12 @@ DROID_ORDER chooseOrderLoc(DROID *psDroid, UDWORD x, UDWORD y, bool altOrder)
 	else if (secondaryGetState(psDroid, DSO_CIRCLE, ModeQueue) == DSS_CIRCLE_SET)  // ModeQueue here means to check whether we pressed the circle button, whether or not it synched yet. The reason for this weirdness is that a circle order makes no sense as a secondary state in the first place (the circle button _should_ have been only in the UI, not in the game state..!), so anything dealing with circle orders will necessarily be weird.
 	{
 		order = DORDER_CIRCLE;
-		secondarySetState(psDroid, DSO_CIRCLE, DSS_NONE);
+		secondarySetState(psDroid, gameWorld.objects, DSO_CIRCLE, DSS_NONE);
 	}
 	else if (secondaryGetState(psDroid, DSO_PATROL, ModeQueue) == DSS_PATROL_SET)  // ModeQueue here means to check whether we pressed the patrol button, whether or not it synched yet. The reason for this weirdness is that a patrol order makes no sense as a secondary state in the first place (the patrol button _should_ have been only in the UI, not in the game state..!), so anything dealing with patrol orders will necessarily be weird.
 	{
 		order = DORDER_PATROL;
-		secondarySetState(psDroid, DSO_PATROL, DSS_NONE);
+		secondarySetState(psDroid, gameWorld.objects, DSO_PATROL, DSS_NONE);
 	}
 
 	return order;
@@ -3396,7 +3396,7 @@ static inline RtrBestResult decideWhereToRepairAndBalance(DROID *psDroid)
 	{
 		if (psStruct->pStructureType->type == REF_HQ)
 		{
-			if (CheckInScrollLimits(psStruct->pos.x, psStruct->pos.y))
+			if (CheckInScrollLimits(gameWorld.map, psStruct->pos.x, psStruct->pos.y))
 			{
 				psHq = psStruct;
 			}
@@ -3404,7 +3404,7 @@ static inline RtrBestResult decideWhereToRepairAndBalance(DROID *psDroid)
 		}
 		if (psStruct->pStructureType->type == REF_REPAIR_FACILITY && psStruct->status == SS_BUILT)
 		{
-			if (!CheckInScrollLimits(psStruct->pos.x, psStruct->pos.y))
+			if (!CheckInScrollLimits(gameWorld.map, psStruct->pos.x, psStruct->pos.y))
 			{
 				continue;
 			}
@@ -3440,7 +3440,7 @@ static inline RtrBestResult decideWhereToRepairAndBalance(DROID *psDroid)
 				if ((psCurr->droidType == DROID_REPAIR || psCurr->droidType == DROID_CYBORG_REPAIR)
 					&& secondaryGetState(psCurr, DSO_ACCEPT_RETREP))
 				{
-					if (!CheckInScrollLimits(psCurr->pos.x, psCurr->pos.y))
+					if (!CheckInScrollLimits(gameWorld.map, psCurr->pos.x, psCurr->pos.y))
 					{
 						continue;
 					}
@@ -3519,7 +3519,7 @@ static inline RtrBestResult decideWhereToRepairAndBalance(DROID *psDroid)
 
 /** This function assigns a state to a droid. It returns true if it assigned and false if it failed to assign.
     Note that this also modifies primary order in some cases */
-bool secondarySetState(DROID *psDroid, SECONDARY_ORDER sec, SECONDARY_STATE State, QUEUE_MODE mode)
+bool secondarySetState(DROID *psDroid, WorldObjectState& objState, SECONDARY_ORDER sec, SECONDARY_STATE State, QUEUE_MODE mode)
 {
 	UDWORD		CurrState, factType, prodType;
 	SDWORD		factoryInc;
@@ -3726,7 +3726,7 @@ bool secondarySetState(DROID *psDroid, SECONDARY_ORDER sec, SECONDARY_STATE Stat
 		if (psDroid->droidType == DROID_COMMAND)
 		{
 			// look for the factories
-			for (STRUCTURE* psStruct : gameWorld.objects.structures[psDroid->player])
+			for (STRUCTURE* psStruct : objState.structures[psDroid->player])
 			{
 				factType = psStruct->pStructureType->type;
 				if (factType == REF_FACTORY ||
@@ -3980,7 +3980,7 @@ static void secondarySetGroupState(UDWORD player, UDWORD group, SECONDARY_ORDER 
 		if (psCurr->group == group &&
 		    secondaryGetState(psCurr, sec) != state)
 		{
-			secondarySetState(psCurr, sec, state);
+			secondarySetState(psCurr, gameWorld.objects, sec, state);
 		}
 	}
 }

--- a/src/order.h
+++ b/src/order.h
@@ -29,6 +29,8 @@
 
 #include "orderdef.h"
 
+struct WorldObjectState;
+
 /** Find some droid to repair, starting at (x, y) within some radius, given a player, or return nullptr.
  * Droids having full HP with order = DORDER_RTR or RTR_SPECIFIED will automatically
  * be sent to delivery point, or back to commander
@@ -114,7 +116,7 @@ bool secondarySupported(const DROID *psDroid, SECONDARY_ORDER sec);
 SECONDARY_STATE secondaryGetState(const DROID *psDroid, SECONDARY_ORDER sec, QUEUE_MODE mode = ModeImmediate);
 
 /** \brief Sets the state of a secondary order, return false if failed. */
-bool secondarySetState(DROID *psDroid, SECONDARY_ORDER sec, SECONDARY_STATE State, QUEUE_MODE mode = ModeQueue);
+bool secondarySetState(DROID *psDroid, WorldObjectState& objState, SECONDARY_ORDER sec, SECONDARY_STATE State, QUEUE_MODE mode = ModeQueue);
 
 /** \brief Checks the damage level of a droid against it's secondary state. */
 void secondaryCheckDamageLevel(DROID *psDroid);

--- a/src/quickjs_backend.cpp
+++ b/src/quickjs_backend.cpp
@@ -1501,7 +1501,7 @@ static JSValue callFunction(JSContext *ctx, const std::string &function, std::ve
 				JSValue droidVal = argv[idx++];
 				int id = QuickJS_GetInt32(ctx, droidVal, "id");
 				int player = QuickJS_GetInt32(ctx, droidVal, "player");
-				DROID *psDroid = IdToDroid(id, player);
+				DROID *psDroid = IdToDroid(gameWorld.objects, id, player);
 				UNBOX_SCRIPT_ASSERT(context, psDroid, "No such droid id %d belonging to player %d", id, player);
 				return psDroid;
 			}

--- a/src/radar.cpp
+++ b/src/radar.cpp
@@ -199,11 +199,11 @@ PIELIGHT inline applyAlpha(PIELIGHT color, float alpha)
 	return ret;
 }
 
-static void DrawRadarTiles();
-static void DrawRadarObjects();
+static void DrawRadarTiles(WorldMapState& mapState);
+static void DrawRadarObjects(GameWorld& world);
 static void DrawRadarExtras(const glm::mat4 &modelViewProjectionMatrix);
 static void DrawNorth(const glm::mat4 &modelViewProjectionMatrix);
-static void setViewingWindow();
+static void setViewingWindow(const WorldMapState& mapState);
 
 static void radarSize(int ZoomLevel)
 {
@@ -255,15 +255,15 @@ bool InitRadar()
 	return true;
 }
 
-bool resizeRadar()
+bool resizeRadar(const WorldMapState& mapState)
 {
 	radarBitmap.clear();
 	if (radarOverlayBuffer)
 	{
 		free(radarOverlayBuffer);
 	}
-	radarTexWidth = static_cast<size_t>(std::abs(gameWorld.map.scroll.maxX - gameWorld.map.scroll.minX));
-	radarTexHeight = static_cast<size_t>(std::abs(gameWorld.map.scroll.maxY - gameWorld.map.scroll.minY));
+	radarTexWidth = static_cast<size_t>(std::abs(mapState.scroll.maxX - mapState.scroll.minX));
+	radarTexHeight = static_cast<size_t>(std::abs(mapState.scroll.maxY - mapState.scroll.minY));
 	radarBufferSize = radarTexWidth * radarTexHeight * sizeof(UDWORD);
 	radarBitmap.allocate(radarTexWidth, radarTexHeight, 4, true);
 	radarOverlayBuffer = (uint32_t*)malloc(radarBufferSize);
@@ -298,7 +298,7 @@ bool ShutdownRadar()
 	return true;
 }
 
-void SetRadarZoom(uint8_t ZoomLevel)
+void SetRadarZoom(const WorldMapState& mapState, uint8_t ZoomLevel)
 {
 	if (ZoomLevel > MAX_RADARZOOM)
 	{
@@ -312,7 +312,7 @@ void SetRadarZoom(uint8_t ZoomLevel)
 	RadarZoom = ZoomLevel;
 	radarSize(RadarZoom);
 	frameSkip = 0;
-	resizeRadar();
+	resizeRadar(mapState);
 }
 
 uint8_t GetRadarZoom()
@@ -328,7 +328,7 @@ static void CalcRadarPixelSize(float *SizeH, float *SizeV)
 }
 
 /** Given a position within the radar, return a world coordinate. */
-void CalcRadarPosition(int mX, int mY, int *PosX, int *PosY)
+void CalcRadarPosition(const WorldMapState& mapState, int mX, int mY, int *PosX, int *PosY)
 {
 	int		sPosX, sPosY;
 	float		pixSizeH, pixSizeV;
@@ -346,23 +346,23 @@ void CalcRadarPosition(int mX, int mY, int *PosX, int *PosY)
 	CalcRadarPixelSize(&pixSizeH, &pixSizeV);
 	sPosX = static_cast<int>(pos.x / pixSizeH);	// adjust for pixel size
 	sPosY = static_cast<int>(pos.y / pixSizeV);
-	sPosX += gameWorld.map.scroll.minX;		// adjust for scroll limits
-	sPosY += gameWorld.map.scroll.minY;
+	sPosX += mapState.scroll.minX;		// adjust for scroll limits
+	sPosY += mapState.scroll.minY;
 
 #if REALLY_DEBUG_RADAR
 	debug(LOG_ERROR, "m=(%d,%d) radar=(%d,%d) pos(%d,%d), scroll=(%u-%u,%u-%u) sPos=(%d,%d), pixSize=(%f,%f)",
-	      mX, mY, radarX, radarY, posX, posY, gameWorld.map.scroll.minX, gameWorld.map.scroll.maxX, gameWorld.map.scroll.minY, gameWorld.map.scroll.maxY, sPosX, sPosY, pixSizeH, pixSizeV);
+	      mX, mY, radarX, radarY, posX, posY, mapState.scroll.minX, mapState.scroll.maxX, mapState.scroll.minY, mapState.scroll.maxY, sPosX, sPosY, pixSizeH, pixSizeV);
 #endif
 
 	// old safety code -- still necessary?
-	sPosX = clip<int>(sPosX, gameWorld.map.scroll.minX, gameWorld.map.scroll.maxX -1);
-	sPosY = clip<int>(sPosY, gameWorld.map.scroll.minY, gameWorld.map.scroll.maxY -1);
+	sPosX = clip<int>(sPosX, mapState.scroll.minX, mapState.scroll.maxX -1);
+	sPosY = clip<int>(sPosY, mapState.scroll.minY, mapState.scroll.maxY -1);
 
 	*PosX = sPosX;
 	*PosY = sPosY;
 }
 
-void drawRadar()
+void drawRadar(GameWorld& world)
 {
 	float	pixSizeH, pixSizeV;
 
@@ -371,13 +371,13 @@ void drawRadar()
 	ASSERT_OR_RETURN(, radarBitmap.bmp_w(), "No radar buffer allocated");
 	ASSERT_OR_RETURN(, radarOverlayBuffer, "No radar buffer allocated");
 
-	setViewingWindow();
+	setViewingWindow(world.map);
 	playerpos = playerPos.p; // cache position
 
 	if (frameSkip <= 0)
 	{
-		DrawRadarTiles();
-		DrawRadarObjects();
+		DrawRadarTiles(world.map);
+		DrawRadarObjects(world);
 		applyMinimapOverlay();
 		pie_DownLoadRadar(radarBitmap);
 		frameSkip = RADAR_FRAME_SKIP;
@@ -495,21 +495,21 @@ static PIELIGHT inline appliedRadarColour(RADAR_DRAW_MODE drawMode, MAPTILE *WTi
 }
 
 /** Draw the map tiles on the radar. */
-static void DrawRadarTiles()
+static void DrawRadarTiles(WorldMapState& mapState)
 {
 	SDWORD	x, y;
 	size_t radarBufferSize2 = radarBitmap.size_in_bytes();
 	unsigned char* pRaderBuffer = radarBitmap.bmp_w();
 
-	for (x = gameWorld.map.scroll.minX; x < gameWorld.map.scroll.maxX; x++)
+	for (x = mapState.scroll.minX; x < mapState.scroll.maxX; x++)
 	{
-		for (y = gameWorld.map.scroll.minY; y < gameWorld.map.scroll.maxY; y++)
+		for (y = mapState.scroll.minY; y < mapState.scroll.maxY; y++)
 		{
-			MAPTILE	*psTile = mapTile(gameWorld.map, x, y);
-			size_t pixelStartPos = (radarTexWidth * (y - gameWorld.map.scroll.minY) + (x - gameWorld.map.scroll.minX)) * 4;
+			MAPTILE	*psTile = mapTile(mapState, x, y);
+			size_t pixelStartPos = (radarTexWidth * (y - mapState.scroll.minY) + (x - mapState.scroll.minX)) * 4;
 
 			ASSERT(pixelStartPos < radarBufferSize2, "Buffer overrun");
-			if (y == gameWorld.map.scroll.minY || x == gameWorld.map.scroll.minX || y == gameWorld.map.scroll.maxY - 1 || x == gameWorld.map.scroll.maxX - 1)
+			if (y == mapState.scroll.minY || x == mapState.scroll.minX || y == mapState.scroll.maxY - 1 || x == mapState.scroll.maxX - 1)
 			{
 				pRaderBuffer[pixelStartPos] = WZCOL_BLACK.byte.r;
 				pRaderBuffer[pixelStartPos + 1] = WZCOL_BLACK.byte.g;
@@ -527,7 +527,7 @@ static void DrawRadarTiles()
 }
 
 /** Draw the droids and structure positions on the radar. */
-static void DrawRadarObjects()
+static void DrawRadarObjects(GameWorld& world)
 {
 	UBYTE				clan;
 	PIELIGHT			playerCol;
@@ -561,10 +561,10 @@ static void DrawRadarObjects()
 		flashCol = flashColours[getPlayerColour(clan)];
 
 		/* Go through all droids */
-		for (const DROID* psDroid : gameWorld.objects.droids[clan])
+		for (const DROID* psDroid : world.objects.droids[clan])
 		{
-			if (psDroid->pos.x < world_coord(gameWorld.map.scroll.minX) || psDroid->pos.y < world_coord(gameWorld.map.scroll.minY)
-			    || psDroid->pos.x >= world_coord(gameWorld.map.scroll.maxX) || psDroid->pos.y >= world_coord(gameWorld.map.scroll.maxY))
+			if (psDroid->pos.x < world_coord(world.map.scroll.minX) || psDroid->pos.y < world_coord(world.map.scroll.minY)
+			    || psDroid->pos.x >= world_coord(world.map.scroll.maxX) || psDroid->pos.y >= world_coord(world.map.scroll.maxY))
 			{
 				continue;
 			}
@@ -574,7 +574,7 @@ static void DrawRadarObjects()
 			{
 				int	x = psDroid->pos.x / TILE_UNITS;
 				int	y = psDroid->pos.y / TILE_UNITS;
-				size_t	pos = (x - gameWorld.map.scroll.minX) + (y - gameWorld.map.scroll.minY) * radarTexWidth;
+				size_t	pos = (x - world.map.scroll.minX) + (y - world.map.scroll.minY) * radarTexWidth;
 
 				ASSERT(pos * sizeof(*radarOverlayBuffer) < radarBufferSize, "Buffer overrun");
 				if (clan == selectedPlayer && gameTime > HIT_NOTIFICATION && gameTime - psDroid->timeLastHit < HIT_NOTIFICATION)
@@ -596,13 +596,13 @@ static void DrawRadarObjects()
 	}
 
 	/* Do the same for structures */
-	for (SDWORD x = gameWorld.map.scroll.minX; x < gameWorld.map.scroll.maxX; x++)
+	for (SDWORD x = world.map.scroll.minX; x < world.map.scroll.maxX; x++)
 	{
-		for (SDWORD y = gameWorld.map.scroll.minY; y < gameWorld.map.scroll.maxY; y++)
+		for (SDWORD y = world.map.scroll.minY; y < world.map.scroll.maxY; y++)
 		{
-			MAPTILE		*psTile = mapTile(gameWorld.map, x, y);
+			MAPTILE		*psTile = mapTile(world.map, x, y);
 			STRUCTURE	*psStruct;
-			size_t		pos = (x - gameWorld.map.scroll.minX) + (y - gameWorld.map.scroll.minY) * radarTexWidth;
+			size_t		pos = (x - world.map.scroll.minX) + (y - world.map.scroll.minY) * radarTexWidth;
 
 			ASSERT(pos * sizeof(*radarOverlayBuffer) < radarBufferSize, "Buffer overrun");
 			if (!TileHasStructure(psTile))
@@ -729,7 +729,7 @@ static SDWORD getLengthAdjust()
 }
 
 /** Draws a Myth/FF7 style viewing window */
-static void setViewingWindow()
+static void setViewingWindow(const WorldMapState& mapState)
 {
 	float pixSizeH, pixSizeV;
 	Vector3i v[4] = {{0, 0, 0}}, tv[4] = {{0, 0, 0}}, centre = {0, 0, 0};
@@ -758,8 +758,8 @@ static void setViewingWindow()
 	v[3].x = -shortX;
 	v[3].y = yDrop;
 
-	centre.x = static_cast<int>(x - gameWorld.map.scroll.minX * pixSizeH);
-	centre.y = static_cast<int>(y - gameWorld.map.scroll.minY * pixSizeV);
+	centre.x = static_cast<int>(x - mapState.scroll.minX * pixSizeH);
+	centre.y = static_cast<int>(y - mapState.scroll.minY * pixSizeV);
 
 	RotateVector2D(v, tv, &centre, playerPos.r.y, 4);
 
@@ -873,7 +873,7 @@ void RadarWidget::mouseDragged(WIDGET_KEY wkey, W_CONTEXT *psStartContext, W_CON
 			int x = screenContext.mx;
 			int y = screenContext.my;
 			int PosX, PosY;
-			CalcRadarPosition(x, y, &PosX, &PosY);
+			CalcRadarPosition(gameWorld.map, x, y, &PosX, &PosY);
 			setViewPos(PosX, PosY, true);
 			if (ctrlShiftDown())
 			{
@@ -888,7 +888,7 @@ void RadarWidget::display(int xOffset, int yOffset)
 	if (!radarVisible()) { return; }
 
 	gfx_api::context::get().debugStringMarker("Draw 3D scene - radar");
-	drawRadar();
+	drawRadar(gameWorld);
 }
 
 bool RadarWidget::hitTest(int x, int y) const
@@ -933,7 +933,7 @@ void RadarWidget::released(W_CONTEXT *context, WIDGET_KEY key)
 			y = m_clickPosition[WKEY_ORDER].value().y;
 
 			/* If we're tracking a droid, then cancel that */
-			CalcRadarPosition(x, y, &PosX, &PosY);
+			CalcRadarPosition(gameWorld.map, x, y, &PosX, &PosY);
 			if (selectedPlayer < MAX_PLAYERS)
 			{
 				// MARKER
@@ -942,7 +942,7 @@ void RadarWidget::released(W_CONTEXT *context, WIDGET_KEY key)
 								 (PosY * TILE_UNITS) + TILE_UNITS / 2, ctrlShiftDown()); // ctrlShiftDown() = ctrl clicked a destination, add an order
 
 			}
-			CheckScrollLimits();
+			CheckScrollLimits(gameWorld.map);
 			audio_PlayTrack(ID_SOUND_MESSAGEEND);
 		}
 	}
@@ -954,7 +954,7 @@ void RadarWidget::released(W_CONTEXT *context, WIDGET_KEY key)
 			x = m_clickPosition[WKEY_SELECT].value().x;
 			y = m_clickPosition[WKEY_SELECT].value().y;
 
-			CalcRadarPosition(x, y, &PosX, &PosY);
+			CalcRadarPosition(gameWorld.map, x, y, &PosX, &PosY);
 
 			if (war_GetRadarJump())
 			{

--- a/src/radar.h
+++ b/src/radar.h
@@ -30,6 +30,9 @@
 
 #include "lib/widget/widget.h"
 
+struct GameWorld;
+struct WorldMapState;
+
 void radarColour(UDWORD tileNumber, uint8_t r, uint8_t g, uint8_t b);	///< Set radar colour for given terrain type.
 
 #define MAX_RADARZOOM		(64)
@@ -39,10 +42,10 @@ void radarColour(UDWORD tileNumber, uint8_t r, uint8_t g, uint8_t b);	///< Set r
 
 bool InitRadar();				///< Initialize minimap subsystem.
 bool ShutdownRadar();			///< Shutdown minimap subsystem.
-bool resizeRadar();				///< Recalculate minimap size. For initialization code only.
-void drawRadar();				///< Draw the minimap on the screen.
-void CalcRadarPosition(int mX, int mY, int *PosX, int *PosY);	///< Given a position within the radar, returns a world coordinate.
-void SetRadarZoom(uint8_t ZoomLevel);		///< Set current zoom level. 1.0 is 1:1 resolution.
+bool resizeRadar(const WorldMapState& mapState);				///< Recalculate minimap size. For initialization code only.
+void drawRadar(GameWorld& world);				///< Draw the minimap on the screen.
+void CalcRadarPosition(const WorldMapState& mapState, int mX, int mY, int *PosX, int *PosY);	///< Given a position within the radar, returns a world coordinate.
+void SetRadarZoom(const WorldMapState& mapState, uint8_t ZoomLevel);		///< Set current zoom level. 1.0 is 1:1 resolution.
 uint8_t GetRadarZoom();			///< Get current zoom level.
 
 /** Different mini-map draw modes. */

--- a/src/raycast.cpp
+++ b/src/raycast.cpp
@@ -64,9 +64,9 @@ static bool tryStep(int32_t &tile, int32_t step, int32_t &cur, int32_t end, int3
 	return true;
 }
 
-void rayCast(Vector2i src, Vector2i dst, RAY_CALLBACK callback, void *data)
+void rayCast(WorldMapState& mapState, Vector2i src, Vector2i dst, RAY_CALLBACK callback, void *data)
 {
-	if (!callback(src, 0, data) || src == dst)  // Start at src.
+	if (!callback(mapState, src, 0, data) || src == dst)  // Start at src.
 	{
 		return;  // Callback gave up after the first point, or there are no other points.
 	}
@@ -109,7 +109,7 @@ void rayCast(Vector2i src, Vector2i dst, RAY_CALLBACK callback, void *data)
 			// But make sure it's on the right tile, since it could be off-by-one if the line passes exactly through a grid intersection.
 			avg.x = std::min(std::max(avg.x, world_coord(selTile.x)), world_coord(selTile.x + 1) - 1);
 			avg.y = std::min(std::max(avg.y, world_coord(selTile.y)), world_coord(selTile.y + 1) - 1);
-			if (!worldOnMap(gameWorld.map, avg) || !callback(avg, iHypot(avg), data))
+			if (!worldOnMap(mapState, avg) || !callback(mapState, avg, iHypot(avg), data))
 			{
 				return;  // Callback doesn't want any more points, or we reached the edge of the map, so return.
 			}
@@ -119,16 +119,16 @@ void rayCast(Vector2i src, Vector2i dst, RAY_CALLBACK callback, void *data)
 	}
 
 	// Include the endpoint.
-	if (!worldOnMap(gameWorld.map, dst))
+	if (!worldOnMap(mapState, dst))
 	{
 		return;  // Stop, since reached the edge of the map.
 	}
-	callback(dst, iHypot(dst), data);
+	callback(mapState, dst, iHypot(dst), data);
 }
 
 //-----------------------------------------------------------------------------------
 /* Will return false when we've hit the edge of the grid */
-static bool getTileHeightCallback(Vector2i pos, int32_t dist, void *data)
+static bool getTileHeightCallback(WorldMapState& mapState, Vector2i pos, int32_t dist, void *data)
 {
 	HeightCallbackHelp_t *help = (HeightCallbackHelp_t *)data;
 #ifdef TEST_RAY
@@ -138,14 +138,14 @@ static bool getTileHeightCallback(Vector2i pos, int32_t dist, void *data)
 	/* Are we still on the grid? */
 	if (clipXY(pos.x, pos.y))
 	{
-		bool HasTallStructure = blockTile(gameWorld.map, map_coord(pos.x), map_coord(pos.y), AUX_MAP) & AIR_BLOCKED;
+		bool HasTallStructure = blockTile(mapState, map_coord(pos.x), map_coord(pos.y), AUX_MAP) & AIR_BLOCKED;
 
 		if (dist > TILE_UNITS || HasTallStructure)
 		{
 			// Only do it the current tile is > TILE_UNITS away from the starting tile. Or..
 			// there is a tall structure  on the current tile and the current tile is not the starting tile.
 			/* Get height at this intersection point */
-			int height = map_Height(gameWorld.map, pos.x, pos.y), heightDiff;
+			int height = map_Height(mapState, pos.x, pos.y), heightDiff;
 			uint16_t newPitch;
 
 			if (HasTallStructure)
@@ -189,13 +189,13 @@ static bool getTileHeightCallback(Vector2i pos, int32_t dist, void *data)
 	return false;
 }
 
-void getBestPitchToEdgeOfGrid(UDWORD x, UDWORD y, uint16_t direction, uint16_t *pitch)
+void getBestPitchToEdgeOfGrid(WorldMapState& mapState, UDWORD x, UDWORD y, uint16_t direction, uint16_t *pitch)
 {
-	HeightCallbackHelp_t help = {map_Height(gameWorld.map, x, y), 0};
+	HeightCallbackHelp_t help = {map_Height(mapState, x, y), 0};
 
 	Vector3i src(x, y, 0);
 	Vector3i delta(iSinCosR(direction, 5430), 0);
-	rayCast(src.xy(), (src + delta).xy(), getTileHeightCallback, &help); // FIXME Magic value
+	rayCast(mapState, src.xy(), (src + delta).xy(), getTileHeightCallback, &help); // FIXME Magic value
 
 	*pitch = help.pitch;
 }

--- a/src/raycast.h
+++ b/src/raycast.h
@@ -26,29 +26,32 @@
 
 #include "lib/framework/vector.h"
 
+struct WorldMapState;
 
 /*!
  * The raycast intersection callback.
+ * \param mapState The game world map state
  * \param pos Current position
  * \param dist Current distance from start
  * \param data Payload (store intermediate results here)
  * \return true if ore points are required, false otherwise
  */
-typedef bool (*RAY_CALLBACK)(Vector2i pos, int32_t dist, void *data);
+typedef bool (*RAY_CALLBACK)(WorldMapState& mapState, Vector2i pos, int32_t dist, void *data);
 
 
 /*!
  * Cast a ray from a position into a certain direction
+ * \param mapState The game world map state
  * \param src Position to cast from
  * \param dst Position to cast to (casts to end of map, if dst is off the map)
  * \param callback Callback to call for each passed tile
  * \param data Data to pass through to the callback
  */
-void rayCast(Vector2i src, Vector2i dst, RAY_CALLBACK callback, void *data);
+void rayCast(WorldMapState& mapState, Vector2i src, Vector2i dst, RAY_CALLBACK callback, void *data);
 
 
 // Calculates the maximum height and distance found along a line from any
 // point to the edge of the grid
-void getBestPitchToEdgeOfGrid(UDWORD x, UDWORD y, uint16_t direction, uint16_t *pitch);
+void getBestPitchToEdgeOfGrid(WorldMapState& mapState, UDWORD x, UDWORD y, uint16_t direction, uint16_t *pitch);
 
 #endif // __INCLUDED_SRC_RAYCAST_H__

--- a/src/research.cpp
+++ b/src/research.cpp
@@ -790,7 +790,7 @@ bool researchAvailable(int inc, UDWORD playerID, QUEUE_MODE mode)
 		bStructFound = true;
 		for (incS = 0; incS < asResearch[inc].pStructList.size(); incS++)
 		{
-			if (!checkSpecificStructExists(asResearch[inc].pStructList[incS], playerID))
+			if (!checkSpecificStructExists(gameWorld.objects, asResearch[inc].pStructList[incS], playerID))
 			{
 				//if not built, quit checking
 				bStructFound = false;

--- a/src/selection.cpp
+++ b/src/selection.cpp
@@ -51,16 +51,16 @@
 static std::vector<std::vector<uint32_t> > combinations;
 
 template <typename T>
-static unsigned selSelectUnitsIf(unsigned player, T condition, bool onlyOnScreen)
+static unsigned selSelectUnitsIf(WorldObjectState& objState, unsigned player, T condition, bool onlyOnScreen)
 {
 	if (player >= MAX_PLAYERS) { return 0; }
 
 	unsigned count = 0;
 
-	selDroidDeselect(player);
+	selDroidDeselect(objState, player);
 
 	// Go through all.
-	for (DROID *psDroid : gameWorld.objects.droids[player])
+	for (DROID *psDroid : objState.droids[player])
 	{
 		bool shouldSelect = (!onlyOnScreen || objectOnScreen(psDroid, 0)) &&
 		                    condition(psDroid);
@@ -79,9 +79,9 @@ static unsigned selSelectUnitsIf(unsigned player, T condition, bool onlyOnScreen
 }
 
 template <typename T, typename U>
-static unsigned selSelectUnitsIf(unsigned player, T condition, U value, bool onlyOnScreen)
+static unsigned selSelectUnitsIf(WorldObjectState& objState, unsigned player, T condition, U value, bool onlyOnScreen)
 {
-	return selSelectUnitsIf(player, [condition, value](DROID *psDroid) { return condition(psDroid, value); }, onlyOnScreen);
+	return selSelectUnitsIf(objState, player, [condition, value](DROID *psDroid) { return condition(psDroid, value); }, onlyOnScreen);
 }
 
 static bool selTransporter(DROID *droid)
@@ -137,12 +137,12 @@ static bool selCombatLandMildlyOrNotDamaged(DROID *psDroid)
 
 // ---------------------------------------------------------------------
 // Deselects all units for the player
-unsigned int selDroidDeselect(unsigned int player)
+unsigned int selDroidDeselect(WorldObjectState& objState, unsigned int player)
 {
 	unsigned int count = 0;
 	if (player >= MAX_PLAYERS) { return 0; }
 
-	for (DROID* psDroid : gameWorld.objects.droids[player])
+	for (DROID* psDroid : objState.droids[player])
 	{
 		if (psDroid->selected)
 		{
@@ -156,12 +156,12 @@ unsigned int selDroidDeselect(unsigned int player)
 
 // ---------------------------------------------------------------------
 // Lets you know how many are selected for a given player
-unsigned int selNumSelected(unsigned int player)
+unsigned int selNumSelected(const WorldObjectState& objState, unsigned int player)
 {
 	unsigned int count = 0;
 	if (player >= MAX_PLAYERS) { return 0; }
 
-	for (const DROID *psDroid : gameWorld.objects.droids[player])
+	for (const DROID *psDroid : objState.droids[player])
 	{
 		if (psDroid->selected)
 		{
@@ -229,7 +229,7 @@ static bool componentsInCombinations(DROID *psDroid, bool add)
 }
 
 // Selects all units with the same propulsion, body and turret(s) as the one(s) selected
-static unsigned int selSelectAllSame(unsigned int player, bool bOnScreen)
+static unsigned int selSelectAllSame(WorldObjectState& objState, unsigned int player, bool bOnScreen)
 {
 	unsigned int i = 0, selected = 0;
 	std::vector<unsigned int> excluded;
@@ -239,7 +239,7 @@ static unsigned int selSelectAllSame(unsigned int player, bool bOnScreen)
 	if (player >= MAX_PLAYERS) { return 0; }
 
 	// find out which units will need to be compared to which component combinations
-	for (DROID *psDroid : gameWorld.objects.droids[player])
+	for (DROID *psDroid : objState.droids[player])
 	{
 		if (bOnScreen && !objectOnScreen(psDroid, 0))
 		{
@@ -260,7 +260,7 @@ static unsigned int selSelectAllSame(unsigned int player, bool bOnScreen)
 	{
 		// reset unit counter
 		i = 0;
-		for (DROID *psDroid : gameWorld.objects.droids[player])
+		for (DROID *psDroid : objState.droids[player])
 		{
 			if (excluded.empty() || *excluded.begin() != i)
 			{
@@ -282,7 +282,7 @@ static unsigned int selSelectAllSame(unsigned int player, bool bOnScreen)
 
 // ffs am
 // ---------------------------------------------------------------------
-void selNextSpecifiedUnit(DROID_TYPE unitType)
+void selNextSpecifiedUnit(WorldObjectState& objState, DROID_TYPE unitType)
 {
 	static DROID *psOldRD = nullptr; // pointer to last selected repair unit
 	DROID *psResult = nullptr, *psFirst = nullptr;
@@ -290,7 +290,7 @@ void selNextSpecifiedUnit(DROID_TYPE unitType)
 
 	ASSERT_OR_RETURN(, selectedPlayer < MAX_PLAYERS, "invalid selectedPlayer: %" PRIu32 "", selectedPlayer);
 
-	for (DROID *psCurr : gameWorld.objects.droids[selectedPlayer])
+	for (DROID *psCurr : objState.droids[selectedPlayer])
 	{
 		//exceptions - as always...
 		bool bMatch = false;
@@ -351,7 +351,7 @@ void selNextSpecifiedUnit(DROID_TYPE unitType)
 
 	if (psResult && !psResult->died)
 	{
-		selDroidDeselect(selectedPlayer);
+		selDroidDeselect(objState, selectedPlayer);
 		SelectDroid(psResult);
 		if (getWarCamStatus())
 		{
@@ -390,7 +390,7 @@ void selNextSpecifiedUnit(DROID_TYPE unitType)
 }
 
 // ---------------------------------------------------------------------
-void selNextUnassignedUnit()
+void selNextUnassignedUnit(WorldObjectState& objState)
 {
 	static DROID *psOldNS = nullptr;
 	DROID *psResult = nullptr, *psFirst = nullptr;
@@ -398,7 +398,7 @@ void selNextUnassignedUnit()
 
 	ASSERT_OR_RETURN(, selectedPlayer < MAX_PLAYERS, "invalid selectedPlayer: %" PRIu32 "", selectedPlayer);
 
-	for (DROID *psCurr : gameWorld.objects.droids[selectedPlayer])
+	for (DROID *psCurr : objState.droids[selectedPlayer])
 	{
 		/* Only look at unselected ones */
 		if (psCurr->group == UBYTE_MAX)
@@ -438,7 +438,7 @@ void selNextUnassignedUnit()
 
 	if (psResult && !psResult->died)
 	{
-		selDroidDeselect(selectedPlayer);
+		selDroidDeselect(objState, selectedPlayer);
 		SelectDroid(psResult);
 		if (getWarCamStatus())
 		{
@@ -462,7 +462,7 @@ void selNextUnassignedUnit()
 }
 
 // ---------------------------------------------------------------------
-void selNextSpecifiedBuilding(STRUCTURE_TYPE structType, bool jump)
+void selNextSpecifiedBuilding(WorldObjectState& objState, STRUCTURE_TYPE structType, bool jump)
 {
 	STRUCTURE *psResult = nullptr, *psOldStruct = nullptr, *psFirst = nullptr;
 	bool bLaterInList = false;
@@ -472,7 +472,7 @@ void selNextSpecifiedBuilding(STRUCTURE_TYPE structType, bool jump)
 	/* Firstly, start coughing if the type is invalid */
 	ASSERT(structType <= NUM_DIFF_BUILDINGS, "Invalid structure type %u", structType);
 
-	for (STRUCTURE *psCurr : gameWorld.objects.structures[selectedPlayer])
+	for (STRUCTURE *psCurr : objState.structures[selectedPlayer])
 	{
 		if (psResult)
 		{
@@ -591,7 +591,7 @@ void selCommander(int n)
    Selects the units of a given player according to given criteria.
    It is also possible to request whether the units be onscreen or not.
    */
-unsigned int selDroidSelection(unsigned int player, SELECTION_CLASS droidClass, SELECTIONTYPE droidType, bool bOnScreen)
+unsigned int selDroidSelection(WorldObjectState& objState, unsigned int player, SELECTION_CLASS droidClass, SELECTIONTYPE droidType, bool bOnScreen)
 {
 	if (player >= MAX_PLAYERS) { return 0; }
 
@@ -602,67 +602,67 @@ unsigned int selDroidSelection(unsigned int player, SELECTION_CLASS droidClass, 
 	switch (droidClass)
 	{
 	case DS_ALL_UNITS:
-		retVal = selSelectUnitsIf(player, selTrue, bOnScreen);
+		retVal = selSelectUnitsIf(objState, player, selTrue, bOnScreen);
 		break;
 	case DS_BY_TYPE:
 		switch (droidType)
 		{
 		case DST_VTOL:
-			retVal = selSelectUnitsIf(player, selProp, PROPULSION_TYPE_LIFT, bOnScreen);
+			retVal = selSelectUnitsIf(objState, player, selProp, PROPULSION_TYPE_LIFT, bOnScreen);
 			break;
 		case DST_VTOL_ARMED:
-			retVal = selSelectUnitsIf(player, selPropArmed, PROPULSION_TYPE_LIFT, bOnScreen);
+			retVal = selSelectUnitsIf(objState, player, selPropArmed, PROPULSION_TYPE_LIFT, bOnScreen);
 			break;
 		case DST_HOVER:
-			retVal = selSelectUnitsIf(player, selProp, PROPULSION_TYPE_HOVER, bOnScreen);
+			retVal = selSelectUnitsIf(objState, player, selProp, PROPULSION_TYPE_HOVER, bOnScreen);
 			break;
 		case DST_WHEELED:
-			retVal = selSelectUnitsIf(player, selProp, PROPULSION_TYPE_WHEELED, bOnScreen);
+			retVal = selSelectUnitsIf(objState, player, selProp, PROPULSION_TYPE_WHEELED, bOnScreen);
 			break;
 		case DST_TRACKED:
-			retVal = selSelectUnitsIf(player, selProp, PROPULSION_TYPE_TRACKED, bOnScreen);
+			retVal = selSelectUnitsIf(objState, player, selProp, PROPULSION_TYPE_TRACKED, bOnScreen);
 			break;
 		case DST_HALF_TRACKED:
-			retVal = selSelectUnitsIf(player, selProp, PROPULSION_TYPE_HALF_TRACKED, bOnScreen);
+			retVal = selSelectUnitsIf(objState, player, selProp, PROPULSION_TYPE_HALF_TRACKED, bOnScreen);
 			break;
 		case DST_CYBORG:
-			retVal = selSelectUnitsIf(player, selProp, PROPULSION_TYPE_LEGGED, bOnScreen);
+			retVal = selSelectUnitsIf(objState, player, selProp, PROPULSION_TYPE_LEGGED, bOnScreen);
 			break;
 		case DST_ENGINEER:
-			retVal = selSelectUnitsIf(player, selType, DROID_CYBORG_CONSTRUCT, bOnScreen);
+			retVal = selSelectUnitsIf(objState, player, selType, DROID_CYBORG_CONSTRUCT, bOnScreen);
 			break;
 		case DST_MECHANIC:
-			retVal = selSelectUnitsIf(player, selType, DROID_CYBORG_REPAIR, bOnScreen);
+			retVal = selSelectUnitsIf(objState, player, selType, DROID_CYBORG_REPAIR, bOnScreen);
 			break;
 		case DST_TRANSPORTER:
-			retVal = selSelectUnitsIf(player, selTransporter, bOnScreen);
+			retVal = selSelectUnitsIf(objState, player, selTransporter, bOnScreen);
 			break;
 		case DST_REPAIR_TANK:
-			retVal = selSelectUnitsIf(player, selType, DROID_REPAIR, bOnScreen);
+			retVal = selSelectUnitsIf(objState, player, selType, DROID_REPAIR, bOnScreen);
 			break;
 		case DST_SENSOR:
-			retVal = selSelectUnitsIf(player, selType, DROID_SENSOR, bOnScreen);
+			retVal = selSelectUnitsIf(objState, player, selType, DROID_SENSOR, bOnScreen);
 			break;
 		case DST_TRUCK:
-			retVal = selSelectUnitsIf(player, selType, DROID_CONSTRUCT, bOnScreen);
+			retVal = selSelectUnitsIf(objState, player, selType, DROID_CONSTRUCT, bOnScreen);
 			break;
 		case DST_ALL_COMBAT:
-			retVal = selSelectUnitsIf(player, selCombat, bOnScreen);
+			retVal = selSelectUnitsIf(objState, player, selCombat, bOnScreen);
 			break;
 		case DST_ALL_COMBAT_LAND:
-			retVal = selSelectUnitsIf(player, selCombatLand, bOnScreen);
+			retVal = selSelectUnitsIf(objState, player, selCombatLand, bOnScreen);
 			break;
 		case DST_ALL_COMBAT_CYBORG:
-			retVal = selSelectUnitsIf(player, selCombatCyborg, bOnScreen);
+			retVal = selSelectUnitsIf(objState, player, selCombatCyborg, bOnScreen);
 			break;
 		case DST_ALL_DAMAGED:
-			retVal = selSelectUnitsIf(player, selDamaged, bOnScreen);
+			retVal = selSelectUnitsIf(objState, player, selDamaged, bOnScreen);
 			break;
 		case DST_ALL_SAME:
-			retVal = selSelectAllSame(player, bOnScreen);
+			retVal = selSelectAllSame(objState, player, bOnScreen);
 			break;
 		case DST_ALL_LAND_MILDLY_OR_NOT_DAMAGED:
-			retVal = selSelectUnitsIf(player, selCombatLandMildlyOrNotDamaged, bOnScreen);
+			retVal = selSelectUnitsIf(objState, player, selCombatLandMildlyOrNotDamaged, bOnScreen);
 			break;
 		default:
 			ASSERT(false, "Invalid selection type");

--- a/src/selection.h
+++ b/src/selection.h
@@ -54,12 +54,14 @@ enum SELECTIONTYPE
 	DST_ALL_LAND_MILDLY_OR_NOT_DAMAGED,
 };
 
-unsigned int selDroidSelection(unsigned int player, SELECTION_CLASS droidClass, SELECTIONTYPE droidType, bool bOnScreen);
-unsigned int selDroidDeselect(unsigned int player);
-unsigned int selNumSelected(unsigned int player);
-void selNextUnassignedUnit();
-void selNextSpecifiedBuilding(STRUCTURE_TYPE structType, bool jump);
-void selNextSpecifiedUnit(DROID_TYPE unitType);
+struct WorldObjectState;
+
+unsigned int selDroidSelection(WorldObjectState& objState, unsigned int player, SELECTION_CLASS droidClass, SELECTIONTYPE droidType, bool bOnScreen);
+unsigned int selDroidDeselect(WorldObjectState& objState, unsigned int player);
+unsigned int selNumSelected(const WorldObjectState& objState, unsigned int player);
+void selNextUnassignedUnit(WorldObjectState& objState);
+void selNextSpecifiedBuilding(WorldObjectState& objState, STRUCTURE_TYPE structType, bool jump);
+void selNextSpecifiedUnit(WorldObjectState& objState, DROID_TYPE unitType);
 // select the n'th command droid
 void selCommander(int n);
 std::vector<uint32_t> buildComponentsFromDroid(const DROID* psDroid);

--- a/src/steering/collision_avoidance_behavior.cpp
+++ b/src/steering/collision_avoidance_behavior.cpp
@@ -37,6 +37,7 @@
 #include "src/fpath.h"
 #include "src/move.h"
 #include "src/objects.h"
+#include "src/game_world.h"
 
 #include <algorithm>
 
@@ -99,7 +100,7 @@ SteeringForce CollisionAvoidanceBehavior::calculate(const SteeringContext& ctx)
 		Vector2i deltaDiff = iSinCosR(obstDirectionGuess, predictionFactor);
 
 		// Don't assume obstacle can go through blocking tiles
-		if (!fpathBlockingTile(map_coord(obstacle->pos.x + deltaDiff.x),
+		if (!fpathBlockingTile(gameWorld.map, map_coord(obstacle->pos.x + deltaDiff.x),
 		                       map_coord(obstacle->pos.y + deltaDiff.y),
 		                       obstaclePropStats->propulsionType))
 		{

--- a/src/structure.cpp
+++ b/src/structure.cpp
@@ -37,6 +37,7 @@
 #include "map.h"
 #include "lib/gamelib/gtime.h"
 #include "objmem.h"
+#include "world_object_state.h"
 #include "visibility.h"
 #include "structure.h"
 #include "research.h"
@@ -139,7 +140,7 @@ static void informPowerGen(STRUCTURE *psStruct);
 static bool electronicReward(STRUCTURE *psStructure, UBYTE attackPlayer);
 static void factoryReward(UBYTE losingPlayer, UBYTE rewardPlayer);
 static void repairFacilityReward(UBYTE losingPlayer, UBYTE rewardPlayer);
-static void findAssemblyPointPosition(UDWORD *pX, UDWORD *pY, UDWORD player);
+static void findAssemblyPointPosition(GameWorld& world, UDWORD *pX, UDWORD *pY, UDWORD player);
 static void removeStructFromMap(STRUCTURE *psStruct);
 static void resetResistanceLag(STRUCTURE *psBuilding);
 static int structureTotalReturn(const STRUCTURE *psStruct);
@@ -254,10 +255,10 @@ bool isBlueprint(const BASE_OBJECT *psObject)
 
 // Add smoke effect to cover the droid's emergence from the factory or when building structures.
 // DISPLAY ONLY - does not affect game state.
-static void displayConstructionCloud(const Vector3i &pos)
+static void displayConstructionCloud(WorldMapState& mapState, const Vector3i &pos)
 {
 	const Vector2i coordinates = {pos.x, pos.y};
-	const MAPTILE *psTile = mapTile(gameWorld.map, map_coord(coordinates));
+	const MAPTILE *psTile = mapTile(mapState, map_coord(coordinates));
 	if (!tileIsClearlyVisible(psTile))
 	{
 		return;
@@ -266,7 +267,7 @@ static void displayConstructionCloud(const Vector3i &pos)
 	Vector3i iVecEffect;
 
 	iVecEffect.x = pos.x;
-	iVecEffect.y = map_Height(gameWorld.map, pos.x, pos.y) + DROID_CONSTRUCTION_SMOKE_HEIGHT;
+	iVecEffect.y = map_Height(mapState, pos.x, pos.y) + DROID_CONSTRUCTION_SMOKE_HEIGHT;
 	iVecEffect.z = pos.y;
 	addEffect(&iVecEffect, EFFECT_CONSTRUCTION, CONSTRUCTION_TYPE_DRIFTING, false, nullptr, 0, gameTime - deltaGameTime + 1);
 	iVecEffect.x = pos.x - DROID_CONSTRUCTION_SMOKE_OFFSET;
@@ -353,7 +354,7 @@ void initFactoryNumFlag()
 }
 
 //called at start of missions
-void resetFactoryNumFlag()
+void resetFactoryNumFlag(const WorldObjectState& objState)
 {
 	for (unsigned int i = 0; i < MAX_PLAYERS; i++)
 	{
@@ -363,7 +364,7 @@ void resetFactoryNumFlag()
 			factoryNumFlag[i][type].clear();
 		}
 		//look through the list of structures to see which have been used
-		for (const STRUCTURE *psStruct : gameWorld.objects.structures[i])
+		for (const STRUCTURE *psStruct : objState.structures[i])
 		{
 			FLAG_TYPE type;
 			switch (psStruct->pStructureType->type)
@@ -745,7 +746,7 @@ bool loadStructureStats(WzConfig &ini)
 }
 
 /* set the current number of structures of each type built */
-void setCurrentStructQuantity(bool displayError)
+void setCurrentStructQuantity(const WorldObjectState& objState, bool displayError)
 {
 	for (unsigned player = 0; player < MAX_PLAYERS; player++)
 	{
@@ -753,7 +754,7 @@ void setCurrentStructQuantity(bool displayError)
 		{
 			asStructureStats[inc].curCount[player] = 0;
 		}
-		for (const STRUCTURE *psCurr : gameWorld.objects.structures[player])
+		for (const STRUCTURE *psCurr : objState.structures[player])
 		{
 			unsigned inc = psCurr->pStructureType - asStructureStats;
 			asStructureStats[inc].curCount[player]++;
@@ -1267,12 +1268,12 @@ bool isBuildableOnWalls(STRUCTURE_TYPE type)
 	return type == REF_DEFENSE || type == REF_GATE;
 }
 
-static void structFindWalls(unsigned player, Vector2i map, bool aWallPresent[5][5], STRUCTURE *apsStructs[5][5])
+static void structFindWalls(WorldMapState& mapState, unsigned player, Vector2i map, bool aWallPresent[5][5], STRUCTURE *apsStructs[5][5])
 {
 	for (int y = -2; y <= 2; ++y)
 		for (int x = -2; x <= 2; ++x)
 		{
-			STRUCTURE *psStruct = castStructure(mapTile(gameWorld.map, map.x + x, map.y + y)->psObject);
+			STRUCTURE *psStruct = castStructure(mapTile(mapState, map.x + x, map.y + y)->psObject);
 			if (psStruct != nullptr && isWallCombiningStructureType(psStruct->pStructureType) && player < MAX_PLAYERS && aiCheckAlliances(player, psStruct->player))
 			{
 				aWallPresent[x + 2][y + 2] = true;
@@ -1296,23 +1297,23 @@ static void structFindWallBlueprints(Vector2i map, bool aWallPresent[5][5])
 		}
 }
 
-static bool wallBlockingTerrainJoin(Vector2i map)
+static bool wallBlockingTerrainJoin(WorldMapState& mapState, Vector2i map)
 {
-	MAPTILE *psTile = mapTile(gameWorld.map, map);
+	MAPTILE *psTile = mapTile(mapState, map);
 	return terrainType(psTile) == TER_WATER || terrainType(psTile) == TER_CLIFFFACE || psTile->psObject != nullptr;
 }
 
-static WallOrientation structWallScanTerrain(bool aWallPresent[5][5], Vector2i map)
+static WallOrientation structWallScanTerrain(WorldMapState& mapState, bool aWallPresent[5][5], Vector2i map)
 {
 	WallOrientation orientation = structWallScan(aWallPresent, 2, 2);
 
 	if (orientation == WallConnectNone)
 	{
 		// If neutral, try choosing horizontal or vertical based on terrain, but don't change to corner type.
-		aWallPresent[2][1] = wallBlockingTerrainJoin(map + Vector2i(0, -1));
-		aWallPresent[2][3] = wallBlockingTerrainJoin(map + Vector2i(0,  1));
-		aWallPresent[1][2] = wallBlockingTerrainJoin(map + Vector2i(-1,  0));
-		aWallPresent[3][2] = wallBlockingTerrainJoin(map + Vector2i(1,  0));
+		aWallPresent[2][1] = wallBlockingTerrainJoin(mapState, map + Vector2i(0, -1));
+		aWallPresent[2][3] = wallBlockingTerrainJoin(mapState, map + Vector2i(0,  1));
+		aWallPresent[1][2] = wallBlockingTerrainJoin(mapState, map + Vector2i(-1,  0));
+		aWallPresent[3][2] = wallBlockingTerrainJoin(mapState, map + Vector2i(1,  0));
 		orientation = structWallScan(aWallPresent, 2, 2);
 		if ((orientation & (WallConnectLeft | WallConnectRight)) != 0 && (orientation & (WallConnectUp | WallConnectDown)) != 0)
 		{
@@ -1323,22 +1324,22 @@ static WallOrientation structWallScanTerrain(bool aWallPresent[5][5], Vector2i m
 	return orientation;
 }
 
-static WallOrientation structChooseWallTypeBlueprint(Vector2i map)
+static WallOrientation structChooseWallTypeBlueprint(WorldMapState& mapState, Vector2i map)
 {
 	bool            aWallPresent[5][5];
 	STRUCTURE      *apsStructs[5][5];
 
 	// scan around the location looking for walls
 	memset(aWallPresent, 0, sizeof(aWallPresent));
-	structFindWalls(selectedPlayer, map, aWallPresent, apsStructs);
+	structFindWalls(mapState, selectedPlayer, map, aWallPresent, apsStructs);
 	structFindWallBlueprints(map, aWallPresent);
 
 	// finally return the type for this wall
-	return structWallScanTerrain(aWallPresent, map);
+	return structWallScanTerrain(mapState, aWallPresent, map);
 }
 
 // Choose a type of wall for a location - and update any neighbouring walls
-static WallOrientation structChooseWallType(unsigned player, Vector2i map)
+static WallOrientation structChooseWallType(WorldMapState& mapState, unsigned player, Vector2i map)
 {
 	bool		aWallPresent[5][5];
 	STRUCTURE	*psStruct;
@@ -1346,7 +1347,7 @@ static WallOrientation structChooseWallType(unsigned player, Vector2i map)
 
 	// scan around the location looking for walls
 	memset(aWallPresent, 0, sizeof(aWallPresent));
-	structFindWalls(player, map, aWallPresent, apsStructs);
+	structFindWalls(mapState, player, map, aWallPresent, apsStructs);
 
 	// now make sure that all the walls around this one are OK
 	for (int x = 1; x <= 3; ++x)
@@ -1381,7 +1382,7 @@ static WallOrientation structChooseWallType(unsigned player, Vector2i map)
 	}
 
 	// finally return the type for this wall
-	return structWallScanTerrain(aWallPresent, map);
+	return structWallScanTerrain(mapState, aWallPresent, map);
 }
 
 
@@ -1427,7 +1428,7 @@ static void buildFlatten(STRUCTURE *pStructure, int h)
 			// We need to raise features on raised tiles to the new height
 			if (TileHasFeature(mapTile(gameWorld.map, b.map.x + width, b.map.y + breadth)))
 			{
-				getTileFeature(b.map.x + width, b.map.y + breadth)->pos.z = h;
+				getTileFeature(gameWorld.map, b.map.x + width, b.map.y + breadth)->pos.z = h;
 			}
 		}
 	}
@@ -1492,17 +1493,17 @@ void alignStructure(STRUCTURE *psBuilding)
 }
 
 /*Builds an instance of a Structure - the x/y passed in are in world coords. */
-STRUCTURE *buildStructure(STRUCTURE_STATS *pStructureType, UDWORD x, UDWORD y, UDWORD player, bool FromSave)
+STRUCTURE *buildStructure(GameWorld& world, STRUCTURE_STATS *pStructureType, UDWORD x, UDWORD y, UDWORD player, bool FromSave)
 {
-	return buildStructureDir(pStructureType, x, y, 0, player, FromSave, generateSynchronisedObjectId());
+	return buildStructureDir(world, pStructureType, x, y, 0, player, FromSave, generateSynchronisedObjectId());
 }
 
-STRUCTURE *buildStructureDir(STRUCTURE_STATS *pStructureType, UDWORD x, UDWORD y, uint16_t direction, UDWORD player, bool FromSave)
+STRUCTURE *buildStructureDir(GameWorld& world, STRUCTURE_STATS *pStructureType, UDWORD x, UDWORD y, uint16_t direction, UDWORD player, bool FromSave)
 {
-	return buildStructureDir(pStructureType, x, y, direction, player, FromSave, generateSynchronisedObjectId());
+	return buildStructureDir(world, pStructureType, x, y, direction, player, FromSave, generateSynchronisedObjectId());
 }
 
-STRUCTURE *buildStructureDir(STRUCTURE_STATS *pStructureType, UDWORD x, UDWORD y, uint16_t direction, UDWORD player, bool FromSave, uint32_t id, bool forceWallOrientation/*= false*/)
+STRUCTURE *buildStructureDir(GameWorld& world, STRUCTURE_STATS *pStructureType, UDWORD x, UDWORD y, uint16_t direction, UDWORD player, bool FromSave, uint32_t id, bool forceWallOrientation/*= false*/)
 {
 	STRUCTURE *psBuilding = nullptr;
 	const Vector2i size = pStructureType->size(direction);
@@ -1532,13 +1533,13 @@ STRUCTURE *buildStructureDir(STRUCTURE_STATS *pStructureType, UDWORD x, UDWORD y
 		y = (y & ~TILE_MASK) + size.y % 2 * TILE_UNITS / 2;
 
 		//check not trying to build too near the edge
-		if (map_coord(x) < TOO_NEAR_EDGE || map_coord(x) > (gameWorld.map.width - TOO_NEAR_EDGE))
+		if (map_coord(x) < TOO_NEAR_EDGE || map_coord(x) > (world.map.width - TOO_NEAR_EDGE))
 		{
 			debug(LOG_WARNING, "attempting to build too closely to map-edge, "
 			      "x coord (%u) too near edge (req. distance is %u)", x, TOO_NEAR_EDGE);
 			return nullptr;
 		}
-		if (map_coord(y) < TOO_NEAR_EDGE || map_coord(y) > (gameWorld.map.height - TOO_NEAR_EDGE))
+		if (map_coord(y) < TOO_NEAR_EDGE || map_coord(y) > (world.map.height - TOO_NEAR_EDGE))
 		{
 			debug(LOG_WARNING, "attempting to build too closely to map-edge, "
 			      "y coord (%u) too near edge (req. distance is %u)", y, TOO_NEAR_EDGE);
@@ -1552,7 +1553,7 @@ STRUCTURE *buildStructureDir(STRUCTURE_STATS *pStructureType, UDWORD x, UDWORD y
 				for (int dx = 0; dx < size.x; ++dx)
 				{
 					Vector2i pos = map_coord(Vector2i(x, y) - size * TILE_UNITS / 2) + Vector2i(dx, dy);
-					wallOrientation = structChooseWallType(player, pos);  // This makes neighbouring walls match us, even if we're a hardpoint, not a wall.
+					wallOrientation = structChooseWallType(world.map, player, pos);  // This makes neighbouring walls match us, even if we're a hardpoint, not a wall.
 				}
 		}
 
@@ -1583,11 +1584,11 @@ STRUCTURE *buildStructureDir(STRUCTURE_STATS *pStructureType, UDWORD x, UDWORD y
 		 * to remove when placing oil derricks! */
 		if (pStructureType->type == REF_RESOURCE_EXTRACTOR)
 		{
-			FEATURE *psFeature = getTileFeature(map_coord(x), map_coord(y));
+			FEATURE *psFeature = getTileFeature(world.map, map_coord(x), map_coord(y));
 
 			if (psFeature && psFeature->psStats->subType == FEAT_OIL_RESOURCE)
 			{
-				if (fireOnLocation(gameWorld.map, psFeature->pos.x, psFeature->pos.y))
+				if (fireOnLocation(world.map, psFeature->pos.x, psFeature->pos.y))
 				{
 					// Can't build on burning oil resource
 					return nullptr;
@@ -1603,7 +1604,7 @@ STRUCTURE *buildStructureDir(STRUCTURE_STATS *pStructureType, UDWORD x, UDWORD y
 		{
 			for (int tileX = map.x; tileX < map.x + size.x; ++tileX)
 			{
-				MAPTILE *psTile = mapTile(gameWorld.map, tileX, tileY);
+				MAPTILE *psTile = mapTile(world.map, tileX, tileY);
 
 				/* Remove any walls underneath the building. You can build defense buildings on top
 				 * of walls, you see. This is not the place to test whether we own it! */
@@ -1619,7 +1620,7 @@ STRUCTURE *buildStructureDir(STRUCTURE_STATS *pStructureType, UDWORD x, UDWORD y
 #endif
 					debug(LOG_ERROR, "Player %u (%s): is building %s at (%d, %d) but found %s already at (%d, %d)",
 					      player, isHumanPlayer(player) ? "Human" : "AI", getStatsName(pStructureType), map.x, map.y,
-					      getStatsName(getTileStructure(tileX, tileY)->pStructureType), tileX, tileY);
+					      getStatsName(getTileStructure(world.map, tileX, tileY)->pStructureType), tileX, tileY);
 #if defined(WZ_CC_GNU) && !defined(WZ_CC_INTEL) && !defined(WZ_CC_CLANG) && (7 <= __GNUC__)
 # pragma GCC diagnostic pop
 #endif
@@ -1635,13 +1636,13 @@ STRUCTURE *buildStructureDir(STRUCTURE_STATS *pStructureType, UDWORD x, UDWORD y
 			for (int tileX = map.x; tileX < map.x + size.x; ++tileX)
 			{
 				// We now know the previous loop didn't return early, so it is safe to save references to `stableBuilding` now.
-				MAPTILE *psTile = mapTile(gameWorld.map, tileX, tileY);
+				MAPTILE *psTile = mapTile(world.map, tileX, tileY);
 				psTile->psObject = psBuilding;
 
 				// if it's a tall structure then flag it in the map.
 				if (psBuilding->sDisplay.imd && psBuilding->sDisplay.imd->max.y > TALLOBJECT_YMAX)
 				{
-					auxSetBlocking(gameWorld.map, tileX, tileY, AIR_BLOCKED);
+					auxSetBlocking(world.map, tileX, tileY, AIR_BLOCKED);
 				}
 			}
 		}
@@ -1726,7 +1727,7 @@ STRUCTURE *buildStructureDir(STRUCTURE_STATS *pStructureType, UDWORD x, UDWORD y
 		}
 
 		// Reveal any tiles that can be seen by the structure
-		visTilesUpdate(psBuilding);
+		visTilesUpdate(psBuilding, world.map);
 
 		/*if we're coming from a SAVEGAME and we're on an Expand_Limbo mission,
 		any factories that were built previously for the selectedPlayer will
@@ -1736,15 +1737,15 @@ STRUCTURE *buildStructureDir(STRUCTURE_STATS *pStructureType, UDWORD x, UDWORD y
 		if (FromSave && player == selectedPlayer && missionLimboExpand())
 		{
 			//save the current values
-			preScrollMinX = gameWorld.map.scroll.minX;
-			preScrollMinY = gameWorld.map.scroll.minY;
-			preScrollMaxX = gameWorld.map.scroll.maxX;
-			preScrollMaxY = gameWorld.map.scroll.maxY;
+			preScrollMinX = world.map.scroll.minX;
+			preScrollMinY = world.map.scroll.minY;
+			preScrollMaxX = world.map.scroll.maxX;
+			preScrollMaxY = world.map.scroll.maxY;
 			//set the current values to mapWidth/mapHeight
-			gameWorld.map.scroll.minX = 0;
-			gameWorld.map.scroll.minY = 0;
-			gameWorld.map.scroll.maxX = gameWorld.map.width;
-			gameWorld.map.scroll.maxY = gameWorld.map.height;
+			world.map.scroll.minX = 0;
+			world.map.scroll.minY = 0;
+			world.map.scroll.maxX = world.map.width;
+			world.map.scroll.maxY = world.map.height;
 			// NOTE: resizeRadar() may be required here, since we change scroll limits?
 		}
 		//set the functionality dependent on the type of structure
@@ -1756,10 +1757,10 @@ STRUCTURE *buildStructureDir(STRUCTURE_STATS *pStructureType, UDWORD x, UDWORD y
 			if (FromSave && player == selectedPlayer && missionLimboExpand())
 			{
 				//reset the current values
-				gameWorld.map.scroll.minX = preScrollMinX;
-				gameWorld.map.scroll.minY = preScrollMinY;
-				gameWorld.map.scroll.maxX = preScrollMaxX;
-				gameWorld.map.scroll.maxY = preScrollMaxY;
+				world.map.scroll.minX = preScrollMinX;
+				world.map.scroll.minY = preScrollMinY;
+				world.map.scroll.maxX = preScrollMaxX;
+				world.map.scroll.maxY = preScrollMaxY;
 				// NOTE: resizeRadar() may be required here, since we change scroll limits?
 			}
 			return nullptr;
@@ -1769,10 +1770,10 @@ STRUCTURE *buildStructureDir(STRUCTURE_STATS *pStructureType, UDWORD x, UDWORD y
 		if (FromSave && player == selectedPlayer && missionLimboExpand())
 		{
 			//reset the current values
-			gameWorld.map.scroll.minX = preScrollMinX;
-			gameWorld.map.scroll.minY = preScrollMinY;
-			gameWorld.map.scroll.maxX = preScrollMaxX;
-			gameWorld.map.scroll.maxY = preScrollMaxY;
+			world.map.scroll.minX = preScrollMinX;
+			world.map.scroll.minY = preScrollMinY;
+			world.map.scroll.maxX = preScrollMaxX;
+			world.map.scroll.maxY = preScrollMaxY;
 			// NOTE: resizeRadar() may be required here, since we change scroll limits?
 		}
 
@@ -1804,7 +1805,7 @@ STRUCTURE *buildStructureDir(STRUCTURE_STATS *pStructureType, UDWORD x, UDWORD y
 		StructureBounds bounds = getStructureBounds(psBuilding);
 		for (unsigned playerNum = 0; playerNum < MAX_PLAYERS; ++playerNum)
 		{
-			for (const STRUCTURE *psStruct : gameWorld.objects.structures[playerNum])
+			for (const STRUCTURE *psStruct : world.objects.structures[playerNum])
 			{
 				if (!psStruct)
 				{
@@ -1825,7 +1826,7 @@ STRUCTURE *buildStructureDir(STRUCTURE_STATS *pStructureType, UDWORD x, UDWORD y
 					if (unsigned(pos.x - bounds.map.x) < unsigned(bounds.size.x) && unsigned(pos.y - bounds.map.y) < unsigned(bounds.size.y))
 					{
 						// Delivery point fp is under the new structure. Need to move it.
-						setAssemblyPoint(fp, fp->coords.x, fp->coords.y, playerNum, true);
+						setAssemblyPoint(world, fp, fp->coords.x, fp->coords.y, playerNum, true);
 					}
 				}
 			}
@@ -1833,7 +1834,7 @@ STRUCTURE *buildStructureDir(STRUCTURE_STATS *pStructureType, UDWORD x, UDWORD y
 
 		if (!FromSave)
 		{
-			displayConstructionCloud(psBuilding->pos);
+			displayConstructionCloud(world.map, psBuilding->pos);
 		}
 	}
 	else //its an upgrade
@@ -1842,7 +1843,7 @@ STRUCTURE *buildStructureDir(STRUCTURE_STATS *pStructureType, UDWORD x, UDWORD y
 		int32_t         bodyDiff = 0;
 
 		//don't create the Structure use existing one
-		psBuilding = getTileStructure(map_coord(x), map_coord(y));
+		psBuilding = getTileStructure(world.map, map_coord(x), map_coord(y));
 
 		if (!psBuilding)
 		{
@@ -1976,7 +1977,7 @@ STRUCTURE *buildStructureDir(STRUCTURE_STATS *pStructureType, UDWORD x, UDWORD y
 	return psBuilding;
 }
 
-optional<STRUCTURE> buildBlueprint(STRUCTURE_STATS const *psStats, Vector3i pos, uint16_t direction, unsigned moduleIndex, STRUCT_STATES state, uint8_t ownerPlayer)
+optional<STRUCTURE> buildBlueprint(WorldMapState& mapState, STRUCTURE_STATS const *psStats, Vector3i pos, uint16_t direction, unsigned moduleIndex, STRUCT_STATES state, uint8_t ownerPlayer)
 {
 	ASSERT_OR_RETURN(nullopt, psStats != nullptr, "No blueprint stats");
 	ASSERT_OR_RETURN(nullopt, psStats->pIMD[0] != nullptr, "No blueprint model for %s", getStatsName(psStats));
@@ -1988,7 +1989,7 @@ optional<STRUCTURE> buildBlueprint(STRUCTURE_STATS const *psStats, Vector3i pos,
 	std::vector<iIMDBaseShape *> const *pIMD = &psStats->pIMD;
 	if (IsStatExpansionModule(psStats))
 	{
-		STRUCTURE *baseStruct = castStructure(worldTile(gameWorld.map, pos.xy())->psObject);
+		STRUCTURE *baseStruct = castStructure(worldTile(mapState, pos.xy())->psObject);
 		if (baseStruct != nullptr)
 		{
 			if (moduleIndex == 0)
@@ -2048,7 +2049,7 @@ optional<STRUCTURE> buildBlueprint(STRUCTURE_STATS const *psStats, Vector3i pos,
 	// Rotate wall if needed.
 	if (blueprint.pStructureType->type == REF_WALL || blueprint.pStructureType->type == REF_GATE)
 	{
-		WallOrientation scanType = structChooseWallTypeBlueprint(map_coord(blueprint.pos.xy()));
+		WallOrientation scanType = structChooseWallTypeBlueprint(mapState, map_coord(blueprint.pos.xy()));
 		unsigned type = wallType(scanType);
 		if (scanType != WallConnectNone)
 		{
@@ -2122,7 +2123,7 @@ static bool setFunctionality(STRUCTURE *psBuilding, STRUCTURE_TYPE functionType)
 
 			// Set the assembly point
 			Vector2i pos = defaultAssemblyPointPos(psBuilding);
-			setAssemblyPoint(psFactory->psAssemblyPoint, pos.x, pos.y, psBuilding->player, true);
+			setAssemblyPoint(gameWorld, psFactory->psAssemblyPoint, pos.x, pos.y, psBuilding->player, true);
 
 			// Add the flag to the list
 			addFlagPosition(psFactory->psAssemblyPoint);
@@ -2170,7 +2171,7 @@ static bool setFunctionality(STRUCTURE *psBuilding, STRUCTURE_TYPE functionType)
 
 			// Set the assembly point
 			Vector2i pos = defaultAssemblyPointPos(psBuilding);
-			setAssemblyPoint(psRepairFac->psDeliveryPoint, pos.x, pos.y, psBuilding->player, true);
+			setAssemblyPoint(gameWorld, psRepairFac->psDeliveryPoint, pos.x, pos.y, psBuilding->player, true);
 
 			// Add the flag (triangular marker on the ground) at the delivery point
 			addFlagPosition(psRepairFac->psDeliveryPoint);
@@ -2337,17 +2338,17 @@ void assignFactoryCommandDroid(STRUCTURE *psStruct, DROID *psCommander)
 	{
 		if (typeFlag == FACTORY_FLAG)
 		{
-			secondarySetState(psFact->psCommander, DSO_CLEAR_PRODUCTION,
+			secondarySetState(psFact->psCommander, gameWorld.objects, DSO_CLEAR_PRODUCTION,
 			                  (SECONDARY_STATE)(1 << (psFact->psAssemblyPoint->factoryInc + DSS_ASSPROD_SHIFT)));
 		}
 		else if (typeFlag == CYBORG_FLAG)
 		{
-			secondarySetState(psFact->psCommander, DSO_CLEAR_PRODUCTION,
+			secondarySetState(psFact->psCommander, gameWorld.objects, DSO_CLEAR_PRODUCTION,
 			                  (SECONDARY_STATE)(1 << (psFact->psAssemblyPoint->factoryInc + DSS_ASSPROD_CYBORG_SHIFT)));
 		}
 		else
 		{
-			secondarySetState(psFact->psCommander, DSO_CLEAR_PRODUCTION,
+			secondarySetState(psFact->psCommander, gameWorld.objects, DSO_CLEAR_PRODUCTION,
 			                  (SECONDARY_STATE)(1 << (psFact->psAssemblyPoint->factoryInc + DSS_ASSPROD_VTOL_SHIFT)));
 		}
 
@@ -2430,13 +2431,13 @@ void clearCommandDroidFactory(DROID *psDroid)
 }
 
 /* Check that a tile is vacant for a droid to be placed */
-static bool structClearTile(UWORD x, UWORD y, PROPULSION_TYPE propulsion)
+static bool structClearTile(const GameWorld& world, UWORD x, UWORD y, PROPULSION_TYPE propulsion)
 {
 	UDWORD	player;
 
 	/* Check for a structure */
 	/* NOTE: Substitute PROPULSION_TYPE_WHEELED for PROPULSION_TYPE_LIFT, as flying droids are initially placed on the ground */
-	if (fpathBlockingTile(x, y, (propulsion != PROPULSION_TYPE_LIFT) ? propulsion : PROPULSION_TYPE_WHEELED))
+	if (fpathBlockingTile(world.map, x, y, (propulsion != PROPULSION_TYPE_LIFT) ? propulsion : PROPULSION_TYPE_WHEELED))
 	{
 		debug(LOG_NEVER, "failed - blocked");
 		return false;
@@ -2445,7 +2446,7 @@ static bool structClearTile(UWORD x, UWORD y, PROPULSION_TYPE propulsion)
 	/* Check for a droid */
 	for (player = 0; player < MAX_PLAYERS; player++)
 	{
-		for (const DROID* psCurr : gameWorld.objects.droids[player])
+		for (const DROID* psCurr : world.objects.droids[player])
 		{
 			if (map_coord(psCurr->pos.x) == x
 			    && map_coord(psCurr->pos.y) == y)
@@ -2529,7 +2530,7 @@ bool placeDroid(STRUCTURE *psStructure, const DROID_TEMPLATE * psTempl, UDWORD *
 	{
 		for (int x = xmin; x <= xmax; ++x)
 		{
-			if (structClearTile(x, y, psTempl->getPropulsionStats()->propulsionType))
+			if (structClearTile(gameWorld, x, y, psTempl->getPropulsionStats()->propulsionType))
 			{
 				tiles.push_back(Vector2i(12 * x - sx, 12 * y - sy));
 			}
@@ -2587,23 +2588,23 @@ void setFactorySecondaryState(DROID *psDroid, STRUCTURE *psStructure)
 		uint32_t diff = newState ^ psDroid->secondaryOrder;
 		if ((diff & DSS_ARANGE_MASK) != 0)
 		{
-			secondarySetState(psDroid, DSO_ATTACK_RANGE, (SECONDARY_STATE)(newState & DSS_ARANGE_MASK));
+			secondarySetState(psDroid, gameWorld.objects, DSO_ATTACK_RANGE, (SECONDARY_STATE)(newState & DSS_ARANGE_MASK));
 		}
 		if ((diff & DSS_REPLEV_MASK) != 0)
 		{
-			secondarySetState(psDroid, DSO_REPAIR_LEVEL, (SECONDARY_STATE)(newState & DSS_REPLEV_MASK));
+			secondarySetState(psDroid, gameWorld.objects, DSO_REPAIR_LEVEL, (SECONDARY_STATE)(newState & DSS_REPLEV_MASK));
 		}
 		if ((diff & DSS_ALEV_MASK) != 0)
 		{
-			secondarySetState(psDroid, DSO_ATTACK_LEVEL, (SECONDARY_STATE)(newState & DSS_ALEV_MASK));
+			secondarySetState(psDroid, gameWorld.objects, DSO_ATTACK_LEVEL, (SECONDARY_STATE)(newState & DSS_ALEV_MASK));
 		}
 		if ((diff & DSS_CIRCLE_MASK) != 0)
 		{
-			secondarySetState(psDroid, DSO_CIRCLE, (SECONDARY_STATE)(newState & DSS_CIRCLE_MASK));
+			secondarySetState(psDroid, gameWorld.objects, DSO_CIRCLE, (SECONDARY_STATE)(newState & DSS_CIRCLE_MASK));
 		}
 		if ((diff & DSS_HALT_MASK) != 0)
 		{
-			secondarySetState(psDroid, DSO_HALTTYPE, (SECONDARY_STATE)(newState & DSS_HALT_MASK));
+			secondarySetState(psDroid, gameWorld.objects, DSO_HALTTYPE, (SECONDARY_STATE)(newState & DSS_HALT_MASK));
 		}
 	}
 }
@@ -2629,7 +2630,7 @@ static bool structPlaceDroid(STRUCTURE *psStructure, DROID_TEMPLATE *psTempl, DR
 		//create a droid near to the structure
 		syncDebug("Placing new droid at (%d,%d)", x, y);
 		turnOffMultiMsg(true);
-		psNewDroid = buildDroid(psTempl, x, y, psStructure->player, false, &initialOrders, psStructure->rot);
+		psNewDroid = buildDroid(gameWorld, psTempl, x, y, psStructure->player, false, &initialOrders, psStructure->rot);
 		turnOffMultiMsg(false);
 		if (!psNewDroid)
 		{
@@ -2649,7 +2650,7 @@ static bool structPlaceDroid(STRUCTURE *psStructure, DROID_TEMPLATE *psTempl, DR
 			}
 		}
 		setFactorySecondaryState(psNewDroid, psStructure);
-		displayConstructionCloud(psNewDroid->pos);
+		displayConstructionCloud(gameWorld.map, psNewDroid->pos);
 		/* add the droid to the list */
 		addDroid(psNewDroid, gameWorld.objects.droids);
 		*ppsDroid = psNewDroid;
@@ -2779,7 +2780,7 @@ static bool IsFactoryCommanderGroupFull(const FACTORY *psFactory)
 
 // Check if a player has a certain structure. Optionally, checks if there is
 // at least one that is built.
-bool structureExists(int player, STRUCTURE_TYPE type, bool built, bool isMission)
+bool structureExists(const WorldObjectState& objState, int player, STRUCTURE_TYPE type, bool built)
 {
 	bool found = false;
 
@@ -2789,8 +2790,7 @@ bool structureExists(int player, STRUCTURE_TYPE type, bool built, bool isMission
 		return false;
 	}
 
-	StructureList* pList = isMission ? &mission.gameWorld.objects.structures[player] : &gameWorld.objects.structures[player];
-	for (const STRUCTURE *psCurr : *pList)
+	for (const STRUCTURE *psCurr : objState.structures[player])
 	{
 		if (psCurr->pStructureType->type == type && (!built || (built && psCurr->status == SS_BUILT)))
 		{
@@ -2869,7 +2869,9 @@ static bool checkHaltOnMaxUnitsReached(STRUCTURE *psStructure, bool isMission)
 	else switch (droidTemplateType(templ))
 		{
 		case DROID_COMMAND:
-			if (!structureExists(player, REF_COMMAND_CONTROL, true, isMission))
+		{
+			const WorldObjectState& objState = isMission ? mission.gameWorld.objects : gameWorld.objects;
+			if (!structureExists(objState, player, REF_COMMAND_CONTROL, true))
 			{
 				isLimit = true;
 				ssprintf(limitMsg, _("Can't build \"%s\" without a Command Relay Center — Production Halted"), templ->name.toUtf8().c_str());
@@ -2880,6 +2882,7 @@ static bool checkHaltOnMaxUnitsReached(STRUCTURE *psStructure, bool isMission)
 				ssprintf(limitMsg, _("Can't build \"%s\", Commander Limit Reached — Production Halted"), templ->name.toUtf8().c_str());
 			}
 			break;
+		}
 		case DROID_CONSTRUCT:
 		case DROID_CYBORG_CONSTRUCT:
 			if (getNumConstructorDroids(player) >= getMaxConstructors(player))
@@ -3025,7 +3028,7 @@ RepairState aiUpdateRepair_handleEvents(STRUCTURE &station, RepairEvents ev, DRO
 		// only call "secondarySetState" *after* triggering "droidWasFullyRepaired"
 		// because in some cases calling it would modify primary order
 		// thus, loosing information that we actually had a RTR|RTR_SPECIFIED before
-		secondarySetState(psDroid, DSO_RETURN_TO_LOC, DSS_NONE);
+		secondarySetState(psDroid, gameWorld.objects, DSO_RETURN_TO_LOC, DSS_NONE);
 		return RepairState::Idle;
 	};
 	case RepairEvents::UnitDied:
@@ -3785,7 +3788,7 @@ void structureUpdate(STRUCTURE *psBuilding, bool bMission)
 
 	if (psBuilding->flags.test(OBJECT_FLAG_DIRTY) && !bMission)
 	{
-		visTilesUpdate(psBuilding);
+		visTilesUpdate(psBuilding, gameWorld.map);
 		psBuilding->flags.set(OBJECT_FLAG_DIRTY, false);
 	}
 
@@ -4044,7 +4047,7 @@ fills the list with Structure that can be built. There is a limit on how many ca
 be built at any one time. Pass back the number available.
 There is now a limit of how many of each type of structure are allowed per mission
 */
-std::vector<STRUCTURE_STATS *> fillStructureList(UDWORD _selectedPlayer, UDWORD limit, bool showFavorites)
+std::vector<STRUCTURE_STATS *> fillStructureList(const WorldObjectState& objState, UDWORD _selectedPlayer, UDWORD limit, bool showFavorites)
 {
 	std::vector<STRUCTURE_STATS *> structureList;
 	UDWORD			inc;
@@ -4064,7 +4067,7 @@ std::vector<STRUCTURE_STATS *> fillStructureList(UDWORD _selectedPlayer, UDWORD 
 	//if currently on a mission can't build factory/research/power/derricks
 	if (!missionIsOffworld())
 	{
-		for (const STRUCTURE* psCurr : gameWorld.objects.structures[_selectedPlayer])
+		for (const STRUCTURE* psCurr : objState.structures[_selectedPlayer])
 		{
 			if (psCurr->pStructureType->type == REF_RESEARCH && psCurr->status == SS_BUILT)
 			{
@@ -4272,15 +4275,15 @@ bool isBlueprintTooClose(STRUCTURE_STATS const *stats1, Vector2i pos1, uint16_t 
 	return dist < minDist;
 }
 
-bool validLocation(BASE_STATS *psStats, Vector2i pos, uint16_t direction, unsigned player, bool bCheckBuildQueue)
+bool validLocation(GameWorld& world, BASE_STATS *psStats, Vector2i pos, uint16_t direction, unsigned player, bool bCheckBuildQueue)
 {
 	ASSERT_OR_RETURN(false, player < MAX_PLAYERS, "player (%u) >= MAX_PLAYERS", player);
 
 	StructureBounds b = getStructureBounds(psStats, pos, direction);
 
 	//make sure we are not too near map edge and not going to go over it
-	if (b.map.x < gameWorld.map.scroll.minX + TOO_NEAR_EDGE || b.map.x + b.size.x > gameWorld.map.scroll.maxX - TOO_NEAR_EDGE ||
-	    b.map.y < gameWorld.map.scroll.minY + TOO_NEAR_EDGE || b.map.y + b.size.y > gameWorld.map.scroll.maxY - TOO_NEAR_EDGE)
+	if (b.map.x < world.map.scroll.minX + TOO_NEAR_EDGE || b.map.x + b.size.x > world.map.scroll.maxX - TOO_NEAR_EDGE ||
+	    b.map.y < world.map.scroll.minY + TOO_NEAR_EDGE || b.map.y + b.size.y > world.map.scroll.maxY - TOO_NEAR_EDGE)
 	{
 		return false;
 	}
@@ -4288,7 +4291,7 @@ bool validLocation(BASE_STATS *psStats, Vector2i pos, uint16_t direction, unsign
 	if (bCheckBuildQueue)
 	{
 		// cant place on top of a delivery point...
-		for (const auto& psFlag : gameWorld.objects.flags[selectedPlayer])
+		for (const auto& psFlag : world.objects.flags[selectedPlayer])
 		{
 			ASSERT_OR_RETURN(false, psFlag->coords.x != ~0, "flag has invalid position");
 			Vector2i flagTile = map_coord(psFlag->coords.xy());
@@ -4308,7 +4311,7 @@ bool validLocation(BASE_STATS *psStats, Vector2i pos, uint16_t direction, unsign
 			{
 				// Don't allow building structures (allow delivery points, though) outside visible area in single-player with debug mode off. (Why..?)
 				const DebugInputManager& dbgInputManager = gInputManager.debugManager();
-				if (!bMultiPlayer && !dbgInputManager.debugMappingsAllowed() && !TEST_TILE_VISIBLE(player, mapTile(gameWorld.map, b.map.x + i, b.map.y + j)))
+				if (!bMultiPlayer && !dbgInputManager.debugMappingsAllowed() && !TEST_TILE_VISIBLE(player, mapTile(world.map, b.map.x + i, b.map.y + j)))
 				{
 					return false;
 				}
@@ -4346,7 +4349,7 @@ bool validLocation(BASE_STATS *psStats, Vector2i pos, uint16_t direction, unsign
 				for (int j = 0; j < b.size.y; ++j)
 					for (int i = 0; i < b.size.x; ++i)
 					{
-						MAPTILE const *psTile = mapTile(gameWorld.map, b.map.x + i, b.map.y + j);
+						MAPTILE const *psTile = mapTile(world.map, b.map.x + i, b.map.y + j);
 						if ((terrainType(psTile) == TER_WATER) ||
 						    (terrainType(psTile) == TER_CLIFFFACE))
 						{
@@ -4357,7 +4360,7 @@ bool validLocation(BASE_STATS *psStats, Vector2i pos, uint16_t direction, unsign
 				for (int j = 0; j < b.size.y; ++j)
 					for (int i = 0; i < b.size.x; ++i)
 					{
-						if (withinLandingZone(b.map.x + i, b.map.y + j))
+						if (withinLandingZone(world.map, b.map.x + i, b.map.y + j))
 						{
 							return false;
 						}
@@ -4374,7 +4377,7 @@ bool validLocation(BASE_STATS *psStats, Vector2i pos, uint16_t direction, unsign
 						for (int i = 0; i < b.size.x; ++i)
 						{
 							int max, min;
-							getTileMaxMin(b.map.x + i, b.map.y + j, &max, &min);
+							getTileMaxMin(world.map, b.map.x + i, b.map.y + j, &max, &min);
 							if (max - min > MAX_INCLINE)
 							{
 								return false;
@@ -4397,7 +4400,7 @@ bool validLocation(BASE_STATS *psStats, Vector2i pos, uint16_t direction, unsign
 						//skip the actual area the structure will cover
 						if (i < 0 || i >= b.size.x || j < 0 || j >= b.size.y)
 						{
-							BASE_OBJECT *object = mapTile(gameWorld.map, b.map.x + i, b.map.y + j)->psObject;
+							BASE_OBJECT *object = mapTile(world.map, b.map.x + i, b.map.y + j)->psObject;
 							STRUCTURE *structure = castStructure(object);
 							if (structure != nullptr && !structure->visible[player] && !aiCheckAlliances(player, structure->player))
 							{
@@ -4422,7 +4425,7 @@ bool validLocation(BASE_STATS *psStats, Vector2i pos, uint16_t direction, unsign
 							//skip the actual area the structure will cover
 							if (i < 0 || i >= b.size.x || j < 0 || j >= b.size.y)
 							{
-								STRUCTURE const *psStruct = getTileStructure(b.map.x + i, b.map.y + j);
+								STRUCTURE const *psStruct = getTileStructure(world.map, b.map.x + i, b.map.y + j);
 								if (psStruct != nullptr && psStruct->player == player && psStruct->status == SS_BUILT)
 								{
 									connection = true;
@@ -4441,12 +4444,12 @@ bool validLocation(BASE_STATS *psStats, Vector2i pos, uint16_t direction, unsign
 				for (int j = 0; j < b.size.y; ++j)
 					for (int i = 0; i < b.size.x; ++i)
 					{
-						MAPTILE const *psTile = mapTile(gameWorld.map, b.map.x + i, b.map.y + j);
+						MAPTILE const *psTile = mapTile(world.map, b.map.x + i, b.map.y + j);
 						if (TileIsKnownOccupied(psTile, player))
 						{
 							if (TileHasWall(psTile) && (psBuilding->type == REF_DEFENSE || psBuilding->type == REF_GATE || psBuilding->type == REF_WALL))
 							{
-								STRUCTURE const *psStruct = getTileStructure(b.map.x + i, b.map.y + j);
+								STRUCTURE const *psStruct = getTileStructure(world.map, b.map.x + i, b.map.y + j);
 								if (psStruct != nullptr && psStruct->player != player)
 								{
 									return false;
@@ -4461,9 +4464,9 @@ bool validLocation(BASE_STATS *psStats, Vector2i pos, uint16_t direction, unsign
 				break;
 			}
 		case REF_FACTORY_MODULE:
-			if (TileHasStructure(worldTile(gameWorld.map, pos)))
+			if (TileHasStructure(worldTile(world.map, pos)))
 			{
-				STRUCTURE const *psStruct = getTileStructure(map_coord(pos.x), map_coord(pos.y));
+				STRUCTURE const *psStruct = getTileStructure(world.map, map_coord(pos.x), map_coord(pos.y));
 				if (psStruct && (psStruct->pStructureType->type == REF_FACTORY ||
 				                 psStruct->pStructureType->type == REF_VTOL_FACTORY)
 					&& psStruct->status == SS_BUILT && aiCheckAlliances(player, psStruct->player)
@@ -4474,9 +4477,9 @@ bool validLocation(BASE_STATS *psStats, Vector2i pos, uint16_t direction, unsign
 			}
 			return false;
 		case REF_RESEARCH_MODULE:
-			if (TileHasStructure(worldTile(gameWorld.map, pos)))
+			if (TileHasStructure(worldTile(world.map, pos)))
 			{
-				STRUCTURE const *psStruct = getTileStructure(map_coord(pos.x), map_coord(pos.y));
+				STRUCTURE const *psStruct = getTileStructure(world.map, map_coord(pos.x), map_coord(pos.y));
 				if (psStruct && psStruct->pStructureType->type == REF_RESEARCH
 					&& psStruct->status == SS_BUILT
 					&& aiCheckAlliances(player, psStruct->player)
@@ -4487,9 +4490,9 @@ bool validLocation(BASE_STATS *psStats, Vector2i pos, uint16_t direction, unsign
 			}
 			return false;
 		case REF_POWER_MODULE:
-			if (TileHasStructure(worldTile(gameWorld.map, pos)))
+			if (TileHasStructure(worldTile(world.map, pos)))
 			{
-				STRUCTURE const *psStruct = getTileStructure(map_coord(pos.x), map_coord(pos.y));
+				STRUCTURE const *psStruct = getTileStructure(world.map, map_coord(pos.x), map_coord(pos.y));
 				if (psStruct && psStruct->pStructureType->type == REF_POWER_GEN
 					&& psStruct->status == SS_BUILT
 					&& aiCheckAlliances(player, psStruct->player)
@@ -4500,9 +4503,9 @@ bool validLocation(BASE_STATS *psStats, Vector2i pos, uint16_t direction, unsign
 			}
 			return false;
 		case REF_RESOURCE_EXTRACTOR:
-			if (TileHasFeature(worldTile(gameWorld.map, pos)))
+			if (TileHasFeature(worldTile(world.map, pos)))
 			{
-				FEATURE const *psFeat = getTileFeature(map_coord(pos.x), map_coord(pos.y));
+				FEATURE const *psFeat = getTileFeature(world.map, map_coord(pos.x), map_coord(pos.y));
 				if (psFeat && psFeat->psStats->subType == FEAT_OIL_RESOURCE)
 				{
 					break;
@@ -4521,7 +4524,7 @@ bool validLocation(BASE_STATS *psStats, Vector2i pos, uint16_t direction, unsign
 	{
 		PROPULSION_STATS *psPropStats = psTemplate->getPropulsionStats();
 
-		if (fpathBlockingTile(b.map.x, b.map.y, psPropStats->propulsionType))
+		if (fpathBlockingTile(world.map, b.map.x, b.map.y, psPropStats->propulsionType))
 		{
 			return false;
 		}
@@ -4529,7 +4532,7 @@ bool validLocation(BASE_STATS *psStats, Vector2i pos, uint16_t direction, unsign
 	else
 	{
 		// not positioning a structure or droid, ie positioning a feature
-		if (fpathBlockingTile(b.map.x, b.map.y, PROPULSION_TYPE_WHEELED))
+		if (fpathBlockingTile(world.map, b.map.x, b.map.y, PROPULSION_TYPE_WHEELED))
 		{
 			return false;
 		}
@@ -4584,7 +4587,7 @@ bool removeStruct(STRUCTURE *psDel, bool bDestroy)
 		HOW MUCH IS THERE && NOT RES EXTRACTORS */
 		if (psDel->pStructureType->type == REF_RESOURCE_EXTRACTOR)
 		{
-			FEATURE *psOil = buildFeature(oilResFeature, psDel->pos.x, psDel->pos.y, false);
+			FEATURE *psOil = buildFeature(gameWorld.map, oilResFeature, psDel->pos.x, psDel->pos.y, false);
 			memcpy(psOil->seenThisTick, psDel->visible, sizeof(psOil->seenThisTick));
 			resourceFound = true;
 		}
@@ -4904,11 +4907,11 @@ bool  STRUCTURE::isIdle() const
 
 /*checks to see if a specific structure type exists -as opposed to a structure
 stat type*/
-bool checkSpecificStructExists(UDWORD structInc, UDWORD player)
+bool checkSpecificStructExists(const WorldObjectState& objState, UDWORD structInc, UDWORD player)
 {
 	ASSERT_OR_RETURN(false, structInc < numStructureStats, "Invalid structure inc");
 
-	for (const STRUCTURE *psStructure : gameWorld.objects.structures[player])
+	for (const STRUCTURE *psStructure : objState.structures[player])
 	{
 		if (psStructure->status == SS_BUILT)
 		{
@@ -4923,7 +4926,7 @@ bool checkSpecificStructExists(UDWORD structInc, UDWORD player)
 
 
 /*finds a suitable position for the assembly point based on one passed in*/
-void findAssemblyPointPosition(UDWORD *pX, UDWORD *pY, UDWORD player)
+void findAssemblyPointPosition(GameWorld& world, UDWORD *pX, UDWORD *pY, UDWORD player)
 {
 	//set up a dummy stat pointer
 	STRUCTURE_STATS     sStats;
@@ -4939,7 +4942,7 @@ void findAssemblyPointPosition(UDWORD *pX, UDWORD *pY, UDWORD player)
 	passes = 0;
 
 	//if the value passed in is not a valid location - find one!
-	if (!validLocation(&sStats, world_coord(Vector2i(*pX, *pY)), 0, player, false))
+	if (!validLocation(world, &sStats, world_coord(Vector2i(*pX, *pY)), 0, player, false))
 	{
 		/* Keep going until we get a tile or we exceed distance */
 		while (passes < LOOK_FOR_EMPTY_TILE)
@@ -4953,7 +4956,7 @@ void findAssemblyPointPosition(UDWORD *pX, UDWORD *pY, UDWORD player)
 					if (i == startX || i == endX || j == startY || j == endY)
 					{
 						/* Good enough? */
-						if (validLocation(&sStats, world_coord(Vector2i(i, j)), 0, player, false))
+						if (validLocation(world, &sStats, world_coord(Vector2i(i, j)), 0, player, false))
 						{
 							/* Set exit conditions and get out NOW */
 							*pX = i;
@@ -4980,7 +4983,7 @@ void findAssemblyPointPosition(UDWORD *pX, UDWORD *pY, UDWORD player)
 
 /*sets the point new droids go to - x/y in world coords for a Factory
 bCheck is set to true for initial placement of the Assembly Point*/
-void setAssemblyPoint(FLAG_POSITION *psAssemblyPoint, UDWORD x, UDWORD y,
+void setAssemblyPoint(GameWorld& world, FLAG_POSITION *psAssemblyPoint, UDWORD x, UDWORD y,
                       UDWORD player, bool bCheck)
 {
 	ASSERT_OR_RETURN(, psAssemblyPoint != nullptr, "invalid AssemblyPoint pointer");
@@ -4990,7 +4993,7 @@ void setAssemblyPoint(FLAG_POSITION *psAssemblyPoint, UDWORD x, UDWORD y,
 	y = map_coord(y);
 	if (bCheck)
 	{
-		findAssemblyPointPosition(&x, &y, player);
+		findAssemblyPointPosition(world, &x, &y, player);
 	}
 	//add half a tile so the centre is in the middle of the tile
 	x = world_coord(x) + TILE_UNITS / 2;
@@ -5000,7 +5003,7 @@ void setAssemblyPoint(FLAG_POSITION *psAssemblyPoint, UDWORD x, UDWORD y,
 	psAssemblyPoint->coords.y = y;
 
 	// Deliv Point sits at the height of the tile it's centre is on + arbitrary amount!
-	psAssemblyPoint->coords.z = map_Height(gameWorld.map, x, y) + ASSEMBLY_POINT_Z_PADDING;
+	psAssemblyPoint->coords.z = map_Height(world.map, x, y) + ASSEMBLY_POINT_Z_PADDING;
 }
 
 
@@ -5233,13 +5236,13 @@ void checkForResExtractors(STRUCTURE *psBuilding)
 	}
 }
 
-uint16_t countPlayerUnusedDerricks()
+uint16_t countPlayerUnusedDerricks(const WorldObjectState& objState)
 {
 	uint16_t total = 0;
 
 	if (selectedPlayer >= MAX_PLAYERS) { return 0; }
 
-	for (const STRUCTURE *psStruct : gameWorld.objects.extractors[selectedPlayer])
+	for (const STRUCTURE *psStruct : objState.extractors[selectedPlayer])
 	{
 		if (psStruct->status == SS_BUILT && psStruct->pStructureType->type == REF_RESOURCE_EXTRACTOR)
 		{
@@ -5409,7 +5412,7 @@ void buildingComplete(STRUCTURE *psBuilding)
 	psBuilding->currentBuildPts = structureBuildPointsToCompletion(*psBuilding);
 	psBuilding->status = SS_BUILT;
 
-	visTilesUpdate(psBuilding);
+	visTilesUpdate(psBuilding, gameWorld.map);
 
 	if (psBuilding->prebuiltImd != nullptr)
 	{
@@ -5440,7 +5443,7 @@ void buildingComplete(STRUCTURE *psBuilding)
 		releaseProduction(psBuilding, ModeImmediate);
 		break;
 	case REF_SAT_UPLINK:
-		revealAll(psBuilding->player);
+		revealAll(gameWorld.map, psBuilding->player);
 		break;
 	case REF_GATE:
 		auxStructureNonblocking(psBuilding);  // Clear outdated flags.
@@ -5926,7 +5929,7 @@ bool electronicReward(STRUCTURE *psStructure, UBYTE attackPlayer)
 		bRewarded = true;
 		break;
 	case REF_HQ:
-		hqReward(psStructure->player, attackPlayer);
+		hqReward(gameWorld, psStructure->player, attackPlayer);
 		if (attackPlayer == selectedPlayer)
 		{
 			addConsoleMessage(_("Electronic Reward - Visibility Report"),	DEFAULT_JUSTIFY, SYSTEM_MESSAGE);
@@ -6065,16 +6068,16 @@ void repairFacilityReward(UBYTE losingPlayer, UBYTE rewardPlayer)
 
 
 /*makes the losing players tiles/structures/features visible to the reward player*/
-void hqReward(UBYTE losingPlayer, UBYTE rewardPlayer)
+void hqReward(GameWorld& world, UBYTE losingPlayer, UBYTE rewardPlayer)
 {
 	ASSERT_OR_RETURN(, losingPlayer < MAX_PLAYERS && rewardPlayer < MAX_PLAYERS, "losingPlayer (%" PRIu8 "), rewardPlayer (%" PRIu8 ") must both be < MAXPLAYERS", losingPlayer, rewardPlayer);
 
 	// share exploration info - pretty useless but perhaps a nice touch?
-	for (int y = 0; y < gameWorld.map.height; ++y)
+	for (int y = 0; y < world.map.height; ++y)
 	{
-		for (int x = 0; x < gameWorld.map.width; ++x)
+		for (int x = 0; x < world.map.width; ++x)
 		{
-			MAPTILE *psTile = mapTile(gameWorld.map, x, y);
+			MAPTILE *psTile = mapTile(world.map, x, y);
 			if (TEST_TILE_VISIBLE(losingPlayer, psTile))
 			{
 				psTile->tileExploredBits |= alliancebits[rewardPlayer];
@@ -6085,7 +6088,7 @@ void hqReward(UBYTE losingPlayer, UBYTE rewardPlayer)
 	//struct
 	for (int i = 0; i < MAX_PLAYERS; ++i)
 	{
-		for (STRUCTURE *psStruct : gameWorld.objects.structures[i])
+		for (STRUCTURE *psStruct : world.objects.structures[i])
 		{
 			if (psStruct->visible[losingPlayer] && !psStruct->died)
 			{
@@ -6094,7 +6097,7 @@ void hqReward(UBYTE losingPlayer, UBYTE rewardPlayer)
 		}
 
 		//droids.
-		for (DROID *psDroid : gameWorld.objects.droids[i])
+		for (DROID *psDroid : world.objects.droids[i])
 		{
 			if (psDroid->visible[losingPlayer] || psDroid->player == losingPlayer)
 			{
@@ -6104,7 +6107,7 @@ void hqReward(UBYTE losingPlayer, UBYTE rewardPlayer)
 	}
 
 	//feature
-	for (FEATURE *psFeat : gameWorld.objects.features[0])
+	for (FEATURE *psFeat : world.objects.features[0])
 	{
 		if (psFeat->visible[losingPlayer])
 		{
@@ -6507,7 +6510,7 @@ bool checkFactoryExists(UDWORD player, UDWORD factoryType, UDWORD inc)
 
 
 //check that delivery points haven't been put down in invalid location
-void checkDeliveryPoints(UDWORD version)
+void checkDeliveryPoints(GameWorld& world, UDWORD version)
 {
 	UBYTE			inc;
 	FACTORY			*psFactory;
@@ -6522,7 +6525,7 @@ void checkDeliveryPoints(UDWORD version)
 		//will have been called to put in down in the first place
 		if (inc != selectedPlayer)
 		{
-			for (STRUCTURE* psStruct : gameWorld.objects.structures[inc])
+			for (STRUCTURE* psStruct : world.objects.structures[inc])
 			{
 				if (!psStruct)
 				{
@@ -6538,7 +6541,7 @@ void checkDeliveryPoints(UDWORD version)
 					}
 					else
 					{
-						setAssemblyPoint(psFactory->psAssemblyPoint, psFactory->psAssemblyPoint->
+						setAssemblyPoint(world, psFactory->psAssemblyPoint, psFactory->psAssemblyPoint->
 						                 coords.x, psFactory->psAssemblyPoint->coords.y, inc, true);
 					}
 				}
@@ -6566,13 +6569,13 @@ void checkDeliveryPoints(UDWORD version)
 							x = map_coord(psStruct->pos.x + 256);
 							y = map_coord(psStruct->pos.y + 256);
 							// Belt and braces - shouldn't be able to build too near edge
-							setAssemblyPoint(psRepair->psDeliveryPoint, world_coord(x),
+							setAssemblyPoint(world, psRepair->psDeliveryPoint, world_coord(x),
 							                 world_coord(y), inc, true);
 						}
 					}
 					else//check existing one
 					{
-						setAssemblyPoint(psRepair->psDeliveryPoint, psRepair->psDeliveryPoint->
+						setAssemblyPoint(world, psRepair->psDeliveryPoint, psRepair->psDeliveryPoint->
 						                 coords.x, psRepair->psDeliveryPoint->coords.y, inc, true);
 					}
 				}
@@ -6887,7 +6890,7 @@ STRUCTURE *giftSingleStructure(STRUCTURE *psStructure, UBYTE attackPlayer, bool 
 
 	ASSERT_OR_RETURN(nullptr, attackPlayer < MAX_PLAYERS, "attackPlayer (%" PRIu32 ") must be < MAX_PLAYERS", attackPlayer);
 	CHECK_STRUCTURE(psStructure);
-	visRemoveVisibility(psStructure);
+	visRemoveVisibility(psStructure, gameWorld.map);
 
 	int prevState = intGetResearchState();
 	bool reward = electronicReward(psStructure, attackPlayer);
@@ -6983,7 +6986,7 @@ STRUCTURE *giftSingleStructure(STRUCTURE *psStructure, UBYTE attackPlayer, bool 
 	bPowerOn = powerCalculated;
 	powerCalculated = false;
 	//build a new one for the attacking player - set last element to true so it doesn't adjust x/y
-	psNewStruct = buildStructure(psType, x, y, attackPlayer, true);
+	psNewStruct = buildStructure(gameWorld, psType, x, y, attackPlayer, true);
 	capacity = psStructure->capacity;
 	if (psNewStruct)
 	{
@@ -6995,14 +6998,14 @@ STRUCTURE *giftSingleStructure(STRUCTURE *psStructure, UBYTE attackPlayer, bool 
 			case REF_POWER_GEN:
 			case REF_RESEARCH:
 				//build the module for powerGen and research
-				buildStructure(psModule, psNewStruct->pos.x, psNewStruct->pos.y, attackPlayer, false);
+				buildStructure(gameWorld, psModule, psNewStruct->pos.x, psNewStruct->pos.y, attackPlayer, false);
 				break;
 			case REF_FACTORY:
 			case REF_VTOL_FACTORY:
 				//build the appropriate number of modules
 				while (capacity)
 				{
-					buildStructure(psModule, psNewStruct->pos.x, psNewStruct->pos.y, attackPlayer, false);
+					buildStructure(gameWorld, psModule, psNewStruct->pos.x, psNewStruct->pos.y, attackPlayer, false);
 					capacity--;
 				}
 				break;

--- a/src/structure.cpp
+++ b/src/structure.cpp
@@ -37,6 +37,7 @@
 #include "map.h"
 #include "lib/gamelib/gtime.h"
 #include "objmem.h"
+#include "world_object_state.h"
 #include "visibility.h"
 #include "structure.h"
 #include "research.h"
@@ -139,7 +140,7 @@ static void informPowerGen(STRUCTURE *psStruct);
 static bool electronicReward(STRUCTURE *psStructure, UBYTE attackPlayer);
 static void factoryReward(UBYTE losingPlayer, UBYTE rewardPlayer);
 static void repairFacilityReward(UBYTE losingPlayer, UBYTE rewardPlayer);
-static void findAssemblyPointPosition(UDWORD *pX, UDWORD *pY, UDWORD player);
+static void findAssemblyPointPosition(GameWorld& world, UDWORD *pX, UDWORD *pY, UDWORD player);
 static void removeStructFromMap(STRUCTURE *psStruct);
 static void resetResistanceLag(STRUCTURE *psBuilding);
 static int structureTotalReturn(const STRUCTURE *psStruct);
@@ -254,10 +255,10 @@ bool isBlueprint(const BASE_OBJECT *psObject)
 
 // Add smoke effect to cover the droid's emergence from the factory or when building structures.
 // DISPLAY ONLY - does not affect game state.
-static void displayConstructionCloud(const Vector3i &pos)
+static void displayConstructionCloud(WorldMapState& mapState, const Vector3i &pos)
 {
 	const Vector2i coordinates = {pos.x, pos.y};
-	const MAPTILE *psTile = mapTile(gameWorld.map, map_coord(coordinates));
+	const MAPTILE *psTile = mapTile(mapState, map_coord(coordinates));
 	if (!tileIsClearlyVisible(psTile))
 	{
 		return;
@@ -266,7 +267,7 @@ static void displayConstructionCloud(const Vector3i &pos)
 	Vector3i iVecEffect;
 
 	iVecEffect.x = pos.x;
-	iVecEffect.y = map_Height(gameWorld.map, pos.x, pos.y) + DROID_CONSTRUCTION_SMOKE_HEIGHT;
+	iVecEffect.y = map_Height(mapState, pos.x, pos.y) + DROID_CONSTRUCTION_SMOKE_HEIGHT;
 	iVecEffect.z = pos.y;
 	addEffect(&iVecEffect, EFFECT_CONSTRUCTION, CONSTRUCTION_TYPE_DRIFTING, false, nullptr, 0, gameTime - deltaGameTime + 1);
 	iVecEffect.x = pos.x - DROID_CONSTRUCTION_SMOKE_OFFSET;
@@ -353,7 +354,7 @@ void initFactoryNumFlag()
 }
 
 //called at start of missions
-void resetFactoryNumFlag()
+void resetFactoryNumFlag(const WorldObjectState& objState)
 {
 	for (unsigned int i = 0; i < MAX_PLAYERS; i++)
 	{
@@ -363,7 +364,7 @@ void resetFactoryNumFlag()
 			factoryNumFlag[i][type].clear();
 		}
 		//look through the list of structures to see which have been used
-		for (const STRUCTURE *psStruct : gameWorld.objects.structures[i])
+		for (const STRUCTURE *psStruct : objState.structures[i])
 		{
 			FLAG_TYPE type;
 			switch (psStruct->pStructureType->type)
@@ -745,7 +746,7 @@ bool loadStructureStats(WzConfig &ini)
 }
 
 /* set the current number of structures of each type built */
-void setCurrentStructQuantity(bool displayError)
+void setCurrentStructQuantity(const WorldObjectState& objState, bool displayError)
 {
 	for (unsigned player = 0; player < MAX_PLAYERS; player++)
 	{
@@ -753,7 +754,7 @@ void setCurrentStructQuantity(bool displayError)
 		{
 			asStructureStats[inc].curCount[player] = 0;
 		}
-		for (const STRUCTURE *psCurr : gameWorld.objects.structures[player])
+		for (const STRUCTURE *psCurr : objState.structures[player])
 		{
 			unsigned inc = psCurr->pStructureType - asStructureStats;
 			asStructureStats[inc].curCount[player]++;
@@ -1267,12 +1268,12 @@ bool isBuildableOnWalls(STRUCTURE_TYPE type)
 	return type == REF_DEFENSE || type == REF_GATE;
 }
 
-static void structFindWalls(unsigned player, Vector2i map, bool aWallPresent[5][5], STRUCTURE *apsStructs[5][5])
+static void structFindWalls(WorldMapState& mapState, unsigned player, Vector2i map, bool aWallPresent[5][5], STRUCTURE *apsStructs[5][5])
 {
 	for (int y = -2; y <= 2; ++y)
 		for (int x = -2; x <= 2; ++x)
 		{
-			STRUCTURE *psStruct = castStructure(mapTile(gameWorld.map, map.x + x, map.y + y)->psObject);
+			STRUCTURE *psStruct = castStructure(mapTile(mapState, map.x + x, map.y + y)->psObject);
 			if (psStruct != nullptr && isWallCombiningStructureType(psStruct->pStructureType) && player < MAX_PLAYERS && aiCheckAlliances(player, psStruct->player))
 			{
 				aWallPresent[x + 2][y + 2] = true;
@@ -1296,23 +1297,23 @@ static void structFindWallBlueprints(Vector2i map, bool aWallPresent[5][5])
 		}
 }
 
-static bool wallBlockingTerrainJoin(Vector2i map)
+static bool wallBlockingTerrainJoin(WorldMapState& mapState, Vector2i map)
 {
-	MAPTILE *psTile = mapTile(gameWorld.map, map);
+	MAPTILE *psTile = mapTile(mapState, map);
 	return terrainType(psTile) == TER_WATER || terrainType(psTile) == TER_CLIFFFACE || psTile->psObject != nullptr;
 }
 
-static WallOrientation structWallScanTerrain(bool aWallPresent[5][5], Vector2i map)
+static WallOrientation structWallScanTerrain(WorldMapState& mapState, bool aWallPresent[5][5], Vector2i map)
 {
 	WallOrientation orientation = structWallScan(aWallPresent, 2, 2);
 
 	if (orientation == WallConnectNone)
 	{
 		// If neutral, try choosing horizontal or vertical based on terrain, but don't change to corner type.
-		aWallPresent[2][1] = wallBlockingTerrainJoin(map + Vector2i(0, -1));
-		aWallPresent[2][3] = wallBlockingTerrainJoin(map + Vector2i(0,  1));
-		aWallPresent[1][2] = wallBlockingTerrainJoin(map + Vector2i(-1,  0));
-		aWallPresent[3][2] = wallBlockingTerrainJoin(map + Vector2i(1,  0));
+		aWallPresent[2][1] = wallBlockingTerrainJoin(mapState, map + Vector2i(0, -1));
+		aWallPresent[2][3] = wallBlockingTerrainJoin(mapState, map + Vector2i(0,  1));
+		aWallPresent[1][2] = wallBlockingTerrainJoin(mapState, map + Vector2i(-1,  0));
+		aWallPresent[3][2] = wallBlockingTerrainJoin(mapState, map + Vector2i(1,  0));
 		orientation = structWallScan(aWallPresent, 2, 2);
 		if ((orientation & (WallConnectLeft | WallConnectRight)) != 0 && (orientation & (WallConnectUp | WallConnectDown)) != 0)
 		{
@@ -1323,22 +1324,22 @@ static WallOrientation structWallScanTerrain(bool aWallPresent[5][5], Vector2i m
 	return orientation;
 }
 
-static WallOrientation structChooseWallTypeBlueprint(Vector2i map)
+static WallOrientation structChooseWallTypeBlueprint(WorldMapState& mapState, Vector2i map)
 {
 	bool            aWallPresent[5][5];
 	STRUCTURE      *apsStructs[5][5];
 
 	// scan around the location looking for walls
 	memset(aWallPresent, 0, sizeof(aWallPresent));
-	structFindWalls(selectedPlayer, map, aWallPresent, apsStructs);
+	structFindWalls(mapState, selectedPlayer, map, aWallPresent, apsStructs);
 	structFindWallBlueprints(map, aWallPresent);
 
 	// finally return the type for this wall
-	return structWallScanTerrain(aWallPresent, map);
+	return structWallScanTerrain(mapState, aWallPresent, map);
 }
 
 // Choose a type of wall for a location - and update any neighbouring walls
-static WallOrientation structChooseWallType(unsigned player, Vector2i map)
+static WallOrientation structChooseWallType(WorldMapState& mapState, unsigned player, Vector2i map)
 {
 	bool		aWallPresent[5][5];
 	STRUCTURE	*psStruct;
@@ -1346,7 +1347,7 @@ static WallOrientation structChooseWallType(unsigned player, Vector2i map)
 
 	// scan around the location looking for walls
 	memset(aWallPresent, 0, sizeof(aWallPresent));
-	structFindWalls(player, map, aWallPresent, apsStructs);
+	structFindWalls(mapState, player, map, aWallPresent, apsStructs);
 
 	// now make sure that all the walls around this one are OK
 	for (int x = 1; x <= 3; ++x)
@@ -1381,7 +1382,7 @@ static WallOrientation structChooseWallType(unsigned player, Vector2i map)
 	}
 
 	// finally return the type for this wall
-	return structWallScanTerrain(aWallPresent, map);
+	return structWallScanTerrain(mapState, aWallPresent, map);
 }
 
 
@@ -1427,7 +1428,7 @@ static void buildFlatten(STRUCTURE *pStructure, int h)
 			// We need to raise features on raised tiles to the new height
 			if (TileHasFeature(mapTile(gameWorld.map, b.map.x + width, b.map.y + breadth)))
 			{
-				getTileFeature(b.map.x + width, b.map.y + breadth)->pos.z = h;
+				getTileFeature(gameWorld.map, b.map.x + width, b.map.y + breadth)->pos.z = h;
 			}
 		}
 	}
@@ -1492,17 +1493,17 @@ void alignStructure(STRUCTURE *psBuilding)
 }
 
 /*Builds an instance of a Structure - the x/y passed in are in world coords. */
-STRUCTURE *buildStructure(STRUCTURE_STATS *pStructureType, UDWORD x, UDWORD y, UDWORD player, bool FromSave)
+STRUCTURE *buildStructure(GameWorld& world, STRUCTURE_STATS *pStructureType, UDWORD x, UDWORD y, UDWORD player, bool FromSave)
 {
-	return buildStructureDir(pStructureType, x, y, 0, player, FromSave, generateSynchronisedObjectId());
+	return buildStructureDir(world, pStructureType, x, y, 0, player, FromSave, generateSynchronisedObjectId());
 }
 
-STRUCTURE *buildStructureDir(STRUCTURE_STATS *pStructureType, UDWORD x, UDWORD y, uint16_t direction, UDWORD player, bool FromSave)
+STRUCTURE *buildStructureDir(GameWorld& world, STRUCTURE_STATS *pStructureType, UDWORD x, UDWORD y, uint16_t direction, UDWORD player, bool FromSave)
 {
-	return buildStructureDir(pStructureType, x, y, direction, player, FromSave, generateSynchronisedObjectId());
+	return buildStructureDir(world, pStructureType, x, y, direction, player, FromSave, generateSynchronisedObjectId());
 }
 
-STRUCTURE *buildStructureDir(STRUCTURE_STATS *pStructureType, UDWORD x, UDWORD y, uint16_t direction, UDWORD player, bool FromSave, uint32_t id)
+STRUCTURE *buildStructureDir(GameWorld& world, STRUCTURE_STATS *pStructureType, UDWORD x, UDWORD y, uint16_t direction, UDWORD player, bool FromSave, uint32_t id)
 {
 	STRUCTURE *psBuilding = nullptr;
 	const Vector2i size = pStructureType->size(direction);
@@ -1532,13 +1533,13 @@ STRUCTURE *buildStructureDir(STRUCTURE_STATS *pStructureType, UDWORD x, UDWORD y
 		y = (y & ~TILE_MASK) + size.y % 2 * TILE_UNITS / 2;
 
 		//check not trying to build too near the edge
-		if (map_coord(x) < TOO_NEAR_EDGE || map_coord(x) > (gameWorld.map.width - TOO_NEAR_EDGE))
+		if (map_coord(x) < TOO_NEAR_EDGE || map_coord(x) > (world.map.width - TOO_NEAR_EDGE))
 		{
 			debug(LOG_WARNING, "attempting to build too closely to map-edge, "
 			      "x coord (%u) too near edge (req. distance is %u)", x, TOO_NEAR_EDGE);
 			return nullptr;
 		}
-		if (map_coord(y) < TOO_NEAR_EDGE || map_coord(y) > (gameWorld.map.height - TOO_NEAR_EDGE))
+		if (map_coord(y) < TOO_NEAR_EDGE || map_coord(y) > (world.map.height - TOO_NEAR_EDGE))
 		{
 			debug(LOG_WARNING, "attempting to build too closely to map-edge, "
 			      "y coord (%u) too near edge (req. distance is %u)", y, TOO_NEAR_EDGE);
@@ -1552,7 +1553,7 @@ STRUCTURE *buildStructureDir(STRUCTURE_STATS *pStructureType, UDWORD x, UDWORD y
 				for (int dx = 0; dx < size.x; ++dx)
 				{
 					Vector2i pos = map_coord(Vector2i(x, y) - size * TILE_UNITS / 2) + Vector2i(dx, dy);
-					wallOrientation = structChooseWallType(player, pos);  // This makes neighbouring walls match us, even if we're a hardpoint, not a wall.
+					wallOrientation = structChooseWallType(world.map, player, pos);  // This makes neighbouring walls match us, even if we're a hardpoint, not a wall.
 				}
 		}
 
@@ -1583,11 +1584,11 @@ STRUCTURE *buildStructureDir(STRUCTURE_STATS *pStructureType, UDWORD x, UDWORD y
 		 * to remove when placing oil derricks! */
 		if (pStructureType->type == REF_RESOURCE_EXTRACTOR)
 		{
-			FEATURE *psFeature = getTileFeature(map_coord(x), map_coord(y));
+			FEATURE *psFeature = getTileFeature(world.map, map_coord(x), map_coord(y));
 
 			if (psFeature && psFeature->psStats->subType == FEAT_OIL_RESOURCE)
 			{
-				if (fireOnLocation(gameWorld.map, psFeature->pos.x, psFeature->pos.y))
+				if (fireOnLocation(world.map, psFeature->pos.x, psFeature->pos.y))
 				{
 					// Can't build on burning oil resource
 					return nullptr;
@@ -1603,7 +1604,7 @@ STRUCTURE *buildStructureDir(STRUCTURE_STATS *pStructureType, UDWORD x, UDWORD y
 		{
 			for (int tileX = map.x; tileX < map.x + size.x; ++tileX)
 			{
-				MAPTILE *psTile = mapTile(gameWorld.map, tileX, tileY);
+				MAPTILE *psTile = mapTile(world.map, tileX, tileY);
 
 				/* Remove any walls underneath the building. You can build defense buildings on top
 				 * of walls, you see. This is not the place to test whether we own it! */
@@ -1619,7 +1620,7 @@ STRUCTURE *buildStructureDir(STRUCTURE_STATS *pStructureType, UDWORD x, UDWORD y
 #endif
 					debug(LOG_ERROR, "Player %u (%s): is building %s at (%d, %d) but found %s already at (%d, %d)",
 					      player, isHumanPlayer(player) ? "Human" : "AI", getStatsName(pStructureType), map.x, map.y,
-					      getStatsName(getTileStructure(tileX, tileY)->pStructureType), tileX, tileY);
+					      getStatsName(getTileStructure(world.map, tileX, tileY)->pStructureType), tileX, tileY);
 #if defined(WZ_CC_GNU) && !defined(WZ_CC_INTEL) && !defined(WZ_CC_CLANG) && (7 <= __GNUC__)
 # pragma GCC diagnostic pop
 #endif
@@ -1635,13 +1636,13 @@ STRUCTURE *buildStructureDir(STRUCTURE_STATS *pStructureType, UDWORD x, UDWORD y
 			for (int tileX = map.x; tileX < map.x + size.x; ++tileX)
 			{
 				// We now know the previous loop didn't return early, so it is safe to save references to `stableBuilding` now.
-				MAPTILE *psTile = mapTile(gameWorld.map, tileX, tileY);
+				MAPTILE *psTile = mapTile(world.map, tileX, tileY);
 				psTile->psObject = psBuilding;
 
 				// if it's a tall structure then flag it in the map.
 				if (psBuilding->sDisplay.imd && psBuilding->sDisplay.imd->max.y > TALLOBJECT_YMAX)
 				{
-					auxSetBlocking(gameWorld.map, tileX, tileY, AIR_BLOCKED);
+					auxSetBlocking(world.map, tileX, tileY, AIR_BLOCKED);
 				}
 			}
 		}
@@ -1726,7 +1727,7 @@ STRUCTURE *buildStructureDir(STRUCTURE_STATS *pStructureType, UDWORD x, UDWORD y
 		}
 
 		// Reveal any tiles that can be seen by the structure
-		visTilesUpdate(psBuilding);
+		visTilesUpdate(psBuilding, world.map);
 
 		/*if we're coming from a SAVEGAME and we're on an Expand_Limbo mission,
 		any factories that were built previously for the selectedPlayer will
@@ -1736,15 +1737,15 @@ STRUCTURE *buildStructureDir(STRUCTURE_STATS *pStructureType, UDWORD x, UDWORD y
 		if (FromSave && player == selectedPlayer && missionLimboExpand())
 		{
 			//save the current values
-			preScrollMinX = gameWorld.map.scroll.minX;
-			preScrollMinY = gameWorld.map.scroll.minY;
-			preScrollMaxX = gameWorld.map.scroll.maxX;
-			preScrollMaxY = gameWorld.map.scroll.maxY;
+			preScrollMinX = world.map.scroll.minX;
+			preScrollMinY = world.map.scroll.minY;
+			preScrollMaxX = world.map.scroll.maxX;
+			preScrollMaxY = world.map.scroll.maxY;
 			//set the current values to mapWidth/mapHeight
-			gameWorld.map.scroll.minX = 0;
-			gameWorld.map.scroll.minY = 0;
-			gameWorld.map.scroll.maxX = gameWorld.map.width;
-			gameWorld.map.scroll.maxY = gameWorld.map.height;
+			world.map.scroll.minX = 0;
+			world.map.scroll.minY = 0;
+			world.map.scroll.maxX = world.map.width;
+			world.map.scroll.maxY = world.map.height;
 			// NOTE: resizeRadar() may be required here, since we change scroll limits?
 		}
 		//set the functionality dependent on the type of structure
@@ -1756,10 +1757,10 @@ STRUCTURE *buildStructureDir(STRUCTURE_STATS *pStructureType, UDWORD x, UDWORD y
 			if (FromSave && player == selectedPlayer && missionLimboExpand())
 			{
 				//reset the current values
-				gameWorld.map.scroll.minX = preScrollMinX;
-				gameWorld.map.scroll.minY = preScrollMinY;
-				gameWorld.map.scroll.maxX = preScrollMaxX;
-				gameWorld.map.scroll.maxY = preScrollMaxY;
+				world.map.scroll.minX = preScrollMinX;
+				world.map.scroll.minY = preScrollMinY;
+				world.map.scroll.maxX = preScrollMaxX;
+				world.map.scroll.maxY = preScrollMaxY;
 				// NOTE: resizeRadar() may be required here, since we change scroll limits?
 			}
 			return nullptr;
@@ -1769,10 +1770,10 @@ STRUCTURE *buildStructureDir(STRUCTURE_STATS *pStructureType, UDWORD x, UDWORD y
 		if (FromSave && player == selectedPlayer && missionLimboExpand())
 		{
 			//reset the current values
-			gameWorld.map.scroll.minX = preScrollMinX;
-			gameWorld.map.scroll.minY = preScrollMinY;
-			gameWorld.map.scroll.maxX = preScrollMaxX;
-			gameWorld.map.scroll.maxY = preScrollMaxY;
+			world.map.scroll.minX = preScrollMinX;
+			world.map.scroll.minY = preScrollMinY;
+			world.map.scroll.maxX = preScrollMaxX;
+			world.map.scroll.maxY = preScrollMaxY;
 			// NOTE: resizeRadar() may be required here, since we change scroll limits?
 		}
 
@@ -1804,7 +1805,7 @@ STRUCTURE *buildStructureDir(STRUCTURE_STATS *pStructureType, UDWORD x, UDWORD y
 		StructureBounds bounds = getStructureBounds(psBuilding);
 		for (unsigned playerNum = 0; playerNum < MAX_PLAYERS; ++playerNum)
 		{
-			for (const STRUCTURE *psStruct : gameWorld.objects.structures[playerNum])
+			for (const STRUCTURE *psStruct : world.objects.structures[playerNum])
 			{
 				if (!psStruct)
 				{
@@ -1825,7 +1826,7 @@ STRUCTURE *buildStructureDir(STRUCTURE_STATS *pStructureType, UDWORD x, UDWORD y
 					if (unsigned(pos.x - bounds.map.x) < unsigned(bounds.size.x) && unsigned(pos.y - bounds.map.y) < unsigned(bounds.size.y))
 					{
 						// Delivery point fp is under the new structure. Need to move it.
-						setAssemblyPoint(fp, fp->coords.x, fp->coords.y, playerNum, true);
+						setAssemblyPoint(world, fp, fp->coords.x, fp->coords.y, playerNum, true);
 					}
 				}
 			}
@@ -1833,7 +1834,7 @@ STRUCTURE *buildStructureDir(STRUCTURE_STATS *pStructureType, UDWORD x, UDWORD y
 
 		if (!FromSave)
 		{
-			displayConstructionCloud(psBuilding->pos);
+			displayConstructionCloud(world.map, psBuilding->pos);
 		}
 	}
 	else //its an upgrade
@@ -1842,7 +1843,7 @@ STRUCTURE *buildStructureDir(STRUCTURE_STATS *pStructureType, UDWORD x, UDWORD y
 		int32_t         bodyDiff = 0;
 
 		//don't create the Structure use existing one
-		psBuilding = getTileStructure(map_coord(x), map_coord(y));
+		psBuilding = getTileStructure(world.map, map_coord(x), map_coord(y));
 
 		if (!psBuilding)
 		{
@@ -1976,7 +1977,7 @@ STRUCTURE *buildStructureDir(STRUCTURE_STATS *pStructureType, UDWORD x, UDWORD y
 	return psBuilding;
 }
 
-optional<STRUCTURE> buildBlueprint(STRUCTURE_STATS const *psStats, Vector3i pos, uint16_t direction, unsigned moduleIndex, STRUCT_STATES state, uint8_t ownerPlayer)
+optional<STRUCTURE> buildBlueprint(WorldMapState& mapState, STRUCTURE_STATS const *psStats, Vector3i pos, uint16_t direction, unsigned moduleIndex, STRUCT_STATES state, uint8_t ownerPlayer)
 {
 	ASSERT_OR_RETURN(nullopt, psStats != nullptr, "No blueprint stats");
 	ASSERT_OR_RETURN(nullopt, psStats->pIMD[0] != nullptr, "No blueprint model for %s", getStatsName(psStats));
@@ -1988,7 +1989,7 @@ optional<STRUCTURE> buildBlueprint(STRUCTURE_STATS const *psStats, Vector3i pos,
 	std::vector<iIMDBaseShape *> const *pIMD = &psStats->pIMD;
 	if (IsStatExpansionModule(psStats))
 	{
-		STRUCTURE *baseStruct = castStructure(worldTile(gameWorld.map, pos.xy())->psObject);
+		STRUCTURE *baseStruct = castStructure(worldTile(mapState, pos.xy())->psObject);
 		if (baseStruct != nullptr)
 		{
 			if (moduleIndex == 0)
@@ -2048,7 +2049,7 @@ optional<STRUCTURE> buildBlueprint(STRUCTURE_STATS const *psStats, Vector3i pos,
 	// Rotate wall if needed.
 	if (blueprint.pStructureType->type == REF_WALL || blueprint.pStructureType->type == REF_GATE)
 	{
-		WallOrientation scanType = structChooseWallTypeBlueprint(map_coord(blueprint.pos.xy()));
+		WallOrientation scanType = structChooseWallTypeBlueprint(mapState, map_coord(blueprint.pos.xy()));
 		unsigned type = wallType(scanType);
 		if (scanType != WallConnectNone)
 		{
@@ -2122,7 +2123,7 @@ static bool setFunctionality(STRUCTURE *psBuilding, STRUCTURE_TYPE functionType)
 
 			// Set the assembly point
 			Vector2i pos = defaultAssemblyPointPos(psBuilding);
-			setAssemblyPoint(psFactory->psAssemblyPoint, pos.x, pos.y, psBuilding->player, true);
+			setAssemblyPoint(gameWorld, psFactory->psAssemblyPoint, pos.x, pos.y, psBuilding->player, true);
 
 			// Add the flag to the list
 			addFlagPosition(psFactory->psAssemblyPoint);
@@ -2170,7 +2171,7 @@ static bool setFunctionality(STRUCTURE *psBuilding, STRUCTURE_TYPE functionType)
 
 			// Set the assembly point
 			Vector2i pos = defaultAssemblyPointPos(psBuilding);
-			setAssemblyPoint(psRepairFac->psDeliveryPoint, pos.x, pos.y, psBuilding->player, true);
+			setAssemblyPoint(gameWorld, psRepairFac->psDeliveryPoint, pos.x, pos.y, psBuilding->player, true);
 
 			// Add the flag (triangular marker on the ground) at the delivery point
 			addFlagPosition(psRepairFac->psDeliveryPoint);
@@ -2337,17 +2338,17 @@ void assignFactoryCommandDroid(STRUCTURE *psStruct, DROID *psCommander)
 	{
 		if (typeFlag == FACTORY_FLAG)
 		{
-			secondarySetState(psFact->psCommander, DSO_CLEAR_PRODUCTION,
+			secondarySetState(psFact->psCommander, gameWorld.objects, DSO_CLEAR_PRODUCTION,
 			                  (SECONDARY_STATE)(1 << (psFact->psAssemblyPoint->factoryInc + DSS_ASSPROD_SHIFT)));
 		}
 		else if (typeFlag == CYBORG_FLAG)
 		{
-			secondarySetState(psFact->psCommander, DSO_CLEAR_PRODUCTION,
+			secondarySetState(psFact->psCommander, gameWorld.objects, DSO_CLEAR_PRODUCTION,
 			                  (SECONDARY_STATE)(1 << (psFact->psAssemblyPoint->factoryInc + DSS_ASSPROD_CYBORG_SHIFT)));
 		}
 		else
 		{
-			secondarySetState(psFact->psCommander, DSO_CLEAR_PRODUCTION,
+			secondarySetState(psFact->psCommander, gameWorld.objects, DSO_CLEAR_PRODUCTION,
 			                  (SECONDARY_STATE)(1 << (psFact->psAssemblyPoint->factoryInc + DSS_ASSPROD_VTOL_SHIFT)));
 		}
 
@@ -2430,13 +2431,13 @@ void clearCommandDroidFactory(DROID *psDroid)
 }
 
 /* Check that a tile is vacant for a droid to be placed */
-static bool structClearTile(UWORD x, UWORD y, PROPULSION_TYPE propulsion)
+static bool structClearTile(const GameWorld& world, UWORD x, UWORD y, PROPULSION_TYPE propulsion)
 {
 	UDWORD	player;
 
 	/* Check for a structure */
 	/* NOTE: Substitute PROPULSION_TYPE_WHEELED for PROPULSION_TYPE_LIFT, as flying droids are initially placed on the ground */
-	if (fpathBlockingTile(x, y, (propulsion != PROPULSION_TYPE_LIFT) ? propulsion : PROPULSION_TYPE_WHEELED))
+	if (fpathBlockingTile(world.map, x, y, (propulsion != PROPULSION_TYPE_LIFT) ? propulsion : PROPULSION_TYPE_WHEELED))
 	{
 		debug(LOG_NEVER, "failed - blocked");
 		return false;
@@ -2445,7 +2446,7 @@ static bool structClearTile(UWORD x, UWORD y, PROPULSION_TYPE propulsion)
 	/* Check for a droid */
 	for (player = 0; player < MAX_PLAYERS; player++)
 	{
-		for (const DROID* psCurr : gameWorld.objects.droids[player])
+		for (const DROID* psCurr : world.objects.droids[player])
 		{
 			if (map_coord(psCurr->pos.x) == x
 			    && map_coord(psCurr->pos.y) == y)
@@ -2529,7 +2530,7 @@ bool placeDroid(STRUCTURE *psStructure, const DROID_TEMPLATE * psTempl, UDWORD *
 	{
 		for (int x = xmin; x <= xmax; ++x)
 		{
-			if (structClearTile(x, y, psTempl->getPropulsionStats()->propulsionType))
+			if (structClearTile(gameWorld, x, y, psTempl->getPropulsionStats()->propulsionType))
 			{
 				tiles.push_back(Vector2i(12 * x - sx, 12 * y - sy));
 			}
@@ -2587,23 +2588,23 @@ void setFactorySecondaryState(DROID *psDroid, STRUCTURE *psStructure)
 		uint32_t diff = newState ^ psDroid->secondaryOrder;
 		if ((diff & DSS_ARANGE_MASK) != 0)
 		{
-			secondarySetState(psDroid, DSO_ATTACK_RANGE, (SECONDARY_STATE)(newState & DSS_ARANGE_MASK));
+			secondarySetState(psDroid, gameWorld.objects, DSO_ATTACK_RANGE, (SECONDARY_STATE)(newState & DSS_ARANGE_MASK));
 		}
 		if ((diff & DSS_REPLEV_MASK) != 0)
 		{
-			secondarySetState(psDroid, DSO_REPAIR_LEVEL, (SECONDARY_STATE)(newState & DSS_REPLEV_MASK));
+			secondarySetState(psDroid, gameWorld.objects, DSO_REPAIR_LEVEL, (SECONDARY_STATE)(newState & DSS_REPLEV_MASK));
 		}
 		if ((diff & DSS_ALEV_MASK) != 0)
 		{
-			secondarySetState(psDroid, DSO_ATTACK_LEVEL, (SECONDARY_STATE)(newState & DSS_ALEV_MASK));
+			secondarySetState(psDroid, gameWorld.objects, DSO_ATTACK_LEVEL, (SECONDARY_STATE)(newState & DSS_ALEV_MASK));
 		}
 		if ((diff & DSS_CIRCLE_MASK) != 0)
 		{
-			secondarySetState(psDroid, DSO_CIRCLE, (SECONDARY_STATE)(newState & DSS_CIRCLE_MASK));
+			secondarySetState(psDroid, gameWorld.objects, DSO_CIRCLE, (SECONDARY_STATE)(newState & DSS_CIRCLE_MASK));
 		}
 		if ((diff & DSS_HALT_MASK) != 0)
 		{
-			secondarySetState(psDroid, DSO_HALTTYPE, (SECONDARY_STATE)(newState & DSS_HALT_MASK));
+			secondarySetState(psDroid, gameWorld.objects, DSO_HALTTYPE, (SECONDARY_STATE)(newState & DSS_HALT_MASK));
 		}
 	}
 }
@@ -2629,7 +2630,7 @@ static bool structPlaceDroid(STRUCTURE *psStructure, DROID_TEMPLATE *psTempl, DR
 		//create a droid near to the structure
 		syncDebug("Placing new droid at (%d,%d)", x, y);
 		turnOffMultiMsg(true);
-		psNewDroid = buildDroid(psTempl, x, y, psStructure->player, false, &initialOrders, psStructure->rot);
+		psNewDroid = buildDroid(gameWorld, psTempl, x, y, psStructure->player, false, &initialOrders, psStructure->rot);
 		turnOffMultiMsg(false);
 		if (!psNewDroid)
 		{
@@ -2649,7 +2650,7 @@ static bool structPlaceDroid(STRUCTURE *psStructure, DROID_TEMPLATE *psTempl, DR
 			}
 		}
 		setFactorySecondaryState(psNewDroid, psStructure);
-		displayConstructionCloud(psNewDroid->pos);
+		displayConstructionCloud(gameWorld.map, psNewDroid->pos);
 		/* add the droid to the list */
 		addDroid(psNewDroid, gameWorld.objects.droids);
 		*ppsDroid = psNewDroid;
@@ -2779,7 +2780,7 @@ static bool IsFactoryCommanderGroupFull(const FACTORY *psFactory)
 
 // Check if a player has a certain structure. Optionally, checks if there is
 // at least one that is built.
-bool structureExists(int player, STRUCTURE_TYPE type, bool built, bool isMission)
+bool structureExists(const WorldObjectState& objState, int player, STRUCTURE_TYPE type, bool built)
 {
 	bool found = false;
 
@@ -2789,8 +2790,7 @@ bool structureExists(int player, STRUCTURE_TYPE type, bool built, bool isMission
 		return false;
 	}
 
-	StructureList* pList = isMission ? &mission.gameWorld.objects.structures[player] : &gameWorld.objects.structures[player];
-	for (const STRUCTURE *psCurr : *pList)
+	for (const STRUCTURE *psCurr : objState.structures[player])
 	{
 		if (psCurr->pStructureType->type == type && (!built || (built && psCurr->status == SS_BUILT)))
 		{
@@ -2869,7 +2869,9 @@ static bool checkHaltOnMaxUnitsReached(STRUCTURE *psStructure, bool isMission)
 	else switch (droidTemplateType(templ))
 		{
 		case DROID_COMMAND:
-			if (!structureExists(player, REF_COMMAND_CONTROL, true, isMission))
+		{
+			const WorldObjectState& objState = isMission ? mission.gameWorld.objects : gameWorld.objects;
+			if (!structureExists(objState, player, REF_COMMAND_CONTROL, true))
 			{
 				isLimit = true;
 				ssprintf(limitMsg, _("Can't build \"%s\" without a Command Relay Center — Production Halted"), templ->name.toUtf8().c_str());
@@ -2880,6 +2882,7 @@ static bool checkHaltOnMaxUnitsReached(STRUCTURE *psStructure, bool isMission)
 				ssprintf(limitMsg, _("Can't build \"%s\", Commander Limit Reached — Production Halted"), templ->name.toUtf8().c_str());
 			}
 			break;
+		}
 		case DROID_CONSTRUCT:
 		case DROID_CYBORG_CONSTRUCT:
 			if (getNumConstructorDroids(player) >= getMaxConstructors(player))
@@ -3025,7 +3028,7 @@ RepairState aiUpdateRepair_handleEvents(STRUCTURE &station, RepairEvents ev, DRO
 		// only call "secondarySetState" *after* triggering "droidWasFullyRepaired"
 		// because in some cases calling it would modify primary order
 		// thus, loosing information that we actually had a RTR|RTR_SPECIFIED before
-		secondarySetState(psDroid, DSO_RETURN_TO_LOC, DSS_NONE);
+		secondarySetState(psDroid, gameWorld.objects, DSO_RETURN_TO_LOC, DSS_NONE);
 		return RepairState::Idle;
 	};
 	case RepairEvents::UnitDied:
@@ -3785,7 +3788,7 @@ void structureUpdate(STRUCTURE *psBuilding, bool bMission)
 
 	if (psBuilding->flags.test(OBJECT_FLAG_DIRTY) && !bMission)
 	{
-		visTilesUpdate(psBuilding);
+		visTilesUpdate(psBuilding, gameWorld.map);
 		psBuilding->flags.set(OBJECT_FLAG_DIRTY, false);
 	}
 
@@ -4044,7 +4047,7 @@ fills the list with Structure that can be built. There is a limit on how many ca
 be built at any one time. Pass back the number available.
 There is now a limit of how many of each type of structure are allowed per mission
 */
-std::vector<STRUCTURE_STATS *> fillStructureList(UDWORD _selectedPlayer, UDWORD limit, bool showFavorites)
+std::vector<STRUCTURE_STATS *> fillStructureList(const WorldObjectState& objState, UDWORD _selectedPlayer, UDWORD limit, bool showFavorites)
 {
 	std::vector<STRUCTURE_STATS *> structureList;
 	UDWORD			inc;
@@ -4064,7 +4067,7 @@ std::vector<STRUCTURE_STATS *> fillStructureList(UDWORD _selectedPlayer, UDWORD 
 	//if currently on a mission can't build factory/research/power/derricks
 	if (!missionIsOffworld())
 	{
-		for (const STRUCTURE* psCurr : gameWorld.objects.structures[_selectedPlayer])
+		for (const STRUCTURE* psCurr : objState.structures[_selectedPlayer])
 		{
 			if (psCurr->pStructureType->type == REF_RESEARCH && psCurr->status == SS_BUILT)
 			{
@@ -4272,15 +4275,15 @@ bool isBlueprintTooClose(STRUCTURE_STATS const *stats1, Vector2i pos1, uint16_t 
 	return dist < minDist;
 }
 
-bool validLocation(BASE_STATS *psStats, Vector2i pos, uint16_t direction, unsigned player, bool bCheckBuildQueue)
+bool validLocation(GameWorld& world, BASE_STATS *psStats, Vector2i pos, uint16_t direction, unsigned player, bool bCheckBuildQueue)
 {
 	ASSERT_OR_RETURN(false, player < MAX_PLAYERS, "player (%u) >= MAX_PLAYERS", player);
 
 	StructureBounds b = getStructureBounds(psStats, pos, direction);
 
 	//make sure we are not too near map edge and not going to go over it
-	if (b.map.x < gameWorld.map.scroll.minX + TOO_NEAR_EDGE || b.map.x + b.size.x > gameWorld.map.scroll.maxX - TOO_NEAR_EDGE ||
-	    b.map.y < gameWorld.map.scroll.minY + TOO_NEAR_EDGE || b.map.y + b.size.y > gameWorld.map.scroll.maxY - TOO_NEAR_EDGE)
+	if (b.map.x < world.map.scroll.minX + TOO_NEAR_EDGE || b.map.x + b.size.x > world.map.scroll.maxX - TOO_NEAR_EDGE ||
+	    b.map.y < world.map.scroll.minY + TOO_NEAR_EDGE || b.map.y + b.size.y > world.map.scroll.maxY - TOO_NEAR_EDGE)
 	{
 		return false;
 	}
@@ -4288,7 +4291,7 @@ bool validLocation(BASE_STATS *psStats, Vector2i pos, uint16_t direction, unsign
 	if (bCheckBuildQueue)
 	{
 		// cant place on top of a delivery point...
-		for (const auto& psFlag : gameWorld.objects.flags[selectedPlayer])
+		for (const auto& psFlag : world.objects.flags[selectedPlayer])
 		{
 			ASSERT_OR_RETURN(false, psFlag->coords.x != ~0, "flag has invalid position");
 			Vector2i flagTile = map_coord(psFlag->coords.xy());
@@ -4308,7 +4311,7 @@ bool validLocation(BASE_STATS *psStats, Vector2i pos, uint16_t direction, unsign
 			{
 				// Don't allow building structures (allow delivery points, though) outside visible area in single-player with debug mode off. (Why..?)
 				const DebugInputManager& dbgInputManager = gInputManager.debugManager();
-				if (!bMultiPlayer && !dbgInputManager.debugMappingsAllowed() && !TEST_TILE_VISIBLE(player, mapTile(gameWorld.map, b.map.x + i, b.map.y + j)))
+				if (!bMultiPlayer && !dbgInputManager.debugMappingsAllowed() && !TEST_TILE_VISIBLE(player, mapTile(world.map, b.map.x + i, b.map.y + j)))
 				{
 					return false;
 				}
@@ -4346,7 +4349,7 @@ bool validLocation(BASE_STATS *psStats, Vector2i pos, uint16_t direction, unsign
 				for (int j = 0; j < b.size.y; ++j)
 					for (int i = 0; i < b.size.x; ++i)
 					{
-						MAPTILE const *psTile = mapTile(gameWorld.map, b.map.x + i, b.map.y + j);
+						MAPTILE const *psTile = mapTile(world.map, b.map.x + i, b.map.y + j);
 						if ((terrainType(psTile) == TER_WATER) ||
 						    (terrainType(psTile) == TER_CLIFFFACE))
 						{
@@ -4357,7 +4360,7 @@ bool validLocation(BASE_STATS *psStats, Vector2i pos, uint16_t direction, unsign
 				for (int j = 0; j < b.size.y; ++j)
 					for (int i = 0; i < b.size.x; ++i)
 					{
-						if (withinLandingZone(b.map.x + i, b.map.y + j))
+						if (withinLandingZone(world.map, b.map.x + i, b.map.y + j))
 						{
 							return false;
 						}
@@ -4374,7 +4377,7 @@ bool validLocation(BASE_STATS *psStats, Vector2i pos, uint16_t direction, unsign
 						for (int i = 0; i < b.size.x; ++i)
 						{
 							int max, min;
-							getTileMaxMin(b.map.x + i, b.map.y + j, &max, &min);
+							getTileMaxMin(world.map, b.map.x + i, b.map.y + j, &max, &min);
 							if (max - min > MAX_INCLINE)
 							{
 								return false;
@@ -4397,7 +4400,7 @@ bool validLocation(BASE_STATS *psStats, Vector2i pos, uint16_t direction, unsign
 						//skip the actual area the structure will cover
 						if (i < 0 || i >= b.size.x || j < 0 || j >= b.size.y)
 						{
-							BASE_OBJECT *object = mapTile(gameWorld.map, b.map.x + i, b.map.y + j)->psObject;
+							BASE_OBJECT *object = mapTile(world.map, b.map.x + i, b.map.y + j)->psObject;
 							STRUCTURE *structure = castStructure(object);
 							if (structure != nullptr && !structure->visible[player] && !aiCheckAlliances(player, structure->player))
 							{
@@ -4422,7 +4425,7 @@ bool validLocation(BASE_STATS *psStats, Vector2i pos, uint16_t direction, unsign
 							//skip the actual area the structure will cover
 							if (i < 0 || i >= b.size.x || j < 0 || j >= b.size.y)
 							{
-								STRUCTURE const *psStruct = getTileStructure(b.map.x + i, b.map.y + j);
+								STRUCTURE const *psStruct = getTileStructure(world.map, b.map.x + i, b.map.y + j);
 								if (psStruct != nullptr && psStruct->player == player && psStruct->status == SS_BUILT)
 								{
 									connection = true;
@@ -4441,12 +4444,12 @@ bool validLocation(BASE_STATS *psStats, Vector2i pos, uint16_t direction, unsign
 				for (int j = 0; j < b.size.y; ++j)
 					for (int i = 0; i < b.size.x; ++i)
 					{
-						MAPTILE const *psTile = mapTile(gameWorld.map, b.map.x + i, b.map.y + j);
+						MAPTILE const *psTile = mapTile(world.map, b.map.x + i, b.map.y + j);
 						if (TileIsKnownOccupied(psTile, player))
 						{
 							if (TileHasWall(psTile) && (psBuilding->type == REF_DEFENSE || psBuilding->type == REF_GATE || psBuilding->type == REF_WALL))
 							{
-								STRUCTURE const *psStruct = getTileStructure(b.map.x + i, b.map.y + j);
+								STRUCTURE const *psStruct = getTileStructure(world.map, b.map.x + i, b.map.y + j);
 								if (psStruct != nullptr && psStruct->player != player)
 								{
 									return false;
@@ -4461,9 +4464,9 @@ bool validLocation(BASE_STATS *psStats, Vector2i pos, uint16_t direction, unsign
 				break;
 			}
 		case REF_FACTORY_MODULE:
-			if (TileHasStructure(worldTile(gameWorld.map, pos)))
+			if (TileHasStructure(worldTile(world.map, pos)))
 			{
-				STRUCTURE const *psStruct = getTileStructure(map_coord(pos.x), map_coord(pos.y));
+				STRUCTURE const *psStruct = getTileStructure(world.map, map_coord(pos.x), map_coord(pos.y));
 				if (psStruct && (psStruct->pStructureType->type == REF_FACTORY ||
 				                 psStruct->pStructureType->type == REF_VTOL_FACTORY)
 					&& psStruct->status == SS_BUILT && aiCheckAlliances(player, psStruct->player)
@@ -4474,9 +4477,9 @@ bool validLocation(BASE_STATS *psStats, Vector2i pos, uint16_t direction, unsign
 			}
 			return false;
 		case REF_RESEARCH_MODULE:
-			if (TileHasStructure(worldTile(gameWorld.map, pos)))
+			if (TileHasStructure(worldTile(world.map, pos)))
 			{
-				STRUCTURE const *psStruct = getTileStructure(map_coord(pos.x), map_coord(pos.y));
+				STRUCTURE const *psStruct = getTileStructure(world.map, map_coord(pos.x), map_coord(pos.y));
 				if (psStruct && psStruct->pStructureType->type == REF_RESEARCH
 					&& psStruct->status == SS_BUILT
 					&& aiCheckAlliances(player, psStruct->player)
@@ -4487,9 +4490,9 @@ bool validLocation(BASE_STATS *psStats, Vector2i pos, uint16_t direction, unsign
 			}
 			return false;
 		case REF_POWER_MODULE:
-			if (TileHasStructure(worldTile(gameWorld.map, pos)))
+			if (TileHasStructure(worldTile(world.map, pos)))
 			{
-				STRUCTURE const *psStruct = getTileStructure(map_coord(pos.x), map_coord(pos.y));
+				STRUCTURE const *psStruct = getTileStructure(world.map, map_coord(pos.x), map_coord(pos.y));
 				if (psStruct && psStruct->pStructureType->type == REF_POWER_GEN
 					&& psStruct->status == SS_BUILT
 					&& aiCheckAlliances(player, psStruct->player)
@@ -4500,9 +4503,9 @@ bool validLocation(BASE_STATS *psStats, Vector2i pos, uint16_t direction, unsign
 			}
 			return false;
 		case REF_RESOURCE_EXTRACTOR:
-			if (TileHasFeature(worldTile(gameWorld.map, pos)))
+			if (TileHasFeature(worldTile(world.map, pos)))
 			{
-				FEATURE const *psFeat = getTileFeature(map_coord(pos.x), map_coord(pos.y));
+				FEATURE const *psFeat = getTileFeature(world.map, map_coord(pos.x), map_coord(pos.y));
 				if (psFeat && psFeat->psStats->subType == FEAT_OIL_RESOURCE)
 				{
 					break;
@@ -4521,7 +4524,7 @@ bool validLocation(BASE_STATS *psStats, Vector2i pos, uint16_t direction, unsign
 	{
 		PROPULSION_STATS *psPropStats = psTemplate->getPropulsionStats();
 
-		if (fpathBlockingTile(b.map.x, b.map.y, psPropStats->propulsionType))
+		if (fpathBlockingTile(world.map, b.map.x, b.map.y, psPropStats->propulsionType))
 		{
 			return false;
 		}
@@ -4529,7 +4532,7 @@ bool validLocation(BASE_STATS *psStats, Vector2i pos, uint16_t direction, unsign
 	else
 	{
 		// not positioning a structure or droid, ie positioning a feature
-		if (fpathBlockingTile(b.map.x, b.map.y, PROPULSION_TYPE_WHEELED))
+		if (fpathBlockingTile(world.map, b.map.x, b.map.y, PROPULSION_TYPE_WHEELED))
 		{
 			return false;
 		}
@@ -4584,7 +4587,7 @@ bool removeStruct(STRUCTURE *psDel, bool bDestroy)
 		HOW MUCH IS THERE && NOT RES EXTRACTORS */
 		if (psDel->pStructureType->type == REF_RESOURCE_EXTRACTOR)
 		{
-			FEATURE *psOil = buildFeature(oilResFeature, psDel->pos.x, psDel->pos.y, false);
+			FEATURE *psOil = buildFeature(gameWorld.map, oilResFeature, psDel->pos.x, psDel->pos.y, false);
 			memcpy(psOil->seenThisTick, psDel->visible, sizeof(psOil->seenThisTick));
 			resourceFound = true;
 		}
@@ -4904,11 +4907,11 @@ bool  STRUCTURE::isIdle() const
 
 /*checks to see if a specific structure type exists -as opposed to a structure
 stat type*/
-bool checkSpecificStructExists(UDWORD structInc, UDWORD player)
+bool checkSpecificStructExists(const WorldObjectState& objState, UDWORD structInc, UDWORD player)
 {
 	ASSERT_OR_RETURN(false, structInc < numStructureStats, "Invalid structure inc");
 
-	for (const STRUCTURE *psStructure : gameWorld.objects.structures[player])
+	for (const STRUCTURE *psStructure : objState.structures[player])
 	{
 		if (psStructure->status == SS_BUILT)
 		{
@@ -4923,7 +4926,7 @@ bool checkSpecificStructExists(UDWORD structInc, UDWORD player)
 
 
 /*finds a suitable position for the assembly point based on one passed in*/
-void findAssemblyPointPosition(UDWORD *pX, UDWORD *pY, UDWORD player)
+void findAssemblyPointPosition(GameWorld& world, UDWORD *pX, UDWORD *pY, UDWORD player)
 {
 	//set up a dummy stat pointer
 	STRUCTURE_STATS     sStats;
@@ -4939,7 +4942,7 @@ void findAssemblyPointPosition(UDWORD *pX, UDWORD *pY, UDWORD player)
 	passes = 0;
 
 	//if the value passed in is not a valid location - find one!
-	if (!validLocation(&sStats, world_coord(Vector2i(*pX, *pY)), 0, player, false))
+	if (!validLocation(world, &sStats, world_coord(Vector2i(*pX, *pY)), 0, player, false))
 	{
 		/* Keep going until we get a tile or we exceed distance */
 		while (passes < LOOK_FOR_EMPTY_TILE)
@@ -4953,7 +4956,7 @@ void findAssemblyPointPosition(UDWORD *pX, UDWORD *pY, UDWORD player)
 					if (i == startX || i == endX || j == startY || j == endY)
 					{
 						/* Good enough? */
-						if (validLocation(&sStats, world_coord(Vector2i(i, j)), 0, player, false))
+						if (validLocation(world, &sStats, world_coord(Vector2i(i, j)), 0, player, false))
 						{
 							/* Set exit conditions and get out NOW */
 							*pX = i;
@@ -4980,7 +4983,7 @@ void findAssemblyPointPosition(UDWORD *pX, UDWORD *pY, UDWORD player)
 
 /*sets the point new droids go to - x/y in world coords for a Factory
 bCheck is set to true for initial placement of the Assembly Point*/
-void setAssemblyPoint(FLAG_POSITION *psAssemblyPoint, UDWORD x, UDWORD y,
+void setAssemblyPoint(GameWorld& world, FLAG_POSITION *psAssemblyPoint, UDWORD x, UDWORD y,
                       UDWORD player, bool bCheck)
 {
 	ASSERT_OR_RETURN(, psAssemblyPoint != nullptr, "invalid AssemblyPoint pointer");
@@ -4990,7 +4993,7 @@ void setAssemblyPoint(FLAG_POSITION *psAssemblyPoint, UDWORD x, UDWORD y,
 	y = map_coord(y);
 	if (bCheck)
 	{
-		findAssemblyPointPosition(&x, &y, player);
+		findAssemblyPointPosition(world, &x, &y, player);
 	}
 	//add half a tile so the centre is in the middle of the tile
 	x = world_coord(x) + TILE_UNITS / 2;
@@ -5000,7 +5003,7 @@ void setAssemblyPoint(FLAG_POSITION *psAssemblyPoint, UDWORD x, UDWORD y,
 	psAssemblyPoint->coords.y = y;
 
 	// Deliv Point sits at the height of the tile it's centre is on + arbitrary amount!
-	psAssemblyPoint->coords.z = map_Height(gameWorld.map, x, y) + ASSEMBLY_POINT_Z_PADDING;
+	psAssemblyPoint->coords.z = map_Height(world.map, x, y) + ASSEMBLY_POINT_Z_PADDING;
 }
 
 
@@ -5233,13 +5236,13 @@ void checkForResExtractors(STRUCTURE *psBuilding)
 	}
 }
 
-uint16_t countPlayerUnusedDerricks()
+uint16_t countPlayerUnusedDerricks(const WorldObjectState& objState)
 {
 	uint16_t total = 0;
 
 	if (selectedPlayer >= MAX_PLAYERS) { return 0; }
 
-	for (const STRUCTURE *psStruct : gameWorld.objects.extractors[selectedPlayer])
+	for (const STRUCTURE *psStruct : objState.extractors[selectedPlayer])
 	{
 		if (psStruct->status == SS_BUILT && psStruct->pStructureType->type == REF_RESOURCE_EXTRACTOR)
 		{
@@ -5409,7 +5412,7 @@ void buildingComplete(STRUCTURE *psBuilding)
 	psBuilding->currentBuildPts = structureBuildPointsToCompletion(*psBuilding);
 	psBuilding->status = SS_BUILT;
 
-	visTilesUpdate(psBuilding);
+	visTilesUpdate(psBuilding, gameWorld.map);
 
 	if (psBuilding->prebuiltImd != nullptr)
 	{
@@ -5440,7 +5443,7 @@ void buildingComplete(STRUCTURE *psBuilding)
 		releaseProduction(psBuilding, ModeImmediate);
 		break;
 	case REF_SAT_UPLINK:
-		revealAll(psBuilding->player);
+		revealAll(gameWorld.map, psBuilding->player);
 		break;
 	case REF_GATE:
 		auxStructureNonblocking(psBuilding);  // Clear outdated flags.
@@ -5926,7 +5929,7 @@ bool electronicReward(STRUCTURE *psStructure, UBYTE attackPlayer)
 		bRewarded = true;
 		break;
 	case REF_HQ:
-		hqReward(psStructure->player, attackPlayer);
+		hqReward(gameWorld, psStructure->player, attackPlayer);
 		if (attackPlayer == selectedPlayer)
 		{
 			addConsoleMessage(_("Electronic Reward - Visibility Report"),	DEFAULT_JUSTIFY, SYSTEM_MESSAGE);
@@ -6065,16 +6068,16 @@ void repairFacilityReward(UBYTE losingPlayer, UBYTE rewardPlayer)
 
 
 /*makes the losing players tiles/structures/features visible to the reward player*/
-void hqReward(UBYTE losingPlayer, UBYTE rewardPlayer)
+void hqReward(GameWorld& world, UBYTE losingPlayer, UBYTE rewardPlayer)
 {
 	ASSERT_OR_RETURN(, losingPlayer < MAX_PLAYERS && rewardPlayer < MAX_PLAYERS, "losingPlayer (%" PRIu8 "), rewardPlayer (%" PRIu8 ") must both be < MAXPLAYERS", losingPlayer, rewardPlayer);
 
 	// share exploration info - pretty useless but perhaps a nice touch?
-	for (int y = 0; y < gameWorld.map.height; ++y)
+	for (int y = 0; y < world.map.height; ++y)
 	{
-		for (int x = 0; x < gameWorld.map.width; ++x)
+		for (int x = 0; x < world.map.width; ++x)
 		{
-			MAPTILE *psTile = mapTile(gameWorld.map, x, y);
+			MAPTILE *psTile = mapTile(world.map, x, y);
 			if (TEST_TILE_VISIBLE(losingPlayer, psTile))
 			{
 				psTile->tileExploredBits |= alliancebits[rewardPlayer];
@@ -6085,7 +6088,7 @@ void hqReward(UBYTE losingPlayer, UBYTE rewardPlayer)
 	//struct
 	for (int i = 0; i < MAX_PLAYERS; ++i)
 	{
-		for (STRUCTURE *psStruct : gameWorld.objects.structures[i])
+		for (STRUCTURE *psStruct : world.objects.structures[i])
 		{
 			if (psStruct->visible[losingPlayer] && !psStruct->died)
 			{
@@ -6094,7 +6097,7 @@ void hqReward(UBYTE losingPlayer, UBYTE rewardPlayer)
 		}
 
 		//droids.
-		for (DROID *psDroid : gameWorld.objects.droids[i])
+		for (DROID *psDroid : world.objects.droids[i])
 		{
 			if (psDroid->visible[losingPlayer] || psDroid->player == losingPlayer)
 			{
@@ -6104,7 +6107,7 @@ void hqReward(UBYTE losingPlayer, UBYTE rewardPlayer)
 	}
 
 	//feature
-	for (FEATURE *psFeat : gameWorld.objects.features[0])
+	for (FEATURE *psFeat : world.objects.features[0])
 	{
 		if (psFeat->visible[losingPlayer])
 		{
@@ -6507,7 +6510,7 @@ bool checkFactoryExists(UDWORD player, UDWORD factoryType, UDWORD inc)
 
 
 //check that delivery points haven't been put down in invalid location
-void checkDeliveryPoints(UDWORD version)
+void checkDeliveryPoints(GameWorld& world, UDWORD version)
 {
 	UBYTE			inc;
 	FACTORY			*psFactory;
@@ -6522,7 +6525,7 @@ void checkDeliveryPoints(UDWORD version)
 		//will have been called to put in down in the first place
 		if (inc != selectedPlayer)
 		{
-			for (STRUCTURE* psStruct : gameWorld.objects.structures[inc])
+			for (STRUCTURE* psStruct : world.objects.structures[inc])
 			{
 				if (!psStruct)
 				{
@@ -6538,7 +6541,7 @@ void checkDeliveryPoints(UDWORD version)
 					}
 					else
 					{
-						setAssemblyPoint(psFactory->psAssemblyPoint, psFactory->psAssemblyPoint->
+						setAssemblyPoint(world, psFactory->psAssemblyPoint, psFactory->psAssemblyPoint->
 						                 coords.x, psFactory->psAssemblyPoint->coords.y, inc, true);
 					}
 				}
@@ -6566,13 +6569,13 @@ void checkDeliveryPoints(UDWORD version)
 							x = map_coord(psStruct->pos.x + 256);
 							y = map_coord(psStruct->pos.y + 256);
 							// Belt and braces - shouldn't be able to build too near edge
-							setAssemblyPoint(psRepair->psDeliveryPoint, world_coord(x),
+							setAssemblyPoint(world, psRepair->psDeliveryPoint, world_coord(x),
 							                 world_coord(y), inc, true);
 						}
 					}
 					else//check existing one
 					{
-						setAssemblyPoint(psRepair->psDeliveryPoint, psRepair->psDeliveryPoint->
+						setAssemblyPoint(world, psRepair->psDeliveryPoint, psRepair->psDeliveryPoint->
 						                 coords.x, psRepair->psDeliveryPoint->coords.y, inc, true);
 					}
 				}
@@ -6887,7 +6890,7 @@ STRUCTURE *giftSingleStructure(STRUCTURE *psStructure, UBYTE attackPlayer, bool 
 
 	ASSERT_OR_RETURN(nullptr, attackPlayer < MAX_PLAYERS, "attackPlayer (%" PRIu32 ") must be < MAX_PLAYERS", attackPlayer);
 	CHECK_STRUCTURE(psStructure);
-	visRemoveVisibility(psStructure);
+	visRemoveVisibility(psStructure, gameWorld.map);
 
 	int prevState = intGetResearchState();
 	bool reward = electronicReward(psStructure, attackPlayer);
@@ -6983,7 +6986,7 @@ STRUCTURE *giftSingleStructure(STRUCTURE *psStructure, UBYTE attackPlayer, bool 
 	bPowerOn = powerCalculated;
 	powerCalculated = false;
 	//build a new one for the attacking player - set last element to true so it doesn't adjust x/y
-	psNewStruct = buildStructure(psType, x, y, attackPlayer, true);
+	psNewStruct = buildStructure(gameWorld, psType, x, y, attackPlayer, true);
 	capacity = psStructure->capacity;
 	if (psNewStruct)
 	{
@@ -6995,14 +6998,14 @@ STRUCTURE *giftSingleStructure(STRUCTURE *psStructure, UBYTE attackPlayer, bool 
 			case REF_POWER_GEN:
 			case REF_RESEARCH:
 				//build the module for powerGen and research
-				buildStructure(psModule, psNewStruct->pos.x, psNewStruct->pos.y, attackPlayer, false);
+				buildStructure(gameWorld, psModule, psNewStruct->pos.x, psNewStruct->pos.y, attackPlayer, false);
 				break;
 			case REF_FACTORY:
 			case REF_VTOL_FACTORY:
 				//build the appropriate number of modules
 				while (capacity)
 				{
-					buildStructure(psModule, psNewStruct->pos.x, psNewStruct->pos.y, attackPlayer, false);
+					buildStructure(gameWorld, psModule, psNewStruct->pos.x, psNewStruct->pos.y, attackPlayer, false);
 					capacity--;
 				}
 				break;

--- a/src/structure.h
+++ b/src/structure.h
@@ -51,6 +51,10 @@
 //used to flag when the Factory is ready to start building
 #define ACTION_START_TIME	0
 
+struct GameWorld;
+struct WorldMapState;
+struct WorldObjectState;
+
 extern std::vector<ProductionRun> asProductionRun[NUM_FACTORY_TYPES];
 
 //Value is stored for easy access to this structure stat
@@ -80,7 +84,7 @@ void setMaxDroids(UDWORD player, int value);
 void setMaxCommanders(UDWORD player, int value);
 void setMaxConstructors(UDWORD player, int value);
 
-bool structureExists(int player, STRUCTURE_TYPE type, bool built, bool isMission);
+bool structureExists(const WorldObjectState& objState, int player, STRUCTURE_TYPE type, bool built);
 
 bool IsPlayerDroidLimitReached(int player);
 
@@ -105,13 +109,13 @@ uint32_t structureBuildPointsToCompletion(const STRUCTURE & structure);
 float structureCompletionProgress(const STRUCTURE & structure);
 
 //builds a specified structure at a given location
-STRUCTURE *buildStructure(STRUCTURE_STATS *pStructureType, UDWORD x, UDWORD y, UDWORD player, bool FromSave);
-STRUCTURE *buildStructureDir(STRUCTURE_STATS *pStructureType, UDWORD x, UDWORD y, uint16_t direction, UDWORD player, bool FromSave, uint32_t id, bool forceWallOrientation = false);
-STRUCTURE *buildStructureDir(STRUCTURE_STATS *pStructureType, UDWORD x, UDWORD y, uint16_t direction, UDWORD player, bool FromSave);
+STRUCTURE *buildStructure(GameWorld& world, STRUCTURE_STATS *pStructureType, UDWORD x, UDWORD y, UDWORD player, bool FromSave);
+STRUCTURE *buildStructureDir(GameWorld& world, STRUCTURE_STATS *pStructureType, UDWORD x, UDWORD y, uint16_t direction, UDWORD player, bool FromSave, uint32_t id, bool forceWallOrientation = false);
+STRUCTURE *buildStructureDir(GameWorld& world, STRUCTURE_STATS *pStructureType, UDWORD x, UDWORD y, uint16_t direction, UDWORD player, bool FromSave);
 /// Create a blueprint structure, with just enough information to render it
 /// IMPORTANT: Do not save the reference to this instance anywhere, since it's
 /// not heap-allocated and thus doesn't have a stable address!
-nonstd::optional<STRUCTURE> buildBlueprint(STRUCTURE_STATS const *psStats, Vector3i xy, uint16_t direction, unsigned moduleIndex, STRUCT_STATES state, uint8_t ownerPlayer);
+nonstd::optional<STRUCTURE> buildBlueprint(WorldMapState& mapState, STRUCTURE_STATS const *psStats, Vector3i xy, uint16_t direction, unsigned moduleIndex, STRUCT_STATES state, uint8_t ownerPlayer);
 /* The main update routine for all Structures */
 void structureUpdate(STRUCTURE *psBuilding, bool bMission);
 
@@ -124,14 +128,14 @@ bool destroyStruct(STRUCTURE *psDel, unsigned impactTime);
 bool removeStruct(STRUCTURE *psDel, bool bDestroy);
 
 //fills the list with Structures that can be built
-std::vector<STRUCTURE_STATS *> fillStructureList(UDWORD selectedPlayer, UDWORD limit, bool showFavorites);
+std::vector<STRUCTURE_STATS *> fillStructureList(const WorldObjectState& objState, UDWORD selectedPlayer, UDWORD limit, bool showFavorites);
 
 /// Checks if the two structures would be too close to build together.
 bool isBlueprintTooClose(STRUCTURE_STATS const *stats1, Vector2i pos1, uint16_t dir1, STRUCTURE_STATS const *stats2, Vector2i pos2, uint16_t dir2);
 
 /// Checks that the location is valid to build on.
 /// pos in world coords
-bool validLocation(BASE_STATS *psStats, Vector2i pos, uint16_t direction, unsigned player, bool bCheckBuildQueue);
+bool validLocation(GameWorld& world, BASE_STATS *psStats, Vector2i pos, uint16_t direction, unsigned player, bool bCheckBuildQueue);
 
 bool isWall(STRUCTURE_TYPE type);                                    ///< Structure is a wall. Not completely sure it handles all cases.
 bool isBuildableOnWalls(STRUCTURE_TYPE type);                        ///< Structure can be built on walls. Not completely sure it handles all cases.
@@ -139,17 +143,17 @@ bool isBuildableOnWalls(STRUCTURE_TYPE type);                        ///< Struct
 void alignStructure(STRUCTURE *psBuilding);
 
 /* set the current number of structures of each type built */
-void setCurrentStructQuantity(bool displayError);
+void setCurrentStructQuantity(const WorldObjectState& objState, bool displayError);
 /* get a stat inc based on the name */
 int32_t getStructStatFromName(const WzString &name);
 /*sets the point new droids go to - x/y in world coords for a Factory*/
-void setAssemblyPoint(FLAG_POSITION *psAssemblyPoint, UDWORD x, UDWORD y, UDWORD player, bool bCheck);
+void setAssemblyPoint(GameWorld& world, FLAG_POSITION *psAssemblyPoint, UDWORD x, UDWORD y, UDWORD player, bool bCheck);
 
 /*initialises the flag before a new data set is loaded up*/
 void initFactoryNumFlag();
 
 //called at start of missions
-void resetFactoryNumFlag();
+void resetFactoryNumFlag(const WorldObjectState& objState);
 
 /* get demolish stat */
 STRUCTURE_STATS *structGetDemolishStat();
@@ -189,7 +193,7 @@ void buildingComplete(STRUCTURE *psBuilding);
 void checkForResExtractors(STRUCTURE *psPowerGen);
 void checkForPowerGen(STRUCTURE *psPowerGen);
 
-uint16_t countPlayerUnusedDerricks();
+uint16_t countPlayerUnusedDerricks(const WorldObjectState& objState);
 
 // Set the command droid that factory production should go to struct _command_droid;
 void assignFactoryCommandDroid(STRUCTURE *psStruct, struct DROID *psCommander);
@@ -225,14 +229,14 @@ bool validStructResistance(const STRUCTURE *psStruct);
 
 /*checks to see if a specific structure type exists -as opposed to a structure
 stat type*/
-bool checkSpecificStructExists(UDWORD structInc, UDWORD player);
+bool checkSpecificStructExists(const WorldObjectState& objState, UDWORD structInc, UDWORD player);
 
 int32_t getStructureDamage(const STRUCTURE *psStructure);
 
 unsigned structureBodyBuilt(const STRUCTURE *psStruct);  ///< Returns the maximum body points of a structure with the current number of build points.
 UDWORD structureResistance(const STRUCTURE_STATS *psStats, UBYTE player);
 
-void hqReward(UBYTE losingPlayer, UBYTE rewardPlayer);
+void hqReward(GameWorld& world, UBYTE losingPlayer, UBYTE rewardPlayer);
 
 // Is a flag a factory delivery point?
 bool FlagIsFactory(const FLAG_POSITION *psCurrFlag);
@@ -254,7 +258,7 @@ void factoryProdAdjust(STRUCTURE *psStructure, DROID_TEMPLATE *psTemplate, bool 
 ProductionRunEntry getProduction(STRUCTURE *psStructure, DROID_TEMPLATE *psTemplate);
 
 //check that delivery points haven't been put down in invalid location
-void checkDeliveryPoints(UDWORD version);
+void checkDeliveryPoints(GameWorld& world, UDWORD version);
 
 //adjust the loop quantity for this factory
 void factoryLoopAdjust(STRUCTURE *psStruct, bool add);

--- a/src/structure.h
+++ b/src/structure.h
@@ -51,6 +51,10 @@
 //used to flag when the Factory is ready to start building
 #define ACTION_START_TIME	0
 
+struct GameWorld;
+struct WorldMapState;
+struct WorldObjectState;
+
 extern std::vector<ProductionRun> asProductionRun[NUM_FACTORY_TYPES];
 
 //Value is stored for easy access to this structure stat
@@ -80,7 +84,7 @@ void setMaxDroids(UDWORD player, int value);
 void setMaxCommanders(UDWORD player, int value);
 void setMaxConstructors(UDWORD player, int value);
 
-bool structureExists(int player, STRUCTURE_TYPE type, bool built, bool isMission);
+bool structureExists(const WorldObjectState& objState, int player, STRUCTURE_TYPE type, bool built);
 
 bool IsPlayerDroidLimitReached(int player);
 
@@ -105,13 +109,13 @@ uint32_t structureBuildPointsToCompletion(const STRUCTURE & structure);
 float structureCompletionProgress(const STRUCTURE & structure);
 
 //builds a specified structure at a given location
-STRUCTURE *buildStructure(STRUCTURE_STATS *pStructureType, UDWORD x, UDWORD y, UDWORD player, bool FromSave);
-STRUCTURE *buildStructureDir(STRUCTURE_STATS *pStructureType, UDWORD x, UDWORD y, uint16_t direction, UDWORD player, bool FromSave, uint32_t id);
-STRUCTURE *buildStructureDir(STRUCTURE_STATS *pStructureType, UDWORD x, UDWORD y, uint16_t direction, UDWORD player, bool FromSave);
+STRUCTURE *buildStructure(GameWorld& world, STRUCTURE_STATS *pStructureType, UDWORD x, UDWORD y, UDWORD player, bool FromSave);
+STRUCTURE *buildStructureDir(GameWorld& world, STRUCTURE_STATS *pStructureType, UDWORD x, UDWORD y, uint16_t direction, UDWORD player, bool FromSave, uint32_t id);
+STRUCTURE *buildStructureDir(GameWorld& world, STRUCTURE_STATS *pStructureType, UDWORD x, UDWORD y, uint16_t direction, UDWORD player, bool FromSave);
 /// Create a blueprint structure, with just enough information to render it
 /// IMPORTANT: Do not save the reference to this instance anywhere, since it's
 /// not heap-allocated and thus doesn't have a stable address!
-nonstd::optional<STRUCTURE> buildBlueprint(STRUCTURE_STATS const *psStats, Vector3i xy, uint16_t direction, unsigned moduleIndex, STRUCT_STATES state, uint8_t ownerPlayer);
+nonstd::optional<STRUCTURE> buildBlueprint(WorldMapState& mapState, STRUCTURE_STATS const *psStats, Vector3i xy, uint16_t direction, unsigned moduleIndex, STRUCT_STATES state, uint8_t ownerPlayer);
 /* The main update routine for all Structures */
 void structureUpdate(STRUCTURE *psBuilding, bool bMission);
 
@@ -124,14 +128,14 @@ bool destroyStruct(STRUCTURE *psDel, unsigned impactTime);
 bool removeStruct(STRUCTURE *psDel, bool bDestroy);
 
 //fills the list with Structures that can be built
-std::vector<STRUCTURE_STATS *> fillStructureList(UDWORD selectedPlayer, UDWORD limit, bool showFavorites);
+std::vector<STRUCTURE_STATS *> fillStructureList(const WorldObjectState& objState, UDWORD selectedPlayer, UDWORD limit, bool showFavorites);
 
 /// Checks if the two structures would be too close to build together.
 bool isBlueprintTooClose(STRUCTURE_STATS const *stats1, Vector2i pos1, uint16_t dir1, STRUCTURE_STATS const *stats2, Vector2i pos2, uint16_t dir2);
 
 /// Checks that the location is valid to build on.
 /// pos in world coords
-bool validLocation(BASE_STATS *psStats, Vector2i pos, uint16_t direction, unsigned player, bool bCheckBuildQueue);
+bool validLocation(GameWorld& world, BASE_STATS *psStats, Vector2i pos, uint16_t direction, unsigned player, bool bCheckBuildQueue);
 
 bool isWall(STRUCTURE_TYPE type);                                    ///< Structure is a wall. Not completely sure it handles all cases.
 bool isBuildableOnWalls(STRUCTURE_TYPE type);                        ///< Structure can be built on walls. Not completely sure it handles all cases.
@@ -139,17 +143,17 @@ bool isBuildableOnWalls(STRUCTURE_TYPE type);                        ///< Struct
 void alignStructure(STRUCTURE *psBuilding);
 
 /* set the current number of structures of each type built */
-void setCurrentStructQuantity(bool displayError);
+void setCurrentStructQuantity(const WorldObjectState& objState, bool displayError);
 /* get a stat inc based on the name */
 int32_t getStructStatFromName(const WzString &name);
 /*sets the point new droids go to - x/y in world coords for a Factory*/
-void setAssemblyPoint(FLAG_POSITION *psAssemblyPoint, UDWORD x, UDWORD y, UDWORD player, bool bCheck);
+void setAssemblyPoint(GameWorld& world, FLAG_POSITION *psAssemblyPoint, UDWORD x, UDWORD y, UDWORD player, bool bCheck);
 
 /*initialises the flag before a new data set is loaded up*/
 void initFactoryNumFlag();
 
 //called at start of missions
-void resetFactoryNumFlag();
+void resetFactoryNumFlag(const WorldObjectState& objState);
 
 /* get demolish stat */
 STRUCTURE_STATS *structGetDemolishStat();
@@ -189,7 +193,7 @@ void buildingComplete(STRUCTURE *psBuilding);
 void checkForResExtractors(STRUCTURE *psPowerGen);
 void checkForPowerGen(STRUCTURE *psPowerGen);
 
-uint16_t countPlayerUnusedDerricks();
+uint16_t countPlayerUnusedDerricks(const WorldObjectState& objState);
 
 // Set the command droid that factory production should go to struct _command_droid;
 void assignFactoryCommandDroid(STRUCTURE *psStruct, struct DROID *psCommander);
@@ -225,14 +229,14 @@ bool validStructResistance(const STRUCTURE *psStruct);
 
 /*checks to see if a specific structure type exists -as opposed to a structure
 stat type*/
-bool checkSpecificStructExists(UDWORD structInc, UDWORD player);
+bool checkSpecificStructExists(const WorldObjectState& objState, UDWORD structInc, UDWORD player);
 
 int32_t getStructureDamage(const STRUCTURE *psStructure);
 
 unsigned structureBodyBuilt(const STRUCTURE *psStruct);  ///< Returns the maximum body points of a structure with the current number of build points.
 UDWORD structureResistance(const STRUCTURE_STATS *psStats, UBYTE player);
 
-void hqReward(UBYTE losingPlayer, UBYTE rewardPlayer);
+void hqReward(GameWorld& world, UBYTE losingPlayer, UBYTE rewardPlayer);
 
 // Is a flag a factory delivery point?
 bool FlagIsFactory(const FLAG_POSITION *psCurrFlag);
@@ -254,7 +258,7 @@ void factoryProdAdjust(STRUCTURE *psStructure, DROID_TEMPLATE *psTemplate, bool 
 ProductionRunEntry getProduction(STRUCTURE *psStructure, DROID_TEMPLATE *psTemplate);
 
 //check that delivery points haven't been put down in invalid location
-void checkDeliveryPoints(UDWORD version);
+void checkDeliveryPoints(GameWorld& world, UDWORD version);
 
 //adjust the loop quantity for this factory
 void factoryLoopAdjust(STRUCTURE *psStruct, bool add);

--- a/src/terrain.cpp
+++ b/src/terrain.cpp
@@ -48,6 +48,7 @@
 #include "lib/ivis_opengl/piematrix.h"
 #include "lib/ivis_opengl/piedraw.h"
 #include "lib/ivis_opengl/pielight_convert.h"
+#include "world_map_state.h"
 #include <glm/mat4x4.hpp>
 #ifndef GLM_ENABLE_EXPERIMENTAL
 	#define GLM_ENABLE_EXPERIMENTAL
@@ -312,44 +313,44 @@ static void averagePos(Vector3i *center, Vector3i *a, Vector3i *b, Vector3i *c, 
 }
 
 /// Is this position next to a water tile?
-static bool isWater(int x, int y)
+static bool isWater(WorldMapState& mapState, int x, int y)
 {
 	bool result = false;
-	result = result || (tileOnMap(gameWorld.map, x  , y) && terrainType(mapTile(gameWorld.map, x  , y)) == TER_WATER);
-	result = result || (tileOnMap(gameWorld.map, x - 1, y) && terrainType(mapTile(gameWorld.map, x - 1, y)) == TER_WATER);
-	result = result || (tileOnMap(gameWorld.map, x  , y - 1) && terrainType(mapTile(gameWorld.map, x  , y - 1)) == TER_WATER);
-	result = result || (tileOnMap(gameWorld.map, x - 1, y - 1) && terrainType(mapTile(gameWorld.map, x - 1, y - 1)) == TER_WATER);
+	result = result || (tileOnMap(mapState, x  , y) && terrainType(mapTile(mapState, x  , y)) == TER_WATER);
+	result = result || (tileOnMap(mapState, x - 1, y) && terrainType(mapTile(mapState, x - 1, y)) == TER_WATER);
+	result = result || (tileOnMap(mapState, x  , y - 1) && terrainType(mapTile(mapState, x  , y - 1)) == TER_WATER);
+	result = result || (tileOnMap(mapState, x - 1, y - 1) && terrainType(mapTile(mapState, x - 1, y - 1)) == TER_WATER);
 	return result;
 }
 
 /// Is this position an *actual* water-only tile?
-static bool isOnlyWater(int x, int y)
+static bool isOnlyWater(WorldMapState& mapState, int x, int y)
 {
 	bool result = true;
-	result = result && (tileOnMap(gameWorld.map, x  , y) && terrainType(mapTile(gameWorld.map, x  , y)) == TER_WATER);
-	result = result && (tileOnMap(gameWorld.map, x - 1, y) && terrainType(mapTile(gameWorld.map, x - 1, y)) == TER_WATER);
-	result = result && (tileOnMap(gameWorld.map, x  , y - 1) && terrainType(mapTile(gameWorld.map, x  , y - 1)) == TER_WATER);
-	result = result && (tileOnMap(gameWorld.map, x - 1, y - 1) && terrainType(mapTile(gameWorld.map, x - 1, y - 1)) == TER_WATER);
+	result = result && (tileOnMap(mapState, x  , y) && terrainType(mapTile(mapState, x  , y)) == TER_WATER);
+	result = result && (tileOnMap(mapState, x - 1, y) && terrainType(mapTile(mapState, x - 1, y)) == TER_WATER);
+	result = result && (tileOnMap(mapState, x  , y - 1) && terrainType(mapTile(mapState, x  , y - 1)) == TER_WATER);
+	result = result && (tileOnMap(mapState, x - 1, y - 1) && terrainType(mapTile(mapState, x - 1, y - 1)) == TER_WATER);
 	return result;
 }
 
 /// Get the position of a grid point
-static void getGridPos(Vector3i *result, int x, int y, bool center, bool water)
+static void getGridPos(const WorldMapState& mapState, Vector3i *result, int x, int y, bool center, bool water)
 {
 	if (center)
 	{
 		Vector3i a, b, c, d;
-		getGridPos(&a, x  , y  , false, water);
-		getGridPos(&b, x + 1, y  , false, water);
-		getGridPos(&c, x  , y + 1, false, water);
-		getGridPos(&d, x + 1, y + 1, false, water);
+		getGridPos(mapState, &a, x  , y  , false, water);
+		getGridPos(mapState, &b, x + 1, y  , false, water);
+		getGridPos(mapState, &c, x  , y + 1, false, water);
+		getGridPos(mapState, &d, x + 1, y + 1, false, water);
 		averagePos(result, &a, &b, &c, &d);
 		return;
 	}
 	result->x = world_coord(x);
 	result->z = world_coord(-y);
 
-	if (x <= 0 || y <= 0 || x >= gameWorld.map.width || y >= gameWorld.map.height)
+	if (x <= 0 || y <= 0 || x >= mapState.width || y >= mapState.height)
 	{
 		result->y = 0;
 	}
@@ -357,28 +358,28 @@ static void getGridPos(Vector3i *result, int x, int y, bool center, bool water)
 	{
 		if (terrainShaderQuality != TerrainShaderQuality::CLASSIC)
 		{
-			result->y = map_TileHeight(gameWorld.map, x, y);
+			result->y = map_TileHeight(mapState, x, y);
 			if (water)
 			{
-				result->y = map_WaterHeight(gameWorld.map, x, y);
+				result->y = map_WaterHeight(mapState, x, y);
 			}
 		}
 		else
 		{
-			result->y = map_TileHeightSurface(gameWorld.map, x, y);
+			result->y = map_TileHeightSurface(mapState, x, y);
 		}
 	}
 }
 
-static Vector3f getGridPosf(int x, int y, bool center = false, bool water = false)
+static Vector3f getGridPosf(const WorldMapState& mapState, int x, int y, bool center = false, bool water = false)
 {
 	Vector3i r;
-	getGridPos(&r, x, y, center, water);
+	getGridPos(mapState, &r, x, y, center, water);
 	return Vector3f(r);
 }
 
 /// Get normal vector of grid point
-static Vector3f getGridNormal(int x, int y, bool center = false)
+static Vector3f getGridNormal(const WorldMapState& mapState, int x, int y, bool center = false)
 {
 	auto calcNormal = [](const Vector3f &pc, const std::vector<Vector3f> &p) {
 		auto res = Vector3f(0.0);
@@ -391,11 +392,11 @@ static Vector3f getGridNormal(int x, int y, bool center = false)
 	};
 	if (center) {
 		// avg nearest normals provide better results
-		return (getGridNormal(x, y) + getGridNormal(x+1, y) + getGridNormal(x+1, y+1) + getGridNormal(x, y+1)) / 4.f;
+		return (getGridNormal(mapState, x, y) + getGridNormal(mapState, x+1, y) + getGridNormal(mapState, x+1, y+1) + getGridNormal(mapState, x, y+1)) / 4.f;
 	} else {
-		return calcNormal(getGridPosf(x, y), {
-			getGridPosf(x+1, y), getGridPosf(x, y, true),     getGridPosf(x, y+1), getGridPosf(x-1, y, true),
-			getGridPosf(x-1, y), getGridPosf(x-1, y-1, true), getGridPosf(x, y-1), getGridPosf(x, y-1, true)
+		return calcNormal(getGridPosf(mapState, x, y), {
+			getGridPosf(mapState, x+1, y), getGridPosf(mapState, x, y, true),     getGridPosf(mapState, x, y+1), getGridPosf(mapState, x-1, y, true),
+			getGridPosf(mapState, x-1, y), getGridPosf(mapState, x-1, y-1, true), getGridPosf(mapState, x, y-1), getGridPosf(mapState, x, y-1, true)
 		});
 	}
 }
@@ -403,7 +404,7 @@ static Vector3f getGridNormal(int x, int y, bool center = false)
 /**
  * Set the terrain and water geometry for the specified sector
  */
-static void setSectorGeometry(int sx, int sy,
+static void setSectorGeometry(const WorldMapState& mapState, int sx, int sy,
 							  TerrainVertex *geometry, WaterVertex *water,
 							  int *geometrySize, int *waterSize)
 {
@@ -412,15 +413,15 @@ static void setSectorGeometry(int sx, int sy,
 		for (int y = sy * sectorSize; y < (sy+1) * sectorSize + 1; y++)
 		{
 			// set up geometry
-			auto pos = getGridPosf(x, y, false, false);
+			auto pos = getGridPosf(mapState, x, y, false, false);
 			geometry[*geometrySize].pos = pos;
 			(*geometrySize)++;
 
-			float waterHeight = map_WaterHeight(gameWorld.map, x, y);
+			float waterHeight = map_WaterHeight(mapState, x, y);
 			water[*waterSize] = glm::vec4(pos.x, (terrainShaderQuality != TerrainShaderQuality::CLASSIC) ? waterHeight : pos.y, pos.z, waterHeight - pos.y);
 			(*waterSize)++;
 
-			pos = getGridPosf(x, y, true, false);
+			pos = getGridPosf(mapState, x, y, true, false);
 			geometry[*geometrySize].pos = pos;
 			(*geometrySize)++;
 
@@ -430,7 +431,7 @@ static void setSectorGeometry(int sx, int sy,
 	}
 }
 
-static void setSectorDecalVertex_SinglePass(int x, int y, gfx_api::TerrainDecalVertex *terrainDecalData, int *terrainDecalSize)
+static void setSectorDecalVertex_SinglePass(WorldMapState& mapState, int x, int y, gfx_api::TerrainDecalVertex *terrainDecalData, int *terrainDecalSize)
 {
 	Vector3i pos;
 	Vector2f uv[2][2], center;
@@ -440,19 +441,19 @@ static void setSectorDecalVertex_SinglePass(int x, int y, gfx_api::TerrainDecalV
 	{
 		for (j = y * sectorSize; j < y * sectorSize + sectorSize; j++)
 		{
-			if (i < 0 || j < 0 || i >= gameWorld.map.width || j >= gameWorld.map.height)
+			if (i < 0 || j < 0 || i >= mapState.width || j >= mapState.height)
 			{
 				continue;
 			}
 
-			MAPTILE *tile = mapTile(gameWorld.map, i, j);
+			MAPTILE *tile = mapTile(mapState, i, j);
 			center = getTileTexArrCoords(*uv, tile->texture);
 			int decalNo = static_cast<int>(TileNumber_tile(tile->texture));
 			bool skipDecalDraw = !TILE_HAS_DECAL(tile);
 			if (terrainShaderQuality == TerrainShaderQuality::CLASSIC)
 			{
 				// in Classic mode, skip drawing any that are the "water only" decal (water is handled separately as a prior pass)
-				skipDecalDraw = skipDecalDraw || (isOnlyWater(i, j) && decalNo == 17); // Magic number hack, but decal # 17 is always the *water only* tile in the legacy terrain tilesets we ship // TODO: Figure out a better way of determining this from the tileset data?
+				skipDecalDraw = skipDecalDraw || (isOnlyWater(mapState, i, j) && decalNo == 17); // Magic number hack, but decal # 17 is always the *water only* tile in the legacy terrain tilesets we ship // TODO: Figure out a better way of determining this from the tileset data?
 			}
 			if (skipDecalDraw)
 			{
@@ -464,22 +465,22 @@ static void setSectorDecalVertex_SinglePass(int x, int y, gfx_api::TerrainDecalV
 			gfx_api::TerrainDecalVertex vs[5];
 			for (int k = 0; k<4; k++) {
 				int dx = dxdy[k][0], dy = dxdy[k][1];
-				getGridPos(&pos, i + dx, j + dy, false, false);
+				getGridPos(mapState, &pos, i + dx, j + dy, false, false);
 				vs[k].pos = pos;
 				vs[k].decalUv = uv[dx][dy];
-				vs[k].normal = getGridNormal(i + dx, j + dy);
+				vs[k].normal = getGridNormal(mapState, i + dx, j + dy);
 				vs[k].decalNo = decalNo;
-				groundsBytes[k] = mapTile(gameWorld.map, i + dx, j + dy)->ground;
+				groundsBytes[k] = mapTile(mapState, i + dx, j + dy)->ground;
 				vs[k].groundWeights.clear();
 				vs[k].groundWeights.setByte(k, 255);
 			}
 			PIELIGHT grounds;
 			grounds.fromRGBA(groundsBytes[0], groundsBytes[1], groundsBytes[2], groundsBytes[3]);
 			// 4 = center;
-			getGridPos(&pos, i, j, true, false);
+			getGridPos(mapState, &pos, i, j, true, false);
 			vs[4].pos = pos;
 			vs[4].decalUv = center;
-			vs[4].normal = getGridNormal(i, j, true);
+			vs[4].normal = getGridNormal(mapState, i, j, true);
 			vs[4].decalNo = decalNo;
 			vs[4].groundWeights = {0, 0, 0, 0}; // special value for shader.
 			for (int k = 0; k < 5; k++) vs[k].grounds = grounds.rgba();
@@ -527,7 +528,7 @@ static void setSectorDecalVertex_SinglePass(int x, int y, gfx_api::TerrainDecalV
 /**
  * Update the sector for when the terrain is changed.
  */
-static void updateSectorGeometry(int x, int y)
+static void updateSectorGeometry(WorldMapState& mapState, int x, int y)
 {
 	TerrainVertex *geometry;
 	WaterVertex *water;
@@ -537,7 +538,7 @@ static void updateSectorGeometry(int x, int y)
 	geometry = new TerrainVertex[sectors[x * ySectors + y].geometrySize];
 	water = (WaterVertex *)malloc(sizeof(WaterVertex) * sectors[x * ySectors + y].waterSize);
 
-	setSectorGeometry(x, y, geometry, water, &geometrySize, &waterSize);
+	setSectorGeometry(mapState, x, y, geometry, water, &geometrySize, &waterSize);
 	ASSERT(geometrySize == sectors[x * ySectors + y].geometrySize, "something went seriously wrong updating the terrain");
 	ASSERT(waterSize    == sectors[x * ySectors + y].waterSize   , "something went seriously wrong updating the terrain");
 
@@ -553,7 +554,7 @@ static void updateSectorGeometry(int x, int y)
 
 	terrainDecalVertexUpdateBuffer.resize(sectors[x * ySectors + y].terrainAndDecalSize); // reuse a buffer to avoid repeated allocations if possible
 	int terrainDecalSize = 0;
-	setSectorDecalVertex_SinglePass(x, y, terrainDecalVertexUpdateBuffer.data(), &terrainDecalSize);
+	setSectorDecalVertex_SinglePass(mapState, x, y, terrainDecalVertexUpdateBuffer.data(), &terrainDecalSize);
 	ASSERT(terrainDecalSize == sectors[x * ySectors + y].terrainAndDecalSize, "Sizes don't match!");
 	terrainDecalVBO->update(sizeof(gfx_api::TerrainDecalVertex)*sectors[x * ySectors + y].terrainAndDecalOffset,
 						 sizeof(gfx_api::TerrainDecalVertex)*sectors[x * ySectors + y].terrainAndDecalSize, terrainDecalVertexUpdateBuffer.data(),
@@ -916,7 +917,7 @@ void reloadTerrainTextures()
  * Check what the videocard + drivers support and divide the loaded map into sectors that can be drawn.
  * It also determines the lightmap size.
  */
-bool initTerrain()
+bool initTerrain(WorldMapState& mapState)
 {
 	int i, j, x, y;
 
@@ -979,8 +980,8 @@ bool initTerrain()
 
 	/////////////////////
 	// Create the sectors
-	xSectors = (gameWorld.map.width + sectorSize - 1) / sectorSize;
-	ySectors = (gameWorld.map.height + sectorSize - 1) / sectorSize;
+	xSectors = (mapState.width + sectorSize - 1) / sectorSize;
+	ySectors = (mapState.height + sectorSize - 1) / sectorSize;
 	sectors = std::unique_ptr<Sector[]> (new Sector[xSectors * ySectors]());
 
 	////////////////////
@@ -1005,7 +1006,7 @@ bool initTerrain()
 			sectors[x * ySectors + y].waterOffset = waterSize;
 			sectors[x * ySectors + y].waterSize = 0;
 
-			setSectorGeometry(x, y, geometry, water, &geometrySize, &waterSize);
+			setSectorGeometry(mapState, x, y, geometry, water, &geometrySize, &waterSize);
 
 			sectors[x * ySectors + y].geometrySize = geometrySize - sectors[x * ySectors + y].geometryOffset;
 			sectors[x * ySectors + y].waterSize = waterSize - sectors[x * ySectors + y].waterOffset;
@@ -1019,7 +1020,7 @@ bool initTerrain()
 			{
 				for (j = 0; j < sectorSize; j++)
 				{
-					if (x * sectorSize + i >= gameWorld.map.width || y * sectorSize + j >= gameWorld.map.height)
+					if (x * sectorSize + i >= mapState.width || y * sectorSize + j >= mapState.height)
 					{
 						continue; // off map, so skip
 					}
@@ -1053,7 +1054,7 @@ bool initTerrain()
 					geometryIndex[geometryIndexSize + 10] = q(i + 1, j  , 0);	// Bottom right
 					geometryIndex[geometryIndexSize + 11] = q(i + 1, j + 1, 0);	// Top right
 					geometryIndexSize += 12;
-					if (isWater(i + x * sectorSize, j + y * sectorSize))
+					if (isWater(mapState, i + x * sectorSize, j + y * sectorSize))
 					{
 						waterIndex[waterIndexSize + 0]  = q(i  , j  , 1);
 						waterIndex[waterIndexSize + 1]  = q(i  , j  , 0);
@@ -1111,7 +1112,7 @@ bool initTerrain()
 
 
 	// and finally the decals
-	gfx_api::TerrainDecalVertex *terrainDecalData = (gfx_api::TerrainDecalVertex *)malloc(sizeof(gfx_api::TerrainDecalVertex) * gameWorld.map.width * gameWorld.map.height * 12);
+	gfx_api::TerrainDecalVertex *terrainDecalData = (gfx_api::TerrainDecalVertex *)malloc(sizeof(gfx_api::TerrainDecalVertex) * mapState.width * mapState.height * 12);
 	int terrainDecalSize = 0;
 
 	for (x = 0; x < xSectors; x++)
@@ -1120,7 +1121,7 @@ bool initTerrain()
 		{
 				sectors[x * ySectors + y].terrainAndDecalOffset = terrainDecalSize;
 				sectors[x * ySectors + y].terrainAndDecalSize = 0;
-				setSectorDecalVertex_SinglePass(x, y, terrainDecalData, &terrainDecalSize);
+				setSectorDecalVertex_SinglePass(mapState, x, y, terrainDecalData, &terrainDecalSize);
 				sectors[x * ySectors + y].terrainAndDecalSize = terrainDecalSize - sectors[x * ySectors + y].terrainAndDecalOffset;
 		}
 	}
@@ -1147,13 +1148,13 @@ bool initTerrain()
 	lightmapWidth = 1;
 	lightmapHeight = 1;
 	// determine the smallest power-of-two size we can use for the lightmap
-	while (gameWorld.map.width > (lightmapWidth <<= 1)) {}
-	while (gameWorld.map.height > (lightmapHeight <<= 1)) {}
-	debug(LOG_TERRAIN, "the size of the map is %ix%i", gameWorld.map.width, gameWorld.map.height);
+	while (mapState.width > (lightmapWidth <<= 1)) {}
+	while (mapState.height > (lightmapHeight <<= 1)) {}
+	debug(LOG_TERRAIN, "the size of the map is %ix%i", mapState.width, mapState.height);
 	debug(LOG_TERRAIN, "lightmap texture size is %zu x %zu", lightmapWidth, lightmapHeight);
 
-	lightmapValues.paramsXLight = glm::vec4(1.0f / world_coord(gameWorld.map.width) *((float)gameWorld.map.width / (float)lightmapWidth), 0, 0, 0);
-	lightmapValues.paramsYLight = glm::vec4(0, 0, -1.0f / world_coord(gameWorld.map.height) *((float)gameWorld.map.height / (float)lightmapHeight), 0);
+	lightmapValues.paramsXLight = glm::vec4(1.0f / world_coord(mapState.width) *((float)mapState.width / (float)lightmapWidth), 0, 0, 0);
+	lightmapValues.paramsYLight = glm::vec4(0, 0, -1.0f / world_coord(mapState.height) *((float)mapState.height / (float)lightmapHeight), 0);
 
 	// shift the lightmap half a tile as lights are supposed to be placed at the center of a tile
 	lightmapValues.lightMatrix = glm::translate(glm::vec3(1.f / (float)lightmapWidth / 2, 1.f / (float)lightmapHeight / 2, 0.f));
@@ -1216,15 +1217,15 @@ void shutdownTerrain()
 	terrainInitialised = false;
 }
 
-static void updateLightMap(const LightMap& lightmap)
+static void updateLightMap(WorldMapState& mapState, const LightMap& lightmap)
 {
 	size_t lightmapChannels = lightmapPixmap->channels(); // should always be 4 now...
 	unsigned char* lightMapWritePtr = lightmapPixmap->bmp_w();
-	for (int j = 0; j < gameWorld.map.height; ++j)
+	for (int j = 0; j < mapState.height; ++j)
 	{
-		for (int i = 0; i < gameWorld.map.width; ++i)
+		for (int i = 0; i < mapState.width; ++i)
 		{
-			MAPTILE *psTile = mapTile(gameWorld.map, i, j);
+			MAPTILE *psTile = mapTile(mapState, i, j);
 			PIELIGHT colour = lightmap(i, j);
 			UBYTE level = static_cast<UBYTE>(psTile->level);
 
@@ -1295,7 +1296,7 @@ static void updateLightMap(const LightMap& lightmap)
 	}
 }
 
-static void cullTerrain()
+static void cullTerrain(WorldMapState& mapState)
 {
 	for (int x = 0; x < xSectors; x++)
 	{
@@ -1314,7 +1315,7 @@ static void cullTerrain()
 				sectors[x * ySectors + y].draw = true;
 				if (sectors[x * ySectors + y].dirty)
 				{
-					updateSectorGeometry(x, y);
+					updateSectorGeometry(mapState, x, y);
 					sectors[x * ySectors + y].dirty = false;
 				}
 			}
@@ -1488,7 +1489,7 @@ static void drawTerrainCombined(const glm::mat4 &ModelViewProjection, const glm:
 
 }
 
-void perFrameTerrainUpdates(const LightMap& lightMap)
+void perFrameTerrainUpdates(WorldMapState& mapState, const LightMap& lightMap)
 {
 	WZ_PROFILE_SCOPE(perFrameTerrainUpdates);
 	///////////////////////////////////
@@ -1498,14 +1499,14 @@ void perFrameTerrainUpdates(const LightMap& lightMap)
 	if (realTime - lightmapLastUpdate >= LIGHTMAP_REFRESH)
 	{
 		lightmapLastUpdate = realTime;
-		updateLightMap(lightMap);
+		updateLightMap(mapState, lightMap);
 
 		lightmap_texture->upload(0, *(lightmapPixmap.get()));
 	}
 
 	///////////////////////////////////
 	// terrain culling
-	cullTerrain();
+	cullTerrain(mapState);
 }
 
 gfx_api::texture* getTerrainLightmapTexture()

--- a/src/terrain.h
+++ b/src/terrain.h
@@ -28,13 +28,14 @@
 
 struct ShadowCascadesInfo;
 struct LightMap;
+struct WorldMapState;
 
 void loadTerrainTextures(MAP_TILESET mapTileset);
 
-bool initTerrain();
+bool initTerrain(WorldMapState& mapState);
 void shutdownTerrain();
 
-void perFrameTerrainUpdates(const LightMap& lightData);
+void perFrameTerrainUpdates(WorldMapState& mapState, const LightMap& lightData);
 void drawTerrainDepthOnly(const glm::mat4 &mvp);
 void drawTerrain(const glm::mat4 &mvp, const glm::mat4& viewMatrix, const Vector3f &cameraPos, const Vector3f &sunPos, const ShadowCascadesInfo& shadowMVPMatrix);
 void drawWater(const glm::mat4 &ModelViewProjection, const glm::mat4& viewMatrix, const Vector3f &cameraPos, const Vector3f &sunPos, const ShadowCascadesInfo& shadowCascades);

--- a/src/transporter.cpp
+++ b/src/transporter.cpp
@@ -938,12 +938,12 @@ void transporterRemoveDroid(DROID *psTransport, DROID *psDroid, QUEUE_MODE mode)
 			//pick a tile because save games won't remember where the droid was when it was loaded
 			droidPos = map_coord(Vector2i(getLandingX(0), getLandingY(0)));
 		}
-		if (!pickATileGen(&droidPos, LOOK_FOR_EMPTY_TILE, zonedPAT))
+		if (!pickATileGen(gameWorld, &droidPos, LOOK_FOR_EMPTY_TILE, zonedPAT))
 		{
 			ASSERT(false, "Unable to find a valid location");
 		}
 		droidSetPosition(psDroid, world_coord(droidPos.x), world_coord(droidPos.y));
-		updateDroidOrientation(psDroid);
+		updateDroidOrientation(psDroid, gameWorld.map);
 	}
 
 	// remove it from the transporter group
@@ -964,7 +964,7 @@ void transporterRemoveDroid(DROID *psTransport, DROID *psDroid, QUEUE_MODE mode)
 	{
 		// We can update the orders now, since everyone has been
 		// notified of the droid exiting the transporter
-		updateDroidOrientation(psDroid);
+		updateDroidOrientation(psDroid, gameWorld.map);
 	}
 	//initialise the movement data
 	initDroidMovement(psDroid);
@@ -1099,7 +1099,7 @@ void transporterAddDroid(DROID *psTransporter, DROID *psDroidToAdd)
 	}
 	else
 	{
-		visRemoveVisibility((BASE_OBJECT *)psDroidToAdd);
+		visRemoveVisibility((BASE_OBJECT *)psDroidToAdd, gameWorld.map);
 	}
 	fpathRemoveDroidData(psDroidToAdd->id);
 
@@ -1257,7 +1257,7 @@ bool updateTransporter(DROID *psTransporter)
 		//Remove visibility so tiles are not bright around where the transporter left the map
 		if (psTransporter->action != DACTION_TRANSPORTIN)
 		{
-			visRemoveVisibility((BASE_OBJECT *) psTransporter);
+			visRemoveVisibility((BASE_OBJECT *) psTransporter, gameWorld.map);
 		}
 
 		// Got to destination

--- a/src/visibility.cpp
+++ b/src/visibility.cpp
@@ -63,8 +63,8 @@ static SDWORD			visLevelInc, visLevelDec;
 class SPOTTER
 {
 public:
-	SPOTTER(int x, int y, int plr, int radius, int type, uint32_t expiry = 0)
-		: pos(x, y, 0), player(plr), sensorRadius(radius), sensorType(type), expiryTime(expiry), numWatchedTiles(0), watchedTiles(nullptr)
+	SPOTTER(WorldMapState& mapState, int x, int y, int plr, int radius, int type, uint32_t expiry = 0)
+		: pos(x, y, 0), player(plr), sensorRadius(radius), sensorType(type), expiryTime(expiry), numWatchedTiles(0), watchedTiles(nullptr), mapState(mapState)
 	{
 		id = generateSynchronisedObjectId();
 	}
@@ -78,6 +78,7 @@ public:
 	int numWatchedTiles;
 	TILEPOS *watchedTiles;
 	uint32_t id;
+	WorldMapState& mapState;
 };
 static std::vector<SPOTTER *> apsInvisibleViewers;
 
@@ -130,10 +131,10 @@ static inline void updateTileVis(MAPTILE *psTile, int player)
 	}
 }
 
-uint32_t addSpotter(int x, int y, int player, int radius, bool radar, uint32_t expiry)
+uint32_t addSpotter(WorldMapState& mapState, int x, int y, int player, int radius, bool radar, uint32_t expiry)
 {
 	ASSERT_OR_RETURN(0, player >= 0 && player < MAX_PLAYERS, "invalid player: %d", player);
-	SPOTTER *psSpot = new SPOTTER(x, y, player, radius, (int)radar, expiry);
+	SPOTTER *psSpot = new SPOTTER(mapState, x, y, player, radius, (int)radar, expiry);
 	size_t size;
 	const WavecastTile *tiles = getWavecastTable(radius, &size);
 	psSpot->watchedTiles = (TILEPOS *)malloc(size * sizeof(*psSpot->watchedTiles));
@@ -141,11 +142,11 @@ uint32_t addSpotter(int x, int y, int player, int radius, bool radar, uint32_t e
 	{
 		const int mapX = x + tiles[i].dx;
 		const int mapY = y + tiles[i].dy;
-		if (mapX < 0 || mapX >= gameWorld.map.width || mapY < 0 || mapY >= gameWorld.map.height)
+		if (mapX < 0 || mapX >= mapState.width || mapY < 0 || mapY >= mapState.height)
 		{
 			continue;
 		}
-		MAPTILE *psTile = mapTile(gameWorld.map, mapX, mapY);
+		MAPTILE *psTile = mapTile(mapState, mapX, mapY);
 		psTile->tileExploredBits |= alliancebits[player];
 		uint16_t *visionType = (!radar) ? psTile->watchers : psTile->sensors;
 		if (visionType[player] < UINT16_MAX)
@@ -214,7 +215,7 @@ SPOTTER::~SPOTTER()
 	for (int i = 0; i < numWatchedTiles; i++)
 	{
 		const TILEPOS tilePos = watchedTiles[i];
-		MAPTILE *psTile = mapTile(gameWorld.map, tilePos.x, tilePos.y);
+		MAPTILE *psTile = mapTile(mapState, tilePos.x, tilePos.y);
 		uint16_t *visionType = (tilePos.type == 0) ? psTile->watchers : psTile->sensors;
 		ASSERT(visionType[player] > 0, "Not watching watched tile (%d, %d)", (int)tilePos.x, (int)tilePos.y);
 		visionType[player]--;
@@ -251,7 +252,7 @@ static inline void visMarkTile(const BASE_OBJECT *psObj, int mapX, int mapY, MAP
 }
 
 /* The terrain revealing ray callback */
-static void doWaveTerrain(BASE_OBJECT *psObj)
+static void doWaveTerrain(BASE_OBJECT *psObj, WorldMapState& mapState)
 {
 	if (psObj == nullptr)
 	{
@@ -283,12 +284,12 @@ static void doWaveTerrain(BASE_OBJECT *psObj)
 	{
 		const int mapX = map_coord(sx) + tiles[i].dx;
 		const int mapY = map_coord(sy) + tiles[i].dy;
-		if (mapX < 0 || mapX >= gameWorld.map.width || mapY < 0 || mapY >= gameWorld.map.height)
+		if (mapX < 0 || mapX >= mapState.width || mapY < 0 || mapY >= mapState.height)
 		{
 			continue;
 		}
 
-		MAPTILE *psTile = mapTile(gameWorld.map, mapX, mapY);
+		MAPTILE *psTile = mapTile(mapState, mapX, mapY);
 		int tileHeight = std::max(psTile->height, psTile->waterLevel);  // If we can see the water surface, then let us see water-covered tiles too.
 		int perspectiveHeight = (tileHeight - sz) * tiles[i].invRadius;
 		int perspectiveHeightLeeway = (tileHeight - sz + MIN_VIS_HEIGHT) * tiles[i].invRadius;
@@ -340,11 +341,11 @@ static void doWaveTerrain(BASE_OBJECT *psObj)
 }
 
 /* The los ray callback */
-static bool rayLOSCallback(Vector2i pos, int32_t dist, void *data)
+static bool rayLOSCallback(WorldMapState& mapState, Vector2i pos, int32_t dist, void *data)
 {
 	VisibleObjectHelp_t *help = (VisibleObjectHelp_t *)data;
 
-	ASSERT(pos.x >= 0 && pos.x < world_coord(gameWorld.map.width) && pos.y >= 0 && pos.y < world_coord(gameWorld.map.height), "rayLOSCallback: coords off map");
+	ASSERT(pos.x >= 0 && pos.x < world_coord(mapState.width) && pos.y >= 0 && pos.y < world_coord(mapState.height), "rayLOSCallback: coords off map");
 
 	if (help->rayStart)
 	{
@@ -361,7 +362,7 @@ static bool rayLOSCallback(Vector2i pos, int32_t dist, void *data)
 	}
 
 	help->lastDist = dist;
-	help->lastHeight = map_Height(gameWorld.map, pos.x, pos.y);
+	help->lastHeight = map_Height(mapState, pos.x, pos.y);
 
 	if (help->wallsBlock)
 	{
@@ -370,7 +371,7 @@ static bool rayLOSCallback(Vector2i pos, int32_t dist, void *data)
 
 		if (tile != help->final)
 		{
-			MAPTILE *psTile = mapTile(gameWorld.map, tile);
+			MAPTILE *psTile = mapTile(mapState, tile);
 			if (TileHasWall_raycast(psTile) && !TileHasSmallStructure(psTile))
 			{
 				STRUCTURE *psStruct = (STRUCTURE *)psTile->psObject;
@@ -389,14 +390,14 @@ static bool rayLOSCallback(Vector2i pos, int32_t dist, void *data)
 
 
 /* Remove tile visibility from object */
-void visRemoveVisibility(BASE_OBJECT *psObj)
+void visRemoveVisibility(BASE_OBJECT *psObj, WorldMapState& mapState)
 {
-	if (gameWorld.map.width && gameWorld.map.height)
+	if (mapState.width && mapState.height)
 	{
 		for (TILEPOS pos : psObj->watchedTiles)
 		{
 			// FIXME: the mapTile might have been swapped out, see swapMissionPointers()
-			MAPTILE *psTile = mapTile(gameWorld.map, pos.x, pos.y);
+			MAPTILE *psTile = mapTile(mapState, pos.x, pos.y);
 
 			ASSERT(pos.type < 2, "Invalid visibility type %d", (int)pos.type);
 			uint16_t *visionType = (pos.type == 0) ? psTile->sensors : psTile->watchers;
@@ -429,12 +430,12 @@ void visRemoveVisibilityOffWorld(BASE_OBJECT *psObj)
 }
 
 /* Check which tiles can be seen by an object */
-void visTilesUpdate(BASE_OBJECT *psObj)
+void visTilesUpdate(BASE_OBJECT *psObj, WorldMapState& mapState)
 {
 	ASSERT(psObj->type != OBJ_FEATURE, "visTilesUpdate: visibility updates are not for features!");
 
 	// Remove previous map visibility provided by object
-	visRemoveVisibility(psObj);
+	visRemoveVisibility(psObj, mapState);
 
 	if (psObj->type == OBJ_STRUCTURE)
 	{
@@ -449,11 +450,11 @@ void visTilesUpdate(BASE_OBJECT *psObj)
 
 	// Do the whole circle in ∞ steps. No more pretty moiré patterns.
 	psObj->flags.set(OBJECT_FLAG_JAMMED_TILES, objJammerPower(psObj) > 0);
-	doWaveTerrain(psObj);
+	doWaveTerrain(psObj, mapState);
 }
 
 /*reveals all the terrain in the map*/
-void revealAll(UBYTE player)
+void revealAll(WorldMapState& mapState, UBYTE player)
 {
 	SDWORD   i, j;
 	MAPTILE	*psTile;
@@ -464,11 +465,11 @@ void revealAll(UBYTE player)
 	}
 
 	//reveal all tiles
-	for (j = 0; j < gameWorld.map.height; j++)
+	for (j = 0; j < mapState.height; j++)
 	{
-		for (i = 0; i < gameWorld.map.width; i++)
+		for (i = 0; i < mapState.width; i++)
 		{
-			psTile = mapTile(gameWorld.map, i, j);
+			psTile = mapTile(mapState, i, j);
 			psTile->tileExploredBits |= alliancebits[player];
 		}
 	}
@@ -579,7 +580,7 @@ int visibleObject(const BASE_OBJECT *psViewer, const BASE_OBJECT *psTarget, bool
 	};
 
 	// Cast a ray from the viewer to the target
-	rayCast(psViewer->pos.xy(), psTarget->pos.xy(), rayLOSCallback, &help);
+	rayCast(gameWorld.map, psViewer->pos.xy(), psTarget->pos.xy(), rayLOSCallback, &help);
 
 	if (gWall != nullptr && gNumWalls != nullptr) // Out globals are set
 	{

--- a/src/visibility.h
+++ b/src/visibility.h
@@ -28,13 +28,15 @@
 
 #define LINE_OF_FIRE_MINIMUM 5
 
+struct WorldMapState;
+
 // initialise the visibility stuff
 bool visInitialise();
 
 /* Check which tiles can be seen by an object */
-void visTilesUpdate(BASE_OBJECT *psObj);
+void visTilesUpdate(BASE_OBJECT *psObj, WorldMapState& mapState);
 
-void revealAll(UBYTE player);
+void revealAll(WorldMapState& mapState, UBYTE player);
 
 /* Check whether psViewer can see psTarget
  * psViewer should be an object that has some form of sensor,
@@ -65,7 +67,7 @@ void visUpdateLevel();
 void setUnderTilesVis(BASE_OBJECT *psObj, UDWORD player);
 
 void visRemoveVisibilityOffWorld(BASE_OBJECT *psObj);
-void visRemoveVisibility(BASE_OBJECT *psObj);
+void visRemoveVisibility(BASE_OBJECT *psObj, WorldMapState& mapState);
 
 // fast test for whether obj2 is in range of obj1
 static inline bool visObjInRange(const BASE_OBJECT *psObj1, const BASE_OBJECT *psObj2, SDWORD range)
@@ -115,6 +117,6 @@ static inline int objJammerPower(const BASE_OBJECT *psObj)
 
 void removeSpotters();
 bool removeSpotter(uint32_t id);
-uint32_t addSpotter(int x, int y, int player, int radius, bool radar, uint32_t expiry = 0);
+uint32_t addSpotter(WorldMapState& mapState, int x, int y, int player, int radius, bool radar, uint32_t expiry = 0);
 
 #endif // __INCLUDED_SRC_VISIBILITY__

--- a/src/warcam.cpp
+++ b/src/warcam.cpp
@@ -725,7 +725,7 @@ static void updateCameraRotationAcceleration(UBYTE update)
 			uint16_t pitch;
 			unsigned group = trackingCamera.target->selected ? GROUP_SELECTED : trackingCamera.target->group;
 			getTrackingConcerns(&xPos, &yPos, &zPos, GROUP_SELECTED, true);  // FIXME Should this be group instead of GROUP_SELECTED?
-			getBestPitchToEdgeOfGrid(xPos, zPos, DEG(180) - getAverageTrackAngle(group, true), &pitch);
+			getBestPitchToEdgeOfGrid(gameWorld.map, xPos, zPos, DEG(180) - getAverageTrackAngle(group, true), &pitch);
 			pitch = MAX(angleDelta(pitch), DEG(14));
 			xConcern = -pitch;
 		}
@@ -881,7 +881,7 @@ static bool camTrackCamera()
 	}
 
 	/* Clip the position to the edge of the map */
-	CheckScrollLimits();
+	CheckScrollLimits(gameWorld.map);
 
 	/* Store away our last update as acceleration and velocity are all fn()/dt */
 	trackingCamera.lastUpdate = realTime;
@@ -925,7 +925,7 @@ DROID *getTrackingDroid()
 //-----------------------------------------------------------------------------------
 UDWORD	getNumDroidsSelected()
 {
-	return (selNumSelected(selectedPlayer));
+	return (selNumSelected(gameWorld.objects, selectedPlayer));
 }
 
 //-----------------------------------------------------------------------------------
@@ -975,7 +975,7 @@ void	camToggleInfo()
 void requestRadarTrack(SDWORD x, SDWORD y)
 {
 	auto initialPosition = Vector3f(playerPos.p);
-	auto targetPosition = Vector3f(x, calculateCameraHeightAt(map_coord(x), map_coord(y)), y);
+	auto targetPosition = Vector3f(x, calculateCameraHeightAt(gameWorld.map, map_coord(x), map_coord(y)), y);
 	auto animationDuration = static_cast<uint32_t>(glm::log(glm::length(targetPosition - initialPosition)) * 100);
 	auto finalRotation = trackingCamera.status == CAM_TRACK_DROID ? trackingCamera.oldView.r : playerPos.r;
 	finalRotation.z = 0;

--- a/src/world_map_state.h
+++ b/src/world_map_state.h
@@ -86,5 +86,6 @@ struct WorldMapState
 	std::unique_ptr<uint8_t[]> blockMap[AUX_MAX];
 	std::unique_ptr<uint8_t[]> auxMap[MAX_PLAYERS + AUX_MAX]; ///< yes, we waste one element... eyes wide open... makes API nicer
 	WorldScrollLimits scroll;
+	/// the list of gateways on the current map
 	GATEWAY_LIST gateways;
 };

--- a/src/wzapi.cpp
+++ b/src/wzapi.cpp
@@ -112,8 +112,8 @@ BASE_OBJECT *IdToObject(OBJECT_TYPE type, int id, int player)
 {
 	switch (type)
 	{
-	case OBJ_DROID: return IdToDroid(id, player);
-	case OBJ_FEATURE: return IdToFeature(id, player);
+	case OBJ_DROID: return IdToDroid(gameWorld.objects, id, player);
+	case OBJ_FEATURE: return IdToFeature(gameWorld.objects, id, player);
 	case OBJ_STRUCTURE: return IdToStruct(id, player);
 	default: return nullptr;
 	}
@@ -404,7 +404,7 @@ bool wzapi::setAssemblyPoint(WZAPI_PARAMS(STRUCTURE *psStruct, int x, int y))
 	SCRIPT_ASSERT(false, context, psStruct->pStructureType->type == REF_FACTORY
 	              || psStruct->pStructureType->type == REF_CYBORG_FACTORY
 	              || psStruct->pStructureType->type == REF_VTOL_FACTORY, "Structure not a factory");
-	setAssemblyPoint(((FACTORY *)psStruct->pFunctionality)->psAssemblyPoint, x, y, psStruct->player, true);
+	setAssemblyPoint(gameWorld, ((FACTORY *)psStruct->pFunctionality)->psAssemblyPoint, x, y, psStruct->player, true);
 	return true;
 }
 
@@ -544,7 +544,7 @@ bool wzapi::cameraTrack(WZAPI_PARAMS(optional<DROID *> _droid))
 //--
 uint32_t wzapi::addSpotter(WZAPI_PARAMS(int x, int y, int player, int range, bool radar, uint32_t expiry))
 {
-	return ::addSpotter(x, y, player, range, radar, expiry);
+	return ::addSpotter(gameWorld.map, x, y, player, range, radar, expiry);
 }
 
 //-- ## removeSpotter(spotterId)
@@ -703,7 +703,7 @@ bool wzapi::getRevealStatus(WZAPI_NO_PARAMS)
 bool wzapi::setRevealStatus(WZAPI_PARAMS(bool status))
 {
 	::setRevealStatus(status);
-	preProcessVisibility();
+	preProcessVisibility(gameWorld.map);
 	return true;
 }
 
@@ -1212,7 +1212,7 @@ std::vector<const BASE_OBJECT *> wzapi::enumSelected(WZAPI_NO_PARAMS_NO_CONTEXT)
 //--
 GATEWAY_LIST wzapi::enumGateways(WZAPI_NO_PARAMS)
 {
-	return gwGetGateways();
+	return gwGetGateways(gameWorld.map);
 }
 
 //-- ## getResearch(researchName[, player])
@@ -1516,7 +1516,7 @@ static bool structDoubleCheck(BASE_STATS *psStat, UDWORD xx, UDWORD yy, SDWORD m
 	yBR = (yy + psBuilding->baseBreadth);
 
 	// check against building in a gateway, as this can seriously block AI passages
-	for (auto psGate : gwGetGateways())
+	for (auto psGate : gwGetGateways(gameWorld.map))
 	{
 		for (x = xx; x <= xBR; x++)
 		{
@@ -1534,7 +1534,7 @@ static bool structDoubleCheck(BASE_STATS *psStat, UDWORD xx, UDWORD yy, SDWORD m
 	y = yTL;	// top
 	for (x = xTL; x != xBR + 1; x++)
 	{
-		if (fpathBlockingTile(x, y, propType))
+		if (fpathBlockingTile(gameWorld.map, x, y, propType))
 		{
 			count++;
 			break;
@@ -1544,7 +1544,7 @@ static bool structDoubleCheck(BASE_STATS *psStat, UDWORD xx, UDWORD yy, SDWORD m
 	y = yBR;	// bottom
 	for (x = xTL; x != xBR + 1; x++)
 	{
-		if (fpathBlockingTile(x, y, propType))
+		if (fpathBlockingTile(gameWorld.map, x, y, propType))
 		{
 			count++;
 			break;
@@ -1554,7 +1554,7 @@ static bool structDoubleCheck(BASE_STATS *psStat, UDWORD xx, UDWORD yy, SDWORD m
 	x = xTL;	// left
 	for (y = yTL + 1; y != yBR; y++)
 	{
-		if (fpathBlockingTile(x, y, propType))
+		if (fpathBlockingTile(gameWorld.map, x, y, propType))
 		{
 			count++;
 			break;
@@ -1564,7 +1564,7 @@ static bool structDoubleCheck(BASE_STATS *psStat, UDWORD xx, UDWORD yy, SDWORD m
 	x = xBR;	// right
 	for (y = yTL + 1; y != yBR; y++)
 	{
-		if (fpathBlockingTile(x, y, propType))
+		if (fpathBlockingTile(gameWorld.map, x, y, propType))
 		{
 			count++;
 			break;
@@ -1610,8 +1610,8 @@ optional<scr_position> wzapi::pickStructLocation(WZAPI_PARAMS(const DROID *psDro
 
 	// save a lot of typing... checks whether a position is valid
 #define LOC_OK(_x, _y) (tileOnMap(gameWorld.map, _x, _y) && \
-                        (!psDroid || fpathCheck(psDroid->pos, Vector3i(world_coord(_x), world_coord(_y), 0), propType)) \
-                        && validLocation(psStat, world_coord(Vector2i(_x, _y)) + offset, 0, player, false) && structDoubleCheck(psStat, _x, _y, maxBlockingTiles, propType))
+                        (!psDroid || fpathCheck(gameWorld.map, psDroid->pos, Vector3i(world_coord(_x), world_coord(_y), 0), propType)) \
+                        && validLocation(gameWorld, psStat, world_coord(Vector2i(_x, _y)) + offset, 0, player, false) && structDoubleCheck(psStat, _x, _y, maxBlockingTiles, propType))
 
 	// first try the original location
 	if (LOC_OK(startX, startY))
@@ -1692,7 +1692,7 @@ bool wzapi::structureCanFit(WZAPI_PARAMS(std::string structureName, int x, int y
 	uint16_t direction = static_cast<uint16_t>(DEG(_direction.value_or(0)));
 
 	return (tileOnMap(gameWorld.map, x, y)
-			&& validLocation(psStat, world_coord(Vector2i(x, y)), direction, player, false));
+			&& validLocation(gameWorld, psStat, world_coord(Vector2i(x, y)), direction, player, false));
 }
 
 //-- ## droidCanReach(droid, x, y)
@@ -1704,7 +1704,7 @@ bool wzapi::droidCanReach(WZAPI_PARAMS(const DROID *psDroid, int x, int y))
 {
 	SCRIPT_ASSERT(false, context, psDroid, "No valid droid provided");
 	const PROPULSION_STATS* psPropStats = psDroid->getPropulsionStats();
-	return fpathCheck(psDroid->pos, Vector3i(world_coord(x), world_coord(y), 0), psPropStats->propulsionType);
+	return fpathCheck(gameWorld.map, psDroid->pos, Vector3i(world_coord(x), world_coord(y), 0), psPropStats->propulsionType);
 }
 
 //-- ## propulsionCanReach(propulsionName, x1, y1, x2, y2)
@@ -1717,7 +1717,7 @@ bool wzapi::propulsionCanReach(WZAPI_PARAMS(std::string propulsionName, int x1, 
 	int propulsionIndex = getCompFromName(COMP_PROPULSION, WzString::fromUtf8(propulsionName));
 	SCRIPT_ASSERT(false, context, propulsionIndex > 0, "No such propulsion: %s", propulsionName.c_str());
 	const PROPULSION_STATS *psPropStats = &asPropulsionStats[propulsionIndex];
-	return fpathCheck(Vector3i(world_coord(x1), world_coord(y1), 0), Vector3i(world_coord(x2), world_coord(y2), 0), psPropStats->propulsionType);
+	return fpathCheck(gameWorld.map, Vector3i(world_coord(x1), world_coord(y1), 0), Vector3i(world_coord(x2), world_coord(y2), 0), psPropStats->propulsionType);
 }
 
 //-- ## terrainType(x, y)
@@ -1953,7 +1953,7 @@ wzapi::returned_nullable_ptr<const DROID> wzapi::addDroid(WZAPI_PARAMS(int playe
 		}
 		else
 		{
-			psDroid = ::buildDroid(psTemplate.get(), world_coord(x) + TILE_UNITS / 2, world_coord(y) + TILE_UNITS / 2, player, onMission, nullptr);
+			psDroid = ::buildDroid(gameWorld, psTemplate.get(), world_coord(x) + TILE_UNITS / 2, world_coord(y) + TILE_UNITS / 2, player, onMission, nullptr);
 			if (psDroid)
 			{
 				addDroid(psDroid, gameWorld.objects.droids);
@@ -1994,12 +1994,12 @@ bool wzapi::addDroidToTransporter(WZAPI_PARAMS(game_object_identifier transporte
 {
 	int transporterId = transporter.id;
 	int transporterPlayer = transporter.player;
-	DROID *psTransporter = IdToMissionDroid(transporterId, transporterPlayer);
+	DROID *psTransporter = IdToDroid(mission.gameWorld.objects, transporterId, transporterPlayer);
 	SCRIPT_ASSERT(false, context, psTransporter, "No such transporter id %d belonging to player %d", transporterId, transporterPlayer);
 	SCRIPT_ASSERT(false, context, psTransporter->isTransporter(), "Droid id %d belonging to player %d is not a transporter", transporterId, transporterPlayer);
 	int droidId = droid.id;
 	int droidPlayer = droid.player;
-	DROID *psDroid = IdToMissionDroid(droidId, droidPlayer);
+	DROID *psDroid = IdToDroid(mission.gameWorld.objects, droidId, droidPlayer);
 	SCRIPT_ASSERT(false, context, psDroid, "No such droid id %d belonging to player %d", droidId, droidPlayer);
 	SCRIPT_ASSERT(false, context, checkTransporterSpace(psTransporter, psDroid), "Not enough room in transporter %d for droid %d", transporterId, droidId);
 	bool removeSuccessful = droidRemove(psDroid, mission.gameWorld.objects.droids);
@@ -2023,7 +2023,7 @@ wzapi::returned_nullable_ptr<const FEATURE> wzapi::addFeature(WZAPI_PARAMS(std::
 		SCRIPT_ASSERT(nullptr, context, map_coord(psFeat->pos.x) != x || map_coord(psFeat->pos.y) != y,
 		              "Building feature on tile already occupied");
 	}
-	FEATURE *psFeature = buildFeature(psStats, world_coord(x), world_coord(y), false);
+	FEATURE *psFeature = buildFeature(gameWorld.map, psStats, world_coord(x), world_coord(y), false);
 	return psFeature;
 }
 
@@ -3114,13 +3114,13 @@ wzapi::no_return_value wzapi::setScrollLimits(WZAPI_PARAMS(int x1, int y1, int x
 	gameWorld.map.scroll.maxY = maxY;
 
 	// When the scroll limits change midgame - need to redo the lighting
-	initLighting(prevMinX < gameWorld.map.scroll.minX ? prevMinX : gameWorld.map.scroll.minX,
+	initLighting(gameWorld.map, prevMinX < gameWorld.map.scroll.minX ? prevMinX : gameWorld.map.scroll.minX,
 	             prevMinY < gameWorld.map.scroll.minY ? prevMinY : gameWorld.map.scroll.minY,
 	             prevMaxX < gameWorld.map.scroll.maxX ? prevMaxX : gameWorld.map.scroll.maxX,
 	             prevMaxY < gameWorld.map.scroll.maxY ? prevMaxY : gameWorld.map.scroll.maxY);
 
 	// need to reset radar to take into account of new size
-	resizeRadar();
+	resizeRadar(gameWorld.map);
 	return {};
 }
 
@@ -3154,7 +3154,7 @@ wzapi::returned_nullable_ptr<const STRUCTURE> wzapi::addStructure(WZAPI_PARAMS(s
 	uint16_t direction = static_cast<uint16_t>(DEG(_direction.value_or(0)));
 
 	STRUCTURE_STATS *psStat = &asStructureStats[structureIndex];
-	STRUCTURE *psStruct = buildStructureDir(psStat, x, y, direction, player, false);
+	STRUCTURE *psStruct = buildStructureDir(gameWorld, psStat, x, y, direction, player, false);
 	if (psStruct)
 	{
 		psStruct->status = SS_BUILT;


### PR DESCRIPTION
Mostly mechanical work to add `GameWorld`/`WorldMapState` or `WorldObjectState` references to various functions throughout the code base. References to global world states are preserved, so no behavioral changes are expected.