### PR TITLE
Add a damage and tile opacity tweak option

### DIFF
--- a/data/base/script/rules.js
+++ b/data/base/script/rules.js
@@ -233,8 +233,8 @@ function reticuleUpdate(obj, eventType)
 
 function setupGame()
 {
-	//Use dark fog for campaign
-	setRevealStatus(false);
+	//Use dark fog for campaign by default
+	setRevealStatus((tweakOptions.unexploredMapOpacity) ? true : false);
 
 	if (tilesetType === "ARIZONA")
 	{

--- a/data/mods/campaign/wz2100_camclassic/mod-info.json.in
+++ b/data/mods/campaign/wz2100_camclassic/mod-info.json.in
@@ -75,6 +75,11 @@
             "id": "towerWars",
             "default": false,
             "userEditable": true
+        },
+        {
+            "id": "heavilyDamagedPenalty",
+            "default": false,
+            "userEditable": true
         }
     ],
     "customTweakOptions": [

--- a/data/mods/campaign/wz2100_camclassic/mod-info.json.in
+++ b/data/mods/campaign/wz2100_camclassic/mod-info.json.in
@@ -80,6 +80,11 @@
             "id": "heavilyDamagedPenalty",
             "default": false,
             "userEditable": true
+        },
+        {
+            "id": "unexploredMapOpacity",
+            "default": false,
+            "userEditable": true
         }
     ],
     "customTweakOptions": [

--- a/data/mods/campaign/wz2100_campumpkin/mod-info.json.in
+++ b/data/mods/campaign/wz2100_campumpkin/mod-info.json.in
@@ -80,6 +80,11 @@
             "id": "heavilyDamagedPenalty",
             "default": true,
             "userEditable": true
+        },
+        {
+            "id": "unexploredMapOpacity",
+            "default": false,
+            "userEditable": true
         }
     ],
     "customTweakOptions": [

--- a/data/mods/campaign/wz2100_campumpkin/mod-info.json.in
+++ b/data/mods/campaign/wz2100_campumpkin/mod-info.json.in
@@ -75,6 +75,11 @@
             "id": "towerWars",
             "default": false,
             "userEditable": true
+        },
+        {
+            "id": "heavilyDamagedPenalty",
+            "default": true,
+            "userEditable": true
         }
     ],
     "customTweakOptions": [

--- a/src/campaigninfo.cpp
+++ b/src/campaigninfo.cpp
@@ -201,3 +201,13 @@ bool getCamTweakOption_FastExp()
 	}
 	return val.get<bool>();
 }
+
+bool getCamTweakOption_heavilyDamagedPenalty()
+{
+	auto val = getCamTweakOptionsValue("heavilyDamagedPenalty", false);
+	if (!val.is_boolean())
+	{
+		return false;
+	}
+	return val.get<bool>();
+}

--- a/src/campaigninfo.h
+++ b/src/campaigninfo.h
@@ -59,5 +59,6 @@ nlohmann::json getCamTweakOptionsValue(const std::string& identifier, nlohmann::
 bool getCamTweakOption_AutosavesOnly();
 bool getCamTweakOption_PS1Modifiers();
 bool getCamTweakOption_FastExp();
+bool getCamTweakOption_heavilyDamagedPenalty();
 
 #endif // __INCLUDED_SRC_CAMPAIGNINFO_H__

--- a/src/combat.cpp
+++ b/src/combat.cpp
@@ -46,9 +46,38 @@
 #include "objmem.h"
 #include "effects.h"
 #include "display3ddef.h"
+#include "campaigninfo.h"
 
 #define DROID_SHIELD_DAMAGE_SPREAD	(16 - rand()%32)
 #define DROID_SHIELD_PARTICLES		(6 + rand()%8)
+
+// Check if an object is below a certain HP threshold. Primarily used for a campaign tweak option to restore
+// original behavior to reduce speed and ROF if heavily damaged.
+bool objectBelowHealthLevel(BASE_OBJECT *psObj, const unsigned int percentage)
+{
+	ASSERT_OR_RETURN(false, psObj != nullptr, "Invalid object to check health against");
+	const unsigned int maxHealthLevel = 100;
+	unsigned int healthLevel = maxHealthLevel; // Fail by default if an unexpected object gets passed here.
+
+	if (psObj->type == OBJ_DROID)
+	{
+		DROID *psDroid = castDroid(psObj);
+		if (psDroid != nullptr)
+		{
+			healthLevel = PERCENT(psDroid->body, psDroid->originalBody);
+		}
+	}
+	else if (psObj->type == OBJ_STRUCTURE)
+	{
+		STRUCTURE *psStructure = castStructure(psObj);
+		if (psStructure != nullptr)
+		{
+			healthLevel = PERCENT(psStructure->body, psStructure->structureBody());
+		}
+	}
+
+	return healthLevel < std::min(maxHealthLevel, percentage);
+}
 
 /* Fire a weapon at something */
 bool combFire(WEAPON *psWeap, BASE_OBJECT *psAttacker, BASE_OBJECT *psTarget, int weapon_slot)
@@ -107,6 +136,10 @@ bool combFire(WEAPON *psWeap, BASE_OBJECT *psAttacker, BASE_OBJECT *psTarget, in
 	/* See when the weapon last fired to control it's rate of fire */
 	firePause = weaponFirePause(*psStats, psAttacker->player);
 	firePause = std::max(firePause, 1u);  // Don't shoot infinitely many shots at once.
+	if (!bMultiPlayer && getCamTweakOption_heavilyDamagedPenalty() && objectBelowHealthLevel(psAttacker, HEAVY_DAMAGE_LEVEL))
+	{
+		firePause += firePause;
+	}
 	fireTime = std::max(fireTime, psWeap->lastFired + firePause);
 
 	if (gameTime < fireTime)

--- a/src/combat.h
+++ b/src/combat.h
@@ -27,6 +27,9 @@
 #include "weapondef.h"
 #include "objectdef.h"
 
+// Checks if an object is below a HP percentage.
+bool objectBelowHealthLevel(BASE_OBJECT *psObj, const unsigned int percentage);
+
 /* Fire a weapon at something added int weapon_slot*/
 bool combFire(WEAPON *psWeap, BASE_OBJECT *psAttacker, BASE_OBJECT *psTarget, int weapon_slot);
 

--- a/src/droid.cpp
+++ b/src/droid.cpp
@@ -205,6 +205,10 @@ int droidReloadBar(const BASE_OBJECT *psObj, const WEAPON *psWeap, int weapon_sl
 		{
 			firingStage = gameTime - psWeap->lastFired;
 			interval = bSalvo ? weaponReloadTime(*psStats, psObj->player) : weaponFirePause(*psStats, psObj->player);
+			if (!bSalvo && !bMultiPlayer && getCamTweakOption_heavilyDamagedPenalty() && objectBelowHealthLevel(const_cast<BASE_OBJECT *>(psObj), HEAVY_DAMAGE_LEVEL))
+			{
+				interval += interval;
+			}
 		}
 		if (firingStage < interval && interval > 0)
 		{

--- a/src/move.cpp
+++ b/src/move.cpp
@@ -59,6 +59,7 @@
 #include "qtscript.h"
 #include "steering/steering.h"
 #include "steering/collision_avoidance_behavior.h"
+#include "combat.h"
 
 /* max and min vtol heights above terrain */
 #define	VTOL_HEIGHT_MIN				250
@@ -1408,6 +1409,10 @@ SDWORD moveCalcDroidSpeed(DROID *psDroid)
 	// now offset the speed for the slope of the droid
 	pitch = angleDelta(psDroid->rot.pitch);
 	speed = (maxPitch - pitch) * speed / maxPitch;
+	if (!bMultiPlayer && getCamTweakOption_heavilyDamagedPenalty() && objectBelowHealthLevel(psDroid, HEAVY_DAMAGE_LEVEL))
+	{
+		speed = 2 * speed / 3; // slow down damaged droids.
+	}
 	if (speed <= 10)
 	{
 		// Very nasty hack to deal with buggy maps, where some cliffs are

--- a/src/multistruct.cpp
+++ b/src/multistruct.cpp
@@ -227,9 +227,8 @@ bool recvLasSat(NETQUEUE queue)
 	{
 		// Lassats have just one weapon
 		unsigned firePause = weaponFirePause(*psStruct->getWeaponStats(0), player);
-		unsigned damLevel = PERCENT(psStruct->body, psStruct->structureBody());
 
-		if (damLevel < HEAVY_DAMAGE_LEVEL)
+		if (objectBelowHealthLevel(psStruct, HEAVY_DAMAGE_LEVEL))
 		{
 			firePause += firePause;
 		}

--- a/src/titleui/campaign.cpp
+++ b/src/titleui/campaign.cpp
@@ -1707,6 +1707,13 @@ static std::vector<WzCampaignTweakOptionSetting> buildTweakOptionSettings(option
 		false, true
 	);
 
+	results.emplace_back(
+		"heavilyDamagedPenalty",
+		_("Heavily Damaged Penalty"),
+		_("ROF and Speed will be reduced when units or structures are below 25% HP."),
+		false, true
+	);
+
 	if (modInfo.has_value())
 	{
 		for (auto it = results.begin(); it != results.end(); )

--- a/src/titleui/campaign.cpp
+++ b/src/titleui/campaign.cpp
@@ -1714,6 +1714,13 @@ static std::vector<WzCampaignTweakOptionSetting> buildTweakOptionSettings(option
 		false, true
 	);
 
+	results.emplace_back(
+		"unexploredMapOpacity",
+		_("Unexplored Map Opacity"),
+		_("Partially reveal the layout of the map without exploration."),
+		false, true
+	);
+
 	if (modInfo.has_value())
 	{
 		for (auto it = results.begin(); it != results.end(); )


### PR DESCRIPTION
Add a tweak to toggle if the whole map and minimap radar is partially visible without exploration. Like how it is in skirmish.

As a continuation of improving upon Pumpkin balance mod: Introduce "Heavily Damaged Penalty" tweak, active by default for the Pumpkin mod, that restores some source behavior found in the original releases. This tweak will reintroduce a speed and ROF reduction to units/structures that get below 25% HP.

Now the only major thing left to do is recreate Nexus units running away from the attacker once HP is low enough. So that they can auto-repair and hit from afar with their massive internal sensor while sitting in safe tiles. And for that I will need a wzapi function that returns a general safe area to go to (needs to account for sensors and general combat units watching specific tiles). As well as likely reducing the time limit of eventAttacked before it can trigger again (a lot of damage can happen in 1 second).