### PR TITLE
Fix wall orientation issues

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -6368,7 +6368,7 @@ static bool loadWzMapStructure(WzMap::Map& wzMap, std::unordered_map<UDWORD, UDW
 				debug(LOG_ERROR, "Found duplicate hard-coded object ID in map data: %" PRIu32 "", structure.id.value());
 			}
 		}
-		psStructure = buildStructureDir(psStats, structure.position.x, structure.position.y, structure.direction, player, true, newID);
+		psStructure = buildStructureDir(psStats, structure.position.x, structure.position.y, structure.direction, player, true, newID, true);
 		if (psStructure == nullptr)
 		{
 			debug(LOG_ERROR, "Structure %s couldn't be built (probably on top of another structure).", structure.name.c_str());

--- a/src/multistruct.cpp
+++ b/src/multistruct.cpp
@@ -121,7 +121,7 @@ bool recvBuildFinished(NETQUEUE queue)
 	for (typeindex = 0; typeindex < numStructureStats && asStructureStats[typeindex].ref != type; typeindex++) {}	// Find structure target
 
 	// Build the structure
-	psStruct = buildStructureDir(&(asStructureStats[typeindex]), pos.x, pos.y, 0, player, true, structId);
+	psStruct = buildStructureDir(&(asStructureStats[typeindex]), pos.x, pos.y, 0, player, true, structId, true);
 	if (psStruct)
 	{
 		psStruct->status	= SS_BUILT;

--- a/src/structure.cpp
+++ b/src/structure.cpp
@@ -1501,7 +1501,7 @@ STRUCTURE *buildStructureDir(STRUCTURE_STATS *pStructureType, UDWORD x, UDWORD y
 	return buildStructureDir(pStructureType, x, y, direction, player, FromSave, generateSynchronisedObjectId());
 }
 
-STRUCTURE *buildStructureDir(STRUCTURE_STATS *pStructureType, UDWORD x, UDWORD y, uint16_t direction, UDWORD player, bool FromSave, uint32_t id)
+STRUCTURE *buildStructureDir(STRUCTURE_STATS *pStructureType, UDWORD x, UDWORD y, uint16_t direction, UDWORD player, bool FromSave, uint32_t id, bool forceWallOrientation/*= false*/)
 {
 	STRUCTURE *psBuilding = nullptr;
 	const Vector2i size = pStructureType->size(direction);
@@ -1545,7 +1545,7 @@ STRUCTURE *buildStructureDir(STRUCTURE_STATS *pStructureType, UDWORD x, UDWORD y
 		}
 
 		WallOrientation wallOrientation = WallConnectNone;
-		if (!FromSave && isWallCombiningStructureType(pStructureType))
+		if ((!FromSave || forceWallOrientation) && isWallCombiningStructureType(pStructureType))
 		{
 			for (int dy = 0; dy < size.y; ++dy)
 				for (int dx = 0; dx < size.x; ++dx)
@@ -1776,7 +1776,7 @@ STRUCTURE *buildStructureDir(STRUCTURE_STATS *pStructureType, UDWORD x, UDWORD y
 		}
 
 		// rotate a wall if necessary
-		if (!FromSave && (pStructureType->type == REF_WALL || pStructureType->type == REF_GATE))
+		if ((!FromSave || forceWallOrientation) && (pStructureType->type == REF_WALL || pStructureType->type == REF_GATE))
 		{
 			psBuilding->pFunctionality->wall.type = wallType(wallOrientation);
 			if (wallOrientation != WallConnectNone)

--- a/src/structure.h
+++ b/src/structure.h
@@ -106,7 +106,7 @@ float structureCompletionProgress(const STRUCTURE & structure);
 
 //builds a specified structure at a given location
 STRUCTURE *buildStructure(STRUCTURE_STATS *pStructureType, UDWORD x, UDWORD y, UDWORD player, bool FromSave);
-STRUCTURE *buildStructureDir(STRUCTURE_STATS *pStructureType, UDWORD x, UDWORD y, uint16_t direction, UDWORD player, bool FromSave, uint32_t id);
+STRUCTURE *buildStructureDir(STRUCTURE_STATS *pStructureType, UDWORD x, UDWORD y, uint16_t direction, UDWORD player, bool FromSave, uint32_t id, bool forceWallOrientation = false);
 STRUCTURE *buildStructureDir(STRUCTURE_STATS *pStructureType, UDWORD x, UDWORD y, uint16_t direction, UDWORD player, bool FromSave);
 /// Create a blueprint structure, with just enough information to render it
 /// IMPORTANT: Do not save the reference to this instance anywhere, since it's


### PR DESCRIPTION
Some experimental changes to:
1. Fix initial map load not giving the correct wall orientation or combining behavior.
2. Fix walls, gates, and such not oriented correctly when placed with the debug menu when building them in a line going up or down. Don't like the location of this currently but it works for now. Edit: ok, didn't see that is exclusive to debug added structures so that's fine then lol.

Easy to observe the difference on the Melting map, where walls that should be `L` shaped are instead the standard `-` shape.

Would be good to know of any maps with complex base defenses that should have `L` and `T` shaped walls. The maps I have are too simple to test this fully.