### PR TITLE
Removing Cobra/Python from Panther/Tiger Research Prerequisites.

### DIFF
--- a/data/mp/stats/research.json
+++ b/data/mp/stats/research.json
@@ -3927,7 +3927,6 @@
 		"name": "Medium Body - Panther",
 		"requiredResearch": [
 			"R-Vehicle-Body02",
-			"R-Vehicle-Body05",
 			"R-Vehicle-Metals04"
 		],
 		"researchPoints": 4800,
@@ -3976,7 +3975,6 @@
 		"msgName": "RES_V_B09",
 		"name": "Heavy Body - Tiger",
 		"requiredResearch": [
-			"R-Vehicle-Body11",
 			"R-Vehicle-Body06",
 			"R-Vehicle-Metals05"
 		],


### PR DESCRIPTION
An obscure change to the collective body tech line to make completely skipping cobra and python research technically possible.
As you won't be forced to research cobra, which mostly negates using leopard, in order to use panther. 
Nor be forced to research python, which mostly negates using panther, in order to use tiger.

  **This doesn't change the minimum research time for panther or tiger but it does reduce their respective total research cost by 37 and 37+75 power**, It also doesn't make the collective bodies any more effective than they already are.  Meaning this change likely doesn't have any downside for the game's balance because cobra and python as prerequisites for panther and tiger has no apparent upside for the game's balance.

  In a short discussion it seems the general conclusion is that the few who deal with needing to researching a body they aren't going to use, Are those who go from cobra to panther and skip building python which they would only need if they want tiger which is seemingly uncommon.  Reinforcing the argument that this change is so incremental it has no practical downside that couldn't be compensated for if later proven necessary, By simply increasing the research cost of panther and tiger by 37 and 75 power.