### PR TITLE
Simplify  `swap_mission_pointers()` and reduce its uses + more world-aware functions (part 2) 

### DIFF
--- a/src/action.cpp
+++ b/src/action.cpp
@@ -622,7 +622,7 @@ static bool actionRemoveDroidsFromBuildPos(unsigned player, Vector2i pos, uint16
 		{
 			// Push the droid out of the way.
 			Vector2i newPos = droid->pos.xy() + iSinCosR(iAtan2(bestDest - droid->pos.xy()), gameTimeAdjustedIncrement(TILE_UNITS));
-			droidSetPosition(droid, newPos.x, newPos.y);
+			droidSetPosition(droid, gameWorld.map, newPos.x, newPos.y);
 		}
 	}
 

--- a/src/droid.cpp
+++ b/src/droid.cpp
@@ -3879,13 +3879,13 @@ bool droidOnMap(const DROID *psDroid)
 }
 
 /** Teleport a droid to a new position on the map */
-void droidSetPosition(DROID *psDroid, int x, int y)
+void droidSetPosition(DROID *psDroid, WorldMapState& mapState, int x, int y)
 {
 	psDroid->pos.x = x;
 	psDroid->pos.y = y;
-	psDroid->pos.z = map_Height(gameWorld.map, psDroid->pos.x, psDroid->pos.y);
+	psDroid->pos.z = map_Height(mapState, psDroid->pos.x, psDroid->pos.y);
 	initDroidMovement(psDroid);
-	visTilesUpdate((BASE_OBJECT *)psDroid, gameWorld.map);
+	visTilesUpdate((BASE_OBJECT *)psDroid, mapState);
 }
 
 /** Check validity of a droid. Crash hard if it fails. */

--- a/src/droid.h
+++ b/src/droid.h
@@ -80,6 +80,7 @@ struct INITIAL_DROID_ORDERS
 };
 
 struct GameWorld;
+struct WorldMapState;
 struct WorldObjectState;
 
 /*Builds an instance of a Structure - the x/y passed in are in world coords.*/
@@ -314,7 +315,7 @@ bool isConstructionDroid(BASE_OBJECT const *psObject);
 /** Check if droid is in a legal world position and is not on its way to drive off the map. */
 bool droidOnMap(const DROID *psDroid);
 
-void droidSetPosition(DROID *psDroid, int x, int y);
+void droidSetPosition(DROID *psDroid, WorldMapState& mapState, int x, int y);
 
 /// Return a percentage of how fully armed the object is, or -1 if N/A.
 int droidReloadBar(const BASE_OBJECT *psObj, const WEAPON *psWeap, int weapon_slot);

--- a/src/fpath.cpp
+++ b/src/fpath.cpp
@@ -353,9 +353,9 @@ bool fpathBaseBlockingTile(const WorldMapState& mapState, SDWORD x, SDWORD y, PR
 	return (blockTile(mapState, x, y, MAX(0, mapIndex - MAX_PLAYERS)) & unitbits) != 0;  // finally check if move is blocked by propulsion related factors
 }
 
-bool fpathDroidBlockingTile(DROID *psDroid, int x, int y, FPATH_MOVETYPE moveType)
+bool fpathDroidBlockingTile(DROID *psDroid, const WorldMapState& mapState, int x, int y, FPATH_MOVETYPE moveType)
 {
-	return fpathBaseBlockingTile(gameWorld.map, x, y, psDroid->getPropulsionStats()->propulsionType, psDroid->player, moveType);
+	return fpathBaseBlockingTile(mapState, x, y, psDroid->getPropulsionStats()->propulsionType, psDroid->player, moveType);
 }
 
 // Check if the map tile at a location blocks a droid
@@ -417,7 +417,7 @@ void fpathRemoveDroidData(int id)
 	pathResults.erase(id);
 }
 
-static FPATH_RETVAL fpathRoute(MOVE_CONTROL *psMove, unsigned id, int startX, int startY, int tX, int tY, PROPULSION_TYPE propulsionType,
+static FPATH_RETVAL fpathRoute(const WorldMapState& mapState, MOVE_CONTROL *psMove, unsigned id, int startX, int startY, int tX, int tY, PROPULSION_TYPE propulsionType,
                                DROID_TYPE droidType, FPATH_MOVETYPE moveType, int owner, bool acceptNearest, StructureBounds const &dstStructure)
 {
 	objTrace(id, "called(*,id=%d,sx=%d,sy=%d,ex=%d,ey=%d,prop=%d,type=%d,move=%d,owner=%d)", id, startX, startY, tX, tY, (int)propulsionType, (int)droidType, (int)moveType, owner);
@@ -443,7 +443,7 @@ static FPATH_RETVAL fpathRoute(MOVE_CONTROL *psMove, unsigned id, int startX, in
 	}
 #endif
 
-	if (!worldOnMap(gameWorld.map, startX, startY) || !worldOnMap(gameWorld.map, tX, tY))
+	if (!worldOnMap(mapState, startX, startY) || !worldOnMap(mapState, tX, tY))
 	{
 		debug(LOG_ERROR, "Droid trying to find path to/from invalid location (%d %d) -> (%d %d).", startX, startY, tX, tY);
 		objTrace(id, "Invalid start/end.");
@@ -541,7 +541,7 @@ queuePathfinding:
 
 
 // Find a route for an DROID to a location in world coordinates
-FPATH_RETVAL fpathDroidRoute(DROID *psDroid, SDWORD tX, SDWORD tY, FPATH_MOVETYPE moveType)
+FPATH_RETVAL fpathDroidRoute(DROID *psDroid, const WorldMapState& mapState, SDWORD tX, SDWORD tY, FPATH_MOVETYPE moveType)
 {
 	bool acceptNearest;
 	PROPULSION_STATS *psPropStats = psDroid->getPropulsionStats();
@@ -558,12 +558,12 @@ FPATH_RETVAL fpathDroidRoute(DROID *psDroid, SDWORD tX, SDWORD tY, FPATH_MOVETYP
 	// Check whether the start and end points of the route are blocking tiles and find an alternative if they are.
 	Position startPos = psDroid->pos;
 	Position endPos = Position(tX, tY, 0);
-	StructureBounds dstStructure = getStructureBounds(worldTile(gameWorld.map, endPos.xy())->psObject);
+	StructureBounds dstStructure = getStructureBounds(worldTile(mapState, endPos.xy())->psObject);
 	const auto droidPropulsionType = psDroid->getPropulsionStats()->propulsionType;
-	startPos = findNonblockingPosition(gameWorld.map, startPos, droidPropulsionType, psDroid->player, moveType);
+	startPos = findNonblockingPosition(mapState, startPos, droidPropulsionType, psDroid->player, moveType);
 	if (!dstStructure.valid())  // If there's a structure over the destination, ignore it, otherwise pathfind from somewhere around the obstruction.
 	{
-		endPos   = findNonblockingPosition(gameWorld.map, endPos, droidPropulsionType, psDroid->player, moveType);
+		endPos   = findNonblockingPosition(mapState, endPos, droidPropulsionType, psDroid->player, moveType);
 	}
 	objTrace(psDroid->id, "Want to go to (%d, %d) -> (%d, %d), going (%d, %d) -> (%d, %d)", map_coord(psDroid->pos.x), map_coord(psDroid->pos.y), map_coord(tX), map_coord(tY), map_coord(startPos.x), map_coord(startPos.y), map_coord(endPos.x), map_coord(endPos.y));
 	switch (psDroid->order.type)
@@ -581,7 +581,7 @@ FPATH_RETVAL fpathDroidRoute(DROID *psDroid, SDWORD tX, SDWORD tY, FPATH_MOVETYP
 		acceptNearest = true;
 		break;
 	}
-	return fpathRoute(&psDroid->sMove, psDroid->id, startPos.x, startPos.y, endPos.x, endPos.y, psPropStats->propulsionType,
+	return fpathRoute(mapState, &psDroid->sMove, psDroid->id, startPos.x, startPos.y, endPos.x, endPos.y, psPropStats->propulsionType,
 	                  psDroid->droidType, moveType, psDroid->player, acceptNearest, dstStructure);
 }
 
@@ -660,7 +660,7 @@ static size_t fpathResultQueueLength()
 // Only used by fpathTest.
 static FPATH_RETVAL fpathSimpleRoute(MOVE_CONTROL *psMove, int id, int startX, int startY, int tX, int tY)
 {
-	return fpathRoute(psMove, id, startX, startY, tX, tY, PROPULSION_TYPE_WHEELED, DROID_WEAPON, FMT_BLOCK, 0, true, getStructureBounds((BASE_OBJECT *)nullptr));
+	return fpathRoute(gameWorld.map, psMove, id, startX, startY, tX, tY, PROPULSION_TYPE_WHEELED, DROID_WEAPON, FMT_BLOCK, 0, true, getStructureBounds((BASE_OBJECT *)nullptr));
 }
 
 void fpathTest(int x, int y, int x2, int y2)

--- a/src/fpath.h
+++ b/src/fpath.h
@@ -79,7 +79,7 @@ void fpathUpdate();
 
 /** Find a route for a droid to a location.
  */
-FPATH_RETVAL fpathDroidRoute(DROID *psDroid, SDWORD targetX, SDWORD targetY, FPATH_MOVETYPE moveType);
+FPATH_RETVAL fpathDroidRoute(DROID *psDroid, const WorldMapState& mapState, SDWORD targetX, SDWORD targetY, FPATH_MOVETYPE moveType);
 
 /// Returns true iff the parameters have equivalent behaviour in fpathBaseBlockingTile.
 bool fpathIsEquivalentBlocking(PROPULSION_TYPE propulsion1, int player1, FPATH_MOVETYPE moveType1,
@@ -98,7 +98,7 @@ bool fpathIsEquivalentBlocking(PROPULSION_TYPE propulsion1, int player1, FPATH_M
  *  @return true if the given tile is blocking for this droid
  */
 bool fpathBlockingTile(const WorldMapState& mapState, SDWORD x, SDWORD y, PROPULSION_TYPE propulsion);
-bool fpathDroidBlockingTile(DROID *psDroid, int x, int y, FPATH_MOVETYPE moveType);
+bool fpathDroidBlockingTile(DROID *psDroid, const WorldMapState& mapState, int x, int y, FPATH_MOVETYPE moveType);
 bool fpathBaseBlockingTile(const WorldMapState& mapState, SDWORD x, SDWORD y, PROPULSION_TYPE propulsion, int player, FPATH_MOVETYPE moveType);
 
 static inline bool fpathBlockingTile(const WorldMapState& mapState, Vector2i tile, PROPULSION_TYPE propulsion)

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2249,20 +2249,20 @@ static bool writeMapFile(const char *fileName, const WorldMapState& mapState);
 
 static bool loadWzMapDroidInit(WzMap::Map &wzMap, std::unordered_map<UDWORD, UDWORD>& fixedMapIdToGeneratedId);
 
-static bool loadSaveDroid(const char *pFileName, PerPlayerDroidLists& ppsCurrentDroidLists);
+static bool loadSaveDroid(const char *pFileName, GameWorld& world, PerPlayerDroidLists& ppsCurrentDroidLists);
 static bool loadSaveDroidPointers(const WzString &pFileName, PerPlayerDroidLists* ppsCurrentDroidLists);
 static bool writeDroidFile(const char *pFileName, const PerPlayerDroidLists& ppsCurrentDroidLists);
 
-static bool loadSaveStructure(char *pFileData, UDWORD filesize);
+static bool loadSaveStructure(char *pFileData, UDWORD filesize, GameWorld& world);
 static bool loadSaveStructure2(const char *pFileName, GameWorld& world);
-static bool loadWzMapStructure(WzMap::Map& wzMap, std::unordered_map<UDWORD, UDWORD>& fixedMapIdToGeneratedId, std::array<std::unordered_map<UDWORD, UDWORD>, MAX_PLAYER_SLOTS>& moduleToBuilding);
+static bool loadWzMapStructure(WzMap::Map& wzMap, std::unordered_map<UDWORD, UDWORD>& fixedMapIdToGeneratedId, std::array<std::unordered_map<UDWORD, UDWORD>, MAX_PLAYER_SLOTS>& moduleToBuilding, GameWorld& world);
 static bool loadSaveStructurePointers(const WzString& filename, PerPlayerStructureLists *ppList);
 static bool writeStructFile(const char *pFileName, const WorldObjectState& objState);
 
 static bool loadSaveTemplate(const char *pFileName);
 static bool writeTemplateFile(const char *pFileName);
 
-static bool loadSaveFeature(char *pFileData, UDWORD filesize);
+static bool loadSaveFeature(char *pFileData, UDWORD filesize, GameWorld& world);
 static bool writeFeatureFile(const char *pFileName, const WorldObjectState& objState);
 static bool loadSaveFeature2(const char *pFileName, GameWorld& world);
 static bool loadWzMapFeature(WzMap::Map &wzMap, std::unordered_map<UDWORD, UDWORD>& fixedMapIdToGeneratedId);
@@ -3047,7 +3047,7 @@ bool loadGame(const GameLoadDetails& gameToLoad, bool keepObjects, bool freeMem)
 				debug(LOG_ERROR, "Failed with: %s", aFileName);
 				goto error;
 			}
-			if (!loadSaveFeature(pFileData, fileSize))
+			if (!loadSaveFeature(pFileData, fileSize, gameWorld))
 			{
 				debug(LOG_ERROR, "Failed with: %s", aFileName);
 				goto error;
@@ -3071,7 +3071,7 @@ bool loadGame(const GameLoadDetails& gameToLoad, bool keepObjects, bool freeMem)
 				goto error;
 			}
 			//load the data into apsStructLists
-			if (!loadSaveStructure(pFileData, fileSize))
+			if (!loadSaveStructure(pFileData, fileSize, gameWorld))
 			{
 				debug(LOG_ERROR, "Failed with: %s", aFileName);
 				goto error;
@@ -3085,7 +3085,7 @@ bool loadGame(const GameLoadDetails& gameToLoad, bool keepObjects, bool freeMem)
 		// load in the mission droids, if any
 		aFileName[fileExten] = '\0';
 		strcat(aFileName, "mdroid.json");
-		if (loadSaveDroid(aFileName, gameWorld.objects.droids))
+		if (loadSaveDroid(aFileName, gameWorld, gameWorld.objects.droids))
 		{
 			droidMap[aFileName] = &mission.gameWorld.objects.droids; // need to swap here to read correct list later
 		}
@@ -3210,7 +3210,7 @@ bool loadGame(const GameLoadDetails& gameToLoad, bool keepObjects, bool freeMem)
 		}
 		else
 		{
-			if (loadSaveDroid(aFileName, gameWorld.objects.droids))
+			if (loadSaveDroid(aFileName, gameWorld, gameWorld.objects.droids))
 			{
 				debug(LOG_SAVE, "Loaded new style droids");
 				droidMap[aFileName] = &gameWorld.objects.droids;	// load pointers later
@@ -3224,7 +3224,7 @@ bool loadGame(const GameLoadDetails& gameToLoad, bool keepObjects, bool freeMem)
 		strcat(aFileName, "droid.json");
 
 		//load the data into apsDroidLists
-		if (!loadSaveDroid(aFileName, gameWorld.objects.droids))
+		if (!loadSaveDroid(aFileName, gameWorld, gameWorld.objects.droids))
 		{
 			debug(LOG_ERROR, "failed to load %s", aFileName);
 			goto error;
@@ -3255,7 +3255,7 @@ bool loadGame(const GameLoadDetails& gameToLoad, bool keepObjects, bool freeMem)
 			strcat(aFileName, "mdroid.json");
 
 			// load the data into mission.apsDroidLists, if any
-			if (loadSaveDroid(aFileName, mission.gameWorld.objects.droids))
+			if (loadSaveDroid(aFileName, mission.gameWorld, mission.gameWorld.objects.droids))
 			{
 				droidMap[aFileName] = &mission.gameWorld.objects.droids;
 			}
@@ -3267,7 +3267,7 @@ bool loadGame(const GameLoadDetails& gameToLoad, bool keepObjects, bool freeMem)
 		// load in the limbo droids, if any
 		aFileName[fileExten] = '\0';
 		strcat(aFileName, "limbo.json");
-		if (loadSaveDroid(aFileName, apsLimboDroids))
+		if (loadSaveDroid(aFileName, gameWorld, apsLimboDroids))
 		{
 			droidMap[aFileName] = &apsLimboDroids;
 		}
@@ -3306,7 +3306,7 @@ bool loadGame(const GameLoadDetails& gameToLoad, bool keepObjects, bool freeMem)
 		{
 			freeAllFlagPositions(gameWorld.objects);		//clear any flags put in during level loads
 		}
-		if (!loadWzMapStructure(*(data.get()), fixedMapIdToGeneratedId, moduleToBuilding))
+		if (!loadWzMapStructure(*(data.get()), fixedMapIdToGeneratedId, moduleToBuilding, gameWorld))
 		{
 			aFileName[fileExten] = '\0';
 			debug(LOG_ERROR, "Failed to load map structure init from map directory: %s", aFileName);
@@ -5629,7 +5629,7 @@ inline T getCompFromName_NullCompOnFail(COMPONENT_TYPE compType, const WzString 
 	return (index >= 0) ? static_cast<T>(index) : 0; // 0 to reference the null weapon / body / etc
 }
 
-static bool loadSaveDroid(const char *pFileName, PerPlayerDroidLists& ppsCurrentDroidLists)
+static bool loadSaveDroid(const char *pFileName, GameWorld& world, PerPlayerDroidLists& ppsCurrentDroidLists)
 {
 	if (!PHYSFS_exists(pFileName))
 	{
@@ -5726,19 +5726,19 @@ static bool loadSaveDroid(const char *pFileName, PerPlayerDroidLists& ppsCurrent
 		// If droid is on a mission, calling with the saved position might cause an assertion. Or something like that.
 		if (!onMission)
 		{
-			pos.x = clip(pos.x, world_coord(1), world_coord(gameWorld.map.width - 1));
-			pos.y = clip(pos.y, world_coord(1), world_coord(gameWorld.map.height - 1));
+			pos.x = clip(pos.x, world_coord(1), world_coord(world.map.width - 1));
+			pos.y = clip(pos.y, world_coord(1), world_coord(world.map.height - 1));
 		}
 
 		/* Create the Droid */
 		turnOffMultiMsg(true);
 		if (id > 0)
 		{
-			psDroid = reallyBuildDroid(gameWorld, psTemplate, pos, player, onMission, rot, id);
+			psDroid = reallyBuildDroid(world, psTemplate, pos, player, onMission, rot, id);
 		} else
 		{
 			// will generate a new id
-			psDroid = reallyBuildDroid(gameWorld, psTemplate, pos, player, onMission, rot);
+			psDroid = reallyBuildDroid(world, psTemplate, pos, player, onMission, rot);
 		}
 		ASSERT_OR_RETURN(false, psDroid != nullptr, "Failed to build unit %s", sortedList[i].second.toUtf8().c_str());
 		turnOffMultiMsg(false);
@@ -5817,7 +5817,7 @@ static bool loadSaveDroid(const char *pFileName, PerPlayerDroidLists& ppsCurrent
 				psDroid->selected = false;  // Droid should be visible in the transporter interface.
 				if (!psDroid->isTransporter())
 				{
-					visRemoveVisibility(psDroid, gameWorld.map); // should not have visibility data when in a transporter
+					visRemoveVisibility(psDroid, world.map); // should not have visibility data when in a transporter
 				}
 			}
 		}
@@ -5917,11 +5917,11 @@ static bool loadSaveDroid(const char *pFileName, PerPlayerDroidLists& ppsCurrent
 		if (psDroid->sMove.Status == MOVEWAITROUTE)
 		{
 			psDroid->sMove.Status = MOVEINACTIVE;
-			fpathDroidRoute(psDroid, psDroid->sMove.destination.x, psDroid->sMove.destination.y, FMT_MOVE);
+			fpathDroidRoute(psDroid, world.map, psDroid->sMove.destination.x, psDroid->sMove.destination.y, FMT_MOVE);
 			psDroid->sMove.Status = MOVEWAITROUTE;
 
 			// Droid might be on a mission, so finish pathfinding now, in case pointers swap and map size changes.
-			FPATH_RETVAL dr = fpathDroidRoute(psDroid, psDroid->sMove.destination.x, psDroid->sMove.destination.y, FMT_MOVE);
+			FPATH_RETVAL dr = fpathDroidRoute(psDroid, world.map, psDroid->sMove.destination.x, psDroid->sMove.destination.y, FMT_MOVE);
 			if (dr == FPR_OK)
 			{
 				psDroid->sMove.Status = MOVENAVIGATE;
@@ -6137,7 +6137,7 @@ static bool writeDroidFile(const char *pFileName, const PerPlayerDroidLists& pps
 
 
 // -----------------------------------------------------------------------------------------
-bool loadSaveStructure(char *pFileData, UDWORD filesize)
+bool loadSaveStructure(char *pFileData, UDWORD filesize, GameWorld& world)
 {
 	STRUCT_SAVEHEADER		*psHeader;
 	SAVE_STRUCTURE_V2		*psSaveStructure, sSaveStructure;
@@ -6241,7 +6241,7 @@ bool loadSaveStructure(char *pFileData, UDWORD filesize)
 		//for modules - need to check the base structure exists
 		if (IsStatExpansionModule(psStats))
 		{
-			psStructure = getTileStructure(gameWorld.map, map_coord(psSaveStructure->x), map_coord(psSaveStructure->y));
+			psStructure = getTileStructure(world.map, map_coord(psSaveStructure->x), map_coord(psSaveStructure->y));
 			if (psStructure == nullptr)
 			{
 				debug(LOG_ERROR, "No owning structure for module - %s for player - %d", getSaveStructNameV19((SAVE_STRUCTURE_V17 *)psSaveStructure), psSaveStructure->player);
@@ -6251,20 +6251,20 @@ bool loadSaveStructure(char *pFileData, UDWORD filesize)
 		}
 
 		//check not trying to build too near the edge
-		if (map_coord(psSaveStructure->x) < TOO_NEAR_EDGE || map_coord(psSaveStructure->x) > gameWorld.map.width - TOO_NEAR_EDGE)
+		if (map_coord(psSaveStructure->x) < TOO_NEAR_EDGE || map_coord(psSaveStructure->x) > world.map.width - TOO_NEAR_EDGE)
 		{
 			debug(LOG_ERROR, "Structure %s, x coord too near the edge of the map. id - %d", getSaveStructNameV19((SAVE_STRUCTURE_V17 *)psSaveStructure), psSaveStructure->id);
 			//ignore this
 			continue;
 		}
-		if (map_coord(psSaveStructure->y) < TOO_NEAR_EDGE || map_coord(psSaveStructure->y) > gameWorld.map.height - TOO_NEAR_EDGE)
+		if (map_coord(psSaveStructure->y) < TOO_NEAR_EDGE || map_coord(psSaveStructure->y) > world.map.height - TOO_NEAR_EDGE)
 		{
 			debug(LOG_ERROR, "Structure %s, y coord too near the edge of the map. id - %d", getSaveStructNameV19((SAVE_STRUCTURE_V17 *)psSaveStructure), psSaveStructure->id);
 			//ignore this
 			continue;
 		}
 
-		psStructure = buildStructureDir(gameWorld, psStats, psSaveStructure->x, psSaveStructure->y, DEG(psSaveStructure->direction), psSaveStructure->player, true);
+		psStructure = buildStructureDir(world, psStats, psSaveStructure->x, psSaveStructure->y, DEG(psSaveStructure->direction), psSaveStructure->player, true);
 		ASSERT(psStructure, "Unable to create structure");
 		if (!psStructure)
 		{
@@ -6313,7 +6313,7 @@ static UDWORD getResearchIdFromName(const WzString &name)
 	return NULL_ID;
 }
 
-static bool loadWzMapStructure(WzMap::Map& wzMap, std::unordered_map<UDWORD, UDWORD>& fixedMapIdToGeneratedId, std::array<std::unordered_map<UDWORD, UDWORD>, MAX_PLAYER_SLOTS>& moduleToBuilding)
+static bool loadWzMapStructure(WzMap::Map& wzMap, std::unordered_map<UDWORD, UDWORD>& fixedMapIdToGeneratedId, std::array<std::unordered_map<UDWORD, UDWORD>, MAX_PLAYER_SLOTS>& moduleToBuilding, GameWorld& world)
 {
 	uint32_t NumberOfSkippedStructures = 0;
 	auto pStructures = wzMap.mapStructures();
@@ -6332,7 +6332,7 @@ static bool loadWzMapStructure(WzMap::Map& wzMap, std::unordered_map<UDWORD, UDW
 		//for modules - need to check the base structure exists
 		if (IsStatExpansionModule(psStats))
 		{
-			STRUCTURE *psStructure = getTileStructure(gameWorld.map, map_coord(structure.position.x), map_coord(structure.position.y));
+			STRUCTURE *psStructure = getTileStructure(world.map, map_coord(structure.position.x), map_coord(structure.position.y));
 			if (psStructure == nullptr)
 			{
 				debug(LOG_ERROR, "No owning structure for module - %s for player - %d", structure.name.c_str(), structure.player);
@@ -6340,8 +6340,8 @@ static bool loadWzMapStructure(WzMap::Map& wzMap, std::unordered_map<UDWORD, UDW
 			}
 		}
 		//check not trying to build too near the edge
-		if (map_coord(structure.position.x) < TOO_NEAR_EDGE || map_coord(structure.position.x) > gameWorld.map.width - TOO_NEAR_EDGE
-		 || map_coord(structure.position.y) < TOO_NEAR_EDGE || map_coord(structure.position.y) > gameWorld.map.height - TOO_NEAR_EDGE)
+		if (map_coord(structure.position.x) < TOO_NEAR_EDGE || map_coord(structure.position.x) > world.map.width - TOO_NEAR_EDGE
+		 || map_coord(structure.position.y) < TOO_NEAR_EDGE || map_coord(structure.position.y) > world.map.height - TOO_NEAR_EDGE)
 		{
 			debug(LOG_ERROR, "Structure %s, coord too near the edge of the map", structure.name.c_str());
 			continue; // skip it
@@ -6369,7 +6369,7 @@ static bool loadWzMapStructure(WzMap::Map& wzMap, std::unordered_map<UDWORD, UDW
 				debug(LOG_ERROR, "Found duplicate hard-coded object ID in map data: %" PRIu32 "", structure.id.value());
 			}
 		}
-		psStructure = buildStructureDir(gameWorld, psStats, structure.position.x, structure.position.y, structure.direction, player, true, newID, true);
+		psStructure = buildStructureDir(world, psStats, structure.position.x, structure.position.y, structure.direction, player, true, newID, true);
 		if (psStructure == nullptr)
 		{
 			debug(LOG_ERROR, "Structure %s couldn't be built (probably on top of another structure).", structure.name.c_str());
@@ -6401,7 +6401,7 @@ static bool loadWzMapStructure(WzMap::Map& wzMap, std::unordered_map<UDWORD, UDW
 			}
 			for (int i = 0; i < structure.modules; ++i)
 			{
-				buildStructure(gameWorld, moduleStat, structure.position.x, structure.position.y, player, true);
+				buildStructure(world, moduleStat, structure.position.x, structure.position.y, player, true);
 			}
 		}
 		buildingComplete(psStructure);
@@ -6978,7 +6978,7 @@ bool loadSaveStructurePointers(const WzString& filename, PerPlayerStructureLists
 }
 
 // -----------------------------------------------------------------------------------------
-bool loadSaveFeature(char *pFileData, UDWORD filesize)
+bool loadSaveFeature(char *pFileData, UDWORD filesize, GameWorld& world)
 {
 	FEATURE_SAVEHEADER		*psHeader;
 	SAVE_FEATURE_V14			*psSaveFeature;
@@ -7064,7 +7064,7 @@ bool loadSaveFeature(char *pFileData, UDWORD filesize)
 			continue;
 		}
 		//create the Feature
-		pFeature = buildFeature(gameWorld.map, psStats, psSaveFeature->x, psSaveFeature->y, true, psSaveFeature->id);
+		pFeature = buildFeature(world.map, psStats, psSaveFeature->x, psSaveFeature->y, true, psSaveFeature->id);
 		if (!pFeature)
 		{
 			debug(LOG_ERROR, "Unable to create feature %s", psSaveFeature->name);

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -3783,15 +3783,11 @@ bool saveGame(const char *aFileName, GAME_TYPE saveType, bool isAutoSave)
 
 	if (saveGameOnMission)
 	{
-		//mission save swap the mission pointers and save the changes
-		swapMissionPointers();
-		//now save the map and droids
-
 		//save the map file
 		CurrentFileName[fileExtension] = '\0';
 		strcat(CurrentFileName, "mission.map");
 		/* Write the data to the file */
-		if (!writeMapFile(CurrentFileName, gameWorld.map))
+		if (!writeMapFile(CurrentFileName, mission.gameWorld.map))
 		{
 			debug(LOG_ERROR, "saveGame: writeMapFile(\"%s\") failed", CurrentFileName);
 			goto error;
@@ -3801,7 +3797,7 @@ bool saveGame(const char *aFileName, GAME_TYPE saveType, bool isAutoSave)
 		CurrentFileName[fileExtension] = '\0';
 		strcat(CurrentFileName, "misvis.bjo");
 		/* Write the data to the file */
-		if (!writeVisibilityData(CurrentFileName, gameWorld.map))
+		if (!writeVisibilityData(CurrentFileName, mission.gameWorld.map))
 		{
 			debug(LOG_ERROR, "saveGame: writeVisibilityData(\"%s\") failed", CurrentFileName);
 			goto error;
@@ -3811,7 +3807,7 @@ bool saveGame(const char *aFileName, GAME_TYPE saveType, bool isAutoSave)
 		CurrentFileName[fileExtension] = '\0';
 		strcat(CurrentFileName, "mstruct.json");
 		/*Write the data to the file*/
-		if (!writeStructFile(CurrentFileName, gameWorld.objects))
+		if (!writeStructFile(CurrentFileName, mission.gameWorld.objects))
 		{
 			debug(LOG_ERROR, "saveGame: writeStructFile(\"%s\") failed", CurrentFileName);
 			goto error;
@@ -3821,14 +3817,11 @@ bool saveGame(const char *aFileName, GAME_TYPE saveType, bool isAutoSave)
 		CurrentFileName[fileExtension] = '\0';
 		strcat(CurrentFileName, "mfeature.json");
 		/*Write the data to the file*/
-		if (!writeFeatureFile(CurrentFileName, gameWorld.objects))
+		if (!writeFeatureFile(CurrentFileName, mission.gameWorld.objects))
 		{
 			debug(LOG_ERROR, "saveGame: writeFeatureFile(\"%s\") failed", CurrentFileName);
 			goto error;
 		}
-
-		//mission save swap back so we can restart the game
-		swapMissionPointers();
 	}
 
 	// strip the last filename

--- a/src/mission.cpp
+++ b/src/mission.cpp
@@ -337,36 +337,8 @@ bool missionShutDown()
 		releaseAllProxDisp();
 		gwShutDown(gameWorld.map);
 
-		for (int inc = 0; inc < MAX_PLAYERS; inc++)
-		{
-			gameWorld.objects.droids[inc] = std::move(mission.gameWorld.objects.droids[inc]);
-			mission.gameWorld.objects.droids[inc].clear();
-			gameWorld.objects.structures[inc] = std::move(mission.gameWorld.objects.structures[inc]);
-			mission.gameWorld.objects.structures[inc].clear();
-			gameWorld.objects.flags[inc] = std::move(mission.gameWorld.objects.flags[inc]);
-			mission.gameWorld.objects.flags[inc].clear();
-			gameWorld.objects.extractors[inc] = std::move(mission.gameWorld.objects.extractors[inc]);
-			mission.gameWorld.objects.extractors[inc].clear();
-		}
-		gameWorld.objects.features[0] = std::move(mission.gameWorld.objects.features[0]);
-		gameWorld.objects.sensors[0] = std::move(mission.gameWorld.objects.sensors[0]);
-		gameWorld.objects.oils[0] = std::move(mission.gameWorld.objects.oils[0]);
-		mission.gameWorld.objects.features[0].clear();
-		mission.gameWorld.objects.sensors[0].clear();
-		mission.gameWorld.objects.oils[0].clear();
-
-		gameWorld.map.tiles = std::move(mission.gameWorld.map.tiles);
-		gameWorld.map.width = mission.gameWorld.map.width;
-		gameWorld.map.height = mission.gameWorld.map.height;
-		for (int i = 0; i < mission.gameWorld.map.blockMap.size(); ++i)
-		{
-			gameWorld.map.blockMap[i] = std::move(mission.gameWorld.map.blockMap[i]);
-		}
-		for (int i = 0; i < mission.gameWorld.map.auxMap.size(); ++i)
-		{
-			gameWorld.map.auxMap[i] = std::move(mission.gameWorld.map.auxMap[i]);
-		}
-		std::swap(mission.gameWorld.map.gateways, gwGetGateways(gameWorld.map));
+		gameWorld = std::move(mission.gameWorld);
+		mission.gameWorld = {};
 	}
 	keybindShutdown();
 	// sorry if this breaks something - but it looks like it's what should happen - John

--- a/src/mission.cpp
+++ b/src/mission.cpp
@@ -1320,7 +1320,7 @@ static void processMission()
 			ASSERT(pickRes != NO_FREE_TILE, "processMission: Unable to find a free location");
 			x = (UWORD)world_coord(droidX);
 			y = (UWORD)world_coord(droidY);
-			droidSetPosition(psDroid, x, y);
+			droidSetPosition(psDroid, gameWorld.map, x, y);
 			ASSERT(worldOnMap(gameWorld.map, psDroid->pos.x, psDroid->pos.y), "the droid is not on the map");
 			updateDroidOrientation(psDroid, gameWorld.map);
 			// Swap the droid and map pointers back again
@@ -1680,7 +1680,7 @@ static void missionResetDroids()
 					int wx = world_coord(x);
 					int wy = world_coord(y);
 
-					droidSetPosition(psDroid, wx, wy);
+					droidSetPosition(psDroid, gameWorld.map, wx, wy);
 					placed = true;
 				}
 			}
@@ -1703,7 +1703,7 @@ static void missionResetDroids()
 							int wx = world_coord(x);
 							int wy = world_coord(y);
 
-							droidSetPosition(psDroid, wx, wy);
+							droidSetPosition(psDroid, gameWorld.map, wx, wy);
 							placed = true;
 						}
 						break;
@@ -1804,7 +1804,7 @@ void unloadTransporter(DROID *psTransporter, UDWORD x, UDWORD y)
 			//add it back into current droid lists
 			addDroid(psDroid, *ppCurrentList);
 
-			droidSetPosition(psDroid, world_coord(droidX), world_coord(droidY));
+			droidSetPosition(psDroid, gameWorld.map, world_coord(droidX), world_coord(droidY));
 			updateDroidOrientation(psDroid, gameWorld.map);
 
 			//reset droid orders

--- a/src/mission.cpp
+++ b/src/mission.cpp
@@ -358,11 +358,11 @@ bool missionShutDown()
 		gameWorld.map.tiles = std::move(mission.gameWorld.map.tiles);
 		gameWorld.map.width = mission.gameWorld.map.width;
 		gameWorld.map.height = mission.gameWorld.map.height;
-		for (int i = 0; i < ARRAY_SIZE(mission.gameWorld.map.blockMap); ++i)
+		for (int i = 0; i < mission.gameWorld.map.blockMap.size(); ++i)
 		{
 			gameWorld.map.blockMap[i] = std::move(mission.gameWorld.map.blockMap[i]);
 		}
-		for (int i = 0; i < ARRAY_SIZE(mission.gameWorld.map.auxMap); ++i)
+		for (int i = 0; i < mission.gameWorld.map.auxMap.size(); ++i)
 		{
 			gameWorld.map.auxMap[i] = std::move(mission.gameWorld.map.auxMap[i]);
 		}
@@ -776,11 +776,11 @@ static void saveMissionData()
 	mission.gameWorld.map.tiles = std::move(gameWorld.map.tiles);
 	mission.gameWorld.map.width = gameWorld.map.width;
 	mission.gameWorld.map.height = gameWorld.map.height;
-	for (int i = 0; i < ARRAY_SIZE(mission.gameWorld.map.blockMap); ++i)
+	for (int i = 0; i < mission.gameWorld.map.blockMap.size(); ++i)
 	{
 		mission.gameWorld.map.blockMap[i] = std::move(gameWorld.map.blockMap[i]);
 	}
-	for (int i = 0; i < ARRAY_SIZE(mission.gameWorld.map.auxMap); ++i)
+	for (int i = 0; i < mission.gameWorld.map.auxMap.size(); ++i)
 	{
 		mission.gameWorld.map.auxMap[i] = std::move(gameWorld.map.auxMap[i]);
 	}
@@ -878,11 +878,11 @@ void restoreMissionData()
 
 	gameWorld.map.width = mission.gameWorld.map.width;
 	gameWorld.map.height = mission.gameWorld.map.height;
-	for (int i = 0; i < ARRAY_SIZE(mission.gameWorld.map.blockMap); ++i)
+	for (int i = 0; i < mission.gameWorld.map.blockMap.size(); ++i)
 	{
 		gameWorld.map.blockMap[i] = std::move(mission.gameWorld.map.blockMap[i]);
 	}
-	for (int i = 0; i < ARRAY_SIZE(mission.gameWorld.map.auxMap); ++i)
+	for (int i = 0; i < mission.gameWorld.map.auxMap.size(); ++i)
 	{
 		gameWorld.map.auxMap[i] = std::move(mission.gameWorld.map.auxMap[i]);
 	}
@@ -1388,11 +1388,11 @@ void swapMissionPointers()
 	std::swap(gameWorld.map.tiles, mission.gameWorld.map.tiles);
 	std::swap(gameWorld.map.width,   mission.gameWorld.map.width);
 	std::swap(gameWorld.map.height,  mission.gameWorld.map.height);
-	for (int i = 0; i < ARRAY_SIZE(mission.gameWorld.map.blockMap); ++i)
+	for (int i = 0; i < mission.gameWorld.map.blockMap.size(); ++i)
 	{
 		std::swap(gameWorld.map.blockMap[i], mission.gameWorld.map.blockMap[i]);
 	}
-	for (int i = 0; i < ARRAY_SIZE(mission.gameWorld.map.auxMap); ++i)
+	for (int i = 0; i < mission.gameWorld.map.auxMap.size(); ++i)
 	{
 		std::swap(gameWorld.map.auxMap[i],   mission.gameWorld.map.auxMap[i]);
 	}

--- a/src/mission.cpp
+++ b/src/mission.cpp
@@ -745,36 +745,12 @@ static void saveMissionData()
 	resetHomeStructureObjects(); //get rid of soon-to-be illegal references of droids in repair facilities and rearming pads.
 
 	//save the mission data
-	mission.gameWorld.map.tiles = std::move(gameWorld.map.tiles);
-	mission.gameWorld.map.width = gameWorld.map.width;
-	mission.gameWorld.map.height = gameWorld.map.height;
-	for (int i = 0; i < mission.gameWorld.map.blockMap.size(); ++i)
-	{
-		mission.gameWorld.map.blockMap[i] = std::move(gameWorld.map.blockMap[i]);
-	}
-	for (int i = 0; i < mission.gameWorld.map.auxMap.size(); ++i)
-	{
-		mission.gameWorld.map.auxMap[i] = std::move(gameWorld.map.auxMap[i]);
-	}
-	mission.gameWorld.map.scroll.minX = gameWorld.map.scroll.minX;
-	mission.gameWorld.map.scroll.minY = gameWorld.map.scroll.minY;
-	mission.gameWorld.map.scroll.maxX = gameWorld.map.scroll.maxX;
-	mission.gameWorld.map.scroll.maxY = gameWorld.map.scroll.maxY;
-	std::swap(mission.gameWorld.map.gateways, gwGetGateways(gameWorld.map));
+	mission.gameWorld = std::move(gameWorld);
+	gameWorld = {};
+
 	// save the selectedPlayer's LZ
 	mission.homeLZ_X = getLandingX(selectedPlayer);
 	mission.homeLZ_Y = getLandingY(selectedPlayer);
-
-	for (unsigned int inc = 0; inc < MAX_PLAYERS; ++inc)
-	{
-		mission.gameWorld.objects.structures[inc] = gameWorld.objects.structures[inc];
-		mission.gameWorld.objects.droids[inc] = gameWorld.objects.droids[inc];
-		mission.gameWorld.objects.flags[inc] = gameWorld.objects.flags[inc];
-		mission.gameWorld.objects.extractors[inc] = gameWorld.objects.extractors[inc];
-	}
-	mission.gameWorld.objects.features[0] = gameWorld.objects.features[0];
-	mission.gameWorld.objects.sensors[0] = gameWorld.objects.sensors[0];
-	mission.gameWorld.objects.oils[0] = gameWorld.objects.oils[0];
 
 	mission.playerX = playerPos.p.x;
 	mission.playerY = playerPos.p.z;

--- a/src/mission.cpp
+++ b/src/mission.cpp
@@ -795,59 +795,17 @@ void restoreMissionData()
 		ASSERT(false, "game type isn't campaign, but we are in a campaign game!");
 		game.type = LEVEL_TYPE::CAMPAIGN;	// fix the issue, since it is obviously a bug
 	}
-	//restore the game pointers
+	//restore the game pointers.
+	//swap mission data over
+	gameWorld = std::move(mission.gameWorld);
+	mission.gameWorld = {};
 	for (inc = 0; inc < MAX_PLAYERS; inc++)
 	{
-		gameWorld.objects.droids[inc] = std::move(mission.gameWorld.objects.droids[inc]);
-		mission.gameWorld.objects.droids[inc].clear();
 		for (DROID* psObj : gameWorld.objects.droids[inc])
 		{
 			psObj->died = false;	//make sure the died flag is not set
 		}
-
-		gameWorld.objects.structures[inc] = std::move(mission.gameWorld.objects.structures[inc]);
-		mission.gameWorld.objects.structures[inc].clear();
-
-		gameWorld.objects.flags[inc] = std::move(mission.gameWorld.objects.flags[inc]);
-		mission.gameWorld.objects.flags[inc].clear();
-
-		gameWorld.objects.extractors[inc] = std::move(mission.gameWorld.objects.extractors[inc]);
-		mission.gameWorld.objects.extractors[inc].clear();
 	}
-	gameWorld.objects.features[0] = std::move(mission.gameWorld.objects.features[0]);
-	gameWorld.objects.sensors[0] = std::move(mission.gameWorld.objects.sensors[0]);
-	gameWorld.objects.oils[0] = std::move(mission.gameWorld.objects.oils[0]);
-	mission.gameWorld.objects.features[0].clear();
-	mission.gameWorld.objects.sensors[0].clear();
-	mission.gameWorld.objects.oils[0].clear();
-	//swap mission data over
-
-	gameWorld.map.tiles = std::move(mission.gameWorld.map.tiles);
-
-	gameWorld.map.width = mission.gameWorld.map.width;
-	gameWorld.map.height = mission.gameWorld.map.height;
-	for (int i = 0; i < mission.gameWorld.map.blockMap.size(); ++i)
-	{
-		gameWorld.map.blockMap[i] = std::move(mission.gameWorld.map.blockMap[i]);
-	}
-	for (int i = 0; i < mission.gameWorld.map.auxMap.size(); ++i)
-	{
-		gameWorld.map.auxMap[i] = std::move(mission.gameWorld.map.auxMap[i]);
-	}
-	gameWorld.map.scroll.minX = mission.gameWorld.map.scroll.minX;
-	gameWorld.map.scroll.minY = mission.gameWorld.map.scroll.minY;
-	gameWorld.map.scroll.maxX = mission.gameWorld.map.scroll.maxX;
-	gameWorld.map.scroll.maxY = mission.gameWorld.map.scroll.maxY;
-	std::swap(mission.gameWorld.map.gateways, gwGetGateways(gameWorld.map));
-	//and clear the mission pointers
-	mission.gameWorld.map.tiles	= nullptr;
-	mission.gameWorld.map.width	= 0;
-	mission.gameWorld.map.height	= 0;
-	mission.gameWorld.map.scroll.minX	= 0;
-	mission.gameWorld.map.scroll.minY	= 0;
-	mission.gameWorld.map.scroll.maxX	= 0;
-	mission.gameWorld.map.scroll.maxY	= 0;
-	mission.gameWorld.map.gateways.clear();
 
 	//reset the current structure lists
 	setCurrentStructQuantity(gameWorld.objects, false);

--- a/src/mission.cpp
+++ b/src/mission.cpp
@@ -1313,18 +1313,15 @@ static void processMission()
 			addDroid(psDroid, mission.gameWorld.objects.droids);
 			droidX = getHomeLandingX();
 			droidY = getHomeLandingY();
-			// Swap the droid and map pointers
-			swapMissionPointers();
 
-			pickRes = pickHalfATile(gameWorld, &droidX, &droidY, LOOK_FOR_EMPTY_TILE);
+			pickRes = pickHalfATile(mission.gameWorld, &droidX, &droidY, LOOK_FOR_EMPTY_TILE);
 			ASSERT(pickRes != NO_FREE_TILE, "processMission: Unable to find a free location");
 			x = (UWORD)world_coord(droidX);
 			y = (UWORD)world_coord(droidY);
-			droidSetPosition(psDroid, gameWorld.map, x, y);
-			ASSERT(worldOnMap(gameWorld.map, psDroid->pos.x, psDroid->pos.y), "the droid is not on the map");
-			updateDroidOrientation(psDroid, gameWorld.map);
-			// Swap the droid and map pointers back again
-			swapMissionPointers();
+			droidSetPosition(psDroid, mission.gameWorld.map, x, y);
+			ASSERT(worldOnMap(mission.gameWorld.map, psDroid->pos.x, psDroid->pos.y), "the droid is not on the map");
+			updateDroidOrientation(psDroid, mission.gameWorld.map);
+
 			psDroid->selected = false;
 			// This is mainly for VTOLs
 			setDroidBase(psDroid, nullptr);

--- a/src/mission.cpp
+++ b/src/mission.cpp
@@ -1384,34 +1384,7 @@ void processMissionLimbo()
 void swapMissionPointers()
 {
 	debug(LOG_SAVE, "called");
-
-	std::swap(gameWorld.map.tiles, mission.gameWorld.map.tiles);
-	std::swap(gameWorld.map.width,   mission.gameWorld.map.width);
-	std::swap(gameWorld.map.height,  mission.gameWorld.map.height);
-	for (int i = 0; i < mission.gameWorld.map.blockMap.size(); ++i)
-	{
-		std::swap(gameWorld.map.blockMap[i], mission.gameWorld.map.blockMap[i]);
-	}
-	for (int i = 0; i < mission.gameWorld.map.auxMap.size(); ++i)
-	{
-		std::swap(gameWorld.map.auxMap[i],   mission.gameWorld.map.auxMap[i]);
-	}
-	//swap gateway zones
-	std::swap(mission.gameWorld.map.gateways, gwGetGateways(gameWorld.map));
-	std::swap(gameWorld.map.scroll.minX, mission.gameWorld.map.scroll.minX);
-	std::swap(gameWorld.map.scroll.minY, mission.gameWorld.map.scroll.minY);
-	std::swap(gameWorld.map.scroll.maxX, mission.gameWorld.map.scroll.maxX);
-	std::swap(gameWorld.map.scroll.maxY, mission.gameWorld.map.scroll.maxY);
-	for (unsigned inc = 0; inc < MAX_PLAYERS; inc++)
-	{
-		std::swap(gameWorld.objects.droids[inc],     mission.gameWorld.objects.droids[inc]);
-		std::swap(gameWorld.objects.structures[inc],    mission.gameWorld.objects.structures[inc]);
-		std::swap(gameWorld.objects.flags[inc],   mission.gameWorld.objects.flags[inc]);
-		std::swap(gameWorld.objects.extractors[inc], mission.gameWorld.objects.extractors[inc]);
-	}
-	std::swap(gameWorld.objects.features[0],   mission.gameWorld.objects.features[0]);
-	std::swap(gameWorld.objects.sensors[0], mission.gameWorld.objects.sensors[0]);
-	std::swap(gameWorld.objects.oils[0],    mission.gameWorld.objects.oils[0]);
+	std::swap(gameWorld, mission.gameWorld);
 }
 
 void endMission()

--- a/src/move.cpp
+++ b/src/move.cpp
@@ -253,7 +253,7 @@ static bool moveDroidToBase(DROID *psDroid, UDWORD x, UDWORD y, bool bFormation,
 	}
 	else
 	{
-		retVal = fpathDroidRoute(psDroid, x, y, moveType);
+		retVal = fpathDroidRoute(psDroid, gameWorld.map, x, y, moveType);
 	}
 
 	if (retVal == FPR_OK)

--- a/src/transporter.cpp
+++ b/src/transporter.cpp
@@ -942,7 +942,7 @@ void transporterRemoveDroid(DROID *psTransport, DROID *psDroid, QUEUE_MODE mode)
 		{
 			ASSERT(false, "Unable to find a valid location");
 		}
-		droidSetPosition(psDroid, world_coord(droidPos.x), world_coord(droidPos.y));
+		droidSetPosition(psDroid, gameWorld.map, world_coord(droidPos.x), world_coord(droidPos.y));
 		updateDroidOrientation(psDroid, gameWorld.map);
 	}
 

--- a/src/world_map_state.h
+++ b/src/world_map_state.h
@@ -26,6 +26,7 @@
 #include "lib/framework/frame.h"
 #include "gateway.h"
 
+#include <array>
 #include <memory>
 
 #include <stdint.h>
@@ -83,8 +84,8 @@ struct WorldMapState
 	std::unique_ptr<MAPTILE[]> tiles;
 	int32_t width = 0;
 	int32_t height = 0;
-	std::unique_ptr<uint8_t[]> blockMap[AUX_MAX];
-	std::unique_ptr<uint8_t[]> auxMap[MAX_PLAYERS + AUX_MAX]; ///< yes, we waste one element... eyes wide open... makes API nicer
+	std::array<std::unique_ptr<uint8_t[]>, AUX_MAX> blockMap;
+	std::array<std::unique_ptr<uint8_t[]>, MAX_PLAYERS + AUX_MAX> auxMap; ///< yes, we waste one element... eyes wide open... makes API nicer
 	WorldScrollLimits scroll;
 	/// the list of gateways on the current map
 	GATEWAY_LIST gateways;


### PR DESCRIPTION
Mostly mechanical changes around the functions directly required to allow removing some of the `swap_mission_pointers()` calls across the code base + simplify the code around copying/moving world state between missions.

There's still a single `swap_mission_pointers()` call site in `game.cpp`, which will be addressed in a following PR.

No semantical changes are expected.

Tests: regular campaign flow, saves/loads across offworld/home missions, loading into Beta/Gamma directly from "New Campaign" menu option.