### PR TITLE
Semperfi AI: Build super scourge borgs when available

### DIFF
--- a/data/mp/multiplay/skirmish/semperfi_includes/production.js
+++ b/data/mp/multiplay/skirmish/semperfi_includes/production.js
@@ -35,8 +35,8 @@ const CYBORG_FLAMERS = [
 	"CyborgFlamer01",
 ];
 const CYBORG_ROCKETS = [
-	"Cyb-Hvywpn-TK",
-	"Cyb-Hvywpn-A-T",
+	"Cyb-Hvywpn-A-T",	// Scourge
+	"Cyb-Hvywpn-TK",	// Tank killer
 ];
 
 // System definitions


### PR DESCRIPTION
Semperfi's cyborg rocket weapon list had the tank killer above the scourge, meaning that scourge cyborgs would never be built. Swapping them around fixes this.

<img width="699" height="612" alt="image" src="https://github.com/user-attachments/assets/2382bc50-4e68-4a4c-a958-0691dcc477c3" />
