### PR TITLE
Remove `swapMissionPointers()` + more world-aware functions (part 3)

### DIFF
--- a/src/droid.cpp
+++ b/src/droid.cpp
@@ -1313,7 +1313,7 @@ bool droidUpdateBuild(DROID *psDroid)
 	unsigned pointsToAdd = constructPoints * (gameTime - psDroid->actionStarted) / GAME_TICKS_PER_SEC;
 	int buildPointsToAdd = pointsToAdd - psDroid->actionPoints;
 
-	structureBuild(psStruct, psDroid, std::max(1, buildPointsToAdd), constructPoints);
+	structureBuild(gameWorld, psStruct, psDroid, std::max(1, buildPointsToAdd), constructPoints);
 
 	//store the amount just added
 	psDroid->actionPoints = pointsToAdd;
@@ -1342,7 +1342,7 @@ bool droidUpdateDemolishing(DROID *psDroid)
 	int constructRate = 5 * constructorPoints(*psDroid->getConstructStats(), psDroid->player);
 	int pointsToAdd = gameTimeAdjustedAverage(constructRate);
 
-	structureDemolish(psStruct, psDroid, pointsToAdd);
+	structureDemolish(gameWorld, psStruct, psDroid, pointsToAdd);
 
 	addConstructorEffect(psStruct);
 

--- a/src/droid.cpp
+++ b/src/droid.cpp
@@ -38,6 +38,7 @@
 
 #include "objects.h"
 #include "loop.h"
+#include "world_object_state.h"
 #include "visibility.h"
 #include "map.h"
 #include "droid.h"
@@ -386,12 +387,12 @@ int32_t droidDamage(DROID *psDroid, PROJECTILE *psProjectile, unsigned damage, W
 		if (bMultiPlayer && !bMultiMessages)
 		{
 			bMultiMessages = true;
-			destroyDroid(psDroid, impactTime);
+			destroyDroid(psDroid, impactTime, gameWorld);
 			bMultiMessages = false;
 		}
 		else
 		{
-			destroyDroid(psDroid, impactTime);
+			destroyDroid(psDroid, impactTime, gameWorld);
 		}
 	}
 
@@ -522,7 +523,7 @@ void recycleDroid(DROID *psDroid)
 	}
 
 	triggerEvent(TRIGGER_OBJECT_RECYCLED, psDroid);
-	vanishDroid(psDroid);
+	vanishDroid(psDroid, gameWorld.objects);
 
 	Vector3i position = psDroid->pos.xzy();
 	const auto mapCoord = map_coord({psDroid->pos.x, psDroid->pos.y});
@@ -536,7 +537,7 @@ void recycleDroid(DROID *psDroid)
 }
 
 
-bool removeDroidBase(DROID *psDel)
+bool removeDroidBase(DROID *psDel, WorldObjectState& objState)
 {
 	CHECK_DROID(psDel);
 
@@ -567,15 +568,15 @@ bool removeDroidBase(DROID *psDel)
 		if (psDel->psGroup)
 		{
 			//free all droids associated with this Transporter
-			mutating_list_iterate(psDel->psGroup->psList, [psDel](DROID* psCurr)
+			mutating_list_iterate(psDel->psGroup->psList, [psDel, &objState](DROID* psCurr)
 			{
 				if (psCurr == psDel)
 				{
 					return IterationResult::BREAK_ITERATION;
 				}
 				/* add droid to droid list then vanish it - hope this works! - GJ */
-				addDroid(psCurr, gameWorld.objects.droids);
-				vanishDroid(psCurr);
+				addDroid(psCurr, objState.droids);
+				vanishDroid(psCurr, objState);
 
 				return IterationResult::CONTINUE_ITERATION;
 			});
@@ -592,7 +593,7 @@ bool removeDroidBase(DROID *psDel)
 	/* Put Deliv. Pts back into world when a command droid dies */
 	if (psDel->droidType == DROID_COMMAND)
 	{
-		for (auto psStruct : gameWorld.objects.structures[psDel->player])
+		for (auto psStruct : objState.structures[psDel->player])
 		{
 			// alexl's stab at a right answer.
 			if (psStruct && psStruct->isFactory()
@@ -632,7 +633,7 @@ bool removeDroidBase(DROID *psDel)
 		intRefreshScreen();
 	}
 
-	killDroid(psDel);
+	killDroid(psDel, objState);
 	return true;
 }
 
@@ -682,7 +683,7 @@ static void removeDroidFX(DROID *psDel, unsigned impactTime)
 	}
 }
 
-bool destroyDroid(DROID *psDel, unsigned impactTime)
+bool destroyDroid(DROID *psDel, unsigned impactTime, GameWorld& world)
 {
 	ASSERT(gameTime - deltaGameTime <= impactTime, "Expected %u <= %u, gameTime = %u, bad impactTime", gameTime - deltaGameTime, impactTime, gameTime);
 
@@ -697,7 +698,7 @@ bool destroyDroid(DROID *psDel, unsigned impactTime)
 		{
 			for (breadth = mapY - 1; breadth <= mapY + 1; breadth++)
 			{
-				psTile = mapTile(gameWorld.map, width, breadth);
+				psTile = mapTile(world.map, width, breadth);
 				if (TEST_TILE_VISIBLE_TO_SELECTEDPLAYER(psTile))
 				{
 					psTile->illumination /= 2;
@@ -708,14 +709,14 @@ bool destroyDroid(DROID *psDel, unsigned impactTime)
 	}
 
 	removeDroidFX(psDel, impactTime);
-	removeDroidBase(psDel);
+	removeDroidBase(psDel, world.objects);
 	psDel->died = impactTime;
 	return true;
 }
 
-void vanishDroid(DROID *psDel)
+void vanishDroid(DROID *psDel, WorldObjectState& objState)
 {
-	removeDroidBase(psDel);
+	removeDroidBase(psDel, objState);
 }
 
 static size_t droidCancelRepairers(DROID *psDroid, PerPlayerDroidLists& pList)
@@ -3527,7 +3528,7 @@ DROID *giftSingleDroid(DROID *psD, UDWORD to, bool electronic, Vector2i pos)
 		}
 		// make the old droid vanish (but is not deleted until next tick)
 		adjustDroidCount(psD, -1);
-		vanishDroid(psD);
+		vanishDroid(psD, gameWorld.objects);
 		// Pick coordinates of the new droid if damaged electronically
 		Position newPos = Position(psD->pos.x, psD->pos.y, 0);
 		if (electronic)

--- a/src/droid.cpp
+++ b/src/droid.cpp
@@ -286,6 +286,7 @@ void addDroidDeathAnimationEffect(DROID *psDroid)
 
 #define UNIT_LOST_DELAY	(5*GAME_TICKS_PER_SEC)
 /* Deals damage to a droid
+ * \param world the game world droid belongs to
  * \param psDroid droid to deal damage to
  * \param psProjectile projectile which hit the object (may be nullptr)
  * \param damage amount of damage to deal
@@ -295,7 +296,7 @@ void addDroidDeathAnimationEffect(DROID *psDroid)
  * \return > 0 when the dealt damage destroys the droid, < 0 when the droid survives
  *
  */
-int32_t droidDamage(DROID *psDroid, PROJECTILE *psProjectile, unsigned damage, WEAPON_CLASS weaponClass, WEAPON_SUBCLASS weaponSubClass, unsigned impactTime, bool isDamagePerSecond, int minDamage, bool empRadiusHit)
+int32_t droidDamage(GameWorld& world, DROID *psDroid, PROJECTILE *psProjectile, unsigned damage, WEAPON_CLASS weaponClass, WEAPON_SUBCLASS weaponSubClass, unsigned impactTime, bool isDamagePerSecond, int minDamage, bool empRadiusHit)
 {
 	int32_t relativeDamage;
 
@@ -326,7 +327,7 @@ int32_t droidDamage(DROID *psDroid, PROJECTILE *psProjectile, unsigned damage, W
 		// reset the attack level
 		if (secondaryGetState(psDroid, DSO_ATTACK_LEVEL) == DSS_ALEV_ATTACKED)
 		{
-			secondarySetState(psDroid, gameWorld.objects, DSO_ATTACK_LEVEL, DSS_ALEV_ALWAYS);
+			secondarySetState(psDroid, world.objects, DSO_ATTACK_LEVEL, DSS_ALEV_ALWAYS);
 		}
 		// Now check for auto return on droid's secondary orders (i.e. return on medium/heavy damage)
 		secondaryCheckDamageLevel(psDroid);
@@ -387,12 +388,12 @@ int32_t droidDamage(DROID *psDroid, PROJECTILE *psProjectile, unsigned damage, W
 		if (bMultiPlayer && !bMultiMessages)
 		{
 			bMultiMessages = true;
-			destroyDroid(psDroid, impactTime, gameWorld);
+			destroyDroid(psDroid, impactTime, world);
 			bMultiMessages = false;
 		}
 		else
 		{
-			destroyDroid(psDroid, impactTime, gameWorld);
+			destroyDroid(psDroid, impactTime, world);
 		}
 	}
 
@@ -1024,7 +1025,7 @@ void droidUpdate(DROID *psDroid)
 		else
 		{
 			// do hardcoded burn damage (this damage automatically applied after periodical damage finished)
-			droidDamage(psDroid, nullptr, BURN_DAMAGE, WC_HEAT, WSC_FLAME, gameTime - deltaGameTime / 2 + 1, true, BURN_MIN_DAMAGE, false);
+			droidDamage(gameWorld, psDroid, nullptr, BURN_DAMAGE, WC_HEAT, WSC_FLAME, gameTime - deltaGameTime / 2 + 1, true, BURN_MIN_DAMAGE, false);
 		}
 	}
 

--- a/src/droid.cpp
+++ b/src/droid.cpp
@@ -611,7 +611,7 @@ bool removeDroidBase(DROID *psDel, WorldObjectState& objState)
 		if (tryingToGetLocation())
 		{
 			int numSelectedConstructors = 0;
-			for (const DROID *psDroid : gameWorld.objects.droids[psDel->player])
+			for (const DROID *psDroid : objState.droids[psDel->player])
 			{
 				numSelectedConstructors += psDroid->selected && psDroid->isConstructionDroid();
 			}

--- a/src/droid.h
+++ b/src/droid.h
@@ -69,7 +69,7 @@ void add_to_experience_queue(int player, int value);
 // initialise droid module
 bool droidInit();
 
-bool removeDroidBase(DROID *psDel);
+bool removeDroidBase(DROID *psDel, WorldObjectState& objState);
 
 struct INITIAL_DROID_ORDERS
 {
@@ -161,10 +161,10 @@ bool droidUpdateRestore(DROID *psDroid);
 void recycleDroid(DROID *psDel);
 
 /* Remove a droid and free it's memory */
-bool destroyDroid(DROID *psDel, unsigned impactTime);
+bool destroyDroid(DROID *psDel, unsigned impactTime, GameWorld& world);
 
 /* Same as destroy droid except no graphical effects */
-void vanishDroid(DROID *psDel);
+void vanishDroid(DROID *psDel, WorldObjectState& objState);
 
 /* Remove a droid from the apsDroidLists so doesn't update or get drawn etc*/
 //returns true if successfully removed from the list

--- a/src/droid.h
+++ b/src/droid.h
@@ -118,7 +118,7 @@ UDWORD calcTemplateBuild(const DROID_TEMPLATE *psTemplate);
 UDWORD calcTemplatePower(const DROID_TEMPLATE *psTemplate);
 
 /* Do damage to a droid */
-int32_t droidDamage(DROID *psDroid, PROJECTILE *psProjectile, unsigned damage, WEAPON_CLASS weaponClass, WEAPON_SUBCLASS weaponSubClass, unsigned impactTime, bool isDamagePerSecond, int minDamage, bool empRadiusHit);
+int32_t droidDamage(GameWorld& world, DROID *psDroid, PROJECTILE *psProjectile, unsigned damage, WEAPON_CLASS weaponClass, WEAPON_SUBCLASS weaponSubClass, unsigned impactTime, bool isDamagePerSecond, int minDamage, bool empRadiusHit);
 
 /* The main update routine for all droids */
 void droidUpdate(DROID *psDroid);

--- a/src/feature.cpp
+++ b/src/feature.cpp
@@ -167,7 +167,7 @@ int32_t featureDamage(FEATURE *psFeature, unsigned damage, WEAPON_CLASS weaponCl
 	if (relativeDamage < 0)
 	{
 		debug(LOG_ATTACK, "feature (id %d) DESTROYED", psFeature->id);
-		destroyFeature(psFeature, impactTime);
+		destroyFeature(psFeature, impactTime, gameWorld);
 		return relativeDamage * -1;
 	}
 	else
@@ -176,14 +176,14 @@ int32_t featureDamage(FEATURE *psFeature, unsigned damage, WEAPON_CLASS weaponCl
 	}
 }
 
-FEATURE *buildFeature(WorldMapState& mapState, FEATURE_STATS *psStats, UDWORD x, UDWORD y, bool FromSave)
+FEATURE *buildFeature(GameWorld& world, FEATURE_STATS *psStats, UDWORD x, UDWORD y, bool FromSave)
 {
 	const auto id = generateSynchronisedObjectId();
-	return buildFeature(mapState, psStats, x, y, FromSave, id);
+	return buildFeature(world, psStats, x, y, FromSave, id);
 }
 
 /* Get pitch and roll from direction and tile data */
-static void updateFeatureOrientation(FEATURE *psFeature)
+static void updateFeatureOrientation(FEATURE *psFeature, const WorldMapState& mapState)
 {
 	int32_t hx0, hx1, hy0, hy1;
 	int newPitch, deltaPitch; //, pitchLimit;
@@ -195,10 +195,10 @@ static void updateFeatureOrientation(FEATURE *psFeature)
 	//    hy0
 	// hx0 * hx1      (* = feature)
 	//    hy1
-	hx1 = map_Height(gameWorld.map, psFeature->pos.x + d, psFeature->pos.y);
-	hx0 = map_Height(gameWorld.map, MAX(0, psFeature->pos.x - d), psFeature->pos.y);
-	hy1 = map_Height(gameWorld.map, psFeature->pos.x, psFeature->pos.y + d);
-	hy0 = map_Height(gameWorld.map, psFeature->pos.x, MAX(0, psFeature->pos.y - d));
+	hx1 = map_Height(mapState, psFeature->pos.x + d, psFeature->pos.y);
+	hx0 = map_Height(mapState, MAX(0, psFeature->pos.x - d), psFeature->pos.y);
+	hy1 = map_Height(mapState, psFeature->pos.x, psFeature->pos.y + d);
+	hy0 = map_Height(mapState, psFeature->pos.x, MAX(0, psFeature->pos.y - d));
 
 	//update height in case in the bottom of a trough
 	psFeature->pos.z = MAX(psFeature->pos.z, (hx0 + hx1) / 2);
@@ -233,14 +233,14 @@ static void updateFeatureOrientation(FEATURE *psFeature)
 }
 
 /* Create a feature on the map */
-FEATURE *buildFeature(WorldMapState& mapState, FEATURE_STATS *psStats, UDWORD x, UDWORD y, bool FromSave, uint32_t id)
+FEATURE *buildFeature(GameWorld& world, FEATURE_STATS *psStats, UDWORD x, UDWORD y, bool FromSave, uint32_t id)
 {
 	//try and create the Feature, obtain stable address.
 	FEATURE& feature = GlobalFeatureContainer().emplace(id, psStats);
 	FEATURE* psFeature = &feature;
 
 	//add the feature to the list - this enables it to be drawn whilst being built
-	addFeature(psFeature);
+	addFeature(psFeature, world.objects);
 
 	// snap the coords to a tile
 	if (!FromSave)
@@ -269,7 +269,7 @@ FEATURE *buildFeature(WorldMapState& mapState, FEATURE_STATS *psStats, UDWORD x,
 	{
 		for (int width = 0; width <= b.size.x; ++width)
 		{
-			int h = map_TileHeight(mapState, b.map.x + width, b.map.y + breadth);
+			int h = map_TileHeight(world.map, b.map.x + width, b.map.y + breadth);
 			foundationMin = std::min(foundationMin, h);
 			foundationMax = std::max(foundationMax, h);
 		}
@@ -305,11 +305,11 @@ FEATURE *buildFeature(WorldMapState& mapState, FEATURE_STATS *psStats, UDWORD x,
 	{
 		for (int width = 0; width < b.size.x; ++width)
 		{
-			MAPTILE *psTile = mapTile(mapState, b.map.x + width, b.map.y + breadth);
+			MAPTILE *psTile = mapTile(world.map, b.map.x + width, b.map.y + breadth);
 
 			//check not outside of map - for load save game
-			ASSERT_OR_RETURN(nullptr, b.map.x + width < mapState.width, "x coord bigger than map width - %s, id = %d", getStatsName(psFeature->psStats), psFeature->id);
-			ASSERT_OR_RETURN(nullptr, b.map.y + breadth < mapState.height, "y coord bigger than map height - %s, id = %d", getStatsName(psFeature->psStats), psFeature->id);
+			ASSERT_OR_RETURN(nullptr, b.map.x + width < world.map.width, "x coord bigger than map width - %s, id = %d", getStatsName(psFeature->psStats), psFeature->id);
+			ASSERT_OR_RETURN(nullptr, b.map.y + breadth < world.map.height, "y coord bigger than map height - %s, id = %d", getStatsName(psFeature->psStats), psFeature->id);
 
 			if (width != psStats->baseWidth && breadth != psStats->baseBreadth)
 			{
@@ -321,7 +321,7 @@ FEATURE *buildFeature(WorldMapState& mapState, FEATURE_STATS *psStats, UDWORD x,
 					      getStatsName(psBlock->psStats), psBlock->id, map_coord(psBlock->pos.x), psBlock->psStats->baseWidth, map_coord(psBlock->pos.y),
 					      psBlock->psStats->baseBreadth, getStatsName(psFeature->psStats), psFeature->id, b.map.x, b.size.x, b.map.y, b.size.y);
 
-					removeFeature(psBlock);
+					removeFeature(psBlock, world);
 				}
 
 				psTile->psObject = (BASE_OBJECT *)psFeature;
@@ -329,12 +329,12 @@ FEATURE *buildFeature(WorldMapState& mapState, FEATURE_STATS *psStats, UDWORD x,
 				// if it's a tall feature then flag it in the map.
 				if (psFeature->sDisplay.imd->max.y > TALLOBJECT_YMAX)
 				{
-					auxSetBlocking(mapState, b.map.x + width, b.map.y + breadth, AIR_BLOCKED);
+					auxSetBlocking(world.map, b.map.x + width, b.map.y + breadth, AIR_BLOCKED);
 				}
 
 				if (psStats->subType != FEAT_GEN_ARTE && psStats->subType != FEAT_OIL_DRUM)
 				{
-					auxSetBlocking(mapState, b.map.x + width, b.map.y + breadth, FEATURE_BLOCKED);
+					auxSetBlocking(world.map, b.map.x + width, b.map.y + breadth, FEATURE_BLOCKED);
 				}
 			}
 
@@ -344,8 +344,8 @@ FEATURE *buildFeature(WorldMapState& mapState, FEATURE_STATS *psStats, UDWORD x,
 			}
 		}
 	}
-	psFeature->pos.z = map_TileHeight(mapState, psFeature->pos.x, psFeature->pos.y);//jps 18july97
-	updateFeatureOrientation(psFeature);
+	psFeature->pos.z = map_TileHeight(world.map, psFeature->pos.x, psFeature->pos.y);//jps 18july97
+	updateFeatureOrientation(psFeature, world.map);
 
 	return psFeature;
 }
@@ -401,7 +401,7 @@ void featureUpdate(FEATURE *psFeat)
 
 
 // free up a feature with no visual effects
-bool removeFeature(FEATURE *psDel)
+bool removeFeature(FEATURE *psDel, GameWorld& world)
 {
 	MESSAGE		*psMessage;
 	Vector3i	pos;
@@ -415,14 +415,14 @@ bool removeFeature(FEATURE *psDel)
 	{
 		for (int width = 0; width < b.size.x; ++width)
 		{
-			if (tileOnMap(gameWorld.map, b.map.x + width, b.map.y + breadth))
+			if (tileOnMap(world.map, b.map.x + width, b.map.y + breadth))
 			{
-				MAPTILE *psTile = mapTile(gameWorld.map, b.map.x + width, b.map.y + breadth);
+				MAPTILE *psTile = mapTile(world.map, b.map.x + width, b.map.y + breadth);
 
 				if (psTile->psObject == psDel)
 				{
 					psTile->psObject = nullptr;
-					auxClearBlocking(gameWorld.map, b.map.x + width, b.map.y + breadth, FEATURE_BLOCKED | AIR_BLOCKED);
+					auxClearBlocking(world.map, b.map.x + width, b.map.y + breadth, FEATURE_BLOCKED | AIR_BLOCKED);
 				}
 			}
 		}
@@ -432,7 +432,7 @@ bool removeFeature(FEATURE *psDel)
 	{
 		pos.x = psDel->pos.x;
 		pos.z = psDel->pos.y;
-		pos.y = map_Height(gameWorld.map, pos.x, pos.z) + 30;
+		pos.y = map_Height(world.map, pos.x, pos.z) + 30;
 		addEffect(&pos, EFFECT_EXPLOSION, EXPLOSION_TYPE_DISCOVERY, false, nullptr, 0, gameTime - deltaGameTime + 1);
 		if (psDel->psStats->subType == FEAT_GEN_ARTE)
 		{
@@ -461,13 +461,13 @@ bool removeFeature(FEATURE *psDel)
 	}
 
 	debug(LOG_DEATH, "Killing off feature %s id %d (%p)", objInfo(psDel), psDel->id, static_cast<void *>(psDel));
-	killFeature(psDel);
+	killFeature(psDel, world.objects);
 
 	return true;
 }
 
 /* Remove a Feature and free it's memory */
-bool destroyFeature(FEATURE *psDel, unsigned impactTime)
+bool destroyFeature(FEATURE *psDel, unsigned impactTime, GameWorld& world)
 {
 	UDWORD			widthScatter, breadthScatter, heightScatter, i;
 	EFFECT_TYPE		explosionSize;
@@ -519,7 +519,7 @@ bool destroyFeature(FEATURE *psDel, unsigned impactTime)
 		/* Then a sequence of effects */
 		pos.x = psDel->pos.x;
 		pos.z = psDel->pos.y;
-		pos.y = map_Height(gameWorld.map, pos.x, pos.z);
+		pos.y = map_Height(world.map, pos.x, pos.z);
 		addEffect(&pos, EFFECT_DESTRUCTION, DESTRUCTION_TYPE_FEATURE, false, nullptr, 0, impactTime);
 
 		//play sound
@@ -546,7 +546,7 @@ bool destroyFeature(FEATURE *psDel, unsigned impactTime)
 			{
 				const unsigned int x = b.map.x + width;
 				const unsigned int y = b.map.y + breadth;
-				MAPTILE *psTile = mapTile(gameWorld.map, x, y);
+				MAPTILE *psTile = mapTile(world.map, x, y);
 				if (psTile->psObject != psDel)
 				{
 					continue;
@@ -561,13 +561,13 @@ bool destroyFeature(FEATURE *psDel, unsigned impactTime)
 						{
 							makeTileRubbleTexture(psTile, x, y, RUBBLE_TILE);
 						}
-						auxClearBlocking(gameWorld.map, x, y, AUXBITS_ALL);
+						auxClearBlocking(world.map, x, y, AUXBITS_ALL);
 					}
 					else
 					{
 						/* This remains a blocking tile */
 						psTile->psObject = nullptr;
-						auxClearBlocking(gameWorld.map, x, y, AIR_BLOCKED);  // Shouldn't remain blocking for air units, however.
+						auxClearBlocking(world.map, x, y, AIR_BLOCKED);  // Shouldn't remain blocking for air units, however.
 						if (isUrban)
 						{
 							makeTileRubbleTexture(psTile, x, y, BLOCKING_RUBBLE_TILE);
@@ -578,7 +578,7 @@ bool destroyFeature(FEATURE *psDel, unsigned impactTime)
 		}
 	}
 
-	removeFeature(psDel);
+	removeFeature(psDel, world);
 	psDel->died = impactTime;
 	return true;
 }

--- a/src/feature.cpp
+++ b/src/feature.cpp
@@ -147,12 +147,13 @@ void featureStatsShutDown()
 }
 
 /** Deals with damage to a feature
+ *  \param world the game world feature belongs to
  *  \param psFeature feature to deal damage to
  *  \param damage amount of damage to deal
  *  \param weaponClass,weaponSubClass the class and subclass of the weapon that deals the damage
  *  \return < 0 never, >= 0 always
  */
-int32_t featureDamage(FEATURE *psFeature, unsigned damage, WEAPON_CLASS weaponClass, WEAPON_SUBCLASS weaponSubClass, unsigned impactTime, bool isDamagePerSecond, int minDamage, bool empRadiusHit)
+int32_t featureDamage(GameWorld& world, FEATURE *psFeature, unsigned damage, WEAPON_CLASS weaponClass, WEAPON_SUBCLASS weaponSubClass, unsigned impactTime, bool isDamagePerSecond, int minDamage, bool empRadiusHit)
 {
 	int32_t relativeDamage;
 
@@ -167,7 +168,7 @@ int32_t featureDamage(FEATURE *psFeature, unsigned damage, WEAPON_CLASS weaponCl
 	if (relativeDamage < 0)
 	{
 		debug(LOG_ATTACK, "feature (id %d) DESTROYED", psFeature->id);
-		destroyFeature(psFeature, impactTime, gameWorld);
+		destroyFeature(psFeature, impactTime, world);
 		return relativeDamage * -1;
 	}
 	else

--- a/src/feature.cpp
+++ b/src/feature.cpp
@@ -305,11 +305,10 @@ FEATURE *buildFeature(GameWorld& world, FEATURE_STATS *psStats, UDWORD x, UDWORD
 	{
 		for (int width = 0; width < b.size.x; ++width)
 		{
-			MAPTILE *psTile = mapTile(world.map, b.map.x + width, b.map.y + breadth);
-
-			//check not outside of map - for load save game
-			ASSERT_OR_RETURN(nullptr, b.map.x + width < world.map.width, "x coord bigger than map width - %s, id = %d", getStatsName(psFeature->psStats), psFeature->id);
-			ASSERT_OR_RETURN(nullptr, b.map.y + breadth < world.map.height, "y coord bigger than map height - %s, id = %d", getStatsName(psFeature->psStats), psFeature->id);
+			const int tileX = b.map.x + width;
+			const int tileY = b.map.y + breadth;
+			ASSERT_OR_RETURN(nullptr, tileOnMap(world.map, tileX, tileY), "feature is off-map - %s, id = %d", getStatsName(psFeature->psStats), psFeature->id);
+			MAPTILE *psTile = mapTile(world.map, tileX, tileY);
 
 			if (width != psStats->baseWidth && breadth != psStats->baseBreadth)
 			{

--- a/src/feature.h
+++ b/src/feature.h
@@ -28,7 +28,7 @@
 #include "lib/framework/wzconfig.h"
 #include "lib/framework/paged_entity_container.h"
 
-struct WorldMapState;
+struct GameWorld;
 
 /* The statistics for the features */
 extern std::vector<FEATURE_STATS> asFeatureStats;
@@ -43,17 +43,17 @@ bool loadFeatureStats(WzConfig &ini);
 void featureStatsShutDown();
 
 /* Create a feature on the map */
-FEATURE *buildFeature(WorldMapState& mapState, FEATURE_STATS *psStats, UDWORD x, UDWORD y, bool FromSave);
-FEATURE *buildFeature(WorldMapState& mapState, FEATURE_STATS *psStats, UDWORD x, UDWORD y, bool FromSave, uint32_t id);
+FEATURE *buildFeature(GameWorld& world, FEATURE_STATS *psStats, UDWORD x, UDWORD y, bool FromSave);
+FEATURE *buildFeature(GameWorld& world, FEATURE_STATS *psStats, UDWORD x, UDWORD y, bool FromSave, uint32_t id);
 
 /* Update routine for features */
 void featureUpdate(FEATURE *psFeat);
 
 // free up a feature with no visual effects
-bool removeFeature(FEATURE *psDel);
+bool removeFeature(FEATURE *psDel, GameWorld& world);
 
 /* Remove a Feature and free it's memory */
-bool destroyFeature(FEATURE *psDel, unsigned impactTime);
+bool destroyFeature(FEATURE *psDel, unsigned impactTime, GameWorld& world);
 
 /* get a feature stat id from its name */
 SDWORD getFeatureStatFromName(const WzString &name);

--- a/src/feature.h
+++ b/src/feature.h
@@ -58,7 +58,7 @@ bool destroyFeature(FEATURE *psDel, unsigned impactTime, GameWorld& world);
 /* get a feature stat id from its name */
 SDWORD getFeatureStatFromName(const WzString &name);
 
-int32_t featureDamage(FEATURE *psFeature, unsigned damage, WEAPON_CLASS weaponClass, WEAPON_SUBCLASS weaponSubClass, unsigned impactTime, bool isDamagePerSecond, int minDamage, bool empRadiusHit);
+int32_t featureDamage(GameWorld& world, FEATURE *psFeature, unsigned damage, WEAPON_CLASS weaponClass, WEAPON_SUBCLASS weaponSubClass, unsigned impactTime, bool isDamagePerSecond, int minDamage, bool empRadiusHit);
 
 void featureInitVars();
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -3008,12 +3008,12 @@ bool loadGame(const GameLoadDetails& gameToLoad, bool keepObjects, bool freeMem)
 			missionScrollMaxY = (UWORD)mission.gameWorld.map.scroll.maxY;
 		}
 
-		//load the map and the droids then swap pointers
+		//load the mission map and objects directly into mission.gameWorld
 
 		//load in the map file
 		aFileName[fileExten] = '\0';
 		strcat(aFileName, "mission.map");
-		if (!mapLoad(aFileName, gameWorld.map))
+		if (!mapLoad(aFileName, mission.gameWorld.map))
 		{
 			debug(LOG_ERROR, "Failed with: %s", aFileName);
 			return false;
@@ -3024,7 +3024,7 @@ bool loadGame(const GameLoadDetails& gameToLoad, bool keepObjects, bool freeMem)
 		strcat(aFileName, "misvis.bjo");
 
 		// Load in the visibility data from the chosen file
-		if (!readVisibilityData(aFileName, gameWorld.map))
+		if (!readVisibilityData(aFileName, mission.gameWorld.map))
 		{
 			debug(LOG_ERROR, "Failed with: %s", aFileName);
 			goto error;
@@ -3036,7 +3036,7 @@ bool loadGame(const GameLoadDetails& gameToLoad, bool keepObjects, bool freeMem)
 		strcat(aFileName, "mfeature.json");
 
 		//load the data into apsFeatureList
-		if (!loadSaveFeature2(aFileName, gameWorld))
+		if (!loadSaveFeature2(aFileName, mission.gameWorld))
 		{
 			aFileName[fileExten] = '\0';
 			strcat(aFileName, "mfeat.bjo");
@@ -3047,7 +3047,7 @@ bool loadGame(const GameLoadDetails& gameToLoad, bool keepObjects, bool freeMem)
 				debug(LOG_ERROR, "Failed with: %s", aFileName);
 				goto error;
 			}
-			if (!loadSaveFeature(pFileData, fileSize, gameWorld))
+			if (!loadSaveFeature(pFileData, fileSize, mission.gameWorld))
 			{
 				debug(LOG_ERROR, "Failed with: %s", aFileName);
 				goto error;
@@ -3059,7 +3059,7 @@ bool loadGame(const GameLoadDetails& gameToLoad, bool keepObjects, bool freeMem)
 		strcat(aFileName, "mstruct.json");
 
 		//load in the mission structures
-		if (!loadSaveStructure2(aFileName, gameWorld))
+		if (!loadSaveStructure2(aFileName, mission.gameWorld))
 		{
 			aFileName[fileExten] = '\0';
 			strcat(aFileName, "mstruct.bjo");
@@ -3071,7 +3071,7 @@ bool loadGame(const GameLoadDetails& gameToLoad, bool keepObjects, bool freeMem)
 				goto error;
 			}
 			//load the data into apsStructLists
-			if (!loadSaveStructure(pFileData, fileSize, gameWorld))
+			if (!loadSaveStructure(pFileData, fileSize, mission.gameWorld))
 			{
 				debug(LOG_ERROR, "Failed with: %s", aFileName);
 				goto error;
@@ -3079,15 +3079,15 @@ bool loadGame(const GameLoadDetails& gameToLoad, bool keepObjects, bool freeMem)
 		}
 		else
 		{
-			structMap[aFileName] = &mission.gameWorld.objects.structures;	// we swap pointers below
+			structMap[aFileName] = &mission.gameWorld.objects.structures;
 		}
 
 		// load in the mission droids, if any
 		aFileName[fileExten] = '\0';
 		strcat(aFileName, "mdroid.json");
-		if (loadSaveDroid(aFileName, gameWorld, gameWorld.objects.droids))
+		if (loadSaveDroid(aFileName, mission.gameWorld, mission.gameWorld.objects.droids))
 		{
-			droidMap[aFileName] = &mission.gameWorld.objects.droids; // need to swap here to read correct list later
+			droidMap[aFileName] = &mission.gameWorld.objects.droids;
 		}
 
 		/* after we've loaded in the units we need to redo the orientation because
@@ -3096,7 +3096,7 @@ bool loadGame(const GameLoadDetails& gameToLoad, bool keepObjects, bool freeMem)
 		 */
 		for (player = 0; player < MAX_PLAYERS; ++player)
 		{
-			for (DROID* psCurr : gameWorld.objects.droids[player])
+			for (DROID* psCurr : mission.gameWorld.objects.droids[player])
 			{
 				if (psCurr->droidType != DROID_PERSON
 				    // && psCurr->droidType != DROID_CYBORG
@@ -3104,12 +3104,10 @@ bool loadGame(const GameLoadDetails& gameToLoad, bool keepObjects, bool freeMem)
 				    && (!psCurr->isTransporter())
 				    && psCurr->pos.x != INVALID_XY)
 				{
-					updateDroidOrientation(psCurr, gameWorld.map);
+					updateDroidOrientation(psCurr, mission.gameWorld.map);
 				}
 			}
 		}
-
-		swapMissionPointers();
 
 		//once the mission map has been loaded reset the mission scroll limits
 		if (saveGameVersion >= VERSION_29)

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -6270,7 +6270,7 @@ bool loadSaveStructure(char *pFileData, UDWORD filesize, GameWorld& world)
 		psStructure->status = (STRUCT_STATES)psSaveStructure->status;
 		if (psStructure->status == SS_BUILT)
 		{
-			buildingComplete(psStructure);
+			buildingComplete(psStructure, world);
 		}
 		if (psStructure->pStructureType->type == REF_HQ)
 		{
@@ -6397,7 +6397,7 @@ static bool loadWzMapStructure(WzMap::Map& wzMap, std::unordered_map<UDWORD, UDW
 				buildStructure(world, moduleStat, structure.position.x, structure.position.y, player, true);
 			}
 		}
-		buildingComplete(psStructure);
+		buildingComplete(psStructure, world);
 		if (psStructure->pStructureType->type == REF_HQ)
 		{
 			scriptSetStartPos(player, psStructure->pos.x, psStructure->pos.y);
@@ -6632,10 +6632,10 @@ static bool loadSaveStructure2(const char *pFileName, GameWorld& world)
 			switch (psStructure->pStructureType->type)
 			{
 			case REF_POWER_GEN:
-				checkForResExtractors(psStructure);
+				checkForResExtractors(psStructure, world.objects);
 				break;
 			case REF_RESOURCE_EXTRACTOR:
-				checkForPowerGen(psStructure);
+				checkForPowerGen(psStructure, world.objects);
 				break;
 			default:
 				//do nothing for factories etc
@@ -6656,7 +6656,7 @@ static bool loadSaveStructure2(const char *pFileName, GameWorld& world)
 		psStructure->status = (STRUCT_STATES)ini.value("status", SS_BUILT).toInt();
 		if (psStructure->status == SS_BUILT)
 		{
-			buildingComplete(psStructure);
+			buildingComplete(psStructure, world);
 		}
 		ini.endGroup();
 	}
@@ -7057,7 +7057,7 @@ bool loadSaveFeature(char *pFileData, UDWORD filesize, GameWorld& world)
 			continue;
 		}
 		//create the Feature
-		pFeature = buildFeature(world.map, psStats, psSaveFeature->x, psSaveFeature->y, true, psSaveFeature->id);
+		pFeature = buildFeature(world, psStats, psSaveFeature->x, psSaveFeature->y, true, psSaveFeature->id);
 		if (!pFeature)
 		{
 			debug(LOG_ERROR, "Unable to create feature %s", psSaveFeature->name);
@@ -7114,7 +7114,7 @@ static bool loadWzMapFeature(WzMap::Map &wzMap, std::unordered_map<UDWORD, UDWOR
 				debug(LOG_ERROR, "Found duplicate hard-coded object ID in map data: %" PRIu32 "", feature.id.value());
 			}
 		}
-		pFeature = buildFeature(gameWorld.map, &*psStats, feature.position.x, feature.position.y, true, newID);
+		pFeature = buildFeature(gameWorld, &*psStats, feature.position.x, feature.position.y, true, newID);
 		if (!pFeature)
 		{
 			debug(LOG_ERROR, "Unable to create feature %s", feature.name.c_str());
@@ -7174,11 +7174,11 @@ bool loadSaveFeature2(const char *pFileName, GameWorld& world)
 		int id = ini.value("id", -1).toInt();
 		if (id > 0)
 		{
-			pFeature = buildFeature(world.map, psStats, pos.x, pos.y, true, id);
+			pFeature = buildFeature(world, psStats, pos.x, pos.y, true, id);
 		}
 		else
 		{
-			pFeature = buildFeature(world.map, psStats, pos.x, pos.y, true);
+			pFeature = buildFeature(world, psStats, pos.x, pos.y, true);
 		}
 		if (!pFeature)
 		{

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -3525,11 +3525,15 @@ error:
 	      keepObjects ? "true" : "false", freeMem ? "true" : "false", UserSaveGame ? "true" : "false");
 
 	/* Clear all the objects off the map and free up the map memory */
+	freeAllDroids(mission.gameWorld);
+	freeAllStructs(mission.gameWorld);
+	freeAllFeatures(mission.gameWorld);
+	mission.gameWorld = {};
 	freeAllDroids(gameWorld);
 	freeAllStructs(gameWorld);
 	freeAllFeatures(gameWorld);
 	droidTemplateShutDown();
-	gameWorld.map.tiles = nullptr;
+	gameWorld = {};
 
 	/* Start the game clock */
 	gameTimeStart();

--- a/src/hci.cpp
+++ b/src/hci.cpp
@@ -1754,7 +1754,7 @@ INT_RETVAL intRunWidgets()
 							}
 							else if (psFeature && psTile->psObject->type == OBJ_FEATURE)
 							{
-								removeFeature(psFeature);
+								removeFeature(psFeature, gameWorld);
 							}
 						}
 						else

--- a/src/keybind.cpp
+++ b/src/keybind.cpp
@@ -925,7 +925,7 @@ void kf_MapCheck()
 
 	for (STRUCTURE* psStruct : gameWorld.objects.structures[selectedPlayer])
 	{
-		alignStructure(psStruct);
+		alignStructure(psStruct, gameWorld.map);
 	}
 
 	for (auto& psFlag : gameWorld.objects.flags[selectedPlayer])
@@ -1704,9 +1704,9 @@ void	kf_JumpToResourceExtractor()
 	}
 }
 
-void keybindInformResourceExtractorRemoved(const STRUCTURE* psResourceExtractor)
+void keybindInformResourceExtractorRemoved(const STRUCTURE* psResourceExtractor, const WorldObjectState& objState)
 {
-	if (psOldRE.has_value() && *psOldRE != gameWorld.objects.extractors[selectedPlayer].end() && **psOldRE == psResourceExtractor)
+	if (psOldRE.has_value() && *psOldRE != objState.extractors[selectedPlayer].end() && **psOldRE == psResourceExtractor)
 	{
 		psOldRE.reset();
 	}

--- a/src/keybind.cpp
+++ b/src/keybind.cpp
@@ -1706,7 +1706,20 @@ void	kf_JumpToResourceExtractor()
 
 void keybindInformResourceExtractorRemoved(const STRUCTURE* psResourceExtractor, const WorldObjectState& objState)
 {
-	if (psOldRE.has_value() && *psOldRE != objState.extractors[selectedPlayer].end() && **psOldRE == psResourceExtractor)
+	if (selectedPlayer >= MAX_PLAYERS)
+	{
+		psOldRE.reset();
+		return;
+	}
+
+	// Only consider the case `objState` represents the currently active game world state.
+	const auto& activeExtractors = gameWorld.objects.extractors[selectedPlayer];
+	if (&objState.extractors[selectedPlayer] != &activeExtractors)
+	{
+		return;
+	}
+
+	if (psOldRE.has_value() && *psOldRE != activeExtractors.end() && **psOldRE == psResourceExtractor)
 	{
 		psOldRE.reset();
 	}

--- a/src/keybind.h
+++ b/src/keybind.h
@@ -207,6 +207,8 @@ void enableGodMode();
 
 void keybindShutdown();
 
-void keybindInformResourceExtractorRemoved(const STRUCTURE* psResourceExtractor);
+struct WorldObjectState;
+
+void keybindInformResourceExtractorRemoved(const STRUCTURE* psResourceExtractor, const WorldObjectState& objState);
 
 #endif // __INCLUDED_SRC_KEYBIND_H__

--- a/src/loop.cpp
+++ b/src/loop.cpp
@@ -581,14 +581,14 @@ static void gameStateUpdate()
 		executeFnAndProcessScriptQueuedRemovals([i]() {
 			mutating_list_iterate(gameWorld.objects.structures[i], [](STRUCTURE* s)
 			{
-				structureUpdate(s, false);
+				structureUpdate(s, gameWorld);
 				return IterationResult::CONTINUE_ITERATION;
 			});
 		});
 		executeFnAndProcessScriptQueuedRemovals([i]() {
 			mutating_list_iterate(mission.gameWorld.objects.structures[i], [](STRUCTURE* s)
 			{
-				structureUpdate(s, true); // update for mission
+				structureUpdate(s, mission.gameWorld); // update for mission
 				return IterationResult::CONTINUE_ITERATION;
 			});
 		});

--- a/src/mission.cpp
+++ b/src/mission.cpp
@@ -686,7 +686,7 @@ static void saveMissionData()
 					&& psStructBeingBuilt == psStruct)
 				{
 					// just give it all its build points
-					structureBuild(psStruct, nullptr, structureBuildPointsToCompletion(*psStruct));
+					structureBuild(gameWorld, psStruct, nullptr, structureBuildPointsToCompletion(*psStruct));
 					//don't bother looking for any other droids working on it
 					break;
 				}

--- a/src/mission.cpp
+++ b/src/mission.cpp
@@ -771,8 +771,6 @@ static void saveMissionData()
 	This routine frees the memory for the offworld mission map (in the call to mapShutdown)
 
 	- so when this routine is called we must still be set to the offworld map data
-	i.e. We shoudn't have called SwapMissionPointers()
-
 */
 void restoreMissionData()
 {
@@ -1278,16 +1276,6 @@ void processMissionLimbo()
 		}
 		return IterationResult::CONTINUE_ITERATION;
 	});
-}
-
-/*switch the pointers for the map and droid lists so that droid placement
- and orientation can occur on the map they will appear on*/
-// NOTE: This is one huge hack for campaign games!
-// Pay special attention on what is getting swapped!
-void swapMissionPointers()
-{
-	debug(LOG_SAVE, "called");
-	std::swap(gameWorld, mission.gameWorld);
 }
 
 void endMission()

--- a/src/mission.cpp
+++ b/src/mission.cpp
@@ -880,7 +880,7 @@ void placeLimboDroids()
 			//KILL OFF TRANSPORTER - should never be one but....
 			if (psDroid->isTransporter())
 			{
-				vanishDroid(psDroid);
+				vanishDroid(psDroid, gameWorld.objects);
 				return IterationResult::CONTINUE_ITERATION;
 			}
 			//set up location for each of the droids
@@ -1046,7 +1046,7 @@ void saveCampaignData()
 	{
 		mutating_list_iterate(gameWorld.objects.droids[inc], [](DROID* d)
 		{
-			vanishDroid(d);
+			vanishDroid(d, gameWorld.objects);
 			return IterationResult::CONTINUE_ITERATION;
 		});
 	}
@@ -1252,13 +1252,13 @@ void processMissionLimbo()
 		//KILL OFF TRANSPORTER - should never be one but....
 		if (psDroid->isTransporter())
 		{
-			vanishDroid(psDroid);
+			vanishDroid(psDroid, gameWorld.objects);
 		}
 		else
 		{
 			if (numDroidsAddedToLimboList >= MAXLIMBODROIDS)		// any room in limbo list
 			{
-				vanishDroid(psDroid);
+				vanishDroid(psDroid, gameWorld.objects);
 			}
 			else
 			{
@@ -1501,7 +1501,7 @@ static void missionResetDroids()
 			//KILL OFF TRANSPORTER
 			if (d->isTransporter())
 			{
-				vanishDroid(d);
+				vanishDroid(d, gameWorld.objects);
 			}
 			else
 			{
@@ -1596,7 +1596,7 @@ static void missionResetDroids()
 					psDroid->pos.y >= world_coord(gameWorld.map.height - EDGE_SIZE))
 				{
 					debug(LOG_ERROR, "missionResetUnits: unit too close to edge of map - removing");
-					vanishDroid(psDroid);
+					vanishDroid(psDroid, gameWorld.objects);
 					return IterationResult::CONTINUE_ITERATION;
 				}
 
@@ -1615,7 +1615,7 @@ static void missionResetDroids()
 			{
 				//can't put it down so get rid of this droid!!
 				ASSERT(false, "missionResetUnits: can't place unit - cancel to continue");
-				vanishDroid(psDroid);
+				vanishDroid(psDroid, gameWorld.objects);
 			}
 		}
 		return IterationResult::CONTINUE_ITERATION;
@@ -2866,7 +2866,7 @@ void missionDestroyObjects()
 
 			mutating_list_iterate(gameWorld.objects.droids[Player], [](DROID* d)
 			{
-				removeDroidBase(d);
+				removeDroidBase(d, gameWorld.objects);
 				return IterationResult::CONTINUE_ITERATION;
 			});
 
@@ -2877,14 +2877,14 @@ void missionDestroyObjects()
 			{
 				//make sure its died flag is not set since we've swapped the apsDroidList pointers over
 				psDroid->died = false;
-				removeDroidBase(psDroid);
+				removeDroidBase(psDroid, gameWorld.objects);
 				return IterationResult::CONTINUE_ITERATION;
 			});
 			mission.gameWorld.objects.droids[Player].clear();
 
 			mutating_list_iterate(gameWorld.objects.structures[Player], [](STRUCTURE* s)
 			{
-				removeStruct(s, true);
+				removeStruct(s, true, gameWorld);
 				return IterationResult::CONTINUE_ITERATION;
 			});
 		}
@@ -2956,7 +2956,7 @@ void processPreviousCampDroids()
 			if (droidRemove(psDroid, mission.gameWorld.objects.droids))
 			{
 				addDroid(psDroid, gameWorld.objects.droids);
-				vanishDroid(psDroid);
+				vanishDroid(psDroid, gameWorld.objects);
 			}
 			return IterationResult::CONTINUE_ITERATION;
 		});
@@ -3159,12 +3159,12 @@ void emptyTransporters(bool bOffWorld)
 					});
 				}
 				//now kill off the Transporter
-				vanishDroid(psTransporter);
+				vanishDroid(psTransporter, gameWorld.objects);
 			}
 			else if (!bOffWorld && orderState(psTransporter, DORDER_TRANSPORTRETURN))
 			{
 				//also destroy transporters in the process of flying back and we're not offWorld
-				vanishDroid(psTransporter);
+				vanishDroid(psTransporter, gameWorld.objects);
 			}
 		}
 		return IterationResult::CONTINUE_ITERATION;

--- a/src/mission.h
+++ b/src/mission.h
@@ -81,8 +81,6 @@ bool missionLimboExpand();
 /** This is called mid Limbo mission via the script. */
 void resetLimboMission();
 
-void swapMissionPointers();
-
 // mission results.
 #define		IDTIMER_FORM			11000
 #define		IDTIMER_DISPLAY			11001

--- a/src/move.cpp
+++ b/src/move.cpp
@@ -787,7 +787,7 @@ static void moveCheckSquished(DROID *psDroid, int32_t emx, int32_t emy)
 			if ((psDroid->player != psObj->player) && !aiCheckAlliances(psDroid->player, psObj->player))
 			{
 				// run over a bloke - kill him
-				destroyDroid((DROID *)psObj, gameTime);
+				destroyDroid((DROID *)psObj, gameTime, gameWorld);
 				scoreUpdateVar(WD_BARBARIANS_MOWED_DOWN);
 				giveExperienceForSquish(psDroid);
 			}
@@ -1629,7 +1629,7 @@ static void moveUpdateDroidPos(DROID *psDroid, int32_t dx, int32_t dy)
 		if (!psDroid->isTransporter())
 		{
 			/* dreadful last-ditch crash-avoiding hack - sort this! - GJ */
-			destroyDroid(psDroid, gameTime);
+			destroyDroid(psDroid, gameTime, gameWorld);
 			return;
 		}
 	}
@@ -2155,7 +2155,7 @@ static void checkLocalFeatures(DROID *psDroid)
 		}
 
 		turnOffMultiMsg(true);
-		removeFeature((FEATURE *)psObj);  // remove artifact+.
+		removeFeature((FEATURE *)psObj, gameWorld);  // remove artifact+.
 		turnOffMultiMsg(false);
 	}
 }

--- a/src/multibot.cpp
+++ b/src/multibot.cpp
@@ -837,7 +837,7 @@ bool recvDestroyDroid(NETQUEUE queue)
 	{
 		turnOffMultiMsg(true);
 		debug(LOG_DEATH, "Killing droid %d on request from player %d - huh?", psDroid->id, queue.index);
-		destroyDroid(psDroid, gameTime - deltaGameTime + 1);  // deltaGameTime is actually 0 here, since we're between updates. However, the value of gameTime - deltaGameTime + 1 will not change when we start the next tick.
+		destroyDroid(psDroid, gameTime - deltaGameTime + 1, gameWorld);  // deltaGameTime is actually 0 here, since we're between updates. However, the value of gameTime - deltaGameTime + 1 will not change when we start the next tick.
 		turnOffMultiMsg(false);
 	}
 	else

--- a/src/multigifts.cpp
+++ b/src/multigifts.cpp
@@ -747,7 +747,7 @@ void  technologyGiveAway(const STRUCTURE *pS)
 		debug(LOG_FEATURE, "Unable to find a free location.");
 		return;
 	}
-	FEATURE *pF = buildFeature(gameWorld.map, &asFeatureStats[featureIndex], world_coord(x), world_coord(y), false);
+	FEATURE *pF = buildFeature(gameWorld, &asFeatureStats[featureIndex], world_coord(x), world_coord(y), false);
 	if (pF)
 	{
 		pF->player = pS->player;
@@ -802,7 +802,7 @@ void recvMultiPlayerFeature(NETQUEUE queue)
 		if (asFeatureStats[i].ref == ref)
 		{
 			// Create a feature of the specified type at the given location
-			buildFeature(gameWorld.map, &asFeatureStats[i], x, y, false, id);
+			buildFeature(gameWorld, &asFeatureStats[i], x, y, false, id);
 			break;
 		}
 	}

--- a/src/multijoin.cpp
+++ b/src/multijoin.cpp
@@ -81,17 +81,17 @@
 // Local Functions
 
 static void resetMultiVisibility(UDWORD player);
-void destroyPlayerResources(WorldObjectState& objState, UDWORD player, bool quietly);
+void destroyPlayerResources(GameWorld& world, UDWORD player, bool quietly);
 
 //////////////////////////////////////////////////////////////////////////////
 /*
 ** when a remote player leaves an arena game do this!
 **
-** @param objState : the object state to destroy the resources for `player` from
+** @param world : the game world to destroy the resources for `player` from
 ** @param player -- the one we need to clear
 ** @param quietly -- true means without any visible effects
 */
-void clearPlayer(WorldObjectState& objState, UDWORD player, bool quietly)
+void clearPlayer(GameWorld& world, UDWORD player, bool quietly)
 {
 	ASSERT_OR_RETURN(, player < MAX_CONNECTED_PLAYERS, "Invalid player: %" PRIu32 "", player);
 
@@ -113,10 +113,10 @@ void clearPlayer(WorldObjectState& objState, UDWORD player, bool quietly)
 		return; // no more to do
 	}
 
-	destroyPlayerResources(objState, player, quietly);
+	destroyPlayerResources(world, player, quietly);
 }
 
-void destroyPlayerResources(WorldObjectState& objState, UDWORD player, bool quietly)
+void destroyPlayerResources(GameWorld& world, UDWORD player, bool quietly)
 {
 	UDWORD			i;
 
@@ -140,31 +140,31 @@ void destroyPlayerResources(WorldObjectState& objState, UDWORD player, bool quie
 
 	debug(LOG_DEATH, "killing off all droids for player %d", player);
 	// delete all droids
-	mutating_list_iterate(objState.droids[player], [quietly](DROID* d)
+	mutating_list_iterate(world.objects.droids[player], [quietly, &world](DROID* d)
 	{
 		if (quietly)			// don't show effects
 		{
-			killDroid(d);
+			killDroid(d, world.objects);
 		}
 		else				// show effects
 		{
-			destroyDroid(d, gameTime);
+			destroyDroid(d, gameTime, world);
 		}
 		return IterationResult::CONTINUE_ITERATION;
 	});
 
 	debug(LOG_DEATH, "killing off all structures for player %d", player);
 	// delete all structs
-	mutating_list_iterate(objState.structures[player], [quietly](STRUCTURE* psStruct)
+	mutating_list_iterate(world.objects.structures[player], [quietly, &world](STRUCTURE* psStruct)
 	{
 		// FIXME: look why destroyStruct() doesn't put back the feature like removeStruct() does
 		if (quietly || psStruct->pStructureType->type == REF_RESOURCE_EXTRACTOR)		// don't show effects
 		{
-			removeStruct(psStruct, true);
+			removeStruct(psStruct, true, world);
 		}
 		else			// show effects
 		{
-			destroyStruct(psStruct, gameTime);
+			destroyStruct(psStruct, gameTime, world);
 		}
 		return IterationResult::CONTINUE_ITERATION;
 	});
@@ -182,11 +182,11 @@ static bool destroyMatchingStructs(UDWORD player, std::function<bool (STRUCTURE 
 			// FIXME: look why destroyStruct() doesn't put back the feature like removeStruct() does
 			if (quietly || psStruct->pStructureType->type == REF_RESOURCE_EXTRACTOR)		// don't show effects
 			{
-				removeStruct(psStruct, true);
+				removeStruct(psStruct, true, gameWorld);
 			}
 			else			// show effects
 			{
-				destroyStruct(psStruct, gameTime);
+				destroyStruct(psStruct, gameTime, gameWorld);
 			}
 			destroyedAnyStructs = true;
 		}
@@ -277,7 +277,7 @@ bool splitResourcesAmongTeam(UDWORD player)
 
 		if (!transferredDroid)
 		{
-			destroyDroid(d, gameTime);
+			destroyDroid(d, gameTime, gameWorld);
 		}
 		return IterationResult::CONTINUE_ITERATION;
 	});
@@ -358,14 +358,14 @@ void handlePlayerLeftInGame(UDWORD player)
 	switch (mode)
 	{
 		case PLAYER_LEAVE_MODE::DESTROY_RESOURCES:
-			destroyPlayerResources(gameWorld.objects, player, false);
+			destroyPlayerResources(gameWorld, player, false);
 			break;
 		case PLAYER_LEAVE_MODE::SPLIT_WITH_TEAM:
 			if (!splitResourcesAmongTeam(player))
 			{
 				// no valid targets to split resources among
 				// instead, destroy the player
-				destroyPlayerResources(gameWorld.objects, player, false);
+				destroyPlayerResources(gameWorld, player, false);
 			}
 			break;
 	}
@@ -520,7 +520,7 @@ bool MultiPlayerLeave(UDWORD playerIndex)
 	if (ingame.localJoiningInProgress)
 	{
 		addConsolePlayerLeftMessage(playerIndex);
-		clearPlayer(gameWorld.objects, playerIndex, false);
+		clearPlayer(gameWorld, playerIndex, false);
 		clearPlayerMultiStats(playerIndex); // local only
 		NetPlay.players[playerIndex].difficulty = AIDifficulty::DISABLED;
 	}

--- a/src/multijoin.h
+++ b/src/multijoin.h
@@ -32,13 +32,13 @@
 using nonstd::optional;
 using nonstd::nullopt;
 
-struct WorldObjectState;
+struct GameWorld;
 
 void recvPlayerLeft(NETQUEUE queue);
 bool MultiPlayerLeave(UDWORD playerIndex);						// A player has left the game.
 bool MultiPlayerJoin(UDWORD playerIndex, optional<EcKey::Key> verifiedJoinIdentity = nullopt);	// A Player has joined the game.
 void setupNewPlayer(UDWORD player);		// stuff to do when player joins.
-void clearPlayer(WorldObjectState& objState, UDWORD player, bool quietly);     // wipe a player off the face of the earth.
+void clearPlayer(GameWorld& world, UDWORD player, bool quietly);     // wipe a player off the face of the earth.
 void handlePlayerLeftInGame(UDWORD player);		   // handle a player leaving in-game
 
 void ShowLobbyStatusMessage(const std::vector<std::string>& msgs);

--- a/src/multilimit.cpp
+++ b/src/multilimit.cpp
@@ -403,7 +403,7 @@ bool applyLimitSet()
 						{
 							if (psStruct->pStructureType->type == asStructureStats[id].type)
 							{
-								removeStruct(psStruct, true);
+								removeStruct(psStruct, true, gameWorld);
 								return IterationResult::BREAK_ITERATION;
 							}
 							return IterationResult::CONTINUE_ITERATION;

--- a/src/multiopt.cpp
+++ b/src/multiopt.cpp
@@ -574,7 +574,7 @@ static bool gameInit()
 			&& !(NetPlay.players[player].isSpectator && NetPlay.players[player].allocated)
 			&& !(player < game.maxPlayers && NetPlay.players[player].allocated))
 		{
-			clearPlayer(gameWorld.objects, player, true);			// do this quietly
+			clearPlayer(gameWorld, player, true);			// do this quietly
 			debug(LOG_NET, "removing disabled AI (%d) from map.", player);
 		}
 	}

--- a/src/multiplay.cpp
+++ b/src/multiplay.cpp
@@ -2320,7 +2320,7 @@ bool recvDestroyFeature(NETQUEUE queue)
 	debug(LOG_FEATURE, "p%d feature id %d destroyed (%s)", pF->player, pF->id, getStatsName(pF->psStats));
 	// Remove the feature locally
 	turnOffMultiMsg(true);
-	destroyFeature(pF, gameTime - deltaGameTime + 1);  // deltaGameTime is actually 0 here, since we're between updates. However, the value of gameTime - deltaGameTime + 1 will not change when we start the next tick.
+	destroyFeature(pF, gameTime - deltaGameTime + 1, gameWorld);  // deltaGameTime is actually 0 here, since we're between updates. However, the value of gameTime - deltaGameTime + 1 will not change when we start the next tick.
 	turnOffMultiMsg(false);
 
 	return true;
@@ -2807,11 +2807,11 @@ bool makePlayerSpectator(uint32_t playerIndex, bool removeAllStructs, bool quiet
 		{
 			if (quietly)
 			{
-				removeStruct(psStruct, true);
+				removeStruct(psStruct, true, gameWorld);
 			}
 			else			// show effects
 			{
-				destroyStruct(psStruct, gameTime);
+				destroyStruct(psStruct, gameTime, gameWorld);
 			}
 		}
 
@@ -2821,11 +2821,11 @@ bool makePlayerSpectator(uint32_t playerIndex, bool removeAllStructs, bool quiet
 		{
 			if (quietly)			// don't show effects
 			{
-				killDroid(d);
+				killDroid(d, gameWorld.objects);
 			}
 			else				// show effects
 			{
-				destroyDroid(d, gameTime);
+				destroyDroid(d, gameTime, gameWorld);
 			}
 			return IterationResult::CONTINUE_ITERATION;
 		});
@@ -2843,11 +2843,11 @@ bool makePlayerSpectator(uint32_t playerIndex, bool removeAllStructs, bool quiet
 				// FIXME: look why destroyStruct() doesn't put back the feature like removeStruct() does
 				if (quietly || psStruct->pStructureType->type == REF_RESOURCE_EXTRACTOR)		// don't show effects
 				{
-					removeStruct(psStruct, true);
+					removeStruct(psStruct, true, gameWorld);
 				}
 				else			// show effects
 				{
-					destroyStruct(psStruct, gameTime);
+					destroyStruct(psStruct, gameTime, gameWorld);
 				}
 			}
 			return IterationResult::CONTINUE_ITERATION;

--- a/src/multistruct.cpp
+++ b/src/multistruct.cpp
@@ -109,7 +109,7 @@ bool recvBuildFinished(NETQUEUE queue)
 		{
 			debug(LOG_SYNC, "Synch error, structure %u was not complete, and should have been.", structId);
 			psStruct->status = SS_BUILT;
-			buildingComplete(psStruct);
+			buildingComplete(psStruct, gameWorld);
 		}
 		debug(LOG_SYNC, "Created normal building %u for player %u", psStruct->id, player);
 		return true;
@@ -125,7 +125,7 @@ bool recvBuildFinished(NETQUEUE queue)
 	if (psStruct)
 	{
 		psStruct->status	= SS_BUILT;
-		buildingComplete(psStruct);
+		buildingComplete(psStruct, gameWorld);
 		debug(LOG_SYNC, "Huge synch error, forced to create building %u for player %u", psStruct->id, player);
 #if defined (DEBUG)
 		NETlogEntry("had to plonk down a building", SYNC_FLAG, player);
@@ -179,7 +179,7 @@ bool recvDestroyStructure(NETQUEUE queue)
 	{
 		turnOffMultiMsg(true);
 		// Remove the struct from remote players machine
-		destroyStruct(psStruct, gameTime - deltaGameTime + 1);  // deltaGameTime is actually 0 here, since we're between updates. However, the value of gameTime - deltaGameTime + 1 will not change when we start the next tick.
+		destroyStruct(psStruct, gameTime - deltaGameTime + 1, gameWorld);  // deltaGameTime is actually 0 here, since we're between updates. However, the value of gameTime - deltaGameTime + 1 will not change when we start the next tick.
 		turnOffMultiMsg(false);
 	}
 

--- a/src/objmem.cpp
+++ b/src/objmem.cpp
@@ -497,7 +497,7 @@ void addDroid(DROID *psDroidToAdd, PerPlayerDroidLists& pList)
 }
 
 /* Destroy a droid */
-void killDroid(DROID *psDel)
+void killDroid(DROID *psDel, WorldObjectState& objState)
 {
 	int i;
 
@@ -514,10 +514,10 @@ void killDroid(DROID *psDel)
 	setDroidBase(psDel, nullptr);
 	if (psDel->droidType == DROID_SENSOR)
 	{
-		removeObjectFromFuncList(gameWorld.objects.sensors, (BASE_OBJECT *)psDel, 0);
+		removeObjectFromFuncList(objState.sensors, (BASE_OBJECT *)psDel, 0);
 	}
 
-	destroyObject(gameWorld.objects.droids, psDel);
+	destroyObject(objState.droids, psDel);
 }
 
 template <typename EntityType>
@@ -633,22 +633,22 @@ void freeAllLimboDroids()
 /**************************  STRUCTURE  *******************************/
 
 /* add the structure to the Structure Lists */
-void addStructure(STRUCTURE *psStructToAdd)
+void addStructure(STRUCTURE *psStructToAdd, WorldObjectState& objState)
 {
-	addObjectToList(gameWorld.objects.structures, psStructToAdd, psStructToAdd->player);
+	addObjectToList(objState.structures, psStructToAdd, psStructToAdd->player);
 	if (psStructToAdd->pStructureType->pSensor
 	    && psStructToAdd->pStructureType->pSensor->location == LOC_TURRET)
 	{
-		addObjectToFuncList(gameWorld.objects.sensors, (BASE_OBJECT *)psStructToAdd, 0);
+		addObjectToFuncList(objState.sensors, (BASE_OBJECT *)psStructToAdd, 0);
 	}
 	else if (psStructToAdd->pStructureType->type == REF_RESOURCE_EXTRACTOR)
 	{
-		addObjectToFuncList(gameWorld.objects.extractors, psStructToAdd, psStructToAdd->player);
+		addObjectToFuncList(objState.extractors, psStructToAdd, psStructToAdd->player);
 	}
 }
 
 /* Destroy a structure */
-void killStruct(STRUCTURE *psBuilding)
+void killStruct(STRUCTURE *psBuilding, WorldObjectState& objState)
 {
 	int i;
 
@@ -660,11 +660,11 @@ void killStruct(STRUCTURE *psBuilding)
 	if (psBuilding->pStructureType->pSensor
 	    && psBuilding->pStructureType->pSensor->location == LOC_TURRET)
 	{
-		removeObjectFromFuncList(gameWorld.objects.sensors, (BASE_OBJECT *)psBuilding, 0);
+		removeObjectFromFuncList(objState.sensors, (BASE_OBJECT *)psBuilding, 0);
 	}
 	else if (psBuilding->pStructureType->type == REF_RESOURCE_EXTRACTOR)
 	{
-		removeObjectFromFuncList(gameWorld.objects.extractors, psBuilding, psBuilding->player);
+		removeObjectFromFuncList(objState.extractors, psBuilding, psBuilding->player);
 	}
 
 	for (i = 0; i < MAX_WEAPONS; i++)
@@ -704,7 +704,7 @@ void killStruct(STRUCTURE *psBuilding)
 		}
 	}
 
-	destroyObject(gameWorld.objects.structures, psBuilding);
+	destroyObject(objState.structures, psBuilding);
 }
 
 /* Remove heapall structures */
@@ -714,49 +714,49 @@ void freeAllStructs(GameWorld& world)
 }
 
 /*Remove a single Structure from a list*/
-void removeStructureFromList(STRUCTURE *psStructToRemove, PerPlayerStructureLists& pList)
+void removeStructureFromList(STRUCTURE *psStructToRemove, WorldObjectState& objState)
 {
 	ASSERT(psStructToRemove->type == OBJ_STRUCTURE,
 	       "removeStructureFromList: pointer is not a structure");
 	ASSERT(psStructToRemove->player < MAX_PLAYERS,
 	       "removeStructureFromList: invalid player for structure");
-	removeObjectFromList(pList, psStructToRemove, psStructToRemove->player);
+	removeObjectFromList(objState.structures, psStructToRemove, psStructToRemove->player);
 	if (psStructToRemove->pStructureType->pSensor
 	    && psStructToRemove->pStructureType->pSensor->location == LOC_TURRET)
 	{
-		removeObjectFromFuncList(gameWorld.objects.sensors, (BASE_OBJECT *)psStructToRemove, 0);
+		removeObjectFromFuncList(objState.sensors, (BASE_OBJECT *)psStructToRemove, 0);
 	}
 	else if (psStructToRemove->pStructureType->type == REF_RESOURCE_EXTRACTOR)
 	{
-		removeObjectFromFuncList(gameWorld.objects.extractors, psStructToRemove, psStructToRemove->player);
+		removeObjectFromFuncList(objState.extractors, psStructToRemove, psStructToRemove->player);
 	}
 }
 
 /**************************  FEATURE  *********************************/
 
 /* add the feature to the Feature Lists */
-void addFeature(FEATURE *psFeatureToAdd)
+void addFeature(FEATURE *psFeatureToAdd, WorldObjectState& objState)
 {
-	addObjectToList(gameWorld.objects.features, psFeatureToAdd, 0);
+	addObjectToList(objState.features, psFeatureToAdd, 0);
 	if (psFeatureToAdd->psStats->subType == FEAT_OIL_RESOURCE)
 	{
-		addObjectToFuncList(gameWorld.objects.oils, psFeatureToAdd, 0);
+		addObjectToFuncList(objState.oils, psFeatureToAdd, 0);
 	}
 }
 
 /* Destroy a feature */
 // set the player to 0 since features have player = maxplayers+1. This screws up destroyObject
 // it's a bit of a hack, but hey, it works
-void killFeature(FEATURE *psDel)
+void killFeature(FEATURE *psDel, WorldObjectState& objState)
 {
 	ASSERT(psDel->type == OBJ_FEATURE,
 	       "killFeature: pointer is not a feature");
 	psDel->player = 0;
-	destroyObject(gameWorld.objects.features, psDel);
+	destroyObject(objState.features, psDel);
 
 	if (psDel->psStats->subType == FEAT_OIL_RESOURCE)
 	{
-		removeObjectFromFuncList(gameWorld.objects.oils, psDel, 0);
+		removeObjectFromFuncList(objState.oils, psDel, 0);
 	}
 }
 
@@ -798,23 +798,17 @@ static bool isFlagPositionInList(FLAG_POSITION *psFlagPosToAdd, const PerPlayerF
 }
 
 /* add the Flag Position to the Flag Position Lists */
-void addFlagPositionToList(FLAG_POSITION *psFlagPosToAdd, PerPlayerFlagPositionLists& list)
+void addFlagPosition(FLAG_POSITION *psFlagPosToAdd, WorldObjectState& objState)
 {
 	ASSERT_OR_RETURN(, psFlagPosToAdd != nullptr, "Invalid FlagPosition pointer");
 	ASSERT_OR_RETURN(, psFlagPosToAdd->coords.x != ~0, "flag has invalid position");
 	ASSERT_OR_RETURN(, psFlagPosToAdd->player < MAX_PLAYERS, "Invalid FlagPosition player: %u", psFlagPosToAdd->player);
-	if (isFlagPositionInList(psFlagPosToAdd, list))
+	if (isFlagPositionInList(psFlagPosToAdd, objState.flags))
 	{
 		debug(LOG_INFO, "FlagPosition is already in the list - ignoring");
 		return;
 	}
-	list[psFlagPosToAdd->player].emplace_front(psFlagPosToAdd);
-}
-
-/* add the Flag Position to the Flag Position Lists */
-void addFlagPosition(FLAG_POSITION *psFlagPosToAdd)
-{
-	addFlagPositionToList(psFlagPosToAdd, gameWorld.objects.flags);
+	objState.flags[psFlagPosToAdd->player].emplace_front(psFlagPosToAdd);
 }
 
 // Remove it from the list, but don't delete it!
@@ -856,7 +850,7 @@ void transferFlagPositionToPlayer(FLAG_POSITION *psFlagPos, UDWORD originalPlaye
 	ASSERT(originalPlayer == psFlagPos->player, "Unexpected originalPlayer (%" PRIu32 ") does not match current flagPos->player (%" PRIu32 ")", originalPlayer, psFlagPos->player);
 	ASSERT(removeFlagPositionFromList(psFlagPos), "Did not find flag position in expected list?");
 	psFlagPos->player = newPlayer;
-	addFlagPosition(psFlagPos);
+	addFlagPosition(psFlagPos, gameWorld.objects);
 }
 
 // free all flag positions

--- a/src/objmem.cpp
+++ b/src/objmem.cpp
@@ -812,12 +812,12 @@ void addFlagPosition(FLAG_POSITION *psFlagPosToAdd, WorldObjectState& objState)
 }
 
 // Remove it from the list, but don't delete it!
-static bool removeFlagPositionFromList(FLAG_POSITION *psRemove)
+static bool removeFlagPositionFromList(WorldObjectState& objState, FLAG_POSITION *psRemove)
 {
 	ASSERT_OR_RETURN(false, psRemove != nullptr, "Invalid Flag Position pointer");
 	ASSERT_OR_RETURN(false, psRemove->player < MAX_PLAYERS, "Invalid Flag Position player: %" PRIu32, psRemove->player);
 
-	auto& flagPosList = gameWorld.objects.flags[psRemove->player];
+	auto& flagPosList = objState.flags[psRemove->player];
 	auto it = std::find(flagPosList.begin(), flagPosList.end(), psRemove);
 	if (it != flagPosList.end())
 	{
@@ -833,7 +833,7 @@ void removeFlagPosition(FLAG_POSITION *psDel)
 {
 	ASSERT_OR_RETURN(, psDel != nullptr, "Invalid Flag Position pointer");
 
-	if (removeFlagPositionFromList(psDel))
+	if (removeFlagPositionFromList(gameWorld.objects, psDel))
 	{
 		free(psDel);
 	}
@@ -844,13 +844,13 @@ void removeFlagPosition(FLAG_POSITION *psDel)
 }
 
 /* Transfer a Flag Position to a new player */
-void transferFlagPositionToPlayer(FLAG_POSITION *psFlagPos, UDWORD originalPlayer, UDWORD newPlayer)
+void transferFlagPositionToPlayer(WorldObjectState& objState, FLAG_POSITION *psFlagPos, UDWORD originalPlayer, UDWORD newPlayer)
 {
 	ASSERT_OR_RETURN(, psFlagPos != nullptr, "Invalid Flag Position pointer");
 	ASSERT(originalPlayer == psFlagPos->player, "Unexpected originalPlayer (%" PRIu32 ") does not match current flagPos->player (%" PRIu32 ")", originalPlayer, psFlagPos->player);
-	ASSERT(removeFlagPositionFromList(psFlagPos), "Did not find flag position in expected list?");
+	ASSERT(removeFlagPositionFromList(objState, psFlagPos), "Did not find flag position in expected list?");
 	psFlagPos->player = newPlayer;
-	addFlagPosition(psFlagPos, gameWorld.objects);
+	addFlagPosition(psFlagPos, objState);
 }
 
 // free all flag positions

--- a/src/objmem.h
+++ b/src/objmem.h
@@ -97,7 +97,7 @@ void addFlagPosition(FLAG_POSITION *psFlagPosToAdd, WorldObjectState& objState);
 /* Remove a Flag Position from the Lists */
 void removeFlagPosition(FLAG_POSITION *psDel);
 /* Transfer a Flag Position to a new player */
-void transferFlagPositionToPlayer(FLAG_POSITION *psFlagPos, UDWORD originalPlayer, UDWORD newPlayer);
+void transferFlagPositionToPlayer(WorldObjectState& objState, FLAG_POSITION *psFlagPos, UDWORD originalPlayer, UDWORD newPlayer);
 // free all flag positions
 void freeAllFlagPositions(WorldObjectState& objState);
 

--- a/src/objmem.h
+++ b/src/objmem.h
@@ -58,7 +58,7 @@ uint32_t generateSynchronisedObjectId();
 void addDroid(DROID *psDroidToAdd, PerPlayerDroidLists& pList);
 
 /*destroy a droid */
-void killDroid(DROID *psDel);
+void killDroid(DROID *psDel, WorldObjectState& objState);
 
 /* Remove all droids */
 void freeAllDroids(GameWorld& world);
@@ -70,22 +70,22 @@ void removeDroid(DROID *psDroidToRemove, PerPlayerDroidLists& pList);
 void freeAllLimboDroids();
 
 /* add the structure to the Structure Lists */
-void addStructure(STRUCTURE *psStructToAdd);
+void addStructure(STRUCTURE *psStructToAdd, WorldObjectState& objState);
 
 /* Destroy a structure */
-void killStruct(STRUCTURE *psDel);
+void killStruct(STRUCTURE *psDel, WorldObjectState& objState);
 
 /* Remove all structures */
 void freeAllStructs(GameWorld& world);
 
 /*Remove a single Structure from a list*/
-void removeStructureFromList(STRUCTURE *psStructToRemove, PerPlayerStructureLists& pList);
+void removeStructureFromList(STRUCTURE *psStructToRemove, WorldObjectState& objState);
 
 /* add the feature to the Feature Lists */
-void addFeature(FEATURE *psFeatureToAdd);
+void addFeature(FEATURE *psFeatureToAdd, WorldObjectState& objState);
 
 /* Destroy a feature */
-void killFeature(FEATURE *psDel);
+void killFeature(FEATURE *psDel, WorldObjectState& objState);
 
 /* Remove all features */
 void freeAllFeatures(GameWorld& world);
@@ -93,15 +93,13 @@ void freeAllFeatures(GameWorld& world);
 /* Create a new Flag Position */
 bool createFlagPosition(FLAG_POSITION **ppsNew, UDWORD player);
 /* add the Flag Position to the Flag Position Lists */
-void addFlagPosition(FLAG_POSITION *psFlagPosToAdd);
+void addFlagPosition(FLAG_POSITION *psFlagPosToAdd, WorldObjectState& objState);
 /* Remove a Flag Position from the Lists */
 void removeFlagPosition(FLAG_POSITION *psDel);
 /* Transfer a Flag Position to a new player */
 void transferFlagPositionToPlayer(FLAG_POSITION *psFlagPos, UDWORD originalPlayer, UDWORD newPlayer);
 // free all flag positions
 void freeAllFlagPositions(WorldObjectState& objState);
-// used to add flag position to a specific list (ex. from assignFactoryCommandDroid)
-void addFlagPositionToList(FLAG_POSITION* psFlagPosToAdd, PerPlayerFlagPositionLists& list);
 
 // Find a base object from it's id
 template <typename ObjectType>

--- a/src/projectile.cpp
+++ b/src/projectile.cpp
@@ -123,7 +123,7 @@ static void	proj_ImpactFunc(PROJECTILE *psObj);
 static void	proj_PostImpactFunc(PROJECTILE *psObj);
 static void proj_checkPeriodicalDamage(PROJECTILE *psProj);
 
-static int32_t objectDamage(DAMAGE *psDamage);
+static int32_t objectDamage(GameWorld& world, DAMAGE *psDamage);
 
 
 static inline void setProjectileDestination(PROJECTILE *psProj, BASE_OBJECT *psObj)
@@ -1089,7 +1089,7 @@ static void proj_radiusSweep(PROJECTILE *psObj, WEAPON_STATS *psStats, Vector3i 
 			empRadius
 		};
 
-		objectDamage(&sDamage);
+		objectDamage(gameWorld, &sDamage);
 	}
 }
 
@@ -1287,7 +1287,7 @@ static void proj_ImpactFunc(PROJECTILE *psObj)
 			};
 
 			// Damage the object
-			relativeDamage = objectDamage(&sDamage);
+			relativeDamage = objectDamage(gameWorld, &sDamage);
 
 			if (relativeDamage >= 0)	// So long as the target wasn't killed
 			{
@@ -1538,7 +1538,7 @@ static void proj_checkPeriodicalDamage(PROJECTILE *psProj)
 			false
 		};
 
-		objectDamage(&sDamage);
+		objectDamage(gameWorld, &sDamage);
 	}
 }
 
@@ -1675,20 +1675,20 @@ UDWORD	calcDamage(UDWORD baseDamage, WEAPON_EFFECT weaponEffect, const BASE_OBJE
  *    multiplied by -1, resulting in a negative number. Killed features do not
  *    result in negative numbers.
  */
-static int32_t objectDamageDispatch(DAMAGE *psDamage)
+static int32_t objectDamageDispatch(GameWorld& world, DAMAGE *psDamage)
 {
 	switch (psDamage->psDest->type)
 	{
 	case OBJ_DROID:
-		return droidDamage((DROID *)psDamage->psDest, psDamage->psProjectile, psDamage->damage, psDamage->weaponClass, psDamage->weaponSubClass, psDamage->impactTime, psDamage->isDamagePerSecond, psDamage->minDamage, psDamage->empRadiusHit);
+		return droidDamage(world, (DROID *)psDamage->psDest, psDamage->psProjectile, psDamage->damage, psDamage->weaponClass, psDamage->weaponSubClass, psDamage->impactTime, psDamage->isDamagePerSecond, psDamage->minDamage, psDamage->empRadiusHit);
 		break;
 
 	case OBJ_STRUCTURE:
-		return structureDamage((STRUCTURE *)psDamage->psDest, psDamage->psProjectile, psDamage->damage, psDamage->weaponClass, psDamage->weaponSubClass, psDamage->impactTime, psDamage->isDamagePerSecond, psDamage->minDamage, psDamage->empRadiusHit);
+		return structureDamage(world, (STRUCTURE *)psDamage->psDest, psDamage->psProjectile, psDamage->damage, psDamage->weaponClass, psDamage->weaponSubClass, psDamage->impactTime, psDamage->isDamagePerSecond, psDamage->minDamage, psDamage->empRadiusHit);
 		break;
 
 	case OBJ_FEATURE:
-		return featureDamage((FEATURE *)psDamage->psDest, psDamage->damage, psDamage->weaponClass, psDamage->weaponSubClass, psDamage->impactTime, psDamage->isDamagePerSecond, psDamage->minDamage, psDamage->empRadiusHit);
+		return featureDamage(world, (FEATURE *)psDamage->psDest, psDamage->damage, psDamage->weaponClass, psDamage->weaponSubClass, psDamage->impactTime, psDamage->isDamagePerSecond, psDamage->minDamage, psDamage->empRadiusHit);
 		break;
 
 	case OBJ_PROJECTILE:
@@ -1740,9 +1740,9 @@ static void updateKills(DAMAGE* psDamage)
 	}
 }
 
-static int32_t objectDamage(DAMAGE *psDamage)
+static int32_t objectDamage(GameWorld& world, DAMAGE *psDamage)
 {
-	int32_t relativeDamage = objectDamageDispatch(psDamage);
+	int32_t relativeDamage = objectDamageDispatch(world, psDamage);
 
 	if (shouldIncreaseExperience(psDamage)) {
 		proj_UpdateExperience(psDamage->psProjectile, abs(relativeDamage) * getExpGain(psDamage->psProjectile->psSource->player) / 100);

--- a/src/structure.cpp
+++ b/src/structure.cpp
@@ -847,13 +847,14 @@ void handleAbandonedStructures()
 }
 
 /* Deals damage to a Structure.
+ * \param world the game world structure belongs to
  * \param psStructure structure to deal damage to
  * \param damage amount of damage to deal
  * \param weaponClass the class of the weapon that deals the damage
  * \param weaponSubClass the subclass of the weapon that deals the damage
  * \return < 0 when the dealt damage destroys the structure, > 0 when the structure survives
  */
-int32_t structureDamage(STRUCTURE *psStructure, PROJECTILE *psProjectile, unsigned damage, WEAPON_CLASS weaponClass, WEAPON_SUBCLASS weaponSubClass, unsigned impactTime, bool isDamagePerSecond, int minDamage, bool empRadiusHit)
+int32_t structureDamage(GameWorld& world, STRUCTURE *psStructure, PROJECTILE *psProjectile, unsigned damage, WEAPON_CLASS weaponClass, WEAPON_SUBCLASS weaponSubClass, unsigned impactTime, bool isDamagePerSecond, int minDamage, bool empRadiusHit)
 {
 	int32_t relativeDamage;
 
@@ -868,7 +869,7 @@ int32_t structureDamage(STRUCTURE *psStructure, PROJECTILE *psProjectile, unsign
 	if (relativeDamage < 0)
 	{
 		debug(LOG_ATTACK, "Structure (id %d) DESTROYED", psStructure->id);
-		destroyStruct(psStructure, impactTime, gameWorld);
+		destroyStruct(psStructure, impactTime, world);
 	}
 	else
 	{

--- a/src/structure.cpp
+++ b/src/structure.cpp
@@ -134,14 +134,14 @@ static		UBYTE	satUplinkExists[MAX_PLAYERS];
 //flag for when the player has one built - either completely or partially
 static		UBYTE	lasSatExists[MAX_PLAYERS];
 
-static bool setFunctionality(STRUCTURE *psBuilding, STRUCTURE_TYPE functionType);
+static bool setFunctionality(STRUCTURE *psBuilding, STRUCTURE_TYPE functionType, GameWorld& world);
 static void setFlagPositionInc(FUNCTIONALITY *pFunctionality, UDWORD player, UBYTE factoryType);
 static void informPowerGen(STRUCTURE *psStruct);
 static bool electronicReward(STRUCTURE *psStructure, UBYTE attackPlayer);
 static void factoryReward(UBYTE losingPlayer, UBYTE rewardPlayer);
 static void repairFacilityReward(UBYTE losingPlayer, UBYTE rewardPlayer);
 static void findAssemblyPointPosition(GameWorld& world, UDWORD *pX, UDWORD *pY, UDWORD player);
-static void removeStructFromMap(STRUCTURE *psStruct);
+static void removeStructFromMap(STRUCTURE *psStruct, WorldMapState& mapState);
 static void resetResistanceLag(STRUCTURE *psBuilding);
 static int structureTotalReturn(const STRUCTURE *psStruct);
 static void parseFavoriteStructs();
@@ -162,7 +162,7 @@ static std::vector<WzString> favoriteStructs;
 
 #define MAX_UNIT_MESSAGE_PAUSE 40000
 
-static void auxStructureNonblocking(STRUCTURE *psStructure)
+static void auxStructureNonblocking(STRUCTURE *psStructure, WorldMapState& mapState)
 {
 	StructureBounds b = getStructureBounds(psStructure);
 
@@ -172,10 +172,10 @@ static void auxStructureNonblocking(STRUCTURE *psStructure)
 		{
 			int x = b.map.x + i;
 			int y = b.map.y + j;
-			MAPTILE *psTile = mapTile(gameWorld.map, x, y);
+			MAPTILE *psTile = mapTile(mapState, x, y);
 			if (psTile->psObject == psStructure)
 			{
-				auxClearAll(gameWorld.map, x, y, AUXBITS_BLOCKING | AUXBITS_OUR_BUILDING | AUXBITS_NONPASSABLE);
+				auxClearAll(mapState, x, y, AUXBITS_BLOCKING | AUXBITS_OUR_BUILDING | AUXBITS_NONPASSABLE);
 			}
 			else
 			{
@@ -186,7 +186,7 @@ static void auxStructureNonblocking(STRUCTURE *psStructure)
 	}
 }
 
-static void auxStructureBlocking(STRUCTURE *psStructure)
+static void auxStructureBlocking(STRUCTURE *psStructure, WorldMapState& mapState)
 {
 	StructureBounds b = getStructureBounds(psStructure);
 
@@ -194,13 +194,13 @@ static void auxStructureBlocking(STRUCTURE *psStructure)
 	{
 		for (int j = 0; j < b.size.y; j++)
 		{
-			auxSetAllied(gameWorld.map, b.map.x + i, b.map.y + j, psStructure->player, AUXBITS_OUR_BUILDING);
-			auxSetAll(gameWorld.map, b.map.x + i, b.map.y + j, AUXBITS_BLOCKING | AUXBITS_NONPASSABLE);
+			auxSetAllied(mapState, b.map.x + i, b.map.y + j, psStructure->player, AUXBITS_OUR_BUILDING);
+			auxSetAll(mapState, b.map.x + i, b.map.y + j, AUXBITS_BLOCKING | AUXBITS_NONPASSABLE);
 		}
 	}
 }
 
-static void auxStructureOpenGate(STRUCTURE *psStructure)
+static void auxStructureOpenGate(STRUCTURE *psStructure, WorldMapState& mapState)
 {
 	StructureBounds b = getStructureBounds(psStructure);
 
@@ -208,12 +208,12 @@ static void auxStructureOpenGate(STRUCTURE *psStructure)
 	{
 		for (int j = 0; j < b.size.y; j++)
 		{
-			auxClearAll(gameWorld.map, b.map.x + i, b.map.y + j, AUXBITS_BLOCKING);
+			auxClearAll(mapState, b.map.x + i, b.map.y + j, AUXBITS_BLOCKING);
 		}
 	}
 }
 
-static void auxStructureClosedGate(STRUCTURE *psStructure)
+static void auxStructureClosedGate(STRUCTURE *psStructure, WorldMapState& mapState)
 {
 	StructureBounds b = getStructureBounds(psStructure);
 
@@ -221,8 +221,8 @@ static void auxStructureClosedGate(STRUCTURE *psStructure)
 	{
 		for (int j = 0; j < b.size.y; j++)
 		{
-			auxSetEnemy(gameWorld.map, b.map.x + i, b.map.y + j, psStructure->player, AUXBITS_NONPASSABLE);
-			auxSetAll(gameWorld.map, b.map.x + i, b.map.y + j, AUXBITS_BLOCKING);
+			auxSetEnemy(mapState, b.map.x + i, b.map.y + j, psStructure->player, AUXBITS_NONPASSABLE);
+			auxSetAll(mapState, b.map.x + i, b.map.y + j, AUXBITS_BLOCKING);
 		}
 	}
 }
@@ -868,7 +868,7 @@ int32_t structureDamage(STRUCTURE *psStructure, PROJECTILE *psProjectile, unsign
 	if (relativeDamage < 0)
 	{
 		debug(LOG_ATTACK, "Structure (id %d) DESTROYED", psStructure->id);
-		destroyStruct(psStructure, impactTime);
+		destroyStruct(psStructure, impactTime, gameWorld);
 	}
 	else
 	{
@@ -968,7 +968,7 @@ void structureBuild(STRUCTURE *psStruct, DROID *psDroid, int buildPoints, int bu
 	//check if structure is built
 	if (buildPoints > 0 && psStruct->currentBuildPts >= structureBuildPointsToCompletion(*psStruct))
 	{
-		buildingComplete(psStruct);
+		buildingComplete(psStruct, gameWorld);
 
 		//only play the sound if selected player
 		if (psDroid &&
@@ -1037,10 +1037,10 @@ void structureBuild(STRUCTURE *psStruct, DROID *psDroid, int buildPoints, int bu
 				break;
 			}
 			case REF_POWER_GEN:
-				releasePowerGen(psStruct);
+				releasePowerGen(psStruct, gameWorld.objects);
 				break;
 			case REF_RESOURCE_EXTRACTOR:
-				releaseResExtractor(psStruct);
+				releaseResExtractor(psStruct, gameWorld.objects);
 				break;
 			case REF_REPAIR_FACILITY:
 			{
@@ -1080,7 +1080,7 @@ void structureBuild(STRUCTURE *psStruct, DROID *psDroid, int buildPoints, int bu
 	if (buildPoints < 0 && psStruct->currentBuildPts == 0)
 	{
 		triggerEvent(TRIGGER_OBJECT_RECYCLED, psStruct);
-		removeStruct(psStruct, true);
+		removeStruct(psStruct, true, gameWorld);
 	}
 
 	if (checkResearchButton)
@@ -1389,7 +1389,7 @@ static WallOrientation structChooseWallType(WorldMapState& mapState, unsigned pl
 /* For now all this does is work out what height the terrain needs to be set to
 An actual foundation structure may end up being placed down
 The x and y passed in are the CENTRE of the structure*/
-static int foundationHeight(const STRUCTURE *psStruct)
+static int foundationHeight(const STRUCTURE *psStruct, const WorldMapState& mapState)
 {
 	StructureBounds b = getStructureBounds(psStruct);
 
@@ -1406,7 +1406,7 @@ static int foundationHeight(const STRUCTURE *psStruct)
 	{
 		for (int width = 0; width <= b.size.x; width++)
 		{
-			int height = map_TileHeight(gameWorld.map, b.map.x + width, b.map.y + breadth);
+			int height = map_TileHeight(mapState, b.map.x + width, b.map.y + breadth);
 			foundationMin = std::min(foundationMin, height);
 			foundationMax = std::max(foundationMax, height);
 		}
@@ -1416,7 +1416,7 @@ static int foundationHeight(const STRUCTURE *psStruct)
 }
 
 
-static void buildFlatten(STRUCTURE *pStructure, int h)
+static void buildFlatten(STRUCTURE *pStructure, WorldMapState& mapState, int h)
 {
 	StructureBounds b = getStructureBounds(pStructure);
 
@@ -1424,11 +1424,11 @@ static void buildFlatten(STRUCTURE *pStructure, int h)
 	{
 		for (int width = 0; width <= b.size.x; ++width)
 		{
-			setTileHeight(gameWorld.map, b.map.x + width, b.map.y + breadth, h);
+			setTileHeight(mapState, b.map.x + width, b.map.y + breadth, h);
 			// We need to raise features on raised tiles to the new height
-			if (TileHasFeature(mapTile(gameWorld.map, b.map.x + width, b.map.y + breadth)))
+			if (TileHasFeature(mapTile(mapState, b.map.x + width, b.map.y + breadth)))
 			{
-				getTileFeature(gameWorld.map, b.map.x + width, b.map.y + breadth)->pos.z = h;
+				getTileFeature(mapState, b.map.x + width, b.map.y + breadth)->pos.z = h;
 			}
 		}
 	}
@@ -1440,14 +1440,14 @@ static bool isPulledToTerrain(const STRUCTURE *psBuilding)
 	return type == REF_DEFENSE || type == REF_GATE || type == REF_WALL || type == REF_WALLCORNER || type == REF_REARM_PAD;
 }
 
-void alignStructure(STRUCTURE *psBuilding)
+void alignStructure(STRUCTURE *psBuilding, WorldMapState& mapState)
 {
 	/* DEFENSIVE structures are pulled to the terrain */
 	if (!isPulledToTerrain(psBuilding))
 	{
-		int mapH = foundationHeight(psBuilding);
+		int mapH = foundationHeight(psBuilding, mapState);
 
-		buildFlatten(psBuilding, mapH);
+		buildFlatten(psBuilding, mapState, mapH);
 		psBuilding->pos.z = mapH;
 		psBuilding->foundationDepth = psBuilding->pos.z;
 
@@ -1458,10 +1458,10 @@ void alignStructure(STRUCTURE *psBuilding)
 		{
 			for (int width = -1; width <= b.size.x; ++width)
 			{
-				STRUCTURE *neighbourStructure = castStructure(mapTile(gameWorld.map, b.map.x + width, b.map.y + breadth)->psObject);
+				STRUCTURE *neighbourStructure = castStructure(mapTile(mapState, b.map.x + width, b.map.y + breadth)->psObject);
 				if (neighbourStructure != nullptr && isPulledToTerrain(neighbourStructure))
 				{
-					alignStructure(neighbourStructure);  // Recursive call, but will go to the else case, so will not re-recurse.
+					alignStructure(neighbourStructure, mapState);  // Recursive call, but will go to the else case, so will not re-recurse.
 				}
 			}
 		}
@@ -1480,10 +1480,10 @@ void alignStructure(STRUCTURE *psBuilding)
 		Vector2i p1{s->max.x * dir.y - s->max.z * dir.x, s->max.x * dir.x + s->max.z * dir.y};
 		Vector2i p2{s->min.x * dir.y - s->min.z * dir.x, s->min.x * dir.x + s->min.z * dir.y};
 
-		int h1 = map_Height(gameWorld.map, psBuilding->pos.x + p1.x, psBuilding->pos.y + p2.y);
-		int h2 = map_Height(gameWorld.map, psBuilding->pos.x + p1.x, psBuilding->pos.y + p1.y);
-		int h3 = map_Height(gameWorld.map, psBuilding->pos.x + p2.x, psBuilding->pos.y + p1.y);
-		int h4 = map_Height(gameWorld.map, psBuilding->pos.x + p2.x, psBuilding->pos.y + p2.y);
+		int h1 = map_Height(mapState, psBuilding->pos.x + p1.x, psBuilding->pos.y + p2.y);
+		int h2 = map_Height(mapState, psBuilding->pos.x + p1.x, psBuilding->pos.y + p1.y);
+		int h3 = map_Height(mapState, psBuilding->pos.x + p2.x, psBuilding->pos.y + p1.y);
+		int h4 = map_Height(mapState, psBuilding->pos.x + p2.x, psBuilding->pos.y + p2.y);
 		int minH = std::min({h1, h2, h3, h4});
 		int maxH = std::max({h1, h2, h3, h4});
 		psBuilding->pos.z = std::max(psBuilding->pos.z, maxH);
@@ -1595,7 +1595,7 @@ STRUCTURE *buildStructureDir(GameWorld& world, STRUCTURE_STATS *pStructureType, 
 				}
 				// remove it from the map
 				turnOffMultiMsg(true); // don't send this one!
-				removeFeature(psFeature);
+				removeFeature(psFeature, world);
 				turnOffMultiMsg(false);
 			}
 		}
@@ -1610,7 +1610,7 @@ STRUCTURE *buildStructureDir(GameWorld& world, STRUCTURE_STATS *pStructureType, 
 				 * of walls, you see. This is not the place to test whether we own it! */
 				if (isBuildableOnWalls(pStructureType->type) && TileHasWall(psTile))
 				{
-					removeStruct((STRUCTURE *)psTile->psObject, true);
+					removeStruct((STRUCTURE *)psTile->psObject, true, world);
 				}
 				else if (TileHasStructure(psTile) && !wzapi::scriptIsObjectQueuedForRemoval(psTile->psObject))
 				{
@@ -1652,7 +1652,7 @@ STRUCTURE *buildStructureDir(GameWorld& world, STRUCTURE_STATS *pStructureType, 
 		case REF_REARM_PAD:
 			break;  // Not blocking.
 		default:
-			auxStructureBlocking(psBuilding);
+			auxStructureBlocking(psBuilding, world.map);
 			break;
 		}
 
@@ -1673,7 +1673,7 @@ STRUCTURE *buildStructureDir(GameWorld& world, STRUCTURE_STATS *pStructureType, 
 		psBuilding->status = SS_BEING_BUILT;
 		psBuilding->currentBuildPts = 0;
 
-		alignStructure(psBuilding);
+		alignStructure(psBuilding, world.map);
 
 		/* Store the weapons */
 		psBuilding->numWeaps = 0;
@@ -1749,9 +1749,9 @@ STRUCTURE *buildStructureDir(GameWorld& world, STRUCTURE_STATS *pStructureType, 
 			// NOTE: resizeRadar() may be required here, since we change scroll limits?
 		}
 		//set the functionality dependent on the type of structure
-		if (!setFunctionality(psBuilding, pStructureType->type))
+		if (!setFunctionality(psBuilding, pStructureType->type, world))
 		{
-			removeStructFromMap(psBuilding);
+			removeStructFromMap(psBuilding, world.map);
 			objmemDestroy(psBuilding, false);
 			//better reset these if you couldn't build the structure!
 			if (FromSave && player == selectedPlayer && missionLimboExpand())
@@ -1792,7 +1792,7 @@ STRUCTURE *buildStructureDir(GameWorld& world, STRUCTURE_STATS *pStructureType, 
 		psBuilding->expectedDamage = 0;  // Begin life optimistically.
 
 		//add the structure to the list - this enables it to be drawn whilst being built
-		addStructure(psBuilding);
+		addStructure(psBuilding, world.objects);
 
 		asStructureStats[max].curCount[player]++;
 
@@ -1917,7 +1917,7 @@ STRUCTURE *buildStructureDir(GameWorld& world, STRUCTURE_STATS *pStructureType, 
 				bUpgraded = true;
 
 				//need to inform any res Extr associated that not digging until complete
-				releasePowerGen(psBuilding);
+				releasePowerGen(psBuilding, gameWorld.objects);
 			}
 		}
 
@@ -1969,7 +1969,7 @@ STRUCTURE *buildStructureDir(GameWorld& world, STRUCTURE_STATS *pStructureType, 
 	}
 
 	/* why is this necessary - it makes tiles under the structure visible */
-	setUnderTilesVis(psBuilding, player);
+	setUnderTilesVis(psBuilding, world.map, player);
 
 	psBuilding->prevTime = gameTime - deltaGameTime;  // Structure hasn't been updated this tick, yet.
 	psBuilding->time = psBuilding->prevTime - 1;      // -1, so the times are different, even before updating.
@@ -2075,7 +2075,7 @@ static Vector2i defaultAssemblyPointPos(STRUCTURE *psBuilding)
 	return {};  // Unreachable.
 }
 
-static bool setFunctionality(STRUCTURE *psBuilding, STRUCTURE_TYPE functionType)
+static bool setFunctionality(STRUCTURE *psBuilding, STRUCTURE_TYPE functionType, GameWorld& world)
 {
 	ASSERT_OR_RETURN(false, psBuilding != nullptr, "Invalid pointer");
 	CHECK_STRUCTURE(psBuilding);
@@ -2123,10 +2123,10 @@ static bool setFunctionality(STRUCTURE *psBuilding, STRUCTURE_TYPE functionType)
 
 			// Set the assembly point
 			Vector2i pos = defaultAssemblyPointPos(psBuilding);
-			setAssemblyPoint(gameWorld, psFactory->psAssemblyPoint, pos.x, pos.y, psBuilding->player, true);
+			setAssemblyPoint(world, psFactory->psAssemblyPoint, pos.x, pos.y, psBuilding->player, true);
 
 			// Add the flag to the list
-			addFlagPosition(psFactory->psAssemblyPoint);
+			addFlagPosition(psFactory->psAssemblyPoint, world.objects);
 			switch (functionType)
 			{
 			case REF_FACTORY:
@@ -2171,10 +2171,10 @@ static bool setFunctionality(STRUCTURE *psBuilding, STRUCTURE_TYPE functionType)
 
 			// Set the assembly point
 			Vector2i pos = defaultAssemblyPointPos(psBuilding);
-			setAssemblyPoint(gameWorld, psRepairFac->psDeliveryPoint, pos.x, pos.y, psBuilding->player, true);
+			setAssemblyPoint(world, psRepairFac->psDeliveryPoint, pos.x, pos.y, psBuilding->player, true);
 
 			// Add the flag (triangular marker on the ground) at the delivery point
-			addFlagPosition(psRepairFac->psDeliveryPoint);
+			addFlagPosition(psRepairFac->psDeliveryPoint, world.objects);
 			setFlagPositionInc(psBuilding->pFunctionality, psBuilding->player, REPAIR_FLAG);
 			break;
 		}
@@ -2357,11 +2357,11 @@ void assignFactoryCommandDroid(STRUCTURE *psStruct, DROID *psCommander)
 		//syncDebug("Removed commander from factory %d", psStruct->id);
 		if (!missionIsOffworld())
 		{
-			addFlagPosition(psFact->psAssemblyPoint);	// add the assembly point back into the list
+			addFlagPosition(psFact->psAssemblyPoint, gameWorld.objects);	// add the assembly point back into the list
 		}
 		else
 		{
-			addFlagPositionToList(psFact->psAssemblyPoint, mission.gameWorld.objects.flags);
+			addFlagPosition(psFact->psAssemblyPoint, mission.gameWorld.objects);
 		}
 	}
 
@@ -2849,7 +2849,7 @@ bool IsPlayerDroidLimitReached(int player)
 }
 
 // Check for max number of units reached and halt production.
-static bool checkHaltOnMaxUnitsReached(STRUCTURE *psStructure, bool isMission)
+static bool checkHaltOnMaxUnitsReached(STRUCTURE *psStructure, const WorldObjectState& objState)
 {
 	CHECK_STRUCTURE(psStructure);
 
@@ -2870,7 +2870,6 @@ static bool checkHaltOnMaxUnitsReached(STRUCTURE *psStructure, bool isMission)
 		{
 		case DROID_COMMAND:
 		{
-			const WorldObjectState& objState = isMission ? mission.gameWorld.objects : gameWorld.objects;
 			if (!structureExists(objState, player, REF_COMMAND_CONTROL, true))
 			{
 				isLimit = true;
@@ -3060,7 +3059,7 @@ void aiUpdateRepairStation(STRUCTURE &station)
 	aiUpdateRepair_handleState(station);
 }
 
-static void aiUpdateStructure(STRUCTURE *psStructure, bool isMission)
+static void aiUpdateStructure(STRUCTURE *psStructure, GameWorld& world)
 {
 	UDWORD structureMode = 0;
 	DROID *psDroid;
@@ -3071,6 +3070,8 @@ static void aiUpdateStructure(STRUCTURE *psStructure, bool isMission)
 	WEAPON_STATS *psWStats;
 	bool bDirect = false;
 	TARGET_ORIGIN tmpOrigin = ORIGIN_UNKNOWN;
+
+	const bool isMission = &world == &mission.gameWorld;
 
 	CHECK_STRUCTURE(psStructure);
 
@@ -3288,7 +3289,7 @@ static void aiUpdateStructure(STRUCTURE *psStructure, bool isMission)
 			if (psChosenObj == nullptr)
 			{
 				objTrace(psStructure->id, "Rearm pad idle - look for victim");
-				for (DROID* psCurr : gameWorld.objects.droids[psStructure->player])
+				for (DROID* psCurr : world.objects.droids[psStructure->player])
 				{
 					// move next droid waiting on ground to rearm pad
 					if (vtolReadyToRearm(psCurr, psStructure) &&
@@ -3304,7 +3305,7 @@ static void aiUpdateStructure(STRUCTURE *psStructure, bool isMission)
 				{
 					if (aiCheckAlliances(i, psStructure->player) && i != psStructure->player)
 					{
-						for (DROID* psCurr : gameWorld.objects.droids[i])
+						for (DROID* psCurr : world.objects.droids[i])
 						{
 							// move next droid waiting on ground to rearm pad
 							if (vtolReadyToRearm(psCurr, psStructure))
@@ -3347,11 +3348,11 @@ static void aiUpdateStructure(STRUCTURE *psStructure, bool isMission)
 					psReArmPad->timeStarted = ACTION_START_TIME;
 					psReArmPad->timeLastUpdated = 0;
 				}
-				auxStructureBlocking(psStructure);
+				auxStructureBlocking(psStructure, world.map);
 			}
 			else
 			{
-				auxStructureNonblocking(psStructure);
+				auxStructureNonblocking(psStructure, world.map);
 			}
 			break;
 		}
@@ -3498,7 +3499,7 @@ static void aiUpdateStructure(STRUCTURE *psStructure, bool isMission)
 				// also need to check if a command droid's group is full
 
 				// If the factory commanders group is full - return
-				if (IsFactoryCommanderGroupFull(psFactory) || checkHaltOnMaxUnitsReached(psStructure, isMission))
+				if (IsFactoryCommanderGroupFull(psFactory) || checkHaltOnMaxUnitsReached(psStructure, world.objects))
 				{
 					return;
 				}
@@ -3523,7 +3524,7 @@ static void aiUpdateStructure(STRUCTURE *psStructure, bool isMission)
 			}
 
 			//check for manufacture to be complete
-			if (psFactory->buildPointsRemaining <= 0 && !IsFactoryCommanderGroupFull(psFactory) && !checkHaltOnMaxUnitsReached(psStructure, isMission))
+			if (psFactory->buildPointsRemaining <= 0 && !IsFactoryCommanderGroupFull(psFactory) && !checkHaltOnMaxUnitsReached(psStructure, world.objects))
 			{
 				if (isMission)
 				{
@@ -3638,7 +3639,7 @@ static void aiUpdateStructure(STRUCTURE *psStructure, bool isMission)
 					//clear the rearm pad
 					psDroid->action = DACTION_NONE;
 					psReArmPad->psObj = nullptr;
-					auxStructureNonblocking(psStructure);
+					auxStructureNonblocking(psStructure, world.map);
 					triggerEventDroidIdle(psDroid);
 					objTrace(psDroid->id, "VTOL happy and ready for action!");
 				}
@@ -3777,18 +3778,20 @@ int gateCurrentOpenHeight(const STRUCTURE *psStructure, uint32_t time, int minim
 }
 
 /* The main update routine for all Structures */
-void structureUpdate(STRUCTURE *psBuilding, bool bMission)
+void structureUpdate(STRUCTURE *psBuilding, GameWorld& world)
 {
 	UDWORD widthScatter, breadthScatter;
 	UDWORD emissionInterval, iPointsToAdd, iPointsRequired;
 	Vector3i dv;
 	int i;
 
+	const bool bMission = &world == &mission.gameWorld;
+
 	syncDebugStructure(psBuilding, '<');
 
 	if (psBuilding->flags.test(OBJECT_FLAG_DIRTY) && !bMission)
 	{
-		visTilesUpdate(psBuilding, gameWorld.map);
+		visTilesUpdate(psBuilding, world.map);
 		psBuilding->flags.set(OBJECT_FLAG_DIRTY, false);
 	}
 
@@ -3808,14 +3811,14 @@ void structureUpdate(STRUCTURE *psBuilding, bool bMission)
 			if (!found)	// no droids on our tile, safe to close
 			{
 				psBuilding->state = SAS_CLOSING;
-				auxStructureClosedGate(psBuilding);     // closed
+				auxStructureClosedGate(psBuilding, world.map);     // closed
 				psBuilding->lastStateTime = gameTime;	// reset timer
 			}
 		}
 		else if (psBuilding->state == SAS_OPENING && psBuilding->lastStateTime + SAS_OPEN_SPEED < gameTime)
 		{
 			psBuilding->state = SAS_OPEN;
-			auxStructureOpenGate(psBuilding);       // opened
+			auxStructureOpenGate(psBuilding, world.map);       // opened
 			psBuilding->lastStateTime = gameTime;	// reset timer
 		}
 		else if (psBuilding->state == SAS_CLOSING && psBuilding->lastStateTime + SAS_OPEN_SPEED < gameTime)
@@ -3865,7 +3868,7 @@ void structureUpdate(STRUCTURE *psBuilding, bool bMission)
 	//update the manufacture/research of the building once complete
 	if (psBuilding->status == SS_BUILT)
 	{
-		aiUpdateStructure(psBuilding, bMission);
+		aiUpdateStructure(psBuilding, world);
 	}
 
 	if (psBuilding->status != SS_BUILT)
@@ -3888,7 +3891,7 @@ void structureUpdate(STRUCTURE *psBuilding, bool bMission)
 
 			if (psBuilding->currentBuildPts == 0)
 			{
-				removeStruct(psBuilding, true);  // If giving up on building something, remove the structure (and remove it from the power queue).
+				removeStruct(psBuilding, true, world);  // If giving up on building something, remove the structure (and remove it from the power queue).
 			}
 		}
 		psBuilding->lastBuildRate = psBuilding->buildRate;
@@ -3992,7 +3995,7 @@ void structureUpdate(STRUCTURE *psBuilding, bool bMission)
 				realY = static_cast<SDWORD>(structHeightScale(psBuilding) * point->y);
 				position.y = psBuilding->pos.z + realY;
 				position.z = static_cast<int>(psBuilding->pos.y - point->z);
-				const auto psTile = mapTile(gameWorld.map, map_coord({position.x, position.y}));
+				const auto psTile = mapTile(world.map, map_coord({position.x, position.y}));
 				if (tileIsClearlyVisible(psTile))
 				{
 					effectSetSize(30);
@@ -4543,9 +4546,9 @@ bool validLocation(GameWorld& world, BASE_STATS *psStats, Vector2i pos, uint16_t
 
 
 //remove a structure from the map
-static void removeStructFromMap(STRUCTURE *psStruct)
+static void removeStructFromMap(STRUCTURE *psStruct, WorldMapState& mapState)
 {
-	auxStructureNonblocking(psStruct);
+	auxStructureNonblocking(psStruct, mapState);
 
 	/* set tiles drawing */
 	StructureBounds b = getStructureBounds(psStruct);
@@ -4553,11 +4556,11 @@ static void removeStructFromMap(STRUCTURE *psStruct)
 	{
 		for (int i = 0; i < b.size.x; ++i)
 		{
-			MAPTILE *psTile = mapTile(gameWorld.map, b.map.x + i, b.map.y + j);
+			MAPTILE *psTile = mapTile(mapState, b.map.x + i, b.map.y + j);
 			if (psTile->psObject == psStruct)
 			{
 				psTile->psObject = nullptr;
-				auxClearBlocking(gameWorld.map, b.map.x + i, b.map.y + j, AIR_BLOCKED);
+				auxClearBlocking(mapState, b.map.x + i, b.map.y + j, AIR_BLOCKED);
 			}
 		}
 	}
@@ -4566,7 +4569,7 @@ static void removeStructFromMap(STRUCTURE *psStruct)
 // remove a structure from a game without any visible effects
 // bDestroy = true if the object is to be destroyed
 // (for example used to change the type of wall at a location)
-bool removeStruct(STRUCTURE *psDel, bool bDestroy)
+bool removeStruct(STRUCTURE *psDel, bool bDestroy, GameWorld& world)
 {
 	bool		resourceFound = false;
 	FLAG_POSITION	*psAssemblyPoint = nullptr;
@@ -4577,7 +4580,7 @@ bool removeStruct(STRUCTURE *psDel, bool bDestroy)
 
 	if (bDestroy)
 	{
-		removeStructFromMap(psDel);
+		removeStructFromMap(psDel, world.map);
 	}
 
 	if (bDestroy)
@@ -4587,7 +4590,7 @@ bool removeStruct(STRUCTURE *psDel, bool bDestroy)
 		HOW MUCH IS THERE && NOT RES EXTRACTORS */
 		if (psDel->pStructureType->type == REF_RESOURCE_EXTRACTOR)
 		{
-			FEATURE *psOil = buildFeature(gameWorld.map, oilResFeature, psDel->pos.x, psDel->pos.y, false);
+			FEATURE *psOil = buildFeature(world, oilResFeature, psDel->pos.x, psDel->pos.y, false);
 			memcpy(psOil->seenThisTick, psDel->visible, sizeof(psOil->seenThisTick));
 			resourceFound = true;
 		}
@@ -4596,15 +4599,15 @@ bool removeStruct(STRUCTURE *psDel, bool bDestroy)
 	if (psDel->pStructureType->type == REF_RESOURCE_EXTRACTOR)
 	{
 		//tell associated Power Gen
-		releaseResExtractor(psDel);
+		releaseResExtractor(psDel, world.objects);
 		//tell keybind that this is going away (to prevent dangling pointer in kf_JumpToResourceExtractor)
-		keybindInformResourceExtractorRemoved(psDel);
+		keybindInformResourceExtractorRemoved(psDel, world.objects);
 	}
 
 	if (psDel->pStructureType->type == REF_POWER_GEN)
 	{
 		//tell associated Res Extractors
-		releasePowerGen(psDel);
+		releasePowerGen(psDel, world.objects);
 	}
 
 	//check for a research topic currently under way
@@ -4666,7 +4669,7 @@ bool removeStruct(STRUCTURE *psDel, bool bDestroy)
 	if (bDestroy)
 	{
 		debug(LOG_DEATH, "Killing off %s id %d (%p)", objInfo(psDel), psDel->id, static_cast<void *>(psDel));
-		killStruct(psDel);
+		killStruct(psDel, world.objects);
 	}
 
 	if (psDel->player == selectedPlayer)
@@ -4682,7 +4685,7 @@ bool removeStruct(STRUCTURE *psDel, bool bDestroy)
 }
 
 /* Remove a structure */
-bool destroyStruct(STRUCTURE *psDel, unsigned impactTime)
+bool destroyStruct(STRUCTURE *psDel, unsigned impactTime, GameWorld& world)
 {
 	UDWORD			widthScatter, breadthScatter, heightScatter;
 
@@ -4726,7 +4729,7 @@ bool destroyStruct(STRUCTURE *psDel, unsigned impactTime)
 		/* Get coordinates for everybody! */
 		pos.x = psDel->pos.x;
 		pos.z = psDel->pos.y;  // z = y [sic] intentional
-		pos.y = map_Height(gameWorld.map, pos.x, pos.z);
+		pos.y = map_Height(world.map, pos.x, pos.z);
 
 		// Set off a fire, provide dimensions for the fire
 		if (bMinor)
@@ -4796,9 +4799,9 @@ bool destroyStruct(STRUCTURE *psDel, unsigned impactTime)
 	}
 
 	// Actually set the tiles on fire - even if the effect is not visible.
-	tileSetFire(gameWorld.map, psDel->pos.x, psDel->pos.y, burnDuration);
+	tileSetFire(world.map, psDel->pos.x, psDel->pos.y, burnDuration);
 
-	const bool resourceFound = removeStruct(psDel, true);
+	const bool resourceFound = removeStruct(psDel, true, world);
 	psDel->died = impactTime;
 
 	// Leave burn marks in the ground where building once stood
@@ -4809,7 +4812,7 @@ bool destroyStruct(STRUCTURE *psDel, unsigned impactTime)
 		{
 			for (int width = 0; width < b.size.x; ++width)
 			{
-				MAPTILE *psTile = mapTile(gameWorld.map, b.map.x + width, b.map.y + breadth);
+				MAPTILE *psTile = mapTile(world.map, b.map.x + width, b.map.y + breadth);
 				if (TEST_TILE_VISIBLE_TO_SELECTEDPLAYER(psTile))
 				{
 					psTile->illumination /= 2;
@@ -5178,7 +5181,7 @@ bool calcStructureMuzzleLocation(const STRUCTURE *psStructure, Vector3i *muzzle,
 
 /*Looks through the list of structures to see if there are any inactive
 resource extractors*/
-void checkForResExtractors(STRUCTURE *psBuilding)
+void checkForResExtractors(STRUCTURE *psBuilding, WorldObjectState& objState)
 {
 	ASSERT_OR_RETURN(, psBuilding->pStructureType->type == REF_POWER_GEN, "invalid structure type");
 
@@ -5187,7 +5190,7 @@ void checkForResExtractors(STRUCTURE *psBuilding)
 	typedef std::vector<Derrick> Derricks;
 	Derricks derricks;
 	derricks.reserve(NUM_POWER_MODULES + 1);
-	for (STRUCTURE *currExtractor : gameWorld.objects.extractors[psBuilding->player])
+	for (STRUCTURE *currExtractor : objState.extractors[psBuilding->player])
 	{
 		RES_EXTRACTOR *resExtractor = &currExtractor->pFunctionality->resourceExtractor;
 
@@ -5257,7 +5260,7 @@ uint16_t countPlayerUnusedDerricks(const WorldObjectState& objState)
 
 /*Looks through the list of structures to see if there are any Power Gens
 with available slots for the new Res Ext*/
-void checkForPowerGen(STRUCTURE *psBuilding)
+void checkForPowerGen(STRUCTURE *psBuilding, WorldObjectState& objState)
 {
 	ASSERT_OR_RETURN(, psBuilding->pStructureType->type == REF_RESOURCE_EXTRACTOR, "invalid structure type");
 
@@ -5270,7 +5273,7 @@ void checkForPowerGen(STRUCTURE *psBuilding)
 	// Find a power generator, if possible with a power module.
 	STRUCTURE *bestPowerGen = nullptr;
 	int bestSlot = 0;
-	for (STRUCTURE *psCurr : gameWorld.objects.structures[psBuilding->player])
+	for (STRUCTURE *psCurr : objState.structures[psBuilding->player])
 	{
 		if (psCurr->pStructureType->type == REF_POWER_GEN && psCurr->status == SS_BUILT)
 		{
@@ -5334,7 +5337,7 @@ void informPowerGen(STRUCTURE *psStruct)
 /*called when a Res extractor is destroyed or runs out of power or is disconnected
 adjusts the owning Power Gen so that it can link to a different Res Extractor if one
 is available*/
-void releaseResExtractor(STRUCTURE *psRelease)
+void releaseResExtractor(STRUCTURE *psRelease, WorldObjectState& objState)
 {
 	if (psRelease->pStructureType->type != REF_RESOURCE_EXTRACTOR)
 	{
@@ -5351,12 +5354,12 @@ void releaseResExtractor(STRUCTURE *psRelease)
 	psRelease->pFunctionality->resourceExtractor.psPowerGen = nullptr;
 
 	//there may be spare resource extractors
-	for (STRUCTURE* psCurr : gameWorld.objects.extractors[psRelease->player])
+	for (STRUCTURE* psCurr : objState.extractors[psRelease->player])
 	{
 		//check not connected and power left and built!
 		if (psCurr != psRelease && psCurr->pFunctionality->resourceExtractor.psPowerGen == nullptr && psCurr->status == SS_BUILT)
 		{
-			checkForPowerGen(psCurr);
+			checkForPowerGen(psCurr, objState);
 		}
 	}
 }
@@ -5365,7 +5368,7 @@ void releaseResExtractor(STRUCTURE *psRelease)
 /*called when a Power Gen is destroyed or is disconnected
 adjusts the associated Res Extractors so that they can link to different Power
 Gens if any are available*/
-void releasePowerGen(STRUCTURE *psRelease)
+void releasePowerGen(STRUCTURE *psRelease, WorldObjectState& objState)
 {
 	POWER_GEN	*psPowerGen;
 	UDWORD		i;
@@ -5387,19 +5390,19 @@ void releasePowerGen(STRUCTURE *psRelease)
 		}
 	}
 	//may have a power gen with spare capacity
-	for (STRUCTURE* psCurr : gameWorld.objects.structures[psRelease->player])
+	for (STRUCTURE* psCurr : objState.structures[psRelease->player])
 	{
 		if (psCurr->pStructureType->type == REF_POWER_GEN &&
 		    psCurr != psRelease && psCurr->status == SS_BUILT)
 		{
-			checkForResExtractors(psCurr);
+			checkForResExtractors(psCurr, objState);
 		}
 	}
 }
 
 
 /*this is called whenever a structure has finished building*/
-void buildingComplete(STRUCTURE *psBuilding)
+void buildingComplete(STRUCTURE *psBuilding, GameWorld& world)
 {
 	CHECK_STRUCTURE(psBuilding);
 
@@ -5412,7 +5415,7 @@ void buildingComplete(STRUCTURE *psBuilding)
 	psBuilding->currentBuildPts = structureBuildPointsToCompletion(*psBuilding);
 	psBuilding->status = SS_BUILT;
 
-	visTilesUpdate(psBuilding, gameWorld.map);
+	visTilesUpdate(psBuilding, world.map);
 
 	if (psBuilding->prebuiltImd != nullptr)
 	{
@@ -5426,10 +5429,10 @@ void buildingComplete(STRUCTURE *psBuilding)
 	switch (psBuilding->pStructureType->type)
 	{
 	case REF_POWER_GEN:
-		checkForResExtractors(psBuilding);
+		checkForResExtractors(psBuilding, world.objects);
 		break;
 	case REF_RESOURCE_EXTRACTOR:
-		checkForPowerGen(psBuilding);
+		checkForPowerGen(psBuilding, world.objects);
 		break;
 	case REF_RESEARCH:
 		//this deals with research facilities that are upgraded whilst mid-research
@@ -5443,11 +5446,11 @@ void buildingComplete(STRUCTURE *psBuilding)
 		releaseProduction(psBuilding, ModeImmediate);
 		break;
 	case REF_SAT_UPLINK:
-		revealAll(gameWorld.map, psBuilding->player);
+		revealAll(world.map, psBuilding->player);
 		break;
 	case REF_GATE:
-		auxStructureNonblocking(psBuilding);  // Clear outdated flags.
-		auxStructureClosedGate(psBuilding);  // Don't block for the sake of allied pathfinding.
+		auxStructureNonblocking(psBuilding, world.map);  // Clear outdated flags.
+		auxStructureClosedGate(psBuilding, world.map);  // Don't block for the sake of allied pathfinding.
 		break;
 	default:
 		//do nothing
@@ -6563,7 +6566,7 @@ void checkDeliveryPoints(GameWorld& world, UDWORD version)
 								ASSERT(!"can't create new delivery point for repair facility", "unable to create new delivery point for repair facility");
 								return;
 							}
-							addFlagPosition(psRepair->psDeliveryPoint);
+							addFlagPosition(psRepair->psDeliveryPoint, gameWorld.objects);
 							setFlagPositionInc(psStruct->pFunctionality, psStruct->player, REPAIR_FLAG);
 							//initialise the assembly point position
 							x = map_coord(psStruct->pos.x + 256);
@@ -6902,10 +6905,10 @@ STRUCTURE *giftSingleStructure(STRUCTURE *psStructure, UBYTE attackPlayer, bool 
 		{
 			originalPlayer = psStructure->player;
 			//tell the system the structure no longer exists
-			(void)removeStruct(psStructure, false);
+			(void)removeStruct(psStructure, false, gameWorld);
 
 			// remove structure from one list
-			removeStructureFromList(psStructure, gameWorld.objects.structures);
+			removeStructureFromList(psStructure, gameWorld.objects);
 
 			psStructure->selected = false;
 
@@ -6916,7 +6919,7 @@ STRUCTURE *giftSingleStructure(STRUCTURE *psStructure, UBYTE attackPlayer, bool 
 			psStructure->resistance = (UWORD)structureResistance(psStructure->pStructureType, psStructure->player);
 
 			// add to other list.
-			addStructure(psStructure);
+			addStructure(psStructure, gameWorld.objects);
 
 			// increment structure count for new owner
 			UDWORD max = psStructure->pStructureType - asStructureStats;
@@ -6955,7 +6958,7 @@ STRUCTURE *giftSingleStructure(STRUCTURE *psStructure, UBYTE attackPlayer, bool 
 
 			if (psStructure->status == SS_BUILT)
 			{
-				buildingComplete(psStructure);
+				buildingComplete(psStructure, gameWorld);
 			}
 			//since the structure isn't being rebuilt, the visibility code needs to be adjusted
 			//make sure this structure is visible to selectedPlayer
@@ -6980,7 +6983,7 @@ STRUCTURE *giftSingleStructure(STRUCTURE *psStructure, UBYTE attackPlayer, bool 
 	//check module not attached
 	psModule = getModuleStat(psStructure);
 	//get rid of the structure
-	(void)removeStruct(psStructure, true);
+	(void)removeStruct(psStructure, true, gameWorld);
 
 	//make sure power is not used to build
 	bPowerOn = powerCalculated;
@@ -7021,7 +7024,7 @@ STRUCTURE *giftSingleStructure(STRUCTURE *psStructure, UBYTE attackPlayer, bool 
 		else
 		{
 			psNewStruct->status = SS_BUILT;
-			buildingComplete(psNewStruct);
+			buildingComplete(psNewStruct, gameWorld);
 			triggerEventStructBuilt(psNewStruct, nullptr);
 			checkPlayerBuiltHQ(psNewStruct);
 		}

--- a/src/structure.cpp
+++ b/src/structure.cpp
@@ -912,7 +912,7 @@ float structureCompletionProgress(const STRUCTURE & structure)
 
 /// Add buildPoints to the structures currentBuildPts, due to construction work by the droid
 /// Also can deconstruct (demolish) a building if passed negative buildpoints
-void structureBuild(STRUCTURE *psStruct, DROID *psDroid, int buildPoints, int buildRate)
+void structureBuild(GameWorld& world, STRUCTURE *psStruct, DROID *psDroid, int buildPoints, int buildRate)
 {
 	bool checkResearchButton = psStruct->status == SS_BUILT;  // We probably just started demolishing, if this is true.
 	int prevResearchState = 0;
@@ -930,7 +930,7 @@ void structureBuild(STRUCTURE *psStruct, DROID *psDroid, int buildPoints, int bu
 	{
 		for (unsigned player = 0; player < MAX_PLAYERS; player++)
 		{
-			for (const DROID *psCurr : gameWorld.objects.droids[player])
+			for (const DROID *psCurr : world.objects.droids[player])
 			{
 				// An enemy droid is blocking it
 				if ((STRUCTURE *) orderStateObj(psCurr, DORDER_BUILD) == psStruct
@@ -969,7 +969,7 @@ void structureBuild(STRUCTURE *psStruct, DROID *psDroid, int buildPoints, int bu
 	//check if structure is built
 	if (buildPoints > 0 && psStruct->currentBuildPts >= structureBuildPointsToCompletion(*psStruct))
 	{
-		buildingComplete(psStruct, gameWorld);
+		buildingComplete(psStruct, world);
 
 		//only play the sound if selected player
 		if (psDroid &&
@@ -987,7 +987,7 @@ void structureBuild(STRUCTURE *psStruct, DROID *psDroid, int buildPoints, int bu
 		if (psDroid)
 		{
 			// Clear all orders for helping hands. Needed for AI script which runs next frame.
-			for (DROID* psIter : gameWorld.objects.droids[psDroid->player])
+			for (DROID* psIter : world.objects.droids[psDroid->player])
 			{
 				if ((psIter->order.type == DORDER_BUILD || psIter->order.type == DORDER_HELPBUILD || psIter->order.type == DORDER_LINEBUILD)
 				    && psIter->order.psObj == psStruct
@@ -1038,10 +1038,10 @@ void structureBuild(STRUCTURE *psStruct, DROID *psDroid, int buildPoints, int bu
 				break;
 			}
 			case REF_POWER_GEN:
-				releasePowerGen(psStruct, gameWorld.objects);
+				releasePowerGen(psStruct, world.objects);
 				break;
 			case REF_RESOURCE_EXTRACTOR:
-				releaseResExtractor(psStruct, gameWorld.objects);
+				releaseResExtractor(psStruct, world.objects);
 				break;
 			case REF_REPAIR_FACILITY:
 			{
@@ -1081,7 +1081,7 @@ void structureBuild(STRUCTURE *psStruct, DROID *psDroid, int buildPoints, int bu
 	if (buildPoints < 0 && psStruct->currentBuildPts == 0)
 	{
 		triggerEvent(TRIGGER_OBJECT_RECYCLED, psStruct);
-		removeStruct(psStruct, true, gameWorld);
+		removeStruct(psStruct, true, world);
 	}
 
 	if (checkResearchButton)
@@ -1110,9 +1110,9 @@ static int structureTotalReturn(const STRUCTURE *psStruct)
 	return power / 2;
 }
 
-void structureDemolish(STRUCTURE *psStruct, DROID *psDroid, int buildPoints)
+void structureDemolish(GameWorld& world, STRUCTURE *psStruct, DROID *psDroid, int buildPoints)
 {
-	structureBuild(psStruct, psDroid, -buildPoints);
+	structureBuild(world, psStruct, psDroid, -buildPoints);
 }
 
 void structureRepair(STRUCTURE *psStruct, DROID *psDroid, int buildRate)

--- a/src/structure.cpp
+++ b/src/structure.cpp
@@ -2238,7 +2238,7 @@ static bool transferFixupFunctionality(STRUCTURE *psBuilding, STRUCTURE_TYPE fun
 			}
 
 			// Transfer / fix-up factory assembly point, and number
-			transferFlagPositionToPlayer(psFactory->psAssemblyPoint, priorPlayer, psBuilding->player);
+			transferFlagPositionToPlayer(gameWorld.objects, psFactory->psAssemblyPoint, priorPlayer, psBuilding->player);
 
 			switch (functionType)
 			{
@@ -2293,7 +2293,7 @@ static bool transferFixupFunctionality(STRUCTURE *psBuilding, STRUCTURE_TYPE fun
 			}
 
 			// Transfer / fix-up factory assembly point, and number
-			transferFlagPositionToPlayer(psRepairFac->psDeliveryPoint, priorPlayer, psBuilding->player);
+			transferFlagPositionToPlayer(gameWorld.objects, psRepairFac->psDeliveryPoint, priorPlayer, psBuilding->player);
 
 			setFlagPositionInc(psBuilding->pFunctionality, psBuilding->player, REPAIR_FLAG);
 			break;

--- a/src/structure.h
+++ b/src/structure.h
@@ -99,7 +99,7 @@ bool structureStatsShutDown();
 int requestOpenGate(STRUCTURE *psStructure);
 int gateCurrentOpenHeight(const STRUCTURE *psStructure, uint32_t time, int minimumStub);  ///< Returns how far open the gate is, or 0 if the structure is not a gate.
 
-int32_t structureDamage(STRUCTURE *psStructure, PROJECTILE *psProjectile, unsigned damage, WEAPON_CLASS weaponClass, WEAPON_SUBCLASS weaponSubClass, unsigned impactTime, bool isDamagePerSecond, int minDamage, bool empRadiusHit);
+int32_t structureDamage(GameWorld& world, STRUCTURE *psStructure, PROJECTILE *psProjectile, unsigned damage, WEAPON_CLASS weaponClass, WEAPON_SUBCLASS weaponSubClass, unsigned impactTime, bool isDamagePerSecond, int minDamage, bool empRadiusHit);
 void structureBuild(STRUCTURE *psStructure, DROID *psDroid, int buildPoints, int buildRate = 1);
 void structureDemolish(STRUCTURE *psStructure, DROID *psDroid, int buildPoints);
 void structureRepair(STRUCTURE *psStruct, DROID *psDroid, int buildRate);

--- a/src/structure.h
+++ b/src/structure.h
@@ -117,15 +117,15 @@ STRUCTURE *buildStructureDir(GameWorld& world, STRUCTURE_STATS *pStructureType, 
 /// not heap-allocated and thus doesn't have a stable address!
 nonstd::optional<STRUCTURE> buildBlueprint(WorldMapState& mapState, STRUCTURE_STATS const *psStats, Vector3i xy, uint16_t direction, unsigned moduleIndex, STRUCT_STATES state, uint8_t ownerPlayer);
 /* The main update routine for all Structures */
-void structureUpdate(STRUCTURE *psBuilding, bool bMission);
+void structureUpdate(STRUCTURE *psBuilding, GameWorld& world);
 
 /* Remove a structure and free it's memory */
-bool destroyStruct(STRUCTURE *psDel, unsigned impactTime);
+bool destroyStruct(STRUCTURE *psDel, unsigned impactTime, GameWorld& world);
 
 // remove a structure from a game without any visible effects
 // bDestroy = true if the object is to be destroyed
 // (for example used to change the type of wall at a location)
-bool removeStruct(STRUCTURE *psDel, bool bDestroy);
+bool removeStruct(STRUCTURE *psDel, bool bDestroy, GameWorld& world);
 
 //fills the list with Structures that can be built
 std::vector<STRUCTURE_STATS *> fillStructureList(const WorldObjectState& objState, UDWORD selectedPlayer, UDWORD limit, bool showFavorites);
@@ -140,7 +140,7 @@ bool validLocation(GameWorld& world, BASE_STATS *psStats, Vector2i pos, uint16_t
 bool isWall(STRUCTURE_TYPE type);                                    ///< Structure is a wall. Not completely sure it handles all cases.
 bool isBuildableOnWalls(STRUCTURE_TYPE type);                        ///< Structure can be built on walls. Not completely sure it handles all cases.
 
-void alignStructure(STRUCTURE *psBuilding);
+void alignStructure(STRUCTURE *psBuilding, WorldMapState& mapState);
 
 /* set the current number of structures of each type built */
 void setCurrentStructQuantity(const WorldObjectState& objState, bool displayError);
@@ -187,11 +187,11 @@ bool calcStructureMuzzleLocation(const STRUCTURE *psStructure, Vector3i *muzzle,
 bool calcStructureMuzzleBaseLocation(const STRUCTURE *psStructure, Vector3i *muzzle, int weapon_slot);
 
 /*this is called whenever a structure has finished building*/
-void buildingComplete(STRUCTURE *psBuilding);
+void buildingComplete(STRUCTURE *psBuilding, GameWorld& world);
 
 // these functions are used in game.c inplace of  building complete
-void checkForResExtractors(STRUCTURE *psPowerGen);
-void checkForPowerGen(STRUCTURE *psPowerGen);
+void checkForResExtractors(STRUCTURE *psPowerGen, WorldObjectState& objState);
+void checkForPowerGen(STRUCTURE *psPowerGen, WorldObjectState& objState);
 
 uint16_t countPlayerUnusedDerricks(const WorldObjectState& objState);
 
@@ -207,12 +207,12 @@ STRUCTURE_STATS *getModuleStat(const STRUCTURE *psStruct);
 /*called when a Res extractor is destroyed or runs out of power or is disconnected
 adjusts the owning Power Gen so that it can link to a different Res Extractor if one
 is available*/
-void releaseResExtractor(STRUCTURE *psRelease);
+void releaseResExtractor(STRUCTURE *psRelease, WorldObjectState& objState);
 
 /*called when a Power Gen is destroyed or is disconnected
 adjusts the associated Res Extractors so that they can link to different Power
 Gens if any are available*/
-void releasePowerGen(STRUCTURE *psRelease);
+void releasePowerGen(STRUCTURE *psRelease, WorldObjectState& objState);
 
 //print some info at the top of the screen dependent on the structure
 void printStructureInfo(STRUCTURE *psStructure);

--- a/src/structure.h
+++ b/src/structure.h
@@ -100,8 +100,8 @@ int requestOpenGate(STRUCTURE *psStructure);
 int gateCurrentOpenHeight(const STRUCTURE *psStructure, uint32_t time, int minimumStub);  ///< Returns how far open the gate is, or 0 if the structure is not a gate.
 
 int32_t structureDamage(GameWorld& world, STRUCTURE *psStructure, PROJECTILE *psProjectile, unsigned damage, WEAPON_CLASS weaponClass, WEAPON_SUBCLASS weaponSubClass, unsigned impactTime, bool isDamagePerSecond, int minDamage, bool empRadiusHit);
-void structureBuild(STRUCTURE *psStructure, DROID *psDroid, int buildPoints, int buildRate = 1);
-void structureDemolish(STRUCTURE *psStructure, DROID *psDroid, int buildPoints);
+void structureBuild(GameWorld& world, STRUCTURE *psStructure, DROID *psDroid, int buildPoints, int buildRate = 1);
+void structureDemolish(GameWorld& world, STRUCTURE *psStructure, DROID *psDroid, int buildPoints);
 void structureRepair(STRUCTURE *psStruct, DROID *psDroid, int buildRate);
 /* Set the type of droid for a factory to build */
 bool structSetManufacture(STRUCTURE *psStruct, DROID_TEMPLATE *psTempl, QUEUE_MODE mode);

--- a/src/visibility.cpp
+++ b/src/visibility.cpp
@@ -793,7 +793,7 @@ static void processVisibilityLevel(BASE_OBJECT *psObj, bool& addedMessage)
 			/* Make sure all tiles under a feature/structure become visible when you see it */
 			if (psObj->type == OBJ_STRUCTURE || psObj->type == OBJ_FEATURE)
 			{
-				setUnderTilesVis(psObj, player);
+				setUnderTilesVis(psObj, gameWorld.map, player);
 			}
 
 			// if a feature has just become visible set the message blips
@@ -900,7 +900,7 @@ void processVisibility()
 	}
 }
 
-void	setUnderTilesVis(BASE_OBJECT *psObj, UDWORD player)
+void	setUnderTilesVis(BASE_OBJECT *psObj, WorldMapState& mapState, UDWORD player)
 {
 	UDWORD		i, j;
 	UDWORD		mapX, mapY, width, breadth;
@@ -937,7 +937,7 @@ void	setUnderTilesVis(BASE_OBJECT *psObj, UDWORD player)
 	{
 		for (j = 0; j < breadth + 1; j++)  // + 1 because visibility is for top left of tile.
 		{
-			psTile = mapTile(gameWorld.map, mapX + i, mapY + j);
+			psTile = mapTile(mapState, mapX + i, mapY + j);
 			if (psTile)
 			{
 				psTile->tileExploredBits |= alliancebits[player];

--- a/src/visibility.cpp
+++ b/src/visibility.cpp
@@ -396,7 +396,6 @@ void visRemoveVisibility(BASE_OBJECT *psObj, WorldMapState& mapState)
 	{
 		for (TILEPOS pos : psObj->watchedTiles)
 		{
-			// FIXME: the mapTile might have been swapped out, see swapMissionPointers()
 			MAPTILE *psTile = mapTile(mapState, pos.x, pos.y);
 
 			ASSERT(pos.type < 2, "Invalid visibility type %d", (int)pos.type);

--- a/src/visibility.h
+++ b/src/visibility.h
@@ -64,7 +64,7 @@ void processVisibility();  ///< Calls processVisibilitySelf and processVisibilit
 // update the visibility reduction
 void visUpdateLevel();
 
-void setUnderTilesVis(BASE_OBJECT *psObj, UDWORD player);
+void setUnderTilesVis(BASE_OBJECT *psObj, WorldMapState& mapState, UDWORD player);
 
 void visRemoveVisibilityOffWorld(BASE_OBJECT *psObj);
 void visRemoveVisibility(BASE_OBJECT *psObj, WorldMapState& mapState);

--- a/src/wzapi.cpp
+++ b/src/wzapi.cpp
@@ -2023,7 +2023,7 @@ wzapi::returned_nullable_ptr<const FEATURE> wzapi::addFeature(WZAPI_PARAMS(std::
 		SCRIPT_ASSERT(nullptr, context, map_coord(psFeat->pos.x) != x || map_coord(psFeat->pos.y) != y,
 		              "Building feature on tile already occupied");
 	}
-	FEATURE *psFeature = buildFeature(gameWorld.map, psStats, world_coord(x), world_coord(y), false);
+	FEATURE *psFeature = buildFeature(gameWorld, psStats, world_coord(x), world_coord(y), false);
 	return psFeature;
 }
 
@@ -3064,7 +3064,7 @@ bool wzapi::allianceExistsBetween(WZAPI_PARAMS(int player1, int player2))
 bool wzapi::removeStruct(WZAPI_PARAMS(STRUCTURE *psStruct)) WZAPI_DEPRECATED
 {
 	SCRIPT_ASSERT(false, context, psStruct, "No valid structure provided");
-	return removeStruct(psStruct, true);
+	return removeStruct(psStruct, true, gameWorld);
 }
 
 //-- ## removeObject(gameObject[, sfx])
@@ -3158,7 +3158,7 @@ wzapi::returned_nullable_ptr<const STRUCTURE> wzapi::addStructure(WZAPI_PARAMS(s
 	if (psStruct)
 	{
 		psStruct->status = SS_BUILT;
-		buildingComplete(psStruct);
+		buildingComplete(psStruct, gameWorld);
 		return psStruct;
 	}
 	return nullptr;
@@ -4836,9 +4836,9 @@ void wzapi::processScriptQueuedObjectRemovals()
 		{
 			switch (psObj->type)
 			{
-			case OBJ_STRUCTURE: destroyStruct((STRUCTURE*)psObj, gameTime); break;
-			case OBJ_DROID: destroyDroid((DROID*)psObj, gameTime); break;
-			case OBJ_FEATURE: destroyFeature((FEATURE*)psObj, gameTime); break;
+			case OBJ_STRUCTURE: destroyStruct((STRUCTURE*)psObj, gameTime, gameWorld); break;
+			case OBJ_DROID: destroyDroid((DROID*)psObj, gameTime, gameWorld); break;
+			case OBJ_FEATURE: destroyFeature((FEATURE*)psObj, gameTime, gameWorld); break;
 			default: ASSERT(false, "Wrong game object type"); break;
 			}
 		}
@@ -4846,9 +4846,9 @@ void wzapi::processScriptQueuedObjectRemovals()
 		{
 			switch (psObj->type)
 			{
-			case OBJ_STRUCTURE: removeStruct((STRUCTURE*)psObj, true); break;
-			case OBJ_DROID: removeDroidBase((DROID*)psObj); break;
-			case OBJ_FEATURE: removeFeature((FEATURE*)psObj); break;
+			case OBJ_STRUCTURE: removeStruct((STRUCTURE*)psObj, true, gameWorld); break;
+			case OBJ_DROID: removeDroidBase((DROID*)psObj, gameWorld.objects); break;
+			case OBJ_FEATURE: removeFeature((FEATURE*)psObj, gameWorld); break;
 			default: ASSERT(false, "Wrong game object type"); break;
 			}
 		}


### PR DESCRIPTION
This changeset converts some more functions to world-aware variants in order to be able to remove the last occurrence of `swapMissionPointers()`.

Tests: regular campaign flow, saves/loads across offworld/home missions.

Closes: https://github.com/Warzone2100/warzone2100/issues/4863