### PR TITLE
Replace deprecated vulkan enum value

### DIFF
--- a/lib/ivis_opengl/gfx_api_vk.cpp
+++ b/lib/ivis_opengl/gfx_api_vk.cpp
@@ -4255,10 +4255,10 @@ void VkRoot::createNewSwapchainAndSwapchainSpecificStuff(const vk::Result& reaso
 vk::SurfaceFormatKHR chooseSwapSurfaceFormat(const std::vector<vk::SurfaceFormatKHR>& availableFormats)
 {
 	const auto desiredFormats = std::array<vk::SurfaceFormatKHR, 4> {
-		vk::SurfaceFormatKHR{ vk::Format::eA2B10G10R10UnormPack32, vk::ColorSpaceKHR::eVkColorspaceSrgbNonlinear },
-		vk::SurfaceFormatKHR{ vk::Format::eA2R10G10B10UnormPack32, vk::ColorSpaceKHR::eVkColorspaceSrgbNonlinear },
-		vk::SurfaceFormatKHR{ vk::Format::eB8G8R8A8Unorm, vk::ColorSpaceKHR::eVkColorspaceSrgbNonlinear },
-		vk::SurfaceFormatKHR{ vk::Format::eR8G8B8A8Unorm, vk::ColorSpaceKHR::eVkColorspaceSrgbNonlinear }
+		vk::SurfaceFormatKHR{ vk::Format::eA2B10G10R10UnormPack32, vk::ColorSpaceKHR::eSrgbNonlinear },
+		vk::SurfaceFormatKHR{ vk::Format::eA2R10G10B10UnormPack32, vk::ColorSpaceKHR::eSrgbNonlinear },
+		vk::SurfaceFormatKHR{ vk::Format::eB8G8R8A8Unorm, vk::ColorSpaceKHR::eSrgbNonlinear },
+		vk::SurfaceFormatKHR{ vk::Format::eR8G8B8A8Unorm, vk::ColorSpaceKHR::eSrgbNonlinear }
 	};
 
 	if(availableFormats.size() == 1
@@ -4266,7 +4266,7 @@ vk::SurfaceFormatKHR chooseSwapSurfaceFormat(const std::vector<vk::SurfaceFormat
 	{
 		// don't appear to be any preferred formats, so create one
 		vk::SurfaceFormatKHR format;
-		format.colorSpace = vk::ColorSpaceKHR::eVkColorspaceSrgbNonlinear;
+		format.colorSpace = vk::ColorSpaceKHR::eSrgbNonlinear;
 		format.format = vk::Format::eB8G8R8A8Unorm;
 		return format;
 	}


### PR DESCRIPTION
Replace `eVkColorspaceSrgbNonlinear` with `eSrgbNonlinear`, as the former was removed in vulkan 1.4.350, and was a legacy alias to the latter (more precisely, `eSrgbNonlinear` → `VK_COLORSPACE_SRGB_NONLINEAR_KHR` → [legacy alias to] `VK_COLOR_SPACE_SRGB_NONLINEAR_KHR` ← `eSrgbNonlinear`).