### PR TITLE
Cobra AI: Full health droids do not need to repair

### DIFF
--- a/data/mp/multiplay/skirmish/cobra_includes/tactics.js
+++ b/data/mp/multiplay/skirmish/cobra_includes/tactics.js
@@ -12,7 +12,7 @@ function droidReady(droidID)
 
 	return (!repairDroid(droidID) &&
 		_droid.order !== DORDER_ATTACK &&
-		_droid.order !== DORDER_RTR &&
+		(_droid.order !== DORDER_RTR || Math.ceil(_droid.health) >= 100) &&
 		_droid.order !== DORDER_RECYCLE &&
 		vtolReady(droidID) //True for non-VTOL units
 	);


### PR DESCRIPTION
Cobra uses the DORDER_RTR order to know when droids are retreating to be repaired. This works because a droid at a repair facility loses this order when it reaches full health. However, if the droid reaches full health before it gets to the repair facility - whether due to auto-repair or allied repair droids - it will retain the DORDER_RTR order and continue trying to reach a repair facility, immediately losing the order when it does. This can cause traffic jams on maps with narrow chokepoints when auto-repair is researched. It's a simple enough fix to let droids using DORDER_RTR that are at full health be pulled back into combat.

<img width="1118" height="512" alt="cobra-repair-fix" src="https://github.com/user-attachments/assets/0fd1c83a-3e1f-4416-8fe5-824cc1fc9cbc" />

_You! Get back out there!_