### PR TITLE
OpenGL: GLSL shader compatibility improvements

### DIFF
--- a/data/base/shaders/quad_texture2darray.frag
+++ b/data/base/shaders/quad_texture2darray.frag
@@ -8,7 +8,7 @@
 #endif
 // 2. OpenGL ES 3.0+
 #if (defined(GL_ES) && (__VERSION__ < 300))
-#error "Unsupported version of GLES"
+#error Unsupported version of GLES
 #endif
 
 uniform ivec4 swizzle;

--- a/data/base/shaders/shadow_mapping.glsl
+++ b/data/base/shaders/shadow_mapping.glsl
@@ -3,7 +3,7 @@
 float getShadowMapDepthComp(vec2 base_uv, float u, float v, vec2 shadowMapSizeInv, int cascadeIndex, float z)
 {
 	vec2 uv = base_uv + vec2(u, v) * shadowMapSizeInv;
-	return texture( shadowMap, vec4(uv, cascadeIndex, z) );
+	return texture( shadowMap, vec4(uv, float(cascadeIndex), z) );
 }
 
 float getShadowVisibility(vec3 fragPosModelSpace, vec3 fragPosViewSpace, float NdotL, float offset)
@@ -190,7 +190,7 @@ float getShadowVisibility(vec3 fragPosModelSpace, vec3 fragPosViewSpace, float N
 
 	// PCF
 
-	float visibility = texture( shadowMap, vec4(pos.xy, cascadeIndex, (pos.z+bias)) );
+	float visibility = texture( shadowMap, vec4(pos.xy, float(cascadeIndex), (pos.z+bias)) );
 
 #if WZ_SHADOW_FILTER_SIZE >= 2
 	const float edgeVal = 0.5+float((WZ_SHADOW_FILTER_SIZE-2)/2);
@@ -202,7 +202,7 @@ float getShadowVisibility(vec3 fragPosModelSpace, vec3 fragPosViewSpace, float N
 	{
 		for (float x=startVal; x<endVal; x+=1.0)
 		{
-			visibility -= visibilityIncrement*(1.0-texture( shadowMap, vec4(pos.xy + vec2(x*texelIncrement, y*texelIncrement), cascadeIndex, (pos.z+bias)) ));
+			visibility -= visibilityIncrement*(1.0-texture( shadowMap, vec4(pos.xy + vec2(x*texelIncrement, y*texelIncrement), float(cascadeIndex), (pos.z+bias)) ));
 		}
 	}
 #endif

--- a/data/base/shaders/terrain_combined.vert
+++ b/data/base/shaders/terrain_combined.vert
@@ -4,7 +4,7 @@
 // Aspects of shader limiting GLSL compat:
 // - "flat" interpolation_qualifier (Desktop GLSL 130+, or GLES 300+)
 #if (!defined(GL_ES) && (__VERSION__ < 130)) || (defined(GL_ES) && (__VERSION__ < 300))
-#error "Unsupported version of GLSL"
+#error Unsupported version of GLSL
 #endif
 
 uniform mat4 ModelViewProjectionMatrix;

--- a/data/base/shaders/terrain_combined_classic.frag
+++ b/data/base/shaders/terrain_combined_classic.frag
@@ -94,7 +94,7 @@ vec3 blendAddEffectLighting(vec3 a, vec3 b) {
 }
 
 vec4 main_classic() {
-	vec4 decal = tile >= 0 ? texture2DArray(decalTex, vec3(uvDecal, tile), WZ_MIP_LOAD_BIAS) : vec4(0.f);
+	vec4 decal = tile >= 0 ? texture2DArray(decalTex, vec3(uvDecal, float(tile)), WZ_MIP_LOAD_BIAS) : vec4(0.f);
 
 	vec3 L = normalize(groundLightDir);
 	vec3 N = vec3(0.f,0.f,1.f);

--- a/data/base/shaders/terrain_combined_classic.frag
+++ b/data/base/shaders/terrain_combined_classic.frag
@@ -8,7 +8,7 @@
 //#endif
 // 2. OpenGL ES 3.0+
 #if (defined(GL_ES) && (__VERSION__ < 300))
-#error "Unsupported version of GLES"
+#error Unsupported version of GLES
 #endif
 
 // constants overridden by WZ when loading shaders (do not modify here in the shader source!)

--- a/data/base/shaders/terrain_combined_high.frag
+++ b/data/base/shaders/terrain_combined_high.frag
@@ -8,7 +8,7 @@
 //#endif
 // 2. OpenGL ES 3.0+
 #if (defined(GL_ES) && (__VERSION__ < 300))
-#error "Unsupported version of GLES"
+#error Unsupported version of GLES
 #endif
 
 // constants overridden by WZ when loading shaders (do not modify here in the shader source!)

--- a/data/base/shaders/terrain_combined_high.frag
+++ b/data/base/shaders/terrain_combined_high.frag
@@ -98,7 +98,7 @@ out vec4 FragColor;
 
 vec3 getGroundUv(int i) {
 	uint groundNo = fgrounds[i];
-	return vec3(uvGround * groundScale[groundNo/4u][groundNo%4u], groundNo);
+	return vec3(uvGround * groundScale[groundNo/4u][groundNo%4u], float(groundNo));
 }
 
 struct BumpData {
@@ -175,7 +175,7 @@ vec4 main_bumpMapping() {
 	getGroundBM(3, bump);
 
 	if (tile >= 0) {
-		vec3 uv = vec3(uvDecal, tile);
+		vec3 uv = vec3(uvDecal, float(tile));
 		vec4 decalColor = texture2DArray(decalTex, uv, WZ_MIP_LOAD_BIAS);
 		float a = decalColor.a;
 		// blend color, normal and gloss with ground ones based on alpha

--- a/data/base/shaders/terrain_combined_medium.frag
+++ b/data/base/shaders/terrain_combined_medium.frag
@@ -8,7 +8,7 @@
 //#endif
 // 2. OpenGL ES 3.0+
 #if (defined(GL_ES) && (__VERSION__ < 300))
-#error "Unsupported version of GLES"
+#error Unsupported version of GLES
 #endif
 
 // constants overridden by WZ when loading shaders (do not modify here in the shader source!)

--- a/data/base/shaders/terrain_combined_medium.frag
+++ b/data/base/shaders/terrain_combined_medium.frag
@@ -91,7 +91,7 @@ out vec4 FragColor;
 
 vec3 getGroundUv(int i) {
 	uint groundNo = fgrounds[i];
-	return vec3(uvGround * groundScale[groundNo/4u][groundNo%4u], groundNo);
+	return vec3(uvGround * groundScale[groundNo/4u][groundNo%4u], float(groundNo));
 }
 
 vec3 getGround(int i) {
@@ -104,7 +104,7 @@ vec3 blendAddEffectLighting(vec3 a, vec3 b) {
 
 vec4 main_medium() {
 	vec3 ground = getGround(0) + getGround(1) + getGround(2) + getGround(3);
-	vec4 decal = tile >= 0 ? texture2DArray(decalTex, vec3(uvDecal, tile), WZ_MIP_LOAD_BIAS) : vec4(0.f);
+	vec4 decal = tile >= 0 ? texture2DArray(decalTex, vec3(uvDecal, float(tile)), WZ_MIP_LOAD_BIAS) : vec4(0.f);
 
 	vec3 L = normalize(groundLightDir);
 	vec3 N = vec3(0.f,0.f,1.f);


### PR DESCRIPTION
- Avoid implicit conversions in terrain shaders (for OpenGL ES / WebGL compatibility)
- Avoid quotes in `#error` directives