### PR TITLE
Windows installer: Include Pumpkin Campaign Balance as part of Core Data

### DIFF
--- a/pkg/win_installer/warzone2100.iss
+++ b/pkg/win_installer/warzone2100.iss
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 //
 // Warzone 2100 Inno Setup Script
-// Copyright (c) 2025 Warzone 2100 Project
+// Copyright (c) 2025-2026 Warzone 2100 Project
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -404,8 +404,10 @@ Source: "{#WZ_DATADIR}\*"; Excludes: "\mods\*,\music\*,\terrain_overrides*"; Des
 Source: "{#WZ_LOCALEDIR}\*"; DestDir: "{app}\{#WZ_LOCALEDIR}"; Components: core; Flags: ignoreversion recursesubdirs createallsubdirs
 // Core Data: Documentation
 Source: "{#WZ_DOCDIR}\*"; DestDir: "{app}\{#WZ_DOCDIR}"; Components: core; Flags: ignoreversion recursesubdirs createallsubdirs
-// Core Data: Classic Campaign Mod
+// Core Data: Classic Campaign Balance Mod
 Source: "{#WZ_DATADIR}\mods\campaign\wz2100_camclassic.wz"; DestDir: "{app}\{#WZ_DATADIR}\mods\campaign"; Components: core; Flags: ignoreversion
+// Core Data: Pumpkin Campaign Balance Mod
+Source: "{#WZ_DATADIR}\mods\campaign\wz2100_campumpkin.wz"; DestDir: "{app}\{#WZ_DATADIR}\mods\campaign"; Components: core; Flags: ignoreversion
 // Core Data: Classic Terrain Pack
 Source: "{#WZ_DATADIR}\terrain_overrides\classic.wz"; DestDir: "{app}\{#WZ_DATADIR}\terrain_overrides"; Components: core; Flags: ignoreversion
 // Core Data: Base Music
@@ -417,7 +419,7 @@ Source: "{#AddBackslash(SourcePath) + "launch_warzone.bat"}"; DestDir: "{app}"; 
 // Addon: High Quality Terrain
 Source: "{#WZ_DATADIR}\terrain_overrides\high.wz"; DestDir: "{app}\{#WZ_DATADIR}\terrain_overrides"; Components: addons\terrain_hq; Flags: ignoreversion
 // Addon Mods
-Source: "{#WZ_DATADIR}\mods\*"; Excludes: "\campaign\wz2100_camclassic.wz"; DestDir: "{app}\{#WZ_DATADIR}\mods"; Components: addons\campaigns; Flags: ignoreversion recursesubdirs createallsubdirs
+Source: "{#WZ_DATADIR}\mods\*"; Excludes: "\campaign\wz2100_camclassic.wz,\campaign\wz2100_campumpkin.wz"; DestDir: "{app}\{#WZ_DATADIR}\mods"; Components: addons\campaigns; Flags: ignoreversion recursesubdirs createallsubdirs
 // Addon Music
 Source: "{#WZ_DATADIR}\music\albums\*"; Excludes: "\original_soundtrack\*"; DestDir: "{app}\{#WZ_DATADIR}\music\albums"; Components: addons\music; Flags: ignoreversion recursesubdirs createallsubdirs
 // Sequences (only one will be selected and downloaded on-demand)


### PR DESCRIPTION
Fixes: Unchecking "Addon Campaigns" would also incorrectly exclude the Pumpkin Campaign Balance Mod