### PR TITLE
Initial support for multi-touch gestures (pinch-to-zoom, two-finger pan)

### DIFF
--- a/lib/framework/input.h
+++ b/lib/framework/input.h
@@ -35,6 +35,10 @@
 #include "vector.h"
 #include <vector>
 
+#include <nonstd/optional.hpp>
+using nonstd::optional;
+using nonstd::nullopt;
+
 
 /** Defines for all the key codes used. */
 enum KEY_CODE
@@ -230,6 +234,9 @@ WZ_DECL_NONNULL(2, 3) bool mouseDrag(MOUSE_KEY_CODE code, UDWORD *px, UDWORD *py
 
 void setMouseWarp(bool value);
 bool getMouseWarp();
+
+/** Returns a float if pinch gesture is in progress */
+optional<float> consumePinchGestureScaleUpdate();
 
 /* The input buffer can contain normal character codes and these control codes */
 #define INPBUF_LEFT		KEY_LEFTARROW

--- a/lib/framework/input.h
+++ b/lib/framework/input.h
@@ -238,6 +238,14 @@ bool getMouseWarp();
 /** Returns a float if pinch gesture is in progress */
 optional<float> consumePinchGestureScaleUpdate();
 
+/** Returns a pair of floats if a pan gesture is in progress */
+struct PanGestureDeltaScreenPts
+{
+	float deltaX;
+	float deltaY;
+};
+optional<PanGestureDeltaScreenPts> consumePanGestureDeltaUpdate();
+
 /* The input buffer can contain normal character codes and these control codes */
 #define INPBUF_LEFT		KEY_LEFTARROW
 #define INPBUF_RIGHT		KEY_RIGHTARROW

--- a/lib/sdl/main_sdl.cpp
+++ b/lib/sdl/main_sdl.cpp
@@ -1,6 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
 /*
 	This file is part of Warzone 2100.
-	Copyright (C) 2011-2020  Warzone 2100 Project
+	Copyright (C) 2011-2026  Warzone 2100 Project
 
 	Warzone 2100 is free software; you can redistribute it and/or modify
 	it under the terms of the GNU General Public License as published by
@@ -20,6 +22,7 @@
  * @file main_sdl.cpp
  *
  * SDL backend code
+ * ​‌⁣‌‌⁣‌‌⁣‌⁣‌‌⁣⁣‌⁣‌⁣‌⁣‌‌‌‌‌⁣‌‌⁣⁣⁣⁣‌⁣‌⁣‌‌⁣‌‌⁣‌⁣‌⁣‌‌‌⁣‌‌‌‌‌⁣‌⁣‌‌⁣⁣⁣‌‌⁣‌⁣‌⁣‌‌‌‌⁣⁣⁣‌⁣‌‌‌⁣‌‌‌‌‌‌⁣‌⁣‌‌⁣‌‌⁣⁣‌‌⁣‌⁣‌⁣⁣‌‌⁣⁣‌‌⁣⁣⁣‌⁣‌⁣‌⁣⁣⁣‌‌⁣⁣‌⁣⁣‌‌⁣‌⁣‌‌⁣‌‌‌‌‌‌⁣⁣‌‌‌‌⁣‌⁣⁣‌⁣⁣⁣‌‌⁣⁣⁣⁣‌‌⁣‌‌⁣‌‌‌‌‌‌⁣⁣⁣‌‌‌‌‌⁣⁣⁣‌‌⁣‌‌⁣⁣‌‌⁣‌⁣‌⁣⁣⁣‌⁣⁣‌‌⁣⁣‌⁣‌‌⁣‌⁣⁣‌⁣⁣⁣⁣‌⁣⁣⁣‌⁣‌⁣‌⁣⁣⁣‌‌⁣⁣‌‌⁣‌‌‌‌‌‌⁣⁣‌⁣⁣⁣⁣‌⁣⁣⁣‌‌⁣‌‌‌⁣‌‌‌‌‌‌⁣⁣⁣‌‌⁣⁣‌⁣⁣⁣‌⁣‌⁣‌⁣⁣‌‌‌⁣‌‌⁣⁣⁣‌‌⁣⁣‌⁣⁣‌‌⁣‌⁣‌⁣⁣⁣‌‌‌⁣‌⁣⁣⁣‌⁣‌⁣‌⁣⁣‌‌⁣‌⁣‌⁣⁣‌⁣⁣⁣‌‌⁣⁣⁣‌⁣‌‌‌‌⁣‌‌‌‌‌‌⁣⁣‌⁣‌‌⁣‌⁣⁣‌⁣⁣⁣‌‌⁣⁣⁣‌‌⁣⁣‌⁣⁣⁣‌⁣‌‌‌⁣⁣⁣‌‌⁣‌‌⁣⁣⁣‌⁣‌⁣‌⁣⁣‌‌‌⁣⁣‌⁣⁣⁣‌⁣‌‌‌⁣⁣‌⁣‌‌⁣‌⁣⁣‌⁣⁣⁣⁣‌⁣⁣‌⁣⁣⁣‌‌⁣⁣⁣‌‌⁣⁣‌‌⁣‌‌‌‌‌‌⁣⁣⁣‌⁣‌‌‌⁣⁣‌⁣⁣⁣⁣‌‌⁣‌‌‌‌‌‌⁣⁣⁣‌‌‌‌‌⁣⁣‌⁣⁣⁣⁣‌⁣⁣⁣‌‌⁣‌‌⁣⁣⁣‌⁣‌‌‌‌⁣‌‌‌‌‌‌⁣⁣⁣‌⁣‌‌‌⁣⁣‌⁣‌‌‌‌⁣⁣‌‌⁣‌⁣‌‌⁣‌‌‌‌‌‌⁣⁣‌‌‌⁣⁣‌⁣⁣‌⁣⁣⁣⁣‌⁣⁣‌‌⁣‌‌‌⁣⁣‌‌⁣‌⁣‌⁣⁣‌‌‌⁣‌‌⁣⁣‌‌‌‌⁣‌⁣⁣⁣‌‌⁣⁣‌⁣⁣‌‌⁣‌⁣‌‌⁣‌‌‌‌‌‌⁣⁣⁣‌⁣‌‌‌⁣⁣‌⁣⁣⁣⁣‌‌⁣‌‌‌‌‌‌⁣⁣‌‌‌‌⁣‌‌⁣‌‌‌‌‌‌⁣⁣‌⁣⁣⁣‌‌⁣⁣‌‌⁣‌⁣‌⁣⁣⁣‌⁣⁣⁣‌‌⁣‌‌‌‌‌‌⁣⁣⁣‌‌‌‌‌⁣⁣‌⁣⁣‌‌‌⁣⁣‌‌‌‌⁣‌⁣⁣⁣‌⁣‌‌‌⁣⁣‌‌⁣⁣‌‌⁣⁣‌⁣⁣⁣⁣‌⁣⁣⁣‌‌⁣‌‌⁣⁣‌⁣⁣‌⁣‌‌⁣‌⁣⁣‌‌‌‌⁣‌‌‌‌‌‌⁣⁣‌‌⁣‌‌‌⁣⁣⁣‌⁣‌⁣‌⁣⁣‌‌⁣‌⁣‌‌⁣‌‌‌‌‌‌⁣⁣⁣‌⁣‌‌‌⁣⁣‌⁣⁣⁣⁣‌‌⁣‌‌‌‌‌‌⁣⁣⁣‌⁣⁣‌‌⁣⁣‌‌‌‌⁣‌⁣⁣⁣‌‌⁣‌‌⁣⁣‌⁣‌‌⁣‌⁣⁣‌⁣⁣⁣⁣‌⁣⁣⁣‌⁣‌⁣‌⁣⁣⁣‌‌⁣⁣‌‌⁣‌‌‌‌‌‌⁣⁣‌‌⁣⁣‌‌⁣⁣‌‌‌‌⁣‌⁣⁣‌‌‌⁣⁣‌⁣⁣⁣‌⁣‌‌‌⁣⁣‌⁣⁣⁣⁣‌⁣⁣⁣‌‌⁣‌‌⁣⁣⁣‌‌⁣⁣‌‌⁣‌‌‌‌‌‌⁣⁣⁣‌⁣⁣⁣‌⁣⁣‌⁣‌‌‌‌⁣⁣‌⁣‌‌⁣‌⁣⁣‌‌‌⁣⁣‌⁣⁣‌⁣‌‌‌‌‌⁣‌‌‌‌‌‌⁣⁣‌‌‌‌⁣‌⁣⁣⁣‌‌⁣‌‌⁣⁣‌‌⁣‌⁣‌‌⁣‌‌‌‌‌‌⁣⁣⁣‌⁣‌⁣‌⁣⁣‌⁣⁣⁣‌‌⁣⁣⁣‌‌⁣‌‌⁣⁣‌‌⁣‌⁣‌⁣⁣⁣‌‌⁣⁣‌⁣⁣‌⁣⁣⁣⁣‌⁣⁣‌⁣⁣‌‌‌⁣⁣⁣‌⁣⁣‌‌⁣⁣‌‌‌‌⁣‌⁣⁣‌‌‌⁣‌‌⁣⁣‌⁣⁣‌‌‌⁣⁣‌‌⁣‌⁣‌‌⁣‌‌‌‌‌‌⁣⁣‌‌‌‌⁣‌⁣⁣⁣‌⁣‌⁣‌⁣⁣⁣‌⁣‌‌‌⁣⁣‌⁣⁣⁣⁣‌⁣⁣‌⁣⁣‌⁣‌⁣⁣‌‌‌‌⁣‌⁣⁣⁣‌⁣‌‌‌⁣⁣‌⁣‌‌⁣‌⁣⁣‌‌‌⁣⁣‌⁣⁣‌‌‌‌⁣‌⁣⁣‌⁣⁣‌‌‌⁣⁣‌⁣⁣‌‌‌⁣⁣⁣⁣‌‌⁣‌‌⁣‌⁣⁣⁣‌‍
  */
 
 // Get platform defines before checking for them!
@@ -208,6 +211,16 @@ static InputKey	pInputBuffer[INPUT_MAXSTR];
 static InputKey	*pStartBuffer, *pEndBuffer;
 static utf_32_char *utf8Buf;				// is like the old 'unicode' from SDL 1.x
 void* GetTextEventsOwner = nullptr;
+
+#if SDL_VERSION_ATLEAST(3, 3, 4)
+# define WZ_SDL_PINCH_EVENTS_SUPPORTED
+#endif
+
+#if defined(WZ_SDL_PINCH_EVENTS_SUPPORTED)
+/* Pinch input status */
+static optional<float> pinchScaleCumulative = nullopt;
+static bool pinchActive = false;
+#endif
 
 static optional<int> wzQuitExitCode;
 
@@ -1403,6 +1416,9 @@ void inputNewFrame(void)
 	}
 	mousePresses.clear();
 	mouseWheelSpeed = Vector2i(0, 0);
+
+	// handle gestures
+	std::ignore = consumePinchGestureScaleUpdate(); // consume any unconsumed update
 }
 
 /*!
@@ -1544,6 +1560,52 @@ bool mouseDrag(MOUSE_KEY_CODE code, UDWORD *px, UDWORD *py)
 
 	return false;
 }
+
+// Returns a float if pinch gesture is in progress
+optional<float> consumePinchGestureScaleUpdate()
+{
+#if defined(WZ_SDL_PINCH_EVENTS_SUPPORTED)
+	auto result = pinchScaleCumulative;
+	if (pinchActive)
+	{
+		pinchScaleCumulative = 1.0f;
+	}
+	else
+	{
+		pinchScaleCumulative.reset();
+	}
+	return result;
+#else
+	return nullopt;
+#endif
+}
+
+#if defined(WZ_SDL_PINCH_EVENTS_SUPPORTED)
+/*!
+ * Handle pinch events
+ */
+static void inputHandlePinchEvent(SDL_PinchFingerEvent *pinchEvent)
+{
+	switch (pinchEvent->type)
+	{
+		case SDL_EVENT_PINCH_BEGIN:
+			debug(LOG_INPUT, "Pinch event: begin");
+			pinchActive = true;
+			pinchScaleCumulative = 1.0f;
+			break;
+		case SDL_EVENT_PINCH_UPDATE:
+			debug(LOG_INPUT, "Pinch event: update (scale: %f)", pinchEvent->scale);
+			pinchScaleCumulative = pinchScaleCumulative.value_or(1.0f) * pinchEvent->scale;
+			break;
+		case SDL_EVENT_PINCH_END:
+			debug(LOG_INPUT, "Pinch event: end");
+			pinchActive = false;
+			break;
+		default:
+			break;
+	}
+}
+#endif
 
 /*!
  * Handle keyboard events
@@ -3700,6 +3762,13 @@ void wzEventLoopOneFrame(void* arg)
 		case SDL_EVENT_TEXT_INPUT:	// SDL now handles text input differently
 			inputhandleText(&event.text);
 			break;
+#if defined(WZ_SDL_PINCH_EVENTS_SUPPORTED)
+		case SDL_EVENT_PINCH_BEGIN:
+		case SDL_EVENT_PINCH_UPDATE:
+		case SDL_EVENT_PINCH_END:
+			inputHandlePinchEvent(&event.pinch);
+			break;
+#endif
 		case SDL_EVENT_QUIT:
 #if defined(__EMSCRIPTEN__)
 			// Exit "soft fullscreen" - (as long as we aren't in "real" fullscreen mode)

--- a/lib/sdl/main_sdl.cpp
+++ b/lib/sdl/main_sdl.cpp
@@ -212,15 +212,35 @@ static InputKey	*pStartBuffer, *pEndBuffer;
 static utf_32_char *utf8Buf;				// is like the old 'unicode' from SDL 1.x
 void* GetTextEventsOwner = nullptr;
 
+/* Touch / finger handling */
+
+// Struct to store cached state of each active finger
+struct TrackedFinger
+{
+	SDL_FingerID id;
+	float currentX;
+	float currentY;
+	float previousX;
+	float previousY;
+};
+std::vector<TrackedFinger> touchPoints;
+
+/* Multi-finger gesture handling */
+
 #if SDL_VERSION_ATLEAST(3, 3, 4)
 # define WZ_SDL_PINCH_EVENTS_SUPPORTED
 #endif
 
-#if defined(WZ_SDL_PINCH_EVENTS_SUPPORTED)
-/* Pinch input status */
+enum class PinchActiveState
+{
+	Inactive,
+	Active_SDLPinchEvent,
+	Active_SDLFingerEvents
+};
+
+// Pinch gesture input status
 static optional<float> pinchScaleCumulative = nullopt;
-static bool pinchActive = false;
-#endif
+static PinchActiveState pinchActive = PinchActiveState::Inactive;
 
 static optional<int> wzQuitExitCode;
 
@@ -1417,8 +1437,8 @@ void inputNewFrame(void)
 	mousePresses.clear();
 	mouseWheelSpeed = Vector2i(0, 0);
 
-	// handle gestures
-	std::ignore = consumePinchGestureScaleUpdate(); // consume any unconsumed update
+	// handle gestures (consume any unconsumed updates)
+	std::ignore = consumePinchGestureScaleUpdate();
 }
 
 /*!
@@ -1561,12 +1581,102 @@ bool mouseDrag(MOUSE_KEY_CODE code, UDWORD *px, UDWORD *py)
 	return false;
 }
 
+// Helper to compute Euclidean distance between two arbitrary points
+float calculateEuclideanDistance(float x1, float y1, float x2, float y2)
+{
+	return std::sqrt((x2 - x1) * (x2 - x1) + (y2 - y1) * (y2 - y1));
+}
+
+static void inputHandleTouchFingerEvent(const SDL_TouchFingerEvent &touchFingerEvent)
+{
+	switch (touchFingerEvent.type)
+	{
+		case SDL_EVENT_FINGER_DOWN:
+			// Register new finger contact. Store incoming position as both current and previous.
+			debug(LOG_NEVER, "Finger down: %" PRIu64, touchFingerEvent.fingerID);
+			touchPoints.push_back({
+				touchFingerEvent.fingerID,
+				touchFingerEvent.x, touchFingerEvent.y,
+				touchFingerEvent.x, touchFingerEvent.y
+			});
+			break;
+		case SDL_EVENT_FINGER_UP:
+		case SDL_EVENT_FINGER_CANCELED:
+		{
+			// Evict finger contact on lift
+			debug(LOG_NEVER, "Finger up: %" PRIu64, touchFingerEvent.fingerID);
+
+			// 1. Reorder elements and get the logical end
+			auto remove_it = std::remove_if(touchPoints.begin(), touchPoints.end(), [&](const TrackedFinger& f) { return f.id == touchFingerEvent.fingerID; });
+
+			// 2. Check if the iterator reached the end
+			bool items_erased = (remove_it != touchPoints.end());
+
+			// 3. Physically erase the elements
+			if (items_erased)
+			{
+				touchPoints.erase(remove_it, touchPoints.end());
+
+				if (pinchActive == PinchActiveState::Active_SDLFingerEvents)
+				{
+					pinchActive = PinchActiveState::Inactive;
+				}
+				panActive = false;
+			}
+			break;
+		}
+
+		case SDL_EVENT_FINGER_MOTION:
+			// Update specific finger positioning tracking matching this hardware interaction id
+			for (auto& f : touchPoints)
+			{
+				if (f.id == touchFingerEvent.fingerID)
+				{
+					f.previousX = f.currentX;
+					f.previousY = f.currentY;
+					f.currentX = touchFingerEvent.x;
+					f.currentY = touchFingerEvent.y;
+					break;
+				}
+			}
+
+			// If exactly two fingers are actively tracing the display screen, calculate two-finger gestures
+			if (touchPoints.size() == 2)
+			{
+				debug(LOG_NEVER, "FingerEvent: Moving %zu fingers", touchPoints.size());
+
+				const auto& f1 = touchPoints[0];
+				const auto& f2 = touchPoints[1];
+
+				if (pinchActive == PinchActiveState::Inactive || pinchActive == PinchActiveState::Active_SDLFingerEvents)
+				{
+					// CALCULATE PINCH (SCALE DELTA)
+					float previousDistance = calculateEuclideanDistance(f1.previousX, f1.previousY, f2.previousX, f2.previousY);
+					float currentDistance  = calculateEuclideanDistance(f1.currentX, f1.currentY, f2.currentX, f2.currentY);
+
+					// Prevent division-by-zero crashes if fingers overlap precisely
+					if (previousDistance > 0.0001f && currentDistance > 0.0001f)
+					{
+						float scaleFactor = currentDistance / previousDistance;
+						debug(LOG_INPUT, "FingerEvent Pinch Scale: %f", scaleFactor);
+
+						pinchScaleCumulative = pinchScaleCumulative.value_or(1.0f) * scaleFactor;
+						pinchActive = PinchActiveState::Active_SDLFingerEvents;
+					}
+				}
+			}
+			break;
+
+		default:
+			break;
+	}
+}
+
 // Returns a float if pinch gesture is in progress
 optional<float> consumePinchGestureScaleUpdate()
 {
-#if defined(WZ_SDL_PINCH_EVENTS_SUPPORTED)
 	auto result = pinchScaleCumulative;
-	if (pinchActive)
+	if (pinchActive != PinchActiveState::Inactive)
 	{
 		pinchScaleCumulative = 1.0f;
 	}
@@ -1575,9 +1685,6 @@ optional<float> consumePinchGestureScaleUpdate()
 		pinchScaleCumulative.reset();
 	}
 	return result;
-#else
-	return nullopt;
-#endif
 }
 
 #if defined(WZ_SDL_PINCH_EVENTS_SUPPORTED)
@@ -1590,16 +1697,22 @@ static void inputHandlePinchEvent(SDL_PinchFingerEvent *pinchEvent)
 	{
 		case SDL_EVENT_PINCH_BEGIN:
 			debug(LOG_INPUT, "Pinch event: begin");
-			pinchActive = true;
-			pinchScaleCumulative = 1.0f;
+			pinchActive = PinchActiveState::Active_SDLPinchEvent; // native pinch events always take precedence over calculated finger pinch events
+			pinchScaleCumulative = pinchScaleCumulative.value_or(1.0f);
 			break;
 		case SDL_EVENT_PINCH_UPDATE:
-			debug(LOG_INPUT, "Pinch event: update (scale: %f)", pinchEvent->scale);
-			pinchScaleCumulative = pinchScaleCumulative.value_or(1.0f) * pinchEvent->scale;
+			if (pinchActive == PinchActiveState::Active_SDLPinchEvent)
+			{
+				debug(LOG_INPUT, "Pinch event: update (scale: %f)", pinchEvent->scale);
+				pinchScaleCumulative = pinchScaleCumulative.value_or(1.0f) * pinchEvent->scale;
+			}
 			break;
 		case SDL_EVENT_PINCH_END:
-			debug(LOG_INPUT, "Pinch event: end");
-			pinchActive = false;
+			if (pinchActive == PinchActiveState::Active_SDLPinchEvent)
+			{
+				debug(LOG_INPUT, "Pinch event: end");
+				pinchActive = PinchActiveState::Inactive;
+			}
 			break;
 		default:
 			break;
@@ -3701,6 +3814,7 @@ static void handleActiveEvent(SDL_Event *event)
 				aKeyState[i].state = KEY_UP;
 				actualKeyState[i].state = KEY_UP;
 			}
+			touchPoints.clear();
 			break;
 		case SDL_EVENT_WINDOW_CLOSE_REQUESTED :
 			debug(LOG_WZ, "Window %d closed", event->window.windowID);
@@ -3761,6 +3875,12 @@ void wzEventLoopOneFrame(void* arg)
 			break;
 		case SDL_EVENT_TEXT_INPUT:	// SDL now handles text input differently
 			inputhandleText(&event.text);
+			break;
+		case SDL_EVENT_FINGER_DOWN:
+		case SDL_EVENT_FINGER_UP:
+		case SDL_EVENT_FINGER_CANCELED:
+		case SDL_EVENT_FINGER_MOTION:
+			inputHandleTouchFingerEvent(event.tfinger);
 			break;
 #if defined(WZ_SDL_PINCH_EVENTS_SUPPORTED)
 		case SDL_EVENT_PINCH_BEGIN:

--- a/lib/sdl/main_sdl.cpp
+++ b/lib/sdl/main_sdl.cpp
@@ -242,6 +242,10 @@ enum class PinchActiveState
 static optional<float> pinchScaleCumulative = nullopt;
 static PinchActiveState pinchActive = PinchActiveState::Inactive;
 
+// Pan gesture input status
+static optional<PanGestureDeltaScreenPts> panScreenPointsCumulative = nullopt;
+static bool panActive = false;
+
 static optional<int> wzQuitExitCode;
 
 bool wzReduceDisplayScalingIfNeeded(int currWidth, int currHeight);
@@ -1439,6 +1443,7 @@ void inputNewFrame(void)
 
 	// handle gestures (consume any unconsumed updates)
 	std::ignore = consumePinchGestureScaleUpdate();
+	std::ignore = consumePanGestureDeltaUpdate();
 }
 
 /*!
@@ -1664,6 +1669,28 @@ static void inputHandleTouchFingerEvent(const SDL_TouchFingerEvent &touchFingerE
 						pinchActive = PinchActiveState::Active_SDLFingerEvents;
 					}
 				}
+
+				// CALCULATE PAN (CENTROID TRANSLATION DELTA)
+				// Find the average center midpoint of the old step vs the current step
+				float previousCenterY = (f1.previousY + f2.previousY) * 0.5f;
+				float previousCenterX = (f1.previousX + f2.previousX) * 0.5f;
+
+				float currentCenterX  = (f1.currentX + f2.currentX) * 0.5f;
+				float currentCenterY  = (f1.currentY + f2.currentY) * 0.5f;
+
+				float deltaX = currentCenterX - previousCenterX;
+				float deltaY = currentCenterY - previousCenterY;
+
+				float deltaXScreenPoints = (deltaX * screenWidth);
+				float deltaYScreenPoints = (deltaY * screenHeight);
+
+				debug(LOG_NEVER, "FingerEvent Pan: (deltaXScreenPts: %f, deltaYScreenPts: %f)", deltaXScreenPoints, deltaYScreenPoints);
+
+				auto updatedPanDelta = panScreenPointsCumulative.value_or(PanGestureDeltaScreenPts{0.f, 0.f});
+				updatedPanDelta.deltaX += deltaXScreenPoints;
+				updatedPanDelta.deltaY += deltaYScreenPoints;
+				panScreenPointsCumulative = updatedPanDelta;
+				panActive = true;
 			}
 			break;
 
@@ -1683,6 +1710,20 @@ optional<float> consumePinchGestureScaleUpdate()
 	else
 	{
 		pinchScaleCumulative.reset();
+	}
+	return result;
+}
+
+optional<PanGestureDeltaScreenPts> consumePanGestureDeltaUpdate()
+{
+	auto result = panScreenPointsCumulative;
+	if (panActive)
+	{
+		panScreenPointsCumulative = PanGestureDeltaScreenPts{0.f,0.f};
+	}
+	else
+	{
+		panScreenPointsCumulative.reset();
 	}
 	return result;
 }

--- a/src/configuration.cpp
+++ b/src/configuration.cpp
@@ -456,6 +456,8 @@ bool loadConfig()
 	{
 		setRotateMouseKey(iniGetMouseKeyCode("mouseKeyRotate", getRotateMouseKey()));
 	}
+	setPinchToZoomTouchGesture(iniGetBool("pinchToZoom", getPinchToZoomTouchGesture()).value());
+	setPanTouchGesture(iniGetBool("touchPan", getPanTouchGesture()).value());
 	setEdgeScrollOutsideWindowBounds(iniGetBool("edgeScrollOutsideWindow", getEdgeScrollOutsideWindowBounds()).value());
 	if (auto value = iniGetIntegerOpt("cursorScale"))
 	{
@@ -835,6 +837,8 @@ bool saveConfig()
 	iniSetInteger("RightClickOrders", (int)(getRightClickOrders()));
 	iniSetMouseKeyOpt("mouseKeyPan", getPanMouseKey());
 	iniSetMouseKeyOpt("mouseKeyRotate", getRotateMouseKey());
+	iniSetInteger("pinchToZoom", (int)(getPinchToZoomTouchGesture()));
+	iniSetInteger("touchPan", (int)(getPanTouchGesture()));
 	iniSetInteger("edgeScrollOutsideWindow", (int)(getEdgeScrollOutsideWindowBounds()));
 	iniSetInteger("cursorScale", (int)war_getCursorScale());
 	iniSetInteger("textureCompression", (wz_texture_compression) ? 1 : 0);

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -1,7 +1,9 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
 /*
 	This file is part of Warzone 2100.
 	Copyright (C) 1999-2004  Eidos Interactive
-	Copyright (C) 2005-2020  Warzone 2100 Project
+	Copyright (C) 2005-2026  Warzone 2100 Project
 
 	Warzone 2100 is free software; you can redistribute it and/or modify
 	it under the terms of the GNU General Public License as published by
@@ -18,9 +20,9 @@
 	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
 */
 /**
- * @file display.c
+ * @file display.cpp
  *
- * Display routines.
+ * Display routines​‌⁣‌‌⁣‌‌⁣‌⁣‌‌⁣⁣‌⁣‌⁣‌⁣‌‌‌‌‌⁣‌‌⁣⁣⁣⁣‌⁣‌⁣‌‌⁣‌‌⁣‌⁣‌⁣‌‌‌⁣‌‌‌‌‌⁣‌⁣‌‌⁣⁣⁣‌‌⁣‌⁣‌⁣‌‌‌‌⁣⁣⁣‌⁣‌‌‌⁣‌‌‌‌‌‌⁣‌⁣‌‌⁣‌‌⁣⁣‌‌⁣‌⁣‌⁣⁣‌‌⁣⁣‌‌⁣⁣⁣‌⁣‌⁣‌⁣⁣⁣‌‌⁣⁣‌⁣⁣‌‌⁣‌⁣‌‌⁣‌‌‌‌‌‌⁣⁣‌‌‌‌⁣‌⁣⁣‌⁣⁣⁣‌‌⁣⁣⁣⁣‌‌⁣‌‌⁣‌‌‌‌‌‌⁣⁣⁣‌‌‌‌‌⁣⁣⁣‌‌⁣‌‌⁣⁣‌‌⁣‌⁣‌⁣⁣⁣‌⁣⁣‌‌⁣⁣‌⁣‌‌⁣‌⁣⁣‌⁣⁣⁣⁣‌⁣⁣⁣‌⁣‌⁣‌⁣⁣⁣‌‌⁣⁣‌‌⁣‌‌‌‌‌‌⁣⁣‌⁣⁣⁣⁣‌⁣⁣⁣‌‌⁣‌‌‌⁣‌‌‌‌‌‌⁣⁣⁣‌‌⁣⁣‌⁣⁣⁣‌⁣‌⁣‌⁣⁣‌‌‌⁣‌‌⁣⁣⁣‌‌⁣⁣‌⁣⁣‌‌⁣‌⁣‌⁣⁣⁣‌‌‌⁣‌⁣⁣⁣‌⁣‌⁣‌⁣⁣‌‌⁣‌⁣‌⁣⁣‌⁣⁣⁣‌‌⁣⁣⁣‌⁣‌‌‌‌⁣‌‌‌‌‌‌⁣⁣‌⁣‌‌⁣‌⁣⁣‌⁣⁣⁣‌‌⁣⁣⁣‌‌⁣⁣‌⁣⁣⁣‌⁣‌‌‌⁣⁣⁣‌‌⁣‌‌⁣⁣⁣‌⁣‌⁣‌⁣⁣‌‌‌⁣⁣‌⁣⁣⁣‌⁣‌‌‌⁣⁣‌⁣‌‌⁣‌⁣⁣‌⁣⁣⁣⁣‌⁣⁣‌⁣⁣⁣‌‌⁣⁣⁣‌‌⁣⁣‌‌⁣‌‌‌‌‌‌⁣⁣⁣‌⁣‌‌‌⁣⁣‌⁣⁣⁣⁣‌‌⁣‌‌‌‌‌‌⁣⁣⁣‌‌‌‌‌⁣⁣‌⁣⁣⁣⁣‌⁣⁣⁣‌‌⁣‌‌⁣⁣⁣‌⁣‌‌‌‌⁣‌‌‌‌‌‌⁣⁣⁣‌⁣‌‌‌⁣⁣‌⁣‌‌‌‌⁣⁣‌‌⁣‌⁣‌‌⁣‌‌‌‌‌‌⁣⁣‌‌‌⁣⁣‌⁣⁣‌⁣⁣⁣⁣‌⁣⁣‌‌⁣‌‌‌⁣⁣‌‌⁣‌⁣‌⁣⁣‌‌‌⁣‌‌⁣⁣‌‌‌‌⁣‌⁣⁣⁣‌‌⁣⁣‌⁣⁣‌‌⁣‌⁣‌‌⁣‌‌‌‌‌‌⁣⁣⁣‌⁣‌‌‌⁣⁣‌⁣⁣⁣⁣‌‌⁣‌‌‌‌‌‌⁣⁣‌‌‌‌⁣‌‌⁣‌‌‌‌‌‌⁣⁣‌⁣⁣⁣‌‌⁣⁣‌‌⁣‌⁣‌⁣⁣⁣‌⁣⁣⁣‌‌⁣‌‌‌‌‌‌⁣⁣⁣‌‌‌‌‌⁣⁣‌⁣⁣‌‌‌⁣⁣‌‌‌‌⁣‌⁣⁣⁣‌⁣‌‌‌⁣⁣‌‌⁣⁣‌‌⁣⁣‌⁣⁣⁣⁣‌⁣⁣⁣‌‌⁣‌‌⁣⁣‌⁣⁣‌⁣‌‌⁣‌⁣⁣‌‌‌‌⁣‌‌‌‌‌‌⁣⁣‌‌⁣‌‌‌⁣⁣⁣‌⁣‌⁣‌⁣⁣‌‌⁣‌⁣‌‌⁣‌‌‌‌‌‌⁣⁣⁣‌⁣‌‌‌⁣⁣‌⁣⁣⁣⁣‌‌⁣‌‌‌‌‌‌⁣⁣⁣‌⁣⁣‌‌⁣⁣‌‌‌‌⁣‌⁣⁣⁣‌‌⁣‌‌⁣⁣‌⁣‌‌⁣‌⁣⁣‌⁣⁣⁣⁣‌⁣⁣⁣‌⁣‌⁣‌⁣⁣⁣‌‌⁣⁣‌‌⁣‌‌‌‌‌‌⁣⁣‌‌⁣⁣‌‌⁣⁣‌‌‌‌⁣‌⁣⁣‌‌‌⁣⁣‌⁣⁣⁣‌⁣‌‌‌⁣⁣‌⁣⁣⁣⁣‌⁣⁣⁣‌‌⁣‌‌⁣⁣⁣‌‌⁣⁣‌‌⁣‌‌‌‌‌‌⁣⁣⁣‌⁣⁣⁣‌⁣⁣‌⁣‌‌‌‌⁣⁣‌⁣‌‌⁣‌⁣⁣‌‌‌⁣⁣‌⁣⁣‌⁣‌‌‌‌‌⁣‌‌‌‌‌‌⁣⁣‌‌‌‌⁣‌⁣⁣⁣‌‌⁣‌‌⁣⁣‌‌⁣‌⁣‌‌⁣‌‌‌‌‌‌⁣⁣⁣‌⁣‌⁣‌⁣⁣‌⁣⁣⁣‌‌⁣⁣⁣‌‌⁣‌‌⁣⁣‌‌⁣‌⁣‌⁣⁣⁣‌‌⁣⁣‌⁣⁣‌⁣⁣⁣⁣‌⁣⁣‌⁣⁣‌‌‌⁣⁣⁣‌⁣⁣‌‌⁣⁣‌‌‌‌⁣‌⁣⁣‌‌‌⁣‌‌⁣⁣‌⁣⁣‌‌‌⁣⁣‌‌⁣‌⁣‌‌⁣‌‌‌‌‌‌⁣⁣‌‌‌‌⁣‌⁣⁣⁣‌⁣‌⁣‌⁣⁣⁣‌⁣‌‌‌⁣⁣‌⁣⁣⁣⁣‌⁣⁣‌⁣⁣‌⁣‌⁣⁣‌‌‌‌⁣‌⁣⁣⁣‌⁣‌‌‌⁣⁣‌⁣‌‌⁣‌⁣⁣‌‌‌⁣⁣‌⁣⁣‌‌‌‌⁣‌⁣⁣‌⁣⁣‌‌‌⁣⁣‌⁣⁣‌‌‌⁣⁣⁣⁣‌‌⁣‌‌⁣‌⁣⁣⁣‌‍
  *
  */
 
@@ -984,6 +986,30 @@ void processMouseClickInput()
 		          || ObjUnderMouse->type == OBJ_DROID))
 		{
 			wzSetCursor(CURSOR_SELECT); // Special casing for LasSat or own unit
+		}
+	}
+}
+
+void processGestureInput()
+{
+	// don't want to process gestures whilst in the Intelligence Screen
+	if (InGameOpUp || bDisplayMultiJoiningStatus || isInGamePopupUp)
+	{
+		return;
+	}
+
+	// consume pinch gesture updates
+	if (auto pinchScaleUpdate = consumePinchGestureScaleUpdate())
+	{
+		if (pinchScaleUpdate.value() != 1.0f)
+		{
+			float startingDistance = viewDistanceAnimation.isActive() ? viewDistanceAnimation.getFinalData() : getViewDistance();
+			float target = std::max<float>(startingDistance, 100.f) * pinchScaleUpdate.value();
+
+			target = std::clamp(target, static_cast<float>(MINDISTANCE), static_cast<float>((!NETisReplay()) ? MAXDISTANCE : MAXDISTANCE_REPLAY));
+
+			animateToViewDistance(target, 0);
+			updateViewDistanceAnimation();
 		}
 	}
 }

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -120,6 +120,8 @@ static bool bInvertMouse = true;
 static bool bRightClickOrders = false;
 optional<MOUSE_KEY_CODE> rotateMouseKey = MOUSE_RMB;
 optional<MOUSE_KEY_CODE> panMouseKey = nullopt;
+static bool bPinchToZoomTouchGesture = true;
+static bool bPanTouchGesture = true;
 static bool bDrawShadows = true;
 static bool bEdgeScrollOutsideWindowBounds = DEFAULT_EDGE_SCROLL_OUTSIDE_WINDOW;
 static SELECTION_TYPE	establishSelection(UDWORD selectedPlayer);
@@ -380,6 +382,26 @@ bool setPanMouseKey(optional<MOUSE_KEY_CODE> key)
 
 	panMouseKey = key;
 	return true;
+}
+
+bool getPinchToZoomTouchGesture()
+{
+	return bPinchToZoomTouchGesture;
+}
+
+void setPinchToZoomTouchGesture(bool enabled)
+{
+	bPinchToZoomTouchGesture = enabled;
+}
+
+bool getPanTouchGesture()
+{
+	return bPanTouchGesture;
+}
+
+void setPanTouchGesture(bool enabled)
+{
+	bPanTouchGesture = enabled;
 }
 
 bool	getDrawShadows()
@@ -1006,35 +1028,41 @@ void processGestureInput()
 	// consume pinch gesture updates
 	if (auto pinchScaleUpdate = consumePinchGestureScaleUpdate())
 	{
-		if (pinchScaleUpdate.value() != 1.0f)
+		if (bPinchToZoomTouchGesture)
 		{
-			float startingDistance = viewDistanceAnimation.isActive() ? viewDistanceAnimation.getFinalData() : getViewDistance();
-			float target = std::max<float>(startingDistance, 100.f) * pinchScaleUpdate.value();
+			if (pinchScaleUpdate.value() != 1.0f)
+			{
+				float startingDistance = viewDistanceAnimation.isActive() ? viewDistanceAnimation.getFinalData() : getViewDistance();
+				float target = std::max<float>(startingDistance, 100.f) * pinchScaleUpdate.value();
 
-			target = std::clamp(target, static_cast<float>(MINDISTANCE), static_cast<float>((!NETisReplay()) ? MAXDISTANCE : MAXDISTANCE_REPLAY));
+				target = std::clamp(target, static_cast<float>(MINDISTANCE), static_cast<float>((!NETisReplay()) ? MAXDISTANCE : MAXDISTANCE_REPLAY));
 
-			animateToViewDistance(target, 0);
-			updateViewDistanceAnimation();
+				animateToViewDistance(target, 0);
+				updateViewDistanceAnimation();
+			}
+			processedGesture = true;
 		}
-		processedGesture = true;
 	}
 
 	// consume pan gesture updates
 	if (auto panDeltaUpdate = consumePanGestureDeltaUpdate())
 	{
-		const double panZoomFactor = 1.0 + ((getViewDistance() - MINDISTANCE) / static_cast<double>(MAXDISTANCE - MINDISTANCE));
+		if (bPanTouchGesture)
+		{
+			const double panZoomFactor = 1.0 + ((getViewDistance() - MINDISTANCE) / static_cast<double>(MAXDISTANCE - MINDISTANCE));
 
-		const double worldDeltaX = panDeltaUpdate.value().deltaX * panZoomFactor;
-		const double worldDeltaY = panDeltaUpdate.value().deltaY * panZoomFactor;
+			const double worldDeltaX = panDeltaUpdate.value().deltaX * panZoomFactor;
+			const double worldDeltaY = panDeltaUpdate.value().deltaY * panZoomFactor;
 
-		const double rot = static_cast<double>(-playerPos.r.y) * (M_PI / 32768.0);
-		playerPos.p.x -= static_cast<int>(cos(rot) * worldDeltaX - sin(rot) * worldDeltaY);
-		playerPos.p.z -= static_cast<int>(sin(rot) * worldDeltaX + cos(rot) * worldDeltaY);
+			const double rot = static_cast<double>(-playerPos.r.y) * (M_PI / 32768.0);
+			playerPos.p.x -= static_cast<int>(cos(rot) * worldDeltaX - sin(rot) * worldDeltaY);
+			playerPos.p.z -= static_cast<int>(sin(rot) * worldDeltaX + cos(rot) * worldDeltaY);
 
-		setWarCamActive(false); // Don't let this thing override the user trying to scroll.
-		CheckScrollLimits(gameWorld.map);
+			setWarCamActive(false); // Don't let this thing override the user trying to scroll.
+			CheckScrollLimits(gameWorld.map);
 
-		processedGesture = true;
+			processedGesture = true;
+		}
 	}
 
 	gestureActive = processedGesture;

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -154,6 +154,8 @@ bool	rotActive = false;
 bool	gameStats = false;
 bool	lockCameraScrollWhileRotating = false;
 
+bool	gestureActive = false;
+
 /* Hackety hack hack hack */
 static int screenShakeTable[100] =
 {
@@ -405,6 +407,7 @@ bool getEdgeScrollOutsideWindowBounds()
 void resetInput()
 {
 	rotActive = false;
+	gestureActive = false;
 	dragBox3D.status = DRAG_INACTIVE;
 	wallDrag.status = DRAG_INACTIVE;
 	gInputManager.contexts().resetStates();
@@ -480,7 +483,7 @@ void processInput()
 
 	if (!isInTextInputMode())
 	{
-		const bool allowMouseWheelEvents = !mouseIsOverScreenOverlayChild && !mouseOverConsole && !mOverConstruction;
+		const bool allowMouseWheelEvents = !mouseIsOverScreenOverlayChild && !mouseOverConsole && !mOverConstruction && !gestureActive;
 		gInputManager.processMappings(allowMouseWheelEvents);
 	}
 	/* Allow the user to clear the (Active) console if need be */
@@ -998,6 +1001,8 @@ void processGestureInput()
 		return;
 	}
 
+	bool processedGesture = false;
+
 	// consume pinch gesture updates
 	if (auto pinchScaleUpdate = consumePinchGestureScaleUpdate())
 	{
@@ -1011,7 +1016,10 @@ void processGestureInput()
 			animateToViewDistance(target, 0);
 			updateViewDistanceAnimation();
 		}
+		processedGesture = true;
 	}
+
+	gestureActive = processedGesture;
 }
 
 static void calcScroll(double *y, double *dydt, double accel, double decel, double targetVelocity, double dt)
@@ -1077,6 +1085,12 @@ static void handleCameraScrolling()
 	}
 
 	if (lockCameraScrollWhileRotating && rotActive && (scrollDirUpDown == 0 && scrollDirLeftRight == 0))
+	{
+		resetScroll();
+		return;
+	}
+
+	if (gestureActive)
 	{
 		resetScroll();
 		return;

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -1019,6 +1019,24 @@ void processGestureInput()
 		processedGesture = true;
 	}
 
+	// consume pan gesture updates
+	if (auto panDeltaUpdate = consumePanGestureDeltaUpdate())
+	{
+		const double panZoomFactor = 1.0 + ((getViewDistance() - MINDISTANCE) / static_cast<double>(MAXDISTANCE - MINDISTANCE));
+
+		const double worldDeltaX = panDeltaUpdate.value().deltaX * panZoomFactor;
+		const double worldDeltaY = panDeltaUpdate.value().deltaY * panZoomFactor;
+
+		const double rot = static_cast<double>(-playerPos.r.y) * (M_PI / 32768.0);
+		playerPos.p.x -= static_cast<int>(cos(rot) * worldDeltaX - sin(rot) * worldDeltaY);
+		playerPos.p.z -= static_cast<int>(sin(rot) * worldDeltaX + cos(rot) * worldDeltaY);
+
+		setWarCamActive(false); // Don't let this thing override the user trying to scroll.
+		CheckScrollLimits(gameWorld.map);
+
+		processedGesture = true;
+	}
+
 	gestureActive = processedGesture;
 }
 

--- a/src/display.h
+++ b/src/display.h
@@ -1,7 +1,9 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
 /*
 	This file is part of Warzone 2100.
 	Copyright (C) 1999-2004  Eidos Interactive
-	Copyright (C) 2005-2020  Warzone 2100 Project
+	Copyright (C) 2005-2026  Warzone 2100 Project
 
 	Warzone 2100 is free software; you can redistribute it and/or modify
 	it under the terms of the GNU General Public License as published by
@@ -17,8 +19,10 @@
 	along with Warzone 2100; if not, write to the Free Software
 	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
 */
-/** @file
- *  Definitions for the display system structures and routines.
+/** @file display.h
+ *
+ *  Definitions for the display system structures and routines
+ *​‌⁣‌‌⁣‌‌⁣‌⁣‌‌⁣⁣‌⁣‌⁣‌⁣‌‌‌‌‌⁣‌‌⁣⁣⁣⁣‌⁣‌⁣‌‌⁣‌‌⁣‌⁣‌⁣‌‌‌⁣‌‌‌‌‌⁣‌⁣‌‌⁣⁣⁣‌‌⁣‌⁣‌⁣‌‌‌‌⁣⁣⁣‌⁣‌‌‌⁣‌‌‌‌‌‌⁣‌⁣‌‌⁣‌‌⁣⁣‌‌⁣‌⁣‌⁣⁣‌‌⁣⁣‌‌⁣⁣⁣‌⁣‌⁣‌⁣⁣⁣‌‌⁣⁣‌⁣⁣‌‌⁣‌⁣‌‌⁣‌‌‌‌‌‌⁣⁣‌‌‌‌⁣‌⁣⁣‌⁣⁣⁣‌‌⁣⁣⁣⁣‌‌⁣‌‌⁣‌‌‌‌‌‌⁣⁣⁣‌‌‌‌‌⁣⁣⁣‌‌⁣‌‌⁣⁣‌‌⁣‌⁣‌⁣⁣⁣‌⁣⁣‌‌⁣⁣‌⁣‌‌⁣‌⁣⁣‌⁣⁣⁣⁣‌⁣⁣⁣‌⁣‌⁣‌⁣⁣⁣‌‌⁣⁣‌‌⁣‌‌‌‌‌‌⁣⁣‌⁣⁣⁣⁣‌⁣⁣⁣‌‌⁣‌‌‌⁣‌‌‌‌‌‌⁣⁣⁣‌‌⁣⁣‌⁣⁣⁣‌⁣‌⁣‌⁣⁣‌‌‌⁣‌‌⁣⁣⁣‌‌⁣⁣‌⁣⁣‌‌⁣‌⁣‌⁣⁣⁣‌‌‌⁣‌⁣⁣⁣‌⁣‌⁣‌⁣⁣‌‌⁣‌⁣‌⁣⁣‌⁣⁣⁣‌‌⁣⁣⁣‌⁣‌‌‌‌⁣‌‌‌‌‌‌⁣⁣‌⁣‌‌⁣‌⁣⁣‌⁣⁣⁣‌‌⁣⁣⁣‌‌⁣⁣‌⁣⁣⁣‌⁣‌‌‌⁣⁣⁣‌‌⁣‌‌⁣⁣⁣‌⁣‌⁣‌⁣⁣‌‌‌⁣⁣‌⁣⁣⁣‌⁣‌‌‌⁣⁣‌⁣‌‌⁣‌⁣⁣‌⁣⁣⁣⁣‌⁣⁣‌⁣⁣⁣‌‌⁣⁣⁣‌‌⁣⁣‌‌⁣‌‌‌‌‌‌⁣⁣⁣‌⁣‌‌‌⁣⁣‌⁣⁣⁣⁣‌‌⁣‌‌‌‌‌‌⁣⁣⁣‌‌‌‌‌⁣⁣‌⁣⁣⁣⁣‌⁣⁣⁣‌‌⁣‌‌⁣⁣⁣‌⁣‌‌‌‌⁣‌‌‌‌‌‌⁣⁣⁣‌⁣‌‌‌⁣⁣‌⁣‌‌‌‌⁣⁣‌‌⁣‌⁣‌‌⁣‌‌‌‌‌‌⁣⁣‌‌‌⁣⁣‌⁣⁣‌⁣⁣⁣⁣‌⁣⁣‌‌⁣‌‌‌⁣⁣‌‌⁣‌⁣‌⁣⁣‌‌‌⁣‌‌⁣⁣‌‌‌‌⁣‌⁣⁣⁣‌‌⁣⁣‌⁣⁣‌‌⁣‌⁣‌‌⁣‌‌‌‌‌‌⁣⁣⁣‌⁣‌‌‌⁣⁣‌⁣⁣⁣⁣‌‌⁣‌‌‌‌‌‌⁣⁣‌‌‌‌⁣‌‌⁣‌‌‌‌‌‌⁣⁣‌⁣⁣⁣‌‌⁣⁣‌‌⁣‌⁣‌⁣⁣⁣‌⁣⁣⁣‌‌⁣‌‌‌‌‌‌⁣⁣⁣‌‌‌‌‌⁣⁣‌⁣⁣‌‌‌⁣⁣‌‌‌‌⁣‌⁣⁣⁣‌⁣‌‌‌⁣⁣‌‌⁣⁣‌‌⁣⁣‌⁣⁣⁣⁣‌⁣⁣⁣‌‌⁣‌‌⁣⁣‌⁣⁣‌⁣‌‌⁣‌⁣⁣‌‌‌‌⁣‌‌‌‌‌‌⁣⁣‌‌⁣‌‌‌⁣⁣⁣‌⁣‌⁣‌⁣⁣‌‌⁣‌⁣‌‌⁣‌‌‌‌‌‌⁣⁣⁣‌⁣‌‌‌⁣⁣‌⁣⁣⁣⁣‌‌⁣‌‌‌‌‌‌⁣⁣⁣‌⁣⁣‌‌⁣⁣‌‌‌‌⁣‌⁣⁣⁣‌‌⁣‌‌⁣⁣‌⁣‌‌⁣‌⁣⁣‌⁣⁣⁣⁣‌⁣⁣⁣‌⁣‌⁣‌⁣⁣⁣‌‌⁣⁣‌‌⁣‌‌‌‌‌‌⁣⁣‌‌⁣⁣‌‌⁣⁣‌‌‌‌⁣‌⁣⁣‌‌‌⁣⁣‌⁣⁣⁣‌⁣‌‌‌⁣⁣‌⁣⁣⁣⁣‌⁣⁣⁣‌‌⁣‌‌⁣⁣⁣‌‌⁣⁣‌‌⁣‌‌‌‌‌‌⁣⁣⁣‌⁣⁣⁣‌⁣⁣‌⁣‌‌‌‌⁣⁣‌⁣‌‌⁣‌⁣⁣‌‌‌⁣⁣‌⁣⁣‌⁣‌‌‌‌‌⁣‌‌‌‌‌‌⁣⁣‌‌‌‌⁣‌⁣⁣⁣‌‌⁣‌‌⁣⁣‌‌⁣‌⁣‌‌⁣‌‌‌‌‌‌⁣⁣⁣‌⁣‌⁣‌⁣⁣‌⁣⁣⁣‌‌⁣⁣⁣‌‌⁣‌‌⁣⁣‌‌⁣‌⁣‌⁣⁣⁣‌‌⁣⁣‌⁣⁣‌⁣⁣⁣⁣‌⁣⁣‌⁣⁣‌‌‌⁣⁣⁣‌⁣⁣‌‌⁣⁣‌‌‌‌⁣‌⁣⁣‌‌‌⁣‌‌⁣⁣‌⁣⁣‌‌‌⁣⁣‌‌⁣‌⁣‌‌⁣‌‌‌‌‌‌⁣⁣‌‌‌‌⁣‌⁣⁣⁣‌⁣‌⁣‌⁣⁣⁣‌⁣‌‌‌⁣⁣‌⁣⁣⁣⁣‌⁣⁣‌⁣⁣‌⁣‌⁣⁣‌‌‌‌⁣‌⁣⁣⁣‌⁣‌‌‌⁣⁣‌⁣‌‌⁣‌⁣⁣‌‌‌⁣⁣‌⁣⁣‌‌‌‌⁣‌⁣⁣‌⁣⁣‌‌‌⁣⁣‌⁣⁣‌‌‌⁣⁣⁣⁣‌‌⁣‌‌⁣‌⁣⁣⁣‌‍
  */
 
 #ifndef __INCLUDED_SRC_DISPLAY_H__
@@ -46,6 +50,7 @@ extern KeyFunctionConfiguration gKeyFuncConfig;
 void ProcessRadarInput();
 
 void processInput();
+void processGestureInput();
 /*don't want to do any of these whilst in the Intelligence Screen*/
 void processMouseClickInput();
 

--- a/src/display.h
+++ b/src/display.h
@@ -75,6 +75,12 @@ bool setRotateMouseKey(optional<MOUSE_KEY_CODE> key);
 optional<MOUSE_KEY_CODE> getPanMouseKey();
 bool setPanMouseKey(optional<MOUSE_KEY_CODE> key);
 
+bool	getPinchToZoomTouchGesture();
+void	setPinchToZoomTouchGesture(bool enabled);
+
+bool	getPanTouchGesture();
+void	setPanTouchGesture(bool enabled);
+
 void	setDrawShadows(bool val);
 bool	getDrawShadows();
 

--- a/src/loop.cpp
+++ b/src/loop.cpp
@@ -328,6 +328,8 @@ static GAMECODE renderLoop()
 		{
 			processInput();
 
+			processGestureInput();
+
 			//no key clicks or in Intelligence Screen
 			if (!isMouseOverRadar() && !isDraggingInGameNotification() && !isMouseClickDownOnScreenOverlayChild() && intRetVal == INT_NONE && !InGameOpUp && !isInGamePopupUp)
 			{

--- a/src/titleui/options/controlsoptions.cpp
+++ b/src/titleui/options/controlsoptions.cpp
@@ -1039,6 +1039,47 @@ std::shared_ptr<OptionsForm> makeControlsOptionsForm()
 		result->addOption(optionInfo, valueChanger, true);
 	}
 
+	// Touch:
+	result->addSection(OptionsSection(N_("Touch"), ""), true);
+	{
+		auto optionInfo = OptionInfo("controls.touch.pinchToZoomGesture", N_("Pinch to Zoom"), N_("Enable pinch-to-zoom for the camera (if two-finger / multi-touch input is supported)."));
+		auto valueChanger = OptionsDropdown<bool>::make(
+			[]() {
+				OptionChoices<bool> result;
+				result.choices = {
+					{ _("Off"), "", false },
+					{ _("On"), "", true },
+				};
+				result.setCurrentIdxForValue(getPinchToZoomTouchGesture());
+				return result;
+			},
+			[](const auto& newValue) -> bool {
+				setPinchToZoomTouchGesture(newValue);
+				return true;
+			}, true
+		);
+		result->addOption(optionInfo, valueChanger, true);
+	}
+	{
+		auto optionInfo = OptionInfo("controls.touch.twoFingerPan", N_("Two-Finger Pan"), N_("Enable panning the camera by dragging two fingers (if two-finger / multi-touch input is supported)."));
+		auto valueChanger = OptionsDropdown<bool>::make(
+			[]() {
+				OptionChoices<bool> result;
+				result.choices = {
+					{ _("Off"), "", false },
+					{ _("On"), "", true },
+				};
+				result.setCurrentIdxForValue(getPanTouchGesture());
+				return result;
+			},
+			[](const auto& newValue) -> bool {
+				setPanTouchGesture(newValue);
+				return true;
+			}, true
+		);
+		result->addOption(optionInfo, valueChanger, true);
+	}
+
 	// Camera:
 	result->addSection(OptionsSection(N_("Camera"), ""), true);
 	{


### PR DESCRIPTION
Pinch-to-zoom:
- Utilizes SDL3's built-in `SDL_EVENT_PINCH_*` events, when supported (requires SDL 3.3.4+, not available on all platforms). Falls back to manually processing two-finger events as necessary.

Two-finger pan:
- Pan the camera by dragging two fingers.