### PR TITLE
Switch to C++20 standard

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ include(WZVcpkgInit) # Must come before project() command
 set(CMAKE_MODULE_PATH "${_OLD_CMAKE_MODULE_PATH}")
 unset(_OLD_CMAKE_MODULE_PATH)
 
-project(warzone2100)
+project(warzone2100 LANGUAGES C CXX)
 
 include(CMakeDependentOption)
 
@@ -63,6 +63,7 @@ endif()
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF) # Disable compiler-specific extensions
+set(CMAKE_CXX_SCAN_FOR_MODULES OFF)
 
 # Support folders (for nicer IDE organization)
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -412,6 +412,8 @@ macro(CONFIGURE_WZ_COMPILER_WARNINGS)
 			set(CMAKE_XCODE_ATTRIBUTE_CLANG_CXX_LANGUAGE_STANDARD "c++14")
 		elseif (CMAKE_CXX_STANDARD EQUAL 17)
 			set(CMAKE_XCODE_ATTRIBUTE_CLANG_CXX_LANGUAGE_STANDARD "c++1z")
+		elseif (CMAKE_CXX_STANDARD EQUAL 20)
+			set(CMAKE_XCODE_ATTRIBUTE_CLANG_CXX_LANGUAGE_STANDARD "c++2a")
 		else()
 			# Additional mapping required for CMAKE_CXX_STANDARD => Xcode's CLANG_CXX_LANGUAGE_STANDARD attribute (above)
 			# Also may need to bump the minimum supported version of Xcode for compilation

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,7 +60,7 @@ else()
 endif()
 
 # CXX Standard
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF) # Disable compiler-specific extensions
 

--- a/lib/framework/file_ext.h
+++ b/lib/framework/file_ext.h
@@ -56,11 +56,21 @@ bool loadFileToBufferVectorT(const char *pFileName, std::vector<T>& outputBuffer
 		return false;
 	}
 
+	const size_t dataSize = static_cast<size_t>(filesize);
+	const size_t bufferSize = dataSize + (appendNullCharacter ? 1u : 0u);
 	outputBuffer.clear();
-	outputBuffer.resize(static_cast<size_t>(filesize + ((appendNullCharacter) ? 1 : 0)));
+	// GCC 12+ treats vector::resize(0) as a stringop-overflow under -Werror (false positive).
+	if (bufferSize > 0)
+	{
+		outputBuffer.resize(bufferSize);
+	}
 
 	/* Load the file data */
-	PHYSFS_sint64 length_read = WZ_PHYSFS_readBytes(pfile, outputBuffer.data(), static_cast<PHYSFS_uint32>(filesize));
+	PHYSFS_sint64 length_read = 0;
+	if (filesize > 0)
+	{
+		length_read = WZ_PHYSFS_readBytes(pfile, outputBuffer.data(), static_cast<PHYSFS_uint32>(filesize));
+	}
 	if (length_read != filesize)
 	{
 		outputBuffer.clear();

--- a/lib/ivis_opengl/3rdparty/ska_sort.hpp
+++ b/lib/ivis_opengl/3rdparty/ska_sort.hpp
@@ -1432,13 +1432,13 @@ template<typename It, typename OutIt, typename ExtractKey>
 bool ska_sort_copy(It begin, It end, OutIt buffer_begin, ExtractKey && key)
 {
     std::ptrdiff_t num_elements = end - begin;
-    if (num_elements < 128 || detail::radix_sort_pass_count<typename std::result_of<ExtractKey(decltype(*begin))>::type> >= 8)
+    if (num_elements < 128 || detail::radix_sort_pass_count<typename std::invoke_result<ExtractKey, decltype(*begin)>::type> >= 8)
     {
         ska_sort(begin, end, key);
         return false;
     }
     else
-        return detail::RadixSorter<typename std::result_of<ExtractKey(decltype(*begin))>::type>::sort(begin, end, buffer_begin, key);
+        return detail::RadixSorter<typename std::invoke_result<ExtractKey, decltype(*begin)>::type>::sort(begin, end, buffer_begin, key);
 }
 template<typename It, typename OutIt>
 bool ska_sort_copy(It begin, It end, OutIt buffer_begin)

--- a/lib/ivis_opengl/CMakeLists.txt
+++ b/lib/ivis_opengl/CMakeLists.txt
@@ -222,3 +222,15 @@ else()
 	add_dependencies(ivis-opengl libjpeg-turbo-ext) # Ensure libjpeg-turbo builds first
 	target_link_libraries(ivis-opengl PRIVATE $<IF:$<TARGET_EXISTS:libjpeg-turbo::turbojpeg>,libjpeg-turbo::turbojpeg,libjpeg-turbo::turbojpeg-static>)
 endif()
+
+if (CMAKE_CXX_STANDARD GREATER_EQUAL 20)
+	# Workaround for Apple requiring min macOS version 13.3 when C++20 is used.
+	# Temporarily require C++17 for ivis-opengl for all platforms, for the sake
+	# of uniformity.
+	set(cpp17_source_files
+		"3rdparty/vkh_renderpasscompat.cpp"
+		"3rdparty/vkh_info.cpp"
+		"gfx_api_vk.cpp"
+		"gfx_api.cpp")
+	set_source_files_properties(${cpp17_source_files} PROPERTIES COMPILE_FLAGS "-std=c++17")
+endif()

--- a/lib/sdl/CMakeLists.txt
+++ b/lib/sdl/CMakeLists.txt
@@ -24,3 +24,10 @@ set_property(TARGET sdl-backend PROPERTY FOLDER "lib")
 message( STATUS "Linking to SDL3 library" )
 target_link_libraries(sdl-backend PRIVATE SDL3::SDL3)
 target_compile_definitions(sdl-backend PRIVATE "-DHAVE_SDL_VULKAN_H")
+
+if (CMAKE_CXX_STANDARD GREATER_EQUAL 20)
+	# Workaround for Apple requiring min macOS version 13.3 when C++20 is used.
+	# Temporarily require C++17 for sdl-backend for all platforms, for the sake
+	# of uniformity.
+	set_target_properties(sdl-backend PROPERTIES CXX_STANDARD 17)
+endif()

--- a/src/astar.cpp
+++ b/src/astar.cpp
@@ -483,8 +483,8 @@ public:
 
 		reference operator[](difference_type n) const { return m_list.contexts[m_list.orderedIndexes[n]]; }
 
-		bool operator== (const Iterator& other) { return m_idx == other.m_idx; }
-		bool operator!= (const Iterator& other) { return m_idx != other.m_idx; }
+		bool operator== (const Iterator& other) const { return m_idx == other.m_idx; }
+		bool operator!= (const Iterator& other) const { return m_idx != other.m_idx; }
 		bool operator< (const Iterator& other) const { return m_idx < other.m_idx; }
 		bool operator> (const Iterator& other) const { return m_idx > other.m_idx; }
 		bool operator<= (const Iterator& other) const { return m_idx <= other.m_idx; }

--- a/src/baseobject.cpp
+++ b/src/baseobject.cpp
@@ -95,8 +95,20 @@ SIMPLE_OBJECT::SIMPLE_OBJECT(OBJECT_TYPE type, uint32_t id, unsigned player)
 
 SIMPLE_OBJECT::~SIMPLE_OBJECT()
 {
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-volatile"
+#elif defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wvolatile"
+#endif
 	const_cast<OBJECT_TYPE volatile &>(type) = (OBJECT_TYPE)(type + 1000000000);  // Hopefully this will trigger an assert              if someone uses the freed object.
 	const_cast<UBYTE volatile &>(player) += 100;                                  // Hopefully this will trigger an assert and/or crash if someone uses the freed object.
+#ifdef __clang__
+#pragma clang diagnostic pop
+#elif defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
 }
 
 BASE_OBJECT::BASE_OBJECT(OBJECT_TYPE type, uint32_t id, unsigned player)

--- a/src/notifications.cpp
+++ b/src/notifications.cpp
@@ -46,6 +46,7 @@ using json = nlohmann::json;
 #include <physfs.h>
 #include "lib/framework/file.h"
 #include <sstream>
+#include <string_view>
 
 class WZ_Notification_Preferences
 {
@@ -759,8 +760,9 @@ std::shared_ptr<W_NOTIFICATION> W_NOTIFICATION::make(WZ_Queued_Notification* req
 
 	if (psActionButton != nullptr || request->notification.duration == 0)
 	{
+		static constexpr std::u8string_view DISMISS_LABEL_PREFIX = u8"▴ ";
 		// 2.) "Dismiss" button
-		dismissLabel = u8"▴ " + dismissLabel;
+		dismissLabel = std::string(DISMISS_LABEL_PREFIX.begin(), DISMISS_LABEL_PREFIX.end()) + dismissLabel;
 		sButInit.id = 3;
 		sButInit.FontID = font_regular;
 		sButInit.width = iV_GetTextWidth(dismissLabel.c_str(), font_regular) + 18;


### PR DESCRIPTION
The changeset also contains a few tweaks for C++20 compilation.

Motivation behind this is that C++20 brings a few very useful features that Warzone 2100 could make use of. For example, native support for C++ coroutines, which may be used to organize cooperative scheduling of various resource loading work on the main thread (a PR will soon follow to implement this).

Please note, that a few things had to be left on C++17 due to problems with `<vulkan.hpp>` header, which unconditionally starts to use `<format>` header in C++20 mode leading to min macOS deployment target version being bumped to 13.3 (while we currently support 10.14+):
* `sdl-backend` library
* `ivis-opengl`:
  * `3rdparty/vkh_renderpasscompat.cpp`
  * `3rdparty/vkh_info.cpp`
  * `gfx_api_vk.cpp`
  * `gfx_api.cpp`

Signed-off-by: Pavel Solodovnikov <pavel.al.solodovnikov@gmail.com>