### PR TITLE
Fix rail projectile visual glitch

### DIFF
--- a/src/projectile.cpp
+++ b/src/projectile.cpp
@@ -487,7 +487,8 @@ static PROJECTILE* proj_SendProjectileAngledInternal(WEAPON* psWeap, SIMPLE_OBJE
 	When we have been created by penetration (spawned from another projectile),
 	we shall live no longer than the original projectile may have lived
 	*/
-	if (psAttacker && psAttacker->type == OBJ_PROJECTILE)
+	const bool spawnedByPenetration = psAttacker && psAttacker->type == OBJ_PROJECTILE;
+	if (spawnedByPenetration)
 	{
 		PROJECTILE *psOldProjectile = (PROJECTILE *)psAttacker;
 		proj.born = psOldProjectile->born;
@@ -557,6 +558,12 @@ static PROJECTILE* proj_SendProjectileAngledInternal(WEAPON* psWeap, SIMPLE_OBJE
 		proj.rot.pitch = iAtan2(proj.vZ, proj.vXY);
 	}
 	proj.state = PROJ_INFLIGHT;
+
+	if (spawnedByPenetration)
+	{
+		proj.prevSpacetime.pos = proj.pos;
+		proj.prevSpacetime.rot = proj.rot;
+	}
 
 	// If droid or structure, set muzzle pitch.
 	// Don't allow pitching the muzzle above outside the weapon's limits.

--- a/src/projectile.cpp
+++ b/src/projectile.cpp
@@ -495,13 +495,11 @@ static PROJECTILE* proj_SendProjectileAngledInternal(WEAPON* psWeap, SIMPLE_OBJE
 		proj.src = psOldProjectile->src;
 
 		proj.prevSpacetime.time = psOldProjectile->time;  // Have partially ticked already.
-		proj.time = gameTime;
-		proj.prevSpacetime.time -= proj.prevSpacetime.time == proj.time;  // Times should not be equal, for interpolation.
+		proj.time = psOldProjectile->time;
+		proj.prevSpacetime.time -= proj.prevSpacetime.time == gameTime;  // Times should not be equal, for interpolation.
 
 		setProjectileSource(&proj, psOldProjectile->psSource);
 		proj.psDamaged = psOldProjectile->psDamaged;
-
-		// TODO Should finish the tick, when penetrating.
 	}
 	else
 	{
@@ -1380,15 +1378,13 @@ static void proj_PostImpactFunc(PROJECTILE *psObj)
 
 /***************************************************************************/
 
-PROJECTILE* PROJECTILE::update()
+static PROJECTILE* proj_UpdateFrom(PROJECTILE *psObj, Spacetime const &startSpacetime)
 {
-	PROJECTILE *psObj = this;
-
 	CHECK_PROJECTILE(psObj);
 
 	syncDebugProjectile(psObj, '<');
 
-	psObj->prevSpacetime = getSpacetime(psObj);
+	psObj->prevSpacetime = startSpacetime;
 
 	/* See if any of the stored objects have died
 	 * since the projectile was created
@@ -1404,7 +1400,7 @@ PROJECTILE* PROJECTILE::update()
 		setProjectileDestination(psObj, nullptr);
 	}
 	// Remove dead objects from psDamaged.
-	psDamaged.erase(std::remove_if(psDamaged.begin(), psDamaged.end(), [](const BASE_OBJECT *psObj) { return ::isDead(psObj); }), psDamaged.end());
+	psObj->psDamaged.erase(std::remove_if(psObj->psDamaged.begin(), psObj->psDamaged.end(), [](const BASE_OBJECT *psObj) { return ::isDead(psObj); }), psObj->psDamaged.end());
 
 	// This extra check fixes a crash in cam2, mission1
 	if (worldOnMap(gameWorld.map, psObj->pos.x, psObj->pos.y) == false)
@@ -1444,6 +1440,11 @@ PROJECTILE* PROJECTILE::update()
 	return spawnedProjectile;
 }
 
+PROJECTILE* PROJECTILE::update()
+{
+	return proj_UpdateFrom(this, getSpacetime(this));
+}
+
 /***************************************************************************/
 
 // iterate through all projectiles and update their status
@@ -1465,6 +1466,22 @@ void proj_UpdateAll()
 		if (spawned)
 		{
 			spawnedProjectiles.emplace_back(spawned);
+		}
+	}
+
+	// Finish the current tick for penetrating projectiles spawned above.
+	for (size_t i = 0; i < spawnedProjectiles.size(); ++i)
+	{
+		PROJECTILE *spawned = spawnedProjectiles[i];
+		if (spawned->time >= gameTime)
+		{
+			continue;
+		}
+
+		PROJECTILE *continued = proj_UpdateFrom(spawned, spawned->prevSpacetime);
+		if (continued)
+		{
+			spawnedProjectiles.emplace_back(continued);
 		}
 	}
 


### PR DESCRIPTION
Fixes #4902 

---

Also finishes the tick for newly spawned projectiles resulting from penetration. I added a new parameter `Spacetime const &startSpacetime` to allow newly spawned projectiles from penetration to manually seed their prevSpacetime from the spacetime of the previous projectile.

Normal projectiles simply pass in their current spacetime:
```cpp
proj_UpdateFrom(this, getSpacetime(this));
```