### PR TITLE
Integrate cooperative resource loading into game startup and load paths

### DIFF
--- a/lib/framework/frameresource.cpp
+++ b/lib/framework/frameresource.cpp
@@ -1,7 +1,9 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
 /*
 	This file is part of Warzone 2100.
 	Copyright (C) 1999-2004  Eidos Interactive
-	Copyright (C) 2005-2020  Warzone 2100 Project
+	Copyright (C) 2005-2026  Warzone 2100 Project (https://github.com/Warzone2100)
 
 	Warzone 2100 is free software; you can redistribute it and/or modify
 	it under the terms of the GNU General Public License as published by
@@ -24,6 +26,8 @@
  *
  */
 #include "frameresource.h"
+
+#include "resource_loading_controller.h"
 
 #include "string_ext.h"
 #include "physfs_ext.h"
@@ -48,8 +52,84 @@ static SDWORD resBlockID;
 // prototypes
 static void ResetResourceFile();
 
-// callback to resload screen.
-static RESLOAD_CALLBACK resLoadCallback = nullptr;
+static ResLoadPlan *activeResLoadPlan = nullptr;
+static size_t resLoadPlanEntriesPerStepSetting = 1;
+
+bool resParserBeginLoadPlanBuild(ResLoadPlan *plan)
+{
+	ASSERT(plan != nullptr, "resParserBeginLoadPlanBuild called with null plan");
+	ASSERT(activeResLoadPlan == nullptr, "res parser plan build already active");
+	if (plan == nullptr || activeResLoadPlan != nullptr)
+	{
+		return false;
+	}
+
+	activeResLoadPlan = plan;
+	activeResLoadPlan->entries.clear();
+	activeResLoadPlan->nextEntry = 0;
+	sstrcpy(aCurrResDir, aResDir);
+	return true;
+}
+
+void resParserEndLoadPlanBuild()
+{
+	activeResLoadPlan = nullptr;
+}
+
+bool resParserSetDirectory(const char *directory)
+{
+	size_t len;
+
+	ASSERT(activeResLoadPlan != nullptr, "resParserSetDirectory called without an active plan");
+	ASSERT(directory != nullptr, "resParserSetDirectory called with null directory");
+	if (activeResLoadPlan == nullptr || directory == nullptr)
+	{
+		return false;
+	}
+
+	debug(LOG_NEVER, "directory: %s", directory);
+	if (strncmp(directory, "/:", strlen("/:")) == 0)
+	{
+		sstrcpy(aCurrResDir, directory);
+	}
+	else
+	{
+		sstrcpy(aCurrResDir, aResDir);
+		sstrcat(aCurrResDir, directory);
+	}
+
+	if (strlen(directory) > 0)
+	{
+		ASSERT(WZ_PHYSFS_isDirectory(aCurrResDir), "%s is not a directory!", aCurrResDir);
+		if (!WZ_PHYSFS_isDirectory(aCurrResDir))
+		{
+			debug(LOG_ERROR, "Resource directory does not exist: %s", aCurrResDir);
+			return false;
+		}
+
+		len = strlen(aCurrResDir);
+		aCurrResDir[len] = '/';
+		aCurrResDir[len + 1] = 0;
+		debug(LOG_NEVER, "Current resource directory: %s", aCurrResDir);
+	}
+
+	return true;
+}
+
+bool resParserAddFile(const char *type, const char *file)
+{
+	ASSERT(activeResLoadPlan != nullptr, "resParserAddFile called without an active plan");
+	ASSERT(type != nullptr, "resParserAddFile called with null type");
+	ASSERT(file != nullptr, "resParserAddFile called with null file");
+	if (activeResLoadPlan == nullptr || type == nullptr || file == nullptr)
+	{
+		return false;
+	}
+
+	debug(LOG_NEVER, "file: %s %s", type, file);
+	activeResLoadPlan->entries.push_back({aCurrResDir, type, file});
+	return true;
+}
 
 
 /* next four used in HashPJW */
@@ -130,22 +210,6 @@ static UDWORD HashStringIgnoreCase(const char *c)
 	return iHashValue;
 }
 
-/* set the callback function for the res loader*/
-void resSetLoadCallback(RESLOAD_CALLBACK funcToCall)
-{
-	resLoadCallback = funcToCall;
-}
-
-/* do the callback for the resload display function */
-void resDoResLoadCallback()
-{
-	if (resLoadCallback)
-	{
-		resLoadCallback();
-	}
-}
-
-
 /* Initialise the resource module */
 bool resInitialise()
 {
@@ -153,7 +217,8 @@ bool resInitialise()
 	       "resInitialise: resource module hasn't been shut down??");
 	psResTypes.clear();
 	resBlockID = 0;
-	resLoadCallback = nullptr;
+	activeResLoadPlan = nullptr;
+	resLoadPlanEntriesPerStepSetting = 1;
 
 	ResetResourceFile();
 
@@ -184,8 +249,10 @@ void resSetBaseDir(const char *pResDir)
 	sstrcpy(aResDir, pResDir);
 }
 
-/* Parse the res file */
-bool resLoad(const char *pResFile, SDWORD blockID)
+namespace
+{
+
+bool resPrepareLoadPlan(const char *pResFile, SDWORD blockID, ResLoadPlan &plan)
 {
 	bool retval = true;
 	lexerinput_t input;
@@ -206,20 +273,81 @@ bool resLoad(const char *pResFile, SDWORD blockID)
 		return false;
 	}
 
-	// and parse it
+	plan = {};
+	plan.resourceFile = pResFile;
+	plan.blockID = blockID;
+	if (!resParserBeginLoadPlanBuild(&plan))
+	{
+		PHYSFS_close(input.input.physfsfile);
+		return false;
+	}
+
 	res_set_extra(&input);
+
+	// Parse the RES file
 	if (res_parse() != 0)
 	{
 		debug(LOG_FATAL, "Failed to parse %s", pResFile);
 		retval = false;
 	}
 
+	resParserEndLoadPlanBuild();
 	res_lex_destroy();
 	PHYSFS_close(input.input.physfsfile);
 
 	return retval;
 }
 
+bool resLoadPlanStep(ResLoadPlan &plan, size_t maxEntriesPerStep)
+{
+	resBlockID = plan.blockID;
+	for (size_t processed = 0; processed < maxEntriesPerStep && plan.nextEntry < plan.entries.size(); ++processed, ++plan.nextEntry)
+	{
+		const ResLoadPlanEntry &entry = plan.entries[plan.nextEntry];
+		sstrcpy(aCurrResDir, entry.resourceDirectory.c_str());
+		if (!resLoadFile(entry.type.c_str(), entry.file.c_str()))
+		{
+			return false;
+		}
+	}
+
+	return true;
+}
+
+bool resLoadPlanComplete(const ResLoadPlan &plan)
+{
+	return plan.nextEntry >= plan.entries.size();
+}
+
+size_t resGetLoadPlanEntriesPerStep()
+{
+	return resLoadPlanEntriesPerStepSetting;
+}
+
+} // anonymous namespace
+
+/* Parse the res file */
+LoadingTask<> resLoad(ResourceLoadingController& controller, const char *pResFile, SDWORD blockID)
+{
+	ResLoadPlan plan;
+	if (!resPrepareLoadPlan(pResFile, blockID, plan))
+	{
+		co_return load_fail();
+	}
+
+	co_await controller.yieldFrame();
+
+	while (!resLoadPlanComplete(plan))
+	{
+		if (!resLoadPlanStep(plan, resGetLoadPlanEntriesPerStep()))
+		{
+			co_return load_fail();
+		}
+		co_await controller.yieldFrame();
+	}
+
+	co_return load_ok();
+}
 
 /* Allocate a RES_TYPE structure */
 static RES_TYPE *resAlloc(const char *pType)
@@ -554,8 +682,6 @@ bool resLoadFile(const char *pType, const char *pFile)
 			return false;
 		}
 	}
-
-	resDoResLoadCallback();		// do callback.
 
 	// Set up the resource structure if there is something to store
 	if (pData != nullptr)

--- a/lib/framework/frameresource.h
+++ b/lib/framework/frameresource.h
@@ -1,7 +1,9 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
 /*
 	This file is part of Warzone 2100.
 	Copyright (C) 1999-2004  Eidos Interactive
-	Copyright (C) 2005-2020  Warzone 2100 Project
+	Copyright (C) 2005-2026  Warzone 2100 Project (https://github.com/Warzone2100)
 
 	Warzone 2100 is free software; you can redistribute it and/or modify
 	it under the terms of the GNU General Public License as published by
@@ -25,8 +27,11 @@
 #define _frameresource_h
 
 #include "lib/framework/frame.h"
+#include "lib/framework/loading_task.h"
 
 #include <list>
+#include <string>
+#include <vector>
 
 /** Maximum number of characters in a resource type. */
 #define RESTYPE_MAXCHAR		20
@@ -41,8 +46,20 @@ typedef bool (*RES_FILELOAD)(const char *pFile, void **pData);
 /** Function pointer for releasing a resource loaded by the above functions. */
 typedef void (*RES_FREE)(void *pData);
 
-/** callback type for resload display callback. */
-typedef void (*RESLOAD_CALLBACK)();
+struct ResLoadPlanEntry
+{
+	std::string resourceDirectory;
+	std::string type;
+	std::string file;
+};
+
+struct ResLoadPlan
+{
+	std::string resourceFile;
+	SDWORD blockID = 0;
+	std::vector<ResLoadPlanEntry> entries;
+	size_t nextEntry = 0;
+};
 
 struct RES_DATA
 {
@@ -75,12 +92,6 @@ struct RES_TYPE
 };
 
 
-/** Set the function to call when loading files with resloadfile. */
-void resSetLoadCallback(RESLOAD_CALLBACK funcToCall);
-
-/* do the callback for the resload display function */
-void resDoResLoadCallback();
-
 /** Initialise the resource module. */
 bool resInitialise();
 
@@ -91,8 +102,10 @@ void resShutDown();
 WZ_DECL_NONNULL(1) void resSetBaseDir(const char *pResDir);
 WZ_DECL_NONNULL(1) void resForceBaseDir(const char *pResDir);
 
+class ResourceLoadingController;
+
 /** Parse the res file. */
-WZ_DECL_NONNULL(1) bool resLoad(const char *pResFile, SDWORD blockID);
+WZ_DECL_NONNULL(2) LoadingTask<> resLoad(ResourceLoadingController& controller, const char *pResFile, SDWORD blockID);
 
 /** Release all the resources currently loaded and the resource load functions. */
 void resReleaseAll();

--- a/lib/framework/load_result.h
+++ b/lib/framework/load_result.h
@@ -41,7 +41,7 @@ inline LoadResult<> load_ok() noexcept
 	return {};
 }
 
-template<typename T>
+template <typename T>
 inline LoadResult<T> load_ok(T value)
 {
 	return value;

--- a/lib/framework/resource_parser.cpp
+++ b/lib/framework/resource_parser.cpp
@@ -1,6 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
 /*
 	This file is part of Warzone 2100.
-	Copyright (C) 2005-2020  Warzone 2100 Project
+	Copyright (C) 2005-2026  Warzone 2100 Project (https://github.com/Warzone2100)
 
 	Warzone 2100 is free software; you can redistribute it and/or modify
 	it under the terms of the GNU General Public License as published by
@@ -88,6 +90,9 @@ extern char* res_get_text(void);
 #include "lib/framework/frameresource.h"
 #include "lib/framework/resly.h"
 #include "lib/framework/physfs_ext.h"
+
+extern bool resParserSetDirectory(const char *directory);
+extern bool resParserAddFile(const char *type, const char *file);
 
 extern void yyerror(const char* msg);
 void yyerror(const char* msg)
@@ -1412,44 +1417,24 @@ yyreduce:
         case 6:
 
 /* Line 1806 of yacc.c  */
-#line 85 "resource_parser.ypp"
+#line 88 "resource_parser.ypp"
     {
-					UDWORD len;
-
-					// set a new input directory
-					debug(LOG_NEVER, "directory: %s", (yyvsp[(2) - (2)].sval));
-					if (strncmp((yyvsp[(2) - (2)].sval), "/:", strlen("/:")) == 0)
-					{
-						// the new dir is rooted
-						sstrcpy(aCurrResDir, (yyvsp[(2) - (2)].sval));
-					}
-					else
-					{
-						sstrcpy(aCurrResDir, aResDir);
-						sstrcat(aCurrResDir, (yyvsp[(2) - (2)].sval));
-					}
-					if (strlen((yyvsp[(2) - (2)].sval)) > 0)
-					{
-						ASSERT(WZ_PHYSFS_isDirectory(aCurrResDir), "%s is not a directory!", aCurrResDir);
-						// Add a trailing '/'
-						len = strlen(aCurrResDir);
-						aCurrResDir[len] = '/';
-						aCurrResDir[len+1] = 0;
-						debug(LOG_NEVER, "Current resource directory: %s", aCurrResDir);
-					}
+					bool success = resParserSetDirectory((yyvsp[(2) - (2)].sval));
 					free((yyvsp[(2) - (2)].sval));
+
+					if (!success)
+					{
+						YYABORT;
+					}
 				}
     break;
 
   case 7:
 
 /* Line 1806 of yacc.c  */
-#line 115 "resource_parser.ypp"
+#line 101 "resource_parser.ypp"
     {
-					bool success;
-					/* load a data file */
-					debug(LOG_NEVER, "file: %s %s", (yyvsp[(2) - (3)].sval), (yyvsp[(3) - (3)].sval));
-					success = resLoadFile((yyvsp[(2) - (3)].sval), (yyvsp[(3) - (3)].sval));
+					bool success = resParserAddFile((yyvsp[(2) - (3)].sval), (yyvsp[(3) - (3)].sval));
 					free((yyvsp[(2) - (3)].sval));
 					free((yyvsp[(3) - (3)].sval));
 

--- a/lib/framework/resource_parser.ypp
+++ b/lib/framework/resource_parser.ypp
@@ -1,7 +1,9 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
 /*
 	This file is part of Warzone 2100.
 	Copyright (C) 1999-2004  Eidos Interactive
-	Copyright (C) 2005-2020  Warzone 2100 Project
+	Copyright (C) 2005-2026  Warzone 2100 Project (https://github.com/Warzone2100)
 
 	Warzone 2100 is free software; you can redistribute it and/or modify
 	it under the terms of the GNU General Public License as published by
@@ -39,6 +41,9 @@ extern char* res_get_text(void);
 #include "lib/framework/frameresource.h"
 #include "lib/framework/resly.h"
 #include "lib/framework/physfs_ext.h"
+
+extern bool resParserSetDirectory(const char *directory);
+extern bool resParserAddFile(const char *type, const char *file);
 
 extern void yyerror(const char* msg);
 void yyerror(const char* msg)
@@ -84,40 +89,20 @@ res_line:			dir_line
 
 dir_line:			DIRECTORY QTEXT_T
 				{
-					UDWORD len;
-
-					// set a new input directory
-					debug(LOG_NEVER, "directory: %s", $2);
-					if (strncmp($2, "/:", strlen("/:")) == 0)
-					{
-						// the new dir is rooted
-						sstrcpy(aCurrResDir, $2);
-					}
-					else
-					{
-						sstrcpy(aCurrResDir, aResDir);
-						sstrcat(aCurrResDir, $2);
-					}
-					if (strlen($2) > 0)
-					{
-						ASSERT(WZ_PHYSFS_isDirectory(aCurrResDir), "%s is not a directory!", aCurrResDir);
-						// Add a trailing '/'
-						len = strlen(aCurrResDir);
-						aCurrResDir[len] = '/';
-						aCurrResDir[len+1] = 0;
-						debug(LOG_NEVER, "Current resource directory: %s", aCurrResDir);
-					}
+					bool success = resParserSetDirectory($2);
 					free($2);
+
+					if (!success)
+					{
+						YYABORT;
+					}
 				}
 				;
 
 
 file_line:			FILETOKEN TEXT_T QTEXT_T
 				{
-					bool success;
-					/* load a data file */
-					debug(LOG_NEVER, "file: %s %s", $2, $3);
-					success = resLoadFile($2, $3);
+					bool success = resParserAddFile($2, $3);
 					free($2);
 					free($3);
 

--- a/lib/framework/wzapp.h
+++ b/lib/framework/wzapp.h
@@ -1,7 +1,9 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
 /*
 	This file is part of Warzone 2100.
 	Copyright (C) 1999-2004  Eidos Interactive
-	Copyright (C) 2005-2020  Warzone 2100 Project
+	Copyright (C) 2005-2026  Warzone 2100 Project (https://github.com/Warzone2100)
 
 	Warzone 2100 is free software; you can redistribute it and/or modify
 	it under the terms of the GNU General Public License as published by
@@ -80,6 +82,9 @@ void wzResetGfxSettingsOnFailure();
 void wzGetGameToRendererScaleFactor(float *horizScaleFactor, float *vertScaleFactor);
 void wzGetGameToRendererScaleFactorInt(unsigned int *horizScalePercentage, unsigned int *vertScalePercentage);
 void wzMainEventLoop(std::function<void()> onShutdown);
+/// Platform event pump for synchronous loading drains. Keeps the OS window responsive
+/// while `runTaskToCompletion` / `runBlockingResourceLoad` spin on the main thread.
+/// Called from game-layer loading housekeeping and lib/ivis_opengl blocking gfx loads.
 void wzPumpEventsWhileLoading();
 void wzQuit(int exitCode);              ///< Quit game
 int wzGetQuitExitCode();

--- a/lib/ivis_opengl/CMakeLists.txt
+++ b/lib/ivis_opengl/CMakeLists.txt
@@ -43,6 +43,7 @@ file(GLOB SRC
 	"bitimage.cpp"
 	"culling.cpp"
 	"gfx_api.cpp"
+	"gfx_api_texture_array_load.cpp"
 	"gfx_api_gl.cpp"
 	"gfx_api_image_basis_priv.cpp"
 	"gfx_api_image_compress_priv.cpp"

--- a/lib/ivis_opengl/gfx_api.cpp
+++ b/lib/ivis_opengl/gfx_api.cpp
@@ -1,6 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
 /*
 	This file is part of Warzone 2100.
-	Copyright (C) 2017-2019  Warzone 2100 Project
+	Copyright (C) 2017-2026  Warzone 2100 Project (https://github.com/Warzone2100)
 
 	Warzone 2100 is free software; you can redistribute it and/or modify
 	it under the terms of the GNU General Public License as published by
@@ -22,6 +24,7 @@
 #include "gfx_api_null.h"
 #include "gfx_api_image_compress_priv.h"
 #include "gfx_api_image_basis_priv.h"
+#include "gfx_api_mipmap_priv.h"
 #include "lib/framework/physfs_ext.h"
 #include <unordered_map>
 #include <algorithm>
@@ -338,19 +341,6 @@ gfx_api::texture* gfx_api::context::loadTextureFromFile(const char *filename, gf
 	}
 }
 
-static inline size_t calcMipmapLevelsForUncompressedImage(const iV_BaseImage& image, gfx_api::texture_type textureType)
-{
-	// 3.) Determine mipmap levels (if needed / desired)
-	bool generateMipMaps = (textureType != gfx_api::texture_type::user_interface);
-	size_t mipmap_levels = 1;
-	if (generateMipMaps)
-	{
-		// Calculate how many mip-map levels (with a target minimum level dimension of 4)
-		mipmap_levels = 1 + static_cast<size_t>(floor(log2(std::max(image.width(), image.height()))));
-	}
-	return mipmap_levels;
-}
-
 static inline bool uncompressedPNGImageConvertChannels(iV_Image& image, gfx_api::pixel_format_target target, gfx_api::texture_type textureType, const std::string& filename)
 {
 	// 1.) Convert to expected # of channels based on textureType
@@ -412,33 +402,6 @@ static bool checkFormatVersusMaxCompressionLevel_FromUncompressed(optional<gfx_a
 	}
 
 	return true;
-}
-
-static std::vector<std::unique_ptr<iV_Image>> generateMipMapsFromUncompressedImage(const iV_Image& image, size_t mipmap_levels, gfx_api::texture_type textureType)
-{
-	std::vector<std::unique_ptr<iV_Image>> results;
-
-	const iV_Image *pLastImage = &image;
-	for (size_t i = 1; i < mipmap_levels; i++)
-	{
-		optional<int> alphaChannelOverride;
-		if (textureType == gfx_api::texture_type::alpha_mask)
-		{
-			alphaChannelOverride = 0;
-		}
-
-		unsigned int output_w = std::max<unsigned int>(1, pLastImage->width() >> 1);
-		unsigned int output_h = std::max<unsigned int>(1, pLastImage->height() >> 1);
-
-		iV_Image *pNewLevel = new iV_Image();
-		pNewLevel->resizedFromOther(*pLastImage, output_w, output_h, alphaChannelOverride);
-
-		results.push_back(std::unique_ptr<iV_Image>(pNewLevel));
-
-		pLastImage = pNewLevel;
-	}
-
-	return results;
 }
 
 // Takes an iv_Image and texture_type and loads a texture as appropriate / possible
@@ -866,245 +829,4 @@ bool gfx_api::context::loadTextureArrayLayerFromBaseImages(gfx_api::texture_arra
 	}
 
 	return true;
-}
-
-static std::vector<std::unique_ptr<iV_BaseImage>> loadUncompressedImageWithMips(const std::string& imageLoadFilename, gfx_api::texture_type textureType, int maxWidth /*= -1*/, int maxHeight /*= -1*/, bool forceRGBA8 /*= false*/)
-{
-	std::vector<std::unique_ptr<iV_BaseImage>> results;
-#if defined(BASIS_ENABLED)
-	if (strEndsWith(imageLoadFilename, ".ktx2"))
-	{
-		results = gfx_api::loadiVImagesFromFile_Basis(imageLoadFilename, textureType, gfx_api::pixel_format_target::texture_2d_array, (forceRGBA8) ? WZ_BASIS_UNCOMPRESSED_FORMAT : gfx_api::context::get().bestUncompressedPixelFormat(gfx_api::pixel_format_target::texture_2d_array, textureType), std::max(0, maxWidth), std::max(0, maxHeight));
-
-		if (forceRGBA8)
-		{
-			for (auto& image : results)
-			{
-				auto pLoadedUncompressedImage = dynamic_cast<iV_Image*>(image.get());
-				if (!pLoadedUncompressedImage)
-				{
-					debug(LOG_ERROR, "Loaded image is not an uncompressed format?: %s", imageLoadFilename.c_str());
-					continue;
-				}
-				pLoadedUncompressedImage->convert_to_rgba();
-			}
-		}
-
-		return results;
-	}
-	else
-#endif
-	if (strEndsWith(imageLoadFilename, ".png"))
-	{
-		auto pCurrentImage = gfx_api::loadUncompressedImageFromFile(imageLoadFilename.c_str(), gfx_api::pixel_format_target::texture_2d_array, textureType, maxWidth, maxHeight, forceRGBA8);
-		if (!pCurrentImage)
-		{
-			debug(LOG_ERROR, "Unable to load image file: %s", imageLoadFilename.c_str());
-			return {};
-		}
-		size_t mipmap_levels = calcMipmapLevelsForUncompressedImage(*pCurrentImage, textureType);
-		auto miplevels = generateMipMapsFromUncompressedImage(*pCurrentImage, mipmap_levels, textureType);
-		results.push_back(std::move(pCurrentImage));
-		results.insert(results.end(), std::make_move_iterator(miplevels.begin()), std::make_move_iterator(miplevels.end()));
-		miplevels.clear();
-	}
-	else
-	{
-		debug(LOG_ERROR, "Unable to load image file: %s", imageLoadFilename.c_str());
-		return {};
-	}
-	return results;
-}
-
-gfx_api::texture_array* gfx_api::context::loadTextureArrayFromFiles(const std::vector<WzString>& filenames, gfx_api::texture_type textureType, int maxWidth /*= -1*/, int maxHeight /*= -1*/, const GenerateDefaultTextureFunc& defaultTextureGenerator, const std::function<void ()>& progressCallback, const std::string& debugName /*= ""*/)
-{
-	ASSERT_OR_RETURN(nullptr, filenames.size() <= gfx_api::context::get().get_context_value(gfx_api::context::context_value::MAX_ARRAY_TEXTURE_LAYERS), "Too many layers");
-
-	std::vector<WzString> imageLoadFilenames;
-	std::transform(filenames.cbegin(), filenames.cend(), std::back_inserter(imageLoadFilenames), [](const WzString& filename) {
-		return imageLoadFilenameFromInputFilename(filename);
-	});
-
-	bool allFilesAreKTX2 = std::all_of(imageLoadFilenames.cbegin(), imageLoadFilenames.cend(), [](const WzString& imageLoadFilename) { return imageLoadFilename.endsWith(".ktx2"); });
-	bool anyFileIsKTX2 = allFilesAreKTX2 || std::any_of(imageLoadFilenames.cbegin(), imageLoadFilenames.cend(), [](const WzString& imageLoadFilename) { return imageLoadFilename.endsWith(".ktx2"); });
-	bool anyFileIsPNG = !allFilesAreKTX2 && std::any_of(imageLoadFilenames.cbegin(), imageLoadFilenames.cend(), [](const WzString& imageLoadFilename) { return imageLoadFilename.endsWith(".png"); });
-
-#if !defined(BASIS_ENABLED)
-	if (anyFileIsKTX2)
-	{
-		for (auto& imageLoadFilename : imageLoadFilenames)
-		{
-			const std::string& filename = imageLoadFilename.toUtf8();
-			if (strEndsWith(filename, ".ktx2"))
-			{
-				debug(LOG_ERROR, "Unable to load image file: %s", filename.c_str());
-			}
-		}
-		return nullptr;
-	}
-#endif
-
-	gfx_api::pixel_format uploadFormat = bestUncompressedPixelFormat(gfx_api::pixel_format_target::texture_2d_array, textureType);
-	gfx_api::pixel_format desiredImageExtractionFormat = uploadFormat;
-#if defined(BASIS_ENABLED)
-	if (allFilesAreKTX2)
-	{
-		auto bestBasisFormat = gfx_api::getBestAvailableTranscodeFormatForBasis(gfx_api::pixel_format_target::texture_2d_array, textureType);
-		if (bestBasisFormat.has_value())
-		{
-			uploadFormat = bestBasisFormat.value();
-			desiredImageExtractionFormat = uploadFormat;
-		}
-	}
-	else
-#endif
-	{
-		// just use the best runtime compression format
-		auto bestAvailableCompressedFormat = gfx_api::bestRealTimeCompressionFormat(gfx_api::pixel_format_target::texture_2d_array, textureType);
-		if (bestAvailableCompressedFormat.has_value() && bestAvailableCompressedFormat.value() != gfx_api::pixel_format::invalid)
-		{
-			uploadFormat = bestAvailableCompressedFormat.value();
-			desiredImageExtractionFormat = gfx_api::pixel_format::FORMAT_RGBA8_UNORM_PACK8; // must extract to RGBA for run-time compression
-		}
-		if (anyFileIsKTX2 && anyFileIsPNG)
-		{
-			debug(LOG_INFO, "Performance info: Some files are .ktx2, but others are .png");
-		}
-	}
-
-	bool uncompressedExtractionFormat = gfx_api::is_uncompressed_format(desiredImageExtractionFormat);
-	std::vector<std::unique_ptr<iV_BaseImage>> defaultTextureMips;
-
-	auto getDefaultTextureMipsP = [&defaultTextureMips, &defaultTextureGenerator, textureType, maxWidth, maxHeight](size_t layer, unsigned int width, unsigned int height, size_t mipmap_levels, gfx_api::pixel_format format) -> std::vector<std::unique_ptr<iV_BaseImage>>* {
-		if (defaultTextureMips.empty())
-		{
-			ASSERT_OR_RETURN(nullptr, defaultTextureGenerator != nullptr, "Failed to generate default texture - no default texture generator provided");
-			ASSERT_OR_RETURN(nullptr, gfx_api::is_uncompressed_format(format), "Expected uncompressed extraction format, but received: %s", gfx_api::format_to_str(format));
-			if (defaultTextureGenerator)
-			{
-				auto pCurrentImage = defaultTextureGenerator((layer > 0) ? width : maxWidth, (layer > 0) ? height : maxHeight, gfx_api::format_channels(format));
-				ASSERT_OR_RETURN(nullptr, pCurrentImage != nullptr, "Failed to generate default texture");
-				if (layer > 0)
-				{
-					ASSERT_OR_RETURN(nullptr, pCurrentImage->width() == width && pCurrentImage->height() == height, "Failed to generate matching default texture");
-				}
-				size_t expectedMipLevels = calcMipmapLevelsForUncompressedImage(*pCurrentImage, textureType);
-				if (layer > 0)
-				{
-					ASSERT_OR_RETURN(nullptr, expectedMipLevels == mipmap_levels, "Failed to generate matching default texture");
-				}
-				auto miplevels = generateMipMapsFromUncompressedImage(*pCurrentImage, expectedMipLevels, textureType);
-				defaultTextureMips.push_back(std::move(pCurrentImage));
-				defaultTextureMips.insert(defaultTextureMips.end(), std::make_move_iterator(miplevels.begin()), std::make_move_iterator(miplevels.end()));
-				miplevels.clear();
-			}
-		}
-		return &defaultTextureMips;
-	};
-
-	std::unique_ptr<gfx_api::texture_array> texture_array = nullptr;
-	unsigned int width = 0;
-	unsigned int height = 0;
-	size_t mipmap_levels = 0;
-	size_t layers_count = imageLoadFilenames.size();
-
-	for (size_t layer = 0; layer < layers_count; ++layer)
-	{
-		const WzString& imageLoadFilename = imageLoadFilenames[layer];
-
-		// load the file to an array of base images
-		std::vector<std::unique_ptr<iV_BaseImage>> loadedImagesForLayer;
-		std::vector<std::unique_ptr<iV_BaseImage>>* pImagesForLayer = nullptr;
-		if (imageLoadFilename.isEmpty())
-		{
-			pImagesForLayer = getDefaultTextureMipsP(layer, width, height, mipmap_levels, desiredImageExtractionFormat);
-			ASSERT_OR_RETURN(nullptr, pImagesForLayer != nullptr, "Failed to generate matching default texture");
-		}
-		else if (uncompressedExtractionFormat || imageLoadFilename.endsWith(".png"))
-		{
-			// load into an uncompressed format
-			loadedImagesForLayer = loadUncompressedImageWithMips(imageLoadFilename.toUtf8(), textureType, maxWidth, maxHeight, desiredImageExtractionFormat == gfx_api::pixel_format::FORMAT_RGBA8_UNORM_PACK8);
-			if (!loadedImagesForLayer.empty())
-			{
-				pImagesForLayer = &loadedImagesForLayer;
-			}
-			else
-			{
-				// failed to load image
-				debug(LOG_INFO, "Using default texture generator for failed image: %s", imageLoadFilename.toUtf8().c_str());
-				pImagesForLayer = getDefaultTextureMipsP(layer, width, height, mipmap_levels, desiredImageExtractionFormat);
-			}
-		}
-		else
-		{
-			// load directly into a compressed format
-#if defined(BASIS_ENABLED)
-			if (imageLoadFilename.endsWith(".ktx2"))
-			{
-				loadedImagesForLayer = gfx_api::loadiVImagesFromFile_Basis(imageLoadFilename.toUtf8(), textureType, gfx_api::pixel_format_target::texture_2d_array, desiredImageExtractionFormat, std::max(0, maxWidth), std::max(0, maxHeight));
-				pImagesForLayer = &loadedImagesForLayer;
-			}
-			else
-#endif
-			{
-				debug(LOG_ERROR, "Unable to load image file: %s", imageLoadFilename.toUtf8().c_str());
-				return {};
-			}
-		}
-
-		if (progressCallback)
-		{
-			progressCallback();
-		}
-
-		ASSERT_OR_RETURN(nullptr, pImagesForLayer && !pImagesForLayer->empty(), "Unable to load images: %s", imageLoadFilename.toUtf8().c_str());
-
-		if (layer == 0)
-		{
-			width = pImagesForLayer->front()->width();
-			height = pImagesForLayer->front()->height();
-			mipmap_levels = pImagesForLayer->size();
-
-			texture_array = std::unique_ptr<gfx_api::texture_array>(gfx_api::context::get().create_texture_array(mipmap_levels, layers_count, width, height, uploadFormat, debugName));
-			ASSERT_OR_RETURN(nullptr, texture_array.get() != nullptr, "Failed to create texture array (miplevels: %zu, layers: %zu, width: %u, height: %u): %s", mipmap_levels, layers_count, width, height, imageLoadFilename.toUtf8().c_str());
-		}
-		else
-		{
-			ASSERT_OR_RETURN(nullptr, width == pImagesForLayer->front()->width() && height == pImagesForLayer->front()->height(), "Unexpected image dimensions (%u x %u) does not match the first image dimensions (%u x %u): %s", pImagesForLayer->front()->width(), pImagesForLayer->front()->height(), width, height, imageLoadFilename.toUtf8().c_str());
-			ASSERT_OR_RETURN(nullptr, pImagesForLayer->size() == mipmap_levels, "Unexpected number of mip levels (%zu; expected: %zu): %s", pImagesForLayer->size(), mipmap_levels, imageLoadFilename.toUtf8().c_str());
-		}
-
-		// upload the layer
-
-		// If already in the uploadFormat
-		if (uploadFormat == desiredImageExtractionFormat)
-		{
-			// just load directly
-			bool uploadSuccess = gfx_api::context::get().loadTextureArrayLayerFromBaseImages(*texture_array, layer, *pImagesForLayer, imageLoadFilename.toUtf8(), width, height);
-			ASSERT_OR_RETURN(nullptr, uploadSuccess, "Failed to loadTextureArrayLayerFromBaseImages");
-		}
-		else
-		{
-			// convert from (presumably uncompressed) to desired run-time compressed target format (for each mip level)
-			ASSERT_OR_RETURN(nullptr, uncompressedExtractionFormat, "Expected uncompressed extraction format, but received: %s", gfx_api::format_to_str(desiredImageExtractionFormat));
-
-			for (size_t level = 0; level < pImagesForLayer->size(); ++level)
-			{
-				const iV_Image* image = dynamic_cast<iV_Image*>(pImagesForLayer->at(level).get());
-				ASSERT_OR_RETURN(nullptr, image != nullptr, "Image wasn't an iV_Image?");
-				// Run-time compression
-				auto compressedImage = gfx_api::compressImage(*image, uploadFormat);
-				ASSERT_OR_RETURN(nullptr, compressedImage != nullptr, "Failed to compress image to format: %zu", static_cast<size_t>(uploadFormat));
-				bool uploadResult = texture_array->upload_layer(layer, level, *compressedImage);
-				ASSERT_OR_RETURN(nullptr, uploadResult, "Failed to upload buffer to image");
-			}
-		}
-	}
-
-	if (texture_array)
-	{
-		texture_array->flush();
-	}
-
-	return texture_array.release();
 }

--- a/lib/ivis_opengl/gfx_api.h
+++ b/lib/ivis_opengl/gfx_api.h
@@ -1,6 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
 /*
 	This file is part of Warzone 2100.
-	Copyright (C) 2017-2020  Warzone 2100 Project
+	Copyright (C) 2017-2026  Warzone 2100 Project (https://github.com/Warzone2100)
 
 	Warzone 2100 is free software; you can redistribute it and/or modify
 	it under the terms of the GNU General Public License as published by
@@ -31,6 +33,7 @@
 
 #include "lib/framework/frame.h"
 #include "lib/framework/wzstring.h"
+#include "lib/framework/loading_task_fwd.h"
 #include "screen.h"
 #include "pietypes.h"
 #include "gfx_api_formats_def.h"
@@ -42,6 +45,8 @@
 #include <nonstd/optional.hpp>
 using nonstd::optional;
 using nonstd::nullopt;
+
+class ResourceLoadingController;
 
 namespace gfx_api
 {
@@ -447,7 +452,8 @@ namespace gfx_api
 		gfx_api::texture* loadTextureFromFile(const char *filename, gfx_api::texture_type textureType, int maxWidth = -1, int maxHeight = -1, bool quiet = false);
 		gfx_api::texture* loadTextureFromUncompressedImage(iV_Image&& image, gfx_api::texture_type textureType, const std::string& filename, int maxWidth = -1, int maxHeight = -1);
 		typedef std::function<std::unique_ptr<iV_Image> (int width, int height, int channels)> GenerateDefaultTextureFunc;
-		gfx_api::texture_array* loadTextureArrayFromFiles(const std::vector<WzString>& filenames, gfx_api::texture_type textureType, int maxWidth = -1, int maxHeight = -1, const GenerateDefaultTextureFunc& defaultTextureGenerator = nullptr, const std::function<void ()>& progressCallback = nullptr, const std::string& debugName = "");
+		LoadingTask<gfx_api::texture_array*> loadTextureArrayFromFiles(ResourceLoadingController& controller, const std::vector<WzString>& filenames, gfx_api::texture_type textureType, int maxWidth = -1, int maxHeight = -1, const GenerateDefaultTextureFunc& defaultTextureGenerator = nullptr, const std::string& debugName = "");
+		gfx_api::texture_array* loadTextureArrayFromFilesBlocking(const std::vector<WzString>& filenames, gfx_api::texture_type textureType, int maxWidth = -1, int maxHeight = -1, const GenerateDefaultTextureFunc& defaultTextureGenerator = nullptr, const std::string& debugName = "");
 
 		bool loadTextureArrayLayerFromUncompressedImage(gfx_api::texture_array& array, size_t layer, const iV_Image& image, gfx_api::texture_type textureType, gfx_api::pixel_format uploadFormat, const std::string& filename, int maxWidth = -1, int maxHeight = -1);
 		bool loadTextureArrayLayerFromUncompressedImage(gfx_api::texture_array& array, size_t layer, const iV_Image& image, gfx_api::texture_type textureType, size_t mipmap_levels, gfx_api::pixel_format uploadFormat, const std::string& filename, int maxWidth = -1, int maxHeight = -1);

--- a/lib/ivis_opengl/gfx_api_mipmap_priv.h
+++ b/lib/ivis_opengl/gfx_api_mipmap_priv.h
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+/*
+	This file is part of Warzone 2100.
+	Copyright (C) 2026  Warzone 2100 Project (https://github.com/Warzone2100)
+
+	Warzone 2100 is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+
+	Warzone 2100 is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with Warzone 2100; if not, write to the Free Software
+	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+/** @file gfx_api_mipmap_priv.h
+ * Shared mipmap helpers for gfx_api texture loading.
+ */
+
+#pragma once
+
+#include "gfx_api.h"
+
+#include <cmath>
+#include <memory>
+#include <vector>
+
+inline size_t calcMipmapLevelsForUncompressedImage(const iV_BaseImage& image, gfx_api::texture_type textureType)
+{
+	bool generateMipMaps = (textureType != gfx_api::texture_type::user_interface);
+	size_t mipmap_levels = 1;
+	if (generateMipMaps)
+	{
+		mipmap_levels = 1 + static_cast<size_t>(floor(log2(std::max(image.width(), image.height()))));
+	}
+	return mipmap_levels;
+}
+
+inline std::vector<std::unique_ptr<iV_Image>> generateMipMapsFromUncompressedImage(const iV_Image& image, size_t mipmap_levels, gfx_api::texture_type textureType)
+{
+	std::vector<std::unique_ptr<iV_Image>> results;
+
+	const iV_Image *pLastImage = &image;
+	for (size_t i = 1; i < mipmap_levels; i++)
+	{
+		optional<int> alphaChannelOverride;
+		if (textureType == gfx_api::texture_type::alpha_mask)
+		{
+			alphaChannelOverride = 0;
+		}
+
+		unsigned int output_w = std::max<unsigned int>(1, pLastImage->width() >> 1);
+		unsigned int output_h = std::max<unsigned int>(1, pLastImage->height() >> 1);
+
+		iV_Image *pNewLevel = new iV_Image();
+		pNewLevel->resizedFromOther(*pLastImage, output_w, output_h, alphaChannelOverride);
+
+		results.push_back(std::unique_ptr<iV_Image>(pNewLevel));
+
+		pLastImage = pNewLevel;
+	}
+
+	return results;
+}

--- a/lib/ivis_opengl/gfx_api_texture_array_load.cpp
+++ b/lib/ivis_opengl/gfx_api_texture_array_load.cpp
@@ -1,0 +1,387 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+/*
+	This file is part of Warzone 2100.
+	Copyright (C) 2026  Warzone 2100 Project (https://github.com/Warzone2100)
+
+	Warzone 2100 is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+
+	Warzone 2100 is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with Warzone 2100; if not, write to the Free Software
+	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+/** @file gfx_api_texture_array_load.cpp
+ * C++20 coroutine-based texture array loading from files.
+ */
+
+#include "gfx_api.h"
+#include "gfx_api_image_basis_priv.h"
+#include "gfx_api_image_compress_priv.h"
+#include "gfx_api_mipmap_priv.h"
+
+#include "lib/framework/loading_task.h"
+#include "lib/framework/resource_loading_controller.h"
+#include "lib/framework/wzapp.h"
+#include "lib/sound/audio.h"
+
+#include <algorithm>
+
+namespace
+{
+
+void pumpBlockingResourceLoadWithoutUI(const ResourceLoadingController::FramePolicy& /*policy*/)
+{
+	wzPumpEventsWhileLoading();
+	audio_Update();
+}
+
+std::vector<std::unique_ptr<iV_BaseImage>> loadUncompressedImageWithMips(const std::string& imageLoadFilename, gfx_api::texture_type textureType, int maxWidth, int maxHeight, bool forceRGBA8)
+{
+	std::vector<std::unique_ptr<iV_BaseImage>> results;
+#if defined(BASIS_ENABLED)
+	if (strEndsWith(imageLoadFilename, ".ktx2"))
+	{
+		results = gfx_api::loadiVImagesFromFile_Basis(imageLoadFilename, textureType, gfx_api::pixel_format_target::texture_2d_array, (forceRGBA8) ? WZ_BASIS_UNCOMPRESSED_FORMAT : gfx_api::context::get().bestUncompressedPixelFormat(gfx_api::pixel_format_target::texture_2d_array, textureType), std::max(0, maxWidth), std::max(0, maxHeight));
+
+		if (forceRGBA8)
+		{
+			for (auto& image : results)
+			{
+				auto pLoadedUncompressedImage = dynamic_cast<iV_Image*>(image.get());
+				if (!pLoadedUncompressedImage)
+				{
+					debug(LOG_ERROR, "Loaded image is not an uncompressed format?: %s", imageLoadFilename.c_str());
+					continue;
+				}
+				pLoadedUncompressedImage->convert_to_rgba();
+			}
+		}
+
+		return results;
+	}
+	else
+#endif
+	if (strEndsWith(imageLoadFilename, ".png"))
+	{
+		auto pCurrentImage = gfx_api::loadUncompressedImageFromFile(imageLoadFilename.c_str(), gfx_api::pixel_format_target::texture_2d_array, textureType, maxWidth, maxHeight, forceRGBA8);
+		if (!pCurrentImage)
+		{
+			debug(LOG_ERROR, "Unable to load image file: %s", imageLoadFilename.c_str());
+			return {};
+		}
+		size_t mipmap_levels = calcMipmapLevelsForUncompressedImage(*pCurrentImage, textureType);
+		auto miplevels = generateMipMapsFromUncompressedImage(*pCurrentImage, mipmap_levels, textureType);
+		results.push_back(std::move(pCurrentImage));
+		results.insert(results.end(), std::make_move_iterator(miplevels.begin()), std::make_move_iterator(miplevels.end()));
+		miplevels.clear();
+	}
+	else
+	{
+		debug(LOG_ERROR, "Unable to load image file: %s", imageLoadFilename.c_str());
+		return {};
+	}
+	return results;
+}
+
+struct TextureArrayLoadContext
+{
+	const std::vector<WzString>& imageLoadFilenames;
+	gfx_api::texture_type textureType;
+	int maxWidth;
+	int maxHeight;
+	gfx_api::context::GenerateDefaultTextureFunc defaultTextureGenerator;
+	const std::string& debugName;
+
+	gfx_api::pixel_format uploadFormat = gfx_api::pixel_format::invalid;
+	gfx_api::pixel_format desiredImageExtractionFormat = gfx_api::pixel_format::invalid;
+	bool uncompressedExtractionFormat = false;
+	std::vector<std::unique_ptr<iV_BaseImage>> defaultTextureMips = {};
+
+	std::unique_ptr<gfx_api::texture_array> texture_array = nullptr;
+	unsigned int width = 0;
+	unsigned int height = 0;
+	size_t mipmap_levels = 0;
+};
+
+std::vector<std::unique_ptr<iV_BaseImage>>* getDefaultTextureMipsP(TextureArrayLoadContext& ctx, size_t layer, unsigned int width, unsigned int height, size_t mipmap_levels, gfx_api::pixel_format format)
+{
+	if (ctx.defaultTextureMips.empty())
+	{
+		ASSERT_OR_RETURN(nullptr, ctx.defaultTextureGenerator != nullptr, "Failed to generate default texture - no default texture generator provided");
+		ASSERT_OR_RETURN(nullptr, gfx_api::is_uncompressed_format(format), "Expected uncompressed extraction format, but received: %s", gfx_api::format_to_str(format));
+		if (ctx.defaultTextureGenerator)
+		{
+			auto pCurrentImage = ctx.defaultTextureGenerator((layer > 0) ? width : ctx.maxWidth, (layer > 0) ? height : ctx.maxHeight, gfx_api::format_channels(format));
+			ASSERT_OR_RETURN(nullptr, pCurrentImage != nullptr, "Failed to generate default texture");
+			if (layer > 0)
+			{
+				ASSERT_OR_RETURN(nullptr, pCurrentImage->width() == width && pCurrentImage->height() == height, "Failed to generate matching default texture");
+			}
+			size_t expectedMipLevels = calcMipmapLevelsForUncompressedImage(*pCurrentImage, ctx.textureType);
+			if (layer > 0)
+			{
+				ASSERT_OR_RETURN(nullptr, expectedMipLevels == mipmap_levels, "Failed to generate matching default texture");
+			}
+			auto miplevels = generateMipMapsFromUncompressedImage(*pCurrentImage, expectedMipLevels, ctx.textureType);
+			ctx.defaultTextureMips.push_back(std::move(pCurrentImage));
+			ctx.defaultTextureMips.insert(ctx.defaultTextureMips.end(), std::make_move_iterator(miplevels.begin()), std::make_move_iterator(miplevels.end()));
+			miplevels.clear();
+		}
+	}
+	return &ctx.defaultTextureMips;
+}
+
+bool loadTextureArrayLayer(TextureArrayLoadContext& ctx, size_t layer)
+{
+	const WzString& imageLoadFilename = ctx.imageLoadFilenames[layer];
+
+	std::vector<std::unique_ptr<iV_BaseImage>> loadedImagesForLayer;
+	std::vector<std::unique_ptr<iV_BaseImage>>* pImagesForLayer = nullptr;
+	if (imageLoadFilename.isEmpty())
+	{
+		pImagesForLayer = getDefaultTextureMipsP(ctx, layer, ctx.width, ctx.height, ctx.mipmap_levels, ctx.desiredImageExtractionFormat);
+		ASSERT_OR_RETURN(false, pImagesForLayer != nullptr, "Failed to generate matching default texture");
+	}
+	else if (ctx.uncompressedExtractionFormat || imageLoadFilename.endsWith(".png"))
+	{
+		loadedImagesForLayer = loadUncompressedImageWithMips(imageLoadFilename.toUtf8(), ctx.textureType, ctx.maxWidth, ctx.maxHeight, ctx.desiredImageExtractionFormat == gfx_api::pixel_format::FORMAT_RGBA8_UNORM_PACK8);
+		if (!loadedImagesForLayer.empty())
+		{
+			pImagesForLayer = &loadedImagesForLayer;
+		}
+		else
+		{
+			debug(LOG_INFO, "Using default texture generator for failed image: %s", imageLoadFilename.toUtf8().c_str());
+			pImagesForLayer = getDefaultTextureMipsP(ctx, layer, ctx.width, ctx.height, ctx.mipmap_levels, ctx.desiredImageExtractionFormat);
+		}
+	}
+	else
+	{
+#if defined(BASIS_ENABLED)
+		if (imageLoadFilename.endsWith(".ktx2"))
+		{
+			loadedImagesForLayer = gfx_api::loadiVImagesFromFile_Basis(imageLoadFilename.toUtf8(), ctx.textureType, gfx_api::pixel_format_target::texture_2d_array, ctx.desiredImageExtractionFormat, std::max(0, ctx.maxWidth), std::max(0, ctx.maxHeight));
+			pImagesForLayer = &loadedImagesForLayer;
+		}
+		else
+#endif
+		{
+			debug(LOG_ERROR, "Unable to load image file: %s", imageLoadFilename.toUtf8().c_str());
+			return false;
+		}
+	}
+
+	ASSERT_OR_RETURN(false, pImagesForLayer && !pImagesForLayer->empty(), "Unable to load images: %s", imageLoadFilename.toUtf8().c_str());
+
+	if (layer == 0)
+	{
+		ctx.width = pImagesForLayer->front()->width();
+		ctx.height = pImagesForLayer->front()->height();
+		ctx.mipmap_levels = pImagesForLayer->size();
+
+		ctx.texture_array = std::unique_ptr<gfx_api::texture_array>(gfx_api::context::get().create_texture_array(ctx.mipmap_levels, ctx.imageLoadFilenames.size(), ctx.width, ctx.height, ctx.uploadFormat, ctx.debugName));
+		ASSERT_OR_RETURN(false, ctx.texture_array.get() != nullptr, "Failed to create texture array (miplevels: %zu, layers: %zu, width: %u, height: %u): %s", ctx.mipmap_levels, ctx.imageLoadFilenames.size(), ctx.width, ctx.height, imageLoadFilename.toUtf8().c_str());
+	}
+	else
+	{
+		ASSERT_OR_RETURN(false, ctx.width == pImagesForLayer->front()->width() && ctx.height == pImagesForLayer->front()->height(), "Unexpected image dimensions (%u x %u) does not match the first image dimensions (%u x %u): %s", pImagesForLayer->front()->width(), pImagesForLayer->front()->height(), ctx.width, ctx.height, imageLoadFilename.toUtf8().c_str());
+		ASSERT_OR_RETURN(false, pImagesForLayer->size() == ctx.mipmap_levels, "Unexpected number of mip levels (%zu; expected: %zu): %s", pImagesForLayer->size(), ctx.mipmap_levels, imageLoadFilename.toUtf8().c_str());
+	}
+
+	if (ctx.uploadFormat == ctx.desiredImageExtractionFormat)
+	{
+		bool uploadSuccess = gfx_api::context::get().loadTextureArrayLayerFromBaseImages(*ctx.texture_array, layer, *pImagesForLayer, imageLoadFilename.toUtf8(), ctx.width, ctx.height);
+		ASSERT_OR_RETURN(false, uploadSuccess, "Failed to loadTextureArrayLayerFromBaseImages");
+	}
+	else
+	{
+		ASSERT_OR_RETURN(false, ctx.uncompressedExtractionFormat, "Expected uncompressed extraction format, but received: %s", gfx_api::format_to_str(ctx.desiredImageExtractionFormat));
+
+		for (size_t level = 0; level < pImagesForLayer->size(); ++level)
+		{
+			const iV_Image* image = dynamic_cast<iV_Image*>(pImagesForLayer->at(level).get());
+			ASSERT_OR_RETURN(false, image != nullptr, "Image wasn't an iV_Image?");
+			auto compressedImage = gfx_api::compressImage(*image, ctx.uploadFormat);
+			ASSERT_OR_RETURN(false, compressedImage != nullptr, "Failed to compress image to format: %zu", static_cast<size_t>(ctx.uploadFormat));
+			bool uploadResult = ctx.texture_array->upload_layer(layer, level, *compressedImage);
+			ASSERT_OR_RETURN(false, uploadResult, "Failed to upload buffer to image");
+		}
+	}
+
+	return true;
+}
+
+bool prepareTextureArrayLoadContext(TextureArrayLoadContext& ctx)
+{
+	ASSERT_OR_RETURN(false, ctx.imageLoadFilenames.size() <= gfx_api::context::get().get_context_value(gfx_api::context::context_value::MAX_ARRAY_TEXTURE_LAYERS), "Too many layers");
+
+	bool allFilesAreKTX2 = std::all_of(ctx.imageLoadFilenames.cbegin(), ctx.imageLoadFilenames.cend(), [](const WzString& imageLoadFilename) { return imageLoadFilename.endsWith(".ktx2"); });
+	bool anyFileIsKTX2 = allFilesAreKTX2 || std::any_of(ctx.imageLoadFilenames.cbegin(), ctx.imageLoadFilenames.cend(), [](const WzString& imageLoadFilename) { return imageLoadFilename.endsWith(".ktx2"); });
+	bool anyFileIsPNG = !allFilesAreKTX2 && std::any_of(ctx.imageLoadFilenames.cbegin(), ctx.imageLoadFilenames.cend(), [](const WzString& imageLoadFilename) { return imageLoadFilename.endsWith(".png"); });
+
+#if !defined(BASIS_ENABLED)
+	if (anyFileIsKTX2)
+	{
+		for (auto& imageLoadFilename : ctx.imageLoadFilenames)
+		{
+			const std::string& filename = imageLoadFilename.toUtf8();
+			if (strEndsWith(filename, ".ktx2"))
+			{
+				debug(LOG_ERROR, "Unable to load image file: %s", filename.c_str());
+			}
+		}
+		return false;
+	}
+#endif
+
+	ctx.uploadFormat = gfx_api::context::get().bestUncompressedPixelFormat(gfx_api::pixel_format_target::texture_2d_array, ctx.textureType);
+	ctx.desiredImageExtractionFormat = ctx.uploadFormat;
+#if defined(BASIS_ENABLED)
+	if (allFilesAreKTX2)
+	{
+		auto bestBasisFormat = gfx_api::getBestAvailableTranscodeFormatForBasis(gfx_api::pixel_format_target::texture_2d_array, ctx.textureType);
+		if (bestBasisFormat.has_value())
+		{
+			ctx.uploadFormat = bestBasisFormat.value();
+			ctx.desiredImageExtractionFormat = ctx.uploadFormat;
+		}
+	}
+	else
+#endif
+	{
+		auto bestAvailableCompressedFormat = gfx_api::bestRealTimeCompressionFormat(gfx_api::pixel_format_target::texture_2d_array, ctx.textureType);
+		if (bestAvailableCompressedFormat.has_value() && bestAvailableCompressedFormat.value() != gfx_api::pixel_format::invalid)
+		{
+			ctx.uploadFormat = bestAvailableCompressedFormat.value();
+			ctx.desiredImageExtractionFormat = gfx_api::pixel_format::FORMAT_RGBA8_UNORM_PACK8;
+		}
+		if (anyFileIsKTX2 && anyFileIsPNG)
+		{
+			debug(LOG_INFO, "Performance info: Some files are .ktx2, but others are .png");
+		}
+	}
+
+	ctx.uncompressedExtractionFormat = gfx_api::is_uncompressed_format(ctx.desiredImageExtractionFormat);
+	return true;
+}
+
+gfx_api::texture_array* finishTextureArrayLoad(TextureArrayLoadContext& ctx)
+{
+	if (ctx.texture_array)
+	{
+		ctx.texture_array->flush();
+	}
+	return ctx.texture_array.release();
+}
+
+std::vector<WzString> imageLoadFilenamesFromInput(const std::vector<WzString>& filenames)
+{
+	std::vector<WzString> imageLoadFilenames;
+	imageLoadFilenames.reserve(filenames.size());
+	std::transform(filenames.cbegin(), filenames.cend(), std::back_inserter(imageLoadFilenames), [](const WzString& filename) {
+		return gfx_api::imageLoadFilenameFromInputFilename(filename);
+	});
+	return imageLoadFilenames;
+}
+
+gfx_api::texture_array* loadTextureArrayFromFilesNoYield(
+	const std::vector<WzString>& filenames,
+	gfx_api::texture_type textureType,
+	int maxWidth,
+	int maxHeight,
+	const gfx_api::context::GenerateDefaultTextureFunc& defaultTextureGenerator,
+	const std::string& debugName)
+{
+	auto imageLoadFilenames = imageLoadFilenamesFromInput(filenames);
+
+	TextureArrayLoadContext ctx{
+		imageLoadFilenames,
+		textureType,
+		maxWidth,
+		maxHeight,
+		defaultTextureGenerator,
+		debugName,
+	};
+
+	if (!prepareTextureArrayLoadContext(ctx))
+	{
+		return nullptr;
+	}
+
+	for (size_t layer = 0; layer < imageLoadFilenames.size(); ++layer)
+	{
+		if (!loadTextureArrayLayer(ctx, layer))
+		{
+			return nullptr;
+		}
+	}
+
+	return finishTextureArrayLoad(ctx);
+}
+
+} // namespace
+
+LoadingTask<gfx_api::texture_array*> gfx_api::context::loadTextureArrayFromFiles(
+	ResourceLoadingController& controller,
+	const std::vector<WzString>& filenames,
+	gfx_api::texture_type textureType,
+	int maxWidth,
+	int maxHeight,
+	const GenerateDefaultTextureFunc& defaultTextureGenerator,
+	const std::string& debugName)
+{
+	auto imageLoadFilenames = imageLoadFilenamesFromInput(filenames);
+
+	TextureArrayLoadContext ctx{
+		imageLoadFilenames,
+		textureType,
+		maxWidth,
+		maxHeight,
+		defaultTextureGenerator,
+		debugName,
+	};
+
+	if (!prepareTextureArrayLoadContext(ctx))
+	{
+		co_return load_fail();
+	}
+
+	for (size_t layer = 0; layer < imageLoadFilenames.size(); ++layer)
+	{
+		if (!loadTextureArrayLayer(ctx, layer))
+		{
+			co_return load_fail();
+		}
+		co_await controller.yieldFrame();
+	}
+
+	co_return load_ok(finishTextureArrayLoad(ctx));
+}
+
+gfx_api::texture_array* gfx_api::context::loadTextureArrayFromFilesBlocking(
+	const std::vector<WzString>& filenames,
+	gfx_api::texture_type textureType,
+	int maxWidth,
+	int maxHeight,
+	const GenerateDefaultTextureFunc& defaultTextureGenerator,
+	const std::string& debugName)
+{
+	auto& controller = ResourceLoadingController::instance();
+	if (controller.isExecutingLoadingCoroutine())
+	{
+		return loadTextureArrayFromFilesNoYield(filenames, textureType, maxWidth, maxHeight, defaultTextureGenerator, debugName);
+	}
+
+	return controller.runTaskToCompletion(
+	    loadTextureArrayFromFiles(controller, filenames, textureType, maxWidth, maxHeight, defaultTextureGenerator, debugName),
+	    ResourceLoadingController::FramePolicy{ResourceLoadingController::FrameProcessingMode::ConsumeFrame, false},
+	    pumpBlockingResourceLoadWithoutUI).value_or(nullptr);
+}

--- a/lib/ivis_opengl/imd.h
+++ b/lib/ivis_opengl/imd.h
@@ -1,7 +1,9 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
 /*
 	This file is part of Warzone 2100.
 	Copyright (C) 1999-2004  Eidos Interactive
-	Copyright (C) 2005-2020  Warzone 2100 Project
+	Copyright (C) 2005-2026  Warzone 2100 Project (https://github.com/Warzone2100)
 
 	Warzone 2100 is free software; you can redistribute it and/or modify
 	it under the terms of the GNU General Public License as published by
@@ -21,10 +23,14 @@
 #define _imd_
 
 #include "lib/framework/wzstring.h"
+#include "lib/framework/loading_task_fwd.h"
 #include <functional>
+
+class ResourceLoadingController;
 
 struct iIMDShape;
 struct iIMDBaseShape;
+struct iIMDShapeTextures;
 
 #define PIE_NAME				"PIE"  // Pumpkin image export data file
 #define PIE_VER				2
@@ -60,6 +66,9 @@ void modelUpdateTilesetIdx(size_t tilesetIdx);
 
 // Enumerate over loaded models
 void enumerateLoadedModels(const std::function<void (const std::string& modelName, iIMDBaseShape& model)>& func);
+
+LoadingTask<> imdLoadLevelTexturesTask(ResourceLoadingController& controller, const iIMDShape& s, size_t tilesetIdx, iIMDShapeTextures& output);
+LoadingTask<> preloadAllModelTexturesTask(ResourceLoadingController& controller);
 
 /// Get filename of model pointer. This is really slow, so do not abuse for logging
 /// purposes, for example.

--- a/lib/ivis_opengl/imdload.cpp
+++ b/lib/ivis_opengl/imdload.cpp
@@ -1375,11 +1375,17 @@ LoadingTask<> preloadAllModelTexturesTask(ResourceLoadingController& controller)
 			if (!(co_await imdLoadLevelTexturesTask(controller, *pDisplayShape, currentTilesetIdx, *pDisplayShape->m_textures)))
 			{
 				++modelTextureLoadingFailures;
+				continue;
 			}
 			pDisplayShape->m_textures->initialized = true;
 		}
 
 		co_await controller.yieldFrame();
+	}
+
+	if (modelTextureLoadingFailures > 0)
+	{
+		co_return load_fail();
 	}
 
 	co_return load_ok();

--- a/lib/ivis_opengl/imdload.cpp
+++ b/lib/ivis_opengl/imdload.cpp
@@ -1,7 +1,9 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
 /*
 	This file is part of Warzone 2100.
 	Copyright (C) 1999-2004  Eidos Interactive
-	Copyright (C) 2005-2020  Warzone 2100 Project
+	Copyright (C) 2005-2026  Warzone 2100 Project (https://github.com/Warzone2100)
 
 	Warzone 2100 is free software; you can redistribute it and/or modify
 	it under the terms of the GNU General Public License as published by
@@ -31,10 +33,12 @@
 
 #include "lib/framework/frame.h"
 #include "lib/framework/string_ext.h"
-#include "lib/framework/frameresource.h"
 #include "lib/framework/fixedpoint.h"
 #include "lib/framework/file.h"
 #include "lib/framework/physfs_ext.h"
+#include "lib/framework/loading_task.h"
+#include "lib/framework/resource_loading_controller.h"
+#include "lib/framework/debug.h"
 #include "lib/ivis_opengl/piematrix.h"
 #include "lib/ivis_opengl/pienormalize.h"
 #include "lib/ivis_opengl/piestate.h"
@@ -1211,67 +1215,174 @@ static void _imd_determine_tileset_texture_files(iIMDShape& s, const LevelSettin
 	}
 }
 
-static bool _imd_load_level_textures(const iIMDShape& s, size_t tilesetIdx, iIMDShapeTextures& output)
+struct ImdResolvedLevelTextureFiles
+{
+	std::string diffuseFile;
+	optional<std::string> tcmaskFile;
+	optional<std::string> normalFile;
+	optional<std::string> specularFile;
+};
+
+static bool imdResolveLevelTextureFiles(const iIMDShape& s, size_t tilesetIdx, ImdResolvedLevelTextureFiles& resolved)
 {
 	const auto& defaultSettings = s.tilesetTextureFiles[0];
 	const auto& tilesetSettings = s.tilesetTextureFiles[tilesetIdx];
 
-	const WzString &filename = s.modelName;
 	const TilesetTextureFiles* pLevelSettingsToUseForTextures = (!tilesetSettings.texfile.empty()) ? &tilesetSettings : &defaultSettings;
-	if (!pLevelSettingsToUseForTextures->texfile.empty())
+	if (pLevelSettingsToUseForTextures->texfile.empty())
 	{
-		optional<size_t> texpage = iV_GetTexture(pLevelSettingsToUseForTextures->texfile.c_str(), gfx_api::texture_type::game_texture);
-		optional<size_t> tcmaskpage;
-		optional<size_t> normalpage;
-		optional<size_t> specpage;
+		return false;
+	}
 
-		ASSERT_OR_RETURN(false, texpage.has_value(), "%s could not load tex page %s", filename.toUtf8().c_str(), pLevelSettingsToUseForTextures->texfile.c_str());
+	resolved.diffuseFile = pLevelSettingsToUseForTextures->texfile;
 
-		const TilesetTextureFiles* pLevelSettingsToUseForTCMask = (!tilesetSettings.tcmaskfile.empty()) ? &tilesetSettings : &defaultSettings;
-		if (!pLevelSettingsToUseForTCMask->tcmaskfile.empty())
-		{
-			// load explicitly specified tcmask file
-			debug(LOG_TEXTURE, "Loading tcmask %s for %s", pLevelSettingsToUseForTCMask->tcmaskfile.c_str(), filename.toUtf8().c_str());
-			tcmaskpage = iV_GetTexture(pLevelSettingsToUseForTCMask->tcmaskfile.c_str(), gfx_api::texture_type::alpha_mask);
-			ASSERT_OR_RETURN(false, tcmaskpage.has_value(), "%s could not load tcmask %s", filename.toUtf8().c_str(), pLevelSettingsToUseForTCMask->tcmaskfile.c_str());
-		}
-		else
-		{
-			// BACKWARDS-COMPATIBILITY (PIE 2/3 compatibility)
-			// check if model should use team colour mask
-			if (s.flags & iV_IMD_TCMASK)
-			{
-				std::string tcmask_name = pie_MakeTexPageTCMaskName(pLevelSettingsToUseForTextures->texfile.c_str());
-				tcmask_name += ".png";
-				tcmaskpage = iV_GetTexture(tcmask_name.c_str(), gfx_api::texture_type::alpha_mask);
-				ASSERT_OR_RETURN(false, tcmaskpage.has_value(), "%s could not load tcmask %s", filename.toUtf8().c_str(), tcmask_name.c_str());
-			}
-		}
+	const TilesetTextureFiles* pLevelSettingsToUseForTCMask = (!tilesetSettings.tcmaskfile.empty()) ? &tilesetSettings : &defaultSettings;
+	if (!pLevelSettingsToUseForTCMask->tcmaskfile.empty())
+	{
+		resolved.tcmaskFile = pLevelSettingsToUseForTCMask->tcmaskfile;
+	}
+	else if (s.flags & iV_IMD_TCMASK)
+	{
+		// BACKWARDS-COMPATIBILITY (PIE 2/3 compatibility)
+		std::string tcmask_name = pie_MakeTexPageTCMaskName(pLevelSettingsToUseForTextures->texfile.c_str());
+		tcmask_name += ".png";
+		resolved.tcmaskFile = std::move(tcmask_name);
+	}
 
-		const TilesetTextureFiles* pLevelSettingsToUseForNormals = (!tilesetSettings.normalfile.empty()) ? &tilesetSettings : &defaultSettings;
-		if (!pLevelSettingsToUseForNormals->normalfile.empty())
-		{
-			debug(LOG_TEXTURE, "Loading normal map %s for %s", pLevelSettingsToUseForNormals->normalfile.c_str(), filename.toUtf8().c_str());
-			normalpage = iV_GetTexture(pLevelSettingsToUseForNormals->normalfile.c_str(), gfx_api::texture_type::normal_map);
-			ASSERT_OR_RETURN(false, normalpage.has_value(), "%s could not load tex page %s", filename.toUtf8().c_str(), pLevelSettingsToUseForNormals->normalfile.c_str());
-		}
+	const TilesetTextureFiles* pLevelSettingsToUseForNormals = (!tilesetSettings.normalfile.empty()) ? &tilesetSettings : &defaultSettings;
+	if (!pLevelSettingsToUseForNormals->normalfile.empty())
+	{
+		resolved.normalFile = pLevelSettingsToUseForNormals->normalfile;
+	}
 
-		const TilesetTextureFiles* pLevelSettingsToUseForSpecular = (!tilesetSettings.specfile.empty()) ? &tilesetSettings : &defaultSettings;
-		if (!pLevelSettingsToUseForSpecular->specfile.empty())
-		{
-			debug(LOG_TEXTURE, "Loading specular map %s for %s", pLevelSettingsToUseForSpecular->specfile.c_str(), filename.toUtf8().c_str());
-			specpage = iV_GetTexture(pLevelSettingsToUseForSpecular->specfile.c_str(), gfx_api::texture_type::specular_map);
-			ASSERT_OR_RETURN(false, specpage.has_value(), "%s could not load tex page %s", filename.toUtf8().c_str(), pLevelSettingsToUseForSpecular->specfile.c_str());
-		}
-
-		// assign tex pages and flags for this level
-		output.texpage = texpage.value();
-		output.tcmaskpage = (tcmaskpage.has_value()) ? tcmaskpage.value() : iV_TEX_INVALID;
-		output.normalpage = (normalpage.has_value()) ? normalpage.value() : iV_TEX_INVALID;
-		output.specularpage = (specpage.has_value()) ? specpage.value() : iV_TEX_INVALID;
+	const TilesetTextureFiles* pLevelSettingsToUseForSpecular = (!tilesetSettings.specfile.empty()) ? &tilesetSettings : &defaultSettings;
+	if (!pLevelSettingsToUseForSpecular->specfile.empty())
+	{
+		resolved.specularFile = pLevelSettingsToUseForSpecular->specfile;
 	}
 
 	return true;
+}
+
+static void imdAssignLoadedLevelTexturePages(iIMDShapeTextures& output, size_t texpage, const optional<size_t>& tcmaskpage, const optional<size_t>& normalpage, const optional<size_t>& specpage)
+{
+	output.texpage = texpage;
+	output.tcmaskpage = tcmaskpage.value_or(iV_TEX_INVALID);
+	output.normalpage = normalpage.value_or(iV_TEX_INVALID);
+	output.specularpage = specpage.value_or(iV_TEX_INVALID);
+}
+
+static bool _imd_load_level_textures(const iIMDShape& s, size_t tilesetIdx, iIMDShapeTextures& output)
+{
+	ImdResolvedLevelTextureFiles resolved;
+	if (!imdResolveLevelTextureFiles(s, tilesetIdx, resolved))
+	{
+		return true;
+	}
+
+	const WzString &filename = s.modelName;
+	optional<size_t> texpage = iV_GetTexture(resolved.diffuseFile.c_str(), gfx_api::texture_type::game_texture);
+	ASSERT_OR_RETURN(false, texpage.has_value(), "%s could not load tex page %s", filename.toUtf8().c_str(), resolved.diffuseFile.c_str());
+
+	optional<size_t> tcmaskpage;
+	if (resolved.tcmaskFile.has_value())
+	{
+		debug(LOG_TEXTURE, "Loading tcmask %s for %s", resolved.tcmaskFile->c_str(), filename.toUtf8().c_str());
+		tcmaskpage = iV_GetTexture(resolved.tcmaskFile->c_str(), gfx_api::texture_type::alpha_mask);
+		ASSERT_OR_RETURN(false, tcmaskpage.has_value(), "%s could not load tcmask %s", filename.toUtf8().c_str(), resolved.tcmaskFile->c_str());
+	}
+
+	optional<size_t> normalpage;
+	if (resolved.normalFile.has_value())
+	{
+		debug(LOG_TEXTURE, "Loading normal map %s for %s", resolved.normalFile->c_str(), filename.toUtf8().c_str());
+		normalpage = iV_GetTexture(resolved.normalFile->c_str(), gfx_api::texture_type::normal_map);
+		ASSERT_OR_RETURN(false, normalpage.has_value(), "%s could not load tex page %s", filename.toUtf8().c_str(), resolved.normalFile->c_str());
+	}
+
+	optional<size_t> specpage;
+	if (resolved.specularFile.has_value())
+	{
+		debug(LOG_TEXTURE, "Loading specular map %s for %s", resolved.specularFile->c_str(), filename.toUtf8().c_str());
+		specpage = iV_GetTexture(resolved.specularFile->c_str(), gfx_api::texture_type::specular_map);
+		ASSERT_OR_RETURN(false, specpage.has_value(), "%s could not load tex page %s", filename.toUtf8().c_str(), resolved.specularFile->c_str());
+	}
+
+	imdAssignLoadedLevelTexturePages(output, texpage.value(), tcmaskpage, normalpage, specpage);
+	return true;
+}
+
+LoadingTask<> imdLoadLevelTexturesTask(
+	ResourceLoadingController& controller,
+	const iIMDShape& s,
+	size_t tilesetIdx,
+	iIMDShapeTextures& output)
+{
+	ImdResolvedLevelTextureFiles resolved;
+	if (!imdResolveLevelTextureFiles(s, tilesetIdx, resolved))
+	{
+		co_return load_ok();
+	}
+
+	const WzString &filename = s.modelName;
+	const auto texpageResult = co_await iV_GetTextureTask(controller, resolved.diffuseFile.c_str(), gfx_api::texture_type::game_texture);
+	CORO_ASSERT_OR_RETURN(load_fail(), texpageResult.has_value() && texpageResult->has_value(), "%s could not load tex page %s", filename.toUtf8().c_str(), resolved.diffuseFile.c_str());
+	optional<size_t> texpage = texpageResult.value();
+	optional<size_t> tcmaskpage;
+	optional<size_t> normalpage;
+	optional<size_t> specpage;
+
+	if (resolved.tcmaskFile.has_value())
+	{
+		debug(LOG_TEXTURE, "Loading tcmask %s for %s", resolved.tcmaskFile->c_str(), filename.toUtf8().c_str());
+		const auto tcmaskpageResult = co_await iV_GetTextureTask(controller, resolved.tcmaskFile->c_str(), gfx_api::texture_type::alpha_mask);
+		CORO_ASSERT_OR_RETURN(load_fail(), tcmaskpageResult.has_value() && tcmaskpageResult->has_value(), "%s could not load tcmask %s", filename.toUtf8().c_str(), resolved.tcmaskFile->c_str());
+		tcmaskpage = tcmaskpageResult.value();
+	}
+
+	if (resolved.normalFile.has_value())
+	{
+		debug(LOG_TEXTURE, "Loading normal map %s for %s", resolved.normalFile->c_str(), filename.toUtf8().c_str());
+		const auto normalpageResult = co_await iV_GetTextureTask(controller, resolved.normalFile->c_str(), gfx_api::texture_type::normal_map);
+		CORO_ASSERT_OR_RETURN(load_fail(), normalpageResult.has_value() && normalpageResult->has_value(), "%s could not load tex page %s", filename.toUtf8().c_str(), resolved.normalFile->c_str());
+		normalpage = normalpageResult.value();
+	}
+
+	if (resolved.specularFile.has_value())
+	{
+		debug(LOG_TEXTURE, "Loading specular map %s for %s", resolved.specularFile->c_str(), filename.toUtf8().c_str());
+		const auto specpageResult = co_await iV_GetTextureTask(controller, resolved.specularFile->c_str(), gfx_api::texture_type::specular_map);
+		CORO_ASSERT_OR_RETURN(load_fail(), specpageResult.has_value() && specpageResult->has_value(), "%s could not load tex page %s", filename.toUtf8().c_str(), resolved.specularFile->c_str());
+		specpage = specpageResult.value();
+	}
+
+	imdAssignLoadedLevelTexturePages(output, texpage.value(), tcmaskpage, normalpage, specpage);
+	co_return load_ok();
+}
+
+LoadingTask<> preloadAllModelTexturesTask(ResourceLoadingController& controller)
+{
+	for (auto& keyvaluepair : models)
+	{
+		iIMDBaseShape& baseModel = *keyvaluepair.second.get();
+		for (iIMDShape *pDisplayShape = baseModel.mutableDisplayModel(); pDisplayShape != nullptr; pDisplayShape = pDisplayShape->next.get())
+		{
+			if (pDisplayShape->m_textures->initialized)
+			{
+				continue;
+			}
+
+			if (!(co_await imdLoadLevelTexturesTask(controller, *pDisplayShape, currentTilesetIdx, *pDisplayShape->m_textures)))
+			{
+				++modelTextureLoadingFailures;
+			}
+			pDisplayShape->m_textures->initialized = true;
+		}
+
+		co_await controller.yieldFrame();
+	}
+
+	co_return load_ok();
 }
 
 // performance hack

--- a/lib/ivis_opengl/ivisdef.h
+++ b/lib/ivis_opengl/ivisdef.h
@@ -1,7 +1,9 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
 /*
 	This file is part of Warzone 2100.
 	Copyright (C) 1999-2004  Eidos Interactive
-	Copyright (C) 2005-2020  Warzone 2100 Project
+	Copyright (C) 2005-2026  Warzone 2100 Project (https://github.com/Warzone2100)
 
 	Warzone 2100 is free software; you can redistribute it and/or modify
 	it under the terms of the GNU General Public License as published by
@@ -149,6 +151,7 @@ protected:
 	friend void modelReloadAllModelTextures();
 	friend bool debugReloadDisplayModelsForBaseModel(iIMDBaseShape& baseModel);
 	friend void debugReloadAllDisplayModels();
+	friend LoadingTask<> preloadAllModelTexturesTask(ResourceLoadingController& controller);
 
 	void replaceDisplayModel(std::unique_ptr<iIMDShape> newDisplayModel);
 	bool debugReloadDisplayModel(); // not to be called normally at runtime - intended for the script / graphics debugger panel
@@ -239,6 +242,7 @@ public:
 
 protected:
 	friend void modelUpdateTilesetIdx(size_t tilesetIdx);
+	friend LoadingTask<> preloadAllModelTexturesTask(ResourceLoadingController& controller);
 	void reloadTexturesIfLoaded();
 
 private:

--- a/lib/ivis_opengl/tex.cpp
+++ b/lib/ivis_opengl/tex.cpp
@@ -1,7 +1,9 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
 /*
 	This file is part of Warzone 2100.
 	Copyright (C) 1999-2004  Eidos Interactive
-	Copyright (C) 2005-2020  Warzone 2100 Project
+	Copyright (C) 2005-2026  Warzone 2100 Project (https://github.com/Warzone2100)
 
 	Warzone 2100 is free software; you can redistribute it and/or modify
 	it under the terms of the GNU General Public License as published by
@@ -19,7 +21,8 @@
 */
 
 #include "lib/framework/frame.h"
-#include "lib/framework/frameresource.h"
+#include "lib/framework/loading_task.h"
+#include "lib/framework/resource_loading_controller.h"
 
 #include "lib/ivis_opengl/ivisdef.h"
 #include "lib/ivis_opengl/piestate.h"
@@ -190,6 +193,9 @@ gfx_api::texture* loadTextureHandleGraphicsOverrides(const char *filename, gfx_a
 	return pTexture;
 }
 
+namespace
+{
+
 /** Retrieve the texture number for a given texture resource.
  *
  *  @note We keep textures in a separate data structure _TEX_PAGE apart from the
@@ -203,7 +209,7 @@ gfx_api::texture* loadTextureHandleGraphicsOverrides(const char *filename, gfx_a
  *  @return a non-negative index number for the texture, negative if no texture
  *          with the given filename could be found
  */
-optional<size_t> iV_GetTexture(const char *filename, gfx_api::texture_type textureType, int maxWidth /*= -1*/, int maxHeight /*= -1*/)
+optional<size_t> loadTexturePageSync(const char *filename, gfx_api::texture_type textureType, int maxWidth /*= -1*/, int maxHeight /*= -1*/)
 {
 	ASSERT(filename != nullptr, "filename must not be null");
 
@@ -222,8 +228,39 @@ optional<size_t> iV_GetTexture(const char *filename, gfx_api::texture_type textu
 	}
 
 	size_t page = pie_AddTexPage(pTexture, filename, textureType);
-	resDoResLoadCallback(); // ensure loading screen doesn't freeze when loading large images
 	return optional<size_t>(page);
+}
+
+} // namespace
+
+optional<size_t> iV_GetTexture(const char *filename, gfx_api::texture_type textureType, int maxWidth /*= -1*/, int maxHeight /*= -1*/)
+{
+	return loadTexturePageSync(filename, textureType, maxWidth, maxHeight);
+}
+
+LoadingTask<optional<size_t>> iV_GetTextureTask(
+	ResourceLoadingController& controller,
+	const char *filename,
+	gfx_api::texture_type textureType,
+	int maxWidth /*= -1*/,
+	int maxHeight /*= -1*/)
+{
+	ASSERT(filename != nullptr, "filename must not be null");
+
+	const auto it = _NAME_TO_TEX_PAGE_MAP.find(filename);
+	if (it != _NAME_TO_TEX_PAGE_MAP.end())
+	{
+		co_return load_ok(optional<size_t>(it->second));
+	}
+
+	optional<size_t> page = loadTexturePageSync(filename, textureType, maxWidth, maxHeight);
+	if (!page.has_value())
+	{
+		co_return load_fail();
+	}
+
+	co_await controller.yieldFrame();
+	co_return load_ok(page);
 }
 
 bool replaceTexture(const WzString &oldfile, const WzString &newfile)

--- a/lib/ivis_opengl/tex.h
+++ b/lib/ivis_opengl/tex.h
@@ -1,7 +1,9 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
 /*
 	This file is part of Warzone 2100.
 	Copyright (C) 1999-2004  Eidos Interactive
-	Copyright (C) 2005-2020  Warzone 2100 Project
+	Copyright (C) 2005-2026  Warzone 2100 Project (https://github.com/Warzone2100)
 
 	Warzone 2100 is free software; you can redistribute it and/or modify
 	it under the terms of the GNU General Public License as published by
@@ -45,6 +47,8 @@ void pie_AssignTexture(size_t page, gfx_api::texture* texture);
 //*************************************************************************
 
 optional<size_t> iV_GetTexture(const char *filename, gfx_api::texture_type textureType, int maxWidth = -1, int maxHeight = -1);
+
+LoadingTask<optional<size_t>> iV_GetTextureTask(ResourceLoadingController& controller, const char *filename, gfx_api::texture_type textureType, int maxWidth = -1, int maxHeight = -1);
 void iV_unloadImage(iV_Image *image);
 gfx_api::pixel_format iV_getPixelFormat(const iV_Image *image);
 

--- a/lib/ivis_opengl/tex.h
+++ b/lib/ivis_opengl/tex.h
@@ -23,6 +23,7 @@
 #define _tex_
 
 #include "lib/framework/wzstring.h"
+#include "lib/framework/loading_task_fwd.h"
 #include "gfx_api.h"
 #include "png_util.h"
 
@@ -47,6 +48,8 @@ void pie_AssignTexture(size_t page, gfx_api::texture* texture);
 //*************************************************************************
 
 optional<size_t> iV_GetTexture(const char *filename, gfx_api::texture_type textureType, int maxWidth = -1, int maxHeight = -1);
+
+class ResourceLoadingController;
 
 LoadingTask<optional<size_t>> iV_GetTextureTask(ResourceLoadingController& controller, const char *filename, gfx_api::texture_type textureType, int maxWidth = -1, int maxHeight = -1);
 void iV_unloadImage(iV_Image *image);

--- a/lib/sdl/main_sdl.cpp
+++ b/lib/sdl/main_sdl.cpp
@@ -4013,6 +4013,7 @@ void wzMainEventLoop(std::function<void()> onShutdown)
 
 void wzPumpEventsWhileLoading()
 {
+	// SDL backend implementation of the platform hook documented in wzapp.h.
 	SDL_PumpEvents();
 }
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2666,7 +2666,8 @@ LoadingTask<> loadGameCleanupOnFailure(ResourceLoadingController& controller, co
 	freeAllStructs(gameWorld);
 	freeAllFeatures(gameWorld);
 	droidTemplateShutDown();
-	gameWorld.map.tiles = nullptr;
+	gwShutDown(gameWorld.map);
+	gameWorld.map = {};
 
 	/* Start the game clock */
 	gameTimeStart();
@@ -3045,6 +3046,8 @@ LoadingTask<> loadGame(ResourceLoadingController& controller, const GameLoadDeta
 		//load in the map file
 		aFileName[fileExten] = '\0';
 		strcat(aFileName, "mission.map");
+		gwShutDown(mission.gameWorld.map);
+		mission.gameWorld.map = {};
 		if (!(co_await mapLoad(controller, aFileName, mission.gameWorld.map)))
 		{
 			debug(LOG_ERROR, "Failed with: %s", aFileName);
@@ -3154,7 +3157,8 @@ LoadingTask<> loadGame(ResourceLoadingController& controller, const GameLoadDeta
 	//if Campaign Expand then don't load in another map
 	if (gameType != GTYPE_SCENARIO_EXPAND)
 	{
-		gameWorld.map.tiles = nullptr;
+		gwShutDown(gameWorld.map);
+		gameWorld.map = {};
 		// load in the map file
 		if (!data)
 		{

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1,7 +1,9 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
 /*
 	This file is part of Warzone 2100.
 	Copyright (C) 1999-2004  Eidos Interactive
-	Copyright (C) 2005-2021  Warzone 2100 Project
+	Copyright (C) 2005-2026  Warzone 2100 Project (https://github.com/Warzone2100)
 
 	Warzone 2100 is free software; you can redistribute it and/or modify
 	it under the terms of the GNU General Public License as published by
@@ -59,6 +61,7 @@
 #include "power.h"
 #include "projectile.h"
 #include "loadsave.h"
+#include "lib/framework/resource_loading_controller.h"
 #include "text.h"
 #include "message.h"
 #include "hci.h"
@@ -103,6 +106,7 @@
 #include "screens/guidescreen.h"
 #include "game_world.h"
 #include <array>
+#include "lib/framework/loading_task.h"
 
 #include "wzphysfszipioprovider.h"
 #include <wzmaplib/map_package.h>
@@ -2240,7 +2244,7 @@ static bool IsScenario;
  */
 /***************************************************************************/
 static bool gameLoadV7(PHYSFS_file *fileHandle, nonstd::optional<nlohmann::json>&);
-static bool gameLoadV(PHYSFS_file *fileHandle, unsigned int version, nonstd::optional<nlohmann::json>&);
+static LoadingTask<> gameLoadV(ResourceLoadingController& controller, PHYSFS_file *fileHandle, unsigned int version, nonstd::optional<nlohmann::json>&);
 static bool loadMainFile(const std::string &fileName);
 static bool loadMainFileFinal(const std::string &fileName);
 static bool writeMainFile(const std::string &fileName, SDWORD saveType);
@@ -2296,7 +2300,7 @@ static bool loadSaveGuideTopics(const char *pFileName);
 
 static bool loadRulesetJson();
 
-static bool gameLoad(const char *fileName);
+static LoadingTask<> gameLoad(ResourceLoadingController& controller, const char *fileName);
 
 /* set the global scroll values to use for the save game */
 static void setMapScroll(WorldMapState& mapState);
@@ -2310,9 +2314,9 @@ static char *getSaveStructNameV19(SAVE_STRUCTURE_V17 *psSaveStructure)
 so can be called in levLoadData when starting a game from a load save game*/
 
 // -----------------------------------------------------------------------------------------
-bool loadGameInit(const GameLoadDetails& gameToLoad)
+LoadingTask<> loadGameInit(ResourceLoadingController& controller, const GameLoadDetails& gameToLoad)
 {
-	ASSERT_OR_RETURN(false, !gameToLoad.filePath.empty(), "filePath is empty??");
+	CORO_ASSERT_OR_RETURN(load_fail(), !gameToLoad.filePath.empty(), "filePath is empty??");
 
 	if (gameToLoad.loadType == GameLoadDetails::GameLoadType::MapPackage)
 	{
@@ -2321,7 +2325,7 @@ bool loadGameInit(const GameLoadDetails& gameToLoad)
 		{
 			// Failed to load map package
 			debug(LOG_ERROR, "Failed to load map package: %s", gameToLoad.filePath.c_str());
-			return false;
+			co_return load_fail();
 		}
 
 		loadRulesetJson();
@@ -2339,14 +2343,14 @@ bool loadGameInit(const GameLoadDetails& gameToLoad)
 			debug(LOG_FATAL, "Should not be called with gameType GTYPE_SAVE_START");
 		}
 		IsScenario = true;
-		return true;
+		co_return load_ok();
 	}
 
 	// Otherwise, for level load or savegame load cases:
 
 	if (strEndsWith(gameToLoad.filePath, ".wzrp"))
 	{
-		ASSERT_OR_RETURN(false, (gameToLoad.loadType == GameLoadDetails::GameLoadType::UserSaveGame), "Invalid load type");
+		CORO_ASSERT_OR_RETURN(load_fail(), (gameToLoad.loadType == GameLoadDetails::GameLoadType::UserSaveGame), "Invalid load type");
 
 		SetGameMode(GS_TITLE_SCREEN); // hack - the caller sets this to GS_NORMAL but we actually want to proceed with normal startGameLoop
 
@@ -2354,24 +2358,23 @@ bool loadGameInit(const GameLoadDetails& gameToLoad)
 		WZGameReplayOptionsHandler optionsHandler;
 		if (!NETloadReplay(gameToLoad.filePath, optionsHandler))
 		{
-			return false;
+			co_return load_fail();
 		}
 
 		bMultiPlayer = true;
 		bMultiMessages = true;
 		changeTitleMode(STARTGAME);
 	}
-	else if (!gameLoad(gameToLoad.filePath.c_str()))
-	{
+	else if (!(co_await gameLoad(controller, gameToLoad.filePath.c_str()))) {
 		debug(LOG_ERROR, "Corrupted / unsupported savegame file %s, Unable to load!", gameToLoad.filePath.c_str());
 		// NOTE: why do we start the game clock on a *failed* load?
 		// Start the game clock
 		gameTimeStart();
 
-		return false;
+		co_return load_fail();
 	}
 
-	return true;
+	co_return load_ok();
 }
 
 
@@ -2648,9 +2651,34 @@ const WzMap::GamInfo* GameLoadDetails::getGamInfoFromPackage() const
 	return nullptr; // silence compiler warning
 }
 
+namespace
+{
+
+LoadingTask<> loadGameCleanupOnFailure(ResourceLoadingController& controller, const GameLoadDetails& gameToLoad, bool keepObjects, bool freeMem)
+{
+	const bool		UserSaveGame = (gameToLoad.loadType == GameLoadDetails::GameLoadType::UserSaveGame);
+
+	debug(LOG_ERROR, "Game load failed for %s, FS:%s, params=%s,%s,%s", gameToLoad.filePath.c_str(), WZ_PHYSFS_getRealDir_String(gameToLoad.filePath.c_str()).c_str(),
+	keepObjects ? "true" : "false", freeMem ? "true" : "false", UserSaveGame ? "true" : "false");
+
+	/* Clear all the objects off the map and free up the map memory */
+	freeAllDroids(gameWorld);
+	freeAllStructs(gameWorld);
+	freeAllFeatures(gameWorld);
+	droidTemplateShutDown();
+	gameWorld.map.tiles = nullptr;
+
+	/* Start the game clock */
+	gameTimeStart();
+
+	co_return load_fail();
+}
+
+} // anonymous namespace
+
 // -----------------------------------------------------------------------------------------
 // UserSaveGame ... this is true when you are loading a players save game
-bool loadGame(const GameLoadDetails& gameToLoad, bool keepObjects, bool freeMem)
+LoadingTask<> loadGame(ResourceLoadingController& controller, const GameLoadDetails& gameToLoad, bool keepObjects, bool freeMem)
 {
 	std::shared_ptr<WzMap::Map> data;
 	std::map<WzString, PerPlayerDroidLists *> droidMap;
@@ -2892,6 +2920,8 @@ bool loadGame(const GameLoadDetails& gameToLoad, bool keepObjects, bool freeMem)
 	sstrcpy(aFileName, gameToLoad.getMapFolderPath().c_str());
 	fileExten = strlen(aFileName);
 
+	co_await controller.yieldFrame();
+
 	// construct the WzMap object for loading map data
 	aFileName[fileExten] = '\0';
 	data = gameToLoad.getMap(gameRandU32());
@@ -2908,13 +2938,13 @@ bool loadGame(const GameLoadDetails& gameToLoad, bool keepObjects, bool freeMem)
 		if (!data)
 		{
 			debug(LOG_ERROR, "Failed to load map from path: %s", aFileName);
-			return false;
+			co_return load_fail();
 		}
 		//load the terrain type data
 		if (!loadTerrainTypeMap(data->mapTerrainTypes()))
 		{
 			debug(LOG_ERROR, "Failed loading terrain types: %s/ttypes.ttp", aFileName);
-			goto error;
+			co_return co_await loadGameCleanupOnFailure(controller, gameToLoad, keepObjects, freeMem);
 		}
 	}
 
@@ -2967,7 +2997,7 @@ bool loadGame(const GameLoadDetails& gameToLoad, bool keepObjects, bool freeMem)
 		if (!loadSaveTemplate(aFileName))
 		{
 			debug(LOG_ERROR, "Failed with: %s", aFileName);
-			goto error;
+			co_return co_await loadGameCleanupOnFailure(controller, gameToLoad, keepObjects, freeMem);
 		}
 	}
 
@@ -2980,7 +3010,7 @@ bool loadGame(const GameLoadDetails& gameToLoad, bool keepObjects, bool freeMem)
 		if (!loadSaveLimits(aFileName))
 		{
 			debug(LOG_ERROR, "failed to load %s", aFileName);
-			goto error;
+			co_return co_await loadGameCleanupOnFailure(controller, gameToLoad, keepObjects, freeMem);
 		}
 	}
 
@@ -2993,9 +3023,11 @@ bool loadGame(const GameLoadDetails& gameToLoad, bool keepObjects, bool freeMem)
 		if (!loadSaveResearch(aFileName))
 		{
 			debug(LOG_ERROR, "Failed to load research data from %s", aFileName);
-			goto error;
+			co_return co_await loadGameCleanupOnFailure(controller, gameToLoad, keepObjects, freeMem);
 		}
 	}
+
+	co_await controller.yieldFrame();
 
 	if (saveGameOnMission && UserSaveGame)
 	{
@@ -3013,10 +3045,10 @@ bool loadGame(const GameLoadDetails& gameToLoad, bool keepObjects, bool freeMem)
 		//load in the map file
 		aFileName[fileExten] = '\0';
 		strcat(aFileName, "mission.map");
-		if (!mapLoad(aFileName, mission.gameWorld.map))
+		if (!(co_await mapLoad(controller, aFileName, mission.gameWorld.map)))
 		{
 			debug(LOG_ERROR, "Failed with: %s", aFileName);
-			return false;
+			co_return load_fail();
 		}
 
 		//load in the visibility file
@@ -3027,7 +3059,7 @@ bool loadGame(const GameLoadDetails& gameToLoad, bool keepObjects, bool freeMem)
 		if (!readVisibilityData(aFileName, mission.gameWorld.map))
 		{
 			debug(LOG_ERROR, "Failed with: %s", aFileName);
-			goto error;
+			co_return co_await loadGameCleanupOnFailure(controller, gameToLoad, keepObjects, freeMem);
 		}
 
 		// reload the objects that were in the mission list
@@ -3045,12 +3077,12 @@ bool loadGame(const GameLoadDetails& gameToLoad, bool keepObjects, bool freeMem)
 			if (!loadFileToBuffer(aFileName, pFileData, FILE_LOAD_BUFFER_SIZE, &fileSize))
 			{
 				debug(LOG_ERROR, "Failed with: %s", aFileName);
-				goto error;
+				co_return co_await loadGameCleanupOnFailure(controller, gameToLoad, keepObjects, freeMem);
 			}
 			if (!loadSaveFeature(pFileData, fileSize, mission.gameWorld))
 			{
 				debug(LOG_ERROR, "Failed with: %s", aFileName);
-				goto error;
+				co_return co_await loadGameCleanupOnFailure(controller, gameToLoad, keepObjects, freeMem);
 			}
 		}
 
@@ -3068,13 +3100,13 @@ bool loadGame(const GameLoadDetails& gameToLoad, bool keepObjects, bool freeMem)
 			if (!loadFileToBuffer(aFileName, pFileData, FILE_LOAD_BUFFER_SIZE, &fileSize))
 			{
 				debug(LOG_ERROR, "Failed with: %s", aFileName);
-				goto error;
+				co_return co_await loadGameCleanupOnFailure(controller, gameToLoad, keepObjects, freeMem);
 			}
 			//load the data into apsStructLists
 			if (!loadSaveStructure(pFileData, fileSize, mission.gameWorld))
 			{
 				debug(LOG_ERROR, "Failed with: %s", aFileName);
-				goto error;
+				co_return co_await loadGameCleanupOnFailure(controller, gameToLoad, keepObjects, freeMem);
 			}
 		}
 		else
@@ -3127,13 +3159,13 @@ bool loadGame(const GameLoadDetails& gameToLoad, bool keepObjects, bool freeMem)
 		if (!data)
 		{
 			debug(LOG_ERROR, "Failed to load map from path: %s", aFileName);
-			return false;
+			co_return load_fail();
 		}
 		auto mapData = data->mapData();
 		if (!mapData)
 		{
 			debug(LOG_ERROR, "Failed to load map data from path: %s", aFileName);
-			return false;
+			co_return load_fail();
 		}
 		if (data->wasScriptGenerated())
 		{
@@ -3143,11 +3175,16 @@ bool loadGame(const GameLoadDetails& gameToLoad, bool keepObjects, bool freeMem)
 			syncDebug("crc(droids) = 0x%08x", data->crcSumDroids(0));
 			syncDebug("crc(features) = 0x%08x", data->crcSumFeatures(0));
 		}
-		if (!mapLoadFromWzMapData(mapData, gameWorld.map))
+
+		co_await controller.yieldFrame();
+
+		if (!(co_await mapLoadFromWzMapData(controller, mapData, gameWorld.map)))
 		{
 			debug(LOG_ERROR, "Failed to process map data from path: %s", aFileName);
-			return false;
+			co_return load_fail();
 		}
+
+		co_await controller.yieldFrame();
 	}
 
 	// FIXME THIS FILE IS A HUGE MESS, this code should probably appear at another position...
@@ -3165,7 +3202,7 @@ bool loadGame(const GameLoadDetails& gameToLoad, bool keepObjects, bool freeMem)
 			if (!readFXData(aFileName, gameWorld.map))
 			{
 				debug(LOG_ERROR, "Failed with: %s", aFileName);
-				goto error;
+				co_return co_await loadGameCleanupOnFailure(controller, gameToLoad, keepObjects, freeMem);
 			}
 		}
 	}
@@ -3203,7 +3240,7 @@ bool loadGame(const GameLoadDetails& gameToLoad, bool keepObjects, bool freeMem)
 			{
 				aFileName[fileExten] = '\0';
 				debug(LOG_ERROR, "Failed to load map droid init from map directory: %s", aFileName);
-				goto error;
+				co_return co_await loadGameCleanupOnFailure(controller, gameToLoad, keepObjects, freeMem);
 			}
 		}
 		else
@@ -3225,7 +3262,7 @@ bool loadGame(const GameLoadDetails& gameToLoad, bool keepObjects, bool freeMem)
 		if (!loadSaveDroid(aFileName, gameWorld, gameWorld.objects.droids))
 		{
 			debug(LOG_ERROR, "failed to load %s", aFileName);
-			goto error;
+			co_return co_await loadGameCleanupOnFailure(controller, gameToLoad, keepObjects, freeMem);
 		}
 		droidMap[aFileName] = &gameWorld.objects.droids;	// load pointers later
 
@@ -3271,6 +3308,8 @@ bool loadGame(const GameLoadDetails& gameToLoad, bool keepObjects, bool freeMem)
 		}
 	}
 
+	co_await controller.yieldFrame();
+
 	//load in the features -do before the structures
 	aFileName[fileExten] = '\0';
 	if (!UserSaveGame)
@@ -3279,7 +3318,7 @@ bool loadGame(const GameLoadDetails& gameToLoad, bool keepObjects, bool freeMem)
 		if (!loadWzMapFeature(*(data.get()), fixedMapIdToGeneratedId))
 		{
 			debug(LOG_ERROR, "Failed to load map feature init from map directory: %s", aFileName);
-			goto error;
+			co_return co_await loadGameCleanupOnFailure(controller, gameToLoad, keepObjects, freeMem);
 		}
 	}
 	else
@@ -3289,9 +3328,11 @@ bool loadGame(const GameLoadDetails& gameToLoad, bool keepObjects, bool freeMem)
 		if (!loadSaveFeature2(aFileName, gameWorld))
 		{
 			debug(LOG_ERROR, "Failed with: %s", aFileName);
-			goto error;
+			co_return co_await loadGameCleanupOnFailure(controller, gameToLoad, keepObjects, freeMem);
 		}
 	}
+
+	co_await controller.yieldFrame();
 
 	//load in the structures
 	initStructLimits();
@@ -3308,7 +3349,7 @@ bool loadGame(const GameLoadDetails& gameToLoad, bool keepObjects, bool freeMem)
 		{
 			aFileName[fileExten] = '\0';
 			debug(LOG_ERROR, "Failed to load map structure init from map directory: %s", aFileName);
-			goto error;
+			co_return co_await loadGameCleanupOnFailure(controller, gameToLoad, keepObjects, freeMem);
 		}
 		if (game.type != LEVEL_TYPE::CAMPAIGN)
 		{
@@ -3320,10 +3361,12 @@ bool loadGame(const GameLoadDetails& gameToLoad, bool keepObjects, bool freeMem)
 		if (!loadSaveStructure2(aFileName, gameWorld))
 		{
 			debug(LOG_ERROR, "Failed with: %s", aFileName);
-			goto error;
+			co_return co_await loadGameCleanupOnFailure(controller, gameToLoad, keepObjects, freeMem);
 		}
 		structMap[aFileName] = &gameWorld.objects.structures;
 	}
+
+	co_await controller.yieldFrame();
 
 	//if user save game then load up the current level for structs and components
 	if (gameType == GTYPE_SAVE_START || gameType == GTYPE_SAVE_MIDMISSION)
@@ -3334,7 +3377,7 @@ bool loadGame(const GameLoadDetails& gameToLoad, bool keepObjects, bool freeMem)
 		if (!loadSaveCompList(aFileName))
 		{
 			debug(LOG_ERROR, "failed to load %s", aFileName);
-			goto error;
+			co_return co_await loadGameCleanupOnFailure(controller, gameToLoad, keepObjects, freeMem);
 		}
 		//load in the structure type list file
 		aFileName[fileExten] = '\0';
@@ -3342,7 +3385,7 @@ bool loadGame(const GameLoadDetails& gameToLoad, bool keepObjects, bool freeMem)
 		if (!loadSaveStructTypeList(aFileName))
 		{
 			debug(LOG_ERROR, "failed to load %s", aFileName);
-			goto error;
+			co_return co_await loadGameCleanupOnFailure(controller, gameToLoad, keepObjects, freeMem);
 		}
 
 		// load in the game guide topics
@@ -3369,7 +3412,7 @@ bool loadGame(const GameLoadDetails& gameToLoad, bool keepObjects, bool freeMem)
 			if (!readVisibilityData(aFileName, gameWorld.map))
 			{
 				debug(LOG_ERROR, "Failed with: %s", aFileName);
-				goto error;
+				co_return co_await loadGameCleanupOnFailure(controller, gameToLoad, keepObjects, freeMem);
 			}
 		}
 	}
@@ -3387,7 +3430,7 @@ bool loadGame(const GameLoadDetails& gameToLoad, bool keepObjects, bool freeMem)
 			if (!readScoreData(aFileName))
 			{
 				debug(LOG_ERROR, "Failed with: %s", aFileName);
-				goto error;
+				co_return co_await loadGameCleanupOnFailure(controller, gameToLoad, keepObjects, freeMem);
 			}
 		}
 	}
@@ -3405,7 +3448,7 @@ bool loadGame(const GameLoadDetails& gameToLoad, bool keepObjects, bool freeMem)
 			if (!readFiresupportDesignators(aFileName))
 			{
 				debug(LOG_ERROR, "Failed with: %s", aFileName);
-				goto error;
+				co_return co_await loadGameCleanupOnFailure(controller, gameToLoad, keepObjects, freeMem);
 			}
 		}
 	}
@@ -3486,6 +3529,8 @@ bool loadGame(const GameLoadDetails& gameToLoad, bool keepObjects, bool freeMem)
 	//set up the mission countdown flag
 	setMissionCountDown();
 
+	co_await controller.yieldFrame();
+
 	/* Start the game clock */
 	gameTimeStart();
 
@@ -3518,27 +3563,7 @@ bool loadGame(const GameLoadDetails& gameToLoad, bool keepObjects, bool freeMem)
 
 	debug(LOG_NEVER, "Done loading");
 
-	return true;
-
-error:
-	debug(LOG_ERROR, "Game load failed for %s, FS:%s, params=%s,%s,%s", gameToLoad.filePath.c_str(), WZ_PHYSFS_getRealDir_String(gameToLoad.filePath.c_str()).c_str(),
-	      keepObjects ? "true" : "false", freeMem ? "true" : "false", UserSaveGame ? "true" : "false");
-
-	/* Clear all the objects off the map and free up the map memory */
-	freeAllDroids(mission.gameWorld);
-	freeAllStructs(mission.gameWorld);
-	freeAllFeatures(mission.gameWorld);
-	mission.gameWorld = {};
-	freeAllDroids(gameWorld);
-	freeAllStructs(gameWorld);
-	freeAllFeatures(gameWorld);
-	droidTemplateShutDown();
-	gameWorld = {};
-
-	/* Start the game clock */
-	gameTimeStart();
-
-	return false;
+	co_return load_ok();
 }
 // -----------------------------------------------------------------------------------------
 
@@ -3897,7 +3922,7 @@ static bool loadRulesetJson()
 }
 
 // -----------------------------------------------------------------------------------------
-static bool gameLoad(const char *fileName)
+static LoadingTask<> gameLoad(ResourceLoadingController& controller, const char *fileName)
 {
 	char CurrentFileName[PATH_MAX];
 	strcpy(CurrentFileName, fileName);
@@ -3913,7 +3938,7 @@ static bool gameLoad(const char *fileName)
 		{
 			debug(LOG_ERROR, "gameLoad: error while reading header from file (%s): %s", fileName, WZ_PHYSFS_getLastError());
 			PHYSFS_close(fileHandle);
-			return false;
+			co_return load_fail();
 		}
 	}
 	else if (gamJsonSave.has_value())
@@ -3929,7 +3954,7 @@ static bool gameLoad(const char *fileName)
 	if (!fileHandle && !gamJsonSave.has_value())
 	{
 		// Failure to open the file is a failure to load the specified savegame
-		return false;
+		co_return load_fail();
 	}
 	debug(LOG_WZ, "gameLoad");
 
@@ -3944,7 +3969,7 @@ static bool gameLoad(const char *fileName)
 
 		PHYSFS_close(fileHandle);
 
-		return false;
+		co_return load_fail();
 	}
 
 	debug(LOG_NEVER, "gl .gam file is version %u\n", fileHeader.version);
@@ -3962,13 +3987,13 @@ static bool gameLoad(const char *fileName)
 		debug(LOG_ERROR, "gameLoad: unsupported save format version %d", fileHeader.version);
 		PHYSFS_close(fileHandle);
 
-		return false;
+		co_return load_fail();
 	}
 	else if (fileHeader.version < VERSION_9)
 	{
 		bool retVal = gameLoadV7(fileHandle, gamJsonSave);
 		PHYSFS_close(fileHandle);
-		return retVal;
+		co_return retVal ? load_ok() : load_fail();
 	}
 	else if (fileHeader.version <= CURRENT_VERSION_NUM)
 	{
@@ -3985,19 +4010,19 @@ static bool gameLoad(const char *fileName)
 		CurrentFileName[strlen(CurrentFileName) - 4] = '\0';
 		loadMainFile(std::string(CurrentFileName) + "/main.json");
 
-		bool retVal = gameLoadV(fileHandle, fileHeader.version, gamJsonSave);
+		const LoadResult<> retVal = co_await gameLoadV(controller, fileHandle, fileHeader.version, gamJsonSave);
 		PHYSFS_close(fileHandle);
 
 		loadMainFileFinal(std::string(CurrentFileName) + "/main.json");
 
-		return retVal;
+		co_return retVal;
 	}
 	else
 	{
 		debug(LOG_ERROR, "Unsupported main save format version %u", fileHeader.version);
 		PHYSFS_close(fileHandle);
 
-		return false;
+		co_return load_fail();
 	}
 }
 
@@ -4184,7 +4209,7 @@ bool gameLoadV7(PHYSFS_file *fileHandle, nonstd::optional<nlohmann::json> &gamJs
 
 // -----------------------------------------------------------------------------------------
 /* non specific version of a save game */
-bool gameLoadV(PHYSFS_file *fileHandle, unsigned int version, nonstd::optional<nlohmann::json> &gamJson)
+LoadingTask<> gameLoadV(ResourceLoadingController& controller, PHYSFS_file *fileHandle, unsigned int version, nonstd::optional<nlohmann::json> &gamJson)
 {
 	unsigned int i, j;
 	static	SAVE_POWER	powerSaved[MAX_PLAYERS];
@@ -4201,7 +4226,7 @@ bool gameLoadV(PHYSFS_file *fileHandle, unsigned int version, nonstd::optional<n
 		{
 			debug(LOG_ERROR, "gameLoadV: error while reading file (with version number %u): %s", version, WZ_PHYSFS_getLastError());
 
-			return false;
+			co_return load_fail();
 		}
 	}
 	else if (version == VERSION_11)
@@ -4210,7 +4235,7 @@ bool gameLoadV(PHYSFS_file *fileHandle, unsigned int version, nonstd::optional<n
 		{
 			debug(LOG_ERROR, "gameLoadV: error while reading file (with version number %u): %s", version, WZ_PHYSFS_getLastError());
 
-			return false;
+			co_return load_fail();
 		}
 	}
 	else if (version <= VERSION_12)
@@ -4219,7 +4244,7 @@ bool gameLoadV(PHYSFS_file *fileHandle, unsigned int version, nonstd::optional<n
 		{
 			debug(LOG_ERROR, "gameLoadV: error while reading file (with version number %u): %s", version, WZ_PHYSFS_getLastError());
 
-			return false;
+			co_return load_fail();
 		}
 	}
 	else if (version <= VERSION_14)
@@ -4228,7 +4253,7 @@ bool gameLoadV(PHYSFS_file *fileHandle, unsigned int version, nonstd::optional<n
 		{
 			debug(LOG_ERROR, "gameLoadV: error while reading file (with version number %u): %s", version, WZ_PHYSFS_getLastError());
 
-			return false;
+			co_return load_fail();
 		}
 	}
 	else if (version <= VERSION_15)
@@ -4237,7 +4262,7 @@ bool gameLoadV(PHYSFS_file *fileHandle, unsigned int version, nonstd::optional<n
 		{
 			debug(LOG_ERROR, "gameLoadV: error while reading file (with version number %u): %s", version, WZ_PHYSFS_getLastError());
 
-			return false;
+			co_return load_fail();
 		}
 	}
 	else if (version <= VERSION_16)
@@ -4246,7 +4271,7 @@ bool gameLoadV(PHYSFS_file *fileHandle, unsigned int version, nonstd::optional<n
 		{
 			debug(LOG_ERROR, "gameLoadV: error while reading file (with version number %u): %s", version, WZ_PHYSFS_getLastError());
 
-			return false;
+			co_return load_fail();
 		}
 	}
 	else if (version <= VERSION_17)
@@ -4255,7 +4280,7 @@ bool gameLoadV(PHYSFS_file *fileHandle, unsigned int version, nonstd::optional<n
 		{
 			debug(LOG_ERROR, "gameLoadV: error while reading file (with version number %u): %s", version, WZ_PHYSFS_getLastError());
 
-			return false;
+			co_return load_fail();
 		}
 	}
 	else if (version <= VERSION_18)
@@ -4264,7 +4289,7 @@ bool gameLoadV(PHYSFS_file *fileHandle, unsigned int version, nonstd::optional<n
 		{
 			debug(LOG_ERROR, "gameLoadV: error while reading file (with version number %u): %s", version, WZ_PHYSFS_getLastError());
 
-			return false;
+			co_return load_fail();
 		}
 	}
 	else if (version <= VERSION_19)
@@ -4273,7 +4298,7 @@ bool gameLoadV(PHYSFS_file *fileHandle, unsigned int version, nonstd::optional<n
 		{
 			debug(LOG_ERROR, "gameLoadV: error while reading file (with version number %u): %s", version, WZ_PHYSFS_getLastError());
 
-			return false;
+			co_return load_fail();
 		}
 	}
 	else if (version <= VERSION_21)
@@ -4282,7 +4307,7 @@ bool gameLoadV(PHYSFS_file *fileHandle, unsigned int version, nonstd::optional<n
 		{
 			debug(LOG_ERROR, "gameLoadV: error while reading file (with version number %u): %s", version, WZ_PHYSFS_getLastError());
 
-			return false;
+			co_return load_fail();
 		}
 	}
 	else if (version <= VERSION_23)
@@ -4291,7 +4316,7 @@ bool gameLoadV(PHYSFS_file *fileHandle, unsigned int version, nonstd::optional<n
 		{
 			debug(LOG_ERROR, "gameLoadV: error while reading file (with version number %u): %s", version, WZ_PHYSFS_getLastError());
 
-			return false;
+			co_return load_fail();
 		}
 	}
 	else if (version <= VERSION_26)
@@ -4300,7 +4325,7 @@ bool gameLoadV(PHYSFS_file *fileHandle, unsigned int version, nonstd::optional<n
 		{
 			debug(LOG_ERROR, "gameLoadV: error while reading file (with version number %u): %s", version, WZ_PHYSFS_getLastError());
 
-			return false;
+			co_return load_fail();
 		}
 	}
 	else if (version <= VERSION_28)
@@ -4309,7 +4334,7 @@ bool gameLoadV(PHYSFS_file *fileHandle, unsigned int version, nonstd::optional<n
 		{
 			debug(LOG_ERROR, "gameLoadV: error while reading file (with version number %u): %s", version, WZ_PHYSFS_getLastError());
 
-			return false;
+			co_return load_fail();
 		}
 	}
 	else if (version <= VERSION_29)
@@ -4318,7 +4343,7 @@ bool gameLoadV(PHYSFS_file *fileHandle, unsigned int version, nonstd::optional<n
 		{
 			debug(LOG_ERROR, "gameLoadV: error while reading file (with version number %u): %s", version, WZ_PHYSFS_getLastError());
 
-			return false;
+			co_return load_fail();
 		}
 	}
 	else if (version <= VERSION_30)
@@ -4327,7 +4352,7 @@ bool gameLoadV(PHYSFS_file *fileHandle, unsigned int version, nonstd::optional<n
 		{
 			debug(LOG_ERROR, "gameLoadV: error while reading file (with version number %u): %s", version, WZ_PHYSFS_getLastError());
 
-			return false;
+			co_return load_fail();
 		}
 	}
 	else if (version <= VERSION_32)
@@ -4336,7 +4361,7 @@ bool gameLoadV(PHYSFS_file *fileHandle, unsigned int version, nonstd::optional<n
 		{
 			debug(LOG_ERROR, "gameLoadV: error while reading file (with version number %u): %s", version, WZ_PHYSFS_getLastError());
 
-			return false;
+			co_return load_fail();
 		}
 	}
 	else if (version <= VERSION_33)
@@ -4345,7 +4370,7 @@ bool gameLoadV(PHYSFS_file *fileHandle, unsigned int version, nonstd::optional<n
 		{
 			debug(LOG_ERROR, "gameLoadV: error while reading file (with version number %u): %s", version, WZ_PHYSFS_getLastError());
 
-			return false;
+			co_return load_fail();
 		}
 	}
 	else if (version <= VERSION_34)
@@ -4354,13 +4379,13 @@ bool gameLoadV(PHYSFS_file *fileHandle, unsigned int version, nonstd::optional<n
 		{
 			debug(LOG_ERROR, "gameLoadV: error while reading file (with version number %u): %s", version, WZ_PHYSFS_getLastError());
 
-			return false;
+			co_return load_fail();
 		}
 	}
 	else if (version < VERSION_39)
 	{
 		debug(LOG_ERROR, "Unsupported savegame version");
-		return false;
+		co_return load_fail();
 	}
 	else if (version <= CURRENT_VERSION_NUM)
 	{
@@ -4370,7 +4395,7 @@ bool gameLoadV(PHYSFS_file *fileHandle, unsigned int version, nonstd::optional<n
 			if (!deserializeSaveGameData_json(gamJson.value(), &saveGameData))
 			{
 				debug(LOG_ERROR, "failed to load gamjson");
-				return false;
+				co_return load_fail();
 			}
 		}
 		else
@@ -4379,7 +4404,7 @@ bool gameLoadV(PHYSFS_file *fileHandle, unsigned int version, nonstd::optional<n
 			if (!deserializeSaveGameData(fileHandle, &saveGameData))
 			{
 				debug(LOG_ERROR, "gameLoadV: error while reading data from file for deserialization (with version number %u): %s", version, WZ_PHYSFS_getLastError());
-				return false;
+				co_return load_fail();
 			}
 		}
 	}
@@ -4387,7 +4412,7 @@ bool gameLoadV(PHYSFS_file *fileHandle, unsigned int version, nonstd::optional<n
 	{
 		debug(LOG_ERROR, "Unsupported version number (%u) for savegame", version);
 
-		return false;
+		co_return load_fail();
 	}
 
 	debug(LOG_SAVE, "Savegame is of type: %u", static_cast<uint8_t>(saveGameData.sGame.type));
@@ -4583,9 +4608,9 @@ bool gameLoadV(PHYSFS_file *fileHandle, unsigned int version, nonstd::optional<n
 		sstrcpy(aLevelName, saveGameData.levelName);
 		//load up the level dataset
 		// Not sure what aLevelName is, in relation to game.map. But need to use aLevelName here, to be able to start the right map for campaign, and need game.hash, to start the right non-campaign map, if there are multiple identically named maps.
-		if (!levLoadData(aLevelName, &saveGameData.sGame.hash, saveGameName, (GAME_TYPE)gameType))
+		if (!(co_await makeLevLoadDataLoadingTask(controller, aLevelName, &saveGameData.sGame.hash, saveGameName, (GAME_TYPE)gameType)))
 		{
-			return false;
+			co_return load_fail();
 		}
 
 		if (saveGameVersion >= VERSION_33)
@@ -4631,7 +4656,7 @@ bool gameLoadV(PHYSFS_file *fileHandle, unsigned int version, nonstd::optional<n
 	radarPermitted = (bool)powerSaved[0].extractedPower; // nice hack, eh? don't want to break savegames now...
 	allowDesign = (bool)powerSaved[1].extractedPower; // nice hack, eh? don't want to break savegames now...
 
-	return true;
+	co_return load_ok();
 }
 
 // -----------------------------------------------------------------------------------------

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -4011,10 +4011,15 @@ static LoadingTask<> gameLoad(ResourceLoadingController& controller, const char 
 		loadMainFile(std::string(CurrentFileName) + "/main.json");
 
 		const LoadResult<> retVal = co_await gameLoadV(controller, fileHandle, fileHeader.version, gamJsonSave);
-		PHYSFS_close(fileHandle);
-
+		if (fileHandle)
+		{
+			PHYSFS_close(fileHandle);
+		}
+		if (!retVal)
+		{
+			co_return retVal;
+		}
 		loadMainFileFinal(std::string(CurrentFileName) + "/main.json");
-
 		co_return retVal;
 	}
 	else

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2938,7 +2938,7 @@ LoadingTask<> loadGame(ResourceLoadingController& controller, const GameLoadDeta
 		if (!data)
 		{
 			debug(LOG_ERROR, "Failed to load map from path: %s", aFileName);
-			co_return load_fail();
+			co_return co_await loadGameCleanupOnFailure(controller, gameToLoad, keepObjects, freeMem);
 		}
 		//load the terrain type data
 		if (!loadTerrainTypeMap(data->mapTerrainTypes()))

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -4613,7 +4613,7 @@ LoadingTask<> gameLoadV(ResourceLoadingController& controller, PHYSFS_file *file
 		sstrcpy(aLevelName, saveGameData.levelName);
 		//load up the level dataset
 		// Not sure what aLevelName is, in relation to game.map. But need to use aLevelName here, to be able to start the right map for campaign, and need game.hash, to start the right non-campaign map, if there are multiple identically named maps.
-		if (!(co_await makeLevLoadDataLoadingTask(controller, aLevelName, &saveGameData.sGame.hash, saveGameName, (GAME_TYPE)gameType)))
+		if (!(co_await makeLevLoadDataLoadingTask(controller, aLevelName, std::make_optional(saveGameData.sGame.hash), saveGameName, static_cast<GAME_TYPE>(gameType))))
 		{
 			co_return load_fail();
 		}

--- a/src/game.h
+++ b/src/game.h
@@ -1,7 +1,9 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
 /*
 	This file is part of Warzone 2100.
 	Copyright (C) 1999-2004  Eidos Interactive
-	Copyright (C) 2005-2020  Warzone 2100 Project
+	Copyright (C) 2005-2026  Warzone 2100 Project (https://github.com/Warzone2100)
 
 	Warzone 2100 is free software; you can redistribute it and/or modify
 	it under the terms of the GNU General Public License as published by
@@ -79,11 +81,11 @@ private:
 	mutable std::shared_ptr<WzMap::MapPackage> m_loadedPackage;
 };
 
-bool loadGame(const GameLoadDetails& gameToLoad, bool keepObjects, bool freeMem);
+LoadingTask<> loadGame(ResourceLoadingController& controller, const GameLoadDetails& gameToLoad, bool keepObjects, bool freeMem);
 
 /*This just loads up the .gam file to determine which level data to set up - split up
 so can be called in levLoadData when starting a game from a load save game*/
-bool loadGameInit(const GameLoadDetails& gameToLoad);
+LoadingTask<> loadGameInit(ResourceLoadingController& controller, const GameLoadDetails& gameToLoad);
 
 bool loadMissionExtras(const char* pGameToLoad, LEVEL_TYPE levelType);
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1192,16 +1192,12 @@ void systemShutdown()
 namespace
 {
 
-LoadingTask<> frontendInitTaskImpl(ResourceLoadingController &controller, bool onInitialStartup)
+LoadingTask<> frontendInitTaskImpl(ResourceLoadingController &controller)
 {
 	SetGameMode(GS_TITLE_SCREEN);
 	frontendIsShuttingDown();
 	static constexpr char resourceFile[] = "wrf/frontend.wrf";
 	debug(LOG_WZ, "== Initializing frontend == : %s", resourceFile);
-	if (!onInitialStartup && !isLoadingScreenActive())
-	{
-		initLoadingScreen(true);
-	}
 	if (!frontendInitialiseSetup())
 	{
 		co_return load_fail();
@@ -1222,13 +1218,26 @@ LoadingTask<> frontendInitTaskImpl(ResourceLoadingController &controller, bool o
 
 LoadingTask<> frontendInitTask(ResourceLoadingController &controller, bool onInitialStartup)
 {
-	if (!(co_await frontendInitTaskImpl(controller, onInitialStartup)))
+	const bool openedLoadingScreen = !onInitialStartup && !isLoadingScreenActive();
+	if (openedLoadingScreen)
 	{
-		closeLoadingScreen();
+		initLoadingScreen(true);
+	}
+
+	if (!(co_await frontendInitTaskImpl(controller)))
+	{
+		if (openedLoadingScreen)
+		{
+			closeLoadingScreen();
+		}
 		debug(LOG_FATAL, "Shutting down after failure");
 		exit(EXIT_FAILURE);
 	}
-	closeLoadingScreen();
+
+	if (openedLoadingScreen)
+	{
+		closeLoadingScreen();
+	}
 	co_return load_ok();
 }
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1,7 +1,9 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
 /*
 	This file is part of Warzone 2100.
 	Copyright (C) 1999-2004  Eidos Interactive
-	Copyright (C) 2005-2020  Warzone 2100 Project
+	Copyright (C) 2005-2026  Warzone 2100 Project (https://github.com/Warzone2100)
 
 	Warzone 2100 is free software; you can redistribute it and/or modify
 	it under the terms of the GNU General Public License as published by
@@ -26,6 +28,7 @@
 #include "lib/framework/frame.h"
 
 #include <string.h>
+#include <utility>
 
 #include "lib/framework/frameresource.h"
 #include "lib/framework/file.h"
@@ -85,6 +88,9 @@
 #include "order.h"
 #include "radar.h"
 #include "research.h"
+#include "lib/framework/resource_loading_controller.h"
+#include "lib/framework/loading_task.h"
+#include "wrappers.h"
 #include "lib/framework/cursors.h"
 #include "text.h"
 #include "transporter.h"
@@ -1183,12 +1189,51 @@ void systemShutdown()
 // ////////////////////////////////////////////////////////////////////////////
 // Called At Frontend Startup.
 
-bool frontendInitialise(const char *ResourceFile)
+namespace
 {
+
+LoadingTask<> frontendInitTaskImpl(ResourceLoadingController &controller, bool onInitialStartup)
+{
+	SetGameMode(GS_TITLE_SCREEN);
 	frontendIsShuttingDown();
+	static constexpr char resourceFile[] = "wrf/frontend.wrf";
+	debug(LOG_WZ, "== Initializing frontend == : %s", resourceFile);
+	if (!onInitialStartup && !isLoadingScreenActive())
+	{
+		initLoadingScreen(true);
+	}
+	if (!frontendInitialiseSetup())
+	{
+		co_return load_fail();
+	}
 
-	debug(LOG_WZ, "== Initializing frontend == : %s", ResourceFile);
+	co_await controller.yieldFrame();
 
+	debug(LOG_MAIN, "frontEndInitialise: loading resource file .....");
+	if (!(co_await resLoad(controller, resourceFile, 0)))
+	{
+		co_return load_fail();
+	}
+
+	co_return frontendInitialiseFinalize() ? load_ok() : load_fail();
+}
+
+} // anonymous namespace
+
+LoadingTask<> frontendInitTask(ResourceLoadingController &controller, bool onInitialStartup)
+{
+	if (!(co_await frontendInitTaskImpl(controller, onInitialStartup)))
+	{
+		closeLoadingScreen();
+		debug(LOG_FATAL, "Shutting down after failure");
+		exit(EXIT_FAILURE);
+	}
+	closeLoadingScreen();
+	co_return load_ok();
+}
+
+bool frontendInitialiseSetup()
+{
 	if (!InitialiseGlobals())				// Initialise all globals and statics everywhere.
 	{
 		return false;
@@ -1209,13 +1254,11 @@ bool frontendInitialise(const char *ResourceFile)
 		return false;
 	}
 
-	debug(LOG_MAIN, "frontEndInitialise: loading resource file .....");
-	if (!resLoad(ResourceFile, 0))
-	{
-		//need the object heaps to have been set up before loading in the save game
-		return false;
-	}
+	return true;
+}
 
+bool frontendInitialiseFinalize()
+{
 	if (!dispInitialise())					// Initialise the display system
 	{
 		return false;
@@ -1683,27 +1726,9 @@ static void displayLoadingErrors()
 	}
 }
 
-bool stageThreeInitialise()
+static bool stageThreeInitialiseSync()
 {
 	bool fromSave = (getSaveGameType() == GTYPE_SAVE_START || getSaveGameType() == GTYPE_SAVE_MIDMISSION);
-
-	debug(LOG_WZ, "== stageThreeInitialise ==");
-
-	loopMissionState = LMS_NORMAL;
-
-	// preload model textures for current tileset
-	size_t modelTilesetIdx = static_cast<size_t>(currentMapTileset);
-	modelUpdateTilesetIdx(modelTilesetIdx);
-	if (!headlessGameMode())
-	{
-		enumerateLoadedModels([](const std::string &modelName, iIMDBaseShape &s){
-			for (const iIMDShape *pDisplayShape = s.displayModel(); pDisplayShape != nullptr; pDisplayShape = pDisplayShape->next.get())
-			{
-				pDisplayShape->getTextures();
-			}
-		});
-	}
-	resDoResLoadCallback();		// do callback.
 
 	if (!InitRadar()) 	// After resLoad cause it needs the game palette initialised.
 	{
@@ -1817,6 +1842,25 @@ bool stageThreeInitialise()
 	countUpdate(false);
 
 	return true;
+}
+
+LoadingTask<> stageThreeInitialiseTask(ResourceLoadingController& controller)
+{
+	debug(LOG_WZ, "== stageThreeInitialise ==");
+
+	loopMissionState = LMS_NORMAL;
+
+	size_t modelTilesetIdx = static_cast<size_t>(currentMapTileset);
+	modelUpdateTilesetIdx(modelTilesetIdx);
+	if (!headlessGameMode())
+	{
+		if (!(co_await preloadAllModelTexturesTask(controller)))
+		{
+			co_return load_fail();
+		}
+	}
+
+	co_return stageThreeInitialiseSync() ? load_ok() : load_fail();
 }
 
 /*****************************************************************************/

--- a/src/init.h
+++ b/src/init.h
@@ -1,7 +1,9 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
 /*
 	This file is part of Warzone 2100.
 	Copyright (C) 1999-2004  Eidos Interactive
-	Copyright (C) 2005-2020  Warzone 2100 Project
+	Copyright (C) 2005-2026  Warzone 2100 Project (https://github.com/Warzone2100)
 
 	Warzone 2100 is free software; you can redistribute it and/or modify
 	it under the terms of the GNU General Public License as published by
@@ -24,10 +26,15 @@
 #ifndef __INCLUDED_SRC_INIT_H__
 #define __INCLUDED_SRC_INIT_H__
 
+#include <cstdint>
+#include <memory>
+#include <string>
 #include <vector>
 #include "terrain_defs.h"
+#include "lib/framework/loading_task_fwd.h"
 
 struct IMAGEFILE;
+class ResourceLoadingController;
 class WzMapZipIO;
 
 // the size of the file loading buffer
@@ -37,13 +44,15 @@ extern char fileLoadBuffer[];
 
 bool systemInitialise(unsigned int horizScalePercentage, unsigned int vertScalePercentage);
 void systemShutdown();
-bool frontendInitialise(const char *ResourceFile);
+LoadingTask<> frontendInitTask(ResourceLoadingController &controller, bool onInitialStartup = false);
+bool frontendInitialiseSetup();
+bool frontendInitialiseFinalize();
 bool frontendShutdown();
 bool stageOneInitialise();
 bool stageOneShutDown();
 bool stageTwoInitialise();
 bool stageTwoShutDown();
-bool stageThreeInitialise();
+LoadingTask<> stageThreeInitialiseTask(ResourceLoadingController& controller);
 bool stageThreeShutDown();
 
 // Reset the game between campaigns

--- a/src/levels.cpp
+++ b/src/levels.cpp
@@ -869,9 +869,9 @@ static GameLoadDetails levConstructGameLoadDetails(LEVEL_DATASET* psNewLevel, SW
 
 struct LevLoadContext
 {
-	std::string    name;
-	Sha256 const*  hash = nullptr;
-	char*          pSaveName = nullptr;
+	std::string              name;
+	std::optional<Sha256>    hash;
+	char*                    pSaveName = nullptr;
 	GAME_TYPE      saveType = GTYPE_SCENARIO_START;
 	LEVEL_DATASET* psNewLevel = nullptr;
 	LEVEL_DATASET* psChangeLevel = nullptr;
@@ -1076,7 +1076,7 @@ static LevDatasetResolveResult levResolveDatasetForLoad(LevLoadContext& ctx)
 	sstrcpy(currentLevelName, ctx.name.c_str());
 
 	// find the level dataset
-	ctx.psNewLevel = levFindDataSet(ctx.name.c_str(), ctx.hash);
+	ctx.psNewLevel = levFindDataSet(ctx.name.c_str(), ctx.hash.has_value() ? &ctx.hash.value() : nullptr);
 	if (ctx.psNewLevel == nullptr)
 	{
 		debug(LOG_INFO, "Dataset %s not found - trying to load as WRF", ctx.name.c_str());
@@ -1383,21 +1383,21 @@ namespace
 
 struct LevLoadJobParams
 {
-	char const *name = nullptr;
-	Sha256 const *hash = nullptr;
-	char *pSaveName = nullptr;
-	GAME_TYPE saveType = GTYPE_SCENARIO_START;
+	std::string              name;
+	std::optional<Sha256>    hash;
+	char                    *pSaveName = nullptr;
+	GAME_TYPE                saveType = GTYPE_SCENARIO_START;
 };
 
 LoadingTask<> levLoadDataTask(ResourceLoadingController &controller, LevLoadJobParams params)
 {
-	if (params.name == nullptr)
+	if (params.name.empty())
 	{
 		co_return load_fail();
 	}
 
-	debug(LOG_WZ, "Loading level %s hash %s (%s, type %d)", params.name,
-	      params.hash == nullptr ? "builtin" : params.hash->toString().c_str(),
+	debug(LOG_WZ, "Loading level %s hash %s (%s, type %d)", params.name.c_str(),
+	      !params.hash.has_value() ? "builtin" : params.hash->toString().c_str(),
 	      params.pSaveName == nullptr ? "<none>" : params.pSaveName,
 	      static_cast<int>(params.saveType));
 
@@ -1417,8 +1417,8 @@ LoadingTask<> levLoadDataTask(ResourceLoadingController &controller, LevLoadJobP
 	levelLoadType = params.saveType;
 
 	LevLoadContext ctx;
-	ctx.name = params.name;
-	ctx.hash = params.hash;
+	ctx.name = std::move(params.name);
+	ctx.hash = std::move(params.hash);
 	ctx.pSaveName = params.pSaveName;
 	ctx.saveType = params.saveType;
 
@@ -1470,13 +1470,13 @@ LoadingTask<> levLoadDataTask(ResourceLoadingController &controller, LevLoadJobP
 } // anonymous namespace
 
 LoadingTask<> makeLevLoadDataLoadingTask(ResourceLoadingController &controller,
-                                       char const *name,
-                                       Sha256 const *hash,
+                                       std::string name,
+                                       std::optional<Sha256> hash,
                                        char *pSaveName,
                                        GAME_TYPE saveType)
 {
-	LevLoadJobParams params{name, hash, pSaveName, saveType};
-	return levLoadDataTask(controller, params);
+	LevLoadJobParams params{std::move(name), std::move(hash), pSaveName, saveType};
+	return levLoadDataTask(controller, std::move(params));
 }
 
 std::string mapNameWithoutTechlevel(const char *mapName)

--- a/src/levels.cpp
+++ b/src/levels.cpp
@@ -1397,7 +1397,8 @@ LoadingTask<> levLoadDataTask(ResourceLoadingController &controller, LevLoadJobP
 	}
 
 	debug(LOG_WZ, "Loading level %s hash %s (%s, type %d)", params.name,
-	      params.hash == nullptr ? "builtin" : params.hash->toString().c_str(), params.pSaveName,
+	      params.hash == nullptr ? "builtin" : params.hash->toString().c_str(),
+	      params.pSaveName == nullptr ? "<none>" : params.pSaveName,
 	      static_cast<int>(params.saveType));
 
 	if (params.saveType == GTYPE_SAVE_START || params.saveType == GTYPE_SAVE_MIDMISSION)

--- a/src/levels.cpp
+++ b/src/levels.cpp
@@ -1,7 +1,9 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
 /*
 	This file is part of Warzone 2100.
 	Copyright (C) 1999-2004  Eidos Interactive
-	Copyright (C) 2005-2020  Warzone 2100 Project
+	Copyright (C) 2005-2026  Warzone 2100 Project (https://github.com/Warzone2100)
 
 	Warzone 2100 is free software; you can redistribute it and/or modify
 	it under the terms of the GNU General Public License as published by
@@ -42,6 +44,8 @@
 #include "mission.h"
 #include "levelint.h"
 #include "game.h"
+#include "lib/framework/resource_loading_controller.h"
+#include "lib/framework/loading_task.h"
 #include "lib/ivis_opengl/piestate.h"
 #include "data.h"
 #include "research.h"
@@ -720,8 +724,6 @@ bool levReleaseMissionData()
 			return false;
 		}
 
-		resDoResLoadCallback();		// do callback.
-
 		// free up the old data
 		for (int i = LEVEL_MAXFILES - 1; i >= 0; i--)
 		{
@@ -758,8 +760,6 @@ bool levReleaseAll(bool forceOnError)
 
 	if (didLoadLevel)
 	{
-		resDoResLoadCallback();		// do callback.
-
 		if (!levReleaseMissionData())
 		{
 			debug(LOG_ERROR, "Failed to unload mission data");
@@ -769,8 +769,6 @@ bool levReleaseAll(bool forceOnError)
 
 	if (didLoadLevel || didLoadBaseLevel || forceOnError)
 	{
-		resDoResLoadCallback();		// do callback.
-
 		// release the base game data
 		if (psBaseData != nullptr || (psCurrLevel != nullptr && psCurrLevel->psBaseData != nullptr))
 		{
@@ -821,12 +819,12 @@ bool levReleaseAll(bool forceOnError)
 }
 
 // load up a single wrf file
-static bool levLoadSingleWRF(const char *name)
+static LoadingTask<> levLoadSingleWRF(ResourceLoadingController& controller, const char *name)
 {
 	// free the old data
 	if (!levReleaseAll())
 	{
-		return false;
+		co_return load_fail();
 	}
 
 	// create the dummy level data
@@ -836,24 +834,23 @@ static bool levLoadSingleWRF(const char *name)
 	// load up the WRF
 	if (!stageOneInitialise())
 	{
-		return false;
+		co_return load_fail();
 	}
 
 	// load the data
 	debug(LOG_WZ, "Loading %s ...", name);
-	if (!resLoad(name, 0))
-	{
-		return false;
+	if (!(co_await resLoad(controller, name, 0))) {
+		co_return load_fail();
 	}
 
-	if (!stageThreeInitialise())
+	if (!(co_await stageThreeInitialiseTask(controller)))
 	{
-		return false;
+		co_return load_fail();
 	}
 
 	psCurrLevel = &sSingleWRF;
 
-	return true;
+	co_return load_ok();
 }
 
 const char *getLevelName()
@@ -919,94 +916,93 @@ static void levPreloadFactionModelsFromLoadedSet()
 		ASSERT(retval != nullptr, "Cannot find the faction PIE model %s (for normal model: %s)",
 			   factionModelInfo.factionModel.toUtf8().c_str(), factionModelInfo.normalModel.toUtf8().c_str());
 	}
-	resDoResLoadCallback();		// do callback.
 }
 
-static bool levStartMissionForLevelType(LEVEL_DATASET* psNewLevel, SWORD i)
+static LoadingTask<> levStartMissionForLevelType(ResourceLoadingController& controller, LEVEL_DATASET* psNewLevel, SWORD i)
 {
 	switch (psNewLevel->type)
 	{
 	case LEVEL_TYPE::LDS_COMPLETE:
 	case LEVEL_TYPE::LDS_CAMSTART:
 		debug(LOG_WZ, "LDS_COMPLETE / LDS_CAMSTART");
-		if (!startMission(LEVEL_TYPE::LDS_CAMSTART, levConstructGameLoadDetails(psNewLevel, i)))
+		if (!(co_await startMission(controller, LEVEL_TYPE::LDS_CAMSTART, levConstructGameLoadDetails(psNewLevel, i))))
 		{
 			debug(LOG_ERROR, "Failed startMission(%d, %s)!", static_cast<int8_t>(LEVEL_TYPE::LDS_CAMSTART), psNewLevel->apDataFiles[i].c_str());
-			return false;
+			co_return load_fail();
 		}
-		return true;
+		co_return load_ok();
 	case LEVEL_TYPE::LDS_BETWEEN:
 		debug(LOG_WZ, "LDS_BETWEEN");
-		if (!startMission(LEVEL_TYPE::LDS_BETWEEN, levConstructGameLoadDetails(psNewLevel, i)))
+		if (!(co_await startMission(controller, LEVEL_TYPE::LDS_BETWEEN, levConstructGameLoadDetails(psNewLevel, i))))
 		{
 			debug(LOG_ERROR, "Failed startMission(%d, %s)!", static_cast<int8_t>(LEVEL_TYPE::LDS_BETWEEN), psNewLevel->apDataFiles[i].c_str());
-			return false;
+			co_return load_fail();
 		}
-		return true;
+		co_return load_ok();
 
 	case LEVEL_TYPE::LDS_MKEEP:
 		debug(LOG_WZ, "LDS_MKEEP");
-		if (!startMission(LEVEL_TYPE::LDS_MKEEP, levConstructGameLoadDetails(psNewLevel, i)))
+		if (!(co_await startMission(controller, LEVEL_TYPE::LDS_MKEEP, levConstructGameLoadDetails(psNewLevel, i))))
 		{
 			debug(LOG_ERROR, "Failed startMission(%d, %s)!", static_cast<int8_t>(LEVEL_TYPE::LDS_MKEEP), psNewLevel->apDataFiles[i].c_str());
-			return false;
+			co_return load_fail();
 		}
-		return true;
+		co_return load_ok();
 	case LEVEL_TYPE::LDS_CAMCHANGE:
 		debug(LOG_WZ, "LDS_CAMCHANGE");
-		if (!startMission(LEVEL_TYPE::LDS_CAMCHANGE, levConstructGameLoadDetails(psNewLevel, i)))
+		if (!(co_await startMission(controller, LEVEL_TYPE::LDS_CAMCHANGE, levConstructGameLoadDetails(psNewLevel, i))))
 		{
 			debug(LOG_ERROR, "Failed startMission(%d, %s)!", static_cast<int8_t>(LEVEL_TYPE::LDS_CAMCHANGE), psNewLevel->apDataFiles[i].c_str());
-			return false;
+			co_return load_fail();
 		}
-		return true;
+		co_return load_ok();
 
 	case LEVEL_TYPE::LDS_EXPAND:
 		debug(LOG_WZ, "LDS_EXPAND");
-		if (!startMission(LEVEL_TYPE::LDS_EXPAND, levConstructGameLoadDetails(psNewLevel, i)))
+		if (!(co_await startMission(controller, LEVEL_TYPE::LDS_EXPAND, levConstructGameLoadDetails(psNewLevel, i))))
 		{
 			debug(LOG_ERROR, "Failed startMission(%d, %s)!", static_cast<int8_t>(LEVEL_TYPE::LDS_EXPAND), psNewLevel->apDataFiles[i].c_str());
-			return false;
+			co_return load_fail();
 		}
-		return true;
+		co_return load_ok();
 	case LEVEL_TYPE::LDS_EXPAND_LIMBO:
 		debug(LOG_WZ, "LDS_LIMBO");
-		if (!startMission(LEVEL_TYPE::LDS_EXPAND_LIMBO, levConstructGameLoadDetails(psNewLevel, i)))
+		if (!(co_await startMission(controller, LEVEL_TYPE::LDS_EXPAND_LIMBO, levConstructGameLoadDetails(psNewLevel, i))))
 		{
 			debug(LOG_ERROR, "Failed startMission(%d, %s)!", static_cast<int8_t>(LEVEL_TYPE::LDS_EXPAND_LIMBO), psNewLevel->apDataFiles[i].c_str());
-			return false;
+			co_return load_fail();
 		}
-		return true;
+		co_return load_ok();
 
 	case LEVEL_TYPE::LDS_MCLEAR:
 		debug(LOG_WZ, "LDS_MCLEAR");
-		if (!startMission(LEVEL_TYPE::LDS_MCLEAR, levConstructGameLoadDetails(psNewLevel, i)))
+		if (!(co_await startMission(controller, LEVEL_TYPE::LDS_MCLEAR, levConstructGameLoadDetails(psNewLevel, i))))
 		{
 			debug(LOG_ERROR, "Failed startMission(%d, %s)!", static_cast<int8_t>(LEVEL_TYPE::LDS_MCLEAR), psNewLevel->apDataFiles[i].c_str());
-			return false;
+			co_return load_fail();
 		}
-		return true;
+		co_return load_ok();
 	case LEVEL_TYPE::LDS_MKEEP_LIMBO:
 		debug(LOG_WZ, "LDS_MKEEP_LIMBO");
-		if (!startMission(LEVEL_TYPE::LDS_MKEEP_LIMBO, levConstructGameLoadDetails(psNewLevel, i)))
+		if (!(co_await startMission(controller, LEVEL_TYPE::LDS_MKEEP_LIMBO, levConstructGameLoadDetails(psNewLevel, i))))
 		{
 			debug(LOG_ERROR, "Failed startMission(%d, %s)!", static_cast<int8_t>(LEVEL_TYPE::LDS_MKEEP_LIMBO), psNewLevel->apDataFiles[i].c_str());
-			return false;
+			co_return load_fail();
 		}
-		return true;
+		co_return load_ok();
 	default:
 		ASSERT(psNewLevel->type >= LEVEL_TYPE::LDS_MULTI_TYPE_START, "Unexpected mission type");
 		debug(LOG_WZ, "default (MULTIPLAYER)");
-		if (!startMission(LEVEL_TYPE::LDS_CAMSTART, levConstructGameLoadDetails(psNewLevel, i)))
+		if (!(co_await startMission(controller, LEVEL_TYPE::LDS_CAMSTART, levConstructGameLoadDetails(psNewLevel, i))))
 		{
 			debug(LOG_ERROR, "Failed startMission(%d, %s) (default)!", static_cast<int8_t>(LEVEL_TYPE::LDS_CAMSTART), psNewLevel->apDataFiles[i].c_str());
-			return false;
+			co_return load_fail();
 		}
-		return true;
+		co_return load_ok();
 	}
 }
 
-static bool levLoadBaseDatasetAndStageOne(LEVEL_DATASET* psNewLevel)
+static LoadingTask<> levLoadBaseDatasetAndStageOne(ResourceLoadingController& controller, LEVEL_DATASET* psNewLevel)
 {
 	// initialise if necessary
 	if (psNewLevel->type == LEVEL_TYPE::LDS_COMPLETE || psBaseData != nullptr)
@@ -1015,7 +1011,7 @@ static bool levLoadBaseDatasetAndStageOne(LEVEL_DATASET* psNewLevel)
 		if (!stageOneInitialise())
 		{
 			debug(LOG_ERROR, "Failed stageOneInitialise!");
-			return false;
+			co_return load_fail();
 		}
 	}
 
@@ -1029,10 +1025,9 @@ static bool levLoadBaseDatasetAndStageOne(LEVEL_DATASET* psNewLevel)
 			{
 				// load the data
 				debug(LOG_WZ, "Loading [directory: %s] %s ...", WZ_PHYSFS_getRealDir_String(psBaseData->apDataFiles[i].c_str()).c_str(), psBaseData->apDataFiles[i].c_str());
-				if (!resLoad(psBaseData->apDataFiles[i].c_str(), i))
-				{
+				if (!(co_await resLoad(controller, psBaseData->apDataFiles[i].c_str(), i))) {
 					debug(LOG_ERROR, "Failed resLoad(%s)!", psBaseData->apDataFiles[i].c_str());
-					return false;
+					co_return load_fail();
 				}
 			}
 		}
@@ -1040,7 +1035,7 @@ static bool levLoadBaseDatasetAndStageOne(LEVEL_DATASET* psNewLevel)
 
 	// preload faction IMDs
 	levPreloadFactionModelsFromLoadedSet();
-	return true;
+	co_return load_ok();
 }
 
 static bool levPrepareLoadEnvironment(LEVEL_DATASET* psNewLevel, char* pSaveName)
@@ -1151,7 +1146,7 @@ static LevDatasetResolveResult levResolveDatasetForLoad(LevLoadContext& ctx)
 	return LevDatasetResolveResult::Ok;
 }
 
-static bool levLoadMissionBranchesBeforeMainLoop(LevLoadContext& ctx)
+static LoadingTask<> levLoadMissionBranchesBeforeMainLoop(ResourceLoadingController& controller, LevLoadContext& ctx)
 {
 	LEVEL_DATASET *psNewLevel = ctx.psNewLevel;
 
@@ -1160,7 +1155,7 @@ static bool levLoadMissionBranchesBeforeMainLoop(LevLoadContext& ctx)
 		if (!campaignReset())
 		{
 			debug(LOG_ERROR, "Failed campaignReset()!");
-			return false;
+			co_return load_fail();
 		}
 	}
 	if (psNewLevel->game == -1)  //no .gam file to load - BETWEEN missions (for Editor games only)
@@ -1174,7 +1169,7 @@ static bool levLoadMissionBranchesBeforeMainLoop(LevLoadContext& ctx)
 				if (!stageTwoInitialise())
 				{
 					debug(LOG_ERROR, "Failed stageTwoInitialise()!");
-					return false;
+					co_return load_fail();
 				}
 			}
 
@@ -1185,7 +1180,7 @@ static bool levLoadMissionBranchesBeforeMainLoop(LevLoadContext& ctx)
 				if (!startMissionSave(psNewLevel->type))
 				{
 					debug(LOG_ERROR, "Failed startMissionSave(%d)!", static_cast<int8_t>(psNewLevel->type));
-					return false;
+					co_return load_fail();
 				}
 
 				debug(LOG_NEVER, "dataSetSaveFlag");
@@ -1193,20 +1188,20 @@ static bool levLoadMissionBranchesBeforeMainLoop(LevLoadContext& ctx)
 			}
 
 			debug(LOG_NEVER, "Loading savegame: %s", ctx.pSaveName);
-			if (!loadGame(GameLoadDetails::makeUserSaveGameLoad(ctx.pSaveName), false, true))
+			if (!(co_await loadGame(controller, GameLoadDetails::makeUserSaveGameLoad(ctx.pSaveName), false, true)))
 			{
 				debug(LOG_ERROR, "Failed loadGame(%s)!", ctx.pSaveName);
-				return false;
+				co_return load_fail();
 			}
 		}
 
 		if (ctx.pSaveName == nullptr || ctx.saveType == GTYPE_SAVE_START)
 		{
 			debug(LOG_NEVER, "Start mission - no .gam");
-			if (!startMission((LEVEL_TYPE)psNewLevel->type, GameLoadDetails::makeLevelFileLoad("")))
+			if (!(co_await startMission(controller, (LEVEL_TYPE)psNewLevel->type, GameLoadDetails::makeLevelFileLoad(""))))
 			{
 				debug(LOG_ERROR, "Failed startMission(%d)!", static_cast<int8_t>(psNewLevel->type));
-				return false;
+				co_return load_fail();
 			}
 		}
 	}
@@ -1221,25 +1216,25 @@ static bool levLoadMissionBranchesBeforeMainLoop(LevLoadContext& ctx)
 				if (!stageTwoInitialise())
 				{
 					debug(LOG_ERROR, "Failed stageTwoInitialise() [camchange]!");
-					return false;
+					co_return load_fail();
 				}
 			}
 
 			debug(LOG_NEVER, "loading savegame: %s", ctx.pSaveName);
-			if (!loadGame(GameLoadDetails::makeUserSaveGameLoad(ctx.pSaveName), false, true))
+			if (!(co_await loadGame(controller, GameLoadDetails::makeUserSaveGameLoad(ctx.pSaveName), false, true)))
 			{
 				debug(LOG_ERROR, "Failed loadGame(%s)!", ctx.pSaveName);
-				return false;
+				co_return load_fail();
 			}
 
 			campaignReset();
 		}
 	}
 
-	return true;
+	co_return load_ok();
 }
 
-static bool levLoadMissionDataLoop(LevLoadContext& ctx)
+static LoadingTask<> levLoadMissionDataLoop(ResourceLoadingController& controller, LevLoadContext& ctx)
 {
 	LEVEL_DATASET *psNewLevel = ctx.psNewLevel;
 
@@ -1255,7 +1250,7 @@ static bool levLoadMissionDataLoop(LevLoadContext& ctx)
 				if (!stageTwoInitialise())
 				{
 					debug(LOG_ERROR, "Failed stageTwoInitialise() [newdata]!");
-					return false;
+					co_return load_fail();
 				}
 			}
 
@@ -1269,7 +1264,7 @@ static bool levLoadMissionDataLoop(LevLoadContext& ctx)
 					if (!startMissionSave(psNewLevel->type))
 					{
 						debug(LOG_ERROR, "Failed startMissionSave(%d)!", static_cast<uint8_t>(psNewLevel->type));
-						return false;
+						co_return load_fail();
 					}
 
 					debug(LOG_NEVER, "dataSetSaveFlag");
@@ -1277,10 +1272,10 @@ static bool levLoadMissionDataLoop(LevLoadContext& ctx)
 				}
 
 				debug(LOG_NEVER, "Loading save game %s", ctx.pSaveName);
-				if (!loadGame(GameLoadDetails::makeUserSaveGameLoad(ctx.pSaveName), false, true))
+				if (!(co_await loadGame(controller, GameLoadDetails::makeUserSaveGameLoad(ctx.pSaveName), false, true)))
 				{
 					debug(LOG_ERROR, "Failed loadGame(%s)!", ctx.pSaveName);
-					return false;
+					co_return load_fail();
 				}
 			}
 
@@ -1288,9 +1283,9 @@ static bool levLoadMissionDataLoop(LevLoadContext& ctx)
 			{
 				// load the game
 				debug(LOG_WZ, "Loading scenario file %s", psNewLevel->apDataFiles[i].c_str());
-				if (!levStartMissionForLevelType(psNewLevel, i))
+				if (!(co_await levStartMissionForLevelType(controller, psNewLevel, i)))
 				{
-					return false;
+					co_return load_fail();
 				}
 			}
 		}
@@ -1298,18 +1293,17 @@ static bool levLoadMissionDataLoop(LevLoadContext& ctx)
 		{
 			// load the data
 			debug(LOG_WZ, "Loading %s", psNewLevel->apDataFiles[i].c_str());
-			if (!resLoad(psNewLevel->apDataFiles[i].c_str(), i + CURRENT_DATAID))
-			{
+			if (!(co_await resLoad(controller, psNewLevel->apDataFiles[i].c_str(), i + CURRENT_DATAID))) {
 				debug(LOG_ERROR, "Failed resLoad(%s, %d) (default)!", psNewLevel->apDataFiles[i].c_str(), i + CURRENT_DATAID);
-				return false;
+				co_return load_fail();
 			}
 		}
 	}
 
-	return true;
+	co_return load_ok();
 }
 
-static bool levFinalizeLevelLoad(LevLoadContext& ctx)
+static LoadingTask<> levFinalizeLevelLoad(ResourceLoadingController& controller, LevLoadContext& ctx)
 {
 	LEVEL_DATASET *psNewLevel = ctx.psNewLevel;
 
@@ -1325,7 +1319,7 @@ static bool levFinalizeLevelLoad(LevLoadContext& ctx)
 		if (!loadMissionExtras(ctx.pSaveName, psNewLevel->type))
 		{
 			debug(LOG_ERROR, "Failed loadMissionExtras(%s, %d)!", ctx.pSaveName, static_cast<int8_t>(psNewLevel->type));
-			return false;
+			co_return load_fail();
 		}
 	}
 
@@ -1337,14 +1331,14 @@ static bool levFinalizeLevelLoad(LevLoadContext& ctx)
 		if (!loadScriptState(ctx.pSaveName))
 		{
 			debug(LOG_ERROR, "Failed loadScriptState(%s)!", ctx.pSaveName);
-			return false;
+			co_return load_fail();
 		}
 	}
 	// this will trigger upgrades
-	if (!stageThreeInitialise())
+	if (!(co_await stageThreeInitialiseTask(controller)))
 	{
-		debug(LOG_ERROR, "Failed stageThreeInitialise()!");
-		return false;
+		debug(LOG_ERROR, "Failed stageThreeInitialiseTask()!");
+		co_return load_fail();
 	}
 
 	dataClearSaveFlag();
@@ -1381,65 +1375,107 @@ static bool levFinalizeLevelLoad(LevLoadContext& ctx)
 	}
 
 	ActivityManager::instance().loadedLevel(psCurrLevel->type, mapNameWithoutTechlevel(getLevelName()));
-	return true;
+	co_return load_ok();
 }
 
-// load up the data for a level
-bool levLoadData(char const *name, Sha256 const *hash, char *pSaveName, GAME_TYPE saveType)
+namespace
 {
-	ASSERT_OR_RETURN(false, name != nullptr, "null level name provided");
-	debug(LOG_WZ, "Loading level %s hash %s (%s, type %d)", name, hash == nullptr ? "builtin" : hash->toString().c_str(), pSaveName != nullptr ? pSaveName : "<none>", (int)saveType);
-	if (saveType == GTYPE_SAVE_START || saveType == GTYPE_SAVE_MIDMISSION)
+
+struct LevLoadJobParams
+{
+	char const *name = nullptr;
+	Sha256 const *hash = nullptr;
+	char *pSaveName = nullptr;
+	GAME_TYPE saveType = GTYPE_SCENARIO_START;
+};
+
+LoadingTask<> levLoadDataTask(ResourceLoadingController &controller, LevLoadJobParams params)
+{
+	if (params.name == nullptr)
+	{
+		co_return load_fail();
+	}
+
+	debug(LOG_WZ, "Loading level %s hash %s (%s, type %d)", params.name,
+	      params.hash == nullptr ? "builtin" : params.hash->toString().c_str(), params.pSaveName,
+	      static_cast<int>(params.saveType));
+
+	if (params.saveType == GTYPE_SAVE_START || params.saveType == GTYPE_SAVE_MIDMISSION)
 	{
 		if (!levReleaseAll())
 		{
 			debug(LOG_ERROR, "Failed to unload old data");
-			return false;
+			co_return load_fail();
 		}
 	}
 
 	// Ensure that the LC_NUMERIC locale setting is "C"
-	ASSERT(strcmp(setlocale(LC_NUMERIC, NULL), "C") == 0, "The LC_NUMERIC locale is not \"C\" - this may break level-data parsing depending on the user's system locale settings");
+	ASSERT(strcmp(setlocale(LC_NUMERIC, NULL), "C") == 0,
+	       "The LC_NUMERIC locale is not \"C\" - this may break level-data parsing depending on the user's system locale settings");
 
-	levelLoadType = saveType;
+	levelLoadType = params.saveType;
 
 	LevLoadContext ctx;
-	ctx.name = name;
-	ctx.hash = hash;
-	ctx.pSaveName = pSaveName;
-	ctx.saveType = saveType;
+	ctx.name = params.name;
+	ctx.hash = params.hash;
+	ctx.pSaveName = params.pSaveName;
+	ctx.saveType = params.saveType;
+
+	co_await controller.yieldFrame();
 
 	switch (levResolveDatasetForLoad(ctx))
 	{
 	case LevDatasetResolveResult::Failed:
-		return false;
+		co_return load_fail();
 	case LevDatasetResolveResult::SingleWRF:
-		return levLoadSingleWRF(ctx.name.c_str());
+		co_return co_await levLoadSingleWRF(controller, ctx.name.c_str());
 	case LevDatasetResolveResult::Ok:
 		break;
 	}
 
+	co_await controller.yieldFrame();
+
 	if (!levPrepareLoadEnvironment(ctx.psNewLevel, ctx.pSaveName))
 	{
-		return false;
+		co_return load_fail();
 	}
-	if (!levLoadBaseDatasetAndStageOne(ctx.psNewLevel))
+
+	co_await controller.yieldFrame();
+
+	if (!(co_await levLoadBaseDatasetAndStageOne(controller, ctx.psNewLevel)))
 	{
-		return false;
+		co_return load_fail();
 	}
-	if (!levLoadMissionBranchesBeforeMainLoop(ctx))
+
+	co_await controller.yieldFrame();
+
+	if (!(co_await levLoadMissionBranchesBeforeMainLoop(controller, ctx)))
 	{
-		return false;
+		co_return load_fail();
 	}
-	if (!levLoadMissionDataLoop(ctx))
+
+	co_await controller.yieldFrame();
+
+	if (!(co_await levLoadMissionDataLoop(controller, ctx)))
 	{
-		return false;
+		co_return load_fail();
 	}
-	if (!levFinalizeLevelLoad(ctx))
-	{
-		return false;
-	}
-	return true;
+
+	co_await controller.yieldFrame();
+
+	co_return co_await levFinalizeLevelLoad(controller, ctx);
+}
+
+} // anonymous namespace
+
+LoadingTask<> makeLevLoadDataLoadingTask(ResourceLoadingController &controller,
+                                       char const *name,
+                                       Sha256 const *hash,
+                                       char *pSaveName,
+                                       GAME_TYPE saveType)
+{
+	LevLoadJobParams params{name, hash, pSaveName, saveType};
+	return levLoadDataTask(controller, params);
 }
 
 std::string mapNameWithoutTechlevel(const char *mapName)

--- a/src/levels.h
+++ b/src/levels.h
@@ -1,7 +1,9 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
 /*
 	This file is part of Warzone 2100.
 	Copyright (C) 1999-2004  Eidos Interactive
-	Copyright (C) 2005-2020  Warzone 2100 Project
+	Copyright (C) 2005-2026  Warzone 2100 Project (https://github.com/Warzone2100)
 
 	Warzone 2100 is free software; you can redistribute it and/or modify
 	it under the terms of the GNU General Public License as published by
@@ -31,6 +33,9 @@
 #include <list>
 #include <string>
 #include <array>
+#include <memory>
+
+class ResourceLoadingController;
 
 /// maximum number of data files
 #define LEVEL_MAXFILES	9
@@ -100,8 +105,12 @@ void levShutDown();
 
 bool levInitialise();
 
-// load up the data for a level
-bool levLoadData(char const *name, Sha256 const *hash, char *pSaveName, GAME_TYPE saveType);
+/// Cooperative level-load coroutine for nesting under another loading task on the same controller.
+LoadingTask<> makeLevLoadDataLoadingTask(ResourceLoadingController &controller,
+                                       char const *name,
+                                       Sha256 const *hash,
+                                       char *pSaveName,
+                                       GAME_TYPE saveType);
 
 // find the level dataset
 LEVEL_DATASET *levFindDataSet(char const *name, Sha256 const *hash = nullptr);

--- a/src/levels.h
+++ b/src/levels.h
@@ -34,6 +34,7 @@
 #include <string>
 #include <array>
 #include <memory>
+#include <optional>
 
 class ResourceLoadingController;
 
@@ -107,8 +108,8 @@ bool levInitialise();
 
 /// Cooperative level-load coroutine for nesting under another loading task on the same controller.
 LoadingTask<> makeLevLoadDataLoadingTask(ResourceLoadingController &controller,
-                                       char const *name,
-                                       Sha256 const *hash,
+                                       std::string name,
+                                       std::optional<Sha256> hash,
                                        char *pSaveName,
                                        GAME_TYPE saveType);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -945,9 +945,7 @@ LoadingTask<> startGameResourceTaskImpl(ResourceLoadingController &controller)
 	co_await controller.yieldFrame();
 
 	// Not sure what aLevelName is, in relation to game.map. But need to use aLevelName here, to be able to start the right map for campaign, and need game.hash, to start the right non-campaign map, if there are multiple identically named maps.
-	LoadResult<> const lev =
-	    co_await makeLevLoadDataLoadingTask(controller, aLevelName, std::make_optional(game.hash), nullptr, GTYPE_SCENARIO_START);
-	if (!lev)
+	if (!(co_await makeLevLoadDataLoadingTask(controller, aLevelName, std::make_optional(game.hash), nullptr, GTYPE_SCENARIO_START)))
 	{
 		co_return load_fail();
 	}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1318,10 +1318,10 @@ void requestMapPreviewLoad(bool hideInterface)
 		ResourceLoadingController::FrameProcessingMode::ContinueMainLoop);
 }
 
-void requestMapPreviewLoad(bool hideInterface, const char *mapName, const Sha256& mapHash)
+void requestMapPreviewLoad(bool hideInterface, std::string mapName, const Sha256& mapHash)
 {
 	submitResourceLoadingTask(
-		[hideInterface, mapName = std::string(mapName), mapHash](ResourceLoadingController &c)
+		[hideInterface, mapName, mapHash](ResourceLoadingController &c)
 		{
 			return mapPreviewLoadTask(c, hideInterface, std::move(mapName), mapHash);
 		},

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -946,7 +946,7 @@ LoadingTask<> startGameResourceTaskImpl(ResourceLoadingController &controller)
 
 	// Not sure what aLevelName is, in relation to game.map. But need to use aLevelName here, to be able to start the right map for campaign, and need game.hash, to start the right non-campaign map, if there are multiple identically named maps.
 	LoadResult<> const lev =
-	    co_await makeLevLoadDataLoadingTask(controller, aLevelName, &game.hash, nullptr, GTYPE_SCENARIO_START);
+	    co_await makeLevLoadDataLoadingTask(controller, aLevelName, std::make_optional(game.hash), nullptr, GTYPE_SCENARIO_START);
 	if (!lev)
 	{
 		co_return load_fail();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,7 +1,9 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
 /*
 	This file is part of Warzone 2100.
 	Copyright (C) 1999-2004  Eidos Interactive
-	Copyright (C) 2005-2020  Warzone 2100 Project
+	Copyright (C) 2005-2026  Warzone 2100 Project (https://github.com/Warzone2100)
 
 	Warzone 2100 is free software; you can redistribute it and/or modify
 	it under the terms of the GNU General Public License as published by
@@ -82,6 +84,10 @@
 #include "frontend.h"
 #include "game.h"
 #include "init.h"
+#include "lib/framework/resource_loading_controller.h"
+#include "lib/framework/loading_task.h"
+#include "resource_loading_dispatch.h"
+#include "multiint.h"
 #include "levels.h"
 #include "lighting.h"
 #include "loadsave.h"
@@ -198,6 +204,8 @@ static bool ignoredSIGPIPE = false;
 #endif
 
 static void stopGameLoop();
+static void startTitleLoop(bool onInitialStartup = false);
+static LoadingTask<> startTitleLoopTask(ResourceLoadingController& controller, bool onInitialStartup = false);
 
 #if defined(WZ_OS_WIN)
 
@@ -730,23 +738,25 @@ static void make_dir(char *dest, const char *dirname, const char *subdir)
  * Preparations before entering the title (mainmenu) loop
  * Would start the timer in an event based mainloop
  */
-static void startTitleLoop(bool onInitialStartup = false)
+static void startTitleLoop(bool onInitialStartup)
+{
+	auto& controller = ResourceLoadingController::instance();
+	ResourceLoadingController::FramePolicy policy;
+	policy.showLoadingScreen = !onInitialStartup;
+	(void)runBlockingResourceLoad(startTitleLoopTask(controller, onInitialStartup), policy);
+}
+
+static LoadingTask<> startTitleLoopTask(ResourceLoadingController& controller, bool onInitialStartup /* = false */)
 {
 	SetGameMode(GS_TITLE_SCREEN);
 
-	if (!onInitialStartup)
-	{
-		initLoadingScreen(true);
-	}
-	if (!frontendInitialise("wrf/frontend.wrf"))
-	{
+	if (!(co_await frontendInitTask(controller, onInitialStartup))) {
 		debug(LOG_FATAL, "Shutting down after failure");
 		exit(EXIT_FAILURE);
 	}
 
-	closeLoadingScreen(); // always ensure the loading screen is closed
+	co_return load_ok();
 }
-
 
 /*!
  * Shutdown/cleanup after the title (mainmenu) loop
@@ -784,11 +794,14 @@ static void setCDAudioForCurrentGameMode()
 	}
 }
 
-/*!
- * Preparations before entering the game loop
- * Would start the timer in an event based mainloop
- */
-static bool startGameLoop()
+static bool saveGameLoadAfter();
+
+namespace
+{
+
+// Prepares entering a new match (multiplayer timeouts, `setGameMode(GS_NORMAL)`,
+// loading screen, activity / CD-audio) before `levLoadData()`.
+void startGameBeforeLevelLoad()
 {
 	if (runningMultiplayer())
 	{
@@ -804,25 +817,33 @@ static bool startGameLoop()
 
 	// set up CD audio for game mode
 	setCDAudioForCurrentGameMode();
+}
 
-	// Not sure what aLevelName is, in relation to game.map. But need to use aLevelName here, to be able to start the right map for campaign, and need game.hash, to start the right non-campaign map, if there are multiple identically named maps.
-	if (!levLoadData(aLevelName, &game.hash, nullptr, GTYPE_SCENARIO_START))
+// Tears down after a failed start-game load and returns to the title loop.
+LoadingTask<> startGameAbortLevelLoadFailure(ResourceLoadingController& controller)
+{
+	debug(LOG_ERROR, "Failed to load level data / map: %s %s", aLevelName, (!game.hash.isZero()) ? game.hash.toString().c_str() : "");
+	if (bMultiPlayer)
 	{
-		debug(LOG_ERROR, "Failed to load level data / map: %s %s", aLevelName, (!game.hash.isZero()) ? game.hash.toString().c_str() : "");
-		if (bMultiPlayer)
-		{
-			multiGameShutdown();
-		}
-		levReleaseAll();
-		closeLoadingScreen();
-		cdAudio_SetGameMode(MusicGameMode::MENUS);
-		stopGameLoop();
-		pie_LoadBackDrop(SCREEN_RANDOMBDROP);
-		startTitleLoop(); // Restart into titleloop
-		gameLoopStatus = GAMECODE_CONTINUE;
-		return false;
+		multiGameShutdown();
 	}
+	levReleaseAll();
+	closeLoadingScreen();
+	cdAudio_SetGameMode(MusicGameMode::MENUS);
+	stopGameLoop();
+	pie_LoadBackDrop(SCREEN_RANDOMBDROP);
+	if (!(co_await startTitleLoopTask(controller))) // Restart into titleloop
+	{
+		co_return load_fail();
+	}
+	gameLoopStatus = GAMECODE_CONTINUE;
 
+	co_return load_ok();
+}
+
+// Post-success setup after `levLoadData()` (UI, gameInitialised, triggers, replay-related, etc.).
+bool startGameAfterLevelLoad()
+{
 	screen_StopBackDrop();
 	closeLoadingScreen();
 
@@ -907,6 +928,133 @@ static bool startGameLoop()
 	return true;
 }
 
+/*!
+ * Preparations before entering the game loop
+ * Would start the timer in an event based mainloop
+ */
+LoadingTask<> startGameResourceTaskImpl(ResourceLoadingController &controller)
+{
+	co_await controller.yieldFrame();
+
+	initLoadingScreen(true);
+
+	co_await controller.yieldFrame();
+
+	startGameBeforeLevelLoad();
+
+	co_await controller.yieldFrame();
+
+	// Not sure what aLevelName is, in relation to game.map. But need to use aLevelName here, to be able to start the right map for campaign, and need game.hash, to start the right non-campaign map, if there are multiple identically named maps.
+	LoadResult<> const lev =
+	    co_await makeLevLoadDataLoadingTask(controller, aLevelName, &game.hash, nullptr, GTYPE_SCENARIO_START);
+	if (!lev)
+	{
+		co_return load_fail();
+	}
+
+	co_await controller.yieldFrame();
+
+	co_return startGameAfterLevelLoad() ? load_ok() : load_fail();
+}
+
+// On save load failure: log/popup, fast-exit game loop, return to title.
+LoadingTask<> saveGameLoadAbortOnFailure(ResourceLoadingController& controller)
+{
+	// FIXME: we really should throw up a error window, but we can't (easily) so I won't.
+	debug(LOG_ERROR, "Trying to load Game %s failed!", saveGameName);
+	debug(LOG_POPUP, _("Failed to load a save game! It is either corrupted or a unsupported format.\n\nRestarting main menu."));
+	// FIXME: If we bomb out on a in game load, then we would crash if we don't do the next two calls
+	// Doesn't seem to be a way to tell where we are in game loop to determine if/when we should do the two calls.
+	gameLoopStatus = GAMECODE_FASTEXIT;
+	// we had a error loading savegame (corrupt?), so go back to title screen?
+	stopGameLoop();
+	if (!(co_await startTitleLoopTask(controller))) // Restart into titleloop
+	{
+		co_return load_fail();
+	}
+	changeTitleMode(TITLE);
+	SetGameMode(GS_TITLE_SCREEN);
+
+	co_return load_ok();
+}
+
+LoadingTask<> loadSaveGameResourceTaskImpl(ResourceLoadingController &controller)
+{
+	co_await controller.yieldFrame();
+
+	SetGameMode(GS_NORMAL);
+
+	co_await controller.yieldFrame();
+
+	if (!(co_await loadGameInit(controller, GameLoadDetails::makeUserSaveGameLoad(saveGameName)))) {
+		co_return load_fail();
+	}
+
+	co_await controller.yieldFrame();
+
+	co_return saveGameLoadAfter() ? load_ok() : load_fail();
+}
+
+} // anonymous namespace
+
+LoadingTask<> startGameResourceTask(ResourceLoadingController &controller)
+{
+	if (co_await startGameResourceTaskImpl(controller))
+	{
+		closeLoadingScreen();
+		co_return load_ok();
+	}
+	if (!(co_await startGameAbortLevelLoadFailure(controller)))
+	{
+		closeLoadingScreen();
+		co_return load_fail();
+	}
+	closeLoadingScreen();
+	debug(LOG_POPUP, _("Failed to load level data or map. Exiting to main menu."));
+	co_return load_fail();
+}
+
+LoadingTask<> loadSaveGameResourceTask(ResourceLoadingController &controller)
+{
+	if (co_await loadSaveGameResourceTaskImpl(controller))
+	{
+		closeLoadingScreen();
+		co_return load_ok();
+	}
+	if (!(co_await saveGameLoadAbortOnFailure(controller)))
+	{
+		closeLoadingScreen();
+		co_return load_fail();
+	}
+	closeLoadingScreen();
+	co_return load_fail();
+}
+
+static bool saveGameLoadAfter()
+{
+	ActivityManager::instance().startingSavedGame();
+	// set up CD audio for game mode
+	// (must come after savegame is loaded so that proper game mode can be determined)
+	setCDAudioForCurrentGameMode();
+
+	screen_StopBackDrop();
+	closeLoadingScreen();
+
+	// Trap the cursor if cursor snapping is enabled
+	if (shouldTrapCursor())
+	{
+		wzGrabMouse();
+	}
+	if (challengeActive)
+	{
+		addMissionTimerInterface();
+	}
+
+	// set a flag for the trigger/event system to indicate initialisation is complete
+	gameInitialised = true;
+
+	return true;
+}
 
 /*!
  * Shutdown/cleanup after the game loop
@@ -966,57 +1114,6 @@ static void stopGameLoop()
 
 
 /*!
- * Load a savegame and start into the game loop
- * Game data should be initialised afterwards, so that startGameLoop is not necessary anymore.
- */
-static bool initSaveGameLoad()
-{
-	// NOTE: always setGameMode correctly before *any* loading routines!
-	SetGameMode(GS_NORMAL);
-	initLoadingScreen(true);
-
-	// load up a save game
-	if (!loadGameInit(GameLoadDetails::makeUserSaveGameLoad(saveGameName)))
-	{
-		// FIXME: we really should throw up a error window, but we can't (easily) so I won't.
-		debug(LOG_ERROR, "Trying to load Game %s failed!", saveGameName);
-		debug(LOG_POPUP, "Failed to load a save game! It is either corrupted or a unsupported format.\n\nRestarting main menu.");
-		// FIXME: If we bomb out on a in game load, then we would crash if we don't do the next two calls
-		// Doesn't seem to be a way to tell where we are in game loop to determine if/when we should do the two calls.
-		gameLoopStatus = GAMECODE_FASTEXIT;	// clear out all old data
-		stopGameLoop();
-		startTitleLoop(); // Restart into titleloop
-		SetGameMode(GS_TITLE_SCREEN);
-		return false;
-	}
-
-	ActivityManager::instance().startingSavedGame();
-
-	// set up CD audio for game mode
-	// (must come after savegame is loaded so that proper game mode can be determined)
-	setCDAudioForCurrentGameMode();
-
-	screen_StopBackDrop();
-	closeLoadingScreen();
-
-	// Trap the cursor if cursor snapping is enabled
-	if (shouldTrapCursor())
-	{
-		wzGrabMouse();
-	}
-	if (challengeActive)
-	{
-		addMissionTimerInterface();
-	}
-
-	// set a flag for the trigger/event system to indicate initialisation is complete
-	gameInitialised = true;
-
-	return true;
-}
-
-
-/*!
  * Run the code inside the gameloop
  */
 static void runGameLoop()
@@ -1036,20 +1133,16 @@ static void runGameLoop()
 	case GAMECODE_LOADGAME:
 		debug(LOG_MAIN, "GAMECODE_LOADGAME");
 		stopGameLoop();
-		initSaveGameLoad(); // Restart and load a savegame
+		// Restart and load a savegame
+		submitResourceLoadingTask(loadSaveGameResourceTask);
 		gameLoopStatus = GAMECODE_CONTINUE;
 		return;
 	case GAMECODE_NEWLEVEL:
 		debug(LOG_MAIN, "GAMECODE_NEWLEVEL");
 		stopGameLoop();
-		if (startGameLoop()) // Restart gameloop
-		{
-			gameLoopStatus = GAMECODE_CONTINUE;
-		}
-		else
-		{
-			debug(LOG_POPUP, _("Failed to load level data or map. Exiting to main menu."));
-		}
+		// Restart gameloop
+		submitResourceLoadingTask(startGameResourceTask);
+		gameLoopStatus = GAMECODE_CONTINUE;
 		return;
 	default:
 		// ignore other values, and proceed with gameLoop
@@ -1105,27 +1198,14 @@ static void runTitleLoop()
 				debug(LOG_MAIN, "TITLECODE_SAVEGAMELOAD");
 				// Restart into gameloop and load a savegame, ONLY on a good savegame load!
 				stopTitleLoop();
-				if (!initSaveGameLoad())
-				{
-					// we had a error loading savegame (corrupt?), so go back to title screen?
-					stopGameLoop();
-					startTitleLoop();
-					changeTitleMode(TITLE);
-				}
-				closeLoadingScreen();
+				submitResourceLoadingTask(loadSaveGameResourceTask);
 				return;
 			}
 		case TITLECODE_STARTGAME:
 			debug(LOG_MAIN, "TITLECODE_STARTGAME");
 			stopTitleLoop();
-			if (startGameLoop()) // Restart into gameloop
-			{
-				closeLoadingScreen();
-			}
-			else
-			{
-				debug(LOG_POPUP, _("Failed to load level data or map. Exiting to main menu."));
-			}
+			// Restart into gameloop
+			submitResourceLoadingTask(startGameResourceTask);
 			return;
 		default:
 			// ignore unexpected value
@@ -1188,12 +1268,18 @@ void mainLoop()
 
 	if (NetPlay.bComms || focusState == FOCUS_IN || !war_GetPauseOnFocusLoss())
 	{
-		if (loop_GetVideoStatus())
+		bool frameEnded = false;
+		if (tickResourceLoadingFrame())
+		{
+			pie_ScreenFrameRenderEnd();
+			frameEnded = true;
+		}
+		if (!frameEnded && loop_GetVideoStatus())
 		{
 			videoLoop(); // Display the video if necessary
 			pie_ScreenFrameRenderEnd();
 		}
-		else switch (GetGameMode())
+		else if (!frameEnded) switch (GetGameMode())
 			{
 			case GS_NORMAL: // Run the gameloop code
 				runGameLoop();
@@ -1221,6 +1307,27 @@ void mainLoop()
 #if defined(ENABLE_DISCORD)
 	discordRPCPerFrame();
 #endif
+}
+
+void requestMapPreviewLoad(bool hideInterface)
+{
+	submitResourceLoadingTask(
+		[hideInterface](ResourceLoadingController &c) { return mapPreviewLoadTask(c, hideInterface); },
+		false,
+		false,
+		ResourceLoadingController::FrameProcessingMode::ContinueMainLoop);
+}
+
+void requestMapPreviewLoad(bool hideInterface, const char *mapName, const Sha256& mapHash)
+{
+	submitResourceLoadingTask(
+		[hideInterface, mapName = std::string(mapName), mapHash](ResourceLoadingController &c)
+		{
+			return mapPreviewLoadTask(c, hideInterface, std::move(mapName), mapHash);
+		},
+		false,
+		false,
+		ResourceLoadingController::FrameProcessingMode::ContinueMainLoop);
 }
 
 bool getUTF8CmdLine(int *const _utfargc WZ_DECL_UNUSED, char *** const _utfargv WZ_DECL_UNUSED) // explicitely pass by reference
@@ -2089,22 +2196,17 @@ int realmain(int argc, char *argv[])
 	{
 	case GS_TITLE_SCREEN:
 		// The usual case (unless command-line flags specify otherwise): Load into the title menu
-		startTitleLoop(true);
+		submitResourceLoadingTask([](ResourceLoadingController &c) { return frontendInitTask(c, true); }, false, false);
 		break;
 	case GS_SAVEGAMELOAD:
 		if (headlessGameMode())
 		{
 			fprintf(stdout, "Loading savegame ...\n");
 		}
-		initSaveGameLoad();
+		submitResourceLoadingTask(loadSaveGameResourceTask);
 		break;
 	case GS_NORMAL:
-		if (!startGameLoop())
-		{
-			// Attempted to load straight into a game from the command-line, but starting the game loop (loading the map, etc) failed
-			// Treat this as a failure and queue an exit
-			wzQuit(EXIT_FAILURE);
-		}
+		submitResourceLoadingTask(startGameResourceTask);
 		break;
 	default:
 		debug(LOG_ERROR, "Weirdy game status, I'm afraid!!");

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1070,6 +1070,9 @@ static void stopGameLoop()
 	{
 		clearBlueprints();
 		initLoadingScreen(true); // returning to f.e. do a loader.render not active
+		presentLoadingScreenForCurrentFrame();
+		pie_ScreenFrameRenderEnd();
+		pie_ScreenFrameRenderBegin();
 		if (gameLoopStatus != GAMECODE_LOADGAME)
 		{
 			game.modHashes.clear(); // must clear this before calling levReleaseAll so that when search paths are reloaded we don't reload mods downloaded for the last game (or loaded for the last replay)

--- a/src/main.h
+++ b/src/main.h
@@ -70,7 +70,7 @@ void SetGameMode(GS_GAMEMODE status);
 void mainLoop();
 
 void requestMapPreviewLoad(bool hideInterface);
-void requestMapPreviewLoad(bool hideInterface, const char *mapName, const Sha256& mapHash);
+void requestMapPreviewLoad(bool hideInterface, std::string mapName, const Sha256& mapHash);
 
 extern char SaveGamePath[PATH_MAX];
 extern char ReplayPath[PATH_MAX];

--- a/src/main.h
+++ b/src/main.h
@@ -1,7 +1,9 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
 /*
 	This file is part of Warzone 2100.
 	Copyright (C) 1999-2004  Eidos Interactive
-	Copyright (C) 2005-2020  Warzone 2100 Project
+	Copyright (C) 2005-2026  Warzone 2100 Project (https://github.com/Warzone2100)
 
 	Warzone 2100 is free software; you can redistribute it and/or modify
 	it under the terms of the GNU General Public License as published by
@@ -20,6 +22,8 @@
 
 #ifndef __INCLUDED_SRC_MAIN_H__
 #define __INCLUDED_SRC_MAIN_H__
+
+struct Sha256;
 
 enum GS_GAMEMODE
 {
@@ -64,6 +68,9 @@ struct SaveGamePath_t
 GS_GAMEMODE GetGameMode() WZ_DECL_PURE;
 void SetGameMode(GS_GAMEMODE status);
 void mainLoop();
+
+void requestMapPreviewLoad(bool hideInterface);
+void requestMapPreviewLoad(bool hideInterface, const char *mapName, const Sha256& mapHash);
 
 extern char SaveGamePath[PATH_MAX];
 extern char ReplayPath[PATH_MAX];

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -1,7 +1,9 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
 /*
 	This file is part of Warzone 2100.
 	Copyright (C) 1999-2004  Eidos Interactive
-	Copyright (C) 2005-2020  Warzone 2100 Project
+	Copyright (C) 2005-2026  Warzone 2100 Project (https://github.com/Warzone2100)
 
 	Warzone 2100 is free software; you can redistribute it and/or modify
 	it under the terms of the GNU General Public License as published by
@@ -35,6 +37,7 @@
 #include <wzmaplib/map.h>
 
 #include "map.h"
+#include "terrain.h"
 #include "hci.h"
 #include "projectile.h"
 #include "display3d.h"
@@ -1001,7 +1004,7 @@ void WzMapDebugLogger::printLog(WzMap::LoggingProtocol::LogLevel level, const ch
 }
 
 /* Initialise the map structure */
-bool mapLoad(char const *filename, WorldMapState& mapState)
+LoadingTask<> mapLoad(ResourceLoadingController& controller, char const *filename, WorldMapState& mapState)
 {
 	WzMapPhysFSIO mapIO;
 	WzMapDebugLogger debugLoggerInstance;
@@ -1010,10 +1013,9 @@ bool mapLoad(char const *filename, WorldMapState& mapState)
 	if (!loadedMap)
 	{
 		// loadMapData call handles logging errors
-		return false;
+		co_return load_fail();
 	}
-	return mapLoadFromWzMapData(loadedMap, mapState);
-
+	co_return co_await mapLoadFromWzMapData(controller, loadedMap, mapState);
 }
 
 // -----------------------------------------------------------------------------------------
@@ -1047,7 +1049,7 @@ bool loadTerrainTypeMap(const std::shared_ptr<WzMap::TerrainTypeData>& ttypeData
 }
 
 ///* Initialise the map structure */
-bool mapLoadFromWzMapData(std::shared_ptr<WzMap::MapData> loadedMap, WorldMapState& mapState)
+LoadingTask<> mapLoadFromWzMapData(ResourceLoadingController& controller, std::shared_ptr<WzMap::MapData> loadedMap, WorldMapState& mapState)
 {
 	uint32_t		width, height;
 	const bool		preview = false;
@@ -1077,14 +1079,20 @@ bool mapLoadFromWzMapData(std::shared_ptr<WzMap::MapData> loadedMap, WorldMapSta
 	// load the ground types
 	if (!mapLoadGroundTypes(preview))
 	{
-		return false;
+		co_return load_fail();
 	}
+
+	co_await controller.yieldFrame();
 
 	if (!preview)
 	{
-		//preload the terrain textures
-		loadTerrainTextures(currentMapTileset);
+		if (!(co_await loadTerrainTextures(controller, currentMapTileset)))
+		{
+			co_return load_fail();
+		}
 	}
+
+	co_await controller.yieldFrame();
 
 	//load in the map data itself
 
@@ -1107,8 +1115,10 @@ bool mapLoadFromWzMapData(std::shared_ptr<WzMap::MapData> loadedMap, WorldMapSta
 	if (preview)
 	{
 		// no need to do anything else for the map preview
-		return true;
+		co_return load_ok();
 	}
+
+	co_await controller.yieldFrame();
 
 	size_t gwIdx = 0;
 	for (const auto gateway : loadedMap->mGateways)
@@ -1120,12 +1130,14 @@ bool mapLoadFromWzMapData(std::shared_ptr<WzMap::MapData> loadedMap, WorldMapSta
 		gwIdx++;
 	}
 
+	co_await controller.yieldFrame();
+
 	if (!afterMapLoad(mapState))
 	{
-		return false;
+		co_return load_fail();
 	}
 
-	return true;
+	co_return load_ok();
 }
 
 static bool afterMapLoad(WorldMapState& mapState)

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -56,6 +56,7 @@
 #include "fpath.h"
 #include "levels.h"
 #include "lib/framework/wzapp.h"
+#include "lib/framework/load_result.h"
 #include "lib/ivis_opengl/pielighting.h"
 
 #define GAME_TICKS_FOR_DANGER (GAME_TICKS_PER_SEC * 2)
@@ -1003,9 +1004,27 @@ void WzMapDebugLogger::printLog(WzMap::LoggingProtocol::LogLevel level, const ch
 	}
 }
 
+namespace
+{
+
+static LoadResult<> mapLoadFail(WorldMapState& mapState)
+{
+	gwShutDown(mapState);
+	mapState = {};
+
+	shutdownTerrain();
+
+	return load_fail();
+}
+
+} // namespace
+
 /* Initialise the map structure */
 LoadingTask<> mapLoad(ResourceLoadingController& controller, char const *filename, WorldMapState& mapState)
 {
+	gwShutDown(mapState);
+	mapState = {};
+
 	WzMapPhysFSIO mapIO;
 	WzMapDebugLogger debugLoggerInstance;
 
@@ -1062,7 +1081,6 @@ LoadingTask<> mapLoadFromWzMapData(ResourceLoadingController& controller, std::s
 
 	/* Allocate the memory for the map */
 	mapState.tiles = std::make_unique<MAPTILE[]>(static_cast<size_t>(width) * height);
-	getCurrentLightmapData().reset(width, height);
 	ASSERT(mapState.tiles != nullptr, "Out of memory");
 
 	mapState.width = width;
@@ -1079,7 +1097,7 @@ LoadingTask<> mapLoadFromWzMapData(ResourceLoadingController& controller, std::s
 	// load the ground types
 	if (!mapLoadGroundTypes(preview))
 	{
-		co_return load_fail();
+		co_return mapLoadFail(mapState);
 	}
 
 	co_await controller.yieldFrame();
@@ -1088,7 +1106,7 @@ LoadingTask<> mapLoadFromWzMapData(ResourceLoadingController& controller, std::s
 	{
 		if (!(co_await loadTerrainTextures(controller, currentMapTileset)))
 		{
-			co_return load_fail();
+			co_return mapLoadFail(mapState);
 		}
 	}
 
@@ -1115,6 +1133,7 @@ LoadingTask<> mapLoadFromWzMapData(ResourceLoadingController& controller, std::s
 	if (preview)
 	{
 		// no need to do anything else for the map preview
+		getCurrentLightmapData().reset(width, height);
 		co_return load_ok();
 	}
 
@@ -1134,9 +1153,10 @@ LoadingTask<> mapLoadFromWzMapData(ResourceLoadingController& controller, std::s
 
 	if (!afterMapLoad(mapState))
 	{
-		co_return load_fail();
+		co_return mapLoadFail(mapState);
 	}
 
+	getCurrentLightmapData().reset(width, height);
 	co_return load_ok();
 }
 
@@ -1257,8 +1277,6 @@ bool mapSaveToWzMapData(WzMap::MapData& output, const WorldMapState& mapState)
 /* Shutdown the map module */
 bool mapShutdown()
 {
-	int x;
-
 	if (dangerThread)
 	{
 		wzSemaphoreWait(dangerDoneSemaphore);
@@ -1273,21 +1291,14 @@ bool mapShutdown()
 	}
 
 	mapDecals = nullptr;
-	gameWorld.map.blockMap[AUX_MAP] = nullptr;
-	gameWorld.map.blockMap[AUX_ASTARMAP] = nullptr;
 	free(floodbucket);
-	gameWorld.map.blockMap[AUX_DANGERMAP] = nullptr;
-	for (x = 0; x < MAX_PLAYERS + AUX_MAX; x++)
-	{
-		gameWorld.map.auxMap[x].reset();
-	}
+	gwShutDown(gameWorld.map);
+	gameWorld.map = {};
 
 	map = nullptr;
 	floodbucket = nullptr;
 	groundTypes.clear();
 	mapDecals = nullptr;
-	gameWorld.map.tiles = nullptr;
-	gameWorld.map.width = gameWorld.map.height = 0;
 	numTile_names = 0;
 	Tile_names = nullptr;
 	if (tilesetDir)

--- a/src/map.h
+++ b/src/map.h
@@ -1,7 +1,9 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
 /*
 	This file is part of Warzone 2100.
 	Copyright (C) 1999-2004  Eidos Interactive
-	Copyright (C) 2005-2020  Warzone 2100 Project
+	Copyright (C) 2005-2026  Warzone 2100 Project (https://github.com/Warzone2100)
 
 	Warzone 2100 is free software; you can redistribute it and/or modify
 	it under the terms of the GNU General Public License as published by
@@ -26,8 +28,10 @@
 
 #include "lib/framework/frame.h"
 #include "lib/framework/debug.h"
+#include "lib/framework/loading_task.h"
 #include <wzmaplib/map.h>
 #include <wzmaplib/terrain_type.h>
+#include "lib/framework/resource_loading_controller.h"
 #include "objects.h"
 #include "terrain.h"
 #include "multiplay.h"
@@ -355,11 +359,13 @@ static inline void clip_world_offmap(const WorldMapState& mapState, int *worldX,
 /* Shutdown the map module */
 bool mapShutdown();
 
+class ResourceLoadingController;
+
 /* Load the map data */
-bool mapLoad(char const *filename, WorldMapState& mapState);
+LoadingTask<> mapLoad(ResourceLoadingController& controller, char const *filename, WorldMapState& mapState);
 struct ScriptMapData;
 bool loadTerrainTypeMap(const std::shared_ptr<WzMap::TerrainTypeData>& ttypeData);
-bool mapLoadFromWzMapData(std::shared_ptr<WzMap::MapData> mapData, WorldMapState& mapState);
+LoadingTask<> mapLoadFromWzMapData(ResourceLoadingController& controller, std::shared_ptr<WzMap::MapData> mapData, WorldMapState& mapState);
 
 // used to reload decal + ground types types when switching terrain overrides
 bool mapReloadGroundTypes();

--- a/src/mission.cpp
+++ b/src/mission.cpp
@@ -156,12 +156,12 @@ static UBYTE   bPlayCountDown;
 //FUNCTIONS**************
 static void addLandingLights(UDWORD x, UDWORD y);
 static void resetHomeStructureObjects();
-static LoadingTask<> startMissionOffClear(ResourceLoadingController& controller, const GameLoadDetails& gameToLoad);
-static LoadingTask<> startMissionOffKeep(ResourceLoadingController& controller, const GameLoadDetails& gameToLoad);
-static LoadingTask<> startMissionCampaignStart(ResourceLoadingController& controller, const GameLoadDetails& gameToLoad);
-static LoadingTask<> startMissionCampaignChange(ResourceLoadingController& controller, const GameLoadDetails& gameToLoad);
-static LoadingTask<> startMissionCampaignExpand(ResourceLoadingController& controller, const GameLoadDetails& gameToLoad);
-static LoadingTask<> startMissionCampaignExpandLimbo(ResourceLoadingController& controller, const GameLoadDetails& gameToLoad);
+static LoadingTask<> startMissionOffClear(ResourceLoadingController& controller, GameLoadDetails gameToLoad);
+static LoadingTask<> startMissionOffKeep(ResourceLoadingController& controller, GameLoadDetails gameToLoad);
+static LoadingTask<> startMissionCampaignStart(ResourceLoadingController& controller, GameLoadDetails gameToLoad);
+static LoadingTask<> startMissionCampaignChange(ResourceLoadingController& controller, GameLoadDetails gameToLoad);
+static LoadingTask<> startMissionCampaignExpand(ResourceLoadingController& controller, GameLoadDetails gameToLoad);
+static LoadingTask<> startMissionCampaignExpandLimbo(ResourceLoadingController& controller, GameLoadDetails gameToLoad);
 static bool startMissionBetween();
 static void endMissionCamChange();
 static void endMissionOffClear();
@@ -389,7 +389,7 @@ void setMissionCountDown()
 }
 
 
-LoadingTask<> startMission(ResourceLoadingController& controller, LEVEL_TYPE missionType, const GameLoadDetails& gameDetails)
+LoadingTask<> startMission(ResourceLoadingController& controller, LEVEL_TYPE missionType, GameLoadDetails gameDetails)
 {
 	bool	loaded = true;
 
@@ -1066,7 +1066,7 @@ void saveCampaignData()
 
 
 //start an off world mission - clearing the object lists
-LoadingTask<> startMissionOffClear(ResourceLoadingController& controller, const GameLoadDetails& gameToLoad)
+LoadingTask<> startMissionOffClear(ResourceLoadingController& controller, GameLoadDetails gameToLoad)
 {
 	debug(LOG_SAVE, "called for %s", gameToLoad.filePath.c_str());
 
@@ -1087,7 +1087,7 @@ LoadingTask<> startMissionOffClear(ResourceLoadingController& controller, const 
 }
 
 //start an off world mission - keeping the object lists
-LoadingTask<> startMissionOffKeep(ResourceLoadingController& controller, const GameLoadDetails& gameToLoad)
+LoadingTask<> startMissionOffKeep(ResourceLoadingController& controller, GameLoadDetails gameToLoad)
 {
 	debug(LOG_SAVE, "called for %s", gameToLoad.filePath.c_str());
 	saveMissionData();
@@ -1106,7 +1106,7 @@ LoadingTask<> startMissionOffKeep(ResourceLoadingController& controller, const G
 	co_return load_ok();
 }
 
-LoadingTask<> startMissionCampaignStart(ResourceLoadingController& controller, const GameLoadDetails& gameToLoad)
+LoadingTask<> startMissionCampaignStart(ResourceLoadingController& controller, GameLoadDetails gameToLoad)
 {
 	debug(LOG_SAVE, "called for %s", gameToLoad.filePath.c_str());
 
@@ -1127,7 +1127,7 @@ LoadingTask<> startMissionCampaignStart(ResourceLoadingController& controller, c
 	co_return load_ok();
 }
 
-LoadingTask<> startMissionCampaignChange(ResourceLoadingController& controller, const GameLoadDetails& gameToLoad)
+LoadingTask<> startMissionCampaignChange(ResourceLoadingController& controller, GameLoadDetails gameToLoad)
 {
 	// Clear out all intelligence screen messages
 	freeMessages();
@@ -1154,7 +1154,7 @@ LoadingTask<> startMissionCampaignChange(ResourceLoadingController& controller, 
 	co_return load_ok();
 }
 
-LoadingTask<> startMissionCampaignExpand(ResourceLoadingController& controller, const GameLoadDetails& gameToLoad)
+LoadingTask<> startMissionCampaignExpand(ResourceLoadingController& controller, GameLoadDetails gameToLoad)
 {
 	//load in the new game details
 	if (!(co_await loadGame(controller, gameToLoad, KEEPOBJECTS, !FREEMEM)))
@@ -1166,7 +1166,7 @@ LoadingTask<> startMissionCampaignExpand(ResourceLoadingController& controller, 
 	co_return load_ok();
 }
 
-LoadingTask<> startMissionCampaignExpandLimbo(ResourceLoadingController& controller, const GameLoadDetails& gameToLoad)
+LoadingTask<> startMissionCampaignExpandLimbo(ResourceLoadingController& controller, GameLoadDetails gameToLoad)
 {
 	saveMissionLimboData();
 

--- a/src/mission.cpp
+++ b/src/mission.cpp
@@ -1,7 +1,9 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
 /*
 	This file is part of Warzone 2100.
 	Copyright (C) 1999-2004  Eidos Interactive
-	Copyright (C) 2005-2020  Warzone 2100 Project
+	Copyright (C) 2005-2026  Warzone 2100 Project (https://github.com/Warzone2100)
 
 	Warzone 2100 is free software; you can redistribute it and/or modify
 	it under the terms of the GNU General Public License as published by
@@ -45,6 +47,7 @@
 #include "challenge.h"
 #include "projectile.h"
 #include "power.h"
+#include "lib/framework/resource_loading_controller.h"
 #include "structure.h"
 #include "message.h"
 #include "research.h"
@@ -85,6 +88,7 @@
 #include "game_world.h"
 #include "wzapi.h"
 #include "screens/guidescreen.h"
+#include "lib/framework/loading_task.h"
 
 #define		IDMISSIONRES_TXT		11004
 #define		IDMISSIONRES_LOAD		11005
@@ -152,12 +156,12 @@ static UBYTE   bPlayCountDown;
 //FUNCTIONS**************
 static void addLandingLights(UDWORD x, UDWORD y);
 static void resetHomeStructureObjects();
-static bool startMissionOffClear(const GameLoadDetails& gameToLoad);
-static bool startMissionOffKeep(const GameLoadDetails& gameToLoad);
-static bool startMissionCampaignStart(const GameLoadDetails& gameToLoad);
-static bool startMissionCampaignChange(const GameLoadDetails& gameToLoad);
-static bool startMissionCampaignExpand(const GameLoadDetails& gameToLoad);
-static bool startMissionCampaignExpandLimbo(const GameLoadDetails& gameToLoad);
+static LoadingTask<> startMissionOffClear(ResourceLoadingController& controller, const GameLoadDetails& gameToLoad);
+static LoadingTask<> startMissionOffKeep(ResourceLoadingController& controller, const GameLoadDetails& gameToLoad);
+static LoadingTask<> startMissionCampaignStart(ResourceLoadingController& controller, const GameLoadDetails& gameToLoad);
+static LoadingTask<> startMissionCampaignChange(ResourceLoadingController& controller, const GameLoadDetails& gameToLoad);
+static LoadingTask<> startMissionCampaignExpand(ResourceLoadingController& controller, const GameLoadDetails& gameToLoad);
+static LoadingTask<> startMissionCampaignExpandLimbo(ResourceLoadingController& controller, const GameLoadDetails& gameToLoad);
 static bool startMissionBetween();
 static void endMissionCamChange();
 static void endMissionOffClear();
@@ -385,7 +389,7 @@ void setMissionCountDown()
 }
 
 
-bool startMission(LEVEL_TYPE missionType, const GameLoadDetails& gameDetails)
+LoadingTask<> startMission(ResourceLoadingController& controller, LEVEL_TYPE missionType, const GameLoadDetails& gameDetails)
 {
 	bool	loaded = true;
 
@@ -406,7 +410,7 @@ bool startMission(LEVEL_TYPE missionType, const GameLoadDetails& gameDetails)
 		/*mission type gets set to none when you have returned from a mission
 		so don't want to go another mission when already on one! - so ignore*/
 		debug(LOG_SAVE, "Already on a mission");
-		return true;
+		co_return load_ok();
 	}
 
 	initEffectsSystem();
@@ -414,7 +418,10 @@ bool startMission(LEVEL_TYPE missionType, const GameLoadDetails& gameDetails)
 	//load the game file for all types of mission except a Between Mission
 	if (missionType != LEVEL_TYPE::LDS_BETWEEN)
 	{
-		loadGameInit(gameDetails);
+		if (!(co_await loadGameInit(controller, gameDetails)))
+		{
+			co_return load_fail();
+		}
 	}
 
 	//all proximity messages are removed between missions now
@@ -423,14 +430,14 @@ bool startMission(LEVEL_TYPE missionType, const GameLoadDetails& gameDetails)
 	switch (missionType)
 	{
 	case LEVEL_TYPE::LDS_CAMSTART:
-		if (!startMissionCampaignStart(gameDetails))
+		if (!(co_await startMissionCampaignStart(controller, gameDetails)))
 		{
 			loaded = false;
 		}
 		break;
 	case LEVEL_TYPE::LDS_MKEEP:
 	case LEVEL_TYPE::LDS_MKEEP_LIMBO:
-		if (!startMissionOffKeep(gameDetails))
+		if (!(co_await startMissionOffKeep(controller, gameDetails)))
 		{
 			loaded = false;
 		}
@@ -443,25 +450,25 @@ bool startMission(LEVEL_TYPE missionType, const GameLoadDetails& gameDetails)
 		}
 		break;
 	case LEVEL_TYPE::LDS_CAMCHANGE:
-		if (!startMissionCampaignChange(gameDetails))
+		if (!(co_await startMissionCampaignChange(controller, gameDetails)))
 		{
 			loaded = false;
 		}
 		break;
 	case LEVEL_TYPE::LDS_EXPAND:
-		if (!startMissionCampaignExpand(gameDetails))
+		if (!(co_await startMissionCampaignExpand(controller, gameDetails)))
 		{
 			loaded = false;
 		}
 		break;
 	case LEVEL_TYPE::LDS_EXPAND_LIMBO:
-		if (!startMissionCampaignExpandLimbo(gameDetails))
+		if (!(co_await startMissionCampaignExpandLimbo(controller, gameDetails)))
 		{
 			loaded = false;
 		}
 		break;
 	case LEVEL_TYPE::LDS_MCLEAR:
-		if (!startMissionOffClear(gameDetails))
+		if (!(co_await startMissionOffClear(controller, gameDetails)))
 		{
 			loaded = false;
 		}
@@ -476,7 +483,7 @@ bool startMission(LEVEL_TYPE missionType, const GameLoadDetails& gameDetails)
 	if (!loaded)
 	{
 		debug(LOG_ERROR, "Failed to start mission, missiontype = %d, game, %s", (int)missionType, gameDetails.filePath.c_str());
-		return false;
+		co_return load_fail();
 	}
 
 	mission.type = missionType;
@@ -498,7 +505,7 @@ bool startMission(LEVEL_TYPE missionType, const GameLoadDetails& gameDetails)
 
 	scoreInitSystem();
 
-	return true;
+	co_return load_ok();
 }
 
 
@@ -1059,16 +1066,16 @@ void saveCampaignData()
 
 
 //start an off world mission - clearing the object lists
-bool startMissionOffClear(const GameLoadDetails& gameToLoad)
+LoadingTask<> startMissionOffClear(ResourceLoadingController& controller, const GameLoadDetails& gameToLoad)
 {
 	debug(LOG_SAVE, "called for %s", gameToLoad.filePath.c_str());
 
 	saveMissionData();
 
 	//load in the new game clearing the lists
-	if (!loadGame(gameToLoad, !KEEPOBJECTS, !FREEMEM))
+	if (!(co_await loadGame(controller, gameToLoad, !KEEPOBJECTS, !FREEMEM)))
 	{
-		return false;
+		co_return load_fail();
 	}
 
 	offWorldKeepLists = false;
@@ -1076,19 +1083,19 @@ bool startMissionOffClear(const GameLoadDetails& gameToLoad)
 	// The message should have been played at the between stage
 	missionCountDown &= ~NOT_PLAYED_ACTIVATED;
 
-	return true;
+	co_return load_ok();
 }
 
 //start an off world mission - keeping the object lists
-bool startMissionOffKeep(const GameLoadDetails& gameToLoad)
+LoadingTask<> startMissionOffKeep(ResourceLoadingController& controller, const GameLoadDetails& gameToLoad)
 {
 	debug(LOG_SAVE, "called for %s", gameToLoad.filePath.c_str());
 	saveMissionData();
 
 	//load in the new game clearing the lists
-	if (!loadGame(gameToLoad, !KEEPOBJECTS, !FREEMEM))
+	if (!(co_await loadGame(controller, gameToLoad, !KEEPOBJECTS, !FREEMEM)))
 	{
-		return false;
+		co_return load_fail();
 	}
 
 	offWorldKeepLists = true;
@@ -1096,10 +1103,10 @@ bool startMissionOffKeep(const GameLoadDetails& gameToLoad)
 	// The message should have been played at the between stage
 	missionCountDown &= ~NOT_PLAYED_ACTIVATED;
 
-	return true;
+	co_return load_ok();
 }
 
-bool startMissionCampaignStart(const GameLoadDetails& gameToLoad)
+LoadingTask<> startMissionCampaignStart(ResourceLoadingController& controller, const GameLoadDetails& gameToLoad)
 {
 	debug(LOG_SAVE, "called for %s", gameToLoad.filePath.c_str());
 
@@ -1110,17 +1117,17 @@ bool startMissionCampaignStart(const GameLoadDetails& gameToLoad)
 	clearCampaignUnits();
 
 	// Load in the new game details
-	if (!loadGame(gameToLoad, !KEEPOBJECTS, FREEMEM))
+	if (!(co_await loadGame(controller, gameToLoad, !KEEPOBJECTS, FREEMEM)))
 	{
-		return false;
+		co_return load_fail();
 	}
 
 	offWorldKeepLists = false;
 
-	return true;
+	co_return load_ok();
 }
 
-bool startMissionCampaignChange(const GameLoadDetails& gameToLoad)
+LoadingTask<> startMissionCampaignChange(ResourceLoadingController& controller, const GameLoadDetails& gameToLoad)
 {
 	// Clear out all intelligence screen messages
 	freeMessages();
@@ -1137,41 +1144,41 @@ bool startMissionCampaignChange(const GameLoadDetails& gameToLoad)
 	saveCampaignData();
 
 	//load in the new game details
-	if (!loadGame(gameToLoad, !KEEPOBJECTS, !FREEMEM))
+	if (!(co_await loadGame(controller, gameToLoad, !KEEPOBJECTS, !FREEMEM)))
 	{
-		return false;
+		co_return load_fail();
 	}
 
 	offWorldKeepLists = false;
 
-	return true;
+	co_return load_ok();
 }
 
-bool startMissionCampaignExpand(const GameLoadDetails& gameToLoad)
+LoadingTask<> startMissionCampaignExpand(ResourceLoadingController& controller, const GameLoadDetails& gameToLoad)
 {
 	//load in the new game details
-	if (!loadGame(gameToLoad, KEEPOBJECTS, !FREEMEM))
+	if (!(co_await loadGame(controller, gameToLoad, KEEPOBJECTS, !FREEMEM)))
 	{
-		return false;
+		co_return load_fail();
 	}
 
 	offWorldKeepLists = false;
-	return true;
+	co_return load_ok();
 }
 
-bool startMissionCampaignExpandLimbo(const GameLoadDetails& gameToLoad)
+LoadingTask<> startMissionCampaignExpandLimbo(ResourceLoadingController& controller, const GameLoadDetails& gameToLoad)
 {
 	saveMissionLimboData();
 
 	//load in the new game details
-	if (!loadGame(gameToLoad, KEEPOBJECTS, !FREEMEM))
+	if (!(co_await loadGame(controller, gameToLoad, KEEPOBJECTS, !FREEMEM)))
 	{
-		return false;
+		co_return load_fail();
 	}
 
 	offWorldKeepLists = false;
 
-	return true;
+	co_return load_ok();
 }
 
 static bool startMissionBetween()

--- a/src/mission.h
+++ b/src/mission.h
@@ -31,7 +31,8 @@
 #include "levels.h"
 #include "missiondef.h"
 #include "group.h"
-#include "lib/framework/resource_loading_controller.h"
+#include "game.h"
+#include "lib/framework/loading_task_fwd.h"
 
 /**
  * The number of areas that can be defined to prevent buildings being placed -
@@ -58,8 +59,9 @@ void releaseMission();
 /** On the PC - sets the countdown played flag. */
 void setMissionCountDown();
 
-struct GameLoadDetails;
-LoadingTask<> startMission(ResourceLoadingController& controller, LEVEL_TYPE missionType, const GameLoadDetails& gameDetails);
+class ResourceLoadingController;
+
+LoadingTask<> startMission(ResourceLoadingController& controller, LEVEL_TYPE missionType, GameLoadDetails gameDetails);
 void endMission();
 
 /** Initialise the mission stuff for a save game. */

--- a/src/mission.h
+++ b/src/mission.h
@@ -1,7 +1,9 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
 /*
 	This file is part of Warzone 2100.
 	Copyright (C) 1999-2004  Eidos Interactive
-	Copyright (C) 2005-2020  Warzone 2100 Project
+	Copyright (C) 2005-2026  Warzone 2100 Project (https://github.com/Warzone2100)
 
 	Warzone 2100 is free software; you can redistribute it and/or modify
 	it under the terms of the GNU General Public License as published by
@@ -29,6 +31,7 @@
 #include "levels.h"
 #include "missiondef.h"
 #include "group.h"
+#include "lib/framework/resource_loading_controller.h"
 
 /**
  * The number of areas that can be defined to prevent buildings being placed -
@@ -56,7 +59,7 @@ void releaseMission();
 void setMissionCountDown();
 
 struct GameLoadDetails;
-bool startMission(LEVEL_TYPE missionType, const GameLoadDetails& gameDetails);
+LoadingTask<> startMission(ResourceLoadingController& controller, LEVEL_TYPE missionType, const GameLoadDetails& gameDetails);
 void endMission();
 
 /** Initialise the mission stuff for a save game. */

--- a/src/multiint.cpp
+++ b/src/multiint.cpp
@@ -747,7 +747,7 @@ private:
 };
 
 /// Loads the entire map just to show a picture of it
-static void loadMapPreview(bool hideInterface, const char *mapName, const Sha256& mapHash)
+static void loadMapPreview(bool hideInterface, std::string mapName, const Sha256& mapHash)
 {
 	std::string		aFileName;
 	Vector2i playerpos[MAX_PLAYERS];	// Will hold player positions
@@ -764,16 +764,16 @@ static void loadMapPreview(bool hideInterface, const char *mapName, const Sha256
 	}
 
 	// load the terrain types
-	LEVEL_DATASET *psLevel = levFindDataSet(mapName, &mapHash);
+	LEVEL_DATASET *psLevel = levFindDataSet(mapName.c_str(), &mapHash);
 	if (psLevel == nullptr)
 	{
-		debug(LOG_INFO, "Could not find level dataset \"%s\" %s. We %s waiting for a download.", mapName, mapHash.toString().c_str(), !NET_getDownloadingWzFiles().empty() ? "are" : "aren't");
+		debug(LOG_INFO, "Could not find level dataset \"%s\" %s. We %s waiting for a download.", mapName.c_str(), mapHash.toString().c_str(), !NET_getDownloadingWzFiles().empty() ? "are" : "aren't");
 		loadEmptyMapPreview();
 		return;
 	}
 	if (psLevel->game < 0 || psLevel->game >= LEVEL_MAXFILES)
 	{
-		debug(LOG_ERROR, "apDataFiles index (%" PRIi16 ") is out of bounds for: \"%s\" %s.", psLevel->game, mapName, mapHash.toString().c_str());
+		debug(LOG_ERROR, "apDataFiles index (%" PRIi16 ") is out of bounds for: \"%s\" %s.", psLevel->game, mapName.c_str(), mapHash.toString().c_str());
 		loadEmptyMapPreview();
 		return;
 	}
@@ -911,7 +911,7 @@ LoadingTask<> mapPreviewLoadTaskImpl(bool hideInterface)
 
 LoadingTask<> mapPreviewLoadTaskImpl(bool hideInterface, std::string mapName, Sha256 mapHash)
 {
-	loadMapPreview(hideInterface, mapName.c_str(), mapHash);
+	loadMapPreview(hideInterface, std::move(mapName), mapHash);
 	co_return load_ok();
 }
 
@@ -6622,7 +6622,7 @@ TITLECODE WzMultiplayerOptionsTitleUI::run()
 						game.maxPlayers = mapData->players;
 						game.isMapMod = CheckForMod(mapData->realFileName);
 						game.isRandom = CheckForRandom(mapData->realFileName, mapData->apDataFiles[0].c_str());
-						requestMapPreviewLoad(false, mapData->pName.c_str(), game.hash);
+						requestMapPreviewLoad(false, mapData->pName, game.hash);
 
 						/* Change game info to match the previous selection if hover preview was displayed */
 						sstrcpy(game.map, oldGameMap);

--- a/src/multiint.cpp
+++ b/src/multiint.cpp
@@ -5606,8 +5606,7 @@ void startMultiplayerGame()
 			auto& controller = ResourceLoadingController::instance();
 			ResourceLoadingController::FramePolicy policy;
 			policy.showLoadingScreen = true;
-			if (!runBlockingResourceLoad(resLoad(controller, "wrf/limiter_data.wrf", 503), policy,
-			                             CloseLoadingScreenOnComplete::No))
+			if (!runBlockingResourceLoad(resLoad(controller, "wrf/limiter_data.wrf", 503), policy))
 			{
 				debug(LOG_INFO, "Unable to load limiter_data.");
 			}

--- a/src/multiint.cpp
+++ b/src/multiint.cpp
@@ -5611,6 +5611,10 @@ void startMultiplayerGame()
 			{
 				debug(LOG_INFO, "Unable to load limiter_data.");
 			}
+			else
+			{
+				bLimiterLoaded = true;
+			}
 		}
 		else
 		{

--- a/src/multiint.cpp
+++ b/src/multiint.cpp
@@ -1,7 +1,9 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
 /*
 	This file is part of Warzone 2100.
 	Copyright (C) 1999-2004  Eidos Interactive
-	Copyright (C) 2005-2020  Warzone 2100 Project
+	Copyright (C) 2005-2026  Warzone 2100 Project (https://github.com/Warzone2100)
 
 	Warzone 2100 is free software; you can redistribute it and/or modify
 	it under the terms of the GNU General Public License as published by
@@ -95,6 +97,10 @@
 #include "random.h"
 #include "notifications.h"
 #include "radar.h"
+#include "lib/framework/resource_loading_controller.h"
+#include "resource_loading_dispatch.h"
+#include "lib/framework/loading_task.h"
+#include "lib/framework/crc.h"
 #include "lib/framework/wztime.h"
 
 #include "multiplay.h"
@@ -741,7 +747,7 @@ private:
 };
 
 /// Loads the entire map just to show a picture of it
-void loadMapPreview(bool hideInterface)
+static void loadMapPreview(bool hideInterface, const char *mapName, const Sha256& mapHash)
 {
 	std::string		aFileName;
 	Vector2i playerpos[MAX_PLAYERS];	// Will hold player positions
@@ -758,16 +764,16 @@ void loadMapPreview(bool hideInterface)
 	}
 
 	// load the terrain types
-	LEVEL_DATASET *psLevel = levFindDataSet(game.map, &game.hash);
+	LEVEL_DATASET *psLevel = levFindDataSet(mapName, &mapHash);
 	if (psLevel == nullptr)
 	{
-		debug(LOG_INFO, "Could not find level dataset \"%s\" %s. We %s waiting for a download.", game.map, game.hash.toString().c_str(), !NET_getDownloadingWzFiles().empty() ? "are" : "aren't");
+		debug(LOG_INFO, "Could not find level dataset \"%s\" %s. We %s waiting for a download.", mapName, mapHash.toString().c_str(), !NET_getDownloadingWzFiles().empty() ? "are" : "aren't");
 		loadEmptyMapPreview();
 		return;
 	}
 	if (psLevel->game < 0 || psLevel->game >= LEVEL_MAXFILES)
 	{
-		debug(LOG_ERROR, "apDataFiles index (%" PRIi16 ") is out of bounds for: \"%s\" %s.", psLevel->game, game.map, game.hash.toString().c_str());
+		debug(LOG_ERROR, "apDataFiles index (%" PRIi16 ") is out of bounds for: \"%s\" %s.", psLevel->game, mapName, mapHash.toString().c_str());
 		loadEmptyMapPreview();
 		return;
 	}
@@ -887,6 +893,38 @@ void loadMapPreview(bool hideInterface)
 	{
 		hideTime = gameTime;
 	}
+}
+
+static void loadMapPreview(bool hideInterface)
+{
+	loadMapPreview(hideInterface, game.map, game.hash);
+}
+
+namespace
+{
+
+LoadingTask<> mapPreviewLoadTaskImpl(bool hideInterface)
+{
+	loadMapPreview(hideInterface);
+	co_return load_ok();
+}
+
+LoadingTask<> mapPreviewLoadTaskImpl(bool hideInterface, std::string mapName, Sha256 mapHash)
+{
+	loadMapPreview(hideInterface, mapName.c_str(), mapHash);
+	co_return load_ok();
+}
+
+} // anonymous namespace
+
+LoadingTask<> mapPreviewLoadTask(ResourceLoadingController &, bool hideInterface)
+{
+	return mapPreviewLoadTaskImpl(hideInterface);
+}
+
+LoadingTask<> mapPreviewLoadTask(ResourceLoadingController &, bool hideInterface, std::string mapName, Sha256 mapHash)
+{
+	return mapPreviewLoadTaskImpl(hideInterface, std::move(mapName), mapHash);
 }
 
 // ////////////////////////////////////////////////////////////////////////////
@@ -5290,12 +5328,13 @@ void multiLobbyRandomizeOptions()
 	// Structure limits are simply 0 or max, only for NO_TANK, NO_CYBORG, NO_VTOL, NO_UPLINK, NO_LASSAT.
 	if (!bLimiterLoaded || !asStructureStats)
 	{
-		initLoadingScreen(true);
-		if (resLoad("wrf/limiter_data.wrf", 503))
+		auto& controller = ResourceLoadingController::instance();
+		ResourceLoadingController::FramePolicy policy;
+		policy.showLoadingScreen = true;
+		if (runBlockingResourceLoad(resLoad(controller, "wrf/limiter_data.wrf", 503), policy))
 		{
 			bLimiterLoaded = true;
 		}
-		closeLoadingScreen();
 	}
 	resetLimits();
 	for (int i = 0; i < static_cast<unsigned>(limitIcons.size()) - 1; ++i)	// skip last item, MPFLAGS_FORCELIMITS
@@ -5564,7 +5603,11 @@ void startMultiplayerGame()
 		{
 			debug(LOG_NET, "limiter was NOT activated, setting defaults");
 
-			if (!resLoad("wrf/limiter_data.wrf", 503))
+			auto& controller = ResourceLoadingController::instance();
+			ResourceLoadingController::FramePolicy policy;
+			policy.showLoadingScreen = true;
+			if (!runBlockingResourceLoad(resLoad(controller, "wrf/limiter_data.wrf", 503), policy,
+			                             CloseLoadingScreenOnComplete::No))
 			{
 				debug(LOG_INFO, "Unable to load limiter_data.");
 			}
@@ -6480,7 +6523,7 @@ TITLECODE WzMultiplayerOptionsTitleUI::run()
 			}
 
 			addPlayerBox(true);				// update the player box.
-			loadMapPreview(false);
+			requestMapPreviewLoad(false);
 			updateGameOptions();
 		}
 	}
@@ -6575,7 +6618,7 @@ TITLECODE WzMultiplayerOptionsTitleUI::run()
 						game.maxPlayers = mapData->players;
 						game.isMapMod = CheckForMod(mapData->realFileName);
 						game.isRandom = CheckForRandom(mapData->realFileName, mapData->apDataFiles[0].c_str());
-						loadMapPreview(false);
+						requestMapPreviewLoad(false, mapData->pName.c_str(), game.hash);
 
 						/* Change game info to match the previous selection if hover preview was displayed */
 						sstrcpy(game.map, oldGameMap);
@@ -6608,7 +6651,7 @@ TITLECODE WzMultiplayerOptionsTitleUI::run()
 					uint8_t oldMaxPlayers = game.maxPlayers;
 					updateMapSettings(mapData);
 
-					loadMapPreview(false);
+					requestMapPreviewLoad(false);
 					loadMapChallengeAndPlayerSettings();
 					debug(LOG_INFO, "Switching map: %s (builtin: %d)", (!mapData->pName.empty()) ? mapData->pName.c_str() : "n/a", (int)builtInMap);
 
@@ -6640,7 +6683,7 @@ TITLECODE WzMultiplayerOptionsTitleUI::run()
 				}
 				break;
 			default:
-				loadMapPreview(false);  // Restore the preview of the old map.
+				requestMapPreviewLoad(false);  // Restore the preview of the old map.
 				break;
 			}
 			if (!isHoverPreview)
@@ -6906,7 +6949,7 @@ void WzMultiplayerOptionsTitleUI::start()
 		}
 	}
 
-	loadMapPreview(false);
+	requestMapPreviewLoad(false);
 
 	const bool hostOrSingle = ingame.side == InGameSide::HOST_OR_SINGLEPLAYER;
 	/* Re-entering or entering without a challenge */

--- a/src/multiint.h
+++ b/src/multiint.h
@@ -1,7 +1,9 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
 /*
 	This file is part of Warzone 2100.
 	Copyright (C) 1999-2004  Eidos Interactive
-	Copyright (C) 2005-2020  Warzone 2100 Project
+	Copyright (C) 2005-2026  Warzone 2100 Project (https://github.com/Warzone2100)
 
 	Warzone 2100 is free software; you can redistribute it and/or modify
 	it under the terms of the GNU General Public License as published by
@@ -30,9 +32,12 @@
 #include "lib/widget/form.h"
 #include "lib/widget/button.h"
 #include <functional>
+#include <memory>
+#include <string>
 #include <vector>
 #include <set>
 #include "lib/framework/wzstring.h"
+#include "lib/framework/loading_task_fwd.h"
 #include "titleui/multiplayer.h"
 #include "faction.h"
 
@@ -169,7 +174,12 @@ std::string getDefaultSkirmishAI(const bool& displayNameOnly=false);
 
 void kickPlayer(uint32_t player_id, const char *reason, LOBBY_ERROR_TYPES type, bool banPlayer = false);
 void displayKickReasonPopup(const std::string &reason);
-void loadMapPreview(bool hideInterface);
+
+struct Sha256;
+class ResourceLoadingController;
+
+LoadingTask<> mapPreviewLoadTask(ResourceLoadingController &controller, bool hideInterface);
+LoadingTask<> mapPreviewLoadTask(ResourceLoadingController &controller, bool hideInterface, std::string mapName, Sha256 mapHash);
 
 bool changeReadyStatus(UBYTE player, bool bReady);
 WzString formatGameName(WzString name);

--- a/src/multilimit.cpp
+++ b/src/multilimit.cpp
@@ -1,7 +1,9 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
 /*
 	This file is part of Warzone 2100.
 	Copyright (C) 1999-2004  Eidos Interactive
-	Copyright (C) 2005-2020  Warzone 2100 Project
+	Copyright (C) 2005-2026  Warzone 2100 Project (https://github.com/Warzone2100)
 
 	Warzone 2100 is free software; you can redistribute it and/or modify
 	it under the terms of the GNU General Public License as published by
@@ -24,6 +26,8 @@
  */
 #include "lib/framework/frame.h"
 #include "lib/framework/frameresource.h"
+#include "lib/framework/resource_loading_controller.h"
+#include "resource_loading_dispatch.h"
 #include "lib/framework/strres.h"
 #include "lib/framework/object_list_iteration.h"
 #include "lib/widget/slider.h"
@@ -110,19 +114,17 @@ void WzMultiLimitTitleUI::start()
 	// load stats...
 	if (!bLimiterLoaded)
 	{
-		initLoadingScreen(true);
-
-		if (!resLoad("wrf/limiter_data.wrf", 503))
+		auto& controller = ResourceLoadingController::instance();
+		ResourceLoadingController::FramePolicy policy;
+		policy.showLoadingScreen = true;
+		if (!runBlockingResourceLoad(resLoad(controller, "wrf/limiter_data.wrf", 503), policy))
 		{
 			debug(LOG_INFO, "Unable to load limiter_data during WzMultiLimitTitleUI start; returning...");
 			changeTitleUI(parent);
-			closeLoadingScreen();
 			return;
 		}
 
 		bLimiterLoaded = true;
-
-		closeLoadingScreen();
 	}
 
 	if (challengeActive)

--- a/src/multiopt.cpp
+++ b/src/multiopt.cpp
@@ -1,7 +1,9 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
 /*
 	This file is part of Warzone 2100.
 	Copyright (C) 1999-2004  Eidos Interactive
-	Copyright (C) 2005-2020  Warzone 2100 Project
+	Copyright (C) 2005-2026  Warzone 2100 Project (https://github.com/Warzone2100)
 
 	Warzone 2100 is free software; you can redistribute it and/or modify
 	it under the terms of the GNU General Public License as published by
@@ -30,6 +32,8 @@
 #include "lib/framework/wzapp.h"
 #include "lib/framework/physfs_ext.h"
 #include "lib/framework/frameresource.h"
+#include "lib/framework/resource_loading_controller.h"
+#include "resource_loading_dispatch.h"
 
 #include "lib/ivis_opengl/piepalette.h" // for pal_Init()
 #include "lib/ivis_opengl/piestate.h"
@@ -265,15 +269,16 @@ bool recvOptions(NETQUEUE queue)
 		// Do not load limits if mods present because mods are not loaded yet
 		if (!modHashesSize && !bLimiterLoaded)
 		{
-			initLoadingScreen(true);
-			if (!resLoad("wrf/limiter_data.wrf", 503))
+			auto& controller = ResourceLoadingController::instance();
+			ResourceLoadingController::FramePolicy policy;
+			policy.showLoadingScreen = true;
+			if (!runBlockingResourceLoad(resLoad(controller, "wrf/limiter_data.wrf", 503), policy))
 			{
 				debug(LOG_INFO, "Unable to load limiter_data during recvOptions!");
 			}
 			else
 			{
 				bLimiterLoaded = true;
-				closeLoadingScreen();
 			}
 		}
 	}
@@ -444,7 +449,7 @@ bool recvOptions(NETQUEUE queue)
 
 	if (mapData)
 	{
-		loadMapPreview(false);
+		requestMapPreviewLoad(false);
 	}
 
 	ActivityManager::instance().updateMultiplayGameData(game, ingame, NETGameIsLocked());

--- a/src/multiplay.cpp
+++ b/src/multiplay.cpp
@@ -1,7 +1,9 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
 /*
 	This file is part of Warzone 2100.
 	Copyright (C) 1999-2004  Eidos Interactive
-	Copyright (C) 2005-2020  Warzone 2100 Project
+	Copyright (C) 2005-2026  Warzone 2100 Project (https://github.com/Warzone2100)
 
 	Warzone 2100 is free software; you can redistribute it and/or modify
 	it under the terms of the GNU General Public License as published by
@@ -2497,7 +2499,7 @@ bool recvMapFileData(NETQUEUE queue)
 			game.isRandom = true;
 		}
 
-		loadMapPreview(false);
+		requestMapPreviewLoad(false);
 		return true;
 	}
 

--- a/src/resource_loading_dispatch.cpp
+++ b/src/resource_loading_dispatch.cpp
@@ -80,9 +80,9 @@ void pumpResourceLoadingHousekeeping(const ResourceLoadingController::FramePolic
 	}
 	lastPresentTime = now;
 
-	pie_ScreenFrameRenderBegin();
 	presentLoadingScreenForCurrentFrame();
 	pie_ScreenFrameRenderEnd();
+	pie_ScreenFrameRenderBegin();
 }
 
 bool tickResourceLoadingFrame()

--- a/src/resource_loading_dispatch.cpp
+++ b/src/resource_loading_dispatch.cpp
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+/*
+	This file is part of Warzone 2100.
+	Copyright (C) 2026  Warzone 2100 Project (https://github.com/Warzone2100)
+
+	Warzone 2100 is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+
+	Warzone 2100 is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with Warzone 2100; if not, write to the Free Software
+	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+/** \file resource_loading_dispatch.cpp
+ * \brief Game-level loading submission implementation.
+ */
+
+#include "resource_loading_dispatch.h"
+
+#include "lib/framework/loading_task.h"
+#include "lib/framework/wzapp.h"
+#include "lib/ivis_opengl/piemode.h"
+#include "lib/sound/audio.h"
+#include "wrappers.h"
+
+#include <chrono>
+
+namespace
+{
+constexpr auto kMinPresentInterval = std::chrono::milliseconds(50);
+std::chrono::steady_clock::time_point lastPresentTime{};
+} // namespace
+
+void submitResourceLoadingTask(ResourceLoadingTaskFactory taskFactory,
+                              bool showLoadingScreen,
+                              bool drawBackdrop,
+                              ResourceLoadingController::FrameProcessingMode frameMode)
+{
+	ASSERT(taskFactory, "submitResourceLoadingJob given null task factory");
+	ResourceLoadingController& controller = ResourceLoadingController::instance();
+	if (!controller.active() && showLoadingScreen && !isLoadingScreenActive())
+	{
+		initLoadingScreen(drawBackdrop);
+	}
+	ResourceLoadingController::FramePolicy policy;
+	policy.showLoadingScreen = showLoadingScreen;
+	policy.frameMode = frameMode;
+	controller.request(taskFactory(controller), policy);
+}
+
+void presentResourceLoadingScreenIfNeeded()
+{
+	if (ResourceLoadingController::instance().loadingScreenHandledByController())
+	{
+		presentLoadingScreenForCurrentFrame();
+	}
+}
+
+void pumpResourceLoadingHousekeeping(const ResourceLoadingController::FramePolicy& policy)
+{
+	wzPumpEventsWhileLoading();
+	audio_Update();
+
+	if (!policy.showLoadingScreen && !isLoadingScreenActive())
+	{
+		return;
+	}
+
+	auto const now = std::chrono::steady_clock::now();
+	if (now - lastPresentTime < kMinPresentInterval)
+	{
+		return;
+	}
+	lastPresentTime = now;
+
+	pie_ScreenFrameRenderBegin();
+	presentLoadingScreenForCurrentFrame();
+	pie_ScreenFrameRenderEnd();
+}
+
+bool tickResourceLoadingFrame()
+{
+	ResourceLoadingController& loadingController = ResourceLoadingController::instance();
+	if (!loadingController.active())
+	{
+		return false;
+	}
+	const auto loadingFrameMode = loadingController.currentFrameProcessingMode();
+	loadingController.step();
+	presentResourceLoadingScreenIfNeeded();
+	return loadingFrameMode == ResourceLoadingController::FrameProcessingMode::ConsumeFrame;
+}

--- a/src/resource_loading_dispatch.h
+++ b/src/resource_loading_dispatch.h
@@ -57,17 +57,18 @@ LoadResult<T> runBlockingResourceLoad(
     ResourceLoadingController::FramePolicy policy,
     CloseLoadingScreenOnComplete closeOnComplete = CloseLoadingScreenOnComplete::Yes)
 {
+	bool openedScreen = false;
 	if (policy.showLoadingScreen && !isLoadingScreenActive())
 	{
 		initLoadingScreen(true);
+		openedScreen = true;
 	}
 
 	ResourceLoadingController& controller = ResourceLoadingController::instance();
 	LoadResult<T> result = controller.runTaskToCompletion(
 	    std::move(task), policy, pumpResourceLoadingHousekeeping);
 
-	if (closeOnComplete == CloseLoadingScreenOnComplete::Yes
-	    && policy.showLoadingScreen && isLoadingScreenActive())
+	if (openedScreen && closeOnComplete == CloseLoadingScreenOnComplete::Yes)
 	{
 		closeLoadingScreen();
 	}

--- a/src/resource_loading_dispatch.h
+++ b/src/resource_loading_dispatch.h
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+/*
+	This file is part of Warzone 2100.
+	Copyright (C) 2026  Warzone 2100 Project (https://github.com/Warzone2100)
+
+	Warzone 2100 is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+
+	Warzone 2100 is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with Warzone 2100; if not, write to the Free Software
+	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+/** \file resource_loading_dispatch.h
+ * \brief Game-level loading submission and loading-screen presentation.
+ */
+
+#pragma once
+
+#include "lib/framework/resource_loading_controller.h"
+#include "wrappers.h"
+
+#include <functional>
+
+using ResourceLoadingTaskFactory = std::function<LoadingTask<>(ResourceLoadingController &)>;
+
+void submitResourceLoadingTask(ResourceLoadingTaskFactory taskFactory,
+                              bool showLoadingScreen = true,
+                              bool drawBackdrop = true,
+                              ResourceLoadingController::FrameProcessingMode frameMode =
+                                  ResourceLoadingController::FrameProcessingMode::ConsumeFrame);
+
+void presentResourceLoadingScreenIfNeeded();
+
+/// Per-quantum housekeeping during blocking loads (events, audio, optional loading UI).
+void pumpResourceLoadingHousekeeping(const ResourceLoadingController::FramePolicy& policy);
+
+/// Advance async loading for one mainLoop iteration. Returns true if the frame was consumed.
+bool tickResourceLoadingFrame();
+
+enum class CloseLoadingScreenOnComplete
+{
+	Yes,
+	No,
+};
+
+template <typename T>
+LoadResult<T> runBlockingResourceLoad(
+    LoadingTask<T> task,
+    ResourceLoadingController::FramePolicy policy,
+    CloseLoadingScreenOnComplete closeOnComplete = CloseLoadingScreenOnComplete::Yes)
+{
+	if (policy.showLoadingScreen && !isLoadingScreenActive())
+	{
+		initLoadingScreen(true);
+	}
+
+	ResourceLoadingController& controller = ResourceLoadingController::instance();
+	LoadResult<T> result = controller.runTaskToCompletion(
+	    std::move(task), policy, pumpResourceLoadingHousekeeping);
+
+	if (closeOnComplete == CloseLoadingScreenOnComplete::Yes
+	    && policy.showLoadingScreen && isLoadingScreenActive())
+	{
+		closeLoadingScreen();
+	}
+	return result;
+}

--- a/src/terrain.cpp
+++ b/src/terrain.cpp
@@ -1,7 +1,9 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
 /*
 	This file is part of Warzone 2100.
 	Copyright (C) 1999-2004  Eidos Interactive
-	Copyright (C) 2005-2020  Warzone 2100 Project
+	Copyright (C) 2005-2026  Warzone 2100 Project (https://github.com/Warzone2100)
 
 	Warzone 2100 is free software; you can redistribute it and/or modify
 	it under the terms of the GNU General Public License as published by
@@ -32,9 +34,11 @@
 #include <string.h>
 
 #include "lib/framework/frame.h"
-#include "lib/framework/frameresource.h"
+#include "lib/framework/loading_task.h"
 #include "lib/framework/opengl.h"
 #include "lib/framework/physfs_ext.h"
+#include "lib/framework/resource_loading_controller.h"
+#include "resource_loading_dispatch.h"
 #include "lib/framework/wzapp.h"
 #include "lib/ivis_opengl/ivisdef.h"
 #include "lib/ivis_opengl/imd.h"
@@ -619,8 +623,6 @@ void dirtyAllSectors()
 	}
 }
 
-void loadWaterTextures(int maxTerrainTextureSize, optional<int> maxTerrainAuxTextureSize = nullopt);
-
 bool setTerrainMappingTexturesMaxSize(int texSize)
 {
 	bool isPowerOfTwo = !(texSize == 0) && !(texSize & (texSize - 1));
@@ -694,7 +696,7 @@ gfx_api::texture* getWaterClassicTexture()
 	return waterClassicTexture;
 }
 
-void loadWaterTextures(int maxTerrainTextureSize, optional<int> maxTerrainAuxTextureSizeOpt)
+static LoadingTask<> loadWaterTexturesTask(ResourceLoadingController& controller, int maxTerrainTextureSize, optional<int> maxTerrainAuxTextureSizeOpt)
 {
 	waterTexturesNormal.clear();
 	waterTexturesHigh.clear();
@@ -745,10 +747,10 @@ void loadWaterTextures(int maxTerrainTextureSize, optional<int> maxTerrainAuxTex
 		if (!std::all_of(waterTextureFilenames.begin(), waterTextureFilenames.end(), [](const WzString& texturePath) -> bool { return !texturePath.isEmpty(); }))
 		{
 			debug(LOG_FATAL, "Missing one or more base water textures?");
-			return;
+			co_return load_fail();
 		}
 
-		waterTexturesHigh.tex = gfx_api::context::get().loadTextureArrayFromFiles(waterTextureFilenames, gfx_api::texture_type::game_texture, maxTerrainTextureSize, maxTerrainTextureSize, nullptr, []() { resDoResLoadCallback(); });
+		waterTexturesHigh.tex = (co_await gfx_api::context::get().loadTextureArrayFromFiles(controller, waterTextureFilenames, gfx_api::texture_type::game_texture, maxTerrainTextureSize, maxTerrainTextureSize)).value_or(nullptr);
 		waterTexturesHigh.tex_nm = nullptr;
 		waterTexturesHigh.tex_sm = nullptr;
 
@@ -758,7 +760,7 @@ void loadWaterTextures(int maxTerrainTextureSize, optional<int> maxTerrainAuxTex
 			return !filename.isEmpty();
 		}))
 		{
-			waterTexturesHigh.tex_nm = gfx_api::context::get().loadTextureArrayFromFiles(waterTextureFilenames_nm, gfx_api::texture_type::normal_map, maxTerrainAuxTextureSize, maxTerrainAuxTextureSize, [](int width, int height, int channels) -> std::unique_ptr<iV_Image> {
+			waterTexturesHigh.tex_nm = (co_await gfx_api::context::get().loadTextureArrayFromFiles(controller, waterTextureFilenames_nm, gfx_api::texture_type::normal_map, maxTerrainAuxTextureSize, maxTerrainAuxTextureSize, [](int width, int height, int channels) -> std::unique_ptr<iV_Image> {
 				std::unique_ptr<iV_Image> pDefaultNormalMap = std::make_unique<iV_Image>();
 				pDefaultNormalMap->allocate(width, height, channels, true);
 				// default normal map: (0,0,1)
@@ -773,19 +775,19 @@ void loadWaterTextures(int maxTerrainTextureSize, optional<int> maxTerrainAuxTex
 					}
 				}
 				return pDefaultNormalMap;
-			}, []() { resDoResLoadCallback(); });
+			})).value_or(nullptr);
 			ASSERT(waterTexturesHigh.tex_nm != nullptr, "Failed to load water normals");
 		}
 		if (std::any_of(waterTextureFilenames_sm.begin(), waterTextureFilenames_sm.end(), [](const WzString& filename) {
 			return !filename.isEmpty();
 		}))
 		{
-			waterTexturesHigh.tex_sm = gfx_api::context::get().loadTextureArrayFromFiles(waterTextureFilenames_sm, gfx_api::texture_type::specular_map, maxTerrainAuxTextureSize, maxTerrainAuxTextureSize, [](int width, int height, int channels) -> std::unique_ptr<iV_Image> {
+			waterTexturesHigh.tex_sm = (co_await gfx_api::context::get().loadTextureArrayFromFiles(controller, waterTextureFilenames_sm, gfx_api::texture_type::specular_map, maxTerrainAuxTextureSize, maxTerrainAuxTextureSize, [](int width, int height, int channels) -> std::unique_ptr<iV_Image> {
 				std::unique_ptr<iV_Image> pDefaultSpecularMap = std::make_unique<iV_Image>();
 				// default specular map: 0
 				pDefaultSpecularMap->allocate(width, height, channels, true);
 				return pDefaultSpecularMap;
-			}, []() { resDoResLoadCallback(); });
+			})).value_or(nullptr);
 			ASSERT(waterTexturesHigh.tex_sm != nullptr, "Failed to load water specular maps");
 		}
 	}
@@ -793,17 +795,20 @@ void loadWaterTextures(int maxTerrainTextureSize, optional<int> maxTerrainAuxTex
 	{
 		// preload classic water texture
 		auto pWaterTexClassic = getWaterClassicTexture();
-		ASSERT_OR_RETURN(, pWaterTexClassic != nullptr, "Failed to load classic water texture?");
+		CORO_ASSERT_OR_RETURN(load_fail(), pWaterTexClassic != nullptr, "Failed to load classic water texture?");
 	}
 	else
 	{
-		ASSERT_OR_RETURN(, false, "Unexpected terrainShaderQuality: %u", static_cast<unsigned>(terrainShaderQuality));
+		CORO_ASSERT_OR_RETURN(load_fail(), false, "Unexpected terrainShaderQuality: %u", static_cast<unsigned>(terrainShaderQuality));
 	}
+
+	co_return load_ok();
 }
 
-void loadTerrainTextures_SinglePass(MAP_TILESET mapTileset)
+static LoadingTask<> loadTerrainTexturesImpl(ResourceLoadingController& controller, MAP_TILESET mapTileset)
 {
-	ASSERT_OR_RETURN(, getNumGroundTypes(), "Ground type was not set, no textures will be seen.");
+	(void)mapTileset;
+	CORO_ASSERT_OR_RETURN(load_fail(), getNumGroundTypes(), "Ground type was not set, no textures will be seen.");
 
 	int32_t maxGfxTextureSize = gfx_api::context::get().get_context_value(gfx_api::context::context_value::MAX_TEXTURE_SIZE);
 	int maxTerrainTextureSize = std::max(std::min({getTextureSize(), maxGfxTextureSize}), MIN_TERRAIN_TEXTURE_SIZE);
@@ -838,7 +843,7 @@ void loadTerrainTextures_SinglePass(MAP_TILESET mapTileset)
 	}
 
 	// load the textures into the texture arrays
-	groundTexArr = gfx_api::context::get().loadTextureArrayFromFiles(groundTextureFilenames, gfx_api::texture_type::game_texture, maxTerrainTextureSize, maxTerrainTextureSize, nullptr, []() { resDoResLoadCallback(); });
+	groundTexArr = (co_await gfx_api::context::get().loadTextureArrayFromFiles(controller, groundTextureFilenames, gfx_api::texture_type::game_texture, maxTerrainTextureSize, maxTerrainTextureSize)).value_or(nullptr);
 	ASSERT(groundTexArr != nullptr, "Failed to load terrain textures");
 
 	int maxTerrainAuxTextureSize = std::max(std::min({getTextureSize(), getTerrainMappingTexturesMaxSize(), maxGfxTextureSize}), MIN_TERRAIN_TEXTURE_SIZE);
@@ -849,7 +854,7 @@ void loadTerrainTextures_SinglePass(MAP_TILESET mapTileset)
 			return !filename.isEmpty();
 		}))
 		{
-			groundNormalArr = gfx_api::context::get().loadTextureArrayFromFiles(groundTextureFilenames_nm, gfx_api::texture_type::normal_map, maxTerrainAuxTextureSize, maxTerrainAuxTextureSize, [](int width, int height, int channels) -> std::unique_ptr<iV_Image> {
+			groundNormalArr = (co_await gfx_api::context::get().loadTextureArrayFromFiles(controller, groundTextureFilenames_nm, gfx_api::texture_type::normal_map, maxTerrainAuxTextureSize, maxTerrainAuxTextureSize, [](int width, int height, int channels) -> std::unique_ptr<iV_Image> {
 				std::unique_ptr<iV_Image> pDefaultNormalMap = std::make_unique<iV_Image>();
 				pDefaultNormalMap->allocate(width, height, channels, true);
 				// default normal map: (0,0,1)
@@ -864,43 +869,58 @@ void loadTerrainTextures_SinglePass(MAP_TILESET mapTileset)
 					}
 				}
 				return pDefaultNormalMap;
-			}, []() { resDoResLoadCallback(); });
+			})).value_or(nullptr);
 			ASSERT(groundNormalArr != nullptr, "Failed to load terrain normals");
 		}
 		if (std::any_of(groundTextureFilenames_spec.begin(), groundTextureFilenames_spec.end(), [](const WzString& filename) {
 			return !filename.isEmpty();
 		}))
 		{
-			groundSpecularArr = gfx_api::context::get().loadTextureArrayFromFiles(groundTextureFilenames_spec, gfx_api::texture_type::specular_map, maxTerrainAuxTextureSize, maxTerrainAuxTextureSize, [](int width, int height, int channels) -> std::unique_ptr<iV_Image> {
+			groundSpecularArr = (co_await gfx_api::context::get().loadTextureArrayFromFiles(controller, groundTextureFilenames_spec, gfx_api::texture_type::specular_map, maxTerrainAuxTextureSize, maxTerrainAuxTextureSize, [](int width, int height, int channels) -> std::unique_ptr<iV_Image> {
 				std::unique_ptr<iV_Image> pDefaultSpecularMap = std::make_unique<iV_Image>();
 				// default specular map: 0
 				pDefaultSpecularMap->allocate(width, height, channels, true);
 				return pDefaultSpecularMap;
-			}, []() { resDoResLoadCallback(); });
+			})).value_or(nullptr);
 			ASSERT(groundSpecularArr != nullptr, "Failed to load terrain specular maps");
 		}
 		if (std::any_of(groundTextureFilenames_height.begin(), groundTextureFilenames_height.end(), [](const WzString& filename) {
 			return !filename.isEmpty();
 		}))
 		{
-			groundHeightArr = gfx_api::context::get().loadTextureArrayFromFiles(groundTextureFilenames_height, gfx_api::texture_type::height_map, maxTerrainAuxTextureSize, maxTerrainAuxTextureSize, [](int width, int height, int channels) -> std::unique_ptr<iV_Image> {
+			groundHeightArr = (co_await gfx_api::context::get().loadTextureArrayFromFiles(controller, groundTextureFilenames_height, gfx_api::texture_type::height_map, maxTerrainAuxTextureSize, maxTerrainAuxTextureSize, [](int width, int height, int channels) -> std::unique_ptr<iV_Image> {
 				std::unique_ptr<iV_Image> pDefaultHeightMap = std::make_unique<iV_Image>();
 				// default height map: 0
 				pDefaultHeightMap->allocate(width, height, channels, true);
 				return pDefaultHeightMap;
-			}, []() { resDoResLoadCallback(); });
+			})).value_or(nullptr);
 			ASSERT(groundHeightArr != nullptr, "Failed to load terrain height maps");
 		}
 	}
 
 	// load water textures
-	loadWaterTextures(maxTerrainTextureSize, maxTerrainAuxTextureSize);
+	co_return co_await loadWaterTexturesTask(controller, maxTerrainTextureSize, maxTerrainAuxTextureSize);
 }
 
-void loadTerrainTextures(MAP_TILESET mapTileset)
+LoadingTask<> loadTerrainTextures(ResourceLoadingController& controller, MAP_TILESET mapTileset)
 {
-	ASSERT_OR_RETURN(, getNumGroundTypes(), "Ground type was not set, no textures will be seen.");
-	loadTerrainTextures_SinglePass(mapTileset);
+	if (getNumGroundTypes() == 0)
+	{
+		co_return load_fail();
+	}
+	co_return co_await loadTerrainTexturesImpl(controller, mapTileset);
+}
+
+void loadTerrainTexturesBlocking(MAP_TILESET mapTileset)
+{
+	if (getNumGroundTypes() == 0)
+	{
+		return;
+	}
+	auto& loadingController = ResourceLoadingController::instance();
+	ResourceLoadingController::FramePolicy policy;
+	policy.showLoadingScreen = false;
+	(void)runBlockingResourceLoad(loadTerrainTextures(loadingController, mapTileset), policy);
 }
 
 void reloadTerrainTextures()
@@ -910,7 +930,7 @@ void reloadTerrainTextures()
 		return; // nothing loaded yet
 	}
 
-	loadTerrainTextures(currentMapTileset);
+	loadTerrainTexturesBlocking(currentMapTileset);
 }
 
 /**

--- a/src/terrain.h
+++ b/src/terrain.h
@@ -1,7 +1,9 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
 /*
 	This file is part of Warzone 2100.
 	Copyright (C) 1999-2004  Eidos Interactive
-	Copyright (C) 2005-2020  Warzone 2100 Project
+	Copyright (C) 2005-2026  Warzone 2100 Project (https://github.com/Warzone2100)
 
 	Warzone 2100 is free software; you can redistribute it and/or modify
 	it under the terms of the GNU General Public License as published by
@@ -25,12 +27,16 @@
 #include "lib/ivis_opengl/pietypes.h"
 #include <wzmaplib/terrain_type.h>
 #include "terrain_defs.h"
+#include "lib/framework/loading_task_fwd.h"
 
 struct ShadowCascadesInfo;
 struct LightMap;
 struct WorldMapState;
 
-void loadTerrainTextures(MAP_TILESET mapTileset);
+class ResourceLoadingController;
+
+LoadingTask<> loadTerrainTextures(ResourceLoadingController& controller, MAP_TILESET mapTileset);
+void loadTerrainTexturesBlocking(MAP_TILESET mapTileset);
 
 bool initTerrain(WorldMapState& mapState);
 void shutdownTerrain();

--- a/src/texture.cpp
+++ b/src/texture.cpp
@@ -1,7 +1,9 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
 /*
 	This file is part of Warzone 2100.
 	Copyright (C) 1999-2004  Eidos Interactive
-	Copyright (C) 2005-2020  Warzone 2100 Project
+	Copyright (C) 2005-2026  Warzone 2100 Project (https://github.com/Warzone2100)
 
 	Warzone 2100 is free software; you can redistribute it and/or modify
 	it under the terms of the GNU General Public License as published by
@@ -262,16 +264,16 @@ bool texLoad(const char *fileName)
 			}
 		}
 
-		decalTexArr = gfx_api::context::get().loadTextureArrayFromFiles(tile_base_filepaths, gfx_api::texture_type::game_texture, mipmap_max, mipmap_max, [](int width, int height, int channels) -> std::unique_ptr<iV_Image> {
+		decalTexArr = gfx_api::context::get().loadTextureArrayFromFilesBlocking(tile_base_filepaths, gfx_api::texture_type::game_texture, mipmap_max, mipmap_max, [](int width, int height, int channels) -> std::unique_ptr<iV_Image> {
 				std::unique_ptr<iV_Image> pDefaultTexture = std::unique_ptr<iV_Image>(new iV_Image);
 				pDefaultTexture->allocate(width, height, channels, true);
 				return pDefaultTexture;
-			}, nullptr, "decalTexArr");
+			}, "decalTexArr");
 		if (has_auxillary_texture_info)
 		{
 			if (has_nm)
 			{
-				decalNormalArr = gfx_api::context::get().loadTextureArrayFromFiles(tile_nm_filepaths, gfx_api::texture_type::normal_map, mipmap_max, mipmap_max, [](int width, int height, int channels) -> std::unique_ptr<iV_Image> {
+				decalNormalArr = gfx_api::context::get().loadTextureArrayFromFilesBlocking(tile_nm_filepaths, gfx_api::texture_type::normal_map, mipmap_max, mipmap_max, [](int width, int height, int channels) -> std::unique_ptr<iV_Image> {
 					std::unique_ptr<iV_Image> pDefaultNormalMap = std::make_unique<iV_Image>();
 					pDefaultNormalMap->allocate(width, height, channels, true);
 					// default normal map: (0,0,1)
@@ -286,27 +288,27 @@ bool texLoad(const char *fileName)
 						}
 					}
 					return pDefaultNormalMap;
-				}, nullptr, "decalNormalArr");
+				}, "decalNormalArr");
 				ASSERT(decalNormalArr != nullptr, "Failed to load tile normals");
 			}
 			if (has_sm)
 			{
-				decalSpecularArr = gfx_api::context::get().loadTextureArrayFromFiles(tile_sm_filepaths, gfx_api::texture_type::specular_map, mipmap_max, mipmap_max, [](int width, int height, int channels) -> std::unique_ptr<iV_Image> {
+				decalSpecularArr = gfx_api::context::get().loadTextureArrayFromFilesBlocking(tile_sm_filepaths, gfx_api::texture_type::specular_map, mipmap_max, mipmap_max, [](int width, int height, int channels) -> std::unique_ptr<iV_Image> {
 					std::unique_ptr<iV_Image> pDefaultSpecularMap = std::make_unique<iV_Image>();
 					// default specular map: 0
 					pDefaultSpecularMap->allocate(width, height, channels, true);
 					return pDefaultSpecularMap;
-				}, nullptr, "decalSpecularArr");
+				}, "decalSpecularArr");
 				ASSERT(decalSpecularArr != nullptr, "Failed to load tile specular maps");
 			}
 			if (has_hm)
 			{
-				decalHeightArr = gfx_api::context::get().loadTextureArrayFromFiles(tile_hm_filepaths, gfx_api::texture_type::height_map, mipmap_max, mipmap_max, [](int width, int height, int channels) -> std::unique_ptr<iV_Image> {
+				decalHeightArr = gfx_api::context::get().loadTextureArrayFromFilesBlocking(tile_hm_filepaths, gfx_api::texture_type::height_map, mipmap_max, mipmap_max, [](int width, int height, int channels) -> std::unique_ptr<iV_Image> {
 					std::unique_ptr<iV_Image> pDefaultHeightMap = std::make_unique<iV_Image>();
 					// default height map: 0
 					pDefaultHeightMap->allocate(width, height, channels, true);
 					return pDefaultHeightMap;
-				}, nullptr, "decalHeightArr");
+				}, "decalHeightArr");
 				ASSERT(decalHeightArr != nullptr, "Failed to load terrain height maps");
 			}
 		}

--- a/src/titleui/widgets/multilobbyoptions.cpp
+++ b/src/titleui/widgets/multilobbyoptions.cpp
@@ -2,7 +2,7 @@
 
 /*
 	This file is part of Warzone 2100.
-	Copyright (C) 2024-2025  Warzone 2100 Project
+	Copyright (C) 2024-2026  Warzone 2100 Project (https://github.com/Warzone2100)
 
 	Warzone 2100 is free software; you can redistribute it and/or modify
 	it under the terms of the GNU General Public License as published by
@@ -44,6 +44,7 @@
 #include "src/multiplay.h"
 #include "src/multivote.h"
 #include "src/multilimit.h"
+#include "src/main.h"
 #include "src/frend.h"
 #include "src/loadsave.h"
 #include "src/intimage.h"
@@ -945,7 +946,7 @@ void WzMultiLobbyOptionsImpl::initialize(bool _isChallenge, const std::shared_pt
 		mapViewButton->setTip(_("Click to see Map"));
 		mapViewButton->addOnClickHandler([](W_BUTTON&) {
 			widgScheduleTask([]{
-				loadMapPreview(true);
+				requestMapPreviewLoad(true);
 			});
 		});
 		auto mapChangeButton = addSectionImageButton(mapWidget, IMAGE_GLOBE, 2);

--- a/src/wrappers.cpp
+++ b/src/wrappers.cpp
@@ -1,7 +1,9 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
 /*
 	This file is part of Warzone 2100.
 	Copyright (C) 1999-2004  Eidos Interactive
-	Copyright (C) 2005-2020  Warzone 2100 Project
+	Copyright (C) 2005-2026  Warzone 2100 Project (https://github.com/Warzone2100)
 
 	Warzone 2100 is free software; you can redistribute it and/or modify
 	it under the terms of the GNU General Public License as published by
@@ -24,7 +26,6 @@
  */
 
 #include "lib/framework/frame.h"
-#include "lib/framework/frameresource.h"
 // FIXME Direct iVis implementation include!
 #include "lib/ivis_opengl/pieblitfunc.h"
 #include "lib/ivis_opengl/piemode.h"
@@ -67,8 +68,8 @@ static HostLaunch hostlaunch = HostLaunch::Normal;  // used to detect if we are 
 static bool bHeadlessAutoGameModeCLIOption = false;
 static bool bActualHeadlessAutoGameMode = false;
 static bool bHostLaunchStartNotReady = false;
+static bool loadingScreenSessionActive = false;
 
-static uint32_t lastTick = 0;
 static int barLeftX, barLeftY, barRightX, barRightY, boxWidth, boxHeight, starsNum, starHeight;
 static STAR *stars = nullptr;
 
@@ -79,6 +80,31 @@ static STAR newStar()
 	s.speed = static_cast<int>((rand() % 30 + 6) * pie_GetVideoBufferWidth() / 640.0);
 	s.colour = pal_SetBrightness(150 + rand() % 100);
 	return s;
+}
+
+static void renderLoadingScreenPass()
+{
+	const PIELIGHT loadingbar_background = WZCOL_LOADING_BAR_BACKGROUND;
+
+	pie_UniTransBoxFill(barLeftX - 2, barLeftY - 2, barRightX + 2, barRightY + 2, loadingbar_background);
+
+	for (unsigned int i = 1; i < static_cast<unsigned int>(starsNum); ++i)
+	{
+		stars[i].xPos = stars[i].xPos + stars[i].speed;
+		if (barLeftX + stars[i].xPos >= barRightX)
+		{
+			stars[i] = newStar();
+			stars[i].xPos = 1;
+		}
+		{
+			const int topX = barLeftX + stars[i].xPos;
+			const int topY = barLeftY + i * (boxHeight - starHeight) / starsNum;
+			const int botX = MIN(topX + stars[i].speed, barRightX);
+			const int botY = topY + starHeight;
+
+			pie_UniTransBoxFill(topX, topY, botX, botY, stars[i].colour);
+		}
+	}
 }
 
 static void setupLoadingScreen()
@@ -278,47 +304,24 @@ TITLECODE titleLoop()
 ////////////////////////////////////////////////////////////////////////////////
 // Loading Screen.
 
-//loadbar update
-void loadingScreenCallback()
+bool isLoadingScreenActive()
 {
-	const PIELIGHT loadingbar_background = WZCOL_LOADING_BAR_BACKGROUND;
-	const uint32_t currTick = wzGetTicks();
-	unsigned int i;
+	return loadingScreenSessionActive;
+}
 
-	if (currTick - lastTick < 50)
+void presentLoadingScreenForCurrentFrame()
+{
+	if (!loadingScreenSessionActive || headlessGameMode())
 	{
 		return;
 	}
 
-	lastTick = currTick;
-
-	/* Draw the black rectangle at the bottom, with a two pixel border */
-	pie_UniTransBoxFill(barLeftX - 2, barLeftY - 2, barRightX + 2, barRightY + 2, loadingbar_background);
-
-	for (i = 1; i < starsNum; ++i)
+	if (screen_GetBackDrop())
 	{
-		stars[i].xPos = stars[i].xPos + stars[i].speed;
-		if (barLeftX + stars[i].xPos >= barRightX)
-		{
-			stars[i] = newStar();
-			stars[i].xPos = 1;
-		}
-		{
-			const int topX = barLeftX + stars[i].xPos;
-			const int topY = barLeftY + i * (boxHeight - starHeight) / starsNum;
-			const int botX = MIN(topX + stars[i].speed, barRightX);
-			const int botY = topY + starHeight;
-
-			pie_UniTransBoxFill(topX, topY, botX, botY, stars[i].colour);
-		}
+		screen_Display();
 	}
 
-	pie_ScreenFrameRenderEnd();
-	pie_ScreenFrameRenderBegin();
-
-	audio_Update();
-
-	wzPumpEventsWhileLoading();
+	renderLoadingScreenPass();
 }
 
 #if defined(__EMSCRIPTEN__)
@@ -338,15 +341,12 @@ void wzemscripten_display_web_loading_indicator(int x)
 // fill buffers with the static screen
 void initLoadingScreen(bool drawbdrop)
 {
-	pie_ScreenFrameRenderBegin(); // start a frame *if one isn't yet started*
 	setupLoadingScreen();
 	wzShowMouse(false);
 	pie_SetFogStatus(false);
+	loadingScreenSessionActive = true;
 
-#if !defined(__EMSCRIPTEN__)
-	// setup the callback....
-	resSetLoadCallback(loadingScreenCallback);
-#else
+#if defined(__EMSCRIPTEN__)
 	wzemscripten_display_web_loading_indicator(1);
 #endif
 
@@ -367,14 +367,14 @@ void initLoadingScreen(bool drawbdrop)
 // shut down the loading screen
 void closeLoadingScreen()
 {
+	loadingScreenSessionActive = false;
+
 	if (stars)
 	{
 		free(stars);
 		stars = nullptr;
 	}
-#if !defined(__EMSCRIPTEN__)
-	resSetLoadCallback(nullptr);
-#else
+#if defined(__EMSCRIPTEN__)
 	wzemscripten_display_web_loading_indicator(0);
 #endif
 }

--- a/src/wrappers.h
+++ b/src/wrappers.h
@@ -1,7 +1,9 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
 /*
 	This file is part of Warzone 2100.
 	Copyright (C) 1999-2004  Eidos Interactive
-	Copyright (C) 2005-2020  Warzone 2100 Project
+	Copyright (C) 2005-2026  Warzone 2100 Project (https://github.com/Warzone2100)
 
 	Warzone 2100 is free software; you can redistribute it and/or modify
 	it under the terms of the GNU General Public License as published by
@@ -59,7 +61,8 @@ TITLECODE titleLoop();
 
 void initLoadingScreen(bool drawbdrop);
 void closeLoadingScreen();
-void loadingScreenCallback();
+bool isLoadingScreenActive();
+void presentLoadingScreenForCurrentFrame();
 
 bool displayGameOver(bool success, bool showBackDrop);
 void setPlayerHasLost(bool val);

--- a/src/wzscriptdebug.cpp
+++ b/src/wzscriptdebug.cpp
@@ -1,6 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
 /*
 	This file is part of Warzone 2100.
-	Copyright (C) 2020-2021  Warzone 2100 Project
+	Copyright (C) 2020-2026  Warzone 2100 Project (https://github.com/Warzone2100)
 
 	Warzone 2100 is free software; you can redistribute it and/or modify
 	it under the terms of the GNU General Public License as published by
@@ -1123,7 +1125,7 @@ public:
 
 		auto texturesLabel = panel->createLabel(0, font_regular_bold, "Textures:");
 		auto prevButton = panel->createButton(0, "Reload Terrain & Water", [](){
-			loadTerrainTextures(currentMapTileset);
+			loadTerrainTexturesBlocking(currentMapTileset);
 			debug(LOG_INFO, "Done");
 		}, texturesLabel);
 		prevButton = panel->createButton(0, "Reload Decals", [](){


### PR DESCRIPTION
Convert major load paths to LoadingTask coroutines driven from `mainLoop` (`tickResourceLoadingFrame`) or blocking helpers. Add `resource_loading_dispatch`:
* `submitResourceLoadingTask` for async work.
* `runBlockingResourceLoad` for synchronous call sites — runs `controller.runTaskToCompletion()` while pumping events, audio, and the loading screen between frame quanta so blocking loads stay responsive (title init, terrain textures, MP limiter WRF, etc.).

High level overview of changes
------------------------------
* Async loads: `submitResourceLoadingTask()` queues work; `mainLoop` calls `tickResourceLoadingFrame()` to advance one or more quanta per frame and optionally consume the tick for the loading screen (`ConsumeFrame`).
* Load logic moves into `LoadingTask` coroutines (`co_await yieldFrame()`) in `src/` (levels, init, game, mission, map, frameresource resLoad, terrain, gfx texture-array load, imdload, etc.).
* `resource_loading_dispatch.{h,cpp}`: thin game layer over the controller (submission, loading-screen presentation, housekeeping pump).

`runBlockingResourceLoad()` helper for blocking jobs
----------------------------------------------------
Template helper in `src/resource_loading_dispatch.h` for call sites that must finish load work before returning (no ongoing mainLoop-driven submission).

What it does in a nutshell:
1. Opens the loading screen when `FramePolicy::showLoadingScreen` is set and it is not already active (`initLoadingScreen`).
2. Runs `ResourceLoadingController::runTaskToCompletion()` on the task, passing `pumpResourceLoadingHousekeeping` as the per-quantum callback.
3. Between quanta, `pumpResourceLoadingHousekeeping()` processes SDL events, updates audio, and (when a loading screen is shown) throttled backdrop redraw — so a "blocking" load still stays responsive instead of freezing.
4. Optionally closes the loading screen when done (`CloseLoadingScreenOnComplete`).

Used where the caller cannot rely on `tickResourceLoadingFrame()`, e.g.:
* `startTitleLoop()` — frontend init before entering the title loop (`main.cpp`)
* `loadTerrainTextures()` blocking entry (`terrain.cpp`)
* Multiplayer UI paths loading `wrf/limiter_data.wrf` (multiint, multiopt, multilimit)

Cooperative (non-blocking) submission remains the default for in-loop flows such as start-game / load-save jobs via `submitResourceLoadingTask()`.

Other notable changes
---------------------
* Split gfx_api texture-array loading into `gfx_api_texture_array_load.cpp` (to avoid introducing dependency on <coroutine> header for `gfx_api.{h,cpp}`).
* Parser/resource and wzapp hooks for yield-aware loading.

Closes: Warzone2100/warzone2100#4858