### PR TITLE
Cobra AI - Production - Check for HQ availability before producing combat units

### DIFF
--- a/data/mp/multiplay/skirmish/cobra_includes/production.js
+++ b/data/mp/multiplay/skirmish/cobra_includes/production.js
@@ -653,6 +653,7 @@ function produce()
 						highOilMap() &&
 						componentAvailable("MG1Mk1") &&
 						__attackers < 2 &&
+						countStruct(_STRUCTURES.hq, me) &&
 						(countStruct(_STRUCTURES.gen, me) && countStruct(_STRUCTURES.derrick, me)))
 					{
 						buildAttacker(_fc.id);
@@ -674,7 +675,7 @@ function produce()
 					}
 					else
 					{
-						if (!countStruct(_STRUCTURES.gen, me) || !countStruct(_STRUCTURES.derrick, me))
+						if (!countStruct(_STRUCTURES.gen, me) || !countStruct(_STRUCTURES.derrick, me) || !countStruct(_STRUCTURES.hq, me))
 						{
 							continue;
 						}


### PR DESCRIPTION
Issue #4949: Cobra on T2-NoBase designs & builds combat units before the HQ is constructed

Cobra AI - added check for HQ before combat units are produced