### PR TITLE
Allow `getObject(type, player, id)` to work with features

### DIFF
--- a/src/qtscript.cpp
+++ b/src/qtscript.cpp
@@ -2560,7 +2560,10 @@ generic_script_object scripting_engine::getObject(WZAPI_PARAMS(wzapi::object_req
 		OBJECT_TYPE type = std::get<0>(type_player_id);
 		int player = std::get<1>(type_player_id);
 		int id = std::get<2>(type_player_id);
-		SCRIPT_ASSERT_PLAYER({}, context, player);
+		if (type != OBJ_FEATURE)
+		{
+			SCRIPT_ASSERT_PLAYER({}, context, player);
+		}
 		return generic_script_object::fromObject(IdToObject(type, id, player));
 	}
 	else if (request.requestType == wzapi::object_request::RequestType::LABEL_REQUEST)


### PR DESCRIPTION
The normal script assert player bounds check doesn't account for features on maps being assigned a unique player value.

Ultimately the player value doesn't matter for this function since it will always be 0 for `IdToFeature()`.


---

`getObject()` used this way always fails cause the default player for features on a map is `PLAYER_FEATURE`, which is `MAX_PLAYERS + 1`, meaning 12. And 12 is going to trip the assert for the player value check.