### PR TITLE
Commander/exp knobs

### DIFF
--- a/data/base/script/campaign/cam2-1x.js
+++ b/data/base/script/campaign/cam2-1x.js
@@ -101,7 +101,7 @@ function setCrashedTeamExp()
 	for (let i = 0; i < droids.length; ++i)
 	{
 		const droid = droids[i];
-		setDroidExperience(droid, DROID_EXP);
+		camSetDroidExperience(droid, DROID_EXP);
 	}
 
 	preDamageUnits();

--- a/data/base/script/campaign/cam2-a.js
+++ b/data/base/script/campaign/cam2-a.js
@@ -120,7 +120,7 @@ function sendPlayerTransporter()
 		tWeap.tank.heavyCannon, tWeap.tank.heavyCannon, tWeap.tank.heavyCannon,
 		tWeap.tank.lancer, tWeap.tank.lancer, tWeap.tank.bombard, tWeap.tank.miniRocketArray
 	];
-	const specialList = [tSensor.sensor, tCommand.commander];
+	const specialList = (tweakOptions.noCommander) ? [tSensor.sensor] : [tSensor.sensor, tCommand.commander];
 	const BODY = bodyList[camRand(bodyList.length)];
 	const PROP = propulsionList[camRand(propulsionList.length)];
 

--- a/data/base/script/campaign/cam2-a.js
+++ b/data/base/script/campaign/cam2-a.js
@@ -323,7 +323,7 @@ function setUnitRank(transport)
 		if (droid.droidType !== DROID_CONSTRUCT && droid.droidType !== DROID_REPAIR)
 		{
 			const USE_COMMAND_RANK = (droid.droidType === DROID_COMMAND || droid.droidType === DROID_SENSOR);
-			setDroidExperience(droid, camGetRankThreshold(ranks[mapRun ? 0 : (transporterIndex - 1)], USE_COMMAND_RANK));
+			camSetDroidExperience(droid, camGetRankThreshold(ranks[mapRun ? 0 : (transporterIndex - 1)], USE_COMMAND_RANK));
 		}
 	}
 }

--- a/data/base/script/campaign/cam3-2.js
+++ b/data/base/script/campaign/cam3-2.js
@@ -87,7 +87,7 @@ function setAlphaExp()
 		const dr = alphaDroids[i];
 		if (!camIsSystemDroid(dr))
 		{
-			setDroidExperience(dr, DROID_EXP);
+			camSetDroidExperience(dr, DROID_EXP);
 		}
 	}
 }

--- a/data/base/script/campaign/cam3-a.js
+++ b/data/base/script/campaign/cam3-a.js
@@ -93,7 +93,7 @@ function setUnitRank(transport)
 		const droid = droids[i];
 		if (droid.droidType !== DROID_CONSTRUCT && droid.droidType !== DROID_REPAIR)
 		{
-			setDroidExperience(droid, droidExp[transporterIndex - 1]);
+			camSetDroidExperience(droid, droidExp[transporterIndex - 1]);
 		}
 	}
 }

--- a/data/base/script/campaign/cam3-a.js
+++ b/data/base/script/campaign/cam3-a.js
@@ -169,7 +169,7 @@ function sendPlayerTransporter()
 		tWeap.tank.inferno, tWeap.tank.assaultGun, tWeap.tank.assaultGun,
 		tWeap.tank.hyperVelocityCannon, tWeap.tank.tankKiller
 	];
-	const specialList = [tConstruct.truck, tConstruct.truck, tCommand.commander, tCommand.commander];
+	const specialList = (tweakOptions.noCommander) ? [tConstruct.truck, tConstruct.truck] : [tConstruct.truck, tConstruct.truck, tCommand.commander, tCommand.commander];
 	const BODY = bodyList[camRand(bodyList.length)];
 	const PROP = propulsionList[camRand(propulsionList.length)];
 

--- a/data/base/script/campaign/libcampaign_includes/events.js
+++ b/data/base/script/campaign/libcampaign_includes/events.js
@@ -185,7 +185,7 @@ function cam_eventDroidBuilt(droid, structure)
 	{
 		return;
 	}
-	camSetDroidExperience(droid);
+	camSetEnemyDroidExperience(droid);
 	__camAddDroidToFactoryGroup(droid, structure);
 }
 

--- a/data/base/script/campaign/libcampaign_includes/misc.js
+++ b/data/base/script/campaign/libcampaign_includes/misc.js
@@ -783,9 +783,34 @@ function camSetOnMapEnemyUnitExp()
 			obj.droidType !== DROID_CONSTRUCT &&
 			obj.droidType !== DROID_REPAIR)
 		{
-			camSetDroidExperience(obj);
+			camSetEnemyDroidExperience(obj);
 		}
 	});
+}
+
+function camSetEnemyDroidExperience(droid)
+{
+	if (droid.droidType === DROID_REPAIR || droid.droidType === DROID_CONSTRUCT || camIsTransporter(droid))
+	{
+		return;
+	}
+	if (droid.player === CAM_HUMAN_PLAYER)
+	{
+		return;
+	}
+	const __CMD_RANK = (droid.droidType === DROID_COMMAND || droid.droidType === DROID_SENSOR);
+	const expRange = __camGetExpRangeLevel(__CMD_RANK);
+	const __EXP = expRange[camRand(expRange.length)];
+	setDroidExperience(droid, __EXP);
+}
+
+function camSetDroidExperience(droid, exp)
+{
+	if (tweakOptions.noExp || droid.droidType === DROID_REPAIR || droid.droidType === DROID_CONSTRUCT || camIsTransporter(droid))
+	{
+		return;
+	}
+	setDroidExperience(droid, exp);
 }
 
 //////////// privates
@@ -939,22 +964,6 @@ function __camGetExpRangeLevel(useCommanderRanks)
 			exp = [ranks.rookie, ranks.rookie];
 	}
 	return exp;
-}
-
-function camSetDroidExperience(droid)
-{
-	if (droid.droidType === DROID_REPAIR || droid.droidType === DROID_CONSTRUCT || camIsTransporter(droid))
-	{
-		return;
-	}
-	if (droid.player === CAM_HUMAN_PLAYER)
-	{
-		return;
-	}
-	const __CMD_RANK = (droid.droidType === DROID_COMMAND || droid.droidType === DROID_SENSOR);
-	const expRange = __camGetExpRangeLevel(__CMD_RANK);
-	const __EXP = expRange[camRand(expRange.length)];
-	setDroidExperience(droid, __EXP);
 }
 
 // Only to prevent prebuilt units from team Gamma on Gamma 6 from having the NavGunSensor.

--- a/data/base/script/campaign/libcampaign_includes/production.js
+++ b/data/base/script/campaign/libcampaign_includes/production.js
@@ -243,7 +243,7 @@ function camUpgradeOnMapTemplates(template1, template2, playerId, excluded)
 			camSafeRemoveObject(dr, false);
 			const droid = addDroid(playerId, droidInfo.x, droidInfo.y, droidInfo.name, template2.body,
 				__camChangePropulsion(template2.prop, playerId), "", "", template2.weap);
-			camSetDroidExperience(droid);
+			camSetEnemyDroidExperience(droid);
 		}
 	}
 }

--- a/data/base/script/campaign/libcampaign_includes/reinforcements.js
+++ b/data/base/script/campaign/libcampaign_includes/reinforcements.js
@@ -61,7 +61,7 @@ function camSendReinforcement(playerId, position, templates, kind, data)
 				const template = templates[i];
 				const __PROP = __camChangePropulsion(template.prop, playerId);
 				const droid = addDroid(playerId, pos.x, pos.y, "Reinforcement", template.body, __PROP, "", "", template.weap);
-				camSetDroidExperience(droid);
+				camSetEnemyDroidExperience(droid);
 				droids.push(droid);
 			}
 			camManageGroup(camMakeGroup(droids), order, order_data);

--- a/data/base/script/campaign/libcampaign_includes/transport.js
+++ b/data/base/script/campaign/libcampaign_includes/transport.js
@@ -156,7 +156,7 @@ function __camLandTransporter(player, pos)
 	{
 		for (let i = 0, len = ti.droids.length; i < len; ++i)
 		{
-			camSetDroidExperience(ti.droids[i]);
+			camSetEnemyDroidExperience(ti.droids[i]);
 		}
 	}
 }

--- a/data/base/script/rules.js
+++ b/data/base/script/rules.js
@@ -281,7 +281,7 @@ function eventGameInit()
 function setLimits()
 {
 	setDroidLimit(selectedPlayer, ((tweakOptions.playerUnitCap40) ? 40 : 100) + 1, DROID_ANY); //note: the transporter is a unit you own
-	setDroidLimit(selectedPlayer, 10, DROID_COMMAND);
+	setDroidLimit(selectedPlayer, ((tweakOptions.noCommander) ? 0 : 10), DROID_COMMAND);
 	setDroidLimit(selectedPlayer, 15, DROID_CONSTRUCT);
 
 	for (let i = 0; i < maxPlayers; ++i)

--- a/data/base/stats/brain.json
+++ b/data/base/stats/brain.json
@@ -1,5 +1,6 @@
 {
 	"CommandBrain01": {
+		"autoRewardRankFromAttach": true,
 		"designable": 1,
 		"droidType": "DROID_COMMAND",
 		"hitpoints": 500,

--- a/data/base/stats/brain.json
+++ b/data/base/stats/brain.json
@@ -7,6 +7,7 @@
 		"maxDroids": 6,
 		"maxDroidsMult": 2,
 		"name": "Command Turret",
+		"productionCommanderExpLimit": 10000,
 		"ranks": [ "Rookie", "Green", "Trained", "Regular", "Professional", "Veteran", "Elite", "Special", "Hero" ],
 		"thresholds": [ 0, 24, 48, 96, 192, 384, 768, 1536, 2048 ],
 		"turret": "CommandTurret1"

--- a/data/mods/campaign/wz2100_camclassic/mod-info.json.in
+++ b/data/mods/campaign/wz2100_camclassic/mod-info.json.in
@@ -72,6 +72,11 @@
             "userEditable": true
         },
         {
+            "id": "noExp",
+            "default": false,
+            "userEditable": true
+        },
+        {
             "id": "towerWars",
             "default": false,
             "userEditable": true

--- a/data/mods/campaign/wz2100_camclassic/mod-info.json.in
+++ b/data/mods/campaign/wz2100_camclassic/mod-info.json.in
@@ -90,6 +90,11 @@
             "id": "unexploredMapOpacity",
             "default": false,
             "userEditable": true
+        },
+        {
+            "id": "noCommander",
+            "default": false,
+            "userEditable": true
         }
     ],
     "customTweakOptions": [

--- a/data/mods/campaign/wz2100_camclassic/stats/brain.json
+++ b/data/mods/campaign/wz2100_camclassic/stats/brain.json
@@ -1,5 +1,6 @@
 {
 	"CommandBrain01": {
+		"autoRewardRankFromAttach": true,
 		"designable": 1,
 		"droidType": "DROID_COMMAND",
 		"hitpoints": 0,

--- a/data/mods/campaign/wz2100_camclassic/stats/brain.json
+++ b/data/mods/campaign/wz2100_camclassic/stats/brain.json
@@ -7,6 +7,7 @@
 		"maxDroids": 6,
 		"maxDroidsMult": 2,
 		"name": "Command Turret",
+		"productionCommanderExpLimit": 10000,
 		"ranks": [ "Rookie", "Green", "Trained", "Regular", "Professional", "Veteran", "Elite", "Special", "Hero" ],
 		"thresholds": [ 0, 16, 32, 64, 128, 256, 512, 1024, 2048 ],
 		"turret": "CommandTurret1"

--- a/data/mods/campaign/wz2100_campumpkin/mod-info.json.in
+++ b/data/mods/campaign/wz2100_campumpkin/mod-info.json.in
@@ -72,6 +72,11 @@
             "userEditable": true
         },
         {
+            "id": "noExp",
+            "default": false,
+            "userEditable": true
+        },
+        {
             "id": "towerWars",
             "default": false,
             "userEditable": true

--- a/data/mods/campaign/wz2100_campumpkin/mod-info.json.in
+++ b/data/mods/campaign/wz2100_campumpkin/mod-info.json.in
@@ -90,6 +90,11 @@
             "id": "unexploredMapOpacity",
             "default": false,
             "userEditable": true
+        },
+        {
+            "id": "noCommander",
+            "default": false,
+            "userEditable": true
         }
     ],
     "customTweakOptions": [

--- a/data/mods/campaign/wz2100_campumpkin/stats/brain.json
+++ b/data/mods/campaign/wz2100_campumpkin/stats/brain.json
@@ -1,5 +1,6 @@
 {
 	"CommandBrain01": {
+		"autoRewardRankFromAttach": true,
 		"designable": 1,
 		"droidType": "DROID_COMMAND",
 		"hitpoints": 0,

--- a/data/mods/campaign/wz2100_campumpkin/stats/brain.json
+++ b/data/mods/campaign/wz2100_campumpkin/stats/brain.json
@@ -7,6 +7,7 @@
 		"maxDroids": 6,
 		"maxDroidsMult": 2,
 		"name": "Command Turret",
+		"productionCommanderExpLimit": 10000,
 		"ranks": [ "Rookie", "Green", "Trained", "Regular", "Professional", "Veteran", "Elite", "Special", "Hero" ],
 		"thresholds": [ 0, 16, 32, 64, 128, 256, 512, 1024, 2048 ],
 		"turret": "CommandTurret1"

--- a/data/mp/stats/brain.json
+++ b/data/mp/stats/brain.json
@@ -1,5 +1,6 @@
 {
 	"CommandBrain01": {
+		"autoRewardRankFromAttach": true,
 		"designable": 1,
 		"droidType": "DROID_COMMAND",
 		"hitpoints": 500,

--- a/data/mp/stats/brain.json
+++ b/data/mp/stats/brain.json
@@ -8,6 +8,7 @@
 		"maxDroidsMult": 2,
 		"name": "Command Turret",
 		"ranks": [ "Rookie", "Green", "Trained", "Regular", "Professional", "Veteran", "Elite", "Special", "Hero" ],
+		"scavengersGiveExpUntilLevel": 2,
 		"thresholds": [ 0, 12, 24, 36, 48, 60, 72, 84, 96 ],
 		"cmdExpRange": [],
 		"turret": "CommandTurret1"
@@ -16,6 +17,7 @@
 		"id": "ZNULLBRAIN",
 		"name": "Z NULL BRAIN",
 		"ranks": [ "Rookie", "Green", "Trained", "Regular", "Professional", "Veteran", "Elite", "Special", "Hero" ],
+		"scavengersGiveExpUntilLevel": 2,
 		"thresholds": [ 0, 2, 4, 6, 8, 10, 12, 14, 16 ],
 		"cmdExpRange": [ 512, 768, 1024, 1024, 1280, 1280, 1280, 1536, 1536 ],
 		"turret": "ZNULLWEAPON"

--- a/data/mp/stats/brain.json
+++ b/data/mp/stats/brain.json
@@ -7,6 +7,7 @@
 		"maxDroids": 6,
 		"maxDroidsMult": 2,
 		"name": "Command Turret",
+		"productionCommanderExpLimit": 36,
 		"ranks": [ "Rookie", "Green", "Trained", "Regular", "Professional", "Veteran", "Elite", "Special", "Hero" ],
 		"scavengersGiveExpUntilLevel": 2,
 		"thresholds": [ 0, 12, 24, 36, 48, 60, 72, 84, 96 ],

--- a/src/campaigninfo.cpp
+++ b/src/campaigninfo.cpp
@@ -202,6 +202,16 @@ bool getCamTweakOption_FastExp()
 	return val.get<bool>();
 }
 
+bool getCamTweakOption_NoExp()
+{
+	auto val = getCamTweakOptionsValue("noExp", false);
+	if (!val.is_boolean())
+	{
+		return false;
+	}
+	return val.get<bool>();
+}
+
 bool getCamTweakOption_heavilyDamagedPenalty()
 {
 	auto val = getCamTweakOptionsValue("heavilyDamagedPenalty", false);

--- a/src/campaigninfo.h
+++ b/src/campaigninfo.h
@@ -59,6 +59,7 @@ nlohmann::json getCamTweakOptionsValue(const std::string& identifier, nlohmann::
 bool getCamTweakOption_AutosavesOnly();
 bool getCamTweakOption_PS1Modifiers();
 bool getCamTweakOption_FastExp();
+bool getCamTweakOption_NoExp();
 bool getCamTweakOption_heavilyDamagedPenalty();
 
 #endif // __INCLUDED_SRC_CAMPAIGNINFO_H__

--- a/src/droid.cpp
+++ b/src/droid.cpp
@@ -2590,6 +2590,23 @@ UDWORD	getNumDroidsForLevel(uint32_t player, UDWORD level)
 	return count;
 }
 
+// Decides if a unit, after defeating a scavenger, gains exp.
+bool droidExpForScavengersOutsideLimits(DROID *psDroid)
+{
+	int limit = psDroid->getBrainStats()->scavengersGiveExpUntilLevel;
+
+	if (limit < 0)
+	{
+		return false; // Always give experience.
+	}
+	else if (limit == 0)
+	{
+		return true; // Give no experience.
+	}
+
+	return getDroidLevel(psDroid) >= limit;
+}
+
 // Increase the experience of a droid (and handle events, if needed).
 void droidIncreaseExperience(DROID *psDroid, uint32_t experienceInc)
 {
@@ -2617,8 +2634,24 @@ void giveExperienceForSquish(DROID *psDroid)
 {
 	if (psDroid->droidType == DROID_WEAPON || psDroid->droidType == DROID_SENSOR || psDroid->droidType == DROID_COMMAND)
 	{
+		if (droidExpForScavengersOutsideLimits(psDroid))
+		{
+			return;
+		}
+
 		const uint32_t expGain = std::max(65536 / 2, 65536 * getExpGain(psDroid->player) / 100);
 		droidIncreaseExperience(psDroid, expGain);
+
+		if (hasCommander(psDroid) && psDroid->psGroup->psCommander)
+		{
+			DROID *psCommander = psDroid->psGroup->psCommander;
+
+			if (droidExpForScavengersOutsideLimits(psCommander))
+			{
+				return;
+			}
+		}
+
 		cmdDroidUpdateExperience(psDroid, expGain);
 	}
 }

--- a/src/droid.cpp
+++ b/src/droid.cpp
@@ -1053,6 +1053,16 @@ void droidUpdate(DROID *psDroid)
 	CHECK_DROID(psDroid);
 }
 
+// Applies the exp cap on commanders when produced
+void limitCommanderExpForProduction(DROID *psCommander)
+{
+	if (!psCommander || psCommander->droidType != DROID_COMMAND)
+	{
+		return;
+	}
+	psCommander->experience = std::min(static_cast<uint32_t>(psCommander->getBrainStats()->productionCommanderExpLimit * 65536), psCommander->experience);
+}
+
 /* Check if droid is within commander's range */
 bool droidWithinCommanderRange(const DROID *psDroid)
 {

--- a/src/droid.cpp
+++ b/src/droid.cpp
@@ -2623,9 +2623,16 @@ bool droidExpForScavengersOutsideLimits(DROID *psDroid)
 // Increase the experience of a droid (and handle events, if needed).
 void droidIncreaseExperience(DROID *psDroid, uint32_t experienceInc)
 {
-	if (!bMultiPlayer && getCamTweakOption_FastExp())
+	if (!bMultiPlayer)
 	{
-		experienceInc = experienceInc * 2;
+		if (getCamTweakOption_NoExp())
+		{
+			return;
+		}
+		if (getCamTweakOption_FastExp())
+		{
+			experienceInc = experienceInc * 2;
+		}
 	}
 
 	ASSERT_OR_RETURN(, experienceInc < (int)(2.1 * 65536), "Experience increase out of range");

--- a/src/droid.cpp
+++ b/src/droid.cpp
@@ -2538,7 +2538,10 @@ UDWORD getDroidEffectiveLevel(const DROID *psDroid, bool commanderDistanceCheck)
 		cmdLevel = cmdGetCommanderLevel(psDroid);
 
 		// Commanders boost units' effectiveness just by being assigned to it
-		level++;
+		if (psDroid->psGroup->psCommander->getBrainStats()->autoRewardRankFromAttach)
+		{
+			level++;
+		}
 	}
 
 	return MAX(level, cmdLevel);

--- a/src/droid.h
+++ b/src/droid.h
@@ -123,6 +123,9 @@ int32_t droidDamage(GameWorld& world, DROID *psDroid, PROJECTILE *psProjectile, 
 /* The main update routine for all droids */
 void droidUpdate(DROID *psDroid);
 
+/* Applies the exp cap on commanders when produced */
+void limitCommanderExpForProduction(DROID *psCommander);
+
 /* Check if droid is within commander's range */
 bool droidWithinCommanderRange(const DROID *psDroid);
 

--- a/src/droid.h
+++ b/src/droid.h
@@ -200,6 +200,7 @@ unsigned int getDroidLevel(unsigned int experience, uint8_t player, uint8_t brai
 UDWORD getDroidEffectiveLevel(const DROID *psDroid, bool commanderDistanceCheck = true);
 const char *getDroidLevelName(const DROID *psDroid);
 // Increase the experience of a droid (and handle events, if needed).
+bool droidExpForScavengersOutsideLimits(DROID *psDroid);
 void droidIncreaseExperience(DROID *psDroid, uint32_t experienceInc);
 void giveExperienceForSquish(DROID *psDroid);
 

--- a/src/hci/manufacture.cpp
+++ b/src/hci/manufacture.cpp
@@ -356,15 +356,20 @@ protected:
 			return;
 		}
 		const auto player = factory->player;
-		const auto exp = getTopExperience(player);
+		auto exp = getTopExperience(player);
 		unsigned int lvl = 0;
 		if (!factory->pFunctionality->factory.psSubject)
 		{
 			// not showing icon when nothing is being built
 			return;
 		}
-		if (factory->pFunctionality->factory.psSubject->droidType == DROID_COMMAND || factory->pFunctionality->factory.psSubject->droidType == DROID_SENSOR)
+		bool isCommander = factory->pFunctionality->factory.psSubject->droidType == DROID_COMMAND;
+		if (isCommander || factory->pFunctionality->factory.psSubject->droidType == DROID_SENSOR)
 		{
+			if (isCommander)
+			{
+				exp = std::min(factory->pFunctionality->factory.psSubject->getBrainStats()->productionCommanderExpLimit * 65536, exp);
+			}
 			lvl = getDroidLevel(exp, player, commandBrainComponent);
 		}
 		else if (factory->pFunctionality->factory.psSubject->droidType == DROID_CONSTRUCT

--- a/src/multibot.cpp
+++ b/src/multibot.cpp
@@ -436,6 +436,8 @@ bool recvDroid(NETQUEUE queue)
 	// If we were able to build the droid set it up
 	if (psDroid)
 	{
+		limitCommanderExpForProduction(psDroid);
+
 		addDroid(psDroid, gameWorld.objects.droids);
 
 		if (haveInitialOrders)

--- a/src/projectile.cpp
+++ b/src/projectile.cpp
@@ -80,6 +80,18 @@ struct INTERVAL
 	int begin, end;  // Time 1 = 0, time 2 = 1024. Or begin >= end if empty.
 };
 
+enum DAMAGE_EXP_SOURCE_TYPE
+{
+	// These happen once for the original projectile.
+	DAM_IMPACT, 			// Damage from the original projectile making a direct impact.
+	DAM_SPLASH,				// Splash damage from the original projectile.
+	// Traveling spawned penetrating projectile(s). Likely hitting multiple targets.
+	DAM_PENETRATE_IMPACT,	// Spawned penetrating projectile -- Impact type making a direct hit.
+	DAM_PENETRATE_SPLASH,	// Spawned penetrating projectile -- Splash radius type.
+	// Damage potentially done to multiple units at the same time.
+	DAM_PERIOD				// Residual Periodical damage lingering over tiles for a time (not the additional hardcoded afterburn damage effect).
+};
+
 struct DAMAGE
 {
 	PROJECTILE *psProjectile;
@@ -91,6 +103,7 @@ struct DAMAGE
 	bool isDamagePerSecond;
 	int minDamage;
 	bool empRadiusHit;
+	int damageSourceType;
 };
 
 // Watermelon:they are from droid.c
@@ -313,8 +326,18 @@ DROID *getDesignatorAttackingObject(int player, BASE_OBJECT *target)
 		: nullptr;
 }
 
+static bool shouldGiveExpGain(DAMAGE *psDamage, DROID *psDroid)
+{
+	if (bMultiPlayer && psDamage && psDamage->psDest && psDamage->psDest->player == scavengerPlayer())
+	{
+		return psDroid != nullptr && !droidExpForScavengersOutsideLimits(psDroid);
+	}
+
+	return true;
+}
+
 // update the source experience after a target is damaged/destroyed
-static void proj_UpdateExperience(PROJECTILE *psObj, uint32_t experienceInc)
+static void proj_UpdateExperience(PROJECTILE *psObj, DAMAGE *psDamage, uint32_t experienceInc)
 {
 	DROID	        *psDroid;
 	BASE_OBJECT     *psSensor;
@@ -327,9 +350,7 @@ static void proj_UpdateExperience(PROJECTILE *psObj, uint32_t experienceInc)
 
 		// If it is 'droid-on-droid' then modify the experience by the Quality factor
 		// Only do this in MP so to not un-balance the campaign
-		if (psObj->psDest != nullptr
-		    && psObj->psDest->type == OBJ_DROID
-		    && bMultiPlayer)
+		if (psObj->psDest != nullptr && psObj->psDest->type == OBJ_DROID && bMultiPlayer)
 		{
 			// Modify the experience gained by the 'quality factor' of the units
 			experienceInc = (uint64_t)experienceInc * qualityFactor(psDroid, (DROID *)psObj->psDest) / 65536;
@@ -337,12 +358,21 @@ static void proj_UpdateExperience(PROJECTILE *psObj, uint32_t experienceInc)
 
 		ASSERT_OR_RETURN(, experienceInc < (int)(2.1 * 65536), "Experience increase out of range");
 
-		droidIncreaseExperience(psDroid, experienceInc);
-
-		cmdDroidUpdateExperience(psDroid, experienceInc);
+		if (shouldGiveExpGain(psDamage, psDroid))
+		{
+			droidIncreaseExperience(psDroid, experienceInc);
+		}
+		if (hasCommander(psDroid))
+		{
+			DROID *psCommander = psDroid->psGroup->psCommander;
+			if (shouldGiveExpGain(psDamage, psCommander))
+			{
+				cmdDroidUpdateExperience(psDroid, experienceInc);
+			}
+		}
 
 		psSensor = orderStateObj(psDroid, DORDER_FIRESUPPORT);
-		if (psSensor && psSensor->type == OBJ_DROID)
+		if (psSensor && psSensor->type == OBJ_DROID && shouldGiveExpGain(psDamage, (DROID *)psSensor))
 		{
 			droidIncreaseExperience((DROID *)psSensor, experienceInc);
 		}
@@ -353,7 +383,7 @@ static void proj_UpdateExperience(PROJECTILE *psObj, uint32_t experienceInc)
 
 		psDroid = getDesignatorAttackingObject(psObj->psSource->player, psObj->psDest);
 
-		if (psDroid != nullptr)
+		if (psDroid != nullptr && shouldGiveExpGain(psDamage, psDroid))
 		{
 			droidIncreaseExperience(psDroid, experienceInc);
 		}
@@ -477,6 +507,7 @@ static PROJECTILE* proj_SendProjectileAngledInternal(WEAPON* psWeap, SIMPLE_OBJE
 	proj.dst             = target;
 
 	proj.bVisible = false;
+	proj.penetratingProjectile = false;
 
 	// Must set ->psDest and ->expectedDamageCaused before first call to setProjectileDestination().
 	proj.psDest = nullptr;
@@ -487,8 +518,7 @@ static PROJECTILE* proj_SendProjectileAngledInternal(WEAPON* psWeap, SIMPLE_OBJE
 	When we have been created by penetration (spawned from another projectile),
 	we shall live no longer than the original projectile may have lived
 	*/
-	const bool spawnedByPenetration = psAttacker && psAttacker->type == OBJ_PROJECTILE;
-	if (spawnedByPenetration)
+	if (psAttacker && psAttacker->type == OBJ_PROJECTILE)
 	{
 		PROJECTILE *psOldProjectile = (PROJECTILE *)psAttacker;
 		proj.born = psOldProjectile->born;
@@ -500,6 +530,8 @@ static PROJECTILE* proj_SendProjectileAngledInternal(WEAPON* psWeap, SIMPLE_OBJE
 
 		setProjectileSource(&proj, psOldProjectile->psSource);
 		proj.psDamaged = psOldProjectile->psDamaged;
+
+		proj.penetratingProjectile = weapon_slot == PROJ_PENETRATE_SLOT; // Searching for PROJ_PENETRATE_SLOT just makes it easier to find where these are initially created from.
 
 		// TODO Should finish the tick, when penetrating.
 	}
@@ -559,7 +591,7 @@ static PROJECTILE* proj_SendProjectileAngledInternal(WEAPON* psWeap, SIMPLE_OBJE
 	}
 	proj.state = PROJ_INFLIGHT;
 
-	if (spawnedByPenetration)
+	if (proj.penetratingProjectile)
 	{
 		proj.prevSpacetime.pos = proj.pos;
 		proj.prevSpacetime.rot = proj.rot;
@@ -960,7 +992,7 @@ static PROJECTILE* proj_InFlightFunc(PROJECTILE *psProj)
 			// Assume we damaged the chosen target
 			psProj->psDamaged.push_back(closestCollisionObject);
 
-			spawnedProjectile = proj_SendProjectileInternal(&asWeap, psProj, psProj->player, psProj->dst, nullptr, true, -1);
+			spawnedProjectile = proj_SendProjectileInternal(&asWeap, psProj, psProj->player, psProj->dst, nullptr, true, PROJ_PENETRATE_SLOT);
 		}
 
 		psProj->state = PROJ_IMPACT;
@@ -1093,7 +1125,8 @@ static void proj_radiusSweep(PROJECTILE *psObj, WEAPON_STATS *psStats, Vector3i 
 			psObj->time,
 			false,
 			(int)psStats->upgrade[psObj->player].minimumDamage,
-			empRadius
+			empRadius,
+			((psObj->penetratingProjectile) ? DAM_PENETRATE_SPLASH : DAM_SPLASH)
 		};
 
 		objectDamage(gameWorld, &sDamage);
@@ -1290,7 +1323,8 @@ static void proj_ImpactFunc(PROJECTILE *psObj)
 				psObj->time,
 				false,
 				(int)psStats->upgrade[psObj->player].minimumDamage,
-				false
+				false,
+				((psObj->penetratingProjectile)) ? DAM_PENETRATE_IMPACT : DAM_IMPACT
 			};
 
 			// Damage the object
@@ -1542,7 +1576,8 @@ static void proj_checkPeriodicalDamage(PROJECTILE *psProj)
 			gameTime - deltaGameTime / 2 + 1,
 			true,
 			(int)psStats->upgrade[psProj->player].minimumDamage,
-			false
+			false,
+			DAM_PERIOD
 		};
 
 		objectDamage(gameWorld, &sDamage);
@@ -1713,9 +1748,19 @@ static bool isFriendlyFire(DAMAGE* psDamage)
 	return psDamage->psDest && psDamage->psProjectile->psSource->player == psDamage->psDest->player;
 }
 
-static bool shouldIncreaseExperience(DAMAGE *psDamage)
+// NOTE: The isFeature() here prevents any exp gain at all, even if the projectile does more than just direct impact damage to non-feature objects.
+static bool mayIncreaseExperience(DAMAGE *psDamage)
 {
 	return psDamage->psProjectile->psSource && !isFeature(psDamage->psProjectile->psDest) && !isFriendlyFire(psDamage);
+}
+
+static bool damageTypeAllowsExpGain(DAMAGE *psDamage)
+{
+	return ((psDamage->damageSourceType == DAM_IMPACT && psDamage->psProjectile->psWStats->flags.test(WEAPON_FLAG_EXP_IMPACT)) ||
+		(psDamage->damageSourceType == DAM_SPLASH && psDamage->psProjectile->psWStats->flags.test(WEAPON_FLAG_EXP_SPLASH)) ||
+		(psDamage->damageSourceType == DAM_PERIOD && psDamage->psProjectile->psWStats->flags.test(WEAPON_FLAG_EXP_PERIODICAL)) ||
+		(psDamage->damageSourceType == DAM_PENETRATE_IMPACT && psDamage->psProjectile->psWStats->flags.test(WEAPON_FLAG_EXP_IMPACT_PENETRATE)) ||
+		(psDamage->damageSourceType == DAM_PENETRATE_SPLASH && psDamage->psProjectile->psWStats->flags.test(WEAPON_FLAG_EXP_SPLASH_PENETRATE)));
 }
 
 static void updateKills(DAMAGE* psDamage)
@@ -1751,12 +1796,15 @@ static int32_t objectDamage(GameWorld& world, DAMAGE *psDamage)
 {
 	int32_t relativeDamage = objectDamageDispatch(world, psDamage);
 
-	if (shouldIncreaseExperience(psDamage)) {
-		proj_UpdateExperience(psDamage->psProjectile, abs(relativeDamage) * getExpGain(psDamage->psProjectile->psSource->player) / 100);
+	if (mayIncreaseExperience(psDamage))
+	{
+		if (damageTypeAllowsExpGain(psDamage))
+		{
+			proj_UpdateExperience(psDamage->psProjectile, psDamage, abs(relativeDamage) * getExpGain(psDamage->psProjectile->psSource->player) / 100);
+		}
 
-		bool isTargetDestroyed = relativeDamage < 0;
-
-		if (isTargetDestroyed) {
+		if (relativeDamage < 0)
+		{
 			updateKills(psDamage);
 		}
 	}

--- a/src/projectile.h
+++ b/src/projectile.h
@@ -45,6 +45,8 @@
 /** How long to display a single electronic warfare shimmmer. */
 #define ELEC_DAMAGE_DURATION    (GAME_TICKS_PER_SEC/5)
 
+#define PROJ_PENETRATE_SLOT -1731
+
 bool	proj_InitSystem();	///< Initialize projectiles subsystem.
 void	proj_UpdateAll();	///< Frame update for projectiles.
 bool	proj_Shutdown();	///< Shut down projectile subsystem.

--- a/src/projectiledef.h
+++ b/src/projectiledef.h
@@ -60,6 +60,7 @@ struct PROJECTILE : public SIMPLE_OBJECT
 	Spacetime       prevSpacetime;          ///< Location of projectile in previous tick.
 	UDWORD          expectedDamageCaused;   ///< Expected damage that this projectile will cause to the target.
 	int             partVisible;            ///< how much of target was visible on shooting (important for homing)
+	bool            penetratingProjectile;  ///< If the projectile is the post-impact spawned one
 };
 
 typedef std::vector<PROJECTILE *>::const_iterator ProjectileIterator;

--- a/src/stats.cpp
+++ b/src/stats.cpp
@@ -801,6 +801,7 @@ bool loadBrainStats(WzConfig &ini)
 
 		psStats->scavengersGiveExpUntilLevel = ini.value("scavengersGiveExpUntilLevel", -1).toInt();
 		psStats->productionCommanderExpLimit = ini.value("productionCommanderExpLimit", 10000).toInt();
+		psStats->autoRewardRankFromAttach = ini.value("autoRewardRankFromAttach", true).toBool();
 		psStats->designable = ini.value("designable", false).toBool();
 		ini.endGroup();
 	}

--- a/src/stats.cpp
+++ b/src/stats.cpp
@@ -800,6 +800,7 @@ bool loadBrainStats(WzConfig &ini)
 		}
 
 		psStats->scavengersGiveExpUntilLevel = ini.value("scavengersGiveExpUntilLevel", -1).toInt();
+		psStats->productionCommanderExpLimit = ini.value("productionCommanderExpLimit", 10000).toInt();
 		psStats->designable = ini.value("designable", false).toBool();
 		ini.endGroup();
 	}

--- a/src/stats.cpp
+++ b/src/stats.cpp
@@ -577,6 +577,32 @@ bool loadWeaponStats(WzConfig &ini)
 		{
 			psStats->flags.set(WEAPON_FLAG_TELEPORT_CAPTURE, true);
 		}
+		// Exp gain is based on damage from projectiles and all forms of damage allow it by default.
+		psStats->flags.set(WEAPON_FLAG_EXP_IMPACT, true);
+		psStats->flags.set(WEAPON_FLAG_EXP_IMPACT_PENETRATE, true);
+		psStats->flags.set(WEAPON_FLAG_EXP_SPLASH_PENETRATE, true);
+		psStats->flags.set(WEAPON_FLAG_EXP_PERIODICAL, true);
+		psStats->flags.set(WEAPON_FLAG_EXP_SPLASH, true);
+		if (std::find(flags.begin(), flags.end(), "expnoimpactdamage") != flags.end()) // "ExpNoImpactDamage"
+		{
+			psStats->flags.set(WEAPON_FLAG_EXP_IMPACT, false);
+		}
+		if (std::find(flags.begin(), flags.end(), "expnopenetrateimpactdamage") != flags.end()) // "ExpNoPenetrateImpactDamage"
+		{
+			psStats->flags.set(WEAPON_FLAG_EXP_IMPACT_PENETRATE, false);
+		}
+		if (std::find(flags.begin(), flags.end(), "expnopenetratesplashdamage") != flags.end()) // "ExpNoPenetrateSplashDamage"
+		{
+			psStats->flags.set(WEAPON_FLAG_EXP_SPLASH_PENETRATE, false);
+		}
+		if (std::find(flags.begin(), flags.end(), "expnoperiodicaldamage") != flags.end()) // "ExpNoPeriodicalDamage"
+		{
+			psStats->flags.set(WEAPON_FLAG_EXP_PERIODICAL, false);
+		}
+		if (std::find(flags.begin(), flags.end(), "expnosplashdamage") != flags.end()) // "ExpNoSplashDamage"
+		{
+			psStats->flags.set(WEAPON_FLAG_EXP_SPLASH, false);
+		}
 
 		//set the weapon sounds to default value
 		psStats->iAudioFireID = NO_SOUND;
@@ -772,6 +798,8 @@ bool loadBrainStats(WzConfig &ini)
 				retVal = false;
 			}
 		}
+
+		psStats->scavengersGiveExpUntilLevel = ini.value("scavengersGiveExpUntilLevel", -1).toInt();
 		psStats->designable = ini.value("designable", false).toBool();
 		ini.endGroup();
 	}

--- a/src/statsdef.h
+++ b/src/statsdef.h
@@ -495,6 +495,7 @@ struct BRAIN_STATS : public COMPONENT_STATS
 	std::vector<std::string> rankNames;
 	std::vector<int> cmdExpRange;
 	int scavengersGiveExpUntilLevel; ///< maximum rank level the droid can have until scavengers stop awarding any experience
+	int productionCommanderExpLimit; ///< maximum exp commanders can be built with
 };
 
 /*

--- a/src/statsdef.h
+++ b/src/statsdef.h
@@ -496,6 +496,7 @@ struct BRAIN_STATS : public COMPONENT_STATS
 	std::vector<int> cmdExpRange;
 	int scavengersGiveExpUntilLevel; ///< maximum rank level the droid can have until scavengers stop awarding any experience
 	int productionCommanderExpLimit; ///< maximum exp commanders can be built with
+	bool autoRewardRankFromAttach;   ///< Attached unit effective rank will consider the unit as one rank above itself when assigning the final rank outcome
 };
 
 /*

--- a/src/statsdef.h
+++ b/src/statsdef.h
@@ -110,6 +110,11 @@ enum WEAPON_FLAGS
 	WEAPON_FLAG_NO_FRIENDLY_FIRE,
 	WEAPON_FLAG_ALLOWED_ON_TRANSPORTER,
 	WEAPON_FLAG_TELEPORT_CAPTURE,
+	WEAPON_FLAG_EXP_IMPACT,
+	WEAPON_FLAG_EXP_SPLASH,
+	WEAPON_FLAG_EXP_IMPACT_PENETRATE,
+	WEAPON_FLAG_EXP_SPLASH_PENETRATE,
+	WEAPON_FLAG_EXP_PERIODICAL,
 	WEAPON_FLAG_COUNT
 };
 
@@ -489,6 +494,7 @@ struct BRAIN_STATS : public COMPONENT_STATS
 	} upgrade[MAX_PLAYERS], base;
 	std::vector<std::string> rankNames;
 	std::vector<int> cmdExpRange;
+	int scavengersGiveExpUntilLevel; ///< maximum rank level the droid can have until scavengers stop awarding any experience
 };
 
 /*

--- a/src/structure.cpp
+++ b/src/structure.cpp
@@ -2659,6 +2659,7 @@ static bool structPlaceDroid(STRUCTURE *psStructure, DROID_TEMPLATE *psTempl, DR
 		}
 		setFactorySecondaryState(psNewDroid, psStructure);
 		displayConstructionCloud(gameWorld.map, psNewDroid->pos);
+		limitCommanderExpForProduction(psNewDroid);
 		/* add the droid to the list */
 		addDroid(psNewDroid, gameWorld.objects.droids);
 		*ppsDroid = psNewDroid;

--- a/src/titleui/campaign.cpp
+++ b/src/titleui/campaign.cpp
@@ -1728,6 +1728,13 @@ static std::vector<WzCampaignTweakOptionSetting> buildTweakOptionSettings(option
 		false, true
 	);
 
+	results.emplace_back(
+		"noCommander",
+		_("No Commanders"),
+		_("Prevent the production of Commanders to test your multitasking capabilities."),
+		false, true
+	);
+
 	if (modInfo.has_value())
 	{
 		for (auto it = results.begin(); it != results.end(); )

--- a/src/titleui/campaign.cpp
+++ b/src/titleui/campaign.cpp
@@ -1701,6 +1701,13 @@ static std::vector<WzCampaignTweakOptionSetting> buildTweakOptionSettings(option
 	);
 
 	results.emplace_back(
+		"noExp",
+		_("No EXP gain"),
+		_("No experience gained. Relive a semblence of your first playthrough again."),
+		false, true
+	);
+
+	results.emplace_back(
 		"towerWars",
 		_("Tower Wars"),
 		_("Player gets significantly stronger structures."),

--- a/src/wzapi.cpp
+++ b/src/wzapi.cpp
@@ -4515,6 +4515,11 @@ nlohmann::json wzapi::constructStatsObject()
 			weap["NoFriendlyFire"] = psStats->flags.test(WEAPON_FLAG_NO_FRIENDLY_FIRE);
 			weap["AllowedOnTransporter"] = psStats->flags.test(WEAPON_FLAG_ALLOWED_ON_TRANSPORTER);
 			weap["TeleportCapture"] = psStats->flags.test(WEAPON_FLAG_TELEPORT_CAPTURE);
+			weap["ExpImpactDamage"] = psStats->flags.test(WEAPON_FLAG_EXP_IMPACT);
+			weap["ExpPenetrateImpactDamage"] = psStats->flags.test(WEAPON_FLAG_EXP_IMPACT_PENETRATE);
+			weap["ExpPenetrateSplashDamage"] = psStats->flags.test(WEAPON_FLAG_EXP_SPLASH_PENETRATE);
+			weap["ExpPeriodicalDamage"] = psStats->flags.test(WEAPON_FLAG_EXP_PERIODICAL);
+			weap["ExpSplashDamage"] = psStats->flags.test(WEAPON_FLAG_EXP_SPLASH);
 			weap["FlightSpeed"] = psStats->flightSpeed;
 			weap["Rotate"] = psStats->rotate;
 			weap["MinElevation"] = psStats->minElevation;


### PR DESCRIPTION
- Weapons can add these to their `flags`: `ExpNoImpactDamage`, `ExpNoPenetrateImpactDamage`, `ExpNoPenetrateSplashDamage`, `ExpNoPeriodicalDamage`, and `ExpNoSplashDamage` to control all exp gain mechanisms.
- Add new brain stat `scavengersGiveExpUntilLevel`, for skirmish/mp only, that limits exp gain from scavenger objects if they are near a rank (0, 1, 2...). If so, no more exp will be awarded from damaging scavenger owned objects. This does not clip exp, so there will be tiny exp overshoot past a rank.
- Add projectile member `penetratingProjectile` to easily tell if the projectile was spawned in-place to potentially penetrate and hit more objects.
- `DAMAGE` struct adds member `damageSourceType` to identify if the projectile damage is from Impact, Penetration, Splash, or Periodic.

Function `droidExpForScavengersOutsideLimits()` is used to determine if scavengers give exp or not. If the new brain stat specifies a negative number (default), then exp is always awarded. If set to zero, none will be given. Otherwise as long as units/commanders keep attacking scavenger objects they will stop gaining exp eventually from them.

Function `damageTypeAllowsExpGain()` is the new addition that will block exp gain if a specific damage source type is disallowed from doing so.

New define `PROJ_PENETRATE_SLOT` created just to make it easier to see where penetrating projectiles are created and set (a lot more informative than weapon_slot = -1).

New `"productionCommanderExpLimit"` Brain stat to limit the effectiveness of the sensor recycle tactic in NTW. This just replaces what the exp would have been with the flat exp value specified in the stat, if it exceeds that limit. The Manufacturing buttons will reflect the rank that will be produced from the Commander.


---

Potential todos:
- I could make the scavenger limiter apply to campaign, just I'd have to add another brain stat that contains which players are scavenger players. Campaign sets maxPlayers to 10 so `scavengerPlayer()` and `scavengerSlot()` will always fail the standard player check, as scavengers are either Pink (p6) and/or Cyan (p7).
- Attacking a feature directly prevents exp gain if it does splash or fire damage to other non-features. This is because of the `isFeature()` check in `mayIncreaseExperience()`. Also incredibly niche so may not be worth fixing.