### PR TITLE
gfx_api: Add render pass graph infrastructure and unify legacy frame passes

### DIFF
--- a/lib/framework/hash_combine.h
+++ b/lib/framework/hash_combine.h
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+/*
+	This file is part of Warzone 2100.
+	Copyright (C) 2026  Warzone 2100 Project (https://github.com/Warzone2100)
+
+	Warzone 2100 is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+
+	Warzone 2100 is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with Warzone 2100; if not, write to the Free Software
+	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+/** @file hash_combine.h
+ * Boost-style `hash_combine` helper for mixing values into a `std::size_t` seed.
+ */
+
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+
+inline void hash_combine(std::size_t& seed) { }
+
+template <typename T, typename... Rest>
+inline void hash_combine(std::size_t& seed, const T& v, Rest... rest)
+{
+	std::hash<T> hasher;
+#if SIZE_MAX >= UINT64_MAX
+	seed ^= hasher(v) + 0x9e3779b97f4a7c15L + (seed << 6) + (seed >> 2);
+#else
+	seed ^= hasher(v) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+#endif
+	hash_combine(seed, rest...);
+}

--- a/lib/ivis_opengl/CMakeLists.txt
+++ b/lib/ivis_opengl/CMakeLists.txt
@@ -12,11 +12,36 @@ file(GLOB HEADERS
 	"culling.h"
 	"gfx_api.h"
 	"gfx_api_formats_def.h"
+	"gfx_api_frame_resource_cache.h"
+	"gfx_api_legacy_pass_compat.h"
 	"gfx_api_gl.h"
 	"gfx_api_image_basis_priv.h"
 	"gfx_api_image_compress_priv.h"
 	"gfx_api_null.h"
 	"gfx_api_vk.h"
+	"render_graph/attachment.h"
+	"render_graph/blueprint.h"
+	"render_graph/blueprint_materializer.h"
+	"render_graph/cached_render_graph.h"
+	"render_graph/compile.h"
+	"render_graph/layout_subresource.h"
+	"render_graph/layout_timeline.h"
+	"render_graph/read_scope.h"
+	"render_graph/pass_resolve.h"
+	"render_graph/pipeline_surfaces.h"
+	"render_graph/render_pass.h"
+	"render_graph/render_pass_id.h"
+	"render_graph/topology.h"
+	"vk/frame_layout_tracker.h"
+	"vk/legacy_layout_final.h"
+	"vk/legacy_pass_layout_commit.h"
+	"vk/layout_key_builder.h"
+	"vk/layout_sync.h"
+	"vk/layout_translation.h"
+	"vk/pass_layout_key.h"
+	"vk/pre_pass_barrier_emitter.h"
+	"vk/render_pass_layout_cache.h"
+	"vk/warm_entry.h"
 	"imd.h"
 	"ivisdef.h"
 	"jpeg_encoder.h"
@@ -43,11 +68,23 @@ file(GLOB SRC
 	"bitimage.cpp"
 	"culling.cpp"
 	"gfx_api.cpp"
+	"gfx_api_legacy_pass_compat.cpp"
 	"gfx_api_texture_array_load.cpp"
 	"gfx_api_gl.cpp"
 	"gfx_api_image_basis_priv.cpp"
 	"gfx_api_image_compress_priv.cpp"
 	"gfx_api_null.cpp"
+	"render_graph/blueprint.cpp"
+	"render_graph/blueprint_materializer.cpp"
+	"render_graph/cached_render_graph.cpp"
+	"render_graph/compile.cpp"
+	"render_graph/layout_subresource.cpp"
+	"render_graph/layout_timeline.cpp"
+	"render_graph/read_scope.cpp"
+	"render_graph/frame_blueprint.cpp"
+	"render_graph/pass_resolve.cpp"
+	"render_graph/pipeline_surfaces.cpp"
+	"render_graph/topology.cpp"
 	"gfx_api_vk.cpp"
 	"imdload.cpp"
 	"jpeg_encoder.cpp"
@@ -88,6 +125,7 @@ include(CheckCXXCompilerFlag)
 
 add_library(ivis-opengl STATIC ${HEADERS} ${SRC})
 set_property(TARGET ivis-opengl PROPERTY FOLDER "lib")
+target_include_directories(ivis-opengl PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 include(WZTargetConfiguration)
 WZ_TARGET_CONFIGURATION(ivis-opengl)
 
@@ -153,6 +191,15 @@ if(WZ_ENABLE_BACKEND_VULKAN)
 		target_sources(ivis-opengl PRIVATE "3rdparty/vkh_info.cpp" "3rdparty/vkh_info.hpp")
 
 		target_sources(ivis-opengl PRIVATE "3rdparty/vk_mem_alloc.cpp" "3rdparty/vk_mem_alloc.h")
+		target_sources(ivis-opengl PRIVATE
+			"vk/frame_layout_tracker.cpp"
+			"vk/legacy_pass_layout_commit.cpp"
+			"vk/layout_key_builder.cpp"
+			"vk/layout_sync.cpp"
+			"vk/layout_translation.cpp"
+			"vk/pass_layout_key.cpp"
+			"vk/pre_pass_barrier_emitter.cpp"
+			"vk/render_pass_layout_cache.cpp")
 		CHECK_CXX_COMPILER_FLAG(-Wno-pedantic COMPILER_SUPPORTS_WNO_PEDANTIC)
 		if(COMPILER_SUPPORTS_WNO_PEDANTIC)
 			set_source_files_properties("3rdparty/vk_mem_alloc.cpp" PROPERTIES COMPILE_FLAGS -Wno-pedantic)
@@ -232,6 +279,18 @@ if (CMAKE_CXX_STANDARD GREATER_EQUAL 20)
 		"3rdparty/vkh_renderpasscompat.cpp"
 		"3rdparty/vkh_info.cpp"
 		"gfx_api_vk.cpp"
-		"gfx_api.cpp")
+		"gfx_api.cpp"
+		"render_graph/compile.cpp"
+		"render_graph/layout_subresource.cpp"
+		"render_graph/layout_timeline.cpp"
+		"render_graph/read_scope.cpp"
+		"vk/frame_layout_tracker.cpp"
+		"vk/legacy_pass_layout_commit.cpp"
+		"vk/layout_key_builder.cpp"
+		"vk/layout_sync.cpp"
+		"vk/layout_translation.cpp"
+		"vk/pass_layout_key.cpp"
+		"vk/pre_pass_barrier_emitter.cpp"
+		"vk/render_pass_layout_cache.cpp")
 	set_source_files_properties(${cpp17_source_files} PROPERTIES COMPILE_FLAGS "-std=c++17")
 endif()

--- a/lib/ivis_opengl/gfx_api.cpp
+++ b/lib/ivis_opengl/gfx_api.cpp
@@ -22,6 +22,8 @@
 #include "gfx_api_vk.h"
 #include "gfx_api_gl.h"
 #include "gfx_api_null.h"
+#include "render_graph/pass_resolve.h"
+#include "render_graph/compile.h"
 #include "gfx_api_image_compress_priv.h"
 #include "gfx_api_image_basis_priv.h"
 #include "gfx_api_mipmap_priv.h"
@@ -614,6 +616,7 @@ const char* gfx_api::format_to_str(gfx_api::pixel_format format)
 		case gfx_api::pixel_format::FORMAT_RGB8_UNORM_PACK8: return "RGB8_UNORM";
 		case gfx_api::pixel_format::FORMAT_RG8_UNORM: return "RG8_UNORM";
 		case gfx_api::pixel_format::FORMAT_R8_UNORM: return "R8_UNORM";
+		case gfx_api::pixel_format::FORMAT_D24_UNORM_S8: return "D24_UNORM_S8";
 		// COMPRESSED FORMAT
 		case gfx_api::pixel_format::FORMAT_RGB_BC1_UNORM: return "RGB_BC1_UNORM";
 		case gfx_api::pixel_format::FORMAT_RGBA_BC2_UNORM: return "RGBA_BC2_UNORM";
@@ -650,6 +653,8 @@ unsigned int gfx_api::format_channels(gfx_api::pixel_format format)
 			return 2;
 		case gfx_api::pixel_format::FORMAT_R8_UNORM:
 			return 1;
+		case gfx_api::pixel_format::FORMAT_D24_UNORM_S8:
+			return 0;
 		// COMPRESSED FORMAT
 		case gfx_api::pixel_format::FORMAT_RGB_BC1_UNORM:
 			return 3;
@@ -685,41 +690,6 @@ static inline size_t calculate_astc_size(size_t width, size_t height)
 	return ((width + blockWidth - 1) / blockWidth) * ((height + blockHeight - 1) / blockHeight) * 16;
 }
 
-size_t gfx_api::format_texel_block_width(gfx_api::pixel_format format)
-{
-	switch (format)
-	{
-		case gfx_api::pixel_format::invalid:
-			return 1; // just return 1 for now...
-		// UNCOMPRESSED FORMATS
-		case gfx_api::pixel_format::FORMAT_RGBA8_UNORM_PACK8:
-		case gfx_api::pixel_format::FORMAT_BGRA8_UNORM_PACK8:
-		case gfx_api::pixel_format::FORMAT_RGB8_UNORM_PACK8:
-		case gfx_api::pixel_format::FORMAT_RG8_UNORM:
-		case gfx_api::pixel_format::FORMAT_R8_UNORM:
-			return 1;
-		// COMPRESSED FORMAT
-		case gfx_api::pixel_format::FORMAT_RGB_BC1_UNORM:
-		case gfx_api::pixel_format::FORMAT_RGBA_BC2_UNORM:
-		case gfx_api::pixel_format::FORMAT_RGBA_BC3_UNORM:
-		case gfx_api::pixel_format::FORMAT_R_BC4_UNORM:
-		case gfx_api::pixel_format::FORMAT_RG_BC5_UNORM:
-			return 4;
-		case gfx_api::pixel_format::FORMAT_RGBA_BPTC_UNORM:
-			return 4;
-		case gfx_api::pixel_format::FORMAT_RGB8_ETC1:
-		case gfx_api::pixel_format::FORMAT_RGB8_ETC2:
-		case gfx_api::pixel_format::FORMAT_RGBA8_ETC2_EAC:
-		case gfx_api::pixel_format::FORMAT_R11_EAC:
-		case gfx_api::pixel_format::FORMAT_RG11_EAC:
-			return 4;
-		case gfx_api::pixel_format::FORMAT_ASTC_4x4_UNORM:
-			return 4;
-	}
-
-	return 1; // silence warning
-}
-
 size_t gfx_api::format_memory_size(gfx_api::pixel_format format, size_t width, size_t height)
 {
 	switch (format)
@@ -736,6 +706,8 @@ size_t gfx_api::format_memory_size(gfx_api::pixel_format format, size_t width, s
 			return width * height * 2;
 		case gfx_api::pixel_format::FORMAT_R8_UNORM:
 			return width * height;
+		case gfx_api::pixel_format::FORMAT_D24_UNORM_S8:
+			return width * height * 4;
 		// [COMPRESSED FORMATS]
 		// BC / DXT formats
 		// 4x4 blocks, each block having a certain number of bytes
@@ -771,52 +743,6 @@ size_t gfx_api::format_memory_size(gfx_api::pixel_format format, size_t width, s
 
 // texture arrays
 
-// loads an image into a texture array, generating mip levels as needed (based on textureType)
-bool gfx_api::context::loadTextureArrayLayerFromUncompressedImage(gfx_api::texture_array& array, size_t layer, const iV_Image& image, gfx_api::texture_type textureType, gfx_api::pixel_format uploadFormat, const std::string& filename, int maxWidth /*= -1*/, int maxHeight /*= -1*/)
-{
-	size_t mipmap_levels = calcMipmapLevelsForUncompressedImage(image, textureType);
-	return loadTextureArrayLayerFromUncompressedImage(array, layer, image, textureType, mipmap_levels, uploadFormat, filename, maxWidth, maxHeight);
-}
-bool gfx_api::context::loadTextureArrayLayerFromUncompressedImage(gfx_api::texture_array& array, size_t layer, const iV_Image& rootImage, gfx_api::texture_type textureType, size_t mipmap_levels, gfx_api::pixel_format uploadFormat, const std::string& filename, int maxWidth /*= -1*/, int maxHeight /*= -1*/)
-{
-	auto miplevels = generateMipMapsFromUncompressedImage(rootImage, mipmap_levels, textureType);
-
-	auto uploadMipLevel = [&](const iV_Image* image, size_t level) {
-		if (uploadFormat == image->pixel_format())
-		{
-			bool uploadResult = array.upload_layer(layer, level, *image);
-			ASSERT_OR_RETURN(false, uploadResult, "Failed to upload buffer to image");
-		}
-		else
-		{
-			// Run-time compression
-			auto compressedImage = gfx_api::compressImage(*image, uploadFormat);
-			ASSERT_OR_RETURN(false, compressedImage != nullptr, "Failed to compress image to format: %zu", static_cast<size_t>(uploadFormat));
-			bool uploadResult = array.upload_layer(layer, level, *compressedImage);
-			ASSERT_OR_RETURN(false, uploadResult, "Failed to upload buffer to image");
-		}
-		return true;
-	};
-
-	if (!uploadMipLevel(&rootImage, 0))
-	{
-		return false;
-	}
-
-	for (size_t level = 1; level <= miplevels.size(); ++level)
-	{
-		const iV_Image* image = dynamic_cast<iV_Image*>(miplevels[level - 1].get());
-		ASSERT_OR_RETURN(false, image != nullptr, "Image wasn't an iV_Image?");
-
-		if (!uploadMipLevel(image, level))
-		{
-			return false;
-		}
-	}
-
-	return true;
-}
-
 // used to load basis mip levels (already encoded in the desired target format) into a texture array
 bool gfx_api::context::loadTextureArrayLayerFromBaseImages(gfx_api::texture_array& array, size_t layer, const std::vector<std::unique_ptr<iV_BaseImage>>& images, const std::string& filename, int maxWidth /*= -1*/, int maxHeight /*= -1*/)
 {
@@ -829,4 +755,88 @@ bool gfx_api::context::loadTextureArrayLayerFromBaseImages(gfx_api::texture_arra
 	}
 
 	return true;
+}
+
+void gfx_api::context::warmCompiledRenderGraph(std::vector<RenderPassDesc>& /*passes*/,
+	PassGraphCompileResult& /*compileResult*/)
+{
+}
+
+void gfx_api::context::executeCompiledRenderGraph(std::vector<RenderPassDesc>& passes,
+	const PassGraphCompileResult& compileResult)
+{
+	ASSERT(compileResult.passes.size() == passes.size(),
+	       "executeCompiledRenderGraph: pass count mismatch (descs=%zu compiled=%zu)",
+	       passes.size(), compileResult.passes.size());
+
+	setRenderGraphExecuting(true);
+
+	bool executedAnyPass = false;
+
+	ASSERT(compileResult.executionBatches.size() > 0
+		|| std::none_of(compileResult.passes.begin(), compileResult.passes.end(),
+			[](const CompiledPass& p) { return !p.skipped; }),
+		"executeCompiledRenderGraph: non-skipped passes but no execution batches");
+
+	for (const ExecutionBatch& batch : compileResult.executionBatches)
+	{
+		ASSERT(batch.startIndex <= compileResult.passes.size()
+			&& batch.count <= compileResult.passes.size() - batch.startIndex,
+			"executeCompiledRenderGraph: batch range out of bounds (start=%zu count=%zu compiled=%zu)",
+			batch.startIndex, batch.count, compileResult.passes.size());
+
+		const CompiledPass& head = compileResult.passes[batch.startIndex];
+		const size_t batchEnd = batch.startIndex + batch.count;
+
+#if defined(DEBUG)
+		ASSERT(passes[head.graphIndex].debugName == head.desc.debugName,
+			"CompiledPass.desc diverged from descs[graphIndex] for pass %zu", head.graphIndex);
+#endif
+
+		debugStringMarker(head.desc.debugName.c_str());
+
+		// Out-of-graph pre-pass barriers must be emitted before the render pass begins (layout
+		// transitions are illegal inside an active render pass) and are coalesced into a single
+		// pipelineBarrier for the whole batch.
+		emitPrePassBarriers(batch, compileResult.passes);
+
+		beginPass(head.desc, &head);
+
+		for (size_t j = batch.startIndex; j < batchEnd; ++j)
+		{
+			const CompiledPass& batchPass = compileResult.passes[j];
+			if (j != batch.startIndex)
+			{
+				debugStringMarker(batchPass.desc.debugName.c_str());
+			}
+			if (batchPass.desc.recordFunc)
+			{
+				const RenderPassContext batchContext = buildRenderPassContext(batchPass);
+				batchPass.desc.recordFunc(batchContext);
+			}
+		}
+
+		endPass(&head);
+		executedAnyPass = true;
+	}
+
+	if (executedAnyPass)
+	{
+		submitFrame();
+	}
+
+	purgeFrameResources();
+
+	setRenderGraphExecuting(false);
+}
+
+void gfx_api::context::executeRenderGraph(std::vector<RenderPassDesc>& passes)
+{
+	PassGraphCompileResult compileResult;
+	if (!compilePassGraph(passes, compileResult))
+	{
+		return;
+	}
+
+	executeCompiledRenderGraph(passes, compileResult);
 }

--- a/lib/ivis_opengl/gfx_api.cpp
+++ b/lib/ivis_opengl/gfx_api.cpp
@@ -829,14 +829,3 @@ void gfx_api::context::executeCompiledRenderGraph(std::vector<RenderPassDesc>& p
 
 	setRenderGraphExecuting(false);
 }
-
-void gfx_api::context::executeRenderGraph(std::vector<RenderPassDesc>& passes)
-{
-	PassGraphCompileResult compileResult;
-	if (!compilePassGraph(passes, compileResult))
-	{
-		return;
-	}
-
-	executeCompiledRenderGraph(passes, compileResult);
-}

--- a/lib/ivis_opengl/gfx_api.h
+++ b/lib/ivis_opengl/gfx_api.h
@@ -37,6 +37,9 @@
 #include "screen.h"
 #include "pietypes.h"
 #include "gfx_api_formats_def.h"
+#include "render_graph/pipeline_surfaces.h"
+#include "render_graph/render_pass.h"
+#include "render_graph/compile.h"
 
 #include <glm/glm.hpp>
 
@@ -404,15 +407,52 @@ namespace gfx_api
 		static bool isInitialized();
 		virtual size_t numDepthPasses() { return 0; }
 		virtual bool setDepthPassProperties(size_t numDepthPasses, size_t depthBufferResolution) { return false; }
+		virtual void beginPass(const RenderPassDesc& pass, const CompiledPass* compiledPass = nullptr) = 0;
+		virtual void endPass(const CompiledPass* compiledPass = nullptr) = 0;
+		virtual void submitFrame() = 0;
+
+		// Legacy direct-recording pass API (game code until render-graph migration).
 		virtual void beginDepthPass(size_t idx) { }
-		virtual size_t getDepthPassDimensions(size_t idx) { return 0; }
 		virtual void endCurrentDepthPass() { }
-		virtual gfx_api::abstract_texture* getDepthTexture() { return nullptr; }
+		virtual gfx_api::abstract_texture* getDepthTexture()
+		{
+			return getPipelineSurface(PipelineSurfaceId::ShadowMap);
+		}
 		virtual void beginSceneRenderPass() { }
 		virtual void endSceneRenderPass() { }
-		virtual gfx_api::abstract_texture* getSceneTexture() { return nullptr; }
+		virtual gfx_api::abstract_texture* getSceneTexture()
+		{
+			return getPipelineSurface(PipelineSurfaceId::SceneColor);
+		}
 		virtual void beginRenderPass() = 0;
 		virtual void endRenderPass() = 0;
+
+		virtual size_t getDepthPassDimensions(size_t idx) { return 0; }
+		virtual gfx_api::abstract_texture* getPipelineSurface(PipelineSurfaceId id) { return nullptr; }
+		virtual PipelineSurfaceMeta pipelineSurfaceMeta(PipelineSurfaceId id) const { return getPipelineSurfaceMeta(id); }
+		virtual nonstd::optional<PipelineSurfaceId> findPipelineSurfaceId(gfx_api::abstract_texture* texture) const { return nonstd::nullopt; }
+		virtual bool isSceneMSAAEnabled() const { return false; }
+		virtual bool isSwapchainMSAAEnabled() const { return false; }
+		virtual bool isMultisampledColorAttachment(abstract_texture* texture) const { return false; }
+		virtual pixel_format getDepthStencilFormat() const { return pixel_format::invalid; }
+
+		// Transient offscreen render targets pooled via FrameResourceCache.
+		// releaseTransientRenderTargets() at graph reset; purgeFrameResources() after submitFrame().
+		virtual abstract_texture* acquireTransientRenderTarget(pixel_format format, uint32_t width, uint32_t height) { return nullptr; }
+		virtual void releaseTransientRenderTargets() {}
+		virtual void purgeFrameResources() {}
+
+		virtual optional<std::pair<uint32_t, uint32_t>> getRenderTargetDimensions(abstract_texture* texture) { return nullopt; }
+
+		virtual void executeRenderGraph(std::vector<RenderPassDesc>& passes);
+		virtual void executeCompiledRenderGraph(std::vector<RenderPassDesc>& passes,
+			const PassGraphCompileResult& compileResult);
+		virtual void warmCompiledRenderGraph(std::vector<RenderPassDesc>& passes,
+			PassGraphCompileResult& compileResult);
+		// Emit any out-of-graph pre-pass layout/sync barriers for a batch of passes (the passes
+		// sharing one render pass). Called once before beginPass, outside any active render pass.
+		virtual void emitPrePassBarriers(const ExecutionBatch& batch,
+			const std::vector<CompiledPass>& compiledPasses) {}
 		virtual void debugStringMarker(const char *str) = 0;
 		virtual void debugSceneBegin(const char *descr) = 0;
 		virtual void debugSceneEnd(const char *descr) = 0;
@@ -429,6 +469,7 @@ namespace gfx_api
 		virtual std::pair<uint32_t, uint32_t> getDrawableDimensions() = 0;
 		virtual bool isYAxisInverted() const = 0;
 		virtual bool shouldDraw() = 0;
+		virtual bool canRecordDrawCommands() const { return renderGraphExecuting(); }
 		virtual void shutdown() = 0;
 		virtual const size_t& current_FrameNum() const = 0;
 		typedef std::function<void()> SetSwapIntervalCompletionHandler;
@@ -441,6 +482,9 @@ namespace gfx_api
 		virtual size_t maxFramesInFlight() const = 0;
 		virtual lighting_constants getShadowConstants() = 0;
 		virtual bool setShadowConstants(lighting_constants values) = 0;
+
+		/// Monotonic counter bumped when render-graph topology inputs change (resize, depth passes, swapchain recreate, etc.).
+		uint64_t getRenderGraphEpoch() const { return _renderGraphEpoch; }
 		// instanced rendering APIs
 		virtual bool supportsInstancedRendering() = 0;
 		virtual void draw_instanced(const std::size_t& offset, const std::size_t &count, const primitive_type &primitive, std::size_t instance_count) = 0;
@@ -455,15 +499,22 @@ namespace gfx_api
 		LoadingTask<gfx_api::texture_array*> loadTextureArrayFromFiles(ResourceLoadingController& controller, const std::vector<WzString>& filenames, gfx_api::texture_type textureType, int maxWidth = -1, int maxHeight = -1, const GenerateDefaultTextureFunc& defaultTextureGenerator = nullptr, const std::string& debugName = "");
 		gfx_api::texture_array* loadTextureArrayFromFilesBlocking(const std::vector<WzString>& filenames, gfx_api::texture_type textureType, int maxWidth = -1, int maxHeight = -1, const GenerateDefaultTextureFunc& defaultTextureGenerator = nullptr, const std::string& debugName = "");
 
-		bool loadTextureArrayLayerFromUncompressedImage(gfx_api::texture_array& array, size_t layer, const iV_Image& image, gfx_api::texture_type textureType, gfx_api::pixel_format uploadFormat, const std::string& filename, int maxWidth = -1, int maxHeight = -1);
-		bool loadTextureArrayLayerFromUncompressedImage(gfx_api::texture_array& array, size_t layer, const iV_Image& image, gfx_api::texture_type textureType, size_t mipmap_levels, gfx_api::pixel_format uploadFormat, const std::string& filename, int maxWidth = -1, int maxHeight = -1);
 		bool loadTextureArrayLayerFromBaseImages(gfx_api::texture_array& array, size_t layer, const std::vector<std::unique_ptr<iV_BaseImage>>& images, const std::string& filename, int maxWidth = -1, int maxHeight = -1);
 
 		optional<unsigned int> getClosestSupportedUncompressedImageFormatChannels(pixel_format_target target, unsigned int channels);
 		gfx_api::pixel_format bestUncompressedPixelFormat(gfx_api::pixel_format_target target, gfx_api::texture_type textureType);
 
 		gfx_api::texture* createTextureForCompatibleImageUploads(const size_t& mipmap_count, const iV_Image& bitmap, const std::string& filename);
+
+	protected:
+		// True while executeRenderGraph() is running. Draw/bind APIs must only be called from record callbacks.
+		bool renderGraphExecuting() const { return _renderGraphExecuting; }
+		void setRenderGraphExecuting(bool executing) { _renderGraphExecuting = executing; }
+		void bumpRenderGraphEpoch() { ++_renderGraphEpoch; }
+
 	private:
+		bool _renderGraphExecuting = false;
+		uint64_t _renderGraphEpoch = 1;
 		virtual bool _initialize(const backend_Impl_Factory& impl, int32_t antialiasing, swap_interval_mode mode, optional<float> mipLodBias, uint32_t depthMapResolution) = 0;
 	};
 

--- a/lib/ivis_opengl/gfx_api.h
+++ b/lib/ivis_opengl/gfx_api.h
@@ -436,10 +436,9 @@ namespace gfx_api
 		virtual bool isMultisampledColorAttachment(abstract_texture* texture) const { return false; }
 		virtual pixel_format getDepthStencilFormat() const { return pixel_format::invalid; }
 
-		// Transient offscreen render targets pooled via FrameResourceCache.
-		// releaseTransientRenderTargets() at graph reset; purgeFrameResources() after submitFrame().
-		virtual abstract_texture* acquireTransientRenderTarget(pixel_format format, uint32_t width, uint32_t height) { return nullptr; }
-		virtual void releaseTransientRenderTargets() {}
+		/// Purge unused pooled framebuffers after frame submit (FBO cache only).
+		/// `beginRenderPass()` resets FBO pool use counts; `endRenderPass()` and
+		/// `executeCompiledRenderGraph()` call this after submit.
 		virtual void purgeFrameResources() {}
 
 		virtual optional<std::pair<uint32_t, uint32_t>> getRenderTargetDimensions(abstract_texture* texture) { return nullopt; }

--- a/lib/ivis_opengl/gfx_api.h
+++ b/lib/ivis_opengl/gfx_api.h
@@ -443,7 +443,6 @@ namespace gfx_api
 
 		virtual optional<std::pair<uint32_t, uint32_t>> getRenderTargetDimensions(abstract_texture* texture) { return nullopt; }
 
-		virtual void executeRenderGraph(std::vector<RenderPassDesc>& passes);
 		virtual void executeCompiledRenderGraph(std::vector<RenderPassDesc>& passes,
 			const PassGraphCompileResult& compileResult);
 		virtual void warmCompiledRenderGraph(std::vector<RenderPassDesc>& passes,
@@ -506,7 +505,7 @@ namespace gfx_api
 		gfx_api::texture* createTextureForCompatibleImageUploads(const size_t& mipmap_count, const iV_Image& bitmap, const std::string& filename);
 
 	protected:
-		// True while executeRenderGraph() is running. Draw/bind APIs must only be called from record callbacks.
+		// True while executeCompiledRenderGraph() is running. Draw/bind APIs must only be called from record callbacks.
 		bool renderGraphExecuting() const { return _renderGraphExecuting; }
 		void setRenderGraphExecuting(bool executing) { _renderGraphExecuting = executing; }
 		void bumpRenderGraphEpoch() { ++_renderGraphEpoch; }

--- a/lib/ivis_opengl/gfx_api_formats_def.h
+++ b/lib/ivis_opengl/gfx_api_formats_def.h
@@ -33,6 +33,7 @@ namespace gfx_api
 		FORMAT_RGB8_UNORM_PACK8,
 		FORMAT_RG8_UNORM,			// not guaranteed support
 		FORMAT_R8_UNORM,
+		FORMAT_D24_UNORM_S8,		// depth/stencil attachment (transient pool)
 
 		// [COMPRESSED FORMATS]
 
@@ -76,9 +77,13 @@ namespace gfx_api
 		return false;
 	}
 
+	static inline bool is_transient_render_target_format(const pixel_format& format)
+	{
+		return is_uncompressed_format(format) || format == pixel_format::FORMAT_D24_UNORM_S8;
+	}
+
 	const char* format_to_str(gfx_api::pixel_format format);
 	unsigned int format_channels(gfx_api::pixel_format format);
-	size_t format_texel_block_width(gfx_api::pixel_format format);
 	size_t format_memory_size(gfx_api::pixel_format format, size_t width, size_t height);
 
 	namespace pixel_format_usage

--- a/lib/ivis_opengl/gfx_api_formats_def.h
+++ b/lib/ivis_opengl/gfx_api_formats_def.h
@@ -33,7 +33,7 @@ namespace gfx_api
 		FORMAT_RGB8_UNORM_PACK8,
 		FORMAT_RG8_UNORM,			// not guaranteed support
 		FORMAT_R8_UNORM,
-		FORMAT_D24_UNORM_S8,		// depth/stencil attachment (transient pool)
+		FORMAT_D24_UNORM_S8,		// depth/stencil attachment
 
 		// [COMPRESSED FORMATS]
 
@@ -75,11 +75,6 @@ namespace gfx_api
 				return false;
 		}
 		return false;
-	}
-
-	static inline bool is_transient_render_target_format(const pixel_format& format)
-	{
-		return is_uncompressed_format(format) || format == pixel_format::FORMAT_D24_UNORM_S8;
 	}
 
 	const char* format_to_str(gfx_api::pixel_format format);

--- a/lib/ivis_opengl/gfx_api_frame_resource_cache.h
+++ b/lib/ivis_opengl/gfx_api_frame_resource_cache.h
@@ -19,7 +19,7 @@
 	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
 */
 /** @file gfx_api_frame_resource_cache.h
- * Per-frame pooled caches for transient render targets and dynamic framebuffers.
+ * Per-frame pooled caches for dynamic framebuffers/FBOs.
  */
 
 #pragma once
@@ -47,58 +47,9 @@ namespace gfx_api
 struct abstract_texture;
 
 /// <summary>
-/// Identity for pooled 2D transient images (format, dimensions, layers, samples).
-///
-/// Used by `FrameResourceCache` and built via `color2d` in backend
-/// `acquireTransientRenderTarget`. `debugName` is diagnostic only (not part of equality).
-/// </summary>
-struct ImageResourceKey
-{
-	/// Pool lookup pixel format.
-	pixel_format format = pixel_format::invalid;
-	/// Pool lookup width.
-	uint32_t width = 0;
-	/// Pool lookup height.
-	uint32_t height = 0;
-	/// Subresource array layers; defaults to single-layer.
-	uint32_t arrayLayers = 1;
-	/// Sample count; defaults to non-MSAA.
-	uint32_t samples = 1;
-	/// Optional label for backend object creation (excluded from equality).
-	std::string debugName;
-
-	bool operator<(const ImageResourceKey& other) const
-	{
-		return std::tie(format, width, height, arrayLayers, samples)
-			< std::tie(other.format, other.width, other.height, other.arrayLayers, other.samples);
-	}
-
-	bool operator==(const ImageResourceKey& other) const
-	{
-		return format == other.format
-			&& width == other.width
-			&& height == other.height
-			&& arrayLayers == other.arrayLayers
-			&& samples == other.samples;
-	}
-
-	/// Factory for the common single-layer color/depth transient key.
-	static ImageResourceKey color2d(pixel_format fmt, uint32_t w, uint32_t h, uint32_t sampleCount = 1)
-	{
-		ImageResourceKey key;
-		key.format = fmt;
-		key.width = w;
-		key.height = h;
-		key.arrayLayers = 1;
-		key.samples = sampleCount;
-		return key;
-	}
-};
-
-/// <summary>
 /// Per-frame pool of reusable GPU resources keyed by attachment/layout.
 ///
-/// Backends own one or more specializations (`FrameResourceCache`, …).
+/// Backends own one or more specializations (`FramebufferResourceCache`, `DynamicFBOCache`, …).
 /// Lifecycle (callers must preserve this ordering):
 /// 1. releaseAll() at frame graph reset (start of accumulation).
 /// 2. acquire() while recording.
@@ -252,9 +203,6 @@ void PooledResourceCache<Key, Storage, Handle>::dropExcess(std::vector<Storage>&
 	}
 }
 
-/// `PooledResourceCache` specialization for transient `abstract_texture*` (see `acquireTransientRenderTarget`).
-using FrameResourceCache = PooledResourceCache<ImageResourceKey, std::unique_ptr<abstract_texture>, abstract_texture*>;
-
 /// <summary>
 /// Key for pooled Vulkan framebuffer instances (render pass + attachment views + size).
 ///
@@ -285,7 +233,6 @@ struct FramebufferResourceKey
 	}
 };
 
-/// VK-only; paired with `FrameResourceCache` in `releaseTransientRenderTargets` / `purgeFrameResources`.
 using FramebufferResourceCache = PooledResourceCache<FramebufferResourceKey, uint64_t, uint64_t>;
 
 /// <summary>

--- a/lib/ivis_opengl/gfx_api_frame_resource_cache.h
+++ b/lib/ivis_opengl/gfx_api_frame_resource_cache.h
@@ -1,0 +1,345 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+/*
+	This file is part of Warzone 2100.
+	Copyright (C) 2026  Warzone 2100 Project (https://github.com/Warzone2100)
+
+	Warzone 2100 is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+
+	Warzone 2100 is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with Warzone 2100; if not, write to the Free Software
+	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+/** @file gfx_api_frame_resource_cache.h
+ * Per-frame pooled caches for transient render targets and dynamic framebuffers.
+ */
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+#include "lib/framework/wzglobal.h"
+#include "gfx_api_formats_def.h"
+#include <algorithm>
+#include <functional>
+#include <iterator>
+#include <memory>
+#include <string>
+#include <tuple>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+#include <nonstd/optional.hpp>
+
+namespace gfx_api
+{
+
+struct abstract_texture;
+
+/// <summary>
+/// Identity for pooled 2D transient images (format, dimensions, layers, samples).
+///
+/// Used by `FrameResourceCache` and built via `color2d` in backend
+/// `acquireTransientRenderTarget`. `debugName` is diagnostic only (not part of equality).
+/// </summary>
+struct ImageResourceKey
+{
+	/// Pool lookup pixel format.
+	pixel_format format = pixel_format::invalid;
+	/// Pool lookup width.
+	uint32_t width = 0;
+	/// Pool lookup height.
+	uint32_t height = 0;
+	/// Subresource array layers; defaults to single-layer.
+	uint32_t arrayLayers = 1;
+	/// Sample count; defaults to non-MSAA.
+	uint32_t samples = 1;
+	/// Optional label for backend object creation (excluded from equality).
+	std::string debugName;
+
+	bool operator<(const ImageResourceKey& other) const
+	{
+		return std::tie(format, width, height, arrayLayers, samples)
+			< std::tie(other.format, other.width, other.height, other.arrayLayers, other.samples);
+	}
+
+	bool operator==(const ImageResourceKey& other) const
+	{
+		return format == other.format
+			&& width == other.width
+			&& height == other.height
+			&& arrayLayers == other.arrayLayers
+			&& samples == other.samples;
+	}
+
+	/// Factory for the common single-layer color/depth transient key.
+	static ImageResourceKey color2d(pixel_format fmt, uint32_t w, uint32_t h, uint32_t sampleCount = 1)
+	{
+		ImageResourceKey key;
+		key.format = fmt;
+		key.width = w;
+		key.height = h;
+		key.arrayLayers = 1;
+		key.samples = sampleCount;
+		return key;
+	}
+};
+
+/// <summary>
+/// Per-frame pool of reusable GPU resources keyed by attachment/layout.
+///
+/// Backends own one or more specializations (`FrameResourceCache`, …).
+/// Lifecycle (callers must preserve this ordering):
+/// 1. releaseAll() at frame graph reset (start of accumulation).
+/// 2. acquire() while recording.
+/// 3. submitFrame() on the backend.
+/// 4. purgeUnused() after submit - drop resources not acquired this frame.
+/// </summary>
+template <typename Key, typename Storage, typename Handle>
+class PooledResourceCache
+{
+public:
+	using PurgeHandleFn = std::function<void(Handle)>;
+
+	/// Return a handle for `key`, creating storage via `createFn` when the pool is exhausted.
+	template <typename CreateFn>
+	Handle acquire(const Key& key, CreateFn&& createFn)
+	{
+		auto cacheIt = std::find_if(_cache.begin(), _cache.end(),
+			[&key](const auto& entry) { return entry.first == key; });
+
+		if (cacheIt == _cache.end())
+		{
+			_cache.emplace_back(key, CacheEntry {});
+			cacheIt = std::prev(_cache.end());
+		}
+
+		CacheEntry& cacheEntry = cacheIt->second;
+		if (cacheEntry.usedCount + 1 > cacheEntry.resources.size())
+		{
+			Storage resource = std::forward<CreateFn>(createFn)();
+			ASSERT(isValidStorage(resource), "Failed to create pooled frame resource");
+			cacheEntry.resources.emplace_back(std::move(resource));
+		}
+
+		return toHandle(cacheEntry.resources[cacheEntry.usedCount++]);
+	}
+
+	/// Reset per-key use counts at the start of frame accumulation.
+	void releaseAll()
+	{
+		for (auto& cacheEntry : _cache)
+		{
+			cacheEntry.second.usedCount = 0;
+		}
+	}
+
+	/// After submit, shrink pools and optionally destroy dropped handles via `onPurge`.
+	void purgeUnused(const PurgeHandleFn& onPurge = PurgeHandleFn())
+	{
+		for (auto it = _cache.begin(); it != _cache.end(); )
+		{
+			CacheEntry& cacheEntry = it->second;
+			dropExcess(cacheEntry.resources, cacheEntry.usedCount, onPurge);
+			if (cacheEntry.usedCount == 0)
+			{
+				it = _cache.erase(it);
+			}
+			else
+			{
+				++it;
+			}
+		}
+	}
+
+	/// Tear down all entries (e.g. device lost / context destroy).
+	void clear(const PurgeHandleFn& onPurge = PurgeHandleFn())
+	{
+		if (onPurge)
+		{
+			for (auto& cacheEntry : _cache)
+			{
+				for (Storage& resource : cacheEntry.second.resources)
+				{
+					if (isValidStorage(resource))
+					{
+						onPurge(toHandle(resource));
+					}
+				}
+			}
+		}
+		_cache.clear();
+	}
+
+private:
+
+	struct CacheEntry
+	{
+		size_t usedCount = 0;
+		std::vector<Storage> resources;
+	};
+
+	static bool isValidStorage(const Storage& resource);
+	static Handle toHandle(Storage& resource);
+	static Handle toHandle(const Storage& resource);
+	static void dropExcess(std::vector<Storage>& resources, size_t usedCount, const PurgeHandleFn& onPurge);
+
+	std::vector<std::pair<Key, CacheEntry>> _cache;
+};
+
+template<typename Key, typename Storage, typename Handle>
+bool PooledResourceCache<Key, Storage, Handle>::isValidStorage(const Storage& resource)
+{
+	if constexpr (std::is_pointer_v<Handle>)
+	{
+		return toHandle(resource) != nullptr;
+	}
+	else
+	{
+		return resource != Storage {};
+	}
+}
+
+template<typename Key, typename Storage, typename Handle>
+Handle PooledResourceCache<Key, Storage, Handle>::toHandle(Storage& resource)
+{
+	if constexpr (std::is_same_v<Storage, std::unique_ptr<abstract_texture>>)
+	{
+		return resource.get();
+	}
+	else
+	{
+		return resource;
+	}
+}
+
+template<typename Key, typename Storage, typename Handle>
+Handle PooledResourceCache<Key, Storage, Handle>::toHandle(const Storage& resource)
+{
+	if constexpr (std::is_same_v<Storage, std::unique_ptr<abstract_texture>>)
+	{
+		return resource.get();
+	}
+	else
+	{
+		return resource;
+	}
+}
+
+template<typename Key, typename Storage, typename Handle>
+void PooledResourceCache<Key, Storage, Handle>::dropExcess(std::vector<Storage>& resources, size_t usedCount,
+	const PurgeHandleFn& onPurge)
+{
+	ASSERT(usedCount <= resources.size(), "Pooled resource cache usedCount exceeds resource count");
+	while (resources.size() > usedCount)
+	{
+		Storage& dropped = resources.back();
+		if (onPurge && isValidStorage(dropped))
+		{
+			onPurge(toHandle(dropped));
+		}
+		resources.pop_back();
+	}
+}
+
+/// `PooledResourceCache` specialization for transient `abstract_texture*` (see `acquireTransientRenderTarget`).
+using FrameResourceCache = PooledResourceCache<ImageResourceKey, std::unique_ptr<abstract_texture>, abstract_texture*>;
+
+/// <summary>
+/// Key for pooled Vulkan framebuffer instances (render pass + attachment views + size).
+///
+/// `attachmentViewHandles` are stored as `uint64_t` so this header stays backend-neutral;
+/// Vulkan `beginPass` fills the key and passes it to `_framebufferCache`.
+/// </summary>
+struct FramebufferResourceKey
+{
+	/// Cached Vulkan render-pass layout index from warm-up on `VkRoot::_warmEntries`.
+	size_t renderPassId = 0;
+	uint32_t width = 0;
+	uint32_t height = 0;
+	/// VkImageView handles stored as uint64_t for backend-neutral cache code.
+	std::vector<uint64_t> attachmentViewHandles;
+
+	bool operator<(const FramebufferResourceKey& other) const
+	{
+		return std::tie(renderPassId, width, height, attachmentViewHandles)
+			< std::tie(other.renderPassId, other.width, other.height, other.attachmentViewHandles);
+	}
+
+	bool operator==(const FramebufferResourceKey& other) const
+	{
+		return renderPassId == other.renderPassId
+			&& width == other.width
+			&& height == other.height
+			&& attachmentViewHandles == other.attachmentViewHandles;
+	}
+};
+
+/// VK-only; paired with `FrameResourceCache` in `releaseTransientRenderTargets` / `purgeFrameResources`.
+using FramebufferResourceCache = PooledResourceCache<FramebufferResourceKey, uint64_t, uint64_t>;
+
+/// <summary>
+/// Key for pooled OpenGL FBO instances (attachment object ids + layers + size).
+///
+/// Built from a resolved `RenderPassDesc` in `gl_context::beginPass` when not targeting
+/// the default framebuffer.
+/// </summary>
+struct DynamicFBOKey
+{
+	struct Slot
+	{
+		uint32_t objectId = 0;
+		uint32_t arrayLayer = 0;
+		bool isRenderbuffer = false;
+		/// True when the attachment is the window default framebuffer (FBO 0).
+		bool isDefaultFramebuffer = false;
+
+		bool operator<(const Slot& other) const
+		{
+			return std::tie(objectId, arrayLayer, isRenderbuffer, isDefaultFramebuffer)
+				< std::tie(other.objectId, other.arrayLayer, other.isRenderbuffer, other.isDefaultFramebuffer);
+		}
+
+		bool operator==(const Slot& other) const
+		{
+			return objectId == other.objectId
+				&& arrayLayer == other.arrayLayer
+				&& isRenderbuffer == other.isRenderbuffer
+				&& isDefaultFramebuffer == other.isDefaultFramebuffer;
+		}
+	};
+
+	uint32_t width = 0;
+	uint32_t height = 0;
+	std::vector<Slot> colorSlots;
+	nonstd::optional<Slot> depthSlot;
+
+	bool operator<(const DynamicFBOKey& other) const
+	{
+		return std::tie(width, height, colorSlots, depthSlot)
+			< std::tie(other.width, other.height, other.colorSlots, other.depthSlot);
+	}
+
+	bool operator==(const DynamicFBOKey& other) const
+	{
+		return width == other.width
+			&& height == other.height
+			&& colorSlots == other.colorSlots
+			&& depthSlot == other.depthSlot;
+	}
+};
+
+/// GL-only counterpart to `FramebufferResourceCache`.
+using DynamicFBOCache = PooledResourceCache<DynamicFBOKey, uint32_t, uint32_t>;
+
+} // namespace gfx_api

--- a/lib/ivis_opengl/gfx_api_gl.cpp
+++ b/lib/ivis_opengl/gfx_api_gl.cpp
@@ -2609,29 +2609,6 @@ std::unique_ptr<gl_gpurendered_renderbuffer> gl_context::create_framebuffer_rend
 	return surface;
 }
 
-std::unique_ptr<gfx_api::abstract_texture> gl_context::createTransientColorRenderTarget(gfx_api::pixel_format format, uint32_t width, uint32_t height, const std::string& debugName)
-{
-	ASSERT(is_uncompressed_format(format), "Transient render targets require an uncompressed format");
-	const GLenum internalFormat = to_gl_internalformat(format, gles);
-	const GLenum glFormat = to_gl_format(format, gles);
-	return std::unique_ptr<gfx_api::abstract_texture>(
-		create_framebuffer_color_texture(internalFormat, glFormat, GL_UNSIGNED_BYTE, width, height, debugName));
-}
-
-std::unique_ptr<gfx_api::abstract_texture> gl_context::createTransientDepthRenderTarget(uint32_t width, uint32_t height, const std::string& debugName)
-{
-	gl_gpurendered_texture* depthTex = create_gpurendered_texture(
-		GL_DEPTH24_STENCIL8, GL_DEPTH_STENCIL, GL_UNSIGNED_INT_24_8, width, height, debugName);
-	ASSERT_OR_RETURN(nullptr, depthTex != nullptr, "Failed to create transient depth texture");
-	depthTex->bind();
-	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
-	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
-	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-	depthTex->unbind();
-	return std::unique_ptr<gfx_api::abstract_texture>(depthTex);
-}
-
 gfx_api::buffer * gl_context::create_buffer_object(const gfx_api::buffer::usage &usage, const buffer_storage_hint& hint /*= buffer_storage_hint::static_draw*/, const std::string& debugName /*= ""*/)
 {
 	return new gl_buffer(usage, hint);
@@ -4541,6 +4518,7 @@ bool gl_context::openLegacySwapchainPass(gfx_api::AttachmentLoadOp colorLoad, gf
 
 void gl_context::beginRenderPass()
 {
+	_dynamicFBOCache.releaseAll();
 	if (!openLegacySwapchainPass(gfx_api::AttachmentLoadOp::Clear, gfx_api::AttachmentLoadOp::Clear))
 	{
 		debug(LOG_ERROR, "Failed to begin legacy swapchain render pass");
@@ -4574,6 +4552,7 @@ void gl_context::endRenderPass()
 	}
 #endif
 
+	purgeFrameResources();
 	setRenderGraphExecuting(false);
 }
 
@@ -5421,7 +5400,6 @@ bool gl_context::canRecordDrawCommands() const
 
 void gl_context::shutdown()
 {
-	_frameResourceCache.clear();
 	clearDynamicFBOCache();
 
 #if !defined(WZ_STATIC_GL_BINDINGS)
@@ -5833,33 +5811,8 @@ bool gl_context::createSceneRenderpass()
 	return !encounteredError;
 }
 
-gfx_api::abstract_texture* gl_context::acquireTransientRenderTarget(gfx_api::pixel_format format, uint32_t width, uint32_t height)
-{
-	ASSERT_OR_RETURN(nullptr, width > 0 && height > 0, "Invalid transient render target dimensions");
-	ASSERT_OR_RETURN(nullptr, is_transient_render_target_format(format), "Unsupported transient render target format");
-
-	static uint32_t transientTargetId = 0;
-	const gfx_api::ImageResourceKey key = gfx_api::ImageResourceKey::color2d(format, width, height);
-	const std::string debugName = "<transient_rt_" + std::to_string(transientTargetId++) + ">";
-
-	return _frameResourceCache.acquire(key, [this, format, width, height, debugName]() {
-		if (format == gfx_api::pixel_format::FORMAT_D24_UNORM_S8)
-		{
-			return createTransientDepthRenderTarget(width, height, debugName);
-		}
-		return createTransientColorRenderTarget(format, width, height, debugName);
-	});
-}
-
-void gl_context::releaseTransientRenderTargets()
-{
-	_frameResourceCache.releaseAll();
-	_dynamicFBOCache.releaseAll();
-}
-
 void gl_context::purgeFrameResources()
 {
-	_frameResourceCache.purgeUnused();
 	_dynamicFBOCache.purgeUnused([](uint32_t fboHandle) {
 		if (fboHandle == 0)
 		{

--- a/lib/ivis_opengl/gfx_api_gl.cpp
+++ b/lib/ivis_opengl/gfx_api_gl.cpp
@@ -21,6 +21,8 @@
 #include "lib/framework/wzapp.h"
 #include "screen.h"
 #include "gfx_api_gl.h"
+#include "gfx_api_legacy_pass_compat.h"
+#include "render_graph/pass_resolve.h"
 #include "lib/exceptionhandler/dumpinfo.h"
 #include "lib/framework/physfs_ext.h"
 #include "lib/framework/wzpaths.h"
@@ -472,6 +474,43 @@ size_t gl_gpurendered_texture::backend_internal_value() const
 void gl_gpurendered_texture::unbind()
 {
 	glBindTexture((_isArray) ? GL_TEXTURE_2D_ARRAY : GL_TEXTURE_2D, 0);
+}
+
+// MARK: gl_gpurendered_renderbuffer
+
+gl_gpurendered_renderbuffer::~gl_gpurendered_renderbuffer()
+{
+	if (_id != 0)
+	{
+		glDeleteRenderbuffers(1, &_id);
+		_id = 0;
+	}
+}
+
+void gl_gpurendered_renderbuffer::bind()
+{
+	glBindRenderbuffer(GL_RENDERBUFFER, _id);
+}
+
+size_t gl_gpurendered_renderbuffer::backend_internal_value() const
+{
+	return 0;
+}
+
+// MARK: gl_pipeline_surface_proxy
+
+gl_pipeline_surface_proxy::gl_pipeline_surface_proxy(GLPipelineSurfaceKind surfaceKind)
+	: kind(surfaceKind)
+{
+}
+
+gl_pipeline_surface_proxy::~gl_pipeline_surface_proxy() = default;
+
+void gl_pipeline_surface_proxy::bind() { }
+
+size_t gl_pipeline_surface_proxy::backend_internal_value() const
+{
+	return static_cast<size_t>(kind);
 }
 
 // MARK: gl_texture
@@ -2484,6 +2523,8 @@ gl_gpurendered_texture* gl_context::create_gpurendered_texture(GLenum internalFo
 	auto* new_texture = new gl_gpurendered_texture();
 	new_texture->gles = gles;
 	new_texture->_isArray = false;
+	new_texture->tex_width = static_cast<uint32_t>(width);
+	new_texture->tex_height = static_cast<uint32_t>(height);
 #if defined(WZ_DEBUG_GFX_API_LEAKS)
 	new_texture->debugName = filename;
 #endif
@@ -2510,6 +2551,8 @@ gl_gpurendered_texture* gl_context::create_gpurendered_texture_array(GLenum inte
 	auto* new_texture = new gl_gpurendered_texture();
 	new_texture->gles = gles;
 	new_texture->_isArray = true;
+	new_texture->tex_width = static_cast<uint32_t>(width);
+	new_texture->tex_height = static_cast<uint32_t>(height);
 #if defined(WZ_DEBUG_GFX_API_LEAKS)
 	new_texture->debugName = filename;
 #endif
@@ -2532,6 +2575,61 @@ gl_gpurendered_texture* gl_context::create_gpurendered_texture_array(GLenum inte
 gl_gpurendered_texture* gl_context::create_framebuffer_color_texture(GLenum internalFormat, GLenum format, GLenum type, const size_t& width, const size_t& height, const std::string& filename)
 {
 	return create_gpurendered_texture(internalFormat, format, type, width, height, filename);
+}
+
+std::unique_ptr<gl_gpurendered_renderbuffer> gl_context::create_framebuffer_renderbuffer(GLenum internalFormat, GLsizei samples,
+	uint32_t width, uint32_t height, const std::string& filename)
+{
+	auto surface = std::make_unique<gl_gpurendered_renderbuffer>();
+	surface->_samples = samples;
+	surface->_width = width;
+	surface->_height = height;
+#if defined(WZ_DEBUG_GFX_API_LEAKS)
+	surface->debugName = filename;
+#endif
+	glGenRenderbuffers(1, &surface->_id);
+	glBindRenderbuffer(GL_RENDERBUFFER, surface->_id);
+	if (samples > 0)
+	{
+		glRenderbufferStorageMultisample(GL_RENDERBUFFER, samples, internalFormat,
+			static_cast<GLsizei>(width), static_cast<GLsizei>(height));
+	}
+	else
+	{
+		glRenderbufferStorage(GL_RENDERBUFFER, internalFormat,
+			static_cast<GLsizei>(width), static_cast<GLsizei>(height));
+	}
+	glBindRenderbuffer(GL_RENDERBUFFER, 0);
+#if defined(WZ_GL_KHR_DEBUG_SUPPORTED)
+	if (!filename.empty())
+	{
+		wzGLObjectLabel(GL_RENDERBUFFER, surface->_id, -1, filename.c_str());
+	}
+#endif
+	return surface;
+}
+
+std::unique_ptr<gfx_api::abstract_texture> gl_context::createTransientColorRenderTarget(gfx_api::pixel_format format, uint32_t width, uint32_t height, const std::string& debugName)
+{
+	ASSERT(is_uncompressed_format(format), "Transient render targets require an uncompressed format");
+	const GLenum internalFormat = to_gl_internalformat(format, gles);
+	const GLenum glFormat = to_gl_format(format, gles);
+	return std::unique_ptr<gfx_api::abstract_texture>(
+		create_framebuffer_color_texture(internalFormat, glFormat, GL_UNSIGNED_BYTE, width, height, debugName));
+}
+
+std::unique_ptr<gfx_api::abstract_texture> gl_context::createTransientDepthRenderTarget(uint32_t width, uint32_t height, const std::string& debugName)
+{
+	gl_gpurendered_texture* depthTex = create_gpurendered_texture(
+		GL_DEPTH24_STENCIL8, GL_DEPTH_STENCIL, GL_UNSIGNED_INT_24_8, width, height, debugName);
+	ASSERT_OR_RETURN(nullptr, depthTex != nullptr, "Failed to create transient depth texture");
+	depthTex->bind();
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+	depthTex->unbind();
+	return std::unique_ptr<gfx_api::abstract_texture>(depthTex);
 }
 
 gfx_api::buffer * gl_context::create_buffer_object(const gfx_api::buffer::usage &usage, const buffer_storage_hint& hint /*= buffer_storage_hint::static_draw*/, const std::string& debugName /*= ""*/)
@@ -3529,6 +3627,7 @@ bool gl_context::_initialize(const gfx_api::backend_Impl_Factory& impl, int32_t 
 		wzResetGfxSettingsOnFailure(); // reset certain settings (like MSAA) that could be contributing to OUT_OF_MEMORY (or other) errors
 		return false;
 	}
+	registerSwapchainPipelineSurfaces();
 	initDepthPasses(depthBufferResolution);
 
 	glBindFramebuffer(GL_FRAMEBUFFER, 0);
@@ -3539,10 +3638,6 @@ bool gl_context::_initialize(const gfx_api::backend_Impl_Factory& impl, int32_t 
 		glDisable(GL_FRAMEBUFFER_SRGB);
 		wzGLCheckErrors();
 	}
-#endif
-
-#if !defined(__EMSCRIPTEN__)
-	_beginRenderPassImpl();
 #endif
 
 	return true;
@@ -4123,7 +4218,7 @@ bool gl_context::initGLContext()
 
 size_t gl_context::numDepthPasses()
 {
-	return depthFBO.size();
+	return depthPassCount;
 }
 
 bool gl_context::setDepthPassProperties(size_t _numDepthPasses, size_t _depthBufferResolution)
@@ -4138,19 +4233,12 @@ bool gl_context::setDepthPassProperties(size_t _numDepthPasses, size_t _depthBuf
 	depthPassCount = _numDepthPasses;
 	depthBufferResolution = _depthBufferResolution;
 
+	bumpRenderGraphEpoch();
+
 	// reinitialize depth passes
 	initDepthPasses(depthBufferResolution);
 
 	return true;
-}
-
-void gl_context::beginDepthPass(size_t idx)
-{
-	ASSERT_OR_RETURN(, idx < depthFBO.size(), "Invalid depth pass #: %zu", idx);
-	glBindFramebuffer(GL_FRAMEBUFFER, depthFBO[idx]);
-	glViewport(0, 0, static_cast<GLsizei>(depthBufferResolution), static_cast<GLsizei>(depthBufferResolution));
-	glDepthMask(GL_TRUE);
-	glClear(GL_DEPTH_BUFFER_BIT);
 }
 
 size_t gl_context::getDepthPassDimensions(size_t idx)
@@ -4158,36 +4246,43 @@ size_t gl_context::getDepthPassDimensions(size_t idx)
 	return depthBufferResolution;
 }
 
-void gl_context::endCurrentDepthPass()
+gfx_api::abstract_texture* gl_context::getPipelineSurface(gfx_api::PipelineSurfaceId id)
 {
-	glBindFramebuffer(GL_FRAMEBUFFER, 0);
-//	glViewport(0, 0, viewportWidth, viewportHeight);
-//	glDepthMask(GL_TRUE);
+	return _pipelineSurfaces.get(id);
 }
 
-gfx_api::abstract_texture* gl_context::getDepthTexture()
+gfx_api::PipelineSurfaceMeta gl_context::pipelineSurfaceMeta(gfx_api::PipelineSurfaceId id) const
 {
-	return depthTexture;
+	return _pipelineSurfaces.meta(id);
 }
 
-void gl_context::_beginRenderPassImpl()
+nonstd::optional<gfx_api::PipelineSurfaceId> gl_context::findPipelineSurfaceId(gfx_api::abstract_texture* texture) const
 {
-	glBindFramebuffer(GL_FRAMEBUFFER, 0);
-	glViewport(0, 0, viewportWidth, viewportHeight);
-	GLbitfield clearFlags = 0;
-	glColorMask(GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
-	glDepthMask(GL_TRUE);
-	clearFlags = GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT | GL_STENCIL_BUFFER_BIT;
-	glClear(clearFlags);
+	return _pipelineSurfaces.findSurfaceId(texture);
 }
 
-void gl_context::beginRenderPass()
+bool gl_context::isSceneMSAAEnabled() const
 {
-#if defined(__EMSCRIPTEN__)
-	_beginRenderPassImpl();
-#else
-	// no-op everywhere else
-#endif
+	return multisamples > 0 && _sceneMsaaSurface != nullptr;
+}
+
+bool gl_context::isSwapchainMSAAEnabled() const
+{
+	return false;
+}
+
+bool gl_context::isMultisampledColorAttachment(gfx_api::abstract_texture* texture) const
+{
+	if (auto* renderbuffer = dynamic_cast<gl_gpurendered_renderbuffer*>(texture))
+	{
+		return renderbuffer->isMultisampled();
+	}
+	return false;
+}
+
+gfx_api::pixel_format gl_context::getDepthStencilFormat() const
+{
+	return gfx_api::pixel_format::FORMAT_D24_UNORM_S8;
 }
 
 [[noreturn]] static void glContextHandleOOMError()
@@ -4197,15 +4292,147 @@ void gl_context::beginRenderPass()
 	abort();
 }
 
-void gl_context::endRenderPass()
+static const char *cbframebuffererror(GLenum err);
+
+namespace
 {
+
+gfx_api::DynamicFBOKey::Slot dynamicFBOKeySlotFromAttachment(const gfx_api::AttachmentDesc& attachment)
+{
+	gfx_api::DynamicFBOKey::Slot slot;
+	if (auto* pipelineSurface = dynamic_cast<gl_pipeline_surface_proxy*>(attachment.texture))
+	{
+		slot.isDefaultFramebuffer = true;
+		slot.objectId = static_cast<uint32_t>(pipelineSurface->kind);
+		return slot;
+	}
+	if (auto* renderbuffer = dynamic_cast<gl_gpurendered_renderbuffer*>(attachment.texture))
+	{
+		slot.objectId = renderbuffer->id();
+		slot.isRenderbuffer = true;
+		return slot;
+	}
+
+	auto* gpuTexture = dynamic_cast<gl_gpurendered_texture*>(attachment.texture);
+	ASSERT_OR_RETURN(slot, gpuTexture != nullptr, "Dynamic pass attachment must be a GPU-rendered texture or renderbuffer");
+	slot.objectId = gpuTexture->id();
+	slot.arrayLayer = attachment.arrayLayer;
+	return slot;
+}
+
+gfx_api::DynamicFBOKey buildDynamicFBOKey(const gfx_api::RenderPassDesc& pass, uint32_t passWidth, uint32_t passHeight)
+{
+	gfx_api::DynamicFBOKey key;
+	key.width = passWidth;
+	key.height = passHeight;
+	key.colorSlots.reserve(pass.colorAttachments.size());
+	for (const auto& colorAttachment : pass.colorAttachments)
+	{
+		key.colorSlots.push_back(dynamicFBOKeySlotFromAttachment(colorAttachment));
+	}
+	if (pass.depthAttachment.has_value() && pass.depthAttachment->texture != nullptr)
+	{
+		key.depthSlot = dynamicFBOKeySlotFromAttachment(pass.depthAttachment.value());
+	}
+	return key;
+}
+
+void bindDynamicPassFramebufferAttachments(const gfx_api::RenderPassDesc& pass)
+{
+	for (size_t i = 0; i < pass.colorAttachments.size(); ++i)
+	{
+		const auto& attachment = pass.colorAttachments[i];
+		ASSERT_OR_RETURN(, attachment.texture != nullptr, "Unresolved color attachment in dynamic pass");
+		if (dynamic_cast<gl_pipeline_surface_proxy*>(attachment.texture) != nullptr)
+		{
+			continue;
+		}
+		const GLenum colorAttachment = GL_COLOR_ATTACHMENT0 + static_cast<GLenum>(i);
+		if (auto* renderbuffer = dynamic_cast<gl_gpurendered_renderbuffer*>(attachment.texture))
+		{
+			glFramebufferRenderbuffer(GL_FRAMEBUFFER, colorAttachment, GL_RENDERBUFFER, renderbuffer->id());
+		}
+		else
+		{
+			auto* gpuTexture = dynamic_cast<gl_gpurendered_texture*>(attachment.texture);
+			ASSERT_OR_RETURN(, gpuTexture != nullptr, "Dynamic pass color attachment must be a GPU-rendered texture or renderbuffer");
+			if (gpuTexture->isArray())
+			{
+				glFramebufferTextureLayer(GL_FRAMEBUFFER, colorAttachment, gpuTexture->id(), 0,
+					static_cast<GLint>(attachment.arrayLayer));
+			}
+			else
+			{
+				glFramebufferTexture2D(GL_FRAMEBUFFER, colorAttachment, gpuTexture->target(), gpuTexture->id(), 0);
+			}
+		}
+	}
+
+	if (pass.depthAttachment.has_value() && pass.depthAttachment->texture != nullptr)
+	{
+		if (dynamic_cast<gl_pipeline_surface_proxy*>(pass.depthAttachment->texture) != nullptr)
+		{
+			return;
+		}
+		const GLenum depthAttachmentPoint = gfx_api::attachmentDepthHasStencil(pass.depthAttachment.value())
+			? GL_DEPTH_STENCIL_ATTACHMENT
+			: GL_DEPTH_ATTACHMENT;
+		if (auto* depthRenderbuffer = dynamic_cast<gl_gpurendered_renderbuffer*>(pass.depthAttachment->texture))
+		{
+			glFramebufferRenderbuffer(GL_FRAMEBUFFER, depthAttachmentPoint, GL_RENDERBUFFER, depthRenderbuffer->id());
+		}
+		else
+		{
+			auto* depthTexture = dynamic_cast<gl_gpurendered_texture*>(pass.depthAttachment->texture);
+			ASSERT_OR_RETURN(, depthTexture != nullptr, "Dynamic pass depth attachment must be a GPU-rendered texture or renderbuffer");
+			if (depthTexture->isArray())
+			{
+				glFramebufferTextureLayer(GL_FRAMEBUFFER, depthAttachmentPoint, depthTexture->id(), 0,
+					static_cast<GLint>(pass.depthAttachment->arrayLayer));
+			}
+			else
+			{
+				glFramebufferTexture2D(GL_FRAMEBUFFER, depthAttachmentPoint, depthTexture->target(), depthTexture->id(), 0);
+			}
+		}
+	}
+}
+
+void configureDynamicPassDrawBuffers(const gfx_api::RenderPassDesc& pass)
+{
+	std::vector<GLenum> drawBuffers;
+	drawBuffers.reserve(pass.colorAttachments.size());
+	for (size_t i = 0; i < pass.colorAttachments.size(); ++i)
+	{
+		drawBuffers.push_back(GL_COLOR_ATTACHMENT0 + static_cast<GLenum>(i));
+	}
+
+	if (drawBuffers.size() > 1)
+	{
+		glDrawBuffers(static_cast<GLsizei>(drawBuffers.size()), drawBuffers.data());
+	}
+	else if (drawBuffers.empty())
+	{
+		const GLenum none = GL_NONE;
+		glDrawBuffers(1, &none);
+		glReadBuffer(GL_NONE);
+	}
+}
+
+} // anonymous namespace
+
+void gl_context::submitFrame()
+{
+	if (!frameHasDrawCommands)
+	{
+		return;
+	}
+
 	frameNum = std::max<size_t>(frameNum + 1, 1);
 	backend_impl->swapWindow();
 	glUseProgram(0);
 	current_program = nullptr;
-#if !defined(__EMSCRIPTEN__)
-	_beginRenderPassImpl();
-#endif
+	frameHasDrawCommands = false;
 
 #if defined(WZ_GL_KHR_DEBUG_SUPPORTED)
 	if (khrCallbackOomDetected.load())
@@ -4213,6 +4440,368 @@ void gl_context::endRenderPass()
 		glContextHandleOOMError();
 	}
 #endif
+}
+
+namespace
+{
+
+void glLegacyClearDefaultFramebuffer(gl_context& ctx)
+{
+	const auto dims = ctx.getDrawableDimensions();
+	glBindFramebuffer(GL_FRAMEBUFFER, 0);
+	glViewport(0, 0, static_cast<GLsizei>(dims.first), static_cast<GLsizei>(dims.second));
+	glColorMask(GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
+	glDepthMask(GL_TRUE);
+	glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT | GL_STENCIL_BUFFER_BIT);
+}
+
+bool glLegacyBeginResolvedPass(gl_context& ctx, gfx_api::RenderPassDesc pass)
+{
+	if (!gfx_api::resolvePassDescription(pass))
+	{
+		return false;
+	}
+	ctx.beginPass(pass);
+	return true;
+}
+
+} // anonymous namespace
+
+void gl_context::beginDepthPass(size_t idx)
+{
+	ASSERT_OR_RETURN(, idx < depthPassCount, "Invalid depth pass #: %zu", idx);
+	setRenderGraphExecuting(true);
+
+	if (hasActivePass)
+	{
+		endPass();
+	}
+
+	gfx_api::RenderPassDesc pass = gfx_api::legacy_pass::buildShadowCascadePassDesc(idx);
+	if (!glLegacyBeginResolvedPass(*this, std::move(pass)))
+	{
+		debug(LOG_ERROR, "Failed to begin legacy shadow cascade pass");
+		setRenderGraphExecuting(false);
+	}
+}
+
+void gl_context::endCurrentDepthPass()
+{
+	if (hasActivePass)
+	{
+		endPass();
+	}
+}
+
+void gl_context::beginSceneRenderPass()
+{
+	setRenderGraphExecuting(true);
+
+	if (hasActivePass)
+	{
+		endPass();
+	}
+
+	gfx_api::RenderPassDesc pass = gfx_api::legacy_pass::buildScenePassDesc();
+	if (!glLegacyBeginResolvedPass(*this, std::move(pass)))
+	{
+		debug(LOG_ERROR, "Failed to begin legacy scene pass");
+		setRenderGraphExecuting(false);
+	}
+}
+
+void gl_context::endSceneRenderPass()
+{
+	if (hasActivePass)
+	{
+		endPass();
+	}
+
+	if (!openLegacySwapchainPass(gfx_api::AttachmentLoadOp::Load, gfx_api::AttachmentLoadOp::Clear))
+	{
+		debug(LOG_ERROR, "Failed to reopen legacy swapchain pass after scene pass");
+		setRenderGraphExecuting(false);
+	}
+	else
+	{
+		setRenderGraphExecuting(true);
+	}
+}
+
+bool gl_context::openLegacySwapchainPass(gfx_api::AttachmentLoadOp colorLoad, gfx_api::AttachmentLoadOp depthLoad)
+{
+	gfx_api::RenderPassDesc pass = gfx_api::legacy_pass::buildSwapchainPassDesc(colorLoad, depthLoad);
+	if (!glLegacyBeginResolvedPass(*this, std::move(pass)))
+	{
+		debug(LOG_ERROR, "Failed to resolve legacy swapchain pass");
+		return false;
+	}
+	return true;
+}
+
+void gl_context::beginRenderPass()
+{
+	if (!openLegacySwapchainPass(gfx_api::AttachmentLoadOp::Clear, gfx_api::AttachmentLoadOp::Clear))
+	{
+		debug(LOG_ERROR, "Failed to begin legacy swapchain render pass");
+		setRenderGraphExecuting(false);
+		return;
+	}
+	setRenderGraphExecuting(true);
+}
+
+void gl_context::endRenderPass()
+{
+	if (hasActivePass)
+	{
+		endPass();
+	}
+
+	frameNum = std::max<size_t>(frameNum + 1, 1);
+	backend_impl->swapWindow();
+	glUseProgram(0);
+	current_program = nullptr;
+#if !defined(__EMSCRIPTEN__)
+	glLegacyClearDefaultFramebuffer(*this);
+#endif
+
+#if defined(WZ_GL_KHR_DEBUG_SUPPORTED)
+	if (khrCallbackOomDetected.load())
+	{
+		wzDisplayFatalGfxBackendFailure("GL_OUT_OF_MEMORY");
+		wzResetGfxSettingsOnFailure();
+		abort();
+	}
+#endif
+
+	setRenderGraphExecuting(false);
+}
+
+void gl_context::applyAttachmentClears(const gfx_api::RenderPassDesc& pass)
+{
+	glColorMask(GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
+	glDepthMask(GL_TRUE);
+
+	for (size_t i = 0; i < pass.colorAttachments.size(); ++i)
+	{
+		const auto& colorAttachment = pass.colorAttachments[i];
+		if (!colorAttachment.shouldClear())
+		{
+			continue;
+		}
+		glClearBufferfv(GL_COLOR, static_cast<GLint>(i),
+			colorAttachment.clearValue.color.data());
+	}
+
+	if (pass.depthAttachment.has_value() && pass.depthAttachment->shouldClear())
+	{
+		const gfx_api::ClearValue& clear = pass.depthAttachment->clearValue;
+		if (gfx_api::attachmentDepthHasStencil(pass.depthAttachment.value()))
+		{
+			glClearBufferfi(GL_DEPTH_STENCIL, 0, clear.depth, static_cast<GLint>(clear.stencil));
+		}
+		else
+		{
+			glClearBufferfv(GL_DEPTH, 0, &clear.depth);
+		}
+	}
+}
+
+void gl_context::warmCompiledRenderGraph(std::vector<gfx_api::RenderPassDesc>& /*passes*/,
+	gfx_api::PassGraphCompileResult& /*compileResult*/)
+{
+}
+
+void gl_context::beginPass(const gfx_api::RenderPassDesc& pass, const gfx_api::CompiledPass* /*compiledPass*/)
+{
+	ASSERT_OR_RETURN(, !hasActivePass, "beginPass called while another pass is active");
+	ASSERT_OR_RETURN(, !_dynamicPassFBO, "Stale pass framebuffer binding");
+	ASSERT_OR_RETURN(, pass.viewportSize.has_value(), "Pass requires resolved viewportSize");
+	ASSERT_OR_RETURN(, !pass.colorAttachments.empty()
+		|| (pass.depthAttachment.has_value() && pass.depthAttachment->texture != nullptr),
+		"Pass requires at least one color or depth attachment");
+
+	const uint32_t passWidth = pass.viewportSize->first;
+	const uint32_t passHeight = pass.viewportSize->second;
+
+	set_depth_range(0.f, 1.f);
+
+	const bool usesDefaultFb = gfx_api::passTargetsSwapchainColor(pass);
+	if (usesDefaultFb)
+	{
+		_dynamicPassFBO = 0;
+		glBindFramebuffer(GL_FRAMEBUFFER, 0);
+	}
+	else
+	{
+		const gfx_api::DynamicFBOKey fboKey = buildDynamicFBOKey(pass, passWidth, passHeight);
+		_dynamicPassFBO = _dynamicFBOCache.acquire(fboKey, [&]() -> uint32_t {
+			GLuint fbo = 0;
+			glGenFramebuffers(1, &fbo);
+			glBindFramebuffer(GL_FRAMEBUFFER, fbo);
+			bindDynamicPassFramebufferAttachments(pass);
+			const GLenum fboStatus = glCheckFramebufferStatus(GL_FRAMEBUFFER);
+			ASSERT_OR_RETURN(0, fboStatus == GL_FRAMEBUFFER_COMPLETE,
+				"Dynamic pass framebuffer incomplete: %s", cbframebuffererror(fboStatus));
+			return fbo;
+		});
+		ASSERT_OR_RETURN(, _dynamicPassFBO != 0, "Failed to acquire dynamic pass framebuffer");
+		glBindFramebuffer(GL_FRAMEBUFFER, _dynamicPassFBO);
+		configureDynamicPassDrawBuffers(pass);
+
+		const GLenum fboStatus = glCheckFramebufferStatus(GL_FRAMEBUFFER);
+		ASSERT_OR_RETURN(, fboStatus == GL_FRAMEBUFFER_COMPLETE, "Dynamic pass framebuffer incomplete: %s", cbframebuffererror(fboStatus));
+	}
+
+	glViewport(0, 0, static_cast<GLsizei>(passWidth), static_cast<GLsizei>(passHeight));
+	glColorMask(GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
+	glDepthMask(GL_TRUE);
+	applyAttachmentClears(pass);
+	_activePassDesc = pass;
+	hasActivePass = true;
+	frameHasDrawCommands = true;
+}
+
+void gl_context::endPass(const gfx_api::CompiledPass* /*compiledPass*/)
+{
+	ASSERT_OR_RETURN(, hasActivePass, "endPass called without an active pass");
+
+	const uint32_t passWidth = _activePassDesc.viewportSize.has_value()
+		? _activePassDesc.viewportSize->first
+		: sceneFramebufferWidth;
+	const uint32_t passHeight = _activePassDesc.viewportSize.has_value()
+		? _activePassDesc.viewportSize->second
+		: sceneFramebufferHeight;
+
+	applyAttachmentStoreOps(_activePassDesc, passWidth, passHeight);
+
+	glBindFramebuffer(GL_FRAMEBUFFER, 0);
+	_dynamicPassFBO = 0;
+	glViewport(0, 0, static_cast<GLsizei>(viewportWidth), static_cast<GLsizei>(viewportHeight));
+	_activePassDesc = gfx_api::RenderPassDesc();
+	hasActivePass = false;
+}
+
+void gl_context::resolveMsaaColorAttachment(const gfx_api::RenderPassDesc& pass, uint32_t passWidth, uint32_t passHeight)
+{
+	if (!gfx_api::passNeedsMsaaResolve(pass))
+	{
+		return;
+	}
+	auto* resolveTexture = dynamic_cast<gl_gpurendered_texture*>(pass.resolveAttachment->texture);
+	ASSERT_OR_RETURN(, resolveTexture != nullptr, "MSAA resolve attachment must be a GPU-rendered texture");
+
+	// If MSAA is enabled, use glBlitFramebuffer from the intermediate MSAA-enabled renderbuffer storage to a standard texture (resolving MSAA)
+	GLuint resolveFBO = 0;
+	glGenFramebuffers(1, &resolveFBO);
+	glBindFramebuffer(GL_DRAW_FRAMEBUFFER, resolveFBO);
+	glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, resolveTexture->target(), resolveTexture->id(), 0);
+
+	glBindFramebuffer(GL_READ_FRAMEBUFFER, _dynamicPassFBO);
+	glBlitFramebuffer(0, 0, static_cast<GLint>(passWidth), static_cast<GLint>(passHeight),
+		0, 0, static_cast<GLint>(passWidth), static_cast<GLint>(passHeight),
+		GL_COLOR_BUFFER_BIT, GL_LINEAR);
+
+	glDeleteFramebuffers(1, &resolveFBO);
+}
+
+void gl_context::invalidateDepthStencilAttachment(const gfx_api::RenderPassDesc& pass)
+{
+	if (!pass.depthAttachment.has_value())
+	{
+		return;
+	}
+
+	glBindFramebuffer(GL_FRAMEBUFFER, _dynamicPassFBO);
+	GLenum invalid_ap[2];
+	if (gles && GLAD_GL_ES_VERSION_3_0)
+	{
+		invalid_ap[0] = GL_DEPTH_STENCIL_ATTACHMENT;
+		glInvalidateFramebuffer(GL_FRAMEBUFFER, 1, invalid_ap);
+	}
+#if !defined(__EMSCRIPTEN__)
+	else
+	{
+		invalid_ap[0] = GL_DEPTH_ATTACHMENT;
+		invalid_ap[1] = GL_STENCIL_ATTACHMENT;
+		if (!gles && GLAD_GL_ARB_invalidate_subdata)
+		{
+		#if !defined(WZ_STATIC_GL_BINDINGS)
+			if (glInvalidateFramebuffer)
+		#endif
+			{
+				glInvalidateFramebuffer(GL_FRAMEBUFFER, 2, invalid_ap);
+			}
+		}
+		else if (gles && GLAD_GL_EXT_discard_framebuffer)
+		{
+		#if !defined(WZ_STATIC_GL_BINDINGS)
+			if (glDiscardFramebufferEXT)
+		#endif
+			{
+				glDiscardFramebufferEXT(GL_FRAMEBUFFER, 2, invalid_ap);
+			}
+		}
+	}
+#endif
+}
+
+void gl_context::applyAttachmentStoreOps(const gfx_api::RenderPassDesc& pass, uint32_t passWidth, uint32_t passHeight)
+{
+	const auto storeOpOr = [](const gfx_api::AttachmentDesc& attachment, gfx_api::AttachmentStoreOp defaultOp) {
+		return attachment.storeOp.value_or(defaultOp);
+	};
+
+	// Performance optimization:
+	//
+	// Before switching the draw framebuffer, call glInvalidateFramebuffer on any parts of the scene framebuffer(s) that we can
+	// NOTE: The only one we need to keep around by the end is sceneTexture, which is bound as GL_COLOR_ATTACHMENT0 on one of the FBOs
+	// However: If using the sceneMsaaRBO, we have to keep that around initially, and only invalidate it after resolving with glBlitFramebuffer
+	//
+	// Support:
+	// - OpenGL:
+	//		- ARB_invalidate_subdata extension provides glInvalidateFramebuffer
+	//			- NOTE: ARB_invalidate_subdata's API does *not* accept GL_DEPTH_STENCIL_ATTACHMENT
+	//		- core in OpenGL 4.3+
+	// - OpenGL ES:
+	//		- EXT_discard_framebuffer provides glDiscardFramebufferEXT
+	//			- NOTE: glDiscardFramebufferEXT does *not* accept GL_DEPTH_STENCIL_ATTACHMENT
+	//			- NOTE: glDiscardFramebufferEXT *only* supports GL_FRAMEBUFFER as a target
+	//		- core in OpenGL ES 3.0+
+
+	if (gfx_api::passNeedsMsaaResolve(pass)
+		&& pass.resolveAttachment.has_value()
+		&& storeOpOr(pass.resolveAttachment.value(), gfx_api::AttachmentStoreOp::Store) == gfx_api::AttachmentStoreOp::Store)
+	{
+		resolveMsaaColorAttachment(pass, passWidth, passHeight);
+
+		if (!pass.colorAttachments.empty()
+			&& storeOpOr(pass.colorAttachments[0], gfx_api::AttachmentStoreOp::Store) == gfx_api::AttachmentStoreOp::DontCare)
+		{
+			GLenum invalidMsaaColorAp[1];
+			invalidMsaaColorAp[0] = GL_COLOR_ATTACHMENT0;
+			glBindFramebuffer(GL_READ_FRAMEBUFFER, _dynamicPassFBO);
+			if (gles && GLAD_GL_ES_VERSION_3_0)
+			{
+				glInvalidateFramebuffer(GL_READ_FRAMEBUFFER, 1, invalidMsaaColorAp);
+			}
+			else
+			{
+#if defined(GL_ARB_invalidate_subdata)
+				if (!gles && GLAD_GL_ARB_invalidate_subdata && glInvalidateFramebuffer)
+				{
+					glInvalidateFramebuffer(GL_READ_FRAMEBUFFER, 1, invalidMsaaColorAp);
+				}
+#endif
+			}
+		}
+	}
+
+	if (pass.depthAttachment.has_value()
+		&& storeOpOr(pass.depthAttachment.value(), gfx_api::AttachmentStoreOp::Store) == gfx_api::AttachmentStoreOp::Invalidate)
+	{
+		invalidateDepthStencilAttachment(pass);
+	}
 }
 
 bool gl_context::supportsInstancedRendering()
@@ -4825,8 +5414,16 @@ bool gl_context::shouldDraw()
 	return viewportWidth > 0 && viewportHeight > 0;
 }
 
+bool gl_context::canRecordDrawCommands() const
+{
+	return renderGraphExecuting() && hasActivePass;
+}
+
 void gl_context::shutdown()
 {
+	_frameResourceCache.clear();
+	clearDynamicFBOCache();
+
 #if !defined(WZ_STATIC_GL_BINDINGS)
 	if (glClear)
 #endif
@@ -4835,17 +5432,7 @@ void gl_context::shutdown()
 	}
 
 	deleteSceneRenderpass();
-
-#if !defined(WZ_STATIC_GL_BINDINGS)
-	if (glDeleteFramebuffers)
-#endif
-	{
-		if (depthFBO.size() > 0)
-		{
-			glDeleteFramebuffers(static_cast<GLsizei>(depthFBO.size()), depthFBO.data());
-			depthFBO.clear();
-		}
-	}
+	destroySwapchainPipelineSurfaces();
 
 	if (depthTexture)
 	{
@@ -5070,8 +5657,22 @@ static const char *cbframebuffererror(GLenum err)
 	}
 }
 
+void gl_context::clearDynamicFBOCache()
+{
+	_dynamicFBOCache.clear([](uint32_t fboHandle) {
+		if (fboHandle == 0)
+		{
+			return;
+		}
+		GLuint fbo = fboHandle;
+		glDeleteFramebuffers(1, &fbo);
+	});
+}
+
 size_t gl_context::initDepthPasses(size_t resolution)
 {
+	clearDynamicFBOCache();
+
 	depthPassCount = std::min<size_t>(depthPassCount, WZ_MAX_SHADOW_CASCADES);
 
 #if !defined(__EMSCRIPTEN__)
@@ -5085,19 +5686,10 @@ size_t gl_context::initDepthPasses(size_t resolution)
 	}
 #endif
 
-	// delete prior depth texture & FBOs (if present)
-#if !defined(WZ_STATIC_GL_BINDINGS)
-	if (glDeleteFramebuffers)
-#endif
-	{
-		if (depthFBO.size() > 0)
-		{
-			glDeleteFramebuffers(static_cast<GLsizei>(depthFBO.size()), depthFBO.data());
-			depthFBO.clear();
-		}
-	}
+	// delete prior depth texture (if present)
 	if (depthTexture)
 	{
+		_pipelineSurfaces.invalidateSurface(gfx_api::PipelineSurfaceId::ShadowMap);
 		delete depthTexture;
 		depthTexture = nullptr;
 	}
@@ -5114,6 +5706,7 @@ size_t gl_context::initDepthPasses(size_t resolution)
 		return 0;
 	}
 	depthTexture = pNewDepthTexture;
+	_pipelineSurfaces.registerSurface(gfx_api::PipelineSurfaceId::ShadowMap, depthTexture);
 
 	GLenum target = depthTexture->target();
 	depthTexture->bind();
@@ -5121,73 +5714,50 @@ size_t gl_context::initDepthPasses(size_t resolution)
 	glTexParameteri(target, GL_TEXTURE_COMPARE_MODE, GL_COMPARE_REF_TO_TEXTURE);
 	depthTexture->unbind();
 
-	for (auto i = 0; i < depthPassCount; ++i)
-	{
-		GLuint newFBO = 0;
-		glGenFramebuffers(1, &newFBO);
-		depthFBO.push_back(newFBO);
-
-		glBindFramebuffer(GL_FRAMEBUFFER, newFBO);
-		if (depthTexture->isArray())
-		{
-#if !defined(WZ_STATIC_GL_BINDINGS)
-			ASSERT(glFramebufferTextureLayer != nullptr, "glFramebufferTextureLayer is not available?");
-#endif
-			glFramebufferTextureLayer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, depthTexture->id(), 0, static_cast<GLint>(i)); // OpenGL 3.0+ / ES 3.0+ only
-		}
-		else
-		{
-			glFramebufferTexture2D(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_TEXTURE_2D, depthTexture->id(), 0);
-		}
-		GLenum buf = GL_NONE;
-		glDrawBuffers(1, &buf);
-		glReadBuffer(GL_NONE);
-
-		GLenum status = glCheckFramebufferStatus(GL_FRAMEBUFFER);
-		if (status != GL_FRAMEBUFFER_COMPLETE)
-		{
-			debug(LOG_ERROR, "Failed to create framebuffer with error: %s", cbframebuffererror(status));
-		}
-
-		glBindFramebuffer(GL_FRAMEBUFFER, 0);
-	}
-
 	return depthPassCount;
 }
 
 void gl_context::deleteSceneRenderpass()
 {
+	clearDynamicFBOCache();
+
+	_pipelineSurfaces.invalidateSurface(gfx_api::PipelineSurfaceId::SceneColor);
+	_pipelineSurfaces.invalidateSurface(gfx_api::PipelineSurfaceId::SceneMSAAColor);
+	_pipelineSurfaces.invalidateSurface(gfx_api::PipelineSurfaceId::SceneDepth);
+
 	// delete prior scene texture & FBOs (if present)
 #if !defined(WZ_STATIC_GL_BINDINGS)
 	if (glDeleteFramebuffers)
 #endif
 	{
-		if (sceneFBO.size() > 0)
-		{
-			glDeleteFramebuffers(static_cast<GLsizei>(sceneFBO.size()), sceneFBO.data());
-			sceneFBO.clear();
-		}
-		if (sceneResolveFBO.size() > 0)
-		{
-			glDeleteFramebuffers(static_cast<GLsizei>(sceneResolveFBO.size()), sceneResolveFBO.data());
-			sceneResolveFBO.clear();
-		}
 	}
-	if (sceneMsaaRBO)
-	{
-		glDeleteRenderbuffers(1, &sceneMsaaRBO);
-		sceneMsaaRBO = 0;
-	}
+	_sceneMsaaSurface.reset();
 	if (sceneTexture)
 	{
 		delete sceneTexture;
 		sceneTexture = nullptr;
 	}
-	if (sceneDepthStencilRBO)
-	{
-		glDeleteRenderbuffers(1, &sceneDepthStencilRBO);
-		sceneDepthStencilRBO = 0;
-	}
+	_sceneDepthStencilSurface.reset();
+}
+
+void gl_context::destroySwapchainPipelineSurfaces()
+{
+	_pipelineSurfaces.invalidateSurface(gfx_api::PipelineSurfaceId::SwapchainColor);
+	_pipelineSurfaces.invalidateSurface(gfx_api::PipelineSurfaceId::SwapchainMSAAColor);
+	_pipelineSurfaces.invalidateSurface(gfx_api::PipelineSurfaceId::SwapchainDepth);
+	_swapchainColorSurface.reset();
+	_swapchainDepthSurface.reset();
+}
+
+void gl_context::registerSwapchainPipelineSurfaces()
+{
+	destroySwapchainPipelineSurfaces();
+
+	_swapchainColorSurface = std::make_unique<gl_pipeline_surface_proxy>(GLPipelineSurfaceKind::SwapchainColor);
+	_swapchainDepthSurface = std::make_unique<gl_pipeline_surface_proxy>(GLPipelineSurfaceKind::SwapchainDepth);
+	_pipelineSurfaces.registerSurface(gfx_api::PipelineSurfaceId::SwapchainColor, _swapchainColorSurface.get());
+	_pipelineSurfaces.registerSurface(gfx_api::PipelineSurfaceId::SwapchainDepth, _swapchainDepthSurface.get());
+	_pipelineSurfaces.invalidateSurface(gfx_api::PipelineSurfaceId::SwapchainMSAAColor);
 }
 
 bool gl_context::createSceneRenderpass()
@@ -5210,14 +5780,9 @@ bool gl_context::createSceneRenderpass()
 
 	if (samples > 0)
 	{
-		// If MSAA is enabled, use glRenderbufferStorageMultisample to create an intermediate buffer with MSAA enabled
-		glGenRenderbuffers(1, &sceneMsaaRBO);
-		ASSERT_GL_NOERRORS_OR_RETURN(false);
-		glBindRenderbuffer(GL_RENDERBUFFER, sceneMsaaRBO);
-		ASSERT_GL_NOERRORS_OR_RETURN(false);
-		glRenderbufferStorageMultisample(GL_RENDERBUFFER, samples, multiSampledBufferInternalFormat, sceneFramebufferWidth, sceneFramebufferHeight); // OpenGL 3.0+, OpenGL ES 3.0+
-		ASSERT_GL_NOERRORS_OR_RETURN(false);
-		glBindRenderbuffer(GL_RENDERBUFFER, 0);
+		_sceneMsaaSurface = create_framebuffer_renderbuffer(multiSampledBufferInternalFormat, samples,
+			sceneFramebufferWidth, sceneFramebufferHeight, "<scene msaa color>");
+		ASSERT_OR_RETURN(false, _sceneMsaaSurface != nullptr, "Failed to create scene MSAA renderbuffer");
 		ASSERT_GL_NOERRORS_OR_RETURN(false);
 	}
 
@@ -5243,205 +5808,100 @@ bool gl_context::createSceneRenderpass()
 	sceneTexture->unbind();
 	ASSERT_GL_NOERRORS_OR_RETURN(false);
 
-	// Create a matching depth/stencil texture
-	sceneDepthStencilRBO = 0;
-	glGenRenderbuffers(1, &sceneDepthStencilRBO);
-	ASSERT_GL_NOERRORS_OR_RETURN(false);
-	glBindRenderbuffer(GL_RENDERBUFFER, sceneDepthStencilRBO);
-	ASSERT_GL_NOERRORS_OR_RETURN(false);
-	glRenderbufferStorageMultisample(GL_RENDERBUFFER, samples, GL_DEPTH24_STENCIL8, sceneFramebufferWidth, sceneFramebufferHeight); // OpenGL 3.0+, OpenGL ES 3.0+
-	ASSERT_GL_NOERRORS_OR_RETURN(false);
-	glBindRenderbuffer(GL_RENDERBUFFER, 0);
+	_sceneDepthStencilSurface = create_framebuffer_renderbuffer(GL_DEPTH24_STENCIL8, samples,
+		sceneFramebufferWidth, sceneFramebufferHeight, "<scene depth stencil>");
+	ASSERT_OR_RETURN(false, _sceneDepthStencilSurface != nullptr, "Failed to create scene depth/stencil renderbuffer");
 	ASSERT_GL_NOERRORS_OR_RETURN(false);
 
-	const size_t numSceneFBOs = 2;
-	for (auto i = 0; i < numSceneFBOs; ++i)
+	ASSERT_GL_NOERRORS_OR_RETURN(false);
+
+	_pipelineSurfaces.registerSurface(gfx_api::PipelineSurfaceId::SceneColor, sceneTexture);
+	_pipelineSurfaces.registerSurface(gfx_api::PipelineSurfaceId::SceneDepth, _sceneDepthStencilSurface.get());
+	const uint32_t sceneSamples = (samples > 0) ? static_cast<uint32_t>(samples) : 1u;
+	_pipelineSurfaces.setSurfaceSamples(gfx_api::PipelineSurfaceId::SceneDepth, sceneSamples);
+	if (_sceneMsaaSurface != nullptr)
 	{
-		GLuint newFBO = 0;
-		glGenFramebuffers(1, &newFBO);
-		ASSERT_GL_NOERRORS_OR_RETURN(false);
-		sceneFBO.push_back(newFBO);
-
-		glBindFramebuffer(GL_FRAMEBUFFER, newFBO);
-		ASSERT_GL_NOERRORS_OR_RETURN(false);
-		if (samples > 0)
-		{
-			// use the MSAA renderbuffer as the color attachment
-			glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_RENDERBUFFER, sceneMsaaRBO);
-			ASSERT_GL_NOERRORS_OR_RETURN(false);
-		}
-		else
-		{
-			// just directly use the sceneTexture as the color attachment (since no MSAA resolving needs to occur)
-			glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, sceneTexture->id(), 0);
-			ASSERT_GL_NOERRORS_OR_RETURN(false);
-		}
-		glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_STENCIL_ATTACHMENT, GL_RENDERBUFFER, sceneDepthStencilRBO);
-		ASSERT_GL_NOERRORS_OR_RETURN(false);
-
-		GLenum status = glCheckFramebufferStatus(GL_FRAMEBUFFER);
-		if (status != GL_FRAMEBUFFER_COMPLETE)
-		{
-			debug(LOG_ERROR, "Failed to create scene framebuffer[%d] (%" PRIu32 " x %" PRIu32 ", samples: %d) with error: %s", i, sceneFramebufferWidth, sceneFramebufferHeight, static_cast<int>(samples), cbframebuffererror(status));
-			encounteredError = true;
-		}
-		ASSERT_GL_NOERRORS_OR_RETURN(false);
-
-		glBindFramebuffer(GL_FRAMEBUFFER, 0);
-		ASSERT_GL_NOERRORS_OR_RETURN(false);
-
-		if (samples > 0)
-		{
-			// Must also create a sceneResolveFBO for resolving MSAA
-			GLuint newResolveRBO = 0;
-			glGenFramebuffers(1, &newResolveRBO);
-			ASSERT_GL_NOERRORS_OR_RETURN(false);
-			sceneResolveFBO.push_back(newResolveRBO);
-
-			glBindFramebuffer(GL_FRAMEBUFFER, newResolveRBO);
-			ASSERT_GL_NOERRORS_OR_RETURN(false);
-			glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, sceneTexture->id(), 0);
-			ASSERT_GL_NOERRORS_OR_RETURN(false);
-			// shouldn't need a depth/stencil buffer
-
-			status = glCheckFramebufferStatus(GL_FRAMEBUFFER);
-			if (status != GL_FRAMEBUFFER_COMPLETE)
-			{
-				debug(LOG_ERROR, "Failed to create scene resolve framebuffer[%d] (%" PRIu32 " x %" PRIu32 ", samples: %d) with error: %s", i, sceneFramebufferWidth, sceneFramebufferHeight, static_cast<int>(samples), cbframebuffererror(status));
-				encounteredError = true;
-			}
-			ASSERT_GL_NOERRORS_OR_RETURN(false);
-
-			glBindFramebuffer(GL_FRAMEBUFFER, 0);
-			ASSERT_GL_NOERRORS_OR_RETURN(false);
-		}
+		_pipelineSurfaces.registerSurface(gfx_api::PipelineSurfaceId::SceneMSAAColor, _sceneMsaaSurface.get());
+		_pipelineSurfaces.setSurfaceSamples(gfx_api::PipelineSurfaceId::SceneMSAAColor, sceneSamples);
+	}
+	else
+	{
+		_pipelineSurfaces.invalidateSurface(gfx_api::PipelineSurfaceId::SceneMSAAColor);
 	}
 
-	ASSERT_GL_NOERRORS_OR_RETURN(false);
-
+	bumpRenderGraphEpoch();
 	return !encounteredError;
 }
 
-void gl_context::beginSceneRenderPass()
+gfx_api::abstract_texture* gl_context::acquireTransientRenderTarget(gfx_api::pixel_format format, uint32_t width, uint32_t height)
 {
-	glBindFramebuffer(GL_FRAMEBUFFER, sceneFBO[sceneFBOIdx]);
-	glViewport(0, 0, sceneFramebufferWidth, sceneFramebufferHeight);
-	GLbitfield clearFlags = 0;
-	glColorMask(GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
-	glDepthMask(GL_TRUE);
-	clearFlags = GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT | GL_STENCIL_BUFFER_BIT;
-	glClear(clearFlags);
+	ASSERT_OR_RETURN(nullptr, width > 0 && height > 0, "Invalid transient render target dimensions");
+	ASSERT_OR_RETURN(nullptr, is_transient_render_target_format(format), "Unsupported transient render target format");
+
+	static uint32_t transientTargetId = 0;
+	const gfx_api::ImageResourceKey key = gfx_api::ImageResourceKey::color2d(format, width, height);
+	const std::string debugName = "<transient_rt_" + std::to_string(transientTargetId++) + ">";
+
+	return _frameResourceCache.acquire(key, [this, format, width, height, debugName]() {
+		if (format == gfx_api::pixel_format::FORMAT_D24_UNORM_S8)
+		{
+			return createTransientDepthRenderTarget(width, height, debugName);
+		}
+		return createTransientColorRenderTarget(format, width, height, debugName);
+	});
 }
 
-void gl_context::endSceneRenderPass()
+void gl_context::releaseTransientRenderTargets()
 {
-	// Performance optimization:
-	//
-	// Before switching the draw framebuffer, call glInvalidateFramebuffer on any parts of the scene framebuffer(s) that we can
-	// NOTE: The only one we need to keep around by the end is sceneTexture, which is bound as GL_COLOR_ATTACHMENT0 on one of the FBOs
-	// However: If using the sceneMsaaRBO, we have to keep that around initially, and only invalidate it after resolving with glBlitFramebuffer
-	//
-	// Support:
-	// - OpenGL:
-	//		- ARB_invalidate_subdata extension provides glInvalidateFramebuffer
-	//			- NOTE: ARB_invalidate_subdata's API does *not* accept GL_DEPTH_STENCIL_ATTACHMENT
-	//		- core in OpenGL 4.3+
-	// - OpenGL ES:
-	//		- EXT_discard_framebuffer provides glDiscardFramebufferEXT
-	//			- NOTE: glDiscardFramebufferEXT does *not* accept GL_DEPTH_STENCIL_ATTACHMENT
-	//			- NOTE: glDiscardFramebufferEXT *only* supports GL_FRAMEBUFFER as a target
-	//		- core in OpenGL ES 3.0+
-
-	// invalidate depth_stencil on sceneFBO[sceneFBOIdx]
-	GLenum invalid_ap[2];
-	if (/*(!gles && GLAD_GL_VERSION_4_3) || */ (gles && GLAD_GL_ES_VERSION_3_0))
-	{
-		invalid_ap[0] = GL_DEPTH_STENCIL_ATTACHMENT;
-		glInvalidateFramebuffer(GL_FRAMEBUFFER, 1, invalid_ap);
-	}
-#if !defined(__EMSCRIPTEN__)
-	else
-	{
-		invalid_ap[0] = GL_DEPTH_ATTACHMENT;
-		invalid_ap[1] = GL_STENCIL_ATTACHMENT;
-		if (!gles && GLAD_GL_ARB_invalidate_subdata)
-		{
-		#if !defined(WZ_STATIC_GL_BINDINGS)
-			if (glInvalidateFramebuffer)
-		#endif
-			{
-				glInvalidateFramebuffer(GL_FRAMEBUFFER, 2, invalid_ap);
-			}
-		}
-		else if (gles && GLAD_GL_EXT_discard_framebuffer)
-		{
-		#if !defined(WZ_STATIC_GL_BINDINGS)
-			if (glDiscardFramebufferEXT)
-		#endif
-			{
-				glDiscardFramebufferEXT(GL_FRAMEBUFFER, 2, invalid_ap);
-			}
-		}
-	}
-#endif
-
-	// If MSAA is enabled, use glBiltFramebuffer from the intermediate MSAA-enabled renderbuffer storage to a standard texture (resolving MSAA)
-	bool usingMSAAIntermediate = (sceneMsaaRBO != 0);
-	if (usingMSAAIntermediate)
-	{
-		glBindFramebuffer(GL_READ_FRAMEBUFFER, sceneFBO[sceneFBOIdx]);
-		glBindFramebuffer(GL_DRAW_FRAMEBUFFER, sceneResolveFBO[sceneFBOIdx]);
-		glBlitFramebuffer(0,0, sceneFramebufferWidth, sceneFramebufferHeight,
-						  0,0, sceneFramebufferWidth, sceneFramebufferHeight,
-						  GL_COLOR_BUFFER_BIT,
-						  GL_LINEAR);
-	}
-
-	// after this, sceneTexture should be the (msaa-resolved) color texture of the scene
-
-	if (usingMSAAIntermediate)
-	{
-		// invalidate color0 (sceneMsaaRBO) in sceneFBO[sceneFBOIdx] (which is GL_READ_FRAMEBUFFER at this point)
-		GLenum invalid_msaarbo_ap[1];
-		invalid_msaarbo_ap[0] = GL_COLOR_ATTACHMENT0;
-		if (/*(!gles && GLAD_GL_VERSION_4_3) || */ (gles && GLAD_GL_ES_VERSION_3_0))
-		{
-			glInvalidateFramebuffer(GL_READ_FRAMEBUFFER, 1, invalid_msaarbo_ap);
-		}
-		else
-		{
-#if defined(GL_ARB_invalidate_subdata)
-			if (!gles && GLAD_GL_ARB_invalidate_subdata && glInvalidateFramebuffer)
-			{
-				glInvalidateFramebuffer(GL_READ_FRAMEBUFFER, 1, invalid_msaarbo_ap);
-			}
-#endif
-//			else if (gles && GLAD_GL_EXT_discard_framebuffer && glDiscardFramebufferEXT)
-//			{
-//				// NOTE: glDiscardFramebufferEXT only supports GL_FRAMEBUFFER... but that doesn't work here
-//				glDiscardFramebufferEXT(GL_FRAMEBUFFER, 1, invalid_msaarbo_ap);
-//			}
-		}
-	}
-
-	sceneFBOIdx++;
-	if (sceneFBOIdx >= sceneFBO.size())
-	{
-		sceneFBOIdx = 0;
-	}
-
-	// switch back to default framebuffer
-	glBindFramebuffer(GL_FRAMEBUFFER, 0);
-	// Because the scene uses the same viewport, a call to glViewport should not be needed (NOTE: viewport is *not* part of the framebuffer state)
-	if (sceneFramebufferWidth != viewportWidth || sceneFramebufferHeight != viewportHeight)
-	{
-		glViewport(0, 0, viewportWidth, viewportHeight);
-	}
+	_frameResourceCache.releaseAll();
+	_dynamicFBOCache.releaseAll();
 }
 
-gfx_api::abstract_texture* gl_context::getSceneTexture()
+void gl_context::purgeFrameResources()
 {
-	return sceneTexture;
+	_frameResourceCache.purgeUnused();
+	_dynamicFBOCache.purgeUnused([](uint32_t fboHandle) {
+		if (fboHandle == 0)
+		{
+			return;
+		}
+		GLuint fbo = fboHandle;
+		glDeleteFramebuffers(1, &fbo);
+	});
+}
+
+optional<std::pair<uint32_t, uint32_t>> gl_context::getRenderTargetDimensions(gfx_api::abstract_texture* texture)
+{
+	if (texture == nullptr)
+	{
+		return nullopt;
+	}
+	if (auto* gpuTexture = dynamic_cast<gl_gpurendered_texture*>(texture))
+	{
+		if (gpuTexture->tex_width > 0 && gpuTexture->tex_height > 0)
+		{
+			return std::make_pair(gpuTexture->tex_width, gpuTexture->tex_height);
+		}
+	}
+	if (auto* renderbuffer = dynamic_cast<gl_gpurendered_renderbuffer*>(texture))
+	{
+		if (renderbuffer->_width > 0 && renderbuffer->_height > 0)
+		{
+			return std::make_pair(renderbuffer->_width, renderbuffer->_height);
+		}
+	}
+	if (dynamic_cast<gl_pipeline_surface_proxy*>(texture) != nullptr)
+	{
+		if (viewportWidth > 0 && viewportHeight > 0)
+		{
+			return std::make_pair(viewportWidth, viewportHeight);
+		}
+	}
+	if (texture == sceneTexture && sceneFramebufferWidth > 0 && sceneFramebufferHeight > 0)
+	{
+		return std::make_pair(sceneFramebufferWidth, sceneFramebufferHeight);
+	}
+	return nullopt;
 }
 
 #if defined(__EMSCRIPTEN__)

--- a/lib/ivis_opengl/gfx_api_gl.h
+++ b/lib/ivis_opengl/gfx_api_gl.h
@@ -385,8 +385,6 @@ struct gl_context final : public gfx_api::context
 	virtual bool isSwapchainMSAAEnabled() const override;
 	virtual bool isMultisampledColorAttachment(gfx_api::abstract_texture* texture) const override;
 	virtual gfx_api::pixel_format getDepthStencilFormat() const override;
-	virtual gfx_api::abstract_texture* acquireTransientRenderTarget(gfx_api::pixel_format format, uint32_t width, uint32_t height) override;
-	virtual void releaseTransientRenderTargets() override;
 	virtual void purgeFrameResources() override;
 	virtual optional<std::pair<uint32_t, uint32_t>> getRenderTargetDimensions(gfx_api::abstract_texture* texture) override;
 	virtual void warmCompiledRenderGraph(std::vector<gfx_api::RenderPassDesc>& passes,
@@ -437,8 +435,6 @@ private:
 	gl_gpurendered_texture* create_framebuffer_color_texture(GLenum internalFormat, GLenum format, GLenum type, const size_t& width, const size_t& height, const std::string& filename);
 	std::unique_ptr<gl_gpurendered_renderbuffer> create_framebuffer_renderbuffer(GLenum internalFormat, GLsizei samples,
 		uint32_t width, uint32_t height, const std::string& filename);
-	std::unique_ptr<gfx_api::abstract_texture> createTransientColorRenderTarget(gfx_api::pixel_format format, uint32_t width, uint32_t height, const std::string& debugName);
-	std::unique_ptr<gfx_api::abstract_texture> createTransientDepthRenderTarget(uint32_t width, uint32_t height, const std::string& debugName);
 	bool createDefaultTextures();
 	bool createSceneRenderpass();
 	void registerSwapchainPipelineSurfaces();
@@ -516,7 +512,6 @@ private:
 	std::unique_ptr<gl_pipeline_surface_proxy> _swapchainDepthSurface;
 
 	gfx_api::PipelineSurfaceRegistry _pipelineSurfaces;
-	gfx_api::FrameResourceCache _frameResourceCache;
 	gfx_api::DynamicFBOCache _dynamicFBOCache;
 
 	GLuint _dynamicPassFBO = 0;

--- a/lib/ivis_opengl/gfx_api_gl.h
+++ b/lib/ivis_opengl/gfx_api_gl.h
@@ -20,6 +20,10 @@
 #pragma once
 
 #include "gfx_api.h"
+#include "gfx_api_frame_resource_cache.h"
+#include "render_graph/pass_resolve.h"
+#include "render_graph/pipeline_surfaces.h"
+#include "render_graph/render_pass.h"
 
 #if defined(__EMSCRIPTEN__)
 # define WZ_STATIC_GL_BINDINGS
@@ -129,6 +133,8 @@ private:
 	GLuint _id;
 	bool gles = false;
 	bool _isArray = false;
+	uint32_t tex_width = 0;
+	uint32_t tex_height = 0;
 #if defined(WZ_DEBUG_GFX_API_LEAKS)
 	std::string debugName;
 #endif
@@ -142,6 +148,46 @@ public:
 	GLenum target() const;
 	unsigned id() const;
 	void unbind();
+};
+
+struct gl_gpurendered_renderbuffer final : public gfx_api::abstract_texture
+{
+	friend struct gl_context;
+	GLuint _id = 0;
+	GLsizei _samples = 0;
+	uint32_t _width = 0;
+	uint32_t _height = 0;
+#if defined(WZ_DEBUG_GFX_API_LEAKS)
+	std::string debugName;
+#endif
+
+	gl_gpurendered_renderbuffer() = default;
+	~gl_gpurendered_renderbuffer() override;
+public:
+	virtual void bind() override;
+	virtual bool isArray() const override { return false; }
+	virtual size_t backend_internal_value() const override;
+	GLuint id() const { return _id; }
+	GLsizei samples() const { return _samples; }
+	bool isMultisampled() const { return _samples > 1; }
+};
+
+enum class GLPipelineSurfaceKind : size_t
+{
+	SwapchainColor = 200,
+	SwapchainDepth = 201,
+};
+
+/// Sentinel pipeline surface for the default framebuffer (no GL texture object).
+struct gl_pipeline_surface_proxy final : public gfx_api::abstract_texture
+{
+	GLPipelineSurfaceKind kind = GLPipelineSurfaceKind::SwapchainColor;
+
+	explicit gl_pipeline_surface_proxy(GLPipelineSurfaceKind surfaceKind);
+	~gl_pipeline_surface_proxy() override;
+	void bind() override;
+	bool isArray() const override { return false; }
+	size_t backend_internal_value() const override;
 };
 
 struct gl_buffer final : public gfx_api::buffer
@@ -322,15 +368,29 @@ struct gl_context final : public gfx_api::context
 
 	virtual size_t numDepthPasses() override;
 	virtual bool setDepthPassProperties(size_t numDepthPasses, size_t depthBufferResolution) override;
+	virtual void beginPass(const gfx_api::RenderPassDesc& pass, const gfx_api::CompiledPass* compiledPass = nullptr) override;
+	virtual void endPass(const gfx_api::CompiledPass* compiledPass = nullptr) override;
+	virtual void submitFrame() override;
 	virtual void beginDepthPass(size_t idx) override;
-	virtual size_t getDepthPassDimensions(size_t idx) override;
 	virtual void endCurrentDepthPass() override;
-	virtual gfx_api::abstract_texture* getDepthTexture() override;
 	virtual void beginSceneRenderPass() override;
 	virtual void endSceneRenderPass() override;
-	virtual gfx_api::abstract_texture* getSceneTexture() override;
 	virtual void beginRenderPass() override;
 	virtual void endRenderPass() override;
+	virtual size_t getDepthPassDimensions(size_t idx) override;
+	virtual gfx_api::abstract_texture* getPipelineSurface(gfx_api::PipelineSurfaceId id) override;
+	virtual gfx_api::PipelineSurfaceMeta pipelineSurfaceMeta(gfx_api::PipelineSurfaceId id) const override;
+	virtual nonstd::optional<gfx_api::PipelineSurfaceId> findPipelineSurfaceId(gfx_api::abstract_texture* texture) const override;
+	virtual bool isSceneMSAAEnabled() const override;
+	virtual bool isSwapchainMSAAEnabled() const override;
+	virtual bool isMultisampledColorAttachment(gfx_api::abstract_texture* texture) const override;
+	virtual gfx_api::pixel_format getDepthStencilFormat() const override;
+	virtual gfx_api::abstract_texture* acquireTransientRenderTarget(gfx_api::pixel_format format, uint32_t width, uint32_t height) override;
+	virtual void releaseTransientRenderTargets() override;
+	virtual void purgeFrameResources() override;
+	virtual optional<std::pair<uint32_t, uint32_t>> getRenderTargetDimensions(gfx_api::abstract_texture* texture) override;
+	virtual void warmCompiledRenderGraph(std::vector<gfx_api::RenderPassDesc>& passes,
+		gfx_api::PassGraphCompileResult& compileResult) override;
 	virtual void debugStringMarker(const char *str) override;
 	virtual void debugSceneBegin(const char *descr) override;
 	virtual void debugSceneEnd(const char *descr) override;
@@ -347,6 +407,7 @@ struct gl_context final : public gfx_api::context
 	virtual std::pair<uint32_t, uint32_t> getDrawableDimensions() override;
 	bool isYAxisInverted() const override { return false; }
 	virtual bool shouldDraw() override;
+	bool canRecordDrawCommands() const override;
 	virtual void shutdown() override;
 	virtual const size_t& current_FrameNum() const override;
 	virtual bool setSwapInterval(gfx_api::context::swap_interval_mode mode, const SetSwapIntervalCompletionHandler& completionHandler) override;
@@ -374,10 +435,15 @@ private:
 	gl_gpurendered_texture* create_gpurendered_texture_array(GLenum internalFormat, GLenum format, GLenum type, const size_t& width, const size_t& height, const size_t& layer_count, const std::string& filename);
 	gl_gpurendered_texture* create_depthmap_texture(const size_t& layer_count, const size_t& width, const size_t& height, const std::string& filename);
 	gl_gpurendered_texture* create_framebuffer_color_texture(GLenum internalFormat, GLenum format, GLenum type, const size_t& width, const size_t& height, const std::string& filename);
+	std::unique_ptr<gl_gpurendered_renderbuffer> create_framebuffer_renderbuffer(GLenum internalFormat, GLsizei samples,
+		uint32_t width, uint32_t height, const std::string& filename);
+	std::unique_ptr<gfx_api::abstract_texture> createTransientColorRenderTarget(gfx_api::pixel_format format, uint32_t width, uint32_t height, const std::string& debugName);
+	std::unique_ptr<gfx_api::abstract_texture> createTransientDepthRenderTarget(uint32_t width, uint32_t height, const std::string& debugName);
 	bool createDefaultTextures();
 	bool createSceneRenderpass();
+	void registerSwapchainPipelineSurfaces();
+	void destroySwapchainPipelineSurfaces();
 	void deleteSceneRenderpass();
-	void _beginRenderPassImpl();
 
 protected:
 	friend struct gl_pipeline_state_object;
@@ -396,9 +462,18 @@ private:
 	uint32_t getSuggestedDefaultDepthBufferResolution() const;
 	bool setSwapIntervalInternal(gfx_api::context::swap_interval_mode mode);
 
+	void applyAttachmentStoreOps(const gfx_api::RenderPassDesc& pass, uint32_t passWidth, uint32_t passHeight);
+	bool openLegacySwapchainPass(gfx_api::AttachmentLoadOp colorLoad, gfx_api::AttachmentLoadOp depthLoad);
+	static void applyAttachmentClears(const gfx_api::RenderPassDesc& pass);
+	void resolveMsaaColorAttachment(const gfx_api::RenderPassDesc& pass, uint32_t passWidth, uint32_t passHeight);
+	void invalidateDepthStencilAttachment(const gfx_api::RenderPassDesc& pass);
+	void clearDynamicFBOCache();
+
 	uint32_t viewportWidth = 0;
 	uint32_t viewportHeight = 0;
 	std::vector<bool> enabledVertexAttribIndexes;
+	bool hasActivePass = false;
+	bool frameHasDrawCommands = false;
 	size_t frameNum = 0;
 	std::string formattedRendererInfoString;
 	std::array<std::vector<gfx_api::pixel_format_usage::flags>, gfx_api::PIXEL_FORMAT_TARGET_COUNT> textureFormatsSupport;
@@ -425,7 +500,6 @@ private:
 	gl_gpurendered_texture *pDefaultDepthTexture = nullptr;
 
 	gl_gpurendered_texture* depthTexture = nullptr;
-	std::vector<GLuint> depthFBO;
 	size_t depthBufferResolution = 4096;
 	size_t depthPassCount = WZ_MAX_SHADOW_CASCADES;
 
@@ -436,9 +510,15 @@ private:
 	GLint maxMultiSampleBufferFormatSamples = 0;
 	uint32_t multisamples = 0;
 	gl_gpurendered_texture* sceneTexture = nullptr;
-	std::vector<GLuint> sceneFBO;
-	std::vector<GLuint> sceneResolveFBO;
-	GLuint sceneMsaaRBO = 0;
-	GLuint sceneDepthStencilRBO = 0;
-	size_t sceneFBOIdx = 0;
+	std::unique_ptr<gl_gpurendered_renderbuffer> _sceneMsaaSurface;
+	std::unique_ptr<gl_gpurendered_renderbuffer> _sceneDepthStencilSurface;
+	std::unique_ptr<gl_pipeline_surface_proxy> _swapchainColorSurface;
+	std::unique_ptr<gl_pipeline_surface_proxy> _swapchainDepthSurface;
+
+	gfx_api::PipelineSurfaceRegistry _pipelineSurfaces;
+	gfx_api::FrameResourceCache _frameResourceCache;
+	gfx_api::DynamicFBOCache _dynamicFBOCache;
+
+	GLuint _dynamicPassFBO = 0;
+	gfx_api::RenderPassDesc _activePassDesc;
 };

--- a/lib/ivis_opengl/gfx_api_legacy_pass_compat.cpp
+++ b/lib/ivis_opengl/gfx_api_legacy_pass_compat.cpp
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+/*
+	This file is part of Warzone 2100.
+	Copyright (C) 2026  Warzone 2100 Project (https://github.com/Warzone2100)
+
+	Warzone 2100 is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+
+	Warzone 2100 is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with Warzone 2100; if not, write to the Free Software
+	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+/** @file gfx_api_legacy_pass_compat.cpp
+ * Implementation of legacy pass description builders shared by Vulkan and OpenGL.
+ */
+
+
+#include "gfx_api_legacy_pass_compat.h"
+
+#include "gfx_api.h"
+#include "render_graph/pipeline_surfaces.h"
+
+#include "lib/framework/wzapp.h"
+
+namespace gfx_api
+{
+namespace legacy_pass
+{
+
+namespace
+{
+
+AttachmentDesc pipelineDepthAttachment(PipelineSurfaceId id, AttachmentLoadOp loadOp,
+	AttachmentStoreOp storeOp, uint32_t arrayLayer = 0)
+{
+	AttachmentDesc attachment = makePipelineSurfaceAttachment(id, loadOp, ClearValue::depthStencilClear());
+	attachment.storeOp = storeOp;
+	attachment.arrayLayer = arrayLayer;
+	return attachment;
+}
+
+AttachmentDesc pipelineColorAttachment(PipelineSurfaceId id, AttachmentLoadOp loadOp,
+	AttachmentStoreOp storeOp)
+{
+	AttachmentDesc attachment = makePipelineSurfaceAttachment(id, loadOp, ClearValue::colorClear());
+	attachment.storeOp = storeOp;
+	return attachment;
+}
+
+void setViewportFromSurface(RenderPassDesc& pass, PipelineSurfaceId id)
+{
+	auto& ctx = gfx_api::context::get();
+	if (abstract_texture* surface = ctx.getPipelineSurface(id))
+	{
+		if (const auto dims = ctx.getRenderTargetDimensions(surface))
+		{
+			pass.viewportSize = *dims;
+			return;
+		}
+	}
+
+	const auto drawable = ctx.getDrawableDimensions();
+	pass.viewportSize = drawable;
+}
+
+} // anonymous namespace
+
+RenderPassDesc buildShadowCascadePassDesc(size_t cascadeIndex)
+{
+	RenderPassDesc pass;
+	pass.debugName = "LegacyShadowCascade";
+	pass.depthAttachment = pipelineDepthAttachment(PipelineSurfaceId::ShadowMap,
+		AttachmentLoadOp::Clear, AttachmentStoreOp::Store, static_cast<uint32_t>(cascadeIndex));
+	setViewportFromSurface(pass, PipelineSurfaceId::ShadowMap);
+	return pass;
+}
+
+RenderPassDesc buildScenePassDesc()
+{
+	auto& ctx = gfx_api::context::get();
+	RenderPassDesc pass;
+	pass.debugName = "LegacyScenePass";
+
+	if (ctx.isSceneMSAAEnabled())
+	{
+		pass.colorAttachments.push_back(pipelineColorAttachment(PipelineSurfaceId::SceneMSAAColor,
+			AttachmentLoadOp::Clear, AttachmentStoreOp::DontCare));
+		pass.resolveAttachment = pipelineColorAttachment(PipelineSurfaceId::SceneColor,
+			AttachmentLoadOp::DontCare, AttachmentStoreOp::Store);
+	}
+	else
+	{
+		pass.colorAttachments.push_back(pipelineColorAttachment(PipelineSurfaceId::SceneColor,
+			AttachmentLoadOp::Clear, AttachmentStoreOp::Store));
+	}
+
+	pass.depthAttachment = pipelineDepthAttachment(PipelineSurfaceId::SceneDepth,
+		AttachmentLoadOp::Clear, AttachmentStoreOp::Invalidate);
+	setViewportFromSurface(pass, PipelineSurfaceId::SceneColor);
+	return pass;
+}
+
+RenderPassDesc buildSwapchainPassDesc(AttachmentLoadOp colorLoad, AttachmentLoadOp depthLoad)
+{
+	auto& ctx = gfx_api::context::get();
+	RenderPassDesc pass;
+	pass.debugName = "LegacySwapchain";
+
+	if (ctx.isSwapchainMSAAEnabled())
+	{
+		pass.colorAttachments.push_back(pipelineColorAttachment(PipelineSurfaceId::SwapchainMSAAColor,
+			colorLoad, AttachmentStoreOp::DontCare));
+		pass.resolveAttachment = pipelineColorAttachment(PipelineSurfaceId::SwapchainColor,
+			AttachmentLoadOp::DontCare, AttachmentStoreOp::Store);
+	}
+	else
+	{
+		pass.colorAttachments.push_back(pipelineColorAttachment(PipelineSurfaceId::SwapchainColor,
+			colorLoad, AttachmentStoreOp::Store));
+	}
+
+	pass.depthAttachment = pipelineDepthAttachment(PipelineSurfaceId::SwapchainDepth,
+		depthLoad, AttachmentStoreOp::DontCare);
+	pass.viewportSize = ctx.getDrawableDimensions();
+	return pass;
+}
+
+} // namespace legacy_pass
+
+} // namespace gfx_api

--- a/lib/ivis_opengl/gfx_api_legacy_pass_compat.h
+++ b/lib/ivis_opengl/gfx_api_legacy_pass_compat.h
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+/*
+	This file is part of Warzone 2100.
+	Copyright (C) 2026  Warzone 2100 Project (https://github.com/Warzone2100)
+
+	Warzone 2100 is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+
+	Warzone 2100 is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with Warzone 2100; if not, write to the Free Software
+	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+/** @file gfx_api_legacy_pass_compat.h
+ * `RenderPassDesc` factories for legacy shadow, scene, and swapchain pass entry points.
+ */
+
+
+#pragma once
+
+#include "render_graph/render_pass.h"
+
+namespace gfx_api
+{
+
+/// <summary>
+/// Factories for standard frame passes expressed as `RenderPassDesc` (shadow, scene, swapchain).
+///
+/// Shared by Vulkan and OpenGL legacy `begin*Pass` entry points until the game frame path
+/// fully migrates to `CachedRenderGraph` / blueprint materialization. Outputs use
+/// `PipelineSurfaceId` attachment sources; callers run `resolvePassDescription` before `beginPass`.
+/// </summary>
+namespace legacy_pass
+{
+
+/// Shadow-map depth pass for cascade `cascadeIndex` (`ShadowMap` surface, array layer = cascade).
+RenderPassDesc buildShadowCascadePassDesc(size_t cascadeIndex);
+
+/// Scene color (+ optional MSAA resolve) and depth (`SceneMSAAColor`/`SceneColor`, `SceneDepth`).
+RenderPassDesc buildScenePassDesc();
+
+/// Final swapchain pass; `colorLoad`/`depthLoad` control clear vs load (UI overlay uses `Load`).
+RenderPassDesc buildSwapchainPassDesc(AttachmentLoadOp colorLoad, AttachmentLoadOp depthLoad);
+
+} // namespace legacy_pass
+} // namespace gfx_api

--- a/lib/ivis_opengl/gfx_api_null.cpp
+++ b/lib/ivis_opengl/gfx_api_null.cpp
@@ -427,19 +427,78 @@ bool null_context::_initialize(const gfx_api::backend_Impl_Factory& impl, int32_
 	return true;
 }
 
-void null_context::beginRenderPass()
+void null_context::warmCompiledRenderGraph(std::vector<gfx_api::RenderPassDesc>& /*passes*/,
+	gfx_api::PassGraphCompileResult& /*compileResult*/)
 {
-	// no-op
 }
 
-void null_context::endRenderPass()
+void null_context::beginPass(const gfx_api::RenderPassDesc& pass, const gfx_api::CompiledPass* /*compiledPass*/)
 {
+	(void)pass;
+	frameHasDrawCommands = true;
+}
+
+void null_context::endPass(const gfx_api::CompiledPass* /*compiledPass*/)
+{
+}
+
+void null_context::submitFrame()
+{
+	if (!frameHasDrawCommands)
+	{
+		return;
+	}
+
 	frameNum = std::max<size_t>(frameNum + 1, 1);
+	frameHasDrawCommands = false;
 
 	// Backend is expected to handle throttling / sleeping
 	backend_impl->swapWindow();
 
 	current_program = nullptr;
+}
+
+void null_context::beginDepthPass(size_t /*idx*/)
+{
+	setRenderGraphExecuting(true);
+}
+
+void null_context::endCurrentDepthPass()
+{
+}
+
+void null_context::beginSceneRenderPass()
+{
+	setRenderGraphExecuting(true);
+}
+
+void null_context::endSceneRenderPass()
+{
+}
+
+void null_context::beginRenderPass()
+{
+	setRenderGraphExecuting(true);
+	frameHasDrawCommands = true;
+}
+
+void null_context::endRenderPass()
+{
+	setRenderGraphExecuting(false);
+	submitFrame();
+}
+
+gfx_api::abstract_texture* null_context::acquireTransientRenderTarget(gfx_api::pixel_format format, uint32_t width, uint32_t height)
+{
+	return nullptr;
+}
+
+void null_context::releaseTransientRenderTargets()
+{
+}
+
+void null_context::purgeFrameResources()
+{
 }
 
 void null_context::handleWindowSizeChange(unsigned int oldWidth, unsigned int oldHeight, unsigned int newWidth, unsigned int newHeight)

--- a/lib/ivis_opengl/gfx_api_null.cpp
+++ b/lib/ivis_opengl/gfx_api_null.cpp
@@ -488,15 +488,6 @@ void null_context::endRenderPass()
 	submitFrame();
 }
 
-gfx_api::abstract_texture* null_context::acquireTransientRenderTarget(gfx_api::pixel_format format, uint32_t width, uint32_t height)
-{
-	return nullptr;
-}
-
-void null_context::releaseTransientRenderTargets()
-{
-}
-
 void null_context::purgeFrameResources()
 {
 }

--- a/lib/ivis_opengl/gfx_api_null.h
+++ b/lib/ivis_opengl/gfx_api_null.h
@@ -137,8 +137,6 @@ public:
 	virtual void endSceneRenderPass() override;
 	virtual void beginRenderPass() override;
 	virtual void endRenderPass() override;
-	virtual gfx_api::abstract_texture* acquireTransientRenderTarget(gfx_api::pixel_format format, uint32_t width, uint32_t height) override;
-	virtual void releaseTransientRenderTargets() override;
 	virtual void purgeFrameResources() override;
 	virtual void warmCompiledRenderGraph(std::vector<gfx_api::RenderPassDesc>& passes,
 		gfx_api::PassGraphCompileResult& compileResult) override;

--- a/lib/ivis_opengl/gfx_api_null.h
+++ b/lib/ivis_opengl/gfx_api_null.h
@@ -128,9 +128,20 @@ public:
 	virtual void set_depth_range(const float& min, const float& max) override;
 	virtual int32_t get_context_value(const context_value property) override;
 	virtual uint64_t get_estimated_vram_mb(bool dedicatedOnly) override;
-
+	virtual void beginPass(const gfx_api::RenderPassDesc& pass, const gfx_api::CompiledPass* compiledPass = nullptr) override;
+	virtual void endPass(const gfx_api::CompiledPass* compiledPass = nullptr) override;
+	virtual void submitFrame() override;
+	virtual void beginDepthPass(size_t idx) override;
+	virtual void endCurrentDepthPass() override;
+	virtual void beginSceneRenderPass() override;
+	virtual void endSceneRenderPass() override;
 	virtual void beginRenderPass() override;
 	virtual void endRenderPass() override;
+	virtual gfx_api::abstract_texture* acquireTransientRenderTarget(gfx_api::pixel_format format, uint32_t width, uint32_t height) override;
+	virtual void releaseTransientRenderTargets() override;
+	virtual void purgeFrameResources() override;
+	virtual void warmCompiledRenderGraph(std::vector<gfx_api::RenderPassDesc>& passes,
+		gfx_api::PassGraphCompileResult& compileResult) override;
 	virtual void debugStringMarker(const char *str) override;
 	virtual void debugSceneBegin(const char *descr) override;
 	virtual void debugSceneEnd(const char *descr) override;
@@ -170,4 +181,5 @@ private:
 private:
 
 	size_t frameNum = 0;
+	bool frameHasDrawCommands = false;
 };

--- a/lib/ivis_opengl/gfx_api_vk.cpp
+++ b/lib/ivis_opengl/gfx_api_vk.cpp
@@ -38,8 +38,30 @@
 //   - the Vulkan Portability Initiative: https://www.khronos.org/vulkan/portability-initiative
 //   - MoltenVK limitations: https://github.com/KhronosGroup/MoltenVK/blob/master/Docs/MoltenVK_Runtime_UserGuide.md#known-moltenvk-limitations
 //
+// Barrier/layout/sync logic lives in lib/ivis_opengl/vk/ (and render_graph/ for compile-time):
+//   render_graph/compile           CompiledPass prePassBarriers / postPassLayoutUpdates
+//   render_graph/layout_timeline   compile-time layout state machine
+//   render_graph/read_scope        ReadProducerScope classification for image barriers
+//   vk/layout_translation          ImageLayout <-> vk::ImageLayout
+//   vk/layout_sync                 LayoutSync, barrier recipes
+//   vk/pass_layout_key             PassLayoutKey identity + attachment metadata
+//   vk/layout_key_builder          PassLayoutKey from RenderPassDesc / CompiledPass
+//   vk/render_pass_layout_cache    VkRenderPass cache keyed by PassLayoutKey
+//   vk/frame_layout_tracker        runtime per-frame layout map + present transition
+//   vk/pre_pass_barrier_emitter    batched pre-pass image barriers
+//   vk/warm_entry.h                warm render-pass layout ids per graphIndex
+//   vk/legacy_pass_layout_commit   out-of-graph final layout capture/commit
+// VkRoot orchestrates the above and owns scratch buffers, FBO setup, and pass begin/end.
+// transitionImageLayout, getVkImageHandle, and getVkImageAspect remain here as facades for vk/ friends.
 
 #include "gfx_api_vk.h"
+#include "gfx_api_legacy_pass_compat.h"
+#include "render_graph/layout_subresource.h"
+#include "render_graph/pass_resolve.h"
+#include "vk/handle_storage.h"
+#include "vk/layout_key_builder.h"
+#include "vk/layout_sync.h"
+#include "vk/layout_translation.h"
 #include "lib/framework/physfs_ext.h"
 #include "lib/framework/wzapp.h"
 #include "lib/exceptionhandler/dumpinfo.h"
@@ -191,7 +213,12 @@ enum class VulkanBackendInternalTextureType : size_t
 	Texture,
 	TextureArray,
 	DepthMap,
-	RenderedImage
+	RenderedImage,
+	AttachmentImage,
+	TransientDepthStencil,
+	SwapchainColorSurface,
+	SwapchainMsaaColorSurface,
+	SwapchainDepthSurface,
 };
 
 // MARK: General helper functions
@@ -811,18 +838,15 @@ perFrameResources_t::perFrameResources_t(vk::Device& _dev, const VmaAllocator& a
 	const auto buffer = dev.allocateCommandBuffers(
 		vk::CommandBufferAllocateInfo()
 		.setCommandPool(pool)
-		.setCommandBufferCount(4)
+		.setCommandBufferCount(2)
 		.setLevel(vk::CommandBufferLevel::ePrimary)
 		, *pVkDynLoader
 	);
 	cmdDraw = buffer[0];
 	cmdCopy = buffer[1];
-	cmdDrawDepth = buffer[2];
-	cmdDrawScene = buffer[3];
 	pCurrentDrawCmdBuffer = &cmdDraw;
 	cmdCopy.begin(vk::CommandBufferBeginInfo().setFlags(vk::CommandBufferUsageFlagBits::eOneTimeSubmit), vkDynLoader);
-	cmdDrawDepth.begin(vk::CommandBufferBeginInfo().setFlags(vk::CommandBufferUsageFlagBits::eOneTimeSubmit), vkDynLoader);
-	cmdDrawScene.begin(vk::CommandBufferBeginInfo().setFlags(vk::CommandBufferUsageFlagBits::eOneTimeSubmit), vkDynLoader);
+	copyCmdBufferBegun = true;
 	previousSubmission = dev.createFence(
 		vk::FenceCreateInfo().setFlags(vk::FenceCreateFlagBits::eSignaled),
 		nullptr, *pVkDynLoader
@@ -842,24 +866,31 @@ perFrameResources_t::DescriptorPoolDetails perFrameResources_t::createNewDescrip
 		), poolSize, maxSets);
 }
 
-void perFrameResources_t::beginDepthPass()
+void perFrameResources_t::ensureDrawCmdBufferBegun()
 {
-	pCurrentDrawCmdBuffer = &cmdDrawDepth;
+	if (!drawCmdBufferBegun)
+	{
+		cmdDraw.begin(vk::CommandBufferBeginInfo().setFlags(vk::CommandBufferUsageFlagBits::eOneTimeSubmit), *pVkDynLoader);
+		drawCmdBufferBegun = true;
+	}
 }
 
-void perFrameResources_t::endCurrentDepthPass()
+void perFrameResources_t::endCopyCmdBufferIfRecording()
 {
-	pCurrentDrawCmdBuffer = &cmdDraw;
+	if (copyCmdBufferBegun)
+	{
+		cmdCopy.end(*pVkDynLoader);
+		copyCmdBufferBegun = false;
+	}
 }
 
-void perFrameResources_t::beginScenePass()
+void perFrameResources_t::endDrawCmdBufferIfRecording()
 {
-	pCurrentDrawCmdBuffer = &cmdDrawScene;
-}
-
-void perFrameResources_t::endScenePass()
-{
-	pCurrentDrawCmdBuffer = &cmdDraw;
+	if (drawCmdBufferBegun)
+	{
+		cmdDraw.end(*pVkDynLoader);
+		drawCmdBufferBegun = false;
+	}
 }
 
 vk::CommandBuffer* perFrameResources_t::currentCopyCmdBuffer()
@@ -877,17 +908,7 @@ vk::CommandBuffer perFrameResources_t::copyCmdBuffer()
 	return cmdCopy;
 }
 
-vk::CommandBuffer perFrameResources_t::depthPassDrawCmdBuffer()
-{
-	return cmdDrawDepth;
-}
-
-vk::CommandBuffer perFrameResources_t::scenePassDrawCmdBuffer()
-{
-	return cmdDrawScene;
-}
-
-vk::CommandBuffer perFrameResources_t::renderPassDrawCmdBuffer()
+vk::CommandBuffer perFrameResources_t::drawCmdBuffer()
 {
 	return cmdDraw;
 }
@@ -952,6 +973,11 @@ void perFrameResources_t::clean()
 		dev.destroyImage(image, nullptr, *pVkDynLoader);
 	}
 	image_to_delete.clear();
+	for (auto memory : devicememory_to_free)
+	{
+		dev.freeMemory(memory, nullptr, *pVkDynLoader);
+	}
+	devicememory_to_free.clear();
 	perPSO_dynamicUniformBufferDescriptorSets.clear();
 	for (auto allocation : vmamemory_to_free)
 	{
@@ -1058,13 +1084,6 @@ size_t buffering_mechanism::numFrames()
 	return perFrameResources.size();
 }
 
-void buffering_mechanism::destroy(vk::Device dev, const WZ_vk::DispatchLoaderDynamic& vkDynLoader)
-{
-	perFrameResources.clear();
-	perSwapchainImageResources.clear();
-	currentFrame = 0;
-}
-
 void buffering_mechanism::swap(vk::Device dev, const WZ_vk::DispatchLoaderDynamic& vkDynLoader)
 {
 	currentFrame = (currentFrame < (perFrameResources.size() - 1)) ? currentFrame + 1 : 0;
@@ -1079,9 +1098,18 @@ void buffering_mechanism::swap(vk::Device dev, const WZ_vk::DispatchLoaderDynami
 	dev.resetFences(fences, vkDynLoader);
 	buffering_mechanism::get_current_resources().resetDescriptorPools();
 	dev.resetCommandPool(buffering_mechanism::get_current_resources().pool, vk::CommandPoolResetFlagBits(), vkDynLoader);
+	buffering_mechanism::get_current_resources().drawCmdBufferBegun = false;
+	buffering_mechanism::get_current_resources().copyCmdBufferBegun = false;
 
 	buffering_mechanism::get_current_resources().clean();
 	buffering_mechanism::get_current_resources().numalloc = 0;
+}
+
+void buffering_mechanism::destroy(vk::Device dev, const WZ_vk::DispatchLoaderDynamic& vkDynLoader)
+{
+	perFrameResources.clear();
+	perSwapchainImageResources.clear();
+	currentFrame = 0;
 }
 
 // MARK: Definitions of statics
@@ -2127,8 +2155,8 @@ VkTexture::VkTexture(const VkRoot& root, const std::size_t& mipmap_count, const 
 #endif
 }
 
-VkDepthMapImage::VkDepthMapImage(const VkRoot& root, const std::size_t& _layer_count, const std::size_t& size, vk::Format depthMapFormat, const std::string& filename)
-	: dev(root.dev), layer_count(_layer_count)
+VkDepthMapImage::VkDepthMapImage(const VkRoot& root, const std::size_t& _layer_count, const std::size_t& size, vk::Format _depthMapFormat, const std::string& filename)
+	: dev(root.dev), layer_count(_layer_count), depthMapFormat(_depthMapFormat), mapSize(static_cast<uint32_t>(size))
 {
 	ASSERT(size > 0, "0 width/height textures are unsupported");
 	ASSERT(size <= static_cast<size_t>(std::numeric_limits<uint32_t>::max()), "width (%zu) exceeds uint32_t max", size);
@@ -2138,7 +2166,7 @@ VkDepthMapImage::VkDepthMapImage(const VkRoot& root, const std::size_t& _layer_c
 #endif
 
 	auto imageCreateInfo = vk::ImageCreateInfo()
-		.setFormat(depthMapFormat)
+		.setFormat(_depthMapFormat)
 		.setArrayLayers(static_cast<uint32_t>(layer_count))
 		.setExtent(vk::Extent3D(static_cast<uint32_t>(size), static_cast<uint32_t>(size), 1))
 		.setImageType(vk::ImageType::e2D)
@@ -2171,7 +2199,7 @@ VkDepthMapImage::VkDepthMapImage(const VkRoot& root, const std::size_t& _layer_c
 	const auto imageViewCreateInfo = vk::ImageViewCreateInfo()
 		.setImage(object)
 		.setViewType(vk::ImageViewType::e2DArray)
-		.setFormat(depthMapFormat)
+		.setFormat(_depthMapFormat)
 		.setComponents(vk::ComponentMapping())
 		.setSubresourceRange(vk::ImageSubresourceRange(vk::ImageAspectFlagBits::eDepth, 0, 1, 0, static_cast<uint32_t>(layer_count)));
 
@@ -2323,6 +2351,11 @@ bool VkTexture::upload_internal(const std::size_t& mip_level, const std::size_t&
 	cmdBuffer->pipelineBarrier(vk::PipelineStageFlagBits::eTransfer, vk::PipelineStageFlagBits::eFragmentShader,
 		vk::DependencyFlags(), nullptr, nullptr, imageMemoryBarriers_AfterCopy, root->vkDynLoader);
 
+	root->noteExternalSubresourceLayout(
+		gfx_api::layoutSubresourceKey(static_cast<gfx_api::abstract_texture*>(this),
+			0, static_cast<uint32_t>(mip_level)),
+		vk::ImageLayout::eShaderReadOnlyOptimal);
+
 	return true;
 }
 
@@ -2350,8 +2383,11 @@ size_t VkTexture::backend_internal_value() const
 
 // MARK: VkRenderedImage
 
-VkRenderedImage::VkRenderedImage(const VkRoot& root, size_t width, size_t height, vk::Format imageFormat, const std::string& filename)
+VkRenderedImage::VkRenderedImage(const VkRoot& root, size_t width, size_t height, vk::Format _imageFormat, const std::string& filename)
 	: dev(root.dev)
+	, imageFormat(_imageFormat)
+	, width(static_cast<uint32_t>(width))
+	, height(static_cast<uint32_t>(height))
 {
 	ASSERT(width > 0 && height > 0, "0 width/height textures are unsupported");
 	ASSERT(width <= static_cast<size_t>(std::numeric_limits<uint32_t>::max()), "width (%zu) exceeds uint32_t max", width);
@@ -2367,7 +2403,7 @@ VkRenderedImage::VkRenderedImage(const VkRoot& root, size_t width, size_t height
 	.setImageType(vk::ImageType::e2D)
 	.setMipLevels(1)
 	.setTiling(vk::ImageTiling::eOptimal)
-	.setFormat(imageFormat)
+	.setFormat(_imageFormat)
 	.setUsage(vk::ImageUsageFlagBits::eSampled | vk::ImageUsageFlagBits::eColorAttachment)
 	.setInitialLayout(vk::ImageLayout::eUndefined)
 	.setSamples(vk::SampleCountFlagBits::e1)
@@ -2396,7 +2432,7 @@ VkRenderedImage::VkRenderedImage(const VkRoot& root, size_t width, size_t height
 	const auto imageViewCreateInfo = vk::ImageViewCreateInfo()
 		.setImage(object)
 		.setViewType(vk::ImageViewType::e2D)
-		.setFormat(imageFormat)
+		.setFormat(_imageFormat)
 		.setComponents(vk::ComponentMapping())
 		.setSubresourceRange(vk::ImageSubresourceRange(vk::ImageAspectFlagBits::eColor, 0, 1, 0, 1));
 
@@ -2461,6 +2497,86 @@ bool VkRenderedImage::isArray() const
 size_t VkRenderedImage::backend_internal_value() const
 {
 	return static_cast<size_t>(VulkanBackendInternalTextureType::RenderedImage);
+}
+
+// MARK: VkAttachmentImage
+
+VkAttachmentImage::VkAttachmentImage(vk::Image _image, vk::ImageView _view, vk::Format format, uint32_t w, uint32_t h,
+	vk::SampleCountFlagBits sampleCount, const std::string& filename)
+	: image(_image)
+	, view(_view)
+	, imageFormat(format)
+	, width(w)
+	, height(h)
+	, samples(sampleCount)
+{
+#if defined(WZ_DEBUG_GFX_API_LEAKS)
+	debugName = filename;
+#endif
+}
+
+VkAttachmentImage::~VkAttachmentImage() = default;
+
+void VkAttachmentImage::bind() { }
+
+size_t VkAttachmentImage::backend_internal_value() const
+{
+	return static_cast<size_t>(VulkanBackendInternalTextureType::AttachmentImage);
+}
+
+// MARK: VkSwapchainColorSurface
+
+VkSwapchainColorSurface::VkSwapchainColorSurface(const VkRoot& rootRef, vk::Format format)
+	: root(rootRef)
+	, imageFormat(format)
+{
+}
+
+VkSwapchainColorSurface::~VkSwapchainColorSurface() = default;
+
+void VkSwapchainColorSurface::bind() { }
+
+size_t VkSwapchainColorSurface::backend_internal_value() const
+{
+	return static_cast<size_t>(VulkanBackendInternalTextureType::SwapchainColorSurface);
+}
+
+// MARK: VkSwapchainMsaaColorSurface
+
+VkSwapchainMsaaColorSurface::VkSwapchainMsaaColorSurface(const VkRoot& rootRef, vk::Format format,
+	vk::SampleCountFlagBits sampleCount)
+	: root(rootRef)
+	, imageFormat(format)
+	, samples(sampleCount)
+{
+}
+
+VkSwapchainMsaaColorSurface::~VkSwapchainMsaaColorSurface() = default;
+
+void VkSwapchainMsaaColorSurface::bind() { }
+
+size_t VkSwapchainMsaaColorSurface::backend_internal_value() const
+{
+	return static_cast<size_t>(VulkanBackendInternalTextureType::SwapchainMsaaColorSurface);
+}
+
+// MARK: VkSwapchainDepthSurface
+
+VkSwapchainDepthSurface::VkSwapchainDepthSurface(const VkRoot& rootRef, vk::Format format,
+	vk::SampleCountFlagBits sampleCount)
+	: root(rootRef)
+	, imageFormat(format)
+	, samples(sampleCount)
+{
+}
+
+VkSwapchainDepthSurface::~VkSwapchainDepthSurface() = default;
+
+void VkSwapchainDepthSurface::bind() { }
+
+size_t VkSwapchainDepthSurface::backend_internal_value() const
+{
+	return static_cast<size_t>(VulkanBackendInternalTextureType::SwapchainDepthSurface);
 }
 
 // MARK: VkTextureArray
@@ -2610,6 +2726,16 @@ void VkTextureArray::flush()
 	cmdBuffer->pipelineBarrier(vk::PipelineStageFlagBits::eTransfer, vk::PipelineStageFlagBits::eFragmentShader,
 		vk::DependencyFlags(), nullptr, nullptr, imageMemoryBarriers_AfterCopy, root->vkDynLoader);
 	transitionedToTransferDstFormat = false;
+
+	for (uint32_t layer = 0; layer < static_cast<uint32_t>(layer_count); ++layer)
+	{
+		for (uint32_t mip = 0; mip < static_cast<uint32_t>(mipmap_levels); ++mip)
+		{
+			root->noteExternalSubresourceLayout(
+				gfx_api::layoutSubresourceKey(static_cast<gfx_api::abstract_texture*>(this), layer, mip),
+				vk::ImageLayout::eShaderReadOnlyOptimal);
+		}
+	}
 }
 
 size_t VkTextureArray::backend_internal_value() const
@@ -2619,7 +2745,10 @@ size_t VkTextureArray::backend_internal_value() const
 
 // MARK: VkRoot
 
-VkRoot::VkRoot(bool _debug) : validationLayer(_debug)
+VkRoot::VkRoot(bool _debug)
+	: validationLayer(_debug)
+	, _renderPassLayoutCache(*this)
+	, _barrierEmitter(*this, _frameLayoutTracker)
 {
 	debugInfo.setOutputHandler([&](const std::string& output) {
 		addDumpInfo(output.c_str());
@@ -2697,7 +2826,7 @@ gfx_api::pipeline_state_object * VkRoot::build_pipeline(gfx_api::pipeline_state_
 	}
 	if (!psoID.has_value())
 	{
-		createdPipelines.emplace_back(createInfo, NUM_RENDERPASS_IDS);
+		createdPipelines.emplace_back(createInfo, renderPasses.size());
 		psoID = createdPipelines.size() - 1;
 		createdPipelines[psoID.value()].renderPassPSO[currentRenderPassId] = pipeline;
 	}
@@ -2716,11 +2845,15 @@ gfx_api::pipeline_state_object * VkRoot::build_pipeline(gfx_api::pipeline_state_
 
 void VkRoot::rebuildPipelinesIfNecessary()
 {
-	ASSERT(defaultRenderpass().rp_compat_info, "Called before rendering pass is set up");
+	if (renderPasses.empty())
+	{
+		return;
+	}
 	// rebuild existing pipelines
 	for (auto& pipelineInfo : createdPipelines)
 	{
-		for (size_t renderPassId = 0; renderPassId < pipelineInfo.renderPassPSO.size(); ++renderPassId)
+		const size_t numRenderPasses = std::min(pipelineInfo.renderPassPSO.size(), renderPasses.size());
+		for (size_t renderPassId = 0; renderPassId < numRenderPasses; ++renderPassId)
 		{
 			auto pipeline = pipelineInfo.renderPassPSO[renderPassId];
 			if (pipeline == nullptr)
@@ -2845,143 +2978,119 @@ static void createColorAttachmentImage(const vk::PhysicalDevice& physicalDevice,
 static void createDepthStencilImage(const vk::PhysicalDevice& physicalDevice, const vk::PhysicalDeviceMemoryProperties& memprops, const vk::Device& dev,
 									const vk::Extent2D& swapchainSize, vk::SampleCountFlagBits msaaSamples, vk::Format depthFormat,
 									vk::Image& depthStencilImage, vk::DeviceMemory& depthStencilMemory, vk::ImageView& depthStencilView,
-									const WZ_vk::DispatchLoaderDynamic& vkDynLoader, const char *loggingKey = "depthStencilImage")
+									const WZ_vk::DispatchLoaderDynamic& vkDynLoader, const char *loggingKey = "depthStencilImage",
+									bool enableShaderSampling = false)
 {
+	vk::ImageUsageFlags usage = vk::ImageUsageFlagBits::eDepthStencilAttachment;
+	if (enableShaderSampling)
+	{
+		usage |= vk::ImageUsageFlagBits::eSampled;
+	}
+
 	createGPUImageAndViewInternal(physicalDevice, memprops, dev,
 										 swapchainSize, msaaSamples, depthFormat,
 										 // FUTURE TODO: Add vk::ImageUsageFlagBits::eTransientAttachment once we get rid of stencil shadows entirely
-										 vk::ImageUsageFlagBits::eDepthStencilAttachment,
+										 usage,
 										 vk::ImageAspectFlagBits::eDepth | vk::ImageAspectFlagBits::eStencil,
 										 depthStencilImage, depthStencilMemory, depthStencilView,
 										 vkDynLoader, loggingKey);
 }
 
-// throws a vk::SystemError on an unrecoverable error (like OOM)
-void VkRoot::createDefaultRenderpass(vk::Format swapchainFormat, vk::Format depthFormat)
+// MARK: VkTransientDepthStencilImage
+
+VkTransientDepthStencilImage::VkTransientDepthStencilImage(const VkRoot& root, uint32_t w, uint32_t h, vk::Format format, const std::string& filename)
+	: dev(root.dev)
+	, imageFormat(format)
+	, width(w)
+	, height(h)
 {
-	bool msaaEnabled = (msaaSamplesSwapchain != vk::SampleCountFlagBits::e1);
+#if defined(WZ_DEBUG_GFX_API_LEAKS)
+	debugName = filename;
+#endif
 
-	auto attachments =
-		std::vector<vk::AttachmentDescription>{
-		vk::AttachmentDescription() // colorAttachment
-			.setFormat(swapchainFormat)
-			.setSamples(msaaSamplesSwapchain)
-			.setInitialLayout(vk::ImageLayout::eUndefined)
-			.setFinalLayout((msaaEnabled) ? vk::ImageLayout::eColorAttachmentOptimal : vk::ImageLayout::ePresentSrcKHR)
-			.setLoadOp(vk::AttachmentLoadOp::eClear)
-			.setStoreOp(vk::AttachmentStoreOp::eStore)
-//			.setStencilLoadOp(vk::AttachmentLoadOp::eClear) // ?
-			.setStencilStoreOp(vk::AttachmentStoreOp::eStore),
-		vk::AttachmentDescription() // depthAttachment
-			.setFormat(depthFormat)
-			.setSamples(msaaSamplesSwapchain)
-			.setInitialLayout(vk::ImageLayout::eDepthStencilAttachmentOptimal)
-			.setFinalLayout(vk::ImageLayout::eDepthStencilAttachmentOptimal)
-			.setLoadOp(vk::AttachmentLoadOp::eClear)
-			.setStoreOp(vk::AttachmentStoreOp::eDontCare)
-			.setStencilLoadOp(vk::AttachmentLoadOp::eClear)
-			.setStencilStoreOp(vk::AttachmentStoreOp::eDontCare)
-	};
-	if (msaaEnabled)
+	createDepthStencilImage(root.physicalDevice, root.memprops, root.dev,
+		vk::Extent2D(w, h), vk::SampleCountFlagBits::e1, format,
+		image, memory, view, root.vkDynLoader, filename.c_str(), true);
+
+	const auto depthSampleViewCreateInfo = vk::ImageViewCreateInfo()
+		.setImage(image)
+		.setViewType(vk::ImageViewType::e2D)
+		.setFormat(format)
+		.setComponents(vk::ComponentMapping())
+		.setSubresourceRange(vk::ImageSubresourceRange(vk::ImageAspectFlagBits::eDepth, 0, 1, 0, 1));
+	depthSampleView = dev.createImageView(depthSampleViewCreateInfo, nullptr, root.vkDynLoader);
+}
+
+VkTransientDepthStencilImage::~VkTransientDepthStencilImage()
+{
+	if (buffering_mechanism::isInitialized())
 	{
-		attachments.push_back(
-			  vk::AttachmentDescription() // colorAttachmentResolve
-			  .setFormat(swapchainFormat)
-			  .setSamples(vk::SampleCountFlagBits::e1)
-			  .setInitialLayout(vk::ImageLayout::eUndefined)
-			  .setFinalLayout(vk::ImageLayout::ePresentSrcKHR)
-			  .setLoadOp(vk::AttachmentLoadOp::eDontCare)
-			  .setStoreOp(vk::AttachmentStoreOp::eStore)
-			  .setStencilLoadOp(vk::AttachmentLoadOp::eDontCare)
-			  .setStencilStoreOp(vk::AttachmentStoreOp::eDontCare)
-		);
-	}
-	const size_t numColorAttachmentRef = 1;
-	const auto colorAttachmentRef =
-		std::array<vk::AttachmentReference, numColorAttachmentRef>{
-		vk::AttachmentReference()
-			.setAttachment(0)
-			.setLayout(vk::ImageLayout::eColorAttachmentOptimal)
-	};
-	static_assert(minRequired_ColorAttachments >= numColorAttachmentRef, "minRequired_ColorAttachments must be >= colorAttachmentRef.size()");
-	const auto depthStencilAttachmentRef =
-		vk::AttachmentReference()
-		.setAttachment(1)
-		.setLayout(vk::ImageLayout::eDepthStencilAttachmentOptimal);
-	const auto colorAttachmentResolveRef =
-		vk::AttachmentReference()
-		.setAttachment(2)
-		.setLayout(vk::ImageLayout::eColorAttachmentOptimal);
-
-	const auto subpasses =
-		std::array<vk::SubpassDescription, 1> {
-		vk::SubpassDescription()
-			.setPipelineBindPoint(vk::PipelineBindPoint::eGraphics)
-			.setColorAttachmentCount(static_cast<uint32_t>(colorAttachmentRef.size()))
-			.setPColorAttachments(colorAttachmentRef.data())
-			.setPDepthStencilAttachment(&depthStencilAttachmentRef)
-			.setPResolveAttachments((msaaEnabled) ? &colorAttachmentResolveRef : nullptr)
-	};
-
-	VkSubpassDependency dependency = {};
-	dependency.srcSubpass = VK_SUBPASS_EXTERNAL;
-	dependency.dstSubpass = 0;
-	dependency.srcStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
-	dependency.srcAccessMask = 0;
-	dependency.dstStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
-	dependency.dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_READ_BIT | VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
-	dependency.dependencyFlags = 0;
-
-	auto createInfo = vk::RenderPassCreateInfo()
-		.setAttachmentCount(static_cast<uint32_t>(attachments.size()))
-		.setPAttachments(attachments.data())
-		.setSubpassCount(static_cast<uint32_t>(subpasses.size()))
-		.setPSubpasses(subpasses.data())
-		.setDependencyCount(1)
-		.setPDependencies((vk::SubpassDependency *)&dependency);
-
-	renderPasses[DEFAULT_RENDER_PASS_ID].rp_compat_info = std::make_shared<VkhRenderPassCompat>(createInfo);
-	renderPasses[DEFAULT_RENDER_PASS_ID].rp = dev.createRenderPass(createInfo, nullptr, vkDynLoader);
-	renderPasses[DEFAULT_RENDER_PASS_ID].msaaSamples = msaaSamplesSwapchain;
-
-	// createFramebuffers for default render pass
-	ASSERT(!swapchainImageView.empty(), "No swapchain image views?");
-	try {
-		std::transform(swapchainImageView.begin(), swapchainImageView.end(), std::back_inserter(renderPasses[DEFAULT_RENDER_PASS_ID].fbo),
-				   [&](const vk::ImageView& imageView) {
-					   const auto attachments = (msaaEnabled) ? std::vector<vk::ImageView>{colorImageView, depthStencilView, imageView}
-																: std::vector<vk::ImageView>{imageView, depthStencilView};
-					   return dev.createFramebuffer(
-													vk::FramebufferCreateInfo()
-													.setAttachmentCount(static_cast<uint32_t>(attachments.size()))
-													.setPAttachments(attachments.data())
-													.setLayers(1)
-													.setWidth(swapchainSize.width)
-													.setHeight(swapchainSize.height)
-													.setRenderPass(renderPasses[DEFAULT_RENDER_PASS_ID].rp)
-													, nullptr, vkDynLoader);
-				   });
-	}
-	catch (const vk::OutOfHostMemoryError& e) {
-		debug(LOG_ERROR, "vkCreateFramebuffer: OutOfHostMemoryError: %s", e.what());
-		throw;
-	}
-	catch (const vk::OutOfDeviceMemoryError& e) {
-		debug(LOG_ERROR, "vkCreateFramebuffer: OutOfDeviceMemoryError: %s", e.what());
-		throw;
+		auto& frameResources = buffering_mechanism::get_current_resources();
+		if (view)
+		{
+			frameResources.image_view_to_delete.emplace_back(view);
+			view = vk::ImageView();
+		}
+		if (depthSampleView)
+		{
+			frameResources.image_view_to_delete.emplace_back(depthSampleView);
+			depthSampleView = vk::ImageView();
+		}
+		if (image)
+		{
+			frameResources.image_to_delete.emplace_back(image);
+			image = vk::Image();
+		}
+		if (memory)
+		{
+			frameResources.devicememory_to_free.emplace_back(memory);
+			memory = vk::DeviceMemory();
+		}
 	}
 }
 
-void VkRoot::createDepthPassImagesAndFBOs(vk::Format depthFormat)
+void VkTransientDepthStencilImage::bind() { }
+
+size_t VkTransientDepthStencilImage::backend_internal_value() const
 {
-	// destroy depth pass objects
-	auto& frameResources = buffering_mechanism::get_current_resources();
-	for (auto f : renderPasses[DEPTH_RENDER_PASS_ID].fbo)
+	return static_cast<size_t>(VulkanBackendInternalTextureType::TransientDepthStencil);
+}
+
+void VkRoot::destroySwapchainPipelineSurfaces()
+{
+	_pipelineSurfaces.invalidateSurface(gfx_api::PipelineSurfaceId::SwapchainColor);
+	_pipelineSurfaces.invalidateSurface(gfx_api::PipelineSurfaceId::SwapchainMSAAColor);
+	_pipelineSurfaces.invalidateSurface(gfx_api::PipelineSurfaceId::SwapchainDepth);
+	_swapchainColorSurface.reset();
+	_swapchainMsaaColorSurface.reset();
+	_swapchainDepthSurface.reset();
+}
+
+void VkRoot::registerSwapchainPipelineSurfaces(vk::Format colorFormat, vk::Format depthFormat)
+{
+	destroySwapchainPipelineSurfaces();
+
+	_swapchainColorSurface = std::make_unique<VkSwapchainColorSurface>(*this, colorFormat);
+	_pipelineSurfaces.registerSurface(gfx_api::PipelineSurfaceId::SwapchainColor, _swapchainColorSurface.get());
+
+	_swapchainDepthSurface = std::make_unique<VkSwapchainDepthSurface>(*this, depthFormat, msaaSamplesSwapchain);
+	_pipelineSurfaces.registerSurface(gfx_api::PipelineSurfaceId::SwapchainDepth, _swapchainDepthSurface.get());
+	const uint32_t swapchainDepthSamples = static_cast<uint32_t>(msaaSamplesSwapchain);
+	_pipelineSurfaces.setSurfaceSamples(gfx_api::PipelineSurfaceId::SwapchainDepth, swapchainDepthSamples);
+
+	if (msaaSamplesSwapchain != vk::SampleCountFlagBits::e1)
 	{
-		// Queue for future deletion
-		frameResources.fbo_to_delete.emplace_back(f);
+		_swapchainMsaaColorSurface = std::make_unique<VkSwapchainMsaaColorSurface>(*this, colorFormat, msaaSamplesSwapchain);
+		_pipelineSurfaces.registerSurface(gfx_api::PipelineSurfaceId::SwapchainMSAAColor, _swapchainMsaaColorSurface.get());
+		_pipelineSurfaces.setSurfaceSamples(gfx_api::PipelineSurfaceId::SwapchainMSAAColor, swapchainDepthSamples);
 	}
-	renderPasses[DEPTH_RENDER_PASS_ID].fbo.clear();
+}
+
+void VkRoot::createDepthPassImages(vk::Format depthFormat)
+{
+	clearFramebufferCache();
+
+	auto& frameResources = buffering_mechanism::get_current_resources();
 	for (auto& imageView : depthMapCascadeView)
 	{
 		if (buffering_mechanism::isInitialized())
@@ -2997,6 +3106,7 @@ void VkRoot::createDepthPassImagesAndFBOs(vk::Format depthFormat)
 	depthMapCascadeView.clear();
 	if (pDepthMapImage)
 	{
+		_pipelineSurfaces.invalidateSurface(gfx_api::PipelineSurfaceId::ShadowMap);
 		// Destructor will automatically queue resources for future deletion once they are unused
 		delete pDepthMapImage;
 		pDepthMapImage = nullptr;
@@ -3010,6 +3120,7 @@ void VkRoot::createDepthPassImagesAndFBOs(vk::Format depthFormat)
 	// Create depth map image + view
 	size_t numCascadeLayers = depthPassCount;
 	pDepthMapImage = new VkDepthMapImage(*this, numCascadeLayers, depthMapSize, depthFormat, "<depth map>");
+	_pipelineSurfaces.registerSurface(gfx_api::PipelineSurfaceId::ShadowMap, pDepthMapImage);
 
 	// For each depth pass (cascade)
 	for (size_t i = 0; i < numCascadeLayers; ++i)
@@ -3036,115 +3147,19 @@ void VkRoot::createDepthPassImagesAndFBOs(vk::Format depthFormat)
 			dev.setDebugUtilsObjectNameEXT(objectNameInfo, vkDynLoader);
 		}
 
-		// FBO for this image view + layer
-		auto cascade_fbo = dev.createFramebuffer(
-			vk::FramebufferCreateInfo()
-			.setAttachmentCount(1)
-			.setPAttachments(&non_unique_imageview_ref)
-			.setLayers(1)
-			.setWidth(depthMapSize)
-			.setHeight(depthMapSize)
-			.setRenderPass(renderPasses[DEPTH_RENDER_PASS_ID].rp)
-			, nullptr, vkDynLoader);
-
 		depthMapCascadeView.push_back(std::move(cascade_view));
-
-		if (debugUtilsExtEnabled)
-		{
-			std::string framebufferName = "<depth cascade frame buffer: " + std::to_string(i) + ">";
-			vk::DebugUtilsObjectNameInfoEXT objectNameInfo;
-			objectNameInfo.setObjectType(vk::ObjectType::eFramebuffer);
-			objectNameInfo.setObjectHandle(uint64_t(static_cast<VkFramebuffer>(cascade_fbo)));
-			objectNameInfo.setPObjectName(framebufferName.c_str());
-			dev.setDebugUtilsObjectNameEXT(objectNameInfo, vkDynLoader);
-		}
-
-		renderPasses[DEPTH_RENDER_PASS_ID].fbo.push_back(cascade_fbo);
 	}
-}
-
-void VkRoot::createDepthPasses(vk::Format depthFormat)
-{
-	auto attachments =
-		std::vector<vk::AttachmentDescription>{
-		vk::AttachmentDescription() // depthAttachment
-			.setFormat(depthFormat)
-			.setSamples(vk::SampleCountFlagBits::e1)
-			.setInitialLayout(vk::ImageLayout::eUndefined)
-			.setFinalLayout(vk::ImageLayout::eDepthStencilReadOnlyOptimal)
-			.setLoadOp(vk::AttachmentLoadOp::eClear)
-			.setStoreOp(vk::AttachmentStoreOp::eStore)
-			.setStencilLoadOp(vk::AttachmentLoadOp::eDontCare)
-			.setStencilStoreOp(vk::AttachmentStoreOp::eDontCare)
-	};
-	const auto depthAttachmentRef =
-		vk::AttachmentReference()
-		.setAttachment(0)
-		.setLayout(vk::ImageLayout::eDepthStencilAttachmentOptimal);
-
-	const auto subpasses =
-		std::array<vk::SubpassDescription, 1> {
-		vk::SubpassDescription()
-			.setPipelineBindPoint(vk::PipelineBindPoint::eGraphics)
-			.setColorAttachmentCount(0)
-			.setPDepthStencilAttachment(&depthAttachmentRef)
-	};
-
-	std::array<vk::SubpassDependency, 2> dependencies {
-		vk::SubpassDependency()
-			.setSrcSubpass(VK_SUBPASS_EXTERNAL)
-			.setDstSubpass(0)
-			.setSrcStageMask(vk::PipelineStageFlagBits::eFragmentShader)
-			.setDstStageMask(vk::PipelineStageFlagBits::eEarlyFragmentTests)
-			.setSrcAccessMask(vk::AccessFlagBits::eShaderRead)
-			.setDstAccessMask(vk::AccessFlagBits::eDepthStencilAttachmentWrite)
-			.setDependencyFlags(vk::DependencyFlagBits::eByRegion)
-		, vk::SubpassDependency()
-			.setSrcSubpass(0)
-			.setDstSubpass(VK_SUBPASS_EXTERNAL)
-			.setSrcStageMask(vk::PipelineStageFlagBits::eLateFragmentTests)
-			.setDstStageMask(vk::PipelineStageFlagBits::eFragmentShader)
-			.setSrcAccessMask(vk::AccessFlagBits::eDepthStencilAttachmentWrite)
-			.setDstAccessMask(vk::AccessFlagBits::eShaderRead)
-			.setDependencyFlags(vk::DependencyFlagBits::eByRegion)
-	};
-
-	auto createInfo = vk::RenderPassCreateInfo()
-		.setAttachmentCount(static_cast<uint32_t>(attachments.size()))
-		.setPAttachments(attachments.data())
-		.setSubpassCount(static_cast<uint32_t>(subpasses.size()))
-		.setPSubpasses(subpasses.data())
-		.setDependencyCount(static_cast<uint32_t>(dependencies.size()))
-		.setPDependencies(dependencies.data());
-
-	renderPasses[DEPTH_RENDER_PASS_ID].rp_compat_info = std::make_shared<VkhRenderPassCompat>(createInfo);
-	renderPasses[DEPTH_RENDER_PASS_ID].rp = dev.createRenderPass(createInfo, nullptr, vkDynLoader);
-	renderPasses[DEPTH_RENDER_PASS_ID].msaaSamples = vk::SampleCountFlagBits::e1;
-
-	if (debugUtilsExtEnabled)
-	{
-		std::string renderpassName = "<depth map render pass>";
-		vk::DebugUtilsObjectNameInfoEXT objectNameInfo;
-		objectNameInfo.setObjectType(vk::ObjectType::eRenderPass);
-		objectNameInfo.setObjectHandle(uint64_t(static_cast<VkRenderPass>(renderPasses[DEPTH_RENDER_PASS_ID].rp)));
-		objectNameInfo.setPObjectName(renderpassName.c_str());
-		dev.setDebugUtilsObjectNameEXT(objectNameInfo, vkDynLoader);
-	}
-
-	createDepthPassImagesAndFBOs(depthFormat);
 }
 
 void VkRoot::destroySceneRenderpass()
 {
-	// destroy scene pass objects
-	if (SCENE_RENDER_PASS_ID < renderPasses.size())
-	{
-		for (auto f : renderPasses[SCENE_RENDER_PASS_ID].fbo)
-		{
-			dev.destroyFramebuffer(f, nullptr, vkDynLoader);
-		}
-		renderPasses[SCENE_RENDER_PASS_ID].fbo.clear();
-	}
+	clearFramebufferCache();
+
+	_pipelineSurfaces.invalidateSurface(gfx_api::PipelineSurfaceId::SceneColor);
+	_pipelineSurfaces.invalidateSurface(gfx_api::PipelineSurfaceId::SceneMSAAColor);
+	_pipelineSurfaces.invalidateSurface(gfx_api::PipelineSurfaceId::SceneDepth);
+	_sceneDepthSurface.reset();
+	_sceneMsaaSurface.reset();
 
 	if (sceneDepthStencilView)
 	{
@@ -3184,138 +3199,15 @@ void VkRoot::destroySceneRenderpass()
 		delete pSceneImage;
 		pSceneImage = nullptr;
 	}
-	if ((SCENE_RENDER_PASS_ID < renderPasses.size()) && renderPasses[SCENE_RENDER_PASS_ID].rp)
-	{
-		dev.destroyRenderPass(renderPasses[SCENE_RENDER_PASS_ID].rp, nullptr, vkDynLoader);
-		renderPasses[SCENE_RENDER_PASS_ID].rp = vk::RenderPass();
-	}
 }
 
 // throws a vk::SystemError on an unrecoverable error (like OOM)
 void VkRoot::createSceneRenderpass(vk::Format sceneFormat, vk::Format depthFormat)
 {
-	bool msaaEnabled = (msaaSamples != vk::SampleCountFlagBits::e1);
+	const bool msaaEnabled = (msaaSamples != vk::SampleCountFlagBits::e1);
 
-	auto attachments = std::vector<vk::AttachmentDescription>();
-
-	auto appendDepthAttachment = [&]() {
-		attachments.push_back(
-			  vk::AttachmentDescription() // depthStencilAttachment
-			  .setFormat(depthFormat)
-			  .setSamples(msaaSamples)
-			  .setInitialLayout(vk::ImageLayout::eUndefined)
-			  .setFinalLayout(vk::ImageLayout::eDepthStencilAttachmentOptimal)
-			  .setLoadOp(vk::AttachmentLoadOp::eClear)
-			  .setStoreOp(vk::AttachmentStoreOp::eDontCare)
-			  .setStencilLoadOp(vk::AttachmentLoadOp::eClear)
-			  .setStencilStoreOp(vk::AttachmentStoreOp::eDontCare)
-		);
-	};
-
-	if (msaaEnabled)
-	{
-		// first attachment is the msaa render buffer as the color attachment
-		attachments.push_back(
-			  vk::AttachmentDescription() // msaa color buffer
-			  .setFormat(sceneFormat)
-			  .setSamples(msaaSamples)
-			  .setInitialLayout(vk::ImageLayout::eUndefined)
-			  .setFinalLayout(vk::ImageLayout::eColorAttachmentOptimal)
-			  .setLoadOp(vk::AttachmentLoadOp::eClear)
-			  .setStoreOp(vk::AttachmentStoreOp::eStore)
-			  .setStencilLoadOp(vk::AttachmentLoadOp::eDontCare)
-			  .setStencilStoreOp(vk::AttachmentStoreOp::eDontCare)
-		);
-
-		appendDepthAttachment(); // should always be second
-	}
-
-	attachments.push_back(
-		  vk::AttachmentDescription() // color (resolved) texture
-		  .setFormat(sceneFormat)
-		  .setSamples(vk::SampleCountFlagBits::e1)
-		  .setInitialLayout(vk::ImageLayout::eUndefined)
-		  .setFinalLayout(vk::ImageLayout::eShaderReadOnlyOptimal)
-		  .setLoadOp((msaaEnabled) ? vk::AttachmentLoadOp::eDontCare : vk::AttachmentLoadOp::eClear)
-		  .setStoreOp(vk::AttachmentStoreOp::eStore)
-		  .setStencilLoadOp(vk::AttachmentLoadOp::eDontCare)
-		  .setStencilStoreOp(vk::AttachmentStoreOp::eDontCare)
-	);
-
-	if (!msaaEnabled)
-	{
-		appendDepthAttachment(); // should always be second
-	}
-
-	const size_t numColorAttachmentRef = 1;
-	const auto colorAttachmentRef =
-		std::array<vk::AttachmentReference, numColorAttachmentRef>{
-		vk::AttachmentReference()
-			.setAttachment(0)
-			.setLayout(vk::ImageLayout::eColorAttachmentOptimal)
-	};
-	static_assert(minRequired_ColorAttachments >= numColorAttachmentRef, "minRequired_ColorAttachments must be >= colorAttachmentRef.size()");
-	const auto depthStencilAttachmentRef =
-		vk::AttachmentReference()
-		.setAttachment(1)
-		.setLayout(vk::ImageLayout::eDepthStencilAttachmentOptimal);
-	const auto colorAttachmentResolveRef =
-		vk::AttachmentReference()
-		.setAttachment(2)
-		.setLayout(vk::ImageLayout::eColorAttachmentOptimal);
-
-	const auto subpasses =
-		std::array<vk::SubpassDescription, 1> {
-		vk::SubpassDescription()
-			.setPipelineBindPoint(vk::PipelineBindPoint::eGraphics)
-			.setColorAttachmentCount(static_cast<uint32_t>(colorAttachmentRef.size()))
-			.setPColorAttachments(colorAttachmentRef.data())
-			.setPDepthStencilAttachment(&depthStencilAttachmentRef)
-			.setPResolveAttachments((msaaEnabled) ? &colorAttachmentResolveRef : nullptr)
-	};
-
-	std::array<vk::SubpassDependency, 2> dependencies {
-		vk::SubpassDependency()
-			.setSrcSubpass(VK_SUBPASS_EXTERNAL)
-			.setDstSubpass(0)
-			.setSrcStageMask(vk::PipelineStageFlagBits::eColorAttachmentOutput | vk::PipelineStageFlagBits::eLateFragmentTests)
-			.setDstStageMask(vk::PipelineStageFlagBits::eColorAttachmentOutput | vk::PipelineStageFlagBits::eEarlyFragmentTests)
-			.setSrcAccessMask(vk::AccessFlagBits::eColorAttachmentWrite | vk::AccessFlagBits::eDepthStencilAttachmentWrite)
-			.setDstAccessMask(vk::AccessFlagBits::eColorAttachmentWrite | vk::AccessFlagBits::eDepthStencilAttachmentWrite | vk::AccessFlagBits::eDepthStencilAttachmentRead)
-			.setDependencyFlags(vk::DependencyFlagBits::eByRegion)
-		, vk::SubpassDependency()
-			.setSrcSubpass(0)
-			.setDstSubpass(VK_SUBPASS_EXTERNAL)
-			.setSrcStageMask(vk::PipelineStageFlagBits::eColorAttachmentOutput)
-			.setDstStageMask(vk::PipelineStageFlagBits::eFragmentShader)
-			.setSrcAccessMask(vk::AccessFlagBits::eColorAttachmentWrite)
-			.setDstAccessMask(vk::AccessFlagBits::eShaderRead)
-			.setDependencyFlags(vk::DependencyFlagBits::eByRegion)
-	};
-
-	auto createInfo = vk::RenderPassCreateInfo()
-		.setAttachmentCount(static_cast<uint32_t>(attachments.size()))
-		.setPAttachments(attachments.data())
-		.setSubpassCount(static_cast<uint32_t>(subpasses.size()))
-		.setPSubpasses(subpasses.data())
-		.setDependencyCount(static_cast<uint32_t>(dependencies.size()))
-		.setPDependencies(dependencies.data());
-
-	renderPasses[SCENE_RENDER_PASS_ID].rp_compat_info = std::make_shared<VkhRenderPassCompat>(createInfo);
-	renderPasses[SCENE_RENDER_PASS_ID].rp = dev.createRenderPass(createInfo, nullptr, vkDynLoader);
-	renderPasses[SCENE_RENDER_PASS_ID].msaaSamples = msaaSamples;
-
-	if (debugUtilsExtEnabled)
-	{
-		std::string renderpassName = "<scene render pass>";
-		vk::DebugUtilsObjectNameInfoEXT objectNameInfo;
-		objectNameInfo.setObjectType(vk::ObjectType::eRenderPass);
-		objectNameInfo.setObjectHandle(uint64_t(static_cast<VkRenderPass>(renderPasses[SCENE_RENDER_PASS_ID].rp)));
-		objectNameInfo.setPObjectName(renderpassName.c_str());
-		dev.setDebugUtilsObjectNameEXT(objectNameInfo, vkDynLoader);
-	}
-
-	// Create scene image + view
+	// Create scene color/depth (and optional MSAA) images and register pipeline surfaces.
+	// VkRenderPass objects are created later by RenderPassLayoutCache::getOrCreate via beginPass / warmCompiledRenderGraph.
 	pSceneImage = new VkRenderedImage(*this, swapchainSize.width, swapchainSize.height, sceneFormat, "<scene image>");
 
 	if (msaaEnabled)
@@ -3343,34 +3235,23 @@ void VkRoot::createSceneRenderpass(vk::Format sceneFormat, vk::Format depthForma
 		throw;
 	}
 
-	// Create an FBO for each frame in flight
-	size_t numSceneFBOs = buffering_mechanism::numFrames();
-	const auto fboAttachments = (msaaEnabled) ? std::vector<vk::ImageView>{sceneMSAAView, sceneDepthStencilView, pSceneImage->view.get()}
-											 : std::vector<vk::ImageView>{pSceneImage->view.get(), sceneDepthStencilView};
-	for (size_t i = 0; i < numSceneFBOs; ++i)
+	_sceneDepthSurface = std::make_unique<VkAttachmentImage>(sceneDepthStencilImage, sceneDepthStencilView, depthFormat,
+		swapchainSize.width, swapchainSize.height, msaaSamples, "<scene depth stencil>");
+	_pipelineSurfaces.registerSurface(gfx_api::PipelineSurfaceId::SceneColor, pSceneImage);
+	_pipelineSurfaces.registerSurface(gfx_api::PipelineSurfaceId::SceneDepth, _sceneDepthSurface.get());
+	const uint32_t sceneSamples = static_cast<uint32_t>(msaaSamples);
+	_pipelineSurfaces.setSurfaceSamples(gfx_api::PipelineSurfaceId::SceneDepth, sceneSamples);
+	if (msaaEnabled)
 	{
-		// FBO for this frame in flight
-		auto frame_fbo = dev.createFramebuffer(
-			vk::FramebufferCreateInfo()
-			.setAttachmentCount(static_cast<uint32_t>(fboAttachments.size()))
-			.setPAttachments(fboAttachments.data())
-			.setLayers(1)
-			.setWidth(swapchainSize.width)
-			.setHeight(swapchainSize.height)
-			.setRenderPass(renderPasses[SCENE_RENDER_PASS_ID].rp)
-			, nullptr, vkDynLoader);
-
-		if (debugUtilsExtEnabled)
-		{
-			std::string framebufferName = "<scene frame buffer: " + std::to_string(i) + ">";
-			vk::DebugUtilsObjectNameInfoEXT objectNameInfo;
-			objectNameInfo.setObjectType(vk::ObjectType::eFramebuffer);
-			objectNameInfo.setObjectHandle(uint64_t(static_cast<VkFramebuffer>(frame_fbo)));
-			objectNameInfo.setPObjectName(framebufferName.c_str());
-			dev.setDebugUtilsObjectNameEXT(objectNameInfo, vkDynLoader);
-		}
-
-		renderPasses[SCENE_RENDER_PASS_ID].fbo.push_back(frame_fbo);
+		_sceneMsaaSurface = std::make_unique<VkAttachmentImage>(sceneMSAAImage, sceneMSAAView, sceneFormat,
+			swapchainSize.width, swapchainSize.height, msaaSamples, "<scene msaa color>");
+		_pipelineSurfaces.registerSurface(gfx_api::PipelineSurfaceId::SceneMSAAColor, _sceneMsaaSurface.get());
+		_pipelineSurfaces.setSurfaceSamples(gfx_api::PipelineSurfaceId::SceneMSAAColor, sceneSamples);
+	}
+	else
+	{
+		_sceneMsaaSurface.reset();
+		_pipelineSurfaces.invalidateSurface(gfx_api::PipelineSurfaceId::SceneMSAAColor);
 	}
 }
 
@@ -3903,12 +3784,28 @@ std::pair<uint32_t, uint32_t> VkRoot::getDrawableDimensions()
 
 bool VkRoot::shouldDraw()
 {
-	return swapchainSize.width > 1 && swapchainSize.height > 1; // check for > 1 here because we use 1,1 in place of a 0,0 swapchain size to avoid other issues
+	// check for > 1 here because we use 1,1 in place of a 0,0 swapchain size to avoid other issues
+	return static_cast<bool>(swapchain)
+		&& swapchainSize.width > 1
+		&& swapchainSize.height > 1;
+}
+
+bool VkRoot::canRecordDrawCommands() const
+{
+	return renderGraphExecuting() && hasActivePass;
 }
 
 
 void VkRoot::shutdown()
 {
+	_frameResourceCache.clear([this](gfx_api::abstract_texture* texture) {
+		if (texture != nullptr)
+		{
+			_frameLayoutTracker.erase(texture);
+		}
+	});
+	clearFramebufferCache();
+
 	destroySwapchainAndSwapchainSpecificStuff(true);
 
 	if (dev)
@@ -3925,26 +3822,13 @@ void VkRoot::shutdown()
 		}
 		createdPipelines.clear();
 
-		// destroy depth pass objects
-		if (DEPTH_RENDER_PASS_ID < renderPasses.size())
-		{
-			for (auto f : renderPasses[DEPTH_RENDER_PASS_ID].fbo)
-			{
-				dev.destroyFramebuffer(f, nullptr, vkDynLoader);
-			}
-			renderPasses[DEPTH_RENDER_PASS_ID].fbo.clear();
-		}
 		depthMapCascadeView.clear();
 		if (pDepthMapImage)
 		{
+			_pipelineSurfaces.invalidateSurface(gfx_api::PipelineSurfaceId::ShadowMap);
 			pDepthMapImage->destroy(dev, allocator, vkDynLoader); // because the buffering_mechanism is gone at this point...
 			delete pDepthMapImage;
 			pDepthMapImage = nullptr;
-		}
-		if ((DEPTH_RENDER_PASS_ID < renderPasses.size()) && renderPasses[DEPTH_RENDER_PASS_ID].rp)
-		{
-			dev.destroyRenderPass(renderPasses[DEPTH_RENDER_PASS_ID].rp, nullptr, vkDynLoader);
-			renderPasses[DEPTH_RENDER_PASS_ID].rp = vk::RenderPass();
 		}
 
 		// destroy default depth map texture
@@ -4033,6 +3917,52 @@ void VkRoot::waitForAllIdle()
 	dev.waitIdle(vkDynLoader);
 }
 
+void VkRoot::finalizeActiveRecording()
+{
+	if (!dev || !buffering_mechanism::isInitialized())
+	{
+		hasActivePass = false;
+		_activePassTargetsSwapchain = false;
+		frameHasDrawCommands = false;
+		currentPSO = nullptr;
+		currentRenderPassId = INVALID_RENDER_PASS_ID;
+		return;
+	}
+
+	auto& frameResources = buffering_mechanism::get_current_resources();
+
+	if (hasActivePass)
+	{
+		if (frameResources.drawCmdBufferBegun)
+		{
+			frameResources.drawCmdBuffer().endRenderPass(vkDynLoader);
+		}
+		_activeDynamicFramebuffer = vk::Framebuffer();
+
+		if (_activePassTargetsSwapchain)
+		{
+			_frameLayoutTracker.noteSwapchainWrite();
+		}
+
+		// Teardown may occur on legacy path (compiledPass unknown); commit is no-op if empty.
+		_legacyPassLayoutCommit.commitTo(_frameLayoutTracker);
+
+		if (_activePassTargetsSwapchain && _swapchainColorSurface != nullptr)
+		{
+			setImageLayout(_swapchainColorSurface.get(), vk::ImageLayout::eColorAttachmentOptimal);
+		}
+	}
+
+	hasActivePass = false;
+	_activePassTargetsSwapchain = false;
+	frameHasDrawCommands = false;
+	currentPSO = nullptr;
+	currentRenderPassId = INVALID_RENDER_PASS_ID;
+
+	frameResources.endDrawCmdBufferIfRecording();
+	frameResources.endCopyCmdBufferIfRecording();
+}
+
 void VkRoot::destroySwapchainAndSwapchainSpecificStuff(bool doDestroySwapchain)
 {
 	if (!dev)
@@ -4041,7 +3971,9 @@ void VkRoot::destroySwapchainAndSwapchainSpecificStuff(bool doDestroySwapchain)
 		return;
 	}
 
+	finalizeActiveRecording();
 	waitForAllIdle();
+	destroyDynamicRenderPasses();
 
 	if (pDefaultTexture)
 	{
@@ -4058,14 +3990,8 @@ void VkRoot::destroySwapchainAndSwapchainSpecificStuff(bool doDestroySwapchain)
 
 	buffering_mechanism::destroy(dev, vkDynLoader);
 
-	if (DEFAULT_RENDER_PASS_ID < renderPasses.size())
-	{
-		for (auto f : renderPasses[DEFAULT_RENDER_PASS_ID].fbo)
-		{
-			dev.destroyFramebuffer(f, nullptr, vkDynLoader);
-		}
-		renderPasses[DEFAULT_RENDER_PASS_ID].fbo.clear();
-	}
+	destroySwapchainPipelineSurfaces();
+	resetImageLayoutTracker();
 
 	if (depthStencilView)
 	{
@@ -4099,23 +4025,24 @@ void VkRoot::destroySwapchainAndSwapchainSpecificStuff(bool doDestroySwapchain)
 		colorImage = vk::Image();
 	}
 
-	if ((DEFAULT_RENDER_PASS_ID < renderPasses.size()) && renderPasses[DEFAULT_RENDER_PASS_ID].rp)
-	{
-		dev.destroyRenderPass(renderPasses[DEFAULT_RENDER_PASS_ID].rp, nullptr, vkDynLoader);
-		renderPasses[DEFAULT_RENDER_PASS_ID].rp = vk::RenderPass();
-	}
-
 	for (auto& imgview : swapchainImageView)
 	{
 		dev.destroyImageView(imgview, nullptr, vkDynLoader);
 	}
 	swapchainImageView.clear();
+	swapchainImages.clear();
 
 	if(doDestroySwapchain && swapchain)
 	{
 		dev.destroySwapchainKHR(swapchain, nullptr, vkDynLoader);
 		swapchain = vk::SwapchainKHR();
 	}
+
+	// Swapchain resources are gone; mark the drawable invalid so shouldDraw() and game
+	// code skip recording until createSwapchain() restores a live swapchain.
+	swapchainSize = vk::Extent2D{1, 1};
+	_legacyFrameStarted = false;
+	setRenderGraphExecuting(false);
 }
 
 // recreate surface + swapchain
@@ -4571,7 +4498,7 @@ void VkRoot::createSwapchain(bool allowHandleSurfaceLost)
 	}
 
 	// createSwapchainImageViews
-	std::vector<vk::Image> swapchainImages = dev.getSwapchainImagesKHR(swapchain, vkDynLoader);
+	swapchainImages = dev.getSwapchainImagesKHR(swapchain, vkDynLoader);
 	debug(LOG_3D, "Requested swapchain minImageCount: %" PRIu32", received: %zu", swapchainDesiredImageCount, swapchainImages.size());
 	try {
 		std::transform(swapchainImages.begin(), swapchainImages.end(), std::back_inserter(swapchainImageView),
@@ -4628,6 +4555,8 @@ void VkRoot::createSwapchain(bool allowHandleSurfaceLost)
 		throw;
 	}
 
+	registerSwapchainPipelineSurfaces(surfaceFormat.format, depthFormat);
+
 	try {
 		setupSwapchainImages();
 	}
@@ -4638,18 +4567,8 @@ void VkRoot::createSwapchain(bool allowHandleSurfaceLost)
 		throw;
 	}
 
-	// create default render pass
-	try {
-		createDefaultRenderpass(surfaceFormat.format, depthFormat);
-	}
-	catch (const vk::SystemError &e) {
-		// Likely(?) possibilities: vk::OutOfHostMemoryError, vk::OutOfDeviceMemoryError
-		auto resultErr = static_cast<vk::Result>(e.code().value());
-		debug(LOG_ERROR, "vkCreateRenderPass (default): %s: %s", vk::to_string(resultErr).c_str(), e.what());
-		throw;
-	}
-
-	// Create scene FBOs + renderpass
+	// Dynamic passes: VkRenderPass instances are created on demand by RenderPassLayoutCache
+	// (via getOrCreatePassRenderPassId), typically from beginPass or warmCompiledRenderGraph.
 	vk::Format sceneFormat = findSceneColorBufferFormat(physicalDevice, vkDynLoader);
 	debug(LOG_3D, "Using scene color format: %s", to_string(sceneFormat).c_str());
 	try {
@@ -4658,7 +4577,7 @@ void VkRoot::createSwapchain(bool allowHandleSurfaceLost)
 	catch (const vk::SystemError &e) {
 		// Likely(?) possibilities: vk::OutOfHostMemoryError, vk::OutOfDeviceMemoryError
 		auto resultErr = static_cast<vk::Result>(e.code().value());
-		debug(LOG_ERROR, "vkCreateRenderPass (scene): %s: %s", vk::to_string(resultErr).c_str(), e.what());
+		debug(LOG_ERROR, "createSceneRenderpass (scene images): %s: %s", vk::to_string(resultErr).c_str(), e.what());
 		throw;
 	}
 
@@ -4700,7 +4619,7 @@ void VkRoot::createSwapchain(bool allowHandleSurfaceLost)
 	}
 	pDefaultArrayTexture->flush();
 
-	startRenderPass();
+	bootstrapLegacySwapchainPass();
 }
 
 static optional<uint32_t> getVKLargestDeviceLocalMemoryHeapIndex(const vk::PhysicalDeviceMemoryProperties& memprops)
@@ -5080,7 +4999,7 @@ bool VkRoot::_initialize(const gfx_api::backend_Impl_Factory& impl, int32_t anti
 	getQueues();
 
 	ASSERT(renderPasses.empty(), "Non-empty renderPasses vector?");
-	renderPasses = { RenderPassDetails(DEFAULT_RENDER_PASS_ID), RenderPassDetails(DEPTH_RENDER_PASS_ID), RenderPassDetails(SCENE_RENDER_PASS_ID) };
+	renderPasses.clear();
 
 	try {
 		createSwapchain(true);
@@ -5102,7 +5021,7 @@ bool VkRoot::_initialize(const gfx_api::backend_Impl_Factory& impl, int32_t anti
 		depthMapSize = getVKSuggestedDefaultDepthBufferResolution(physDeviceProps, memprops);
 	}
 
-	createDepthPasses(depthBufferFormat); // TODO: Handle failures?
+	createDepthPassImages(depthBufferFormat);
 
 	pDefaultDepthMapTexture = new VkDepthMapImage(*this, 1, 4, depthBufferFormat, "<default depth map>");
 	const auto imageMemoryBarriers_TransitionDefaultDepthImage = std::array<vk::ImageMemoryBarrier, 1> {
@@ -5452,6 +5371,9 @@ void VkRoot::getQueues()
 
 void VkRoot::draw(const std::size_t& offset, const std::size_t& count, const gfx_api::primitive_type&)
 {
+	ASSERT_OR_RETURN(, renderGraphExecuting() && hasActivePass,
+		"draw() called outside render graph record callback");
+
 	ASSERT(offset <= static_cast<size_t>(std::numeric_limits<uint32_t>::max()), "offset (%zu) exceeds uint32_t max", offset);
 	ASSERT(count <= static_cast<size_t>(std::numeric_limits<uint32_t>::max()), "count (%zu) exceeds uint32_t max", count);
 	buffering_mechanism::get_current_resources().currentDrawCmdBuffer()->draw(static_cast<uint32_t>(count), 1, static_cast<uint32_t>(offset), 0, vkDynLoader);
@@ -5466,6 +5388,8 @@ void VkRoot::draw_instanced(const std::size_t& offset, const std::size_t &count,
 
 void VkRoot::draw_elements(const std::size_t& offset, const std::size_t& count, const gfx_api::primitive_type&, const gfx_api::index_type&)
 {
+	ASSERT_OR_RETURN(, renderGraphExecuting() && hasActivePass,
+		"draw_elements() called outside render graph record callback");
 	ASSERT_OR_RETURN(, currentPSO != nullptr, "currentPSO == NULL");
 	ASSERT(offset <= static_cast<size_t>(std::numeric_limits<uint32_t>::max()), "offset (%zu) exceeds uint32_t max", offset);
 	ASSERT(count <= static_cast<size_t>(std::numeric_limits<uint32_t>::max()), "count (%zu) exceeds uint32_t max", count);
@@ -5755,6 +5679,7 @@ void VkRoot::bind_textures(const std::vector<gfx_api::texture_input>& attribute_
 	for (auto* texture : textures)
 	{
 		vk::ImageView imageView;
+		vk::ImageLayout imageLayout = vk::ImageLayout::eShaderReadOnlyOptimal;
 		if (texture != nullptr)
 		{
 			auto texture_type = static_cast<VulkanBackendInternalTextureType>(texture->backend_internal_value());
@@ -5776,6 +5701,20 @@ void VkRoot::bind_textures(const std::vector<gfx_api::texture_input>& attribute_
 				case VulkanBackendInternalTextureType::RenderedImage:
 					ASSERT(target_type == gfx_api::pixel_format_target::texture_2d, "Unexpected target type: (%d)", static_cast<int>(target_type));
 					imageView = static_cast<VkRenderedImage*>(texture)->view.get();
+					break;
+				case VulkanBackendInternalTextureType::AttachmentImage:
+					ASSERT(target_type == gfx_api::pixel_format_target::texture_2d, "Unexpected target type: (%d)", static_cast<int>(target_type));
+					imageView = static_cast<VkAttachmentImage*>(texture)->view;
+					break;
+				case VulkanBackendInternalTextureType::TransientDepthStencil:
+					ASSERT(target_type == gfx_api::pixel_format_target::texture_2d, "Unexpected target type: (%d)", static_cast<int>(target_type));
+					imageView = static_cast<VkTransientDepthStencilImage*>(texture)->depthSampleView;
+					imageLayout = vk::ImageLayout::eDepthStencilReadOnlyOptimal;
+					break;
+				case VulkanBackendInternalTextureType::SwapchainColorSurface:
+				case VulkanBackendInternalTextureType::SwapchainMsaaColorSurface:
+				case VulkanBackendInternalTextureType::SwapchainDepthSurface:
+					debug(LOG_FATAL, "Swapchain pipeline surfaces are not shader-sampled");
 					break;
 				case VulkanBackendInternalTextureType::Invalid:
 					debug(LOG_FATAL, "Invalid internal texture type??");
@@ -5799,7 +5738,6 @@ void VkRoot::bind_textures(const std::vector<gfx_api::texture_input>& attribute_
 			}
 		}
 
-		vk::ImageLayout imageLayout = vk::ImageLayout::eShaderReadOnlyOptimal;
 		switch (attribute_descriptions.at(i).target)
 		{
 			case gfx_api::pixel_format_target::texture_2d:
@@ -5903,6 +5841,9 @@ void VkRoot::set_uniforms(const size_t& first, const std::vector<std::tuple<cons
 
 void VkRoot::bind_pipeline(gfx_api::pipeline_state_object* pso, bool /*notextures*/)
 {
+	ASSERT_OR_RETURN(, renderGraphExecuting() && hasActivePass,
+		"bind_pipeline() called outside render graph record callback");
+
 	VkPSOId* newPSOId = static_cast<VkPSOId*>(pso);
 	// lookup PSO
 	auto& pipelineInfo = createdPipelines[newPSOId->psoID];
@@ -5997,70 +5938,492 @@ VkRoot::AcquireNextSwapchainImageResult VkRoot::acquireNextSwapchainImage(bool a
 	}
 
 	currentSwapchainIndex = acquireNextImageResult.value;
+	_frameLayoutTracker.beginFrame();
 	return AcquireNextSwapchainImageResult::eSuccess;
 }
 
-void VkRoot::beginSceneRenderPass()
+gfx_api::abstract_texture* VkRoot::getPipelineSurface(gfx_api::PipelineSurfaceId id)
 {
-	// There only needs to be a single scene RenderPass object
-	// What actually swaps out is the FBO used in the call to beginRenderPass
-	auto& sceneRenderPass = renderPasses[SCENE_RENDER_PASS_ID];
-
-	const auto clearValue = std::array<vk::ClearValue, 2> {
-		vk::ClearValue(), vk::ClearValue(vk::ClearDepthStencilValue(1.f, 0u))
-	};
-	buffering_mechanism::get_current_resources().scenePassDrawCmdBuffer().beginRenderPass(
-		vk::RenderPassBeginInfo()
-		.setFramebuffer(sceneRenderPass.fbo[buffering_mechanism::get_current_frame_num()])
-		.setClearValueCount(static_cast<uint32_t>(clearValue.size()))
-		.setPClearValues(clearValue.data())
-		.setRenderPass(sceneRenderPass.rp)
-		.setRenderArea(vk::Rect2D(vk::Offset2D(), swapchainSize)),
-		vk::SubpassContents::eInline,
-		vkDynLoader);
-	const auto viewports = std::array<vk::Viewport, 1> {
-		vk::Viewport().setHeight(swapchainSize.height).setWidth(swapchainSize.width).setMinDepth(0.f).setMaxDepth(1.f)
-	};
-	buffering_mechanism::get_current_resources().scenePassDrawCmdBuffer().setViewport(0, viewports, vkDynLoader);
-	const auto scissors = std::array<vk::Rect2D, 1> {
-		vk::Rect2D().setExtent(swapchainSize)
-	};
-	buffering_mechanism::get_current_resources().scenePassDrawCmdBuffer().setScissor(0, scissors, vkDynLoader);
-
-	// Set up the buffering_mechanism resources state, so subsequent calls to currentDrawCmdBuffer() use the one for the depth pass
-	buffering_mechanism::get_current_resources().beginScenePass();
-	currentRenderPassId = SCENE_RENDER_PASS_ID;
-	currentPSO = nullptr;
+	return _pipelineSurfaces.get(id);
 }
 
-void VkRoot::endSceneRenderPass()
+gfx_api::PipelineSurfaceMeta VkRoot::pipelineSurfaceMeta(gfx_api::PipelineSurfaceId id) const
 {
-	ASSERT_OR_RETURN(, currentRenderPassId == SCENE_RENDER_PASS_ID, "Current render pass is not a scene pass! (Mismatched beginSceneRenderPass/endSceneRenderPass calls.)");
-
-	auto scenePassDrawCmdBuffer = buffering_mechanism::get_current_resources().scenePassDrawCmdBuffer();
-	scenePassDrawCmdBuffer.endRenderPass(vkDynLoader);
-
-	// Set up the buffering_mechanism resources state, so subsequent calls to currentDrawCmdBuffer() use the one for the default render pass
-	buffering_mechanism::get_current_resources().endScenePass();
-	currentRenderPassId = DEFAULT_RENDER_PASS_ID;
-	currentPSO = nullptr;
+	return _pipelineSurfaces.meta(id);
 }
 
-gfx_api::abstract_texture* VkRoot::getSceneTexture()
+nonstd::optional<gfx_api::PipelineSurfaceId> VkRoot::findPipelineSurfaceId(gfx_api::abstract_texture* texture) const
 {
-	return pSceneImage;
+	return _pipelineSurfaces.findSurfaceId(texture);
 }
 
-void VkRoot::beginRenderPass()
+bool VkRoot::isSceneMSAAEnabled() const
 {
-	if (startedRenderPass)
+	return msaaSamples != vk::SampleCountFlagBits::e1;
+}
+
+bool VkRoot::isSwapchainMSAAEnabled() const
+{
+	return msaaSamplesSwapchain != vk::SampleCountFlagBits::e1;
+}
+
+bool VkRoot::isMultisampledColorAttachment(gfx_api::abstract_texture* texture) const
+{
+	if (auto* attachmentImage = dynamic_cast<VkAttachmentImage*>(texture))
 	{
-		return; // don't double-start the render pass
+		return attachmentImage->samples != vk::SampleCountFlagBits::e1;
 	}
-	startRenderPass();
+	if (dynamic_cast<VkSwapchainMsaaColorSurface*>(texture) != nullptr)
+	{
+		return true;
+	}
+	return false;
 }
 
-bool VkRoot::endRenderPass_RecreateSwapchain(const vk::Result& reason)
+gfx_api::pixel_format VkRoot::getDepthStencilFormat() const
+{
+	return gfx_api::pixel_format::FORMAT_D24_UNORM_S8;
+}
+
+gfx_api::abstract_texture* VkRoot::acquireTransientRenderTarget(gfx_api::pixel_format format, uint32_t width, uint32_t height)
+{
+	ASSERT_OR_RETURN(nullptr, width > 0 && height > 0, "Invalid transient render target dimensions");
+	ASSERT_OR_RETURN(nullptr, is_transient_render_target_format(format), "Unsupported transient render target format");
+
+	static uint32_t transientTargetId = 0;
+	const gfx_api::ImageResourceKey key = gfx_api::ImageResourceKey::color2d(format, width, height);
+	const std::string debugName = "<transient_rt_" + std::to_string(transientTargetId++) + ">";
+
+	gfx_api::abstract_texture* texture = _frameResourceCache.acquire(key, [this, format, width, height, debugName]() -> std::unique_ptr<gfx_api::abstract_texture> {
+		if (format == gfx_api::pixel_format::FORMAT_D24_UNORM_S8)
+		{
+			return std::unique_ptr<gfx_api::abstract_texture>(
+				new VkTransientDepthStencilImage(*this, width, height, depthBufferFormat, debugName));
+		}
+		const vk::Format vkFormat = get_format(format);
+		return std::unique_ptr<gfx_api::abstract_texture>(new VkRenderedImage(*this, width, height, vkFormat, debugName));
+	});
+	if (texture != nullptr)
+	{
+		setImageLayout(texture, vk::ImageLayout::eUndefined);
+	}
+	return texture;
+}
+
+void VkRoot::releaseTransientRenderTargets()
+{
+	_frameResourceCache.releaseAll();
+	_framebufferCache.releaseAll();
+	resetImageLayoutTracker();
+}
+
+void VkRoot::purgeFrameResources()
+{
+	_frameResourceCache.purgeUnused([this](gfx_api::abstract_texture* texture) {
+		if (texture != nullptr)
+		{
+			_frameLayoutTracker.erase(texture);
+		}
+	});
+	_framebufferCache.purgeUnused([this](uint64_t framebufferHandle) {
+		deferDestroyFramebuffer(vk::Framebuffer(gfx_api::vk::decodeHandle<VkFramebuffer>(framebufferHandle)));
+	});
+}
+
+void VkRoot::resetImageLayoutTracker()
+{
+	_frameLayoutTracker.reset();
+}
+
+void VkRoot::setImageLayout(gfx_api::abstract_texture* texture, vk::ImageLayout layout)
+{
+	setImageLayout(gfx_api::layoutSubresourceKey(texture), layout);
+}
+
+void VkRoot::setImageLayout(const gfx_api::LayoutSubresourceKey& subresource, vk::ImageLayout layout)
+{
+	_frameLayoutTracker.set(subresource, layout);
+}
+
+void VkRoot::noteExternalSubresourceLayout(const gfx_api::LayoutSubresourceKey& subresource,
+	vk::ImageLayout layout) const
+{
+	_frameLayoutTracker.set(subresource, layout);
+}
+
+vk::ImageLayout VkRoot::getImageLayout(gfx_api::abstract_texture* texture) const
+{
+	return getImageLayout(gfx_api::layoutSubresourceKey(texture));
+}
+
+vk::ImageLayout VkRoot::getImageLayout(const gfx_api::LayoutSubresourceKey& subresource) const
+{
+	return _frameLayoutTracker.get(subresource);
+}
+
+vk::Image VkRoot::getVkImageHandle(gfx_api::abstract_texture* texture) const
+{
+	ASSERT_OR_RETURN(vk::Image(), texture != nullptr, "Null texture for layout transition");
+	if (auto* renderedImage = dynamic_cast<VkRenderedImage*>(texture))
+	{
+		return renderedImage->object;
+	}
+	if (auto* depthImage = dynamic_cast<VkDepthMapImage*>(texture))
+	{
+		return depthImage->object;
+	}
+	if (auto* attachmentImage = dynamic_cast<VkAttachmentImage*>(texture))
+	{
+		return attachmentImage->image;
+	}
+	if (auto* transientDepth = dynamic_cast<VkTransientDepthStencilImage*>(texture))
+	{
+		return transientDepth->image;
+	}
+	if (auto* vkTexture = dynamic_cast<VkTexture*>(texture))
+	{
+		return vkTexture->object;
+	}
+	if (auto* vkTextureArray = dynamic_cast<VkTextureArray*>(texture))
+	{
+		return vkTextureArray->object;
+	}
+	if (dynamic_cast<VkSwapchainColorSurface*>(texture) != nullptr)
+	{
+		ASSERT_OR_RETURN(vk::Image(), currentSwapchainIndex < swapchainImages.size(),
+			"Swapchain image index out of range");
+		return swapchainImages[currentSwapchainIndex];
+	}
+	debug(LOG_FATAL, "Unsupported texture type for layout transition");
+	return vk::Image();
+}
+
+vk::ImageAspectFlags VkRoot::getVkImageAspect(gfx_api::abstract_texture* texture) const
+{
+	if (dynamic_cast<VkDepthMapImage*>(texture) != nullptr)
+	{
+		return vk::ImageAspectFlagBits::eDepth;
+	}
+	if (dynamic_cast<VkTransientDepthStencilImage*>(texture) != nullptr)
+	{
+		// Combined D/S images require both aspects in pipeline barriers unless
+		// separateDepthStencilLayouts is enabled. Shader sampling uses depthSampleView instead.
+		return vk::ImageAspectFlagBits::eDepth | vk::ImageAspectFlagBits::eStencil;
+	}
+	if (auto* attachmentImage = dynamic_cast<VkAttachmentImage*>(texture))
+	{
+		if (attachmentImage->imageFormat == depthBufferFormat)
+		{
+			return vk::ImageAspectFlagBits::eDepth | vk::ImageAspectFlagBits::eStencil;
+		}
+	}
+	return vk::ImageAspectFlagBits::eColor;
+}
+
+void VkRoot::transitionImageLayout(vk::CommandBuffer cmdBuffer,
+	const gfx_api::LayoutSubresourceKey& subresource, vk::ImageLayout oldLayout, vk::ImageLayout newLayout,
+	vk::PipelineStageFlags srcStage, vk::PipelineStageFlags dstStage,
+	vk::AccessFlags srcAccess, vk::AccessFlags dstAccess)
+{
+	ASSERT_OR_RETURN(, subresource.texture != nullptr, "Null texture for layout transition");
+	if (oldLayout == newLayout)
+	{
+		return;
+	}
+
+	const auto barrier = vk::ImageMemoryBarrier()
+		.setImage(getVkImageHandle(subresource.texture))
+		.setOldLayout(oldLayout)
+		.setNewLayout(newLayout)
+		.setSrcQueueFamilyIndex(VK_QUEUE_FAMILY_IGNORED)
+		.setDstQueueFamilyIndex(VK_QUEUE_FAMILY_IGNORED)
+		.setSubresourceRange(vk::ImageSubresourceRange(
+			getVkImageAspect(subresource.texture),
+			subresource.mipLevel, 1,
+			subresource.arrayLayer, 1))
+		.setSrcAccessMask(srcAccess)
+		.setDstAccessMask(dstAccess);
+
+	cmdBuffer.pipelineBarrier(srcStage, dstStage, vk::DependencyFlags(), nullptr, nullptr, barrier, vkDynLoader);
+	setImageLayout(subresource, newLayout);
+}
+
+void VkRoot::transitionImageLayout(vk::CommandBuffer cmdBuffer, gfx_api::abstract_texture* texture, vk::ImageLayout oldLayout,
+	vk::ImageLayout newLayout, vk::PipelineStageFlags srcStage, vk::PipelineStageFlags dstStage,
+	vk::AccessFlags srcAccess, vk::AccessFlags dstAccess)
+{
+	transitionImageLayout(cmdBuffer, gfx_api::layoutSubresourceKey(texture),
+		oldLayout, newLayout, srcStage, dstStage, srcAccess, dstAccess);
+}
+
+void VkRoot::transitionImageLayout(vk::CommandBuffer cmdBuffer, gfx_api::abstract_texture* texture, vk::ImageLayout newLayout,
+	vk::PipelineStageFlags srcStage, vk::PipelineStageFlags dstStage, vk::AccessFlags srcAccess, vk::AccessFlags dstAccess)
+{
+	transitionImageLayout(cmdBuffer, texture, getImageLayout(texture), newLayout, srcStage, dstStage, srcAccess, dstAccess);
+}
+
+void VkRoot::emitPrePassBarriers(const gfx_api::ExecutionBatch& batch,
+	const std::vector<gfx_api::CompiledPass>& compiledPasses)
+{
+	_barrierEmitter.emitBatch(batch, compiledPasses);
+}
+
+void VkRoot::applyCompiledPostPassLayouts(const gfx_api::CompiledPass& pass)
+{
+	_frameLayoutTracker.applyPostPassUpdates(pass);
+#if defined(DEBUG)
+	for (const gfx_api::LayoutStateUpdate& update : pass.postPassLayoutUpdates)
+	{
+		if (update.texture == nullptr)
+		{
+			continue;
+		}
+		const vk::ImageLayout vkLayout = gfx_api::vk::toVkImageLayout(update.layout);
+		const vk::ImageLayout trackedLayout = _frameLayoutTracker.get(gfx_api::layoutSubresourceKey(
+			update.texture, update.arrayLayer, update.mipLevel));
+		ASSERT(trackedLayout == vkLayout,
+			"FrameLayoutTracker mismatch after post-pass update for texture %p (expected %d, got %d)",
+			static_cast<void*>(update.texture), static_cast<int>(vkLayout), static_cast<int>(trackedLayout));
+	}
+#endif
+}
+
+void VkRoot::ensureRenderPassPSOCapacity(size_t requiredCount)
+{
+	for (auto& pipelineInfo : createdPipelines)
+	{
+		if (pipelineInfo.renderPassPSO.size() < requiredCount)
+		{
+			pipelineInfo.renderPassPSO.resize(requiredCount, nullptr);
+		}
+	}
+}
+
+void VkRoot::destroyRenderPassIndexedPSOs(size_t fromIndex)
+{
+	for (auto& pipelineInfo : createdPipelines)
+	{
+		for (size_t i = fromIndex; i < pipelineInfo.renderPassPSO.size(); ++i)
+		{
+			if (pipelineInfo.renderPassPSO[i] != nullptr)
+			{
+				delete pipelineInfo.renderPassPSO[i];
+				pipelineInfo.renderPassPSO[i] = nullptr;
+			}
+		}
+		if (pipelineInfo.renderPassPSO.size() > fromIndex)
+		{
+			pipelineInfo.renderPassPSO.resize(fromIndex);
+		}
+	}
+}
+
+vk::Format VkRoot::getAttachmentVkFormat(gfx_api::abstract_texture* texture) const
+{
+	ASSERT_OR_RETURN(vk::Format::eUndefined, texture != nullptr, "Null attachment texture");
+	if (auto* renderedImage = dynamic_cast<VkRenderedImage*>(texture))
+	{
+		return renderedImage->imageFormat;
+	}
+	if (auto* depthImage = dynamic_cast<VkDepthMapImage*>(texture))
+	{
+		return depthImage->depthMapFormat;
+	}
+	if (auto* attachmentImage = dynamic_cast<VkAttachmentImage*>(texture))
+	{
+		return attachmentImage->imageFormat;
+	}
+	if (auto* swapchainColor = dynamic_cast<VkSwapchainColorSurface*>(texture))
+	{
+		return swapchainColor->imageFormat;
+	}
+	if (auto* swapchainMsaaColor = dynamic_cast<VkSwapchainMsaaColorSurface*>(texture))
+	{
+		return swapchainMsaaColor->imageFormat;
+	}
+	if (auto* swapchainDepth = dynamic_cast<VkSwapchainDepthSurface*>(texture))
+	{
+		return swapchainDepth->imageFormat;
+	}
+	if (auto* transientDepth = dynamic_cast<VkTransientDepthStencilImage*>(texture))
+	{
+		return transientDepth->imageFormat;
+	}
+	debug(LOG_FATAL, "Unsupported attachment texture type for dynamic pass");
+	return vk::Format::eUndefined;
+}
+
+vk::SampleCountFlagBits VkRoot::getAttachmentVkSamples(gfx_api::abstract_texture* texture) const
+{
+	ASSERT_OR_RETURN(vk::SampleCountFlagBits::e1, texture != nullptr, "Null attachment texture");
+	if (auto* attachmentImage = dynamic_cast<VkAttachmentImage*>(texture))
+	{
+		return attachmentImage->samples;
+	}
+	if (auto* swapchainMsaaColor = dynamic_cast<VkSwapchainMsaaColorSurface*>(texture))
+	{
+		return swapchainMsaaColor->samples;
+	}
+	return vk::SampleCountFlagBits::e1;
+}
+
+vk::ImageView VkRoot::getAttachmentImageView(const gfx_api::AttachmentDesc& attachment) const
+{
+	ASSERT_OR_RETURN(vk::ImageView(), attachment.texture != nullptr, "Null attachment texture");
+	if (auto* renderedImage = dynamic_cast<VkRenderedImage*>(attachment.texture))
+	{
+		return renderedImage->view.get();
+	}
+	if (auto* depthImage = dynamic_cast<VkDepthMapImage*>(attachment.texture))
+	{
+		if (attachment.arrayLayer < depthMapCascadeView.size())
+		{
+			return depthMapCascadeView[attachment.arrayLayer].get();
+		}
+		return depthImage->view.get();
+	}
+	if (auto* attachmentImage = dynamic_cast<VkAttachmentImage*>(attachment.texture))
+	{
+		return attachmentImage->view;
+	}
+	if (dynamic_cast<VkSwapchainColorSurface*>(attachment.texture) != nullptr)
+	{
+		ASSERT_OR_RETURN(vk::ImageView(), !swapchainImageView.empty(), "No swapchain image views");
+		ASSERT_OR_RETURN(vk::ImageView(), currentSwapchainIndex < swapchainImageView.size(),
+			"Swapchain index out of range");
+		return swapchainImageView[currentSwapchainIndex];
+	}
+	if (dynamic_cast<VkSwapchainMsaaColorSurface*>(attachment.texture) != nullptr)
+	{
+		return colorImageView;
+	}
+	if (dynamic_cast<VkSwapchainDepthSurface*>(attachment.texture) != nullptr)
+	{
+		return depthStencilView;
+	}
+	if (auto* transientDepth = dynamic_cast<VkTransientDepthStencilImage*>(attachment.texture))
+	{
+		return transientDepth->view;
+	}
+	debug(LOG_FATAL, "Unsupported attachment texture type for dynamic pass");
+	return vk::ImageView();
+}
+
+size_t VkRoot::getOrCreatePassRenderPassId(const gfx_api::vk::PassLayoutKey& key)
+{
+	return _renderPassLayoutCache.getOrCreate(key);
+}
+
+void VkRoot::applyViewport(vk::CommandBuffer cmdBuffer, uint32_t width, uint32_t height, float minDepth, float maxDepth)
+{
+	const auto viewports = std::array<vk::Viewport, 1> {
+		vk::Viewport()
+			.setWidth(static_cast<float>(width))
+			.setHeight(static_cast<float>(height))
+			.setMinDepth(minDepth)
+			.setMaxDepth(maxDepth)
+	};
+	cmdBuffer.setViewport(0, viewports, vkDynLoader);
+	const auto scissors = std::array<vk::Rect2D, 1> {
+		vk::Rect2D().setExtent(vk::Extent2D(width, height))
+	};
+	cmdBuffer.setScissor(0, scissors, vkDynLoader);
+}
+
+void VkRoot::deferDestroyFramebuffer(vk::Framebuffer framebuffer)
+{
+	if (!framebuffer || !buffering_mechanism::isInitialized())
+	{
+		return;
+	}
+	// Vulkan: do not destroy framebuffers (or other objects referenced by recorded
+	// commands) until the command buffer has been ended and the GPU is done.
+	buffering_mechanism::get_current_resources().fbo_to_delete.emplace_back(framebuffer);
+}
+
+void VkRoot::clearFramebufferCache()
+{
+	_framebufferCache.clear([this](uint64_t framebufferHandle) {
+		deferDestroyFramebuffer(vk::Framebuffer(gfx_api::vk::decodeHandle<VkFramebuffer>(framebufferHandle)));
+	});
+}
+
+void VkRoot::destroyDynamicRenderPasses()
+{
+	bumpRenderGraphEpoch();
+	invalidateWarmEntries();
+	clearFramebufferCache();
+
+	if (!dev)
+	{
+		_renderPassLayoutCache.clear();
+		return;
+	}
+
+	for (size_t i = 0; i < renderPasses.size(); ++i)
+	{
+		if (renderPasses[i].rp)
+		{
+			dev.destroyRenderPass(renderPasses[i].rp, nullptr, vkDynLoader);
+			renderPasses[i].rp = vk::RenderPass();
+		}
+	}
+	renderPasses.clear();
+	destroyRenderPassIndexedPSOs(0);
+	_renderPassLayoutCache.clear();
+}
+
+optional<std::pair<uint32_t, uint32_t>> VkRoot::getRenderTargetDimensions(gfx_api::abstract_texture* texture)
+{
+	if (texture == nullptr)
+	{
+		return nullopt;
+	}
+	if (auto* renderedImage = dynamic_cast<VkRenderedImage*>(texture))
+	{
+		if (renderedImage->width > 0 && renderedImage->height > 0)
+		{
+			return std::make_pair(renderedImage->width, renderedImage->height);
+		}
+	}
+	if (auto* depthImage = dynamic_cast<VkDepthMapImage*>(texture))
+	{
+		if (depthImage->mapSize > 0)
+		{
+			return std::make_pair(depthImage->mapSize, depthImage->mapSize);
+		}
+	}
+	if (auto* attachmentImage = dynamic_cast<VkAttachmentImage*>(texture))
+	{
+		if (attachmentImage->width > 0 && attachmentImage->height > 0)
+		{
+			return std::make_pair(attachmentImage->width, attachmentImage->height);
+		}
+	}
+	if (auto* transientDepth = dynamic_cast<VkTransientDepthStencilImage*>(texture))
+	{
+		if (transientDepth->width > 0 && transientDepth->height > 0)
+		{
+			return std::make_pair(transientDepth->width, transientDepth->height);
+		}
+	}
+	if (dynamic_cast<VkSwapchainColorSurface*>(texture) != nullptr
+		|| dynamic_cast<VkSwapchainMsaaColorSurface*>(texture) != nullptr
+		|| dynamic_cast<VkSwapchainDepthSurface*>(texture) != nullptr)
+	{
+		if (swapchainSize.width > 0 && swapchainSize.height > 0)
+		{
+			return std::make_pair(swapchainSize.width, swapchainSize.height);
+		}
+	}
+	if (texture == pSceneImage && swapchainSize.width > 0 && swapchainSize.height > 0)
+	{
+		return std::make_pair(swapchainSize.width, swapchainSize.height);
+	}
+	return nullopt;
+}
+
+bool VkRoot::recreateSwapchainAfterPresentError(const vk::Result& reason)
 {
 	try {
 		createNewSwapchainAndSwapchainSpecificStuff(reason);
@@ -6094,19 +6457,176 @@ bool VkRoot::endRenderPass_RecreateSwapchain(const vk::Result& reason)
 	return false;
 }
 
+namespace
+{
+
+bool vkLegacyBeginResolvedPass(VkRoot& ctx, gfx_api::RenderPassDesc pass)
+{
+	if (!gfx_api::resolvePassDescription(pass))
+	{
+		debug(LOG_ERROR, "Failed to resolve legacy pass \"%s\"", pass.debugName.c_str());
+		return false;
+	}
+	ctx.beginPass(pass);
+	return true;
+}
+
+} // anonymous namespace
+
+void VkRoot::beginDepthPass(size_t idx)
+{
+	ASSERT_OR_RETURN(, idx < depthPassCount, "Invalid depth pass #: %zu", idx);
+	setRenderGraphExecuting(true);
+
+	if (hasActivePass)
+	{
+		endPass();
+	}
+
+	gfx_api::RenderPassDesc pass = gfx_api::legacy_pass::buildShadowCascadePassDesc(idx);
+	if (!vkLegacyBeginResolvedPass(*this, std::move(pass)))
+	{
+		debug(LOG_ERROR, "Failed to begin legacy depth pass #%zu", idx);
+		setRenderGraphExecuting(false);
+	}
+}
+
+void VkRoot::endCurrentDepthPass()
+{
+	if (hasActivePass)
+	{
+		endPass();
+	}
+}
+
+void VkRoot::beginSceneRenderPass()
+{
+	setRenderGraphExecuting(true);
+
+	if (hasActivePass)
+	{
+		endPass();
+	}
+
+	gfx_api::RenderPassDesc pass = gfx_api::legacy_pass::buildScenePassDesc();
+	if (!vkLegacyBeginResolvedPass(*this, std::move(pass)))
+	{
+		debug(LOG_ERROR, "Failed to begin legacy scene render pass");
+		setRenderGraphExecuting(false);
+	}
+}
+
+void VkRoot::endSceneRenderPass()
+{
+	if (hasActivePass)
+	{
+		endPass();
+	}
+
+	if (!openLegacySwapchainPass(gfx_api::AttachmentLoadOp::Load, gfx_api::AttachmentLoadOp::Clear))
+	{
+		debug(LOG_ERROR, "Failed to reopen legacy swapchain pass after scene pass");
+		setRenderGraphExecuting(false);
+	}
+	else
+	{
+		setRenderGraphExecuting(true);
+	}
+}
+
+bool VkRoot::openLegacySwapchainPass(gfx_api::AttachmentLoadOp colorLoad, gfx_api::AttachmentLoadOp depthLoad)
+{
+	gfx_api::RenderPassDesc pass = gfx_api::legacy_pass::buildSwapchainPassDesc(colorLoad, depthLoad);
+	if (!gfx_api::resolvePassDescription(pass))
+	{
+		debug(LOG_ERROR, "Failed to resolve legacy swapchain pass");
+		return false;
+	}
+	beginPass(pass);
+	return true;
+}
+
+void VkRoot::bootstrapLegacySwapchainPass()
+{
+	if (!openLegacySwapchainPass(gfx_api::AttachmentLoadOp::Clear, gfx_api::AttachmentLoadOp::Clear))
+	{
+		debug(LOG_ERROR, "Failed to bootstrap legacy swapchain pass after swapchain creation");
+		setRenderGraphExecuting(false);
+		return;
+	}
+	setRenderGraphExecuting(true);
+	_legacyFrameStarted = true;
+}
+
+void VkRoot::beginRenderPass()
+{
+	if (_legacyFrameStarted)
+	{
+		return;
+	}
+	if (!openLegacySwapchainPass(gfx_api::AttachmentLoadOp::Clear, gfx_api::AttachmentLoadOp::Clear))
+	{
+		debug(LOG_ERROR, "Failed to begin legacy swapchain render pass");
+		setRenderGraphExecuting(false);
+		return;
+	}
+	setRenderGraphExecuting(true);
+	_legacyFrameStarted = true;
+}
+
 void VkRoot::endRenderPass()
 {
+	if (hasActivePass)
+	{
+		endPass();
+	}
+
+	setRenderGraphExecuting(false);
+	_legacyFrameStarted = false;
+	submitFrame();
+}
+
+void VkRoot::submitFrame()
+{
+	if (!frameHasDrawCommands)
+	{
+		return;
+	}
+
 	frameNum = std::max<size_t>(frameNum + 1, 1);
 
 	currentPSO = nullptr;
 
-	buffering_mechanism::get_current_resources().depthPassDrawCmdBuffer().end(vkDynLoader);
-	buffering_mechanism::get_current_resources().scenePassDrawCmdBuffer().end(vkDynLoader);
+	const bool hadDrawCmdBufferRecording = buffering_mechanism::get_current_resources().drawCmdBufferBegun;
 
-	buffering_mechanism::get_current_resources().renderPassDrawCmdBuffer().endRenderPass(vkDynLoader);
-	buffering_mechanism::get_current_resources().renderPassDrawCmdBuffer().end(vkDynLoader);
+	if (hasActivePass)
+	{
+		buffering_mechanism::get_current_resources().drawCmdBuffer().endRenderPass(vkDynLoader);
+		_activeDynamicFramebuffer = vk::Framebuffer();
+		if (_activePassTargetsSwapchain)
+		{
+			_frameLayoutTracker.noteSwapchainWrite();
+			// The render pass left the swapchain in ColorAttachmentOptimal (its final layout).
+			setImageLayout(_swapchainColorSurface.get(), vk::ImageLayout::eColorAttachmentOptimal);
+		}
+		hasActivePass = false;
+		_activePassTargetsSwapchain = false;
+	}
+	if (buffering_mechanism::get_current_resources().drawCmdBufferBegun)
+	{
+		// Single per-frame transition of the swapchain image to PresentSrcKHR. Render passes
+		// keep the swapchain in ColorAttachmentOptimal, so this is the only present-related
+		// layout transition in the frame (no per-pass Present <-> ColorAttachment ping-pong).
+		if (_swapchainColorSurface)
+		{
+			vk::CommandBuffer drawCmdBuffer = buffering_mechanism::get_current_resources().drawCmdBuffer();
+			_frameLayoutTracker.transitionSwapchainToPresent(*this, drawCmdBuffer, _swapchainColorSurface.get());
+		}
+		buffering_mechanism::get_current_resources().drawCmdBuffer().end(vkDynLoader);
+		buffering_mechanism::get_current_resources().drawCmdBufferBegun = false;
+	}
 
-	startedRenderPass = false;
+	frameHasDrawCommands = false;
 
 	// Add memory barrier at end of cmdCopy
 	const auto memoryBarriers = std::array<vk::MemoryBarrier, 1> {
@@ -6120,6 +6640,7 @@ void VkRoot::endRenderPass()
 																				 vk::DependencyFlagBits(), memoryBarriers, nullptr, nullptr, vkDynLoader);
 
 	buffering_mechanism::get_current_resources().copyCmdBuffer().end(vkDynLoader);
+	buffering_mechanism::get_current_resources().copyCmdBufferBegun = false;
 
 	buffering_mechanism::get_current_resources().uniformBufferAllocator.flushAutomappedMemory();
 	buffering_mechanism::get_current_resources().uniformBufferAllocator.unmapAutomappedMemory();
@@ -6144,19 +6665,23 @@ void VkRoot::endRenderPass()
 		}
 	}
 
-	const auto executableCmdBuffer = std::array<vk::CommandBuffer, 4>{
+	const bool submitDrawBuffer = !mustSkipDrawing && hadDrawCmdBufferRecording;
+	if (!mustSkipDrawing && !hadDrawCmdBufferRecording)
+	{
+		debug(LOG_ERROR, "submitFrame: skipping draw command buffer submit (draw command buffer was not recording)");
+	}
+
+	const auto executableCmdBuffer = std::array<vk::CommandBuffer, 2>{
 		buffering_mechanism::get_current_resources().copyCmdBuffer(), // copy before render
-		buffering_mechanism::get_current_resources().depthPassDrawCmdBuffer(),
-		buffering_mechanism::get_current_resources().scenePassDrawCmdBuffer(),
-		buffering_mechanism::get_current_resources().renderPassDrawCmdBuffer()};
+		buffering_mechanism::get_current_resources().drawCmdBuffer(),
+	};
 	const vk::PipelineStageFlags waitStage = vk::PipelineStageFlagBits::eColorAttachmentOutput; //vk::PipelineStageFlagBits::eAllCommands;
 
 	auto submitInfo = vk::SubmitInfo()
-		// if mustSkipDrawing, only submit the cmdCopy buffer
-		.setCommandBufferCount((!mustSkipDrawing) ? static_cast<uint32_t>(executableCmdBuffer.size()) : 1)
+		.setCommandBufferCount(submitDrawBuffer ? static_cast<uint32_t>(executableCmdBuffer.size()) : 1)
 		.setPCommandBuffers(executableCmdBuffer.data());
 
-	if (!mustSkipDrawing)
+	if (submitDrawBuffer)
 	{
 		submitInfo
 			.setWaitSemaphoreCount(1)
@@ -6169,7 +6694,7 @@ void VkRoot::endRenderPass()
 		.setSwapchainCount(1)
 		.setPImageIndices(&currentSwapchainIndex);
 
-	if (!mustSkipDrawing)
+	if (submitDrawBuffer)
 	{
 		// Add synchronization to:
 		// - handle separate graphics and presentation queues
@@ -6217,11 +6742,11 @@ void VkRoot::endRenderPass()
 
 	if (mustRecreateSwapchain)
 	{
-		endRenderPass_RecreateSwapchain(vk::Result::eErrorOutOfDateKHR);
+		recreateSwapchainAfterPresentError(vk::Result::eErrorOutOfDateKHR);
 		return; // end processing this flip
 	}
 
-	if (!mustSkipDrawing)
+	if (submitDrawBuffer)
 	{
 		vk::Result presentResult;
 		try {
@@ -6260,7 +6785,7 @@ void VkRoot::endRenderPass()
 
 		if (mustRecreateSwapchain)
 		{
-			endRenderPass_RecreateSwapchain(presentResult);
+			recreateSwapchainAfterPresentError(presentResult);
 			return; // end processing this flip
 		}
 	}
@@ -6290,7 +6815,7 @@ void VkRoot::endRenderPass()
 		handleUnrecoverableError(resultErr);
 	}
 
-	if (!mustSkipDrawing)
+	if (submitDrawBuffer)
 	{
 		try {
 			if (acquireNextSwapchainImage(true) != AcquireNextSwapchainImageResult::eSuccess)
@@ -6322,12 +6847,12 @@ void VkRoot::endRenderPass()
 				// Must re-create swapchain
 				debug(LOG_3D, "[3] Drawable size (%d x %d) does not match swapchainSize (%d x %d) - re-create swapchain", w, h, (int)swapchainSize.width, (int)swapchainSize.height);
 
-				endRenderPass_RecreateSwapchain(vk::Result::eErrorOutOfDateKHR);
+				recreateSwapchainAfterPresentError(vk::Result::eErrorOutOfDateKHR);
 				return; // end processing this flip
 			}
 		}
 	}
-	else
+	else if (mustSkipDrawing)
 	{
 		// since we skipped drawing, don't bother acquiring a new swapchain image
 		// however, to avoid endless CPU drain, add a delay in here
@@ -6343,39 +6868,247 @@ void VkRoot::endRenderPass()
 	}
 
 	buffering_mechanism::get_current_resources().copyCmdBuffer().begin(vk::CommandBufferBeginInfo().setFlags(vk::CommandBufferUsageFlagBits::eOneTimeSubmit), vkDynLoader);
-	buffering_mechanism::get_current_resources().depthPassDrawCmdBuffer().begin(vk::CommandBufferBeginInfo().setFlags(vk::CommandBufferUsageFlagBits::eOneTimeSubmit), vkDynLoader);
-	buffering_mechanism::get_current_resources().scenePassDrawCmdBuffer().begin(vk::CommandBufferBeginInfo().setFlags(vk::CommandBufferUsageFlagBits::eOneTimeSubmit), vkDynLoader);
+	buffering_mechanism::get_current_resources().copyCmdBufferBegun = true;
 }
 
-void VkRoot::startRenderPass()
+bool VkRoot::buildPassLayoutKey(gfx_api::vk::PassLayoutKey& out, const gfx_api::RenderPassDesc& pass,
+	const gfx_api::CompiledPass* compiledPass)
 {
-	ASSERT(currentRenderPassId == DEFAULT_RENDER_PASS_ID, "A previous depth pass wasn't properly ended?");
+	gfx_api::vk::LayoutKeyBuildContext ctx;
+	ctx.compiledPass = compiledPass;
+	ctx.runtimeLayoutSource = this;
+	return gfx_api::vk::buildPassLayoutKey(out, pass, ctx, *this);
+}
 
-	buffering_mechanism::get_current_resources().renderPassDrawCmdBuffer().begin(vk::CommandBufferBeginInfo().setFlags(vk::CommandBufferUsageFlagBits::eOneTimeSubmit), vkDynLoader);
+void VkRoot::buildFramebufferKey(gfx_api::FramebufferResourceKey& out, size_t renderPassId, uint32_t passWidth,
+	uint32_t passHeight, const std::vector<vk::ImageView>& fboAttachments)
+{
+	out.renderPassId = renderPassId;
+	out.width = passWidth;
+	out.height = passHeight;
+	out.attachmentViewHandles.clear();
+	out.attachmentViewHandles.reserve(fboAttachments.size());
+	for (const vk::ImageView& attachmentView : fboAttachments)
+	{
+		const VkImageView imageViewHandle = attachmentView;
+		out.attachmentViewHandles.push_back(gfx_api::vk::encodeHandle<VkImageView>(imageViewHandle));
+	}
+}
 
-	const auto clearValue = std::array<vk::ClearValue, 2> {
-		vk::ClearValue(), vk::ClearValue(vk::ClearDepthStencilValue(1.f, 0u))
-	};
-	buffering_mechanism::get_current_resources().renderPassDrawCmdBuffer().beginRenderPass(
+void VkRoot::warmCompiledRenderGraph(std::vector<gfx_api::RenderPassDesc>& passes,
+	gfx_api::PassGraphCompileResult& compileResult)
+{
+	const uint64_t epoch = getRenderGraphEpoch();
+	std::vector<gfx_api::CompiledPass>& compiledPasses = compileResult.passes;
+
+	resizeWarmEntries(compiledPasses.size());
+	invalidateWarmEntries();
+
+	for (gfx_api::CompiledPass& compiledPass : compiledPasses)
+	{
+		if (compiledPass.skipped)
+		{
+			continue;
+		}
+
+		ASSERT_OR_RETURN(, compiledPass.graphIndex < passes.size(),
+			"warmCompiledRenderGraph: graphIndex out of range (%zu >= %zu)",
+			compiledPass.graphIndex, passes.size());
+
+		gfx_api::RenderPassDesc& passDesc = passes[compiledPass.graphIndex];
+		if (gfx_api::passHasTransientAttachment(passDesc))
+		{
+			continue;
+		}
+
+		ASSERT_OR_RETURN(, buildPassLayoutKey(_passLayoutScratch, passDesc, &compiledPass),
+			"Failed to build pass layout key for warm-up");
+		gfx_api::vk::VulkanWarmEntry& warm = warmEntry(compiledPass.graphIndex);
+		warm.renderPassLayoutId = getOrCreatePassRenderPassId(_passLayoutScratch);
+		warm.warmEpoch = epoch;
+	}
+}
+
+void VkRoot::resizeWarmEntries(size_t passCount)
+{
+	_warmEntries.resize(passCount);
+}
+
+void VkRoot::invalidateWarmEntries()
+{
+	for (gfx_api::vk::VulkanWarmEntry& entry : _warmEntries)
+	{
+		entry.renderPassLayoutId = gfx_api::vk::VulkanWarmEntry::INVALID_LAYOUT_ID;
+		entry.warmEpoch = 0;
+	}
+}
+
+gfx_api::vk::VulkanWarmEntry& VkRoot::warmEntry(size_t graphIndex)
+{
+	ASSERT_OR_RETURN(gfx_api::vk::VulkanWarmEntry::invalid(), graphIndex < _warmEntries.size(),
+		"Warm entry graphIndex out of range");
+	return _warmEntries[graphIndex];
+}
+
+const gfx_api::vk::VulkanWarmEntry& VkRoot::warmEntry(size_t graphIndex) const
+{
+	ASSERT_OR_RETURN(gfx_api::vk::VulkanWarmEntry::invalid(), graphIndex < _warmEntries.size(),
+		"Warm entry graphIndex out of range");
+	return _warmEntries[graphIndex];
+}
+
+void VkRoot::beginPass(const gfx_api::RenderPassDesc& pass, const gfx_api::CompiledPass* compiledPass)
+{
+	ASSERT_OR_RETURN(, !hasActivePass, "beginPass called while another pass is active");
+	ASSERT_OR_RETURN(, pass.viewportSize.has_value(), "Pass requires resolved viewportSize");
+	ASSERT_OR_RETURN(, !pass.colorAttachments.empty()
+		|| (pass.depthAttachment.has_value() && pass.depthAttachment->texture != nullptr),
+		"Pass requires at least one color or depth attachment");
+
+	hasActivePass = true;
+	_activePassTargetsSwapchain = gfx_api::passTargetsSwapchainColor(pass);
+
+	const uint32_t passWidth = pass.viewportSize->first;
+	const uint32_t passHeight = pass.viewportSize->second;
+
+	size_t renderPassId = INVALID_RENDER_PASS_ID;
+	if (compiledPass != nullptr)
+	{
+		const gfx_api::vk::VulkanWarmEntry& warm = warmEntry(compiledPass->graphIndex);
+		if (warm.renderPassLayoutId != gfx_api::vk::VulkanWarmEntry::INVALID_LAYOUT_ID
+			&& warm.warmEpoch == getRenderGraphEpoch())
+		{
+			renderPassId = warm.renderPassLayoutId;
+		}
+	}
+	if (renderPassId == INVALID_RENDER_PASS_ID)
+	{
+		ASSERT_OR_RETURN(, buildPassLayoutKey(_passLayoutScratch, pass, compiledPass),
+			"Failed to build pass layout key");
+		renderPassId = getOrCreatePassRenderPassId(_passLayoutScratch);
+	}
+
+	// Out-of-graph (legacy) passes: _legacyPassLayoutCommit captures final layouts from the pass key here.
+	// Graph passes rely on CompiledPass::postPassLayoutUpdates applied in endPass via applyCompiledPostPassLayouts.
+	if (compiledPass == nullptr)
+	{
+		_legacyPassLayoutCommit.captureFromPassKey(pass, _passLayoutScratch);
+	}
+	else
+	{
+		_legacyPassLayoutCommit.clear();
+	}
+
+	buffering_mechanism::get_current_resources().ensureDrawCmdBufferBegun();
+	frameHasDrawCommands = true;
+
+	vk::CommandBuffer drawCmdBuffer = buffering_mechanism::get_current_resources().drawCmdBuffer();
+
+	_fboAttachmentsScratch.clear();
+	const size_t resolveAttachmentCount = pass.resolveAttachment.has_value() ? 1 : 0;
+	_fboAttachmentsScratch.reserve(pass.colorAttachments.size()
+		+ (pass.depthAttachment.has_value() ? 1 : 0)
+		+ resolveAttachmentCount);
+	for (const auto& colorAttachment : pass.colorAttachments)
+	{
+		_fboAttachmentsScratch.push_back(getAttachmentImageView(colorAttachment));
+	}
+	if (pass.depthAttachment.has_value() && pass.depthAttachment->texture != nullptr)
+	{
+		_fboAttachmentsScratch.push_back(getAttachmentImageView(pass.depthAttachment.value()));
+	}
+	if (pass.resolveAttachment.has_value() && pass.resolveAttachment->texture != nullptr)
+	{
+		_fboAttachmentsScratch.push_back(getAttachmentImageView(pass.resolveAttachment.value()));
+	}
+
+	buildFramebufferKey(_framebufferKeyScratch, renderPassId, passWidth, passHeight, _fboAttachmentsScratch);
+
+	const vk::RenderPass renderPass = renderPasses[renderPassId].rp;
+	const uint64_t cachedFramebufferHandle = _framebufferCache.acquire(_framebufferKeyScratch, [&]() -> uint64_t {
+		const vk::Framebuffer framebuffer = dev.createFramebuffer(
+			vk::FramebufferCreateInfo()
+				.setAttachmentCount(static_cast<uint32_t>(_fboAttachmentsScratch.size()))
+				.setPAttachments(_fboAttachmentsScratch.data())
+				.setWidth(passWidth)
+				.setHeight(passHeight)
+				.setLayers(1)
+				.setRenderPass(renderPass),
+			nullptr, vkDynLoader);
+		const VkFramebuffer framebufferHandle = framebuffer;
+		return gfx_api::vk::encodeHandle<VkFramebuffer>(framebufferHandle);
+	});
+	_activeDynamicFramebuffer = vk::Framebuffer(gfx_api::vk::decodeHandle<VkFramebuffer>(cachedFramebufferHandle));
+
+	_clearValuesScratch.clear();
+	_clearValuesScratch.reserve(pass.colorAttachments.size() + 1);
+	for (const auto& colorAttachment : pass.colorAttachments)
+	{
+		const auto& c = colorAttachment.clearValue.color;
+		_clearValuesScratch.push_back(vk::ClearColorValue(std::array<float, 4> {c[0], c[1], c[2], c[3]}));
+	}
+	if (pass.depthAttachment.has_value() && pass.depthAttachment->texture != nullptr)
+	{
+		_clearValuesScratch.push_back(vk::ClearDepthStencilValue(
+			pass.depthAttachment->clearValue.depth,
+			pass.depthAttachment->clearValue.stencil));
+	}
+
+	drawCmdBuffer.beginRenderPass(
 		vk::RenderPassBeginInfo()
-		.setFramebuffer(defaultRenderpass().fbo[currentSwapchainIndex])
-		.setClearValueCount(static_cast<uint32_t>(clearValue.size()))
-		.setPClearValues(clearValue.data())
-		.setRenderPass(defaultRenderpass().rp)
-		.setRenderArea(vk::Rect2D(vk::Offset2D(), swapchainSize)),
+			.setFramebuffer(_activeDynamicFramebuffer)
+			.setClearValueCount(static_cast<uint32_t>(_clearValuesScratch.size()))
+			.setPClearValues(_clearValuesScratch.data())
+			.setRenderPass(renderPasses[renderPassId].rp)
+			.setRenderArea(vk::Rect2D(vk::Offset2D(), vk::Extent2D(passWidth, passHeight))),
 		vk::SubpassContents::eInline,
 		vkDynLoader);
-	const auto viewports = std::array<vk::Viewport, 1> {
-		vk::Viewport().setHeight(swapchainSize.height).setWidth(swapchainSize.width).setMinDepth(0.f).setMaxDepth(1.f)
-	};
-	buffering_mechanism::get_current_resources().renderPassDrawCmdBuffer().setViewport(0, viewports, vkDynLoader);
-	const auto scissors = std::array<vk::Rect2D, 1> {
-		vk::Rect2D().setExtent(swapchainSize)
-	};
-	buffering_mechanism::get_current_resources().renderPassDrawCmdBuffer().setScissor(0, scissors, vkDynLoader);
 
-	startedRenderPass = true;
-	currentRenderPassId = DEFAULT_RENDER_PASS_ID;
+	applyViewport(drawCmdBuffer, passWidth, passHeight,
+		_activePassTargetsSwapchain ? _viewportMinDepth : 0.f,
+		_activePassTargetsSwapchain ? _viewportMaxDepth : 1.f);
+
+	currentRenderPassId = renderPassId;
+	currentPSO = nullptr;
+}
+
+void VkRoot::endPass(const gfx_api::CompiledPass* compiledPass)
+{
+	ASSERT_OR_RETURN(, hasActivePass, "endPass called without an active pass");
+
+	buffering_mechanism::get_current_resources().drawCmdBuffer().endRenderPass(vkDynLoader);
+	_activeDynamicFramebuffer = vk::Framebuffer();
+	if (_activePassTargetsSwapchain)
+	{
+		_frameLayoutTracker.noteSwapchainWrite();
+	}
+	if (compiledPass != nullptr)
+	{
+		applyCompiledPostPassLayouts(*compiledPass);
+	}
+	else
+	{
+		// Legacy path: commit captured finals into _frameLayoutTracker.
+		_legacyPassLayoutCommit.commitTo(_frameLayoutTracker);
+	}
+	if (_activePassTargetsSwapchain && _swapchainColorSurface != nullptr)
+	{
+		// Render passes leave the swapchain in ColorAttachmentOptimal; mirror submitFrame force-end
+		// so present transition never no-ops with a stale PresentSrcKHR tracker entry.
+		setImageLayout(_swapchainColorSurface.get(), vk::ImageLayout::eColorAttachmentOptimal);
+#if defined(DEBUG)
+		if (compiledPass != nullptr)
+		{
+			const vk::ImageLayout trackedLayout = _frameLayoutTracker.get(_swapchainColorSurface.get());
+			ASSERT(trackedLayout == vk::ImageLayout::eColorAttachmentOptimal,
+				"Swapchain tracker not ColorAttachmentOptimal after graph pass end");
+		}
+#endif
+	}
+	currentRenderPassId = INVALID_RENDER_PASS_ID;
+	currentPSO = nullptr;
+	hasActivePass = false;
+	_activePassTargetsSwapchain = false;
 }
 
 size_t VkRoot::numDepthPasses()
@@ -6395,68 +7128,16 @@ bool VkRoot::setDepthPassProperties(size_t _numDepthPasses, size_t _depthBufferR
 	depthPassCount = _numDepthPasses;
 	depthMapSize = static_cast<uint32_t>(_depthBufferResolution);
 
-	createDepthPassImagesAndFBOs(depthBufferFormat);
+	bumpRenderGraphEpoch();
+	invalidateWarmEntries();
+	createDepthPassImages(depthBufferFormat);
 
 	return true;
-}
-
-void VkRoot::beginDepthPass(size_t idx)
-{
-	auto& depthRenderPass = renderPasses[DEPTH_RENDER_PASS_ID];
-	ASSERT_OR_RETURN(, idx < depthRenderPass.fbo.size(), "Invalid depth pass #: %zu (exceeds depthPass FBOs count: %zu)", idx, depthRenderPass.fbo.size());
-
-	// There only needs to be a single RenderPass object for 1 or more depth passes
-	// What actually swaps out is the FBO used in the call to beginRenderPass
-	auto depthPassExtent = vk::Extent2D(depthMapSize, depthMapSize);
-
-	const auto clearValue = std::array<vk::ClearValue, 1> {
-		vk::ClearValue(vk::ClearDepthStencilValue(1.f, 0u))
-	};
-	buffering_mechanism::get_current_resources().depthPassDrawCmdBuffer().beginRenderPass(
-		vk::RenderPassBeginInfo()
-		.setFramebuffer(depthRenderPass.fbo[idx])
-		.setClearValueCount(static_cast<uint32_t>(clearValue.size()))
-		.setPClearValues(clearValue.data())
-		.setRenderPass(depthRenderPass.rp)
-		.setRenderArea(vk::Rect2D(vk::Offset2D(), depthPassExtent)),
-		vk::SubpassContents::eInline,
-		vkDynLoader);
-	const auto viewports = std::array<vk::Viewport, 1> {
-		vk::Viewport().setHeight(depthMapSize).setWidth(depthMapSize).setMinDepth(0.f).setMaxDepth(1.f)
-	};
-	buffering_mechanism::get_current_resources().depthPassDrawCmdBuffer().setViewport(0, viewports, vkDynLoader);
-	const auto scissors = std::array<vk::Rect2D, 1> {
-		vk::Rect2D().setExtent(depthPassExtent)
-	};
-	buffering_mechanism::get_current_resources().depthPassDrawCmdBuffer().setScissor(0, scissors, vkDynLoader);
-
-	// Set up the buffering_mechanism resources state, so subsequent calls to currentDrawCmdBuffer() use the one for the depth pass
-	buffering_mechanism::get_current_resources().beginDepthPass();
-	currentRenderPassId = DEPTH_RENDER_PASS_ID;
-	currentPSO = nullptr;
 }
 
 size_t VkRoot::getDepthPassDimensions(size_t idx)
 {
 	return depthMapSize;
-}
-
-void VkRoot::endCurrentDepthPass()
-{
-	ASSERT_OR_RETURN(, currentRenderPassId == DEPTH_RENDER_PASS_ID, "Current render pass is not a depth pass! (Mismatched beginDepthPass/endCurrentDepthPass calls.)");
-
-	auto depthPassDrawCmdBuffer = buffering_mechanism::get_current_resources().depthPassDrawCmdBuffer();
-	depthPassDrawCmdBuffer.endRenderPass(vkDynLoader);
-
-	// Set up the buffering_mechanism resources state, so subsequent calls to currentDrawCmdBuffer() use the one for the default render pass
-	buffering_mechanism::get_current_resources().endCurrentDepthPass();
-	currentRenderPassId = DEFAULT_RENDER_PASS_ID;
-	currentPSO = nullptr;
-}
-
-gfx_api::abstract_texture* VkRoot::getDepthTexture()
-{
-	return pDepthMapImage;
 }
 
 void VkRoot::set_polygon_offset(const float& offset, const float& slope)
@@ -6466,15 +7147,17 @@ void VkRoot::set_polygon_offset(const float& offset, const float& slope)
 
 void VkRoot::set_depth_range(const float& min, const float& max)
 {
-	vk::Extent2D currentRenderpassExtent = swapchainSize;
-	if (currentRenderPassId == DEPTH_RENDER_PASS_ID)
+	_viewportMinDepth = min;
+	_viewportMaxDepth = max;
+
+	// Cache-only until a swapchain pass record callback applies it (see pie_Begin3DScene / pie_BeginInterface).
+	if (!renderGraphExecuting() || !hasActivePass || !_activePassTargetsSwapchain)
 	{
-		currentRenderpassExtent = vk::Extent2D(depthMapSize, depthMapSize);
+		return;
 	}
-	const auto viewports = std::array<vk::Viewport, 1> {
-		vk::Viewport().setHeight(currentRenderpassExtent.height).setWidth(currentRenderpassExtent.width).setMinDepth(min).setMaxDepth(max)
-	};
-	buffering_mechanism::get_current_resources().currentDrawCmdBuffer()->setViewport(0, viewports, vkDynLoader);
+
+	applyViewport(buffering_mechanism::get_current_resources().drawCmdBuffer(),
+		swapchainSize.width, swapchainSize.height, min, max);
 }
 
 int32_t VkRoot::get_context_value(const gfx_api::context::context_value property)
@@ -6663,7 +7346,8 @@ bool VkRoot::setShadowConstants(gfx_api::lighting_constants newValues)
 	// Must rebuild any shaders that used these values
 	for (auto& pipelineInfo : createdPipelines)
 	{
-		for (size_t renderPassId = 0; renderPassId < pipelineInfo.renderPassPSO.size(); ++renderPassId)
+		const size_t numRenderPasses = std::min(pipelineInfo.renderPassPSO.size(), renderPasses.size());
+		for (size_t renderPassId = 0; renderPassId < numRenderPasses; ++renderPassId)
 		{
 			auto pipeline = pipelineInfo.renderPassPSO[renderPassId];
 			if (pipeline == nullptr)
@@ -6689,7 +7373,8 @@ bool VkRoot::debugRecompileAllPipelines()
 {
 	for (auto& pipelineInfo : createdPipelines)
 	{
-		for (size_t renderPassId = 0; renderPassId < pipelineInfo.renderPassPSO.size(); ++renderPassId)
+		const size_t numRenderPasses = std::min(pipelineInfo.renderPassPSO.size(), renderPasses.size());
+		for (size_t renderPassId = 0; renderPassId < numRenderPasses; ++renderPassId)
 		{
 			auto pipeline = pipelineInfo.renderPassPSO[renderPassId];
 			if (pipeline == nullptr)

--- a/lib/ivis_opengl/gfx_api_vk.cpp
+++ b/lib/ivis_opengl/gfx_api_vk.cpp
@@ -215,7 +215,6 @@ enum class VulkanBackendInternalTextureType : size_t
 	DepthMap,
 	RenderedImage,
 	AttachmentImage,
-	TransientDepthStencil,
 	SwapchainColorSurface,
 	SwapchainMsaaColorSurface,
 	SwapchainDepthSurface,
@@ -2996,66 +2995,6 @@ static void createDepthStencilImage(const vk::PhysicalDevice& physicalDevice, co
 										 vkDynLoader, loggingKey);
 }
 
-// MARK: VkTransientDepthStencilImage
-
-VkTransientDepthStencilImage::VkTransientDepthStencilImage(const VkRoot& root, uint32_t w, uint32_t h, vk::Format format, const std::string& filename)
-	: dev(root.dev)
-	, imageFormat(format)
-	, width(w)
-	, height(h)
-{
-#if defined(WZ_DEBUG_GFX_API_LEAKS)
-	debugName = filename;
-#endif
-
-	createDepthStencilImage(root.physicalDevice, root.memprops, root.dev,
-		vk::Extent2D(w, h), vk::SampleCountFlagBits::e1, format,
-		image, memory, view, root.vkDynLoader, filename.c_str(), true);
-
-	const auto depthSampleViewCreateInfo = vk::ImageViewCreateInfo()
-		.setImage(image)
-		.setViewType(vk::ImageViewType::e2D)
-		.setFormat(format)
-		.setComponents(vk::ComponentMapping())
-		.setSubresourceRange(vk::ImageSubresourceRange(vk::ImageAspectFlagBits::eDepth, 0, 1, 0, 1));
-	depthSampleView = dev.createImageView(depthSampleViewCreateInfo, nullptr, root.vkDynLoader);
-}
-
-VkTransientDepthStencilImage::~VkTransientDepthStencilImage()
-{
-	if (buffering_mechanism::isInitialized())
-	{
-		auto& frameResources = buffering_mechanism::get_current_resources();
-		if (view)
-		{
-			frameResources.image_view_to_delete.emplace_back(view);
-			view = vk::ImageView();
-		}
-		if (depthSampleView)
-		{
-			frameResources.image_view_to_delete.emplace_back(depthSampleView);
-			depthSampleView = vk::ImageView();
-		}
-		if (image)
-		{
-			frameResources.image_to_delete.emplace_back(image);
-			image = vk::Image();
-		}
-		if (memory)
-		{
-			frameResources.devicememory_to_free.emplace_back(memory);
-			memory = vk::DeviceMemory();
-		}
-	}
-}
-
-void VkTransientDepthStencilImage::bind() { }
-
-size_t VkTransientDepthStencilImage::backend_internal_value() const
-{
-	return static_cast<size_t>(VulkanBackendInternalTextureType::TransientDepthStencil);
-}
-
 void VkRoot::destroySwapchainPipelineSurfaces()
 {
 	_pipelineSurfaces.invalidateSurface(gfx_api::PipelineSurfaceId::SwapchainColor);
@@ -3798,12 +3737,6 @@ bool VkRoot::canRecordDrawCommands() const
 
 void VkRoot::shutdown()
 {
-	_frameResourceCache.clear([this](gfx_api::abstract_texture* texture) {
-		if (texture != nullptr)
-		{
-			_frameLayoutTracker.erase(texture);
-		}
-	});
 	clearFramebufferCache();
 
 	destroySwapchainAndSwapchainSpecificStuff(true);
@@ -5706,11 +5639,6 @@ void VkRoot::bind_textures(const std::vector<gfx_api::texture_input>& attribute_
 					ASSERT(target_type == gfx_api::pixel_format_target::texture_2d, "Unexpected target type: (%d)", static_cast<int>(target_type));
 					imageView = static_cast<VkAttachmentImage*>(texture)->view;
 					break;
-				case VulkanBackendInternalTextureType::TransientDepthStencil:
-					ASSERT(target_type == gfx_api::pixel_format_target::texture_2d, "Unexpected target type: (%d)", static_cast<int>(target_type));
-					imageView = static_cast<VkTransientDepthStencilImage*>(texture)->depthSampleView;
-					imageLayout = vk::ImageLayout::eDepthStencilReadOnlyOptimal;
-					break;
 				case VulkanBackendInternalTextureType::SwapchainColorSurface:
 				case VulkanBackendInternalTextureType::SwapchainMsaaColorSurface:
 				case VulkanBackendInternalTextureType::SwapchainDepthSurface:
@@ -5985,46 +5913,8 @@ gfx_api::pixel_format VkRoot::getDepthStencilFormat() const
 	return gfx_api::pixel_format::FORMAT_D24_UNORM_S8;
 }
 
-gfx_api::abstract_texture* VkRoot::acquireTransientRenderTarget(gfx_api::pixel_format format, uint32_t width, uint32_t height)
-{
-	ASSERT_OR_RETURN(nullptr, width > 0 && height > 0, "Invalid transient render target dimensions");
-	ASSERT_OR_RETURN(nullptr, is_transient_render_target_format(format), "Unsupported transient render target format");
-
-	static uint32_t transientTargetId = 0;
-	const gfx_api::ImageResourceKey key = gfx_api::ImageResourceKey::color2d(format, width, height);
-	const std::string debugName = "<transient_rt_" + std::to_string(transientTargetId++) + ">";
-
-	gfx_api::abstract_texture* texture = _frameResourceCache.acquire(key, [this, format, width, height, debugName]() -> std::unique_ptr<gfx_api::abstract_texture> {
-		if (format == gfx_api::pixel_format::FORMAT_D24_UNORM_S8)
-		{
-			return std::unique_ptr<gfx_api::abstract_texture>(
-				new VkTransientDepthStencilImage(*this, width, height, depthBufferFormat, debugName));
-		}
-		const vk::Format vkFormat = get_format(format);
-		return std::unique_ptr<gfx_api::abstract_texture>(new VkRenderedImage(*this, width, height, vkFormat, debugName));
-	});
-	if (texture != nullptr)
-	{
-		setImageLayout(texture, vk::ImageLayout::eUndefined);
-	}
-	return texture;
-}
-
-void VkRoot::releaseTransientRenderTargets()
-{
-	_frameResourceCache.releaseAll();
-	_framebufferCache.releaseAll();
-	resetImageLayoutTracker();
-}
-
 void VkRoot::purgeFrameResources()
 {
-	_frameResourceCache.purgeUnused([this](gfx_api::abstract_texture* texture) {
-		if (texture != nullptr)
-		{
-			_frameLayoutTracker.erase(texture);
-		}
-	});
 	_framebufferCache.purgeUnused([this](uint64_t framebufferHandle) {
 		deferDestroyFramebuffer(vk::Framebuffer(gfx_api::vk::decodeHandle<VkFramebuffer>(framebufferHandle)));
 	});
@@ -6076,10 +5966,6 @@ vk::Image VkRoot::getVkImageHandle(gfx_api::abstract_texture* texture) const
 	{
 		return attachmentImage->image;
 	}
-	if (auto* transientDepth = dynamic_cast<VkTransientDepthStencilImage*>(texture))
-	{
-		return transientDepth->image;
-	}
 	if (auto* vkTexture = dynamic_cast<VkTexture*>(texture))
 	{
 		return vkTexture->object;
@@ -6103,12 +5989,6 @@ vk::ImageAspectFlags VkRoot::getVkImageAspect(gfx_api::abstract_texture* texture
 	if (dynamic_cast<VkDepthMapImage*>(texture) != nullptr)
 	{
 		return vk::ImageAspectFlagBits::eDepth;
-	}
-	if (dynamic_cast<VkTransientDepthStencilImage*>(texture) != nullptr)
-	{
-		// Combined D/S images require both aspects in pipeline barriers unless
-		// separateDepthStencilLayouts is enabled. Shader sampling uses depthSampleView instead.
-		return vk::ImageAspectFlagBits::eDepth | vk::ImageAspectFlagBits::eStencil;
 	}
 	if (auto* attachmentImage = dynamic_cast<VkAttachmentImage*>(texture))
 	{
@@ -6245,10 +6125,6 @@ vk::Format VkRoot::getAttachmentVkFormat(gfx_api::abstract_texture* texture) con
 	{
 		return swapchainDepth->imageFormat;
 	}
-	if (auto* transientDepth = dynamic_cast<VkTransientDepthStencilImage*>(texture))
-	{
-		return transientDepth->imageFormat;
-	}
 	debug(LOG_FATAL, "Unsupported attachment texture type for dynamic pass");
 	return vk::Format::eUndefined;
 }
@@ -6300,10 +6176,6 @@ vk::ImageView VkRoot::getAttachmentImageView(const gfx_api::AttachmentDesc& atta
 	if (dynamic_cast<VkSwapchainDepthSurface*>(attachment.texture) != nullptr)
 	{
 		return depthStencilView;
-	}
-	if (auto* transientDepth = dynamic_cast<VkTransientDepthStencilImage*>(attachment.texture))
-	{
-		return transientDepth->view;
 	}
 	debug(LOG_FATAL, "Unsupported attachment texture type for dynamic pass");
 	return vk::ImageView();
@@ -6398,13 +6270,6 @@ optional<std::pair<uint32_t, uint32_t>> VkRoot::getRenderTargetDimensions(gfx_ap
 		if (attachmentImage->width > 0 && attachmentImage->height > 0)
 		{
 			return std::make_pair(attachmentImage->width, attachmentImage->height);
-		}
-	}
-	if (auto* transientDepth = dynamic_cast<VkTransientDepthStencilImage*>(texture))
-	{
-		if (transientDepth->width > 0 && transientDepth->height > 0)
-		{
-			return std::make_pair(transientDepth->width, transientDepth->height);
 		}
 	}
 	if (dynamic_cast<VkSwapchainColorSurface*>(texture) != nullptr
@@ -6564,6 +6429,8 @@ void VkRoot::beginRenderPass()
 	{
 		return;
 	}
+	_framebufferCache.releaseAll();
+	resetImageLayoutTracker();
 	if (!openLegacySwapchainPass(gfx_api::AttachmentLoadOp::Clear, gfx_api::AttachmentLoadOp::Clear))
 	{
 		debug(LOG_ERROR, "Failed to begin legacy swapchain render pass");
@@ -6584,6 +6451,7 @@ void VkRoot::endRenderPass()
 	setRenderGraphExecuting(false);
 	_legacyFrameStarted = false;
 	submitFrame();
+	purgeFrameResources();
 }
 
 void VkRoot::submitFrame()
@@ -6916,10 +6784,6 @@ void VkRoot::warmCompiledRenderGraph(std::vector<gfx_api::RenderPassDesc>& passe
 			compiledPass.graphIndex, passes.size());
 
 		gfx_api::RenderPassDesc& passDesc = passes[compiledPass.graphIndex];
-		if (gfx_api::passHasTransientAttachment(passDesc))
-		{
-			continue;
-		}
 
 		ASSERT_OR_RETURN(, buildPassLayoutKey(_passLayoutScratch, passDesc, &compiledPass),
 			"Failed to build pass layout key for warm-up");

--- a/lib/ivis_opengl/gfx_api_vk.h
+++ b/lib/ivis_opengl/gfx_api_vk.h
@@ -629,32 +629,7 @@ struct VkSwapchainDepthSurface final : public gfx_api::abstract_texture
 	virtual ~VkSwapchainDepthSurface() override;
 	virtual void bind() override;
 	virtual bool isArray() const override { return false; }
-	virtual size_t backend_internal_value() const override;
-};
-
-/// Owned depth/stencil image for per-frame transient pool allocations.
-struct VkTransientDepthStencilImage final : public gfx_api::abstract_texture
-{
-	vk::Device dev;
-	vk::Image image = {};
-	vk::DeviceMemory memory = {};
-	/// Depth+stencil view for framebuffer attachment.
-	vk::ImageView view = {};
-	/// Depth-only view for shader sampling (descriptor sets require a single aspect).
-	vk::ImageView depthSampleView = {};
-	vk::Format imageFormat = vk::Format::eUndefined;
-	uint32_t width = 0;
-	uint32_t height = 0;
-
-#if defined(WZ_DEBUG_GFX_API_LEAKS)
-	std::string debugName;
-#endif
-
-	VkTransientDepthStencilImage(const VkRoot& root, uint32_t w, uint32_t h, vk::Format format, const std::string& filename);
-	~VkTransientDepthStencilImage() override;
-	void bind() override;
-	bool isArray() const override { return false; }
-	size_t backend_internal_value() const override;
+	virtual 	size_t backend_internal_value() const override;
 };
 
 struct QueueFamilyIndices
@@ -905,8 +880,6 @@ public:
 	virtual bool isSwapchainMSAAEnabled() const override;
 	virtual bool isMultisampledColorAttachment(gfx_api::abstract_texture* texture) const override;
 	virtual gfx_api::pixel_format getDepthStencilFormat() const override;
-	virtual gfx_api::abstract_texture* acquireTransientRenderTarget(gfx_api::pixel_format format, uint32_t width, uint32_t height) override;
-	virtual void releaseTransientRenderTargets() override;
 	virtual void purgeFrameResources() override;
 	virtual optional<std::pair<uint32_t, uint32_t>> getRenderTargetDimensions(gfx_api::abstract_texture* texture) override;
 	virtual void warmCompiledRenderGraph(std::vector<gfx_api::RenderPassDesc>& passes,
@@ -1054,7 +1027,6 @@ private:
 	std::unique_ptr<VkSwapchainMsaaColorSurface> _swapchainMsaaColorSurface;
 	std::unique_ptr<VkSwapchainDepthSurface> _swapchainDepthSurface;
 	gfx_api::PipelineSurfaceRegistry _pipelineSurfaces;
-	gfx_api::FrameResourceCache _frameResourceCache;
 	gfx_api::FramebufferResourceCache _framebufferCache;
 
 	/// Reusable `PassLayoutKey` buffer for `buildPassLayoutKey` / cache lookup at call sites.

--- a/lib/ivis_opengl/gfx_api_vk.h
+++ b/lib/ivis_opengl/gfx_api_vk.h
@@ -21,37 +21,28 @@
 
 #if defined(WZ_VULKAN_ENABLED)
 
-#if defined( _MSC_VER )
-#pragma warning( push )
-#pragma warning( disable : 4191 ) // warning C4191: '<function-style-cast>': unsafe conversion from 'PFN_vkVoidFunction' to 'PFN_vk<...>'
-#endif
-#if defined(__clang__)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wshadow"
-#pragma clang diagnostic ignored "-Wnewline-eof"
-#endif
-#if !defined(__clang__) && defined(__GNUC__) && __GNUC__ >= 9
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-copy" // Ignore warnings caused by vulkan.hpp 148
-#pragma GCC diagnostic ignored "-Wshadow"
-#pragma GCC diagnostic ignored "-Wcast-align"
-#endif
-#define VULKAN_HPP_TYPESAFE_CONVERSION 1
-#include <vulkan/vulkan.hpp>
-#if !defined(__clang__) && defined(__GNUC__) && __GNUC__ >= 9
-#pragma GCC diagnostic pop
-#endif
-#if defined( _MSC_VER )
-#pragma warning( pop )
-#endif
+#include "vk/vulkan_hpp_include.h"
 
 #include "lib/framework/frame.h"
+#include "lib/framework/hash_combine.h"
 
 #include "gfx_api.h"
+#include "gfx_api_frame_resource_cache.h"
+#include "render_graph/layout_subresource.h"
+#include "render_graph/pass_resolve.h"
+#include "render_graph/pipeline_surfaces.h"
+#include "vk/frame_layout_tracker.h"
+#include "vk/legacy_pass_layout_commit.h"
+#include "vk/layout_key_builder.h"
+#include "vk/pass_layout_key.h"
+#include "vk/pre_pass_barrier_emitter.h"
+#include "vk/render_pass_layout_cache.h"
+#include "vk/warm_entry.h"
 #include <algorithm>
 #include <sstream>
 #include <map>
 #include <vector>
+#include <limits>
 #include <unordered_map>
 #include <typeindex>
 
@@ -116,18 +107,6 @@ namespace WZ_vk {
 	using UniqueSemaphore = vk::UniqueHandle<vk::Semaphore, WZ_vk::DispatchLoaderDynamic>;
 }
 
-inline void hash_combine(std::size_t& seed) { }
-
-template <typename T, typename... Rest>
-inline void hash_combine(std::size_t& seed, const T& v, Rest... rest) {
-	std::hash<T> hasher;
-#if SIZE_MAX >= UINT64_MAX
-	seed ^= hasher(v) + 0x9e3779b97f4a7c15L + (seed<<6) + (seed>>2);
-#else
-	seed ^= hasher(v) + 0x9e3779b9 + (seed<<6) + (seed>>2);
-#endif
-	hash_combine(seed, rest...);
-}
 namespace std {
 	template <>
 	struct hash<vk::DescriptorBufferInfo>
@@ -243,6 +222,7 @@ struct perFrameResources_t
 	std::vector</*WZ_vk::UniqueBuffer*/vk::Buffer> buffer_to_delete;
 	std::vector</*WZ_vk::UniqueImage*/vk::Image> image_to_delete;
 	std::vector<WZ_vk::UniqueImageView> image_view_to_delete;
+	std::vector<vk::DeviceMemory> devicememory_to_free;
 	std::vector<VmaAllocation> vmamemory_to_free;
 	std::vector<VkPSO*> pso_to_delete;
 	std::vector<vk::Framebuffer> fbo_to_delete;
@@ -262,33 +242,26 @@ struct perFrameResources_t
 	~perFrameResources_t();
 
 public:
-	void beginDepthPass();
-	void endCurrentDepthPass();
-
-	void beginScenePass();
-	void endScenePass();
-
 	vk::CommandBuffer* currentCopyCmdBuffer();
 	vk::CommandBuffer* currentDrawCmdBuffer();
 
 	vk::CommandBuffer copyCmdBuffer();
-	vk::CommandBuffer depthPassDrawCmdBuffer();
-	vk::CommandBuffer scenePassDrawCmdBuffer();
-	vk::CommandBuffer renderPassDrawCmdBuffer();
+	vk::CommandBuffer drawCmdBuffer();
+
+	void ensureDrawCmdBufferBegun();
+	void endCopyCmdBufferIfRecording();
+	void endDrawCmdBufferIfRecording();
+
+	bool drawCmdBufferBegun = false;
+	bool copyCmdBufferBegun = false;
 
 protected:
 	friend struct buffering_mechanism;
 
-	// main command buffer for copying command
+	// upload / transfer commands
 	vk::CommandBuffer cmdCopy;
 
-	// drawing command buffer for depth pass(es)
-	vk::CommandBuffer cmdDrawDepth;
-
-	// drawing command buffer for scene pass
-	vk::CommandBuffer cmdDrawScene;
-
-	// main command buffer for drawing (default render pass)
+	// all render passes recorded sequentially in graph order
 	vk::CommandBuffer cmdDraw;
 
 	void resetDescriptorPools();
@@ -543,6 +516,8 @@ struct VkDepthMapImage final : public gfx_api::abstract_texture
 	VmaAllocation allocation = VK_NULL_HANDLE;
 
 	size_t layer_count;
+	vk::Format depthMapFormat = vk::Format::eUndefined;
+	uint32_t mapSize = 0;
 
 #if defined(WZ_DEBUG_GFX_API_LEAKS)
 	std::string debugName;
@@ -571,6 +546,10 @@ struct VkRenderedImage final : public gfx_api::abstract_texture
 //	WZ_vk::UniqueDeviceMemory memory;
 	VmaAllocation allocation = VK_NULL_HANDLE;
 
+	vk::Format imageFormat = vk::Format::eUndefined;
+	uint32_t width = 0;
+	uint32_t height = 0;
+
 #if defined(WZ_DEBUG_GFX_API_LEAKS)
 	std::string debugName;
 #endif
@@ -587,6 +566,95 @@ struct VkRenderedImage final : public gfx_api::abstract_texture
 
 	VkRenderedImage( const VkRenderedImage& other ) = delete; // non construction-copyable
 	VkRenderedImage& operator=( const VkRenderedImage& ) = delete; // non copyable
+};
+
+/// Non-owning wrapper for pipeline attachment images (scene MSAA / depth) owned by VkRoot.
+struct VkAttachmentImage final : public gfx_api::abstract_texture
+{
+	vk::Image image;
+	vk::ImageView view;
+	vk::Format imageFormat = vk::Format::eUndefined;
+	uint32_t width = 0;
+	uint32_t height = 0;
+	vk::SampleCountFlagBits samples = vk::SampleCountFlagBits::e1;
+
+#if defined(WZ_DEBUG_GFX_API_LEAKS)
+	std::string debugName;
+#endif
+
+	VkAttachmentImage(vk::Image _image, vk::ImageView _view, vk::Format format, uint32_t w, uint32_t h,
+		vk::SampleCountFlagBits sampleCount, const std::string& filename);
+
+	virtual ~VkAttachmentImage() override;
+	virtual void bind() override;
+	virtual bool isArray() const override { return false; }
+	virtual size_t backend_internal_value() const override;
+};
+
+/// Non-owning wrapper for the current swapchain image (view selected per frame).
+struct VkSwapchainColorSurface final : public gfx_api::abstract_texture
+{
+	const VkRoot& root;
+	vk::Format imageFormat = vk::Format::eUndefined;
+
+	VkSwapchainColorSurface(const VkRoot& rootRef, vk::Format format);
+	virtual ~VkSwapchainColorSurface() override;
+	virtual void bind() override;
+	virtual bool isArray() const override { return false; }
+	virtual size_t backend_internal_value() const override;
+};
+
+/// Non-owning wrapper for the swapchain MSAA color intermediate (when enabled).
+struct VkSwapchainMsaaColorSurface final : public gfx_api::abstract_texture
+{
+	const VkRoot& root;
+	vk::Format imageFormat = vk::Format::eUndefined;
+	vk::SampleCountFlagBits samples = vk::SampleCountFlagBits::e1;
+
+	VkSwapchainMsaaColorSurface(const VkRoot& rootRef, vk::Format format, vk::SampleCountFlagBits sampleCount);
+	virtual ~VkSwapchainMsaaColorSurface() override;
+	virtual void bind() override;
+	virtual bool isArray() const override { return false; }
+	virtual size_t backend_internal_value() const override;
+};
+
+/// Non-owning wrapper for the shared swapchain depth/stencil image.
+struct VkSwapchainDepthSurface final : public gfx_api::abstract_texture
+{
+	const VkRoot& root;
+	vk::Format imageFormat = vk::Format::eUndefined;
+	vk::SampleCountFlagBits samples = vk::SampleCountFlagBits::e1;
+
+	VkSwapchainDepthSurface(const VkRoot& rootRef, vk::Format format, vk::SampleCountFlagBits sampleCount);
+	virtual ~VkSwapchainDepthSurface() override;
+	virtual void bind() override;
+	virtual bool isArray() const override { return false; }
+	virtual size_t backend_internal_value() const override;
+};
+
+/// Owned depth/stencil image for per-frame transient pool allocations.
+struct VkTransientDepthStencilImage final : public gfx_api::abstract_texture
+{
+	vk::Device dev;
+	vk::Image image = {};
+	vk::DeviceMemory memory = {};
+	/// Depth+stencil view for framebuffer attachment.
+	vk::ImageView view = {};
+	/// Depth-only view for shader sampling (descriptor sets require a single aspect).
+	vk::ImageView depthSampleView = {};
+	vk::Format imageFormat = vk::Format::eUndefined;
+	uint32_t width = 0;
+	uint32_t height = 0;
+
+#if defined(WZ_DEBUG_GFX_API_LEAKS)
+	std::string debugName;
+#endif
+
+	VkTransientDepthStencilImage(const VkRoot& root, uint32_t w, uint32_t h, vk::Format format, const std::string& filename);
+	~VkTransientDepthStencilImage() override;
+	void bind() override;
+	bool isArray() const override { return false; }
+	size_t backend_internal_value() const override;
 };
 
 struct QueueFamilyIndices
@@ -658,6 +726,7 @@ struct VkRoot final : gfx_api::context
 	vk::SurfaceFormatKHR surfaceFormat;
 	vk::SwapchainKHR swapchain;
 	uint32_t currentSwapchainIndex = 0;
+	std::vector<vk::Image> swapchainImages;
 	std::vector<vk::ImageView> swapchainImageView;
 
 	vk::SampleCountFlagBits msaaSamples = vk::SampleCountFlagBits::e1; // msaaSamples used for scene
@@ -671,16 +740,12 @@ struct VkRoot final : gfx_api::context
 	vk::ImageView depthStencilView;
 
 	// render passes
-	const size_t DEFAULT_RENDER_PASS_ID = 0;
-	const size_t DEPTH_RENDER_PASS_ID = 1;
-	const size_t SCENE_RENDER_PASS_ID = 2;
-	const size_t NUM_RENDERPASS_IDS = 3;
+	static constexpr size_t INVALID_RENDER_PASS_ID = std::numeric_limits<size_t>::max();
 
 	struct RenderPassDetails
 	{
 		vk::RenderPass rp;
 		std::shared_ptr<VkhRenderPassCompat> rp_compat_info;
-		std::vector<vk::Framebuffer> fbo;
 		vk::SampleCountFlagBits msaaSamples = vk::SampleCountFlagBits::e1;
 		size_t identifier;
 
@@ -744,7 +809,8 @@ struct VkRoot final : gfx_api::context
 	bool debugCallbacksEnabled = true;
 	bool debugUtilsExtEnabled = false;
 
-	bool startedRenderPass = false;
+	bool frameHasDrawCommands = false;
+	bool hasActivePass = false;
 	const size_t maxErrorHandlingDepth = 10;
 	std::vector<vk::Result> errorHandlingDepth;
 
@@ -795,9 +861,9 @@ private:
 	void createSwapchain(bool allowHandleSurfaceLost = true); // Throws on failure
 	void rebuildPipelinesIfNecessary();
 
-	void createDefaultRenderpass(vk::Format swapchainFormat, vk::Format depthFormat);
-	void createDepthPasses(vk::Format depthFormat);
-	void createDepthPassImagesAndFBOs(vk::Format depthFormat);
+	void registerSwapchainPipelineSurfaces(vk::Format colorFormat, vk::Format depthFormat);
+	void destroySwapchainPipelineSurfaces();
+	void createDepthPassImages(vk::Format depthFormat);
 	void createSceneRenderpass(vk::Format sceneFormat, vk::Format depthFormat);
 	void destroySceneRenderpass();
 	void setupSwapchainImages();
@@ -822,22 +888,32 @@ public:
 
 	virtual size_t numDepthPasses() override;
 	virtual bool setDepthPassProperties(size_t numDepthPasses, size_t depthBufferResolution) override;
+	virtual void beginPass(const gfx_api::RenderPassDesc& pass, const gfx_api::CompiledPass* compiledPass = nullptr) override;
+	virtual void endPass(const gfx_api::CompiledPass* compiledPass = nullptr) override;
+	virtual void submitFrame() override;
 	virtual void beginDepthPass(size_t idx) override;
-	virtual size_t getDepthPassDimensions(size_t idx) override;
 	virtual void endCurrentDepthPass() override;
-	virtual gfx_api::abstract_texture* getDepthTexture() override;
-
 	virtual void beginSceneRenderPass() override;
 	virtual void endSceneRenderPass() override;
-	virtual gfx_api::abstract_texture* getSceneTexture() override;
-
 	virtual void beginRenderPass() override;
 	virtual void endRenderPass() override;
+	virtual size_t getDepthPassDimensions(size_t idx) override;
+	virtual gfx_api::abstract_texture* getPipelineSurface(gfx_api::PipelineSurfaceId id) override;
+	virtual gfx_api::PipelineSurfaceMeta pipelineSurfaceMeta(gfx_api::PipelineSurfaceId id) const override;
+	virtual nonstd::optional<gfx_api::PipelineSurfaceId> findPipelineSurfaceId(gfx_api::abstract_texture* texture) const override;
+	virtual bool isSceneMSAAEnabled() const override;
+	virtual bool isSwapchainMSAAEnabled() const override;
+	virtual bool isMultisampledColorAttachment(gfx_api::abstract_texture* texture) const override;
+	virtual gfx_api::pixel_format getDepthStencilFormat() const override;
+	virtual gfx_api::abstract_texture* acquireTransientRenderTarget(gfx_api::pixel_format format, uint32_t width, uint32_t height) override;
+	virtual void releaseTransientRenderTargets() override;
+	virtual void purgeFrameResources() override;
+	virtual optional<std::pair<uint32_t, uint32_t>> getRenderTargetDimensions(gfx_api::abstract_texture* texture) override;
+	virtual void warmCompiledRenderGraph(std::vector<gfx_api::RenderPassDesc>& passes,
+		gfx_api::PassGraphCompileResult& compileResult) override;
 	virtual void set_polygon_offset(const float& offset, const float& slope) override;
 	virtual void set_depth_range(const float& min, const float& max) override;
 private:
-	void startRenderPass();
-
 	enum AcquireNextSwapchainImageResult
 	{
 		eSuccess,
@@ -847,6 +923,8 @@ private:
 
 	void handleSurfaceLost(); // Throws on failure
 	void waitForAllIdle(); // Throws on failure
+	/// Close any in-progress command buffer / render pass recording before GPU teardown.
+	void finalizeActiveRecording();
 	void destroySwapchainAndSwapchainSpecificStuff(bool doDestroySwapchain);
 	void createNewSwapchainAndSwapchainSpecificStuff(const vk::Result& reason); // Throws on failure
 
@@ -869,6 +947,7 @@ public:
 	virtual std::pair<uint32_t, uint32_t> getDrawableDimensions() override;
 	bool isYAxisInverted() const override { return true; }
 	virtual bool shouldDraw() override;
+	bool canRecordDrawCommands() const override;
 	virtual void shutdown() override;
 	virtual const size_t& current_FrameNum() const override;
 	virtual bool setSwapInterval(gfx_api::context::swap_interval_mode mode, const SetSwapIntervalCompletionHandler& completionHandler) override;
@@ -886,6 +965,9 @@ public:
 	virtual void draw_elements_instanced(const std::size_t& offset, const std::size_t& count, const gfx_api::primitive_type& primitive, const gfx_api::index_type& index, std::size_t instance_count) override;
 	// debug apis for recompiling pipelines
 	virtual bool debugRecompileAllPipelines() override;
+	/// Records post-upload / external-producer layout for one subresource.
+	void noteExternalSubresourceLayout(const gfx_api::LayoutSubresourceKey& subresource,
+		vk::ImageLayout layout) const;
 private:
 	virtual bool _initialize(const gfx_api::backend_Impl_Factory& impl, int32_t antialiasing, swap_interval_mode mode, optional<float> mipLodBias, uint32_t depthMapResolution) override;
 	bool initPixelFormatsSupport();
@@ -893,14 +975,71 @@ private:
 	std::string calculateFormattedRendererInfoString() const;
 	void set_uniforms_set(const size_t& set_idx, const void* buffer, size_t bufferSize);
 	const RenderPassDetails& currentRenderPass();
-	RenderPassDetails& defaultRenderpass() { return renderPasses[DEFAULT_RENDER_PASS_ID]; }
-	bool endRenderPass_RecreateSwapchain(const vk::Result& reason);
+	bool recreateSwapchainAfterPresentError(const vk::Result& reason);
+	bool openLegacySwapchainPass(gfx_api::AttachmentLoadOp colorLoad, gfx_api::AttachmentLoadOp depthLoad);
+	void bootstrapLegacySwapchainPass();
+	void ensureRenderPassPSOCapacity(size_t requiredCount);
+	void destroyRenderPassIndexedPSOs(size_t fromIndex);
+	size_t getOrCreatePassRenderPassId(const gfx_api::vk::PassLayoutKey& key);
+	vk::Format getAttachmentVkFormat(gfx_api::abstract_texture* texture) const;
+	vk::SampleCountFlagBits getAttachmentVkSamples(gfx_api::abstract_texture* texture) const;
+	vk::ImageView getAttachmentImageView(const gfx_api::AttachmentDesc& attachment) const;
+	void destroyDynamicRenderPasses();
+	void resetImageLayoutTracker();
+	void setImageLayout(gfx_api::abstract_texture* texture, vk::ImageLayout layout);
+	void setImageLayout(const gfx_api::LayoutSubresourceKey& subresource, vk::ImageLayout layout);
+	vk::ImageLayout getImageLayout(gfx_api::abstract_texture* texture) const;
+	vk::ImageLayout getImageLayout(const gfx_api::LayoutSubresourceKey& subresource) const;
+	vk::Image getVkImageHandle(gfx_api::abstract_texture* texture) const;
+	vk::ImageAspectFlags getVkImageAspect(gfx_api::abstract_texture* texture) const;
+	/// Records an image barrier and updates `_frameLayoutTracker`
+	void transitionImageLayout(vk::CommandBuffer cmdBuffer, const gfx_api::LayoutSubresourceKey& subresource,
+		vk::ImageLayout oldLayout, vk::ImageLayout newLayout,
+		vk::PipelineStageFlags srcStage, vk::PipelineStageFlags dstStage,
+		vk::AccessFlags srcAccess, vk::AccessFlags dstAccess);
+	/// Records an image barrier and updates `_frameLayoutTracker`
+	void transitionImageLayout(vk::CommandBuffer cmdBuffer, gfx_api::abstract_texture* texture, vk::ImageLayout newLayout,
+		vk::PipelineStageFlags srcStage, vk::PipelineStageFlags dstStage, vk::AccessFlags srcAccess, vk::AccessFlags dstAccess);
+	/// Records an image barrier and updates `_frameLayoutTracker`
+	void transitionImageLayout(vk::CommandBuffer cmdBuffer, gfx_api::abstract_texture* texture, vk::ImageLayout oldLayout,
+		vk::ImageLayout newLayout, vk::PipelineStageFlags srcStage, vk::PipelineStageFlags dstStage,
+		vk::AccessFlags srcAccess, vk::AccessFlags dstAccess);
+	/// Delegates to `_barrierEmitter.emitBatch`
+	void emitPrePassBarriers(const gfx_api::ExecutionBatch& batch,
+		const std::vector<gfx_api::CompiledPass>& compiledPasses) override;
+	/// Applies `CompiledPass::postPassLayoutUpdates` via `_frameLayoutTracker`.
+	void applyCompiledPostPassLayouts(const gfx_api::CompiledPass& pass);
+	void applyViewport(vk::CommandBuffer cmdBuffer, uint32_t width, uint32_t height, float minDepth, float maxDepth);
+	void deferDestroyFramebuffer(vk::Framebuffer framebuffer);
+	void clearFramebufferCache();
+	bool buildPassLayoutKey(gfx_api::vk::PassLayoutKey& out, const gfx_api::RenderPassDesc& pass,
+		const gfx_api::CompiledPass* compiledPass);
+	void buildFramebufferKey(gfx_api::FramebufferResourceKey& out, size_t renderPassId, uint32_t passWidth,
+		uint32_t passHeight, const std::vector<vk::ImageView>& fboAttachments);
+	/// Resizes `_warmEntries` to match compiled pass count.
+	void resizeWarmEntries(size_t passCount);
+	/// Marks all warm entries cold (epoch bump / render-graph rebuild).
+	void invalidateWarmEntries();
+	/// Per-`graphIndex` warm cache entry; populated by `warmCompiledRenderGraph`.
+	gfx_api::vk::VulkanWarmEntry& warmEntry(size_t graphIndex);
+	const gfx_api::vk::VulkanWarmEntry& warmEntry(size_t graphIndex) const;
+
+	// Friend access for vk/ modules that need device state, renderPasses[], and attachment helpers.
+	friend class gfx_api::vk::RenderPassLayoutCache;
+	friend class gfx_api::vk::FrameLayoutTracker;
+	friend class gfx_api::vk::PrePassBarrierEmitter;
+	friend bool gfx_api::vk::populatePassLayoutKeyFormats(gfx_api::vk::PassLayoutKey&,
+		const gfx_api::RenderPassDesc&, const VkRoot&);
+	friend bool gfx_api::vk::populatePassLayoutKeyLayouts(gfx_api::vk::PassLayoutKey&,
+		const gfx_api::RenderPassDesc&, const gfx_api::vk::LayoutKeyBuildContext&);
+	friend bool gfx_api::vk::buildPassLayoutKey(gfx_api::vk::PassLayoutKey&,
+		const gfx_api::RenderPassDesc&, const gfx_api::vk::LayoutKeyBuildContext&, const VkRoot&);
 private:
 	size_t depthPassCount = WZ_MAX_SHADOW_CASCADES;
 	std::string formattedRendererInfoString;
 	std::vector<gfx_api::pixel_format_usage::flags> texture2DFormatsSupport;
 	uint32_t lastRenderPassEndTime = 0;
-	size_t currentRenderPassId = DEFAULT_RENDER_PASS_ID;
+	size_t currentRenderPassId = INVALID_RENDER_PASS_ID;
 
 	struct QueuedSwapModeChange
 	{
@@ -908,6 +1047,37 @@ private:
 		SetSwapIntervalCompletionHandler completionHandler;
 	};
 	optional<QueuedSwapModeChange> queuedSwapModeChange = nullopt;
+
+	std::unique_ptr<VkAttachmentImage> _sceneDepthSurface;
+	std::unique_ptr<VkAttachmentImage> _sceneMsaaSurface;
+	std::unique_ptr<VkSwapchainColorSurface> _swapchainColorSurface;
+	std::unique_ptr<VkSwapchainMsaaColorSurface> _swapchainMsaaColorSurface;
+	std::unique_ptr<VkSwapchainDepthSurface> _swapchainDepthSurface;
+	gfx_api::PipelineSurfaceRegistry _pipelineSurfaces;
+	gfx_api::FrameResourceCache _frameResourceCache;
+	gfx_api::FramebufferResourceCache _framebufferCache;
+
+	/// Reusable `PassLayoutKey` buffer for `buildPassLayoutKey` / cache lookup at call sites.
+	gfx_api::vk::PassLayoutKey _passLayoutScratch;
+	/// Owns layout keys and on-demand `vk::RenderPass` creation.
+	gfx_api::vk::RenderPassLayoutCache _renderPassLayoutCache;
+	/// Runtime per-texture layout map and swapchain present transition.
+	mutable gfx_api::vk::FrameLayoutTracker _frameLayoutTracker;
+	/// Batched pre-pass barriers from `CompiledPass::prePassBarriers`.
+	gfx_api::vk::PrePassBarrierEmitter _barrierEmitter;
+	/// Warm render-pass layout ids keyed by `CompiledPass::graphIndex`.
+	std::vector<gfx_api::vk::VulkanWarmEntry> _warmEntries;
+	std::vector<vk::ImageView> _fboAttachmentsScratch;
+	std::vector<vk::ClearValue> _clearValuesScratch;
+	gfx_api::FramebufferResourceKey _framebufferKeyScratch;
+
+	float _viewportMinDepth = 0.f;
+	float _viewportMaxDepth = 1.f;
+	bool _activePassTargetsSwapchain = false;
+	bool _legacyFrameStarted = false;
+	/// Captures out-of-graph final layouts at `beginPass`, commits at `endPass`.
+	gfx_api::vk::LegacyPassLayoutCommit _legacyPassLayoutCommit;
+	vk::Framebuffer _activeDynamicFramebuffer;
 };
 
 #endif // defined(WZ_VULKAN_ENABLED)

--- a/lib/ivis_opengl/piedraw.cpp
+++ b/lib/ivis_opengl/piedraw.cpp
@@ -26,6 +26,7 @@
 
 #include "lib/ivis_opengl/piedraw.h"
 #include "lib/framework/frame.h"
+#include "lib/framework/hash_combine.h"
 #include "lib/framework/pool_allocator.h"
 #include "lib/ivis_opengl/ivisdef.h"
 #include "lib/ivis_opengl/imd.h"
@@ -333,19 +334,6 @@ void pie_Draw3DButton(const iIMDShape *shape, PIELIGHT teamcolour, const glm::ma
 	polyCount += shape->polys.size();
 	gfx_api::Draw3DShapeOpaque::get().unbind_vertex_buffers(shape->buffers[VBO_VERTEX], shape->buffers[VBO_NORMAL], shape->buffers[VBO_TEXCOORD], pTangentBuffer);
 	gfx_api::context::get().unbind_index_buffer(*shape->buffers[VBO_INDEX]);
-}
-
-inline void hash_combine(std::size_t& seed) { }
-
-template <typename T, typename... Rest>
-inline void hash_combine(std::size_t& seed, const T& v, Rest... rest) {
-	std::hash<T> hasher;
-#if SIZE_MAX >= UINT64_MAX
-	seed ^= hasher(v) + 0x9e3779b97f4a7c15L + (seed<<6) + (seed>>2);
-#else
-	seed ^= hasher(v) + 0x9e3779b9 + (seed<<6) + (seed>>2);
-#endif
-	hash_combine(seed, rest...);
 }
 
 struct templatedState

--- a/lib/ivis_opengl/piemode.cpp
+++ b/lib/ivis_opengl/piemode.cpp
@@ -92,7 +92,12 @@ void pie_ShutDown()
 
 /***************************************************************************/
 
-static bool renderingFrame = true; // starts off true
+static bool renderingFrame = false;
+
+bool pie_IsScreenFrameRendering()
+{
+	return renderingFrame;
+}
 
 void pie_ScreenFrameRenderBegin()
 {
@@ -103,7 +108,7 @@ void pie_ScreenFrameRenderBegin()
 	}
 	renderingFrame = true;
 	gfx_api::context::get().beginRenderPass();
-	if (screen_GetBackDrop())
+	if (screen_GetBackDrop() && gfx_api::context::get().canRecordDrawCommands())
 	{
 		screen_Display();
 	}

--- a/lib/ivis_opengl/piemode.h
+++ b/lib/ivis_opengl/piemode.h
@@ -51,6 +51,7 @@ bool pie_Initialise();
 void pie_ShutDown();
 void pie_ScreenFrameRenderBegin();
 void pie_ScreenFrameRenderEnd();
+bool pie_IsScreenFrameRendering();
 void pie_UpdateSurfaceGeometry();
 UDWORD pie_GetResScalingFactor();
 

--- a/lib/ivis_opengl/render_graph/attachment.h
+++ b/lib/ivis_opengl/render_graph/attachment.h
@@ -49,7 +49,7 @@ enum class AttachmentLoadOp
 /// </summary>
 enum class AttachmentStoreOp : uint8_t
 {
-	Store,      // keep contents (shadow depth, resolve output, transient scratch)
+	Store,      // keep contents (shadow depth, resolve output)
 	DontCare,   // contents not needed after pass (MSAA intermediate color)
 	Resolve,    // MSAA color → resolve attachment (VK subpass; GL blit target)
 	Invalidate, // tile-friendly discard (scene depth/stencil after scene pass)
@@ -81,20 +81,10 @@ struct ClearValue
 };
 
 /// <summary>
-/// Where an attachment's backing storage comes from at execute time.
-/// </summary>
-enum class AttachmentSource
-{
-	Texture,          // explicit abstract_texture* or pipeline surface
-	Transient,        // per-frame cache allocation (texture resolved at execute)
-};
-
-/// <summary>
 /// Describes a color, depth, or resolve attachment for a render pass.
 /// </summary>
 struct AttachmentDesc
 {
-	AttachmentSource source = AttachmentSource::Texture;
 	abstract_texture* texture = nullptr;
 	AttachmentLoadOp loadOp = AttachmentLoadOp::Clear;
 	/// When unset, resolved during pass resolution.
@@ -108,16 +98,10 @@ struct AttachmentDesc
 		return loadOp == AttachmentLoadOp::Clear;
 	}
 
-	bool isTransient() const
-	{
-		return source == AttachmentSource::Transient;
-	}
-
 	static AttachmentDesc color(abstract_texture* tex, AttachmentLoadOp op = AttachmentLoadOp::Clear,
 		ClearValue clear = ClearValue::colorClear())
 	{
 		AttachmentDesc desc;
-		desc.source = AttachmentSource::Texture;
 		desc.texture = tex;
 		desc.loadOp = op;
 		desc.clearValue = clear;
@@ -128,30 +112,7 @@ struct AttachmentDesc
 		ClearValue clear = ClearValue::depthStencilClear())
 	{
 		AttachmentDesc desc;
-		desc.source = AttachmentSource::Texture;
 		desc.texture = tex;
-		desc.loadOp = op;
-		desc.clearValue = clear;
-		return desc;
-	}
-
-	/// Per-frame pooled color target; texture is filled in during pass resolution.
-	static AttachmentDesc transientColor(AttachmentLoadOp op = AttachmentLoadOp::Clear,
-		ClearValue clear = ClearValue::colorClear())
-	{
-		AttachmentDesc desc;
-		desc.source = AttachmentSource::Transient;
-		desc.loadOp = op;
-		desc.clearValue = clear;
-		return desc;
-	}
-
-	/// Per-frame pooled depth/stencil target; texture is filled in during pass resolution.
-	static AttachmentDesc transientDepth(AttachmentLoadOp op = AttachmentLoadOp::Clear,
-		ClearValue clear = ClearValue::depthStencilClear())
-	{
-		AttachmentDesc desc;
-		desc.source = AttachmentSource::Transient;
 		desc.loadOp = op;
 		desc.clearValue = clear;
 		return desc;

--- a/lib/ivis_opengl/render_graph/attachment.h
+++ b/lib/ivis_opengl/render_graph/attachment.h
@@ -1,0 +1,161 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+/*
+	This file is part of Warzone 2100.
+	Copyright (C) 2026  Warzone 2100 Project (https://github.com/Warzone2100)
+
+	Warzone 2100 is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+
+	Warzone 2100 is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with Warzone 2100; if not, write to the Free Software
+	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+/** @file attachment.h
+ * Attachment load/store operations and `AttachmentDesc` for render pass inputs and outputs.
+ */
+
+#pragma once
+
+#include <array>
+#include <cstdint>
+
+#include <optional>
+
+namespace gfx_api
+{
+
+struct abstract_texture;
+
+/// <summary>
+/// Load operation for a render pass attachment
+/// </summary>
+enum class AttachmentLoadOp
+{
+	Clear,
+	Load,
+	DontCare
+};
+
+/// <summary>
+/// Store operation for a render pass attachment (post-pass contract).
+/// </summary>
+enum class AttachmentStoreOp : uint8_t
+{
+	Store,      // keep contents (shadow depth, resolve output, transient scratch)
+	DontCare,   // contents not needed after pass (MSAA intermediate color)
+	Resolve,    // MSAA color → resolve attachment (VK subpass; GL blit target)
+	Invalidate, // tile-friendly discard (scene depth/stencil after scene pass)
+};
+
+/// <summary>
+/// Clear values for color and depth/stencil attachments.
+/// </summary>
+struct ClearValue
+{
+	std::array<float, 4> color = {0.f, 0.f, 0.f, 1.f};
+	float depth = 1.f;
+	uint32_t stencil = 0;
+
+	static ClearValue colorClear(float r = 0.f, float g = 0.f, float b = 0.f, float a = 1.f)
+	{
+		ClearValue v;
+		v.color = {r, g, b, a};
+		return v;
+	}
+
+	static ClearValue depthStencilClear(float depthValue = 1.f, uint32_t stencilValue = 0)
+	{
+		ClearValue v;
+		v.depth = depthValue;
+		v.stencil = stencilValue;
+		return v;
+	}
+};
+
+/// <summary>
+/// Where an attachment's backing storage comes from at execute time.
+/// </summary>
+enum class AttachmentSource
+{
+	Texture,          // explicit abstract_texture* or pipeline surface
+	Transient,        // per-frame cache allocation (texture resolved at execute)
+};
+
+/// <summary>
+/// Describes a color, depth, or resolve attachment for a render pass.
+/// </summary>
+struct AttachmentDesc
+{
+	AttachmentSource source = AttachmentSource::Texture;
+	abstract_texture* texture = nullptr;
+	AttachmentLoadOp loadOp = AttachmentLoadOp::Clear;
+	/// When unset, resolved during pass resolution.
+	std::optional<AttachmentStoreOp> storeOp;
+	ClearValue clearValue;
+	uint32_t mipLevel = 0;
+	uint32_t arrayLayer = 0;
+
+	bool shouldClear() const
+	{
+		return loadOp == AttachmentLoadOp::Clear;
+	}
+
+	bool isTransient() const
+	{
+		return source == AttachmentSource::Transient;
+	}
+
+	static AttachmentDesc color(abstract_texture* tex, AttachmentLoadOp op = AttachmentLoadOp::Clear,
+		ClearValue clear = ClearValue::colorClear())
+	{
+		AttachmentDesc desc;
+		desc.source = AttachmentSource::Texture;
+		desc.texture = tex;
+		desc.loadOp = op;
+		desc.clearValue = clear;
+		return desc;
+	}
+
+	static AttachmentDesc depth(abstract_texture* tex, AttachmentLoadOp op = AttachmentLoadOp::Clear,
+		ClearValue clear = ClearValue::depthStencilClear())
+	{
+		AttachmentDesc desc;
+		desc.source = AttachmentSource::Texture;
+		desc.texture = tex;
+		desc.loadOp = op;
+		desc.clearValue = clear;
+		return desc;
+	}
+
+	/// Per-frame pooled color target; texture is filled in during pass resolution.
+	static AttachmentDesc transientColor(AttachmentLoadOp op = AttachmentLoadOp::Clear,
+		ClearValue clear = ClearValue::colorClear())
+	{
+		AttachmentDesc desc;
+		desc.source = AttachmentSource::Transient;
+		desc.loadOp = op;
+		desc.clearValue = clear;
+		return desc;
+	}
+
+	/// Per-frame pooled depth/stencil target; texture is filled in during pass resolution.
+	static AttachmentDesc transientDepth(AttachmentLoadOp op = AttachmentLoadOp::Clear,
+		ClearValue clear = ClearValue::depthStencilClear())
+	{
+		AttachmentDesc desc;
+		desc.source = AttachmentSource::Transient;
+		desc.loadOp = op;
+		desc.clearValue = clear;
+		return desc;
+	}
+};
+
+} // namespace gfx_api

--- a/lib/ivis_opengl/render_graph/blueprint.cpp
+++ b/lib/ivis_opengl/render_graph/blueprint.cpp
@@ -1,0 +1,233 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+/*
+	This file is part of Warzone 2100.
+	Copyright (C) 2026  Warzone 2100 Project (https://github.com/Warzone2100)
+
+	Warzone 2100 is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+
+	Warzone 2100 is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with Warzone 2100; if not, write to the Free Software
+	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+/** @file blueprint.cpp
+ * `BlueprintBuilder` implementation and swapchain/scene pass blueprint helpers.
+ */
+
+#include "blueprint.h"
+
+#include "lib/framework/hash_combine.h"
+#include "lib/framework/wzapp.h"
+
+#include <fmt/format.h>
+#include <fmt/ostream.h>
+#include <sstream>
+#include <string>
+
+namespace gfx_api
+{
+
+namespace
+{
+
+static BlueprintAttachment makePipelineColorAttachment(PipelineSurfaceId surface, AttachmentLoadOp load,
+	AttachmentStoreOp store, ClearValue clear = ClearValue::colorClear())
+{
+	BlueprintAttachment attachment;
+	attachment.target = BlueprintAttachment::Target::PipelineSurface;
+	attachment.surfaceId = surface;
+	attachment.loadOp = load;
+	attachment.storeOp = store;
+	attachment.clearValue = clear;
+	return attachment;
+}
+
+static BlueprintAttachment makePipelineDepthAttachment(PipelineSurfaceId surface, AttachmentLoadOp load,
+	AttachmentStoreOp store, optional<uint32_t> arrayLayer = nullopt,
+	ClearValue clear = ClearValue::depthStencilClear())
+{
+	BlueprintAttachment attachment;
+	attachment.target = BlueprintAttachment::Target::PipelineSurface;
+	attachment.surfaceId = surface;
+	attachment.loadOp = load;
+	attachment.storeOp = store;
+	attachment.arrayLayer = arrayLayer;
+	attachment.clearValue = clear;
+	return attachment;
+}
+
+void hashBlueprintAttachment(std::size_t& h, const BlueprintAttachment& attachment)
+{
+	hash_combine(h,
+		static_cast<std::size_t>(attachment.target),
+		static_cast<std::size_t>(attachment.surfaceId),
+		static_cast<std::size_t>(attachment.loadOp),
+		static_cast<std::size_t>(attachment.storeOp),
+		attachment.arrayLayer.has_value() ? 1u : 0u);
+	if (attachment.arrayLayer.has_value())
+	{
+		hash_combine(h, attachment.arrayLayer.value());
+	}
+}
+
+void hashBlueprintReadEdge(std::size_t& h, const BlueprintReadEdge& edge)
+{
+	hash_combine(h,
+		static_cast<std::size_t>(edge.producerPass),
+		static_cast<std::size_t>(edge.producerRole),
+		edge.attachmentIndex);
+}
+
+} // anonymous namespace
+
+BlueprintBuilder& BlueprintBuilder::beginPass(PassId id, std::string debugName)
+{
+	_passes.push_back({});
+	_current = &_passes.back();
+	_current->id = id;
+	_current->debugName = std::move(debugName);
+	return *this;
+}
+
+BlueprintBuilder& BlueprintBuilder::color(PipelineSurfaceId surface, AttachmentLoadOp load, AttachmentStoreOp store,
+	ClearValue clear)
+{
+	ASSERT(_current != nullptr, "BlueprintBuilder::color without beginPass");
+	_current->colorAttachments.push_back(makePipelineColorAttachment(surface, load, store, clear));
+	return *this;
+}
+
+BlueprintBuilder& BlueprintBuilder::depth(PipelineSurfaceId surface, AttachmentLoadOp load, AttachmentStoreOp store,
+	optional<uint32_t> arrayLayer, ClearValue clear)
+{
+	ASSERT(_current != nullptr, "BlueprintBuilder::depth without beginPass");
+	_current->depthAttachment = makePipelineDepthAttachment(surface, load, store, arrayLayer, clear);
+	return *this;
+}
+
+BlueprintBuilder& BlueprintBuilder::resolve(PipelineSurfaceId surface, AttachmentLoadOp load, AttachmentStoreOp store,
+	ClearValue clear)
+{
+	ASSERT(_current != nullptr, "BlueprintBuilder::resolve without beginPass");
+	_current->resolveAttachment = makePipelineColorAttachment(surface, load, store, clear);
+	return *this;
+}
+
+BlueprintBuilder& BlueprintBuilder::viewport(ViewportRule rule, uint32_t cascadeIndex)
+{
+	ASSERT(_current != nullptr, "BlueprintBuilder::viewport without beginPass");
+	_current->viewportRule = rule;
+	_current->viewportCascadeIndex = cascadeIndex;
+	return *this;
+}
+
+BlueprintBuilder& BlueprintBuilder::readFrom(PassId producer, AttachmentRole role, uint32_t attachmentIndex)
+{
+	ASSERT(_current != nullptr, "BlueprintBuilder::readFrom without beginPass");
+	BlueprintReadEdge edge;
+	edge.producerPass = producer;
+	edge.producerRole = role;
+	edge.attachmentIndex = attachmentIndex;
+	_current->reads.push_back(edge);
+	return *this;
+}
+
+PassGraphTopologyBlueprint BlueprintBuilder::build()
+{
+	PassGraphTopologyBlueprint blueprint;
+	blueprint._passes = std::move(_passes);
+	_current = nullptr;
+	return blueprint;
+}
+
+uint64_t PassGraphTopologyBlueprint::topologyHash() const
+{
+	std::size_t h = 0;
+	hash_combine(h, _passes.size());
+	for (const BlueprintPass& pass : _passes)
+	{
+		hash_combine(h,
+			static_cast<std::size_t>(pass.id),
+			static_cast<std::size_t>(pass.viewportRule),
+			pass.viewportCascadeIndex);
+
+		for (const BlueprintAttachment& colorAttachment : pass.colorAttachments)
+		{
+			hashBlueprintAttachment(h, colorAttachment);
+		}
+		if (pass.depthAttachment.has_value())
+		{
+			hashBlueprintAttachment(h, pass.depthAttachment.value());
+		}
+		if (pass.resolveAttachment.has_value())
+		{
+			hashBlueprintAttachment(h, pass.resolveAttachment.value());
+		}
+		for (const BlueprintReadEdge& read : pass.reads)
+		{
+			hashBlueprintReadEdge(h, read);
+		}
+	}
+	return static_cast<uint64_t>(h);
+}
+
+void addScenePassToBuilder(BlueprintBuilder& builder, PassId id, bool sceneMsaa)
+{
+	builder.beginPass(id, "ScenePass");
+	if (sceneMsaa)
+	{
+		builder.color(PipelineSurfaceId::SceneMSAAColor, AttachmentLoadOp::Clear, AttachmentStoreOp::DontCare)
+			.resolve(PipelineSurfaceId::SceneColor, AttachmentLoadOp::DontCare, AttachmentStoreOp::Store);
+	}
+	else
+	{
+		builder.color(PipelineSurfaceId::SceneColor, AttachmentLoadOp::Clear, AttachmentStoreOp::Store);
+	}
+	builder.depth(PipelineSurfaceId::SceneDepth, AttachmentLoadOp::Clear, AttachmentStoreOp::Invalidate)
+		.viewport(ViewportRule::SceneColorTarget);
+}
+
+void addSwapchainPassToBuilder(BlueprintBuilder& builder, PassId id, std::string debugName,
+	bool swapchainMsaa, AttachmentLoadOp colorLoad, optional<AttachmentLoadOp> depthLoadOverride)
+{
+	builder.beginPass(id, std::move(debugName));
+	if (swapchainMsaa)
+	{
+		builder.color(PipelineSurfaceId::SwapchainMSAAColor, colorLoad, AttachmentStoreOp::DontCare)
+			.resolve(PipelineSurfaceId::SwapchainColor, AttachmentLoadOp::DontCare, AttachmentStoreOp::Store);
+	}
+	else
+	{
+		builder.color(PipelineSurfaceId::SwapchainColor, colorLoad, AttachmentStoreOp::Store);
+	}
+
+	const AttachmentLoadOp depthLoad = depthLoadOverride.has_value()
+		? depthLoadOverride.value()
+		: ((colorLoad == AttachmentLoadOp::Clear) ? AttachmentLoadOp::Clear : AttachmentLoadOp::Load);
+	builder.depth(PipelineSurfaceId::SwapchainDepth, depthLoad, AttachmentStoreOp::DontCare)
+		.viewport(ViewportRule::Drawable);
+}
+
+std::string dumpBlueprint(const PassGraphTopologyBlueprint& blueprint)
+{
+	std::ostringstream out;
+	fmt::print(out, "Blueprint passes={} hash=0x{:x}\n",
+		blueprint.passes().size(), blueprint.topologyHash());
+	for (size_t i = 0; i < blueprint.passes().size(); ++i)
+	{
+		const BlueprintPass& pass = blueprint.passes()[i];
+		fmt::print(out, "  [{}] {} id={} reads={}\n",
+			i, pass.debugName, static_cast<unsigned>(pass.id), pass.reads.size());
+	}
+	return out.str();
+}
+
+} // namespace gfx_api

--- a/lib/ivis_opengl/render_graph/blueprint.h
+++ b/lib/ivis_opengl/render_graph/blueprint.h
@@ -67,7 +67,7 @@ struct RecordFuncTable
 ///
 /// Describes *what kind* of attachment to bind, not a resolved `AttachmentDesc`.
 /// `BlueprintMaterializer` turns each slot into a concrete texture using the current
-/// `RenderTopologySnapshot` (pipeline surfaces) or transient pool (offscreen targets).
+/// `RenderTopologySnapshot` (pipeline surfaces only).
 /// </summary>
 struct BlueprintAttachment
 {
@@ -76,14 +76,10 @@ struct BlueprintAttachment
 	{
 		/// Named surface from `PipelineSurfaceId` (scene, swapchain, shadow map, …).
 		PipelineSurface,
-		/// Per-frame pooled color target; dimensions come from the pass viewport.
-		TransientColor,
-		/// Per-frame pooled depth target; dimensions come from the pass viewport.
-		TransientDepth,
 	};
 
 	Target target = Target::PipelineSurface;
-	/// Used when `target == PipelineSurface`; ignored for transient targets.
+	/// Used when `target == PipelineSurface`.
 	PipelineSurfaceId surfaceId = PipelineSurfaceId::SceneColor;
 	AttachmentLoadOp loadOp = AttachmentLoadOp::Clear;
 	AttachmentStoreOp storeOp = AttachmentStoreOp::Store;

--- a/lib/ivis_opengl/render_graph/blueprint.h
+++ b/lib/ivis_opengl/render_graph/blueprint.h
@@ -1,0 +1,219 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+/*
+	This file is part of Warzone 2100.
+	Copyright (C) 2026  Warzone 2100 Project (https://github.com/Warzone2100)
+
+	Warzone 2100 is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+
+	Warzone 2100 is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with Warzone 2100; if not, write to the Free Software
+	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+/** @file blueprint.h
+ * Topology-stable pass graph blueprint types, `BlueprintBuilder`, and `RecordFuncTable`.
+ */
+
+#pragma once
+
+#include "render_pass.h"
+#include "render_pass_id.h"
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include <optional>
+using std::optional;
+using std::nullopt;
+
+namespace gfx_api
+{
+
+/// <summary>
+/// Draw-callback registry keyed by stable pass identity (`PassId`).
+///
+/// Attaches record callbacks to passes without storing them in
+/// `PassGraphTopologyBlueprint`, so topology can be cached, hashed,
+/// rematerialized on resize, and debug-dumped independently of game draw code.
+///
+/// `BlueprintMaterializer` merges this table with the blueprint at
+/// materialize time; `CachedRenderGraph` keeps it across rematerializations.
+/// </summary>
+struct RecordFuncTable
+{
+	/// Per `PassId` record callbacks; empty slots are skipped at execute time.
+	std::array<RenderPassDesc::RecordFunc, static_cast<size_t>(PassId::Count)> funcs{};
+
+	/// Register the draw callback for a pass slot.
+	void set(PassId id, RenderPassDesc::RecordFunc func)
+	{
+		funcs[static_cast<size_t>(id)] = std::move(func);
+	}
+};
+
+/// <summary>
+/// Declarative attachment slot for a blueprint pass (load/store/clear), before GPU textures exist.
+///
+/// Describes *what kind* of attachment to bind, not a resolved `AttachmentDesc`.
+/// `BlueprintMaterializer` turns each slot into a concrete texture using the current
+/// `RenderTopologySnapshot` (pipeline surfaces) or transient pool (offscreen targets).
+/// </summary>
+struct BlueprintAttachment
+{
+	/// How the materializer resolves this slot to a texture.
+	enum class Target : uint8_t
+	{
+		/// Named surface from `PipelineSurfaceId` (scene, swapchain, shadow map, …).
+		PipelineSurface,
+		/// Per-frame pooled color target; dimensions come from the pass viewport.
+		TransientColor,
+		/// Per-frame pooled depth target; dimensions come from the pass viewport.
+		TransientDepth,
+	};
+
+	Target target = Target::PipelineSurface;
+	/// Used when `target == PipelineSurface`; ignored for transient targets.
+	PipelineSurfaceId surfaceId = PipelineSurfaceId::SceneColor;
+	AttachmentLoadOp loadOp = AttachmentLoadOp::Clear;
+	AttachmentStoreOp storeOp = AttachmentStoreOp::Store;
+	/// Shadow-map cascade layer; only for depth pipeline surfaces that use array layers.
+	optional<uint32_t> arrayLayer;
+	ClearValue clearValue = ClearValue::colorClear();
+};
+
+/// <summary>
+/// Cross-pass read dependency declared in topology form (producer `PassId`, not pass index).
+///
+/// At materialize time, `BlueprintMaterializer` maps `producerPass` to the producer's
+/// runtime `PassHandle` and emits a `ReadDesc` on the consumer pass. The compiler /
+/// backend use that to insert barriers and to resolve inputs in `RenderPassContext`.
+/// </summary>
+struct BlueprintReadEdge
+{
+	/// Stable identity of the pass that wrote the attachment being read.
+	PassId producerPass = PassId::Count;
+	/// Which output of the producer (color, depth, resolve, …).
+	AttachmentRole producerRole = AttachmentRole::PrimaryColor;
+	/// Index into the producer's `colorAttachments` when `producerRole == Color`.
+	uint32_t attachmentIndex = 0;
+};
+
+/// <summary>
+/// Rule for choosing pass viewport width/height at materialize time.
+///
+/// Blueprint stores the rule only; pixel sizes come from `RenderTopologySnapshot`
+/// (`drawableW`/`drawableH`, `sceneW`/`sceneH`, or shadow-map dimensions).
+/// </summary>
+enum class ViewportRule : uint8_t
+{
+	/// Swapchain / drawable size (`drawableW` x `drawableH`).
+	Drawable,
+	/// Offscreen scene color target size (`sceneW` x `sceneH`).
+	SceneColorTarget,
+	/// Shadow cascade map size; use `BlueprintPass::viewportCascadeIndex` to pick the cascade.
+	DepthCascade,
+};
+
+/// <summary>
+/// One node in the pass graph: attachments, viewport rule, and inbound read edges.
+///
+/// Carries a stable `PassId` and debug name but no draw callbacks (those live in
+/// `RecordFuncTable`). Becomes one `RenderPassDesc` when materialized.
+/// </summary>
+struct BlueprintPass
+{
+	/// Stable pass identity; used to look up `RecordFuncTable` entries.
+	PassId id = PassId::Count;
+	std::string debugName;
+	std::vector<BlueprintAttachment> colorAttachments;
+	optional<BlueprintAttachment> depthAttachment;
+	optional<BlueprintAttachment> resolveAttachment;
+	ViewportRule viewportRule = ViewportRule::Drawable;
+	/// Cascade index when `viewportRule == DepthCascade`.
+	uint32_t viewportCascadeIndex = 0;
+	/// Producer passes this pass reads from (compile-time topology edges).
+	std::vector<BlueprintReadEdge> reads;
+};
+
+/// <summary>
+/// Immutable pass-graph topology: pass list, attachments, and read edges only.
+///
+/// Contains no lambdas, viewport pixel sizes, or backend handles. Built from
+/// `RenderTopologySnapshot` (see `fromSnapshot`) or `BlueprintBuilder`, then cached
+/// by `topologyHash` in `CachedRenderGraph`. Rematerialized separately when
+/// `materializeHash` changes (resize, backend epoch).
+/// </summary>
+class PassGraphTopologyBlueprint
+{
+public:
+	/// Ordered pass sequence for this frame topology.
+	const std::vector<BlueprintPass>& passes() const { return _passes; }
+	/// Hash of pass ids, attachment layout, reads, and viewport rules (not dimensions).
+	uint64_t topologyHash() const;
+
+	/// Build the standard topology for a screen kind / feature set (see frame_blueprint.cpp).
+	static PassGraphTopologyBlueprint fromSnapshot(const struct RenderTopologySnapshot& snapshot);
+
+private:
+	friend class BlueprintBuilder;
+	std::vector<BlueprintPass> _passes;
+};
+
+/// Human-readable dump of pass order, attachments, and read edges (debug logging).
+std::string dumpBlueprint(const PassGraphTopologyBlueprint& blueprint);
+
+/// <summary>
+/// Fluent builder for `PassGraphTopologyBlueprint` (structure only).
+///
+/// Call `beginPass`, attach color/depth/resolve slots, set viewport rule and
+/// `readFrom` edges, then `build()`. Used by frame blueprint helpers and custom
+/// topology setup; does not register `RecordFuncTable` callbacks.
+/// </summary>
+class BlueprintBuilder
+{
+public:
+	/// Start a new pass; subsequent calls append to this pass until the next `beginPass`.
+	BlueprintBuilder& beginPass(PassId id, std::string debugName);
+	/// Add a color attachment bound to a pipeline surface.
+	BlueprintBuilder& color(PipelineSurfaceId surface, AttachmentLoadOp load, AttachmentStoreOp store,
+		ClearValue clear = ClearValue::colorClear());
+	/// Add a depth attachment; `arrayLayer` selects a shadow-map cascade slice when needed.
+	BlueprintBuilder& depth(PipelineSurfaceId surface, AttachmentLoadOp load, AttachmentStoreOp store,
+		optional<uint32_t> arrayLayer = nullopt,
+		ClearValue clear = ClearValue::depthStencilClear());
+	/// Add an MSAA resolve target attachment.
+	BlueprintBuilder& resolve(PipelineSurfaceId surface, AttachmentLoadOp load, AttachmentStoreOp store,
+		ClearValue clear = ClearValue::colorClear());
+	/// Set viewport sizing rule for the current pass.
+	BlueprintBuilder& viewport(ViewportRule rule, uint32_t cascadeIndex = 0);
+	/// Declare that the current pass reads an output from a prior pass (by `PassId`).
+	BlueprintBuilder& readFrom(PassId producer, AttachmentRole role = AttachmentRole::PrimaryColor,
+		uint32_t attachmentIndex = 0);
+
+	/// Finish building; invalidates the builder's current-pass cursor.
+	PassGraphTopologyBlueprint build();
+
+private:
+	std::vector<BlueprintPass> _passes;
+	BlueprintPass* _current = nullptr;
+};
+
+/// Append the standard offscreen scene pass (MSAA or single-sample) to `builder`.
+void addScenePassToBuilder(BlueprintBuilder& builder, PassId id, bool sceneMsaa);
+/// Append a swapchain-target pass (MSAA resolve when enabled) with shared depth setup.
+void addSwapchainPassToBuilder(BlueprintBuilder& builder, PassId id, std::string debugName,
+	bool swapchainMsaa, AttachmentLoadOp colorLoad,
+	optional<AttachmentLoadOp> depthLoadOverride = nullopt);
+
+} // namespace gfx_api

--- a/lib/ivis_opengl/render_graph/blueprint_materializer.cpp
+++ b/lib/ivis_opengl/render_graph/blueprint_materializer.cpp
@@ -41,39 +41,22 @@ BlueprintMaterializer::BlueprintMaterializer(const RenderTopologySnapshot& snaps
 
 AttachmentDesc BlueprintMaterializer::resolveAttachment(const BlueprintAttachment& attachment) const
 {
-	switch (attachment.target)
+	ASSERT(attachment.target == BlueprintAttachment::Target::PipelineSurface,
+		"BlueprintMaterializer: only PipelineSurface attachments are supported");
+	auto& ctx = gfx_api::context::get();
+	abstract_texture* texture = ctx.getPipelineSurface(attachment.surfaceId);
+	const PipelineSurfaceMeta meta = ctx.pipelineSurfaceMeta(attachment.surfaceId);
+	const bool isDepth = meta.usage == PipelineSurfaceUsage::DepthStencil
+		|| meta.usage == PipelineSurfaceUsage::DepthOnly;
+	AttachmentDesc desc = isDepth
+		? AttachmentDesc::depth(texture, attachment.loadOp, attachment.clearValue)
+		: AttachmentDesc::color(texture, attachment.loadOp, attachment.clearValue);
+	desc.storeOp = attachment.storeOp;
+	if (attachment.arrayLayer.has_value())
 	{
-	case BlueprintAttachment::Target::PipelineSurface:
-	{
-		auto& ctx = gfx_api::context::get();
-		abstract_texture* texture = ctx.getPipelineSurface(attachment.surfaceId);
-		const PipelineSurfaceMeta meta = ctx.pipelineSurfaceMeta(attachment.surfaceId);
-		const bool isDepth = meta.usage == PipelineSurfaceUsage::DepthStencil
-			|| meta.usage == PipelineSurfaceUsage::DepthOnly;
-		AttachmentDesc desc = isDepth
-			? AttachmentDesc::depth(texture, attachment.loadOp, attachment.clearValue)
-			: AttachmentDesc::color(texture, attachment.loadOp, attachment.clearValue);
-		desc.storeOp = attachment.storeOp;
-		if (attachment.arrayLayer.has_value())
-		{
-			desc.arrayLayer = attachment.arrayLayer.value();
-		}
-		return desc;
+		desc.arrayLayer = attachment.arrayLayer.value();
 	}
-	case BlueprintAttachment::Target::TransientColor:
-	{
-		AttachmentDesc desc = AttachmentDesc::transientColor(attachment.loadOp, attachment.clearValue);
-		desc.storeOp = attachment.storeOp;
-		return desc;
-	}
-	case BlueprintAttachment::Target::TransientDepth:
-	{
-		AttachmentDesc desc = AttachmentDesc::transientDepth(attachment.loadOp, attachment.clearValue);
-		desc.storeOp = attachment.storeOp;
-		return desc;
-	}
-	}
-	return {};
+	return desc;
 }
 
 std::pair<uint32_t, uint32_t> BlueprintMaterializer::resolveViewport(const BlueprintPass& pass) const

--- a/lib/ivis_opengl/render_graph/blueprint_materializer.cpp
+++ b/lib/ivis_opengl/render_graph/blueprint_materializer.cpp
@@ -1,0 +1,174 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+/*
+	This file is part of Warzone 2100.
+	Copyright (C) 2026  Warzone 2100 Project (https://github.com/Warzone2100)
+
+	Warzone 2100 is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+
+	Warzone 2100 is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with Warzone 2100; if not, write to the Free Software
+	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+/** @file blueprint_materializer.cpp
+ * Implementation of blueprint materialization (surfaces, viewports, record callbacks).
+ */
+
+#include "blueprint_materializer.h"
+
+#include "gfx_api.h"
+#include "pipeline_surfaces.h"
+
+#include "lib/framework/wzapp.h"
+
+#include <unordered_map>
+
+namespace gfx_api
+{
+
+BlueprintMaterializer::BlueprintMaterializer(const RenderTopologySnapshot& snapshot)
+	: _snapshot(snapshot)
+{
+}
+
+AttachmentDesc BlueprintMaterializer::resolveAttachment(const BlueprintAttachment& attachment) const
+{
+	switch (attachment.target)
+	{
+	case BlueprintAttachment::Target::PipelineSurface:
+	{
+		auto& ctx = gfx_api::context::get();
+		abstract_texture* texture = ctx.getPipelineSurface(attachment.surfaceId);
+		const PipelineSurfaceMeta meta = ctx.pipelineSurfaceMeta(attachment.surfaceId);
+		const bool isDepth = meta.usage == PipelineSurfaceUsage::DepthStencil
+			|| meta.usage == PipelineSurfaceUsage::DepthOnly;
+		AttachmentDesc desc = isDepth
+			? AttachmentDesc::depth(texture, attachment.loadOp, attachment.clearValue)
+			: AttachmentDesc::color(texture, attachment.loadOp, attachment.clearValue);
+		desc.storeOp = attachment.storeOp;
+		if (attachment.arrayLayer.has_value())
+		{
+			desc.arrayLayer = attachment.arrayLayer.value();
+		}
+		return desc;
+	}
+	case BlueprintAttachment::Target::TransientColor:
+	{
+		AttachmentDesc desc = AttachmentDesc::transientColor(attachment.loadOp, attachment.clearValue);
+		desc.storeOp = attachment.storeOp;
+		return desc;
+	}
+	case BlueprintAttachment::Target::TransientDepth:
+	{
+		AttachmentDesc desc = AttachmentDesc::transientDepth(attachment.loadOp, attachment.clearValue);
+		desc.storeOp = attachment.storeOp;
+		return desc;
+	}
+	}
+	return {};
+}
+
+std::pair<uint32_t, uint32_t> BlueprintMaterializer::resolveViewport(const BlueprintPass& pass) const
+{
+	switch (pass.viewportRule)
+	{
+	case ViewportRule::Drawable:
+		return {_snapshot.drawableW, _snapshot.drawableH};
+	case ViewportRule::SceneColorTarget:
+		return {_snapshot.sceneW, _snapshot.sceneH};
+	case ViewportRule::DepthCascade:
+	{
+		const size_t dim = gfx_api::context::get().getDepthPassDimensions(pass.viewportCascadeIndex);
+		return {static_cast<uint32_t>(dim), static_cast<uint32_t>(dim)};
+	}
+	}
+	return {0, 0};
+}
+
+std::vector<RenderPassDesc> BlueprintMaterializer::materialize(const PassGraphTopologyBlueprint& blueprint,
+	const RecordFuncTable& recordFuncs) const
+{
+	std::vector<RenderPassDesc> passes;
+	std::unordered_map<PassId, PassHandle> idToHandle;
+
+	passes.reserve(blueprint.passes().size());
+	idToHandle.reserve(blueprint.passes().size());
+
+	for (const BlueprintPass& bpPass : blueprint.passes())
+	{
+		RenderPassDesc desc;
+		desc.debugName = bpPass.debugName;
+		desc.passId = bpPass.id;
+
+		const size_t funcIndex = static_cast<size_t>(bpPass.id);
+		if (funcIndex >= static_cast<size_t>(PassId::Count))
+		{
+			debug(LOG_ERROR, "BlueprintMaterializer: invalid PassId=%zu", funcIndex);
+			return {};
+		}
+		desc.recordFunc = recordFuncs.funcs[funcIndex];
+
+		desc.colorAttachments.reserve(bpPass.colorAttachments.size());
+		for (const BlueprintAttachment& colorAttachment : bpPass.colorAttachments)
+		{
+			desc.colorAttachments.emplace_back(resolveAttachment(colorAttachment));
+		}
+		if (bpPass.depthAttachment.has_value())
+		{
+			desc.depthAttachment = resolveAttachment(bpPass.depthAttachment.value());
+		}
+		if (bpPass.resolveAttachment.has_value())
+		{
+			desc.resolveAttachment = resolveAttachment(bpPass.resolveAttachment.value());
+		}
+
+		const auto viewport = resolveViewport(bpPass);
+		if (viewport.first > 0 && viewport.second > 0)
+		{
+			desc.viewportSize = viewport;
+		}
+
+		const PassHandle myHandle = passes.size();
+		if (!idToHandle.emplace(bpPass.id, myHandle).second)
+		{
+			debug(LOG_ERROR, "BlueprintMaterializer: duplicate PassId=%u", static_cast<unsigned>(bpPass.id));
+			return {};
+		}
+
+		desc.reads.reserve(bpPass.reads.size());
+		for (const BlueprintReadEdge& edge : bpPass.reads)
+		{
+			ReadDesc read;
+			read.source = ReadSource::PassOutput;
+			const auto producerIt = idToHandle.find(edge.producerPass);
+			if (producerIt == idToHandle.end())
+			{
+				debug(LOG_ERROR, "BlueprintMaterializer: unresolved producer PassId=%u for consumer PassId=%u",
+					static_cast<unsigned>(edge.producerPass), static_cast<unsigned>(bpPass.id));
+				return {};
+			}
+			read.producerPass = producerIt->second;
+			read.producerRole = edge.producerRole;
+			read.attachmentIndex = edge.attachmentIndex;
+			desc.reads.emplace_back(std::move(read));
+		}
+
+		passes.emplace_back(std::move(desc));
+	}
+
+	ASSERT(passes.size() == expectedPassCount(_snapshot),
+	       "BlueprintMaterializer: materialized %zu passes, expected %zu",
+	       passes.size(), expectedPassCount(_snapshot));
+
+	return passes;
+}
+
+} // namespace gfx_api

--- a/lib/ivis_opengl/render_graph/blueprint_materializer.h
+++ b/lib/ivis_opengl/render_graph/blueprint_materializer.h
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+/*
+	This file is part of Warzone 2100.
+	Copyright (C) 2026  Warzone 2100 Project (https://github.com/Warzone2100)
+
+	Warzone 2100 is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+
+	Warzone 2100 is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with Warzone 2100; if not, write to the Free Software
+	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+/** @file blueprint_materializer.h
+ * Turns a topology blueprint into executable `RenderPassDesc` lists for one frame.
+ */
+
+#pragma once
+
+#include "blueprint.h"
+#include "topology.h"
+
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+namespace gfx_api
+{
+
+/// <summary>
+/// Turns a `PassGraphTopologyBlueprint` into executable `RenderPassDesc` list for one frame.
+///
+/// Binds blueprint attachment slots and viewport rules to concrete textures and pixel sizes
+/// using a `RenderTopologySnapshot`, and attaches draw callbacks from `RecordFuncTable`.
+/// Called on every materialize (including resize); does not cache results itself
+/// (`CachedRenderGraph` owns caching).
+/// </summary>
+class BlueprintMaterializer
+{
+public:
+	/// Snapshot supplies drawable/scene/shadow dimensions and backend epoch for this frame.
+	explicit BlueprintMaterializer(const RenderTopologySnapshot& snapshot);
+
+	/// Produce ordered pass descriptions ready for `compilePassGraph` / execution.
+	std::vector<RenderPassDesc> materialize(const PassGraphTopologyBlueprint& blueprint,
+		const RecordFuncTable& recordFuncs) const;
+
+private:
+	AttachmentDesc resolveAttachment(const BlueprintAttachment& attachment) const;
+	std::pair<uint32_t, uint32_t> resolveViewport(const BlueprintPass& pass) const;
+
+	const RenderTopologySnapshot& _snapshot;
+};
+
+} // namespace gfx_api

--- a/lib/ivis_opengl/render_graph/cached_render_graph.cpp
+++ b/lib/ivis_opengl/render_graph/cached_render_graph.cpp
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+/*
+	This file is part of Warzone 2100.
+	Copyright (C) 2026  Warzone 2100 Project (https://github.com/Warzone2100)
+
+	Warzone 2100 is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+
+	Warzone 2100 is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with Warzone 2100; if not, write to the Free Software
+	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+/** @file cached_render_graph.cpp
+ * Implementation of `CachedRenderGraph::ensureBuilt` and `execute`.
+ */
+
+#include "cached_render_graph.h"
+
+#include "gfx_api.h"
+#include "blueprint_materializer.h"
+#include "pass_resolve.h"
+#include "topology.h"
+
+#include "lib/framework/wzapp.h"
+
+namespace gfx_api
+{
+
+void CachedRenderGraph::invalidateCache(bool clearTopologyHash)
+{
+	_passes.clear();
+	_compileResult = {};
+	_cachedMaterializeHash = 0;
+	if (clearTopologyHash)
+	{
+		_cachedTopologyHash = 0;
+	}
+}
+
+void CachedRenderGraph::setBlueprintFactory(BlueprintFactory factory)
+{
+	_blueprintFactory = std::move(factory);
+	invalidateCache();
+}
+
+void CachedRenderGraph::setRecordFuncs(RecordFuncTable funcs)
+{
+	_recordFuncs = std::move(funcs);
+	invalidateCache(false);
+}
+
+void CachedRenderGraph::ensureBuilt(const RenderTopologySnapshot& snapshot)
+{
+	const uint64_t materializeHash = snapshot.materializeHash();
+	if (materializeHash == _cachedMaterializeHash && !_passes.empty())
+	{
+		return;
+	}
+
+	const uint64_t topologyHash = snapshot.topologyHash();
+	if (topologyHash != _cachedTopologyHash)
+	{
+		if (!_blueprintFactory)
+		{
+			debug(LOG_WZ, "CachedRenderGraph: blueprint factory not set");
+			invalidateCache();
+			return;
+		}
+		_blueprint = _blueprintFactory(snapshot);
+	}
+
+	_passes = BlueprintMaterializer(snapshot).materialize(_blueprint, _recordFuncs);
+	if (_passes.empty())
+	{
+		debug(LOG_ERROR, "CachedRenderGraph: materialize failed");
+		invalidateCache();
+		return;
+	}
+
+	if (!compilePassGraph(_passes, _compileResult))
+	{
+		debug(LOG_ERROR, "CachedRenderGraph: compile failed");
+		invalidateCache();
+		return;
+	}
+
+	gfx_api::context::get().warmCompiledRenderGraph(_passes, _compileResult);
+
+#if defined(DEBUG)
+	{
+		const bool topologyChanged = topologyHash != _cachedTopologyHash;
+		++_rebuildCount;
+		debug(LOG_WZ, "CachedRenderGraph: %s (passes=%zu topologyHash=0x%llx materializeHash=0x%llx rebuild#=%llu)",
+		      topologyChanged ? "topology rebuild" : "rematerialize",
+		      _passes.size(),
+		      static_cast<unsigned long long>(topologyHash),
+		      static_cast<unsigned long long>(materializeHash),
+		      static_cast<unsigned long long>(_rebuildCount));
+		if (topologyChanged)
+		{
+			debug(LOG_WZ, "%s", dumpBlueprint(_blueprint).c_str());
+		}
+	}
+#endif
+
+	_cachedTopologyHash = topologyHash;
+	_cachedMaterializeHash = materializeHash;
+}
+
+void CachedRenderGraph::execute()
+{
+	if (_passes.empty())
+	{
+		return;
+	}
+
+	gfx_api::context& ctx = gfx_api::context::get();
+	if (passesHaveTransientAttachments(_passes))
+	{
+		ctx.executeRenderGraph(_passes);
+	}
+	else
+	{
+		ctx.executeCompiledRenderGraph(_passes, _compileResult);
+	}
+}
+
+} // namespace gfx_api

--- a/lib/ivis_opengl/render_graph/cached_render_graph.cpp
+++ b/lib/ivis_opengl/render_graph/cached_render_graph.cpp
@@ -26,7 +26,6 @@
 
 #include "gfx_api.h"
 #include "blueprint_materializer.h"
-#include "pass_resolve.h"
 #include "topology.h"
 
 #include "lib/framework/wzapp.h"
@@ -121,16 +120,7 @@ void CachedRenderGraph::execute()
 	{
 		return;
 	}
-
-	gfx_api::context& ctx = gfx_api::context::get();
-	if (passesHaveTransientAttachments(_passes))
-	{
-		ctx.executeRenderGraph(_passes);
-	}
-	else
-	{
-		ctx.executeCompiledRenderGraph(_passes, _compileResult);
-	}
+	gfx_api::context::get().executeCompiledRenderGraph(_passes, _compileResult);
 }
 
 } // namespace gfx_api

--- a/lib/ivis_opengl/render_graph/cached_render_graph.h
+++ b/lib/ivis_opengl/render_graph/cached_render_graph.h
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+/*
+	This file is part of Warzone 2100.
+	Copyright (C) 2026  Warzone 2100 Project (https://github.com/Warzone2100)
+
+	Warzone 2100 is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+
+	Warzone 2100 is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with Warzone 2100; if not, write to the Free Software
+	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+/** @file cached_render_graph.h
+ * Cached frame render graph: blueprint rebuild, materialize, compile, and execute.
+ */
+
+#pragma once
+
+#include "render_pass.h"
+#include "blueprint.h"
+#include "compile.h"
+#include "topology.h"
+
+#include <cstdint>
+#include <functional>
+#include <vector>
+
+namespace gfx_api
+{
+
+/// <summary>
+/// Frame render-graph cache: blueprint, materialized passes, and compile result.
+///
+/// `ensureBuilt` compares `RenderTopologySnapshot::topologyHash` and `materializeHash`
+/// to avoid rebuilding blueprint vs rematerializing passes. `execute` runs the graph
+/// via `executeCompiledRenderGraph` (or `executeRenderGraph` when transients are present).
+/// </summary>
+class CachedRenderGraph
+{
+public:
+	/// Builds `PassGraphTopologyBlueprint` when topology changes (typically `fromSnapshot`).
+	using BlueprintFactory = std::function<PassGraphTopologyBlueprint(const RenderTopologySnapshot&)>;
+
+	void setBlueprintFactory(BlueprintFactory factory);
+	/// Draw callbacks keyed by `PassId`; reused across rematerializations.
+	void setRecordFuncs(RecordFuncTable funcs);
+
+	/// Rebuild or rematerialize if snapshot hashes differ; compile and warm backend layouts.
+	void ensureBuilt(const RenderTopologySnapshot& snapshot);
+	/// Record and submit the cached pass list for the current frame.
+	void execute();
+
+private:
+	PassGraphTopologyBlueprint _blueprint;
+	uint64_t _cachedTopologyHash = 0;
+	uint64_t _cachedMaterializeHash = 0;
+#if defined(DEBUG)
+	uint64_t _rebuildCount = 0;
+#endif
+	std::vector<RenderPassDesc> _passes;
+	PassGraphCompileResult _compileResult;
+	BlueprintFactory _blueprintFactory;
+	RecordFuncTable _recordFuncs;
+
+	void invalidateCache(bool clearTopologyHash = true);
+};
+
+} // namespace gfx_api

--- a/lib/ivis_opengl/render_graph/cached_render_graph.h
+++ b/lib/ivis_opengl/render_graph/cached_render_graph.h
@@ -41,7 +41,7 @@ namespace gfx_api
 ///
 /// `ensureBuilt` compares `RenderTopologySnapshot::topologyHash` and `materializeHash`
 /// to avoid rebuilding blueprint vs rematerializing passes. `execute` runs the graph
-/// via `executeCompiledRenderGraph` (or `executeRenderGraph` when transients are present).
+/// via `executeCompiledRenderGraph`.
 /// </summary>
 class CachedRenderGraph
 {

--- a/lib/ivis_opengl/render_graph/compile.cpp
+++ b/lib/ivis_opengl/render_graph/compile.cpp
@@ -1,0 +1,215 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+/*
+	This file is part of Warzone 2100.
+	Copyright (C) 2026  Warzone 2100 Project (https://github.com/Warzone2100)
+
+	Warzone 2100 is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+
+	Warzone 2100 is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with Warzone 2100; if not, write to the Free Software
+	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+/** @file compile.cpp
+ * Pass graph compilation: attachment resolution, layout planning, and batch assignment.
+ */
+
+#include "compile.h"
+
+#include "gfx_api.h"
+#include "layout_timeline.h"
+#include "pass_resolve.h"
+#include "pipeline_surfaces.h"
+
+#include "lib/framework/wzapp.h"
+
+#include <algorithm>
+
+namespace gfx_api
+{
+
+namespace
+{
+
+std::optional<ResolvedRead> resolveSingleRead(const ReadDesc& read,
+	const std::vector<RenderPassDesc>& descs, size_t consumerIndex,
+	const std::vector<CompiledPass>& compiledPasses)
+{
+	auto& ctx = gfx_api::context::get();
+	ResolvedRead resolved;
+
+	switch (read.source)
+	{
+	case ReadSource::ExplicitTexture:
+		ASSERT_OR_RETURN(std::nullopt, read.texture != nullptr,
+			"Pass \"%s\" read[%zu]: explicit texture is null",
+			descs[consumerIndex].debugName.c_str(), consumerIndex);
+		resolved.texture = read.texture;
+		break;
+	case ReadSource::PipelineSurface:
+		resolved.texture = ctx.getPipelineSurface(read.pipelineSurface);
+		ASSERT_OR_RETURN(std::nullopt, resolved.texture != nullptr,
+			"Pass \"%s\": pipeline surface %u is not registered",
+			descs[consumerIndex].debugName.c_str(), static_cast<unsigned>(read.pipelineSurface));
+		{
+			const PipelineSurfaceUsage usage = ctx.pipelineSurfaceMeta(read.pipelineSurface).usage;
+			resolved.isDepth = usage == PipelineSurfaceUsage::DepthOnly
+				|| usage == PipelineSurfaceUsage::DepthStencil;
+		}
+		break;
+	case ReadSource::PassOutput:
+		ASSERT_OR_RETURN(std::nullopt, read.producerPass != INVALID_PASS_HANDLE,
+			"Pass \"%s\": PassOutput read has invalid producer handle",
+			descs[consumerIndex].debugName.c_str());
+		ASSERT_OR_RETURN(std::nullopt, read.producerPass < consumerIndex,
+			"Pass \"%s\": cannot read output from pass %zu (not prior to consumer %zu)",
+			descs[consumerIndex].debugName.c_str(), read.producerPass, consumerIndex);
+		ASSERT_OR_RETURN(std::nullopt, read.producerPass < descs.size(),
+			"Pass \"%s\": producer pass handle %zu out of range",
+			descs[consumerIndex].debugName.c_str(), read.producerPass);
+		if (compiledPasses[read.producerPass].skipped)
+		{
+			debug(LOG_ERROR,
+				"Pass \"%s\": PassOutput read from skipped producer pass %zu",
+				descs[consumerIndex].debugName.c_str(), read.producerPass);
+			return std::nullopt;
+		}
+		ASSERT_OR_RETURN(std::nullopt, !passTargetsSwapchainColor(descs[read.producerPass]),
+			"Pass \"%s\": cannot read PassOutput from swapchain pass %zu",
+			descs[consumerIndex].debugName.c_str(), read.producerPass);
+		{
+			const auto output = getPassOutputAttachment(descs[read.producerPass],
+				read.producerRole, read.attachmentIndex);
+			ASSERT_OR_RETURN(std::nullopt, output.has_value(),
+				"Pass \"%s\": failed to resolve PassOutput from pass %zu role %u",
+				descs[consumerIndex].debugName.c_str(), read.producerPass,
+				static_cast<unsigned>(read.producerRole));
+			if (read.producerRole == AttachmentRole::Color && output->isMultisampled)
+			{
+				ASSERT(false,
+					"Pass \"%s\": cannot read multisampled Color attachment from pass %zu; use PrimaryColor or Resolve",
+					descs[consumerIndex].debugName.c_str(), read.producerPass);
+				return std::nullopt;
+			}
+			resolved.texture = output->texture;
+			resolved.arrayLayer = read.arrayLayer.has_value() ? read.arrayLayer.value() : output->arrayLayer;
+			resolved.mipLevel = read.mipLevel.has_value() ? read.mipLevel.value() : output->mipLevel;
+			resolved.isDepth = output->isDepth;
+		}
+		break;
+	}
+
+	if (read.arrayLayer.has_value() && read.source != ReadSource::PassOutput)
+	{
+		resolved.arrayLayer = read.arrayLayer.value();
+	}
+	if (read.mipLevel.has_value() && read.source != ReadSource::PassOutput)
+	{
+		resolved.mipLevel = read.mipLevel.value();
+	}
+
+	ASSERT_OR_RETURN(std::nullopt, resolved.texture != nullptr,
+		"Pass \"%s\": unresolved read texture", descs[consumerIndex].debugName.c_str());
+	return resolved;
+}
+
+bool resolvePassReads(const std::vector<RenderPassDesc>& descs, size_t passIndex,
+	std::vector<ResolvedRead>& outReads,
+	const std::vector<CompiledPass>& compiledPasses)
+{
+	outReads.clear();
+	if (passIndex >= descs.size())
+	{
+		return false;
+	}
+	for (const ReadDesc& read : descs[passIndex].reads)
+	{
+		const auto resolved = resolveSingleRead(read, descs, passIndex, compiledPasses);
+		if (!resolved.has_value())
+		{
+			return false;
+		}
+		outReads.emplace_back(resolved.value());
+	}
+	return true;
+}
+
+} // anonymous namespace
+
+RenderPassContext buildRenderPassContext(const CompiledPass& compiledPass)
+{
+	return RenderPassContext(compiledPass.desc, compiledPass.resolvedReads);
+}
+
+bool compilePassGraph(std::vector<RenderPassDesc>& descs, PassGraphCompileResult& out)
+{
+	out.passes.clear();
+	out.executionBatches.clear();
+	out.passes.resize(descs.size());
+
+	for (size_t i = 0; i < descs.size(); ++i)
+	{
+		out.passes[i].graphIndex = i;
+		out.passes[i].skipped = !resolvePassDescription(descs[i]);
+		if (!out.passes[i].skipped)
+		{
+			out.passes[i].desc = descs[i];
+		}
+	}
+
+	for (size_t i = 0; i < descs.size(); ++i)
+	{
+		if (out.passes[i].skipped)
+		{
+			continue;
+		}
+		if (!resolvePassReads(descs, i, out.passes[i].resolvedReads, out.passes))
+		{
+			return false;
+		}
+	}
+
+#if defined(DEBUG)
+	for (const CompiledPass& p : out.passes)
+	{
+		if (p.skipped)
+		{
+			debug(LOG_WZ, "compilePassGraph: skipped \"%s\" (index=%zu)",
+				descs[p.graphIndex].debugName.c_str(), p.graphIndex);
+		}
+	}
+#endif
+
+	if (!planLayoutTimeline(out.passes))
+	{
+		return false;
+	}
+
+	assignExecutionBatches(out.passes, out.executionBatches);
+	return true;
+}
+
+RenderPassContext::RenderPassContext(const RenderPassDesc& desc, std::vector<ResolvedRead> resolvedReads)
+	: _desc(desc)
+	, _resolvedReads(std::move(resolvedReads))
+{
+}
+
+abstract_texture* RenderPassContext::getRead(size_t index) const
+{
+	if (index >= _resolvedReads.size())
+	{
+		return nullptr;
+	}
+	return _resolvedReads[index].texture;
+}
+
+} // namespace gfx_api

--- a/lib/ivis_opengl/render_graph/compile.h
+++ b/lib/ivis_opengl/render_graph/compile.h
@@ -130,9 +130,8 @@ struct ExecutionBatch
 /// `passes` mirrors the materialized `RenderPassDesc` list (same order and count); each
 /// `CompiledPass` holds pre-resolved reads, layout barriers, and attachment final layouts
 /// so execution does not repeat that work every frame. Consumed by `warmCompiledRenderGraph`
-/// (Vulkan warm render-pass layout ids on `VkRoot`) and `executeCompiledRenderGraph`
-/// (fast path when no transients). Cached on `CachedRenderGraph` and reused until
-/// `compilePassGraph` runs again.
+/// (Vulkan warm render-pass layout ids on `VkRoot`) and `executeCompiledRenderGraph`.
+/// Cached on `CachedRenderGraph` and reused until `compilePassGraph` runs again.
 /// </summary>
 struct PassGraphCompileResult
 {

--- a/lib/ivis_opengl/render_graph/compile.h
+++ b/lib/ivis_opengl/render_graph/compile.h
@@ -1,0 +1,151 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+/*
+	This file is part of Warzone 2100.
+	Copyright (C) 2026  Warzone 2100 Project (https://github.com/Warzone2100)
+
+	Warzone 2100 is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+
+	Warzone 2100 is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with Warzone 2100; if not, write to the Free Software
+	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+/** @file compile.h
+ * Compiled pass artifacts, execution batches, and `compilePassGraph` API.
+ */
+
+#pragma once
+
+#include "read_scope.h"
+#include "render_pass.h"
+
+#include <cstdint>
+#include <vector>
+
+#include <optional>
+
+namespace gfx_api
+{
+
+/// <summary>
+/// Backend-agnostic image layout state tracked across pass graph compilation.
+///
+/// Drives `ImageBarrierOp` planning and Vulkan `PassLayoutKey` final layouts.
+/// </summary>
+enum class CompileImageLayout : uint8_t
+{
+	Undefined,
+	ShaderReadOnly,
+	DepthReadOnly,
+	ColorAttachment,
+	DepthAttachment,
+	Present,
+};
+
+/// Layout transition to emit before a pass records (per subresource).
+struct ImageBarrierOp
+{
+	abstract_texture* texture = nullptr;
+	uint32_t arrayLayer = 0;
+	uint32_t mipLevel = 0;
+	bool isDepth = false;
+	/// Whether the producer of `texture` is tracked in the compile-time layout timeline.
+	/// External: backend resolves `oldLayout` from the runtime tracker and emits an
+	/// execution/memory barrier even when old == new layout. InGraph: prior layout is
+	/// known at compile time; render-pass subpass dependencies cover matching layouts.
+	ReadProducerScope producerScope = ReadProducerScope::InGraph;
+	CompileImageLayout oldLayout = CompileImageLayout::Undefined;
+	CompileImageLayout newLayout = CompileImageLayout::Undefined;
+};
+
+/// Layout state to record after a pass completes (feeds next pass barrier planning).
+struct LayoutStateUpdate
+{
+	abstract_texture* texture = nullptr;
+	uint32_t arrayLayer = 0;
+	uint32_t mipLevel = 0;
+	CompileImageLayout layout = CompileImageLayout::Undefined;
+};
+
+/// <summary>
+/// Per-pass attachment final layouts derived at compile time.
+///
+/// Stored on `CompiledPass` and consumed by Vulkan backend when building render passes.
+/// </summary>
+struct CompiledPassLayoutMetadata
+{
+	/// Layout each attachment is in as the pass begins (RP initialLayout).
+	/// Undefined => contents discarded (Clear/DontCare) or first use.
+	CompileImageLayout depthInitialLayout = CompileImageLayout::Undefined;
+	std::vector<CompileImageLayout> colorInitialLayouts;
+	std::optional<CompileImageLayout> resolveInitialLayout;
+
+	/// Layout each attachment is left in once the pass ends (RP finalLayout).
+	CompileImageLayout depthFinalLayout = CompileImageLayout::DepthAttachment;
+	std::vector<CompileImageLayout> colorFinalLayouts;
+	std::optional<CompileImageLayout> resolveFinalLayout;
+};
+
+/// <summary>
+/// One pass after graph compilation: resolved reads, barriers, and layout metadata.
+///
+/// When `skipped == false`, `desc` is the fully resolved `RenderPassDesc` (equals
+/// `descs[graphIndex]` after compilePassGraph). When `skipped == true`, `desc` is
+/// default-empty and the pass is omitted from executionBatches; it must not be referenced
+/// by any successfully compiled PassOutput read.
+/// </summary>
+struct CompiledPass
+{
+	RenderPassDesc desc;
+	/// Index in the original `descs` vector passed to `compilePassGraph`.
+	size_t graphIndex = 0;
+	bool skipped = false;
+	/// Inputs resolved from `desc.reads` for `RenderPassContext::getRead`.
+	std::vector<ResolvedRead> resolvedReads;
+	std::vector<ImageBarrierOp> prePassBarriers;
+	std::vector<LayoutStateUpdate> postPassLayoutUpdates;
+	CompiledPassLayoutMetadata renderPassLayouts;
+};
+
+/// Contiguous slice of `PassGraphCompileResult::passes` executed as one backend render pass.
+/// Indices refer to the compiled pass vector (includes skipped passes at their materialize indices,
+/// but skipped passes never appear in any batch).
+struct ExecutionBatch
+{
+	size_t startIndex = 0;
+	size_t count = 0;
+};
+
+/// <summary>
+/// Compiled render-graph artifact produced once per topology/materialize rebuild.
+///
+/// `passes` mirrors the materialized `RenderPassDesc` list (same order and count); each
+/// `CompiledPass` holds pre-resolved reads, layout barriers, and attachment final layouts
+/// so execution does not repeat that work every frame. Consumed by `warmCompiledRenderGraph`
+/// (Vulkan warm render-pass layout ids on `VkRoot`) and `executeCompiledRenderGraph`
+/// (fast path when no transients). Cached on `CachedRenderGraph` and reused until
+/// `compilePassGraph` runs again.
+/// </summary>
+struct PassGraphCompileResult
+{
+	std::vector<CompiledPass> passes;
+	/// Precomputed execution batches; populated by assignExecutionBatches in compilePassGraph.
+	/// Empty when all passes are skipped or compile failed before assignment.
+	std::vector<ExecutionBatch> executionBatches;
+};
+
+/// Resolve attachments, plan layout transitions, and fill `out` (one `CompiledPass` per input desc).
+bool compilePassGraph(std::vector<RenderPassDesc>& descs, PassGraphCompileResult& out);
+
+/// Build the `RenderPassContext` passed to a pass `RecordFunc` at execute time.
+RenderPassContext buildRenderPassContext(const CompiledPass& compiledPass);
+
+} // namespace gfx_api

--- a/lib/ivis_opengl/render_graph/frame_blueprint.cpp
+++ b/lib/ivis_opengl/render_graph/frame_blueprint.cpp
@@ -1,0 +1,166 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+/*
+	This file is part of Warzone 2100.
+	Copyright (C) 2026  Warzone 2100 Project (https://github.com/Warzone2100)
+
+	Warzone 2100 is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+
+	Warzone 2100 is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with Warzone 2100; if not, write to the Free Software
+	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+/** @file frame_blueprint.cpp
+ * Screen-kind blueprint templates (in-game, title, loading, video) built from topology snapshots.
+ */
+
+#include "blueprint.h"
+#include "topology.h"
+
+#include "lib/framework/wzapp.h"
+
+#include <string>
+
+namespace gfx_api
+{
+
+namespace
+{
+
+PassGraphTopologyBlueprint buildInGameBlueprint(const RenderTopologySnapshot& snapshot)
+{
+	ASSERT(snapshot.screenKind == RenderScreenKind::InGame, "buildInGameBlueprint: wrong screen kind");
+
+	BlueprintBuilder builder;
+
+	if (snapshot.features & RenderFeatures::Backdrop)
+	{
+		addSwapchainPassToBuilder(builder, PassId::Backdrop, "Backdrop", snapshot.swapchainMsaa,
+			AttachmentLoadOp::Clear, AttachmentLoadOp::Clear);
+	}
+
+	for (uint32_t i = 0; i < snapshot.numShadowCascades; ++i)
+	{
+		builder.beginPass(shadowCascadePassId(i), "ShadowCascade" + std::to_string(i))
+			.depth(PipelineSurfaceId::ShadowMap, AttachmentLoadOp::Clear, AttachmentStoreOp::Store, i)
+			.viewport(ViewportRule::DepthCascade, i);
+	}
+
+	addScenePassToBuilder(builder, PassId::ScenePass, snapshot.sceneMsaa);
+
+	builder.beginPass(PassId::SceneBlit, std::string("SceneBlit"));
+	if (snapshot.swapchainMsaa)
+	{
+		builder.color(PipelineSurfaceId::SwapchainMSAAColor, snapshot.sceneBlitColorLoad, AttachmentStoreOp::DontCare)
+			.resolve(PipelineSurfaceId::SwapchainColor, AttachmentLoadOp::DontCare, AttachmentStoreOp::Store);
+	}
+	else
+	{
+		builder.color(PipelineSurfaceId::SwapchainColor, snapshot.sceneBlitColorLoad, AttachmentStoreOp::Store);
+	}
+	builder.depth(PipelineSurfaceId::SwapchainDepth, AttachmentLoadOp::Load, AttachmentStoreOp::DontCare)
+		.viewport(ViewportRule::Drawable)
+		.readFrom(PassId::ScenePass, AttachmentRole::PrimaryColor);
+
+	addSwapchainPassToBuilder(builder, PassId::TargettingEffects, "TargettingEffects", snapshot.swapchainMsaa,
+		AttachmentLoadOp::Load, AttachmentLoadOp::Clear);
+	addSwapchainPassToBuilder(builder, PassId::SceneOverlays, "3DSceneOverlays", snapshot.swapchainMsaa,
+		AttachmentLoadOp::Load);
+	if (snapshot.features & RenderFeatures::DebugOverlays)
+	{
+		addSwapchainPassToBuilder(builder, PassId::SceneDebugOverlays, "3DSceneDebugOverlays", snapshot.swapchainMsaa,
+			AttachmentLoadOp::Load);
+	}
+
+	if (snapshot.features & RenderFeatures::GameStartFadeSlot)
+	{
+		addSwapchainPassToBuilder(builder, PassId::GameStartFade, "GameStartFade", snapshot.swapchainMsaa,
+			AttachmentLoadOp::Load);
+	}
+
+	addSwapchainPassToBuilder(builder, PassId::InGameUI, "InGameUI", snapshot.swapchainMsaa,
+		AttachmentLoadOp::Load, AttachmentLoadOp::Clear);
+
+	return builder.build();
+}
+
+PassGraphTopologyBlueprint buildTitleBlueprint(const RenderTopologySnapshot& snapshot)
+{
+	ASSERT(snapshot.screenKind == RenderScreenKind::Title, "buildTitleBlueprint: wrong screen kind");
+
+	BlueprintBuilder builder;
+
+	if (snapshot.features & RenderFeatures::Backdrop)
+	{
+		addSwapchainPassToBuilder(builder, PassId::Backdrop, "Backdrop", snapshot.swapchainMsaa,
+			AttachmentLoadOp::Clear, AttachmentLoadOp::Clear);
+	}
+
+	const AttachmentLoadOp titleColorLoad = (snapshot.features & RenderFeatures::Backdrop)
+		? AttachmentLoadOp::Load
+		: AttachmentLoadOp::Clear;
+	addSwapchainPassToBuilder(builder, PassId::TitleUI, "TitleUI", snapshot.swapchainMsaa, titleColorLoad);
+
+	return builder.build();
+}
+
+PassGraphTopologyBlueprint buildLoadingBlueprint(const RenderTopologySnapshot& snapshot)
+{
+	ASSERT(snapshot.screenKind == RenderScreenKind::Loading, "buildLoadingBlueprint: wrong screen kind");
+
+	BlueprintBuilder builder;
+
+	if (snapshot.features & RenderFeatures::Backdrop)
+	{
+		addSwapchainPassToBuilder(builder, PassId::LoadingBackdrop, "LoadingBackdrop", snapshot.swapchainMsaa,
+			AttachmentLoadOp::Clear, AttachmentLoadOp::Clear);
+	}
+
+	const AttachmentLoadOp loadingColorLoad = (snapshot.features & RenderFeatures::Backdrop)
+		? AttachmentLoadOp::Load
+		: AttachmentLoadOp::Clear;
+	addSwapchainPassToBuilder(builder, PassId::LoadingScreen, "LoadingScreen", snapshot.swapchainMsaa,
+		loadingColorLoad);
+
+	return builder.build();
+}
+
+PassGraphTopologyBlueprint buildVideoBlueprint(const RenderTopologySnapshot& snapshot)
+{
+	ASSERT(snapshot.screenKind == RenderScreenKind::Video, "buildVideoBlueprint: wrong screen kind");
+
+	BlueprintBuilder builder;
+	// Video mode stops the backdrop pass (see loop_SetVideoPlaybackMode); always clear swapchain.
+	addSwapchainPassToBuilder(builder, PassId::VideoPlayback, "VideoPlayback", snapshot.swapchainMsaa,
+		AttachmentLoadOp::Clear);
+
+	return builder.build();
+}
+
+} // anonymous namespace
+
+PassGraphTopologyBlueprint PassGraphTopologyBlueprint::fromSnapshot(const RenderTopologySnapshot& snapshot)
+{
+	switch (snapshot.screenKind)
+	{
+	case RenderScreenKind::InGame:
+		return buildInGameBlueprint(snapshot);
+	case RenderScreenKind::Title:
+		return buildTitleBlueprint(snapshot);
+	case RenderScreenKind::Loading:
+		return buildLoadingBlueprint(snapshot);
+	case RenderScreenKind::Video:
+		return buildVideoBlueprint(snapshot);
+	}
+	return {};
+}
+
+} // namespace gfx_api

--- a/lib/ivis_opengl/render_graph/layout_subresource.cpp
+++ b/lib/ivis_opengl/render_graph/layout_subresource.cpp
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+/*
+	This file is part of Warzone 2100.
+	Copyright (C) 2026  Warzone 2100 Project (https://github.com/Warzone2100)
+
+	Warzone 2100 is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+
+	Warzone 2100 is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with Warzone 2100; if not, write to the Free Software
+	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+/** @file layout_subresource.cpp
+ * Implementation of layout subresource key construction from attachments and reads.
+ */
+
+#include "layout_subresource.h"
+
+#include "attachment.h"
+#include "render_pass.h"
+
+#include "lib/framework/hash_combine.h"
+
+namespace gfx_api
+{
+
+namespace
+{
+
+bool attachmentMatchesSubresource(const AttachmentDesc& attachment, const LayoutSubresourceKey& subresource)
+{
+	return attachment.texture == subresource.texture
+		&& attachment.arrayLayer == subresource.arrayLayer
+		&& attachment.mipLevel == subresource.mipLevel;
+}
+
+} // anonymous namespace
+
+size_t LayoutSubresourceKeyHash::operator()(const LayoutSubresourceKey& key) const noexcept
+{
+	size_t h = 0;
+	hash_combine(h, key.texture, key.arrayLayer, key.mipLevel);
+	return h;
+}
+
+LayoutSubresourceKey layoutSubresourceKey(abstract_texture* texture, uint32_t arrayLayer, uint32_t mipLevel)
+{
+	return LayoutSubresourceKey {texture, arrayLayer, mipLevel};
+}
+
+LayoutSubresourceKey layoutSubresourceKey(const AttachmentDesc& attachment)
+{
+	return LayoutSubresourceKey {attachment.texture, attachment.arrayLayer, attachment.mipLevel};
+}
+
+LayoutSubresourceKey layoutSubresourceKey(const ResolvedRead& read)
+{
+	return LayoutSubresourceKey {read.texture, read.arrayLayer, read.mipLevel};
+}
+
+bool isPassAttachmentSubresource(const RenderPassDesc& pass, const LayoutSubresourceKey& subresource)
+{
+	if (subresource.texture == nullptr)
+	{
+		return false;
+	}
+
+	for (const AttachmentDesc& colorAttachment : pass.colorAttachments)
+	{
+		if (attachmentMatchesSubresource(colorAttachment, subresource))
+		{
+			return true;
+		}
+	}
+
+	if (pass.depthAttachment.has_value()
+		&& attachmentMatchesSubresource(pass.depthAttachment.value(), subresource))
+	{
+		return true;
+	}
+
+	if (pass.resolveAttachment.has_value()
+		&& attachmentMatchesSubresource(pass.resolveAttachment.value(), subresource))
+	{
+		return true;
+	}
+
+	return false;
+}
+
+} // namespace gfx_api

--- a/lib/ivis_opengl/render_graph/layout_subresource.h
+++ b/lib/ivis_opengl/render_graph/layout_subresource.h
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+/*
+	This file is part of Warzone 2100.
+	Copyright (C) 2026  Warzone 2100 Project (https://github.com/Warzone2100)
+
+	Warzone 2100 is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+
+	Warzone 2100 is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with Warzone 2100; if not, write to the Free Software
+	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+/** @file layout_subresource.h
+ * `LayoutSubresourceKey` and helpers for per-slice image layout tracking.
+ */
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <unordered_set>
+
+namespace gfx_api
+{
+
+struct abstract_texture;
+struct AttachmentDesc;
+struct ResolvedRead;
+struct RenderPassDesc;
+
+/// Compile-time and runtime layout tracking key for one image subresource.
+struct LayoutSubresourceKey
+{
+	abstract_texture* texture = nullptr;
+	uint32_t arrayLayer = 0;
+	uint32_t mipLevel = 0;
+};
+
+inline bool operator==(const LayoutSubresourceKey& a, const LayoutSubresourceKey& b)
+{
+	return a.texture == b.texture && a.arrayLayer == b.arrayLayer && a.mipLevel == b.mipLevel;
+}
+
+inline bool operator!=(const LayoutSubresourceKey& a, const LayoutSubresourceKey& b)
+{
+	return !(a == b);
+}
+
+struct LayoutSubresourceKeyHash
+{
+	size_t operator()(const LayoutSubresourceKey& key) const noexcept;
+};
+
+using LayoutSubresourceSet = std::unordered_set<LayoutSubresourceKey, LayoutSubresourceKeyHash>;
+
+LayoutSubresourceKey layoutSubresourceKey(abstract_texture* texture, uint32_t arrayLayer = 0, uint32_t mipLevel = 0);
+LayoutSubresourceKey layoutSubresourceKey(const AttachmentDesc& attachment);
+LayoutSubresourceKey layoutSubresourceKey(const ResolvedRead& read);
+bool isPassAttachmentSubresource(const RenderPassDesc& pass, const LayoutSubresourceKey& subresource);
+
+} // namespace gfx_api

--- a/lib/ivis_opengl/render_graph/layout_timeline.cpp
+++ b/lib/ivis_opengl/render_graph/layout_timeline.cpp
@@ -1,0 +1,399 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+/*
+	This file is part of Warzone 2100.
+	Copyright (C) 2026  Warzone 2100 Project (https://github.com/Warzone2100)
+
+	Warzone 2100 is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+
+	Warzone 2100 is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with Warzone 2100; if not, write to the Free Software
+	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+/** @file layout_timeline.cpp
+ * Implementation of layout timeline planning across compiled passes.
+ */
+
+#include "layout_timeline.h"
+
+#include "gfx_api.h"
+#include "layout_subresource.h"
+#include "pass_resolve.h"
+#include "pipeline_surfaces.h"
+#include "read_scope.h"
+
+#include <unordered_map>
+
+namespace gfx_api
+{
+
+namespace
+{
+
+CompileImageLayout getReadTargetLayout(const ResolvedRead& read)
+{
+	return read.isDepth ? CompileImageLayout::DepthReadOnly : CompileImageLayout::ShaderReadOnly;
+}
+
+enum class PostPassAttachmentKind : uint8_t
+{
+	Color,
+	Resolve,
+	Depth,
+};
+
+LayoutStateUpdate makeLayoutStateUpdate(const LayoutSubresourceKey& subresource, CompileImageLayout layout)
+{
+	LayoutStateUpdate update;
+	update.texture = subresource.texture;
+	update.arrayLayer = subresource.arrayLayer;
+	update.mipLevel = subresource.mipLevel;
+	update.layout = layout;
+	return update;
+}
+
+// Final (post-pass) layout for a stored attachment, derived purely from whether the
+// produced texture is sampled by a later pass before being overwritten.
+//
+// The decision is intentionally surface-agnostic: the swapchain is treated like any
+// other color target (left in ColorAttachment), and the single PresentSrcKHR transition
+// is handled once per frame by the backend rather than baked into a render pass.
+std::optional<CompileImageLayout> getAttachmentPostPassLayout(
+	const RenderPassDesc& pass,
+	const AttachmentDesc& attachment,
+	PostPassAttachmentKind kind,
+	const LayoutSubresourceSet& sampledAfter,
+	size_t colorIndex = 0)
+{
+	if (attachment.texture == nullptr)
+	{
+		return std::nullopt;
+	}
+
+	const AttachmentStoreOp storeOp = attachmentStoreOpOr(attachment);
+	if (storeOp == AttachmentStoreOp::DontCare || storeOp == AttachmentStoreOp::Invalidate
+		|| storeOp == AttachmentStoreOp::Resolve)
+	{
+		return std::nullopt;
+	}
+
+	const LayoutSubresourceKey subresource = layoutSubresourceKey(attachment);
+	const bool sampledLater = sampledAfter.count(subresource) > 0;
+
+	switch (kind)
+	{
+	case PostPassAttachmentKind::Color:
+		// The multisampled color buffer of an MSAA-resolve pass is never the stored
+		// output (it is resolved, not stored); the resolve attachment carries it.
+		if (passNeedsMsaaResolve(pass) && colorIndex == 0)
+		{
+			return std::nullopt;
+		}
+		return sampledLater ? CompileImageLayout::ShaderReadOnly : CompileImageLayout::ColorAttachment;
+	case PostPassAttachmentKind::Resolve:
+		if (!passNeedsMsaaResolve(pass))
+		{
+			return std::nullopt;
+		}
+		return sampledLater ? CompileImageLayout::ShaderReadOnly : CompileImageLayout::ColorAttachment;
+	case PostPassAttachmentKind::Depth:
+		return sampledLater ? CompileImageLayout::DepthReadOnly : CompileImageLayout::DepthAttachment;
+	}
+
+	return std::nullopt;
+}
+
+// Layout an attachment is in as the pass begins (RP initialLayout).
+// Clear/DontCare discard previous contents, so the cheapest correct layout is Undefined.
+// Load preserves contents, so we must name the layout the producer left the texture in.
+CompileImageLayout incomingInitialLayout(const AttachmentDesc& attachment, const LayoutStateMap& layoutState)
+{
+	if (attachment.texture == nullptr || attachment.loadOp != AttachmentLoadOp::Load)
+	{
+		return CompileImageLayout::Undefined;
+	}
+	const auto it = layoutState.find(layoutSubresourceKey(attachment));
+	return (it != layoutState.end()) ? it->second : CompileImageLayout::Undefined;
+}
+
+void populateCompiledPassInitialLayouts(CompiledPass& compiledPass, const LayoutStateMap& layoutState)
+{
+	const RenderPassDesc& pass = compiledPass.desc;
+	CompiledPassLayoutMetadata& metadata = compiledPass.renderPassLayouts;
+	metadata.colorInitialLayouts.clear();
+	metadata.resolveInitialLayout.reset();
+	metadata.depthInitialLayout = CompileImageLayout::Undefined;
+
+	metadata.colorInitialLayouts.reserve(pass.colorAttachments.size());
+	for (const AttachmentDesc& colorAttachment : pass.colorAttachments)
+	{
+		metadata.colorInitialLayouts.emplace_back(incomingInitialLayout(colorAttachment, layoutState));
+	}
+
+	if (pass.resolveAttachment.has_value())
+	{
+		metadata.resolveInitialLayout = incomingInitialLayout(pass.resolveAttachment.value(), layoutState);
+	}
+
+	if (pass.depthAttachment.has_value())
+	{
+		metadata.depthInitialLayout = incomingInitialLayout(pass.depthAttachment.value(), layoutState);
+	}
+}
+
+void populateCompiledPassLayoutMetadata(CompiledPass& compiledPass,
+	const LayoutSubresourceSet& sampledAfter)
+{
+	const RenderPassDesc& pass = compiledPass.desc;
+	CompiledPassLayoutMetadata& metadata = compiledPass.renderPassLayouts;
+	metadata.colorFinalLayouts.clear();
+	metadata.resolveFinalLayout.reset();
+	metadata.depthFinalLayout = CompileImageLayout::DepthAttachment;
+
+	metadata.colorFinalLayouts.reserve(pass.colorAttachments.size());
+	for (size_t i = 0; i < pass.colorAttachments.size(); ++i)
+	{
+		const AttachmentDesc& colorAttachment = pass.colorAttachments[i];
+		const auto postPassLayout = getAttachmentPostPassLayout(pass, colorAttachment,
+			PostPassAttachmentKind::Color, sampledAfter, i);
+		// nullopt: attachment-optimal RP final layout; compile tracker left unchanged.
+		metadata.colorFinalLayouts.emplace_back(postPassLayout.value_or(CompileImageLayout::ColorAttachment));
+	}
+
+	if (pass.resolveAttachment.has_value())
+	{
+		const auto postPassLayout = getAttachmentPostPassLayout(pass, pass.resolveAttachment.value(),
+			PostPassAttachmentKind::Resolve, sampledAfter);
+		metadata.resolveFinalLayout = postPassLayout.value_or(CompileImageLayout::ColorAttachment);
+	}
+
+	if (pass.depthAttachment.has_value())
+	{
+		const auto postPassLayout = getAttachmentPostPassLayout(pass, pass.depthAttachment.value(),
+			PostPassAttachmentKind::Depth, sampledAfter);
+		metadata.depthFinalLayout = postPassLayout.value_or(CompileImageLayout::DepthAttachment);
+	}
+}
+
+void applyPostPassLayoutUpdates(CompiledPass& compiledPass, LayoutStateMap& layoutState,
+	const LayoutSubresourceSet& sampledAfter)
+{
+	const RenderPassDesc& pass = compiledPass.desc;
+
+	if (passNeedsMsaaResolve(pass) && pass.resolveAttachment.has_value())
+	{
+		const AttachmentDesc& resolveAttachment = pass.resolveAttachment.value();
+		const LayoutSubresourceKey subresource = layoutSubresourceKey(resolveAttachment);
+		const auto layout = getAttachmentPostPassLayout(pass, resolveAttachment,
+			PostPassAttachmentKind::Resolve, sampledAfter);
+		if (layout.has_value())
+		{
+			compiledPass.postPassLayoutUpdates.push_back(makeLayoutStateUpdate(subresource, layout.value()));
+			layoutState[subresource] = layout.value();
+		}
+	}
+	else
+	{
+		for (size_t i = 0; i < pass.colorAttachments.size(); ++i)
+		{
+			const AttachmentDesc& colorAttachment = pass.colorAttachments[i];
+			const LayoutSubresourceKey subresource = layoutSubresourceKey(colorAttachment);
+			const auto layout = getAttachmentPostPassLayout(pass, colorAttachment,
+				PostPassAttachmentKind::Color, sampledAfter, i);
+			if (layout.has_value())
+			{
+				compiledPass.postPassLayoutUpdates.push_back(makeLayoutStateUpdate(subresource, layout.value()));
+				layoutState[subresource] = layout.value();
+			}
+		}
+	}
+
+	if (pass.depthAttachment.has_value())
+	{
+		const AttachmentDesc& depthAttachment = pass.depthAttachment.value();
+		const LayoutSubresourceKey subresource = layoutSubresourceKey(depthAttachment);
+		const auto layout = getAttachmentPostPassLayout(pass, depthAttachment,
+			PostPassAttachmentKind::Depth, sampledAfter);
+		if (layout.has_value())
+		{
+			compiledPass.postPassLayoutUpdates.push_back(makeLayoutStateUpdate(subresource, layout.value()));
+			layoutState[subresource] = layout.value();
+		}
+	}
+}
+
+// For each pass, the set of subresources it is the (most recent) producer of that some later
+// pass samples before they are overwritten. This is the single source of truth for whether
+// a produced attachment must end the pass in a read-only layout.
+std::vector<LayoutSubresourceSet> computeSampledAfter(
+	const std::vector<CompiledPass>& passes)
+{
+	std::vector<LayoutSubresourceSet> sampledAfter(passes.size());
+	std::unordered_map<LayoutSubresourceKey, size_t, LayoutSubresourceKeyHash> lastProducer;
+
+	for (size_t i = 0; i < passes.size(); ++i)
+	{
+		const CompiledPass& compiledPass = passes[i];
+		if (compiledPass.skipped)
+		{
+			continue;
+		}
+		const RenderPassDesc& pass = compiledPass.desc;
+
+		// Attribute each sample at this pass to the most recent earlier producer of that subresource.
+		LayoutSubresourceSet seenReads;
+		for (const ResolvedRead& read : compiledPass.resolvedReads)
+		{
+			const LayoutSubresourceKey readSubresource = layoutSubresourceKey(read);
+			if (read.texture == nullptr || !seenReads.insert(readSubresource).second)
+			{
+				continue;
+			}
+			if (isPassAttachmentSubresource(pass, readSubresource))
+			{
+				continue;
+			}
+			const auto producerIt = lastProducer.find(readSubresource);
+			if (producerIt != lastProducer.end())
+			{
+				sampledAfter[producerIt->second].insert(readSubresource);
+			}
+		}
+
+		// Register this pass as the producer of each stored attachment output.
+		const auto registerStored = [&](const AttachmentDesc& attachment)
+		{
+			if (attachment.texture != nullptr && attachmentStoreOpOr(attachment) == AttachmentStoreOp::Store)
+			{
+				lastProducer[layoutSubresourceKey(attachment)] = i;
+			}
+		};
+		for (const AttachmentDesc& colorAttachment : pass.colorAttachments)
+		{
+			registerStored(colorAttachment);
+		}
+		if (pass.resolveAttachment.has_value())
+		{
+			registerStored(pass.resolveAttachment.value());
+		}
+		if (pass.depthAttachment.has_value())
+		{
+			registerStored(pass.depthAttachment.value());
+		}
+	}
+
+	return sampledAfter;
+}
+
+} // anonymous namespace
+
+bool planLayoutTimeline(std::vector<CompiledPass>& passes)
+{
+	LayoutStateMap layoutState;
+
+	std::vector<RenderPassDesc> passDescs;
+	passDescs.reserve(passes.size());
+	for (const CompiledPass& compiledPass : passes)
+	{
+		passDescs.push_back(compiledPass.desc);
+	}
+
+	auto& ctx = gfx_api::context::get();
+	if (gfx_api::abstract_texture* swapchainColor = ctx.getPipelineSurface(PipelineSurfaceId::SwapchainColor))
+	{
+		// Across frames the swapchain image starts in PresentSrcKHR (left there by the
+		// previous frame's single present transition). This only matters for a Load.
+		layoutState[layoutSubresourceKey(swapchainColor)] = CompileImageLayout::Present;
+	}
+
+	const auto sampledAfter = computeSampledAfter(passes);
+
+	for (size_t passIndex = 0; passIndex < passes.size(); ++passIndex)
+	{
+		CompiledPass& compiledPass = passes[passIndex];
+		compiledPass.prePassBarriers.clear();
+		compiledPass.postPassLayoutUpdates.clear();
+		compiledPass.renderPassLayouts = CompiledPassLayoutMetadata {};
+		if (compiledPass.skipped)
+		{
+			continue;
+		}
+
+		const RenderPassDesc& pass = compiledPass.desc;
+
+		LayoutSubresourceSet seenReadSubresources;
+		for (size_t readIndex = 0; readIndex < compiledPass.resolvedReads.size(); ++readIndex)
+		{
+			const ResolvedRead& read = compiledPass.resolvedReads[readIndex];
+			const ReadDesc& readDesc = compiledPass.desc.reads[readIndex];
+			const LayoutSubresourceKey readSubresource = layoutSubresourceKey(read);
+			if (read.texture == nullptr || !seenReadSubresources.insert(readSubresource).second)
+			{
+				continue;
+			}
+			if (isPassAttachmentSubresource(pass, readSubresource))
+			{
+				continue;
+			}
+
+			const ReadProducerScope scope = classifyReadProducerScope(readDesc, passDescs, passIndex, layoutState);
+			const CompileImageLayout targetLayout = getReadTargetLayout(read);
+
+			if (scope == ReadProducerScope::External)
+			{
+				ImageBarrierOp barrier;
+				barrier.texture = read.texture;
+				barrier.arrayLayer = read.arrayLayer;
+				barrier.mipLevel = read.mipLevel;
+				barrier.isDepth = read.isDepth;
+				barrier.producerScope = ReadProducerScope::External;
+				barrier.oldLayout = CompileImageLayout::Undefined; // resolved at runtime
+				barrier.newLayout = targetLayout;
+				compiledPass.prePassBarriers.emplace_back(std::move(barrier));
+				layoutState[readSubresource] = targetLayout;
+				continue;
+			}
+
+			const auto layoutIt = layoutState.find(readSubresource);
+			ASSERT_OR_RETURN(false, layoutIt != layoutState.end(),
+				"Pass \"%s\": InGraph read missing layout state (texture=%p layer=%u mip=%u)",
+				pass.debugName.c_str(),
+				static_cast<void*>(readSubresource.texture),
+				readSubresource.arrayLayer,
+				readSubresource.mipLevel);
+
+			const CompileImageLayout currentLayout = layoutIt->second;
+			if (currentLayout != targetLayout)
+			{
+				ImageBarrierOp barrier;
+				barrier.texture = read.texture;
+				barrier.arrayLayer = read.arrayLayer;
+				barrier.mipLevel = read.mipLevel;
+				barrier.isDepth = read.isDepth;
+				barrier.producerScope = ReadProducerScope::InGraph;
+				barrier.oldLayout = currentLayout;
+				barrier.newLayout = targetLayout;
+				compiledPass.prePassBarriers.emplace_back(std::move(barrier));
+				layoutState[readSubresource] = targetLayout;
+			}
+		}
+
+		// Record the layout each attachment is in as the pass begins (before this pass
+		// mutates the tracker), then advance the tracker / record final layouts.
+		populateCompiledPassInitialLayouts(compiledPass, layoutState);
+		applyPostPassLayoutUpdates(compiledPass, layoutState, sampledAfter[passIndex]);
+		populateCompiledPassLayoutMetadata(compiledPass, sampledAfter[passIndex]);
+	}
+
+	return true;
+}
+
+} // namespace gfx_api

--- a/lib/ivis_opengl/render_graph/layout_timeline.h
+++ b/lib/ivis_opengl/render_graph/layout_timeline.h
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+/*
+	This file is part of Warzone 2100.
+	Copyright (C) 2026  Warzone 2100 Project (https://github.com/Warzone2100)
+
+	Warzone 2100 is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+
+	Warzone 2100 is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with Warzone 2100; if not, write to the Free Software
+	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+/** @file layout_timeline.h
+ * Compile-time layout timeline planner (`planLayoutTimeline`) for pre/post-pass barriers.
+ */
+
+#pragma once
+
+#include "compile.h"
+
+#include <vector>
+
+namespace gfx_api
+{
+
+/// <summary>
+/// Plans pre/post-pass layout metadata and barrier ops for all passes.
+///
+/// Seeds swapchain Present via `context::getPipelineSurface(SwapchainColor)`.
+/// Returns false on unrecoverable compile error (e.g. InGraph read / layoutState mismatch).
+/// </summary>
+bool planLayoutTimeline(std::vector<CompiledPass>& passes);
+
+} // namespace gfx_api

--- a/lib/ivis_opengl/render_graph/pass_resolve.cpp
+++ b/lib/ivis_opengl/render_graph/pass_resolve.cpp
@@ -40,14 +40,7 @@ namespace
 
 bool attachmentIsResolved(const AttachmentDesc& attachment)
 {
-	switch (attachment.source)
-	{
-	case AttachmentSource::Texture:
-		return attachment.texture != nullptr;
-	case AttachmentSource::Transient:
-		return true;
-	}
-	return false;
+	return attachment.texture != nullptr;
 }
 
 bool passHasResolvedAttachments(const RenderPassDesc& pass)
@@ -114,58 +107,6 @@ void tryInferPassDimensions(RenderPassDesc& pass, gfx_api::context& ctx, uint32_
 	{
 		pass.viewportSize = std::make_pair(width, height);
 	}
-}
-
-bool resolveTransientAttachment(gfx_api::context& ctx, AttachmentDesc& attachment,
-	uint32_t width, uint32_t height, pixel_format format)
-{
-	if (!attachment.isTransient())
-	{
-		return true;
-	}
-	if (attachment.texture != nullptr)
-	{
-		return true;
-	}
-
-	attachment.source = AttachmentSource::Texture;
-	attachment.texture = ctx.acquireTransientRenderTarget(format, width, height);
-	return attachment.texture != nullptr;
-}
-
-bool resolveTransientAttachments(RenderPassDesc& pass, gfx_api::context& ctx, uint32_t width, uint32_t height)
-{
-	static constexpr auto COLOR_FORMAT = pixel_format::FORMAT_RGBA8_UNORM_PACK8;
-
-	for (auto& colorAttachment : pass.colorAttachments)
-	{
-		if (!resolveTransientAttachment(ctx, colorAttachment, width, height, COLOR_FORMAT))
-		{
-			return false;
-		}
-	}
-
-	if (pass.depthAttachment.has_value() && pass.depthAttachment->isTransient())
-	{
-		const auto depthFormat = ctx.getDepthStencilFormat();
-		ASSERT_OR_RETURN(false, depthFormat != pixel_format::invalid,
-			"Transient depth attachment on pass \"%s\" requires a valid depth/stencil format",
-			pass.debugName.c_str());
-		if (!resolveTransientAttachment(ctx, pass.depthAttachment.value(), width, height, depthFormat))
-		{
-			return false;
-		}
-	}
-
-	if (pass.resolveAttachment.has_value())
-	{
-		if (!resolveTransientAttachment(ctx, pass.resolveAttachment.value(), width, height, COLOR_FORMAT))
-		{
-			return false;
-		}
-	}
-
-	return true;
 }
 
 void setDefaultStoreOpIfUnset(AttachmentDesc& attachment, AttachmentStoreOp storeOp)
@@ -268,12 +209,6 @@ bool resolvePassDescription(RenderPassDesc& pass)
 		"Pass \"%s\" requires at least one resolved color or depth attachment", pass.debugName.c_str());
 	ASSERT_OR_RETURN(false, width > 0 && height > 0,
 		"Pass \"%s\" requires viewportSize or inferrable attachment dimensions", pass.debugName.c_str());
-
-	if (!resolveTransientAttachments(pass, ctx, width, height))
-	{
-		ASSERT(false, "Failed to resolve transient attachments for pass \"%s\"", pass.debugName.c_str());
-		return false;
-	}
 
 	applyDefaultAttachmentStoreOps(pass);
 
@@ -593,38 +528,6 @@ bool passNeedsMsaaResolve(const RenderPassDesc& pass)
 	return gfx_api::context::get().isMultisampledColorAttachment(pass.colorAttachments[0].texture);
 }
 
-bool passHasTransientAttachment(const RenderPassDesc& pass)
-{
-	for (const AttachmentDesc& attachment : pass.colorAttachments)
-	{
-		if (attachment.isTransient())
-		{
-			return true;
-		}
-	}
-	if (pass.depthAttachment.has_value() && pass.depthAttachment->isTransient())
-	{
-		return true;
-	}
-	if (pass.resolveAttachment.has_value() && pass.resolveAttachment->isTransient())
-	{
-		return true;
-	}
-	return false;
-}
-
-bool passesHaveTransientAttachments(const std::vector<RenderPassDesc>& passes)
-{
-	for (const RenderPassDesc& pass : passes)
-	{
-		if (passHasTransientAttachment(pass))
-		{
-			return true;
-		}
-	}
-	return false;
-}
-
 bool attachmentDepthHasStencil(const AttachmentDesc& attachment)
 {
 	if (attachment.texture == nullptr)
@@ -637,8 +540,7 @@ bool attachmentDepthHasStencil(const AttachmentDesc& attachment)
 	{
 		return ctx.pipelineSurfaceMeta(surfaceId.value()).usage == PipelineSurfaceUsage::DepthStencil;
 	}
-	// Transient depth attachments use D24S8.
-	return true;
+	return false;
 }
 
 std::optional<PassOutputView> getPassOutputAttachment(

--- a/lib/ivis_opengl/render_graph/pass_resolve.cpp
+++ b/lib/ivis_opengl/render_graph/pass_resolve.cpp
@@ -615,18 +615,6 @@ std::optional<PassOutputView> getPassOutputAttachment(
 	return view;
 }
 
-bool isDepthShaderSampledSurface(abstract_texture* texture)
-{
-	if (texture == nullptr)
-	{
-		return false;
-	}
-	auto& ctx = gfx_api::context::get();
-	const auto surfaceId = ctx.findPipelineSurfaceId(texture);
-	return surfaceId.has_value()
-		&& ctx.pipelineSurfaceMeta(surfaceId.value()).usage == PipelineSurfaceUsage::DepthOnly;
-}
-
 bool isSwapchainPresentableColorSurface(abstract_texture* texture)
 {
 	if (texture == nullptr)
@@ -663,27 +651,6 @@ bool passTargetsSwapchainColor(const RenderPassDesc& pass)
 		}
 	}
 	return false;
-}
-
-std::unordered_set<abstract_texture*> getPassAttachmentTextures(const RenderPassDesc& pass)
-{
-	std::unordered_set<abstract_texture*> textures;
-	for (const auto& colorAttachment : pass.colorAttachments)
-	{
-		if (colorAttachment.texture != nullptr)
-		{
-			textures.insert(colorAttachment.texture);
-		}
-	}
-	if (pass.depthAttachment.has_value() && pass.depthAttachment->texture != nullptr)
-	{
-		textures.insert(pass.depthAttachment->texture);
-	}
-	if (pass.resolveAttachment.has_value() && pass.resolveAttachment->texture != nullptr)
-	{
-		textures.insert(pass.resolveAttachment->texture);
-	}
-	return textures;
 }
 
 } // namespace gfx_api

--- a/lib/ivis_opengl/render_graph/pass_resolve.cpp
+++ b/lib/ivis_opengl/render_graph/pass_resolve.cpp
@@ -1,0 +1,787 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+/*
+	This file is part of Warzone 2100.
+	Copyright (C) 2026  Warzone 2100 Project (https://github.com/Warzone2100)
+
+	Warzone 2100 is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+
+	Warzone 2100 is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with Warzone 2100; if not, write to the Free Software
+	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+/** @file pass_resolve.cpp
+ * Implementation of pass description resolution, read binding, and batch merging rules.
+ */
+
+#include "pass_resolve.h"
+
+#include "gfx_api.h"
+#include "pipeline_surfaces.h"
+#include "render_pass.h"
+
+#include "lib/framework/wzapp.h"
+
+#include <algorithm>
+
+namespace gfx_api
+{
+
+namespace
+{
+
+bool attachmentIsResolved(const AttachmentDesc& attachment)
+{
+	switch (attachment.source)
+	{
+	case AttachmentSource::Texture:
+		return attachment.texture != nullptr;
+	case AttachmentSource::Transient:
+		return true;
+	}
+	return false;
+}
+
+bool passHasResolvedAttachments(const RenderPassDesc& pass)
+{
+	for (const auto& colorAttachment : pass.colorAttachments)
+	{
+		if (attachmentIsResolved(colorAttachment))
+		{
+			return true;
+		}
+	}
+	return pass.depthAttachment.has_value() && attachmentIsResolved(pass.depthAttachment.value());
+}
+
+void tryInferPassDimensions(RenderPassDesc& pass, gfx_api::context& ctx, uint32_t& width, uint32_t& height)
+{
+	if (pass.viewportSize.has_value())
+	{
+		width = pass.viewportSize->first;
+		height = pass.viewportSize->second;
+		if (width > 0 && height > 0)
+		{
+			return;
+		}
+	}
+
+	auto tryFromTexture = [&](gfx_api::abstract_texture* texture) {
+		if ((width > 0 && height > 0) || texture == nullptr)
+		{
+			return;
+		}
+		const auto dims = ctx.getRenderTargetDimensions(texture);
+		if (dims.has_value())
+		{
+			width = dims->first;
+			height = dims->second;
+		}
+	};
+
+	for (const auto& colorAttachment : pass.colorAttachments)
+	{
+		tryFromTexture(colorAttachment.texture);
+	}
+	if (pass.depthAttachment.has_value())
+	{
+		tryFromTexture(pass.depthAttachment->texture);
+	}
+	if (pass.resolveAttachment.has_value())
+	{
+		tryFromTexture(pass.resolveAttachment->texture);
+	}
+
+	if (width == 0 || height == 0)
+	{
+		const auto drawable = ctx.getDrawableDimensions();
+		if (drawable.first > 0 && drawable.second > 0)
+		{
+			width = drawable.first;
+			height = drawable.second;
+		}
+	}
+
+	if (width > 0 && height > 0)
+	{
+		pass.viewportSize = std::make_pair(width, height);
+	}
+}
+
+bool resolveTransientAttachment(gfx_api::context& ctx, AttachmentDesc& attachment,
+	uint32_t width, uint32_t height, pixel_format format)
+{
+	if (!attachment.isTransient())
+	{
+		return true;
+	}
+	if (attachment.texture != nullptr)
+	{
+		return true;
+	}
+
+	attachment.source = AttachmentSource::Texture;
+	attachment.texture = ctx.acquireTransientRenderTarget(format, width, height);
+	return attachment.texture != nullptr;
+}
+
+bool resolveTransientAttachments(RenderPassDesc& pass, gfx_api::context& ctx, uint32_t width, uint32_t height)
+{
+	static constexpr auto COLOR_FORMAT = pixel_format::FORMAT_RGBA8_UNORM_PACK8;
+
+	for (auto& colorAttachment : pass.colorAttachments)
+	{
+		if (!resolveTransientAttachment(ctx, colorAttachment, width, height, COLOR_FORMAT))
+		{
+			return false;
+		}
+	}
+
+	if (pass.depthAttachment.has_value() && pass.depthAttachment->isTransient())
+	{
+		const auto depthFormat = ctx.getDepthStencilFormat();
+		ASSERT_OR_RETURN(false, depthFormat != pixel_format::invalid,
+			"Transient depth attachment on pass \"%s\" requires a valid depth/stencil format",
+			pass.debugName.c_str());
+		if (!resolveTransientAttachment(ctx, pass.depthAttachment.value(), width, height, depthFormat))
+		{
+			return false;
+		}
+	}
+
+	if (pass.resolveAttachment.has_value())
+	{
+		if (!resolveTransientAttachment(ctx, pass.resolveAttachment.value(), width, height, COLOR_FORMAT))
+		{
+			return false;
+		}
+	}
+
+	return true;
+}
+
+void setDefaultStoreOpIfUnset(AttachmentDesc& attachment, AttachmentStoreOp storeOp)
+{
+	if (!attachment.storeOp.has_value())
+	{
+		attachment.storeOp = storeOp;
+	}
+}
+
+std::optional<PipelineSurfaceUsage> getAttachmentSurfaceUsage(gfx_api::context& ctx,
+	const AttachmentDesc& attachment)
+{
+	if (attachment.texture == nullptr)
+	{
+		return std::nullopt;
+	}
+	const auto surfaceId = ctx.findPipelineSurfaceId(attachment.texture);
+	if (!surfaceId.has_value())
+	{
+		return std::nullopt;
+	}
+	return ctx.pipelineSurfaceMeta(surfaceId.value()).usage;
+}
+
+AttachmentStoreOp defaultDepthStoreOp(gfx_api::context& ctx, const RenderPassDesc& pass,
+	const AttachmentDesc& depthAttachment)
+{
+	const auto usage = getAttachmentSurfaceUsage(ctx, depthAttachment);
+	if (usage.has_value())
+	{
+		if (usage.value() == PipelineSurfaceUsage::DepthOnly)
+		{
+			return AttachmentStoreOp::Store;
+		}
+		if (usage.value() == PipelineSurfaceUsage::DepthStencil)
+		{
+			return AttachmentStoreOp::Invalidate;
+		}
+	}
+	if (passIsDepthOnly(pass))
+	{
+		return AttachmentStoreOp::Store;
+	}
+	if (attachmentDepthHasStencil(depthAttachment))
+	{
+		return AttachmentStoreOp::Invalidate;
+	}
+	return AttachmentStoreOp::Store;
+}
+
+void applyDefaultAttachmentStoreOps(RenderPassDesc& pass)
+{
+	auto& ctx = gfx_api::context::get();
+	const bool needsMsaaResolve = passNeedsMsaaResolve(pass);
+
+	for (size_t i = 0; i < pass.colorAttachments.size(); ++i)
+	{
+		auto& colorAttachment = pass.colorAttachments[i];
+		if (needsMsaaResolve && i == 0
+			&& colorAttachment.texture != nullptr
+			&& ctx.isMultisampledColorAttachment(colorAttachment.texture))
+		{
+			setDefaultStoreOpIfUnset(colorAttachment, AttachmentStoreOp::DontCare);
+		}
+		else
+		{
+			setDefaultStoreOpIfUnset(colorAttachment, AttachmentStoreOp::Store);
+		}
+	}
+
+	if (pass.resolveAttachment.has_value())
+	{
+		setDefaultStoreOpIfUnset(pass.resolveAttachment.value(), AttachmentStoreOp::Store);
+	}
+
+	if (pass.depthAttachment.has_value() && pass.depthAttachment->texture != nullptr)
+	{
+		setDefaultStoreOpIfUnset(pass.depthAttachment.value(),
+			defaultDepthStoreOp(ctx, pass, pass.depthAttachment.value()));
+	}
+}
+
+} // anonymous namespace
+
+AttachmentStoreOp attachmentStoreOpOr(const AttachmentDesc& attachment)
+{
+	return attachment.storeOp.value_or(AttachmentStoreOp::Store);
+}
+
+bool resolvePassDescription(RenderPassDesc& pass)
+{
+	auto& ctx = gfx_api::context::get();
+
+	uint32_t width = 0;
+	uint32_t height = 0;
+	tryInferPassDimensions(pass, ctx, width, height);
+
+	ASSERT_OR_RETURN(false, passHasResolvedAttachments(pass),
+		"Pass \"%s\" requires at least one resolved color or depth attachment", pass.debugName.c_str());
+	ASSERT_OR_RETURN(false, width > 0 && height > 0,
+		"Pass \"%s\" requires viewportSize or inferrable attachment dimensions", pass.debugName.c_str());
+
+	if (!resolveTransientAttachments(pass, ctx, width, height))
+	{
+		ASSERT(false, "Failed to resolve transient attachments for pass \"%s\"", pass.debugName.c_str());
+		return false;
+	}
+
+	applyDefaultAttachmentStoreOps(pass);
+
+	return true;
+}
+
+namespace
+{
+
+bool passViewportSizesMatch(const RenderPassDesc& a, const RenderPassDesc& b)
+{
+	return a.viewportSize.has_value() && b.viewportSize.has_value()
+		&& a.viewportSize.value() == b.viewportSize.value();
+}
+
+bool passAttachmentBindingsMatch(const RenderPassDesc& a, const RenderPassDesc& b)
+{
+	if (!passViewportSizesMatch(a, b))
+	{
+		return false;
+	}
+	if (a.colorAttachments.size() != b.colorAttachments.size())
+	{
+		return false;
+	}
+	for (size_t i = 0; i < a.colorAttachments.size(); ++i)
+	{
+		const AttachmentDesc& aAttachment = a.colorAttachments[i];
+		const AttachmentDesc& bAttachment = b.colorAttachments[i];
+		if (aAttachment.texture != bAttachment.texture
+			|| aAttachment.arrayLayer != bAttachment.arrayLayer
+			|| aAttachment.mipLevel != bAttachment.mipLevel)
+		{
+			return false;
+		}
+	}
+	const bool aHasDepth = a.depthAttachment.has_value() && a.depthAttachment->texture != nullptr;
+	const bool bHasDepth = b.depthAttachment.has_value() && b.depthAttachment->texture != nullptr;
+	if (aHasDepth != bHasDepth)
+	{
+		return false;
+	}
+	if (aHasDepth)
+	{
+		const AttachmentDesc& aDepth = a.depthAttachment.value();
+		const AttachmentDesc& bDepth = b.depthAttachment.value();
+		if (aDepth.texture != bDepth.texture
+			|| aDepth.arrayLayer != bDepth.arrayLayer
+			|| aDepth.mipLevel != bDepth.mipLevel)
+		{
+			return false;
+		}
+	}
+	const bool aHasResolve = a.resolveAttachment.has_value() && a.resolveAttachment->texture != nullptr;
+	const bool bHasResolve = b.resolveAttachment.has_value() && b.resolveAttachment->texture != nullptr;
+	if (aHasResolve != bHasResolve)
+	{
+		return false;
+	}
+	if (aHasResolve)
+	{
+		const AttachmentDesc& aResolve = a.resolveAttachment.value();
+		const AttachmentDesc& bResolve = b.resolveAttachment.value();
+		if (aResolve.texture != bResolve.texture
+			|| aResolve.arrayLayer != bResolve.arrayLayer
+			|| aResolve.mipLevel != bResolve.mipLevel)
+		{
+			return false;
+		}
+	}
+	return true;
+}
+
+bool passAttachmentLoadOpsMatch(const RenderPassDesc& a, const RenderPassDesc& b)
+{
+	if (a.colorAttachments.size() != b.colorAttachments.size())
+	{
+		return false;
+	}
+	for (size_t i = 0; i < a.colorAttachments.size(); ++i)
+	{
+		if (a.colorAttachments[i].loadOp != b.colorAttachments[i].loadOp)
+		{
+			return false;
+		}
+	}
+	const bool aHasDepth = a.depthAttachment.has_value() && a.depthAttachment->texture != nullptr;
+	const bool bHasDepth = b.depthAttachment.has_value() && b.depthAttachment->texture != nullptr;
+	if (aHasDepth != bHasDepth)
+	{
+		return false;
+	}
+	if (aHasDepth && a.depthAttachment->loadOp != b.depthAttachment->loadOp)
+	{
+		return false;
+	}
+	const bool aHasResolve = a.resolveAttachment.has_value() && a.resolveAttachment->texture != nullptr;
+	const bool bHasResolve = b.resolveAttachment.has_value() && b.resolveAttachment->texture != nullptr;
+	if (aHasResolve != bHasResolve)
+	{
+		return false;
+	}
+	if (aHasResolve && a.resolveAttachment->loadOp != b.resolveAttachment->loadOp)
+	{
+		return false;
+	}
+	return true;
+}
+
+bool passAttachmentStoreOpsMatch(const RenderPassDesc& a, const RenderPassDesc& b)
+{
+	if (a.colorAttachments.size() != b.colorAttachments.size())
+	{
+		return false;
+	}
+	for (size_t i = 0; i < a.colorAttachments.size(); ++i)
+	{
+		if (attachmentStoreOpOr(a.colorAttachments[i]) != attachmentStoreOpOr(b.colorAttachments[i]))
+		{
+			return false;
+		}
+	}
+	const bool aHasDepth = a.depthAttachment.has_value() && a.depthAttachment->texture != nullptr;
+	const bool bHasDepth = b.depthAttachment.has_value() && b.depthAttachment->texture != nullptr;
+	if (aHasDepth != bHasDepth)
+	{
+		return false;
+	}
+	if (aHasDepth
+		&& attachmentStoreOpOr(a.depthAttachment.value()) != attachmentStoreOpOr(b.depthAttachment.value()))
+	{
+		return false;
+	}
+	const bool aHasResolve = a.resolveAttachment.has_value() && a.resolveAttachment->texture != nullptr;
+	const bool bHasResolve = b.resolveAttachment.has_value() && b.resolveAttachment->texture != nullptr;
+	if (aHasResolve != bHasResolve)
+	{
+		return false;
+	}
+	if (aHasResolve
+		&& attachmentStoreOpOr(a.resolveAttachment.value()) != attachmentStoreOpOr(b.resolveAttachment.value()))
+	{
+		return false;
+	}
+	return true;
+}
+
+bool compiledPassLayoutMetadataMatch(
+	const CompiledPassLayoutMetadata& a,
+	const CompiledPassLayoutMetadata& b)
+{
+	return a.depthInitialLayout == b.depthInitialLayout
+		&& a.depthFinalLayout == b.depthFinalLayout
+		&& a.colorInitialLayouts == b.colorInitialLayouts
+		&& a.colorFinalLayouts == b.colorFinalLayouts
+		&& a.resolveInitialLayout == b.resolveInitialLayout
+		&& a.resolveFinalLayout == b.resolveFinalLayout;
+}
+
+bool compiledPassPostPassLayoutUpdatesMatch(const CompiledPass& a, const CompiledPass& b)
+{
+	if (a.postPassLayoutUpdates.size() != b.postPassLayoutUpdates.size())
+	{
+		return false;
+	}
+	for (size_t i = 0; i < a.postPassLayoutUpdates.size(); ++i)
+	{
+		const LayoutStateUpdate& lhs = a.postPassLayoutUpdates[i];
+		const LayoutStateUpdate& rhs = b.postPassLayoutUpdates[i];
+		if (lhs.texture != rhs.texture
+			|| lhs.arrayLayer != rhs.arrayLayer
+			|| lhs.mipLevel != rhs.mipLevel
+			|| lhs.layout != rhs.layout)
+		{
+			return false;
+		}
+	}
+	return true;
+}
+
+bool compiledPassBatchBarrierSafe(const CompiledPass& candidate)
+{
+	for (const ImageBarrierOp& op : candidate.prePassBarriers)
+	{
+		if (op.producerScope == ReadProducerScope::InGraph)
+		{
+			return false;
+		}
+	}
+	return true;
+}
+
+} // anonymous namespace
+
+bool canExtendPassBatch(const CompiledPass& batchHead, const CompiledPass& candidate)
+{
+	const RenderPassDesc& headDesc = batchHead.desc;
+	const RenderPassDesc& candidateDesc = candidate.desc;
+
+	if (!passAttachmentBindingsMatch(headDesc, candidateDesc))
+	{
+		return false;
+	}
+	// Batching shares one backend render pass; only the batch head's load/clear ops run.
+	// Matching load ops across all attachments is sufficient — no per-candidate Clear guard needed.
+	if (!passAttachmentLoadOpsMatch(headDesc, candidateDesc))
+	{
+		return false;
+	}
+	if (!passAttachmentStoreOpsMatch(headDesc, candidateDesc))
+	{
+		return false;
+	}
+	if (!compiledPassLayoutMetadataMatch(batchHead.renderPassLayouts, candidate.renderPassLayouts))
+	{
+		return false;
+	}
+	if (!compiledPassPostPassLayoutUpdatesMatch(batchHead, candidate))
+	{
+		return false;
+	}
+	if (!compiledPassBatchBarrierSafe(candidate))
+	{
+		return false;
+	}
+	return true;
+}
+
+void assignExecutionBatches(const std::vector<CompiledPass>& passes,
+	std::vector<ExecutionBatch>& outBatches)
+{
+	outBatches.clear();
+
+	for (size_t i = 0; i < passes.size(); )
+	{
+		if (passes[i].skipped)
+		{
+			++i;
+			continue;
+		}
+
+		ExecutionBatch batch {i, 1};
+		while (i + batch.count < passes.size())
+		{
+			const CompiledPass& next = passes[i + batch.count];
+			if (next.skipped)
+			{
+				break;
+			}
+			if (!canExtendPassBatch(passes[i], next))
+			{
+				break;
+			}
+			++batch.count;
+		}
+
+#if defined(DEBUG)
+		if (batch.count > 1)
+		{
+			const CompiledPass& head = passes[batch.startIndex];
+			debug(LOG_WZ, "ExecutionBatch [%zu..%zu): head=%s count=%zu",
+				batch.startIndex, batch.startIndex + batch.count,
+				head.desc.debugName.c_str(), batch.count);
+			for (size_t j = batch.startIndex + 1; j < batch.startIndex + batch.count; ++j)
+			{
+				ASSERT(compiledPassLayoutMetadataMatch(
+					head.renderPassLayouts, passes[j].renderPassLayouts),
+					"assignExecutionBatches: layout metadata mismatch %s vs %s",
+					head.desc.debugName.c_str(), passes[j].desc.debugName.c_str());
+				ASSERT(compiledPassPostPassLayoutUpdatesMatch(head, passes[j]),
+					"assignExecutionBatches: postPassLayoutUpdates mismatch %s vs %s",
+					head.desc.debugName.c_str(), passes[j].desc.debugName.c_str());
+			}
+		}
+#endif
+
+		outBatches.push_back(batch);
+		i += batch.count;
+	}
+
+#if defined(DEBUG)
+	size_t nonSkippedExecuted = 0;
+	for (const ExecutionBatch& batch : outBatches)
+	{
+		nonSkippedExecuted += batch.count;
+	}
+	size_t nonSkippedTotal = 0;
+	for (const CompiledPass& pass : passes)
+	{
+		if (!pass.skipped)
+		{
+			++nonSkippedTotal;
+		}
+	}
+	ASSERT(nonSkippedExecuted == nonSkippedTotal,
+		"assignExecutionBatches: batch partition does not cover all non-skipped passes");
+#endif
+}
+
+bool passIsDepthOnly(const RenderPassDesc& pass)
+{
+	return pass.colorAttachments.empty()
+		&& pass.depthAttachment.has_value()
+		&& pass.depthAttachment->texture != nullptr;
+}
+
+bool passNeedsMsaaResolve(const RenderPassDesc& pass)
+{
+	if (!pass.resolveAttachment.has_value() || pass.resolveAttachment->texture == nullptr)
+	{
+		return false;
+	}
+	if (pass.colorAttachments.empty() || pass.colorAttachments[0].texture == nullptr)
+	{
+		return false;
+	}
+	return gfx_api::context::get().isMultisampledColorAttachment(pass.colorAttachments[0].texture);
+}
+
+bool passHasTransientAttachment(const RenderPassDesc& pass)
+{
+	for (const AttachmentDesc& attachment : pass.colorAttachments)
+	{
+		if (attachment.isTransient())
+		{
+			return true;
+		}
+	}
+	if (pass.depthAttachment.has_value() && pass.depthAttachment->isTransient())
+	{
+		return true;
+	}
+	if (pass.resolveAttachment.has_value() && pass.resolveAttachment->isTransient())
+	{
+		return true;
+	}
+	return false;
+}
+
+bool passesHaveTransientAttachments(const std::vector<RenderPassDesc>& passes)
+{
+	for (const RenderPassDesc& pass : passes)
+	{
+		if (passHasTransientAttachment(pass))
+		{
+			return true;
+		}
+	}
+	return false;
+}
+
+bool attachmentDepthHasStencil(const AttachmentDesc& attachment)
+{
+	if (attachment.texture == nullptr)
+	{
+		return false;
+	}
+	auto& ctx = gfx_api::context::get();
+	const auto surfaceId = ctx.findPipelineSurfaceId(attachment.texture);
+	if (surfaceId.has_value())
+	{
+		return ctx.pipelineSurfaceMeta(surfaceId.value()).usage == PipelineSurfaceUsage::DepthStencil;
+	}
+	// Transient depth attachments use D24S8.
+	return true;
+}
+
+std::optional<PassOutputView> getPassOutputAttachment(
+	const RenderPassDesc& producer,
+	AttachmentRole role,
+	uint32_t colorIndex)
+{
+	auto& ctx = gfx_api::context::get();
+	PassOutputView view;
+
+	switch (role)
+	{
+	case AttachmentRole::PrimaryColor:
+		if (passNeedsMsaaResolve(producer))
+		{
+			if (!producer.resolveAttachment.has_value() || producer.resolveAttachment->texture == nullptr)
+			{
+				return std::nullopt;
+			}
+			view.texture = producer.resolveAttachment->texture;
+			view.mipLevel = producer.resolveAttachment->mipLevel;
+			view.arrayLayer = producer.resolveAttachment->arrayLayer;
+		}
+		else if (!producer.colorAttachments.empty() && producer.colorAttachments[0].texture != nullptr)
+		{
+			view.texture = producer.colorAttachments[0].texture;
+			view.mipLevel = producer.colorAttachments[0].mipLevel;
+			view.arrayLayer = producer.colorAttachments[0].arrayLayer;
+			view.isMultisampled = ctx.isMultisampledColorAttachment(view.texture);
+		}
+		else
+		{
+			return std::nullopt;
+		}
+		break;
+	case AttachmentRole::Resolve:
+		if (!producer.resolveAttachment.has_value() || producer.resolveAttachment->texture == nullptr)
+		{
+			return std::nullopt;
+		}
+		view.texture = producer.resolveAttachment->texture;
+		view.mipLevel = producer.resolveAttachment->mipLevel;
+		view.arrayLayer = producer.resolveAttachment->arrayLayer;
+		break;
+	case AttachmentRole::Color:
+		if (colorIndex >= producer.colorAttachments.size()
+			|| producer.colorAttachments[colorIndex].texture == nullptr)
+		{
+			return std::nullopt;
+		}
+		view.texture = producer.colorAttachments[colorIndex].texture;
+		view.mipLevel = producer.colorAttachments[colorIndex].mipLevel;
+		view.arrayLayer = producer.colorAttachments[colorIndex].arrayLayer;
+		view.isMultisampled = ctx.isMultisampledColorAttachment(view.texture);
+		break;
+	case AttachmentRole::Depth:
+		if (!producer.depthAttachment.has_value() || producer.depthAttachment->texture == nullptr)
+		{
+			return std::nullopt;
+		}
+		view.texture = producer.depthAttachment->texture;
+		view.mipLevel = producer.depthAttachment->mipLevel;
+		view.arrayLayer = producer.depthAttachment->arrayLayer;
+		view.isDepth = true;
+		break;
+	}
+
+	if (view.texture == nullptr)
+	{
+		return std::nullopt;
+	}
+	return view;
+}
+
+bool isDepthShaderSampledSurface(abstract_texture* texture)
+{
+	if (texture == nullptr)
+	{
+		return false;
+	}
+	auto& ctx = gfx_api::context::get();
+	const auto surfaceId = ctx.findPipelineSurfaceId(texture);
+	return surfaceId.has_value()
+		&& ctx.pipelineSurfaceMeta(surfaceId.value()).usage == PipelineSurfaceUsage::DepthOnly;
+}
+
+bool isSwapchainPresentableColorSurface(abstract_texture* texture)
+{
+	if (texture == nullptr)
+	{
+		return false;
+	}
+	auto& ctx = gfx_api::context::get();
+	const auto surfaceId = ctx.findPipelineSurfaceId(texture);
+	return surfaceId.has_value() && surfaceId.value() == PipelineSurfaceId::SwapchainColor;
+}
+
+bool passTargetsSwapchainColor(const RenderPassDesc& pass)
+{
+	auto& ctx = gfx_api::context::get();
+	for (const auto& attachment : pass.colorAttachments)
+	{
+		if (attachment.texture != nullptr)
+		{
+			const auto surfaceId = ctx.findPipelineSurfaceId(attachment.texture);
+			if (surfaceId.has_value()
+				&& (surfaceId.value() == PipelineSurfaceId::SwapchainColor
+					|| surfaceId.value() == PipelineSurfaceId::SwapchainMSAAColor))
+			{
+				return true;
+			}
+		}
+	}
+	if (pass.resolveAttachment.has_value() && pass.resolveAttachment->texture != nullptr)
+	{
+		const auto surfaceId = ctx.findPipelineSurfaceId(pass.resolveAttachment->texture);
+		if (surfaceId.has_value() && surfaceId.value() == PipelineSurfaceId::SwapchainColor)
+		{
+			return true;
+		}
+	}
+	return false;
+}
+
+std::unordered_set<abstract_texture*> getPassAttachmentTextures(const RenderPassDesc& pass)
+{
+	std::unordered_set<abstract_texture*> textures;
+	for (const auto& colorAttachment : pass.colorAttachments)
+	{
+		if (colorAttachment.texture != nullptr)
+		{
+			textures.insert(colorAttachment.texture);
+		}
+	}
+	if (pass.depthAttachment.has_value() && pass.depthAttachment->texture != nullptr)
+	{
+		textures.insert(pass.depthAttachment->texture);
+	}
+	if (pass.resolveAttachment.has_value() && pass.resolveAttachment->texture != nullptr)
+	{
+		textures.insert(pass.resolveAttachment->texture);
+	}
+	return textures;
+}
+
+} // namespace gfx_api

--- a/lib/ivis_opengl/render_graph/pass_resolve.h
+++ b/lib/ivis_opengl/render_graph/pass_resolve.h
@@ -52,8 +52,8 @@ struct PassOutputView
 };
 
 /// <summary>
-/// Materialize a `RenderPassDesc` for GPU recording: resolve attachment sources,
-/// allocate transients, and set `viewportSize` when inferrable.
+/// Materialize a `RenderPassDesc` for GPU recording: resolve attachment sources
+/// and set `viewportSize` when inferrable.
 ///
 /// Single entry point used by legacy pass factories and `compilePassGraph` (via
 /// `resolvePassDescription` before compile). Mutates `pass` in place; returns false
@@ -81,12 +81,6 @@ bool passIsDepthOnly(const RenderPassDesc& pass);
 
 /// True when `resolveAttachment` is set and the first color attachment is multisampled.
 bool passNeedsMsaaResolve(const RenderPassDesc& pass);
-
-/// True when any attachment uses `AttachmentSource::Transient`.
-bool passHasTransientAttachment(const RenderPassDesc& pass);
-
-/// True when any pass in the list has a transient attachment.
-bool passesHaveTransientAttachments(const std::vector<RenderPassDesc>& passes);
 
 /// True when resolved depth includes stencil (scene depth, not shadow map).
 bool attachmentDepthHasStencil(const AttachmentDesc& attachment);

--- a/lib/ivis_opengl/render_graph/pass_resolve.h
+++ b/lib/ivis_opengl/render_graph/pass_resolve.h
@@ -85,14 +85,8 @@ bool passNeedsMsaaResolve(const RenderPassDesc& pass);
 /// True when resolved depth includes stencil (scene depth, not shadow map).
 bool attachmentDepthHasStencil(const AttachmentDesc& attachment);
 
-/// True when the texture is the shadow-map pipeline surface.
-bool isDepthShaderSampledSurface(abstract_texture* texture);
-
 /// True when the texture is the swapchain presentable color surface.
 bool isSwapchainPresentableColorSurface(abstract_texture* texture);
-
-/// All non-null color, depth, and resolve textures referenced by the pass.
-std::unordered_set<abstract_texture*> getPassAttachmentTextures(const RenderPassDesc& pass);
 
 /// Resolve which texture/subresource a producer pass exposes for a given `AttachmentRole`.
 std::optional<PassOutputView> getPassOutputAttachment(

--- a/lib/ivis_opengl/render_graph/pass_resolve.h
+++ b/lib/ivis_opengl/render_graph/pass_resolve.h
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+/*
+	This file is part of Warzone 2100.
+	Copyright (C) 2026  Warzone 2100 Project (https://github.com/Warzone2100)
+
+	Warzone 2100 is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+
+	Warzone 2100 is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with Warzone 2100; if not, write to the Free Software
+	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+/** @file pass_resolve.h
+ * Pass attachment resolution, MSAA helpers, and execution batch assignment API.
+ */
+
+#pragma once
+
+#include "attachment.h"
+#include "compile.h"
+#include "render_pass.h"
+
+#include <unordered_set>
+
+#include <optional>
+
+namespace gfx_api
+{
+
+struct RenderPassDesc;
+
+/// <summary>
+/// Resolved view of one producer pass output (texture + subresource flags).
+///
+/// Returned by `getPassOutputAttachment` when resolving `ReadSource::PassOutput` reads.
+/// </summary>
+struct PassOutputView
+{
+	abstract_texture* texture = nullptr;
+	uint32_t arrayLayer = 0;
+	uint32_t mipLevel = 0;
+	bool isDepth = false;
+	bool isMultisampled = false;
+};
+
+/// <summary>
+/// Materialize a `RenderPassDesc` for GPU recording: resolve attachment sources,
+/// allocate transients, and set `viewportSize` when inferrable.
+///
+/// Single entry point used by legacy pass factories and `compilePassGraph` (via
+/// `resolvePassDescription` before compile). Mutates `pass` in place; returns false
+/// if resolution fails (missing surface, invalid dimensions).
+/// </summary>
+bool resolvePassDescription(RenderPassDesc& pass);
+
+/// Effective store op; unset attachments default to `Store`.
+AttachmentStoreOp attachmentStoreOpOr(const AttachmentDesc& attachment);
+
+/// True when the pass targets swapchain color (pre- or post-MSAA resolve).
+bool passTargetsSwapchainColor(const RenderPassDesc& pass);
+
+/// True when `candidate` can share one backend render-pass instance with `batchHead`.
+/// Used only by assignExecutionBatches during compilePassGraph.
+bool canExtendPassBatch(const CompiledPass& batchHead, const CompiledPass& candidate);
+
+/// Partition non-skipped compiled passes into execution batches.
+/// Called from compilePassGraph after planLayoutTimeline.
+void assignExecutionBatches(const std::vector<CompiledPass>& passes,
+	std::vector<ExecutionBatch>& outBatches);
+
+/// True when the pass has no color attachments and a resolved depth attachment.
+bool passIsDepthOnly(const RenderPassDesc& pass);
+
+/// True when `resolveAttachment` is set and the first color attachment is multisampled.
+bool passNeedsMsaaResolve(const RenderPassDesc& pass);
+
+/// True when any attachment uses `AttachmentSource::Transient`.
+bool passHasTransientAttachment(const RenderPassDesc& pass);
+
+/// True when any pass in the list has a transient attachment.
+bool passesHaveTransientAttachments(const std::vector<RenderPassDesc>& passes);
+
+/// True when resolved depth includes stencil (scene depth, not shadow map).
+bool attachmentDepthHasStencil(const AttachmentDesc& attachment);
+
+/// True when the texture is the shadow-map pipeline surface.
+bool isDepthShaderSampledSurface(abstract_texture* texture);
+
+/// True when the texture is the swapchain presentable color surface.
+bool isSwapchainPresentableColorSurface(abstract_texture* texture);
+
+/// All non-null color, depth, and resolve textures referenced by the pass.
+std::unordered_set<abstract_texture*> getPassAttachmentTextures(const RenderPassDesc& pass);
+
+/// Resolve which texture/subresource a producer pass exposes for a given `AttachmentRole`.
+std::optional<PassOutputView> getPassOutputAttachment(
+	const RenderPassDesc& producer,
+	AttachmentRole role,
+	uint32_t colorIndex = 0);
+
+} // namespace gfx_api

--- a/lib/ivis_opengl/render_graph/pipeline_surfaces.cpp
+++ b/lib/ivis_opengl/render_graph/pipeline_surfaces.cpp
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+/*
+	This file is part of Warzone 2100.
+	Copyright (C) 2026  Warzone 2100 Project (https://github.com/Warzone2100)
+
+	Warzone 2100 is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+
+	Warzone 2100 is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with Warzone 2100; if not, write to the Free Software
+	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+/** @file pipeline_surfaces.cpp
+ * Implementation of pipeline surface metadata and registry lookup helpers.
+ */
+
+#include "pipeline_surfaces.h"
+
+#include "gfx_api.h"
+
+#include "lib/framework/wzapp.h"
+
+namespace gfx_api
+{
+
+PipelineSurfaceMeta getPipelineSurfaceMeta(PipelineSurfaceId id)
+{
+	PipelineSurfaceMeta meta;
+	switch (id)
+	{
+	case PipelineSurfaceId::SceneColor:
+		meta.usage = PipelineSurfaceUsage::ColorResolve;
+		meta.format = pixel_format::FORMAT_RGBA8_UNORM_PACK8;
+		meta.samples = 1;
+		break;
+	case PipelineSurfaceId::SceneMSAAColor:
+		meta.usage = PipelineSurfaceUsage::ColorMSAA;
+		meta.format = pixel_format::FORMAT_RGBA8_UNORM_PACK8;
+		meta.samples = 1;
+		break;
+	case PipelineSurfaceId::SceneDepth:
+		meta.usage = PipelineSurfaceUsage::DepthStencil;
+		meta.format = pixel_format::FORMAT_D24_UNORM_S8;
+		meta.samples = 1;
+		break;
+	case PipelineSurfaceId::ShadowMap:
+		meta.usage = PipelineSurfaceUsage::DepthOnly;
+		meta.format = pixel_format::FORMAT_D24_UNORM_S8;
+		meta.samples = 1;
+		break;
+	case PipelineSurfaceId::SwapchainColor:
+		meta.usage = PipelineSurfaceUsage::SwapchainPresent;
+		meta.format = pixel_format::FORMAT_RGBA8_UNORM_PACK8;
+		meta.samples = 1;
+		break;
+	case PipelineSurfaceId::SwapchainMSAAColor:
+		meta.usage = PipelineSurfaceUsage::ColorMSAA;
+		meta.format = pixel_format::FORMAT_RGBA8_UNORM_PACK8;
+		meta.samples = 1;
+		break;
+	case PipelineSurfaceId::SwapchainDepth:
+		meta.usage = PipelineSurfaceUsage::DepthStencil;
+		meta.format = pixel_format::FORMAT_D24_UNORM_S8;
+		meta.samples = 1;
+		break;
+	case PipelineSurfaceId::Count:
+		ASSERT(false, "Invalid pipeline surface ID");
+		break;
+	}
+	return meta;
+}
+
+void PipelineSurfaceRegistry::registerSurface(PipelineSurfaceId id, abstract_texture* surface)
+{
+	_surfaces[static_cast<size_t>(id)] = surface;
+}
+
+void PipelineSurfaceRegistry::invalidateSurface(PipelineSurfaceId id)
+{
+	_surfaces[static_cast<size_t>(id)] = nullptr;
+	_samplesOverride[static_cast<size_t>(id)] = 0;
+}
+
+abstract_texture* PipelineSurfaceRegistry::get(PipelineSurfaceId id) const
+{
+	return _surfaces[static_cast<size_t>(id)];
+}
+
+void PipelineSurfaceRegistry::setSurfaceSamples(PipelineSurfaceId id, uint32_t samples)
+{
+	_samplesOverride[static_cast<size_t>(id)] = samples;
+}
+
+PipelineSurfaceMeta PipelineSurfaceRegistry::meta(PipelineSurfaceId id) const
+{
+	PipelineSurfaceMeta result = getPipelineSurfaceMeta(id);
+	const uint32_t overrideSamples = _samplesOverride[static_cast<size_t>(id)];
+	if (overrideSamples > 0)
+	{
+		result.samples = overrideSamples;
+	}
+	return result;
+}
+
+nonstd::optional<PipelineSurfaceId> PipelineSurfaceRegistry::findSurfaceId(abstract_texture* texture) const
+{
+	if (texture == nullptr)
+	{
+		return nonstd::nullopt;
+	}
+	for (size_t i = 0; i < static_cast<size_t>(PipelineSurfaceId::Count); ++i)
+	{
+		if (_surfaces[i] == texture)
+		{
+			return static_cast<PipelineSurfaceId>(i);
+		}
+	}
+	return nonstd::nullopt;
+}
+
+AttachmentDesc makePipelineSurfaceAttachment(PipelineSurfaceId id, AttachmentLoadOp op, ClearValue clear)
+{
+	AttachmentDesc desc;
+	desc.source = AttachmentSource::Texture;
+	desc.texture = context::get().getPipelineSurface(id);
+	ASSERT(desc.texture != nullptr, "Pipeline surface %u is not registered", static_cast<unsigned>(id));
+	desc.loadOp = op;
+	desc.clearValue = clear;
+	return desc;
+}
+
+} // namespace gfx_api

--- a/lib/ivis_opengl/render_graph/pipeline_surfaces.cpp
+++ b/lib/ivis_opengl/render_graph/pipeline_surfaces.cpp
@@ -129,7 +129,6 @@ nonstd::optional<PipelineSurfaceId> PipelineSurfaceRegistry::findSurfaceId(abstr
 AttachmentDesc makePipelineSurfaceAttachment(PipelineSurfaceId id, AttachmentLoadOp op, ClearValue clear)
 {
 	AttachmentDesc desc;
-	desc.source = AttachmentSource::Texture;
 	desc.texture = context::get().getPipelineSurface(id);
 	ASSERT(desc.texture != nullptr, "Pipeline surface %u is not registered", static_cast<unsigned>(id));
 	desc.loadOp = op;

--- a/lib/ivis_opengl/render_graph/pipeline_surfaces.h
+++ b/lib/ivis_opengl/render_graph/pipeline_surfaces.h
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+/*
+	This file is part of Warzone 2100.
+	Copyright (C) 2026  Warzone 2100 Project (https://github.com/Warzone2100)
+
+	Warzone 2100 is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+
+	Warzone 2100 is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with Warzone 2100; if not, write to the Free Software
+	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+/** @file pipeline_surfaces.h
+ * Named persistent render targets (`PipelineSurfaceId`) and backend surface registry.
+ */
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+
+#include "attachment.h"
+#include "../gfx_api_formats_def.h"
+
+#include <nonstd/optional.hpp>
+
+namespace gfx_api
+{
+
+struct abstract_texture;
+
+/// <summary>
+/// Named persistent render targets shared across passes (scene, swapchain, shadow map).
+///
+/// Backends register live `abstract_texture*` instances in `PipelineSurfaceRegistry`.
+/// Blueprints and `BlueprintMaterializer` refer to surfaces by id, not raw pointers.
+/// </summary>
+enum class PipelineSurfaceId : uint8_t
+{
+	SceneColor,
+	SceneMSAAColor,
+	SceneDepth,
+	ShadowMap,
+	SwapchainColor,
+	SwapchainMSAAColor,
+	SwapchainDepth,
+	/// Array size and invalid id sentinel.
+	Count
+};
+
+/// <summary>
+/// Role of a pipeline surface (drives format defaults and layout/barrier hints).
+/// </summary>
+enum class PipelineSurfaceUsage : uint8_t
+{
+	ColorResolve,
+	ColorMSAA,
+	DepthStencil,
+	DepthOnly,
+	/// Swapchain / default framebuffer presentable color (not shader-sampled).
+	SwapchainPresent,
+};
+
+/// <summary>
+/// Static description of a pipeline surface: usage class, pixel format, and sample count.
+/// </summary>
+struct PipelineSurfaceMeta
+{
+	PipelineSurfaceUsage usage = PipelineSurfaceUsage::ColorResolve;
+	pixel_format format = pixel_format::invalid;
+	/// Default 1; MSAA surfaces may override via `PipelineSurfaceRegistry::setSurfaceSamples`.
+	uint32_t samples = 1;
+};
+
+/// Built-in defaults per `PipelineSurfaceId` (samples may be overridden at registration).
+PipelineSurfaceMeta getPipelineSurfaceMeta(PipelineSurfaceId id);
+
+/// <summary>
+/// Fixed-size registry of persistent pipeline render targets owned by the gfx backend.
+///
+/// Populated at swapchain/scene/shadow setup (`registerSurface`); read during
+/// `resolvePassDescription` and `BlueprintMaterializer`. Lives on `gfx_api::context`.
+/// </summary>
+class PipelineSurfaceRegistry
+{
+public:
+	/// Bind a backend texture to a surface slot (non-owning pointer).
+	void registerSurface(PipelineSurfaceId id, abstract_texture* surface);
+	/// Clear a slot (e.g. on swapchain teardown).
+	void invalidateSurface(PipelineSurfaceId id);
+	abstract_texture* get(PipelineSurfaceId id) const;
+
+	/// Runtime sample count override (e.g. `SceneMSAAColor` / `SceneDepth` when MSAA is on).
+	void setSurfaceSamples(PipelineSurfaceId id, uint32_t samples);
+	/// Effective meta: static defaults merged with `_samplesOverride`.
+	PipelineSurfaceMeta meta(PipelineSurfaceId id) const;
+
+	/// Reverse lookup for attachment classification (depth-sampled vs swapchain present).
+	nonstd::optional<PipelineSurfaceId> findSurfaceId(abstract_texture* texture) const;
+
+private:
+	std::array<abstract_texture*, static_cast<size_t>(PipelineSurfaceId::Count)> _surfaces {};
+	std::array<uint32_t, static_cast<size_t>(PipelineSurfaceId::Count)> _samplesOverride {};
+};
+
+/// Build an `AttachmentDesc` from a registered pipeline surface and load/clear ops.
+AttachmentDesc makePipelineSurfaceAttachment(PipelineSurfaceId id,
+	AttachmentLoadOp op = AttachmentLoadOp::Clear,
+	ClearValue clear = ClearValue::colorClear());
+
+} // namespace gfx_api

--- a/lib/ivis_opengl/render_graph/read_scope.cpp
+++ b/lib/ivis_opengl/render_graph/read_scope.cpp
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+/*
+	This file is part of Warzone 2100.
+	Copyright (C) 2026  Warzone 2100 Project (https://github.com/Warzone2100)
+
+	Warzone 2100 is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+
+	Warzone 2100 is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with Warzone 2100; if not, write to the Free Software
+	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+/** @file read_scope.cpp
+ * Implementation of read producer scope and compile-time layout state queries.
+ */
+
+#include "read_scope.h"
+
+#include "layout_subresource.h"
+
+#include "gfx_api.h"
+#include "pass_resolve.h"
+
+namespace gfx_api
+{
+
+ReadProducerScope classifyReadProducerScope(const ReadDesc& read,
+	const std::vector<RenderPassDesc>& descs, size_t consumerIndex,
+	const LayoutStateMap& layoutStateAtRead)
+{
+	switch (read.source)
+	{
+	case ReadSource::ExplicitTexture:
+	case ReadSource::PipelineSurface:
+		return ReadProducerScope::External;
+	case ReadSource::PassOutput:
+		if (read.producerPass >= consumerIndex || read.producerPass >= descs.size())
+		{
+			return ReadProducerScope::External;
+		}
+		{
+			const auto output = getPassOutputAttachment(descs[read.producerPass],
+				read.producerRole, read.attachmentIndex);
+			if (!output.has_value() || output->texture == nullptr)
+			{
+				return ReadProducerScope::External;
+			}
+			if (layoutStateAtRead.find(layoutSubresourceKey(output->texture, output->arrayLayer, output->mipLevel))
+				!= layoutStateAtRead.end())
+			{
+				return ReadProducerScope::InGraph;
+			}
+			return ReadProducerScope::External;
+		}
+	}
+	return ReadProducerScope::External;
+}
+
+} // namespace gfx_api

--- a/lib/ivis_opengl/render_graph/read_scope.h
+++ b/lib/ivis_opengl/render_graph/read_scope.h
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+/*
+	This file is part of Warzone 2100.
+	Copyright (C) 2026  Warzone 2100 Project (https://github.com/Warzone2100)
+
+	Warzone 2100 is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+
+	Warzone 2100 is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with Warzone 2100; if not, write to the Free Software
+	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+/** @file read_scope.h
+ * `ReadProducerScope` classification (in-graph vs external) for image barrier planning.
+ */
+
+#pragma once
+
+#include "layout_subresource.h"
+#include "render_pass.h"
+
+#include <cstdint>
+#include <unordered_map>
+#include <vector>
+
+namespace gfx_api
+{
+
+enum class CompileImageLayout : uint8_t;
+
+/// Whether a sampled read's producer is tracked in the compile-time layout timeline.
+enum class ReadProducerScope : uint8_t
+{
+	/// Prior in-graph producer exists in the layout timeline.
+	InGraph,
+	/// Explicit barrier path; old layout from runtime `FrameLayoutTracker` (out-of-graph / legacy reads).
+	External,
+};
+
+/// Compile-time layout state keyed by texture subresource; used by `planLayoutTimeline` and `classifyReadProducerScope`.
+using LayoutStateMap = std::unordered_map<LayoutSubresourceKey, CompileImageLayout, LayoutSubresourceKeyHash>;
+
+/// Classify a read when planning barriers. Uses ReadDesc + layout timeline state.
+/// Does NOT mutate ResolvedRead — scope is stored on ImageBarrierOp only.
+ReadProducerScope classifyReadProducerScope(const ReadDesc& read,
+	const std::vector<RenderPassDesc>& descs, size_t consumerIndex,
+	const LayoutStateMap& layoutStateAtRead);
+
+} // namespace gfx_api

--- a/lib/ivis_opengl/render_graph/render_pass.h
+++ b/lib/ivis_opengl/render_graph/render_pass.h
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+/*
+	This file is part of Warzone 2100.
+	Copyright (C) 2026  Warzone 2100 Project (https://github.com/Warzone2100)
+
+	Warzone 2100 is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+
+	Warzone 2100 is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with Warzone 2100; if not, write to the Free Software
+	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+/** @file render_pass.h
+ * `RenderPassDesc`, read descriptors, and `RenderPassContext` for graph pass recording.
+ */
+
+#pragma once
+
+#include "attachment.h"
+#include "pipeline_surfaces.h"
+#include "render_pass_id.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <optional>
+using std::optional;
+using std::nullopt;
+
+namespace gfx_api
+{
+
+struct abstract_texture;
+
+/// Runtime index of a pass within a materialized `vector<RenderPassDesc>` (execution order).
+using PassHandle = size_t;
+static constexpr PassHandle INVALID_PASS_HANDLE = ~PassHandle(0);
+
+/// <summary>
+/// Which producer attachment a pass read refers to when `ReadSource::PassOutput`.
+/// </summary>
+enum class AttachmentRole : uint8_t
+{
+	/// Resolve target if MSAA resolve exists, else `colorAttachments[0]`.
+	PrimaryColor,
+	/// `colorAttachments[attachmentIndex]`.
+	Color,
+	/// `depthAttachment` (includes `arrayLayer` from producer).
+	Depth,
+	/// `resolveAttachment`.
+	Resolve,
+};
+
+/// <summary>
+/// How a `ReadDesc` input is resolved at compile / materialize time.
+/// </summary>
+enum class ReadSource : uint8_t
+{
+	/// Direct `abstract_texture*` on the read descriptor.
+	ExplicitTexture,
+	/// Named `PipelineSurfaceId` surface.
+	PipelineSurface,
+	/// Output of a prior pass in the same graph (`producerPass` + `AttachmentRole`).
+	PassOutput,
+};
+
+/// <summary>
+/// Declared input dependency for a pass (compile resolves to textures + layouts).
+/// </summary>
+struct ReadDesc
+{
+	ReadSource source = ReadSource::ExplicitTexture;
+	/// Used when `source == ExplicitTexture`.
+	abstract_texture* texture = nullptr;
+	/// Used when `source == PipelineSurface`.
+	PipelineSurfaceId pipelineSurface = PipelineSurfaceId::SceneColor;
+	/// Used when `source == PassOutput` (materializer maps from `PassId` to this handle).
+	PassHandle producerPass = INVALID_PASS_HANDLE;
+	AttachmentRole producerRole = AttachmentRole::PrimaryColor;
+	uint32_t attachmentIndex = 0;
+	optional<uint32_t> arrayLayer;
+	optional<uint32_t> mipLevel;
+};
+
+/// <summary>
+/// Compile-time resolved read: concrete texture, subresource, and depth flag for barriers.
+/// </summary>
+struct ResolvedRead
+{
+	abstract_texture* texture = nullptr;
+	uint32_t arrayLayer = 0;
+	uint32_t mipLevel = 0;
+	bool isDepth = false;
+};
+
+class RenderPassContext;
+
+/// <summary>
+/// Fully materialized render pass: GPU attachments, viewport, reads, and record callback.
+///
+/// Output of `BlueprintMaterializer`; consumed by `compilePassGraph` and
+/// `executeCompiledRenderGraph`. `passId` retains stable `PassId` for debugging and callbacks.
+/// </summary>
+struct RenderPassDesc
+{
+	std::string debugName;
+
+	/// Records draw calls for this pass; must only call gfx_api bind/draw while the pass is active.
+	using RecordFunc = std::function<void(const RenderPassContext&)>;
+	/// Draw callback; often populated from `RecordFuncTable` at materialize time.
+	RecordFunc recordFunc;
+
+	std::vector<AttachmentDesc> colorAttachments;
+	optional<AttachmentDesc> depthAttachment;
+	optional<AttachmentDesc> resolveAttachment;
+	optional<std::pair<uint32_t, uint32_t>> viewportSize;
+	std::vector<ReadDesc> reads;
+	/// Stable pass identity; `PassId::Count` means unset.
+	PassId passId = PassId::Count;
+};
+
+/// <summary>
+/// Per-pass data passed to `RecordFunc` callbacks after reads are compile-resolved.
+/// </summary>
+class RenderPassContext
+{
+public:
+	RenderPassContext(const RenderPassDesc& desc, std::vector<ResolvedRead> resolvedReads);
+
+	/// Resolved input texture for `reads[index]` (barriers already emitted).
+	abstract_texture* getRead(size_t index) const;
+	/// Stable id from `RenderPassDesc::passId`.
+	PassId passId() const { return _desc.passId; }
+
+private:
+	const RenderPassDesc& _desc;
+	std::vector<ResolvedRead> _resolvedReads;
+};
+
+} // namespace gfx_api

--- a/lib/ivis_opengl/render_graph/render_pass_id.h
+++ b/lib/ivis_opengl/render_graph/render_pass_id.h
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+/*
+	This file is part of Warzone 2100.
+	Copyright (C) 2026  Warzone 2100 Project (https://github.com/Warzone2100)
+
+	Warzone 2100 is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+
+	Warzone 2100 is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with Warzone 2100; if not, write to the Free Software
+	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+/** @file render_pass_id.h
+ * Stable `PassId` enum identifying pass slots across topology, callbacks, and caching.
+ */
+
+#pragma once
+
+#include <cstdint>
+
+namespace gfx_api
+{
+
+/// <summary>
+/// Stable semantic identity for a render pass slot across topology, callbacks, and caching.
+///
+/// Pass vector index can change when optional passes are added (e.g. shadow cascades);
+/// `PassId` is the key for `RecordFuncTable`, blueprint `BlueprintPass::id`, and
+/// `RenderPassDesc::passId`. `Count` is the array bound and "unset" sentinel.
+/// </summary>
+enum class PassId : uint16_t
+{
+	Backdrop,
+	ShadowCascade0,
+	ShadowCascade1,
+	ShadowCascade2,
+	ShadowCascade3,
+	ScenePass,
+	SceneBlit,
+	TargettingEffects,
+	SceneOverlays,
+	SceneDebugOverlays,
+	GameStartFade,
+	InGameUI,
+	TitleUI,
+	LoadingBackdrop,
+	LoadingScreen,
+	VideoPlayback,
+	/// Array size and invalid/unset pass id (not a real pass).
+	Count
+};
+
+/// Map shadow cascade index (`0` .. `WZ_SHADOW_CASCADES_COUNT` - 1) to the corresponding `PassId`.
+inline PassId shadowCascadePassId(uint32_t cascadeIndex)
+{
+	constexpr uint32_t first = static_cast<uint32_t>(PassId::ShadowCascade0);
+	constexpr uint32_t last = static_cast<uint32_t>(PassId::ShadowCascade3);
+	const uint32_t value = first + cascadeIndex;
+	if (value > last)
+	{
+		return PassId::Count;
+	}
+	return static_cast<PassId>(value);
+}
+
+/// Inverse of `shadowCascadePassId`; returns `UINT32_MAX` if `id` is outside the cascade `PassId` range.
+inline uint32_t passIdToCascadeIndex(PassId id)
+{
+	const uint16_t base = static_cast<uint16_t>(PassId::ShadowCascade0);
+	const uint16_t value = static_cast<uint16_t>(id);
+	if (value < base || value > static_cast<uint16_t>(PassId::ShadowCascade3))
+	{
+		return UINT32_MAX;
+	}
+	return value - base;
+}
+
+} // namespace gfx_api

--- a/lib/ivis_opengl/render_graph/topology.cpp
+++ b/lib/ivis_opengl/render_graph/topology.cpp
@@ -1,0 +1,164 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+/*
+	This file is part of Warzone 2100.
+	Copyright (C) 2026  Warzone 2100 Project (https://github.com/Warzone2100)
+
+	Warzone 2100 is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+
+	Warzone 2100 is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with Warzone 2100; if not, write to the Free Software
+	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+/** @file topology.cpp
+ * Topology snapshot construction, pass-count validation, and topology/materialize hashing.
+ */
+
+#include "topology.h"
+
+#include "gfx_api.h"
+#include "pipeline_surfaces.h"
+#include "shadows.h"
+
+#include "lib/framework/hash_combine.h"
+#include "lib/framework/wzapp.h"
+
+#include <algorithm>
+
+namespace gfx_api
+{
+
+namespace
+{
+
+size_t expectedInGamePassCount(const RenderTopologySnapshot& snapshot)
+{
+	ASSERT(snapshot.screenKind == RenderScreenKind::InGame, "expectedInGamePassCount: wrong screen kind");
+	size_t count = 6; // Scene, SceneBlit, Targetting, overlays, fade slot, UI
+	if (snapshot.features & RenderFeatures::DebugOverlays)
+	{
+		++count;
+	}
+	if (snapshot.features & RenderFeatures::Backdrop)
+	{
+		++count;
+	}
+	count += snapshot.numShadowCascades;
+	return count;
+}
+
+} // anonymous namespace
+
+uint64_t RenderTopologySnapshot::topologyHash() const
+{
+	std::size_t h = 0;
+	hash_combine(h,
+		static_cast<std::size_t>(screenKind),
+		features,
+		numShadowCascades,
+		sceneMsaa ? 1u : 0u,
+		swapchainMsaa ? 1u : 0u,
+		static_cast<std::size_t>(sceneBlitColorLoad));
+	return static_cast<uint64_t>(h);
+}
+
+uint64_t RenderTopologySnapshot::materializeHash() const
+{
+	std::size_t h = static_cast<std::size_t>(topologyHash());
+	hash_combine(h,
+		backendEpoch,
+		drawableW,
+		drawableH,
+		sceneW,
+		sceneH,
+		shadowMapSize);
+	return static_cast<uint64_t>(h);
+}
+
+size_t expectedPassCount(const RenderTopologySnapshot& snapshot)
+{
+	switch (snapshot.screenKind)
+	{
+	case RenderScreenKind::InGame:
+		return expectedInGamePassCount(snapshot);
+	case RenderScreenKind::Title:
+		return (snapshot.features & RenderFeatures::Backdrop) ? 2u : 1u;
+	case RenderScreenKind::Loading:
+		return (snapshot.features & RenderFeatures::Backdrop) ? 2u : 1u;
+	case RenderScreenKind::Video:
+		return 1u;
+	}
+	return 0;
+}
+
+namespace render_topology
+{
+
+RenderTopologySnapshot snapshot(const IRenderTopologyQuery& query)
+{
+	RenderTopologySnapshot snapshot;
+
+	if (query.isLoadingScreenActive())
+	{
+		snapshot.screenKind = RenderScreenKind::Loading;
+	}
+	else if (query.isVideoPlaybackActive())
+	{
+		snapshot.screenKind = RenderScreenKind::Video;
+	}
+	else if (query.isTitleScreenActive())
+	{
+		snapshot.screenKind = RenderScreenKind::Title;
+	}
+	else
+	{
+		snapshot.screenKind = RenderScreenKind::InGame;
+	}
+
+	snapshot.backendEpoch = query.backendEpoch();
+	snapshot.sceneMsaa = query.sceneMsaa();
+	snapshot.swapchainMsaa = query.swapchainMsaa();
+
+	if (query.shadowMode() == ShadowMode::Shadow_Mapping)
+	{
+		snapshot.numShadowCascades = std::min<uint32_t>(query.numDepthPasses(), WZ_MAX_SHADOW_CASCADES);
+		snapshot.shadowMapSize = query.shadowMapSize();
+	}
+
+	if (query.hasBackdrop())
+	{
+		snapshot.features |= RenderFeatures::Backdrop;
+		snapshot.sceneBlitColorLoad = AttachmentLoadOp::Load;
+	}
+
+	if (snapshot.screenKind == RenderScreenKind::InGame)
+	{
+		snapshot.features |= RenderFeatures::GameStartFadeSlot;
+		if (query.debugOverlaysEnabled())
+		{
+			snapshot.features |= RenderFeatures::DebugOverlays;
+		}
+	}
+
+	const auto drawable = query.drawableDimensions();
+	snapshot.drawableW = drawable.first;
+	snapshot.drawableH = drawable.second;
+
+	const auto sceneColor = query.sceneColorDimensions();
+	snapshot.sceneW = sceneColor.first;
+	snapshot.sceneH = sceneColor.second;
+
+	return snapshot;
+}
+
+} // namespace render_topology
+
+} // namespace gfx_api

--- a/lib/ivis_opengl/render_graph/topology.h
+++ b/lib/ivis_opengl/render_graph/topology.h
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+/*
+	This file is part of Warzone 2100.
+	Copyright (C) 2026  Warzone 2100 Project (https://github.com/Warzone2100)
+
+	Warzone 2100 is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+
+	Warzone 2100 is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with Warzone 2100; if not, write to the Free Software
+	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+/** @file topology.h
+ * Frame topology snapshot, feature flags, and `IRenderTopologyQuery` facade.
+ */
+
+#pragma once
+
+#include "attachment.h"
+#include "../piedef.h"
+
+#include <cstdint>
+#include <tuple>
+#include <utility>
+
+namespace gfx_api
+{
+
+/// <summary>
+/// Which frame-graph template to build (`PassGraphTopologyBlueprint::fromSnapshot`).
+/// </summary>
+enum class RenderScreenKind : uint8_t
+{
+	InGame,
+	Title,
+	Loading,
+	Video,
+};
+
+/// <summary>
+/// Optional pass/feature flags OR'd into `RenderTopologySnapshot::features`.
+/// </summary>
+struct RenderFeatures
+{
+	enum : uint32_t
+	{
+		/// Include a backdrop swapchain pass before main content.
+		Backdrop          = 1u << 0,
+		/// Reserve the in-game start fade pass slot (in-game topology only).
+		GameStartFadeSlot = 1u << 1,
+		/// Include the debug overlay pass slot (in-game topology only).
+		DebugOverlays     = 1u << 2,
+	};
+};
+
+/// <summary>
+/// Per-frame inputs that drive blueprint selection, materialization, and cache keys.
+///
+/// Collected from `IRenderTopologyQuery` via `render_topology::snapshot`. Split into
+/// `topologyHash` (graph shape / MSAA / features) and `materializeHash` (adds sizes
+/// and `backendEpoch`) so `CachedRenderGraph` can rebuild blueprint vs rematerialize passes separately.
+/// </summary>
+struct RenderTopologySnapshot
+{
+	RenderScreenKind screenKind = RenderScreenKind::InGame;
+	/// `RenderFeatures` bit mask.
+	uint32_t features = 0;
+	/// Active shadow-map passes when shadow mapping is enabled.
+	uint32_t numShadowCascades = 0;
+	bool sceneMsaa = false;
+	bool swapchainMsaa = false;
+	/// Color load op for the scene-to-swapchain blit pass (`Load` when backdrop is present).
+	AttachmentLoadOp sceneBlitColorLoad = AttachmentLoadOp::Clear;
+	/// Bumps when swapchain/surfaces are recreated; part of `materializeHash` only.
+	uint64_t backendEpoch = 0;
+	uint32_t drawableW = 0;
+	uint32_t drawableH = 0;
+	uint32_t sceneW = 0;
+	uint32_t sceneH = 0;
+	uint32_t shadowMapSize = 0;
+
+	bool operator==(const RenderTopologySnapshot& other) const
+	{
+		return std::tie(screenKind, features, numShadowCascades, sceneMsaa, swapchainMsaa,
+			sceneBlitColorLoad, backendEpoch, drawableW, drawableH, sceneW, sceneH, shadowMapSize)
+			== std::tie(other.screenKind, other.features, other.numShadowCascades, other.sceneMsaa,
+				other.swapchainMsaa, other.sceneBlitColorLoad, other.backendEpoch, other.drawableW,
+				other.drawableH, other.sceneW, other.sceneH, other.shadowMapSize);
+	}
+
+	/// Hash of screen kind, features, cascade count, MSAA flags, and scene blit load op.
+	uint64_t topologyHash() const;
+	/// `topologyHash` plus dimensions, `backendEpoch`, and `shadowMapSize`.
+	uint64_t materializeHash() const;
+};
+
+/// <summary>
+/// Game-state facade used to build a `RenderTopologySnapshot` each frame.
+///
+/// Implemented by the active screen / game loop; keeps render_graph free of direct
+/// calls into pie, loop, or loading code.
+/// </summary>
+class IRenderTopologyQuery
+{
+public:
+	virtual ~IRenderTopologyQuery() = default;
+
+	virtual bool isTitleScreenActive() const = 0;
+	virtual ShadowMode shadowMode() const = 0;
+	virtual bool hasBackdrop() const = 0;
+	virtual bool headlessOrSkipDrawing() const = 0;
+	virtual bool isLoadingScreenActive() const = 0;
+	virtual bool isVideoPlaybackActive() const = 0;
+	virtual uint32_t numDepthPasses() const = 0;
+	virtual bool sceneMsaa() const = 0;
+	virtual bool swapchainMsaa() const = 0;
+	virtual uint64_t backendEpoch() const = 0;
+	virtual std::pair<uint32_t, uint32_t> drawableDimensions() const = 0;
+	virtual std::pair<uint32_t, uint32_t> sceneColorDimensions() const = 0;
+	virtual uint32_t shadowMapSize() const = 0;
+	/// True when the in-game debug overlay pass slot should exist (persistent toggles only).
+	virtual bool debugOverlaysEnabled() const = 0;
+};
+
+namespace render_topology
+{
+
+/// Fill a `RenderTopologySnapshot` from current game/screen state.
+RenderTopologySnapshot snapshot(const IRenderTopologyQuery& query);
+
+} // namespace render_topology
+
+/// Expected pass count for validation after blueprint materialize (per screen kind / features).
+size_t expectedPassCount(const RenderTopologySnapshot& snapshot);
+
+/// Global query instance used during normal gameplay frame setup.
+IRenderTopologyQuery& getGameRenderTopologyQuery();
+
+} // namespace gfx_api

--- a/lib/ivis_opengl/screen.cpp
+++ b/lib/ivis_opengl/screen.cpp
@@ -285,6 +285,7 @@ void screen_SetBackDropFromFile(const char *filename)
 	int maxTextureSize = gfx_api::context::get().get_context_value(gfx_api::context::context_value::MAX_TEXTURE_SIZE);
 	backdropGfx->loadTexture(filename, gfx_api::texture_type::user_interface, maxTextureSize, maxTextureSize);
 	backdropIsMapPreview = false;
+	bBackDrop = true;
 	// Generate coordinates and put them into VBOs
 	screen_GenerateCoordinatesAndVBOs();
 }
@@ -296,7 +297,7 @@ void screen_StopBackDrop()
 
 bool screen_RestartBackDrop()
 {
-	bool changedValue = !bBackDrop;
+	const bool changedValue = !bBackDrop;
 	bBackDrop = true;
 	return changedValue;
 }
@@ -400,6 +401,7 @@ void screen_Upload(iV_Image&& newBackdropImage)
 	// Bitmap MUST be (BACKDROP_HACK_WIDTH * BACKDROP_HACK_HEIGHT) for now.
 	backdropGfx->loadTexture(std::move(newBackdropImage), gfx_api::texture_type::user_interface, "mem::generated_map_preview");
 	backdropIsMapPreview = true;
+	bBackDrop = true;
 
 	// Generate coordinates and put them into VBOs
 	screen_GenerateCoordinatesAndVBOs();
@@ -587,8 +589,12 @@ void screen_FlipIfBackDropTransition()
 	static auto hadBackDrop = false;
 	if (hadBackDrop != screen_GetBackDrop())
 	{
-		pie_ScreenFrameRenderEnd();
-		pie_ScreenFrameRenderBegin();
+		auto& ctx = gfx_api::context::get();
+		if (ctx.shouldDraw() && ctx.canRecordDrawCommands())
+		{
+			pie_ScreenFrameRenderEnd();
+			pie_ScreenFrameRenderBegin();
+		}
 		hadBackDrop = screen_GetBackDrop();
 	}
 }

--- a/lib/ivis_opengl/vk/frame_layout_tracker.cpp
+++ b/lib/ivis_opengl/vk/frame_layout_tracker.cpp
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+/*
+	This file is part of Warzone 2100.
+	Copyright (C) 2026  Warzone 2100 Project (https://github.com/Warzone2100)
+
+	Warzone 2100 is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+
+	Warzone 2100 is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with Warzone 2100; if not, write to the Free Software
+	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+/** @file frame_layout_tracker.cpp
+ * Implementation of `FrameLayoutTracker` layout get/set and present transition.
+ */
+
+#if defined(WZ_VULKAN_ENABLED)
+
+#include "vk/frame_layout_tracker.h"
+
+#include "gfx_api_vk.h"
+#include "render_graph/layout_subresource.h"
+#include "vk/layout_translation.h"
+
+namespace gfx_api::vk
+{
+
+void FrameLayoutTracker::reset()
+{
+	_layouts.clear();
+	_swapchainTouchedThisFrame = false;
+}
+
+void FrameLayoutTracker::beginFrame()
+{
+	_swapchainTouchedThisFrame = false;
+}
+
+void FrameLayoutTracker::noteSwapchainWrite()
+{
+	_swapchainTouchedThisFrame = true;
+}
+
+void FrameLayoutTracker::set(gfx_api::abstract_texture* texture, ::vk::ImageLayout layout)
+{
+	set(gfx_api::layoutSubresourceKey(texture), layout);
+}
+
+void FrameLayoutTracker::set(const gfx_api::LayoutSubresourceKey& subresource, ::vk::ImageLayout layout)
+{
+	if (subresource.texture != nullptr)
+	{
+		_layouts[subresource] = layout;
+	}
+}
+
+void FrameLayoutTracker::erase(gfx_api::abstract_texture* texture)
+{
+	erase(gfx_api::layoutSubresourceKey(texture));
+}
+
+void FrameLayoutTracker::erase(const gfx_api::LayoutSubresourceKey& subresource)
+{
+	if (subresource.texture != nullptr)
+	{
+		_layouts.erase(subresource);
+	}
+}
+
+::vk::ImageLayout FrameLayoutTracker::get(gfx_api::abstract_texture* texture) const
+{
+	return get(gfx_api::layoutSubresourceKey(texture));
+}
+
+::vk::ImageLayout FrameLayoutTracker::get(const gfx_api::LayoutSubresourceKey& subresource) const
+{
+	if (subresource.texture == nullptr)
+	{
+		return ::vk::ImageLayout::eUndefined;
+	}
+	const auto it = _layouts.find(subresource);
+	if (it != _layouts.end())
+	{
+		return it->second;
+	}
+	return ::vk::ImageLayout::eUndefined;
+}
+
+void FrameLayoutTracker::applyPostPassUpdates(const gfx_api::CompiledPass& pass)
+{
+	for (const gfx_api::LayoutStateUpdate& update : pass.postPassLayoutUpdates)
+	{
+		if (update.texture == nullptr)
+		{
+			continue;
+		}
+		set(gfx_api::layoutSubresourceKey(update.texture, update.arrayLayer, update.mipLevel),
+			toVkImageLayout(update.layout));
+	}
+}
+
+void FrameLayoutTracker::commitLegacyFinalLayouts(const std::vector<LegacyLayoutFinal>& finals)
+{
+	for (const LegacyLayoutFinal& entry : finals)
+	{
+		set(entry.subresource, entry.layout);
+	}
+}
+
+void FrameLayoutTracker::transitionSwapchainToPresent(VkRoot& root, ::vk::CommandBuffer cmd,
+	gfx_api::abstract_texture* swapchainColor)
+{
+	if (!_swapchainTouchedThisFrame || swapchainColor == nullptr)
+	{
+		return;
+	}
+
+	::vk::ImageLayout oldLayout = get(swapchainColor);
+	if (oldLayout == ::vk::ImageLayout::ePresentSrcKHR)
+	{
+		// Swapchain was written this frame but tracker was not reset to ColorAttachment after the write.
+		oldLayout = ::vk::ImageLayout::eColorAttachmentOptimal;
+	}
+	root.transitionImageLayout(cmd, swapchainColor, oldLayout,
+		::vk::ImageLayout::ePresentSrcKHR,
+		::vk::PipelineStageFlagBits::eColorAttachmentOutput, ::vk::PipelineStageFlagBits::eBottomOfPipe,
+		::vk::AccessFlagBits::eColorAttachmentWrite, ::vk::AccessFlags());
+}
+
+} // namespace gfx_api::vk
+
+#endif // defined(WZ_VULKAN_ENABLED)

--- a/lib/ivis_opengl/vk/frame_layout_tracker.h
+++ b/lib/ivis_opengl/vk/frame_layout_tracker.h
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+/*
+	This file is part of Warzone 2100.
+	Copyright (C) 2026  Warzone 2100 Project (https://github.com/Warzone2100)
+
+	Warzone 2100 is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+
+	Warzone 2100 is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with Warzone 2100; if not, write to the Free Software
+	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+/** @file frame_layout_tracker.h
+ * Runtime per-subresource layout map and swapchain present transition for the current frame.
+ */
+
+#pragma once
+
+#if defined(WZ_VULKAN_ENABLED)
+
+#include "vk/vulkan_hpp_include.h"
+
+#include "render_graph/compile.h"
+#include "render_graph/layout_subresource.h"
+#include "vk/legacy_layout_final.h"
+
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+struct VkRoot;
+
+namespace gfx_api::vk
+{
+
+/// <summary>
+/// Runtime per-subresource layout map for the current frame.
+///
+/// Separate from compile-time `LayoutStateMap` in `layout_timeline`. Consumed by
+/// `PrePassBarrierEmitter` (External read old layouts), post-pass updates from
+/// `CompiledPass`, `LegacyPassLayoutCommit`, and the single swapchain present transition.
+/// </summary>
+class FrameLayoutTracker
+{
+public:
+	/// Clears all tracked layouts and the swapchain-touched flag.
+	void reset();
+	/// Resets per-frame swapchain write tracking at frame start.
+	void beginFrame();
+	/// Marks that the swapchain color surface was written this frame.
+	void noteSwapchainWrite();
+	void set(gfx_api::abstract_texture* texture, ::vk::ImageLayout layout);
+	void set(const gfx_api::LayoutSubresourceKey& subresource, ::vk::ImageLayout layout);
+	void erase(gfx_api::abstract_texture* texture);
+	void erase(const gfx_api::LayoutSubresourceKey& subresource);
+	/// Returns tracked layout for the subresource, or eUndefined when not in the map.
+	::vk::ImageLayout get(gfx_api::abstract_texture* texture) const;
+	::vk::ImageLayout get(const gfx_api::LayoutSubresourceKey& subresource) const;
+
+	/// Applies `CompiledPass::postPassLayoutUpdates` after a graph pass ends.
+	void applyPostPassUpdates(const gfx_api::CompiledPass& pass);
+	/// Commits out-of-graph final layouts captured by `LegacyPassLayoutCommit`.
+	void commitLegacyFinalLayouts(const std::vector<LegacyLayoutFinal>& finals);
+
+	/// Single frame-level swapchain -> Present transition. No-op if swapchain not touched or texture is null.
+	void transitionSwapchainToPresent(VkRoot& root, ::vk::CommandBuffer cmd,
+		gfx_api::abstract_texture* swapchainColor);
+
+private:
+	std::unordered_map<gfx_api::LayoutSubresourceKey, ::vk::ImageLayout, gfx_api::LayoutSubresourceKeyHash> _layouts;
+	bool _swapchainTouchedThisFrame = false;
+};
+
+} // namespace gfx_api::vk
+
+#endif // defined(WZ_VULKAN_ENABLED)

--- a/lib/ivis_opengl/vk/handle_storage.h
+++ b/lib/ivis_opengl/vk/handle_storage.h
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+/*
+	This file is part of Warzone 2100.
+	Copyright (C) 2026  Warzone 2100 Project (https://github.com/Warzone2100)
+
+	Warzone 2100 is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+
+	Warzone 2100 is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with Warzone 2100; if not, write to the Free Software
+	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+/** @file handle_storage.h
+ * Portable encode/decode of Vulkan opaque handles into uint64_t cache storage.
+ */
+
+#pragma once
+
+#if defined(WZ_VULKAN_ENABLED)
+
+#include <cstdint>
+#include <cstring>
+
+namespace gfx_api::vk
+{
+
+template<typename Handle>
+uint64_t encodeHandle(Handle handle)
+{
+	static_assert(sizeof(Handle) <= sizeof(uint64_t), "Vulkan handle too large for uint64_t storage");
+	uint64_t encoded = 0;
+	std::memcpy(&encoded, &handle, sizeof(handle));
+	return encoded;
+}
+
+template<typename Handle>
+Handle decodeHandle(uint64_t encoded)
+{
+	static_assert(sizeof(Handle) <= sizeof(uint64_t), "Vulkan handle too large for uint64_t storage");
+	Handle handle {};
+	std::memcpy(&handle, &encoded, sizeof(handle));
+	return handle;
+}
+
+} // namespace gfx_api::vk
+
+#endif // defined(WZ_VULKAN_ENABLED)

--- a/lib/ivis_opengl/vk/layout_key_builder.cpp
+++ b/lib/ivis_opengl/vk/layout_key_builder.cpp
@@ -1,0 +1,319 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+/*
+	This file is part of Warzone 2100.
+	Copyright (C) 2026  Warzone 2100 Project (https://github.com/Warzone2100)
+
+	Warzone 2100 is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+
+	Warzone 2100 is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with Warzone 2100; if not, write to the Free Software
+	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+/** @file layout_key_builder.cpp
+ * Implementation of pass layout key population for graph and legacy passes.
+ */
+
+#if defined(WZ_VULKAN_ENABLED)
+
+#include "vk/layout_key_builder.h"
+
+#include "gfx_api_vk.h"
+#include "render_graph/layout_subresource.h"
+#include "render_graph/pass_resolve.h"
+#include "vk/layout_translation.h"
+
+namespace gfx_api::vk
+{
+
+namespace
+{
+
+void clearPassLayoutKey(PassLayoutKey& layoutKey)
+{
+	layoutKey.colorFormats.clear();
+	layoutKey.colorLoadOps.clear();
+	layoutKey.colorStoreOps.clear();
+	layoutKey.colorSamples.clear();
+	layoutKey.colorInitialLayouts.clear();
+	layoutKey.colorFinalLayouts.clear();
+	layoutKey.resolveFormat.reset();
+	layoutKey.resolveLoadOp = AttachmentLoadOp::DontCare;
+	layoutKey.resolveStoreOp = AttachmentStoreOp::Store;
+	layoutKey.resolveInitialLayout.reset();
+	layoutKey.resolveFinalLayout.reset();
+	layoutKey.depthFormat.reset();
+	layoutKey.depthLoadOp = AttachmentLoadOp::DontCare;
+	layoutKey.depthStoreOp = AttachmentStoreOp::DontCare;
+	layoutKey.depthInitialLayout.reset();
+	layoutKey.depthFinalLayout = ::vk::ImageLayout::eDepthStencilAttachmentOptimal;
+}
+
+::vk::ImageLayout initialColorAttachmentLayout(AttachmentLoadOp loadOp)
+{
+	return (loadOp == AttachmentLoadOp::Clear)
+		? ::vk::ImageLayout::eUndefined
+		: ::vk::ImageLayout::eColorAttachmentOptimal;
+}
+
+::vk::ImageLayout initialResolveAttachmentLayout(AttachmentLoadOp loadOp)
+{
+	return (loadOp == AttachmentLoadOp::Clear || loadOp == AttachmentLoadOp::DontCare)
+		? ::vk::ImageLayout::eUndefined
+		: ::vk::ImageLayout::eColorAttachmentOptimal;
+}
+
+::vk::ImageLayout initialDepthAttachmentLayout(AttachmentLoadOp loadOp)
+{
+	return (loadOp == AttachmentLoadOp::Clear)
+		? ::vk::ImageLayout::eUndefined
+		: ::vk::ImageLayout::eDepthStencilAttachmentOptimal;
+}
+
+::vk::ImageLayout depthFinalLayoutFromStoreOp(AttachmentStoreOp storeOp)
+{
+	return (storeOp == AttachmentStoreOp::Store)
+		? ::vk::ImageLayout::eDepthStencilReadOnlyOptimal
+		: ::vk::ImageLayout::eDepthStencilAttachmentOptimal;
+}
+
+void applyCompiledRenderPassLayoutsToKey(PassLayoutKey& layoutKey, const gfx_api::CompiledPass& compiledPass,
+	const gfx_api::RenderPassDesc& pass)
+{
+	const gfx_api::CompiledPassLayoutMetadata& metadata = compiledPass.renderPassLayouts;
+
+	layoutKey.colorInitialLayouts.clear();
+	layoutKey.colorInitialLayouts.reserve(metadata.colorInitialLayouts.size());
+	for (const gfx_api::CompileImageLayout colorInitialLayout : metadata.colorInitialLayouts)
+	{
+		layoutKey.colorInitialLayouts.push_back(toVkImageLayout(colorInitialLayout));
+	}
+	if (metadata.resolveInitialLayout.has_value())
+	{
+		layoutKey.resolveInitialLayout = toVkImageLayout(metadata.resolveInitialLayout.value());
+	}
+	else
+	{
+		layoutKey.resolveInitialLayout.reset();
+	}
+	if (pass.depthAttachment.has_value() && pass.depthAttachment->texture != nullptr)
+	{
+		layoutKey.depthInitialLayout = toVkImageLayout(metadata.depthInitialLayout);
+	}
+
+	layoutKey.colorFinalLayouts.clear();
+	layoutKey.colorFinalLayouts.reserve(metadata.colorFinalLayouts.size());
+	for (const gfx_api::CompileImageLayout colorFinalLayout : metadata.colorFinalLayouts)
+	{
+		layoutKey.colorFinalLayouts.push_back(toVkImageLayout(colorFinalLayout));
+	}
+	if (metadata.resolveFinalLayout.has_value())
+	{
+		layoutKey.resolveFinalLayout = toVkImageLayout(metadata.resolveFinalLayout.value());
+	}
+	else
+	{
+		layoutKey.resolveFinalLayout.reset();
+	}
+	if (pass.depthAttachment.has_value() && pass.depthAttachment->texture != nullptr)
+	{
+		layoutKey.depthFinalLayout = toVkImageLayout(metadata.depthFinalLayout);
+	}
+}
+
+void ensurePassLayoutFinalLayouts(PassLayoutKey& layoutKey, const gfx_api::RenderPassDesc& pass)
+{
+	if (!layoutKey.colorFinalLayouts.empty())
+	{
+		return;
+	}
+
+	// Legacy (out-of-graph / ReadProducerScope::External) fallback: derive final layouts from store ops.
+	// The swapchain is left in ColorAttachmentOptimal (the layout it is rendered in) so the only
+	// swapchain transition is the single PresentSrcKHR barrier emitted once per frame in submitFrame().
+	layoutKey.colorFinalLayouts.reserve(layoutKey.colorFormats.size());
+	for (size_t i = 0; i < layoutKey.colorFormats.size(); ++i)
+	{
+		const AttachmentStoreOp colorStoreOp = (i < layoutKey.colorStoreOps.size())
+			? layoutKey.colorStoreOps[i]
+			: AttachmentStoreOp::Store;
+		if (i < pass.colorAttachments.size()
+			&& gfx_api::isSwapchainPresentableColorSurface(pass.colorAttachments[i].texture))
+		{
+			layoutKey.colorFinalLayouts.push_back(::vk::ImageLayout::eColorAttachmentOptimal);
+		}
+		else
+		{
+			layoutKey.colorFinalLayouts.push_back(colorFinalLayoutFromStoreOp(colorStoreOp));
+		}
+	}
+
+	if (layoutKey.resolveFormat.has_value() && !layoutKey.resolveFinalLayout.has_value())
+	{
+		if (pass.resolveAttachment.has_value()
+			&& gfx_api::isSwapchainPresentableColorSurface(pass.resolveAttachment->texture))
+		{
+			layoutKey.resolveFinalLayout = ::vk::ImageLayout::eColorAttachmentOptimal;
+		}
+		else
+		{
+			layoutKey.resolveFinalLayout = colorFinalLayoutFromStoreOp(layoutKey.resolveStoreOp);
+		}
+	}
+}
+
+} // anonymous namespace
+
+::vk::AttachmentLoadOp toVkAttachmentLoadOp(AttachmentLoadOp loadOp)
+{
+	switch (loadOp)
+	{
+	case AttachmentLoadOp::Clear:
+		return ::vk::AttachmentLoadOp::eClear;
+	case AttachmentLoadOp::Load:
+		return ::vk::AttachmentLoadOp::eLoad;
+	case AttachmentLoadOp::DontCare:
+		return ::vk::AttachmentLoadOp::eDontCare;
+	}
+	return ::vk::AttachmentLoadOp::eDontCare;
+}
+
+::vk::AttachmentStoreOp toVkAttachmentStoreOp(AttachmentStoreOp storeOp)
+{
+	switch (storeOp)
+	{
+	case AttachmentStoreOp::Store:
+		return ::vk::AttachmentStoreOp::eStore;
+	case AttachmentStoreOp::DontCare:
+	case AttachmentStoreOp::Invalidate:
+	case AttachmentStoreOp::Resolve:
+		return ::vk::AttachmentStoreOp::eDontCare;
+	}
+	return ::vk::AttachmentStoreOp::eDontCare;
+}
+
+::vk::ImageLayout colorFinalLayoutFromStoreOp(AttachmentStoreOp storeOp)
+{
+	return (storeOp == AttachmentStoreOp::Store)
+		? ::vk::ImageLayout::eShaderReadOnlyOptimal
+		: ::vk::ImageLayout::eColorAttachmentOptimal;
+}
+
+::vk::ImageLayout resolveColorInitialLayout(const PassLayoutKey& key, size_t colorIndex)
+{
+	if (colorIndex < key.colorInitialLayouts.size())
+	{
+		return key.colorInitialLayouts[colorIndex];
+	}
+	return initialColorAttachmentLayout(key.colorLoadOps[colorIndex]);
+}
+
+::vk::ImageLayout resolveResolveInitialLayout(const PassLayoutKey& key)
+{
+	if (key.resolveInitialLayout.has_value())
+	{
+		return key.resolveInitialLayout.value();
+	}
+	return initialResolveAttachmentLayout(key.resolveLoadOp);
+}
+
+::vk::ImageLayout resolveDepthInitialLayout(const PassLayoutKey& key)
+{
+	if (key.depthInitialLayout.has_value())
+	{
+		return key.depthInitialLayout.value();
+	}
+	return initialDepthAttachmentLayout(key.depthLoadOp);
+}
+
+bool populatePassLayoutKeyFormats(PassLayoutKey& key, const gfx_api::RenderPassDesc& pass, const VkRoot& root)
+{
+	for (const auto& colorAttachment : pass.colorAttachments)
+	{
+		ASSERT_OR_RETURN(false, colorAttachment.texture != nullptr, "Unresolved color attachment in dynamic pass");
+		key.colorFormats.push_back(root.getAttachmentVkFormat(colorAttachment.texture));
+		key.colorLoadOps.push_back(colorAttachment.loadOp);
+		key.colorStoreOps.push_back(gfx_api::attachmentStoreOpOr(colorAttachment));
+		key.colorSamples.push_back(root.getAttachmentVkSamples(colorAttachment.texture));
+	}
+	if (gfx_api::passNeedsMsaaResolve(pass))
+	{
+		key.resolveFormat = root.getAttachmentVkFormat(pass.resolveAttachment->texture);
+		key.resolveLoadOp = pass.resolveAttachment->loadOp;
+		key.resolveStoreOp = gfx_api::attachmentStoreOpOr(pass.resolveAttachment.value());
+	}
+	if (pass.depthAttachment.has_value() && pass.depthAttachment->texture != nullptr)
+	{
+		key.depthFormat = root.getAttachmentVkFormat(pass.depthAttachment->texture);
+		key.depthLoadOp = pass.depthAttachment->loadOp;
+		key.depthStoreOp = gfx_api::attachmentStoreOpOr(pass.depthAttachment.value());
+	}
+	return true;
+}
+
+bool populatePassLayoutKeyLayouts(PassLayoutKey& key, const gfx_api::RenderPassDesc& pass,
+	const LayoutKeyBuildContext& ctx)
+{
+	if (ctx.compiledPass != nullptr)
+	{
+		applyCompiledRenderPassLayoutsToKey(key, *ctx.compiledPass, pass);
+		return true;
+	}
+
+	ASSERT_OR_RETURN(false, ctx.runtimeLayoutSource != nullptr, "Legacy pass layout key requires runtimeLayoutSource");
+
+	const auto legacyInitialLayout = [&](const gfx_api::AttachmentDesc& attachment) -> ::vk::ImageLayout {
+		if (attachment.texture == nullptr || attachment.loadOp != AttachmentLoadOp::Load)
+		{
+			return ::vk::ImageLayout::eUndefined;
+		}
+		return ctx.runtimeLayoutSource->getImageLayout(
+			gfx_api::layoutSubresourceKey(attachment));
+	};
+
+	key.colorInitialLayouts.clear();
+	key.colorInitialLayouts.reserve(pass.colorAttachments.size());
+	for (const auto& colorAttachment : pass.colorAttachments)
+	{
+		key.colorInitialLayouts.push_back(legacyInitialLayout(colorAttachment));
+	}
+	if (gfx_api::passNeedsMsaaResolve(pass))
+	{
+		key.resolveInitialLayout = legacyInitialLayout(pass.resolveAttachment.value());
+	}
+	if (pass.depthAttachment.has_value() && pass.depthAttachment->texture != nullptr)
+	{
+		key.depthInitialLayout = legacyInitialLayout(pass.depthAttachment.value());
+		key.depthFinalLayout = depthFinalLayoutFromStoreOp(key.depthStoreOp);
+	}
+	return true;
+}
+
+bool buildPassLayoutKey(PassLayoutKey& out, const gfx_api::RenderPassDesc& pass,
+	const LayoutKeyBuildContext& ctx, const VkRoot& root)
+{
+	ASSERT_OR_RETURN(false, pass.viewportSize.has_value(), "Pass requires resolved viewportSize");
+
+	clearPassLayoutKey(out);
+
+	if (!populatePassLayoutKeyFormats(out, pass, root)
+		|| !populatePassLayoutKeyLayouts(out, pass, ctx))
+	{
+		clearPassLayoutKey(out);
+		return false;
+	}
+	ensurePassLayoutFinalLayouts(out, pass);
+	return true;
+}
+
+} // namespace gfx_api::vk
+
+#endif // defined(WZ_VULKAN_ENABLED)

--- a/lib/ivis_opengl/vk/layout_key_builder.h
+++ b/lib/ivis_opengl/vk/layout_key_builder.h
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+/*
+	This file is part of Warzone 2100.
+	Copyright (C) 2026  Warzone 2100 Project (https://github.com/Warzone2100)
+
+	Warzone 2100 is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+
+	Warzone 2100 is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with Warzone 2100; if not, write to the Free Software
+	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+/** @file layout_key_builder.h
+ * Builds `PassLayoutKey` from `RenderPassDesc` and optional compiled pass metadata.
+ */
+
+#pragma once
+
+#if defined(WZ_VULKAN_ENABLED)
+
+#include "render_graph/compile.h"
+#include "render_graph/render_pass.h"
+#include "vk/pass_layout_key.h"
+
+struct VkRoot;
+
+namespace gfx_api::vk
+{
+
+/// <summary>
+/// Inputs for building a `PassLayoutKey`.
+///
+/// When `compiledPass` is non-null, initial/final layouts come from compile metadata.
+/// When null (out-of-graph / legacy pass), layouts are resolved from the runtime
+/// `FrameLayoutTracker` via `runtimeLayoutSource`.
+/// </summary>
+struct LayoutKeyBuildContext
+{
+	/// When non-null, initial/final layouts come from compiled metadata.
+	const gfx_api::CompiledPass* compiledPass = nullptr;
+	/// Supplies runtime layout lookups for legacy passes when `compiledPass` is null.
+	const VkRoot* runtimeLayoutSource = nullptr;
+};
+
+/// Fills formats, load/store ops, and sample counts from pass attachments.
+bool populatePassLayoutKeyFormats(PassLayoutKey& key, const gfx_api::RenderPassDesc& pass, const VkRoot& root);
+/// Fills initial/final layouts from compile metadata or the runtime tracker.
+bool populatePassLayoutKeyLayouts(PassLayoutKey& key, const gfx_api::RenderPassDesc& pass,
+	const LayoutKeyBuildContext& ctx);
+/// Builds a complete `PassLayoutKey` (formats then layouts).
+bool buildPassLayoutKey(PassLayoutKey& out, const gfx_api::RenderPassDesc& pass,
+	const LayoutKeyBuildContext& ctx, const VkRoot& root);
+
+::vk::AttachmentLoadOp toVkAttachmentLoadOp(gfx_api::AttachmentLoadOp loadOp);
+::vk::AttachmentStoreOp toVkAttachmentStoreOp(gfx_api::AttachmentStoreOp storeOp);
+/// Derives RP finalLayout for a color attachment from its store op.
+::vk::ImageLayout colorFinalLayoutFromStoreOp(gfx_api::AttachmentStoreOp storeOp);
+/// Resolves effective color attachment initialLayout (load-op default when unset).
+::vk::ImageLayout resolveColorInitialLayout(const PassLayoutKey& key, size_t colorIndex);
+/// Resolves effective resolve attachment initialLayout (load-op default when unset).
+::vk::ImageLayout resolveResolveInitialLayout(const PassLayoutKey& key);
+/// Resolves effective depth attachment initialLayout (load-op default when unset).
+::vk::ImageLayout resolveDepthInitialLayout(const PassLayoutKey& key);
+
+} // namespace gfx_api::vk
+
+#endif // defined(WZ_VULKAN_ENABLED)

--- a/lib/ivis_opengl/vk/layout_sync.cpp
+++ b/lib/ivis_opengl/vk/layout_sync.cpp
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+/*
+	This file is part of Warzone 2100.
+	Copyright (C) 2026  Warzone 2100 Project (https://github.com/Warzone2100)
+
+	Warzone 2100 is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+
+	Warzone 2100 is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with Warzone 2100; if not, write to the Free Software
+	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+/** @file layout_sync.cpp
+ * Implementation of barrier recipes between compile-time image layouts.
+ */
+
+#if defined(WZ_VULKAN_ENABLED)
+
+#include "vk/layout_sync.h"
+
+#include "vk/layout_translation.h"
+
+namespace gfx_api::vk
+{
+
+LayoutSync layoutProducerSync(::vk::ImageLayout layout)
+{
+	switch (layout)
+	{
+	case ::vk::ImageLayout::eColorAttachmentOptimal:
+		return { ::vk::PipelineStageFlagBits::eColorAttachmentOutput, ::vk::AccessFlagBits::eColorAttachmentWrite };
+	case ::vk::ImageLayout::eDepthStencilAttachmentOptimal:
+		return {
+			::vk::PipelineStageFlagBits::eEarlyFragmentTests | ::vk::PipelineStageFlagBits::eLateFragmentTests,
+			::vk::AccessFlagBits::eDepthStencilAttachmentWrite
+		};
+	case ::vk::ImageLayout::eShaderReadOnlyOptimal:
+	case ::vk::ImageLayout::eDepthStencilReadOnlyOptimal:
+		return { ::vk::PipelineStageFlagBits::eFragmentShader, ::vk::AccessFlagBits::eShaderRead };
+	case ::vk::ImageLayout::ePresentSrcKHR:
+		return { ::vk::PipelineStageFlagBits::eBottomOfPipe, ::vk::AccessFlags() };
+	case ::vk::ImageLayout::eUndefined:
+	default:
+		return { ::vk::PipelineStageFlagBits::eTopOfPipe, ::vk::AccessFlags() };
+	}
+}
+
+LayoutSync layoutConsumerSync(::vk::ImageLayout layout)
+{
+	switch (layout)
+	{
+	case ::vk::ImageLayout::eColorAttachmentOptimal:
+		// Covers blend / Load reads of the color attachment as well as writes.
+		return { ::vk::PipelineStageFlagBits::eColorAttachmentOutput,
+			::vk::AccessFlagBits::eColorAttachmentWrite | ::vk::AccessFlagBits::eColorAttachmentRead };
+	case ::vk::ImageLayout::eDepthStencilAttachmentOptimal:
+		return {
+			::vk::PipelineStageFlagBits::eEarlyFragmentTests | ::vk::PipelineStageFlagBits::eLateFragmentTests,
+			::vk::AccessFlagBits::eDepthStencilAttachmentWrite | ::vk::AccessFlagBits::eDepthStencilAttachmentRead
+		};
+	case ::vk::ImageLayout::eShaderReadOnlyOptimal:
+	case ::vk::ImageLayout::eDepthStencilReadOnlyOptimal:
+		return { ::vk::PipelineStageFlagBits::eFragmentShader, ::vk::AccessFlagBits::eShaderRead };
+	case ::vk::ImageLayout::ePresentSrcKHR:
+		return { ::vk::PipelineStageFlagBits::eBottomOfPipe, ::vk::AccessFlags() };
+	case ::vk::ImageLayout::eUndefined:
+	default:
+		return { ::vk::PipelineStageFlagBits::eTopOfPipe, ::vk::AccessFlags() };
+	}
+}
+
+BarrierRecipe getBarrierRecipe(CompileImageLayout oldLayout, CompileImageLayout newLayout)
+{
+	const LayoutSync src = layoutProducerSync(toVkImageLayout(oldLayout));
+	const LayoutSync dst = layoutConsumerSync(toVkImageLayout(newLayout));
+
+	BarrierRecipe recipe;
+	recipe.srcStage = src.stage;
+	recipe.srcAccess = src.access;
+	recipe.dstStage = dst.stage;
+	recipe.dstAccess = dst.access;
+	return recipe;
+}
+
+} // namespace gfx_api::vk
+
+#endif // defined(WZ_VULKAN_ENABLED)

--- a/lib/ivis_opengl/vk/layout_sync.h
+++ b/lib/ivis_opengl/vk/layout_sync.h
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+/*
+	This file is part of Warzone 2100.
+	Copyright (C) 2026  Warzone 2100 Project (https://github.com/Warzone2100)
+
+	Warzone 2100 is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+
+	Warzone 2100 is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with Warzone 2100; if not, write to the Free Software
+	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+/** @file layout_sync.h
+ * Pipeline stage and access flags for layout transitions (`LayoutSync`, barrier recipes).
+ */
+
+#pragma once
+
+#if defined(WZ_VULKAN_ENABLED)
+
+#include "vk/vulkan_hpp_include.h"
+
+#include "render_graph/compile.h"
+
+namespace gfx_api::vk
+{
+
+/// Pipeline stage and access flags associated with a single `vk::ImageLayout`.
+struct LayoutSync
+{
+	::vk::PipelineStageFlags stage {};
+	::vk::AccessFlags access {};
+};
+
+/// Producer-side stage/access for an image in the given layout (writes / attachment output).
+LayoutSync layoutProducerSync(::vk::ImageLayout layout);
+/// Consumer-side stage/access for an image in the given layout (reads / shader sampling).
+LayoutSync layoutConsumerSync(::vk::ImageLayout layout);
+
+/// <summary>
+/// Source and destination sync for an image layout transition barrier.
+///
+/// Union of producer sync for `oldLayout` and consumer sync for `newLayout`.
+/// Consumed by `PrePassBarrierEmitter` when emitting `vkCmdPipelineBarrier`.
+/// </summary>
+struct BarrierRecipe
+{
+	::vk::PipelineStageFlags srcStage = ::vk::PipelineStageFlagBits::eTopOfPipe;
+	::vk::PipelineStageFlags dstStage = ::vk::PipelineStageFlagBits::eFragmentShader;
+	::vk::AccessFlags srcAccess {};
+	::vk::AccessFlags dstAccess = ::vk::AccessFlagBits::eShaderRead;
+};
+
+/// Builds a `BarrierRecipe` from compile-time `CompileImageLayout` old/new pair.
+BarrierRecipe getBarrierRecipe(CompileImageLayout oldLayout, CompileImageLayout newLayout);
+
+} // namespace gfx_api::vk
+
+#endif // defined(WZ_VULKAN_ENABLED)

--- a/lib/ivis_opengl/vk/layout_translation.cpp
+++ b/lib/ivis_opengl/vk/layout_translation.cpp
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+/*
+	This file is part of Warzone 2100.
+	Copyright (C) 2026  Warzone 2100 Project (https://github.com/Warzone2100)
+
+	Warzone 2100 is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+
+	Warzone 2100 is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with Warzone 2100; if not, write to the Free Software
+	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+/** @file layout_translation.cpp
+ * Implementation of compile-image-layout ↔ Vulkan layout translation.
+ */
+
+#if defined(WZ_VULKAN_ENABLED)
+
+#include "vk/layout_translation.h"
+
+namespace gfx_api::vk
+{
+
+::vk::ImageLayout toVkImageLayout(CompileImageLayout layout)
+{
+	switch (layout)
+	{
+	case CompileImageLayout::Undefined:
+		return ::vk::ImageLayout::eUndefined;
+	case CompileImageLayout::ShaderReadOnly:
+		return ::vk::ImageLayout::eShaderReadOnlyOptimal;
+	case CompileImageLayout::DepthReadOnly:
+		return ::vk::ImageLayout::eDepthStencilReadOnlyOptimal;
+	case CompileImageLayout::ColorAttachment:
+		return ::vk::ImageLayout::eColorAttachmentOptimal;
+	case CompileImageLayout::DepthAttachment:
+		return ::vk::ImageLayout::eDepthStencilAttachmentOptimal;
+	case CompileImageLayout::Present:
+		return ::vk::ImageLayout::ePresentSrcKHR;
+	}
+	return ::vk::ImageLayout::eUndefined;
+}
+
+CompileImageLayout fromVkImageLayout(::vk::ImageLayout layout)
+{
+	switch (layout)
+	{
+	case ::vk::ImageLayout::eShaderReadOnlyOptimal:
+		return CompileImageLayout::ShaderReadOnly;
+	case ::vk::ImageLayout::eDepthStencilReadOnlyOptimal:
+		return CompileImageLayout::DepthReadOnly;
+	case ::vk::ImageLayout::eColorAttachmentOptimal:
+		return CompileImageLayout::ColorAttachment;
+	case ::vk::ImageLayout::eDepthStencilAttachmentOptimal:
+		return CompileImageLayout::DepthAttachment;
+	case ::vk::ImageLayout::ePresentSrcKHR:
+		return CompileImageLayout::Present;
+	default:
+		return CompileImageLayout::Undefined;
+	}
+}
+
+} // namespace gfx_api::vk
+
+#endif // defined(WZ_VULKAN_ENABLED)

--- a/lib/ivis_opengl/vk/layout_translation.h
+++ b/lib/ivis_opengl/vk/layout_translation.h
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+/*
+	This file is part of Warzone 2100.
+	Copyright (C) 2026  Warzone 2100 Project (https://github.com/Warzone2100)
+
+	Warzone 2100 is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+
+	Warzone 2100 is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with Warzone 2100; if not, write to the Free Software
+	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+/** @file layout_translation.h
+ * Maps backend-agnostic `CompileImageLayout` to and from `vk::ImageLayout`.
+ */
+
+#pragma once
+
+#if defined(WZ_VULKAN_ENABLED)
+
+#include "vk/vulkan_hpp_include.h"
+
+#include "render_graph/compile.h"
+
+namespace gfx_api::vk
+{
+
+/// Maps backend-agnostic `CompileImageLayout` to `vk::ImageLayout`.
+::vk::ImageLayout toVkImageLayout(CompileImageLayout layout);
+/// Maps `vk::ImageLayout` back to `CompileImageLayout` for compile/runtime round-trips.
+CompileImageLayout fromVkImageLayout(::vk::ImageLayout layout);
+
+} // namespace gfx_api::vk
+
+#endif // defined(WZ_VULKAN_ENABLED)

--- a/lib/ivis_opengl/vk/legacy_layout_final.h
+++ b/lib/ivis_opengl/vk/legacy_layout_final.h
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+/*
+	This file is part of Warzone 2100.
+	Copyright (C) 2026  Warzone 2100 Project (https://github.com/Warzone2100)
+
+	Warzone 2100 is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+
+	Warzone 2100 is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with Warzone 2100; if not, write to the Free Software
+	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+/** @file legacy_layout_final.h
+ * Final subresource layout captured from a legacy out-of-graph render pass.
+ */
+
+#pragma once
+
+#if defined(WZ_VULKAN_ENABLED)
+
+#include "vk/vulkan_hpp_include.h"
+
+#include "render_graph/layout_subresource.h"
+
+namespace gfx_api::vk
+{
+
+/// Final layout for one attachment subresource captured from a legacy pass.
+struct LegacyLayoutFinal
+{
+	gfx_api::LayoutSubresourceKey subresource;
+	::vk::ImageLayout layout = ::vk::ImageLayout::eUndefined;
+};
+
+} // namespace gfx_api::vk
+
+#endif // defined(WZ_VULKAN_ENABLED)

--- a/lib/ivis_opengl/vk/legacy_pass_layout_commit.cpp
+++ b/lib/ivis_opengl/vk/legacy_pass_layout_commit.cpp
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+/*
+	This file is part of Warzone 2100.
+	Copyright (C) 2026  Warzone 2100 Project (https://github.com/Warzone2100)
+
+	Warzone 2100 is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+
+	Warzone 2100 is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with Warzone 2100; if not, write to the Free Software
+	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+/** @file legacy_pass_layout_commit.cpp
+ * Implementation of legacy pass layout capture at begin and commit at end.
+ */
+
+#if defined(WZ_VULKAN_ENABLED)
+
+#include "vk/legacy_pass_layout_commit.h"
+
+#include "render_graph/layout_subresource.h"
+#include "vk/frame_layout_tracker.h"
+
+namespace gfx_api::vk
+{
+
+void LegacyPassLayoutCommit::clear()
+{
+	_finals.clear();
+}
+
+void LegacyPassLayoutCommit::captureFromPassKey(const gfx_api::RenderPassDesc& pass,
+	const PassLayoutKey& key)
+{
+	clear();
+	for (size_t i = 0; i < pass.colorAttachments.size(); ++i)
+	{
+		if (pass.colorAttachments[i].texture != nullptr && i < key.colorFinalLayouts.size())
+		{
+			_finals.push_back({
+				gfx_api::layoutSubresourceKey(pass.colorAttachments[i]),
+				key.colorFinalLayouts[i]});
+		}
+	}
+	if (pass.resolveAttachment.has_value() && pass.resolveAttachment->texture != nullptr
+		&& key.resolveFinalLayout.has_value())
+	{
+		_finals.push_back({
+			gfx_api::layoutSubresourceKey(pass.resolveAttachment.value()),
+			key.resolveFinalLayout.value()});
+	}
+	if (pass.depthAttachment.has_value() && pass.depthAttachment->texture != nullptr
+		&& key.depthFormat.has_value())
+	{
+		_finals.push_back({
+			gfx_api::layoutSubresourceKey(pass.depthAttachment.value()),
+			key.depthFinalLayout});
+	}
+}
+
+void LegacyPassLayoutCommit::commitTo(FrameLayoutTracker& tracker)
+{
+	tracker.commitLegacyFinalLayouts(_finals);
+	clear();
+}
+
+} // namespace gfx_api::vk
+
+#endif // defined(WZ_VULKAN_ENABLED)

--- a/lib/ivis_opengl/vk/legacy_pass_layout_commit.h
+++ b/lib/ivis_opengl/vk/legacy_pass_layout_commit.h
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+/*
+	This file is part of Warzone 2100.
+	Copyright (C) 2026  Warzone 2100 Project (https://github.com/Warzone2100)
+
+	Warzone 2100 is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+
+	Warzone 2100 is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with Warzone 2100; if not, write to the Free Software
+	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+/** @file legacy_pass_layout_commit.h
+ * Captures and commits legacy pass final layouts into `FrameLayoutTracker`.
+ */
+
+#pragma once
+
+#if defined(WZ_VULKAN_ENABLED)
+
+#include "vk/vulkan_hpp_include.h"
+
+#include "render_graph/render_pass.h"
+#include "vk/legacy_layout_final.h"
+#include "vk/pass_layout_key.h"
+
+#include <vector>
+
+namespace gfx_api::vk
+{
+
+class FrameLayoutTracker;
+
+/// <summary>
+/// Captures and commits final attachment layouts for out-of-graph (legacy) passes.
+///
+/// Graph passes use `CompiledPass::postPassLayoutUpdates` instead. `captureFromPassKey`
+/// runs in `beginPass` when `compiledPass == null`; `commitTo` runs in `endPass`.
+/// </summary>
+class LegacyPassLayoutCommit
+{
+public:
+	void clear();
+	/// Records final layouts from a freshly built `PassLayoutKey` (out-of-graph path only).
+	void captureFromPassKey(const gfx_api::RenderPassDesc& pass, const PassLayoutKey& key);
+	/// Commits captured finals via `FrameLayoutTracker::commitLegacyFinalLayouts` and clears.
+	void commitTo(FrameLayoutTracker& tracker);
+
+private:
+	std::vector<LegacyLayoutFinal> _finals;
+};
+
+} // namespace gfx_api::vk
+
+#endif // defined(WZ_VULKAN_ENABLED)

--- a/lib/ivis_opengl/vk/pass_layout_key.cpp
+++ b/lib/ivis_opengl/vk/pass_layout_key.cpp
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+/*
+	This file is part of Warzone 2100.
+	Copyright (C) 2026  Warzone 2100 Project (https://github.com/Warzone2100)
+
+	Warzone 2100 is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+
+	Warzone 2100 is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with Warzone 2100; if not, write to the Free Software
+	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+/** @file pass_layout_key.cpp
+ * Implementation of `PassLayoutKey` comparison and hashing.
+ */
+
+#if defined(WZ_VULKAN_ENABLED)
+
+#include "vk/pass_layout_key.h"
+
+namespace gfx_api::vk
+{
+
+bool PassLayoutKey::operator==(const PassLayoutKey& other) const
+{
+	return colorFormats == other.colorFormats
+		&& colorLoadOps == other.colorLoadOps
+		&& colorStoreOps == other.colorStoreOps
+		&& colorSamples == other.colorSamples
+		&& resolveFormat == other.resolveFormat
+		&& resolveLoadOp == other.resolveLoadOp
+		&& resolveStoreOp == other.resolveStoreOp
+		&& depthFormat == other.depthFormat
+		&& depthLoadOp == other.depthLoadOp
+		&& depthStoreOp == other.depthStoreOp
+		&& colorInitialLayouts == other.colorInitialLayouts
+		&& resolveInitialLayout == other.resolveInitialLayout
+		&& depthInitialLayout == other.depthInitialLayout
+		&& depthFinalLayout == other.depthFinalLayout
+		&& colorFinalLayouts == other.colorFinalLayouts
+		&& resolveFinalLayout == other.resolveFinalLayout;
+}
+
+} // namespace gfx_api::vk
+
+#endif // defined(WZ_VULKAN_ENABLED)

--- a/lib/ivis_opengl/vk/pass_layout_key.h
+++ b/lib/ivis_opengl/vk/pass_layout_key.h
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+/*
+	This file is part of Warzone 2100.
+	Copyright (C) 2026  Warzone 2100 Project (https://github.com/Warzone2100)
+
+	Warzone 2100 is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+
+	Warzone 2100 is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with Warzone 2100; if not, write to the Free Software
+	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+/** @file pass_layout_key.h
+ * `PassLayoutKey` identity for Vulkan render pass creation and cache lookup.
+ */
+
+#pragma once
+
+#if defined(WZ_VULKAN_ENABLED)
+
+#include "vk/vulkan_hpp_include.h"
+
+#include "render_graph/attachment.h"
+
+#include <optional>
+#include <vector>
+
+namespace gfx_api::vk
+{
+
+/// <summary>
+/// Identity key for `RenderPassLayoutCache` and `vk::RenderPass` creation.
+///
+/// Mirrors attachment formats, load/store ops, samples, and initial/final layouts.
+/// Built by `layout_key_builder` from `RenderPassDesc` and optional
+/// `CompiledPass::renderPassLayouts`. Dimensions are keyed separately via
+/// `FramebufferResourceKey`.
+/// </summary>
+struct PassLayoutKey
+{
+	std::vector<::vk::Format> colorFormats;
+	std::vector<AttachmentLoadOp> colorLoadOps;
+	std::vector<AttachmentStoreOp> colorStoreOps;
+	std::vector<::vk::SampleCountFlagBits> colorSamples;
+	std::optional<::vk::Format> resolveFormat;
+	AttachmentLoadOp resolveLoadOp = AttachmentLoadOp::DontCare;
+	AttachmentStoreOp resolveStoreOp = AttachmentStoreOp::Store;
+	std::optional<::vk::Format> depthFormat;
+	AttachmentLoadOp depthLoadOp = AttachmentLoadOp::DontCare;
+	AttachmentStoreOp depthStoreOp = AttachmentStoreOp::DontCare;
+	/// Layout each color attachment is in as the pass begins (RP initialLayout).
+	/// Empty => fall back to a load-op derived default.
+	std::vector<::vk::ImageLayout> colorInitialLayouts;
+	/// Layout the resolve attachment is in as the pass begins (RP initialLayout).
+	std::optional<::vk::ImageLayout> resolveInitialLayout;
+	/// Layout the depth attachment is in as the pass begins (RP initialLayout).
+	std::optional<::vk::ImageLayout> depthInitialLayout;
+	/// Layout the depth attachment is left in once the pass ends (RP finalLayout).
+	::vk::ImageLayout depthFinalLayout = ::vk::ImageLayout::eDepthStencilAttachmentOptimal;
+	/// Layout each color attachment is left in once the pass ends (RP finalLayout).
+	std::vector<::vk::ImageLayout> colorFinalLayouts;
+	/// Layout the resolve attachment is left in once the pass ends (RP finalLayout).
+	std::optional<::vk::ImageLayout> resolveFinalLayout;
+
+	bool operator==(const PassLayoutKey& other) const;
+
+	static const PassLayoutKey& invalid()
+	{
+		static const PassLayoutKey kInvalid {};
+		return kInvalid;
+	}
+};
+
+} // namespace gfx_api::vk
+
+#endif // defined(WZ_VULKAN_ENABLED)

--- a/lib/ivis_opengl/vk/pre_pass_barrier_emitter.cpp
+++ b/lib/ivis_opengl/vk/pre_pass_barrier_emitter.cpp
@@ -1,0 +1,146 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+/*
+	This file is part of Warzone 2100.
+	Copyright (C) 2026  Warzone 2100 Project (https://github.com/Warzone2100)
+
+	Warzone 2100 is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+
+	Warzone 2100 is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with Warzone 2100; if not, write to the Free Software
+	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+/** @file pre_pass_barrier_emitter.cpp
+ * Implementation of batched pre-pass barrier recording and tracker updates.
+ */
+
+#if defined(WZ_VULKAN_ENABLED)
+
+#include "vk/pre_pass_barrier_emitter.h"
+
+#include "gfx_api_vk.h"
+#include "render_graph/layout_subresource.h"
+#include "vk/frame_layout_tracker.h"
+#include "vk/layout_sync.h"
+#include "vk/layout_translation.h"
+
+namespace gfx_api::vk
+{
+
+PrePassBarrierEmitter::PrePassBarrierEmitter(VkRoot& root, FrameLayoutTracker& tracker)
+	: _root(root)
+	, _tracker(tracker)
+{
+}
+
+void PrePassBarrierEmitter::appendImageBarrier(std::vector<::vk::ImageMemoryBarrier>& outBarriers,
+	::vk::PipelineStageFlags& srcStageAccum, ::vk::PipelineStageFlags& dstStageAccum,
+	gfx_api::abstract_texture* texture, uint32_t arrayLayer, uint32_t mipLevel,
+	::vk::ImageLayout oldLayout, ::vk::ImageLayout newLayout,
+	::vk::PipelineStageFlags srcStage, ::vk::PipelineStageFlags dstStage,
+	::vk::AccessFlags srcAccess, ::vk::AccessFlags dstAccess)
+{
+	if (texture == nullptr)
+	{
+		return;
+	}
+
+	srcStageAccum |= srcStage;
+	dstStageAccum |= dstStage;
+	outBarriers.push_back(
+		::vk::ImageMemoryBarrier()
+			.setImage(_root.getVkImageHandle(texture))
+			.setOldLayout(oldLayout)
+			.setNewLayout(newLayout)
+			.setSrcQueueFamilyIndex(VK_QUEUE_FAMILY_IGNORED)
+			.setDstQueueFamilyIndex(VK_QUEUE_FAMILY_IGNORED)
+			.setSubresourceRange(::vk::ImageSubresourceRange(_root.getVkImageAspect(texture), mipLevel, 1, arrayLayer, 1))
+			.setSrcAccessMask(srcAccess)
+			.setDstAccessMask(dstAccess));
+	_tracker.set(gfx_api::layoutSubresourceKey(texture, arrayLayer, mipLevel), newLayout);
+}
+
+void PrePassBarrierEmitter::emitBatch(const gfx_api::ExecutionBatch& batch,
+	const std::vector<gfx_api::CompiledPass>& compiledPasses)
+{
+	if (batch.count == 0)
+	{
+		return;
+	}
+
+	ASSERT_OR_RETURN(, batch.startIndex <= compiledPasses.size()
+		&& batch.count <= compiledPasses.size() - batch.startIndex,
+		"emitBatch: batch range out of bounds (start=%zu count=%zu compiled=%zu)",
+		batch.startIndex, batch.count, compiledPasses.size());
+
+	_scratch.clear();
+	::vk::PipelineStageFlags srcStage {};
+	::vk::PipelineStageFlags dstStage {};
+	// A given subresource transitions at most once per batch (batch members share one render pass
+	// and identical attachments), so dedupe cross-pass reads of the same External texture slice.
+	LayoutSubresourceSet seen;
+
+	const size_t batchEnd = batch.startIndex + batch.count;
+	for (size_t b = batch.startIndex; b < batchEnd; ++b)
+	{
+		for (const gfx_api::ImageBarrierOp& barrierOp : compiledPasses[b].prePassBarriers)
+		{
+			if (barrierOp.texture == nullptr)
+			{
+				continue;
+			}
+			const gfx_api::LayoutSubresourceKey subresource = gfx_api::layoutSubresourceKey(
+				barrierOp.texture, barrierOp.arrayLayer, barrierOp.mipLevel);
+			if (!seen.insert(subresource).second)
+			{
+				continue;
+			}
+
+			const ::vk::ImageLayout vkNewLayout = toVkImageLayout(barrierOp.newLayout);
+			// External reads: real previous layout lives in the runtime tracker.
+			// InGraph ops carry their old layout from the compiled timeline.
+			const ::vk::ImageLayout vkOldLayout = barrierOp.producerScope == gfx_api::ReadProducerScope::External
+				? _tracker.get(subresource)
+				: toVkImageLayout(barrierOp.oldLayout);
+
+			// InGraph transitions already satisfied are no-ops; External reads still need a
+			// pure execution/memory barrier to establish the producer -> consumer dependency.
+			if (vkOldLayout == vkNewLayout && barrierOp.producerScope == gfx_api::ReadProducerScope::InGraph)
+			{
+				continue;
+			}
+
+			const gfx_api::CompileImageLayout recipeOldLayout = barrierOp.producerScope == gfx_api::ReadProducerScope::External
+				? fromVkImageLayout(vkOldLayout)
+				: barrierOp.oldLayout;
+			const BarrierRecipe recipe = getBarrierRecipe(recipeOldLayout, barrierOp.newLayout);
+			appendImageBarrier(_scratch, srcStage, dstStage,
+				barrierOp.texture, barrierOp.arrayLayer, barrierOp.mipLevel,
+				vkOldLayout, vkNewLayout,
+				recipe.srcStage, recipe.dstStage, recipe.srcAccess, recipe.dstAccess);
+		}
+	}
+
+	if (_scratch.empty())
+	{
+		return;
+	}
+
+	buffering_mechanism::get_current_resources().ensureDrawCmdBufferBegun();
+	buffering_mechanism::get_current_resources().drawCmdBuffer().pipelineBarrier(
+		srcStage ? srcStage : ::vk::PipelineStageFlagBits::eTopOfPipe,
+		dstStage ? dstStage : ::vk::PipelineStageFlagBits::eFragmentShader,
+		::vk::DependencyFlags(), nullptr, nullptr, _scratch, _root.vkDynLoader);
+}
+
+} // namespace gfx_api::vk
+
+#endif // defined(WZ_VULKAN_ENABLED)

--- a/lib/ivis_opengl/vk/pre_pass_barrier_emitter.h
+++ b/lib/ivis_opengl/vk/pre_pass_barrier_emitter.h
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+/*
+	This file is part of Warzone 2100.
+	Copyright (C) 2026  Warzone 2100 Project (https://github.com/Warzone2100)
+
+	Warzone 2100 is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+
+	Warzone 2100 is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with Warzone 2100; if not, write to the Free Software
+	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+/** @file pre_pass_barrier_emitter.h
+ * Coalesced emission of compiled pre-pass image barriers before `beginPass`.
+ */
+
+#pragma once
+
+#if defined(WZ_VULKAN_ENABLED)
+
+#include "vk/vulkan_hpp_include.h"
+
+#include "render_graph/compile.h"
+
+#include <vector>
+
+struct VkRoot;
+
+namespace gfx_api::vk
+{
+
+class FrameLayoutTracker;
+
+/// <summary>
+/// Batches `CompiledPass::prePassBarriers` into coalesced `vkCmdPipelineBarrier` calls.
+///
+/// Honors `ReadProducerScope::External` (runtime old layout, always emit) vs
+/// `ReadProducerScope::InGraph` (compile-time old layout, skip when old == new).
+/// Invoked from `VkRoot::emitPrePassBarriers` before `beginPass`.
+/// </summary>
+class PrePassBarrierEmitter
+{
+public:
+	PrePassBarrierEmitter(VkRoot& root, FrameLayoutTracker& tracker);
+
+	/// Coalesced batch emit before beginPass. Ensures draw cmd buffer begun.
+	void emitBatch(const gfx_api::ExecutionBatch& batch,
+		const std::vector<gfx_api::CompiledPass>& compiledPasses);
+
+private:
+	void appendImageBarrier(std::vector<::vk::ImageMemoryBarrier>& outBarriers,
+		::vk::PipelineStageFlags& srcStageAccum, ::vk::PipelineStageFlags& dstStageAccum,
+		gfx_api::abstract_texture* texture, uint32_t arrayLayer, uint32_t mipLevel,
+		::vk::ImageLayout oldLayout, ::vk::ImageLayout newLayout,
+		::vk::PipelineStageFlags srcStage, ::vk::PipelineStageFlags dstStage,
+		::vk::AccessFlags srcAccess, ::vk::AccessFlags dstAccess);
+
+	VkRoot& _root;
+	FrameLayoutTracker& _tracker;
+	std::vector<::vk::ImageMemoryBarrier> _scratch;
+};
+
+} // namespace gfx_api::vk
+
+#endif // defined(WZ_VULKAN_ENABLED)

--- a/lib/ivis_opengl/vk/render_pass_layout_cache.cpp
+++ b/lib/ivis_opengl/vk/render_pass_layout_cache.cpp
@@ -1,0 +1,376 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+/*
+	This file is part of Warzone 2100.
+	Copyright (C) 2026  Warzone 2100 Project (https://github.com/Warzone2100)
+
+	Warzone 2100 is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+
+	Warzone 2100 is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with Warzone 2100; if not, write to the Free Software
+	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+/** @file render_pass_layout_cache.cpp
+ * Implementation of Vulkan render pass layout cache get-or-create.
+ */
+
+#if defined(WZ_VULKAN_ENABLED)
+
+#include "vk/render_pass_layout_cache.h"
+
+#include "gfx_api_vk.h"
+#include "vk/layout_key_builder.h"
+#include "vk/layout_sync.h"
+
+#include <array>
+
+namespace
+{
+
+bool validatePassLayoutKey(const gfx_api::vk::PassLayoutKey& key)
+{
+	if (key.resolveFormat.has_value())
+	{
+		if (key.colorFormats.size() != 1)
+		{
+			return false;
+		}
+		if (!key.depthFormat.has_value())
+		{
+			return false;
+		}
+	}
+	return true;
+}
+
+::vk::SubpassDependency crossFrameExternalToSubpass0(
+	::vk::PipelineStageFlags srcStage,
+	::vk::PipelineStageFlags dstStage,
+	::vk::AccessFlags srcAccess,
+	::vk::AccessFlags dstAccess)
+{
+	return ::vk::SubpassDependency()
+		.setSrcSubpass(VK_SUBPASS_EXTERNAL)
+		.setDstSubpass(0)
+		.setSrcStageMask(srcStage)
+		.setDstStageMask(dstStage)
+		.setSrcAccessMask(srcAccess)
+		.setDstAccessMask(dstAccess)
+		.setDependencyFlags(::vk::DependencyFlagBits::eByRegion);
+}
+
+void appendCrossFrameIncomingDependencies(
+	const gfx_api::vk::PassLayoutKey& key,
+	std::vector<::vk::SubpassDependency>& dependencies)
+{
+	const bool hasColor = !key.colorFormats.empty();
+	const bool hasDepth = key.depthFormat.has_value();
+
+	// Prior-frame shader read of depth → this pass depth write (depth-only and color+depth).
+	if (hasDepth)
+	{
+		dependencies.push_back(crossFrameExternalToSubpass0(
+			::vk::PipelineStageFlagBits::eFragmentShader,
+			::vk::PipelineStageFlagBits::eEarlyFragmentTests,
+			::vk::AccessFlagBits::eShaderRead,
+			::vk::AccessFlagBits::eDepthStencilAttachmentWrite));
+	}
+
+	// Prior-frame shader read of color → this pass color write.
+	if (hasColor)
+	{
+		dependencies.push_back(crossFrameExternalToSubpass0(
+			::vk::PipelineStageFlagBits::eFragmentShader,
+			::vk::PipelineStageFlagBits::eColorAttachmentOutput,
+			::vk::AccessFlagBits::eShaderRead,
+			::vk::AccessFlagBits::eColorAttachmentWrite));
+	}
+
+	// Cross-frame WAW on reused attachment writes (initialLayout is Undefined after Clear).
+	if (hasColor)
+	{
+		dependencies.push_back(crossFrameExternalToSubpass0(
+			::vk::PipelineStageFlagBits::eColorAttachmentOutput | ::vk::PipelineStageFlagBits::eLateFragmentTests,
+			::vk::PipelineStageFlagBits::eColorAttachmentOutput | ::vk::PipelineStageFlagBits::eEarlyFragmentTests,
+			::vk::AccessFlagBits::eColorAttachmentWrite | ::vk::AccessFlagBits::eDepthStencilAttachmentWrite,
+			::vk::AccessFlagBits::eColorAttachmentWrite | ::vk::AccessFlagBits::eDepthStencilAttachmentWrite | ::vk::AccessFlagBits::eDepthStencilAttachmentRead));
+	}
+}
+
+} // anonymous namespace
+
+namespace gfx_api::vk
+{
+
+RenderPassLayoutCache::RenderPassLayoutCache(VkRoot& root)
+	: _root(root)
+{
+}
+
+void RenderPassLayoutCache::clear()
+{
+	_keys.clear();
+}
+
+const PassLayoutKey& RenderPassLayoutCache::keyAt(size_t layoutId) const
+{
+	ASSERT_OR_RETURN(PassLayoutKey::invalid(), layoutId < _keys.size(), "Render pass layout id out of range");
+	return _keys[layoutId];
+}
+
+size_t RenderPassLayoutCache::getOrCreate(const PassLayoutKey& key)
+{
+	for (size_t i = 0; i < _keys.size(); ++i)
+	{
+		if (_keys[i] == key)
+		{
+			return i;
+		}
+	}
+
+	ASSERT_OR_RETURN(0, validatePassLayoutKey(key), "Invalid PassLayoutKey for render pass creation");
+
+	const size_t renderPassId = _root.renderPasses.size();
+	_root.renderPasses.push_back(VkRoot::RenderPassDetails(renderPassId));
+
+	const bool hasMsaaResolve = key.resolveFormat.has_value();
+	const ::vk::SampleCountFlagBits sampleCount = (hasMsaaResolve && !key.colorSamples.empty())
+		? key.colorSamples[0]
+		: ::vk::SampleCountFlagBits::e1;
+
+	std::vector<::vk::AttachmentDescription> attachments;
+	if (hasMsaaResolve)
+	{
+		ASSERT_OR_RETURN(0, key.colorFormats.size() == 1, "MSAA resolve pass expects one color attachment");
+		ASSERT_OR_RETURN(0, key.depthFormat.has_value(), "MSAA resolve pass requires depth");
+
+		const gfx_api::AttachmentStoreOp msaaColorStoreOp = (key.colorStoreOps.size() > 0)
+			? key.colorStoreOps[0]
+			: gfx_api::AttachmentStoreOp::DontCare;
+		const ::vk::AttachmentLoadOp vkColorLoadOp = toVkAttachmentLoadOp(key.colorLoadOps[0]);
+		attachments.push_back(
+			::vk::AttachmentDescription()
+				.setFormat(key.colorFormats[0])
+				.setSamples(sampleCount)
+				.setLoadOp(vkColorLoadOp)
+				.setStoreOp(toVkAttachmentStoreOp(msaaColorStoreOp))
+				.setStencilLoadOp(::vk::AttachmentLoadOp::eDontCare)
+				.setStencilStoreOp(::vk::AttachmentStoreOp::eDontCare)
+				.setInitialLayout(resolveColorInitialLayout(key, 0))
+				.setFinalLayout((!key.colorFinalLayouts.empty())
+					? key.colorFinalLayouts[0]
+					: colorFinalLayoutFromStoreOp(msaaColorStoreOp))
+		);
+
+		const ::vk::AttachmentLoadOp vkDepthLoadOp = toVkAttachmentLoadOp(key.depthLoadOp);
+		const ::vk::AttachmentStoreOp vkDepthStoreOp = toVkAttachmentStoreOp(key.depthStoreOp);
+		attachments.push_back(
+			::vk::AttachmentDescription()
+				.setFormat(key.depthFormat.value())
+				.setSamples(sampleCount)
+				.setLoadOp(vkDepthLoadOp)
+				.setStoreOp(vkDepthStoreOp)
+				.setStencilLoadOp(vkDepthLoadOp)
+				.setStencilStoreOp(vkDepthStoreOp)
+				.setInitialLayout(resolveDepthInitialLayout(key))
+				.setFinalLayout(key.depthFinalLayout)
+		);
+
+		const ::vk::AttachmentLoadOp vkResolveLoadOp = toVkAttachmentLoadOp(key.resolveLoadOp);
+		attachments.push_back(
+			::vk::AttachmentDescription()
+				.setFormat(key.resolveFormat.value())
+				.setSamples(::vk::SampleCountFlagBits::e1)
+				.setLoadOp(vkResolveLoadOp)
+				.setStoreOp(toVkAttachmentStoreOp(key.resolveStoreOp))
+				.setStencilLoadOp(::vk::AttachmentLoadOp::eDontCare)
+				.setStencilStoreOp(::vk::AttachmentStoreOp::eDontCare)
+				.setInitialLayout(resolveResolveInitialLayout(key))
+				.setFinalLayout(key.resolveFinalLayout.has_value()
+					? key.resolveFinalLayout.value()
+					: colorFinalLayoutFromStoreOp(key.resolveStoreOp))
+		);
+	}
+	else
+	{
+		attachments.reserve(key.colorFormats.size() + (key.depthFormat.has_value() ? 1 : 0));
+		for (size_t i = 0; i < key.colorFormats.size(); ++i)
+		{
+			const ::vk::SampleCountFlagBits colorSamples = (i < key.colorSamples.size())
+				? key.colorSamples[i]
+				: ::vk::SampleCountFlagBits::e1;
+			const gfx_api::AttachmentStoreOp colorStoreOp = (i < key.colorStoreOps.size())
+				? key.colorStoreOps[i]
+				: gfx_api::AttachmentStoreOp::Store;
+			const ::vk::AttachmentLoadOp vkLoadOp = toVkAttachmentLoadOp(key.colorLoadOps[i]);
+			attachments.push_back(
+				::vk::AttachmentDescription()
+					.setFormat(key.colorFormats[i])
+					.setSamples(colorSamples)
+					.setLoadOp(vkLoadOp)
+					.setStoreOp(toVkAttachmentStoreOp(colorStoreOp))
+					.setStencilLoadOp(::vk::AttachmentLoadOp::eDontCare)
+					.setStencilStoreOp(::vk::AttachmentStoreOp::eDontCare)
+					.setInitialLayout(resolveColorInitialLayout(key, i))
+					.setFinalLayout((i < key.colorFinalLayouts.size())
+						? key.colorFinalLayouts[i]
+						: colorFinalLayoutFromStoreOp(colorStoreOp))
+			);
+		}
+
+		if (key.depthFormat.has_value())
+		{
+			const ::vk::AttachmentLoadOp vkDepthLoadOp = toVkAttachmentLoadOp(key.depthLoadOp);
+			attachments.push_back(
+				::vk::AttachmentDescription()
+					.setFormat(key.depthFormat.value())
+					.setSamples(::vk::SampleCountFlagBits::e1)
+					.setLoadOp(vkDepthLoadOp)
+					.setStoreOp(toVkAttachmentStoreOp(key.depthStoreOp))
+					.setStencilLoadOp(::vk::AttachmentLoadOp::eDontCare)
+					.setStencilStoreOp(::vk::AttachmentStoreOp::eDontCare)
+					.setInitialLayout(resolveDepthInitialLayout(key))
+					.setFinalLayout(key.depthFinalLayout)
+			);
+		}
+	}
+
+	optional<::vk::AttachmentReference> depthStencilAttachmentRef;
+	optional<::vk::AttachmentReference> colorAttachmentResolveRef;
+	if (hasMsaaResolve)
+	{
+		depthStencilAttachmentRef = ::vk::AttachmentReference()
+			.setAttachment(1)
+			.setLayout(::vk::ImageLayout::eDepthStencilAttachmentOptimal);
+		colorAttachmentResolveRef = ::vk::AttachmentReference()
+			.setAttachment(2)
+			.setLayout(::vk::ImageLayout::eColorAttachmentOptimal);
+	}
+	else if (key.depthFormat.has_value())
+	{
+		const uint32_t depthAttachmentIndex = static_cast<uint32_t>(attachments.size()) - 1;
+		depthStencilAttachmentRef = ::vk::AttachmentReference()
+			.setAttachment(depthAttachmentIndex)
+			.setLayout(::vk::ImageLayout::eDepthStencilAttachmentOptimal);
+	}
+
+	std::vector<::vk::AttachmentReference> colorAttachmentRefs;
+	if (hasMsaaResolve)
+	{
+		colorAttachmentRefs.push_back(
+			::vk::AttachmentReference()
+				.setAttachment(0)
+				.setLayout(::vk::ImageLayout::eColorAttachmentOptimal)
+		);
+	}
+	else
+	{
+		colorAttachmentRefs.reserve(key.colorFormats.size());
+		for (uint32_t i = 0; i < static_cast<uint32_t>(key.colorFormats.size()); ++i)
+		{
+			colorAttachmentRefs.push_back(
+				::vk::AttachmentReference()
+					.setAttachment(i)
+					.setLayout(::vk::ImageLayout::eColorAttachmentOptimal)
+			);
+		}
+	}
+
+	const auto subpasses = std::array<::vk::SubpassDescription, 1> {
+		::vk::SubpassDescription()
+			.setPipelineBindPoint(::vk::PipelineBindPoint::eGraphics)
+			.setColorAttachmentCount(static_cast<uint32_t>(colorAttachmentRefs.size()))
+			.setPColorAttachments(colorAttachmentRefs.data())
+			.setPDepthStencilAttachment(depthStencilAttachmentRef.has_value() ? &depthStencilAttachmentRef.value() : nullptr)
+			.setPResolveAttachments(colorAttachmentResolveRef.has_value() ? &colorAttachmentResolveRef.value() : nullptr)
+	};
+
+	// Outgoing producer synchronization, derived from the layout table: an attachment that ends
+	// the pass in a read-only layout will be sampled by a later pass and thus needs a
+	// 0->EXTERNAL dependency. The source scope is how this subpass produced it (its in-subpass
+	// attachment layout); the destination scope is how the later pass consumes it (its read-only
+	// final layout). One unioned dependency covers all such attachments and works identically for
+	// the graph and legacy paths, with no surface/read-list special cases.
+	::vk::PipelineStageFlags outSrcStage {};
+	::vk::PipelineStageFlags outDstStage {};
+	::vk::AccessFlags outSrcAccess {};
+	::vk::AccessFlags outDstAccess {};
+	bool anyReadOnlyFinal = false;
+	const auto addReadOnlyFinal = [&](::vk::ImageLayout subpassLayout, ::vk::ImageLayout finalLayout)
+	{
+		const LayoutSync producer = layoutProducerSync(subpassLayout);
+		const LayoutSync consumer = layoutConsumerSync(finalLayout);
+		outSrcStage |= producer.stage;
+		outSrcAccess |= producer.access;
+		outDstStage |= consumer.stage;
+		outDstAccess |= consumer.access;
+		anyReadOnlyFinal = true;
+	};
+	for (const ::vk::ImageLayout colorFinalLayout : key.colorFinalLayouts)
+	{
+		if (colorFinalLayout == ::vk::ImageLayout::eShaderReadOnlyOptimal)
+		{
+			addReadOnlyFinal(::vk::ImageLayout::eColorAttachmentOptimal, colorFinalLayout);
+		}
+	}
+	if (key.resolveFinalLayout.has_value()
+		&& key.resolveFinalLayout.value() == ::vk::ImageLayout::eShaderReadOnlyOptimal)
+	{
+		addReadOnlyFinal(::vk::ImageLayout::eColorAttachmentOptimal, key.resolveFinalLayout.value());
+	}
+	if (key.depthFormat.has_value()
+		&& key.depthFinalLayout == ::vk::ImageLayout::eDepthStencilReadOnlyOptimal)
+	{
+		addReadOnlyFinal(::vk::ImageLayout::eDepthStencilAttachmentOptimal, key.depthFinalLayout);
+	}
+
+	// Incoming consumer synchronization stays conservative (not table-derived). Reused render
+	// targets are Cleared each frame, so their initialLayout is Undefined and cannot express the
+	// cross-frame WAR/WAW hazard against the previous frame's access to the same image; these
+	// templates encode that worst-case prior access (prior sample and/or prior attachment write).
+	std::vector<::vk::SubpassDependency> dependencies;
+	appendCrossFrameIncomingDependencies(key, dependencies);
+
+	if (anyReadOnlyFinal)
+	{
+		dependencies.push_back(
+			::vk::SubpassDependency()
+				.setSrcSubpass(0)
+				.setDstSubpass(VK_SUBPASS_EXTERNAL)
+				.setSrcStageMask(outSrcStage)
+				.setDstStageMask(outDstStage)
+				.setSrcAccessMask(outSrcAccess)
+				.setDstAccessMask(outDstAccess)
+				.setDependencyFlags(::vk::DependencyFlagBits::eByRegion)
+		);
+	}
+
+	auto createInfo = ::vk::RenderPassCreateInfo()
+		.setAttachmentCount(static_cast<uint32_t>(attachments.size()))
+		.setPAttachments(attachments.data())
+		.setSubpassCount(static_cast<uint32_t>(subpasses.size()))
+		.setPSubpasses(subpasses.data())
+		.setDependencyCount(static_cast<uint32_t>(dependencies.size()))
+		.setPDependencies(dependencies.data());
+
+	auto& renderPassDetails = _root.renderPasses[renderPassId];
+	renderPassDetails.rp_compat_info = std::make_shared<VkhRenderPassCompat>(createInfo);
+	renderPassDetails.rp = _root.dev.createRenderPass(createInfo, nullptr, _root.vkDynLoader);
+	renderPassDetails.msaaSamples = hasMsaaResolve ? _root.msaaSamples : ::vk::SampleCountFlagBits::e1;
+
+	_keys.push_back(key);
+	_root.ensureRenderPassPSOCapacity(_root.renderPasses.size());
+	return renderPassId;
+}
+
+} // namespace gfx_api::vk
+
+#endif // defined(WZ_VULKAN_ENABLED)

--- a/lib/ivis_opengl/vk/render_pass_layout_cache.h
+++ b/lib/ivis_opengl/vk/render_pass_layout_cache.h
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+/*
+	This file is part of Warzone 2100.
+	Copyright (C) 2026  Warzone 2100 Project (https://github.com/Warzone2100)
+
+	Warzone 2100 is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+
+	Warzone 2100 is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with Warzone 2100; if not, write to the Free Software
+	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+/** @file render_pass_layout_cache.h
+ * On-demand `vk::RenderPass` cache keyed by `PassLayoutKey`.
+ */
+
+#pragma once
+
+#if defined(WZ_VULKAN_ENABLED)
+
+#include "vk/pass_layout_key.h"
+
+#include <vector>
+
+struct VkRoot;
+
+namespace gfx_api::vk
+{
+
+/// <summary>
+/// On-demand `vk::RenderPass` cache keyed by `PassLayoutKey`.
+///
+/// Owns stored keys and creates render pass objects on cache miss. Cleared on render-graph
+/// epoch bump via `VkRoot::destroyDynamicRenderPasses`. Used by `beginPass`,
+/// `warmCompiledRenderGraph`, and framebuffer/PSO lookup paths.
+/// </summary>
+class RenderPassLayoutCache
+{
+public:
+	explicit RenderPassLayoutCache(VkRoot& root);
+
+	/// Returns cached render-pass layout id; creates `vk::RenderPass` on miss.
+	size_t getOrCreate(const PassLayoutKey& key);
+	/// Drops all cached keys and render passes (epoch invalidation).
+	void clear();
+	/// Returns the key for a previously issued layout id; used by framebuffer and PSO paths.
+	const PassLayoutKey& keyAt(size_t layoutId) const;
+
+private:
+	VkRoot& _root;
+	std::vector<PassLayoutKey> _keys;
+};
+
+} // namespace gfx_api::vk
+
+#endif // defined(WZ_VULKAN_ENABLED)

--- a/lib/ivis_opengl/vk/vulkan_hpp_include.h
+++ b/lib/ivis_opengl/vk/vulkan_hpp_include.h
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+/*
+	This file is part of Warzone 2100.
+	Copyright (C) 2026  Warzone 2100 Project (https://github.com/Warzone2100)
+
+	Warzone 2100 is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+
+	Warzone 2100 is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with Warzone 2100; if not, write to the Free Software
+	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+/** @file vulkan_hpp_include.h
+ * Guarded include of Vulkan-Hpp for all lib/ivis_opengl/vk headers.
+ */
+
+#pragma once
+
+#if defined(WZ_VULKAN_ENABLED)
+
+#if defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable : 4191) // warning C4191: unsafe conversion in vulkan_structs.hpp debug callback PFN casts
+#endif
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wshadow"
+#pragma clang diagnostic ignored "-Wnewline-eof"
+#endif
+#if !defined(__clang__) && defined(__GNUC__) && __GNUC__ >= 9
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-copy" // Ignore warnings caused by vulkan.hpp 148
+#pragma GCC diagnostic ignored "-Wshadow"
+#pragma GCC diagnostic ignored "-Wcast-align"
+#endif
+
+#define VULKAN_HPP_TYPESAFE_CONVERSION 1
+#include <vulkan/vulkan.hpp>
+
+#if !defined(__clang__) && defined(__GNUC__) && __GNUC__ >= 9
+#pragma GCC diagnostic pop
+#endif
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif
+
+#endif // defined(WZ_VULKAN_ENABLED)

--- a/lib/ivis_opengl/vk/warm_entry.h
+++ b/lib/ivis_opengl/vk/warm_entry.h
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+/*
+	This file is part of Warzone 2100.
+	Copyright (C) 2026  Warzone 2100 Project (https://github.com/Warzone2100)
+
+	Warzone 2100 is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+
+	Warzone 2100 is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with Warzone 2100; if not, write to the Free Software
+	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+/** @file warm_entry.h
+ * Per-graph-index warm cache entry for prebuilt render pass layout IDs.
+ */
+
+#pragma once
+
+#if defined(WZ_VULKAN_ENABLED)
+
+#include <cstdint>
+
+namespace gfx_api::vk
+{
+
+/// <summary>
+/// Warm-cache entry for one compiled graph pass.
+///
+/// Stored on `VkRoot::_warmEntries` keyed by `CompiledPass::graphIndex`. Populated by
+/// `warmCompiledRenderGraph`; invalidated when the render-graph epoch bumps.
+/// </summary>
+struct VulkanWarmEntry
+{
+	static constexpr size_t INVALID_LAYOUT_ID = ~size_t(0);
+	/// Cached `RenderPassLayoutCache` layout id, or `INVALID_LAYOUT_ID` when cold.
+	size_t renderPassLayoutId = INVALID_LAYOUT_ID;
+	/// Epoch stamp; must match `VkRoot::getRenderGraphEpoch()` for the entry to be valid.
+	uint64_t warmEpoch = 0;
+
+	static VulkanWarmEntry& invalid()
+	{
+		static VulkanWarmEntry kInvalid {};
+		return kInvalid;
+	}
+};
+
+} // namespace gfx_api::vk
+
+#endif // defined(WZ_VULKAN_ENABLED)

--- a/lib/widget/widget.cpp
+++ b/lib/widget/widget.cpp
@@ -1640,7 +1640,8 @@ void widgDisplayScreen(const std::shared_ptr<W_SCREEN> &psScreen)
 	debugLoc = debugLoc[1] == -1 ? debugSequence : debugLoc[0] == debugCode ? debugLoc : debugLoc[1] == debugCode ? debugLoc + 1 : debugSequence;
 	debugBoundingBoxes = debugBoundingBoxes ^ (debugLoc[1] == -1);
 
-	bool skipDrawing = !gfx_api::context::get().shouldDraw();
+	bool skipDrawing = !gfx_api::context::get().shouldDraw()
+		|| !gfx_api::context::get().canRecordDrawCommands();
 
 	cleanupDeletedOverlays();
 

--- a/src/display3d.cpp
+++ b/src/display3d.cpp
@@ -1556,6 +1556,7 @@ static void drawTiles(iView *player, LightingData& lightData, LightMap& lightmap
 	}
 
 	// Draw the scene to the default framebuffer
+	if (gfx_api::context::get().canRecordDrawCommands())
 	{
 		WZ_PROFILE_SCOPE(copyToFBO);
 		gfx_api::WorldToScreenPSO::get().bind();

--- a/src/loop.cpp
+++ b/src/loop.cpp
@@ -160,7 +160,12 @@ static GAMECODE renderLoop()
 		handleInGameHostQuit();
 	}
 
-	bool skipDrawing = !gfx_api::context::get().shouldDraw();
+	const auto shouldSkipDrawing = []() {
+		auto& ctx = gfx_api::context::get();
+		return !ctx.shouldDraw() || !ctx.canRecordDrawCommands();
+	};
+
+	bool skipDrawing = shouldSkipDrawing();
 
 	audio_Update();
 
@@ -322,9 +327,9 @@ static GAMECODE renderLoop()
 			pie_LoadBackDrop(SCREEN_RANDOMBDROP);
 		}
 	}
-	if (!loop_GetVideoStatus() && !quitting && !headlessGameMode() && !skipDrawing)
+	if (!loop_GetVideoStatus() && !quitting && !headlessGameMode())
 	{
-		if (!gameUpdatePaused())
+		if (!skipDrawing && !gameUpdatePaused())
 		{
 			processInput();
 
@@ -337,17 +342,20 @@ static GAMECODE renderLoop()
 			}
 			displayWorld();
 		}
-		wzPerfBegin(PERF_GUI, "User interface");
-		WZ_PROFILE_SCOPE(DrawUI);
-		/* Display the in game interface */
-		pie_SetFogStatus(false);
-
-		if (getWidgetsStatus())
+		if (!shouldSkipDrawing())
 		{
-			intDisplayWidgets();
+			wzPerfBegin(PERF_GUI, "User interface");
+			WZ_PROFILE_SCOPE(DrawUI);
+			/* Display the in game interface */
+			pie_SetFogStatus(false);
+
+			if (getWidgetsStatus())
+			{
+				intDisplayWidgets();
+			}
+			pie_SetFogStatus(true);
+			wzPerfEnd(PERF_GUI);
 		}
-		pie_SetFogStatus(true);
-		wzPerfEnd(PERF_GUI);
 	}
 
 	pie_GetResetCounts(&loopPieCount, &loopPolyCount);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1311,6 +1311,11 @@ void mainLoop()
 #if defined(ENABLE_DISCORD)
 	discordRPCPerFrame();
 #endif
+
+	if (pie_IsScreenFrameRendering())
+	{
+		pie_ScreenFrameRenderEnd();
+	}
 }
 
 void requestMapPreviewLoad(bool hideInterface)
@@ -2171,6 +2176,7 @@ int realmain(int argc, char *argv[])
 	pie_LoadBackDrop(SCREEN_RANDOMBDROP);
 	pie_SetFogStatus(false);
 
+	pie_ScreenFrameRenderBegin();
 	pie_ScreenFrameRenderEnd();
 
 	if (!systemInitialise(horizScaleFactor, vertScaleFactor))

--- a/src/wrappers.cpp
+++ b/src/wrappers.cpp
@@ -30,6 +30,7 @@
 #include "lib/ivis_opengl/pieblitfunc.h"
 #include "lib/ivis_opengl/piemode.h"
 #include "lib/ivis_opengl/piestate.h"
+#include "lib/ivis_opengl/gfx_api.h"
 #include "lib/ivis_opengl/screen.h"
 #include "lib/netplay/connection_provider_registry.h"
 #include "lib/netplay/netplay.h"	// multiplayer
@@ -320,6 +321,11 @@ bool isLoadingScreenActive()
 void presentLoadingScreenForCurrentFrame()
 {
 	if (!loadingScreenSessionActive || headlessGameMode())
+	{
+		return;
+	}
+
+	if (!gfx_api::context::get().canRecordDrawCommands())
 	{
 		return;
 	}


### PR DESCRIPTION
Add render pass graph infrastructure (`RenderPassDesc`, pipeline surfaces, blueprint materialization, compile/barrier planning, `CachedRenderGraph`) and route GL/VK frame passes through shared beginPass/endPass execution.

The game still uses the legacy `begin*Pass` API; legacy_pass factories express shadow/scene/swapchain passes as `RenderPassDesc`. Draw recording is gated on `canRecordDrawCommands()`, with both backends opening the swapchain pass at frame boundaries so UI and compositing work.

Many things have been extracted from `gfx_api_vk.h/cpp` into separate modules under the `vk/` subdirectory.

NOTE 1: There will be a follow-up PR to properly integrate the new render graph architecture into the game rendering code. After that point, all legacy-prefixed stuff will naturally go away.

NOTE 2: Benchmarking on Linux and Windows 11 in various conditions show roughly the same performance as in the current master.

Signed-off-by: Pavel Solodovnikov <pavel.al.solodovnikov@gmail.com>