### PR TITLE
Emit room status after player identity verified

### DIFF
--- a/src/multisync.cpp
+++ b/src/multisync.cpp
@@ -352,6 +352,7 @@ bool recvPing(NETQUEUE queue)
 			std::string senderPublicKeyB64 = base64Encode(senderIdentity.toBytes(EcKey::Public));
 			std::string senderIdentityHash = senderIdentity.publicHashString();
 			wz_command_interface_output("WZEVENT: player identity VERIFIED: %" PRIu32 " %s %s %s\n", sender, senderPublicKeyB64.c_str(), senderIdentityHash.c_str(), NetPlay.players[sender].IPtextAddress);
+			wz_command_interface_output_room_status_json();
 		}
 
 		// Note that we have received it


### PR DESCRIPTION
Previously, the room status was not emitted, resulting in stale room status and need for manual status fetching upon player identity change


This is needed because the room status maintains the `pk` (public key) property for all human players/spectators. It should be updated appropriately.