### PR TITLE
Fix: Remove object tile visibility against the correct world map

### DIFF
--- a/src/baseobject.cpp
+++ b/src/baseobject.cpp
@@ -133,7 +133,14 @@ BASE_OBJECT::BASE_OBJECT(OBJECT_TYPE type, uint32_t id, unsigned player)
 
 BASE_OBJECT::~BASE_OBJECT()
 {
-	visRemoveVisibility(this, gameWorld.map);
+	// Tile visibility must already have been removed (against the object's own world map) by
+	// the time we get here.
+	//
+	// See flushPendingVisRemoval(), the killXXX + objmemUpdate path, and the freeAllXXX teardown path.
+	//
+	// The destructor cannot do it itself because it has no reliable way to know which world's map this
+	// object belonged to.
+	ASSERT(watchedTiles.empty(), "watchedTiles not removed before destruction (player %d)", (int)player);
 }
 
 

--- a/src/mechanics.cpp
+++ b/src/mechanics.cpp
@@ -33,6 +33,7 @@
 #include "objmem.h"
 #include "research.h"
 #include "structure.h"
+#include "visibility.h"
 
 /* Shutdown the mechanics system */
 bool mechanicsShutdown()
@@ -43,6 +44,9 @@ bool mechanicsShutdown()
 	}
 	for (BASE_OBJECT* psObj : psDestroyedObj)
 	{
+		// Force-destroying everything: clear any not-yet-removed tile visibility (the owning
+		// map may already be gone, so don't touch it) so the destructor's assert is satisfied
+		visRemoveVisibilityOffWorld(psObj);
 		objmemDestroy(psObj, true);
 	}
 	psDestroyedObj.clear();

--- a/src/mission.cpp
+++ b/src/mission.cpp
@@ -349,6 +349,9 @@ bool missionShutDown()
 		releaseAllProxDisp();
 		gwShutDown(gameWorld.map);
 
+		// freeAll*() above flushed gameWorld's pending visibility removals
+		// nothing should be left to strand when this world is overwritten by the swap
+		ASSERT(gameWorld.objects.pendingVisRemoval.empty(), "pending visibility removals lost on world swap");
 		gameWorld = std::move(mission.gameWorld);
 		mission.gameWorld = {};
 	}
@@ -760,6 +763,11 @@ static void saveMissionData()
 	resetHomeStructureObjects(); //get rid of soon-to-be illegal references of droids in repair facilities and rearming pads.
 
 	//save the mission data
+	// NOTE:
+	// - gameWorld's queue is preserved by the move into mission.gameWorld, but the (stale)
+	//   mission.gameWorld being overwritten must have its own queue flushed first so nothing is
+	//   stranded
+	flushPendingVisRemoval(mission.gameWorld);
 	mission.gameWorld = std::move(gameWorld);
 	gameWorld = {};
 
@@ -810,6 +818,9 @@ void restoreMissionData()
 	}
 	//restore the game pointers.
 	//swap mission data over
+	// freeAllXXX above flushed gameWorld's pending visibility removals; nothing should be
+	// left to strand when this world is overwritten by the swap.
+	ASSERT(gameWorld.objects.pendingVisRemoval.empty(), "pending visibility removals lost on world swap");
 	gameWorld = std::move(mission.gameWorld);
 	mission.gameWorld = {};
 	for (inc = 0; inc < MAX_PLAYERS; inc++)

--- a/src/objmem.cpp
+++ b/src/objmem.cpp
@@ -45,6 +45,7 @@
 #include "order.h"
 #include "wzcrashhandlingproviders.h"
 #include "world_object_state.h"
+#include "game_world.h"
 
 #include <algorithm>
 
@@ -316,6 +317,13 @@ void objmemUpdate()
 	objListIntegCheck();
 #endif
 
+	// Remove tile visibility for objects killed this tick, each against its own world's map
+	//
+	// This is done here (rather than in the object destructor) so that the correct map is used
+	// even for the inactive (offworld / home-base) world
+	flushPendingVisRemoval(gameWorld);
+	flushPendingVisRemoval(mission.gameWorld);
+
 	/* Go through the destroyed objects list looking for objects that
 	   were destroyed before this turn */
 
@@ -378,11 +386,17 @@ static inline void addObjectToFuncList(FunctionList& list, OBJECT *object, int p
 }
 
 /* Move an object from the active list to the destroyed list.
+ * \param objState is the world object state that owns the list (and the pending-vis-removal queue)
  * \param list is a pointer to the object list
- * \param del is a pointer to the object to remove
+ * \param object is a pointer to the object to remove
+ *
+ * Note: Tile visibility is NOT removed here. Instead the object is queued on
+ * objState.pendingVisRemoval and processed (against this world's own map) by
+ * flushPendingVisRemoval() at the end of the tick, so that the rest of this tick still sees
+ * the object's visibility and removal always targets the correct map
  */
 template <typename OBJECT, size_t PlayerCount = MAX_PLAYERS>
-static inline void destroyObject(PerPlayerObjectLists<OBJECT, PlayerCount>& list, OBJECT* object)
+static inline void destroyObject(WorldObjectState& objState, PerPlayerObjectLists<OBJECT, PlayerCount>& list, OBJECT* object)
 {
 	ASSERT_OR_RETURN(, object != nullptr, "Invalid pointer");
 	ASSERT_OR_RETURN(, object->player < PlayerCount, "Invalid player index: %d", object->player);
@@ -398,10 +412,23 @@ static inline void destroyObject(PerPlayerObjectLists<OBJECT, PlayerCount>& list
 		// Prepend the object to the destruction list
 		psDestroyedObj.emplace_front((BASE_OBJECT*)object);
 
+		// Queue tile-visibility removal against this world's map (done at end of tick)
+		objState.pendingVisRemoval.emplace_back((BASE_OBJECT*)object);
+
 		// Set destruction time
 		object->died = gameTime;
 	}
 	scriptRemoveObject(object);
+}
+
+/* Remove tile visibility for objects killed this tick in the given world, against that world's own map */
+void flushPendingVisRemoval(GameWorld& world)
+{
+	for (BASE_OBJECT* psObj : world.objects.pendingVisRemoval)
+	{
+		visRemoveVisibility(psObj, world.map);
+	}
+	world.objects.pendingVisRemoval.clear();
 }
 
 /* Remove an object from the active list
@@ -517,7 +544,7 @@ void killDroid(DROID *psDel, WorldObjectState& objState)
 		removeObjectFromFuncList(objState.sensors, (BASE_OBJECT *)psDel, 0);
 	}
 
-	destroyObject(objState.droids, psDel);
+	destroyObject(objState, objState.droids, psDel);
 }
 
 template <typename EntityType>
@@ -571,8 +598,15 @@ struct GlobalEntityContainerTraits<FEATURE>
 	}
 };
 
+// Frees every object in entityLists directly (bypassing the kill*()/destroyObject() path)
+//
+// These objects are deleted immediately, so their tile visibility must be removed first or
+// the BASE_OBJECT destructor's "watchedTiles empty" assert would trip
+//
+// When map is non-null the removal updates that map's counters,
+// when map is null (e.g. limbo droids, with no associated map) visibility is just cleared
 template <typename Entity, unsigned PlayerCount>
-static void freeAllEntitiesImpl(PerPlayerObjectLists<Entity, PlayerCount>& entityLists)
+static void freeAllEntitiesImpl(PerPlayerObjectLists<Entity, PlayerCount>& entityLists, WorldMapState* map)
 {
 	using Traits = GlobalEntityContainerTraits<Entity>;
 	auto& entityContainer = Traits::getContainer();
@@ -580,6 +614,14 @@ static void freeAllEntitiesImpl(PerPlayerObjectLists<Entity, PlayerCount>& entit
 	{
 		for (auto* ent : list)
 		{
+			if (map != nullptr)
+			{
+				visRemoveVisibility((BASE_OBJECT*)ent, *map);
+			}
+			else
+			{
+				visRemoveVisibilityOffWorld((BASE_OBJECT*)ent);
+			}
 			auto it = entityContainer.find(*ent);
 			if (it == entityContainer.end()) {
 				ASSERT(false, "%s not found in the global container!", Traits::entityName());
@@ -594,7 +636,9 @@ static void freeAllEntitiesImpl(PerPlayerObjectLists<Entity, PlayerCount>& entit
 /* Remove all droids */
 void freeAllDroids(GameWorld& world)
 {
-	freeAllEntitiesImpl<DROID, MAX_PLAYERS>(world.objects.droids);
+	// objects killed but not yet vis-removed would be stranded by the world teardown - flush first
+	flushPendingVisRemoval(world);
+	freeAllEntitiesImpl<DROID, MAX_PLAYERS>(world.objects.droids, &world.map);
 }
 
 /*Remove a single Droid from a list*/
@@ -627,7 +671,8 @@ void removeDroid(DROID* psDroidToRemove, PerPlayerDroidLists& pList)
 /*Removes all droids that may be stored in the limbo lists*/
 void freeAllLimboDroids()
 {
-	freeAllEntitiesImpl<DROID, MAX_PLAYERS>(apsLimboDroids);
+	// limbo droids have no associated map; their tile visibility was already removed off-world
+	freeAllEntitiesImpl<DROID, MAX_PLAYERS>(apsLimboDroids, nullptr);
 }
 
 /**************************  STRUCTURE  *******************************/
@@ -704,13 +749,15 @@ void killStruct(STRUCTURE *psBuilding, WorldObjectState& objState)
 		}
 	}
 
-	destroyObject(objState.structures, psBuilding);
+	destroyObject(objState, objState.structures, psBuilding);
 }
 
 /* Remove heapall structures */
 void freeAllStructs(GameWorld& world)
 {
-	freeAllEntitiesImpl<STRUCTURE, MAX_PLAYERS>(world.objects.structures);
+	// objects killed but not yet vis-removed would be stranded by the world teardown - flush first
+	flushPendingVisRemoval(world);
+	freeAllEntitiesImpl<STRUCTURE, MAX_PLAYERS>(world.objects.structures, &world.map);
 }
 
 /*Remove a single Structure from a list*/
@@ -752,7 +799,7 @@ void killFeature(FEATURE *psDel, WorldObjectState& objState)
 	ASSERT(psDel->type == OBJ_FEATURE,
 	       "killFeature: pointer is not a feature");
 	psDel->player = 0;
-	destroyObject(objState.features, psDel);
+	destroyObject(objState, objState.features, psDel);
 
 	if (psDel->psStats->subType == FEAT_OIL_RESOURCE)
 	{
@@ -763,7 +810,9 @@ void killFeature(FEATURE *psDel, WorldObjectState& objState)
 /* Remove all features */
 void freeAllFeatures(GameWorld& world)
 {
-	freeAllEntitiesImpl<FEATURE, 1>(world.objects.features);
+	// objects killed but not yet vis-removed would be stranded by the world teardown - flush first
+	flushPendingVisRemoval(world);
+	freeAllEntitiesImpl<FEATURE, 1>(world.objects.features, &world.map);
 }
 
 /**************************  FLAG_POSITION ********************************/

--- a/src/objmem.h
+++ b/src/objmem.h
@@ -45,6 +45,10 @@ void objmemShutdown();
 /* General housekeeping for the object system */
 void objmemUpdate();
 
+/* Remove tile visibility for objects killed this tick in the given world, against that
+ * world's own map. Safe to call repeatedly; clears the world's pending-removal queue. */
+void flushPendingVisRemoval(GameWorld& world);
+
 /* Remove an object from the destroyed list, finally freeing its memory
  * Hopefully by this time, no pointers still refer to it! */
 bool objmemDestroy(BASE_OBJECT* psObj, bool checkRefs);

--- a/src/structure.cpp
+++ b/src/structure.cpp
@@ -1753,7 +1753,14 @@ STRUCTURE *buildStructureDir(GameWorld& world, STRUCTURE_STATS *pStructureType, 
 		if (!setFunctionality(psBuilding, pStructureType->type, world))
 		{
 			removeStructFromMap(psBuilding, world.map);
+
+			// visTilesUpdate() above populated watchedTiles - this object is destroyed directly
+			// (it was never killed via killStruct, so it isn't on the pending-vis-removal queue),
+			// so remove its tile visibility here, against this world's map, before deletion
+			visRemoveVisibility(psBuilding, world.map);
+
 			objmemDestroy(psBuilding, false);
+
 			//better reset these if you couldn't build the structure!
 			if (FromSave && player == selectedPlayer && missionLimboExpand())
 			{

--- a/src/world_object_state.h
+++ b/src/world_object_state.h
@@ -26,6 +26,8 @@
 
 #include "object_lists_types.h"
 
+#include <vector>
+
 /// <summary>
 /// A simple wrapper around various object lists (per-world).
 /// </summary>
@@ -38,4 +40,11 @@ struct WorldObjectState
 	PerPlayerExtractorLists extractors;
 	GlobalSensorList sensors; ///< List of sensors in the game.
 	GlobalOilList oils;
+
+	/// Objects killed in this world but whose tile visibility has not yet been removed.
+	/// Drained once per tick by flushPendingVisRemoval() against this world's map, so that
+	/// visibility is always removed against the correct map (even after world swaps). Lives
+	/// here (rather than alongside the global destroyed-object list) so it travels with the
+	/// world's map.
+	std::vector<BASE_OBJECT*> pendingVisRemoval;
 };


### PR DESCRIPTION
`BASE_OBJECT`'s destructor removed tile visibility against `gameWorld.map`, but for campaign games `gameWorld` may have been swapped with the offworld / home-base map (`mission.gameWorld`) since the object was killed (or if some other destruction of offworld objects happens), so the wrong map's vision counters could be touched.

Move visibility removal out of the destructor and into a per-tick drain that always targets the object's own world map:

- Add `WorldObjectState::pendingVisRemoval`: a queue that travels with its world's map
- `destroyObject()` enqueues the killed object, keeping visibility stable for the rest of the tick (preserving fairness for later objects)
- `flushPendingVisRemoval()` drains each world's queue against that world's map (called for both `gameWorld` and `mission.gameWorld` each `objmemUpdate`)
- `freeAll*()` flush the queue and remove visibility for directly-freed live objects before erasing them
- `mechanicsShutdown` clears residual tiles
- `saveMissionData` flushes the discarded world before the swap
- `BASE_OBJECT`'s destructor now just `ASSERTs` `watchedTiles` is empty