### PR TITLE
quickjs_backend: Significantly improve problematic round-tripping (save / restore of script state)

### DIFF
--- a/data/mp/multiplay/skirmish/bonecrusher/functions.js
+++ b/data/mp/multiplay/skirmish/bonecrusher/functions.js
@@ -14,7 +14,7 @@
 // cheat - true(читерим, видя через туман войны), null/false/undefined(не читерим, возвращем только то, что можем видеть)
 // inc - true(прибавляем value+1 и возвращаем), null/false/undefined(просто возвращаем value)
 
-var _globalInfoNear = [];
+var _globalInfoNear = {};
 
 function getInfoNear(x, y, command, range, time, obj, cheat, inc)
 {

--- a/data/mp/multiplay/skirmish/bonecrusher/performance.js
+++ b/data/mp/multiplay/skirmish/bonecrusher/performance.js
@@ -5,8 +5,8 @@ debugMsg('Module: performance.js', 'init');
 
 // }
 
-var perfFunc = [];
-var perfOrder = [];
+var perfFunc = {};
+var perfOrder = {};
 
 function distBetweenTwoPoints_p(x1, y1, x2, y2)
 {

--- a/src/quickjs_backend.cpp
+++ b/src/quickjs_backend.cpp
@@ -216,7 +216,8 @@ static const char* WZ_JSON_TAG_NUMBER = "number";   // a non-finite double (NaN 
 static const char* WZ_JSON_ID_KEY     = "@@id";     // reference identity (int)
 static const char* WZ_JSON_CLASS_KEY  = "@@class";  // class name (string)
 static const char* WZ_JSON_DATA_KEY   = "@@data";   // own data properties (object) / elements (array)
-static const char* WZ_JSON_ARR_KEY    = "@@arr";    // on a "ref": true if the target is an array
+static const char* WZ_JSON_KIND_KEY   = "@@kind";   // on a "ref": type ("array", possibly others in the future). Absent = object.
+static const char* WZ_JSON_KIND_ARRAY = "array";
 static const char* WZ_JSON_VALUE_KEY  = "@@value";  // on a "number": "NaN" / "Infinity" / "-Infinity"
 static const char* WZ_JSON_PROPS_KEY  = "@@props";  // on an "array": named (non-index) own properties (object)
 
@@ -1090,13 +1091,14 @@ JSValue mapJsonToQuickJSValueWithContext(JsonToJSContext& c, const nlohmann::jso
 				{
 					return JS_DupValue(ctx, found->second);
 				}
-				// Forward reference: create a placeholder of the correct kind (object or
-				// array) that the matching definition will populate in-place later, so all
-				// holders share one identity.
-				bool refIsArray = false;
-				auto arrIt = instance.find(WZ_JSON_ARR_KEY);
-				if (arrIt != instance.end() && arrIt->is_boolean()) { refIsArray = arrIt->get<bool>(); }
-				JSValue placeholder = refIsArray ? JS_NewArray(ctx) : JS_NewObject(ctx);
+				// Forward reference: create a placeholder of the correct kind that the
+				// matching definition will populate in-place later, so all holders share one
+				// identity. The kind comes from @@kind ("array"; possibly others later). An
+				// absent @@kind means a plain object.
+				std::string refKind;
+				auto kindIt = instance.find(WZ_JSON_KIND_KEY);
+				if (kindIt != instance.end() && kindIt->is_string()) { refKind = kindIt->get<std::string>(); }
+				JSValue placeholder = (refKind == WZ_JSON_KIND_ARRAY) ? JS_NewArray(ctx) : JS_NewObject(ctx);
 				if (id >= 0) { c.idMap[id] = JS_DupValue(ctx, placeholder); }
 				return placeholder;
 			}
@@ -4145,7 +4147,9 @@ nlohmann::json wz_qjs_to_json(JSToJsonContext &c, JSValue value)
 				nlohmann::json ref = nlohmann::json::object();
 				ref[WZ_JSON_TAG_KEY] = WZ_JSON_TAG_REF;
 				ref[WZ_JSON_ID_KEY] = refIt->second;
-				if (isArray) { ref[WZ_JSON_ARR_KEY] = true; }
+				// Record the targets's kind so a forward reference can build a matching
+				// placeholder. Object is the default (no @@kind).
+				if (isArray) { ref[WZ_JSON_KIND_KEY] = WZ_JSON_KIND_ARRAY; }
 				return ref;
 			}
 		}

--- a/src/quickjs_backend.cpp
+++ b/src/quickjs_backend.cpp
@@ -989,6 +989,11 @@ struct JsonToJSContext
 			JS_FreeValue(ctx, kv.second);
 		}
 	}
+
+	JsonToJSContext(const JsonToJSContext&) = delete;
+	JsonToJSContext& operator=(const JsonToJSContext&) = delete;
+	JsonToJSContext(JsonToJSContext&&) = delete;
+	JsonToJSContext& operator=(JsonToJSContext&&) = delete;
 };
 
 // Resolves the prototype object for a script-defined class by name.

--- a/src/quickjs_backend.cpp
+++ b/src/quickjs_backend.cpp
@@ -80,6 +80,7 @@
 #include "lib/framework/file.h"
 #include <unordered_map>
 #include <limits>
+#include <cmath>
 
 #if !defined(__clang__) && defined(__GNUC__) && __GNUC__ >= 8
 #pragma GCC diagnostic push
@@ -200,15 +201,17 @@ struct JSToJsonContext
 // NOTES:
 // - Script globals are not expected to use property names beginning with "@@".
 //
-static const char* WZ_JSON_TAG_KEY    = "@@wztype"; // "class" / "object" / "array" / "ref"
+static const char* WZ_JSON_TAG_KEY    = "@@wztype"; // "class" / "object" / "array" / "ref" / "number"
 static const char* WZ_JSON_TAG_CLASS  = "class";
 static const char* WZ_JSON_TAG_OBJECT = "object";
 static const char* WZ_JSON_TAG_ARRAY  = "array";
 static const char* WZ_JSON_TAG_REF    = "ref";
+static const char* WZ_JSON_TAG_NUMBER = "number";   // a non-finite double (NaN / Infinity / -Infinity)
 static const char* WZ_JSON_ID_KEY     = "@@id";     // reference identity (int)
 static const char* WZ_JSON_CLASS_KEY  = "@@class";  // class name (string)
 static const char* WZ_JSON_DATA_KEY   = "@@data";   // own data properties (object) / elements (array)
 static const char* WZ_JSON_ARR_KEY    = "@@arr";    // on a "ref": true if the target is an array
+static const char* WZ_JSON_VALUE_KEY  = "@@value";  // on a "number": "NaN" / "Infinity" / "-Infinity"
 
 // NOTE ON SAVE FORMAT COMPATIBILITY:
 // - When tagging is enabled (the save / restore path), *every* object and array is wrapped in a tag object
@@ -972,6 +975,19 @@ JSValue mapJsonToQuickJSValueWithContext(JsonToJSContext& c, const nlohmann::jso
 		if (tagIt != instance.end() && tagIt->is_string())
 		{
 			const std::string tag = tagIt->get<std::string>();
+
+			// Non-finite number (NaN / Infinity / -Infinity)
+			if (tag == WZ_JSON_TAG_NUMBER)
+			{
+				std::string token;
+				auto valIt = instance.find(WZ_JSON_VALUE_KEY);
+				if (valIt != instance.end() && valIt->is_string()) { token = valIt->get<std::string>(); }
+				double dblVal = std::numeric_limits<double>::quiet_NaN();
+				if (token == "Infinity") { dblVal = std::numeric_limits<double>::infinity(); }
+				else if (token == "-Infinity") { dblVal = -std::numeric_limits<double>::infinity(); }
+				return JS_NewFloat64(ctx, dblVal);
+			}
+
 			int id = -1;
 			auto idIt = instance.find(WZ_JSON_ID_KEY);
 			if (idIt != instance.end() && idIt->is_number_integer()) { id = idIt->get<int>(); }
@@ -4176,6 +4192,16 @@ nlohmann::json wz_qjs_to_json(JSToJsonContext &c, JSValue value)
 			{
 				// Failed
 				debug(LOG_SCRIPT, "Failed to convert to double");
+			}
+			if (c.tag_class_instances && !std::isfinite(dblVal))
+			{
+				// JSON cannot represent NaN / Infinity (nlohmann::json serializes them as null, which would reload as undefined).
+				// Encode them as a tagged value so they round-trip. (Only done on the tagged save / restore path.)
+				nlohmann::json num = nlohmann::json::object();
+				num[WZ_JSON_TAG_KEY] = WZ_JSON_TAG_NUMBER;
+				if (std::isnan(dblVal)) { num[WZ_JSON_VALUE_KEY] = "NaN"; }
+				else { num[WZ_JSON_VALUE_KEY] = (dblVal < 0.0) ? "-Infinity" : "Infinity"; }
+				return num;
 			}
 			return dblVal;
 		}

--- a/src/quickjs_backend.cpp
+++ b/src/quickjs_backend.cpp
@@ -319,6 +319,42 @@ static bool isOwnAccessorProperty(JSContext* ctx, JSValue obj, JSAtom atom)
 	return isAccessor;
 }
 
+// If `value` is an instance of a built-in exotic type (Map/Set/Date/RegExp/typed array/...),
+// this function returns its constructor name.
+//
+// Such objects currently serialize to an essentially empty object (i.e. their contents are lost)
+// because their internal state does not live in own properties, and specialized handling would be
+// required to round-trip them properly.
+//
+// Returns empty for plain objects and script-defined classes (which are handled separately).
+// Used purely to emit a diagnostic for script authors.
+static std::string getBuiltinExoticClassName(JSToJsonContext& c, JSValue value)
+{
+	JSContext* ctx = c.ctx;
+	JSValue proto = JS_GetPrototype(ctx, value);
+	if (!JS_IsObject(proto) || JS_SameValueZero(ctx, proto, c.objectProto()))
+	{
+		JS_FreeValue(ctx, proto);
+		return std::string();
+	}
+	std::string result;
+	JSValue ctor = JS_GetPropertyStr(ctx, proto, "constructor");
+	if (JS_IsConstructor(ctx, ctor))
+	{
+		JSValue nameVal = JS_GetPropertyStr(ctx, ctor, "name");
+		const char* nameStr = JS_ToCString(ctx, nameVal);
+		if (nameStr && nameStr[0] != '\0' && isBuiltinConstructorName(nameStr))
+		{
+			result = nameStr;
+		}
+		if (nameStr) { JS_FreeCString(ctx, nameStr); }
+		JS_FreeValue(ctx, nameVal);
+	}
+	JS_FreeValue(ctx, ctor);
+	JS_FreeValue(ctx, proto);
+	return result;
+}
+
 // NOTE: May throw if there is a circular reference!
 nlohmann::json wz_qjs_to_json(JSToJsonContext &c, JSValue value); // forward-declare
 
@@ -4149,6 +4185,14 @@ nlohmann::json wz_qjs_to_json(JSToJsonContext &c, JSValue value)
 				else
 				{
 					j[WZ_JSON_TAG_KEY] = WZ_JSON_TAG_OBJECT;
+					// Warn script authors when a built-in exotic object (Map/Set/Date/...) is
+					// being saved: its internal state lives in internal slots, not own
+					// properties, so it degrades to an (essentially empty) plain object.
+					std::string builtinName = getBuiltinExoticClassName(c, value);
+					if (!builtinName.empty())
+					{
+						debug(LOG_SCRIPT, "Cannot fully save script global of built-in type \"%s\": its internal state is not serializable; it will be restored as a plain object (%zu own propert%s preserved)", builtinName.c_str(), static_cast<size_t>(data.size()), (data.size() == 1) ? "y" : "ies");
+					}
 				}
 				j[WZ_JSON_DATA_KEY] = std::move(data);
 			}

--- a/src/quickjs_backend.cpp
+++ b/src/quickjs_backend.cpp
@@ -296,6 +296,29 @@ static std::string getSerializableClassName(JSToJsonContext& c, JSValue value)
 	return result;
 }
 
+// Returns true if `atom` is an own accessor (getter/setter) property of `obj`.
+//
+// Such properties are skipped when serializing globals: the getter/setter are arbitrary
+// closures that cannot be serialized, and snapshotting the getter's current value as plain
+// data would be misleading (it would mask a prototype accessor of the same name, or freeze
+// derived state).
+//
+// NOTE: class/prototype accessors are not "own" and are unaffected.
+static bool isOwnAccessorProperty(JSContext* ctx, JSValue obj, JSAtom atom)
+{
+	JSPropertyDescriptor desc;
+	int ret = JS_GetOwnProperty(ctx, &desc, obj, atom);
+	if (ret != 1)
+	{
+		return false; // not an own property, or an error occurred
+	}
+	bool isAccessor = (desc.flags & JS_PROP_GETSET) != 0;
+	JS_FreeValue(ctx, desc.value);
+	JS_FreeValue(ctx, desc.getter);
+	JS_FreeValue(ctx, desc.setter);
+	return isAccessor;
+}
+
 // NOTE: May throw if there is a circular reference!
 nlohmann::json wz_qjs_to_json(JSToJsonContext &c, JSValue value); // forward-declare
 
@@ -4093,6 +4116,12 @@ nlohmann::json wz_qjs_to_json(JSToJsonContext &c, JSValue value)
 				std::string className = getSerializableClassName(c, value);
 				nlohmann::json data = nlohmann::json::object();
 				QuickJS_EnumerateObjectProperties(c.ctx, value, [&c, value, &data](const char *key, JSAtom &atom) {
+					if (isOwnAccessorProperty(c.ctx, value, atom))
+					{
+						// can't serialize getter/setter closures
+						debug(LOG_SCRIPT, "Skipping own accessor property \"%s\" when saving script global: getter/setter closures cannot be serialized", key);
+						return;
+					}
 					JSValue jsVal = JS_GetProperty(c.ctx, value, atom);
 					std::string nameStr = key;
 					if (!JS_IsException(jsVal))

--- a/src/quickjs_backend.cpp
+++ b/src/quickjs_backend.cpp
@@ -194,6 +194,12 @@ struct JSToJsonContext
 	{
 		return stack.empty();
 	}
+
+	// For safety, we really don't want JSToJsonContext to be copied or moved (just passed down through a function hierarchy)
+	JSToJsonContext(const JSToJsonContext&) = delete;
+	JSToJsonContext& operator=(const JSToJsonContext&) = delete;
+	JSToJsonContext(JSToJsonContext&&) = delete;
+	JSToJsonContext& operator=(JSToJsonContext&&) = delete;
 };
 
 // Reserved JSON keys used to encode rich JS values (class instances, shared references) within the otherwise-plain-JSON global save format.

--- a/src/quickjs_backend.cpp
+++ b/src/quickjs_backend.cpp
@@ -145,11 +145,44 @@ struct JSToJsonContext
 	JSContext *ctx;
 	std::vector<JSValue> stack;
 	bool skip_constructors;
+	// When true, script-defined class instances are serialized with type+identity tags
+	// (so they can be restored as proper instances), and shared object references are
+	// preserved via back-references.
+	// Only enabled for the save/restore path (not for debug display or plain value conversion).
+	bool tag_class_instances;
+	// Maps object identity -> assigned reference id. Deliberately *not* cleared by reset()
+	// so that objects shared across multiple globals keep a single identity in the save.
+	std::unordered_map<const void*, int> refIds;
+	int nextRefId = 0;
+	JSValue cachedObjectProto = JS_UNINITIALIZED;
 
-	JSToJsonContext(JSContext *ctx, bool skip_constructors)
+	JSToJsonContext(JSContext *ctx, bool skip_constructors, bool tag_class_instances = false)
 	: ctx(ctx)
 	, skip_constructors(skip_constructors)
+	, tag_class_instances(tag_class_instances)
 	{ }
+
+	~JSToJsonContext()
+	{
+		if (!JS_IsUninitialized(cachedObjectProto))
+		{
+			JS_FreeValue(ctx, cachedObjectProto);
+		}
+	}
+
+	// Returns Object.prototype for this context (borrowed reference, owned by the context)
+	JSValue objectProto()
+	{
+		if (JS_IsUninitialized(cachedObjectProto))
+		{
+			JSValue g = JS_GetGlobalObject(ctx);
+			JSValue objCtor = JS_GetPropertyStr(ctx, g, "Object");
+			cachedObjectProto = JS_GetPropertyStr(ctx, objCtor, "prototype");
+			JS_FreeValue(ctx, objCtor);
+			JS_FreeValue(ctx, g);
+		}
+		return cachedObjectProto;
+	}
 
 	void reset()
 	{
@@ -161,6 +194,104 @@ struct JSToJsonContext
 		return stack.empty();
 	}
 };
+
+// Reserved JSON keys used to encode rich JS values (class instances, shared references) within the otherwise-plain-JSON global save format.
+//
+// NOTES:
+// - Script globals are not expected to use property names beginning with "@@".
+//
+static const char* WZ_JSON_TAG_KEY    = "@@wztype"; // "class" / "object" / "array" / "ref"
+static const char* WZ_JSON_TAG_CLASS  = "class";
+static const char* WZ_JSON_TAG_OBJECT = "object";
+static const char* WZ_JSON_TAG_ARRAY  = "array";
+static const char* WZ_JSON_TAG_REF    = "ref";
+static const char* WZ_JSON_ID_KEY     = "@@id";     // reference identity (int)
+static const char* WZ_JSON_CLASS_KEY  = "@@class";  // class name (string)
+static const char* WZ_JSON_DATA_KEY   = "@@data";   // own data properties (object) / elements (array)
+static const char* WZ_JSON_ARR_KEY    = "@@arr";    // on a "ref": true if the target is an array
+
+// NOTE ON SAVE FORMAT COMPATIBILITY:
+// - When tagging is enabled (the save / restore path), *every* object and array is wrapped in a tag object
+//   carrying an "@@id", so that shared references and cycles of any kind round-trip correctly.
+// - Older saves wrote bare objects and arrays with no tags - the loader detects the absence of "@@wztype"
+//   and falls back to the legacy plain-object / plain-array decoding, so old saves continue to load.
+
+// Built-in global constructors that must never be treated as restorable script classes.
+static bool isBuiltinConstructorName(const std::string& name)
+{
+	static const std::unordered_set<std::string> builtins = {
+		"Object", "Function", "Array", "Number", "Boolean", "String", "Symbol", "BigInt",
+		"Date", "RegExp", "Error", "EvalError", "RangeError", "ReferenceError", "SyntaxError",
+		"TypeError", "URIError", "Map", "Set", "WeakMap", "WeakSet", "Promise", "Proxy",
+		"ArrayBuffer", "SharedArrayBuffer", "DataView",
+		"Int8Array", "Uint8Array", "Uint8ClampedArray", "Int16Array", "Uint16Array",
+		"Int32Array", "Uint32Array", "Float32Array", "Float64Array", "BigInt64Array", "BigUint64Array"
+	};
+	return builtins.count(name) != 0;
+}
+
+// Resolves a top-level binding by name through the script's global scope.
+//
+// IMPORTANT: top-level `class` / `let` / `const` declarations are *lexical* bindings stored
+// in the global lexical scope (ctx->global_var_obj) - NOT properties of the global object.
+// So JS_GetGlobalObject()+JS_GetPropertyStr (which only sees `var` / function declarations)
+// cannot find them.
+//
+// JS_GetGlobalLexicalOrVar performs a pure property lookup of the global lexical scope first,
+// then the global object, returning the bound value.
+//
+// Returns JS_UNDEFINED if the name does not resolve.
+static JSValue resolveGlobalBindingByName(JSContext* ctx, const std::string& name)
+{
+	ASSERT_OR_RETURN(JS_UNDEFINED, name.size() < 1024, "Rejecting name that exceeds length limit: \"%s\"", name.c_str());
+	return JS_GetGlobalLexicalOrVar(ctx, name.c_str(), name.size());
+}
+
+// If `value` is an instance of a script-defined (global) class, returns that class's name.
+//
+// The class must round-trip by name through the global scope to the same constructor (so it
+// can be reliably resolved again at restore time). Returns an empty string otherwise (plain
+// objects, built-in exotic objects, anonymous/non-global classes, etc).
+static std::string getSerializableClassName(JSToJsonContext& c, JSValue value)
+{
+	JSContext* ctx = c.ctx;
+	JSValue proto = JS_GetPrototype(ctx, value);
+	if (!JS_IsObject(proto))
+	{
+		JS_FreeValue(ctx, proto);
+		return std::string();
+	}
+	// Plain objects (prototype === Object.prototype) are not class instances.
+	if (JS_SameValueZero(ctx, proto, c.objectProto()))
+	{
+		JS_FreeValue(ctx, proto);
+		return std::string();
+	}
+	std::string result;
+	JSValue ctor = JS_GetPropertyStr(ctx, proto, "constructor");
+	if (JS_IsConstructor(ctx, ctor))
+	{
+		JSValue nameVal = JS_GetPropertyStr(ctx, ctor, "name");
+		const char* nameStr = JS_ToCString(ctx, nameVal);
+		if (nameStr && nameStr[0] != '\0' && !isBuiltinConstructorName(nameStr))
+		{
+			// Round-trip check: the class must be resolvable by this name through the global
+			// scope (including the global lexical scope, where top-level `class` lives) and
+			// resolve to this exact constructor.
+			JSValue resolved = resolveGlobalBindingByName(ctx, nameStr);
+			if (JS_SameValueZero(ctx, resolved, ctor))
+			{
+				result = nameStr;
+			}
+			JS_FreeValue(ctx, resolved);
+		}
+		if (nameStr) { JS_FreeCString(ctx, nameStr); }
+		JS_FreeValue(ctx, nameVal);
+	}
+	JS_FreeValue(ctx, ctor);
+	JS_FreeValue(ctx, proto);
+	return result;
+}
 
 // NOTE: May throw if there is a circular reference!
 nlohmann::json wz_qjs_to_json(JSToJsonContext &c, JSValue value); // forward-declare
@@ -769,6 +900,174 @@ JSValue mapJsonToQuickJSValue(JSContext *ctx, const nlohmann::json &instance, ui
 		case json::value_t::discarded : return JS_UNDEFINED;
 	}
 	return JS_UNDEFINED; // should never be reached
+}
+
+// Context carried through global restoration to reconstruct class instances and to
+// re-link objects that were shared (the same object referenced from multiple places) at
+// save time. ids map to the (single) restored object for each saved identity.
+struct JsonToJSContext
+{
+	JSContext* ctx;
+	std::unordered_map<int, JSValue> idMap; // reference id -> created object (owned)
+
+	JsonToJSContext(JSContext* ctx)
+	: ctx(ctx)
+	{ }
+
+	~JsonToJSContext()
+	{
+		for (auto& kv : idMap)
+		{
+			JS_FreeValue(ctx, kv.second);
+		}
+	}
+};
+
+// Resolves the prototype object for a script-defined class by name.
+//
+// Resolves through the global scope (including the global lexical scope, where top-level
+// `class` declarations live - they are NOT global-object properties), so it finds classes
+// that a plain global-object lookup would miss.
+//
+// Returns JS_UNINITIALIZED if not resolvable.
+static JSValue resolveClassPrototype(JSContext* ctx, const std::string& className)
+{
+	JSValue ctor = resolveGlobalBindingByName(ctx, className);
+	if (!JS_IsConstructor(ctx, ctor))
+	{
+		JS_FreeValue(ctx, ctor);
+		return JS_UNINITIALIZED;
+	}
+	JSValue proto = JS_GetPropertyStr(ctx, ctor, "prototype");
+	JS_FreeValue(ctx, ctor);
+	if (!JS_IsObject(proto))
+	{
+		JS_FreeValue(ctx, proto);
+		return JS_UNINITIALIZED;
+	}
+	return proto; // owned
+}
+
+JSValue mapJsonToQuickJSValueWithContext(JsonToJSContext& c, const nlohmann::json& instance, uint8_t prop_flags); // forward-declare
+
+static void populateObjectProperties(JsonToJSContext& c, JSValue obj, const nlohmann::json& obj_json, uint8_t prop_flags)
+{
+	for (auto it = obj_json.begin(); it != obj_json.end(); ++it)
+	{
+		JSValue prop_val = mapJsonToQuickJSValueWithContext(c, it.value(), prop_flags);
+		JS_DefinePropertyValueStr(c.ctx, obj, it.key().c_str(), prop_val, prop_flags);
+	}
+}
+
+// Like mapJsonToQuickJSValue, but additionally decodes the tagged wrappers emitted by
+// wz_qjs_to_json on the save path (class instances, plain objects, arrays and shared
+// references). JSON values without an "@@wztype" tag are decoded the legacy way, so older
+// saves (which wrote bare objects/arrays) continue to load.
+JSValue mapJsonToQuickJSValueWithContext(JsonToJSContext& c, const nlohmann::json& instance, uint8_t prop_flags)
+{
+	JSContext* ctx = c.ctx;
+	if (instance.is_object())
+	{
+		auto tagIt = instance.find(WZ_JSON_TAG_KEY);
+		if (tagIt != instance.end() && tagIt->is_string())
+		{
+			const std::string tag = tagIt->get<std::string>();
+			int id = -1;
+			auto idIt = instance.find(WZ_JSON_ID_KEY);
+			if (idIt != instance.end() && idIt->is_number_integer()) { id = idIt->get<int>(); }
+
+			// Back-reference to another (already or not-yet decoded) object.
+			if (tag == WZ_JSON_TAG_REF)
+			{
+				auto found = (id >= 0) ? c.idMap.find(id) : c.idMap.end();
+				if (found != c.idMap.end())
+				{
+					return JS_DupValue(ctx, found->second);
+				}
+				// Forward reference: create a placeholder of the correct kind (object or
+				// array) that the matching definition will populate in-place later, so all
+				// holders share one identity.
+				bool refIsArray = false;
+				auto arrIt = instance.find(WZ_JSON_ARR_KEY);
+				if (arrIt != instance.end() && arrIt->is_boolean()) { refIsArray = arrIt->get<bool>(); }
+				JSValue placeholder = refIsArray ? JS_NewArray(ctx) : JS_NewObject(ctx);
+				if (id >= 0) { c.idMap[id] = JS_DupValue(ctx, placeholder); }
+				return placeholder;
+			}
+
+			if (tag == WZ_JSON_TAG_CLASS || tag == WZ_JSON_TAG_OBJECT || tag == WZ_JSON_TAG_ARRAY)
+			{
+				const bool isArray = (tag == WZ_JSON_TAG_ARRAY);
+
+				// Re-use a placeholder created by an earlier forward reference (if any), so
+				// every reference ends up pointing at the same object.
+				JSValue obj;
+				auto existing = (id >= 0) ? c.idMap.find(id) : c.idMap.end();
+				if (existing != c.idMap.end())
+				{
+					obj = JS_DupValue(ctx, existing->second);
+				}
+				else
+				{
+					obj = isArray ? JS_NewArray(ctx) : JS_NewObject(ctx);
+					if (id >= 0) { c.idMap[id] = JS_DupValue(ctx, obj); }
+				}
+
+				if (tag == WZ_JSON_TAG_CLASS)
+				{
+					std::string className;
+					auto classIt = instance.find(WZ_JSON_CLASS_KEY);
+					if (classIt != instance.end() && classIt->is_string()) { className = classIt->get<std::string>(); }
+					// Re-attach the class prototype (the constructor is intentionally not run)
+					JSValue proto = resolveClassPrototype(ctx, className);
+					if (!JS_IsUninitialized(proto))
+					{
+						JS_SetPrototype(ctx, obj, proto);
+						JS_FreeValue(ctx, proto);
+					}
+					else if (!className.empty())
+					{
+						debug(LOG_SCRIPT, "Could not resolve class \"%s\" while restoring globals; restoring as a plain object", className.c_str());
+					}
+				}
+
+				auto dataIt = instance.find(WZ_JSON_DATA_KEY);
+				if (dataIt != instance.end())
+				{
+					if (isArray && dataIt->is_array())
+					{
+						for (int i = 0; i < dataIt->size(); i++)
+						{
+							JS_DefinePropertyValueUint32(ctx, obj, i, mapJsonToQuickJSValueWithContext(c, dataIt->at(i), prop_flags), prop_flags);
+						}
+					}
+					else if (!isArray && dataIt->is_object())
+					{
+						populateObjectProperties(c, obj, *dataIt, prop_flags);
+					}
+				}
+				return obj;
+			}
+			// Unknown tag: fall through and treat as a legacy plain object.
+		}
+
+		// Legacy bare object.
+		JSValue value = JS_NewObject(ctx);
+		populateObjectProperties(c, value, instance, prop_flags);
+		return value;
+	}
+	else if (instance.is_array())
+	{
+		// Legacy bare array.
+		JSValue value = JS_NewArray(ctx);
+		for (int i = 0; i < instance.size(); i++)
+		{
+			JS_DefinePropertyValueUint32(ctx, value, i, mapJsonToQuickJSValueWithContext(c, instance.at(i), prop_flags), prop_flags);
+		}
+		return value;
+	}
+	// Scalars (and anything else) cannot carry tags - delegate to the plain mapper.
+	return mapJsonToQuickJSValue(ctx, instance, prop_flags);
 }
 
 int JS_DeletePropertyStr(JSContext *ctx, JSValueConst this_obj,
@@ -2838,7 +3137,7 @@ bool quickjs_scripting_instance::readyInstanceForExecution()
 
 bool quickjs_scripting_instance::saveScriptGlobals(nlohmann::json &result)
 {
-	auto toJsonContext = JSToJsonContext(ctx, true);
+	auto toJsonContext = JSToJsonContext(ctx, true, /*tag_class_instances=*/true);
 
 	// we save 'scriptName' and 'me' implicitly
 	QuickJS_EnumerateObjectProperties(ctx, global_obj, [this, &result, &toJsonContext](const char *key, JSAtom &atom) {
@@ -2871,6 +3170,7 @@ bool quickjs_scripting_instance::saveScriptGlobals(nlohmann::json &result)
 bool quickjs_scripting_instance::loadScriptGlobals(const nlohmann::json &result)
 {
 	ASSERT_OR_RETURN(false, result.is_object(), "Can't load script globals from non-json-object");
+	JsonToJSContext loadCtx(ctx);
 	for (auto it : result.items())
 	{
 		// IMPORTANT: "null" JSON values *MUST* map to JS_UNDEFINED.
@@ -2878,7 +3178,7 @@ bool quickjs_scripting_instance::loadScriptGlobals(const nlohmann::json &result)
 		//			  (mapJsonToQuickJSValue handles this properly.)
 		// NOTE: Properties created on the JS global object (as "global variables") should be non-configurable.
 		//		 However *their* properties should probably be C_W_E.
-		int ret = JS_DefinePropertyValueStr(ctx, global_obj, it.key().c_str(), mapJsonToQuickJSValue(ctx, it.value(), JS_PROP_C_W_E), JS_PROP_WRITABLE | JS_PROP_ENUMERABLE | JS_PROP_THROW);
+		int ret = JS_DefinePropertyValueStr(ctx, global_obj, it.key().c_str(), mapJsonToQuickJSValueWithContext(loadCtx, it.value(), JS_PROP_C_W_E), JS_PROP_WRITABLE | JS_PROP_ENUMERABLE | JS_PROP_THROW);
 		if (ret != 1)
 		{
 			// Failed to load script global
@@ -3715,18 +4015,102 @@ nlohmann::json wz_qjs_to_json(JSToJsonContext &c, JSValue value)
 			return (!c.skip_constructors) ? "<constructor>" : nlohmann::json() /* null value */;
 		}
 
-		if (std::any_of(c.stack.begin(), c.stack.end(), [ctx = c.ctx, &value](JSValue& stackVal) -> bool { return JS_SameValueZero(ctx, stackVal, value) != 0; }))
+		bool isArray = WZ_QJS_IsArray(c.ctx, value) != 0;
+
+		if (c.tag_class_instances)
 		{
-			// circular reference
-			throw std::runtime_error("Circular reference detected!");
+			// If we've already serialized this exact object, emit a back-reference instead
+			// of duplicating it. This preserves shared identity across the whole save and
+			// breaks reference cycles of any kind.
+			auto refIt = c.refIds.find(JS_VALUE_GET_PTR(value));
+			if (refIt != c.refIds.end())
+			{
+				nlohmann::json ref = nlohmann::json::object();
+				ref[WZ_JSON_TAG_KEY] = WZ_JSON_TAG_REF;
+				ref[WZ_JSON_ID_KEY] = refIt->second;
+				if (isArray) { ref[WZ_JSON_ARR_KEY] = true; }
+				return ref;
+			}
+		}
+		else
+		{
+			// Legacy / non-tagging path (debug display, value conversion) has no reference
+			// table to break cycles, so guard against them with the recursion stack.
+			if (std::any_of(c.stack.begin(), c.stack.end(), [ctx = c.ctx, &value](JSValue& stackVal) -> bool { return JS_SameValueZero(ctx, stackVal, value) != 0; }))
+			{
+				// circular reference
+				throw std::runtime_error("Circular reference detected!");
+			}
 		}
 
 		nlohmann::json j;
 		c.stack.push_back(value);
 
-		if (WZ_QJS_IsArray(c.ctx, value))
+		if (c.tag_class_instances)
 		{
-			// Handle array
+			// Assign a reference id *before* recursing into children, so that cyclic or
+			// shared children become back-references to this object.
+			int id = c.nextRefId++;
+			c.refIds[JS_VALUE_GET_PTR(value)] = id;
+
+			j = nlohmann::json::object();
+			j[WZ_JSON_ID_KEY] = id;
+
+			if (isArray)
+			{
+				nlohmann::json data = nlohmann::json::array();
+				uint64_t length = 0;
+				if (QuickJS_GetArrayLength(c.ctx, value, length))
+				{
+					for (uint64_t k = 0; k < length; k++)
+					{
+						JSValue jsVal = JS_GetPropertyUint32(c.ctx, value, k);
+						data.push_back(wz_qjs_to_json(c, jsVal));
+						JS_FreeValue(c.ctx, jsVal);
+					}
+				}
+				j[WZ_JSON_TAG_KEY] = WZ_JSON_TAG_ARRAY;
+				j[WZ_JSON_DATA_KEY] = std::move(data);
+			}
+			else
+			{
+				std::string className = getSerializableClassName(c, value);
+				nlohmann::json data = nlohmann::json::object();
+				QuickJS_EnumerateObjectProperties(c.ctx, value, [&c, value, &data](const char *key, JSAtom &atom) {
+					JSValue jsVal = JS_GetProperty(c.ctx, value, atom);
+					std::string nameStr = key;
+					if (!JS_IsException(jsVal))
+					{
+						if (!JS_IsConstructor(c.ctx, jsVal))
+						{
+							data[nameStr] = wz_qjs_to_json(c, jsVal);
+						}
+						else if (!c.skip_constructors)
+						{
+							data[nameStr] = "<constructor>";
+						}
+					}
+					else
+					{
+						debug(LOG_INFO, "Got an exception trying to get the value of \"%s\"?", nameStr.c_str());
+					}
+					JS_FreeValue(c.ctx, jsVal);
+				}, false);
+				if (!className.empty())
+				{
+					j[WZ_JSON_TAG_KEY] = WZ_JSON_TAG_CLASS;
+					j[WZ_JSON_CLASS_KEY] = className;
+				}
+				else
+				{
+					j[WZ_JSON_TAG_KEY] = WZ_JSON_TAG_OBJECT;
+				}
+				j[WZ_JSON_DATA_KEY] = std::move(data);
+			}
+		}
+		else if (isArray)
+		{
+			// Legacy bare array
 			j = nlohmann::json::array();
 			uint64_t length = 0;
 			if (QuickJS_GetArrayLength(c.ctx, value, length))
@@ -3742,7 +4126,7 @@ nlohmann::json wz_qjs_to_json(JSToJsonContext &c, JSValue value)
 		}
 		else
 		{
-			// Handle actual objects
+			// Legacy bare object
 			j = nlohmann::json::object();
 			QuickJS_EnumerateObjectProperties(c.ctx, value, [&c, value, &j](const char *key, JSAtom &atom) {
 				JSValue jsVal = JS_GetProperty(c.ctx, value, atom);

--- a/src/quickjs_backend.cpp
+++ b/src/quickjs_backend.cpp
@@ -218,12 +218,32 @@ static const char* WZ_JSON_CLASS_KEY  = "@@class";  // class name (string)
 static const char* WZ_JSON_DATA_KEY   = "@@data";   // own data properties (object) / elements (array)
 static const char* WZ_JSON_ARR_KEY    = "@@arr";    // on a "ref": true if the target is an array
 static const char* WZ_JSON_VALUE_KEY  = "@@value";  // on a "number": "NaN" / "Infinity" / "-Infinity"
+static const char* WZ_JSON_PROPS_KEY  = "@@props";  // on an "array": named (non-index) own properties (object)
 
 // NOTE ON SAVE FORMAT COMPATIBILITY:
 // - When tagging is enabled (the save / restore path), *every* object and array is wrapped in a tag object
 //   carrying an "@@id", so that shared references and cycles of any kind round-trip correctly.
 // - Older saves wrote bare objects and arrays with no tags - the loader detects the absence of "@@wztype"
 //   and falls back to the legacy plain-object / plain-array decoding, so old saves continue to load.
+
+// True if `key` is a canonical array index string ("0", "1", ... - no leading zeros, and
+// strictly less than 2^32-1, the max array index). Such keys are array *elements* (already
+// captured in @@data). Everything else on an array (e.g. "length", "meta") is a named
+// property.
+static bool isCanonicalArrayIndexKey(const std::string& key)
+{
+	if (key.empty()) { return false; }
+	if (key == "0") { return true; }
+	if (key[0] < '1' || key[0] > '9') { return false; } // reject leading zero / non-digit
+	unsigned long long v = 0;
+	for (char ch : key)
+	{
+		if (ch < '0' || ch > '9') { return false; }
+		v = v * 10 + static_cast<unsigned long long>(ch - '0');
+		if (v >= 4294967295ULL) { return false; } // >= 2^32-1 -> not a valid array index
+	}
+	return true;
+}
 
 // Built-in global constructors that must never be treated as restorable script classes.
 static bool isBuiltinConstructorName(const std::string& name)
@@ -1132,6 +1152,17 @@ JSValue mapJsonToQuickJSValueWithContext(JsonToJSContext& c, const nlohmann::jso
 						populateObjectProperties(c, obj, *dataIt, prop_flags);
 					}
 				}
+
+				// Restore named (non-index) own properties attached to an array
+				if (isArray)
+				{
+					auto propsIt = instance.find(WZ_JSON_PROPS_KEY);
+					if (propsIt != instance.end() && propsIt->is_object())
+					{
+						populateObjectProperties(c, obj, *propsIt, prop_flags);
+					}
+				}
+
 				return obj;
 			}
 			// Unknown tag: fall through and treat as a legacy plain object.
@@ -4157,6 +4188,37 @@ nlohmann::json wz_qjs_to_json(JSToJsonContext &c, JSValue value)
 				}
 				j[WZ_JSON_TAG_KEY] = WZ_JSON_TAG_ARRAY;
 				j[WZ_JSON_DATA_KEY] = std::move(data);
+
+				// Preserve any *named* (non-index) own properties a script attached to the array (e.g. `arr.meta = ...`).
+				// The 0..length-1 elements above are skipped here ("length" is intrinsic), & own accessors can't be serialized.
+				nlohmann::json props = nlohmann::json::object();
+				QuickJS_EnumerateObjectProperties(c.ctx, value, [&c, value, &props](const char *key, JSAtom &atom) {
+					std::string nameStr = key;
+					if (nameStr == "length" || isCanonicalArrayIndexKey(nameStr)) { return; }
+					if (isOwnAccessorProperty(c.ctx, value, atom))
+					{
+						debug(LOG_SCRIPT, "Skipping own accessor property \"%s\" when saving script global: getter/setter closures cannot be serialized", key);
+						return;
+					}
+					JSValue jsVal = JS_GetProperty(c.ctx, value, atom);
+					if (!JS_IsException(jsVal))
+					{
+						if (!JS_IsConstructor(c.ctx, jsVal))
+						{
+							debug(LOG_SCRIPT, "Serializing named property \"%s\" attached to array", nameStr.c_str());
+							props[nameStr] = wz_qjs_to_json(c, jsVal);
+						}
+						else if (!c.skip_constructors)
+						{
+							props[nameStr] = "<constructor>";
+						}
+					}
+					JS_FreeValue(c.ctx, jsVal);
+				}, false);
+				if (!props.empty())
+				{
+					j[WZ_JSON_PROPS_KEY] = std::move(props);
+				}
 			}
 			else
 			{


### PR DESCRIPTION
Significantly improves problematic round-tripping (save/restore) of script-defined Class instances, shared object references, reference cycles, and non-finite numbers.

## Issues Addressed:

Several issues & limitations impacted the fidelity of script state save / restore in WZ:

- saveScriptGlobals() serialized each global to plain JSON, discarding script-defined global class prototypes
  (A `new Team()` restored as a plain Object with no methods and `instanceof Team === false`)

- Objects shared between two globals were duplicated on restore, breaking identity
  (Ex: endconditions.js's `teams` and `playersTeam`, which alias the same Team instances)

- Reference cycles were simply rejected, and the entire impacted global would be dropped from the save

- Non-finite numbers (`NaN`, `Infinity` or `-Infinity`) were previously lost across save/load (these should probably be avoided anyway in scripts, but fixing this was easy after the rest of the changes)

- Lack of visibility & logging, resulting in silent save / restore state corruption

## Details:

To fix these issues, we revise how serialization works in the save / restore path:

### 1. Every object & array is tagged+wrapped with an `"@@id"` so that shared identity and cycles of any kind round-trip:

- arrays  -> `{"@@wztype":"array","@@id":1,"@@data":[...]}`
- objects -> `{"@@wztype":"object","@@id":2,"@@data":{...}}`
- refs -> `{"@@wztype":"ref","@@id":1}` (+ `"@@arr":true` for arrays)

The reference id is assigned before recursing into children, so all reference cycles now serialize as a back-reference.

### 2. Script-defined global class instances are detected, wrapped with a "class" type and a "@@class" tag:

- classes -> `{"@@wztype":"class","@@id":N,"@@class":"Team","@@data":{...}}`

Restoration resolves the class constructor by name, re-attaches its prototype with `JS_SetPrototype` (without running the constructor), and populates the saved data.

> [!NOTE]
> Current limitation: Unknown/anonymous/non-global classes and built-ins are currently non-restorable, and degrade to plain objects.

### 3. Backwards-compatible with earlier saves & other conversion cases:

Loading detects tags per-node - values without `"@@wztype"` take the legacy plain-object / plain-array decoding, thus older saves (which wrote bare objects and arrays) continue to load unchanged.

The non-tagging path (debug snapshots / `mapJsonToQuickJSValue` value conversion) still emits bare JSON (and keeps the cycle guards).

### 4. Loading references / object instances is decode-order-agnostic:

Forward references create a placeholder of the correct kind (object or array, via `"@@arr"`) that the matching definition populates in-place, preserving shared identity regardless of load/decode order.

### 5. Non-finite numbers are encoded as a tagged value

- non-finite numbers -> `{"@@wztype":"number","@@value":"NaN"|"Infinity"|"-Infinity"}`

### 6. Preserve named (non-index) properties on saved arrays

Preserve any *named* (non-index) own properties a script attached to an array (example: `arr.meta = ...`)

### 7. Additional detections and logging of some unsupported / edge cases

Own accessor properties & built-in exotics that degrade to plain objects are logged so that script authors can easily catch known edge cases that could impact the fidelity of a script's state restoration.

----

## Follow-ups:

- Removing the need for `eventGameLoaded` to be utilized in more / all cases. (For example, this PR's fixes mean that `endconditions.js` should have its globals automatically & properly restored after saveload.)