### PR TITLE
Don't show transporter launch button in skirmish/multiplayer

### DIFF
--- a/src/transporter.cpp
+++ b/src/transporter.cpp
@@ -329,7 +329,13 @@ bool intAddTransporterLaunch(DROID *psDroid)
 {
 	UDWORD          capacity;
 
-	if (bMultiPlayer)
+	// The transporter launch button is a campaign-only reinforcement mechanic.
+	// Guard on game.type (a stable value) rather than only bMultiPlayer: mods
+	// wrap desync-unsafe script calls such as addDroid() in hackNetOff() /
+	// hackNetOn(), which temporarily sets bMultiPlayer = false. A transporter
+	// spawned inside that window would otherwise create this button (and set
+	// psCurrTransporter) in a skirmish/multiplayer game.
+	if (bMultiPlayer || game.type != LEVEL_TYPE::CAMPAIGN)
 	{
 		return true;
 	}


### PR DESCRIPTION
This can occur when a mod spawns a transporter like so:
```js
hackNetOff();
addDroid(player, x, y, "Transporter", "SuperTransportBody", "V-Tol", "", "", "NULL-VTOL-Transport-Turret");
hackNetOn();
```
... because `hackNetOff()` temporarily sets `bMultiPlayer = false`

test mod: [test.zip](https://github.com/user-attachments/files/29579278/test.zip)

- Fixes #4974

help from Claude Opus 4.8 xhigh