### PR TITLE
Fix desync caused by unordered derricks

### DIFF
--- a/src/qtscript.cpp
+++ b/src/qtscript.cpp
@@ -283,7 +283,7 @@ bool bInTutorial = false;
 // ----------------------------------------------------------
 
 Vector2i positions[MAX_PLAYERS];
-static std::unordered_set<uint16_t> derricks;
+static std::set<uint16_t> derricks;
 
 void scriptSetStartPos(int position, int x, int y)
 {
@@ -312,7 +312,6 @@ bool scriptInit()
 		scriptSetStartPos(i, 0, 0);
 	}
 	derricks.clear();
-	derricks.reserve(8 * MAX_PLAYERS);
 	return true;
 }
 


### PR DESCRIPTION
test mod [multiplay.zip](https://github.com/user-attachments/files/29583035/multiplay.zip)

4.7.0

```js
namespace("debug_");

function debug_eventChat()
{
	addStructure("A0ResourceExtractor", 0, derrickPositions[0].x*128, derrickPositions[0].y*128);
}
```