### PR TITLE
Add ray-traced sun shadows (Vulkan ray query)

### DIFF
--- a/data/CMakeLists.txt
+++ b/data/CMakeLists.txt
@@ -132,28 +132,92 @@ file(GLOB VK_SHADERS
 	"${CMAKE_CURRENT_SOURCE_DIR}/base/shaders/vk/world_to_screen.frag"
 )
 
+if(NOT GLSLC)
+	# Fall back to glslangValidator (ships with many distros / the Vulkan SDK)
+	find_program( GLSLANG_VALIDATOR "glslangValidator"
+				  PATHS "$ENV{VULKAN_SDK}/bin"
+	)
+endif()
+
+# _wz_add_vk_shader_compile_command(<shader source path> <output dir> <output var for output file>
+#                                   TARGET_ENV <vulkan1.0|vulkan1.2> [OUTPUT_NAME <name.spv>] [DEFINES <MACRO=VALUE>...])
+function(_wz_add_vk_shader_compile_command SHADER _output_dir _outputfile_var)
+	set(_options)
+	set(_oneValueArgs TARGET_ENV OUTPUT_NAME)
+	set(_multiValueArgs DEFINES)
+	cmake_parse_arguments(PARSE_ARGV 3 "shdr" "${_options}" "${_oneValueArgs}" "${_multiValueArgs}")
+	if(NOT DEFINED shdr_TARGET_ENV)
+		set(shdr_TARGET_ENV "vulkan1.0")
+	endif()
+	get_filename_component(SHADER_FILE ${SHADER} NAME)
+	if(DEFINED shdr_OUTPUT_NAME)
+		set(_output_name "${shdr_OUTPUT_NAME}")
+	else()
+		set(_output_name "${SHADER_FILE}.spv")
+	endif()
+	set(_define_args)
+	foreach(_define ${shdr_DEFINES})
+		list(APPEND _define_args "-D${_define}")
+	endforeach()
+	if(GLSLC)
+		set(_compile_command "${GLSLC}")
+		set(_compile_args "-c" "${SHADER}" "--target-env=${shdr_TARGET_ENV}" ${_define_args} "-o" "${_output_dir}/${_output_name}")
+	else()
+		set(_compile_command "${GLSLANG_VALIDATOR}")
+		# glslangValidator requires the include directive extension to be explicitly enabled
+		set(_compile_args "-V" "-P#extension GL_GOOGLE_include_directive : enable" "--target-env" "${shdr_TARGET_ENV}" ${_define_args} "${SHADER}" "-o" "${_output_dir}/${_output_name}")
+	endif()
+	add_custom_command(OUTPUT "${_output_dir}/${_output_name}"
+		COMMAND "${_compile_command}"
+		ARGS ${_compile_args}
+		WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/base/shaders/vk"
+		DEPENDS "${SHADER}"
+		VERBATIM
+	)
+	set(${_outputfile_var} "${_output_dir}/${_output_name}" PARENT_SCOPE)
+endfunction()
+
 set(SHADER_LIST "")
-if(GLSLC)
-	message(STATUS "Found glslc: ${GLSLC}")
+if(GLSLC OR GLSLANG_VALIDATOR)
+	if(GLSLC)
+		message(STATUS "Found glslc: ${GLSLC}")
+	else()
+		message(STATUS "Found glslangValidator: ${GLSLANG_VALIDATOR}")
+	endif()
 	set(_output_dir "${CMAKE_CURRENT_BINARY_DIR}/base/shaders/vk")
 	file(MAKE_DIRECTORY "${_output_dir}")
 	foreach(SHADER ${VK_SHADERS})
-		get_filename_component(SHADER_FILE_PATH ${SHADER} DIRECTORY)
-		get_filename_component(SHADER_FILE ${SHADER} NAME)
-		set(_output_name "${SHADER_FILE}.spv")
-		add_custom_command(OUTPUT "${_output_dir}/${_output_name}"
-			COMMAND "${GLSLC}"
-			ARGS "-c" "${SHADER}" "-o" "${_output_dir}/${_output_name}"
-			WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/base/shaders/vk"
-			DEPENDS "${SHADER}"
-			VERBATIM
-		)
-		list(APPEND SHADER_LIST "${_output_dir}/${_output_name}")
+		_wz_add_vk_shader_compile_command("${SHADER}" "${_output_dir}" _shader_output_file TARGET_ENV "vulkan1.0")
+		list(APPEND SHADER_LIST "${_shader_output_file}")
+	endforeach()
+	# Ray-query (ray-traced shadows) shaders require SPIR-V >= 1.4, hence target env vulkan1.2
+	set(VK_SHADERS_RAYQUERY
+		"${CMAKE_CURRENT_SOURCE_DIR}/base/shaders/vk/rayshadow_fullscreen.vert"
+		"${CMAKE_CURRENT_SOURCE_DIR}/base/shaders/vk/rayshadow_mask.frag"
+		"${CMAKE_CURRENT_SOURCE_DIR}/base/shaders/vk/rayshadow_blur.frag"
+	)
+	foreach(SHADER ${VK_SHADERS_RAYQUERY})
+		_wz_add_vk_shader_compile_command("${SHADER}" "${_output_dir}" _shader_output_file TARGET_ENV "vulkan1.2")
+		list(APPEND SHADER_LIST "${_shader_output_file}")
+	endforeach()
+	# Ray-query variants of material shaders (ray-traced point-light shadows / reflection occlusion),
+	# compiled from the same sources with WZ_RAYQUERY_SHADERS=1; selected at pipeline-build time
+	# when ray-traced shadows are active
+	set(VK_SHADERS_RAYQUERY_VARIANTS
+		"tcmask_instanced.frag"
+		"terrain_combined_high.frag"
+		"terrain_water_high.frag"
+	)
+	foreach(SHADER_NAME ${VK_SHADERS_RAYQUERY_VARIANTS})
+		string(REPLACE ".frag" "_rq.frag.spv" _rq_output_name "${SHADER_NAME}")
+		_wz_add_vk_shader_compile_command("${CMAKE_CURRENT_SOURCE_DIR}/base/shaders/vk/${SHADER_NAME}" "${_output_dir}" _shader_output_file
+			TARGET_ENV "vulkan1.2" OUTPUT_NAME "${_rq_output_name}" DEFINES "WZ_RAYQUERY_SHADERS=1")
+		list(APPEND SHADER_LIST "${_shader_output_file}")
 	endforeach()
 	add_custom_target(glsl_compilation DEPENDS ${SHADER_LIST})
 	set_property(TARGET glsl_compilation PROPERTY FOLDER "data")
 else()
-	message(STATUS "Unable to find glslc")
+	message(STATUS "Unable to find glslc or glslangValidator")
 endif()
 
 set(_glsl_generatedfiles_PATHS)

--- a/data/base/shaders/vk/pointlights.glsl
+++ b/data/base/shaders/vk/pointlights.glsl
@@ -1,3 +1,28 @@
+// Ray-traced point-light shadow: 1.0 = unoccluded, 0.0 = shadowed.
+// Only available in the ray-query shader variants (requires the wzTopLevelAS declaration).
+float wzPointLightOcclusion(vec3 fragWorldPos, vec3 lightWorldPos)
+{
+#if WZ_RAYQUERY_SHADERS
+	vec3 v = lightWorldPos - fragWorldPos;
+	float dist = length(v);
+	if (dist < 16.0)
+	{
+		return 1.0; // fragment is essentially at the light
+	}
+	vec3 dir = v / dist;
+	rayQueryEXT rayQuery;
+	// offset the origin along the ray (we may not have a world-space normal here), and stop
+	// short of the light so emitter geometry (muzzles, lamps) doesn't shadow its own light
+	rayQueryInitializeEXT(rayQuery, wzTopLevelAS,
+						  gl_RayFlagsTerminateOnFirstHitEXT | gl_RayFlagsOpaqueEXT,
+						  0xFF, fragWorldPos + dir * 4.0, 0.0, dir, max(dist - 24.0, 0.0));
+	rayQueryProceedEXT(rayQuery);
+	return (rayQueryGetIntersectionTypeEXT(rayQuery, true) == gl_RayQueryCommittedIntersectionNoneEXT) ? 1.0 : 0.0;
+#else
+	return 1.0;
+#endif
+}
+
 // See https://lisyarus.github.io/blog/graphics/2022/07/30/point-light-attenuation.html for explanation
 // we want something that looks somewhat physically correct, but must absolutely be 0 past range
 float pointLightEnergyAtPosition(vec3 pointLightVector, float range)
@@ -49,7 +74,18 @@ vec4 iterateOverAllPointLights(
 		vec4 position = PointLightsPosition[lightIndex];
 		vec4 colorAndEnergy = PointLightsColorAndEnergy[lightIndex];
 		vec3 tmp = position.xyz * vec3(1., 1., -1.);
-		light += processPointLight(WorldFragPos, fragNormal, viewVector, albedo, gloss, tmp, colorAndEnergy.w, colorAndEnergy.xyz, spaceMatrix);
+		// skip the (expensive) shadow ray entirely for lights whose energy at this fragment
+		// is zero or negligible - the attenuation is hard-zero past the light's range
+		float energy = pointLightEnergyAtPosition(tmp - WorldFragPos, colorAndEnergy.w);
+		if (energy <= 0.004)
+		{
+			continue;
+		}
+		float occlusion = wzPointLightOcclusion(WorldFragPos, tmp);
+		if (occlusion > 0.0)
+		{
+			light += occlusion * processPointLight(WorldFragPos, fragNormal, viewVector, albedo, gloss, tmp, colorAndEnergy.w, colorAndEnergy.xyz, spaceMatrix);
+		}
 	}
 	return light;
 }

--- a/data/base/shaders/vk/rayshadow_blur.frag
+++ b/data/base/shaders/vk/rayshadow_blur.frag
@@ -1,0 +1,59 @@
+#version 460
+
+// Depth-aware separable Gaussian blur for the ray-traced shadow/AO mask (RG).
+// Run twice (horizontal then vertical) to soften the low-sample-count trace results.
+
+layout(set = 0, binding = 0) uniform sampler2D maskTexture;
+layout(set = 0, binding = 1) uniform sampler2D depthTexture;
+
+layout(push_constant) uniform PushConstants
+{
+	vec4 dirAndInvSize; // xy = blur direction (in texels), zw = 1 / mask texture size
+	vec4 params;        // x = relative view-depth rejection threshold (e.g. 0.08 = 8%)
+};
+
+// camera near/far planes (must match pie_PerspectiveGet, lib/ivis_opengl/piematrix.cpp)
+const float WZ_ZNEAR = 330.0;
+const float WZ_ZFAR = 45000.0;
+
+float linearizeDepth(float d)
+{
+	// GL-convention depth remapped by the engine's z=(z+w)/2 fixup
+	float zNdc = 2.0 * d - 1.0;
+	return (2.0 * WZ_ZNEAR * WZ_ZFAR) / (WZ_ZFAR + WZ_ZNEAR - zNdc * (WZ_ZFAR - WZ_ZNEAR));
+}
+
+layout(location = 0) in vec2 texCoords;
+layout(location = 0) out vec2 result;
+
+const float WEIGHTS[3] = float[](0.2270270270, 0.3162162162, 0.0702702703);
+const float OFFSETS[3] = float[](0.0, 1.3846153846, 3.2307692308);
+
+// the camera depth prepass is rendered without the engine's Vulkan y-flip; flip v to match
+// the (screen-oriented) mask
+float sampleSceneDepth(vec2 uv)
+{
+	return texture(depthTexture, vec2(uv.x, 1.0 - uv.y)).r;
+}
+
+void main()
+{
+	vec2 texelDir = dirAndInvSize.xy * dirAndInvSize.zw;
+	float centerZ = linearizeDepth(sampleSceneDepth(texCoords));
+	vec2 total = texture(maskTexture, texCoords).rg * WEIGHTS[0];
+	float totalWeight = WEIGHTS[0];
+	for (int i = 1; i < 3; ++i)
+	{
+		for (int s = -1; s <= 1; s += 2)
+		{
+			vec2 uv = texCoords + texelDir * (OFFSETS[i] * float(s));
+			float sampleZ = linearizeDepth(sampleSceneDepth(uv));
+			// reject samples across depth discontinuities (silhouettes) - relative view-space
+			// threshold so smooth slopes keep full weights at any distance
+			float w = WEIGHTS[i] * max(0.0, 1.0 - abs(sampleZ - centerZ) / (params.x * centerZ));
+			total += texture(maskTexture, uv).rg * w;
+			totalWeight += w;
+		}
+	}
+	result = total / max(totalWeight, 0.0001);
+}

--- a/data/base/shaders/vk/rayshadow_fullscreen.vert
+++ b/data/base/shaders/vk/rayshadow_fullscreen.vert
@@ -1,0 +1,12 @@
+#version 460
+
+// Fullscreen triangle (no vertex buffer required)
+
+layout(location = 0) out vec2 texCoords;
+
+void main()
+{
+	vec2 pos = vec2(float((gl_VertexIndex << 1) & 2), float(gl_VertexIndex & 2));
+	texCoords = pos;
+	gl_Position = vec4(pos * 2.0 - 1.0, 0.0, 1.0);
+}

--- a/data/base/shaders/vk/rayshadow_mask.frag
+++ b/data/base/shaders/vk/rayshadow_mask.frag
@@ -1,0 +1,180 @@
+#version 460
+#extension GL_EXT_ray_query : require
+
+// Ray-traced sun-shadow + ambient-occlusion mask pass.
+// Casts one cone-jittered ray toward the sun (soft shadows) plus a few short cosine-hemisphere
+// rays (contact shadows / AO) per pixel, using the camera depth prepass to reconstruct world
+// positions. Output: R = sun visibility (1 = lit), G = ambient occlusion (1 = open sky).
+
+layout(set = 0, binding = 0) uniform accelerationStructureEXT topLevelAS;
+layout(set = 0, binding = 1) uniform sampler2D depthTexture;
+
+layout(push_constant) uniform PushConstants
+{
+	mat4 invProjectionView; // inverse of the GL-convention projection * view matrix
+	vec4 sunDirection;      // xyz = normalized direction toward the sun (world space)
+	vec4 cameraPosition;    // xyz = camera position (world space)
+	vec4 params;            // x = ray tMin, y = ray tMax, z = normal offset scale, w = sun cone angle (radians)
+	vec4 aoParams;          // x = AO ray count, y = AO max distance, z = AO strength, w = unused
+};
+
+layout(location = 0) in vec2 texCoords;
+layout(location = 0) out vec2 visibility;
+
+// NOTE on orientation: the engine's depth-only vertex shaders intentionally do NOT apply the
+// Vulkan y-flip (the cascade shadow-map sampling convention depends on that), so the camera
+// depth prepass image is vertically mirrored relative to screen orientation. Flip v here.
+float sampleSceneDepth(vec2 uv)
+{
+	return texture(depthTexture, vec2(uv.x, 1.0 - uv.y)).r;
+}
+
+vec3 reconstructWorldPos(vec2 uv, float depth)
+{
+	// Undo the engine's clip-space z remap (gl_Position.z = (z + w) / 2), then unproject with
+	// the GL-convention inverse projection-view matrix. The depth prepass rasterizes WITHOUT
+	// the y-flip, so after the v-flip in sampleSceneDepth our uv is already screen-oriented:
+	// screen v = (1 - gl_ndc.y) / 2  =>  gl_ndc.y = 1 - 2 * v.
+	vec4 clip = vec4(uv.x * 2.0 - 1.0, 1.0 - 2.0 * uv.y, 2.0 * depth - 1.0, 1.0);
+	vec4 world = invProjectionView * clip;
+	return world.xyz / world.w;
+}
+
+// Interleaved gradient noise - stable per-pixel randomization (no temporal accumulation)
+float interleavedGradientNoise(vec2 pixel)
+{
+	return fract(52.9829189 * fract(dot(pixel, vec2(0.06711056, 0.00583715))));
+}
+
+mat3 buildBasis(vec3 n)
+{
+	vec3 up = (abs(n.y) < 0.99) ? vec3(0.0, 1.0, 0.0) : vec3(1.0, 0.0, 0.0);
+	vec3 t = normalize(cross(up, n));
+	vec3 b = cross(n, t);
+	return mat3(t, b, n);
+}
+
+bool traceOcclusion(vec3 origin, vec3 dir, float tMin, float tMax)
+{
+	rayQueryEXT rayQuery;
+	rayQueryInitializeEXT(rayQuery, topLevelAS,
+						  gl_RayFlagsTerminateOnFirstHitEXT | gl_RayFlagsOpaqueEXT,
+						  0xFF, origin, tMin, dir, tMax);
+	rayQueryProceedEXT(rayQuery);
+	return rayQueryGetIntersectionTypeEXT(rayQuery, true) != gl_RayQueryCommittedIntersectionNoneEXT;
+}
+
+void main()
+{
+	float depth = sampleSceneDepth(texCoords);
+	if (depth >= 1.0)
+	{
+		visibility = vec2(1.0, 1.0); // sky / no geometry
+		return;
+	}
+
+	vec3 worldPos = reconstructWorldPos(texCoords, depth);
+
+	// Reconstruct the surface normal from the depth buffer using one-sided differences,
+	// picking per axis whichever neighbor has the smaller depth delta. Unlike dFdx/dFdy
+	// (which straddle face boundaries and silhouettes, producing invalid normals on
+	// small or detailed geometry), this stays on the same surface at edges.
+	vec2 texel = 1.0 / vec2(textureSize(depthTexture, 0));
+	float dL = sampleSceneDepth(texCoords - vec2(texel.x, 0.0));
+	float dR = sampleSceneDepth(texCoords + vec2(texel.x, 0.0));
+	float dU = sampleSceneDepth(texCoords - vec2(0.0, texel.y));
+	float dD = sampleSceneDepth(texCoords + vec2(0.0, texel.y));
+	vec3 ddx = (abs(dR - depth) <= abs(dL - depth))
+		? (reconstructWorldPos(texCoords + vec2(texel.x, 0.0), dR) - worldPos)
+		: (worldPos - reconstructWorldPos(texCoords - vec2(texel.x, 0.0), dL));
+	vec3 ddy = (abs(dD - depth) <= abs(dU - depth))
+		? (reconstructWorldPos(texCoords + vec2(0.0, texel.y), dD) - worldPos)
+		: (worldPos - reconstructWorldPos(texCoords - vec2(0.0, texel.y), dU));
+	vec3 geomNormal = cross(ddx, ddy);
+	float normalLen = length(geomNormal);
+	geomNormal = (normalLen > 0.0001) ? (geomNormal / normalLen) : vec3(0.0, 1.0, 0.0);
+	// enforce camera-facing orientation (the cross product's sign depends on winding)
+	if (dot(geomNormal, cameraPosition.xyz - worldPos) < 0.0)
+	{
+		geomNormal = -geomNormal;
+	}
+
+	float noise = interleavedGradientNoise(gl_FragCoord.xy);
+
+	// --- sun shadow: one ray, jittered within the sun's angular cone for penumbra ---
+	// Always trace (no backface early-out): the reconstructed face normal is noisier than
+	// the smooth shading normals used by the lighting shaders, and a hard zero at its
+	// terminator would bleed through the blur onto lit neighbors. Genuinely self-shadowed
+	// surfaces block their own ray and return 0 at the geometrically correct boundary.
+	float sunNdotL = dot(geomNormal, sunDirection.xyz);
+	// slope-scaled origin offset (the ray-traced equivalent of shadow-map slope bias),
+	// pushed out on the sun-facing side of the surface
+	vec3 sunSideNormal = (sunNdotL < 0.0) ? -geomNormal : geomNormal;
+	float slopeScale = clamp(1.0 / max(abs(sunNdotL), 0.2), 1.0, 5.0);
+	vec3 origin = worldPos + sunSideNormal * (params.z * slopeScale);
+
+	float coneAngle = params.w;
+	vec3 sunDir = sunDirection.xyz;
+	if (coneAngle > 0.0)
+	{
+		mat3 sunBasis = buildBasis(sunDir);
+		float r = sqrt(noise) * tan(coneAngle);
+		float phi = 6.2831853 * interleavedGradientNoise(gl_FragCoord.yx + vec2(17.0, 59.0));
+		sunDir = normalize(sunBasis * vec3(r * cos(phi), r * sin(phi), 1.0));
+	}
+
+	visibility.r = traceOcclusion(origin, sunDir, params.x, params.y) ? 0.0 : 1.0;
+
+	// --- ambient occlusion / contact shadows: a fixed, deterministic cone of rays around the
+	// surface normal, anchored to a world-space frame. No stochastic sampling: random hemisphere
+	// rays are highly divergent (slow on some GPUs) and produce screen-anchored noise that
+	// "swims" when the camera scrolls. A deterministic pattern is noise-free and coherent.
+	int aoRayCount = int(aoParams.x);
+	if (aoRayCount > 0)
+	{
+		// world-space tangent frame around the normal (stable under camera movement)
+		vec3 tangentSeed = (abs(geomNormal.y) < 0.99) ? vec3(0.0, 1.0, 0.0) : vec3(1.0, 0.0, 0.0);
+		vec3 tangent = normalize(cross(tangentSeed, geomNormal));
+		vec3 bitangent = cross(geomNormal, tangent);
+
+		vec3 aoOrigin = worldPos + geomNormal * (params.z * 2.0);
+		const float CONE_TILT = 0.7; // ~45 degrees off the normal - catches walls and overhangs
+		float occlusion = 0.0;
+		float totalWeight = 0.0;
+		for (int i = 0; i < aoRayCount; ++i)
+		{
+			vec3 dir;
+			if (i < 3)
+			{
+				// three rays tilted around the normal at fixed 120-degree azimuths
+				float phi = 2.0943951 * float(i); // 2*pi/3
+				dir = normalize(geomNormal + (tangent * cos(phi) + bitangent * sin(phi)) * CONE_TILT);
+			}
+			else
+			{
+				dir = geomNormal; // optional 4th ray straight along the normal
+			}
+			rayQueryEXT aoQuery;
+			rayQueryInitializeEXT(aoQuery, topLevelAS, gl_RayFlagsTerminateOnFirstHitEXT | gl_RayFlagsOpaqueEXT, 0xFF,
+								  aoOrigin, params.x * 2.0, dir, aoParams.y);
+			rayQueryProceedEXT(aoQuery);
+			if (rayQueryGetIntersectionTypeEXT(aoQuery, true) != gl_RayQueryCommittedIntersectionNoneEXT)
+			{
+				// distance-weighted: contact-range hits occlude fully, farther hits fade out
+				float hitT = rayQueryGetIntersectionTEXT(aoQuery, true);
+				occlusion += 1.0 - clamp(hitT / aoParams.y, 0.0, 1.0);
+			}
+			totalWeight += 1.0;
+		}
+		// fade AO out on vertical surfaces: contact shadows belong primarily on up-facing
+		// surfaces (walls otherwise accumulate occlusion from the ground plane)
+		float upFacing = clamp(geomNormal.y, 0.0, 1.0);
+		float aoStrength = aoParams.z * mix(0.25, 1.0, upFacing);
+		float ao = 1.0 - (occlusion / max(totalWeight, 1.0)) * aoStrength;
+		visibility.g = clamp(ao, 0.0, 1.0);
+	}
+	else
+	{
+		visibility.g = 1.0;
+	}
+}

--- a/data/base/shaders/vk/shadow_mapping.glsl
+++ b/data/base/shaders/vk/shadow_mapping.glsl
@@ -6,8 +6,37 @@ float getShadowMapDepthComp(vec2 base_uv, float u, float v, vec2 shadowMapSizeIn
 	return texture( shadowMap, vec4(uv, cascadeIndex, z) );
 }
 
+// Ray-traced ambient occlusion (contact shadows) - stored in the mask's green channel.
+// Returns 1.0 (no occlusion) when ray-traced shadows are inactive.
+float getRayAmbientOcclusion()
+{
+	if (WZ_RAY_SHADOWS == 1)
+	{
+		vec2 uv = gl_FragCoord.xy / vec2(viewportWidth, viewportHeight);
+		return texture(rayShadowMask, uv).g;
+	}
+	// modes 2/3 are channel-isolation debug views handled in getShadowVisibility
+	return 1.0;
+}
+
 float getShadowVisibility(vec3 fragPosModelSpace, vec3 fragPosViewSpace, float NdotL, float offset)
 {
+	if (WZ_RAY_SHADOWS >= 1)
+	{
+		// ray-traced sun shadows: sample the screen-space visibility mask instead of the shadow map
+		vec2 uv = gl_FragCoord.xy / vec2(viewportWidth, viewportHeight);
+		vec2 rayMask = texture(rayShadowMask, uv).rg;
+		if (WZ_RAY_SHADOWS == 2)
+		{
+			return rayMask.r; // debug: raw sun-shadow channel, no visibility floor
+		}
+		if (WZ_RAY_SHADOWS == 3)
+		{
+			return rayMask.g; // debug: raw ambient-occlusion channel
+		}
+		// same visibility floor as the shadow-mapping path below
+		return clamp(rayMask.r, 0.5, 1.0);
+	}
 	if (WZ_SHADOW_MODE == 0 || WZ_SHADOW_FILTER_SIZE == 0)
 	{
 		// no shadow-mapping

--- a/data/base/shaders/vk/tcmask_instanced.frag
+++ b/data/base/shaders/vk/tcmask_instanced.frag
@@ -1,5 +1,8 @@
-#version 450
+#version 460
 //#pragma debug(on)
+#if WZ_RAYQUERY_SHADERS
+#extension GL_EXT_ray_query : require
+#endif
 
 #include "tcmask_instanced.glsl"
 
@@ -8,6 +11,7 @@ layout (constant_id = 1) const uint WZ_SHADOW_MODE = 1;
 layout (constant_id = 2) const uint WZ_SHADOW_FILTER_SIZE = 5;
 layout (constant_id = 3) const uint WZ_SHADOW_CASCADES_COUNT = 3;
 layout (constant_id = 4) const uint WZ_POINT_LIGHT_ENABLED = 0;
+layout (constant_id = 5) const uint WZ_RAY_SHADOWS = 0;
 
 layout(set = 2, binding = 0) uniform sampler2D Texture; // diffuse
 layout(set = 2, binding = 1) uniform sampler2D TextureTcmask; // tcmask
@@ -15,6 +19,10 @@ layout(set = 2, binding = 2) uniform sampler2D TextureNormal; // normal map
 layout(set = 2, binding = 3) uniform sampler2D TextureSpecular; // specular map
 layout(set = 2, binding = 4) uniform sampler2DArrayShadow shadowMap; // shadow map
 layout(set = 2, binding = 5) uniform sampler2D lightmap_tex;
+layout(set = 2, binding = 6) uniform sampler2D rayShadowMask; // ray-traced shadow visibility mask
+#if WZ_RAYQUERY_SHADERS
+layout(set = 3, binding = 0) uniform accelerationStructureEXT wzTopLevelAS;
+#endif
 
 layout(location = 0) in vec3 normal;
 layout(location = 1) in vec3 lightDir;
@@ -122,7 +130,7 @@ void main()
 
 	vec4 ambientLight = vec4(blendAddEffectLighting(ambient.rgb, ((lightmap_vec4.rgb * lightmapFactor) / 3.f)), ambient.a) * diffuseMap;
 	// ambient light maxed for classic models to keep results similar to original
-	light += ambientLight * (1.0 + (1.0 - float(specularmap))) * visibility;
+	light += ambientLight * (1.0 + (1.0 - float(specularmap))) * max(visibility * getRayAmbientOcclusion(), 0.5); // joint floor: shadow+AO never remove more than half of ambient
 
 	if (WZ_POINT_LIGHT_ENABLED == 1)
 	{

--- a/data/base/shaders/vk/terrain_combined_classic.frag
+++ b/data/base/shaders/vk/terrain_combined_classic.frag
@@ -6,6 +6,7 @@ layout (constant_id = 0) const float WZ_MIP_LOAD_BIAS = 0.f;
 layout (constant_id = 1) const uint WZ_SHADOW_MODE = 1;
 layout (constant_id = 2) const uint WZ_SHADOW_FILTER_SIZE = 5;
 layout (constant_id = 3) const uint WZ_SHADOW_CASCADES_COUNT = 3;
+layout (constant_id = 5) const uint WZ_RAY_SHADOWS = 0;
 
 layout(set = 1, binding = 0) uniform sampler2D lightmap_tex;
 
@@ -23,6 +24,7 @@ layout(set = 1, binding = 8) uniform sampler2DArray decalHeight;
 
 // depth map
 layout(set = 1, binding = 9) uniform sampler2DArrayShadow shadowMap;
+layout(set = 1, binding = 10) uniform sampler2D rayShadowMask; // ray-traced shadow visibility mask
 
 layout(location = 0) in FragData frag;
 layout(location = 10) flat in FragFlatData fragf;
@@ -45,7 +47,7 @@ vec4 main_classic() {
 	float visibility = getShadowVisibility(frag.posModelSpace, frag.posViewSpace, diffuseFactor, 0.001f);
 
 	vec4 lightmap_vec4 = texture(lightmap_tex, frag.uvLightmap);
-	vec4 light = (visibility*diffuseLight*0.75*diffuseFactor + ambientLight*0.25) * lightmap_vec4.a; // ... * tile brightness / ambient occlusion (stored in lightmap.a);
+	vec4 light = (visibility*diffuseLight*0.75*diffuseFactor + ambientLight*0.25*mix(1.0, getRayAmbientOcclusion(), 0.5)) * lightmap_vec4.a; // lightmap.a already bakes AO - apply ray AO at half strength // ... * tile brightness / ambient occlusion (stored in lightmap.a);
 	light.rgb = blendAddEffectLighting(light.rgb, (lightmap_vec4.rgb / 1.5f)); // additive color (from environmental point lights / effects)
 	light.a = 1.f;
 

--- a/data/base/shaders/vk/terrain_combined_high.frag
+++ b/data/base/shaders/vk/terrain_combined_high.frag
@@ -1,4 +1,7 @@
-#version 450
+#version 460
+#if WZ_RAYQUERY_SHADERS
+#extension GL_EXT_ray_query : require
+#endif
 
 #include "terrain_combined.glsl"
 
@@ -7,6 +10,7 @@ layout (constant_id = 1) const uint WZ_SHADOW_MODE = 1;
 layout (constant_id = 2) const uint WZ_SHADOW_FILTER_SIZE = 5;
 layout (constant_id = 3) const uint WZ_SHADOW_CASCADES_COUNT = 3;
 layout (constant_id = 4) const uint WZ_POINT_LIGHT_ENABLED = 0;
+layout (constant_id = 5) const uint WZ_RAY_SHADOWS = 0;
 
 layout(set = 1, binding = 0) uniform sampler2D lightmap_tex;
 
@@ -24,6 +28,10 @@ layout(set = 1, binding = 8) uniform sampler2DArray decalHeight;
 
 // depth map
 layout(set = 1, binding = 9) uniform sampler2DArrayShadow shadowMap;
+layout(set = 1, binding = 10) uniform sampler2D rayShadowMask; // ray-traced shadow visibility mask
+#if WZ_RAYQUERY_SHADERS
+layout(set = 2, binding = 0) uniform accelerationStructureEXT wzTopLevelAS;
+#endif
 
 layout(location = 0) in FragData frag;
 layout(location = 10) flat in FragFlatData fragf;
@@ -72,7 +80,7 @@ vec4 doBumpMapping(BumpData b, vec3 groundLightDir, vec3 groundHalfVec) {
 
 	float adjustedTileBrightness = pow(lightmap_vec4.a, 2.f-lightmap_vec4.a); // ... * tile brightness / ambient occlusion (stored in lightmap.a)
 
-	vec4 adjustedAmbientLight = ambientLight * adjustedTileBrightness;
+	vec4 adjustedAmbientLight = ambientLight * min(adjustedTileBrightness, getRayAmbientOcclusion()); // lightmap.a already bakes tile AO - take the stronger of the two, don't stack them
 	vec4 light = adjustedAmbientLight + diffuseLight * diffuseFactor;
 	light.rgb = blendAddEffectLighting(light.rgb, (lightmap_vec4.rgb / 1.4f)); // additive color (from environmental point lights / effects)
 

--- a/data/base/shaders/vk/terrain_combined_medium.frag
+++ b/data/base/shaders/vk/terrain_combined_medium.frag
@@ -6,6 +6,7 @@ layout (constant_id = 0) const float WZ_MIP_LOAD_BIAS = 0.f;
 layout (constant_id = 1) const uint WZ_SHADOW_MODE = 1;
 layout (constant_id = 2) const uint WZ_SHADOW_FILTER_SIZE = 5;
 layout (constant_id = 3) const uint WZ_SHADOW_CASCADES_COUNT = 3;
+layout (constant_id = 5) const uint WZ_RAY_SHADOWS = 0;
 
 layout(set = 1, binding = 0) uniform sampler2D lightmap_tex;
 
@@ -23,6 +24,7 @@ layout(set = 1, binding = 8) uniform sampler2DArray decalHeight;
 
 // depth map
 layout(set = 1, binding = 9) uniform sampler2DArrayShadow shadowMap;
+layout(set = 1, binding = 10) uniform sampler2D rayShadowMask; // ray-traced shadow visibility mask
 
 layout(location = 0) in FragData frag;
 layout(location = 10) flat in FragFlatData fragf;
@@ -56,7 +58,7 @@ vec4 main_medium() {
 	float visibility = getShadowVisibility(frag.posModelSpace, frag.posViewSpace, diffuseFactor, 0.001f);
 
 	vec4 lightmap_vec4 = texture(lightmap_tex, frag.uvLightmap);
-	vec4 light = (visibility*diffuseLight*0.8*(diffuseFactor*diffuseFactor) + ambientLight*0.2) * lightmap_vec4.a; // ... * tile brightness / ambient occlusion (stored in lightmap.a)
+	vec4 light = (visibility*diffuseLight*0.8*(diffuseFactor*diffuseFactor) + ambientLight*0.2*mix(1.0, getRayAmbientOcclusion(), 0.5)) * lightmap_vec4.a; // lightmap.a already bakes AO - apply ray AO at half strength // ... * tile brightness / ambient occlusion (stored in lightmap.a)
 	light.rgb = blendAddEffectLighting(light.rgb, (lightmap_vec4.rgb / 1.5f)); // additive color (from environmental point lights / effects)
 	light.a = 1.f;
 

--- a/data/base/shaders/vk/terrain_water_high.frag
+++ b/data/base/shaders/vk/terrain_water_high.frag
@@ -1,4 +1,7 @@
-#version 450
+#version 460
+#if WZ_RAYQUERY_SHADERS
+#extension GL_EXT_ray_query : require
+#endif
 
 #include "terrain_water_high.glsl"
 
@@ -6,6 +9,7 @@ layout (constant_id = 0) const float WZ_MIP_LOAD_BIAS = 0.f;
 layout (constant_id = 1) const uint WZ_SHADOW_MODE = 1;
 layout (constant_id = 2) const uint WZ_SHADOW_FILTER_SIZE = 5;
 layout (constant_id = 3) const uint WZ_SHADOW_CASCADES_COUNT = 3;
+layout (constant_id = 5) const uint WZ_RAY_SHADOWS = 0;
 
 layout(set = 1, binding = 0) uniform sampler2DArray tex;
 layout(set = 1, binding = 1) uniform sampler2DArray tex_nm;
@@ -13,6 +17,10 @@ layout(set = 1, binding = 2) uniform sampler2DArray tex_sm;
 layout(set = 1, binding = 3) uniform sampler2D lightmap_tex;
 // depth map
 layout(set = 1, binding = 4) uniform sampler2DArrayShadow shadowMap;
+layout(set = 1, binding = 5) uniform sampler2D rayShadowMask; // ray-traced shadow visibility mask
+#if WZ_RAYQUERY_SHADERS
+layout(set = 2, binding = 0) uniform accelerationStructureEXT wzTopLevelAS;
+#endif
 
 layout(location = 1) in vec4 uv1_uv2;
 layout(location = 2) in vec2 uvLightmap;
@@ -67,13 +75,35 @@ vec4 main_bumpMapping()
 	float r = pow(max(dot(reflectLight, halfVec), 0.0), 14.0);
 	specularFactor = (specularFactor + r) * 0.5;
 
-	vec4 ambientColor = vec4(ambientLight.rgb * foam, 0.15);
+	vec4 ambientColor = vec4(ambientLight.rgb * foam, 0.15); // no ray AO: the mask holds the submerged terrain's values, not the water surface's
 	vec4 diffuseColor = vec4(diffuseLight.rgb * diffuseFactor * waterColor+noise*noise*0.5, 0.35);
 	vec4 specColor = vec4(specularLight.rgb * specularFactor * diffuseFactor, fresnel_alpha);
 
 	vec4 finalColor = vec4(0.0);
 	finalColor.rgb = ambientColor.rgb + diffuseColor.rgb + specColor.rgb;
-	finalColor.rgb = mix(finalColor.rgb, (finalColor.rgb+vec3(1.0,0.8,0.63))*0.5, fresnel);
+	float skyReflectionVisibility = 1.0;
+#if WZ_RAYQUERY_SHADERS
+	{
+		// ray-traced reflection occlusion: dim the sky reflection where geometry (cliffs,
+		// structures) blocks it, so reflections ground the water into the scene
+		vec3 reflDir = reflect(-normalize(eyeVec), normalize(N));
+		bool reflectionBlocked = (reflDir.y <= 0.01);
+		if (!reflectionBlocked)
+		{
+			rayQueryEXT rayQuery;
+			rayQueryInitializeEXT(rayQuery, wzTopLevelAS,
+								  gl_RayFlagsTerminateOnFirstHitEXT | gl_RayFlagsOpaqueEXT,
+								  0xFF, frag.posModelSpace + vec3(0.0, 4.0, 0.0), 2.0, reflDir, 6000.0);
+			rayQueryProceedEXT(rayQuery);
+			reflectionBlocked = (rayQueryGetIntersectionTypeEXT(rayQuery, true) != gl_RayQueryCommittedIntersectionNoneEXT);
+		}
+		if (reflectionBlocked)
+		{
+			skyReflectionVisibility = 0.35;
+		}
+	}
+#endif
+	finalColor.rgb = mix(finalColor.rgb, (finalColor.rgb+vec3(1.0,0.8,0.63))*0.5, fresnel * skyReflectionVisibility);
 	finalColor.a = (ambientColor.a + diffuseColor.a + specColor.a) * (1.0-depth);
 
 	vec4 lightmap = texture(lightmap_tex, uvLightmap, 0.0);

--- a/data/base/shaders/vk/terrain_water_high.glsl
+++ b/data/base/shaders/vk/terrain_water_high.glsl
@@ -20,6 +20,8 @@ layout(std140, set = 0, binding = 0) uniform cbuffer {
 	float fogEnd;
 	float fogStart;
 	float timeSec;
+	int viewportWidth;
+	int viewportHeight;
 };
 
 // interpolated data. location count = 2

--- a/lib/ivis_opengl/CMakeLists.txt
+++ b/lib/ivis_opengl/CMakeLists.txt
@@ -17,6 +17,7 @@ file(GLOB HEADERS
 	"gfx_api_image_compress_priv.h"
 	"gfx_api_null.h"
 	"gfx_api_vk.h"
+	"gfx_api_vk_rt.h"
 	"imd.h"
 	"ivisdef.h"
 	"jpeg_encoder.h"
@@ -49,6 +50,7 @@ file(GLOB SRC
 	"gfx_api_image_compress_priv.cpp"
 	"gfx_api_null.cpp"
 	"gfx_api_vk.cpp"
+	"gfx_api_vk_rt.cpp"
 	"imdload.cpp"
 	"jpeg_encoder.cpp"
 	"jpeg_util.cpp"
@@ -232,6 +234,7 @@ if (CMAKE_CXX_STANDARD GREATER_EQUAL 20)
 		"3rdparty/vkh_renderpasscompat.cpp"
 		"3rdparty/vkh_info.cpp"
 		"gfx_api_vk.cpp"
+		"gfx_api_vk_rt.cpp"
 		"gfx_api.cpp")
 	set_source_files_properties(${cpp17_source_files} PROPERTIES COMPILE_FLAGS "-std=c++17")
 endif()

--- a/lib/ivis_opengl/gfx_api.h
+++ b/lib/ivis_opengl/gfx_api.h
@@ -338,14 +338,40 @@ namespace gfx_api
 		uint32_t shadowFilterSize = 5;
 		uint32_t shadowCascadesCount = WZ_MAX_SHADOW_CASCADES;
 		bool isPointLightPerPixelEnabled = false;
+		uint32_t rayShadows = 0; // 1 = sample ray-traced shadow mask instead of shadow map
+		uint32_t rayQueryMaterials = 0; // 1 = use ray-query material shader variants (point-light shadows, reflections)
 
 		bool operator==(const lighting_constants& rhs) const
 		{
 			return shadowMode == rhs.shadowMode
 			&& shadowFilterSize == rhs.shadowFilterSize
 			&& shadowCascadesCount == rhs.shadowCascadesCount
-			&& isPointLightPerPixelEnabled == rhs.isPointLightPerPixelEnabled;
+			&& isPointLightPerPixelEnabled == rhs.isPointLightPerPixelEnabled
+			&& rayShadows == rhs.rayShadows
+			&& rayQueryMaterials == rhs.rayQueryMaterials;
 		}
+	};
+
+	// Parameters for the per-frame ray-traced shadow mask trace + filter passes
+	enum class ray_shadow_mode : uint32_t
+	{
+		Off = 0,
+		HalfRes = 1,
+		FullRes = 2,
+		QuarterRes = 3,
+	};
+	struct ray_shadow_frame_params
+	{
+		glm::mat4 inverseProjectionViewMatrix = glm::mat4(1.f);
+		glm::vec4 sunDirectionWorld = glm::vec4(0.f, 1.f, 0.f, 0.f); // direction *toward* the sun, render/world space
+		glm::vec4 cameraPositionWorld = glm::vec4(0.f); // camera position, render/world space (for surface-normal orientation)
+		float rayTMin = 4.f;
+		float rayTMax = 8000.f; // sun-ray range; misses pay for the whole traversal, so keep this tight
+		float normalOffsetScale = 4.f;
+		float sunConeAngle = 0.025f; // angular radius (radians) of the sun for soft shadows / penumbra
+		uint32_t aoRayCount = 3; // ambient occlusion rays per pixel: 3 = fixed cone, 4 = +normal ray (0 = AO disabled)
+		float aoMaxDistance = 160.f; // AO ray length in world units (128 = one tile)
+		float aoStrength = 0.55f; // how dark full occlusion gets (0..1)
 	};
 
 	struct context
@@ -411,6 +437,27 @@ namespace gfx_api
 		virtual void beginSceneRenderPass() { }
 		virtual void endSceneRenderPass() { }
 		virtual gfx_api::abstract_texture* getSceneTexture() { return nullptr; }
+		// Optional ray-traced (ray query) sun shadow support - currently Vulkan-only.
+		// Default implementations are no-ops so backends without support need not override.
+		virtual bool supportsRayTracedShadows() const { return false; }
+		virtual bool rayShadows_setMode(ray_shadow_mode mode) { return mode == ray_shadow_mode::Off; }
+		virtual ray_shadow_mode rayShadows_getMode() const { return ray_shadow_mode::Off; }
+		// Terrain geometry (positions: tightly-packed float3, world space; indices: u32)
+		virtual void rayShadows_setTerrainGeometry(const float* vertices, size_t vertexCount, const uint32_t* indices, size_t indexCount) { }
+		virtual void rayShadows_updateTerrainVertices(size_t startVertex, const float* vertices, size_t vertexCount) { }
+		virtual void rayShadows_clearTerrainGeometry() { }
+		// Mesh geometry, registered lazily per (meshKey, variant); variant encodes vertex-shader
+		// deformation (e.g. structure "stretch") already applied to the supplied positions
+		virtual bool rayShadows_hasMeshBLAS(const void* meshKey, int32_t variant) { return true; }
+		virtual void rayShadows_registerMeshGeometry(const void* meshKey, int32_t variant, const float* vertices, size_t vertexCount, const uint32_t* indices, size_t indexCount) { }
+		virtual void rayShadows_invalidateMesh(const void* meshKey) { }
+		// Per-frame instance list + passes
+		virtual void rayShadows_beginFrame() { }
+		virtual void rayShadows_addInstance(const void* meshKey, int32_t variant, const glm::mat4& worldTransform) { }
+		virtual void rayShadows_addTerrainInstance() { }
+		virtual void rayShadows_beginDepthPass() { }
+		virtual void rayShadows_traceAndFilter(const ray_shadow_frame_params& params) { }
+		virtual gfx_api::abstract_texture* rayShadows_getMaskTexture() { return nullptr; }
 		virtual void beginRenderPass() = 0;
 		virtual void endRenderPass() = 0;
 		virtual void debugStringMarker(const char *str) = 0;
@@ -836,7 +883,8 @@ namespace gfx_api
 	texture_description<2, sampler_type::anisotropic>, // normal map
 	texture_description<3, sampler_type::anisotropic>, // specular map
 	texture_description<4, sampler_type::bilinear_border, pixel_format_target::depth_map, border_color::opaque_white>,  // depth / shadow map
-	texture_description<5, sampler_type::bilinear> // lightmap
+	texture_description<5, sampler_type::bilinear>, // lightmap
+	texture_description<6, sampler_type::bilinear> // ray-traced shadow mask (or 1x1 white fallback)
 	>, shader>;
 
 	using Draw3DShapeOpaque_Instanced = Draw3DShapeInstanced<REND_OPAQUE, SHADER_COMPONENT_INSTANCED, DEPTH_CMP_LEQ_WRT_ON>;
@@ -870,6 +918,28 @@ namespace gfx_api
 	vertex_buffer_description<12, gfx_api::vertex_attribute_input_rate::vertex, vertex_attribute_description<normal, gfx_api::vertex_attribute_type::float3, 0>>,
 //	vertex_buffer_description<16, gfx_api::vertex_attribute_input_rate::vertex, vertex_attribute_description<texcoord, gfx_api::vertex_attribute_type::float4, 0>>,
 //	vertex_buffer_description<16, gfx_api::vertex_attribute_input_rate::vertex, vertex_attribute_description<tangent, gfx_api::vertex_attribute_type::float4, 0>>,
+	// instance data
+	vertex_buffer_description<sizeof(Draw3DShapePerInstanceInterleavedData), gfx_api::vertex_attribute_input_rate::instance,
+		vertex_attribute_description<instance_modelMatrix, gfx_api::vertex_attribute_type::float4, 0>,
+		vertex_attribute_description<instance_modelMatrix + 1, gfx_api::vertex_attribute_type::float4, sizeof(glm::vec4)>,
+		vertex_attribute_description<instance_modelMatrix + 2, gfx_api::vertex_attribute_type::float4, sizeof(glm::vec4)*2>,
+		vertex_attribute_description<instance_modelMatrix + 3, gfx_api::vertex_attribute_type::float4, sizeof(glm::vec4)*3>,
+		vertex_attribute_description<instance_packedValues, gfx_api::vertex_attribute_type::float4, offsetof(Draw3DShapePerInstanceInterleavedData, shaderStretch_ecmState_alphaTest_animFrameNumber)>,
+		vertex_attribute_description<instance_Colour, gfx_api::vertex_attribute_type::u8x4_norm, offsetof(Draw3DShapePerInstanceInterleavedData, colour)>,
+		vertex_attribute_description<instance_TeamColour, gfx_api::vertex_attribute_type::u8x4_norm, offsetof(Draw3DShapePerInstanceInterleavedData, teamcolour)>
+		>
+	>, notexture, SHADER_COMPONENT_DEPTH_INSTANCED>;
+
+	// Camera depth prepass variant (for ray-traced shadows): the shadow_mapping cull mode
+	// intentionally rasterizes the *far* face set (shadow-map acne trick), which is wrong for
+	// reconstructing the camera-visible surface - use no culling instead
+	using Draw3DShapeCameraDepth_Instanced = typename gfx_api::pipeline_state_helper<rasterizer_state<REND_OPAQUE, DEPTH_CMP_LEQ_WRT_ON, 255, polygon_offset::disabled, stencil_mode::stencil_disabled, cull_mode::none>, primitive_type::triangles, index_type::u16,
+	std::tuple<
+	Draw3DShapeInstancedDepthOnlyGlobalUniforms
+	>,
+	std::tuple<
+	vertex_buffer_description<12, gfx_api::vertex_attribute_input_rate::vertex, vertex_attribute_description<position, gfx_api::vertex_attribute_type::float3, 0>>,
+	vertex_buffer_description<12, gfx_api::vertex_attribute_input_rate::vertex, vertex_attribute_description<normal, gfx_api::vertex_attribute_type::float3, 0>>,
 	// instance data
 	vertex_buffer_description<sizeof(Draw3DShapePerInstanceInterleavedData), gfx_api::vertex_attribute_input_rate::instance,
 		vertex_attribute_description<instance_modelMatrix, gfx_api::vertex_attribute_type::float4, 0>,
@@ -1013,7 +1083,8 @@ namespace gfx_api
 	texture_description<6, sampler_type::anisotropic, pixel_format_target::texture_2d_array>, // decal normal
 	texture_description<7, sampler_type::anisotropic, pixel_format_target::texture_2d_array>, // decal specular
 	texture_description<8, sampler_type::anisotropic, pixel_format_target::texture_2d_array>,  // decal height
-	texture_description<9, sampler_type::bilinear_border, pixel_format_target::depth_map, border_color::opaque_white>  // depth / shadow map
+	texture_description<9, sampler_type::bilinear_border, pixel_format_target::depth_map, border_color::opaque_white>,  // depth / shadow map
+	texture_description<10, sampler_type::bilinear> // ray-traced shadow mask (or 1x1 white fallback)
 	>, shader>;
 
 	using TerrainCombined_Classic = TerrainCombinedTemplate<REND_ALPHA, SHADER_TERRAIN_COMBINED_CLASSIC>;
@@ -1070,6 +1141,8 @@ namespace gfx_api
 		float fog_begin;
 		float fog_end;
 		float timeSec;
+		int viewportWidth;
+		int viewportHeight;
 	};
 
 	using WaterHighPSO = typename gfx_api::pipeline_state_helper<rasterizer_state<REND_ALPHA, DEPTH_CMP_LEQ_WRT_OFF, 255, polygon_offset::disabled, stencil_mode::stencil_disabled, cull_mode::back>, primitive_type::triangles, index_type::u32,
@@ -1081,7 +1154,8 @@ namespace gfx_api
 		texture_description<1, sampler_type::anisotropic_repeat, pixel_format_target::texture_2d_array>, // normal maps
 		texture_description<2, sampler_type::anisotropic_repeat, pixel_format_target::texture_2d_array>, // specular maps
 		texture_description<3, sampler_type::bilinear>, // lightmap
-		texture_description<4, sampler_type::bilinear_border, pixel_format_target::depth_map, border_color::opaque_white>  // depth / shadow map
+		texture_description<4, sampler_type::bilinear_border, pixel_format_target::depth_map, border_color::opaque_white>,  // depth / shadow map
+		texture_description<5, sampler_type::bilinear> // ray-traced shadow mask (or 1x1 white fallback)
 	>, SHADER_WATER_HIGH>;
 
 	template<>

--- a/lib/ivis_opengl/gfx_api_vk.cpp
+++ b/lib/ivis_opengl/gfx_api_vk.cpp
@@ -40,6 +40,7 @@
 //
 
 #include "gfx_api_vk.h"
+#include "gfx_api_vk_rt.h"
 #include "lib/framework/physfs_ext.h"
 #include "lib/framework/wzapp.h"
 #include "lib/exceptionhandler/dumpinfo.h"
@@ -66,11 +67,13 @@
 #endif
 
 const uint32_t minSupportedVulkanVersion = VK_API_VERSION_1_0;
-#if defined(DEBUG)
-// For debug builds, limit to the minimum that should be supported by this backend (which is Vulkan 1.0, see above)
+// Currently limit to: Vulkan 1.3
+// Note: Optional features (like ray-query shadows) require instance versions above the 1.0
+// minimum, so debug builds also default to 1.3. Define WZ_VK_MAX_INSTANCE_VERSION_1_0 to
+// limit debug builds to Vulkan 1.0 (the minimum this backend supports) for testing purposes.
+#if defined(DEBUG) && defined(WZ_VK_MAX_INSTANCE_VERSION_1_0)
 const uint32_t maxRequestableInstanceVulkanVersion = VK_API_VERSION_1_0;
 #else
-// For regular builds, currently limit to: Vulkan 1.3
 const uint32_t maxRequestableInstanceVulkanVersion = (uint32_t)VK_MAKE_VERSION(1, 3, 0);
 #endif
 
@@ -97,6 +100,18 @@ const std::vector<const char*> optionalDeviceExtensions = {
 	VK_KHR_DEDICATED_ALLOCATION_EXTENSION_NAME,
 	"VK_KHR_portability_subset" // According to VUID-VkDeviceCreateInfo-pProperties-04451, if device supports this extension it *must* be enabled
 };
+
+#if defined(WZ_VK_RAY_QUERY_POSSIBLE)
+// Used for optional ray-traced shadows support.
+// Only enabled (together as a set) on devices with apiVersion >= 1.2 whose features check out,
+// since VK_KHR_acceleration_structure's other dependencies (descriptor indexing, buffer device
+// address) are only satisfied via Vulkan 1.2 core here.
+const std::vector<const char*> rayQueryDeviceExtensions = {
+	VK_KHR_ACCELERATION_STRUCTURE_EXTENSION_NAME,
+	VK_KHR_RAY_QUERY_EXTENSION_NAME,
+	VK_KHR_DEFERRED_HOST_OPERATIONS_EXTENSION_NAME
+};
+#endif
 
 const std::vector<vk::Format> supportedDepthStencilFormats = {
 	vk::Format::eD32SfloatS8Uint,
@@ -941,6 +956,20 @@ void perFrameResources_t::clean()
 		dev.destroyFramebuffer(fbo, nullptr, *pVkDynLoader);
 	}
 	fbo_to_delete.clear();
+#if defined(VK_KHR_acceleration_structure)
+	if (!as_to_delete.empty())
+	{
+		ASSERT(pVkDynLoader->vkDestroyAccelerationStructureKHR != nullptr, "Acceleration structures queued for deletion, but extension entry point unavailable?");
+		if (pVkDynLoader->vkDestroyAccelerationStructureKHR != nullptr)
+		{
+			for (auto as : as_to_delete)
+			{
+				dev.destroyAccelerationStructureKHR(as, nullptr, *pVkDynLoader);
+			}
+		}
+		as_to_delete.clear();
+	}
+#endif
 	for (auto buffer : buffer_to_delete)
 	{
 		dev.destroyBuffer(buffer, nullptr, *pVkDynLoader);
@@ -1199,22 +1228,26 @@ struct shader_infos
 	bool specializationConstant_2_shadowFilterSize = false;
 	bool specializationConstant_3_shadowCascadesCount = false;
 	bool specializationConstant_4_pointLightEnabled = false;
+	bool specializationConstant_5_rayShadows = false;
+	// optional ray-query fragment shader variant (WZ_RAYQUERY_SHADERS=1, SPIR-V 1.4+),
+	// selected at pipeline-build time when ray-traced shadows are active
+	std::string rayQueryFragmentSpv = {};
 };
 
 static const std::map<SHADER_MODE, shader_infos> spv_files
 {
 	std::make_pair(SHADER_COMPONENT, shader_infos{ "shaders/vk/tcmask.vert.spv", "shaders/vk/tcmask.frag.spv", true }),
-	std::make_pair(SHADER_COMPONENT_INSTANCED, shader_infos{ "shaders/vk/tcmask_instanced.vert.spv", "shaders/vk/tcmask_instanced.frag.spv", true, true, true, true, true }),
+	std::make_pair(SHADER_COMPONENT_INSTANCED, shader_infos{ "shaders/vk/tcmask_instanced.vert.spv", "shaders/vk/tcmask_instanced.frag.spv", true, true, true, true, true, true, "shaders/vk/tcmask_instanced_rq.frag.spv" }),
 	std::make_pair(SHADER_COMPONENT_DEPTH_INSTANCED, shader_infos{ "shaders/vk/tcmask_depth_instanced.vert.spv", "shaders/vk/tcmask_depth_instanced.frag.spv" }),
 	std::make_pair(SHADER_NOLIGHT, shader_infos{ "shaders/vk/nolight.vert.spv", "shaders/vk/nolight.frag.spv", true }),
 	std::make_pair(SHADER_NOLIGHT_INSTANCED, shader_infos{ "shaders/vk/nolight_instanced.vert.spv", "shaders/vk/nolight_instanced.frag.spv", true }),
 	std::make_pair(SHADER_TERRAIN_DEPTH, shader_infos{ "shaders/vk/terrain_depth.vert.spv", "shaders/vk/terraindepth.frag.spv" }),
 	std::make_pair(SHADER_TERRAIN_DEPTHMAP, shader_infos{ "shaders/vk/terrain_depth_only.vert.spv", "shaders/vk/terrain_depth_only.frag.spv" }),
-	std::make_pair(SHADER_TERRAIN_COMBINED_CLASSIC, shader_infos{ "shaders/vk/terrain_combined.vert.spv", "shaders/vk/terrain_combined_classic.frag.spv", true, true, true, true }),
-	std::make_pair(SHADER_TERRAIN_COMBINED_MEDIUM, shader_infos{ "shaders/vk/terrain_combined.vert.spv", "shaders/vk/terrain_combined_medium.frag.spv", true, true, true, true }),
-	std::make_pair(SHADER_TERRAIN_COMBINED_HIGH, shader_infos{ "shaders/vk/terrain_combined.vert.spv", "shaders/vk/terrain_combined_high.frag.spv", true, true, true, true, true }),
+	std::make_pair(SHADER_TERRAIN_COMBINED_CLASSIC, shader_infos{ "shaders/vk/terrain_combined.vert.spv", "shaders/vk/terrain_combined_classic.frag.spv", true, true, true, true, false, true }),
+	std::make_pair(SHADER_TERRAIN_COMBINED_MEDIUM, shader_infos{ "shaders/vk/terrain_combined.vert.spv", "shaders/vk/terrain_combined_medium.frag.spv", true, true, true, true, false, true }),
+	std::make_pair(SHADER_TERRAIN_COMBINED_HIGH, shader_infos{ "shaders/vk/terrain_combined.vert.spv", "shaders/vk/terrain_combined_high.frag.spv", true, true, true, true, true, true, "shaders/vk/terrain_combined_high_rq.frag.spv" }),
 	std::make_pair(SHADER_WATER, shader_infos{ "shaders/vk/terrain_water.vert.spv", "shaders/vk/water.frag.spv", true }),
-	std::make_pair(SHADER_WATER_HIGH, shader_infos{ "shaders/vk/terrain_water_high.vert.spv", "shaders/vk/terrain_water_high.frag.spv", true, true, true, true }),
+	std::make_pair(SHADER_WATER_HIGH, shader_infos{ "shaders/vk/terrain_water_high.vert.spv", "shaders/vk/terrain_water_high.frag.spv", true, true, true, true, false, true, "shaders/vk/terrain_water_high_rq.frag.spv" }),
 	std::make_pair(SHADER_WATER_CLASSIC, shader_infos{ "shaders/vk/terrain_water_classic.vert.spv", "shaders/vk/terrain_water_classic.frag.spv", true }),
 	std::make_pair(SHADER_RECT, shader_infos{ "shaders/vk/rect.vert.spv", "shaders/vk/rect.frag.spv" }),
 	std::make_pair(SHADER_RECT_INSTANCED, shader_infos{ "shaders/vk/rect_instanced.vert.spv", "shaders/vk/rect_instanced.frag.spv" }),
@@ -1719,6 +1752,21 @@ VkPSO::VkPSO(vk::Device _dev,
 	textures_first_set = static_cast<uint32_t>(layout_desc.size()); // Store descriptor set index for textures
 	layout_desc.push_back(textures_set_layout);
 
+	// Use the ray-query fragment shader variant (with the extra TLAS descriptor set) when
+	// ray-traced shadows are active and this shader has one
+	usesRayQueryTLAS = false;
+	{
+		const auto& shaderVariantInfo = spv_files.at(shader_mode);
+		if (!shaderVariantInfo.rayQueryFragmentSpv.empty()
+			&& root->rayQuerySupported
+			&& root->shadowConstants.rayShadows == 1
+			&& root->shadowConstants.rayQueryMaterials == 1
+			&& root->materialTlasSetLayout)
+		{
+			usesRayQueryTLAS = true;
+			layout_desc.push_back(root->materialTlasSetLayout);
+		}
+	}
 
 	const auto layoutCreateInfo = vk::PipelineLayoutCreateInfo()
 		.setPSetLayouts(layout_desc.data())
@@ -1795,7 +1843,7 @@ VkPSO::VkPSO(vk::Device _dev,
 	const auto rasterizationState = to_vk(state_desc.offset, state_desc.cull);
 	const auto& shaderInfo = spv_files.at(shader_mode);
 	vertexShader = get_module(shaderInfo.vertexSpv, *pVkDynLoader);
-	fragmentShader = get_module(shaderInfo.fragmentSpv, *pVkDynLoader);
+	fragmentShader = get_module((usesRayQueryTLAS) ? shaderInfo.rayQueryFragmentSpv : shaderInfo.fragmentSpv, *pVkDynLoader);
 	auto pipelineStages = get_stages(vertexShader, fragmentShader);
 
 	std::vector<char> specializationConstantsDataBuffer;
@@ -1834,6 +1882,11 @@ VkPSO::VkPSO(vk::Device _dev,
 	{
 		appendSpecializationConstant_uint32(4, static_cast<uint32_t>(root->shadowConstants.isPointLightPerPixelEnabled));
 		hasSpecializationConstant_PointLightConstants = true;
+	}
+	if (shaderInfo.specializationConstant_5_rayShadows)
+	{
+		appendSpecializationConstant_uint32(5, root->shadowConstants.rayShadows);
+		hasSpecializationConstant_ShadowConstants = true;
 	}
 	if (!specializationEntries.empty())
 	{
@@ -3735,6 +3788,22 @@ int rateDeviceSuitability(const vk::PhysicalDevice &device, const vk::SurfaceKHR
 	// Maximum possible size of textures affects graphics quality
 	score += deviceProperties.limits.maxImageDimension2D;
 
+	// Prefer devices with more device-local memory (differentiates between multiple discrete
+	// GPUs - e.g. a flagship dGPU + a small secondary dGPU would otherwise tie)
+	{
+		const auto memProperties = device.getMemoryProperties(vkDynLoader);
+		vk::DeviceSize largestDeviceLocalHeap = 0;
+		for (uint32_t i = 0; i < memProperties.memoryHeapCount; ++i)
+		{
+			if (memProperties.memoryHeaps[i].flags & vk::MemoryHeapFlagBits::eDeviceLocal)
+			{
+				largestDeviceLocalHeap = std::max(largestDeviceLocalHeap, memProperties.memoryHeaps[i].size);
+			}
+		}
+		// in MB, capped so this never outweighs the discrete-vs-integrated tier bonus
+		score += static_cast<int>(std::min<vk::DeviceSize>(largestDeviceLocalHeap / (1024 * 1024), 500000));
+	}
+
 	// Requires: deviceProperties.apiVersion >= minSupportedVulkanVersion
 	if (!VK_VERSION_GREATER_THAN_OR_EQUAL(deviceProperties.apiVersion, minSupportedVulkanVersion))
 	{
@@ -3911,6 +3980,13 @@ void VkRoot::shutdown()
 {
 	destroySwapchainAndSwapchainSpecificStuff(true);
 
+	if (rayShadowBackend)
+	{
+		// must destroy immediately (the buffering_mechanism is gone at this point, but the device is still alive)
+		rayShadowBackend->destroyNow();
+		rayShadowBackend.reset();
+	}
+
 	if (dev)
 	{
 		for (auto& pipelineInfo : createdPipelines)
@@ -4035,6 +4111,8 @@ void VkRoot::waitForAllIdle()
 
 void VkRoot::destroySwapchainAndSwapchainSpecificStuff(bool doDestroySwapchain)
 {
+	discardPendingScreenshots();
+	swapchainImages.clear();
 	if (!dev)
 	{
 		// Logical device is null - return
@@ -4514,6 +4592,9 @@ void VkRoot::createSwapchain(bool allowHandleSurfaceLost)
 	surfaceFormat = chooseSwapSurfaceFormat(swapChainSupport.formats);
 	debug(LOG_3D, "Using surface format: %s - %s", to_string(surfaceFormat.format).c_str(), to_string(surfaceFormat.colorSpace).c_str());
 
+	// screenshots require copying from the swapchain images
+	swapchainSupportsScreenshotCopy = static_cast<bool>(swapChainSupport.capabilities.supportedUsageFlags & vk::ImageUsageFlagBits::eTransferSrc);
+
 	// pick compositeAlpha
 	vk::CompositeAlphaFlagBitsKHR compositeAlphaMode = vk::CompositeAlphaFlagBitsKHR::eOpaque;
 	if (swapChainSupport.capabilities.supportedCompositeAlpha & vk::CompositeAlphaFlagBitsKHR::eOpaque)
@@ -4534,7 +4615,7 @@ void VkRoot::createSwapchain(bool allowHandleSurfaceLost)
 		.setSurface(surface)
 		.setMinImageCount(swapchainDesiredImageCount)
 		.setPresentMode(presentMode)
-		.setImageUsage(vk::ImageUsageFlagBits::eColorAttachment)
+		.setImageUsage(vk::ImageUsageFlagBits::eColorAttachment | ((swapchainSupportsScreenshotCopy) ? vk::ImageUsageFlagBits::eTransferSrc : vk::ImageUsageFlags()))
 		.setImageArrayLayers(1)
 		.setCompositeAlpha(compositeAlphaMode)
 		.setClipped(true)
@@ -4571,7 +4652,7 @@ void VkRoot::createSwapchain(bool allowHandleSurfaceLost)
 	}
 
 	// createSwapchainImageViews
-	std::vector<vk::Image> swapchainImages = dev.getSwapchainImagesKHR(swapchain, vkDynLoader);
+	swapchainImages = dev.getSwapchainImagesKHR(swapchain, vkDynLoader);
 	debug(LOG_3D, "Requested swapchain minImageCount: %" PRIu32", received: %zu", swapchainDesiredImageCount, swapchainImages.size());
 	try {
 		std::transform(swapchainImages.begin(), swapchainImages.end(), std::back_inserter(swapchainImageView),
@@ -5276,6 +5357,33 @@ bool VkRoot::createLogicalDevice()
 	auto supportedOptionalExtensions = findSupportedDeviceExtensions(physicalDevice, optionalDeviceExtensions, vkDynLoader);
 	enabledDeviceExtensions.insert(std::end(enabledDeviceExtensions), supportedOptionalExtensions.begin(), supportedOptionalExtensions.end());
 
+	// determine whether ray query (for optional ray-traced shadows) can be enabled
+	rayQuerySupported = false;
+#if defined(WZ_VK_RAY_QUERY_POSSIBLE)
+	if (canUseVulkanDeviceAPI(VK_MAKE_VERSION(1, 2, 0)) && canUseVulkanInstanceAPI(VK_MAKE_VERSION(1, 1, 0)))
+	{
+		auto supportedRayQueryExtensions = findSupportedDeviceExtensions(physicalDevice, rayQueryDeviceExtensions, vkDynLoader);
+		if (supportedRayQueryExtensions.size() == rayQueryDeviceExtensions.size())
+		{
+			auto rayQueryFeaturesChain = physicalDevice.getFeatures2<vk::PhysicalDeviceFeatures2, vk::PhysicalDeviceVulkan12Features, vk::PhysicalDeviceAccelerationStructureFeaturesKHR, vk::PhysicalDeviceRayQueryFeaturesKHR>(vkDynLoader);
+			const auto& vk12Features = rayQueryFeaturesChain.get<vk::PhysicalDeviceVulkan12Features>();
+			const auto& asFeatures = rayQueryFeaturesChain.get<vk::PhysicalDeviceAccelerationStructureFeaturesKHR>();
+			const auto& rqFeatures = rayQueryFeaturesChain.get<vk::PhysicalDeviceRayQueryFeaturesKHR>();
+			if (vk12Features.bufferDeviceAddress && asFeatures.accelerationStructure && rqFeatures.rayQuery)
+			{
+				rayQuerySupported = true;
+				enabledDeviceExtensions.insert(std::end(enabledDeviceExtensions), supportedRayQueryExtensions.begin(), supportedRayQueryExtensions.end());
+			}
+			else
+			{
+				debug(LOG_3D, "Vulkan: ray query extensions present but required features unavailable (bufferDeviceAddress: %d, accelerationStructure: %d, rayQuery: %d)",
+					  (int)vk12Features.bufferDeviceAddress, (int)asFeatures.accelerationStructure, (int)rqFeatures.rayQuery);
+			}
+		}
+	}
+	debug(LOG_3D, "Vulkan: ray query support: %s", (rayQuerySupported) ? "yes" : "no");
+#endif
+
 	// create logical device
 	std::vector<vk::DeviceQueueCreateInfo> queueCreateInfos;
 	debug(LOG_3D, "Using queue family indicies: <graphics: %" PRIu32">, <presentation: %" PRIu32">", queueFamilyIndices.graphicsFamily.value(), queueFamilyIndices.presentFamily.value());
@@ -5308,12 +5416,28 @@ bool VkRoot::createLogicalDevice()
 	});
 	debug(LOG_3D, "Using device extensions: %s", deviceExtensionsAsString.c_str());
 
-	const auto deviceCreateInfo = vk::DeviceCreateInfo()
+	auto deviceCreateInfo = vk::DeviceCreateInfo()
 		.setEnabledExtensionCount(static_cast<uint32_t>(enabledDeviceExtensions.size()))
 		.setPpEnabledExtensionNames(enabledDeviceExtensions.data())
 		.setPEnabledFeatures(&enabledFeatures)
 		.setQueueCreateInfoCount(static_cast<uint32_t>(queueCreateInfos.size()))
 		.setPQueueCreateInfos(queueCreateInfos.data());
+
+#if defined(WZ_VK_RAY_QUERY_POSSIBLE)
+	// feature structs for ray query support, chained into deviceCreateInfo.pNext when supported
+	auto enabledVk12Features = vk::PhysicalDeviceVulkan12Features()
+		.setBufferDeviceAddress(true);
+	auto enabledASFeatures = vk::PhysicalDeviceAccelerationStructureFeaturesKHR()
+		.setAccelerationStructure(true);
+	auto enabledRQFeatures = vk::PhysicalDeviceRayQueryFeaturesKHR()
+		.setRayQuery(true);
+	if (rayQuerySupported)
+	{
+		enabledVk12Features.setPNext(&enabledASFeatures);
+		enabledASFeatures.setPNext(&enabledRQFeatures);
+		deviceCreateInfo.setPNext(&enabledVk12Features);
+	}
+#endif
 
 	try {
 		dev = physicalDevice.createDevice(deviceCreateInfo, nullptr, vkDynLoader);
@@ -5371,6 +5495,11 @@ bool VkRoot::createAllocator()
 	if (enabled_VK_KHR_get_memory_requirements2 && enabled_VK_KHR_dedicated_allocation)
 	{
 		allocatorInfo.flags |= VMA_ALLOCATOR_CREATE_KHR_DEDICATED_ALLOCATION_BIT;
+	}
+	if (rayQuerySupported)
+	{
+		// the bufferDeviceAddress device feature was enabled (required for acceleration structure builds)
+		allocatorInfo.flags |= VMA_ALLOCATOR_CREATE_BUFFER_DEVICE_ADDRESS_BIT;
 	}
 
 	VmaVulkanFunctions vulkanFunctions = {};
@@ -5833,6 +5962,15 @@ void VkRoot::bind_textures(const std::vector<gfx_api::texture_input>& attribute_
 	}
 	dev.updateDescriptorSets(write_info, nullptr, vkDynLoader);
 	buffering_mechanism::get_current_resources().currentDrawCmdBuffer()->bindDescriptorSets(vk::PipelineBindPoint::eGraphics, currentPSO->layout, currentPSO->textures_first_set, set, nullptr, vkDynLoader);
+
+	if (currentPSO->usesRayQueryTLAS && rayShadowBackend)
+	{
+		vk::DescriptorSet tlasSet = rayShadowBackend->getMaterialTlasDescSet();
+		if (tlasSet)
+		{
+			buffering_mechanism::get_current_resources().currentDrawCmdBuffer()->bindDescriptorSets(vk::PipelineBindPoint::eGraphics, currentPSO->layout, currentPSO->textures_first_set + 1, 1, &tlasSet, 0, nullptr, vkDynLoader);
+		}
+	}
 }
 
 void VkRoot::set_constants(const void* buffer, const std::size_t& size)
@@ -6104,6 +6242,19 @@ void VkRoot::endRenderPass()
 	buffering_mechanism::get_current_resources().scenePassDrawCmdBuffer().end(vkDynLoader);
 
 	buffering_mechanism::get_current_resources().renderPassDrawCmdBuffer().endRenderPass(vkDynLoader);
+
+	bool recordedScreenshotThisFrame = false;
+	if (saveScreenshotCallback)
+	{
+		recordedScreenshotThisFrame = recordScreenshotReadback();
+		if (!recordedScreenshotThisFrame)
+		{
+			// unable to record - fail the request
+			saveScreenshotCallback(nullptr);
+			saveScreenshotCallback = nullptr;
+		}
+	}
+
 	buffering_mechanism::get_current_resources().renderPassDrawCmdBuffer().end(vkDynLoader);
 
 	startedRenderPass = false;
@@ -6141,6 +6292,16 @@ void VkRoot::endRenderPass()
 			// Must re-create swapchain
 			debug(LOG_3D, "[1] Drawable size (%d x %d) does not match swapchainSize (%d x %d) - must re-create swapchain", w, h, (int)swapchainSize.width, (int)swapchainSize.height);
 			mustRecreateSwapchain = true;
+		}
+	}
+
+	if (recordedScreenshotThisFrame && mustSkipDrawing)
+	{
+		// the draw cmd buffer (with the readback) will not be submitted this frame
+		ASSERT(!pendingScreenshots.empty(), "Recorded screenshot but no pending entry?");
+		if (!pendingScreenshots.empty())
+		{
+			pendingScreenshots.back().submitted = false;
 		}
 	}
 
@@ -6266,7 +6427,8 @@ void VkRoot::endRenderPass()
 	}
 
 	try {
-		buffering_mechanism::swap(dev, vkDynLoader); // must be called *before* acquireNextSwapchainImage()
+		buffering_mechanism::swap(dev, vkDynLoader);
+	processPendingScreenshots(); // must be called *before* acquireNextSwapchainImage()
 	}
 	catch (const vk::OutOfHostMemoryError& e)
 	{
@@ -6614,11 +6776,172 @@ std::string VkRoot::calculateFormattedRendererInfoString() const
 	return std::string("Vulkan ") + VkhInfo::vulkan_apiversion_to_string(physDeviceProps.apiVersion) + " (" + static_cast<const char*>(physDeviceProps.deviceName) + ")";
 }
 
+bool VkRoot::recordScreenshotReadback()
+{
+	if (!swapchainSupportsScreenshotCopy || currentSwapchainIndex >= swapchainImages.size())
+	{
+		return false;
+	}
+
+	const vk::DeviceSize bufferSize = static_cast<vk::DeviceSize>(swapchainSize.width) * swapchainSize.height * 4;
+	auto bufferCreateInfo = vk::BufferCreateInfo()
+		.setSize(bufferSize)
+		.setUsage(vk::BufferUsageFlagBits::eTransferDst)
+		.setSharingMode(vk::SharingMode::eExclusive);
+	VmaAllocationCreateInfo allocCreateInfo = {};
+	allocCreateInfo.usage = VMA_MEMORY_USAGE_GPU_TO_CPU;
+	allocCreateInfo.flags = VMA_ALLOCATION_CREATE_MAPPED_BIT;
+	VmaAllocationInfo allocInfo = {};
+	PendingScreenshotReadback readback;
+	VkResult result = vmaCreateBuffer(allocator, reinterpret_cast<const VkBufferCreateInfo*>(&bufferCreateInfo), &allocCreateInfo, reinterpret_cast<VkBuffer*>(&readback.buffer), &readback.allocation, &allocInfo);
+	if (result != VK_SUCCESS || allocInfo.pMappedData == nullptr)
+	{
+		debug(LOG_ERROR, "Failed to create screenshot readback buffer: %s", to_string(static_cast<vk::Result>(result)).c_str());
+		if (result == VK_SUCCESS)
+		{
+			vmaDestroyBuffer(allocator, static_cast<VkBuffer>(readback.buffer), readback.allocation);
+		}
+		return false;
+	}
+	readback.pMapped = allocInfo.pMappedData;
+	readback.width = swapchainSize.width;
+	readback.height = swapchainSize.height;
+	readback.format = surfaceFormat.format;
+	readback.callback = std::move(saveScreenshotCallback);
+	saveScreenshotCallback = nullptr;
+	readback.frameIdx = buffering_mechanism::get_current_frame_num();
+
+	auto cmdBuffer = buffering_mechanism::get_current_resources().renderPassDrawCmdBuffer();
+	vk::Image swapchainImage = swapchainImages[currentSwapchainIndex];
+
+	const auto toTransferBarrier = vk::ImageMemoryBarrier()
+		.setSrcAccessMask(vk::AccessFlagBits::eColorAttachmentWrite)
+		.setDstAccessMask(vk::AccessFlagBits::eTransferRead)
+		.setOldLayout(vk::ImageLayout::ePresentSrcKHR)
+		.setNewLayout(vk::ImageLayout::eTransferSrcOptimal)
+		.setSrcQueueFamilyIndex(VK_QUEUE_FAMILY_IGNORED)
+		.setDstQueueFamilyIndex(VK_QUEUE_FAMILY_IGNORED)
+		.setImage(swapchainImage)
+		.setSubresourceRange(vk::ImageSubresourceRange(vk::ImageAspectFlagBits::eColor, 0, 1, 0, 1));
+	cmdBuffer.pipelineBarrier(vk::PipelineStageFlagBits::eColorAttachmentOutput, vk::PipelineStageFlagBits::eTransfer,
+							  vk::DependencyFlags(), nullptr, nullptr, toTransferBarrier, vkDynLoader);
+
+	const auto copyRegion = vk::BufferImageCopy()
+		.setBufferOffset(0)
+		.setBufferRowLength(0)
+		.setBufferImageHeight(0)
+		.setImageSubresource(vk::ImageSubresourceLayers(vk::ImageAspectFlagBits::eColor, 0, 0, 1))
+		.setImageOffset(vk::Offset3D(0, 0, 0))
+		.setImageExtent(vk::Extent3D(swapchainSize.width, swapchainSize.height, 1));
+	cmdBuffer.copyImageToBuffer(swapchainImage, vk::ImageLayout::eTransferSrcOptimal, readback.buffer, 1, &copyRegion, vkDynLoader);
+
+	const auto toPresentBarrier = vk::ImageMemoryBarrier()
+		.setSrcAccessMask(vk::AccessFlagBits::eTransferRead)
+		.setDstAccessMask(vk::AccessFlags())
+		.setOldLayout(vk::ImageLayout::eTransferSrcOptimal)
+		.setNewLayout(vk::ImageLayout::ePresentSrcKHR)
+		.setSrcQueueFamilyIndex(VK_QUEUE_FAMILY_IGNORED)
+		.setDstQueueFamilyIndex(VK_QUEUE_FAMILY_IGNORED)
+		.setImage(swapchainImage)
+		.setSubresourceRange(vk::ImageSubresourceRange(vk::ImageAspectFlagBits::eColor, 0, 1, 0, 1));
+	cmdBuffer.pipelineBarrier(vk::PipelineStageFlagBits::eTransfer, vk::PipelineStageFlagBits::eBottomOfPipe,
+							  vk::DependencyFlags(), nullptr, nullptr, toPresentBarrier, vkDynLoader);
+
+	pendingScreenshots.push_back(std::move(readback));
+	return true;
+}
+
+void VkRoot::processPendingScreenshots()
+{
+	if (pendingScreenshots.empty())
+	{
+		return;
+	}
+	// entries recorded with frameIdx == the (new) current frame index have had their fence waited
+	size_t currFrame = buffering_mechanism::get_current_frame_num();
+	for (auto it = pendingScreenshots.begin(); it != pendingScreenshots.end(); )
+	{
+		if (it->frameIdx != currFrame)
+		{
+			++it;
+			continue;
+		}
+		if (it->submitted && it->pMapped)
+		{
+			vmaInvalidateAllocation(allocator, it->allocation, 0, VK_WHOLE_SIZE);
+			auto image = std::make_unique<iV_Image>();
+			image->allocate(it->width, it->height, 3, false);
+			const uint8_t* srcData = reinterpret_cast<const uint8_t*>(it->pMapped);
+			uint8_t* dstData = image->bmp_w();
+			const bool swapRB = (it->format == vk::Format::eB8G8R8A8Unorm || it->format == vk::Format::eB8G8R8A8Srgb);
+			const bool packed101010 = (it->format == vk::Format::eA2B10G10R10UnormPack32 || it->format == vk::Format::eA2R10G10B10UnormPack32);
+			const bool packedSwapRB = (it->format == vk::Format::eA2R10G10B10UnormPack32);
+			for (size_t dstY = 0; dstY < it->height; ++dstY)
+			{
+				// the screenshot save path expects GL-convention (bottom-up) row order
+				const size_t srcY = (it->height - 1) - dstY;
+				const uint8_t* srcRow = srcData + (srcY * static_cast<size_t>(it->width) * 4);
+				uint8_t* dstRow = dstData + (dstY * static_cast<size_t>(it->width) * 3);
+				for (size_t x = 0; x < it->width; ++x)
+				{
+					if (packed101010)
+					{
+						uint32_t packedValue;
+						memcpy(&packedValue, srcRow + (x * 4), sizeof(uint32_t));
+						uint8_t c0 = static_cast<uint8_t>(((packedValue >> 0) & 0x3FF) >> 2);
+						uint8_t c1 = static_cast<uint8_t>(((packedValue >> 10) & 0x3FF) >> 2);
+						uint8_t c2 = static_cast<uint8_t>(((packedValue >> 20) & 0x3FF) >> 2);
+						dstRow[x * 3 + 0] = (packedSwapRB) ? c2 : c0;
+						dstRow[x * 3 + 1] = c1;
+						dstRow[x * 3 + 2] = (packedSwapRB) ? c0 : c2;
+					}
+					else
+					{
+						dstRow[x * 3 + 0] = srcRow[x * 4 + ((swapRB) ? 2 : 0)];
+						dstRow[x * 3 + 1] = srcRow[x * 4 + 1];
+						dstRow[x * 3 + 2] = srcRow[x * 4 + ((swapRB) ? 0 : 2)];
+					}
+				}
+			}
+			it->callback(std::move(image));
+		}
+		else
+		{
+			it->callback(nullptr);
+		}
+		vmaDestroyBuffer(allocator, static_cast<VkBuffer>(it->buffer), it->allocation);
+		it = pendingScreenshots.erase(it);
+	}
+}
+
+void VkRoot::discardPendingScreenshots()
+{
+	for (auto& pending : pendingScreenshots)
+	{
+		if (pending.callback)
+		{
+			pending.callback(nullptr);
+		}
+		vmaDestroyBuffer(allocator, static_cast<VkBuffer>(pending.buffer), pending.allocation);
+	}
+	pendingScreenshots.clear();
+	if (saveScreenshotCallback)
+	{
+		saveScreenshotCallback(nullptr);
+		saveScreenshotCallback = nullptr;
+	}
+}
+
 bool VkRoot::getScreenshot(std::function<void (std::unique_ptr<iV_Image>)> callback)
 {
-	// TODO: Implement - save the callback, and trigger a screenshot save at the next opportunity
-	// saveScreenshotCallback = callback;
-	return false;
+	if (!swapchainSupportsScreenshotCopy)
+	{
+		return false;
+	}
+	// the readback is recorded at the end of the current frame (endRenderPass) and the
+	// callback fires once that frame's fence has been waited (maxFramesInFlight later)
+	saveScreenshotCallback = std::move(callback);
+	return true;
 }
 
 const size_t& VkRoot::current_FrameNum() const

--- a/lib/ivis_opengl/gfx_api_vk.h
+++ b/lib/ivis_opengl/gfx_api_vk.h
@@ -103,6 +103,11 @@ namespace gfx_api
 	};
 }
 
+// Whether the Vulkan headers in use support the extensions needed for optional ray-traced shadows
+#if defined(VK_KHR_acceleration_structure) && defined(VK_KHR_ray_query) && defined(VK_KHR_deferred_host_operations)
+#define WZ_VK_RAY_QUERY_POSSIBLE 1
+#endif
+
 namespace WZ_vk {
 #if VK_HEADER_VERSION >= 301
 	using DispatchLoaderDynamic = vk::detail::DispatchLoaderDynamic;
@@ -199,6 +204,7 @@ private:
 struct VkRoot; // forward-declare
 struct VkPSO; // forward-declare
 struct buffering_mechanism;
+struct VkRayShadowBackend; // forward-declare (gfx_api_vk_rt.h)
 
 struct perFrameResources_t
 {
@@ -246,6 +252,9 @@ struct perFrameResources_t
 	std::vector<VmaAllocation> vmamemory_to_free;
 	std::vector<VkPSO*> pso_to_delete;
 	std::vector<vk::Framebuffer> fbo_to_delete;
+#if defined(VK_KHR_acceleration_structure)
+	std::vector<vk::AccelerationStructureKHR> as_to_delete;
+#endif
 
 	BlockBufferAllocator stagingBufferAllocator;
 	BlockBufferAllocator streamedVertexBufferAllocator;
@@ -379,6 +388,7 @@ struct VkPSO final
 	std::shared_ptr<VkhRenderPassCompat> renderpass_compat;
 	bool hasSpecializationConstant_ShadowConstants = false;
 	bool hasSpecializationConstant_PointLightConstants = false;
+	bool usesRayQueryTLAS = false; // pipeline layout includes the TLAS descriptor set (at textures_first_set + 1)
 
 private:
 	// Read shader into text buffer
@@ -609,6 +619,8 @@ struct SwapChainSupportDetails
 
 struct VkRoot final : gfx_api::context
 {
+	friend struct VkRayShadowBackend;
+
 	std::unique_ptr<gfx_api::backend_Vulkan_Impl> backend_impl;
 	VkhInfo debugInfo;
 	gfx_api::context::swap_interval_mode swapMode = gfx_api::context::swap_interval_mode::vsync;
@@ -649,6 +661,13 @@ struct VkRoot final : gfx_api::context
 	vk::Queue presentQueue;
 	bool queueSupportsTimestamps = false;
 
+	// ray-traced shadows (VK_KHR_ray_query) support
+	bool rayQuerySupported = false;
+	std::unique_ptr<VkRayShadowBackend> rayShadowBackend;
+	// descriptor set layout for the TLAS set appended to ray-query material pipelines
+	// (owned by the ray shadow backend; set/cleared with its pipelines)
+	vk::DescriptorSetLayout materialTlasSetLayout;
+
 	// allocator
 	VmaAllocator allocator = VK_NULL_HANDLE;
 
@@ -659,6 +678,24 @@ struct VkRoot final : gfx_api::context
 	vk::SwapchainKHR swapchain;
 	uint32_t currentSwapchainIndex = 0;
 	std::vector<vk::ImageView> swapchainImageView;
+	std::vector<vk::Image> swapchainImages;
+	bool swapchainSupportsScreenshotCopy = false;
+
+	// screenshot readback support
+	struct PendingScreenshotReadback
+	{
+		vk::Buffer buffer;
+		VmaAllocation allocation = VK_NULL_HANDLE;
+		void* pMapped = nullptr;
+		uint32_t width = 0;
+		uint32_t height = 0;
+		vk::Format format = vk::Format::eUndefined;
+		std::function<void (std::unique_ptr<iV_Image>)> callback;
+		size_t frameIdx = 0;
+		bool submitted = true;
+	};
+	std::vector<PendingScreenshotReadback> pendingScreenshots;
+	std::function<void (std::unique_ptr<iV_Image>)> saveScreenshotCallback;
 
 	vk::SampleCountFlagBits msaaSamples = vk::SampleCountFlagBits::e1; // msaaSamples used for scene
 	vk::SampleCountFlagBits msaaSamplesSwapchain = vk::SampleCountFlagBits::e1; // msaaSamples used for swapchain assets (should generally be 1)
@@ -831,6 +868,23 @@ public:
 	virtual void endSceneRenderPass() override;
 	virtual gfx_api::abstract_texture* getSceneTexture() override;
 
+	// ray-traced shadows (implemented in gfx_api_vk_rt.cpp)
+	virtual bool supportsRayTracedShadows() const override;
+	virtual bool rayShadows_setMode(gfx_api::ray_shadow_mode mode) override;
+	virtual gfx_api::ray_shadow_mode rayShadows_getMode() const override;
+	virtual void rayShadows_setTerrainGeometry(const float* vertices, size_t vertexCount, const uint32_t* indices, size_t indexCount) override;
+	virtual void rayShadows_updateTerrainVertices(size_t startVertex, const float* vertices, size_t vertexCount) override;
+	virtual void rayShadows_clearTerrainGeometry() override;
+	virtual bool rayShadows_hasMeshBLAS(const void* meshKey, int32_t variant) override;
+	virtual void rayShadows_registerMeshGeometry(const void* meshKey, int32_t variant, const float* vertices, size_t vertexCount, const uint32_t* indices, size_t indexCount) override;
+	virtual void rayShadows_invalidateMesh(const void* meshKey) override;
+	virtual void rayShadows_beginFrame() override;
+	virtual void rayShadows_addInstance(const void* meshKey, int32_t variant, const glm::mat4& worldTransform) override;
+	virtual void rayShadows_addTerrainInstance() override;
+	virtual void rayShadows_beginDepthPass() override;
+	virtual void rayShadows_traceAndFilter(const gfx_api::ray_shadow_frame_params& params) override;
+	virtual gfx_api::abstract_texture* rayShadows_getMaskTexture() override;
+
 	virtual void beginRenderPass() override;
 	virtual void endRenderPass() override;
 	virtual void set_polygon_offset(const float& offset, const float& slope) override;
@@ -893,6 +947,9 @@ private:
 	std::string calculateFormattedRendererInfoString() const;
 	void set_uniforms_set(const size_t& set_idx, const void* buffer, size_t bufferSize);
 	const RenderPassDetails& currentRenderPass();
+	bool recordScreenshotReadback(); // records a swapchain->buffer copy into the default cmd buffer
+	void processPendingScreenshots(); // delivers readbacks whose frame fence has been waited
+	void discardPendingScreenshots(); // fails + frees all pending readbacks
 	RenderPassDetails& defaultRenderpass() { return renderPasses[DEFAULT_RENDER_PASS_ID]; }
 	bool endRenderPass_RecreateSwapchain(const vk::Result& reason);
 private:

--- a/lib/ivis_opengl/gfx_api_vk_rt.cpp
+++ b/lib/ivis_opengl/gfx_api_vk_rt.cpp
@@ -1,0 +1,1481 @@
+/*
+	This file is part of Warzone 2100.
+	Copyright (C) 2026  Warzone 2100 Project
+
+	Warzone 2100 is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+
+	Warzone 2100 is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with Warzone 2100; if not, write to the Free Software
+	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+
+// Ray-traced (VK_KHR_ray_query) sun shadows - Vulkan backend implementation.
+// See gfx_api_vk_rt.h for an overview.
+
+#if defined(WZ_VULKAN_ENABLED)
+
+#include "gfx_api_vk.h"
+#include "gfx_api_vk_rt.h"
+#include "lib/framework/frame.h"
+#include "lib/framework/physfs_ext.h"
+
+#include <cstring>
+#include <algorithm>
+#include <array>
+
+#if defined(WZ_VK_RAY_QUERY_POSSIBLE)
+
+#if VK_HEADER_VERSION >= 260
+# define WZ_THROW_VK_RESULT_EXCEPTION_RT(result, message) vk::detail::throwResultException(result, message)
+#else
+# define WZ_THROW_VK_RESULT_EXCEPTION_RT(result, message) vk::throwResultException(result, message)
+#endif
+
+// MARK: helpers
+
+namespace
+{
+	constexpr uint32_t WZ_RT_MIN_INSTANCE_CAPACITY = 512;
+
+	struct TracePushConstants
+	{
+		glm::mat4 invProjectionView;
+		glm::vec4 sunDirection;
+		glm::vec4 cameraPosition;
+		glm::vec4 params; // x = tMin, y = tMax, z = normalOffsetScale, w = sun cone angle
+		glm::vec4 aoParams; // x = AO ray count, y = AO max distance, z = AO strength, w = unused
+	};
+	static_assert(sizeof(TracePushConstants) <= 128, "Push constants exceed minimum guaranteed size");
+
+	struct BlurPushConstants
+	{
+		glm::vec4 dirAndInvSize; // xy = blur direction (in texels), zw = 1/maskExtent
+		glm::vec4 params; // x = depth edge threshold scale, yzw = unused
+	};
+
+	std::vector<uint32_t> readSpvFile(const std::string& name)
+	{
+		auto fp = PHYSFS_openRead(name.c_str());
+		ASSERT_OR_RETURN({}, fp != nullptr, "Could not open %s", name.c_str());
+
+		const auto filesize = PHYSFS_fileLength(fp);
+		if (filesize <= 0 || (filesize % sizeof(uint32_t)) != 0)
+		{
+			PHYSFS_close(fp);
+			ASSERT(false, "Invalid spv file size (%lld): %s", (long long)filesize, name.c_str());
+			return {};
+		}
+
+		auto buffer = std::vector<uint32_t>(static_cast<size_t>(filesize / sizeof(uint32_t)));
+		WZ_PHYSFS_readBytes(fp, buffer.data(), static_cast<PHYSFS_uint32>(filesize));
+		PHYSFS_close(fp);
+		return buffer;
+	}
+
+	vk::TransformMatrixKHR toVkTransform(const glm::mat4& m)
+	{
+		// glm is column-major; VkTransformMatrixKHR is a 3x4 row-major matrix
+		vk::TransformMatrixKHR result;
+		for (uint32_t row = 0; row < 3; ++row)
+		{
+			for (uint32_t col = 0; col < 4; ++col)
+			{
+				result.matrix[row][col] = m[col][row];
+			}
+		}
+		return result;
+	}
+
+	vk::DeviceAddress alignAddress(vk::DeviceAddress address, vk::DeviceSize alignment)
+	{
+		if (alignment == 0) { return address; }
+		return (address + alignment - 1) & ~(alignment - 1);
+	}
+}
+
+// MARK: construction / destruction
+
+VkRayShadowBackend::VkRayShadowBackend(VkRoot& _root)
+	: root(_root)
+{
+}
+
+VkRayShadowBackend::~VkRayShadowBackend()
+{
+	// Resources are destroyed via destroyNow() (shutdown) or deferred destruction (setMode(Off)).
+	// If neither has happened, attempt deferred destruction while the buffering mechanism is alive.
+	if (pipelinesCreated)
+	{
+		destroyNow();
+	}
+}
+
+// MARK: buffers
+
+VkRayShadowBackend::RTBuffer VkRayShadowBackend::createRTBuffer(vk::DeviceSize size, vk::BufferUsageFlags usage, VmaMemoryUsage memUsage, bool mapped, const char* debugName)
+{
+	RTBuffer result;
+
+	auto bufferCreateInfo = vk::BufferCreateInfo()
+		.setSize(size)
+		.setUsage(usage)
+		.setSharingMode(vk::SharingMode::eExclusive);
+
+	VmaAllocationCreateInfo allocCreateInfo = {};
+	allocCreateInfo.usage = memUsage;
+	if (mapped)
+	{
+		allocCreateInfo.flags |= VMA_ALLOCATION_CREATE_MAPPED_BIT;
+	}
+
+	VmaAllocationInfo allocInfo = {};
+	VkResult vkResult = vmaCreateBuffer(root.allocator, reinterpret_cast<const VkBufferCreateInfo*>(&bufferCreateInfo), &allocCreateInfo, reinterpret_cast<VkBuffer*>(&result.buffer), &result.allocation, &allocInfo);
+	if (vkResult != VK_SUCCESS)
+	{
+		debug(LOG_ERROR, "vmaCreateBuffer(%s, %llu) failed: %s", debugName, (unsigned long long)size, to_string(static_cast<vk::Result>(vkResult)).c_str());
+		return RTBuffer();
+	}
+	result.size = size;
+	result.pMapped = (mapped) ? allocInfo.pMappedData : nullptr;
+
+	if (usage & vk::BufferUsageFlagBits::eShaderDeviceAddress)
+	{
+		auto addressInfo = vk::BufferDeviceAddressInfo().setBuffer(result.buffer);
+		result.address = root.dev.getBufferAddress(addressInfo, root.vkDynLoader);
+	}
+
+	if (root.debugUtilsExtEnabled && debugName)
+	{
+		vk::DebugUtilsObjectNameInfoEXT objectNameInfo;
+		objectNameInfo.setObjectType(vk::ObjectType::eBuffer);
+		objectNameInfo.setObjectHandle(uint64_t(static_cast<VkBuffer>(result.buffer)));
+		objectNameInfo.setPObjectName(debugName);
+		root.dev.setDebugUtilsObjectNameEXT(objectNameInfo, root.vkDynLoader);
+	}
+
+	return result;
+}
+
+void VkRayShadowBackend::destroyRTBufferNow(RTBuffer& buf)
+{
+	if (buf.buffer)
+	{
+		vmaDestroyBuffer(root.allocator, static_cast<VkBuffer>(buf.buffer), buf.allocation);
+	}
+	buf = RTBuffer();
+}
+
+void VkRayShadowBackend::destroyRTBufferDeferred(RTBuffer& buf)
+{
+	if (!buf.buffer)
+	{
+		buf = RTBuffer();
+		return;
+	}
+	if (buffering_mechanism::isInitialized())
+	{
+		auto& frameResources = buffering_mechanism::get_current_resources();
+		frameResources.buffer_to_delete.emplace_back(std::move(buf.buffer));
+		frameResources.vmamemory_to_free.push_back(buf.allocation);
+	}
+	else
+	{
+		vmaDestroyBuffer(root.allocator, static_cast<VkBuffer>(buf.buffer), buf.allocation);
+	}
+	buf = RTBuffer();
+}
+
+void VkRayShadowBackend::destroyASDeferred(vk::AccelerationStructureKHR& as)
+{
+	if (!as)
+	{
+		return;
+	}
+	if (buffering_mechanism::isInitialized())
+	{
+		buffering_mechanism::get_current_resources().as_to_delete.push_back(as);
+	}
+	else
+	{
+		root.dev.destroyAccelerationStructureKHR(as, nullptr, root.vkDynLoader);
+	}
+	as = vk::AccelerationStructureKHR();
+}
+
+// MARK: BLAS
+
+VkRayShadowBackend::BlasEntry VkRayShadowBackend::createBlas(const float* vertices, size_t vertexCount, const uint32_t* indices, size_t indexCount, bool keepGeometryBuffer, const char* debugName)
+{
+	BlasEntry entry;
+	ASSERT_OR_RETURN(entry, vertexCount > 0 && indexCount >= 3, "Empty geometry (%s)", debugName);
+
+	const vk::DeviceSize vertexBytes = vertexCount * sizeof(float) * 3;
+	const vk::DeviceSize indexOffset = alignAddress(vertexBytes, 4);
+	const vk::DeviceSize indexBytes = indexCount * sizeof(uint32_t);
+	const uint32_t triangleCount = static_cast<uint32_t>(indexCount / 3);
+
+	// geometry buffer (device-local), filled via the per-frame staging allocator + cmdCopy
+	RTBuffer geometryBuffer = createRTBuffer(indexOffset + indexBytes,
+											 vk::BufferUsageFlagBits::eAccelerationStructureBuildInputReadOnlyKHR | vk::BufferUsageFlagBits::eShaderDeviceAddress | vk::BufferUsageFlagBits::eTransferDst,
+											 VMA_MEMORY_USAGE_GPU_ONLY, false, debugName);
+	ASSERT_OR_RETURN(entry, geometryBuffer.buffer, "Failed to create BLAS geometry buffer (%s)", debugName);
+
+	auto& frameResources = buffering_mechanism::get_current_resources();
+	const auto cmdBuffer = frameResources.currentCopyCmdBuffer();
+	{
+		const auto stagingMemory = frameResources.stagingBufferAllocator.alloc(static_cast<uint32_t>(vertexBytes), 4);
+		auto* mappedMem = frameResources.stagingBufferAllocator.mapMemory(stagingMemory);
+		memcpy(mappedMem, vertices, vertexBytes);
+		frameResources.stagingBufferAllocator.unmapMemory(stagingMemory);
+		const auto copyRegions = std::array<vk::BufferCopy, 1> { vk::BufferCopy(stagingMemory.offset, 0, vertexBytes) };
+		cmdBuffer->copyBuffer(stagingMemory.buffer, geometryBuffer.buffer, copyRegions, root.vkDynLoader);
+	}
+	{
+		const auto stagingMemory = frameResources.stagingBufferAllocator.alloc(static_cast<uint32_t>(indexBytes), 4);
+		auto* mappedMem = frameResources.stagingBufferAllocator.mapMemory(stagingMemory);
+		memcpy(mappedMem, indices, indexBytes);
+		frameResources.stagingBufferAllocator.unmapMemory(stagingMemory);
+		const auto copyRegions = std::array<vk::BufferCopy, 1> { vk::BufferCopy(stagingMemory.offset, indexOffset, indexBytes) };
+		cmdBuffer->copyBuffer(stagingMemory.buffer, geometryBuffer.buffer, copyRegions, root.vkDynLoader);
+	}
+
+	// query build sizes
+	auto triangleData = vk::AccelerationStructureGeometryTrianglesDataKHR()
+		.setVertexFormat(vk::Format::eR32G32B32Sfloat)
+		.setVertexData(vk::DeviceOrHostAddressConstKHR().setDeviceAddress(geometryBuffer.address))
+		.setVertexStride(sizeof(float) * 3)
+		.setMaxVertex(static_cast<uint32_t>(vertexCount - 1))
+		.setIndexType(vk::IndexType::eUint32)
+		.setIndexData(vk::DeviceOrHostAddressConstKHR().setDeviceAddress(geometryBuffer.address + indexOffset));
+	auto geometry = vk::AccelerationStructureGeometryKHR()
+		.setGeometryType(vk::GeometryTypeKHR::eTriangles)
+		.setFlags(vk::GeometryFlagBitsKHR::eOpaque)
+		.setGeometry(vk::AccelerationStructureGeometryDataKHR().setTriangles(triangleData));
+	auto buildInfo = vk::AccelerationStructureBuildGeometryInfoKHR()
+		.setType(vk::AccelerationStructureTypeKHR::eBottomLevel)
+		.setFlags(vk::BuildAccelerationStructureFlagBitsKHR::ePreferFastTrace)
+		.setMode(vk::BuildAccelerationStructureModeKHR::eBuild)
+		.setGeometryCount(1)
+		.setPGeometries(&geometry);
+
+	const auto buildSizes = root.dev.getAccelerationStructureBuildSizesKHR(vk::AccelerationStructureBuildTypeKHR::eDevice, buildInfo, { triangleCount }, root.vkDynLoader);
+
+	entry.asBuffer = createRTBuffer(buildSizes.accelerationStructureSize,
+									vk::BufferUsageFlagBits::eAccelerationStructureStorageKHR | vk::BufferUsageFlagBits::eShaderDeviceAddress,
+									VMA_MEMORY_USAGE_GPU_ONLY, false, debugName);
+	if (!entry.asBuffer.buffer)
+	{
+		destroyRTBufferDeferred(geometryBuffer);
+		return entry;
+	}
+
+	auto asCreateInfo = vk::AccelerationStructureCreateInfoKHR()
+		.setBuffer(entry.asBuffer.buffer)
+		.setOffset(0)
+		.setSize(buildSizes.accelerationStructureSize)
+		.setType(vk::AccelerationStructureTypeKHR::eBottomLevel);
+	entry.as = root.dev.createAccelerationStructureKHR(asCreateInfo, nullptr, root.vkDynLoader);
+	entry.address = root.dev.getAccelerationStructureAddressKHR(vk::AccelerationStructureDeviceAddressInfoKHR().setAccelerationStructure(entry.as), root.vkDynLoader);
+
+	PendingBlasBuild pending;
+	pending.dst = entry.as;
+	pending.geometryBuffer = geometryBuffer;
+	pending.vertexAddress = geometryBuffer.address;
+	pending.indexAddress = geometryBuffer.address + indexOffset;
+	pending.vertexCount = static_cast<uint32_t>(vertexCount);
+	pending.triangleCount = triangleCount;
+	pending.scratchSize = buildSizes.buildScratchSize;
+	pending.keepGeometryBuffer = keepGeometryBuffer;
+	pendingBuilds.push_back(pending);
+
+	return entry;
+}
+
+bool VkRayShadowBackend::hasMeshBLAS(const void* meshKey, int32_t variant) const
+{
+	return meshBlas.count(std::make_pair(meshKey, variant)) > 0;
+}
+
+void VkRayShadowBackend::registerMeshGeometry(const void* meshKey, int32_t variant, const float* vertices, size_t vertexCount, const uint32_t* indices, size_t indexCount)
+{
+	const auto key = std::make_pair(meshKey, variant);
+	if (meshBlas.count(key) > 0)
+	{
+		return;
+	}
+	BlasEntry entry = createBlas(vertices, vertexCount, indices, indexCount, false, "<rt mesh blas>");
+	if (!entry.as)
+	{
+		return;
+	}
+	meshBlas[key] = entry;
+}
+
+void VkRayShadowBackend::invalidateMesh(const void* meshKey)
+{
+	for (auto it = meshBlas.begin(); it != meshBlas.end(); )
+	{
+		if (it->first.first == meshKey)
+		{
+			// drop any not-yet-recorded build targeting this acceleration structure
+			pendingBuilds.erase(std::remove_if(pendingBuilds.begin(), pendingBuilds.end(), [this, &it](PendingBlasBuild& b) {
+				if (b.dst != it->second.as)
+				{
+					return false;
+				}
+				if (!b.keepGeometryBuffer)
+				{
+					destroyRTBufferDeferred(b.geometryBuffer);
+				}
+				return true;
+			}), pendingBuilds.end());
+			destroyASDeferred(it->second.as);
+			destroyRTBufferDeferred(it->second.asBuffer);
+			it = meshBlas.erase(it);
+		}
+		else
+		{
+			++it;
+		}
+	}
+}
+
+// MARK: terrain
+
+void VkRayShadowBackend::setTerrainGeometry(const float* vertices, size_t vertexCount, const uint32_t* indices, size_t indexCount)
+{
+	clearTerrainGeometry();
+
+	terrainBlas = createBlas(vertices, vertexCount, indices, indexCount, true, "<rt terrain blas>");
+	if (!terrainBlas.as)
+	{
+		return;
+	}
+	// createBlas queued the initial build; keep the geometry buffer for later vertex updates + rebuilds
+	terrainGeometryBuffer = pendingBuilds.back().geometryBuffer;
+	terrainVertexCount = static_cast<uint32_t>(vertexCount);
+	terrainTriangleCount = static_cast<uint32_t>(indexCount / 3);
+	terrainScratchSize = pendingBuilds.back().scratchSize;
+	haveTerrain = true;
+	terrainBlasDirty = false; // the initial build is already queued
+}
+
+void VkRayShadowBackend::updateTerrainVertices(size_t startVertex, const float* vertices, size_t vertexCount)
+{
+	ASSERT_OR_RETURN(, haveTerrain, "No terrain geometry set");
+	ASSERT_OR_RETURN(, startVertex + vertexCount <= terrainVertexCount, "Terrain vertex update out of range");
+
+	const vk::DeviceSize updateBytes = vertexCount * sizeof(float) * 3;
+	auto& frameResources = buffering_mechanism::get_current_resources();
+	const auto cmdBuffer = frameResources.currentCopyCmdBuffer();
+	const auto stagingMemory = frameResources.stagingBufferAllocator.alloc(static_cast<uint32_t>(updateBytes), 4);
+	auto* mappedMem = frameResources.stagingBufferAllocator.mapMemory(stagingMemory);
+	memcpy(mappedMem, vertices, updateBytes);
+	frameResources.stagingBufferAllocator.unmapMemory(stagingMemory);
+	const auto copyRegions = std::array<vk::BufferCopy, 1> { vk::BufferCopy(stagingMemory.offset, startVertex * sizeof(float) * 3, updateBytes) };
+	cmdBuffer->copyBuffer(stagingMemory.buffer, terrainGeometryBuffer.buffer, copyRegions, root.vkDynLoader);
+
+	terrainBlasDirty = true;
+}
+
+void VkRayShadowBackend::clearTerrainGeometry()
+{
+	if (!haveTerrain)
+	{
+		return;
+	}
+	// remove any pending build targeting the terrain BLAS
+	pendingBuilds.erase(std::remove_if(pendingBuilds.begin(), pendingBuilds.end(), [this](const PendingBlasBuild& b) { return b.dst == terrainBlas.as; }), pendingBuilds.end());
+	destroyASDeferred(terrainBlas.as);
+	destroyRTBufferDeferred(terrainBlas.asBuffer);
+	destroyRTBufferDeferred(terrainGeometryBuffer);
+	terrainBlas = BlasEntry();
+	terrainVertexCount = 0;
+	terrainTriangleCount = 0;
+	terrainScratchSize = 0;
+	terrainBlasDirty = false;
+	haveTerrain = false;
+}
+
+// MARK: pending builds
+
+void VkRayShadowBackend::recordPendingBuilds(vk::CommandBuffer cmdBuffer)
+{
+	// terrain rebuild (vertex data changed in-place; counts are unchanged so sizes still hold)
+	if (terrainBlasDirty && haveTerrain && terrainBlas.as)
+	{
+		const vk::DeviceSize vertexBytes = static_cast<vk::DeviceSize>(terrainVertexCount) * sizeof(float) * 3;
+		PendingBlasBuild rebuild;
+		rebuild.dst = terrainBlas.as;
+		rebuild.geometryBuffer = RTBuffer(); // owned by terrainGeometryBuffer - do not free
+		rebuild.vertexAddress = terrainGeometryBuffer.address;
+		rebuild.indexAddress = terrainGeometryBuffer.address + alignAddress(vertexBytes, 4);
+		rebuild.vertexCount = terrainVertexCount;
+		rebuild.triangleCount = terrainTriangleCount;
+		rebuild.scratchSize = terrainScratchSize;
+		rebuild.keepGeometryBuffer = true;
+		pendingBuilds.push_back(rebuild);
+		terrainBlasDirty = false;
+	}
+
+	if (pendingBuilds.empty())
+	{
+		return;
+	}
+
+	// ensure staged geometry copies (recorded earlier in cmdCopy) are complete before building
+	const auto preBuildBarrier = std::array<vk::MemoryBarrier, 1> {
+		vk::MemoryBarrier()
+			.setSrcAccessMask(vk::AccessFlagBits::eTransferWrite)
+			.setDstAccessMask(vk::AccessFlagBits::eShaderRead)
+	};
+	cmdBuffer.pipelineBarrier(vk::PipelineStageFlagBits::eTransfer,
+							  vk::PipelineStageFlagBits::eAccelerationStructureBuildKHR,
+							  vk::DependencyFlags(), preBuildBarrier, nullptr, nullptr, root.vkDynLoader);
+
+	for (auto& pending : pendingBuilds)
+	{
+		// transient scratch buffer (deferred-deleted once the frame completes)
+		RTBuffer scratch = createRTBuffer(pending.scratchSize + 256,
+										  vk::BufferUsageFlagBits::eStorageBuffer | vk::BufferUsageFlagBits::eShaderDeviceAddress,
+										  VMA_MEMORY_USAGE_GPU_ONLY, false, "<rt blas scratch>");
+		if (!scratch.buffer)
+		{
+			continue;
+		}
+
+		auto triangleData = vk::AccelerationStructureGeometryTrianglesDataKHR()
+			.setVertexFormat(vk::Format::eR32G32B32Sfloat)
+			.setVertexData(vk::DeviceOrHostAddressConstKHR().setDeviceAddress(pending.vertexAddress))
+			.setVertexStride(sizeof(float) * 3)
+			.setMaxVertex(pending.vertexCount - 1)
+			.setIndexType(vk::IndexType::eUint32)
+			.setIndexData(vk::DeviceOrHostAddressConstKHR().setDeviceAddress(pending.indexAddress));
+		auto geometry = vk::AccelerationStructureGeometryKHR()
+			.setGeometryType(vk::GeometryTypeKHR::eTriangles)
+			.setFlags(vk::GeometryFlagBitsKHR::eOpaque)
+			.setGeometry(vk::AccelerationStructureGeometryDataKHR().setTriangles(triangleData));
+		auto buildInfo = vk::AccelerationStructureBuildGeometryInfoKHR()
+			.setType(vk::AccelerationStructureTypeKHR::eBottomLevel)
+			.setFlags(vk::BuildAccelerationStructureFlagBitsKHR::ePreferFastTrace)
+			.setMode(vk::BuildAccelerationStructureModeKHR::eBuild)
+			.setDstAccelerationStructure(pending.dst)
+			.setGeometryCount(1)
+			.setPGeometries(&geometry)
+			.setScratchData(vk::DeviceOrHostAddressKHR().setDeviceAddress(alignAddress(scratch.address, 256)));
+
+		auto rangeInfo = vk::AccelerationStructureBuildRangeInfoKHR()
+			.setPrimitiveCount(pending.triangleCount)
+			.setPrimitiveOffset(0)
+			.setFirstVertex(0)
+			.setTransformOffset(0);
+		const vk::AccelerationStructureBuildRangeInfoKHR* pRangeInfo = &rangeInfo;
+
+		cmdBuffer.buildAccelerationStructuresKHR(1, &buildInfo, &pRangeInfo, root.vkDynLoader);
+
+		destroyRTBufferDeferred(scratch);
+		if (!pending.keepGeometryBuffer)
+		{
+			destroyRTBufferDeferred(pending.geometryBuffer);
+		}
+	}
+	pendingBuilds.clear();
+
+	// BLAS builds must complete before the TLAS build reads them
+	const auto postBuildBarrier = std::array<vk::MemoryBarrier, 1> {
+		vk::MemoryBarrier()
+			.setSrcAccessMask(vk::AccessFlagBits::eAccelerationStructureWriteKHR)
+			.setDstAccessMask(vk::AccessFlagBits::eAccelerationStructureReadKHR)
+	};
+	cmdBuffer.pipelineBarrier(vk::PipelineStageFlagBits::eAccelerationStructureBuildKHR,
+							  vk::PipelineStageFlagBits::eAccelerationStructureBuildKHR,
+							  vk::DependencyFlags(), postBuildBarrier, nullptr, nullptr, root.vkDynLoader);
+}
+
+// MARK: per-frame resources / TLAS
+
+VkRayShadowBackend::PerFrame& VkRayShadowBackend::currentPerFrame()
+{
+	size_t frameIdx = buffering_mechanism::get_current_frame_num();
+	if (frameIdx >= perFrame.size())
+	{
+		perFrame.resize(frameIdx + 1);
+	}
+	return perFrame[frameIdx];
+}
+
+void VkRayShadowBackend::buildTlas(vk::CommandBuffer cmdBuffer, PerFrame& pf)
+{
+	const uint32_t instanceCount = static_cast<uint32_t>(frameInstances.size());
+
+	// (re)create instance buffer if needed
+	const uint32_t neededCapacity = std::max(instanceCount, WZ_RT_MIN_INSTANCE_CAPACITY);
+	if (pf.instanceCapacity < neededCapacity || !pf.instanceBuffer.buffer)
+	{
+		destroyRTBufferDeferred(pf.instanceBuffer);
+		const uint32_t newCapacity = std::max(neededCapacity + neededCapacity / 2, WZ_RT_MIN_INSTANCE_CAPACITY);
+		pf.instanceBuffer = createRTBuffer(static_cast<vk::DeviceSize>(newCapacity) * sizeof(vk::AccelerationStructureInstanceKHR),
+										   vk::BufferUsageFlagBits::eAccelerationStructureBuildInputReadOnlyKHR | vk::BufferUsageFlagBits::eShaderDeviceAddress,
+										   VMA_MEMORY_USAGE_CPU_TO_GPU, true, "<rt tlas instances>");
+		pf.instanceCapacity = (pf.instanceBuffer.buffer) ? newCapacity : 0;
+	}
+	ASSERT_OR_RETURN(, pf.instanceBuffer.buffer && pf.instanceBuffer.pMapped, "No instance buffer");
+
+	if (instanceCount > 0)
+	{
+		memcpy(pf.instanceBuffer.pMapped, frameInstances.data(), instanceCount * sizeof(vk::AccelerationStructureInstanceKHR));
+	}
+	vmaFlushAllocation(root.allocator, pf.instanceBuffer.allocation, 0, instanceCount * sizeof(vk::AccelerationStructureInstanceKHR));
+
+	auto instancesData = vk::AccelerationStructureGeometryInstancesDataKHR()
+		.setArrayOfPointers(false)
+		.setData(vk::DeviceOrHostAddressConstKHR().setDeviceAddress(pf.instanceBuffer.address));
+	auto geometry = vk::AccelerationStructureGeometryKHR()
+		.setGeometryType(vk::GeometryTypeKHR::eInstances)
+		.setGeometry(vk::AccelerationStructureGeometryDataKHR().setInstances(instancesData));
+	auto buildInfo = vk::AccelerationStructureBuildGeometryInfoKHR()
+		.setType(vk::AccelerationStructureTypeKHR::eTopLevel)
+		.setFlags(vk::BuildAccelerationStructureFlagBitsKHR::ePreferFastBuild)
+		.setMode(vk::BuildAccelerationStructureModeKHR::eBuild)
+		.setGeometryCount(1)
+		.setPGeometries(&geometry);
+
+	// (re)create the TLAS + scratch if capacity is insufficient
+	if (pf.tlasCapacity < instanceCount || !pf.tlas)
+	{
+		const uint32_t newCapacity = std::max(std::max(instanceCount + instanceCount / 2, WZ_RT_MIN_INSTANCE_CAPACITY), pf.tlasCapacity);
+		const auto buildSizes = root.dev.getAccelerationStructureBuildSizesKHR(vk::AccelerationStructureBuildTypeKHR::eDevice, buildInfo, { newCapacity }, root.vkDynLoader);
+
+		destroyASDeferred(pf.tlas);
+		destroyRTBufferDeferred(pf.tlasBuffer);
+		destroyRTBufferDeferred(pf.tlasScratchBuffer);
+
+		pf.tlasBuffer = createRTBuffer(buildSizes.accelerationStructureSize,
+									   vk::BufferUsageFlagBits::eAccelerationStructureStorageKHR | vk::BufferUsageFlagBits::eShaderDeviceAddress,
+									   VMA_MEMORY_USAGE_GPU_ONLY, false, "<rt tlas>");
+		ASSERT_OR_RETURN(, pf.tlasBuffer.buffer, "Failed to create TLAS buffer");
+		pf.tlasScratchBuffer = createRTBuffer(buildSizes.buildScratchSize + 256,
+											  vk::BufferUsageFlagBits::eStorageBuffer | vk::BufferUsageFlagBits::eShaderDeviceAddress,
+											  VMA_MEMORY_USAGE_GPU_ONLY, false, "<rt tlas scratch>");
+		ASSERT_OR_RETURN(, pf.tlasScratchBuffer.buffer, "Failed to create TLAS scratch buffer");
+
+		auto asCreateInfo = vk::AccelerationStructureCreateInfoKHR()
+			.setBuffer(pf.tlasBuffer.buffer)
+			.setOffset(0)
+			.setSize(buildSizes.accelerationStructureSize)
+			.setType(vk::AccelerationStructureTypeKHR::eTopLevel);
+		pf.tlas = root.dev.createAccelerationStructureKHR(asCreateInfo, nullptr, root.vkDynLoader);
+		pf.tlasCapacity = newCapacity;
+	}
+
+	buildInfo.setDstAccelerationStructure(pf.tlas);
+	buildInfo.setScratchData(vk::DeviceOrHostAddressKHR().setDeviceAddress(alignAddress(pf.tlasScratchBuffer.address, 256)));
+
+	auto rangeInfo = vk::AccelerationStructureBuildRangeInfoKHR()
+		.setPrimitiveCount(instanceCount)
+		.setPrimitiveOffset(0)
+		.setFirstVertex(0)
+		.setTransformOffset(0);
+	const vk::AccelerationStructureBuildRangeInfoKHR* pRangeInfo = &rangeInfo;
+
+	cmdBuffer.buildAccelerationStructuresKHR(1, &buildInfo, &pRangeInfo, root.vkDynLoader);
+
+	// TLAS build must complete before the fragment-shader ray queries read it
+	const auto postTlasBarrier = std::array<vk::MemoryBarrier, 1> {
+		vk::MemoryBarrier()
+			.setSrcAccessMask(vk::AccessFlagBits::eAccelerationStructureWriteKHR)
+			.setDstAccessMask(vk::AccessFlagBits::eAccelerationStructureReadKHR)
+	};
+	cmdBuffer.pipelineBarrier(vk::PipelineStageFlagBits::eAccelerationStructureBuildKHR,
+							  vk::PipelineStageFlagBits::eFragmentShader,
+							  vk::DependencyFlags(), postTlasBarrier, nullptr, nullptr, root.vkDynLoader);
+}
+
+// MARK: frame instance list
+
+void VkRayShadowBackend::beginFrame()
+{
+	frameInstances.clear();
+}
+
+void VkRayShadowBackend::addInstance(const void* meshKey, int32_t variant, const glm::mat4& worldTransform)
+{
+	auto it = meshBlas.find(std::make_pair(meshKey, variant));
+	if (it == meshBlas.end())
+	{
+		return;
+	}
+	auto instance = vk::AccelerationStructureInstanceKHR()
+		.setTransform(toVkTransform(worldTransform))
+		.setInstanceCustomIndex(0)
+		.setMask(0xFF)
+		.setInstanceShaderBindingTableRecordOffset(0)
+		.setFlags(vk::GeometryInstanceFlagBitsKHR::eTriangleFacingCullDisable | vk::GeometryInstanceFlagBitsKHR::eForceOpaque)
+		.setAccelerationStructureReference(it->second.address);
+	frameInstances.push_back(instance);
+}
+
+void VkRayShadowBackend::addTerrainInstance()
+{
+	if (!haveTerrain || !terrainBlas.as)
+	{
+		return;
+	}
+	auto instance = vk::AccelerationStructureInstanceKHR()
+		.setTransform(toVkTransform(glm::mat4(1.f)))
+		.setInstanceCustomIndex(0)
+		.setMask(0xFF)
+		.setInstanceShaderBindingTableRecordOffset(0)
+		.setFlags(vk::GeometryInstanceFlagBitsKHR::eTriangleFacingCullDisable | vk::GeometryInstanceFlagBitsKHR::eForceOpaque)
+		.setAccelerationStructureReference(terrainBlas.address);
+	frameInstances.push_back(instance);
+}
+
+// MARK: images
+
+vk::Extent2D VkRayShadowBackend::targetMaskExtent() const
+{
+	uint32_t divisor = 1;
+	switch (mode)
+	{
+		case gfx_api::ray_shadow_mode::HalfRes: divisor = 2; break;
+		case gfx_api::ray_shadow_mode::QuarterRes: divisor = 4; break;
+		default: break;
+	}
+	return vk::Extent2D(std::max(1u, (root.swapchainSize.width + divisor - 1) / divisor),
+						std::max(1u, (root.swapchainSize.height + divisor - 1) / divisor));
+}
+
+void VkRayShadowBackend::destroyImages()
+{
+	maskValid = false;
+	if (buffering_mechanism::isInitialized())
+	{
+		auto& frameResources = buffering_mechanism::get_current_resources();
+		if (rtDepthFbo) { frameResources.fbo_to_delete.push_back(rtDepthFbo); rtDepthFbo = vk::Framebuffer(); }
+		if (maskFboA) { frameResources.fbo_to_delete.push_back(maskFboA); maskFboA = vk::Framebuffer(); }
+		if (maskFboB) { frameResources.fbo_to_delete.push_back(maskFboB); maskFboB = vk::Framebuffer(); }
+		if (rtDepthView) { frameResources.image_view_to_delete.emplace_back(std::move(rtDepthView)); }
+		if (rtDepthImage)
+		{
+			frameResources.image_to_delete.emplace_back(std::move(rtDepthImage));
+			rtDepthImage = vk::Image();
+			frameResources.vmamemory_to_free.push_back(rtDepthAllocation);
+			rtDepthAllocation = VK_NULL_HANDLE;
+		}
+	}
+	else
+	{
+		if (rtDepthFbo) { root.dev.destroyFramebuffer(rtDepthFbo, nullptr, root.vkDynLoader); rtDepthFbo = vk::Framebuffer(); }
+		if (maskFboA) { root.dev.destroyFramebuffer(maskFboA, nullptr, root.vkDynLoader); maskFboA = vk::Framebuffer(); }
+		if (maskFboB) { root.dev.destroyFramebuffer(maskFboB, nullptr, root.vkDynLoader); maskFboB = vk::Framebuffer(); }
+		rtDepthView.reset();
+		if (rtDepthImage)
+		{
+			root.dev.destroyImage(rtDepthImage, nullptr, root.vkDynLoader);
+			rtDepthImage = vk::Image();
+			vmaFreeMemory(root.allocator, rtDepthAllocation);
+			rtDepthAllocation = VK_NULL_HANDLE;
+		}
+	}
+	// VkRenderedImage destructor defers destruction (or releases if the buffering mechanism is gone)
+	delete pMaskImageA;
+	pMaskImageA = nullptr;
+	delete pMaskImageB;
+	pMaskImageB = nullptr;
+	maskExtent = vk::Extent2D(0, 0);
+}
+
+bool VkRayShadowBackend::recreateImagesIfNeeded()
+{
+	const auto target = targetMaskExtent();
+	if (maskExtent == target && pMaskImageA && rtDepthImage)
+	{
+		return true;
+	}
+
+	destroyImages();
+
+	try
+	{
+		// camera depth image (same format + render pass as the shadow-map depth passes)
+		auto imageCreateInfo = vk::ImageCreateInfo()
+			.setArrayLayers(1)
+			.setExtent(vk::Extent3D(target.width, target.height, 1))
+			.setImageType(vk::ImageType::e2D)
+			.setMipLevels(1)
+			.setTiling(vk::ImageTiling::eOptimal)
+			.setFormat(root.depthBufferFormat)
+			.setUsage(vk::ImageUsageFlagBits::eDepthStencilAttachment | vk::ImageUsageFlagBits::eSampled)
+			.setInitialLayout(vk::ImageLayout::eUndefined)
+			.setSamples(vk::SampleCountFlagBits::e1)
+			.setSharingMode(vk::SharingMode::eExclusive);
+		VmaAllocationCreateInfo allocInfo = {};
+		allocInfo.usage = VMA_MEMORY_USAGE_GPU_ONLY;
+		VkResult result = vmaCreateImage(root.allocator, reinterpret_cast<const VkImageCreateInfo*>(&imageCreateInfo), &allocInfo, reinterpret_cast<VkImage*>(&rtDepthImage), &rtDepthAllocation, nullptr);
+		if (result != VK_SUCCESS)
+		{
+			debug(LOG_ERROR, "Failed to create ray-shadow depth image: %s", to_string(static_cast<vk::Result>(result)).c_str());
+			return false;
+		}
+
+		const auto depthViewCreateInfo = vk::ImageViewCreateInfo()
+			.setImage(rtDepthImage)
+			.setViewType(vk::ImageViewType::e2D)
+			.setFormat(root.depthBufferFormat)
+			.setComponents(vk::ComponentMapping())
+			.setSubresourceRange(vk::ImageSubresourceRange(vk::ImageAspectFlagBits::eDepth, 0, 1, 0, 1));
+		rtDepthView = root.dev.createImageViewUnique(depthViewCreateInfo, nullptr, root.vkDynLoader);
+
+		vk::ImageView nonUniqueDepthView = rtDepthView.get();
+		rtDepthFbo = root.dev.createFramebuffer(
+			vk::FramebufferCreateInfo()
+			.setAttachmentCount(1)
+			.setPAttachments(&nonUniqueDepthView)
+			.setLayers(1)
+			.setWidth(target.width)
+			.setHeight(target.height)
+			.setRenderPass(root.renderPasses[root.DEPTH_RENDER_PASS_ID].rp)
+			, nullptr, root.vkDynLoader);
+
+		// mask images (R8)
+		pMaskImageA = new VkRenderedImage(root, target.width, target.height, vk::Format::eR8G8Unorm, "<rt shadow mask A>");
+		pMaskImageB = new VkRenderedImage(root, target.width, target.height, vk::Format::eR8G8Unorm, "<rt shadow mask B>");
+
+		vk::ImageView maskViewA = pMaskImageA->view.get();
+		maskFboA = root.dev.createFramebuffer(
+			vk::FramebufferCreateInfo()
+			.setAttachmentCount(1)
+			.setPAttachments(&maskViewA)
+			.setLayers(1)
+			.setWidth(target.width)
+			.setHeight(target.height)
+			.setRenderPass(maskRenderPass)
+			, nullptr, root.vkDynLoader);
+		vk::ImageView maskViewB = pMaskImageB->view.get();
+		maskFboB = root.dev.createFramebuffer(
+			vk::FramebufferCreateInfo()
+			.setAttachmentCount(1)
+			.setPAttachments(&maskViewB)
+			.setLayers(1)
+			.setWidth(target.width)
+			.setHeight(target.height)
+			.setRenderPass(maskRenderPass)
+			, nullptr, root.vkDynLoader);
+	}
+	catch (const vk::SystemError& e)
+	{
+		debug(LOG_ERROR, "Failed to create ray-shadow images: %s", e.what());
+		destroyImages();
+		return false;
+	}
+
+	maskExtent = target;
+	return true;
+}
+
+// MARK: pipelines
+
+bool VkRayShadowBackend::createPipelines()
+{
+	if (pipelinesCreated)
+	{
+		return true;
+	}
+
+	auto vertSpv = readSpvFile("shaders/vk/rayshadow_fullscreen.vert.spv");
+	auto traceSpv = readSpvFile("shaders/vk/rayshadow_mask.frag.spv");
+	auto blurSpv = readSpvFile("shaders/vk/rayshadow_blur.frag.spv");
+	if (vertSpv.empty() || traceSpv.empty() || blurSpv.empty())
+	{
+		debug(LOG_INFO, "Ray-traced shadows unavailable: shaders not found (shaders/vk/rayshadow_*.spv)");
+		return false;
+	}
+
+	try
+	{
+		fullscreenVertShader = root.dev.createShaderModule(vk::ShaderModuleCreateInfo().setCodeSize(vertSpv.size() * 4).setPCode(vertSpv.data()), nullptr, root.vkDynLoader);
+		traceFragShader = root.dev.createShaderModule(vk::ShaderModuleCreateInfo().setCodeSize(traceSpv.size() * 4).setPCode(traceSpv.data()), nullptr, root.vkDynLoader);
+		blurFragShader = root.dev.createShaderModule(vk::ShaderModuleCreateInfo().setCodeSize(blurSpv.size() * 4).setPCode(blurSpv.data()), nullptr, root.vkDynLoader);
+
+		// samplers
+		depthSampler = root.dev.createSampler(vk::SamplerCreateInfo()
+			.setMinFilter(vk::Filter::eNearest).setMagFilter(vk::Filter::eNearest)
+			.setMipmapMode(vk::SamplerMipmapMode::eNearest)
+			.setAddressModeU(vk::SamplerAddressMode::eClampToEdge)
+			.setAddressModeV(vk::SamplerAddressMode::eClampToEdge)
+			.setAddressModeW(vk::SamplerAddressMode::eClampToEdge)
+			.setMaxLod(0.f), nullptr, root.vkDynLoader);
+		maskSampler = root.dev.createSampler(vk::SamplerCreateInfo()
+			.setMinFilter(vk::Filter::eLinear).setMagFilter(vk::Filter::eLinear)
+			.setMipmapMode(vk::SamplerMipmapMode::eNearest)
+			.setAddressModeU(vk::SamplerAddressMode::eClampToEdge)
+			.setAddressModeV(vk::SamplerAddressMode::eClampToEdge)
+			.setAddressModeW(vk::SamplerAddressMode::eClampToEdge)
+			.setMaxLod(0.f), nullptr, root.vkDynLoader);
+
+		// mask render pass (R8 color, no depth); used by the trace pass and both blur passes
+		auto colorAttachment = vk::AttachmentDescription()
+			.setFormat(vk::Format::eR8G8Unorm)
+			.setSamples(vk::SampleCountFlagBits::e1)
+			.setInitialLayout(vk::ImageLayout::eUndefined)
+			.setFinalLayout(vk::ImageLayout::eShaderReadOnlyOptimal)
+			.setLoadOp(vk::AttachmentLoadOp::eDontCare)
+			.setStoreOp(vk::AttachmentStoreOp::eStore)
+			.setStencilLoadOp(vk::AttachmentLoadOp::eDontCare)
+			.setStencilStoreOp(vk::AttachmentStoreOp::eDontCare);
+		const auto colorAttachmentRef = vk::AttachmentReference().setAttachment(0).setLayout(vk::ImageLayout::eColorAttachmentOptimal);
+		const auto subpass = vk::SubpassDescription()
+			.setPipelineBindPoint(vk::PipelineBindPoint::eGraphics)
+			.setColorAttachmentCount(1)
+			.setPColorAttachments(&colorAttachmentRef);
+		const std::array<vk::SubpassDependency, 2> dependencies {
+			vk::SubpassDependency()
+				.setSrcSubpass(VK_SUBPASS_EXTERNAL)
+				.setDstSubpass(0)
+				.setSrcStageMask(vk::PipelineStageFlagBits::eFragmentShader)
+				.setDstStageMask(vk::PipelineStageFlagBits::eColorAttachmentOutput)
+				.setSrcAccessMask(vk::AccessFlagBits::eShaderRead)
+				.setDstAccessMask(vk::AccessFlagBits::eColorAttachmentWrite),
+			vk::SubpassDependency()
+				.setSrcSubpass(0)
+				.setDstSubpass(VK_SUBPASS_EXTERNAL)
+				.setSrcStageMask(vk::PipelineStageFlagBits::eColorAttachmentOutput)
+				.setDstStageMask(vk::PipelineStageFlagBits::eFragmentShader)
+				.setSrcAccessMask(vk::AccessFlagBits::eColorAttachmentWrite)
+				.setDstAccessMask(vk::AccessFlagBits::eShaderRead)
+		};
+		maskRenderPass = root.dev.createRenderPass(vk::RenderPassCreateInfo()
+			.setAttachmentCount(1)
+			.setPAttachments(&colorAttachment)
+			.setSubpassCount(1)
+			.setPSubpasses(&subpass)
+			.setDependencyCount(static_cast<uint32_t>(dependencies.size()))
+			.setPDependencies(dependencies.data()), nullptr, root.vkDynLoader);
+
+		// descriptor set layouts
+		const std::array<vk::DescriptorSetLayoutBinding, 2> traceBindings {
+			vk::DescriptorSetLayoutBinding().setBinding(0).setDescriptorType(vk::DescriptorType::eAccelerationStructureKHR).setDescriptorCount(1).setStageFlags(vk::ShaderStageFlagBits::eFragment),
+			vk::DescriptorSetLayoutBinding().setBinding(1).setDescriptorType(vk::DescriptorType::eCombinedImageSampler).setDescriptorCount(1).setStageFlags(vk::ShaderStageFlagBits::eFragment)
+		};
+		traceDescLayout = root.dev.createDescriptorSetLayout(vk::DescriptorSetLayoutCreateInfo()
+			.setBindingCount(static_cast<uint32_t>(traceBindings.size())).setPBindings(traceBindings.data()), nullptr, root.vkDynLoader);
+
+		const std::array<vk::DescriptorSetLayoutBinding, 2> blurBindings {
+			vk::DescriptorSetLayoutBinding().setBinding(0).setDescriptorType(vk::DescriptorType::eCombinedImageSampler).setDescriptorCount(1).setStageFlags(vk::ShaderStageFlagBits::eFragment),
+			vk::DescriptorSetLayoutBinding().setBinding(1).setDescriptorType(vk::DescriptorType::eCombinedImageSampler).setDescriptorCount(1).setStageFlags(vk::ShaderStageFlagBits::eFragment)
+		};
+		blurDescLayout = root.dev.createDescriptorSetLayout(vk::DescriptorSetLayoutCreateInfo()
+			.setBindingCount(static_cast<uint32_t>(blurBindings.size())).setPBindings(blurBindings.data()), nullptr, root.vkDynLoader);
+
+		// pipeline layouts
+		const auto tracePushRange = vk::PushConstantRange().setStageFlags(vk::ShaderStageFlagBits::eFragment).setOffset(0).setSize(sizeof(TracePushConstants));
+		tracePipelineLayout = root.dev.createPipelineLayout(vk::PipelineLayoutCreateInfo()
+			.setSetLayoutCount(1).setPSetLayouts(&traceDescLayout)
+			.setPushConstantRangeCount(1).setPPushConstantRanges(&tracePushRange), nullptr, root.vkDynLoader);
+		const auto blurPushRange = vk::PushConstantRange().setStageFlags(vk::ShaderStageFlagBits::eFragment).setOffset(0).setSize(sizeof(BlurPushConstants));
+		blurPipelineLayout = root.dev.createPipelineLayout(vk::PipelineLayoutCreateInfo()
+			.setSetLayoutCount(1).setPSetLayouts(&blurDescLayout)
+			.setPushConstantRangeCount(1).setPPushConstantRanges(&blurPushRange), nullptr, root.vkDynLoader);
+
+		// pipelines (fullscreen triangle; no vertex inputs; dynamic viewport/scissor)
+		const auto vertexInputState = vk::PipelineVertexInputStateCreateInfo();
+		const auto inputAssemblyState = vk::PipelineInputAssemblyStateCreateInfo().setTopology(vk::PrimitiveTopology::eTriangleList);
+		const auto viewportState = vk::PipelineViewportStateCreateInfo().setViewportCount(1).setScissorCount(1);
+		const auto rasterizationState = vk::PipelineRasterizationStateCreateInfo()
+			.setPolygonMode(vk::PolygonMode::eFill)
+			.setCullMode(vk::CullModeFlagBits::eNone)
+			.setFrontFace(vk::FrontFace::eCounterClockwise)
+			.setLineWidth(1.f);
+		const auto multisampleState = vk::PipelineMultisampleStateCreateInfo().setRasterizationSamples(vk::SampleCountFlagBits::e1);
+		const auto depthStencilState = vk::PipelineDepthStencilStateCreateInfo();
+		const auto colorBlendAttachment = vk::PipelineColorBlendAttachmentState()
+			.setBlendEnable(false)
+			.setColorWriteMask(vk::ColorComponentFlagBits::eR | vk::ColorComponentFlagBits::eG | vk::ColorComponentFlagBits::eB | vk::ColorComponentFlagBits::eA);
+		const auto colorBlendState = vk::PipelineColorBlendStateCreateInfo().setAttachmentCount(1).setPAttachments(&colorBlendAttachment);
+		const std::array<vk::DynamicState, 2> dynamicStates { vk::DynamicState::eViewport, vk::DynamicState::eScissor };
+		const auto dynamicState = vk::PipelineDynamicStateCreateInfo().setDynamicStateCount(static_cast<uint32_t>(dynamicStates.size())).setPDynamicStates(dynamicStates.data());
+
+		auto makePipeline = [&](vk::ShaderModule fragModule, vk::PipelineLayout layout) -> vk::Pipeline {
+			const std::array<vk::PipelineShaderStageCreateInfo, 2> stages {
+				vk::PipelineShaderStageCreateInfo().setModule(fullscreenVertShader).setPName("main").setStage(vk::ShaderStageFlagBits::eVertex),
+				vk::PipelineShaderStageCreateInfo().setModule(fragModule).setPName("main").setStage(vk::ShaderStageFlagBits::eFragment)
+			};
+			auto createInfo = vk::GraphicsPipelineCreateInfo()
+				.setStageCount(static_cast<uint32_t>(stages.size()))
+				.setPStages(stages.data())
+				.setPVertexInputState(&vertexInputState)
+				.setPInputAssemblyState(&inputAssemblyState)
+				.setPViewportState(&viewportState)
+				.setPRasterizationState(&rasterizationState)
+				.setPMultisampleState(&multisampleState)
+				.setPDepthStencilState(&depthStencilState)
+				.setPColorBlendState(&colorBlendState)
+				.setPDynamicState(&dynamicState)
+				.setLayout(layout)
+				.setRenderPass(maskRenderPass);
+			auto result = root.dev.createGraphicsPipeline(vk::PipelineCache(), createInfo, nullptr, root.vkDynLoader);
+			if (result.result != vk::Result::eSuccess)
+			{
+				WZ_THROW_VK_RESULT_EXCEPTION_RT(result.result, "createGraphicsPipeline");
+			}
+			return result.value;
+		};
+
+		tracePipeline = makePipeline(traceFragShader, tracePipelineLayout);
+		blurPipeline = makePipeline(blurFragShader, blurPipelineLayout);
+
+		// descriptor pool (per-frame sets: 1 trace + 2 blur + 1 material TLAS)
+		const std::array<vk::DescriptorPoolSize, 2> poolSizes {
+			vk::DescriptorPoolSize(vk::DescriptorType::eAccelerationStructureKHR, 16),
+			vk::DescriptorPoolSize(vk::DescriptorType::eCombinedImageSampler, 32)
+		};
+		descriptorPool = root.dev.createDescriptorPool(vk::DescriptorPoolCreateInfo()
+			.setMaxSets(24)
+			.setPoolSizeCount(static_cast<uint32_t>(poolSizes.size()))
+			.setPPoolSizes(poolSizes.data()), nullptr, root.vkDynLoader);
+
+		// TLAS descriptor set layout for material-shader ray-query pipeline variants
+		// (published on the root so VkPSO creation can append it to pipeline layouts)
+		const auto materialTlasBinding = vk::DescriptorSetLayoutBinding()
+			.setBinding(0)
+			.setDescriptorType(vk::DescriptorType::eAccelerationStructureKHR)
+			.setDescriptorCount(1)
+			.setStageFlags(vk::ShaderStageFlagBits::eFragment);
+		root.materialTlasSetLayout = root.dev.createDescriptorSetLayout(vk::DescriptorSetLayoutCreateInfo()
+			.setBindingCount(1).setPBindings(&materialTlasBinding), nullptr, root.vkDynLoader);
+	}
+	catch (const vk::SystemError& e)
+	{
+		debug(LOG_ERROR, "Failed to create ray-shadow pipelines: %s", e.what());
+		destroyPipelines();
+		return false;
+	}
+
+	if (!createEmptyTlas())
+	{
+		destroyPipelines();
+		return false;
+	}
+
+	pipelinesCreated = true;
+	return true;
+}
+
+bool VkRayShadowBackend::createEmptyTlas()
+{
+	// build a 0-instance TLAS as a safe fallback for material-shader ray queries on frames
+	// where no trace has run yet (e.g. menus); queries against it always miss
+	auto instancesData = vk::AccelerationStructureGeometryInstancesDataKHR()
+		.setArrayOfPointers(false)
+		.setData(vk::DeviceOrHostAddressConstKHR().setDeviceAddress(0));
+	auto geometry = vk::AccelerationStructureGeometryKHR()
+		.setGeometryType(vk::GeometryTypeKHR::eInstances)
+		.setGeometry(vk::AccelerationStructureGeometryDataKHR().setInstances(instancesData));
+	auto buildInfo = vk::AccelerationStructureBuildGeometryInfoKHR()
+		.setType(vk::AccelerationStructureTypeKHR::eTopLevel)
+		.setFlags(vk::BuildAccelerationStructureFlagBitsKHR::ePreferFastBuild)
+		.setMode(vk::BuildAccelerationStructureModeKHR::eBuild)
+		.setGeometryCount(1)
+		.setPGeometries(&geometry);
+
+	const auto buildSizes = root.dev.getAccelerationStructureBuildSizesKHR(vk::AccelerationStructureBuildTypeKHR::eDevice, buildInfo, { 0u }, root.vkDynLoader);
+
+	emptyTlasBuffer = createRTBuffer(buildSizes.accelerationStructureSize,
+									 vk::BufferUsageFlagBits::eAccelerationStructureStorageKHR | vk::BufferUsageFlagBits::eShaderDeviceAddress,
+									 VMA_MEMORY_USAGE_GPU_ONLY, false, "<rt empty tlas>");
+	ASSERT_OR_RETURN(false, emptyTlasBuffer.buffer, "Failed to create empty TLAS buffer");
+	RTBuffer scratch = createRTBuffer(buildSizes.buildScratchSize + 256,
+									  vk::BufferUsageFlagBits::eStorageBuffer | vk::BufferUsageFlagBits::eShaderDeviceAddress,
+									  VMA_MEMORY_USAGE_GPU_ONLY, false, "<rt empty tlas scratch>");
+	if (!scratch.buffer)
+	{
+		destroyRTBufferNow(emptyTlasBuffer);
+		return false;
+	}
+
+	auto asCreateInfo = vk::AccelerationStructureCreateInfoKHR()
+		.setBuffer(emptyTlasBuffer.buffer)
+		.setOffset(0)
+		.setSize(buildSizes.accelerationStructureSize)
+		.setType(vk::AccelerationStructureTypeKHR::eTopLevel);
+	emptyTlas = root.dev.createAccelerationStructureKHR(asCreateInfo, nullptr, root.vkDynLoader);
+
+	buildInfo.setDstAccelerationStructure(emptyTlas);
+	buildInfo.setScratchData(vk::DeviceOrHostAddressKHR().setDeviceAddress(alignAddress(scratch.address, 256)));
+
+	auto rangeInfo = vk::AccelerationStructureBuildRangeInfoKHR()
+		.setPrimitiveCount(0)
+		.setPrimitiveOffset(0)
+		.setFirstVertex(0)
+		.setTransformOffset(0);
+	const vk::AccelerationStructureBuildRangeInfoKHR* pRangeInfo = &rangeInfo;
+
+	auto cmdBuffer = buffering_mechanism::get_current_resources().copyCmdBuffer();
+	cmdBuffer.buildAccelerationStructuresKHR(1, &buildInfo, &pRangeInfo, root.vkDynLoader);
+	const auto postBuildBarrier = std::array<vk::MemoryBarrier, 1> {
+		vk::MemoryBarrier()
+			.setSrcAccessMask(vk::AccessFlagBits::eAccelerationStructureWriteKHR)
+			.setDstAccessMask(vk::AccessFlagBits::eAccelerationStructureReadKHR)
+	};
+	cmdBuffer.pipelineBarrier(vk::PipelineStageFlagBits::eAccelerationStructureBuildKHR,
+							  vk::PipelineStageFlagBits::eFragmentShader,
+							  vk::DependencyFlags(), postBuildBarrier, nullptr, nullptr, root.vkDynLoader);
+
+	destroyRTBufferDeferred(scratch);
+	return true;
+}
+
+void VkRayShadowBackend::writeMaterialTlasDescSet(PerFrame& pf, vk::AccelerationStructureKHR tlas)
+{
+	if (!pf.materialTlasDescSet)
+	{
+		const std::array<vk::DescriptorSetLayout, 1> layouts { root.materialTlasSetLayout };
+		auto sets = root.dev.allocateDescriptorSets(vk::DescriptorSetAllocateInfo()
+			.setDescriptorPool(descriptorPool)
+			.setDescriptorSetCount(1)
+			.setPSetLayouts(layouts.data()), root.vkDynLoader);
+		pf.materialTlasDescSet = sets[0];
+	}
+	auto tlasWriteInfo = vk::WriteDescriptorSetAccelerationStructureKHR()
+		.setAccelerationStructureCount(1)
+		.setPAccelerationStructures(&tlas);
+	const auto write = vk::WriteDescriptorSet()
+		.setDstSet(pf.materialTlasDescSet)
+		.setDstBinding(0)
+		.setDescriptorCount(1)
+		.setDescriptorType(vk::DescriptorType::eAccelerationStructureKHR)
+		.setPNext(&tlasWriteInfo);
+	root.dev.updateDescriptorSets(1, &write, 0, nullptr, root.vkDynLoader);
+}
+
+vk::DescriptorSet VkRayShadowBackend::getMaterialTlasDescSet()
+{
+	if (!pipelinesCreated || !emptyTlas)
+	{
+		return vk::DescriptorSet();
+	}
+	// only ever called for the current frame (whose prior submission has been fence-waited),
+	// so updating this frame's descriptor set here is safe
+	PerFrame& pf = currentPerFrame();
+	if (!pf.materialTlasDescSet || pf.materialTlasDescSetStale)
+	{
+		writeMaterialTlasDescSet(pf, emptyTlas);
+		pf.materialTlasDescSetStale = false;
+	}
+	return pf.materialTlasDescSet;
+}
+
+void VkRayShadowBackend::destroyPipelines()
+{
+	// only called at shutdown or after pipeline-creation failure (no deferred destruction needed:
+	// either nothing was submitted using these, or the device is idle at shutdown)
+	if (tracePipeline) { root.dev.destroyPipeline(tracePipeline, nullptr, root.vkDynLoader); tracePipeline = vk::Pipeline(); }
+	if (blurPipeline) { root.dev.destroyPipeline(blurPipeline, nullptr, root.vkDynLoader); blurPipeline = vk::Pipeline(); }
+	if (tracePipelineLayout) { root.dev.destroyPipelineLayout(tracePipelineLayout, nullptr, root.vkDynLoader); tracePipelineLayout = vk::PipelineLayout(); }
+	if (blurPipelineLayout) { root.dev.destroyPipelineLayout(blurPipelineLayout, nullptr, root.vkDynLoader); blurPipelineLayout = vk::PipelineLayout(); }
+	if (traceDescLayout) { root.dev.destroyDescriptorSetLayout(traceDescLayout, nullptr, root.vkDynLoader); traceDescLayout = vk::DescriptorSetLayout(); }
+	if (blurDescLayout) { root.dev.destroyDescriptorSetLayout(blurDescLayout, nullptr, root.vkDynLoader); blurDescLayout = vk::DescriptorSetLayout(); }
+	if (descriptorPool) { root.dev.destroyDescriptorPool(descriptorPool, nullptr, root.vkDynLoader); descriptorPool = vk::DescriptorPool(); }
+	if (root.materialTlasSetLayout) { root.dev.destroyDescriptorSetLayout(root.materialTlasSetLayout, nullptr, root.vkDynLoader); root.materialTlasSetLayout = vk::DescriptorSetLayout(); }
+	if (emptyTlas) { root.dev.destroyAccelerationStructureKHR(emptyTlas, nullptr, root.vkDynLoader); emptyTlas = vk::AccelerationStructureKHR(); }
+	destroyRTBufferNow(emptyTlasBuffer);
+	if (maskRenderPass) { root.dev.destroyRenderPass(maskRenderPass, nullptr, root.vkDynLoader); maskRenderPass = vk::RenderPass(); }
+	if (depthSampler) { root.dev.destroySampler(depthSampler, nullptr, root.vkDynLoader); depthSampler = vk::Sampler(); }
+	if (maskSampler) { root.dev.destroySampler(maskSampler, nullptr, root.vkDynLoader); maskSampler = vk::Sampler(); }
+	if (fullscreenVertShader) { root.dev.destroyShaderModule(fullscreenVertShader, nullptr, root.vkDynLoader); fullscreenVertShader = vk::ShaderModule(); }
+	if (traceFragShader) { root.dev.destroyShaderModule(traceFragShader, nullptr, root.vkDynLoader); traceFragShader = vk::ShaderModule(); }
+	if (blurFragShader) { root.dev.destroyShaderModule(blurFragShader, nullptr, root.vkDynLoader); blurFragShader = vk::ShaderModule(); }
+	pipelinesCreated = false;
+}
+
+// MARK: descriptor sets
+
+void VkRayShadowBackend::updateDescriptorSets(PerFrame& pf)
+{
+	if (!pf.descSetsAllocated)
+	{
+		const std::array<vk::DescriptorSetLayout, 3> layouts { traceDescLayout, blurDescLayout, blurDescLayout };
+		auto sets = root.dev.allocateDescriptorSets(vk::DescriptorSetAllocateInfo()
+			.setDescriptorPool(descriptorPool)
+			.setDescriptorSetCount(static_cast<uint32_t>(layouts.size()))
+			.setPSetLayouts(layouts.data()), root.vkDynLoader);
+		pf.traceDescSet = sets[0];
+		pf.blurDescSetA = sets[1];
+		pf.blurDescSetB = sets[2];
+		pf.descSetsAllocated = true;
+	}
+
+	auto tlasWriteInfo = vk::WriteDescriptorSetAccelerationStructureKHR()
+		.setAccelerationStructureCount(1)
+		.setPAccelerationStructures(&pf.tlas);
+	auto depthImageInfo = vk::DescriptorImageInfo()
+		.setSampler(depthSampler)
+		.setImageView(rtDepthView.get())
+		.setImageLayout(vk::ImageLayout::eDepthStencilReadOnlyOptimal);
+	auto maskAImageInfo = vk::DescriptorImageInfo()
+		.setSampler(maskSampler)
+		.setImageView(pMaskImageA->view.get())
+		.setImageLayout(vk::ImageLayout::eShaderReadOnlyOptimal);
+	auto maskBImageInfo = vk::DescriptorImageInfo()
+		.setSampler(maskSampler)
+		.setImageView(pMaskImageB->view.get())
+		.setImageLayout(vk::ImageLayout::eShaderReadOnlyOptimal);
+
+	const std::array<vk::WriteDescriptorSet, 6> writes {
+		vk::WriteDescriptorSet().setDstSet(pf.traceDescSet).setDstBinding(0).setDescriptorCount(1).setDescriptorType(vk::DescriptorType::eAccelerationStructureKHR).setPNext(&tlasWriteInfo),
+		vk::WriteDescriptorSet().setDstSet(pf.traceDescSet).setDstBinding(1).setDescriptorCount(1).setDescriptorType(vk::DescriptorType::eCombinedImageSampler).setPImageInfo(&depthImageInfo),
+		vk::WriteDescriptorSet().setDstSet(pf.blurDescSetA).setDstBinding(0).setDescriptorCount(1).setDescriptorType(vk::DescriptorType::eCombinedImageSampler).setPImageInfo(&maskAImageInfo),
+		vk::WriteDescriptorSet().setDstSet(pf.blurDescSetA).setDstBinding(1).setDescriptorCount(1).setDescriptorType(vk::DescriptorType::eCombinedImageSampler).setPImageInfo(&depthImageInfo),
+		vk::WriteDescriptorSet().setDstSet(pf.blurDescSetB).setDstBinding(0).setDescriptorCount(1).setDescriptorType(vk::DescriptorType::eCombinedImageSampler).setPImageInfo(&maskBImageInfo),
+		vk::WriteDescriptorSet().setDstSet(pf.blurDescSetB).setDstBinding(1).setDescriptorCount(1).setDescriptorType(vk::DescriptorType::eCombinedImageSampler).setPImageInfo(&depthImageInfo)
+	};
+	root.dev.updateDescriptorSets(static_cast<uint32_t>(writes.size()), writes.data(), 0, nullptr, root.vkDynLoader);
+}
+
+// MARK: mode
+
+bool VkRayShadowBackend::setMode(gfx_api::ray_shadow_mode newMode)
+{
+	if (newMode == mode)
+	{
+		return true;
+	}
+	if (newMode == gfx_api::ray_shadow_mode::Off)
+	{
+		destroyImages();
+		for (auto& pf : perFrame)
+		{
+			releasePerFrameResources(pf);
+		}
+		mode = gfx_api::ray_shadow_mode::Off;
+		return true;
+	}
+	if (!createPipelines())
+	{
+		return false;
+	}
+	if (mode == gfx_api::ray_shadow_mode::Off)
+	{
+		// force image (re)creation at the new resolution on the next frame
+		maskExtent = vk::Extent2D(0, 0);
+	}
+	mode = newMode;
+	maskValid = false;
+	return true;
+}
+
+void VkRayShadowBackend::releasePerFrameResources(PerFrame& pf)
+{
+	destroyASDeferred(pf.tlas);
+	destroyRTBufferDeferred(pf.tlasBuffer);
+	destroyRTBufferDeferred(pf.tlasScratchBuffer);
+	destroyRTBufferDeferred(pf.instanceBuffer);
+	pf.tlasCapacity = 0;
+	pf.instanceCapacity = 0;
+	// descriptor sets remain allocated (pool-owned); they will be re-written before next use.
+	// The material TLAS set may reference the just-released TLAS - mark it stale so it gets
+	// re-pointed at the empty TLAS before its next use (we cannot update it here: other
+	// frames-in-flight may still have it bound in submitted command buffers)
+	pf.materialTlasDescSetStale = (pf.materialTlasDescSet) ? true : false;
+}
+
+// MARK: per-frame passes
+
+void VkRayShadowBackend::beginDepthPass()
+{
+	ASSERT_OR_RETURN(, mode != gfx_api::ray_shadow_mode::Off, "Ray shadows not enabled");
+	ASSERT_OR_RETURN(, !depthPassActive, "Ray shadow depth pass already active");
+
+	if (!recreateImagesIfNeeded())
+	{
+		return;
+	}
+
+	const auto clearValue = std::array<vk::ClearValue, 1> {
+		vk::ClearValue(vk::ClearDepthStencilValue(1.f, 0u))
+	};
+	auto cmdBuffer = buffering_mechanism::get_current_resources().depthPassDrawCmdBuffer();
+	cmdBuffer.beginRenderPass(
+		vk::RenderPassBeginInfo()
+		.setFramebuffer(rtDepthFbo)
+		.setClearValueCount(static_cast<uint32_t>(clearValue.size()))
+		.setPClearValues(clearValue.data())
+		.setRenderPass(root.renderPasses[root.DEPTH_RENDER_PASS_ID].rp)
+		.setRenderArea(vk::Rect2D(vk::Offset2D(), maskExtent)),
+		vk::SubpassContents::eInline,
+		root.vkDynLoader);
+	const auto viewports = std::array<vk::Viewport, 1> {
+		vk::Viewport().setHeight(maskExtent.height).setWidth(maskExtent.width).setMinDepth(0.f).setMaxDepth(1.f)
+	};
+	cmdBuffer.setViewport(0, viewports, root.vkDynLoader);
+	const auto scissors = std::array<vk::Rect2D, 1> {
+		vk::Rect2D().setExtent(maskExtent)
+	};
+	cmdBuffer.setScissor(0, scissors, root.vkDynLoader);
+
+	// route subsequent gfx_api draws (which use the depth-pass PSO variants) into the depth cmd buffer
+	buffering_mechanism::get_current_resources().beginDepthPass();
+	root.currentRenderPassId = root.DEPTH_RENDER_PASS_ID;
+	root.currentPSO = nullptr;
+
+	depthPassActive = true;
+}
+
+void VkRayShadowBackend::traceAndFilter(const gfx_api::ray_shadow_frame_params& params)
+{
+	ASSERT_OR_RETURN(, depthPassActive, "Ray shadow depth pass was not begun");
+	depthPassActive = false;
+
+	auto& frameResources = buffering_mechanism::get_current_resources();
+	auto depthCmdBuffer = frameResources.depthPassDrawCmdBuffer();
+
+	// end the camera depth prepass
+	depthCmdBuffer.endRenderPass(root.vkDynLoader);
+	frameResources.endCurrentDepthPass();
+	root.currentRenderPassId = root.DEFAULT_RENDER_PASS_ID;
+	root.currentPSO = nullptr;
+
+	// record acceleration structure builds into cmdCopy (executes before all draw cmd buffers)
+	auto copyCmdBuffer = frameResources.copyCmdBuffer();
+	recordPendingBuilds(copyCmdBuffer);
+	PerFrame& pf = currentPerFrame();
+	buildTlas(copyCmdBuffer, pf);
+	ASSERT_OR_RETURN(, pf.tlas, "No TLAS available");
+
+	updateDescriptorSets(pf);
+
+	const auto viewports = std::array<vk::Viewport, 1> {
+		vk::Viewport().setHeight(maskExtent.height).setWidth(maskExtent.width).setMinDepth(0.f).setMaxDepth(1.f)
+	};
+	const auto scissors = std::array<vk::Rect2D, 1> {
+		vk::Rect2D().setExtent(maskExtent)
+	};
+	const auto beginMaskPass = [&](vk::Framebuffer fbo) {
+		depthCmdBuffer.beginRenderPass(
+			vk::RenderPassBeginInfo()
+			.setFramebuffer(fbo)
+			.setRenderPass(maskRenderPass)
+			.setRenderArea(vk::Rect2D(vk::Offset2D(), maskExtent)),
+			vk::SubpassContents::eInline,
+			root.vkDynLoader);
+		depthCmdBuffer.setViewport(0, viewports, root.vkDynLoader);
+		depthCmdBuffer.setScissor(0, scissors, root.vkDynLoader);
+	};
+
+	// 1. trace pass -> mask A
+	beginMaskPass(maskFboA);
+	depthCmdBuffer.bindPipeline(vk::PipelineBindPoint::eGraphics, tracePipeline, root.vkDynLoader);
+	depthCmdBuffer.bindDescriptorSets(vk::PipelineBindPoint::eGraphics, tracePipelineLayout, 0, 1, &pf.traceDescSet, 0, nullptr, root.vkDynLoader);
+	TracePushConstants tracePush;
+	tracePush.invProjectionView = params.inverseProjectionViewMatrix;
+	tracePush.sunDirection = glm::vec4(glm::normalize(glm::vec3(params.sunDirectionWorld)), 0.f);
+	tracePush.cameraPosition = params.cameraPositionWorld;
+	tracePush.params = glm::vec4(params.rayTMin, params.rayTMax, params.normalOffsetScale, params.sunConeAngle);
+	tracePush.aoParams = glm::vec4(static_cast<float>(params.aoRayCount), params.aoMaxDistance, params.aoStrength, 0.f);
+	depthCmdBuffer.pushConstants(tracePipelineLayout, vk::ShaderStageFlagBits::eFragment, 0, sizeof(TracePushConstants), &tracePush, root.vkDynLoader);
+	depthCmdBuffer.draw(3, 1, 0, 0, root.vkDynLoader);
+	depthCmdBuffer.endRenderPass(root.vkDynLoader);
+
+	const glm::vec2 invSize = glm::vec2(1.f / static_cast<float>(maskExtent.width), 1.f / static_cast<float>(maskExtent.height));
+
+	// 2. horizontal blur: mask A -> mask B
+	beginMaskPass(maskFboB);
+	depthCmdBuffer.bindPipeline(vk::PipelineBindPoint::eGraphics, blurPipeline, root.vkDynLoader);
+	depthCmdBuffer.bindDescriptorSets(vk::PipelineBindPoint::eGraphics, blurPipelineLayout, 0, 1, &pf.blurDescSetA, 0, nullptr, root.vkDynLoader);
+	BlurPushConstants blurPush;
+	blurPush.dirAndInvSize = glm::vec4(1.f, 0.f, invSize.x, invSize.y);
+	blurPush.params = glm::vec4(0.08f, 0.f, 0.f, 0.f); // relative view-depth rejection threshold
+	depthCmdBuffer.pushConstants(blurPipelineLayout, vk::ShaderStageFlagBits::eFragment, 0, sizeof(BlurPushConstants), &blurPush, root.vkDynLoader);
+	depthCmdBuffer.draw(3, 1, 0, 0, root.vkDynLoader);
+	depthCmdBuffer.endRenderPass(root.vkDynLoader);
+
+	// 3. vertical blur: mask B -> mask A (final, exposed via getMaskTexture)
+	beginMaskPass(maskFboA);
+	depthCmdBuffer.bindPipeline(vk::PipelineBindPoint::eGraphics, blurPipeline, root.vkDynLoader);
+	depthCmdBuffer.bindDescriptorSets(vk::PipelineBindPoint::eGraphics, blurPipelineLayout, 0, 1, &pf.blurDescSetB, 0, nullptr, root.vkDynLoader);
+	blurPush.dirAndInvSize = glm::vec4(0.f, 1.f, invSize.x, invSize.y);
+	depthCmdBuffer.pushConstants(blurPipelineLayout, vk::ShaderStageFlagBits::eFragment, 0, sizeof(BlurPushConstants), &blurPush, root.vkDynLoader);
+	depthCmdBuffer.draw(3, 1, 0, 0, root.vkDynLoader);
+	depthCmdBuffer.endRenderPass(root.vkDynLoader);
+
+	// point the material-shader TLAS set at this frame's freshly-built TLAS
+	writeMaterialTlasDescSet(pf, pf.tlas);
+	pf.materialTlasDescSetStale = false;
+
+	maskValid = true;
+}
+
+gfx_api::abstract_texture* VkRayShadowBackend::getMaskTexture()
+{
+	if (!maskValid || mode == gfx_api::ray_shadow_mode::Off)
+	{
+		return nullptr;
+	}
+	return pMaskImageA;
+}
+
+// MARK: shutdown
+
+void VkRayShadowBackend::destroyNow()
+{
+	// the device is expected to be idle at this point (called from VkRoot::shutdown)
+	maskValid = false;
+
+	for (auto& kv : meshBlas)
+	{
+		if (kv.second.as) { root.dev.destroyAccelerationStructureKHR(kv.second.as, nullptr, root.vkDynLoader); }
+		destroyRTBufferNow(kv.second.asBuffer);
+	}
+	meshBlas.clear();
+
+	for (auto& pending : pendingBuilds)
+	{
+		if (!pending.keepGeometryBuffer)
+		{
+			destroyRTBufferNow(pending.geometryBuffer);
+		}
+	}
+	pendingBuilds.clear();
+
+	if (terrainBlas.as) { root.dev.destroyAccelerationStructureKHR(terrainBlas.as, nullptr, root.vkDynLoader); terrainBlas.as = vk::AccelerationStructureKHR(); }
+	destroyRTBufferNow(terrainBlas.asBuffer);
+	destroyRTBufferNow(terrainGeometryBuffer);
+	haveTerrain = false;
+
+	for (auto& pf : perFrame)
+	{
+		if (pf.tlas) { root.dev.destroyAccelerationStructureKHR(pf.tlas, nullptr, root.vkDynLoader); pf.tlas = vk::AccelerationStructureKHR(); }
+		destroyRTBufferNow(pf.tlasBuffer);
+		destroyRTBufferNow(pf.tlasScratchBuffer);
+		destroyRTBufferNow(pf.instanceBuffer);
+	}
+	perFrame.clear();
+
+	// images (buffering mechanism is gone at shutdown; destroyImages handles both cases)
+	if (pMaskImageA) { pMaskImageA->destroy(root.dev, root.allocator, root.vkDynLoader); }
+	if (pMaskImageB) { pMaskImageB->destroy(root.dev, root.allocator, root.vkDynLoader); }
+	destroyImages();
+
+	destroyPipelines();
+}
+
+// MARK: VkRoot ray-shadow API
+
+bool VkRoot::supportsRayTracedShadows() const
+{
+	return rayQuerySupported;
+}
+
+bool VkRoot::rayShadows_setMode(gfx_api::ray_shadow_mode newMode)
+{
+	if (!rayQuerySupported)
+	{
+		return newMode == gfx_api::ray_shadow_mode::Off;
+	}
+	if (!rayShadowBackend)
+	{
+		if (newMode == gfx_api::ray_shadow_mode::Off)
+		{
+			return true;
+		}
+		rayShadowBackend = std::make_unique<VkRayShadowBackend>(*this);
+	}
+	return rayShadowBackend->setMode(newMode);
+}
+
+gfx_api::ray_shadow_mode VkRoot::rayShadows_getMode() const
+{
+	return (rayShadowBackend) ? rayShadowBackend->getMode() : gfx_api::ray_shadow_mode::Off;
+}
+
+void VkRoot::rayShadows_setTerrainGeometry(const float* vertices, size_t vertexCount, const uint32_t* indices, size_t indexCount)
+{
+	if (rayShadowBackend) { rayShadowBackend->setTerrainGeometry(vertices, vertexCount, indices, indexCount); }
+}
+
+void VkRoot::rayShadows_updateTerrainVertices(size_t startVertex, const float* vertices, size_t vertexCount)
+{
+	if (rayShadowBackend) { rayShadowBackend->updateTerrainVertices(startVertex, vertices, vertexCount); }
+}
+
+void VkRoot::rayShadows_clearTerrainGeometry()
+{
+	if (rayShadowBackend) { rayShadowBackend->clearTerrainGeometry(); }
+}
+
+bool VkRoot::rayShadows_hasMeshBLAS(const void* meshKey, int32_t variant)
+{
+	return (rayShadowBackend) ? rayShadowBackend->hasMeshBLAS(meshKey, variant) : true;
+}
+
+void VkRoot::rayShadows_registerMeshGeometry(const void* meshKey, int32_t variant, const float* vertices, size_t vertexCount, const uint32_t* indices, size_t indexCount)
+{
+	if (rayShadowBackend) { rayShadowBackend->registerMeshGeometry(meshKey, variant, vertices, vertexCount, indices, indexCount); }
+}
+
+void VkRoot::rayShadows_invalidateMesh(const void* meshKey)
+{
+	if (rayShadowBackend) { rayShadowBackend->invalidateMesh(meshKey); }
+}
+
+void VkRoot::rayShadows_beginFrame()
+{
+	if (rayShadowBackend) { rayShadowBackend->beginFrame(); }
+}
+
+void VkRoot::rayShadows_addInstance(const void* meshKey, int32_t variant, const glm::mat4& worldTransform)
+{
+	if (rayShadowBackend) { rayShadowBackend->addInstance(meshKey, variant, worldTransform); }
+}
+
+void VkRoot::rayShadows_addTerrainInstance()
+{
+	if (rayShadowBackend) { rayShadowBackend->addTerrainInstance(); }
+}
+
+void VkRoot::rayShadows_beginDepthPass()
+{
+	if (rayShadowBackend) { rayShadowBackend->beginDepthPass(); }
+}
+
+void VkRoot::rayShadows_traceAndFilter(const gfx_api::ray_shadow_frame_params& params)
+{
+	if (rayShadowBackend) { rayShadowBackend->traceAndFilter(params); }
+}
+
+gfx_api::abstract_texture* VkRoot::rayShadows_getMaskTexture()
+{
+	return (rayShadowBackend) ? rayShadowBackend->getMaskTexture() : nullptr;
+}
+
+#else // !defined(WZ_VK_RAY_QUERY_POSSIBLE)
+
+// Vulkan headers too old for ray query support - provide stub implementations
+bool VkRoot::supportsRayTracedShadows() const { return false; }
+bool VkRoot::rayShadows_setMode(gfx_api::ray_shadow_mode newMode) { return newMode == gfx_api::ray_shadow_mode::Off; }
+gfx_api::ray_shadow_mode VkRoot::rayShadows_getMode() const { return gfx_api::ray_shadow_mode::Off; }
+void VkRoot::rayShadows_setTerrainGeometry(const float*, size_t, const uint32_t*, size_t) { }
+void VkRoot::rayShadows_updateTerrainVertices(size_t, const float*, size_t) { }
+void VkRoot::rayShadows_clearTerrainGeometry() { }
+bool VkRoot::rayShadows_hasMeshBLAS(const void*, int32_t) { return true; }
+void VkRoot::rayShadows_registerMeshGeometry(const void*, int32_t, const float*, size_t, const uint32_t*, size_t) { }
+void VkRoot::rayShadows_invalidateMesh(const void*) { }
+void VkRoot::rayShadows_beginFrame() { }
+void VkRoot::rayShadows_addInstance(const void*, int32_t, const glm::mat4&) { }
+void VkRoot::rayShadows_addTerrainInstance() { }
+void VkRoot::rayShadows_beginDepthPass() { }
+void VkRoot::rayShadows_traceAndFilter(const gfx_api::ray_shadow_frame_params&) { }
+gfx_api::abstract_texture* VkRoot::rayShadows_getMaskTexture() { return nullptr; }
+
+#endif // defined(WZ_VK_RAY_QUERY_POSSIBLE)
+
+#endif // defined(WZ_VULKAN_ENABLED)

--- a/lib/ivis_opengl/gfx_api_vk_rt.h
+++ b/lib/ivis_opengl/gfx_api_vk_rt.h
@@ -1,0 +1,214 @@
+/*
+	This file is part of Warzone 2100.
+	Copyright (C) 2026  Warzone 2100 Project
+
+	Warzone 2100 is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+
+	Warzone 2100 is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with Warzone 2100; if not, write to the Free Software
+	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+
+// Ray-traced (VK_KHR_ray_query) sun shadows backend for the Vulkan gfx_api implementation.
+//
+// The rasterized pipeline is untouched; this adds:
+// - a BLAS cache for model meshes (keyed by (meshKey, deformation variant)) and the terrain
+// - a per-frame TLAS built from the frame's shadow-casting instance list
+// - a camera depth prepass (reusing the depth-only render pass + PSOs at the mask resolution)
+// - a fullscreen fragment-shader ray-query pass writing an RG8 mask (R = sun visibility,
+//   G = ambient occlusion)
+// - two depth-aware separable blur passes
+// The resulting mask texture is sampled by the existing lighting shaders (gated by the
+// WZ_RAY_SHADOWS specialization constant) via gl_FragCoord.
+
+#pragma once
+
+#if defined(WZ_VULKAN_ENABLED)
+
+#include "gfx_api_vk.h"
+
+#if defined(WZ_VK_RAY_QUERY_POSSIBLE)
+
+#include <vector>
+#include <map>
+#include <memory>
+
+struct VkRayShadowBackend
+{
+	VkRayShadowBackend(VkRoot& root);
+	~VkRayShadowBackend();
+
+	VkRayShadowBackend(const VkRayShadowBackend&) = delete;
+	VkRayShadowBackend& operator=(const VkRayShadowBackend&) = delete;
+
+	bool setMode(gfx_api::ray_shadow_mode newMode);
+	gfx_api::ray_shadow_mode getMode() const { return mode; }
+
+	void setTerrainGeometry(const float* vertices, size_t vertexCount, const uint32_t* indices, size_t indexCount);
+	void updateTerrainVertices(size_t startVertex, const float* vertices, size_t vertexCount);
+	void clearTerrainGeometry();
+
+	bool hasMeshBLAS(const void* meshKey, int32_t variant) const;
+	void registerMeshGeometry(const void* meshKey, int32_t variant, const float* vertices, size_t vertexCount, const uint32_t* indices, size_t indexCount);
+	void invalidateMesh(const void* meshKey);
+
+	void beginFrame();
+	void addInstance(const void* meshKey, int32_t variant, const glm::mat4& worldTransform);
+	void addTerrainInstance();
+	void beginDepthPass();
+	void traceAndFilter(const gfx_api::ray_shadow_frame_params& params);
+	gfx_api::abstract_texture* getMaskTexture();
+
+	// TLAS descriptor set for material shaders (ray-query pipeline variants); points at the
+	// current frame's TLAS once traceAndFilter has run, else at an empty fallback TLAS
+	vk::DescriptorSet getMaterialTlasDescSet();
+
+	// Immediate destruction of all resources (for VkRoot::shutdown, after the buffering_mechanism is gone)
+	void destroyNow();
+
+private:
+	struct RTBuffer
+	{
+		vk::Buffer buffer;
+		VmaAllocation allocation = VK_NULL_HANDLE;
+		vk::DeviceSize size = 0;
+		void* pMapped = nullptr;
+		vk::DeviceAddress address = 0;
+	};
+
+	struct BlasEntry
+	{
+		vk::AccelerationStructureKHR as;
+		RTBuffer asBuffer;
+		vk::DeviceAddress address = 0;
+	};
+
+	struct PendingBlasBuild
+	{
+		vk::AccelerationStructureKHR dst;
+		RTBuffer geometryBuffer; // freed (deferred) after the build is recorded
+		vk::DeviceAddress vertexAddress = 0;
+		vk::DeviceAddress indexAddress = 0;
+		uint32_t vertexCount = 0;
+		uint32_t triangleCount = 0;
+		vk::DeviceSize scratchSize = 0;
+		bool keepGeometryBuffer = false; // terrain keeps its geometry buffer for later rebuilds
+	};
+
+	struct PerFrame
+	{
+		RTBuffer instanceBuffer; // host-visible, mapped
+		uint32_t instanceCapacity = 0;
+		vk::AccelerationStructureKHR tlas;
+		RTBuffer tlasBuffer;
+		RTBuffer tlasScratchBuffer;
+		uint32_t tlasCapacity = 0;
+		vk::DescriptorSet traceDescSet;
+		vk::DescriptorSet blurDescSetA; // reads maskA (+depth)
+		vk::DescriptorSet blurDescSetB; // reads maskB (+depth)
+		bool descSetsAllocated = false;
+		vk::DescriptorSet materialTlasDescSet; // TLAS set for material (ray-query variant) pipelines
+		bool materialTlasDescSetStale = false; // set's TLAS was released; re-point at emptyTlas before next use
+	};
+
+private:
+	bool createPipelines(); // returns false if e.g. shaders are unavailable
+	void destroyPipelines();
+	bool recreateImagesIfNeeded(); // (re)creates mask/depth images + FBOs at the current target extent
+	void destroyImages();
+	void releasePerFrameResources(PerFrame& pf);
+
+	RTBuffer createRTBuffer(vk::DeviceSize size, vk::BufferUsageFlags usage, VmaMemoryUsage memUsage, bool mapped, const char* debugName);
+	void destroyRTBufferNow(RTBuffer& buf);
+	void destroyRTBufferDeferred(RTBuffer& buf);
+	void destroyASDeferred(vk::AccelerationStructureKHR& as);
+
+	BlasEntry createBlas(const float* vertices, size_t vertexCount, const uint32_t* indices, size_t indexCount, bool keepGeometryBuffer, const char* debugName);
+	void recordPendingBuilds(vk::CommandBuffer cmdBuffer);
+	void buildTlas(vk::CommandBuffer cmdBuffer, PerFrame& pf);
+	void updateDescriptorSets(PerFrame& pf);
+	PerFrame& currentPerFrame();
+	bool createEmptyTlas(); // fallback TLAS for material shaders on frames without a trace
+	void writeMaterialTlasDescSet(PerFrame& pf, vk::AccelerationStructureKHR tlas);
+
+	vk::Extent2D targetMaskExtent() const;
+
+private:
+	VkRoot& root;
+	gfx_api::ray_shadow_mode mode = gfx_api::ray_shadow_mode::Off;
+
+	// BLAS cache
+	std::map<std::pair<const void*, int32_t>, BlasEntry> meshBlas;
+	std::vector<PendingBlasBuild> pendingBuilds;
+
+	// terrain
+	BlasEntry terrainBlas;
+	RTBuffer terrainGeometryBuffer;
+	uint32_t terrainVertexCount = 0;
+	uint32_t terrainTriangleCount = 0;
+	vk::DeviceSize terrainScratchSize = 0;
+	bool terrainBlasDirty = false;
+	bool haveTerrain = false;
+
+	// per-frame instance list (CPU)
+	std::vector<vk::AccelerationStructureInstanceKHR> frameInstances;
+
+	// per-frame GPU resources
+	std::vector<PerFrame> perFrame;
+
+	// images / passes
+	vk::Extent2D maskExtent = vk::Extent2D(0, 0);
+	VkRenderedImage* pMaskImageA = nullptr; // final mask (exposed)
+	VkRenderedImage* pMaskImageB = nullptr; // blur ping-pong
+	vk::Image rtDepthImage;
+	VmaAllocation rtDepthAllocation = VK_NULL_HANDLE;
+	WZ_vk::UniqueImageView rtDepthView;
+	vk::Framebuffer rtDepthFbo;
+	vk::Framebuffer maskFboA;
+	vk::Framebuffer maskFboB;
+
+	// pipelines
+	bool pipelinesCreated = false;
+	vk::RenderPass maskRenderPass;
+	vk::DescriptorSetLayout traceDescLayout;
+	vk::DescriptorSetLayout blurDescLayout;
+	vk::PipelineLayout tracePipelineLayout;
+	vk::PipelineLayout blurPipelineLayout;
+	vk::Pipeline tracePipeline;
+	vk::Pipeline blurPipeline;
+	vk::ShaderModule fullscreenVertShader;
+	vk::ShaderModule traceFragShader;
+	vk::ShaderModule blurFragShader;
+	vk::Sampler depthSampler; // nearest, clamp
+	vk::Sampler maskSampler; // linear, clamp
+	vk::DescriptorPool descriptorPool;
+
+	// empty fallback TLAS (0 instances) for material-shader ray queries outside traced frames
+	vk::AccelerationStructureKHR emptyTlas;
+	RTBuffer emptyTlasBuffer;
+
+	// frame state
+	bool depthPassActive = false;
+	bool maskValid = false;
+};
+
+#else // !defined(WZ_VK_RAY_QUERY_POSSIBLE)
+
+// Stub so that VkRoot's std::unique_ptr<VkRayShadowBackend> member has a complete type
+struct VkRayShadowBackend
+{
+	void destroyNow() {}
+	vk::DescriptorSet getMaterialTlasDescSet() { return vk::DescriptorSet(); }
+};
+
+#endif // defined(WZ_VK_RAY_QUERY_POSSIBLE)
+
+#endif // defined(WZ_VULKAN_ENABLED)

--- a/lib/ivis_opengl/imdload.cpp
+++ b/lib/ivis_opengl/imdload.cpp
@@ -86,6 +86,12 @@ void iIMDShape::freeInternalResources()
 		delete buffer;
 		buffer = nullptr;
 	}
+	if (gfx_api::context::isInitialized())
+	{
+		// invalidate any cached ray-tracing geometry keyed on this shape
+		// (covers both destruction and in-place geometry replacement via move-assignment)
+		gfx_api::context::get().rayShadows_invalidateMesh(this);
+	}
 }
 
 iIMDShape& iIMDShape::operator=(iIMDShape&& other) noexcept

--- a/lib/ivis_opengl/piedef.h
+++ b/lib/ivis_opengl/piedef.h
@@ -78,4 +78,23 @@ optional<bool> pie_supportsShadowMapping();
 bool pie_setShadowMapResolution(uint32_t resolution);
 uint32_t pie_getShadowMapResolution();
 
+// Ray-traced (ray query) sun shadows - requires backend support (currently Vulkan-only)
+namespace gfx_api
+{
+	enum class ray_shadow_mode : uint32_t;
+	struct abstract_texture;
+}
+optional<bool> pie_supportsRayShadows();
+bool pie_setRayShadowsMode(gfx_api::ray_shadow_mode mode);
+gfx_api::ray_shadow_mode pie_getRayShadowsMode();
+bool pie_rayShadowsActive();
+// Individual ray-traced effect toggles (applied on top of the master mode)
+void pie_setRayShadowsEffects(bool aoEnabled, bool pointLightShadowsEnabled);
+bool pie_getRayShadowsAOEnabled();
+bool pie_getRayShadowsPointLightsEnabled();
+// Debug visualization: 0 = off, 2 = raw sun-shadow channel, 3 = raw AO channel
+void pie_setRayShadowsDebugMode(uint32_t mode);
+// Returns the ray-traced shadow visibility mask when active, else a 1x1 white fallback texture
+gfx_api::abstract_texture* pie_GetRayShadowMaskTexture();
+
 #endif // _piedef_h

--- a/lib/ivis_opengl/piedraw.cpp
+++ b/lib/ivis_opengl/piedraw.cpp
@@ -120,14 +120,26 @@ static inline bool isShadowMappingEnabled()
 	return (shadows && shadowMode == ShadowMode::Shadow_Mapping);
 }
 
+static inline bool isRayShadowsActive()
+{
+	return isShadowMappingEnabled() && (gfx_api::context::get().rayShadows_getMode() != gfx_api::ray_shadow_mode::Off);
+}
+
+// individual ray-traced effect toggles (the master mode switch is rayShadows_setMode)
+static bool rayShadowsAOEnabled = true;
+static bool rayShadowsPointLightsEnabled = false; // expensive material-shader variants; opt-in
+static uint32_t rayShadowsDebugMode = 0; // 0 = off, 2 = raw shadow channel, 3 = raw AO channel
+
 static void refreshShadowShaders()
 {
 	if (gfx_api::context::isInitialized())
 	{
 		auto shadowConstants = gfx_api::context::get().getShadowConstants();
 		bool bShadowMappingEnabled = isShadowMappingEnabled();
-		uint32_t actualNumCascadesAndPasses = (bShadowMappingEnabled) ? numShadowCascades : 0;
-		if (bShadowMappingEnabled)
+		bool bRayShadowsActive = isRayShadowsActive();
+		// when ray-traced shadows are active, the shadow-map cascade depth passes are replaced by the ray-query passes
+		uint32_t actualNumCascadesAndPasses = (bShadowMappingEnabled && !bRayShadowsActive) ? numShadowCascades : 0;
+		if (bShadowMappingEnabled && !bRayShadowsActive)
 		{
 			shadowConstants.shadowMode = 1; // Possible future TODO: Could get this from the config file to allow testing alternative filter methods
 			shadowConstants.shadowCascadesCount = actualNumCascadesAndPasses;
@@ -136,6 +148,10 @@ static void refreshShadowShaders()
 		{
 			shadowConstants.shadowMode = 0; // Disable shader-drawn / shadow-mapping shadows
 		}
+		shadowConstants.rayShadows = (bRayShadowsActive) ? ((rayShadowsDebugMode != 0) ? rayShadowsDebugMode : 1) : 0;
+		// ray-query material shader variants (point-light shadow rays, water reflection occlusion)
+		// carry a whole-scene occupancy cost on some GPUs - only used when explicitly enabled
+		shadowConstants.rayQueryMaterials = (bRayShadowsActive && rayShadowsPointLightsEnabled) ? 1 : 0;
 
 		// Preserve existing shadowFilterSize
 
@@ -212,6 +228,93 @@ ShadowMode pie_getShadowMode()
 	return shadowMode;
 }
 
+optional<bool> pie_supportsRayShadows()
+{
+	if (!gfx_api::context::isInitialized())
+	{
+		// can't determine support yet
+		return nullopt;
+	}
+	return gfx_api::context::get().supportsRayTracedShadows() && pie_supportsShadowMapping().value_or(false);
+}
+
+bool pie_setRayShadowsMode(gfx_api::ray_shadow_mode mode)
+{
+	ASSERT_OR_RETURN(false, gfx_api::context::isInitialized(), "Can't set ray shadows mode until gfx backend is initialized");
+	bool successfulChangeToInputMode = true;
+	if (mode != gfx_api::ray_shadow_mode::Off && !pie_supportsRayShadows().value_or(false))
+	{
+		// gracefully fall back to the regular shadow-mapping path
+		mode = gfx_api::ray_shadow_mode::Off;
+		successfulChangeToInputMode = false;
+	}
+	if (!gfx_api::context::get().rayShadows_setMode(mode))
+	{
+		// backend could not enable the requested mode (e.g. required shaders unavailable)
+		gfx_api::context::get().rayShadows_setMode(gfx_api::ray_shadow_mode::Off);
+		successfulChangeToInputMode = false;
+	}
+	refreshShadowShaders();
+	return successfulChangeToInputMode;
+}
+
+gfx_api::ray_shadow_mode pie_getRayShadowsMode()
+{
+	if (!gfx_api::context::isInitialized())
+	{
+		return gfx_api::ray_shadow_mode::Off;
+	}
+	return gfx_api::context::get().rayShadows_getMode();
+}
+
+bool pie_rayShadowsActive()
+{
+	if (!gfx_api::context::isInitialized())
+	{
+		return false;
+	}
+	return isRayShadowsActive();
+}
+
+void pie_setRayShadowsEffects(bool aoEnabled, bool pointLightShadowsEnabled)
+{
+	if (rayShadowsAOEnabled == aoEnabled && rayShadowsPointLightsEnabled == pointLightShadowsEnabled)
+	{
+		return;
+	}
+	rayShadowsAOEnabled = aoEnabled;
+	rayShadowsPointLightsEnabled = pointLightShadowsEnabled;
+	refreshShadowShaders();
+}
+
+bool pie_getRayShadowsAOEnabled()
+{
+	return rayShadowsAOEnabled;
+}
+
+bool pie_getRayShadowsPointLightsEnabled()
+{
+	return rayShadowsPointLightsEnabled;
+}
+
+void pie_setRayShadowsDebugMode(uint32_t mode)
+{
+	if (mode != 0 && mode != 2 && mode != 3)
+	{
+		debug(LOG_ERROR, "Invalid ray shadows debug mode: %" PRIu32, mode);
+		return;
+	}
+	if (rayShadowsDebugMode == mode)
+	{
+		return;
+	}
+	rayShadowsDebugMode = mode;
+	if (gfx_api::context::isInitialized())
+	{
+		refreshShadowShaders();
+	}
+}
+
 bool pie_setShadowCascades(uint32_t newValue)
 {
 	if (newValue == 0 || newValue > WZ_MAX_SHADOW_CASCADES)
@@ -286,6 +389,34 @@ static gfx_api::buffer* getZeroedVertexBuffer(size_t size)
 		currentSize = size;
 	}
 	return pZeroedVertexBuffer;
+}
+
+static gfx_api::texture* pWhiteFallbackTexture = nullptr;
+
+static gfx_api::texture* getWhiteFallbackTexture()
+{
+	if (!pWhiteFallbackTexture)
+	{
+		pWhiteFallbackTexture = gfx_api::context::get().create_texture(1, 1, 1, gfx_api::pixel_format::FORMAT_RGBA8_UNORM_PACK8, "<white fallback texture>");
+		iV_Image whiteImage;
+		whiteImage.allocate(1, 1, 4, true);
+		memset(whiteImage.bmp_w(), 255, 4);
+		pWhiteFallbackTexture->upload(0, whiteImage);
+	}
+	return pWhiteFallbackTexture;
+}
+
+gfx_api::abstract_texture* pie_GetRayShadowMaskTexture()
+{
+	if (pie_rayShadowsActive())
+	{
+		auto* mask = gfx_api::context::get().rayShadows_getMaskTexture();
+		if (mask)
+		{
+			return mask;
+		}
+	}
+	return getWhiteFallbackTexture();
 }
 
 void pie_Draw3DButton(const iIMDShape *shape, PIELIGHT teamcolour, const glm::mat4 &modelMatrix, const glm::mat4 &viewMatrix)
@@ -1293,6 +1424,11 @@ void pie_CleanUp()
 		delete pZeroedVertexBuffer;
 		pZeroedVertexBuffer = nullptr;
 	}
+	if (pWhiteFallbackTexture)
+	{
+		delete pWhiteFallbackTexture;
+		pWhiteFallbackTexture = nullptr;
+	}
 }
 
 bool pie_Draw3DShape(const iIMDShape *shape, int frame, int team, PIELIGHT colour, int pieFlag, int pieFlagData, const glm::mat4 &modelMatrix, const glm::mat4 &viewMatrix, float stretchDepth, bool onlySingleLevel)
@@ -1435,6 +1571,36 @@ void pie_DrawAllMeshes(uint64_t currentGameFrame, const glm::mat4 &projectionMat
 	instancedMeshRenderer.DrawAll(currentGameFrame, projectionMatrix, viewMatrix, cameraPos, shadowMVPMatrix, drawParts, depthPass);
 }
 
+static void registerShapeGeometryForRayShadows(const iIMDShape* shape, int32_t variant, float stretch)
+{
+	std::vector<float> positions;
+	positions.reserve(shape->points.size() * 3);
+	for (const auto& p : shape->points)
+	{
+		float y = p.y;
+		if (stretch > 0.f && y <= 0.f)
+		{
+			y -= stretch;
+		}
+		positions.push_back(p.x);
+		positions.push_back(y);
+		positions.push_back(p.z);
+	}
+	std::vector<uint32_t> indices;
+	indices.reserve(shape->polys.size() * 3);
+	for (const auto& poly : shape->polys)
+	{
+		indices.push_back(poly.pindex[0]);
+		indices.push_back(poly.pindex[1]);
+		indices.push_back(poly.pindex[2]);
+	}
+	if (positions.empty() || indices.empty())
+	{
+		return;
+	}
+	gfx_api::context::get().rayShadows_registerMeshGeometry(shape, variant, positions.data(), shape->points.size(), indices.data(), indices.size());
+}
+
 bool InstancedMeshRenderer::FinalizeInstances()
 {
 	if (!useInstancedRendering)
@@ -1445,6 +1611,12 @@ bool InstancedMeshRenderer::FinalizeInstances()
 
 	instancesData.clear();
 	finalizedDrawCalls.clear();
+
+	const bool bRayShadowsActive = pie_rayShadowsActive();
+	if (bRayShadowsActive)
+	{
+		gfx_api::context::get().rayShadows_beginFrame();
+	}
 
 	if (instancesCount + translucentInstancesCount + additiveInstancesCount == 0)
 	{
@@ -1462,6 +1634,25 @@ bool InstancedMeshRenderer::FinalizeInstances()
 			instancesData.push_back(GenerateInstanceData(instance.frame, instance.colour, instance.teamcolour, instance.flag, instance.flag_data, instance.modelMatrix, instance.stretch));
 		}
 		finalizedDrawCalls.emplace_back(mesh.first, meshInstances.size(), startingIdxInInstancesBuffer);
+
+		// mirror the shadow-map caster set into the ray-tracing acceleration structure instance list
+		if (bRayShadowsActive && (mesh.first.pieFlag & (pie_SHADOW | pie_STATIC_SHADOW)))
+		{
+			auto& ctx = gfx_api::context::get();
+			const iIMDShape* shape = mesh.first.shape;
+			for (const auto& instance : meshInstances)
+			{
+				// structure "stretch" (positive values pull y<=0 vertices down in the vertex
+				// shader) is baked into per-variant BLAS geometry; negative values are metadata
+				// for droids and cause no deformation
+				const int32_t variant = (instance.stretch > 0.f) ? static_cast<int32_t>(lroundf(instance.stretch)) : 0;
+				if (!ctx.rayShadows_hasMeshBLAS(shape, variant))
+				{
+					registerShapeGeometryForRayShadows(shape, variant, (variant > 0) ? instance.stretch : 0.f);
+				}
+				ctx.rayShadows_addInstance(shape, variant, instance.modelMatrix);
+			}
+		}
 	}
 
 	startIdxTranslucentDrawCalls = finalizedDrawCalls.size();
@@ -1584,24 +1775,25 @@ static void drawInstanced3dShapeTemplated_Inner(ShaderOnce& globalsOnce, const g
 		std::make_tuple(shape->buffers[VBO_TEXCOORD], 0),
 		std::make_tuple(pTangentBuffer, 0),
 		std::make_tuple(instanceDataBuffer, instanceBufferOffset) });
-	Draw3DInstancedPSO::get().bind_textures(&pie_Texture(textures.texpage), tcmask, normalmap, specularmap, gfx_api::context::get().getDepthTexture(), lightmapTexture);
+	Draw3DInstancedPSO::get().bind_textures(&pie_Texture(textures.texpage), tcmask, normalmap, specularmap, gfx_api::context::get().getDepthTexture(), lightmapTexture, pie_GetRayShadowMaskTexture());
 
 	Draw3DInstancedPSO::get().draw_elements_instanced(shape->polys.size() * 3, 0, instance_count);
 //	Draw3DInstancedPSO::get().unbind_vertex_buffers(shape->buffers[VBO_VERTEX], shape->buffers[VBO_NORMAL], shape->buffers[VBO_TEXCOORD]);
 }
 
-static void drawInstanced3dShapeDepthOnly(ShaderOnce& globalsOnce, const gfx_api::Draw3DShapeInstancedGlobalUniforms& globalUniforms, const iIMDShape * shape, int pieFlag, gfx_api::buffer* instanceDataBuffer, size_t instanceBufferOffset, size_t instance_count)
+template<typename DepthPSO>
+static void drawInstanced3dShapeDepthOnlyT(ShaderOnce& globalsOnce, const gfx_api::Draw3DShapeInstancedGlobalUniforms& globalUniforms, const iIMDShape * shape, int pieFlag, gfx_api::buffer* instanceDataBuffer, size_t instanceBufferOffset, size_t instance_count)
 {
 	if (pieFlag & pie_NODEPTHWRITE)
 	{
 		return;
 	}
 
-	gfx_api::Draw3DShapeDepthOnly_Instanced::get().bind();
+	DepthPSO::get().bind();
 	gfx_api::context::get().bind_index_buffer(*shape->buffers[VBO_INDEX], gfx_api::index_type::u16);
-	globalsOnce.perform_once<gfx_api::Draw3DShapeDepthOnly_Instanced>([&globalUniforms]{
+	globalsOnce.perform_once<DepthPSO>([&globalUniforms]{
 		gfx_api::Draw3DShapeInstancedDepthOnlyGlobalUniforms depthGlobals = {globalUniforms.ProjectionMatrix, globalUniforms.ViewMatrix};
-		gfx_api::Draw3DShapeDepthOnly_Instanced::get().set_uniforms_at(0, depthGlobals);
+		DepthPSO::get().set_uniforms_at(0, depthGlobals);
 	});
 
 //	gfx_api::Draw3DShapeDepthOnly_Instanced::get().set_uniforms_at(1, meshUniforms);
@@ -1613,8 +1805,22 @@ static void drawInstanced3dShapeDepthOnly(ShaderOnce& globalsOnce, const gfx_api
 		std::make_tuple(instanceDataBuffer, instanceBufferOffset) });
 //	gfx_api::Draw3DShapeDepthOnly_Instanced::get().bind_textures(&pie_Texture(shape->texpage), tcmask, normalmap, specularmap);
 
-	gfx_api::Draw3DShapeDepthOnly_Instanced::get().draw_elements_instanced(shape->polys.size() * 3, 0, instance_count);
+	DepthPSO::get().draw_elements_instanced(shape->polys.size() * 3, 0, instance_count);
 //	Draw3DInstancedPSO::get().unbind_vertex_buffers(shape->buffers[VBO_VERTEX], shape->buffers[VBO_NORMAL], shape->buffers[VBO_TEXCOORD]);
+}
+
+static void drawInstanced3dShapeDepthOnly(ShaderOnce& globalsOnce, const gfx_api::Draw3DShapeInstancedGlobalUniforms& globalUniforms, const iIMDShape * shape, int pieFlag, gfx_api::buffer* instanceDataBuffer, size_t instanceBufferOffset, size_t instance_count, bool cameraDepthPass)
+{
+	if (cameraDepthPass)
+	{
+		// camera-visible surface depth (for ray-traced shadow reconstruction)
+		drawInstanced3dShapeDepthOnlyT<gfx_api::Draw3DShapeCameraDepth_Instanced>(globalsOnce, globalUniforms, shape, pieFlag, instanceDataBuffer, instanceBufferOffset, instance_count);
+	}
+	else
+	{
+		// shadow-map depth (intentionally rasterizes the far face set)
+		drawInstanced3dShapeDepthOnlyT<gfx_api::Draw3DShapeDepthOnly_Instanced>(globalsOnce, globalUniforms, shape, pieFlag, instanceDataBuffer, instanceBufferOffset, instance_count);
+	}
 }
 
 template<SHADER_MODE shader, typename AdditivePSO, typename AdditiveNoDepthWRTPSO, typename AlphaPSO, typename AlphaNoDepthWRTPSO, typename PremultipliedPSO, typename PremultipliedNoDepthWRTPSO, typename OpaquePSO>
@@ -1706,7 +1912,10 @@ static void pie_Draw3DShape2_Instanced(ShaderOnce& globalsOnce, const gfx_api::D
 
 	if (depthPass)
 	{
-		drawInstanced3dShapeDepthOnly(globalsOnce, globalUniforms, shape, pieFlag, instanceDataBuffer, instanceBufferOffset, instance_count);
+		// when ray-traced shadows are active the cascade passes are skipped entirely, so any
+		// depth pass is the RT camera prepass (which needs camera-visible faces, not the
+		// shadow-map far-face trick)
+		drawInstanced3dShapeDepthOnly(globalsOnce, globalUniforms, shape, pieFlag, instanceDataBuffer, instanceBufferOffset, instance_count, isRayShadowsActive());
 	}
 	else if (light)
 	{

--- a/src/clparse.cpp
+++ b/src/clparse.cpp
@@ -29,6 +29,7 @@
 #include "lib/ivis_opengl/screen.h"
 #include "lib/netplay/netplay.h"
 #include "lib/ivis_opengl/pieclip.h"
+#include "lib/ivis_opengl/piedef.h"
 #include "lib/ivis_opengl/png_util.h"
 
 #include "levels.h"
@@ -322,6 +323,7 @@ typedef enum
 	CLI_RESOLUTION,
 	CLI_SHADOWS,
 	CLI_NOSHADOWS,
+	CLI_RAYSHADOWS_DEBUG,
 	CLI_SOUND,
 	CLI_NOSOUND,
 	CLI_CONNECTTOIP,
@@ -408,6 +410,7 @@ static const struct poptOption *getOptionsTable()
 		{ "resolution", POPT_ARG_STRING, CLI_RESOLUTION, N_("Set the resolution to use"),         N_("WIDTHxHEIGHT") },
 		{ "shadows", POPT_ARG_NONE, CLI_SHADOWS,    N_("Enable shadows"),                    nullptr },
 		{ "noshadows", POPT_ARG_NONE, CLI_NOSHADOWS,  N_("Disable shadows"),                   nullptr },
+		{ "rayshadows-debug", POPT_ARG_STRING, CLI_RAYSHADOWS_DEBUG, N_("Debug-visualize the ray-traced shadow mask"), "shadow|ao" },
 		{ "sound", POPT_ARG_NONE, CLI_SOUND,      N_("Enable sound"),                      nullptr },
 		{ "nosound", POPT_ARG_NONE, CLI_NOSOUND,    N_("Disable sound"),                     nullptr },
 		{ "join", POPT_ARG_STRING, CLI_CONNECTTOIP, N_("Connect directly to IP/hostname"),  N_("host") },
@@ -998,6 +1001,26 @@ bool ParseCommandLine(int argc, const char * const *argv)
 
 		case CLI_NOSHADOWS:
 			setDrawShadows(false);
+			break;
+
+		case CLI_RAYSHADOWS_DEBUG:
+			token = poptGetOptArg(poptCon);
+			if (token == nullptr)
+			{
+				qFatal("Bad rayshadows-debug argument");
+			}
+			if (strcmp(token, "shadow") == 0)
+			{
+				pie_setRayShadowsDebugMode(2);
+			}
+			else if (strcmp(token, "ao") == 0)
+			{
+				pie_setRayShadowsDebugMode(3);
+			}
+			else
+			{
+				qFatal("Unsupported rayshadows-debug value (expected: shadow|ao)");
+			}
 			break;
 
 		case CLI_SOUND:

--- a/src/configuration.cpp
+++ b/src/configuration.cpp
@@ -728,6 +728,12 @@ bool loadConfig()
 		auto value = iniGetBoolOpt("pointLightsPerpixel");
 		war_setPointLightPerPixelLighting(value.value_or(false));
 	}
+	if (auto value = iniGetIntegerOpt("rayShadows"))
+	{
+		war_setRayShadows(static_cast<uint32_t>(std::max(value.value(), 0)));
+	}
+	war_setRayShadowsAO(iniGetBool("rayShadowsAO", true).value());
+	war_setRayShadowsPointLights(iniGetBool("rayShadowsPointLights", false).value());
 
 	std::string defAI = iniGetString("defaultSkirmishAI", DEFAULT_SKIRMISH_AI_SCRIPT_NAME).value();
 	setDefaultSkirmishAI(defAI);
@@ -932,6 +938,9 @@ bool saveConfig()
 	iniSetInteger("shadowFilterSize", (int)war_getShadowFilterSize());
 	iniSetInteger("shadowMapResolution", (int)war_getShadowMapResolution());
 	iniSetBool("pointLightsPerpixel", war_getPointLightPerPixelLighting());
+	iniSetInteger("rayShadows", (int)war_getRayShadows());
+	iniSetBool("rayShadowsAO", war_getRayShadowsAO());
+	iniSetBool("rayShadowsPointLights", war_getRayShadowsPointLights());
 	iniSetString("defaultSkirmishAI", getDefaultSkirmishAI());
 	iniSetBool("audioCueGroupReporting", war_getPlayAudioCue_GroupReporting());
 

--- a/src/display3d.cpp
+++ b/src/display3d.cpp
@@ -1341,9 +1341,10 @@ static void drawTiles(iView *player, LightingData& lightData, LightMap& lightmap
 
 	// Calculate shadow mapping cascades
 	glm::vec3 lightInvDir = getTheSun();
+	const bool bRayShadowsActive = pie_rayShadowsActive();
 	size_t numShadowCascades = std::min<size_t>(gfx_api::context::get().numDepthPasses(), WZ_MAX_SHADOW_CASCADES);
 	std::vector<Cascade> shadowCascades;
-	if (currShadowMode == ShadowMode::Shadow_Mapping)
+	if (currShadowMode == ShadowMode::Shadow_Mapping && !bRayShadowsActive)
 	{
 		calculateShadowCascades(player, distance, baseViewMatrix, lightInvDir, numShadowCascades, shadowCascades);
 	}
@@ -1499,7 +1500,7 @@ static void drawTiles(iView *player, LightingData& lightData, LightMap& lightmap
 		shadowCascadesInfo.shadowCascadeSplit[i] = shadowCascades[i].splitDepth;
 	}
 
-	if (currShadowMode == ShadowMode::Shadow_Mapping)
+	if (currShadowMode == ShadowMode::Shadow_Mapping && !bRayShadowsActive)
 	{
 		WZ_PROFILE_SCOPE(ShadowMapping);
 		for (size_t i = 0; i < numShadowCascades; ++i)
@@ -1512,6 +1513,31 @@ static void drawTiles(iView *player, LightingData& lightData, LightMap& lightmap
 			pie_DrawAllMeshes(currentGameFrame, shadowCascades[i].projectionMatrix, shadowCascades[i].viewMatrix, cameraPos, shadowCascadesInfo, true);
 			gfx_api::context::get().endCurrentDepthPass();
 		}
+	}
+
+	if (bRayShadowsActive)
+	{
+		WZ_PROFILE_SCOPE(RayShadows);
+		// ray-traced sun shadows: camera depth prepass (reusing the depth-only PSOs with camera
+		// matrices), then the ray-query trace + blur passes producing the screen-space mask
+		if (bDrawTerrainShadows)
+		{
+			gfx_api::context::get().rayShadows_addTerrainInstance();
+		}
+		gfx_api::context::get().rayShadows_beginDepthPass();
+		drawTerrainDepthOnly(perspectiveViewMatrix);
+		pie_DrawAllMeshes(currentGameFrame, perspectiveMatrix, viewMatrix, cameraPos, shadowCascadesInfo, true);
+		gfx_api::ray_shadow_frame_params rayShadowParams;
+		rayShadowParams.inverseProjectionViewMatrix = glm::inverse(perspectiveViewMatrix);
+		// The raster lighting's toward-the-sun direction is -getTheSun():
+		// tcmask_instanced.vert computes lightDir = -normalize(inverse(ViewMatrix) * (ViewMatrix * getTheSun()))
+		rayShadowParams.sunDirectionWorld = glm::vec4(glm::normalize(-getTheSun()), 0.f);
+		rayShadowParams.cameraPositionWorld = glm::vec4(cameraPos, 0.f);
+		if (!pie_getRayShadowsAOEnabled())
+		{
+			rayShadowParams.aoRayCount = 0;
+		}
+		gfx_api::context::get().rayShadows_traceAndFilter(rayShadowParams);
 	}
 	// start main render pass
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2158,6 +2158,12 @@ int realmain(int argc, char *argv[])
 	{
 		return EXIT_FAILURE;
 	}
+	if (war_getRayShadows() != 0)
+	{
+		// apply persisted ray-traced shadows settings (gracefully falls back to off when unsupported)
+		pie_setRayShadowsEffects(war_getRayShadowsAO(), war_getRayShadowsPointLights());
+		pie_setRayShadowsMode(static_cast<gfx_api::ray_shadow_mode>(war_getRayShadows()));
+	}
 	if (!screenInitialise())
 	{
 		return EXIT_FAILURE;

--- a/src/terrain.cpp
+++ b/src/terrain.cpp
@@ -51,6 +51,7 @@
 #include "lib/ivis_opengl/pielighting.h"
 #include "lib/ivis_opengl/piematrix.h"
 #include "lib/ivis_opengl/piedraw.h"
+#include "lib/ivis_opengl/piedef.h"
 #include "lib/ivis_opengl/pielight_convert.h"
 #include "world_map_state.h"
 #include <glm/mat4x4.hpp>
@@ -552,6 +553,10 @@ static void updateSectorGeometry(WorldMapState& mapState, int x, int y)
 	waterVBO->update(sizeof(WaterVertex)*sectors[x * ySectors + y].waterOffset,
 					 sizeof(WaterVertex)*sectors[x * ySectors + y].waterSize, water,
 					 gfx_api::buffer::update_flag::non_overlapping_updates_promise);
+
+	static_assert(sizeof(TerrainVertex) == sizeof(float) * 3, "TerrainVertex is expected to be a tightly-packed float3");
+	gfx_api::context::get().rayShadows_updateTerrainVertices(sectors[x * ySectors + y].geometryOffset,
+							reinterpret_cast<const float*>(geometry), sectors[x * ySectors + y].geometrySize);
 
 	delete[] geometry;
 	free(water);
@@ -1103,12 +1108,19 @@ bool initTerrain(WorldMapState& mapState)
 		delete geometryVBO;
 	geometryVBO = gfx_api::context::get().create_buffer_object(gfx_api::buffer::usage::vertex_buffer, gfx_api::context::buffer_storage_hint::dynamic_draw, "terrain::geometryVBO");
 	geometryVBO->upload(sizeof(TerrainVertex)*geometrySize, geometry);
-	delete[] geometry;
 
 	if (geometryIndexVBO)
 		delete geometryIndexVBO;
 	geometryIndexVBO = gfx_api::context::get().create_buffer_object(gfx_api::buffer::usage::index_buffer, gfx_api::context::buffer_storage_hint::static_draw, "terrain::geometryIndexVBO");
 	geometryIndexVBO->upload(sizeof(GLuint)*geometryIndexSize, geometryIndex);
+
+	// hand the terrain geometry to the (optional) ray-traced shadows backend before freeing it
+	static_assert(sizeof(TerrainVertex) == sizeof(float) * 3, "TerrainVertex is expected to be a tightly-packed float3");
+	static_assert(sizeof(GLuint) == sizeof(uint32_t), "GLuint is expected to match uint32_t");
+	gfx_api::context::get().rayShadows_setTerrainGeometry(reinterpret_cast<const float*>(geometry), geometrySize,
+														  reinterpret_cast<const uint32_t*>(geometryIndex), geometryIndexSize);
+
+	delete[] geometry;
 	free(geometryIndex);
 
 	if (waterVBO)
@@ -1203,6 +1215,10 @@ bool initTerrain(WorldMapState& mapState)
 /// free all memory and opengl buffers used by the terrain renderer
 void shutdownTerrain()
 {
+	if (gfx_api::context::isInitialized())
+	{
+		gfx_api::context::get().rayShadows_clearTerrainGeometry();
+	}
 	delete geometryVBO;
 	geometryVBO = nullptr;
 	delete geometryIndexVBO;
@@ -1442,7 +1458,8 @@ static void drawTerrainCombinedmpl(const glm::mat4 &ModelViewProjection, const g
 		lightmap_texture,
 		groundTexArr, groundNormalArr, groundSpecularArr, groundHeightArr,
 		decalTexArr, decalNormalArr, decalSpecularArr, decalHeightArr,
-		gfx_api::context::get().getDepthTexture());
+		gfx_api::context::get().getDepthTexture(),
+		pie_GetRayShadowMaskTexture());
 	PSO::get().bind_vertex_buffers(terrainDecalVBO);
 	glm::mat4 groundScale = glm::mat4(0);
 	for (int i = 0; i < getNumGroundTypes(); i++) {
@@ -1658,14 +1675,16 @@ void drawWaterHighImpl(const glm::mat4 &ModelViewProjection, const glm::mat4& vi
 		waterTexturesHigh.tex_nm,
 		waterTexturesHigh.tex_sm,
 		lightmap_texture,
-		gfx_api::context::get().getDepthTexture());
+		gfx_api::context::get().getDepthTexture(),
+		pie_GetRayShadowMaskTexture());
 	PSO::get().bind_vertex_buffers(waterVBO);
+	auto dimension = gfx_api::context::get().getDrawableDimensions();
 	PSO::get().bind_constants({
 		ModelViewProjection, viewMatrix, lightmapValues.ModelUVLightmap, {shadowCascades.shadowMVPMatrix[0], shadowCascades.shadowMVPMatrix[1], shadowCascades.shadowMVPMatrix[2]},
 		glm::vec4(cameraPos, 0), glm::vec4(glm::normalize(sunPos), 0),
 		pie_GetLighting0(LIGHT_EMISSIVE), pie_GetLighting0(LIGHT_AMBIENT), pie_GetLighting0(LIGHT_DIFFUSE), pie_GetLighting0(LIGHT_SPECULAR),
 		getFogColorVec4(), {shadowCascades.shadowCascadeSplit[0], shadowCascades.shadowCascadeSplit[1], shadowCascades.shadowCascadeSplit[2], pie_getPerspectiveZFar()}, shadowCascades.shadowMapSize, renderState.fogEnabled, renderState.fogBegin, renderState.fogEnd,
-		waterOffset*10
+		waterOffset*10, static_cast<int>(dimension.first), static_cast<int>(dimension.second)
 	});
 
 	gfx_api::context::get().bind_index_buffer(*waterIndexVBO, gfx_api::index_type::u32);

--- a/src/titleui/options/graphicsoptions.cpp
+++ b/src/titleui/options/graphicsoptions.cpp
@@ -66,6 +66,14 @@ OptionInfo::AvailabilityResult PerPixelLightingAvailable(const OptionInfo&)
 	return result;
 }
 
+OptionInfo::AvailabilityResult SupportsRayShadows(const OptionInfo&)
+{
+	OptionInfo::AvailabilityResult result;
+	result.available = pie_supportsRayShadows().value_or(false);
+	result.localizedUnavailabilityReason = _("Ray-traced shadows require the Vulkan graphics backend and a GPU with ray tracing support.");
+	return result;
+}
+
 // MARK: -
 
 std::shared_ptr<OptionsForm> makeGraphicsOptionsForm()
@@ -241,6 +249,82 @@ std::shared_ptr<OptionsForm> makeGraphicsOptionsForm()
 					return false;
 				}
 				war_setShadowFilterSize(newFilterSize);
+				return true;
+			}, false
+		);
+		result->addOption(optionInfo, valueChanger, true);
+	}
+	{
+		auto optionInfo = OptionInfo("gfx.rayShadows", N_("Ray-Traced Shadows"), N_("Use hardware ray tracing to render sun shadows, instead of shadow maps. Half resolution traces one ray per half-resolution pixel for better performance."));
+		optionInfo.addAvailabilityCondition(ShadowsEnabled);
+		optionInfo.addAvailabilityCondition(SupportsRayShadows);
+		auto valueChanger = OptionsDropdown<uint32_t>::make(
+			[]() {
+				OptionChoices<uint32_t> result;
+				result.choices = {
+					{ _("Off"), "", 0 },
+					{ _("Quarter Resolution"), "", 3 },
+					{ _("Half Resolution"), "", 1 },
+					{ _("Full Resolution"), "", 2 },
+				};
+				result.setCurrentIdxForValue(static_cast<uint32_t>(pie_getRayShadowsMode()));
+				return result;
+			},
+			[](const auto& newMode) -> bool {
+				if (newMode != 0 && !pie_supportsRayShadows().value_or(false))
+				{
+					return false;
+				}
+				if (!pie_setRayShadowsMode(static_cast<gfx_api::ray_shadow_mode>(newMode)))
+				{
+					debug(LOG_ERROR, "Failed to set ray shadows mode: %" PRIu32, newMode);
+					return false;
+				}
+				war_setRayShadows(newMode);
+				return true;
+			}, false
+		);
+		result->addOption(optionInfo, valueChanger, true);
+	}
+	{
+		auto optionInfo = OptionInfo("gfx.rayShadowsAO", N_("RT Contact Shadows"), N_("Ray-traced ambient occlusion: contact shadows under units and structures, and terrain crevice shading."));
+		optionInfo.addAvailabilityCondition(ShadowsEnabled);
+		optionInfo.addAvailabilityCondition(SupportsRayShadows);
+		auto valueChanger = OptionsDropdown<bool>::make(
+			[]() {
+				OptionChoices<bool> result;
+				result.choices = {
+					{ _("Off"), "", false },
+					{ _("On"), "", true },
+				};
+				result.setCurrentIdxForValue(pie_getRayShadowsAOEnabled());
+				return result;
+			},
+			[](const auto& enabled) -> bool {
+				pie_setRayShadowsEffects(enabled, pie_getRayShadowsPointLightsEnabled());
+				war_setRayShadowsAO(enabled);
+				return true;
+			}, false
+		);
+		result->addOption(optionInfo, valueChanger, true);
+	}
+	{
+		auto optionInfo = OptionInfo("gfx.rayShadowsPointLights", N_("RT Light & Reflection Effects"), N_("Ray-traced shadows from point lights (searchlights, muzzle flashes, explosions) and water reflection occlusion. Expensive - can significantly reduce performance on some GPUs."));
+		optionInfo.addAvailabilityCondition(ShadowsEnabled);
+		optionInfo.addAvailabilityCondition(SupportsRayShadows);
+		auto valueChanger = OptionsDropdown<bool>::make(
+			[]() {
+				OptionChoices<bool> result;
+				result.choices = {
+					{ _("Off"), "", false },
+					{ _("On"), "", true },
+				};
+				result.setCurrentIdxForValue(pie_getRayShadowsPointLightsEnabled());
+				return result;
+			},
+			[](const auto& enabled) -> bool {
+				pie_setRayShadowsEffects(pie_getRayShadowsAOEnabled(), enabled);
+				war_setRayShadowsPointLights(enabled);
 				return true;
 			}, false
 		);

--- a/src/warzoneconfig.cpp
+++ b/src/warzoneconfig.cpp
@@ -103,6 +103,9 @@ struct WARZONE_GLOBALS
 	uint32_t shadowFilterSize = 5;
 	uint32_t shadowMapResolution = 0; // this defaults to 0, which causes the gfx backend to figure out a recommended default based on the system properties
 	bool pointLightLighting = false;
+	uint32_t rayShadows = 0; // ray-traced shadows: 0 = off, 1 = half resolution, 2 = full resolution, 3 = quarter resolution
+	bool rayShadowsAO = true; // ray-traced contact shadows / ambient occlusion
+	bool rayShadowsPointLights = false; // ray-traced point-light shadows + reflections (expensive)
 	// UI config
 	bool groupsMenuEnabled = true;
 	uint8_t optionsButtonVisibility = 100;
@@ -755,6 +758,41 @@ bool war_getPointLightPerPixelLighting()
 void war_setPointLightPerPixelLighting(bool perPixelEnabled)
 {
 	warGlobs.pointLightLighting = perPixelEnabled;
+}
+
+uint32_t war_getRayShadows()
+{
+	return warGlobs.rayShadows;
+}
+
+void war_setRayShadows(uint32_t mode)
+{
+	if (mode > 3)
+	{
+		debug(LOG_ERROR, "Ray shadows mode %" PRIu32 " is unsupported: must be 0 (off), 1 (half res), 2 (full res) or 3 (quarter res)", mode);
+		return;
+	}
+	warGlobs.rayShadows = mode;
+}
+
+bool war_getRayShadowsAO()
+{
+	return warGlobs.rayShadowsAO;
+}
+
+void war_setRayShadowsAO(bool enabled)
+{
+	warGlobs.rayShadowsAO = enabled;
+}
+
+bool war_getRayShadowsPointLights()
+{
+	return warGlobs.rayShadowsPointLights;
+}
+
+void war_setRayShadowsPointLights(bool enabled)
+{
+	warGlobs.rayShadowsPointLights = enabled;
 }
 
 bool war_getGroupsMenuEnabled()

--- a/src/warzoneconfig.h
+++ b/src/warzoneconfig.h
@@ -187,6 +187,13 @@ void war_setShadowMapResolution(uint32_t resolution);
 bool war_getPointLightPerPixelLighting();
 void war_setPointLightPerPixelLighting(bool perPixelEnabled);
 
+uint32_t war_getRayShadows();
+void war_setRayShadows(uint32_t mode);
+bool war_getRayShadowsAO();
+void war_setRayShadowsAO(bool enabled);
+bool war_getRayShadowsPointLights();
+void war_setRayShadowsPointLights(bool enabled);
+
 bool war_getGroupsMenuEnabled();
 void war_setGroupsMenuEnabled(bool enabled);
 uint8_t war_getOptionsButtonVisibility();


### PR DESCRIPTION
Optional hybrid-rendering feature: rasterization is unchanged, with a screen-space ray-traced mask replacing the cascaded shadow maps when enabled (Vulkan-only, requires VK_KHR_ray_query support).

- BLAS cache per model (with structure-stretch variants) and terrain; per-frame TLAS built from the shadow-caster instance list
- Camera depth prepass at mask resolution (full/half/quarter res), one cone-jittered sun ray per pixel for soft shadows, deterministic 3-ray ambient occlusion for contact shadows, depth-aware blur
- Lighting shaders sample the mask via a new WZ_RAY_SHADOWS specialization constant; visibility keeps the existing 0.5 floor
- Optional ray-query material shader variants (dual-compiled from the same sources) add point-light shadows and water reflection occlusion; off by default due to their performance cost
- Settings: rayShadows (0-3), rayShadowsAO, rayShadowsPointLights, with graphics options UI rows; graceful fallback on unsupported systems (OpenGL backends, MoltenVK, pre-RT GPUs)
- --rayshadows-debug=shadow|ao flag to visualize the mask channels

Supporting changes:
- Implement gfx_api::context::getScreenshot for the Vulkan backend via swapchain readback (fixes screenshots on Vulkan)
- Weight Vulkan physical device selection by device-local memory so multi-GPU systems prefer the most capable discrete GPU
- data: support glslangValidator as a fallback when glslc is not found; per-shader target environments and compile definitions