### PR TITLE
scripting: scriptState save format v2, substantial round-trip fixes for scripting saveload

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -3611,10 +3611,9 @@ bool saveGame(const char *aFileName, GAME_TYPE saveType, bool isAutoSave)
 	strcat(CurrentFileName, "gameinfo.json");
 	writeGameInfo(CurrentFileName);
 
-	// Save labels
-	CurrentFileName[fileExtension] = '\0';
-	strcat(CurrentFileName, "labels.json");
-	writeLabels(CurrentFileName);
+	// NOTE:
+	// Savegame labels are embedded in the script state (see saveScriptStates2), not written to a separate labels.json
+	// (Map/scenario labels.json is authored externally and is loaded for non-savegame loads)
 
 	//create the droids filename
 	CurrentFileName[fileExtension] = '\0';

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2340,7 +2340,9 @@ LoadingTask<> loadGameInit(ResourceLoadingController& controller, const GameLoad
 		//set IsScenario to true if not a user saved game
 		if (gameType == GTYPE_SAVE_START)
 		{
-			debug(LOG_FATAL, "Should not be called with gameType GTYPE_SAVE_START");
+			// GTYPE_SAVE_START is deprecated/unsupported and must never be loaded
+			debug(LOG_FATAL, "GTYPE_SAVE_START is deprecated/unsupported and cannot be loaded");
+			co_return load_fail();
 		}
 		IsScenario = true;
 		co_return load_ok();
@@ -2397,7 +2399,7 @@ bool loadMissionExtras(const char* pGameToLoad, LEVEL_TYPE levelType)
 	if (saveGameVersion >= VERSION_11)
 	{
 		//if user save game then load up the messages AFTER any droids or structures are loaded
-		if (gameType == GTYPE_SAVE_START || gameType == GTYPE_SAVE_MIDMISSION)
+		if (gameType == GTYPE_SAVE_MIDMISSION)
 		{
 			//load in the message list file
 			aFileName[fileExten] = '\0';
@@ -2705,8 +2707,7 @@ LoadingTask<> loadGame(ResourceLoadingController& controller, const GameLoadDeta
 	/* Stop the game clock */
 	gameTimeStop();
 
-	if ((gameType == GTYPE_SAVE_START) ||
-	    (gameType == GTYPE_SAVE_MIDMISSION))
+	if (gameType == GTYPE_SAVE_MIDMISSION)
 	{
 		gameTimeReset(savedGameTime);//added 14 may 98 JPS to solve kev's problem with no firing droids
 	}
@@ -2908,7 +2909,7 @@ LoadingTask<> loadGame(ResourceLoadingController& controller, const GameLoadDeta
 	getPlayerNames();
 
 	//clear the player Power structs
-	if ((gameType != GTYPE_SAVE_START) && (gameType != GTYPE_SAVE_MIDMISSION) &&
+	if ((gameType != GTYPE_SAVE_MIDMISSION) &&
 	    (!keepObjects))
 	{
 		clearPlayerPower();
@@ -3016,7 +3017,7 @@ LoadingTask<> loadGame(ResourceLoadingController& controller, const GameLoadDeta
 	}
 
 	//if user save game then load up the research BEFORE any droids or structures are loaded
-	if (gameType == GTYPE_SAVE_START || gameType == GTYPE_SAVE_MIDMISSION)
+	if (gameType == GTYPE_SAVE_MIDMISSION)
 	{
 		//load in the research list file
 		aFileName[fileExten] = '\0';
@@ -3195,8 +3196,7 @@ LoadingTask<> loadGame(ResourceLoadingController& controller, const GameLoadDeta
 	if (saveGameVersion > VERSION_12)
 	{
 		//if user save game then load up the FX
-		if ((gameType == GTYPE_SAVE_START) ||
-		    (gameType == GTYPE_SAVE_MIDMISSION))
+		if (gameType == GTYPE_SAVE_MIDMISSION)
 		{
 			//load in the message list file
 			aFileName[fileExten] = '\0';
@@ -3373,7 +3373,7 @@ LoadingTask<> loadGame(ResourceLoadingController& controller, const GameLoadDeta
 	co_await controller.yieldFrame();
 
 	//if user save game then load up the current level for structs and components
-	if (gameType == GTYPE_SAVE_START || gameType == GTYPE_SAVE_MIDMISSION)
+	if (gameType == GTYPE_SAVE_MIDMISSION)
 	{
 		//load in the component list file
 		aFileName[fileExten] = '\0';
@@ -3405,8 +3405,7 @@ LoadingTask<> loadGame(ResourceLoadingController& controller, const GameLoadDeta
 	if (saveGameVersion >= VERSION_11)
 	{
 		//if user save game then load up the Visibility
-		if ((gameType == GTYPE_SAVE_START) ||
-		    (gameType == GTYPE_SAVE_MIDMISSION))
+		if (gameType == GTYPE_SAVE_MIDMISSION)
 		{
 			//load in the visibility file
 			aFileName[fileExten] = '\0';
@@ -3424,8 +3423,7 @@ LoadingTask<> loadGame(ResourceLoadingController& controller, const GameLoadDeta
 	if (saveGameVersion >= VERSION_16)
 	{
 		//if user save game then load up the FX
-		if ((gameType == GTYPE_SAVE_START) ||
-		    (gameType == GTYPE_SAVE_MIDMISSION))
+		if (gameType == GTYPE_SAVE_MIDMISSION)
 		{
 			aFileName[fileExten] = '\0';
 			strcat(aFileName, "score.json");
@@ -3442,8 +3440,7 @@ LoadingTask<> loadGame(ResourceLoadingController& controller, const GameLoadDeta
 	if (saveGameVersion >= VERSION_21)
 	{
 		//rebuild the apsCommandDesignation AFTER all droids and structures are loaded
-		if ((gameType == GTYPE_SAVE_START) ||
-		    (gameType == GTYPE_SAVE_MIDMISSION))
+		if (gameType == GTYPE_SAVE_MIDMISSION)
 		{
 			//load in the command list file
 			aFileName[fileExten] = '\0';
@@ -3501,8 +3498,7 @@ LoadingTask<> loadGame(ResourceLoadingController& controller, const GameLoadDeta
 	loadLabels(aFileName, fixedMapIdToGeneratedId, moduleToBuilding, UserSaveGame);
 
 	//if user save game then reset the time - BEWARE IF YOU USE IT
-	if ((gameType == GTYPE_SAVE_START) ||
-	    (gameType == GTYPE_SAVE_MIDMISSION))
+	if (gameType == GTYPE_SAVE_MIDMISSION)
 	{
 		ASSERT(gameTime == savedGameTime, "loadGame; game time modified during load");
 		gameTimeReset(savedGameTime);//added 14 may 98 JPS to solve kev's problem with no firing droids
@@ -4209,7 +4205,9 @@ bool gameLoadV7(PHYSFS_file *fileHandle, nonstd::optional<nlohmann::json> &gamJs
 	//set IsScenario to true if not a user saved game
 	if (gameType == GTYPE_SAVE_START)
 	{
-		debug(LOG_FATAL, "Should not be called with gameType GTYPE_SAVE_START");
+		// GTYPE_SAVE_START is deprecated/unsupported and must never be loaded
+		debug(LOG_FATAL, "GTYPE_SAVE_START is deprecated/unsupported and cannot be loaded");
+		return false;
 	}
 	IsScenario = true;
 
@@ -4498,6 +4496,14 @@ LoadingTask<> gameLoadV(ResourceLoadingController& controller, PHYSFS_file *file
 	height = saveGameData.ScrollMaxY - saveGameData.ScrollMinY;
 	gameType = static_cast<GAME_TYPE>(saveGameData.GameType);
 
+	if (gameType == GTYPE_SAVE_START)
+	{
+		// GTYPE_SAVE_START is deprecated/unsupported
+		// Reject any (legacy) savegame of this type rather than attempting to load it
+		debug(LOG_FATAL, "GTYPE_SAVE_START is deprecated/unsupported and cannot be loaded");
+		co_return load_fail();
+	}
+
 	if (version >= VERSION_11)
 	{
 		//camera position
@@ -4601,8 +4607,7 @@ LoadingTask<> gameLoadV(ResourceLoadingController& controller, PHYSFS_file *file
 	droidInit();
 
 	//set IsScenario to true if not a user saved game
-	if ((gameType == GTYPE_SAVE_START) ||
-	    (gameType == GTYPE_SAVE_MIDMISSION))
+	if (gameType == GTYPE_SAVE_MIDMISSION)
 	{
 		for (i = 0; i < MAX_PLAYERS; ++i)
 		{
@@ -4843,7 +4848,7 @@ static bool loadMainFileFinal(const std::string &fileName)
 // binary blobbery, for future usage.
 static bool writeMainFile(const std::string &fileName, SDWORD saveType)
 {
-	ASSERT(saveType == GTYPE_SAVE_START || saveType == GTYPE_SAVE_MIDMISSION, "invalid save type");
+	ASSERT(saveType == GTYPE_SAVE_MIDMISSION, "invalid save type (GTYPE_SAVE_START is deprecated)");
 
 	WzConfig save(WzString::fromUtf8(fileName), WzConfig::ReadAndWrite);
 
@@ -5023,7 +5028,7 @@ static bool writeGameFile(const char *fileName, SDWORD saveType)
 
 	debug(LOG_SAVE, "fileversion is %u, (%s) ", fileHeader.version, fileName);
 
-	ASSERT(saveType == GTYPE_SAVE_START || saveType == GTYPE_SAVE_MIDMISSION, "invalid save type");
+	ASSERT(saveType == GTYPE_SAVE_MIDMISSION, "invalid save type (GTYPE_SAVE_START is deprecated)");
 	saveGame.saveKey = getCampaignNumber();
 	if (missionIsOffworld())
 	{
@@ -7821,14 +7826,6 @@ bool loadSaveMessage(const char* pFileName, LEVEL_TYPE levelType)
 	if (gameType == GTYPE_SAVE_MIDMISSION)
 	{
 		freeMessages();
-	}
-	else if (gameType == GTYPE_SAVE_START)
-	{
-		// If we are loading in a CamStart or a CamChange then we are not interested in any saved messages
-		if (levelType == LEVEL_TYPE::LDS_CAMSTART || levelType == LEVEL_TYPE::LDS_CAMCHANGE)
-		{
-			return true;
-		}
 	}
 
 	WzConfig ini(pFileName, WzConfig::ReadOnly);

--- a/src/gamedef.h
+++ b/src/gamedef.h
@@ -44,8 +44,8 @@
 #define VERSION_11              11	        // newstyle save game with extending structure checked in 13 Nov.
 #define VERSION_12              12	        // mission and order stuff checked in 20 Nov.
 //#define VERSION_13            13	        // odds and ends to 24 Nov. and hashed scripts
-#define VERSION_14              14	        // 
-#define VERSION_15              15	        // 
+#define VERSION_14              14	        //
+#define VERSION_15              15	        //
 #define VERSION_16              16	        // beta save game
 #define VERSION_17              17	        // objId and new struct stats included
 #define VERSION_18              18	        // droid name savegame validity stamps
@@ -82,7 +82,7 @@ enum GAME_TYPE
 	GTYPE_SCENARIO_START,   ///< Initial scenario state.
 	GTYPE_SCENARIO_EXPAND,  ///< Scenario scroll area expansion.
 	GTYPE_MISSION,          ///< Stand alone mission.
-	GTYPE_SAVE_START,       ///< User saved game - at the start of a level.
+	GTYPE_SAVE_START,       ///< DEPRECATED / UNUSED / UNSUPPORTED. Never written & rejected on load. Retained only to preserve the enum values of later entries and to detect & reject legacy saves of this type.
 	GTYPE_SAVE_MIDMISSION,  ///< User saved game - in the middle of a level
 };
 

--- a/src/hci.cpp
+++ b/src/hci.cpp
@@ -1420,7 +1420,9 @@ INT_RETVAL intRunWidgets()
 		}
 		else
 		{
-			if (saveGame(sRequestResult, GTYPE_SAVE_START))
+			// NOTE: this mission-results save path is currently unreachable (FUTURE TODO: remove)
+			// GTYPE_SAVE_START is deprecated, so use MIDMISSION
+			if (saveGame(sRequestResult, GTYPE_SAVE_MIDMISSION))
 			{
 				char msg[256] = {'\0'};
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1737,7 +1737,7 @@ static void displayLoadingErrors()
 
 static bool stageThreeInitialiseSync()
 {
-	bool fromSave = (getSaveGameType() == GTYPE_SAVE_START || getSaveGameType() == GTYPE_SAVE_MIDMISSION);
+	bool fromSave = (getSaveGameType() == GTYPE_SAVE_MIDMISSION);
 
 	if (!InitRadar()) 	// After resLoad cause it needs the game palette initialised.
 	{
@@ -1774,7 +1774,7 @@ static bool stageThreeInitialiseSync()
 
 	preProcessVisibility(gameWorld.map);
 
-	prepareScripts(getLevelLoadType() == GTYPE_SAVE_MIDMISSION || getLevelLoadType() == GTYPE_SAVE_START);
+	prepareScripts(getLevelLoadType() == GTYPE_SAVE_MIDMISSION);
 
 	if (!fpathInitialise())
 	{
@@ -1808,7 +1808,7 @@ static bool stageThreeInitialiseSync()
 
 	countUpdate();
 
-	if (getLevelLoadType() == GTYPE_SAVE_MIDMISSION || getLevelLoadType() == GTYPE_SAVE_START)
+	if (getLevelLoadType() == GTYPE_SAVE_MIDMISSION)
 	{
 		executeFnAndProcessScriptQueuedRemovals([]() { triggerEvent(TRIGGER_GAME_LOADED); });
 	}

--- a/src/levels.cpp
+++ b/src/levels.cpp
@@ -875,7 +875,6 @@ struct LevLoadContext
 	GAME_TYPE      saveType = GTYPE_SCENARIO_START;
 	LEVEL_DATASET* psNewLevel = nullptr;
 	LEVEL_DATASET* psChangeLevel = nullptr;
-	bool           bCamChangeSaveGame = false;
 };
 
 enum class LevDatasetResolveResult
@@ -1084,15 +1083,9 @@ static LevDatasetResolveResult levResolveDatasetForLoad(LevLoadContext& ctx)
 	}
 	debug(LOG_WZ, "** Data set found is %s type %d", ctx.psNewLevel->pName.c_str(), (int)ctx.psNewLevel->type);
 
-	ctx.bCamChangeSaveGame = ctx.pSaveName != nullptr && ctx.saveType == GTYPE_SAVE_START && ctx.psNewLevel->psChange != nullptr;
-	if (ctx.bCamChangeSaveGame)
-	{
-		debug(LOG_WZ, "** CAMCHANGE FOUND");
-	}
-
 	// select the change dataset if there is one
 	ctx.psChangeLevel = nullptr;
-	if (((ctx.psNewLevel->psChange != nullptr) && (psCurrLevel != nullptr)) || ctx.bCamChangeSaveGame)
+	if ((ctx.psNewLevel->psChange != nullptr) && (psCurrLevel != nullptr))
 	{
 		//store the level name
 		debug(LOG_WZ, "Found CAMCHANGE dataset");
@@ -1195,7 +1188,7 @@ static LoadingTask<> levLoadMissionBranchesBeforeMainLoop(ResourceLoadingControl
 			}
 		}
 
-		if (ctx.pSaveName == nullptr || ctx.saveType == GTYPE_SAVE_START)
+		if (ctx.pSaveName == nullptr)
 		{
 			debug(LOG_NEVER, "Start mission - no .gam");
 			if (!(co_await startMission(controller, (LEVEL_TYPE)psNewLevel->type, GameLoadDetails::makeLevelFileLoad(""))))
@@ -1203,31 +1196,6 @@ static LoadingTask<> levLoadMissionBranchesBeforeMainLoop(ResourceLoadingControl
 				debug(LOG_ERROR, "Failed startMission(%d)!", static_cast<int8_t>(psNewLevel->type));
 				co_return load_fail();
 			}
-		}
-	}
-
-	//we need to load up the save game data here for a camchange
-	if (ctx.bCamChangeSaveGame)
-	{
-		if (ctx.pSaveName != nullptr)
-		{
-			if (psBaseData != nullptr)
-			{
-				if (!stageTwoInitialise())
-				{
-					debug(LOG_ERROR, "Failed stageTwoInitialise() [camchange]!");
-					co_return load_fail();
-				}
-			}
-
-			debug(LOG_NEVER, "loading savegame: %s", ctx.pSaveName);
-			if (!(co_await loadGame(controller, GameLoadDetails::makeUserSaveGameLoad(ctx.pSaveName), false, true)))
-			{
-				debug(LOG_ERROR, "Failed loadGame(%s)!", ctx.pSaveName);
-				co_return load_fail();
-			}
-
-			campaignReset();
 		}
 	}
 
@@ -1245,7 +1213,7 @@ static LoadingTask<> levLoadMissionDataLoop(ResourceLoadingController& controlle
 		if (psNewLevel->game == i)
 		{
 			// do some more initialising if necessary
-			if (psNewLevel->type == LEVEL_TYPE::LDS_COMPLETE || psNewLevel->type >= LEVEL_TYPE::LDS_MULTI_TYPE_START || (psBaseData != nullptr && !ctx.bCamChangeSaveGame))
+			if (psNewLevel->type == LEVEL_TYPE::LDS_COMPLETE || psNewLevel->type >= LEVEL_TYPE::LDS_MULTI_TYPE_START || (psBaseData != nullptr))
 			{
 				if (!stageTwoInitialise())
 				{
@@ -1255,7 +1223,7 @@ static LoadingTask<> levLoadMissionDataLoop(ResourceLoadingController& controlle
 			}
 
 			// load a savegame if there is one - but not if already done so
-			if (ctx.pSaveName != nullptr && !ctx.bCamChangeSaveGame)
+			if (ctx.pSaveName != nullptr)
 			{
 				//set the mission type before the saveGame data is loaded
 				if (ctx.saveType == GTYPE_SAVE_MIDMISSION)
@@ -1279,7 +1247,7 @@ static LoadingTask<> levLoadMissionDataLoop(ResourceLoadingController& controlle
 				}
 			}
 
-			if (ctx.pSaveName == nullptr || ctx.saveType == GTYPE_SAVE_START)
+			if (ctx.pSaveName == nullptr)
 			{
 				// load the game
 				debug(LOG_WZ, "Loading scenario file %s", psNewLevel->apDataFiles[i].c_str());
@@ -1401,7 +1369,7 @@ LoadingTask<> levLoadDataTask(ResourceLoadingController &controller, LevLoadJobP
 	      params.pSaveName == nullptr ? "<none>" : params.pSaveName,
 	      static_cast<int>(params.saveType));
 
-	if (params.saveType == GTYPE_SAVE_START || params.saveType == GTYPE_SAVE_MIDMISSION)
+	if (params.saveType == GTYPE_SAVE_MIDMISSION)
 	{
 		if (!levReleaseAll())
 		{

--- a/src/loop.cpp
+++ b/src/loop.cpp
@@ -271,7 +271,9 @@ static GAMECODE renderLoop()
 
 				if (saveInMissionRes())
 				{
-					if (saveGame(sRequestResult, GTYPE_SAVE_START))
+					// NOTE: this mission-results save path is currently unreachable (FUTURE TODO: remove)
+					// GTYPE_SAVE_START is deprecated, so use MIDMISSION
+					if (saveGame(sRequestResult, GTYPE_SAVE_MIDMISSION))
 					{
 						sstrcpy(msgbuffer, _("GAME SAVED: "));
 						sstrcat(msgbuffer, savegameWithoutExtension(sRequestResult));

--- a/src/mission.cpp
+++ b/src/mission.cpp
@@ -2435,25 +2435,10 @@ static bool _intAddMissionResult(bool result, bool bPlaySuccess, bool showBackDr
 			widgAddButton(psWScreen, &sButInit);
 		}
 
-		// FIXME, We got serious issues with savegames at the *END* of some missions, and while they
-		// will load, they don't have the correct state information or other settings.
-		// See transition from CAM2->CAM3 for a example.
-		/* Only add save option if in the game for real, ie, not fastplay.
-		* And the player hasn't just completed the whole game
-		* Don't add save option if just lost and in debug mode.
-		if (!bMultiPlayer && !testPlayerHasWon() && !(testPlayerHasLost() && getDebugMappingStatus()))
-		{
-			//save
-			sButInit.id			= IDMISSIONRES_SAVE;
-			sButInit.x			= MISSION_1_X;
-			sButInit.y			= MISSION_1_Y;
-			sButInit.pText		= _("Save Game");//"Save Game";
-			widgAddButton(psWScreen, &sButInit);
-
-			// automatically save the game to be able to restart a mission
-			saveGame((char *)"savegames/Autosave.gam", GTYPE_SAVE_START);
-		}
-		*/
+		// NOTE: There used to be a "Save Game" option here, but it was long disabled because of
+		// serious issues with savegames at the *END* of some missions (example: the CAM2->CAM3
+		// transition) that loaded but had incorrect state. It used the now-deprecated
+		// GTYPE_SAVE_START path and has been removed.
 	}
 	else
 	{
@@ -2525,7 +2510,10 @@ void intRunMissionResult()
 				{
 					char msg[256] = {'\0'};
 
-					saveGame(sRequestResult, GTYPE_SAVE_START);
+					// NOTE: this mission-results save path is currently unreachable (FUTURE TODO: remove)
+					// (the "Save Game" button is no longer added)
+					// GTYPE_SAVE_START is deprecated, so use MIDMISSION
+					saveGame(sRequestResult, GTYPE_SAVE_MIDMISSION);
 					sstrcpy(msg, _("GAME SAVED :"));
 					sstrcat(msg, savegameWithoutExtension(sRequestResult));
 					addConsoleMessage(msg, LEFT_JUSTIFY, NOTIFY_MESSAGE);

--- a/src/qtscript.cpp
+++ b/src/qtscript.cpp
@@ -1933,11 +1933,11 @@ scripting_engine& scripting_engine::instance()
 std::vector<scripting_engine::LabelInfo> scripting_engine::debug_GetLabelInfo() const
 {
 	std::vector<scripting_engine::LabelInfo> results;
-	for (LABELMAP::const_iterator i = labels.cbegin(); i != labels.cend(); i++)
+	// 'scope' is the owning script for an owned label, or "global" for a map-authored / legacy label
+	auto addLabelInfo = [&](const std::string& name, const LABEL& l, const WzString& scope)
 	{
-		const LABEL &l = i->second;
 		scripting_engine::LabelInfo labelInfo;
-		labelInfo.label = WzString::fromUtf8(i->first);
+		labelInfo.label = WzString::fromUtf8(name);
 		const char *c = "?";
 		switch (l.type)
 		{
@@ -1960,23 +1960,22 @@ std::vector<scripting_engine::LabelInfo> scripting_engine::debug_GetLabelInfo() 
 		case 0: labelInfo.trigger = "Active"; break;
 		default: labelInfo.trigger = "Done"; break;
 		}
-		if (l.player == ALL_PLAYERS)
-		{
-			labelInfo.owner = "ALL";
-		}
-		else
-		{
-			labelInfo.owner = WzString::number(l.player);
-		}
-		if (l.subscriber == ALL_PLAYERS)
-		{
-			labelInfo.subscriber = "ALL";
-		}
-		else
-		{
-			labelInfo.subscriber = WzString::number(l.subscriber);
-		}
+		labelInfo.owner = (l.player == ALL_PLAYERS) ? WzString("ALL") : WzString::number(l.player);
+		labelInfo.subscriber = (l.subscriber == ALL_PLAYERS) ? WzString("ALL") : WzString::number(l.subscriber);
+		labelInfo.scope = scope;
 		results.push_back(std::move(labelInfo));
+	};
+	for (const auto &it : globalLabels)
+	{
+		addLabelInfo(it.first, it.second, WzString("global"));
+	}
+	for (const auto &bucket : ownedLabels)
+	{
+		WzString scope = WzString::fromUtf8(bucket.first->scriptName());
+		for (const auto &it : bucket.second)
+		{
+			addLabelInfo(it.first, it.second, scope);
+		}
 	}
 	return results;
 }
@@ -1995,14 +1994,20 @@ void clearMarks()
 
 void scripting_engine::markAllLabels(bool only_active)
 {
-	for (const auto &it : labels)
+	auto markBucket = [&](const LABELMAP& bucket)
 	{
-		const auto &key = it.first;
-		const LABEL &l = it.second;
-		if (!only_active || l.triggered <= 0)
+		for (const auto &it : bucket)
 		{
-			showLabel(key, false, false);
+			if (!only_active || it.second.triggered <= 0)
+			{
+				showLabel(it.first, false, false);
+			}
 		}
+	};
+	markBucket(globalLabels);
+	for (const auto &bucket : ownedLabels)
+	{
+		markBucket(bucket.second);
 	}
 }
 
@@ -2010,12 +2015,31 @@ void scripting_engine::markAllLabels(bool only_active)
 
 void scripting_engine::showLabel(const std::string &key, bool clear_old, bool jump_to)
 {
-	if (labels.count(key) == 0)
+	// Search all scopes (global, then any owned bucket) for the label by name
+	const LABEL *pLabel = nullptr;
+	auto globalIt = globalLabels.find(key);
+	if (globalIt != globalLabels.end())
+	{
+		pLabel = &globalIt->second;
+	}
+	else
+	{
+		for (const auto &bucket : ownedLabels)
+		{
+			auto ownedIt = bucket.second.find(key);
+			if (ownedIt != bucket.second.end())
+			{
+				pLabel = &ownedIt->second;
+				break;
+			}
+		}
+	}
+	if (pLabel == nullptr)
 	{
 		debug(LOG_ERROR, "label %s not found", key.c_str());
 		return;
 	}
-	LABEL &l = labels[key];
+	const LABEL &l = *pLabel;
 	if (clear_old)
 	{
 		clearMarks();
@@ -2106,12 +2130,12 @@ std::pair<bool, int> scripting_engine::seenLabelCheck(wzapi::scripting_instance 
 	auto seenObjIt = psMap->map().find(seen);
 	int groupId = (seenObjIt != psMap->map().end()) ? seenObjIt->second : 0;
 	bool foundObj = false, foundGroup = false;
-	for (auto &it : labels)
+	// Only union(this instance's own, global) labels - never another instance's owned labels
+	forEachScopedLabel(instance, [&](const std::string& /*name*/, LABEL& l) -> bool
 	{
-		LABEL &l = it.second;
 		if (l.triggered != 0 || !(l.subscriber == ALL_PLAYERS || l.subscriber == viewer->player))
 		{
-			continue;
+			return true; // not a candidate - keep enumerating
 		}
 
 		// Don't let a seen game object ID which matches a group label ID to prematurely
@@ -2126,7 +2150,8 @@ std::pair<bool, int> scripting_engine::seenLabelCheck(wzapi::scripting_instance 
 			l.triggered = viewer->id; // record who made the discovery
 			foundGroup = true;
 		}
-	}
+		return true; // check every visible label
+	});
 	if (foundObj || foundGroup)
 	{
 		jsDebugUpdateLabels();
@@ -2139,17 +2164,40 @@ bool scripting_engine::areaLabelCheck(DROID *psDroid)
 	int x = psDroid->pos.x;
 	int y = psDroid->pos.y;
 	bool activated = false;
-	for (LABELMAP::iterator i = labels.begin(); i != labels.end(); i++)
+	// Trip any untriggered area/radius label the droid has entered
+	// - A global (map-authored) label fires eventArea to every instance (triggerEventArea)
+	// - An owned label fires only to its owner
+	auto checkBucket = [&](LABELMAP& bucket, wzapi::scripting_instance* owner)
 	{
-		LABEL &l = i->second;
-		if (l.triggered == 0 && (l.subscriber == ALL_PLAYERS || l.subscriber == psDroid->player)
-		    && ((l.type == SCRIPT_AREA && l.p1.x < x && l.p1.y < y && l.p2.x > x && l.p2.y > y)
-		        || (l.type == SCRIPT_RADIUS && iHypot(l.p1 - psDroid->pos.xy()) < l.p2.x)))
+		for (auto& it : bucket)
 		{
-			// We're inside an untriggered area
-			activated = true;
-			l.triggered = psDroid->id;
-			triggerEventArea(i->first, psDroid);
+			LABEL& l = it.second;
+			if (l.triggered == 0 && (l.subscriber == ALL_PLAYERS || l.subscriber == psDroid->player)
+			    && ((l.type == SCRIPT_AREA && l.p1.x < x && l.p1.y < y && l.p2.x > x && l.p2.y > y)
+			        || (l.type == SCRIPT_RADIUS && iHypot(l.p1 - psDroid->pos.xy()) < l.p2.x)))
+			{
+				// We're inside an untriggered area
+				activated = true;
+				l.triggered = psDroid->id;
+				if (owner)
+				{
+					owner->handle_eventArea(it.first, psDroid); // owned label - only its creating instance
+				}
+				else
+				{
+					triggerEventArea(it.first, psDroid); // global/map label - all instances
+				}
+			}
+		}
+	};
+	checkBucket(globalLabels, nullptr);
+	// Iterate owners in `scripts` order (deterministic across clients)
+	for (auto* instance : scripts)
+	{
+		auto bucketIt = ownedLabels.find(instance);
+		if (bucketIt != ownedLabels.end())
+		{
+			checkBucket(bucketIt->second, instance);
 		}
 	}
 	if (activated)
@@ -2157,6 +2205,97 @@ bool scripting_engine::areaLabelCheck(DROID *psDroid)
 		jsDebugUpdateLabels();
 	}
 	return activated;
+}
+
+// ----------------------------------------------------------------------------------------
+// Label scoping helpers
+//
+// Resolve own-first, then global
+// (ownedLabels is not yet populated, so these currently reduce to the global bucket - i.e. identical to the previous single-map behavior)
+
+LABEL* scripting_engine::findScopedLabel(wzapi::scripting_instance *instance, const std::string &name)
+{
+	if (instance)
+	{
+		auto bucketIt = ownedLabels.find(instance);
+		if (bucketIt != ownedLabels.end())
+		{
+			auto labelIt = bucketIt->second.find(name);
+			if (labelIt != bucketIt->second.end())
+			{
+				return &labelIt->second;
+			}
+		}
+	}
+	auto globalIt = globalLabels.find(name);
+	if (globalIt != globalLabels.end())
+	{
+		return &globalIt->second;
+	}
+	return nullptr;
+}
+
+size_t scripting_engine::eraseScopedLabel(wzapi::scripting_instance *instance, const std::string &name)
+{
+	if (instance)
+	{
+		auto bucketIt = ownedLabels.find(instance);
+		if (bucketIt != ownedLabels.end())
+		{
+			size_t erased = bucketIt->second.erase(name);
+			if (erased > 0)
+			{
+				return erased;
+			}
+		}
+	}
+	return globalLabels.erase(name);
+}
+
+scripting_engine::LABELMAP& scripting_engine::labelCreationBucket(wzapi::scripting_instance *instance)
+{
+	// A script-created label is owned by its creating instance
+	// (No instance context - which should not happen for addLabel - falls back to the global bucket)
+	if (instance)
+	{
+		return ownedLabels[instance];
+	}
+	return globalLabels;
+}
+
+void scripting_engine::forEachScopedLabel(wzapi::scripting_instance *instance, const std::function<bool(const std::string&, LABEL&)>& fn)
+{
+	LABELMAP *ownBucket = nullptr;
+	if (instance)
+	{
+		auto bucketIt = ownedLabels.find(instance);
+		if (bucketIt != ownedLabels.end())
+		{
+			ownBucket = &bucketIt->second;
+		}
+	}
+	if (ownBucket)
+	{
+		for (auto &it : *ownBucket)
+		{
+			if (!fn(it.first, it.second))
+			{
+				return; // fn requested early stop
+			}
+		}
+	}
+	for (auto &it : globalLabels)
+	{
+		// own-shadows-global: skip a global label whose name the instance overrides with its own
+		if (ownBucket && ownBucket->count(it.first) > 0)
+		{
+			continue;
+		}
+		if (!fn(it.first, it.second))
+		{
+			return; // fn requested early stop
+		}
+	}
 }
 
 // ----------------------------------------------------------------------------------------
@@ -2255,7 +2394,8 @@ bool scripting_engine::loadLabels(const char *filename, const std::unordered_map
 bool scripting_engine::loadLabels(const nlohmann::json &result, const std::unordered_map<UDWORD, UDWORD>& fixedMapIdToGeneratedId, std::array<std::unordered_map<UDWORD, UDWORD>, MAX_PLAYER_SLOTS>& moduleToBuilding, bool UserSaveGame)
 {
 	ASSERT_OR_RETURN(false, result.is_object(), "Labels JSON is not an object");
-	labels.clear();
+	globalLabels.clear();
+	ownedLabels.clear();
 	debug(LOG_SAVE, "Loading %zu labels... (fixedMapToGeneratedId.count = %zu)", result.size(), fixedMapIdToGeneratedId.size());
 
 	// matches WzConfig::vector2i: a [x, y] array, defaulting to (0, 0) if missing / malformed
@@ -2298,7 +2438,35 @@ bool scripting_engine::loadLabels(const nlohmann::json &result, const std::unord
 		const nlohmann::json &section = it.value();
 		LABEL p;
 		std::string label = section.value("label", std::string());
-		if (labels.count(label) > 0)
+
+		// Resolve which bucket this label belongs to:
+		// - Owner keys (ownerPlayer/ownerScript) are written only for script-created labels and are honored only on savegame loads
+		// - Map/scenario labels are always global
+		LABELMAP* targetBucket = &globalLabels;
+		auto ownerScriptIt = section.find("ownerScript");
+		if (ownerScriptIt != section.end() && ownerScriptIt->is_string())
+		{
+			if (!UserSaveGame)
+			{
+				// A map/scenario labels file must never carry owners - log, keep global
+				debug(LOG_ERROR, "Label '%s' (section %s) carries an owner on a non-savegame load; treating as global",
+				      label.c_str(), sectionName.c_str());
+			}
+			else
+			{
+				int ownerPlayer = section.value("ownerPlayer", -1);
+				WzString ownerScript = WzString::fromUtf8(ownerScriptIt->get<std::string>());
+				// fall back to global bucket if the owner instance can't be found
+				// (findInstanceForPlayer will ASSERT and log)
+				wzapi::scripting_instance* ownerInstance = findInstanceForPlayer(ownerPlayer, ownerScript);
+				if (ownerInstance)
+				{
+					targetBucket = &ownedLabels[ownerInstance];
+				}
+			}
+		}
+
+		if (targetBucket->count(label) > 0)
 		{
 			debug(LOG_ERROR, "Duplicate label found");
 		}
@@ -2311,7 +2479,7 @@ bool scripting_engine::loadLabels(const nlohmann::json &result, const std::unord
 			p.id = -1;
 			p.triggered = section.value("triggered", -1); // deactivated by default
 			p.subscriber = ALL_PLAYERS;
-			labels[label] = p;
+			(*targetBucket)[label] = p;
 		}
 		else if (startsWith(sectionName, "area"))
 		{
@@ -2322,7 +2490,7 @@ bool scripting_engine::loadLabels(const nlohmann::json &result, const std::unord
 			p.triggered = section.value("triggered", 0); // activated by default
 			p.id = -1;
 			p.subscriber = section.value("subscriber", ALL_PLAYERS);
-			labels[label] = p;
+			(*targetBucket)[label] = p;
 		}
 		else if (startsWith(sectionName, "radius"))
 		{
@@ -2334,7 +2502,7 @@ bool scripting_engine::loadLabels(const nlohmann::json &result, const std::unord
 			p.triggered = section.value("triggered", 0); // activated by default
 			p.subscriber = section.value("subscriber", ALL_PLAYERS);
 			p.id = -1;
-			labels[label] = p;
+			(*targetBucket)[label] = p;
 		}
 		else if (startsWith(sectionName, "object"))
 		{
@@ -2370,7 +2538,7 @@ bool scripting_engine::loadLabels(const nlohmann::json &result, const std::unord
 			{
 				debug(LOG_SAVEGAME, "Failed to find object that label references (probably destroyed before save): %s", label.c_str());
 			}
-			labels[label] = p;
+			(*targetBucket)[label] = p;
 		}
 		else if (startsWith(sectionName, "group"))
 		{
@@ -2411,7 +2579,7 @@ bool scripting_engine::loadLabels(const nlohmann::json &result, const std::unord
 			}
 			p.triggered = section.value("triggered", -1); // deactivated by default
 			p.subscriber = section.value("subscriber", ALL_PLAYERS);
-			labels[label] = p;
+			(*targetBucket)[label] = p;
 		}
 		else
 		{
@@ -2447,43 +2615,43 @@ bool scripting_engine::writeLabels(nlohmann::json &result)
 {
 	int c[5]; // make unique, incremental section names
 	memset(c, 0, sizeof(c));
-	for (LABELMAP::const_iterator i = labels.begin(); i != labels.end(); i++)
+
+	// Write a single label section:
+	// - 'owner' is the creating instance for an owned (script-created) label, or nullptr for a global (map-authored / legacy) label
+	// Owned labels are tagged with ownerPlayer/ownerScript so they round-trip back into the right bucket on load (savegames only)
+	auto writeOne = [&](const std::string& key, const LABEL& l, const wzapi::scripting_instance* owner)
 	{
-		const std::string& key = i->first;
-		const LABEL &l = i->second;
+		nlohmann::json section = nlohmann::json::object();
+		std::string sectionName;
 		if (l.type == SCRIPT_POSITION)
 		{
-			nlohmann::json section = nlohmann::json::object();
 			section["pos"] = nlohmann::json::array({ l.p1.x, l.p1.y });
 			section["label"] = key;
 			section["triggered"] = l.triggered;
-			result["position_" + std::to_string(c[0]++)] = std::move(section);
+			sectionName = "position_" + std::to_string(c[0]++);
 		}
 		else if (l.type == SCRIPT_AREA)
 		{
-			nlohmann::json section = nlohmann::json::object();
 			section["pos1"] = nlohmann::json::array({ l.p1.x, l.p1.y });
 			section["pos2"] = nlohmann::json::array({ l.p2.x, l.p2.y });
 			section["label"] = key;
 			section["player"] = l.player;
 			section["triggered"] = l.triggered;
 			section["subscriber"] = l.subscriber;
-			result["area_" + std::to_string(c[1]++)] = std::move(section);
+			sectionName = "area_" + std::to_string(c[1]++);
 		}
 		else if (l.type == SCRIPT_RADIUS)
 		{
-			nlohmann::json section = nlohmann::json::object();
 			section["pos"] = nlohmann::json::array({ l.p1.x, l.p1.y });
 			section["radius"] = l.p2.x;
 			section["label"] = key;
 			section["player"] = l.player;
 			section["triggered"] = l.triggered;
 			section["subscriber"] = l.subscriber;
-			result["radius_" + std::to_string(c[2]++)] = std::move(section);
+			sectionName = "radius_" + std::to_string(c[2]++);
 		}
 		else if (l.type == SCRIPT_GROUP)
 		{
-			nlohmann::json section = nlohmann::json::object();
 			section["id"] = l.id; // Persist the group id so it round-trips
 			section["player"] = l.player;
 			section["triggered"] = l.triggered;
@@ -2495,17 +2663,39 @@ bool scripting_engine::writeLabels(nlohmann::json &result)
 			section["members"] = std::move(members);
 			section["label"] = key;
 			section["subscriber"] = l.subscriber;
-			result["group_" + std::to_string(c[3]++)] = std::move(section);
+			sectionName = "group_" + std::to_string(c[3]++);
 		}
 		else
 		{
-			nlohmann::json section = nlohmann::json::object();
 			section["id"] = l.id;
 			section["player"] = l.player;
 			section["type"] = l.type;
 			section["label"] = key;
 			section["triggered"] = l.triggered;
-			result["object_" + std::to_string(c[4]++)] = std::move(section);
+			sectionName = "object_" + std::to_string(c[4]++);
+		}
+		if (owner)
+		{
+			section["ownerPlayer"] = owner->player();
+			section["ownerScript"] = owner->scriptName();
+		}
+		result[sectionName] = std::move(section);
+	};
+
+	// Global (map-authored / legacy) labels: no owner key
+	for (const auto& it : globalLabels)
+	{
+		writeOne(it.first, it.second, nullptr);
+	}
+	// Owned (script-created) labels: tagged with their creating instance
+	// (ownedLabels is not yet populated - addLabel does not assign owners yet - so the output is
+	// currently identical to before: global labels only, no owner keys)
+	for (const auto& bucket : ownedLabels)
+	{
+		const wzapi::scripting_instance* owner = bucket.first;
+		for (const auto& it : bucket.second)
+		{
+			writeOne(it.first, it.second, owner);
 		}
 	}
 	return true;
@@ -2545,11 +2735,11 @@ bool scripting_engine::writeLabels(nlohmann::json &result)
 //--
 wzapi::no_return_value scripting_engine::resetLabel(WZAPI_PARAMS(std::string labelName, optional<int> playerFilter))
 {
-	LABELMAP& labels = scripting_engine::instance().labels;
-	SCRIPT_ASSERT({}, context, labels.count(labelName) > 0, "Label %s not found", labelName.c_str());
-	LABEL &label = labels[labelName];
-	label.triggered = 0; // make active again
-	label.subscriber = playerFilter.value_or(ALL_PLAYERS);
+	// own-first, then global (so a script can still reset map/global labels - campaign relies on this)
+	LABEL *label = scripting_engine::instance().findScopedLabel(context.currentInstance(), labelName);
+	SCRIPT_ASSERT({}, context, label != nullptr, "Label %s not found", labelName.c_str());
+	label->triggered = 0; // make active again
+	label->subscriber = playerFilter.value_or(ALL_PLAYERS);
 	return {};
 }
 
@@ -2560,28 +2750,17 @@ wzapi::no_return_value scripting_engine::resetLabel(WZAPI_PARAMS(std::string lab
 //--
 std::vector<std::string> scripting_engine::enumLabels(WZAPI_PARAMS(optional<int> filterLabelType))
 {
-	const LABELMAP& labels = scripting_engine::instance().labels;
+	// Enumerate union(the caller's own, global) labels (own-shadows-global handled by forEachScopedLabel)
+	optional<SCRIPT_TYPE> filter = filterLabelType.has_value() ? optional<SCRIPT_TYPE>((SCRIPT_TYPE)filterLabelType.value()) : nullopt;
 	std::vector<std::string> matches;
-	if (filterLabelType.has_value()) // filter
+	scripting_engine::instance().forEachScopedLabel(context.currentInstance(), [&](const std::string& name, LABEL& label) -> bool
 	{
-		SCRIPT_TYPE type = (SCRIPT_TYPE)filterLabelType.value();
-		for (LABELMAP::const_iterator i = labels.begin(); i != labels.end(); i++)
+		if (!filter.has_value() || label.type == filter.value())
 		{
-			const LABEL &label = i->second;
-			if (label.type == type)
-			{
-				matches.push_back(i->first);
-			}
+			matches.push_back(name);
 		}
-	}
-	else // fast path, give all
-	{
-		matches.reserve(labels.size());
-		for (LABELMAP::const_iterator i = labels.begin(); i != labels.end(); i++)
-		{
-			matches.push_back(i->first);
-		}
-	}
+		return true; // collect every visible label
+	});
 	return matches;
 }
 
@@ -2710,7 +2889,6 @@ LABEL generic_script_object::toNewLabel() const
 //--
 wzapi::no_return_value scripting_engine::addLabel(WZAPI_PARAMS(generic_script_object object, std::string label, optional<int> _triggered))
 {
-	LABELMAP& labels = scripting_engine::instance().labels;
 	LABEL value = object.toNewLabel();
 
 	if (value.type == OBJ_DROID || value.type == OBJ_STRUCTURE || value.type == OBJ_FEATURE)
@@ -2726,7 +2904,8 @@ wzapi::no_return_value scripting_engine::addLabel(WZAPI_PARAMS(generic_script_ob
 		value.triggered = _triggered.value();
 	}
 
-	labels[label] = value;
+	// Store the label in the creating instance's own bucket (scoped to that script)
+	scripting_engine::instance().labelCreationBucket(context.currentInstance())[label] = value;
 	jsDebugUpdateLabels();
 	return {};
 }
@@ -2738,8 +2917,8 @@ wzapi::no_return_value scripting_engine::addLabel(WZAPI_PARAMS(generic_script_ob
 //--
 int scripting_engine::removeLabel(WZAPI_PARAMS(std::string label))
 {
-	LABELMAP& labels = scripting_engine::instance().labels;
-	int result = labels.erase(label);
+	// own-first, then global (so a script can still remove a global/map label if it has no own one)
+	int result = static_cast<int>(scripting_engine::instance().eraseScopedLabel(context.currentInstance(), label));
 	jsDebugUpdateLabels();
 	return result;
 }
@@ -2757,29 +2936,30 @@ optional<std::string> scripting_engine::getLabel(WZAPI_PARAMS(const BASE_OBJECT 
 	tmp.id = psObj->id;
 	tmp.player = psObj->player;
 	tmp.type = psObj->type;
-	return _findMatchingLabel(tmp);
+	return _findMatchingLabel(context.currentInstance(), tmp);
 }
 optional<std::string> scripting_engine::getLabelJS(WZAPI_PARAMS(wzapi::game_object_identifier obj_id))
 {
-	return _findMatchingLabel(obj_id);
+	return _findMatchingLabel(context.currentInstance(), obj_id);
 }
-optional<std::string> scripting_engine::_findMatchingLabel(wzapi::game_object_identifier obj_id)
+optional<std::string> scripting_engine::_findMatchingLabel(wzapi::scripting_instance *instance, wzapi::game_object_identifier obj_id)
 {
-	const LABELMAP& labels = scripting_engine::instance().labels;
+	// Search union(the caller's own, global) labels (own-first), returning the first matching label name
 	LABEL value;
 	value.id = obj_id.id;
 	value.player = obj_id.player;
 	value.type = obj_id.type;
 	debug(LOG_NEVER, "looking for label %i;%i;%i", obj_id.id, obj_id.player, obj_id.type);
 	std::string label;
-	for (const auto &it : labels)
+	scripting_engine::instance().forEachScopedLabel(instance, [&](const std::string& name, LABEL& l) -> bool
 	{
-		if (it.second == value)
+		if (l == value)
 		{
-			label = it.first;
-			break;
+			label = name; // own labels are visited first, so they take priority
+			return false; // first match found - stop enumerating
 		}
-	}
+		return true;
+	});
 
 	optional<std::string> retLabel;
 	if (!label.empty())
@@ -2840,11 +3020,12 @@ generic_script_object scripting_engine::getObject(WZAPI_PARAMS(wzapi::object_req
 
 generic_script_object scripting_engine::getObjectFromLabel(WZAPI_PARAMS(const std::string& label))
 {
-	// get by label case
+	// get by label case (own-first, then global)
 	BASE_OBJECT *psObj = nullptr;
-	if (labels.count(label) > 0)
+	const LABEL *pLabel = findScopedLabel(context.currentInstance(), label);
+	if (pLabel != nullptr)
 	{
-		const LABEL &p = labels[label];
+		const LABEL &p = *pLabel;
 		switch (p.type)
 		{
 		case SCRIPT_RADIUS:
@@ -2887,8 +3068,9 @@ generic_script_object scripting_engine::getObjectFromLabel(WZAPI_PARAMS(const st
 //--
 std::vector<const BASE_OBJECT *> scripting_engine::enumAreaByLabel(WZAPI_PARAMS(std::string label, optional<int> _playerFilter, optional<bool> _seen))
 {
-	SCRIPT_ASSERT({}, context, instance().labels.count(label) > 0, "Label %s not found", label.c_str());
-	const LABEL &p = instance().labels[label];
+	const LABEL *pLabel = instance().findScopedLabel(context.currentInstance(), label); // own-first, then global
+	SCRIPT_ASSERT({}, context, pLabel != nullptr, "Label %s not found", label.c_str());
+	const LABEL &p = *pLabel;
 	SCRIPT_ASSERT({}, context, p.type == SCRIPT_AREA, "Wrong label type for %s", label.c_str());
 	int x1 = p.p1.x;
 	int y1 = p.p1.y;
@@ -3050,7 +3232,10 @@ bool scripting_engine::unregisterFunctions(wzapi::scripting_instance *instance)
 		num = 1;
 	}
 	ASSERT(num == 1, "Number of engines removed from group map is %d!", num);
-	labels.clear();
+	// TODO: erase only this instance's owned bucket - clear globalLabels on the last teardown
+	// For now this preserves the existing blanket clear (ownedLabels is empty anyway, currently)
+	globalLabels.clear();
+	ownedLabels.erase(instance);
 	return true;
 }
 
@@ -3059,10 +3244,13 @@ bool scripting_engine::unregisterFunctions(wzapi::scripting_instance *instance)
 void scripting_engine::prepareLabels()
 {
 	// load the label group data into every scripting context, with the same negative group id
+	//
+	// Only map-authored (global) group labels exist at this point - owned labels are created later
+	// via runtime addLabel - so iterating globalLabels is the full set (unchanged behavior)
 	for (ENGINEMAP::iterator iter = groups.begin(); iter != groups.end(); ++iter)
 	{
 		wzapi::scripting_instance *instance = iter->first;
-		for (LABELMAP::iterator i = labels.begin(); i != labels.end(); ++i)
+		for (LABELMAP::iterator i = globalLabels.begin(); i != globalLabels.end(); ++i)
 		{
 			const LABEL &l = i->second;
 			if (l.type == SCRIPT_GROUP)
@@ -3085,9 +3273,10 @@ void scripting_engine::prepareLabels()
 
 wzapi::no_return_value scripting_engine::hackMarkTiles_ByLabel(WZAPI_PARAMS(const std::string& label))
 {
-	SCRIPT_ASSERT({}, context, labels.count(label) > 0, "Label %s not found", label.c_str());
+	const LABEL *pLabel = findScopedLabel(context.currentInstance(), label); // own-first, then global
+	SCRIPT_ASSERT({}, context, pLabel != nullptr, "Label %s not found", label.c_str());
 
-	const LABEL &l = labels[label];
+	const LABEL &l = *pLabel;
 	if (l.type == SCRIPT_AREA)
 	{
 		for (int x = map_coord(l.p1.x); x < map_coord(l.p2.x); x++)

--- a/src/qtscript.cpp
+++ b/src/qtscript.cpp
@@ -903,7 +903,8 @@ bool scripting_engine::loadScriptStates(const char *filename)
 			// filter out "scriptName" and "me" variables
 			result.erase("me");
 			result.erase("scriptName");
-			instance->loadScriptGlobals(result);
+			// v1 (this legacy loader): undefined was stored as JSON null, so null -> undefined
+			instance->loadScriptGlobals(result, /*fixedNulls=*/false);
 		}
 		else if (instance && list[i].startsWith("groups_"))
 		{
@@ -988,7 +989,8 @@ bool scripting_engine::loadScriptStates2(const nlohmann::json &root)
 				// filter out "scriptName" and "me" variables (saved implicitly inside globals)
 				globals.erase("me");
 				globals.erase("scriptName");
-				instance->loadScriptGlobals(globals);
+				// v2 saves tag undefined explicitly, so a bare JSON null means JS null
+				instance->loadScriptGlobals(globals, /*fixedNulls=*/true);
 			}
 
 			// Group memberships: { "lastNewGroupId": <int>, "<droidId>": ["<groupId>", ...], ... }

--- a/src/qtscript.cpp
+++ b/src/qtscript.cpp
@@ -2254,8 +2254,6 @@ bool scripting_engine::loadLabels(const char *filename, const std::unordered_map
 // ("position_<n>" / "area_<n>" / "radius_<n>" / "object_<n>" / "group_<n>"), matching writeLabels.
 bool scripting_engine::loadLabels(const nlohmann::json &result, const std::unordered_map<UDWORD, UDWORD>& fixedMapIdToGeneratedId, std::array<std::unordered_map<UDWORD, UDWORD>, MAX_PLAYER_SLOTS>& moduleToBuilding, bool UserSaveGame)
 {
-	int groupidx = -1;
-
 	ASSERT_OR_RETURN(false, result.is_object(), "Labels JSON is not an object");
 	labels.clear();
 	debug(LOG_SAVE, "Loading %zu labels... (fixedMapToGeneratedId.count = %zu)", result.size(), fixedMapIdToGeneratedId.size());
@@ -2274,6 +2272,20 @@ bool scripting_engine::loadLabels(const nlohmann::json &result, const std::unord
 	auto startsWith = [](const std::string &s, const char *prefix) -> bool {
 		return s.rfind(prefix, 0) == 0;
 	};
+
+	// Group labels carry a persisted "id" (new saves). Those that don't (legacy saves / map files) fall back
+	// to a synthetic negative id assigned positionally.
+	// Pre-scan so the fallback counter starts below the most-negative persisted id and can't collide with one.
+	int groupidx = -1;
+	for (auto it = result.begin(); it != result.end(); ++it)
+	{
+		if (!it->is_object() || !startsWith(it.key(), "group")) { continue; }
+		auto idIt = it->find("id");
+		if (idIt != it->end() && idIt->is_number_integer())
+		{
+			groupidx = std::min(groupidx, idIt->get<int>() - 1);
+		}
+	}
 
 	// Iterate section objects (matches WzConfig::childGroups, which only returns object-valued keys)
 	for (auto it = result.begin(); it != result.end(); ++it)
@@ -2362,7 +2374,17 @@ bool scripting_engine::loadLabels(const nlohmann::json &result, const std::unord
 		}
 		else if (startsWith(sectionName, "group"))
 		{
-			p.id = groupidx--;
+			// Use the persisted id if present (so it matches the saved group memberships),
+			// otherwise fall back to a synthetic negative id (legacy saves / map files)
+			auto idIt = section.find("id");
+			if (idIt != section.end() && idIt->is_number_integer())
+			{
+				p.id = idIt->get<int>();
+			}
+			else
+			{
+				p.id = groupidx--;
+			}
 			p.type = SCRIPT_GROUP;
 			p.player = section.value("player", 0);
 			auto membersIt = section.find("members");
@@ -2462,6 +2484,7 @@ bool scripting_engine::writeLabels(nlohmann::json &result)
 		else if (l.type == SCRIPT_GROUP)
 		{
 			nlohmann::json section = nlohmann::json::object();
+			section["id"] = l.id; // Persist the group id so it round-trips
 			section["player"] = l.player;
 			section["triggered"] = l.triggered;
 			nlohmann::json members = nlohmann::json::array();

--- a/src/qtscript.cpp
+++ b/src/qtscript.cpp
@@ -737,6 +737,15 @@ bool scripting_engine::saveScriptStates2(const char *filename)
 
 		instanceObj["isReceivingAllEvents"] = instance->isReceivingAllEvents();
 
+		// This instance's owned (script-created) labels - (Omitted entirely when the instance has none)
+		auto ownedIt = ownedLabels.find(instance);
+		if (ownedIt != ownedLabels.end() && !ownedIt->second.empty())
+		{
+			nlohmann::json instanceLabels = nlohmann::json::array();
+			writeLabelMap(ownedIt->second, instanceLabels);
+			instanceObj["labels"] = std::move(instanceLabels);
+		}
+
 		instancesArray.push_back(std::move(instanceObj));
 	}
 	root["instances"] = std::move(instancesArray);
@@ -765,6 +774,11 @@ bool scripting_engine::saveScriptStates2(const char *filename)
 		timersArray.push_back(std::move(nodeInfo));
 	}
 	root["timers"] = std::move(timersArray);
+
+	// Global (map-authored / legacy / unowned) labels go at the top level
+	nlohmann::json globalLabelsArr = nlohmann::json::array();
+	writeLabelMap(globalLabels, globalLabelsArr);
+	root["labels"] = std::move(globalLabelsArr);
 
 	return saveJSONToFile(root, filename);
 }
@@ -932,6 +946,18 @@ bool scripting_engine::loadScriptStates2(const nlohmann::json &root)
 {
 	uniqueTimerID maxRestoredTimerID = 0;
 
+	// Labels: a v2 save is the authoritative source, so clear and rebuild both buckets here
+	// - Global (map-authored / legacy / unowned) labels live at the top level
+	// - Each instance's owned labels are nested under it (loaded in the instance loop below)
+	// - No map->id remapping is needed - savegame labels store already-synchronized runtime ids
+	globalLabels.clear();
+	ownedLabels.clear();
+	auto topLabelsIt = root.find("labels");
+	if (topLabelsIt != root.end() && topLabelsIt->is_array())
+	{
+		loadLabelMap(*topLabelsIt, globalLabels);
+	}
+
 	// Instances: per-instance globals + group memberships + flags
 	auto instancesIt = root.find("instances");
 	if (instancesIt != root.end() && instancesIt->is_array())
@@ -1015,6 +1041,13 @@ bool scripting_engine::loadScriptStates2(const nlohmann::json &root)
 			{
 				instance->setReceiveAllEvents(recvIt->get<bool>());
 			}
+
+			// This instance's owned labels
+			auto instLabelsIt = instanceObj.find("labels");
+			if (instLabelsIt != instanceObj.end() && instLabelsIt->is_array())
+			{
+				loadLabelMap(*instLabelsIt, ownedLabels[instance]);
+			}
 		}
 	}
 
@@ -1078,6 +1111,7 @@ bool scripting_engine::loadScriptStates2(const nlohmann::json &root)
 	}
 
 	lastTimerID = maxRestoredTimerID;
+
 	return true;
 }
 
@@ -2390,8 +2424,10 @@ bool scripting_engine::loadLabels(const char *filename, const std::unordered_map
 	return loadLabels(ini.currentJsonValue(), fixedMapIdToGeneratedId, moduleToBuilding, UserSaveGame);
 }
 
-// Load labels from an in-memory JSON object. The object's keys are section names
-// ("position_<n>" / "area_<n>" / "radius_<n>" / "object_<n>" / "group_<n>"), matching writeLabels.
+// Loader A: load flat labels.json (map/scenario data or an old v1 savegame) from an in-memory JSON object
+// - The object's keys are section names ("position_<n>" / "area_<n>" / "radius_<n>" / "object_<n>" / "group_<n>")
+// - All labels are global (this format has no ownership)
+// - Object/group ids are remapped via the map-load tables
 bool scripting_engine::loadLabels(const nlohmann::json &result, const std::unordered_map<UDWORD, UDWORD>& fixedMapIdToGeneratedId, std::array<std::unordered_map<UDWORD, UDWORD>, MAX_PLAYER_SLOTS>& moduleToBuilding, bool UserSaveGame)
 {
 	ASSERT_OR_RETURN(false, result.is_object(), "Labels JSON is not an object");
@@ -2440,36 +2476,12 @@ bool scripting_engine::loadLabels(const nlohmann::json &result, const std::unord
 		LABEL p;
 		std::string label = section.value("label", std::string());
 
-		// Resolve which bucket this label belongs to:
-		// - Owner keys (ownerPlayer/ownerScript) are written only for script-created labels and are honored only on savegame loads
-		// - Map/scenario labels are always global
-		LABELMAP* targetBucket = &globalLabels;
-		auto ownerScriptIt = section.find("ownerScript");
-		if (ownerScriptIt != section.end() && ownerScriptIt->is_string())
+		// The flat labels.json format (map/scenario data and old v1 savegames) has no concept of
+		// per-instance ownership - every label is global. (Owned labels are a v2 feature and travel
+		// inside the script state, loaded by loadLabelMap, not here)
+		if (globalLabels.count(label) > 0)
 		{
-			if (!UserSaveGame)
-			{
-				// A map/scenario labels file must never carry owners - log, keep global
-				debug(LOG_ERROR, "Label '%s' (section %s) carries an owner on a non-savegame load; treating as global",
-				      label.c_str(), sectionName.c_str());
-			}
-			else
-			{
-				int ownerPlayer = section.value("ownerPlayer", -1);
-				WzString ownerScript = WzString::fromUtf8(ownerScriptIt->get<std::string>());
-				// fall back to global bucket if the owner instance can't be found
-				// (findInstanceForPlayer will ASSERT and log)
-				wzapi::scripting_instance* ownerInstance = findInstanceForPlayer(ownerPlayer, ownerScript);
-				if (ownerInstance)
-				{
-					targetBucket = &ownedLabels[ownerInstance];
-				}
-			}
-		}
-
-		if (targetBucket->count(label) > 0)
-		{
-			debug(LOG_ERROR, "Duplicate label found");
+			debug(LOG_ERROR, "Duplicate label found: \"%s\"", label.c_str());
 		}
 		else if (startsWith(sectionName, "position"))
 		{
@@ -2480,7 +2492,7 @@ bool scripting_engine::loadLabels(const nlohmann::json &result, const std::unord
 			p.id = -1;
 			p.triggered = section.value("triggered", -1); // deactivated by default
 			p.subscriber = ALL_PLAYERS;
-			(*targetBucket)[label] = p;
+			globalLabels[label] = p;
 		}
 		else if (startsWith(sectionName, "area"))
 		{
@@ -2491,7 +2503,7 @@ bool scripting_engine::loadLabels(const nlohmann::json &result, const std::unord
 			p.triggered = section.value("triggered", 0); // activated by default
 			p.id = -1;
 			p.subscriber = section.value("subscriber", ALL_PLAYERS);
-			(*targetBucket)[label] = p;
+			globalLabels[label] = p;
 		}
 		else if (startsWith(sectionName, "radius"))
 		{
@@ -2503,7 +2515,7 @@ bool scripting_engine::loadLabels(const nlohmann::json &result, const std::unord
 			p.triggered = section.value("triggered", 0); // activated by default
 			p.subscriber = section.value("subscriber", ALL_PLAYERS);
 			p.id = -1;
-			(*targetBucket)[label] = p;
+			globalLabels[label] = p;
 		}
 		else if (startsWith(sectionName, "object"))
 		{
@@ -2539,7 +2551,7 @@ bool scripting_engine::loadLabels(const nlohmann::json &result, const std::unord
 			{
 				debug(LOG_SAVEGAME, "Failed to find object that label references (probably destroyed before save): %s", label.c_str());
 			}
-			(*targetBucket)[label] = p;
+			globalLabels[label] = p;
 		}
 		else if (startsWith(sectionName, "group"))
 		{
@@ -2556,8 +2568,12 @@ bool scripting_engine::loadLabels(const nlohmann::json &result, const std::unord
 			}
 			p.type = SCRIPT_GROUP;
 			p.player = section.value("player", 0);
+			// 'members' is a map-load seed consumed by prepareLabels()
+			// - For savegame loads prepareLabels does not run and the live membership is restored
+			//   from the saved groups, so the seed is dead data - skip it (keeping savegame
+			//   group-label idlist empty) to handle the case of v1 saves that still wrote it
 			auto membersIt = section.find("members");
-			if (membersIt != section.end() && membersIt->is_array())
+			if (!UserSaveGame && membersIt != section.end() && membersIt->is_array())
 			{
 				for (const auto &j : *membersIt)
 				{
@@ -2580,7 +2596,7 @@ bool scripting_engine::loadLabels(const nlohmann::json &result, const std::unord
 			}
 			p.triggered = section.value("triggered", -1); // deactivated by default
 			p.subscriber = section.value("subscriber", ALL_PLAYERS);
-			(*targetBucket)[label] = p;
+			globalLabels[label] = p;
 		}
 		else
 		{
@@ -2590,114 +2606,192 @@ bool scripting_engine::loadLabels(const nlohmann::json &result, const std::unord
 	return true;
 }
 
-bool writeLabels(const char *filename)
+// Loader for the script-state v2 embedded label format: a JSON array of label objects, each
+// self-described by a "type" field
+//
+// Loaded into a single, caller-chosen bucket (does *not* clear it), so it can be called once
+// per bucket (top-level globals, then each instance's owned labels)
+//
+// Unlike loadLabels (Loader A, for map/scenario + old v1 labels.json) there is deliberately:
+// - no map->id remapping (a v2 save stores already-synchronized runtime ids)
+// Object/group ids are resolved as-is, tolerating an object destroyed before save
+// (v2 labels only ever come from savegames)
+bool scripting_engine::loadLabelMap(const nlohmann::json &labelArray, LABELMAP &target)
 {
-	return scripting_engine::instance().writeLabels(filename);
-}
+	ASSERT_OR_RETURN(false, labelArray.is_array(), "v2 labels is not an array");
 
-bool writeLabels(nlohmann::json &result)
-{
-	return scripting_engine::instance().writeLabels(result);
-}
+	auto jsonVector2i = [](const nlohmann::json &entry, const char *key) -> Vector2i {
+		Vector2i r(0, 0);
+		auto it = entry.find(key);
+		if (it == entry.end() || !it->is_array() || it->size() != 2) { return r; }
+		try {
+			r.x = (*it)[0].get<int>();
+			r.y = (*it)[1].get<int>();
+		} catch (const std::exception &) { /* leave as (0, 0) */ }
+		return r;
+	};
+	// A label's player/subscriber must be a real player slot or ALL_PLAYERS
+	// The upper bound is MAX_PLAYER_SLOTS (see: PLAYER_FEATURE, scavenger player slot)
+	auto isValidLabelPlayer = [](int v) -> bool {
+		return v == ALL_PLAYERS || (v >= 0 && v < MAX_PLAYER_SLOTS);
+	};
 
-// Write labels to a file - builds the in-memory JSON document and saves it.
-bool scripting_engine::writeLabels(const char *filename)
-{
-	nlohmann::json result = nlohmann::json::object();
-	if (!writeLabels(result))
+	for (const auto& entry : labelArray)
 	{
-		return false;
-	}
-	return saveJSONToFile(result, filename);
-}
+		if (!entry.is_object()) { continue; }
+		LABEL p;
+		std::string label = entry.value("label", std::string());
+		std::string type = entry.value("type", std::string());
 
-// Write labels into an in-memory JSON object, keyed by incremental section names.
-bool scripting_engine::writeLabels(nlohmann::json &result)
-{
-	int c[5]; // make unique, incremental section names
-	memset(c, 0, sizeof(c));
+		// Sanity-check player/subscriber up-front (Absent keys default to ALL_PLAYERS, which is valid)
+		int entryPlayer = entry.value("player", ALL_PLAYERS);
+		int entrySubscriber = entry.value("subscriber", ALL_PLAYERS);
+		if (!isValidLabelPlayer(entryPlayer) || !isValidLabelPlayer(entrySubscriber))
+		{
+			debug(LOG_ERROR, "Invalid player/subscriber (%d/%d) for label '%s' - skipping", entryPlayer, entrySubscriber, label.c_str());
+			continue;
+		}
 
-	// Write a single label section:
-	// - 'owner' is the creating instance for an owned (script-created) label, or nullptr for a global (map-authored / legacy) label
-	// Owned labels are tagged with ownerPlayer/ownerScript so they round-trip back into the right bucket on load (savegames only)
-	auto writeOne = [&](const std::string& key, const LABEL& l, const wzapi::scripting_instance* owner)
-	{
-		nlohmann::json section = nlohmann::json::object();
-		std::string sectionName;
-		if (l.type == SCRIPT_POSITION)
+		if (target.count(label) > 0)
 		{
-			section["pos"] = nlohmann::json::array({ l.p1.x, l.p1.y });
-			section["label"] = key;
-			section["triggered"] = l.triggered;
-			sectionName = "position_" + std::to_string(c[0]++);
+			debug(LOG_ERROR, "Duplicate label found: %s", label.c_str());
 		}
-		else if (l.type == SCRIPT_AREA)
+		else if (type == "position")
 		{
-			section["pos1"] = nlohmann::json::array({ l.p1.x, l.p1.y });
-			section["pos2"] = nlohmann::json::array({ l.p2.x, l.p2.y });
-			section["label"] = key;
-			section["player"] = l.player;
-			section["triggered"] = l.triggered;
-			section["subscriber"] = l.subscriber;
-			sectionName = "area_" + std::to_string(c[1]++);
+			p.p1 = jsonVector2i(entry, "pos");
+			p.p2 = p.p1;
+			p.type = SCRIPT_POSITION;
+			p.player = ALL_PLAYERS;
+			p.id = -1;
+			p.triggered = entry.value("triggered", -1); // deactivated by default
+			p.subscriber = ALL_PLAYERS;
+			target[label] = p;
 		}
-		else if (l.type == SCRIPT_RADIUS)
+		else if (type == "area")
 		{
-			section["pos"] = nlohmann::json::array({ l.p1.x, l.p1.y });
-			section["radius"] = l.p2.x;
-			section["label"] = key;
-			section["player"] = l.player;
-			section["triggered"] = l.triggered;
-			section["subscriber"] = l.subscriber;
-			sectionName = "radius_" + std::to_string(c[2]++);
+			p.p1 = jsonVector2i(entry, "pos1");
+			p.p2 = jsonVector2i(entry, "pos2");
+			p.type = SCRIPT_AREA;
+			p.player = entryPlayer;
+			p.triggered = entry.value("triggered", 0); // activated by default
+			p.id = -1;
+			p.subscriber = entrySubscriber;
+			target[label] = p;
 		}
-		else if (l.type == SCRIPT_GROUP)
+		else if (type == "radius")
 		{
-			section["id"] = l.id; // Persist the group id so it round-trips
-			section["player"] = l.player;
-			section["triggered"] = l.triggered;
-			nlohmann::json members = nlohmann::json::array();
-			for (int val : l.idlist)
+			p.p1 = jsonVector2i(entry, "pos");
+			p.p2.x = entry.value("radius", 0);
+			p.p2.y = 0; // unused
+			p.type = SCRIPT_RADIUS;
+			p.player = entryPlayer;
+			p.triggered = entry.value("triggered", 0); // activated by default
+			p.subscriber = entrySubscriber;
+			p.id = -1;
+			target[label] = p;
+		}
+		else if (type == "object")
+		{
+			int objectType = entry.value("objectType", -1); // the OBJECT_TYPE
+			if (objectType < 0 || objectType >= OBJ_NUM_TYPES)
 			{
-				members.push_back(std::to_string(val));
+				debug(LOG_ERROR, "Invalid objectType %d for object label '%s' - skipping", objectType, label.c_str());
+				continue;
 			}
-			section["members"] = std::move(members);
-			section["label"] = key;
-			section["subscriber"] = l.subscriber;
-			sectionName = "group_" + std::to_string(c[3]++);
+			auto id = entry.value("id", 0);
+			ASSERT(id > 0, "Unexpected id %d for object label", id);
+			p.id = id; // already a runtime id - no map remapping for savegame labels
+			p.type = objectType;
+			p.player = entryPlayer;
+			p.triggered = entry.value("triggered", -1); // deactivated by default
+			p.subscriber = ALL_PLAYERS; // object labels do not carry a subscriber
+			if (IdToObject((OBJECT_TYPE)p.type, p.id, p.player) == nullptr)
+			{
+				debug(LOG_SAVEGAME, "Failed to find object that label references (probably destroyed before save): %s", label.c_str());
+			}
+			target[label] = p;
+		}
+		else if (type == "group")
+		{
+			// v2 always persists the group id (writeLabelMap), so the label matches the saved group memberships
+			auto idIt = entry.find("id");
+			ASSERT(idIt != entry.end() && idIt->is_number_integer(), "Group label '%s' missing persisted id", label.c_str());
+			p.id = (idIt != entry.end() && idIt->is_number_integer()) ? idIt->get<int>() : 0;
+			p.type = SCRIPT_GROUP;
+			p.player = entryPlayer;
+			// NOTE: No members to read - a group label's idlist is only a map-load seed for prepareLabels
+			// (which does not run for savegames), and the live membership is restored from the saved groups
+			p.triggered = entry.value("triggered", -1); // deactivated by default
+			p.subscriber = entrySubscriber;
+			target[label] = p;
 		}
 		else
 		{
-			section["id"] = l.id;
-			section["player"] = l.player;
-			section["type"] = l.type;
-			section["label"] = key;
-			section["triggered"] = l.triggered;
-			sectionName = "object_" + std::to_string(c[4]++);
+			debug(LOG_ERROR, "Unknown label type '%s' (label: %s)", type.c_str(), label.c_str());
 		}
-		if (owner)
-		{
-			section["ownerPlayer"] = owner->player();
-			section["ownerScript"] = owner->scriptName();
-		}
-		result[sectionName] = std::move(section);
-	};
-
-	// Global (map-authored / legacy) labels: no owner key
-	for (const auto& it : globalLabels)
-	{
-		writeOne(it.first, it.second, nullptr);
 	}
-	// Owned (script-created) labels: tagged with their creating instance
-	// (ownedLabels is not yet populated - addLabel does not assign owners yet - so the output is
-	// currently identical to before: global labels only, no owner keys)
-	for (const auto& bucket : ownedLabels)
+	return true;
+}
+
+// Serialize one bucket of labels into a JSON array (one object per label), each self-described by a
+// "type" field ("position" / "area" / "radius" / "group" / "object").
+// Ownership is conveyed by which bucket is serialized and where the caller places the array in the
+// v2 script state (top-level "labels" for globals, an instance's "labels" for its owned labels)
+bool scripting_engine::writeLabelMap(const LABELMAP& labels, nlohmann::json& result)
+{
+	for (const auto& it : labels)
 	{
-		const wzapi::scripting_instance* owner = bucket.first;
-		for (const auto& it : bucket.second)
+		const std::string& key = it.first;
+		const LABEL& l = it.second;
+		nlohmann::json entry = nlohmann::json::object();
+		entry["label"] = key;
+		if (l.type == SCRIPT_POSITION)
 		{
-			writeOne(it.first, it.second, owner);
+			entry["type"] = "position";
+			entry["pos"] = nlohmann::json::array({ l.p1.x, l.p1.y });
+			entry["triggered"] = l.triggered;
 		}
+		else if (l.type == SCRIPT_AREA)
+		{
+			entry["type"] = "area";
+			entry["pos1"] = nlohmann::json::array({ l.p1.x, l.p1.y });
+			entry["pos2"] = nlohmann::json::array({ l.p2.x, l.p2.y });
+			entry["player"] = l.player;
+			entry["triggered"] = l.triggered;
+			entry["subscriber"] = l.subscriber;
+		}
+		else if (l.type == SCRIPT_RADIUS)
+		{
+			entry["type"] = "radius";
+			entry["pos"] = nlohmann::json::array({ l.p1.x, l.p1.y });
+			entry["radius"] = l.p2.x;
+			entry["player"] = l.player;
+			entry["triggered"] = l.triggered;
+			entry["subscriber"] = l.subscriber;
+		}
+		else if (l.type == SCRIPT_GROUP)
+		{
+			entry["type"] = "group";
+			entry["id"] = l.id; // Persist the group id so it round-trips
+			entry["player"] = l.player;
+			entry["triggered"] = l.triggered;
+			entry["subscriber"] = l.subscriber;
+			// No members:
+			// 1. a group label's idlist is only a map-load seed, consumed (cleared) by prepareLabels
+			// 2. the live membership is persisted separately (saveGroups)
+			// So it must be empty here - assert to catch any future change that leaves stale seed data on a label
+			ASSERT(l.idlist.empty(), "Group label '%s' has %zu stale idlist member(s) at save time (expected prepareLabels to have consumed them)", key.c_str(), l.idlist.size());
+		}
+		else
+		{
+			// Object label: l.type is the OBJECT_TYPE (< OBJ_NUM_TYPES), stored as "objectType"
+			entry["type"] = "object";
+			entry["objectType"] = l.type;
+			entry["id"] = l.id;
+			entry["player"] = l.player;
+			entry["triggered"] = l.triggered;
+		}
+		result.push_back(std::move(entry));
 	}
 	return true;
 }
@@ -3251,7 +3345,7 @@ void scripting_engine::prepareLabels()
 	//
 	// idlist is a one-time seed: once its members are materialized into the per-instance group maps
 	// (which saveGroups persists), it is consumed (cleared). It would otherwise go stale (it never
-	// tracks units added/removed during play) and be redundantly re-serialized by writeLabels.
+	// tracks units added/removed during play) and be redundantly re-serialized by writeLabelMap.
 	for (LABELMAP::iterator i = globalLabels.begin(); i != globalLabels.end(); ++i)
 	{
 		LABEL &l = i->second;

--- a/src/qtscript.cpp
+++ b/src/qtscript.cpp
@@ -1342,7 +1342,8 @@ bool triggerEvent(SCRIPT_TRIGGER_TYPE trigger, BASE_OBJECT *psObj)
 
 	if ((trigger == TRIGGER_START_LEVEL || trigger == TRIGGER_GAME_LOADED) && !saveandquit_enabled().empty())
 	{
-		saveGame(saveandquit_enabled().c_str(), GTYPE_SAVE_START);
+		// --saveandquit produces a normal mid-mission save (which, unlike the old START path, also captures script state)
+		saveGame(saveandquit_enabled().c_str(), GTYPE_SAVE_MIDMISSION);
 		wzQuit(0);
 	}
 

--- a/src/qtscript.cpp
+++ b/src/qtscript.cpp
@@ -3243,30 +3243,36 @@ bool scripting_engine::unregisterFunctions(wzapi::scripting_instance *instance)
 // since all game state may not be fully loaded by then
 void scripting_engine::prepareLabels()
 {
-	// load the label group data into every scripting context, with the same negative group id
+	// Load the group-label seed data into every scripting context, with the same negative group id
 	//
 	// Only map-authored (global) group labels exist at this point - owned labels are created later
 	// via runtime addLabel - so iterating globalLabels is the full set (unchanged behavior)
-	for (ENGINEMAP::iterator iter = groups.begin(); iter != groups.end(); ++iter)
+	//
+	// idlist is a one-time seed: once its members are materialized into the per-instance group maps
+	// (which saveGroups persists), it is consumed (cleared). It would otherwise go stale (it never
+	// tracks units added/removed during play) and be redundantly re-serialized by writeLabels.
+	for (LABELMAP::iterator i = globalLabels.begin(); i != globalLabels.end(); ++i)
 	{
-		wzapi::scripting_instance *instance = iter->first;
-		for (LABELMAP::iterator i = globalLabels.begin(); i != globalLabels.end(); ++i)
+		LABEL &l = i->second;
+		if (l.type != SCRIPT_GROUP)
 		{
-			const LABEL &l = i->second;
-			if (l.type == SCRIPT_GROUP)
+			continue;
+		}
+		for (ENGINEMAP::iterator iter = groups.begin(); iter != groups.end(); ++iter)
+		{
+			wzapi::scripting_instance *instance = iter->first;
+			for (std::vector<int>::const_iterator j = l.idlist.begin(); j != l.idlist.end(); j++)
 			{
-				for (std::vector<int>::const_iterator j = l.idlist.begin(); j != l.idlist.end(); j++)
+				int id = (*j);
+				BASE_OBJECT *psObj = IdToPointer(id, l.player);
+				ASSERT(psObj, "Unit %d belonging to player %d not found", id, l.player);
+				if (psObj)
 				{
-					int id = (*j);
-					BASE_OBJECT *psObj = IdToPointer(id, l.player);
-					ASSERT(psObj, "Unit %d belonging to player %d not found", id, l.player);
-					if (psObj)
-					{
-						groupAddObject(psObj, l.id, instance);
-					}
+					groupAddObject(psObj, l.id, instance);
 				}
 			}
 		}
+		l.idlist.clear(); // consume the seed - the live membership now lives in the group maps
 	}
 	jsDebugUpdateLabels();
 }

--- a/src/qtscript.cpp
+++ b/src/qtscript.cpp
@@ -695,34 +695,60 @@ bool saveScriptStates(const char *filename)
 	return scripting_engine::instance().saveScriptStates(filename);
 }
 
+// Script-state save format version:
+// 1 (or absent): Legacy flat layout (globals_<i> / groups_<i> / triggers_<i> keys, matched back
+//                to instances by embedded "me"/"scriptName"), written via WzConfig
+// 2: A single structured JSON document with top-level "instances" and "timers" arrays
+//    Each instance bundles its own "globals", "groups" and per-instance flags
+//    (ex. "isReceivingAllEvents"). "timers" is an ordered array restored in-order.
+static const int SCRIPTSTATE_VERSION = 2;
+
 bool scripting_engine::saveScriptStates(const char *filename)
 {
-	WzConfig ini(filename, WzConfig::ReadAndWrite);
+	return saveScriptStates2(filename);
+}
+
+bool scripting_engine::saveScriptStates2(const char *filename)
+{
+	nlohmann::json root = nlohmann::json::object();
+	root["version"] = SCRIPTSTATE_VERSION;
+
+	// One object per script instance, bundling its globals, group memberships, and per-instance flags
+	nlohmann::json instancesArray = nlohmann::json::array();
 	for (int i = 0; i < scripts.size(); ++i)
 	{
 		wzapi::scripting_instance* instance = scripts.at(i);
 
+		nlohmann::json instanceObj = nlohmann::json::object();
+		// 'me'/'scriptName' identify the instance on load (findInstanceForPlayer)
+		instanceObj["me"] = instance->player();
+		instanceObj["scriptName"] = instance->scriptName();
+
 		nlohmann::json globalsResult = nlohmann::json::object();
 		instance->saveScriptGlobals(globalsResult);
-		// 'scriptName' and 'me' should be saved implicitly by the backend's saveScriptGlobals
+		// 'scriptName' and 'me' are also saved implicitly inside globals by the backend's saveScriptGlobals
 		ASSERT(globalsResult.contains("me"), "Missing required global \"me\"");
 		ASSERT(globalsResult.contains("scriptName"), "Missing required global \"scriptName\"");
-		ini.setValue("globals_" + WzString::number(i), globalsResult);
+		instanceObj["globals"] = std::move(globalsResult);
 
-		// we have to save 'scriptName' and 'me' explicitly
 		nlohmann::json groupsResult = nlohmann::json::object();
 		saveGroups(groupsResult, instance);
-		groupsResult["me"] = instance->player();
-		groupsResult["scriptName"] = instance->scriptName();
-		ini.setValue("groups_" + WzString::number(i), std::move(groupsResult));
+		instanceObj["groups"] = std::move(groupsResult);
+
+		instanceObj["isReceivingAllEvents"] = instance->isReceivingAllEvents();
+
+		instancesArray.push_back(std::move(instanceObj));
 	}
-	size_t timerIdx = 0;
+	root["instances"] = std::move(instancesArray);
+
+	// Timers as an ordered array - serialized (and thus restored) in the same order as the timers list
+	nlohmann::json timersArray = nlohmann::json::array();
 	for (const auto& node : timers)
 	{
 		nlohmann::json nodeInfo = nlohmann::json::object();
-		nodeInfo["timerID"] = node->timerID;
-		nodeInfo["timerName"] = node->timerName;
-		// we have to save 'scriptName' and 'me' explicitly
+		nodeInfo["id"] = node->timerID;
+		nodeInfo["name"] = node->timerName;
+		// 'me'/'scriptName' identify the owning instance on load
 		nodeInfo["me"] = node->player;
 		nodeInfo["scriptName"] = node->instance->scriptName();
 		nodeInfo["functionRestoreInfo"] = node->instance->saveTimerFunction(node->timerID, node->timerName, node->additionalTimerFuncParam.get());
@@ -736,10 +762,11 @@ bool scripting_engine::saveScriptStates(const char *filename)
 		nodeInfo["calls"] = node->calls;
 		nodeInfo["type"] = (int)node->type;
 
-		ini.setValue("triggers_" + WzString::number(timerIdx), std::move(nodeInfo));
-		++timerIdx;
+		timersArray.push_back(std::move(nodeInfo));
 	}
-	return true;
+	root["timers"] = std::move(timersArray);
+
+	return saveJSONToFile(root, filename);
 }
 
 wzapi::scripting_instance* scripting_engine::findInstanceForPlayer(int match, const WzString& _scriptName)
@@ -766,8 +793,16 @@ bool loadScriptStates(const char *filename)
 
 bool scripting_engine::loadScriptStates(const char *filename)
 {
-	uniqueTimerID maxRestoredTimerID = 0;
 	WzConfig ini(filename, WzConfig::ReadOnly);
+	const int version = ini.value("version", 1).toInt();
+	if (version >= 2)
+	{
+		debug(LOG_SAVE, "Loading script states (v%d) for %zu script contexts", version, scripts.size());
+		return loadScriptStates2(ini.currentJsonValue());
+	}
+
+	// ---- Legacy v1 loader (flat globals_<i> / groups_<i> / triggers_<i> layout) ----
+	uniqueTimerID maxRestoredTimerID = 0;
 	std::vector<WzString> list = ini.childGroups();
 	debug(LOG_SAVE, "Loading script states for %zu script contexts", scripts.size());
 	for (size_t i = 0; i < list.size(); ++i)
@@ -800,7 +835,8 @@ bool scripting_engine::loadScriptStates(const char *filename)
 			node->instance = instance;
 			debug(LOG_SAVE, "Registering trigger %zu for player %d, script %s",
 			      i, player, scriptName.toUtf8().c_str());
-			node->baseobj = ini.value("baseobj", -1).toInt();
+			// NOTE: the save side has always written this under the "object" key (never "baseobj")
+			node->baseobj = ini.value("object", -1).toInt();
 			node->baseobjtype = (OBJECT_TYPE)ini.value("objectType", (int)OBJ_NUM_TYPES).toInt();
 			node->frameTime = ini.value("frame").toInt();
 			node->ms = ini.value("ms").toInt();
@@ -886,6 +922,161 @@ bool scripting_engine::loadScriptStates(const char *filename)
 		}
 		ini.endGroup();
 	}
+	lastTimerID = maxRestoredTimerID;
+	return true;
+}
+
+// Loader for save format v2 (see SCRIPTSTATE_VERSION): a structured JSON document with top-level
+// "instances" and "triggers" arrays - 'root' is the parsed document object
+bool scripting_engine::loadScriptStates2(const nlohmann::json &root)
+{
+	uniqueTimerID maxRestoredTimerID = 0;
+
+	// Instances: per-instance globals + group memberships + flags
+	auto instancesIt = root.find("instances");
+	if (instancesIt != root.end() && instancesIt->is_array())
+	{
+		for (const auto& instanceObj : *instancesIt)
+		{
+			if (!instanceObj.is_object())
+			{
+				ASSERT(false, "Malformed instance entry in script states (not an object)");
+				continue;
+			}
+			int player = instanceObj.value("me", -1);
+			WzString scriptName = WzString::fromUtf8(instanceObj.value("scriptName", std::string()));
+			wzapi::scripting_instance* instance = findInstanceForPlayer(player, scriptName);
+			if (!instance)
+			{
+				continue;
+			}
+
+			// Globals
+			auto globalsIt = instanceObj.find("globals");
+			if (globalsIt != instanceObj.end() && globalsIt->is_object())
+			{
+				nlohmann::json globals = *globalsIt;
+				debug(LOG_SAVE, "Loading script globals for player %d, script %s -- found %zu values",
+				      instance->player(), instance->scriptName().c_str(), globals.size());
+				// filter out "scriptName" and "me" variables (saved implicitly inside globals)
+				globals.erase("me");
+				globals.erase("scriptName");
+				instance->loadScriptGlobals(globals);
+			}
+
+			// Group memberships: { "lastNewGroupId": <int>, "<droidId>": ["<groupId>", ...], ... }
+			auto groupsIt = instanceObj.find("groups");
+			if (groupsIt != instanceObj.end() && groupsIt->is_object())
+			{
+				for (auto it = groupsIt->begin(); it != groupsIt->end(); ++it)
+				{
+					if (it.key() == "lastNewGroupId" || !it->is_array())
+					{
+						continue;
+					}
+					bool ok = false; // check if the key is a (droid) id number
+					int droidId = WzString::fromUtf8(it.key()).toInt(&ok);
+					if (!ok)
+					{
+						continue;
+					}
+					for (const auto& groupIdVal : *it)
+					{
+						int groupId = 0;
+						if (groupIdVal.is_number_integer())
+						{
+							groupId = groupIdVal.get<int>();
+						}
+						else if (groupIdVal.is_string())
+						{
+							groupId = WzString::fromUtf8(groupIdVal.get<std::string>()).toInt();
+						}
+						else
+						{
+							continue;
+						}
+						loadGroup(instance, groupId, droidId);
+					}
+				}
+				auto lastNewIt = groupsIt->find("lastNewGroupId");
+				if (lastNewIt != groupsIt->end() && lastNewIt->is_number_integer())
+				{
+					GROUPMAP *psMap = getGroupMap(instance);
+					if (psMap)
+					{
+						psMap->saveLoadSetLastNewGroupId(lastNewIt->get<int>());
+					}
+				}
+			}
+
+			// Per-instance flags
+			auto recvIt = instanceObj.find("isReceivingAllEvents");
+			if (recvIt != instanceObj.end() && recvIt->is_boolean())
+			{
+				instance->setReceiveAllEvents(recvIt->get<bool>());
+			}
+		}
+	}
+
+	// Timers: ordered array of timer nodes, restored in-order
+	auto timersIt = root.find("timers");
+	if (timersIt != root.end() && timersIt->is_array())
+	{
+		for (const auto& nodeInfo : *timersIt)
+		{
+			if (!nodeInfo.is_object())
+			{
+				ASSERT(false, "Malformed timer entry in script states (not an object)");
+				continue;
+			}
+			int player = nodeInfo.value("me", -1);
+			WzString scriptName = WzString::fromUtf8(nodeInfo.value("scriptName", std::string()));
+			wzapi::scripting_instance* instance = findInstanceForPlayer(player, scriptName);
+			if (!instance)
+			{
+				continue;
+			}
+
+			std::shared_ptr<timerNode> node = std::make_shared<timerNode>();
+			node->timerID = nodeInfo.contains("id") ? nodeInfo["id"].get<int>() : getNextAvailableTimerID();
+			node->timerName = nodeInfo.value("name", std::string());
+			node->instance = instance;
+			debug(LOG_SAVE, "Registering timer for player %d, script %s",
+			      player, scriptName.toUtf8().c_str());
+			node->baseobj = nodeInfo.value("object", -1);
+			node->baseobjtype = (OBJECT_TYPE)nodeInfo.value("objectType", (int)OBJ_NUM_TYPES);
+			node->frameTime = nodeInfo.value("frame", 0);
+			node->ms = nodeInfo.value("ms", 0);
+			node->player = player;
+			node->calls = nodeInfo.value("calls", 0);
+			node->type = (timerType)nodeInfo.value("type", (int)TIMER_REPEAT);
+
+			std::tuple<TimerFunc, std::unique_ptr<timerAdditionalData>> restoredTimerInfo;
+			try
+			{
+				auto friIt = nodeInfo.find("functionRestoreInfo");
+				if (friIt == nodeInfo.end())
+				{
+					ASSERT(false, "Invalid trigger in save - missing functionRestoreInfo block");
+					continue;
+				}
+				restoredTimerInfo = instance->restoreTimerFunction(*friIt);
+			}
+			catch (const std::exception& e)
+			{
+				ASSERT(false, "Failed to restore saved timer function info: %s", e.what());
+				continue;
+			}
+
+			node->function = std::get<0>(restoredTimerInfo);
+			node->additionalTimerFuncParam = std::move(std::get<1>(restoredTimerInfo));
+
+			maxRestoredTimerID = std::max<uniqueTimerID>(maxRestoredTimerID, node->timerID);
+
+			addTimerNode(std::move(node));
+		}
+	}
+
 	lastTimerID = maxRestoredTimerID;
 	return true;
 }

--- a/src/qtscript.cpp
+++ b/src/qtscript.cpp
@@ -775,6 +775,9 @@ bool scripting_engine::saveScriptStates2(const char *filename)
 	}
 	root["timers"] = std::move(timersArray);
 
+	// Persist the monotonic timer-id counter
+	root["lastTimerID"] = lastTimerID;
+
 	// Global (map-authored / legacy / unowned) labels go at the top level
 	nlohmann::json globalLabelsArr = nlohmann::json::array();
 	writeLabelMap(globalLabels, globalLabelsArr);
@@ -944,8 +947,6 @@ bool scripting_engine::loadScriptStates(const char *filename)
 // "instances" and "triggers" arrays - 'root' is the parsed document object
 bool scripting_engine::loadScriptStates2(const nlohmann::json &root)
 {
-	uniqueTimerID maxRestoredTimerID = 0;
-
 	// Labels: a v2 save is the authoritative source, so clear and rebuild both buckets here
 	// - Global (map-authored / legacy / unowned) labels live at the top level
 	// - Each instance's owned labels are nested under it (loaded in the instance loop below)
@@ -1104,13 +1105,12 @@ bool scripting_engine::loadScriptStates2(const nlohmann::json &root)
 			node->function = std::get<0>(restoredTimerInfo);
 			node->additionalTimerFuncParam = std::move(std::get<1>(restoredTimerInfo));
 
-			maxRestoredTimerID = std::max<uniqueTimerID>(maxRestoredTimerID, node->timerID);
-
 			addTimerNode(std::move(node));
 		}
 	}
 
-	lastTimerID = maxRestoredTimerID;
+	// Restore the monotonic timer-id counter
+	lastTimerID = root.value("lastTimerID", static_cast<uniqueTimerID>(0));
 
 	return true;
 }

--- a/src/qtscript.cpp
+++ b/src/qtscript.cpp
@@ -2233,76 +2233,110 @@ bool loadLabels(const char *filename, const std::unordered_map<UDWORD, UDWORD>& 
 	return scripting_engine::instance().loadLabels(filename, fixedMapIdToGeneratedId, moduleToBuilding, UserSaveGame);
 }
 
-// Load labels
+bool loadLabels(const nlohmann::json &result, const std::unordered_map<UDWORD, UDWORD>& fixedMapIdToGeneratedId, std::array<std::unordered_map<UDWORD, UDWORD>, MAX_PLAYER_SLOTS>& moduleToBuilding, bool UserSaveGame)
+{
+	return scripting_engine::instance().loadLabels(result, fixedMapIdToGeneratedId, moduleToBuilding, UserSaveGame);
+}
+
+// Load labels from a file - reads the JSON document and delegates to the in-memory loader.
 bool scripting_engine::loadLabels(const char *filename, const std::unordered_map<UDWORD, UDWORD>& fixedMapIdToGeneratedId, std::array<std::unordered_map<UDWORD, UDWORD>, MAX_PLAYER_SLOTS>& moduleToBuilding, bool UserSaveGame)
 {
-	int groupidx = -1;
-
 	if (!PHYSFS_exists(filename))
 	{
 		debug(LOG_SAVE, "No %s found -- not adding any labels", filename);
 		return false;
 	}
 	WzConfig ini(filename, WzConfig::ReadOnly);
+	return loadLabels(ini.currentJsonValue(), fixedMapIdToGeneratedId, moduleToBuilding, UserSaveGame);
+}
+
+// Load labels from an in-memory JSON object. The object's keys are section names
+// ("position_<n>" / "area_<n>" / "radius_<n>" / "object_<n>" / "group_<n>"), matching writeLabels.
+bool scripting_engine::loadLabels(const nlohmann::json &result, const std::unordered_map<UDWORD, UDWORD>& fixedMapIdToGeneratedId, std::array<std::unordered_map<UDWORD, UDWORD>, MAX_PLAYER_SLOTS>& moduleToBuilding, bool UserSaveGame)
+{
+	int groupidx = -1;
+
+	ASSERT_OR_RETURN(false, result.is_object(), "Labels JSON is not an object");
 	labels.clear();
-	std::vector<WzString> list = ini.childGroups();
-	debug(LOG_SAVE, "Loading %zu labels... (fixedMapToGeneratedId.count = %zu)", list.size(), fixedMapIdToGeneratedId.size());
-	for (int i = 0; i < list.size(); ++i)
+	debug(LOG_SAVE, "Loading %zu labels... (fixedMapToGeneratedId.count = %zu)", result.size(), fixedMapIdToGeneratedId.size());
+
+	// matches WzConfig::vector2i: a [x, y] array, defaulting to (0, 0) if missing / malformed
+	auto jsonVector2i = [](const nlohmann::json &section, const char *key) -> Vector2i {
+		Vector2i r(0, 0);
+		auto it = section.find(key);
+		if (it == section.end() || !it->is_array() || it->size() != 2) { return r; }
+		try {
+			r.x = (*it)[0].get<int>();
+			r.y = (*it)[1].get<int>();
+		} catch (const std::exception &) { /* leave as (0, 0) */ }
+		return r;
+	};
+	auto startsWith = [](const std::string &s, const char *prefix) -> bool {
+		return s.rfind(prefix, 0) == 0;
+	};
+
+	// Iterate section objects (matches WzConfig::childGroups, which only returns object-valued keys)
+	for (auto it = result.begin(); it != result.end(); ++it)
 	{
-		ini.beginGroup(list[i]);
+		if (!it->is_object())
+		{
+			continue;
+		}
+		const std::string &sectionName = it.key();
+		const nlohmann::json &section = it.value();
 		LABEL p;
-		std::string label = ini.value("label").toWzString().toUtf8();
+		std::string label = section.value("label", std::string());
 		if (labels.count(label) > 0)
 		{
 			debug(LOG_ERROR, "Duplicate label found");
 		}
-		else if (list[i].startsWith("position"))
+		else if (startsWith(sectionName, "position"))
 		{
-			p.p1 = ini.vector2i("pos");
+			p.p1 = jsonVector2i(section, "pos");
 			p.p2 = p.p1;
 			p.type = SCRIPT_POSITION;
 			p.player = ALL_PLAYERS;
 			p.id = -1;
-			p.triggered = ini.value("triggered", -1).toInt(); // deactivated by default
+			p.triggered = section.value("triggered", -1); // deactivated by default
 			p.subscriber = ALL_PLAYERS;
 			labels[label] = p;
 		}
-		else if (list[i].startsWith("area"))
+		else if (startsWith(sectionName, "area"))
 		{
-			p.p1 = ini.vector2i("pos1");
-			p.p2 = ini.vector2i("pos2");
+			p.p1 = jsonVector2i(section, "pos1");
+			p.p2 = jsonVector2i(section, "pos2");
 			p.type = SCRIPT_AREA;
-			p.player = ini.value("player", ALL_PLAYERS).toInt();
-			p.triggered = ini.value("triggered", 0).toInt(); // activated by default
+			p.player = section.value("player", ALL_PLAYERS);
+			p.triggered = section.value("triggered", 0); // activated by default
 			p.id = -1;
-			p.subscriber = ini.value("subscriber", ALL_PLAYERS).toInt();
+			p.subscriber = section.value("subscriber", ALL_PLAYERS);
 			labels[label] = p;
 		}
-		else if (list[i].startsWith("radius"))
+		else if (startsWith(sectionName, "radius"))
 		{
-			p.p1 = ini.vector2i("pos");
-			p.p2.x = ini.value("radius").toInt();
+			p.p1 = jsonVector2i(section, "pos");
+			p.p2.x = section.value("radius", 0);
 			p.p2.y = 0; // unused
 			p.type = SCRIPT_RADIUS;
-			p.player = ini.value("player", ALL_PLAYERS).toInt();
-			p.triggered = ini.value("triggered", 0).toInt(); // activated by default
-			p.subscriber = ini.value("subscriber", ALL_PLAYERS).toInt();
+			p.player = section.value("player", ALL_PLAYERS);
+			p.triggered = section.value("triggered", 0); // activated by default
+			p.subscriber = section.value("subscriber", ALL_PLAYERS);
 			p.id = -1;
 			labels[label] = p;
 		}
-		else if (list[i].startsWith("object"))
+		else if (startsWith(sectionName, "object"))
 		{
-			auto id = ini.value("id").toInt();
+			auto id = section.value("id", 0);
 			ASSERT(id > 0, "Unexpected id %d for object label", id);
-			auto it = fixedMapIdToGeneratedId.find(static_cast<uint32_t>(id));
-			if (it != fixedMapIdToGeneratedId.end())
+			auto itr = fixedMapIdToGeneratedId.find(static_cast<uint32_t>(id));
+			if (itr != fixedMapIdToGeneratedId.end())
 			{
 				// replace fixed hard-coded map-load id with its new generated (synchronized) id
 				// note: must come *before* the moduleToBuilding call below
-				debug(LOG_MAP, "replaced fixed map id %d with %d", id, it->second);
-				id = it->second;
+				debug(LOG_MAP, "replaced fixed map id %d with %d", id, itr->second);
+				id = itr->second;
 			}
-			const auto player = ini.value("player").toInt();
+			const auto player = section.value("player", 0);
 			const auto it_modulemap = moduleToBuilding[player].find(id);
 			if (it_modulemap != moduleToBuilding[player].end())
 			{
@@ -2311,10 +2345,10 @@ bool scripting_engine::loadLabels(const char *filename, const std::unordered_map
 				id = it_modulemap->second;
 			}
 			p.id = id;
-			p.type = ini.value("type").toInt();
+			p.type = section.value("type", 0);
 			p.player = player;
-			p.triggered = ini.value("triggered", -1).toInt(); // deactivated by default
-			p.subscriber = ini.value("subscriber", ALL_PLAYERS).toInt();
+			p.triggered = section.value("triggered", -1); // deactivated by default
+			p.subscriber = section.value("subscriber", ALL_PLAYERS);
 			auto checkFoundObject = IdToObject((OBJECT_TYPE)p.type, p.id, p.player);
 			if (!UserSaveGame)
 			{
@@ -2326,37 +2360,41 @@ bool scripting_engine::loadLabels(const char *filename, const std::unordered_map
 			}
 			labels[label] = p;
 		}
-		else if (list[i].startsWith("group"))
+		else if (startsWith(sectionName, "group"))
 		{
 			p.id = groupidx--;
 			p.type = SCRIPT_GROUP;
-			p.player = ini.value("player").toInt();
-			std::vector<WzString> memberList = ini.value("members").toWzStringList();
-			for (WzString const &j : memberList)
+			p.player = section.value("player", 0);
+			auto membersIt = section.find("members");
+			if (membersIt != section.end() && membersIt->is_array())
 			{
-				int id = j.toInt();
-				ASSERT(id > 0, "Unexpected id %d for group member", id);
-				auto it = fixedMapIdToGeneratedId.find(static_cast<uint32_t>(id));
-				if (it != fixedMapIdToGeneratedId.end())
+				for (const auto &j : *membersIt)
 				{
-					// replace fixed hard-coded map-load id with its new generated (synchronized) id
-					debug(LOG_NEVER, "replaced fixed map id %d with %d", id, it->second);
-					id = it->second;
+					int id = 0;
+					if (j.is_string()) { id = WzString::fromUtf8(j.get<std::string>()).toInt(); }
+					else if (j.is_number_integer()) { id = j.get<int>(); }
+					ASSERT(id > 0, "Unexpected id %d for group member", id);
+					auto itr = fixedMapIdToGeneratedId.find(static_cast<uint32_t>(id));
+					if (itr != fixedMapIdToGeneratedId.end())
+					{
+						// replace fixed hard-coded map-load id with its new generated (synchronized) id
+						debug(LOG_NEVER, "replaced fixed map id %d with %d", id, itr->second);
+						id = itr->second;
+					}
+					BASE_OBJECT *psObj = IdToPointer(id, p.player);
+					ASSERT(psObj, "Unit %d belonging to player %d not found from label %s",
+					       id, p.player, sectionName.c_str());
+					p.idlist.push_back(id);
 				}
-				BASE_OBJECT *psObj = IdToPointer(id, p.player);
-				ASSERT(psObj, "Unit %d belonging to player %d not found from label %s",
-				       id, p.player, list[i].toUtf8().c_str());
-				p.idlist.push_back(id);
 			}
-			p.triggered = ini.value("triggered", -1).toInt(); // deactivated by default
-			p.subscriber = ini.value("subscriber", ALL_PLAYERS).toInt();
+			p.triggered = section.value("triggered", -1); // deactivated by default
+			p.subscriber = section.value("subscriber", ALL_PLAYERS);
 			labels[label] = p;
 		}
 		else
 		{
-			debug(LOG_ERROR, "Misnamed group in %s", filename);
+			debug(LOG_ERROR, "Misnamed group in labels (section: %s)", sectionName.c_str());
 		}
-		ini.endGroup();
 	}
 	return true;
 }
@@ -2366,72 +2404,85 @@ bool writeLabels(const char *filename)
 	return scripting_engine::instance().writeLabels(filename);
 }
 
+bool writeLabels(nlohmann::json &result)
+{
+	return scripting_engine::instance().writeLabels(result);
+}
+
+// Write labels to a file - builds the in-memory JSON document and saves it.
 bool scripting_engine::writeLabels(const char *filename)
+{
+	nlohmann::json result = nlohmann::json::object();
+	if (!writeLabels(result))
+	{
+		return false;
+	}
+	return saveJSONToFile(result, filename);
+}
+
+// Write labels into an in-memory JSON object, keyed by incremental section names.
+bool scripting_engine::writeLabels(nlohmann::json &result)
 {
 	int c[5]; // make unique, incremental section names
 	memset(c, 0, sizeof(c));
-	WzConfig ini(filename, WzConfig::ReadAndWrite);
 	for (LABELMAP::const_iterator i = labels.begin(); i != labels.end(); i++)
 	{
 		const std::string& key = i->first;
 		const LABEL &l = i->second;
 		if (l.type == SCRIPT_POSITION)
 		{
-			ini.beginGroup("position_" + WzString::number(c[0]++));
-			ini.setVector2i("pos", l.p1);
-			ini.setValue("label", WzString::fromUtf8(key));
-			ini.setValue("triggered", l.triggered);
-			ini.endGroup();
+			nlohmann::json section = nlohmann::json::object();
+			section["pos"] = nlohmann::json::array({ l.p1.x, l.p1.y });
+			section["label"] = key;
+			section["triggered"] = l.triggered;
+			result["position_" + std::to_string(c[0]++)] = std::move(section);
 		}
 		else if (l.type == SCRIPT_AREA)
 		{
-			ini.beginGroup("area_" + WzString::number(c[1]++));
-			ini.setVector2i("pos1", l.p1);
-			ini.setVector2i("pos2", l.p2);
-			ini.setValue("label", WzString::fromUtf8(key));
-			ini.setValue("player", l.player);
-			ini.setValue("triggered", l.triggered);
-			ini.setValue("subscriber", l.subscriber);
-			ini.endGroup();
+			nlohmann::json section = nlohmann::json::object();
+			section["pos1"] = nlohmann::json::array({ l.p1.x, l.p1.y });
+			section["pos2"] = nlohmann::json::array({ l.p2.x, l.p2.y });
+			section["label"] = key;
+			section["player"] = l.player;
+			section["triggered"] = l.triggered;
+			section["subscriber"] = l.subscriber;
+			result["area_" + std::to_string(c[1]++)] = std::move(section);
 		}
 		else if (l.type == SCRIPT_RADIUS)
 		{
-			ini.beginGroup("radius_" + WzString::number(c[2]++));
-			ini.setVector2i("pos", l.p1);
-			ini.setValue("radius", l.p2.x);
-			ini.setValue("label", WzString::fromUtf8(key));
-			ini.setValue("player", l.player);
-			ini.setValue("triggered", l.triggered);
-			ini.setValue("subscriber", l.subscriber);
-			ini.endGroup();
+			nlohmann::json section = nlohmann::json::object();
+			section["pos"] = nlohmann::json::array({ l.p1.x, l.p1.y });
+			section["radius"] = l.p2.x;
+			section["label"] = key;
+			section["player"] = l.player;
+			section["triggered"] = l.triggered;
+			section["subscriber"] = l.subscriber;
+			result["radius_" + std::to_string(c[2]++)] = std::move(section);
 		}
 		else if (l.type == SCRIPT_GROUP)
 		{
-			ini.beginGroup("group_" + WzString::number(c[3]++));
-			ini.setValue("player", l.player);
-			ini.setValue("triggered", l.triggered);
-			std::vector<WzString> list;
-			list.reserve(l.idlist.size());
+			nlohmann::json section = nlohmann::json::object();
+			section["player"] = l.player;
+			section["triggered"] = l.triggered;
+			nlohmann::json members = nlohmann::json::array();
 			for (int val : l.idlist)
 			{
-				list.push_back(WzString::number(val));
+				members.push_back(std::to_string(val));
 			}
-			ini.setValue("members", list);
-			ini.setValue("label", WzString::fromUtf8(key));
-			ini.setValue("subscriber", l.subscriber);
-			ini.endGroup();
+			section["members"] = std::move(members);
+			section["label"] = key;
+			section["subscriber"] = l.subscriber;
+			result["group_" + std::to_string(c[3]++)] = std::move(section);
 		}
 		else
 		{
-			auto id = l.id;
-			auto player = l.player;
-			ini.beginGroup("object_" + WzString::number(c[4]++));
-			ini.setValue("id", id);
-			ini.setValue("player", player);
-			ini.setValue("type", l.type);
-			ini.setValue("label", WzString::fromUtf8(key));
-			ini.setValue("triggered", l.triggered);
-			ini.endGroup();
+			nlohmann::json section = nlohmann::json::object();
+			section["id"] = l.id;
+			section["player"] = l.player;
+			section["type"] = l.type;
+			section["label"] = key;
+			section["triggered"] = l.triggered;
+			result["object_" + std::to_string(c[4]++)] = std::move(section);
 		}
 	}
 	return true;

--- a/src/qtscript.cpp
+++ b/src/qtscript.cpp
@@ -71,6 +71,7 @@
 #include <unordered_map>
 #include <sstream>
 #include <iomanip>
+#include <algorithm>
 #include <queue>
 #include <limits>
 
@@ -114,8 +115,13 @@ void scripting_engine::GROUPMAP::insertObjectIntoGroup(const BASE_OBJECT *psObj,
 	std::pair<ObjectToGroupMap::iterator,bool> result = m_map.insert(std::pair<const BASE_OBJECT *, scripting_engine::GROUPMAP::groupID>(psObj, groupId));
 	if (result.second)
 	{
-		auto groupSetResult = m_groups[groupId].insert(psObj);
-		ASSERT(groupSetResult.second, "Object already exists in group!");
+		// Keep the member list sorted by object id
+		// - The m_map insert above already guarantees psObj is not in any group, so this is always a new element
+		auto &groupSet = m_groups[groupId];
+		auto insertIt = std::lower_bound(groupSet.begin(), groupSet.end(), psObj,
+			[](const BASE_OBJECT *a, const BASE_OBJECT *b) { return a->id < b->id; });
+		ASSERT(insertIt == groupSet.end() || (*insertIt)->id != psObj->id, "Object already exists in group!");
+		groupSet.insert(insertIt, psObj);
 	}
 }
 
@@ -137,8 +143,15 @@ optional<scripting_engine::GROUPMAP::groupID> scripting_engine::GROUPMAP::remove
 		groupID groupId = it->second;
 		m_map.erase(it);
 
-		size_t numItemsErased = m_groups[groupId].erase(psObj);
-		ASSERT(numItemsErased == 1, "Object did not exist in group set??");
+		auto &groupSet = m_groups[groupId];
+		auto eraseIt = std::lower_bound(groupSet.begin(), groupSet.end(), psObj,
+			[](const BASE_OBJECT *a, const BASE_OBJECT *b) { return a->id < b->id; });
+		bool erased = (eraseIt != groupSet.end() && *eraseIt == psObj);
+		if (erased)
+		{
+			groupSet.erase(eraseIt);
+		}
+		ASSERT(erased, "Object did not exist in group set??");
 		return optional<groupID>(groupId);
 	}
 	return optional<groupID>();

--- a/src/qtscript.cpp
+++ b/src/qtscript.cpp
@@ -750,6 +750,10 @@ bool scripting_engine::saveScriptStates2(const char *filename)
 
 		instanceObj["isReceivingAllEvents"] = instance->isReceivingAllEvents();
 
+		// Math.random() PRNG state, so a resumed instance continues the identical sequence rather than
+		// re-seeding from wall-clock time (which would desync host-side AI decisions across a restore)
+		instanceObj["mathRandomState"] = instance->saveMathRandomState();
+
 		// This instance's owned (script-created) labels - (Omitted entirely when the instance has none)
 		auto ownedIt = ownedLabels.find(instance);
 		if (ownedIt != ownedLabels.end() && !ownedIt->second.empty())
@@ -1066,6 +1070,13 @@ bool scripting_engine::loadScriptStates2(const nlohmann::json &root)
 			if (recvIt != instanceObj.end() && recvIt->is_boolean())
 			{
 				instance->setReceiveAllEvents(recvIt->get<bool>());
+			}
+
+			// Math.random() PRNG state (see saveScriptStates2)
+			auto rngIt = instanceObj.find("mathRandomState");
+			if (rngIt != instanceObj.end() && rngIt->is_number())
+			{
+				instance->restoreMathRandomState(rngIt->get<uint64_t>());
 			}
 
 			// This instance's owned labels

--- a/src/qtscript.cpp
+++ b/src/qtscript.cpp
@@ -253,7 +253,12 @@ uniqueTimerID scripting_engine::setTimer(wzapi::scripting_instance *caller, cons
 // internal-only function that adds a Timer node (used for restoring saved games)
 void scripting_engine::addTimerNode(std::shared_ptr<scripting_engine::timerNode>&& node)
 {
-	ASSERT(timerIDMap.count(node->timerID) == 0, "Duplicate timerID found: %s", WzString::number(node->timerID).toUtf8().c_str());
+	if (timerIDMap.count(node->timerID) != 0)
+	{
+		// Skip a colliding id - should never happen for live timers
+		ASSERT(false, "Duplicate timerID found: %s", WzString::number(node->timerID).toUtf8().c_str());
+		return;
+	}
 	auto inserted_iter = timers.emplace(timers.end(), std::move(node));
 	timerIDMap[(*inserted_iter)->timerID] = inserted_iter;
 }
@@ -1092,8 +1097,16 @@ bool scripting_engine::loadScriptStates2(const nlohmann::json &root)
 	auto timersIt = root.find("timers");
 	if (timersIt != root.end() && timersIt->is_array())
 	{
+		// Bound the number of restored timers to something far above any real game
+		constexpr size_t MAX_RESTORED_TIMERS = 100000;
+		size_t restoredTimerCount = 0;
 		for (const auto& nodeInfo : *timersIt)
 		{
+			if (restoredTimerCount >= MAX_RESTORED_TIMERS)
+			{
+				debug(LOG_ERROR, "Too many timers in script state (> %zu); ignoring the rest", MAX_RESTORED_TIMERS);
+				break;
+			}
 			if (!nodeInfo.is_object())
 			{
 				ASSERT(false, "Malformed timer entry in script states (not an object)");
@@ -1117,6 +1130,11 @@ bool scripting_engine::loadScriptStates2(const nlohmann::json &root)
 			node->baseobjtype = (OBJECT_TYPE)nodeInfo.value("objectType", (int)OBJ_NUM_TYPES);
 			node->frameTime = nodeInfo.value("frame", 0);
 			node->ms = nodeInfo.value("ms", 0);
+			if (node->ms < 0)
+			{
+				debug(LOG_ERROR, "Skipping restore of timer with negative ms (%d)", node->ms);
+				continue;
+			}
 			node->player = player;
 			node->calls = nodeInfo.value("calls", 0);
 			node->type = (timerType)nodeInfo.value("type", (int)TIMER_REPEAT);
@@ -1142,6 +1160,7 @@ bool scripting_engine::loadScriptStates2(const nlohmann::json &root)
 			node->additionalTimerFuncParam = std::move(std::get<1>(restoredTimerInfo));
 
 			addTimerNode(std::move(node));
+			++restoredTimerCount;
 		}
 	}
 

--- a/src/qtscript.cpp
+++ b/src/qtscript.cpp
@@ -948,6 +948,16 @@ bool scripting_engine::loadScriptStates(const char *filename)
 // "instances" and "triggers" arrays - 'root' is the parsed document object
 bool scripting_engine::loadScriptStates2(const nlohmann::json &root)
 {
+	const int version = root.value("version", 1);
+	ASSERT_OR_RETURN(false, version >= 2, "Invalid version: %d", version);
+
+	if (version > SCRIPTSTATE_VERSION)
+	{
+		// script state version is newer than this version of WZ can support
+		debug(LOG_ERROR, "The scriptState version is newer than this version of WZ can support: %d", version);
+		return false;
+	}
+
 	// Labels: a v2 save is the authoritative source, so clear and rebuild both buckets here
 	// - Global (map-authored / legacy / unowned) labels live at the top level
 	// - Each instance's owned labels are nested under it (loaded in the instance loop below)

--- a/src/qtscript.h
+++ b/src/qtscript.h
@@ -25,6 +25,7 @@
 #include "random.h"
 #include "wzapi.h"
 #include <chrono>
+#include <functional>
 #include <memory>
 #include <unordered_set>
 #include <unordered_map>
@@ -286,7 +287,14 @@ public:
 	};
 private:
 	typedef std::map<std::string, LABEL> LABELMAP;
-	LABELMAP labels;
+	// Label scoping:
+	//
+	// - Map-authored and legacy labels live in the global bucket (visible to every instance)
+	// - Labels a script creates via addLabel are owned by their creating instance
+	// - Lookups for an instance resolve own-first, then global
+	// (ownedLabels is not yet populated - addLabel still targets the global bucket - so behavior is identical to the previous single map)
+	LABELMAP globalLabels;
+	std::map<wzapi::scripting_instance *, LABELMAP> ownedLabels;
 
 	typedef std::map<wzapi::scripting_instance *, GROUPMAP *> ENGINEMAP;
 	ENGINEMAP groups;
@@ -408,7 +416,7 @@ public:
 	generic_script_object getObjectFromLabel(WZAPI_PARAMS(const std::string& label));
 	wzapi::no_return_value hackMarkTiles_ByLabel(WZAPI_PARAMS(const std::string& label));
 private:
-	static optional<std::string> _findMatchingLabel(wzapi::game_object_identifier obj_id);
+	static optional<std::string> _findMatchingLabel(wzapi::scripting_instance *instance, wzapi::game_object_identifier obj_id);
 public:
 
 	static generic_script_object getObject(WZAPI_PARAMS(wzapi::object_request request));
@@ -491,6 +499,7 @@ public:
 		WzString trigger;
 		WzString owner;
 		WzString subscriber;
+		WzString scope; // owning script for an owned label, or "global"
 	};
 
 	class DebugInterface
@@ -530,6 +539,22 @@ private:
 	std::pair<bool, int> seenLabelCheck(wzapi::scripting_instance *instance, const BASE_OBJECT *seen, const BASE_OBJECT *viewer);
 	void removeFromGroup(wzapi::scripting_instance *instance, GROUPMAP *psMap, const BASE_OBJECT *psObj);
 	bool groupAddObject(const BASE_OBJECT *psObj, int groupId, wzapi::scripting_instance *instance);
+
+	// Label-scoping helpers: encode the own-first-then-global resolution in one place
+	// Find a label visible to `instance` (its own bucket first, then global), nullptr if none
+	LABEL* findScopedLabel(wzapi::scripting_instance *instance, const std::string &name);
+	// Erase a label visible to `instance` (own first, then global)
+	// Returns the number erased (0 or 1)
+	size_t eraseScopedLabel(wzapi::scripting_instance *instance, const std::string &name);
+	// The bucket a new label created by 'instance' is stored in (its own bucket, or global if no instance)
+	LABELMAP& labelCreationBucket(wzapi::scripting_instance *instance);
+	// Visit every label visible to 'instance' - its own labels, then global labels not shadowed by an
+	// own label of the same name (own-first / own-shadows-global)
+	//
+	// NOTES:
+	// - `fn` may mutate the LABEL
+	// - `fn` returns true to keep enumerating, false to stop early
+	void forEachScopedLabel(wzapi::scripting_instance *instance, const std::function<bool(const std::string&, LABEL&)>& fn);
 };
 
 /// Clear all map markers (used by label marking, for instance)

--- a/src/qtscript.h
+++ b/src/qtscript.h
@@ -224,10 +224,6 @@ public:
 bool loadLabels(const char *filename, const std::unordered_map<UDWORD, UDWORD>& fixedMapIdToGeneratedId, std::array<std::unordered_map<UDWORD, UDWORD>, MAX_PLAYER_SLOTS>& moduleToBuilding, bool UserSaveGame);
 bool loadLabels(const nlohmann::json &result, const std::unordered_map<UDWORD, UDWORD>& fixedMapIdToGeneratedId, std::array<std::unordered_map<UDWORD, UDWORD>, MAX_PLAYER_SLOTS>& moduleToBuilding, bool UserSaveGame);
 
-/// Write map labels to savegame (to a file, or into an in-memory JSON document)
-bool writeLabels(const char *filename);
-bool writeLabels(nlohmann::json &result);
-
 class scripting_engine
 {
 public:
@@ -332,15 +328,16 @@ public:
 
 // MARK: LABELS
 public:
-	/// Load map labels - from a file, or from an already-parsed in-memory JSON document.
-	/// The file variant reads the document and delegates to the JSON variant.
+	/// Loader A - flat labels.json (map/scenario data and old v1 savegames):
+	/// - Applies map->id remapping and UserSaveGame object-existence tolerance
+	/// - All labels are global
 	bool loadLabels(const char *filename, const std::unordered_map<UDWORD, UDWORD>& fixedMapIdToGeneratedId, std::array<std::unordered_map<UDWORD, UDWORD>, MAX_PLAYER_SLOTS>& moduleToBuilding, bool UserSaveGame);
 	bool loadLabels(const nlohmann::json &result, const std::unordered_map<UDWORD, UDWORD>& fixedMapIdToGeneratedId, std::array<std::unordered_map<UDWORD, UDWORD>, MAX_PLAYER_SLOTS>& moduleToBuilding, bool UserSaveGame);
 
-	/// Write map labels to savegame - to a file, or into an in-memory JSON document.
-	/// The file variant builds the document and saves it.
-	bool writeLabels(const char *filename);
-	bool writeLabels(nlohmann::json &result);
+	/// Loader B / writer for the script-state v2 embedded label format:
+	/// - A JSON array of label objects (each with a "type" field) for one ownership bucket
+	bool writeLabelMap(const LABELMAP& labels, nlohmann::json& result);
+	bool loadLabelMap(const nlohmann::json& labelArray, LABELMAP& target);
 
 // MARK: GROUPS
 public:

--- a/src/qtscript.h
+++ b/src/qtscript.h
@@ -219,11 +219,13 @@ public:
 	LABEL toNewLabel() const;
 };
 
-/// Load map labels
+/// Load map labels (from a file, or from an already-parsed in-memory JSON document)
 bool loadLabels(const char *filename, const std::unordered_map<UDWORD, UDWORD>& fixedMapIdToGeneratedId, std::array<std::unordered_map<UDWORD, UDWORD>, MAX_PLAYER_SLOTS>& moduleToBuilding, bool UserSaveGame);
+bool loadLabels(const nlohmann::json &result, const std::unordered_map<UDWORD, UDWORD>& fixedMapIdToGeneratedId, std::array<std::unordered_map<UDWORD, UDWORD>, MAX_PLAYER_SLOTS>& moduleToBuilding, bool UserSaveGame);
 
-/// Write map labels to savegame
+/// Write map labels to savegame (to a file, or into an in-memory JSON document)
 bool writeLabels(const char *filename);
+bool writeLabels(nlohmann::json &result);
 
 class scripting_engine
 {
@@ -322,11 +324,15 @@ public:
 
 // MARK: LABELS
 public:
-	/// Load map labels
+	/// Load map labels - from a file, or from an already-parsed in-memory JSON document.
+	/// The file variant reads the document and delegates to the JSON variant.
 	bool loadLabels(const char *filename, const std::unordered_map<UDWORD, UDWORD>& fixedMapIdToGeneratedId, std::array<std::unordered_map<UDWORD, UDWORD>, MAX_PLAYER_SLOTS>& moduleToBuilding, bool UserSaveGame);
+	bool loadLabels(const nlohmann::json &result, const std::unordered_map<UDWORD, UDWORD>& fixedMapIdToGeneratedId, std::array<std::unordered_map<UDWORD, UDWORD>, MAX_PLAYER_SLOTS>& moduleToBuilding, bool UserSaveGame);
 
-	/// Write map labels to savegame
+	/// Write map labels to savegame - to a file, or into an in-memory JSON document.
+	/// The file variant builds the document and saves it.
 	bool writeLabels(const char *filename);
+	bool writeLabels(nlohmann::json &result);
 
 // MARK: GROUPS
 public:

--- a/src/qtscript.h
+++ b/src/qtscript.h
@@ -311,6 +311,11 @@ public:
 	// but before triggering any events.
 	bool loadScriptStates(const char *filename);
 	bool saveScriptStates(const char *filename);
+private:
+	// Script-state save format v2: a single structured JSON document (top-level "instances" and "timers" arrays, etc)
+	bool saveScriptStates2(const char *filename);
+	bool loadScriptStates2(const nlohmann::json &root);
+public:
 
 	bool unregisterFunctions(wzapi::scripting_instance *instance);
 	void prepareLabels();

--- a/src/qtscript.h
+++ b/src/qtscript.h
@@ -233,7 +233,8 @@ public:
 		typedef std::unordered_map<const BASE_OBJECT *, groupID> ObjectToGroupMap;
 	private:
 		ObjectToGroupMap m_map;
-		typedef std::unordered_set<const BASE_OBJECT *> GroupSet;
+		// Members are kept sorted by object id so enumeration order is deterministic
+		typedef std::vector<const BASE_OBJECT *> GroupSet;
 		std::unordered_map<groupID, GroupSet> m_groups;
 		int lastNewGroupId = 0;
 	protected:

--- a/src/quickjs_backend.cpp
+++ b/src/quickjs_backend.cpp
@@ -213,6 +213,7 @@ static const char* WZ_JSON_TAG_OBJECT = "object";
 static const char* WZ_JSON_TAG_ARRAY  = "array";
 static const char* WZ_JSON_TAG_REF    = "ref";
 static const char* WZ_JSON_TAG_NUMBER = "number";   // a non-finite double (NaN / Infinity / -Infinity)
+static const char* WZ_JSON_TAG_UNDEF  = "undef";    // JS undefined (distinct from JSON null == JS null)
 static const char* WZ_JSON_ID_KEY     = "@@id";     // reference identity (int)
 static const char* WZ_JSON_CLASS_KEY  = "@@class";  // class name (string)
 static const char* WZ_JSON_DATA_KEY   = "@@data";   // own data properties (object) / elements (array)
@@ -470,7 +471,7 @@ private:
 public:
 	// save / restore state
 	virtual bool saveScriptGlobals(nlohmann::json &result) override;
-	virtual bool loadScriptGlobals(const nlohmann::json &result) override;
+	virtual bool loadScriptGlobals(const nlohmann::json &result, bool fixedNulls) override;
 
 	virtual nlohmann::json saveTimerFunction(uniqueTimerID timerID, std::string timerName, const timerAdditionalData* additionalParam) override;
 
@@ -998,9 +999,14 @@ struct JsonToJSContext
 {
 	JSContext* ctx;
 	std::unordered_map<int, JSValue> idMap; // reference id -> created object (owned)
+	// When true (save format version >= 2), the save distinguishes null from undefined:
+	// a bare JSON null maps to JS null, and the "undef" tag maps to JS undefined. When
+	// false (older saves, which stored undefined as null), JSON null maps to undefined.
+	bool fixedNulls = false;
 
-	JsonToJSContext(JSContext* ctx)
+	JsonToJSContext(JSContext* ctx, bool fixedNulls = false)
 	: ctx(ctx)
+	, fixedNulls(fixedNulls)
 	{ }
 
 	~JsonToJSContext()
@@ -1077,6 +1083,12 @@ JSValue mapJsonToQuickJSValueWithContext(JsonToJSContext& c, const nlohmann::jso
 				if (token == "Infinity") { dblVal = std::numeric_limits<double>::infinity(); }
 				else if (token == "-Infinity") { dblVal = -std::numeric_limits<double>::infinity(); }
 				return JS_NewFloat64(ctx, dblVal);
+			}
+
+			// JS undefined (a bare JSON null means JS null in this format - see fixedNulls)
+			if (tag == WZ_JSON_TAG_UNDEF)
+			{
+				return JS_UNDEFINED;
 			}
 
 			int id = -1;
@@ -1184,6 +1196,12 @@ JSValue mapJsonToQuickJSValueWithContext(JsonToJSContext& c, const nlohmann::jso
 			JS_DefinePropertyValueUint32(ctx, value, i, mapJsonToQuickJSValueWithContext(c, instance.at(i), prop_flags), prop_flags);
 		}
 		return value;
+	}
+	// In the version-2 format, a bare JSON null means JS null (undefined is tagged)
+	// Older saves stored undefined as null, so without fixedNulls a null still maps to undefined
+	if (instance.is_null())
+	{
+		return c.fixedNulls ? JS_NULL : JS_UNDEFINED;
 	}
 	// Scalars (and anything else) cannot carry tags - delegate to the plain mapper.
 	return mapJsonToQuickJSValue(ctx, instance, prop_flags);
@@ -3286,15 +3304,12 @@ bool quickjs_scripting_instance::saveScriptGlobals(nlohmann::json &result)
 	return true;
 }
 
-bool quickjs_scripting_instance::loadScriptGlobals(const nlohmann::json &result)
+bool quickjs_scripting_instance::loadScriptGlobals(const nlohmann::json &result, bool fixedNulls)
 {
 	ASSERT_OR_RETURN(false, result.is_object(), "Can't load script globals from non-json-object");
-	JsonToJSContext loadCtx(ctx);
+	JsonToJSContext loadCtx(ctx, fixedNulls);
 	for (auto it : result.items())
 	{
-		// IMPORTANT: "null" JSON values *MUST* map to JS_UNDEFINED.
-		//			  If they are set to JS_NULL, it causes issues for libcampaign.js. (As the values become "defined".)
-		//			  (mapJsonToQuickJSValue handles this properly.)
 		// NOTE: Properties created on the JS global object (as "global variables") should be non-configurable.
 		//		 However *their* properties should probably be C_W_E.
 		int ret = JS_DefinePropertyValueStr(ctx, global_obj, it.key().c_str(), mapJsonToQuickJSValueWithContext(loadCtx, it.value(), JS_PROP_C_W_E), JS_PROP_WRITABLE | JS_PROP_ENUMERABLE | JS_PROP_THROW);
@@ -4356,7 +4371,16 @@ nlohmann::json wz_qjs_to_json(JSToJsonContext &c, JSValue value)
 			return dblVal;
 		}
 		case JS_TAG_UNDEFINED:
-			return nlohmann::json(); // null value // ???
+			if (c.tag_class_instances)
+			{
+				// On the save path, distinguish undefined from null:
+				// - undefined is tagged, so a bare JSON null unambiguously means JS null
+				// - (Legacy/non-tag callers keep collapsing both to JSON null)
+				nlohmann::json undef = nlohmann::json::object();
+				undef[WZ_JSON_TAG_KEY] = WZ_JSON_TAG_UNDEF;
+				return undef;
+			}
+			return nlohmann::json(); // null value
 		case JS_TAG_STRING:
 		{
 			const char* pStr = JS_ToCString(c.ctx, value);

--- a/src/quickjs_backend.cpp
+++ b/src/quickjs_backend.cpp
@@ -1035,6 +1035,12 @@ struct JsonToJSContext
 // Returns JS_UNINITIALIZED if not resolvable.
 static JSValue resolveClassPrototype(JSContext* ctx, const std::string& className)
 {
+	// Mirror the save side (getSerializableClassName), which only serializes script-defined classes
+	// (and never a built-in constructor name)
+	if (className.empty() || isBuiltinConstructorName(className))
+	{
+		return JS_UNINITIALIZED;
+	}
 	JSValue ctor = resolveGlobalBindingByName(ctx, className);
 	if (!JS_IsConstructor(ctx, ctor))
 	{
@@ -1159,9 +1165,9 @@ JSValue mapJsonToQuickJSValueWithContext(JsonToJSContext& c, const nlohmann::jso
 				{
 					if (isArray && dataIt->is_array())
 					{
-						for (int i = 0; i < dataIt->size(); i++)
+						for (size_t i = 0; i < dataIt->size(); i++)
 						{
-							JS_DefinePropertyValueUint32(ctx, obj, i, mapJsonToQuickJSValueWithContext(c, dataIt->at(i), prop_flags), prop_flags);
+							JS_DefinePropertyValueUint32(ctx, obj, static_cast<uint32_t>(i), mapJsonToQuickJSValueWithContext(c, dataIt->at(i), prop_flags), prop_flags);
 						}
 					}
 					else if (!isArray && dataIt->is_object())
@@ -1194,9 +1200,9 @@ JSValue mapJsonToQuickJSValueWithContext(JsonToJSContext& c, const nlohmann::jso
 	{
 		// Legacy bare array.
 		JSValue value = JS_NewArray(ctx);
-		for (int i = 0; i < instance.size(); i++)
+		for (size_t i = 0; i < instance.size(); i++)
 		{
-			JS_DefinePropertyValueUint32(ctx, value, i, mapJsonToQuickJSValueWithContext(c, instance.at(i), prop_flags), prop_flags);
+			JS_DefinePropertyValueUint32(ctx, value, static_cast<uint32_t>(i), mapJsonToQuickJSValueWithContext(c, instance.at(i), prop_flags), prop_flags);
 		}
 		return value;
 	}
@@ -2974,6 +2980,7 @@ static JSValue js_setTimer(JSContext *ctx, JSValueConst this_val, int argc, JSVa
 	SCRIPT_ASSERT(ctx, JS_IsString(argv[0]), "Timer functions must be quoted");
 	std::string functionName = JSValueToStdString(ctx, argv[0]);
 	int32_t ms = JSValueToInt32(ctx, argv[1]);
+	SCRIPT_ASSERT(ctx, ms >= 0, "Timer delay must be non-negative");
 
 	JSValue global_obj = JS_GetGlobalObject(ctx);
 	auto free_global_obj = gsl::finally([ctx, global_obj] { JS_FreeValue(ctx, global_obj); });  // establish exit action
@@ -3313,9 +3320,39 @@ bool quickjs_scripting_instance::loadScriptGlobals(const nlohmann::json &result,
 	JsonToJSContext loadCtx(ctx, fixedNulls);
 	for (auto it : result.items())
 	{
+		const std::string &key = it.key();
+		// Mirror the saveScriptGlobals filter so restored data cannot clobber engine bindings or built-ins:
+		// skip internal-namespace names, and any existing global binding that is a function / constructor,
+		// an accessor, or a non-enumerable built-in (none of which a legitimate save holds)
+		bool skip = (internalNamespace.count(key) != 0);
+		if (!skip)
+		{
+			JSAtom atom = JS_NewAtom(ctx, key.c_str());
+			JSPropertyDescriptor desc;
+			int has = JS_GetOwnProperty(ctx, &desc, global_obj, atom);
+			JS_FreeAtom(ctx, atom);
+			if (has == 1)
+			{
+				// Overwritable only if it is currently an enumerable data property that is not callable
+				skip = JS_IsFunction(ctx, desc.value) || JS_IsConstructor(ctx, desc.value)
+					|| (desc.flags & (JS_PROP_GETSET | JS_PROP_ENUMERABLE)) != JS_PROP_ENUMERABLE;
+				JS_FreeValue(ctx, desc.value);
+				JS_FreeValue(ctx, desc.getter);
+				JS_FreeValue(ctx, desc.setter);
+			}
+			else if (has < 0)
+			{
+				skip = true; // error probing the property - be conservative
+			}
+		}
+		if (skip)
+		{
+			debug(LOG_ERROR, "[script: %s] Skipping restore of protected/internal global: \"%s\"", scriptName().c_str(), key.c_str());
+			continue;
+		}
 		// NOTE: Properties created on the JS global object (as "global variables") should be non-configurable.
 		//		 However *their* properties should probably be C_W_E.
-		int ret = JS_DefinePropertyValueStr(ctx, global_obj, it.key().c_str(), mapJsonToQuickJSValueWithContext(loadCtx, it.value(), JS_PROP_C_W_E), JS_PROP_WRITABLE | JS_PROP_ENUMERABLE | JS_PROP_THROW);
+		int ret = JS_DefinePropertyValueStr(ctx, global_obj, key.c_str(), mapJsonToQuickJSValueWithContext(loadCtx, it.value(), JS_PROP_C_W_E), JS_PROP_WRITABLE | JS_PROP_ENUMERABLE | JS_PROP_THROW);
 		if (ret != 1)
 		{
 			// Failed to load script global

--- a/src/quickjs_backend.cpp
+++ b/src/quickjs_backend.cpp
@@ -478,6 +478,9 @@ public:
 	// recreates timer functions (and additional userdata) based on the information saved by the saveTimerFunction() method
 	virtual std::tuple<TimerFunc, std::unique_ptr<timerAdditionalData>> restoreTimerFunction(const nlohmann::json& savedTimerFuncData) override;
 
+	virtual uint64_t saveMathRandomState() const override;
+	virtual void restoreMathRandomState(uint64_t state) override;
+
 public:
 	// get state for debugging
 	nlohmann::json debugGetAllScriptGlobals() override;
@@ -3329,6 +3332,16 @@ bool quickjs_scripting_instance::loadScriptGlobals(const nlohmann::json &result,
 		}
 	}
 	return true;
+}
+
+uint64_t quickjs_scripting_instance::saveMathRandomState() const
+{
+	return JS_GetRandomState(ctx);
+}
+
+void quickjs_scripting_instance::restoreMathRandomState(uint64_t state)
+{
+	JS_SetRandomState(ctx, state);
 }
 
 nlohmann::json quickjs_scripting_instance::saveTimerFunction(uniqueTimerID timerID, std::string timerName, const timerAdditionalData* additionalParam)

--- a/src/wzapi.h
+++ b/src/wzapi.h
@@ -631,7 +631,9 @@ namespace wzapi
 	public:
 		// save / restore state
 		virtual bool saveScriptGlobals(nlohmann::json &result) = 0;
-		virtual bool loadScriptGlobals(const nlohmann::json &result) = 0;
+		// fixedNulls: true if the save distinguishes JS null from undefined (save format
+		// version >= 2). When false (older saves), JSON null is mapped to JS undefined.
+		virtual bool loadScriptGlobals(const nlohmann::json &result, bool fixedNulls) = 0;
 
 		virtual nlohmann::json saveTimerFunction(uniqueTimerID timerID, std::string timerName, const timerAdditionalData* additionalParam) = 0;
 

--- a/src/wzapi.h
+++ b/src/wzapi.h
@@ -640,6 +640,12 @@ namespace wzapi
 		// recreates timer functions (and additional userdata) based on the information saved by the saveTimerFunction() method
 		virtual std::tuple<TimerFunc, std::unique_ptr<timerAdditionalData>> restoreTimerFunction(const nlohmann::json& savedTimerFuncData) = 0;
 
+		// save / restore the script engine's Math.random() PRNG state
+		// - Restoring it lets a resumed instance continue the identical Math.random() sequence instead of re-seeding from wall-clock
+		//   time at context creation (otherwise AI bots that call Math.random() diverge across a save/restore)
+		virtual uint64_t saveMathRandomState() const = 0;
+		virtual void restoreMathRandomState(uint64_t state) = 0;
+
 	public:
 		// get state for debugging
 		virtual nlohmann::json debugGetAllScriptGlobals() = 0;

--- a/src/wzscriptdebug.cpp
+++ b/src/wzscriptdebug.cpp
@@ -2387,12 +2387,14 @@ public:
 		auto triggerLabel = createColHeaderLabel("Trigger");
 		auto ownerLabel = createColHeaderLabel("Owner");
 		auto subscriberLabel = createColHeaderLabel("Subscriber");
+		auto scopeLabel = createColHeaderLabel("Scope");
 		std::vector<TableColumn> columns {
 			{labelLabel, TableColumn::ResizeBehavior::RESIZABLE},
 			{typeLabel, TableColumn::ResizeBehavior::RESIZABLE},
 			{triggerLabel, TableColumn::ResizeBehavior::RESIZABLE},
 			{ownerLabel, TableColumn::ResizeBehavior::RESIZABLE},
-			{subscriberLabel, TableColumn::ResizeBehavior::RESIZABLE}
+			{subscriberLabel, TableColumn::ResizeBehavior::RESIZABLE},
+			{scopeLabel, TableColumn::ResizeBehavior::RESIZABLE}
 		};
 		std::vector<size_t> minimumColumnWidths;
 		for (auto& column : columns)
@@ -2511,11 +2513,11 @@ private:
 	}
 	RowDataModel fillLabelsModel(const std::vector<scripting_engine::LabelInfo>& labels)
 	{
-		RowDataModel result(5);
+		RowDataModel result(6);
 		std::weak_ptr<WzScriptLabelsPanel> psWeakParent = std::dynamic_pointer_cast<WzScriptLabelsPanel>(shared_from_this());
 		for (const auto &label : labels)
 		{
-			std::vector<WzString> columnTexts = {label.label, label.type, label.trigger, label.owner, label.subscriber};
+			std::vector<WzString> columnTexts = {label.label, label.type, label.trigger, label.owner, label.subscriber, label.scope};
 			auto row = result.newRow(columnTexts, SCRIPTDEBUG_ROW_HEIGHT);
 			std::string labelStringCopy = label.label.toStdString();
 			row->addOnClickHandler([labelStringCopy, psWeakParent](W_BUTTON& button) {


### PR DESCRIPTION
Fixes numerous issues with script state round-tripping, including:

- `isReceivingAllEvents` wasn't persisted across saveload
- object timers did not round-trip (baseobj was lost)
- group labels didn't persist `id` across saveload, breaking `eventGroupSeen` after load
- `lastTimerId` wasn't persisted across save load
- JS `undefined` and `null` both serialized to JSON `null`, and restored to `undefined`, thus silently downgrading an actual JS `null` to `undefined` on saveload

There is also a major correctness change:
- Script-created labels (i.e. via `addLabel`) are now scoped exclusively to the creating instance, ensuring that different instances can't interfere or overwrite each others' labels
  - Nullbot, for example, explicitly has a workaround for the issue of script-created labels being global (cross-instance) state, including `me` in the label name: https://github.com/Warzone2100/warzone2100/blob/ec008f9af101931c1fbf29b625155d5c7926de59/data/mp/multiplay/skirmish/nb_includes/tactics.js#L158
  - Map/scenario-specified labels (and older savegame labels) are still globally-scoped. In particular, map/scenario-specified labels are used by the global / campaign scripts.

Additionally, this PR implements a new, cleaner v2 scriptstate json format, which integrates labels (which are runtime scripting state).

Existing (v1 scriptstate) saves should load as before. New saves will get these round-trip fixes.

---

This PR should remove the need for a lot of the `eventGameLoaded` workarounds that existing scripts have used (whether that's recreating labels / groups, calling `receiveAllEvents`, etc)