### PR TITLE
Fix possible desync due to mismatched terrain overrides handling

### DIFF
--- a/src/frontend.cpp
+++ b/src/frontend.cpp
@@ -82,7 +82,6 @@
 #include "titleui/gamebrowser.h"
 #include "urlhelpers.h"
 #include "game.h"
-#include "map.h" //for builtInMap and useTerrainOverrides
 #include "notifications.h"
 #include "activity.h"
 #include "hci/groups.h"
@@ -434,8 +433,6 @@ void SPinit(LEVEL_TYPE gameType)
 	}
 	setPlayerColour(0, playercolor);
 	game.hash.setZero();	// must reset this to zero
-	builtInMap = true;
-	useTerrainOverrides = true;
 }
 
 bool runSinglePlayerMenu()

--- a/src/levels.cpp
+++ b/src/levels.cpp
@@ -41,6 +41,7 @@
 #include "objects.h"
 #include "hci.h"
 #include "levels.h"
+#include "map.h"
 #include "mission.h"
 #include "levelint.h"
 #include "game.h"
@@ -1401,6 +1402,12 @@ LoadingTask<> levLoadDataTask(ResourceLoadingController &controller, LevLoadJobP
 	case LevDatasetResolveResult::Ok:
 		break;
 	}
+
+	// The map load consults these when loading terrain types (see mapLoadTertiles), so they must be set from
+	// the resolved level dataset on every path that loads a level, or a multiplayer desync could occur.
+	// (Loading a savegame may overwrite them with the values stored in the save file.)
+	builtInMap = (ctx.psNewLevel->realFileName == nullptr);
+	useTerrainOverrides = builtInMap && shouldLoadTerrainTypeOverrides(ctx.psNewLevel->pName);
 
 	co_await controller.yieldFrame();
 

--- a/src/multiint.cpp
+++ b/src/multiint.cpp
@@ -784,14 +784,10 @@ static void loadMapPreview(bool hideInterface, std::string mapName, const Sha256
 	}
 	if (psLevel->realFileName == nullptr)
 	{
-		builtInMap = true;
-		useTerrainOverrides = shouldLoadTerrainTypeOverrides(psLevel->pName);
-		debug(LOG_WZ, "Loading map preview: \"%s\" builtin t%d override %d", psLevel->pName.c_str(), psLevel->dataDir, (int)useTerrainOverrides);
+		debug(LOG_WZ, "Loading map preview: \"%s\" builtin t%d", psLevel->pName.c_str(), psLevel->dataDir);
 	}
 	else
 	{
-		builtInMap = false;
-		useTerrainOverrides = false;
 		debug(LOG_WZ, "Loading map preview: \"%s\" in (%s)\"%s\"  %s t%d", psLevel->pName.c_str(), WZ_PHYSFS_getRealDir_String(psLevel->realFileName).c_str(), psLevel->realFileName, psLevel->realFileHash.toString().c_str(), psLevel->dataDir);
 	}
 	rebuildSearchPath(psLevel->dataDir, false);
@@ -8131,10 +8127,6 @@ bool WZGameReplayOptionsHandler::restoreOptions(const nlohmann::json& object, Em
 		debug(LOG_POPUP, "Missing map used for replay: \"%s\" (hash: %s)", game.map, game.hash.toString().c_str());
 		return false;
 	}
-	// Must restore `useTerrainOverrides` (this matters for re-loading the map!) - see loadMapPreview() in multiint.cpp
-	builtInMap = (mapData->realFileName == nullptr);
-	useTerrainOverrides = builtInMap && shouldLoadTerrainTypeOverrides(mapData->pName);
-
 	for (Sha256 &hash : game.modHashes)
 	{
 		// TODO: Actually check the loaded mods??


### PR DESCRIPTION
`loadMapPreview()` was the only place in the normal MP flow that set `builtInMap` / `useTerrainOverrides`, as a side-effect of loading the map preview. However, these variables impact how terrain type overrides are loaded, and must be set across all host+clients consistently.

There were some conditions where `loadMapPreview()` could return early without setting these values (ex. a client connecting to a blind simple lobby), which could cause a discrepancy between how the host loaded the map's terrain type overrides and how clients loaded them, resulting in a desync near game start due to different blocking maps.

More robustly set `builtInMap` / `useTerrainOverrides` from the level dataset in `levLoadData()` itself, so every path that loads a level gets correct values. Remove the other (now-redundant) assignments elsewhere. Loading a savegame still overwrites them with the values stored in the save before the map itself is loaded.