### PR TITLE
Add collision avoidance behavior to transporters

### DIFF
--- a/src/steering/collision_avoidance_behavior.cpp
+++ b/src/steering/collision_avoidance_behavior.cpp
@@ -32,10 +32,12 @@
 
 #include "src/droid.h"
 #include "src/droiddef.h"
+#include "src/stats.h"
 #include "src/mapgrid.h"
 #include "src/map.h"
 #include "src/fpath.h"
 #include "src/move.h"
+#include "src/transporter.h"
 #include "src/objects.h"
 #include "src/game_world.h"
 
@@ -43,6 +45,18 @@
 
 namespace steering
 {
+
+static bool isAirPropulsion(const DROID* psDroid)
+{
+	return asPropulsionTypes[psDroid->getPropulsionStats()->propulsionType].travel == AIR;
+}
+
+// Whether droids can currently embark on / disembark from this transporter.
+static bool isBoardableTransporter(const DROID* psDroid)
+{
+	return psDroid->isTransporter()
+	       && (!psDroid->isFlightBasedTransporter() || !transporterFlying(psDroid));
+}
 
 SteeringForce CollisionAvoidanceBehavior::calculate(const SteeringContext& ctx)
 {
@@ -166,8 +180,8 @@ bool CollisionAvoidanceBehavior::isEnabled(const SteeringContext& ctx) const
 	{
 		return false;
 	}
-	// Transporters have their own movement logic
-	return !ctx.droid->isTransporter();
+	// Every droid steers; which obstacles matter is decided by isValidObstacle().
+	return true;
 }
 
 Vector2i CollisionAvoidanceBehavior::estimateObstacleVelocity(DROID* obstacle)
@@ -212,14 +226,14 @@ bool CollisionAvoidanceBehavior::isValidObstacle(const BASE_OBJECT* obj, const D
 		return false;
 	}
 
-	// VTOL droids only avoid each other and don't affect ground droids
-	if (ourDroid->isVtol() != obstacle->isVtol())
+	// A transporter that can currently be boarded must allow collision
+	if (isBoardableTransporter(ourDroid) || isBoardableTransporter(obstacle))
 	{
 		return false;
 	}
 
-	// Don't avoid transporters
-	if (obstacle->isTransporter())
+	// Air droids only avoid each other and don't affect ground droids
+	if (isAirPropulsion(ourDroid) != isAirPropulsion(obstacle))
 	{
 		return false;
 	}

--- a/src/steering/collision_avoidance_behavior.h
+++ b/src/steering/collision_avoidance_behavior.h
@@ -67,7 +67,7 @@ public:
 
 	const char* name() const override { return "CollisionAvoidance"; }
 
-	// Disabled for transporters (they have their own movement logic).
+	// Enabled for every droid; obstacle selection is left to isValidObstacle().
 	bool isEnabled(const SteeringContext& ctx) const override;
 
 private:


### PR DESCRIPTION
- Prevent transporters from merging together into a singularity
- VTOL and transporters also avoid each other now (previously ignored each other)
- ⚠️ Inherited problem: Large groups of transporters take a while to land now (same problem with VTOL)

# Before

Figure 1: Forty Super Transporters merged into a singularity
<img width="1366" height="768" alt="wz2100-20260718_221345-Sk-Rush" src="https://github.com/user-attachments/assets/d38644fb-adfe-457a-a21d-b7721a62ad78" />
Figure 2: Forty Super Transporters landed on the ground (it took only 5 seconds)
<img width="1366" height="768" alt="wz2100-20260718_233321-Sk-Rush" src="https://github.com/user-attachments/assets/14c80570-931a-4d88-b9e4-303352fc65b2" />

# After
Figure 3: Forty Super Transporters flying
<img width="1366" height="768" alt="wz2100-20260718_220637-Sk-Rush" src="https://github.com/user-attachments/assets/26fd0583-5367-4a71-bb58-cbebd708d171" />
Figure 4: Forty Super Transporters trying to land
<img width="1366" height="768" alt="wz2100-20260718_220805-Sk-Rush" src="https://github.com/user-attachments/assets/562fba54-c27e-4808-ba13-487f158d6a1f" />
Figure 5: Forty Super Transporters still trying to land
<img width="1366" height="768" alt="wz2100-20260718_220745-Sk-Rush" src="https://github.com/user-attachments/assets/5947c4cb-19c5-44fb-aac9-21c30c6e436f" />



---

# Future work

Consolidate the 2 helpers I made:
```cpp
static bool isAirPropulsion(const DROID* psDroid)
{
	return asPropulsionTypes[psDroid->getPropulsionStats()->propulsionType].travel == AIR;
}

// Whether droids can currently embark on / disembark from this transporter.
static bool isBoardableTransporter(const DROID* psDroid)
{
	return psDroid->isTransporter()
	       && (!psDroid->isFlightBasedTransporter() || !transporterFlying(psDroid));
}
```
with all the other identical occurrences throughout the codebase