### PR TITLE
gfx_api: vk: Fix swapchain lifecycle around screen-frame Begin/End

### DIFF
--- a/lib/framework/wzapp.h
+++ b/lib/framework/wzapp.h
@@ -94,6 +94,7 @@ bool wzIsSupportedWindowMode(WINDOW_MODE mode);
 WINDOW_MODE wzGetNextWindowMode(WINDOW_MODE currentMode);
 WINDOW_MODE wzAltEnterToggleFullscreen();
 bool wzChangeWindowMode(WINDOW_MODE mode, bool silent = false);
+void wzProcessPendingWindowChanges();
 WINDOW_MODE wzGetCurrentWindowMode();
 bool wzIsMaximized();
 bool wzIsFullscreen();

--- a/lib/ivis_opengl/CMakeLists.txt
+++ b/lib/ivis_opengl/CMakeLists.txt
@@ -40,6 +40,7 @@ file(GLOB HEADERS
 	"vk/render_pass_layout_cache.h"
 	"vk/screen_frame_coordinator.h"
 	"vk/swapchain_presentation_state.h"
+	"vk/wsi_platform_policy.h"
 	"vk/transfer_recorder.h"
 	"vk/transfer_recording_context.h"
 	"vk/warm_entry.h"
@@ -201,6 +202,7 @@ if(WZ_ENABLE_BACKEND_VULKAN)
 			"vk/render_pass_layout_cache.cpp"
 			"vk/screen_frame_coordinator.cpp"
 			"vk/swapchain_presentation_state.cpp"
+			"vk/wsi_platform_policy.cpp"
 			"vk/transfer_recorder.cpp")
 		CHECK_CXX_COMPILER_FLAG(-Wno-pedantic COMPILER_SUPPORTS_WNO_PEDANTIC)
 		if(COMPILER_SUPPORTS_WNO_PEDANTIC)
@@ -295,6 +297,7 @@ if (CMAKE_CXX_STANDARD GREATER_EQUAL 20)
 		"vk/render_pass_layout_cache.cpp"
 		"vk/screen_frame_coordinator.cpp"
 		"vk/swapchain_presentation_state.cpp"
+		"vk/wsi_platform_policy.cpp"
 		"vk/transfer_recorder.cpp")
 	set_source_files_properties(${cpp17_source_files} PROPERTIES COMPILE_FLAGS "-std=c++17")
 endif()

--- a/lib/ivis_opengl/gfx_api.h
+++ b/lib/ivis_opengl/gfx_api.h
@@ -413,25 +413,33 @@ namespace gfx_api
 		/// Screen-frame lifecycle (owned by piemode / main loop):
 		///
 		///   pie_ScreenFrameRenderBegin()
-		///     -> beginScreenFrame()           // per-frame flag reset; releaseAll() on FBO pool;
-		///                                     // Vulkan: open transfer (copy) command buffer
+		///     -> wzProcessPendingWindowChanges() // apply queued window mode / resize / display scale
+		///     -> reconcileSwapchainAtFrameOpen()  // Vulkan: recreate/surface-lost only; no acquire
+		///                                         // (before beginScreenFrame; !_screenFrameOpen)
+		///     -> beginScreenFrame()               // per-frame flag reset; releaseAll() on FBO pool;
+		///                                         // Vulkan: open transfer (copy) command buffer
 		///     -> consumeScreenGeometryDirty() -> screen_updateGeometry() when drawable changed
 		///     ... game logic, uploads (TransferRecorder records copy work on Vulkan) ...
 		///   pie_ScreenFrameRenderEnd()
 		///     ... when !headlessOrSkipDrawing() ...
-		///     -> prepareSwapchainForDrawing() // late swapchain acquire (Vulkan; no-op elsewhere)
-		///     -> CachedRenderGraph::ensureBuilt(snapshot)
-		///     -> CachedRenderGraph::execute() // RECORD only (executeCompiledRenderGraph)
-		///     -> finishScreenFrame()          // ALWAYS when gfx initialized: seal/submit/present,
-		///                                     // ring advance, frameNum++, purge FBO pool
+		///     -> acquireSwapchainForFrameDraw()   // Vulkan: acquire only; never recreate
+		///     -> CachedRenderGraph::ensureBuilt(snapshot) + execute() when canRecordSwapchainDraws()
+		///     -> finishScreenFrame()              // ALWAYS when gfx initialized: seal/submit/present,
+		///                                         // ring advance; WSI recovery deferred to next Begin
 		///
 		/// Upload paths record into the current frame's copy command buffer throughout the
 		/// screen frame. finishScreenFrame() must NOT be gated on graph execution or shouldDraw().
 		/// Must pair beginScreenFrame() with finishScreenFrame().
 		virtual void beginScreenFrame() = 0;
 		virtual void finishScreenFrame() = 0;
-		/// Acquire a swapchain image for draw recording when the drawable is in sync (Vulkan).
-		virtual void prepareSwapchainForDrawing() {}
+		/// Vulkan: recreate swapchain / recover surface at frame open when needed.
+		/// Must be called before beginScreenFrame() while no screen frame is open. Does not acquire.
+		virtual void reconcileSwapchainAtFrameOpen() {}
+		/// Vulkan: acquire a swapchain image immediately before render-graph record.
+		/// Must not destroy/recreate the swapchain (defer WSI errors to next Begin reconcile).
+		virtual void acquireSwapchainForFrameDraw() {}
+		/// True when swapchain image is acquired and safe to record swapchain-targeting passes (Vulkan).
+		virtual bool canRecordSwapchainDraws() const { return true; }
 		/// Mark UI/backdrop geometry stale after a drawable resize (called from backends).
 		/// Consumed at pie_ScreenFrameRenderBegin(); do not call screen_updateGeometry() directly on resize.
 		void markScreenGeometryDirty() { _screenGeometryDirty = true; }

--- a/lib/ivis_opengl/gfx_api_vk.cpp
+++ b/lib/ivis_opengl/gfx_api_vk.cpp
@@ -3751,6 +3751,7 @@ bool VkRoot::shouldDraw()
 
 void VkRoot::shutdown()
 {
+	_screenFrameOpen = false;
 	clearFramebufferCache();
 
 	destroySwapchainAndSwapchainSpecificStuff(true);
@@ -3902,7 +3903,6 @@ void VkRoot::finalizeActiveRecording()
 	frameHasDrawCommands = false;
 	currentPSO = nullptr;
 	currentRenderPassId = INVALID_RENDER_PASS_ID;
-	_screenFrameOpen = false;
 
 	frameResources.endDrawCmdBufferIfRecording();
 	frameResources.endCopyCmdBufferIfRecording();
@@ -4277,11 +4277,6 @@ gfx_api::context::swap_interval_mode VkRoot::getSwapInterval() const
 	return from_vk_presentmode(presentMode);
 }
 
-template <typename T>
-T clamp(const T& n, const T& lower, const T& upper) {
-	return std::max(lower, std::min(n, upper));
-}
-
 // throws a vk::SystemError on an unrecoverable error (like OOM)
 void VkRoot::createSwapchain(bool allowHandleSurfaceLost)
 {
@@ -4518,25 +4513,12 @@ void VkRoot::createSwapchain(bool allowHandleSurfaceLost)
 		throw;
 	}
 
-	try {
-		auto acquireNextResult = acquireNextSwapchainImage(allowHandleSurfaceLost, true);
-		switch (acquireNextResult)
-		{
-			case AcquireNextSwapchainImageResult::eSuccess:
-				// continue on with processing
-				break;
-			case AcquireNextSwapchainImageResult::eRecoveredFromError:
-				// acquireNextSwapchainImage recovered from an error - that means it succeeded at re-setting things up
-				// return immediately (this iteration is no longer responsible for creating the swapchain)
-				return;
-		}
+	// End acquireSwapchainForFrameDraw() owns the first image for this swapchain.
+	if (buffering_mechanism::isInitialized())
+	{
+		buffering_mechanism::get_current_resources().swapchainImageAcquired = false;
 	}
-	catch (const vk::SystemError& e) {
-		// acquireNextSwapchainImage failed, and couldn't recover
-		auto resultErr = static_cast<vk::Result>(e.code().value());
-		debug((resultErr == vk::Result::eSuboptimalKHR) ? LOG_3D : LOG_ERROR, "acquireNextSwapchainImage failed: %s", vk::to_string(resultErr).c_str());
-		throw;
-	}
+	currentSwapchainIndex = 0;
 
 	// create defaultTexture (2x2, all initialized to 0)
 	const size_t defaultTexture_width = 2;
@@ -5796,7 +5778,7 @@ void VkRoot::bind_pipeline(gfx_api::pipeline_state_object* pso, bool /*notexture
 }
 
 // throws a vk::SystemError on an unrecoverable error (like OOM)
-VkRoot::AcquireNextSwapchainImageResult VkRoot::acquireNextSwapchainImage(bool allowHandleSurfaceLost, bool onCreate)
+VkRoot::SwapchainAcquireStatus VkRoot::tryAcquireSwapchainImage()
 {
 	vk::ResultValue<uint32_t> acquireNextImageResult = vk::ResultValue<uint32_t>(vk::Result::eNotReady, 0);
 	try {
@@ -5804,34 +5786,13 @@ VkRoot::AcquireNextSwapchainImageResult VkRoot::acquireNextSwapchainImage(bool a
 	}
 	catch (const vk::OutOfDateKHRError&)
 	{
-		debug(LOG_3D, "vk::Device::acquireNextImageKHR: ErrorOutOfDateKHR - must recreate swapchain");
-		try {
-			createNewSwapchainAndSwapchainSpecificStuff(vk::Result::eErrorOutOfDateKHR); // throws on failure
-			return AcquireNextSwapchainImageResult::eRecoveredFromError;
-		}
-		catch (const vk::SystemError& e) {
-			auto resultErr = static_cast<vk::Result>(e.code().value());
-			debug(LOG_ERROR, "Failed to recreate out-of-date swapchain: %s: %s", vk::to_string(resultErr).c_str(), e.what());
-			throw;
-		}
+		debug(LOG_3D, "vk::Device::acquireNextImageKHR: ErrorOutOfDateKHR");
+		return SwapchainAcquireStatus::OutOfDate;
 	}
 	catch (const vk::SurfaceLostKHRError&)
 	{
-		debug(LOG_3D, "vk::Device::acquireNextImageKHR: ErrorSurfaceLostKHR - must recreate surface + swapchain");
-		// recreate surface + swapchain
-		if (allowHandleSurfaceLost)
-		{
-			try {
-				handleSurfaceLost();
-				return AcquireNextSwapchainImageResult::eRecoveredFromError;
-			}
-			catch (const vk::SystemError& e) {
-				auto resultErr = static_cast<vk::Result>(e.code().value());
-				debug(LOG_ERROR, "handleSurfaceLost failed: %s: %s", vk::to_string(resultErr).c_str(), e.what());
-				throw;
-			}
-		}
-		throw;
+		debug(LOG_3D, "vk::Device::acquireNextImageKHR: ErrorSurfaceLostKHR");
+		return SwapchainAcquireStatus::SurfaceLost;
 	}
 	catch (const vk::DeviceLostError& e)
 	{
@@ -5843,38 +5804,39 @@ VkRoot::AcquireNextSwapchainImageResult VkRoot::acquireNextSwapchainImage(bool a
 		debug(LOG_ERROR, "vk::Device::acquireNextImageKHR: unhandled error: %s", e.what());
 		throw;
 	}
+
 	if (acquireNextImageResult.result == vk::Result::eSuboptimalKHR)
 	{
-		debug(LOG_3D, "vk::Device::acquireNextImageKHR returned eSuboptimalKHR - should probably recreate swapchain (in the future)");
-		_screenFrameCoordinator.markDrawableSizeDirty();
-#ifdef WZ_OS_MAC
-		// Workaround MoltenVK issue: https://github.com/KhronosGroup/MoltenVK/issues/2542
-		if (!onCreate)
-		{
-			debug(LOG_INFO, "vk::Device::acquireNextImageKHR returned eSuboptimalKHR - immediately recreate");
-			try {
-				createNewSwapchainAndSwapchainSpecificStuff(vk::Result::eSuboptimalKHR); // throws on failure
-				return AcquireNextSwapchainImageResult::eRecoveredFromError;
-			}
-			catch (const vk::SystemError& e) {
-				auto resultErr = static_cast<vk::Result>(e.code().value());
-				debug((resultErr == vk::Result::eSuboptimalKHR) ? LOG_3D : LOG_ERROR, "Failed to recreate out-of-date swapchain: %s: %s", vk::to_string(resultErr).c_str(), e.what());
-				throw;
-			}
-		}
-		else
-		{
-			// Can't recreate (already attempting to), so throw eSuboptimalKHR as an exception,
-			// and rely on calling code to skip drawing until the swapchain can be properly recreated...
-			WZ_THROW_VK_RESULT_EXCEPTION(vk::Result::eSuboptimalKHR, "acquireNextImageKHR failed");
-		}
-#endif
+		debug(LOG_3D, "vk::Device::acquireNextImageKHR returned eSuboptimalKHR");
+		// Do not consume the image index - coordinator decides defer vs recreate+retry.
+		return SwapchainAcquireStatus::Suboptimal;
+	}
+
+	if (acquireNextImageResult.result != vk::Result::eSuccess)
+	{
+		debug(LOG_ERROR, "vk::Device::acquireNextImageKHR: unexpected result: %s",
+			vk::to_string(acquireNextImageResult.result).c_str());
+		WZ_THROW_VK_RESULT_EXCEPTION(acquireNextImageResult.result, "acquireNextImageKHR unexpected result");
 	}
 
 	currentSwapchainIndex = acquireNextImageResult.value;
 	buffering_mechanism::get_current_resources().swapchainImageAcquired = true;
 	_frameLayoutTracker.beginFrame();
-	return AcquireNextSwapchainImageResult::eSuccess;
+	return SwapchainAcquireStatus::Success;
+}
+
+void VkRoot::rebindOpenScreenFrameResources()
+{
+	ASSERT(_screenFrameOpen, "rebindOpenScreenFrameResources requires an open screen frame");
+	ASSERT(buffering_mechanism::isInitialized(), "rebindOpenScreenFrameResources: buffering not initialized");
+
+	auto& frameResources = buffering_mechanism::get_current_resources();
+	frameResources.transferWorkRecorded = false;
+	frameHasDrawCommands = false;
+	ASSERT(!hasActivePass, "Active pass at open-screen-frame rebind");
+
+	frameResources.ensureTransferRecordingBegun(vkDynLoader);
+	_framebufferCache.releaseAll();
 }
 
 gfx_api::abstract_texture* VkRoot::getPipelineSurface(gfx_api::PipelineSurfaceId id)
@@ -6295,7 +6257,7 @@ optional<std::pair<uint32_t, uint32_t>> VkRoot::getRenderTargetDimensions(gfx_ap
 	return nullopt;
 }
 
-bool VkRoot::recreateSwapchainAfterPresentError(const vk::Result& reason)
+bool VkRoot::recreateSwapchain(const vk::Result& reason)
 {
 	try {
 		createNewSwapchainAndSwapchainSpecificStuff(reason);
@@ -6461,8 +6423,10 @@ void VkRoot::sealAndSubmitTransferGraphics(ScreenFramePipelineState& state)
 	{
 		frameResources.sealTransferStream(vkDynLoader);
 
+		const bool drawSkippedButRecorded = state.hadDrawCmdBufferRecording && !state.submitDrawBuffer;
 		const bool ringSlotWillAdvance = state.submitDrawBuffer
-			|| (!state.mustSkipDrawing && !state.mustRecreateSwapchain);
+			|| (state.hasCopyWork && !drawSkippedButRecorded
+				&& !state.mustSkipDrawing && !state.swapchainRecreatePending);
 		if (ringSlotWillAdvance)
 		{
 			frameResources.flushMappedAllocators();
@@ -6529,9 +6493,19 @@ void VkRoot::beginScreenFrame()
 	_framebufferCache.releaseAll();
 }
 
-void VkRoot::prepareSwapchainForDrawing()
+void VkRoot::reconcileSwapchainAtFrameOpen()
 {
-	_screenFrameCoordinator.prepareSwapchainForDrawing();
+	_screenFrameCoordinator.reconcileSwapchainAtFrameOpen();
+}
+
+void VkRoot::acquireSwapchainForFrameDraw()
+{
+	_screenFrameCoordinator.acquireSwapchainForFrameDraw();
+}
+
+bool VkRoot::canRecordSwapchainDraws() const
+{
+	return _screenFrameCoordinator.canRecordSwapchainDraws();
 }
 
 void VkRoot::finishScreenFrame()

--- a/lib/ivis_opengl/gfx_api_vk.cpp
+++ b/lib/ivis_opengl/gfx_api_vk.cpp
@@ -1099,6 +1099,7 @@ void buffering_mechanism::swap(vk::Device dev, const WZ_vk::DispatchLoaderDynami
 	dev.resetCommandPool(buffering_mechanism::get_current_resources().pool, vk::CommandPoolResetFlagBits(), vkDynLoader);
 	buffering_mechanism::get_current_resources().drawCmdBufferBegun = false;
 	buffering_mechanism::get_current_resources().copyCmdBufferBegun = false;
+	buffering_mechanism::get_current_resources().transferWorkRecorded = false;
 	buffering_mechanism::get_current_resources().copyCmdBufferSubmittedSincePoolReset = false;
 	buffering_mechanism::get_current_resources().swapchainImageAcquired = false;
 
@@ -5861,7 +5862,6 @@ void VkRoot::rebindOpenScreenFrameResources()
 	ASSERT(buffering_mechanism::isInitialized(), "rebindOpenScreenFrameResources: buffering not initialized");
 
 	auto& frameResources = buffering_mechanism::get_current_resources();
-	frameResources.transferWorkRecorded = false;
 	frameHasDrawCommands = false;
 	ASSERT(!hasActivePass, "Active pass at open-screen-frame rebind");
 
@@ -6325,7 +6325,7 @@ gfx_api::vk::TransferRecorder VkRoot::transferRecorder() const
 {
 	return gfx_api::vk::TransferRecorder(
 		const_cast<perFrameResources_t&>(buffering_mechanism::get_current_resources()),
-		gfx_api::vk::TransferRecordingContext{ vkDynLoader, _screenFrameOpen });
+		gfx_api::vk::TransferRecordingContext{ vkDynLoader });
 }
 
 // MARK: perFrameResources_t screen-frame commit
@@ -6408,6 +6408,7 @@ void perFrameResources_t::submitCommandBuffers(const FrameQueueSubmitParams& sub
 		submit.graphicsQueue.submit(submitInfo, previousSubmission, submit.vkDynLoader);
 		state.submittedQueueWork = true;
 		copyCmdBufferSubmittedSincePoolReset = true;
+		transferWorkRecorded = false;
 		if (state.submitDrawBuffer)
 		{
 			swapchainImageAcquired = false;
@@ -6515,7 +6516,6 @@ void VkRoot::beginScreenFrame()
 	_screenFrameOpen = true;
 
 	auto& frameResources = buffering_mechanism::get_current_resources();
-	frameResources.transferWorkRecorded = false;
 	frameHasDrawCommands = false;
 	ASSERT(!hasActivePass, "Active pass at screen frame open");
 

--- a/lib/ivis_opengl/gfx_api_vk.cpp
+++ b/lib/ivis_opengl/gfx_api_vk.cpp
@@ -3910,6 +3910,35 @@ void VkRoot::finalizeActiveRecording()
 	frameResources.uniformBufferAllocator.unmapAutomappedMemory();
 }
 
+// Texture and buffer uploads are recorded into the current ring slot's copy command
+// buffer, with pixel data in that slot's staging allocator. Both are destroyed by
+// buffering_mechanism::destroy(), and uploads are never re-recorded, so discarding
+// them leaves images permanently in VK_IMAGE_LAYOUT_UNDEFINED. Submit them first.
+// The subsequent waitForAllIdle() guarantees completion before teardown.
+void VkRoot::submitPendingTransferWork()
+{
+	if (!buffering_mechanism::isInitialized() || !graphicsQueue)
+	{
+		return;
+	}
+
+	auto& frameResources = buffering_mechanism::get_current_resources();
+	if (!frameResources.copyCmdBufferBegun)
+	{
+		return;
+	}
+
+	frameResources.sealTransferStream(vkDynLoader);
+
+	const auto cmdBuffers = std::array<vk::CommandBuffer, 1> { frameResources.copyCmdBuffer() };
+	auto submitInfo = vk::SubmitInfo()
+		.setCommandBufferCount(static_cast<uint32_t>(cmdBuffers.size()))
+		.setPCommandBuffers(cmdBuffers.data());
+	graphicsQueue.submit(submitInfo, frameResources.previousSubmission, vkDynLoader);
+	frameResources.copyCmdBufferSubmittedSincePoolReset = true;
+	frameResources.transferWorkRecorded = false;
+}
+
 void VkRoot::destroySwapchainAndSwapchainSpecificStuff(bool doDestroySwapchain)
 {
 	if (!dev)
@@ -3918,6 +3947,7 @@ void VkRoot::destroySwapchainAndSwapchainSpecificStuff(bool doDestroySwapchain)
 		return;
 	}
 
+	submitPendingTransferWork();
 	finalizeActiveRecording();
 	waitForAllIdle();
 	destroyDynamicRenderPasses();

--- a/lib/ivis_opengl/gfx_api_vk.h
+++ b/lib/ivis_opengl/gfx_api_vk.h
@@ -961,6 +961,8 @@ private:
 
 	void handleSurfaceLost(); // Throws on failure
 	void waitForAllIdle(); // Throws on failure
+	/// Submit recorded-but-unsubmitted copy work so pending uploads survive buffering teardown.
+	void submitPendingTransferWork(); // Throws on failure
 	/// Close any in-progress command buffer / render pass recording before GPU teardown.
 	/// Does not clear _screenFrameOpen (owned by beginScreenFrame / finish / shutdown).
 	void finalizeActiveRecording();

--- a/lib/ivis_opengl/gfx_api_vk.h
+++ b/lib/ivis_opengl/gfx_api_vk.h
@@ -191,7 +191,10 @@ class ScreenFrameCoordinator;
 struct ScreenFramePipelineState
 {
 	bool mustSkipDrawing = false;
-	bool mustRecreateSwapchain = false;
+	/// Signal only - recreate is deferred to next Begin reconcile (except macOS present suboptimal).
+	bool swapchainRecreatePending = false;
+	/// Snapshot of ring-slot acquire before seal/submit clears swapchainImageAcquired.
+	bool acquiredSwapchainImage = false;
 	int drawableWidth = 0;
 	int drawableHeight = 0;
 
@@ -285,7 +288,7 @@ public:
 
 	bool drawCmdBufferBegun = false;
 	bool copyCmdBufferBegun = false;
-	/// True after acquireNextSwapchainImage() signals imageAcquireSemaphore for this slot.
+	/// True after tryAcquireSwapchainImage() signals imageAcquireSemaphore for this slot.
 	bool swapchainImageAcquired = false;
 	/// True when TransferRecorder recorded copy/barrier work this screen frame.
 	bool transferWorkRecorded = false;
@@ -884,6 +887,8 @@ private:
 	bool createLogicalDevice();
 	bool createAllocator();
 	void getQueues();
+	/// Create the swapchain and swapchain-specific resources.
+	/// Does not acquire an image; End acquireSwapchainForFrameDraw() owns acquire.
 	void createSwapchain(bool allowHandleSurfaceLost = true); // Throws on failure
 	void rebuildPipelinesIfNecessary();
 
@@ -918,7 +923,9 @@ public:
 	virtual void endPass(const gfx_api::CompiledPass* compiledPass = nullptr) override;
 	virtual void beginScreenFrame() override;
 	virtual void finishScreenFrame() override;
-	virtual void prepareSwapchainForDrawing() override;
+	virtual void reconcileSwapchainAtFrameOpen() override;
+	virtual void acquireSwapchainForFrameDraw() override;
+	virtual bool canRecordSwapchainDraws() const override;
 	/// True between beginScreenFrame() and finishScreenFrame().
 	bool isScreenFrameOpen() const { return _screenFrameOpen; }
 	/// Typed wrapper for per-frame GPU upload / copy command recording.
@@ -938,16 +945,24 @@ public:
 	virtual void set_polygon_offset(const float& offset, const float& slope) override;
 	virtual void set_depth_range(const float& min, const float& max) override;
 private:
-	enum AcquireNextSwapchainImageResult
+	enum class SwapchainAcquireStatus
 	{
-		eSuccess,
-		eRecoveredFromError
+		Success,      // eSuccess - image acquired
+		Suboptimal,   // eSuboptimalKHR - index returned by Vulkan, but not consumed here
+		OutOfDate,
+		SurfaceLost
 	};
-	AcquireNextSwapchainImageResult acquireNextSwapchainImage(bool allowHandleSurfaceLost, bool onCreate = false);
+	/// acquireNextImageKHR only. Never recreates, never sets pending WSI flags (coordinator owns that).
+	/// On Success: sets currentSwapchainIndex, swapchainImageAcquired, beginFrame().
+	/// On Suboptimal/OutOfDate/SurfaceLost: does not mark acquired (image abandoned until recreate).
+	SwapchainAcquireStatus tryAcquireSwapchainImage();
+	/// Re-attach an already-open screen frame to buffering after mid-frame swapchain recreate.
+	void rebindOpenScreenFrameResources();
 
 	void handleSurfaceLost(); // Throws on failure
 	void waitForAllIdle(); // Throws on failure
 	/// Close any in-progress command buffer / render pass recording before GPU teardown.
+	/// Does not clear _screenFrameOpen (owned by beginScreenFrame / finish / shutdown).
 	void finalizeActiveRecording();
 	void destroySwapchainAndSwapchainSpecificStuff(bool doDestroySwapchain);
 	void createNewSwapchainAndSwapchainSpecificStuff(const vk::Result& reason); // Throws on failure
@@ -998,7 +1013,7 @@ private:
 	std::string calculateFormattedRendererInfoString() const;
 	void set_uniforms_set(const size_t& set_idx, const void* buffer, size_t bufferSize);
 	const RenderPassDetails& currentRenderPass();
-	bool recreateSwapchainAfterPresentError(const vk::Result& reason);
+	bool recreateSwapchain(const vk::Result& reason);
 	void sealActivePassForFrameFinish();
 	void sealDrawCommandBufferForPresent();
 	void sealAndSubmitTransferGraphics(ScreenFramePipelineState& state);

--- a/lib/ivis_opengl/piemode.cpp
+++ b/lib/ivis_opengl/piemode.cpp
@@ -119,8 +119,11 @@ void pie_ScreenFrameRenderBegin()
 
 	pie_ResetInGame3DFrameContextForFrame();
 
+	wzProcessPendingWindowChanges();
+
 	if (gfx_api::context::isInitialized())
 	{
+		gfx_api::context::get().reconcileSwapchainAtFrameOpen();
 		gfx_api::context::get().beginScreenFrame();
 	}
 
@@ -141,15 +144,21 @@ void pie_ScreenFrameRenderEnd()
 	const gfx_api::IRenderTopologyQuery& query = gfx_api::getGameRenderTopologyQuery();
 	if (!query.headlessOrSkipDrawing())
 	{
+		bool drawSwapchain = true;
 		if (gfx_api::context::isInitialized())
 		{
-			gfx_api::context::get().prepareSwapchainForDrawing();
+			gfx_api::context::get().acquireSwapchainForFrameDraw();
+			drawSwapchain = gfx_api::context::get().canRecordSwapchainDraws();
 		}
-		const gfx_api::RenderTopologySnapshot snapshot = gfx_api::render_topology::snapshot(query);
-		gfx_api::CachedRenderGraph& graph = pie_GetCachedFrameRenderGraph();
-		graph.ensureBuilt(snapshot);
-		graph.execute();
-		screenDoDumpToDiskIfRequired();
+
+		if (drawSwapchain)
+		{
+			const gfx_api::RenderTopologySnapshot snapshot = gfx_api::render_topology::snapshot(query);
+			gfx_api::CachedRenderGraph& graph = pie_GetCachedFrameRenderGraph();
+			graph.ensureBuilt(snapshot);
+			graph.execute();
+			screenDoDumpToDiskIfRequired();
+		}
 	}
 
 	if (gfx_api::context::isInitialized())

--- a/lib/ivis_opengl/vk/render_pass_layout_cache.cpp
+++ b/lib/ivis_opengl/vk/render_pass_layout_cache.cpp
@@ -94,14 +94,45 @@ void appendCrossFrameIncomingDependencies(
 			::vk::AccessFlagBits::eColorAttachmentWrite));
 	}
 
-	// Cross-frame WAW on reused attachment writes (initialLayout is Undefined after Clear).
-	if (hasColor)
+	// Attachment reuse: prior-frame attachment writes and beginRP layout-transition
+	// writes -> this subpass's attachment Read|Write (covers Clear WAW and LOAD_OP_LOAD RAW,
+	// including Present->ColorAttachment on FrozenWorldOverlay). Destination scope comes from
+	// layoutConsumerSync so Load/blend stay aligned with explicit barriers and outgoing
+	// 0->EXTERNAL deps.
+	if (hasColor || hasDepth)
 	{
+		::vk::PipelineStageFlags dstStage {};
+		::vk::AccessFlags dstAccess {};
+		if (hasColor)
+		{
+			const gfx_api::vk::LayoutSync colorConsumer =
+				gfx_api::vk::layoutConsumerSync(::vk::ImageLayout::eColorAttachmentOptimal);
+			dstStage |= colorConsumer.stage;
+			dstAccess |= colorConsumer.access;
+		}
+		if (hasDepth)
+		{
+			const gfx_api::vk::LayoutSync depthConsumer =
+				gfx_api::vk::layoutConsumerSync(::vk::ImageLayout::eDepthStencilAttachmentOptimal);
+			dstStage |= depthConsumer.stage;
+			dstAccess |= depthConsumer.access;
+		}
+
+		::vk::PipelineStageFlags srcStage {};
+		::vk::AccessFlags srcAccess {};
+		if (hasColor)
+		{
+			srcStage |= ::vk::PipelineStageFlagBits::eColorAttachmentOutput;
+			srcAccess |= ::vk::AccessFlagBits::eColorAttachmentWrite;
+		}
+		if (hasDepth)
+		{
+			srcStage |= ::vk::PipelineStageFlagBits::eLateFragmentTests;
+			srcAccess |= ::vk::AccessFlagBits::eDepthStencilAttachmentWrite;
+		}
+
 		dependencies.push_back(crossFrameExternalToSubpass0(
-			::vk::PipelineStageFlagBits::eColorAttachmentOutput | ::vk::PipelineStageFlagBits::eLateFragmentTests,
-			::vk::PipelineStageFlagBits::eColorAttachmentOutput | ::vk::PipelineStageFlagBits::eEarlyFragmentTests,
-			::vk::AccessFlagBits::eColorAttachmentWrite | ::vk::AccessFlagBits::eDepthStencilAttachmentWrite,
-			::vk::AccessFlagBits::eColorAttachmentWrite | ::vk::AccessFlagBits::eDepthStencilAttachmentWrite | ::vk::AccessFlagBits::eDepthStencilAttachmentRead));
+			srcStage, dstStage, srcAccess, dstAccess));
 	}
 }
 
@@ -332,10 +363,9 @@ size_t RenderPassLayoutCache::getOrCreate(const PassLayoutKey& key)
 		addReadOnlyFinal(::vk::ImageLayout::eDepthStencilAttachmentOptimal, key.depthFinalLayout);
 	}
 
-	// Incoming consumer synchronization stays conservative (not table-derived). Reused render
-	// targets are Cleared each frame, so their initialLayout is Undefined and cannot express the
-	// cross-frame WAR/WAW hazard against the previous frame's access to the same image; these
-	// templates encode that worst-case prior access (prior sample and/or prior attachment write).
+	// Incoming EXTERNAL templates stay conservative for worst-case prior access (prior sample
+	// and/or prior attachment write). Attachment-reuse destination stage/access is table-derived
+	// via layoutConsumerSync so LOAD_OP_LOAD after a beginRP layout transition is covered.
 	std::vector<::vk::SubpassDependency> dependencies;
 	appendCrossFrameIncomingDependencies(key, dependencies);
 

--- a/lib/ivis_opengl/vk/screen_frame_coordinator.cpp
+++ b/lib/ivis_opengl/vk/screen_frame_coordinator.cpp
@@ -535,7 +535,6 @@ void ScreenFrameCoordinator::advanceRingBufferAfterSubmit(ScreenFramePipelineSta
 void ScreenFrameCoordinator::completeScreenFrameFinishTail()
 {
 	_root.frameNum = std::max<size_t>(_root.frameNum + 1, 1);
-	buffering_mechanism::get_current_resources().transferWorkRecorded = false;
 	_root.purgeFrameResources();
 	_root._screenFrameOpen = false;
 }

--- a/lib/ivis_opengl/vk/screen_frame_coordinator.cpp
+++ b/lib/ivis_opengl/vk/screen_frame_coordinator.cpp
@@ -197,6 +197,8 @@ void ScreenFrameCoordinator::acquireSwapchainForFrameDraw()
 				{
 					return;
 				}
+				// createSwapchain already synced the drawable, so next Begin needs no further recreate
+				_presentation.clearSwapchainRecreatePending();
 				_root.rebindOpenScreenFrameResources();
 				status = _root.tryAcquireSwapchainImage();
 				if (status == VkRoot::SwapchainAcquireStatus::Success)
@@ -466,7 +468,11 @@ void ScreenFrameCoordinator::presentAndAdvanceRing(ScreenFramePipelineState& sta
 		{
 		case SuboptimalPresentAction::RecreateInline:
 			debug(LOG_3D, "presentKHR returned eSuboptimalKHR (%d) - recreate swapchain", (int)presentResult);
-			_root.recreateSwapchain(presentResult);
+			if (_root.recreateSwapchain(presentResult))
+			{
+				// createSwapchain already synced the drawable, so next Begin needs no further recreate
+				_presentation.clearSwapchainRecreatePending();
+			}
 			state.shouldPresent = false;
 			state.submittedQueueWork = false;
 			state.ringSwapped = true;

--- a/lib/ivis_opengl/vk/screen_frame_coordinator.cpp
+++ b/lib/ivis_opengl/vk/screen_frame_coordinator.cpp
@@ -20,9 +20,18 @@
 */
 /** @file screen_frame_coordinator.cpp
  * Screen-frame finish path: commit inputs, present/acquire, ring advance, and frame epilogue.
+ *
+ * Screen-frame swapchain invariants (Vulkan):
+ *   Phase              | recreate          | acquire | present
+ *   Begin reconcile    | yes               | no      | no
+ *   End acquire        | no*               | yes     | no
+ *   finish present     | no*               | no      | yes
+ *   * macOS suboptimal acquire/present only, via WsiPlatformPolicy.
  */
 
 #include "screen_frame_coordinator.h"
+
+#include "wsi_platform_policy.h"
 
 #include "lib/framework/wzapp.h"
 #include "lib/ivis_opengl/gfx_api_vk.h"
@@ -44,16 +53,100 @@ void ScreenFrameCoordinator::markDrawableSizeDirty()
 	_root.markScreenGeometryDirty();
 }
 
-void ScreenFrameCoordinator::tryAcquireSwapchainImageForDrawing()
+void ScreenFrameCoordinator::requestSwapchainRecreate()
 {
-	if (!_root.shouldDraw())
+	_presentation.requestSwapchainRecreate();
+	_root.markScreenGeometryDirty();
+}
+
+void ScreenFrameCoordinator::requestSurfaceLostRecovery()
+{
+	_presentation.requestSurfaceLostRecovery();
+	_root.markScreenGeometryDirty();
+}
+
+void ScreenFrameCoordinator::reconcileSwapchainAtFrameOpen()
+{
+	_frameGate.reconcileOk = false;
+
+	if (!buffering_mechanism::isInitialized() || !_root.backend_impl)
+	{
+		return;
+	}
+
+	ASSERT(!_root._screenFrameOpen, "reconcileSwapchainAtFrameOpen while screen frame is open");
+
+	if (_presentation.surfaceLostPending())
+	{
+		try {
+			_root.handleSurfaceLost();
+			_presentation.clearSurfaceLostPending();
+			_presentation.clearSwapchainRecreatePending();
+		}
+		catch (const ::vk::SystemError& e)
+		{
+			auto resultErr = static_cast<::vk::Result>(e.code().value());
+			debug(LOG_ERROR, "reconcileSwapchainAtFrameOpen: handleSurfaceLost failed: %s: %s",
+				::vk::to_string(resultErr).c_str(), e.what());
+			return;
+		}
+	}
+
+	int drawableWidth = 0;
+	int drawableHeight = 0;
+	_root.backend_impl->getDrawableSize(&drawableWidth, &drawableHeight);
+
+	const bool drawableMismatch = _presentation.drawableRequiresSwapchainRecreate(drawableWidth, drawableHeight,
+		_root.swapchainSize, _root.swapchain);
+	const bool forceRecreate = _presentation.swapchainRecreatePending();
+
+	if (!drawableMismatch && !forceRecreate)
+	{
+		if (_presentation.drawableSizeDirty())
+		{
+			_presentation.syncDrawableSize(drawableWidth, drawableHeight);
+		}
+		_frameGate.reconcileOk = _root.shouldDraw();
+		return;
+	}
+
+	if (forceRecreate && !drawableMismatch)
+	{
+		debug(LOG_3D, "reconcileSwapchainAtFrameOpen: recreating swapchain (pending, drawable %d x %d, swapchain %d x %d)",
+			drawableWidth, drawableHeight, (int)_root.swapchainSize.width, (int)_root.swapchainSize.height);
+	}
+	else
+	{
+		debug(LOG_3D, "reconcileSwapchainAtFrameOpen: recreating swapchain (drawable %d x %d, swapchain %d x %d)",
+			drawableWidth, drawableHeight, (int)_root.swapchainSize.width, (int)_root.swapchainSize.height);
+	}
+
+	if (!_root.recreateSwapchain(::vk::Result::eErrorOutOfDateKHR))
+	{
+		return;
+	}
+
+	_presentation.syncDrawableSize(drawableWidth, drawableHeight);
+	_presentation.clearSwapchainRecreatePending();
+	// createSwapchain never acquires: End acquireSwapchainForFrameDraw() owns the image.
+	_frameGate.reconcileOk = _root.shouldDraw();
+}
+
+void ScreenFrameCoordinator::acquireSwapchainForFrameDraw()
+{
+	if (!buffering_mechanism::isInitialized() || !_root.backend_impl)
+	{
+		return;
+	}
+
+	if (!_frameGate.reconcileOk || !_root.shouldDraw())
 	{
 		return;
 	}
 
 	if (_presentation.drawableSizeDirty())
 	{
-		// Drawable size not synced with swapchain; finishFrame() handles recreate.
+		debug(LOG_3D, "acquireSwapchainForFrameDraw: drawable dirty mid-frame, skipping draw");
 		return;
 	}
 
@@ -63,49 +156,98 @@ void ScreenFrameCoordinator::tryAcquireSwapchainImageForDrawing()
 		return;
 	}
 
+	const auto deferWithPlaceholderExtents = [this](bool surfaceLost) {
+		if (surfaceLost)
+		{
+			requestSurfaceLostRecovery();
+		}
+		else
+		{
+			requestSwapchainRecreate();
+		}
+		_root.swapchainSize.width = 1;
+		_root.swapchainSize.height = 1;
+	};
+
 	try {
-		_root.acquireNextSwapchainImage(true);
+		auto status = _root.tryAcquireSwapchainImage();
+		switch (status)
+		{
+		case VkRoot::SwapchainAcquireStatus::Success:
+			return;
+
+		case VkRoot::SwapchainAcquireStatus::OutOfDate:
+			deferWithPlaceholderExtents(false);
+			return;
+
+		case VkRoot::SwapchainAcquireStatus::SurfaceLost:
+			deferWithPlaceholderExtents(true);
+			return;
+
+		case VkRoot::SwapchainAcquireStatus::Suboptimal:
+			requestSwapchainRecreate();
+			switch (WsiPlatformPolicy::suboptimalAcquireAction())
+			{
+			case SuboptimalAcquireAction::DeferToNextBegin:
+				return;
+
+			case SuboptimalAcquireAction::RecreateAndRetryOnce:
+				debug(LOG_INFO, "acquireSwapchainForFrameDraw: eSuboptimalKHR - immediately recreate");
+				if (!_root.recreateSwapchain(::vk::Result::eSuboptimalKHR))
+				{
+					return;
+				}
+				_root.rebindOpenScreenFrameResources();
+				status = _root.tryAcquireSwapchainImage();
+				if (status == VkRoot::SwapchainAcquireStatus::Success)
+				{
+					return;
+				}
+				if (status == VkRoot::SwapchainAcquireStatus::SurfaceLost)
+				{
+					requestSurfaceLostRecovery();
+				}
+				else
+				{
+					requestSwapchainRecreate();
+				}
+				if (status == VkRoot::SwapchainAcquireStatus::OutOfDate
+					|| status == VkRoot::SwapchainAcquireStatus::SurfaceLost)
+				{
+					_root.swapchainSize.width = 1;
+					_root.swapchainSize.height = 1;
+				}
+				return;
+			}
+			return;
+		}
 	}
 	catch (const ::vk::SystemError& e)
 	{
 		auto resultErr = static_cast<::vk::Result>(e.code().value());
-		const bool isRecoverableError =
-			resultErr == ::vk::Result::eSuboptimalKHR ||
-			resultErr == ::vk::Result::eErrorOutOfDateKHR ||
-			resultErr == ::vk::Result::eErrorSurfaceLostKHR;
-		debug(isRecoverableError ? LOG_3D : LOG_ERROR,
-			"tryAcquireSwapchainImageForDrawing failed: %s", ::vk::to_string(resultErr).c_str());
-		if (isRecoverableError)
-		{
-			_root.swapchainSize.width = 1;
-			_root.swapchainSize.height = 1;
-			markDrawableSizeDirty();
-		}
-		else
-		{
-			handleUnrecoverableError(resultErr);
-		}
+		debug(LOG_ERROR, "acquireSwapchainForFrameDraw failed: %s", ::vk::to_string(resultErr).c_str());
+		handleUnrecoverableError(resultErr);
 	}
 }
 
-void ScreenFrameCoordinator::prepareSwapchainForDrawing()
+bool ScreenFrameCoordinator::canRecordSwapchainDraws() const
 {
-	tryAcquireSwapchainImageForDrawing();
+	return _frameGate.reconcileOk
+		&& buffering_mechanism::isInitialized()
+		&& buffering_mechanism::get_current_resources().swapchainImageAcquired;
 }
 
 ScreenFramePipelineState ScreenFrameCoordinator::buildCommitInputs()
 {
 	ScreenFramePipelineState state;
-	state.mustSkipDrawing = !_root.shouldDraw();
-	state.mustRecreateSwapchain = false;
+	state.swapchainRecreatePending = false;
+	state.acquiredSwapchainImage = buffering_mechanism::isInitialized()
+		&& buffering_mechanism::get_current_resources().swapchainImageAcquired;
+	state.mustSkipDrawing = !_root.shouldDraw() || !state.acquiredSwapchainImage;
 
-	auto& frameResources = buffering_mechanism::get_current_resources();
-
-	// Steady state: drawable unchanged and swapchain image already acquired for this slot.
-	if (!_presentation.drawableSizeDirty() && frameResources.swapchainImageAcquired)
+	if (!buffering_mechanism::isInitialized() || !_root.backend_impl)
 	{
-		state.drawableWidth = _presentation.lastKnownDrawableWidth();
-		state.drawableHeight = _presentation.lastKnownDrawableHeight();
+		state.mustSkipDrawing = true;
 		return state;
 	}
 
@@ -114,11 +256,12 @@ ScreenFramePipelineState ScreenFrameCoordinator::buildCommitInputs()
 		_root.swapchainSize, _root.swapchain))
 	{
 		state.mustSkipDrawing = true;
-		debug(LOG_3D, "[1] Drawable size (%d x %d) does not match swapchainSize (%d x %d) - must re-create swapchain",
+		debug(LOG_3D, "[1] Drawable size (%d x %d) does not match swapchainSize (%d x %d) - defer recreate to next Begin",
 			state.drawableWidth, state.drawableHeight, (int)_root.swapchainSize.width, (int)_root.swapchainSize.height);
-		state.mustRecreateSwapchain = true;
+		state.swapchainRecreatePending = true;
+		requestSwapchainRecreate();
 	}
-	else
+	else if (_presentation.drawableSizeDirty())
 	{
 		_presentation.syncDrawableSize(state.drawableWidth, state.drawableHeight);
 	}
@@ -126,14 +269,48 @@ ScreenFramePipelineState ScreenFrameCoordinator::buildCommitInputs()
 	return state;
 }
 
+bool ScreenFrameCoordinator::shouldAdvanceRingAfterSubmit(const ScreenFramePipelineState& state)
+{
+	if (!state.submittedQueueWork || state.ringSwapped)
+	{
+		return false;
+	}
+
+	// Draw was recorded but not submitted - hold the ring slot (loading/resync path).
+	if (state.hadDrawCmdBufferRecording && !state.submitDrawBuffer)
+	{
+		return false;
+	}
+
+	// Successful present path advances the ring in presentAndAdvanceRing().
+	if (state.submitDrawBuffer)
+	{
+		return false;
+	}
+
+	// Copy-only upload with no draw recording may advance to chain on the slot fence.
+	if (state.hasCopyWork && !state.hadDrawCmdBufferRecording)
+	{
+		return !state.mustSkipDrawing && !state.swapchainRecreatePending;
+	}
+
+	return false;
+}
+
 void ScreenFrameCoordinator::logScreenFrameDrawSubmitSkip(const ScreenFramePipelineState& state) const
 {
-	const auto& frameResources = buffering_mechanism::get_current_resources();
-	if (!state.mustSkipDrawing && state.hadDrawCmdBufferRecording && !frameResources.swapchainImageAcquired)
+	// submitCommandBuffers clears swapchainImageAcquired after a successful draw submit -
+	// only diagnose actual skips; use the pre-submit snapshot for acquire state.
+	if (state.submitDrawBuffer || state.mustSkipDrawing)
 	{
-		debug(LOG_3D, "finishScreenFrame: skipping draw command buffer submit (swapchain image not acquired for current frame slot)");
+		return;
 	}
-	else if (!state.mustSkipDrawing && !state.hadDrawCmdBufferRecording)
+
+	if (state.hadDrawCmdBufferRecording && !state.acquiredSwapchainImage)
+	{
+		debug(LOG_ERROR, "finishScreenFrame: skipping draw command buffer submit (swapchain image not acquired for current frame slot)");
+	}
+	else if (!state.hadDrawCmdBufferRecording)
 	{
 		debug(LOG_ERROR, "finishScreenFrame: skipping draw command buffer submit (draw command buffer was not recording)");
 	}
@@ -144,30 +321,36 @@ void ScreenFrameCoordinator::handleSwapchainPostSubmit(ScreenFramePipelineState&
 	if (_root.queuedSwapModeChange.has_value())
 	{
 		_root.swapMode = _root.queuedSwapModeChange.value().newMode;
-		state.mustRecreateSwapchain = true;
+		requestSwapchainRecreate();
+		state.swapchainRecreatePending = true;
+		// Keep queuedSwapModeChange until Begin recreateSwapchain runs the completion handler.
+		// Present this frame if draw was already submitted - do not destroy the swapchain here.
 	}
 
-	if (state.mustRecreateSwapchain)
+	if (state.shouldPresent)
 	{
-		_root.recreateSwapchainAfterPresentError(::vk::Result::eErrorOutOfDateKHR);
-		state.submittedQueueWork = false;
-		state.ringSwapped = true;
+		presentAndAdvanceRing(state);
+		return;
 	}
-	else if (state.shouldPresent)
+
+	if (state.swapchainRecreatePending)
 	{
-		presentAndAcquireScreenFrame(state);
+		// Draw was skipped; recovery is next Begin. Hold ring if copy submitted.
+		if (state.submittedQueueWork)
+		{
+			state.ringSwapped = true;
+		}
+		return;
+	}
+
+	if (shouldAdvanceRingAfterSubmit(state))
+	{
+		advanceRingBufferAfterSubmit(state);
 	}
 	else if (state.submittedQueueWork)
 	{
-		if (!state.mustSkipDrawing && !state.mustRecreateSwapchain)
-		{
-			advanceRingBufferAfterSubmit(state);
-		}
-		else
-		{
-			// Copy-only while skipping draw (resize): keep the ring slot, chain on its fence.
-			state.ringSwapped = true;
-		}
+		// Copy-only while skipping draw (resize): keep the ring slot, chain on its fence.
+		state.ringSwapped = true;
 	}
 }
 
@@ -189,9 +372,10 @@ void ScreenFrameCoordinator::finishFrame()
 	{
 		handleSwapchainPostSubmit(state);
 	}
-	else if (state.mustRecreateSwapchain)
+	else if (state.swapchainRecreatePending)
 	{
-		_root.recreateSwapchainAfterPresentError(::vk::Result::eErrorOutOfDateKHR);
+		// Already requested via buildCommitInputs / presentation flags - next Begin reconciles.
+		state.ringSwapped = true;
 	}
 
 	if (!state.submitDrawBuffer && state.mustSkipDrawing)
@@ -199,11 +383,42 @@ void ScreenFrameCoordinator::finishFrame()
 		throttleSkippedDrawingFrame();
 	}
 
-	advanceRingBufferAfterSubmit(state);
+	if (shouldAdvanceRingAfterSubmit(state))
+	{
+#if defined(DEBUG)
+		ASSERT(!(state.submitDrawBuffer && state.ringSwapped),
+			"double ring buffer advance (present path already advanced)");
+#endif
+		advanceRingBufferAfterSubmit(state);
+	}
+
+#if defined(DEBUG)
+	// Acquire implies present this frame unless WSI recovery was requested or drawing is disabled.
+	ASSERT(!state.acquiredSwapchainImage
+		|| state.submitDrawBuffer
+		|| state.swapchainRecreatePending
+		|| !_root.shouldDraw(),
+		"swapchain acquired for draw but not submitted for present");
+#endif
+
 	completeScreenFrameFinishTail();
 }
 
-void ScreenFrameCoordinator::presentAndAcquireScreenFrame(ScreenFramePipelineState& state)
+void ScreenFrameCoordinator::deferSwapchainRecreate(ScreenFramePipelineState& state)
+{
+	requestSwapchainRecreate();
+	state.swapchainRecreatePending = true;
+}
+
+void ScreenFrameCoordinator::advanceRingIfSubmittedDraw(ScreenFramePipelineState& state)
+{
+	if (state.submittedQueueWork && state.submitDrawBuffer)
+	{
+		advanceRingBufferAfterSubmit(state);
+	}
+}
+
+void ScreenFrameCoordinator::presentAndAdvanceRing(ScreenFramePipelineState& state)
 {
 	auto presentInfo = ::vk::PresentInfoKHR()
 		.setPSwapchains(&_root.swapchain)
@@ -212,29 +427,23 @@ void ScreenFrameCoordinator::presentAndAcquireScreenFrame(ScreenFramePipelineSta
 		.setWaitSemaphoreCount(1)
 		.setPWaitSemaphores(&buffering_mechanism::get_swapchain_resources(_root.currentSwapchainIndex).renderFinishedSemaphore);
 
-	::vk::Result presentResult;
+	::vk::Result presentResult = ::vk::Result::eSuccess;
 	try {
 		presentResult = _root.presentQueue.presentKHR(presentInfo, _root.vkDynLoader);
 	}
 	catch (const ::vk::OutOfDateKHRError&)
 	{
-		debug(LOG_3D, "::vk::Queue::presentKHR: ErrorOutOfDateKHR - must recreate swapchain");
+		debug(LOG_3D, "::vk::Queue::presentKHR: ErrorOutOfDateKHR - defer recreate to next frame Begin");
 		presentResult = ::vk::Result::eErrorOutOfDateKHR;
-		state.mustRecreateSwapchain = true;
-		markDrawableSizeDirty();
 	}
 	catch (const ::vk::SurfaceLostKHRError&)
 	{
-		debug(LOG_3D, "::vk::Queue::presentKHR: ErrorSurfaceLostKHR - must recreate surface + swapchain");
-		try {
-			_root.handleSurfaceLost();
-		}
-		catch (const ::vk::SystemError& e) {
-			auto resultErr = static_cast<::vk::Result>(e.code().value());
-			debug(LOG_ERROR, "handleSurfaceLost failed: %s: %s", ::vk::to_string(resultErr).c_str(), e.what());
-			handleUnrecoverableError(resultErr);
-		}
+		debug(LOG_3D, "::vk::Queue::presentKHR: ErrorSurfaceLostKHR - defer surface recovery to next frame Begin");
+		requestSurfaceLostRecovery();
+		state.swapchainRecreatePending = true;
 		state.shouldPresent = false;
+		// Submit already signaled renderFinished; present attempted the wait - advance ring.
+		advanceRingIfSubmittedDraw(state);
 		return;
 	}
 	catch (const ::vk::SystemError& e)
@@ -243,64 +452,35 @@ void ScreenFrameCoordinator::presentAndAcquireScreenFrame(ScreenFramePipelineSta
 		handleUnrecoverableError(static_cast<::vk::Result>(e.code().value()));
 	}
 
-	if (presentResult == ::vk::Result::eSuboptimalKHR)
+	if (presentResult == ::vk::Result::eErrorOutOfDateKHR)
 	{
-		debug(LOG_3D, "presentKHR returned eSuboptimalKHR (%d) - recreate swapchain", (int)presentResult);
-		state.mustRecreateSwapchain = true;
-		markDrawableSizeDirty();
-	}
-
-	if (state.mustRecreateSwapchain)
-	{
-		_root.recreateSwapchainAfterPresentError(presentResult);
-		state.shouldPresent = false;
+		deferSwapchainRecreate(state);
+		advanceRingIfSubmittedDraw(state);
 		return;
 	}
 
-	if (state.submittedQueueWork)
+	if (presentResult == ::vk::Result::eSuboptimalKHR)
 	{
-		advanceRingBufferAfterSubmit(state);
-	}
-
-	try {
-		if (_root.acquireNextSwapchainImage(true) != VkRoot::AcquireNextSwapchainImageResult::eSuccess)
+		requestSwapchainRecreate();
+		switch (WsiPlatformPolicy::suboptimalPresentAction())
 		{
+		case SuboptimalPresentAction::RecreateInline:
+			debug(LOG_3D, "presentKHR returned eSuboptimalKHR (%d) - recreate swapchain", (int)presentResult);
+			_root.recreateSwapchain(presentResult);
+			state.shouldPresent = false;
+			state.submittedQueueWork = false;
+			state.ringSwapped = true;
+			return;
+		case SuboptimalPresentAction::DeferToNextBegin:
+			debug(LOG_3D, "presentKHR returned eSuboptimalKHR (%d) - defer swapchain recreate to next frame Begin", (int)presentResult);
+			state.swapchainRecreatePending = true;
+			advanceRingIfSubmittedDraw(state);
 			return;
 		}
 	}
-	catch (const ::vk::SystemError& e) {
-		auto resultErr = static_cast<::vk::Result>(e.code().value());
-		debug((resultErr == ::vk::Result::eSuboptimalKHR) ? LOG_3D : LOG_ERROR, "acquireNextSwapchainImage failed: %s", ::vk::to_string(resultErr).c_str());
-		if (resultErr == ::vk::Result::eSuboptimalKHR)
-		{
-			_root.swapchainSize.width = 1;
-			_root.swapchainSize.height = 1;
-			markDrawableSizeDirty();
-		}
-		else
-		{
-			handleUnrecoverableError(resultErr);
-		}
-		return;
-	}
 
-	if (!_presentation.drawableSizeDirty())
-	{
-		return;
-	}
-
-	int w, h;
-	_root.backend_impl->getDrawableSize(&w, &h);
-	if (_presentation.drawableRequiresSwapchainRecreate(w, h, _root.swapchainSize, _root.swapchain))
-	{
-		debug(LOG_3D, "[3] Drawable size (%d x %d) does not match swapchainSize (%d x %d) - re-create swapchain", w, h, (int)_root.swapchainSize.width, (int)_root.swapchainSize.height);
-		markDrawableSizeDirty();
-		_root.recreateSwapchainAfterPresentError(::vk::Result::eErrorOutOfDateKHR);
-	}
-	else
-	{
-		_presentation.syncDrawableSize(w, h);
-	}
+	// Success
+	advanceRingIfSubmittedDraw(state);
 }
 
 void ScreenFrameCoordinator::throttleSkippedDrawingFrame()
@@ -326,7 +506,7 @@ void ScreenFrameCoordinator::advanceRingBufferAfterSubmit(ScreenFramePipelineSta
 	}
 
 	try {
-		buffering_mechanism::swap(_root.dev, _root.vkDynLoader); // must be called *before* acquireNextSwapchainImage()
+		buffering_mechanism::swap(_root.dev, _root.vkDynLoader); // must be called *before* End tryAcquireSwapchainImage()
 		state.ringSwapped = true;
 	}
 	catch (const ::vk::OutOfHostMemoryError& e)

--- a/lib/ivis_opengl/vk/screen_frame_coordinator.h
+++ b/lib/ivis_opengl/vk/screen_frame_coordinator.h
@@ -19,7 +19,7 @@
 	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
 */
 /** @file screen_frame_coordinator.h
- * Screen-frame finish path: commit inputs, present/acquire, ring advance, and frame epilogue.
+ * Vulkan screen-frame coordinator: Begin reconcile, End acquire, finish submit/present.
  */
 
 #pragma once
@@ -33,16 +33,14 @@ namespace gfx_api::vk
 {
 
 /// <summary>
-/// Vulkan screen-frame finish coordinator owned by `VkRoot`.
+/// Vulkan screen-frame coordinator owned by `VkRoot`.
 ///
-/// Owns `SwapchainPresentationState` and implements `finishScreenFrame()`:
-/// * build commit inputs
-/// * seal/submit via `VkRoot::sealAndSubmitTransferGraphics`
-/// * present/acquire
-/// * ring advance
-/// * frame epilogue (`frameNum++`, close screen frame, purge FBO pool)
-/// `prepareSwapchainForDrawing()` performs late swapchain acquire before render-graph
-/// record (called from piemode).
+/// Lifecycle:
+/// * `reconcileSwapchainAtFrameOpen()` at Begin (recreate / surface-lost only; no acquire)
+/// * `acquireSwapchainForFrameDraw()` at End before graph (acquire; recreate only via
+///   WsiPlatformPolicy macOS suboptimal)
+/// * `finishFrame()`: seal/submit/present/advance; WSI recovery deferred to next Begin
+///   (macOS present suboptimal via WsiPlatformPolicy is the sole mid-finish recreate exception)
 /// </summary>
 class ScreenFrameCoordinator
 {
@@ -53,21 +51,35 @@ public:
 	const SwapchainPresentationState& presentation() const { return _presentation; }
 
 	void markDrawableSizeDirty();
-	void prepareSwapchainForDrawing();
+	void requestSwapchainRecreate();
+	void requestSurfaceLostRecovery();
+	void reconcileSwapchainAtFrameOpen();
+	bool reconcileSucceededAtFrameOpen() const { return _frameGate.reconcileOk; }
+	void acquireSwapchainForFrameDraw();
+	bool canRecordSwapchainDraws() const;
 	ScreenFramePipelineState buildCommitInputs();
 	void finishFrame();
 
 private:
-	void tryAcquireSwapchainImageForDrawing();
+	struct FrameSwapchainGate
+	{
+		bool reconcileOk = false;
+	};
+
+	static bool shouldAdvanceRingAfterSubmit(const ScreenFramePipelineState& state);
+
 	void logScreenFrameDrawSubmitSkip(const ScreenFramePipelineState& state) const;
 	void handleSwapchainPostSubmit(ScreenFramePipelineState& state);
-	void presentAndAcquireScreenFrame(ScreenFramePipelineState& state);
+	void presentAndAdvanceRing(ScreenFramePipelineState& state);
+	void deferSwapchainRecreate(ScreenFramePipelineState& state);
+	void advanceRingIfSubmittedDraw(ScreenFramePipelineState& state);
 	void throttleSkippedDrawingFrame();
 	void advanceRingBufferAfterSubmit(ScreenFramePipelineState& state);
 	void completeScreenFrameFinishTail();
 
 	VkRoot& _root;
 	SwapchainPresentationState _presentation;
+	FrameSwapchainGate _frameGate;
 };
 
 } // namespace gfx_api::vk

--- a/lib/ivis_opengl/vk/swapchain_presentation_state.h
+++ b/lib/ivis_opengl/vk/swapchain_presentation_state.h
@@ -19,7 +19,7 @@
 	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
 */
 /** @file swapchain_presentation_state.h
- * Drawable/swapchain sync state: cached surface extents and last-known drawable size.
+ * Drawable/swapchain sync state: cached surface extents, dirty flags, and deferred WSI recovery.
  */
 
 #pragma once
@@ -32,18 +32,42 @@ namespace gfx_api::vk
 /// <summary>
 /// Drawable vs swapchain sync state for resize and WSI handling.
 ///
-/// Tracks drawable dirty flag, last-known drawable size, and cached surface min/max extents.
-/// Owned by `ScreenFrameCoordinator`; supports O(1) recreate checks and extent clamping at
-/// swapchain create/finish without querying WSI every frame.
+/// Separates:
+/// * drawable dirty - cached drawable size / UI geometry may be stale (does not imply recreate)
+/// * swapchain recreate pending - WSI reported stale swapchain or present-mode change
+/// * surface lost pending - surface must be recreated at frame Begin
+///
+/// Owned by `ScreenFrameCoordinator`.
 /// </summary>
 class SwapchainPresentationState
 {
 public:
 	bool drawableSizeDirty() const { return _drawableSizeDirty; }
+	bool swapchainRecreatePending() const { return _swapchainRecreatePending; }
+	bool surfaceLostPending() const { return _surfaceLostPending; }
 	int lastKnownDrawableWidth() const { return _lastKnownDrawableWidth; }
 	int lastKnownDrawableHeight() const { return _lastKnownDrawableHeight; }
 
 	void markDrawableSizeDirty() { _drawableSizeDirty = true; }
+
+	/// Request swapchain recreate at next frame Begin (even if drawable extents still match).
+	void requestSwapchainRecreate()
+	{
+		_swapchainRecreatePending = true;
+		_drawableSizeDirty = true;
+	}
+
+	/// Request surface + swapchain recovery at next frame Begin.
+	void requestSurfaceLostRecovery()
+	{
+		_surfaceLostPending = true;
+		_swapchainRecreatePending = true;
+		_drawableSizeDirty = true;
+	}
+
+	void clearSwapchainRecreatePending() { _swapchainRecreatePending = false; }
+	void clearSurfaceLostPending() { _surfaceLostPending = false; }
+
 	void syncDrawableSize(int drawableWidth, int drawableHeight);
 	void updateCachedExtentLimits(const ::vk::SurfaceCapabilitiesKHR& capabilities);
 	void invalidateCachedExtentLimits();
@@ -54,6 +78,8 @@ public:
 
 private:
 	bool _drawableSizeDirty = true;
+	bool _swapchainRecreatePending = false;
+	bool _surfaceLostPending = false;
 	int _lastKnownDrawableWidth = 0;
 	int _lastKnownDrawableHeight = 0;
 	::vk::Extent2D _cachedMinImageExtent{};

--- a/lib/ivis_opengl/vk/transfer_recorder.cpp
+++ b/lib/ivis_opengl/vk/transfer_recorder.cpp
@@ -43,9 +43,6 @@ bool TransferRecorder::hasWork() const
 
 void TransferRecorder::markWork()
 {
-#if defined(DEBUG)
-	ASSERT(_context.screenFrameOpen, "Transfer recording outside screen frame");
-#endif
 	_frame.ensureTransferRecordingBegun(_context.vkDynLoader);
 	_frame.transferWorkRecorded = true;
 }

--- a/lib/ivis_opengl/vk/transfer_recorder.h
+++ b/lib/ivis_opengl/vk/transfer_recorder.h
@@ -40,9 +40,11 @@ namespace gfx_api::vk
 /// <summary>
 /// Typed wrapper around the per-frame transfer (copy) command buffer.
 ///
-/// Used by buffer/texture upload paths during the screen frame. Recording opens at
-/// `beginScreenFrame()`; `cmd()` sets `transferWorkRecorded` on the current ring slot;
-/// work is sealed and submitted in `finishScreenFrame()` via `VkRoot::sealAndSubmitTransferGraphics`.
+/// Used by buffer/texture upload paths, during the screen frame or between frames
+/// (uploads recorded after frame end ride the current ring slot's copy stream).
+/// `cmd()` opens recording if needed and sets `transferWorkRecorded` on the slot.
+/// Work is sealed and submitted by `VkRoot::sealAndSubmitTransferGraphics` at frame
+/// finish, or by `VkRoot::submitPendingTransferWork()` before buffering teardown.
 /// </summary>
 class TransferRecorder
 {

--- a/lib/ivis_opengl/vk/transfer_recording_context.h
+++ b/lib/ivis_opengl/vk/transfer_recording_context.h
@@ -32,7 +32,6 @@ namespace gfx_api::vk
 struct TransferRecordingContext
 {
 	const WZ_vk::DispatchLoaderDynamic& vkDynLoader;
-	bool screenFrameOpen = false;
 };
 
 } // namespace gfx_api::vk

--- a/lib/ivis_opengl/vk/wsi_platform_policy.cpp
+++ b/lib/ivis_opengl/vk/wsi_platform_policy.cpp
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+/*
+	This file is part of Warzone 2100.
+	Copyright (C) 2026  Warzone 2100 Project (https://github.com/Warzone2100)
+
+	Warzone 2100 is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+
+	Warzone 2100 is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with Warzone 2100; if not, write to the Free Software
+	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+/** @file wsi_platform_policy.cpp
+ * Platform-specific WSI suboptimal acquire/present policy.
+ */
+
+#include "wsi_platform_policy.h"
+
+#include "lib/framework/frame.h"
+
+namespace gfx_api::vk
+{
+
+SuboptimalAcquireAction WsiPlatformPolicy::suboptimalAcquireAction()
+{
+#if defined(WZ_OS_MAC)
+	// Workaround MoltenVK issue: https://github.com/KhronosGroup/MoltenVK/issues/2542
+	return SuboptimalAcquireAction::RecreateAndRetryOnce;
+#else
+	return SuboptimalAcquireAction::DeferToNextBegin;
+#endif
+}
+
+SuboptimalPresentAction WsiPlatformPolicy::suboptimalPresentAction()
+{
+#if defined(WZ_OS_MAC)
+	return SuboptimalPresentAction::RecreateInline;
+#else
+	return SuboptimalPresentAction::DeferToNextBegin;
+#endif
+}
+
+} // namespace gfx_api::vk

--- a/lib/ivis_opengl/vk/wsi_platform_policy.h
+++ b/lib/ivis_opengl/vk/wsi_platform_policy.h
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+/*
+	This file is part of Warzone 2100.
+	Copyright (C) 2026  Warzone 2100 Project (https://github.com/Warzone2100)
+
+	Warzone 2100 is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+
+	Warzone 2100 is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with Warzone 2100; if not, write to the Free Software
+	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+/** @file wsi_platform_policy.h
+ * Platform-specific WSI suboptimal acquire/present policy (sole home for macOS MoltenVK exceptions).
+ */
+
+#pragma once
+
+namespace gfx_api::vk
+{
+
+enum class SuboptimalAcquireAction
+{
+	DeferToNextBegin,       // non-macOS: request recreate already done by caller; fail acquire
+	RecreateAndRetryOnce    // macOS/MoltenVK: recreate then one retry acquire
+};
+
+enum class SuboptimalPresentAction
+{
+	DeferToNextBegin,       // non-macOS: request recreate + advance ring if submitted draw
+	RecreateInline          // macOS/MoltenVK: sole mid-finish recreate
+};
+
+struct WsiPlatformPolicy
+{
+	static SuboptimalAcquireAction suboptimalAcquireAction();
+	static SuboptimalPresentAction suboptimalPresentAction();
+};
+
+} // namespace gfx_api::vk

--- a/lib/sdl/main_sdl.cpp
+++ b/lib/sdl/main_sdl.cpp
@@ -120,6 +120,57 @@ struct QueuedWindowDimensions
 };
 optional<QueuedWindowDimensions> deferredDimensionReset = nullopt;
 
+struct QueuedWindowModeChange
+{
+	WINDOW_MODE mode = WINDOW_MODE::windowed;
+	bool silent = false;
+};
+
+struct QueuedDrawableResize
+{
+	unsigned int oldWidth = 0;
+	unsigned int oldHeight = 0;
+	unsigned int newWidth = 0;
+	unsigned int newHeight = 0;
+};
+
+struct QueuedDisplayScaleChange
+{
+	unsigned int displayScale = 100;
+};
+
+static optional<QueuedWindowModeChange> queuedWindowModeChange = nullopt;
+static optional<QueuedDrawableResize> queuedDrawableResize = nullopt;
+static optional<optional<screeninfo>> queuedFullscreenDisplayModeChange = nullopt;
+static optional<QueuedDisplayScaleChange> queuedDisplayScaleChange = nullopt;
+
+static bool shouldDeferSurfaceMutation()
+{
+	return pie_IsScreenFrameRendering();
+}
+
+static void queueDrawableResize(unsigned int oldWidth, unsigned int oldHeight, unsigned int newWidth, unsigned int newHeight)
+{
+	if (oldWidth == newWidth && oldHeight == newHeight)
+	{
+		return;
+	}
+
+	if (queuedDrawableResize.has_value())
+	{
+		queuedDrawableResize->newWidth = newWidth;
+		queuedDrawableResize->newHeight = newHeight;
+	}
+	else
+	{
+		queuedDrawableResize = QueuedDrawableResize{oldWidth, oldHeight, newWidth, newHeight};
+	}
+}
+
+static bool wzChangeWindowModeImmediate(WINDOW_MODE mode, bool silent);
+static bool wzChangeFullscreenDisplayModeImmediate(optional<screeninfo> config);
+static bool wzChangeDisplayScaleImmediate(unsigned int displayScale);
+
 static std::vector<optional<screeninfo>> displaylist;	// holds all our possible display lists
 
 std::atomic<Uint32> wzSDLAppEvent((Uint32)-1);
@@ -783,6 +834,30 @@ void wzPostChangedSwapInterval()
 }
 
 bool wzChangeWindowMode(WINDOW_MODE mode, bool silent)
+{
+	auto previousMode = wzGetCurrentWindowMode();
+	if (previousMode == mode)
+	{
+		return true;
+	}
+
+	if (!wzIsSupportedWindowMode(mode))
+	{
+		return false;
+	}
+
+	if (shouldDeferSurfaceMutation())
+	{
+		queuedWindowModeChange = QueuedWindowModeChange{mode, silent};
+		debug(LOG_WZ, "Deferring window mode change: %s -> %s",
+			to_display_string(previousMode).c_str(), to_display_string(mode).c_str());
+		return true;
+	}
+
+	return wzChangeWindowModeImmediate(mode, silent);
+}
+
+static bool wzChangeWindowModeImmediate(WINDOW_MODE mode, bool silent)
 {
 	auto previousMode = wzGetCurrentWindowMode();
 	if (previousMode == mode)
@@ -2063,6 +2138,48 @@ void handleWindowSizeChange(unsigned int oldWidth, unsigned int oldHeight, unsig
 	gfx_api::context::get().handleWindowSizeChange(oldWidth, oldHeight, newWidth, newHeight);
 }
 
+void wzProcessPendingWindowChanges()
+{
+	if (queuedWindowModeChange.has_value())
+	{
+		const QueuedWindowModeChange queued = queuedWindowModeChange.value();
+		queuedWindowModeChange.reset();
+		if (!wzChangeWindowModeImmediate(queued.mode, queued.silent))
+		{
+			debug(LOG_ERROR, "Deferred window mode change failed: %s",
+				to_display_string(queued.mode).c_str());
+		}
+	}
+
+	if (queuedFullscreenDisplayModeChange.has_value())
+	{
+		optional<screeninfo> config = queuedFullscreenDisplayModeChange.value();
+		queuedFullscreenDisplayModeChange.reset();
+		if (!wzChangeFullscreenDisplayModeImmediate(std::move(config)))
+		{
+			debug(LOG_ERROR, "Deferred fullscreen display mode change failed");
+		}
+	}
+
+	// Display scale before drawable resize - scale affects logical mapping / min window size.
+	if (queuedDisplayScaleChange.has_value())
+	{
+		const QueuedDisplayScaleChange queued = queuedDisplayScaleChange.value();
+		queuedDisplayScaleChange.reset();
+		if (!wzChangeDisplayScaleImmediate(queued.displayScale))
+		{
+			debug(LOG_ERROR, "Deferred display scale change failed: %u%%", queued.displayScale);
+		}
+	}
+
+	if (queuedDrawableResize.has_value())
+	{
+		const QueuedDrawableResize queued = queuedDrawableResize.value();
+		queuedDrawableResize.reset();
+		handleWindowSizeChange(queued.oldWidth, queued.oldHeight, queued.newWidth, queued.newHeight);
+	}
+}
+
 
 void wzGetMinimumWindowSizeForDisplayScaleFactor(unsigned int *minWindowWidth, unsigned int *minWindowHeight, float displayScaleFactor = current_displayScaleFactor)
 {
@@ -2217,6 +2334,24 @@ bool wzChangeDisplayScale(unsigned int displayScale)
 		return false;
 	}
 
+	if (shouldDeferSurfaceMutation())
+	{
+		queuedDisplayScaleChange = QueuedDisplayScaleChange{displayScale};
+		debug(LOG_WZ, "Deferring display scale change to %u%%", displayScale);
+		return true; // optimistic, same as deferred window mode
+	}
+
+	return wzChangeDisplayScaleImmediate(displayScale);
+}
+
+static bool wzChangeDisplayScaleImmediate(unsigned int displayScale)
+{
+	if (WZwindow == nullptr)
+	{
+		debug(LOG_WARNING, "wzChangeDisplayScale called when window is not available");
+		return false;
+	}
+
 	float newDisplayScaleFactor = (float)displayScale / 100.f;
 
 	if (wzWindowSizeIsSmallerThanMinimumRequired(windowWidth, windowHeight, newDisplayScaleFactor))
@@ -2312,6 +2447,24 @@ bool wzReduceDisplayScalingIfNeeded(int currWidth, int currHeight)
 }
 
 bool wzChangeFullscreenDisplayMode(optional<screeninfo> config)
+{
+	if (WZwindow == nullptr)
+	{
+		debug(LOG_WARNING, "wzChangeFullscreenDisplayMode called when window is not available");
+		return false;
+	}
+
+	if (shouldDeferSurfaceMutation())
+	{
+		queuedFullscreenDisplayModeChange = std::move(config);
+		debug(LOG_WZ, "Deferring fullscreen display mode change");
+		return true;
+	}
+
+	return wzChangeFullscreenDisplayModeImmediate(std::move(config));
+}
+
+static bool wzChangeFullscreenDisplayModeImmediate(optional<screeninfo> config)
 {
 	if (WZwindow == nullptr)
 	{
@@ -3762,7 +3915,8 @@ static void handleActiveEvent(SDL_Event *event)
 
 				int newWindowWidth = 0, newWindowHeight = 0;
 				SDL_GetWindowSize(WZwindow, &newWindowWidth, &newWindowHeight);
-				handleWindowSizeChange(oldWindowWidth, oldWindowHeight, newWindowWidth, newWindowHeight);
+				windowWidth = static_cast<unsigned int>(newWindowWidth);
+				windowHeight = static_cast<unsigned int>(newWindowHeight);
 
 				// Store the new values (in case the user manually resized the window bounds)
 				if (wzGetCurrentWindowMode() == WINDOW_MODE::windowed)
@@ -3770,6 +3924,8 @@ static void handleActiveEvent(SDL_Event *event)
 					war_SetWidth(newWindowWidth);
 					war_SetHeight(newWindowHeight);
 				}
+
+				queueDrawableResize(oldWindowWidth, oldWindowHeight, static_cast<unsigned int>(newWindowWidth), static_cast<unsigned int>(newWindowHeight));
 
 				// Handle deferred size reset
 				if (deferredDimensionReset.has_value())
@@ -3814,7 +3970,9 @@ static void handleActiveEvent(SDL_Event *event)
 					|| oldDrawableDimensions.first != newDrawableWidth || oldDrawableDimensions.second != newDrawableHeight)
 				{
 					debug(LOG_WZ, "Triggering handleWindowSizeChange from window restore event");
-					handleWindowSizeChange(oldWindowWidth, oldWindowHeight, newWindowWidth, newWindowHeight);
+					windowWidth = static_cast<unsigned int>(newWindowWidth);
+					windowHeight = static_cast<unsigned int>(newWindowHeight);
+					queueDrawableResize(oldWindowWidth, oldWindowHeight, static_cast<unsigned int>(newWindowWidth), static_cast<unsigned int>(newWindowHeight));
 				}
 			}
 			break;
@@ -4078,7 +4236,9 @@ EM_BOOL wz_emscripten_window_resized_callback(int eventType, const void *reserve
 
 		unsigned int oldWindowWidth = windowWidth;
 		unsigned int oldWindowHeight = windowHeight;
-		handleWindowSizeChange(oldWindowWidth, oldWindowHeight, newWindowWidth, newWindowHeight);
+		windowWidth = static_cast<unsigned int>(newWindowWidth);
+		windowHeight = static_cast<unsigned int>(newWindowHeight);
+		queueDrawableResize(oldWindowWidth, oldWindowHeight, static_cast<unsigned int>(newWindowWidth), static_cast<unsigned int>(newWindowHeight));
 		// Store the new values (in case the user manually resized the window bounds)
 		war_SetWidth(newWindowWidth);
 		war_SetHeight(newWindowHeight);


### PR DESCRIPTION
Defer SDL window/mode/scale mutations to frame Begin, then reconcile swapchain before `beginScreenFrame` and acquire only at End when the graph will draw.

Separate recreate/surface-lost pending from drawable dirty, keep WSI recovery off the open-frame path (Mac suboptimal via `WsiPlatformPolicy`), and make VkRoot acquire a dumb op owned by `ScreenFrameCoordinator`.

Also includes a drive-by fix for LOAD_OP_LOAD sync hazard in render-pass EXTERNAL deps.