### PR TITLE
Clear production loop on factory transfer

### DIFF
--- a/src/structure.cpp
+++ b/src/structure.cpp
@@ -1178,7 +1178,7 @@ bool structSetManufacture(STRUCTURE *psStruct, DROID_TEMPLATE *psTempl, QUEUE_MO
 		if (psStruct->player != selectedPlayer)
 		{
 			//set quantity to produce
-			psFact->productionLoops = 1;
+			psFact->productionLoops = 0;
 		}
 
 		psFact->timeStarted = ACTION_START_TIME;//gameTime;
@@ -2227,6 +2227,9 @@ static bool transferFixupFunctionality(STRUCTURE *psBuilding, STRUCTURE_TYPE fun
 	case REF_VTOL_FACTORY:
 		{
 			FACTORY *psFactory = &psBuilding->pFunctionality->factory;
+
+			psFactory->productionLoops = 0;
+			psFactory->loopsPerformed = 0;
 
 			// Reset factoryNumFlag for prior player
 			auto psAssemblyPoint = psFactory->psAssemblyPoint;


### PR DESCRIPTION
- Fixes #4727 

Fixed in 2 redundant locations (either one would fix it):
- Loops are client-side only. So for other players the number of loops was initialized to 1 (so twice). Updated to 0.
- Explicitly clear on transfer