### PR TITLE
Fix: Allow clipboard paste (and other keybinds) for in-game editbox

### DIFF
--- a/src/screens/chatscreen.cpp
+++ b/src/screens/chatscreen.cpp
@@ -705,10 +705,6 @@ void WzInGameChatScreen_CLICKFORM::run(W_CONTEXT *psContext)
 			giveChatBoxFocus();
 		}
 	}
-
-	// while this is displayed, clear the input buffer
-	// (ensuring that subsequent screens / the main screen do not get the input to handle)
-	inputLoseFocus();
 }
 
 // MARK: - WzGameStartOverlayScreen


### PR DESCRIPTION
I suspect `inputLoseFocus();` existed to prevent keybinds from falling through to the actual game. But in testing, removal of this call fixed the issue and I could not reproduce any "fall-through" behavior

- #4989 

The deleted comment claimed it was clearing "the input buffer," but it doesn't actually do that