### PR TITLE
Improve droid removal from build position; less stuck trucks

### DIFF
--- a/src/action.cpp
+++ b/src/action.cpp
@@ -621,7 +621,19 @@ static bool actionRemoveDroidsFromBuildPos(unsigned player, Vector2i pos, uint16
 		if (bestDist != UINT32_MAX)
 		{
 			// Push the droid out of the way.
+			auto blocked = [droid](Vector2i p) {
+				return fpathBlockingTile(gameWorld.map, map_coord(p.x), map_coord(p.y), droid->getPropulsionStats()->propulsionType);
+			};
 			Vector2i newPos = droid->pos.xy() + iSinCosR(iAtan2(bestDest - droid->pos.xy()), gameTimeAdjustedIncrement(TILE_UNITS));
+			if (blocked(newPos))
+			{
+				// Slide along whichever axis stays on unblocked ground, keeping
+				// the droid on unblocked tiles until it can cross cleanly into
+				// the destination tile.
+				Vector2i slideX(newPos.x, droid->pos.y);
+				Vector2i slideY(droid->pos.x, newPos.y);
+				newPos = !blocked(slideX) ? slideX : !blocked(slideY) ? slideY : droid->pos.xy();
+			}
 			droidSetPosition(droid, gameWorld.map, newPos.x, newPos.y);
 		}
 	}


### PR DESCRIPTION
Do not teleport droids into adjacent blocking tiles when removing

I ran a set of comprehensive tests to handle every single case where trucks get stuck.
# Test Mod
Auto-order truck to build and make itself stuck. Also report before and after position.
[truk-stuk.zip](https://github.com/user-attachments/files/30205759/truk-stuk.zip)
# Test Map
Edit `input` (lines 44-46) to alter the trap pattern
[2c-truk-stuk.zip](https://github.com/user-attachments/files/30205757/2c-truk-stuk.zip)

Use a script and test file to auto-compile and launch:
```batch
@echo off
setlocal

set "MAP_NAME=2c-truk-stuk"
set "TEST_FILE=truk-stuk.json"
set "SOURCE=repos\maps-wz2100\truk-stuk\2c-truk-stuk\*"

set "TARGET_FOLDER=C:\Users\aco4\AppData\Roaming\Warzone 2100 Project\Warzone 2100 truk-stuk\maps"
set "EXE_FOLDER=Downloads\stuk2-warzone2100_win_x64_archive\warzone2100_win_x64_archive\bin"

REM Create a ZIP archive
powershell -Command "Compress-Archive -Path '%SOURCE%' -DestinationPath '%MAP_NAME%.zip' -Force"

REM Rename to .wz
rename "%MAP_NAME%.zip" "%MAP_NAME%.wz"

REM Move to Warzone maps directory
move /Y "%MAP_NAME%.wz" "%TARGET_FOLDER%"

REM Launch the game
pushd "%EXE_FOLDER%"
start "" /b "warzone2100.exe" --skirmish=%TEST_FILE%
popd

endlocal
```
`truk-stuk.json`:
```json
{
    "locked": {
        "ai": false,
        "alliances": false,
        "bases": false,
        "cheats": false,
        "difficulty": false,
        "name": false,
        "position": false,
        "power": false,
        "readybeforefull": false,
        "scavengers": false,
        "spectators": false,
        "teams": true
    },
    "challenge": {
        "alliances": 0,
        "bases": 3,
        "map": "truk-stuk",
        "maxPlayers": 2,
        "name": "My Game",
        "openSpectatorSlots": 10,
        "powerLevel": 2,
        "scavengers": 0,
        "spectatorHost": true,
        "techLevel": 1,
        "version": 2
    },
    "player_0": {
        "position": 0,
        "team": 0
    },
    "player_1": {
        "position": 1,
        "team": 1,
        "name": "Nexus",
        "ai": "nexus.js",
        "difficulty": "Medium"
    }
}
```

# Test Results

# Test Setup
"x" = blocked tile
"." = empty tile
"0" = truck in NW corner of tile (x=0,y=0)
"1" = truck in NE corner of tile (x=127,y=0)
"2" = truck in SW corner of tile (x=0,y=127)
"3" = truck in SE corner of tile (x=127,y=127)

# Tests
## 4.7.0
### Test 1
Setup:
```
xx.
x0.
...
```
Result: The truck slides for a tick then snaps to the SE corner of (9, 9) and starts building.
Stuck: Yes
Before: 10 10
After: 9 9

### Test 2
Setup:
```
xxx
x0x
xx.
```
Result: The truck slides to the SE corner of (10, 10) and starts building.
Stuck: No
Before: 10 10
After: 10 11

### Test 3
Setup:
```
xx.
x0x
xxx
```
Result: The truck slides for a tick then snaps to the SE corner of (9, 9) and starts building.
Stuck: Yes
Before: 10 10
After: 9 9

### Test 4
Setup:
```
xxx
x0.
x..
```
Result: The truck slides to the W edge of (11, 10) and starts building.
Stuck: No
Before: 10 10
After: 11 10

### Test 5
Setup:
```
xxx
x0x
.xx
```
Result: The truck slides for a tick then snaps to the SE corner of (9, 9) and starts building.
Stuck: Yes
Before: 10 10
After: 9 9

### Test 6
Setup:
```
.xx
x0x
xxx
```
Result: The truck slides across the tiny gap to the SE corner of (9, 9) and starts building.
Stuck: No
Before: 10 10
After: 9 9

### Test 7
Setup:
```
xx.
x0x
...
```
Result: The truck slides for a tick then snaps to the SE corner of (9, 9) and starts building.
Stuck: Yes
Before: 10 10
After: 9 9

### Test 8
Setup:
```
xx.
x3x
.xx
```
Result: The truck slides N for a few ticks then starts building.
Stuck: Yes
Before: 10 10
After: 11 10

### Test 9
Setup:
```
.x.
x2x
xx.
```
Result: The truck slides N for a few ticks then starts building.
Stuck: Yes
Before: 10 10
After: 9 10

### Test 10
Setup:
```
.x.
x1x
.x.
```
Result: The truck slides across the tiny gap to the SW corner of (11, 9) and starts building.
Stuck: No
Before: 10 10
After: 11 9

## Modified Branch
### Test 1
Setup:
```
xx.
x0.
...
```
Result: The truck slides to the W edge of (11, 10) and starts building.
Stuck: No
Before: 10 10
After: 11 10

### Test 2
Setup:
```
xxx
x0x
xx.
```
Result: The truck slides to the NW corner of (11, 11) and starts building.
Stuck: No
Before: 10 10
After: 11 11

### Test 3
Setup:
```
xx.
x0x
xxx
```
Result: The truck slides to the SW corner of (11, 9) and starts building. It has a bit of trouble when crossing the diagonal and "wiggles" a bit.
Stuck: No
Before: 10 10
After: 11 9

### Test 4
Setup:
```
xxx
x0.
x..
```
Result: The truck slides to the W edge of (11, 10) and starts building.
Stuck: No
Before: 10 10
After: 11 10

### Test 5
Setup:
```
xxx
x0x
.xx
```
Result: The truck slides to the NE corner of (9, 11) and starts building. It has a tiny hiccup getting there and "wiggles" a tiny bit.
Stuck: No
Before: 10 10
After: 9 11

### Test 6
Setup:
```
.xx
x0x
xxx
```
Result: The truck slides across the tiny gap to the SE corner of (9, 9) and starts building.
Stuck: No
Before: 10 10
After: 9 9

### Test 7
Setup:
```
xx.
x0x
...
```
Result: The truck slides to the N edge of (10, 11) and starts building.
Stuck: No
Before: 10 10
After: 10 11

### Test 8
Setup:
```
xx.
x3x
.xx
```
Result: The truck slides to the SW corner of (11, 9) with some hesitancy and starts building.
Stuck: No
Before: 10 10
After: 11 9

### Test 9
Setup:
```
.x.
x2x
xx.
```
Result: The truck slides to the SE corner of (9, 9) with some hesitancy and starts building.
Stuck: No
Before: 10 10
After: 9 9

### Test 10
Setup:
```
.x.
x1x
.x.
```
Result: The truck slides across the tiny gap to the SW corner of (11, 9) and starts building.
Stuck: No
Before: 10 10
After: 11 9