### PR TITLE
Fix long-range build/repair due to slipping

### DIFF
--- a/src/action.cpp
+++ b/src/action.cpp
@@ -1743,25 +1743,19 @@ void actionUpdateDroid(DROID *psDroid)
 			formationLeave(psDroid->sMove.psFormation, psDroid);
 			psDroid->sMove.psFormation = nullptr;
 		}
-		if (DROID_STOPPED(psDroid) &&
-		    !actionReachedBuildPos(psDroid, psDroid->actionPos.x, psDroid->actionPos.y, order->direction, order->psStats))
+		if (!actionReachedBuildPos(psDroid, psDroid->actionPos.x, psDroid->actionPos.y, order->direction, order->psStats))
 		{
-			objTrace(psDroid->id, "DACTION_BUILD: Starting to drive toward construction site");
-			moveDroidToNoFormation(psDroid, psDroid->actionPos.x, psDroid->actionPos.y);
+			objTrace(psDroid->id, "DACTION_BUILD: No longer in range, returning to construction site");
+			psDroid->action = DACTION_MOVETOBUILD;
+			break;
 		}
-		else if (!DROID_STOPPED(psDroid) &&
-		         psDroid->sMove.Status != MOVETURNTOTARGET &&
-		         psDroid->sMove.Status != MOVESHUFFLE &&
-		         actionReachedBuildPos(psDroid, psDroid->actionPos.x, psDroid->actionPos.y, order->direction, order->psStats))
+		// Stop at the construction site
+		if (!DROID_STOPPED(psDroid) &&
+		    psDroid->sMove.Status != MOVETURNTOTARGET &&
+		    psDroid->sMove.Status != MOVESHUFFLE)
 		{
 			objTrace(psDroid->id, "DACTION_BUILD: Stopped - at construction site");
 			moveStopDroid(psDroid);
-		}
-		if (psDroid->action == DACTION_SULK)
-		{
-			objTrace(psDroid->id, "Failed to go to objective, aborting build action");
-			psDroid->action = DACTION_NONE;
-			break;
 		}
 		if (droidUpdateBuild(psDroid))
 		{
@@ -1879,28 +1873,34 @@ void actionUpdateDroid(DROID *psDroid)
 			break;
 		}
 
-		// now do the action update
-		if (DROID_STOPPED(psDroid) && !actionReachedBuildPos(psDroid, psDroid->actionPos.x, psDroid->actionPos.y, ((STRUCTURE *)psDroid->psActionTarget[0])->rot.direction, order->psStats))
+		if (!actionReachedBuildPos(psDroid, psDroid->actionPos.x, psDroid->actionPos.y, ((STRUCTURE *)psDroid->psActionTarget[0])->rot.direction, order->psStats))
 		{
 			if (order->type != DORDER_HOLD && (!secHoldActive || (secHoldActive && order->type != DORDER_NONE)))
 			{
-				objTrace(psDroid->id, "Secondary order: Go to construction site");
-				moveDroidToNoFormation(psDroid, psDroid->actionPos.x, psDroid->actionPos.y);
+				objTrace(psDroid->id, "No longer in range, returning to construction site");
+				switch (psDroid->action)
+				{
+				case DACTION_DEMOLISH: psDroid->action = DACTION_MOVETODEMOLISH; break;
+				case DACTION_REPAIR:   psDroid->action = DACTION_MOVETOREPAIR;   break;
+				case DACTION_RESTORE:  psDroid->action = DACTION_MOVETORESTORE;  break;
+				default: break;
+				}
 			}
 			else
 			{
 				psDroid->action = DACTION_NONE;
 			}
+			break;
 		}
-		else if (!DROID_STOPPED(psDroid) &&
-		         psDroid->sMove.Status != MOVETURNTOTARGET &&
-		         psDroid->sMove.Status != MOVESHUFFLE &&
-		         actionReachedBuildPos(psDroid, psDroid->actionPos.x, psDroid->actionPos.y, ((STRUCTURE *)psDroid->psActionTarget[0])->rot.direction, order->psStats))
+		// Stop at the construction site
+		if (!DROID_STOPPED(psDroid) &&
+		    psDroid->sMove.Status != MOVETURNTOTARGET &&
+		    psDroid->sMove.Status != MOVESHUFFLE)
 		{
 			objTrace(psDroid->id, "Stopped - reached build position");
 			moveStopDroid(psDroid);
 		}
-		else if (actionUpdateFunc(psDroid))
+		if (actionUpdateFunc(psDroid))
 		{
 			//use 0 for non-combat(only 1 'weapon')
 			actionTargetTurret(psDroid, psDroid->psActionTarget[0], &psDroid->asWeaps[0]);

--- a/src/droid.cpp
+++ b/src/droid.cpp
@@ -1285,14 +1285,6 @@ bool droidUpdateBuild(DROID *psDroid)
 	ASSERT_OR_RETURN(false, psStruct->type == OBJ_STRUCTURE, "target is not a structure");
 	ASSERT_OR_RETURN(false, psDroid->asBits[COMP_CONSTRUCT] < asConstructStats.size(), "Invalid construct pointer for unit");
 
-	// droid distance sanity check
-	unsigned distanceSq = droidSqDist(psDroid, psStruct);
-	if (distanceSq > REPAIR_MAXDIST * REPAIR_MAXDIST)
-	{
-		psDroid->action = DACTION_NONE;
-		return false;
-	}
-
 	// First check the structure hasn't been completed by another droid
 	if (psStruct->status == SS_BUILT)
 	{
@@ -1341,14 +1333,6 @@ bool droidUpdateDemolishing(DROID *psDroid)
 	STRUCTURE *psStruct = (STRUCTURE *)psDroid->order.psObj;
 	ASSERT_OR_RETURN(false, psStruct->type == OBJ_STRUCTURE, "target is not a structure");
 
-	// droid distance sanity check
-	unsigned distanceSq = droidSqDist(psDroid, psStruct);
-	if (distanceSq > REPAIR_MAXDIST * REPAIR_MAXDIST)
-	{
-		psDroid->action = DACTION_NONE;
-		return false;
-	}
-
 	int constructRate = 5 * constructorPoints(*psDroid->getConstructStats(), psDroid->player);
 	int pointsToAdd = gameTimeAdjustedAverage(constructRate);
 
@@ -1382,14 +1366,6 @@ bool droidUpdateRestore(DROID *psDroid)
 	WEAPON_STATS *psStats = &asWeaponStats[compIndex];
 
 	ASSERT_OR_RETURN(false, psStats->weaponSubClass == WSC_ELECTRONIC, "unit's weapon is not EW");
-
-	// droid distance sanity check
-	unsigned distanceSq = droidSqDist(psDroid, psStruct);
-	if (distanceSq > REPAIR_MAXDIST * REPAIR_MAXDIST)
-	{
-		psDroid->action = DACTION_NONE;
-		return false;
-	}
 
 	unsigned restorePoints = calcDamage(weaponDamage(*psStats, psDroid->player),
 							   psStats->weaponEffect, (BASE_OBJECT *)psStruct);


### PR DESCRIPTION
# Before
The truck's range was only checked when it was `DROID_STOPPED`. A truck could continue to build/repair/etc. as long as it was moving. Pseudocode summary:
```cpp
case DACTION_BUILD: // while building
    if (STOPPED and not inRange) {
        moveToStructure();
    } else if (inRange and not STOPPED and not turning/shuffling) {
        stop();
    }
    if (SULK) {
        droid->action = DACTION_NONE;
        break;
    }
    addBuildProgress(structure);
    break;
case DACTION_DEMOLISH: // while demolishing/repairing/restoring
case DACTION_REPAIR:
case DACTION_RESTORE:
    if (STOPPED and not inRange) {
        if (not HOLD) {
            moveToStructure();
        } else {
            droid->action = DACTION_NONE;
        }
    } else if (inRange and not STOPPED and not turning/shuffling) {
        stop();
    } else {
        addProgress(structure);
    }
```

# After
Check for range FIRST, and don't require `DROID_STOPPED`:
```cpp
case DACTION_BUILD: // while building
    if (not inRange) {
        droid->action = DACTION_MOVETOBUILD;
        break;
    }
    // stop when in range
    if (not STOPPED and not turning/shuffling) {
        stop();
    }
    addBuildProgress(structure);
    break;
case DACTION_DEMOLISH: // while demolishing/repairing/restoring
case DACTION_REPAIR:
case DACTION_RESTORE:
    if (not inRange) {
        if (not HOLD) {
            droid->action = DACTION_MOVETODEMOLISH or DACTION_MOVETOREPAIR or DACTION_MOVETORESTORE;
        } else {
            droid->action = DACTION_NONE;
        }
    } else if (not STOPPED and not turning/shuffling) {
        stop();
    } else {
        addProgress(structure);
    }
```
(The `DACTION_SULK` check is also removed. It's now handled naturally in `case DACTION_MOVETOBUILD`.)