### PR TITLE
Fix damage prediction calculation against highly armoured targets

### DIFF
--- a/src/combat.cpp
+++ b/src/combat.cpp
@@ -633,7 +633,7 @@ unsigned int objGuessFutureDamage(WEAPON_STATS *psStats, unsigned int player, BA
 	actualDamage = (damage * (100 - EXP_REDUCE_DAMAGE * level)) / 100;
 
 	// You always do at least a third of the experience modified damage
-	actualDamage = MAX(actualDamage - armour, actualDamage * psStats->upgrade[player].minimumDamage / 100);
+	actualDamage = MAX(actualDamage - armour, actualDamage * (int)psStats->upgrade[player].minimumDamage / 100);
 
 	// And at least MIN_WEAPON_DAMAGE points
 	actualDamage = MAX(actualDamage, MIN_WEAPON_DAMAGE);


### PR DESCRIPTION
Do not promote a negative operand to a huge unsigned value

Weapons try to guess how much damage the enemy will receive so unnecessary shots are not fired. But this doesn't work for artillery, which will waste huge amounts of ammunition on a single target.

# Reproduce the bug
1. Start a **T4** skirmish game against 1 Nexus bot on **Sk-Wheel**
2. Enable debug mode (Shift + Backspace)
3. Open debug menu (Ctrl + O)
4. Click **Reveal All**
5. Add ~200 Ripple Rockets Batteries to the map, and 1 nearby sensor
6. Change `selectedPlayer` from `0` to `1`
7. Spawn a Heavy Machinegun Bunker near the sensor
8. ⚠️ All Ripple Rocket Batteries fire, each launching 8 rounds into the enemy bunker. ~80% of the rockets are wasted.

**Expected Result**: Only ~20 Ripple Rockets fire, each firing 2-3 rockets. ~7% are wasted.

# Explanation of Bug
The bug happens because `predictedDamage = 1`, but `actualDamage = 9`. Therefore 9x more rockets are used to kill the enemy.

The bug is in `objGuessFutureDamage()`:
https://github.com/Warzone2100/warzone2100/blob/6cbae9d59557832e92ebb178beccc3341d776174/src/combat.cpp#L596-L644

Specifically on line 636:
```cpp
actualDamage = MAX(actualDamage - armour, actualDamage * psStats->upgrade[player].minimumDamage / 100);
```
When `armour` is higher than `actualDamage`, the left operand is negative. The right operand is `int * unsigned`.

The types differ, so the left operand is promoted to `unsigned`. In testing, this converts an example value of `-76` to `4294967220`, which wins the `MAX`. Assigned back to int, `actualDamage` becomes `-76`, and the final `MAX(-76, 1)` sets it to `MIN_WEAPON_DAMAGE = 1`.

Therefore resulting in a predicted damage of `1` against highly armored opponents, even though the actual is `9`.