### PR TITLE
Add a tweak option for the campaign to disable the weather system

### DIFF
--- a/data/base/script/weather.js
+++ b/data/base/script/weather.js
@@ -8,7 +8,7 @@ function wRandom(max)
 
 function weatherCycle()
 {
-	if (wRandom(100) > 33)
+	if (tweakOptions.activateWeather && wRandom(100) > 33)
 	{
 		if (tilesetType === "URBAN")
 		{

--- a/data/mods/campaign/wz2100_camclassic/mod-info.json.in
+++ b/data/mods/campaign/wz2100_camclassic/mod-info.json.in
@@ -95,6 +95,11 @@
             "id": "noCommander",
             "default": false,
             "userEditable": true
+        },
+        {
+            "id": "activateWeather",
+            "default": true,
+            "userEditable": true
         }
     ],
     "customTweakOptions": [

--- a/data/mods/campaign/wz2100_campumpkin/mod-info.json.in
+++ b/data/mods/campaign/wz2100_campumpkin/mod-info.json.in
@@ -95,6 +95,11 @@
             "id": "noCommander",
             "default": false,
             "userEditable": true
+        },
+        {
+            "id": "activateWeather",
+            "default": true,
+            "userEditable": true
         }
     ],
     "customTweakOptions": [

--- a/src/titleui/campaign.cpp
+++ b/src/titleui/campaign.cpp
@@ -1735,6 +1735,13 @@ static std::vector<WzCampaignTweakOptionSetting> buildTweakOptionSettings(option
 		false, true
 	);
 
+	results.emplace_back(
+		"activateWeather",
+		_("Activate Weather"),
+		_("Toggles the weather system (Disable for consistent FPS tests or to help weak computers)."),
+		true, true
+	);
+
 	if (modInfo.has_value())
 	{
 		for (auto it = results.begin(); it != results.end(); )


### PR DESCRIPTION
I tire of the randomly activated rain and snow being too stronk in this game, creating inconsistency and blowing out graphics cards with ~20-40% FPS reductions merely by being active (and yes, 1700->900s is a real thing just from snow which is the worst offender).

Now with this tweak an age of perfect order for FPS testing is guaranteed.