### PR TITLE
Performance, headless, and savegame improvements

### DIFF
--- a/lib/ivis_opengl/gfx_api.h
+++ b/lib/ivis_opengl/gfx_api.h
@@ -637,7 +637,7 @@ namespace gfx_api
 		void bind_textures(Args&&... args)
 		{
 			static_assert(sizeof...(args) == std::tuple_size<texture_inputs>::value, "Wrong number of textures");
-			gfx_api::context::get().bind_textures(untuple<texture_input>(texture_inputs{}), { args... });
+			gfx_api::context::get().bind_textures(texture_descriptions(), { args... });
 		}
 
 		void bind_constants(const constant_buffer_type<shader>& data)
@@ -684,7 +684,7 @@ namespace gfx_api
 
 		bool recompile()
 		{
-			nextpso = gfx_api::context::get().build_pipeline(pso, pipeline_create_info(rasterizer::get(), shader, primitive, untuple_typeinfo(uniform_inputs{}), untuple<texture_input>(texture_inputs{}), untuple<vertex_buffer>(vertex_buffer_inputs{})));
+			nextpso = gfx_api::context::get().build_pipeline(pso, pipeline_create_info(rasterizer::get(), shader, primitive, untuple_typeinfo(uniform_inputs{}), texture_descriptions(), untuple<vertex_buffer>(vertex_buffer_inputs{})));
 			return nextpso != nullptr && !nextpso->broken;
 		}
 
@@ -718,10 +718,21 @@ namespace gfx_api
 
 		// C++11, but requires specifying Output type
 		template<typename Output, typename...Args>
-		std::vector<Output> untuple(const std::tuple<Args...>&)
+		static std::vector<Output> untuple(const std::tuple<Args...>&)
 		{
 			return std::vector<Output>({ Args::get_desc()... });
 		}
+
+		// The texture descriptors are built purely from texture_inputs' template arguments
+		// (texture_description::get_desc() is static and returns its own non-type parameters), so they
+		// are identical for every draw through this pipeline. Build the list once per instantiation
+		// rather than allocating a fresh vector on every bind_textures() call.
+		static const std::vector<texture_input>& texture_descriptions()
+		{
+			static const std::vector<texture_input> descriptions = untuple<texture_input>(texture_inputs{});
+			return descriptions;
+		}
+
 		template<typename...Args>
 		std::vector<std::type_index> untuple_typeinfo(const std::tuple<Args...>&) const
 		{

--- a/lib/ivis_opengl/gfx_api_vk.cpp
+++ b/lib/ivis_opengl/gfx_api_vk.cpp
@@ -5372,6 +5372,8 @@ void VkRoot::bind_vertex_buffers(const std::size_t& first, const std::vector<std
 	ASSERT_OR_RETURN(, currentPSO != nullptr, "currentPSO == NULL");
 	std::vector<vk::Buffer> buffers;
 	std::vector<VkDeviceSize> offsets;
+	buffers.reserve(vertex_buffers_offset.size());
+	offsets.reserve(vertex_buffers_offset.size());
 	for (const auto &input : vertex_buffers_offset)
 	{
 		// null vertex buffers are not supported
@@ -5639,6 +5641,7 @@ void VkRoot::bind_textures(const std::vector<gfx_api::texture_input>& attribute_
 
 	uint32_t i = 0;
 	auto image_descriptor = std::vector<vk::DescriptorImageInfo>{};
+	image_descriptor.reserve(textures.size());
 	for (auto* texture : textures)
 	{
 		vk::ImageView imageView;
@@ -5713,7 +5716,9 @@ void VkRoot::bind_textures(const std::vector<gfx_api::texture_input>& attribute_
 		i++;
 	}
 	i = 0;
+	// Sized up front: the entries below point into image_descriptor, which must not grow again
 	auto write_info = std::vector<vk::WriteDescriptorSet>{};
+	write_info.reserve(textures.size());
 	for (auto* texture : textures)
 	{
 		(void)texture; // silence unused variable warning

--- a/lib/ivis_opengl/piedef.h
+++ b/lib/ivis_opengl/piedef.h
@@ -62,6 +62,9 @@ void pie_Lighting0(LIGHTING_TYPE entry, const float value[4]);
 glm::vec4 pie_GetLighting0(LIGHTING_TYPE entry);
 
 void pie_InitializeInstancedRenderer();
+/// Frees the mesh batch storage the renderer keeps across frames. For ending a match, so a finished
+/// game's peak batch memory is not held for the rest of the session. Leaves the GPU buffers alone.
+void pie_ReleaseMeshBatchMemory();
 void pie_CleanUp();
 
 enum class ShadowMode

--- a/lib/ivis_opengl/piedraw.cpp
+++ b/lib/ivis_opengl/piedraw.cpp
@@ -1069,13 +1069,19 @@ private:
 
 	MemoryPool memoryPool{ memPoolOpts };
 	PoolAllocator<SHAPE> poolAllocator;
+	// InsertionOrderMap holds its value allocator by reference, so the batches need an allocator of
+	// their own exact type to point at rather than a converted temporary.
+	PoolAllocator<gfx_api::Draw3DShapePerInstanceInterleavedData> instanceDataPoolAllocator;
 
 	using ShapeVector = std::vector<SHAPE, PoolAllocator<SHAPE>>;
+	// The instanced batches hold the interleaved data the buffer upload wants, built when the mesh is
+	// queued. Only the non-instanced fallback path still needs a SHAPE per instance.
+	using InstanceDataVector = std::vector<gfx_api::Draw3DShapePerInstanceInterleavedData, PoolAllocator<gfx_api::Draw3DShapePerInstanceInterleavedData>>;
 	typedef templatedState MeshInstanceKey;
-	std::unordered_map<MeshInstanceKey, ShapeVector, std::hash<MeshInstanceKey>, std::equal_to<MeshInstanceKey>, PoolAllocator<std::pair<const MeshInstanceKey, ShapeVector>>> instanceMeshes;
-	InsertionOrderMap<MeshInstanceKey, ShapeVector> instanceTranslucentMeshes;
-	InsertionOrderMap<MeshInstanceKey, ShapeVector> instanceTranslucentMeshesNoDepthWrite;
-	InsertionOrderMap<MeshInstanceKey, ShapeVector> instanceAdditiveMeshes;
+	std::unordered_map<MeshInstanceKey, InstanceDataVector, std::hash<MeshInstanceKey>, std::equal_to<MeshInstanceKey>, PoolAllocator<std::pair<const MeshInstanceKey, InstanceDataVector>>> instanceMeshes;
+	InsertionOrderMap<MeshInstanceKey, InstanceDataVector> instanceTranslucentMeshes;
+	InsertionOrderMap<MeshInstanceKey, InstanceDataVector> instanceTranslucentMeshesNoDepthWrite;
+	InsertionOrderMap<MeshInstanceKey, InstanceDataVector> instanceAdditiveMeshes;
 	size_t instancesCount = 0;
 	size_t translucentInstancesCount = 0;
 	size_t additiveInstancesCount = 0;
@@ -1111,10 +1117,11 @@ private:
 
 InstancedMeshRenderer::InstancedMeshRenderer()
 	: poolAllocator(memoryPool),
-	instanceMeshes(poolAllocator),
-	instanceTranslucentMeshes(poolAllocator),
-	instanceTranslucentMeshesNoDepthWrite(poolAllocator),
-	instanceAdditiveMeshes(poolAllocator),
+	instanceDataPoolAllocator(memoryPool),
+	instanceMeshes(instanceDataPoolAllocator),
+	instanceTranslucentMeshes(instanceDataPoolAllocator),
+	instanceTranslucentMeshesNoDepthWrite(instanceDataPoolAllocator),
+	instanceAdditiveMeshes(instanceDataPoolAllocator),
 	tshapes(poolAllocator),
 	shapes(poolAllocator)
 {
@@ -1219,39 +1226,46 @@ bool InstancedMeshRenderer::Draw3DShape(const iIMDShape *shape, int frame, PIELI
 
 	templatedState currentState = templatedState((light) ? ((useInstancedRendering) ? SHADER_COMPONENT_INSTANCED : SHADER_COMPONENT) : ((useInstancedRendering) ? SHADER_NOLIGHT_INSTANCED : SHADER_NOLIGHT), shape, pieFlag);
 
-	SHAPE tshape;
-	tshape.shape = shape;
-	tshape.frame = frame;
-	tshape.colour = colour;
-	tshape.teamcolour = teamcolour;
-	tshape.flag = pieFlag;
-	tshape.flag_data = pieFlagData;
-	tshape.stretch = stretchDepth;
-	tshape.modelMatrix = modelMatrix;
+	glm::mat4 shapeModelMatrix = modelMatrix;
 
 	if (pieFlag & pie_SHIELD)
 	{
-		tshape.modelMatrix = glm::scale(tshape.modelMatrix, glm::vec3(pie_SHIELD_FACTOR, pie_SHIELD_FACTOR, pie_SHIELD_FACTOR));
+		shapeModelMatrix = glm::scale(shapeModelMatrix, glm::vec3(pie_SHIELD_FACTOR, pie_SHIELD_FACTOR, pie_SHIELD_FACTOR));
 	}
 
 	if (pieFlag & pie_HEIGHT_SCALED)	// construct
 	{
-		tshape.modelMatrix = glm::scale(tshape.modelMatrix, glm::vec3(1.0f, (float)pieFlagData / (float)pie_RAISE_SCALE, 1.0f));
+		shapeModelMatrix = glm::scale(shapeModelMatrix, glm::vec3(1.0f, (float)pieFlagData / (float)pie_RAISE_SCALE, 1.0f));
 	}
 	if (pieFlag & pie_RAISE)		// collapse
 	{
-		tshape.modelMatrix = glm::translate(tshape.modelMatrix, glm::vec3(1.0f, (-shape->max.y * (pie_RAISE_SCALE - pieFlagData)) * (1.0f / pie_RAISE_SCALE), 1.0f));
+		shapeModelMatrix = glm::translate(shapeModelMatrix, glm::vec3(1.0f, (-shape->max.y * (pie_RAISE_SCALE - pieFlagData)) * (1.0f / pie_RAISE_SCALE), 1.0f));
 	}
+
+	// The instanced path stores the interleaved data directly, so no SHAPE is built for it at all.
+	// Only the non-instanced fallback still needs one.
+	auto fallbackShape = [&]() {
+		SHAPE tshape;
+		tshape.shape = shape;
+		tshape.frame = frame;
+		tshape.colour = colour;
+		tshape.teamcolour = teamcolour;
+		tshape.flag = pieFlag;
+		tshape.flag_data = pieFlagData;
+		tshape.stretch = stretchDepth;
+		tshape.modelMatrix = shapeModelMatrix;
+		return tshape;
+	};
 
 	if (pieFlag & (pie_ADDITIVE | pie_PREMULTIPLIED))
 	{
 		if (useInstancedRendering)
 		{
-			instanceAdditiveMeshes[currentState].push_back(tshape);
+			instanceAdditiveMeshes[currentState].push_back(GenerateInstanceData(frame, colour, teamcolour, pieFlag, pieFlagData, shapeModelMatrix, stretchDepth));
 		}
 		else
 		{
-			tshapes.push_back(tshape);
+			tshapes.push_back(fallbackShape());
 		}
 		++additiveInstancesCount;
 	}
@@ -1261,16 +1275,16 @@ bool InstancedMeshRenderer::Draw3DShape(const iIMDShape *shape, int frame, PIELI
 		{
 			if (pieFlag & pie_NODEPTHWRITE)
 			{
-				instanceTranslucentMeshesNoDepthWrite[currentState].push_back(tshape);
+				instanceTranslucentMeshesNoDepthWrite[currentState].push_back(GenerateInstanceData(frame, colour, teamcolour, pieFlag, pieFlagData, shapeModelMatrix, stretchDepth));
 			}
 			else
 			{
-				instanceTranslucentMeshes[currentState].push_back(tshape);
+				instanceTranslucentMeshes[currentState].push_back(GenerateInstanceData(frame, colour, teamcolour, pieFlag, pieFlagData, shapeModelMatrix, stretchDepth));
 			}
 		}
 		else
 		{
-			tshapes.push_back(tshape);
+			tshapes.push_back(fallbackShape());
 		}
 		++translucentInstancesCount;
 	}
@@ -1304,12 +1318,12 @@ bool InstancedMeshRenderer::Draw3DShape(const iIMDShape *shape, int frame, PIELI
 		}
 		if (useInstancedRendering)
 		{
-			auto [it, _] = instanceMeshes.try_emplace(currentState, poolAllocator);
-			it->second.push_back(tshape);
+			auto [it, _] = instanceMeshes.try_emplace(currentState, instanceDataPoolAllocator);
+			it->second.push_back(GenerateInstanceData(frame, colour, teamcolour, pieFlag, pieFlagData, shapeModelMatrix, stretchDepth));
 		}
 		else
 		{
-			shapes.push_back(tshape);
+			shapes.push_back(fallbackShape());
 		}
 
 		++instancesCount;
@@ -1508,10 +1522,7 @@ bool InstancedMeshRenderer::FinalizeInstances()
 			continue;
 		}
 		size_t startingIdxInInstancesBuffer = instancesData.size();
-		for (const auto& instance : meshInstances)
-		{
-			instancesData.push_back(GenerateInstanceData(instance.frame, instance.colour, instance.teamcolour, instance.flag, instance.flag_data, instance.modelMatrix, instance.stretch));
-		}
+		instancesData.insert(instancesData.end(), meshInstances.begin(), meshInstances.end());
 		finalizedDrawCalls.emplace_back(mesh.first, meshInstances.size(), startingIdxInInstancesBuffer);
 	}
 
@@ -1521,10 +1532,7 @@ bool InstancedMeshRenderer::FinalizeInstances()
 	{
 		const auto& meshInstances = mesh.second;
 		size_t startingIdxInInstancesBuffer = instancesData.size();
-		for (const auto& instance : meshInstances)
-		{
-			instancesData.push_back(GenerateInstanceData(instance.frame, instance.colour, instance.teamcolour, instance.flag, instance.flag_data, instance.modelMatrix, instance.stretch));
-		}
+		instancesData.insert(instancesData.end(), meshInstances.begin(), meshInstances.end());
 		finalizedDrawCalls.emplace_back(mesh.first, meshInstances.size(), startingIdxInInstancesBuffer);
 	}
 
@@ -1534,10 +1542,7 @@ bool InstancedMeshRenderer::FinalizeInstances()
 	{
 		const auto& meshInstances = mesh.second;
 		size_t startingIdxInInstancesBuffer = instancesData.size();
-		for (const auto& instance : meshInstances)
-		{
-			instancesData.push_back(GenerateInstanceData(instance.frame, instance.colour, instance.teamcolour, instance.flag, instance.flag_data, instance.modelMatrix, instance.stretch));
-		}
+		instancesData.insert(instancesData.end(), meshInstances.begin(), meshInstances.end());
 		finalizedDrawCalls.emplace_back(mesh.first, meshInstances.size(), startingIdxInInstancesBuffer);
 	}
 
@@ -1547,10 +1552,7 @@ bool InstancedMeshRenderer::FinalizeInstances()
 	{
 		const auto& meshInstances = mesh.second;
 		size_t startingIdxInInstancesBuffer = instancesData.size();
-		for (const auto& instance : meshInstances)
-		{
-			instancesData.push_back(GenerateInstanceData(instance.frame, instance.colour, instance.teamcolour, instance.flag, instance.flag_data, instance.modelMatrix, instance.stretch));
-		}
+		instancesData.insert(instancesData.end(), meshInstances.begin(), meshInstances.end());
 		finalizedDrawCalls.emplace_back(mesh.first, meshInstances.size(), startingIdxInInstancesBuffer);
 	}
 

--- a/lib/ivis_opengl/piedraw.cpp
+++ b/lib/ivis_opengl/piedraw.cpp
@@ -996,6 +996,12 @@ public:
 		usedCount = 0;
 		keyToValuesIdxMap.clear();
 	}
+	// Drops slots retained beyond what the last frame actually used. Must run before
+	// clearRetainingCapacity(), which is what resets usedCount.
+	void compact()
+	{
+		values.erase(values.begin() + usedCount, values.end());
+	}
 	// Drops the retained slots as well. For teardown, not for per-frame use.
 	void releaseMemory() noexcept
 	{
@@ -1086,6 +1092,13 @@ private:
 	size_t translucentInstancesCount = 0;
 	size_t additiveInstancesCount = 0;
 
+	// Batches are retained across frames, so without a sweep a long match accumulates one for every
+	// mesh it has ever drawn, each holding its capacity and a shape pointer, and FinalizeInstances
+	// walks the dead ones every frame to skip them. Long enough that a batch drawn even rarely is
+	// unlikely to be dropped and re-inserted repeatedly.
+	static constexpr uint32_t batchCompactionIntervalFrames = 600;
+	uint32_t framesSinceBatchCompaction = 0;
+
 	ShapeVector tshapes;
 	ShapeVector shapes;
 
@@ -1151,10 +1164,47 @@ void InstancedMeshRenderer::clear()
 	// Empty the batches but keep them, along with the capacity of each batch's vector. Consecutive
 	// frames draw a near-identical set of meshes, so destroying the batches here only means regrowing
 	// every one of them from zero next frame. Batches left empty are skipped in FinalizeInstances().
-	for (auto& mesh : instanceMeshes)
+	//
+	// Every so often, drop the ones that went unused instead of keeping them forever. A batch that is
+	// still empty here was not drawn into during the previous frame, since this runs at the start of
+	// one. Re-inserting it later costs a single insert, which is what first use would have cost anyway.
+	if (++framesSinceBatchCompaction >= batchCompactionIntervalFrames)
 	{
-		mesh.second.clear();
+		framesSinceBatchCompaction = 0;
+
+		bool erasedAny = false;
+		for (auto it = instanceMeshes.begin(); it != instanceMeshes.end(); )
+		{
+			if (it->second.empty())
+			{
+				it = instanceMeshes.erase(it);
+				erasedAny = true;
+			}
+			else
+			{
+				it->second.clear();
+				++it;
+			}
+		}
+		if (erasedAny)
+		{
+			// Give back the bucket array the dropped batches were sized for
+			instanceMeshes.rehash(0);
+		}
+
+		// Runs before clearRetainingCapacity(), which resets the used-slot count these read
+		instanceTranslucentMeshes.compact();
+		instanceTranslucentMeshesNoDepthWrite.compact();
+		instanceAdditiveMeshes.compact();
 	}
+	else
+	{
+		for (auto& mesh : instanceMeshes)
+		{
+			mesh.second.clear();
+		}
+	}
+
 	instanceTranslucentMeshes.clearRetainingCapacity();
 	instanceTranslucentMeshesNoDepthWrite.clearRetainingCapacity();
 	instanceAdditiveMeshes.clearRetainingCapacity();
@@ -1177,6 +1227,7 @@ void InstancedMeshRenderer::releaseBatchMemory()
 	instancesCount = 0;
 	translucentInstancesCount = 0;
 	additiveInstancesCount = 0;
+	framesSinceBatchCompaction = 0;
 	ShapeVector(poolAllocator).swap(tshapes);
 	ShapeVector(poolAllocator).swap(shapes);
 	std::vector<gfx_api::Draw3DShapePerInstanceInterleavedData>().swap(instancesData);

--- a/lib/ivis_opengl/piedraw.cpp
+++ b/lib/ivis_opengl/piedraw.cpp
@@ -970,22 +970,48 @@ public:
 		{
 			return values[it->second].second;
 		}
-		auto idx = values.size();
-		values.emplace_back(k, allocator);
+		auto idx = usedCount++;
+		if (idx < values.size())
+		{
+			// Re-use a slot left over from a previous frame. Its value was emptied by
+			// clearRetainingCapacity(), so this hands back a vector that kept its capacity.
+			values[idx].first = k;
+		}
+		else
+		{
+			values.emplace_back(k, allocator);
+		}
 		keyToValuesIdxMap[k] = idx;
 		return values[idx].second;
 	}
-	void clear() noexcept
+	// Empties the map for the next frame while keeping the slots (and so the capacity of each value)
+	// allocated. Slots are handed back out in insertion order, so the order this map exists to
+	// preserve is still the current frame's, not the order keys were first seen in.
+	void clearRetainingCapacity() noexcept
 	{
-		values.clear();
+		for (size_t i = 0; i < usedCount; ++i)
+		{
+			values[i].second.clear();
+		}
+		usedCount = 0;
 		keyToValuesIdxMap.clear();
 	}
+	// Drops the retained slots as well. For teardown, not for per-frame use.
+	void releaseMemory() noexcept
+	{
+		usedCount = 0;
+		PairVector().swap(values);
+		std::unordered_map<Key, size_t>().swap(keyToValuesIdxMap);
+	}
 	iterator begin() noexcept { return values.begin(); }
-	iterator end() noexcept { return values.end(); }
+	iterator end() noexcept { return values.begin() + usedCount; }
 	const_iterator cbegin() const noexcept { return values.cbegin(); }
-	const_iterator cend() const noexcept { return values.cend(); }
+	const_iterator cend() const noexcept { return values.cbegin() + usedCount; }
 private:
 	PairVector values;
+	// Number of leading entries in `values` that are live this frame. Anything past it is a retained
+	// but currently unused slot.
+	size_t usedCount = 0;
 	std::unordered_map<Key, size_t> keyToValuesIdxMap;
 	const ValueAllocator& allocator;
 };
@@ -1022,6 +1048,9 @@ public:
 public:
 	bool initialize();
 	void clear();
+	// Drops the batch storage retained across frames by clear(). Call when the match ends, so a
+	// finished game's peak batch memory (and the shape pointers its keys hold) is not kept around.
+	void releaseBatchMemory();
 	void reset();
 	void setLightmap(gfx_api::texture* _lightmapTexture, const glm::mat4& _modelUVLightmapMatrix)
 	{
@@ -1112,10 +1141,16 @@ bool InstancedMeshRenderer::initialize()
 
 void InstancedMeshRenderer::clear()
 {
-	instanceMeshes.clear();
-	instanceTranslucentMeshes.clear();
-	instanceTranslucentMeshesNoDepthWrite.clear();
-	instanceAdditiveMeshes.clear();
+	// Empty the batches but keep them, along with the capacity of each batch's vector. Consecutive
+	// frames draw a near-identical set of meshes, so destroying the batches here only means regrowing
+	// every one of them from zero next frame. Batches left empty are skipped in FinalizeInstances().
+	for (auto& mesh : instanceMeshes)
+	{
+		mesh.second.clear();
+	}
+	instanceTranslucentMeshes.clearRetainingCapacity();
+	instanceTranslucentMeshesNoDepthWrite.clearRetainingCapacity();
+	instanceAdditiveMeshes.clearRetainingCapacity();
 	instancesCount = 0;
 	translucentInstancesCount = 0;
 	additiveInstancesCount = 0;
@@ -1125,9 +1160,27 @@ void InstancedMeshRenderer::clear()
 	modelUVLightmapMatrix = glm::mat4();
 }
 
+void InstancedMeshRenderer::releaseBatchMemory()
+{
+	instanceMeshes.clear();
+	instanceMeshes.rehash(0);
+	instanceTranslucentMeshes.releaseMemory();
+	instanceTranslucentMeshesNoDepthWrite.releaseMemory();
+	instanceAdditiveMeshes.releaseMemory();
+	instancesCount = 0;
+	translucentInstancesCount = 0;
+	additiveInstancesCount = 0;
+	ShapeVector(poolAllocator).swap(tshapes);
+	ShapeVector(poolAllocator).swap(shapes);
+	std::vector<gfx_api::Draw3DShapePerInstanceInterleavedData>().swap(instancesData);
+	std::vector<InstancedDrawCall>().swap(finalizedDrawCalls);
+	lightmapTexture = nullptr;
+	modelUVLightmapMatrix = glm::mat4();
+}
+
 void InstancedMeshRenderer::reset()
 {
-	clear();
+	releaseBatchMemory();
 	for (auto buffer : instanceDataBuffers)
 	{
 		delete buffer;
@@ -1270,6 +1323,11 @@ static InstancedMeshRenderer instancedMeshRenderer;
 void pie_InitializeInstancedRenderer()
 {
 	instancedMeshRenderer.initialize();
+}
+
+void pie_ReleaseMeshBatchMemory()
+{
+	instancedMeshRenderer.releaseBatchMemory();
 }
 
 void pie_CleanUp()
@@ -1444,6 +1502,11 @@ bool InstancedMeshRenderer::FinalizeInstances()
 	for (const auto& mesh : instanceMeshes)
 	{
 		const auto& meshInstances = mesh.second;
+		if (meshInstances.empty())
+		{
+			// A batch retained from an earlier frame that nothing drew into this time
+			continue;
+		}
 		size_t startingIdxInInstancesBuffer = instancesData.size();
 		for (const auto& instance : meshInstances)
 		{

--- a/lib/ivis_opengl/textdraw.cpp
+++ b/lib/ivis_opengl/textdraw.cpp
@@ -522,8 +522,9 @@ struct TextRun
 	hb_language_t language;
 	FTFace* fontFace;
 
-	hb_buffer_t* buffer = nullptr; // owned
 	unsigned int glyphCount;
+	// Point into the shaper's shared HarfBuzz buffer, and so are only valid until the next run is
+	// shaped. Not owned here.
 	hb_glyph_info_t* glyphInfos = nullptr;
 	hb_glyph_position_t* glyphPositions = nullptr;
 	const uint32_t* codePoints = nullptr;
@@ -533,14 +534,6 @@ public:
 	TextRun(const uint32_t* codePoints, int startOffset, int endOffset, hb_script_t script, hb_direction_t direction, hb_language_t language, FTFace& face)
 	: startOffset(startOffset), endOffset(endOffset), script(script), direction(direction), language(language), fontFace(&face), codePoints(codePoints)
 	{ }
-
-	~TextRun()
-	{
-		if (buffer)
-		{
-			hb_buffer_destroy(buffer);
-		}
-	}
 
 public:
 	// Prevent copies
@@ -552,12 +545,6 @@ public:
 	{
 		if (this != &other)
 		{
-			// Free the existing (owned) buffer, if any
-			if (buffer)
-			{
-				hb_buffer_destroy(buffer);
-			}
-
 			// Get the other data
 			startOffset = other.startOffset;
 			endOffset = other.endOffset;
@@ -566,14 +553,12 @@ public:
 			language = other.language;
 			fontFace = other.fontFace;
 
-			buffer = other.buffer; // owned
 			glyphCount = other.glyphCount;
 			glyphInfos = other.glyphInfos;
 			glyphPositions = other.glyphPositions;
 			codePoints = other.codePoints;
 
 			// Reset other's pointer types
-			other.buffer = nullptr;
 			other.glyphInfos = nullptr;
 			other.glyphPositions = nullptr;
 		}
@@ -644,11 +629,24 @@ struct TextShaper
 		int32_t y_advance = 0;
 	};
 
+	// One buffer reused for every run of every shape. HarfBuzz recommends this over creating and
+	// destroying a buffer per run. Shaping a run resets it, so a run's glyph arrays must be consumed
+	// before the next run is shaped.
+	hb_buffer_t* m_hbBuffer = nullptr;
+
 	TextShaper()
-	{ }
+	{
+		m_hbBuffer = hb_buffer_create();
+	}
 
 	~TextShaper()
-	{ }
+	{
+		if (m_hbBuffer)
+		{
+			hb_buffer_destroy(m_hbBuffer);
+			m_hbBuffer = nullptr;
+		}
+	}
 
 	// Returns the maximum text run length (in WzString characters) that fits within a max width (supplied *IN PIXELS*)
 	uint32_t getTextMaxLenForWidth(const WzString& text, iV_fonts fontID, uint32_t maxWidthInPixels, bool rightToLeft)
@@ -1037,15 +1035,15 @@ struct TextShaper
 
 		ShapingResult shapingResult;
 
-		for (int i = 0; i < textRuns.size(); ++i)
-		{
-			shapeHarfbuzz(textRuns[i], *textRuns[i].fontFace);
-		}
-
 		int32_t x = 0;
 		int32_t y = 0;
 
-		auto processTextRunGlyphs = [&](const TextRun& run) {
+		// Shaping a run resets the shared HarfBuzz buffer its glyph arrays point into, so each run is
+		// shaped and consumed in the same step rather than shaping them all up front. Runs shape
+		// independently of one another, so this produces the same glyphs either way.
+		auto processTextRunGlyphs = [&](TextRun& run) {
+			shapeHarfbuzz(run, *run.fontFace);
+
 			for (unsigned int glyphIndex = 0; glyphIndex < run.glyphCount; ++glyphIndex)
 			{
 				hb_glyph_position_t& current_glyphPos = run.glyphPositions[glyphIndex];
@@ -1063,12 +1061,12 @@ struct TextShaper
 		if (!(FRIBIDI_IS_RTL(baseDirection)))
 		{
 #endif // defined(WZ_FRIBIDI_ENABLED)
-			std::for_each(textRuns.cbegin(), textRuns.cend(), processTextRunGlyphs);
+			std::for_each(textRuns.begin(), textRuns.end(), processTextRunGlyphs);
 #if defined(WZ_FRIBIDI_ENABLED)
 		}
 		else
 		{
-			std::for_each(textRuns.crbegin(), textRuns.crend(), processTextRunGlyphs);
+			std::for_each(textRuns.rbegin(), textRuns.rend(), processTextRunGlyphs);
 		}
 #endif // defined(WZ_FRIBIDI_ENABLED)
 
@@ -1089,22 +1087,24 @@ struct TextShaper
 		return shapeText(codePoints, fontID);
 	}
 
+	// Shapes one run into the shared buffer. The run's glyph arrays point into that buffer, so the run
+	// must be consumed before another one is shaped.
 	inline void shapeHarfbuzz(TextRun& run, FTFace& face)
 	{
-		run.buffer = hb_buffer_create();
-		hb_buffer_set_direction(run.buffer, run.direction);
-		hb_buffer_set_script(run.buffer, run.script);
-		hb_buffer_set_language(run.buffer, run.language);
-		hb_buffer_add_utf32(run.buffer, run.codePoints + run.startOffset,
+		hb_buffer_reset(m_hbBuffer);
+		hb_buffer_set_direction(m_hbBuffer, run.direction);
+		hb_buffer_set_script(m_hbBuffer, run.script);
+		hb_buffer_set_language(m_hbBuffer, run.language);
+		hb_buffer_add_utf32(m_hbBuffer, run.codePoints + run.startOffset,
                             run.endOffset - run.startOffset, 0,
                             run.endOffset - run.startOffset);
-		hb_buffer_set_flags(run.buffer, (hb_buffer_flags_t)(HB_BUFFER_FLAG_BOT | HB_BUFFER_FLAG_EOT));
-		std::array<hb_feature_t, 3> features = { {HBFeature::KerningOn, HBFeature::LigatureOn, HBFeature::CligOn} };
+		hb_buffer_set_flags(m_hbBuffer, (hb_buffer_flags_t)(HB_BUFFER_FLAG_BOT | HB_BUFFER_FLAG_EOT));
+		static const std::array<hb_feature_t, 3> features = { {HBFeature::KerningOn, HBFeature::LigatureOn, HBFeature::CligOn} };
 
-		hb_shape(face.m_font, run.buffer, features.data(), static_cast<unsigned int>(features.size()));
+		hb_shape(face.m_font, m_hbBuffer, features.data(), static_cast<unsigned int>(features.size()));
 
-		run.glyphInfos = hb_buffer_get_glyph_infos(run.buffer, &run.glyphCount);
-		run.glyphPositions = hb_buffer_get_glyph_positions(run.buffer, &run.glyphCount);
+		run.glyphInfos = hb_buffer_get_glyph_infos(m_hbBuffer, &run.glyphCount);
+		run.glyphPositions = hb_buffer_get_glyph_positions(m_hbBuffer, &run.glyphCount);
 	}
 };
 

--- a/src/basedef.h
+++ b/src/basedef.h
@@ -99,7 +99,6 @@ struct BASE_OBJECT : public SIMPLE_OBJECT
 	UBYTE               selected;                   ///< Whether the object is selected (might want this elsewhere)
 	UBYTE               visible[MAX_PLAYERS];       ///< Whether object is visible to specific player
 	UBYTE               seenThisTick[MAX_PLAYERS];  ///< Whether object has been seen this tick by the specific player.
-	UDWORD              lastEmission;               ///< When did it last puff out smoke?
 	WEAPON_SUBCLASS     lastHitWeapon;              ///< The weapon that last hit it
 	UDWORD              timeLastHit;                ///< The time the structure was last attacked
 	UDWORD              body;                       ///< Hit points with lame name
@@ -110,6 +109,7 @@ struct BASE_OBJECT : public SIMPLE_OBJECT
 	// DISPLAY-ONLY (*NOT* for game state calculations)
 	UDWORD              timeAnimationStarted;       ///< Animation start time, zero for do not animate
 	UBYTE               animationEvent;             ///< If animation start time > 0, this points to which animation to run
+	UDWORD              lastEmission;               ///< When did it last puff out smoke? Only rate-limits the smoke itself
 	//
 
 	unsigned            numWeaps;

--- a/src/baseobject.cpp
+++ b/src/baseobject.cpp
@@ -114,7 +114,6 @@ SIMPLE_OBJECT::~SIMPLE_OBJECT()
 BASE_OBJECT::BASE_OBJECT(OBJECT_TYPE type, uint32_t id, unsigned player)
 	: SIMPLE_OBJECT(type, id, player)
 	, selected(false)
-	, lastEmission(0)
 	, lastHitWeapon(WSC_NUM_WEAPON_SUBCLASSES)  // No such weapon.
 	, timeLastHit(UDWORD_MAX)
 	, body(0)
@@ -122,6 +121,7 @@ BASE_OBJECT::BASE_OBJECT(OBJECT_TYPE type, uint32_t id, unsigned player)
 	, periodicalDamage(0)
 	, timeAnimationStarted(0)
 	, animationEvent(ANIM_EVENT_NONE)
+	, lastEmission(0)
 {
 	memset(visible, 0, sizeof(visible));
 	sDisplay.imd = nullptr;

--- a/src/display3d.cpp
+++ b/src/display3d.cpp
@@ -1459,6 +1459,10 @@ void shutdown3DView()
 	droidText = WzText();
 
 	batchedObjectStatusRenderer.clear(); // NOTE: *NOT* reset() - see shutdown3DView_FullReset below for why
+
+	// Drop the mesh batches the instanced renderer keeps across frames. Safe here (unlike the GPU
+	// buffers noted below) because it is plain CPU-side storage that just regrows on the next match.
+	pie_ReleaseMeshBatchMemory();
 }
 
 void shutdown3DView_FullReset()

--- a/src/droid.cpp
+++ b/src/droid.cpp
@@ -915,16 +915,12 @@ void droidUpdate(DROID *psDroid)
 			// Done animating (animation is defined by body - other components should follow suit)
 			if (psDroid->animationEvent == ANIM_EVENT_DYING)
 			{
-				// case theoretically should not happen anymore, as death animations are handled separately as effects now?
+				// Death animations are handled separately as effects, so a live droid should never
+				// reach this. A pre-2023 savegame can still restore one, so clear it and carry on.
 				debug(LOG_DEATH, "%s (%d) died to burn anim (died=%d)", objInfo(psDroid), (int)psDroid->id, (int)psDroid->died);
-				return;
 			}
 			psDroid->animationEvent = ANIM_EVENT_NONE;
 		}
-	}
-	else if (psDroid->animationEvent == ANIM_EVENT_DYING)
-	{
-		return; // rest below is irrelevant if dead
 	}
 
 	// Restore group from repairGroup if the droid gets interrupted while retreating.

--- a/src/effects.cpp
+++ b/src/effects.cpp
@@ -2344,6 +2344,165 @@ void effectResetUpdates()
 	memset(lastUpdateStructures, 0, sizeof(lastUpdateStructures));
 }
 
+// MARK: - Active effect list serialization (disk savegame, display-only)
+//
+// Restoring the effect list is purely so a loaded game looks like the one that was saved (ex. a
+// destroyed oil derrick still burning). Nothing here feeds the simulation, which is why it lives in
+// the savegame's local per-client section rather than the game state document.
+
+static nlohmann::ordered_json writeEffectVector3f(const Vector3f &v)
+{
+	return nlohmann::ordered_json::array({ v.x, v.y, v.z });
+}
+
+static nlohmann::ordered_json writeEffectVector3i(const Vector3i &v)
+{
+	return nlohmann::ordered_json::array({ v.x, v.y, v.z });
+}
+
+static bool readEffectVector3f(const nlohmann::ordered_json &j, const char *key, Vector3f &out)
+{
+	if (!j.contains(key))
+	{
+		return false;
+	}
+	const nlohmann::ordered_json &v = j.at(key);
+	if (!v.is_array() || v.size() < 3)
+	{
+		return false;
+	}
+	out = Vector3f(v[0].get<float>(), v[1].get<float>(), v[2].get<float>());
+	return true;
+}
+
+static bool readEffectVector3i(const nlohmann::ordered_json &j, const char *key, Vector3i &out)
+{
+	if (!j.contains(key))
+	{
+		return false;
+	}
+	const nlohmann::ordered_json &v = j.at(key);
+	if (!v.is_array() || v.size() < 3)
+	{
+		return false;
+	}
+	out = Vector3i(v[0].get<int32_t>(), v[1].get<int32_t>(), v[2].get<int32_t>());
+	return true;
+}
+
+std::vector<nlohmann::ordered_json> serializeActiveEffects()
+{
+	std::vector<nlohmann::ordered_json> out;
+	out.reserve(gActiveEffects.size());
+
+	for (auto iter = gActiveEffects.begin(); iter != gActiveEffects.end(); ++iter)
+	{
+		const EFFECT &e = *iter;
+		if (e.group == EFFECT_FREED)
+		{
+			continue;
+		}
+
+		nlohmann::ordered_json j = nlohmann::ordered_json::object();
+		j["group"] = static_cast<int>(e.group);
+		j["type"] = static_cast<int>(e.type);
+		j["control"] = e.control;
+		j["frameNumber"] = e.frameNumber;
+		j["size"] = e.size;
+		j["baseScale"] = e.baseScale;
+		j["specific"] = e.specific;
+		// The player colour the effect was created with. Gravitons, giblets and the droid death
+		// animation are drawn in it, so it must survive the round-trip.
+		j["player"] = e.player;
+		j["position"] = writeEffectVector3f(e.position);
+		j["velocity"] = writeEffectVector3f(e.velocity);
+		j["rotation"] = writeEffectVector3i(e.rotation);
+		j["spin"] = writeEffectVector3i(e.spin);
+		j["birthTime"] = e.birthTime;
+		j["lastFrame"] = e.lastFrame;
+		j["frameDelay"] = e.frameDelay;
+		j["lifeSpan"] = e.lifeSpan;
+		j["radius"] = e.radius;
+		if (e.imd)
+		{
+			j["imd"] = modelName(e.imd).toUtf8();
+		}
+
+		out.push_back(std::move(j));
+	}
+
+	return out;
+}
+
+void restoreActiveEffects(const std::vector<nlohmann::ordered_json> &effects)
+{
+	if (headlessGameMode())
+	{
+		// Nothing drains the list without the 3D draw path, so leave it empty
+		return;
+	}
+
+	// The restore is authoritative: drop anything already added (the world restore re-creates the
+	// landing lights via setNoGoArea, and those are permanent, so replaying on top would double them).
+	initEffectsSystem();
+
+	for (const nlohmann::ordered_json &j : effects)
+	{
+		if (!j.is_object())
+		{
+			continue;
+		}
+
+		const int group = j.value("group", static_cast<int>(EFFECT_FREED));
+		const int type = j.value("type", -1);
+		if (group < 0 || group >= EFFECT_FREED || type < 0 || type > DROID_ANIMEVENT_DYING_NORMAL_ST)
+		{
+			continue;
+		}
+
+		EFFECT e;
+		e.group = static_cast<EFFECT_GROUP>(group);
+		e.type = static_cast<EFFECT_TYPE>(type);
+		e.control = j.value("control", static_cast<uint8_t>(0));
+		e.frameNumber = j.value("frameNumber", static_cast<uint8_t>(0));
+		e.size = j.value("size", static_cast<uint16_t>(0));
+		e.baseScale = j.value("baseScale", static_cast<uint8_t>(0));
+		e.specific = j.value("specific", static_cast<uint8_t>(0));
+		e.player = j.value("player", static_cast<uint8_t>(0));
+		readEffectVector3f(j, "position", e.position);
+		readEffectVector3f(j, "velocity", e.velocity);
+		readEffectVector3i(j, "rotation", e.rotation);
+		readEffectVector3i(j, "spin", e.spin);
+		e.birthTime = j.value("birthTime", graphicsTime);
+		e.lastFrame = j.value("lastFrame", e.birthTime);
+		e.frameDelay = j.value("frameDelay", static_cast<uint16_t>(0));
+		e.lifeSpan = j.value("lifeSpan", static_cast<uint16_t>(0));
+		e.radius = j.value("radius", static_cast<uint16_t>(0));
+
+		if (j.contains("imd"))
+		{
+			const WzString imdName = WzString::fromUtf8(j.at("imd").get<std::string>());
+			const iIMDBaseShape *baseImd = (!imdName.isEmpty()) ? modelGet(imdName) : nullptr;
+			e.imd = (baseImd) ? baseImd->displayModel() : nullptr;
+		}
+
+		// Same requirement addEffect() asserts: everything except these groups is drawn from its imd,
+		// so an entry that lost its model would be a null dereference at render time.
+		if (e.imd == nullptr && e.group != EFFECT_DESTRUCTION && e.group != EFFECT_FIRE && e.group != EFFECT_SAT_LASER)
+		{
+			continue;
+		}
+
+		// updateFire() scatters its spawns with rand() % radius, so a zero radius would divide by zero.
+		if (e.group == EFFECT_FIRE && e.radius == 0)
+		{
+			e.radius = 1;
+		}
+
+		gActiveEffects.emplace(std::move(e));
+	}
+}
+
 /** This will save out the effects data */
 bool writeFXData(const char *fileName)
 {

--- a/src/effects.cpp
+++ b/src/effects.cpp
@@ -34,6 +34,17 @@
 	************************************************************
 	* STILL NEED TO REMOVE SOME MAGIC NUMBERS INTO #DEFINES!!! *
 	************************************************************
+
+	Effects are DISPLAY-ONLY and must stay that way:
+	- Nothing here may read or write game simulation state, or consume the synchronised RNG
+	  (gameRand / gameRandU32). Use plain rand() for visual variation.
+	- The active effect list is only advanced by processEffects(), which runs from the 3D draw
+	  path. It never runs in headless mode, so addEffect() / addMultiEffect() bail out there
+	  rather than accumulate effects that would never be processed.
+	- Sound is fine (it is presentation, not simulation).
+
+	The one exception is readFXData(), which sets burning tiles when loading a classic savegame,
+	because that format persists tile fire nowhere else.
 */
 #include "lib/framework/wzapp.h"
 #include "lib/framework/wzconfig.h"
@@ -72,6 +83,7 @@
 #include "component.h"
 #include "profiling.h"
 #include "game_world.h"
+#include "wrappers.h"
 
 #ifndef GLM_ENABLE_EXPERIMENTAL
 	#define GLM_ENABLE_EXPERIMENTAL
@@ -257,7 +269,7 @@ void effectSetSize(UDWORD size)
 void addMultiEffect(const Vector3i *basePos, Vector3i *scatter, EFFECT_GROUP group,
                     EFFECT_TYPE type, bool specified, const iIMDShape *imd, unsigned int number, bool lit, unsigned int size, unsigned effectTime)
 {
-	if (number == 0)
+	if (number == 0 || headlessGameMode())
 	{
 		return;
 	}
@@ -358,7 +370,7 @@ static void renderDroidDeathAnimationEffect(const EFFECT *psEffect, const glm::m
 
 void addEffect(const Vector3i *pos, EFFECT_GROUP group, EFFECT_TYPE type, bool specified, const iIMDShape *imd, int lit, unsigned effectTime, Vector3i *rot /*= nullptr*/, Vector3f *velocity /*= nullptr*/)
 {
-	if (gamePaused())
+	if (gamePaused() || headlessGameMode())
 	{
 		return;
 	}

--- a/src/effects.h
+++ b/src/effects.h
@@ -28,6 +28,10 @@
 	temporary world 'effects
 	Alex McLean, Pumpkin Studios, EIDOS Interactive, 1998.
 */
+#include <vector>
+
+#include <nlohmann/json_fwd.hpp>
+
 #include "lib/ivis_opengl/piedef.h"
 #include "lib/framework/fixedpoint.h"
 #include "lib/ivis_opengl/pietypes.h"
@@ -166,6 +170,18 @@ struct WorldMapState;
 
 bool	readFXData(const char *fileName, WorldMapState& mapState);
 bool	writeFXData(const char *fileName);
+
+/// Serializes the live effect list, one JSON object per effect.
+/// Effects are display-only, so this belongs to the savegame's local (per-client) section and is
+/// never part of the networked game state. Returns an empty list in headless mode.
+std::vector<nlohmann::ordered_json> serializeActiveEffects();
+
+/// Replaces the live effect list with a previously serialized one. Clears whatever is already there,
+/// so the restore is authoritative and effects the world restore re-created (ex. the landing lights
+/// setNoGoArea adds) are not doubled up. Malformed entries are skipped rather than failing the load.
+/// Unlike readFXData(), this does NOT set tiles on fire: the savegame restores that from the map.
+void restoreActiveEffects(const std::vector<nlohmann::ordered_json> &effects);
+
 void	effectSetSize(UDWORD size);
 void	effectSetLandLightSpec(LAND_LIGHT_SPEC spec);
 void	SetEffectForPlayer(uint8_t player);

--- a/src/gamestate_savegame.cpp
+++ b/src/gamestate_savegame.cpp
@@ -44,6 +44,7 @@
 #include "display3d.h"      // playerPos (camera) - local view state
 #include "radar.h"          // Get/SetRadarZoom - local view state
 #include "mission.h"        // Cheated - local meta flag
+#include "effects.h"        // serialize/restoreActiveEffects - local display state
 #include "multistat.h"      // loadMultiStats, setMultiStats, getMultiStats
 #include "modding.h"        // getLoadedMods, setOverrideMods, clearOverrideMods
 #include "init.h"           // rebuildSearchPath, buildMapList, searchPathMode
@@ -634,6 +635,11 @@ static nlohmann::ordered_json writeLocalState()
 		guide["disableTopicPopups"] = getGameGuideDisableTopicPopups();
 		j["guideTopics"] = std::move(guide);
 	}
+
+	// The live effect list (smoke, fire, explosions, debris). Purely so a loaded game looks like the
+	// one that was saved, ex. a destroyed oil derrick still burning. Per-client and display-only, so
+	// it belongs here rather than in the game state document. Empty in headless mode.
+	j["effects"] = serializeActiveEffects();
 	return j;
 }
 
@@ -668,6 +674,14 @@ static void readLocalState(const nlohmann::ordered_json &j)
 			restoreLoadedGuideTopics(guide.at("loaded").get<std::vector<std::string>>());
 		}
 		setGameGuideDisableTopicPopups(guide.value("disableTopicPopups", false));
+	}
+
+	// The saved effect list (see writeLocalState). Applied after the world restore, so it also clears
+	// the effects that restore re-created. Absent for saves written before this section existed, in
+	// which case the world restore's own effects are simply left alone.
+	if (j.contains("effects") && j.at("effects").is_array())
+	{
+		restoreActiveEffects(j.at("effects").get<std::vector<nlohmann::ordered_json>>());
 	}
 }
 

--- a/src/projectile.cpp
+++ b/src/projectile.cpp
@@ -60,6 +60,7 @@
 #include "display3d.h"
 #include "profiling.h"
 #include "game_world.h"
+#include "wrappers.h"
 
 #include <algorithm>
 #include <functional>
@@ -1016,7 +1017,7 @@ static PROJECTILE* proj_InFlightFunc(PROJECTILE *psProj)
 	}
 
 	/* Paint effects if visible */
-	if (gfxVisible(psProj))
+	if (!headlessGameMode() && gfxVisible(psProj))
 	{
 		uint32_t effectTime;
 		for (effectTime = ((psProj->prevSpacetime.time + 31) & ~31); effectTime < psProj->time; effectTime += 32)

--- a/src/terrain.cpp
+++ b/src/terrain.cpp
@@ -1318,15 +1318,20 @@ static void updateLightMap(WorldMapState& mapState, const LightMap& lightmap)
 
 static void cullTerrain(WorldMapState& mapState)
 {
+	const float maxDistance = static_cast<float>(world_coord(terrainDistance));
+	const float maxDistanceSquared = maxDistance * maxDistance;
+
 	for (int x = 0; x < xSectors; x++)
 	{
 		for (int y = 0; y < ySectors; y++)
 		{
 			float xPos = world_coord(x * sectorSize + sectorSize / 2);
 			float yPos = world_coord(y * sectorSize + sectorSize / 2);
-			float distance = pow(playerPos.p.x - xPos, 2) + pow(playerPos.p.z - yPos, 2);
+			float xDelta = playerPos.p.x - xPos;
+			float yDelta = playerPos.p.z - yPos;
+			float distance = xDelta * xDelta + yDelta * yDelta;
 
-			if (distance > pow((double)world_coord(terrainDistance), 2))
+			if (distance > maxDistanceSquared)
 			{
 				sectors[x * ySectors + y].draw = false;
 			}


### PR DESCRIPTION
Various small tweaks to:
- reduce repeat allocations on the hot path
- avoid unnecessary work in headless mode

Plus: persist and restore effects in the new gamestate saveload