### PR TITLE
gfx_api: Introduce pipeline surface store and harden teardown lifecycle

### DIFF
--- a/lib/ivis_opengl/gfx_api.cpp
+++ b/lib/ivis_opengl/gfx_api.cpp
@@ -617,6 +617,9 @@ const char* gfx_api::format_to_str(gfx_api::pixel_format format)
 		case gfx_api::pixel_format::FORMAT_RG8_UNORM: return "RG8_UNORM";
 		case gfx_api::pixel_format::FORMAT_R8_UNORM: return "R8_UNORM";
 		case gfx_api::pixel_format::FORMAT_D24_UNORM_S8: return "D24_UNORM_S8";
+		case gfx_api::pixel_format::FORMAT_A2B10G10R10_UNORM_PACK32: return "A2B10G10R10_UNORM_PACK32";
+		case gfx_api::pixel_format::FORMAT_D32_SFLOAT_S8_UINT: return "D32_SFLOAT_S8_UINT";
+		case gfx_api::pixel_format::FORMAT_D32_SFLOAT: return "D32_SFLOAT";
 		// COMPRESSED FORMAT
 		case gfx_api::pixel_format::FORMAT_RGB_BC1_UNORM: return "RGB_BC1_UNORM";
 		case gfx_api::pixel_format::FORMAT_RGBA_BC2_UNORM: return "RGBA_BC2_UNORM";
@@ -654,7 +657,11 @@ unsigned int gfx_api::format_channels(gfx_api::pixel_format format)
 		case gfx_api::pixel_format::FORMAT_R8_UNORM:
 			return 1;
 		case gfx_api::pixel_format::FORMAT_D24_UNORM_S8:
+		case gfx_api::pixel_format::FORMAT_D32_SFLOAT_S8_UINT:
+		case gfx_api::pixel_format::FORMAT_D32_SFLOAT:
 			return 0;
+		case gfx_api::pixel_format::FORMAT_A2B10G10R10_UNORM_PACK32:
+			return 4;
 		// COMPRESSED FORMAT
 		case gfx_api::pixel_format::FORMAT_RGB_BC1_UNORM:
 			return 3;
@@ -707,6 +714,13 @@ size_t gfx_api::format_memory_size(gfx_api::pixel_format format, size_t width, s
 		case gfx_api::pixel_format::FORMAT_R8_UNORM:
 			return width * height;
 		case gfx_api::pixel_format::FORMAT_D24_UNORM_S8:
+			return width * height * 4;
+		case gfx_api::pixel_format::FORMAT_A2B10G10R10_UNORM_PACK32:
+			return width * height * 4;
+		case gfx_api::pixel_format::FORMAT_D32_SFLOAT_S8_UINT:
+			// Vulkan packs D32F+S8 as 64-bit texels (32-bit depth + 8-bit stencil + padding).
+			return width * height * 8;
+		case gfx_api::pixel_format::FORMAT_D32_SFLOAT:
 			return width * height * 4;
 		// [COMPRESSED FORMATS]
 		// BC / DXT formats

--- a/lib/ivis_opengl/gfx_api.h
+++ b/lib/ivis_opengl/gfx_api.h
@@ -453,12 +453,28 @@ namespace gfx_api
 
 		virtual size_t getDepthPassDimensions(size_t idx) { return 0; }
 		virtual gfx_api::abstract_texture* getPipelineSurface(PipelineSurfaceId id) { return nullptr; }
-		virtual PipelineSurfaceMeta pipelineSurfaceMeta(PipelineSurfaceId id) const { return getPipelineSurfaceMeta(id); }
+		virtual PipelineSurfaceUsage pipelineSurfaceUsage(PipelineSurfaceId id) const;
+		virtual const ResolvedSurfaceSpec& resolvedPipelineSurface(PipelineSurfaceId id) const;
 		virtual nonstd::optional<PipelineSurfaceId> findPipelineSurfaceId(gfx_api::abstract_texture* texture) const { return nonstd::nullopt; }
+		bool isPipelineSurfaceDepthRole(PipelineSurfaceId id) const
+		{
+			return isDepthUsage(pipelineSurfaceUsage(id));
+		}
+		/// Dimensions from the live resolved surface spec (nullopt if disabled / zero extent).
+		virtual optional<std::pair<uint32_t, uint32_t>> getPipelineSurfaceDimensions(PipelineSurfaceId id) const;
 		virtual bool isSceneMSAAEnabled() const { return false; }
 		virtual bool isSwapchainMSAAEnabled() const { return false; }
 		virtual bool isMultisampledColorAttachment(abstract_texture* texture) const { return false; }
 		virtual pixel_format getDepthStencilFormat() const { return pixel_format::invalid; }
+
+		/// Per-sync sizes / MSAA / cascades / present format from backend state.
+		virtual PipelineSurfaceSyncInputs pipelineSurfaceSyncInputs() const { return {}; }
+		/// Backend HW-negotiated formats for catalog format classes.
+		virtual SurfaceCapabilityHints surfaceCapabilities() const { return {}; }
+		/// Create / update / destroy pipeline surfaces from resolved specs (store + allocator).
+		virtual bool ensurePipelineSurfaces(const ResolvedSurfaceTable& specs) = 0;
+		/// Resolve catalog against sync inputs + capabilities, then ensure surfaces.
+		bool syncPipelineSurfaces();
 
 		/// Purge unused pooled framebuffers/FBOs after the frame accumulation window.
 		/// Backends call releaseAll() at beginScreenFrame() and purgeFrameResources() at finish.

--- a/lib/ivis_opengl/gfx_api_formats_def.h
+++ b/lib/ivis_opengl/gfx_api_formats_def.h
@@ -57,8 +57,13 @@ namespace gfx_api
 
 		// ASTC (LDR) - requires an extension
 		FORMAT_ASTC_4x4_UNORM,
+
+		// Additional uncompressed / depth formats (appended to preserve prior enumerant values)
+		FORMAT_A2B10G10R10_UNORM_PACK32, // 10-bit RGB + 2-bit A (e.g. VK scene color)
+		FORMAT_D32_SFLOAT_S8_UINT,       // depth/stencil attachment
+		FORMAT_D32_SFLOAT,               // depth-only (e.g. shadow maps)
 	};
-	constexpr pixel_format MAX_PIXEL_FORMAT = pixel_format::FORMAT_ASTC_4x4_UNORM;
+	constexpr pixel_format MAX_PIXEL_FORMAT = pixel_format::FORMAT_D32_SFLOAT;
 
 	static inline bool is_uncompressed_format(const pixel_format& format)
 	{
@@ -70,6 +75,7 @@ namespace gfx_api
 			case gfx_api::pixel_format::FORMAT_RGB8_UNORM_PACK8:
 			case gfx_api::pixel_format::FORMAT_RG8_UNORM:
 			case gfx_api::pixel_format::FORMAT_R8_UNORM:
+			case gfx_api::pixel_format::FORMAT_A2B10G10R10_UNORM_PACK32:
 				return true;
 			default:
 				return false;

--- a/lib/ivis_opengl/gfx_api_gl.cpp
+++ b/lib/ivis_opengl/gfx_api_gl.cpp
@@ -3596,15 +3596,13 @@ bool gl_context::_initialize(const gfx_api::backend_Impl_Factory& impl, int32_t 
 		depthBufferResolution = getSuggestedDefaultDepthBufferResolution();
 	}
 
-	if (!createSceneRenderpass())
+	if (!syncPipelineSurfaces())
 	{
-		// Treat failure to create the scene render pass as a fatal error
+		// Treat failure to sync pipeline surfaces as a fatal error
 		shutdown();
 		wzResetGfxSettingsOnFailure(); // reset certain settings (like MSAA) that could be contributing to OUT_OF_MEMORY (or other) errors
 		return false;
 	}
-	registerSwapchainPipelineSurfaces();
-	initDepthPasses(depthBufferResolution);
 
 	glBindFramebuffer(GL_FRAMEBUFFER, 0);
 
@@ -4199,22 +4197,18 @@ size_t gl_context::numDepthPasses()
 
 bool gl_context::setDepthPassProperties(size_t _numDepthPasses, size_t _depthBufferResolution)
 {
-	if (depthPassCount == _numDepthPasses
+	const size_t clampedDepthPasses = std::min<size_t>(_numDepthPasses, WZ_MAX_SHADOW_CASCADES);
+	if (depthPassCount == clampedDepthPasses
 		&& depthBufferResolution == _depthBufferResolution)
 	{
 		// nothing to do
 		return true;
 	}
 
-	depthPassCount = _numDepthPasses;
+	depthPassCount = clampedDepthPasses;
 	depthBufferResolution = _depthBufferResolution;
 
-	bumpRenderGraphEpoch();
-
-	// reinitialize depth passes
-	initDepthPasses(depthBufferResolution);
-
-	return true;
+	return syncPipelineSurfaces();
 }
 
 size_t gl_context::getDepthPassDimensions(size_t idx)
@@ -4227,19 +4221,24 @@ gfx_api::abstract_texture* gl_context::getPipelineSurface(gfx_api::PipelineSurfa
 	return _pipelineSurfaces.get(id);
 }
 
-gfx_api::PipelineSurfaceMeta gl_context::pipelineSurfaceMeta(gfx_api::PipelineSurfaceId id) const
+gfx_api::PipelineSurfaceUsage gl_context::pipelineSurfaceUsage(gfx_api::PipelineSurfaceId id) const
 {
-	return _pipelineSurfaces.meta(id);
+	return _pipelineSurfaces.usage(id);
+}
+
+const gfx_api::ResolvedSurfaceSpec& gl_context::resolvedPipelineSurface(gfx_api::PipelineSurfaceId id) const
+{
+	return _pipelineSurfaces.spec(id);
 }
 
 nonstd::optional<gfx_api::PipelineSurfaceId> gl_context::findPipelineSurfaceId(gfx_api::abstract_texture* texture) const
 {
-	return _pipelineSurfaces.findSurfaceId(texture);
+	return _pipelineSurfaces.find(texture);
 }
 
 bool gl_context::isSceneMSAAEnabled() const
 {
-	return multisamples > 0 && _sceneMsaaSurface != nullptr;
+	return multisamples > 0 && _pipelineSurfaces.has(gfx_api::PipelineSurfaceId::SceneMSAAColor);
 }
 
 bool gl_context::isSwapchainMSAAEnabled() const
@@ -4259,6 +4258,47 @@ bool gl_context::isMultisampledColorAttachment(gfx_api::abstract_texture* textur
 gfx_api::pixel_format gl_context::getDepthStencilFormat() const
 {
 	return gfx_api::pixel_format::FORMAT_D24_UNORM_S8;
+}
+
+gfx_api::PipelineSurfaceSyncInputs gl_context::pipelineSurfaceSyncInputs() const
+{
+	gfx_api::PipelineSurfaceSyncInputs inputs;
+	// Drawable may be 0x0 when minimized; scene dims stay floored (>=2) from the last sensible size.
+	inputs.drawableW = viewportWidth;
+	inputs.drawableH = viewportHeight;
+	inputs.sceneW = sceneFramebufferWidth;
+	inputs.sceneH = sceneFramebufferHeight;
+	inputs.shadowMapSize = static_cast<uint32_t>(depthBufferResolution);
+	inputs.numShadowCascades = static_cast<uint32_t>(std::min<size_t>(depthPassCount, WZ_MAX_SHADOW_CASCADES));
+	const uint32_t clampedMsaa = (multisamples > 0 && maxMultiSampleBufferFormatSamples > 0)
+		? std::min<uint32_t>(multisamples, static_cast<uint32_t>(maxMultiSampleBufferFormatSamples))
+		: 0u;
+	inputs.sceneMsaaSamples = (clampedMsaa > 0) ? clampedMsaa : 1u;
+	inputs.swapchainMsaaSamples = 1;
+	inputs.presentColorFormat = gfx_api::pixel_format::FORMAT_RGBA8_UNORM_PACK8;
+	return inputs;
+}
+
+gfx_api::SurfaceCapabilityHints gl_context::surfaceCapabilities() const
+{
+	gfx_api::SurfaceCapabilityHints caps;
+	const uint32_t clampedMsaa = (multisamples > 0 && maxMultiSampleBufferFormatSamples > 0)
+		? std::min<uint32_t>(multisamples, static_cast<uint32_t>(maxMultiSampleBufferFormatSamples))
+		: 0u;
+	// When MSAA is active, scene color must match the MSAA renderbuffer format (RGBA8)
+	// on both desktop GL and GLES.
+	caps.sceneColorFormat = (clampedMsaa > 1)
+		? gfx_api::pixel_format::FORMAT_RGBA8_UNORM_PACK8
+		: gfx_api::pixel_format::FORMAT_RGB8_UNORM_PACK8;
+	caps.depthStencilFormat = gfx_api::pixel_format::FORMAT_D24_UNORM_S8;
+	caps.depthSampledFormat = gfx_api::pixel_format::FORMAT_D32_SFLOAT;
+	return caps;
+}
+
+bool gl_context::ensurePipelineSurfaces(const gfx_api::ResolvedSurfaceTable& specs)
+{
+	PipelineSurfaceAllocator alloc(*this);
+	return _pipelineSurfaces.ensure(specs, alloc);
 }
 
 [[noreturn]] static void glContextHandleOOMError()
@@ -4602,7 +4642,7 @@ void gl_context::applyAttachmentStoreOps(const gfx_api::RenderPassDesc& pass, ui
 	// Performance optimization:
 	//
 	// Before switching the draw framebuffer, call glInvalidateFramebuffer on any parts of the scene framebuffer(s) that we can
-	// NOTE: The only one we need to keep around by the end is sceneTexture, which is bound as GL_COLOR_ATTACHMENT0 on one of the FBOs
+	// NOTE: SceneColor remains the resolved color target used by later passes / blits.
 	// However: If using the sceneMsaaRBO, we have to keep that around initially, and only invalidate it after resolving with glBlitFramebuffer
 	//
 	// Support:
@@ -5242,7 +5282,10 @@ void gl_context::handleWindowSizeChange(unsigned int oldWidth, unsigned int oldH
 		{
 			sceneFramebufferWidth = newSceneFramebufferWidth;
 			sceneFramebufferHeight = newSceneFramebufferHeight;
-			createSceneRenderpass();
+			if (!syncPipelineSurfaces())
+			{
+				debug(LOG_ERROR, "syncPipelineSurfaces failed after window size change");
+			}
 		}
 	}
 	else
@@ -5265,8 +5308,6 @@ bool gl_context::shouldDraw()
 
 void gl_context::shutdown()
 {
-	clearDynamicFBOCache();
-
 #if !defined(WZ_STATIC_GL_BINDINGS)
 	if (glClear)
 #endif
@@ -5274,14 +5315,7 @@ void gl_context::shutdown()
 		glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT | GL_STENCIL_BUFFER_BIT);
 	}
 
-	deleteSceneRenderpass();
-	destroySwapchainPipelineSurfaces();
-
-	if (depthTexture)
-	{
-		delete depthTexture;
-		depthTexture = nullptr;
-	}
+	resetAllPipelineSurfaceSlots();
 
 	if (pDefaultTexture)
 	{
@@ -5512,168 +5546,151 @@ void gl_context::clearDynamicFBOCache()
 	});
 }
 
-size_t gl_context::initDepthPasses(size_t resolution)
+void gl_context::PipelineSurfaceAllocator::destroy(gfx_api::PipelineSurfaceId id, gfx_api::abstract_texture* /*texture*/)
 {
-	clearDynamicFBOCache();
+	ASSERT_OR_RETURN(, id != gfx_api::PipelineSurfaceId::Count, "Invalid pipeline surface id");
+	root._surfaceGpu[static_cast<size_t>(id)].texture.reset();
+}
 
-	depthPassCount = std::min<size_t>(depthPassCount, WZ_MAX_SHADOW_CASCADES);
+bool gl_context::PipelineSurfaceAllocator::create(gfx_api::PipelineSurfaceId id, const gfx_api::ResolvedSurfaceSpec& createSpec,
+	gfx_api::abstract_texture*& outTexture)
+{
+	outTexture = nullptr;
+	ASSERT_OR_RETURN(false, id != gfx_api::PipelineSurfaceId::Count, "Invalid pipeline surface id");
+	GlSurfaceGpu& gpu = root._surfaceGpu[static_cast<size_t>(id)];
 
-#if !defined(__EMSCRIPTEN__)
-	if (depthPassCount > 1)
+	wzGLClearErrors();
+
+	const GLsizei glSamples = (createSpec.samples > 1) ? static_cast<GLsizei>(createSpec.samples) : 0;
+
+	switch (createSpec.provisionMode)
 	{
-		if ((!gles && !GLAD_GL_VERSION_3_0) || (gles && !GLAD_GL_ES_VERSION_3_0))
+	case gfx_api::SurfaceProvisionMode::WsiPresentColor:
+		gpu.texture = std::make_unique<gl_pipeline_surface_proxy>(GLPipelineSurfaceKind::SwapchainColor);
+		break;
+
+	case gfx_api::SurfaceProvisionMode::WsiPresentDepth:
+		gpu.texture = std::make_unique<gl_pipeline_surface_proxy>(GLPipelineSurfaceKind::SwapchainDepth);
+		break;
+
+	case gfx_api::SurfaceProvisionMode::Allocate:
+		switch (createSpec.storageKind)
 		{
-			// glFramebufferTextureLayer requires OpenGL 3.0+ / ES 3.0+
-			debug(LOG_ERROR, "Cannot create depth texture array - requires OpenGL 3.0+ / OpenGL ES 3.0+ - this will fail");
+		case gfx_api::SurfaceStorageKind::SampledColor2D:
+		{
+			const bool useRgba = (createSpec.format == gfx_api::pixel_format::FORMAT_RGBA8_UNORM_PACK8);
+			const GLenum colorInternalFormat = useRgba ? root.multiSampledBufferInternalFormat : GL_RGB8;
+			const GLenum colorBaseFormat = useRgba ? root.multiSampledBufferBaseFormat : GL_RGB;
+			auto* sceneTex = root.create_framebuffer_color_texture(colorInternalFormat, colorBaseFormat, GL_UNSIGNED_BYTE,
+				createSpec.width, createSpec.height, "<scene texture>");
+			if (!sceneTex)
+			{
+				debug(LOG_ERROR, "Failed to create scene color texture (%" PRIu32 " x %" PRIu32 ")", createSpec.width, createSpec.height);
+				return false;
+			}
+			// Own immediately so any later ASSERT_GL early-return frees the texture.
+			gpu.texture.reset(sceneTex);
+			ASSERT_GL_NOERRORS_OR_RETURN(false);
+			sceneTex->bind();
+			ASSERT_GL_NOERRORS_OR_RETURN(false);
+			glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+			ASSERT_GL_NOERRORS_OR_RETURN(false);
+			glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+			ASSERT_GL_NOERRORS_OR_RETURN(false);
+			sceneTex->unbind();
+			ASSERT_GL_NOERRORS_OR_RETURN(false);
+			break;
 		}
-	}
-#endif
-
-	// delete prior depth texture (if present)
-	if (depthTexture)
-	{
-		_pipelineSurfaces.invalidateSurface(gfx_api::PipelineSurfaceId::ShadowMap);
-		delete depthTexture;
-		depthTexture = nullptr;
-	}
-
-	if (depthPassCount == 0)
-	{
-		return 0;
-	}
-
-	auto pNewDepthTexture = create_depthmap_texture(depthPassCount, resolution, resolution, "<depth map>");
-	if (!pNewDepthTexture)
-	{
-		debug(LOG_ERROR, "Failed to create depth texture");
-		return 0;
-	}
-	depthTexture = pNewDepthTexture;
-	_pipelineSurfaces.registerSurface(gfx_api::PipelineSurfaceId::ShadowMap, depthTexture);
-
-	GLenum target = depthTexture->target();
-	depthTexture->bind();
-	glTexParameteri(target, GL_TEXTURE_COMPARE_FUNC, GL_LEQUAL);
-	glTexParameteri(target, GL_TEXTURE_COMPARE_MODE, GL_COMPARE_REF_TO_TEXTURE);
-	depthTexture->unbind();
-
-	return depthPassCount;
-}
-
-void gl_context::deleteSceneRenderpass()
-{
-	clearDynamicFBOCache();
-
-	_pipelineSurfaces.invalidateSurface(gfx_api::PipelineSurfaceId::SceneColor);
-	_pipelineSurfaces.invalidateSurface(gfx_api::PipelineSurfaceId::SceneMSAAColor);
-	_pipelineSurfaces.invalidateSurface(gfx_api::PipelineSurfaceId::SceneDepth);
-
-	// delete prior scene texture & FBOs (if present)
-#if !defined(WZ_STATIC_GL_BINDINGS)
-	if (glDeleteFramebuffers)
-#endif
-	{
-	}
-	_sceneMsaaSurface.reset();
-	if (sceneTexture)
-	{
-		delete sceneTexture;
-		sceneTexture = nullptr;
-	}
-	_sceneDepthStencilSurface.reset();
-}
-
-void gl_context::destroySwapchainPipelineSurfaces()
-{
-	_pipelineSurfaces.invalidateSurface(gfx_api::PipelineSurfaceId::SwapchainColor);
-	_pipelineSurfaces.invalidateSurface(gfx_api::PipelineSurfaceId::SwapchainMSAAColor);
-	_pipelineSurfaces.invalidateSurface(gfx_api::PipelineSurfaceId::SwapchainDepth);
-	_swapchainColorSurface.reset();
-	_swapchainDepthSurface.reset();
-}
-
-void gl_context::registerSwapchainPipelineSurfaces()
-{
-	destroySwapchainPipelineSurfaces();
-
-	_swapchainColorSurface = std::make_unique<gl_pipeline_surface_proxy>(GLPipelineSurfaceKind::SwapchainColor);
-	_swapchainDepthSurface = std::make_unique<gl_pipeline_surface_proxy>(GLPipelineSurfaceKind::SwapchainDepth);
-	_pipelineSurfaces.registerSurface(gfx_api::PipelineSurfaceId::SwapchainColor, _swapchainColorSurface.get());
-	_pipelineSurfaces.registerSurface(gfx_api::PipelineSurfaceId::SwapchainDepth, _swapchainDepthSurface.get());
-	_pipelineSurfaces.invalidateSurface(gfx_api::PipelineSurfaceId::SwapchainMSAAColor);
-}
-
-bool gl_context::createSceneRenderpass()
-{
-	deleteSceneRenderpass();
-
+		case gfx_api::SurfaceStorageKind::MsaaColorAttachment:
+		{
+			const GLenum msaaFormat = (createSpec.format == gfx_api::pixel_format::FORMAT_RGBA8_UNORM_PACK8)
+				? root.multiSampledBufferInternalFormat
+				: GL_RGB8;
+			auto msaa = root.create_framebuffer_renderbuffer(msaaFormat, glSamples,
+				createSpec.width, createSpec.height, "<scene msaa color>");
+			ASSERT_OR_RETURN(false, msaa != nullptr, "Failed to create MSAA color renderbuffer");
+			ASSERT_GL_NOERRORS_OR_RETURN(false);
+			gpu.texture = std::move(msaa);
+			break;
+		}
+		case gfx_api::SurfaceStorageKind::DepthStencilAttachment:
+		{
+			GLenum depthInternalFormat = GL_DEPTH24_STENCIL8;
+			switch (createSpec.format)
+			{
+			case gfx_api::pixel_format::FORMAT_D24_UNORM_S8:
+				depthInternalFormat = GL_DEPTH24_STENCIL8;
+				break;
+			case gfx_api::pixel_format::FORMAT_D32_SFLOAT_S8_UINT:
+				depthInternalFormat = GL_DEPTH32F_STENCIL8;
+				break;
+			case gfx_api::pixel_format::FORMAT_D32_SFLOAT:
+				depthInternalFormat = GL_DEPTH_COMPONENT32F;
+				break;
+			default:
+				debug(LOG_WARNING, "Unsupported depth/stencil format for GL renderbuffer; using DEPTH24_STENCIL8");
+				depthInternalFormat = GL_DEPTH24_STENCIL8;
+				break;
+			}
+			auto depthRb = root.create_framebuffer_renderbuffer(depthInternalFormat, glSamples,
+				createSpec.width, createSpec.height, "<scene depth stencil>");
+			ASSERT_OR_RETURN(false, depthRb != nullptr, "Failed to create depth/stencil renderbuffer");
+			ASSERT_GL_NOERRORS_OR_RETURN(false);
+			gpu.texture = std::move(depthRb);
+			break;
+		}
+		case gfx_api::SurfaceStorageKind::SampledDepthArray:
+		{
 #if !defined(__EMSCRIPTEN__)
-	if ( ! ((!gles && GLAD_GL_VERSION_3_0) || (gles && GLAD_GL_ES_VERSION_3_0)) )
-	{
-		// The following requires OpenGL 3.0+ or OpenGL ES 3.0+
-		debug(LOG_ERROR, "Unsupported version of OpenGL / OpenGL ES.");
-		return false;
-	}
+			if (createSpec.arrayLayers > 1)
+			{
+				if ((!root.gles && !GLAD_GL_VERSION_3_0) || (root.gles && !GLAD_GL_ES_VERSION_3_0))
+				{
+					// glFramebufferTextureLayer requires OpenGL 3.0+ / ES 3.0+
+					debug(LOG_ERROR, "Cannot create depth texture array - requires OpenGL 3.0+ / OpenGL ES 3.0+ - this will fail");
+				}
+			}
 #endif
-
-	wzGLClearErrors(); // clear OpenGL error states
-
-	bool encounteredError = false;
-	GLsizei samples = std::min<GLsizei>(multisamples, maxMultiSampleBufferFormatSamples);
-
-	if (samples > 0)
-	{
-		_sceneMsaaSurface = create_framebuffer_renderbuffer(multiSampledBufferInternalFormat, samples,
-			sceneFramebufferWidth, sceneFramebufferHeight, "<scene msaa color>");
-		ASSERT_OR_RETURN(false, _sceneMsaaSurface != nullptr, "Failed to create scene MSAA renderbuffer");
-		ASSERT_GL_NOERRORS_OR_RETURN(false);
+			auto* depthMap = root.create_depthmap_texture(createSpec.arrayLayers, createSpec.width, createSpec.height, "<depth map>");
+			if (!depthMap)
+			{
+				debug(LOG_ERROR, "Failed to create depth texture");
+				return false;
+			}
+			GLenum target = depthMap->target();
+			depthMap->bind();
+			glTexParameteri(target, GL_TEXTURE_COMPARE_FUNC, GL_LEQUAL);
+			glTexParameteri(target, GL_TEXTURE_COMPARE_MODE, GL_COMPARE_REF_TO_TEXTURE);
+			depthMap->unbind();
+			gpu.texture.reset(depthMap);
+			break;
+		}
+		case gfx_api::SurfaceStorageKind::None:
+			debug(LOG_ERROR, "Allocate surface %u has storageKind None", static_cast<unsigned>(id));
+			return false;
+		}
+		break;
 	}
 
-	// Always create a standard color texture (for the resolved color values)
-	// NOTE:
-	// - OpenGL ES: color texture format must *MATCH* the format used for the multisampled color render buffer
-	GLenum colorInternalFormat = (samples > 0 && gles) ? multiSampledBufferInternalFormat : GL_RGB8;
-	GLenum colorBaseFormat = (samples > 0 && gles) ? multiSampledBufferBaseFormat : GL_RGB;
-	auto pNewSceneTexture = create_framebuffer_color_texture(colorInternalFormat, colorBaseFormat, GL_UNSIGNED_BYTE, sceneFramebufferWidth, sceneFramebufferHeight, "<scene texture>");
-	ASSERT_GL_NOERRORS_OR_RETURN(false);
-	if (!pNewSceneTexture)
-	{
-		debug(LOG_ERROR, "Failed to create scene color texture (%" PRIu32 " x %" PRIu32 ")", sceneFramebufferWidth, sceneFramebufferHeight);
-		return false;
-	}
-	sceneTexture = pNewSceneTexture;
-	sceneTexture->bind();
-	ASSERT_GL_NOERRORS_OR_RETURN(false);
-	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-	ASSERT_GL_NOERRORS_OR_RETURN(false);
-	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-	ASSERT_GL_NOERRORS_OR_RETURN(false);
-	sceneTexture->unbind();
-	ASSERT_GL_NOERRORS_OR_RETURN(false);
+	outTexture = gpu.texture.get();
+	return outTexture != nullptr;
+}
 
-	_sceneDepthStencilSurface = create_framebuffer_renderbuffer(GL_DEPTH24_STENCIL8, samples,
-		sceneFramebufferWidth, sceneFramebufferHeight, "<scene depth stencil>");
-	ASSERT_OR_RETURN(false, _sceneDepthStencilSurface != nullptr, "Failed to create scene depth/stencil renderbuffer");
-	ASSERT_GL_NOERRORS_OR_RETURN(false);
+void gl_context::PipelineSurfaceAllocator::prepareForSurfaceDestroy()
+{
+	root.clearDynamicFBOCache();
+}
 
-	ASSERT_GL_NOERRORS_OR_RETURN(false);
+void gl_context::PipelineSurfaceAllocator::onChanged()
+{
+	root.clearDynamicFBOCache();
+	root.bumpRenderGraphEpoch();
+}
 
-	_pipelineSurfaces.registerSurface(gfx_api::PipelineSurfaceId::SceneColor, sceneTexture);
-	_pipelineSurfaces.registerSurface(gfx_api::PipelineSurfaceId::SceneDepth, _sceneDepthStencilSurface.get());
-	const uint32_t sceneSamples = (samples > 0) ? static_cast<uint32_t>(samples) : 1u;
-	_pipelineSurfaces.setSurfaceSamples(gfx_api::PipelineSurfaceId::SceneDepth, sceneSamples);
-	if (_sceneMsaaSurface != nullptr)
-	{
-		_pipelineSurfaces.registerSurface(gfx_api::PipelineSurfaceId::SceneMSAAColor, _sceneMsaaSurface.get());
-		_pipelineSurfaces.setSurfaceSamples(gfx_api::PipelineSurfaceId::SceneMSAAColor, sceneSamples);
-	}
-	else
-	{
-		_pipelineSurfaces.invalidateSurface(gfx_api::PipelineSurfaceId::SceneMSAAColor);
-	}
-
-	bumpRenderGraphEpoch();
-	return !encounteredError;
+void gl_context::resetAllPipelineSurfaceSlots()
+{
+	PipelineSurfaceAllocator alloc(*this);
+	_pipelineSurfaces.resetAll(alloc);
 }
 
 void gl_context::purgeFrameResources()
@@ -5715,7 +5732,8 @@ optional<std::pair<uint32_t, uint32_t>> gl_context::getRenderTargetDimensions(gf
 			return std::make_pair(viewportWidth, viewportHeight);
 		}
 	}
-	if (texture == sceneTexture && sceneFramebufferWidth > 0 && sceneFramebufferHeight > 0)
+	if (texture == getPipelineSurface(gfx_api::PipelineSurfaceId::SceneColor)
+		&& sceneFramebufferWidth > 0 && sceneFramebufferHeight > 0)
 	{
 		return std::make_pair(sceneFramebufferWidth, sceneFramebufferHeight);
 	}

--- a/lib/ivis_opengl/gfx_api_gl.h
+++ b/lib/ivis_opengl/gfx_api_gl.h
@@ -190,6 +190,14 @@ struct gl_pipeline_surface_proxy final : public gfx_api::abstract_texture
 	size_t backend_internal_value() const override;
 };
 
+struct gl_context;
+
+/// Backend-owned GPU objects for one pipeline surface (store holds non-owning texture*).
+struct GlSurfaceGpu
+{
+	std::unique_ptr<gfx_api::abstract_texture> texture;
+};
+
 struct gl_buffer final : public gfx_api::buffer
 {
 	gfx_api::buffer::usage usage;
@@ -374,12 +382,16 @@ struct gl_context final : public gfx_api::context
 	virtual void finishScreenFrame() override;
 	virtual size_t getDepthPassDimensions(size_t idx) override;
 	virtual gfx_api::abstract_texture* getPipelineSurface(gfx_api::PipelineSurfaceId id) override;
-	virtual gfx_api::PipelineSurfaceMeta pipelineSurfaceMeta(gfx_api::PipelineSurfaceId id) const override;
+	virtual gfx_api::PipelineSurfaceUsage pipelineSurfaceUsage(gfx_api::PipelineSurfaceId id) const override;
+	virtual const gfx_api::ResolvedSurfaceSpec& resolvedPipelineSurface(gfx_api::PipelineSurfaceId id) const override;
 	virtual nonstd::optional<gfx_api::PipelineSurfaceId> findPipelineSurfaceId(gfx_api::abstract_texture* texture) const override;
 	virtual bool isSceneMSAAEnabled() const override;
 	virtual bool isSwapchainMSAAEnabled() const override;
 	virtual bool isMultisampledColorAttachment(gfx_api::abstract_texture* texture) const override;
 	virtual gfx_api::pixel_format getDepthStencilFormat() const override;
+	virtual gfx_api::PipelineSurfaceSyncInputs pipelineSurfaceSyncInputs() const override;
+	virtual gfx_api::SurfaceCapabilityHints surfaceCapabilities() const override;
+	virtual bool ensurePipelineSurfaces(const gfx_api::ResolvedSurfaceTable& specs) override;
 	virtual void purgeFrameResources() override;
 	virtual optional<std::pair<uint32_t, uint32_t>> getRenderTargetDimensions(gfx_api::abstract_texture* texture) override;
 	virtual void warmCompiledRenderGraph(std::vector<gfx_api::RenderPassDesc>& passes,
@@ -422,18 +434,27 @@ private:
 	void initPixelFormatsSupport();
 	bool initInstancedFunctions();
 	bool initCheckBorderClampSupport();
-	size_t initDepthPasses(size_t resolution);
 	gl_gpurendered_texture* create_gpurendered_texture(GLenum internalFormat, GLenum format, GLenum type, const size_t& width, const size_t& height, const std::string& filename);
 	gl_gpurendered_texture* create_gpurendered_texture_array(GLenum internalFormat, GLenum format, GLenum type, const size_t& width, const size_t& height, const size_t& layer_count, const std::string& filename);
 	gl_gpurendered_texture* create_depthmap_texture(const size_t& layer_count, const size_t& width, const size_t& height, const std::string& filename);
 	gl_gpurendered_texture* create_framebuffer_color_texture(GLenum internalFormat, GLenum format, GLenum type, const size_t& width, const size_t& height, const std::string& filename);
+	/// Create a color or depth/stencil renderbuffer.
+	/// Pass samples == 0 for non-multisampled storage; samples > 1 selects glRenderbufferStorageMultisample.
 	std::unique_ptr<gl_gpurendered_renderbuffer> create_framebuffer_renderbuffer(GLenum internalFormat, GLsizei samples,
 		uint32_t width, uint32_t height, const std::string& filename);
 	bool createDefaultTextures();
-	bool createSceneRenderpass();
-	void registerSwapchainPipelineSurfaces();
-	void destroySwapchainPipelineSurfaces();
-	void deleteSceneRenderpass();
+	void resetAllPipelineSurfaceSlots();
+
+	struct PipelineSurfaceAllocator final : gfx_api::SurfaceAllocator
+	{
+		gl_context& root;
+		explicit PipelineSurfaceAllocator(gl_context& r) : root(r) {}
+		bool create(gfx_api::PipelineSurfaceId id, const gfx_api::ResolvedSurfaceSpec& spec,
+			gfx_api::abstract_texture*& outTexture) override;
+		void destroy(gfx_api::PipelineSurfaceId id, gfx_api::abstract_texture* texture) override;
+		void prepareForSurfaceDestroy() override;
+		void onChanged() override;
+	};
 
 protected:
 	friend struct gl_pipeline_state_object;
@@ -488,7 +509,6 @@ private:
 	gl_texture_array *pDefaultArrayTexture = nullptr;
 	gl_gpurendered_texture *pDefaultDepthTexture = nullptr;
 
-	gl_gpurendered_texture* depthTexture = nullptr;
 	size_t depthBufferResolution = 4096;
 	size_t depthPassCount = WZ_MAX_SHADOW_CASCADES;
 
@@ -498,13 +518,9 @@ private:
 	GLenum multiSampledBufferBaseFormat = GL_INVALID_ENUM;
 	GLint maxMultiSampleBufferFormatSamples = 0;
 	uint32_t multisamples = 0;
-	gl_gpurendered_texture* sceneTexture = nullptr;
-	std::unique_ptr<gl_gpurendered_renderbuffer> _sceneMsaaSurface;
-	std::unique_ptr<gl_gpurendered_renderbuffer> _sceneDepthStencilSurface;
-	std::unique_ptr<gl_pipeline_surface_proxy> _swapchainColorSurface;
-	std::unique_ptr<gl_pipeline_surface_proxy> _swapchainDepthSurface;
 
-	gfx_api::PipelineSurfaceRegistry _pipelineSurfaces;
+	std::array<GlSurfaceGpu, gfx_api::PIPELINE_SURFACE_COUNT> _surfaceGpu {};
+	gfx_api::PipelineSurfaceStore _pipelineSurfaces;
 	gfx_api::DynamicFBOCache _dynamicFBOCache;
 
 	GLuint _dynamicPassFBO = 0;

--- a/lib/ivis_opengl/gfx_api_null.cpp
+++ b/lib/ivis_opengl/gfx_api_null.cpp
@@ -448,6 +448,11 @@ void null_context::beginScreenFrame()
 	purgeFrameResources();
 }
 
+bool null_context::ensurePipelineSurfaces(const gfx_api::ResolvedSurfaceTable& /*specs*/)
+{
+	return true;
+}
+
 void null_context::finishScreenFrame()
 {
 	if (frameHasDrawCommands)

--- a/lib/ivis_opengl/gfx_api_null.h
+++ b/lib/ivis_opengl/gfx_api_null.h
@@ -132,6 +132,7 @@ public:
 	virtual void endPass(const gfx_api::CompiledPass* compiledPass = nullptr) override;
 	virtual void beginScreenFrame() override;
 	virtual void finishScreenFrame() override;
+	virtual bool ensurePipelineSurfaces(const gfx_api::ResolvedSurfaceTable& specs) override;
 	virtual void purgeFrameResources() override;
 	virtual void warmCompiledRenderGraph(std::vector<gfx_api::RenderPassDesc>& passes,
 		gfx_api::PassGraphCompileResult& compileResult) override;

--- a/lib/ivis_opengl/gfx_api_vk.cpp
+++ b/lib/ivis_opengl/gfx_api_vk.cpp
@@ -216,7 +216,6 @@ enum class VulkanBackendInternalTextureType : size_t
 	RenderedImage,
 	AttachmentImage,
 	SwapchainColorSurface,
-	SwapchainMsaaColorSurface,
 	SwapchainDepthSurface,
 };
 
@@ -2563,25 +2562,6 @@ size_t VkSwapchainColorSurface::backend_internal_value() const
 	return static_cast<size_t>(VulkanBackendInternalTextureType::SwapchainColorSurface);
 }
 
-// MARK: VkSwapchainMsaaColorSurface
-
-VkSwapchainMsaaColorSurface::VkSwapchainMsaaColorSurface(const VkRoot& rootRef, vk::Format format,
-	vk::SampleCountFlagBits sampleCount)
-	: root(rootRef)
-	, imageFormat(format)
-	, samples(sampleCount)
-{
-}
-
-VkSwapchainMsaaColorSurface::~VkSwapchainMsaaColorSurface() = default;
-
-void VkSwapchainMsaaColorSurface::bind() { }
-
-size_t VkSwapchainMsaaColorSurface::backend_internal_value() const
-{
-	return static_cast<size_t>(VulkanBackendInternalTextureType::SwapchainMsaaColorSurface);
-}
-
 // MARK: VkSwapchainDepthSurface
 
 VkSwapchainDepthSurface::VkSwapchainDepthSurface(const VkRoot& rootRef, vk::Format format,
@@ -3019,203 +2999,264 @@ static void createDepthStencilImage(const vk::PhysicalDevice& physicalDevice, co
 										 vkDynLoader, loggingKey);
 }
 
-void VkRoot::destroySwapchainPipelineSurfaces()
+namespace
 {
-	_pipelineSurfaces.invalidateSurface(gfx_api::PipelineSurfaceId::SwapchainColor);
-	_pipelineSurfaces.invalidateSurface(gfx_api::PipelineSurfaceId::SwapchainMSAAColor);
-	_pipelineSurfaces.invalidateSurface(gfx_api::PipelineSurfaceId::SwapchainDepth);
-	_swapchainColorSurface.reset();
-	_swapchainMsaaColorSurface.reset();
-	_swapchainDepthSurface.reset();
-}
 
-void VkRoot::registerSwapchainPipelineSurfaces(vk::Format colorFormat, vk::Format depthFormat)
+vk::SampleCountFlagBits toVkSampleCount(uint32_t samples)
 {
-	destroySwapchainPipelineSurfaces();
-
-	_swapchainColorSurface = std::make_unique<VkSwapchainColorSurface>(*this, colorFormat);
-	_pipelineSurfaces.registerSurface(gfx_api::PipelineSurfaceId::SwapchainColor, _swapchainColorSurface.get());
-
-	_swapchainDepthSurface = std::make_unique<VkSwapchainDepthSurface>(*this, depthFormat, msaaSamplesSwapchain);
-	_pipelineSurfaces.registerSurface(gfx_api::PipelineSurfaceId::SwapchainDepth, _swapchainDepthSurface.get());
-	const uint32_t swapchainDepthSamples = static_cast<uint32_t>(msaaSamplesSwapchain);
-	_pipelineSurfaces.setSurfaceSamples(gfx_api::PipelineSurfaceId::SwapchainDepth, swapchainDepthSamples);
-
-	if (msaaSamplesSwapchain != vk::SampleCountFlagBits::e1)
+	switch (samples)
 	{
-		_swapchainMsaaColorSurface = std::make_unique<VkSwapchainMsaaColorSurface>(*this, colorFormat, msaaSamplesSwapchain);
-		_pipelineSurfaces.registerSurface(gfx_api::PipelineSurfaceId::SwapchainMSAAColor, _swapchainMsaaColorSurface.get());
-		_pipelineSurfaces.setSurfaceSamples(gfx_api::PipelineSurfaceId::SwapchainMSAAColor, swapchainDepthSamples);
+	case 2: return vk::SampleCountFlagBits::e2;
+	case 4: return vk::SampleCountFlagBits::e4;
+	case 8: return vk::SampleCountFlagBits::e8;
+	case 16: return vk::SampleCountFlagBits::e16;
+	case 32: return vk::SampleCountFlagBits::e32;
+	case 64: return vk::SampleCountFlagBits::e64;
+	default: return vk::SampleCountFlagBits::e1;
 	}
 }
 
-void VkRoot::createDepthPassImages(vk::Format depthFormat)
+void destroySurfaceGpuImage(VkRoot& root, VkSurfaceGpu& gpu)
 {
-	clearFramebufferCache();
-
-	auto& frameResources = buffering_mechanism::get_current_resources();
-	for (auto& imageView : depthMapCascadeView)
+	if (buffering_mechanism::isInitialized())
 	{
-		if (buffering_mechanism::isInitialized())
+		// Runtime ensure may recreate surfaces while command buffers still reference the
+		// previous view/image/memory - defer until the frame slot is recycled.
+		auto& frameResources = buffering_mechanism::get_current_resources();
+		if (gpu.view)
 		{
-			// Queue for future deletion
-			frameResources.image_view_to_delete.emplace_back(std::move(imageView));
+#if VK_HEADER_VERSION >= 301
+			using ImageViewDestroy = vk::detail::ObjectDestroy<vk::Device, WZ_vk::DispatchLoaderDynamic>;
+#else
+			using ImageViewDestroy = vk::ObjectDestroy<vk::Device, WZ_vk::DispatchLoaderDynamic>;
+#endif
+			frameResources.image_view_to_delete.emplace_back(
+				WZ_vk::UniqueImageView(gpu.view, ImageViewDestroy(root.dev, nullptr, root.vkDynLoader)));
+			gpu.view = vk::ImageView();
 		}
-		else
+		if (gpu.image)
 		{
-			imageView.reset();
+			frameResources.image_to_delete.emplace_back(gpu.image);
+			gpu.image = vk::Image();
 		}
-	}
-	depthMapCascadeView.clear();
-	if (pDepthMapImage)
-	{
-		_pipelineSurfaces.invalidateSurface(gfx_api::PipelineSurfaceId::ShadowMap);
-		// Destructor will automatically queue resources for future deletion once they are unused
-		delete pDepthMapImage;
-		pDepthMapImage = nullptr;
-	}
-
-	if (depthPassCount == 0)
-	{
+		if (gpu.memory)
+		{
+			frameResources.devicememory_to_free.emplace_back(gpu.memory);
+			gpu.memory = vk::DeviceMemory();
+		}
 		return;
 	}
 
-	// Create depth map image + view
-	size_t numCascadeLayers = depthPassCount;
-	pDepthMapImage = new VkDepthMapImage(*this, numCascadeLayers, depthMapSize, depthFormat, "<depth map>");
-	_pipelineSurfaces.registerSurface(gfx_api::PipelineSurfaceId::ShadowMap, pDepthMapImage);
-
-	// For each depth pass (cascade)
-	for (size_t i = 0; i < numCascadeLayers; ++i)
+	// Buffering gone (shutdown / post-idle hard reset after buffering_mechanism::destroy).
+	if (gpu.view)
 	{
-		// Image view for just this layer
-		const auto imageViewCreateInfo = vk::ImageViewCreateInfo()
-			.setImage(pDepthMapImage->object)
-			.setViewType(vk::ImageViewType::e2DArray)
-			.setFormat(depthFormat)
-			.setComponents(vk::ComponentMapping())
-			.setSubresourceRange(vk::ImageSubresourceRange(vk::ImageAspectFlagBits::eDepth, 0, 1, static_cast<uint32_t>(i), 1));
-
-		auto cascade_view = dev.createImageViewUnique(imageViewCreateInfo, nullptr, vkDynLoader);
-
-		vk::ImageView non_unique_imageview_ref = cascade_view.get();
-
-		if (debugUtilsExtEnabled)
-		{
-			std::string imageViewName = "<depth cascade image view: " + std::to_string(i) + ">";
-			vk::DebugUtilsObjectNameInfoEXT objectNameInfo;
-			objectNameInfo.setObjectType(vk::ObjectType::eImageView);
-			objectNameInfo.setObjectHandle(uint64_t(static_cast<VkImageView>(non_unique_imageview_ref)));
-			objectNameInfo.setPObjectName(imageViewName.c_str());
-			dev.setDebugUtilsObjectNameEXT(objectNameInfo, vkDynLoader);
-		}
-
-		depthMapCascadeView.push_back(std::move(cascade_view));
+		root.dev.destroyImageView(gpu.view, nullptr, root.vkDynLoader);
+		gpu.view = vk::ImageView();
+	}
+	if (gpu.image)
+	{
+		root.dev.destroyImage(gpu.image, nullptr, root.vkDynLoader);
+		gpu.image = vk::Image();
+	}
+	if (gpu.memory)
+	{
+		root.dev.freeMemory(gpu.memory, nullptr, root.vkDynLoader);
+		gpu.memory = vk::DeviceMemory();
 	}
 }
 
-void VkRoot::destroySceneRenderpass()
+const char* pipelineSurfaceDebugName(gfx_api::PipelineSurfaceId id)
 {
-	clearFramebufferCache();
-
-	_pipelineSurfaces.invalidateSurface(gfx_api::PipelineSurfaceId::SceneColor);
-	_pipelineSurfaces.invalidateSurface(gfx_api::PipelineSurfaceId::SceneMSAAColor);
-	_pipelineSurfaces.invalidateSurface(gfx_api::PipelineSurfaceId::SceneDepth);
-	_sceneDepthSurface.reset();
-	_sceneMsaaSurface.reset();
-
-	if (sceneDepthStencilView)
+	switch (id)
 	{
-		dev.destroyImageView(sceneDepthStencilView, nullptr, vkDynLoader);
-		sceneDepthStencilView = vk::ImageView();
-	}
-	if (sceneDepthStencilMemory)
-	{
-		dev.freeMemory(sceneDepthStencilMemory, nullptr, vkDynLoader);
-		sceneDepthStencilMemory = vk::DeviceMemory();
-	}
-	if (sceneDepthStencilImage)
-	{
-		dev.destroyImage(sceneDepthStencilImage, nullptr, vkDynLoader);
-		sceneDepthStencilImage = vk::Image();
-	}
-
-	if (sceneMSAAView)
-	{
-		dev.destroyImageView(sceneMSAAView, nullptr, vkDynLoader);
-		sceneMSAAView = vk::ImageView();
-	}
-	if (sceneMSAAMemory)
-	{
-		dev.freeMemory(sceneMSAAMemory, nullptr, vkDynLoader);
-		sceneMSAAMemory = vk::DeviceMemory();
-	}
-	if (sceneMSAAImage)
-	{
-		dev.destroyImage(sceneMSAAImage, nullptr, vkDynLoader);
-		sceneMSAAImage = vk::Image();
-	}
-
-	if (pSceneImage)
-	{
-		pSceneImage->destroy(dev, allocator, vkDynLoader); // because the buffering_mechanism may be gone by the time this is called...
-		delete pSceneImage;
-		pSceneImage = nullptr;
+	case gfx_api::PipelineSurfaceId::SceneColor: return "<scene image>";
+	case gfx_api::PipelineSurfaceId::SceneMSAAColor: return "<scene msaa color>";
+	case gfx_api::PipelineSurfaceId::SceneDepth: return "<scene depth stencil>";
+	case gfx_api::PipelineSurfaceId::ShadowMap: return "<depth map>";
+	case gfx_api::PipelineSurfaceId::SwapchainMSAAColor: return "<swapchain msaa color>";
+	default: return "<pipeline surface>";
 	}
 }
 
-// throws a vk::SystemError on an unrecoverable error (like OOM)
-void VkRoot::createSceneRenderpass(vk::Format sceneFormat, vk::Format depthFormat)
+const char* pipelineSurfaceImageKey(gfx_api::PipelineSurfaceId id)
 {
-	const bool msaaEnabled = (msaaSamples != vk::SampleCountFlagBits::e1);
-
-	// Create scene color/depth (and optional MSAA) images and register pipeline surfaces.
-	// VkRenderPass objects are created later by RenderPassLayoutCache::getOrCreate via beginPass / warmCompiledRenderGraph.
-	pSceneImage = new VkRenderedImage(*this, swapchainSize.width, swapchainSize.height, sceneFormat, "<scene image>");
-
-	if (msaaEnabled)
+	switch (id)
 	{
-		// create sceneMSAAImage / sceneMSAAView / etc
-		try {
-			createColorAttachmentImage(physicalDevice, memprops, dev, swapchainSize, msaaSamples, sceneFormat,
-									   sceneMSAAImage, sceneMSAAMemory, sceneMSAAView, vkDynLoader, "sceneMSAAColorImage");
-		}
-		catch (const vk::SystemError& e)
+	case gfx_api::PipelineSurfaceId::SceneMSAAColor: return "sceneMSAAColorImage";
+	case gfx_api::PipelineSurfaceId::SwapchainMSAAColor: return "swapchainMSAAColorImage";
+	case gfx_api::PipelineSurfaceId::SceneDepth: return "sceneDepthStencilImage";
+	default: return "pipelineSurfaceImage";
+	}
+}
+
+} // namespace
+
+void VkRoot::PipelineSurfaceAllocator::destroy(gfx_api::PipelineSurfaceId id, gfx_api::abstract_texture* /*texture*/)
+{
+	ASSERT_OR_RETURN(, id != gfx_api::PipelineSurfaceId::Count, "Invalid pipeline surface id");
+	VkSurfaceGpu& gpu = root._surfaceGpu[static_cast<size_t>(id)];
+
+	if (buffering_mechanism::isInitialized())
+	{
+		auto& frameResources = buffering_mechanism::get_current_resources();
+		for (auto& cascadeView : gpu.cascadeViews)
 		{
-			debug(LOG_ERROR, "Failed to create scene MSAA color image: %s", e.what());
-			throw;
+			frameResources.image_view_to_delete.emplace_back(std::move(cascadeView));
 		}
 	}
+	gpu.cascadeViews.clear();
 
-	// create depth/stencil image
-	try {
-		createDepthStencilImage(physicalDevice, memprops, dev, swapchainSize, msaaSamples, depthFormat,
-								sceneDepthStencilImage, sceneDepthStencilMemory, sceneDepthStencilView, vkDynLoader, "sceneDepthStencilImage");
+	// VMA-backed images: release via explicit destroy when buffering may be gone, else unique_ptr dtor.
+	if (auto* rendered = dynamic_cast<VkRenderedImage*>(gpu.texture.get()))
+	{
+		if (!buffering_mechanism::isInitialized())
+		{
+			rendered->destroy(root.dev, root.allocator, root.vkDynLoader);
+		}
+	}
+	else if (auto* depthMap = dynamic_cast<VkDepthMapImage*>(gpu.texture.get()))
+	{
+		if (!buffering_mechanism::isInitialized())
+		{
+			depthMap->destroy(root.dev, root.allocator, root.vkDynLoader);
+		}
+	}
+	gpu.texture.reset();
+	destroySurfaceGpuImage(root, gpu);
+}
+
+bool VkRoot::PipelineSurfaceAllocator::create(gfx_api::PipelineSurfaceId id, const gfx_api::ResolvedSurfaceSpec& createSpec,
+	gfx_api::abstract_texture*& outTexture)
+{
+	outTexture = nullptr;
+	ASSERT_OR_RETURN(false, id != gfx_api::PipelineSurfaceId::Count, "Invalid pipeline surface id");
+	VkSurfaceGpu& gpu = root._surfaceGpu[static_cast<size_t>(id)];
+
+	const vk::Format vkFormat = gfx_api::pixelFormatToVkFormat(createSpec.format);
+	const vk::SampleCountFlagBits vkSamples = toVkSampleCount(createSpec.samples);
+	const vk::Extent2D extent { createSpec.width, createSpec.height };
+
+	try
+	{
+		switch (createSpec.provisionMode)
+		{
+		case gfx_api::SurfaceProvisionMode::WsiPresentColor:
+			gpu.texture = std::make_unique<VkSwapchainColorSurface>(root, vkFormat);
+			break;
+
+		case gfx_api::SurfaceProvisionMode::WsiPresentDepth:
+			createDepthStencilImage(root.physicalDevice, root.memprops, root.dev, extent, vkSamples, vkFormat,
+				gpu.image, gpu.memory, gpu.view, root.vkDynLoader, "swapchainDepthStencilImage");
+			gpu.texture = std::make_unique<VkSwapchainDepthSurface>(root, vkFormat, vkSamples);
+			break;
+
+		case gfx_api::SurfaceProvisionMode::Allocate:
+			switch (createSpec.storageKind)
+			{
+			case gfx_api::SurfaceStorageKind::SampledColor2D:
+			{
+				auto* rendered = new VkRenderedImage(root, createSpec.width, createSpec.height, vkFormat,
+					pipelineSurfaceDebugName(id));
+				gpu.texture.reset(rendered);
+				break;
+			}
+			case gfx_api::SurfaceStorageKind::MsaaColorAttachment:
+				createColorAttachmentImage(root.physicalDevice, root.memprops, root.dev, extent, vkSamples, vkFormat,
+					gpu.image, gpu.memory, gpu.view, root.vkDynLoader, pipelineSurfaceImageKey(id));
+				gpu.texture = std::make_unique<VkAttachmentImage>(gpu.image, gpu.view, vkFormat, createSpec.width, createSpec.height, vkSamples,
+					pipelineSurfaceDebugName(id));
+				break;
+			case gfx_api::SurfaceStorageKind::DepthStencilAttachment:
+				createDepthStencilImage(root.physicalDevice, root.memprops, root.dev, extent, vkSamples, vkFormat,
+					gpu.image, gpu.memory, gpu.view, root.vkDynLoader, pipelineSurfaceImageKey(id));
+				gpu.texture = std::make_unique<VkAttachmentImage>(gpu.image, gpu.view, vkFormat, createSpec.width, createSpec.height, vkSamples,
+					pipelineSurfaceDebugName(id));
+				break;
+			case gfx_api::SurfaceStorageKind::SampledDepthArray:
+			{
+				auto* depthMap = new VkDepthMapImage(root, createSpec.arrayLayers, createSpec.width, vkFormat,
+					pipelineSurfaceDebugName(id));
+				gpu.texture.reset(depthMap);
+				for (uint32_t i = 0; i < createSpec.arrayLayers; ++i)
+				{
+					const auto imageViewCreateInfo = vk::ImageViewCreateInfo()
+						.setImage(depthMap->object)
+						.setViewType(vk::ImageViewType::e2DArray)
+						.setFormat(vkFormat)
+						.setComponents(vk::ComponentMapping())
+						.setSubresourceRange(vk::ImageSubresourceRange(vk::ImageAspectFlagBits::eDepth, 0, 1, i, 1));
+					auto cascade_view = root.dev.createImageViewUnique(imageViewCreateInfo, nullptr, root.vkDynLoader);
+					if (root.debugUtilsExtEnabled)
+					{
+						std::string imageViewName = "<depth cascade image view: " + std::to_string(i) + ">";
+						vk::DebugUtilsObjectNameInfoEXT objectNameInfo;
+						objectNameInfo.setObjectType(vk::ObjectType::eImageView);
+						objectNameInfo.setObjectHandle(uint64_t(static_cast<VkImageView>(cascade_view.get())));
+						objectNameInfo.setPObjectName(imageViewName.c_str());
+						root.dev.setDebugUtilsObjectNameEXT(objectNameInfo, root.vkDynLoader);
+					}
+					gpu.cascadeViews.push_back(std::move(cascade_view));
+				}
+				break;
+			}
+			case gfx_api::SurfaceStorageKind::None:
+				debug(LOG_ERROR, "Allocate surface %u has storageKind None", static_cast<unsigned>(id));
+				return false;
+			}
+			break;
+		}
 	}
 	catch (const vk::SystemError& e)
 	{
-		debug(LOG_ERROR, "Failed to create scene depth stencil image: %s", e.what());
-		throw;
+		debug(LOG_ERROR, "Failed to create pipeline surface %u: %s", static_cast<unsigned>(id), e.what());
+		destroy(id, nullptr);
+		return false;
+	}
+	catch (const std::exception& e)
+	{
+		debug(LOG_ERROR, "Failed to create pipeline surface %u: %s", static_cast<unsigned>(id), e.what());
+		destroy(id, nullptr);
+		return false;
 	}
 
-	_sceneDepthSurface = std::make_unique<VkAttachmentImage>(sceneDepthStencilImage, sceneDepthStencilView, depthFormat,
-		swapchainSize.width, swapchainSize.height, msaaSamples, "<scene depth stencil>");
-	_pipelineSurfaces.registerSurface(gfx_api::PipelineSurfaceId::SceneColor, pSceneImage);
-	_pipelineSurfaces.registerSurface(gfx_api::PipelineSurfaceId::SceneDepth, _sceneDepthSurface.get());
-	const uint32_t sceneSamples = static_cast<uint32_t>(msaaSamples);
-	_pipelineSurfaces.setSurfaceSamples(gfx_api::PipelineSurfaceId::SceneDepth, sceneSamples);
-	if (msaaEnabled)
-	{
-		_sceneMsaaSurface = std::make_unique<VkAttachmentImage>(sceneMSAAImage, sceneMSAAView, sceneFormat,
-			swapchainSize.width, swapchainSize.height, msaaSamples, "<scene msaa color>");
-		_pipelineSurfaces.registerSurface(gfx_api::PipelineSurfaceId::SceneMSAAColor, _sceneMsaaSurface.get());
-		_pipelineSurfaces.setSurfaceSamples(gfx_api::PipelineSurfaceId::SceneMSAAColor, sceneSamples);
-	}
-	else
-	{
-		_sceneMsaaSurface.reset();
-		_pipelineSurfaces.invalidateSurface(gfx_api::PipelineSurfaceId::SceneMSAAColor);
-	}
+	outTexture = gpu.texture.get();
+	return outTexture != nullptr;
+}
+
+void VkRoot::PipelineSurfaceAllocator::prepareForSurfaceDestroy()
+{
+	// Defer framebuffer deletes only. Do not flush here — runtime ensure() must not
+	// destroy FBs still referenced by in-flight command buffers. Hard-reset paths
+	// (after waitForAllIdle) flush via reset* wrappers / destroySwapchain.
+	root.clearFramebufferCache();
+}
+
+void VkRoot::PipelineSurfaceAllocator::onChanged()
+{
+	root.clearFramebufferCache();
+	root.bumpRenderGraphEpoch();
+}
+
+void VkRoot::resetAllPipelineSurfaceSlots()
+{
+	PipelineSurfaceAllocator alloc(*this);
+	_pipelineSurfaces.resetAll(alloc);
+	// Hard-reset callers wait idle first. Flush FBs deferred by prepare so they die
+	// before deferred attachment views/images are recycled (or before immediate
+	// destroy when buffering is already gone).
+	flushDeferredFramebufferDeletes();
+}
+
+void VkRoot::resetSwapchainPipelineSurfaceSlots()
+{
+	std::vector<gfx_api::PipelineSurfaceId> ids;
+	gfx_api::collectPipelineSurfaceIdsByLifetime(gfx_api::SurfaceLifetimePolicy::SwapchainBound, ids);
+	PipelineSurfaceAllocator alloc(*this);
+	_pipelineSurfaces.resetIds(alloc, ids);
+	// Hard-reset callers wait idle first. Flush FBs deferred by prepare so they die
+	// before deferred attachment views/images are recycled (or before immediate
+	// destroy when buffering is already gone).
+	flushDeferredFramebufferDeletes();
 }
 
 bool VkRoot::setupDebugUtilsCallbacks(const std::vector<const char*>& extensions, PFN_vkGetInstanceProcAddr _vkGetInstanceProcAddr)
@@ -3753,9 +3794,9 @@ bool VkRoot::shouldDraw()
 void VkRoot::shutdown()
 {
 	_screenFrameOpen = false;
-	clearFramebufferCache();
-
 	destroySwapchainAndSwapchainSpecificStuff(true);
+	// ShadowMap and other non-swapchain surfaces after swapchain/buffering teardown (GPU idle, FBs flushed).
+	resetAllPipelineSurfaceSlots();
 
 	if (dev)
 	{
@@ -3771,15 +3812,7 @@ void VkRoot::shutdown()
 		}
 		createdPipelines.clear();
 
-		depthMapCascadeView.clear();
-		if (pDepthMapImage)
-		{
-			_pipelineSurfaces.invalidateSurface(gfx_api::PipelineSurfaceId::ShadowMap);
-			pDepthMapImage->destroy(dev, allocator, vkDynLoader); // because the buffering_mechanism is gone at this point...
-			delete pDepthMapImage;
-			pDepthMapImage = nullptr;
-		}
-
+		// ShadowMap was reset above; swapchain/scene surfaces were reset in destroySwapchain.
 		// destroy default depth map texture
 		if (pDefaultDepthMapTexture)
 		{
@@ -3891,11 +3924,10 @@ void VkRoot::finalizeActiveRecording()
 		if (_activePassTargetsSwapchain)
 		{
 			_frameLayoutTracker.noteSwapchainWrite();
-		}
-
-		if (_activePassTargetsSwapchain && _swapchainColorSurface != nullptr)
-		{
-			setImageLayout(_swapchainColorSurface.get(), vk::ImageLayout::eColorAttachmentOptimal);
+			if (auto* swapchainColor = getPipelineSurface(gfx_api::PipelineSurfaceId::SwapchainColor))
+			{
+				setImageLayout(swapchainColor, vk::ImageLayout::eColorAttachmentOptimal);
+			}
 		}
 	}
 
@@ -3953,6 +3985,7 @@ void VkRoot::destroySwapchainAndSwapchainSpecificStuff(bool doDestroySwapchain)
 	waitForAllIdle();
 	_screenshotReadback.shutdown(vkDynLoader);
 	destroyDynamicRenderPasses();
+	flushDeferredFramebufferDeletes();
 
 	if (pDefaultTexture)
 	{
@@ -3965,44 +3998,11 @@ void VkRoot::destroySwapchainAndSwapchainSpecificStuff(bool doDestroySwapchain)
 		pDefaultArrayTexture = nullptr;
 	}
 
-	destroySceneRenderpass();
+	resetSwapchainPipelineSurfaceSlots();
 
 	buffering_mechanism::destroy(dev, vkDynLoader);
 
-	destroySwapchainPipelineSurfaces();
 	resetImageLayoutTracker();
-
-	if (depthStencilView)
-	{
-		dev.destroyImageView(depthStencilView, nullptr, vkDynLoader);
-		depthStencilView = vk::ImageView();
-	}
-	if (depthStencilMemory)
-	{
-		dev.freeMemory(depthStencilMemory, nullptr, vkDynLoader);
-		depthStencilMemory = vk::DeviceMemory();
-	}
-	if (depthStencilImage)
-	{
-		dev.destroyImage(depthStencilImage, nullptr, vkDynLoader);
-		depthStencilImage = vk::Image();
-	}
-
-	if (colorImageView)
-	{
-		dev.destroyImageView(colorImageView, nullptr, vkDynLoader);
-		colorImageView = vk::ImageView();
-	}
-	if (colorImageMemory)
-	{
-		dev.freeMemory(colorImageMemory, nullptr, vkDynLoader);
-		colorImageMemory = vk::DeviceMemory();
-	}
-	if (colorImage)
-	{
-		dev.destroyImage(colorImage, nullptr, vkDynLoader);
-		colorImage = vk::Image();
-	}
 
 	for (auto& imgview : swapchainImageView)
 	{
@@ -4309,6 +4309,8 @@ gfx_api::context::swap_interval_mode VkRoot::getSwapInterval() const
 	return from_vk_presentmode(presentMode);
 }
 
+static uint32_t getVKSuggestedDefaultDepthBufferResolution(const vk::PhysicalDeviceProperties &physicalDeviceProperties, const vk::PhysicalDeviceMemoryProperties& memprops);
+
 // throws a vk::SystemError on an unrecoverable error (like OOM)
 void VkRoot::createSwapchain(bool allowHandleSurfaceLost)
 {
@@ -4505,32 +4507,20 @@ void VkRoot::createSwapchain(bool allowHandleSurfaceLost)
 		throw;
 	}
 
-	// createColorResources
-	vk::Format colorFormat = surfaceFormat.format;
-	try {
-		createColorAttachmentImage(physicalDevice, memprops, dev, swapchainSize, msaaSamplesSwapchain, colorFormat,
-								   colorImage, colorImageMemory, colorImageView, vkDynLoader, "colorImage");
-	}
-	catch (const vk::SystemError& e) {
-		auto resultErr = static_cast<vk::Result>(e.code().value());
-		debug(LOG_ERROR, "Failed to create MSAA color attachment image: %s: %s", vk::to_string(resultErr).c_str(), e.what());
-		throw;
+	depthStencilAttachmentFormat = findDepthStencilFormat(physicalDevice, vkDynLoader);
+	sceneColorVkFormat = findSceneColorBufferFormat(physicalDevice, vkDynLoader);
+	debug(LOG_3D, "Using depth buffer format: %s", to_string(depthStencilAttachmentFormat).c_str());
+	debug(LOG_3D, "Using scene color format: %s", to_string(sceneColorVkFormat).c_str());
+
+	if (depthMapSize == 0)
+	{
+		depthMapSize = getVKSuggestedDefaultDepthBufferResolution(physDeviceProps, memprops);
 	}
 
-	// createDepthStencilImage
-	vk::Format depthFormat = findDepthStencilFormat(physicalDevice, vkDynLoader);
-	debug(LOG_3D, "Using depth buffer format: %s", to_string(depthFormat).c_str());
-	try {
-		createDepthStencilImage(physicalDevice, memprops, dev, swapchainSize, msaaSamplesSwapchain, depthFormat,
-								depthStencilImage, depthStencilMemory, depthStencilView, vkDynLoader, "depthStencilImage");
+	if (!syncPipelineSurfaces())
+	{
+		throw vk::OutOfDeviceMemoryError("syncPipelineSurfaces failed");
 	}
-	catch (const vk::SystemError& e) {
-		auto resultErr = static_cast<vk::Result>(e.code().value());
-		debug(LOG_ERROR, "Failed to create depth stencil image: %s: %s", vk::to_string(resultErr).c_str(), e.what());
-		throw;
-	}
-
-	registerSwapchainPipelineSurfaces(surfaceFormat.format, depthFormat);
 
 	try {
 		setupSwapchainImages();
@@ -4539,20 +4529,6 @@ void VkRoot::createSwapchain(bool allowHandleSurfaceLost)
 	{
 		auto resultErr = static_cast<vk::Result>(e.code().value());
 		debug(LOG_ERROR, "Failed to setup swapchain images: %s: %s", vk::to_string(resultErr).c_str(), e.what());
-		throw;
-	}
-
-	// Dynamic passes: VkRenderPass instances are created on demand by RenderPassLayoutCache
-	// (via getOrCreatePassRenderPassId), typically from beginPass or warmCompiledRenderGraph.
-	vk::Format sceneFormat = findSceneColorBufferFormat(physicalDevice, vkDynLoader);
-	debug(LOG_3D, "Using scene color format: %s", to_string(sceneFormat).c_str());
-	try {
-		createSceneRenderpass(sceneFormat, depthFormat);
-	}
-	catch (const vk::SystemError &e) {
-		// Likely(?) possibilities: vk::OutOfHostMemoryError, vk::OutOfDeviceMemoryError
-		auto resultErr = static_cast<vk::Result>(e.code().value());
-		debug(LOG_ERROR, "createSceneRenderpass (scene images): %s: %s", vk::to_string(resultErr).c_str(), e.what());
 		throw;
 	}
 
@@ -4981,9 +4957,12 @@ bool VkRoot::_initialize(const gfx_api::backend_Impl_Factory& impl, int32_t anti
 	if (depthMapSize == 0)
 	{
 		depthMapSize = getVKSuggestedDefaultDepthBufferResolution(physDeviceProps, memprops);
+		if (!syncPipelineSurfaces())
+		{
+			debug(LOG_ERROR, "syncPipelineSurfaces failed after defaulting depthMapSize");
+			return false;
+		}
 	}
-
-	createDepthPassImages(depthBufferFormat);
 
 	pDefaultDepthMapTexture = new VkDepthMapImage(*this, 1, 4, depthBufferFormat, "<default depth map>");
 	const auto imageMemoryBarriers_TransitionDefaultDepthImage = std::array<vk::ImageMemoryBarrier, 1> {
@@ -5427,29 +5406,35 @@ void VkRoot::setupSwapchainImages()
 		, vkDynLoader
 	);
 
-	//
-	const auto imageMemoryBarriers_ColorImage = std::array<vk::ImageMemoryBarrier, 1> {
-		vk::ImageMemoryBarrier()
-			.setOldLayout(vk::ImageLayout::eUndefined)
-			.setNewLayout(vk::ImageLayout::eColorAttachmentOptimal)
-			.setImage(colorImage)
-			.setSubresourceRange(vk::ImageSubresourceRange(vk::ImageAspectFlagBits::eColor, 0, 1, 0, 1))
-			.setDstAccessMask(vk::AccessFlagBits::eColorAttachmentRead | vk::AccessFlagBits::eColorAttachmentWrite)
-	};
-	internalCommandBuffer.pipelineBarrier(vk::PipelineStageFlagBits::eAllCommands, vk::PipelineStageFlagBits::eAllCommands,
-		vk::DependencyFlagBits(), nullptr, nullptr, imageMemoryBarriers_ColorImage, vkDynLoader);
+	const vk::Image swapchainMsaaImage = _surfaceGpu[static_cast<size_t>(gfx_api::PipelineSurfaceId::SwapchainMSAAColor)].image;
+	if (swapchainMsaaImage)
+	{
+		const auto imageMemoryBarriers_ColorImage = std::array<vk::ImageMemoryBarrier, 1> {
+			vk::ImageMemoryBarrier()
+				.setOldLayout(vk::ImageLayout::eUndefined)
+				.setNewLayout(vk::ImageLayout::eColorAttachmentOptimal)
+				.setImage(swapchainMsaaImage)
+				.setSubresourceRange(vk::ImageSubresourceRange(vk::ImageAspectFlagBits::eColor, 0, 1, 0, 1))
+				.setDstAccessMask(vk::AccessFlagBits::eColorAttachmentRead | vk::AccessFlagBits::eColorAttachmentWrite)
+		};
+		internalCommandBuffer.pipelineBarrier(vk::PipelineStageFlagBits::eAllCommands, vk::PipelineStageFlagBits::eAllCommands,
+			vk::DependencyFlagBits(), nullptr, nullptr, imageMemoryBarriers_ColorImage, vkDynLoader);
+	}
 
-	//
-	const auto imageMemoryBarriers_DepthStencilImage = std::array<vk::ImageMemoryBarrier, 1> {
-		vk::ImageMemoryBarrier()
-			.setOldLayout(vk::ImageLayout::eUndefined)
-			.setNewLayout(vk::ImageLayout::eDepthStencilAttachmentOptimal)
-			.setImage(depthStencilImage)
-			.setSubresourceRange(vk::ImageSubresourceRange(vk::ImageAspectFlagBits::eDepth | vk::ImageAspectFlagBits::eStencil, 0, 1, 0, 1))
-			.setDstAccessMask(vk::AccessFlagBits::eDepthStencilAttachmentRead | vk::AccessFlagBits::eDepthStencilAttachmentWrite)
-	};
-	internalCommandBuffer.pipelineBarrier(vk::PipelineStageFlagBits::eAllCommands, vk::PipelineStageFlagBits::eAllCommands,
-		vk::DependencyFlagBits(), nullptr, nullptr, imageMemoryBarriers_DepthStencilImage, vkDynLoader);
+	const vk::Image swapchainDepthImage = _surfaceGpu[static_cast<size_t>(gfx_api::PipelineSurfaceId::SwapchainDepth)].image;
+	if (swapchainDepthImage)
+	{
+		const auto imageMemoryBarriers_DepthStencilImage = std::array<vk::ImageMemoryBarrier, 1> {
+			vk::ImageMemoryBarrier()
+				.setOldLayout(vk::ImageLayout::eUndefined)
+				.setNewLayout(vk::ImageLayout::eDepthStencilAttachmentOptimal)
+				.setImage(swapchainDepthImage)
+				.setSubresourceRange(vk::ImageSubresourceRange(vk::ImageAspectFlagBits::eDepth | vk::ImageAspectFlagBits::eStencil, 0, 1, 0, 1))
+				.setDstAccessMask(vk::AccessFlagBits::eDepthStencilAttachmentRead | vk::AccessFlagBits::eDepthStencilAttachmentWrite)
+		};
+		internalCommandBuffer.pipelineBarrier(vk::PipelineStageFlagBits::eAllCommands, vk::PipelineStageFlagBits::eAllCommands,
+			vk::DependencyFlagBits(), nullptr, nullptr, imageMemoryBarriers_DepthStencilImage, vkDynLoader);
+	}
 
 	internalCommandBuffer.end(vkDynLoader);
 
@@ -5507,48 +5492,85 @@ void VkRoot::setupSwapchainImages()
 	}
 }
 
-vk::Format VkRoot::get_format(const gfx_api::pixel_format& format) const
+gfx_api::pixel_format gfx_api::vkFormatToPixelFormat(::vk::Format format)
+{
+	switch (format)
+	{
+	case ::vk::Format::eR8G8B8A8Unorm:
+		return gfx_api::pixel_format::FORMAT_RGBA8_UNORM_PACK8;
+	case ::vk::Format::eB8G8R8A8Unorm:
+		return gfx_api::pixel_format::FORMAT_BGRA8_UNORM_PACK8;
+	case ::vk::Format::eR8G8B8Unorm:
+		return gfx_api::pixel_format::FORMAT_RGB8_UNORM_PACK8;
+	case ::vk::Format::eA2B10G10R10UnormPack32:
+		return gfx_api::pixel_format::FORMAT_A2B10G10R10_UNORM_PACK32;
+	case ::vk::Format::eD24UnormS8Uint:
+		return gfx_api::pixel_format::FORMAT_D24_UNORM_S8;
+	case ::vk::Format::eD32SfloatS8Uint:
+		return gfx_api::pixel_format::FORMAT_D32_SFLOAT_S8_UINT;
+	case ::vk::Format::eD32Sfloat:
+		return gfx_api::pixel_format::FORMAT_D32_SFLOAT;
+	default:
+		debug(LOG_WARNING, "Unhandled vk::Format for pixel_format mapping: %s", to_string(format).c_str());
+		return gfx_api::pixel_format::invalid;
+	}
+}
+
+::vk::Format gfx_api::pixelFormatToVkFormat(gfx_api::pixel_format format)
 {
 	switch (format)
 	{
 	case gfx_api::pixel_format::FORMAT_RGBA8_UNORM_PACK8:
-		return vk::Format::eR8G8B8A8Unorm;
+		return ::vk::Format::eR8G8B8A8Unorm;
 	case gfx_api::pixel_format::FORMAT_BGRA8_UNORM_PACK8:
-		return vk::Format::eB8G8R8A8Unorm;
+		return ::vk::Format::eB8G8R8A8Unorm;
 	case gfx_api::pixel_format::FORMAT_RGB8_UNORM_PACK8:
-		return vk::Format::eR8G8B8Unorm;
+		return ::vk::Format::eR8G8B8Unorm;
 	case gfx_api::pixel_format::FORMAT_RG8_UNORM:
-		return vk::Format::eR8G8Unorm;
+		return ::vk::Format::eR8G8Unorm;
 	case gfx_api::pixel_format::FORMAT_R8_UNORM:
-		return vk::Format::eR8Unorm;
+		return ::vk::Format::eR8Unorm;
+	case gfx_api::pixel_format::FORMAT_A2B10G10R10_UNORM_PACK32:
+		return ::vk::Format::eA2B10G10R10UnormPack32;
+	case gfx_api::pixel_format::FORMAT_D24_UNORM_S8:
+		return ::vk::Format::eD24UnormS8Uint;
+	case gfx_api::pixel_format::FORMAT_D32_SFLOAT_S8_UINT:
+		return ::vk::Format::eD32SfloatS8Uint;
+	case gfx_api::pixel_format::FORMAT_D32_SFLOAT:
+		return ::vk::Format::eD32Sfloat;
 	case gfx_api::pixel_format::FORMAT_RGB_BC1_UNORM:
-		return vk::Format::eBc1RgbUnormBlock;
+		return ::vk::Format::eBc1RgbUnormBlock;
 	case gfx_api::pixel_format::FORMAT_RGBA_BC2_UNORM:
-		return vk::Format::eBc2UnormBlock;
+		return ::vk::Format::eBc2UnormBlock;
 	case gfx_api::pixel_format::FORMAT_RGBA_BC3_UNORM:
-		return vk::Format::eBc3UnormBlock;
+		return ::vk::Format::eBc3UnormBlock;
 	case gfx_api::pixel_format::FORMAT_R_BC4_UNORM:
-		return vk::Format::eBc4UnormBlock;
+		return ::vk::Format::eBc4UnormBlock;
 	case gfx_api::pixel_format::FORMAT_RG_BC5_UNORM:
-		return vk::Format::eBc5UnormBlock;
+		return ::vk::Format::eBc5UnormBlock;
 	case gfx_api::pixel_format::FORMAT_RGBA_BPTC_UNORM:
-		return vk::Format::eBc7UnormBlock;
+		return ::vk::Format::eBc7UnormBlock;
 	case gfx_api::pixel_format::FORMAT_RGB8_ETC2:
-		return vk::Format::eEtc2R8G8B8UnormBlock;
+		return ::vk::Format::eEtc2R8G8B8UnormBlock;
 	case gfx_api::pixel_format::FORMAT_RGBA8_ETC2_EAC:
-		return vk::Format::eEtc2R8G8B8A8UnormBlock;
+		return ::vk::Format::eEtc2R8G8B8A8UnormBlock;
 	case gfx_api::pixel_format::FORMAT_R11_EAC:
-		return vk::Format::eEacR11UnormBlock;
+		return ::vk::Format::eEacR11UnormBlock;
 	case gfx_api::pixel_format::FORMAT_RG11_EAC:
-		return vk::Format::eEacR11G11UnormBlock;
+		return ::vk::Format::eEacR11G11UnormBlock;
 	case gfx_api::pixel_format::FORMAT_ASTC_4x4_UNORM:
-		return vk::Format::eAstc4x4UnormBlock;
+		return ::vk::Format::eAstc4x4UnormBlock;
 	case gfx_api::pixel_format::FORMAT_RGB8_ETC1:
 		// Not supported!
 	default:
 		debug(LOG_FATAL, "Unsupported format: %d", (int)format);
 	}
 	throw;
+}
+
+vk::Format VkRoot::get_format(const gfx_api::pixel_format& format) const
+{
+	return gfx_api::pixelFormatToVkFormat(format);
 }
 
 bool VkRoot::textureFormatIsSupported(gfx_api::pixel_format_target target, gfx_api::pixel_format format, gfx_api::pixel_format_usage::flags usage)
@@ -5670,7 +5692,6 @@ void VkRoot::bind_textures(const std::vector<gfx_api::texture_input>& attribute_
 					imageView = static_cast<VkAttachmentImage*>(texture)->view;
 					break;
 				case VulkanBackendInternalTextureType::SwapchainColorSurface:
-				case VulkanBackendInternalTextureType::SwapchainMsaaColorSurface:
 				case VulkanBackendInternalTextureType::SwapchainDepthSurface:
 					debug(LOG_FATAL, "Swapchain pipeline surfaces are not shader-sampled");
 					break;
@@ -5886,14 +5907,19 @@ gfx_api::abstract_texture* VkRoot::getPipelineSurface(gfx_api::PipelineSurfaceId
 	return _pipelineSurfaces.get(id);
 }
 
-gfx_api::PipelineSurfaceMeta VkRoot::pipelineSurfaceMeta(gfx_api::PipelineSurfaceId id) const
+gfx_api::PipelineSurfaceUsage VkRoot::pipelineSurfaceUsage(gfx_api::PipelineSurfaceId id) const
 {
-	return _pipelineSurfaces.meta(id);
+	return _pipelineSurfaces.usage(id);
+}
+
+const gfx_api::ResolvedSurfaceSpec& VkRoot::resolvedPipelineSurface(gfx_api::PipelineSurfaceId id) const
+{
+	return _pipelineSurfaces.spec(id);
 }
 
 nonstd::optional<gfx_api::PipelineSurfaceId> VkRoot::findPipelineSurfaceId(gfx_api::abstract_texture* texture) const
 {
-	return _pipelineSurfaces.findSurfaceId(texture);
+	return _pipelineSurfaces.find(texture);
 }
 
 bool VkRoot::isSceneMSAAEnabled() const
@@ -5912,16 +5938,77 @@ bool VkRoot::isMultisampledColorAttachment(gfx_api::abstract_texture* texture) c
 	{
 		return attachmentImage->samples != vk::SampleCountFlagBits::e1;
 	}
-	if (dynamic_cast<VkSwapchainMsaaColorSurface*>(texture) != nullptr)
-	{
-		return true;
-	}
 	return false;
 }
 
 gfx_api::pixel_format VkRoot::getDepthStencilFormat() const
 {
-	return gfx_api::pixel_format::FORMAT_D24_UNORM_S8;
+	if (depthStencilAttachmentFormat != vk::Format::eUndefined)
+	{
+		const gfx_api::pixel_format fmt = gfx_api::vkFormatToPixelFormat(depthStencilAttachmentFormat);
+		if (fmt != gfx_api::pixel_format::invalid)
+		{
+			return fmt;
+		}
+	}
+	return surfaceCapabilities().depthStencilFormat;
+}
+
+gfx_api::PipelineSurfaceSyncInputs VkRoot::pipelineSurfaceSyncInputs() const
+{
+	gfx_api::PipelineSurfaceSyncInputs inputs;
+	const uint32_t w = swapchainSize.width;
+	const uint32_t h = swapchainSize.height;
+	if (w > 0 && h > 0)
+	{
+		inputs.drawableW = w;
+		inputs.drawableH = h;
+		inputs.sceneW = std::max(w, 2u);
+		inputs.sceneH = std::max(h, 2u);
+	}
+	inputs.shadowMapSize = depthMapSize;
+	inputs.numShadowCascades = static_cast<uint32_t>(std::min<size_t>(depthPassCount, WZ_MAX_SHADOW_CASCADES));
+	inputs.sceneMsaaSamples = static_cast<uint32_t>(msaaSamples);
+	inputs.swapchainMsaaSamples = static_cast<uint32_t>(msaaSamplesSwapchain);
+	inputs.presentColorFormat = gfx_api::vkFormatToPixelFormat(surfaceFormat.format);
+	if (inputs.presentColorFormat == gfx_api::pixel_format::invalid)
+	{
+		inputs.presentColorFormat = gfx_api::pixel_format::FORMAT_RGBA8_UNORM_PACK8;
+	}
+	return inputs;
+}
+
+gfx_api::SurfaceCapabilityHints VkRoot::surfaceCapabilities() const
+{
+	gfx_api::SurfaceCapabilityHints caps;
+	caps.sceneColorFormat = (sceneColorVkFormat != vk::Format::eUndefined)
+		? gfx_api::vkFormatToPixelFormat(sceneColorVkFormat)
+		: gfx_api::pixel_format::FORMAT_RGBA8_UNORM_PACK8;
+	if (caps.sceneColorFormat == gfx_api::pixel_format::invalid)
+	{
+		caps.sceneColorFormat = gfx_api::pixel_format::FORMAT_RGBA8_UNORM_PACK8;
+	}
+	caps.depthStencilFormat = (depthStencilAttachmentFormat != vk::Format::eUndefined)
+		? gfx_api::vkFormatToPixelFormat(depthStencilAttachmentFormat)
+		: gfx_api::pixel_format::FORMAT_D24_UNORM_S8;
+	if (caps.depthStencilFormat == gfx_api::pixel_format::invalid)
+	{
+		caps.depthStencilFormat = gfx_api::pixel_format::FORMAT_D24_UNORM_S8;
+	}
+	caps.depthSampledFormat = (depthBufferFormat != vk::Format::eUndefined)
+		? gfx_api::vkFormatToPixelFormat(depthBufferFormat)
+		: gfx_api::pixel_format::FORMAT_D24_UNORM_S8;
+	if (caps.depthSampledFormat == gfx_api::pixel_format::invalid)
+	{
+		caps.depthSampledFormat = gfx_api::pixel_format::FORMAT_D24_UNORM_S8;
+	}
+	return caps;
+}
+
+bool VkRoot::ensurePipelineSurfaces(const gfx_api::ResolvedSurfaceTable& specs)
+{
+	PipelineSurfaceAllocator alloc(*this);
+	return _pipelineSurfaces.ensure(specs, alloc);
 }
 
 void VkRoot::purgeFrameResources()
@@ -5991,6 +6078,10 @@ vk::Image VkRoot::getVkImageHandle(gfx_api::abstract_texture* texture) const
 			"Swapchain image index out of range");
 		return swapchainImages[currentSwapchainIndex];
 	}
+	if (dynamic_cast<VkSwapchainDepthSurface*>(texture) != nullptr)
+	{
+		return _surfaceGpu[static_cast<size_t>(gfx_api::PipelineSurfaceId::SwapchainDepth)].image;
+	}
 	debug(LOG_FATAL, "Unsupported texture type for layout transition");
 	return vk::Image();
 }
@@ -6001,11 +6092,26 @@ vk::ImageAspectFlags VkRoot::getVkImageAspect(gfx_api::abstract_texture* texture
 	{
 		return vk::ImageAspectFlagBits::eDepth;
 	}
+	if (dynamic_cast<VkSwapchainDepthSurface*>(texture) != nullptr)
+	{
+		return vk::ImageAspectFlagBits::eDepth | vk::ImageAspectFlagBits::eStencil;
+	}
 	if (auto* attachmentImage = dynamic_cast<VkAttachmentImage*>(texture))
 	{
-		if (attachmentImage->imageFormat == depthBufferFormat)
+		switch (attachmentImage->imageFormat)
 		{
+		case vk::Format::eD16Unorm:
+		case vk::Format::eX8D24UnormPack32:
+		case vk::Format::eD32Sfloat:
+			return vk::ImageAspectFlagBits::eDepth;
+		case vk::Format::eS8Uint:
+			return vk::ImageAspectFlagBits::eStencil;
+		case vk::Format::eD16UnormS8Uint:
+		case vk::Format::eD24UnormS8Uint:
+		case vk::Format::eD32SfloatS8Uint:
 			return vk::ImageAspectFlagBits::eDepth | vk::ImageAspectFlagBits::eStencil;
+		default:
+			break;
 		}
 	}
 	return vk::ImageAspectFlagBits::eColor;
@@ -6128,10 +6234,6 @@ vk::Format VkRoot::getAttachmentVkFormat(gfx_api::abstract_texture* texture) con
 	{
 		return swapchainColor->imageFormat;
 	}
-	if (auto* swapchainMsaaColor = dynamic_cast<VkSwapchainMsaaColorSurface*>(texture))
-	{
-		return swapchainMsaaColor->imageFormat;
-	}
 	if (auto* swapchainDepth = dynamic_cast<VkSwapchainDepthSurface*>(texture))
 	{
 		return swapchainDepth->imageFormat;
@@ -6147,9 +6249,9 @@ vk::SampleCountFlagBits VkRoot::getAttachmentVkSamples(gfx_api::abstract_texture
 	{
 		return attachmentImage->samples;
 	}
-	if (auto* swapchainMsaaColor = dynamic_cast<VkSwapchainMsaaColorSurface*>(texture))
+	if (auto* swapchainDepth = dynamic_cast<VkSwapchainDepthSurface*>(texture))
 	{
-		return swapchainMsaaColor->samples;
+		return swapchainDepth->samples;
 	}
 	return vk::SampleCountFlagBits::e1;
 }
@@ -6163,9 +6265,14 @@ vk::ImageView VkRoot::getAttachmentImageView(const gfx_api::AttachmentDesc& atta
 	}
 	if (auto* depthImage = dynamic_cast<VkDepthMapImage*>(attachment.texture))
 	{
-		if (attachment.arrayLayer < depthMapCascadeView.size())
+		const auto surfaceId = _pipelineSurfaces.find(attachment.texture);
+		if (surfaceId.has_value()
+			&& _pipelineSurfaces.spec(surfaceId.value()).storageKind == gfx_api::SurfaceStorageKind::SampledDepthArray)
 		{
-			return depthMapCascadeView[attachment.arrayLayer].get();
+			const auto& cascadeViews = _surfaceGpu[static_cast<size_t>(surfaceId.value())].cascadeViews;
+			ASSERT_OR_RETURN(vk::ImageView(), attachment.arrayLayer < cascadeViews.size(),
+				"Shadow cascade arrayLayer %u out of range (%zu)", attachment.arrayLayer, cascadeViews.size());
+			return cascadeViews[attachment.arrayLayer].get();
 		}
 		return depthImage->view.get();
 	}
@@ -6180,13 +6287,9 @@ vk::ImageView VkRoot::getAttachmentImageView(const gfx_api::AttachmentDesc& atta
 			"Swapchain index out of range");
 		return swapchainImageView[currentSwapchainIndex];
 	}
-	if (dynamic_cast<VkSwapchainMsaaColorSurface*>(attachment.texture) != nullptr)
-	{
-		return colorImageView;
-	}
 	if (dynamic_cast<VkSwapchainDepthSurface*>(attachment.texture) != nullptr)
 	{
-		return depthStencilView;
+		return _surfaceGpu[static_cast<size_t>(gfx_api::PipelineSurfaceId::SwapchainDepth)].view;
 	}
 	debug(LOG_FATAL, "Unsupported attachment texture type for dynamic pass");
 	return vk::ImageView();
@@ -6222,6 +6325,22 @@ void VkRoot::deferDestroyFramebuffer(vk::Framebuffer framebuffer)
 	// Vulkan: do not destroy framebuffers (or other objects referenced by recorded
 	// commands) until the command buffer has been ended and the GPU is done.
 	buffering_mechanism::get_current_resources().fbo_to_delete.emplace_back(framebuffer);
+}
+
+void VkRoot::flushDeferredFramebufferDeletes()
+{
+	if (!dev || !buffering_mechanism::isInitialized())
+	{
+		return;
+	}
+	for (auto& frameResources : buffering_mechanism::perFrameResources)
+	{
+		for (auto fbo : frameResources->fbo_to_delete)
+		{
+			dev.destroyFramebuffer(fbo, nullptr, vkDynLoader);
+		}
+		frameResources->fbo_to_delete.clear();
+	}
 }
 
 void VkRoot::clearFramebufferCache()
@@ -6284,7 +6403,6 @@ optional<std::pair<uint32_t, uint32_t>> VkRoot::getRenderTargetDimensions(gfx_ap
 		}
 	}
 	if (dynamic_cast<VkSwapchainColorSurface*>(texture) != nullptr
-		|| dynamic_cast<VkSwapchainMsaaColorSurface*>(texture) != nullptr
 		|| dynamic_cast<VkSwapchainDepthSurface*>(texture) != nullptr)
 	{
 		if (swapchainSize.width > 0 && swapchainSize.height > 0)
@@ -6292,7 +6410,8 @@ optional<std::pair<uint32_t, uint32_t>> VkRoot::getRenderTargetDimensions(gfx_ap
 			return std::make_pair(swapchainSize.width, swapchainSize.height);
 		}
 	}
-	if (texture == pSceneImage && swapchainSize.width > 0 && swapchainSize.height > 0)
+	if (texture == getPipelineSurface(gfx_api::PipelineSurfaceId::SceneColor)
+		&& swapchainSize.width > 0 && swapchainSize.height > 0)
 	{
 		return std::make_pair(swapchainSize.width, swapchainSize.height);
 	}
@@ -6513,7 +6632,10 @@ void VkRoot::sealActivePassForFrameFinish()
 	if (_activePassTargetsSwapchain)
 	{
 		_frameLayoutTracker.noteSwapchainWrite();
-		setImageLayout(_swapchainColorSurface.get(), vk::ImageLayout::eColorAttachmentOptimal);
+		if (auto* swapchainColor = getPipelineSurface(gfx_api::PipelineSurfaceId::SwapchainColor))
+		{
+			setImageLayout(swapchainColor, vk::ImageLayout::eColorAttachmentOptimal);
+		}
 	}
 	hasActivePass = false;
 	_activePassTargetsSwapchain = false;
@@ -6529,18 +6651,19 @@ void VkRoot::sealDrawCommandBufferForPresent()
 	}
 
 	vk::CommandBuffer drawCmdBuffer = frameResources.drawCmdBuffer();
+	auto* swapchainColor = getPipelineSurface(gfx_api::PipelineSurfaceId::SwapchainColor);
 
-	if (_screenshotReadback.hasAwaitingRecord() && _swapchainColorSurface
+	if (_screenshotReadback.hasAwaitingRecord() && swapchainColor
 		&& _frameLayoutTracker.swapchainTouchedThisFrame())
 	{
 		ASSERT(currentSwapchainIndex < swapchainImages.size(),
 		       "Swapchain image index out of range for screenshot");
 		const vk::Image swapchainImage = swapchainImages[currentSwapchainIndex];
-		_screenshotReadback.recordCopy(*this, drawCmdBuffer, _swapchainColorSurface.get(), swapchainImage);
+		_screenshotReadback.recordCopy(*this, drawCmdBuffer, swapchainColor, swapchainImage);
 	}
-	else if (_swapchainColorSurface && _frameLayoutTracker.swapchainTouchedThisFrame())
+	else if (swapchainColor && _frameLayoutTracker.swapchainTouchedThisFrame())
 	{
-		_frameLayoutTracker.transitionSwapchainToPresent(*this, drawCmdBuffer, _swapchainColorSurface.get());
+		_frameLayoutTracker.transitionSwapchainToPresent(*this, drawCmdBuffer, swapchainColor);
 	}
 
 	drawCmdBuffer.end(vkDynLoader);
@@ -6780,19 +6903,22 @@ void VkRoot::endPass(const gfx_api::CompiledPass* compiledPass)
 	{
 		applyCompiledPostPassLayouts(*compiledPass);
 	}
-	if (_activePassTargetsSwapchain && _swapchainColorSurface != nullptr)
+	if (_activePassTargetsSwapchain)
 	{
-		// Render passes leave the swapchain in ColorAttachmentOptimal; mirror finishScreenFrame force-end
-		// so present transition never no-ops with a stale PresentSrcKHR tracker entry.
-		setImageLayout(_swapchainColorSurface.get(), vk::ImageLayout::eColorAttachmentOptimal);
-#if defined(DEBUG)
-		if (compiledPass != nullptr)
+		if (auto* swapchainColor = getPipelineSurface(gfx_api::PipelineSurfaceId::SwapchainColor))
 		{
-			const vk::ImageLayout trackedLayout = _frameLayoutTracker.get(_swapchainColorSurface.get());
-			ASSERT(trackedLayout == vk::ImageLayout::eColorAttachmentOptimal,
-				"Swapchain tracker not ColorAttachmentOptimal after graph pass end");
-		}
+			// Render passes leave the swapchain in ColorAttachmentOptimal; mirror finishScreenFrame force-end
+			// so present transition never no-ops with a stale PresentSrcKHR tracker entry.
+			setImageLayout(swapchainColor, vk::ImageLayout::eColorAttachmentOptimal);
+#if defined(DEBUG)
+			if (compiledPass != nullptr)
+			{
+				const vk::ImageLayout trackedLayout = _frameLayoutTracker.get(swapchainColor);
+				ASSERT(trackedLayout == vk::ImageLayout::eColorAttachmentOptimal,
+					"Swapchain tracker not ColorAttachmentOptimal after graph pass end");
+			}
 #endif
+		}
 	}
 	currentRenderPassId = INVALID_RENDER_PASS_ID;
 	currentPSO = nullptr;
@@ -6807,19 +6933,32 @@ size_t VkRoot::numDepthPasses()
 
 bool VkRoot::setDepthPassProperties(size_t _numDepthPasses, size_t _depthBufferResolution)
 {
-	if (depthPassCount == _numDepthPasses
-		&& depthMapSize == _depthBufferResolution)
+	const size_t clampedDepthPasses = std::min<size_t>(_numDepthPasses, WZ_MAX_SHADOW_CASCADES);
+	const uint32_t clampedDepthMapSize = static_cast<uint32_t>(_depthBufferResolution);
+	if (depthPassCount == clampedDepthPasses
+		&& depthMapSize == clampedDepthMapSize)
 	{
 		// nothing to do
 		return true;
 	}
 
-	depthPassCount = _numDepthPasses;
-	depthMapSize = static_cast<uint32_t>(_depthBufferResolution);
+	const size_t previousDepthPassCount = depthPassCount;
+	const uint32_t previousDepthMapSize = depthMapSize;
+	depthPassCount = clampedDepthPasses;
+	depthMapSize = clampedDepthMapSize;
 
-	bumpRenderGraphEpoch();
 	invalidateWarmEntries();
-	createDepthPassImages(depthBufferFormat);
+	if (!syncPipelineSurfaces())
+	{
+		depthPassCount = previousDepthPassCount;
+		depthMapSize = previousDepthMapSize;
+		invalidateWarmEntries();
+		if (!syncPipelineSurfaces())
+		{
+			debug(LOG_ERROR, "Failed to restore previous depth pass surfaces after sync failure");
+		}
+		return false;
+	}
 
 	return true;
 }

--- a/lib/ivis_opengl/gfx_api_vk.h
+++ b/lib/ivis_opengl/gfx_api_vk.h
@@ -79,6 +79,11 @@ using nonstd::optional;
 
 namespace gfx_api
 {
+	/// Map a Vulkan format to gfx_api::pixel_format (surface / capability reporting).
+	pixel_format vkFormatToPixelFormat(::vk::Format format);
+	/// Map gfx_api::pixel_format to a Vulkan format (textures + pipeline surfaces).
+	::vk::Format pixelFormatToVkFormat(pixel_format format);
+
 	class backend_Vulkan_Impl
 	{
 	public:
@@ -646,20 +651,6 @@ struct VkSwapchainColorSurface final : public gfx_api::abstract_texture
 	virtual size_t backend_internal_value() const override;
 };
 
-/// Non-owning wrapper for the swapchain MSAA color intermediate (when enabled).
-struct VkSwapchainMsaaColorSurface final : public gfx_api::abstract_texture
-{
-	const VkRoot& root;
-	vk::Format imageFormat = vk::Format::eUndefined;
-	vk::SampleCountFlagBits samples = vk::SampleCountFlagBits::e1;
-
-	VkSwapchainMsaaColorSurface(const VkRoot& rootRef, vk::Format format, vk::SampleCountFlagBits sampleCount);
-	virtual ~VkSwapchainMsaaColorSurface() override;
-	virtual void bind() override;
-	virtual bool isArray() const override { return false; }
-	virtual size_t backend_internal_value() const override;
-};
-
 /// Non-owning wrapper for the shared swapchain depth/stencil image.
 struct VkSwapchainDepthSurface final : public gfx_api::abstract_texture
 {
@@ -690,6 +681,21 @@ struct SwapChainSupportDetails
 	vk::SurfaceCapabilitiesKHR capabilities;
 	std::vector<vk::SurfaceFormatKHR> formats;
 	std::vector<vk::PresentModeKHR> presentModes;
+};
+
+struct VkRoot;
+
+/// Backend-owned GPU objects for one pipeline surface (store holds non-owning texture*).
+struct VkSurfaceGpu
+{
+	std::unique_ptr<gfx_api::abstract_texture> texture;
+	std::vector<WZ_vk::UniqueImageView> cascadeViews; // ShadowMap only
+
+	// Owned GPU resources for attachment-style allocates (MSAA color / depth).
+	// Unused when texture owns VMA resources (SceneColor / ShadowMap) or WsiPresentColor.
+	vk::Image image {};
+	vk::DeviceMemory memory {};
+	vk::ImageView view {};
 };
 
 struct VkRoot final : gfx_api::context
@@ -749,13 +755,6 @@ struct VkRoot final : gfx_api::context
 
 	vk::SampleCountFlagBits msaaSamples = vk::SampleCountFlagBits::e1; // msaaSamples used for scene
 	vk::SampleCountFlagBits msaaSamplesSwapchain = vk::SampleCountFlagBits::e1; // msaaSamples used for swapchain assets (should generally be 1)
-	vk::Image colorImage;
-	vk::DeviceMemory colorImageMemory;
-	vk::ImageView colorImageView;
-
-	vk::Image depthStencilImage;
-	vk::DeviceMemory depthStencilMemory;
-	vk::ImageView depthStencilView;
 
 	// render passes
 	static constexpr size_t INVALID_RENDER_PASS_ID = std::numeric_limits<size_t>::max();
@@ -775,21 +774,11 @@ struct VkRoot final : gfx_api::context
 	// render passes
 	std::vector<RenderPassDetails> renderPasses;
 
-	// depth render passes
+	// depth render passes / scene formats (cached for sync inputs + capabilities)
 	vk::Format depthBufferFormat = vk::Format::eUndefined;
+	vk::Format depthStencilAttachmentFormat = vk::Format::eUndefined;
+	vk::Format sceneColorVkFormat = vk::Format::eUndefined;
 	uint32_t depthMapSize = 4096;
-	VkDepthMapImage* pDepthMapImage = nullptr;
-	std::vector<WZ_vk::UniqueImageView> depthMapCascadeView;
-
-	// scene render pass
-	vk::Format sceneImageFormat = vk::Format::eUndefined;
-	VkRenderedImage* pSceneImage = nullptr;
-	vk::Image sceneMSAAImage;
-	vk::DeviceMemory sceneMSAAMemory;
-	vk::ImageView sceneMSAAView;
-	vk::Image sceneDepthStencilImage;
-	vk::DeviceMemory sceneDepthStencilMemory;
-	vk::ImageView sceneDepthStencilView;
 
 	// default textures
 	VkTexture* pDefaultTexture = nullptr;
@@ -883,12 +872,21 @@ private:
 	void createSwapchain(bool allowHandleSurfaceLost = true); // Throws on failure
 	void rebuildPipelinesIfNecessary();
 
-	void registerSwapchainPipelineSurfaces(vk::Format colorFormat, vk::Format depthFormat);
-	void destroySwapchainPipelineSurfaces();
-	void createDepthPassImages(vk::Format depthFormat);
-	void createSceneRenderpass(vk::Format sceneFormat, vk::Format depthFormat);
-	void destroySceneRenderpass();
 	void setupSwapchainImages();
+	void resetAllPipelineSurfaceSlots();
+	/// Reset scene + swapchain surfaces; keeps ShadowMap across swapchain recreate.
+	void resetSwapchainPipelineSurfaceSlots();
+
+	struct PipelineSurfaceAllocator final : gfx_api::SurfaceAllocator
+	{
+		VkRoot& root;
+		explicit PipelineSurfaceAllocator(VkRoot& r) : root(r) {}
+		bool create(gfx_api::PipelineSurfaceId id, const gfx_api::ResolvedSurfaceSpec& spec,
+			gfx_api::abstract_texture*& outTexture) override;
+		void destroy(gfx_api::PipelineSurfaceId id, gfx_api::abstract_texture* texture) override;
+		void prepareForSurfaceDestroy() override;
+		void onChanged() override;
+	};
 
 public:
 	vk::Format get_format(const gfx_api::pixel_format& format) const;
@@ -923,12 +921,16 @@ public:
 	gfx_api::vk::TransferRecorder transferRecorder() const;
 	virtual size_t getDepthPassDimensions(size_t idx) override;
 	virtual gfx_api::abstract_texture* getPipelineSurface(gfx_api::PipelineSurfaceId id) override;
-	virtual gfx_api::PipelineSurfaceMeta pipelineSurfaceMeta(gfx_api::PipelineSurfaceId id) const override;
+	virtual gfx_api::PipelineSurfaceUsage pipelineSurfaceUsage(gfx_api::PipelineSurfaceId id) const override;
+	virtual const gfx_api::ResolvedSurfaceSpec& resolvedPipelineSurface(gfx_api::PipelineSurfaceId id) const override;
 	virtual nonstd::optional<gfx_api::PipelineSurfaceId> findPipelineSurfaceId(gfx_api::abstract_texture* texture) const override;
 	virtual bool isSceneMSAAEnabled() const override;
 	virtual bool isSwapchainMSAAEnabled() const override;
 	virtual bool isMultisampledColorAttachment(gfx_api::abstract_texture* texture) const override;
 	virtual gfx_api::pixel_format getDepthStencilFormat() const override;
+	virtual gfx_api::PipelineSurfaceSyncInputs pipelineSurfaceSyncInputs() const override;
+	virtual gfx_api::SurfaceCapabilityHints surfaceCapabilities() const override;
+	virtual bool ensurePipelineSurfaces(const gfx_api::ResolvedSurfaceTable& specs) override;
 	virtual void purgeFrameResources() override;
 	virtual optional<std::pair<uint32_t, uint32_t>> getRenderTargetDimensions(gfx_api::abstract_texture* texture) override;
 	virtual void warmCompiledRenderGraph(std::vector<gfx_api::RenderPassDesc>& passes,
@@ -1044,6 +1046,8 @@ private:
 	void applyCompiledPostPassLayouts(const gfx_api::CompiledPass& pass);
 	void applyViewport(vk::CommandBuffer cmdBuffer, uint32_t width, uint32_t height, float minDepth, float maxDepth);
 	void deferDestroyFramebuffer(vk::Framebuffer framebuffer);
+	/// Destroy all framebuffers queued in per-frame `fbo_to_delete` lists (requires GPU idle).
+	void flushDeferredFramebufferDeletes();
 	void clearFramebufferCache();
 	bool buildPassLayoutKey(gfx_api::vk::PassLayoutKey& out, const gfx_api::RenderPassDesc& pass,
 		const gfx_api::CompiledPass* compiledPass);
@@ -1083,12 +1087,8 @@ private:
 	};
 	optional<QueuedSwapModeChange> queuedSwapModeChange = nullopt;
 
-	std::unique_ptr<VkAttachmentImage> _sceneDepthSurface;
-	std::unique_ptr<VkAttachmentImage> _sceneMsaaSurface;
-	std::unique_ptr<VkSwapchainColorSurface> _swapchainColorSurface;
-	std::unique_ptr<VkSwapchainMsaaColorSurface> _swapchainMsaaColorSurface;
-	std::unique_ptr<VkSwapchainDepthSurface> _swapchainDepthSurface;
-	gfx_api::PipelineSurfaceRegistry _pipelineSurfaces;
+	std::array<VkSurfaceGpu, gfx_api::PIPELINE_SURFACE_COUNT> _surfaceGpu {};
+	gfx_api::PipelineSurfaceStore _pipelineSurfaces;
 	gfx_api::FramebufferResourceCache _framebufferCache;
 
 	/// Reusable `PassLayoutKey` buffer for `buildPassLayoutKey` / cache lookup at call sites.

--- a/lib/ivis_opengl/render_graph/attachment.h
+++ b/lib/ivis_opengl/render_graph/attachment.h
@@ -29,6 +29,8 @@
 
 #include <optional>
 
+#include "pipeline_surfaces.h"
+
 namespace gfx_api
 {
 
@@ -92,6 +94,8 @@ struct AttachmentDesc
 	ClearValue clearValue;
 	uint32_t mipLevel = 0;
 	uint32_t arrayLayer = 0;
+	/// Set by BlueprintMaterializer when the attachment is a pipeline surface.
+	std::optional<PipelineSurfaceId> pipelineSurfaceId;
 
 	bool shouldClear() const
 	{

--- a/lib/ivis_opengl/render_graph/blueprint_materializer.cpp
+++ b/lib/ivis_opengl/render_graph/blueprint_materializer.cpp
@@ -45,9 +45,7 @@ AttachmentDesc BlueprintMaterializer::resolveAttachment(const BlueprintAttachmen
 		"BlueprintMaterializer: only PipelineSurface attachments are supported");
 	auto& ctx = gfx_api::context::get();
 	abstract_texture* texture = ctx.getPipelineSurface(attachment.surfaceId);
-	const PipelineSurfaceMeta meta = ctx.pipelineSurfaceMeta(attachment.surfaceId);
-	const bool isDepth = meta.usage == PipelineSurfaceUsage::DepthStencil
-		|| meta.usage == PipelineSurfaceUsage::DepthOnly;
+	const bool isDepth = isDepthUsage(ctx.pipelineSurfaceUsage(attachment.surfaceId));
 	AttachmentDesc desc = isDepth
 		? AttachmentDesc::depth(texture, attachment.loadOp, attachment.clearValue)
 		: AttachmentDesc::color(texture, attachment.loadOp, attachment.clearValue);
@@ -56,6 +54,7 @@ AttachmentDesc BlueprintMaterializer::resolveAttachment(const BlueprintAttachmen
 	{
 		desc.arrayLayer = attachment.arrayLayer.value();
 	}
+	desc.pipelineSurfaceId = attachment.surfaceId;
 	return desc;
 }
 

--- a/lib/ivis_opengl/render_graph/compile.cpp
+++ b/lib/ivis_opengl/render_graph/compile.cpp
@@ -43,7 +43,6 @@ std::optional<ResolvedRead> resolveSingleRead(const ReadDesc& read,
 	const std::vector<RenderPassDesc>& descs, size_t consumerIndex,
 	const std::vector<CompiledPass>& compiledPasses)
 {
-	auto& ctx = gfx_api::context::get();
 	ResolvedRead resolved;
 
 	switch (read.source)
@@ -53,17 +52,6 @@ std::optional<ResolvedRead> resolveSingleRead(const ReadDesc& read,
 			"Pass \"%s\" read[%zu]: explicit texture is null",
 			descs[consumerIndex].debugName.c_str(), consumerIndex);
 		resolved.texture = read.texture;
-		break;
-	case ReadSource::PipelineSurface:
-		resolved.texture = ctx.getPipelineSurface(read.pipelineSurface);
-		ASSERT_OR_RETURN(std::nullopt, resolved.texture != nullptr,
-			"Pass \"%s\": pipeline surface %u is not registered",
-			descs[consumerIndex].debugName.c_str(), static_cast<unsigned>(read.pipelineSurface));
-		{
-			const PipelineSurfaceUsage usage = ctx.pipelineSurfaceMeta(read.pipelineSurface).usage;
-			resolved.isDepth = usage == PipelineSurfaceUsage::DepthOnly
-				|| usage == PipelineSurfaceUsage::DepthStencil;
-		}
 		break;
 	case ReadSource::PassOutput:
 		ASSERT_OR_RETURN(std::nullopt, read.producerPass != INVALID_PASS_HANDLE,

--- a/lib/ivis_opengl/render_graph/pass_resolve.cpp
+++ b/lib/ivis_opengl/render_graph/pass_resolve.cpp
@@ -43,6 +43,19 @@ bool attachmentIsResolved(const AttachmentDesc& attachment)
 	return attachment.texture != nullptr;
 }
 
+std::optional<PipelineSurfaceId> attachmentPipelineSurfaceId(const AttachmentDesc& attachment)
+{
+	if (attachment.pipelineSurfaceId.has_value())
+	{
+		return attachment.pipelineSurfaceId;
+	}
+	if (attachment.texture == nullptr)
+	{
+		return std::nullopt;
+	}
+	return gfx_api::context::get().findPipelineSurfaceId(attachment.texture);
+}
+
 bool passHasResolvedAttachments(const RenderPassDesc& pass)
 {
 	for (const auto& colorAttachment : pass.colorAttachments)
@@ -120,16 +133,12 @@ void setDefaultStoreOpIfUnset(AttachmentDesc& attachment, AttachmentStoreOp stor
 std::optional<PipelineSurfaceUsage> getAttachmentSurfaceUsage(gfx_api::context& ctx,
 	const AttachmentDesc& attachment)
 {
-	if (attachment.texture == nullptr)
-	{
-		return std::nullopt;
-	}
-	const auto surfaceId = ctx.findPipelineSurfaceId(attachment.texture);
+	const auto surfaceId = attachmentPipelineSurfaceId(attachment);
 	if (!surfaceId.has_value())
 	{
 		return std::nullopt;
 	}
-	return ctx.pipelineSurfaceMeta(surfaceId.value()).usage;
+	return ctx.pipelineSurfaceUsage(surfaceId.value());
 }
 
 AttachmentStoreOp defaultDepthStoreOp(gfx_api::context& ctx, const RenderPassDesc& pass,
@@ -530,17 +539,13 @@ bool passNeedsMsaaResolve(const RenderPassDesc& pass)
 
 bool attachmentDepthHasStencil(const AttachmentDesc& attachment)
 {
-	if (attachment.texture == nullptr)
+	const auto surfaceId = attachmentPipelineSurfaceId(attachment);
+	if (!surfaceId.has_value())
 	{
 		return false;
 	}
-	auto& ctx = gfx_api::context::get();
-	const auto surfaceId = ctx.findPipelineSurfaceId(attachment.texture);
-	if (surfaceId.has_value())
-	{
-		return ctx.pipelineSurfaceMeta(surfaceId.value()).usage == PipelineSurfaceUsage::DepthStencil;
-	}
-	return false;
+	return gfx_api::context::get().pipelineSurfaceUsage(surfaceId.value())
+		== PipelineSurfaceUsage::DepthStencil;
 }
 
 std::optional<PassOutputView> getPassOutputAttachment(
@@ -626,25 +631,27 @@ bool isSwapchainPresentableColorSurface(abstract_texture* texture)
 	return surfaceId.has_value() && surfaceId.value() == PipelineSurfaceId::SwapchainColor;
 }
 
+bool isSwapchainPresentableColorSurface(const AttachmentDesc& attachment)
+{
+	const auto surfaceId = attachmentPipelineSurfaceId(attachment);
+	return surfaceId.has_value() && surfaceId.value() == PipelineSurfaceId::SwapchainColor;
+}
+
 bool passTargetsSwapchainColor(const RenderPassDesc& pass)
 {
-	auto& ctx = gfx_api::context::get();
 	for (const auto& attachment : pass.colorAttachments)
 	{
-		if (attachment.texture != nullptr)
+		const auto surfaceId = attachmentPipelineSurfaceId(attachment);
+		if (surfaceId.has_value()
+			&& (surfaceId.value() == PipelineSurfaceId::SwapchainColor
+				|| surfaceId.value() == PipelineSurfaceId::SwapchainMSAAColor))
 		{
-			const auto surfaceId = ctx.findPipelineSurfaceId(attachment.texture);
-			if (surfaceId.has_value()
-				&& (surfaceId.value() == PipelineSurfaceId::SwapchainColor
-					|| surfaceId.value() == PipelineSurfaceId::SwapchainMSAAColor))
-			{
-				return true;
-			}
+			return true;
 		}
 	}
-	if (pass.resolveAttachment.has_value() && pass.resolveAttachment->texture != nullptr)
+	if (pass.resolveAttachment.has_value())
 	{
-		const auto surfaceId = ctx.findPipelineSurfaceId(pass.resolveAttachment->texture);
+		const auto surfaceId = attachmentPipelineSurfaceId(pass.resolveAttachment.value());
 		if (surfaceId.has_value() && surfaceId.value() == PipelineSurfaceId::SwapchainColor)
 		{
 			return true;

--- a/lib/ivis_opengl/render_graph/pass_resolve.h
+++ b/lib/ivis_opengl/render_graph/pass_resolve.h
@@ -87,6 +87,8 @@ bool attachmentDepthHasStencil(const AttachmentDesc& attachment);
 
 /// True when the texture is the swapchain presentable color surface.
 bool isSwapchainPresentableColorSurface(abstract_texture* texture);
+/// True when the attachment is the swapchain presentable color surface.
+bool isSwapchainPresentableColorSurface(const AttachmentDesc& attachment);
 
 /// Resolve which texture/subresource a producer pass exposes for a given `AttachmentRole`.
 std::optional<PassOutputView> getPassOutputAttachment(

--- a/lib/ivis_opengl/render_graph/pipeline_surfaces.cpp
+++ b/lib/ivis_opengl/render_graph/pipeline_surfaces.cpp
@@ -19,7 +19,7 @@
 	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
 */
 /** @file pipeline_surfaces.cpp
- * Implementation of pipeline surface metadata and registry lookup helpers.
+ * Catalog table, resolvePipelineSurfaces, PipelineSurfaceStore ensure engine, and sync helpers.
  */
 
 #include "pipeline_surfaces.h"
@@ -30,95 +30,415 @@
 
 namespace gfx_api
 {
-
-PipelineSurfaceMeta getPipelineSurfaceMeta(PipelineSurfaceId id)
+namespace
 {
-	PipelineSurfaceMeta meta;
-	switch (id)
+
+constexpr PipelineSurfaceCatalogEntry makeCatalogEntry(
+	PipelineSurfaceUsage usage,
+	SurfaceExtentPolicy extentPolicy,
+	SurfaceSamplePolicy samplePolicy,
+	SurfaceFormatClass formatClass,
+	SurfaceGpuUsage gpuUsage,
+	SurfaceArrayLayerPolicy arrayLayerPolicy,
+	SurfaceEnablePolicy enablePolicy,
+	SurfaceProvisionMode provisionMode,
+	SurfaceStorageKind storageKind,
+	SurfaceLifetimePolicy lifetimePolicy,
+	PipelineSurfaceId formatCompanion = PipelineSurfaceId::Count)
+{
+	PipelineSurfaceCatalogEntry entry;
+	entry.usage = usage;
+	entry.extentPolicy = extentPolicy;
+	entry.samplePolicy = samplePolicy;
+	entry.formatClass = formatClass;
+	entry.gpuUsage = gpuUsage;
+	entry.arrayLayerPolicy = arrayLayerPolicy;
+	entry.enablePolicy = enablePolicy;
+	entry.provisionMode = provisionMode;
+	entry.storageKind = storageKind;
+	entry.lifetimePolicy = lifetimePolicy;
+	entry.formatCompanion = formatCompanion;
+	return entry;
+}
+
+const PipelineSurfaceCatalogTable PIPELINE_SURFACE_CATALOG = {{
+	// SceneColor
+	makeCatalogEntry(
+		PipelineSurfaceUsage::ColorResolve,
+		SurfaceExtentPolicy::MatchScene,
+		SurfaceSamplePolicy::One,
+		SurfaceFormatClass::SceneColor,
+		SurfaceGpuUsage::ColorAttachment | SurfaceGpuUsage::Sampled,
+		SurfaceArrayLayerPolicy::One,
+		SurfaceEnablePolicy::Always,
+		SurfaceProvisionMode::Allocate,
+		SurfaceStorageKind::SampledColor2D,
+		SurfaceLifetimePolicy::SwapchainBound),
+	// SceneMSAAColor
+	makeCatalogEntry(
+		PipelineSurfaceUsage::ColorMSAA,
+		SurfaceExtentPolicy::MatchScene,
+		SurfaceSamplePolicy::SceneMsaa,
+		SurfaceFormatClass::MatchCompanion,
+		SurfaceGpuUsage::ColorAttachment,
+		SurfaceArrayLayerPolicy::One,
+		SurfaceEnablePolicy::SceneMsaaActive,
+		SurfaceProvisionMode::Allocate,
+		SurfaceStorageKind::MsaaColorAttachment,
+		SurfaceLifetimePolicy::SwapchainBound,
+		PipelineSurfaceId::SceneColor),
+	// SceneDepth
+	makeCatalogEntry(
+		PipelineSurfaceUsage::DepthStencil,
+		SurfaceExtentPolicy::MatchScene,
+		SurfaceSamplePolicy::SceneMsaa,
+		SurfaceFormatClass::DepthStencil,
+		SurfaceGpuUsage::DepthStencilAttachment,
+		SurfaceArrayLayerPolicy::One,
+		SurfaceEnablePolicy::Always,
+		SurfaceProvisionMode::Allocate,
+		SurfaceStorageKind::DepthStencilAttachment,
+		SurfaceLifetimePolicy::SwapchainBound),
+	// ShadowMap
+	makeCatalogEntry(
+		PipelineSurfaceUsage::DepthOnly,
+		SurfaceExtentPolicy::ShadowMapSquare,
+		SurfaceSamplePolicy::One,
+		SurfaceFormatClass::DepthSampled,
+		SurfaceGpuUsage::DepthStencilAttachment | SurfaceGpuUsage::Sampled,
+		SurfaceArrayLayerPolicy::ShadowCascadeCount,
+		SurfaceEnablePolicy::ShadowCascadesNonZero,
+		SurfaceProvisionMode::Allocate,
+		SurfaceStorageKind::SampledDepthArray,
+		SurfaceLifetimePolicy::Persistent),
+	// SwapchainColor
+	makeCatalogEntry(
+		PipelineSurfaceUsage::SwapchainPresent,
+		SurfaceExtentPolicy::MatchDrawable,
+		SurfaceSamplePolicy::One,
+		SurfaceFormatClass::PresentColor,
+		SurfaceGpuUsage::ColorAttachment,
+		SurfaceArrayLayerPolicy::One,
+		SurfaceEnablePolicy::Always,
+		SurfaceProvisionMode::WsiPresentColor,
+		SurfaceStorageKind::None,
+		SurfaceLifetimePolicy::SwapchainBound),
+	// SwapchainMSAAColor — see header note: GL keeps this disabled via sync inputs / EnablePolicy.
+	makeCatalogEntry(
+		PipelineSurfaceUsage::ColorMSAA,
+		SurfaceExtentPolicy::MatchDrawable,
+		SurfaceSamplePolicy::SwapchainMsaa,
+		SurfaceFormatClass::MatchCompanion,
+		SurfaceGpuUsage::ColorAttachment,
+		SurfaceArrayLayerPolicy::One,
+		SurfaceEnablePolicy::SwapchainMsaaActive,
+		SurfaceProvisionMode::Allocate,
+		SurfaceStorageKind::MsaaColorAttachment,
+		SurfaceLifetimePolicy::SwapchainBound,
+		PipelineSurfaceId::SwapchainColor),
+	// SwapchainDepth
+	makeCatalogEntry(
+		PipelineSurfaceUsage::DepthStencil,
+		SurfaceExtentPolicy::MatchDrawable,
+		SurfaceSamplePolicy::SwapchainMsaa,
+		SurfaceFormatClass::DepthStencil,
+		SurfaceGpuUsage::DepthStencilAttachment,
+		SurfaceArrayLayerPolicy::One,
+		SurfaceEnablePolicy::Always,
+		SurfaceProvisionMode::WsiPresentDepth,
+		SurfaceStorageKind::None,
+		SurfaceLifetimePolicy::SwapchainBound),
+}};
+
+void validatePipelineSurfaceCatalog()
+{
+	size_t persistentCount = 0;
+	for (size_t i = 0; i < PIPELINE_SURFACE_COUNT; ++i)
 	{
-	case PipelineSurfaceId::SceneColor:
-		meta.usage = PipelineSurfaceUsage::ColorResolve;
-		meta.format = pixel_format::FORMAT_RGBA8_UNORM_PACK8;
-		meta.samples = 1;
+		const PipelineSurfaceCatalogEntry& cat = PIPELINE_SURFACE_CATALOG[i];
+		if (cat.provisionMode == SurfaceProvisionMode::Allocate)
+		{
+			ASSERT(cat.storageKind != SurfaceStorageKind::None,
+				"Allocate catalog row %zu must set storageKind", i);
+		}
+		else
+		{
+			ASSERT(cat.storageKind == SurfaceStorageKind::None,
+				"WSI catalog row %zu must use storageKind None", i);
+		}
+
+		SurfaceGpuUsage expected = SurfaceGpuUsage::None;
+		switch (cat.storageKind)
+		{
+		case SurfaceStorageKind::SampledColor2D:
+			expected = SurfaceGpuUsage::ColorAttachment | SurfaceGpuUsage::Sampled;
+			break;
+		case SurfaceStorageKind::MsaaColorAttachment:
+			expected = SurfaceGpuUsage::ColorAttachment;
+			break;
+		case SurfaceStorageKind::DepthStencilAttachment:
+			expected = SurfaceGpuUsage::DepthStencilAttachment;
+			break;
+		case SurfaceStorageKind::SampledDepthArray:
+			expected = SurfaceGpuUsage::DepthStencilAttachment | SurfaceGpuUsage::Sampled;
+			break;
+		case SurfaceStorageKind::None:
+			expected = (cat.provisionMode == SurfaceProvisionMode::WsiPresentDepth)
+				? SurfaceGpuUsage::DepthStencilAttachment
+				: SurfaceGpuUsage::ColorAttachment;
+			break;
+		}
+		ASSERT(cat.gpuUsage == expected,
+			"Catalog row %zu gpuUsage does not match storageKind", i);
+
+		if (cat.lifetimePolicy == SurfaceLifetimePolicy::Persistent)
+		{
+			++persistentCount;
+			ASSERT(static_cast<PipelineSurfaceId>(i) == PipelineSurfaceId::ShadowMap,
+				"Only ShadowMap should be Persistent (row %zu)", i);
+		}
+
+		if (cat.formatClass == SurfaceFormatClass::MatchCompanion)
+		{
+			ASSERT(cat.formatCompanion != PipelineSurfaceId::Count,
+				"MatchCompanion catalog row %zu requires formatCompanion", i);
+			ASSERT(static_cast<size_t>(cat.formatCompanion) < i,
+				"MatchCompanion companion index must precede dependent (row %zu)", i);
+		}
+	}
+	ASSERT(persistentCount == 1, "Expected exactly one Persistent catalog surface, got %zu", persistentCount);
+}
+
+struct CatalogValidator
+{
+	CatalogValidator()
+	{
+		validatePipelineSurfaceCatalog();
+	}
+};
+const CatalogValidator kCatalogValidator {};
+
+bool evalEnablePolicy(SurfaceEnablePolicy policy, const PipelineSurfaceSyncInputs& inputs)
+{
+	switch (policy)
+	{
+	case SurfaceEnablePolicy::Always:
+		return true;
+	case SurfaceEnablePolicy::SceneMsaaActive:
+		return inputs.sceneMsaaSamples > 1u;
+	case SurfaceEnablePolicy::SwapchainMsaaActive:
+		return inputs.swapchainMsaaSamples > 1u;
+	case SurfaceEnablePolicy::ShadowCascadesNonZero:
+		return inputs.numShadowCascades > 0u;
+	}
+	return false;
+}
+
+void resolveExtent(SurfaceExtentPolicy policy, const PipelineSurfaceSyncInputs& inputs,
+	uint32_t& width, uint32_t& height)
+{
+	switch (policy)
+	{
+	case SurfaceExtentPolicy::MatchDrawable:
+		width = inputs.drawableW;
+		height = inputs.drawableH;
 		break;
-	case PipelineSurfaceId::SceneMSAAColor:
-		meta.usage = PipelineSurfaceUsage::ColorMSAA;
-		meta.format = pixel_format::FORMAT_RGBA8_UNORM_PACK8;
-		meta.samples = 1;
+	case SurfaceExtentPolicy::MatchScene:
+		width = inputs.sceneW;
+		height = inputs.sceneH;
 		break;
-	case PipelineSurfaceId::SceneDepth:
-		meta.usage = PipelineSurfaceUsage::DepthStencil;
-		meta.format = pixel_format::FORMAT_D24_UNORM_S8;
-		meta.samples = 1;
-		break;
-	case PipelineSurfaceId::ShadowMap:
-		meta.usage = PipelineSurfaceUsage::DepthOnly;
-		meta.format = pixel_format::FORMAT_D24_UNORM_S8;
-		meta.samples = 1;
-		break;
-	case PipelineSurfaceId::SwapchainColor:
-		meta.usage = PipelineSurfaceUsage::SwapchainPresent;
-		meta.format = pixel_format::FORMAT_RGBA8_UNORM_PACK8;
-		meta.samples = 1;
-		break;
-	case PipelineSurfaceId::SwapchainMSAAColor:
-		meta.usage = PipelineSurfaceUsage::ColorMSAA;
-		meta.format = pixel_format::FORMAT_RGBA8_UNORM_PACK8;
-		meta.samples = 1;
-		break;
-	case PipelineSurfaceId::SwapchainDepth:
-		meta.usage = PipelineSurfaceUsage::DepthStencil;
-		meta.format = pixel_format::FORMAT_D24_UNORM_S8;
-		meta.samples = 1;
-		break;
-	case PipelineSurfaceId::Count:
-		ASSERT(false, "Invalid pipeline surface ID");
+	case SurfaceExtentPolicy::ShadowMapSquare:
+		width = inputs.shadowMapSize;
+		height = inputs.shadowMapSize;
 		break;
 	}
-	return meta;
 }
 
-void PipelineSurfaceRegistry::registerSurface(PipelineSurfaceId id, abstract_texture* surface)
+uint32_t resolveSamples(SurfaceSamplePolicy policy, const PipelineSurfaceSyncInputs& inputs)
 {
-	_surfaces[static_cast<size_t>(id)] = surface;
-}
-
-void PipelineSurfaceRegistry::invalidateSurface(PipelineSurfaceId id)
-{
-	_surfaces[static_cast<size_t>(id)] = nullptr;
-	_samplesOverride[static_cast<size_t>(id)] = 0;
-}
-
-abstract_texture* PipelineSurfaceRegistry::get(PipelineSurfaceId id) const
-{
-	return _surfaces[static_cast<size_t>(id)];
-}
-
-void PipelineSurfaceRegistry::setSurfaceSamples(PipelineSurfaceId id, uint32_t samples)
-{
-	_samplesOverride[static_cast<size_t>(id)] = samples;
-}
-
-PipelineSurfaceMeta PipelineSurfaceRegistry::meta(PipelineSurfaceId id) const
-{
-	PipelineSurfaceMeta result = getPipelineSurfaceMeta(id);
-	const uint32_t overrideSamples = _samplesOverride[static_cast<size_t>(id)];
-	if (overrideSamples > 0)
+	switch (policy)
 	{
-		result.samples = overrideSamples;
+	case SurfaceSamplePolicy::One:
+		return 1u;
+	case SurfaceSamplePolicy::SceneMsaa:
+		return inputs.sceneMsaaSamples > 0u ? inputs.sceneMsaaSamples : 1u;
+	case SurfaceSamplePolicy::SwapchainMsaa:
+		return inputs.swapchainMsaaSamples > 0u ? inputs.swapchainMsaaSamples : 1u;
 	}
-	return result;
+	return 1u;
 }
 
-nonstd::optional<PipelineSurfaceId> PipelineSurfaceRegistry::findSurfaceId(abstract_texture* texture) const
+uint32_t resolveArrayLayers(SurfaceArrayLayerPolicy policy, const PipelineSurfaceSyncInputs& inputs)
+{
+	switch (policy)
+	{
+	case SurfaceArrayLayerPolicy::One:
+		return 1u;
+	case SurfaceArrayLayerPolicy::ShadowCascadeCount:
+		return inputs.numShadowCascades;
+	}
+	return 1u;
+}
+
+pixel_format resolveFormat(SurfaceFormatClass formatClass, PipelineSurfaceId formatCompanion,
+	const PipelineSurfaceSyncInputs& inputs, const SurfaceCapabilityHints& caps,
+	const ResolvedSurfaceTable& out)
+{
+	switch (formatClass)
+	{
+	case SurfaceFormatClass::SceneColor:
+		return caps.sceneColorFormat;
+	case SurfaceFormatClass::DepthStencil:
+		return caps.depthStencilFormat;
+	case SurfaceFormatClass::DepthSampled:
+		return caps.depthSampledFormat;
+	case SurfaceFormatClass::PresentColor:
+		return inputs.presentColorFormat;
+	case SurfaceFormatClass::MatchCompanion:
+		ASSERT(formatCompanion != PipelineSurfaceId::Count, "MatchCompanion requires formatCompanion");
+		ASSERT(static_cast<size_t>(formatCompanion) < PIPELINE_SURFACE_COUNT,
+			"Invalid formatCompanion id");
+		return out[static_cast<size_t>(formatCompanion)].format;
+	}
+	return pixel_format::invalid;
+}
+
+} // namespace
+
+const PipelineSurfaceCatalogTable& pipelineSurfaceCatalog()
+{
+	return PIPELINE_SURFACE_CATALOG;
+}
+
+const PipelineSurfaceCatalogEntry& pipelineSurfaceCatalogEntry(PipelineSurfaceId id)
+{
+	ASSERT(id != PipelineSurfaceId::Count, "Invalid pipeline surface ID");
+	return PIPELINE_SURFACE_CATALOG[static_cast<size_t>(id)];
+}
+
+void collectPipelineSurfaceIdsByLifetime(SurfaceLifetimePolicy policy,
+	std::vector<PipelineSurfaceId>& out)
+{
+	out.clear();
+	for (size_t i = 0; i < PIPELINE_SURFACE_COUNT; ++i)
+	{
+		if (PIPELINE_SURFACE_CATALOG[i].lifetimePolicy == policy)
+		{
+			out.push_back(static_cast<PipelineSurfaceId>(i));
+		}
+	}
+}
+
+bool context::syncPipelineSurfaces()
+{
+	return ensurePipelineSurfaces(resolvePipelineSurfaces(pipelineSurfaceSyncInputs(), surfaceCapabilities()));
+}
+
+PipelineSurfaceUsage context::pipelineSurfaceUsage(PipelineSurfaceId id) const
+{
+	return pipelineSurfaceCatalogEntry(id).usage;
+}
+
+const ResolvedSurfaceSpec& context::resolvedPipelineSurface(PipelineSurfaceId id) const
+{
+	static const auto EMPTY_SPECS = [] {
+		std::array<ResolvedSurfaceSpec, PIPELINE_SURFACE_COUNT> table {};
+		for (size_t i = 0; i < PIPELINE_SURFACE_COUNT; ++i)
+		{
+			table[i].id = static_cast<PipelineSurfaceId>(i);
+			table[i].enabled = false;
+		}
+		return table;
+	}();
+	ASSERT(id != PipelineSurfaceId::Count, "Invalid pipeline surface ID");
+	return EMPTY_SPECS[static_cast<size_t>(id)];
+}
+
+optional<std::pair<uint32_t, uint32_t>> context::getPipelineSurfaceDimensions(PipelineSurfaceId id) const
+{
+	const ResolvedSurfaceSpec& spec = resolvedPipelineSurface(id);
+	if (!spec.enabled || spec.width == 0 || spec.height == 0)
+	{
+		return nullopt;
+	}
+	return {{spec.width, spec.height}};
+}
+
+ResolvedSurfaceTable resolvePipelineSurfaces(const PipelineSurfaceSyncInputs& inputs,
+	const SurfaceCapabilityHints& caps)
+{
+	ResolvedSurfaceTable out {};
+	for (size_t i = 0; i < PIPELINE_SURFACE_COUNT; ++i)
+	{
+		const PipelineSurfaceId id = static_cast<PipelineSurfaceId>(i);
+		const PipelineSurfaceCatalogEntry& cat = PIPELINE_SURFACE_CATALOG[i];
+		ResolvedSurfaceSpec& spec = out[i];
+
+		spec.id = id;
+		spec.usage = cat.usage;
+		spec.provisionMode = cat.provisionMode;
+		spec.storageKind = cat.storageKind;
+		spec.gpuUsage = cat.gpuUsage;
+		spec.enabled = evalEnablePolicy(cat.enablePolicy, inputs);
+		spec.preserveIfDisabled = false;
+
+		uint32_t width = 0;
+		uint32_t height = 0;
+		resolveExtent(cat.extentPolicy, inputs, width, height);
+
+		if (cat.extentPolicy == SurfaceExtentPolicy::ShadowMapSquare && inputs.shadowMapSize == 0u)
+		{
+			spec.enabled = false;
+			spec.preserveIfDisabled = false;
+			width = 0;
+			height = 0;
+		}
+		else if (spec.enabled
+			&& (cat.extentPolicy == SurfaceExtentPolicy::MatchDrawable
+				|| cat.extentPolicy == SurfaceExtentPolicy::MatchScene)
+			&& (width == 0u || height == 0u))
+		{
+			spec.enabled = false;
+			spec.preserveIfDisabled = true;
+			width = 0;
+			height = 0;
+		}
+
+		spec.width = width;
+		spec.height = height;
+		spec.samples = resolveSamples(cat.samplePolicy, inputs);
+		spec.arrayLayers = resolveArrayLayers(cat.arrayLayerPolicy, inputs);
+		spec.format = resolveFormat(cat.formatClass, cat.formatCompanion, inputs, caps, out);
+	}
+	return out;
+}
+
+abstract_texture* PipelineSurfaceStore::get(PipelineSurfaceId id) const
+{
+	ASSERT(id != PipelineSurfaceId::Count, "Invalid pipeline surface ID");
+	return _slots[static_cast<size_t>(id)].texture;
+}
+
+const ResolvedSurfaceSpec& PipelineSurfaceStore::spec(PipelineSurfaceId id) const
+{
+	ASSERT(id != PipelineSurfaceId::Count, "Invalid pipeline surface ID");
+	return _slots[static_cast<size_t>(id)].spec;
+}
+
+bool PipelineSurfaceStore::has(PipelineSurfaceId id) const
+{
+	return get(id) != nullptr;
+}
+
+nonstd::optional<PipelineSurfaceId> PipelineSurfaceStore::find(abstract_texture* texture) const
 {
 	if (texture == nullptr)
 	{
 		return nonstd::nullopt;
 	}
-	for (size_t i = 0; i < static_cast<size_t>(PipelineSurfaceId::Count); ++i)
+	for (size_t i = 0; i < PIPELINE_SURFACE_COUNT; ++i)
 	{
-		if (_surfaces[i] == texture)
+		if (_slots[i].texture == texture)
 		{
 			return static_cast<PipelineSurfaceId>(i);
 		}
@@ -126,14 +446,137 @@ nonstd::optional<PipelineSurfaceId> PipelineSurfaceRegistry::findSurfaceId(abstr
 	return nonstd::nullopt;
 }
 
-AttachmentDesc makePipelineSurfaceAttachment(PipelineSurfaceId id, AttachmentLoadOp op, ClearValue clear)
+PipelineSurfaceUsage PipelineSurfaceStore::usage(PipelineSurfaceId id) const
 {
-	AttachmentDesc desc;
-	desc.texture = context::get().getPipelineSurface(id);
-	ASSERT(desc.texture != nullptr, "Pipeline surface %u is not registered", static_cast<unsigned>(id));
-	desc.loadOp = op;
-	desc.clearValue = clear;
-	return desc;
+	ASSERT(id != PipelineSurfaceId::Count, "Invalid pipeline surface ID");
+	const PipelineSurfaceSlotView& slot = _slots[static_cast<size_t>(id)];
+	if (slot.spec.id == id)
+	{
+		return slot.spec.usage;
+	}
+	return pipelineSurfaceCatalogEntry(id).usage;
+}
+
+bool PipelineSurfaceStore::matches(const PipelineSurfaceSlotView& slot, const ResolvedSurfaceSpec& spec)
+{
+	if (slot.spec.enabled != spec.enabled
+		|| slot.spec.format != spec.format
+		|| slot.spec.samples != spec.samples
+		|| slot.spec.width != spec.width
+		|| slot.spec.height != spec.height
+		|| slot.spec.arrayLayers != spec.arrayLayers
+		|| slot.spec.gpuUsage != spec.gpuUsage
+		|| slot.spec.provisionMode != spec.provisionMode
+		|| slot.spec.storageKind != spec.storageKind)
+	{
+		return false;
+	}
+	if (spec.enabled)
+	{
+		return slot.texture != nullptr;
+	}
+	if (spec.preserveIfDisabled)
+	{
+		return true;
+	}
+	return slot.texture == nullptr;
+}
+
+bool PipelineSurfaceStore::ensure(const ResolvedSurfaceTable& resolved, SurfaceAllocator& alloc)
+{
+	bool changed = false;
+	bool prepareCalled = false;
+	auto ensurePrepared = [&]() {
+		if (!prepareCalled)
+		{
+			alloc.prepareForSurfaceDestroy();
+			prepareCalled = true;
+		}
+	};
+	for (size_t i = 0; i < PIPELINE_SURFACE_COUNT; ++i)
+	{
+		const auto id = static_cast<PipelineSurfaceId>(i);
+		const ResolvedSurfaceSpec& spec = resolved[i];
+		PipelineSurfaceSlotView& slot = _slots[i];
+		if (matches(slot, spec))
+		{
+			slot.spec = spec;
+			continue;
+		}
+		if (!spec.enabled)
+		{
+			if (spec.preserveIfDisabled)
+			{
+				slot.spec = spec;
+				continue;
+			}
+			if (slot.texture != nullptr)
+			{
+				ensurePrepared();
+				alloc.destroy(id, slot.texture);
+				slot.texture = nullptr;
+				changed = true;
+			}
+			slot.spec = spec;
+			continue;
+		}
+		if (slot.texture != nullptr)
+		{
+			ensurePrepared();
+			alloc.destroy(id, slot.texture);
+			slot.texture = nullptr;
+			changed = true;
+		}
+		abstract_texture* created = nullptr;
+		if (!alloc.create(id, spec, created) || created == nullptr)
+		{
+			slot.spec = ResolvedSurfaceSpec {};
+			slot.texture = nullptr;
+			// Partial store state; caller should treat as hard failure and re-sync / abort init.
+			if (changed)
+			{
+				alloc.onChanged();
+			}
+			return false;
+		}
+		slot.texture = created;
+		slot.spec = spec;
+		changed = true;
+	}
+	if (changed)
+	{
+		alloc.onChanged();
+	}
+	return true;
+}
+
+void PipelineSurfaceStore::resetAll(SurfaceAllocator& alloc)
+{
+	alloc.prepareForSurfaceDestroy();
+	for (size_t i = 0; i < PIPELINE_SURFACE_COUNT; ++i)
+	{
+		const auto id = static_cast<PipelineSurfaceId>(i);
+		PipelineSurfaceSlotView& slot = _slots[i];
+		alloc.destroy(id, slot.texture);
+		slot.texture = nullptr;
+		slot.spec = ResolvedSurfaceSpec {};
+	}
+	alloc.onChanged();
+}
+
+void PipelineSurfaceStore::resetIds(SurfaceAllocator& alloc, const PipelineSurfaceId* ids, size_t count)
+{
+	alloc.prepareForSurfaceDestroy();
+	for (size_t i = 0; i < count; ++i)
+	{
+		const PipelineSurfaceId id = ids[i];
+		ASSERT(id != PipelineSurfaceId::Count, "Invalid pipeline surface ID");
+		PipelineSurfaceSlotView& slot = _slots[static_cast<size_t>(id)];
+		alloc.destroy(id, slot.texture);
+		slot.texture = nullptr;
+		slot.spec = ResolvedSurfaceSpec {};
+	}
+	alloc.onChanged();
 }
 
 } // namespace gfx_api

--- a/lib/ivis_opengl/render_graph/pipeline_surfaces.h
+++ b/lib/ivis_opengl/render_graph/pipeline_surfaces.h
@@ -19,7 +19,20 @@
 	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
 */
 /** @file pipeline_surfaces.h
- * Named persistent render targets (`PipelineSurfaceId`) and backend surface registry.
+ * Pipeline surface architecture:
+ * catalog policies -> resolvePipelineSurfaces -> PipelineSurfaceStore::ensure(SurfaceAllocator)
+ * -> backend GPU ownership (VkSurfaceGpu / GlSurfaceGpu). Context exposes get / usage / resolved.
+ *
+ * Adding a PipelineSurfaceId:
+ * 1. Append enum value (before Count) and catalog row (policies + lifetime).
+ * 2. Implement create/destroy for storageKind in VK and GL PipelineSurfaceAllocator.
+ * 3. Wire blueprint attachments / topology if the surface is graph-visible.
+ * 4. beginPass attachment binding if new cascade/view rules are needed.
+ * 5. LifetimePolicy=Persistent only if it must survive swapchain recreate.
+ *
+ * Swapchain MSAA: enabled only when sync inputs report swapchainMsaaSamples > 1.
+ * GL currently forces samples=1 / isSwapchainMSAAEnabled()==false — catalog row stays
+ * for VK parity; surface remains disabled on GL via EnablePolicy::SwapchainMsaaActive.
  */
 
 #pragma once
@@ -27,8 +40,9 @@
 #include <array>
 #include <cstddef>
 #include <cstdint>
+#include <initializer_list>
+#include <vector>
 
-#include "attachment.h"
 #include "../gfx_api_formats_def.h"
 
 #include <nonstd/optional.hpp>
@@ -41,8 +55,8 @@ struct abstract_texture;
 /// <summary>
 /// Named persistent render targets shared across passes (scene, swapchain, shadow map).
 ///
-/// Backends register live `abstract_texture*` instances in `PipelineSurfaceRegistry`.
-/// Blueprints and `BlueprintMaterializer` refer to surfaces by id, not raw pointers.
+/// Backends store live GPU objects behind PipelineSurfaceStore; context exposes them via
+/// `getPipelineSurface` / usage / resolved-spec accessors. Blueprints refer to surfaces by id.
 /// </summary>
 enum class PipelineSurfaceId : uint8_t
 {
@@ -70,51 +84,236 @@ enum class PipelineSurfaceUsage : uint8_t
 	SwapchainPresent,
 };
 
-/// <summary>
-/// Static description of a pipeline surface: usage class, pixel format, and sample count.
-/// </summary>
-struct PipelineSurfaceMeta
+inline bool isDepthUsage(PipelineSurfaceUsage usage)
+{
+	return usage == PipelineSurfaceUsage::DepthStencil
+		|| usage == PipelineSurfaceUsage::DepthOnly;
+}
+
+/// How resolve derives width/height from sync inputs.
+enum class SurfaceExtentPolicy : uint8_t
+{
+	MatchDrawable,
+	MatchScene,
+	ShadowMapSquare,
+};
+
+/// How resolve derives MSAA sample count from sync inputs.
+enum class SurfaceSamplePolicy : uint8_t
+{
+	One,
+	SceneMsaa,
+	SwapchainMsaa,
+};
+
+/// Which format source resolve uses (HW capability slot, present format, or companion).
+enum class SurfaceFormatClass : uint8_t
+{
+	SceneColor,
+	DepthStencil,
+	DepthSampled,
+	PresentColor,
+	MatchCompanion,
+};
+
+/// Abstract GPU usage flags the backend must honor when allocating.
+enum class SurfaceGpuUsage : uint32_t
+{
+	None = 0,
+	ColorAttachment = 1u << 0,
+	DepthStencilAttachment = 1u << 1,
+	Sampled = 1u << 2,
+};
+
+constexpr SurfaceGpuUsage operator|(SurfaceGpuUsage a, SurfaceGpuUsage b)
+{
+	return static_cast<SurfaceGpuUsage>(static_cast<uint32_t>(a) | static_cast<uint32_t>(b));
+}
+
+constexpr SurfaceGpuUsage operator&(SurfaceGpuUsage a, SurfaceGpuUsage b)
+{
+	return static_cast<SurfaceGpuUsage>(static_cast<uint32_t>(a) & static_cast<uint32_t>(b));
+}
+
+constexpr bool hasFlag(SurfaceGpuUsage value, SurfaceGpuUsage flag)
+{
+	return (static_cast<uint32_t>(value) & static_cast<uint32_t>(flag)) != 0u;
+}
+
+/// How resolve derives array layer count from sync inputs.
+enum class SurfaceArrayLayerPolicy : uint8_t
+{
+	One,
+	ShadowCascadeCount,
+};
+
+/// When resolve marks a catalog surface enabled for the current inputs.
+enum class SurfaceEnablePolicy : uint8_t
+{
+	Always,
+	SceneMsaaActive,
+	SwapchainMsaaActive,
+	ShadowCascadesNonZero,
+};
+
+/// How the backend materializes the surface (allocate vs WSI import).
+enum class SurfaceProvisionMode : uint8_t
+{
+	Allocate,
+	WsiPresentColor,
+	WsiPresentDepth,
+};
+
+/// Which GPU constructor the backend allocator uses when provisionMode == Allocate.
+enum class SurfaceStorageKind : uint8_t
+{
+	None,                    // WSI rows; must be None if provisionMode != Allocate
+	SampledColor2D,          // VkRenderedImage / GL color texture
+	MsaaColorAttachment,     // Vk MSAA color image / GL MSAA color renderbuffer
+	DepthStencilAttachment,  // Vk depth image / GL depth-stencil renderbuffer
+	SampledDepthArray,       // VkDepthMapImage + cascade views / GL depth array + compare
+};
+
+/// Whether a surface survives swapchain teardown/recreate.
+enum class SurfaceLifetimePolicy : uint8_t
+{
+	SwapchainBound, // reset with swapchain (scene + present surfaces)
+	Persistent,    // survives swapchain recreate (ShadowMap)
+};
+
+/// Static policy row for one PipelineSurfaceId (never holds runtime sizes/formats).
+struct PipelineSurfaceCatalogEntry
 {
 	PipelineSurfaceUsage usage = PipelineSurfaceUsage::ColorResolve;
-	pixel_format format = pixel_format::invalid;
-	/// Default 1; MSAA surfaces may override via `PipelineSurfaceRegistry::setSurfaceSamples`.
-	uint32_t samples = 1;
+	SurfaceExtentPolicy extentPolicy = SurfaceExtentPolicy::MatchDrawable;
+	SurfaceSamplePolicy samplePolicy = SurfaceSamplePolicy::One;
+	SurfaceFormatClass formatClass = SurfaceFormatClass::SceneColor;
+	SurfaceGpuUsage gpuUsage = SurfaceGpuUsage::None;
+	SurfaceArrayLayerPolicy arrayLayerPolicy = SurfaceArrayLayerPolicy::One;
+	SurfaceEnablePolicy enablePolicy = SurfaceEnablePolicy::Always;
+	SurfaceProvisionMode provisionMode = SurfaceProvisionMode::Allocate;
+	SurfaceStorageKind storageKind = SurfaceStorageKind::None;
+	SurfaceLifetimePolicy lifetimePolicy = SurfaceLifetimePolicy::SwapchainBound;
+	PipelineSurfaceId formatCompanion = PipelineSurfaceId::Count; // MatchCompanion only
 };
 
-/// Built-in defaults per `PipelineSurfaceId` (samples may be overridden at registration).
-PipelineSurfaceMeta getPipelineSurfaceMeta(PipelineSurfaceId id);
+/// Runtime identity produced by resolve; consumed by ensure / matches.
+struct ResolvedSurfaceSpec
+{
+	PipelineSurfaceId id = PipelineSurfaceId::Count;
+	PipelineSurfaceUsage usage = PipelineSurfaceUsage::ColorResolve;
+	SurfaceProvisionMode provisionMode = SurfaceProvisionMode::Allocate;
+	SurfaceStorageKind storageKind = SurfaceStorageKind::None;
+	SurfaceGpuUsage gpuUsage = SurfaceGpuUsage::None;
+	pixel_format format = pixel_format::invalid;
+	uint32_t samples = 1;
+	uint32_t width = 0;
+	uint32_t height = 0;
+	uint32_t arrayLayers = 1;
+	bool enabled = false;
+	bool preserveIfDisabled = false; // keep GPU objects when disabled due to zero extent
+};
 
-/// <summary>
-/// Fixed-size registry of persistent pipeline render targets owned by the gfx backend.
+/// Per-sync sizes, sample counts, cascade count, and present format from the backend.
+struct PipelineSurfaceSyncInputs
+{
+	uint32_t drawableW = 0;
+	uint32_t drawableH = 0;
+	uint32_t sceneW = 0;
+	uint32_t sceneH = 0;
+	uint32_t shadowMapSize = 0;
+	uint32_t numShadowCascades = 0;
+	uint32_t sceneMsaaSamples = 1;
+	uint32_t swapchainMsaaSamples = 1;
+	pixel_format presentColorFormat = pixel_format::FORMAT_RGBA8_UNORM_PACK8;
+};
+
+/// Backend HW-negotiated formats for each SurfaceFormatClass capability slot.
+struct SurfaceCapabilityHints
+{
+	pixel_format sceneColorFormat = pixel_format::FORMAT_RGBA8_UNORM_PACK8;
+	pixel_format depthStencilFormat = pixel_format::FORMAT_D24_UNORM_S8;
+	pixel_format depthSampledFormat = pixel_format::FORMAT_D24_UNORM_S8;
+};
+
+constexpr size_t PIPELINE_SURFACE_COUNT = static_cast<size_t>(PipelineSurfaceId::Count);
+
+using PipelineSurfaceCatalogTable = std::array<PipelineSurfaceCatalogEntry, PIPELINE_SURFACE_COUNT>;
+using ResolvedSurfaceTable = std::array<ResolvedSurfaceSpec, PIPELINE_SURFACE_COUNT>;
+
+/// Catalog policy row for `id`.
+const PipelineSurfaceCatalogEntry& pipelineSurfaceCatalogEntry(PipelineSurfaceId id);
+/// Full static catalog table.
+const PipelineSurfaceCatalogTable& pipelineSurfaceCatalog();
+
+/// Resolve catalog policies against sync inputs and HW capability hints.
+ResolvedSurfaceTable resolvePipelineSurfaces(const PipelineSurfaceSyncInputs& inputs,
+	const SurfaceCapabilityHints& caps);
+
+/// Append all catalog IDs with the given lifetime policy (stable enum order).
+void collectPipelineSurfaceIdsByLifetime(SurfaceLifetimePolicy policy,
+	std::vector<PipelineSurfaceId>& out);
+
+/// Per-id view held by `PipelineSurfaceStore` (non-owning texture pointer).
+struct PipelineSurfaceSlotView
+{
+	ResolvedSurfaceSpec spec {};
+	abstract_texture* texture = nullptr;
+};
+
+/// Backend port: GPU create/destroy only. Must not mutate the store directly.
+struct SurfaceAllocator
+{
+	virtual ~SurfaceAllocator() = default;
+	/// Allocate or import; on success set outTexture non-null. On failure leave outTexture null.
+	virtual bool create(PipelineSurfaceId id, const ResolvedSurfaceSpec& spec,
+		abstract_texture*& outTexture) = 0;
+	/// Destroy GPU objects for id. texture may be null (no-op / clear orphans). Store clears its pointer after.
+	virtual void destroy(PipelineSurfaceId id, abstract_texture* texture) = 0;
+	/// Called once before any destroy in reset*/ensure mutate paths.
+	/// Must clear pass-resource caches and *defer* framebuffer deletes (VK).
+	/// Do not flush here — runtime ensure() is not GPU-idle. Hard-reset paths
+	/// flush deferred FBs after idle (reset wrappers / swapchain teardown).
+	virtual void prepareForSurfaceDestroy() = 0;
+	/// Called once if any slot changed (create/destroy). Clear FBO/FB caches + bump epoch.
+	virtual void onChanged() = 0;
+};
+
+/// Shared resolved-state table + ensure engine (texture ownership stays in the backend allocator).
 ///
-/// Populated at swapchain/scene/shadow setup (`registerSurface`); read during
-/// `resolvePassDescription` and `BlueprintMaterializer`. Lives on `gfx_api::context`.
-/// </summary>
-class PipelineSurfaceRegistry
+/// Teardown contract:
+/// - Store order: prepareForSurfaceDestroy() -> destroy GPU objects -> onChanged()
+/// - prepare clears pass FB/FBO caches and defers FB deletes (VK); it does not flush
+/// - Runtime ensure (not GPU-idle): defer FBs + defer attachment view/image/memory
+/// - Hard reset (after waitForAllIdle): same store order; reset wrappers / swapchain
+///   teardown flush deferred FBs; attachment images defer while buffering is live and
+///   are freed on buffering destroy, or destroyed immediately once buffering is gone
+/// Framebuffers/FBOs must not outlive the image views/attachments they reference.
+class PipelineSurfaceStore
 {
 public:
-	/// Bind a backend texture to a surface slot (non-owning pointer).
-	void registerSurface(PipelineSurfaceId id, abstract_texture* surface);
-	/// Clear a slot (e.g. on swapchain teardown).
-	void invalidateSurface(PipelineSurfaceId id);
 	abstract_texture* get(PipelineSurfaceId id) const;
+	const ResolvedSurfaceSpec& spec(PipelineSurfaceId id) const;
+	bool has(PipelineSurfaceId id) const;
+	nonstd::optional<PipelineSurfaceId> find(abstract_texture* texture) const;
+	PipelineSurfaceUsage usage(PipelineSurfaceId id) const;
 
-	/// Runtime sample count override (e.g. `SceneMSAAColor` / `SceneDepth` when MSAA is on).
-	void setSurfaceSamples(PipelineSurfaceId id, uint32_t samples);
-	/// Effective meta: static defaults merged with `_samplesOverride`.
-	PipelineSurfaceMeta meta(PipelineSurfaceId id) const;
-
-	/// Reverse lookup for attachment classification (depth-sampled vs swapchain present).
-	nonstd::optional<PipelineSurfaceId> findSurfaceId(abstract_texture* texture) const;
+	bool ensure(const ResolvedSurfaceTable& resolved, SurfaceAllocator& alloc);
+	void resetAll(SurfaceAllocator& alloc);
+	void resetIds(SurfaceAllocator& alloc, const PipelineSurfaceId* ids, size_t count);
+	void resetIds(SurfaceAllocator& alloc, std::initializer_list<PipelineSurfaceId> ids)
+	{
+		resetIds(alloc, ids.begin(), ids.size());
+	}
+	void resetIds(SurfaceAllocator& alloc, const std::vector<PipelineSurfaceId>& ids)
+	{
+		resetIds(alloc, ids.data(), ids.size());
+	}
 
 private:
-	std::array<abstract_texture*, static_cast<size_t>(PipelineSurfaceId::Count)> _surfaces {};
-	std::array<uint32_t, static_cast<size_t>(PipelineSurfaceId::Count)> _samplesOverride {};
-};
+	std::array<PipelineSurfaceSlotView, PIPELINE_SURFACE_COUNT> _slots {};
 
-/// Build an `AttachmentDesc` from a registered pipeline surface and load/clear ops.
-AttachmentDesc makePipelineSurfaceAttachment(PipelineSurfaceId id,
-	AttachmentLoadOp op = AttachmentLoadOp::Clear,
-	ClearValue clear = ClearValue::colorClear());
+	static bool matches(const PipelineSurfaceSlotView& slot, const ResolvedSurfaceSpec& spec);
+};
 
 } // namespace gfx_api

--- a/lib/ivis_opengl/render_graph/read_scope.cpp
+++ b/lib/ivis_opengl/render_graph/read_scope.cpp
@@ -39,7 +39,6 @@ ReadProducerScope classifyReadProducerScope(const ReadDesc& read,
 	switch (read.source)
 	{
 	case ReadSource::ExplicitTexture:
-	case ReadSource::PipelineSurface:
 		return ReadProducerScope::External;
 	case ReadSource::PassOutput:
 		if (read.producerPass >= consumerIndex || read.producerPass >= descs.size())

--- a/lib/ivis_opengl/render_graph/render_pass.h
+++ b/lib/ivis_opengl/render_graph/render_pass.h
@@ -70,8 +70,6 @@ enum class ReadSource : uint8_t
 {
 	/// Direct `abstract_texture*` on the read descriptor.
 	ExplicitTexture,
-	/// Named `PipelineSurfaceId` surface.
-	PipelineSurface,
 	/// Output of a prior pass in the same graph (`producerPass` + `AttachmentRole`).
 	PassOutput,
 };
@@ -84,8 +82,6 @@ struct ReadDesc
 	ReadSource source = ReadSource::ExplicitTexture;
 	/// Used when `source == ExplicitTexture`.
 	abstract_texture* texture = nullptr;
-	/// Used when `source == PipelineSurface`.
-	PipelineSurfaceId pipelineSurface = PipelineSurfaceId::SceneColor;
 	/// Used when `source == PassOutput` (materializer maps from `PassId` to this handle).
 	PassHandle producerPass = INVALID_PASS_HANDLE;
 	AttachmentRole producerRole = AttachmentRole::PrimaryColor;

--- a/lib/ivis_opengl/vk/layout_key_builder.cpp
+++ b/lib/ivis_opengl/vk/layout_key_builder.cpp
@@ -167,7 +167,7 @@ void ensurePassLayoutFinalLayouts(PassLayoutKey& layoutKey, const gfx_api::Rende
 			? layoutKey.colorStoreOps[i]
 			: AttachmentStoreOp::Store;
 		if (i < pass.colorAttachments.size()
-			&& gfx_api::isSwapchainPresentableColorSurface(pass.colorAttachments[i].texture))
+			&& gfx_api::isSwapchainPresentableColorSurface(pass.colorAttachments[i]))
 		{
 			layoutKey.colorFinalLayouts.push_back(::vk::ImageLayout::eColorAttachmentOptimal);
 		}
@@ -180,7 +180,7 @@ void ensurePassLayoutFinalLayouts(PassLayoutKey& layoutKey, const gfx_api::Rende
 	if (layoutKey.resolveFormat.has_value() && !layoutKey.resolveFinalLayout.has_value())
 	{
 		if (pass.resolveAttachment.has_value()
-			&& gfx_api::isSwapchainPresentableColorSurface(pass.resolveAttachment->texture))
+			&& gfx_api::isSwapchainPresentableColorSurface(pass.resolveAttachment.value()))
 		{
 			layoutKey.resolveFinalLayout = ::vk::ImageLayout::eColorAttachmentOptimal;
 		}

--- a/src/render_topology_game.cpp
+++ b/src/render_topology_game.cpp
@@ -91,9 +91,8 @@ public:
 
 	std::pair<uint32_t, uint32_t> sceneColorDimensions() const override
 	{
-		gfx_api::abstract_texture* sceneColor = gfx_api::context::get().getPipelineSurface(
+		const auto dims = gfx_api::context::get().getPipelineSurfaceDimensions(
 			gfx_api::PipelineSurfaceId::SceneColor);
-		const auto dims = gfx_api::context::get().getRenderTargetDimensions(sceneColor);
 		if (dims.has_value())
 		{
 			return dims.value();


### PR DESCRIPTION
Replace ad-hoc scene/swapchain/shadow targets with a catalog -> resolve -> PipelineSurfaceStore -> SurfaceAllocator path, and backend-owned Vk/GlSurfaceGpu slots keyed by PipelineSurfaceId.

Also fix Vulkan validation on force-close by flushing framebuffer deletes before destroying surface image views, derive swapchain-bound reset sets from catalog lifetime policy, and carry pipelineSurfaceId on AttachmentDesc for id-centric pass resolution.

Key changes:
* `SurfaceAllocator`: prepare (defer FB/FBO cache clears) -> destroy -> onChanged. Hard-reset (GPU idle) flushes deferred FBs; runtime ensure defers attachment view/image/memory while buffering is live
* `SurfaceLifetimePolicy`: Persistent (`ShadowMap`) vs `SwapchainBound` reset sets
* `AttachmentDesc.pipelineSurfaceId` for id-centric pass resolution
* `context::getPipelineSurfaceDimensions`; drop unused `ReadSource::PipelineSurface` and `makePipelineSurfaceAttachment`