### PR TITLE
gfx_api: Resolve pass surfaces by id and sample ShadowMap via graph reads

### DIFF
--- a/lib/ivis_opengl/gfx_api.h
+++ b/lib/ivis_opengl/gfx_api.h
@@ -455,7 +455,6 @@ namespace gfx_api
 		virtual gfx_api::abstract_texture* getPipelineSurface(PipelineSurfaceId id) { return nullptr; }
 		virtual PipelineSurfaceUsage pipelineSurfaceUsage(PipelineSurfaceId id) const;
 		virtual const ResolvedSurfaceSpec& resolvedPipelineSurface(PipelineSurfaceId id) const;
-		virtual nonstd::optional<PipelineSurfaceId> findPipelineSurfaceId(gfx_api::abstract_texture* texture) const { return nonstd::nullopt; }
 		bool isPipelineSurfaceDepthRole(PipelineSurfaceId id) const
 		{
 			return isDepthUsage(pipelineSurfaceUsage(id));

--- a/lib/ivis_opengl/gfx_api_gl.cpp
+++ b/lib/ivis_opengl/gfx_api_gl.cpp
@@ -4231,11 +4231,6 @@ const gfx_api::ResolvedSurfaceSpec& gl_context::resolvedPipelineSurface(gfx_api:
 	return _pipelineSurfaces.spec(id);
 }
 
-nonstd::optional<gfx_api::PipelineSurfaceId> gl_context::findPipelineSurfaceId(gfx_api::abstract_texture* texture) const
-{
-	return _pipelineSurfaces.find(texture);
-}
-
 bool gl_context::isSceneMSAAEnabled() const
 {
 	return multisamples > 0 && _pipelineSurfaces.has(gfx_api::PipelineSurfaceId::SceneMSAAColor);

--- a/lib/ivis_opengl/gfx_api_gl.h
+++ b/lib/ivis_opengl/gfx_api_gl.h
@@ -384,7 +384,6 @@ struct gl_context final : public gfx_api::context
 	virtual gfx_api::abstract_texture* getPipelineSurface(gfx_api::PipelineSurfaceId id) override;
 	virtual gfx_api::PipelineSurfaceUsage pipelineSurfaceUsage(gfx_api::PipelineSurfaceId id) const override;
 	virtual const gfx_api::ResolvedSurfaceSpec& resolvedPipelineSurface(gfx_api::PipelineSurfaceId id) const override;
-	virtual nonstd::optional<gfx_api::PipelineSurfaceId> findPipelineSurfaceId(gfx_api::abstract_texture* texture) const override;
 	virtual bool isSceneMSAAEnabled() const override;
 	virtual bool isSwapchainMSAAEnabled() const override;
 	virtual bool isMultisampledColorAttachment(gfx_api::abstract_texture* texture) const override;

--- a/lib/ivis_opengl/gfx_api_vk.cpp
+++ b/lib/ivis_opengl/gfx_api_vk.cpp
@@ -5922,11 +5922,6 @@ const gfx_api::ResolvedSurfaceSpec& VkRoot::resolvedPipelineSurface(gfx_api::Pip
 	return _pipelineSurfaces.spec(id);
 }
 
-nonstd::optional<gfx_api::PipelineSurfaceId> VkRoot::findPipelineSurfaceId(gfx_api::abstract_texture* texture) const
-{
-	return _pipelineSurfaces.find(texture);
-}
-
 bool VkRoot::isSceneMSAAEnabled() const
 {
 	return msaaSamples != vk::SampleCountFlagBits::e1;
@@ -6270,11 +6265,11 @@ vk::ImageView VkRoot::getAttachmentImageView(const gfx_api::AttachmentDesc& atta
 	}
 	if (auto* depthImage = dynamic_cast<VkDepthMapImage*>(attachment.texture))
 	{
-		const auto surfaceId = _pipelineSurfaces.find(attachment.texture);
-		if (surfaceId.has_value()
-			&& _pipelineSurfaces.spec(surfaceId.value()).storageKind == gfx_api::SurfaceStorageKind::SampledDepthArray)
+		if (attachment.pipelineSurfaceId.has_value()
+			&& attachment.pipelineSurfaceId.value() == gfx_api::PipelineSurfaceId::ShadowMap)
 		{
-			const auto& cascadeViews = _surfaceGpu[static_cast<size_t>(surfaceId.value())].cascadeViews;
+			const auto& cascadeViews =
+				_surfaceGpu[static_cast<size_t>(gfx_api::PipelineSurfaceId::ShadowMap)].cascadeViews;
 			ASSERT_OR_RETURN(vk::ImageView(), attachment.arrayLayer < cascadeViews.size(),
 				"Shadow cascade arrayLayer %u out of range (%zu)", attachment.arrayLayer, cascadeViews.size());
 			return cascadeViews[attachment.arrayLayer].get();

--- a/lib/ivis_opengl/gfx_api_vk.h
+++ b/lib/ivis_opengl/gfx_api_vk.h
@@ -923,7 +923,6 @@ public:
 	virtual gfx_api::abstract_texture* getPipelineSurface(gfx_api::PipelineSurfaceId id) override;
 	virtual gfx_api::PipelineSurfaceUsage pipelineSurfaceUsage(gfx_api::PipelineSurfaceId id) const override;
 	virtual const gfx_api::ResolvedSurfaceSpec& resolvedPipelineSurface(gfx_api::PipelineSurfaceId id) const override;
-	virtual nonstd::optional<gfx_api::PipelineSurfaceId> findPipelineSurfaceId(gfx_api::abstract_texture* texture) const override;
 	virtual bool isSceneMSAAEnabled() const override;
 	virtual bool isSwapchainMSAAEnabled() const override;
 	virtual bool isMultisampledColorAttachment(gfx_api::abstract_texture* texture) const override;

--- a/lib/ivis_opengl/piedraw.cpp
+++ b/lib/ivis_opengl/piedraw.cpp
@@ -1045,10 +1045,10 @@ public:
 	static constexpr int DrawParts_All = DrawParts::ShadowCastingShapes | DrawParts::TranslucentShapes | DrawParts::AdditiveShapes;
 
 	// Draws all queued meshes, given a projection + view matrix
-	bool DrawAll(uint64_t currentGameFrame, const glm::mat4 &projectionMatrix, const glm::mat4 &viewMatrix, const Vector3f &cameraPos, const ShadowCascadesInfo& shadowMVPMatrix, int drawParts = DrawParts_All, bool depthPass = false);
+	bool DrawAll(uint64_t currentGameFrame, const glm::mat4 &projectionMatrix, const glm::mat4 &viewMatrix, const Vector3f &cameraPos, const ShadowCascadesInfo& shadowMVPMatrix, gfx_api::abstract_texture* shadowMap, int drawParts = DrawParts_All, bool depthPass = false);
 public:
 	// New, instanced rendering
-	void Draw3DShapes_Instanced(uint64_t currentGameFrame, ShaderOnce& globalsOnce, const gfx_api::Draw3DShapeInstancedGlobalUniforms& globalUniforms, int drawParts = DrawParts_All, bool depthPass = false);
+	void Draw3DShapes_Instanced(uint64_t currentGameFrame, ShaderOnce& globalsOnce, const gfx_api::Draw3DShapeInstancedGlobalUniforms& globalUniforms, gfx_api::abstract_texture* shadowMap, int drawParts = DrawParts_All, bool depthPass = false);
 	// Old, non-instanced rendering
 	void Draw3DShapes_Old(uint64_t currentGameFrame, ShaderOnce& globalsOnce, const gfx_api::Draw3DShapeGlobalUniforms& globalUniforms, int drawParts = DrawParts_All);
 public:
@@ -1523,7 +1523,7 @@ void pie_FinalizeMeshes(uint64_t currentGameFrame)
 	instancedMeshRenderer.FinalizeInstances();
 }
 
-void pie_DrawAllMeshes(uint64_t currentGameFrame, const glm::mat4 &projectionMatrix, const glm::mat4& viewMatrix, const Vector3f &cameraPos, const ShadowCascadesInfo& shadowMVPMatrix, bool depthPass)
+void pie_DrawAllMeshes(uint64_t currentGameFrame, const glm::mat4 &projectionMatrix, const glm::mat4& viewMatrix, const Vector3f &cameraPos, const ShadowCascadesInfo& shadowMVPMatrix, gfx_api::abstract_texture* shadowMap, bool depthPass)
 {
 	int drawParts = InstancedMeshRenderer::DrawParts_All;
 	if (shadowMode == ShadowMode::Fallback_Stencil_Shadows)
@@ -1543,7 +1543,7 @@ void pie_DrawAllMeshes(uint64_t currentGameFrame, const glm::mat4 &projectionMat
 	{
 		return;
 	}
-	instancedMeshRenderer.DrawAll(currentGameFrame, projectionMatrix, viewMatrix, cameraPos, shadowMVPMatrix, drawParts, depthPass);
+	instancedMeshRenderer.DrawAll(currentGameFrame, projectionMatrix, viewMatrix, cameraPos, shadowMVPMatrix, shadowMap, drawParts, depthPass);
 }
 
 bool InstancedMeshRenderer::FinalizeInstances()
@@ -1620,7 +1620,7 @@ bool InstancedMeshRenderer::FinalizeInstances()
 	return true;
 }
 
-bool InstancedMeshRenderer::DrawAll(uint64_t currentGameFrame, const glm::mat4& projectionMatrix, const glm::mat4& viewMatrix, const Vector3f &cameraPos, const ShadowCascadesInfo& shadowCascades, int drawParts, bool depthPass)
+bool InstancedMeshRenderer::DrawAll(uint64_t currentGameFrame, const glm::mat4& projectionMatrix, const glm::mat4& viewMatrix, const Vector3f &cameraPos, const ShadowCascadesInfo& shadowCascades, gfx_api::abstract_texture* shadowMap, int drawParts, bool depthPass)
 {
 	perFrameUniformsShaderOnce.reset();
 
@@ -1646,7 +1646,7 @@ bool InstancedMeshRenderer::DrawAll(uint64_t currentGameFrame, const glm::mat4& 
 			{shadowCascades.shadowCascadeSplit[0], shadowCascades.shadowCascadeSplit[1], shadowCascades.shadowCascadeSplit[2], pie_getPerspectiveZFar()}, shadowCascades.shadowMapSize,
 			renderState.fogBegin, renderState.fogEnd, pie_GetShaderTime(), renderState.fogEnabled, static_cast<int>(dimension.first), static_cast<int>(dimension.second), 0.f, bucketLight.positions, bucketLight.colorAndEnergy, bucketLight.bucketOffsetAndSize, bucketLight.light_index, static_cast<int>(bucketLight.bucketDimensionUsed)
 		};
-		Draw3DShapes_Instanced(currentGameFrame, perFrameUniformsShaderOnce, globalUniforms, drawParts, depthPass);
+		Draw3DShapes_Instanced(currentGameFrame, perFrameUniformsShaderOnce, globalUniforms, shadowMap, drawParts, depthPass);
 	}
 	else
 	{
@@ -1662,7 +1662,7 @@ bool InstancedMeshRenderer::DrawAll(uint64_t currentGameFrame, const glm::mat4& 
 }
 
 template<SHADER_MODE shader, typename Draw3DInstancedPSO>
-static void drawInstanced3dShapeTemplated_Inner(ShaderOnce& globalsOnce, const gfx_api::Draw3DShapeInstancedGlobalUniforms& globalUniforms, const iIMDShape * shape, gfx_api::buffer* instanceDataBuffer, size_t instanceBufferOffset, size_t instance_count, gfx_api::texture* lightmapTexture, bool shieldEffect)
+static void drawInstanced3dShapeTemplated_Inner(ShaderOnce& globalsOnce, const gfx_api::Draw3DShapeInstancedGlobalUniforms& globalUniforms, const iIMDShape * shape, gfx_api::buffer* instanceDataBuffer, size_t instanceBufferOffset, size_t instance_count, gfx_api::abstract_texture* shadowMap, gfx_api::texture* lightmapTexture, bool shieldEffect)
 {
 	const auto& textures = shape->getTextures();
 	auto* tcmask = textures.tcmaskpage != iV_TEX_INVALID ? &pie_Texture(textures.tcmaskpage) : nullptr;
@@ -1688,7 +1688,7 @@ static void drawInstanced3dShapeTemplated_Inner(ShaderOnce& globalsOnce, const g
 		std::make_tuple(shape->buffers[VBO_TEXCOORD], 0),
 		std::make_tuple(pTangentBuffer, 0),
 		std::make_tuple(instanceDataBuffer, instanceBufferOffset) });
-	Draw3DInstancedPSO::get().bind_textures(&pie_Texture(textures.texpage), tcmask, normalmap, specularmap, gfx_api::context::get().getPipelineSurface(gfx_api::PipelineSurfaceId::ShadowMap), lightmapTexture);
+	Draw3DInstancedPSO::get().bind_textures(&pie_Texture(textures.texpage), tcmask, normalmap, specularmap, shadowMap, lightmapTexture);
 
 	Draw3DInstancedPSO::get().draw_elements_instanced(shape->polys.size() * 3, 0, instance_count);
 //	Draw3DInstancedPSO::get().unbind_vertex_buffers(shape->buffers[VBO_VERTEX], shape->buffers[VBO_NORMAL], shape->buffers[VBO_TEXCOORD]);
@@ -1722,7 +1722,7 @@ static void drawInstanced3dShapeDepthOnly(ShaderOnce& globalsOnce, const gfx_api
 }
 
 template<SHADER_MODE shader, typename AdditivePSO, typename AdditiveNoDepthWRTPSO, typename AlphaPSO, typename AlphaNoDepthWRTPSO, typename PremultipliedPSO, typename PremultipliedNoDepthWRTPSO, typename OpaquePSO>
-static void drawInstanced3dShapeTemplated(ShaderOnce& globalsOnce, const gfx_api::Draw3DShapeInstancedGlobalUniforms& globalUniforms, const iIMDShape * shape, int pieFlag, gfx_api::buffer* instanceDataBuffer, size_t instanceBufferOffset, size_t instance_count, gfx_api::texture* lightmapTexture)
+static void drawInstanced3dShapeTemplated(ShaderOnce& globalsOnce, const gfx_api::Draw3DShapeInstancedGlobalUniforms& globalUniforms, const iIMDShape * shape, int pieFlag, gfx_api::buffer* instanceDataBuffer, size_t instanceBufferOffset, size_t instance_count, gfx_api::abstract_texture* shadowMap, gfx_api::texture* lightmapTexture)
 {
 	bool shieldEffect = pieFlag & pie_SHIELD;
 
@@ -1731,42 +1731,42 @@ static void drawInstanced3dShapeTemplated(ShaderOnce& globalsOnce, const gfx_api
 	{
 		if (!(pieFlag & pie_NODEPTHWRITE))
 		{
-			return drawInstanced3dShapeTemplated_Inner<shader, AdditivePSO>(globalsOnce, globalUniforms, shape, instanceDataBuffer, instanceBufferOffset, instance_count, lightmapTexture, shieldEffect);
+			return drawInstanced3dShapeTemplated_Inner<shader, AdditivePSO>(globalsOnce, globalUniforms, shape, instanceDataBuffer, instanceBufferOffset, instance_count, shadowMap, lightmapTexture, shieldEffect);
 		}
 		else
 		{
-			return drawInstanced3dShapeTemplated_Inner<shader, AdditiveNoDepthWRTPSO>(globalsOnce, globalUniforms, shape, instanceDataBuffer, instanceBufferOffset, instance_count, lightmapTexture, shieldEffect);
+			return drawInstanced3dShapeTemplated_Inner<shader, AdditiveNoDepthWRTPSO>(globalsOnce, globalUniforms, shape, instanceDataBuffer, instanceBufferOffset, instance_count, shadowMap, lightmapTexture, shieldEffect);
 		}
 	}
 	else if (pieFlag & pie_TRANSLUCENT)
 	{
 		if (!(pieFlag & pie_NODEPTHWRITE))
 		{
-			return drawInstanced3dShapeTemplated_Inner<shader, AlphaPSO>(globalsOnce, globalUniforms, shape, instanceDataBuffer, instanceBufferOffset, instance_count, lightmapTexture, shieldEffect);
+			return drawInstanced3dShapeTemplated_Inner<shader, AlphaPSO>(globalsOnce, globalUniforms, shape, instanceDataBuffer, instanceBufferOffset, instance_count, shadowMap, lightmapTexture, shieldEffect);
 		}
 		else
 		{
-			return drawInstanced3dShapeTemplated_Inner<shader, AlphaNoDepthWRTPSO>(globalsOnce, globalUniforms, shape, instanceDataBuffer, instanceBufferOffset, instance_count, lightmapTexture, shieldEffect);
+			return drawInstanced3dShapeTemplated_Inner<shader, AlphaNoDepthWRTPSO>(globalsOnce, globalUniforms, shape, instanceDataBuffer, instanceBufferOffset, instance_count, shadowMap, lightmapTexture, shieldEffect);
 		}
 	}
 	else if (pieFlag & pie_PREMULTIPLIED)
 	{
 		if (!(pieFlag & pie_NODEPTHWRITE))
 		{
-			return drawInstanced3dShapeTemplated_Inner<shader, PremultipliedPSO>(globalsOnce, globalUniforms, shape, instanceDataBuffer, instanceBufferOffset, instance_count, lightmapTexture, shieldEffect);
+			return drawInstanced3dShapeTemplated_Inner<shader, PremultipliedPSO>(globalsOnce, globalUniforms, shape, instanceDataBuffer, instanceBufferOffset, instance_count, shadowMap, lightmapTexture, shieldEffect);
 		}
 		else
 		{
-			return drawInstanced3dShapeTemplated_Inner<shader, PremultipliedNoDepthWRTPSO>(globalsOnce, globalUniforms, shape, instanceDataBuffer, instanceBufferOffset, instance_count, lightmapTexture, shieldEffect);
+			return drawInstanced3dShapeTemplated_Inner<shader, PremultipliedNoDepthWRTPSO>(globalsOnce, globalUniforms, shape, instanceDataBuffer, instanceBufferOffset, instance_count, shadowMap, lightmapTexture, shieldEffect);
 		}
 	}
 	else
 	{
-		return drawInstanced3dShapeTemplated_Inner<shader, OpaquePSO>(globalsOnce, globalUniforms, shape, instanceDataBuffer, instanceBufferOffset, instance_count, lightmapTexture, shieldEffect);
+		return drawInstanced3dShapeTemplated_Inner<shader, OpaquePSO>(globalsOnce, globalUniforms, shape, instanceDataBuffer, instanceBufferOffset, instance_count, shadowMap, lightmapTexture, shieldEffect);
 	}
 }
 
-static void pie_Draw3DShape2_Instanced(ShaderOnce& globalsOnce, const gfx_api::Draw3DShapeInstancedGlobalUniforms& globalUniforms, const iIMDShape *shape, int pieFlag, gfx_api::buffer* instanceDataBuffer, size_t instanceBufferOffset, size_t instance_count, bool depthPass, gfx_api::texture* lightmapTexture)
+static void pie_Draw3DShape2_Instanced(ShaderOnce& globalsOnce, const gfx_api::Draw3DShapeInstancedGlobalUniforms& globalUniforms, const iIMDShape *shape, int pieFlag, gfx_api::buffer* instanceDataBuffer, size_t instanceBufferOffset, size_t instance_count, bool depthPass, gfx_api::abstract_texture* shadowMap, gfx_api::texture* lightmapTexture)
 {
 	bool light = true;
 
@@ -1814,17 +1814,17 @@ static void pie_Draw3DShape2_Instanced(ShaderOnce& globalsOnce, const gfx_api::D
 	}
 	else if (light)
 	{
-		drawInstanced3dShapeTemplated<SHADER_COMPONENT_INSTANCED, gfx_api::Draw3DShapeAdditive_Instanced, gfx_api::Draw3DShapeAdditiveNoDepthWRT_Instanced, gfx_api::Draw3DShapeAlpha_Instanced, gfx_api::Draw3DShapeAlphaNoDepthWRT_Instanced, gfx_api::Draw3DShapePremul_Instanced, gfx_api::Draw3DShapePremulNoDepthWRT_Instanced, gfx_api::Draw3DShapeOpaque_Instanced>(globalsOnce, globalUniforms, shape, pieFlag, instanceDataBuffer, instanceBufferOffset, instance_count, lightmapTexture);
+		drawInstanced3dShapeTemplated<SHADER_COMPONENT_INSTANCED, gfx_api::Draw3DShapeAdditive_Instanced, gfx_api::Draw3DShapeAdditiveNoDepthWRT_Instanced, gfx_api::Draw3DShapeAlpha_Instanced, gfx_api::Draw3DShapeAlphaNoDepthWRT_Instanced, gfx_api::Draw3DShapePremul_Instanced, gfx_api::Draw3DShapePremulNoDepthWRT_Instanced, gfx_api::Draw3DShapeOpaque_Instanced>(globalsOnce, globalUniforms, shape, pieFlag, instanceDataBuffer, instanceBufferOffset, instance_count, shadowMap, lightmapTexture);
 	}
 	else
 	{
-		drawInstanced3dShapeTemplated<SHADER_NOLIGHT_INSTANCED, gfx_api::Draw3DShapeNoLightAdditive_Instanced, gfx_api::Draw3DShapeNoLightAdditiveNoDepthWRT_Instanced, gfx_api::Draw3DShapeNoLightAlpha_Instanced, gfx_api::Draw3DShapeNoLightAlphaNoDepthWRT_Instanced, gfx_api::Draw3DShapeNoLightPremul_Instanced, gfx_api::Draw3DShapeNoLightPremulNoDepthWRT_Instanced, gfx_api::Draw3DShapeNoLightOpaque_Instanced>(globalsOnce, globalUniforms, shape, pieFlag, instanceDataBuffer, instanceBufferOffset, instance_count, lightmapTexture);
+		drawInstanced3dShapeTemplated<SHADER_NOLIGHT_INSTANCED, gfx_api::Draw3DShapeNoLightAdditive_Instanced, gfx_api::Draw3DShapeNoLightAdditiveNoDepthWRT_Instanced, gfx_api::Draw3DShapeNoLightAlpha_Instanced, gfx_api::Draw3DShapeNoLightAlphaNoDepthWRT_Instanced, gfx_api::Draw3DShapeNoLightPremul_Instanced, gfx_api::Draw3DShapeNoLightPremulNoDepthWRT_Instanced, gfx_api::Draw3DShapeNoLightOpaque_Instanced>(globalsOnce, globalUniforms, shape, pieFlag, instanceDataBuffer, instanceBufferOffset, instance_count, shadowMap, lightmapTexture);
 	}
 
 	polyCount += shape->polys.size();
 }
 
-void InstancedMeshRenderer::Draw3DShapes_Instanced(uint64_t currentGameFrame, ShaderOnce& globalsOnce, const gfx_api::Draw3DShapeInstancedGlobalUniforms& globalUniforms, int drawParts, bool depthPass)
+void InstancedMeshRenderer::Draw3DShapes_Instanced(uint64_t currentGameFrame, ShaderOnce& globalsOnce, const gfx_api::Draw3DShapeInstancedGlobalUniforms& globalUniforms, gfx_api::abstract_texture* shadowMap, int drawParts, bool depthPass)
 {
 	if (finalizedDrawCalls.empty())
 	{
@@ -1845,7 +1845,7 @@ void InstancedMeshRenderer::Draw3DShapes_Instanced(uint64_t currentGameFrame, Sh
 				continue;
 			}
 			size_t instanceBufferOffset = static_cast<size_t>(sizeof(gfx_api::Draw3DShapePerInstanceInterleavedData) * call.startingIdxInInstancesBuffer);
-			pie_Draw3DShape2_Instanced(perFrameUniformsShaderOnce, globalUniforms, shape, call.state.pieFlag, instanceDataBuffers[currInstanceBufferIdx], instanceBufferOffset, call.instance_count, depthPass, lightmapTexture);
+			pie_Draw3DShape2_Instanced(perFrameUniformsShaderOnce, globalUniforms, shape, call.state.pieFlag, instanceDataBuffers[currInstanceBufferIdx], instanceBufferOffset, call.instance_count, depthPass, shadowMap, lightmapTexture);
 		}
 		if (startIdxTranslucentDrawCalls > 0)
 		{
@@ -1873,7 +1873,7 @@ void InstancedMeshRenderer::Draw3DShapes_Instanced(uint64_t currentGameFrame, Sh
 			const auto& call = finalizedDrawCalls[i];
 			const iIMDShape * shape = call.state.shape;
 			size_t instanceBufferOffset = static_cast<size_t>(sizeof(gfx_api::Draw3DShapePerInstanceInterleavedData) * call.startingIdxInInstancesBuffer);
-			pie_Draw3DShape2_Instanced(perFrameUniformsShaderOnce, globalUniforms, shape, call.state.pieFlag, instanceDataBuffers[currInstanceBufferIdx], instanceBufferOffset, call.instance_count, depthPass, lightmapTexture);
+			pie_Draw3DShape2_Instanced(perFrameUniformsShaderOnce, globalUniforms, shape, call.state.pieFlag, instanceDataBuffers[currInstanceBufferIdx], instanceBufferOffset, call.instance_count, depthPass, shadowMap, lightmapTexture);
 		}
 		if (startIdxTranslucentDrawCalls < startIdxTranslucentNoDepthWriteDrawCalls)
 		{
@@ -1888,7 +1888,7 @@ void InstancedMeshRenderer::Draw3DShapes_Instanced(uint64_t currentGameFrame, Sh
 			const auto& call = finalizedDrawCalls[i];
 			const iIMDShape * shape = call.state.shape;
 			size_t instanceBufferOffset = static_cast<size_t>(sizeof(gfx_api::Draw3DShapePerInstanceInterleavedData) * call.startingIdxInInstancesBuffer);
-			pie_Draw3DShape2_Instanced(perFrameUniformsShaderOnce, globalUniforms, shape, call.state.pieFlag, instanceDataBuffers[currInstanceBufferIdx], instanceBufferOffset, call.instance_count, depthPass, lightmapTexture);
+			pie_Draw3DShape2_Instanced(perFrameUniformsShaderOnce, globalUniforms, shape, call.state.pieFlag, instanceDataBuffers[currInstanceBufferIdx], instanceBufferOffset, call.instance_count, depthPass, shadowMap, lightmapTexture);
 		}
 		if (startIdxTranslucentNoDepthWriteDrawCalls < startIdxAdditiveDrawCalls)
 		{
@@ -1906,7 +1906,7 @@ void InstancedMeshRenderer::Draw3DShapes_Instanced(uint64_t currentGameFrame, Sh
 			const auto& call = finalizedDrawCalls[i];
 			const iIMDShape * shape = call.state.shape;
 			size_t instanceBufferOffset = static_cast<size_t>(sizeof(gfx_api::Draw3DShapePerInstanceInterleavedData) * call.startingIdxInInstancesBuffer);
-			pie_Draw3DShape2_Instanced(perFrameUniformsShaderOnce, globalUniforms, shape, call.state.pieFlag, instanceDataBuffers[currInstanceBufferIdx], instanceBufferOffset, call.instance_count, depthPass, lightmapTexture);
+			pie_Draw3DShape2_Instanced(perFrameUniformsShaderOnce, globalUniforms, shape, call.state.pieFlag, instanceDataBuffers[currInstanceBufferIdx], instanceBufferOffset, call.instance_count, depthPass, shadowMap, lightmapTexture);
 		}
 		if (startIdxAdditiveDrawCalls < finalizedDrawCalls.size())
 		{

--- a/lib/ivis_opengl/piedraw.h
+++ b/lib/ivis_opengl/piedraw.h
@@ -27,10 +27,11 @@
 
 namespace gfx_api
 {
+	struct abstract_texture; // forward-declare
 	struct texture; // forward-declare
 }
 
 void pie_StartMeshes();
 void pie_UpdateLightmap(gfx_api::texture* lightmapTexture, const glm::mat4& modelUVLightmapMatrix);
 void pie_FinalizeMeshes(uint64_t currentGameFrame);
-void pie_DrawAllMeshes(uint64_t currentGameFrame, const glm::mat4 &projectionMatrix, const glm::mat4 &viewMatrix, const Vector3f &cameraPos, const ShadowCascadesInfo& shadowMVPMatrix, bool depthPass);
+void pie_DrawAllMeshes(uint64_t currentGameFrame, const glm::mat4 &projectionMatrix, const glm::mat4 &viewMatrix, const Vector3f &cameraPos, const ShadowCascadesInfo& shadowMVPMatrix, gfx_api::abstract_texture* shadowMap, bool depthPass);

--- a/lib/ivis_opengl/render_graph/compile.cpp
+++ b/lib/ivis_opengl/render_graph/compile.cpp
@@ -200,4 +200,11 @@ abstract_texture* RenderPassContext::getRead(size_t index) const
 	return _resolvedReads[index].texture;
 }
 
+const ResolvedRead& RenderPassContext::resolvedRead(size_t index) const
+{
+	ASSERT(index < _resolvedReads.size(), "Resolved read index %zu out of range (%zu)",
+		index, _resolvedReads.size());
+	return _resolvedReads[index];
+}
+
 } // namespace gfx_api

--- a/lib/ivis_opengl/render_graph/pass_resolve.cpp
+++ b/lib/ivis_opengl/render_graph/pass_resolve.cpp
@@ -45,15 +45,9 @@ bool attachmentIsResolved(const AttachmentDesc& attachment)
 
 std::optional<PipelineSurfaceId> attachmentPipelineSurfaceId(const AttachmentDesc& attachment)
 {
-	if (attachment.pipelineSurfaceId.has_value())
-	{
-		return attachment.pipelineSurfaceId;
-	}
-	if (attachment.texture == nullptr)
-	{
-		return std::nullopt;
-	}
-	return gfx_api::context::get().findPipelineSurfaceId(attachment.texture);
+	// Authoritative: materializer always sets this for pipeline surfaces. Unset means
+	// the attachment is not a pipeline surface (no texture->id reverse lookup).
+	return attachment.pipelineSurfaceId;
 }
 
 bool passHasResolvedAttachments(const RenderPassDesc& pass)
@@ -80,12 +74,26 @@ void tryInferPassDimensions(RenderPassDesc& pass, gfx_api::context& ctx, uint32_
 		}
 	}
 
-	auto tryFromTexture = [&](gfx_api::abstract_texture* texture) {
-		if ((width > 0 && height > 0) || texture == nullptr)
+	auto tryFromAttachment = [&](const AttachmentDesc& attachment) {
+		if (width > 0 && height > 0)
 		{
 			return;
 		}
-		const auto dims = ctx.getRenderTargetDimensions(texture);
+		if (attachment.pipelineSurfaceId.has_value())
+		{
+			const auto dims = ctx.getPipelineSurfaceDimensions(attachment.pipelineSurfaceId.value());
+			if (dims.has_value())
+			{
+				width = dims->first;
+				height = dims->second;
+				return;
+			}
+		}
+		if (attachment.texture == nullptr)
+		{
+			return;
+		}
+		const auto dims = ctx.getRenderTargetDimensions(attachment.texture);
 		if (dims.has_value())
 		{
 			width = dims->first;
@@ -95,15 +103,15 @@ void tryInferPassDimensions(RenderPassDesc& pass, gfx_api::context& ctx, uint32_
 
 	for (const auto& colorAttachment : pass.colorAttachments)
 	{
-		tryFromTexture(colorAttachment.texture);
+		tryFromAttachment(colorAttachment);
 	}
 	if (pass.depthAttachment.has_value())
 	{
-		tryFromTexture(pass.depthAttachment->texture);
+		tryFromAttachment(pass.depthAttachment.value());
 	}
 	if (pass.resolveAttachment.has_value())
 	{
-		tryFromTexture(pass.resolveAttachment->texture);
+		tryFromAttachment(pass.resolveAttachment.value());
 	}
 
 	if (width == 0 || height == 0)
@@ -618,17 +626,6 @@ std::optional<PassOutputView> getPassOutputAttachment(
 		return std::nullopt;
 	}
 	return view;
-}
-
-bool isSwapchainPresentableColorSurface(abstract_texture* texture)
-{
-	if (texture == nullptr)
-	{
-		return false;
-	}
-	auto& ctx = gfx_api::context::get();
-	const auto surfaceId = ctx.findPipelineSurfaceId(texture);
-	return surfaceId.has_value() && surfaceId.value() == PipelineSurfaceId::SwapchainColor;
 }
 
 bool isSwapchainPresentableColorSurface(const AttachmentDesc& attachment)

--- a/lib/ivis_opengl/render_graph/pass_resolve.h
+++ b/lib/ivis_opengl/render_graph/pass_resolve.h
@@ -85,9 +85,8 @@ bool passNeedsMsaaResolve(const RenderPassDesc& pass);
 /// True when resolved depth includes stencil (scene depth, not shadow map).
 bool attachmentDepthHasStencil(const AttachmentDesc& attachment);
 
-/// True when the texture is the swapchain presentable color surface.
-bool isSwapchainPresentableColorSurface(abstract_texture* texture);
-/// True when the attachment is the swapchain presentable color surface.
+/// True when the attachment is the swapchain presentable color surface
+/// (`pipelineSurfaceId == SwapchainColor`).
 bool isSwapchainPresentableColorSurface(const AttachmentDesc& attachment);
 
 /// Resolve which texture/subresource a producer pass exposes for a given `AttachmentRole`.

--- a/lib/ivis_opengl/render_graph/pipeline_surfaces.cpp
+++ b/lib/ivis_opengl/render_graph/pipeline_surfaces.cpp
@@ -123,7 +123,7 @@ const PipelineSurfaceCatalogTable PIPELINE_SURFACE_CATALOG = {{
 		SurfaceProvisionMode::WsiPresentColor,
 		SurfaceStorageKind::None,
 		SurfaceLifetimePolicy::SwapchainBound),
-	// SwapchainMSAAColor — see header note: GL keeps this disabled via sync inputs / EnablePolicy.
+	// SwapchainMSAAColor - see header note: GL keeps this disabled via sync inputs / EnablePolicy.
 	makeCatalogEntry(
 		PipelineSurfaceUsage::ColorMSAA,
 		SurfaceExtentPolicy::MatchDrawable,
@@ -428,22 +428,6 @@ const ResolvedSurfaceSpec& PipelineSurfaceStore::spec(PipelineSurfaceId id) cons
 bool PipelineSurfaceStore::has(PipelineSurfaceId id) const
 {
 	return get(id) != nullptr;
-}
-
-nonstd::optional<PipelineSurfaceId> PipelineSurfaceStore::find(abstract_texture* texture) const
-{
-	if (texture == nullptr)
-	{
-		return nonstd::nullopt;
-	}
-	for (size_t i = 0; i < PIPELINE_SURFACE_COUNT; ++i)
-	{
-		if (_slots[i].texture == texture)
-		{
-			return static_cast<PipelineSurfaceId>(i);
-		}
-	}
-	return nonstd::nullopt;
 }
 
 PipelineSurfaceUsage PipelineSurfaceStore::usage(PipelineSurfaceId id) const

--- a/lib/ivis_opengl/render_graph/pipeline_surfaces.h
+++ b/lib/ivis_opengl/render_graph/pipeline_surfaces.h
@@ -31,7 +31,7 @@
  * 5. LifetimePolicy=Persistent only if it must survive swapchain recreate.
  *
  * Swapchain MSAA: enabled only when sync inputs report swapchainMsaaSamples > 1.
- * GL currently forces samples=1 / isSwapchainMSAAEnabled()==false — catalog row stays
+ * GL currently forces samples=1 / isSwapchainMSAAEnabled()==false - catalog row stays
  * for VK parity; surface remains disabled on GL via EnablePolicy::SwapchainMsaaActive.
  */
 
@@ -272,7 +272,7 @@ struct SurfaceAllocator
 	virtual void destroy(PipelineSurfaceId id, abstract_texture* texture) = 0;
 	/// Called once before any destroy in reset*/ensure mutate paths.
 	/// Must clear pass-resource caches and *defer* framebuffer deletes (VK).
-	/// Do not flush here — runtime ensure() is not GPU-idle. Hard-reset paths
+	/// Do not flush here - runtime ensure() is not GPU-idle. Hard-reset paths
 	/// flush deferred FBs after idle (reset wrappers / swapchain teardown).
 	virtual void prepareForSurfaceDestroy() = 0;
 	/// Called once if any slot changed (create/destroy). Clear FBO/FB caches + bump epoch.
@@ -295,7 +295,6 @@ public:
 	abstract_texture* get(PipelineSurfaceId id) const;
 	const ResolvedSurfaceSpec& spec(PipelineSurfaceId id) const;
 	bool has(PipelineSurfaceId id) const;
-	nonstd::optional<PipelineSurfaceId> find(abstract_texture* texture) const;
 	PipelineSurfaceUsage usage(PipelineSurfaceId id) const;
 
 	bool ensure(const ResolvedSurfaceTable& resolved, SurfaceAllocator& alloc);

--- a/lib/ivis_opengl/render_graph/render_pass.h
+++ b/lib/ivis_opengl/render_graph/render_pass.h
@@ -129,14 +129,22 @@ struct RenderPassDesc
 
 /// <summary>
 /// Per-pass data passed to `RecordFunc` callbacks after reads are compile-resolved.
+///
+/// ScenePass contract: when shadow cascades > 0, `reads[i]` is cascade `i` Depth
+/// (`PassOutput`); all share the same ShadowMap array texture - bind once via
+/// `getRead(0)`. When cascades == 0, `readCount() == 0`.
 /// </summary>
 class RenderPassContext
 {
 public:
 	RenderPassContext(const RenderPassDesc& desc, std::vector<ResolvedRead> resolvedReads);
 
+	/// Number of compile-resolved reads (matches `RenderPassDesc::reads` size on success).
+	size_t readCount() const { return _resolvedReads.size(); }
 	/// Resolved input texture for `reads[index]` (barriers already emitted).
 	abstract_texture* getRead(size_t index) const;
+	/// Full resolved read metadata (texture + layer/mip/depth flag).
+	const ResolvedRead& resolvedRead(size_t index) const;
 	/// Stable id from `RenderPassDesc::passId`.
 	PassId passId() const { return _desc.passId; }
 

--- a/src/display3d_render_graph.cpp
+++ b/src/display3d_render_graph.cpp
@@ -78,7 +78,24 @@ static Vector3f toVector3f(const glm::vec3& v)
 	return Vector3f(v.x, v.y, v.z);
 }
 
-static void recordScenePass(const gfx_api::RenderPassContext&)
+/// ScenePass reads are exclusively ordered ShadowCascade Depth outputs; all share one array texture.
+static gfx_api::abstract_texture* shadowMapFromScenePassReads(const gfx_api::RenderPassContext& ctx)
+{
+	if (ctx.readCount() == 0)
+	{
+		return nullptr;
+	}
+	gfx_api::abstract_texture* shadowMap = ctx.getRead(0);
+	for (size_t i = 0; i < ctx.readCount(); ++i)
+	{
+		const auto& read = ctx.resolvedRead(i);
+		ASSERT(read.isDepth, "ScenePass read %zu must be Depth (cascade)", i);
+		ASSERT(read.texture == shadowMap, "ScenePass cascade reads must share ShadowMap texture");
+	}
+	return shadowMap;
+}
+
+static void recordScenePass(const gfx_api::RenderPassContext& passCtx)
 {
 	if (!pie_IsInGame3DFrameContextReady())
 	{
@@ -87,10 +104,11 @@ static void recordScenePass(const gfx_api::RenderPassContext&)
 	const auto& fc = pie_GetInGame3DFrameContext();
 	const Vector3f cameraPos = toVector3f(fc.cameraPos);
 	const Vector3f sunPos = toVector3f(-getTheSun());
+	gfx_api::abstract_texture* shadowMap = shadowMapFromScenePassReads(passCtx);
 
 	wzPerfBegin(PERF_TERRAIN, "3D scene - terrain");
 	pie_SetFogStatus(true);
-	drawTerrain(fc.perspectiveViewMatrix, fc.viewMatrix, cameraPos, sunPos, fc.shadowCascadesInfo);
+	drawTerrain(fc.perspectiveViewMatrix, fc.viewMatrix, cameraPos, sunPos, fc.shadowCascadesInfo, shadowMap);
 	wzPerfEnd(PERF_TERRAIN);
 
 	wzPerfBegin(PERF_SKYBOX, "3D scene - skybox");
@@ -99,13 +117,13 @@ static void recordScenePass(const gfx_api::RenderPassContext&)
 
 	wzPerfBegin(PERF_WATER, "3D scene - water");
 	pie_SetFogStatus(true);
-	drawWater(fc.perspectiveViewMatrix, fc.viewMatrix, cameraPos, sunPos, fc.shadowCascadesInfo);
+	drawWater(fc.perspectiveViewMatrix, fc.viewMatrix, cameraPos, sunPos, fc.shadowCascadesInfo, shadowMap);
 	wzPerfEnd(PERF_WATER);
 
 	wzPerfBegin(PERF_MODELS, "3D scene - models");
 	{
 		WZ_PROFILE_SCOPE(pie_DrawAllMeshes);
-		pie_DrawAllMeshes(fc.currentGameFrame, fc.perspectiveMatrix, fc.viewMatrix, cameraPos, fc.shadowCascadesInfo, false);
+		pie_DrawAllMeshes(fc.currentGameFrame, fc.perspectiveMatrix, fc.viewMatrix, cameraPos, fc.shadowCascadesInfo, shadowMap, false);
 	}
 	wzPerfEnd(PERF_MODELS);
 
@@ -135,7 +153,7 @@ static void recordShadowCascade(const gfx_api::RenderPassContext& passCtx)
 		drawTerrainDepthOnly(fc.cascadeProj[cascadeIndex] * fc.cascadeView[cascadeIndex]);
 	}
 	pie_DrawAllMeshes(fc.currentGameFrame, fc.cascadeProj[cascadeIndex], fc.cascadeView[cascadeIndex],
-		cameraPos, fc.shadowCascadesInfo, true);
+		cameraPos, fc.shadowCascadesInfo, nullptr, true);
 }
 
 static void recordSceneBlit(const gfx_api::RenderPassContext& passCtx)

--- a/src/terrain.cpp
+++ b/src/terrain.cpp
@@ -1439,7 +1439,7 @@ glm::vec4 getFogColorVec4()
 }
 
 template<typename PSO>
-static void drawTerrainCombinedmpl(const glm::mat4 &ModelViewProjection, const glm::mat4& ViewMatrix, const glm::mat4 &ModelUVLightmap, const Vector3f &cameraPos, const Vector3f &sunPos, const ShadowCascadesInfo& shadowCascades)
+static void drawTerrainCombinedmpl(const glm::mat4 &ModelViewProjection, const glm::mat4& ViewMatrix, const glm::mat4 &ModelUVLightmap, const Vector3f &cameraPos, const Vector3f &sunPos, const ShadowCascadesInfo& shadowCascades, gfx_api::abstract_texture* shadowMap)
 {
 	const auto &renderState = getCurrentRenderState();
 	PSO::get().bind();
@@ -1447,7 +1447,7 @@ static void drawTerrainCombinedmpl(const glm::mat4 &ModelViewProjection, const g
 		lightmap_texture,
 		groundTexArr, groundNormalArr, groundSpecularArr, groundHeightArr,
 		decalTexArr, decalNormalArr, decalSpecularArr, decalHeightArr,
-		gfx_api::context::get().getPipelineSurface(gfx_api::PipelineSurfaceId::ShadowMap));
+		shadowMap);
 	PSO::get().bind_vertex_buffers(terrainDecalVBO);
 	glm::mat4 groundScale = glm::mat4(0);
 	for (int i = 0; i < getNumGroundTypes(); i++) {
@@ -1494,18 +1494,18 @@ static void drawTerrainCombinedmpl(const glm::mat4 &ModelViewProjection, const g
 	PSO::get().unbind_vertex_buffers(terrainDecalVBO);
 }
 
-static void drawTerrainCombined(const glm::mat4 &ModelViewProjection, const glm::mat4& ViewMatrix, const glm::mat4 &ModelUVLightmap, const Vector3f &cameraPos, const Vector3f &sunPos, const ShadowCascadesInfo& shadowCascades)
+static void drawTerrainCombined(const glm::mat4 &ModelViewProjection, const glm::mat4& ViewMatrix, const glm::mat4 &ModelUVLightmap, const Vector3f &cameraPos, const Vector3f &sunPos, const ShadowCascadesInfo& shadowCascades, gfx_api::abstract_texture* shadowMap)
 {
 	switch (terrainShaderQuality)
 	{
 		case TerrainShaderQuality::CLASSIC:
-			drawTerrainCombinedmpl<gfx_api::TerrainCombined_Classic>(ModelViewProjection, ViewMatrix, ModelUVLightmap, cameraPos, sunPos, shadowCascades);
+			drawTerrainCombinedmpl<gfx_api::TerrainCombined_Classic>(ModelViewProjection, ViewMatrix, ModelUVLightmap, cameraPos, sunPos, shadowCascades, shadowMap);
 			break;
 		case TerrainShaderQuality::MEDIUM:
-			drawTerrainCombinedmpl<gfx_api::TerrainCombined_Medium>(ModelViewProjection, ViewMatrix, ModelUVLightmap, cameraPos, sunPos, shadowCascades);
+			drawTerrainCombinedmpl<gfx_api::TerrainCombined_Medium>(ModelViewProjection, ViewMatrix, ModelUVLightmap, cameraPos, sunPos, shadowCascades, shadowMap);
 			break;
 		case TerrainShaderQuality::NORMAL_MAPPING:
-			drawTerrainCombinedmpl<gfx_api::TerrainCombined_High>(ModelViewProjection, ViewMatrix, ModelUVLightmap, cameraPos, sunPos, shadowCascades);
+			drawTerrainCombinedmpl<gfx_api::TerrainCombined_High>(ModelViewProjection, ViewMatrix, ModelUVLightmap, cameraPos, sunPos, shadowCascades, shadowMap);
 			break;
 		case TerrainShaderQuality::UNINITIALIZED_PICK_DEFAULT:
 			// should not happen
@@ -1554,7 +1554,7 @@ void drawTerrainDepthOnly(const glm::mat4 &mvp)
  * This function first draws the terrain in black, and then uses additive blending to put the terrain layers
  * on it one by one. Finally the decals are drawn.
  */
-void drawTerrain(const glm::mat4 &mvp, const glm::mat4& viewMatrix, const Vector3f &cameraPos, const Vector3f &sunPos, const ShadowCascadesInfo& shadowCascades)
+void drawTerrain(const glm::mat4 &mvp, const glm::mat4& viewMatrix, const Vector3f &cameraPos, const Vector3f &sunPos, const ShadowCascadesInfo& shadowCascades, gfx_api::abstract_texture* shadowMap)
 {
 	WZ_PROFILE_SCOPE(drawTerrain);
 	const glm::vec4& paramsXLight = lightmapValues.paramsXLight;
@@ -1576,7 +1576,7 @@ void drawTerrain(const glm::mat4 &mvp, const glm::mat4& viewMatrix, const Vector
 
 	///////////////////////////////////
 	// terrain + decals
-	drawTerrainCombined(mvp, viewMatrix, ModelUVLightmap, cameraPos, sunPos, shadowCascades);
+	drawTerrainCombined(mvp, viewMatrix, ModelUVLightmap, cameraPos, sunPos, shadowCascades, shadowMap);
 }
 
 /**
@@ -1642,7 +1642,7 @@ void drawWaterNormalImpl(const glm::mat4 &ModelViewProjection, const Vector3f &c
 }
 
 template<typename PSO>
-void drawWaterHighImpl(const glm::mat4 &ModelViewProjection, const glm::mat4& viewMatrix, const Vector3f &cameraPos, const Vector3f &sunPos, const ShadowCascadesInfo& shadowCascades)
+void drawWaterHighImpl(const glm::mat4 &ModelViewProjection, const glm::mat4& viewMatrix, const Vector3f &cameraPos, const Vector3f &sunPos, const ShadowCascadesInfo& shadowCascades, gfx_api::abstract_texture* shadowMap)
 {
 	if (!waterIndexVBO)
 	{
@@ -1663,7 +1663,7 @@ void drawWaterHighImpl(const glm::mat4 &ModelViewProjection, const glm::mat4& vi
 		waterTexturesHigh.tex_nm,
 		waterTexturesHigh.tex_sm,
 		lightmap_texture,
-		gfx_api::context::get().getPipelineSurface(gfx_api::PipelineSurfaceId::ShadowMap));
+		shadowMap);
 	PSO::get().bind_vertex_buffers(waterVBO);
 	PSO::get().bind_constants({
 		ModelViewProjection, viewMatrix, lightmapValues.ModelUVLightmap, {shadowCascades.shadowMVPMatrix[0], shadowCascades.shadowMVPMatrix[1], shadowCascades.shadowMVPMatrix[2]},
@@ -1758,7 +1758,7 @@ void drawWaterClassic(const glm::mat4 &ModelViewProjection, const glm::mat4 &Mod
 
 #include <lib/ivis_opengl/pieblitfunc.h>
 
-void drawWater(const glm::mat4 &ModelViewProjection, const glm::mat4& viewMatrix, const Vector3f &cameraPos, const Vector3f &sunPos, const ShadowCascadesInfo& shadowCascades)
+void drawWater(const glm::mat4 &ModelViewProjection, const glm::mat4& viewMatrix, const Vector3f &cameraPos, const Vector3f &sunPos, const ShadowCascadesInfo& shadowCascades, gfx_api::abstract_texture* shadowMap)
 {
 	switch (terrainShaderQuality)
 	{
@@ -1769,7 +1769,7 @@ void drawWater(const glm::mat4 &ModelViewProjection, const glm::mat4& viewMatrix
 			drawWaterNormalImpl<gfx_api::WaterPSO>(ModelViewProjection, cameraPos, sunPos);
 			return;
 		case TerrainShaderQuality::NORMAL_MAPPING:
-			drawWaterHighImpl<gfx_api::WaterHighPSO>(ModelViewProjection, viewMatrix, cameraPos, sunPos, shadowCascades);
+			drawWaterHighImpl<gfx_api::WaterHighPSO>(ModelViewProjection, viewMatrix, cameraPos, sunPos, shadowCascades, shadowMap);
 			return;
 		case TerrainShaderQuality::UNINITIALIZED_PICK_DEFAULT:
 			// should not happen

--- a/src/terrain.h
+++ b/src/terrain.h
@@ -41,15 +41,18 @@ void loadTerrainTexturesBlocking(MAP_TILESET mapTileset);
 bool initTerrain(WorldMapState& mapState);
 void shutdownTerrain();
 
-void perFrameTerrainUpdates(WorldMapState& mapState, const LightMap& lightData);
-void drawTerrainDepthOnly(const glm::mat4 &mvp);
-void drawTerrain(const glm::mat4 &mvp, const glm::mat4& viewMatrix, const Vector3f &cameraPos, const Vector3f &sunPos, const ShadowCascadesInfo& shadowMVPMatrix);
-void drawWater(const glm::mat4 &ModelViewProjection, const glm::mat4& viewMatrix, const Vector3f &cameraPos, const Vector3f &sunPos, const ShadowCascadesInfo& shadowCascades);
-
 namespace gfx_api
 {
+	struct abstract_texture; // forward-declare
 	struct texture; // forward-declare
 }
+
+void perFrameTerrainUpdates(WorldMapState& mapState, const LightMap& lightData);
+void drawTerrainDepthOnly(const glm::mat4 &mvp);
+void drawTerrain(const glm::mat4 &mvp, const glm::mat4& viewMatrix, const Vector3f &cameraPos, const Vector3f &sunPos,
+	const ShadowCascadesInfo& shadowMVPMatrix, gfx_api::abstract_texture* shadowMap);
+void drawWater(const glm::mat4 &ModelViewProjection, const glm::mat4& viewMatrix, const Vector3f &cameraPos, const Vector3f &sunPos,
+	const ShadowCascadesInfo& shadowCascades, gfx_api::abstract_texture* shadowMap);
 
 gfx_api::texture* getTerrainLightmapTexture();
 const glm::mat4& getModelUVLightmapMatrix();


### PR DESCRIPTION
Make `AttachmentDesc.pipelineSurfaceId` the sole surface identity for pass helpers so we can drop texture->id reverse lookup (`findPipelineSurfaceId`).

That removes a brittle pointer scan and keeps swapchain/cascade decisions aligned with what the materializer already wrote.

`ScenePass` already declared cascade `PassOutput` Depth reads for barriers; wire those resolved reads into terrain/water/mesh binds instead of `getPipelineSurface(ShadowMap)`. Sampling then follows the same graph dependency the layout timeline already honors, including the `cascades==0` null->default path.