### PR TITLE
Align tcmask and tcmask_instanced shader lighting, fixup terrain decal tangent handedness + migrate to MikkTSpace

### DIFF
--- a/data/base/shaders/nolight.vert
+++ b/data/base/shaders/nolight.vert
@@ -12,7 +12,8 @@
 #endif
 
 uniform mat4 ProjectionMatrix;
-uniform mat4 ModelViewMatrix;
+uniform mat4 ViewMatrix;
+uniform mat4 ModelMatrix;
 uniform float animFrameNumber;
 
 #if defined(NEWGL) || defined(GL_EXT_gpu_shader4)
@@ -48,7 +49,7 @@ void main()
 	texCoord = vec2(texCoord.x + uFrame, texCoord.y + vFrame);
 
 	// Translate every vertex according to the Model View and Projection Matrix
-	mat4 ModelViewProjectionMatrix = ProjectionMatrix * ModelViewMatrix;
+	mat4 ModelViewProjectionMatrix = ProjectionMatrix * ViewMatrix * ModelMatrix;
 	vec4 gposition = ModelViewProjectionMatrix * vertex;
 	gl_Position = gposition;
 

--- a/data/base/shaders/nolight.vert
+++ b/data/base/shaders/nolight.vert
@@ -26,7 +26,7 @@ in vec4 vertex;
 in vec4 vertexTexCoordAndTexAnim;
 #else
 attribute vec4 vertex;
-attribute vec2 vertexTexCoordAndTexAnim;
+attribute vec4 vertexTexCoordAndTexAnim;
 #endif
 
 #ifdef NEWGL

--- a/data/base/shaders/tangentspace.glsl
+++ b/data/base/shaders/tangentspace.glsl
@@ -50,4 +50,34 @@ vec2 wzParallaxOffset(mat3 tbn, vec3 viewVec, float height, float scale)
 	return wzTangentDirToUV(v.xy / denom) * (height * scale);
 }
 
+// Decode a sampled normal map into the space the caller lights in.
+//
+//   sampled      - the raw texture sample (.xyz, 0..1)
+//   hasTangents  - non-zero when the model carries a tangent basis
+//   tbn          - the (T, B, N) matrix; pass mat3(1.0) if already lighting in
+//                  tangent space, in which case the tangent branch is a no-op
+//   normalMatrix - model -> world, used only by the object-space branch
+//
+// The two branches are NOT symmetric and neither swizzle is redundant:
+//
+//  - tangent space: the basis is (T, B, N) and the map is (R, G, B) along
+//    exactly those axes, so the sample is used unswizzled. See
+//    tangentspace.glsl for why no v-flip correction is needed - the tangent
+//    generator already accounts for it.
+//
+//  - object space: the map is in the model's own axes, which WZ stores with y
+//    and z exchanged relative to the shader, hence .xzy; and with x and z
+//    running the other way, hence the two negations. This path never touches
+//    the tangent basis, so nothing here cancels against it.
+vec3 wzDecodeNormalMap(vec3 sampled, int hasTangents, mat3 tbn, mat3 normalMatrix)
+{
+	if (hasTangents != 0)
+	{
+		return tbn * (sampled.rgb * 2.0 - 1.0);
+	}
+
+	vec3 nObjectSpace = sampled.xzy * 2.0 - 1.0;
+	return normalMatrix * vec3(-nObjectSpace.x, nObjectSpace.y, -nObjectSpace.z);
+}
+
 #endif // WZ_TANGENTSPACE_GLSL

--- a/data/base/shaders/tcmask.frag
+++ b/data/base/shaders/tcmask.frag
@@ -44,12 +44,14 @@ in vec3 normal;
 in vec3 lightDir;
 in vec3 halfVec;
 in vec2 texCoord;
+in mat3 TangentSpaceMatrix;
 #else
 varying float vertexDistance;
 varying vec3 normal;
 varying vec3 lightDir;
 varying vec3 halfVec;
 varying vec2 texCoord;
+varying mat3 TangentSpaceMatrix;
 #endif
 
 #ifdef NEWGL
@@ -75,11 +77,7 @@ void main()
 	{
 		vec3 normalFromMap = texture(TextureNormal, texCoord, WZ_MIP_LOAD_BIAS).xyz;
 
-		// This shader lights in TANGENT space (the vertex shader rotates lightDir
-		// into the basis), so the tangent branch wants the decoded map as-is -
-		// hence the identity basis. The object-space branch is unaffected by that
-		// and goes through NormalMatrix exactly as in tcmask_instanced.frag.
-		N = wzDecodeNormalMap(normalFromMap, hasTangents, mat3(1.0), mat3(NormalMatrix));
+		N = wzDecodeNormalMap(normalFromMap, hasTangents, TangentSpaceMatrix, mat3(NormalMatrix));
 	}
 	N = normalize(N);
 

--- a/data/base/shaders/tcmask.frag
+++ b/data/base/shaders/tcmask.frag
@@ -58,6 +58,8 @@ out vec4 FragColor;
 // Uses gl_FragColor
 #endif
 
+#include "tangentspace.glsl"
+
 void main()
 {
 	vec4 diffuseMap = texture(Texture, texCoord, WZ_MIP_LOAD_BIAS);
@@ -73,24 +75,11 @@ void main()
 	{
 		vec3 normalFromMap = texture(TextureNormal, texCoord, WZ_MIP_LOAD_BIAS).xyz;
 
-		if (hasTangents != 0)
-		{
-			// Tangent-space normal map, in the conventional (T, B, N) basis.
-			// No compensating negation: the vertex shader now negates the light
-			// exactly as tcmask_instanced.vert does, so this is identical to
-			// that shader's "TangentSpaceMatrix * (normalFromMap.rgb * 2 - 1)",
-			// expressed in tangent space rather than world space.
-			N = normalFromMap.rgb * 2.0 - 1.0;
-		}
-		else
-		{
-			// Object-space normal map. This path goes through NormalMatrix and
-			// never touches TangentSpaceMatrix, so the (T, N, B) -> (T, B, N)
-			// reorder does not cancel the .xzy swizzle here the way it does
-			// above - it has to stay, as it does in tcmask_instanced.frag.
-			vec3 nObjectSpace = normalFromMap.xzy * 2.0 - 1.0;
-			N = (NormalMatrix * vec4(-nObjectSpace.x, nObjectSpace.y, -nObjectSpace.z, 0.0)).xyz;
-		}
+		// This shader lights in TANGENT space (the vertex shader rotates lightDir
+		// into the basis), so the tangent branch wants the decoded map as-is -
+		// hence the identity basis. The object-space branch is unaffected by that
+		// and goes through NormalMatrix exactly as in tcmask_instanced.frag.
+		N = wzDecodeNormalMap(normalFromMap, hasTangents, mat3(1.0), mat3(NormalMatrix));
 	}
 	N = normalize(N);
 

--- a/data/base/shaders/tcmask.frag
+++ b/data/base/shaders/tcmask.frag
@@ -76,11 +76,11 @@ void main()
 		if (hasTangents != 0)
 		{
 			// Tangent-space normal map, in the conventional (T, B, N) basis.
-			// The compensating negation has to follow the basis: the normal
-			// component was index 1 under the old mat3(t, n, b) + .xzy pair,
-			// and is index 2 now.
+			// No compensating negation: the vertex shader now negates the light
+			// exactly as tcmask_instanced.vert does, so this is identical to
+			// that shader's "TangentSpaceMatrix * (normalFromMap.rgb * 2 - 1)",
+			// expressed in tangent space rather than world space.
 			N = normalFromMap.rgb * 2.0 - 1.0;
-			N.z = -N.z; // FIXME - to match WZ's light
 		}
 		else
 		{
@@ -88,9 +88,8 @@ void main()
 			// never touches TangentSpaceMatrix, so the (T, N, B) -> (T, B, N)
 			// reorder does not cancel the .xzy swizzle here the way it does
 			// above - it has to stay, as it does in tcmask_instanced.frag.
-			N = normalFromMap.xzy * 2.0 - 1.0;
-			N.y = -N.y; // FIXME - to match WZ's light
-			N = (NormalMatrix * vec4(N, 0.0)).xyz;
+			vec3 nObjectSpace = normalFromMap.xzy * 2.0 - 1.0;
+			N = (NormalMatrix * vec4(-nObjectSpace.x, nObjectSpace.y, -nObjectSpace.z, 0.0)).xyz;
 		}
 	}
 	N = normalize(N);

--- a/data/base/shaders/tcmask.vert
+++ b/data/base/shaders/tcmask.vert
@@ -17,7 +17,7 @@ uniform mat4 ModelMatrix;
 uniform mat4 NormalMatrix;
 uniform vec4 cameraPos; // in world space
 uniform int hasTangents; // whether tangents were calculated for model
-uniform vec4 lightPosition;
+uniform vec4 lightPosition; // in world space
 uniform float stretch;
 uniform float animFrameNumber;
 
@@ -72,7 +72,7 @@ void main()
 	// Classic models are lit with the normal negated, which cancels against the
 	// negated light below.
 	normal = -normalize((NormalMatrix * vec4(vertexNormal, 0.0)).xyz);
-	lightDir = -normalize(mat3(inverse(ViewMatrix)) * lightPosition.xyz);
+	lightDir = -normalize(lightPosition.xyz);
 
 	if (hasTangents != 0)
 	{

--- a/data/base/shaders/tcmask.vert
+++ b/data/base/shaders/tcmask.vert
@@ -12,6 +12,7 @@
 #endif
 
 uniform mat4 ProjectionMatrix;
+uniform mat4 ViewMatrix;
 uniform mat4 ModelViewMatrix;
 uniform mat4 NormalMatrix;
 uniform int hasTangents; // whether tangents were calculated for model
@@ -64,12 +65,19 @@ void main()
 	// Lighting we pass to the fragment shader
 	vec4 viewVertex = ModelViewMatrix * vec4(vertex.xyz, -vertex.w); // FIXME
 	vec3 eyeVec = normalize(-viewVertex.xyz);
-	vec3 n = normalize((NormalMatrix * vec4(vertexNormal, 0.0)).xyz);
-	lightDir = normalize(lightPosition.xyz);
+	// Classic models are lit with the normal negated, which cancels against the
+	// negated light below. Both halves are taken verbatim from
+	// tcmask_instanced.vert so that the two paths agree by construction rather
+	// than by each carrying its own compensation.
+	vec3 n = -normalize((NormalMatrix * vec4(vertexNormal, 0.0)).xyz);
+	lightDir = -normalize(mat3(inverse(ViewMatrix)) * lightPosition.xyz);
 
 	if (hasTangents != 0)
 	{
-		// Building the matrix Eye Space -> Tangent Space with handness
+		// ...but NOT negated when it is the shading normal of a tangent basis.
+		n = normalize((NormalMatrix * vec4(vertexNormal, 0.0)).xyz);
+
+		// Building the matrix World Space -> Tangent Space with handness
 		vec3 t = normalize((NormalMatrix * vertexTangent).xyz);
 		vec3 b = cross (n, t) * vertexTangent.w;
 		mat3 TangentSpaceMatrix = mat3(t, b, n); // conventional (T, B, N)
@@ -80,11 +88,16 @@ void main()
 
 		// ...and the geometric normal with them. The fragment shader starts
 		// from "N = normal" and only replaces it when a normal map is bound,
-		// so leaving this in eye space lights any model that has a NORMALS
-		// block but no usable normal map against a tangent-space lightDir.
+		// so leaving it outside this basis would light any model that has a
+		// NORMALS block but no normal map against a tangent-space lightDir.
 		// In this basis it becomes (0, 0, 1), which is exactly what a flat
 		// tangent-space normal map decodes to - the mapped and unmapped cases
 		// have to agree.
+		//
+		// NOTE: eyeVec above is still in eye space, so halfVec mixes spaces
+		// when ViewMatrix is not identity. Harmless on the button path (which
+		// passes identity) and unreachable elsewhere; fixed properly when this
+		// shader moves to a world-space cameraVec.
 		n = n * TangentSpaceMatrix;
 	}
 

--- a/data/base/shaders/tcmask.vert
+++ b/data/base/shaders/tcmask.vert
@@ -77,6 +77,15 @@ void main()
 		// Transform light and eye direction vectors by tangent basis
 		lightDir *= TangentSpaceMatrix;
 		eyeVec *= TangentSpaceMatrix;
+
+		// ...and the geometric normal with them. The fragment shader starts
+		// from "N = normal" and only replaces it when a normal map is bound,
+		// so leaving this in eye space lights any model that has a NORMALS
+		// block but no usable normal map against a tangent-space lightDir.
+		// In this basis it becomes (0, 0, 1), which is exactly what a flat
+		// tangent-space normal map decodes to - the mapped and unmapped cases
+		// have to agree.
+		n = n * TangentSpaceMatrix;
 	}
 
 	normal = n;

--- a/data/base/shaders/tcmask.vert
+++ b/data/base/shaders/tcmask.vert
@@ -13,8 +13,9 @@
 
 uniform mat4 ProjectionMatrix;
 uniform mat4 ViewMatrix;
-uniform mat4 ModelViewMatrix;
+uniform mat4 ModelMatrix;
 uniform mat4 NormalMatrix;
+uniform vec4 cameraPos; // in world space
 uniform int hasTangents; // whether tangents were calculated for model
 uniform vec4 lightPosition;
 uniform float stretch;
@@ -42,10 +43,12 @@ attribute vec4 vertexTangent;
 out float vertexDistance;
 out vec3 normal, lightDir, halfVec;
 out vec2 texCoord;
+out mat3 TangentSpaceMatrix;
 #else
 varying float vertexDistance;
 varying vec3 normal, lightDir, halfVec;
 varying vec2 texCoord;
+varying mat3 TangentSpaceMatrix;
 #endif
 
 float when_gt(float x, float y) {
@@ -62,47 +65,28 @@ void main()
 	float vFrame = float(frame / framesPerLine) * vertexTexCoordAndTexAnim.w; // texAnim.y
 	texCoord = vec2(texCoord.x + uFrame, texCoord.y + vFrame);
 
-	// Lighting we pass to the fragment shader
-	vec4 viewVertex = ModelViewMatrix * vec4(vertex.xyz, -vertex.w); // FIXME
-	vec3 eyeVec = normalize(-viewVertex.xyz);
+	// Lighting, all in WORLD space
+	vec3 posWorld = (ModelMatrix * vertex).xyz;
+	vec3 cameraVec = normalize(cameraPos.xyz - posWorld);
+
 	// Classic models are lit with the normal negated, which cancels against the
-	// negated light below. Both halves are taken verbatim from
-	// tcmask_instanced.vert so that the two paths agree by construction rather
-	// than by each carrying its own compensation.
-	vec3 n = -normalize((NormalMatrix * vec4(vertexNormal, 0.0)).xyz);
+	// negated light below.
+	normal = -normalize((NormalMatrix * vec4(vertexNormal, 0.0)).xyz);
 	lightDir = -normalize(mat3(inverse(ViewMatrix)) * lightPosition.xyz);
 
 	if (hasTangents != 0)
 	{
 		// ...but NOT negated when it is the shading normal of a tangent basis.
-		n = normalize((NormalMatrix * vec4(vertexNormal, 0.0)).xyz);
+		normal = normalize((NormalMatrix * vec4(vertexNormal, 0.0)).xyz);
 
-		// Building the matrix World Space -> Tangent Space with handness
+		// Building the World Space -> Tangent Space matrix with handness w to
+		// support uv mirroring. The fragment shader applies it.
 		vec3 t = normalize((NormalMatrix * vertexTangent).xyz);
-		vec3 b = cross (n, t) * vertexTangent.w;
-		mat3 TangentSpaceMatrix = mat3(t, b, n); // conventional (T, B, N)
-
-		// Transform light and eye direction vectors by tangent basis
-		lightDir *= TangentSpaceMatrix;
-		eyeVec *= TangentSpaceMatrix;
-
-		// ...and the geometric normal with them. The fragment shader starts
-		// from "N = normal" and only replaces it when a normal map is bound,
-		// so leaving it outside this basis would light any model that has a
-		// NORMALS block but no normal map against a tangent-space lightDir.
-		// In this basis it becomes (0, 0, 1), which is exactly what a flat
-		// tangent-space normal map decodes to - the mapped and unmapped cases
-		// have to agree.
-		//
-		// NOTE: eyeVec above is still in eye space, so halfVec mixes spaces
-		// when ViewMatrix is not identity. Harmless on the button path (which
-		// passes identity) and unreachable elsewhere; fixed properly when this
-		// shader moves to a world-space cameraVec.
-		n = n * TangentSpaceMatrix;
+		vec3 b = cross (normal, t) * vertexTangent.w;
+		TangentSpaceMatrix = mat3(t, b, normal); // conventional (T, B, N)
 	}
 
-	normal = n;
-	halfVec = lightDir + eyeVec;
+	halfVec = lightDir + cameraVec;
 
 	// Implement building stretching to accommodate terrain
 	vec4 position = vertex;
@@ -115,7 +99,7 @@ void main()
 	}
 
 	// Translate every vertex according to the Model View and Projection Matrix
-	mat4 ModelViewProjectionMatrix = ProjectionMatrix * ModelViewMatrix;
+	mat4 ModelViewProjectionMatrix = ProjectionMatrix * ViewMatrix * ModelMatrix;
 	vec4 gposition = ModelViewProjectionMatrix * position;
 	gl_Position = gposition;
 

--- a/data/base/shaders/tcmask_instanced.frag
+++ b/data/base/shaders/tcmask_instanced.frag
@@ -118,17 +118,7 @@ void main()
 	{
 		vec3 normalFromMap = texture(TextureNormal, texCoord, WZ_MIP_LOAD_BIAS).xyz;
 
-		if (hasTangents != 0)
-		{
-			// tangent-space normal map -> world space
-			N = TangentSpaceMatrix * (normalFromMap.rgb * 2.0 - 1.0);
-		}
-		else
-		{
-			// object-space normal map -> world space
-			vec3 nObjectSpace = normalFromMap.xzy * 2.0 - 1.0;
-			N = NormalMatrix * vec3(-nObjectSpace.x, nObjectSpace.y, -nObjectSpace.z);
-		}
+		N = wzDecodeNormalMap(normalFromMap, hasTangents, TangentSpaceMatrix, NormalMatrix);
 	}
 	N = normalize(N);
 

--- a/data/base/shaders/tcmask_instanced.vert
+++ b/data/base/shaders/tcmask_instanced.vert
@@ -16,7 +16,7 @@ uniform mat4 ViewMatrix;
 uniform mat4 ModelUVLightmapMatrix;
 
 uniform int hasTangents; // whether tangents were calculated for model
-uniform vec4 lightPosition; // in view space
+uniform vec4 lightPosition; // in world space
 uniform vec4 cameraPos; // in model space
 
 #if defined(NEWGL) || defined(GL_EXT_gpu_shader4)
@@ -93,7 +93,7 @@ void main()
 	posViewSpace = vec3(ModelVeiwMatrix * vertex);
 	posModelSpace = vec3(instanceModelMatrix * vertex);
 	vec3 cameraVec = normalize(cameraPos.xyz - posModelSpace.xyz);
-	lightDir = -normalize(mat3(inverse(ViewMatrix)) * lightPosition.xyz); //to-do: pass Sun pos in world space
+	lightDir = -normalize(lightPosition.xyz);
 	halfVec = lightDir + cameraVec;
 
 	vec3 localPosition = vertex.xyz;

--- a/data/base/shaders/terrain_combined.vert
+++ b/data/base/shaders/terrain_combined.vert
@@ -64,7 +64,7 @@ void main()
 		groundLightDir = ModelTangentMatrix * sunPos.xyz; // already normalized
 		groundHalfVec = groundLightDir + eyeVec;
 
-		vec3 bitangentDecal = -cross(vertexNormal, vertexTangent.xyz) * vertexTangent.w;
+		vec3 bitangentDecal = cross(vertexNormal, vertexTangent.xyz) * vertexTangent.w;
 		// transformation matrix from decal tangent space to ground tangent space for normals xy
 		decal2groundMat2 = mat2(
 			dot(vertexTangent.xyz, tangent), dot(bitangentDecal, tangent),

--- a/data/base/shaders/vk/nolight.frag
+++ b/data/base/shaders/vk/nolight.frag
@@ -8,6 +8,7 @@ layout(std140, set = 0, binding = 0) uniform globaluniforms
 	mat4 ProjectionMatrix;
 	mat4 ViewMatrix;
 	mat4 ShadowMapMVPMatrix;
+	vec4 cameraPos;
 	vec4 lightPosition;
 	vec4 sceneColor;
 	vec4 ambient;
@@ -31,7 +32,7 @@ layout(std140, set = 1, binding = 0) uniform meshuniforms
 
 layout(std140, set = 2, binding = 0) uniform instanceuniforms
 {
-	mat4 ModelViewMatrix;
+	mat4 ModelMatrix;
 	mat4 NormalMatrix;
 	vec4 colour;
 	vec4 teamcolour;

--- a/data/base/shaders/vk/nolight.frag
+++ b/data/base/shaders/vk/nolight.frag
@@ -9,7 +9,7 @@ layout(std140, set = 0, binding = 0) uniform globaluniforms
 	mat4 ViewMatrix;
 	mat4 ShadowMapMVPMatrix;
 	vec4 cameraPos;
-	vec4 lightPosition;
+	vec4 lightPosition; // in world space
 	vec4 sceneColor;
 	vec4 ambient;
 	vec4 diffuse;

--- a/data/base/shaders/vk/nolight.vert
+++ b/data/base/shaders/vk/nolight.vert
@@ -6,6 +6,7 @@ layout(std140, set = 0, binding = 0) uniform globaluniforms
 	mat4 ProjectionMatrix;
 	mat4 ViewMatrix;
 	mat4 ShadowMapMVPMatrix;
+	vec4 cameraPos;
 	vec4 lightPosition;
 	vec4 sceneColor;
 	vec4 ambient;
@@ -29,7 +30,7 @@ layout(std140, set = 1, binding = 0) uniform meshuniforms
 
 layout(std140, set = 2, binding = 0) uniform instanceuniforms
 {
-	mat4 ModelViewMatrix;
+	mat4 ModelMatrix;
 	mat4 NormalMatrix;
 	vec4 colour;
 	vec4 teamcolour;
@@ -55,7 +56,7 @@ void main()
 	texCoord = vec2(texCoord.x + uFrame, texCoord.y + vFrame);
 
 	// Translate every vertex according to the Model, View and Projection matrices
-	mat4 ModelViewProjectionMatrix = ProjectionMatrix * ModelViewMatrix;
+	mat4 ModelViewProjectionMatrix = ProjectionMatrix * ViewMatrix * ModelMatrix;
 	gl_Position = ModelViewProjectionMatrix * vertex;
 	gl_Position.y *= -1.;
 	gl_Position.z = (gl_Position.z + gl_Position.w) / 2.0;

--- a/data/base/shaders/vk/nolight.vert
+++ b/data/base/shaders/vk/nolight.vert
@@ -7,7 +7,7 @@ layout(std140, set = 0, binding = 0) uniform globaluniforms
 	mat4 ViewMatrix;
 	mat4 ShadowMapMVPMatrix;
 	vec4 cameraPos;
-	vec4 lightPosition;
+	vec4 lightPosition; // in world space
 	vec4 sceneColor;
 	vec4 ambient;
 	vec4 diffuse;

--- a/data/base/shaders/vk/tangentspace.glsl
+++ b/data/base/shaders/vk/tangentspace.glsl
@@ -50,4 +50,34 @@ vec2 wzParallaxOffset(mat3 tbn, vec3 viewVec, float height, float scale)
 	return wzTangentDirToUV(v.xy / denom) * (height * scale);
 }
 
+// Decode a sampled normal map into the space the caller lights in.
+//
+//   sampled      - the raw texture sample (.xyz, 0..1)
+//   hasTangents  - non-zero when the model carries a tangent basis
+//   tbn          - the (T, B, N) matrix; pass mat3(1.0) if already lighting in
+//                  tangent space, in which case the tangent branch is a no-op
+//   normalMatrix - model -> world, used only by the object-space branch
+//
+// The two branches are NOT symmetric and neither swizzle is redundant:
+//
+//  - tangent space: the basis is (T, B, N) and the map is (R, G, B) along
+//    exactly those axes, so the sample is used unswizzled. See
+//    tangentspace.glsl for why no v-flip correction is needed - the tangent
+//    generator already accounts for it.
+//
+//  - object space: the map is in the model's own axes, which WZ stores with y
+//    and z exchanged relative to the shader, hence .xzy; and with x and z
+//    running the other way, hence the two negations. This path never touches
+//    the tangent basis, so nothing here cancels against it.
+vec3 wzDecodeNormalMap(vec3 sampled, int hasTangents, mat3 tbn, mat3 normalMatrix)
+{
+	if (hasTangents != 0)
+	{
+		return tbn * (sampled.rgb * 2.0 - 1.0);
+	}
+
+	vec3 nObjectSpace = sampled.xzy * 2.0 - 1.0;
+	return normalMatrix * vec3(-nObjectSpace.x, nObjectSpace.y, -nObjectSpace.z);
+}
+
 #endif // WZ_TANGENTSPACE_GLSL

--- a/data/base/shaders/vk/tcmask.frag
+++ b/data/base/shaders/vk/tcmask.frag
@@ -70,11 +70,11 @@ void main()
 		if (hasTangents != 0)
 		{
 			// Tangent-space normal map, in the conventional (T, B, N) basis.
-			// The compensating negation has to follow the basis: the normal
-			// component was index 1 under the old mat3(t, n, b) + .xzy pair,
-			// and is index 2 now.
+			// No compensating negation: the vertex shader now negates the light
+			// exactly as tcmask_instanced.vert does, so this is identical to
+			// that shader's "TangentSpaceMatrix * (normalFromMap.rgb * 2 - 1)",
+			// expressed in tangent space rather than world space.
 			N = normalFromMap.rgb * 2.0 - 1.0;
-			N.z = -N.z; // FIXME - to match WZ's light
 		}
 		else
 		{
@@ -82,9 +82,8 @@ void main()
 			// never touches TangentSpaceMatrix, so the (T, N, B) -> (T, B, N)
 			// reorder does not cancel the .xzy swizzle here the way it does
 			// above - it has to stay, as it does in tcmask_instanced.frag.
-			N = normalFromMap.xzy * 2.0 - 1.0;
-			N.y = -N.y; // FIXME - to match WZ's light
-			N = (NormalMatrix * vec4(N, 0.0)).xyz;
+			vec3 nObjectSpace = normalFromMap.xzy * 2.0 - 1.0;
+			N = (NormalMatrix * vec4(-nObjectSpace.x, nObjectSpace.y, -nObjectSpace.z, 0.0)).xyz;
 		}
 	}
 	N = normalize(N);

--- a/data/base/shaders/vk/tcmask.frag
+++ b/data/base/shaders/vk/tcmask.frag
@@ -12,7 +12,7 @@ layout(std140, set = 0, binding = 0) uniform globaluniforms
 	mat4 ViewMatrix;
 	mat4 ShadowMapMVPMatrix;
 	vec4 cameraPos;
-	vec4 lightPosition;
+	vec4 lightPosition; // in world space
 	vec4 sceneColor;
 	vec4 ambient;
 	vec4 diffuse;

--- a/data/base/shaders/vk/tcmask.frag
+++ b/data/base/shaders/vk/tcmask.frag
@@ -52,6 +52,8 @@ layout(location = 4) in vec2 texCoord;
 
 layout(location = 0) out vec4 FragColor;
 
+#include "tangentspace.glsl"
+
 void main()
 {
 	vec4 diffuseMap = texture(Texture, texCoord, WZ_MIP_LOAD_BIAS);
@@ -67,24 +69,11 @@ void main()
 	{
 		vec3 normalFromMap = texture(TextureNormal, texCoord, WZ_MIP_LOAD_BIAS).xyz;
 
-		if (hasTangents != 0)
-		{
-			// Tangent-space normal map, in the conventional (T, B, N) basis.
-			// No compensating negation: the vertex shader now negates the light
-			// exactly as tcmask_instanced.vert does, so this is identical to
-			// that shader's "TangentSpaceMatrix * (normalFromMap.rgb * 2 - 1)",
-			// expressed in tangent space rather than world space.
-			N = normalFromMap.rgb * 2.0 - 1.0;
-		}
-		else
-		{
-			// Object-space normal map. This path goes through NormalMatrix and
-			// never touches TangentSpaceMatrix, so the (T, N, B) -> (T, B, N)
-			// reorder does not cancel the .xzy swizzle here the way it does
-			// above - it has to stay, as it does in tcmask_instanced.frag.
-			vec3 nObjectSpace = normalFromMap.xzy * 2.0 - 1.0;
-			N = (NormalMatrix * vec4(-nObjectSpace.x, nObjectSpace.y, -nObjectSpace.z, 0.0)).xyz;
-		}
+		// This shader lights in TANGENT space (the vertex shader rotates lightDir
+		// into the basis), so the tangent branch wants the decoded map as-is -
+		// hence the identity basis. The object-space branch is unaffected by that
+		// and goes through NormalMatrix exactly as in tcmask_instanced.frag.
+		N = wzDecodeNormalMap(normalFromMap, hasTangents, mat3(1.0), mat3(NormalMatrix));
 	}
 	N = normalize(N);
 

--- a/data/base/shaders/vk/tcmask.frag
+++ b/data/base/shaders/vk/tcmask.frag
@@ -11,6 +11,7 @@ layout(std140, set = 0, binding = 0) uniform globaluniforms
 	mat4 ProjectionMatrix;
 	mat4 ViewMatrix;
 	mat4 ShadowMapMVPMatrix;
+	vec4 cameraPos;
 	vec4 lightPosition;
 	vec4 sceneColor;
 	vec4 ambient;
@@ -34,7 +35,7 @@ layout(std140, set = 1, binding = 0) uniform meshuniforms
 
 layout(std140, set = 2, binding = 0) uniform instanceuniforms
 {
-	mat4 ModelViewMatrix;
+	mat4 ModelMatrix;
 	mat4 NormalMatrix;
 	vec4 colour;
 	vec4 teamcolour;
@@ -49,6 +50,7 @@ layout(location = 1) in vec3 normal;
 layout(location = 2) in vec3 lightDir;
 layout(location = 3) in vec3 halfVec;
 layout(location = 4) in vec2 texCoord;
+layout(location = 5) in mat3 TangentSpaceMatrix; // occupies locations 5, 6, 7
 
 layout(location = 0) out vec4 FragColor;
 
@@ -69,11 +71,7 @@ void main()
 	{
 		vec3 normalFromMap = texture(TextureNormal, texCoord, WZ_MIP_LOAD_BIAS).xyz;
 
-		// This shader lights in TANGENT space (the vertex shader rotates lightDir
-		// into the basis), so the tangent branch wants the decoded map as-is -
-		// hence the identity basis. The object-space branch is unaffected by that
-		// and goes through NormalMatrix exactly as in tcmask_instanced.frag.
-		N = wzDecodeNormalMap(normalFromMap, hasTangents, mat3(1.0), mat3(NormalMatrix));
+		N = wzDecodeNormalMap(normalFromMap, hasTangents, TangentSpaceMatrix, mat3(NormalMatrix));
 	}
 	N = normalize(N);
 

--- a/data/base/shaders/vk/tcmask.vert
+++ b/data/base/shaders/vk/tcmask.vert
@@ -7,7 +7,7 @@ layout(std140, set = 0, binding = 0) uniform globaluniforms
 	mat4 ViewMatrix;
 	mat4 ShadowMapMVPMatrix;
 	vec4 cameraPos;
-	vec4 lightPosition;
+	vec4 lightPosition; // in world space
 	vec4 sceneColor;
 	vec4 ambient;
 	vec4 diffuse;
@@ -73,7 +73,7 @@ void main()
 	// Classic models are lit with the normal negated, which cancels against the
 	// negated light below.
 	normal = -normalize((NormalMatrix * vec4(vertexNormal, 0.0)).xyz);
-	lightDir = -normalize(mat3(inverse(ViewMatrix)) * lightPosition.xyz);
+	lightDir = -normalize(lightPosition.xyz);
 
 	if (hasTangents != 0)
 	{

--- a/data/base/shaders/vk/tcmask.vert
+++ b/data/base/shaders/vk/tcmask.vert
@@ -67,12 +67,19 @@ void main()
 	// Lighting we pass to the fragment shader
 	vec4 viewVertex = ModelViewMatrix * vec4(vertex.xyz, -vertex.w); // FIXME
 	vec3 eyeVec = normalize(-viewVertex.xyz);
-	vec3 n = normalize((NormalMatrix * vec4(vertexNormal, 0.0)).xyz);
-	lightDir = normalize(lightPosition.xyz);
+	// Classic models are lit with the normal negated, which cancels against the
+	// negated light below. Both halves are taken verbatim from
+	// tcmask_instanced.vert so that the two paths agree by construction rather
+	// than by each carrying its own compensation.
+	vec3 n = -normalize((NormalMatrix * vec4(vertexNormal, 0.0)).xyz);
+	lightDir = -normalize(mat3(inverse(ViewMatrix)) * lightPosition.xyz);
 
 	if (hasTangents != 0)
 	{
-		// Building the matrix Eye Space -> Tangent Space with handness
+		// ...but NOT negated when it is the shading normal of a tangent basis.
+		n = normalize((NormalMatrix * vec4(vertexNormal, 0.0)).xyz);
+
+		// Building the matrix World Space -> Tangent Space with handness
 		vec3 t = normalize((NormalMatrix * vertexTangent).xyz);
 		vec3 b = cross (n, t) * vertexTangent.w;
 		mat3 TangentSpaceMatrix = mat3(t, b, n); // conventional (T, B, N)
@@ -83,11 +90,16 @@ void main()
 
 		// ...and the geometric normal with them. The fragment shader starts
 		// from "N = normal" and only replaces it when a normal map is bound,
-		// so leaving this in eye space lights any model that has a NORMALS
-		// block but no usable normal map against a tangent-space lightDir.
+		// so leaving it outside this basis would light any model that has a
+		// NORMALS block but no normal map against a tangent-space lightDir.
 		// In this basis it becomes (0, 0, 1), which is exactly what a flat
 		// tangent-space normal map decodes to - the mapped and unmapped cases
 		// have to agree.
+		//
+		// NOTE: eyeVec above is still in eye space, so halfVec mixes spaces
+		// when ViewMatrix is not identity. Harmless on the button path (which
+		// passes identity) and unreachable elsewhere; fixed properly when this
+		// shader moves to a world-space cameraVec.
 		n = n * TangentSpaceMatrix;
 	}
 

--- a/data/base/shaders/vk/tcmask.vert
+++ b/data/base/shaders/vk/tcmask.vert
@@ -6,6 +6,7 @@ layout(std140, set = 0, binding = 0) uniform globaluniforms
 	mat4 ProjectionMatrix;
 	mat4 ViewMatrix;
 	mat4 ShadowMapMVPMatrix;
+	vec4 cameraPos;
 	vec4 lightPosition;
 	vec4 sceneColor;
 	vec4 ambient;
@@ -29,7 +30,7 @@ layout(std140, set = 1, binding = 0) uniform meshuniforms
 
 layout(std140, set = 2, binding = 0) uniform instanceuniforms
 {
-	mat4 ModelViewMatrix;
+	mat4 ModelMatrix;
 	mat4 NormalMatrix;
 	vec4 colour;
 	vec4 teamcolour;
@@ -49,6 +50,7 @@ layout(location = 1) out vec3 normal;
 layout(location = 2) out vec3 lightDir;
 layout(location = 3) out vec3 halfVec;
 layout(location = 4) out vec2 texCoord;
+layout(location = 5) out mat3 TangentSpaceMatrix; // occupies locations 5, 6, 7
 
 float when_gt(float x, float y) {
   return max(sign(x - y), 0.0);
@@ -64,47 +66,28 @@ void main()
 	float vFrame = float(frame / framesPerLine) * vertexTexCoordAndTexAnim.w; // texAnim.y
 	texCoord = vec2(texCoord.x + uFrame, texCoord.y + vFrame);
 
-	// Lighting we pass to the fragment shader
-	vec4 viewVertex = ModelViewMatrix * vec4(vertex.xyz, -vertex.w); // FIXME
-	vec3 eyeVec = normalize(-viewVertex.xyz);
+	// Lighting, all in WORLD space
+	vec3 posWorld = (ModelMatrix * vertex).xyz;
+	vec3 cameraVec = normalize(cameraPos.xyz - posWorld);
+
 	// Classic models are lit with the normal negated, which cancels against the
-	// negated light below. Both halves are taken verbatim from
-	// tcmask_instanced.vert so that the two paths agree by construction rather
-	// than by each carrying its own compensation.
-	vec3 n = -normalize((NormalMatrix * vec4(vertexNormal, 0.0)).xyz);
+	// negated light below.
+	normal = -normalize((NormalMatrix * vec4(vertexNormal, 0.0)).xyz);
 	lightDir = -normalize(mat3(inverse(ViewMatrix)) * lightPosition.xyz);
 
 	if (hasTangents != 0)
 	{
 		// ...but NOT negated when it is the shading normal of a tangent basis.
-		n = normalize((NormalMatrix * vec4(vertexNormal, 0.0)).xyz);
+		normal = normalize((NormalMatrix * vec4(vertexNormal, 0.0)).xyz);
 
-		// Building the matrix World Space -> Tangent Space with handness
+		// Building the World Space -> Tangent Space matrix with handness w to
+		// support uv mirroring. The fragment shader applies it.
 		vec3 t = normalize((NormalMatrix * vertexTangent).xyz);
-		vec3 b = cross (n, t) * vertexTangent.w;
-		mat3 TangentSpaceMatrix = mat3(t, b, n); // conventional (T, B, N)
-
-		// Transform light and eye direction vectors by tangent basis
-		lightDir *= TangentSpaceMatrix;
-		eyeVec *= TangentSpaceMatrix;
-
-		// ...and the geometric normal with them. The fragment shader starts
-		// from "N = normal" and only replaces it when a normal map is bound,
-		// so leaving it outside this basis would light any model that has a
-		// NORMALS block but no normal map against a tangent-space lightDir.
-		// In this basis it becomes (0, 0, 1), which is exactly what a flat
-		// tangent-space normal map decodes to - the mapped and unmapped cases
-		// have to agree.
-		//
-		// NOTE: eyeVec above is still in eye space, so halfVec mixes spaces
-		// when ViewMatrix is not identity. Harmless on the button path (which
-		// passes identity) and unreachable elsewhere; fixed properly when this
-		// shader moves to a world-space cameraVec.
-		n = n * TangentSpaceMatrix;
+		vec3 b = cross (normal, t) * vertexTangent.w;
+		TangentSpaceMatrix = mat3(t, b, normal); // conventional (T, B, N)
 	}
 
-	normal = n;
-	halfVec = lightDir + eyeVec;
+	halfVec = lightDir + cameraVec;
 
 	// Implement building stretching to accommodate terrain
 	vec4 position = vertex;
@@ -117,7 +100,7 @@ void main()
 	}
 
 	// Translate every vertex according to the Model View and Projection Matrix
-	mat4 ModelViewProjectionMatrix = ProjectionMatrix * ModelViewMatrix;
+	mat4 ModelViewProjectionMatrix = ProjectionMatrix * ViewMatrix * ModelMatrix;
 	vec4 gposition = ModelViewProjectionMatrix * position;
 	gl_Position = gposition;
 

--- a/data/base/shaders/vk/tcmask.vert
+++ b/data/base/shaders/vk/tcmask.vert
@@ -80,6 +80,15 @@ void main()
 		// Transform light and eye direction vectors by tangent basis
 		lightDir *= TangentSpaceMatrix;
 		eyeVec *= TangentSpaceMatrix;
+
+		// ...and the geometric normal with them. The fragment shader starts
+		// from "N = normal" and only replaces it when a normal map is bound,
+		// so leaving this in eye space lights any model that has a NORMALS
+		// block but no usable normal map against a tangent-space lightDir.
+		// In this basis it becomes (0, 0, 1), which is exactly what a flat
+		// tangent-space normal map decodes to - the mapped and unmapped cases
+		// have to agree.
+		n = n * TangentSpaceMatrix;
 	}
 
 	normal = n;

--- a/data/base/shaders/vk/tcmask_instanced.frag
+++ b/data/base/shaders/vk/tcmask_instanced.frag
@@ -73,17 +73,7 @@ void main()
 	{
 		vec3 normalFromMap = texture(TextureNormal, texCoord, WZ_MIP_LOAD_BIAS).xyz;
 
-		if (hasTangents != 0)
-		{
-			// tangent-space normal map -> world space
-			N = TangentSpaceMatrix * (normalFromMap.rgb * 2.0 - 1.0);
-		}
-		else
-		{
-			// object-space normal map -> world space
-			vec3 nObjectSpace = normalFromMap.xzy * 2.0 - 1.0;
-			N = NormalMatrix * vec3(-nObjectSpace.x, nObjectSpace.y, -nObjectSpace.z);
-		}
+		N = wzDecodeNormalMap(normalFromMap, hasTangents, TangentSpaceMatrix, NormalMatrix);
 	}
 	N = normalize(N);
 

--- a/data/base/shaders/vk/tcmask_instanced.glsl
+++ b/data/base/shaders/vk/tcmask_instanced.glsl
@@ -13,7 +13,7 @@ layout(std140, set = 0, binding = 0) uniform globaluniforms
 	mat4 ModelUVLightmapMatrix;
 	mat4 ShadowMapMVPMatrix[WZ_MAX_SHADOW_CASCADES];
 	vec4 cameraPos; // in model space
-	vec4 lightPosition; // in view space
+	vec4 lightPosition; // in world space
 	vec4 sceneColor;
 	vec4 ambient;
 	vec4 diffuse;

--- a/data/base/shaders/vk/tcmask_instanced.vert
+++ b/data/base/shaders/vk/tcmask_instanced.vert
@@ -64,7 +64,7 @@ void main()
 	posViewSpace = vec3(ModelVeiwMatrix * vertex);
 	posModelSpace = vec3(instanceModelMatrix * vertex);
 	vec3 cameraVec = normalize(cameraPos.xyz - posModelSpace.xyz);
-	lightDir = -normalize(mat3(inverse(ViewMatrix)) * lightPosition.xyz); //to-do: pass Sun pos in world space
+	lightDir = -normalize(lightPosition.xyz);
 	halfVec = lightDir + cameraVec;
 
 	vec3 localPosition = vertex.xyz;

--- a/data/base/shaders/vk/terrain_combined.vert
+++ b/data/base/shaders/vk/terrain_combined.vert
@@ -41,7 +41,7 @@ void main()
 		frag.groundLightDir = ModelTangentMatrix * sunPos.xyz; // already normalized
 		frag.groundHalfVec = frag.groundLightDir + eyeVec;
 
-		vec3 bitangentDecal = -cross(vertexNormal, vertexTangent.xyz) * vertexTangent.w;
+		vec3 bitangentDecal = cross(vertexNormal, vertexTangent.xyz) * vertexTangent.w;
 		// transformation matrix from decal tangent space to ground tangent space for normals xy
 		frag.decal2groundMat2 = mat2(
 			dot(vertexTangent.xyz, tangent), dot(bitangentDecal, tangent),

--- a/lib/ivis_opengl/gfx_api.h
+++ b/lib/ivis_opengl/gfx_api.h
@@ -900,6 +900,7 @@ namespace gfx_api
 		glm::mat4 ProjectionMatrix;
 		glm::mat4 ViewMatrix;
 		glm::mat4 ShadowMapMVPMatrix;
+		glm::vec4 cameraPos; // in world space
 		glm::vec4 sunPos;
 		glm::vec4 sceneColor;
 		glm::vec4 ambient;
@@ -925,8 +926,7 @@ namespace gfx_api
 	// Change per instance of mesh
 	struct Draw3DShapePerInstanceUniforms
 	{
-		// instead of passing the modelMatrix, pre-calculate the ModelViewMatrix and NormalMatrix CPU-side
-		glm::mat4 ModelViewMatrix;
+		glm::mat4 ModelMatrix;
 		glm::mat4 NormalMatrix;
 		glm::vec4 colour;
 		glm::vec4 teamcolour;

--- a/lib/ivis_opengl/gfx_api.h
+++ b/lib/ivis_opengl/gfx_api.h
@@ -901,7 +901,7 @@ namespace gfx_api
 		glm::mat4 ViewMatrix;
 		glm::mat4 ShadowMapMVPMatrix;
 		glm::vec4 cameraPos; // in world space
-		glm::vec4 sunPos;
+		glm::vec4 sunPos; // in world space
 		glm::vec4 sceneColor;
 		glm::vec4 ambient;
 		glm::vec4 diffuse;
@@ -980,7 +980,7 @@ namespace gfx_api
 		glm::mat4 ModelUVLightmapMatrix;
 		glm::mat4 ShadowMapMVPMatrix[WZ_MAX_SHADOW_CASCADES];
 		glm::vec4 cameraPos; // in modelSpace
-		glm::vec4 sunPos;
+		glm::vec4 sunPos; // in world space
 		glm::vec4 sceneColor;
 		glm::vec4 ambient;
 		glm::vec4 diffuse;

--- a/lib/ivis_opengl/gfx_api_gl.cpp
+++ b/lib/ivis_opengl/gfx_api_gl.cpp
@@ -910,11 +910,11 @@ static const std::map<SHADER_MODE, program_data> shader_to_file_table =
 	std::make_pair(SHADER_COMPONENT, program_data{ "Component program", "shaders/tcmask.vert", "shaders/tcmask.frag",
 		{
 			// per-frame global uniforms
-			"ProjectionMatrix", "ViewMatrix", "ShadowMapMVPMatrix", "lightPosition", "sceneColor", "ambient", "diffuse", "specular", "fogColor", "fogEnd", "fogStart", "graphicsCycle", "fogEnabled",
+			"ProjectionMatrix", "ViewMatrix", "ShadowMapMVPMatrix", "cameraPos", "lightPosition", "sceneColor", "ambient", "diffuse", "specular", "fogColor", "fogEnd", "fogStart", "graphicsCycle", "fogEnabled",
 			// per-mesh uniforms
 			"tcmask", "normalmap", "specularmap", "hasTangents",
 			// per-instance uniforms
-			"ModelViewMatrix", "NormalMatrix", "colour", "teamcolour", "stretch", "animFrameNumber", "ecmEffect", "alphaTest",
+			"ModelMatrix", "NormalMatrix", "colour", "teamcolour", "stretch", "animFrameNumber", "ecmEffect", "alphaTest",
 			// appended per-frame global uniforms
 			"WZ_MIP_LOAD_BIAS"
 		} }),
@@ -939,11 +939,11 @@ static const std::map<SHADER_MODE, program_data> shader_to_file_table =
 	std::make_pair(SHADER_NOLIGHT, program_data{ "Plain program", "shaders/nolight.vert", "shaders/nolight.frag",
 		{
 			// per-frame global uniforms
-			"ProjectionMatrix", "ViewMatrix", "ShadowMapMVPMatrix", "lightPosition", "sceneColor", "ambient", "diffuse", "specular", "fogColor", "fogEnd", "fogStart", "graphicsCycle", "fogEnabled",
+			"ProjectionMatrix", "ViewMatrix", "ShadowMapMVPMatrix", "cameraPos", "lightPosition", "sceneColor", "ambient", "diffuse", "specular", "fogColor", "fogEnd", "fogStart", "graphicsCycle", "fogEnabled",
 			// per-mesh uniforms
 			"tcmask", "normalmap", "specularmap", "hasTangents",
 			// per-instance uniforms
-			"ModelViewMatrix", "NormalMatrix", "colour", "teamcolour", "stretch", "animFrameNumber", "ecmEffect", "alphaTest",
+			"ModelMatrix", "NormalMatrix", "colour", "teamcolour", "stretch", "animFrameNumber", "ecmEffect", "alphaTest",
 			// appended per-frame global uniforms
 			"WZ_MIP_LOAD_BIAS"
 		} }),
@@ -2244,38 +2244,39 @@ void gl_pipeline_state_object::set_constants(const gfx_api::Draw3DShapeGlobalUni
 	setUniforms(0, cbuf.ProjectionMatrix);
 	setUniforms(1, cbuf.ViewMatrix);
 	setUniforms(2, cbuf.ShadowMapMVPMatrix);
-	setUniforms(3, cbuf.sunPos);
-	setUniforms(4, cbuf.sceneColor);
-	setUniforms(5, cbuf.ambient);
-	setUniforms(6, cbuf.diffuse);
-	setUniforms(7, cbuf.specular);
-	setUniforms(8, cbuf.fogColour);
-	setUniforms(9, cbuf.fogEnd);
-	setUniforms(10, cbuf.fogBegin);
-	setUniforms(11, cbuf.timeState);
-	setUniforms(12, cbuf.fogEnabled);
-	// index 25 is the appended name after the per mesh and per instance uniforms
-	setUniforms(25, cbuf.mipLoadBias);
+	setUniforms(3, cbuf.cameraPos);
+	setUniforms(4, cbuf.sunPos);
+	setUniforms(5, cbuf.sceneColor);
+	setUniforms(6, cbuf.ambient);
+	setUniforms(7, cbuf.diffuse);
+	setUniforms(8, cbuf.specular);
+	setUniforms(9, cbuf.fogColour);
+	setUniforms(10, cbuf.fogEnd);
+	setUniforms(11, cbuf.fogBegin);
+	setUniforms(12, cbuf.timeState);
+	setUniforms(13, cbuf.fogEnabled);
+	// index 26 is the appended name after the per mesh and per instance uniforms
+	setUniforms(26, cbuf.mipLoadBias);
 }
 
 void gl_pipeline_state_object::set_constants(const gfx_api::Draw3DShapePerMeshUniforms& cbuf)
 {
-	setUniforms(13, cbuf.tcmask);
-	setUniforms(14, cbuf.normalMap);
-	setUniforms(15, cbuf.specularMap);
-	setUniforms(16, cbuf.hasTangents);
+	setUniforms(14, cbuf.tcmask);
+	setUniforms(15, cbuf.normalMap);
+	setUniforms(16, cbuf.specularMap);
+	setUniforms(17, cbuf.hasTangents);
 }
 
 void gl_pipeline_state_object::set_constants(const gfx_api::Draw3DShapePerInstanceUniforms& cbuf)
 {
-	setUniforms(17, cbuf.ModelViewMatrix);
-	setUniforms(18, cbuf.NormalMatrix);
-	setUniforms(19, cbuf.colour);
-	setUniforms(20, cbuf.teamcolour);
-	setUniforms(21, cbuf.shaderStretch);
-	setUniforms(22, cbuf.animFrameNumber);
-	setUniforms(23, cbuf.ecmState);
-	setUniforms(24, cbuf.alphaTest);
+	setUniforms(18, cbuf.ModelMatrix);
+	setUniforms(19, cbuf.NormalMatrix);
+	setUniforms(20, cbuf.colour);
+	setUniforms(21, cbuf.teamcolour);
+	setUniforms(22, cbuf.shaderStretch);
+	setUniforms(23, cbuf.animFrameNumber);
+	setUniforms(24, cbuf.ecmState);
+	setUniforms(25, cbuf.alphaTest);
 }
 
 void gl_pipeline_state_object::set_constants(const gfx_api::Draw3DShapeInstancedGlobalUniforms& cbuf)

--- a/lib/ivis_opengl/piedraw.cpp
+++ b/lib/ivis_opengl/piedraw.cpp
@@ -401,8 +401,17 @@ private:
 };
 
 template<SHADER_MODE shader, typename AdditivePSO, typename AlphaPSO, typename AlphaNoDepthWRTPSO, typename PremultipliedPSO, typename OpaquePSO>
-static void draw3dShapeTemplated(const templatedState &lastState, ShaderOnce& globalsOnce, const gfx_api::Draw3DShapeGlobalUniforms& globalUniforms, const PIELIGHT &colour, const PIELIGHT &teamcolour, const float& stretch, const int& ecmState, const glm::mat4 & modelViewMatrix, const iIMDShape * shape, int pieFlag, int frame)
+static void draw3dShapeTemplated(const templatedState &lastState, ShaderOnce& globalsOnce, const gfx_api::Draw3DShapeGlobalUniforms& globalUniforms, const PIELIGHT &colour, const PIELIGHT &teamcolour, const float& stretch, const int& ecmState, const glm::mat4 & modelMatrix, const iIMDShape * shape, int pieFlag, int frame)
 {
+	// NOTE: takes the MODEL matrix, not the ModelView matrix. NormalMatrix has to
+	// be derived from the model matrix alone so that it maps into the same space
+	// as lightPosition (which is currentSunPosition, in world space). Deriving it
+	// from the ModelView matrix instead yields eye-space normals lit by a
+	// world-space sun, i.e. lighting that rotates with the camera.
+	//
+	// pie_Draw3DButton has always done it this way; this brings the other caller
+	// of these shaders into line. See also tcmask.vert.
+	const glm::mat4 modelViewMatrix = globalUniforms.ViewMatrix * modelMatrix;
 	templatedState currentState = templatedState(shader, shape, pieFlag);
 
 	const auto& textures = shape->getTextures();
@@ -416,7 +425,7 @@ static void draw3dShapeTemplated(const templatedState &lastState, ShaderOnce& gl
 
 	gfx_api::Draw3DShapePerInstanceUniforms instanceUniforms {
 		modelViewMatrix,
-		glm::transpose(glm::inverse(modelViewMatrix)),
+		glm::transpose(glm::inverse(modelMatrix)),
 		pal_PIELIGHTtoVec4(colour), pal_PIELIGHTtoVec4(teamcolour),
 		stretch, float(frame), ecmState, !(pieFlag & pie_PREMULTIPLIED)
 	};
@@ -594,11 +603,11 @@ static templatedState pie_Draw3DShape2(const templatedState &lastState, ShaderOn
 
 	if (light)
 	{
-		draw3dShapeTemplated<SHADER_COMPONENT, gfx_api::Draw3DShapeAdditive, gfx_api::Draw3DShapeAlpha, gfx_api::Draw3DShapeAlphaNoDepthWRT, gfx_api::Draw3DShapePremul, gfx_api::Draw3DShapeOpaque>(lastState, globalsOnce, globalUniforms, colour, teamcolour, stretchDepth, ecmState, globalUniforms.ViewMatrix * modelMatrix, shape, pieFlag, frame);
+		draw3dShapeTemplated<SHADER_COMPONENT, gfx_api::Draw3DShapeAdditive, gfx_api::Draw3DShapeAlpha, gfx_api::Draw3DShapeAlphaNoDepthWRT, gfx_api::Draw3DShapePremul, gfx_api::Draw3DShapeOpaque>(lastState, globalsOnce, globalUniforms, colour, teamcolour, stretchDepth, ecmState, modelMatrix, shape, pieFlag, frame);
 	}
 	else
 	{
-		draw3dShapeTemplated<SHADER_NOLIGHT, gfx_api::Draw3DShapeNoLightAdditive, gfx_api::Draw3DShapeNoLightAlpha, gfx_api::Draw3DShapeNoLightAlphaNoDepthWRT, gfx_api::Draw3DShapeNoLightPremul, gfx_api::Draw3DShapeNoLightOpaque>(lastState, globalsOnce, globalUniforms, colour, teamcolour, stretchDepth, ecmState, globalUniforms.ViewMatrix * modelMatrix, shape, pieFlag, frame);
+		draw3dShapeTemplated<SHADER_NOLIGHT, gfx_api::Draw3DShapeNoLightAdditive, gfx_api::Draw3DShapeNoLightAlpha, gfx_api::Draw3DShapeNoLightAlphaNoDepthWRT, gfx_api::Draw3DShapeNoLightPremul, gfx_api::Draw3DShapeNoLightOpaque>(lastState, globalsOnce, globalUniforms, colour, teamcolour, stretchDepth, ecmState, modelMatrix, shape, pieFlag, frame);
 	}
 
 	polyCount += shape->polys.size();

--- a/lib/ivis_opengl/piedraw.cpp
+++ b/lib/ivis_opengl/piedraw.cpp
@@ -233,7 +233,7 @@ uint32_t pie_getShadowCascades()
 	return numShadowCascades;
 }
 
-static Vector3f currentSunPosition(0.f, 0.f, 0.f);
+static Vector3f currentSunPosition(0.f, 0.f, 0.f); // world space
 
 void pie_BeginLighting(const Vector3f &light)
 {
@@ -1365,8 +1365,9 @@ bool InstancedMeshRenderer::Draw3DShape(const iIMDShape *shape, int frame, PIELI
 			if (distance < SHADOW_END_DISTANCE)
 			{
 				// Calculate the light position relative to the object
+				// (currentSunPosition is world space, so this is inverse of the Model matrix)
 				glm::vec4 pos_light0 = glm::vec4(currentSunPosition, 0.f);
-				glm::mat4 invmat = glm::inverse(scshape.modelViewMatrix);
+				glm::mat4 invmat = glm::inverse(modelMatrix);
 
 				scshape.light = invmat * pos_light0;
 				scshape.shape = shape;

--- a/lib/ivis_opengl/piedraw.cpp
+++ b/lib/ivis_opengl/piedraw.cpp
@@ -322,7 +322,7 @@ void pie_Draw3DButton(const iIMDShape *shape, PIELIGHT teamcolour, const glm::ma
 
 	gfx_api::Draw3DShapePerInstanceUniforms instanceUniforms {
 		modelMatrix,
-		glm::transpose(glm::inverse(modelMatrix)),
+		glm::mat4(glm::transpose(glm::inverse(glm::mat3(modelMatrix)))),
 		pal_PIELIGHTtoVec4(colour), pal_PIELIGHTtoVec4(teamcolour),
 		0.f, 0.f, 0, !(shape->flags & pie_PREMULTIPLIED)
 	};
@@ -424,7 +424,7 @@ static void draw3dShapeTemplated(const templatedState &lastState, ShaderOnce& gl
 
 	gfx_api::Draw3DShapePerInstanceUniforms instanceUniforms {
 		modelMatrix,
-		glm::transpose(glm::inverse(modelMatrix)),
+		glm::mat4(glm::transpose(glm::inverse(glm::mat3(modelMatrix)))),
 		pal_PIELIGHTtoVec4(colour), pal_PIELIGHTtoVec4(teamcolour),
 		stretch, float(frame), ecmState, !(pieFlag & pie_PREMULTIPLIED)
 	};

--- a/lib/ivis_opengl/piedraw.cpp
+++ b/lib/ivis_opengl/piedraw.cpp
@@ -307,6 +307,9 @@ void pie_Draw3DButton(const iIMDShape *shape, PIELIGHT teamcolour, const glm::ma
 
 	gfx_api::Draw3DShapeGlobalUniforms globalUniforms {
 		pie_UIPerspectiveGet(), viewMatrix, glm::mat4(1.f),
+		// The button "camera" sits at the origin looking down -Z
+		// Callers pass an identity view matrix, so world space and eye space coincide here
+		glm::vec4(0.f, 0.f, 0.f, 0.f),
 		glm::vec4(getDefaultSunPosition(), 0.f),
 		sceneColor, ambient, diffuse, specular, glm::vec4(0.f),
 		0.f, 0.f, 0.f, 0,
@@ -318,7 +321,7 @@ void pie_Draw3DButton(const iIMDShape *shape, PIELIGHT teamcolour, const glm::ma
 	};
 
 	gfx_api::Draw3DShapePerInstanceUniforms instanceUniforms {
-		viewMatrix * modelMatrix,
+		modelMatrix,
 		glm::transpose(glm::inverse(modelMatrix)),
 		pal_PIELIGHTtoVec4(colour), pal_PIELIGHTtoVec4(teamcolour),
 		0.f, 0.f, 0, !(shape->flags & pie_PREMULTIPLIED)
@@ -403,15 +406,11 @@ private:
 template<SHADER_MODE shader, typename AdditivePSO, typename AlphaPSO, typename AlphaNoDepthWRTPSO, typename PremultipliedPSO, typename OpaquePSO>
 static void draw3dShapeTemplated(const templatedState &lastState, ShaderOnce& globalsOnce, const gfx_api::Draw3DShapeGlobalUniforms& globalUniforms, const PIELIGHT &colour, const PIELIGHT &teamcolour, const float& stretch, const int& ecmState, const glm::mat4 & modelMatrix, const iIMDShape * shape, int pieFlag, int frame)
 {
-	// NOTE: takes the MODEL matrix, not the ModelView matrix. NormalMatrix has to
-	// be derived from the model matrix alone so that it maps into the same space
-	// as lightPosition (which is currentSunPosition, in world space). Deriving it
-	// from the ModelView matrix instead yields eye-space normals lit by a
-	// world-space sun, i.e. lighting that rotates with the camera.
-	//
-	// pie_Draw3DButton has always done it this way; this brings the other caller
-	// of these shaders into line. See also tcmask.vert.
-	const glm::mat4 modelViewMatrix = globalUniforms.ViewMatrix * modelMatrix;
+	// NOTE: takes the MODEL matrix, not the ModelView matrix. Everything the
+	// shaders derive from it - NormalMatrix, world-space positions - has to land
+	// in the same space as lightPosition (currentSunPosition) and cameraPos,
+	// both of which are world space. The shaders form ModelView themselves from
+	// the global ViewMatrix, exactly as the instanced path does.
 	templatedState currentState = templatedState(shader, shape, pieFlag);
 
 	const auto& textures = shape->getTextures();
@@ -424,7 +423,7 @@ static void draw3dShapeTemplated(const templatedState &lastState, ShaderOnce& gl
 	};
 
 	gfx_api::Draw3DShapePerInstanceUniforms instanceUniforms {
-		modelViewMatrix,
+		modelMatrix,
 		glm::transpose(glm::inverse(modelMatrix)),
 		pal_PIELIGHTtoVec4(colour), pal_PIELIGHTtoVec4(teamcolour),
 		stretch, float(frame), ecmState, !(pieFlag & pie_PREMULTIPLIED)
@@ -1662,6 +1661,7 @@ bool InstancedMeshRenderer::DrawAll(uint64_t currentGameFrame, const glm::mat4& 
 	{
 		gfx_api::Draw3DShapeGlobalUniforms globalUniforms {
 			projectionMatrix, viewMatrix, shadowCascades.shadowMVPMatrix[0],
+			glm::vec4(cameraPos, 0.f),
 			glm::vec4(currentSunPosition, 0.f), sceneColor, ambient, diffuse, specular, fogColor,
 			renderState.fogBegin, renderState.fogEnd, pie_GetShaderTime(), renderState.fogEnabled,
 			gfx_api::context::get().getSceneMipLodBias()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -130,6 +130,7 @@ endif()
 
 target_link_libraries(warzone2100 exception-handler gamelib wzmaplib ZipIOProvider ivis-opengl netplay sdl-backend framework sequence sound widget)
 target_link_libraries(warzone2100 launchinfo EmbeddedJSONSignature)
+target_link_libraries(warzone2100 mikktspace) # terrain decal tangents - see calcDecalTangents
 target_link_libraries(warzone2100 fmt::fmt)
 if(ENABLE_NLS)
 	target_link_libraries(warzone2100 ${Intl_LIBRARIES})

--- a/src/display3d.cpp
+++ b/src/display3d.cpp
@@ -1244,8 +1244,8 @@ static void drawTiles(iView *player, LightingData& lightData, LightMap& lightmap
 	actualCameraPosition.y -= -player->p.y;
 
 	// this also determines the length of the shadows
-	const Vector3f theSun = (viewMatrix * glm::vec4(getTheSun(), 0.f)).xyz();
-	pie_BeginLighting(theSun);
+	// NOTE: the sun in world space
+	pie_BeginLighting(getTheSun());
 
 	// Reset all lighting data
 	lightData.lights.clear();

--- a/src/terrain.cpp
+++ b/src/terrain.cpp
@@ -33,6 +33,8 @@
 
 #include <string.h>
 
+#include "mikktspace.h"
+
 #include "lib/framework/frame.h"
 #include "lib/framework/loading_task.h"
 #include "lib/framework/opengl.h"
@@ -339,6 +341,12 @@ static void getGridPos(const WorldMapState& mapState, Vector3i *result, int x, i
 		averagePos(result, &a, &b, &c, &d);
 		return;
 	}
+	// NOTE: z is NEGATED - map space and world space differ by a z flip. Anything
+	// comparing a direction or a winding across the two has to account for it:
+	// theSun_ForTileIllumination (lighting.cpp) is the shaders' light direction with
+	// z flipped for exactly this reason, and a tile's triangles are wound
+	// consistently with their +Y normals only once the negation is applied, which
+	// MikkTSpace relies on in calcDecalTangents below.
 	result->x = world_coord(x);
 	result->z = world_coord(-y);
 
@@ -515,51 +523,109 @@ static TileDecalInfo getTileDecalInfo(WorldMapState& mapState, int i, int j)
 	return info;
 }
 
-/// Calc decal tangents: accumulate the per-triangle tangents at each vertex
-/// (vertices shared between triangles get the average of their triangles'), then
-/// orthonormalize against each vertex normal and store with the mirror handedness.
+// MikkTSpace tangent generation for terrain decals
+//
+// The same reference implementation the models use (lib/ivis_opengl/imdload.cpp),
+// and the same one every tool that bakes normal maps uses (Blender, Substance,
+// xNormal, Marmoset, etc) so a decal normal map is rendered against the tangent
+// frame it was baked against.
+//
+// V handling matches imdload.cpp: WZ texture coordinates have v running DOWN
+// the image, while MikkTSpace assumes the standard convention, so it is handed
+// V-flipped coordinates. T is unaffected and B = dP/dv changes sign, which
+// reproduces the -dP/dv bitangent that "green up" normal maps need - i.e. exactly
+// the meaning vertexTangent.w already has here.
+
+namespace {
+
+struct MikkDecalMesh
+{
+	gfx_api::TerrainDecalVertex *vs;
+	const int (*tris)[3];
+	int numTris;
+};
+
+inline int mikkDecalIndex(const MikkDecalMesh *m, int iFace, int iVert)
+{
+	return m->tris[iFace][iVert];
+}
+
+int mikkDecalGetNumFaces(const SMikkTSpaceContext *pContext)
+{
+	return static_cast<const MikkDecalMesh *>(pContext->m_pUserData)->numTris;
+}
+
+int mikkDecalGetNumVerticesOfFace(const SMikkTSpaceContext *, const int)
+{
+	return 3;
+}
+
+void mikkDecalGetPosition(const SMikkTSpaceContext *pContext, float fvPosOut[], const int iFace, const int iVert)
+{
+	const auto *m = static_cast<const MikkDecalMesh *>(pContext->m_pUserData);
+	const Vector3f &p = m->vs[mikkDecalIndex(m, iFace, iVert)].pos;
+	fvPosOut[0] = p.x; fvPosOut[1] = p.y; fvPosOut[2] = p.z;
+}
+
+void mikkDecalGetNormal(const SMikkTSpaceContext *pContext, float fvNormOut[], const int iFace, const int iVert)
+{
+	const auto *m = static_cast<const MikkDecalMesh *>(pContext->m_pUserData);
+	const Vector3f &n = m->vs[mikkDecalIndex(m, iFace, iVert)].normal;
+	fvNormOut[0] = n.x; fvNormOut[1] = n.y; fvNormOut[2] = n.z;
+}
+
+void mikkDecalGetTexCoord(const SMikkTSpaceContext *pContext, float fvTexcOut[], const int iFace, const int iVert)
+{
+	const auto *m = static_cast<const MikkDecalMesh *>(pContext->m_pUserData);
+	const Vector2f &uv = m->vs[mikkDecalIndex(m, iFace, iVert)].decalUv;
+	fvTexcOut[0] = uv.x;
+	fvTexcOut[1] = 1.f - uv.y; // V flip - see the note above
+}
+
+void mikkDecalSetTSpaceBasic(const SMikkTSpaceContext *pContext, const float fvTangent[], const float fSign, const int iFace, const int iVert)
+{
+	auto *m = static_cast<MikkDecalMesh *>(pContext->m_pUserData);
+	m->vs[mikkDecalIndex(m, iFace, iVert)].decalTangent = glm::vec4(fvTangent[0], fvTangent[1], fvTangent[2], fSign);
+}
+
+} // anonymous namespace
+
+/// Calc decal tangents for one tile's vertices, over the same triangulation as the index buffer.
 ///
-/// The handedness w is defined so that
+/// The handedness w is stored so that
 ///     bitangent = cross(normal, tangent) * w
-/// reproduces -dP/dv, which is the bitangent "green up" normal maps need where v
-/// runs DOWN the image. That is the same meaning w has for models
-/// (lib/ivis_opengl/imdload.cpp feeds MikkTSpace V-flipped coordinates to get it),
-/// so the one expression above is correct everywhere in the engine.
+/// reproduces -dP/dv, the bitangent "green up" normal maps need where v runs down the image.
+/// That is the meaning w has for models too, so the one expression above is correct everywhere in the engine.
+///
+/// NOTE: MikkTSpace returns its results unindexed and warns against writing them
+/// through an index list that merges vertices. That is safe here because these
+/// indices only ever refer back to the *same* vertex - a tile's shared corner and
+/// centre vertices carry one position, one decal UV and one normal each - which is
+/// the criterion MikkTSpace welds on internally, so every corner sharing an index
+/// receives the same tangent anyway.
 static void calcDecalTangents(gfx_api::TerrainDecalVertex *vs, int numVerts, const int (*tris)[3], int numTris)
 {
 	constexpr int maxVerts = (MAX_TERRAIN_MESH_SUBDIVISION + 1) * (MAX_TERRAIN_MESH_SUBDIVISION + 1);
 	ASSERT_OR_RETURN(, numVerts <= maxVerts, "too many vertices (%d)", numVerts);
-	Vector3f tangentSum[maxVerts] = {};
-	Vector3f bitangentSum[maxVerts] = {};
-	for (int t = 0; t < numTris; t++) {
-		const auto &p0 = vs[tris[t][0]];
-		const auto &p1 = vs[tris[t][1]];
-		const auto &p2 = vs[tris[t][2]];
-		auto e1 = p1.pos - p0.pos;
-		auto e2 = p2.pos - p0.pos;
-		auto uv1 = p1.decalUv - p0.decalUv;
-		auto uv2 = p2.decalUv - p0.decalUv;
-		float r = 1.0f / (uv1.x * uv2.y - uv2.x * uv1.y);
-		Vector3f tangent = glm::normalize(r * (uv2.y * e1 - uv1.y * e2));
-		Vector3f bitangent = glm::normalize(r * (-uv2.x * e1 + uv1.x * e2));
-		if (glm::any(glm::isnan(tangent)) || glm::any(glm::isnan(bitangent))) {
-			continue; // degenerate decal UVs
-		}
-		for (int k = 0; k < 3; k++) {
-			tangentSum[tris[t][k]] += tangent;
-			bitangentSum[tris[t][k]] += bitangent;
-		}
-	}
-	for (int k = 0; k < numVerts; k++) {
-		const auto &n = vs[k].normal;
-		const auto tangent = glm::normalize(tangentSum[k]);
-		const auto t = glm::normalize(tangent - (n * glm::dot(tangent, n)));
-		// Compared against -dP/dv, not +dP/dv - see the note above.
-		float w = 1.0f; // not mirrored
-		if (glm::dot(glm::cross(n, t), -glm::normalize(bitangentSum[k])) < 0.0f) {
-			w = -1.0f; // we're mirrored
-		}
-		vs[k].decalTangent = glm::vec4(t, w);
+
+	MikkDecalMesh mesh { vs, tris, numTris };
+
+	SMikkTSpaceInterface mikkInterface = {};
+	mikkInterface.m_getNumFaces = mikkDecalGetNumFaces;
+	mikkInterface.m_getNumVerticesOfFace = mikkDecalGetNumVerticesOfFace;
+	mikkInterface.m_getPosition = mikkDecalGetPosition;
+	mikkInterface.m_getNormal = mikkDecalGetNormal;
+	mikkInterface.m_getTexCoord = mikkDecalGetTexCoord;
+	mikkInterface.m_setTSpaceBasic = mikkDecalSetTSpaceBasic;
+
+	SMikkTSpaceContext mikkContext = {};
+	mikkContext.m_pInterface = &mikkInterface;
+	mikkContext.m_pUserData = &mesh;
+
+	if (!genTangSpaceDefault(&mikkContext))
+	{
+		// leave the defaults in place rather than half-written tangents
+		debug(LOG_ERROR, "MikkTSpace tangent generation failed for a terrain decal tile");
 	}
 }
 

--- a/src/terrain.cpp
+++ b/src/terrain.cpp
@@ -517,7 +517,14 @@ static TileDecalInfo getTileDecalInfo(WorldMapState& mapState, int i, int j)
 
 /// Calc decal tangents: accumulate the per-triangle tangents at each vertex
 /// (vertices shared between triangles get the average of their triangles'), then
-/// orthonormalize against each vertex normal and store with the mirror handedness
+/// orthonormalize against each vertex normal and store with the mirror handedness.
+///
+/// The handedness w is defined so that
+///     bitangent = cross(normal, tangent) * w
+/// reproduces -dP/dv, which is the bitangent "green up" normal maps need where v
+/// runs DOWN the image. That is the same meaning w has for models
+/// (lib/ivis_opengl/imdload.cpp feeds MikkTSpace V-flipped coordinates to get it),
+/// so the one expression above is correct everywhere in the engine.
 static void calcDecalTangents(gfx_api::TerrainDecalVertex *vs, int numVerts, const int (*tris)[3], int numTris)
 {
 	constexpr int maxVerts = (MAX_TERRAIN_MESH_SUBDIVISION + 1) * (MAX_TERRAIN_MESH_SUBDIVISION + 1);
@@ -547,8 +554,9 @@ static void calcDecalTangents(gfx_api::TerrainDecalVertex *vs, int numVerts, con
 		const auto &n = vs[k].normal;
 		const auto tangent = glm::normalize(tangentSum[k]);
 		const auto t = glm::normalize(tangent - (n * glm::dot(tangent, n)));
+		// Compared against -dP/dv, not +dP/dv - see the note above.
 		float w = 1.0f; // not mirrored
-		if (glm::dot(glm::cross(n, t), glm::normalize(bitangentSum[k])) < 0.0f) {
+		if (glm::dot(glm::cross(n, t), -glm::normalize(bitangentSum[k])) < 0.0f) {
 			w = -1.0f; // we're mirrored
 		}
 		vs[k].decalTangent = glm::vec4(t, w);


### PR DESCRIPTION
Fixes a bunch of inconsistencies, makes it easier to reason across the two tcmask variants and other shaders, and fixes up terrain decal tangent handedness (plus migrates to MikkTSpace, just like the models did previously).

Design view and buttons should now render models like in-game models are rendered - previously this was sometimes broken (especially with normal/specular-mapped models).