### PR TITLE
Fixes for saveload and offworld transitions

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -7334,6 +7334,7 @@ bool loadSaveTemplate(const char *pFileName)
 			debug(LOG_ERROR, "Stored template \"%s\" contains an unknown component.", ini.string("name").toUtf8().c_str());
 		}
 		t.name = ini.string("name");
+		t.id = ini.string("id");
 		t.multiPlayerID = ini.value("multiPlayerID", generateNewObjectId()).toInt();
 		t.enabled = ini.value("enabled", false).toBool();
 		t.stored = ini.value("stored", false).toBool();
@@ -7403,6 +7404,7 @@ bool loadSaveTemplate(const char *pFileName)
 static nlohmann::json convGameTemplateToJSON(DROID_TEMPLATE *psCurr)
 {
 	nlohmann::json templateObj = saveTemplateCommon(psCurr);
+	templateObj["id"] = psCurr->id;
 	templateObj["ref"] = psCurr->ref;
 	templateObj["multiPlayerID"] = psCurr->multiPlayerID;
 	templateObj["enabled"] = psCurr->enabled;

--- a/src/gamestate_serialize.cpp
+++ b/src/gamestate_serialize.cpp
@@ -814,6 +814,8 @@ static nlohmann::ordered_json writeTemplates()
 		enumerateTemplates(p, [&jlist](DROID_TEMPLATE *psTempl)
 		{
 			nlohmann::ordered_json jt = saveTemplateCommon(psTempl);
+			// The stats id is what map-placed droids resolve against
+			jt["id"] = psTempl->id.toUtf8();
 			jt["multiPlayerID"] = psTempl->multiPlayerID;
 			jt["enabled"] = psTempl->enabled;
 			jt["stored"] = psTempl->stored;
@@ -855,6 +857,7 @@ static void readTemplates(const nlohmann::ordered_json &j, uint32_t version)
 			{
 				throw StateError("template contains an unknown component (different stats/mods?)");
 			}
+			psTempl->id = WzString::fromUtf8(jt.value("id", std::string()));
 			psTempl->multiPlayerID = jt.at("multiPlayerID").get<uint32_t>();
 			psTempl->enabled = jt.at("enabled").get<bool>();
 			psTempl->stored = jt.at("stored").get<bool>();

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -822,6 +822,10 @@ bool mapReloadGroundTypes()
 	{
 		return false;
 	}
+	if (mission.gameWorld.map.tiles && !mapSetGroundTypes(mission.gameWorld.map))
+	{
+		return false;
+	}
 	return true;
 }
 


### PR DESCRIPTION
Map-placed droids are resolved by stats id, through getTemplateFromTranslatedNameNoPlayer, and only loadDroidTemplates sets it.

readTemplates clears every player's templates and rebuilds them from the save, so after a load nothing had an id and the next map load in that session (ex. going offworld in campaign) skipped every map-placed unit.